### PR TITLE
MTG2D-63: Scryfall url change update

### DIFF
--- a/Assets/Resources/Sets/10E.json
+++ b/Assets/Resources/Sets/10E.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5f8287b1-5bb6-5f4c-ad17-316a40d5bb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5cd03c-4227-4551-aa4b-7d119f0468b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5cd03c-4227-4551-aa4b-7d119f0468b5.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Ancestor's Chosen comes into play, you gain 1 life for each card in your graveyard.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "b7c19924-b4bf-56fc-aa73-f586e940bd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82072a1d-c1ab-4b4f-875f-d0591447e0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82072a1d-c1ab-4b4f-875f-d0591447e0a4.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "57aaebc1-850c-503d-9f6e-bb8d00d8bf7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7980d4-da43-4d6d-ad16-14b8a34ae91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7980d4-da43-4d6d-ad16-14b8a34ae91d.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "8fd4e2eb-3eb4-50ea-856b-ef638fa47f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0157252-6949-4f03-a15c-c168512123a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0157252-6949-4f03-a15c-c168512123a8.jpg?1",
             "name": "Angel of Mercy",
             "text": "",
             "colours": [
@@ -146,7 +146,7 @@
         },
         {
             "id": "55bd38ca-dc73-5c06-8f80-a6ddd2f44382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285aa3f-bcfb-4fc3-8441-85a56c72a3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285aa3f-bcfb-4fc3-8441-85a56c72a3e4.jpg?1",
             "name": "Angelic Blessing",
             "text": "Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "c5655330-5131-5f40-9d3e-0549d88c6e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7f007-2fe3-47c2-aaa3-b8d084053bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7f007-2fe3-47c2-aaa3-b8d084053bae.jpg?1",
             "name": "Angelic Blessing",
             "text": "",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "3b77bb52-4181-57f5-b3cd-f3a15b95aa29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835ff5d-e03d-4a93-98bb-704eaa1e2b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835ff5d-e03d-4a93-98bb-704eaa1e2b64.jpg?1",
             "name": "Angelic Chorus",
             "text": "Whenever a creature comes into play under your control, you gain life equal to its toughness.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "fadda48c-6226-5ac5-a2b9-e9170d2017cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa1f42f-1729-46ea-99c6-015d66c627d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa1f42f-1729-46ea-99c6-015d66c627d4.jpg?1",
             "name": "Angelic Wall",
             "text": "Defender, flying (This creature can't attack, and it can block creatures with flying.)",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "60b93108-8790-591b-844e-c3d311698767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e26cb-c77a-4ba1-ba3d-e649bfab3d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e26cb-c77a-4ba1-ba3d-e649bfab3d24.jpg?1",
             "name": "Angelic Wall",
             "text": "",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "fac6ad26-f8c2-51bd-9f6a-a1b0940b4cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae635d18-5d22-494c-8bc7-5d52f3021cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae635d18-5d22-494c-8bc7-5d52f3021cbb.jpg?1",
             "name": "Aura of Silence",
             "text": "Artifact and enchantment spells your opponents play cost {2} more to play.\nSacrifice Aura of Silence: Destroy target artifact or enchantment.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "8ac972b5-9f6e-5cc8-91c3-b9a40a98232e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407110e9-19af-4ff5-97b2-c03225031a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407110e9-19af-4ff5-97b2-c03225031a73.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "6adaf14d-43e3-521a-adf1-960c808e5b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671cbd0e-b9d8-403a-ad12-f2ddb275b08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671cbd0e-b9d8-403a-ad12-f2ddb275b08a.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "a69b404f-144a-5317-b10e-7d9dce135b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d17394-b9c4-43f6-9a6d-2c7c7ecb1d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d17394-b9c4-43f6-9a6d-2c7c7ecb1d74.jpg?1",
             "name": "Ballista Squad",
             "text": "{X}{W}, {T}: Ballista Squad deals X damage to target attacking or blocking creature.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "6d268c95-c176-5766-9a46-c14f739aba1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c17e3b-4d7f-4472-afe1-8e9358b82f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c17e3b-4d7f-4472-afe1-8e9358b82f2c.jpg?1",
             "name": "Bandage",
             "text": "Prevent the next 1 damage that would be dealt to target creature or player this turn.\nDraw a card.",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "56f4935b-f6c5-59b9-88bf-9bcce20247ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9b5da-d3fa-4d70-a71a-a2342dbfd527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9b5da-d3fa-4d70-a71a-a2342dbfd527.jpg?1",
             "name": "Beacon of Immortality",
             "text": "Double target player's life total. Shuffle Beacon of Immortality into its owner's library.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "62365fbb-af07-5c2a-976d-e3092bdfc317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ae60d0-20d3-452c-9953-e229567c06f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ae60d0-20d3-452c-9953-e229567c06f5.jpg?1",
             "name": "Benalish Knight",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "0d2a4e1d-cc12-5675-8044-9a7bc7d60050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccebfdd-85cb-4549-93a4-c0dcd667ee04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccebfdd-85cb-4549-93a4-c0dcd667ee04.jpg?1",
             "name": "Benalish Knight",
             "text": "",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "81daea6a-2735-5a46-a2da-b65a2ad5738f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe04dfe7-6376-4c12-9404-0e1ae0942917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe04dfe7-6376-4c12-9404-0e1ae0942917.jpg?1",
             "name": "Cho-Manno, Revolutionary",
             "text": "Prevent all damage that would be dealt to Cho-Manno, Revolutionary.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "7fef665c-36a1-5f7a-9299-cf8938708710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9edff0-58a8-405d-9f2e-39f8269bbcb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9edff0-58a8-405d-9f2e-39f8269bbcb2.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -658,7 +658,7 @@
         },
         {
             "id": "2f9c211e-1869-5b3f-94ea-f73b7910a5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197c672-dfa1-4d1e-97ea-af916864d23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197c672-dfa1-4d1e-97ea-af916864d23c.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -690,7 +690,7 @@
         },
         {
             "id": "668c64a2-cecb-5f48-af16-d7a64814d3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e22d287-274e-4222-9ed7-3e609a84ac07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e22d287-274e-4222-9ed7-3e609a84ac07.jpg?1",
             "name": "Field Marshal",
             "text": "Other Soldier creatures get +1/+1 and have first strike. (They deal combat damage before creatures without first strike.)",
             "colours": [
@@ -726,7 +726,7 @@
         },
         {
             "id": "6d6a31d5-a80b-5f31-9b46-2c2083a95581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac20a92-9650-4cb1-bf7a-752a5db31b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac20a92-9650-4cb1-bf7a-752a5db31b39.jpg?1",
             "name": "Field Marshal",
             "text": "",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "d68306e2-9877-5987-84b3-12b8234c8eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd81534-79cb-4fde-bfa5-11c510ac6e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd81534-79cb-4fde-bfa5-11c510ac6e11.jpg?1",
             "name": "Ghost Warden",
             "text": "{T}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "546eac7c-1424-597d-ac13-bf8558e88fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbc588-019e-416a-938c-4ccbe7121335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbc588-019e-416a-938c-4ccbe7121335.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -828,7 +828,7 @@
         },
         {
             "id": "c19bcfc2-fc10-5040-8239-1c193098df47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a49daec-5f0f-497b-a88e-fa62bf48ca23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a49daec-5f0f-497b-a88e-fa62bf48ca23.jpg?1",
             "name": "Hail of Arrows",
             "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
             "colours": [
@@ -860,7 +860,7 @@
         },
         {
             "id": "36fcaa1e-64e3-56e3-950c-907db167e41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa4b29-ce6b-4579-bee6-06a9ccfda55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa4b29-ce6b-4579-bee6-06a9ccfda55c.jpg?1",
             "name": "Heart of Light",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nPrevent all damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "08548840-8e62-5fed-b432-f2a5a0cb5f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f599cc6e-1ecb-407c-98fc-06e903f8b72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f599cc6e-1ecb-407c-98fc-06e903f8b72f.jpg?1",
             "name": "Heart of Light",
             "text": "",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "60f49caf-3583-5f85-b4b3-08dca73a8628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79b3153-8874-458d-8e7e-cf97c6c1887c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79b3153-8874-458d-8e7e-cf97c6c1887c.jpg?1",
             "name": "High Ground",
             "text": "Each creature you control can block an additional creature.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "02e23fa1-b2f0-528c-b331-12a0c27bc5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3895c0c-0db8-4962-b386-57887fb60701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3895c0c-0db8-4962-b386-57887fb60701.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "4e4cbdec-e2d4-5f31-98a3-f2ef052c849d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21264cb-d915-4431-92fd-b0aa32a715fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21264cb-d915-4431-92fd-b0aa32a715fc.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "79996e77-112f-51e8-980c-0ec82f2d7754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b957dd74-d6c0-4da1-a7e8-86459f23d090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b957dd74-d6c0-4da1-a7e8-86459f23d090.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "9bee1901-1125-5635-9e22-3b4f37989c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a5add-87af-447d-9fd7-c4aeec3685fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a5add-87af-447d-9fd7-c4aeec3685fb.jpg?1",
             "name": "Honor Guard",
             "text": "{W}: Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "cb865391-5b14-58ce-aa99-b36b83e6377f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f8c040-b6da-42f4-9140-7cd5eceb51c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f8c040-b6da-42f4-9140-7cd5eceb51c7.jpg?1",
             "name": "Icatian Priest",
             "text": "{1}{W}{W}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "bb6e511d-3e7f-5dd3-b40c-dbeb09c734f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d742a-52a1-45c8-961a-85b6ff120c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d742a-52a1-45c8-961a-85b6ff120c44.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "{T}: All combat damage that would be dealt to you by unblocked creatures this turn is dealt to Kjeldoran Royal Guard instead.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "73e8c198-4ba4-5f42-9781-167150eae4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bf030b-4e20-49b0-837f-935f96b5d1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bf030b-4e20-49b0-837f-935f96b5d1fe.jpg?1",
             "name": "Loxodon Mystic",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -1204,7 +1204,7 @@
         },
         {
             "id": "3f809288-0eaa-5f55-8144-483ed8ea810c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf02b5fa-8589-462e-90f5-552c8f28a22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf02b5fa-8589-462e-90f5-552c8f28a22f.jpg?1",
             "name": "Loyal Sentry",
             "text": "When Loyal Sentry blocks a creature, destroy that creature and Loyal Sentry.",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "efe6103c-6a3e-5ed0-a689-81a2efe4273b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc636-439f-4ce0-8189-5d00b0cf6b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc636-439f-4ce0-8189-5d00b0cf6b1a.jpg?1",
             "name": "Luminesce",
             "text": "Prevent all damage that black sources and red sources would deal this turn.",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "7f1bea50-20c0-51b3-8b2a-ac60f5d31133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccc50a9-2cd0-4ee0-b4c9-a181b6b0cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccc50a9-2cd0-4ee0-b4c9-a181b6b0cc7f.jpg?1",
             "name": "Mobilization",
             "text": "Soldier creatures have vigilance. (Attacking doesn't cause them to tap.)\n{2}{W}: Put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "1afcbee1-1310-5144-86ea-e7bf0fb34d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8afceba-d9f6-4a98-8dbd-f6922492a296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8afceba-d9f6-4a98-8dbd-f6922492a296.jpg?1",
             "name": "Mobilization",
             "text": "",
             "colours": [
@@ -1337,7 +1337,7 @@
         },
         {
             "id": "5d53a06b-68a0-5d1a-a1a5-a676f16c23dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468f109-8020-4a74-8ffd-bba771362f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468f109-8020-4a74-8ffd-bba771362f76.jpg?1",
             "name": "Nomad Mythmaker",
             "text": "{W}, {T}: Put target Aura card in a graveyard into play attached to a creature you control. (You control that Aura.)",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "ac19e0e0-6d8e-55ad-a7a9-68fd6032eaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11417661-a53f-4392-abb3-b415fd939311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11417661-a53f-4392-abb3-b415fd939311.jpg?1",
             "name": "Nomad Mythmaker",
             "text": "",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "26fc6830-a092-5e24-9b58-97f4c38f3e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686352f6-d8e7-4d31-83bd-3d087c103e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686352f6-d8e7-4d31-83bd-3d087c103e75.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature can't attack or block.",
             "colours": [
@@ -1446,7 +1446,7 @@
         },
         {
             "id": "b1e43df0-d501-5297-9cb4-c84d2a76945d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84817323-785e-4f8c-b0ce-6b9e36bebaf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84817323-785e-4f8c-b0ce-6b9e36bebaf1.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "214dbfe9-0f16-5b6b-be30-8771192a89ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1a8e1-35f4-4b4a-aa68-21b5219527a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1a8e1-35f4-4b4a-aa68-21b5219527a9.jpg?1",
             "name": "Paladin en-Vec",
             "text": "First strike, protection from black, protection from red (This creature deals combat damage before creatures without first strike. It can't be blocked, targeted, dealt damage, or enchanted by anything black or red.)",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "08a671f0-ea90-531e-bbeb-c00793a57672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1db895-5e14-48c7-b464-4e36be432579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1db895-5e14-48c7-b464-4e36be432579.jpg?1",
             "name": "Paladin en-Vec",
             "text": "",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "7dff9ddf-213e-593d-a007-a72cf6ff925e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3f7e4f-57d1-4b8b-85d7-ef62ceccce93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3f7e4f-57d1-4b8b-85d7-ef62ceccce93.jpg?1",
             "name": "Pariah",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nAll damage that would be dealt to you is dealt to enchanted creature instead.",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "9f315280-5d52-5dea-a679-a2d97386907e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c110365-493f-4995-b919-59d0f4e2092c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c110365-493f-4995-b919-59d0f4e2092c.jpg?1",
             "name": "Pariah",
             "text": "",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "39b50224-8305-56dd-9849-09deecb07d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3dd79-ac4c-4ffc-9442-1efa0082f60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3dd79-ac4c-4ffc-9442-1efa0082f60f.jpg?1",
             "name": "Reviving Dose",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "6028cab2-0478-584b-a880-8174a88eb188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81ef83-41c2-46dc-aff9-41bb3a32637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81ef83-41c2-46dc-aff9-41bb3a32637a.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nAt the beginning of your upkeep, you may return target creature card from your graveyard to play.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "341f9c8d-a838-58f9-933b-094c8d889a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9349fdc-3d9c-4fa9-88b6-a7bc782bfd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9349fdc-3d9c-4fa9-88b6-a7bc782bfd44.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "9a14261a-b567-5429-a5ca-a913e15d8bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda6c9d5-113f-44f1-bfaf-c40001ba9f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda6c9d5-113f-44f1-bfaf-c40001ba9f60.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "eee00aa2-c730-5ff1-84a9-51d95a9fe180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529ebe9-c809-4c84-9096-1fa05388b660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529ebe9-c809-4c84-9096-1fa05388b660.jpg?1",
             "name": "Rule of Law",
             "text": "Each player can't play more than one spell each turn.",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "a2be2e9b-5211-53e6-ac6a-abd65dbcac1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621f9a58-0bc8-40dd-aef1-43618274d6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621f9a58-0bc8-40dd-aef1-43618274d6fe.jpg?1",
             "name": "Samite Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "be665b02-1cf2-50c6-8861-85da921bc853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b2f11-7420-4fa7-98f0-4f4be2093355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b2f11-7420-4fa7-98f0-4f4be2093355.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance (This creature can't be blocked except by creatures with flying or reach, and attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "b2f56602-e85a-588f-a4be-40b6e56f44f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354aa649-0261-4fb3-ac83-babc0e957be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354aa649-0261-4fb3-ac83-babc0e957be2.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "fe9187fa-cd14-5618-9a62-bcf18b523d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba6c4f3-59cf-4eb8-97fb-c9138005e19c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba6c4f3-59cf-4eb8-97fb-c9138005e19c.jpg?1",
             "name": "Serra's Embrace",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+2 and has flying and vigilance. (It can't be blocked except by creatures with flying or reach, and attacking doesn't cause it to tap.)",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "dc219ada-64b4-5846-9840-e49986109aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288d296-a8d5-43b5-b281-ba7063407724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288d296-a8d5-43b5-b281-ba7063407724.jpg?1",
             "name": "Serra's Embrace",
             "text": "",
             "colours": [
@@ -1968,7 +1968,7 @@
         },
         {
             "id": "db398a18-0d81-50ba-bc86-a7de52a1be7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cda455-34dc-45b6-aafc-825c1c42b67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cda455-34dc-45b6-aafc-825c1c42b67b.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "Flying, first strike (This creature can't be blocked except by creatures with flying or reach, and it deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "db62961f-51de-569a-bfd8-b3f82abf1b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9989475-fba5-4043-98bd-a4eb106eb487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9989475-fba5-4043-98bd-a4eb106eb487.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "66993685-84dd-5143-9454-8a4028d10a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa4af5-f0cb-4512-bef5-2e46a43aa27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa4af5-f0cb-4512-bef5-2e46a43aa27b.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying, vigilance (This creature can't be blocked except by creatures with flying or reach, and attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "5e670818-f7b1-52a6-bc6f-c9eccb8ce3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae3b1f4-54d3-40b5-8696-1d0e1989e931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae3b1f4-54d3-40b5-8696-1d0e1989e931.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "261c0ce9-13d9-58e2-922b-d4068ff4d743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fd8f5-6e12-4675-99bb-b493af6a9e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fd8f5-6e12-4675-99bb-b493af6a9e52.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "Flying, double strike (This creature can't be blocked except by creatures with flying or reach, and it deals both first-strike and regular combat damage.)",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "0bd58de8-5807-55d0-a5ad-ebe42f2f1ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bfcc61-80fe-4d21-8219-d31420a28989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bfcc61-80fe-4d21-8219-d31420a28989.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "bcc70712-566e-5a6f-8d73-f1ab87c57454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe5fe13-b57d-4514-89e6-79909474f7e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe5fe13-b57d-4514-89e6-79909474f7e8.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature comes into play, you gain 1 life.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "a563f008-ed9f-5fc4-b6aa-1e68d63cb814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d0e011-b0e3-461d-bbf2-bb1ca77b94bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d0e011-b0e3-461d-bbf2-bb1ca77b94bd.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "0da4a2a0-4d13-5c8a-bdff-12b67070798e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc4de07-4a46-41d6-81b8-4d6299b88ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc4de07-4a46-41d6-81b8-4d6299b88ee7.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "ae68e914-6896-5ee8-af5f-8ea88f5e0200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e436d-5c46-4a39-b773-99548befb9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e436d-5c46-4a39-b773-99548befb9fa.jpg?1",
             "name": "Spirit Weaver",
             "text": "{2}: Target green or blue creature gets +0/+1 until end of turn.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "ecf2b08e-7eca-5f13-a9f7-7a915ee259f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d2139e-76ea-49e2-ac43-6d9cc51ca09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d2139e-76ea-49e2-ac43-6d9cc51ca09f.jpg?1",
             "name": "Starlight Invoker",
             "text": "{7}{W}: You gain 5 life.",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "c81dca90-b0cf-5ce8-965c-8dbe5a55cc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a5c12b-c947-4a71-b54f-e310150858a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a5c12b-c947-4a71-b54f-e310150858a3.jpg?1",
             "name": "Steadfast Guard",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "c3b8083a-bbe4-524f-8e90-8b8a493152db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07631735-2024-4e7a-b8b3-b7743f4e4a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07631735-2024-4e7a-b8b3-b7743f4e4a86.jpg?1",
             "name": "Steadfast Guard",
             "text": "",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "b5bdfa8c-00ab-5b6a-b97a-ee77ffcbc4e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6194fab1-c185-4df5-8900-37d28ffae545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6194fab1-c185-4df5-8900-37d28ffae545.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "6b754dda-9a6c-5762-ae67-8069101eb4d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4886566-af41-4d14-8ae1-ce2952db8e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4886566-af41-4d14-8ae1-ce2952db8e42.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "f286fe97-e2ad-5a5a-8e7f-0caa9dc898b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d4bbec-c20b-437f-88e2-d609fd7c6003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d4bbec-c20b-437f-88e2-d609fd7c6003.jpg?1",
             "name": "Suntail Hawk",
             "text": "",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "f44e0c48-1740-5e18-859f-4e4615f3a3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1475f999-5a85-4177-aa30-15c51cf69812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1475f999-5a85-4177-aa30-15c51cf69812.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -2566,7 +2566,7 @@
         },
         {
             "id": "cfa41bcc-edea-53e6-8aec-e7f9d5d23089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0282b59e-78ef-412d-bb76-fb337f32a213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0282b59e-78ef-412d-bb76-fb337f32a213.jpg?1",
             "name": "Treasure Hunter",
             "text": "When Treasure Hunter comes into play, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "46743f03-e0a4-5976-8d42-c3b698384b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a9c5c4-47d1-4b87-8cbd-2212ee6c5887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a9c5c4-47d1-4b87-8cbd-2212ee6c5887.jpg?1",
             "name": "True Believer",
             "text": "You have shroud. (You can't be the target of spells or abilities.)",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "c84cfe08-d681-58e9-a003-1447f3b6d0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e41e3-919c-4bd3-9eea-adc0291f5f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e41e3-919c-4bd3-9eea-adc0291f5f8a.jpg?1",
             "name": "True Believer",
             "text": "",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "94cb0244-f6ae-50c5-ba26-fd3f861c3bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f573db-f4f8-4311-ba47-234e5171da3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f573db-f4f8-4311-ba47-234e5171da3d.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2707,7 +2707,7 @@
         },
         {
             "id": "ede09d78-f4b5-59eb-8356-dd125323f74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eec9aa-3058-4746-9a7d-0e880b0ce3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eec9aa-3058-4746-9a7d-0e880b0ce3ad.jpg?1",
             "name": "Tundra Wolves",
             "text": "",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "8732b0a8-0c4e-5179-9855-d139dbad85c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36501d5-4f45-4191-b8ec-6ab435b61bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36501d5-4f45-4191-b8ec-6ab435b61bc1.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "814b54df-221c-5fdb-a516-0fbd438b57a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4673ac-4305-4fb2-9ba2-1c72f04574c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4673ac-4305-4fb2-9ba2-1c72f04574c3.jpg?1",
             "name": "Voice of All",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nAs Voice of All comes into play, choose a color.\nVoice of All has protection from the chosen color. (It can't be blocked, targeted, dealt damage, or enchanted by anything of the chosen color.)",
             "colours": [
@@ -2813,7 +2813,7 @@
         },
         {
             "id": "3c6b79b0-1a84-5584-83c6-954430868f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db289ae0-b36a-43de-9e1b-56aaf6bf6ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db289ae0-b36a-43de-9e1b-56aaf6bf6ad8.jpg?1",
             "name": "Voice of All",
             "text": "",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "fefca4a6-440f-56be-ba90-b8587c55d347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6938602-d531-4ff1-abb3-c7982864c2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6938602-d531-4ff1-abb3-c7982864c2e0.jpg?1",
             "name": "Wall of Swords",
             "text": "Defender, flying (This creature can't attack, and it can block creatures with flying.)",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "4ffc3780-0054-5128-b97e-b19d06b483c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14792249-fadc-48a6-a4df-2034c576688f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14792249-fadc-48a6-a4df-2034c576688f.jpg?1",
             "name": "Wall of Swords",
             "text": "",
             "colours": [
@@ -2918,7 +2918,7 @@
         },
         {
             "id": "2bf3fff9-15c9-5cda-9a04-d0ea22180c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09117d06-79e6-4f86-ba92-d1f8fe165147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09117d06-79e6-4f86-ba92-d1f8fe165147.jpg?1",
             "name": "Warrior's Honor",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "75e792c1-d5d9-5712-9462-230fa196f861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ecf12-b750-4a95-85c8-8612d2a77a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ecf12-b750-4a95-85c8-8612d2a77a0a.jpg?1",
             "name": "Wild Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "9e583bce-5201-59f8-aa5c-f85c55824f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed40871-63a9-4ae2-8df8-8229e12fa252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed40871-63a9-4ae2-8df8-8229e12fa252.jpg?1",
             "name": "Wild Griffin",
             "text": "",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "556e35e6-ad67-51c6-8580-eda71597a507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b6d10c-89eb-42a9-beda-129dbc5c79af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b6d10c-89eb-42a9-beda-129dbc5c79af.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCreatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "9e49c166-9728-5259-b3e9-758b3c1357c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd367-9f6c-42d2-ab67-54d6e3b61d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd367-9f6c-42d2-ab67-54d6e3b61d7b.jpg?1",
             "name": "Windborn Muse",
             "text": "",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "3c0d065a-4aa4-55f4-bc11-bd326d23e5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b969f680-b176-4bfa-a160-714de8e03c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b969f680-b176-4bfa-a160-714de8e03c25.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "f4937944-9439-5887-85e0-fc3705243da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb437-9c76-4b87-99ba-1e24047dc3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb437-9c76-4b87-99ba-1e24047dc3a6.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "bfed2fdd-d029-545f-88f7-5ab45446cf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b0f2a2-464d-41c1-a78a-49a4c1f0db69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b0f2a2-464d-41c1-a78a-49a4c1f0db69.jpg?1",
             "name": "Youthful Knight",
             "text": "",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "b8a68840-4044-52c0-a14e-0a1c630ba42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62ca800-ec24-476e-b56f-834eef9622a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62ca800-ec24-476e-b56f-834eef9622a9.jpg?1",
             "name": "Academy Researchers",
             "text": "When Academy Researchers comes into play, you may put an Aura card from your hand into play attached to Academy Researchers.",
             "colours": [
@@ -3229,7 +3229,7 @@
         },
         {
             "id": "76ddd7f5-1a84-55d5-98f5-4883c217e0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2326dd-78c9-46bb-a459-306602939a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2326dd-78c9-46bb-a459-306602939a41.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "76d4f437-02e5-5f1c-a1d3-eddb55e8725d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0720105-eb26-42a0-a12e-1f05e8af0f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0720105-eb26-42a0-a12e-1f05e8af0f3d.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "29723d8d-34c9-5009-8b79-2c679e35f674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b261067f-b5de-41cc-ba9e-6ef4c061e170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b261067f-b5de-41cc-ba9e-6ef4c061e170.jpg?1",
             "name": "Ambassador Laquatus",
             "text": "{3}: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -3336,7 +3336,7 @@
         },
         {
             "id": "6f08f7f6-ecfb-584f-ae7a-c6e4d9c4da35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed53483-4bec-491b-9ae6-afc6faf122a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed53483-4bec-491b-9ae6-afc6faf122a2.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "aeb1b742-645c-5dab-ba9b-35d51649e074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55552a2b-1861-4235-a60d-ccabb4839d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55552a2b-1861-4235-a60d-ccabb4839d54.jpg?1",
             "name": "Aura Graft",
             "text": "Gain control of target Aura that's attached to a permanent. Attach it to another permanent it can enchant.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "758df5d5-992f-5d30-b6bc-87cb1a0788ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2cd91-84a7-4d05-9a0c-55440491be1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2cd91-84a7-4d05-9a0c-55440491be1e.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "e4b4684b-8e14-5fcf-9286-497b7afd5b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21991934-378a-49e0-8678-0c444f8f94ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21991934-378a-49e0-8678-0c444f8f94ee.jpg?1",
             "name": "Aven Fisher",
             "text": "",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "d833c453-58c5-5ff6-91b2-f526ca5f808a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67d7ae-3117-433f-ad82-44a4f015fecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67d7ae-3117-433f-ad82-44a4f015fecf.jpg?1",
             "name": "Aven Windreader",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{1}{U}: Target player reveals the top card of his or her library.",
             "colours": [
@@ -3513,7 +3513,7 @@
         },
         {
             "id": "e11ae348-44d1-5d45-bc5c-99a44d2acd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c0a27-eefc-46f6-88ad-ab0846e802ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c0a27-eefc-46f6-88ad-ab0846e802ef.jpg?1",
             "name": "Aven Windreader",
             "text": "",
             "colours": [
@@ -3550,7 +3550,7 @@
         },
         {
             "id": "1aac00c8-3b6e-5bdd-9fde-6cfcbc7837c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4095675-1e3f-4d3c-b565-5c434d2e5cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4095675-1e3f-4d3c-b565-5c434d2e5cc0.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "cdc96814-2f52-5314-80ab-0cff2dcc5054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850d1d5-f506-4e50-9d51-408f987bbbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850d1d5-f506-4e50-9d51-408f987bbbbd.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -3614,7 +3614,7 @@
         },
         {
             "id": "9af574e4-dc6e-5246-8fe7-fee6c4c77a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c5272d-df5b-4c21-9bff-4d6245b8d2a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c5272d-df5b-4c21-9bff-4d6245b8d2a6.jpg?1",
             "name": "Cephalid Constable",
             "text": "Whenever Cephalid Constable deals combat damage to a player, return up to that many target permanents that player controls to their owners' hands.",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "8dfc67e9-8323-5d1f-9e25-9f9394abd5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782f78b-ff4d-4567-8606-d4f0ebb0a304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782f78b-ff4d-4567-8606-d4f0ebb0a304.jpg?1",
             "name": "Clone",
             "text": "As Clone comes into play, you may choose a creature in play. If you do, Clone comes into play as a copy of that creature.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "596a7bd4-895b-5e7c-8124-373fd709444d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc3025-704f-476b-bcb3-74b905755dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc3025-704f-476b-bcb3-74b905755dc9.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "4fed8c53-5ff9-51ce-a7a8-2fc629bf3d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa91c8a-0838-4c12-8f7a-c038ff6d6e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa91c8a-0838-4c12-8f7a-c038ff6d6e69.jpg?1",
             "name": "Cloud Elemental",
             "text": "",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "fdbec3b3-f6f2-5149-a70a-4f9d2622a87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feacf831-a6e4-456b-b8f2-d7ec554281a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feacf831-a6e4-456b-b8f2-d7ec554281a1.jpg?1",
             "name": "Cloud Sprite",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCloud Sprite can block only creatures with flying.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "ba5acf09-98cc-5052-b65e-c5145e92fc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0bf2fd-0341-461b-b19b-c79016f0d890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0bf2fd-0341-461b-b19b-c79016f0d890.jpg?1",
             "name": "Cloud Sprite",
             "text": "",
             "colours": [
@@ -3823,7 +3823,7 @@
         },
         {
             "id": "eb5c94c7-5494-5669-9c54-6f3672d65683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1224718a-e1a7-473d-ac9d-497e624376cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1224718a-e1a7-473d-ac9d-497e624376cd.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "Draw two cards.",
             "colours": [
@@ -3855,7 +3855,7 @@
         },
         {
             "id": "8d5f87fd-7a87-572b-bdce-303effec6b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186271c-2b03-4e0c-b922-27e23787d865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186271c-2b03-4e0c-b922-27e23787d865.jpg?1",
             "name": "Crafty Pathmage",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "5a50a7e8-2ed1-5e8a-8867-c96f1186bd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414ad73-146e-47a6-926a-ec148194bb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414ad73-146e-47a6-926a-ec148194bb50.jpg?1",
             "name": "Dehydration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "2bbaf3d6-9fbc-5ab8-93d3-d26e2ddec999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404659c-7354-419c-b6bb-7f2fe21af958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404659c-7354-419c-b6bb-7f2fe21af958.jpg?1",
             "name": "Dehydration",
             "text": "",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "a9a74d88-7663-5419-a74c-5a28e8642b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf37153-ec4c-4c2f-89f7-450f0a157311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf37153-ec4c-4c2f-89f7-450f0a157311.jpg?1",
             "name": "Deluge",
             "text": "Tap all creatures without flying.",
             "colours": [
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "f4ee3e9e-21da-5a63-8278-3efa59da7df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7e928-511c-4a31-b1fb-8c28bd41182a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7e928-511c-4a31-b1fb-8c28bd41182a.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep comes into play, return each other creature you control to its owner's hand.",
             "colours": [
@@ -4026,7 +4026,7 @@
         },
         {
             "id": "e2066f75-65de-5254-82f2-8e1f969bf31b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bee0d51-f4a1-4a3a-9ccd-540c3afe62d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bee0d51-f4a1-4a3a-9ccd-540c3afe62d0.jpg?1",
             "name": "Discombobulate",
             "text": "Counter target spell. Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "6f9ae90a-5638-5b88-a3d7-ccea4372eb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ebb96f-185b-4aa5-ad4b-9c02ce44d387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ebb96f-185b-4aa5-ad4b-9c02ce44d387.jpg?1",
             "name": "Dreamborn Muse",
             "text": "At the beginning of each player's upkeep, that player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards in his or her hand.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "100f46ae-e457-5491-b5d1-66cd9284304c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978fa0a-a52b-4464-afe3-d9f7bc202e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978fa0a-a52b-4464-afe3-d9f7bc202e63.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "f90fe5cb-ee47-51f2-8a8c-3ced26f1b446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e5fd8-2542-4fc9-a806-d9af287dd734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e5fd8-2542-4fc9-a806-d9af287dd734.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -4156,7 +4156,7 @@
         },
         {
             "id": "5d45d146-5a42-502e-affb-71f3e81cf7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95534175-0bf8-4460-8182-117dc1487dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95534175-0bf8-4460-8182-117dc1487dcb.jpg?1",
             "name": "Fog Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Fog Elemental attacks or blocks, sacrifice it at end of combat.",
             "colours": [
@@ -4191,7 +4191,7 @@
         },
         {
             "id": "6c515488-2a63-5b1e-84a4-987b5fa993af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5c785-a51d-4c43-8cda-57005ae566a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5c785-a51d-4c43-8cda-57005ae566a8.jpg?1",
             "name": "Fog Elemental",
             "text": "",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "4492a8f1-a2bf-581a-9ee0-e488f9241c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7be532-d353-4961-94bf-db3265515753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7be532-d353-4961-94bf-db3265515753.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "4405f887-4eb7-5e3e-874d-1bfe79ec0ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32862f4-53ed-41c7-b90f-5df2c01dd447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32862f4-53ed-41c7-b90f-5df2c01dd447.jpg?1",
             "name": "Horseshoe Crab",
             "text": "{U}: Untap Horseshoe Crab.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "5ac794d2-4c66-5332-afb1-54b24bc11823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a42c38-6129-4e6e-9e27-e2c812ce6f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a42c38-6129-4e6e-9e27-e2c812ce6f45.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "Return all artifacts target player owns to his or her hand.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "cb8e5b8f-706a-5b09-884e-ed32ceeec0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a03ba5a-ac27-4fce-9eaf-b029ab26f9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a03ba5a-ac27-4fce-9eaf-b029ab26f9e1.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "404d6f98-eefb-5dea-8e81-aed2b5956437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a79bb42-a4c4-46c6-a5ed-43bbf028a7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a79bb42-a4c4-46c6-a5ed-43bbf028a7f0.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "206c4a07-1442-5fee-acd8-7a8a00da57a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95fb2c-3d6b-4b12-8bf3-f869dd2c2a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95fb2c-3d6b-4b12-8bf3-f869dd2c2a17.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "60961bae-4655-5a6b-843d-f6180c2c310d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17edd1-e9ed-4fd5-a304-f9a34983d138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17edd1-e9ed-4fd5-a304-f9a34983d138.jpg?1",
             "name": "March of the Machines",
             "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
             "colours": [
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "82306a22-03b6-5cbd-ba72-0002755c4217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94aadbd-625c-4bfc-8e31-00a680094332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94aadbd-625c-4bfc-8e31-00a680094332.jpg?1",
             "name": "March of the Machines",
             "text": "",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "46a7e3a9-4e93-5d73-b35e-6ad63cc195cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e4e99d-5834-4f6c-b915-4f95edc1337f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e4e99d-5834-4f6c-b915-4f95edc1337f.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "7cf5654d-d547-50ce-838a-75ff6045fd0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a5bfa-9a50-4610-acd7-19fc0a53f798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a5bfa-9a50-4610-acd7-19fc0a53f798.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"islandwalk.\" This effect doesn't end at end of turn.)",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "b00ad339-0cc1-59d4-b8a4-c827b6512b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb5c0f0-fa65-4868-b0da-e4e7b4c9a2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb5c0f0-fa65-4868-b0da-e4e7b4c9a2f3.jpg?1",
             "name": "Mind Bend",
             "text": "",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "284ed7cc-8917-5005-bfa9-e7c61b1fb85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869a6c06-eae5-418e-9a5c-26598a929416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869a6c06-eae5-418e-9a5c-26598a929416.jpg?1",
             "name": "Peek",
             "text": "Look at target player's hand.\nDraw a card.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "b4f659b7-bef9-527b-95e8-55cc9c444ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e957fab3-7a79-4b8f-813a-daaabb0ccbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e957fab3-7a79-4b8f-813a-daaabb0ccbea.jpg?1",
             "name": "Persuasion",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nYou control enchanted creature.",
             "colours": [
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "022ee2d2-d02b-580e-a549-ed9555ef9153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab3611c-b0ab-48ea-8c64-e7c500e95fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab3611c-b0ab-48ea-8c64-e7c500e95fc5.jpg?1",
             "name": "Persuasion",
             "text": "",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "8d5006e3-45cb-5d9f-896d-83a22d86d53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ea51c-1ef0-49ed-93de-52f8f6a9d595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ea51c-1ef0-49ed-93de-52f8f6a9d595.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "5a1f3fc3-e970-5408-94ef-e7c78e57000b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ae2f8-1e19-495a-86a9-8391e1e14ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ae2f8-1e19-495a-86a9-8391e1e14ac5.jpg?1",
             "name": "Plagiarize",
             "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "c7f34f83-c800-5987-8520-5ae1705871d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0814958-2fec-443e-b27e-cd2416ccbf95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0814958-2fec-443e-b27e-cd2416ccbf95.jpg?1",
             "name": "Puppeteer",
             "text": "{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "4fa9bf42-9170-594e-bbf9-42111adea313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49a8b0d-f130-4a16-a79c-607618cc40bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49a8b0d-f130-4a16-a79c-607618cc40bd.jpg?1",
             "name": "Reminisce",
             "text": "Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "f37b2caa-03c5-51ec-a02a-c2e5311a9fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35673701-684c-4ba6-99f5-74364bc6fec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35673701-684c-4ba6-99f5-74364bc6fec2.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "9626b37d-3a04-5cd6-a636-943981354e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9948fcc3-6e95-4b39-accd-a4083fff1244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9948fcc3-6e95-4b39-accd-a4083fff1244.jpg?1",
             "name": "Robe of Mirrors",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "23aabc91-9146-5367-9cce-4fe955861abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110b92c8-6bc3-4b2d-b71d-d04db8c3b465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110b92c8-6bc3-4b2d-b71d-d04db8c3b465.jpg?1",
             "name": "Robe of Mirrors",
             "text": "",
             "colours": [
@@ -4937,7 +4937,7 @@
         },
         {
             "id": "f1eba89f-dd82-5843-80a9-e9b2cd3a6037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da47bd4-58b6-4ef3-bd42-caf947e38645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da47bd4-58b6-4ef3-bd42-caf947e38645.jpg?1",
             "name": "Rootwater Commando",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "f76ee94d-b1a1-5c9f-bdc8-4bf659844cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c1cfde-c08e-4fda-8b3c-7e7a0121f87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c1cfde-c08e-4fda-8b3c-7e7a0121f87b.jpg?1",
             "name": "Rootwater Commando",
             "text": "",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "fc96da15-9362-585a-b555-f7a7e5480e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09179261-aa02-4144-9028-3b8d6420a860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09179261-aa02-4144-9028-3b8d6420a860.jpg?1",
             "name": "Rootwater Matriarch",
             "text": "{T}: Gain control of target creature as long as that creature is enchanted.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "cdf65c48-2ac8-522a-bbcf-2f8165187a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed89567-cb18-4e51-a978-eac81d112aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed89567-cb18-4e51-a978-eac81d112aa1.jpg?1",
             "name": "Sage Owl",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Sage Owl comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "67adcf6f-bf56-5ca8-a3fb-a1045b4fba41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d6c0f1-7479-4f15-8d85-e8dfface190d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d6c0f1-7479-4f15-8d85-e8dfface190d.jpg?1",
             "name": "Sage Owl",
             "text": "",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "d5124438-a5d4-5b3b-88af-d179f4b9c9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ca697-bdf4-41df-973d-22a0ce89ad35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ca697-bdf4-41df-973d-22a0ce89ad35.jpg?1",
             "name": "Scalpelexis",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Scalpelexis deals combat damage to a player, that player removes the top four cards of his or her library from the game. If two or more of those cards have the same name, repeat this process.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "f4670242-6ae0-5ec4-872d-391386bb026b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d19d71-3ae2-4c48-aa7e-406b2c188b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d19d71-3ae2-4c48-aa7e-406b2c188b99.jpg?1",
             "name": "Scalpelexis",
             "text": "",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "9db6f50d-3242-5cbc-9f71-45477f4967df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3809b4c6-79b4-4a06-8fc9-beabc278cbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3809b4c6-79b4-4a06-8fc9-beabc278cbf8.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an Island.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "a122a3b0-b686-5b96-a02c-926423c65b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c9aa9f-acd5-4908-9e11-1a152363ef42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c9aa9f-acd5-4908-9e11-1a152363ef42.jpg?1",
             "name": "Shimmering Wings",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\n{U}: Return Shimmering Wings to its owner's hand.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "41b6098d-f7d9-5a37-9734-01dff7ce4912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2c0439-aed2-4ed5-b38a-d2b321811ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2c0439-aed2-4ed5-b38a-d2b321811ccc.jpg?1",
             "name": "Shimmering Wings",
             "text": "",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "39adc884-8e24-572d-ad54-74561b1cb139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917a5c02-89b1-4d06-8d65-8db8c9c485a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917a5c02-89b1-4d06-8d65-8db8c9c485a9.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -5317,7 +5317,7 @@
         },
         {
             "id": "18db55ad-e62f-5c76-a6b8-743378d6ea38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e0e4-d077-46a5-850c-68399fd16da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e0e4-d077-46a5-850c-68399fd16da6.jpg?1",
             "name": "Sky Weaver",
             "text": "{2}: Target white or black creature gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -5353,7 +5353,7 @@
         },
         {
             "id": "e451cc8a-2bbe-5850-adc4-fb1b738bcef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58d58cf-3023-43cd-8aec-61e32510471a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58d58cf-3023-43cd-8aec-61e32510471a.jpg?1",
             "name": "Sky Weaver",
             "text": "",
             "colours": [
@@ -5389,7 +5389,7 @@
         },
         {
             "id": "381e8d26-d8ca-5755-ba19-5fba857a7920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b2ad93-8287-4b87-88ed-c627bd54fd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b2ad93-8287-4b87-88ed-c627bd54fd49.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "c0b0e7a5-4252-57f5-8ed0-399d08c0523f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fdfc2-782c-4a3f-8761-ace19c479b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fdfc2-782c-4a3f-8761-ace19c479b07.jpg?1",
             "name": "Snapping Drake",
             "text": "",
             "colours": [
@@ -5459,7 +5459,7 @@
         },
         {
             "id": "e0d42d12-40a7-54d5-b688-84841a8bc72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0586e0-5e93-4742-a5ae-893edd49117d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0586e0-5e93-4742-a5ae-893edd49117d.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nSacrifice Spiketail Hatchling: Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -5494,7 +5494,7 @@
         },
         {
             "id": "c31c9d06-507b-59fa-a1bc-402d38a5d9a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4905c-9227-4f0f-a41a-d7509740c1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4905c-9227-4f0f-a41a-d7509740c1ce.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "",
             "colours": [
@@ -5529,7 +5529,7 @@
         },
         {
             "id": "0d3888b4-3eb2-5cb5-b7de-0c8a3257f0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f136c6af-fda0-4c4a-a67b-f431e4e51385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f136c6af-fda0-4c4a-a67b-f431e4e51385.jpg?1",
             "name": "Sunken Hope",
             "text": "At the beginning of each player's upkeep, that player returns a creature he or she controls to its owner's hand.",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "976585bc-fe72-56aa-b841-c4331d81655f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158b0bb5-04c0-41aa-ac39-43bb0f274fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158b0bb5-04c0-41aa-ac39-43bb0f274fd7.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -5593,7 +5593,7 @@
         },
         {
             "id": "27745694-8868-5240-aa72-cdb326bd1e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caf69d0-58bd-4cd1-9108-56e6cbf882e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caf69d0-58bd-4cd1-9108-56e6cbf882e4.jpg?1",
             "name": "Telling Time",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "3c265fdb-4a70-5ee7-ba8e-a67eac8d7b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96395d53-5eaa-4d17-a473-f685ad925eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96395d53-5eaa-4d17-a473-f685ad925eaf.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "2081f76c-b206-5d08-a191-fcb60723b9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270ec8a0-71c0-45dc-b79b-6272216eceb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270ec8a0-71c0-45dc-b79b-6272216eceb3.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "9add78c6-3207-5f67-aa15-618adb14497b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39195bf4-896a-4a58-a7de-b9110216333b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39195bf4-896a-4a58-a7de-b9110216333b.jpg?1",
             "name": "Tidings",
             "text": "Draw four cards.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "81bcb781-c127-5def-8c17-ffcc2f09849a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521d1b29-c25b-443b-ae5f-07c11786947e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521d1b29-c25b-443b-ae5f-07c11786947e.jpg?1",
             "name": "Time Stop",
             "text": "End the turn. (Remove all spells and abilities on the stack from the game, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "4b375581-c43d-5bd1-b990-a0fa496b8262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433ca5fe-2b38-4b37-98eb-4f2860990f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433ca5fe-2b38-4b37-98eb-4f2860990f87.jpg?1",
             "name": "Time Stop",
             "text": "",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "5ef80896-673a-548a-9eaa-05db2cbb07a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c878780-f666-44ab-a60e-c9985f628fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c878780-f666-44ab-a60e-c9985f628fc3.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "e5b81af3-5518-57ab-b42b-ab62e3732c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4e697d-8fef-4db9-ac8c-c5e940a9ab07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4e697d-8fef-4db9-ac8c-c5e940a9ab07.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "0ead5084-cdde-5f7e-a60b-1a0b9f64a995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d65aee-242e-4255-b2a7-5a3a3b464b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d65aee-242e-4255-b2a7-5a3a3b464b48.jpg?1",
             "name": "Twincast",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "7b259873-da0b-5e3c-982e-986bf2504820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881386b4-fc85-49f7-b2a5-3b41f6a6c920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881386b4-fc85-49f7-b2a5-3b41f6a6c920.jpg?1",
             "name": "Twitch",
             "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "7248b1c8-b57b-5382-9c5f-4366ed1c254c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe16e3c-9cf5-4b5a-8ec9-8a2d60f3fcc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe16e3c-9cf5-4b5a-8ec9-8a2d60f3fcc9.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "0d2b2057-eb16-5435-aea9-61b3038ae9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea34a540-486b-42dc-993c-93698988d024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea34a540-486b-42dc-993c-93698988d024.jpg?1",
             "name": "Vedalken Mastermind",
             "text": "{U}, {T}: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "48792ac1-73cf-5a28-bf61-949b5950d881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40595366-8601-40e0-a070-fc218723270d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40595366-8601-40e0-a070-fc218723270d.jpg?1",
             "name": "Wall of Air",
             "text": "Defender, flying (This creature can't attack, and it can block creatures with flying.)",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "c7e4eda9-dc2e-5243-8a1d-7097e3b2b319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ce111-91c4-4ae2-91ed-6c69a91fb2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ce111-91c4-4ae2-91ed-6c69a91fb2bb.jpg?1",
             "name": "Wall of Air",
             "text": "",
             "colours": [
@@ -6058,7 +6058,7 @@
         },
         {
             "id": "9acf4d13-d68f-5fec-93b4-caf0a14725a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f18447-2853-469b-b3b3-20d6bcafa6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f18447-2853-469b-b3b3-20d6bcafa6e7.jpg?1",
             "name": "Afflict",
             "text": "Target creature gets -1/-1 until end of turn.\nDraw a card.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "4429ce97-b78e-5bc4-bd34-a38b26794bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bac7a8-d3bb-4032-b30b-db7328e4d2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bac7a8-d3bb-4032-b30b-db7328e4d2fc.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand and choose two cards from it. Put them on top of that player's library in any order.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "bba43f4e-a9eb-5c89-8389-5935a1fbd8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82419eea-a397-41df-b526-f3bea857bbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82419eea-a397-41df-b526-f3bea857bbbd.jpg?1",
             "name": "Ascendant Evincar",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nOther black creatures get +1/+1.\nNonblack creatures get -1/-1.",
             "colours": [
@@ -6161,7 +6161,7 @@
         },
         {
             "id": "c206ab94-4325-5766-91d6-62b8f50aeac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1244ad-5b5f-41e8-bb0e-9cc854e663fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1244ad-5b5f-41e8-bb0e-9cc854e663fb.jpg?1",
             "name": "Ascendant Evincar",
             "text": "",
             "colours": [
@@ -6200,7 +6200,7 @@
         },
         {
             "id": "c6f3da33-27e8-51e4-9859-ef7cb3cdbe61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79599f4-7038-4b8f-9a44-e58b650f21a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79599f4-7038-4b8f-9a44-e58b650f21a7.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -6232,7 +6232,7 @@
         },
         {
             "id": "efdd5367-9393-54c1-a6b8-c7810ee87ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee97c64-39ab-4967-a7e4-3fc5e793d534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee97c64-39ab-4967-a7e4-3fc5e793d534.jpg?1",
             "name": "Beacon of Unrest",
             "text": "Put target artifact or creature card in a graveyard into play under your control. Shuffle Beacon of Unrest into its owner's library.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "ac084dab-6ac0-55fa-94b7-e009fede9012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b39f2d-96f2-4cac-9f6d-a061dbef749b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b39f2d-96f2-4cac-9f6d-a061dbef749b.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -6299,7 +6299,7 @@
         },
         {
             "id": "efaa7c3d-c5e0-5346-b3b2-c6a3d132c27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151643af-a8b7-4291-9ba1-839091eb342f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151643af-a8b7-4291-9ba1-839091eb342f.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "26180f1b-41a1-5fa5-9f6b-39ee08a1a203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8117171-08a7-44f6-9c14-12e8b96c7632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8117171-08a7-44f6-9c14-12e8b96c7632.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "2562f5f1-4de2-5834-a9ff-99092380d910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b6552-367e-4b0b-9095-42322843b1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b6552-367e-4b0b-9095-42322843b1b2.jpg?1",
             "name": "Contaminated Bond",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "9c0311e8-03c1-527d-9d90-6fa2dba2aae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f5ba76-b6dd-46cb-8b5f-415da19986e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f5ba76-b6dd-46cb-8b5f-415da19986e0.jpg?1",
             "name": "Contaminated Bond",
             "text": "",
             "colours": [
@@ -6436,7 +6436,7 @@
         },
         {
             "id": "e77dbe8c-5878-5881-b5f3-8203af673278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d9c1d-a984-4971-810c-e493d0a55e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d9c1d-a984-4971-810c-e493d0a55e5c.jpg?1",
             "name": "Cruel Edict",
             "text": "Target opponent sacrifices a creature.",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "7069fe50-d855-59ea-b445-e8068cda7559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9271cc-6525-4a44-af24-915f0ba5afa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9271cc-6525-4a44-af24-915f0ba5afa9.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -6500,7 +6500,7 @@
         },
         {
             "id": "e9435188-40bd-54c7-938f-798459b038ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb98f0e-5fa0-497e-9061-85cf0b3a3eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb98f0e-5fa0-497e-9061-85cf0b3a3eff.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -6532,7 +6532,7 @@
         },
         {
             "id": "77ce01d6-3609-519e-a0d4-6ad6770c45e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb7ade-ebbb-49fb-b64f-fa247f9a9af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb7ade-ebbb-49fb-b64f-fa247f9a9af6.jpg?1",
             "name": "Distress",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "49f64f3e-f0ff-5d4c-a730-5ea919857d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ff8ca-068d-4115-9139-df00b63e2912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ff8ca-068d-4115-9139-df00b63e2912.jpg?1",
             "name": "Doomed Necromancer",
             "text": "{B}, {T}, Sacrifice Doomed Necromancer: Return target creature card from your graveyard to play.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "fea2ad06-355d-5a9a-822d-66275d89cad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd5c07e-4ece-4c8b-93c8-6abd7dd3a39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd5c07e-4ece-4c8b-93c8-6abd7dd3a39a.jpg?1",
             "name": "Dross Crocodile",
             "text": "",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "2d080e75-7e1b-5f75-9c8f-18d02a4710dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e71542-b9c1-4431-bfef-da629a3edc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e71542-b9c1-4431-bfef-da629a3edc57.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "d9902515-6292-5a4a-9bde-a7616ad5f0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9038925-7acf-42b7-abec-c8eec9f591b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9038925-7acf-42b7-abec-c8eec9f591b6.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "42022e6f-e123-54a6-84df-ec826b13f5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f264f6-832c-42fe-8642-00ee0f009c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f264f6-832c-42fe-8642-00ee0f009c08.jpg?1",
             "name": "Dusk Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "b75509f6-c893-54a7-a51e-757066a0b4da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bcb6ac-b27f-4da3-9f68-40b3c59cda88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bcb6ac-b27f-4da3-9f68-40b3c59cda88.jpg?1",
             "name": "Dusk Imp",
             "text": "",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "d38298f2-29e8-57b0-b978-140aa2171cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af61c18-a7ac-42c8-a942-d2f546c1ef57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af61c18-a7ac-42c8-a942-d2f546c1ef57.jpg?1",
             "name": "Essence Drain",
             "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "b159e707-915c-5940-bd70-7f0416cc8def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa57eb-e307-4104-a291-c6cbfa235816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa57eb-e307-4104-a291-c6cbfa235816.jpg?1",
             "name": "Fear",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -6842,7 +6842,7 @@
         },
         {
             "id": "f49300ef-efa0-5b82-ace3-f2f06795fbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4136b-ad5b-4234-a476-90e1dcae00c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4136b-ad5b-4234-a476-90e1dcae00c6.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -6877,7 +6877,7 @@
         },
         {
             "id": "004adf9a-b59a-5d56-9093-df73b9929bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce1a3a3-f0b8-4088-85f6-8cbdd1f29e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce1a3a3-f0b8-4088-85f6-8cbdd1f29e65.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "f180c680-0dc9-5132-a713-65fdc4eefa75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd23186-6796-4430-86c5-f0d5337bbc91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd23186-6796-4430-86c5-f0d5337bbc91.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control is put into a graveyard from play, each other player sacrifices a creature.",
             "colours": [
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "1430ebef-2e40-57ce-8801-2f94b05d027e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d460b79-f1a5-41c4-a5b3-61f703fd97df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d460b79-f1a5-41c4-a5b3-61f703fd97df.jpg?1",
             "name": "Graveborn Muse",
             "text": "At the beginning of your upkeep, you draw X cards and you lose X life, where X is the number of Zombies you control.",
             "colours": [
@@ -6979,7 +6979,7 @@
         },
         {
             "id": "71fd9f58-2931-5c3c-957c-d98f2ab02862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57d35a-ca0b-4f93-867c-d0a9fb5108f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57d35a-ca0b-4f93-867c-d0a9fb5108f1.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7013,7 +7013,7 @@
         },
         {
             "id": "4c1a672a-3089-563f-a852-9580a425dbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b3c413-96ca-42c5-b263-f2da195c1854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b3c413-96ca-42c5-b263-f2da195c1854.jpg?1",
             "name": "Hate Weaver",
             "text": "{2}: Target blue or red creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7048,7 +7048,7 @@
         },
         {
             "id": "6b7fba1d-4937-5867-8a77-863ec30d432e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ab3037-7e62-46a7-800e-8bfa7d33f237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ab3037-7e62-46a7-800e-8bfa7d33f237.jpg?1",
             "name": "Head Games",
             "text": "Target opponent puts the cards from his or her hand on top of his or her library. Search that player's library for that many cards. The player puts those cards into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "6d030b32-0534-55c9-9c40-00bb59d4e164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac9d57-a724-4ad1-b6a7-805381c21bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac9d57-a724-4ad1-b6a7-805381c21bb3.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play, sacrifice it unless you discard a creature card.",
             "colours": [
@@ -7114,7 +7114,7 @@
         },
         {
             "id": "f58e52e4-ab1c-5ccf-a751-5d174e5138a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4d095-664e-4704-b922-f868d0d454d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4d095-664e-4704-b922-f868d0d454d3.jpg?1",
             "name": "Highway Robber",
             "text": "When Highway Robber comes into play, you gain 2 life and target opponent loses 2 life.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "c620a95f-984f-5234-b8f3-a2e359972e85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08978a4-1c3a-4abf-9991-fe36220e1f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08978a4-1c3a-4abf-9991-fe36220e1f4f.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
             "colours": [
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "f39b4446-0ca6-5446-8507-4b1ba37bb3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110f97e-d9a2-4575-be70-8b13dc85d418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110f97e-d9a2-4575-be70-8b13dc85d418.jpg?1",
             "name": "Hypnotic Specter",
             "text": "",
             "colours": [
@@ -7219,7 +7219,7 @@
         },
         {
             "id": "ec5227b0-8cbd-5cad-a27e-32a798a3ae0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d665187f-a8d3-40b6-bfaf-cf25d84484b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d665187f-a8d3-40b6-bfaf-cf25d84484b4.jpg?1",
             "name": "Knight of Dusk",
             "text": "{B}{B}: Destroy target creature blocking Knight of Dusk.",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "8830d071-858a-534c-ba8f-376dcc56d74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba629ab-a322-4a7c-b6e5-477ca1b709bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba629ab-a322-4a7c-b6e5-477ca1b709bf.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "50c75c75-4a07-5620-9798-5632fadf09e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea363c-ec09-4d79-aaf9-f8ff2e2a34c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea363c-ec09-4d79-aaf9-f8ff2e2a34c0.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample (This creature can't be blocked except by creatures with flying or reach. If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nAt the beginning of your upkeep, sacrifice a creature other than Lord of the Pit. If you can't, Lord of the Pit deals 7 damage to you.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "ad67ee3e-ce9d-5fd4-845b-a1673f717f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6293b9d-5454-4fb2-8351-b545b3187430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6293b9d-5454-4fb2-8351-b545b3187430.jpg?1",
             "name": "Lord of the Pit",
             "text": "",
             "colours": [
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "6022d604-c21f-599e-b65e-ff895bc51005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e773b-5feb-407f-a162-f35d6e693cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e773b-5feb-407f-a162-f35d6e693cca.jpg?1",
             "name": "Lord of the Undead",
             "text": "Other Zombie creatures get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "93ee4f89-0cd1-50a1-9525-401e2fccd32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5e3ea-fcca-42c2-b3af-bfcd3a81dfff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5e3ea-fcca-42c2-b3af-bfcd3a81dfff.jpg?1",
             "name": "Mass of Ghouls",
             "text": "",
             "colours": [
@@ -7427,7 +7427,7 @@
         },
         {
             "id": "0c960d75-fd2e-5a5a-ba78-58e10530fea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13604ba3-b238-4a63-80f7-9dc2d5d04ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13604ba3-b238-4a63-80f7-9dc2d5d04ded.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -7459,7 +7459,7 @@
         },
         {
             "id": "952369f6-d553-558f-8385-5c219c66653b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4239c4e8-41f3-47fd-bd01-fa0b28976e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4239c4e8-41f3-47fd-bd01-fa0b28976e29.jpg?1",
             "name": "Midnight Ritual",
             "text": "Remove X target creature cards in your graveyard from the game. For each creature card removed this way, put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -7491,7 +7491,7 @@
         },
         {
             "id": "9ba7d620-4e3f-554d-b245-7ad70b63a746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77cb309-1fb2-451e-a96d-b02b8c99932c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77cb309-1fb2-451e-a96d-b02b8c99932c.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "3616d597-cbda-5839-9478-85b8e18d0011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d9cfce-1507-4cdf-9d58-6ebaf44e72e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d9cfce-1507-4cdf-9d58-6ebaf44e72e3.jpg?1",
             "name": "Mortal Combat",
             "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
             "colours": [
@@ -7555,7 +7555,7 @@
         },
         {
             "id": "889dbfab-bcc2-5a94-ba57-01d229c6dccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad89ad-03ee-4227-b2a6-5d5002eecead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad89ad-03ee-4227-b2a6-5d5002eecead.jpg?1",
             "name": "Mortivore",
             "text": "Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\n{B}: Regenerate Mortivore. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "4cd3a77f-82ac-5204-8f60-b04234d2db30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c213d-9262-4cba-8bde-161baf8cc0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c213d-9262-4cba-8bde-161baf8cc0c0.jpg?1",
             "name": "Mortivore",
             "text": "",
             "colours": [
@@ -7625,7 +7625,7 @@
         },
         {
             "id": "60122d6f-448b-5df8-ac2a-8f5a1e841278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8f8f83-65bb-4da3-8263-e58162ebb24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8f8f83-65bb-4da3-8263-e58162ebb24b.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -7660,7 +7660,7 @@
         },
         {
             "id": "f560811b-3c5d-5929-8b17-e9ae8730cec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca42df8-a9a2-4391-8dec-7097f788c250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca42df8-a9a2-4391-8dec-7097f788c250.jpg?1",
             "name": "Nekrataal",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Nekrataal comes into play, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "37f0071d-09b9-5fdc-a5de-52061a01cb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24721dc-7473-4a7b-b42e-8ddcf027c7e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24721dc-7473-4a7b-b42e-8ddcf027c7e2.jpg?1",
             "name": "Nekrataal",
             "text": "",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "5bd291f0-560a-5046-bd07-a91bd3004f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88111e2b-84ff-48bf-9a64-b4e9022b6dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88111e2b-84ff-48bf-9a64-b4e9022b6dae.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -7768,7 +7768,7 @@
         },
         {
             "id": "d6fff2c5-c356-543e-9708-3a25de95244a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0001a4-18f9-460c-b26f-476ce55e6294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0001a4-18f9-460c-b26f-476ce55e6294.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "8d4f5d80-16ea-52cc-8201-93a46b803efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cfd454-5bc3-456c-9ca2-151af99f69ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cfd454-5bc3-456c-9ca2-151af99f69ce.jpg?1",
             "name": "No Rest for the Wicked",
             "text": "Sacrifice No Rest for the Wicked: Return to your hand all creature cards that were put into your graveyard from play this turn.",
             "colours": [
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "274c6a91-31d3-5adb-8707-3edca2cb62b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902c9b72-170c-4c25-a966-a55d689daae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902c9b72-170c-4c25-a966-a55d689daae8.jpg?1",
             "name": "Phage the Untouchable",
             "text": "When Phage the Untouchable comes into play, if you didn't play it from your hand, you lose the game.\nWhenever Phage deals combat damage to a creature, destroy that creature. It can't be regenerated.\nWhenever Phage deals combat damage to a player, that player loses the game.",
             "colours": [
@@ -7873,7 +7873,7 @@
         },
         {
             "id": "f9be8a22-a0cb-54e3-adbd-97fc4a5a3b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a85419a-7ebb-4fe1-891f-b5295e18878f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a85419a-7ebb-4fe1-891f-b5295e18878f.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager comes into play, you draw a card and you lose 1 life.",
             "colours": [
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "a29c83ec-1698-5321-b89f-06b782674335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5d3dac-98df-433f-a417-bcb9c91722fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5d3dac-98df-433f-a417-bcb9c91722fb.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -7943,7 +7943,7 @@
         },
         {
             "id": "65b16f51-24dc-5039-9d54-4a00c387fc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcc163a-6041-45a0-befb-b1174cfd6da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcc163a-6041-45a0-befb-b1174cfd6da4.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "0af7633e-8851-5afa-8611-fb3272f05fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327d38a9-e631-4f5e-a7c3-b99794a40954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327d38a9-e631-4f5e-a7c3-b99794a40954.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -8010,7 +8010,7 @@
         },
         {
             "id": "fd50dffd-b4d8-5956-9fec-b454fd1fef06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5811f4ee-f352-4b41-8f56-da0cb7f3f11b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5811f4ee-f352-4b41-8f56-da0cb7f3f11b.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy target land.",
             "colours": [
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "f4cf6831-f6af-51c9-af91-1246830ae0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8b556-6e18-46ee-80f8-cbd922e37432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8b556-6e18-46ee-80f8-cbd922e37432.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "aa1053c3-4b45-5742-beb6-36d9316b204f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864efca-d7c8-4ec7-8cda-ba89f9df7722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864efca-d7c8-4ec7-8cda-ba89f9df7722.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "70eb81fd-23fb-521a-9ac3-fae8f0ca5bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa876b-d6d4-4108-83e5-c06e9a786bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa876b-d6d4-4108-83e5-c06e9a786bcd.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature in play named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "23e48622-2895-5385-99a4-892c93a5d3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1d6b5-ee32-4d62-848d-884da6376c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1d6b5-ee32-4d62-848d-884da6376c63.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -8177,7 +8177,7 @@
         },
         {
             "id": "8c2f219b-5122-52b2-940c-988c5818d788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cbf71-1199-4457-9b09-f66e7cb294d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cbf71-1199-4457-9b09-f66e7cb294d5.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "74fa21a6-66f3-5395-a95f-19e9f0b1d24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1570397-0efa-4b31-a7fd-bdf4dcf690a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1570397-0efa-4b31-a7fd-bdf4dcf690a1.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever a creature dealt damage by Sengir Vampire this turn is put into a graveyard, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "47fe8296-36c6-5338-b239-9fa0cceba156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf0027a-4a1f-4403-bd7d-bc56ad5746cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf0027a-4a1f-4403-bd7d-bc56ad5746cb.jpg?1",
             "name": "Sengir Vampire",
             "text": "",
             "colours": [
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "e9cf9c31-aa62-53f4-bff2-71cd5e2f4004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82633f38-5af1-429e-8c9d-db536af85309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82633f38-5af1-429e-8c9d-db536af85309.jpg?1",
             "name": "Severed Legion",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "285ed705-6771-5dc8-8076-c252fe984278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34919e82-fded-4652-beaa-a2b2927e9dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34919e82-fded-4652-beaa-a2b2927e9dea.jpg?1",
             "name": "Severed Legion",
             "text": "",
             "colours": [
@@ -8351,7 +8351,7 @@
         },
         {
             "id": "d1797b46-68c8-57b9-913e-cca4feb3dae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60096938-d520-424a-afe4-0c5ee8b90aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60096938-d520-424a-afe4-0c5ee8b90aa1.jpg?1",
             "name": "Sleeper Agent",
             "text": "When Sleeper Agent comes into play, target opponent gains control of it.\nAt the beginning of your upkeep, Sleeper Agent deals 2 damage to you.",
             "colours": [
@@ -8386,7 +8386,7 @@
         },
         {
             "id": "65e0dbca-81ed-538d-8f71-d5ddc5a927b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a8d6d-8cd0-4dfe-9894-77eb60620884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a8d6d-8cd0-4dfe-9894-77eb60620884.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "e24e5e4e-722f-56ff-9555-9b76303fc6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0221a713-2fdc-4ff0-abe3-1d340d272232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0221a713-2fdc-4ff0-abe3-1d340d272232.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -8454,7 +8454,7 @@
         },
         {
             "id": "4c9c5ea9-5bca-5301-a0a2-2680fe75b04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509a386-0c11-425c-9946-ab4add1abfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509a386-0c11-425c-9946-ab4add1abfee.jpg?1",
             "name": "Stronghold Discipline",
             "text": "Each player loses 1 life for each creature he or she controls.",
             "colours": [
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "5fab2f5f-3737-5e5b-b572-26abb094331b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ccc3b-a6bd-4dc8-b7ba-99172d612106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ccc3b-a6bd-4dc8-b7ba-99172d612106.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8518,7 +8518,7 @@
         },
         {
             "id": "01d6c876-b6e6-5534-8bef-42862a9cd839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6fe257-b1bd-4eaf-9941-e8819f3bc89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6fe257-b1bd-4eaf-9941-e8819f3bc89a.jpg?1",
             "name": "Thrull Surgeon",
             "text": "{1}{B}, Sacrifice Thrull Surgeon: Look at target player's hand and choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -8552,7 +8552,7 @@
         },
         {
             "id": "86b465df-0605-555c-aaa4-303f7e32d4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e212d55-c98d-4df6-ab5a-389f38099070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e212d55-c98d-4df6-ab5a-389f38099070.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -8584,7 +8584,7 @@
         },
         {
             "id": "53d6532f-43a4-5c01-891c-3ff67a49d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc48d8-7ff9-46d4-921a-03e63ca41a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc48d8-7ff9-46d4-921a-03e63ca41a66.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "27d4596d-3c6c-5d6e-a978-424044a468d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb681091-331f-40d7-bc32-56899f3e6885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb681091-331f-40d7-bc32-56899f3e6885.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "4c9c45db-116c-59e0-a708-d471e38c6361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114f37e0-0a00-4ab0-840c-8f02cea101b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114f37e0-0a00-4ab0-840c-8f02cea101b3.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{B}: Vampire Bats gets +1/+0 until end of turn. Play this ability no more than twice each turn.",
             "colours": [
@@ -8689,7 +8689,7 @@
         },
         {
             "id": "e65aae37-20bc-5499-aee4-c1f30832f7b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff7fed-93ab-4e80-8548-744a7da9be0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff7fed-93ab-4e80-8548-744a7da9be0d.jpg?1",
             "name": "Vampire Bats",
             "text": "",
             "colours": [
@@ -8724,7 +8724,7 @@
         },
         {
             "id": "5119e249-f9be-56b3-9deb-72d7cba52ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdd01bd-ab41-4005-8807-46db0cfc4da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdd01bd-ab41-4005-8807-46db0cfc4da4.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "08099cff-a271-54f1-942e-2fe7101c7bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f084952-991b-459f-b347-e7d2f2f04b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f084952-991b-459f-b347-e7d2f2f04b31.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "",
             "colours": [
@@ -8794,7 +8794,7 @@
         },
         {
             "id": "f6226c44-1f81-530a-9dda-8a63b412c727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41764237-fa31-4b27-92ff-712a42d350b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41764237-fa31-4b27-92ff-712a42d350b9.jpg?1",
             "name": "Arcane Teachings",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+2 and has \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -8829,7 +8829,7 @@
         },
         {
             "id": "66cdbfaf-8bc2-5313-9c5c-7d422d2e4b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0942b-3a63-43e8-806e-2471fdebf72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0942b-3a63-43e8-806e-2471fdebf72e.jpg?1",
             "name": "Arcane Teachings",
             "text": "",
             "colours": [
@@ -8864,7 +8864,7 @@
         },
         {
             "id": "5543c576-ef2b-59ac-878b-3aff199f27de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830b73b-1def-4d34-902d-966ecdbc7717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830b73b-1def-4d34-902d-966ecdbc7717.jpg?1",
             "name": "Beacon of Destruction",
             "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
             "colours": [
@@ -8896,7 +8896,7 @@
         },
         {
             "id": "e54f8939-0853-5b0b-81b0-a29391bfb9e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213035f9-40f5-4b4e-88b3-e262ad684294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213035f9-40f5-4b4e-88b3-e262ad684294.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -8928,7 +8928,7 @@
         },
         {
             "id": "9ae3a282-1852-5b73-8c60-eabca0956349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4050c0a3-a318-4283-ae72-8fffcf8d45e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4050c0a3-a318-4283-ae72-8fffcf8d45e9.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "{R}, Sacrifice Bloodfire Colossus: Bloodfire Colossus deals 6 damage to each creature and each player.",
             "colours": [
@@ -8962,7 +8962,7 @@
         },
         {
             "id": "9370dddd-ba64-53f9-8890-f391ee305326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a830f8-b508-431e-aadc-36330dcfe5db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a830f8-b508-431e-aadc-36330dcfe5db.jpg?1",
             "name": "Bloodrock Cyclops",
             "text": "Bloodrock Cyclops attacks each turn if able.",
             "colours": [
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "c676dcc1-ff7c-51eb-a878-7e1bb3ee6ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9be02-935e-4428-863b-95e84c88834a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9be02-935e-4428-863b-95e84c88834a.jpg?1",
             "name": "Bogardan Firefiend",
             "text": "When Bogardan Firefiend is put into a graveyard from play, it deals 2 damage to target creature.",
             "colours": [
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "cdc0805a-73b1-5d98-bff3-4e06e6a1f036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec5e56a-5bab-4965-9035-128c3f1ae175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec5e56a-5bab-4965-9035-128c3f1ae175.jpg?1",
             "name": "Cone of Flame",
             "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
             "colours": [
@@ -9063,7 +9063,7 @@
         },
         {
             "id": "ab4f32a2-6671-5724-8ce9-6b721a5f2417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf386439-0f68-454f-993b-d55dcc989d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf386439-0f68-454f-993b-d55dcc989d81.jpg?1",
             "name": "Cryoclasm",
             "text": "Destroy target Plains or Island. Cryoclasm deals 3 damage to that land's controller.",
             "colours": [
@@ -9095,7 +9095,7 @@
         },
         {
             "id": "8e171679-0214-5448-9188-883cfa365c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558503-5124-44cb-8343-6dec0130f8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558503-5124-44cb-8343-6dec0130f8f7.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -9127,7 +9127,7 @@
         },
         {
             "id": "890a9b49-9cea-500c-80c2-220e38b661fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da84a3e-a8b2-4cb4-b9c9-1b5c2dca8c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da84a3e-a8b2-4cb4-b9c9-1b5c2dca8c67.jpg?1",
             "name": "Dragon Roost",
             "text": "{5}{R}{R}: Put a 5/5 red Dragon creature token with flying into play. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "6bb35d3c-20f6-5e0e-aea9-cffbef432373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8785edc4-2ec5-4eb3-a130-1277088ebf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8785edc4-2ec5-4eb3-a130-1277088ebf83.jpg?1",
             "name": "Dragon Roost",
             "text": "",
             "colours": [
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "91ea7dc6-6498-5ecf-853f-0090ae00fbfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913e4d2-3502-41f3-871e-59b3b13df58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913e4d2-3502-41f3-871e-59b3b13df58a.jpg?1",
             "name": "Duct Crawler",
             "text": "{1}{R}: Target creature can't block Duct Crawler this turn.",
             "colours": [
@@ -9227,7 +9227,7 @@
         },
         {
             "id": "4bdb6002-18d3-5a09-a94c-da7796980b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf4360-ba2f-464f-86f0-1620532e6a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf4360-ba2f-464f-86f0-1620532e6a0a.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -9261,7 +9261,7 @@
         },
         {
             "id": "02aa05a4-ff94-5bda-8ad7-24f00bd19ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c623048-8c87-46d8-bf77-9fe1b38f494f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c623048-8c87-46d8-bf77-9fe1b38f494f.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -9296,7 +9296,7 @@
         },
         {
             "id": "bf599cd8-8095-5725-bcca-244b9e69f5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261b73f8-1d48-40d1-8273-d2a8854cace8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261b73f8-1d48-40d1-8273-d2a8854cace8.jpg?1",
             "name": "Firebreathing",
             "text": "",
             "colours": [
@@ -9331,7 +9331,7 @@
         },
         {
             "id": "e43188e9-33c7-5df9-b611-c2d2ddd3d78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fab4a7e-ef8a-4f38-b659-5598a2ead833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fab4a7e-ef8a-4f38-b659-5598a2ead833.jpg?1",
             "name": "Fists of the Anvil",
             "text": "Target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -9363,7 +9363,7 @@
         },
         {
             "id": "75578928-5ef3-5c91-87d8-e16191a1764e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dad8247-1970-4dfb-aad5-d683160ab1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dad8247-1970-4dfb-aad5-d683160ab1b9.jpg?1",
             "name": "Flamewave Invoker",
             "text": "{7}{R}: Flamewave Invoker deals 5 damage to target player.",
             "colours": [
@@ -9398,7 +9398,7 @@
         },
         {
             "id": "7e457744-dd60-5fd0-ae58-1718ef65c1a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074121e8-aecc-469f-b181-8e6a9e918826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074121e8-aecc-469f-b181-8e6a9e918826.jpg?1",
             "name": "Flowstone Slide",
             "text": "All creatures get +X/-X until end of turn.",
             "colours": [
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "9932f234-b27f-55df-96be-18b6583ba3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef98-b6d5-406f-956b-7107550889d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef98-b6d5-406f-956b-7107550889d8.jpg?1",
             "name": "Furnace of Rath",
             "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -9462,7 +9462,7 @@
         },
         {
             "id": "b9abc758-c583-5d39-b761-9e83496927aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c00aa95-3ef3-4639-bda2-6593515f68ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c00aa95-3ef3-4639-bda2-6593515f68ae.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "60d613d8-fd21-5d63-b920-75c0d3e12121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f71c4d-9390-4cf4-b307-0c73ac9ce023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f71c4d-9390-4cf4-b307-0c73ac9ce023.jpg?1",
             "name": "Furnace Whelp",
             "text": "",
             "colours": [
@@ -9532,7 +9532,7 @@
         },
         {
             "id": "ad3f67e9-ab12-5242-a9c8-4a7c3c004934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa052041-14db-4a3f-86ad-683c1f162cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa052041-14db-4a3f-86ad-683c1f162cd7.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "Whenever Goblin Elite Infantry blocks or becomes blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -9567,7 +9567,7 @@
         },
         {
             "id": "9075708d-9c83-519c-aa81-465d35078747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b266935-25ea-49c5-a1da-57c22a4362fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b266935-25ea-49c5-a1da-57c22a4362fd.jpg?1",
             "name": "Goblin King",
             "text": "Other Goblin creatures get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -9602,7 +9602,7 @@
         },
         {
             "id": "e8650f78-41cc-562b-b18a-b20207d716e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696ca38e-3035-492f-8f1b-258f60b8788c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696ca38e-3035-492f-8f1b-258f60b8788c.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "f8084160-8edf-58fa-b453-81daf28278d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e990aa-5124-4e9d-ab4e-178bcda12abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e990aa-5124-4e9d-ab4e-178bcda12abd.jpg?1",
             "name": "Goblin Lore",
             "text": "Draw four cards, then discard three cards at random.",
             "colours": [
@@ -9669,7 +9669,7 @@
         },
         {
             "id": "c0258169-1e97-55b4-8513-427baf8fe898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae72d6-f2a2-4345-822d-6a7c2409a237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae72d6-f2a2-4345-822d-6a7c2409a237.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -9704,7 +9704,7 @@
         },
         {
             "id": "bc3a62a0-3be0-553f-bf42-a10e954c815f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbd596b-56c2-475c-93e4-c72f9f29281b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbd596b-56c2-475c-93e4-c72f9f29281b.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "edc4b78a-6130-5fd4-b5ff-c46850e2b957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa7444-25c4-4524-931a-f65446d132f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa7444-25c4-4524-931a-f65446d132f6.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "",
             "colours": [
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "8d805d91-280e-5c7e-81d2-2676b9ee93b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf3bac0-6e63-4bd3-bbd6-547f46c2d126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf3bac0-6e63-4bd3-bbd6-547f46c2d126.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nWhen a spell or ability an opponent controls causes you to discard Guerrilla Tactics, Guerrilla Tactics deals 4 damage to target creature or player.",
             "colours": [
@@ -9808,7 +9808,7 @@
         },
         {
             "id": "39f4ab79-50be-53cd-b422-354d0b320126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c2be6a-9ca6-4d3a-8dd0-db4ea40799f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c2be6a-9ca6-4d3a-8dd0-db4ea40799f8.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -9842,7 +9842,7 @@
         },
         {
             "id": "67a83049-b3fc-5438-9d37-581ae6f2bcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723fb62e-735a-4ca6-9d38-f1c3944fe69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723fb62e-735a-4ca6-9d38-f1c3944fe69a.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
             "colours": [
@@ -9874,7 +9874,7 @@
         },
         {
             "id": "2b887770-1bb2-5ded-9340-1f703007efc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b9336-5aa3-4992-b04b-4786150c6074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b9336-5aa3-4992-b04b-4786150c6074.jpg?1",
             "name": "Kamahl, Pit Fighter",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Kamahl, Pit Fighter deals 3 damage to target creature or player.",
             "colours": [
@@ -9912,7 +9912,7 @@
         },
         {
             "id": "d44d44ca-fa5a-59e7-8790-f9b107f6c2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea44c0c-722f-4b91-bc56-54f61e4d7df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea44c0c-722f-4b91-bc56-54f61e4d7df9.jpg?1",
             "name": "Kamahl, Pit Fighter",
             "text": "",
             "colours": [
@@ -9950,7 +9950,7 @@
         },
         {
             "id": "4b135a97-07ad-5cb0-a130-c5900ea1791a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28a286-3ea0-4760-bcc4-c7e8299c298e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28a286-3ea0-4760-bcc4-c7e8299c298e.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "3f736237-5bba-5b24-8fc5-ad279eec8c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74adb3f7-2453-4133-a08b-4a2b1dc714b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74adb3f7-2453-4133-a08b-4a2b1dc714b9.jpg?1",
             "name": "Lavaborn Muse",
             "text": "At the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Lavaborn Muse deals 3 damage to him or her.",
             "colours": [
@@ -10016,7 +10016,7 @@
         },
         {
             "id": "0c77c055-2d74-5328-b3b1-eb4f9e1ad63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a557c16-2b58-45c4-9e97-cf6047a83d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a557c16-2b58-45c4-9e97-cf6047a83d17.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -10051,7 +10051,7 @@
         },
         {
             "id": "265e33a7-c32f-5177-8b16-8998931bc8a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9358c3-d4a6-4c62-8484-0a12b79db178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9358c3-d4a6-4c62-8484-0a12b79db178.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "85245362-de1a-59fd-9f9a-d6a0c9522592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009b1aff-a8c7-4032-ab29-a77c94c5af59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009b1aff-a8c7-4032-ab29-a77c94c5af59.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to that player.",
             "colours": [
@@ -10118,7 +10118,7 @@
         },
         {
             "id": "767ee0a4-a8fa-5bce-a948-0a067fa4ba89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185949ab-55d0-439f-b25b-1f525e3eddf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185949ab-55d0-439f-b25b-1f525e3eddf7.jpg?1",
             "name": "Mogg Fanatic",
             "text": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
             "colours": [
@@ -10152,7 +10152,7 @@
         },
         {
             "id": "06af24c4-9cbe-5c8f-9c22-63273cf74ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fca10-0eb8-4f70-80bb-dd9aee50a018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fca10-0eb8-4f70-80bb-dd9aee50a018.jpg?1",
             "name": "Orcish Artillery",
             "text": "{T}: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -10187,7 +10187,7 @@
         },
         {
             "id": "8b63019c-7755-502c-b599-b264b0b12c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6023c95-8cd8-4f12-960a-6557fbefd628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6023c95-8cd8-4f12-960a-6557fbefd628.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "518754bb-441f-5f22-a106-377017a55ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e7131-db26-448d-afda-f48337a026f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e7131-db26-448d-afda-f48337a026f0.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "6fd7afbb-7725-5f7a-91fe-cb578229971a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cec628-5f6a-4b42-9044-3f9a80cac3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cec628-5f6a-4b42-9044-3f9a80cac3e6.jpg?1",
             "name": "Rage Weaver",
             "text": "{2}: Target black or green creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "9e0f4c70-6db0-5798-8307-caf4f98f17f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f171f5f3-6457-4a1b-84ef-f532748f804b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f171f5f3-6457-4a1b-84ef-f532748f804b.jpg?1",
             "name": "Rage Weaver",
             "text": "",
             "colours": [
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "b91e7385-f4a8-5d1b-ac43-23857284e185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181ed588-5b9e-4160-967c-ed927b7e0048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181ed588-5b9e-4160-967c-ed927b7e0048.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -10362,7 +10362,7 @@
         },
         {
             "id": "5cfbcc15-d710-51d0-b0e8-90e66649839e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594f850f-dab1-40e0-828c-c200bbac060f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594f850f-dab1-40e0-828c-c200bbac060f.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -10398,7 +10398,7 @@
         },
         {
             "id": "cb833dcb-2d9b-528d-bf47-889102212f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00c810c-7d92-484b-9bed-deae5f29582b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00c810c-7d92-484b-9bed-deae5f29582b.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -10430,7 +10430,7 @@
         },
         {
             "id": "c371ba25-9ad2-5650-af82-98c534ec327a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dc08b0-491f-470c-b920-2ca961d0d569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dc08b0-491f-470c-b920-2ca961d0d569.jpg?1",
             "name": "Rock Badger",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -10466,7 +10466,7 @@
         },
         {
             "id": "90b87b65-7385-596e-bbea-64fe7dd67ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bef28-eb1d-4f43-bc76-304e027ba453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bef28-eb1d-4f43-bc76-304e027ba453.jpg?1",
             "name": "Rock Badger",
             "text": "",
             "colours": [
@@ -10502,7 +10502,7 @@
         },
         {
             "id": "3c25757c-4c47-5685-a14d-dcabb08fc79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406f7fef-00f0-4ca5-ada4-c4a760e68467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406f7fef-00f0-4ca5-ada4-c4a760e68467.jpg?1",
             "name": "Scoria Wurm",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, return Scoria Wurm to its owner's hand.",
             "colours": [
@@ -10536,7 +10536,7 @@
         },
         {
             "id": "ceb02498-5932-532d-80f3-0f2d892aaed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14363cc7-ef76-41ad-9307-8ab3ed469a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14363cc7-ef76-41ad-9307-8ab3ed469a23.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "855f7c1e-d582-5ae3-8f58-00a5c0d77c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a1aa93-26d1-40b0-82d8-414f56a36337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a1aa93-26d1-40b0-82d8-414f56a36337.jpg?1",
             "name": "Shatterstorm",
             "text": "Destroy all artifacts. They can't be regenerated.",
             "colours": [
@@ -10600,7 +10600,7 @@
         },
         {
             "id": "5f06ccaf-7381-55e6-acb8-99c923d6a3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdd2db-1a4b-48dd-94cf-bd719ff40da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdd2db-1a4b-48dd-94cf-bd719ff40da9.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -10635,7 +10635,7 @@
         },
         {
             "id": "1102852c-8ade-5273-b9a3-4acb8ad97060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bfdf43-8d4c-4415-bf19-34aa481cd91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bfdf43-8d4c-4415-bf19-34aa481cd91c.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -10670,7 +10670,7 @@
         },
         {
             "id": "25634111-8644-5d96-9e23-3b00c2ea0ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03993ba0-cdf1-4170-ab4e-7d1378aede12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03993ba0-cdf1-4170-ab4e-7d1378aede12.jpg?1",
             "name": "Shivan Hellkite",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{1}{R}: Shivan Hellkite deals 1 damage to target creature or player.",
             "colours": [
@@ -10705,7 +10705,7 @@
         },
         {
             "id": "12458b60-30cf-5ce8-aa7d-89c8a75575e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9de5450-030e-4347-a852-1380527b3219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9de5450-030e-4347-a852-1380527b3219.jpg?1",
             "name": "Shivan Hellkite",
             "text": "",
             "colours": [
@@ -10740,7 +10740,7 @@
         },
         {
             "id": "da226026-1ef7-5663-bc44-a1218f8a0b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ad39a-4088-4530-8f3c-d34e7cc99fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ad39a-4088-4530-8f3c-d34e7cc99fae.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "8b56bd26-7d38-50f1-b4ce-5b6989081b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e54b10e-5307-4138-8f80-28406170f2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e54b10e-5307-4138-8f80-28406170f2c6.jpg?1",
             "name": "Shunt",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -10804,7 +10804,7 @@
         },
         {
             "id": "d899942a-ee50-5305-ab9c-5000f9bb3708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a232d-7289-48c2-9160-54c1c4154721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a232d-7289-48c2-9160-54c1c4154721.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander comes into play, put three 1/1 red Goblin creature tokens into play.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "e732ba9a-fdfa-50a3-80a4-d91af06d575e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c39852-efd3-4a25-b33b-3c13dad96e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c39852-efd3-4a25-b33b-3c13dad96e7d.jpg?1",
             "name": "Smash",
             "text": "Destroy target artifact.\nDraw a card.",
             "colours": [
@@ -10870,7 +10870,7 @@
         },
         {
             "id": "9a6b8e1e-1dc7-5807-bafd-bcd4fa1c6401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4e1b9-d93e-443e-91a4-69d4c9dac517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4e1b9-d93e-443e-91a4-69d4c9dac517.jpg?1",
             "name": "Soulblast",
             "text": "As an additional cost to play Soulblast, sacrifice all creatures you control.\nSoulblast deals damage to target creature or player equal to the total power of the sacrificed creatures.",
             "colours": [
@@ -10902,7 +10902,7 @@
         },
         {
             "id": "4798151f-368c-5c06-910b-f0f63c2ec88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7dfad-aca9-498d-bd1c-5503b411ca5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7dfad-aca9-498d-bd1c-5503b411ca5f.jpg?1",
             "name": "Spark Elemental",
             "text": "Trample, haste (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player. This creature can attack and {T} as soon as it comes under your control.)\nAt end of turn, sacrifice Spark Elemental.",
             "colours": [
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "e35dd1c6-3d00-5d23-898f-aa07be8e98aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90624323-97aa-4ce7-8003-40773a0bc58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90624323-97aa-4ce7-8003-40773a0bc58b.jpg?1",
             "name": "Spark Elemental",
             "text": "",
             "colours": [
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "799c2ab7-18cb-5be5-92f3-079e27487073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475294e2-792c-400b-b5ff-d4bf9e70718e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475294e2-792c-400b-b5ff-d4bf9e70718e.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals damage equal to the number of Mountains you control to target creature.",
             "colours": [
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "99be8d57-8eeb-5208-aa32-0a303e000795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92bcec-ddfa-41bf-97e4-983d850fe32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92bcec-ddfa-41bf-97e4-983d850fe32e.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -11040,7 +11040,7 @@
         },
         {
             "id": "b1dd04ef-45b8-5aa8-9564-6cd209a8402f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e2c82-cdb8-4745-9af6-804717c541d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e2c82-cdb8-4745-9af6-804717c541d7.jpg?1",
             "name": "Stun",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "55492210-8ce6-553c-bdb7-573d824ca3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6560bb7-28d4-4b5c-bdfa-986a5c114349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6560bb7-28d4-4b5c-bdfa-986a5c114349.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -11104,7 +11104,7 @@
         },
         {
             "id": "de76ac44-6732-54a1-94a0-e87866b58aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d467d4-f7d2-403c-9b70-1b054b2c82bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d467d4-f7d2-403c-9b70-1b054b2c82bc.jpg?1",
             "name": "Threaten",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -11137,7 +11137,7 @@
         },
         {
             "id": "e691cb00-dabd-51ec-a678-6227dddb7b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adaaa1f-4a56-4f41-9d91-7b6dfdafd4dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adaaa1f-4a56-4f41-9d91-7b6dfdafd4dd.jpg?1",
             "name": "Threaten",
             "text": "",
             "colours": [
@@ -11170,7 +11170,7 @@
         },
         {
             "id": "e3f6afc6-060e-52e1-b537-3dc8039ca113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6b8f09-f021-4ac8-900f-daeac527477e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6b8f09-f021-4ac8-900f-daeac527477e.jpg?1",
             "name": "Thundering Giant",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -11205,7 +11205,7 @@
         },
         {
             "id": "a778b5ec-ca7e-5e11-92e0-c1a99b8599cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3640ff-3935-4904-881a-a87abd444023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3640ff-3935-4904-881a-a87abd444023.jpg?1",
             "name": "Thundering Giant",
             "text": "",
             "colours": [
@@ -11240,7 +11240,7 @@
         },
         {
             "id": "c2e79d18-b72d-5219-8418-d0e1f71887c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9c85a-ba8e-40d4-ab09-1a22a7462030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9c85a-ba8e-40d4-ab09-1a22a7462030.jpg?1",
             "name": "Uncontrollable Anger",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -11275,7 +11275,7 @@
         },
         {
             "id": "61a544c2-1700-500c-b93f-bc292114df3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a70926-a99b-4e73-9c2a-8120b085abd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a70926-a99b-4e73-9c2a-8120b085abd0.jpg?1",
             "name": "Uncontrollable Anger",
             "text": "",
             "colours": [
@@ -11310,7 +11310,7 @@
         },
         {
             "id": "f7aa8817-24f8-5dbb-a726-353611565ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa862a0-388d-43b8-973f-3a00ebf53952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa862a0-388d-43b8-973f-3a00ebf53952.jpg?1",
             "name": "Viashino Runner",
             "text": "Viashino Runner can't be blocked except by two or more creatures.",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "1c1fe501-7af9-5df6-9b1e-7187f5445d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102f139d-1baf-4ca6-a940-70b7efdc29f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102f139d-1baf-4ca6-a940-70b7efdc29f2.jpg?1",
             "name": "Viashino Sandscout",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAt end of turn, return Viashino Sandscout to its owner's hand. (Return it only if it's in play.)",
             "colours": [
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "1b122375-8e96-5a83-969a-2d772eceba4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237da964-df20-4bb1-bb87-c3a9582b54ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237da964-df20-4bb1-bb87-c3a9582b54ab.jpg?1",
             "name": "Viashino Sandscout",
             "text": "",
             "colours": [
@@ -11416,7 +11416,7 @@
         },
         {
             "id": "d2a33bcc-4679-54e9-90ad-1387ff8716e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e461bb-5d51-4f9c-a753-9fb090f564e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e461bb-5d51-4f9c-a753-9fb090f564e8.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "16342dc0-7314-5c08-a076-eeeb1956b7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f56b2c-f4e4-42ea-a31a-bd929d2d2ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f56b2c-f4e4-42ea-a31a-bd929d2d2ebc.jpg?1",
             "name": "Wall of Fire",
             "text": "",
             "colours": [
@@ -11486,7 +11486,7 @@
         },
         {
             "id": "56abb591-a158-5945-8dd6-97664f1c82cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0df0a08-7f62-4b8a-a37d-c778c07076c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0df0a08-7f62-4b8a-a37d-c778c07076c6.jpg?1",
             "name": "Warp World",
             "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way into play, then puts all enchantment cards revealed this way into play, then puts all cards revealed this way that weren't put into play on the bottom of his or her library in any order.",
             "colours": [
@@ -11518,7 +11518,7 @@
         },
         {
             "id": "38513fa0-ea83-5642-8ecd-4f0b3daa6768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46184f97-d5c9-4a98-9fd9-e19057ce9b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46184f97-d5c9-4a98-9fd9-e19057ce9b7e.jpg?1",
             "name": "Abundance",
             "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -11550,7 +11550,7 @@
         },
         {
             "id": "0dea6b2e-25bc-5c31-aa1b-a7690af6b853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf92ae01-9d1e-4b41-b068-096648daadf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf92ae01-9d1e-4b41-b068-096648daadf6.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -11582,7 +11582,7 @@
         },
         {
             "id": "b1c3860c-0def-5059-b183-d76ba9a1c93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca570876-23b2-4915-a5b9-20f1fa976fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca570876-23b2-4915-a5b9-20f1fa976fab.jpg?1",
             "name": "Avatar of Might",
             "text": "If an opponent controls at least four more creatures than you, Avatar of Might costs {6} less to play.\nTrample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -11617,7 +11617,7 @@
         },
         {
             "id": "a5e37da8-d36c-5bcb-945d-7be448ddc7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb29ae78-39ba-4249-a95f-a7c64330bc0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb29ae78-39ba-4249-a95f-a7c64330bc0a.jpg?1",
             "name": "Avatar of Might",
             "text": "",
             "colours": [
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "28e56ac7-6a09-5118-9ade-6755b051bc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44060205-8a5c-4f6d-8190-e65d5250935a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44060205-8a5c-4f6d-8190-e65d5250935a.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -11687,7 +11687,7 @@
         },
         {
             "id": "22578321-9dba-5729-ade5-69c7b61f77fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68996f6d-0f19-4ec1-9616-be8af06ae86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68996f6d-0f19-4ec1-9616-be8af06ae86b.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -11722,7 +11722,7 @@
         },
         {
             "id": "dd3828b6-8e14-5f19-97f6-7ffdd9ffc91b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd07ac98-f705-485e-8336-86f7cafd9055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd07ac98-f705-485e-8336-86f7cafd9055.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "062e0ec2-391d-5394-a5d6-04dbc467751f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b462ff-a130-4c0f-97e9-b096511d7abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b462ff-a130-4c0f-97e9-b096511d7abb.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -11792,7 +11792,7 @@
         },
         {
             "id": "34f1354b-31a3-5ff2-8ee3-70df534c7b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d403b-9b86-46f6-8a82-a69c754984e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d403b-9b86-46f6-8a82-a69c754984e0.jpg?1",
             "name": "Canopy Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -11827,7 +11827,7 @@
         },
         {
             "id": "68c5cace-080c-55d1-a55a-6c2190479941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb86063-6a79-491c-9949-ca458aaed03e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb86063-6a79-491c-9949-ca458aaed03e.jpg?1",
             "name": "Canopy Spider",
             "text": "",
             "colours": [
@@ -11862,7 +11862,7 @@
         },
         {
             "id": "0b5e3059-787a-555f-9bb3-38db93233ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d01445-ada9-452e-a6c0-d9dff59755f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d01445-ada9-452e-a6c0-d9dff59755f9.jpg?1",
             "name": "Civic Wayfinder",
             "text": "When Civic Wayfinder comes into play, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -11898,7 +11898,7 @@
         },
         {
             "id": "889c7527-2776-59b2-bebe-9b138ceebaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760d616-b73a-4c7f-8a38-5606a9a321e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760d616-b73a-4c7f-8a38-5606a9a321e3.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -11930,7 +11930,7 @@
         },
         {
             "id": "93c6c384-3214-5eee-ab55-c3bbcfae5472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6b8e11-b799-4235-bd8f-c4b55946c769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6b8e11-b799-4235-bd8f-c4b55946c769.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -11964,7 +11964,7 @@
         },
         {
             "id": "613639f1-7372-5b5c-9109-bef041108023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68d2204-e771-427a-a840-98f6150f648c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68d2204-e771-427a-a840-98f6150f648c.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -11996,7 +11996,7 @@
         },
         {
             "id": "9f55a614-586a-53dd-881a-d4a9648f2ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4bf2a88-2771-4ea8-b448-35642e034965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4bf2a88-2771-4ea8-b448-35642e034965.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders can't be blocked except by Walls and/or creatures with flying.",
             "colours": [
@@ -12030,7 +12030,7 @@
         },
         {
             "id": "d24cf9a8-91e1-55ae-8f2c-023c8a2a14eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777633d7-e31c-4ea3-a085-2858d6ee6040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777633d7-e31c-4ea3-a085-2858d6ee6040.jpg?1",
             "name": "Elvish Berserker",
             "text": "Whenever Elvish Berserker becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "85f9f23a-a3ec-527f-aec2-1f0afaba0235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42a3fd-21ae-49cf-b11d-3700835f2f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42a3fd-21ae-49cf-b11d-3700835f2f96.jpg?1",
             "name": "Elvish Champion",
             "text": "Other Elf creatures get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -12100,7 +12100,7 @@
         },
         {
             "id": "8ea7f1a9-a15e-5775-af3e-1a56a1e0b098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3495d3-fcf8-411f-995f-4cd32967f5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3495d3-fcf8-411f-995f-4cd32967f5cd.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -12135,7 +12135,7 @@
         },
         {
             "id": "c3808d11-6614-57a9-b4bf-d276aa88f5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5535cb2-8cda-4eb7-b201-6528c686815c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5535cb2-8cda-4eb7-b201-6528c686815c.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: You may put a creature card from your hand into play.",
             "colours": [
@@ -12170,7 +12170,7 @@
         },
         {
             "id": "1ebad7f2-d761-56b8-81ae-1e0225968026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f698125f-3961-4295-8dcf-3227ec9f4694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f698125f-3961-4295-8dcf-3227ec9f4694.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -12204,7 +12204,7 @@
         },
         {
             "id": "312306e1-001c-50b8-9a24-249bd40cfae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61df49d2-1324-460b-8c72-6b6fe8b03c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61df49d2-1324-460b-8c72-6b6fe8b03c15.jpg?1",
             "name": "Femeref Archers",
             "text": "{T}: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "373a5b22-c165-5533-aa12-893f13cc06d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a60271-edfc-4bb1-83d5-4d6fa0403b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a60271-edfc-4bb1-83d5-4d6fa0403b19.jpg?1",
             "name": "Gaea's Herald",
             "text": "Creature spells can't be countered.",
             "colours": [
@@ -12273,7 +12273,7 @@
         },
         {
             "id": "d15347ac-1e85-5d2a-9979-eef3f15c7376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4db271b-b7f2-4a12-b606-2215bab4ac17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4db271b-b7f2-4a12-b606-2215bab4ac17.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -12305,7 +12305,7 @@
         },
         {
             "id": "033917bc-01f6-5202-93af-d56bde440b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fefe43-144a-4f47-80ce-c627efed9ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fefe43-144a-4f47-80ce-c627efed9ac6.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "e9397b67-e88c-5f8b-9839-b8887bb9c1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d83722-f7c7-445e-ae45-748021f17bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d83722-f7c7-445e-ae45-748021f17bec.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -12375,7 +12375,7 @@
         },
         {
             "id": "b49d7ef1-e841-5647-8590-4857eca7e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409f9b88-f03e-40b6-9883-68c14c37c0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409f9b88-f03e-40b6-9883-68c14c37c0de.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -12409,7 +12409,7 @@
         },
         {
             "id": "6e2980cb-0c4a-521b-a99f-072533de225e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f752fb0c-31c4-4338-91c5-f2471c38d345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f752fb0c-31c4-4338-91c5-f2471c38d345.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play.",
             "colours": [
@@ -12443,7 +12443,7 @@
         },
         {
             "id": "aa1c3b14-8a65-55ba-b741-68eef451a922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371d83e8-f514-433c-bc6a-e0eeef3fab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371d83e8-f514-433c-bc6a-e0eeef3fab2a.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -12475,7 +12475,7 @@
         },
         {
             "id": "2f39f144-a02a-5017-a45a-4a3cfc2c7a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61751365-3acf-4eb8-b1f9-358ebccccf94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61751365-3acf-4eb8-b1f9-358ebccccf94.jpg?1",
             "name": "Joiner Adept",
             "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -12510,7 +12510,7 @@
         },
         {
             "id": "f83c4766-5cf2-5ccb-943c-3c938b78c7b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa1bf2d-a4b4-44f6-9126-195c602605e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa1bf2d-a4b4-44f6-9126-195c602605e0.jpg?1",
             "name": "Karplusan Strider",
             "text": "Karplusan Strider can't be the target of blue or black spells.",
             "colours": [
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "0bd38891-1832-51a7-a311-efd7a4442f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b343c2ba-e646-4614-aace-9f8772974069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b343c2ba-e646-4614-aace-9f8772974069.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber comes into play, draw a card.",
             "colours": [
@@ -12578,7 +12578,7 @@
         },
         {
             "id": "51106f17-5dd1-5853-b45b-453d83b9d979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7fe6e-aa5a-4be6-a730-5cfff4fb89e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7fe6e-aa5a-4be6-a730-5cfff4fb89e3.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -12613,7 +12613,7 @@
         },
         {
             "id": "fdfd9504-cf9b-5fec-81ba-fd23f2e509d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda18561-4767-4f8e-bc6d-9117d1a480b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda18561-4767-4f8e-bc6d-9117d1a480b1.jpg?1",
             "name": "Llanowar Sentinel",
             "text": "When Llanowar Sentinel comes into play, you may pay {1}{G}. If you do, search your library for a card named Llanowar Sentinel and put that card into play. Then shuffle your library.",
             "colours": [
@@ -12647,7 +12647,7 @@
         },
         {
             "id": "9ecee142-54dd-5a05-8e0d-702467b0ded5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e36efa-266f-48f1-b352-862920487f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e36efa-266f-48f1-b352-862920487f58.jpg?1",
             "name": "Lure",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nAll creatures able to block enchanted creature do so.",
             "colours": [
@@ -12682,7 +12682,7 @@
         },
         {
             "id": "7bd0f6ac-3239-57c5-89a1-f2edc86a4be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07260aa-96f4-440f-b448-72482a5643b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07260aa-96f4-440f-b448-72482a5643b1.jpg?1",
             "name": "Lure",
             "text": "",
             "colours": [
@@ -12717,7 +12717,7 @@
         },
         {
             "id": "c879e36f-630c-573d-a6a6-25737805752f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73957035-c02f-4de6-9258-ef339565bd1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73957035-c02f-4de6-9258-ef339565bd1d.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -12749,7 +12749,7 @@
         },
         {
             "id": "126a046f-002e-50d8-ad2b-45973a624639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd09923-4a4b-4ac6-a487-6e00d17183cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd09923-4a4b-4ac6-a487-6e00d17183cb.jpg?1",
             "name": "Might Weaver",
             "text": "{2}: Target red or white creature gains trample until end of turn. (If it would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -12785,7 +12785,7 @@
         },
         {
             "id": "de602e4a-da36-5b49-a2ed-388bcdbfb54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8cb591-e1e5-42d5-abdb-12a6fa39683a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8cb591-e1e5-42d5-abdb-12a6fa39683a.jpg?1",
             "name": "Might Weaver",
             "text": "",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "21edc41a-e830-58d0-80b5-85eabe32d0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4a6ac2-bec1-4d01-8d7c-e8fd43bd9e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4a6ac2-bec1-4d01-8d7c-e8fd43bd9e4d.jpg?1",
             "name": "Mirri, Cat Warrior",
             "text": "First strike, forestwalk, vigilance (This creature deals combat damage before creatures without first strike, it's unblockable as long as defending player controls a Forest, and attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -12859,7 +12859,7 @@
         },
         {
             "id": "410efb52-131f-5288-8bc5-a9c4a1e7bef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a39caf-85af-466e-bf07-16ff4cc0d5c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a39caf-85af-466e-bf07-16ff4cc0d5c2.jpg?1",
             "name": "Mirri, Cat Warrior",
             "text": "",
             "colours": [
@@ -12897,7 +12897,7 @@
         },
         {
             "id": "52c9439c-c1b8-565e-bd8f-9e3203d7a051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b879e83-07f7-4d9f-a144-04d81d9f700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b879e83-07f7-4d9f-a144-04d81d9f700e.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -12934,7 +12934,7 @@
         },
         {
             "id": "7887f1e9-6c2f-5d54-bf8d-8ebbb956fd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8701858c-38ac-4c50-aa8f-84abb445eb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8701858c-38ac-4c50-aa8f-84abb445eb96.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "a3cc9902-7bc8-577c-8c06-477ef8a82bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983874b1-3179-4ac6-a4f3-efa133331c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983874b1-3179-4ac6-a4f3-efa133331c6f.jpg?1",
             "name": "Natural Spring",
             "text": "Target player gains 8 life.",
             "colours": [
@@ -13003,7 +13003,7 @@
         },
         {
             "id": "33bdbf35-7ded-53cd-b02c-48d1bb62ed04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4e513-a8a7-4338-99de-b9303813d086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4e513-a8a7-4338-99de-b9303813d086.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -13035,7 +13035,7 @@
         },
         {
             "id": "f4cf6ecc-c308-5d3f-8358-ab273f375a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d39834-a8d4-4ac4-b64b-dab1e9d472ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d39834-a8d4-4ac4-b64b-dab1e9d472ac.jpg?1",
             "name": "Overgrowth",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nWhenever enchanted land is tapped for mana, its controller adds {G}{G} to his or her mana pool.",
             "colours": [
@@ -13070,7 +13070,7 @@
         },
         {
             "id": "f82185b9-c5c6-50f3-a681-0241e7d52503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1dc69-4a91-4788-8f35-9a9bc7170250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1dc69-4a91-4788-8f35-9a9bc7170250.jpg?1",
             "name": "Overgrowth",
             "text": "",
             "colours": [
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "60c34bbe-d318-57e8-9226-c6f4af90c0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bea6a3-a8eb-42c5-9224-89cdac7e8523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bea6a3-a8eb-42c5-9224-89cdac7e8523.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (If a creature you control would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -13138,7 +13138,7 @@
         },
         {
             "id": "f92a05a7-c0b3-5136-92c2-a8b6b6531bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec07b33-5d11-4bab-a01a-f6531e0b8a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec07b33-5d11-4bab-a01a-f6531e0b8a2a.jpg?1",
             "name": "Overrun",
             "text": "",
             "colours": [
@@ -13171,7 +13171,7 @@
         },
         {
             "id": "a840ae9a-5214-52fe-83de-73559845536b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484372-325a-4bef-ae86-a7f61816fd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484372-325a-4bef-ae86-a7f61816fd65.jpg?1",
             "name": "Pincher Beetles",
             "text": "Shroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "4e83393d-bb3f-5e39-8730-45202587ad47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20daa230-e72a-447a-a824-21f4433dbf97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20daa230-e72a-447a-a824-21f4433dbf97.jpg?1",
             "name": "Pincher Beetles",
             "text": "",
             "colours": [
@@ -13241,7 +13241,7 @@
         },
         {
             "id": "1ee00edc-c888-5ad2-b591-e1810ca7ce59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3b738-703d-465c-bc76-2b66f1e0aff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3b738-703d-465c-bc76-2b66f1e0aff2.jpg?1",
             "name": "Primal Rage",
             "text": "Creatures you control have trample. (If a creature you control would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -13274,7 +13274,7 @@
         },
         {
             "id": "93043613-bd0a-5937-a129-3c089a63ca8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0b1fb-9c4b-4f54-9f98-13832c1beec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0b1fb-9c4b-4f54-9f98-13832c1beec2.jpg?1",
             "name": "Primal Rage",
             "text": "",
             "colours": [
@@ -13307,7 +13307,7 @@
         },
         {
             "id": "2c6cd5b8-2f45-5ce2-9e60-6b381d8c88c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dead95f5-2e72-4591-be1e-bce6726e1c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dead95f5-2e72-4591-be1e-bce6726e1c5e.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you play a white, blue, black, or red spell, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -13341,7 +13341,7 @@
         },
         {
             "id": "a3bf2c4d-066f-5397-81c6-a18f25d7e7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee662f0a-f874-464c-8206-d4ff427daf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee662f0a-f874-464c-8206-d4ff427daf2b.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -13373,7 +13373,7 @@
         },
         {
             "id": "4dd68de9-3c96-5c4f-b829-3c5c2c485c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb6ca3-0d7f-45ba-99d2-283d517f1463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb6ca3-0d7f-45ba-99d2-283d517f1463.jpg?1",
             "name": "Recollect",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "1fcd5586-bd5b-5fe1-8875-c167a6137d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b848c69-0f64-4631-84b9-6597c359f3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b848c69-0f64-4631-84b9-6597c359f3ba.jpg?1",
             "name": "Regeneration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{G}: Regenerate enchanted creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -13440,7 +13440,7 @@
         },
         {
             "id": "222c5769-1eff-5539-a79e-33d1db864d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c46536d-05a3-43d6-8ae3-549a49b332e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c46536d-05a3-43d6-8ae3-549a49b332e4.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -13475,7 +13475,7 @@
         },
         {
             "id": "1cc6e0b9-e297-5ea0-9e51-d6fbd4fe512c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa50126-f6ec-4917-ac45-4b1f8f23ca09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa50126-f6ec-4917-ac45-4b1f8f23ca09.jpg?1",
             "name": "Rhox",
             "text": "You may have Rhox deal its combat damage to defending player as though it weren't blocked.\n{2}{G}: Regenerate Rhox. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -13511,7 +13511,7 @@
         },
         {
             "id": "3e72aae2-58f2-5c9f-9450-cbbb7e2c0111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1292402-312b-422c-abad-f59ba0715f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1292402-312b-422c-abad-f59ba0715f87.jpg?1",
             "name": "Rhox",
             "text": "",
             "colours": [
@@ -13547,7 +13547,7 @@
         },
         {
             "id": "5e52c0be-d4fa-5f73-8d06-1080da4d0942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727c757a-2ae5-45fd-9832-646a355a5710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727c757a-2ae5-45fd-9832-646a355a5710.jpg?1",
             "name": "Root Maze",
             "text": "Artifacts and lands come into play tapped.",
             "colours": [
@@ -13579,7 +13579,7 @@
         },
         {
             "id": "01248698-729b-5a69-ba8c-f1686a181abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed6122e-670f-4b02-a774-2c230f369147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed6122e-670f-4b02-a774-2c230f369147.jpg?1",
             "name": "Rootwalla",
             "text": "{1}{G}: Rootwalla gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -13613,7 +13613,7 @@
         },
         {
             "id": "e737e5cd-43e1-5a29-a977-fbb673c6367c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed23582-3260-44c6-9884-904d294442ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed23582-3260-44c6-9884-904d294442ad.jpg?1",
             "name": "Rushwood Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -13648,7 +13648,7 @@
         },
         {
             "id": "307db1e5-c643-578c-9e1d-718dd92694d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f61a381-7945-4535-b707-5ebd050d7fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f61a381-7945-4535-b707-5ebd050d7fc5.jpg?1",
             "name": "Rushwood Dryad",
             "text": "",
             "colours": [
@@ -13683,7 +13683,7 @@
         },
         {
             "id": "23d4bb2e-1ed1-5f22-8b08-bbdc15dcb31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a78413-17e3-4652-91b4-708aa66a50ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a78413-17e3-4652-91b4-708aa66a50ca.jpg?1",
             "name": "Scion of the Wild",
             "text": "Scion of the Wild's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -13717,7 +13717,7 @@
         },
         {
             "id": "204da544-dd71-552f-9bbd-bdb2cfa01964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3927cd85-9ee9-4f3c-b92e-8c860136283b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3927cd85-9ee9-4f3c-b92e-8c860136283b.jpg?1",
             "name": "Seedborn Muse",
             "text": "Untap all permanents you control during each other player's untap step.",
             "colours": [
@@ -13751,7 +13751,7 @@
         },
         {
             "id": "971aa202-f2c4-5c25-a3d0-15156ed0384c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2fd9e5-1986-4998-b08c-80897b9b27e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2fd9e5-1986-4998-b08c-80897b9b27e7.jpg?1",
             "name": "Skyshroud Ranger",
             "text": "{T}: You may put a land card from your hand into play. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -13786,7 +13786,7 @@
         },
         {
             "id": "40c181b0-a2d6-54de-ab55-3a09b0b3750b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e855e965-e01c-4203-bc5b-84646e99ac11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e855e965-e01c-4203-bc5b-84646e99ac11.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -13820,7 +13820,7 @@
         },
         {
             "id": "c63ab08b-7b43-5a3e-bbb8-e69d324b7b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8741d0e8-2e4c-49f1-96ad-d3903d29a6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8741d0e8-2e4c-49f1-96ad-d3903d29a6fd.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be blocked by more than one creature.",
             "colours": [
@@ -13854,7 +13854,7 @@
         },
         {
             "id": "20eaaca9-d27f-5521-a9f3-a6b1fcfab114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0912be9-afa5-4ca9-940a-682df7f993fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0912be9-afa5-4ca9-940a-682df7f993fd.jpg?1",
             "name": "Stampeding Wildebeests",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nAt the beginning of your upkeep, return a green creature you control to its owner's hand.",
             "colours": [
@@ -13890,7 +13890,7 @@
         },
         {
             "id": "b240df99-f98a-5450-a3e2-cc0946bb1caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b34009-9398-476d-85b1-ad2f397199c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b34009-9398-476d-85b1-ad2f397199c0.jpg?1",
             "name": "Stampeding Wildebeests",
             "text": "",
             "colours": [
@@ -13926,7 +13926,7 @@
         },
         {
             "id": "e553a0fb-cc04-551c-b0f7-f047cf0c2d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ca1865-a7cb-4107-b2dc-0ead1cd7e6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ca1865-a7cb-4107-b2dc-0ead1cd7e6e7.jpg?1",
             "name": "Sylvan Basilisk",
             "text": "Whenever Sylvan Basilisk becomes blocked by a creature, destroy that creature.",
             "colours": [
@@ -13960,7 +13960,7 @@
         },
         {
             "id": "52d9f396-b080-5da2-b904-302c6f319f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa5aac-d4b6-47c8-b148-3077e2077e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa5aac-d4b6-47c8-b148-3077e2077e53.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -13992,7 +13992,7 @@
         },
         {
             "id": "ec55586c-f4ae-5085-a6f0-20200af2ba76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1e75e1-a827-46c1-896f-cd8fbdf79fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1e75e1-a827-46c1-896f-cd8fbdf79fa8.jpg?1",
             "name": "Tangle Spider",
             "text": "Flash (You may play this spell any time you could play an instant.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "8b39d0fc-ddef-5d5a-95fc-975bee2fbe06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e250967-ce3f-49e1-abdd-e9d356cadae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e250967-ce3f-49e1-abdd-e9d356cadae8.jpg?1",
             "name": "Tangle Spider",
             "text": "",
             "colours": [
@@ -14062,7 +14062,7 @@
         },
         {
             "id": "75f33095-04ee-5cfc-b58a-863fc8819ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84185d8-c058-4fe7-b46e-f5ca90e70f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84185d8-c058-4fe7-b46e-f5ca90e70f12.jpg?1",
             "name": "Treetop Bracers",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 and can't be blocked except by creatures with flying.",
             "colours": [
@@ -14097,7 +14097,7 @@
         },
         {
             "id": "4c708bbf-9168-5fa5-a02e-5ce3bcc6158b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72741f22-ee30-4478-8706-d0b64b5e7e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72741f22-ee30-4478-8706-d0b64b5e7e3c.jpg?1",
             "name": "Treetop Bracers",
             "text": "",
             "colours": [
@@ -14132,7 +14132,7 @@
         },
         {
             "id": "154824ca-2444-5562-927f-cedddab5a8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d447186e-62a7-4767-bb85-6439fd795350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d447186e-62a7-4767-bb85-6439fd795350.jpg?1",
             "name": "Troll Ascetic",
             "text": "Troll Ascetic can't be the target of spells or abilities your opponents control.\n{1}{G}: Regenerate Troll Ascetic. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -14168,7 +14168,7 @@
         },
         {
             "id": "ba1b342b-9a40-5bdb-9a64-e392b752bd76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1bfa-eb85-4f64-bd11-8af53bf4c3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1bfa-eb85-4f64-bd11-8af53bf4c3d4.jpg?1",
             "name": "Troll Ascetic",
             "text": "",
             "colours": [
@@ -14204,7 +14204,7 @@
         },
         {
             "id": "51bf24e5-bfa3-5262-b6c7-b7b6b6d09b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c47cac-679f-4b48-977f-2fa149a6c3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c47cac-679f-4b48-977f-2fa149a6c3c3.jpg?1",
             "name": "Upwelling",
             "text": "Mana pools don't empty at the end of phases or turns. (This effect stops mana burn.)",
             "colours": [
@@ -14237,7 +14237,7 @@
         },
         {
             "id": "5c0bbc6b-9f29-5d67-9065-22a1d99ad7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec2a66-0725-4933-8651-e2ba41a8f434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec2a66-0725-4933-8651-e2ba41a8f434.jpg?1",
             "name": "Upwelling",
             "text": "",
             "colours": [
@@ -14270,7 +14270,7 @@
         },
         {
             "id": "c6eedc08-9b48-52b9-a9ec-bb0347fd3987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd3ac60-aae0-45e6-8592-32be316d2f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd3ac60-aae0-45e6-8592-32be316d2f14.jpg?1",
             "name": "Verdant Force",
             "text": "At the beginning of each upkeep, put a 1/1 green Saproling creature token into play under your control.",
             "colours": [
@@ -14304,7 +14304,7 @@
         },
         {
             "id": "abb362ed-d21a-5b20-929a-9caca69b3dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82082bf-5b15-4835-93ad-2263f0b0a62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82082bf-5b15-4835-93ad-2263f0b0a62c.jpg?1",
             "name": "Viridian Shaman",
             "text": "When Viridian Shaman comes into play, destroy target artifact.",
             "colours": [
@@ -14339,7 +14339,7 @@
         },
         {
             "id": "564d110e-2a39-5fcb-967a-bacf3a432799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864e25e-f940-47e5-9439-ab721049c690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864e25e-f940-47e5-9439-ab721049c690.jpg?1",
             "name": "Wall of Wood",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -14374,7 +14374,7 @@
         },
         {
             "id": "a6778999-a426-51ea-82d1-749bf98619be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f529ea-3dd2-4e74-8b64-b31905a4544d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f529ea-3dd2-4e74-8b64-b31905a4544d.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -14409,7 +14409,7 @@
         },
         {
             "id": "14878086-100b-5658-a753-571278cbb546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60e2daa-3740-40f0-a333-8b7f4c2da34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60e2daa-3740-40f0-a333-8b7f4c2da34a.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "da0a5791-2fc2-53e4-bc8b-c4d8cd026ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d12cd-a517-4604-97ac-b93d1a94a757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d12cd-a517-4604-97ac-b93d1a94a757.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player plays a white spell, you may gain 1 life.",
             "colours": [],
@@ -14472,7 +14472,7 @@
         },
         {
             "id": "8402d391-a810-5c04-af77-d3fb01dbacca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7cc984-1378-4b01-8115-d3c5b4f68a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7cc984-1378-4b01-8115-d3c5b4f68a2a.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: You gain 3 life.",
             "colours": [],
@@ -14503,7 +14503,7 @@
         },
         {
             "id": "da8f1e81-fc1f-57f4-b4ec-0c5445a299e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca0425d-f41c-4ba5-ac06-9ce5bab2a4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca0425d-f41c-4ba5-ac06-9ce5bab2a4b9.jpg?1",
             "name": "Chimeric Staff",
             "text": "{X}: Chimeric Staff becomes an X/X Construct artifact creature until end of turn.",
             "colours": [],
@@ -14531,7 +14531,7 @@
         },
         {
             "id": "3785490a-01f5-511d-b471-60b1209b3d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3233db3e-ec30-4be5-867d-81855652a8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3233db3e-ec30-4be5-867d-81855652a8b0.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color to your mana pool.\nWhen Chromatic Star is put into a graveyard from play, draw a card.",
             "colours": [],
@@ -14559,7 +14559,7 @@
         },
         {
             "id": "b0a0f3ea-f483-53e3-ae41-bdb409141fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e0dff-d9f0-4222-a308-e86581c440cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e0dff-d9f0-4222-a308-e86581c440cc.jpg?1",
             "name": "Citanul Flute",
             "text": "{X}, {T}: Search your library for a creature card with converted mana cost X or less, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -14587,7 +14587,7 @@
         },
         {
             "id": "515fce14-605b-5768-b743-e8497b583d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2602f046-5e79-4a8a-a5b1-b7c3cbb307fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2602f046-5e79-4a8a-a5b1-b7c3cbb307fc.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if a Goblin Warrior, a Goblin Scout, and a Zombie Goblin are in play, each gets +2/+2.)",
             "colours": [],
@@ -14616,7 +14616,7 @@
         },
         {
             "id": "ffe80735-543f-53c2-9e48-ee66c78d7393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e098d9e-3e1f-4421-aa41-6f0dc095eb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e098d9e-3e1f-4421-aa41-6f0dc095eb96.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -14645,7 +14645,7 @@
         },
         {
             "id": "827e7d75-66de-5aee-bae3-517306eb4536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd164011-7a8e-44a2-8599-0a1c0878b5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd164011-7a8e-44a2-8599-0a1c0878b5b5.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nColossus of Sardia doesn't untap during your untap step.\n{9}: Untap Colossus of Sardia. Play this ability only during your upkeep.",
             "colours": [],
@@ -14677,7 +14677,7 @@
         },
         {
             "id": "725ab389-a7a2-5869-929b-c8e1098b547d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a80eae-6a58-4833-80fa-2c22d531b9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a80eae-6a58-4833-80fa-2c22d531b9d1.jpg?1",
             "name": "Colossus of Sardia",
             "text": "",
             "colours": [],
@@ -14709,7 +14709,7 @@
         },
         {
             "id": "7db42d14-4950-5478-b87c-fbbd93889801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd4637-737d-4913-80e3-ab4bf3428680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd4637-737d-4913-80e3-ab4bf3428680.jpg?1",
             "name": "Composite Golem",
             "text": "Sacrifice Composite Golem: Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [],
@@ -14746,7 +14746,7 @@
         },
         {
             "id": "80baae17-693b-5662-aad7-071f3b031fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc887b1-299e-49f2-94ab-7c3fb24b1432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc887b1-299e-49f2-94ab-7c3fb24b1432.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play land cards from your graveyard.",
             "colours": [],
@@ -14774,7 +14774,7 @@
         },
         {
             "id": "bbea1480-68f2-51fb-8ac9-e7c7485f39fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edba12b8-1418-4122-8e8a-ebbdb654e801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edba12b8-1418-4122-8e8a-ebbdb654e801.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player plays a black spell, you may gain 1 life.",
             "colours": [],
@@ -14802,7 +14802,7 @@
         },
         {
             "id": "49383392-e722-56a9-afd0-c531ecb05310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d946df5-f206-4241-bb55-97db67dc793c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d946df5-f206-4241-bb55-97db67dc793c.jpg?1",
             "name": "Doubling Cube",
             "text": "{3}, {T}: Double the amount of each type of mana in your mana pool.",
             "colours": [],
@@ -14830,7 +14830,7 @@
         },
         {
             "id": "3a76f884-3f71-5dbd-8ac8-6bb24e72704d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963237e-cb33-4833-a725-4196cfdd87ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963237e-cb33-4833-a725-4196cfdd87ef.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player plays a red spell, you may gain 1 life.",
             "colours": [],
@@ -14858,7 +14858,7 @@
         },
         {
             "id": "01e48603-fbf2-5178-92d2-3d6c9944f4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8515a993-0f9d-4ac8-8452-889f23d9d9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8515a993-0f9d-4ac8-8452-889f23d9d9a9.jpg?1",
             "name": "Fountain of Youth",
             "text": "{2}, {T}: You gain 1 life.",
             "colours": [],
@@ -14886,7 +14886,7 @@
         },
         {
             "id": "2c7b2887-e138-547b-804a-c02ce8c51de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4141e02a-d42c-4272-833d-98e2614ab371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4141e02a-d42c-4272-833d-98e2614ab371.jpg?1",
             "name": "The Hive",
             "text": "{5}, {T}: Put a 1/1 Insect artifact creature token with flying named Wasp into play. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -14915,7 +14915,7 @@
         },
         {
             "id": "0a8f1091-c245-5569-b121-ffd0a50008b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec7d032-72df-49ad-9f59-41bf468ba850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec7d032-72df-49ad-9f59-41bf468ba850.jpg?1",
             "name": "The Hive",
             "text": "",
             "colours": [],
@@ -14944,7 +14944,7 @@
         },
         {
             "id": "03b06cf7-aa45-504c-b4af-ceefce384f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe62264-058d-4337-a793-a66eb42551f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe62264-058d-4337-a793-a66eb42551f7.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -14972,7 +14972,7 @@
         },
         {
             "id": "eef8487a-450f-5e19-b9f1-2886839d02ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c67344c-2066-4e19-88a2-52b272d7d216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c67344c-2066-4e19-88a2-52b272d7d216.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -15000,7 +15000,7 @@
         },
         {
             "id": "2443b453-cb6e-5981-b7ff-3bb6ecb06c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4736f-e19e-4e7b-9846-4d0806e46ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4736f-e19e-4e7b-9846-4d0806e46ce9.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -15028,7 +15028,7 @@
         },
         {
             "id": "c397d44d-ce30-511a-af0a-3c6a7f977df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ac76c-34c0-4d3b-868b-aa395edb221e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ac76c-34c0-4d3b-868b-aa395edb221e.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -15059,7 +15059,7 @@
         },
         {
             "id": "8dfa8b47-af66-51df-9472-16c2bc4cf8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56df2ec-a0e3-4b45-bb44-a8ea8c03eac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56df2ec-a0e3-4b45-bb44-a8ea8c03eac3.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player plays a blue spell, you may gain 1 life.",
             "colours": [],
@@ -15087,7 +15087,7 @@
         },
         {
             "id": "4afd939d-f7b3-5807-bcc9-c2d7d4ac3ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2ef7bf-6e5b-40a0-8b25-478323b64bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2ef7bf-6e5b-40a0-8b25-478323b64bdc.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Remove target permanent from the game.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -15123,7 +15123,7 @@
         },
         {
             "id": "178922c9-620a-5eaa-8391-8216ec579232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cceb7b-7166-491f-b471-8e0bc42f611e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cceb7b-7166-491f-b471-8e0bc42f611e.jpg?1",
             "name": "Leonin Scimitar",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15154,7 +15154,7 @@
         },
         {
             "id": "16b6100b-950e-567e-a815-603b78f526e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e786d55b-42e5-431d-aa27-d68c2a2ebcea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e786d55b-42e5-431d-aa27-d68c2a2ebcea.jpg?1",
             "name": "Leonin Scimitar",
             "text": "",
             "colours": [],
@@ -15185,7 +15185,7 @@
         },
         {
             "id": "8c265b98-5ca4-529e-a238-72d5de968dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f3f215-389b-4d86-8393-65e5af4ab981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f3f215-389b-4d86-8393-65e5af4ab981.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0 and has lifelink and trample. (When it deals damage, you gain that much life. If it would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15216,7 +15216,7 @@
         },
         {
             "id": "39afdeca-0f97-5d0a-ac7f-af0ae4d75b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8820a0-b07c-4595-b391-28b47cf48d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8820a0-b07c-4595-b391-28b47cf48d9d.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "",
             "colours": [],
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "ea9feb69-1c09-5d99-a920-54760fd7fd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86111211-b3d9-42eb-bab7-ee2cf9acda5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86111211-b3d9-42eb-bab7-ee2cf9acda5d.jpg?1",
             "name": "Mantis Engine",
             "text": "{2}: Mantis Engine gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)\n{2}: Mantis Engine gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -15279,7 +15279,7 @@
         },
         {
             "id": "bc899285-8adc-5280-92fd-dcf278c76da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e023e4-7fb2-4452-894a-39b6e889deac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e023e4-7fb2-4452-894a-39b6e889deac.jpg?1",
             "name": "Mantis Engine",
             "text": "",
             "colours": [],
@@ -15311,7 +15311,7 @@
         },
         {
             "id": "afdc12d3-7a55-5b55-b85c-12195718c79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a00d0ea-f08c-446a-8537-80a1df6702ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a00d0ea-f08c-446a-8537-80a1df6702ad.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -15339,7 +15339,7 @@
         },
         {
             "id": "d089fdc1-4d21-58e8-b9c8-23d8b3191fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52284689-f2e0-442d-80d0-9e766759e2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52284689-f2e0-442d-80d0-9e766759e2bc.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -15367,7 +15367,7 @@
         },
         {
             "id": "18bacc5a-3ca0-5b72-bacb-ea98e6036c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d784214-dc69-42d4-b897-995ca5751e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d784214-dc69-42d4-b897-995ca5751e13.jpg?1",
             "name": "Ornithopter",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -15399,7 +15399,7 @@
         },
         {
             "id": "4b7ee21b-ccb2-5590-98d7-146bbe0ba10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acf7453-1229-4758-bb17-8afc7dffa9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acf7453-1229-4758-bb17-8afc7dffa9a0.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -15431,7 +15431,7 @@
         },
         {
             "id": "31ecdb2e-eec0-56fb-9a12-7af9069f3673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70e601-ec60-434e-af9e-eb0bf2a580e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70e601-ec60-434e-af9e-eb0bf2a580e2.jpg?1",
             "name": "Phyrexian Vault",
             "text": "{2}, {T}, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -15459,7 +15459,7 @@
         },
         {
             "id": "cae5ac32-6265-5615-a060-21fb1a2dea5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d8adbf-37b8-4d69-b25a-57ebd777b53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d8adbf-37b8-4d69-b25a-57ebd777b53d.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle comes into play, name a card.\nActivated abilities of sources with the chosen name can't be played unless they're mana abilities.",
             "colours": [],
@@ -15487,7 +15487,7 @@
         },
         {
             "id": "c5075bc5-ad52-5c59-b764-22bfc4b1c39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698f66ac-dae6-4b42-ae6f-d468b69b25be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698f66ac-dae6-4b42-ae6f-d468b69b25be.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -15519,7 +15519,7 @@
         },
         {
             "id": "47432616-5812-59fd-b90e-88dadd613161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f259e4e8-d50e-41ef-86d2-0046f55089a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f259e4e8-d50e-41ef-86d2-0046f55089a6.jpg?1",
             "name": "Platinum Angel",
             "text": "",
             "colours": [],
@@ -15551,7 +15551,7 @@
         },
         {
             "id": "41e69f7f-cf4a-5f5e-a5ce-5ef73900a9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e539af0-4390-482e-8bc9-25909d782b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e539af0-4390-482e-8bc9-25909d782b70.jpg?1",
             "name": "Razormane Masticore",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nAt the beginning of your upkeep, sacrifice Razormane Masticore unless you discard a card.\nAt the beginning of your draw step, you may have Razormane Masticore deal 3 damage to target creature.",
             "colours": [],
@@ -15583,7 +15583,7 @@
         },
         {
             "id": "0720c621-c070-5870-b4d7-40d2cae2cb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1d6b0-a13a-4bb2-ba07-1a7742953b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1d6b0-a13a-4bb2-ba07-1a7742953b15.jpg?1",
             "name": "Razormane Masticore",
             "text": "",
             "colours": [],
@@ -15615,7 +15615,7 @@
         },
         {
             "id": "b6b8b11d-0406-54e5-aed1-46d1588262e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1f1431-b324-4915-89e8-2697cf755441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1f1431-b324-4915-89e8-2697cf755441.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -15643,7 +15643,7 @@
         },
         {
             "id": "98becc43-123e-5e33-90f0-59318c221f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41368983-14f8-4efa-bb60-b0a7ceb3d021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41368983-14f8-4efa-bb60-b0a7ceb3d021.jpg?1",
             "name": "Sculpting Steel",
             "text": "As Sculpting Steel comes into play, you may choose an artifact in play. If you do, Sculpting Steel comes into play as a copy of that artifact.",
             "colours": [],
@@ -15671,7 +15671,7 @@
         },
         {
             "id": "06058b88-09c6-5475-a4b3-a72df2a7bea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1adade15-5675-495b-a536-e531c4306d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1adade15-5675-495b-a536-e531c4306d3e.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -15699,7 +15699,7 @@
         },
         {
             "id": "a4bd6d9a-942d-53a3-8607-2354f86cc810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d9b1ae-755d-49e4-b012-db95019491c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d9b1ae-755d-49e4-b012-db95019491c6.jpg?1",
             "name": "Steel Golem",
             "text": "You can't play creature spells.",
             "colours": [],
@@ -15730,7 +15730,7 @@
         },
         {
             "id": "6c08e1af-bbb8-5a03-b680-e00e45c68ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172980e-5464-4a9a-8919-9da86261d0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172980e-5464-4a9a-8919-9da86261d0c4.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable and has shroud. (It can't be the target of spells or abilities.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15761,7 +15761,7 @@
         },
         {
             "id": "d44c9385-588c-50e2-a3fc-2ff233f41086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a8c29d-a950-4c17-9e67-394cfe431c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a8c29d-a950-4c17-9e67-394cfe431c09.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "",
             "colours": [],
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "a1629073-cd64-5aa4-aca6-4d4e64dff8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfc32a-479b-4517-b7d5-808774516bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfc32a-479b-4517-b7d5-808774516bb6.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player plays a green spell, you may gain 1 life.",
             "colours": [],
@@ -15820,7 +15820,7 @@
         },
         {
             "id": "11727081-4070-56db-8162-b970dd7f94bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cf014-7ac9-428b-9ce9-8ba5ebfdd252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cf014-7ac9-428b-9ce9-8ba5ebfdd252.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "dec9c4f1-455e-56de-aad4-9a1d18cf5588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0df1e5f-8cef-4e13-babf-4254a85ac46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0df1e5f-8cef-4e13-babf-4254a85ac46b.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "ca560ce6-8093-51e9-9b7f-2c11756d6516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afcfca-c065-4a33-95b1-ec2b08bcb493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afcfca-c065-4a33-95b1-ec2b08bcb493.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -15913,7 +15913,7 @@
         },
         {
             "id": "a807430a-5a37-550c-989f-72d125d7b0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac3c4e31-673e-4148-bd2e-de569906ce7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac3c4e31-673e-4148-bd2e-de569906ce7d.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -15944,7 +15944,7 @@
         },
         {
             "id": "0f95923c-e501-52ed-9666-5e73c531c642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69df4707-09c5-48e7-9681-0cf7960aeeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69df4707-09c5-48e7-9681-0cf7960aeeb1.jpg?1",
             "name": "Faerie Conclave",
             "text": "Faerie Conclave comes into play tapped.\n{T}: Add {U} to your mana pool.\n{1}{U}: Faerie Conclave becomes a 2/1 blue Faerie creature with flying until end of turn. It's still a land. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -15975,7 +15975,7 @@
         },
         {
             "id": "5b975ab5-c9d5-5fd3-a425-27842542683a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e8460b-cf14-40cc-8adc-c8650c6a02d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e8460b-cf14-40cc-8adc-c8650c6a02d1.jpg?1",
             "name": "Faerie Conclave",
             "text": "",
             "colours": [],
@@ -16006,7 +16006,7 @@
         },
         {
             "id": "b3de8302-e27e-5553-9ed6-f6a6f5fad14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb8c9c-3108-4a06-8ad9-a0dbe3cc5c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb8c9c-3108-4a06-8ad9-a0dbe3cc5c02.jpg?1",
             "name": "Forbidding Watchtower",
             "text": "Forbidding Watchtower comes into play tapped.\n{T}: Add {W} to your mana pool.\n{1}{W}: Forbidding Watchtower becomes a 1/5 white Soldier creature until end of turn. It's still a land.",
             "colours": [],
@@ -16036,7 +16036,7 @@
         },
         {
             "id": "e04a8147-589b-5b9d-8101-50073d47eb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4f58d5-1dc0-4824-a554-56adc1700d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4f58d5-1dc0-4824-a554-56adc1700d33.jpg?1",
             "name": "Ghitu Encampment",
             "text": "Ghitu Encampment comes into play tapped.\n{T}: Add {R} to your mana pool.\n{1}{R}: Ghitu Encampment becomes a 2/1 red Warrior creature with first strike until end of turn. It's still a land. (It deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -16067,7 +16067,7 @@
         },
         {
             "id": "d1b05ebd-7023-5236-bf3b-470476c6f59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f39841d-b8f0-4265-a3bf-73901b24f2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f39841d-b8f0-4265-a3bf-73901b24f2eb.jpg?1",
             "name": "Ghitu Encampment",
             "text": "",
             "colours": [],
@@ -16098,7 +16098,7 @@
         },
         {
             "id": "0bcc33de-dce2-556f-9bdc-080f7ae67529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56ad1cb-c1b9-4856-8d46-55012aee4d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56ad1cb-c1b9-4856-8d46-55012aee4d47.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -16129,7 +16129,7 @@
         },
         {
             "id": "15139516-eb75-5f45-b35f-3372217cfc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9d9e2d-6176-4593-b34a-c892a7b34695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9d9e2d-6176-4593-b34a-c892a7b34695.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -16160,7 +16160,7 @@
         },
         {
             "id": "6c4d1103-3acd-5828-9bf7-77a0b1d405a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8042ec-5306-4851-9854-f05ed7e1acf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8042ec-5306-4851-9854-f05ed7e1acf6.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -16188,7 +16188,7 @@
         },
         {
             "id": "ff703e3a-4ea3-59d6-99e5-02c4db74f035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62ea973-7799-4179-9d36-60e2287feae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62ea973-7799-4179-9d36-60e2287feae7.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -16219,7 +16219,7 @@
         },
         {
             "id": "0f3d794f-2e02-5fa8-b9a7-8ffa74f9615d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b49ff-2020-4203-b93e-4b3306afc337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b49ff-2020-4203-b93e-4b3306afc337.jpg?1",
             "name": "Spawning Pool",
             "text": "Spawning Pool comes into play tapped.\n{T}: Add {B} to your mana pool.\n{1}{B}: Spawning Pool becomes a 1/1 black Skeleton creature with \"{B}: Regenerate this creature\" until end of turn. It's still a land. (If it regenerates, the next time it would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [],
@@ -16250,7 +16250,7 @@
         },
         {
             "id": "85e3e30b-c47d-5606-a6fd-0b4a9931de79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495bec8c-20d1-4133-92eb-a1e405026e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495bec8c-20d1-4133-92eb-a1e405026e4f.jpg?1",
             "name": "Spawning Pool",
             "text": "",
             "colours": [],
@@ -16281,7 +16281,7 @@
         },
         {
             "id": "5ff7b860-8e0f-51a3-a2db-9819417afd06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f2426-5a56-4dca-a059-65aa7266ac83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f2426-5a56-4dca-a059-65aa7266ac83.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -16312,7 +16312,7 @@
         },
         {
             "id": "2137fcba-c774-53da-b051-321a3fcf8f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6858542c-b8f9-449b-b7da-65c96a67636a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6858542c-b8f9-449b-b7da-65c96a67636a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -16340,7 +16340,7 @@
         },
         {
             "id": "4e82f56f-3533-50af-9d10-b723005d5b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de15f8fd-499c-4fa0-9a10-425f81c61579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de15f8fd-499c-4fa0-9a10-425f81c61579.jpg?1",
             "name": "Treetop Village",
             "text": "Treetop Village comes into play tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [],
@@ -16371,7 +16371,7 @@
         },
         {
             "id": "4ed247e0-386b-5166-9c99-875d6f82f681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1773793a-31af-4a22-a4ac-90e4c3dc5090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1773793a-31af-4a22-a4ac-90e4c3dc5090.jpg?1",
             "name": "Treetop Village",
             "text": "",
             "colours": [],
@@ -16402,7 +16402,7 @@
         },
         {
             "id": "0cc99e92-fbb3-52d1-909c-ee619996e795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298bf7-2514-43d4-a285-1386d6ba0835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298bf7-2514-43d4-a285-1386d6ba0835.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -16433,7 +16433,7 @@
         },
         {
             "id": "a139944e-bae3-523b-a29c-4aa3c544e532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1d58ea-39f2-4bdb-a960-b610c39e35e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1d58ea-39f2-4bdb-a960-b610c39e35e3.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -16464,7 +16464,7 @@
         },
         {
             "id": "c4823642-08dd-5c10-ae26-ef8d52cf3a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfd53b2-3991-4a57-81b5-46618aecce4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfd53b2-3991-4a57-81b5-46618aecce4a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16502,7 +16502,7 @@
         },
         {
             "id": "3d407269-4586-51e3-9da6-298d65aff831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95e9696-6e9d-462a-a40e-117df77e3909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95e9696-6e9d-462a-a40e-117df77e3909.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16540,7 +16540,7 @@
         },
         {
             "id": "053c8559-8ab8-5a1a-9444-6140b41470c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2db9b8-648f-4c7f-bd58-1069a1417a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2db9b8-648f-4c7f-bd58-1069a1417a22.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16578,7 +16578,7 @@
         },
         {
             "id": "77977762-e1e1-507b-8d59-e9ed6671a926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b68c00-59ed-410f-87fe-b411f07662e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b68c00-59ed-410f-87fe-b411f07662e3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16616,7 +16616,7 @@
         },
         {
             "id": "2e21d91d-3970-503f-b36a-e2b0e37fb3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74648fc-587c-4d20-9432-58465bd7dca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74648fc-587c-4d20-9432-58465bd7dca9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16654,7 +16654,7 @@
         },
         {
             "id": "a494d14e-b4c3-5467-8af5-bad8b41da09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5328db-c55a-488d-b085-fcfa7be184ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5328db-c55a-488d-b085-fcfa7be184ca.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16692,7 +16692,7 @@
         },
         {
             "id": "6c88ef33-31c8-545f-96dc-de46d68bdbc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eebf59-25ec-448f-b7a6-df9a1ecad3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eebf59-25ec-448f-b7a6-df9a1ecad3a2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "31bd4e75-e2c5-5252-a7ff-4eb2a99a4a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d3de4f-dfef-4c04-a297-4fd90884087e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d3de4f-dfef-4c04-a297-4fd90884087e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16768,7 +16768,7 @@
         },
         {
             "id": "ec72e59f-bc37-50fd-a1b5-3afac5a402b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6497c73-4bbb-4923-8151-8234c98ca6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6497c73-4bbb-4923-8151-8234c98ca6d4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16806,7 +16806,7 @@
         },
         {
             "id": "4b3673bc-4f31-5877-9710-44d875dcca8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72aa721-c20c-4306-aca9-dbf2e36d5ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72aa721-c20c-4306-aca9-dbf2e36d5ba7.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16844,7 +16844,7 @@
         },
         {
             "id": "3e951ede-39fc-58c6-8a89-e2c320902ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eaedaf2-a9a3-44c6-84c1-4cc2da1da459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eaedaf2-a9a3-44c6-84c1-4cc2da1da459.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16882,7 +16882,7 @@
         },
         {
             "id": "eedae11d-cb7c-5b59-bcdd-419e3d6311a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eed3360-1634-4e60-b24d-4128c4896994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eed3360-1634-4e60-b24d-4128c4896994.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16920,7 +16920,7 @@
         },
         {
             "id": "c1f98960-ef31-5ec9-af8d-d6d56169047b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aae748-27d8-48f8-beb2-8e0192d7cc5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aae748-27d8-48f8-beb2-8e0192d7cc5c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -16958,7 +16958,7 @@
         },
         {
             "id": "3e12f3ab-96ab-5d5a-8bed-92b37ffee9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253c7d53-e34b-493b-8d46-da946245bebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253c7d53-e34b-493b-8d46-da946245bebb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -16996,7 +16996,7 @@
         },
         {
             "id": "87d6bcfb-0e75-59f7-be6c-30aa7c344ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c1e97b-4d7a-4a76-8999-5c76b4bae9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c1e97b-4d7a-4a76-8999-5c76b4bae9cb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17034,7 +17034,7 @@
         },
         {
             "id": "47e1bdab-e112-526d-bd9f-7f1cffef7187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91df0ada-4828-41ca-9000-5132fcb29e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91df0ada-4828-41ca-9000-5132fcb29e6b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17072,7 +17072,7 @@
         },
         {
             "id": "4a17c998-1a44-5537-b675-b19522d43bee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99d5685-538d-4e6a-809b-3ebeab634363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99d5685-538d-4e6a-809b-3ebeab634363.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17110,7 +17110,7 @@
         },
         {
             "id": "06ac124d-5c6e-542e-bf11-552ec9cc19cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e30de-fc01-4512-b218-a1411cb50789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e30de-fc01-4512-b218-a1411cb50789.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17148,7 +17148,7 @@
         },
         {
             "id": "0f0aa930-854b-59fb-bd76-69d987356f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc29dea-b48c-4363-8f17-da0413a49a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc29dea-b48c-4363-8f17-da0413a49a92.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17186,7 +17186,7 @@
         },
         {
             "id": "4d710f8c-6249-5877-9799-edf65d0c3e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d4cf1d-6101-40e7-8e0a-a6ad5bd5d3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d4cf1d-6101-40e7-8e0a-a6ad5bd5d3fc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17224,7 +17224,7 @@
         },
         {
             "id": "5aea21ce-bd08-5cd4-87f1-991f8f708d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ae31d1-9a6e-43f3-9b04-bd15699f73d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ae31d1-9a6e-43f3-9b04-bd15699f73d6.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -17258,7 +17258,7 @@
         },
         {
             "id": "63ac47ed-3457-5af8-9a33-1bb5dcb9ca9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73e348-5bf1-4465-978b-3f31408bade9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73e348-5bf1-4465-978b-3f31408bade9.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17292,7 +17292,7 @@
         },
         {
             "id": "7decf258-eb10-50da-83f7-c7eba74adbfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b3b90-74c3-479b-b3e6-3f1cd8f1da04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b3b90-74c3-479b-b3e6-3f1cd8f1da04.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -17326,7 +17326,7 @@
         },
         {
             "id": "8b44e4ca-fb3a-5ef1-a607-6ed5b98cb216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9577d3c-ee19-4b53-adac-b304287a066f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9577d3c-ee19-4b53-adac-b304287a066f.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -17360,7 +17360,7 @@
         },
         {
             "id": "e5f8bf25-2f3e-59c6-a59e-313184ee43db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698d48fa-d6c1-44b9-8aa2-bb03e0e53788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698d48fa-d6c1-44b9-8aa2-bb03e0e53788.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -17394,7 +17394,7 @@
         },
         {
             "id": "ce98066c-a3a1-51a2-bffc-12c38ef45905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b81b5-5c84-45d4-832a-20c038372bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b81b5-5c84-45d4-832a-20c038372bc6.jpg?1",
             "name": "Wasp",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/2X2.json
+++ b/Assets/Resources/Sets/2X2.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5169592e-dd93-535a-b5af-51c9aaccbf36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249db4d4-2542-47ee-a216-e13ffbc2319c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249db4d4-2542-47ee-a216-e13ffbc2319c.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -40,7 +40,7 @@
         },
         {
             "id": "14e24424-15a0-5b28-817f-de8c72748469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27cf7b7-7982-46bd-a559-7789c0e74bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27cf7b7-7982-46bd-a559-7789c0e74bae.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -76,7 +76,7 @@
         },
         {
             "id": "664e694d-acf8-5937-b1ca-9ce8ce48762c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464a820-65de-44f2-9895-46a35e8621a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464a820-65de-44f2-9895-46a35e8621a0.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -112,7 +112,7 @@
         },
         {
             "id": "18468b64-37ef-5e4d-b95a-781265b533a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db62ac2c-0d24-4d6f-a6ca-cca4371a3bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db62ac2c-0d24-4d6f-a6ca-cca4371a3bd7.jpg?1",
             "name": "Abzan Falconer",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "454b109d-f148-5f55-a5a0-7316e013e8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1778cf9a-2703-41e9-86d7-ec21af8cf61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1778cf9a-2703-41e9-86d7-ec21af8cf61d.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "ab1619d5-df3c-5434-b900-36561e62468f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fb9f7-ec03-4831-96d4-a26c89b91830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fb9f7-ec03-4831-96d4-a26c89b91830.jpg?1",
             "name": "Anointer of Valor",
             "text": "Flying\nWhenever a creature attacks, you may pay {3}. When you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "ab9fb17d-4491-50bc-adac-c230a3d6d262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4e3a08-05a6-4730-8b4a-a8cb440dc299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4e3a08-05a6-4730-8b4a-a8cb440dc299.jpg?1",
             "name": "Battlefield Promotion",
             "text": "Put a +1/+1 counter on target creature. That creature gains first strike until end of turn. You gain 2 life.",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "045cb387-99c2-5790-9a7a-b8a01736babc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a73bd5a-eb22-41dc-84ff-93d23d84afae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a73bd5a-eb22-41dc-84ff-93d23d84afae.jpg?1",
             "name": "Divine Visitation",
             "text": "If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "270cb060-9fcf-5a5a-b87e-6ec5a0e278b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5642cdda-789f-4125-a9ff-7c445bb51950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5642cdda-789f-4125-a9ff-7c445bb51950.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "eefc87b8-59ea-53e9-9a44-7ba5e4fefd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f594562-7e9f-47e6-a033-fb70e3cf1e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f594562-7e9f-47e6-a033-fb70e3cf1e10.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "106f7578-028f-5c49-bef6-03f9d65a77bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cccf30-2025-49bb-9b1e-240bbef03f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cccf30-2025-49bb-9b1e-240bbef03f27.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "c98f1fae-d2bd-5f29-87a3-30bc0035f4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8181eee-c03b-40db-aea1-24a4b34a4785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8181eee-c03b-40db-aea1-24a4b34a4785.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nScry 1.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "96dd18dd-d401-53eb-8c56-9de750ce403c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc0f1f-191a-4141-965f-8d159bf54732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc0f1f-191a-4141-965f-8d159bf54732.jpg?1",
             "name": "Hyena Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has first strike.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "4ffc473c-aaa2-5352-8050-1b833b142e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f20ca6-1a92-4be5-a84a-e7f8f0b7f648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f20ca6-1a92-4be5-a84a-e7f8f0b7f648.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, create a 2/2 white Knight creature token with vigilance.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "848c6273-60e1-5c8f-af31-8ca166021e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cca37a-7efd-4b01-bf96-15d0a032524d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cca37a-7efd-4b01-bf96-15d0a032524d.jpg?1",
             "name": "Last Breath",
             "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "408cfbb3-8d24-50a9-a369-ae442e6a2327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f827b-ebc3-45a4-8d12-c71a14478038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f827b-ebc3-45a4-8d12-c71a14478038.jpg?1",
             "name": "Leonin Arbiter",
             "text": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "colours": [
@@ -562,7 +562,7 @@
         },
         {
             "id": "73ae97f7-f6a2-587c-9851-3feaa23da4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c78b83-49d4-48c6-8aef-497541431c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c78b83-49d4-48c6-8aef-497541431c77.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "4bc2ee77-513b-54b8-9abc-a80b264ec274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3535f-bf13-442a-b632-590a69cf0ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3535f-bf13-442a-b632-590a69cf0ca4.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -638,7 +638,7 @@
         },
         {
             "id": "75ffdc56-66cf-5e20-b595-980b67ae88d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe9413b-5702-4998-aed7-d3a1102a8d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe9413b-5702-4998-aed7-d3a1102a8d7e.jpg?1",
             "name": "Militia Bugler",
             "text": "Vigilance\nWhen Militia Bugler enters the battlefield, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "12b2f9db-f0ca-59b2-bf98-86ea712572d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa0d1c6-9110-4956-97eb-e18c457bb130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa0d1c6-9110-4956-97eb-e18c457bb130.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "e0b86afa-e1d3-5f75-87bf-acadd64c31a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c8e27f-a7eb-4247-bd3d-2d0b02ead334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c8e27f-a7eb-4247-bd3d-2d0b02ead334.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "60efa78e-67d7-51e6-b779-a8f7747c366b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15afcabf-58a8-4650-a6cf-b7f2f01d0671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15afcabf-58a8-4650-a6cf-b7f2f01d0671.jpg?1",
             "name": "Myth Realized",
             "text": "Whenever you cast a noncreature spell, put a lore counter on Myth Realized.\n{2}{W}: Put a lore counter on Myth Realized.\n{W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\"",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "b53abfb4-efc9-5944-a4c8-dd55fe4f7981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90460227-6f34-4403-b2ef-d79f95f44790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90460227-6f34-4403-b2ef-d79f95f44790.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -807,7 +807,7 @@
         },
         {
             "id": "8ac21c9e-852a-5d0c-acea-1d61ac6522dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f4c1d-dbe7-4d9f-9974-b2d1a2989ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f4c1d-dbe7-4d9f-9974-b2d1a2989ddf.jpg?1",
             "name": "Relief Captain",
             "text": "When Relief Captain enters the battlefield, support 3. (Put a +1/+1 counter on each of up to three other target creatures.)",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "03cbecab-7fc0-5187-b351-e7d77d5e73cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f7f491-0733-42fa-ad8b-594252e74703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f7f491-0733-42fa-ad8b-594252e74703.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "a10359d9-8f11-52b2-80f2-20cfe661d138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b4dcd6-b1b6-4f1c-9264-e58bdc87399b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b4dcd6-b1b6-4f1c-9264-e58bdc87399b.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "18f8c5aa-4e9b-5cf3-8b36-0ef27a7efcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d5ed22-c0af-47dd-b6e8-49b51e354c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d5ed22-c0af-47dd-b6e8-49b51e354c7d.jpg?1",
             "name": "Scale Blessing",
             "text": "Bolster 1, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "44eaca88-b941-59d5-8690-b8f0b2f1b0e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e3cb28-d318-4d5d-b5bf-1ea7c6249a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e3cb28-d318-4d5d-b5bf-1ea7c6249a89.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "304fd640-ef4c-5beb-a245-6788cc19e274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d308c11-cc8d-4fa6-bbe1-357b164733ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d308c11-cc8d-4fa6-bbe1-357b164733ad.jpg?1",
             "name": "Sensor Splicer",
             "text": "When Sensor Splicer enters the battlefield, create a 3/3 colorless Phyrexian Golem artifact creature token.\nGolem creatures you control have vigilance.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "a9c4148b-46e6-59c9-b057-20a6e1ec1703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca74453c-278e-4a6c-aa37-e5654e16b08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca74453c-278e-4a6c-aa37-e5654e16b08b.jpg?1",
             "name": "Settle Beyond Reality",
             "text": "Choose one or both \u2014\n\u2022 Exile target creature you don't control.\n\u2022 Exile target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "8a0ce690-5a0d-5944-8388-ad7a95cb1d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a4bbe-2af0-4d4a-95d4-d52c5937c747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a4bbe-2af0-4d4a-95d4-d52c5937c747.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "90dea43d-b2bb-574d-8c93-6d14d35dbd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa1cb-1e35-44f2-a143-98c0f107f5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa1cb-1e35-44f2-a143-98c0f107f5ca.jpg?1",
             "name": "Teferi's Protection",
             "text": "Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)\nExile Teferi's Protection.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "1f645031-97ad-5817-ae0a-308830becc9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6504e634-d8cd-41bc-978d-769431bd896d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6504e634-d8cd-41bc-978d-769431bd896d.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "e1c7ee58-705e-5aa5-abab-30996d76ca83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09656d96-c366-49ec-b687-cad903de1385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09656d96-c366-49ec-b687-cad903de1385.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, put it into your hand, then shuffle. Activate only if an opponent controls more lands than you.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "d1f899e8-c964-5315-aba6-f53fdc3fa73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0234e0-6cdd-46b8-91b5-1b8ba7db3014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0234e0-6cdd-46b8-91b5-1b8ba7db3014.jpg?1",
             "name": "Wingsteed Rider",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "ccc80965-40fe-59e4-b560-03e2895c2e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044b2bfc-a5cc-4505-831d-5e1e3a6fdb3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044b2bfc-a5cc-4505-831d-5e1e3a6fdb3c.jpg?1",
             "name": "Advanced Stitchwing",
             "text": "Flying\n{2}{U}, Discard two cards: Return Advanced Stitchwing from your graveyard to the battlefield tapped.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "a19ee1ad-4a32-532a-8958-467b2ce8ca5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc9b5ee-4d6d-42ea-8b13-b8a7059781c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc9b5ee-4d6d-42ea-8b13-b8a7059781c9.jpg?1",
             "name": "Aethersnipe",
             "text": "When Aethersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "5d93f138-840a-5a80-a5f3-25041d0b4255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c468b523-84fc-4657-adef-acc1eec6ef2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c468b523-84fc-4657-adef-acc1eec6ef2e.jpg?1",
             "name": "As Foretold",
             "text": "At the beginning of your upkeep, put a time counter on As Foretold.\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast with mana value X or less, where X is the number of time counters on As Foretold.",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "082cc8cb-ded1-5397-b29b-6cc36064a3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078dfbe-ebdf-4ea8-aed7-cb2c986e7656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078dfbe-ebdf-4ea8-aed7-cb2c986e7656.jpg?1",
             "name": "Aven Initiate",
             "text": "Flying\nEmbalm {6}{U} ({6}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "d8b5a1f0-1d2c-5ab2-b265-85c2a20e7efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7497f2c-62a9-45c4-b2dc-c95818fa2fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7497f2c-62a9-45c4-b2dc-c95818fa2fa6.jpg?1",
             "name": "Body Double",
             "text": "You may have Body Double enter the battlefield as a copy of any creature card in a graveyard.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "7800d47e-4539-53a3-9e19-56d698b56e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22075f41-3aeb-406d-99b6-88ddae992d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22075f41-3aeb-406d-99b6-88ddae992d0b.jpg?1",
             "name": "Breakthrough",
             "text": "Draw four cards, then choose X cards in your hand and discard the rest.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "277c8dc8-72eb-56de-a949-299496d44bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cd21f5-94fd-4609-9e6a-d052aa81fe57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cd21f5-94fd-4609-9e6a-d052aa81fe57.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "1c66d6f7-adef-57d5-a4e2-90082a650327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bd60fc-2777-44bc-b314-a792e8e48360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bd60fc-2777-44bc-b314-a792e8e48360.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "240c726c-980a-5500-b9dc-f35686b07efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90296536-a56d-482e-8548-132a99894bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90296536-a56d-482e-8548-132a99894bde.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1538,7 +1538,7 @@
         },
         {
             "id": "79aebf18-2171-57b1-a4af-237b53d5f01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2784c1e-1066-411f-96ea-287d60e0c115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2784c1e-1066-411f-96ea-287d60e0c115.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Mill a card: Add {C}.",
             "colours": [
@@ -1573,7 +1573,7 @@
         },
         {
             "id": "5b137eaa-691a-5b01-89de-e96e8efca820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a885848-005f-4387-8982-40052b924076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a885848-005f-4387-8982-40052b924076.jpg?1",
             "name": "Disciple of the Ring",
             "text": "{1}, Exile an instant or sorcery card from your graveyard: Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Disciple of the Ring gets +1/+1 until end of turn.\n\u2022 Tap target creature.\n\u2022 Untap target creature.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "03c0bd60-d242-5159-a266-bf24f7b861bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5e940b-e247-4ee3-939b-679e4f8ea771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5e940b-e247-4ee3-939b-679e4f8ea771.jpg?1",
             "name": "Domestication",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your end step, if enchanted creature's power is 4 or greater, sacrifice Domestication.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "51191ce8-62b2-5816-a2ca-02e43f4155c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ab47ce-a6dd-4839-ab41-053c5c5de768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ab47ce-a6dd-4839-ab41-053c5c5de768.jpg?1",
             "name": "Eel Umbra",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "aacab549-f97f-5a6c-be60-566b3982f131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f39b4-f428-483f-999a-6ebee7659c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f39b4-f428-483f-999a-6ebee7659c5a.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1711,7 +1711,7 @@
         },
         {
             "id": "03e8a3a3-b9c7-5aed-ab0d-7ea7fc9c8ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1825a719-1b2a-4af9-9cd2-7cb497cd0317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1825a719-1b2a-4af9-9cd2-7cb497cd0317.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "a5b7204f-89b6-5770-a907-b43b104b276b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc950b6c-0346-4939-b36b-9f10a75f7a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc950b6c-0346-4939-b36b-9f10a75f7a32.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle.",
             "colours": [
@@ -1781,7 +1781,7 @@
         },
         {
             "id": "402dfc22-1b73-5806-94c7-6609c9a788c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a264f107-f9dd-4599-a134-62db6a242a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a264f107-f9dd-4599-a134-62db6a242a8b.jpg?1",
             "name": "Ingenious Skaab",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{U}: Ingenious Skaab gets +1/-1 until end of turn.",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "86b1ee64-b517-5661-8504-b5feea1a4104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fd9091-2d22-411f-955a-24c32293cdca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fd9091-2d22-411f-955a-24c32293cdca.jpg?1",
             "name": "Jeskai Elder",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jeskai Elder deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "0d475c1e-1f6b-5fac-8a1c-67f96a1aa4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938ef232-1bf5-4290-abd9-3da653cf2e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938ef232-1bf5-4290-abd9-3da653cf2e85.jpg?1",
             "name": "Kasmina's Transmutation",
             "text": "Enchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "7ffaeeaf-f4cb-52fa-8412-adef854a20c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cdb22d-90e6-49c4-9ad7-3249d9196ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cdb22d-90e6-49c4-9ad7-3249d9196ca9.jpg?1",
             "name": "Kederekt Leviathan",
             "text": "When Kederekt Leviathan enters the battlefield, return all other nonland permanents to their owners' hands.\nUnearth {6}{U} ({6}{U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "f3d710c2-7652-5e12-904e-62294638bc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e74b52-1137-4da5-bf2d-294daa8e65f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e74b52-1137-4da5-bf2d-294daa8e65f2.jpg?1",
             "name": "Makeshift Mauler",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.",
             "colours": [
@@ -1956,7 +1956,7 @@
         },
         {
             "id": "d8b9d0ec-bb20-5457-95c7-c00f2519434e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c429c40-2389-41e5-8681-4bb274e25eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c429c40-2389-41e5-8681-4bb274e25eba.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "d26a9f27-ab78-52a2-82cc-06ef6051903f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179236d9-6fe2-4db6-bdfb-f851e8d531a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179236d9-6fe2-4db6-bdfb-f851e8d531a2.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "ba7e5fd2-3fc2-53ec-8bd9-bb8d91f9c656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a2dd0d-8034-47f7-801d-c893f32f0708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a2dd0d-8034-47f7-801d-c893f32f0708.jpg?1",
             "name": "Mistfire Adept",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, target creature gains flying until end of turn.",
             "colours": [
@@ -2058,7 +2058,7 @@
         },
         {
             "id": "09744103-92f7-59c6-af8d-82bb1a3b21af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fed1e5-fcbd-4597-91b5-ba809571573b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fed1e5-fcbd-4597-91b5-ba809571573b.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "6846624b-41a7-5c7e-a6db-27a21590fab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a17b5-422c-4add-adbf-63e4492121e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a17b5-422c-4add-adbf-63e4492121e8.jpg?1",
             "name": "Nephalia Smuggler",
             "text": "{3}{U}, {T}: Exile another target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "121383d1-774e-55f0-9e7b-ee7c212f45b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5013fde-4714-4bea-b368-5b14684a05fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5013fde-4714-4bea-b368-5b14684a05fc.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "2f82a48a-ce96-5c2a-83e3-66de8fdb7556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b8a9db-d126-4038-abb1-74dcc5b36136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b8a9db-d126-4038-abb1-74dcc5b36136.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "3ee7784a-5e81-5ddd-9e18-573d6b9b1df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca9530f-ecec-4f12-bc5a-9e211b97be70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca9530f-ecec-4f12-bc5a-9e211b97be70.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "562d303a-6406-51ff-b9f8-6014306013ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afee6b3-55a4-44e5-b08c-85e0c813cd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afee6b3-55a4-44e5-b08c-85e0c813cd09.jpg?1",
             "name": "Thought Scour",
             "text": "Target player mills two cards.\nDraw a card.",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "752586b8-e40d-59df-914a-848fe4bb379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e19416-aa6c-46f1-b247-a94da5d1a13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e19416-aa6c-46f1-b247-a94da5d1a13a.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -2309,7 +2309,7 @@
         },
         {
             "id": "8b44ffe2-ec1a-5ff1-a6a7-e06e775d5463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc468f97-08f7-4103-898f-b14fa61b99bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc468f97-08f7-4103-898f-b14fa61b99bc.jpg?1",
             "name": "Wash Out",
             "text": "Return all permanents of the color of your choice to their owners' hands.",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "8773f2b1-421c-5247-8bf7-9b508227cc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b4ce37-f102-4f2b-9651-9d0a9d231d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b4ce37-f102-4f2b-9651-9d0a9d231d6d.jpg?1",
             "name": "Balustrade Spy",
             "text": "Flying\nWhen Balustrade Spy enters the battlefield, target player reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "a85eb72e-2a35-5c0e-88c9-2c7ebd285291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9640cbf-b016-410e-9eff-e8924883517b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9640cbf-b016-410e-9eff-e8924883517b.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
             "colours": [
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "0bd8fca0-eae7-538f-999e-97b3a79d77d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693dd112-d04a-4404-8fce-74f7e5497312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693dd112-d04a-4404-8fce-74f7e5497312.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "b60b7042-8547-5444-b445-f656cbc43dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f198b57-8bfe-4d13-9a16-10990707b455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f198b57-8bfe-4d13-9a16-10990707b455.jpg?1",
             "name": "Bloodflow Connoisseur",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "b1f7be4f-4c74-5ea4-a601-d6b95be0d6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06b2ab-2161-41fa-abe6-c4a4d848efd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06b2ab-2161-41fa-abe6-c4a4d848efd3.jpg?1",
             "name": "Carrier Thrall",
             "text": "When Carrier Thrall dies, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "d1daaab5-3a27-5b2d-82dc-a0e24a82cc15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c0aac5-b9f1-4446-bfea-3e1dd1cf1f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c0aac5-b9f1-4446-bfea-3e1dd1cf1f2f.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "809b83dd-5d48-55f4-be35-15e4c44364ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d96bc-6c19-4dec-9e9d-c6ea50a30cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d96bc-6c19-4dec-9e9d-c6ea50a30cbc.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "65d36a91-2510-5fe5-bc88-4945c32c98ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738c356-734a-4930-acd3-31dead241bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738c356-734a-4930-acd3-31dead241bea.jpg?1",
             "name": "Eyeblight's Ending",
             "text": "Destroy target non-Elf creature.",
             "colours": [
@@ -2619,7 +2619,7 @@
         },
         {
             "id": "f3693e7b-b851-5fb4-b354-b4ec49dbd404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e966c-80ce-4942-a993-21b960aa28ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e966c-80ce-4942-a993-21b960aa28ab.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "5ad31db2-d416-5581-852b-ef7d37807301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e62471-07bf-48af-8868-b8a72032a50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e62471-07bf-48af-8868-b8a72032a50b.jpg?1",
             "name": "Graveblade Marauder",
             "text": "Deathtouch\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "ddf5cd53-89a6-517e-9d70-3de592d82cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951ff2ed-9af0-4551-929a-ba6679fc2e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951ff2ed-9af0-4551-929a-ba6679fc2e15.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "62abe9c7-9a6f-53a9-9d91-2767279cb5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71a6bd3-7478-4c3a-8ae0-98352ce28492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71a6bd3-7478-4c3a-8ae0-98352ce28492.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "92af8dce-f610-5093-9956-c20c82b23052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f38740-20fd-4097-90f8-f0c2c2ff7281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f38740-20fd-4097-90f8-f0c2c2ff7281.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "7a05291f-d4ec-597f-8685-db41838d38c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ae5085-0d0d-4d7d-80a3-614315a07de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ae5085-0d0d-4d7d-80a3-614315a07de5.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "f1b64874-2cfa-5b4e-ad9a-36a726648ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da81fa-0bd1-4415-b112-3fa4438efe4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da81fa-0bd1-4415-b112-3fa4438efe4b.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "5895b511-6ee6-5a66-824c-deb05faccb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc3557d-49c6-49cd-a540-1b24897f4e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc3557d-49c6-49cd-a540-1b24897f4e86.jpg?1",
             "name": "Necrotic Ooze",
             "text": "As long as Necrotic Ooze is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
             "colours": [
@@ -2901,7 +2901,7 @@
         },
         {
             "id": "dcbf81c3-6368-53d7-a9bb-31f1c53de9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c727f49-833a-4b79-9946-bfbc6b06999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c727f49-833a-4b79-9946-bfbc6b06999c.jpg?1",
             "name": "Ob Nixilis, Unshackled",
             "text": "Flying, trample\nWhenever an opponent searches their library, that player sacrifices a creature and loses 10 life.\nWhenever another creature dies, put a +1/+1 counter on Ob Nixilis, Unshackled.",
             "colours": [
@@ -2939,7 +2939,7 @@
         },
         {
             "id": "f2422c6c-40c8-50bb-85b8-8d26ac634f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd79780e-ddad-4ef4-a94d-ab191d118882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd79780e-ddad-4ef4-a94d-ab191d118882.jpg?1",
             "name": "Oona's Prowler",
             "text": "Flying\nDiscard a card: Oona's Prowler gets -2/-0 until end of turn. Any player may activate this ability.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "b4fbbf1f-7998-59c9-88d5-43862c145441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416845ec-7efd-464a-a0cb-7e9170ccdd38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416845ec-7efd-464a-a0cb-7e9170ccdd38.jpg?1",
             "name": "Scion of Darkness",
             "text": "Trample\nWhenever Scion of Darkness deals combat damage to a player, you may put target creature card from that player's graveyard onto the battlefield under your control.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "4c374ed7-073b-5ae1-8dd5-280656a802af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30573211-ba4d-41c7-a3cd-283aaf04dffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30573211-ba4d-41c7-a3cd-283aaf04dffb.jpg?1",
             "name": "Seekers' Squire",
             "text": "When Seekers' Squire enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "5da2f2db-9f4d-50b6-867c-c9049df4cf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7496304-2ab2-497b-bb3a-b3c91ee1ff60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7496304-2ab2-497b-bb3a-b3c91ee1ff60.jpg?1",
             "name": "Severed Strands",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nYou gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.",
             "colours": [
@@ -3077,7 +3077,7 @@
         },
         {
             "id": "9dbeb506-143e-590a-8c6e-9ed6274f0c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7ba1de-48f9-423b-867a-22bd3f6c06c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7ba1de-48f9-423b-867a-22bd3f6c06c2.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "A deck can have any number of cards named Shadowborn Apostle.\n{B}, Sacrifice six creatures named Shadowborn Apostle: Search your library for a Demon creature card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "fc383342-50dd-523d-8ccd-f144668e9603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8a04f1-9a7b-41d6-8447-4baa639fe183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8a04f1-9a7b-41d6-8447-4baa639fe183.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "258573e8-0557-51d5-8ec5-e8d763f7d346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca107d96-0351-49a9-9f65-b055c1514d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca107d96-0351-49a9-9f65-b055c1514d7b.jpg?1",
             "name": "Skinrender",
             "text": "When Skinrender enters the battlefield, put three -1/-1 counters on target creature.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "8f7eb70f-5869-5105-8bb9-f63d17bbeefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95efd3d-ee88-4908-908a-830595f03c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95efd3d-ee88-4908-908a-830595f03c5d.jpg?1",
             "name": "Strands of Undeath",
             "text": "Enchant creature\nWhen Strands of Undeath enters the battlefield, target player discards two cards.\n{B}: Regenerate enchanted creature.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "b99b0ae4-3eb9-592e-a878-81a2a41f30c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a0278b-3198-4c8d-b20c-f42e8b1569f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a0278b-3198-4c8d-b20c-f42e8b1569f4.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "5a566f46-524b-5bf7-a6f9-a13b9b949cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15d76ac-1c23-4503-8225-375ac2bf2fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15d76ac-1c23-4503-8225-375ac2bf2fb6.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "3223a730-6a67-5368-90c1-764428cbf8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7023aa24-ef49-4973-8978-7d0d3af719d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7023aa24-ef49-4973-8978-7d0d3af719d3.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "eec5f5e7-f2c9-5648-b947-a558f12563d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f73271-b70f-40ae-be64-f8de7805923a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f73271-b70f-40ae-be64-f8de7805923a.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "84c900ca-58cf-515f-a634-72ef6d3eae89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f0f05-fe4e-4827-bedf-a54352f95967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f0f05-fe4e-4827-bedf-a54352f95967.jpg?1",
             "name": "Vampire Sovereign",
             "text": "Flying\nWhen Vampire Sovereign enters the battlefield, target opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "5f245a93-c908-5d26-9cd3-7ddb7cf28558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9947ed-de58-4172-91df-82a93584e6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9947ed-de58-4172-91df-82a93584e6fe.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "85b3ac40-66de-5d30-bf39-6b2838d35e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4f8f35-5860-4416-b7bb-9ba56540a28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4f8f35-5860-4416-b7bb-9ba56540a28c.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "97a99557-e25c-50df-bf0a-a8e0d68c5df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd94f624-9b35-4468-829f-106366f61c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd94f624-9b35-4468-829f-106366f61c1a.jpg?1",
             "name": "Abbot of Keral Keep",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Abbot of Keral Keep enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "7599dbf5-3ea2-5b62-9984-d884f89133d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5067fda-fbee-4e44-aba7-8ab2c0e396f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5067fda-fbee-4e44-aba7-8ab2c0e396f7.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "9194275c-7e27-5c6c-996b-46e3d590e0d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92088c2-74c2-4e63-8a54-83d39f9d6ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92088c2-74c2-4e63-8a54-83d39f9d6ad6.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "81346358-4be1-5df4-ae9f-299f7945021e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb3f1cb-7180-4c5f-8e04-58bb9bf45733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb3f1cb-7180-4c5f-8e04-58bb9bf45733.jpg?1",
             "name": "Backdraft Hellkite",
             "text": "Flying\nWhenever Backdraft Hellkite attacks, each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
             "colours": [
@@ -3605,7 +3605,7 @@
         },
         {
             "id": "9b8cdf43-bfcb-5b40-a742-d514d308576f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9333564-2792-470e-be73-61f2445e018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9333564-2792-470e-be73-61f2445e018f.jpg?1",
             "name": "Bedlam Reveler",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "e1e14986-bc75-5125-a086-03859d69b16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c20d8d5-a54a-4d81-9211-e82a10abdde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c20d8d5-a54a-4d81-9211-e82a10abdde2.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -3677,7 +3677,7 @@
         },
         {
             "id": "e0e02b7b-d92f-58ca-a7a8-ce3113b6e2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35664f-b99d-46b6-988e-8f2814b0a854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35664f-b99d-46b6-988e-8f2814b0a854.jpg?1",
             "name": "Dark-Dweller Oracle",
             "text": "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -3712,7 +3712,7 @@
         },
         {
             "id": "1104bdaa-8841-5b80-8300-0e8d0fcd33b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2e3efb-75cb-430f-b9f4-cb58f3aeb91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2e3efb-75cb-430f-b9f4-cb58f3aeb91b.jpg?1",
             "name": "Dockside Extortionist",
             "text": "When Dockside Extortionist enters the battlefield, create X Treasure tokens, where X is the number of artifacts and enchantments your opponents control. (Treasure tokens are artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "fe296d6e-1e5c-50b5-8cc6-80f1bbc3e752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11f5d27-37f3-430a-833c-84e249b5e744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11f5d27-37f3-430a-833c-84e249b5e744.jpg?1",
             "name": "Dreamshaper Shaman",
             "text": "At the beginning of your end step, you may pay {2}{R} and sacrifice a nonland permanent. If you do, reveal cards from the top of your library until you reveal a nonland permanent card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "616f6b4a-666c-5cc7-a4ff-a166af81e0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed3229f-40ab-420d-a41a-57f1ff8ab7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed3229f-40ab-420d-a41a-57f1ff8ab7ad.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3818,7 +3818,7 @@
         },
         {
             "id": "77777a46-0684-5acb-ba26-e898569ec29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf20cfd7-81f4-423c-a662-c4b6676edfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf20cfd7-81f4-423c-a662-c4b6676edfdd.jpg?1",
             "name": "Goblin Banneret",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\n{1}{R}: Goblin Banneret gets +2/+0 until end of turn.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "60eeee2d-49f9-5de4-9180-56c086ab7bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf6bf0-4821-41eb-bacc-32e9a2d47845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf6bf0-4821-41eb-bacc-32e9a2d47845.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate only if Greater Gargadon is suspended.",
             "colours": [
@@ -3889,7 +3889,7 @@
         },
         {
             "id": "c18e049c-e1ff-5519-976b-20aca86db00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abd74bb-01b8-4382-90d4-0ffc43e5295d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abd74bb-01b8-4382-90d4-0ffc43e5295d.jpg?1",
             "name": "Hero of the Games",
             "text": "Whenever you cast a spell that targets Hero of the Games, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -3924,7 +3924,7 @@
         },
         {
             "id": "8b04bee0-d2c7-5ccb-884f-0fb55ba2c123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2268cf4b-de6d-4447-86e8-f8298728a3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2268cf4b-de6d-4447-86e8-f8298728a3bd.jpg?1",
             "name": "Hissing Iguanar",
             "text": "Whenever another creature dies, you may have Hissing Iguanar deal 1 damage to target player or planeswalker.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "6382f369-33d0-52b0-8d4d-e61f20b1f88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da0851-c349-4b2c-bedf-21e3c2d35922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da0851-c349-4b2c-bedf-21e3c2d35922.jpg?1",
             "name": "Kruin Striker",
             "text": "Whenever another creature enters the battlefield under your control, Kruin Striker gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -3993,7 +3993,7 @@
         },
         {
             "id": "1cb91328-2cbc-52cd-9f99-472efdff0c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee955ad-6eed-4d5a-bcda-94339f155555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee955ad-6eed-4d5a-bcda-94339f155555.jpg?1",
             "name": "Labyrinth Champion",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Labyrinth Champion, Labyrinth Champion deals 2 damage to any target.",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "7314bb47-d3b6-5e5b-b57b-d1281138782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802c39df-4b92-4acc-92f9-bebd3d405471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802c39df-4b92-4acc-92f9-bebd3d405471.jpg?1",
             "name": "Lava Coil",
             "text": "Lava Coil deals 4 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "0aa4288b-47ee-5d3b-8b81-5479779a8b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ba16f-c8fb-42fe-aabf-87089cb214a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ba16f-c8fb-42fe-aabf-87089cb214a7.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "009c492a-c0e1-5dba-9caa-68e52d73e556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b9b6-7727-45e9-931f-28f7facf8692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b9b6-7727-45e9-931f-28f7facf8692.jpg?1",
             "name": "Living Lightning",
             "text": "When Living Lightning dies, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "dc75b85f-50d6-57cf-a214-9ac437f9969d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b9d59d-bac9-4092-901e-2b861c186868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b9d59d-bac9-4092-901e-2b861c186868.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "e66ecb7f-0f26-56d2-85b0-80726bf8e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097e866-9d24-43b6-bafb-b6da05b47a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097e866-9d24-43b6-bafb-b6da05b47a30.jpg?1",
             "name": "Pirate's Pillage",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "ca0ce0af-be75-5d96-bd41-a2dd408c7b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd318d3-3d84-4f3f-a48f-6a242474a4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd318d3-3d84-4f3f-a48f-6a242474a4a2.jpg?1",
             "name": "Purphoros's Emissary",
             "text": "Bestow {6}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nMenace (This creature can't be blocked except by two or more creatures.)\nEnchanted creature gets +3/+3 and has menace.",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "06cca63d-8700-554f-8e23-4ed96002dc10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccd0ada-92b2-48f3-b5ae-96346fc138b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccd0ada-92b2-48f3-b5ae-96346fc138b6.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to any target.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "0aa6573b-ce1b-5f4e-a74e-31f3b2ad9952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427f615-8430-426e-a669-f9fe12033ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427f615-8430-426e-a669-f9fe12033ac4.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "11423f8a-5277-5205-9243-8435e4cd6029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10b4edf-5f0e-4edd-88f9-2e3e7d9cad0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10b4edf-5f0e-4edd-88f9-2e3e7d9cad0a.jpg?1",
             "name": "Sparkmage's Gambit",
             "text": "Sparkmage's Gambit deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "6f8522de-9967-523d-9568-d0dab4547541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56976d52-053d-49e9-94c0-f21dc13029ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56976d52-053d-49e9-94c0-f21dc13029ac.jpg?1",
             "name": "Staggershock",
             "text": "Staggershock deals 2 damage to any target.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4367,7 +4367,7 @@
         },
         {
             "id": "04247e47-a8e3-5b62-9db1-ac8e7a6422dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189836c8-3ffb-4734-8d3e-6a21a28335be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189836c8-3ffb-4734-8d3e-6a21a28335be.jpg?1",
             "name": "Storm Fleet Pyromancer",
             "text": "Raid \u2014 When Storm Fleet Pyromancer enters the battlefield, if you attacked this turn, Storm Fleet Pyromancer deals 2 damage to any target.",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "f60afd3f-8430-5cab-a14c-0d6d9938b38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c10004-eaef-4b19-828f-a0f9bde82984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c10004-eaef-4b19-828f-a0f9bde82984.jpg?1",
             "name": "Surreal Memoir",
             "text": "Return an instant card at random from your graveyard to your hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "d774774d-3a8d-5e73-998b-3a45f826e35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1bfbe-7cfd-4b11-be95-0df327a83c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1bfbe-7cfd-4b11-be95-0df327a83c12.jpg?1",
             "name": "Titan's Strength",
             "text": "Target creature gets +3/+1 until end of turn. Scry 1.",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "f53a1067-05da-5fd2-92f4-efe86b05b3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa7c17-55e7-44e4-a965-182f63f32c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa7c17-55e7-44e4-a965-182f63f32c72.jpg?1",
             "name": "Twinflame",
             "text": "Strive \u2014 This spell costs {2}{R} more to cast for each target beyond the first.\nChoose any number of target creatures you control. For each of them, create a token that's a copy of that creature, except it has haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "d3634815-6ba9-5e9b-8c22-65cdc7ef2c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10759-e862-4b69-8b58-474df2cdae29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10759-e862-4b69-8b58-474df2cdae29.jpg?1",
             "name": "Warrior's Oath",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -4535,7 +4535,7 @@
         },
         {
             "id": "9cfe5dd7-0f94-557d-a175-1f1b9e723cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219577e6-758a-4135-9a8d-f95df964137a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219577e6-758a-4135-9a8d-f95df964137a.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "88a0e731-383e-5584-ae5b-eb678fbe3221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afa0ee5-a0b8-472e-9991-09402ddb5de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afa0ee5-a0b8-472e-9991-09402ddb5de3.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "This spell can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "9fd1b083-24e8-5a8c-9f34-129a2880f115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df71162-7e8f-47c5-aff4-59d82d8c674d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df71162-7e8f-47c5-aff4-59d82d8c674d.jpg?1",
             "name": "Ambuscade",
             "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "b069cf46-c38a-5976-87e8-bb3b3054d1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6108741c-30de-4390-8482-3f293bdce4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6108741c-30de-4390-8482-3f293bdce4bd.jpg?1",
             "name": "Annoyed Altisaur",
             "text": "Reach, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -4676,7 +4676,7 @@
         },
         {
             "id": "0c74ec73-d9e5-5237-817a-61bfa0d107d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782fbd4-36fe-4da7-a73f-20d533de8960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782fbd4-36fe-4da7-a73f-20d533de8960.jpg?1",
             "name": "Arachnus Spinner",
             "text": "Reach\nTap an untapped Spider you control: Search your graveyard and/or library for a card named Arachnus Web and put it onto the battlefield attached to target creature. If you search your library this way, shuffle.",
             "colours": [
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "c56a87e7-ece2-5828-b1ee-077262c7623a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec348d8d-6b49-4a40-a668-fc6dd2af4f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec348d8d-6b49-4a40-a668-fc6dd2af4f0d.jpg?1",
             "name": "Arachnus Web",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the end step, if enchanted creature's power is 4 or greater, destroy Arachnus Web.",
             "colours": [
@@ -4744,7 +4744,7 @@
         },
         {
             "id": "cb3ccd46-b5a2-5bb3-9f00-723bb7d7c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8e93a0-33fd-4a1b-82b9-4b4a99fbb75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8e93a0-33fd-4a1b-82b9-4b4a99fbb75b.jpg?1",
             "name": "Biogenic Upgrade",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.",
             "colours": [
@@ -4776,7 +4776,7 @@
         },
         {
             "id": "2edc1e09-a9d3-5e9f-a792-c33874cd0dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06fc1f-d8f6-43b0-a795-d759fcdf8272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06fc1f-d8f6-43b0-a795-d759fcdf8272.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "686f99a9-e30d-50a7-8631-8df3a2943f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a005933-e206-4b14-9a0f-755fae6c5a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a005933-e206-4b14-9a0f-755fae6c5a2a.jpg?1",
             "name": "Brindle Shoat",
             "text": "When Brindle Shoat dies, create a 3/3 green Boar creature token.",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "09d273e2-eac8-5fd6-9a3f-e7a10ff3e1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d190aac9-9ac8-4b54-9f51-d7d1561dc743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d190aac9-9ac8-4b54-9f51-d7d1561dc743.jpg?1",
             "name": "Centaur Battlemaster",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Centaur Battlemaster, put three +1/+1 counters on Centaur Battlemaster.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "e7791969-b9ec-55a5-8405-354f6d5a0d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a26f51-5bff-4f06-abaa-6fbb56a8b5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a26f51-5bff-4f06-abaa-6fbb56a8b5b6.jpg?1",
             "name": "Concordant Crossroads",
             "text": "All creatures have haste.",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "0b443bdf-c4ef-566d-a41a-b4c29a551788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02191caa-60f9-4604-8c90-ecfc6aee8c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02191caa-60f9-4604-8c90-ecfc6aee8c09.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach, deathtouch",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "bddc210c-24cc-503e-9e66-15b6ed3fe2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab94f16-778d-4437-a1b9-2f67cd214cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab94f16-778d-4437-a1b9-2f67cd214cc0.jpg?1",
             "name": "Devoted Druid",
             "text": "{T}: Add {G}.\nPut a -1/-1 counter on Devoted Druid: Untap Devoted Druid.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "6882945a-2bca-5f00-b11a-25b2feeeea8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10403c-b15b-4884-9984-25b3ac976305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10403c-b15b-4884-9984-25b3ac976305.jpg?1",
             "name": "Elvish Rejuvenator",
             "text": "When Elvish Rejuvenator enters the battlefield, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "f785d5bd-82b8-5ea1-a5ca-f4ec3bd3e2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d7fa2c-4dbc-4e9e-9448-5bf8bbee95d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d7fa2c-4dbc-4e9e-9448-5bf8bbee95d6.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "1c746510-9f4d-519c-b7b1-78bbb968687d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589d8494-58c0-4584-a878-37d498621992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589d8494-58c0-4584-a878-37d498621992.jpg?1",
             "name": "Experiment One",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nRemove two +1/+1 counters from Experiment One: Regenerate Experiment One.",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "615356e0-c8c5-5b4c-a581-fa1f49748d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb912458-e016-4ea2-a2ea-40ac1a57f8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb912458-e016-4ea2-a2ea-40ac1a57f8fb.jpg?1",
             "name": "Food Chain",
             "text": "Exile a creature you control: Add X mana of any one color, where X is 1 plus the exiled creature's mana value. Spend this mana only to cast creature spells.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "c1a788dd-63d5-59fc-8469-97cf5b2b2912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3009640-23b1-49ce-a51b-982a48602c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3009640-23b1-49ce-a51b-982a48602c1d.jpg?1",
             "name": "Gnarlback Rhino",
             "text": "Trample\nWhenever you cast a spell that targets Gnarlback Rhino, draw a card.",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "e8a4663f-be8e-5bde-84a3-e282cb5367ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c874c79e-18e5-4c33-8580-1269e6b0fc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c874c79e-18e5-4c33-8580-1269e6b0fc55.jpg?1",
             "name": "Grapple with the Past",
             "text": "Mill three cards, then you may return a creature or land card from your graveyard to your hand.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "60bd2419-35d8-505a-b8ba-d8a9f5c76d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70291c7b-a86f-4466-8502-c28765a89b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70291c7b-a86f-4466-8502-c28765a89b2a.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with mana value X or less, put it onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "57654daf-636d-52e2-ba4e-c76adbdcc73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf31b01-0836-4366-948d-879999832abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf31b01-0836-4366-948d-879999832abe.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "70ead3ec-c748-5a23-b4b4-287cdcd52eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa77ae-f685-48ee-85dc-ba6084cd30ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa77ae-f685-48ee-85dc-ba6084cd30ba.jpg?1",
             "name": "Impervious Greatwurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
             "colours": [
@@ -5301,7 +5301,7 @@
         },
         {
             "id": "bad80f8c-587c-5808-9691-65fad3a9e1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c7c36-2b15-463b-a023-683972303a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c7c36-2b15-463b-a023-683972303a0a.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "abcf2177-565b-5158-8f1b-44dab5e3fa08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373a4e3e-6244-43e8-80ac-f5508db9ce57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373a4e3e-6244-43e8-80ac-f5508db9ce57.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -5371,7 +5371,7 @@
         },
         {
             "id": "5f98cebb-739a-5499-8166-35c201cc6f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89572b1f-f65a-4bd4-b52a-4e84eb373e90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89572b1f-f65a-4bd4-b52a-4e84eb373e90.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "2474ba0f-ec16-5eff-b91a-74802ce45f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6b411-4a31-4bfc-8dd6-e19f553bb29b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6b411-4a31-4bfc-8dd6-e19f553bb29b.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "9c595888-9b05-59e6-94e6-4a4cbcba5057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d320f16c-798a-4dbe-875e-6abe7a9b9e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d320f16c-798a-4dbe-875e-6abe7a9b9e6b.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "4b7d7d05-8008-5e47-9efa-d99ca8e8ff4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e20241b-515f-420f-9012-2f693f333187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e20241b-515f-420f-9012-2f693f333187.jpg?1",
             "name": "Spider Spawning",
             "text": "Create a 1/2 green Spider creature token with reach for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "cf483dd0-d391-55e4-a7c3-9fd418a7ef61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ac9fc-b8b3-43f1-8579-62171ca976cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ac9fc-b8b3-43f1-8579-62171ca976cf.jpg?1",
             "name": "Splinterfright",
             "text": "Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, mill two cards.",
             "colours": [
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "800500ea-5caf-5819-9c08-46717f0a1e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7383f71d-3f51-4632-9ea0-27d47fa2fa50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7383f71d-3f51-4632-9ea0-27d47fa2fa50.jpg?1",
             "name": "Summer Bloom",
             "text": "You may play up to three additional lands this turn.",
             "colours": [
@@ -5579,7 +5579,7 @@
         },
         {
             "id": "cb60ef12-1e96-5db8-95eb-b56f0bdd9cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c8bdb1-fa35-462e-ac3f-6953fe7f3476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c8bdb1-fa35-462e-ac3f-6953fe7f3476.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "2ccfe811-1018-5d19-a8de-a164bb12f888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66284816-1fd8-4489-b006-a9e605d8d144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66284816-1fd8-4489-b006-a9e605d8d144.jpg?1",
             "name": "Travel Preparations",
             "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "bb538a48-6c0f-5ec5-8547-158703bb3df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4eab4-a2e6-4cb0-b32a-700aac59fc40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4eab4-a2e6-4cb0-b32a-700aac59fc40.jpg?1",
             "name": "Tuskguard Captain",
             "text": "Outlast {G} ({G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5679,7 +5679,7 @@
         },
         {
             "id": "a5436142-3e72-5f61-942d-dd2171dece58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576807eb-47fa-4f08-8982-1c0b3526fdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576807eb-47fa-4f08-8982-1c0b3526fdd2.jpg?1",
             "name": "Webweaver Changeling",
             "text": "Changeling (This card is every creature type.)\nReach\nWhen Webweaver Changeling enters the battlefield, if there are three or more creature cards in your graveyard, you gain 5 life.",
             "colours": [
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "766398ed-e584-502c-92ea-7c7acef54899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b722d9-be9d-463c-929e-78f7156af9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b722d9-be9d-463c-929e-78f7156af9c6.jpg?1",
             "name": "Abzan Ascendancy",
             "text": "When Abzan Ascendancy enters the battlefield, put a +1/+1 counter on each creature you control.\nWhenever a nontoken creature you control dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "db8ad183-ae1e-5b9e-9fe5-10ad4afa6d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1757a916-60d3-4f6b-8759-32a1645dadd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1757a916-60d3-4f6b-8759-32a1645dadd2.jpg?1",
             "name": "Abzan Charm",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power 3 or greater.\n\u2022 You draw two cards and you lose 2 life.\n\u2022 Distribute two +1/+1 counters among one or two target creatures.",
             "colours": [
@@ -5787,7 +5787,7 @@
         },
         {
             "id": "edf002e8-0ba2-54d9-9e3f-f71b82e43126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df59b2e4-21a6-4cf1-80bd-f92f8ea99f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df59b2e4-21a6-4cf1-80bd-f92f8ea99f2c.jpg?1",
             "name": "Aethermage's Touch",
             "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -5821,7 +5821,7 @@
         },
         {
             "id": "da4b11e5-7ab9-573b-bd32-c564fbc973bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890a23e-1da0-432b-8dc8-85b92dee9ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890a23e-1da0-432b-8dc8-85b92dee9ba1.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5855,7 +5855,7 @@
         },
         {
             "id": "1adf84c0-bba8-5f75-8452-aa024ab8d741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc010302-e715-4946-89eb-a214e0b836ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc010302-e715-4946-89eb-a214e0b836ba.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "+1: Draw a card, then put a card from your hand on top of your library.\n\u22121: Exile another target permanent you own, then return it to the battlefield under your control.\n\u22126: Choose left or right. Each player gains control of all nonland permanents other than Aminatou, the Fateshifter controlled by the next player in the chosen direction.\nAminatou, the Fateshifter can be your commander.",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "ea8e188e-1002-54b4-a361-89a68dc36670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16de91dc-5d82-43ec-84ad-67bae644795a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16de91dc-5d82-43ec-84ad-67bae644795a.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "9592bbd9-2a3b-59ce-abdd-2affa993270a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da57d0-1ae3-4f05-a52d-eb76ad56cae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da57d0-1ae3-4f05-a52d-eb76ad56cae7.jpg?1",
             "name": "Animar, Soul of Elements",
             "text": "Protection from white and from black\nWhenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.\nCreature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "3f4a027a-549f-5320-8cf9-a68baea07056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb83da3-5a8e-4349-bbcc-dcbd3b70264b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb83da3-5a8e-4349-bbcc-dcbd3b70264b.jpg?1",
             "name": "Arjun, the Shifting Flame",
             "text": "Flying\nWhenever you cast a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
             "colours": [
@@ -6016,7 +6016,7 @@
         },
         {
             "id": "440f367d-36a3-53c1-8c62-f1584a08e64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2054d9-d10f-4127-aece-71c3f0ef547c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2054d9-d10f-4127-aece-71c3f0ef547c.jpg?1",
             "name": "Ashen Rider",
             "text": "Flying\nWhen Ashen Rider enters the battlefield or dies, exile target permanent.",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "13da7e17-9db5-5d43-914c-bb3589687019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac7744-ba18-4fc5-8a6f-840dad28f6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac7744-ba18-4fc5-8a6f-840dad28f6c0.jpg?1",
             "name": "Ashenmoor Liege",
             "text": "Other black creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\nWhenever Ashenmoor Liege becomes the target of a spell or ability an opponent controls, that player loses 4 life.",
             "colours": [
@@ -6093,7 +6093,7 @@
         },
         {
             "id": "054b4133-063e-5a25-8402-255af93975c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb63464-d06b-4626-a57a-1e393ef04a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb63464-d06b-4626-a57a-1e393ef04a58.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "df88e587-7c9b-569d-845e-840440fcda39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b152e-c94e-4c10-9f0d-d960e878a430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b152e-c94e-4c10-9f0d-d960e878a430.jpg?1",
             "name": "Atarka's Command",
             "text": "Choose two \u2014\n\u2022 Your opponents can't gain life this turn.\n\u2022 Atarka's Command deals 3 damage to each opponent.\n\u2022 You may put a land card from your hand onto the battlefield.\n\u2022 Creatures you control get +1/+1 and gain reach until end of turn.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "16979287-4b12-5381-a27f-d7f61fede09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b18981-c0be-455c-baa4-d3f45c55b4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b18981-c0be-455c-baa4-d3f45c55b4e3.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "{2}, {T}: Create a 0/1 green Egg creature token with defender.\nWhenever an Egg you control dies, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "bf8d8a2e-0178-5e79-8371-3ad08a2394f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d7413b-2ad3-4e8f-8728-5649f938d06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d7413b-2ad3-4e8f-8728-5649f938d06e.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -6243,7 +6243,7 @@
         },
         {
             "id": "cdf091f2-2591-5bb5-bbc9-eccd7f3b8e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722682f-952c-4829-b4ef-e52300b7950e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722682f-952c-4829-b4ef-e52300b7950e.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia, the Warleader attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "ca9d39c4-ff74-5e8b-8596-981be4e8a5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed13445-c9a0-4f17-aa69-af353679e6a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed13445-c9a0-4f17-aa69-af353679e6a7.jpg?1",
             "name": "Balefire Liege",
             "text": "Other red creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nWhenever you cast a red spell, Balefire Liege deals 3 damage to target player or planeswalker.\nWhenever you cast a white spell, you gain 3 life.",
             "colours": [
@@ -6322,7 +6322,7 @@
         },
         {
             "id": "c7bb9c77-4273-585f-aef2-7443b5bda0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7906b1e8-3049-4f4e-b1fd-b2547e7079f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7906b1e8-3049-4f4e-b1fd-b2547e7079f0.jpg?1",
             "name": "Bant Charm",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Put target creature on the bottom of its owner's library.\n\u2022 Counter target instant spell.",
             "colours": [
@@ -6358,7 +6358,7 @@
         },
         {
             "id": "edfaf8d8-7378-52a0-b1e0-f0fc21ab62d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28194ca7-3b2a-49b8-8f03-56a2c97859d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28194ca7-3b2a-49b8-8f03-56a2c97859d9.jpg?1",
             "name": "Bear's Companion",
             "text": "When Bear's Companion enters the battlefield, create a 4/4 green Bear creature token.",
             "colours": [
@@ -6397,7 +6397,7 @@
         },
         {
             "id": "f836ca2c-95f5-566a-80d3-ab919c52c7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85603-0ac6-4587-9724-e35ac06ffab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85603-0ac6-4587-9724-e35ac06ffab9.jpg?1",
             "name": "Blazing Hellhound",
             "text": "{1}, Sacrifice another creature: Blazing Hellhound deals 1 damage to any target.",
             "colours": [
@@ -6434,7 +6434,7 @@
         },
         {
             "id": "ecc36e5a-1b3b-5f9e-84f1-80598894fdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f12f6f-9383-47e6-a44f-2834ad130e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f12f6f-9383-47e6-a44f-2834ad130e51.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "0800124b-c0c6-58e9-b451-a2adde40b0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab31-1455-4b31-ba81-c346e608c34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab31-1455-4b31-ba81-c346e608c34e.jpg?1",
             "name": "Bloodwater Entity",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bloodwater Entity enters the battlefield, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "0e749a78-6ba3-5ffe-95c4-da5e30745a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f28e081-7994-468d-8505-9981b90c001c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f28e081-7994-468d-8505-9981b90c001c.jpg?1",
             "name": "Boartusk Liege",
             "text": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "4a69374a-ff97-52d0-a4a4-3fcaea282176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e038250-f8a9-4bce-baa6-7c2502929b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e038250-f8a9-4bce-baa6-7c2502929b59.jpg?1",
             "name": "Bounty of the Luxa",
             "text": "At the beginning of your precombat main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U}.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "cd288c55-34cf-541a-86a1-6713483626c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3399260-a81a-475c-9b87-1efb1a13f8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3399260-a81a-475c-9b87-1efb1a13f8d6.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -6619,7 +6619,7 @@
         },
         {
             "id": "d640fb11-ab4e-5aa2-9257-82a293890663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba327a5e-bd57-4e24-b4b4-062202df30e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba327a5e-bd57-4e24-b4b4-062202df30e1.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G}.",
             "colours": [
@@ -6658,7 +6658,7 @@
         },
         {
             "id": "1cbddcd6-adbc-5183-a415-a56f8e29ac0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf31f32f-bbca-4e70-93ca-f74c20202939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf31f32f-bbca-4e70-93ca-f74c20202939.jpg?1",
             "name": "Call to the Feast",
             "text": "Create three 1/1 white Vampire creature tokens with lifelink.",
             "colours": [
@@ -6692,7 +6692,7 @@
         },
         {
             "id": "91b58274-a3ee-54e0-b35f-eb5fec6cdad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17906962-d89f-42ae-b019-22974490513c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17906962-d89f-42ae-b019-22974490513c.jpg?1",
             "name": "Cartel Aristocrat",
             "text": "Sacrifice another creature: Cartel Aristocrat gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -6729,7 +6729,7 @@
         },
         {
             "id": "1143ffe6-7afe-5fb1-a9fa-3ffa865e4013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2373625-af3c-4c2a-a1d1-5288c446955d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2373625-af3c-4c2a-a1d1-5288c446955d.jpg?1",
             "name": "Child of Alara",
             "text": "Trample\nWhen Child of Alara dies, destroy all nonland permanents. They can't be regenerated.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "2a65de33-2d38-548e-916c-387580276d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a60ba3-208c-41c9-a40a-46d3586acdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a60ba3-208c-41c9-a40a-46d3586acdfd.jpg?1",
             "name": "Chronicler of Heroes",
             "text": "When Chronicler of Heroes enters the battlefield, draw a card if you control a creature with a +1/+1 counter on it.",
             "colours": [
@@ -6812,7 +6812,7 @@
         },
         {
             "id": "f41b1e0f-d579-587a-acf4-69ce54096b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffec325d-63d9-4f01-8bfd-ae6618b3e891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffec325d-63d9-4f01-8bfd-ae6618b3e891.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "9fd8035f-05be-5380-b664-0e9b389ac442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2d72f6-bde3-49fb-976e-2d0c4dce60e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2d72f6-bde3-49fb-976e-2d0c4dce60e3.jpg?1",
             "name": "Conclave Mentor",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.\nWhen Conclave Mentor dies, you gain life equal to its power.",
             "colours": [
@@ -6889,7 +6889,7 @@
         },
         {
             "id": "5c536660-2262-5fcd-8ce2-90bd2fc3a2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66e5673-e34b-46e8-a0e4-55f3ee20f99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66e5673-e34b-46e8-a0e4-55f3ee20f99a.jpg?1",
             "name": "Crackling Doom",
             "text": "Crackling Doom deals 2 damage to each opponent. Each opponent sacrifices a creature with the greatest power among creatures that player controls.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "209dc644-814e-5b63-988e-4ccaea3e8e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4e9ea4-5b86-4eb1-965c-ae67be24f4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4e9ea4-5b86-4eb1-965c-ae67be24f4ea.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may create a 1/1 black and green Worm creature token.",
             "colours": [
@@ -6963,7 +6963,7 @@
         },
         {
             "id": "9afbdd7b-d5e3-5055-9834-7143c7853ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ad8e0-575b-43cc-95fd-53ddd14e65c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ad8e0-575b-43cc-95fd-53ddd14e65c2.jpg?1",
             "name": "Dack's Duplicate",
             "text": "You may have Dack's Duplicate enter the battlefield as a copy of any creature on the battlefield, except it has haste and dethrone. (Whenever it attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "6f6d44c6-60a0-5ee8-97b0-56cb8c2e0e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ccd70-4b94-4287-977e-6262731c58d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ccd70-4b94-4287-977e-6262731c58d1.jpg?1",
             "name": "Dauntless Escort",
             "text": "Sacrifice Dauntless Escort: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -7040,7 +7040,7 @@
         },
         {
             "id": "29debff3-e25e-5940-b194-3ff4db7ae422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d5f2f-7e54-4538-9f0a-eed464a74016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d5f2f-7e54-4538-9f0a-eed464a74016.jpg?1",
             "name": "Deathbringer Liege",
             "text": "Other white creatures you control get +1/+1.\nOther black creatures you control get +1/+1.\nWhenever you cast a white spell, you may tap target creature.\nWhenever you cast a black spell, you may destroy target creature if it's tapped.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "7cb55053-0e06-5bd3-a2f2-8c994da4abef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ad8e7f-cda0-4529-94fc-dd3709158a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ad8e7f-cda0-4529-94fc-dd3709158a94.jpg?1",
             "name": "Doran, the Siege Tower",
             "text": "Each creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "ced75dfe-2ce8-5f5e-9656-ff0460d1c527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4262e71a-b1fa-4b54-b623-34f4a7ccd500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4262e71a-b1fa-4b54-b623-34f4a7ccd500.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "This spell can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -7163,7 +7163,7 @@
         },
         {
             "id": "6402195b-902d-5b07-90cc-abb6d5c2eb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee837b8-c280-4a5b-acdf-71247ab096f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee837b8-c280-4a5b-acdf-71247ab096f5.jpg?1",
             "name": "Dragonlord Silumgar",
             "text": "Flying, deathtouch\nWhen Dragonlord Silumgar enters the battlefield, gain control of target creature or planeswalker for as long as you control Dragonlord Silumgar.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "db657bdc-b52a-538b-8306-1665475fa4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a865b-617d-40bf-900f-4aeca3602600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a865b-617d-40bf-900f-4aeca3602600.jpg?1",
             "name": "Dreg Mangler",
             "text": "Haste\nScavenge {3}{B}{G} ({3}{B}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "a83eb15b-23ca-5512-8283-4385696c56de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0ae1f-75cf-4bb0-8651-fbf14fa59f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0ae1f-75cf-4bb0-8651-fbf14fa59f81.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying, double strike, lifelink\nWhenever you gain life, draw a card.",
             "colours": [
@@ -7279,7 +7279,7 @@
         },
         {
             "id": "c2fc46db-5daa-597e-9346-8562aedfe6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1437f747-51b7-4fe1-bd98-282a27c3470f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1437f747-51b7-4fe1-bd98-282a27c3470f.jpg?1",
             "name": "Dromoka's Command",
             "text": "Choose two \u2014\n\u2022 Prevent all damage target instant or sorcery spell would deal this turn.\n\u2022 Target player sacrifices an enchantment.\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7315,7 +7315,7 @@
         },
         {
             "id": "477fefc7-8c5d-5e82-a0ff-d550125274e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e34147-588b-4fe5-88dd-2dfda567681d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e34147-588b-4fe5-88dd-2dfda567681d.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "87b77345-9411-51ce-9ba0-f5ffb01d076a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0728027-a1ec-4814-87c4-10c3baced0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0728027-a1ec-4814-87c4-10c3baced0e0.jpg?1",
             "name": "Elsha of the Infinite",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nYou may look at the top card of your library any time.\nYou may cast noncreature spells from the top of your library. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "8ec07169-8188-5c0a-978c-09c48d6e5bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908d523-1911-4a49-9e3f-ea1b719a8f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908d523-1911-4a49-9e3f-ea1b719a8f0b.jpg?1",
             "name": "Empyrial Archangel",
             "text": "Flying\nShroud (This creature can't be the target of spells or abilities.)\nAll damage that would be dealt to you is dealt to Empyrial Archangel instead.",
             "colours": [
@@ -7440,7 +7440,7 @@
         },
         {
             "id": "aedf1c7e-9352-5347-b0e3-521fb6f61386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769e3f-d27d-4aff-8da0-f03c10b8650b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769e3f-d27d-4aff-8da0-f03c10b8650b.jpg?1",
             "name": "Extract from Darkness",
             "text": "Each player mills two cards. Then you put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "0f327954-9e82-50d6-95d5-5f6388e443e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf721b0-2b5a-4085-b50c-89cbe7420673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf721b0-2b5a-4085-b50c-89cbe7420673.jpg?1",
             "name": "Ezuri, Claw of Progress",
             "text": "Whenever a creature with power 2 or less enters the battlefield under your control, you get an experience counter.\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is the number of experience counters you have.",
             "colours": [
@@ -7516,7 +7516,7 @@
         },
         {
             "id": "8c71ba45-4ce8-5a79-a04e-0173c5283a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144668d6-cab6-45e6-8498-ab7cd927f9df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144668d6-cab6-45e6-8498-ab7cd927f9df.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.",
             "colours": [
@@ -7554,7 +7554,7 @@
         },
         {
             "id": "c488933c-1aee-5ed1-9c16-53acf427dc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d779966-4bd4-4315-8b45-d3a4492f2bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d779966-4bd4-4315-8b45-d3a4492f2bb2.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a Kithkin Spirit with base power and toughness 2/2.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "0f75e5f5-ff7d-5f10-bdfc-483edb46d7e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df03ac18-1ab4-4264-9821-3f92333c3ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df03ac18-1ab4-4264-9821-3f92333c3ed8.jpg?1",
             "name": "Fireblade Artist",
             "text": "Haste\nAt the beginning of your upkeep, you may sacrifice a creature. When you do, Fireblade Artist deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "8009ba0e-a15b-503a-b204-9b880602ca4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5edf4f-5695-42fc-9e57-c4faef60fbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5edf4f-5695-42fc-9e57-c4faef60fbc3.jpg?1",
             "name": "Firesong and Sunspeaker",
             "text": "Red instant and sorcery spells you control have lifelink.\nWhenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "95488514-0f79-5dd6-b4a3-18a0b387ba50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2be0e99-cf43-423f-974f-02e3313b3aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2be0e99-cf43-423f-974f-02e3313b3aa9.jpg?1",
             "name": "Ghave, Guru of Spores",
             "text": "Ghave, Guru of Spores enters the battlefield with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from a creature you control: Create a 1/1 green Saproling creature token.\n{1}, Sacrifice a creature: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "84f66fd6-48b1-5152-b153-b92b896268d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374d2d74-1209-4822-b370-ab8b049d4ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374d2d74-1209-4822-b370-ab8b049d4ce0.jpg?1",
             "name": "Glen Elendra Liege",
             "text": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "f27bb4fd-15bd-5d09-b9cc-777424f1ad13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54a2256-673d-4d93-9e1d-7790bf254881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54a2256-673d-4d93-9e1d-7790bf254881.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player mills ten cards.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "3f876a96-078e-53f1-9b52-c8df6e39605a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e48e-e0a4-4a45-8d82-2ab56fee7246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e48e-e0a4-4a45-8d82-2ab56fee7246.jpg?1",
             "name": "Gloryscale Viashino",
             "text": "Whenever you cast a multicolored spell, Gloryscale Viashino gets +3/+3 until end of turn.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "824412bd-6770-57ad-b3fe-c78814530ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f56d8-3ea1-4750-b88d-c5a7837681b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f56d8-3ea1-4750-b88d-c5a7837681b5.jpg?1",
             "name": "Glowspore Shaman",
             "text": "When Glowspore Shaman enters the battlefield, mill three cards. You may put a land card from your graveyard on top of your library.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "d9f634fb-ddd4-5284-9959-a9dfda961e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43748ea-1d65-4ee8-9c66-221412a284c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43748ea-1d65-4ee8-9c66-221412a284c0.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -7907,7 +7907,7 @@
         },
         {
             "id": "e8d96510-39bf-577f-a1b1-4e8a062b127e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce33033-f673-451e-bb8e-cd3e2309e4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce33033-f673-451e-bb8e-cd3e2309e4b4.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -7947,7 +7947,7 @@
         },
         {
             "id": "2c0274f7-731d-5afb-9eda-25a86e66c58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c61bd1-4bf5-4c38-835d-2249f8e8d5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c61bd1-4bf5-4c38-835d-2249f8e8d5d4.jpg?1",
             "name": "Ground Assault",
             "text": "Ground Assault deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "2dd0140b-602c-5362-abf6-3dd2f08cd96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66c8ada-82a6-46d9-acd0-b4ff9e1e12bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66c8ada-82a6-46d9-acd0-b4ff9e1e12bd.jpg?1",
             "name": "Guided Passage",
             "text": "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle.",
             "colours": [
@@ -8019,7 +8019,7 @@
         },
         {
             "id": "df571be4-e69a-5459-9b6f-26a93cd57031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99869b4-0bb6-444a-bdc4-5916371c9d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99869b4-0bb6-444a-bdc4-5916371c9d29.jpg?1",
             "name": "Hellkite Overlord",
             "text": "Flying, trample, haste\n{R}: Hellkite Overlord gets +1/+0 until end of turn.\n{B}{G}: Regenerate Hellkite Overlord.",
             "colours": [
@@ -8059,7 +8059,7 @@
         },
         {
             "id": "63f35266-c63d-5fb0-9c7f-d51a2a80c7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5817ce-a8ba-4007-b8ca-6d39a421a9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5817ce-a8ba-4007-b8ca-6d39a421a9bc.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste.",
             "colours": [
@@ -8093,7 +8093,7 @@
         },
         {
             "id": "b02a234d-3024-53a9-a993-81d1a0c3ab81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1481378-25c3-4f8d-93bc-0a433f467dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1481378-25c3-4f8d-93bc-0a433f467dca.jpg?1",
             "name": "Hostage Taker",
             "text": "When Hostage Taker enters the battlefield, exile another target creature or artifact until Hostage Taker leaves the battlefield. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -8132,7 +8132,7 @@
         },
         {
             "id": "0d9bd644-be84-58da-865c-f0a39ecefd8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65010991-2097-4769-be96-f24b4bf9276f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65010991-2097-4769-be96-f24b4bf9276f.jpg?1",
             "name": "Hydroid Krasis",
             "text": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nHydroid Krasis enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "c534f0cf-dbc5-5918-a1d2-b21ad4762fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35517572-b5d4-4dbf-b090-4e4c4b040a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35517572-b5d4-4dbf-b090-4e4c4b040a0d.jpg?1",
             "name": "Intet, the Dreamer",
             "text": "Flying\nWhenever Intet, the Dreamer deals combat damage to a player, you may pay {2}{U}. If you do, exile the top card of your library face down. You may look at that card for as long as it remains exiled. You may play that card without paying its mana cost for as long as Intet remains on the battlefield.",
             "colours": [
@@ -8214,7 +8214,7 @@
         },
         {
             "id": "31d045e8-a7e9-509e-ace5-a19a0c20cfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4b8a7-4153-4694-9aae-f61d3124c785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4b8a7-4153-4694-9aae-f61d3124c785.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Izzet Charm deals 2 damage to target creature.\n\u2022 Draw two cards, then discard two cards.",
             "colours": [
@@ -8248,7 +8248,7 @@
         },
         {
             "id": "cffb93bf-c1db-5ee3-9320-78ebd4125109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8399fc-4cba-44c5-888e-2cfc0f6739f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8399fc-4cba-44c5-888e-2cfc0f6739f6.jpg?1",
             "name": "Jeskai Ascendancy",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn. Untap those creatures.\nWhenever you cast a noncreature spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -8286,7 +8286,7 @@
         },
         {
             "id": "9de32ef4-9a20-5bf8-b469-b7c4506fa8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c0fcdb-a312-4976-bcfb-73930c0a556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c0fcdb-a312-4976-bcfb-73930c0a556c.jpg?1",
             "name": "Jeskai Charm",
             "text": "Choose one \u2014\n\u2022 Put target creature on top of its owner's library.\n\u2022 Jeskai Charm deals 4 damage to target opponent or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "6b063fe6-b14b-5699-8908-90f0679cbeb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c18cb4-96b1-4af2-912e-974e22877ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c18cb4-96b1-4af2-912e-974e22877ede.jpg?1",
             "name": "Jodah, Archmage Eternal",
             "text": "Flying\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "f6238e61-70de-5c8f-9381-7d19f797ad76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4fc28d1-61d5-4a78-8fbb-6566128486ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4fc28d1-61d5-4a78-8fbb-6566128486ce.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -8408,7 +8408,7 @@
         },
         {
             "id": "ce143ef3-0096-5b2d-80a0-93ea338b279a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6631f-f3a6-4d3c-8618-4b4ab4e82483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6631f-f3a6-4d3c-8618-4b4ab4e82483.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -8451,7 +8451,7 @@
         },
         {
             "id": "88fad682-8a9e-53ef-ab82-8a6ef5b789d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b8259d-0bfa-4327-ac91-157c0b9e7dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b8259d-0bfa-4327-ac91-157c0b9e7dfb.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent casts a spell, Kaervek the Merciless deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -8492,7 +8492,7 @@
         },
         {
             "id": "9aa56a84-2427-5d92-95b3-9c7308a41de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e47d49-e5b5-487b-a1ec-373dbf89b2ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e47d49-e5b5-487b-a1ec-373dbf89b2ec.jpg?1",
             "name": "Kambal, Consul of Allocation",
             "text": "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "f119390e-0e74-5172-91f2-1360a641b20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6200ac79-b166-43d0-9a0b-5b547625ed57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6200ac79-b166-43d0-9a0b-5b547625ed57.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -8576,7 +8576,7 @@
         },
         {
             "id": "230f89d4-9778-5de6-a3b7-2b85b8ebe8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dab027-a475-481b-b012-b6a76e21e494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dab027-a475-481b-b012-b6a76e21e494.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to any target.",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "7e9a04e4-0081-567b-88e4-5faf03c6dd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e903a1d8-2127-4a32-9223-8ff6574c503f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e903a1d8-2127-4a32-9223-8ff6574c503f.jpg?1",
             "name": "Lavalanche",
             "text": "Lavalanche deals X damage to target player or planeswalker and each creature that player or that planeswalker's controller controls.",
             "colours": [
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "e5d7577b-6386-5694-b8fd-ea45212466f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07478486-b065-4173-837e-cd3335a0567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07478486-b065-4173-837e-cd3335a0567d.jpg?1",
             "name": "League Guildmage",
             "text": "{3}{U}, {T}: Draw a card.\n{X}{R}, {T}: Copy target instant or sorcery spell you control with mana value X. You may choose new targets for the copy.",
             "colours": [
@@ -8688,7 +8688,7 @@
         },
         {
             "id": "f4ca29b1-6047-59cc-927f-2d02c5deba0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f950f-b818-4150-af71-b53a502ca0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f950f-b818-4150-af71-b53a502ca0d5.jpg?1",
             "name": "Legion's Initiative",
             "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
             "colours": [
@@ -8724,7 +8724,7 @@
         },
         {
             "id": "ca1f16f9-50f5-5d59-aa31-30df5e641ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f25737-a195-4763-bc23-b3c4d38b9e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f25737-a195-4763-bc23-b3c4d38b9e58.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -8758,7 +8758,7 @@
         },
         {
             "id": "10020527-fbad-500a-9996-219202ed797b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696cb81d-bc00-4603-b340-c0b2e55c0959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696cb81d-bc00-4603-b340-c0b2e55c0959.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -8796,7 +8796,7 @@
         },
         {
             "id": "fff1d7a3-6507-56f3-b036-49b78ea65a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc138550-a797-4a57-91b3-626aac1b1edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc138550-a797-4a57-91b3-626aac1b1edd.jpg?1",
             "name": "Lotleth Troll",
             "text": "Trample\nDiscard a creature card: Put a +1/+1 counter on Lotleth Troll.\n{B}: Regenerate Lotleth Troll.",
             "colours": [
@@ -8833,7 +8833,7 @@
         },
         {
             "id": "3240ee59-b746-5bd3-b4af-1eaed503143d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3e1033-428a-4263-8813-fdb8bb4b6425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3e1033-428a-4263-8813-fdb8bb4b6425.jpg?1",
             "name": "Lyev Skyknight",
             "text": "Flying\nWhen Lyev Skyknight enters the battlefield, detain target nonland permanent an opponent controls. (Until your next turn, that permanent can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -8870,7 +8870,7 @@
         },
         {
             "id": "8a9c820c-1959-58af-92c9-1da98df43a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be662808-e452-407d-b142-bf6f30990b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be662808-e452-407d-b142-bf6f30990b5a.jpg?1",
             "name": "Magister Sphinx",
             "text": "Flying\nWhen Magister Sphinx enters the battlefield, target player's life total becomes 10.",
             "colours": [
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "0f906c25-1f97-55a6-a815-ef9316b7582a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3242a9f0-2ba3-4852-ac8f-366772ac1c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3242a9f0-2ba3-4852-ac8f-366772ac1c62.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "Dethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nOther creatures you control have dethrone.\nWhenever a creature you control with a +1/+1 counter on it dies, return that card to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -8955,7 +8955,7 @@
         },
         {
             "id": "e8fdb3b6-7a50-5d90-92fc-03d33377bdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf662e7-e63f-40c2-b163-1ebce47d8696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf662e7-e63f-40c2-b163-1ebce47d8696.jpg?1",
             "name": "Martial Glory",
             "text": "Target creature gets +3/+0 until end of turn.\nTarget creature gets +0/+3 until end of turn.",
             "colours": [
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "bd6a5ddb-00ff-54de-8690-b69aca0a001f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a57b0e38-8931-4715-ac13-b3af30b27895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a57b0e38-8931-4715-ac13-b3af30b27895.jpg?1",
             "name": "Master Biomancer",
             "text": "Each other creature you control enters the battlefield with a number of additional +1/+1 counters on it equal to Master Biomancer's power and as a Mutant in addition to its other types.",
             "colours": [
@@ -9028,7 +9028,7 @@
         },
         {
             "id": "78f3c2c9-9c74-5214-b12c-ffd43c9cc488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25266b22-3cee-4ac8-91e8-5a23fbaa457a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25266b22-3cee-4ac8-91e8-5a23fbaa457a.jpg?1",
             "name": "Master of Cruelties",
             "text": "First strike, deathtouch\nMaster of Cruelties can only attack alone.\nWhenever Master of Cruelties attacks a player and isn't blocked, that player's life total becomes 1. Master of Cruelties assigns no combat damage this combat.",
             "colours": [
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "7f183d7f-165f-5274-9763-203dbb4a8501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921b65b1-18bf-4b02-a35d-7eaee1846611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921b65b1-18bf-4b02-a35d-7eaee1846611.jpg?1",
             "name": "Mathas, Fiend Seeker",
             "text": "Menace\nAt the beginning of your end step, put a bounty counter on target creature an opponent controls. For as long as that creature has a bounty counter on it, it has \"When this creature dies, each opponent draws a card and gains 2 life.\"",
             "colours": [
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "367c0744-3fbb-56b8-a807-a89c4d55d5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53170fe-7f18-47ef-b501-1ed398306419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53170fe-7f18-47ef-b501-1ed398306419.jpg?1",
             "name": "Mayael's Aria",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
             "colours": [
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "f4367933-5ba2-54f8-b7b3-fbaa1a140aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173413-0431-4b70-a509-f1bc11a59225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173413-0431-4b70-a509-f1bc11a59225.jpg?1",
             "name": "The Mimeoplasm",
             "text": "As The Mimeoplasm enters the battlefield, you may exile two creature cards from graveyards. If you do, it enters the battlefield as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
             "colours": [
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "53a8ae14-ce42-5bab-bc80-93c1f43388fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6dd439-78f6-480b-bdc3-1cb3481bcaf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6dd439-78f6-480b-bdc3-1cb3481bcaf1.jpg?1",
             "name": "Mindwrack Liege",
             "text": "Other blue creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\n{UR}{UR}{UR}{UR}: You may put a blue or red creature card from your hand onto the battlefield.",
             "colours": [
@@ -9227,7 +9227,7 @@
         },
         {
             "id": "f680c970-f39f-5494-8356-8190aa54c438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0119777-70da-4cba-8104-a7e78604d515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0119777-70da-4cba-8104-a7e78604d515.jpg?1",
             "name": "Mistmeadow Witch",
             "text": "{2}{W}{U}: Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -9264,7 +9264,7 @@
         },
         {
             "id": "f0710344-ccac-5f9b-8466-81c8e784a50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069bf085-3f70-4c85-8e90-609d1d182e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069bf085-3f70-4c85-8e90-609d1d182e29.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "88a33a30-2171-5877-89dd-9a030cbd5dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4125bb0-b104-438e-a6a2-97f9d141243c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4125bb0-b104-438e-a6a2-97f9d141243c.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -9349,7 +9349,7 @@
         },
         {
             "id": "0e6b2d26-9230-57aa-bd90-7508b502a47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16677645-f635-4183-8afc-056520b94122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16677645-f635-4183-8afc-056520b94122.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "6cac882b-57d3-5b6b-a3c9-56dcd5401f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597ca22d-2f08-47b3-9d93-c4d685cefb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597ca22d-2f08-47b3-9d93-c4d685cefb5f.jpg?1",
             "name": "Nicol Bolas, God-Pharaoh",
             "text": "+2: Target opponent exiles cards from the top of their library until they exile a nonland card. Until end of turn, you may cast that card without paying its mana cost.\n+1: Each opponent exiles two cards from their hand.\n\u22124: Nicol Bolas, God-Pharaoh deals 7 damage to target opponent, creature an opponent controls, or planeswalker an opponent controls.\n\u221212: Exile each nonland permanent your opponents control.",
             "colours": [
@@ -9429,7 +9429,7 @@
         },
         {
             "id": "b2829fde-5c82-54e6-a1db-408b5092147a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e36323c-75d0-475e-a5a7-9a1567ff2b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e36323c-75d0-475e-a5a7-9a1567ff2b62.jpg?1",
             "name": "Orzhov Pontiff",
             "text": "Haunt (When this creature dies, exile it haunting target creature.)\nWhen Orzhov Pontiff enters the battlefield or the creature it haunts dies, choose one \u2014\n\u2022 Creatures you control get +1/+1 until end of turn.\n\u2022 Creatures you don't control get -1/-1 until end of turn.",
             "colours": [
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "f90d8c75-6641-54ba-bbfa-7a779f78be0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd85ec-13b3-4d63-b144-5baa39ad6524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd85ec-13b3-4d63-b144-5baa39ad6524.jpg?1",
             "name": "Phyrexian Tyranny",
             "text": "Whenever a player draws a card, that player loses 2 life unless they pay {2}.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "8b753ca1-31af-535c-b588-43e48056f0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9655bbe4-062f-4278-ad05-a326a64c5b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9655bbe4-062f-4278-ad05-a326a64c5b69.jpg?1",
             "name": "Privileged Position",
             "text": "Other permanents you control have hexproof.",
             "colours": [
@@ -9541,7 +9541,7 @@
         },
         {
             "id": "74792188-b94b-51b4-a25d-e64364d1380e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844c9fa7-8751-49be-827a-7fb6986bae59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844c9fa7-8751-49be-827a-7fb6986bae59.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -9579,7 +9579,7 @@
         },
         {
             "id": "ce80dae4-630a-53cd-befe-578317fccb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b79c31-597f-484b-a684-f1520cae314a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b79c31-597f-484b-a684-f1520cae314a.jpg?1",
             "name": "Prophetic Bolt",
             "text": "Prophetic Bolt deals 4 damage to any target. Look at the top four cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "1ba3b058-453b-50f7-84f3-8aee80307397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145d817-9c84-4acd-977c-fe00325568fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145d817-9c84-4acd-977c-fe00325568fd.jpg?1",
             "name": "Psychic Symbiont",
             "text": "Flying\nWhen Psychic Symbiont enters the battlefield, target opponent discards a card and you draw a card.",
             "colours": [
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "add8069c-43a8-5e34-863e-b9faea2cbf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103646d-b363-4896-a48f-0527d746587e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103646d-b363-4896-a48f-0527d746587e.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "94cea151-fddc-5d37-bb90-8a3bb17c40b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12259d86-f610-47c7-bb81-0da9bb6a2795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12259d86-f610-47c7-bb81-0da9bb6a2795.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "c51b5d01-8534-5e59-b4de-aefbfbab2425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff9aa6-bc5e-476d-9dd1-1318ed521b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff9aa6-bc5e-476d-9dd1-1318ed521b6f.jpg?1",
             "name": "River Hoopoe",
             "text": "Flying\n{3}{G}{U}: You gain 2 life and draw a card.",
             "colours": [
@@ -9768,7 +9768,7 @@
         },
         {
             "id": "2f8ecb6e-ebc2-5bb3-884d-41dc84cf55b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e2d6c2-a233-4e37-94c9-673a4a957e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e2d6c2-a233-4e37-94c9-673a4a957e0c.jpg?1",
             "name": "Roon of the Hidden Realm",
             "text": "Vigilance, trample\n{2}, {T}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "868a0110-e985-5a81-bf74-14561019a8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa828bdc-221e-4e81-9e71-6f288690ddcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa828bdc-221e-4e81-9e71-6f288690ddcd.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each combat if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "63561c08-6118-5a19-9ca8-31d1eeb81b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68aa496d-15c0-4da0-b3c9-4bb7e57d9a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68aa496d-15c0-4da0-b3c9-4bb7e57d9a31.jpg?1",
             "name": "Scab-Clan Giant",
             "text": "When Scab-Clan Giant enters the battlefield, it fights target creature an opponent controls chosen at random.",
             "colours": [
@@ -9889,7 +9889,7 @@
         },
         {
             "id": "217679f7-38ee-59f9-85d8-5b13e662eef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0fe75-cfaf-483e-8412-9ffb5d96ae25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0fe75-cfaf-483e-8412-9ffb5d96ae25.jpg?1",
             "name": "Sedraxis Specter",
             "text": "Flying\nWhenever Sedraxis Specter deals combat damage to a player, that player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -9927,7 +9927,7 @@
         },
         {
             "id": "428d724c-0a3b-52a2-827c-3f3d1199a1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e787a7-3721-4ba7-b643-a103488cfc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e787a7-3721-4ba7-b643-a103488cfc8a.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -9971,7 +9971,7 @@
         },
         {
             "id": "1c3e0174-606f-58ca-9f10-a4c5337fa0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a30e27-4c52-4191-8541-e25732a2dd42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a30e27-4c52-4191-8541-e25732a2dd42.jpg?1",
             "name": "Shattergang Brothers",
             "text": "{2}{B}, Sacrifice a creature: Each other player sacrifices a creature.\n{2}{R}, Sacrifice an artifact: Each other player sacrifices an artifact.\n{2}{G}, Sacrifice an enchantment: Each other player sacrifices an enchantment.",
             "colours": [
@@ -10014,7 +10014,7 @@
         },
         {
             "id": "88ca9de5-3496-58d7-a21a-327922f1724d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f08fd3-9c0a-476a-9894-1938179824c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f08fd3-9c0a-476a-9894-1938179824c6.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "e3fc013b-c7f7-5c56-8cee-02542be2de50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd0bf11-4e43-43f1-82e3-755beed0ede0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd0bf11-4e43-43f1-82e3-755beed0ede0.jpg?1",
             "name": "Skullbriar, the Walking Grave",
             "text": "Haste\nWhenever Skullbriar, the Walking Grave deals combat damage to a player, put a +1/+1 counter on it.\nCounters remain on Skullbriar as it moves to any zone other than a player's hand or library.",
             "colours": [
@@ -10098,7 +10098,7 @@
         },
         {
             "id": "232142c2-9d13-5fec-b7ce-fbb4cc4cd680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b05cf1-1bc2-43e1-b383-9cbb69517389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b05cf1-1bc2-43e1-b383-9cbb69517389.jpg?1",
             "name": "Sprouting Thrinax",
             "text": "When Sprouting Thrinax dies, create three 1/1 green Saproling creature tokens.",
             "colours": [
@@ -10136,7 +10136,7 @@
         },
         {
             "id": "953ed7de-42df-5f99-8dbf-c191d3912057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcc4f4b-a1bd-4581-858f-bbd3ff6a9d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcc4f4b-a1bd-4581-858f-bbd3ff6a9d7a.jpg?1",
             "name": "Sultai Soothsayer",
             "text": "When Sultai Soothsayer enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -10175,7 +10175,7 @@
         },
         {
             "id": "45c509a6-eee6-5a69-b2e5-1b6be733d4ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b5fe42-929c-406d-9377-40b49f9d2e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b5fe42-929c-406d-9377-40b49f9d2e2c.jpg?1",
             "name": "Supreme Verdict",
             "text": "This spell can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -10212,7 +10212,7 @@
         },
         {
             "id": "aa29ca23-6ae3-5d07-8863-970cf54b0eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b588dc15-68e6-4cbb-9345-a921c10f862d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b588dc15-68e6-4cbb-9345-a921c10f862d.jpg?1",
             "name": "Tariel, Reckoner of Souls",
             "text": "Flying, vigilance\n{T}: Choose a creature card at random from target opponent's graveyard. Put that card onto the battlefield under your control.",
             "colours": [
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "c2ada85b-56d0-5c51-affc-8bea5572dcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8caa7115-1b26-4615-842f-671b24dc96d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8caa7115-1b26-4615-842f-671b24dc96d8.jpg?1",
             "name": "Teneb, the Harvester",
             "text": "Flying\nWhenever Teneb, the Harvester deals combat damage to a player, you may pay {2}{B}. If you do, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -10296,7 +10296,7 @@
         },
         {
             "id": "ea001a1e-07b9-516c-b7d2-a1b48ecb2001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0c8d75-fb20-49f2-9a03-35411f06c1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0c8d75-fb20-49f2-9a03-35411f06c1a7.jpg?1",
             "name": "Tenth District Legionnaire",
             "text": "Haste\nWhenever you cast a spell that targets Tenth District Legionnaire, put a +1/+1 counter on Tenth District Legionnaire, then scry 1.",
             "colours": [
@@ -10333,7 +10333,7 @@
         },
         {
             "id": "98a5d7fe-1c33-5723-9f51-22940d66ff96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cba6180-a15e-4f7f-8843-e48e69e758a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cba6180-a15e-4f7f-8843-e48e69e758a0.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -10369,7 +10369,7 @@
         },
         {
             "id": "1651bede-be68-5bf2-93c6-0a7dc6659cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a21a0c-fe3d-456b-a905-8d962c0b1e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a21a0c-fe3d-456b-a905-8d962c0b1e3c.jpg?1",
             "name": "Thistledown Liege",
             "text": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
             "colours": [
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "d5fba822-6308-5bb9-b1a1-d8dd73c8eb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e22fb-7afc-43bc-b309-e36ee48d6b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e22fb-7afc-43bc-b309-e36ee48d6b03.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -10445,7 +10445,7 @@
         },
         {
             "id": "84f02141-3ce5-5e45-9827-b9ab247396c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7334eb-66c1-4410-966c-4e76c1b9e9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7334eb-66c1-4410-966c-4e76c1b9e9a7.jpg?1",
             "name": "Thraximundar",
             "text": "Haste\nWhenever Thraximundar attacks, defending player sacrifices a creature.\nWhenever a player sacrifices a creature, you may put a +1/+1 counter on Thraximundar.",
             "colours": [
@@ -10488,7 +10488,7 @@
         },
         {
             "id": "17173ae0-3c40-5642-a65c-65caf449240b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aef108-6aaf-465d-b3f6-5ac1499f44a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aef108-6aaf-465d-b3f6-5ac1499f44a3.jpg?1",
             "name": "Tower Gargoyle",
             "text": "Flying",
             "colours": [
@@ -10527,7 +10527,7 @@
         },
         {
             "id": "4c5e4a6c-ce15-5734-a4db-c40ef64e55bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1",
             "name": "Ulasht, the Hate Seed",
             "text": "Ulasht, the Hate Seed enters the battlefield with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one \u2014\n\u2022 Ulasht deals 1 damage to target creature.\n\u2022 Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "f0ad0151-5127-5f0e-a9e3-c1c8b4462cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca984fdb-aaca-4d8f-af2f-72387122607b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca984fdb-aaca-4d8f-af2f-72387122607b.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "Hexproof\nUril, the Miststalker gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -10610,7 +10610,7 @@
         },
         {
             "id": "85dc658b-3746-50fa-8518-74c8c9c104eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1caccc8-4f33-4ae3-a09a-b41b9c4663a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1caccc8-4f33-4ae3-a09a-b41b9c4663a1.jpg?1",
             "name": "Varina, Lich Queen",
             "text": "Whenever you attack with one or more Zombies, draw that many cards, then discard that many cards. You gain that much life.\n{2}, Exile two cards from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "b8640965-bab9-5d78-aa46-240541fcf42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c4bd2-b84a-4dbd-9452-90c9734d78fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c4bd2-b84a-4dbd-9452-90c9734d78fb.jpg?1",
             "name": "Villainous Wealth",
             "text": "Target opponent exiles the top X cards of their library. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "90d59752-59f4-5119-99c9-75503e3e1915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07790bd5-0d27-490e-b1ae-3b866882461e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07790bd5-0d27-490e-b1ae-3b866882461e.jpg?1",
             "name": "Wasitora, Nekoru Queen",
             "text": "Flying, trample\nWhenever Wasitora, Nekoru Queen deals combat damage to a player, that player sacrifices a creature. If the player can't, you create a 3/3 black, red, and green Cat Dragon creature token with flying.",
             "colours": [
@@ -10734,7 +10734,7 @@
         },
         {
             "id": "be162e18-8e5c-56ac-9b5d-25b1508779ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4928cb86-6971-458b-ad74-1b39c0e1c177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4928cb86-6971-458b-ad74-1b39c0e1c177.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -10773,7 +10773,7 @@
         },
         {
             "id": "1690f261-906c-5c48-a264-8f30b472c4cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400862ac-f229-4f73-949c-779f6bfa868b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400862ac-f229-4f73-949c-779f6bfa868b.jpg?1",
             "name": "Winged Coatl",
             "text": "Flash\nFlying, deathtouch",
             "colours": [
@@ -10809,7 +10809,7 @@
         },
         {
             "id": "3f2cdb30-dd78-5ea8-96e4-4efd56396e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd498cc-a609-4457-9325-6888d59ca36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd498cc-a609-4457-9325-6888d59ca36f.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -10851,7 +10851,7 @@
         },
         {
             "id": "5b2886f1-1614-52a1-a141-c5e019aa0425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb0160a-dfdc-4b1f-865e-ef905aee65d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb0160a-dfdc-4b1f-865e-ef905aee65d5.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -10894,7 +10894,7 @@
         },
         {
             "id": "22b2e747-6d2b-503a-bc8e-0d28b82340e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e8d2fd-b132-4807-9410-8edeffa519ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e8d2fd-b132-4807-9410-8edeffa519ed.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with mana value equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -10925,7 +10925,7 @@
         },
         {
             "id": "ad2def85-d307-5fee-bf98-93ecf0f22739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1939833-05e5-4cbd-b766-7837e72e5929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1939833-05e5-4cbd-b766-7837e72e5929.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -10958,7 +10958,7 @@
         },
         {
             "id": "a749c48d-3833-5709-9912-9bdb9ae78610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c1112-4cfc-4af9-85a9-4431886f19bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c1112-4cfc-4af9-85a9-4431886f19bb.jpg?1",
             "name": "Civic Saber",
             "text": "Equipped creature gets +1/+0 for each of its colors.\nEquip {1}",
             "colours": [],
@@ -10988,7 +10988,7 @@
         },
         {
             "id": "2296faa9-091f-511c-90e2-c9d36f73ad6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2548ad2-3c62-4ed1-899c-1002b46cdd8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2548ad2-3c62-4ed1-899c-1002b46cdd8f.jpg?1",
             "name": "Coldsteel Heart",
             "text": "Coldsteel Heart enters the battlefield tapped.\nAs Coldsteel Heart enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -11018,7 +11018,7 @@
         },
         {
             "id": "a41f61e6-266d-59a5-984b-c7faec99f333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f5399a-26c6-4ecd-9715-f6440f6958f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f5399a-26c6-4ecd-9715-f6440f6958f1.jpg?1",
             "name": "Conqueror's Flail",
             "text": "Equipped creature gets +1/+1 for each color among permanents you control.\nAs long as Conqueror's Flail is attached to a creature, your opponents can't cast spells during your turn.\nEquip {2}",
             "colours": [],
@@ -11050,7 +11050,7 @@
         },
         {
             "id": "bb3f2dc8-8e08-5152-a6a0-44a194246b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4893ef-f983-418b-b7a4-5f073c844545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4893ef-f983-418b-b7a4-5f073c844545.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "f3e783a3-ea19-56d8-bd09-651a74de57c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f99fb1e-99a6-4c83-98eb-7bff23996a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f99fb1e-99a6-4c83-98eb-7bff23996a7f.jpg?1",
             "name": "Darksteel Plate",
             "text": "Indestructible\nEquipped creature has indestructible.\nEquip {2}",
             "colours": [],
@@ -11113,7 +11113,7 @@
         },
         {
             "id": "e08cd29d-f912-5faf-a57d-256882b9e0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2312a56-088f-42f9-9bd2-7b0b94935236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2312a56-088f-42f9-9bd2-7b0b94935236.jpg?1",
             "name": "Dragon Arch",
             "text": "{2}, {T}: You may put a multicolored creature card from your hand onto the battlefield.",
             "colours": [],
@@ -11141,7 +11141,7 @@
         },
         {
             "id": "c264a1a7-1e3e-5598-a758-f54a02f7d023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f918-df2e-4663-b622-f731b0e01b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f918-df2e-4663-b622-f731b0e01b6d.jpg?1",
             "name": "Firemind Vessel",
             "text": "Firemind Vessel enters the battlefield tapped.\n{T}: Add two mana of different colors.",
             "colours": [],
@@ -11169,7 +11169,7 @@
         },
         {
             "id": "88d3346f-68f7-58e0-97c4-f6b1dd2797b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac4633-066b-4897-b484-2ec654c7eaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac4633-066b-4897-b484-2ec654c7eaa1.jpg?1",
             "name": "Livewire Lash",
             "text": "Equipped creature gets +2/+0 and has \"Whenever this creature becomes the target of a spell, this creature deals 2 damage to any target.\"\nEquip {2}",
             "colours": [],
@@ -11199,7 +11199,7 @@
         },
         {
             "id": "35caa9dd-fb92-5df1-85a1-18aa98e3b97a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a31d52-a407-4ded-bfca-cc812f11afa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a31d52-a407-4ded-bfca-cc812f11afa0.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -11230,7 +11230,7 @@
         },
         {
             "id": "4802bb6c-137d-5854-b02d-91c47ae4d569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787b1cc8-42b4-4d3e-9b8a-a252de297b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787b1cc8-42b4-4d3e-9b8a-a252de297b1a.jpg?1",
             "name": "Nim Deathmantle",
             "text": "Equipped creature gets +2/+2, has intimidate, and is a black Zombie. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever a nontoken creature is put into your graveyard from the battlefield, you may pay {4}. If you do, return that card to the battlefield and attach Nim Deathmantle to it.\nEquip {4}",
             "colours": [],
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "2b914ffc-6103-5dac-a4ca-e4436d9242ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998d0cc8-ca2a-41c3-ab65-d05c26ab8278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998d0cc8-ca2a-41c3-ab65-d05c26ab8278.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -11293,7 +11293,7 @@
         },
         {
             "id": "55121999-d723-5c41-b01c-06d3183fe849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9f93c-50a8-41a9-be98-d1900bf1c12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9f93c-50a8-41a9-be98-d1900bf1c12f.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "33ea1b54-cdcc-52a8-8a80-d79bbd1478fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776899f8-e977-42b7-8b54-6f726a349e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776899f8-e977-42b7-8b54-6f726a349e3c.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -11355,7 +11355,7 @@
         },
         {
             "id": "ebe68561-0858-5fa1-9582-f894682e1727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30879758-841c-46a9-a0b6-179ac163f0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30879758-841c-46a9-a0b6-179ac163f0ac.jpg?1",
             "name": "Planar Bridge",
             "text": "{8}, {T}: Search your library for a permanent card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "1a871666-a17b-51c4-9f96-8202311eaeb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5142b7a-e580-4737-a4aa-2590f6610ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5142b7a-e580-4737-a4aa-2590f6610ceb.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -11418,7 +11418,7 @@
         },
         {
             "id": "149416da-a41f-5b30-8cba-ec3693d68de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14adc0af-de61-4872-916c-3cf480dece46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14adc0af-de61-4872-916c-3cf480dece46.jpg?1",
             "name": "Thrumming Stone",
             "text": "Spells you cast have ripple 4. (Whenever you cast a spell, you may reveal the top four cards of your library. You may cast spells with the same name as that spell from among the revealed cards without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [],
@@ -11450,7 +11450,7 @@
         },
         {
             "id": "2416fd04-9d07-525f-ac38-7f277baf0fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93621a8-d0f4-436e-9e4f-cccc0447eae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93621a8-d0f4-436e-9e4f-cccc0447eae8.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -11478,7 +11478,7 @@
         },
         {
             "id": "b8e14f08-2817-51eb-b6c4-18c9f4a7e5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44067327-6fe3-4222-b591-6d14d0e360d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44067327-6fe3-4222-b591-6d14d0e360d7.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may cast spells as though they had flash.",
             "colours": [],
@@ -11509,7 +11509,7 @@
         },
         {
             "id": "eaaafb79-49c0-5c10-996d-7e1e0647cf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7084fc02-8941-4a4f-805d-3c1625cf1d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7084fc02-8941-4a4f-805d-3c1625cf1d58.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U}.",
             "colours": [],
@@ -11542,7 +11542,7 @@
         },
         {
             "id": "79aed9ca-85af-5a55-9d1f-23deb80d0b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26abe8c-4f06-448d-9e0e-8214592cb885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26abe8c-4f06-448d-9e0e-8214592cb885.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W}.",
             "colours": [],
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "01603f03-a5ea-53d0-9d9e-14770b97be39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e697ea72-e10e-4fed-be8f-8c6455cc3fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e697ea72-e10e-4fed-be8f-8c6455cc3fc8.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -11606,7 +11606,7 @@
         },
         {
             "id": "167ffae5-73d5-5e65-8028-950e4abfbb45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed4a63d-632a-4a3a-b35f-f8e155237d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed4a63d-632a-4a3a-b35f-f8e155237d27.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -11637,7 +11637,7 @@
         },
         {
             "id": "5d279ecc-ddd4-5aa4-9d65-02fb3cdaa639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b7b90-80d4-4cad-af7c-a0b36c590ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b7b90-80d4-4cad-af7c-a0b36c590ca0.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B}.",
             "colours": [],
@@ -11670,7 +11670,7 @@
         },
         {
             "id": "3a7c814b-dcc2-5984-86c3-461b7217a97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db644c-1acf-477d-9c20-f72221f1108a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db644c-1acf-477d-9c20-f72221f1108a.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color.\nWhenever you tap Forbidden Orchard for mana, target opponent creates a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -11701,7 +11701,7 @@
         },
         {
             "id": "272c4bdb-e8d7-5263-8f96-1d49639116a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b093d-a483-4c7d-81b5-9c70c866bbb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b093d-a483-4c7d-81b5-9c70c866bbb1.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G}.",
             "colours": [],
@@ -11734,7 +11734,7 @@
         },
         {
             "id": "d73fac11-44c0-5750-9df7-2a3befa5c76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294b7e06-4758-4590-b1f0-b7f97537218f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294b7e06-4758-4590-b1f0-b7f97537218f.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G}.",
             "colours": [],
@@ -11767,7 +11767,7 @@
         },
         {
             "id": "1eb2ee1e-c0b6-5050-a90f-63daea2bdebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb746aeb-7595-4b45-8ffc-90f220308960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb746aeb-7595-4b45-8ffc-90f220308960.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R}.",
             "colours": [],
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "bb91fb3e-627a-5d88-b22f-f95cfbe2948c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d7237b-6749-4d39-bc69-5185d01e24d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d7237b-6749-4d39-bc69-5185d01e24d4.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -11833,7 +11833,7 @@
         },
         {
             "id": "501a4114-ee5d-55ff-8af1-13e9489ce8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66bacf-ad9a-40c3-a2b7-464be8d4dd24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66bacf-ad9a-40c3-a2b7-464be8d4dd24.jpg?1",
             "name": "Pillar of the Paruns",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a multicolored spell.",
             "colours": [],
@@ -11863,7 +11863,7 @@
         },
         {
             "id": "a3027e70-2e3e-5ded-be51-416c582b4826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c4a77-a458-4493-a35e-6bbb6d88087f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c4a77-a458-4493-a35e-6bbb6d88087f.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R}.",
             "colours": [],
@@ -11896,7 +11896,7 @@
         },
         {
             "id": "1f16e387-647d-5a2c-9570-933171722241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8af7e5a-806b-4264-9010-f497b40a7fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8af7e5a-806b-4264-9010-f497b40a7fb4.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W}.",
             "colours": [],
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "9c18876f-d6cb-5875-833a-e1d63aabaea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511cf93-3443-4e35-8425-a1e2d24a6157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511cf93-3443-4e35-8425-a1e2d24a6157.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U}.",
             "colours": [],
@@ -11962,7 +11962,7 @@
         },
         {
             "id": "bbc08c11-694c-509e-819e-3f515b14c2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309a6684-ecb3-491c-899a-3aa15a51130b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309a6684-ecb3-491c-899a-3aa15a51130b.jpg?1",
             "name": "Cryptic Spires",
             "text": "As you create your deck, circle two of the colors below.\nCryptic Spires enters the battlefield tapped.\n{T}: Add one mana of either of the circled colors.",
             "colours": [],
@@ -11989,7 +11989,7 @@
         },
         {
             "id": "d0d78dd8-cbe2-5387-8433-5ce7e4ef0d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8638c18-f5ea-4e36-9c48-ec1446d0f7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8638c18-f5ea-4e36-9c48-ec1446d0f7a6.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -12029,7 +12029,7 @@
         },
         {
             "id": "691697d5-b4b5-5515-8388-74f1bd72c290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169fcff7-58f2-420b-a5f1-642ad38709b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169fcff7-58f2-420b-a5f1-642ad38709b3.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "f58d9aa7-9a43-5556-ae17-9636e6c7ef15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765fd969-d3da-426a-8bf2-d4e1bb7ae878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765fd969-d3da-426a-8bf2-d4e1bb7ae878.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -12107,7 +12107,7 @@
         },
         {
             "id": "c83d9fb9-922a-50cd-ac0b-59627916983d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b4b6cd-6d0f-4060-b51f-61f481000d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b4b6cd-6d0f-4060-b51f-61f481000d51.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -12143,7 +12143,7 @@
         },
         {
             "id": "1458a72a-e137-5813-8a82-70cb454e3ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc085e9-bbb2-463a-b35c-bee13008a2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc085e9-bbb2-463a-b35c-bee13008a2c6.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "60b71ed3-0e96-57c4-a06a-d816e986cb83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3331a24-e4c0-45ca-9b72-ae14d5cd94eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3331a24-e4c0-45ca-9b72-ae14d5cd94eb.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.",
             "colours": [
@@ -12219,7 +12219,7 @@
         },
         {
             "id": "e129055d-563d-55e5-a33b-9f683dc37d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a595d04e-4cdb-49d1-a323-7b6d1e3ccbe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a595d04e-4cdb-49d1-a323-7b6d1e3ccbe9.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -12255,7 +12255,7 @@
         },
         {
             "id": "757e6ffc-f1ec-5ad2-995d-fd09e392b906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b974f99-28d0-4cd5-87a7-3f9661ddd1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b974f99-28d0-4cd5-87a7-3f9661ddd1b4.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "3ba26d10-99b3-53a3-a36b-ec14a4113a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb79bb-657d-469d-b3f2-381a82891ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb79bb-657d-469d-b3f2-381a82891ccc.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -12329,7 +12329,7 @@
         },
         {
             "id": "c599bdd0-d7fb-5996-8651-4362bc68242b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca736b62-9b02-49bf-8abd-5de6c4bf0ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca736b62-9b02-49bf-8abd-5de6c4bf0ab0.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -12364,7 +12364,7 @@
         },
         {
             "id": "b3fe4fff-90b6-5631-b7db-66c921c33cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08707-1599-4b3f-9be1-363dfe4ecdbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08707-1599-4b3f-9be1-363dfe4ecdbe.jpg?1",
             "name": "Teferi's Protection",
             "text": "Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)\nExile Teferi's Protection.",
             "colours": [
@@ -12399,7 +12399,7 @@
         },
         {
             "id": "9da8789e-40e1-5175-b66f-5278b4e2d840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c9e989-b3fd-43ca-b2a5-d051f3b504b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c9e989-b3fd-43ca-b2a5-d051f3b504b3.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -12435,7 +12435,7 @@
         },
         {
             "id": "106eb1f8-1452-55cd-8bfb-7db43bc5a3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4397224-5e64-4615-8c53-e6672655f2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4397224-5e64-4615-8c53-e6672655f2ad.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -12472,7 +12472,7 @@
         },
         {
             "id": "e6f88c32-1836-5add-8995-9b18d6f7b34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5396b405-6fa0-43d7-a8f6-f64154e95e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5396b405-6fa0-43d7-a8f6-f64154e95e98.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -12507,7 +12507,7 @@
         },
         {
             "id": "d863befe-facd-5a0e-92ae-5468fb4e4f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb51da3a-9058-4817-ae69-d1d02a81b207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb51da3a-9058-4817-ae69-d1d02a81b207.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle.",
             "colours": [
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "a5f55cca-b38c-5e82-bb37-6c2488db16a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456a2f03-8304-4512-804c-76653e30f436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456a2f03-8304-4512-804c-76653e30f436.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value.",
             "colours": [
@@ -12577,7 +12577,7 @@
         },
         {
             "id": "252d5437-fa8e-547f-b4ed-9bde68d37920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99074b05-f252-4626-a96a-6bc286e8d03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99074b05-f252-4626-a96a-6bc286e8d03a.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -12613,7 +12613,7 @@
         },
         {
             "id": "0afff012-e2bd-549d-aa18-ad6f78190cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c8f1c8-2b57-41a3-abeb-77ac7de62fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c8f1c8-2b57-41a3-abeb-77ac7de62fa1.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -12647,7 +12647,7 @@
         },
         {
             "id": "e8d67cfe-48a0-5a71-90a3-140a59d41ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370142f-441b-4e70-bef9-f79e6a877ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370142f-441b-4e70-bef9-f79e6a877ee9.jpg?1",
             "name": "Thought Scour",
             "text": "Target player mills two cards.\nDraw a card.",
             "colours": [
@@ -12681,7 +12681,7 @@
         },
         {
             "id": "b0f2b7f2-459e-5912-93c5-c6e9825ea7f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5587191b-b56a-452d-8a18-1622df83c267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5587191b-b56a-452d-8a18-1622df83c267.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -12717,7 +12717,7 @@
         },
         {
             "id": "7d23e27f-35e5-5324-975c-61e7d854fe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca972d7-fcf8-4ac4-a98b-fffb2fbb4dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca972d7-fcf8-4ac4-a98b-fffb2fbb4dbc.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -12752,7 +12752,7 @@
         },
         {
             "id": "cc50fdf0-d575-5706-8437-8cbf0eb2de6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0163dd21-9f9f-4656-b0b2-7774be0b6ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0163dd21-9f9f-4656-b0b2-7774be0b6ada.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -12787,7 +12787,7 @@
         },
         {
             "id": "05adc052-5d16-5435-a6d4-8e264523673d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599cf02f-47a1-47b4-b67e-8f27fa65c151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599cf02f-47a1-47b4-b67e-8f27fa65c151.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "c2dae913-4061-5f8d-b60c-592c92273005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b359c884-dfbe-4c16-9c83-f9f906db1f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b359c884-dfbe-4c16-9c83-f9f906db1f40.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles.",
             "colours": [
@@ -12856,7 +12856,7 @@
         },
         {
             "id": "4d71fd80-e9df-5945-b64f-cad92328c43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656127b7-21c4-40ce-8fff-5cc3d38398f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656127b7-21c4-40ce-8fff-5cc3d38398f8.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -12890,7 +12890,7 @@
         },
         {
             "id": "edd650f2-9ce5-50eb-b5d5-70c92d7df9bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedcbd3b-7e30-44cf-b9b7-1bb32c11ef67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedcbd3b-7e30-44cf-b9b7-1bb32c11ef67.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -12925,7 +12925,7 @@
         },
         {
             "id": "207d4c0c-f0ef-5e5f-b116-200995f2a3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ba4278-c63e-49b4-bf60-16dfe5c70a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ba4278-c63e-49b4-bf60-16dfe5c70a0b.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -12960,7 +12960,7 @@
         },
         {
             "id": "110e193d-f86b-59f0-a979-fd0615c7576e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fdac35-d709-4078-8205-ad7c79b6644c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fdac35-d709-4078-8205-ad7c79b6644c.jpg?1",
             "name": "Dockside Extortionist",
             "text": "When Dockside Extortionist enters the battlefield, create X Treasure tokens, where X is the number of artifacts and enchantments your opponents control.",
             "colours": [
@@ -12998,7 +12998,7 @@
         },
         {
             "id": "190a854f-6657-59fb-a551-4bf99e4a5905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c8390f-4072-454f-8dc4-174919187a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c8390f-4072-454f-8dc4-174919187a47.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -13032,7 +13032,7 @@
         },
         {
             "id": "6185a1cb-a43f-5ee4-b0ee-7b9b6753f81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9899a8-f5b0-427f-ac87-09fc8afe0f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9899a8-f5b0-427f-ac87-09fc8afe0f23.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "c05a844d-dfe2-5c45-8eff-83ab3d895682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da7322-924c-4018-a38a-89f4ea85d435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da7322-924c-4018-a38a-89f4ea85d435.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -13107,7 +13107,7 @@
         },
         {
             "id": "4d9a74ef-c1e0-518d-955e-1c59da57e8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f10099a-d256-44ec-a7a3-c93b27741d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f10099a-d256-44ec-a7a3-c93b27741d06.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -13144,7 +13144,7 @@
         },
         {
             "id": "a7c8a3fc-9af8-57b0-92f3-6fe75c775509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e99bd-04dc-4bf9-87df-86a810135dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e99bd-04dc-4bf9-87df-86a810135dfe.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "This spell can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -13182,7 +13182,7 @@
         },
         {
             "id": "d9856433-aecc-5b5b-84bf-55b919ce5a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200693d6-7164-4b24-8cff-c1f3e407fea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200693d6-7164-4b24-8cff-c1f3e407fea9.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -13220,7 +13220,7 @@
         },
         {
             "id": "9af7a005-4ba6-5c12-bcb1-a43776649f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e276fb-3af7-444e-b132-1fe9f2e1fd2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e276fb-3af7-444e-b132-1fe9f2e1fd2a.jpg?1",
             "name": "Concordant Crossroads",
             "text": "All creatures have haste.",
             "colours": [
@@ -13257,7 +13257,7 @@
         },
         {
             "id": "8c28db13-d9da-54c2-823d-d99cfe7dd00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf722227-5b90-47e3-9f56-5ba43114c14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf722227-5b90-47e3-9f56-5ba43114c14e.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -13294,7 +13294,7 @@
         },
         {
             "id": "c098afe1-1b41-5f8e-994b-ae4b2121c038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b635f1c-1e65-4aec-af23-e75e49665014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b635f1c-1e65-4aec-af23-e75e49665014.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -13329,7 +13329,7 @@
         },
         {
             "id": "03c7a115-6f8c-5257-aa68-208b2d75a32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dce077-4ecd-406a-9052-05d5485ffa6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dce077-4ecd-406a-9052-05d5485ffa6f.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -13367,7 +13367,7 @@
         },
         {
             "id": "c695ef98-6a16-51c2-a998-308adfcd080a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bbf009-0798-4d8b-b375-6d6fde975c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bbf009-0798-4d8b-b375-6d6fde975c34.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13401,7 +13401,7 @@
         },
         {
             "id": "5a55e755-8812-5599-bcb8-c97d1cb3b950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f4ff8-efd2-4d22-8491-54bd6e73006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f4ff8-efd2-4d22-8491-54bd6e73006c.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "f114e89e-fafa-5eb9-b750-efa6b0391d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6031e3f0-0181-4785-9016-574823985a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6031e3f0-0181-4785-9016-574823985a69.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -13477,7 +13477,7 @@
         },
         {
             "id": "02255d52-a851-59b4-9177-0fabc9eb6f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78efee5c-970c-4f9b-9a6b-96ef3e79caaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78efee5c-970c-4f9b-9a6b-96ef3e79caaa.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G}.",
             "colours": [
@@ -13516,7 +13516,7 @@
         },
         {
             "id": "b2c7dd2e-903f-51ab-8cbe-c6523b4e44ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033e6145-cf40-4fa8-98a4-ed8b5e8a66ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033e6145-cf40-4fa8-98a4-ed8b5e8a66ab.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -13556,7 +13556,7 @@
         },
         {
             "id": "5d573f4f-1a13-59f4-b39c-be30eacb45f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a6236c-0148-48de-be63-6ddbb34f9a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a6236c-0148-48de-be63-6ddbb34f9a2a.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "This spell can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "dcf68e3a-76b9-514a-b01e-490f5f375d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d129496d-3ae0-4e61-9e20-6259c0754b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d129496d-3ae0-4e61-9e20-6259c0754b9e.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "3095c89b-909d-5203-849e-0f4d9a12c2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d6f1ff-7514-4fed-80e9-fd912e21bd26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d6f1ff-7514-4fed-80e9-fd912e21bd26.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player mills ten cards.",
             "colours": [
@@ -13677,7 +13677,7 @@
         },
         {
             "id": "ab0fd9eb-fb14-58e1-b39a-07973bb9d859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0143eb00-b054-4741-8423-66eed0362a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0143eb00-b054-4741-8423-66eed0362a30.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -13719,7 +13719,7 @@
         },
         {
             "id": "86ab57f0-4d43-55e9-8b58-78d9ec3151b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356110b1-9cfe-420c-963a-c12469786e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356110b1-9cfe-420c-963a-c12469786e40.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -13759,7 +13759,7 @@
         },
         {
             "id": "e5524868-2e11-56d1-8ab6-04fe70ece2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8bdd10-0bdc-4339-bd84-b540606438d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8bdd10-0bdc-4339-bd84-b540606438d6.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to any target.",
             "colours": [
@@ -13796,7 +13796,7 @@
         },
         {
             "id": "cdc3a0d2-3c56-50c5-84c1-39d3d985c8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9975663-3038-4c72-b29c-65635dbe36bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9975663-3038-4c72-b29c-65635dbe36bb.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "Dethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nOther creatures you control have dethrone.\nWhenever a creature you control with a +1/+1 counter on it dies, return that card to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -13840,7 +13840,7 @@
         },
         {
             "id": "2f85b076-20ba-55d2-b174-6f8061bcb90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32086e-47a1-4088-a36b-85025daee5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32086e-47a1-4088-a36b-85025daee5fe.jpg?1",
             "name": "The Mimeoplasm",
             "text": "As The Mimeoplasm enters the battlefield, you may exile two creature cards from graveyards. If you do, it enters the battlefield as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "931b2a2d-20ec-563d-9f58-d63e7be14e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7d02a-7b83-4444-ac65-1661637183ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7d02a-7b83-4444-ac65-1661637183ee.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "4b701105-1e43-58b4-a45f-5703a0d9dd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dd7473-9baa-4410-aeab-3373f3a5ffb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dd7473-9baa-4410-aeab-3373f3a5ffb9.jpg?1",
             "name": "Privileged Position",
             "text": "Other permanents you control have hexproof.",
             "colours": [
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "530f4531-fd66-5f04-947f-db8fd7adfcc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035fa74-7e0d-4bcc-8bd7-4ae0c33db317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035fa74-7e0d-4bcc-8bd7-4ae0c33db317.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -14003,7 +14003,7 @@
         },
         {
             "id": "9d5b6d08-f88d-597e-938d-4373f78a7564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a2deb-034c-4ed8-83cd-b71c2ca36cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a2deb-034c-4ed8-83cd-b71c2ca36cea.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -14047,7 +14047,7 @@
         },
         {
             "id": "38fdf18d-942a-5676-bb42-0aec7803a369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b760cc-800a-48a3-97d9-316e1eeafd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b760cc-800a-48a3-97d9-316e1eeafd4c.jpg?1",
             "name": "Supreme Verdict",
             "text": "This spell can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -14084,7 +14084,7 @@
         },
         {
             "id": "f6d65518-322a-5cf1-a08c-fb9b71fd306f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f3c523-09dc-4f2a-9bd9-7614e061de28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f3c523-09dc-4f2a-9bd9-7614e061de28.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -14120,7 +14120,7 @@
         },
         {
             "id": "c495d485-7a34-5061-a2df-ac27c700a813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec17fa3c-9033-4eab-a236-3f0068595536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec17fa3c-9033-4eab-a236-3f0068595536.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -14157,7 +14157,7 @@
         },
         {
             "id": "5e506e06-9d1a-572f-b440-516be17b177b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e26409-430b-419b-8cd2-1bce007f12d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e26409-430b-419b-8cd2-1bce007f12d6.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with mana value equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -14188,7 +14188,7 @@
         },
         {
             "id": "07025bd9-6da4-53f4-b67e-f87429dcf3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66202ab-cd10-4116-8e22-05b45a45fa85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66202ab-cd10-4116-8e22-05b45a45fa85.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -14221,7 +14221,7 @@
         },
         {
             "id": "05bb86bb-98b7-5338-900f-c630a865b43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dccb71b-a25a-4ef8-b2ab-716fd38dcc0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dccb71b-a25a-4ef8-b2ab-716fd38dcc0b.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -14252,7 +14252,7 @@
         },
         {
             "id": "ce333667-b107-5333-9dad-f18b707f623b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a941b1f6-9f18-4c9e-993f-bf8f52bd6f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a941b1f6-9f18-4c9e-993f-bf8f52bd6f53.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -14283,7 +14283,7 @@
         },
         {
             "id": "fc1d7d9a-4de1-50dc-af70-aa308b22a3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c801e-b429-45d3-896e-289ec0497db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c801e-b429-45d3-896e-289ec0497db0.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -14314,7 +14314,7 @@
         },
         {
             "id": "1d49a1c0-f25f-53e4-b7b8-4442eed8837d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043de2ce-9ee9-414f-9385-6e5260173988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043de2ce-9ee9-414f-9385-6e5260173988.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -14345,7 +14345,7 @@
         },
         {
             "id": "b0e65a6a-e443-5c3f-90ea-404004cf6d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e997845-be0e-4130-8d07-5d2963ce8a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e997845-be0e-4130-8d07-5d2963ce8a5e.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -14376,7 +14376,7 @@
         },
         {
             "id": "cd5a990a-e06b-55ee-9c0b-c9b0c54490a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696792c7-245a-437e-b495-477b177773ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696792c7-245a-437e-b495-477b177773ba.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -14407,7 +14407,7 @@
         },
         {
             "id": "ecc44e22-b39e-5528-8f84-10a443bec6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91adeef-c1d5-4b14-9d79-ddd0dc035786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91adeef-c1d5-4b14-9d79-ddd0dc035786.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may cast spells as though they had flash.",
             "colours": [],
@@ -14438,7 +14438,7 @@
         },
         {
             "id": "93d56685-b571-5240-90d1-0addb9919628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a944c2-0711-4e0c-9cd5-cfd5ad5f8266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a944c2-0711-4e0c-9cd5-cfd5ad5f8266.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U}.",
             "colours": [],
@@ -14471,7 +14471,7 @@
         },
         {
             "id": "c4b7c3cf-5421-594a-ae49-d5fce862cec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cdfa12-e933-4c64-b7d5-c856a6a054ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cdfa12-e933-4c64-b7d5-c856a6a054ff.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W}.",
             "colours": [],
@@ -14504,7 +14504,7 @@
         },
         {
             "id": "749ccb78-b54f-520e-ab79-80d56cb90b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4222863c-c851-4ef7-b29f-7111b05bb843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4222863c-c851-4ef7-b29f-7111b05bb843.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -14535,7 +14535,7 @@
         },
         {
             "id": "06546c18-ffe5-5148-82f3-5f3049ee1e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869ec7dc-dbf5-4ed4-a368-328da384ecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869ec7dc-dbf5-4ed4-a368-328da384ecae.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -14566,7 +14566,7 @@
         },
         {
             "id": "febaa4c7-ff25-5d3a-a365-3412a7216b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7761b314-844a-4ade-a584-f37712cd2293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7761b314-844a-4ade-a584-f37712cd2293.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B}.",
             "colours": [],
@@ -14599,7 +14599,7 @@
         },
         {
             "id": "6e1332bf-be25-5940-9cc4-7129b2aa5d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dd80b6-28ff-488a-bc39-fb661da52e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dd80b6-28ff-488a-bc39-fb661da52e30.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color.\nWhenever you tap Forbidden Orchard for mana, target opponent creates a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -14630,7 +14630,7 @@
         },
         {
             "id": "4e3efb88-566e-5c3d-af4d-59816b4679c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6729320-d557-4860-80e4-32afcf6aad34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6729320-d557-4860-80e4-32afcf6aad34.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G}.",
             "colours": [],
@@ -14663,7 +14663,7 @@
         },
         {
             "id": "dfe56f31-eb1a-5f3f-a2eb-c11a86137b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380f74f-aa76-42dc-9596-92d651e1c1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380f74f-aa76-42dc-9596-92d651e1c1f6.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G}.",
             "colours": [],
@@ -14696,7 +14696,7 @@
         },
         {
             "id": "ad642426-341d-52cd-a155-744be7a8fdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891067e9-dd89-4f0e-9ef8-694a831962aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891067e9-dd89-4f0e-9ef8-694a831962aa.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R}.",
             "colours": [],
@@ -14729,7 +14729,7 @@
         },
         {
             "id": "7909a9a9-ba17-5e1c-b923-99a0a15b7364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ee89c5-5504-4b9b-b70e-4b48e4c66c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ee89c5-5504-4b9b-b70e-4b48e4c66c76.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -14762,7 +14762,7 @@
         },
         {
             "id": "5c169133-2453-5415-b397-4ba9233ef7a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197d420-fc69-4672-90f0-2264f35d1c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197d420-fc69-4672-90f0-2264f35d1c61.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R}.",
             "colours": [],
@@ -14795,7 +14795,7 @@
         },
         {
             "id": "1e1887ca-10b3-569a-87e7-fbdef5b988dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41907913-2308-4d76-b737-216088ce0d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41907913-2308-4d76-b737-216088ce0d57.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W}.",
             "colours": [],
@@ -14828,7 +14828,7 @@
         },
         {
             "id": "7eac1a36-d22d-5a9e-b293-e3468fb97d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e1b11-1796-4fec-bb1c-111b0f9768f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e1b11-1796-4fec-bb1c-111b0f9768f7.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U}.",
             "colours": [],
@@ -14861,7 +14861,7 @@
         },
         {
             "id": "1ec929f1-c791-5dfe-b3a3-1b29a165ea72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c632e1-faa8-40f9-a5b7-8773644516fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c632e1-faa8-40f9-a5b7-8773644516fa.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -14896,7 +14896,7 @@
         },
         {
             "id": "bc7929be-9502-5450-92bf-f154bf326456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4358e0-9dad-48dd-aad0-d4a3ab4766c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4358e0-9dad-48dd-aad0-d4a3ab4766c7.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -14931,7 +14931,7 @@
         },
         {
             "id": "1e2054ca-3739-5e40-be61-38d01bba937c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942c0703-f745-40bb-b894-8a64e854cd64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942c0703-f745-40bb-b894-8a64e854cd64.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -14966,7 +14966,7 @@
         },
         {
             "id": "11f9b6b3-d54f-5b63-8b3b-eb0bae59608d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68a7e08-6af2-4eab-afd4-7eb9db431e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68a7e08-6af2-4eab-afd4-7eb9db431e9c.jpg?1",
             "name": "Divine Visitation",
             "text": "If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.",
             "colours": [
@@ -14999,7 +14999,7 @@
         },
         {
             "id": "f3fe7174-21b1-54e4-ba62-7315e7184662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ac0230-151f-4079-9963-42b123e4b3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ac0230-151f-4079-9963-42b123e4b3fe.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.",
             "colours": [
@@ -15038,7 +15038,7 @@
         },
         {
             "id": "6c1ee181-714f-5420-89aa-4b26e0e7f7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f882a1-a34a-4319-bb75-c11a1193e8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f882a1-a34a-4319-bb75-c11a1193e8e8.jpg?1",
             "name": "Leonin Arbiter",
             "text": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "colours": [
@@ -15074,7 +15074,7 @@
         },
         {
             "id": "fe5f6fe7-fc59-58fd-bfed-582bc82b3688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc0779-8c92-404d-b959-db9f4bd63947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc0779-8c92-404d-b959-db9f4bd63947.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -15112,7 +15112,7 @@
         },
         {
             "id": "e7bf29be-534e-53f8-ad96-f04f8d61d0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8208ec-5049-4f9b-a5ea-89097cb1d141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8208ec-5049-4f9b-a5ea-89097cb1d141.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "9cd71216-938a-515a-b524-7d4eae442f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38befc96-938e-4b7f-97da-ed67ccd8900b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38befc96-938e-4b7f-97da-ed67ccd8900b.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -15183,7 +15183,7 @@
         },
         {
             "id": "2c871ee7-04bf-53a2-b818-1776bf6bdb9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8ab20-e402-48d9-8a39-7cf09d333374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8ab20-e402-48d9-8a39-7cf09d333374.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -15218,7 +15218,7 @@
         },
         {
             "id": "e171d406-a546-57a4-a8a5-1711aa6a8213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3b9aac-c5d5-4284-9c7c-67b23748fa45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3b9aac-c5d5-4284-9c7c-67b23748fa45.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -15252,7 +15252,7 @@
         },
         {
             "id": "be0745d1-0a66-53e3-9ec2-19c321916c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1802943c-07cc-48bb-a861-f18cb5f2b0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1802943c-07cc-48bb-a861-f18cb5f2b0ae.jpg?1",
             "name": "Teferi's Protection",
             "text": "Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)\nExile Teferi's Protection.",
             "colours": [
@@ -15286,7 +15286,7 @@
         },
         {
             "id": "2d1df6ec-03be-5af2-9fe2-8ac9b3168e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ac8a0-9f1a-4ece-a1b3-b175bb1e8486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ac8a0-9f1a-4ece-a1b3-b175bb1e8486.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, put it into your hand, then shuffle. Activate only if an opponent controls more lands than you.",
             "colours": [
@@ -15324,7 +15324,7 @@
         },
         {
             "id": "3a11e7bd-85a0-5f2d-a9e2-422c99ac05b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebda0fb2-ba10-46e0-ab9d-5a2736553b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebda0fb2-ba10-46e0-ab9d-5a2736553b5d.jpg?1",
             "name": "As Foretold",
             "text": "At the beginning of your upkeep, put a time counter on As Foretold.\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast with mana value X or less, where X is the number of time counters on As Foretold.",
             "colours": [
@@ -15357,7 +15357,7 @@
         },
         {
             "id": "bf3e52bb-4017-5760-8db6-838ee858421d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fddeced-9d04-4b4c-bf3f-e9add96f4f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fddeced-9d04-4b4c-bf3f-e9add96f4f5a.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -15393,7 +15393,7 @@
         },
         {
             "id": "6514ab17-e04a-555c-aaab-9fb79c1ff5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc1a7bc-03fe-43ae-97b2-f0a63bae7c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc1a7bc-03fe-43ae-97b2-f0a63bae7c74.jpg?1",
             "name": "Disciple of the Ring",
             "text": "{1}, Exile an instant or sorcery card from your graveyard: Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Disciple of the Ring gets +1/+1 until end of turn.\n\u2022 Tap target creature.\n\u2022 Untap target creature.",
             "colours": [
@@ -15429,7 +15429,7 @@
         },
         {
             "id": "3ccbf5e8-fc80-5256-956b-6da4542397ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d840284-ce56-4e4f-822f-8b237a261d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d840284-ce56-4e4f-822f-8b237a261d1e.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -15463,7 +15463,7 @@
         },
         {
             "id": "541a2ae4-d3a0-5d30-8dce-9e8c17c3dc64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a69886-8fc7-4f0e-b43e-afa4fc1a0ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a69886-8fc7-4f0e-b43e-afa4fc1a0ec5.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle.",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "46d6c1ec-09d5-598a-b2ff-dc0a3b8d72d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b178b9-c71b-4f4b-ac0d-ae2a16a19410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b178b9-c71b-4f4b-ac0d-ae2a16a19410.jpg?1",
             "name": "Kederekt Leviathan",
             "text": "When Kederekt Leviathan enters the battlefield, return all other nonland permanents to their owners' hands.\nUnearth {6}{U} ({6}{U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -15532,7 +15532,7 @@
         },
         {
             "id": "2d80ee0b-285b-5a76-88b4-e80660c58c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc7d280-31be-48b8-aa1e-8de676ca01ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc7d280-31be-48b8-aa1e-8de676ca01ba.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value.",
             "colours": [
@@ -15566,7 +15566,7 @@
         },
         {
             "id": "57b7d10a-f859-587a-8563-3bf5832354bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eac20be-9c39-4808-a8bc-d89fe7991dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eac20be-9c39-4808-a8bc-d89fe7991dd7.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -15599,7 +15599,7 @@
         },
         {
             "id": "3b3e5976-cd07-5f58-a3f5-082002336e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aaaffa-4518-466b-9157-7cd41ac28fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aaaffa-4518-466b-9157-7cd41ac28fcf.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "dcac458a-9e3c-5856-9584-f94777a60449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68409196-abd1-4ac5-87d0-72cb1e4a68fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68409196-abd1-4ac5-87d0-72cb1e4a68fd.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -15675,7 +15675,7 @@
         },
         {
             "id": "e58c9de1-7a3e-5cda-9450-f3cba35de613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0b3575-c7bd-411d-9aa4-3a986b7876a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0b3575-c7bd-411d-9aa4-3a986b7876a9.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
             "colours": [
@@ -15711,7 +15711,7 @@
         },
         {
             "id": "f19a8eab-60fa-5ff2-88e2-35c9fbbdfde0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c7ad21-2f01-4f9c-8631-7d7e17169ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c7ad21-2f01-4f9c-8631-7d7e17169ce4.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -15745,7 +15745,7 @@
         },
         {
             "id": "d67721f8-6719-54d0-ade6-70131c927ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6e96a0-5c2d-44f4-9191-48a6bd27536e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6e96a0-5c2d-44f4-9191-48a6bd27536e.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -15780,7 +15780,7 @@
         },
         {
             "id": "0ee631d7-2b00-56c9-ab26-87394e91cdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef9e68-0d77-4b56-b03c-b520f4af4c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef9e68-0d77-4b56-b03c-b520f4af4c01.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -15814,7 +15814,7 @@
         },
         {
             "id": "f93cadb6-5cd4-5b3b-a374-c44c57cd1c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50269303-0bd9-474e-bd16-e0d13a5cbb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50269303-0bd9-474e-bd16-e0d13a5cbb74.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -15853,7 +15853,7 @@
         },
         {
             "id": "de1692f6-ee16-51c5-b275-dfa2cb878753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870c962b-2c0d-4b17-b951-1a73f17c65f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870c962b-2c0d-4b17-b951-1a73f17c65f7.jpg?1",
             "name": "Necrotic Ooze",
             "text": "As long as Necrotic Ooze is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
             "colours": [
@@ -15888,7 +15888,7 @@
         },
         {
             "id": "33172601-a444-5d49-814c-f997a51755e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971631cc-f2e1-4eaf-8c23-71707489bdfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971631cc-f2e1-4eaf-8c23-71707489bdfc.jpg?1",
             "name": "Ob Nixilis, Unshackled",
             "text": "Flying, trample\nWhenever an opponent searches their library, that player sacrifices a creature and loses 10 life.\nWhenever another creature dies, put a +1/+1 counter on Ob Nixilis, Unshackled.",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "8a5b964f-b146-5894-8ef5-8c3a32191392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961ec8de-1029-489c-a8a3-283b5f2bf77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961ec8de-1029-489c-a8a3-283b5f2bf77c.jpg?1",
             "name": "Oona's Prowler",
             "text": "Flying\nDiscard a card: Oona's Prowler gets -2/-0 until end of turn. Any player may activate this ability.",
             "colours": [
@@ -15961,7 +15961,7 @@
         },
         {
             "id": "05491552-acdc-5d47-90dd-c5c85ce3a643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67fec89d-a66b-460f-b8dd-96e8c97d8d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67fec89d-a66b-460f-b8dd-96e8c97d8d50.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "dd3ecd49-b135-5288-a845-cf7c9e93bf0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c810eb-1402-428b-850a-72d81f880d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c810eb-1402-428b-850a-72d81f880d8f.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -16033,7 +16033,7 @@
         },
         {
             "id": "cc206399-12a6-5c5c-be68-c7b550b6ea19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355dcac7-120b-4c52-b077-bf36c41c579d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355dcac7-120b-4c52-b077-bf36c41c579d.jpg?1",
             "name": "Abbot of Keral Keep",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Abbot of Keral Keep enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -16069,7 +16069,7 @@
         },
         {
             "id": "b27447f4-6fe2-58c2-8ce4-5b03b8e4965a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9136885-785f-4b71-a834-d0eb1d2a042a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9136885-785f-4b71-a834-d0eb1d2a042a.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -16109,7 +16109,7 @@
         },
         {
             "id": "83074ae3-ef6d-59d8-9b0e-d8139d1377a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1702e178-f67c-4fe8-9dc9-99247f5b9f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1702e178-f67c-4fe8-9dc9-99247f5b9f96.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "e2cdbfd9-096f-5fdc-8418-ef3bafe2034d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d606c86-ea7a-49c8-9afb-778265063113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d606c86-ea7a-49c8-9afb-778265063113.jpg?1",
             "name": "Backdraft Hellkite",
             "text": "Flying\nWhenever Backdraft Hellkite attacks, each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
             "colours": [
@@ -16178,7 +16178,7 @@
         },
         {
             "id": "09ac00a3-bf04-555e-afa3-0d25c2e56112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61828058-6ad2-4788-adfd-a898e25974a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61828058-6ad2-4788-adfd-a898e25974a3.jpg?1",
             "name": "Bedlam Reveler",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -16214,7 +16214,7 @@
         },
         {
             "id": "b16456b6-9571-50de-bcb1-78b382b4fab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eebe1a2-5723-4c61-bdb8-4167c244bf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eebe1a2-5723-4c61-bdb8-4167c244bf6a.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -16248,7 +16248,7 @@
         },
         {
             "id": "3db882c7-a3ab-53b7-9e00-652609755b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eea863e-ebc0-4c8e-b464-80b7dbabe30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eea863e-ebc0-4c8e-b464-80b7dbabe30b.jpg?1",
             "name": "Dockside Extortionist",
             "text": "When Dockside Extortionist enters the battlefield, create X Treasure tokens, where X is the number of artifacts and enchantments your opponents control.",
             "colours": [
@@ -16285,7 +16285,7 @@
         },
         {
             "id": "075ae136-f694-5b73-976f-db1fa3e21405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc93bbd-db0d-47d2-a079-186a78224136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc93bbd-db0d-47d2-a079-186a78224136.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate only if Greater Gargadon is suspended.",
             "colours": [
@@ -16320,7 +16320,7 @@
         },
         {
             "id": "11fc95b1-f4aa-5afe-ae7d-3bc918e49b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab0dc75-e883-4428-b65a-bbbc582b3c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab0dc75-e883-4428-b65a-bbbc582b3c97.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -16357,7 +16357,7 @@
         },
         {
             "id": "aefa405d-c42a-5944-aefe-feac51ff9c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af570ca5-4123-4043-a2fc-8b3a7bdfdf38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af570ca5-4123-4043-a2fc-8b3a7bdfdf38.jpg?1",
             "name": "Twinflame",
             "text": "Strive \u2014 This spell costs {2}{R} more to cast for each target beyond the first.\nChoose any number of target creatures you control. For each of them, create a token that's a copy of that creature, except it has haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -16390,7 +16390,7 @@
         },
         {
             "id": "4459cfd5-d632-5298-8452-1dd22b5b6540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2af40-f20b-4f78-8ef5-ed33e6f0b835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2af40-f20b-4f78-8ef5-ed33e6f0b835.jpg?1",
             "name": "Warrior's Oath",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -16423,7 +16423,7 @@
         },
         {
             "id": "fab78aec-1c4b-525c-a166-bcfec63fc359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51661771-f654-418a-8ef9-11b651fce97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51661771-f654-418a-8ef9-11b651fce97c.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "This spell can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -16460,7 +16460,7 @@
         },
         {
             "id": "2ac6ca11-7b22-5b34-af27-81ec8947fa01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acde10-c524-428e-b406-23d6644295d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acde10-c524-428e-b406-23d6644295d5.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -16497,7 +16497,7 @@
         },
         {
             "id": "fb66c0b4-b14a-55a9-86ee-88225d3c7e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e99da13-fecb-4468-8786-146be83052c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e99da13-fecb-4468-8786-146be83052c0.jpg?1",
             "name": "Concordant Crossroads",
             "text": "All creatures have haste.",
             "colours": [
@@ -16533,7 +16533,7 @@
         },
         {
             "id": "cb276905-3228-50d7-97ff-3ae871fcc596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df9df79-981f-4b45-afd0-00d2e97c958b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df9df79-981f-4b45-afd0-00d2e97c958b.jpg?1",
             "name": "Food Chain",
             "text": "Exile a creature you control: Add X mana of any one color, where X is 1 plus the exiled creature's mana value. Spend this mana only to cast creature spells.",
             "colours": [
@@ -16566,7 +16566,7 @@
         },
         {
             "id": "30da076a-8487-5a2b-899a-bb126c88af08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586fdc7a-add9-4ed6-88f6-188061647c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586fdc7a-add9-4ed6-88f6-188061647c31.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with mana value X or less, put it onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -16599,7 +16599,7 @@
         },
         {
             "id": "fac07cac-d394-5de6-b433-35f6c56d1d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a4076-d5cf-494f-bf78-cbe8a689681e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a4076-d5cf-494f-bf78-cbe8a689681e.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -16633,7 +16633,7 @@
         },
         {
             "id": "1fdd7f64-cb77-59e3-97f8-363e8a2a3c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a70b17-281a-4f36-ba5e-c2f0d02af848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a70b17-281a-4f36-ba5e-c2f0d02af848.jpg?1",
             "name": "Impervious Greatwurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
             "colours": [
@@ -16668,7 +16668,7 @@
         },
         {
             "id": "bbcb921f-d3a9-5601-a955-cb7a687573cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fdbc1-4180-493c-8e99-5bee56647080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fdbc1-4180-493c-8e99-5bee56647080.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -16705,7 +16705,7 @@
         },
         {
             "id": "13cfd2af-2eb6-59f5-8eda-c6ab26840812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235415e7-c900-418c-8848-c70db24e03fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235415e7-c900-418c-8848-c70db24e03fd.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -16743,7 +16743,7 @@
         },
         {
             "id": "2c984d9b-c6dd-5383-b70e-49154205cf04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbd6337-784c-4400-ac42-32150bd7fcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbd6337-784c-4400-ac42-32150bd7fcc6.jpg?1",
             "name": "Splinterfright",
             "text": "Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, mill two cards.",
             "colours": [
@@ -16778,7 +16778,7 @@
         },
         {
             "id": "166a9f6c-7e93-54ce-b393-32dc9fd8ac16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df01c9a-5d2c-4391-99a3-f10e404b7133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df01c9a-5d2c-4391-99a3-f10e404b7133.jpg?1",
             "name": "Abzan Ascendancy",
             "text": "When Abzan Ascendancy enters the battlefield, put a +1/+1 counter on each creature you control.\nWhenever a nontoken creature you control dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -16815,7 +16815,7 @@
         },
         {
             "id": "2dea8d12-124b-557f-b170-d4e6ec2a0384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6a8db-d855-47c4-867f-349a3260010b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6a8db-d855-47c4-867f-349a3260010b.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "+1: Draw a card, then put a card from your hand on top of your library.\n\u22121: Exile another target permanent you own, then return it to the battlefield under your control.\n\u22126: Choose left or right. Each player gains control of all nonland permanents other than Aminatou, the Fateshifter controlled by the next player in the chosen direction.\nAminatou, the Fateshifter can be your commander.",
             "colours": [
@@ -16856,7 +16856,7 @@
         },
         {
             "id": "ad3e0cf2-4dbe-5205-b5f6-bd36f01d6968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7b04-cfab-44d9-929a-3c106b29471a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7b04-cfab-44d9-929a-3c106b29471a.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -16891,7 +16891,7 @@
         },
         {
             "id": "39b254ab-6bad-5da2-b5c3-228959111547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924e9db3-3f7b-4e07-b523-5ec236f99681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924e9db3-3f7b-4e07-b523-5ec236f99681.jpg?1",
             "name": "Animar, Soul of Elements",
             "text": "Protection from white and from black\nWhenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.\nCreature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.",
             "colours": [
@@ -16932,7 +16932,7 @@
         },
         {
             "id": "a1188f89-4fa6-592b-9179-6099ef9c9d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffd3512-2328-41c7-9c37-7eeda8fa127f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffd3512-2328-41c7-9c37-7eeda8fa127f.jpg?1",
             "name": "Arjun, the Shifting Flame",
             "text": "Flying\nWhenever you cast a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "ae03bbc8-8c9e-550a-ad99-f2739fc97ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f961e5d-2fd6-4d13-90fa-b8da36ab3785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f961e5d-2fd6-4d13-90fa-b8da36ab3785.jpg?1",
             "name": "Ashen Rider",
             "text": "Flying\nWhen Ashen Rider enters the battlefield or dies, exile target permanent.",
             "colours": [
@@ -17009,7 +17009,7 @@
         },
         {
             "id": "bbdc21d3-0a62-58f0-9958-09c9fd6bc612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235b41c7-1e22-42e8-9ea1-a3610576dc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235b41c7-1e22-42e8-9ea1-a3610576dc3a.jpg?1",
             "name": "Ashenmoor Liege",
             "text": "Other black creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\nWhenever Ashenmoor Liege becomes the target of a spell or ability an opponent controls, that player loses 4 life.",
             "colours": [
@@ -17047,7 +17047,7 @@
         },
         {
             "id": "ec1c0bd6-635c-5d5c-911d-eab33d2f103f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885c728-67a9-4f8c-943d-1dca22b9d8f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885c728-67a9-4f8c-943d-1dca22b9d8f9.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -17083,7 +17083,7 @@
         },
         {
             "id": "7748d310-ff93-5929-a040-c9d0965e0096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ff7b-04c7-415a-835b-ae9886f172df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ff7b-04c7-415a-835b-ae9886f172df.jpg?1",
             "name": "Atarka's Command",
             "text": "Choose two \u2014\n\u2022 Your opponents can't gain life this turn.\n\u2022 Atarka's Command deals 3 damage to each opponent.\n\u2022 You may put a land card from your hand onto the battlefield.\n\u2022 Creatures you control get +1/+1 and gain reach until end of turn.",
             "colours": [
@@ -17118,7 +17118,7 @@
         },
         {
             "id": "8023c394-3f9d-5bb7-97e3-f7cf234b7348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5ac70-cc49-4520-8076-3df237fe7cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5ac70-cc49-4520-8076-3df237fe7cd8.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "{2}, {T}: Create a 0/1 green Egg creature token with defender.\nWhenever an Egg you control dies, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -17160,7 +17160,7 @@
         },
         {
             "id": "cff5c1bf-758b-5f4d-9c1d-12e46b1f02be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd984e2c-7145-4300-8358-ac72e2d16e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd984e2c-7145-4300-8358-ac72e2d16e75.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia, the Warleader attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -17199,7 +17199,7 @@
         },
         {
             "id": "d63b0cf5-ecb2-52ad-8c58-1b36dacbf3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a8e3de-f953-4ce5-9864-03cfa9e902b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a8e3de-f953-4ce5-9864-03cfa9e902b0.jpg?1",
             "name": "Balefire Liege",
             "text": "Other red creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nWhenever you cast a red spell, Balefire Liege deals 3 damage to target player or planeswalker.\nWhenever you cast a white spell, you gain 3 life.",
             "colours": [
@@ -17237,7 +17237,7 @@
         },
         {
             "id": "75063531-5110-5b7a-a2ad-9b190db52f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8da744-99ef-4f67-82f6-c84a594a4a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8da744-99ef-4f67-82f6-c84a594a4a5f.jpg?1",
             "name": "Boartusk Liege",
             "text": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
             "colours": [
@@ -17275,7 +17275,7 @@
         },
         {
             "id": "e4f9d90c-a6eb-51f4-9930-06520951164e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a1e2a-37db-4575-ad63-3de7e664ab33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a1e2a-37db-4575-ad63-3de7e664ab33.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -17311,7 +17311,7 @@
         },
         {
             "id": "4adbb05b-913a-5113-995b-561245adab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee37f07d-e420-431e-98be-4a68e0416a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee37f07d-e420-431e-98be-4a68e0416a1d.jpg?1",
             "name": "Child of Alara",
             "text": "Trample\nWhen Child of Alara dies, destroy all nonland permanents. They can't be regenerated.",
             "colours": [
@@ -17356,7 +17356,7 @@
         },
         {
             "id": "59e9564a-c603-5134-a07e-422eca0ab87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f5a635-1ebc-4345-84ab-5d6964a32778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f5a635-1ebc-4345-84ab-5d6964a32778.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may create a 1/1 black and green Worm creature token.",
             "colours": [
@@ -17393,7 +17393,7 @@
         },
         {
             "id": "036b8e20-524b-5293-8265-254bed81e798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121ea9e6-aebd-4053-9104-339a47a1430a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121ea9e6-aebd-4053-9104-339a47a1430a.jpg?1",
             "name": "Dack's Duplicate",
             "text": "You may have Dack's Duplicate enter the battlefield as a copy of any creature on the battlefield, except it has haste and dethrone. (Whenever it attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)",
             "colours": [
@@ -17430,7 +17430,7 @@
         },
         {
             "id": "597cb97c-154d-5173-a5c7-168fbf0a842a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85973-b1de-4e7b-816b-fcc0f241a884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85973-b1de-4e7b-816b-fcc0f241a884.jpg?1",
             "name": "Dauntless Escort",
             "text": "Sacrifice Dauntless Escort: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -17468,7 +17468,7 @@
         },
         {
             "id": "b419c566-fef7-5f6f-bddf-8d91a40f98b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227c96a-14e1-479b-8e78-6d335394ad10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227c96a-14e1-479b-8e78-6d335394ad10.jpg?1",
             "name": "Deathbringer Liege",
             "text": "Other white creatures you control get +1/+1.\nOther black creatures you control get +1/+1.\nWhenever you cast a white spell, you may tap target creature.\nWhenever you cast a black spell, you may destroy target creature if it's tapped.",
             "colours": [
@@ -17505,7 +17505,7 @@
         },
         {
             "id": "b907a771-c0ca-5e00-97b5-dd88a4b85d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e221061-7317-4cac-a909-610533c06b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e221061-7317-4cac-a909-610533c06b68.jpg?1",
             "name": "Doran, the Siege Tower",
             "text": "Each creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -17547,7 +17547,7 @@
         },
         {
             "id": "64b3d3c5-1bf5-5b40-a585-4398fb1b4074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22562492-f77e-4505-81cd-84e473822cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22562492-f77e-4505-81cd-84e473822cdb.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "This spell can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -17588,7 +17588,7 @@
         },
         {
             "id": "48999ab4-8e2a-5706-8fb9-20e2ae27d77e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7633a9c0-ab4b-4955-888c-3581de297830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7633a9c0-ab4b-4955-888c-3581de297830.jpg?1",
             "name": "Dragonlord Silumgar",
             "text": "Flying, deathtouch\nWhen Dragonlord Silumgar enters the battlefield, gain control of target creature or planeswalker for as long as you control Dragonlord Silumgar.",
             "colours": [
@@ -17628,7 +17628,7 @@
         },
         {
             "id": "5d6b4182-f4ed-5493-a7ca-3879030db617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43fffd6-51a1-4a9c-b4f1-86354382aa63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43fffd6-51a1-4a9c-b4f1-86354382aa63.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying, double strike, lifelink\nWhenever you gain life, draw a card.",
             "colours": [
@@ -17665,7 +17665,7 @@
         },
         {
             "id": "bfcf0a50-e2ae-5a22-ad6d-6a290b820a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d0d2a-4984-47f9-b791-4055c8298ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d0d2a-4984-47f9-b791-4055c8298ac1.jpg?1",
             "name": "Dromoka's Command",
             "text": "Choose two \u2014\n\u2022 Prevent all damage target instant or sorcery spell would deal this turn.\n\u2022 Target player sacrifices an enchantment.\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -17700,7 +17700,7 @@
         },
         {
             "id": "54030e70-d578-53a0-9c35-ff2f46b0e476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f80199-16f9-4190-af96-f07ac9a22363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f80199-16f9-4190-af96-f07ac9a22363.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -17741,7 +17741,7 @@
         },
         {
             "id": "a9eb10f2-947f-5327-b715-e664a9f1d8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1b606-cda9-4394-85af-d6e513699b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1b606-cda9-4394-85af-d6e513699b91.jpg?1",
             "name": "Elsha of the Infinite",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nYou may look at the top card of your library any time.\nYou may cast noncreature spells from the top of your library. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -17783,7 +17783,7 @@
         },
         {
             "id": "c8a00807-bb42-594a-9a79-4e7985d8db9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9487b5a-8280-4854-9d3b-3b030e99eb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9487b5a-8280-4854-9d3b-3b030e99eb0c.jpg?1",
             "name": "Empyrial Archangel",
             "text": "Flying\nShroud (This creature can't be the target of spells or abilities.)\nAll damage that would be dealt to you is dealt to Empyrial Archangel instead.",
             "colours": [
@@ -17822,7 +17822,7 @@
         },
         {
             "id": "6502f553-422b-5588-8576-4e2c69ac1f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f766a3-ec88-46ee-bf07-b6997cd0f95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f766a3-ec88-46ee-bf07-b6997cd0f95a.jpg?1",
             "name": "Ezuri, Claw of Progress",
             "text": "Whenever a creature with power 2 or less enters the battlefield under your control, you get an experience counter.\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is the number of experience counters you have.",
             "colours": [
@@ -17863,7 +17863,7 @@
         },
         {
             "id": "d2956b35-e5c9-5352-bd49-f9deaf2fde30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e4b67-8082-43de-9a1c-11e0b1983788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e4b67-8082-43de-9a1c-11e0b1983788.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.",
             "colours": [
@@ -17900,7 +17900,7 @@
         },
         {
             "id": "f5892f2f-6551-5610-9272-2a9abc142e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b761b353-1c72-49f9-8c77-3b47ff5c3c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b761b353-1c72-49f9-8c77-3b47ff5c3c4f.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a Kithkin Spirit with base power and toughness 2/2.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
             "colours": [
@@ -17937,7 +17937,7 @@
         },
         {
             "id": "bc41a9c7-755b-5235-9125-cfbc5c51ee01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f4325-32be-41be-99f3-bd7c27226918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f4325-32be-41be-99f3-bd7c27226918.jpg?1",
             "name": "Firesong and Sunspeaker",
             "text": "Red instant and sorcery spells you control have lifelink.\nWhenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.",
             "colours": [
@@ -17977,7 +17977,7 @@
         },
         {
             "id": "10caf812-a1c9-54cc-8ae4-7c64cf3c77cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4df5e-14b3-42ed-89dd-d87450cc78f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4df5e-14b3-42ed-89dd-d87450cc78f2.jpg?1",
             "name": "Ghave, Guru of Spores",
             "text": "Ghave, Guru of Spores enters the battlefield with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from a creature you control: Create a 1/1 green Saproling creature token.\n{1}, Sacrifice a creature: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -18019,7 +18019,7 @@
         },
         {
             "id": "a4e81dcf-0ea1-5b33-b073-056bbac6a52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3486e0-f64b-4b27-9d9a-3f5968f73454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3486e0-f64b-4b27-9d9a-3f5968f73454.jpg?1",
             "name": "Glen Elendra Liege",
             "text": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
             "colours": [
@@ -18057,7 +18057,7 @@
         },
         {
             "id": "f5241c77-8d09-5c78-8572-de45aca9569e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cd3942-f385-493c-b667-e35af7f60b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cd3942-f385-493c-b667-e35af7f60b83.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player mills ten cards.",
             "colours": [
@@ -18093,7 +18093,7 @@
         },
         {
             "id": "02f406d8-b1d5-5be6-9b90-263bc8414ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ecdb6c-7456-4941-b51f-5600ec337479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ecdb6c-7456-4941-b51f-5600ec337479.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -18134,7 +18134,7 @@
         },
         {
             "id": "89d6aacc-feab-5f23-8957-3d4ddc42df2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ade84c1-80b5-446b-9547-d09d3bf4264a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ade84c1-80b5-446b-9547-d09d3bf4264a.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -18173,7 +18173,7 @@
         },
         {
             "id": "9cf61818-b9c9-5d87-9903-72d7aaed24d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800411e2-3fd0-4f5b-9751-5f5609f904e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800411e2-3fd0-4f5b-9751-5f5609f904e5.jpg?1",
             "name": "Guided Passage",
             "text": "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle.",
             "colours": [
@@ -18210,7 +18210,7 @@
         },
         {
             "id": "116db879-ae86-5c15-9e13-b1fda9a60c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ee7d-dd79-4d77-8873-c44f820ca5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ee7d-dd79-4d77-8873-c44f820ca5b0.jpg?1",
             "name": "Hellkite Overlord",
             "text": "Flying, trample, haste\n{R}: Hellkite Overlord gets +1/+0 until end of turn.\n{B}{G}: Regenerate Hellkite Overlord.",
             "colours": [
@@ -18249,7 +18249,7 @@
         },
         {
             "id": "1e1f7031-0a13-5b09-931e-46e0d2f3130b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f66a7-beb2-483b-a155-eed85f878843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f66a7-beb2-483b-a155-eed85f878843.jpg?1",
             "name": "Hostage Taker",
             "text": "When Hostage Taker enters the battlefield, exile another target creature or artifact until Hostage Taker leaves the battlefield. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -18287,7 +18287,7 @@
         },
         {
             "id": "4d313756-01b5-54f3-8342-fd880bc568a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b004684e-bd98-42fc-b90c-9a13a48dd120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b004684e-bd98-42fc-b90c-9a13a48dd120.jpg?1",
             "name": "Hydroid Krasis",
             "text": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nHydroid Krasis enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -18326,7 +18326,7 @@
         },
         {
             "id": "fa75d027-5cdf-5a50-895e-2a4d7cd5fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb99af-853b-4773-877a-ab5efcff9828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb99af-853b-4773-877a-ab5efcff9828.jpg?1",
             "name": "Intet, the Dreamer",
             "text": "Flying\nWhenever Intet, the Dreamer deals combat damage to a player, you may pay {2}{U}. If you do, exile the top card of your library face down. You may look at that card for as long as it remains exiled. You may play that card without paying its mana cost for as long as Intet remains on the battlefield.",
             "colours": [
@@ -18367,7 +18367,7 @@
         },
         {
             "id": "b18e7855-762c-5545-88b6-af93a23b4120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65868ea1-4e80-4871-a93f-66582690869a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65868ea1-4e80-4871-a93f-66582690869a.jpg?1",
             "name": "Jeskai Ascendancy",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn. Untap those creatures.\nWhenever you cast a noncreature spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -18404,7 +18404,7 @@
         },
         {
             "id": "c7b92ec3-357b-58b2-a101-5270a201bcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06cb72-ccbc-4efe-9457-dd76f503fa34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06cb72-ccbc-4efe-9457-dd76f503fa34.jpg?1",
             "name": "Jodah, Archmage Eternal",
             "text": "Flying\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -18448,7 +18448,7 @@
         },
         {
             "id": "aefae7a1-17bd-5ccb-827c-0d5bb8f940d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c8784d-22b9-485b-8f35-d33664db45b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c8784d-22b9-485b-8f35-d33664db45b5.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -18488,7 +18488,7 @@
         },
         {
             "id": "0bbbca26-562b-5724-88fd-aae0f889a13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576a670d-4efd-498b-8c53-eda6e18868a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576a670d-4efd-498b-8c53-eda6e18868a4.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -18530,7 +18530,7 @@
         },
         {
             "id": "7a9ca742-9b06-549f-b975-fc91971dcb38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298d3b70-f858-4138-97e4-1442a5b6afb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298d3b70-f858-4138-97e4-1442a5b6afb6.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent casts a spell, Kaervek the Merciless deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -18570,7 +18570,7 @@
         },
         {
             "id": "b29d06ea-07cc-5623-b6f4-8d8448d23b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67852fca-37a5-414e-bc1f-5256e46483d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67852fca-37a5-414e-bc1f-5256e46483d1.jpg?1",
             "name": "Kambal, Consul of Allocation",
             "text": "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -18610,7 +18610,7 @@
         },
         {
             "id": "41aa892e-1a1f-5ca3-830e-c502988b5257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee1fba-ad5b-41ca-a29f-ecc8cf1edeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee1fba-ad5b-41ca-a29f-ecc8cf1edeff.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -18652,7 +18652,7 @@
         },
         {
             "id": "8f77344a-a55f-5147-9424-2784877afc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f190f-7e46-4877-a47e-ae1b28e40a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f190f-7e46-4877-a47e-ae1b28e40a42.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to any target.",
             "colours": [
@@ -18688,7 +18688,7 @@
         },
         {
             "id": "119afbfb-8425-5915-8530-3d0cbb9e8720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864f0611-042a-4f71-b92f-ce70c69bc79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864f0611-042a-4f71-b92f-ce70c69bc79f.jpg?1",
             "name": "Lavalanche",
             "text": "Lavalanche deals X damage to target player or planeswalker and each creature that player or that planeswalker's controller controls.",
             "colours": [
@@ -18725,7 +18725,7 @@
         },
         {
             "id": "c5e749f6-ad3e-59d8-890a-78ae253e96cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257cd42e-c808-41b5-9878-e0c4386eb0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257cd42e-c808-41b5-9878-e0c4386eb0c1.jpg?1",
             "name": "Legion's Initiative",
             "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
             "colours": [
@@ -18760,7 +18760,7 @@
         },
         {
             "id": "5e9b2e4b-da3a-5692-83b8-d4def2f7f958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1721464-f9e5-434a-b8e6-9c8157199264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1721464-f9e5-434a-b8e6-9c8157199264.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -18797,7 +18797,7 @@
         },
         {
             "id": "503b9284-2472-5683-9188-0f193e7b7b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f26682-24c8-4990-9ceb-629fdac20036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f26682-24c8-4990-9ceb-629fdac20036.jpg?1",
             "name": "Magister Sphinx",
             "text": "Flying\nWhen Magister Sphinx enters the battlefield, target player's life total becomes 10.",
             "colours": [
@@ -18837,7 +18837,7 @@
         },
         {
             "id": "8f1a847d-eb05-5a3d-85f9-2cb84d23b7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47617780-620d-409a-944c-bc7035826b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47617780-620d-409a-944c-bc7035826b38.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "Dethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nOther creatures you control have dethrone.\nWhenever a creature you control with a +1/+1 counter on it dies, return that card to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -18880,7 +18880,7 @@
         },
         {
             "id": "f07fd5e2-c604-5663-9db9-53fd4f1c4562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dda584b-0cb4-452e-963a-d6e6bac0e402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dda584b-0cb4-452e-963a-d6e6bac0e402.jpg?1",
             "name": "Master Biomancer",
             "text": "Each other creature you control enters the battlefield with a number of additional +1/+1 counters on it equal to Master Biomancer's power and as a Mutant in addition to its other types.",
             "colours": [
@@ -18918,7 +18918,7 @@
         },
         {
             "id": "48166bf7-9683-549e-b854-084e0c33e7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b95dab-4c26-4eb9-ba2c-bec968fdaea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b95dab-4c26-4eb9-ba2c-bec968fdaea9.jpg?1",
             "name": "Master of Cruelties",
             "text": "First strike, deathtouch\nMaster of Cruelties can only attack alone.\nWhenever Master of Cruelties attacks a player and isn't blocked, that player's life total becomes 1. Master of Cruelties assigns no combat damage this combat.",
             "colours": [
@@ -18955,7 +18955,7 @@
         },
         {
             "id": "918f209e-9d65-5484-af4c-c9700c224188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238bb7a7-cf3a-432a-8c40-d745d7e7cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238bb7a7-cf3a-432a-8c40-d745d7e7cf9f.jpg?1",
             "name": "Mathas, Fiend Seeker",
             "text": "Menace\nAt the beginning of your end step, put a bounty counter on target creature an opponent controls. For as long as that creature has a bounty counter on it, it has \"When this creature dies, each opponent draws a card and gains 2 life.\"",
             "colours": [
@@ -18996,7 +18996,7 @@
         },
         {
             "id": "903174cf-1d38-57c1-bf25-3ffb32bcba28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a705820-8a40-4724-9448-d6b219d76c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a705820-8a40-4724-9448-d6b219d76c76.jpg?1",
             "name": "Mayael's Aria",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
             "colours": [
@@ -19033,7 +19033,7 @@
         },
         {
             "id": "21903cfa-038b-5309-8532-e020827b537e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4916b0ed-a0cd-4b32-9505-140f98301ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4916b0ed-a0cd-4b32-9505-140f98301ed5.jpg?1",
             "name": "The Mimeoplasm",
             "text": "As The Mimeoplasm enters the battlefield, you may exile two creature cards from graveyards. If you do, it enters the battlefield as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
             "colours": [
@@ -19075,7 +19075,7 @@
         },
         {
             "id": "8e2338ee-3362-580d-a142-e63c10014267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9395a0-922c-4062-a917-796786000f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9395a0-922c-4062-a917-796786000f2b.jpg?1",
             "name": "Mindwrack Liege",
             "text": "Other blue creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\n{UR}{UR}{UR}{UR}: You may put a blue or red creature card from your hand onto the battlefield.",
             "colours": [
@@ -19112,7 +19112,7 @@
         },
         {
             "id": "efcf0ac3-db08-5b58-8a27-1e6bc5f965cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2dd0e-b321-4f1a-b7d8-30920e134b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2dd0e-b321-4f1a-b7d8-30920e134b62.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -19152,7 +19152,7 @@
         },
         {
             "id": "0b97605d-495c-50eb-8ff2-8f2ac657cfbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a81b1b-92c1-4ee8-affe-6e1c027c7393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a81b1b-92c1-4ee8-affe-6e1c027c7393.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -19195,7 +19195,7 @@
         },
         {
             "id": "6f3644a8-017b-5761-b3a9-51a530551866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcfb7a-2a7c-4ae8-8719-8d1b37d07819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcfb7a-2a7c-4ae8-8719-8d1b37d07819.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -19232,7 +19232,7 @@
         },
         {
             "id": "62278030-0f17-5cad-bdb7-9607a15bc898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b49a2e-02ac-4b50-b283-dd2c782cd0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b49a2e-02ac-4b50-b283-dd2c782cd0d1.jpg?1",
             "name": "Nicol Bolas, God-Pharaoh",
             "text": "+2: Target opponent exiles cards from the top of their library until they exile a nonland card. Until end of turn, you may cast that card without paying its mana cost.\n+1: Each opponent exiles two cards from their hand.\n\u22124: Nicol Bolas, God-Pharaoh deals 7 damage to target opponent, creature an opponent controls, or planeswalker an opponent controls.\n\u221212: Exile each nonland permanent your opponents control.",
             "colours": [
@@ -19273,7 +19273,7 @@
         },
         {
             "id": "97d3a50c-b774-55bb-8ea0-b19f2301ca05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ceea14-c018-456d-83cd-07f4e3bc5817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ceea14-c018-456d-83cd-07f4e3bc5817.jpg?1",
             "name": "Phyrexian Tyranny",
             "text": "Whenever a player draws a card, that player loses 2 life unless they pay {2}.",
             "colours": [
@@ -19310,7 +19310,7 @@
         },
         {
             "id": "4b170fa3-a277-5bcd-a41b-46b4cba0ee06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5656b93-8dcd-4c46-95b4-d5a311d17096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5656b93-8dcd-4c46-95b4-d5a311d17096.jpg?1",
             "name": "Privileged Position",
             "text": "Other permanents you control have hexproof.",
             "colours": [
@@ -19346,7 +19346,7 @@
         },
         {
             "id": "f2055ae6-9a39-54e7-a7ca-14a9298b7a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc296a-6479-42ca-b0a8-c14b3ded1cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc296a-6479-42ca-b0a8-c14b3ded1cec.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -19383,7 +19383,7 @@
         },
         {
             "id": "9234754c-ba5f-527b-ae94-5f5dfef61ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d892-9b9e-450f-84b7-612655af23be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d892-9b9e-450f-84b7-612655af23be.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -19425,7 +19425,7 @@
         },
         {
             "id": "36fffe0a-d02a-59be-862b-86db1d5302c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0579dea8-3963-403c-b89d-204e007ce3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0579dea8-3963-403c-b89d-204e007ce3ed.jpg?1",
             "name": "Roon of the Hidden Realm",
             "text": "Vigilance, trample\n{2}, {T}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -19467,7 +19467,7 @@
         },
         {
             "id": "09e7d56a-6cb1-5798-932d-ae64be678832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a0966f-622c-47d6-a383-f1db19dfb01c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a0966f-622c-47d6-a383-f1db19dfb01c.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each combat if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "cff96abd-04fa-5495-b264-49ae5a9f1f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3600e910-784e-4b69-86dc-801a1b27288c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3600e910-784e-4b69-86dc-801a1b27288c.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -19550,7 +19550,7 @@
         },
         {
             "id": "6ca991f2-3a02-5f42-9fd0-f475fbf84b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ebe9d-27fd-4b5d-acde-d7648063fd0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ebe9d-27fd-4b5d-acde-d7648063fd0c.jpg?1",
             "name": "Shattergang Brothers",
             "text": "{2}{B}, Sacrifice a creature: Each other player sacrifices a creature.\n{2}{R}, Sacrifice an artifact: Each other player sacrifices an artifact.\n{2}{G}, Sacrifice an enchantment: Each other player sacrifices an enchantment.",
             "colours": [
@@ -19592,7 +19592,7 @@
         },
         {
             "id": "ac0432f1-765f-5949-805a-3b736eec5aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c5c9cc-16ae-4274-a52b-9947332ff5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c5c9cc-16ae-4274-a52b-9947332ff5a1.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -19634,7 +19634,7 @@
         },
         {
             "id": "b14243ae-8344-5f7b-b312-51f0bbecf92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3159553d-ab09-4970-8c68-613a9cd56a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3159553d-ab09-4970-8c68-613a9cd56a2d.jpg?1",
             "name": "Skullbriar, the Walking Grave",
             "text": "Haste\nWhenever Skullbriar, the Walking Grave deals combat damage to a player, put a +1/+1 counter on it.\nCounters remain on Skullbriar as it moves to any zone other than a player's hand or library.",
             "colours": [
@@ -19674,7 +19674,7 @@
         },
         {
             "id": "4ea05d00-fdf8-5564-9a41-26e92908c84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24c37e1-8d3f-4a76-8ea4-242d322794ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24c37e1-8d3f-4a76-8ea4-242d322794ec.jpg?1",
             "name": "Supreme Verdict",
             "text": "This spell can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -19710,7 +19710,7 @@
         },
         {
             "id": "6d5baecf-d65e-5816-91d1-3bd0662d0fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2753-385e-493a-9f6d-14aa0f392b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2753-385e-493a-9f6d-14aa0f392b69.jpg?1",
             "name": "Tariel, Reckoner of Souls",
             "text": "Flying, vigilance\n{T}: Choose a creature card at random from target opponent's graveyard. Put that card onto the battlefield under your control.",
             "colours": [
@@ -19751,7 +19751,7 @@
         },
         {
             "id": "979f8c43-e711-5f8c-9d89-9b79c0441092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1994667d-19b7-493b-9961-d823d0c92b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1994667d-19b7-493b-9961-d823d0c92b86.jpg?1",
             "name": "Teneb, the Harvester",
             "text": "Flying\nWhenever Teneb, the Harvester deals combat damage to a player, you may pay {2}{B}. If you do, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -19792,7 +19792,7 @@
         },
         {
             "id": "77b3818b-2517-53da-bae0-d671ac6211b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe277b7-e346-4c18-9fcf-1c8469354fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe277b7-e346-4c18-9fcf-1c8469354fed.jpg?1",
             "name": "Thistledown Liege",
             "text": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
             "colours": [
@@ -19830,7 +19830,7 @@
         },
         {
             "id": "107017dd-f69e-52f7-ac8c-902105f61a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da9c9a-1778-4eea-ad40-2475fe6fabc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da9c9a-1778-4eea-ad40-2475fe6fabc2.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -19866,7 +19866,7 @@
         },
         {
             "id": "f87b9e1c-27ac-50d9-b1c4-3ddcea7f8655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04638352-cb8c-477e-979a-46b4fc69ac98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04638352-cb8c-477e-979a-46b4fc69ac98.jpg?1",
             "name": "Thraximundar",
             "text": "Haste\nWhenever Thraximundar attacks, defending player sacrifices a creature.\nWhenever a player sacrifices a creature, you may put a +1/+1 counter on Thraximundar.",
             "colours": [
@@ -19908,7 +19908,7 @@
         },
         {
             "id": "ae6c1a29-ce51-54c1-b530-47c0b749246b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb8a87-85d9-48ae-b0b3-84b9420ae082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb8a87-85d9-48ae-b0b3-84b9420ae082.jpg?1",
             "name": "Ulasht, the Hate Seed",
             "text": "Ulasht, the Hate Seed enters the battlefield with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one \u2014\n\u2022 Ulasht deals 1 damage to target creature.\n\u2022 Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -19948,7 +19948,7 @@
         },
         {
             "id": "3b8e04d0-9d7e-5ee7-ad53-694023101337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c140c-2ac4-40e8-b02c-a64032303666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c140c-2ac4-40e8-b02c-a64032303666.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "Hexproof\nUril, the Miststalker gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -19989,7 +19989,7 @@
         },
         {
             "id": "699a83aa-6a4b-5ce4-8186-4b66de1794ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b16b28-f628-4d38-b3f8-c9021e322734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b16b28-f628-4d38-b3f8-c9021e322734.jpg?1",
             "name": "Varina, Lich Queen",
             "text": "Whenever you attack with one or more Zombies, draw that many cards, then discard that many cards. You gain that much life.\n{2}, Exile two cards from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -20031,7 +20031,7 @@
         },
         {
             "id": "c814a428-9c00-5b4e-ac6f-e571b8b2e45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8663bcef-df55-4765-b8a6-7afd1e09c32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8663bcef-df55-4765-b8a6-7afd1e09c32d.jpg?1",
             "name": "Villainous Wealth",
             "text": "Target opponent exiles the top X cards of their library. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -20068,7 +20068,7 @@
         },
         {
             "id": "35c13264-d2c6-5b8b-8f5b-4a63e6a0fc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1605dc-7204-4684-ade3-66e727f4deb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1605dc-7204-4684-ade3-66e727f4deb5.jpg?1",
             "name": "Wasitora, Nekoru Queen",
             "text": "Flying, trample\nWhenever Wasitora, Nekoru Queen deals combat damage to a player, that player sacrifices a creature. If the player can't, you create a 3/3 black, red, and green Cat Dragon creature token with flying.",
             "colours": [
@@ -20110,7 +20110,7 @@
         },
         {
             "id": "f73ba1db-743f-5438-80b1-c77d43e2b37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed350949-34b3-485d-99bb-d084006b4dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed350949-34b3-485d-99bb-d084006b4dcd.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -20148,7 +20148,7 @@
         },
         {
             "id": "5cdc6abc-175b-55ab-9b4a-e70ec7449b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4282ddd-3e5b-4d4c-b1b7-a48401a3521f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4282ddd-3e5b-4d4c-b1b7-a48401a3521f.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -20189,7 +20189,7 @@
         },
         {
             "id": "b1f2ab94-5d64-556d-af8a-61251f2543f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb1b3d5-6bd8-42f4-ba36-d345fe4e78ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb1b3d5-6bd8-42f4-ba36-d345fe4e78ab.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -20231,7 +20231,7 @@
         },
         {
             "id": "29e82994-8a43-5d5b-8277-743cc9d66a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f4f24-f62b-4f52-8168-62b5b9971162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f4f24-f62b-4f52-8168-62b5b9971162.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with mana value equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -20261,7 +20261,7 @@
         },
         {
             "id": "d9981ce3-76d7-564b-b626-a0382dd5b342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5205e059-97c5-4cad-ac36-22db3a050784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5205e059-97c5-4cad-ac36-22db3a050784.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -20293,7 +20293,7 @@
         },
         {
             "id": "c5ac491d-1c5a-52fb-ab99-4514906a1fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428dfa7-da5f-4aaa-9e7b-0e8b236bd15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428dfa7-da5f-4aaa-9e7b-0e8b236bd15b.jpg?1",
             "name": "Conqueror's Flail",
             "text": "Equipped creature gets +1/+1 for each color among permanents you control.\nAs long as Conqueror's Flail is attached to a creature, your opponents can't cast spells during your turn.\nEquip {2}",
             "colours": [],
@@ -20324,7 +20324,7 @@
         },
         {
             "id": "98615fc0-1101-58bc-a965-acce17421f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ca51fb-46f9-42c1-8e2f-442c9425adfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ca51fb-46f9-42c1-8e2f-442c9425adfb.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -20354,7 +20354,7 @@
         },
         {
             "id": "d37afbc9-53d8-567a-85c7-0acb76272318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6251c38d-ad22-4372-b086-5df52cdb153e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6251c38d-ad22-4372-b086-5df52cdb153e.jpg?1",
             "name": "Darksteel Plate",
             "text": "Indestructible\nEquipped creature has indestructible.\nEquip {2}",
             "colours": [],
@@ -20385,7 +20385,7 @@
         },
         {
             "id": "91ed750f-7471-5c90-aade-698d967c043a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e44bec-fce8-42e0-9734-8e6dea8b7e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e44bec-fce8-42e0-9734-8e6dea8b7e04.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -20415,7 +20415,7 @@
         },
         {
             "id": "9c9eb7ef-5c09-5ebe-bffa-6c80c293f184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f60690-7625-4c4a-8354-69a30f5fc1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f60690-7625-4c4a-8354-69a30f5fc1a3.jpg?1",
             "name": "Nim Deathmantle",
             "text": "Equipped creature gets +2/+2, has intimidate, and is a black Zombie. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever a nontoken creature is put into your graveyard from the battlefield, you may pay {4}. If you do, return that card to the battlefield and attach Nim Deathmantle to it.\nEquip {4}",
             "colours": [],
@@ -20446,7 +20446,7 @@
         },
         {
             "id": "0a33c097-4e38-574b-876c-5cabbebc1c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d68b906-8d37-4952-82e7-faba4effcf22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d68b906-8d37-4952-82e7-faba4effcf22.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -20476,7 +20476,7 @@
         },
         {
             "id": "3d441e97-6b78-5345-b635-84e28fda8303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49141090-f3b0-4748-a7ee-800093fcf29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49141090-f3b0-4748-a7ee-800093fcf29d.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -20506,7 +20506,7 @@
         },
         {
             "id": "dcd510d1-6d97-5314-8f9a-d3199126d251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45560d90-fe3a-443e-91f2-2b55ce0255c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45560d90-fe3a-443e-91f2-2b55ce0255c6.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -20536,7 +20536,7 @@
         },
         {
             "id": "24edfa10-056a-54f8-a06c-69ade91f50d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847ffd9-7986-4402-b4bc-ecf3dfd2a2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847ffd9-7986-4402-b4bc-ecf3dfd2a2f2.jpg?1",
             "name": "Planar Bridge",
             "text": "{8}, {T}: Search your library for a permanent card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -20567,7 +20567,7 @@
         },
         {
             "id": "157e7c91-47f3-507f-955e-49a86483c89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef87d80-5a31-4233-a6f2-7c26a9388107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef87d80-5a31-4233-a6f2-7c26a9388107.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -20597,7 +20597,7 @@
         },
         {
             "id": "b086bf93-01c5-5bc2-8ea3-79eb8efa9641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e79372-5ad3-4dea-9dcc-cf20f3b267c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e79372-5ad3-4dea-9dcc-cf20f3b267c7.jpg?1",
             "name": "Thrumming Stone",
             "text": "Spells you cast have ripple 4. (Whenever you cast a spell, you may reveal the top four cards of your library. You may cast spells with the same name as that spell from among the revealed cards without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [],
@@ -20628,7 +20628,7 @@
         },
         {
             "id": "b91b37f6-7ae2-56e7-93bc-c600dd711a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60306d4-3705-4bcc-84da-4787a65737b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60306d4-3705-4bcc-84da-4787a65737b7.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may cast spells as though they had flash.",
             "colours": [],
@@ -20658,7 +20658,7 @@
         },
         {
             "id": "f59890f1-d5da-5d4d-99ed-7fd1a65de3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f31ea61-cc66-4dc2-a38c-04e3f8418cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f31ea61-cc66-4dc2-a38c-04e3f8418cb8.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -20688,7 +20688,7 @@
         },
         {
             "id": "9cab59d9-723d-573a-99a7-cf3b05ec1907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35a4a4d-4b78-4c61-91bd-80c09c82895d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35a4a4d-4b78-4c61-91bd-80c09c82895d.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -20718,7 +20718,7 @@
         },
         {
             "id": "57bfa77a-a7d6-5069-98a3-bfb52ddca33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3e78b-4ca4-444a-9661-c0df4e36226e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3e78b-4ca4-444a-9661-c0df4e36226e.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color.\nWhenever you tap Forbidden Orchard for mana, target opponent creates a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -20748,7 +20748,7 @@
         },
         {
             "id": "65627b0c-6ee7-5aba-aa82-a2121a0757a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02221d76-922a-4ad4-8d40-c279b5a446b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02221d76-922a-4ad4-8d40-c279b5a446b9.jpg?1",
             "name": "Pillar of the Paruns",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a multicolored spell.",
             "colours": [],
@@ -20777,7 +20777,7 @@
         },
         {
             "id": "001e28fe-5bc1-57ef-9814-adc1195a297b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e2a410-fca6-4d3d-9b6b-519a968e5e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e2a410-fca6-4d3d-9b6b-519a968e5e86.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -20816,7 +20816,7 @@
         },
         {
             "id": "4aee00b4-2e77-597c-b90b-ffdba349b303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b1203f-1f4c-4d02-a79f-1f6486904ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b1203f-1f4c-4d02-a79f-1f6486904ea6.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -20857,7 +20857,7 @@
         },
         {
             "id": "a9e37c90-1112-53ea-a442-27897a256f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f6aed-e18e-4c8e-8e58-b1ed43ad54e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f6aed-e18e-4c8e-8e58-b1ed43ad54e7.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -20892,7 +20892,7 @@
         },
         {
             "id": "6d4e18c2-1652-5291-99db-e0c592132359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2f9d5b-8a88-443d-8046-2b2a77fd1d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2f9d5b-8a88-443d-8046-2b2a77fd1d64.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -20927,7 +20927,7 @@
         },
         {
             "id": "9c11a355-fd21-5a81-a8a4-0ccb2f34aabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00afe028-fef9-49dd-a062-085fafa8586d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00afe028-fef9-49dd-a062-085fafa8586d.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -20962,7 +20962,7 @@
         },
         {
             "id": "618274eb-37b7-5009-bc6a-5c60e8c4f233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1b6cf0-24b0-43b0-ab95-8bf73710c8ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1b6cf0-24b0-43b0-ab95-8bf73710c8ee.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, put it into your hand, then shuffle. Activate only if an opponent controls more lands than you.",
             "colours": [
@@ -21000,7 +21000,7 @@
         },
         {
             "id": "99a96354-f726-5420-9325-c665661bbfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ed050-ed2a-4043-b12b-5d29fb506eb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ed050-ed2a-4043-b12b-5d29fb506eb3.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -21036,7 +21036,7 @@
         },
         {
             "id": "7cba0b1c-2752-57f2-bdee-e0f45123aa54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b1462-dd9c-42af-8ba0-e840f8a651e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b1462-dd9c-42af-8ba0-e840f8a651e2.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -21068,7 +21068,7 @@
         },
         {
             "id": "833fee32-d935-51e4-b378-8fa466620a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c672ee51-0e77-463f-8586-191b413c44dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c672ee51-0e77-463f-8586-191b413c44dd.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -21099,7 +21099,7 @@
         },
         {
             "id": "4ad6b1d3-c030-52bd-a568-6134cd2ea3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31434b32-b741-4a4d-813e-7006fe7ffa3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31434b32-b741-4a4d-813e-7006fe7ffa3c.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -21134,7 +21134,7 @@
         },
         {
             "id": "03462caa-c066-5f44-8af9-5932944e808b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12feaabf-7b3e-4cef-8d45-1b9bbe2baaf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12feaabf-7b3e-4cef-8d45-1b9bbe2baaf6.jpg?1",
             "name": "Aven Initiate",
             "text": "",
             "colours": [
@@ -21171,7 +21171,7 @@
         },
         {
             "id": "06558f31-bce8-5504-9058-d836968bab2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73ee667-09a1-40b9-85e8-902d9c06adcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73ee667-09a1-40b9-85e8-902d9c06adcf.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -21206,7 +21206,7 @@
         },
         {
             "id": "e4440487-4f32-5ed9-b485-0e34a2258f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9d16af-2b50-426f-98d2-992d97a4a150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9d16af-2b50-426f-98d2-992d97a4a150.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -21241,7 +21241,7 @@
         },
         {
             "id": "d9361551-ef54-562f-b97a-0d2500ac5588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17763402-d0bc-44d8-8655-ceca164cae9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17763402-d0bc-44d8-8655-ceca164cae9d.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -21276,7 +21276,7 @@
         },
         {
             "id": "5bb80cf6-edae-5967-8e02-a2692efe9268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebb3b03-943e-4b5a-be04-f59316b81333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebb3b03-943e-4b5a-be04-f59316b81333.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -21311,7 +21311,7 @@
         },
         {
             "id": "5e95d749-81f3-5294-a405-b4b65a32eb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287a7057-ce44-4082-a3da-8c09b8a88fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287a7057-ce44-4082-a3da-8c09b8a88fba.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -21346,7 +21346,7 @@
         },
         {
             "id": "7c0e0855-217e-56a4-9a75-5409a158aec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a4bb3-7f76-4f8a-8af6-439b09b3ee0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a4bb3-7f76-4f8a-8af6-439b09b3ee0f.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -21381,7 +21381,7 @@
         },
         {
             "id": "367b2213-a86a-5fdb-90f7-8c93a74cb3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55998d0d-b169-4e1b-a9e2-a2ea75b4bbf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55998d0d-b169-4e1b-a9e2-a2ea75b4bbf0.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -21417,7 +21417,7 @@
         },
         {
             "id": "64241dfe-167b-5c4a-ba03-c0bb9a4996b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31603503-fd3a-4c57-90ad-4175bb2c8150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31603503-fd3a-4c57-90ad-4175bb2c8150.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -21452,7 +21452,7 @@
         },
         {
             "id": "27b9adf3-cfb3-5551-adad-757e7f00201c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462bb611-5a02-441c-ae8a-911b75436864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462bb611-5a02-441c-ae8a-911b75436864.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -21487,7 +21487,7 @@
         },
         {
             "id": "18eef80e-48c6-500e-98cf-3ed4c3601b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169a2e1-ed39-41cf-9a36-3c2b59499819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169a2e1-ed39-41cf-9a36-3c2b59499819.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -21522,7 +21522,7 @@
         },
         {
             "id": "c8599875-0389-5953-be39-61a5a7b5bb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a911fad-7af3-4bc4-bafc-cac2d5f18f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a911fad-7af3-4bc4-bafc-cac2d5f18f22.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -21557,7 +21557,7 @@
         },
         {
             "id": "9db7edf6-2139-5df7-8e94-5906ee38136d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b545a43-8837-49a1-83d8-7c548d5237d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b545a43-8837-49a1-83d8-7c548d5237d2.jpg?1",
             "name": "Egg",
             "text": "",
             "colours": [
@@ -21592,7 +21592,7 @@
         },
         {
             "id": "b04a8173-24b6-577f-a150-cd7e51791c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c9bcf4-4e8c-467c-8c72-4a9cd0556e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c9bcf4-4e8c-467c-8c72-4a9cd0556e93.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -21627,7 +21627,7 @@
         },
         {
             "id": "23cf1fd4-4cb8-52d1-89ca-401b60ff3ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74900ca-7f0d-460c-86b0-b515c8b44e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74900ca-7f0d-460c-86b0-b515c8b44e67.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -21662,7 +21662,7 @@
         },
         {
             "id": "77468071-de65-572f-80bc-88e11a77392f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e883aa-5f73-4c45-9253-1350c24222e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e883aa-5f73-4c45-9253-1350c24222e4.jpg?1",
             "name": "Cat Dragon",
             "text": "",
             "colours": [
@@ -21702,7 +21702,7 @@
         },
         {
             "id": "d1b963a7-1ccd-5e24-91d9-fe750f54a7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b71ab8-7f94-4cd9-9a15-0c2291e17b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b71ab8-7f94-4cd9-9a15-0c2291e17b47.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -21739,7 +21739,7 @@
         },
         {
             "id": "5450889c-b58f-5974-955c-b5f0d88d1338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83842dfb-e5ea-41dc-91b1-b1dd53e5ecca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83842dfb-e5ea-41dc-91b1-b1dd53e5ecca.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -21772,7 +21772,7 @@
         },
         {
             "id": "ba3bda5a-b0c8-5931-818b-0126c810dc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649d42c1-a465-435e-8b67-e901ab9ad8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649d42c1-a465-435e-8b67-e901ab9ad8ab.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -21803,7 +21803,7 @@
         },
         {
             "id": "2d0f1dda-5182-553c-97d2-57710d02a3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88493c-293b-4b89-8571-712dcf110df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88493c-293b-4b89-8571-712dcf110df5.jpg?1",
             "name": "Liliana, the Last Hope Emblem",
             "text": "",
             "colours": [],
@@ -21833,7 +21833,7 @@
         },
         {
             "id": "695a65fa-4180-5482-aed8-1c9f84226998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35578c3f-e818-4887-83c4-dc3a89e28ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35578c3f-e818-4887-83c4-dc3a89e28ed4.jpg?1",
             "name": "Wrenn and Six Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/2XM.json
+++ b/Assets/Resources/Sets/2XM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fc5dff7e-489f-5a42-bf3f-926985aaef4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c6662-4dde-40a2-97e0-0318478c0367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c6662-4dde-40a2-97e0-0318478c0367.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "6b31b436-0e4c-56aa-b8f4-73a46abb0f33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef65e86-3759-465d-862b-29516eed46e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef65e86-3759-465d-862b-29516eed46e6.jpg?1",
             "name": "Alabaster Mage",
             "text": "{1}{W}: Target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "8b18a63d-e741-5c34-a2b5-8b119bb77ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ca85e4-f1ca-47ff-bb67-eb0d66d35cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ca85e4-f1ca-47ff-bb67-eb0d66d35cc8.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "813198d6-f2c4-5ac3-b0a0-4ed4d866fd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccfe469-3fa7-4672-ae15-8f25971e7c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccfe469-3fa7-4672-ae15-8f25971e7c56.jpg?1",
             "name": "Angel of the Dawn",
             "text": "Flying\nWhen Angel of the Dawn enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "e5fa76e0-e10e-5eec-b6ac-8bb6549dd233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c34447-b0f4-4fcc-b557-23c92850b31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c34447-b0f4-4fcc-b557-23c92850b31b.jpg?1",
             "name": "Archangel of Thune",
             "text": "Flying, lifelink\nWhenever you gain life, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "84a4a758-4ca1-5c52-a9f2-a0cbbccfbb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb996b-1da6-41a3-8d9a-a45c2353c401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb996b-1da6-41a3-8d9a-a45c2353c401.jpg?1",
             "name": "Auriok Salvagers",
             "text": "{1}{W}: Return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "d806b135-3258-509b-adb0-52b2ac0d154c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d36e87ca-71e1-43d2-841f-b01a58fe27f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d36e87ca-71e1-43d2-841f-b01a58fe27f0.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "2818f287-8403-5217-9a59-c11af2ab77e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0519776-3d86-4f7d-9c3b-71c1dfbf7e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0519776-3d86-4f7d-9c3b-71c1dfbf7e12.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "5b9dacb4-c5a1-5950-8951-e3239a9b4983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277bc4e5-f43a-4f1e-a7e9-11796e78fcdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277bc4e5-f43a-4f1e-a7e9-11796e78fcdf.jpg?1",
             "name": "Blade Splicer",
             "text": "When Blade Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolems you control have first strike.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "ce463b18-101c-5bd3-a425-aa2e169a0e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4032a7-600c-4b30-a012-fe3cde1be9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4032a7-600c-4b30-a012-fe3cde1be9c9.jpg?1",
             "name": "Boon Reflection",
             "text": "If you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "1455b16b-e445-5117-99ce-be8bb0d68154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa187c9-90b3-4770-963a-8a9f932430ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa187c9-90b3-4770-963a-8a9f932430ef.jpg?1",
             "name": "Council's Judgment",
             "text": "Will of the council \u2014 Starting with you, each player votes for a nonland permanent you don't control. Exile each permanent with the most votes or tied for most votes.",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "8a3a1659-5731-59fc-9cbf-3647cc569356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c53df6a-618d-40d4-a390-44b2e3202d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c53df6a-618d-40d4-a390-44b2e3202d7d.jpg?1",
             "name": "Crib Swap",
             "text": "Changeling (This card is every creature type.)\nExile target creature. Its controller creates a 1/1 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "25dc1ae0-9511-5dac-9ea4-08625c9e0386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81e6aaa-aea4-4187-a4ca-fbbea0d10c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81e6aaa-aea4-4187-a4ca-fbbea0d10c7d.jpg?1",
             "name": "Crusader of Odric",
             "text": "Crusader of Odric's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "6fe16551-19f8-575f-a071-8404a937fe36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8e0f8-fdb9-4f24-a3e3-439f6cc3ebdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8e0f8-fdb9-4f24-a3e3-439f6cc3ebdc.jpg?1",
             "name": "Ethersworn Canonist",
             "text": "Each player who has cast a nonartifact spell this turn can't cast additional nonartifact spells.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "2ce1ba66-f602-542e-9b66-e802f5b894fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f198c0-5819-42fc-89f5-cad46cf8d5d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f198c0-5819-42fc-89f5-cad46cf8d5d1.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "9189b384-fcf2-5a45-912b-411c467e45c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0ed8ee-d6ea-469c-a575-6643d3995f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0ed8ee-d6ea-469c-a575-6643d3995f54.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -557,7 +557,7 @@
         },
         {
             "id": "f46dd0cf-3666-59fe-8e48-4e826bef54d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4974169a-f454-4b8a-9301-18498c73c5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4974169a-f454-4b8a-9301-18498c73c5ab.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "63b8f929-b55c-555e-a683-be61fd52086e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2fd5ac-963b-49ea-bd72-d0958ef8eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2fd5ac-963b-49ea-bd72-d0958ef8eb3e.jpg?1",
             "name": "Glint-Sleeve Artisan",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "b270b745-70c2-5ad7-9189-91a4f1b19230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e92cf6-8382-44b5-9f14-c91e572685b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e92cf6-8382-44b5-9f14-c91e572685b9.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, create a 2/2 white Cat creature token for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -661,7 +661,7 @@
         },
         {
             "id": "0d30a492-1f46-5774-a281-1cec988739b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bba319-5f66-4085-9f2a-ab71f727ab64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bba319-5f66-4085-9f2a-ab71f727ab64.jpg?1",
             "name": "Land Tax",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -693,7 +693,7 @@
         },
         {
             "id": "1f5ef27d-0cc6-51e1-9b79-e925bc088f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14397b59-ff0d-4838-92c3-9728bf6b0af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14397b59-ff0d-4838-92c3-9728bf6b0af5.jpg?1",
             "name": "Leonin Abunas",
             "text": "Artifacts you control have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "7cebda51-4ad7-5f5c-adec-335b52076f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32e82fc-6613-462b-b11f-523db195f435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32e82fc-6613-462b-b11f-523db195f435.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolems you control get +1/+1.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "1db31e0b-65b6-5ab8-8cfe-e963ff1d2ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783c15b7-6a7f-471e-b9f7-8c38115e66c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783c15b7-6a7f-471e-b9f7-8c38115e66c0.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, create a 1/1 colorless Myr artifact creature token.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "f6a99f9c-e810-58d3-94cd-00a1153c20bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c5a822-0f5e-4b5f-b969-b27324e4543f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c5a822-0f5e-4b5f-b969-b27324e4543f.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control. (Auras with nothing to enchant remain in graveyards.)",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "fff91993-bbbd-5738-b1ca-b2bd68e80257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d36855-c38a-4bba-a642-cff3f81e057e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d36855-c38a-4bba-a642-cff3f81e057e.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle their library.",
             "colours": [
@@ -863,7 +863,7 @@
         },
         {
             "id": "ad3ece0b-6b3d-59d3-8dc8-ca436a778ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abcc2e6-82e7-4cc5-8956-05dd617e3e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abcc2e6-82e7-4cc5-8956-05dd617e3e7d.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -898,7 +898,7 @@
         },
         {
             "id": "c6d225e3-34cd-55e9-947c-74b5662faf72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ca034-9cea-4b84-98ba-76c24f038edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ca034-9cea-4b84-98ba-76c24f038edb.jpg?1",
             "name": "Remember the Fallen",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "3793cd8b-d540-5c40-ae28-af79ca778138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd4fc26-8351-4371-948b-f43346c3e771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd4fc26-8351-4371-948b-f43346c3e771.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "de4b9359-a582-5fc8-86b1-80b65ed47d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0714cb-21e5-4922-b971-ebcb9e3c9196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0714cb-21e5-4922-b971-ebcb9e3c9196.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle enters the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "ec2e6c4d-8988-5eca-8eec-656530723297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86322472-52e5-4af4-8a41-1ccc3ff6fd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86322472-52e5-4af4-8a41-1ccc3ff6fd92.jpg?1",
             "name": "Sanctum Spirit",
             "text": "Lifelink\nDiscard a historic card: Sanctum Spirit gains indestructible until end of turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "bb5cedfe-72ac-5788-b453-75ddfa96c44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3473d0-b46f-41f5-ac1e-ba217f7747d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3473d0-b46f-41f5-ac1e-ba217f7747d4.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.\n{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "a2ff821b-379c-518d-89e7-71eac84d91c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efda05d-01ea-4478-b075-00a31d7037f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efda05d-01ea-4478-b075-00a31d7037f8.jpg?1",
             "name": "Stonehewer Giant",
             "text": "Vigilance\n{1}{W}, {T}: Search your library for an Equipment card and put it onto the battlefield. Attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "2791dcb2-9a4d-52d8-af3b-a08aafd3097a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6843952d-e633-4992-99d5-4ef8b87494c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6843952d-e633-4992-99d5-4ef8b87494c8.jpg?1",
             "name": "Strength of Arms",
             "text": "Target creature gets +2/+2 until end of turn. If you control an Equipment, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -1135,7 +1135,7 @@
         },
         {
             "id": "d56abffa-6fe8-582b-b4fe-10e026f17ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956cc7b5-b120-4a98-9509-03047d8acd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956cc7b5-b120-4a98-9509-03047d8acd4a.jpg?1",
             "name": "Tempered Steel",
             "text": "Artifact creatures you control get +2/+2.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "4e8564ab-9cc4-5ae4-a5c8-24a5baa2e650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39749-ad6f-4160-99eb-c677eee7f1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39749-ad6f-4160-99eb-c677eee7f1b2.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "3e84d54f-06f7-5574-827e-34f583938c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab74e12a-ad7c-4563-aa06-632654bac91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab74e12a-ad7c-4563-aa06-632654bac91d.jpg?1",
             "name": "Topple the Statue",
             "text": "Tap target permanent. If it's an artifact, destroy it.\nDraw a card.",
             "colours": [
@@ -1234,7 +1234,7 @@
         },
         {
             "id": "52992fb2-ba08-587e-8751-56e7a9e92126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7428ad-4bd4-401d-a45c-3900bb05a3f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7428ad-4bd4-401d-a45c-3900bb05a3f7.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "8834baf0-51b8-5cf9-8be4-9e72464b5869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72729e-d2fa-4bbb-8524-8c88acb30850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72729e-d2fa-4bbb-8524-8c88acb30850.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "33ee3d00-153e-5d6e-a439-1b0ca9d3ad70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e6656-36a3-4635-9f33-9f8901afd397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e6656-36a3-4635-9f33-9f8901afd397.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "378986fb-5bee-5f86-99f7-980ab62189c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13026a8-7e3c-45b2-9838-080f14ae4b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13026a8-7e3c-45b2-9838-080f14ae4b29.jpg?1",
             "name": "Apprentice Wizard",
             "text": "{U}, {T}: Add {C}{C}{C}.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "3110237b-e998-5a6a-9767-f6bcc0b177ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ecf811-2efc-4fa6-9af8-ef09f559ec1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ecf811-2efc-4fa6-9af8-ef09f559ec1a.jpg?1",
             "name": "Arcum Dagsson",
             "text": "{T}: Target artifact creature's controller sacrifices it. That player may search their library for a noncreature artifact card, put it onto the battlefield, then shuffle their library.",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "acfb4e43-bcdd-5c7b-b995-7c823680e98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14b3a6-5490-4a50-9449-542e23f1d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14b3a6-5490-4a50-9449-542e23f1d6b1.jpg?1",
             "name": "Argivian Restoration",
             "text": "Return target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "99eb6e1c-b52b-5103-9669-95dcc19cad34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593dfb2f-ede0-413a-b037-46ae5c3769e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593dfb2f-ede0-413a-b037-46ae5c3769e4.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from their hand onto the battlefield.",
             "colours": [
@@ -1473,7 +1473,7 @@
         },
         {
             "id": "64329194-cb04-530b-9763-6c331596a1ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb0421-b7af-44cd-a7f6-7daaa3dcaa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb0421-b7af-44cd-a7f6-7daaa3dcaa38.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "11c2194f-054b-56ac-8819-c5c46065ed70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afaeec0-9ea3-4aec-9876-8e005e787d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afaeec0-9ea3-4aec-9876-8e005e787d71.jpg?1",
             "name": "Cloudreader Sphinx",
             "text": "Flying\nWhen Cloudreader Sphinx enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "be568e91-35ed-5769-b349-59be469888e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3f6598-18a7-472d-8d05-715203379089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3f6598-18a7-472d-8d05-715203379089.jpg?1",
             "name": "Corridor Monitor",
             "text": "When Corridor Monitor enters the battlefield, untap target artifact or creature you control.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "1017ece8-fc06-528b-b6ca-f204d3acf75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08e5ed-f47b-4d8e-8b8b-41675dccef8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08e5ed-f47b-4d8e-8b8b-41675dccef8b.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "dd401668-4d04-5eac-8dca-9c57958be642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b26dc-de39-4510-9fcf-6cb43372f543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b26dc-de39-4510-9fcf-6cb43372f543.jpg?1",
             "name": "Deepglow Skate",
             "text": "When Deepglow Skate enters the battlefield, double the number of each kind of counter on any number of target permanents.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "39c42a35-6390-58b7-80d7-5f4b94d4f925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7269b26a-058c-4a5c-aadf-733ea60f3de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7269b26a-058c-4a5c-aadf-733ea60f3de0.jpg?1",
             "name": "Esperzoa",
             "text": "Flying\nAt the beginning of your upkeep, return an artifact you control to its owner's hand.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "d0b03af8-ea61-54c6-919a-efcc6401c488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b14d57-a856-49d4-931f-ff5a0407b135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b14d57-a856-49d4-931f-ff5a0407b135.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist enters the battlefield, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "65ba05d3-76c2-54e1-bfcb-c12c6fead81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60b291-0a88-4e8e-bef8-76cdfd6c8183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60b291-0a88-4e8e-bef8-76cdfd6c8183.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "21b834ec-8da1-57ad-93d6-ac10545e3aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89be5f5-75d4-42a0-81e9-5da5bf868e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89be5f5-75d4-42a0-81e9-5da5bf868e73.jpg?1",
             "name": "Frogify",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1. (It loses all other card types and creature types.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "30e8e88d-4f8b-584f-ad32-b1ddea0bf3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce909d-a53e-4711-a9fd-b110433d460f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce909d-a53e-4711-a9fd-b110433d460f.jpg?1",
             "name": "Grand Architect",
             "text": "Other blue creatures you control get +1/+1.\n{U}: Target artifact creature becomes blue until end of turn.\nTap an untapped blue creature you control: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -1818,7 +1818,7 @@
         },
         {
             "id": "dfffa641-f6a3-5897-97a2-daa32b334f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebaedfd-3f65-4867-bb59-df548a6eb113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebaedfd-3f65-4867-bb59-df548a6eb113.jpg?1",
             "name": "Hinder",
             "text": "Counter target spell. If that spell is countered this way, put that card on the top or bottom of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "5ab32b55-afe5-54d1-817c-baa2c59c95ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7a6dfb-a8f8-4899-b2db-c48d542dfd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7a6dfb-a8f8-4899-b2db-c48d542dfd55.jpg?1",
             "name": "Inkwell Leviathan",
             "text": "Islandwalk, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "896a92b1-ed29-5daf-bf89-2502224f8f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8817585-0d32-4d56-9142-0d29512e86a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8817585-0d32-4d56-9142-0d29512e86a9.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
             "colours": [
@@ -1923,7 +1923,7 @@
         },
         {
             "id": "b26d0f16-0f6d-576e-a716-9c1df0a8ad21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c860286-9807-4ab5-b66f-e8696e9e6ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c860286-9807-4ab5-b66f-e8696e9e6ac9.jpg?1",
             "name": "Master of Etherium",
             "text": "Master of Etherium's power and toughness are each equal to the number of artifacts you control.\nOther artifact creatures you control get +1/+1.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "98f85a2a-c64c-5a72-aae6-7c7b4125ba0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb74f-9e62-41f7-b48a-b4249aab5752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb74f-9e62-41f7-b48a-b4249aab5752.jpg?1",
             "name": "Master Transmuter",
             "text": "{U}, {T}, Return an artifact you control to its owner's hand: You may put an artifact card from your hand onto the battlefield.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "a4bb8e88-27fa-54c0-881c-d3fa9d3aca69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34785944-7b51-48a9-855c-3e656cd78251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34785944-7b51-48a9-855c-3e656cd78251.jpg?1",
             "name": "Metallic Rebuke",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "c97c9388-6244-51b2-9932-0638ecaf844f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70017989-aaf1-4a70-98aa-e447d6ce793a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70017989-aaf1-4a70-98aa-e447d6ce793a.jpg?1",
             "name": "Parasitic Strix",
             "text": "Flying\nWhen Parasitic Strix enters the battlefield, if you control a black permanent, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "0381e84a-634b-5b34-a4f5-bc314306344a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6afeb07-ed44-4e15-99b6-436f8365326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6afeb07-ed44-4e15-99b6-436f8365326f.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "({PU} can be paid with either {U} or 2 life.)\nYou may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [
@@ -2100,7 +2100,7 @@
         },
         {
             "id": "454d01cf-80b6-51ca-9131-507bf63c84c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7a6db-e0a3-45f7-9ef7-e4fd5490adb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7a6db-e0a3-45f7-9ef7-e4fd5490adb7.jpg?1",
             "name": "Pongify",
             "text": "Destroy target creature. It can't be regenerated. Its controller creates a 3/3 green Ape creature token.",
             "colours": [
@@ -2132,7 +2132,7 @@
         },
         {
             "id": "2a197a04-5cde-591e-a501-e0b73004d3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbced19d-7035-4284-93b3-cf2d4bcf9734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbced19d-7035-4284-93b3-cf2d4bcf9734.jpg?1",
             "name": "Relic Runner",
             "text": "Relic Runner can't be blocked if you've cast a historic spell this turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "0f088f6b-cffb-526e-8527-d91ccb4e5487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8a8f14-bced-4388-b263-5e70431b191f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8a8f14-bced-4388-b263-5e70431b191f.jpg?1",
             "name": "Reshape",
             "text": "As an additional cost to cast this spell, sacrifice an artifact.\nSearch your library for an artifact card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "8af6d0c1-e49b-52db-b045-2c135359dbb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aab84-5e71-496f-8c46-ecd31fb97d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aab84-5e71-496f-8c46-ecd31fb97d27.jpg?1",
             "name": "Riddlesmith",
             "text": "Whenever you cast an artifact spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "a0324058-3078-5296-841c-81873f5a01cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca07a9-5c24-490f-8871-b125cb337e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca07a9-5c24-490f-8871-b125cb337e2c.jpg?1",
             "name": "Rush of Knowledge",
             "text": "Draw cards equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "1722767a-6005-56eb-9964-73d98dbcc917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19284d8-4404-4032-8dee-3c7af2819045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19284d8-4404-4032-8dee-3c7af2819045.jpg?1",
             "name": "Sentinel of the Pearl Trident",
             "text": "Flash\nWhen Sentinel of the Pearl Trident enters the battlefield, you may exile target historic permanent you control. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "9bf3c968-6c02-5b2d-bbab-1651e6da17ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb01cf8-9bca-4446-9e56-62777c6dfbe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb01cf8-9bca-4446-9e56-62777c6dfbe8.jpg?1",
             "name": "Serra Sphinx",
             "text": "Flying, vigilance",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "54f3cb18-1e58-5707-9e5a-b8d53c790e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9fb948-86fb-497b-98bf-1f69eac9901e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9fb948-86fb-497b-98bf-1f69eac9901e.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "5e8f6143-a14d-5009-a0d9-f5ecab44b8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227437d-1fc7-4a00-ace5-80795adc51d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227437d-1fc7-4a00-ace5-80795adc51d3.jpg?1",
             "name": "Steel Sabotage",
             "text": "Choose one \u2014\n\u2022 Counter target artifact spell.\n\u2022 Return target artifact to its owner's hand.",
             "colours": [
@@ -2399,7 +2399,7 @@
         },
         {
             "id": "ef59ce4d-ec3e-5e68-9000-8b4f75829533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46afb6e7-b2d9-436e-9532-0d09099de158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46afb6e7-b2d9-436e-9532-0d09099de158.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -2431,7 +2431,7 @@
         },
         {
             "id": "1a864ea8-6684-598e-9b30-1e96eecf6a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169e197-5ef4-454d-a31f-fcadedb74cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169e197-5ef4-454d-a31f-fcadedb74cfc.jpg?1",
             "name": "Thought Reflection",
             "text": "If you would draw a card, draw two cards instead.",
             "colours": [
@@ -2463,7 +2463,7 @@
         },
         {
             "id": "d64e95e6-ffd9-5ad8-a74f-5e91217a1726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea2fcd-f090-4545-a055-30d7980ad66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea2fcd-f090-4545-a055-30d7980ad66f.jpg?1",
             "name": "Treasure Mage",
             "text": "When Treasure Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "16ee5f83-d6aa-5b2a-982e-9e9485b59c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b9d11-0aab-4300-90b6-c8b56de36ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b9d11-0aab-4300-90b6-c8b56de36ec3.jpg?1",
             "name": "Vedalken Infuser",
             "text": "At the beginning of your upkeep, you may put a charge counter on target artifact.",
             "colours": [
@@ -2533,7 +2533,7 @@
         },
         {
             "id": "98ca597f-1cac-57d1-94ce-6ea7ee4314cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7796b82-5a7c-406e-be71-1f37abdbc44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7796b82-5a7c-406e-be71-1f37abdbc44f.jpg?1",
             "name": "Well of Ideas",
             "text": "When Well of Ideas enters the battlefield, draw two cards.\nAt the beginning of each other player's draw step, that player draws an additional card.\nAt the beginning of your draw step, draw two additional cards.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "c19def09-b6ae-5761-a786-e7b694d4eac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f2c53e-ff58-4aa8-89a6-4f45628cc571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f2c53e-ff58-4aa8-89a6-4f45628cc571.jpg?1",
             "name": "Ad Nauseam",
             "text": "Reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost. You may repeat this process any number of times.",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "ba2bb3ae-9ad2-5079-ae3d-8fa73fd19530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd199b-1855-4208-8bf7-8930e91ab139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd199b-1855-4208-8bf7-8930e91ab139.jpg?1",
             "name": "Beacon of Unrest",
             "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "d4996eed-a712-5d8e-83da-86be83bb6799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7de3d27-f3e0-4aea-a737-6577de1bd1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7de3d27-f3e0-4aea-a737-6577de1bd1c5.jpg?1",
             "name": "Bone Picker",
             "text": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -2663,7 +2663,7 @@
         },
         {
             "id": "cf32347b-17d0-5087-94a1-273d8c86ab0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480fecdd-5978-47e6-9c25-7a04cdf616db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480fecdd-5978-47e6-9c25-7a04cdf616db.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "fe55f2e4-177b-52ec-a481-2c88e03f98bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598405fd-02d2-4bf8-b241-7a2ae6338913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598405fd-02d2-4bf8-b241-7a2ae6338913.jpg?1",
             "name": "Costly Plunder",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "300725c7-140d-589d-a14f-d40f9ec5b63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d88239-43dc-46b8-8d46-626e2f8f1070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d88239-43dc-46b8-8d46-626e2f8f1070.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "8fdd86ea-8d26-59a9-94cf-2517155ba347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526ff6e-c079-4ad4-ac8d-5e26ecacf50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526ff6e-c079-4ad4-ac8d-5e26ecacf50d.jpg?1",
             "name": "Death's Shadow",
             "text": "Death's Shadow gets -X/-X, where X is your life total.",
             "colours": [
@@ -2798,7 +2798,7 @@
         },
         {
             "id": "b5d03323-b50b-5e86-9f5e-0d73d458cdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f113f11-9b87-4219-a106-9f6595d85b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f113f11-9b87-4219-a106-9f6595d85b81.jpg?1",
             "name": "Defiant Salvager",
             "text": "Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "799f3747-8263-528b-8c64-6c59cd0b1a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f86b94-2a86-4120-97cd-ec2c89d106cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f86b94-2a86-4120-97cd-ec2c89d106cb.jpg?1",
             "name": "Dire Fleet Hoarder",
             "text": "When Dire Fleet Hoarder dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "9fb379dd-cbef-52c3-9741-244a10721410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b70c101-d8b0-4acb-ad65-59bf9860708a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b70c101-d8b0-4acb-ad65-59bf9860708a.jpg?1",
             "name": "Disciple of Bolas",
             "text": "When Disciple of Bolas enters the battlefield, sacrifice another creature. You gain X life and draw X cards, where X is that creature's power.",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "23ab39a0-1531-586d-b0e6-d47e23a2ba7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c539843-4e3f-47a7-92e1-412eaaa2d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c539843-4e3f-47a7-92e1-412eaaa2d9c5.jpg?1",
             "name": "Disciple of the Vault",
             "text": "Whenever an artifact is put into a graveyard from the battlefield, you may have target opponent lose 1 life.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "12cdef28-6759-5d88-ae03-c5b2fd573c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494cb6d-1a99-40b6-96cc-0dc2ddec102f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494cb6d-1a99-40b6-96cc-0dc2ddec102f.jpg?1",
             "name": "Divest",
             "text": "Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "9f6e5403-76a5-5d25-92e4-9d7c2eb6672c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a21acd-100a-4a25-932b-f36943728ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a21acd-100a-4a25-932b-f36943728ac9.jpg?1",
             "name": "Doomed Necromancer",
             "text": "{B}, {T}, Sacrifice Doomed Necromancer: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "978a7807-5f69-5550-8334-1cc4d1ff9ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa9e00-e73e-4a6e-9607-77533aac4be4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa9e00-e73e-4a6e-9607-77533aac4be4.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "3f28ec5b-6bcb-5579-9725-f842d63cc236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46f4e7-ec58-4542-94b3-785bc46d26ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46f4e7-ec58-4542-94b3-785bc46d26ea.jpg?1",
             "name": "Driver of the Dead",
             "text": "When Driver of the Dead dies, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "fd47f6ea-033d-55be-b781-e168589e6f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e8a62-5b8c-432a-bb8f-c09048c51e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e8a62-5b8c-432a-bb8f-c09048c51e0b.jpg?1",
             "name": "Drown in Sorrow",
             "text": "All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "be690a68-9c47-5750-ba05-0ce332bf962a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ea333-96e1-4ad8-8947-21d6bc3a9f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ea333-96e1-4ad8-8947-21d6bc3a9f91.jpg?1",
             "name": "Executioner's Capsule",
             "text": "{1}{B}, {T}, Sacrifice Executioner's Capsule: Destroy target nonblack creature.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "ff508c3b-070d-5977-8bd8-ff2ef435e779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9d8fe4-fd9b-4923-92bf-7dd6b8fa02e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9d8fe4-fd9b-4923-92bf-7dd6b8fa02e7.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt \u2014 Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "b6d215d2-014f-5af7-93fd-ce6f7f768d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d56a4-fc94-43d8-9d65-361b66172a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d56a4-fc94-43d8-9d65-361b66172a5f.jpg?1",
             "name": "Geth, Lord of the Vault",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\n{X}{B}: Put target artifact or creature card with converted mana cost X from an opponent's graveyard onto the battlefield under your control tapped. Then that player mills X cards.",
             "colours": [
@@ -3207,7 +3207,7 @@
         },
         {
             "id": "b9de76f5-7fad-5ffc-98d1-baa9136289f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f9a946-f961-4e19-a30a-6e1a95683340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f9a946-f961-4e19-a30a-6e1a95683340.jpg?1",
             "name": "Glaze Fiend",
             "text": "Flying\nWhenever another artifact enters the battlefield under your control, Glaze Fiend gets +2/+2 until end of turn.",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "4bee3b6a-545b-56b6-bfdd-a38fccaf9fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b705cd6-da20-4f0a-bb94-2acd1cecd64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b705cd6-da20-4f0a-bb94-2acd1cecd64c.jpg?1",
             "name": "Heartless Pillage",
             "text": "Target opponent discards two cards.\nRaid \u2014 If you attacked this turn, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "2e0d8eb7-87e2-5cd8-b0fe-9cd3a6f85c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954157a-0c05-4788-8a0f-6093ebbb38c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954157a-0c05-4788-8a0f-6093ebbb38c3.jpg?1",
             "name": "Magus of the Abyss",
             "text": "At the beginning of each player's upkeep, destroy target nonartifact creature that player controls of their choice. It can't be regenerated.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "1122ebd6-9c5f-5bf4-8bde-1d30702ff5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c41068-59d8-4ef4-aae4-a93b0a9ee19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c41068-59d8-4ef4-aae4-a93b0a9ee19e.jpg?1",
             "name": "Magus of the Will",
             "text": "{2}{B}, {T}, Exile Magus of the Will: Until end of turn, you may play lands and cast spells from your graveyard. If a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -3344,7 +3344,7 @@
         },
         {
             "id": "0c74d47e-d5b8-52bd-bdcf-ae56a8975889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6fd09e-55af-41dd-a0c0-ba1064737c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6fd09e-55af-41dd-a0c0-ba1064737c90.jpg?1",
             "name": "Morkrut Banshee",
             "text": "Morbid \u2014 When Morkrut Banshee enters the battlefield, if a creature died this turn, target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "1db1f518-6fa5-5d8a-9575-f3c658e64cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4800a7d-c229-4ced-97ff-0e58645d58d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4800a7d-c229-4ced-97ff-0e58645d58d6.jpg?1",
             "name": "Oubliette",
             "text": "When Oubliette enters the battlefield, target creature phases out until Oubliette leaves the battlefield. Tap that creature as it phases in this way. (Auras and Equipment phase out with it. While permanents are phased out, they're treated as though they don't exist.)",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "bfe87b9c-6c97-52d5-8674-fee71b6a8728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3ba73e-58aa-417e-bd52-d7f93c80adc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3ba73e-58aa-417e-bd52-d7f93c80adc6.jpg?1",
             "name": "Ovalchase Daredevil",
             "text": "Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "9a4ad5b4-97fd-5228-9ef9-491ccdb60ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79301fd4-2f00-4ff5-993f-a6af2440064b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79301fd4-2f00-4ff5-993f-a6af2440064b.jpg?1",
             "name": "Painsmith",
             "text": "Whenever you cast an artifact spell, you may have target creature get +2/+0 and gain deathtouch until end of turn.",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "96c5334f-c9e6-5835-af66-356198506bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0fae06-1a93-43ac-a349-f3719e60076e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0fae06-1a93-43ac-a349-f3719e60076e.jpg?1",
             "name": "Ravenous Trap",
             "text": "If an opponent had three or more cards put into their graveyard from anywhere this turn, you may pay {0} rather than pay this spell's mana cost.\nExile all cards from target player's graveyard.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "58851415-e7e1-56ce-a0ff-b1a71c1f0215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7175febd-ae8e-4945-91ab-b6c67c40f04b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7175febd-ae8e-4945-91ab-b6c67c40f04b.jpg?1",
             "name": "Salvage Titan",
             "text": "You may sacrifice three artifacts rather than pay this spell's mana cost.\nExile three artifact cards from your graveyard: Return Salvage Titan from your graveyard to your hand.",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "21d935e0-d088-5d70-9f70-682e544335ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047fd05e-7545-4148-b3d7-eccf72ae43fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047fd05e-7545-4148-b3d7-eccf72ae43fb.jpg?1",
             "name": "Silumgar Scavenger",
             "text": "Flying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhenever another creature you control dies, put a +1/+1 counter on Silumgar Scavenger. It gains haste until end of turn if it exploited that creature.",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "f2d8f179-3470-5d1a-bf76-8d1dad6d4472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dd19e9-23ff-4854-bbce-ce0a00a7b5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dd19e9-23ff-4854-bbce-ce0a00a7b5b4.jpg?1",
             "name": "Skirsdag High Priest",
             "text": "Morbid \u2014 {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token with flying. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "0ee7621b-b728-5ef0-9536-e2887896acf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab61c7e-e00a-413b-a0b5-7718b479582f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab61c7e-e00a-413b-a0b5-7718b479582f.jpg?1",
             "name": "Skithiryx, the Blight Dragon",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{B}: Skithiryx, the Blight Dragon gains haste until end of turn.\n{B}{B}: Regenerate Skithiryx.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "5e1b0e13-eae6-5db2-ada3-a9e27dae94a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bff1b7-838f-48de-96bd-0c79e59ff827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bff1b7-838f-48de-96bd-0c79e59ff827.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "8e8097bd-ccd9-5f97-b9c2-0c8ee324accc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281a308-ab6b-47b6-bec7-632c9aaecede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281a308-ab6b-47b6-bec7-632c9aaecede.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -3723,7 +3723,7 @@
         },
         {
             "id": "d5783732-6927-5fed-b498-ce1b9a5402ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fa18f-d50a-4d3f-929e-91f29141b1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fa18f-d50a-4d3f-929e-91f29141b1df.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "9164a450-c787-55e3-aca3-563d74e502c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffae38ec-7712-4701-b072-9f962ec9c259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffae38ec-7712-4701-b072-9f962ec9c259.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "3a40176d-a4f1-5eba-aee6-c81ee38f9ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec2e55-fa60-4ee1-b9c0-e6b84939697b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec2e55-fa60-4ee1-b9c0-e6b84939697b.jpg?1",
             "name": "Vampire Hexmage",
             "text": "First strike\nSacrifice Vampire Hexmage: Remove all counters from target permanent.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "d94a1cb3-e3fe-5f86-885a-c93b84bee2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14a82c-877a-445f-8910-33aaa6fe3d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14a82c-877a-445f-8910-33aaa6fe3d15.jpg?1",
             "name": "Wound Reflection",
             "text": "At the beginning of each end step, each opponent loses life equal to the life they lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "01df4e32-7fe4-5b8d-9460-0f08fa29153e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da9431-7e52-44f5-bc18-2f2d8a4ca81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da9431-7e52-44f5-bc18-2f2d8a4ca81e.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -3891,7 +3891,7 @@
         },
         {
             "id": "7d666343-4f91-59c3-8700-0d1e584d5626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81848391-ed73-498a-a650-4041fb9a46bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81848391-ed73-498a-a650-4041fb9a46bc.jpg?1",
             "name": "Balduvian Rage",
             "text": "Target attacking creature gets +X/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "a9a7eb21-f400-5865-bfdf-e2924f0c1a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25920434-8254-4fbf-8ef1-6d0e2cd8ee39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25920434-8254-4fbf-8ef1-6d0e2cd8ee39.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "ba1ffdda-f3c0-5a66-9415-1cc106f471d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff02fcd-241e-4a3e-a0d0-5adc90e7d0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff02fcd-241e-4a3e-a0d0-5adc90e7d0db.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "774de3b7-06ad-517d-b5fa-1210429183a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d072e9ca-aae7-45dc-8025-3ce590bae63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d072e9ca-aae7-45dc-8025-3ce590bae63f.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "9bb62efe-c223-544b-948d-c61fc300c265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779a130b-1d23-4a20-9914-dbdc2268ae3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779a130b-1d23-4a20-9914-dbdc2268ae3b.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -4059,7 +4059,7 @@
         },
         {
             "id": "27054272-c862-52d6-b02b-a7ec77abe5a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fa0577-f02a-4d24-835b-fef8d849b37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fa0577-f02a-4d24-835b-fef8d849b37a.jpg?1",
             "name": "Brimstone Volley",
             "text": "Brimstone Volley deals 3 damage to any target.\nMorbid \u2014 Brimstone Volley deals 5 damage instead if a creature died this turn.",
             "colours": [
@@ -4091,7 +4091,7 @@
         },
         {
             "id": "6ebb5610-cd01-5d2c-985d-6449df3f42a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fa6f3-29e8-4788-bfcd-59576187c399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fa6f3-29e8-4788-bfcd-59576187c399.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "7a010b19-992a-5245-8928-3c21eaf65699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b13d612-f5d4-4423-99bc-359c47a8aa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b13d612-f5d4-4423-99bc-359c47a8aa99.jpg?1",
             "name": "Cragganwick Cremator",
             "text": "When Cragganwick Cremator enters the battlefield, discard a card at random. If you discard a creature card this way, Cragganwick Cremator deals damage equal to that card's power to target player or planeswalker.",
             "colours": [
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "0e33df1d-af7a-5abc-ab7e-112886d35b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86862339-a5a5-45c4-bba5-981cff4f45f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86862339-a5a5-45c4-bba5-981cff4f45f5.jpg?1",
             "name": "Dismantle",
             "text": "Destroy target artifact. If that artifact had counters on it, put that many +1/+1 counters or charge counters on an artifact you control.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "731c31d1-16f7-5746-afab-4b0fc430e94a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4814b8-9aea-4e44-aec1-d585473f5d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4814b8-9aea-4e44-aec1-d585473f5d1c.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4225,7 +4225,7 @@
         },
         {
             "id": "250c00e4-d094-5cb5-a75d-6bc692365df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cb1e-314a-4894-82df-f9812825f52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cb1e-314a-4894-82df-f9812825f52e.jpg?1",
             "name": "Galvanic Blast",
             "text": "Galvanic Blast deals 2 damage to any target.\nMetalcraft \u2014 Galvanic Blast deals 4 damage instead if you control three or more artifacts.",
             "colours": [
@@ -4257,7 +4257,7 @@
         },
         {
             "id": "233a0bd8-0ef6-563e-b92e-72bf523f212e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f44f3ea-504e-4745-9716-cbe28ed7873d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f44f3ea-504e-4745-9716-cbe28ed7873d.jpg?1",
             "name": "Goblin Gaveleer",
             "text": "Trample\nGoblin Gaveleer gets +2/+0 for each Equipment attached to it.",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "1609c919-63d6-5487-9589-871b9753a26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f5411-1940-410f-96ce-6f92513f753a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f5411-1940-410f-96ce-6f92513f753a.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "605e26ed-436d-5390-8728-be5a79f8dd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d1368-fbbe-48f8-9b44-d51946529322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d1368-fbbe-48f8-9b44-d51946529322.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card and put it onto the battlefield. If you do, shuffle your library.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -4366,7 +4366,7 @@
         },
         {
             "id": "a1236691-5f91-5325-b948-1479aee35971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2a0d71-15a2-4061-b5f2-434755094aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2a0d71-15a2-4061-b5f2-434755094aa4.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -4401,7 +4401,7 @@
         },
         {
             "id": "5d162141-f2d7-5db4-bd8d-c5dbb5081299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86956f26-3761-4841-a9b5-f8205bf01f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86956f26-3761-4841-a9b5-f8205bf01f19.jpg?1",
             "name": "Heat Shimmer",
             "text": "Create a token that's a copy of target creature, except it has haste and \"At the beginning of the end step, exile this permanent.\"",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "60eb5e26-d3a0-55c4-bfbf-833f8d12e53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d915eebf-1617-4339-b8b0-72b313c6dab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d915eebf-1617-4339-b8b0-72b313c6dab2.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4468,7 +4468,7 @@
         },
         {
             "id": "e76d33d1-f706-5e85-9fda-61d85d64f9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f02fc34-a2f6-456a-a8e5-da5a7327f954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f02fc34-a2f6-456a-a8e5-da5a7327f954.jpg?1",
             "name": "Ion Storm",
             "text": "{1}{R}, Remove a +1/+1 counter or a charge counter from a permanent you control: Ion Storm deals 2 damage to any target.",
             "colours": [
@@ -4500,7 +4500,7 @@
         },
         {
             "id": "a516eb59-43e3-5f48-aa3f-8c39a6f91ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7377e5a7-b479-48cc-8fbb-01af87c62566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7377e5a7-b479-48cc-8fbb-01af87c62566.jpg?1",
             "name": "Kazuul's Toll Collector",
             "text": "{0}: Attach target Equipment you control to Kazuul's Toll Collector. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4535,7 +4535,7 @@
         },
         {
             "id": "66785d2f-458b-5826-b4c9-3b286399ce51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226e1d72-4ed0-4db6-ac0a-f4631db986a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226e1d72-4ed0-4db6-ac0a-f4631db986a9.jpg?1",
             "name": "Kuldotha Flamefiend",
             "text": "When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "141bcc9a-d1da-5871-87de-5c978c1376cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91344085-92ef-4212-b59f-848ab57cd3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91344085-92ef-4212-b59f-848ab57cd3e0.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -4601,7 +4601,7 @@
         },
         {
             "id": "317f8bcf-a711-5925-b886-6bd387a6109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd079929-fa58-4484-91b7-31305b87ee43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd079929-fa58-4484-91b7-31305b87ee43.jpg?1",
             "name": "Mana Echoes",
             "text": "Whenever a creature enters the battlefield, you may add an amount of {C} equal to the number of creatures you control that share a creature type with it.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "42c19824-f54c-5b31-994a-d028100c8965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ac010e-bcd9-4e40-91f5-3f6058dca104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ac010e-bcd9-4e40-91f5-3f6058dca104.jpg?1",
             "name": "Orcish Vandal",
             "text": "{T}, Sacrifice an artifact: Orcish Vandal deals 2 damage to any target.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "f902d349-a20d-5f9b-9178-62ed74c2658e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f195c52-4018-4d57-9c62-5f0a10f7336c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f195c52-4018-4d57-9c62-5f0a10f7336c.jpg?1",
             "name": "Pyrewild Shaman",
             "text": "Bloodrush \u2014 {1}{R}, Discard Pyrewild Shaman: Target attacking creature gets +3/+1 until end of turn.\nWhenever one or more creatures you control deal combat damage to a player, if Pyrewild Shaman is in your graveyard, you may pay {3}. If you do, return Pyrewild Shaman to your hand.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "586fe151-5038-52d9-9b5d-0a6a819924cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b767e176-1df5-4adc-bf6b-418d71b4dbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b767e176-1df5-4adc-bf6b-418d71b4dbbe.jpg?1",
             "name": "Rage Reflection",
             "text": "Creatures you control have double strike.",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "5d153af6-b6f1-5d81-a706-bb9793b72543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca026be-d204-4ec2-a349-aac5fc3a05ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca026be-d204-4ec2-a349-aac5fc3a05ec.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "676ae5dd-0fd7-5b98-993d-baf33f358acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d6da8-9cfe-4c1b-90c9-477a743f6d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d6da8-9cfe-4c1b-90c9-477a743f6d62.jpg?1",
             "name": "Ravenous Intruder",
             "text": "Sacrifice an artifact: Ravenous Intruder gets +2/+2 until end of turn.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "979add19-bcdc-505d-835a-d2f44859f8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ab37d4-6ba3-404a-8162-f207874738ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ab37d4-6ba3-404a-8162-f207874738ea.jpg?1",
             "name": "Rolling Earthquake",
             "text": "Rolling Earthquake deals X damage to each creature without horsemanship and each player.",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "21aeac7a-0b3a-5ff6-8612-b4820e69ebb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec0d9-42b4-4aff-8d55-0721c8911de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec0d9-42b4-4aff-8d55-0721c8911de3.jpg?1",
             "name": "Salivating Gremlins",
             "text": "Whenever an artifact enters the battlefield under your control, Salivating Gremlins gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -4869,7 +4869,7 @@
         },
         {
             "id": "1f6ee190-467f-5c8c-a398-5db71afae59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9535cdfe-d505-4ee5-bec0-cfd7aa4b2a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9535cdfe-d505-4ee5-bec0-cfd7aa4b2a23.jpg?1",
             "name": "Skinbrand Goblin",
             "text": "Bloodrush \u2014 {R}, Discard Skinbrand Goblin: Target attacking creature gets +2/+1 until end of turn.",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "3556c2f3-d271-566e-8289-25f0838081da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9709ea-5962-4590-8b14-5213b14f9229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9709ea-5962-4590-8b14-5213b14f9229.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "db7d9ebb-b55b-5377-8e26-73c18f91ef0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88258dee-b5c0-4472-86d6-cc534c32fe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88258dee-b5c0-4472-86d6-cc534c32fe27.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "ecba687d-a132-5ee0-91de-e905d56fe8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aa7ba-4b35-42e5-bdcd-e7b3360fd01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aa7ba-4b35-42e5-bdcd-e7b3360fd01f.jpg?1",
             "name": "Thopter Engineer",
             "text": "When Thopter Engineer enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\nArtifact creatures you control have haste.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "49b67cf1-bee5-581d-ac3b-55b585768d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75993427-fb8d-41cc-9016-323e804a5eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75993427-fb8d-41cc-9016-323e804a5eb7.jpg?1",
             "name": "Trash for Treasure",
             "text": "As an additional cost to cast this spell, sacrifice an artifact.\nReturn target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -5037,7 +5037,7 @@
         },
         {
             "id": "8a787bb5-3d1e-5ed4-a07b-99801816b176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17f5403-7692-41ca-a3c9-b81c31bddc00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17f5403-7692-41ca-a3c9-b81c31bddc00.jpg?1",
             "name": "Tuktuk the Explorer",
             "text": "Haste\nWhen Tuktuk the Explorer dies, create Tuktuk the Returned, a legendary 5/5 colorless Goblin Golem artifact creature token.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "0708b9c5-c6f0-5af3-a198-3e56599387dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19330317-0c5e-44fc-bb87-89b3f6dd3704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19330317-0c5e-44fc-bb87-89b3f6dd3704.jpg?1",
             "name": "Weapon Surge",
             "text": "Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "2984adaa-c321-55f3-b781-edd229d1bb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726039a0-6c0d-48ef-9b42-99de5d4e41d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726039a0-6c0d-48ef-9b42-99de5d4e41d2.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5137,7 +5137,7 @@
         },
         {
             "id": "cb687b79-d8db-53d9-a746-1bf4522b38f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609d255-a15a-482a-95f2-1b9ef1076652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609d255-a15a-482a-95f2-1b9ef1076652.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "88902e1d-6eec-5628-9302-06eea232ddb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0c3878-3097-4451-9ec0-7f45a0f72323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0c3878-3097-4451-9ec0-7f45a0f72323.jpg?1",
             "name": "Awakening Zone",
             "text": "At the beginning of your upkeep, you may create a 0/1 colorless Eldrazi Spawn creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "91d54e8c-8cca-5d5f-a502-0ca2f2dacd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9281d7-9c11-4dc8-9035-902fa3a69ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9281d7-9c11-4dc8-9035-902fa3a69ebf.jpg?1",
             "name": "Bloodbriar",
             "text": "Whenever you sacrifice another permanent, put a +1/+1 counter on Bloodbriar.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "24d15f70-4fdc-530c-83f0-5b51a9b20415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bc8355-3a02-44a5-b06f-8be24d7cbcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bc8355-3a02-44a5-b06f-8be24d7cbcbe.jpg?1",
             "name": "Bloodspore Thrinax",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nEach other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on Bloodspore Thrinax.",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "9e87e9d8-3743-52b9-bed8-def79d101434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb2e0d6-3181-4d3d-a3b4-3896288b2e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb2e0d6-3181-4d3d-a3b4-3896288b2e0e.jpg?1",
             "name": "Champion of Lambholt",
             "text": "Creatures with power less than Champion of Lambholt's power can't block creatures you control.\nWhenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.",
             "colours": [
@@ -5307,7 +5307,7 @@
         },
         {
             "id": "e608f676-4694-5f10-aeda-0e96981c1111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7e1991-9ffa-4a57-b8eb-ebe542a47f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7e1991-9ffa-4a57-b8eb-ebe542a47f09.jpg?1",
             "name": "Chatter of the Squirrel",
             "text": "Create a 1/1 green Squirrel creature token.\nFlashback {1}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "674fafea-14d6-52d9-b95b-72edffc2f168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac257a9-39bf-4185-9d2e-f80f0848a96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac257a9-39bf-4185-9d2e-f80f0848a96a.jpg?1",
             "name": "Chord of Calling",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5373,7 +5373,7 @@
         },
         {
             "id": "4442bb99-e7c6-56ad-a9fe-8d511db557db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ff66fc-bd38-4607-b394-8c4e09affec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ff66fc-bd38-4607-b394-8c4e09affec8.jpg?1",
             "name": "Clear Shot",
             "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "33931625-ebe6-5f7e-b7df-a33b1d84456c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a5372-b25a-4559-96b8-2d8d54199a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a5372-b25a-4559-96b8-2d8d54199a38.jpg?1",
             "name": "Conclave Naturalists",
             "text": "When Conclave Naturalists enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "d3ac0d6c-7128-500b-acec-0c0d33b0afe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4249cc64-f75b-4c76-a41a-5b25873c74bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4249cc64-f75b-4c76-a41a-5b25873c74bc.jpg?1",
             "name": "Crop Rotation",
             "text": "As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a land card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "91106490-58bc-5b8d-8d58-fa7432ff25ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa22a85-1c92-48f3-921a-867a73a6bbf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa22a85-1c92-48f3-921a-867a73a6bbf7.jpg?1",
             "name": "Crushing Vines",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "2a568f10-e248-5727-881e-49c7b8d7855a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def88ab5-1b82-46f5-a136-ee1addff4214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def88ab5-1b82-46f5-a136-ee1addff4214.jpg?1",
             "name": "Death-Hood Cobra",
             "text": "{1}{G}: Death-Hood Cobra gains reach until end of turn.\n{1}{G}: Death-Hood Cobra gains deathtouch until end of turn.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "07daf4eb-fba7-560e-b70b-56ee686724e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676d164-c76e-402b-a649-6ded3f549b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676d164-c76e-402b-a649-6ded3f549b6e.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "7e07a173-7cbd-52b8-a878-beee64adf53a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f865601c-fddf-42fe-acd0-c9075fa84783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f865601c-fddf-42fe-acd0-c9075fa84783.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G}.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "4e92beed-d6d1-51a6-920a-5452f584a229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e699f-5f2c-4487-8a40-42be6f561631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e699f-5f2c-4487-8a40-42be6f561631.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "76a56b00-4e84-589b-9d43-5ca5be70cb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4c6535-afea-4704-b35c-badeb04c4f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4c6535-afea-4704-b35c-badeb04c4f4c.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "abc0b650-e749-5e87-9815-912e339ae903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ddd38-397c-4119-8d55-50c7407883f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ddd38-397c-4119-8d55-50c7407883f9.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "02ba2b6f-23cd-5db0-b31f-1b701cd5c995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5c2be0-76ab-4873-a1fc-9ff65a9347c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5c2be0-76ab-4873-a1fc-9ff65a9347c7.jpg?1",
             "name": "Gelatinous Genesis",
             "text": "Create X X/X green Ooze creature tokens.",
             "colours": [
@@ -5741,7 +5741,7 @@
         },
         {
             "id": "30466a4c-5a4c-5df9-8c6c-2191cb8a6919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046aff0b-fa01-4a2d-a030-021a7ad01e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046aff0b-fa01-4a2d-a030-021a7ad01e60.jpg?1",
             "name": "Greater Good",
             "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then discard three cards.",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "efbcbb0e-ab0a-5eba-b612-7ff9eeed8212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb1e59-b858-42cf-93f8-8a3badb3eaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb1e59-b858-42cf-93f8-8a3badb3eaad.jpg?1",
             "name": "Heartbeat of Spring",
             "text": "Whenever a player taps a land for mana, that player adds one mana of any type that land produced.",
             "colours": [
@@ -5805,7 +5805,7 @@
         },
         {
             "id": "ce99b731-c030-539f-9871-05d58f01ea7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0899da3-7beb-4161-81a3-e2d694e5b8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0899da3-7beb-4161-81a3-e2d694e5b8a5.jpg?1",
             "name": "Invigorate",
             "text": "If you control a Forest, rather than pay this spell's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "3c7c2c6e-2dbd-5ad6-9143-80be150b3988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8614f43-21c3-47cd-894a-8cc952bc561a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8614f43-21c3-47cd-894a-8cc952bc561a.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "85e0c859-c7ca-558c-909e-1db920aac789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dea9d0-9f93-460d-bf69-ae1c1172a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dea9d0-9f93-460d-bf69-ae1c1172a95e.jpg?1",
             "name": "Liege of the Tangle",
             "text": "Trample\nWhenever Liege of the Tangle deals combat damage to a player, you may choose any number of target lands you control and put an awakening counter on each of them. Each of those lands is an 8/8 green Elemental creature for as long as it has an awakening counter on it. They're still lands.",
             "colours": [
@@ -5906,7 +5906,7 @@
         },
         {
             "id": "85e82f91-01a1-5584-b0fd-d8b88f848aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e0d739-990f-4ba5-b456-165c033014cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e0d739-990f-4ba5-b456-165c033014cf.jpg?1",
             "name": "Mana Reflection",
             "text": "If you tap a permanent for mana, it produces twice as much of that mana instead.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "3aefff7a-e5dd-5d90-a971-6b0bf4311a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9900f47d-e1ec-411d-92f3-aed8e01ee535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9900f47d-e1ec-411d-92f3-aed8e01ee535.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "df4a0c0d-9e09-5de4-a16a-274509fa3cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400382a4-aea2-4827-b06a-1b0b3745908b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400382a4-aea2-4827-b06a-1b0b3745908b.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U}.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "d7a0488f-df8d-55e3-a1ec-1d3809e9a8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e378a-f033-44ca-8295-855382cc838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e378a-f033-44ca-8295-855382cc838d.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -6044,7 +6044,7 @@
         },
         {
             "id": "19b5842b-7936-5cb9-a4f2-44aaa20c93e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5945a80f-b604-4b15-a016-e2dfddeb95ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5945a80f-b604-4b15-a016-e2dfddeb95ba.jpg?1",
             "name": "Shamanic Revelation",
             "text": "Draw a card for each creature you control.\nFerocious \u2014 You gain 4 life for each creature you control with power 4 or greater.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "f87f0d3c-6707-5db0-ac85-f4012a22c33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88f730-2817-4f15-b785-c0dccbb6bf11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88f730-2817-4f15-b785-c0dccbb6bf11.jpg?1",
             "name": "Skullmulcher",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nWhen Skullmulcher enters the battlefield, draw a card for each creature it devoured.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "0734b636-4790-5269-9470-fc498f4aac25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e1ecf4-bf72-4ae9-9993-9b9a6ca80da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e1ecf4-bf72-4ae9-9993-9b9a6ca80da7.jpg?1",
             "name": "Sylvan Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nFlashback {2}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "692a1ec9-9d61-5265-b83a-7fad214a3df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cf30a6-8071-4628-8846-20a2cf4e622e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cf30a6-8071-4628-8846-20a2cf4e622e.jpg?1",
             "name": "Terastodon",
             "text": "When Terastodon enters the battlefield, you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -6176,7 +6176,7 @@
         },
         {
             "id": "3ad3a656-ecd2-52eb-a1c5-666937ff5dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8459b-4dea-4dc9-8b95-a3748472f699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8459b-4dea-4dc9-8b95-a3748472f699.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "bc6bb700-3c01-5a8b-97ac-713223927330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1614bad6-07db-4a7c-8336-3ac3db393689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1614bad6-07db-4a7c-8336-3ac3db393689.jpg?1",
             "name": "Ulvenwald Mysteries",
             "text": "Whenever a nontoken creature you control dies, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -6242,7 +6242,7 @@
         },
         {
             "id": "ef7389f9-e6da-566e-91dd-b9518994bbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5631668d-75f2-4d2d-b644-90c073c7be21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5631668d-75f2-4d2d-b644-90c073c7be21.jpg?1",
             "name": "Vengevine",
             "text": "Haste\nWhenever you cast a spell, if it's the second creature spell you cast this turn, you may return Vengevine from your graveyard to the battlefield.",
             "colours": [
@@ -6276,7 +6276,7 @@
         },
         {
             "id": "557a214b-8127-57e7-9646-1fdfb2c358be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6c19cc-6469-4958-a547-1d0fe97c70e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6c19cc-6469-4958-a547-1d0fe97c70e8.jpg?1",
             "name": "Veteran Explorer",
             "text": "When Veteran Explorer dies, each player may search their library for up to two basic land cards and put them onto the battlefield. Then each player who searched their library this way shuffles it.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "f3293bdc-2484-5c8a-9244-7228b9c59a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf17d8a-c7ee-4909-bc80-4138dcfe7e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf17d8a-c7ee-4909-bc80-4138dcfe7e67.jpg?1",
             "name": "Whisperer of the Wilds",
             "text": "{T}: Add {G}.\nFerocious \u2014 {T}: Add {G}{G}. Activate this ability only if you control a creature with power 4 or greater.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "80b32090-d254-5f78-8a15-1ee0fd99bbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021bc8f5-3992-4d6a-9806-ed43c89e99f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021bc8f5-3992-4d6a-9806-ed43c89e99f2.jpg?1",
             "name": "Woodland Champion",
             "text": "Whenever one or more tokens enter the battlefield under your control, put that many +1/+1 counters on Woodland Champion.",
             "colours": [
@@ -6382,7 +6382,7 @@
         },
         {
             "id": "3afd5bc6-d872-5502-b230-067159472137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881607c8-bfe7-4903-861f-b51a5a332c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881607c8-bfe7-4903-861f-b51a5a332c17.jpg?1",
             "name": "Arixmethes, Slumbering Isle",
             "text": "Arixmethes, Slumbering Isle enters the battlefield tapped with five slumber counters on it.\nAs long as Arixmethes has a slumber counter on it, it's a land. (It's not a creature.)\nWhenever you cast a spell, you may remove a slumber counter from Arixmethes.\n{T}: Add {G}{U}.",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "09472571-34c7-5636-963c-a8ff6aa96f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d33d52-3d28-4635-b985-51e126289259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d33d52-3d28-4635-b985-51e126289259.jpg?1",
             "name": "Atraxa, Praetors' Voice",
             "text": "Flying, vigilance, deathtouch, lifelink\nAt the beginning of your end step, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "7accc40a-e84c-5858-a415-1d2f5b96e823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b799b2-bb4e-482f-9afd-5aab90090710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b799b2-bb4e-482f-9afd-5aab90090710.jpg?1",
             "name": "Baleful Strix",
             "text": "Flying, deathtouch\nWhen Baleful Strix enters the battlefield, draw a card.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "35fbfa3d-44fc-51aa-8b32-26ebd75c1f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f700-7311-46a4-ad9b-4e743a345785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f700-7311-46a4-ad9b-4e743a345785.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "0d9d021f-9e3e-5da4-b190-6420f756b3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff27a-eb58-4a95-b2df-4a341cf9bef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff27a-eb58-4a95-b2df-4a341cf9bef6.jpg?1",
             "name": "Brudiclad, Telchor Engineer",
             "text": "Creature tokens you control have haste.\nAt the beginning of combat on your turn, create a 2/1 blue Myr artifact creature token. Then you may choose a token you control. If you do, each other token you control becomes a copy of that token.",
             "colours": [
@@ -6586,7 +6586,7 @@
         },
         {
             "id": "6642095b-d59f-570e-8f11-6f6a3df31173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6346a-5154-4c93-9a24-8b1936683517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6346a-5154-4c93-9a24-8b1936683517.jpg?1",
             "name": "Deathreap Ritual",
             "text": "Morbid \u2014 At the beginning of each end step, if a creature died this turn, you may draw a card.",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "11b1543b-aa11-55d6-a2b4-4de19a4fc186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ac7f19-bf6f-4a87-ad39-6eb2553d2202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ac7f19-bf6f-4a87-ad39-6eb2553d2202.jpg?1",
             "name": "Falkenrath Aristocrat",
             "text": "Flying, haste\nSacrifice a creature: Falkenrath Aristocrat gains indestructible until end of turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.",
             "colours": [
@@ -6657,7 +6657,7 @@
         },
         {
             "id": "c82ab013-45a3-55ca-a31b-02038d282af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420d1ea2-23f9-4650-993e-de99eedaa587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420d1ea2-23f9-4650-993e-de99eedaa587.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -6694,7 +6694,7 @@
         },
         {
             "id": "c788ba7a-7a54-5ff3-83d8-fa084b69e632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6554820-e501-44d4-9141-7c83f81d3fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6554820-e501-44d4-9141-7c83f81d3fd7.jpg?1",
             "name": "Geist of Saint Traft",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Geist of Saint Traft attacks, create a 4/4 white Angel creature token with flying that's tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "c33e7882-ed2a-5702-aa77-cf89c36bf6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aae3f29-dde8-4880-b675-75468d53b3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aae3f29-dde8-4880-b675-75468d53b3f4.jpg?1",
             "name": "Ghor-Clan Rampager",
             "text": "Trample\nBloodrush \u2014 {R}{G}, Discard Ghor-Clan Rampager: Target attacking creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "061279d5-1f12-5c32-a56e-4dd5993dd981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a8c38-c968-4337-88b3-b0b03b249a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a8c38-c968-4337-88b3-b0b03b249a4b.jpg?1",
             "name": "Glassdust Hulk",
             "text": "Whenever another artifact enters the battlefield under your control, Glassdust Hulk gets +1/+1 until end of turn and can't be blocked this turn.\nCycling {WU} ({WU}, Discard this card: Draw a card.)",
             "colours": [
@@ -6806,7 +6806,7 @@
         },
         {
             "id": "839a69a1-7a89-5043-aaa6-d47ecb7118cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16352af7-c001-41e8-8052-cd98997aebbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16352af7-c001-41e8-8052-cd98997aebbb.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "0c702ed0-d1f2-59ff-a994-baa643e7c559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9119c90-716b-4884-9b1e-471f262c2639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9119c90-716b-4884-9b1e-471f262c2639.jpg?1",
             "name": "Hidden Stockpile",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.\n{1}, Sacrifice a creature: Scry 1.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "f3a09b1f-8a6e-5224-8f8b-c5f0c4a3ac7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8f0789-aa08-4ce5-8ed1-6544de1e3ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8f0789-aa08-4ce5-8ed1-6544de1e3ed4.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Izzet Charm deals 2 damage to target creature.\n\u2022 Draw two cards, then discard two cards.",
             "colours": [
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "d57c1a70-972f-51ef-ab7f-5133763c4490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f77d23d-6257-4dae-b585-29f45f13f2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f77d23d-6257-4dae-b585-29f45f13f2e2.jpg?1",
             "name": "Jhoira, Weatherlight Captain",
             "text": "Whenever you cast a historic spell, draw a card. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "62514af8-a9a4-59c5-bf13-4b3252e1d9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc9eaf-c8d9-4da2-8fd8-8d423a02a3a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc9eaf-c8d9-4da2-8fd8-8d423a02a3a8.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -6995,7 +6995,7 @@
         },
         {
             "id": "10ca5b9b-5c29-5e9e-a0ad-5292540574c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfb85e8-278b-48a4-970e-e65bad1c4c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfb85e8-278b-48a4-970e-e65bad1c4c47.jpg?1",
             "name": "Karrthus, Tyrant of Jund",
             "text": "Flying, haste\nWhen Karrthus, Tyrant of Jund enters the battlefield, gain control of all Dragons, then untap all Dragons.\nOther Dragon creatures you control have haste.",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "d4240a95-d89b-5a5a-ad51-82f0f30896d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e514b13d-2d22-4d9e-a501-b0667f02edac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e514b13d-2d22-4d9e-a501-b0667f02edac.jpg?1",
             "name": "Maelstrom Nexus",
             "text": "The first spell you cast each turn has cascade. (When you cast your first spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -7075,7 +7075,7 @@
         },
         {
             "id": "50d5a4ca-6a62-5a2b-8e68-742b7f6aa916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ab73f-2759-43b6-9ae8-ca33a55ebf80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ab73f-2759-43b6-9ae8-ca33a55ebf80.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -7109,7 +7109,7 @@
         },
         {
             "id": "e2c60f1d-ead4-5f06-a25d-50176c0b2dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf9070e-14be-4ce5-a19a-6addc79359c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf9070e-14be-4ce5-a19a-6addc79359c1.jpg?1",
             "name": "Manamorphose",
             "text": "Add two mana in any combination of colors.\nDraw a card.",
             "colours": [
@@ -7143,7 +7143,7 @@
         },
         {
             "id": "eaaf9cc5-6175-59da-b661-8f77e79a5fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fb8520-1bc4-40e7-a4cc-2933ed7e0c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fb8520-1bc4-40e7-a4cc-2933ed7e0c00.jpg?1",
             "name": "Mazirek, Kraul Death Priest",
             "text": "Flying\nWhenever a player sacrifices another permanent, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -7182,7 +7182,7 @@
         },
         {
             "id": "5a7b685a-0e13-5937-9f13-f65d82270728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de734753-e102-489b-9160-b3f3d10be4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de734753-e102-489b-9160-b3f3d10be4f1.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage enters the battlefield, choose a nonland card name.\nSpells with the chosen name can't be cast.",
             "colours": [
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "7f467453-1dde-516c-862e-3a9f2d11a407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f160f304-64a2-4211-afa6-65acb5b686f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f160f304-64a2-4211-afa6-65acb5b686f7.jpg?1",
             "name": "Merciless Eviction",
             "text": "Choose one \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all planeswalkers.",
             "colours": [
@@ -7255,7 +7255,7 @@
         },
         {
             "id": "a72b71ee-33ae-520d-9d31-0176ad5cfc62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acba72e1-3f7f-4e5c-af3f-dfe37b5d61f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acba72e1-3f7f-4e5c-af3f-dfe37b5d61f9.jpg?1",
             "name": "Progenitor Mimic",
             "text": "You may have Progenitor Mimic enter the battlefield as a copy of any creature on the battlefield, except it has \"At the beginning of your upkeep, if this creature isn't a token, create a token that's a copy of this creature.\"",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "5997ef7e-9611-529d-8a06-0e76783cccde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91dadcb-31e9-43b0-b425-c9311af3e9d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91dadcb-31e9-43b0-b425-c9311af3e9d7.jpg?1",
             "name": "Rhys the Redeemed",
             "text": "{2}{RW}, {T}: Create a 1/1 green and white Elf Warrior creature token.\n{4}{RW}{RW}, {T}: For each creature token you control, create a token that's a copy of that creature.",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "a8d8e790-8c57-5104-9915-6f69a00d335b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dd138f-391a-4956-bc2a-fe186429c71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dd138f-391a-4956-bc2a-fe186429c71a.jpg?1",
             "name": "Riku of Two Reflections",
             "text": "Whenever you cast an instant or sorcery spell, you may pay {U}{R}. If you do, copy that spell. You may choose new targets for the copy.\nWhenever another nontoken creature enters the battlefield under your control, you may pay {G}{U}. If you do, create a token that's a copy of that creature.",
             "colours": [
@@ -7371,7 +7371,7 @@
         },
         {
             "id": "b583e7e0-216a-5e7d-b9c6-2576514dc810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0ef33b-d2bf-4d8b-a7ba-604a37ca5c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0ef33b-d2bf-4d8b-a7ba-604a37ca5c14.jpg?1",
             "name": "Savageborn Hydra",
             "text": "Double strike\nSavageborn Hydra enters the battlefield with X +1/+1 counters on it.\n{1}{RG}: Put a +1/+1 counter on Savageborn Hydra. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "eed81bd3-096f-5757-9516-0c86485953d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ee141-0ea6-45d6-a682-96a37d703394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ee141-0ea6-45d6-a682-96a37d703394.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "678c131a-6ec4-54e7-856b-8dfa8fa0729f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209ed4c-207f-4e37-8c92-255f8b8eb3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209ed4c-207f-4e37-8c92-255f8b8eb3d1.jpg?1",
             "name": "Selesnya Guildmage",
             "text": "{3}{G}: Create a 1/1 green Saproling creature token.\n{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "5cb2c20c-9865-54ce-a3d3-d1b59e0a02ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac5292-9817-4f5d-b3fa-611f9ba44443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac5292-9817-4f5d-b3fa-611f9ba44443.jpg?1",
             "name": "Sen Triplets",
             "text": "At the beginning of your upkeep, choose target opponent. This turn, that player can't cast spells or activate abilities and plays with their hand revealed. You may play lands and cast spells from that player's hand this turn.",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "a04ced15-50bb-5d34-b5f0-6273369485f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af80ef38-ab95-476f-b0dd-b5ef3e9bceab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af80ef38-ab95-476f-b0dd-b5ef3e9bceab.jpg?1",
             "name": "Sharuum the Hegemon",
             "text": "Flying\nWhen Sharuum the Hegemon enters the battlefield, you may return target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -7565,7 +7565,7 @@
         },
         {
             "id": "9d6f4f0c-ba84-5904-b356-0b162b1c34c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad955c4d-248b-4468-a975-abad97cf84a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad955c4d-248b-4468-a975-abad97cf84a4.jpg?1",
             "name": "Sphinx Summoner",
             "text": "Flying\nWhen Sphinx Summoner enters the battlefield, you may search your library for an artifact creature card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "174fbff1-7570-5087-86d0-d6a4c700d583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a89a8f-b3a7-4c38-80fb-b5484ddbf8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a89a8f-b3a7-4c38-80fb-b5484ddbf8ec.jpg?1",
             "name": "Swiftblade Vindicator",
             "text": "Double strike, vigilance, trample",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "2931f6e6-8913-5504-9db1-eb4c2cf2138c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8dcd5e-d4d0-49ae-a591-78d80322105d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8dcd5e-d4d0-49ae-a591-78d80322105d.jpg?1",
             "name": "Thopter Foundry",
             "text": "{1}, Sacrifice a nontoken artifact: Create a 1/1 blue Thopter artifact creature token with flying. You gain 1 life.",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "10c4baba-dbe2-55b6-80f2-8d907d7cb209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8b424-0cec-490e-a571-bd051f952adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8b424-0cec-490e-a571-bd051f952adf.jpg?1",
             "name": "Time Sieve",
             "text": "{T}, Sacrifice five artifacts: Take an extra turn after this one.",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "c31ad170-9dc1-5c1f-a20e-cf8d44857023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402c2c37-9439-4393-b9d7-d7abe8045d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402c2c37-9439-4393-b9d7-d7abe8045d4d.jpg?1",
             "name": "Unlicensed Disintegration",
             "text": "Destroy target creature. If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller.",
             "colours": [
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "4852ed44-c6b6-568d-9581-a3b85b951c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0acfb7-c2d9-4b94-9ac6-9374856abad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0acfb7-c2d9-4b94-9ac6-9374856abad1.jpg?1",
             "name": "Vexing Shusher",
             "text": "This spell can't be countered.\n{RG}: Target spell can't be countered.",
             "colours": [
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "a637874c-282a-5d6f-8ba0-1160880a7949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5f9d21-4cc9-4b7e-9f55-322dcf91c1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5f9d21-4cc9-4b7e-9f55-322dcf91c1b7.jpg?1",
             "name": "Vish Kal, Blood Arbiter",
             "text": "Flying, lifelink\nSacrifice a creature: Put X +1/+1 counters on Vish Kal, Blood Arbiter, where X is the sacrificed creature's power.\nRemove all +1/+1 counters from Vish Kal: Target creature gets -1/-1 until end of turn for each +1/+1 counter removed this way.",
             "colours": [
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "6d0eb160-0cef-55cb-b18a-03f04b35767c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d1e843-71c9-4a65-bc36-d23858ef5ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d1e843-71c9-4a65-bc36-d23858ef5ead.jpg?1",
             "name": "Voice of Resurgence",
             "text": "Whenever an opponent casts a spell during your turn or when Voice of Resurgence dies, create a green and white Elemental creature token with \"This creature's power and toughness are each equal to the number of creatures you control.\"",
             "colours": [
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "d86e7f2e-67d1-5dcb-83ab-2ebb91055cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaa5ed4-041d-47d6-a4e0-baf8910430ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaa5ed4-041d-47d6-a4e0-baf8910430ed.jpg?1",
             "name": "Weapons Trainer",
             "text": "Other creatures you control get +1/+0 as long as you control an Equipment.",
             "colours": [
@@ -7892,7 +7892,7 @@
         },
         {
             "id": "0098d837-df32-5b07-9c7a-6b6d48d790d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac29eb6-2770-4723-942b-b393c2abc02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac29eb6-2770-4723-942b-b393c2abc02b.jpg?1",
             "name": "Yavimaya's Embrace",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets +2/+2 and has trample.",
             "colours": [
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "da3b4163-ec84-50ef-b17e-6f7d2f0b9b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa453daf-6ceb-4e45-bfb3-f6f45835ac11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa453daf-6ceb-4e45-bfb3-f6f45835ac11.jpg?1",
             "name": "Accomplished Automaton",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "a7f26cad-b758-5e0d-9cc4-9cc183f6c891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba16bfb3-dbd3-4b3a-b155-08b613268d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba16bfb3-dbd3-4b3a-b155-08b613268d57.jpg?1",
             "name": "Adaptive Automaton",
             "text": "As Adaptive Automaton enters the battlefield, choose a creature type.\nAdaptive Automaton is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "60d2a6aa-1fd3-5dae-b02e-99961460bcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79de5e7-1545-420c-bfe1-ee2444fca85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79de5e7-1545-420c-bfe1-ee2444fca85b.jpg?1",
             "name": "Basalt Monolith",
             "text": "Basalt Monolith doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{3}: Untap Basalt Monolith.",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "85ddf0ff-ce28-58a9-a22d-4c8ad0b4ae6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f3f0d-0609-46f0-a7b6-d933c4131f5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f3f0d-0609-46f0-a7b6-d933c4131f5c.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "691af5ad-c30b-5ce5-bd68-7f93a29bcf3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f16fdf-a3f5-462d-a64a-789d893b6ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f16fdf-a3f5-462d-a64a-789d893b6ef5.jpg?1",
             "name": "Batterskull",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return Batterskull to its owner's hand.\nEquip {5}",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "fa62fc90-4b85-582b-a775-2d1a8d900ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18adbda4-8d36-47cd-afbc-c785aaa8ed80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18adbda4-8d36-47cd-afbc-c785aaa8ed80.jpg?1",
             "name": "Blightsteel Colossus",
             "text": "Trample, infect, indestructible\nIf Blightsteel Colossus would be put into a graveyard from anywhere, reveal Blightsteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -8114,7 +8114,7 @@
         },
         {
             "id": "778fea48-fe4a-5131-9be9-c8bda0504501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90055174-ad09-4a0b-b65a-10ad80727d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90055174-ad09-4a0b-b65a-10ad80727d8e.jpg?1",
             "name": "Bosh, Iron Golem",
             "text": "Trample\n{3}{R}, Sacrifice an artifact: Bosh, Iron Golem deals damage equal to the sacrificed artifact's converted mana cost to any target.",
             "colours": [],
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "f9cdadf4-ad28-535d-9df8-b5c182814f37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ddba34-e627-4f4c-b78c-ea0c48a22537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ddba34-e627-4f4c-b78c-ea0c48a22537.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion dies, add {C}{C}{C}.",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "dc8cac42-15a4-52c7-b64f-c34a57afb550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf306f7f-b231-4343-807c-083df8b90c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf306f7f-b231-4343-807c-083df8b90c87.jpg?1",
             "name": "Chief of the Foundry",
             "text": "Other artifact creatures you control get +1/+1.",
             "colours": [],
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "14fb295b-1ba9-5a7c-9104-b32fb972d20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117fded3-1157-41a3-b37a-e76dcd1b5447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117fded3-1157-41a3-b37a-e76dcd1b5447.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color.\nWhen Chromatic Star is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "0788dfb0-f4d8-54c0-b158-ee2a644521b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340cbf7-5bbe-45b9-a4bf-d1caa500ff93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340cbf7-5bbe-45b9-a4bf-d1caa500ff93.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint \u2014 When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors.",
             "colours": [],
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "ddf5e2cb-2693-59a2-b861-5b4d670ad803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627ec9-f75c-4a9d-8a4f-1f632a67e17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627ec9-f75c-4a9d-8a4f-1f632a67e17b.jpg?1",
             "name": "Clone Shell",
             "text": "Imprint \u2014 When Clone Shell enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library in any order.\nWhen Clone Shell dies, turn the exiled card face up. If it's a creature card, put it onto the battlefield under your control.",
             "colours": [],
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "b80d3cf8-7ff6-55f7-8ded-7d6bd6211965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfde3f-f7d3-4902-b3cd-23f3fa53eff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfde3f-f7d3-4902-b3cd-23f3fa53eff4.jpg?1",
             "name": "Cogwork Assembler",
             "text": "{7}: Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "35620027-44d5-5da0-a3a9-50a4af80b136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3435fd09-a7a2-475e-a690-3c2011b70024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3435fd09-a7a2-475e-a690-3c2011b70024.jpg?1",
             "name": "Conjurer's Closet",
             "text": "At the beginning of your end step, you may exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [],
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "54c73f76-e8f9-54b7-925b-687016197c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572083a6-e105-43d8-ae72-e1701611f729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572083a6-e105-43d8-ae72-e1701611f729.jpg?1",
             "name": "Coretapper",
             "text": "{T}: Put a charge counter on target artifact.\nSacrifice Coretapper: Put two charge counters on target artifact.",
             "colours": [],
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "dc6d9b79-787c-5992-8e46-8938ce05fe4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1375f17-bc25-4a65-98b7-4785bbdbe974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1375f17-bc25-4a65-98b7-4785bbdbe974.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1}",
             "colours": [],
@@ -8422,7 +8422,7 @@
         },
         {
             "id": "ce0b2121-f514-565b-9418-e51a660222ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dc8c2a-928d-465e-8f76-82a90cc66854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dc8c2a-928d-465e-8f76-82a90cc66854.jpg?1",
             "name": "Culling Dais",
             "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
             "colours": [],
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "69953bd8-5cfb-5fd5-b2c9-ca5aedbe4ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6bfe57-872d-4f69-bff5-a3f2584d6e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6bfe57-872d-4f69-bff5-a3f2584d6e0a.jpg?1",
             "name": "Darksteel Axe",
             "text": "Indestructible\nEquipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "704eb2ef-caaa-5bbd-8684-b9b0fb66da62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421089c4-c8d3-48c5-b313-fb1741546271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421089c4-c8d3-48c5-b313-fb1741546271.jpg?1",
             "name": "Darksteel Forge",
             "text": "Artifacts you control have indestructible.",
             "colours": [],
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "80492ffe-a7c0-5ac8-83b3-526a2755cfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b39497c-79fc-437b-9d63-86d906c0455a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b39497c-79fc-437b-9d63-86d906c0455a.jpg?1",
             "name": "Duplicant",
             "text": "Imprint \u2014 When Duplicant enters the battlefield, you may exile target nontoken creature.\nAs long as a card exiled with Duplicant is a creature card, Duplicant has the power, toughness, and creature types of the last creature card exiled with Duplicant. It's still a Shapeshifter.",
             "colours": [],
@@ -8539,7 +8539,7 @@
         },
         {
             "id": "3ec0fd78-b9f4-5d02-b7ed-0421433ba1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b23ca61-157b-4616-bbf4-0c1298ddbbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b23ca61-157b-4616-bbf4-0c1298ddbbb4.jpg?1",
             "name": "Eager Construct",
             "text": "When Eager Construct enters the battlefield, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [],
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "9dc6a71f-2fe8-518e-8291-96cc9fb78d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a39fc25-f9f0-44ab-a94c-9720f8722620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a39fc25-f9f0-44ab-a94c-9720f8722620.jpg?1",
             "name": "Endless Atlas",
             "text": "{2}, {T}: Draw a card. Activate this ability only if you control three or more lands with the same name.",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "1d556750-351d-5c20-8c1f-21978ec8a743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420bf1e9-f2ec-4dff-b540-e64de71e58be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420bf1e9-f2ec-4dff-b540-e64de71e58be.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "fb734f32-6678-59bb-845a-548878d43aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf825a56-4870-463a-a2ef-eec86be891db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf825a56-4870-463a-a2ef-eec86be891db.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "982635ea-d722-5275-804f-ecbe774da065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd8112f-21e0-4272-9f0d-14d1ef989779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd8112f-21e0-4272-9f0d-14d1ef989779.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "8debbb01-9749-50f4-b280-4304e0f3cd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551c0a45-9515-4e51-84e5-79703832a661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551c0a45-9515-4e51-84e5-79703832a661.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "1fd37b49-dbe2-50b4-98ae-c79a5a61fcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b394f9-644d-426e-801b-110774092018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b394f9-644d-426e-801b-110774092018.jpg?1",
             "name": "Flayer Husk",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nEquip {2}",
             "colours": [],
@@ -8742,7 +8742,7 @@
         },
         {
             "id": "b108243c-71f0-52f6-a877-ac14227a3e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410c7922-5d99-4b94-bcdb-4f02ca175e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410c7922-5d99-4b94-bcdb-4f02ca175e65.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen Gleaming Barrier dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "417210e8-94db-540d-b12f-9ee358d2c973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ef4e1-52a5-4e73-9f71-5f12c96c8caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ef4e1-52a5-4e73-9f71-5f12c96c8caf.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -8804,7 +8804,7 @@
         },
         {
             "id": "032c606c-4222-5720-89bd-fde520bffaeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198804-a247-46b9-be6e-71bbb5840401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198804-a247-46b9-be6e-71bbb5840401.jpg?1",
             "name": "Golem-Skin Gauntlets",
             "text": "Equipped creature gets +1/+0 for each Equipment attached to it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8834,7 +8834,7 @@
         },
         {
             "id": "3ec7d1d5-5ef0-525b-92f8-ff98915c185c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbce79af-968a-481b-8cd7-a323c083851d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbce79af-968a-481b-8cd7-a323c083851d.jpg?1",
             "name": "Hammer of Nazahn",
             "text": "Whenever Hammer of Nazahn or another Equipment enters the battlefield under your control, you may attach that Equipment to target creature you control.\nEquipped creature gets +2/+0 and has indestructible.\nEquip {4}",
             "colours": [],
@@ -8866,7 +8866,7 @@
         },
         {
             "id": "3ce20325-2172-5e88-93f3-154ac6da6bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce84c30-5d59-4f0d-af44-96b993f3902f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce84c30-5d59-4f0d-af44-96b993f3902f.jpg?1",
             "name": "Ichor Wellspring",
             "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -8894,7 +8894,7 @@
         },
         {
             "id": "d88f923f-d7e0-5b46-92b9-f3c050a75e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545521f8-ab61-4f18-b290-16cd2c2d505e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545521f8-ab61-4f18-b290-16cd2c2d505e.jpg?1",
             "name": "Iron Bully",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Iron Bully enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "f1ae6bce-ce12-5406-9a67-fb6313c9cf75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60370058-da94-444b-aafd-23202296070b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60370058-da94-444b-aafd-23202296070b.jpg?1",
             "name": "Iron League Steed",
             "text": "Haste\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -8956,7 +8956,7 @@
         },
         {
             "id": "64220263-9879-58c2-b910-92cde60b2f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa24fe0-e275-4307-b26c-2a656068a451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa24fe0-e275-4307-b26c-2a656068a451.jpg?1",
             "name": "Isochron Scepter",
             "text": "Imprint \u2014 When Isochron Scepter enters the battlefield, you may exile an instant card with converted mana cost 2 or less from your hand.\n{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its mana cost.",
             "colours": [],
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "81c8ec18-70d3-5f0e-9135-39f87bfaee7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b89a074-9aca-4f7f-953a-b401199be1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b89a074-9aca-4f7f-953a-b401199be1cb.jpg?1",
             "name": "Jhoira's Familiar",
             "text": "Flying\nHistoric spells you cast cost {1} less to cast. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -9015,7 +9015,7 @@
         },
         {
             "id": "ea258112-1b50-5139-9e15-5783e1bc8007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c768267f-5ad2-4f4d-bbc7-6639325401c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c768267f-5ad2-4f4d-bbc7-6639325401c7.jpg?1",
             "name": "Kuldotha Forgemaster",
             "text": "{T}, Sacrifice three artifacts: Search your library for an artifact card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -9046,7 +9046,7 @@
         },
         {
             "id": "c29d9ba2-2197-54f8-b1f1-ffcd16718e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cec97f-0a2b-4543-a02e-d5e42d337790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cec97f-0a2b-4543-a02e-d5e42d337790.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -9078,7 +9078,7 @@
         },
         {
             "id": "b42db7ea-3105-5fb5-94d9-1160398bca7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b7fee-100b-444e-9f13-45b36fd10295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b7fee-100b-444e-9f13-45b36fd10295.jpg?1",
             "name": "Lux Cannon",
             "text": "{T}: Put a charge counter on Lux Cannon.\n{T}, Remove three charge counters from Lux Cannon: Destroy target permanent.",
             "colours": [],
@@ -9106,7 +9106,7 @@
         },
         {
             "id": "75449cdc-2490-58f6-9a82-af9ebc80b325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c879b-c566-431e-a8fa-6104c39b6d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c879b-c566-431e-a8fa-6104c39b6d7c.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -9134,7 +9134,7 @@
         },
         {
             "id": "583bf60c-cbde-52b0-8051-977206ef497b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d960186-4559-4af0-bd22-63baa15f8939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d960186-4559-4af0-bd22-63baa15f8939.jpg?1",
             "name": "Mana Crypt",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -9164,7 +9164,7 @@
         },
         {
             "id": "4d2599ca-cd0b-5dd9-bc91-365329ec1c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af244fed-ea12-4d8c-b090-91c5de62edb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af244fed-ea12-4d8c-b090-91c5de62edb8.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "You may have Masterwork of Ingenuity enter the battlefield as a copy of any Equipment on the battlefield.",
             "colours": [],
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "42df2acc-f685-5202-8463-c0b5bed6176d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fbdbb-f2ae-4823-9d2a-4c505332aa5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fbdbb-f2ae-4823-9d2a-4c505332aa5b.jpg?1",
             "name": "Mesmeric Orb",
             "text": "Whenever a permanent becomes untapped, that permanent's controller mills a card. (They put the top card of their library into their graveyard.)",
             "colours": [],
@@ -9222,7 +9222,7 @@
         },
         {
             "id": "a221382a-91ed-54f2-ad78-df53ae7ea881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3e1c7a-5672-4f76-9e04-a18cf0089fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3e1c7a-5672-4f76-9e04-a18cf0089fa7.jpg?1",
             "name": "Metalspinner's Puzzleknot",
             "text": "When Metalspinner's Puzzleknot enters the battlefield, you draw a card and you lose 1 life.\n{2}{B}, Sacrifice Metalspinner's Puzzleknot: You draw a card and you lose 1 life.",
             "colours": [],
@@ -9252,7 +9252,7 @@
         },
         {
             "id": "265a1471-d133-50b5-8bb8-bd0fdc241e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbbf9b-8fee-4c32-a513-02dac6ac8a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbbf9b-8fee-4c32-a513-02dac6ac8a39.jpg?1",
             "name": "Mishra's Bauble",
             "text": "{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "71b15a22-9e76-585f-b10c-10394291d5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56001a36-126b-4c08-af98-a6cc4d84210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56001a36-126b-4c08-af98-a6cc4d84210e.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -9312,7 +9312,7 @@
         },
         {
             "id": "930aeec3-c68e-5705-9bb1-9ed156fc3b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31837c7c-267a-4483-8712-406bfa7c4fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31837c7c-267a-4483-8712-406bfa7c4fde.jpg?1",
             "name": "Myr Battlesphere",
             "text": "When Myr Battlesphere enters the battlefield, create four 1/1 colorless Myr artifact creature tokens.\nWhenever Myr Battlesphere attacks, you may tap X untapped Myr you control. If you do, Myr Battlesphere gets +X/+0 until end of turn and deals X damage to the player or planeswalker it's attacking.",
             "colours": [],
@@ -9344,7 +9344,7 @@
         },
         {
             "id": "57ed239a-8f63-5329-966b-ea6662d74aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0149d4-0731-474a-a1c3-28c25e486c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0149d4-0731-474a-a1c3-28c25e486c14.jpg?1",
             "name": "Myr Retriever",
             "text": "When Myr Retriever dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "141bb905-a5a4-5fd9-9f8b-265e27db498b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08db5b31-6b5a-4b99-b103-d628afaea2ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08db5b31-6b5a-4b99-b103-d628afaea2ba.jpg?1",
             "name": "O-Naginata",
             "text": "O-Naginata can be attached only to a creature with power 3 or greater.\nEquipped creature gets +3/+0 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "dd5f2903-9362-59f5-9ab3-d19844a59568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbbeaf1-92ac-4ea4-8733-2da6af870542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbbeaf1-92ac-4ea4-8733-2da6af870542.jpg?1",
             "name": "Oblivion Stone",
             "text": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice Oblivion Stone: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "9224bce6-f8cc-5767-ae7c-69f42ddedf92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9bd97-f256-4dcd-b2a7-3239d443a0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9bd97-f256-4dcd-b2a7-3239d443a0af.jpg?1",
             "name": "Peace Strider",
             "text": "When Peace Strider enters the battlefield, you gain 3 life.",
             "colours": [],
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "25c91158-c5dc-52eb-aa37-5adb70e0c8fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2862c5-afa8-4e38-a312-483300f8b194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2862c5-afa8-4e38-a312-483300f8b194.jpg?1",
             "name": "Pentad Prism",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\nRemove a charge counter from Pentad Prism: Add one mana of any color.",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "0354c49b-7f88-5be8-a025-b8b10f9bf201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6982a82c-dd32-40d2-8dd2-ec92d0fc6c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6982a82c-dd32-40d2-8dd2-ec92d0fc6c2d.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, choose a nonland card name.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -9524,7 +9524,7 @@
         },
         {
             "id": "eec2052e-3f30-5fdf-b40c-4665968af48d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088c801d-381f-403b-aeb7-fbbfafee99bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088c801d-381f-403b-aeb7-fbbfafee99bf.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "{R}, Sacrifice Pyrite Spellbomb: It deals 2 damage to any target.\n{1}, Sacrifice Pyrite Spellbomb: Draw a card.",
             "colours": [],
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "27d81532-dae5-5508-a1b9-5ba09fc033e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd85da-9aba-46ea-9c10-617bec99a2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd85da-9aba-46ea-9c10-617bec99a2f5.jpg?1",
             "name": "Ratchet Bomb",
             "text": "{T}: Put a charge counter on Ratchet Bomb.\n{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "59a501d5-fa17-57f4-8111-4225b2ceb9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2847c7-2d48-48ca-8cc3-3c9a154ed69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2847c7-2d48-48ca-8cc3-3c9a154ed69d.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "df7765c9-6518-546a-b0fe-8622c7727cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54dc9-3b27-4e90-a423-3aeeb4cedb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54dc9-3b27-4e90-a423-3aeeb4cedb06.jpg?1",
             "name": "Sculpting Steel",
             "text": "You may have Sculpting Steel enter the battlefield as a copy of any artifact on the battlefield.",
             "colours": [],
@@ -9641,7 +9641,7 @@
         },
         {
             "id": "71b80e77-4126-5457-a7a1-5e6ae2257163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f449cc-461e-4e89-8cd2-83e539bb40f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f449cc-461e-4e89-8cd2-83e539bb40f4.jpg?1",
             "name": "Sickleslicer",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +2/+2.\nEquip {4}",
             "colours": [],
@@ -9671,7 +9671,7 @@
         },
         {
             "id": "6cf3c6ef-d08b-5969-8b24-4b4a4353513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c65e0ff-7dab-4090-8a99-f42d486728c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c65e0ff-7dab-4090-8a99-f42d486728c9.jpg?1",
             "name": "Skinwing",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +2/+2 and has flying.\nEquip {6}",
             "colours": [],
@@ -9701,7 +9701,7 @@
         },
         {
             "id": "d206ab68-7c2b-51b0-8833-7fe3f151cb45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9bf341-0060-467d-99b3-a5bc7f2270b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9bf341-0060-467d-99b3-a5bc7f2270b8.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "d0d48f5e-de5b-5205-85ea-9f3dac0d4545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cab5f-c05e-4688-b300-33ab0dd98598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cab5f-c05e-4688-b300-33ab0dd98598.jpg?1",
             "name": "Sphinx of the Guildpact",
             "text": "Sphinx of the Guildpact is all colors.\nFlying\nHexproof from monocolored (This creature can't be the target of monocolored spells or abilities your opponents control.)",
             "colours": [
@@ -9778,7 +9778,7 @@
         },
         {
             "id": "feacfa10-caa2-52b7-bd29-76a98aa1ec69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b3869b-6da1-4b01-a2e7-2018d478b6e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b3869b-6da1-4b01-a2e7-2018d478b6e5.jpg?1",
             "name": "Springleaf Drum",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color.",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "2d78d695-a9ad-5002-9414-f39efad828ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ebb5d3-72b1-411d-8c90-83dac5b37898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ebb5d3-72b1-411d-8c90-83dac5b37898.jpg?1",
             "name": "Sundering Titan",
             "text": "When Sundering Titan enters the battlefield or leaves the battlefield, choose a land of each basic land type, then destroy those lands.",
             "colours": [],
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "2d3a8682-39c0-525d-b226-30018f76bc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3945c488-6966-4c7d-a0b7-487a2c1837aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3945c488-6966-4c7d-a0b7-487a2c1837aa.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "56800ad4-ba77-5f28-918d-4577ca9d3000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743fc231-2ab3-42f1-9dd3-af42241229aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743fc231-2ab3-42f1-9dd3-af42241229aa.jpg?1",
             "name": "Surge Node",
             "text": "Surge Node enters the battlefield with six charge counters on it.\n{1}, {T}, Remove a charge counter from Surge Node: Put a charge counter on target artifact.",
             "colours": [],
@@ -9898,7 +9898,7 @@
         },
         {
             "id": "16cfc604-974b-5de4-8180-6151288a80c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffe5f80-a2ac-41b8-8fce-fd3485643557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffe5f80-a2ac-41b8-8fce-fd3485643557.jpg?1",
             "name": "Sword of Body and Mind",
             "text": "Equipped creature gets +2/+2 and has protection from green and from blue.\nWhenever equipped creature deals combat damage to a player, you create a 2/2 green Wolf creature token and that player mills ten cards.\nEquip {2}",
             "colours": [],
@@ -9930,7 +9930,7 @@
         },
         {
             "id": "274b6fe3-662a-5dbb-a09b-53e1dc3aa548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7710eb5-c56a-437b-8847-2a829c404d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7710eb5-c56a-437b-8847-2a829c404d47.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -9962,7 +9962,7 @@
         },
         {
             "id": "6ff43bd3-30f1-5c32-aa04-4d7ba6670548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2626d4c9-fcef-4057-a154-7d987a4a4b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2626d4c9-fcef-4057-a154-7d987a4a4b84.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to any target and you draw a card.\nEquip {2}",
             "colours": [],
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "409e346d-62b1-5cbf-8f9f-478a54062926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378c8bf-85ed-4d28-aec9-4925d12bca4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378c8bf-85ed-4d28-aec9-4925d12bca4a.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -10026,7 +10026,7 @@
         },
         {
             "id": "6711036a-bb62-568c-b2da-e88a225c9116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0c2773-3205-4ac4-b31c-c54fb06fdd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0c2773-3205-4ac4-b31c-c54fb06fdd7c.jpg?1",
             "name": "Sword of the Meek",
             "text": "Equipped creature gets +1/+2.\nEquip {2}\nWhenever a 1/1 creature enters the battlefield under your control, you may return Sword of the Meek from your graveyard to the battlefield, then attach it to that creature.",
             "colours": [],
@@ -10056,7 +10056,7 @@
         },
         {
             "id": "5a8da3e2-b78a-595a-9c58-3d7a7cdbc601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e6f50b-4b18-4aab-a7b0-869f25bc4c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e6f50b-4b18-4aab-a7b0-869f25bc4c40.jpg?1",
             "name": "Sword of War and Peace",
             "text": "Equipped creature gets +2/+2 and has protection from red and from white.\nWhenever equipped creature deals combat damage to a player, Sword of War and Peace deals damage to that player equal to the number of cards in their hand and you gain 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "88661a0e-b6c6-561c-bfd9-adbb61d39072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5719f8b-0a65-4f0c-bde0-74c5e107b64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5719f8b-0a65-4f0c-bde0-74c5e107b64d.jpg?1",
             "name": "Throne of Geth",
             "text": "{T}, Sacrifice an artifact: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "8c5fd7a3-3e6a-5789-a908-3306e550944c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2808aa-1f30-42c3-a2d1-c9eb91828e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2808aa-1f30-42c3-a2d1-c9eb91828e66.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with converted mana cost 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "93463363-2e20-58ca-9c8a-b208799d8bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316caa4e-a53a-460b-978c-5f0fba7bc549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316caa4e-a53a-460b-978c-5f0fba7bc549.jpg?1",
             "name": "Trinisphere",
             "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to cast costs three mana to cast. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to cast costs {2}{B} to cast instead.)",
             "colours": [],
@@ -10175,7 +10175,7 @@
         },
         {
             "id": "0400ff81-cc28-5bbb-92a2-745010492627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74baa632-d046-401a-9172-1ab6284240bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74baa632-d046-401a-9172-1ab6284240bc.jpg?1",
             "name": "Tumble Magnet",
             "text": "Tumble Magnet enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Tumble Magnet: Tap target artifact or creature.",
             "colours": [],
@@ -10203,7 +10203,7 @@
         },
         {
             "id": "6fd054e8-fe75-5fa1-b0d8-1ce62ebcf522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7318db50-1b78-4cc0-954b-9798af26a633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7318db50-1b78-4cc0-954b-9798af26a633.jpg?1",
             "name": "Vulshok Gauntlets",
             "text": "Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10233,7 +10233,7 @@
         },
         {
             "id": "718b099b-ef4e-5bcf-87ca-49f49065e7a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5272436e-74f0-44c4-a291-ea8ebc3f1525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5272436e-74f0-44c4-a291-ea8ebc3f1525.jpg?1",
             "name": "Walking Ballista",
             "text": "Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to any target.",
             "colours": [],
@@ -10264,7 +10264,7 @@
         },
         {
             "id": "76b12bd0-da1e-5175-8da3-83f72014a0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275ec0c4-1c59-4818-9999-b2389d17c2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275ec0c4-1c59-4818-9999-b2389d17c2e7.jpg?1",
             "name": "Welding Jar",
             "text": "Sacrifice Welding Jar: Regenerate target artifact.",
             "colours": [],
@@ -10292,7 +10292,7 @@
         },
         {
             "id": "b5a86869-617b-56ed-a91e-b37f52abc98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d275f04-cc60-4e3f-95cc-3d02bc916b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d275f04-cc60-4e3f-95cc-3d02bc916b82.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Engine dies, create a 3/3 colorless Wurm artifact creature token with deathtouch and a 3/3 colorless Wurm artifact creature token with lifelink.",
             "colours": [],
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "1544787e-b20c-59fc-a454-72e4e71bc536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95b7645-154f-4904-bf71-db7eb24d4df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95b7645-154f-4904-bf71-db7eb24d4df2.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Put target artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "e8f3c2a6-ae83-5953-87f8-1e3d894b9b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4dd417-43fd-4dee-aaf2-80d425bd0191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4dd417-43fd-4dee-aaf2-80d425bd0191.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [],
@@ -10388,7 +10388,7 @@
         },
         {
             "id": "ebe2c3bb-5098-5206-ac5b-b7539defe17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac535c1-9ef3-45b5-8959-7e79589d47ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac535c1-9ef3-45b5-8959-7e79589d47ad.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {C}.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -10416,7 +10416,7 @@
         },
         {
             "id": "39a9a454-dce0-5647-ab69-d8f054dbf6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65afdc-a994-44cb-83f9-6e7f0f3ab2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65afdc-a994-44cb-83f9-6e7f0f3ab2f1.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -10444,7 +10444,7 @@
         },
         {
             "id": "bf8eda89-5ce5-5fa8-b454-088fea96da5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e912b4-492f-415b-b0ad-d9f90c6139c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e912b4-492f-415b-b0ad-d9f90c6139c6.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {C}.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R}.",
             "colours": [],
@@ -10475,7 +10475,7 @@
         },
         {
             "id": "51332a7a-56b3-5924-84e1-7f744cac6f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb17a0-5a13-4d02-b7fb-f99531bc8ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb17a0-5a13-4d02-b7fb-f99531bc8ca5.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -10506,7 +10506,7 @@
         },
         {
             "id": "0d6c5c1e-a053-591c-b8e4-98c045059f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd582037-8682-4738-b459-177a9d6e03b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd582037-8682-4738-b459-177a9d6e03b6.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Indestructible\n{T}: Add {C}.",
             "colours": [],
@@ -10535,7 +10535,7 @@
         },
         {
             "id": "501b356b-5d45-575f-ba70-3354e7bc830f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713d95ae-4217-4544-9e00-06854fd0c6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713d95ae-4217-4544-9e00-06854fd0c6c7.jpg?1",
             "name": "Fetid Heath",
             "text": "{T}: Add {C}.\n{WB}, {T}: Add {W}{W}, {W}{B}, or {B}{B}.",
             "colours": [],
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "cf5886aa-ff48-5e8a-b454-70ad553b7ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927d645-ca43-4b8e-9932-7e70acca7aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927d645-ca43-4b8e-9932-7e70acca7aa6.jpg?1",
             "name": "Fire-Lit Thicket",
             "text": "{T}: Add {C}.\n{RG}, {T}: Add {R}{R}, {R}{G}, or {G}{G}.",
             "colours": [],
@@ -10597,7 +10597,7 @@
         },
         {
             "id": "23fd13c0-630c-5031-b473-beb6782d5e2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45d763d-75f5-4d96-ae7c-9eb869d4dead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45d763d-75f5-4d96-ae7c-9eb869d4dead.jpg?1",
             "name": "Flooded Grove",
             "text": "{T}: Add {C}.\n{GW}, {T}: Add {G}{G}, {G}{U}, or {U}{U}.",
             "colours": [],
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "f507d50a-89ad-5f4e-8572-bbea500c41e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a639687-d9e3-46a8-bc9f-6ca3912c46ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a639687-d9e3-46a8-bc9f-6ca3912c46ab.jpg?1",
             "name": "Glimmervoid",
             "text": "At the beginning of the end step, if you control no artifacts, sacrifice Glimmervoid.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -10656,7 +10656,7 @@
         },
         {
             "id": "2b4ff631-a40f-5691-abcb-7c4d9eb61ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0127d42f-bf40-48f4-a3a0-1a1c4039f432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0127d42f-bf40-48f4-a3a0-1a1c4039f432.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {C}.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R}.",
             "colours": [],
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "1eb37f49-43b5-5904-9ab8-4e4bc7ac0938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c99e02f-52e7-4a42-87dc-966034be79c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c99e02f-52e7-4a42-87dc-966034be79c7.jpg?1",
             "name": "High Market",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: You gain 1 life.",
             "colours": [],
@@ -10715,7 +10715,7 @@
         },
         {
             "id": "03bc2366-034a-5f22-9ded-35f8727b8e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78114f25-f40a-4e2e-bf89-29ea9b3500e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78114f25-f40a-4e2e-bf89-29ea9b3500e2.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -10743,7 +10743,7 @@
         },
         {
             "id": "93cfe998-5cd6-57fe-8d93-654c1bbbda66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b6fe0c-7bbe-433f-8400-4be4ce0e3f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b6fe0c-7bbe-433f-8400-4be4ce0e3f15.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -10771,7 +10771,7 @@
         },
         {
             "id": "19deb0b2-2876-5afd-b32e-764bb83b5835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe71ae5-5553-4b41-89e0-fd767f9bf430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe71ae5-5553-4b41-89e0-fd767f9bf430.jpg?1",
             "name": "Mystic Gate",
             "text": "{T}: Add {C}.\n{WU}, {T}: Add {W}{W}, {W}{U}, or {U}{U}.",
             "colours": [],
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "5e3242ed-f501-5c83-8e33-d72ffe7a133b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd301-7d04-480d-94ed-52537d944c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd301-7d04-480d-94ed-52537d944c6f.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {C}.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W}.",
             "colours": [],
@@ -10833,7 +10833,7 @@
         },
         {
             "id": "b23e0292-97f4-51c9-a03f-62873d2861a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9181d30d-4f8e-421f-89b8-149ed8000fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9181d30d-4f8e-421f-89b8-149ed8000fb2.jpg?1",
             "name": "Sunken Ruins",
             "text": "{T}: Add {C}.\n{UB}, {T}: Add {U}{U}, {U}{B}, or {B}{B}.",
             "colours": [],
@@ -10864,7 +10864,7 @@
         },
         {
             "id": "eb2bbc76-d24d-54cf-a6fa-e114d45109dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a926d-7788-4668-8bd8-7572dbf5f5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a926d-7788-4668-8bd8-7572dbf5f5eb.jpg?1",
             "name": "Thespian's Stage",
             "text": "{T}: Add {C}.\n{2}, {T}: Thespian's Stage becomes a copy of target land, except it has this ability.",
             "colours": [],
@@ -10892,7 +10892,7 @@
         },
         {
             "id": "0de72cc6-eca4-55e1-9ff3-68b8aefeb152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c59bee-0369-4a34-832f-fe3829a391b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c59bee-0369-4a34-832f-fe3829a391b3.jpg?1",
             "name": "Twilight Mire",
             "text": "{T}: Add {C}.\n{BG}, {T}: Add {B}{B}, {B}{G}, or {G}{G}.",
             "colours": [],
@@ -10923,7 +10923,7 @@
         },
         {
             "id": "44aa5a93-15bb-5c79-8f05-332d9bbd7ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dea8f6-bd32-44a3-bec4-93a5607819df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dea8f6-bd32-44a3-bec4-93a5607819df.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -10956,7 +10956,7 @@
         },
         {
             "id": "fc4c79d8-5237-5051-9a6f-6e4ce2e84ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54445d1f-5426-47e9-9e02-0274cea7174f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54445d1f-5426-47e9-9e02-0274cea7174f.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -10989,7 +10989,7 @@
         },
         {
             "id": "779b1b57-193b-539b-87f0-7b7efe1fbc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e369f3f-354b-42bf-9b2f-286912730c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e369f3f-354b-42bf-9b2f-286912730c6c.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -11022,7 +11022,7 @@
         },
         {
             "id": "923a3506-93a4-58ef-9ffd-46645b2e02c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b591ec-0231-4b91-a132-eb3aedfdf8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b591ec-0231-4b91-a132-eb3aedfdf8fa.jpg?1",
             "name": "Wooded Bastion",
             "text": "{T}: Add {C}.\n{RW}, {T}: Add {G}{G}, {G}{W}, or {W}{W}.",
             "colours": [],
@@ -11053,7 +11053,7 @@
         },
         {
             "id": "511dc2ac-7185-5b74-99d4-1cb44a61ba02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d1a254-01a8-4590-8878-690c5bfb4a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d1a254-01a8-4590-8878-690c5bfb4a95.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -11087,7 +11087,7 @@
         },
         {
             "id": "516dd7a4-fad8-5eed-bcdb-c05088762303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec386bc3-137b-49b5-8380-8daff470f0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec386bc3-137b-49b5-8380-8daff470f0bc.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
             "colours": [
@@ -11125,7 +11125,7 @@
         },
         {
             "id": "9bf9c63a-0fe5-5bb2-9cef-32cc94c3aa29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db149aaa-3da9-48c4-92cc-b3d804285290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db149aaa-3da9-48c4-92cc-b3d804285290.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -11163,7 +11163,7 @@
         },
         {
             "id": "0df712a3-ef9f-5873-8693-50229c2bcf9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32301593-f16a-4a46-8a4e-eecedd2a9013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32301593-f16a-4a46-8a4e-eecedd2a9013.jpg?1",
             "name": "Council's Judgment",
             "text": "Will of the council \u2014 Starting with you, each player votes for a nonland permanent you don't control. Exile each permanent with the most votes or tied for most votes.",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "bfbb2163-e383-5446-b171-e99916050a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb49805c-8546-463d-b78c-f4ea109851b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb49805c-8546-463d-b78c-f4ea109851b4.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.\n{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
             "colours": [
@@ -11234,7 +11234,7 @@
         },
         {
             "id": "baa76f04-4212-5aa5-a5cc-9b0810add79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd595e2f-65e4-46e8-9d28-f94ac308b275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd595e2f-65e4-46e8-9d28-f94ac308b275.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -11268,7 +11268,7 @@
         },
         {
             "id": "00217f81-e16f-5f98-afd3-43160585826a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9baef6e-a086-41d4-a20e-486f01d72406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9baef6e-a086-41d4-a20e-486f01d72406.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -11302,7 +11302,7 @@
         },
         {
             "id": "9b764b1d-5130-5084-bba8-e5c866fd9c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec136ce7-bad4-4ebb-ab00-b86de3d209a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec136ce7-bad4-4ebb-ab00-b86de3d209a7.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -11336,7 +11336,7 @@
         },
         {
             "id": "1ca5702b-74db-514d-be83-d0ea017c17a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacaf5ec-6745-4584-9175-36c98742958f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacaf5ec-6745-4584-9175-36c98742958f.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "({PU} can be paid with either {U} or 2 life.)\nYou may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "65e2b37a-2b3a-5aaf-b1b1-0e699e3fcf63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c821158-f71a-48f9-b6b4-b0e605f22bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c821158-f71a-48f9-b6b4-b0e605f22bec.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -11411,7 +11411,7 @@
         },
         {
             "id": "1ead4754-36eb-5463-bf63-c1fe672bc3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a50516-a20f-4e6e-b4f2-0049b673f942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a50516-a20f-4e6e-b4f2-0049b673f942.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt \u2014 Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -11445,7 +11445,7 @@
         },
         {
             "id": "88400e06-e77c-55b6-bb5f-6809663e6824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702503-8f2d-46c8-abdb-6edd6c431d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702503-8f2d-46c8-abdb-6edd6c431d19.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -11479,7 +11479,7 @@
         },
         {
             "id": "8df896f3-ae43-5c65-9504-270cd5093aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73731e45-51bb-4188-a54d-fdaa4bdfaf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73731e45-51bb-4188-a54d-fdaa4bdfaf1f.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -11513,7 +11513,7 @@
         },
         {
             "id": "d765f102-5ce7-5add-9841-55ade11b3c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35575d0-0b10-4d1b-b5a2-a9f36f9eada4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35575d0-0b10-4d1b-b5a2-a9f36f9eada4.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -11547,7 +11547,7 @@
         },
         {
             "id": "eac74bc2-9497-501f-b44f-ac876eecc7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2058c-3f20-4566-b366-93a2cbbe682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2058c-3f20-4566-b366-93a2cbbe682f.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
             "colours": [
@@ -11584,7 +11584,7 @@
         },
         {
             "id": "c2d44d80-704b-5776-9629-738d1f1519c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c11ba-533d-48c9-821c-3fec846bca97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c11ba-533d-48c9-821c-3fec846bca97.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -11618,7 +11618,7 @@
         },
         {
             "id": "4b41a542-1730-55fc-a409-e8fb5c116a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187abedf-c2eb-453b-bea0-a10afa399e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187abedf-c2eb-453b-bea0-a10afa399e03.jpg?1",
             "name": "Crop Rotation",
             "text": "As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a land card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "f2bfda59-3560-55a7-80a1-9d19f1a1d163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c9c856-af15-40b1-a799-1c2066df2099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c9c856-af15-40b1-a799-1c2066df2099.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "08b103c0-7f31-539a-a600-2cc4665fee55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3fc61c-c26e-47f3-a1eb-f6f10f8469e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3fc61c-c26e-47f3-a1eb-f6f10f8469e2.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -11720,7 +11720,7 @@
         },
         {
             "id": "9533d949-e6d4-571f-a3fa-1c347f49045b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8008977f-b164-4ab7-a38a-25b382c6a16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8008977f-b164-4ab7-a38a-25b382c6a16f.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U}.",
             "colours": [
@@ -11759,7 +11759,7 @@
         },
         {
             "id": "f9924588-6741-531a-a72b-16e1248234e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac080ef-8f40-43a2-8440-b457b6074b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac080ef-8f40-43a2-8440-b457b6074b69.jpg?1",
             "name": "Atraxa, Praetors' Voice",
             "text": "Flying, vigilance, deathtouch, lifelink\nAt the beginning of your end step, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "4e23d3ea-bebe-5755-ba29-0cf04ff82400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f670f9-c5b7-4eb0-a7d0-d16513fadf74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f670f9-c5b7-4eb0-a7d0-d16513fadf74.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -11848,7 +11848,7 @@
         },
         {
             "id": "1c249118-08ce-5abf-a60d-455530c1836e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9847f3-5a4c-4b49-8e25-e444d1446bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9847f3-5a4c-4b49-8e25-e444d1446bf9.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage enters the battlefield, choose a nonland card name.\nSpells with the chosen name can't be cast.",
             "colours": [
@@ -11887,7 +11887,7 @@
         },
         {
             "id": "7bea19d9-e5a5-5275-b9d7-befe61f93f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc5ac8-b944-4b71-b022-c78183eb92c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc5ac8-b944-4b71-b022-c78183eb92c3.jpg?1",
             "name": "Batterskull",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return Batterskull to its owner's hand.\nEquip {5}",
             "colours": [],
@@ -11919,7 +11919,7 @@
         },
         {
             "id": "d847642f-62a2-5541-abf1-b72620b53ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccd5597-2d4e-4f3e-94b7-46783486853a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccd5597-2d4e-4f3e-94b7-46783486853a.jpg?1",
             "name": "Blightsteel Colossus",
             "text": "Trample, infect, indestructible\nIf Blightsteel Colossus would be put into a graveyard from anywhere, reveal Blightsteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -11953,7 +11953,7 @@
         },
         {
             "id": "f0e5c86a-d541-5b77-957d-f63feb0d3d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e94d334-e043-42f2-ba5c-be497d82f2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e94d334-e043-42f2-ba5c-be497d82f2c8.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint \u2014 When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors.",
             "colours": [],
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "33641834-53ff-5ec2-b40a-479fcc151c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc6178b-16e7-4089-974f-7048b9632fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc6178b-16e7-4089-974f-7048b9632fc2.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "010ca5c3-0ec0-5ee7-a012-dfdd964bdee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70eab734-875b-4b76-901b-3ac7d2133ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70eab734-875b-4b76-901b-3ac7d2133ad9.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -12045,7 +12045,7 @@
         },
         {
             "id": "0fa179ca-39f2-5ba7-ae24-ccf5214f2da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cd274-ed83-475a-9b4f-adb9c780a6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cd274-ed83-475a-9b4f-adb9c780a6f4.jpg?1",
             "name": "Mana Crypt",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -12075,7 +12075,7 @@
         },
         {
             "id": "a225fb12-0b43-5711-9e39-02b901af1362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547e3aa5-d88a-4418-ab9d-dd65385f031b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547e3aa5-d88a-4418-ab9d-dd65385f031b.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -12107,7 +12107,7 @@
         },
         {
             "id": "4ee41bec-e81d-529f-b7f3-042faae33c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc0b4eb-8ee9-4213-8194-02e7d63428d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc0b4eb-8ee9-4213-8194-02e7d63428d3.jpg?1",
             "name": "Sword of Body and Mind",
             "text": "Equipped creature gets +2/+2 and has protection from green and from blue.\nWhenever equipped creature deals combat damage to a player, you create a 2/2 green Wolf creature token and that player mills ten cards.\nEquip {2}",
             "colours": [],
@@ -12139,7 +12139,7 @@
         },
         {
             "id": "52e3658b-6edc-52f8-90b9-0f6b8d783bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a469d00-1416-48dd-ad91-eb6f3fb4b42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a469d00-1416-48dd-ad91-eb6f3fb4b42b.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -12171,7 +12171,7 @@
         },
         {
             "id": "2ca04fb4-adc0-5263-8f1a-1912dbd8aa9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22cd80dd-1c57-423c-81e2-9a956901565f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22cd80dd-1c57-423c-81e2-9a956901565f.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to any target and you draw a card.\nEquip {2}",
             "colours": [],
@@ -12203,7 +12203,7 @@
         },
         {
             "id": "208bcf9f-fa26-5fcf-a506-5bed62581b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a195efe-8c4f-479d-bd0f-563ee4bb49a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a195efe-8c4f-479d-bd0f-563ee4bb49a1.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -12235,7 +12235,7 @@
         },
         {
             "id": "aa7a756d-49c3-5731-9493-c13742cd0c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c0681d-97da-4363-b75a-079c209e7e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c0681d-97da-4363-b75a-079c209e7e4a.jpg?1",
             "name": "Sword of War and Peace",
             "text": "Equipped creature gets +2/+2 and has protection from red and from white.\nWhenever equipped creature deals combat damage to a player, Sword of War and Peace deals damage to that player equal to the number of cards in their hand and you gain 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -12267,7 +12267,7 @@
         },
         {
             "id": "df0b5465-c327-5f52-b79b-819662ff0ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097accb-28ad-4b22-b615-103c74e07708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097accb-28ad-4b22-b615-103c74e07708.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Engine dies, create a 3/3 colorless Wurm artifact creature token with deathtouch and a 3/3 colorless Wurm artifact creature token with lifelink.",
             "colours": [],
@@ -12301,7 +12301,7 @@
         },
         {
             "id": "a6d54fb2-c2e7-592f-8551-fb8c64307a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e55604-56da-44b5-aa78-f5de76ce9d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e55604-56da-44b5-aa78-f5de76ce9d20.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Put target artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "6ae82cdd-ac8a-5183-8701-a216e731f126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e0452-5304-41fa-9e3a-a3fa5a571315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e0452-5304-41fa-9e3a-a3fa5a571315.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -12368,7 +12368,7 @@
         },
         {
             "id": "2a6bca5f-d886-567e-9a3d-cef2aa16fd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936335d7-1c4a-4fcd-80ff-cd4d4fcab8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936335d7-1c4a-4fcd-80ff-cd4d4fcab8c4.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -12401,7 +12401,7 @@
         },
         {
             "id": "8edeacf8-e29f-5c33-b588-b9cb1c6d14f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75672e0-fa2d-43c5-9381-e17f2fd6d3bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75672e0-fa2d-43c5-9381-e17f2fd6d3bc.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -12434,7 +12434,7 @@
         },
         {
             "id": "1da4d114-3355-50e7-8388-76d48f31e63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3db531-3f21-49a2-8aeb-d98b7db94397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3db531-3f21-49a2-8aeb-d98b7db94397.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12470,7 +12470,7 @@
         },
         {
             "id": "1154d51e-0f8c-5c98-b251-bb83f81f9f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f015fe9-c7fa-4503-b0cc-c0e7f098882f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f015fe9-c7fa-4503-b0cc-c0e7f098882f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12506,7 +12506,7 @@
         },
         {
             "id": "538f6fe0-2b63-594c-8fe2-06b82f0c03c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91595b00-6233-48be-a012-1e87bd704aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91595b00-6233-48be-a012-1e87bd704aca.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "b9377685-a89e-5ceb-8e58-bead1fbcb1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a51829-8319-4271-93b2-a7a635b30e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a51829-8319-4271-93b2-a7a635b30e80.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12578,7 +12578,7 @@
         },
         {
             "id": "93073301-4800-52f2-826d-35ef994e8528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5eef83-a3d4-44c7-a6cb-7f6803825b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5eef83-a3d4-44c7-a6cb-7f6803825b9e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12614,7 +12614,7 @@
         },
         {
             "id": "8fbb7d04-6299-5c69-bcf8-cd4a2cf572e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cb941f-e3cf-45d2-9989-2a0a454d5497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cb941f-e3cf-45d2-9989-2a0a454d5497.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12650,7 +12650,7 @@
         },
         {
             "id": "90a56b45-8298-5f31-b548-ad330d1f449c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6418bc71-de29-410c-baf3-f63f5615eee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6418bc71-de29-410c-baf3-f63f5615eee2.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12686,7 +12686,7 @@
         },
         {
             "id": "0fe1aeaa-6ab6-5ed0-b65e-d731b9ff23f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8584b531-6dfa-43b2-99ba-b614b147f9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8584b531-6dfa-43b2-99ba-b614b147f9a8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "cd828bea-b68d-5a81-b4b1-cc103c35713a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146b803f-0455-497b-8362-03da2547070d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146b803f-0455-497b-8362-03da2547070d.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12758,7 +12758,7 @@
         },
         {
             "id": "f4f409bb-98a9-5ac2-85a9-7ac9debd4152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10cf58b-e01e-413e-979b-c6fe9e93100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10cf58b-e01e-413e-979b-c6fe9e93100b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12794,7 +12794,7 @@
         },
         {
             "id": "cd131db0-d77b-5048-9f45-69e660389e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91be77a-bd5b-485f-b5ca-0e6148c236ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91be77a-bd5b-485f-b5ca-0e6148c236ca.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -12827,7 +12827,7 @@
         },
         {
             "id": "bcd861de-1206-5df9-a2c5-e6a3464b37b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef345fc-e64e-4053-b643-2f8648a5473a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef345fc-e64e-4053-b643-2f8648a5473a.jpg?1",
             "name": "Chord of Calling",
             "text": "",
             "colours": [
@@ -12860,7 +12860,7 @@
         },
         {
             "id": "4346b802-ff21-513e-8ba9-1bce9bc0d26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e3f3c1-866c-4214-82e0-dcca2d1aba1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e3f3c1-866c-4214-82e0-dcca2d1aba1e.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -12892,7 +12892,7 @@
         },
         {
             "id": "1d4754fb-6636-50bc-b84b-273f1dc27277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798cef87-237b-4e4a-b7ed-78d15c720391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798cef87-237b-4e4a-b7ed-78d15c720391.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -12923,7 +12923,7 @@
         },
         {
             "id": "20ed6cbc-ff63-5be7-acee-c6e34d490685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0335da-631f-46b8-bfa1-b2f210c91f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0335da-631f-46b8-bfa1-b2f210c91f5f.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -12958,7 +12958,7 @@
         },
         {
             "id": "d3de374f-d4ac-50db-a857-b28760fec851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f859b55c-0b49-4190-b1fa-94f97a59b57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f859b55c-0b49-4190-b1fa-94f97a59b57c.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -12993,7 +12993,7 @@
         },
         {
             "id": "697e7dfa-754d-5a54-8f27-63f88029538f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3683cc6-70e0-4d33-9fed-6a56ba8b6e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3683cc6-70e0-4d33-9fed-6a56ba8b6e9b.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -13029,7 +13029,7 @@
         },
         {
             "id": "427f8834-cc43-5c81-95ce-cb56615b806b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa14443-d02e-41db-942a-498857e6b83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa14443-d02e-41db-942a-498857e6b83c.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -13064,7 +13064,7 @@
         },
         {
             "id": "cd183a9e-8db1-5261-8f81-f27c0de1c01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483c8cd6-288c-49d7-ac28-642132f85259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483c8cd6-288c-49d7-ac28-642132f85259.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "b5b44ebe-3809-5952-95e8-ab372abbcddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8b4fc-238f-4c1f-ad98-a1769fd44eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8b4fc-238f-4c1f-ad98-a1769fd44eab.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [
@@ -13136,7 +13136,7 @@
         },
         {
             "id": "068c9dc1-ab3c-5fe7-af14-6005ebb4b874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3c99d1-ebd3-4eb4-ba04-941819394567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3c99d1-ebd3-4eb4-ba04-941819394567.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -13171,7 +13171,7 @@
         },
         {
             "id": "93b079d9-286b-5abd-a242-41344559f6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc467e-b345-446c-b9b7-5f164e6651a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc467e-b345-446c-b9b7-5f164e6651a4.jpg?1",
             "name": "Germ",
             "text": "",
             "colours": [
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "ffabd0a6-5006-5c9a-8718-531071d99107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb248ba0-2ee7-4994-be57-2bcc8df29680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb248ba0-2ee7-4994-be57-2bcc8df29680.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -13243,7 +13243,7 @@
         },
         {
             "id": "ce8711c2-89a5-5c92-b3ab-36d351e9ac92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2d434d-5d9b-4475-b421-6d004c988997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2d434d-5d9b-4475-b421-6d004c988997.jpg?1",
             "name": "Ape",
             "text": "",
             "colours": [
@@ -13278,7 +13278,7 @@
         },
         {
             "id": "2f121db8-67ac-5db9-b8e2-9c630b2ace68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d270aeed-b15f-46f9-97ba-ccce562caefa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d270aeed-b15f-46f9-97ba-ccce562caefa.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -13313,7 +13313,7 @@
         },
         {
             "id": "8a91a134-801f-57c0-b095-73380ee4edba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e49e47-d658-4378-9e83-7946f7346ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e49e47-d658-4378-9e83-7946f7346ede.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -13348,7 +13348,7 @@
         },
         {
             "id": "3df270fb-2842-5181-aeb3-6a653e0691bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e76d6-d8d5-410b-9b00-088c039b668f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e76d6-d8d5-410b-9b00-088c039b668f.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -13383,7 +13383,7 @@
         },
         {
             "id": "e4b71c7b-3c28-599f-a717-8da11efef5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d05bfc-c447-474a-9ec9-9f4772821bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d05bfc-c447-474a-9ec9-9f4772821bfb.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -13418,7 +13418,7 @@
         },
         {
             "id": "35397384-bc4d-5df0-a6e7-a22d246a9ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95483574-95b7-42a3-b700-616189163b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95483574-95b7-42a3-b700-616189163b0a.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "b414d100-00cf-51eb-84fc-f0e4d50fb8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa846cf5-c618-4304-bb92-5df936ebca9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa846cf5-c618-4304-bb92-5df936ebca9b.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -13488,7 +13488,7 @@
         },
         {
             "id": "b484e108-19d6-592c-97c1-a25761a1d38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371056-43dd-41ab-8d05-b16a8bdc8d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371056-43dd-41ab-8d05-b16a8bdc8d28.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -13523,7 +13523,7 @@
         },
         {
             "id": "12178f65-27ca-5393-b766-89bb2bd13cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676704a-419e-4a00-a052-bca2ad34ecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676704a-419e-4a00-a052-bca2ad34ecae.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -13560,7 +13560,7 @@
         },
         {
             "id": "d76f682c-a7c1-53dc-88d1-9a1237a3d1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8caa61-e294-4501-b357-a44abd77d09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8caa61-e294-4501-b357-a44abd77d09a.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "37292e23-13f4-5108-bac2-2e75f92f6a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dfd9b9-8214-4e20-b1c9-48c9f7276883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dfd9b9-8214-4e20-b1c9-48c9f7276883.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -13629,7 +13629,7 @@
         },
         {
             "id": "fc308b6a-24aa-5500-b6b8-98e72a4cfce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7becaa04-f142-4163-9286-00018b95c4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7becaa04-f142-4163-9286-00018b95c4ca.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -13661,7 +13661,7 @@
         },
         {
             "id": "37c45f60-9cdb-5706-8070-48d24b7ece38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -13693,7 +13693,7 @@
         },
         {
             "id": "dcad146d-8118-5810-ae0a-252f4adf69ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e32b9-431c-43d9-a0df-d73f4ff4fbc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e32b9-431c-43d9-a0df-d73f4ff4fbc2.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "dfdf8ee7-220c-53dd-b7b7-74c65fb75df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75602e25-a0ab-430e-b610-5e12c1cab3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75602e25-a0ab-430e-b610-5e12c1cab3d8.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -13757,7 +13757,7 @@
         },
         {
             "id": "adf54ee8-8ed7-51d9-909c-ba875c4f64e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791f5fa0-f972-455e-9802-ff299853607f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791f5fa0-f972-455e-9802-ff299853607f.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -13788,7 +13788,7 @@
         },
         {
             "id": "ced7b783-d646-567a-a951-6a1ad02808b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7822b-f155-4f3f-b835-ec64f3a71307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7822b-f155-4f3f-b835-ec64f3a71307.jpg?1",
             "name": "Tuktuk the Returned",
             "text": "",
             "colours": [],
@@ -13821,7 +13821,7 @@
         },
         {
             "id": "27b9da7b-7621-59be-a477-1137f41b7a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68e816f-f9ac-435b-ad0b-ceedbe72447a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68e816f-f9ac-435b-ad0b-ceedbe72447a.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -13853,7 +13853,7 @@
         },
         {
             "id": "8639ed93-ad63-5cd8-ac84-9cb0e6b91869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee0db9-ac89-4ab6-ac2e-8a7527d9ecbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee0db9-ac89-4ab6-ac2e-8a7527d9ecbd.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -13885,7 +13885,7 @@
         },
         {
             "id": "70911aa0-1297-5263-b92c-2348ab09b87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6870a2af-80e1-4813-a332-2b1bd789f1c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6870a2af-80e1-4813-a332-2b1bd789f1c1.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/4ED.json
+++ b/Assets/Resources/Sets/4ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c10487df-6778-58a4-ae45-29f4d7682d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c931a4-297a-4f7f-8f71-6bdcbe4e94b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c931a4-297a-4f7f-8f71-6bdcbe4e94b7.jpg?1",
             "name": "Alabaster Potion",
             "text": "Give target player X life, or prevent X damage to any creature or player.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "bfb86ce8-1503-562b-a219-07fe40d22572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27de9b02-1810-41ee-aa90-5d89b6e1bf87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27de9b02-1810-41ee-aa90-5d89b6e1bf87.jpg?1",
             "name": "Amrou Kithkin",
             "text": "No creature with power greater than 2 may be assigned to block Kithkin.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "0c7d298c-2472-5925-9e43-9be7602b3171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26d1c4d-af95-4b40-83a5-b51f8b2506db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26d1c4d-af95-4b40-83a5-b51f8b2506db.jpg?1",
             "name": "Angry Mob",
             "text": "Trample\nDuring your turn, Angry Mob has power and toughness each equal to 2 plus the total number of swamps opponents control. During other turns, Angry Mob has power and toughness 2/2.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "0fda6d00-c69d-5fdf-bceb-f6c492003600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ee58e5-f493-4e27-9639-5599a9573387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ee58e5-f493-4e27-9639-5599a9573387.jpg?1",
             "name": "Animate Wall",
             "text": "Target wall can now attack.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "78ca99cd-de79-5473-bd30-e0ae3445f90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0794bc35-a8e1-4268-87b2-af5483ca6e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0794bc35-a8e1-4268-87b2-af5483ca6e5e.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -165,7 +165,7 @@
         },
         {
             "id": "63249fc5-9772-5ab6-aae1-6e9310dab473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3e219d-8e5e-44c7-97b3-2d489e2808b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3e219d-8e5e-44c7-97b3-2d489e2808b9.jpg?1",
             "name": "Balance",
             "text": "Each player sacrifices enough lands to equalize the number of lands all players control. The player who controls the fewest lands cannot sacrifice any in this way. All players then equalize cards in hand and then creatures in play in the same way.",
             "colours": [
@@ -196,7 +196,7 @@
         },
         {
             "id": "364f7d3d-2910-51f4-bf79-916ae5b18413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd204832-5f3b-4213-9c06-b89a296a9d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd204832-5f3b-4213-9c06-b89a296a9d47.jpg?1",
             "name": "Benalish Hero",
             "text": "Banding",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "5dda15e5-5bc9-5d67-b249-780e1fa3c843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218b1327-5f76-4ee2-a93d-d2ba412043c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218b1327-5f76-4ee2-a93d-d2ba412043c2.jpg?1",
             "name": "Black Ward",
             "text": "Target creature gains protection from black. The protection granted by Black Ward does not destroy Black Ward.",
             "colours": [
@@ -263,7 +263,7 @@
         },
         {
             "id": "9521e85c-e633-57f1-9bd6-4a7b80c53503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea35ac3-071d-4a42-9a7a-9104fe63bddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea35ac3-071d-4a42-9a7a-9104fe63bddc.jpg?1",
             "name": "Blessing",
             "text": "oo\nW Target creature Blessing enchants gets +1/+1 until end of turn.",
             "colours": [
@@ -296,7 +296,7 @@
         },
         {
             "id": "6ab3c740-65d0-5b6d-802d-3e5c78c44b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de62c833-c66b-442e-99ed-99ccd8eca024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de62c833-c66b-442e-99ed-99ccd8eca024.jpg?1",
             "name": "Blue Ward",
             "text": "Target creature gains protection from blue. The protection granted by Blue Ward does not destroy Blue Ward.",
             "colours": [
@@ -329,7 +329,7 @@
         },
         {
             "id": "4c5d42b7-096d-52c1-b07e-8940da5887f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c6d853-dc3a-4eed-894a-b58bf6e56dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c6d853-dc3a-4eed-894a-b58bf6e56dc8.jpg?1",
             "name": "Brainwash",
             "text": "Target creature cannot attack unless its controller pays an additional o3.",
             "colours": [
@@ -362,7 +362,7 @@
         },
         {
             "id": "89d5a4eb-73ca-5d85-9887-5d856ee92753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ee86b-222b-4d7a-9c5b-ea10e1d73756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ee86b-222b-4d7a-9c5b-ea10e1d73756.jpg?1",
             "name": "Castle",
             "text": "Untapped creatures you control get +0/+2 when not attacking.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "87ad7a17-0deb-58e6-8992-917d2dc93faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfddcee-704f-4189-8cb0-6025fe98d7e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfddcee-704f-4189-8cb0-6025fe98d7e9.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "o2: Prevent all damage against you from one artifact source. If a source deals damage to you more than once in a turn, you may pay o2 each time to prevent the damage.",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "8e452bb5-e4c0-5ce5-b2bb-3a80304a5c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9971cbae-3f08-48c6-955a-76ce8ed41c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9971cbae-3f08-48c6-955a-76ce8ed41c6c.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage against you from one black source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "2fbb52d9-cfa7-5d17-b4cd-8327dffe99bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7cdfd5-bef9-4f33-b81a-2a395c9bba29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7cdfd5-bef9-4f33-b81a-2a395c9bba29.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage against you from one blue source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "62a82db6-c716-5ef3-9cfb-f0e8cb44e18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192c50c5-ef98-47bd-9cab-cb3feaf6080b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192c50c5-ef98-47bd-9cab-cb3feaf6080b.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage against you from one green source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "ce1ab841-a843-5cd2-b1e2-325caa3060ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3575259-b019-47d0-a6d3-3fe4963294ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3575259-b019-47d0-a6d3-3fe4963294ae.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage against you from one red source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "24941298-728b-532c-812a-af9da26c54d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e1e153-cf5c-429a-9680-53b7c89dbd88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e1e153-cf5c-429a-9680-53b7c89dbd88.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage against you from one white source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "c4624be3-f634-59ef-9f8b-eb98722c1eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df33281-bebc-4c2a-97ce-528a67574670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df33281-bebc-4c2a-97ce-528a67574670.jpg?1",
             "name": "Conversion",
             "text": "All mountains become basic plains. During your upkeep, pay o\nWo\nW or destroy Conversion.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "ff21a76c-2d99-58b5-8314-79b04833e098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5428ef-847d-4ac1-b9a9-31afe155650f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5428ef-847d-4ac1-b9a9-31afe155650f.jpg?1",
             "name": "Crusade",
             "text": "All white creatures get +1/+1.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "1a99cbfa-5512-521c-94dc-301837eaed40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c54ffe-2479-4178-a5dc-dca7b564efce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c54ffe-2479-4178-a5dc-dca7b564efce.jpg?1",
             "name": "Death Ward",
             "text": "Regenerate target creature.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "d4dd8e58-7b6a-503a-81ad-cffeceb43fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a915f261-2cdc-499c-9163-da5b628b0127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a915f261-2cdc-499c-9163-da5b628b0127.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target enchantment or artifact.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "2baa2816-21d2-56d2-9fef-352e3475e1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59605bf-27d8-47ca-805e-527aab6ddf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59605bf-27d8-47ca-805e-527aab6ddf70.jpg?1",
             "name": "Divine Transformation",
             "text": "Target creature gets +3/+3.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "c32d2c8c-1ae2-520b-a72c-db35b04a6756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188d0d4-cd7c-4314-ae65-cb49e4674241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188d0d4-cd7c-4314-ae65-cb49e4674241.jpg?1",
             "name": "Elder Land Wurm",
             "text": "Trample\nCannot attack until assigned as a blocker.",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "4119e22a-fac6-581c-a7e5-22367e4ede6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc41bca-73fc-42da-b639-b73a8de8a9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc41bca-73fc-42da-b639-b73a8de8a9c6.jpg?1",
             "name": "Eye for an Eye",
             "text": "You may cast Eye for an Eye only when a creature, spell, or effect deals damage to you. Eye for an Eye deals an equal amount of damage to the controller of that creature, spell, or effect. If another spell or effect reduces the amount of damage you receive, it does not reduce the damage dealt by Eye for an Eye.",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "526661d6-c7f2-5260-9795-d837f306219c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f89968f-0182-4639-96fd-0dc94b6ad926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f89968f-0182-4639-96fd-0dc94b6ad926.jpg?1",
             "name": "Fortified Area",
             "text": "All walls you control gain banding and get +1/+0.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "de3c157c-a2e1-5c4a-a5ad-2b18cc56ecb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7548dc7-11dc-4611-85a5-71bdb48d8a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7548dc7-11dc-4611-85a5-71bdb48d8a62.jpg?1",
             "name": "Green Ward",
             "text": "Target creature gains protection from green. The protection granted by Green Ward does not destroy Green Ward.",
             "colours": [
@@ -865,7 +865,7 @@
         },
         {
             "id": "c9d0c5f4-59d8-5878-9631-eeaac714d27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd08b3b-196e-43a5-9318-9dae9edc6d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd08b3b-196e-43a5-9318-9dae9edc6d12.jpg?1",
             "name": "Healing Salve",
             "text": "Give target player 3 life, or prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "e131ef26-266c-5e65-a3a0-cbff91f83e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9dba-f621-4700-8a36-bf326e04cbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9dba-f621-4700-8a36-bf326e04cbac.jpg?1",
             "name": "Holy Armor",
             "text": "Target creature gets +0/+2.\noo\nW Target creature Holy Armor enchants gets +0/+1 until end of turn.",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "a91a7d35-965f-5847-a0ef-76a6558b74a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9f19-66d1-44e5-9aed-955e6bfd9902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9f19-66d1-44e5-9aed-955e6bfd9902.jpg?1",
             "name": "Holy Strength",
             "text": "Target creature gets +1/+2.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "cb3108b4-0dab-5bc9-ae3a-b9197960c963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0eff4d1-4ce6-48b1-84ae-a95bd1d04d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0eff4d1-4ce6-48b1-84ae-a95bd1d04d16.jpg?1",
             "name": "Island Sanctuary",
             "text": "During your draw phase, you may draw one less card from your library. If you do so, until start of your next turn the only creatures that can attack you are those with flying or islandwalk.",
             "colours": [
@@ -993,7 +993,7 @@
         },
         {
             "id": "86e48276-2df9-55db-8de1-695a5aa884ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acd8dd7-f561-487f-abae-4ad910db9d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acd8dd7-f561-487f-abae-4ad910db9d27.jpg?1",
             "name": "Karma",
             "text": "During each player's upkeep, Karma deals 1 damage to that player for each swamp he or she controls.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "715acb28-4809-5877-b14a-42c93ae6fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2381234-cf5a-4baf-89f9-cdec15557cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2381234-cf5a-4baf-89f9-cdec15557cf4.jpg?1",
             "name": "Kismet",
             "text": "All of target player's creatures, lands, and artifacts come into play tapped.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "304ce4d5-b1af-53a2-bcdd-578a8dd6bbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1301e203-7d9a-4735-8db3-7882ad70d343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1301e203-7d9a-4735-8db3-7882ad70d343.jpg?1",
             "name": "Land Tax",
             "text": "During your upkeep, if an opponent controls more land than you, you may search your library and remove up to three basic land cards and put them into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "5da5d6cc-806d-57c9-a491-11cdd76ae321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c0faf1-0c16-441a-97fd-6d4e91c894a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c0faf1-0c16-441a-97fd-6d4e91c894a5.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Flying, banding",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "66fed355-a8b8-5dca-87cf-07159d22ad95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52cdfe3-fca1-420c-b5c0-2366ea58345b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52cdfe3-fca1-420c-b5c0-2366ea58345b.jpg?1",
             "name": "Morale",
             "text": "All attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "81bed4a3-b841-5f88-9cbc-c1bd4b3b2959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e97dce-6bef-480d-939e-d35cfbf6b989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e97dce-6bef-480d-939e-d35cfbf6b989.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target black permanent.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "3220c226-8e9b-5dab-806f-c0b6d886d746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da915d3c-8d43-44c2-9052-08c1cd2afa7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da915d3c-8d43-44c2-9052-08c1cd2afa7b.jpg?1",
             "name": "Osai Vultures",
             "text": "Flying\nAt the end of any turn in which a creature is put into the graveyard from play, put a carrion counter on Vultures.\no0: Remove two carrion counters to give Vultures +1/+1 until end of turn.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "8534ea4c-c654-5c03-a625-3fb1a7035c62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acc78fc-1eab-47aa-993d-6781b2d2408a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acc78fc-1eab-47aa-993d-6781b2d2408a.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "157b620d-3e30-5552-99e4-faa23d55eb41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b107c80-0c9a-46cd-8f00-26c37f080ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b107c80-0c9a-46cd-8f00-26c37f080ce7.jpg?1",
             "name": "Personal Incarnation",
             "text": "Owner may redirect any or all damage done to Personal Incarnation to self instead. If Personal Incarnation is put into the graveyard from play, owner loses half his or her remaining life, rounding up the loss. Effects that redirect or prevent damage cannot be used to counter this loss of life.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "b171c92d-f1e0-5299-a080-5cb0fb916df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4942a9f-6b8f-438b-a2ea-366228038ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4942a9f-6b8f-438b-a2ea-366228038ed8.jpg?1",
             "name": "Piety",
             "text": "All blocking creatures get +0/+3 until end of turn.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "b9b7d0bf-b500-56b0-a26c-573f6bbbf584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015cc1ad-8b9f-484c-aa7d-d44f7bc914d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015cc1ad-8b9f-484c-aa7d-d44f7bc914d2.jpg?1",
             "name": "Pikemen",
             "text": "Banding, first strike",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "2e75c100-be1e-53af-bad9-cccd6580ae40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5736fcc7-fa95-4ef4-b821-392ec00e03bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5736fcc7-fa95-4ef4-b821-392ec00e03bf.jpg?1",
             "name": "Purelace",
             "text": "Change the color of target spell or target permanent to white. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "c693bef0-8717-54a4-b06a-a13a47500f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e8ec0-f36a-46a6-b7b1-e983e90a091a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e8ec0-f36a-46a6-b7b1-e983e90a091a.jpg?1",
             "name": "Red Ward",
             "text": "Target creature gains protection from red. The protection granted by Red Ward does not destroy Red Ward.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "caad38ad-d173-5b71-9649-495a77219e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd458c66-0183-4bad-a651-6fe52a6d14c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd458c66-0183-4bad-a651-6fe52a6d14c4.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage dealt to you so far this turn by one source is retroactively added to your life total instead of subtracted. Further damage this turn is treated normally.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "97a3e95c-681f-5127-91d4-87a894290f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fccc7f2-b317-40c4-9b55-658d67dca843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fccc7f2-b317-40c4-9b55-658d67dca843.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "694043fd-331e-5b17-9cda-b78ccc2bcedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b354858f-d25b-4264-8a0b-fecc3a58db6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b354858f-d25b-4264-8a0b-fecc3a58db6d.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "441235a0-79b8-5e5c-95d2-99a24e7dc808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ee9127-d007-48e8-b797-88ef72bc7c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ee9127-d007-48e8-b797-88ef72bc7c8b.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "4bffee75-885e-5012-8c46-92b9ace8b664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052825f-d9fc-4820-b8c4-dbc204730b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052825f-d9fc-4820-b8c4-dbc204730b7c.jpg?1",
             "name": "Seeker",
             "text": "Target creature cannot be blocked except by white creatures and artifact creatures.",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "ebb16e0f-415a-55e0-92b1-1af287fbf624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8072d00a-82ff-4406-bdf8-1af20cd3a170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8072d00a-82ff-4406-bdf8-1af20cd3a170.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nAttacking does not cause Serra Angel to tap.",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "f165113f-c7c2-513c-b7e7-876f870f0be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58838b77-3bac-41b7-8055-5737c07df12e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58838b77-3bac-41b7-8055-5737c07df12e.jpg?1",
             "name": "Spirit Link",
             "text": "Gain 1 life for every 1 damage target creature deals. You may gain more life than the toughness or the total life of the creature or player damaged by the creature Spirit Link enchants.",
             "colours": [
@@ -1641,7 +1641,7 @@
         },
         {
             "id": "008f142f-f9c0-507b-802f-5f2d4b715cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd501ae-5814-4336-a45b-2b88cb85d29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd501ae-5814-4336-a45b-2b88cb85d29e.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Remove target creature from the game. The creature's controller gains life equal to its power.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "873beb7b-4710-563a-8870-60a31aaa01e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8527ac-27c3-4e2d-b46c-bfd6a1e1f778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8527ac-27c3-4e2d-b46c-bfd6a1e1f778.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "4f6347e9-f5e1-5121-8070-b710082ec50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fed0e6-0e56-4987-b0dd-b294156c0233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fed0e6-0e56-4987-b0dd-b294156c0233.jpg?1",
             "name": "Visions",
             "text": "Look at the top five cards of any library. You may then shuffle that library.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "dbfe8903-1451-5f01-ad75-637c202ff8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ffa85c-61c4-49b7-8946-ab353355a11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ffa85c-61c4-49b7-8946-ab353355a11c.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "b4e8acaf-c2f4-5f54-806b-260a771050b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8f8a10-6984-46a7-a641-5f712dab5c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8f8a10-6984-46a7-a641-5f712dab5c57.jpg?1",
             "name": "White Knight",
             "text": "Protection from black, first strike",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "1728d672-b2c4-5606-b88f-527af949c897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c467f-0e33-43e8-b108-0ea00d6adcc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c467f-0e33-43e8-b108-0ea00d6adcc2.jpg?1",
             "name": "White Ward",
             "text": "Target creature gains protection from white. The protection granted by White Ward does not destroy White Ward.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "eaaabf41-5f10-55b1-a76d-fb81bbf33095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4566f6a3-4d25-4df0-84be-fe4201138955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4566f6a3-4d25-4df0-84be-fe4201138955.jpg?1",
             "name": "Wrath of God",
             "text": "Bury all creatures.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "31100617-7483-5f16-aa37-92e99b633cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cfaefb-764c-4c56-bdb3-5f0375168597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cfaefb-764c-4c56-bdb3-5f0375168597.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "aa664d4b-c72e-566e-98a0-52998f79a2a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea613c48-258b-499d-975b-f56fbef3c665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea613c48-258b-499d-975b-f56fbef3c665.jpg?1",
             "name": "Animate Artifact",
             "text": "Target artifact becomes an artifact creature with power and toughness each equal to its casting cost; target retains all its original abilities. Animate Artifact does not affect artifact creatures.",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "889e912b-8543-5857-b0e2-c9a05005a706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ef569e-91e7-45f5-83b0-5a820242c628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ef569e-91e7-45f5-83b0-5a820242c628.jpg?1",
             "name": "Apprentice Wizard",
             "text": "o\nU, oc\nT: Add o3 to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "bd6b2e65-5f83-5607-bc9d-c8fd647713df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad34094d-a7ec-4b04-a288-4d4f1a07fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad34094d-a7ec-4b04-a288-4d4f1a07fc6b.jpg?1",
             "name": "Backfire",
             "text": "Backfire deals 1 damage to target creature's controller for each 1 damage dealt to you by that creature.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "bca136d4-afd7-5e1a-ace5-b4b3da26ee54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988f7b31-24b2-45c2-89e4-ff6bd9e0c8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988f7b31-24b2-45c2-89e4-ff6bd9e0c8c7.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Counter target red spell or destroy target red permanent.",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "e23005af-b7ab-5f6a-828c-a9b6aa5466c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb371e5-424e-42dd-9966-732c22e8ece8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb371e5-424e-42dd-9966-732c22e8ece8.jpg?1",
             "name": "Control Magic",
             "text": "Gain control of target creature.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "30b90630-2945-5fc0-ac1d-643a19086498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8493631-6c9c-40a8-b7de-ecf26ba6bf7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8493631-6c9c-40a8-b7de-ecf26ba6bf7d.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "7b977d05-008c-55db-b2c6-23857a00ca23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5ee5-a033-4a58-bdcb-ef54e6c8b7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5ee5-a033-4a58-bdcb-ef54e6c8b7a9.jpg?1",
             "name": "Creature Bond",
             "text": "If target creature is put into the graveyard, Creature Bond deals damage equal to the creature's toughness to that creature's controller.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "5c4cbeda-2857-5c9a-bd7b-439dcd06bd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3009237-fb96-497f-9a6e-b93b8115528a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3009237-fb96-497f-9a6e-b93b8115528a.jpg?1",
             "name": "Drain Power",
             "text": "Target player must draw all mana from his or her available lands; then, all mana in target player's mana pool drains into your mana pool.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "32d77666-3967-53cc-88a1-139e59890664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfa8400-1820-4108-a7f3-6ae8a1897f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfa8400-1820-4108-a7f3-6ae8a1897f0c.jpg?1",
             "name": "Energy Flux",
             "text": "During each player's upkeep, destroy all artifacts that player controls. The player may pay an additional o2 for each artifact he or she wishes to prevent Energy Flux from destroying.",
             "colours": [
@@ -2190,7 +2190,7 @@
         },
         {
             "id": "78258377-db37-5add-bcd3-559f1b682bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67692d-9df6-4841-a36b-26c28110b63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67692d-9df6-4841-a36b-26c28110b63b.jpg?1",
             "name": "Energy Tap",
             "text": "Tap target creature you control. Add an amount of colorless mana equal to that creature's casting cost to your mana pool.",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "3839846f-6f88-552d-898f-f94acaae94d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc539ff-03f5-4bec-877a-061fb5d40de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc539ff-03f5-4bec-877a-061fb5d40de9.jpg?1",
             "name": "Erosion",
             "text": "During his or her upkeep, target land's controller pays o1 or 1 life, or target land is destroyed. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "411bf62f-97f1-5314-ac49-d9dc181feb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5a60e6-be5f-454e-a354-ab736839f092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5a60e6-be5f-454e-a354-ab736839f092.jpg?1",
             "name": "Feedback",
             "text": "Feedback deals 1 damage to controller of target enchantment during that player's upkeep.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "13a6bf82-5df9-57bc-9d9d-eb0185a99c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867cb70-f615-4583-bf0b-fb1016209785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867cb70-f615-4583-bf0b-fb1016209785.jpg?1",
             "name": "Flight",
             "text": "Target creature gains flying.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "21bfef60-f117-5315-8bdc-cac8f56223a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba099785-bfa0-4224-be19-0dcded94fba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba099785-bfa0-4224-be19-0dcded94fba5.jpg?1",
             "name": "Flood",
             "text": "o\nUoo\nU Tap target creature without flying.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "69d84cff-149f-5662-b284-a240a29a8560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdd00f0-c6aa-4e8b-a035-fb3403711741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdd00f0-c6aa-4e8b-a035-fb3403711741.jpg?1",
             "name": "Gaseous Form",
             "text": "Target creature neither deals nor receives damage during combat.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "84b5c061-b24e-59df-8aa6-c25986d31d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af0b9ce-0a9c-4619-95c1-bbbfffa7fcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af0b9ce-0a9c-4619-95c1-bbbfffa7fcec.jpg?1",
             "name": "Ghost Ship",
             "text": "Flying\no\nUo\nUoo\nU Regenerate",
             "colours": [
@@ -2417,7 +2417,7 @@
         },
         {
             "id": "fff0c807-b6b2-5b93-9dbf-ad46e7a3ecfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512addb-5888-49f3-985b-53cc11831e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512addb-5888-49f3-985b-53cc11831e5e.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gets +0/+3 while untapped.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "58a4a35b-fd77-5adc-af1c-6cc5e2013c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee569a6-20b0-4d37-91d6-db18de4b90c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee569a6-20b0-4d37-91d6-db18de4b90c6.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "All artifacts in play owned by target player are returned to that player's hand.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "05f3511e-c68f-5425-b867-1649f29597a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f18188-70fa-433e-a114-2f1dd49388ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f18188-70fa-433e-a114-2f1dd49388ed.jpg?1",
             "name": "Island Fish Jasconius",
             "text": "Does not untap during your untap phase.\nCannot attack if defending player controls no islands. If at any time you control no islands, bury Island Fish Jasconius.\no\nUo\nUoo\nU Untap Island Fish. Use this ability only during your upkeep.",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "df0b2514-c626-5ba9-bb06-07818dd9531a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b994bf9-5b3d-42c7-b4c6-f1029d78dd80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b994bf9-5b3d-42c7-b4c6-f1029d78dd80.jpg?1",
             "name": "Jump",
             "text": "Target creature gains flying until end of turn.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "ab15e752-dccf-59f1-aae2-2708c2b3a6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc98990-7fb0-4f69-a80d-38443966b3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc98990-7fb0-4f69-a80d-38443966b3ae.jpg?1",
             "name": "Leviathan",
             "text": "Trample\nComes into play tapped and does not untap during your untap phase.\nDuring your upkeep, you may sacrifice two islands to untap Leviathan.\nLeviathan cannot attack unless you sacrifice two islands during your attack.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "cf86aa45-01a0-51c7-b62f-c294cb6f43d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd3bd-d29b-4481-990b-f320e60c4f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd3bd-d29b-4481-990b-f320e60c4f91.jpg?1",
             "name": "Lifetap",
             "text": "Gain 1 life each time a forest controlled by target opponent becomes tapped.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "1d9ce2bb-72b6-51fe-91d5-d31d5ad3e4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846572ce-c8fd-402c-9212-8288336c75e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846572ce-c8fd-402c-9212-8288336c75e8.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk gain islandwalk and get +1/+1.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "d037bac0-70db-5035-9e9e-6eb1dba019f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c57f8a-6592-49b4-acb1-9b30500d1e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c57f8a-6592-49b4-acb1-9b30500d1e8c.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of target spell or target permanent by replacing all occurrences of one basic land type with another. For example, you may change \"swampwalk\" to \"plainswalk.\"",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "58d8e5bc-20c5-5cf2-8cd6-a28fd074d270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71935f14-d7ca-4406-9263-b2c7f5f5b94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71935f14-d7ca-4406-9263-b2c7f5f5b94f.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "85b0a8ed-b812-576c-969d-d87dcb7e1a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84fdcc-5463-45e9-9421-1d554ecdb8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84fdcc-5463-45e9-9421-1d554ecdb8ae.jpg?1",
             "name": "Mana Short",
             "text": "Mana Short empties target player's mana pool and taps that player's lands.",
             "colours": [
@@ -2737,7 +2737,7 @@
         },
         {
             "id": "1e8077ab-1ed7-5c5a-8364-76fb373352d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93661c9f-b529-4d82-b68d-3ce050f77e0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93661c9f-b529-4d82-b68d-3ce050f77e0d.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "75195773-b284-5799-931d-d633e1d095d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae30614-f558-4627-8e08-bf8a30ecd5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae30614-f558-4627-8e08-bf8a30ecd5b9.jpg?1",
             "name": "Mind Bomb",
             "text": "Mind Bomb deals 3 damage to each player. All players may discard up to three cards of their choice from their hands. Each card a player discards in this manner prevents 1 damage to that player from Mind Bomb.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "6a6a9a01-b8cb-5f48-9ff6-07fc90157329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc15dcf-6f78-4968-8af9-c115dfa10e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc15dcf-6f78-4968-8af9-c115dfa10e4c.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nDuring your upkeep, pay o\nU or destroy Phantasmal Forces.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "b6a2eaf4-af4c-5bd2-808a-6f5c1bfeff81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b3b65-e1f9-4a0d-95a6-42c2c4a358e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b3b65-e1f9-4a0d-95a6-42c2c4a358e5.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Target land becomes any basic land type of your choice.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "3d80c003-4148-5285-a194-dd3a6e26b719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa120ce-63a6-4d5e-9801-123d5e05646e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa120ce-63a6-4d5e-9801-123d5e05646e.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "fd5470b3-a07c-57e8-9680-e8ad08b9438f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7f104a-fb06-41a4-abd9-38f2c6017bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7f104a-fb06-41a4-abd9-38f2c6017bbf.jpg?1",
             "name": "Pirate Ship",
             "text": "Cannot attack if defending player controls no islands. If at any time you control no islands, bury Pirate Ship.\noc\nT: Pirate Ship deals 1 damage to target creature or player.",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "e8ed3095-6b41-5fc8-8d30-a802ac0247e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f235d7-8f6b-4d17-bc36-6f2cb6d5deec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f235d7-8f6b-4d17-bc36-6f2cb6d5deec.jpg?1",
             "name": "Power Leak",
             "text": "During the upkeep of target enchantment's controller, Power Leak deals 2 damage to him or her. That player may pay o1 for each damage he or she wishes to prevent from Power Leak.",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "0a1d403b-77f7-5b83-98c7-8055239872a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c51ab-c8b1-47be-8169-7f842712771c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c51ab-c8b1-47be-8169-7f842712771c.jpg?1",
             "name": "Power Sink",
             "text": "Counter a target spell if its caster does not pay o\nX. Target spell's caster must draw and pay all available mana from lands and mana pool until o\nX is paid; he or she may also pay mana from other sources if desired.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "a98e7244-2c9a-5264-a9ae-378799d27a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4e1161-5008-427f-a88e-5497a8eb84cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4e1161-5008-427f-a88e-5497a8eb84cd.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "32450317-bc7d-5776-92df-4bd54dbecaff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6641a587-c066-4f0a-a951-b91d3f749eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6641a587-c066-4f0a-a951-b91d3f749eb2.jpg?1",
             "name": "Psionic Entity",
             "text": "oc\nT: Psionic Entity deals 2 damage to target creature or player and 3 damage to itself.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "d085bd0a-507e-5d31-86ff-42b5b314c6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138db623-393d-485a-8fa8-f1b1b933fce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138db623-393d-485a-8fa8-f1b1b933fce5.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever target land becomes tapped, Psychic Venom deals 2 damage to that land's controller.",
             "colours": [
@@ -3098,7 +3098,7 @@
         },
         {
             "id": "c2d2b235-bb56-5ba1-a648-d6276ba2362b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05eee3dd-e17f-4154-8f8d-29c5421cd89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05eee3dd-e17f-4154-8f8d-29c5421cd89d.jpg?1",
             "name": "Relic Bind",
             "text": "When target artifact opponent controls becomes tapped, you may give 1 life or have Relic Bind deal 1 damage to target player.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "4aefa1eb-4f0c-5fa7-b6bc-b8b67b836da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e474391c-9ff0-4db4-9352-3fc07eeb4b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e474391c-9ff0-4db4-9352-3fc07eeb4b51.jpg?1",
             "name": "Sea Serpent",
             "text": "Cannot attack if defending player controls no islands. If at any time you control no islands, bury Sea Serpent.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "12361900-7922-56b5-9ee9-ae83b66d7a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e6e890-d1d0-4a9b-a453-5b51974a9dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e6e890-d1d0-4a9b-a453-5b51974a9dff.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "bbb9dfb4-db10-5335-8d79-d1c2b3362ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6906d0-4963-4f4b-aa29-ad98e9944107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6906d0-4963-4f4b-aa29-ad98e9944107.jpg?1",
             "name": "Sindbad",
             "text": "oc\nT: Draw a card. If it is not a land, discard it.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "b59d5f75-ae4e-5d11-bdcf-7e37016f13e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51832cfb-0a2e-4674-bb36-38027a71ac6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51832cfb-0a2e-4674-bb36-38027a71ac6d.jpg?1",
             "name": "Siren's Call",
             "text": "All of target opponent's creatures that can attack must do so. At end of turn, destroy any non-wall creatures that did not attack. Play only during opponent's turn, before opponent's attack. Siren's Call does not affect creatures brought under opponent's control this turn.",
             "colours": [
@@ -3261,7 +3261,7 @@
         },
         {
             "id": "332d5630-6183-575d-9060-b2c2ba13d033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd21dc3d-c9e6-4592-a655-1a20ee13ae73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd21dc3d-c9e6-4592-a655-1a20ee13ae73.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of target spell or target permanent by replacing all occurrences of one color word with another. For example, you may change \"Counters black spells\" to \"Counters blue spells.\" Sleight of Mind cannot change mana symbols.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "55db956d-b27d-5dd3-a0f1-b6ab637d9d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008df307-f010-47bc-8548-65a1c7b1c4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008df307-f010-47bc-8548-65a1c7b1c4b8.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell. X is the casting cost of the target spell.",
             "colours": [
@@ -3323,7 +3323,7 @@
         },
         {
             "id": "496c5077-f081-5def-b6a1-a027c449cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d29fed-248d-4547-9455-3d69b1f2787d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d29fed-248d-4547-9455-3d69b1f2787d.jpg?1",
             "name": "Stasis",
             "text": "Players do not get an untap phase. During your upkeep, pay o\nU or destroy Stasis.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "9f9c0d2c-83b4-5f9b-b7a6-756f8463bf01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd9ee1d-d1c5-4725-98fc-f6cff3a79512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd9ee1d-d1c5-4725-98fc-f6cff3a79512.jpg?1",
             "name": "Steal Artifact",
             "text": "Gain control of target artifact.",
             "colours": [
@@ -3387,7 +3387,7 @@
         },
         {
             "id": "7d568435-0a0e-558f-9b3e-96ad0e57f590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f89b4-cf98-4354-a2f4-3f63fe2dd99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f89b4-cf98-4354-a2f4-3f63fe2dd99e.jpg?1",
             "name": "Sunken City",
             "text": "All blue creatures get +1/+1. During your upkeep, pay o\nUo\nU or destroy Sunken City.",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "925a1d65-e640-504b-9622-cf9e81b7ff5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185674a4-db97-444d-b0e9-7dcfc245ce4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185674a4-db97-444d-b0e9-7dcfc245ce4b.jpg?1",
             "name": "Thoughtlace",
             "text": "Change the color of target spell or target permanent to blue. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "745922b8-822e-59e7-b983-ed17481a0005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957fa561-d090-435d-a0da-f405edb7e591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957fa561-d090-435d-a0da-f405edb7e591.jpg?1",
             "name": "Time Elemental",
             "text": "o2o\nUo\nU, oc\nT: Return target permanent to owner's hand. You cannot use this ability on permanents with enchantment cards played on them. If Time Elemental blocks or attacks, destroy it at end of combat. In this case, Time Elemental deals 5 damage to its controller.",
             "colours": [
@@ -3482,7 +3482,7 @@
         },
         {
             "id": "889a81ba-af08-5072-8289-e2d53354bdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db401643-6114-4254-8e40-ea7605e5ed82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db401643-6114-4254-8e40-ea7605e5ed82.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target land, artifact, or creature.",
             "colours": [
@@ -3513,7 +3513,7 @@
         },
         {
             "id": "617b2901-a4f9-5fb2-b42f-6256e43c19a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841ae3a3-30b5-4f0c-ad2f-af3d5e0da2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841ae3a3-30b5-4f0c-ad2f-af3d5e0da2e9.jpg?1",
             "name": "Unstable Mutation",
             "text": "Target creature gets +3/+3. During each of its controller's upkeeps, put a -1/-1 counter on the creature. These counters remain even if Unstable Mutation is removed.",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "733e9767-9853-507d-8cf5-77800cec0617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338948aa-463d-4af4-a0d6-64132512334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338948aa-463d-4af4-a0d6-64132512334c.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to owner's hand.",
             "colours": [
@@ -3577,7 +3577,7 @@
         },
         {
             "id": "ead3dd46-7f9d-5db1-bdb6-027e69734ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5828713a-edb3-4b11-b1f9-8f1bfc3c103f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5828713a-edb3-4b11-b1f9-8f1bfc3c103f.jpg?1",
             "name": "Volcanic Eruption",
             "text": "Destroy X target mountains. Volcanic Eruption deals 1 damage to each creature and player for each mountain put into the graveyard in this way.",
             "colours": [
@@ -3608,7 +3608,7 @@
         },
         {
             "id": "de5fe448-40c6-509f-9d3b-09303c6a719c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239435c8-3380-4556-9618-09fc0e40b69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239435c8-3380-4556-9618-09fc0e40b69d.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "f24fc8c9-1f57-55d6-a246-61ba0cddb097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78028eda-61b0-408c-b3fc-adc968d39b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78028eda-61b0-408c-b3fc-adc968d39b47.jpg?1",
             "name": "Wall of Water",
             "text": "oo\nU +1/+0 until end of turn",
             "colours": [
@@ -3674,7 +3674,7 @@
         },
         {
             "id": "ec426a99-e659-5117-9e5c-06bd1c55eb33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadea972-714e-4f6d-8fb7-a59c0ac1e028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadea972-714e-4f6d-8fb7-a59c0ac1e028.jpg?1",
             "name": "Water Elemental",
             "text": "",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "44b88c17-34d1-5dee-b32e-3e6a4b4b8e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ee0fd-9eb3-4d81-9972-9e7f4c4d64e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ee0fd-9eb3-4d81-9972-9e7f4c4d64e4.jpg?1",
             "name": "Zephyr Falcon",
             "text": "Flying\nAttacking does not cause Zephyr Falcon to tap.",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "80592cff-0521-5d10-9939-0e0888a659cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a363bc91-8278-448e-9d5c-564e4b51eb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a363bc91-8278-448e-9d5c-564e4b51eb62.jpg?1",
             "name": "Abomination",
             "text": "At the end of combat, destroy all green and white creatures blocking or blocked by Abomination.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "44844f70-8247-5b78-aa78-8255735a3bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1dc456-1f64-4f24-a646-84c57e641b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1dc456-1f64-4f24-a646-84c57e641b3b.jpg?1",
             "name": "Animate Dead",
             "text": "Take target creature from any graveyard and put it directly into play under your control with -1/-0. Treat this creature as though it were just summoned. If Animate Dead is removed, bury the creature in its owner's graveyard.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "aa3a29d9-1fa7-5e83-a1c1-f9c443a38b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f40650-9dd5-473d-a660-448672d475a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f40650-9dd5-473d-a660-448672d475a5.jpg?1",
             "name": "Ashes to Ashes",
             "text": "Ashes to Ashes removes two target non-artifact creatures from the game and deals 5 damage to you.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "13b2b052-d557-5f16-9501-0648b2b7e958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca216e2-27a5-40e1-bb61-0ddcd8ee02ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca216e2-27a5-40e1-bb61-0ddcd8ee02ae.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures get +1/+1.",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "de61e097-e684-5d0e-921c-c1d5d81b7cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47716cf4-f35c-4613-9686-4e00b5063408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47716cf4-f35c-4613-9686-4e00b5063408.jpg?1",
             "name": "Black Knight",
             "text": "Protection from white, first strike",
             "colours": [
@@ -3902,7 +3902,7 @@
         },
         {
             "id": "53251e4f-db9c-5b32-b8b2-55de7f1fd6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59365350-d149-4c0d-a08f-eabdfb7cce3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59365350-d149-4c0d-a08f-eabdfb7cce3d.jpg?1",
             "name": "Blight",
             "text": "If target land becomes tapped, destroy it at end of turn.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "2a48b903-2e45-5028-8969-b5f8a3eb9846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50c3053-3cf3-40d3-bc9e-2fc292f11c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50c3053-3cf3-40d3-bc9e-2fc292f11c34.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "1ca5c1fe-e999-51eb-8fc5-9f0389f3763b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf82ad6-b32e-41ea-abea-22b8eef69e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf82ad6-b32e-41ea-abea-22b8eef69e67.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "cbf26c87-78b7-5636-81f8-a759e16942c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5de329d-fb08-4c4a-883f-1d77dc64470d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5de329d-fb08-4c4a-883f-1d77dc64470d.jpg?1",
             "name": "Carrion Ants",
             "text": "o1: +1/+1 until end of turn",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "0b8f7989-e7d0-5713-9071-34e4bb306bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e975cc-e89d-4ac3-b9dc-dad202dacc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e975cc-e89d-4ac3-b9dc-dad202dacc14.jpg?1",
             "name": "Cosmic Horror",
             "text": "First strike\nDuring your upkeep, pay o3o\nBo\nBo\nB or destroy Cosmic Horror. If you destroy Cosmic Horror in this way, it deals 7 damage to you.",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "d8b75815-5fd6-5062-a340-7f0a5b26ba34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d9fb0a-1087-43cd-9e14-24c1685a2057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d9fb0a-1087-43cd-9e14-24c1685a2057.jpg?1",
             "name": "Cursed Land",
             "text": "Cursed Land deals 1 damage to target land's controller during his or her upkeep.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "642ed5f4-fb4c-5e9c-b5a4-1424cdaf39b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201b51b-da03-4207-805c-134e527c42e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201b51b-da03-4207-805c-134e527c42e1.jpg?1",
             "name": "Cyclopean Mummy",
             "text": "If Mummy is put into the graveyard from play, remove it from the game.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "b8a5d2d9-1285-50fc-9084-3c7bc8a32735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3477f601-5374-4316-a74e-b5e198af482b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3477f601-5374-4316-a74e-b5e198af482b.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "e3da185b-8c34-5678-a953-baa45094cb15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2ae05-29ec-4005-8d78-280a190601c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2ae05-29ec-4005-8d78-280a190601c4.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Counter target green spell. Play this ability as an interrupt.",
             "colours": [
@@ -4195,7 +4195,7 @@
         },
         {
             "id": "4a8a9241-829f-5368-9645-ef3a26ac11db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e37fb-383d-432c-8ac3-1332096567db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e37fb-383d-432c-8ac3-1332096567db.jpg?1",
             "name": "Deathlace",
             "text": "Change the color of target spell or target permanent to black. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "e8d97363-a6e0-50e8-863b-6b3e6289ebfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d10677-36f0-4339-a2c3-213e8ee1c51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d10677-36f0-4339-a2c3-213e8ee1c51d.jpg?1",
             "name": "Drain Life",
             "text": "Drain Life deals 1 damage to a target creature or player for each o\nB you pay in addition to the casting cost. You then gain 1 life for each 1 damage dealt. You cannot gain more life than the toughness of the creature or the total life of the player Drain Life damages.",
             "colours": [
@@ -4257,7 +4257,7 @@
         },
         {
             "id": "88b1acea-74c9-5597-a72e-9c65504832a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d223d3-72c1-4240-9323-84484167c5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d223d3-72c1-4240-9323-84484167c5e0.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -4290,7 +4290,7 @@
         },
         {
             "id": "9a20c486-2374-5a16-a051-356122e226dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371bd2-89ad-487e-8f27-37a6e75ca0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371bd2-89ad-487e-8f27-37a6e75ca0f5.jpg?1",
             "name": "El-Hajj\u00e2j",
             "text": "Gain 1 life for every 1 damage El-Hajj\u00e2j deals. You cannot gain more life in this way than the toughness of the creature or the total life of the player that El-Hajj\u00e2j damages.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "fa1bb5f6-1cc6-53cb-832c-99fbea177298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320906ee-791a-41c0-9b28-9a287cdb3340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320906ee-791a-41c0-9b28-9a287cdb3340.jpg?1",
             "name": "El-Hajj\u00e2j",
             "text": "",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "b4a8e92a-c848-591f-9240-dfd1bf68679f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472c83ff-66aa-485b-9ca7-aef8731de20a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472c83ff-66aa-485b-9ca7-aef8731de20a.jpg?1",
             "name": "Erg Raiders",
             "text": "If you do not attack with Erg Raiders during your turn, it deals 2 damage to you at end of turn. Erg Raiders deals no damage to you the turn it comes into play on your side.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "709985a4-8f48-5dd7-bd2e-05587d046947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbca45f-7b08-408b-9445-e3f2b9563f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbca45f-7b08-408b-9445-e3f2b9563f1b.jpg?1",
             "name": "Evil Presence",
             "text": "Target land becomes a basic swamp.",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "06ffff78-cb07-5016-bbe0-445798c13aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126c1b02-01bd-4b70-9293-a89173b4cd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126c1b02-01bd-4b70-9293-a89173b4cd32.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked except by black creatures and artifact creatures.",
             "colours": [
@@ -4462,7 +4462,7 @@
         },
         {
             "id": "d6486f4f-10cc-5eaf-b087-a372a45518e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95547c2a-c01b-45ed-b775-f33c157b17a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95547c2a-c01b-45ed-b775-f33c157b17a5.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "23b8bb5e-ee8d-5d64-8036-b17caeb8bb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a8573d-0e2d-4a7f-a47f-7e1bc472d4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a8573d-0e2d-4a7f-a47f-7e1bc472d4fa.jpg?1",
             "name": "Gloom",
             "text": "White spells cost an additional o3 to cast. White enchantments with activation costs require an additional o3 to use.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "bd2cec1a-9948-5d49-a58a-76b8bc45a364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb0c62-1c53-464e-a2df-59285f2d593d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb0c62-1c53-464e-a2df-59285f2d593d.jpg?1",
             "name": "Greed",
             "text": "oo\nB Pay 2 life to draw a card. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "776d361e-8a02-580a-b8b0-1a9c3fee23d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba7b1e-90a0-419e-bcba-a6b19beacf29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba7b1e-90a0-419e-bcba-a6b19beacf29.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "65448da2-b6b0-5aba-9077-a298475b19b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5900350-be08-4904-8f1b-cc180ed08485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5900350-be08-4904-8f1b-cc180ed08485.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nAn opponent damaged by Specter discards a card at random from his or her hand. Ignore this effect if opponent has no cards in hand.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "04261def-edd3-5afb-baa5-63d0abf61eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398a2b0f-0b91-408c-8083-3bc89873b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398a2b0f-0b91-408c-8083-3bc89873b69f.jpg?1",
             "name": "Jun\u00fan Efreet",
             "text": "Flying\nDuring your upkeep, pay o\nBo\nB or bury Jun\u00fan Efreet.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "7a95a968-3b71-5b6e-be4c-31b53504ddb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9691e76c-770d-4721-b758-805574227de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9691e76c-770d-4721-b758-805574227de1.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nDuring your upkeep, sacrifice a creature. If you cannot sacrifice a creature, Lord of the Pit deals 7 damage to you. You cannot sacrifice Lord of the Pit to itself.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "db8f1035-781d-5861-be92-e0a6841aef12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b875b1-e534-4ed8-9ebd-8f4d5a066e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b875b1-e534-4ed8-9ebd-8f4d5a066e7d.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "71cbf3a7-3f16-526e-a829-ce3fd10447e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c65bf9-cbab-45ee-9c6e-f8ee832dbe61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c65bf9-cbab-45ee-9c6e-f8ee832dbe61.jpg?1",
             "name": "Marsh Gas",
             "text": "All creatures get -2/-0 until end of turn.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "ad44c9a4-b7f0-5bff-a5cd-dcd576d7c084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb6765c-a052-46dc-a589-200b8ba8c99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb6765c-a052-46dc-a589-200b8ba8c99f.jpg?1",
             "name": "Mind Twist",
             "text": "Target player discards X cards at random from his or her hand. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "1a75e115-7cfd-5d69-accc-4a2037683656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7731dc37-2eac-4e60-bb0f-6230205a5323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7731dc37-2eac-4e60-bb0f-6230205a5323.jpg?1",
             "name": "Murk Dwellers",
             "text": "When attacking and not blocked, Murk Dwellers gets +2/+0 until end of turn.",
             "colours": [
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "65e20f1c-de88-50f4-9562-7e260221611f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d9e96-0c7f-45c5-b6d0-6444ef84bab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d9e96-0c7f-45c5-b6d0-6444ef84bab1.jpg?1",
             "name": "Nether Shadow",
             "text": "At the end of your upkeep, if Shadow is in your graveyard with at least three creature cards above it, you may return it to play. Shadow can attack the turn it comes into play.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "a25221d0-6a12-5709-b239-69b3aefac69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db11b832-7584-4e4b-8d02-b03fe76dcbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db11b832-7584-4e4b-8d02-b03fe76dcbc3.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare has power and toughness each equal to the number of swamps its controller controls.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "8ce49d4c-7501-5754-8ba6-ba3e45dd6002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bcad9a-b69c-434a-8d48-6b727bd8e382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bcad9a-b69c-434a-8d48-6b727bd8e382.jpg?1",
             "name": "Paralyze",
             "text": "Target creature does not untap during its controller's untap phase. That player may pay an additional o4 during his or her upkeep to untap it. Tap target creatures when Paralyze comes into play.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "5533725e-a850-5e7f-af9f-07d2ee18fb89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90886a02-4c1f-48ea-8563-6d80c97d9f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90886a02-4c1f-48ea-8563-6d80c97d9f58.jpg?1",
             "name": "Pestilence",
             "text": "At the end of any turn, if there are no creatures in play, bury Pestilence.\noo\nB Pestilence deals 1 damage to all creatures and players.",
             "colours": [
@@ -4947,7 +4947,7 @@
         },
         {
             "id": "a3c70845-cd5f-52bd-8d34-b8d30139637b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a53418c-3720-4aa3-a525-6bc82c363844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a53418c-3720-4aa3-a525-6bc82c363844.jpg?1",
             "name": "Pit Scorpion",
             "text": "If Pit Scorpion damages a player, he or she gets a poison counter. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "d1c4db3e-d5b4-5d63-be9f-1a0563461260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901591cb-a7e9-47c1-96ff-3de7b39b1055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901591cb-a7e9-47c1-96ff-3de7b39b1055.jpg?1",
             "name": "Plague Rats",
             "text": "Plague Rats has power and toughness each equal to the number of Plague Rats in play, no matter who controls them. For example, if there are two Plague Rats in play, each has power and toughness 2/2.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "f80ac040-e936-5c1f-8c13-19e27ff240f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a02f9-81f7-412b-8e98-d7be3eb73eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a02f9-81f7-412b-8e98-d7be3eb73eca.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at target opponent's hand. If that player has any creature cards in hand, he or she discards one of them at random. Use this ability only during your turn.",
             "colours": [
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "a1d2b18a-ae77-54a8-a5ac-59e8a90ce144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2096e54e-1a55-4fd7-8415-a6f2fdb2a536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2096e54e-1a55-4fd7-8415-a6f2fdb2a536.jpg?1",
             "name": "Raise Dead",
             "text": "Take target creature from your graveyard and put it into your hand.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "c3f261bd-308f-5684-8b1c-2467763d52ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d51bdf-f118-4a1e-9060-bdf3c78697f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d51bdf-f118-4a1e-9060-bdf3c78697f2.jpg?1",
             "name": "Royal Assassin",
             "text": "oc\nT: Destroy target tapped creature.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "5c84f582-7aa0-550c-b947-b69c7ec1807a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd55d32-e969-4d12-b101-a35db8a53921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd55d32-e969-4d12-b101-a35db8a53921.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "8ddc4675-a7cd-5ac3-8951-1cdde968c9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0baaa9-c42b-413a-b10d-95689e4ddb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0baaa9-c42b-413a-b10d-95689e4ddb50.jpg?1",
             "name": "Scavenging Ghoul",
             "text": "At the end of each turn, put a corpse counter on Scavenging Ghoul for each creature put into the graveyard during that turn.\no0: Remove a corpse counter from Scavenging Ghoul to regenerate it.",
             "colours": [
@@ -5178,7 +5178,7 @@
         },
         {
             "id": "b98a33cc-3cb9-5e91-b391-0012430de104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e29882a-c194-48b8-ba18-439b0bda395e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e29882a-c194-48b8-ba18-439b0bda395e.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nPut a +1/+1 counter on Sengir Vampire each time a creature is put into the graveyard the same turn Sengir Vampire damaged it.",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "53e7692f-fb0e-527f-936c-7f2e6af0aae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c23232c-a264-4df9-824b-4111a5c6524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c23232c-a264-4df9-824b-4111a5c6524c.jpg?1",
             "name": "Simulacrum",
             "text": "All damage done to you so far this turn is instead retroactively applied to a target creature you control. Further damage this turn is treated normally.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "3a6b1975-3a04-5c11-801a-3be205ee324d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4855db6-570c-4845-9074-a9df7611307a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4855db6-570c-4845-9074-a9df7611307a.jpg?1",
             "name": "Sorceress Queen",
             "text": "oc\nT: Target creature other than Sorceress Queen becomes 0/2 until end of turn.",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "d3a00043-d96c-58d7-b8c3-33d4791ed1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df0c902-3fe1-4de7-9777-7ddb563b6cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df0c902-3fe1-4de7-9777-7ddb563b6cec.jpg?1",
             "name": "Spirit Shackle",
             "text": "Put a -0/-2 counter on target creature every time it becomes tapped. These counters remain even if Spirit Shackle is removed.",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "1e7f5837-86ac-5d6c-9720-55a43703ba01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5d44d-977d-4d0d-8242-17c8ffa7247c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5d44d-977d-4d0d-8242-17c8ffa7247c.jpg?1",
             "name": "Terror",
             "text": "Bury target non-black, non-artifact creature.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "5e7ca5b8-31ee-525a-8c25-198b1dfbb784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf5aa58-f68b-4197-9697-1e6653760853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf5aa58-f68b-4197-9697-1e6653760853.jpg?1",
             "name": "Uncle Istvan",
             "text": "All damage done to Uncle Istvan by creatures is reduced to 0.",
             "colours": [
@@ -5373,7 +5373,7 @@
         },
         {
             "id": "84d19be4-a4d8-5047-82f8-2f25ef51cca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c3c85-1462-406c-8e3b-c25deda9c4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c3c85-1462-406c-8e3b-c25deda9c4e6.jpg?1",
             "name": "Unholy Strength",
             "text": "Target creature gets +2/+1.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "01cc31a8-e1da-5dde-bec1-b656a32cc866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2aed701-5164-4c63-9539-3d2406970f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2aed701-5164-4c63-9539-3d2406970f46.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying\noo\nB +1/+0 until end of turn. You cannot spend more than o\nBo\nB in this way each turn.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "c33226f0-f6c4-5ada-bdf2-d32373a48fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce3251-017f-4834-9935-0985c56cccb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce3251-017f-4834-9935-0985c56cccb7.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "f516d4a9-a726-58e6-b6ca-16c6d29330ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc2fcd5-e7a5-4a66-b385-82726ee6e3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc2fcd5-e7a5-4a66-b385-82726ee6e3cc.jpg?1",
             "name": "Warp Artifact",
             "text": "Warp Artifact deals 1 damage to target artifact's controller during his or her upkeep.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "1b323990-6633-5521-8e35-71375ad7c5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d4cd1-7cc6-44ee-872e-68e5bcc608fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d4cd1-7cc6-44ee-872e-68e5bcc608fb.jpg?1",
             "name": "Weakness",
             "text": "Target creature gets -2/-1.",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "275f938f-c895-517c-9bd7-cae92f7c6a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef317-8105-4917-ba3c-93de3eebd944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef317-8105-4917-ba3c-93de3eebd944.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying\noo\nB Regenerate",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "41916568-555a-59ff-b4de-e21ea15281a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715472e1-585b-4379-b335-8f3b5e572d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715472e1-585b-4379-b335-8f3b5e572d83.jpg?1",
             "name": "Word of Binding",
             "text": "Tap X target creatures.",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "6fed95cb-c1f3-5576-85fd-1a5bb721f237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c546db-0871-4a13-8654-c26ae9f9b50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c546db-0871-4a13-8654-c26ae9f9b50a.jpg?1",
             "name": "Xenic Poltergeist",
             "text": "oc\nT: Target non-creature artifact becomes an artifact creature with power and toughness each equal to its casting cost. Target retains all original abilities. This change lasts until your next upkeep.",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "99c0cef6-1881-5050-b8e9-4a41dcbfb741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86753ae-c8da-47d7-b97a-3c75f83ee929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86753ae-c8da-47d7-b97a-3c75f83ee929.jpg?1",
             "name": "Zombie Master",
             "text": "All zombies gain swampwalk and\n\"oo\nB Regenerate.\"",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "b472c43a-64d0-5ca8-aedd-1fecc4a31604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92191f72-e3d7-4679-97a2-f0c2d19d7738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92191f72-e3d7-4679-97a2-f0c2d19d7738.jpg?1",
             "name": "Ali Baba",
             "text": "oo\nR Tap target wall.",
             "colours": [
@@ -5703,7 +5703,7 @@
         },
         {
             "id": "20a644ac-87e2-5124-bf47-82e2e617771b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bccf9a0-8d93-4b5e-ada0-1f19f260e5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bccf9a0-8d93-4b5e-ada0-1f19f260e5a8.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample\nBall Lightning can attack the turn it comes into play. At the end of any turn, bury Ball Lightning.",
             "colours": [
@@ -5736,7 +5736,7 @@
         },
         {
             "id": "366ff2f6-17cc-53c0-8a0b-2d1a513e5727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81a99a-0380-456f-8e81-753add511dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81a99a-0380-456f-8e81-753add511dbe.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "a6c1ddbe-1675-5feb-8c57-7524f8a61de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426e477f-2873-4115-9527-a50a97769dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426e477f-2873-4115-9527-a50a97769dd1.jpg?1",
             "name": "Blood Lust",
             "text": "Target creature gets +4/-4 until end of turn. If this reduces creature's toughness to less than 1, creature's toughness becomes 1.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "86032e38-18f3-55b4-ba84-6edad18f7033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66674f3a-e882-44f1-addc-d74605150c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66674f3a-e882-44f1-addc-d74605150c39.jpg?1",
             "name": "Brothers of Fire",
             "text": "1o\nRoo\nR Brothers of Fire deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "9c4f6677-c11c-50e4-8399-27d98dac9c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946f1a83-6fcc-45b0-91fc-9c75504a16f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946f1a83-6fcc-45b0-91fc-9c75504a16f3.jpg?1",
             "name": "Burrowing",
             "text": "Target creature gains mountainwalk.",
             "colours": [
@@ -5868,7 +5868,7 @@
         },
         {
             "id": "2a89fd09-e5b6-545c-a811-409be073a5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9ff47-b98c-4ab6-a4bc-8914360c3f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9ff47-b98c-4ab6-a4bc-8914360c3f6d.jpg?1",
             "name": "Cave People",
             "text": "When attacking, Cave People gets +1/-2 until end of turn.\n1o\nRo\nR, oc\nT: Target creature gains mountainwalk until end of turn.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "d887cc5e-1334-5473-9dd4-f993e5e9ecdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476180df-8b88-4ead-b6c5-6ccb3e8a2cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476180df-8b88-4ead-b6c5-6ccb3e8a2cfd.jpg?1",
             "name": "Chaoslace",
             "text": "Change the color of target spell or target permanent to red. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "48cec9ab-481b-52ff-9ef3-a6f08e1c23a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8fc5c-368f-4b25-a33e-a32855037c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8fc5c-368f-4b25-a33e-a32855037c4b.jpg?1",
             "name": "Crimson Manticore",
             "text": "Flying\no\nR, oc\nT: Manticore deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -5965,7 +5965,7 @@
         },
         {
             "id": "24ca8b51-803f-5ce4-811b-528e84f43318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e23d23-92ca-4d74-88e8-e1137d7faaf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e23d23-92ca-4d74-88e8-e1137d7faaf1.jpg?1",
             "name": "Detonate",
             "text": "Bury target artifact. Detonate deals X damage to the artifact's controller, where X is the casting cost of the artifact.",
             "colours": [
@@ -5996,7 +5996,7 @@
         },
         {
             "id": "a9b0d5aa-3322-5892-b99f-2c67534a7a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f41f868-454e-4075-9ef4-bcf3754d421c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f41f868-454e-4075-9ef4-bcf3754d421c.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate deals X damage to target creature or player. The target cannot regenerate until end of turn. If the target receives lethal damage this turn, remove it from the game entirely.",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "3baef929-6dea-5506-a1cb-5994493745a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ff6e6-b914-4787-bb90-ea77a3550d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ff6e6-b914-4787-bb90-ea77a3550d23.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\noo\nR +1/+0 until end of turn. If you spend more than o\nRo\nRo\nR in this way during one turn, destroy Dragon Whelp at end of turn.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "852e2a66-1ad6-5d80-b593-d561b85c0378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3616f381-ca10-4945-b95e-96dfefa3c303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3616f381-ca10-4945-b95e-96dfefa3c303.jpg?1",
             "name": "Dwarven Warriors",
             "text": "oc\nT: Target creature with power no greater than 2 becomes unblockable until end of turn. Other effects may later be used to increase the creature's power beyond 2.",
             "colours": [
@@ -6094,7 +6094,7 @@
         },
         {
             "id": "d22ec98f-620f-59b3-8d39-4f55827b198b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a859fd-28a3-470f-adf4-c6431ced27e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a859fd-28a3-470f-adf4-c6431ced27e1.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "544a97b7-763c-5a44-9aca-cabdabf753cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ec03ce-a8a3-42c3-a895-21cce1657411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ec03ce-a8a3-42c3-a895-21cce1657411.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each player and each creature without flying.",
             "colours": [
@@ -6158,7 +6158,7 @@
         },
         {
             "id": "e9aaf530-a67f-5010-bc40-87efd71e96fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d574075-9909-444a-817f-d6ad419aa62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d574075-9909-444a-817f-d6ad419aa62c.jpg?1",
             "name": "Eternal Warrior",
             "text": "Attacking does not cause target creature to tap.",
             "colours": [
@@ -6191,7 +6191,7 @@
         },
         {
             "id": "03c06c2f-77af-59d1-86b5-0bf492f9a4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0261cd0f-e763-49b5-96ed-5e5767a3d8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0261cd0f-e763-49b5-96ed-5e5767a3d8d7.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "903f2b9a-0b13-54f2-be60-06391544c58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe078d7-cdde-44bb-942e-417123ebeccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe078d7-cdde-44bb-942e-417123ebeccb.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage, divided evenly (round down) among any number of target creatures and/or players. Pay an additional o1 for each target beyond the first.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "d09ed90f-6c42-5372-bdda-0dc4c83fdedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294892cb-3927-4bf0-97ca-f37bdd0b9de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294892cb-3927-4bf0-97ca-f37bdd0b9de5.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Target creature Firebreathing enchants gets +1/+0 until end of turn.",
             "colours": [
@@ -6288,7 +6288,7 @@
         },
         {
             "id": "e8c52da2-9dfc-5caa-bb4a-bfb8b4f994c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7601b15a-53d8-499f-837b-abf369d1e3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7601b15a-53d8-499f-837b-abf369d1e3f4.jpg?1",
             "name": "Fissure",
             "text": "Bury target land or creature.",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "1949c2c5-fe6b-5535-b79a-c3936cdbb083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0de18a-1dad-49f1-8127-09aa07b69eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0de18a-1dad-49f1-8127-09aa07b69eb0.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "1ddce5f9-8efc-5136-8c80-eec949fbe20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1aebd61-311c-4269-aa75-5c004639178d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1aebd61-311c-4269-aa75-5c004639178d.jpg?1",
             "name": "Giant Strength",
             "text": "Target creature gets +2/+2.",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "02046592-7755-5f65-8e24-ea7110dca7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866df71c-856c-451d-a11b-c2086c265868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866df71c-856c-451d-a11b-c2086c265868.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "oo\nR Flying until end of turn",
             "colours": [
@@ -6417,7 +6417,7 @@
         },
         {
             "id": "2d03c702-bc5a-599b-a976-8c47708043f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dd4aef-6d15-4d74-96cf-1cc51812b541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dd4aef-6d15-4d74-96cf-1cc51812b541.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins gain mountainwalk and get +1/+1.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "05bc686b-4f13-50a8-9357-d973bec32e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f4f0c1-a43e-4282-b20e-91c711c57521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f4f0c1-a43e-4282-b20e-91c711c57521.jpg?1",
             "name": "Goblin Rock Sled",
             "text": "Trample\nCannot attack if defending player controls no mountains. Rock Sled does not untap during your untap phase if it attacked during your last turn.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "3cffdb63-be36-501e-829c-7f17e8c09d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2cc0-799f-4eb8-b338-ed7543f469e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2cc0-799f-4eb8-b338-ed7543f469e7.jpg?1",
             "name": "Gray Ogre",
             "text": "",
             "colours": [
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "1523626c-d2bf-5b2c-bf53-99f1e4941640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac25236-c2f2-48df-8dbb-d4f9ce790cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac25236-c2f2-48df-8dbb-d4f9ce790cfb.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "a0c74804-2327-5038-9bdc-a8a81c78cd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c27de-e788-4ad7-b1e3-030e7ef00471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c27de-e788-4ad7-b1e3-030e7ef00471.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "3e5fa9a0-1603-5d16-b92a-9381318fad1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0ab2b-04bf-4cba-8efa-3d1d0ab4f50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0ab2b-04bf-4cba-8efa-3d1d0ab4f50d.jpg?1",
             "name": "Hurr Jackal",
             "text": "oc\nT: Target creature cannot regenerate this turn.",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "1b576374-2daf-5152-8679-57ac46e2ea16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dbfdc1-a598-4c72-9b0d-91207bd067ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dbfdc1-a598-4c72-9b0d-91207bd067ab.jpg?1",
             "name": "Immolation",
             "text": "Target creature gets +2/-2.",
             "colours": [
@@ -6648,7 +6648,7 @@
         },
         {
             "id": "b810484a-09b4-5236-8e05-49af16261376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db90782-fa89-4470-bec5-27614e88a0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db90782-fa89-4470-bec5-27614e88a0a9.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to all players and all creatures.",
             "colours": [
@@ -6679,7 +6679,7 @@
         },
         {
             "id": "9f3d38e3-b063-5e0c-b2d6-45d0b481ea0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d882105f-2de0-46ae-b673-01508c016cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d882105f-2de0-46ae-b673-01508c016cc6.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Cannot be assigned to block any creature with power greater than 1.",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "a488205f-4022-53f6-ac38-6c11f66e7980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a32db7-e1a8-47d8-a708-987bcbf0636e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a32db7-e1a8-47d8-a708-987bcbf0636e.jpg?1",
             "name": "Keldon Warlord",
             "text": "Keldon Warlord has power and toughness each equal to the number of non-wall creatures you control, including Warlord. For example, if you control two other non-wall creatures, Warlord is 3/3. If one of those creatures leaves play, Warlord immediately becomes 2/2.",
             "colours": [
@@ -6746,7 +6746,7 @@
         },
         {
             "id": "61aa652c-e307-5b1c-9332-9025ebbcb504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9521375e-0bc1-45ef-b513-6d332a25f9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9521375e-0bc1-45ef-b513-6d332a25f9d2.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "3de4a6ef-8236-5d9a-acab-e6c2a8b8e57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993a14d5-a33d-426e-ab49-c3226a6fcdca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993a14d5-a33d-426e-ab49-c3226a6fcdca.jpg?1",
             "name": "Magnetic Mountain",
             "text": "Blue creatures do not untap during their controllers' untap phase. During his or her upkeep, a player may pay an additional o4 to untap a blue creature he or she controls.",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "596277e0-8429-566a-a802-6864f58b5cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01f27b7-f1d0-4fb6-b743-ca7a810ef85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01f27b7-f1d0-4fb6-b743-ca7a810ef85c.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to any player whose coin comes up tails. Repeat this process until both players' coins come up heads at the same time.",
             "colours": [
@@ -6839,7 +6839,7 @@
         },
         {
             "id": "2180d8d3-87ca-50ab-b289-da08d035c68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7169e26-e700-4e71-b959-4592a03f3c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7169e26-e700-4e71-b959-4592a03f3c9f.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever a player taps a land for mana, it produces one additional mana of the same type.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "ef702226-9086-546c-b41f-c8fbd1486001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4f505-bc05-44ac-9190-60101f813c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4f505-bc05-44ac-9190-60101f813c65.jpg?1",
             "name": "Manabarbs",
             "text": "Each time any land is tapped for mana, Manabarbs deals 1 damage to that land's controller.",
             "colours": [
@@ -6901,7 +6901,7 @@
         },
         {
             "id": "56f25954-dca7-57cc-a247-1d35d35e3b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f31c715-9ab8-4578-989f-141099b6750c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f31c715-9ab8-4578-989f-141099b6750c.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "d777db02-4e5e-51d0-954a-41d64e657ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19281eb4-f5b6-4b27-8c65-7e56d2a8ab77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19281eb4-f5b6-4b27-8c65-7e56d2a8ab77.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -6968,7 +6968,7 @@
         },
         {
             "id": "6b2b6763-754b-5524-9f28-9a83499fb8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc0d8b-2d4b-4c3b-a9af-b5fae35e6ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc0d8b-2d4b-4c3b-a9af-b5fae35e6ec5.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "All attacking creatures you control get +1/+0.",
             "colours": [
@@ -6999,7 +6999,7 @@
         },
         {
             "id": "d8c085d5-026d-517b-a37d-55dea1ab8230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5717af-a1a3-45cb-8b05-7543eed5532a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5717af-a1a3-45cb-8b05-7543eed5532a.jpg?1",
             "name": "Power Surge",
             "text": "During each player's upkeep, Power Surge deals that player 1 damage for each land he or she controls that was untapped at the beginning of the turn, before the untap phase.",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "bb06a258-4d15-5546-a000-46da0bff46c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e32142d-b161-4497-a6cd-ba4c67e16a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e32142d-b161-4497-a6cd-ba4c67e16a6f.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -7061,7 +7061,7 @@
         },
         {
             "id": "4f7097d5-d451-51b0-8e21-6aca031bb56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54246c9-5e5c-484e-a546-ae1f9fd020f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54246c9-5e5c-484e-a546-ae1f9fd020f3.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Counter target blue spell or destroy target blue permanent.",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "e32a177c-282e-5040-8708-b6fd6887c7be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd44196-aa28-4143-872d-592c6fc175a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd44196-aa28-4143-872d-592c6fc175a9.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -7123,7 +7123,7 @@
         },
         {
             "id": "56cccad5-d100-5871-96d0-29b9b46670d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70846483-9c23-42c4-9f9f-1fc5cda17c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70846483-9c23-42c4-9f9f-1fc5cda17c77.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\noo\nR +1/+0 until end of turn",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "92241b85-ecc8-5e6b-8947-9fbe447494e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ab53c-133a-4211-8499-aea00ed3ee1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ab53c-133a-4211-8499-aea00ed3ee1d.jpg?1",
             "name": "Sisters of the Flame",
             "text": "oc\nT: Add o\nR to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7190,7 +7190,7 @@
         },
         {
             "id": "2c3300df-f3ed-5813-ba1c-dfe4861ae53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2069f9b-578a-45da-bd52-3c208465be88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2069f9b-578a-45da-bd52-3c208465be88.jpg?1",
             "name": "Smoke",
             "text": "No player may untap more than one creature during his or her untap phase.",
             "colours": [
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "c1617b76-fd89-5848-9f40-24076765a760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265de55e-63d2-4a5d-9078-858da70f2a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265de55e-63d2-4a5d-9078-858da70f2a08.jpg?1",
             "name": "Stone Giant",
             "text": "oc\nT: Target creature you control, which must have toughness less than Stone Giant's power, gains flying until end of turn. Destroy that creature at end of turn. Other effects may later be used to increase the creature's toughness beyond Stone Giant's power.",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "a762daa9-d0ce-5c5a-8583-45cdb93e576e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9029bfb-fcff-4f80-a423-c2cfdc881c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9029bfb-fcff-4f80-a423-c2cfdc881c61.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "1fd6bd7b-a754-5d97-89e3-e84336d848f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea6dfe-64d6-451a-bd34-31546996e711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea6dfe-64d6-451a-bd34-31546996e711.jpg?1",
             "name": "Tempest Efreet",
             "text": "oc\nT: Choose a card at random from target opponent's hand and put it in yours. Bury Tempest Efreet in opponent's graveyard. The change in ownership is permanent. Play this ability as an interrupt. Before you choose the card to be switched, the opponent may prevent effect by paying 10 life or conceding game; if this is done, bury Tempest Efreet. Effects that prevent or redirect damage cannot be used to counter this loss of life. Remove Tempest Efreet from your deck before playing if not playing for ante.",
             "colours": [
@@ -7318,7 +7318,7 @@
         },
         {
             "id": "9cf35445-ebca-5a9e-986a-bb19c52d0e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b58ca62-6532-45e5-ad51-84a388d5cc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b58ca62-6532-45e5-ad51-84a388d5cc4d.jpg?1",
             "name": "The Brute",
             "text": "Target creature gets +1/+0.\no\nRo\nRoo\nR Regenerate target creature The Brute enchants.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "a589dfa9-65a3-5a1a-aed0-664008418566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9483f5d0-c627-43ed-bfaa-1559855c8a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9483f5d0-c627-43ed-bfaa-1559855c8a6d.jpg?1",
             "name": "Tunnel",
             "text": "Bury target wall.",
             "colours": [
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "f88714c2-9f4c-5460-b006-74a21ac477e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dea433-2dee-4faf-a868-6af664c6af4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dea433-2dee-4faf-a868-6af664c6af4a.jpg?1",
             "name": "Uthden Troll",
             "text": "oo\nR Regenerate",
             "colours": [
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "1db8254a-7ecc-5e8a-a8d7-282861bd9eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25b81fb-1d0f-4c0c-8d54-fbf9c1d54578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25b81fb-1d0f-4c0c-8d54-fbf9c1d54578.jpg?1",
             "name": "Wall of Dust",
             "text": "No creature blocked by Wall of Dust may attack during its controller's next turn.",
             "colours": [
@@ -7448,7 +7448,7 @@
         },
         {
             "id": "fdad627b-0a88-5fd3-b6a6-d75723dc4e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7753b-0f01-42f3-9a5b-fe1ac6e7441d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7753b-0f01-42f3-9a5b-fe1ac6e7441d.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "1785ef81-a71d-5d33-b369-2a8be862e93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b68e0-ec8b-4dad-91ee-dc1da5db6251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b68e0-ec8b-4dad-91ee-dc1da5db6251.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "eeeda5b7-2aea-5f8e-b343-30b7e1662820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77071f4c-d00b-4c79-a2e6-6be0720af36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77071f4c-d00b-4c79-a2e6-6be0720af36b.jpg?1",
             "name": "Winds of Change",
             "text": "All players shuffle their hands into their libraries and then draw the same number of cards they originally held.",
             "colours": [
@@ -7545,7 +7545,7 @@
         },
         {
             "id": "1e359442-c4a8-5e87-99ce-bdf1ad86b223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e780b8-8002-47d4-9d0c-bd65a40ea34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e780b8-8002-47d4-9d0c-bd65a40ea34e.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Increase target creature's power and toughness by half the number of forests you control, rounding down for power and up for toughness.",
             "colours": [
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "818b2a46-5e03-5d18-bbe4-3680f69e100c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8852e36-204c-4b3a-a4f8-33a98548fa7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8852e36-204c-4b3a-a4f8-33a98548fa7b.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7611,7 +7611,7 @@
         },
         {
             "id": "fe18c835-f5bd-5cd9-bfbd-facf3aa8a4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f449835-5e20-4244-b7f4-c22838910076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f449835-5e20-4244-b7f4-c22838910076.jpg?1",
             "name": "Carnivorous Plant",
             "text": "",
             "colours": [
@@ -7645,7 +7645,7 @@
         },
         {
             "id": "6172d215-b718-5306-b2f9-6cbda5bfbed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42eb95f-638d-410c-a830-a414fb2494ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42eb95f-638d-410c-a830-a414fb2494ec.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, you may add colorless mana to your mana pool at a cost of 1 life per one mana. Play these additions as interrupts. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -7676,7 +7676,7 @@
         },
         {
             "id": "63221d10-e8b3-5678-8d05-9cf88b6e69bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406dfe1-68e9-4757-9487-0b556c97d07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406dfe1-68e9-4757-9487-0b556c97d07a.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nAt the end of combat, destroy all non-wall creatures blocking or blocked by Cockatrice.",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "8347af1e-8f64-5003-a74d-3e112ab50221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e9cf07-a335-4725-a124-0e983721f2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e9cf07-a335-4725-a124-0e983721f2f8.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "dc01e332-3ffa-58f2-aac8-b5534a4e5dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86873be9-21eb-496c-b278-4c9847563b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86873be9-21eb-496c-b278-4c9847563b0f.jpg?1",
             "name": "Crumble",
             "text": "Bury target artifact. Artifact's controller gains life equal to the artifact's casting cost.",
             "colours": [
@@ -7773,7 +7773,7 @@
         },
         {
             "id": "42d9e334-770f-5878-ad41-460d569d69b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5603ce3f-3b39-4433-8ccf-44b44dc99de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5603ce3f-3b39-4433-8ccf-44b44dc99de5.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy target permanent.",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "b59f1588-a572-5e87-b41e-ce835af8fb27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85ab895-d2b9-47f5-91f0-07b0cb43fc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85ab895-d2b9-47f5-91f0-07b0cb43fc7c.jpg?1",
             "name": "Durkwood Boars",
             "text": "",
             "colours": [
@@ -7837,7 +7837,7 @@
         },
         {
             "id": "0c31dde3-6e50-5bd4-8b08-41e843cdb9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906095f6-25c7-4f61-8513-9d75e32aab02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906095f6-25c7-4f61-8513-9d75e32aab02.jpg?1",
             "name": "Elven Riders",
             "text": "Cannot be blocked except by walls and by creatures with flying.",
             "colours": [
@@ -7870,7 +7870,7 @@
         },
         {
             "id": "e3ee0a16-8ef5-551c-a369-0360b22458fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd21750-856f-4017-a728-dcbf3f506f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd21750-856f-4017-a728-dcbf3f506f20.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "9d893010-24f6-5e6d-8750-d41ef1886c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1959de7-e945-438c-a90a-158e21c4d5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1959de7-e945-438c-a90a-158e21c4d5bf.jpg?1",
             "name": "Fog",
             "text": "No creatures deal damage in combat this turn.",
             "colours": [
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "6c02fd04-850f-5acc-ab8a-934a4b623827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef1a44-faf8-42bd-aaff-778f65d18ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef1a44-faf8-42bd-aaff-778f65d18ae9.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nDuring your upkeep, pay o\nGo\nGo\nGo\nG or Force of Nature deals 8 damage to you.",
             "colours": [
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "84582d5d-c586-509e-9429-619e0dedf845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9ff903-176f-45e7-82fd-e9705c1c719f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9ff903-176f-45e7-82fd-e9705c1c719f.jpg?1",
             "name": "Fungusaur",
             "text": "At the end of any turn in which Fungusaur receives damage but does not leave play, put a +1/+1 counter on it.",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "db1bf520-c2b9-5155-94ea-f6c70de74315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9e1c1b-bc7c-41b8-a983-b1c60f558547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9e1c1b-bc7c-41b8-a983-b1c60f558547.jpg?1",
             "name": "Gaea's Liege",
             "text": "Gaea's Liege has power and toughness each equal to the number of forests you control; when Gaea's Liege attacks, these are instead equal to the number of forests defending player controls.\noc\nT: Target land becomes a basic forest until Gaea's Liege leaves play.",
             "colours": [
@@ -8035,7 +8035,7 @@
         },
         {
             "id": "e07288af-ec8e-51b8-94fd-ad033a6cd826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ce96a5-76f1-48ca-854d-a37fb6a023a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ce96a5-76f1-48ca-854d-a37fb6a023a0.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "9eb550a6-e91d-5e0d-b4ac-4dc671734230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd711db-661d-4e2c-b817-0905e26ed929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd711db-661d-4e2c-b817-0905e26ed929.jpg?1",
             "name": "Giant Spider",
             "text": "Can block creatures with flying.",
             "colours": [
@@ -8099,7 +8099,7 @@
         },
         {
             "id": "febce88c-aa1d-59ef-805c-744d594a5e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc72de-2093-477b-b39e-696339d2fdbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc72de-2093-477b-b39e-696339d2fdbc.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -8132,7 +8132,7 @@
         },
         {
             "id": "3f7c68d1-5c91-50b7-a16c-5477d58f93d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8457f271-4075-4694-a1c0-280aff910953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8457f271-4075-4694-a1c0-280aff910953.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each player and each creature with flying.",
             "colours": [
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "64ede1f4-bdc5-5f76-bae0-cb5e98f8e089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eeb4671-e6f6-4f64-83f8-8c2a56defa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eeb4671-e6f6-4f64-83f8-8c2a56defa1b.jpg?1",
             "name": "Instill Energy",
             "text": "Target creature can attack the turn it comes into play on your side.\no0: During your turn, untap target creature Instill Energy enchants. Use this ability only once each turn.",
             "colours": [
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "99111c10-232d-5ce1-8e3a-6718f046c28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c93c85-5263-4770-b937-704e57912478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c93c85-5263-4770-b937-704e57912478.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "93be0163-917c-59bc-b807-4fdb6ac38448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e748b0-4041-4266-a777-e1b8a5533e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e748b0-4041-4266-a777-e1b8a5533e80.jpg?1",
             "name": "Killer Bees",
             "text": "Flying\noo\nG +1/+1 until end of turn",
             "colours": [
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "9d88bc5a-d4e2-5f49-bb0d-3d6d0f6ffe42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1d97c-5bfa-4791-9004-5f2464908c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1d97c-5bfa-4791-9004-5f2464908c30.jpg?1",
             "name": "Land Leeches",
             "text": "First strike",
             "colours": [
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "3cf09a0d-c914-5b16-8727-6581f54438dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925adfb2-cfe3-4847-9db0-20bbe4e7baf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925adfb2-cfe3-4847-9db0-20bbe4e7baf1.jpg?1",
             "name": "Ley Druid",
             "text": "oc\nT: Untap target land. Play this ability as an interrupt.",
             "colours": [
@@ -8329,7 +8329,7 @@
         },
         {
             "id": "7637745d-bb0e-570f-a58a-9609efe77b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ca1cc3-e588-4ef7-b846-d5dba3c875a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ca1cc3-e588-4ef7-b846-d5dba3c875a0.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Counter target black spell. Play this ability as an interrupt.",
             "colours": [
@@ -8360,7 +8360,7 @@
         },
         {
             "id": "10d8629f-b498-522c-9795-fcfc706f520f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf312acb-2fa6-440a-964b-424ad8abc331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf312acb-2fa6-440a-964b-424ad8abc331.jpg?1",
             "name": "Lifelace",
             "text": "Change the color of target spell or target permanent to green. Costs to cast, tap, maintain or use a special ability of target remain unchanged.",
             "colours": [
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "f9e5006c-e47f-5b78-b62f-c71b4498dcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbe717c-313c-4a8c-85a5-d23d3796ff26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbe717c-313c-4a8c-85a5-d23d3796ff26.jpg?1",
             "name": "Living Artifact",
             "text": "Put a vitality counter on Living Artifact for each damage dealt to you.\no0: During your upkeep, remove a vitality counter to gain 1 life. Remove only one vitality counter during each of your upkeeps.",
             "colours": [
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "6c1c0cac-4c17-50e3-bce6-635e7bfbfb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d5c0df-3db4-4e2d-9688-223383e02b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d5c0df-3db4-4e2d-9688-223383e02b02.jpg?1",
             "name": "Living Lands",
             "text": "All forests become 1/1 creatures. The forests still count as lands but cannot be tapped for mana the turn they come into play.",
             "colours": [
@@ -8455,7 +8455,7 @@
         },
         {
             "id": "09cc2670-1901-5b23-bbab-da36c88f08e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d972d7-5ed9-49c1-8d27-ec162771284d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d972d7-5ed9-49c1-8d27-ec162771284d.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -8489,7 +8489,7 @@
         },
         {
             "id": "6b39ce77-4196-5f6e-be22-cc0d913c6138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abc17aa-8f6b-4156-b148-fc049e1d316a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abc17aa-8f6b-4156-b148-fc049e1d316a.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. Lure does not prevent a creature from blocking more than one creature if blocker has that ability. If blocker is forced to block more creatures than it is allowed to, defender chooses which of these creatures to block, but must block as many creatures as allowed.",
             "colours": [
@@ -8522,7 +8522,7 @@
         },
         {
             "id": "a4eb9c13-da44-51c2-b368-c64f968b8253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16524bd2-0d88-451c-a394-7d5fe204dfc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16524bd2-0d88-451c-a394-7d5fe204dfc6.jpg?1",
             "name": "Marsh Viper",
             "text": "If Marsh Viper damages a player, he or she gets two poison counters. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -8555,7 +8555,7 @@
         },
         {
             "id": "442e341f-c708-5e41-81fc-d2293525e41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db4a4ef-20a8-415f-8d7d-a6740b482f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db4a4ef-20a8-415f-8d7d-a6740b482f73.jpg?1",
             "name": "Nafs Asp",
             "text": "If Nafs Asp damages a player, it also deals 1 damage to that player during his or her next draw phase. Before then, the player may pay o1 to prevent this damage.",
             "colours": [
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "eee47855-0069-50a7-bde6-6e290611af04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2338aeec-63f6-4cc1-833e-77d44994a7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2338aeec-63f6-4cc1-833e-77d44994a7ca.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nG, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "47605cff-ef74-5f15-82f0-7536226647bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504e4e18-a70c-47d6-8331-2ca3c6210a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504e4e18-a70c-47d6-8331-2ca3c6210a98.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying until end of turn.",
             "colours": [
@@ -8655,7 +8655,7 @@
         },
         {
             "id": "82fd3e6e-9c58-575e-8afe-5f6132d07ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c01d57-2bd4-433e-bea7-1acc70d14be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c01d57-2bd4-433e-bea7-1acc70d14be3.jpg?1",
             "name": "Rebirth",
             "text": "Each player may be healed to 20 life. Any player choosing to be healed antes an additional card from the top of his or her library. Remove Rebirth from your deck before playing if not playing for ante.",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "6b3c3eec-a1ed-599e-be6a-377bd5fec9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5697b2e7-25c5-4ae0-a9ac-48cbc6a94c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5697b2e7-25c5-4ae0-a9ac-48cbc6a94c15.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate target creature Regeneration enchants.",
             "colours": [
@@ -8719,7 +8719,7 @@
         },
         {
             "id": "5897b27a-ee2e-5406-80f8-81c23fa7fffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9af432-3997-426a-b532-52333c3c50c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9af432-3997-426a-b532-52333c3c50c4.jpg?1",
             "name": "Sandstorm",
             "text": "Sandstorm deals 1 damage to all attacking creatures.",
             "colours": [
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "7b1c38d3-9b88-5d52-a838-a52827c35de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281e8da8-1383-460e-b74e-ad56f1b6d007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281e8da8-1383-460e-b74e-ad56f1b6d007.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "8663248b-ff73-55e3-b7cd-656dd990052d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8f8c01-6f1c-4902-a7fd-c9cf04b28461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8f8c01-6f1c-4902-a7fd-c9cf04b28461.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk",
             "colours": [
@@ -8817,7 +8817,7 @@
         },
         {
             "id": "41b937d0-1ea2-5800-a768-bafc348bb02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367627-9be3-4e80-a214-0b3f0f2ab867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367627-9be3-4e80-a214-0b3f0f2ab867.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -8848,7 +8848,7 @@
         },
         {
             "id": "9d98ca8e-fad6-5e50-b07d-e47f521ae401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a9682c-ecca-4caa-9e5a-17874167082b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a9682c-ecca-4caa-9e5a-17874167082b.jpg?1",
             "name": "Sylvan Library",
             "text": "You may draw two extra cards during your draw phase. If you do so, put two of the cards drawn this turn back on top of your library (in any order) or pay 4 life per card not replaced. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "ee0ba41b-b6c6-5e6f-a436-1f93b6c1447e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63c16a5-588e-4ef1-9e79-4d36127cd84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63c16a5-588e-4ef1-9e79-4d36127cd84b.jpg?1",
             "name": "Thicket Basilisk",
             "text": "At the end of combat, destroy all non-wall creatures blocking or blocked by Basilisk.",
             "colours": [
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "03c7c775-6dbd-5ed3-b193-1d8e1bf8f6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f84fc8-69b4-4756-9634-4d6c17ec88a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f84fc8-69b4-4756-9634-4d6c17ec88a1.jpg?1",
             "name": "Timber Wolves",
             "text": "Banding",
             "colours": [
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "68c2c3e7-9bcb-5bd0-bae4-29a4fa029f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19dd44e3-d62c-405d-a620-7dc871eef81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19dd44e3-d62c-405d-a620-7dc871eef81c.jpg?1",
             "name": "Titania's Song",
             "text": "All non-creature artifacts lose all their usual abilities and become artifact creatures with toughness and power each equal to their casting costs. If Titania's Song leaves play, artifacts return to normal just before the untap phase of the next turn.",
             "colours": [
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "e688964c-36e7-57f0-8687-d23d9013859a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c8b995-f3d9-435a-8360-4047a619b23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c8b995-f3d9-435a-8360-4047a619b23b.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "2f0db0e1-9281-52a8-83ac-a67bcc07c15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227c2abc-d484-4198-863c-3266a83249c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227c2abc-d484-4198-863c-3266a83249c6.jpg?1",
             "name": "Tsunami",
             "text": "Destroy all islands.",
             "colours": [
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "f242671b-4311-5d13-9988-4461921c5363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2d276d-7a73-4a8f-9803-a37301bc2905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2d276d-7a73-4a8f-9803-a37301bc2905.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for any one basic land and put it directly into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards.",
             "colours": [
@@ -9069,7 +9069,7 @@
         },
         {
             "id": "c92f6f81-4c19-50b8-95e6-060e36414992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a314a0-14cb-4df1-8f2f-653455f13b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a314a0-14cb-4df1-8f2f-653455f13b09.jpg?1",
             "name": "Venom",
             "text": "At the end of combat, destroy all non-wall creatures blocking or blocked by target creature.",
             "colours": [
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "b0a16233-46aa-53d2-9d6c-0dbcf392f810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e30d22-da86-49a1-a319-22e8a909d443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e30d22-da86-49a1-a319-22e8a909d443.jpg?1",
             "name": "Verduran Enchantress",
             "text": "o0: Draw a card when you successfully cast an enchantment. Use this effect only once for each enchantment cast.",
             "colours": [
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "92dbfcf0-5a79-5720-b447-a3b24501cc3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd66c7c-19fb-4daa-996e-70107d732732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd66c7c-19fb-4daa-996e-70107d732732.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerate",
             "colours": [
@@ -9170,7 +9170,7 @@
         },
         {
             "id": "68277e91-0f3e-55ef-944f-1939d3668934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d702bd22-6079-4f4c-9540-42cf2a29f4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d702bd22-6079-4f4c-9540-42cf2a29f4a3.jpg?1",
             "name": "Wall of Ice",
             "text": "",
             "colours": [
@@ -9203,7 +9203,7 @@
         },
         {
             "id": "dd43b149-4801-51be-80d1-0f321f11d013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f236da-8391-487b-88d4-a45342bfff62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f236da-8391-487b-88d4-a45342bfff62.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -9236,7 +9236,7 @@
         },
         {
             "id": "f126eeab-e06b-5762-8bb2-65bfec2ee334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4144ca4-4817-4bb9-929b-613fc609bdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4144ca4-4817-4bb9-929b-613fc609bdb5.jpg?1",
             "name": "Wanderlust",
             "text": "Wanderlust deals 1 damage to target creature's controller during that player's upkeep.",
             "colours": [
@@ -9269,7 +9269,7 @@
         },
         {
             "id": "13663ef2-561b-5248-866a-80383456220d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2137757c-161c-4a3b-9a99-0fd23aa0c847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2137757c-161c-4a3b-9a99-0fd23aa0c847.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -9302,7 +9302,7 @@
         },
         {
             "id": "a9412b4d-28f4-5e4e-8507-b973bfcfe08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0547a390-ceee-4b8a-9d0e-36d8778ec693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0547a390-ceee-4b8a-9d0e-36d8778ec693.jpg?1",
             "name": "Web",
             "text": "Target creature gets +0/+2 and can block creatures with flying.",
             "colours": [
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "b8dc8dc2-b139-5de8-813a-2ab78f890253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4724e-f22e-4156-97fd-1adfccc47be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4724e-f22e-4156-97fd-1adfccc47be3.jpg?1",
             "name": "Whirling Dervish",
             "text": "Protection from black\nPut a +1/+1 counter on Whirling Dervish at the end of each turn in which it damages opponent.",
             "colours": [
@@ -9369,7 +9369,7 @@
         },
         {
             "id": "3bb1cbac-8ce6-5176-94a4-d8e87e06ef4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aea57a2-2753-4014-9724-2701455a6be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aea57a2-2753-4014-9724-2701455a6be8.jpg?1",
             "name": "Wild Growth",
             "text": "Wild Growth adds o\nG to your mana pool each time target land is tapped for mana.",
             "colours": [
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "042dae66-ae89-53eb-8790-8eb5d823807f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4f72de-51e9-45c2-853b-1b6668416417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4f72de-51e9-45c2-853b-1b6668416417.jpg?1",
             "name": "Winter Blast",
             "text": "Tap X target creatures. Winter Blast deals 2 damage to each of these target creatures with flying.",
             "colours": [
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "cc63d251-fe83-5dda-9343-7dba3945d8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e7cf40-c136-4fcb-a947-558b713b39f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e7cf40-c136-4fcb-a947-558b713b39f6.jpg?1",
             "name": "Aladdin's Lamp",
             "text": "o\nX, oc\nT: Instead of drawing a card from the top of your library, draw X cards but choose only one to put into your hand. Shuffle the leftover cards and put them at the bottom of your library. X cannot be 0.",
             "colours": [],
@@ -9460,7 +9460,7 @@
         },
         {
             "id": "c5cdb316-9a13-522c-9a64-d0f85d07242a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9907bbb-12aa-4826-9a65-b2ddda5fc1e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9907bbb-12aa-4826-9a65-b2ddda5fc1e2.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "89bac005-ab4b-5649-b7cf-55ceff772bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc1716d-5817-49f4-a9db-c162e6ceacbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc1716d-5817-49f4-a9db-c162e6ceacbf.jpg?1",
             "name": "Amulet of Kroog",
             "text": "o2, oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "62cd8c67-c3a0-5d80-a529-b6a7c62afa34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44135b17-69e7-4002-a6e0-d76f4c0c423b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44135b17-69e7-4002-a6e0-d76f4c0c423b.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Each time a player puts a land into play, Ankh of Mishra deals 2 damage to that player.",
             "colours": [],
@@ -9541,7 +9541,7 @@
         },
         {
             "id": "5dfdf761-aad1-5b58-a778-f0b70c15e669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fe10-0f6e-4b7f-98fc-3a21c399c38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fe10-0f6e-4b7f-98fc-3a21c399c38a.jpg?1",
             "name": "Armageddon Clock",
             "text": "During your upkeep, put one doom counter on Armageddon Clock. At the end of your upkeep, Armageddon Clock deals X damage to each player, where X is the number of doom counters on Armageddon Clock. During any upkeep, any player may pay o4 to remove a doom counter from Armageddon Clock.",
             "colours": [],
@@ -9568,7 +9568,7 @@
         },
         {
             "id": "6669a1b7-9f0d-5566-b060-a3c800b04456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc11285-0891-4cc3-a056-b698911166c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc11285-0891-4cc3-a056-b698911166c7.jpg?1",
             "name": "Ashnod's Battle Gear",
             "text": "o2, oc\nT: Target creature you control gets +2/-2 as long as Ashnod's Battle Gear remains tapped. You may choose not to untap Ashnod's Battle Gear during your untap phase.",
             "colours": [],
@@ -9595,7 +9595,7 @@
         },
         {
             "id": "e3de83b1-2db6-5f01-9f17-cb3a15afbb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5ea1c-0ea7-4b84-b886-ebd346f4e154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5ea1c-0ea7-4b84-b886-ebd346f4e154.jpg?1",
             "name": "Battering Ram",
             "text": "Banding when attacking\nAt the end of combat, destroy all walls blocking Battering Ram.",
             "colours": [],
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "a980f71b-b609-505a-af25-7552c1c00a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81f7a0f-183f-438b-b252-738d8d30c245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81f7a0f-183f-438b-b252-738d8d30c245.jpg?1",
             "name": "Black Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Black Mana Battery.\noc\nT: Add o\nB to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Black Mana Battery, add o\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -9654,7 +9654,7 @@
         },
         {
             "id": "87e77d24-e808-5a21-8a2d-3f774260959e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196b83a1-2a25-498d-83b8-8faacd79909d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196b83a1-2a25-498d-83b8-8faacd79909d.jpg?1",
             "name": "Black Vise",
             "text": "At the end of target opponent's upkeep, Black Vise deals that player 1 damage for each card in his or her hand in excess of four.",
             "colours": [],
@@ -9681,7 +9681,7 @@
         },
         {
             "id": "89cea107-1f39-5599-994f-1c447cf5e57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2cb84e-c079-486e-87ad-d188fe38bc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2cb84e-c079-486e-87ad-d188fe38bc76.jpg?1",
             "name": "Blue Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Blue Mana Battery.\noc\nT: Add o\nU to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Blue Mana Battery, add o\nU to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -9710,7 +9710,7 @@
         },
         {
             "id": "15ff78aa-b460-57fa-8a99-107f071deef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1924860-4532-40c2-b0e8-28584d22ccb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1924860-4532-40c2-b0e8-28584d22ccb5.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o1: Sacrifice Bottle of Suleiman. Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Bottle of Suleiman deals 5 damage to you. Otherwise, put a Djinn token into play. Treat this token as a 5/5 artifact creature with flying.",
             "colours": [],
@@ -9737,7 +9737,7 @@
         },
         {
             "id": "9c087263-1411-5023-b533-562527d88b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab18c6d-2705-473e-b404-75660ff28736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab18c6d-2705-473e-b404-75660ff28736.jpg?1",
             "name": "Brass Man",
             "text": "Brass Man does not untap during your untap phase.\no1: Untap Brass Man. Use this ability only during your upkeep.",
             "colours": [],
@@ -9767,7 +9767,7 @@
         },
         {
             "id": "f05a01b1-71d1-51b1-98bd-300759e513b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad56033-c1f9-4477-9dd6-ba7009c30593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad56033-c1f9-4477-9dd6-ba7009c30593.jpg?1",
             "name": "Bronze Tablet",
             "text": "Comes into play tapped.\no4, oc\nT: Remove Bronze Tablet and target card opponent owns from the game. You become owner of opponent's card, and opponent becomes owner of Bronze Tablet. Opponent may prevent this exchange by paying 10 life; if he or she does so, destroy Bronze Tablet. Effects that prevent or redirect damage cannot be used to counter this loss of life. Play this ability as an interrupt.\nRemove Bronze Tablet from your deck before playing if not playing for ante.",
             "colours": [],
@@ -9794,7 +9794,7 @@
         },
         {
             "id": "6f9a9cad-85af-5fda-8dfd-f86b7b2cfd56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ca1534-0049-4672-9677-99f1ba00fb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ca1534-0049-4672-9677-99f1ba00fb78.jpg?1",
             "name": "Celestial Prism",
             "text": "o2, oc\nT: Add one mana of any color to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "4f244144-bb3d-5ab3-9f13-3008c729ee3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd9b203-fa4c-4383-a671-265101f4453a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd9b203-fa4c-4383-a671-265101f4453a.jpg?1",
             "name": "Clay Statue",
             "text": "o2: Regenerate",
             "colours": [],
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "2ce6909d-9f0c-564f-aac2-a80efd648b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a92484b-064c-4588-a1ea-6de8fd485ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a92484b-064c-4588-a1ea-6de8fd485ca4.jpg?1",
             "name": "Clockwork Avian",
             "text": "Flying\nWhen Clockwork Avian comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Avian is assigned to attack or block, remove a counter.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Avian. You may have no more than four of these counters on Clockwork Avian. Use this ability only during your upkeep.",
             "colours": [],
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "f3bf3b80-f4d6-5452-bffc-9a6b93b93e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc8595-32b9-4045-bae3-5078c9a17527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc8595-32b9-4045-bae3-5078c9a17527.jpg?1",
             "name": "Clockwork Beast",
             "text": "When Clockwork Beast comes into play, put seven +1/+0 counters on it. At the end of any combat in which Clockwork Beast is assigned to attack or block, remove a counter.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Beast. You may have no more than seven of these counters on Clockwork Beast. Use this ability only during your upkeep.",
             "colours": [],
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "3664fa1b-ccb5-51e0-b0d1-e73c0df3dd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063acc0f-8062-4461-b0f5-8c3a835e1fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063acc0f-8062-4461-b0f5-8c3a835e1fbf.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample\nColossus does not untap during your untap phase.\no9: Untap Colossus. Use this ability only during your upkeep.",
             "colours": [],
@@ -9941,7 +9941,7 @@
         },
         {
             "id": "0678d1e3-d045-5a0a-bc80-864d0ff9f788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6639eea-d0ae-4f0d-a8da-1b863b482b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6639eea-d0ae-4f0d-a8da-1b863b482b68.jpg?1",
             "name": "Conservator",
             "text": "o3, oc\nT: Prevent up to 2 damage to you.",
             "colours": [],
@@ -9968,7 +9968,7 @@
         },
         {
             "id": "04991ddf-2459-5746-8a8a-435e40dd5529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6065242b-e14e-44fa-bbe0-00f070f0140a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6065242b-e14e-44fa-bbe0-00f070f0140a.jpg?1",
             "name": "Coral Helm",
             "text": "o3: Discard a card at random from your hand to give target creature +2/+2 until end of turn.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "1dd9a508-7bf5-5d7e-85ca-697d10f5e86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c17c7-49c2-41f2-842e-d980e7d62613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c17c7-49c2-41f2-842e-d980e7d62613.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Gain 1 life for a successfully cast blue spell. Use this effect either when the spell is cast or later in the turn but only once for each blue spell cast.",
             "colours": [],
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "eabdab64-c961-59a1-8895-8166b50a9db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cbcab8-5593-4ef0-8689-77e71fb1c41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cbcab8-5593-4ef0-8689-77e71fb1c41a.jpg?1",
             "name": "Cursed Rack",
             "text": "Target opponent discards down to four cards during his or her discard phase.",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "7eec7c4e-ff16-5c62-b075-0f9138c58bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0662881-664f-47d2-8164-b4727125ba0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0662881-664f-47d2-8164-b4727125ba0b.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -10079,7 +10079,7 @@
         },
         {
             "id": "ddac534b-33cf-505e-a54c-cbb28852a952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d2c7c2-5696-49a0-b6b0-789bfe839f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d2c7c2-5696-49a0-b6b0-789bfe839f8d.jpg?1",
             "name": "Diabolic Machine",
             "text": "o3: Regenerate",
             "colours": [],
@@ -10109,7 +10109,7 @@
         },
         {
             "id": "fca9e9ea-9f69-576f-af30-71204cde3cf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c44bba-5eaa-41a6-a11a-0bc8fb751ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c44bba-5eaa-41a6-a11a-0bc8fb751ad8.jpg?1",
             "name": "Dingus Egg",
             "text": "Each time a player puts a land into the graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -10136,7 +10136,7 @@
         },
         {
             "id": "b6aea9a8-76e3-59ce-86c5-c281d8d77902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9b9085-6dd7-44fc-b3a5-7f797c34f8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9b9085-6dd7-44fc-b3a5-7f797c34f8dc.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player chooses and discards one card from his or her hand. Use this ability only during your turn.",
             "colours": [],
@@ -10163,7 +10163,7 @@
         },
         {
             "id": "be0c13bb-b928-5b34-b63a-3475e1e4a704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ecbbb3-2d0d-49dc-90b3-1b396d47bf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ecbbb3-2d0d-49dc-90b3-1b396d47bf56.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: +1/+0 until end of turn",
             "colours": [],
@@ -10193,7 +10193,7 @@
         },
         {
             "id": "bf25c958-daba-588e-9d19-55f2bc300fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665f9dc-a5df-4ad7-9067-9b48f942bdde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665f9dc-a5df-4ad7-9067-9b48f942bdde.jpg?1",
             "name": "Ebony Horse",
             "text": "o2, oc\nT: Untap target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [],
@@ -10220,7 +10220,7 @@
         },
         {
             "id": "36869ce9-21b0-5d9d-a7f1-685736c1509f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7a41cc-277a-4d95-a30c-91bf5aa7ac11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7a41cc-277a-4d95-a30c-91bf5aa7ac11.jpg?1",
             "name": "Fellwar Stone",
             "text": "oc\nT: Add one mana to your mana pool. This mana may be of any type that any land opponent controls can produce. Play this ability as an interrupt.",
             "colours": [],
@@ -10247,7 +10247,7 @@
         },
         {
             "id": "c950a7ad-d002-5cd6-9ebd-0a63bfff62ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300428ea-7909-4c2b-81cc-a03d51030bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300428ea-7909-4c2b-81cc-a03d51030bcb.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn. If that creature is put into the graveyard before end of turn, destroy Flying Carpet.",
             "colours": [],
@@ -10274,7 +10274,7 @@
         },
         {
             "id": "f6599ae6-de4b-5daa-aa13-99c726c68a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d71a210-eb2c-4bcc-ae3b-f60a6fb615cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d71a210-eb2c-4bcc-ae3b-f60a6fb615cb.jpg?1",
             "name": "Glasses of Urza",
             "text": "oc\nT: Look at target player's hand.",
             "colours": [],
@@ -10301,7 +10301,7 @@
         },
         {
             "id": "eb5c188f-d2f0-584c-ba60-3d7cde025cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f96f18-8340-4b50-9b4c-3c72c0bbc2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f96f18-8340-4b50-9b4c-3c72c0bbc2f2.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "oc\nT: Grapeshot Catapult deals 1 damage to target creature with flying.",
             "colours": [],
@@ -10331,7 +10331,7 @@
         },
         {
             "id": "1d7877fb-849d-578f-a9ab-1513e357bdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a6e224-72df-4f1f-93d1-5114779aed2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a6e224-72df-4f1f-93d1-5114779aed2c.jpg?1",
             "name": "Green Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Green Mana Battery.\noc\nT: Add o\nG to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Green Mana Battery, add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "92d6e2ae-58d0-5edb-8fab-f2a070b08bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c0a08-1aaf-4976-8eea-c93a9f9486fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c0a08-1aaf-4976-8eea-c93a9f9486fa.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1, oc\nT: Target creature gains banding until end of turn.",
             "colours": [],
@@ -10387,7 +10387,7 @@
         },
         {
             "id": "efea3ef2-f30a-5d8f-a9db-365f40590567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df1be4-364e-4582-929a-05f2905f8ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df1be4-364e-4582-929a-05f2905f8ce6.jpg?1",
             "name": "Howling Mine",
             "text": "Each player draws one extra card during his or her draw phase.",
             "colours": [],
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "aefb2b05-7cb1-57fa-8765-462a1e14086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8846e66-fd42-4e74-80fe-858944108d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8846e66-fd42-4e74-80fe-858944108d40.jpg?1",
             "name": "Iron Star",
             "text": "o1: Gain 1 life for a successfully cast red spell. Use this effect either when the spell is cast or later in the turn but only once for each red spell cast.",
             "colours": [],
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "84d89519-a8d6-5aea-a1fa-3530796fe683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f378af-ea54-4035-9e3e-e8cf980d1e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f378af-ea54-4035-9e3e-e8cf980d1e84.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Gain 1 life for a successfully cast white spell. Use this effect either when the spell is cast or later in the turn but only once for each white spell cast.",
             "colours": [],
@@ -10468,7 +10468,7 @@
         },
         {
             "id": "8968656c-c168-53e8-bfab-ea39db0de6ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff5624d-fffa-48c1-91f3-f03585e45c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff5624d-fffa-48c1-91f3-f03585e45c69.jpg?1",
             "name": "Ivory Tower",
             "text": "At the beginning of your upkeep, gain 1 life for each card in your hand in excess of four.",
             "colours": [],
@@ -10495,7 +10495,7 @@
         },
         {
             "id": "e87b5651-8beb-54cb-9de3-509275706b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044e5475-4ab5-45c5-b86d-9b4720e7ba0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044e5475-4ab5-45c5-b86d-9b4720e7ba0c.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: Redirect to yourself all damage done to any creature. The source of the damage does not change.",
             "colours": [],
@@ -10522,7 +10522,7 @@
         },
         {
             "id": "dfd7d802-1f9c-54db-93e4-af51330f46c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15b58c-80b4-4da7-8ed6-d963702eda3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15b58c-80b4-4da7-8ed6-d963702eda3a.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3, oc\nT: Untap target creature.",
             "colours": [],
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "eba20a0a-774e-55a5-85c4-4bf99325b9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009fceb-9140-457b-b980-875f6a2f70fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009fceb-9140-457b-b980-875f6a2f70fd.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw one card.",
             "colours": [],
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "f64bb23b-0d85-5c6a-b48c-d7b9c570f5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd054ed-9c91-4bc6-9d0d-0c045c089bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd054ed-9c91-4bc6-9d0d-0c045c089bd9.jpg?1",
             "name": "Kormus Bell",
             "text": "All swamps become 1/1 black creatures. The swamps still count as lands but cannot be tapped for mana the turn they come into play.",
             "colours": [],
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "28df2f32-8c39-5afd-ab0b-f8f8f08416cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b811a515-87a2-4dee-8689-48bfba12e6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b811a515-87a2-4dee-8689-48bfba12e6c5.jpg?1",
             "name": "Library of Leng",
             "text": "Skip the discard phase of your turn. If a spell or effect forces you to discard, you may discard to the top of your library rather than to your graveyard. If the discard is random, you may look at the card before choosing where to discard it.",
             "colours": [],
@@ -10630,7 +10630,7 @@
         },
         {
             "id": "6a8c1bb2-d681-5064-93c7-35d7ed198840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be9942c-89b3-422f-bb9d-b55f51a22a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be9942c-89b3-422f-bb9d-b55f51a22a37.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault does not untap during your untap phase. If it remains tapped during your upkeep, Mana Vault deals 1 damage to you.\no4: Untap Mana Vault. Use this ability only during your upkeep.\noc\nT: Add three colorless mana to your mana pool. Play these additions as interrupts.",
             "colours": [],
@@ -10657,7 +10657,7 @@
         },
         {
             "id": "5b7a23bf-d1ab-5085-ad2e-b94211717678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9714ce0-7fc3-4bf3-ad65-68555a9d2f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9714ce0-7fc3-4bf3-ad65-68555a9d2f35.jpg?1",
             "name": "Meekstone",
             "text": "No creatures with power greater than 2 untap during their controllers' untap phase.",
             "colours": [],
@@ -10684,7 +10684,7 @@
         },
         {
             "id": "b603d42b-cc9d-5e1b-a31e-67772591e256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16f7d28-1bc2-44b6-973b-c60d966101a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16f7d28-1bc2-44b6-973b-c60d966101a6.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Take the top two cards from target player's library and put them into that player's graveyard.",
             "colours": [],
@@ -10711,7 +10711,7 @@
         },
         {
             "id": "a5afed40-fd83-527b-a786-156a17d0d5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7b5921-3e10-47e7-98a7-8411a18313bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7b5921-3e10-47e7-98a7-8411a18313bf.jpg?1",
             "name": "Mishra's War Machine",
             "text": "Banding\nDuring your upkeep, choose and discard one card from your hand, or Mishra's War Machine deals 3 damage to you. If Mishra's War Machine deals damage to you in this way, tap it.",
             "colours": [],
@@ -10741,7 +10741,7 @@
         },
         {
             "id": "8cd1977a-692a-54fb-9896-fa9aaaef8d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427396c-f1ef-46ac-b130-ed1e51e826a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427396c-f1ef-46ac-b130-ed1e51e826a3.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Comes into play tapped.\no1, oc\nT: Destroy all creatures, enchantments, and artifacts, including Nevinyrral's Disk itself.",
             "colours": [],
@@ -10768,7 +10768,7 @@
         },
         {
             "id": "64bcff7d-96c5-5cb2-bde3-dd8adf39cc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837605e3-f4c2-4b60-8478-f21ca8734ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837605e3-f4c2-4b60-8478-f21ca8734ef2.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -10798,7 +10798,7 @@
         },
         {
             "id": "f3477c68-b506-5bca-9659-5cd5f64c8971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64c2dff-9c11-4c91-a606-b5de704f18d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64c2dff-9c11-4c91-a606-b5de704f18d4.jpg?1",
             "name": "Onulet",
             "text": "If Onulet is put into the graveyard from play, you gain 2 life.",
             "colours": [],
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "2fc22d79-502e-5c60-b288-0bd7a61a0e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeb3ce1-1e7f-4269-a326-700f27e9e932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeb3ce1-1e7f-4269-a326-700f27e9e932.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -10858,7 +10858,7 @@
         },
         {
             "id": "28b09388-1548-54eb-80c4-914ab85d9c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc49d724-b46d-449b-bd2b-03551e130a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc49d724-b46d-449b-bd2b-03551e130a06.jpg?1",
             "name": "Primal Clay",
             "text": "When Primal Clay comes into play, choose whether to make it a 1/6 wall, a 2/2 creature with flying, or a 3/3 creature.",
             "colours": [],
@@ -10888,7 +10888,7 @@
         },
         {
             "id": "4f6897d5-846e-5d0a-9c12-8a2bef32064a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e507bc-441d-4f44-85d4-cf93ca199d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e507bc-441d-4f44-85d4-cf93ca199d2e.jpg?1",
             "name": "Red Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Red Mana Battery.\noc\nT: Add o\nR to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Red Mana Battery, add o\nR to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -10917,7 +10917,7 @@
         },
         {
             "id": "7344c4fa-2b5d-5534-84b7-e964b2ecb09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf9da4-4647-4c66-a3ce-fab7ca9618d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf9da4-4647-4c66-a3ce-fab7ca9618d1.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -10944,7 +10944,7 @@
         },
         {
             "id": "53b8c030-d92e-5d30-96a6-0ae6ff682aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9d1526-9888-41bc-b77d-88d62325e0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9d1526-9888-41bc-b77d-88d62325e0b2.jpg?1",
             "name": "Shapeshifter",
             "text": "Shapeshifter has power and toughness that add up to seven, but neither may be more than seven. Set them when Shapeshifter comes into play; you may change them during your upkeep.",
             "colours": [],
@@ -10974,7 +10974,7 @@
         },
         {
             "id": "ba68ca6f-2b8a-5603-b17a-59bc7ffa04be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccacae0-f8db-45e0-b25a-35418fd24389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccacae0-f8db-45e0-b25a-35418fd24389.jpg?1",
             "name": "Soul Net",
             "text": "o1: Gain 1 life when a creature is put into the graveyard from play. Use this effect only once each time a creature is put into the graveyard.",
             "colours": [],
@@ -11001,7 +11001,7 @@
         },
         {
             "id": "6c1f73fb-eaf0-596b-8d38-63bb3b5bc1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a225462-947c-49d7-81b2-91f875664dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a225462-947c-49d7-81b2-91f875664dca.jpg?1",
             "name": "Sunglasses of Urza",
             "text": "You may use white mana in your mana pool as either white or red mana.",
             "colours": [],
@@ -11028,7 +11028,7 @@
         },
         {
             "id": "bb70e61a-f84f-58de-8739-a94375c50ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d566993f-18a6-4e5c-abc3-0fe9a03e97d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d566993f-18a6-4e5c-abc3-0fe9a03e97d2.jpg?1",
             "name": "Tawnos's Wand",
             "text": "o2, oc\nT: Target creature with power no greater than 2 becomes unblockable until end of turn. Other effects may later be used to increase the creature's power beyond 2.",
             "colours": [],
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "0f5c07bd-d7b8-5f9b-b87a-6d21bd8eb77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4750787e-9fef-4bdf-b2e3-e410c84999f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4750787e-9fef-4bdf-b2e3-e410c84999f2.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "o2, oc\nT: Target creature gets +1/+1 as long as Tawnos's Weaponry remains tapped.\nYou may choose not to untap Tawnos's Weaponry during your untap phase.",
             "colours": [],
@@ -11082,7 +11082,7 @@
         },
         {
             "id": "637a799c-46fb-53a2-acad-7bea043d8013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1a2b2-50f0-4ed0-bd8f-06cd6aada04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1a2b2-50f0-4ed0-bd8f-06cd6aada04f.jpg?1",
             "name": "Tetravus",
             "text": "Flying\nWhen Tetravus comes into play, put three +1/+1 counters on it.\nDuring your upkeep, you may move each of these counters on or off of Tetravus, regardless of who controls them. Counters that are removed become Tetravite tokens. Treat these tokens as 1/1 artifact creatures with flying. These creatures cannot have enchantment played on them and do not share any enchantments on Tetravus.",
             "colours": [],
@@ -11112,7 +11112,7 @@
         },
         {
             "id": "67950764-6e2b-578a-a942-e8eee5df6181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d01a2e-2687-4b37-aed6-63202cd81231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d01a2e-2687-4b37-aed6-63202cd81231.jpg?1",
             "name": "The Hive",
             "text": "5, oc\nT: Put a Wasp token into play. Treat this token as a 1/1 artifact creature with flying.",
             "colours": [],
@@ -11139,7 +11139,7 @@
         },
         {
             "id": "d080d796-76af-5bbe-b0f7-bf471c2103d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e19104f-55d5-40e5-a61d-ddba2cf5a527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e19104f-55d5-40e5-a61d-ddba2cf5a527.jpg?1",
             "name": "The Rack",
             "text": "At the end of target opponent's upkeep, The Rack deals that player 1 damage for each card in his or her hand fewer than three.",
             "colours": [],
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "3c24cbf8-0585-5fb7-b368-012e76707988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e77be1-3c29-40b4-9c47-44fa2d9d4454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e77be1-3c29-40b4-9c47-44fa2d9d4454.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Gain 1 life for a successfully cast black spell. Use this effect either when the spell is cast or later in the turn but only once for each black spell cast.",
             "colours": [],
@@ -11193,7 +11193,7 @@
         },
         {
             "id": "6dde0a14-fc03-5279-9ef3-da9c5a08d3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09294401-a895-4084-8302-196a946863d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09294401-a895-4084-8302-196a946863d6.jpg?1",
             "name": "Triskelion",
             "text": "When Triskelion comes into play, put three +1/+1 counters on it.\no0: Remove one of these counters from Triskelion to have Triskelion deal 1 damage to target creature or player.",
             "colours": [],
@@ -11223,7 +11223,7 @@
         },
         {
             "id": "b3d2e90e-3aaa-5ffe-8e27-fd2aec507450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dd1daa-0b5d-4d0c-9a67-a59083038f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dd1daa-0b5d-4d0c-9a67-a59083038f2d.jpg?1",
             "name": "Urza's Avenger",
             "text": "o0: Urza's Avenger gets -1/-1 until end of turn and your choice of flying, banding, first strike, or trample until end of turn.",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "7dba6348-cce4-5566-9d3d-8c60c62cd2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad580bfc-8827-4a8a-a5ec-b6195b3146bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad580bfc-8827-4a8a-a5ec-b6195b3146bb.jpg?1",
             "name": "Wall of Spears",
             "text": "First strike, counts as a wall",
             "colours": [],
@@ -11283,7 +11283,7 @@
         },
         {
             "id": "b49f1ca7-1e8d-5c76-9740-c5fabe7ca70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b622e694-858d-482f-a67d-0e52d268708c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b622e694-858d-482f-a67d-0e52d268708c.jpg?1",
             "name": "White Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on White Mana Battery.\noc\nT: Add o\nW to your mana pool and remove as many charge counters as you wish. For each charge counter removed from White Mana Battery, add o\nW to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -11312,7 +11312,7 @@
         },
         {
             "id": "bfba2f60-46ba-5206-a96e-51d0794f9a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60ee90d-5f7b-4294-8d52-9744fada8d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60ee90d-5f7b-4294-8d52-9744fada8d36.jpg?1",
             "name": "Winter Orb",
             "text": "No player may untap more than one land during his or her untap phase.",
             "colours": [],
@@ -11339,7 +11339,7 @@
         },
         {
             "id": "c09e02c3-7b89-501a-944e-e331cc63a456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51abf0-8661-4776-929d-35b7bd345e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51abf0-8661-4776-929d-35b7bd345e21.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Gain 1 life for a successfully cast green spell. Use this effect either when the spell is cast or later in the turn but only once for each green spell cast.",
             "colours": [],
@@ -11366,7 +11366,7 @@
         },
         {
             "id": "ae84e95a-0c71-5118-ab1b-3b8df60f8c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaab84be-bb96-437b-a9a7-aa7a11ffd21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaab84be-bb96-437b-a9a7-aa7a11ffd21d.jpg?1",
             "name": "Yotian Soldier",
             "text": "Attacking does not cause Yotian Soldier to tap.",
             "colours": [],
@@ -11396,7 +11396,7 @@
         },
         {
             "id": "2347c3a6-6604-53ee-9ce5-d1094e26b467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff8d4f1-eaad-4afb-9097-2afab133f707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff8d4f1-eaad-4afb-9097-2afab133f707.jpg?1",
             "name": "Mishra's Factory",
             "text": "oc\nT: Add 1 colorless mana to your mana pool.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker still counts as a land but cannot be tapped for mana the turn it comes into play.\noc\nT: Target Assembly Worker gets +1/+1 until end of turn.",
             "colours": [],
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "c6b69718-6590-5289-990b-02b6007b9fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d51a6de-7bb4-4e3d-82a7-a298c8d742ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d51a6de-7bb4-4e3d-82a7-a298c8d742ef.jpg?1",
             "name": "Oasis",
             "text": "oc\nT: Prevent 1 damage to any creature.",
             "colours": [],
@@ -11450,7 +11450,7 @@
         },
         {
             "id": "cc47a9fc-d4e0-5140-9dc8-cfbdee1a0fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5899b46-226b-4be6-8e80-d2396f54210d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5899b46-226b-4be6-8e80-d2396f54210d.jpg?1",
             "name": "Strip Mine",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Sacrifice Strip Mine to destroy target land.",
             "colours": [],
@@ -11477,7 +11477,7 @@
         },
         {
             "id": "fdc50021-e80d-5470-9915-080a682d9905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639e47dc-c90f-4f55-9b3a-721240ec04ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639e47dc-c90f-4f55-9b3a-721240ec04ed.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11513,7 +11513,7 @@
         },
         {
             "id": "8e19b83d-6a97-5a6e-baad-f9bf8f3ac80d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17f8abd-c087-4039-8dfd-c6168f7db0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17f8abd-c087-4039-8dfd-c6168f7db0a6.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11549,7 +11549,7 @@
         },
         {
             "id": "331c2b62-41fc-5d5b-bd89-90e24a3f94b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1317da-9e81-4aff-8c04-9155d14be90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1317da-9e81-4aff-8c04-9155d14be90c.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11585,7 +11585,7 @@
         },
         {
             "id": "412017f1-c163-59fb-943f-672e75228456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06bbd6e-eb0d-45fc-88ef-0e085d6505ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06bbd6e-eb0d-45fc-88ef-0e085d6505ef.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11621,7 +11621,7 @@
         },
         {
             "id": "965542e6-b302-5634-8206-be0cd10df222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e3819-3d75-40d4-9a93-1147834dfd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e3819-3d75-40d4-9a93-1147834dfd69.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11657,7 +11657,7 @@
         },
         {
             "id": "6279ec6e-af89-5318-9712-5f934552c6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a05f9a-1285-4d14-b827-8b81968e09df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a05f9a-1285-4d14-b827-8b81968e09df.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11693,7 +11693,7 @@
         },
         {
             "id": "1b3a28ad-41ca-587a-9feb-5f40154976da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84634023-5c94-4dcc-9449-abf73ecea542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84634023-5c94-4dcc-9449-abf73ecea542.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "d94ba293-88b8-5617-8d0b-164ac11048c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa0be1-7358-4ea2-8c40-be6d699a6631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa0be1-7358-4ea2-8c40-be6d699a6631.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11765,7 +11765,7 @@
         },
         {
             "id": "11f51715-d399-5ce8-bfa0-642dd23f1eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac4979a-5b2f-4db1-b665-9d8ccc15ba82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac4979a-5b2f-4db1-b665-9d8ccc15ba82.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11801,7 +11801,7 @@
         },
         {
             "id": "41f2d93b-bd7b-590a-b1a7-3b7569163c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5c9379-b686-4823-b85a-eaf2c4b63205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5c9379-b686-4823-b85a-eaf2c4b63205.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11837,7 +11837,7 @@
         },
         {
             "id": "3b48a4bf-1f20-5d47-bb1f-31ee7fa14514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10478e22-d1dd-4e02-81a7-d93ce71ed81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10478e22-d1dd-4e02-81a7-d93ce71ed81d.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11873,7 +11873,7 @@
         },
         {
             "id": "88b58c4c-b100-5ac2-9ded-02c3d9cf3b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50352268-88a6-4575-a5e1-cd8bef7f8286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50352268-88a6-4575-a5e1-cd8bef7f8286.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11909,7 +11909,7 @@
         },
         {
             "id": "7e574557-d888-5fde-8ef8-d02f21fedcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c4d73-5b71-446a-a739-25d494591aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c4d73-5b71-446a-a739-25d494591aa1.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11945,7 +11945,7 @@
         },
         {
             "id": "fea502b2-f7ed-5947-8c11-2659905e539a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb35995-0298-4281-88d1-2531c93a4916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb35995-0298-4281-88d1-2531c93a4916.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11981,7 +11981,7 @@
         },
         {
             "id": "51c25e02-f5fa-5100-8a2f-39b1547cba69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794073f-4188-45c9-9e65-c9d7f2ecc24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794073f-4188-45c9-9e65-c9d7f2ecc24b.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/5DN.json
+++ b/Assets/Resources/Sets/5DN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "dd2af968-b944-551b-9833-c7aab9ad6484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0bf63-0399-40d6-9162-4562d7bcdd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0bf63-0399-40d6-9162-4562d7bcdd0e.jpg?1",
             "name": "Abuna's Chant",
             "text": "Choose one You gain 5 life; or prevent the next 5 damage that would be dealt to target creature this turn.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "b6082941-6bf7-5ca5-aa08-38b142db7165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7029fac9-ef8a-499f-aa42-c145b6b528ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7029fac9-ef8a-499f-aa42-c145b6b528ae.jpg?1",
             "name": "Armed Response",
             "text": "Armed Response deals damage to target attacking creature equal to the number of Equipment you control.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "0d1f7fb7-3831-5b3a-94a6-2709881250df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6bf0b-bb39-4d0f-9035-a276e604f609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6bf0b-bb39-4d0f-9035-a276e604f609.jpg?1",
             "name": "Auriok Champion",
             "text": "Protection from black and from red\nWhenever another creature comes into play, you may gain 1 life.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "08730fac-b23f-5af6-bd62-ccffe96578fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c9cd1b-9260-4f98-ac7a-25bb5ae3e06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c9cd1b-9260-4f98-ac7a-25bb5ae3e06d.jpg?1",
             "name": "Auriok Salvagers",
             "text": "{1}{W}: Return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "a3f84e2d-0d21-5b84-b767-04582f9d4ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d060-9858-405c-a442-c7a278134f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d060-9858-405c-a442-c7a278134f00.jpg?1",
             "name": "Auriok Windwalker",
             "text": "Flying\n{T}: Attach target Equipment you control to target creature you control.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "1252fe2e-4d39-52b7-8479-b3d6a4af90d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601bb6d1-77f4-4ffe-94d0-bed74c33013b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601bb6d1-77f4-4ffe-94d0-bed74c33013b.jpg?1",
             "name": "Beacon of Immortality",
             "text": "Double target player's life total. Shuffle Beacon of Immortality into its owner's library.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "18cdf686-d5c7-5017-b942-0bc1237cbe7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a7117-b1e2-46bd-873e-baf9d9fac009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a7117-b1e2-46bd-873e-baf9d9fac009.jpg?1",
             "name": "Bringer of the White Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the White Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may return target artifact card from your graveyard to play.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "1570dbb3-43c5-58b3-a160-5ba143d8f07a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e7267-3d71-4724-b3e7-ae5a6a1f002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e7267-3d71-4724-b3e7-ae5a6a1f002a.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "{2}: The next time an artifact source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "d2582edd-a186-55d4-a613-40e3f80ce0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5320ff-1fe6-492a-b27f-86a84a1768ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5320ff-1fe6-492a-b27f-86a84a1768ed.jpg?1",
             "name": "Leonin Squire",
             "text": "When Leonin Squire comes into play, return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "fd9622a1-7f43-5f70-9979-adc947857b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f0113-3ced-49c7-9fa8-f1cc873bdc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f0113-3ced-49c7-9fa8-f1cc873bdc4c.jpg?1",
             "name": "Loxodon Anchorite",
             "text": "{T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "992210ba-e9e4-5dc1-853e-e2353eb07b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e58f4fb-5b4e-45bc-99b3-d09cd79132df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e58f4fb-5b4e-45bc-99b3-d09cd79132df.jpg?1",
             "name": "Loxodon Stalwart",
             "text": "Attacking doesn't cause Loxodon Stalwart to tap.\n{W}: Loxodon Stalwart gets +0/+1 until end of turn.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "54118dec-49c6-5c67-8a33-2791490183fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45501767-2ba8-443f-af9b-c86ead0aa30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45501767-2ba8-443f-af9b-c86ead0aa30d.jpg?1",
             "name": "Raksha Golden Cub",
             "text": "Attacking doesn't cause Raksha Golden Cub to tap.\nAs long as Raksha is equipped, Cats you control get +2/+2 and have double strike.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "7002b5a8-8f5c-543a-8765-1a9015499765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58acdda6-6754-46f2-ad68-f1580b8ab0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58acdda6-6754-46f2-ad68-f1580b8ab0dd.jpg?1",
             "name": "Retaliate",
             "text": "Destroy all creatures that dealt damage to you this turn.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "4e8029d7-b01d-5a98-babd-40b1c57a1cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d560e242-44ef-4162-8589-965897e4cdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d560e242-44ef-4162-8589-965897e4cdad.jpg?1",
             "name": "Roar of Reclamation",
             "text": "Each player returns all artifact cards from his or her graveyard to play.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "945cc9b8-ca9d-56e5-a2ff-be9ea72ed104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4065bb-8deb-46d5-a57e-d61c77493274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4065bb-8deb-46d5-a57e-d61c77493274.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying\nAttacking doesn't cause Skyhunter Prowler to tap.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "8de80063-ab58-518c-a93d-10b64c9b6dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975d0549-e6b6-456b-8693-227591e4db91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975d0549-e6b6-456b-8693-227591e4db91.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "Flying, double strike",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "339ef173-f5e3-5252-8522-235d0887ce4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d3a024-6cf3-4008-a4f6-1d96ff5de22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d3a024-6cf3-4008-a4f6-1d96ff5de22a.jpg?1",
             "name": "Stand Firm",
             "text": "Target creature gets +1/+1 until end of turn.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "635a8785-29bb-5905-b6dd-750e5afb33d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2ca75e-ccb0-4e5b-8dda-445fe0130732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2ca75e-ccb0-4e5b-8dda-445fe0130732.jpg?1",
             "name": "Stasis Cocoon",
             "text": "Enchanted artifact's activated abilities can't be played.\nIf enchanted artifact is a creature, it can't attack or block.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "708f58a6-102a-5267-a8e0-13a1bdd9f841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75b77f-a230-4bad-b697-a40687671842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75b77f-a230-4bad-b697-a40687671842.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "c3107bb9-40c5-573b-a91b-0523f69daf80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bae717-56c0-4028-b1e7-a445d6a57176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bae717-56c0-4028-b1e7-a445d6a57176.jpg?1",
             "name": "Vanquish",
             "text": "Destroy target blocking creature.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "2f92becf-7732-5fed-9ab8-cb5dd00c0c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993957c7-5d61-4c98-826d-b657aed667e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993957c7-5d61-4c98-826d-b657aed667e1.jpg?1",
             "name": "Acquire",
             "text": "Search target opponent's library for an artifact card and put that card into play under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "784c2661-9c33-545e-901d-cd892e7b534b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384d50a-5801-47ed-ab9f-5c7e4f1f20dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384d50a-5801-47ed-ab9f-5c7e4f1f20dd.jpg?1",
             "name": "Advanced Hoverguard",
             "text": "Flying\n{U}: Advanced Hoverguard can't be the target of spells or abilities this turn.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "5049883c-4aa7-5cb9-9bd4-36a4de847e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe37c88-afd7-45ac-9f84-f4bd881a1462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe37c88-afd7-45ac-9f84-f4bd881a1462.jpg?1",
             "name": "Artificer's Intuition",
             "text": "{U}, Discard an artifact card from your hand: Search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "13784941-0eae-572c-8041-280c4355e27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab166c9-af3e-4e65-88ed-9766b046c95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab166c9-af3e-4e65-88ed-9766b046c95b.jpg?1",
             "name": "Beacon of Tomorrows",
             "text": "Target player takes an extra turn after this one. Shuffle Beacon of Tomorrows into its owner's library.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "5085beee-b5f3-5757-95bd-ac8a273371ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb4d9a3-e7f6-41e2-9545-4682efd71f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb4d9a3-e7f6-41e2-9545-4682efd71f46.jpg?1",
             "name": "Blinkmoth Infusion",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nUntap all artifacts.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "0a546a8d-a2f2-5088-89e8-1f50160ba1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dc82a0-f054-4614-a7b9-4c5a7c9d2a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dc82a0-f054-4614-a7b9-4c5a7c9d2a77.jpg?1",
             "name": "Bringer of the Blue Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Blue Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may draw two cards.",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "bf3b94ff-05ec-552c-98dd-e3e2dc633d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8303b80-e29a-46b8-90b0-c0cfe551b435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8303b80-e29a-46b8-90b0-c0cfe551b435.jpg?1",
             "name": "Condescend",
             "text": "Counter target spell unless its controller pays {X}.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "bc93c235-1539-5221-8add-dbeaf9ae74af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b6f7e-4e08-465d-b9c7-d1a167850cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b6f7e-4e08-465d-b9c7-d1a167850cf9.jpg?1",
             "name": "Disruption Aura",
             "text": "Enchanted artifact has \"At the beginning of your upkeep, sacrifice this artifact unless you pay its mana cost.\"",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "aa3692ec-3801-545b-b629-7b3f46469e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5989d4c4-bfa4-4b07-ab64-65a3aee6144e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5989d4c4-bfa4-4b07-ab64-65a3aee6144e.jpg?1",
             "name": "Early Frost",
             "text": "Tap up to three target lands.",
             "colours": [
@@ -979,7 +979,7 @@
         },
         {
             "id": "47dcd733-b48a-5ec6-9d6b-1bd783a94d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb0716-e0fc-415d-8fc3-d3f5ee31e9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb0716-e0fc-415d-8fc3-d3f5ee31e9c5.jpg?1",
             "name": "Eyes of the Watcher",
             "text": "Whenever you play an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "42df3437-ae03-57ac-8d96-021163b5d896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615157d6-0160-417b-b06c-0e253b306c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615157d6-0160-417b-b06c-0e253b306c37.jpg?1",
             "name": "Fold into Aether",
             "text": "Counter target spell. If you do, that spell's controller may put a creature card from his or her hand into play.",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "8650c19d-0943-5ec8-aee3-a95cab25433b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55773fd5-86a2-4fd4-9849-a2f0d4c8298f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55773fd5-86a2-4fd4-9849-a2f0d4c8298f.jpg?1",
             "name": "Hoverguard Sweepers",
             "text": "Flying\nWhen Hoverguard Sweepers comes into play, you may return up to two target creatures to their owners' hands.",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "0be714ce-98d7-5dd7-ab1b-522a0981c504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31ff9-f403-4082-88f8-65807c0af812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31ff9-f403-4082-88f8-65807c0af812.jpg?1",
             "name": "Into Thin Air",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nReturn target artifact to its owner's hand.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "33cd41a8-ea0c-54d8-9497-8bc3509eb3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035a8a69-1e48-4c44-b407-cc8acc8ba94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035a8a69-1e48-4c44-b407-cc8acc8ba94c.jpg?1",
             "name": "Plasma Elemental",
             "text": "Plasma Elemental is unblockable.",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "b24cb5d1-eaa0-5033-aacf-a8943180de69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54102e68-dded-440c-b9b1-28771c8033d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54102e68-dded-440c-b9b1-28771c8033d4.jpg?1",
             "name": "Qumulox",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "2d0035b3-65b8-520b-a3be-e9006cf37e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61952-88ba-447a-835a-f1e9643fcd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61952-88ba-447a-835a-f1e9643fcd0d.jpg?1",
             "name": "Serum Visions",
             "text": "Draw a card.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "10e30eeb-cdd8-54ce-9508-2b2638ce4601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a3f75d-9a79-4c16-8f50-43a18add4579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a3f75d-9a79-4c16-8f50-43a18add4579.jpg?1",
             "name": "Spectral Shift",
             "text": "Choose one Change the text of target spell or permanent by replacing all instances of one basic land type with another; or change the text of target spell or permanent by replacing all instances of one color word with another. (These effects don't end at end of turn.)\nEntwine {2}",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "da8d6299-797a-5af9-b622-234bdd0c126b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837b6315-d5c6-480b-902e-44107a72b581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837b6315-d5c6-480b-902e-44107a72b581.jpg?1",
             "name": "Thought Courier",
             "text": "{T}: Draw a card, then discard a card from your hand.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "0258196f-f314-594f-8cf6-6bfa245717c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a41ab-1840-4abb-a8bb-f0b1e7d1b450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a41ab-1840-4abb-a8bb-f0b1e7d1b450.jpg?1",
             "name": "Trinket Mage",
             "text": "When Trinket Mage comes into play, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1311,7 +1311,7 @@
         },
         {
             "id": "eafe03d7-84f7-50a7-b9fa-1fba2bc9c111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d8c7ed-62ce-4865-8f9e-5fcc8b23cff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d8c7ed-62ce-4865-8f9e-5fcc8b23cff5.jpg?1",
             "name": "Vedalken Mastermind",
             "text": "{U}, {T}: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -1346,7 +1346,7 @@
         },
         {
             "id": "419360cc-4b71-5f91-9e6a-72c86eb93f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a0e0c-cf75-46ec-a65b-e6d3d371f28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a0e0c-cf75-46ec-a65b-e6d3d371f28a.jpg?1",
             "name": "Beacon of Unrest",
             "text": "Put target artifact or creature card from a graveyard into play under your control. Shuffle Beacon of Unrest into its owner's library.",
             "colours": [
@@ -1378,7 +1378,7 @@
         },
         {
             "id": "da3e503c-039d-5c92-a5af-b90d01b7b387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5440a-7460-4b4f-a167-a6c4fb2d855e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5440a-7460-4b4f-a167-a6c4fb2d855e.jpg?1",
             "name": "Blind Creeper",
             "text": "Whenever a player plays a spell, Blind Creeper gets -1/-1 until end of turn.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "2bdf763d-bbd3-5058-9815-69a5e4657d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e5e882-02d4-4d69-aabf-ae9bf31f2923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e5e882-02d4-4d69-aabf-ae9bf31f2923.jpg?1",
             "name": "Bringer of the Black Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Black Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may pay 2 life. If you do, search your library for a card, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -1451,7 +1451,7 @@
         },
         {
             "id": "c4375935-cd79-5b0a-9b73-205c3ae669be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641080d8-1b2e-4990-a114-04bea9a5adce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641080d8-1b2e-4990-a114-04bea9a5adce.jpg?1",
             "name": "Cackling Imp",
             "text": "Flying\n{T}: Target player loses 1 life.",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "d0785e19-c015-5fb8-9ff7-96d482f55fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c14a7a-cce3-45a8-9092-834e71447f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c14a7a-cce3-45a8-9092-834e71447f62.jpg?1",
             "name": "Desecration Elemental",
             "text": "Fear\nWhenever a player plays a spell, sacrifice a creature.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "ab32e99d-327e-5ac2-bc1a-589c1bad7987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c80584-b7b5-4dcd-8a00-812b9dd9b1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c80584-b7b5-4dcd-8a00-812b9dd9b1b9.jpg?1",
             "name": "Devour in Shadow",
             "text": "Destroy target creature. It can't be regenerated. You lose life equal to that creature's toughness.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "fdc07f4a-c6b1-597c-a292-be07c5f975e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e61e00-c55b-4384-923b-a777f75cbe79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e61e00-c55b-4384-923b-a777f75cbe79.jpg?1",
             "name": "Dross Crocodile",
             "text": "",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "85263657-fdee-5ce1-88b7-43eff6435dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254ea05c-c349-4a95-8751-779b044603bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254ea05c-c349-4a95-8751-779b044603bb.jpg?1",
             "name": "Ebon Drake",
             "text": "Flying\nWhenever a player plays a spell, you lose 1 life.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "571ec204-371e-5f09-9c9a-2fb91b3a632e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266323da-9528-462e-a0a8-6ef2dda5f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266323da-9528-462e-a0a8-6ef2dda5f1ee.jpg?1",
             "name": "Endless Whispers",
             "text": "Each creature has \"When this creature is put into a graveyard from play, choose target opponent. That player puts this creature card from that graveyard into play under his or her control at end of turn.\"",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "228dee18-2e14-5ab6-a533-df617d49653d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682bbd3-9f52-452d-b886-a6a8def35f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682bbd3-9f52-452d-b886-a6a8def35f27.jpg?1",
             "name": "Fill with Fright",
             "text": "Target player discards two cards from his or her hand.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "1bb8d310-0fab-542d-b81b-811b826e47e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01095217-bc33-4d71-bf10-2ead9f8ebd25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01095217-bc33-4d71-bf10-2ead9f8ebd25.jpg?1",
             "name": "Fleshgrafter",
             "text": "Discard an artifact card from your hand: Fleshgrafter gets +2/+2 until end of turn.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "0d7bc552-bfa8-524c-aed8-66ac48471cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d7bf6-00f4-4c7e-b1a4-f7fd690d4788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d7bf6-00f4-4c7e-b1a4-f7fd690d4788.jpg?1",
             "name": "Lose Hope",
             "text": "Target creature gets -1/-1 until end of turn.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "9904c18b-174a-55e0-bed3-120a9e424128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754f202f-4f08-4c39-9219-1114d8508788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754f202f-4f08-4c39-9219-1114d8508788.jpg?1",
             "name": "Mephidross Vampire",
             "text": "Flying\nEach creature you control is a Vampire in addition to its other creature types and has \"Whenever this creature deals damage to a creature, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "0bb7d751-e71c-5e5e-8a39-1de6aca509ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ffdeb8-52d2-4059-b9c6-0ad71b96516a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ffdeb8-52d2-4059-b9c6-0ad71b96516a.jpg?1",
             "name": "Moriok Rigger",
             "text": "Whenever an artifact is put into a graveyard from play, you may put a +1/+1 counter on Moriok Rigger.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "b7ab5cc9-6085-5f29-8fda-b9654d75a37f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f0c6f6-b90d-4eb1-a5db-86e0a3997501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f0c6f6-b90d-4eb1-a5db-86e0a3997501.jpg?1",
             "name": "Night's Whisper",
             "text": "You draw two cards and you lose 2 life.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "028cd7a1-f550-54d4-b53c-1c22d670b1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ae8bc7-8bf1-4fce-afaa-76acfb261419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ae8bc7-8bf1-4fce-afaa-76acfb261419.jpg?1",
             "name": "Nim Grotesque",
             "text": "Nim Grotesque gets +1/+0 for each artifact you control.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "99a4298a-17be-5de4-824f-4a4f2c324429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c74b4-dd9e-43d6-ad0a-06e026a8d672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c74b4-dd9e-43d6-ad0a-06e026a8d672.jpg?1",
             "name": "Plunge into Darkness",
             "text": "Choose one Sacrifice any number of creatures, then you gain 3 life for each sacrificed creature; or pay X life, then look at the top X cards of your library, put one of those cards into your hand, and remove the rest from the game.\nEntwine {B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "bc49d701-e728-5870-97da-6090b4f41ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9caf97-75c6-4e12-8724-1abe32212bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9caf97-75c6-4e12-8724-1abe32212bef.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature in play named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "e0040697-63f9-5c21-b506-db91b543b6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb957bd-99e4-431e-b163-c25e9b7850d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb957bd-99e4-431e-b163-c25e9b7850d9.jpg?1",
             "name": "Shattered Dreams",
             "text": "Target opponent reveals his or her hand. Choose an artifact card from it. That player discards that card.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "b578504c-6463-5db9-8a1e-545897106c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca003f-dc03-4533-a245-fde836aab5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca003f-dc03-4533-a245-fde836aab5eb.jpg?1",
             "name": "Vicious Betrayal",
             "text": "As an additional cost to play Vicious Betrayal, sacrifice any number of creatures.\nTarget creature gets +2/+2 until end of turn for each creature sacrificed this way.",
             "colours": [
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "bc0e7f1f-3bae-510d-86cd-44c50f3065c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fae532-7189-450e-aa7f-e639163278fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fae532-7189-450e-aa7f-e639163278fc.jpg?1",
             "name": "Beacon of Destruction",
             "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "c5ba3725-7a80-5ed8-9f17-7a0e0c936455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a58bb1-4c4d-41f2-9c69-d3c3a8a8ab09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a58bb1-4c4d-41f2-9c69-d3c3a8a8ab09.jpg?1",
             "name": "Bringer of the Red Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Red Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may untap target creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "b0dc3a84-fb9b-595d-844e-05888fa6dd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deaa0b9b-258e-4daf-8fec-ce64864d6bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deaa0b9b-258e-4daf-8fec-ce64864d6bbf.jpg?1",
             "name": "Cosmic Larva",
             "text": "Trample\nAt the beginning of your upkeep, sacrifice Cosmic Larva unless you sacrifice two lands.",
             "colours": [
@@ -2121,7 +2121,7 @@
         },
         {
             "id": "5948e408-d8ee-507d-840f-f36568d1e48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a370375c-14bf-4381-9359-f2e600867e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a370375c-14bf-4381-9359-f2e600867e7c.jpg?1",
             "name": "Feedback Bolt",
             "text": "Feedback Bolt deals damage to target player equal to the number of artifacts you control.",
             "colours": [
@@ -2153,7 +2153,7 @@
         },
         {
             "id": "383642c2-378d-5cbe-853e-a9a74808a2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1726eba-c471-40bd-a487-40d910b75d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1726eba-c471-40bd-a487-40d910b75d64.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "8f4887e2-3600-5bb3-9b6d-20f0a64fdd48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6586c04-f92d-4c3f-8b03-59e5ef158ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6586c04-f92d-4c3f-8b03-59e5ef158ed4.jpg?1",
             "name": "Goblin Brawler",
             "text": "First strike\nGoblin Brawler can't be equipped.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "38dd77f4-ba89-5a36-8c33-530ecf540fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13798b8-689e-4f19-af10-b72d3fe19f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13798b8-689e-4f19-af10-b72d3fe19f3c.jpg?1",
             "name": "Granulate",
             "text": "Destroy each nonland artifact with converted mana cost 4 or less.",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "382a872e-5d24-5c9d-8b80-7fe776a7cf87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296acb6-a304-42ab-b26b-5cbe796e72b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296acb6-a304-42ab-b26b-5cbe796e72b7.jpg?1",
             "name": "Ion Storm",
             "text": "{1}{R}, Remove a +1/+1 counter or a charge counter from a permanent you control: Ion Storm deals 2 damage to target creature or player.",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "40f5f6c6-ab85-570b-8b17-9b4f9fe4ab5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb36352-2f16-4572-b1aa-dc28b11f4229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb36352-2f16-4572-b1aa-dc28b11f4229.jpg?1",
             "name": "Iron-Barb Hellion",
             "text": "Haste\nIron-Barb Hellion can't block.",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "358e06c1-90e1-58f8-8efd-90c44b4c25ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110a5e2-31e1-4a63-96cd-56295f67d436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110a5e2-31e1-4a63-96cd-56295f67d436.jpg?1",
             "name": "Krark-Clan Engineers",
             "text": "{R}, Sacrifice two artifacts: Destroy target artifact.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "83cad0e6-9a6a-5c08-baf5-4ff7caf9776c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649f561c-0b90-4f1d-a003-bab351632bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649f561c-0b90-4f1d-a003-bab351632bd3.jpg?1",
             "name": "Krark-Clan Ogre",
             "text": "{R}, Sacrifice an artifact: Target creature can't block this turn.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "2cff6552-58a9-5716-a864-02b62e2f9861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57670afe-cc40-44f5-b97c-a8f0377c710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57670afe-cc40-44f5-b97c-a8f0377c710a.jpg?1",
             "name": "Magma Giant",
             "text": "When Magma Giant comes into play, it deals 2 damage to each creature and each player.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "d4a14a9b-112c-5418-8d7c-2f6f6af7019e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea1728-08aa-4553-90b2-919c70712ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea1728-08aa-4553-90b2-919c70712ed5.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to target creature or player.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "2373e03c-9390-5099-9074-cecadff2ce8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0c1e37-fedc-43d9-97fd-b797c6c2fbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0c1e37-fedc-43d9-97fd-b797c6c2fbbe.jpg?1",
             "name": "Magnetic Theft",
             "text": "Attach target Equipment to target creature. (Control of the Equipment doesn't change.)",
             "colours": [
@@ -2488,7 +2488,7 @@
         },
         {
             "id": "90b3dac8-69e1-5b36-9f31-5899f093cb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3929662e-99d7-48e9-afac-1852af8be722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3929662e-99d7-48e9-afac-1852af8be722.jpg?1",
             "name": "Mana Geyser",
             "text": "Add {R} to your mana pool for each tapped land your opponents control.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "aa601f7e-c981-5937-9d51-9c8178f55869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a6ecc6-83c8-408b-8600-687cdb383ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a6ecc6-83c8-408b-8600-687cdb383ca9.jpg?1",
             "name": "Rain of Rust",
             "text": "Choose one Destroy target artifact; or destroy target land.\nEntwine {3}{R} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "ba5644df-a8e2-5847-bd41-311bff5579bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf87c0-369e-4ec2-bb9f-e8e29d63d448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf87c0-369e-4ec2-bb9f-e8e29d63d448.jpg?1",
             "name": "Reversal of Fortune",
             "text": "Target opponent reveals his or her hand. You may copy an instant or sorcery card in it and play the copy without paying its mana cost.",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "6784589d-08f9-568b-bd31-22c0fa549e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8488b6-3785-4346-a81b-c28d355f9d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8488b6-3785-4346-a81b-c28d355f9d25.jpg?1",
             "name": "Screaming Fury",
             "text": "Target creature gets +5/+0 and gains haste until end of turn.",
             "colours": [
@@ -2616,7 +2616,7 @@
         },
         {
             "id": "efe6e99e-3c7f-576c-9631-e342d02d1dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c8bcb2-8247-4d91-baf6-b08de1eb9cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c8bcb2-8247-4d91-baf6-b08de1eb9cde.jpg?1",
             "name": "Spark Elemental",
             "text": "Trample, haste\nAt end of turn, sacrifice Spark Elemental.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "e0e6459c-4908-5114-a1ea-76db282f6268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7207dd-854a-4150-b813-f60713ecfc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7207dd-854a-4150-b813-f60713ecfc30.jpg?1",
             "name": "Vulshok Sorcerer",
             "text": "Haste\n{T}: Vulshok Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "8f1fa4f2-365e-5f27-89a8-1a84bf04e29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefabea5-b6f0-46f4-a1a5-037c2482b979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefabea5-b6f0-46f4-a1a5-037c2482b979.jpg?1",
             "name": "All Suns' Dawn",
             "text": "For each color, return up to one target card of that color from your graveyard to your hand. Then remove All Suns' Dawn from the game.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "511a2ff2-8cec-56ed-a5ef-b2755b573de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc629de-18a3-4780-9df6-28ee54a34b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc629de-18a3-4780-9df6-28ee54a34b81.jpg?1",
             "name": "Beacon of Creation",
             "text": "Put a 1/1 green Insect creature token into play for each Forest you control. Shuffle Beacon of Creation into its owner's library.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "587bfa0d-4a16-5ab9-88aa-128c6461381d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41.jpg?1",
             "name": "Bringer of the Green Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Green Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may put a 3/3 green Beast creature token into play.",
             "colours": [
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "33697c85-e27b-5fd5-87a9-9906d65530c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf574c8-a7e0-482e-bb41-680454988097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf574c8-a7e0-482e-bb41-680454988097.jpg?1",
             "name": "Channel the Suns",
             "text": "Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "7ff7cb43-c180-5a0b-b07d-5060ab636538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a124f-f11e-4ea1-a7b2-b94eea988d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a124f-f11e-4ea1-a7b2-b94eea988d4e.jpg?1",
             "name": "Dawn's Reflection",
             "text": "Whenever enchanted land is tapped for mana, its controller adds two mana of any combination of colored mana to his or her mana pool.",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "5cdba3c6-0801-52e0-8331-6ad8f75e5819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e10ca7-1e5d-4224-82cf-798a4d436d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e10ca7-1e5d-4224-82cf-798a4d436d72.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness comes into play, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "d262f3d3-b5e0-522e-9643-e5030141f54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59679bcf-4436-48f8-bc6a-d7e0ec6b04c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59679bcf-4436-48f8-bc6a-d7e0ec6b04c9.jpg?1",
             "name": "Fangren Pathcutter",
             "text": "Whenever Fangren Pathcutter attacks, attacking creatures gain trample until end of turn.",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "4a2fc96e-5811-5a1b-a421-720b3c091c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3749181f-7b4e-4b9d-aaf3-94f707c306aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3749181f-7b4e-4b9d-aaf3-94f707c306aa.jpg?1",
             "name": "Ferocious Charge",
             "text": "Target creature gets +4/+4 until end of turn.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "089eb197-9d83-5fa8-8be2-c4f835109d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acf1a5f-1dbd-4481-b58d-b84e32d2b6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acf1a5f-1dbd-4481-b58d-b84e32d2b6b3.jpg?1",
             "name": "Joiner Adept",
             "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "cc6ce5a2-49d0-59de-a17e-362f47b67773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e08f8-7608-4137-9a58-f6eda8f84313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e08f8-7608-4137-9a58-f6eda8f84313.jpg?1",
             "name": "Ouphe Vandals",
             "text": "{G}, Sacrifice Ouphe Vandals: Counter target activated ability from an artifact source and destroy that artifact if it's in play. (Mana abilities can't be targeted.)",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "33b02745-1487-5de2-a6be-deea6ef4fc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea92a0c-f73f-4e85-9d87-6401aa1b052e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea92a0c-f73f-4e85-9d87-6401aa1b052e.jpg?1",
             "name": "Rite of Passage",
             "text": "Whenever a creature you control is dealt damage, put a +1/+1 counter on it. (The damage is dealt before the counter is put on.)",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "759d520c-6a62-5c4a-bc36-2b01484bea99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0164e2ed-b722-4a7d-a4fb-5401af008cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0164e2ed-b722-4a7d-a4fb-5401af008cbf.jpg?1",
             "name": "Rude Awakening",
             "text": "Choose one Untap all lands you control; or until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "6160d1ce-8628-5ec7-9854-f0b5299d75dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed328af-bc0d-4a9d-a9ee-bc0196a2afaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed328af-bc0d-4a9d-a9ee-bc0196a2afaf.jpg?1",
             "name": "Sylvok Explorer",
             "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [
@@ -3127,7 +3127,7 @@
         },
         {
             "id": "36d2bdbd-0db3-5f16-8f0a-64d1afb71c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e13ac56-72a9-4605-b389-24d1cb712b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e13ac56-72a9-4605-b389-24d1cb712b3c.jpg?1",
             "name": "Tangle Asp",
             "text": "Whenever Tangle Asp blocks or becomes blocked by a creature, destroy that creature at end of combat.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "04a7ab22-e8ae-53a2-a9a1-a12548957b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99fefa37-c876-4039-8cc4-4b2138181a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99fefa37-c876-4039-8cc4-4b2138181a1d.jpg?1",
             "name": "Tel-Jilad Justice",
             "text": "Destroy target artifact.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "abf6a77c-2185-5ccc-acbe-8dc8ce29160e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee58a5ef-68ec-48cf-bb7e-73bcbe86cc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee58a5ef-68ec-48cf-bb7e-73bcbe86cc3c.jpg?1",
             "name": "Tel-Jilad Lifebreather",
             "text": "{G}, {T}, Sacrifice a Forest: Regenerate target creature.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "cb0e8e68-a8f9-5b2c-9288-e38cb318e6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09751cf-6aa9-4d64-a1db-4f1826774f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09751cf-6aa9-4d64-a1db-4f1826774f00.jpg?1",
             "name": "Tornado Elemental",
             "text": "When Tornado Elemental comes into play, it deals 6 damage to each creature with flying.\nYou may have Tornado Elemental deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "6f179741-900d-502f-bca1-5d0e36c35e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb0cc0e-f71f-456f-a6ec-6a70cf838c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb0cc0e-f71f-456f-a6ec-6a70cf838c35.jpg?1",
             "name": "Tyrranax",
             "text": "{1}{G}: Tyrranax gets -1/+1 until end of turn.",
             "colours": [
@@ -3297,7 +3297,7 @@
         },
         {
             "id": "2a1ba908-f8c5-543d-a5db-4e8002fa17bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85673b93-39b7-44e1-b27d-b716bde42f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85673b93-39b7-44e1-b27d-b716bde42f0b.jpg?1",
             "name": "Viridian Lorebearers",
             "text": "{3}{G}, {T}: Target creature gets +X/+X until end of turn, where X is the number of artifacts your opponents control.",
             "colours": [
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "55ae1261-22cc-5d9e-8986-51d18c032448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3260a427-b67f-4908-8c56-5c0fab009598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3260a427-b67f-4908-8c56-5c0fab009598.jpg?1",
             "name": "Viridian Scout",
             "text": "{2}{G}, Sacrifice Viridian Scout: Viridian Scout deals 2 damage to target creature with flying.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "c8ec9d3c-e920-5f00-9480-b9adcf3e811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97773f5-548a-4107-b29c-56b5428d5ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97773f5-548a-4107-b29c-56b5428d5ddb.jpg?1",
             "name": "Anodet Lurker",
             "text": "When Anodet Lurker is put into a graveyard from play, you gain 3 life.",
             "colours": [],
@@ -3399,7 +3399,7 @@
         },
         {
             "id": "3a6d1ad1-3c8c-5710-a008-fb1078918689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836d5ce6-d5c9-4fb5-8302-53d25b5531b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836d5ce6-d5c9-4fb5-8302-53d25b5531b5.jpg?1",
             "name": "Arachnoid",
             "text": "Arachnoid may block as though it had flying.",
             "colours": [],
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "666ff2ce-c498-5246-9651-600b76f58878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4242f34-33c0-4e16-a6d9-18499dc8f2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4242f34-33c0-4e16-a6d9-18499dc8f2eb.jpg?1",
             "name": "Arcbound Wanderer",
             "text": "Modular\u2014\nSunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "06d6a598-24a2-5109-9269-3c021f401450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a5cfa8-4091-445c-8641-64402cca7d2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a5cfa8-4091-445c-8641-64402cca7d2d.jpg?1",
             "name": "Avarice Totem",
             "text": "{5}: Exchange control of Avarice Totem and target nonland permanent.",
             "colours": [],
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "1b442baf-a409-578f-b8cb-f74650cdbf6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d363970c-2418-42f9-8d13-0e5700161b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d363970c-2418-42f9-8d13-0e5700161b62.jpg?1",
             "name": "Baton of Courage",
             "text": "You may play Baton of Courage any time you could play an instant.\nSunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nRemove a charge counter from Baton of Courage: Target creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "f62f0ab9-c670-5132-8494-76c0968bc073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69add35-c529-4b30-8e64-f09b8308432f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69add35-c529-4b30-8e64-f09b8308432f.jpg?1",
             "name": "Battered Golem",
             "text": "Battered Golem doesn't untap during your untap step.\nWhenever an artifact comes into play, you may untap Battered Golem.",
             "colours": [],
@@ -3548,7 +3548,7 @@
         },
         {
             "id": "bb385b99-081d-5ed2-b95d-e4031f575868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e2f832-6601-4232-b250-fd1c88538fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e2f832-6601-4232-b250-fd1c88538fbd.jpg?1",
             "name": "Blasting Station",
             "text": "{T}, Sacrifice a creature: Blasting Station deals 1 damage to target creature or player.\nWhenever a creature comes into play, you may untap Blasting Station.",
             "colours": [],
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "b9341f93-34a6-59b2-888e-945896802f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbe14e2-89f2-4458-a84f-08ed3c6ae3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbe14e2-89f2-4458-a84f-08ed3c6ae3d7.jpg?1",
             "name": "Chimeric Coils",
             "text": "{X}{1}: Chimeric Coils becomes an X/X artifact creature. Sacrifice it at end of turn.",
             "colours": [],
@@ -3604,7 +3604,7 @@
         },
         {
             "id": "5c8148a5-34f8-5fba-986f-0e129b054b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5458c041-dde0-4df7-82bb-ada36a482c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5458c041-dde0-4df7-82bb-ada36a482c53.jpg?1",
             "name": "Clearwater Goblet",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nAt the beginning of your upkeep, you may gain 1 life for each charge counter on Clearwater Goblet.",
             "colours": [],
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "679250de-faea-513b-a1d9-7735ed28b52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffce71b-eb60-4649-a62b-a1b4acaa9d2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffce71b-eb60-4649-a62b-a1b4acaa9d2d.jpg?1",
             "name": "Clock of Omens",
             "text": "Tap two untapped artifacts you control: Untap target artifact.",
             "colours": [],
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "0d3865b6-9df4-576b-9a13-2daaac2c9795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eba4407-0405-41fa-99e5-1bfa3a787398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eba4407-0405-41fa-99e5-1bfa3a787398.jpg?1",
             "name": "Composite Golem",
             "text": "Sacrifice Composite Golem: Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [],
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "d3a70cdc-f694-5e0c-b90e-ae0eaf9c8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32960e-d182-455f-8e74-eb11b10050da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32960e-d182-455f-8e74-eb11b10050da.jpg?1",
             "name": "Conjurer's Bauble",
             "text": "{T}, Sacrifice Conjurer's Bauble: Put up to one target card from your graveyard on the bottom of your library. Draw a card.",
             "colours": [],
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "bb8342fa-767b-548b-ac19-f60ebd63ef7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea95d0-9f95-462b-a080-22a5da7b2e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea95d0-9f95-462b-a080-22a5da7b2e97.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "7a2122c0-11aa-5520-aa72-734ea616518a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312a6058-de08-487d-95bd-b3c56807fdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312a6058-de08-487d-95bd-b3c56807fdd6.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play land cards from your graveyard as though they were in your hand.",
             "colours": [],
@@ -3785,7 +3785,7 @@
         },
         {
             "id": "4b37813d-08c1-5911-ae78-3a1f916ab5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ffeae-6b51-4426-a080-b1b065b1290d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ffeae-6b51-4426-a080-b1b065b1290d.jpg?1",
             "name": "Door to Nothingness",
             "text": "Door to Nothingness comes into play tapped.\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice Door to Nothingness: Target player loses the game.",
             "colours": [],
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "2cb0bb1f-bea4-5ded-85ab-9eefc9b931f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220d3a38-10f8-4d4a-84b8-f17b10a2cd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220d3a38-10f8-4d4a-84b8-f17b10a2cd6c.jpg?1",
             "name": "Doubling Cube",
             "text": "{3}, {T}: Double the amount of each type of mana in your mana pool.",
             "colours": [],
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "18e71a6c-0b2b-524a-8206-2d4e4be28353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6a6ad6-77a5-4dec-922f-1cd6780c8671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6a6ad6-77a5-4dec-922f-1cd6780c8671.jpg?1",
             "name": "Energy Chamber",
             "text": "At the beginning of your upkeep, choose one Put a +1/+1 counter on target artifact creature; or put a charge counter on target noncreature artifact.",
             "colours": [],
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "cb1e9e42-9a35-53c0-8684-3a4027833a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8492a272-e595-4f94-a6eb-08d29f211fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8492a272-e595-4f94-a6eb-08d29f211fd6.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "d3d9ac61-721f-5547-9c1b-04412eaee414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2a16e2-ea98-4bf2-9e5c-7612d2dd039b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2a16e2-ea98-4bf2-9e5c-7612d2dd039b.jpg?1",
             "name": "Ensouled Scimitar",
             "text": "{3}: Ensouled Scimitar becomes a 1/5 artifact creature with flying until end of turn. (Equipment that's a creature can't equip a creature.)\nEquipped creature gets +1/+5.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "480dd905-fa78-5c0c-9bcc-e62c6af77922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d6b270-b4c9-489d-9322-7c8ddc0ca0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d6b270-b4c9-489d-9322-7c8ddc0ca0ac.jpg?1",
             "name": "Eon Hub",
             "text": "Players skip their upkeep steps.",
             "colours": [],
@@ -3961,7 +3961,7 @@
         },
         {
             "id": "901999b3-c419-59ca-97db-1fe26263c874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fcd005-9b54-42c1-8ce1-a20665d0fd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fcd005-9b54-42c1-8ce1-a20665d0fd8b.jpg?1",
             "name": "Etched Oracle",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\n{1}, Remove four +1/+1 counters from Etched Oracle: Target player draws three cards.",
             "colours": [],
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "f935661b-9277-540b-b43c-554d64c40800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf8248c-ef2c-4b1e-8a0b-05def43ca2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf8248c-ef2c-4b1e-8a0b-05def43ca2af.jpg?1",
             "name": "Ferropede",
             "text": "Ferropede is unblockable.\nWhenever Ferropede deals combat damage to a player, you may remove a counter from target permanent.",
             "colours": [],
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "dbb835a4-bd01-56b7-9ebe-14ddad9e1465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9997c580-596b-43d5-b4a0-9acc8fc2ef26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9997c580-596b-43d5-b4a0-9acc8fc2ef26.jpg?1",
             "name": "Fist of Suns",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you play.",
             "colours": [],
@@ -4057,7 +4057,7 @@
         },
         {
             "id": "c03db40c-826d-51cd-a7b4-547d20d9cb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef37a3-4538-47b2-8f88-3fa0a4e32329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef37a3-4538-47b2-8f88-3fa0a4e32329.jpg?1",
             "name": "Gemstone Array",
             "text": "{2}: Put a charge counter on Gemstone Array.\nRemove a charge counter from Gemstone Array: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "5eb66b7d-beb9-5d02-be63-399798c53b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b023c0cd-7046-418b-ad31-5c91c6930d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b023c0cd-7046-418b-ad31-5c91c6930d45.jpg?1",
             "name": "Goblin Cannon",
             "text": "{2}: Goblin Cannon deals 1 damage to target creature or player. Sacrifice Goblin Cannon.",
             "colours": [],
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "e9e695ea-39e5-5121-b08e-e670f8f67462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5269cfbd-1202-47fe-a12d-d95ff304b335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5269cfbd-1202-47fe-a12d-d95ff304b335.jpg?1",
             "name": "Grafted Wargear",
             "text": "Equipped creature gets +3/+2.\nWhenever Grafted Wargear becomes unattached from a creature, sacrifice that creature.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "1693cad4-6096-5ba5-9af3-6d5a70539d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1df511-b52c-45cd-9503-ffce4271a802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1df511-b52c-45cd-9503-ffce4271a802.jpg?1",
             "name": "Grinding Station",
             "text": "{T}, Sacrifice an artifact: Target player puts the top three cards of his or her library into his or her graveyard.\nWhenever an artifact comes into play, you may untap Grinding Station.",
             "colours": [],
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "48a66494-6b50-5447-a6f5-908552a87c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62a73-b7db-47ec-9b68-65dd7c1a06a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62a73-b7db-47ec-9b68-65dd7c1a06a5.jpg?1",
             "name": "Guardian Idol",
             "text": "Guardian Idol comes into play tapped.\n{T}: Add {1} to your mana pool.\n{2}: Guardian Idol becomes a 2/2 artifact creature until end of turn.",
             "colours": [],
@@ -4199,7 +4199,7 @@
         },
         {
             "id": "028dc6dd-1205-5393-bae2-0106c37f0c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9565f076-54a6-43d6-bcf0-dcb932f6c116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9565f076-54a6-43d6-bcf0-dcb932f6c116.jpg?1",
             "name": "Healer's Headdress",
             "text": "Equipped creature gets +0/+2 and has \"{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\"\n{W}{W}: Attach Healer's Headdress to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "f0a79afd-72e8-5a67-a566-c708cb2f83d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d65fa8e-6944-4fe8-b7b4-c77dfbddf605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d65fa8e-6944-4fe8-b7b4-c77dfbddf605.jpg?1",
             "name": "Heliophial",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\n{2}, Sacrifice Heliophial: Heliophial deals damage to target creature or player equal to the number of charge counters on Heliophial.",
             "colours": [],
@@ -4259,7 +4259,7 @@
         },
         {
             "id": "053bc255-ce7b-59fa-a054-723e9d1ae58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76514aa-3cc1-4d5f-ba33-d933a36920a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76514aa-3cc1-4d5f-ba33-d933a36920a4.jpg?1",
             "name": "Helm of Kaldra",
             "text": "Equipped creature has first strike, trample, and haste.\n{1}: If you control Equipment named Helm of Kaldra, Sword of Kaldra, and Shield of Kaldra, put a 4/4 colorless Avatar Legend creature token named Kaldra into play and attach those Equipment to it.\nEquip {2}",
             "colours": [],
@@ -4291,7 +4291,7 @@
         },
         {
             "id": "e77a965b-3b00-5b91-89fd-77a22faec274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c408a-0a19-44a3-a436-295380573f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c408a-0a19-44a3-a436-295380573f91.jpg?1",
             "name": "Horned Helm",
             "text": "Equipped creature gets +1/+1 and has trample.\n{G}{G}: Attach Horned Helm to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "d9be47c4-5190-56ef-a02a-5255e1123e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fd2639-3c95-435d-8e94-cd4e4d069e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fd2639-3c95-435d-8e94-cd4e4d069e3e.jpg?1",
             "name": "Infused Arrows",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\n{T}, Remove X charge counters from Infused Arrows: Target creature gets -X/-X until end of turn.",
             "colours": [],
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "6dc2e300-bda8-55c7-996b-a790ae396632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60174d6-1f9d-4870-b3db-34d6fcb3f6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60174d6-1f9d-4870-b3db-34d6fcb3f6ab.jpg?1",
             "name": "Krark-Clan Ironworks",
             "text": "Sacrifice an artifact: Add {2} to your mana pool.",
             "colours": [],
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "a361f4b9-8d4a-5597-8e6f-dbdd8ea0b718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e4c78-75fe-4692-b177-974b148f0614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e4c78-75fe-4692-b177-974b148f0614.jpg?1",
             "name": "Lantern of Insight",
             "text": "Each player plays with the top card of his or her library revealed.\n{T}, Sacrifice Lantern of Insight: Target player shuffles his or her library.",
             "colours": [],
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "29b02bd1-ae51-5af4-81f3-7fd80e80ad9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2348e5-6bf9-4a7e-91a4-ba93bb108897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2348e5-6bf9-4a7e-91a4-ba93bb108897.jpg?1",
             "name": "Lunar Avenger",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nRemove a +1/+1 counter from Lunar Avenger: Lunar Avenger gains your choice of flying, first strike, or haste until end of turn.",
             "colours": [],
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "adece9ea-5211-5601-9a23-5b99458352cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3200fa2-182f-4515-b326-ab4fdb95c8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3200fa2-182f-4515-b326-ab4fdb95c8c1.jpg?1",
             "name": "Mycosynth Golem",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nArtifact creature spells you play have affinity for artifacts. (They cost {1} less to play for each artifact you control.)",
             "colours": [],
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "cd21744b-a8ab-5c6d-a359-a8cca8d1fd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5576fe4d-cf12-460b-af15-996baeca5065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5576fe4d-cf12-460b-af15-996baeca5065.jpg?1",
             "name": "Myr Quadropod",
             "text": "{3}: Switch Myr Quadropod's power and toughness until end of turn.",
             "colours": [],
@@ -4500,7 +4500,7 @@
         },
         {
             "id": "26942e5a-c447-55f4-b479-75185044bf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127e05-d1d6-4dd5-90e1-a93e3a51b1b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127e05-d1d6-4dd5-90e1-a93e3a51b1b0.jpg?1",
             "name": "Myr Servitor",
             "text": "At the beginning of your upkeep, if Myr Servitor is in play, each player returns all cards named Myr Servitor from his or her graveyard to play.",
             "colours": [],
@@ -4531,7 +4531,7 @@
         },
         {
             "id": "4ae342e9-f966-52f0-9213-8d3185fac905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ad83a-7374-435d-a5bd-2dd455fa6420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ad83a-7374-435d-a5bd-2dd455fa6420.jpg?1",
             "name": "Neurok Stealthsuit",
             "text": "Equipped creature can't be the target of spells or abilities.\n{U}{U}: Attach Neurok Stealthsuit to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "98b9ec07-54cd-5144-b1e3-6c697df9b03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae84edd-1294-4722-89d1-84d9f336871c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae84edd-1294-4722-89d1-84d9f336871c.jpg?1",
             "name": "Opaline Bracers",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nEquipped creature gets +X/+X, where X is the number of charge counters on Opaline Bracers.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4593,7 +4593,7 @@
         },
         {
             "id": "7c2a11f7-9a20-53c9-842f-dc922d29ec02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252e9e2-2dd5-4bd6-aa56-f0a0ba056a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252e9e2-2dd5-4bd6-aa56-f0a0ba056a77.jpg?1",
             "name": "Paradise Mantle",
             "text": "Equipped creature has \"{T}: Add one mana of any color to your mana pool.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "ea5e4bf2-c980-516b-bfd4-6ae9493341f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672b9b16-daef-44e6-9a3a-cfd9f3c78bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672b9b16-daef-44e6-9a3a-cfd9f3c78bc7.jpg?1",
             "name": "Pentad Prism",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nRemove a charge counter from Pentad Prism: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "b839e700-f588-5f12-bd1b-c071e33f7886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616836e6-caf4-4398-a772-9c67f84c73c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616836e6-caf4-4398-a772-9c67f84c73c5.jpg?1",
             "name": "Possessed Portal",
             "text": "If a player would draw a card, that player skips that draw instead.\nAt the end of each turn, each player sacrifices a permanent unless he or she discards a card from his or her hand.",
             "colours": [],
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "07a21ea5-dc13-5771-8245-d739073b8c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e79f57-2214-414a-ab34-2b737d4bb972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e79f57-2214-414a-ab34-2b737d4bb972.jpg?1",
             "name": "Razorgrass Screen",
             "text": "(Walls can't attack.)\nRazorgrass Screen blocks each turn if able.",
             "colours": [],
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "58f6e6a9-1a27-5312-8e26-cbac4965ab27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81dbdc0-dffe-4c10-9e81-d66a77eb6c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81dbdc0-dffe-4c10-9e81-d66a77eb6c49.jpg?1",
             "name": "Razormane Masticore",
             "text": "First strike\nAt the beginning of your upkeep, sacrifice Razormane Masticore unless you discard a card from your hand.\nAt the beginning of your draw step, you may have Razormane Masticore deal 3 damage to target creature.",
             "colours": [],
@@ -4741,7 +4741,7 @@
         },
         {
             "id": "2733ce07-081f-5441-8472-8dd377f3427c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d760d8-030e-47d0-a555-d88ee43d3d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d760d8-030e-47d0-a555-d88ee43d3d80.jpg?1",
             "name": "Relic Barrier",
             "text": "{T}: Tap target artifact.",
             "colours": [],
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "e07c5bfa-1fb8-5a2d-a88f-d747c7a54acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0336e07-8eaf-4b90-af54-4764e5ba50f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0336e07-8eaf-4b90-af54-4764e5ba50f2.jpg?1",
             "name": "Salvaging Station",
             "text": "{T}: Return target noncreature artifact card with converted mana cost 1 or less from your graveyard to play.\nWhenever a creature is put into a graveyard from play, you may untap Salvaging Station.",
             "colours": [],
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "4b4a5120-63d3-5786-a15a-f6b951ea696d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c36de4a-807d-471d-ba59-0462d7bb028a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c36de4a-807d-471d-ba59-0462d7bb028a.jpg?1",
             "name": "Sawtooth Thresher",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nRemove two +1/+1 counters from Sawtooth Thresher: Sawtooth Thresher gets +4/+4 until end of turn.",
             "colours": [],
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "d59df6a0-029c-57cc-a2e0-ad4b6ddf46a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65229ebf-da43-476b-9e9d-8cc0102a24c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65229ebf-da43-476b-9e9d-8cc0102a24c3.jpg?1",
             "name": "Silent Arbiter",
             "text": "No more than one creature may attack each combat.\nNo more than one creature may block each combat.",
             "colours": [],
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "8822ae5b-b4e7-5f4c-8ca0-0b3b8c2084f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f32bf4-e58b-42f9-8829-4c985dc94963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f32bf4-e58b-42f9-8829-4c985dc94963.jpg?1",
             "name": "Skullcage",
             "text": "At the beginning of each opponent's upkeep, Skullcage deals 2 damage to that player unless he or she has exactly three or exactly four cards in hand.",
             "colours": [],
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "0f79cb4f-239f-5818-9033-d1d8355cd23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b11e69-09ec-4e26-a64d-c129c45574b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b11e69-09ec-4e26-a64d-c129c45574b1.jpg?1",
             "name": "Skyreach Manta",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nFlying",
             "colours": [],
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "567814dc-bb0b-5b01-a66a-9fee4e707dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9070dd3e-7600-493e-84b9-931ac92f44bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9070dd3e-7600-493e-84b9-931ac92f44bc.jpg?1",
             "name": "Solarion",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\n{T}: Double the number of +1/+1 counters on Solarion.",
             "colours": [],
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "93a17805-ec8f-53b3-b78e-57f89445de68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc31145-19b4-4dbe-8756-f49791aa147e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc31145-19b4-4dbe-8756-f49791aa147e.jpg?1",
             "name": "Sparring Collar",
             "text": "Equipped creature has first strike.\n{R}{R}: Attach Sparring Collar to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4981,7 +4981,7 @@
         },
         {
             "id": "72247469-2c4b-593b-a371-1f692919ce02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aefaec4-741b-4a90-bf2c-e18215aac57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aefaec4-741b-4a90-bf2c-e18215aac57c.jpg?1",
             "name": "Spinal Parasite",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nRemove two +1/+1 counters from Spinal Parasite: Remove a counter from target permanent.",
             "colours": [],
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "f5ab7fdb-b37c-582f-891f-4df0a8de5391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980fc3b-71d5-427d-bd42-087256fd2059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980fc3b-71d5-427d-bd42-087256fd2059.jpg?1",
             "name": "Staff of Domination",
             "text": "{1}: Untap Staff of Domination.\n{2}, {T}: You gain 1 life.\n{3}, {T}: Untap target creature.\n{4}, {T}: Tap target creature.\n{5}, {T}: Draw a card.",
             "colours": [],
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "08045c26-aa4f-5764-887b-5d8ec73b9528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ac02-5dab-423a-9cf3-275d9203f26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ac02-5dab-423a-9cf3-275d9203f26d.jpg?1",
             "name": "Summoner's Egg",
             "text": "Imprint When Summoner's Egg comes into play, you may remove a card in your hand from the game face down.\nWhen Summoner's Egg is put into a graveyard from play, turn the imprinted face-down card face up. If that card is a creature card, put it into play under your control.",
             "colours": [],
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "972dafe2-254f-520f-be72-cb21ac19a5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8072944-268a-41e0-a1d8-9fe33e964bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8072944-268a-41e0-a1d8-9fe33e964bff.jpg?1",
             "name": "Summoning Station",
             "text": "{T}: Put a 2/2 colorless Pincher creature token into play.\nWhenever an artifact is put into a graveyard from play, you may untap Summoning Station.",
             "colours": [],
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "b608144c-2405-529c-9203-1f4a385e088c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c22071-959e-4986-aa25-ed883a20796b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c22071-959e-4986-aa25-ed883a20796b.jpg?1",
             "name": "Suncrusher",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\n{4}, {T}, Remove a +1/+1 counter from Suncrusher: Destroy target creature.\n{2}, Remove a +1/+1 counter from Suncrusher: Return Suncrusher to its owner's hand.",
             "colours": [],
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "0957ffa9-88b8-5975-b093-b8b9fd08d2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6c82f-b943-435e-a716-a58ae30b3922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6c82f-b943-435e-a716-a58ae30b3922.jpg?1",
             "name": "Suntouched Myr",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)",
             "colours": [],
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "78bba303-a370-5ab5-a6c0-a483734aaf09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16ef3b5-31ad-45f8-bac1-3b0a08964888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16ef3b5-31ad-45f8-bac1-3b0a08964888.jpg?1",
             "name": "Synod Centurion",
             "text": "When you control no other artifacts, sacrifice Synod Centurion.",
             "colours": [],
@@ -5192,7 +5192,7 @@
         },
         {
             "id": "e9e39c42-5e42-5cdf-aac4-bf28dc116c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb86854f-c933-4b6c-bd0a-67c3615e908f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb86854f-c933-4b6c-bd0a-67c3615e908f.jpg?1",
             "name": "Thermal Navigator",
             "text": "Sacrifice an artifact: Thermal Navigator gains flying until end of turn.",
             "colours": [],
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "80b90a56-8db7-5209-8c0f-4a4a5472583a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b546fa-af65-4afa-bb16-69b33674d3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b546fa-af65-4afa-bb16-69b33674d3d1.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may play nonland cards any time you could play an instant.",
             "colours": [],
@@ -5251,7 +5251,7 @@
         },
         {
             "id": "0146a3c4-a07d-5640-8047-5ce0271c20d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef06f56-a7a8-4c0f-8755-56b46d2aa82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef06f56-a7a8-4c0f-8755-56b46d2aa82c.jpg?1",
             "name": "Vedalken Shackles",
             "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control as long as Vedalken Shackles remains tapped.",
             "colours": [],
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "298d0681-4f38-52f6-9f31-fa4bdd1b9b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8fc1d-69fa-4a88-8f12-11fd614aac01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8fc1d-69fa-4a88-8f12-11fd614aac01.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [],

--- a/Assets/Resources/Sets/5ED.json
+++ b/Assets/Resources/Sets/5ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "86a560a1-8c44-5a79-ab56-bc686054679f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b5b70d-e5b9-4bc3-87b1-51dc6e5085a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b5b70d-e5b9-4bc3-87b1-51dc6e5085a5.jpg?1",
             "name": "Abbey Gargoyles",
             "text": "Flying, protection from red",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "d0112a3c-4f56-5257-9b5f-6d0098c26ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b658243-267b-473f-acce-b4e211945c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b658243-267b-473f-acce-b4e211945c67.jpg?1",
             "name": "Akron Legionnaire",
             "text": "Except for Legionnaires and artifact creatures, creatures you control cannot attack.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "90cfb718-6da2-53d4-a641-43977527f4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950acce3-b079-49fc-8016-75fcdbca9b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950acce3-b079-49fc-8016-75fcdbca9b82.jpg?1",
             "name": "Alabaster Potion",
             "text": "Target player gains X life, or prevent X damage to any creature or player.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "c46dfa0f-37cd-5960-b908-9bf5b5f5d914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9ebe90-dad9-44b0-a2fa-13fc77953502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9ebe90-dad9-44b0-a2fa-13fc77953502.jpg?1",
             "name": "Angry Mob",
             "text": "Trample\nDuring your turn, Angry Mob has power and toughness each equal to 2 plus the number of swamps all opponents control. During other turns, Angry Mob has power and toughness each equal to 2.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "1e4b6310-78db-5a61-ae4e-9e29034bb59c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7f102d-18ff-420b-9b0b-323daad759de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7f102d-18ff-420b-9b0b-323daad759de.jpg?1",
             "name": "Animate Wall",
             "text": "Play only on a Wall.\nEnchanted creature can attack as though it were not a Wall.",
             "colours": [
@@ -168,7 +168,7 @@
         },
         {
             "id": "31ead1fe-4755-5418-9c41-d3165d4546ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2bf14c-f04d-4380-b0d5-25028ddd999b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2bf14c-f04d-4380-b0d5-25028ddd999b.jpg?1",
             "name": "Arenson's Aura",
             "text": "o\nW, Sacrifice an enchantment: Destroy target enchantment.\no3o\nUoo\nU Counter target enchantment spell. Play this ability as an interrupt.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "2212f07d-9c92-51ab-9440-027501c46387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8949d6f8-6491-489a-916d-7007deaf0371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8949d6f8-6491-489a-916d-7007deaf0371.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "cdb007cc-9966-56cd-94eb-a4cd520dfd3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdb3c08-aa9e-45d4-ae82-00019aee03b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdb3c08-aa9e-45d4-ae82-00019aee03b6.jpg?1",
             "name": "Armor of Faith",
             "text": "Enchanted creature gets +1/+1.\noo\nW Enchanted creature gets +0/+1 until end of turn.",
             "colours": [
@@ -264,7 +264,7 @@
         },
         {
             "id": "10f50d43-d097-5b5e-a6d7-b6af1c4c98ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01c564f-d997-4667-93af-c8495d8764e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01c564f-d997-4667-93af-c8495d8764e6.jpg?1",
             "name": "Aysen Bureaucrats",
             "text": "oc\nT: Tap target creature with power 2 or less.",
             "colours": [
@@ -298,7 +298,7 @@
         },
         {
             "id": "d01cdd9a-e8e6-5ec7-a2d6-88d3ac9a52c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dcd608-ef94-4047-841d-5c3471375d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dcd608-ef94-4047-841d-5c3471375d5d.jpg?1",
             "name": "Benalish Hero",
             "text": "Banding",
             "colours": [
@@ -332,7 +332,7 @@
         },
         {
             "id": "0eef452f-35b2-5ac9-b8ac-796ba27cd4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee815d6-ce79-42ff-9d18-b2f92671d1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee815d6-ce79-42ff-9d18-b2f92671d1c4.jpg?1",
             "name": "Blessed Wine",
             "text": "Gain 1 life.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -363,7 +363,7 @@
         },
         {
             "id": "98066222-75f2-56ce-a52f-fdc841ea0b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ff7626-de7d-443a-8eb7-fccaba6f2336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ff7626-de7d-443a-8eb7-fccaba6f2336.jpg?1",
             "name": "Blinking Spirit",
             "text": "o0: Return Blinking Spirit to owner's hand.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "793bf221-6295-5a80-bca1-a39d7e3dfe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afcbd6d-2b83-4393-9fc8-fe91f86117fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afcbd6d-2b83-4393-9fc8-fe91f86117fe.jpg?1",
             "name": "Brainwash",
             "text": "Enchanted creature cannot attack this turn unless its controller pays an additional o3.",
             "colours": [
@@ -429,7 +429,7 @@
         },
         {
             "id": "bc0a54bf-1ebd-570b-ac61-d4491cdac445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686022b1-359f-4348-a096-992140fff460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686022b1-359f-4348-a096-992140fff460.jpg?1",
             "name": "Caribou Range",
             "text": "Play only on a land you control.\no\nWo\nW, Tap enchanted land: Put a Caribou token into play. Treat this token as a 0/1 white creature.\nSacrifice a Caribou token: Gain 1 life.",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "8b83a72e-05e3-5009-9cab-6a99db477775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf8196e-3dd6-480f-a431-0e17005f7168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf8196e-3dd6-480f-a431-0e17005f7168.jpg?1",
             "name": "Castle",
             "text": "Each untapped creature you control gets +0/+2 unless it is attacking.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "ee502d84-81d4-5de3-a064-2bf282636aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cca7a8-439a-4388-8daf-6f04e78f5e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cca7a8-439a-4388-8daf-6f04e78f5e3a.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "o2: Prevent all damage to you from an artifact source. Treat further damage from that source normally.",
             "colours": [
@@ -524,7 +524,7 @@
         },
         {
             "id": "85082027-587c-52d0-9882-61580e7fd489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8160786c-288a-4160-8c8b-c575a61e00fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8160786c-288a-4160-8c8b-c575a61e00fc.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage to you from a black source. Treat further damage from that source normally.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "394eec02-f489-5366-b352-c72cac90eca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8b94bd-fffd-4c8a-b705-2b8e60cb8d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8b94bd-fffd-4c8a-b705-2b8e60cb8d68.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage to you from a blue source. Treat further damage from that source normally.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "ff39c9ad-10ef-51fb-8a58-c52b986ef8a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73bc89-887b-4ed8-ab68-20214b8aabcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73bc89-887b-4ed8-ab68-20214b8aabcf.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage to you from a green source. Treat further damage from that source normally.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "cec8c360-7d16-5755-9241-38cab525fad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af7af94-75b1-45ab-8608-6c935cedad77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af7af94-75b1-45ab-8608-6c935cedad77.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage to you from a red source. Treat further damage from that source normally.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "3845f02b-290e-544a-ab2c-c71bca3cbb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1477ea65-76b8-40b7-985d-02bc4aec9210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1477ea65-76b8-40b7-985d-02bc4aec9210.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage to you from a white source. Treat further damage from that source normally.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "7fd7b061-2d2c-5837-842e-049bf38fca5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3745725e-2bae-4c9b-bece-9e6b5f45c3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3745725e-2bae-4c9b-bece-9e6b5f45c3c9.jpg?1",
             "name": "Crusade",
             "text": "All white creatures get +1/+1.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "c84fcc73-b329-5a68-91b4-48b76f9797ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57621be-3420-49f5-87a3-a9f66fc7c2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57621be-3420-49f5-87a3-a9f66fc7c2e1.jpg?1",
             "name": "D'Avenant Archer",
             "text": "oc\nT: D'Avenant Archer deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "d01f79c5-57fb-53c2-8ef5-1b839c63882e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f70687-1d96-4d85-bed6-f08edef223cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f70687-1d96-4d85-bed6-f08edef223cd.jpg?1",
             "name": "Death Speakers",
             "text": "Protection from black",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "85150d1b-376f-55eb-af84-8951563438c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1502b21a-90e0-48af-ad55-b1edf2d0582c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1502b21a-90e0-48af-ad55-b1edf2d0582c.jpg?1",
             "name": "Death Ward",
             "text": "Regenerate target creature.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "33e20ad5-ba76-5234-a458-0f788aaaf9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18720641-3a34-48f1-954e-49a703f12578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18720641-3a34-48f1-954e-49a703f12578.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "cf172249-3ef2-5057-a68f-fd02f7bd0f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53562e-6b8f-484d-a083-2c635c2f222b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53562e-6b8f-484d-a083-2c635c2f222b.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. Gain an amount of life equal to that artifact's total casting cost.",
             "colours": [
@@ -872,7 +872,7 @@
         },
         {
             "id": "53b0ba7e-f033-5aa8-81a8-280a82c0b4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3994c6-8e84-4d06-ab46-fb5f061cc34d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3994c6-8e84-4d06-ab46-fb5f061cc34d.jpg?1",
             "name": "Divine Transformation",
             "text": "Enchanted creature gets +3/+3.",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "97871357-f990-5a2e-8eee-bc62b1fe379d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a9a5c-0e5f-4498-88d8-6aac465923b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a9a5c-0e5f-4498-88d8-6aac465923b1.jpg?1",
             "name": "Dust to Dust",
             "text": "Remove two target artifacts from the game.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "a7f796ca-0b18-561a-b250-622a08e7a248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28234a6-0e6b-4555-b5f9-edcc7b29194b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28234a6-0e6b-4555-b5f9-edcc7b29194b.jpg?1",
             "name": "Eye for an Eye",
             "text": "Play only when a creature, spell, or effect assigns damage to you. Eye for an Eye deals an equal amount of damage to that source's controller.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "0fcac723-73a1-5e1a-a1ce-86aafb4b471e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8eb77b-cdf7-44c6-8dce-898cfa173d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8eb77b-cdf7-44c6-8dce-898cfa173d66.jpg?1",
             "name": "Greater Realm of Preservation",
             "text": "o1oo\nW Prevent all damage to you from a black or red source. Treat further damage from that source normally.",
             "colours": [
@@ -998,7 +998,7 @@
         },
         {
             "id": "564e7a13-5a86-5743-8356-65fa863bfae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20676ce-fd87-4a63-9b96-02a26015edc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20676ce-fd87-4a63-9b96-02a26015edc2.jpg?1",
             "name": "Heal",
             "text": "Prevent 1 damage to any creature or player.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "cc24427d-c87a-5fb7-8471-bb64866041e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6855af25-0d35-4bf7-92e7-9dffdafa1eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6855af25-0d35-4bf7-92e7-9dffdafa1eca.jpg?1",
             "name": "Healing Salve",
             "text": "Target player gains 3 life, or prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "ff1f817d-f746-5dd9-9f6c-6bd25784b6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26fc403-b8af-499a-8cbc-4077ff97b8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26fc403-b8af-499a-8cbc-4077ff97b8b0.jpg?1",
             "name": "Hipparion",
             "text": "Hipparion cannot be assigned to block any creature with power 3 or greater unless you pay an additional o1.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "8fa2edb4-bdd5-5bcf-b227-db8e38a5be8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f938d4-5964-4f55-a2ce-0ca7e25fe565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f938d4-5964-4f55-a2ce-0ca7e25fe565.jpg?1",
             "name": "Holy Strength",
             "text": "Enchanted creature gets +1/+2.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "b65f38d0-e877-50f3-b0e9-f974e24041f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabf21ed-0262-4909-8b0f-c2c0e82830b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabf21ed-0262-4909-8b0f-c2c0e82830b0.jpg?1",
             "name": "Icatian Phalanx",
             "text": "Banding",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "c86238b9-d26a-56ba-a511-a8982e481798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02133f-71ff-45a1-9733-2ee3584dbbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02133f-71ff-45a1-9733-2ee3584dbbe5.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "fe564eb5-e059-54de-ae98-64f6c03aa72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e06788f-e87b-4071-ba7d-e0253a52132d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e06788f-e87b-4071-ba7d-e0253a52132d.jpg?1",
             "name": "Icatian Town",
             "text": "Put four Citizen tokens into play. Treat these tokens as 1/1 white creatures.",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "12bd0d68-1afe-5361-8a9a-2980db991a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5521bab-3252-4f81-9e9e-783160a5718c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5521bab-3252-4f81-9e9e-783160a5718c.jpg?1",
             "name": "Island Sanctuary",
             "text": "Skip drawing a card: Until the beginning of your next turn, only creatures with flying or islandwalk can attack you. Use this ability only during your draw phase and only once each turn.",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "d9d3d61d-a765-5a34-9435-e7399ecec3f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563dd5f5-6e37-4b36-b41b-1f4810e6ef8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563dd5f5-6e37-4b36-b41b-1f4810e6ef8c.jpg?1",
             "name": "Ivory Guardians",
             "text": "Protection from red\nAs long as any opponent controls any red cards in play, all Guardians get +1/+1.",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "782f613b-7640-52f7-bab3-dce80c71cd45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb11e16f-edf5-4e0e-862b-b055fd800682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb11e16f-edf5-4e0e-862b-b055fd800682.jpg?1",
             "name": "Justice",
             "text": "During your upkeep, pay o\nWo\nW or bury Justice.\nWhenever any red creature or spell assigns damage, Justice deals an equal amount of damage to that creature's or spell's controller.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "be35b511-da33-5d2e-ade2-e8c0d8b00e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cd8fd6-f30d-4e79-af68-688c2cfd39ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cd8fd6-f30d-4e79-af68-688c2cfd39ea.jpg?1",
             "name": "Karma",
             "text": "During each player's upkeep, Karma deals to that player an amount of damage equal to the number of swamps he or she controls.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "319614ec-99b6-56e4-99c7-919a0e4e0a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf81644f-6a93-4183-9f71-c3505cca6db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf81644f-6a93-4183-9f71-c3505cca6db4.jpg?1",
             "name": "Kismet",
             "text": "Artifacts, creatures, and lands target player controls come into play tapped.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "6fe3e0a8-7ea4-5d10-85c8-3796d914852c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafc9583-d16c-4a3b-88c5-2938038784bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafc9583-d16c-4a3b-88c5-2938038784bc.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: Redirect from you to Kjeldoran Royal Guard all combat damage dealt by unblocked creatures this turn.",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "5837d6d8-02a2-5d92-b7e9-9cc17d491774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1f4c4d-dbb6-42b9-a56f-5ee119f68cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1f4c4d-dbb6-42b9-a56f-5ee119f68cf6.jpg?1",
             "name": "Kjeldoran Skycaptain",
             "text": "Banding, flying, first strike",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "2b7d7016-a257-5add-a079-a199fce1d91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd27e15-688b-43aa-9d2a-8cd35e960a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd27e15-688b-43aa-9d2a-8cd35e960a9d.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "edd4139a-a117-5867-80d0-51e47bbc9bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552089f3-1ae4-4f73-a19c-731ef98e1979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552089f3-1ae4-4f73-a19c-731ef98e1979.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Banding, flying",
             "colours": [
@@ -1518,7 +1518,7 @@
         },
         {
             "id": "9a87c8e1-d124-5d0a-95a3-7ed3238e6b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc09bb52-c31c-4afd-80ea-a48a46f82f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc09bb52-c31c-4afd-80ea-a48a46f82f00.jpg?1",
             "name": "Order of the Sacred Torch",
             "text": "oc\nT, Pay 1 life: Counter target black spell. Play this ability as an interrupt.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "3c2c5474-ea28-5684-bd30-3760ca4d2c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8581f-d953-4600-b08f-f02c3eccdbcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8581f-d953-4600-b08f-f02c3eccdbcc.jpg?1",
             "name": "Order of the White Shield",
             "text": "Protection from black\noo\nW First strike until end of turn\no\nWoo\nW +1/+0 until end of turn",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "2c3698f3-98fe-5ce1-a715-3b84362fd323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33ef5b-a0ff-459c-a9d4-a0a00ac66b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33ef5b-a0ff-459c-a9d4-a0a00ac66b31.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -1619,7 +1619,7 @@
         },
         {
             "id": "5d53e49a-989b-5fe9-8919-8d41415c7f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a7836f-5a67-4915-8c59-0dd02f8bc0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a7836f-5a67-4915-8c59-0dd02f8bc0a9.jpg?1",
             "name": "Personal Incarnation",
             "text": "Personal Incarnation's owner may redirect any amount of damage from it to himself or herself.\nIf Personal Incarnation is put into any graveyard from play, its owner loses half his or her life, rounded up.",
             "colours": [
@@ -1653,7 +1653,7 @@
         },
         {
             "id": "afb14323-7c78-5ec0-95a1-ebe1ef02766e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18243ac8-6097-4f2c-8064-3dab48038e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18243ac8-6097-4f2c-8064-3dab48038e4a.jpg?1",
             "name": "Pikemen",
             "text": "Banding, first strike",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "9b928199-a333-5e9d-8142-0f1a5e78831d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8ce55-2fb1-4330-9db4-146a120aed81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8ce55-2fb1-4330-9db4-146a120aed81.jpg?1",
             "name": "Prismatic Ward",
             "text": "When you play Prismatic Ward, choose a color.\nAll damage dealt to enchanted creature by sources of the chosen color is reduced to 0.",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "a950ffe2-fdac-5017-bffc-0667aeb46376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bd3587-301e-49ea-a589-1091c880145b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bd3587-301e-49ea-a589-1091c880145b.jpg?1",
             "name": "Repentant Blacksmith",
             "text": "Protection from red",
             "colours": [
@@ -1753,7 +1753,7 @@
         },
         {
             "id": "93510b8d-d978-53d9-853e-b672c937a1fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6987f7d-d7a0-4b75-87ca-3e7b681d449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6987f7d-d7a0-4b75-87ca-3e7b681d449c.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage dealt to you so far this turn from one source is retroactively added to your life total instead of subtracted. Treat further damage from that source normally.",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "dc06afc8-5c6b-5981-bfa8-4c95aa225fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a76892-2806-4fb4-882b-6de2869839c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a76892-2806-4fb4-882b-6de2869839c2.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "c94bca9e-7f90-5484-a820-004dffe0cb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abb4791-d2ad-4266-a900-aef8a802b3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abb4791-d2ad-4266-a900-aef8a802b3e5.jpg?1",
             "name": "Sacred Boon",
             "text": "Prevent up to 3 damage to target creature. At end of turn, put a +0/+1 counter on that creature for each 1 damage prevented in this way.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "8b3eaee6-504c-5f48-a207-1130893ebcb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3b2aaa-f04e-4a2a-8d5f-b3cc54605b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3b2aaa-f04e-4a2a-8d5f-b3cc54605b28.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "7ad050ce-91a9-5a52-9f1b-49931b01c02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2de654e-ee5c-4ae6-bd4c-c564ed6a5e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2de654e-ee5c-4ae6-bd4c-c564ed6a5e83.jpg?1",
             "name": "Seraph",
             "text": "Flying\nWhenever any creature Seraph damaged this turn is put into any graveyard, put that creature into play under your control at end of turn. Bury the creature if you lose control of Seraph.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "25b5bf8c-df2d-5bd6-8a5f-a4483b68122a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92bb33d-567c-4504-8e3c-5152fb61d100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92bb33d-567c-4504-8e3c-5152fb61d100.jpg?1",
             "name": "Serra Bestiary",
             "text": "During your upkeep, pay o\nWo\nW or bury Serra Bestiary.\nEnchanted creature cannot attack, block, or play any ability that includes oc\nT in its activation cost.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "c400cac8-7434-5cfe-9527-5b137caf94a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d282d-a777-4587-ab23-c30a4dba0494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d282d-a777-4587-ab23-c30a4dba0494.jpg?1",
             "name": "Serra Paladin",
             "text": "oc\nT: Prevent 1 damage to any creature or player.\no1o\nWo\nW, oc\nT: Attacking this turn does not cause target creature to tap.",
             "colours": [
@@ -1980,7 +1980,7 @@
         },
         {
             "id": "873bc7f0-f09a-5eef-aad0-648abf2c6e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7cfc0f-b9cc-4405-9c2d-2788d4ab49b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7cfc0f-b9cc-4405-9c2d-2788d4ab49b4.jpg?1",
             "name": "Shield Bearer",
             "text": "Banding",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "8d83191e-6681-5d14-88ca-d50225b95d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0d954-f3d1-4ba6-b9ee-778e09f4eea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0d954-f3d1-4ba6-b9ee-778e09f4eea7.jpg?1",
             "name": "Shield Wall",
             "text": "All creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "f474d7a3-575d-5c49-94d3-e936e6d5e754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3327949d-3b11-4409-911c-4289a89b488f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3327949d-3b11-4409-911c-4289a89b488f.jpg?1",
             "name": "Spirit Link",
             "text": "For each 1 damage enchanted creature deals, gain 1 life.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "806f0368-2b99-5e46-bb62-3d4b73f392a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4f53fc-69d7-49fb-885b-4cc02bf5facc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4f53fc-69d7-49fb-885b-4cc02bf5facc.jpg?1",
             "name": "Truce",
             "text": "Each player may draw up to two cards. For each card less than two any player draws, that player gains 2 life.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "a9ca1bc8-c255-5638-a92c-9a4f76b60c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2f982d-cbd0-466e-8804-b055374a9dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2f982d-cbd0-466e-8804-b055374a9dec.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "261aa57d-2b30-59ca-9567-3dd034025893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bada1968-8bc5-4c75-bd60-91015961907b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bada1968-8bc5-4c75-bd60-91015961907b.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "f627a11c-863c-5b89-8159-7b1ebdc9c836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8529a0-0259-4ccd-a481-8ad1b5feadf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8529a0-0259-4ccd-a481-8ad1b5feadf9.jpg?1",
             "name": "White Knight",
             "text": "First strike, protection from black",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "584ac580-3d3d-5593-b497-5346b25f29b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def142a8-cc73-4bd2-a1a8-ae47a0c9c948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def142a8-cc73-4bd2-a1a8-ae47a0c9c948.jpg?1",
             "name": "Wrath of God",
             "text": "Bury all creatures.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "5a7c81f1-2043-5539-9fe9-e3414372739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6b89e-f24a-4d32-a6f7-8466f46d9ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6b89e-f24a-4d32-a6f7-8466f46d9ad0.jpg?1",
             "name": "Aether Storm",
             "text": "Summon spells cannot be played.\nAny player may pay 4 life to bury \u00c6ther Storm.",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "e59c3a3b-5af3-54da-b83a-b01297c9fe84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692bd3dd-4aa8-44a8-9f96-fd6e8698b6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692bd3dd-4aa8-44a8-9f96-fd6e8698b6a2.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "1f916d33-9468-5101-a2d0-e12e32e418de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54642f0e-2d5f-49eb-8181-054c84038072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54642f0e-2d5f-49eb-8181-054c84038072.jpg?1",
             "name": "Anti-Magic Aura",
             "text": "Enchanted creature cannot be the target of enchantments, instants, or sorceries. This effect does not bury Anti-Magic Aura. (Other enchantments on that creature are buried because their target is now illegal.)",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "8de483cb-62a5-57f2-9a16-1e84fe8ad918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9086e-112a-45e6-854e-70cab2b008a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9086e-112a-45e6-854e-70cab2b008a3.jpg?1",
             "name": "Azure Drake",
             "text": "Flying",
             "colours": [
@@ -2370,7 +2370,7 @@
         },
         {
             "id": "3c1c0a33-d2a1-52aa-b133-7b5490292c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9af233-f0b9-489f-8561-77bff8280814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9af233-f0b9-489f-8561-77bff8280814.jpg?1",
             "name": "Binding Grasp",
             "text": "During your upkeep, pay o1o\nU or bury Binding Grasp.\nGain control of enchanted creature. That creature gets +0/+1.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "94c04eed-a652-553f-a719-c36a462f77fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04c924-3806-44a4-9b1b-d8e1a38432f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04c924-3806-44a4-9b1b-d8e1a38432f0.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to owner's hand.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "9779da12-5dda-58f4-9d55-6ef8c19e1c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffc0bfd-8e64-44bf-ae0a-5d2ee54c58df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffc0bfd-8e64-44bf-ae0a-5d2ee54c58df.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "981141a6-ded8-5ed1-ad8f-4cab7d52c5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6603e3-0680-4ba3-951b-cd9919eefd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6603e3-0680-4ba3-951b-cd9919eefd4f.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards. Then, put any two cards from your hand on top of your library in any order.",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "63c55c67-d47f-5d9f-8718-a9cc8a67e2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b975289d-d8b8-46b4-8c60-d6ed4b594519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b975289d-d8b8-46b4-8c60-d6ed4b594519.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2531,7 +2531,7 @@
         },
         {
             "id": "095da25b-9add-52d9-b59d-950f556f9f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff8402-7bfe-441a-8c6e-6a9ee9608911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff8402-7bfe-441a-8c6e-6a9ee9608911.jpg?1",
             "name": "Dance of Many",
             "text": "During your upkeep, pay o\nUo\nU or bury Dance of Many.\nWhen you play Dance of Many, choose target summon card. When Dance of Many comes into play, put a token creature into play and treat it as an exact copy of that summon card. If either Dance of Many or the token creature leaves play, bury the other.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "0b3dc354-ebae-5fad-bad7-d5b4f154ae22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac60e8c-ef5b-4893-b3e5-4a54cb0a0d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac60e8c-ef5b-4893-b3e5-4a54cb0a0d3a.jpg?1",
             "name": "Dand\u00e2n",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "3bfa80b2-6821-52ab-878d-b860ccc61e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0349-a114-4bb8-a9ae-97d0f8f46ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0349-a114-4bb8-a9ae-97d0f8f46ddb.jpg?1",
             "name": "Dark Maze",
             "text": "o0: Dark Maze can attack this turn as though it were not a Wall. At end of turn, remove Dark Maze from the game.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "a8e38f6d-e582-5708-9fbf-f03a44b6e1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9b1251-17fe-4f00-83cf-4947ac365af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9b1251-17fe-4f00-83cf-4947ac365af6.jpg?1",
             "name": "Deflection",
             "text": "Target spell with a single target now targets a new legal target of your choice.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "c704e0b3-4b16-54c2-b551-96a38334fb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582d8496-f319-4666-a6cd-160ff33578db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582d8496-f319-4666-a6cd-160ff33578db.jpg?1",
             "name": "Drain Power",
             "text": "Target player draws all mana from all lands he or she controls. Put all mana from that player's mana pool into yours.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "0bc390b1-de59-5caa-ac0b-fb359f53748f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75dea2-aec1-4674-8db9-4759270296ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75dea2-aec1-4674-8db9-4759270296ec.jpg?1",
             "name": "Energy Flux",
             "text": "All artifacts gain \"During your upkeep, pay o2 or bury this artifact.\"",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "cd7bb609-5243-5ce1-8963-ad9daf5a9333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357f9dc-6eaf-4dc3-a1b0-ef63fd0b1367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357f9dc-6eaf-4dc3-a1b0-ef63fd0b1367.jpg?1",
             "name": "Enervate",
             "text": "Tap target artifact, creature, or land. Draw a card at the beginning of the next turn.",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "1743ae11-7574-5aad-b3e9-aa8813b46e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d452de7-3f44-4594-bb24-2178812da9d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d452de7-3f44-4594-bb24-2178812da9d6.jpg?1",
             "name": "Feedback",
             "text": "During the upkeep of enchanted enchantment's controller, Feedback deals 1 damage to him or her.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "d70ab11c-0bd1-59f9-922c-e6b25376522d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74e5168-9503-4cf9-8a66-29b68ec2092c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74e5168-9503-4cf9-8a66-29b68ec2092c.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature gains flying.",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "1361f0da-d817-5661-9f54-4d37ab0eece4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aefbeae-ac72-4a13-8898-8d1e42a633a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aefbeae-ac72-4a13-8898-8d1e42a633a6.jpg?1",
             "name": "Flood",
             "text": "o\nUoo\nU Tap target creature without flying.",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "91421c32-3389-5b21-89dd-547be23f950f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba23d540-8c2d-4a42-b4c0-86f0988bd1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba23d540-8c2d-4a42-b4c0-86f0988bd1ce.jpg?1",
             "name": "Force Spike",
             "text": "Counter target spell unless its caster pays an additional o1.",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "2cb637b5-d803-5fe3-a077-8dcd20a36be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaa7b0-b11d-47d6-9cdf-7c9fa85bea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaa7b0-b11d-47d6-9cdf-7c9fa85bea20.jpg?1",
             "name": "Forget",
             "text": "Target player chooses and discards two cards, then draws as many cards as he or she discarded in this way.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "566781aa-1b76-5ba6-ab32-20131bfbb4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28477df-667a-4233-b90a-ee30e5bc29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28477df-667a-4233-b90a-ee30e5bc29fc.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchanted creature neither deals nor receives combat damage.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "a9e77fb8-6089-59e6-b7b2-73ed9a1fa910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5797da37-ece2-40d0-ba2a-c47ce55e3744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5797da37-ece2-40d0-ba2a-c47ce55e3744.jpg?1",
             "name": "Glacial Wall",
             "text": "",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "ca2b4cf5-d3da-58ae-a9a4-80a91f629c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f20d8e-bbdf-4af8-9505-d5604b04ad72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f20d8e-bbdf-4af8-9505-d5604b04ad72.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior cannot be the target of spells or effects until end of turn and does not untap during your next untap phase. Tap Homarid Warrior.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "9bd5a45f-8c58-528a-9ac5-8bcade378e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c7e94-25ef-4859-88db-05b085744dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c7e94-25ef-4859-88db-05b085744dc0.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "Return to target player's hand all artifacts in play he or she owns.",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "732921b6-be4f-5cac-86e7-03b4fc25879c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a30b8f-6594-42ea-8e60-13ccb1e7efc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a30b8f-6594-42ea-8e60-13ccb1e7efc0.jpg?1",
             "name": "Hydroblast",
             "text": "Counter target spell if it is red, or destroy target permanent if it is red. (If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "bff20ebd-a974-5b98-8acc-a58401a80fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60dc7c3-4a6c-4c17-9025-29341a3afee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60dc7c3-4a6c-4c17-9025-29341a3afee1.jpg?1",
             "name": "Juxtapose",
             "text": "Exchange with target player control of the creature with the highest total casting cost that you each control. If two or more creatures are tied for highest total casting cost creature a player controls, he or she chooses between them. Exchange control of artifacts in the same way.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "90c7b1d1-c898-5608-81f1-7914b55c46cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91568ea-cef0-4355-8029-840f5e621ae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91568ea-cef0-4355-8029-840f5e621ae8.jpg?1",
             "name": "Krovikan Sorcerer",
             "text": "oc\nT, Choose and discard a nonblack card: Draw a card.\noc\nT, Choose and discard a black card: Draw two cards, then choose and discard one of them.",
             "colours": [
@@ -3138,7 +3138,7 @@
         },
         {
             "id": "998af111-8461-5d17-88db-1409875b4822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa8c435-55c1-46af-bb93-3f8ce81b1544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa8c435-55c1-46af-bb93-3f8ce81b1544.jpg?1",
             "name": "Labyrinth Minotaur",
             "text": "If Labyrinth Minotaur blocks any creature, that creature does not untap during its controller's next untap phase.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "3afd23c2-e8f0-5836-8fe3-6d100e00d5ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e96456-93bf-4d28-9a4b-5bc24ae07fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e96456-93bf-4d28-9a4b-5bc24ae07fc2.jpg?1",
             "name": "Leviathan",
             "text": "Trample\nLeviathan comes into play tapped and does not untap during your untap phase.\nLeviathan cannot attack this turn unless you sacrifice two islands.\nSacrifice two islands: Untap Leviathan. Use this ability only during your upkeep.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "9fa33a9c-e063-5c00-8b3b-31f7806f36cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af066a2d-d357-45a7-90d8-2c34b6d0ebf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af066a2d-d357-45a7-90d8-2c34b6d0ebf8.jpg?1",
             "name": "Lifetap",
             "text": "Whenever any forest target opponent controls becomes tapped, gain 1 life.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "03ce995a-aadd-5a7b-9e76-9fce7fc67878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaad8e0-947f-47d9-b78f-b0f2a5a06906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaad8e0-947f-47d9-b78f-b0f2a5a06906.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk get +1/+1 and gain islandwalk. (If defending player controls any islands, these creatures are unblockable.)",
             "colours": [
@@ -3268,7 +3268,7 @@
         },
         {
             "id": "055d92ce-6a64-52e7-984e-baa5d2c99479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2349d53-d9f0-450f-be96-463791ee7aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2349d53-d9f0-450f-be96-463791ee7aab.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of target permanent or spell by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "4e20e8d5-3315-5f6d-8dc9-e34c851ab830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adf168a-039e-4f8f-8ca4-3f364eef373d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adf168a-039e-4f8f-8ca4-3f364eef373d.jpg?1",
             "name": "Magus of the Unseen",
             "text": "o1o\nU, oc\nT: Untap target artifact an opponent controls and gain control of it until end of turn. That artifact is unaffected by summoning sickness this turn. Tap the artifact if you lose control of it at end of this turn.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "aaee744c-8ab2-52a0-b665-bde505186ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9010e5e2-fd32-4f2f-aa68-1dbe58c078a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9010e5e2-fd32-4f2f-aa68-1dbe58c078a2.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of owner's library.",
             "colours": [
@@ -3364,7 +3364,7 @@
         },
         {
             "id": "9a41517a-5a29-5ef5-890f-727a29087555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7003be-4464-4eab-a77d-ab0346643613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7003be-4464-4eab-a77d-ab0346643613.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "fbed7a9f-5d2a-5015-82dd-f9a6c0611c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c46d040-58c2-4f7a-8b66-fea33fcb0e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c46d040-58c2-4f7a-8b66-fea33fcb0e11.jpg?1",
             "name": "Mind Bomb",
             "text": "Mind Bomb deals 3 damage to each player. Each player may choose and discard up to three cards to prevent that amount of damage to him or her from Mind Bomb.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "d5f4faf3-3678-524b-85e6-1ee2b65bec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b26cb-ec7d-464b-b835-82e60e86f827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b26cb-ec7d-464b-b835-82e60e86f827.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nDuring your upkeep, pay o\nU or bury Phantasmal Forces.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "436b63be-361e-5c92-90a1-cc3cceab4b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6541b-9f23-48f1-a9bb-081ad7022fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6541b-9f23-48f1-a9bb-081ad7022fd4.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Enchanted land is a basic land type of your choice.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "c2e14caa-3962-52b8-a6bf-326d36253996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8a6c0-1a17-4b7e-b1e6-cdd52ee1ece8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8a6c0-1a17-4b7e-b1e6-cdd52ee1ece8.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "186828bc-9aee-5d7d-95d2-57a3ff9872b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad5912-6d1e-4ad3-9911-0c768417d6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad5912-6d1e-4ad3-9911-0c768417d6d4.jpg?1",
             "name": "Pirate Ship",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)\noc\nT: Pirate Ship deals 1 damage to target creature or player.",
             "colours": [
@@ -3561,7 +3561,7 @@
         },
         {
             "id": "cb001d15-c4ec-5c5d-b4e0-97d5dbe5566a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e317e0f-4c6e-4ede-846a-fb76fa77c6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e317e0f-4c6e-4ede-846a-fb76fa77c6bf.jpg?1",
             "name": "Portent",
             "text": "Look at the top three cards of target player's library. Shuffle that library or put those three cards back on top of it in any order. Draw a card at the beginning of the next turn.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "bc74a117-fbf7-540f-bb04-64f84f006337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb32bc8-ae9f-4484-b2de-bce35e9f5df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb32bc8-ae9f-4484-b2de-bce35e9f5df5.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless that spell's caster pays an additional o\nX. That player draws and pays all mana from lands and mana pool until o\nX is paid; he or she may also draw and pay mana from other sources if desired.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "f85e9cd6-369d-5318-98ab-343e4d3e2d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c743b0fb-a4cb-40a6-94d9-2318386d0afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c743b0fb-a4cb-40a6-94d9-2318386d0afb.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "1ad629d1-9820-5daa-bd4d-a731f5f66133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004b6463-0aef-4419-b4f2-dc3fa6eee901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004b6463-0aef-4419-b4f2-dc3fa6eee901.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever enchanted land becomes tapped, Psychic Venom deals 2 damage to that land's controller.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "4b73b347-1c2d-51c5-9cfc-57e5f102fc28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e498567-2bb0-4622-8250-a56b9ff79a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e498567-2bb0-4622-8250-a56b9ff79a7e.jpg?1",
             "name": "Ray of Command",
             "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature is unaffected by summoning sickness this turn. Tap the creature if you lose control of it at end of this turn.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "0df3be68-03f6-5bc4-8753-7ee34f709341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53dd70-e2a7-4203-ae00-240694d7220e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53dd70-e2a7-4203-ae00-240694d7220e.jpg?1",
             "name": "Recall",
             "text": "Choose and discard X cards: Return X target cards in your graveyard to your hand. Remove Recall from the game.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "245af4be-cd2b-57f3-a5bd-cc6995ff8675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d712139-bf12-4f7b-bb9b-34d15fac56df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d712139-bf12-4f7b-bb9b-34d15fac56df.jpg?1",
             "name": "Reef Pirates",
             "text": "If Reef Pirates damages any opponent, put the top card of that player's library into his or her graveyard.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "393b45ff-43d7-5131-8e89-b6820df602bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6bbb81-b830-4b22-be9a-852d9edbda21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6bbb81-b830-4b22-be9a-852d9edbda21.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target summon spell.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "418e1ae6-9229-5f2c-896d-3e541f6c54b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e170bb1e-f2eb-4631-af95-ada585b7ef57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e170bb1e-f2eb-4631-af95-ada585b7ef57.jpg?1",
             "name": "Sea Serpent",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "c0f4dd0e-c6d5-534a-9ed0-dd63cb33fbdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08933cca-6ed1-43da-a539-355ded52c5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08933cca-6ed1-43da-a539-355ded52c5b6.jpg?1",
             "name": "Sea Spirit",
             "text": "oo\nU +1/+0 until end of turn",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "89272355-7b1c-5252-a65b-dfb09200cf0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec37c5-b927-47ae-8cd6-3eddd55a3472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec37c5-b927-47ae-8cd6-3eddd55a3472.jpg?1",
             "name": "Sea Sprite",
             "text": "Flying, protection from red",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "8c007e26-1632-59ae-bbe0-32473e0066b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851545d3-cc23-40da-84c5-93da0dd14a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851545d3-cc23-40da-84c5-93da0dd14a8d.jpg?1",
             "name": "Seasinger",
             "text": "If you control no islands, bury Seasinger.\nYou may choose not to untap Seasinger during your untap phase.\noc\nT: Gain control of target creature whose controller controls any islands as long as you control Seasinger and Seasinger remains tapped.",
             "colours": [
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "6785fbbb-1af6-53e9-94eb-5ede9ff3b7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873c47-dfed-4ffb-a472-2cb304934ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873c47-dfed-4ffb-a472-2cb304934ad9.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk (If defending player controls any islands, this creature is unblockable.)",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "bf225e27-b8b3-5967-801a-68c75bc83f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9382b01d-4ff5-4e33-ab05-412ad694b85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9382b01d-4ff5-4e33-ab05-412ad694b85f.jpg?1",
             "name": "Sibilant Spirit",
             "text": "Flying\nIf Sibilant Spirit attacks, defending player may draw a card.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "67f43f3b-f683-55ff-958c-ace8cc03b018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb4f1c-6754-4269-8fac-d4edc02c8e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb4f1c-6754-4269-8fac-d4edc02c8e00.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of target permanent or spell by replacing all instances of one color word with another. (For example, you may change \"nongreen creature\" to \"nonred creature.\" If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -4047,7 +4047,7 @@
         },
         {
             "id": "ed07bca4-ddf8-5103-b5bf-9ab82a603d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd50e68-2063-4fae-bb56-eb224d43b147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd50e68-2063-4fae-bb56-eb224d43b147.jpg?1",
             "name": "Soul Barrier",
             "text": "Whenever target opponent successfully casts a summon spell, Soul Barrier deals 2 damage to him or her. That player may pay o2 to prevent this damage.",
             "colours": [
@@ -4078,7 +4078,7 @@
         },
         {
             "id": "8849c3de-5ce5-5056-8932-8b92ba1d3dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e4584f-6e44-4ff8-8313-c8791e0156af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e4584f-6e44-4ff8-8313-c8791e0156af.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with total casting cost equal to X.",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "cf69b1e2-6d1f-5319-b342-0bc3de6113e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96570023-a9d6-4536-ac11-f0baad041d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96570023-a9d6-4536-ac11-f0baad041d7c.jpg?1",
             "name": "Stasis",
             "text": "Each player skips his or her untap phase.\nDuring your upkeep, pay o\nU or bury Stasis.",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "a40a30cb-a66f-5e90-95e0-d2bb8ed6f704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e08d3b2-9c85-4482-b110-5f399672e550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e08d3b2-9c85-4482-b110-5f399672e550.jpg?1",
             "name": "Steal Artifact",
             "text": "Gain control of enchanted artifact.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "f8d6c2d2-de5e-5f94-bf16-56421186419f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b1e44-776a-44b9-a976-777e49ae628e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b1e44-776a-44b9-a976-777e49ae628e.jpg?1",
             "name": "Time Elemental",
             "text": "If Time Elemental attacks or blocks, it deals 5 damage to you and is buried at end of combat.\no2o\nUo\nU, oc\nT: Return target permanent with no enchantments on it to owner's hand.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "a89d25de-3960-5332-8814-f54fc4df1edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9fa429-a3d5-418d-b94d-ef534b5b86f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9fa429-a3d5-418d-b94d-ef534b5b86f0.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "1283109d-c517-5b11-8212-8c2fb5f922a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127abfdc-8d9e-4ba3-8f31-c13a54831824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127abfdc-8d9e-4ba3-8f31-c13a54831824.jpg?1",
             "name": "Unstable Mutation",
             "text": "Enchanted creature gets +3/+3.\nDuring its controller's upkeep, put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "68543872-ea16-56f1-83bd-50f79015b743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c830b54-0441-4df2-87de-a579dc734d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c830b54-0441-4df2-87de-a579dc734d97.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to owner's hand.",
             "colours": [
@@ -4301,7 +4301,7 @@
         },
         {
             "id": "cefd17e8-1b4f-5b9d-9aca-e7ce079b0f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4c1316-d6df-4bc4-9bfe-0458ff7c2908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4c1316-d6df-4bc4-9bfe-0458ff7c2908.jpg?1",
             "name": "Updraft",
             "text": "Target creature gains flying until end of turn.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -4332,7 +4332,7 @@
         },
         {
             "id": "7134ebd7-5ea2-53eb-b317-cfc7fa320313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d204d-e495-4067-9c38-1a895824f95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d204d-e495-4067-9c38-1a895824f95a.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -4366,7 +4366,7 @@
         },
         {
             "id": "23b7b5a8-0818-5f31-a7e5-dc623048abca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a53c7-99fa-4183-a173-f84ec06088b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a53c7-99fa-4183-a173-f84ec06088b2.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "5942116c-d792-5840-a414-11960e36a46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70495b9-3fec-4eea-addf-1f401a1f49ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70495b9-3fec-4eea-addf-1f401a1f49ed.jpg?1",
             "name": "Wind Spirit",
             "text": "Flying\nWind Spirit cannot be blocked by only one creature.",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "695ba04f-d026-53f2-9a13-75582b1571ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d11923e-98c6-4041-b115-f4847fb71149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d11923e-98c6-4041-b115-f4847fb71149.jpg?1",
             "name": "Zephyr Falcon",
             "text": "Flying\nAttacking does not cause Zephyr Falcon to tap.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "f6623b62-1d97-571a-bb64-c4fcd1392474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded7b01-2920-4b94-a511-088b521de9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded7b01-2920-4b94-a511-088b521de9f7.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands face up.\nWhenever any player draws a card, any other player may pay 2 life to force the drawing player to discard that card.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "8bbaefc7-64ef-5a52-a559-ff88b7cfd5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32aca-94d0-46df-9ca9-503a51416b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32aca-94d0-46df-9ca9-503a51416b14.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nIf Abyssal Specter damages any player, he or she chooses and discards a card.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "08bb4f23-19be-5a00-9e25-c765df72b5ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2cd314-8f99-4443-ae86-a967effc7490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2cd314-8f99-4443-ae86-a967effc7490.jpg?1",
             "name": "Animate Dead",
             "text": "When you play Animate Dead, choose target creature card in any graveyard. When Animate Dead comes into play, put that creature into play and Animate Dead becomes a creature enchantment that targets the creature. Enchanted creature gets -1/-0. If Animate Dead leaves play, bury the creature.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "80695a3b-fad0-57ec-a055-740babf71e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7240709d-a469-4801-82bd-f5db50859763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7240709d-a469-4801-82bd-f5db50859763.jpg?1",
             "name": "Ashes to Ashes",
             "text": "Remove two target nonartifact creatures from the game. Ashes to Ashes deals 5 damage to you.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "7a76e338-564b-5e63-adce-17f439d9ee5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d28603-b116-4948-a46f-b95ae9118d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d28603-b116-4948-a46f-b95ae9118d9e.jpg?1",
             "name": "Ashes to Ashes",
             "text": "",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "ee2d9396-627c-560d-9166-aeec1010330a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb6d665-42f5-4f44-8797-16c0351ab3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb6d665-42f5-4f44-8797-16c0351ab3c0.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures get +1/+1.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "45a2eb0e-dddd-567d-ab70-8f23928be80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03b6221-2c85-44c0-82f1-b2b9e2c83c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03b6221-2c85-44c0-82f1-b2b9e2c83c80.jpg?1",
             "name": "Black Knight",
             "text": "First strike, protection from white",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "db372037-682b-509d-9f35-751392e81104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affd5566-9ec6-4713-a804-cec9b13b1da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affd5566-9ec6-4713-a804-cec9b13b1da1.jpg?1",
             "name": "Blight",
             "text": "If enchanted land becomes tapped, destroy it at end of turn.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "c27ef5a3-6055-5091-8265-f298501f72b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11924b2-c290-47a1-803d-b00c433cf840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11924b2-c290-47a1-803d-b00c433cf840.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "a9862058-18e6-5db0-b480-ae3844ab6b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e325363-1ab9-4b44-9c00-0758830289e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e325363-1ab9-4b44-9c00-0758830289e8.jpg?1",
             "name": "Bog Rats",
             "text": "Bog Rats cannot be blocked by Walls.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "54ddbfb6-731c-59bd-ab87-1fc06e457d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae74c5b-1090-4910-87a4-81dbffd1fd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae74c5b-1090-4910-87a4-81dbffd1fd69.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "f4db3d68-bf78-54fc-ad6b-c83ec932eff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe305196-fd9d-4f92-a37c-6c4fe5abad1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe305196-fd9d-4f92-a37c-6c4fe5abad1f.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -4863,7 +4863,7 @@
         },
         {
             "id": "4864ea20-099d-5f63-9dc8-aef0527ecd1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9b663-5c02-4221-9efb-59841dfd2188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9b663-5c02-4221-9efb-59841dfd2188.jpg?1",
             "name": "Breeding Pit",
             "text": "During your upkeep, pay o\nBo\nB or bury Breeding Pit.\nAt the end of your turn, put a Thrull token into play. Treat this token as a 0/1 black creature.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "925c89eb-f54e-53c8-8c39-85e0ef972adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824823fb-5ae1-48b1-bc46-e452afa73cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824823fb-5ae1-48b1-bc46-e452afa73cd8.jpg?1",
             "name": "Broken Visage",
             "text": "Bury target nonartifact attacking creature and put a Shadow token into play. Treat this token as a black creature with the same power and toughness as that attacking creature. At end of turn, bury the token.",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "19843078-7ef4-5b9d-8d9e-7f519e072fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bf491b-b876-4453-8c85-8d7c419b0900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bf491b-b876-4453-8c85-8d7c419b0900.jpg?1",
             "name": "Carrion Ants",
             "text": "o1: +1/+1 until end of turn",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "7a1ed85e-cea2-53bd-b78a-ef26e185782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430a4e23-d13c-4413-9032-f18350a128da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430a4e23-d13c-4413-9032-f18350a128da.jpg?1",
             "name": "Cloak of Confusion",
             "text": "o0: Defending player discards a card at random. Enchanted creature deals no combat damage this turn. Use this ability only if enchanted creature is attacking and unblocked and only once each turn.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "55286446-89f4-5167-b444-9ae205ced34f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9801b-9707-4868-bde1-39960b761992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9801b-9707-4868-bde1-39960b761992.jpg?1",
             "name": "Cursed Land",
             "text": "During the upkeep of enchanted land's controller, Cursed Land deals 1 damage to him or her.",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "25fa6a23-7212-5510-99ed-ef2f1747a8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae25afd-0d16-431c-a85e-7ac91cef9050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae25afd-0d16-431c-a85e-7ac91cef9050.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "3f4403d2-8acd-5815-bf22-1c608aa09cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934a6704-3fb5-4259-96e0-1f93a45b3f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934a6704-3fb5-4259-96e0-1f93a45b3f8c.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Counter target green spell. Play this ability as an interrupt.",
             "colours": [
@@ -5086,7 +5086,7 @@
         },
         {
             "id": "79751bca-abab-535c-829c-3479dd979b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b050783f-945e-4d61-a896-9a5b79ae7982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b050783f-945e-4d61-a896-9a5b79ae7982.jpg?1",
             "name": "Derelor",
             "text": "Your black spells cost an additional o\nB to play.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "1a42ef33-0905-5a26-abf7-6f0617eca59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a9b3b2-4ac9-4e50-bcd2-8831d0739e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a9b3b2-4ac9-4e50-bcd2-8831d0739e85.jpg?1",
             "name": "Drain Life",
             "text": "oo\nX Drain Life deals X damage to target creature or player. Spend only black mana in this way. Gain 1 life for each 1 damage dealt, but not more than the toughness of the creature or the life total of the player Drain Life damages.",
             "colours": [
@@ -5150,7 +5150,7 @@
         },
         {
             "id": "5fe0d393-11ab-550f-aa7b-ba427fbc82ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127bb737-85ed-4de3-9a1d-ec789d54b7cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127bb737-85ed-4de3-9a1d-ec789d54b7cd.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "6578f75e-11ba-5f83-b9cd-f046be1a77c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc87da4-8f68-4c40-afdb-2dfcc075ce91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc87da4-8f68-4c40-afdb-2dfcc075ce91.jpg?1",
             "name": "Erg Raiders",
             "text": "At the end of your turn, Erg Raiders deals 2 damage to you if it did not attack this turn. Ignore this effect if Erg Raiders has summoning sickness.",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "cef99eac-7709-5de6-9730-65048869e2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c7e01b-68a9-4380-94b6-d687e2c2ee86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c7e01b-68a9-4380-94b6-d687e2c2ee86.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "Evil Eye of Orms-by-Gore cannot be blocked except by Walls.\nExcept for Evil Eyes, creatures you control cannot attack.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "c0df5508-0422-5202-9e5b-1ff96d588692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3042fdde-595d-4f60-be59-364eedecf3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3042fdde-595d-4f60-be59-364eedecf3bd.jpg?1",
             "name": "Evil Presence",
             "text": "Enchanted land is a swamp.",
             "colours": [
@@ -5283,7 +5283,7 @@
         },
         {
             "id": "dca781b2-9ad7-5511-b4e8-0bb06ad44c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68022e3e-99d0-4f14-9ef8-17f27a157edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68022e3e-99d0-4f14-9ef8-17f27a157edd.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: +2/+1 until end of turn",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "84381ffb-3ae2-5482-915f-3d4e807e407e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c917d05d-395d-4e2f-aecc-616ae9aa9b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c917d05d-395d-4e2f-aecc-616ae9aa9b5b.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -5349,7 +5349,7 @@
         },
         {
             "id": "41c5877f-3cf2-5222-93d9-3d520bde70bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd0b4ff-f49f-4079-991a-f66d1220235d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd0b4ff-f49f-4079-991a-f66d1220235d.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -5382,7 +5382,7 @@
         },
         {
             "id": "5e0a2ef4-68f3-575b-8481-16db8d3d5925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e7bbae-1438-4a47-9c14-c4b6d8702ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e7bbae-1438-4a47-9c14-c4b6d8702ec4.jpg?1",
             "name": "Funeral March",
             "text": "If enchanted creature leaves play, its controller sacrifices a creature.",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "98e54b89-b425-575d-94b4-c3d61be03dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6fff23-21c9-4519-b84a-59868a918996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6fff23-21c9-4519-b84a-59868a918996.jpg?1",
             "name": "Gloom",
             "text": "White spells cost an additional o3 to play. Activated abilities of white enchantments cost an additional o3 to play.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "8f5f2d90-0220-58fd-bca5-0aeb68235c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b77373-6066-436b-aa60-4cb0f8077599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b77373-6066-436b-aa60-4cb0f8077599.jpg?1",
             "name": "Greater Werewolf",
             "text": "At end of combat, put a -0/-2 counter on each creature blocking or blocked by Greater Werewolf.",
             "colours": [
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "74cd8d88-b7c0-5c0a-ae38-0496fadfb411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43671b63-d38e-4ef5-94bd-300cda82a88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43671b63-d38e-4ef5-94bd-300cda82a88b.jpg?1",
             "name": "Hecatomb",
             "text": "When Hecatomb comes into play, sacrifice four creatures or bury Hecatomb.\nTap a swamp you control: Hecatomb deals 1 damage to target creature or player.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "99c65860-258c-528a-928b-c5adb1b64df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88d96c-6192-48e6-9a3b-97eff587e115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88d96c-6192-48e6-9a3b-97eff587e115.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "b885d14e-9b4f-549a-9f0c-b9f01215ac25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83085df-1ffb-4178-9fc0-fd347196673f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83085df-1ffb-4178-9fc0-fd347196673f.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. If o4 or more is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn. Play this ability as a mana source.",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "f39808a6-8193-5529-b199-6cdd2c044274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4a92a3-4df5-4d83-b015-59859e6bccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4a92a3-4df5-4d83-b015-59859e6bccc8.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "2bf09a49-0b56-51f2-856d-4aeb0ccb6b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590c219d-536a-47a4-93a4-b77ce808a024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590c219d-536a-47a4-93a4-b77ce808a024.jpg?1",
             "name": "Kjeldoran Dead",
             "text": "When Kjeldoran Dead comes into play, sacrifice a creature.\noo\nB Regenerate",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "66157ba7-30cd-57c6-88ce-4a65ba3e867e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c73dd-3a80-4355-a71d-c6de99cb11cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c73dd-3a80-4355-a71d-c6de99cb11cb.jpg?1",
             "name": "Knight of Stromgald",
             "text": "Protection from white\no\nB: First strike until end of turn\no\nBo\nB: +1/+0 until end of turn",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "c871e429-be59-54bc-af7c-1625bd6cc208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db46edd-d2d3-4d3e-beae-f8d01bb5078e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db46edd-d2d3-4d3e-beae-f8d01bb5078e.jpg?1",
             "name": "Krovikan Fetish",
             "text": "Draw a card at the beginning of the turn after Krovikan Fetish comes into play.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "87f80bad-3a30-5fca-921e-576f2becbfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6aee0b-1039-496f-a096-2d4d71621d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6aee0b-1039-496f-a096-2d4d71621d99.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Enchanted creature gains swampwalk. (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "f63f64d7-e780-5fa4-b07e-c9f57d1310fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4c083f-d619-4913-aa7b-d345e3bdb1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4c083f-d619-4913-aa7b-d345e3bdb1c4.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nDuring your upkeep, sacrifice a creature other than Lord of the Pit. If you cannot, Lord of the Pit deals 7 damage to you.",
             "colours": [
@@ -5777,7 +5777,7 @@
         },
         {
             "id": "a57aa715-748e-5477-ac27-67fd35f6e362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff73c4c8-1761-4fc8-96b1-8983b9b78b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff73c4c8-1761-4fc8-96b1-8983b9b78b46.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -5811,7 +5811,7 @@
         },
         {
             "id": "4cc49439-cdc7-59c0-bd64-f9bf5d8d3023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9a0296-3690-45c7-98af-d546296ad9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9a0296-3690-45c7-98af-d546296ad9fe.jpg?1",
             "name": "Mind Ravel",
             "text": "Target player chooses and discards a card.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "4998f76b-9cc1-5ee8-b562-10b58ac8ba2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de86fd7e-438c-48a2-a69d-193d8b8ebbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de86fd7e-438c-48a2-a69d-193d8b8ebbac.jpg?1",
             "name": "Mind Warp",
             "text": "Look at target player's hand. He or she discards X cards of your choice.",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "f3cbc787-ee1a-5d18-b366-47014af56faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b1439-b83d-4e6d-8956-b0964b1e3ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b1439-b83d-4e6d-8956-b0964b1e3ed9.jpg?1",
             "name": "Mindstab Thrull",
             "text": "Sacrifice Mindstab Thrull: Defending player chooses and discards three cards. Use this ability only if Mindstab Thrull is attacking and unblocked.",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "ecd058d3-48e9-5947-b1d3-01298f9cf023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90042a-a5e9-4c3f-a08a-c24e5606110b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90042a-a5e9-4c3f-a08a-c24e5606110b.jpg?1",
             "name": "Mindstab Thrull",
             "text": "",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "ecc7bba2-fb35-5e83-a033-9bbe3f6888b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f43c9-1e71-4e5f-a6ce-eca94993558f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f43c9-1e71-4e5f-a6ce-eca94993558f.jpg?1",
             "name": "Mole Worms",
             "text": "You may choose not to untap Mole Worms during your untap phase.\noc\nT: Tap target land. As long as Mole Worms remains tapped, that land does not untap during its controller's untap phase.",
             "colours": [
@@ -5976,7 +5976,7 @@
         },
         {
             "id": "588c71c9-56e2-586f-a11c-18a7ef765970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740564ec-c473-45bc-ba94-288786bf28b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740564ec-c473-45bc-ba94-288786bf28b9.jpg?1",
             "name": "Murk Dwellers",
             "text": "If Murk Dwellers attacks and is not blocked, it gets +2/+0 until end of turn.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "919eb07d-7810-5cd8-864d-2756f064eed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc0941-5837-41cf-9ae6-5f8d1fe4dfe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc0941-5837-41cf-9ae6-5f8d1fe4dfe4.jpg?1",
             "name": "Necrite",
             "text": "Sacrifice Necrite: Bury target creature defending player controls. Use this ability only if Necrite is attacking and unblocked.",
             "colours": [
@@ -6044,7 +6044,7 @@
         },
         {
             "id": "a61f6b9e-6a2a-5281-b5b4-6540c338db74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892150a2-0a0b-4ac5-afb5-6434d6f42396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892150a2-0a0b-4ac5-afb5-6434d6f42396.jpg?1",
             "name": "Necrite",
             "text": "",
             "colours": [
@@ -6079,7 +6079,7 @@
         },
         {
             "id": "c1370d2e-b28a-5b17-be26-a3fd54228df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222cfbec-8839-43fa-95a0-2ea91b59515c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222cfbec-8839-43fa-95a0-2ea91b59515c.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw phase.\nWhenever you discard a card, remove that card from the game.\nPay 1 life: Set aside the top card of your library. Put that card into your hand at the beginning of your discard phase.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "5481b769-78b3-57ac-94a0-1f5bb0b8e540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0877527-6dbe-49f2-862f-5c79e66a92e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0877527-6dbe-49f2-862f-5c79e66a92e9.jpg?1",
             "name": "Nether Shadow",
             "text": "Nether Shadow is unaffected by summoning sickness.\nAt the end of your upkeep, if Nether Shadow is in your graveyard with at least three creature cards above it, you may put Nether Shadow into play.",
             "colours": [
@@ -6143,7 +6143,7 @@
         },
         {
             "id": "d5a5b717-bfd0-54df-8eab-bb49ff437742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60304328-7a02-4f4c-a884-fc6ce7816060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60304328-7a02-4f4c-a884-fc6ce7816060.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare has power and toughness each equal to the number of swamps you control.",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "10c8933e-1865-522f-a52c-4710999aaa87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1823c578-d3a1-40de-bdac-ec6547e8ee24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1823c578-d3a1-40de-bdac-ec6547e8ee24.jpg?1",
             "name": "Paralyze",
             "text": "When Paralyze comes into play, tap enchanted creature.\nEnchanted creature does not untap during its controller's untap phase. That player may pay an additional o4 during his or her upkeep to untap it.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "fa9c4c88-65ea-5516-8495-bcff35ffeffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e46c1-f56d-4836-95c8-76f0d76e0d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e46c1-f56d-4836-95c8-76f0d76e0d02.jpg?1",
             "name": "Pestilence",
             "text": "At the end of any turn, if there are no creatures in play, bury Pestilence.\noo\nB Pestilence deals 1 damage to each creature and player.",
             "colours": [
@@ -6241,7 +6241,7 @@
         },
         {
             "id": "312b1354-c922-5a53-8e11-bfbf145424c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe106ff1-cdc6-44cc-adb7-131203a05292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe106ff1-cdc6-44cc-adb7-131203a05292.jpg?1",
             "name": "Pit Scorpion",
             "text": "If Pit Scorpion damages any player, he or she gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -6274,7 +6274,7 @@
         },
         {
             "id": "31cf1e52-a0fa-566d-af5f-a91e6f8f27bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99fd75c-4b41-411f-92b0-ca3b220946b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99fd75c-4b41-411f-92b0-ca3b220946b5.jpg?1",
             "name": "Plague Rats",
             "text": "Plague Rats has power and toughness each equal to the number of Plague Rats in play.",
             "colours": [
@@ -6307,7 +6307,7 @@
         },
         {
             "id": "b6a296f1-7add-5c31-a26b-36a325cde05d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036057d-c7ab-4a37-a011-d10508cec2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036057d-c7ab-4a37-a011-d10508cec2bc.jpg?1",
             "name": "Pox",
             "text": "Each player loses 1/3 of his or her life; then chooses and discards 1/3 of his or her hand; then sacrifices 1/3 of the creatures he or she controls; and then sacrifices 1/3 of the lands he or she controls. Round each loss up.",
             "colours": [
@@ -6338,7 +6338,7 @@
         },
         {
             "id": "0c0af1d5-316b-5468-b5ef-73cedeb2b53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc54f1d6-8a2c-434e-bcae-942b3ccc44b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc54f1d6-8a2c-434e-bcae-942b3ccc44b5.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at target opponent's hand. That player discards a creature card at random. Use this ability only during your turn.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "24a878ab-f17b-5841-a42e-ce76bb6a4f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58326b13-0ab8-4fe5-8e63-c0333ffe5380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58326b13-0ab8-4fe5-8e63-c0333ffe5380.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card in your graveyard to your hand.",
             "colours": [
@@ -6403,7 +6403,7 @@
         },
         {
             "id": "c4112a24-025e-5b8e-8158-ee2e060bb34f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed910299-b9e3-45b3-8fd1-2ebd47cd8275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed910299-b9e3-45b3-8fd1-2ebd47cd8275.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -6436,7 +6436,7 @@
         },
         {
             "id": "77473910-cf54-5488-825a-71c2fac901a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac17237-778d-4551-9a92-8be546e233dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac17237-778d-4551-9a92-8be546e233dc.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat comes into play, put three Serf tokens into play. Treat these tokens as 0/1 black creatures.\nIf Sengir Autocrat leaves play, bury all Serf tokens.",
             "colours": [
@@ -6469,7 +6469,7 @@
         },
         {
             "id": "fb4ff874-1265-58ca-b8bc-175c787e218c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657979b3-6e4f-41a8-a518-4bd329307770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657979b3-6e4f-41a8-a518-4bd329307770.jpg?1",
             "name": "Sorceress Queen",
             "text": "oc\nT: Target creature other than Sorceress Queen is 0/2 until end of turn.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "743aa35d-92ad-5f01-9c99-2b98ec1baf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afac3a0a-e03d-4610-b12d-4bc2244163d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afac3a0a-e03d-4610-b12d-4bc2244163d1.jpg?1",
             "name": "Stromgald Cabal",
             "text": "oc\nT, Pay 1 life: Counter target white spell. Play this ability as an interrupt.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "3d1f95c4-4e9f-564d-8697-ade292e32f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0191ac-0924-4240-bfb9-700e6c09ddd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0191ac-0924-4240-bfb9-700e6c09ddd1.jpg?1",
             "name": "Terror",
             "text": "Bury target nonartifact, nonblack creature.",
             "colours": [
@@ -6568,7 +6568,7 @@
         },
         {
             "id": "2fbf6f13-4aff-5042-896f-cb3b265637b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729f4543-79f3-4fe2-973f-fb2598045877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729f4543-79f3-4fe2-973f-fb2598045877.jpg?1",
             "name": "The Wretched",
             "text": "At end of combat, gain control of all creatures blocking The Wretched as long as you control The Wretched.",
             "colours": [
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "9907b0c1-7f99-5d59-9f5b-489a8a70aa7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c86ca-a09d-4ca3-a5db-310c7612c96d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c86ca-a09d-4ca3-a5db-310c7612c96d.jpg?1",
             "name": "Thrull Retainer",
             "text": "Enchanted creature gets +1/+1.\nSacrifice Thrull Retainer: Regenerate enchanted creature.",
             "colours": [
@@ -6634,7 +6634,7 @@
         },
         {
             "id": "13fd553b-098c-50f1-8edf-cbd1b48fbb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afdd3de-4f0c-4b78-8534-562db8be9c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afdd3de-4f0c-4b78-8534-562db8be9c6b.jpg?1",
             "name": "Torture",
             "text": "o1oo\nB Put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "358cb717-c6ab-5f4e-89fc-bb3798080acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e529fb-b951-4f64-85c9-1c2e3b9581a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e529fb-b951-4f64-85c9-1c2e3b9581a2.jpg?1",
             "name": "Touch of Death",
             "text": "Touch of Death deals 1 damage to target player and you gain 1 life.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -6698,7 +6698,7 @@
         },
         {
             "id": "719dd814-3194-54e1-94e6-9b3928d8836a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0182f2f-a089-427b-aaf1-4cfaa4c0dc94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0182f2f-a089-427b-aaf1-4cfaa4c0dc94.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchanted creature gets +2/+1.",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "efb09671-65a0-50e3-ae0f-2238b8975125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b8aa03-c777-467f-9b05-812183553f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b8aa03-c777-467f-9b05-812183553f7b.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying\noo\nB +1/+0 until end of turn. You cannot spend more than o\nBo\nB in this way each turn.",
             "colours": [
@@ -6764,7 +6764,7 @@
         },
         {
             "id": "94cedd78-0fdc-5451-8466-baeb6637fabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931152c1-89a7-434e-adff-5f580a3be8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931152c1-89a7-434e-adff-5f580a3be8ed.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "37eb5586-b1d9-59c4-aec2-5a0b6dfde0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94355dce-dfd6-45d6-9b86-0c2bc10e0231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94355dce-dfd6-45d6-9b86-0c2bc10e0231.jpg?1",
             "name": "Warp Artifact",
             "text": "During the upkeep of enchanted artifact's controller, Warp Artifact deals 1 damage to him or her.",
             "colours": [
@@ -6831,7 +6831,7 @@
         },
         {
             "id": "5a5132b2-aeb8-575c-a0ce-cd0e1dc87939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5210f08b-2278-47a2-9582-b0d79ebdfc2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5210f08b-2278-47a2-9582-b0d79ebdfc2f.jpg?1",
             "name": "Weakness",
             "text": "Enchanted creature gets -2/-1.",
             "colours": [
@@ -6864,7 +6864,7 @@
         },
         {
             "id": "bfe44ff6-21fe-52a0-986a-ddc4f44b0810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcedc3f5-f4ab-4f7b-84c0-bd5a6a4b0f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcedc3f5-f4ab-4f7b-84c0-bd5a6a4b0f5e.jpg?1",
             "name": "Xenic Poltergeist",
             "text": "oc\nT: Until your next upkeep, target noncreature artifact is an artifact creature with power and toughness each equal to its total casting cost. (That artifact retains all of its original abilities.)",
             "colours": [
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "f524c048-2e70-543a-8912-4e7e0088ec70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e9f0ff-5436-4faf-9d20-b828fd18baa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e9f0ff-5436-4faf-9d20-b828fd18baa6.jpg?1",
             "name": "Zombie Master",
             "text": "All Zombies gain \"oo\nB Regenerate\" and swampwalk. (If defending player controls any swamps, these creatures are unblockable.)",
             "colours": [
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "4dd93006-b5dc-5b49-88d6-d5e2cdf20fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e464c69-84c0-4c09-ae86-b728a15ec77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e464c69-84c0-4c09-ae86-b728a15ec77f.jpg?1",
             "name": "Ambush Party",
             "text": "First strike\nAmbush Party is unaffected by summoning sickness.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "0426b3f8-35c4-5cbf-bbe9-5dec7abb033a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f123fe6a-99ca-48c1-9a7a-ae905c10108a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f123fe6a-99ca-48c1-9a7a-ae905c10108a.jpg?1",
             "name": "Atog",
             "text": "Sacrifice an artifact: +2/+2 until end of turn",
             "colours": [
@@ -6997,7 +6997,7 @@
         },
         {
             "id": "d8cd6319-97f2-516b-ad1e-621a55641258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede7920-e219-4e9d-bfa5-e0f562460914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede7920-e219-4e9d-bfa5-e0f562460914.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample\nBall Lightning is unaffected by summoning sickness.\nAt the end of any turn, bury Ball Lightning.",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "31fbdcd4-6220-56ca-8afb-cd3be2e8f8ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02750f36-d9d3-4c50-adbf-dadab46e92fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02750f36-d9d3-4c50-adbf-dadab46e92fd.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "4040669e-4fd6-5c12-9758-cbf75cca1419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a63f96-e2d4-4786-80ea-79b206263cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a63f96-e2d4-4786-80ea-79b206263cef.jpg?1",
             "name": "Blood Lust",
             "text": "Target creature gets +4/-4 until end of turn. If this reduces that creature's toughness to less than 1, the creature's toughness is 1.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "0e720eb8-5465-5381-a2d5-69e3fe814cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f068807-3e0d-42b0-aa11-7fd61492f12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f068807-3e0d-42b0-aa11-7fd61492f12b.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Brassclaw Orcs cannot be assigned to block any creature with power 2 or greater.",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "7eb3cd76-827a-5fe0-8a7a-e84fc4334484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3400509-7de8-4c1d-8546-a3df9bee1e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3400509-7de8-4c1d-8546-a3df9bee1e75.jpg?1",
             "name": "Brothers of Fire",
             "text": "o1o\nRoo\nR Brothers of Fire deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "fcea2dcd-19f7-5281-8de1-462d1c3677f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb29b6b9-1674-483f-9912-0892e39ab106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb29b6b9-1674-483f-9912-0892e39ab106.jpg?1",
             "name": "Cave People",
             "text": "If Cave People attacks, it gets +1/-2 until end of turn.\no1o\nRo\nR, oc\nT: Target creature gains mountainwalk until end of turn. (If defending player controls any mountains, that creature is unblockable.)",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "b4112bbc-033f-5876-8af0-0260d1bbaff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29354d9a-6d92-4ddf-a485-33064d666a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29354d9a-6d92-4ddf-a485-33064d666a76.jpg?1",
             "name": "Conquer",
             "text": "Gain control of enchanted land.",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "a3628e43-f944-5ba6-8d7a-839860617052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6884be-9e7c-407b-9165-6a720a634bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6884be-9e7c-407b-9165-6a720a634bb5.jpg?1",
             "name": "Crimson Manticore",
             "text": "Flying\no\nR, oc\nT: Crimson Manticore deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "be8bdc9b-30ac-5a5c-bdbc-43a65f53255a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66b93c-1510-4063-b4b0-11fa1ea81c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66b93c-1510-4063-b4b0-11fa1ea81c6b.jpg?1",
             "name": "Detonate",
             "text": "Bury target artifact with total casting cost equal to X. Detonate deals X damage to that artifact's controller.",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "b5d9fd31-ba7b-5da6-825e-ec1de58f2c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1dce58-c0e5-472e-a575-b8d4b5958b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1dce58-c0e5-472e-a575-b8d4b5958b3a.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate deals X damage to target creature or player. That creature cannot regenerate this turn. If the creature is dealt lethal damage this turn, remove it from the game.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "cd6203a3-bdf8-58d6-af93-6146b75cb329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3617ce3-240f-4846-94d9-ea852c5b842a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3617ce3-240f-4846-94d9-ea852c5b842a.jpg?1",
             "name": "Dwarven Catapult",
             "text": "Dwarven Catapult deals X damage divided evenly, rounded down, among all creatures target opponent controls.",
             "colours": [
@@ -7354,7 +7354,7 @@
         },
         {
             "id": "97a49592-8a4c-5734-a18e-aa4cc56206c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7438382c-15a0-40b1-a17b-2ef7bd67866c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7438382c-15a0-40b1-a17b-2ef7bd67866c.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by any Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "5c7ab097-e203-580b-82da-7449ee2d38aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d217942b-1253-4d4b-b0d2-09fc4e15cc62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d217942b-1253-4d4b-b0d2-09fc4e15cc62.jpg?1",
             "name": "Dwarven Warriors",
             "text": "oc\nT: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -7422,7 +7422,7 @@
         },
         {
             "id": "8d9cdc86-3d58-5a9e-af43-9ec05e78cf7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bde909-899d-4efc-aac5-57b69fa764db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bde909-899d-4efc-aac5-57b69fa764db.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "d0267879-caf2-5e47-bf80-8c48cd348c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b97aa2-cda9-4683-ad5d-1f713bd0505c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b97aa2-cda9-4683-ad5d-1f713bd0505c.jpg?1",
             "name": "Errantry",
             "text": "Enchanted creature gets +3/+0 and cannot attack during any turn in which any other creatures attack.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "e55edefb-437a-562d-b4f0-31d26b572c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1a36ca-2467-4c23-ba03-744c76b0be51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1a36ca-2467-4c23-ba03-744c76b0be51.jpg?1",
             "name": "Eternal Warrior",
             "text": "Attacking does not cause enchanted creature to tap.",
             "colours": [
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "7dd231dc-2dbe-5ffb-9075-a4ae31c67dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94218b-26d7-40cd-aef7-0e2415d1551f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94218b-26d7-40cd-aef7-0e2415d1551f.jpg?1",
             "name": "Fire Drake",
             "text": "Flying\noo\nR +1/+0 until end of turn. You cannot spend more than o\nR in this way each turn.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "ed40c7a7-4f50-5e8d-b44f-f5b6776d46b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad457b10-6e00-411f-b827-ff844f9b300d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad457b10-6e00-411f-b827-ff844f9b300d.jpg?1",
             "name": "Fireball",
             "text": "Pay o1 for each target beyond the first: Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.",
             "colours": [
@@ -7583,7 +7583,7 @@
         },
         {
             "id": "2495e67f-83d0-52ff-b29f-a67ab9acf1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb793e74-cfed-4b1a-aaba-d67d2ab6f149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb793e74-cfed-4b1a-aaba-d67d2ab6f149.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "f524f67e-bf21-59fb-b6b6-d4a009c973d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e60702-1ca3-413a-a44e-22c8fc074b7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e60702-1ca3-413a-a44e-22c8fc074b7f.jpg?1",
             "name": "Flame Spirit",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "aa525fd1-ebcc-52f2-b10d-ba7d64b46b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc046c2-be9b-4f93-ac7d-e7dea6c4df9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc046c2-be9b-4f93-ac7d-e7dea6c4df9a.jpg?1",
             "name": "Flare",
             "text": "Flare deals 1 damage to target creature or player.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "09befe63-d21d-5c87-bc9a-4d4c69b6805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fafab5c-3ce7-41fc-a3e7-68e322566cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fafab5c-3ce7-41fc-a3e7-68e322566cfd.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "474c7984-32e9-51b7-83a8-447617b79954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b44933-6b0b-426a-97d4-7a7cf6ad1d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b44933-6b0b-426a-97d4-7a7cf6ad1d65.jpg?1",
             "name": "Game of Chaos",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. The loser of the flip loses 1 life. The winner of the flip gains 1 life and may choose to repeat the process. Double the stakes each time.",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "577ae165-cfb3-5a7b-b6fc-2c3d5f42292b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4aaab5-a202-4905-839b-ebf39b910082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4aaab5-a202-4905-839b-ebf39b910082.jpg?1",
             "name": "Game of Chaos",
             "text": "",
             "colours": [
@@ -7778,7 +7778,7 @@
         },
         {
             "id": "d93301cc-0df6-5df0-beef-800aaf0d1b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77caee7-b441-4458-bdc8-45fd1185380d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77caee7-b441-4458-bdc8-45fd1185380d.jpg?1",
             "name": "Giant Strength",
             "text": "Enchanted creature gets +2/+2.",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "37b96728-2787-5b92-af5f-ab42315e0b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3feb2-e94b-4d02-8179-63d0289dd7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3feb2-e94b-4d02-8179-63d0289dd7d1.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT, Sacrifice Goblin Digging Team: Destroy target Wall.",
             "colours": [
@@ -7844,7 +7844,7 @@
         },
         {
             "id": "9564a162-e44c-503d-995b-a0f873554884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d21c8c9-6e16-4eb2-b2f5-3998f0f958ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d21c8c9-6e16-4eb2-b2f5-3998f0f958ae.jpg?1",
             "name": "Goblin Hero",
             "text": "",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "671b3464-7145-5409-92e7-d7b779a9cff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc72e1d3-f782-4b1c-9ea1-8e5b8566a187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc72e1d3-f782-4b1c-9ea1-8e5b8566a187.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and gain mountainwalk. (If defending player controls any mountains, these creatures are unblockable.)",
             "colours": [
@@ -7910,7 +7910,7 @@
         },
         {
             "id": "77928142-a521-5d73-8d34-91cdacccd177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b57d24a-1f2d-4227-a952-03abaecb19de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b57d24a-1f2d-4227-a952-03abaecb19de.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each creature you control cannot be blocked by only one creature.",
             "colours": [
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "78e06a6d-6f82-5c05-acea-231d4204dfc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218245-5e0f-4233-896a-00ec0cc34fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218245-5e0f-4233-896a-00ec0cc34fcc.jpg?1",
             "name": "Goblin Warrens",
             "text": "o2o\nR, Sacrifice two Goblins: Put three Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -7972,7 +7972,7 @@
         },
         {
             "id": "804de3d3-4e2a-5442-9324-180368413129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9d069-1163-46bd-9a71-21c05898330e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9d069-1163-46bd-9a71-21c05898330e.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "62ca630f-d114-5394-9d94-136f643b6e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb3745e-402f-47b6-9aaf-1d177d03cabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb3745e-402f-47b6-9aaf-1d177d03cabe.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -8038,7 +8038,7 @@
         },
         {
             "id": "335cbf2e-ab68-535e-acac-e62bce1845dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a256b0-e25b-43c6-9f7a-2ad76b268d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a256b0-e25b-43c6-9f7a-2ad76b268d22.jpg?1",
             "name": "Imposing Visage",
             "text": "Enchanted creature cannot be blocked by only one creature.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "e0df82de-4ada-57c8-af9a-1389f441681e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0f7e1f-bcb5-414f-a2e9-6a158fec2ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0f7e1f-bcb5-414f-a2e9-6a158fec2ff5.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. Creatures damaged by Incinerate cannot regenerate this turn.",
             "colours": [
@@ -8102,7 +8102,7 @@
         },
         {
             "id": "3005e937-8af8-50b4-8224-40d2cb968fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d04a75-647f-400f-b0dc-c4544f7db2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d04a75-647f-400f-b0dc-c4544f7db2d4.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and player.",
             "colours": [
@@ -8135,7 +8135,7 @@
         },
         {
             "id": "a64c5a3b-f77b-50d9-b01c-1735809a2fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2850e8-f135-4a51-905b-ae30b83913a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2850e8-f135-4a51-905b-ae30b83913a6.jpg?1",
             "name": "Inferno",
             "text": "",
             "colours": [
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "7915658f-76c0-5ffd-95fa-45ab9f30b976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed35d03-80fd-421d-a8be-6708a5570a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed35d03-80fd-421d-a8be-6708a5570a85.jpg?1",
             "name": "Ironclaw Curse",
             "text": "Enchanted creature gets -0/-1 and cannot be assigned to block any creature with power greater than or equal to enchanted creature's toughness.",
             "colours": [
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "dacd6e5e-bb13-5cd2-abce-2ba553c36840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346eef90-35c3-4153-a64a-55f4d7b232e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346eef90-35c3-4153-a64a-55f4d7b232e2.jpg?1",
             "name": "Ironclaw Curse",
             "text": "",
             "colours": [
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "46b4531e-9973-532a-bae0-6d5794312117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628a3506-352d-4d4f-b63e-05abb3ca906d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628a3506-352d-4d4f-b63e-05abb3ca906d.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Ironclaw Orcs cannot be assigned to block any creature with power 2 or greater.",
             "colours": [
@@ -8271,7 +8271,7 @@
         },
         {
             "id": "17f8379d-43b0-5e75-9dfc-33a013ba1c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d81e479-45b7-4237-a0eb-95245582e87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d81e479-45b7-4237-a0eb-95245582e87d.jpg?1",
             "name": "Jokulhaups",
             "text": "Bury all artifacts, creatures, and lands.",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "98ee29fe-4ca1-5da5-82fe-3fab617ad534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c67ccfa-e2ac-4abd-a55d-bd10d570220a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c67ccfa-e2ac-4abd-a55d-bd10d570220a.jpg?1",
             "name": "Keldon Warlord",
             "text": "Keldon Warlord has power and toughness each equal to the number of non-Wall creatures you control.",
             "colours": [
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "9336867f-e184-582b-9494-30b4be3a2800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2e818-a5a8-4b9b-93e8-121dd7fefe32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2e818-a5a8-4b9b-93e8-121dd7fefe32.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads at the same time.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "0e30faa3-c446-5328-be75-217a21dc7ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d9af72-1633-4433-83ce-7de806611448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d9af72-1633-4433-83ce-7de806611448.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever any player taps a land for mana, it produces one additional mana of the same type.",
             "colours": [
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "3e91e939-2fa7-53ec-bec7-4ee5911e3962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a2d1d-0964-44a9-9f32-09804f2c7445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a2d1d-0964-44a9-9f32-09804f2c7445.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever any player taps a land for mana, Manabarbs deals 1 damage to him or her.",
             "colours": [
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "4d8b1e13-856b-5961-880a-ebff6efabef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffef6ac8-a42c-4025-b4ef-3f772129b8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffef6ac8-a42c-4025-b4ef-3f772129b8f7.jpg?1",
             "name": "Manabarbs",
             "text": "",
             "colours": [
@@ -8464,7 +8464,7 @@
         },
         {
             "id": "37a37685-4a76-5860-af98-552c84644b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8324c5a9-d126-4510-90ac-c6b1424137d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8324c5a9-d126-4510-90ac-c6b1424137d9.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -8497,7 +8497,7 @@
         },
         {
             "id": "99b20b82-0cf6-5f45-baee-772dac71bd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbec9fe6-a951-48b2-a0d2-3cdf69b5400f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbec9fe6-a951-48b2-a0d2-3cdf69b5400f.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk (If defending player controls any mountains, this creature is unblockable.)",
             "colours": [
@@ -8530,7 +8530,7 @@
         },
         {
             "id": "177481a3-d5ef-5fab-9666-dcd245baec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ddc97b-b13e-4947-b4df-f35790b89f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ddc97b-b13e-4947-b4df-f35790b89f15.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -8564,7 +8564,7 @@
         },
         {
             "id": "a130c818-55da-5744-afff-db132eaa58c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d422f-101e-44f2-ab0d-7ad962c6d657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d422f-101e-44f2-ab0d-7ad962c6d657.jpg?1",
             "name": "Orcish Captain",
             "text": "o1: Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, target Orc gets +2/+0 until end of turn. Otherwise, that Orc gets -0/-2 until end of turn.",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "297ad706-71d2-53b2-9a8d-a30490370c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17025cde-28a1-4a38-ad5a-1ead518d77af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17025cde-28a1-4a38-ad5a-1ead518d77af.jpg?1",
             "name": "Orcish Conscripts",
             "text": "Orcish Conscripts cannot attack this turn unless at least two other creatures are attacking.\nOrcish Conscripts cannot be assigned to block this turn unless at least two other creatures are blocking.",
             "colours": [
@@ -8631,7 +8631,7 @@
         },
         {
             "id": "f6e04969-c164-5561-aed6-cd1219a669fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2bb2b4-87ff-4971-9835-fd68d913af26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2bb2b4-87ff-4971-9835-fd68d913af26.jpg?1",
             "name": "Orcish Farmer",
             "text": "oc\nT: Target land is a swamp until its controller's next untap phase.",
             "colours": [
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "bc541992-8b32-5828-b41e-8a8e1e8dd507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00e95e-6bf1-445a-a46a-29aeb05bf9be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00e95e-6bf1-445a-a46a-29aeb05bf9be.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "3232e632-7a81-5efc-9eb3-ec8da500e5b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27af5-cb26-4f39-8648-193bb116e3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27af5-cb26-4f39-8648-193bb116e3d6.jpg?1",
             "name": "Orcish Squatters",
             "text": "o0: Gain control of target land defending player controls as long as you control Orcish Squatters. Orcish Squatters deals no combat damage this turn. Use this ability only if Orcish Squatters is attacking and unblocked and only once each turn.",
             "colours": [
@@ -8728,7 +8728,7 @@
         },
         {
             "id": "12dca2b9-a9a2-57b7-97d2-4e1234e1d1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7eef087-8500-4fca-a10a-ff65d348bcb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7eef087-8500-4fca-a10a-ff65d348bcb1.jpg?1",
             "name": "Orgg",
             "text": "Trample\nOrgg cannot attack if defending player controls an untapped creature with power 3 or greater.\nOrgg cannot be assigned to block any creature with power 3 or greater.",
             "colours": [
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "39f19bad-56cd-5f48-9c5e-226c34020d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a86ee4-200e-4994-bd6f-0c1d3227ce5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a86ee4-200e-4994-bd6f-0c1d3227ce5b.jpg?1",
             "name": "Panic",
             "text": "Play only during combat before blockers are declared.\nTarget creature cannot be assigned to block this turn.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -8792,7 +8792,7 @@
         },
         {
             "id": "bfc4b035-59d1-56bf-a0d3-54e1bbfd9b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d8d6d-b8d3-4f71-a88a-5d639ce2925f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d8d6d-b8d3-4f71-a88a-5d639ce2925f.jpg?1",
             "name": "Primordial Ooze",
             "text": "Primordial Ooze attacks each turn if able.\nDuring your upkeep, put a +1/+1 counter on Primordial Ooze. Then pay o\nX, where X is equal to the number of these counters on Primordial Ooze, or tap Primordial Ooze and it deals X damage to you.",
             "colours": [
@@ -8825,7 +8825,7 @@
         },
         {
             "id": "f338e36e-fc5e-5a76-b76d-a2dfbbd6660f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2d7cd-d29d-4f19-8490-88bd526ff1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2d7cd-d29d-4f19-8490-88bd526ff1c5.jpg?1",
             "name": "Pyroblast",
             "text": "Counter target spell if it is blue, or destroy target permanent if it is blue. (If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -8856,7 +8856,7 @@
         },
         {
             "id": "ebc667f9-be9b-5ec3-bd5f-d1fb88933662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e9f71f-cb85-4b57-9bb3-fe98ed4a524e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e9f71f-cb85-4b57-9bb3-fe98ed4a524e.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -8887,7 +8887,7 @@
         },
         {
             "id": "ab6ed27e-8bc8-5ebb-b333-27f624a04291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb936214-df72-4d77-b8f7-879c2b4e31d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb936214-df72-4d77-b8f7-879c2b4e31d7.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "b9b60853-248c-5bd7-a1ce-9ae8f3b694d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1edce4-0550-4683-a4d6-5dff6b9f0122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1edce4-0550-4683-a4d6-5dff6b9f0122.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -8951,7 +8951,7 @@
         },
         {
             "id": "ddd47129-c3ac-531d-87ae-0a58ea9c5ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d38e6-b659-4fcb-8192-797bb61e7700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d38e6-b659-4fcb-8192-797bb61e7700.jpg?1",
             "name": "Shatterstorm",
             "text": "Bury all artifacts.",
             "colours": [
@@ -8982,7 +8982,7 @@
         },
         {
             "id": "7a24a4dd-a3e5-5b06-b133-ad4fd6293eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b05edd-4128-4150-9457-8aff895bd0b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b05edd-4128-4150-9457-8aff895bd0b7.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\noo\nR +1/+0 until end of turn",
             "colours": [
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "2f118c2e-da99-54a6-894b-5c948d74b0f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97e7318-f916-4556-9f89-dda7914359c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97e7318-f916-4556-9f89-dda7914359c1.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -9052,7 +9052,7 @@
         },
         {
             "id": "8af58c14-650d-5821-8123-0251ca64425b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4710dd0-2797-40dd-8a24-bdd3da112c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4710dd0-2797-40dd-8a24-bdd3da112c39.jpg?1",
             "name": "Smoke",
             "text": "Players cannot untap more than one creature during their untap phases.",
             "colours": [
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "c052a640-ef6a-5378-bd3c-0edd3470bcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f736379-1fe8-43b8-b749-f1e9baef96a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f736379-1fe8-43b8-b749-f1e9baef96a6.jpg?1",
             "name": "Stone Giant",
             "text": "oc\nT: Target creature you control with toughness less than Stone Giant's power gains flying until end of turn. At end of turn, destroy that creature.",
             "colours": [
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "1a07170d-08bb-5a2a-bebf-34fcd7b402e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5935ef-8cc5-4587-b8eb-f6a2b2856260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5935ef-8cc5-4587-b8eb-f6a2b2856260.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -9147,7 +9147,7 @@
         },
         {
             "id": "4f947827-c670-5b49-8abf-aec77fb048a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c927b-1258-4758-bbff-10cc032587a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c927b-1258-4758-bbff-10cc032587a2.jpg?1",
             "name": "Stone Spirit",
             "text": "Stone Spirit cannot be blocked by creatures with flying.",
             "colours": [
@@ -9181,7 +9181,7 @@
         },
         {
             "id": "8670c8c3-b5b1-5597-a69c-1751132d717b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ded8fa-facf-4196-8964-56ebc6424be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ded8fa-facf-4196-8964-56ebc6424be1.jpg?1",
             "name": "The Brute",
             "text": "Enchanted creature gets +1/+0.\no\nRo\nRoo\nR Regenerate enchanted creature.",
             "colours": [
@@ -9214,7 +9214,7 @@
         },
         {
             "id": "b55111fc-522b-5041-9d65-f79dca7cf353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debc9415-ae75-4514-9d5d-b1b403420d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debc9415-ae75-4514-9d5d-b1b403420d1d.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "5fba64ae-d3cc-5cc8-b341-ac732223153b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47e4f33-3eb5-4aac-acb4-74ff60558db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47e4f33-3eb5-4aac-acb4-74ff60558db7.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "c8ac7c35-46b2-591e-ad41-aaa1fc078f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38712e4f-aabd-40b3-b41f-b034e032a729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38712e4f-aabd-40b3-b41f-b034e032a729.jpg?1",
             "name": "Winds of Change",
             "text": "Each player shuffles his or her hand into his or her library, then draws a new hand of as many cards as he or she had before.",
             "colours": [
@@ -9311,7 +9311,7 @@
         },
         {
             "id": "44cc384b-384e-515d-aa13-40bf7e2bf96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dc1c22-ef39-4f5f-a8af-4267a3d5db6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dc1c22-ef39-4f5f-a8af-4267a3d5db6f.jpg?1",
             "name": "Word of Blasting",
             "text": "Bury target Wall. Word of Blasting deals to that Wall's controller an amount of damage equal to the Wall's total casting cost.",
             "colours": [
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "541286ec-358b-5383-96d8-a70d63b61632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5955eb2b-31a2-4e1e-bbbe-82eb53def698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5955eb2b-31a2-4e1e-bbbe-82eb53def698.jpg?1",
             "name": "An-Havva Constable",
             "text": "An-Havva Constable has toughness equal to 1 plus the number of green creatures in play.",
             "colours": [
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "5cf1ef5b-e3ea-510c-a2d3-ffca0c2195f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38af8356-2d7f-4699-9e57-08906c1c831b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38af8356-2d7f-4699-9e57-08906c1c831b.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Enchanted creature gets +*/+*, where * is equal to half the number of forests you control, rounded down for power and up for toughness.",
             "colours": [
@@ -9408,7 +9408,7 @@
         },
         {
             "id": "6d27eabf-6f22-5161-98e5-7ce54caa859b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd473981-a62c-480f-aeae-0218f3e07fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd473981-a62c-480f-aeae-0218f3e07fa6.jpg?1",
             "name": "Aurochs",
             "text": "Trample\nIf Aurochs attacks, it gets +1/+0 until end of turn for each other Aurochs that attacks.",
             "colours": [
@@ -9441,7 +9441,7 @@
         },
         {
             "id": "dc05274d-da81-59c3-8361-72c973503bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79357f4-ddd1-4b29-9e5f-813c799513ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79357f4-ddd1-4b29-9e5f-813c799513ee.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -9474,7 +9474,7 @@
         },
         {
             "id": "e8ea438b-f1e6-5af9-a696-0bc7b4bbcee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22891f6c-7365-4baf-ae5a-49380be50895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22891f6c-7365-4baf-ae5a-49380be50895.jpg?1",
             "name": "Carapace",
             "text": "Enchanted creature gets +0/+2.\nSacrifice Carapace: Regenerate enchanted creature.",
             "colours": [
@@ -9507,7 +9507,7 @@
         },
         {
             "id": "965d04c8-d5ae-5f25-8a58-7b13dbbb04c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0180bd6-f8eb-4cf7-b6d0-acb513076e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0180bd6-f8eb-4cf7-b6d0-acb513076e00.jpg?1",
             "name": "Cat Warriors",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)",
             "colours": [
@@ -9541,7 +9541,7 @@
         },
         {
             "id": "5af44039-cc59-5e78-ab83-251319769282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d977294-051a-4e6d-b2ba-c04494474aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d977294-051a-4e6d-b2ba-c04494474aac.jpg?1",
             "name": "Chub Toad",
             "text": "If Chub Toad blocks or is blocked, it gets +2/+2 until end of turn.",
             "colours": [
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "bc2ca0c8-d617-58f1-ada1-39bfaa7b114f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853d15cd-a1a2-47a8-89c4-81b7ca663fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853d15cd-a1a2-47a8-89c4-81b7ca663fff.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nIf Cockatrice blocks or is blocked by any non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -9607,7 +9607,7 @@
         },
         {
             "id": "02f97c49-df7c-5d75-a300-ec32cb8968d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06274d3b-8feb-4c68-adbc-b1ee633c3353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06274d3b-8feb-4c68-adbc-b1ee633c3353.jpg?1",
             "name": "Craw Giant",
             "text": "Trample; rampage 2 (For each creature assigned to block it beyond the first, this creature gets +2/+2 until end of turn.)",
             "colours": [
@@ -9640,7 +9640,7 @@
         },
         {
             "id": "d6096cdb-63d6-540e-9a14-955d22d5f87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e6afb-7094-4fa3-9246-58343f8d80b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e6afb-7094-4fa3-9246-58343f8d80b8.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -9673,7 +9673,7 @@
         },
         {
             "id": "f7fc1872-08b1-5ace-af9c-45adbec50378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c781ee-7ffb-4dd3-ac84-4d6fe4649591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c781ee-7ffb-4dd3-ac84-4d6fe4649591.jpg?1",
             "name": "Crumble",
             "text": "Bury target artifact. That artifact's controller gains an amount of life equal to its total casting cost.",
             "colours": [
@@ -9704,7 +9704,7 @@
         },
         {
             "id": "d6cf5547-7519-5029-b29c-db4110794f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15dc6a9-f288-414a-9052-f03846176bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15dc6a9-f288-414a-9052-f03846176bff.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy target permanent.",
             "colours": [
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "b9ff1479-3dec-5e7f-8ac1-d34a817420a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68418099-c199-428a-b4aa-db54909efd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68418099-c199-428a-b4aa-db54909efd0d.jpg?1",
             "name": "Durkwood Boars",
             "text": "",
             "colours": [
@@ -9768,7 +9768,7 @@
         },
         {
             "id": "d89147f9-31df-5203-a708-0e66ec1f3122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2151c8f2-c031-4c96-a420-ff2108df7ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2151c8f2-c031-4c96-a420-ff2108df7ad8.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG, oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -9803,7 +9803,7 @@
         },
         {
             "id": "9876593c-922c-5ecb-8997-5842ac8f505d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb6c97-b972-4c78-ba95-6053f2466f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb6c97-b972-4c78-ba95-6053f2466f20.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders cannot be blocked except by Walls or creatures with flying.",
             "colours": [
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "0066bb60-6063-5f45-92cc-aa33933d32dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92d92c-a9c7-40c5-82f3-dbd19697f999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92d92c-a9c7-40c5-82f3-dbd19697f999.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "c6c243ad-90ef-5506-90e3-34a36e091864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82954c1c-8c58-48bf-aefe-e7ec5108a124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82954c1c-8c58-48bf-aefe-e7ec5108a124.jpg?1",
             "name": "Fog",
             "text": "Creatures deal no combat damage this turn.",
             "colours": [
@@ -9901,7 +9901,7 @@
         },
         {
             "id": "6cfc95f5-8b69-54af-a693-e450e731b909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86f61bb-c2b5-4672-b262-1c72bd1de51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86f61bb-c2b5-4672-b262-1c72bd1de51f.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nDuring your upkeep, pay o\nGo\nGo\nGo\nG or Force of Nature deals 8 damage to you.",
             "colours": [
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "7fa802b9-bb7d-5d98-bc83-42ea71bf94be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1638c4-effb-460b-af5d-aa17559dbd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1638c4-effb-460b-af5d-aa17559dbd37.jpg?1",
             "name": "Foxfire",
             "text": "Untap target attacking creature. That creature neither deals nor receives combat damage this turn.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -9965,7 +9965,7 @@
         },
         {
             "id": "b2606216-cdbe-574d-ae3c-2d60fd47c151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f6f2bd-4e0e-42d8-b5a6-ad4ee736c69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f6f2bd-4e0e-42d8-b5a6-ad4ee736c69e.jpg?1",
             "name": "Fungusaur",
             "text": "At the end of any turn in which Fungusaur was damaged, put a +1/+1 counter on it.",
             "colours": [
@@ -9999,7 +9999,7 @@
         },
         {
             "id": "0af9c9ae-3db7-5d47-a10d-25dd2b0ef845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8532a8-966e-4cba-b3a5-99cfb0ee1220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8532a8-966e-4cba-b3a5-99cfb0ee1220.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "69156217-5138-5e84-b58b-fe34d9e580fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa6c0d6-aa18-4c32-a641-1ec8e50a26f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa6c0d6-aa18-4c32-a641-1ec8e50a26f3.jpg?1",
             "name": "Ghazb\u00e1n Ogre",
             "text": "During your upkeep, if a player has more life than any other, he or she gains control of Ghazb\u00e1n Ogre.",
             "colours": [
@@ -10066,7 +10066,7 @@
         },
         {
             "id": "87da33ec-5e4c-535e-90c1-1a79f0577bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07aee96b-1cf3-4cd9-9998-39ab16170c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07aee96b-1cf3-4cd9-9998-39ab16170c6b.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -10097,7 +10097,7 @@
         },
         {
             "id": "b4af0d0f-aa1b-523e-8e34-cfb6495a05bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953cf3be-b975-4a10-8c92-c783c727dcfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953cf3be-b975-4a10-8c92-c783c727dcfa.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can block creatures with flying.",
             "colours": [
@@ -10130,7 +10130,7 @@
         },
         {
             "id": "7b3ef7fa-30ce-527c-b74e-1d375404e42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8ad43-adea-47e8-9d9e-e14c2ad41489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8ad43-adea-47e8-9d9e-e14c2ad41489.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -10163,7 +10163,7 @@
         },
         {
             "id": "c9bc22af-de54-5e2e-a7b7-3b1067851796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ba2bff-08e6-4413-929b-80e13f193b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ba2bff-08e6-4413-929b-80e13f193b1e.jpg?1",
             "name": "Hungry Mist",
             "text": "During your upkeep, pay o\nGo\nG or bury Hungry Mist.",
             "colours": [
@@ -10196,7 +10196,7 @@
         },
         {
             "id": "6f4c4c11-b7df-5574-9241-aff8b68ad717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa0de8c-a23f-49d2-ac16-91c0d1eb17a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa0de8c-a23f-49d2-ac16-91c0d1eb17a6.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -10227,7 +10227,7 @@
         },
         {
             "id": "b4b1cd2e-1ff2-564d-aecc-a062a684d2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9b2cc-b362-4488-93ef-e98398ff73ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9b2cc-b362-4488-93ef-e98398ff73ea.jpg?1",
             "name": "Instill Energy",
             "text": "Enchanted creature is unaffected by summoning sickness.\no0: Untap enchanted creature. Use this ability only during your turn and only once each turn.",
             "colours": [
@@ -10260,7 +10260,7 @@
         },
         {
             "id": "6a089758-dc05-55f9-8f5b-4c1c83da1155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdbba38-b4c9-4c14-b869-669b39390e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdbba38-b4c9-4c14-b869-669b39390e4e.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -10293,7 +10293,7 @@
         },
         {
             "id": "3ffbda4e-59b4-5aa3-9c64-e35ead017a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca51ce-e0f4-42ce-b2a5-db73268bcf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca51ce-e0f4-42ce-b2a5-db73268bcf1f.jpg?1",
             "name": "Johtull Wurm",
             "text": "For each creature assigned to block it beyond the first, Johtull Wurm gets -2/-1 until end of turn.",
             "colours": [
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "fb85a79b-ec7a-50c2-9ea6-b330d69cbcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a749837-56ff-4e42-9bf2-82633bccdc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a749837-56ff-4e42-9bf2-82633bccdc39.jpg?1",
             "name": "Killer Bees",
             "text": "Flying\noo\nG +1/+1 until end of turn",
             "colours": [
@@ -10359,7 +10359,7 @@
         },
         {
             "id": "b7c7169c-223b-5adc-826a-2743d208752e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acc4f93-1bf1-4b00-b0e0-d44c2b2cd079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acc4f93-1bf1-4b00-b0e0-d44c2b2cd079.jpg?1",
             "name": "Ley Druid",
             "text": "oc\nT: Untap target land.",
             "colours": [
@@ -10393,7 +10393,7 @@
         },
         {
             "id": "17cdc1c7-b984-5372-824d-eae20cdaf076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fadc2d27-0c6c-4f68-bee0-0af6688f304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fadc2d27-0c6c-4f68-bee0-0af6688f304d.jpg?1",
             "name": "Lhurgoyf",
             "text": "Lhurgoyf has power equal to the number of creature cards in all graveyards and toughness equal to 1 plus the number of creature cards in all graveyards.",
             "colours": [
@@ -10426,7 +10426,7 @@
         },
         {
             "id": "3cfd89a3-9585-5dea-9a51-71f249830bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1681fa-2edc-4c0c-b5ca-f7f2602a3467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1681fa-2edc-4c0c-b5ca-f7f2602a3467.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Counter target black spell. Play this ability as an interrupt.",
             "colours": [
@@ -10457,7 +10457,7 @@
         },
         {
             "id": "e0daff8d-98c5-5028-bb55-0989aedc8ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af097b1-9eae-4bd6-8ee6-582cae57e970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af097b1-9eae-4bd6-8ee6-582cae57e970.jpg?1",
             "name": "Living Artifact",
             "text": "For each 1 damage dealt to you, put a vitality counter on Living Artifact.\nRemove a vitality counter from Living Artifact: Gain 1 life. Use this ability only during your upkeep and only once each turn.",
             "colours": [
@@ -10490,7 +10490,7 @@
         },
         {
             "id": "89bad8f3-36dd-5dc2-ac20-effd36c31a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9a2294-dd5b-4658-9f79-334a51b03ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9a2294-dd5b-4658-9f79-334a51b03ea3.jpg?1",
             "name": "Living Lands",
             "text": "All forests are 1/1 creatures. (These creatures still count as lands.)",
             "colours": [
@@ -10521,7 +10521,7 @@
         },
         {
             "id": "1b769898-d759-547b-b0e4-e934e4d14859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632b9428-45c6-4b81-a701-f1c7d7e8d2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632b9428-45c6-4b81-a701-f1c7d7e8d2f0.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -10555,7 +10555,7 @@
         },
         {
             "id": "3eb8df0a-4ce8-5dc6-9ee7-ab9f179fadd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380e07a-9d5c-4579-93f5-4cf52d90897d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380e07a-9d5c-4579-93f5-4cf52d90897d.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -10588,7 +10588,7 @@
         },
         {
             "id": "a9de76d7-c287-5f81-8062-f4621673fe27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4c0606-f9af-4dee-bc36-5051395b5f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4c0606-f9af-4dee-bc36-5051395b5f44.jpg?1",
             "name": "Marsh Viper",
             "text": "If Marsh Viper damages any player, he or she gets two poison counters. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "de86b3f2-a93f-5edf-8482-eabeb90cbd34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4ffc1-7731-42d9-b970-2a8d84cba14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4ffc1-7731-42d9-b970-2a8d84cba14d.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a forest card and put that card into play. Shuffle your library afterwards.",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "87d7ddfa-0a9b-5eaf-8731-0f186c301d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee195a-c331-4918-ad9e-3877dd3f4e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee195a-c331-4918-ad9e-3877dd3f4e3a.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nG, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -10686,7 +10686,7 @@
         },
         {
             "id": "62890693-8189-502b-b19d-eb3904d5f8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b455a-417a-4490-8495-bda9441306c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b455a-417a-4490-8495-bda9441306c8.jpg?1",
             "name": "Primal Order",
             "text": "During each player's upkeep, Primal Order deals to that player an amount of damage equal to the number of nonbasic lands he or she controls.",
             "colours": [
@@ -10717,7 +10717,7 @@
         },
         {
             "id": "210fa277-6acc-58ad-953f-1c498194c6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dbfeb2-76ac-48b2-99fb-fa4bcc59b2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dbfeb2-76ac-48b2-99fb-fa4bcc59b2a5.jpg?1",
             "name": "Rabid Wombat",
             "text": "Attacking does not cause Rabid Wombat to tap.\nRabid Wombat gets +2/+2 for each creature enchantment on it.",
             "colours": [
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "9925ce80-e5d5-5c08-a3fe-afccd2c84674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf02a10-86ba-4c2d-adc5-e4a2b7cc089e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf02a10-86ba-4c2d-adc5-e4a2b7cc089e.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying until end of turn.",
             "colours": [
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "53119a31-f307-51f0-8d18-f4fbfe6f34b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd0d1d-9422-4941-9491-8a8d64909f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd0d1d-9422-4941-9491-8a8d64909f8e.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "0d648789-a2c5-5303-bcff-a2e0fba101e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad1b3a-3464-4080-819b-a62bf6c23a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad1b3a-3464-4080-819b-a62bf6c23a13.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "814ba42f-59a7-5bc5-815a-17668dec176a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d1549-d0d5-48f8-9d8a-2e2940523307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d1549-d0d5-48f8-9d8a-2e2940523307.jpg?1",
             "name": "Scavenger Folk",
             "text": "o\nG, oc\nT, Sacrifice Scavenger Folk: Destroy target artifact.",
             "colours": [
@@ -10882,7 +10882,7 @@
         },
         {
             "id": "433501ef-d8f9-5378-af63-6a5cbef13a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab52f491-26f1-494f-8ec7-9630c4f9653a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab52f491-26f1-494f-8ec7-9630c4f9653a.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -10915,7 +10915,7 @@
         },
         {
             "id": "078c45d3-46da-52e2-822f-30681e5daa20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34163ceb-5c7a-4a3b-9290-bc4f22e0259d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34163ceb-5c7a-4a3b-9290-bc4f22e0259d.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)",
             "colours": [
@@ -10949,7 +10949,7 @@
         },
         {
             "id": "a26f9817-49d7-5eb0-ad7b-541af34f05a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f96537-76d2-4887-b17f-b8297fa50fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f96537-76d2-4887-b17f-b8297fa50fd5.jpg?1",
             "name": "Shrink",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -10980,7 +10980,7 @@
         },
         {
             "id": "8d987691-d2da-50d9-9945-7ccd65e6f570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcec8997-bc9b-42c0-bac1-5644e9915fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcec8997-bc9b-42c0-bac1-5644e9915fa2.jpg?1",
             "name": "Stampede",
             "text": "All attacking creatures get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -11011,7 +11011,7 @@
         },
         {
             "id": "a2b0ea45-d4af-50e8-8c9b-9e127812e7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738e9ec1-a186-44ad-8a68-d5cc183ccdc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738e9ec1-a186-44ad-8a68-d5cc183ccdc0.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "1130f1d1-e413-5cda-8b87-c08122db60a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b337de-4c43-45b6-a0ca-262a983f3589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b337de-4c43-45b6-a0ca-262a983f3589.jpg?1",
             "name": "Sylvan Library",
             "text": "o0: Draw two cards, then choose any two cards in your hand drawn this turn. For each of those cards, pay 4 life or put that card back on top of your library. Use this ability only during your draw phase and only once each turn.",
             "colours": [
@@ -11073,7 +11073,7 @@
         },
         {
             "id": "157f3b6e-c9bf-548d-910b-edf58c3955ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2160d57-9ebf-43fb-811f-0c014e417ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2160d57-9ebf-43fb-811f-0c014e417ea0.jpg?1",
             "name": "Tarpan",
             "text": "If Tarpan is put into any graveyard from play, gain 1 life.",
             "colours": [
@@ -11106,7 +11106,7 @@
         },
         {
             "id": "26305603-189c-5176-b823-2dabbd2c8505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511d4bc3-05ea-48f3-b182-dd0cd049ce54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511d4bc3-05ea-48f3-b182-dd0cd049ce54.jpg?1",
             "name": "Thicket Basilisk",
             "text": "If Thicket Basilisk blocks or is blocked by any non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -11139,7 +11139,7 @@
         },
         {
             "id": "48a960f0-146f-5835-84dd-1823cf4183ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837f0c8-4822-41f1-8677-988c13efe8d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837f0c8-4822-41f1-8677-988c13efe8d5.jpg?1",
             "name": "Titania's Song",
             "text": "Each noncreature artifact loses its abilities and is an artifact creature with power and toughness each equal to its total casting cost. If Titania's Song leaves play, this effect continues until end of turn.",
             "colours": [
@@ -11170,7 +11170,7 @@
         },
         {
             "id": "b8548b80-9f1f-59b5-ae0f-e76c5947ca22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f8bd4a-ec7f-4da5-bd39-cba29541ee83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f8bd4a-ec7f-4da5-bd39-cba29541ee83.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -11201,7 +11201,7 @@
         },
         {
             "id": "05b53743-f748-5b7a-a1f8-a01877841b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab151ce-9468-4427-853b-4e0011d783fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab151ce-9468-4427-853b-4e0011d783fb.jpg?1",
             "name": "Tsunami",
             "text": "Destroy all islands.",
             "colours": [
@@ -11232,7 +11232,7 @@
         },
         {
             "id": "0f5db6fa-a305-5dde-9f15-889840e26d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979f6606-a4d7-43e8-95fb-c4f06c16d1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979f6606-a4d7-43e8-95fb-c4f06c16d1b4.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a basic land card and put that card into play. Shuffle your library afterwards.",
             "colours": [
@@ -11263,7 +11263,7 @@
         },
         {
             "id": "860b734a-55e9-5621-87ac-1e4c52ef846f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb503ef-31a4-492d-9c7d-26b72c36904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb503ef-31a4-492d-9c7d-26b72c36904b.jpg?1",
             "name": "Venom",
             "text": "If enchanted creature blocks or is blocked by any non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "a808fbfd-aceb-5329-a718-1d6d04bab1be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5bf9e-db83-498d-bccc-9588f2fcb9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5bf9e-db83-498d-bccc-9588f2fcb9ff.jpg?1",
             "name": "Verduran Enchantress",
             "text": "o0: Draw a card. Use this ability only when you successfully cast an enchantment spell and only once for each such spell.",
             "colours": [
@@ -11330,7 +11330,7 @@
         },
         {
             "id": "a43ff381-dc0f-59b2-8323-b161c1876180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8780a20-8504-406e-aea1-722f146be5f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8780a20-8504-406e-aea1-722f146be5f7.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerate",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "81b68fd7-2d5e-5f3f-9b75-82decf9d546c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d93816b-cb5e-49b7-98bd-22de674c7873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d93816b-cb5e-49b7-98bd-22de674c7873.jpg?1",
             "name": "Wanderlust",
             "text": "During the upkeep of enchanted creature's controller, Wanderlust deals 1 damage to him or her.",
             "colours": [
@@ -11397,7 +11397,7 @@
         },
         {
             "id": "2c901cd4-4f79-5f60-8941-f9fe61b962e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38912a6-0327-411a-9499-d659b635e2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38912a6-0327-411a-9499-d659b635e2bd.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -11430,7 +11430,7 @@
         },
         {
             "id": "b41113b0-8562-5400-af12-94039ad5dc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51bfbd4-2319-41eb-b694-72874c24b31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51bfbd4-2319-41eb-b694-72874c24b31a.jpg?1",
             "name": "Whirling Dervish",
             "text": "Protection from black\nIf Whirling Dervish damages any opponent, put a +1/+1 counter on it at end of turn.",
             "colours": [
@@ -11464,7 +11464,7 @@
         },
         {
             "id": "6ead9616-23d3-543d-bd0f-8ea6d55fd0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6630-d57c-47fd-af0f-b2e2c2025599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6630-d57c-47fd-af0f-b2e2c2025599.jpg?1",
             "name": "Wild Growth",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional o\nG.",
             "colours": [
@@ -11497,7 +11497,7 @@
         },
         {
             "id": "9a97948a-0939-5c27-84bd-1b87cc7e3f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b01c34-faa9-43a3-a3dc-0f966e88e089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b01c34-faa9-43a3-a3dc-0f966e88e089.jpg?1",
             "name": "Winter Blast",
             "text": "Tap X target creatures. Winter Blast deals 2 damage to each of those creatures with flying.",
             "colours": [
@@ -11528,7 +11528,7 @@
         },
         {
             "id": "15e00628-0d7b-5398-ab90-66f54a4a7d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6d1e8-0985-4560-aea2-7ad1925a2f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6d1e8-0985-4560-aea2-7ad1925a2f5a.jpg?1",
             "name": "Wolverine Pack",
             "text": "Rampage 2 (For each creature assigned to block it beyond the first, this creature gets +2/+2 until end of turn.)",
             "colours": [
@@ -11561,7 +11561,7 @@
         },
         {
             "id": "ea10c52e-fc00-5168-be71-26fe96a0da8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d06d6b2-2eff-4fc5-99e1-c6bc585a4926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d06d6b2-2eff-4fc5-99e1-c6bc585a4926.jpg?1",
             "name": "Wyluli Wolf",
             "text": "oc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -11594,7 +11594,7 @@
         },
         {
             "id": "872cc4c3-e4e0-5173-986f-7f71cab31f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e4ed4-4470-4b3b-98cd-e4a8660b9768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e4ed4-4470-4b3b-98cd-e4a8660b9768.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -11621,7 +11621,7 @@
         },
         {
             "id": "aec9325a-c672-5b9b-9dca-c9ce606803d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50871a5f-ad52-470a-840a-2277f43ea47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50871a5f-ad52-470a-840a-2277f43ea47b.jpg?1",
             "name": "Amulet of Kroog",
             "text": "o2, oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [],
@@ -11648,7 +11648,7 @@
         },
         {
             "id": "9db7c01a-55c4-50af-bb53-714e0a3465b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d917dd-243e-4df2-9a44-1c2eae6ff859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d917dd-243e-4df2-9a44-1c2eae6ff859.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Whenever a land comes into play, Ankh of Mishra deals 2 damage to that land's controller.",
             "colours": [],
@@ -11675,7 +11675,7 @@
         },
         {
             "id": "72bec6ee-7912-554e-b066-07c64d80ed72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab611c3-3a24-4033-864f-084b71317320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab611c3-3a24-4033-864f-084b71317320.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add two colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -11702,7 +11702,7 @@
         },
         {
             "id": "500b4524-a2db-5091-8327-c1568323805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee48bcd6-afb5-4023-9417-ed3126bcc31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee48bcd6-afb5-4023-9417-ed3126bcc31d.jpg?1",
             "name": "Ashnod's Transmogrant",
             "text": "oc\nT, Sacrifice Ashnod's Transmogrant: Put a +1/+1 counter on target nonartifact creature. That creature becomes an artifact creature permanently.",
             "colours": [],
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "15957305-76b2-517d-8d01-8c2a9adc1dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9791ab-1cc4-41ad-a721-57f214c357f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9791ab-1cc4-41ad-a721-57f214c357f8.jpg?1",
             "name": "Barbed Sextant",
             "text": "o1, oc\nT, Sacrifice Barbed Sextant: Add one mana of any color to your mana pool. Play this ability as a mana source. Draw a card at the beginning of the next turn.",
             "colours": [],
@@ -11756,7 +11756,7 @@
         },
         {
             "id": "dba02447-186d-578e-abc7-10cd49da324b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce3e79-c729-4efd-a2f3-5d2910ba2c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce3e79-c729-4efd-a2f3-5d2910ba2c3f.jpg?1",
             "name": "Barl's Cage",
             "text": "o3: Target creature does not untap during its controller's next untap phase.",
             "colours": [],
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "c3b4cdb6-ad40-52d7-94bf-72e718d72326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e2857f-f6eb-4091-b758-7bb508544170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e2857f-f6eb-4091-b758-7bb508544170.jpg?1",
             "name": "Battering Ram",
             "text": "Banding when attacking\nIf Battering Ram is blocked by any Wall, destroy that Wall at end of combat.",
             "colours": [],
@@ -11813,7 +11813,7 @@
         },
         {
             "id": "65b3355a-230a-5fc2-801a-8968a3e45d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1de13cc-65b4-4a72-8a53-a05a46a40f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1de13cc-65b4-4a72-8a53-a05a46a40f61.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o1, Sacrifice Bottle of Suleiman: Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Bottle of Suleiman deals 5 damage to you. Otherwise, put a Djinn token into play. Treat this token as a 5/5 artifact creature with flying.",
             "colours": [],
@@ -11840,7 +11840,7 @@
         },
         {
             "id": "98f30e50-658e-5558-ae55-52177d1ac187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34727679-9c42-4577-80c3-88495aa0e96d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34727679-9c42-4577-80c3-88495aa0e96d.jpg?1",
             "name": "Clay Statue",
             "text": "o2: Regenerate",
             "colours": [],
@@ -11870,7 +11870,7 @@
         },
         {
             "id": "e4d8f88d-3f38-531b-97bd-9862e331f31c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5507d5-7f1b-4cbf-8341-495c33e5ab6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5507d5-7f1b-4cbf-8341-495c33e5ab6c.jpg?1",
             "name": "Clockwork Beast",
             "text": "When Clockwork Beast comes into play, put seven +1/+0 counters on it. At the end of any combat in which Clockwork Beast attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Beast. You may have no more than seven of of these counters on Clockwork Beast. Use this ability only during your upkeep.",
             "colours": [],
@@ -11900,7 +11900,7 @@
         },
         {
             "id": "507e0d40-7544-53b0-a66f-4fb094ff53d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d83b9-4454-40c0-bac0-de736c634a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d83b9-4454-40c0-bac0-de736c634a53.jpg?1",
             "name": "Clockwork Steed",
             "text": "Clockwork Steed cannot be blocked by artifact creatures.\nWhen Clockwork Steed comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Steed attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Steed. You may have no more than four of these counters on Clockwork Steed. Use this ability only during your upkeep.",
             "colours": [],
@@ -11930,7 +11930,7 @@
         },
         {
             "id": "60e0630f-ac63-57da-8b8c-eb4541c11355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f1ffdd-897e-4a1d-bdd2-d9de0de5d5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f1ffdd-897e-4a1d-bdd2-d9de0de5d5a2.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample\nColossus of Sardia does not untap during your untap phase.\no9: Untap Colossus of Sardia. Use this ability only during your upkeep.",
             "colours": [],
@@ -11960,7 +11960,7 @@
         },
         {
             "id": "03d781e9-44fc-5c90-b872-2d9dd789daff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3a79-d7e5-46e2-bd9f-209e67294f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3a79-d7e5-46e2-bd9f-209e67294f82.jpg?1",
             "name": "Coral Helm",
             "text": "o3, Discard a card at random: Target creature gets +2/+2 until end of turn.",
             "colours": [],
@@ -11987,7 +11987,7 @@
         },
         {
             "id": "1714c49a-28c4-5dad-a110-1e9c56e4df80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b549e5-c25d-4688-b362-faab109ba092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b549e5-c25d-4688-b362-faab109ba092.jpg?1",
             "name": "Crown of the Ages",
             "text": "o4, oc\nT: Move target enchantment from one creature to another. The enchantment's new target must be legal.",
             "colours": [],
@@ -12014,7 +12014,7 @@
         },
         {
             "id": "9144ee6a-cd46-5fb3-a801-730492fdb056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf1c7de-73b5-415b-897b-085ab5776932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf1c7de-73b5-415b-897b-085ab5776932.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Gain 1 life. Use this ability only when a blue spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -12041,7 +12041,7 @@
         },
         {
             "id": "a2b6a27b-72f4-52c4-9028-a99dc3fa5650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f3d92-171f-45e6-b159-b83faad7f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f3d92-171f-45e6-b159-b83faad7f7fd.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "34126198-4299-5d51-8d41-98bd9177c5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c76a433-4760-4ebb-ab0c-d69bba7d7ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c76a433-4760-4ebb-ab0c-d69bba7d7ca1.jpg?1",
             "name": "Diabolic Machine",
             "text": "o3: Regenerate",
             "colours": [],
@@ -12101,7 +12101,7 @@
         },
         {
             "id": "48c311c6-5f14-5b3f-8b02-7d1d1f5b9f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d1107-a18c-4e25-86c7-8e09cba72a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d1107-a18c-4e25-86c7-8e09cba72a12.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into any graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -12128,7 +12128,7 @@
         },
         {
             "id": "4ae6f8dc-bc1d-5f90-8d41-39c0b05785de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f2e80-f7af-4b9d-bb0f-3de14ddf0b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f2e80-f7af-4b9d-bb0f-3de14ddf0b02.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player chooses and discards a card. Use this ability only during your turn.",
             "colours": [],
@@ -12155,7 +12155,7 @@
         },
         {
             "id": "c7a4a479-78b7-52d4-be84-0a0483ac1248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f26891-e624-4aa9-ad04-6db3933a74e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f26891-e624-4aa9-ad04-6db3933a74e9.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: +1/+0 until end of turn",
             "colours": [],
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "0d2ee163-b0a7-5b93-aa3a-3691e84fa98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5b60a9-3041-4524-9a53-ab3a597c20ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5b60a9-3041-4524-9a53-ab3a597c20ac.jpg?1",
             "name": "Elkin Bottle",
             "text": "o3, oc\nT: Set the top card of your library aside face up. You may play that card as though it were in your hand. At the beginning of your next turn, bury the card if you have not played it.",
             "colours": [],
@@ -12212,7 +12212,7 @@
         },
         {
             "id": "4cfb3a9d-e420-5498-87a6-108f7760e5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030301c9-b576-43ba-b05a-a52904c92be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030301c9-b576-43ba-b05a-a52904c92be9.jpg?1",
             "name": "Feldon's Cane",
             "text": "oc\nT, Remove Feldon's Cane from the game: Shuffle your graveyard into your library.",
             "colours": [],
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "deb654c3-3750-57a6-acb6-f1b8ecafebe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2716dacb-4fb7-4fa8-869d-22af82920564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2716dacb-4fb7-4fa8-869d-22af82920564.jpg?1",
             "name": "Fellwar Stone",
             "text": "oc\nT: Add to your mana pool one mana of any type that any opponent's lands can produce. Play this ability as a mana source.",
             "colours": [],
@@ -12266,7 +12266,7 @@
         },
         {
             "id": "07200afc-1406-5cc5-9fb2-a9e6fc9077f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5133a47c-bde3-49d5-ba44-196980ace436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5133a47c-bde3-49d5-ba44-196980ace436.jpg?1",
             "name": "Feroz's Ban",
             "text": "Summon spells cost an additional o2 to play.",
             "colours": [],
@@ -12293,7 +12293,7 @@
         },
         {
             "id": "a7eca833-c427-5b85-93f2-036e8e95efc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f33257-4539-4b33-86d5-26fedbc417b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f33257-4539-4b33-86d5-26fedbc417b1.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn. If that creature is put into any graveyard this turn, bury Flying Carpet.",
             "colours": [],
@@ -12320,7 +12320,7 @@
         },
         {
             "id": "b2e877b9-1cc0-5e54-b1d1-3397dd2eb78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726d567-ad74-4b77-bbd5-8a0902cdaf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726d567-ad74-4b77-bbd5-8a0902cdaf6a.jpg?1",
             "name": "Fountain of Youth",
             "text": "o2, oc\nT: Gain 1 life.",
             "colours": [],
@@ -12347,7 +12347,7 @@
         },
         {
             "id": "daeeceff-a93e-5e3f-bd50-d765a628a7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548045fe-5302-4295-9060-e85614bb9a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548045fe-5302-4295-9060-e85614bb9a91.jpg?1",
             "name": "Gauntlets of Chaos",
             "text": "o5, Sacrifice Gauntlets of Chaos: Exchange control of target artifact, creature, or land you control for control of target permanent of the same type that an opponent controls. Bury all enchantments played on those permanents.",
             "colours": [],
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "fa164117-fc2a-56f0-895f-8ebe4c6303e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a69e-1011-475b-b554-8cf5a25169f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a69e-1011-475b-b554-8cf5a25169f3.jpg?1",
             "name": "Glasses of Urza",
             "text": "oc\nT: Look at target player's hand.",
             "colours": [],
@@ -12401,7 +12401,7 @@
         },
         {
             "id": "0bf896a3-6d84-597b-b609-3c9f2a10aa71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0fe07-85b6-4179-859b-fbae74faab5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0fe07-85b6-4179-859b-fbae74faab5f.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "oc\nT: Grapeshot Catapult deals 1 damage to target creature with flying.",
             "colours": [],
@@ -12431,7 +12431,7 @@
         },
         {
             "id": "a697441f-a3b5-5139-b3fd-686369778986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9664a59d-182a-429b-a6f7-047b8b8e5ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9664a59d-182a-429b-a6f7-047b8b8e5ffe.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1, oc\nT: Target creature gains banding until end of turn.",
             "colours": [],
@@ -12458,7 +12458,7 @@
         },
         {
             "id": "9f48fda8-0e4c-5f6f-bb00-d819c0d7c563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a50b3bd-81b0-408d-ab73-9eadd2fb1eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a50b3bd-81b0-408d-ab73-9eadd2fb1eae.jpg?1",
             "name": "Howling Mine",
             "text": "During each player's draw phase, that player draws an additional card.",
             "colours": [],
@@ -12485,7 +12485,7 @@
         },
         {
             "id": "71883c8a-3143-59cf-b053-2dd16f74caae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbafc838-7458-4542-86f3-594326ec0691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbafc838-7458-4542-86f3-594326ec0691.jpg?1",
             "name": "Infinite Hourglass",
             "text": "During your upkeep, put a time counter on Infinite Hourglass.\nAll creatures get +X/+0, where X is equal to the number of time counters on Infinite Hourglass.\nAny player may pay o3 during any upkeep to remove a time counter from Infinite Hourglass.",
             "colours": [],
@@ -12512,7 +12512,7 @@
         },
         {
             "id": "94df0ad4-0745-5868-b383-c9994c23c827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcbaa97-49f8-41b4-8901-eb53f6c15faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcbaa97-49f8-41b4-8901-eb53f6c15faf.jpg?1",
             "name": "Iron Star",
             "text": "o1: Gain 1 life. Use this ability only when a red spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -12539,7 +12539,7 @@
         },
         {
             "id": "36231740-4ec6-5859-bdee-e7f402f3ed99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8085b-4bed-4b0b-b05e-5237bb896d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8085b-4bed-4b0b-b05e-5237bb896d00.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Gain 1 life. Use this ability only when a white spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "0373d099-cbe4-5431-b0ec-21d2af46ad2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a8f00d-e813-4cb7-8d09-1edae560f287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a8f00d-e813-4cb7-8d09-1edae560f287.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: Redirect all damage from any creature to yourself.",
             "colours": [],
@@ -12593,7 +12593,7 @@
         },
         {
             "id": "7cf5a64c-4731-5338-bc41-0f23ee82c68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe15fc-420f-49fe-a7d8-84dd74964ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe15fc-420f-49fe-a7d8-84dd74964ce5.jpg?1",
             "name": "Jalum Tome",
             "text": "o2, oc\nT: Draw a card, then choose and discard a card.",
             "colours": [],
@@ -12620,7 +12620,7 @@
         },
         {
             "id": "b0de140e-d27f-55b8-be07-37dadc9ab9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a9b1d-4046-484c-add9-567b3303cc98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a9b1d-4046-484c-add9-567b3303cc98.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3, oc\nT: Untap target creature.",
             "colours": [],
@@ -12647,7 +12647,7 @@
         },
         {
             "id": "3a42ab48-e716-57f0-9716-86b19870f704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0736c836-d90b-440c-bb6f-4b2eeaaa3d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0736c836-d90b-440c-bb6f-4b2eeaaa3d73.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw a card.",
             "colours": [],
@@ -12674,7 +12674,7 @@
         },
         {
             "id": "5aad4dfe-13f0-565b-add3-d119285ce852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10f2619-e723-4402-ae4e-79d762004477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10f2619-e723-4402-ae4e-79d762004477.jpg?1",
             "name": "Jester's Cap",
             "text": "o2, oc\nT, Sacrifice Jester's Cap: Look through target player's library and remove any three of those cards from the game. Shuffle that library afterwards.",
             "colours": [],
@@ -12701,7 +12701,7 @@
         },
         {
             "id": "0bb27381-f2e8-5482-87bc-010b1e899ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7aa8e-5873-4e18-8adb-1523c01d4e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7aa8e-5873-4e18-8adb-1523c01d4e86.jpg?1",
             "name": "Joven's Tools",
             "text": "o4, oc\nT: Target creature cannot be blocked this turn except by Walls.",
             "colours": [],
@@ -12728,7 +12728,7 @@
         },
         {
             "id": "313d2830-beae-538a-bd87-95ba8004a66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe1d1ae-bcc0-4b0d-a60f-f5ed30184329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe1d1ae-bcc0-4b0d-a60f-f5ed30184329.jpg?1",
             "name": "Library of Leng",
             "text": "Skip your discard phase.\nWhenever a spell or effect forces you to discard a card, you may instead discard that card to the top of your library.",
             "colours": [],
@@ -12755,7 +12755,7 @@
         },
         {
             "id": "2612c63c-dc69-52d1-aae7-85ee8fae17bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e9fec4-1e0a-4206-ab2b-cc2543cba667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e9fec4-1e0a-4206-ab2b-cc2543cba667.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault does not untap during your untap phase.\nAt the end of your upkeep, if Mana Vault is tapped, it deals 1 damage to you.\no4: Untap Mana Vault at end of upkeep. Use this ability only during your upkeep.\noc\nT: Add three colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -12782,7 +12782,7 @@
         },
         {
             "id": "b7947d79-e758-51f3-a273-69868522aa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391d903-1370-4a3a-9919-7a07e580a26c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391d903-1370-4a3a-9919-7a07e580a26c.jpg?1",
             "name": "Meekstone",
             "text": "Creatures with power 3 or greater do not untap during their controllers' untap phases.",
             "colours": [],
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "dd3440ee-f90d-5ba2-8298-cf07ee96bd9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e0b9ff-cf4c-446a-b706-58e5c496599e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e0b9ff-cf4c-446a-b706-58e5c496599e.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Put the top two cards of target player's library into his or her graveyard.",
             "colours": [],
@@ -12836,7 +12836,7 @@
         },
         {
             "id": "adc19b3c-24c3-5606-9203-07ab8c2bf513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9652c405-17fb-4505-8470-8a2969c73b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9652c405-17fb-4505-8470-8a2969c73b6b.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk comes into play tapped.\no1, oc\nT: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -12863,7 +12863,7 @@
         },
         {
             "id": "acf97d3a-82c1-5512-b8e9-26927b432e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0672d1-1d47-42ea-b8b0-95c400b0f78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0672d1-1d47-42ea-b8b0-95c400b0f78e.jpg?1",
             "name": "Obelisk of Undoing",
             "text": "o6, oc\nT: Return target permanent you control and own to your hand.",
             "colours": [],
@@ -12890,7 +12890,7 @@
         },
         {
             "id": "fd0f4cf2-2145-53e1-9439-8f0fffd4b3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00427d72-b140-45eb-b2ec-2ac2dab16966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00427d72-b140-45eb-b2ec-2ac2dab16966.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -12920,7 +12920,7 @@
         },
         {
             "id": "32f47529-7dc8-5b9c-bad8-b37cd7fb916d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2334ac3-2a58-49ba-902e-98dbad51547b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2334ac3-2a58-49ba-902e-98dbad51547b.jpg?1",
             "name": "Pentagram of the Ages",
             "text": "o4, oc\nT: Prevent all damage to you from one source. Treat further damage from that source normally.",
             "colours": [],
@@ -12947,7 +12947,7 @@
         },
         {
             "id": "9c3002f4-f817-5c44-b6f8-1884405853e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f731f-78a6-444e-9a43-85446fa38f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f731f-78a6-444e-9a43-85446fa38f30.jpg?1",
             "name": "Primal Clay",
             "text": "When you play Primal Clay, choose one\u2014Primal Clay is a 2/2 artifact creature with flying; or Primal Clay is a 3/3 artifact creature; or Primal Clay is a 1/6 artifact creature that counts as a Wall.",
             "colours": [],
@@ -12977,7 +12977,7 @@
         },
         {
             "id": "31a5ef1a-df22-5df2-8f12-dab053ba1d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1589724f-bec2-43a9-824a-1e85020731a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1589724f-bec2-43a9-824a-1e85020731a4.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -13004,7 +13004,7 @@
         },
         {
             "id": "a923d9d8-5b5f-59aa-8b02-beb8c82df361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08f89d-2ce3-4686-a8bd-ed982280ae4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08f89d-2ce3-4686-a8bd-ed982280ae4d.jpg?1",
             "name": "Serpent Generator",
             "text": "o4, oc\nT: Put a Poison Snake token into play. Treat this token as a 1/1 artifact creature. If any Poison Snake damages any player, he or she gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [],
@@ -13031,7 +13031,7 @@
         },
         {
             "id": "9a040a5b-4d0f-59b6-bce6-7ceb53f8f97a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aca05e-87c0-4c50-af47-37c61c55934d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aca05e-87c0-4c50-af47-37c61c55934d.jpg?1",
             "name": "Shapeshifter",
             "text": "Shapeshifter has total power and toughness of 7, divided any way you choose, though neither can be more than 7.\nWhen you play Shapeshifter, choose its power and toughness.\nDuring your upkeep, choose Shapeshifter's power and toughness.",
             "colours": [],
@@ -13061,7 +13061,7 @@
         },
         {
             "id": "76d475fe-cd86-572e-b301-994a5c4f1c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6baa736-60c3-4192-a5d3-150c90c31847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6baa736-60c3-4192-a5d3-150c90c31847.jpg?1",
             "name": "Skull Catapult",
             "text": "o1, oc\nT, Sacrifice a creature: Skull Catapult deals 2 damage to target creature or player.",
             "colours": [],
@@ -13088,7 +13088,7 @@
         },
         {
             "id": "28759cc4-eb2e-5185-9bb5-d5e810d96078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d3dc9-4bd0-440e-9436-c565f500e126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d3dc9-4bd0-440e-9436-c565f500e126.jpg?1",
             "name": "Soul Net",
             "text": "o1: Gain 1 life. Use this ability only when a creature is put into any graveyard from play and only once for each such creature.",
             "colours": [],
@@ -13115,7 +13115,7 @@
         },
         {
             "id": "fadb23f6-0fd7-50ca-a1ae-0f5632dfe309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe0113-8ac4-4d89-8ed3-010ccb57f3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe0113-8ac4-4d89-8ed3-010ccb57f3f0.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "You may choose not to untap Tawnos's Weaponry during your untap phase.\no2, oc\nT: Target creature gets +1/+1 as long as Tawnos's Weaponry remains tapped.",
             "colours": [],
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "ee954eb9-fe49-5f88-a2b8-9202744738f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c72d8-cee1-4a67-a394-b7dfe89bbd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c72d8-cee1-4a67-a394-b7dfe89bbd2e.jpg?1",
             "name": "The Hive",
             "text": "o5, oc\nT: Put a Wasp token into play. Treat this token as a 1/1 artifact creature with flying.",
             "colours": [],
@@ -13169,7 +13169,7 @@
         },
         {
             "id": "5d4f07f5-f915-55b0-86c9-5d47191091ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631db179-e23c-4099-9214-5bd347e4aa9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631db179-e23c-4099-9214-5bd347e4aa9e.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Gain 1 life. Use this ability only when a black spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -13196,7 +13196,7 @@
         },
         {
             "id": "bdb963c1-3693-5363-8bd2-5d05260188ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b9a42-29a5-47f9-9c65-db9f3d432bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b9a42-29a5-47f9-9c65-db9f3d432bf5.jpg?1",
             "name": "Time Bomb",
             "text": "During your upkeep, put a time counter on Time Bomb.\no1, oc\nT, Sacrifice Time Bomb: Time Bomb deals to each creature and player an amount of damage equal to the number of time counters on Time Bomb.",
             "colours": [],
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "875b382a-70bc-5423-a19a-ac084478bae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bd9559-1a8f-47d0-af6b-d0681cae4060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bd9559-1a8f-47d0-af6b-d0681cae4060.jpg?1",
             "name": "Urza's Avenger",
             "text": "o0: -1/-1 and your choice of banding, flying, first strike, or trample until end of turn",
             "colours": [],
@@ -13253,7 +13253,7 @@
         },
         {
             "id": "4eff710e-528e-5471-b76d-d281fb8d3eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876c1811-990c-41ca-874f-fd0512b59d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876c1811-990c-41ca-874f-fd0512b59d06.jpg?1",
             "name": "Urza's Bauble",
             "text": "oc\nT, Sacrifice Urza's Bauble: Choose a card at random from target player's hand and look at that card. Draw a card at the beginning of the next turn.",
             "colours": [],
@@ -13280,7 +13280,7 @@
         },
         {
             "id": "0e716ba5-29e5-5a1b-9865-e55053348935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a116c9-2f80-4e76-b158-c23f101872db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a116c9-2f80-4e76-b158-c23f101872db.jpg?1",
             "name": "Wall of Spears",
             "text": "First strike\nWall of Spears counts as a Wall.",
             "colours": [],
@@ -13310,7 +13310,7 @@
         },
         {
             "id": "54cd66c1-1694-553e-9e88-f521c93b9c60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a674ec8-5531-4d06-aa57-929c6ac29238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a674ec8-5531-4d06-aa57-929c6ac29238.jpg?1",
             "name": "Winter Orb",
             "text": "Players cannot untap more than one land during their untap phases.",
             "colours": [],
@@ -13337,7 +13337,7 @@
         },
         {
             "id": "2668d2e2-7f38-501e-a550-3f431d193ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d05202-da8d-44b8-8a01-d8a16a2b1898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d05202-da8d-44b8-8a01-d8a16a2b1898.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Gain 1 life. Use this ability only when a green spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -13364,7 +13364,7 @@
         },
         {
             "id": "ac71cdac-6e55-59bb-812e-3cd022dfc371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1e5f1-4665-4afc-83e4-4968df72eb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1e5f1-4665-4afc-83e4-4968df72eb8f.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "d8f70200-5fe0-5d59-bfa4-b7956015c65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8913994-c3e7-4d9e-9409-a8409ce68442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8913994-c3e7-4d9e-9409-a8409ce68442.jpg?1",
             "name": "Bottomless Vault",
             "text": "Bottomless Vault comes into play tapped.\nYou may choose not to untap Bottomless Vault during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Bottomless Vault: Add an amount of o\nB equal to X to your mana pool.",
             "colours": [],
@@ -13423,7 +13423,7 @@
         },
         {
             "id": "d0b76583-6692-5235-9d55-099922a6706c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6793b15-37fb-495e-b5e2-22c1df4cdc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6793b15-37fb-495e-b5e2-22c1df4cdc05.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "565bf8b1-3d78-53dc-abac-a9d9ed2fdb0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56816a2d-4faa-4fbd-bf1a-35fa3e90ccf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56816a2d-4faa-4fbd-bf1a-35fa3e90ccf6.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -13480,7 +13480,7 @@
         },
         {
             "id": "cbc8c37f-a86d-5212-8eb5-2ede17d4f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cb55f0-f0e8-4644-8c19-54efe5854973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cb55f0-f0e8-4644-8c19-54efe5854973.jpg?1",
             "name": "Dwarven Hold",
             "text": "Dwarven Hold comes into play tapped.\nYou may choose not to untap Dwarven Hold during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Dwarven Hold: Add an amount of o\nR equal to X to your mana pool.",
             "colours": [],
@@ -13509,7 +13509,7 @@
         },
         {
             "id": "1aa8bd00-8840-5b6f-be19-6fc48e642250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fc9a8-cc3c-43a1-89dd-c9a8fa72bdc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fc9a8-cc3c-43a1-89dd-c9a8fa72bdc6.jpg?1",
             "name": "Dwarven Ruins",
             "text": "Dwarven Ruins comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Dwarven Ruins: Add o\nRo\nR to your mana pool.",
             "colours": [],
@@ -13538,7 +13538,7 @@
         },
         {
             "id": "f316d004-4754-5e08-9b80-c149b50c7760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509266-2bd5-4958-a497-935e004cc20f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509266-2bd5-4958-a497-935e004cc20f.jpg?1",
             "name": "Ebon Stronghold",
             "text": "Ebon Stronghold comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Ebon Stronghold: Add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -13567,7 +13567,7 @@
         },
         {
             "id": "a27e5caf-482f-5936-a9a2-60df91b696be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a1d66-7694-4e12-a4d6-34ca36656db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a1d66-7694-4e12-a4d6-34ca36656db4.jpg?1",
             "name": "Havenwood Battleground",
             "text": "Havenwood Battleground comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Havenwood Battleground: Add o\nGo\nG to your mana pool.",
             "colours": [],
@@ -13596,7 +13596,7 @@
         },
         {
             "id": "3aa015f9-8a8f-580e-95e6-155d33d6e35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d30a4-a24e-4537-9230-bf6f57fbcd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d30a4-a24e-4537-9230-bf6f57fbcd98.jpg?1",
             "name": "Hollow Trees",
             "text": "Hollow Trees comes into play tapped.\nYou may choose not to untap Hollow Trees during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Hollow Trees: Add an amount of o\nG equal to X to your mana pool.",
             "colours": [],
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "75c73cea-ce88-5657-b569-bd4761715b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68c45d3-0f3c-4429-a93e-4ca70ea6b1a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68c45d3-0f3c-4429-a93e-4ca70ea6b1a4.jpg?1",
             "name": "Icatian Store",
             "text": "Icatian Store comes into play tapped.\nYou may choose not to untap Icatian Store during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Icatian Store: Add an amount of o\nW equal to X to your mana pool.",
             "colours": [],
@@ -13654,7 +13654,7 @@
         },
         {
             "id": "45afd269-d65f-5e3a-91b8-58c4d7ce816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550a334-f185-4f1f-8759-d320b154c62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550a334-f185-4f1f-8759-d320b154c62f.jpg?1",
             "name": "Ice Floe",
             "text": "You may choose not to untap Ice Floe during your untap phase.\noc\nT: Tap target creature without flying that is attacking you. As long as Ice Floe remains tapped, that creature does not untap during its controller's untap phase.",
             "colours": [],
@@ -13681,7 +13681,7 @@
         },
         {
             "id": "2569780a-88ef-5db2-a9bf-a19e959d9793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d59e6e-0154-4c89-a58f-521e3424581b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d59e6e-0154-4c89-a58f-521e3424581b.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -13711,7 +13711,7 @@
         },
         {
             "id": "627ecb97-37cf-539a-b7d8-641b0758aaae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ec8a0-5cde-4c24-b605-b5f53553d065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ec8a0-5cde-4c24-b605-b5f53553d065.jpg?1",
             "name": "Ruins of Trokair",
             "text": "Ruins of Trokair comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Ruins of Trokair: Add o\nWo\nW to your mana pool.",
             "colours": [],
@@ -13740,7 +13740,7 @@
         },
         {
             "id": "b9d6be32-2cd8-5460-856f-f14cd0a3beb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769de45-903f-4269-a100-9ceca1df26ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769de45-903f-4269-a100-9ceca1df26ac.jpg?1",
             "name": "Sand Silos",
             "text": "Sand Silos comes into play tapped.\nYou may choose not to untap Sand Silos during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Sand Silos: Add an amount of o\nU equal to X to your mana pool.",
             "colours": [],
@@ -13769,7 +13769,7 @@
         },
         {
             "id": "63221e47-a497-52bc-8a42-313b8c01a4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a2097d-5acb-46d5-ac07-021fa9da4026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a2097d-5acb-46d5-ac07-021fa9da4026.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -13799,7 +13799,7 @@
         },
         {
             "id": "7272c44b-4da5-540f-b86d-35555f9a6b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22744530-792f-4098-ad2f-fee1a02b04b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22744530-792f-4098-ad2f-fee1a02b04b1.jpg?1",
             "name": "Svyelunite Temple",
             "text": "Svyelunite Temple comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Svyelunite Temple: Add o\nUo\nU to your mana pool.",
             "colours": [],
@@ -13828,7 +13828,7 @@
         },
         {
             "id": "a1e7303e-2dc1-558a-a7a5-b0bde670d8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9efd79-1b1d-4e02-8922-0154ad20e4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9efd79-1b1d-4e02-8922-0154ad20e4d4.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -13858,7 +13858,7 @@
         },
         {
             "id": "53048d45-9a4e-5b8f-b50f-14682383c3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6c9f3e-6df7-459c-a1b0-d628f17bb7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6c9f3e-6df7-459c-a1b0-d628f17bb7a6.jpg?1",
             "name": "Urza's Mine",
             "text": "oc\nT: Add one colorless mana to your mana pool. If you control Urza's Mine, Urza's Power Plant, and Urza's Tower, add two colorless mana to your mana pool instead of one.",
             "colours": [],
@@ -13888,7 +13888,7 @@
         },
         {
             "id": "2479c9f0-b76d-5ee6-9902-3e1150375437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a294bd-e6f6-4b88-b34c-135aff907b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a294bd-e6f6-4b88-b34c-135aff907b17.jpg?1",
             "name": "Urza's Power Plant",
             "text": "oc\nT: Add one colorless mana to your mana pool. If you control Urza's Mine, Urza's Power Plant, and Urza's Tower, add two colorless mana to your mana pool instead of one.",
             "colours": [],
@@ -13918,7 +13918,7 @@
         },
         {
             "id": "15d47e68-e7ea-52ed-9496-111d3c5aa4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb66579-0840-4ec3-aa6a-731874662dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb66579-0840-4ec3-aa6a-731874662dbb.jpg?1",
             "name": "Urza's Tower",
             "text": "oc\nT: Add one colorless mana to your mana pool. If you control Urza's Mine, Urza's Power Plant, and Urza's Tower, add three colorless mana to your mana pool instead of one.",
             "colours": [],
@@ -13948,7 +13948,7 @@
         },
         {
             "id": "24e70c1e-f19e-5fe4-8841-127e98a57620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cab2ebd-6ab7-4273-bda3-d7dea81b52c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cab2ebd-6ab7-4273-bda3-d7dea81b52c3.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -13985,7 +13985,7 @@
         },
         {
             "id": "b5816194-2e99-5b34-877d-88ad27077d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600cc3f3-5400-40f4-99ff-8a4a905e79cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600cc3f3-5400-40f4-99ff-8a4a905e79cf.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -14022,7 +14022,7 @@
         },
         {
             "id": "80238632-b16e-5d17-a853-c2a4566fd911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38789fff-0207-4b38-9bfd-5464ab62a533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38789fff-0207-4b38-9bfd-5464ab62a533.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -14059,7 +14059,7 @@
         },
         {
             "id": "f97c670a-ab28-5385-a653-8d40ac06fbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1c6830-758e-4242-85f7-3f20b872272c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1c6830-758e-4242-85f7-3f20b872272c.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -14096,7 +14096,7 @@
         },
         {
             "id": "e3e9a356-3e13-5b99-9734-a8c604e390ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8820e22-44ee-4ccf-a1fb-f93d98b8b494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8820e22-44ee-4ccf-a1fb-f93d98b8b494.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "257e0275-21d2-539d-baf4-59fcafcc32f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbf2762-1e9c-4d7c-84d0-8561d9a41735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbf2762-1e9c-4d7c-84d0-8561d9a41735.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14170,7 +14170,7 @@
         },
         {
             "id": "d1df51c2-a741-5857-b23f-11af95a23118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09376cac-44bd-42c4-9c07-9e4d6c972a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09376cac-44bd-42c4-9c07-9e4d6c972a64.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "285dfc75-adfe-5dd0-9d4d-00d1541209f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1218e0-8c75-4f8e-b317-051ce84949a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1218e0-8c75-4f8e-b317-051ce84949a5.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "cbaaa977-9f8b-5830-ace1-8a6544297e7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc8f8cb-dc67-4549-be2f-f4d4057065a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc8f8cb-dc67-4549-be2f-f4d4057065a3.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14281,7 +14281,7 @@
         },
         {
             "id": "4cc4a59c-72da-58a1-8dd8-9b1f61a28d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df95545-fe5e-47a5-99d8-1776e02c5713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df95545-fe5e-47a5-99d8-1776e02c5713.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14318,7 +14318,7 @@
         },
         {
             "id": "dbedf2fb-aa81-5faa-8a14-ef675471cea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31228d3c-08e4-4042-a1a1-db8dff3177d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31228d3c-08e4-4042-a1a1-db8dff3177d9.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "90a0b880-196a-58c8-abe6-8b6b47552a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e09e49-1a87-4967-8557-6d331c48a563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e09e49-1a87-4967-8557-6d331c48a563.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14392,7 +14392,7 @@
         },
         {
             "id": "6bbb66a9-013e-5a0e-b505-42e767fffec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b08a29-8b53-44c9-82a0-ac689c9feeb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b08a29-8b53-44c9-82a0-ac689c9feeb5.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14429,7 +14429,7 @@
         },
         {
             "id": "85a5f98c-6fe4-5dd1-a2f9-b73d75fe7e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0916a2-e2f1-42b5-9f2c-b6a18a605138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0916a2-e2f1-42b5-9f2c-b6a18a605138.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14466,7 +14466,7 @@
         },
         {
             "id": "4d20c1aa-1753-54bb-bde3-bd14b10ebccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5d88e-1699-4ce3-a4aa-3e8d1ef2bc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5d88e-1699-4ce3-a4aa-3e8d1ef2bc39.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14503,7 +14503,7 @@
         },
         {
             "id": "96e8547f-ea0f-5f18-a1ab-4fdf15f520e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dfeb23-204c-4e48-8a23-c69daf92340f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dfeb23-204c-4e48-8a23-c69daf92340f.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14540,7 +14540,7 @@
         },
         {
             "id": "c95398e2-3f05-568c-b8c2-ade0c5ecb4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04eb20ea-1784-475e-a612-48057e5578c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04eb20ea-1784-475e-a612-48057e5578c1.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -14577,7 +14577,7 @@
         },
         {
             "id": "c4688bdd-c19d-5927-8d01-fc314bb4365e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13635ba7-0635-4c16-9e14-444470e06287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13635ba7-0635-4c16-9e14-444470e06287.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -14614,7 +14614,7 @@
         },
         {
             "id": "05e85f83-53e0-57de-a9ed-0f91d4f2a7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925e07e8-a897-443f-8962-ef11fc41002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925e07e8-a897-443f-8962-ef11fc41002a.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -14651,7 +14651,7 @@
         },
         {
             "id": "bed7917a-fd4b-571d-8034-6ca9b1533ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdbb450-4b80-4f81-9992-ee8fbeeb1857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdbb450-4b80-4f81-9992-ee8fbeeb1857.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/6ED.json
+++ b/Assets/Resources/Sets/6ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4c133233-fd46-595a-88f1-0fb33c56d4d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdb3a14-c5cc-4655-9b0c-e8be153413af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdb3a14-c5cc-4655-9b0c-e8be153413af.jpg?1",
             "name": "Animate Wall",
             "text": "Enchanted creature can attack as though it weren't a Wall.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "34b733ae-d709-5e56-b66c-379ae512d361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734c616-cb19-4ed6-af7f-fc077f299e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734c616-cb19-4ed6-af7f-fc077f299e6e.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking doesn't cause Archangel to tap.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "68cd5d1f-0315-5316-b3a7-a1011e8384ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95608d51-9ec0-497c-a065-15adb7eff242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95608d51-9ec0-497c-a065-15adb7eff242.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "ca6b0c3c-bed0-5337-a679-2063aa9c31df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf3abe6-0b86-4010-8fc6-616af77b4ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf3abe6-0b86-4010-8fc6-616af77b4ace.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "06213ae0-94d5-53d2-8c61-0595fe672229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1b462d-4b0f-40cf-89a0-17a3e1c8a0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1b462d-4b0f-40cf-89a0-17a3e1c8a0ba.jpg?1",
             "name": "Armored Pegasus",
             "text": "Flying",
             "colours": [
@@ -168,7 +168,7 @@
         },
         {
             "id": "a13a2e22-f577-507c-a901-0f96ca141c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a77e784-d7a8-4b92-8765-375ad70b929e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a77e784-d7a8-4b92-8765-375ad70b929e.jpg?1",
             "name": "Castle",
             "text": "Untapped creatures you control get +0/+2.",
             "colours": [
@@ -199,7 +199,7 @@
         },
         {
             "id": "bba268ef-ff98-5a8b-93b3-e8e82102fb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a51b3c5-7b4a-4ed3-be33-5b854c005b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a51b3c5-7b4a-4ed3-be33-5b854c005b99.jpg?1",
             "name": "Celestial Dawn",
             "text": "Nonland cards you own that aren't in play are white. Nonland permanents you control are white. Lands you control are plains. Colored mana symbols in the costs on all those cards and permanents are o\nW.",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "fdc1e17a-33c9-5495-8a69-45131682a0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605bbcc8-973b-4e06-8c33-7e444d03fcd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605bbcc8-973b-4e06-8c33-7e444d03fcd8.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -261,7 +261,7 @@
         },
         {
             "id": "774645d1-e0fa-5dfd-80ce-9f0d923b8961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286368f3-65a6-4858-ac7f-edb06a741151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286368f3-65a6-4858-ac7f-edb06a741151.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: The next time a blue source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -292,7 +292,7 @@
         },
         {
             "id": "79d3bf12-53ee-56b4-8bed-9ce23d059f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3187cbd-7925-467b-a745-a0050045900b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3187cbd-7925-467b-a745-a0050045900b.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: The next time a green source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "8ee2d15a-13bc-5706-9795-bc82b7bb6a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3357139a-8b8b-47c5-a35b-3ed98968ba4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3357139a-8b8b-47c5-a35b-3ed98968ba4d.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "7750569b-3948-5666-bf0f-56fc1123a05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b7a978-692e-4015-9b90-e51ee98c5e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b7a978-692e-4015-9b90-e51ee98c5e3e.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: The next time a white source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -385,7 +385,7 @@
         },
         {
             "id": "65a516c2-50fd-50ce-a19d-4b113fd0934c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f5f07-f692-4531-81b6-31813574ec12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f5f07-f692-4531-81b6-31813574ec12.jpg?1",
             "name": "Crusade",
             "text": "White creatures get +1/+1.",
             "colours": [
@@ -416,7 +416,7 @@
         },
         {
             "id": "ed60ae22-bcce-514d-9daf-e390056206f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795a1d6-9caf-472a-a349-fca97bccf8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795a1d6-9caf-472a-a349-fca97bccf8e2.jpg?1",
             "name": "Daraja Griffin",
             "text": "Flying\nSacrifice Daraja Griffin: Destroy target black creature.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "81653e43-7cf2-5583-addd-9467aab4eac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97985bb-75ab-454e-894d-963890043caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97985bb-75ab-454e-894d-963890043caf.jpg?1",
             "name": "D'Avenant Archer",
             "text": "oc\nT: D'Avenant Archer deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "751d31cd-ff3e-5872-9253-dabb5e6b7e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47578ce0-dbaa-4a15-b46c-2fd2cb352be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47578ce0-dbaa-4a15-b46c-2fd2cb352be9.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "c02421b5-10d1-5192-bad5-0520cb696ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d2e46-814b-40cb-81a0-8d89285bf196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d2e46-814b-40cb-81a0-8d89285bf196.jpg?1",
             "name": "Divine Transformation",
             "text": "Enchanted creature gets +3/+3.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "7d1e2fc8-9e04-531d-9249-59d7f9977405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eec4ac-7d28-4f76-a1d5-a0a19c142514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eec4ac-7d28-4f76-a1d5-a0a19c142514.jpg?1",
             "name": "Ekundu Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "091cd056-1c0c-5f06-820c-de7935329b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869da95-2c47-4796-aadc-50652ebb4d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869da95-2c47-4796-aadc-50652ebb4d03.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "49eb435f-5ad6-57a5-9fb9-fc13c1b3da31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1733e2-bee2-4b85-b165-d4329402578b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1733e2-bee2-4b85-b165-d4329402578b.jpg?1",
             "name": "Ethereal Champion",
             "text": "Pay 1 life: Prevent the next 1 damage to Ethereal Champion this turn.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "7c8530db-2ec1-594c-bb32-42ba1d11398b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e3ca4-5b56-40bb-bec7-c92fc7eb50d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e3ca4-5b56-40bb-bec7-c92fc7eb50d2.jpg?1",
             "name": "Exile",
             "text": "Remove target nonwhite attacking creature from the game. You gain life equal to its toughness.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "3b2624ba-0e7d-5a19-ae4e-a898ad38fa79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4953ac06-dc8c-4a9c-8ff6-8e4432dae91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4953ac06-dc8c-4a9c-8ff6-8e4432dae91f.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage to target creature or player this turn.",
             "colours": [
@@ -707,7 +707,7 @@
         },
         {
             "id": "8956a292-120e-5896-8448-7ccac70cdcd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c587228-b633-4049-beb8-e45aae967167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c587228-b633-4049-beb8-e45aae967167.jpg?1",
             "name": "Heavy Ballista",
             "text": "oc\nT: Heavy Ballista deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "f68c5391-315d-51e4-aa87-48abc1b17033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a0f233-895e-4072-8339-c9448110d3e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a0f233-895e-4072-8339-c9448110d3e8.jpg?1",
             "name": "Hero's Resolve",
             "text": "Enchanted creature gets +1/+5.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "09410ad9-90eb-578b-b9e4-f971058ebc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7582903-57b0-42e6-991c-0f93ab9172d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7582903-57b0-42e6-991c-0f93ab9172d0.jpg?1",
             "name": "Icatian Town",
             "text": "Put four 1/1 white Citizen creature tokens into play.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "c9a21aa6-dc8b-5097-a915-72895732a773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c911f-917a-4c3e-ad35-2a01c25339e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c911f-917a-4c3e-ad35-2a01c25339e9.jpg?1",
             "name": "Infantry Veteran",
             "text": "oc\nT: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "3bab7e35-57a5-5dd2-9943-1387e8fac83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d53f6-4cec-4c91-a507-39038d300b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d53f6-4cec-4c91-a507-39038d300b00.jpg?1",
             "name": "Kismet",
             "text": "Artifacts, creatures, and lands your opponents play come into play tapped.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "6d8ded94-4a30-5624-aee6-d3ac7f4027af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e65e795-84e2-44c9-9f20-469e8c59f147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e65e795-84e2-44c9-9f20-469e8c59f147.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: All combat damage that would be dealt to you by unblocked creatures this turn is dealt to Kjeldoran Royal Guard instead.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "428f3662-ac13-533b-9a22-58b6fec8d5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5af047-7d98-4ba9-9ce1-c67563c19866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5af047-7d98-4ba9-9ce1-c67563c19866.jpg?1",
             "name": "Light of Day",
             "text": "Black creatures can't attack or block.",
             "colours": [
@@ -935,7 +935,7 @@
         },
         {
             "id": "055d0e85-2cd2-52cc-9e58-84d3d12bc004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdac001-4cfb-4991-ac70-d430750d5047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdac001-4cfb-4991-ac70-d430750d5047.jpg?1",
             "name": "Longbow Archer",
             "text": "First strike\nLongbow Archer can block as though it had flying.",
             "colours": [
@@ -970,7 +970,7 @@
         },
         {
             "id": "0c5b6fb7-03da-53e1-ac38-7851b0c67d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ce1b8e-13ba-4eed-a445-435300f3101e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ce1b8e-13ba-4eed-a445-435300f3101e.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW Mesa Falcon gets +0/+1 until end of turn.",
             "colours": [
@@ -1003,7 +1003,7 @@
         },
         {
             "id": "92523a80-77a3-5547-9536-65469f1d30f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760cf598-41e1-4cdc-9a30-964e67ffaf52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760cf598-41e1-4cdc-9a30-964e67ffaf52.jpg?1",
             "name": "Order of the Sacred Torch",
             "text": "oc\nT, Pay 1 life: Counter target black spell.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "4c783738-154d-504a-8cec-14bfa20bcb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d0ac2-08aa-4f3b-9616-006c0bf09f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d0ac2-08aa-4f3b-9616-006c0bf09f59.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "84042482-ccfb-5df0-8c71-10771306e836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efee309-2eba-4702-9361-0f75043922bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efee309-2eba-4702-9361-0f75043922bb.jpg?1",
             "name": "Pearl Dragon",
             "text": "Flying\no1oo\nW Pearl Dragon gets +0/+1 until end of turn.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "c57f48ab-27c9-522b-9be6-09e6418d7239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ca9b1c-fead-4bb6-800f-8b762a82fda7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ca9b1c-fead-4bb6-800f-8b762a82fda7.jpg?1",
             "name": "Regal Unicorn",
             "text": "",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "fd44d922-11bf-55da-93b9-2eb6628c9cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cdfb23-3c62-4312-a503-e30be384e3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cdfb23-3c62-4312-a503-e30be384e3ab.jpg?1",
             "name": "Remedy",
             "text": "Prevent the next 5 damage this turn divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "fccc7aed-bcd9-592a-bf5f-fef98b6b2078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229be020-de00-4985-b6f0-e6276018591e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229be020-de00-4985-b6f0-e6276018591e.jpg?1",
             "name": "Reprisal",
             "text": "Destroy target creature with power 4 or greater. It can't be regenerated.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "ba1e4f51-5c6e-576b-9865-c183e583267f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abf09d8-f972-4b81-80e9-70fb4a33ed56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abf09d8-f972-4b81-80e9-70fb4a33ed56.jpg?1",
             "name": "Resistance Fighter",
             "text": "Sacrifice Resistance Fighter: Target creature deals no combat damage this turn.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "121f4121-f11d-5e67-a5ad-16425d3f813c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1040133a-f80d-48dc-a50b-a11e5b793a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1040133a-f80d-48dc-a50b-a11e5b793a2b.jpg?1",
             "name": "Reverse Damage",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "d880ef34-3625-51c5-a12a-a596396ab4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1166d39-e186-4bb0-8ca4-ccc0200d13de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1166d39-e186-4bb0-8ca4-ccc0200d13de.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent the next 1 damage to target creature or player this turn.",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "43484472-949b-59be-a38f-473121cfde64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b37593d-13e7-4489-84bc-7074032b6f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b37593d-13e7-4489-84bc-7074032b6f05.jpg?1",
             "name": "Serenity",
             "text": "At the beginning of your upkeep, destroy all artifacts and enchantments. They can't be regenerated.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "f0fc4cfe-980a-5af5-b719-8b190ba79e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6751671-9ef9-45f2-8e27-8c896936929a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6751671-9ef9-45f2-8e27-8c896936929a.jpg?1",
             "name": "Serra's Blessing",
             "text": "Attacking doesn't cause creatures you control to tap.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "13194d28-20e5-57b1-80cf-d4f1131f10b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb60c6-d5e9-474f-a20f-8f705e7372cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb60c6-d5e9-474f-a20f-8f705e7372cd.jpg?1",
             "name": "Spirit Link",
             "text": "Whenever enchanted creature deals damage, you gain life equal to the damage dealt this way.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "8863123d-22b1-55c1-8cd0-28ced7fa9630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7db7c36-0992-413d-851b-0c7e095d7a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7db7c36-0992-413d-851b-0c7e095d7a6e.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking doesn't cause Standing Troops to tap.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "7f11d449-72cf-5171-ae1f-69f26ef75b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2c54f-a1f4-4015-a4f3-8cd360fa466d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2c54f-a1f4-4015-a4f3-8cd360fa466d.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, you gain 4 life.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "e69b8d38-4e71-5c5d-875e-7036b5e60e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b55e90-021e-48be-8abd-177e39200d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b55e90-021e-48be-8abd-177e39200d15.jpg?1",
             "name": "Sunweb",
             "text": "(Walls can't attack.)\nFlying\nSunweb can't block creatures with power 2 or less.",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "54ba611c-692f-52d3-ace9-5af164b4c4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61094858-b8a8-425f-9c96-fac4fc6ecae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61094858-b8a8-425f-9c96-fac4fc6ecae8.jpg?1",
             "name": "Tariff",
             "text": "Each player chooses a creature with the highest converted mana cost he or she controls, then pays mana equal to that cost or sacrifices that creature.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "47aea5ba-a0b7-5b5b-8a7f-666899564fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1e1378-9e27-4cce-88e7-a3bf3dcd2977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1e1378-9e27-4cce-88e7-a3bf3dcd2977.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -1557,7 +1557,7 @@
         },
         {
             "id": "719ccffb-0e36-5d05-a47b-9d9a160e2630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7af2b0-e07f-4b59-8fcf-e51c47f4f095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7af2b0-e07f-4b59-8fcf-e51c47f4f095.jpg?1",
             "name": "Unyaro Griffin",
             "text": "Flying\nSacrifice Unyaro Griffin: Counter target red instant or sorcery spell.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "b23f6746-8837-5c82-895b-c9dfa58a525b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fdd5d-2ed0-42d9-a1b5-34f1d61b668b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fdd5d-2ed0-42d9-a1b5-34f1d61b668b.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "5c3303dc-8041-50f0-8a9b-e7d8c918ed5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0219d-1bf9-4514-9ab3-b241bc541525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0219d-1bf9-4514-9ab3-b241bc541525.jpg?1",
             "name": "Wall of Swords",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -1658,7 +1658,7 @@
         },
         {
             "id": "e15fe99d-11c7-5e20-aadd-5e42ed894041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebd9062-a702-4f30-bba4-c2531e5ca5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebd9062-a702-4f30-bba4-c2531e5ca5cd.jpg?1",
             "name": "Warmth",
             "text": "Whenever one of your opponents plays a red spell, you gain 2 life.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "9aad0661-1d4a-5116-b557-3eff37ef3f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74900e91-d661-4846-984e-5774c5ce0540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74900e91-d661-4846-984e-5774c5ce0540.jpg?1",
             "name": "Warrior's Honor",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "d062c914-1c28-5b25-89e7-4c75a8a00a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5513964-1cad-4083-a3a5-1e55ec145a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5513964-1cad-4083-a3a5-1e55ec145a6e.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "1f9a86c7-ca08-5068-8219-290153c0c8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c82bef-50d6-4d25-bc3f-dda2826fc99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c82bef-50d6-4d25-bc3f-dda2826fc99c.jpg?1",
             "name": "Abduction",
             "text": "When Abduction comes into play, untap enchanted creature.\nYou control enchanted creature.\nWhen enchanted creature is put into a graveyard, return that creature to play under its owner's control.",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "be132567-6735-5e7f-933a-7726b770a60a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d31dca7-df16-4a70-8f17-b78d745bac96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d31dca7-df16-4a70-8f17-b78d745bac96.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "2d5f3d1a-81ba-5df3-bb55-717cbb7b85d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9953a9d1-62db-4610-bf8c-74c321f059c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9953a9d1-62db-4610-bf8c-74c321f059c2.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your library and put two of them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "77eea01b-2e7c-5b73-a42a-fa47093ecd9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3c7465-6534-4fa9-a772-8859b7210fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3c7465-6534-4fa9-a772-8859b7210fdf.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "6b1e53ce-fbfd-5f12-bd1f-bc346d699bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd1b41f-5113-4a7c-9c35-04ebdf002af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd1b41f-5113-4a7c-9c35-04ebdf002af2.jpg?1",
             "name": "Browse",
             "text": "o2o\nUoo\nU Look at the top five cards of your library and put one of them into your hand. Remove the rest from the game.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "ab0d1563-943a-5fe6-96f1-795039d73d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24846eba-e085-4d1d-8c7a-d4faf11034a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24846eba-e085-4d1d-8c7a-d4faf11034a6.jpg?1",
             "name": "Chill",
             "text": "Red spells cost o2 more to play.",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "7a264584-27b5-5ba0-b1ee-1a4671ec2d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0d3f5f-7790-4772-bead-5d7114a23e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0d3f5f-7790-4772-bead-5d7114a23e94.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1972,7 +1972,7 @@
         },
         {
             "id": "784f53a5-fcbd-5025-9b4b-8ed578dc2529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0344006b-990e-46a0-a6d4-ace88af66b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0344006b-990e-46a0-a6d4-ace88af66b46.jpg?1",
             "name": "Daring Apprentice",
             "text": "oc\nT, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "c7527261-21ba-5f42-8a2b-27bfcb893101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca34222-bf30-41e9-a166-e6b02bd6e46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca34222-bf30-41e9-a166-e6b02bd6e46a.jpg?1",
             "name": "Deflection",
             "text": "Choose a new target for target spell with a single target.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "2b169a23-71e7-54de-93e8-21c01c324f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac212677-daa3-49ee-adb1-53a169cb7e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac212677-daa3-49ee-adb1-53a169cb7e9d.jpg?1",
             "name": "Desertion",
             "text": "Counter target spell. If it's an artifact or creature card, put it into play under your control instead of into its owner's graveyard.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "8aaabb91-767a-57d8-9e9b-dffc42910a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c00fc18-8101-48ff-9842-2b157eb02681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c00fc18-8101-48ff-9842-2b157eb02681.jpg?1",
             "name": "Diminishing Returns",
             "text": "Each player shuffles his or her hand and graveyard into his or her library. You remove the top ten cards of your library from the game. Then each player draws up to seven cards.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "2d1c8d8d-25f6-59c4-a0bc-489496509f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642bb62e-1339-4f97-8429-ec46ec0435a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642bb62e-1339-4f97-8429-ec46ec0435a0.jpg?1",
             "name": "Dream Cache",
             "text": "Draw three cards. Choose two cards from your hand and put both on either the top or the bottom of your library.",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "d7ede6e2-2929-54ee-af21-511cef6b4c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2f44d-74a9-4635-bf10-bf4cf179cab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2f44d-74a9-4635-bf10-bf4cf179cab5.jpg?1",
             "name": "Flash",
             "text": "Put a creature card from your hand into play. You may pay its mana cost reduced by up to o2. If you don't, sacrifice it.",
             "colours": [
@@ -2161,7 +2161,7 @@
         },
         {
             "id": "5107f7a1-d20e-5914-a689-25c8fdfa1e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99d08e-edc4-4049-a3de-99f6c5cb0f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99d08e-edc4-4049-a3de-99f6c5cb0f70.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature gains flying.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "b08ba496-4703-5256-922a-9c618e60fc86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0e0c8-3121-46ff-b202-9669c16c2df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0e0c8-3121-46ff-b202-9669c16c2df4.jpg?1",
             "name": "Fog Elemental",
             "text": "Flying\nWhen Fog Elemental attacks or blocks, sacrifice it at end of combat.",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "86856b1d-a851-5bfb-ae2e-9f95a0f2af42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e367-1aa4-43b6-b17a-01bfb097f620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e367-1aa4-43b6-b17a-01bfb097f620.jpg?1",
             "name": "Forget",
             "text": "Target player chooses and discards two cards from his or her hand, then draws as many cards as he or she discarded this way.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "8890a65f-404d-5e97-ba05-4348b78606db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d74e17-5d3c-4102-aadd-263bfecca510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d74e17-5d3c-4102-aadd-263bfecca510.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchanted creature deals no combat damage.\nPrevent all combat damage that would be dealt to enchanted creature.",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "fa28ffc8-a7a0-5c00-a518-9b9c5c2691ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea929add-39a4-4840-a127-16aeb37f55f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea929add-39a4-4840-a127-16aeb37f55f5.jpg?1",
             "name": "Glacial Wall",
             "text": "(Walls can't attack.)",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "75d93453-1585-5dc0-9abe-31a080b3718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fc0ba3-6ffa-4fd4-b332-88da41b8778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fc0ba3-6ffa-4fd4-b332-88da41b8778a.jpg?1",
             "name": "Harmattan Efreet",
             "text": "Flying\no1o\nUoo\nU Target creature gains flying until end of turn.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "c6642786-7753-5fd7-a9e9-64fb0291d10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63e2f7d-52aa-43a1-ab86-7a510a131b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63e2f7d-52aa-43a1-ab86-7a510a131b4c.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "fda79319-093a-5b22-a0fb-aece57fdbfda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a4bbf-2afd-48c5-b6b0-73c32bc3561b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a4bbf-2afd-48c5-b6b0-73c32bc3561b.jpg?1",
             "name": "Insight",
             "text": "Whenever one of your opponents plays a green spell, you draw a card.",
             "colours": [
@@ -2421,7 +2421,7 @@
         },
         {
             "id": "3e48e619-7116-515b-940e-0159c5bfb345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1374df24-bcff-45eb-a2fd-2f39439c9e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1374df24-bcff-45eb-a2fd-2f39439c9e6a.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "f41173cb-432e-5fbc-bc22-1383ea7e8ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1fb725-0daa-45f4-ad31-6a061fa4d20f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1fb725-0daa-45f4-ad31-6a061fa4d20f.jpg?1",
             "name": "Juxtapose",
             "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. (If two or more permanents a player controls are tied for highest cost, that player chooses between them.)",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "26d15fd4-1424-5f93-886b-e573017290f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea40438-90ca-47ff-9805-df130d47ae48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea40438-90ca-47ff-9805-df130d47ae48.jpg?1",
             "name": "Library of Lat-Nam",
             "text": "Target opponent chooses one You draw three cards at the beginning of the next turn's upkeep; or you search your library for a card, put that card into your hand, and then shuffle your library.",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "72149ee4-00f8-5c43-982f-3201ccecd523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d753d343-fedc-4406-b889-87e0f719d361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d753d343-fedc-4406-b889-87e0f719d361.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk get +1/+1 and gain islandwalk. (They're unblockable if defending player controls an island.)",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "5dec76ba-0c1d-528d-9256-95606cddea7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2893b8-11e4-4a76-a3bf-6dd86c11ae09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2893b8-11e4-4a76-a3bf-6dd86c11ae09.jpg?1",
             "name": "Mana Short",
             "text": "Tap all lands target player controls and empty his or her mana pool.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "bff5f562-5202-54ca-b02b-bfd2faf3f172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc92a87-3ad2-4db6-aeae-001342f17d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc92a87-3ad2-4db6-aeae-001342f17d10.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "27b5580e-7f65-516c-b4d3-653a6f2e88eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c43f23-19c1-4b5a-91d4-9961ffc7fcf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c43f23-19c1-4b5a-91d4-9961ffc7fcf1.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "0a7392b3-85bc-5f22-b409-2e1598848d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1571b584-9007-45ee-a3c3-6c72f227fee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1571b584-9007-45ee-a3c3-6c72f227fee2.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "e82e2113-20ce-55e3-8215-9d5c2115da3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ab11d8-0cc2-4a00-9fe8-06a9b3683311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ab11d8-0cc2-4a00-9fe8-06a9b3683311.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Enchanted land is a basic land type of your choice.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "b928a993-a4f5-567b-a558-bd0d830c4acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215e560f-077b-4a4f-aba3-e5c8dab912fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215e560f-077b-4a4f-aba3-e5c8dab912fe.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "9b2573da-771c-5ff5-8976-eff70717ee99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b8c9b-40d0-4986-9457-ef1263fdfae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b8c9b-40d0-4986-9457-ef1263fdfae1.jpg?1",
             "name": "Polymorph",
             "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until a creature card is revealed. The player puts that card into play and shuffles all other revealed cards into his or her library.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "b1f0eb77-741d-5994-9632-bdf435fa5e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098d3f20-e377-4579-b8d7-2d5e7ee3fb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098d3f20-e377-4579-b8d7-2d5e7ee3fb4e.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless its controller pays o\nX more. If he or she doesn't, tap all mana-producing lands that player controls and empty his or her mana pool.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "ab62553a-d382-5fce-aefd-3bffc244f58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf045ee-7923-4b3d-9bb4-f573d37cc7d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf045ee-7923-4b3d-9bb4-f573d37cc7d8.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "f43e615f-d8e3-5234-bc22-b385cd720139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0c86df-ee91-4bea-bb05-7e5db3558169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0c86df-ee91-4bea-bb05-7e5db3558169.jpg?1",
             "name": "Prosperity",
             "text": "Each player draws X cards.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "4e2c1f67-76ae-5811-a4ee-8bbf45ad5c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d848a3e1-de15-4b8f-9881-d32aa2456488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d848a3e1-de15-4b8f-9881-d32aa2456488.jpg?1",
             "name": "Psychic Transfer",
             "text": "If the difference between your life total and target player's life total is 5 or less, exchange life totals with that player.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "0dfac25f-8b8b-573a-a779-1ee4c1be8d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba1b264-1dd5-475b-9522-9eb9efcea572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba1b264-1dd5-475b-9522-9eb9efcea572.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever enchanted land is tapped, Psychic Venom deals 2 damage to that land's controller.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "aa01daf8-4a9d-593d-bb99-58e676862a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791af96f-1de9-46f2-a1e5-93921c4905c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791af96f-1de9-46f2-a1e5-93921c4905c7.jpg?1",
             "name": "Recall",
             "text": "Choose and discard X cards from your hand, then return that many cards from your graveyard to your hand. Remove Recall from the game.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "e848b1d6-8547-5518-b4ca-b355a99ca9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358f4122-fffb-46f6-996c-f4558ba79407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358f4122-fffb-46f6-996c-f4558ba79407.jpg?1",
             "name": "Relearn",
             "text": "Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "af0ffc99-8449-55c7-bca7-7b2220202f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19345cab-4595-4325-b6b4-539c2003679e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19345cab-4595-4325-b6b4-539c2003679e.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "e293fccc-2935-5f46-b327-f6c8ee1bee9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f83acb-c7be-49cf-895b-9fa6f4d32083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f83acb-c7be-49cf-895b-9fa6f4d32083.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl comes into play, look at the top four cards of your library and put them back in any order you choose.",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "122bfa87-c0b1-596e-bfbd-12b77a339844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cecf934-d1fe-424f-932a-043908546157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cecf934-d1fe-424f-932a-043908546157.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an island.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "16113dbb-db5b-5ca3-ab85-7b83e9593e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f796dd2-9ecf-490a-86c0-acb46130518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f796dd2-9ecf-490a-86c0-acb46130518b.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk (This creature is unblockable if defending player controls an island.)",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "e74cf0ac-f2f7-5a33-8be7-99d6b21150ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd219fee-45d2-4d68-911e-9ecdc3a6e81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd219fee-45d2-4d68-911e-9ecdc3a6e81c.jpg?1",
             "name": "Sibilant Spirit",
             "text": "Flying\nWhenever Sibilant Spirit attacks, defending player may draw a card.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "f4363234-d4ef-5e51-991f-df53c42e9374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268c3726-0e2d-40df-811d-2cdf6b328ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268c3726-0e2d-40df-811d-2cdf6b328ea3.jpg?1",
             "name": "Soldevi Sage",
             "text": "oc\nT, Sacrifice two lands: Draw three cards, then choose and discard one of them.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "31a9cae2-7f02-5b6f-a127-d527fdc5859c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e470d0f-06a0-4fdf-98eb-79d536dff894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e470d0f-06a0-4fdf-98eb-79d536dff894.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with converted mana cost equal to X.",
             "colours": [
@@ -3221,7 +3221,7 @@
         },
         {
             "id": "9a78cca7-dc6a-54c2-8fc6-078691a06732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1bf438-3cd8-4bd8-85f1-fc97f49b44d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1bf438-3cd8-4bd8-85f1-fc97f49b44d9.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "81f17c10-fd0b-5614-937b-b37e3b26d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae1d63-aee0-4cbe-852d-25fde10fa4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae1d63-aee0-4cbe-852d-25fde10fa4b7.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap up to three target creatures without flying.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "b3277453-5e29-54a9-a4c5-be40504fa150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff96224-d6cd-492b-ab2f-3ec15b3230cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff96224-d6cd-492b-ab2f-3ec15b3230cb.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "e9459099-5c21-56a5-b565-2bd9d836642e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fae146-a0dd-4622-ab11-f00b372f8221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fae146-a0dd-4622-ab11-f00b372f8221.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "eb47023a-c079-5c99-918f-a10b9be47dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a99adbb-7723-4046-92af-95d6d21fae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a99adbb-7723-4046-92af-95d6d21fae53.jpg?1",
             "name": "Wall of Air",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "8b37b7de-70e2-5d1b-8fb8-b348f8c94ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ca5eed-53a3-4da5-b7fc-f08e6cc93946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ca5eed-53a3-4da5-b7fc-f08e6cc93946.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "3f5269eb-af58-52ec-8c21-2f26b5eeedd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9041dc6-7521-4ae3-b8b3-5134fea97581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9041dc6-7521-4ae3-b8b3-5134fea97581.jpg?1",
             "name": "Wind Spirit",
             "text": "Flying\nWind Spirit can't be blocked by only one creature each combat.",
             "colours": [
@@ -3450,7 +3450,7 @@
         },
         {
             "id": "c9f61fe9-ba9e-50b7-976a-d594de985838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a31bb-5f3b-4215-9e21-9965d459f032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a31bb-5f3b-4215-9e21-9965d459f032.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands revealed.\nWhenever a player would draw a card, instead reveal it. Any other player may pay 2 life to put that card into its owner's graveyard. If no one does, that player then draws the card.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "6320df7d-8ffd-5f36-970f-68a188c2917f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f6ad7-4782-40db-8eb3-e71d71ec3388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f6ad7-4782-40db-8eb3-e71d71ec3388.jpg?1",
             "name": "Abyssal Hunter",
             "text": "o\nB, oc\nT: Tap target creature. Abyssal Hunter deals damage equal to its power to that creature.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "e7e2fbc9-9f68-56aa-aea1-c2fb6908b51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e4df76-41c8-4410-a505-4f328c94b974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e4df76-41c8-4410-a505-4f328c94b974.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter deals damage to a player, that player chooses and discards a card from his or her hand.",
             "colours": [
@@ -3548,7 +3548,7 @@
         },
         {
             "id": "12520903-5bfd-5978-b2b4-5c24e2a81ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556e1e2-44a6-49f1-8417-be8dae4ef65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556e1e2-44a6-49f1-8417-be8dae4ef65b.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand and choose two cards from it. Put those cards on top of that player's library in any order you choose.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "3df91841-c427-5808-b987-cea2aa964c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fa11f5-546b-4a14-afd0-80866d4968ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fa11f5-546b-4a14-afd0-80866d4968ab.jpg?1",
             "name": "Ashen Powder",
             "text": "Put target creature card from one of your opponents' graveyards into play under your control.",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "1e0a492d-0a3a-56d1-9ca1-9ece1b536847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a08e1fd-7ab1-4981-9fc4-f9d32a58ac4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a08e1fd-7ab1-4981-9fc4-f9d32a58ac4e.jpg?1",
             "name": "Blight",
             "text": "When enchanted land is tapped, destroy it.",
             "colours": [
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "6e78201b-00fe-51fc-8661-015ccc4c2c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d46c90a-215a-4897-94f8-52a02abf25c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d46c90a-215a-4897-94f8-52a02abf25c4.jpg?1",
             "name": "Blighted Shaman",
             "text": "oc\nT, Sacrifice a swamp: Target creature gets +1/+1 until end of turn.\noc\nT, Sacrifice a creature: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "cceb6ca7-63e4-5b38-b724-3406be1ee7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b30e7e-f628-4ae0-8338-c95022b3fedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b30e7e-f628-4ae0-8338-c95022b3fedf.jpg?1",
             "name": "Blood Pet",
             "text": "Sacrifice Blood Pet: Add o\nB to your mana pool.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "a053eb35-d849-5281-bd56-009e4e5c4c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02b4a5-8302-483c-9f38-b559974a601c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02b4a5-8302-483c-9f38-b559974a601c.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "b0d51ec8-6e01-5d58-b30b-5ba8488c40f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da038c4-73ff-4d82-8440-9bca2f051fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da038c4-73ff-4d82-8440-9bca2f051fd5.jpg?1",
             "name": "Bog Rats",
             "text": "Bog Rats can't be blocked by Walls.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "068b9a8c-8a80-5ead-b41f-8c235a1f1a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145a4b6-36f9-4cdc-9e81-ad8c22a21150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145a4b6-36f9-4cdc-9e81-ad8c22a21150.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable if defending player controls a swamp.)",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "6344a68b-3ff3-5e65-994b-9fdd1f7b4588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8337ac-fddc-4af7-a623-e9a8c8323564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8337ac-fddc-4af7-a623-e9a8c8323564.jpg?1",
             "name": "Coercion",
             "text": "Look at target opponent's hand and choose a card from it. That player discards that card.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "b1fe2fa1-7144-57f2-a42d-4667b794a790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530043ad-d4bf-4fb0-b6e0-f8a744968cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530043ad-d4bf-4fb0-b6e0-f8a744968cfc.jpg?1",
             "name": "Derelor",
             "text": "Your black spells cost o\nB more to play.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "db6adb27-4a5d-53b0-9f4c-d655457ac29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9dbfa-0043-47d2-acfe-f636841afc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9dbfa-0043-47d2-acfe-f636841afc2c.jpg?1",
             "name": "Doomsday",
             "text": "Search your library and graveyard for five cards of your choice and remove the rest from the game. Put the chosen cards on top of your library in any order you choose. You lose half your life, rounded up.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "51944792-fda0-5938-b5aa-87eae19a9c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4105fb4-ab13-4a34-810b-1d294c5a6eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4105fb4-ab13-4a34-810b-1d294c5a6eee.jpg?1",
             "name": "Dread of Night",
             "text": "White creatures get -1/-1.",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "b3c34ec0-82d2-5a25-ba77-303e95b36903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7105716-8f9e-4f32-b6bc-cb7b231d1fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7105716-8f9e-4f32-b6bc-cb7b231d1fa1.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate Drudge Skeletons.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "e599f2f9-b8ca-5951-b751-aa3d1a886f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670f4eb-cca7-45fd-b3d7-58b436c00526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670f4eb-cca7-45fd-b3d7-58b436c00526.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "fd35667d-7534-58b9-a025-31c683fa587b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f765719b-609a-47ae-8dc8-0c97db104d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f765719b-609a-47ae-8dc8-0c97db104d1b.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and each player.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "eb29571b-d84e-5cb5-97f1-350a77f8ab95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63418388-4e48-42cd-a84d-d631d01476a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63418388-4e48-42cd-a84d-d631d01476a3.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchanted creature gets -2/-2.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "3fcf9c11-6ee4-5f2a-84b2-a157a8f0c3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31caa65-accd-4306-a975-1aaa5d98aeaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31caa65-accd-4306-a975-1aaa5d98aeaa.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "Evil Eye of Orms-by-Gore can't be blocked except by Walls.\nExcept for Evil Eye of Orms-by-Gore, creatures you control can't attack.",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "553b43e5-2a7c-5481-aa10-7816225a8430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd81ae10-ebf4-4731-b32c-dc5954c3442c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd81ae10-ebf4-4731-b32c-dc5954c3442c.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "0617c723-e477-524a-94a4-e62c7bef67b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890c3aa-9321-4c41-9b16-cff4e6364350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890c3aa-9321-4c41-9b16-cff4e6364350.jpg?1",
             "name": "Fatal Blow",
             "text": "Destroy target creature that was dealt damage this turn. It can't be regenerated.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "a748cdec-e745-5e06-b22c-0ed6f2d9236b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb729a6b-7efc-4b94-9221-cba25f6506dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb729a6b-7efc-4b94-9221-cba25f6506dc.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "66478a23-2ec6-5335-9d6d-b1f5b0b3a61e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a5a97-d81e-4f4d-ab8f-5a9cabd4c685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a5a97-d81e-4f4d-ab8f-5a9cabd4c685.jpg?1",
             "name": "Feast of the Unicorn",
             "text": "Enchanted creature gets +4/+0.",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "f8aa6cbc-5079-5e7f-b6f2-0e22d38a1f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08263b27-487c-4b5c-aca6-0d77acdcc624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08263b27-487c-4b5c-aca6-0d77acdcc624.jpg?1",
             "name": "Feral Shadow",
             "text": "Flying",
             "colours": [
@@ -4266,7 +4266,7 @@
         },
         {
             "id": "31b453aa-6617-5466-a311-f73ae603d0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f5f509-707b-4ed6-9824-626dea5869b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f5f509-707b-4ed6-9824-626dea5869b0.jpg?1",
             "name": "Forbidden Crypt",
             "text": "Whenever you would draw a card, instead return target card from your graveyard to your hand. If you can't, you lose the game.\nWhenever a card would be put into your graveyard, instead remove that card from the game.",
             "colours": [
@@ -4297,7 +4297,7 @@
         },
         {
             "id": "e11828dc-9b3f-50f9-9d74-05f8bef106c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df21b384-6073-477e-bd95-fc94ca2f2f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df21b384-6073-477e-bd95-fc94ca2f2f2c.jpg?1",
             "name": "Gravebane Zombie",
             "text": "When Gravebane Zombie would be put into a graveyard from play, instead put Gravebane Zombie on top of its owner's library.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "7f894c98-1189-502c-8ce3-ce1f3a0dab0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ae81a3-f76a-406b-bbac-36f8abf456ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ae81a3-f76a-406b-bbac-36f8abf456ce.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "00dee035-db3c-5149-939d-dabd2926c7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977d0b73-ebc1-4082-a90c-eda363732bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977d0b73-ebc1-4082-a90c-eda363732bbe.jpg?1",
             "name": "Greed",
             "text": "o\nB, Pay 2 life: Draw a card.",
             "colours": [
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "ae9b5a97-a5b4-5379-986e-abe934ff6594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d2908e-1608-4858-b93c-e9ea9808f9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d2908e-1608-4858-b93c-e9ea9808f9c9.jpg?1",
             "name": "Hecatomb",
             "text": "When Hecatomb comes into play, you may sacrifice four creatures. If you don't, sacrifice Hecatomb.\nTap an untapped swamp you control: Hecatomb deals 1 damage to target creature or player.",
             "colours": [
@@ -4425,7 +4425,7 @@
         },
         {
             "id": "c753827f-c0d8-5198-94c8-0ea9a1277bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785de2b3-ffd6-40f5-a5d2-c8fa30dbf10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785de2b3-ffd6-40f5-a5d2-c8fa30dbf10f.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play, choose and discard a creature card from your hand. If you don't, sacrifice Hidden Horror.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "d070396f-d208-5edd-a2b6-2f5e9f551b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb9612-cc19-4769-9d07-38d5e2796053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb9612-cc19-4769-9d07-38d5e2796053.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "ea369760-adf0-5893-86fd-b02fbc2f62eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94517aeb-c018-4390-b601-c44a7af0f090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94517aeb-c018-4390-b601-c44a7af0f090.jpg?1",
             "name": "Infernal Contract",
             "text": "Draw four cards. You lose half your life, rounded up.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "2f8d4786-0206-5430-9870-5d162c42d41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dff6e2-4280-494b-9647-9ec85248ac77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dff6e2-4280-494b-9647-9ec85248ac77.jpg?1",
             "name": "Kjeldoran Dead",
             "text": "When Kjeldoran Dead comes into play, sacrifice a creature.\noo\nB Regenerate Kjeldoran Dead.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "fdf09646-de35-5d32-871d-a227dc7cc90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c44599f-f788-43fa-ace3-a521f15256ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c44599f-f788-43fa-ace3-a521f15256ad.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Enchanted creature gains swampwalk. (It's unblockable if defending player controls a swamp.)",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "faa30e91-a2da-5400-9d74-25e2daad70fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401896ac-6234-468a-a9af-cf11c7a11cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401896ac-6234-468a-a9af-cf11c7a11cd0.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk (This creature is unblockable if defending player controls a swamp.)",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "2fe6f150-5146-5d82-b7f0-393deaacfcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f0d58c-24fa-498f-9531-e62144401e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f0d58c-24fa-498f-9531-e62144401e86.jpg?1",
             "name": "Mind Warp",
             "text": "Look at target player's hand and choose X cards from it. That player discards them.",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "4d3cd442-4589-550e-af77-8d1e213c9f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11803b8-d1df-454d-93ec-b1bb276843b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11803b8-d1df-454d-93ec-b1bb276843b6.jpg?1",
             "name": "Mischievous Poltergeist",
             "text": "Flying\nPay 1 life: Regenerate Mischievous Poltergeist.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "02432e52-f31b-57b7-96a6-157d75149e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a9755-f003-456d-a827-d6ef6cc29a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a9755-f003-456d-a827-d6ef6cc29a86.jpg?1",
             "name": "Necrosavant",
             "text": "o3o\nBo\nB, Sacrifice a creature: Return Necrosavant from your graveyard to play.\nPlay this ability only during your upkeep.",
             "colours": [
@@ -4718,7 +4718,7 @@
         },
         {
             "id": "8ce66027-512d-5255-9bc7-b6ba6335d510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2a1e82-4922-4075-a869-3a1b607498c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2a1e82-4922-4075-a869-3a1b607498c3.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of swamps you control.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "fe6712b7-9054-5941-a7ae-c77f87f9612d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdec2ddc-3a91-4872-b4c0-e75af6cbb184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdec2ddc-3a91-4872-b4c0-e75af6cbb184.jpg?1",
             "name": "Painful Memories",
             "text": "Look at target opponent's hand and choose a card from it. Put that card on top of that player's library.",
             "colours": [
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "8d02ce18-c375-5cc2-99b6-b44bcbcb4890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77192bdf-d89f-45a1-a30b-20107e990031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77192bdf-d89f-45a1-a30b-20107e990031.jpg?1",
             "name": "Perish",
             "text": "Destroy all green creatures. They can't be regenerated.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "61f45545-8a67-52a6-aff3-aa733110a330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d852c4-bd53-4a3b-b1e2-896917cbc27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d852c4-bd53-4a3b-b1e2-896917cbc27f.jpg?1",
             "name": "Pestilence",
             "text": "At end of turn, if there are no creatures in play, sacrifice Pestilence.\noo\nB Pestilence deals 1 damage to each creature and each player.",
             "colours": [
@@ -4845,7 +4845,7 @@
         },
         {
             "id": "9d4683b7-ccba-5430-9a11-887929932e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe194-1d9b-4d3f-b7a0-aa058945aca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe194-1d9b-4d3f-b7a0-aa058945aca1.jpg?1",
             "name": "Python",
             "text": "",
             "colours": [
@@ -4878,7 +4878,7 @@
         },
         {
             "id": "b1a9478a-40cb-5dc4-9b28-a2bfa8eff977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef9159a-66ee-4e99-8fb6-6f45b02f9880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef9159a-66ee-4e99-8fb6-6f45b02f9880.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at target opponent's hand. That player discards a creature card at random from it. Play this ability only during your turn.",
             "colours": [
@@ -4912,7 +4912,7 @@
         },
         {
             "id": "7dee27cf-1f9a-5f8d-a135-57bca5047e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bb239e-4517-4add-a660-a89095e40a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bb239e-4517-4add-a660-a89095e40a8e.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "4c267abd-50dd-57c9-9ed1-eca1abfa4c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab55c86-3576-43fd-b555-ab0b3ad936c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab55c86-3576-43fd-b555-ab0b3ad936c7.jpg?1",
             "name": "Razortooth Rats",
             "text": "Razortooth Rats can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -4976,7 +4976,7 @@
         },
         {
             "id": "8370fdce-e2f0-531d-b55a-1bd7774a61e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e992239-691b-4bb2-a005-c73c24a52a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e992239-691b-4bb2-a005-c73c24a52a9b.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "1fbb3b2a-c675-5446-baff-41cb9ae52662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a5401-bbe4-40ab-9204-12d944fbd2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a5401-bbe4-40ab-9204-12d944fbd2b1.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat comes into play, put three 0/1 black Serf creature tokens into play.\nWhen Sengir Autocrat leaves play, remove all Serf tokens from play.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "c9c9963b-66da-5085-91c2-026ee1c1ab08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13382490-205e-4dcd-8524-2b17008b5237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13382490-205e-4dcd-8524-2b17008b5237.jpg?1",
             "name": "Strands of Night",
             "text": "o\nBo\nB, Pay 2 life, Sacrifice a swamp: Return target creature card from your graveyard to play.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "cff5fb99-f0e5-5a29-a479-b37770bab9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d78c90b-b44e-431a-a4e6-ceae0a019428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d78c90b-b44e-431a-a4e6-ceae0a019428.jpg?1",
             "name": "Stromgald Cabal",
             "text": "oc\nT, Pay 1 life: Counter target white spell.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "9e48b63f-cf1d-5ea5-a8a7-a1123cadb535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec72a6-b482-4e04-8491-c6cb0afeb568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec72a6-b482-4e04-8491-c6cb0afeb568.jpg?1",
             "name": "Stupor",
             "text": "Target opponent discards a card at random from his or her hand, then chooses and discards a card from his or her hand.",
             "colours": [
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "ba1679c4-0bd8-508e-9541-3c4e2cb57947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b329533-9d55-456f-8fb1-0ab97c4b3037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b329533-9d55-456f-8fb1-0ab97c4b3037.jpg?1",
             "name": "Syphon Soul",
             "text": "Syphon Soul deals 2 damage to each other player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "f81623bb-ddb6-5a40-8d01-f03e1f31ca23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe73e689-b9da-4b1e-9809-c25056c06048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe73e689-b9da-4b1e-9809-c25056c06048.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "3ef135ce-7a12-52e4-8874-281c947ee92b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8505bc8-218f-4b56-be78-ebde535ebaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8505bc8-218f-4b56-be78-ebde535ebaa0.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "5352cdb6-0fb9-55de-a7a8-b1117832ab90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346707a7-e816-432c-bb93-16b5cb4616e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346707a7-e816-432c-bb93-16b5cb4616e0.jpg?1",
             "name": "Zombie Master",
             "text": "All Zombies gain \"oo\nB Regenerate this creature\" and swampwalk. (They're unblockable if defending player controls a swamp.)",
             "colours": [
@@ -5264,7 +5264,7 @@
         },
         {
             "id": "b8a03d0a-1b1a-58a0-90d5-01e39ee87a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61721ec-6008-4704-85d6-83d4f2558b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61721ec-6008-4704-85d6-83d4f2558b5a.jpg?1",
             "name": "Aether Flash",
             "text": "Whenever a creature comes into play, \u00c6ther Flash deals 2 damage to it.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "ce5cc7af-7e24-570a-b854-70ebf30bec18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c21e32-6f43-4475-bd9e-472ca8cbd4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c21e32-6f43-4475-bd9e-472ca8cbd4a6.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "5c7e061d-d0cc-553b-a9fd-203b900bea5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8eccc-551d-4109-866e-7285435ffd19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8eccc-551d-4109-866e-7285435ffd19.jpg?1",
             "name": "Anaba Shaman",
             "text": "o\nR, oc\nT: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "fb11b588-cee4-582d-b4fc-6a134be6ceb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de983bae-1b73-4dd7-a2f4-4200a21abe6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de983bae-1b73-4dd7-a2f4-4200a21abe6a.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "e07bb1cb-50ec-5767-a9a5-5ca709f28d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbcf78f-b5a9-4ed0-a409-d4565bebc56d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbcf78f-b5a9-4ed0-a409-d4565bebc56d.jpg?1",
             "name": "Balduvian Horde",
             "text": "When Balduvian Horde comes into play, discard a card at random from your hand. If you don't, sacrifice Balduvian Horde.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "86a59a3a-5568-54a3-960a-5b0a1697fb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09111a-e714-4f8f-8a48-61c102e45123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09111a-e714-4f8f-8a48-61c102e45123.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "e2b02f05-4256-5466-a076-35d2f929a902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8cd169-0eaa-4430-a175-7f9bbf552929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8cd169-0eaa-4430-a175-7f9bbf552929.jpg?1",
             "name": "Boil",
             "text": "Destroy all islands.",
             "colours": [
@@ -5492,7 +5492,7 @@
         },
         {
             "id": "3f01110e-ea0c-5904-9c2f-77f4a742398f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c665180c-a69b-446e-9894-3b3be624db7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c665180c-a69b-446e-9894-3b3be624db7f.jpg?1",
             "name": "Burrowing",
             "text": "Enchanted creature gains mountainwalk. (It's unblockable if defending player controls a mountain.)",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "e5683c44-bbb7-58c4-9434-4d2a135a4ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb9ae3b-0da5-40df-8f52-54238c965137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb9ae3b-0da5-40df-8f52-54238c965137.jpg?1",
             "name": "Conquer",
             "text": "You control enchanted land.",
             "colours": [
@@ -5558,7 +5558,7 @@
         },
         {
             "id": "ce64bbd2-8193-5741-8431-b71617be578f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88daedae-a848-4d08-bceb-b71cec2673fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88daedae-a848-4d08-bceb-b71cec2673fb.jpg?1",
             "name": "Crimson Hellkite",
             "text": "Flying\no\nX, oc\nT: Crimson Hellkite deals X damage to target creature. Spend only red mana this way.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "154e8480-0573-5843-95b1-33bfaa0cf649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58f85d-905a-4569-b3e6-adafc387c1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58f85d-905a-4569-b3e6-adafc387c1cb.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "9ded3e49-2a09-530e-9ce4-30cedf6fd705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84b68c-2079-4268-840c-f7a86675c0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84b68c-2079-4268-840c-f7a86675c0ba.jpg?1",
             "name": "Fervor",
             "text": "Creatures you control gain haste. (They may attack and oc\nT the turn they come under your control.)",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "f69d00c0-e385-572b-b445-cff62e67cd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627aeab7-ccdd-4b23-8e6c-976636fe308e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627aeab7-ccdd-4b23-8e6c-976636fe308e.jpg?1",
             "name": "Final Fortune",
             "text": "Take another turn after this one. At the end of that turn, you lose the game.",
             "colours": [
@@ -5684,7 +5684,7 @@
         },
         {
             "id": "f1cadd87-7779-5f12-af1c-65a6d47c5ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3b58b-ce10-459f-87f7-bb243b854fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3b58b-ce10-459f-87f7-bb243b854fc3.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "0060dad6-8a5b-55b3-a02d-4b725db44fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d54f3-d21f-4854-a4ab-5912771330a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d54f3-d21f-4854-a4ab-5912771330a5.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "7e89a663-bf8a-56bf-84f1-90629eefb6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79c17d2-dcf1-4464-ae58-5ea5117ae531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79c17d2-dcf1-4464-ae58-5ea5117ae531.jpg?1",
             "name": "Fit of Rage",
             "text": "Target creature gets +3/+3 and gains first strike until end of turn.",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "dc31c349-4d3e-5278-bffa-1f8f19a2b61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75509b1c-ae9c-4708-8f9b-67af18a7e9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75509b1c-ae9c-4708-8f9b-67af18a7e9d3.jpg?1",
             "name": "Flame Spirit",
             "text": "oo\nR Flame Spirit gets +1/+0 until end of turn.",
             "colours": [
@@ -5815,7 +5815,7 @@
         },
         {
             "id": "3143095b-57f3-57e5-925f-e56ad4485c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc2cc5-4438-481a-83b0-bf822d3f44cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc2cc5-4438-481a-83b0-bf822d3f44cd.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains.",
             "colours": [
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "c8f6d493-9300-57eb-ac0c-0d489123e0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28f7c1c-1d75-4d78-8577-1e98cf8e0703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28f7c1c-1d75-4d78-8577-1e98cf8e0703.jpg?1",
             "name": "Giant Strength",
             "text": "Enchanted creature gets +2/+2.",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "111b4f6b-3bc3-5a74-82cd-8ec43f8ced7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f9cf20-ad89-4942-83f5-17515c538faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f9cf20-ad89-4942-83f5-17515c538faa.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT, Sacrifice Goblin Digging Team: Destroy target Wall.",
             "colours": [
@@ -5912,7 +5912,7 @@
         },
         {
             "id": "67251729-5da8-5bdb-aced-2db37fef4f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb6e4a7-206e-496d-947a-65cbeae60841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb6e4a7-206e-496d-947a-65cbeae60841.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "Whenever Goblin Elite Infantry blocks or is blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -5946,7 +5946,7 @@
         },
         {
             "id": "b0db89bb-cf92-53ca-a33f-6ddaf3c413b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39f3d36-6648-4e3c-bd9d-336479d1ad72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39f3d36-6648-4e3c-bd9d-336479d1ad72.jpg?1",
             "name": "Goblin Hero",
             "text": "",
             "colours": [
@@ -5979,7 +5979,7 @@
         },
         {
             "id": "807f5631-3a0f-579e-ac6c-307140903bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440546d3-91d4-45f3-ae36-bdf5bec2b673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440546d3-91d4-45f3-ae36-bdf5bec2b673.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and gain mountainwalk. (They're unblockable if defending player controls a mountain.)",
             "colours": [
@@ -6012,7 +6012,7 @@
         },
         {
             "id": "b2060664-c1fc-500a-a56d-d4dd70a064f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd1548-2ffa-4705-ba88-913f37d4ce92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd1548-2ffa-4705-ba88-913f37d4ce92.jpg?1",
             "name": "Goblin Recruiter",
             "text": "When Goblin Recruiter comes into play, search your library for any number of Goblin cards you choose. Reveal those cards, then shuffle your library and put them on top of it in any order you choose.",
             "colours": [
@@ -6045,7 +6045,7 @@
         },
         {
             "id": "a2f44b44-46f6-5ce7-8e41-8371b6e9900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1255654b-f983-4862-9112-9e378ea5d9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1255654b-f983-4862-9112-9e378ea5d9fe.jpg?1",
             "name": "Goblin Warrens",
             "text": "o2o\nR, Sacrifice two Goblins: Put three 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "b34c8734-b49c-5f66-8432-579a13180f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759a8d8-9c6b-4d1b-b17a-6b4f349dd553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759a8d8-9c6b-4d1b-b17a-6b4f349dd553.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "Hammer of Bogardan deals 3 damage to target creature or player.\no2o\nRo\nRoo\nR Return Hammer of Bogardan to your hand. Play this ability only during your upkeep and only if Hammer of Bogardan is in your graveyard.",
             "colours": [
@@ -6107,7 +6107,7 @@
         },
         {
             "id": "5bc78588-6b2e-5efa-92c8-2e6a8680c21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966fa96-2453-4555-8a90-8e4b7a393038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966fa96-2453-4555-8a90-8e4b7a393038.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops can't block.",
             "colours": [
@@ -6140,7 +6140,7 @@
         },
         {
             "id": "4bde8263-f5a9-517d-9758-7a2854bdf1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d68c39-cfdd-4883-9058-d648d073ae36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d68c39-cfdd-4883-9058-d648d073ae36.jpg?1",
             "name": "Illicit Auction",
             "text": "Choose target creature. Each player may bid life for control of that creature. You begin the bidding at 0. Proceeding in turn order, each player may top the high bid. The auction ends when the high bid stands. The high bidder loses life equal to the high bid and gains control of the creature.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "292917d0-ca49-57c0-a484-8e85957d906d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfa44a4-5351-4334-a9d5-c5c19fcccca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfa44a4-5351-4334-a9d5-c5c19fcccca5.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and each player.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "253975b1-3e63-5132-bfa3-50839ca51d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef08669-ccce-45a3-94fc-d3caa213c068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef08669-ccce-45a3-94fc-d3caa213c068.jpg?1",
             "name": "Jokulhaups",
             "text": "Destroy all artifacts, creatures, and lands. They can't be regenerated.",
             "colours": [
@@ -6233,7 +6233,7 @@
         },
         {
             "id": "a9717f9b-5817-5b40-bcd2-b0582f4dd755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c92e4a-34d2-4947-9c5f-2ceb8e5ae53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c92e4a-34d2-4947-9c5f-2ceb8e5ae53d.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "85a5bff3-1766-554e-b67e-cfc93029af2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4942f9-c3ec-4cb1-9300-9f6ed9e7caa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4942f9-c3ec-4cb1-9300-9f6ed9e7caa9.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to him or her.",
             "colours": [
@@ -6295,7 +6295,7 @@
         },
         {
             "id": "0199da87-80b6-5816-954c-e58f75835ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47754124-37e2-4878-a711-a3e00ae0bc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47754124-37e2-4878-a711-a3e00ae0bc70.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk (This creature is unblockable if defending player controls a mountain.)",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "5f73f14c-1923-5898-b6b2-36fdaae56222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d71507-d71a-476d-aa8d-9eab60183f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d71507-d71a-476d-aa8d-9eab60183f95.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -6362,7 +6362,7 @@
         },
         {
             "id": "b1772898-24a4-5dd4-a357-e4ae23e71de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11192972-eb57-4042-83f2-2470b49940b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11192972-eb57-4042-83f2-2470b49940b8.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "a17d2332-a3ce-5bf3-bcb9-8a70b4fa4ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04eeaba-7db8-49e8-b775-fbe9c89413fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04eeaba-7db8-49e8-b775-fbe9c89413fd.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "b8fd502a-904e-52c1-aaba-1feae43ebc92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4cb5f-a9f0-41a1-b9a8-ea483e12633f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4cb5f-a9f0-41a1-b9a8-ea483e12633f.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "ef76a188-6cb4-5500-b0fc-2eadd5cd3975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41205d2-ed1c-4c16-a171-096c06016705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41205d2-ed1c-4c16-a171-096c06016705.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6489,7 +6489,7 @@
         },
         {
             "id": "0a6fa674-29eb-5e60-bc3f-c27a13582611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f262e8-0567-4e6d-8435-eda661d89a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f262e8-0567-4e6d-8435-eda661d89a8f.jpg?1",
             "name": "Reckless Embermage",
             "text": "o1oo\nR Reckless Embermage deals 1 damage to target creature or player and 1 damage to itself.",
             "colours": [
@@ -6523,7 +6523,7 @@
         },
         {
             "id": "9169b3ad-56ce-5097-a0de-f5b77ecc90db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb66d77-2bf5-441c-9ef8-1728dc5987ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb66d77-2bf5-441c-9ef8-1728dc5987ca.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You get an additional combat phase followed by an additional main phase this turn.",
             "colours": [
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "61d83a74-5894-5340-977c-0d8b9fed9425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f0585f-f4ea-4b49-b090-8fdf56e5de7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f0585f-f4ea-4b49-b090-8fdf56e5de7d.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -6587,7 +6587,7 @@
         },
         {
             "id": "cae705e7-4d4b-5ca5-b378-3701070e5e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a255e43-be06-45f0-a74e-3436d76899f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a255e43-be06-45f0-a74e-3436d76899f9.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "9b2a6416-37e8-5159-8bc1-b39c5511633e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5129c8a-735b-44f5-9233-24b905e3103a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5129c8a-735b-44f5-9233-24b905e3103a.jpg?1",
             "name": "Shatterstorm",
             "text": "Destroy all artifacts. They can't be regenerated.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "93080b10-1d25-53ff-a53a-45f84afcf871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a68db8-5e4e-4c98-a319-7717cc39e831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a68db8-5e4e-4c98-a319-7717cc39e831.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "0f685883-f795-561c-b765-264154e0c57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ec1676-f59b-4ab6-995c-d2525ac11370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ec1676-f59b-4ab6-995c-d2525ac11370.jpg?1",
             "name": "Spitting Drake",
             "text": "Flying\noo\nR Spitting Drake gets +1/+0 until end of turn. Spend no more than o\nR this way each turn.",
             "colours": [
@@ -6713,7 +6713,7 @@
         },
         {
             "id": "af2147c0-bc9c-5cfe-a8ed-0da90e52a1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e87de2-9d6b-4158-a871-5c81d05db7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e87de2-9d6b-4158-a871-5c81d05db7f0.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to target creature damage equal to the number of mountains you control.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "5f5bf4cb-db6d-5578-9b0e-2e49de51d0e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9a0841-609f-4a57-8a4a-39d460e31af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9a0841-609f-4a57-8a4a-39d460e31af8.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "5a6b8aba-fd83-58c8-8bfa-b04f0324b5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4f1317-5e9b-4f49-9ed8-4f97f8c4b8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4f1317-5e9b-4f49-9ed8-4f97f8c4b8d0.jpg?1",
             "name": "Talruum Minotaur",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6809,7 +6809,7 @@
         },
         {
             "id": "ae5b91a1-e3b3-5ab9-9d76-d70163962171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f143421-a770-4df1-a593-af24025bdb2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f143421-a770-4df1-a593-af24025bdb2f.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "85fd4264-3530-52be-a60b-ead5e53862d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58ac6a-095e-47d7-ba42-56d148e3c6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58ac6a-095e-47d7-ba42-56d148e3c6b9.jpg?1",
             "name": "Vertigo",
             "text": "Vertigo deals 2 damage to target creature with flying. That creature loses flying until end of turn.",
             "colours": [
@@ -6871,7 +6871,7 @@
         },
         {
             "id": "07999653-91b7-5c87-9fdc-5164518aa5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb467271-898f-4bcd-8533-e8165b318b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb467271-898f-4bcd-8533-e8165b318b43.jpg?1",
             "name": "Viashino Warrior",
             "text": "",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "85221803-4a54-500c-b651-1c01a3dbe9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983c88c-6b0d-498a-b8e8-65b9733db62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983c88c-6b0d-498a-b8e8-65b9733db62c.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying; haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "0c9ac8dc-7ad9-50cf-9b11-991db5e207bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e89d367-b213-4f73-8f23-79788c00d7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e89d367-b213-4f73-8f23-79788c00d7c1.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "77db1f33-ec77-51f2-8f82-90f3a80a4306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5da58c5-51a9-4d4b-8b68-a21b6981602d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5da58c5-51a9-4d4b-8b68-a21b6981602d.jpg?1",
             "name": "Wall of Fire",
             "text": "(Walls can't attack.)\noo\nR Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "4bb468a1-c588-5eef-809c-dfbefd741fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad85d15-e700-455d-96f4-dfd6661f9722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad85d15-e700-455d-96f4-dfd6661f9722.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of a color of your choice to your mana pool.",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "884d1652-da1b-5ffa-af7a-b045ee4050e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99602c-92a0-489d-a00d-1e65563365c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99602c-92a0-489d-a00d-1e65563365c6.jpg?1",
             "name": "Call of the Wild",
             "text": "o2o\nGo\nG: Reveal the top card of your library. If it's a creature card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "2b1123d2-6520-5825-a878-e87cf4e95b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90823485-83cd-4260-b860-7f05d8588905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90823485-83cd-4260-b860-7f05d8588905.jpg?1",
             "name": "Cat Warriors",
             "text": "Forestwalk (This creature is unblockable if defending player controls a forest.)",
             "colours": [
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "81892ec7-c0cf-5fa2-9cbf-b4bafcb868ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4cf599-2fd6-46cc-a3dc-4fe8e4c21f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4cf599-2fd6-46cc-a3dc-4fe8e4c21f42.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, land, or enchantment.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "6bf0deb5-c48a-5c8c-bd9c-d79d6fa433d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6232f04-cd4c-4889-97dc-cccc4a09f9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6232f04-cd4c-4889-97dc-cccc4a09f9c4.jpg?1",
             "name": "Dense Foliage",
             "text": "Creatures can't be the targets of spells.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "57643b43-85a6-58db-8356-f3f571e6164e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df2d73-e58b-43e7-90ad-2d61ca33ccbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df2d73-e58b-43e7-90ad-2d61ca33ccbb.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "f9b09a30-b48a-58bc-904d-13eca3bd05ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da912a54-ab69-4765-b23e-7b9d622590a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da912a54-ab69-4765-b23e-7b9d622590a8.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG, oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "a302bb3f-80e3-53ec-8d22-65dc451cca8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d3d239-1e16-4a23-9098-ee67d32e0208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d3d239-1e16-4a23-9098-ee67d32e0208.jpg?1",
             "name": "Elven Cache",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "57b3f0fc-ad27-5985-b0c4-59ca2dac8086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6da6713-f5bd-4613-90d1-37d62b3ed011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6da6713-f5bd-4613-90d1-37d62b3ed011.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders can't be blocked except by creatures with flying or Walls.",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "9edbea9f-2dbf-5c39-8af3-39c828914591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164ee97d-736e-4659-878d-d161c204142e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164ee97d-736e-4659-878d-d161c204142e.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -7326,7 +7326,7 @@
         },
         {
             "id": "b67edbea-92b9-58aa-8aa2-e536f07baa66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b02b12-415c-49f4-9f60-fa53beb4216f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b02b12-415c-49f4-9f60-fa53beb4216f.jpg?1",
             "name": "Fallow Earth",
             "text": "Put target land on top of its owner's library.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "73337c44-0367-565d-be8b-4f3841e07756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e963b-d316-4c45-8c01-4a40042b977e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e963b-d316-4c45-8c01-4a40042b977e.jpg?1",
             "name": "Familiar Ground",
             "text": "Each creature you control can't be blocked by more than one creature each combat.",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "9e084e17-1aa9-5364-a90f-8695e563616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17fb15-fa7a-45f1-b2a4-0b4729a69fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17fb15-fa7a-45f1-b2a4-0b4729a69fea.jpg?1",
             "name": "Femeref Archers",
             "text": "oc\nT: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -7422,7 +7422,7 @@
         },
         {
             "id": "4ba798c6-c5a9-50ab-903c-af0348c80f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c06b61-f6b7-47d1-820a-01eb3f4497bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c06b61-f6b7-47d1-820a-01eb3f4497bc.jpg?1",
             "name": "Fog",
             "text": "Creatures deal no combat damage this turn.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "9923c7da-1cb9-590f-ae8f-807c193578f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2a2d39-92dd-4123-8a3f-5c756d22b6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2a2d39-92dd-4123-8a3f-5c756d22b6ee.jpg?1",
             "name": "Fyndhorn Brownie",
             "text": "o2o\nG, oc\nT: Untap target creature.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "7b75b7bb-68ca-50a7-b237-bca7cc995bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8876d176-5f4e-4c3c-b8b8-5a3fe2fedf65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8876d176-5f4e-4c3c-b8b8-5a3fe2fedf65.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool.",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "16016d7f-1ad3-50f4-9e3c-32e31c427906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9299742-564b-48ca-a7fa-cf5ed0d98ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9299742-564b-48ca-a7fa-cf5ed0d98ef6.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "c32d15c9-b980-556a-9771-2a087142153f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f78166-50e9-4aa8-9025-930b46f70041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f78166-50e9-4aa8-9025-930b46f70041.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can block as though it had flying.",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "50a72d88-2af1-5037-ad7f-522c0cc983e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a296e4f-7ac8-4c4b-99d1-c02963d26b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a296e4f-7ac8-4c4b-99d1-c02963d26b74.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1oo\nG Regenerate Gorilla Chieftain.",
             "colours": [
@@ -7617,7 +7617,7 @@
         },
         {
             "id": "47388ac5-8a7b-58c5-86ea-88d423c5ad67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c845b8-40f1-44df-9e91-dab7606f6271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c845b8-40f1-44df-9e91-dab7606f6271.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "19e3e45f-d294-5c20-bfb7-5a8dce45bebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ea4e2-a64e-4aa7-ade1-bbf6b67ce831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ea4e2-a64e-4aa7-ade1-bbf6b67ce831.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "40f40ba4-eca6-5744-bd5e-c63313454125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805d850-e3c2-44b4-87f0-8bba4038717c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805d850-e3c2-44b4-87f0-8bba4038717c.jpg?1",
             "name": "Living Lands",
             "text": "All forests are 1/1 creatures that are still lands.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "ca44162b-6c9f-53de-9e58-21c5b7a3330d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95a9a7-b0a3-4199-8c05-2519ccda738b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95a9a7-b0a3-4199-8c05-2519ccda738b.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [
@@ -7746,7 +7746,7 @@
         },
         {
             "id": "6658c957-68a3-517f-92e5-58065b020082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79eff92-b47f-4fc6-960c-f085127841ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79eff92-b47f-4fc6-960c-f085127841ca.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -7779,7 +7779,7 @@
         },
         {
             "id": "976403ae-815f-5352-8ae8-f8c30849c932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee9fb8b-5f1a-45ee-b9a4-a024b7b0936d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee9fb8b-5f1a-45ee-b9a4-a024b7b0936d.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -7812,7 +7812,7 @@
         },
         {
             "id": "f5c91798-9394-5821-8156-ce6133629a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95a777-9ba6-4858-9ea9-255b5301c71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95a777-9ba6-4858-9ea9-255b5301c71a.jpg?1",
             "name": "Nature's Resurgence",
             "text": "Each player draws as many cards as there are creature cards in his or her graveyard.",
             "colours": [
@@ -7843,7 +7843,7 @@
         },
         {
             "id": "87422cc4-b774-5bd6-afec-7d0c5e8a9cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba165e25-5328-40f4-b87c-9d02590f9d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba165e25-5328-40f4-b87c-9d02590f9d38.jpg?1",
             "name": "Panther Warriors",
             "text": "",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "c0a47ab0-9c32-5edd-9149-dc3c740e6a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9b18c-4993-4ce1-b2bd-ab14c9f3aad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9b18c-4993-4ce1-b2bd-ab14c9f3aad7.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nG, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -7911,7 +7911,7 @@
         },
         {
             "id": "5eb161aa-25a4-55d3-9574-5179dd63e6a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae5f0a-1fea-4c20-85b2-4b8eb2aba57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae5f0a-1fea-4c20-85b2-4b8eb2aba57c.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying until end of turn.",
             "colours": [
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "9d792b53-cd66-514c-9c33-5605701c489b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061c59-f8f3-4d47-9996-6f75ef27bd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061c59-f8f3-4d47-9996-6f75ef27bd4e.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -7975,7 +7975,7 @@
         },
         {
             "id": "fc87b990-0811-58ad-b381-0f32528eceeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a954994b-1858-47d3-a81a-5b01d4ea7619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a954994b-1858-47d3-a81a-5b01d4ea7619.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -8008,7 +8008,7 @@
         },
         {
             "id": "1c5bed86-d47d-5fa2-a46a-3e2b7233cc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3fc7bf-4a12-479a-af13-9b5703d46a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3fc7bf-4a12-479a-af13-9b5703d46a3a.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "ceded080-aaca-59b5-83b5-ad776b1dcb32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff58d35-eb23-47ee-9b8c-6919ad1a413a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff58d35-eb23-47ee-9b8c-6919ad1a413a.jpg?1",
             "name": "River Boa",
             "text": "Islandwalk (This creature is unblockable if defending player controls an island.)\noo\nG Regenerate River Boa.",
             "colours": [
@@ -8074,7 +8074,7 @@
         },
         {
             "id": "d895f1b4-94a1-5315-8f47-186baed198af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f17db7-6f3f-45ec-9ed2-dd15ce25ff07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f17db7-6f3f-45ec-9ed2-dd15ce25ff07.jpg?1",
             "name": "Rowen",
             "text": "Reveal the first card you draw each turn. Whenever you reveal a basic land card this way, draw a card.",
             "colours": [
@@ -8105,7 +8105,7 @@
         },
         {
             "id": "8fe9cd75-7611-5c41-a9ad-25663ab328fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3d8906-52d5-4ed1-b548-be13ca82f21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3d8906-52d5-4ed1-b548-be13ca82f21a.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -8138,7 +8138,7 @@
         },
         {
             "id": "1cd7f4ef-c22f-524a-8021-f462f179d9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f7b4be-dce2-414e-a9f4-f7e46c1bd15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f7b4be-dce2-414e-a9f4-f7e46c1bd15e.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk (This creature is unblockable if defending player controls a forest.)",
             "colours": [
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "340b6c6c-f4e0-5464-9b63-77e514344eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35730e8e-bc86-41d5-9c7a-75a92e6dd11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35730e8e-bc86-41d5-9c7a-75a92e6dd11e.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be blocked by more than one creature each combat.",
             "colours": [
@@ -8205,7 +8205,7 @@
         },
         {
             "id": "2c4c5e5b-3613-5b32-a348-1e2b90b1b53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b52f44-11fb-470a-b7ab-aaaeaf6f05e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b52f44-11fb-470a-b7ab-aaaeaf6f05e2.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "b6fe306d-e1c0-50d7-90ca-dbec48e1a35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185823cc-8c08-481f-9429-e996f4983090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185823cc-8c08-481f-9429-e996f4983090.jpg?1",
             "name": "Summer Bloom",
             "text": "Play up to three additional lands this turn.",
             "colours": [
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "4fd23af5-4a40-55a2-8ec4-49cb6d04918a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182fcd8-96ff-4232-917a-0fb4eb9bb7c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182fcd8-96ff-4232-917a-0fb4eb9bb7c2.jpg?1",
             "name": "Thicket Basilisk",
             "text": "Whenever Thicket Basilisk blocks or becomes blocked by a non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "84868018-50b8-5b99-8fa2-3180c256b3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6956b1-148e-47cc-8f5b-ec31e5e8c030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6956b1-148e-47cc-8f5b-ec31e5e8c030.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "c63a9ecb-5874-558f-9f75-013c4abf13e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177118a-6455-4177-8a6d-a43a03160ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177118a-6455-4177-8a6d-a43a03160ab3.jpg?1",
             "name": "Tranquil Grove",
             "text": "o1o\nGoo\nG Destroy all other enchantments.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "f2716d3d-6536-52ed-a45a-d94fcb7964ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51255821-abb7-4b8a-bc74-eb6c9788de02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51255821-abb7-4b8a-bc74-eb6c9788de02.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -8395,7 +8395,7 @@
         },
         {
             "id": "ce43db94-23d5-5ab2-8fb3-4ef1c0303664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a944ef-dbf2-47c9-a245-dfd2533a0680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a944ef-dbf2-47c9-a245-dfd2533a0680.jpg?1",
             "name": "Uktabi Orangutan",
             "text": "When Uktabi Orangutan comes into play, destroy target artifact.",
             "colours": [
@@ -8428,7 +8428,7 @@
         },
         {
             "id": "9035630b-2cef-5fc2-8df5-f85969db4368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7570b03-400e-482f-9d90-2d48b95d5ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7570b03-400e-482f-9d90-2d48b95d5ac3.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "Uktabi Wildcats's power and toughness are each equal to the number of forests you control.\no\nG, Sacrifice a forest: Regenerate Uktabi Wildcats.",
             "colours": [
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "a4241efe-b56a-5f34-a9a0-8ba3fb372dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc03eea5-ff21-4f4d-b4c2-ce9d8f456440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc03eea5-ff21-4f4d-b4c2-ce9d8f456440.jpg?1",
             "name": "Unseen Walker",
             "text": "Forestwalk (This creature is unblockable if defending player controls a forest.)\no1o\nGoo\nG Target creature gains forestwalk until end of turn.",
             "colours": [
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "8122a194-0945-574f-b746-50be2ca9c271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e522c2-ed5d-46bc-b043-6a37d6402a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e522c2-ed5d-46bc-b043-6a37d6402a9f.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a basic land card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "81523555-1efe-588b-925b-124e10f7a2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77131286-50ec-47a3-80fb-6194da338de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77131286-50ec-47a3-80fb-6194da338de6.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -8559,7 +8559,7 @@
         },
         {
             "id": "9086302a-37e4-59f8-9cc0-cf6fc52171ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a4569-fa62-4e1a-b837-f68159cb270d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a4569-fa62-4e1a-b837-f68159cb270d.jpg?1",
             "name": "Vitalize",
             "text": "Untap all creatures you control.",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "fdbe5c97-3eb1-57a4-8e75-0873ee98171d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6.jpg?1",
             "name": "Waiting in the Weeds",
             "text": "Each player counts the untapped forests he or she controls and puts that many 1/1 green Cat creature tokens into play.",
             "colours": [
@@ -8621,7 +8621,7 @@
         },
         {
             "id": "c9c681b6-ac13-5e1e-ad3d-c83e5c21ad85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65630c7-3813-404c-9919-0e46c557f7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65630c7-3813-404c-9919-0e46c557f7b8.jpg?1",
             "name": "Warthog",
             "text": "Swampwalk (This creature is unblockable if defending player controls a swamp.)",
             "colours": [
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "1125b692-e3c7-5b5a-b1bd-1dd6ac480787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac714416-60ec-477d-b49f-83b3853a409f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac714416-60ec-477d-b49f-83b3853a409f.jpg?1",
             "name": "Wild Growth",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional o\nG.",
             "colours": [
@@ -8687,7 +8687,7 @@
         },
         {
             "id": "44196b0e-62a9-507c-a224-6bcfcf60c29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d9054-5ad8-4a7d-a5c8-58bc39051834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d9054-5ad8-4a7d-a5c8-58bc39051834.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "80100e3c-7686-5578-99ca-211c11a226ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a24af58-5d75-4b41-a226-60abc415ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a24af58-5d75-4b41-a226-60abc415ff71.jpg?1",
             "name": "Wyluli Wolf",
             "text": "oc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -8751,7 +8751,7 @@
         },
         {
             "id": "a580f461-2432-53b0-b097-6496f6c68daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6595fe-8190-4e8c-8731-cd801f550eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6595fe-8190-4e8c-8731-cd801f550eab.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "3b0bfa9b-b62f-5b0a-8853-6a253dcc13e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db90a5e7-8238-442a-a6a4-78c59a6adb3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db90a5e7-8238-442a-a6a4-78c59a6adb3d.jpg?1",
             "name": "Amber Prison",
             "text": "You may choose not to untap Amber Prison during your untap step.\no4, oc\nT: Tap target artifact, creature, or land. As long as Amber Prison is tapped, that permanent doesn't untap during its controller's untap step.",
             "colours": [],
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "6e1067cb-0677-515b-b8d0-ebab556cafd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07903f1-defc-4ec7-accb-724b0219acd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07903f1-defc-4ec7-accb-724b0219acd8.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Whenever a land comes into play, Ankh of Mishra deals 2 damage to that land's controller.",
             "colours": [],
@@ -8832,7 +8832,7 @@
         },
         {
             "id": "d9076564-9e77-56db-9804-af3e9682e074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f8965-ecd3-4da2-80aa-9c5034c0cd3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f8965-ecd3-4da2-80aa-9c5034c0cd3b.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "8faf8cf8-ec0c-57eb-94d8-60e4d1d07e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec36f9a-cd66-4c01-ae3f-42fd82f0546b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec36f9a-cd66-4c01-ae3f-42fd82f0546b.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o1, Sacrifice Bottle of Suleiman: Flip a coin. If you lose the flip, Bottle of Suleiman deals 5 damage to you. If you win the flip, put a 5/5 Djinn artifact creature token into play. That creature has flying.",
             "colours": [],
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "0ddce71f-4e8a-5058-b746-33f977a99f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc870ce-f296-4cb8-950f-69440651f4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc870ce-f296-4cb8-950f-69440651f4e7.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond comes into play tapped.\noc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -8915,7 +8915,7 @@
         },
         {
             "id": "28119080-a4ac-5aa6-98ed-6d7b27400a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f1b0a3-fae4-4b87-99be-db1edabe62ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f1b0a3-fae4-4b87-99be-db1edabe62ed.jpg?1",
             "name": "Crystal Rod",
             "text": "Whenever a player plays a blue spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "a483eb21-8cf8-524c-afc5-3f06b0f4939b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048ceee4-0a56-4e43-92f2-80058844baba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048ceee4-0a56-4e43-92f2-80058844baba.jpg?1",
             "name": "Cursed Totem",
             "text": "Players can't play activated abilities of creatures.",
             "colours": [],
@@ -8969,7 +8969,7 @@
         },
         {
             "id": "df5954ce-8fd1-5896-8c33-d9b210fbf49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e64a6d-f54a-418e-8a84-63033447ab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e64a6d-f54a-418e-8a84-63033447ab38.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "42beeb5d-9f5b-51f4-9473-d69ec0ebea4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4262efc-c464-4f67-8885-2160d6a7f542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4262efc-c464-4f67-8885-2160d6a7f542.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into a graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "2434eb8a-1602-5cbb-ac9d-c9f2d1021e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c246aa71-b833-495b-9b12-54bd158dc2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c246aa71-b833-495b-9b12-54bd158dc2a8.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player chooses and discards a card from his or her hand. Play this ability only during your turn.",
             "colours": [],
@@ -9053,7 +9053,7 @@
         },
         {
             "id": "9b6158ff-2e73-5f56-a6da-3757fdae5636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b785730-32eb-40c0-83d0-a7ea59aac3e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b785730-32eb-40c0-83d0-a7ea59aac3e7.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: Dragon Engine gets +1/+0 until end of turn.",
             "colours": [],
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "f961f488-828c-5a92-a6ab-71c26e9910f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5109270-b052-489c-951c-d4b21a41ff6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5109270-b052-489c-951c-d4b21a41ff6f.jpg?1",
             "name": "Dragon Mask",
             "text": "o3, oc\nT: Target creature you control gets +2/+2 until end of turn. At end of turn, return that creature to its owner's hand.",
             "colours": [],
@@ -9110,7 +9110,7 @@
         },
         {
             "id": "3f8c9722-8330-5c16-ae46-06b9d3b36bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57070e7-6359-4be2-b4d3-4a3489a2deaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57070e7-6359-4be2-b4d3-4a3489a2deaa.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond comes into play tapped.\noc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -9139,7 +9139,7 @@
         },
         {
             "id": "a87dd351-b1dc-5da8-b518-b0b1bb9ccbf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936233f9-ad2a-4be1-8107-3ddcad783a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936233f9-ad2a-4be1-8107-3ddcad783a30.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn.",
             "colours": [],
@@ -9166,7 +9166,7 @@
         },
         {
             "id": "bb1bffde-5a2d-53fd-9b6d-6a45011a132d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40eed5d-adc2-469b-9a17-e368e8ebc34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40eed5d-adc2-469b-9a17-e368e8ebc34f.jpg?1",
             "name": "Fountain of Youth",
             "text": "o2, oc\nT: You gain 1 life.",
             "colours": [],
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "6b2852fb-b423-587d-976f-67e01b8e28b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc743ec-4845-4e2e-8918-7e7854ecccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc743ec-4845-4e2e-8918-7e7854ecccfc.jpg?1",
             "name": "Glasses of Urza",
             "text": "oc\nT: Look at target player's hand.",
             "colours": [],
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "ce3ecc70-35be-5733-bbf2-670a3e3de90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95017ca7-4f45-4aea-9973-ca3f0833f77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95017ca7-4f45-4aea-9973-ca3f0833f77f.jpg?1",
             "name": "Grinning Totem",
             "text": "o2, oc\nT, Sacrifice Grinning Totem: Search target opponent's library for a card and set that card aside. That player then shuffles his or her library. You may play the card as though it were in your hand. At the beginning of your next upkeep, if you haven't played the card, put it into its owner's graveyard.",
             "colours": [],
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "298dae5c-c604-56b2-97d6-96bce98f4e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3aa493-3801-400e-965e-e518c38eb770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3aa493-3801-400e-965e-e518c38eb770.jpg?1",
             "name": "The Hive",
             "text": "o5, oc\nT: Put a 1/1 Wasp artifact creature token into play. That creature has flying.",
             "colours": [],
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "c9ed18aa-0fc0-59b3-9134-dc2ff7681381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a6afe-c030-458c-8cc5-5051e0cd6fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a6afe-c030-458c-8cc5-5051e0cd6fd2.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws an additional card.",
             "colours": [],
@@ -9301,7 +9301,7 @@
         },
         {
             "id": "00a3da0c-10ca-5fab-a2b7-07b459f61fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1a0e8-3ca4-4928-9299-36efce7fb641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1a0e8-3ca4-4928-9299-36efce7fb641.jpg?1",
             "name": "Iron Star",
             "text": "Whenever a player plays a red spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "c23fc7d5-10ed-5fa8-b097-66b98f784415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade1a965-fd85-4545-a850-65c93132b8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade1a965-fd85-4545-a850-65c93132b8b5.jpg?1",
             "name": "Ivory Cup",
             "text": "Whenever a player plays a white spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -9355,7 +9355,7 @@
         },
         {
             "id": "1797f329-fc13-5898-86da-84a1d98482f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3055a4-9a1e-4cd3-993e-8fecb6eee9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3055a4-9a1e-4cd3-993e-8fecb6eee9a3.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: The next time a source of your choice would deal damage to target creature this turn, that damage is dealt to you instead.",
             "colours": [],
@@ -9382,7 +9382,7 @@
         },
         {
             "id": "ac3a6b9f-32cd-5aae-a0ba-d7fa062466b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0489c2d-bcf9-4179-b07a-781c6ac07980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0489c2d-bcf9-4179-b07a-781c6ac07980.jpg?1",
             "name": "Jalum Tome",
             "text": "o2, oc\nT: Draw a card, then choose and discard a card from your hand.",
             "colours": [],
@@ -9409,7 +9409,7 @@
         },
         {
             "id": "d140ba57-f08b-5c36-82eb-5c24df3bb636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c53463-5e99-430d-b824-2650264e8fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c53463-5e99-430d-b824-2650264e8fe8.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw a card.",
             "colours": [],
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "43ca3ff6-4455-588b-b894-3d436f116cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba3857-9bd7-434d-b77f-d697776f33e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba3857-9bd7-434d-b77f-d697776f33e4.jpg?1",
             "name": "Lead Golem",
             "text": "Whenever Lead Golem attacks, it doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "a997ee26-0720-5665-a019-c5926a14e307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f77654-7e37-4c0d-9dd2-fb79e968bd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f77654-7e37-4c0d-9dd2-fb79e968bd15.jpg?1",
             "name": "Mana Prism",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add one mana of a color of your choice to your mana pool.",
             "colours": [],
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "c02ccc0c-103b-5ee3-adb9-7beba95c2402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20b4858-3648-4a86-a3c1-698254f90d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20b4858-3648-4a86-a3c1-698254f90d5b.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond comes into play tapped.\noc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "1c8f7cc9-fdf2-5017-adcd-1a335903738f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d01df6-ede2-4cca-89a5-b041b1238ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d01df6-ede2-4cca-89a5-b041b1238ebb.jpg?1",
             "name": "Meekstone",
             "text": "Each creature with power 3 or greater doesn't untap during its controller's untap step.",
             "colours": [],
@@ -9549,7 +9549,7 @@
         },
         {
             "id": "d14e65f4-6db9-5b3a-b8ad-69f0d07b6baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8207d783-2548-45fe-b830-d24c677c1c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8207d783-2548-45fe-b830-d24c677c1c8e.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Put the top two cards of target player's library into his or her graveyard.",
             "colours": [],
@@ -9576,7 +9576,7 @@
         },
         {
             "id": "72475d53-4202-5a84-8e68-74a5166f9646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2551f-f267-4c30-b631-d755e43dc237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2551f-f267-4c30-b631-d755e43dc237.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond comes into play tapped.\noc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "4bc5e73f-4d71-525c-8422-928178b3e663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80bfd76-52f9-4dea-9056-8570c9b290a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80bfd76-52f9-4dea-9056-8570c9b290a4.jpg?1",
             "name": "Mystic Compass",
             "text": "o1, oc\nT: Target land is a basic land type of your choice until end of turn.",
             "colours": [],
@@ -9632,7 +9632,7 @@
         },
         {
             "id": "e221143b-1e7d-5d8d-b94f-bb51eb55393e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96123be9-c1df-418f-b2b3-98746a0f1692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96123be9-c1df-418f-b2b3-98746a0f1692.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "ebaf3ee3-65a2-5be7-a83f-9f3385d7b762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c6ac8a-01b1-4af5-89d8-ad66d9a81ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c6ac8a-01b1-4af5-89d8-ad66d9a81ceb.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -9692,7 +9692,7 @@
         },
         {
             "id": "2b7e2aa0-e8b1-50dc-a92f-9358e6999032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d7ea-6240-44a4-9792-6a8416d15e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d7ea-6240-44a4-9792-6a8416d15e49.jpg?1",
             "name": "Patagia Golem",
             "text": "o3: Patagia Golem gains flying until end of turn.",
             "colours": [],
@@ -9722,7 +9722,7 @@
         },
         {
             "id": "a156c4c3-63fe-50c3-a43c-8a69f7966eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b5650-8b2c-4d2d-9829-3208c130116a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b5650-8b2c-4d2d-9829-3208c130116a.jpg?1",
             "name": "Pentagram of the Ages",
             "text": "o4, oc\nT: The next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [],
@@ -9749,7 +9749,7 @@
         },
         {
             "id": "ea2487bc-a6a9-53b4-a4f5-d7865d958b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f4d88-4773-4520-b4df-22ae6008ebc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f4d88-4773-4520-b4df-22ae6008ebc1.jpg?1",
             "name": "Phyrexian Vault",
             "text": "o2, oc\nT, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "506f047e-5ca7-59f4-aa93-47543c894387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f588d-9ee6-4436-ad75-46a84dd2b168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f588d-9ee6-4436-ad75-46a84dd2b168.jpg?1",
             "name": "Primal Clay",
             "text": "Primal Clay comes into play as your choice of a 3/3 artifact creature; a 2/2 artifact creature with flying; or a 1/6 Wall artifact creature. (Walls can't attack.)",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "5456bcf2-b8c9-5415-9e50-23c83ae50af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bf5fd-141a-4743-ad73-70ec2173e476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bf5fd-141a-4743-ad73-70ec2173e476.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -9833,7 +9833,7 @@
         },
         {
             "id": "920e48e1-1185-51a2-9a15-83b253d207df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1967f0-f6a9-469a-96f9-57fe77059e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1967f0-f6a9-469a-96f9-57fe77059e88.jpg?1",
             "name": "Skull Catapult",
             "text": "o1, oc\nT, Sacrifice a creature: Skull Catapult deals 2 damage to target creature or player.",
             "colours": [],
@@ -9860,7 +9860,7 @@
         },
         {
             "id": "6c80de5b-efbe-5323-a934-7ff4773f757a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c771a9-a652-4661-a175-a97d4684cd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c771a9-a652-4661-a175-a97d4684cd92.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond comes into play tapped.\noc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -9889,7 +9889,7 @@
         },
         {
             "id": "853c438e-81c0-5067-b317-82a046b3ad0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9bc174-1d10-49bf-af4f-2f6061b1796e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9bc174-1d10-49bf-af4f-2f6061b1796e.jpg?1",
             "name": "Snake Basket",
             "text": "o\nX, Sacrifice Snake Basket: Put X 1/1 green Cobra creature tokens into play. Play this ability only if you're allowed to play a sorcery.",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "f0ee2f13-9add-5873-9436-61d75a34aeba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22d79a5-1da4-475e-9605-f4c7bdc76590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22d79a5-1da4-475e-9605-f4c7bdc76590.jpg?1",
             "name": "Soul Net",
             "text": "Whenever a creature is put into a graveyard from play, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -9943,7 +9943,7 @@
         },
         {
             "id": "9094bfdf-cc94-57f8-8603-c65476dca3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab556986-a6f4-4445-b004-64b4bc189e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab556986-a6f4-4445-b004-64b4bc189e55.jpg?1",
             "name": "Storm Cauldron",
             "text": "Each player may play an additional land during each of his or her turns.\nWhenever a land is tapped for mana, return it to its owner's hand.",
             "colours": [],
@@ -9970,7 +9970,7 @@
         },
         {
             "id": "eefb27ca-2d90-5471-afb1-07f0e0a9f95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5caf27-e426-420b-895d-a359e6021993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5caf27-e426-420b-895d-a359e6021993.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player counts the cards in his or her hand, puts them on the bottom of his or her library, and then draws that many cards.",
             "colours": [],
@@ -9997,7 +9997,7 @@
         },
         {
             "id": "be26096f-3770-53d2-9167-5f7f8c613eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca1df90-d51a-4d2f-a03f-a4591031671d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca1df90-d51a-4d2f-a03f-a4591031671d.jpg?1",
             "name": "Throne of Bone",
             "text": "Whenever a player plays a black spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -10024,7 +10024,7 @@
         },
         {
             "id": "f147e35f-8b9b-5636-9189-56c4b70d3152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f37dd8-87d6-432f-a60d-a7a699da3080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f37dd8-87d6-432f-a60d-a7a699da3080.jpg?1",
             "name": "Wand of Denial",
             "text": "oc\nT: Look at the top card of target player's library. If it's a nonland card, you may pay 2 life. If you do, put it into that player's graveyard.",
             "colours": [],
@@ -10051,7 +10051,7 @@
         },
         {
             "id": "1b6ba678-3313-56d9-9c99-4e198b64998e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef706d86-6e7f-4f3a-9e4d-8aa6d9aac74a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef706d86-6e7f-4f3a-9e4d-8aa6d9aac74a.jpg?1",
             "name": "Wooden Sphere",
             "text": "Whenever a player plays a green spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -10078,7 +10078,7 @@
         },
         {
             "id": "82327e30-d60c-5733-8d8e-3caddc957530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764eff32-466f-4443-a3db-1007f446980b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764eff32-466f-4443-a3db-1007f446980b.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "0f6bde03-6078-5786-8064-c352a8589136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792f4213-67ab-41d9-975d-ff783668f93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792f4213-67ab-41d9-975d-ff783668f93d.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "d60769cf-9eaa-557a-9f16-db7e4f92414c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff64e0-e7bd-4e82-8495-2cc8889c4107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff64e0-e7bd-4e82-8495-2cc8889c4107.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass is tapped, it deals 1 damage to you.\noc\nT: Add one mana of a color of your choice to your mana pool.",
             "colours": [],
@@ -10165,7 +10165,7 @@
         },
         {
             "id": "fa4f7fd8-becd-5deb-98a4-7e907f348cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a807243-fdcd-4dfb-b9d1-a15859a15c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a807243-fdcd-4dfb-b9d1-a15859a15c51.jpg?1",
             "name": "Crystal Vein",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Crystal Vein: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "1ac0ed04-a088-5323-b275-fe7c02cd6355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840627fa-dec9-481e-b356-56f3d079a60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840627fa-dec9-481e-b356-56f3d079a60c.jpg?1",
             "name": "Dwarven Ruins",
             "text": "Dwarven Ruins comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Dwarven Ruins: Add o\nRo\nR to your mana pool.",
             "colours": [],
@@ -10221,7 +10221,7 @@
         },
         {
             "id": "6cef8b4d-18d9-5eb9-b44f-e427c9cc1085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b386a-d148-41c8-b540-5637cc0eb458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b386a-d148-41c8-b540-5637cc0eb458.jpg?1",
             "name": "Ebon Stronghold",
             "text": "Ebon Stronghold comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Ebon Stronghold: Add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "3913206a-4d26-5026-a94b-3e892535241b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2f7ee8-bd9b-40a7-9ae2-268b4b9f8315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2f7ee8-bd9b-40a7-9ae2-268b4b9f8315.jpg?1",
             "name": "Havenwood Battleground",
             "text": "Havenwood Battleground comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Havenwood Battleground: Add o\nGo\nG to your mana pool.",
             "colours": [],
@@ -10279,7 +10279,7 @@
         },
         {
             "id": "1b24ca7e-8657-5541-91bb-7c405f8b77ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e8e26-3fb3-4388-bc64-fa751e401dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e8e26-3fb3-4388-bc64-fa751e401dca.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "c9e9a206-c2a5-5f8d-bafb-a6f0806da45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaeb7-7061-4e8c-a086-32a12b6e2666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaeb7-7061-4e8c-a086-32a12b6e2666.jpg?1",
             "name": "Ruins of Trokair",
             "text": "Ruins of Trokair comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Ruins of Trokair: Add o\nWo\nW to your mana pool.",
             "colours": [],
@@ -10338,7 +10338,7 @@
         },
         {
             "id": "e51ebe50-e880-5a44-acaf-a90060ffd5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e40dcb-fde5-4eb0-9e2b-6109132332a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e40dcb-fde5-4eb0-9e2b-6109132332a8.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -10368,7 +10368,7 @@
         },
         {
             "id": "5cd433cb-23fc-5466-badf-8ee04cc66b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d57618a-21d2-4ded-9f17-d72786869b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d57618a-21d2-4ded-9f17-d72786869b19.jpg?1",
             "name": "Svyelunite Temple",
             "text": "Svyelunite Temple comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Svyelunite Temple: Add o\nUo\nU to your mana pool.",
             "colours": [],
@@ -10397,7 +10397,7 @@
         },
         {
             "id": "28be14cd-96a2-52c6-b462-c7d8951be39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142dd41a-0e98-41d7-9de9-63cda1cf8915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142dd41a-0e98-41d7-9de9-63cda1cf8915.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "22ee9de2-7951-56cd-9048-b9418a2c842e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1ab59-3771-484c-8a79-2bb36655b6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1ab59-3771-484c-8a79-2bb36655b6dd.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10464,7 +10464,7 @@
         },
         {
             "id": "f86dec0f-e26d-531b-807a-93d4f7259ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c789adc0-69ed-4d1c-8a20-ca219020fd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c789adc0-69ed-4d1c-8a20-ca219020fd2c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "4cf91220-6c0a-57aa-84fc-4659adb0c8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addf844-2790-4da5-a22d-18df878f2219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addf844-2790-4da5-a22d-18df878f2219.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10538,7 +10538,7 @@
         },
         {
             "id": "7d721cd4-0444-5c87-babf-7118a1d3066b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978fa58-0860-4082-a674-2d6abce899b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978fa58-0860-4082-a674-2d6abce899b9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10575,7 +10575,7 @@
         },
         {
             "id": "bb1aa770-47eb-5daf-a089-e37ad44dfa5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f9ffc8-8115-4858-bd71-deaca9889f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f9ffc8-8115-4858-bd71-deaca9889f72.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10612,7 +10612,7 @@
         },
         {
             "id": "a16d4088-e362-5c17-9b1c-4033c13834b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e8da7b-f565-403b-9603-5f53cd3be8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e8da7b-f565-403b-9603-5f53cd3be8fe.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10649,7 +10649,7 @@
         },
         {
             "id": "094ab429-388b-52e0-93a6-5855781e744f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8958d4-067b-4815-a128-5d1577b94173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8958d4-067b-4815-a128-5d1577b94173.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10686,7 +10686,7 @@
         },
         {
             "id": "bc879be8-0856-5688-b4d0-9bb0f2747eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ff74a8-e1e8-41ec-98fc-1529f4075074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ff74a8-e1e8-41ec-98fc-1529f4075074.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "0c83ca66-3282-533d-8344-cbfda7d18faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2a9fa6-3c7c-409a-8565-e3d533107971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2a9fa6-3c7c-409a-8565-e3d533107971.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10760,7 +10760,7 @@
         },
         {
             "id": "4cd8b145-a2ab-508b-99d6-65bda4bfdfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af0cba-c058-4833-a74a-21ad91e5ad7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af0cba-c058-4833-a74a-21ad91e5ad7c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10797,7 +10797,7 @@
         },
         {
             "id": "6bdebecc-b0e9-5f42-a6ab-db585b98c3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9019a639-929a-40d9-98b1-6b5268da5246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9019a639-929a-40d9-98b1-6b5268da5246.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10834,7 +10834,7 @@
         },
         {
             "id": "151f0d39-58bc-5e8e-ac8f-67f2c7e13720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c576c27d-f361-4448-8607-0f6a99642283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c576c27d-f361-4448-8607-0f6a99642283.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10871,7 +10871,7 @@
         },
         {
             "id": "cea0db39-b74c-5f20-9334-aabb6c192f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e450ae-3ed8-424f-b974-7d9a8e8ac7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e450ae-3ed8-424f-b974-7d9a8e8ac7e4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10908,7 +10908,7 @@
         },
         {
             "id": "aefce677-f215-565c-8db4-10bbfb2c9d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7681b-37e3-4f6c-8415-ab9613446ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7681b-37e3-4f6c-8415-ab9613446ccc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10945,7 +10945,7 @@
         },
         {
             "id": "d824822e-0943-5a46-bfd9-e4a134c74c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c17b3c-6f3b-4952-a06b-0df5a5a18f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c17b3c-6f3b-4952-a06b-0df5a5a18f0d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "a9dc2754-2a14-574d-ab28-fd34958e6126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95585c69-6474-432e-b80a-489a2b69d4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95585c69-6474-432e-b80a-489a2b69d4e6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11019,7 +11019,7 @@
         },
         {
             "id": "25d0bf7f-1a5d-579f-97f3-f4b18db45d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc477b44-a7b3-4dda-b897-6f164e28541b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc477b44-a7b3-4dda-b897-6f164e28541b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11056,7 +11056,7 @@
         },
         {
             "id": "612715d9-fcfa-51c7-beb3-3a93f10da4b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c256a-1f0e-4e57-9667-5b8cb2f18ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c256a-1f0e-4e57-9667-5b8cb2f18ff0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11093,7 +11093,7 @@
         },
         {
             "id": "60bd17e0-c71c-5700-8ec5-ba8badbb9a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade2cdc-9625-427b-92b2-9596ac48904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade2cdc-9625-427b-92b2-9596ac48904b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11130,7 +11130,7 @@
         },
         {
             "id": "f99a52fc-d88e-5225-849a-4c3e96d66e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e57a496-09ce-4c2d-9a00-0c359d01e78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e57a496-09ce-4c2d-9a00-0c359d01e78e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/7ED.json
+++ b/Assets/Resources/Sets/7ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "cfe05eff-7428-53ef-afc8-788ef5964925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aebe60-bbd4-4591-bf3c-6cec67e41cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aebe60-bbd4-4591-bf3c-6cec67e41cf6.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "ab55424f-58d5-5d9b-bc0d-01e9368aa5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a610860b-cc2f-4f7e-99f4-481d15c7cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a610860b-cc2f-4f7e-99f4-481d15c7cd90.jpg?1",
             "name": "Angelic Page",
             "text": "",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "1ba5c10c-b45e-5151-96bf-2f3d158c2985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67252f6-0265-4f4e-8db8-2d1853262f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67252f6-0265-4f4e-8db8-2d1853262f91.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "7dd7c5f8-8b74-541c-952c-26e72f799657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b57b5e-134e-45a7-92d6-670d762d68b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b57b5e-134e-45a7-92d6-670d762d68b4.jpg?1",
             "name": "Ardent Militia",
             "text": "",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "f5dfb9d3-eb40-5f32-a1cd-90534b56b01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1d373-f619-4855-9154-aee6deeacb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1d373-f619-4855-9154-aee6deeacb59.jpg?1",
             "name": "Blessed Reversal",
             "text": "You gain 3 life for each creature attacking you.",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "c812a5f0-2a05-51f8-9ae2-f6667d15920d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aaa618-ebe9-43ff-90dd-7ab1429f2c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aaa618-ebe9-43ff-90dd-7ab1429f2c58.jpg?1",
             "name": "Blessed Reversal",
             "text": "",
             "colours": [
@@ -214,7 +214,7 @@
         },
         {
             "id": "8601b57c-aa16-50a3-b80c-c7cb077705b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee1bad3-85e0-4c65-916c-d744e6e6ec61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee1bad3-85e0-4c65-916c-d744e6e6ec61.jpg?1",
             "name": "Breath of Life",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "d59b03b8-27ca-5b35-8c98-e64130464d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a985b-d57a-4409-9ec4-fabd31afc461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a985b-d57a-4409-9ec4-fabd31afc461.jpg?1",
             "name": "Breath of Life",
             "text": "",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "1d5daf66-94b9-5e7b-8086-950384df8f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe82e29-e781-48bf-8673-7954553f7cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe82e29-e781-48bf-8673-7954553f7cf0.jpg?1",
             "name": "Castle",
             "text": "Untapped creatures you control get +0/+2.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "92913e85-7b3a-5970-896f-b2ddf8615338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c73efe3-e3ab-4161-88cc-82d3ac7d6a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c73efe3-e3ab-4161-88cc-82d3ac7d6a4a.jpg?1",
             "name": "Castle",
             "text": "",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "e4aff119-2578-5b1b-92c1-ab83bfc9bcef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7967ce4-6688-40d0-bedb-4e0f38502f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7967ce4-6688-40d0-bedb-4e0f38502f09.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "0699ca11-e6d0-5503-ae33-ea74ff283a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c8da0-0201-41ab-be98-8ed3a899cd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c8da0-0201-41ab-be98-8ed3a899cd3d.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "592f46da-afcc-51fe-b323-e5d3daab5f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babb5c99-6cb1-4b13-8aac-e495d508a61c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babb5c99-6cb1-4b13-8aac-e495d508a61c.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: The next time a blue source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "84ef0f0c-116a-5812-8fff-88ef661c48ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb254e-137f-4920-9e2b-d4fbe7861101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb254e-137f-4920-9e2b-d4fbe7861101.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "9a898043-cf57-5192-9355-31eac4114e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0b146-4241-436b-b8b0-45a9be21ead7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0b146-4241-436b-b8b0-45a9be21ead7.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: The next time a green source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "89737e69-cc9d-54a6-a9ed-c43895af45d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf8b0e9-a420-4066-b423-90eec1f27eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf8b0e9-a420-4066-b423-90eec1f27eb0.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "a3d7c9d3-c252-5254-8590-068935de2085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4833ce-5e7b-402e-97a9-4411aa62a46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4833ce-5e7b-402e-97a9-4411aa62a46c.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "c51f205a-106c-5e98-bc98-81c000831c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a65a2a3-ee40-4a00-aa66-f64b04ccdaa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a65a2a3-ee40-4a00-aa66-f64b04ccdaa8.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "16bdfc1c-f8ea-51c1-a64b-2ffd02cbfe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cab871-5783-40e1-a065-0607a842998b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cab871-5783-40e1-a065-0607a842998b.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: The next time a white source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "d7b9f247-8d3d-5718-b9cf-589b331908cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d55297-9049-4627-8154-bafdef63c66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d55297-9049-4627-8154-bafdef63c66d.jpg?1",
             "name": "Circle of Protection: White",
             "text": "",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "6aa8923c-0503-5f48-9ae6-3600d5d83106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cd5854-56ef-48ec-ad12-1690fa45b4a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cd5854-56ef-48ec-ad12-1690fa45b4a5.jpg?1",
             "name": "Cloudchaser Eagle",
             "text": "Flying\nWhen Cloudchaser Eagle comes into play, destroy target enchantment.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "95b3f21f-96c6-5ff2-b22f-0c0ba36ece6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c95d068-e153-4ac9-bce6-c79ef4fe101d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c95d068-e153-4ac9-bce6-c79ef4fe101d.jpg?1",
             "name": "Cloudchaser Eagle",
             "text": "",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "25c3ae0f-f7eb-5745-a5bc-6c86f0a308ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61cc896-1da5-419c-87db-01321522c40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61cc896-1da5-419c-87db-01321522c40b.jpg?1",
             "name": "Crossbow Infantry",
             "text": "oc\nT: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "537acf95-677a-5eff-aed9-38316aef66b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bedaa217-8dbd-4d2c-961a-a7cff2398832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bedaa217-8dbd-4d2c-961a-a7cff2398832.jpg?1",
             "name": "Crossbow Infantry",
             "text": "",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "143b0fd0-d24d-5edc-acf6-94674be12e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f71fc-807c-4718-956b-7ffe66c646d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f71fc-807c-4718-956b-7ffe66c646d4.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "a7569782-df72-5df9-85ed-9232374eced9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4715aacd-ca2f-4dbf-b1a1-c171dea7305f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4715aacd-ca2f-4dbf-b1a1-c171dea7305f.jpg?1",
             "name": "Disenchant",
             "text": "",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "5e817a4b-0fcd-546b-8cda-9ed63d4ec0b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b89ce6-8a73-4e27-8696-e65ea0c16925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b89ce6-8a73-4e27-8696-e65ea0c16925.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "8ef1aa9e-c26a-5fa0-b1e2-94840eb54302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b718ad-1ca3-4587-994d-6a9df47db1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b718ad-1ca3-4587-994d-6a9df47db1e0.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "25e2bc90-61c6-54f8-885c-44741131681c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dc7a7b-ec69-406f-82c5-9af54ac1e9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dc7a7b-ec69-406f-82c5-9af54ac1e9a3.jpg?1",
             "name": "Elite Archers",
             "text": "oc\nT: Elite Archers deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "bedd66e9-a754-5bf6-b2ae-8b4e5ffa0f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269193a9-2647-4b7a-a51b-6e2eae160020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269193a9-2647-4b7a-a51b-6e2eae160020.jpg?1",
             "name": "Elite Archers",
             "text": "",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "53b59473-d5e9-524e-b823-a963080d618e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43378f0-b518-499e-9950-c583bc2f11f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43378f0-b518-499e-9950-c583bc2f11f8.jpg?1",
             "name": "Gerrard's Wisdom",
             "text": "You gain 2 life for each card in your hand.",
             "colours": [
@@ -1065,7 +1065,7 @@
         },
         {
             "id": "73c9e320-f0ab-5cec-82a5-d018b763ca6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71618fb4-22ab-4ef5-932d-69bf596a69d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71618fb4-22ab-4ef5-932d-69bf596a69d0.jpg?1",
             "name": "Gerrard's Wisdom",
             "text": "",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "618b0e3d-b864-56a9-a6ca-04cb0e26ca2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f18de6-a99b-49ce-812b-bca8b0aaec38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f18de6-a99b-49ce-812b-bca8b0aaec38.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "1e1f8f5d-6df1-5770-99e6-2e8c475d7224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607ddd6d-db70-4db0-a3ac-caaa911c8fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607ddd6d-db70-4db0-a3ac-caaa911c8fe4.jpg?1",
             "name": "Glorious Anthem",
             "text": "",
             "colours": [
@@ -1164,7 +1164,7 @@
         },
         {
             "id": "2e5ec1d9-e7cb-579e-acfd-49144acd031b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670a69a-bd68-4de9-bf83-c912564012f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670a69a-bd68-4de9-bf83-c912564012f6.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "de7577ff-c717-56bb-a2d2-96ec3378e771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eff9691-f3e0-4622-ae8f-b884763bbcd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eff9691-f3e0-4622-ae8f-b884763bbcd6.jpg?1",
             "name": "Healing Salve",
             "text": "",
             "colours": [
@@ -1230,7 +1230,7 @@
         },
         {
             "id": "8fed2ceb-3f5b-5ba5-8baa-77b14aa57553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b665186-7ee5-47dd-b849-cb9c318f31e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b665186-7ee5-47dd-b849-cb9c318f31e6.jpg?1",
             "name": "Heavy Ballista",
             "text": "oc\nT: Heavy Ballista deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "38da3bb8-dfa6-5bc3-aa50-05ea80d495ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6e66f3-8a2e-4b68-b483-7cb6923bd9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6e66f3-8a2e-4b68-b483-7cb6923bd9f9.jpg?1",
             "name": "Heavy Ballista",
             "text": "",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "762fbb16-0eba-5815-beeb-472711966e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabca37-9099-41ca-a169-33332c82d76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabca37-9099-41ca-a169-33332c82d76f.jpg?1",
             "name": "Holy Strength",
             "text": "Enchanted creature gets +1/+2.",
             "colours": [
@@ -1337,7 +1337,7 @@
         },
         {
             "id": "1a055628-85a1-570d-987a-5c127c70450f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20ca0f-8747-43a6-9723-bca7669badb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20ca0f-8747-43a6-9723-bca7669badb7.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1372,7 +1372,7 @@
         },
         {
             "id": "cf3a5ffb-78eb-5452-8830-578bff7d5335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff788a3-3182-4bf5-897e-521d977e6aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff788a3-3182-4bf5-897e-521d977e6aaf.jpg?1",
             "name": "Honor Guard",
             "text": "oo\nW Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "a0b83a94-6684-58eb-879c-c9e57b1062be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3725d9-b58a-4632-b542-26fa94b3ba6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3725d9-b58a-4632-b542-26fa94b3ba6b.jpg?1",
             "name": "Honor Guard",
             "text": "",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "04895a52-82da-52ac-9806-afafd142071d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49430d37-03af-4088-a92b-9e0ff3defe29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49430d37-03af-4088-a92b-9e0ff3defe29.jpg?1",
             "name": "Intrepid Hero",
             "text": "oc\nT: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1480,7 +1480,7 @@
         },
         {
             "id": "3977f1a4-6418-51e7-b791-85a8769ed27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f544e171-c26b-4c14-96ff-3d3ddce7e785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f544e171-c26b-4c14-96ff-3d3ddce7e785.jpg?1",
             "name": "Intrepid Hero",
             "text": "",
             "colours": [
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "2fcaae1c-3291-5b33-adea-5a94ea324217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da50eb5-e559-4d67-8568-d5be80ff62de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da50eb5-e559-4d67-8568-d5be80ff62de.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: All combat damage that unblocked creatures would deal to you this turn is dealt to Kjeldoran Royal Guard instead.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "8873d399-e0cc-52d8-b7b0-6969cdcd4de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb58da0d-4f11-4973-ac9c-d541031ff728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb58da0d-4f11-4973-ac9c-d541031ff728.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "9c6449d5-0a0c-5ee4-a0aa-97c9193bcbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1d55b-6be0-4bb5-b452-ba4994b21774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1d55b-6be0-4bb5-b452-ba4994b21774.jpg?1",
             "name": "Knight Errant",
             "text": "",
             "colours": [
@@ -1624,7 +1624,7 @@
         },
         {
             "id": "5d118f3d-68e3-56a9-b45e-5d7e9e180ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413f10fe-0e53-46ca-bd64-0d66dee8882d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413f10fe-0e53-46ca-bd64-0d66dee8882d.jpg?1",
             "name": "Knight Errant",
             "text": "",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "c9bc5770-4953-5547-a872-0a3dc13c30a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da88c0a-255d-4484-b464-bd742d66e3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da88c0a-255d-4484-b464-bd742d66e3fe.jpg?1",
             "name": "Knighthood",
             "text": "Creatures you control have first strike.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "34b70cd0-fa14-5ae5-9693-c563674b7f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e367b-329f-4ee6-be1e-6263ccc0f06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e367b-329f-4ee6-be1e-6263ccc0f06d.jpg?1",
             "name": "Knighthood",
             "text": "",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "03266ee0-8dad-50cd-a304-9d2acb3c833c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac3672e-ebab-4bb1-bf4d-5020047296d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac3672e-ebab-4bb1-bf4d-5020047296d8.jpg?1",
             "name": "Longbow Archer",
             "text": "First strike\nLongbow Archer may block as though it had flying.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "0ee33b35-0a47-535f-842e-530f79e49fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0437fd-070a-4679-b1c9-6cb22820d181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0437fd-070a-4679-b1c9-6cb22820d181.jpg?1",
             "name": "Longbow Archer",
             "text": "",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "d32b62b9-13eb-52c4-87e6-6350d7183efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfdc12c-fd1f-4053-8a1a-63f440ef0102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfdc12c-fd1f-4053-8a1a-63f440ef0102.jpg?1",
             "name": "Master Healer",
             "text": "oc\nT: Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "48904c35-c5d3-527f-bddf-2cbe48c2838a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5be6df-f35e-4696-a08e-fd725ee9b13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5be6df-f35e-4696-a08e-fd725ee9b13c.jpg?1",
             "name": "Master Healer",
             "text": "",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "d55f9832-d162-5d37-9a7a-c9f367d09f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed1fb50-b7c3-43e9-a0ef-a33135a12300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed1fb50-b7c3-43e9-a0ef-a33135a12300.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target black permanent.",
             "colours": [
@@ -1908,7 +1908,7 @@
         },
         {
             "id": "db315f00-61b8-572a-ab4a-6a387cf89800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cce5e-3af9-4f51-8d65-35be576df236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cce5e-3af9-4f51-8d65-35be576df236.jpg?1",
             "name": "Northern Paladin",
             "text": "",
             "colours": [
@@ -1944,7 +1944,7 @@
         },
         {
             "id": "96ad96eb-1325-5b1b-821b-cae348224b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6758f0-86da-4812-bbe0-ebbb8c67937a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6758f0-86da-4812-bbe0-ebbb8c67937a.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "006f4667-e7b7-5937-a6fb-76fb6ecb29f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3524e49-93df-4a3d-808e-7a2d31c3a12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3524e49-93df-4a3d-808e-7a2d31c3a12d.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "e5a88536-54c7-576d-b734-14f53099a0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079b8e9b-74ac-48c0-8c65-82d70911dd9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079b8e9b-74ac-48c0-8c65-82d70911dd9e.jpg?1",
             "name": "Pariah",
             "text": "All damage that would be dealt to you is dealt to enchanted creature instead.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "8b0773fc-9a64-5a6c-aa42-0286709b9659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a94805d-9f71-4968-a297-7d93859fe79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a94805d-9f71-4968-a297-7d93859fe79f.jpg?1",
             "name": "Pariah",
             "text": "",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "2f4a2e9c-1e59-589c-bcac-bfcdfc59177b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfb77ea-6776-4bb4-886d-9a60f56e1fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfb77ea-6776-4bb4-886d-9a60f56e1fa7.jpg?1",
             "name": "Purify",
             "text": "Destroy all artifacts and enchantments.",
             "colours": [
@@ -2117,7 +2117,7 @@
         },
         {
             "id": "890387a6-de62-5e6e-a38c-f08c057ff255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f84bff-a9e7-4bc4-9dc9-b5eb34166d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f84bff-a9e7-4bc4-9dc9-b5eb34166d40.jpg?1",
             "name": "Purify",
             "text": "",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "670fa953-60ac-52f6-8ad5-fe3567e9f3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc73761c-6d1a-4466-9be1-b350a1dcc48a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc73761c-6d1a-4466-9be1-b350a1dcc48a.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "39439f67-3de7-5774-baf0-c81b408c461b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3131a2d-05b3-494c-9373-e1a7913615f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3131a2d-05b3-494c-9373-e1a7913615f9.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "70124c60-9bf0-5526-9b4a-b6df7b64e4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3868f7ff-8a84-4153-bf5a-ff001d34e0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3868f7ff-8a84-4153-bf5a-ff001d34e0f0.jpg?1",
             "name": "Reprisal",
             "text": "Destroy target creature with power 4 or greater. It can't be regenerated.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "741a14a5-6ad0-5e68-af8a-6d801822da2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f73b0f4-cf49-4ae3-8117-0e2e37c7ab31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f73b0f4-cf49-4ae3-8117-0e2e37c7ab31.jpg?1",
             "name": "Reprisal",
             "text": "",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "5a5c7cdb-2545-5dcf-9ade-59b04a8bf89b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af458eaa-ee16-4b2b-9a55-259458357224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af458eaa-ee16-4b2b-9a55-259458357224.jpg?1",
             "name": "Reverse Damage",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain that much life.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "2a410da7-4d99-532d-80d0-0b94a4950bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867777d-000d-48b9-99da-1c2194722dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867777d-000d-48b9-99da-1c2194722dde.jpg?1",
             "name": "Reverse Damage",
             "text": "",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "dc814515-3dd0-5fbd-9fe3-66730d4549b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9993e9c6-2e30-4bf4-838d-751cbd153390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9993e9c6-2e30-4bf4-838d-751cbd153390.jpg?1",
             "name": "Rolling Stones",
             "text": "Walls may attack as though they weren't Walls.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "0c5b30c5-d905-5a09-8265-2b6c31babb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66582c6-2eaa-43a8-a0cd-43dab0abc656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66582c6-2eaa-43a8-a0cd-43dab0abc656.jpg?1",
             "name": "Rolling Stones",
             "text": "",
             "colours": [
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "9196ef2d-f7d3-5a57-a416-edc1ff0b2621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43ccab9-c059-4f25-b27c-3f2d506251bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43ccab9-c059-4f25-b27c-3f2d506251bd.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever a spell or ability an opponent controls puts a land into your graveyard from play, return that land to play.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "d2d6f984-0896-53ee-8bf7-5d9d67c416c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83d48a7-c6d3-4aa9-8416-88eece34a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83d48a7-c6d3-4aa9-8416-88eece34a158.jpg?1",
             "name": "Sacred Ground",
             "text": "",
             "colours": [
@@ -2484,7 +2484,7 @@
         },
         {
             "id": "aab9b93d-0fc6-558b-ad35-d6f284d37fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f298a56d-8a33-46b1-aca0-acb68cdb3e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f298a56d-8a33-46b1-aca0-acb68cdb3e29.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "065ad7ce-8339-5d24-9d6c-a70fe2e730eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4b8de0-0bb5-40fb-8b73-d00d38a582d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4b8de0-0bb5-40fb-8b73-d00d38a582d5.jpg?1",
             "name": "Sacred Nectar",
             "text": "",
             "colours": [
@@ -2550,7 +2550,7 @@
         },
         {
             "id": "50549bb2-eeb1-59a3-bd23-7d1ad0f88b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d997ce-6b08-4058-a7f8-82cc74b9974d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d997ce-6b08-4058-a7f8-82cc74b9974d.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "985ac0f6-0ca6-50a8-9966-6bad1fd3635d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ff360-3f4c-40e7-acb0-273cb35a903d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ff360-3f4c-40e7-acb0-273cb35a903d.jpg?1",
             "name": "Samite Healer",
             "text": "",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "4fb4da71-0f73-5740-aa9d-ca3e94c6ca44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f15d4-e0e9-416b-9fe8-66c86160ff1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f15d4-e0e9-416b-9fe8-66c86160ff1a.jpg?1",
             "name": "Sanctimony",
             "text": "Whenever an opponent taps a mountain for mana, you may gain 1 life.",
             "colours": [
@@ -2655,7 +2655,7 @@
         },
         {
             "id": "54b7e74d-e916-55e5-9d33-9cefc21c7c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273a8178-bae8-4668-9827-abcf9485554e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273a8178-bae8-4668-9827-abcf9485554e.jpg?1",
             "name": "Sanctimony",
             "text": "",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "f5e7d5d6-3bdf-506a-b440-f54d89d32a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40221db-f36f-40e4-9029-5c18422cc172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40221db-f36f-40e4-9029-5c18422cc172.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "b5dfa47a-b233-56bf-8111-2b0f8204a9c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96600d-9592-4bf7-aea2-5ebf0660b915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96600d-9592-4bf7-aea2-5ebf0660b915.jpg?1",
             "name": "Seasoned Marshal",
             "text": "",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "9ea1b179-4e0e-5edc-a029-4d3a2bb7db2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a411716d-aff1-4b8f-961d-a873707b9f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a411716d-aff1-4b8f-961d-a873707b9f2a.jpg?1",
             "name": "Serra Advocate",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "515e62b3-c4ea-58c3-8f5a-2b99243d5798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f05d654-f3d1-4965-9d89-9848d6fc2123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f05d654-f3d1-4965-9d89-9848d6fc2123.jpg?1",
             "name": "Serra Advocate",
             "text": "",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "609a05ca-05bf-5feb-a96d-16fe0e2d64a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b4e357-de48-4461-8109-bbb07fff5171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b4e357-de48-4461-8109-bbb07fff5171.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nAttacking doesn't cause Serra Angel to tap.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "1badea75-a7fd-5407-926a-2adaeb770d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a398d30-2db9-4530-9f68-fb4dd6ebcbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a398d30-2db9-4530-9f68-fb4dd6ebcbd2.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "d7c50d4d-e9ce-5fdd-a77e-5627137375c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff41d966-5c11-4732-99e1-ada41a6020a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff41d966-5c11-4732-99e1-ada41a6020a7.jpg?1",
             "name": "Serra's Embrace",
             "text": "Enchanted creature gets +2/+2, has flying, and attacking doesn't cause it to tap.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "74af2163-63e4-5317-833e-98af52fcbb45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06573466-dd60-4cab-acdc-9287daf232cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06573466-dd60-4cab-acdc-9287daf232cf.jpg?1",
             "name": "Serra's Embrace",
             "text": "",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "1a4417b3-b11a-50fb-a0b4-1a3acce82014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b70c30-dbc9-4d30-81d8-b0bde9b626df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b70c30-dbc9-4d30-81d8-b0bde9b626df.jpg?1",
             "name": "Shield Wall",
             "text": "Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "fbc4d75d-8b2c-5c5e-b463-f83808500007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb49655-ba5c-4a62-881d-669593a398c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb49655-ba5c-4a62-881d-669593a398c8.jpg?1",
             "name": "Shield Wall",
             "text": "",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "8e618cc1-e3b7-57fa-b4eb-bee4aa015636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41aec1d-d86f-4a52-a446-5cef71d1ebd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41aec1d-d86f-4a52-a446-5cef71d1ebd4.jpg?1",
             "name": "Skyshroud Falcon",
             "text": "Flying\nAttacking doesn't cause Skyshroud Falcon to tap.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "053b653d-1192-5eeb-bc4c-34825e412443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f46ee43-9706-41cf-b413-3b5fec762194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f46ee43-9706-41cf-b413-3b5fec762194.jpg?1",
             "name": "Skyshroud Falcon",
             "text": "",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "34227385-7126-56d2-8b99-cbf5da31a4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fa1570-3103-494c-8316-8f0bf484f22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fa1570-3103-494c-8316-8f0bf484f22d.jpg?1",
             "name": "Southern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target red permanent.",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "73eaf424-96c9-5664-aec7-7e47c52bfc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a98f74-1b59-47ce-b5ab-dda5aefd9f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a98f74-1b59-47ce-b5ab-dda5aefd9f78.jpg?1",
             "name": "Southern Paladin",
             "text": "",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "8d757fae-1745-5268-a802-37a44e792c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f92671-5023-4cf1-bc06-58e8c094c6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f92671-5023-4cf1-bc06-58e8c094c6a2.jpg?1",
             "name": "Spirit Link",
             "text": "Whenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "cb9cab04-a32d-586b-bb37-bb7552c1a8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a6a4db-045d-48f7-8f82-4486231d755a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a6a4db-045d-48f7-8f82-4486231d755a.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "c2e57261-b07c-553c-a89a-62eea0304dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb299f-5601-4852-9fea-3c375b4851e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb299f-5601-4852-9fea-3c375b4851e8.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking doesn't cause Standing Troops to tap.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "e2444c3d-44a4-5d88-b830-4a9160c5d40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71123df7-1a4d-47cd-a72e-44c431860e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71123df7-1a4d-47cd-a72e-44c431860e88.jpg?1",
             "name": "Standing Troops",
             "text": "",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "769251bb-f938-5f0e-9cd7-9c19d0353cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9ef338-1a74-433c-a7d9-f667246e6622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9ef338-1a74-433c-a7d9-f667246e6622.jpg?1",
             "name": "Starlight",
             "text": "You gain 3 life for each black creature target opponent controls.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "8db11048-9279-5dfd-be51-22c33fafb2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413c5a7e-e19d-4cbd-9279-88391b75c6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413c5a7e-e19d-4cbd-9279-88391b75c6c5.jpg?1",
             "name": "Starlight",
             "text": "",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "ace51b53-fc1c-5d4a-9768-16bdaf5f62fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c5acf-efcb-4df9-b956-b7bce336a5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c5acf-efcb-4df9-b956-b7bce336a5cb.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, you gain 4 life.",
             "colours": [
@@ -3422,7 +3422,7 @@
         },
         {
             "id": "d25a01b1-8c6e-5bcf-8913-e5be75be927a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc642f16-049f-499b-a300-5f5a7372b98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc642f16-049f-499b-a300-5f5a7372b98f.jpg?1",
             "name": "Staunch Defenders",
             "text": "",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "91826b17-014e-56f6-bdb4-6be103a6a18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8466271c-0d9b-4680-a856-efabc7dbc1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8466271c-0d9b-4680-a856-efabc7dbc1ef.jpg?1",
             "name": "Sunweb",
             "text": "(Walls can't attack.)\nFlying\nSunweb can't block creatures with power 2 or less.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "82aac0a4-2158-5908-af9f-80b5925730a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fdb8e2-76d6-4471-8fe3-c83872f0c198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fdb8e2-76d6-4471-8fe3-c83872f0c198.jpg?1",
             "name": "Sunweb",
             "text": "",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "dd37ad18-2d39-521f-80b4-35736efce32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb7af98-1fba-488b-9e92-2f6a35eb4866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb7af98-1fba-488b-9e92-2f6a35eb4866.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "Flying\nWhenever Sustainer of the Realm blocks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "7567d80c-4877-5cf8-81ae-3b4315644700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286955b5-c866-44f4-a76b-54632192918d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286955b5-c866-44f4-a76b-54632192918d.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "1e7c11ca-a0c7-5d9b-9a28-197d81b19d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b59eeaf-5629-4216-8d97-1dbd1927b8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b59eeaf-5629-4216-8d97-1dbd1927b8fe.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "efc3a32f-b214-5f74-8c01-19ba4466e704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac3fb9a-f4c8-421b-994f-418bb340e84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac3fb9a-f4c8-421b-994f-418bb340e84b.jpg?1",
             "name": "Venerable Monk",
             "text": "",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "2496c546-1cff-5e0a-9d56-4b7c247f0cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b9836-fee4-4e83-add7-5e13cb1275d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b9836-fee4-4e83-add7-5e13cb1275d6.jpg?1",
             "name": "Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "fb239dcf-2831-5416-b6d1-552adac746bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0e4d5a-079c-429f-b4f7-aa12fded1dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0e4d5a-079c-429f-b4f7-aa12fded1dce.jpg?1",
             "name": "Vengeance",
             "text": "",
             "colours": [
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "792e6e9f-d995-58db-9489-813f72597915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade80fd-813e-4823-a7ac-2989c440a4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade80fd-813e-4823-a7ac-2989c440a4d8.jpg?1",
             "name": "Wall of Swords",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "10f2067b-1fad-5b98-9c35-7af9cb55ca59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df722ab-3302-4158-a9fb-f0f9608f0cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df722ab-3302-4158-a9fb-f0f9608f0cec.jpg?1",
             "name": "Wall of Swords",
             "text": "",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "b0e52a09-3dfe-5f4e-85b8-75e9c341ca5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7cacaf-6dd9-4ed3-b589-30854a501021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7cacaf-6dd9-4ed3-b589-30854a501021.jpg?1",
             "name": "Worship",
             "text": "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "07742ac0-f4f6-506e-b0ed-1892e53fffc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3283f4-1228-4fb4-9b97-8a9a90929cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3283f4-1228-4fb4-9b97-8a9a90929cb2.jpg?1",
             "name": "Worship",
             "text": "",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "fd6f7db2-e6aa-58a6-a67c-7cb5ceb2edcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d223e83-0d3c-459e-96f5-ba9227fe49dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d223e83-0d3c-459e-96f5-ba9227fe49dd.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "e97cfc4f-02c6-5d46-87e8-2adfbd3119fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc5ed6-41ff-4f8a-b47a-fc9390c2aa81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc5ed6-41ff-4f8a-b47a-fc9390c2aa81.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "54190167-d981-5e50-9e56-330ebe9085ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0331818-208c-460a-b15d-81c8fd54669d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0331818-208c-460a-b15d-81c8fd54669d.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "666bb570-4cab-5c0e-bc3f-04018c09e6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9004140e-0369-44ae-84eb-5208a7ef4ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9004140e-0369-44ae-84eb-5208a7ef4ced.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "8c8d0389-4822-5f04-bd49-b6f58def95ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0ca8-a66a-452f-be5f-17f631ba0ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0ca8-a66a-452f-be5f-17f631ba0ee0.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your library. Put two of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "b1f6b954-62da-5092-bdb9-f8ee4ebe324f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfe6027-1e97-45b1-949b-73e6cf25bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfe6027-1e97-45b1-949b-73e6cf25bc82.jpg?1",
             "name": "Ancestral Memories",
             "text": "",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "32fef4e0-249f-5a51-b087-a88793a31792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e3bcd7-60f8-472a-ada0-c3147cf06588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e3bcd7-60f8-472a-ada0-c3147cf06588.jpg?1",
             "name": "Arcane Laboratory",
             "text": "Each player can't play more than one spell each turn.",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "aac0a14f-b0e4-5f82-9668-679ac064eda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783435f7-5fb1-49bb-98a3-b8da8f76ce25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783435f7-5fb1-49bb-98a3-b8da8f76ce25.jpg?1",
             "name": "Arcane Laboratory",
             "text": "",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "94042d07-cd33-52e6-a621-4334ebfce8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e44374d-b327-4193-ad3b-628191461d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e44374d-b327-4193-ad3b-628191461d05.jpg?1",
             "name": "Archivist",
             "text": "oc\nT: Draw a card.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "cf159560-469e-59ad-b17a-bca95dce0651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067421-8481-449e-9c97-6aa1c4610c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067421-8481-449e-9c97-6aa1c4610c71.jpg?1",
             "name": "Archivist",
             "text": "",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "b2a99474-101b-5e9e-a1ff-c90dc4b9616b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c53b808-c2c5-4941-bead-1cb94adc5a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c53b808-c2c5-4941-bead-1cb94adc5a2f.jpg?1",
             "name": "Baleful Stare",
             "text": "Target opponent reveals his or her hand. You draw a card for each mountain and red card in it.",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "623b5465-b24b-53cf-8f9a-19757a066155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f3896d-f54f-44fc-a619-ea3a71a513c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f3896d-f54f-44fc-a619-ea3a71a513c0.jpg?1",
             "name": "Baleful Stare",
             "text": "",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "975bc023-4c8f-54e9-a74d-8de14d08069e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19577bda-2728-40c8-a262-26051e6c226b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19577bda-2728-40c8-a262-26051e6c226b.jpg?1",
             "name": "Benthic Behemoth",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "9fe13a8c-a0f8-5c08-ae7c-ff5a9a47d45d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb24340-0c10-485c-a9a8-3ac65d494a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb24340-0c10-485c-a9a8-3ac65d494a57.jpg?1",
             "name": "Benthic Behemoth",
             "text": "",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "425a5092-204a-5a49-a7f4-967f09b1a182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7e31b5-fe27-44ad-a1d8-7263c3edbc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7e31b5-fe27-44ad-a1d8-7263c3edbc7d.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "c417a2ab-18ab-5c03-9cfa-62e53a7f6a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724b7896-74d0-491a-8aa6-183324660634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724b7896-74d0-491a-8aa6-183324660634.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "429b478f-c7aa-55c9-b058-dfdcd73ecc8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8440565-8359-4283-aad1-6b594a5a96eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8440565-8359-4283-aad1-6b594a5a96eb.jpg?1",
             "name": "Confiscate",
             "text": "You control enchanted permanent.",
             "colours": [
@@ -4451,7 +4451,7 @@
         },
         {
             "id": "b1ce506a-e733-5acd-b539-4fb9038db2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892f0980-eb6b-4454-88b8-e2e79983d065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892f0980-eb6b-4454-88b8-e2e79983d065.jpg?1",
             "name": "Confiscate",
             "text": "",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "0c93c8bc-d5a8-5789-a63d-4d47b164cf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ea1af2-f944-4ee1-88bd-2f3ea09bf9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ea1af2-f944-4ee1-88bd-2f3ea09bf9e6.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "24dbbc34-1567-5037-9884-7b9b9528a077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cb3579-1a75-4ff4-a007-5d65969b887c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cb3579-1a75-4ff4-a007-5d65969b887c.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "e5280460-9949-5bf9-95ce-b1a4be15b1ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bb1b85-9444-4bfa-b622-092a6873631c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bb1b85-9444-4bfa-b622-092a6873631c.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "dc8bb2d4-2d9b-5397-9009-d7438aea2572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed211e-f3ec-4e9e-b9a7-0989930dd049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed211e-f3ec-4e9e-b9a7-0989930dd049.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "f93e1577-2945-55fa-a60c-afd55b960337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f0cbe-aba9-4f20-909e-c4692a5ad899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f0cbe-aba9-4f20-909e-c4692a5ad899.jpg?1",
             "name": "Daring Apprentice",
             "text": "oc\nT, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "67913b1c-506f-5214-b65c-7632870069bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1b9eb1-fd88-48f9-bd06-d0b5578d7f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1b9eb1-fd88-48f9-bd06-d0b5578d7f82.jpg?1",
             "name": "Daring Apprentice",
             "text": "",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "d6321c26-f3bc-5b34-88c0-a18ff3b30a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b18ce34-2ff4-4662-aab3-24c10e9657cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b18ce34-2ff4-4662-aab3-24c10e9657cc.jpg?1",
             "name": "Deflection",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "d1e74389-9c14-57e6-a000-2169c4cef491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1aa45-1cee-4710-8b61-a80b393d597d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1aa45-1cee-4710-8b61-a80b393d597d.jpg?1",
             "name": "Deflection",
             "text": "",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "028871b9-a7aa-5e3d-81e9-be2ffe5b4f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43fba7-699e-4bb5-ab3e-b5b1c290340c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43fba7-699e-4bb5-ab3e-b5b1c290340c.jpg?1",
             "name": "Delusions of Mediocrity",
             "text": "When Delusions of Mediocrity comes into play, you gain 10 life.\nWhen Delusions of Mediocrity leaves play, you lose 10 life.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "81943386-668a-56e9-af5c-f0e101d9485b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8239e492-0946-4278-add2-9bc6a8b3661d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8239e492-0946-4278-add2-9bc6a8b3661d.jpg?1",
             "name": "Delusions of Mediocrity",
             "text": "",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "f2cf0856-09a5-5752-94ee-f34997d15f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbe8836-88c3-4f5d-88a0-73e54673960e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbe8836-88c3-4f5d-88a0-73e54673960e.jpg?1",
             "name": "Equilibrium",
             "text": "Whenever you play a creature spell, you may pay o1. If you do, return target creature to its owner's hand.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "aca5fee7-2e56-512d-9bc6-8136e034f931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef600ab-dca3-4853-88b8-5f3bd7ec0a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef600ab-dca3-4853-88b8-5f3bd7ec0a68.jpg?1",
             "name": "Equilibrium",
             "text": "",
             "colours": [
@@ -4892,7 +4892,7 @@
         },
         {
             "id": "96914b57-aa02-538c-83de-b8739e8ac58d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1144eb-701d-4716-9051-e8b77480e72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1144eb-701d-4716-9051-e8b77480e72d.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "de650645-248d-501d-9429-4cc1a2e9f3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89dd4a6d-271d-4997-8c61-bc6129bf26da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89dd4a6d-271d-4997-8c61-bc6129bf26da.jpg?1",
             "name": "Evacuation",
             "text": "",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "a960b7d8-b782-56b9-8340-1a9a93af9012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76952add-6ca8-4db0-97bd-4a85432be997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76952add-6ca8-4db0-97bd-4a85432be997.jpg?1",
             "name": "Fighting Drake",
             "text": "Flying",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "af9df135-8013-57c7-9f81-47b87d514f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2206-1c9a-4a08-ae13-61e2b5a10727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2206-1c9a-4a08-ae13-61e2b5a10727.jpg?1",
             "name": "Fighting Drake",
             "text": "",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "18feb622-1d2d-5960-8ce9-fbcf11364455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35971a15-7d8f-4b05-918e-605a26a11f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35971a15-7d8f-4b05-918e-605a26a11f4c.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying\no1oo\nU Return Fleeting Image to its owner's hand.",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "3d78320e-cd24-5a5d-83cb-5268479968e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a6f29-6fbf-4fd9-a923-1fdf33abbe16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a6f29-6fbf-4fd9-a923-1fdf33abbe16.jpg?1",
             "name": "Fleeting Image",
             "text": "",
             "colours": [
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "ee43916a-ad02-503b-bc19-c8a3e953740c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abcd7f6-ce34-4c1f-8250-3e262ef0bc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abcd7f6-ce34-4c1f-8250-3e262ef0bc05.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature has flying.",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "cd82c2f8-5b7e-5f08-8f8d-fe54866805ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b8d33-4b80-4ed6-95ce-b672d495be4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b8d33-4b80-4ed6-95ce-b672d495be4e.jpg?1",
             "name": "Flight",
             "text": "",
             "colours": [
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "97661580-c711-569a-a211-7b8e24e164e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d03d73f-0530-4125-8689-1c43e502e331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d03d73f-0530-4125-8689-1c43e502e331.jpg?1",
             "name": "Force Spike",
             "text": "Counter target spell unless its controller pays o1.",
             "colours": [
@@ -5201,7 +5201,7 @@
         },
         {
             "id": "adc70c66-640a-5b32-947d-1bdcf0f2df84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7d6594-a57d-4557-880a-d65f46bb6033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7d6594-a57d-4557-880a-d65f46bb6033.jpg?1",
             "name": "Force Spike",
             "text": "",
             "colours": [
@@ -5234,7 +5234,7 @@
         },
         {
             "id": "b2737892-9493-51ab-a574-e46949afd72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b707b2d-63e1-4c2c-ba42-9e027f02b1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b707b2d-63e1-4c2c-ba42-9e027f02b1ff.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "db25b444-a013-5f63-a45c-cc9eda8459c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6343d49-1336-445d-ac7a-83e436953332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6343d49-1336-445d-ac7a-83e436953332.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "fe988473-7529-5f28-91e0-eb60cf36718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3207ed8-a7b5-490e-bf7e-602937e4408d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3207ed8-a7b5-490e-bf7e-602937e4408d.jpg?1",
             "name": "Glacial Wall",
             "text": "(Walls can't attack.)",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "308a74b7-a3f5-5f43-9104-f446d8baceb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c498cb2-02f7-487d-8561-974f3e516aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c498cb2-02f7-487d-8561-974f3e516aac.jpg?1",
             "name": "Glacial Wall",
             "text": "",
             "colours": [
@@ -5374,7 +5374,7 @@
         },
         {
             "id": "3fca6db4-4bab-5a93-bf72-77fd1536798f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f7d826-ec78-48dd-bed1-e3768e8fa324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f7d826-ec78-48dd-bed1-e3768e8fa324.jpg?1",
             "name": "Hibernation",
             "text": "Return all green permanents to their owners' hands.",
             "colours": [
@@ -5407,7 +5407,7 @@
         },
         {
             "id": "7218e818-8feb-5f22-bfdf-d30a0161a596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e87e73-b999-4d57-98ee-1c9f33baca74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e87e73-b999-4d57-98ee-1c9f33baca74.jpg?1",
             "name": "Hibernation",
             "text": "",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "8df154ca-afa9-5b77-82f0-a9774341db44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15005ab0-da4e-415e-99fe-34c112819c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15005ab0-da4e-415e-99fe-34c112819c45.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "1adb2b07-5d11-5ac6-841e-dcd0c45d7300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64b45d0-4387-4187-8511-12c8a323a772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64b45d0-4387-4187-8511-12c8a323a772.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "5b0859dd-08af-5d59-989a-fa1b16343823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38c335-5a85-4d39-8d58-2b284758de53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38c335-5a85-4d39-8d58-2b284758de53.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "dd28db1a-35a0-58cd-9bb0-1b142d00652f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494dd66f-44af-4a10-94bb-9447af645512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494dd66f-44af-4a10-94bb-9447af645512.jpg?1",
             "name": "Inspiration",
             "text": "",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "05858b2b-febc-5b0e-bf6f-e16edf26e6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f05d944-1800-4542-a496-62504efc5292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f05d944-1800-4542-a496-62504efc5292.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "668872a0-a5dd-5be7-bb25-8e37b2b1cdb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5c04b2-ec1c-4954-8551-5421c0843e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5c04b2-ec1c-4954-8551-5421c0843e2b.jpg?1",
             "name": "Levitation",
             "text": "",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "1370b5f7-8a2e-534f-afb8-fdeceda5d391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd279366-8de2-47c5-9ac0-f41f8f81c643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd279366-8de2-47c5-9ac0-f41f8f81c643.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk get +1/+1 and have islandwalk. (They're unblockable as long as defending player controls an island.)",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "3a68754f-d55b-5e09-b100-74a228e181de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200f395-4bb9-4d70-9473-a131b46b60ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200f395-4bb9-4d70-9473-a131b46b60ce.jpg?1",
             "name": "Lord of Atlantis",
             "text": "",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "0286f862-2c26-58ef-bff9-9c7c5078e80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d464226-5607-4db2-bd43-7855efb92628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d464226-5607-4db2-bd43-7855efb92628.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "82e041f8-132b-5343-aaee-9ffd59650841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e138f24-73ca-4040-b9cc-7ebcf605372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e138f24-73ca-4040-b9cc-7ebcf605372e.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -5782,7 +5782,7 @@
         },
         {
             "id": "5b5ac019-2a8a-5518-a6bc-b4970dd29307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a7eff-89c8-4799-b264-38892912ba05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a7eff-89c8-4799-b264-38892912ba05.jpg?1",
             "name": "Mana Breach",
             "text": "Whenever a player plays a spell, that player returns a land he or she controls to its owner's hand.",
             "colours": [
@@ -5815,7 +5815,7 @@
         },
         {
             "id": "ce403e97-e400-5d92-b57c-61400adf0134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f8b6a-415a-4b73-bfd9-5081c5fcefb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f8b6a-415a-4b73-bfd9-5081c5fcefb3.jpg?1",
             "name": "Mana Breach",
             "text": "",
             "colours": [
@@ -5848,7 +5848,7 @@
         },
         {
             "id": "dd425fd6-d097-5a38-be01-6b29ed30b92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0486784-de03-47a7-949d-550fd23492bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0486784-de03-47a7-949d-550fd23492bc.jpg?1",
             "name": "Mana Short",
             "text": "Tap all lands target player controls and empty his or her mana pool.",
             "colours": [
@@ -5881,7 +5881,7 @@
         },
         {
             "id": "e2e03199-6250-5bbe-883a-164cab77dcf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279acd2-7d73-4f42-8696-654326d64bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279acd2-7d73-4f42-8696-654326d64bba.jpg?1",
             "name": "Mana Short",
             "text": "",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "0fb091c3-ff71-5f46-9d43-305224a36788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48494f33-34b5-4c76-bb24-23a78b856e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48494f33-34b5-4c76-bb24-23a78b856e3c.jpg?1",
             "name": "Mawcor",
             "text": "Flying\noc\nT: Mawcor deals 1 damage to target creature or player.",
             "colours": [
@@ -5949,7 +5949,7 @@
         },
         {
             "id": "c183f37c-5432-581d-a40a-b0efa3bd59c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abc4a5-25b5-4f05-9278-a557fb268114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abc4a5-25b5-4f05-9278-a557fb268114.jpg?1",
             "name": "Mawcor",
             "text": "",
             "colours": [
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "f7563a03-c7eb-540e-baff-9a49e85644a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d85cc30-ccae-4af8-834a-f7870dace679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d85cc30-ccae-4af8-834a-f7870dace679.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "c5d086f3-fcd4-5cc1-b6d8-cbaece14857a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2437b9-22ed-4835-9ac4-e9625bf8464a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2437b9-22ed-4835-9ac4-e9625bf8464a.jpg?1",
             "name": "Memory Lapse",
             "text": "",
             "colours": [
@@ -6050,7 +6050,7 @@
         },
         {
             "id": "2f467e35-cb7f-573c-8f56-9f83edec94ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec07b20-9768-4c21-90d5-70d57959c698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec07b20-9768-4c21-90d5-70d57959c698.jpg?1",
             "name": "Merfolk Looter",
             "text": "oc\nT: Draw a card, then discard a card from your hand.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "eb9442d4-89e4-53d0-85fc-507d80435779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffaacf-bf53-49ca-8003-795773477ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffaacf-bf53-49ca-8003-795773477ad3.jpg?1",
             "name": "Merfolk Looter",
             "text": "",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "dc684645-d2fd-5d4a-92c2-3c6a702150da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e7d1a5-b8ad-48e8-9b54-3663310eca33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e7d1a5-b8ad-48e8-9b54-3663310eca33.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -6157,7 +6157,7 @@
         },
         {
             "id": "37553ebc-1b36-5d4a-ae35-bccb92c8630b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd471f7-4d06-4a86-bb24-564b88344cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd471f7-4d06-4a86-bb24-564b88344cdc.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -6192,7 +6192,7 @@
         },
         {
             "id": "011a3a24-f471-5030-887e-5668f4627e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01d4d9-c9e9-4826-a155-4527f9be758e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01d4d9-c9e9-4826-a155-4527f9be758e.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -6225,7 +6225,7 @@
         },
         {
             "id": "2ea9ad2a-c794-5fdf-9207-9ed9a909f27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f083a1-664f-46d7-a54d-95f5c10217f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f083a1-664f-46d7-a54d-95f5c10217f2.jpg?1",
             "name": "Opportunity",
             "text": "",
             "colours": [
@@ -6258,7 +6258,7 @@
         },
         {
             "id": "cba06033-ec4d-512d-9320-d77da4ed1e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980e292-1384-4662-aa72-bc4f6ca30d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980e292-1384-4662-aa72-bc4f6ca30d51.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "0cf3d24a-7cb1-5d30-bfec-1c41aebe1647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f849df-8a20-4490-a573-1ad3af65e540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f849df-8a20-4490-a573-1ad3af65e540.jpg?1",
             "name": "Opposition",
             "text": "",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "52fa1bd9-eaba-5bb7-a372-1363424b3d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594550a7-9d75-4bae-9295-14249f60cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594550a7-9d75-4bae-9295-14249f60cc7f.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "859e44d1-2672-5c3a-bde8-e07fd419c677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55672640-d58f-4e00-a0ac-00916c8375b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55672640-d58f-4e00-a0ac-00916c8375b1.jpg?1",
             "name": "Phantom Warrior",
             "text": "",
             "colours": [
@@ -6396,7 +6396,7 @@
         },
         {
             "id": "f9163243-1aec-53d9-b2d9-80f36343862c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30a846e-a5b1-4603-af4f-6494f3c4fbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30a846e-a5b1-4603-af4f-6494f3c4fbb3.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "968b80af-f7c7-5b96-a945-044842353432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da1bfc3-de07-4600-ae01-b22057ba59d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da1bfc3-de07-4600-ae01-b22057ba59d1.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "a826b162-7ec7-5828-85c5-a6825bd64c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25f4f0e-bbf4-46b1-97fd-e796ff9e138f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25f4f0e-bbf4-46b1-97fd-e796ff9e138f.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "ee29638f-8a42-5930-9ef1-ba9d9dd26345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1736d01-1bd0-444c-9d7a-3846441bd409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1736d01-1bd0-444c-9d7a-3846441bd409.jpg?1",
             "name": "Remove Soul",
             "text": "",
             "colours": [
@@ -6534,7 +6534,7 @@
         },
         {
             "id": "13a97b00-dc44-5fd7-b351-1a3c6f4fce3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9a3aba-25ae-4b5e-b356-9745e7236f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9a3aba-25ae-4b5e-b356-9745e7236f35.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "5b3eafe5-6253-5ac8-8925-8cebb6cc8b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b79c1-71ee-483d-be6d-07a4a6320200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b79c1-71ee-483d-be6d-07a4a6320200.jpg?1",
             "name": "Sage Owl",
             "text": "",
             "colours": [
@@ -6604,7 +6604,7 @@
         },
         {
             "id": "a4f746d7-87db-54f6-ad54-3fb789d1b28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c8829-80f5-49d3-9887-e6ed276440c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c8829-80f5-49d3-9887-e6ed276440c9.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an island.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "b0c1a7f6-d901-50ad-a3dd-1010d242b47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dad56c-7f9a-4f11-920a-5a9d8eee45ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dad56c-7f9a-4f11-920a-5a9d8eee45ce.jpg?1",
             "name": "Sea Monster",
             "text": "",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "7e7a22e7-6f97-51da-bfbc-37d668ae7f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fff80-4dea-47ee-a020-d8dc9ea7acdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fff80-4dea-47ee-a020-d8dc9ea7acdf.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -6707,7 +6707,7 @@
         },
         {
             "id": "3f12e73d-cfbf-5783-a187-88e0e399f2dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14525e5c-3e50-4478-8149-7e9c012a85bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14525e5c-3e50-4478-8149-7e9c012a85bf.jpg?1",
             "name": "Sleight of Hand",
             "text": "",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "afe2af9f-8f4a-52b4-8db8-0e7307689095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f76c5c-f445-4c02-98d1-d7376a76d612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f76c5c-f445-4c02-98d1-d7376a76d612.jpg?1",
             "name": "Steal Artifact",
             "text": "You control enchanted artifact.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "0adc0928-6404-5252-9899-d66e78e0a278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbad5469-0b78-476f-8573-22fb117392ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbad5469-0b78-476f-8573-22fb117392ab.jpg?1",
             "name": "Steal Artifact",
             "text": "",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "a24b67a1-0f54-5a99-992f-bd8da74d942e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e573308-40d0-43ce-be04-dbab6bc1ed35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e573308-40d0-43ce-be04-dbab6bc1ed35.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "e36dc9cf-c47d-510a-811a-60c9015cf10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c0a35-09b5-449f-be30-d837e330cb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c0a35-09b5-449f-be30-d837e330cb6b.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "0d3b84cb-17f2-50bd-af73-4abf545e1298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb39c9-7853-4032-882a-83d4863dcbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb39c9-7853-4032-882a-83d4863dcbc5.jpg?1",
             "name": "Telepathic Spies",
             "text": "When Telepathic Spies comes into play, look at target opponent's hand.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "7449b7df-d915-5ae8-86d8-622af39392a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8346c3-8e36-45de-97ec-dfad12ac980c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8346c3-8e36-45de-97ec-dfad12ac980c.jpg?1",
             "name": "Telepathic Spies",
             "text": "",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "ef6fdd8b-559e-5f14-a94f-3ae4e90cd558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b65a4b-d0d9-4439-96f9-0e0dd532c824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b65a4b-d0d9-4439-96f9-0e0dd532c824.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "0ede7443-c168-54cc-b100-bd5ff1a88b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eeef0a-599d-455b-b482-83426f5fdc67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eeef0a-599d-455b-b482-83426f5fdc67.jpg?1",
             "name": "Telepathy",
             "text": "",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "9bbd6068-deea-54fa-9a8c-20c6f5b6b026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef6d283-a966-4ee9-ab23-5485ccceaf5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef6d283-a966-4ee9-ab23-5485ccceaf5c.jpg?1",
             "name": "Temporal Adept",
             "text": "o\nUo\nUo\nU, oc\nT: Return target permanent to its owner's hand.",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "dc8c3824-a62c-5a90-a7c3-83ea6588d88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9f738-3988-4c60-854d-fb6f9b82ee0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9f738-3988-4c60-854d-fb6f9b82ee0b.jpg?1",
             "name": "Temporal Adept",
             "text": "",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "6abc83a2-05f1-5492-9bec-0fc2cfa4c84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a487411-ef89-4500-be3c-8e191bd7ddc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a487411-ef89-4500-be3c-8e191bd7ddc4.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -7125,7 +7125,7 @@
         },
         {
             "id": "4c18797e-f52a-51dc-b5f5-77ec58a08790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5993ed-5ed6-4712-9f69-62d140a0bba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5993ed-5ed6-4712-9f69-62d140a0bba5.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -7160,7 +7160,7 @@
         },
         {
             "id": "cc77f8e3-6a9f-54bc-964a-4b19e7111876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd9981-bb5e-450d-90c3-4405a7097939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd9981-bb5e-450d-90c3-4405a7097939.jpg?1",
             "name": "Tolarian Winds",
             "text": "Discard your hand, then draw that many cards.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "363d5637-c801-55b5-bd89-dd4feac907a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad47859-0756-4aae-b21f-7689da1077bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad47859-0756-4aae-b21f-7689da1077bb.jpg?1",
             "name": "Tolarian Winds",
             "text": "",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "aa751407-1d46-5673-88fa-00667a08b75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f79962-ca0f-4df1-9dc8-d7ea1025cab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f79962-ca0f-4df1-9dc8-d7ea1025cab1.jpg?1",
             "name": "Treasure Trove",
             "text": "o2o\nUoo\nU Draw a card.",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "cbdfb66a-dddd-5291-bef2-89d895d84c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8646aef-f926-4e04-9a6d-c10bea1dd992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8646aef-f926-4e04-9a6d-c10bea1dd992.jpg?1",
             "name": "Treasure Trove",
             "text": "",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "10375afc-d34d-5bbb-858b-c9153c6d8218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9483fed-0fc8-4aff-b1b4-8470166fdb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9483fed-0fc8-4aff-b1b4-8470166fdb9b.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7325,7 +7325,7 @@
         },
         {
             "id": "c96c4851-e1dd-5d4a-a24a-1c21fb29f931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945956d4-ffd6-4fbc-ae2d-32f981337dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945956d4-ffd6-4fbc-ae2d-32f981337dd4.jpg?1",
             "name": "Twiddle",
             "text": "",
             "colours": [
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "f2ad2a16-3a7e-5e02-b1c5-29dac555e68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922636e6-9e4e-4aa8-9030-6e1417d241a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922636e6-9e4e-4aa8-9030-6e1417d241a1.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "28ed483d-c7ea-51b7-9380-83166bc3fdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5616986-970c-45d3-878e-403434b35988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5616986-970c-45d3-878e-403434b35988.jpg?1",
             "name": "Unsummon",
             "text": "",
             "colours": [
@@ -7424,7 +7424,7 @@
         },
         {
             "id": "8e728944-1726-596d-bd46-c0cfa29102ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb4be1f-3e5b-4881-9fae-9ed022f8eeac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb4be1f-3e5b-4881-9fae-9ed022f8eeac.jpg?1",
             "name": "Vigilant Drake",
             "text": "Flying\no2oo\nU Untap Vigilant Drake",
             "colours": [
@@ -7459,7 +7459,7 @@
         },
         {
             "id": "5675c405-7b17-5d42-b46b-5ee7032cbe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1e116a-370d-494f-8fbb-d964c34f49b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1e116a-370d-494f-8fbb-d964c34f49b4.jpg?1",
             "name": "Vigilant Drake",
             "text": "",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "cfe7c04b-1bc2-56bc-8f93-301f86f074a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c681e3-fc54-4da1-80ff-13507688dbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c681e3-fc54-4da1-80ff-13507688dbc3.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -7530,7 +7530,7 @@
         },
         {
             "id": "46982267-9516-5979-889c-11cae30a9fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ecab6-e145-4dfd-9e9e-56492db30b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ecab6-e145-4dfd-9e9e-56492db30b4c.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "710b4e5a-048e-5ac9-898a-590c65094238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b43e8-23d7-4df6-822b-ae3b57c6f1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b43e8-23d7-4df6-822b-ae3b57c6f1dc.jpg?1",
             "name": "Wall of Air",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "277146f2-a08a-5673-b321-bf7c31dc6c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68367ab-cf67-4e0d-a446-676b2734141c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68367ab-cf67-4e0d-a446-676b2734141c.jpg?1",
             "name": "Wall of Air",
             "text": "",
             "colours": [
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "c03a332e-1dda-561d-8c91-dac33b71956e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c73e58-e906-4c67-9f84-b20456629cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c73e58-e906-4c67-9f84-b20456629cb0.jpg?1",
             "name": "Wall of Wonder",
             "text": "(Walls can't attack.)\no2o\nUoo\nU Wall of Wonder gets +4/-4 until end of turn and may attack this turn as though it weren't a Wall.",
             "colours": [
@@ -7671,7 +7671,7 @@
         },
         {
             "id": "0ccd9169-fdb0-566d-9266-c4c2c4235df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713698c2-fd5a-4763-b699-00fe73fa6641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713698c2-fd5a-4763-b699-00fe73fa6641.jpg?1",
             "name": "Wall of Wonder",
             "text": "",
             "colours": [
@@ -7706,7 +7706,7 @@
         },
         {
             "id": "ad1e760c-fad0-568e-8baf-cd86b8857d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314b5efa-c16f-4bcf-beed-bd0d77511a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314b5efa-c16f-4bcf-beed-bd0d77511a25.jpg?1",
             "name": "Wind Dancer",
             "text": "Flying\noc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "4b49ed68-9f3e-5db4-9143-f33de2768b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c7c034-f70e-47c1-b4e9-ec34194bf0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c7c034-f70e-47c1-b4e9-ec34194bf0b6.jpg?1",
             "name": "Wind Dancer",
             "text": "",
             "colours": [
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "b75014aa-920b-53b3-b61f-352bf6aa2f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba63d1d-6170-4ccd-afd9-987e549fa58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba63d1d-6170-4ccd-afd9-987e549fa58e.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "c2017715-ab76-53f3-b3f2-7da67575e2aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e2c8c5-b039-42ed-90f8-95c80d124564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e2c8c5-b039-42ed-90f8-95c80d124564.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -7846,7 +7846,7 @@
         },
         {
             "id": "d5796f65-5b20-5a9d-bafe-26f26280e418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb42943-f599-4068-a364-a023e70c4ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb42943-f599-4068-a364-a023e70c4ed2.jpg?1",
             "name": "Abyssal Horror",
             "text": "Flying\nWhen Abyssal Horror comes into play, target player discards two cards from his or her hand.",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "27e800c1-ba16-53d1-baa6-52e4a95827d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37aa76c5-0391-496a-8f34-d966813fe4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37aa76c5-0391-496a-8f34-d966813fe4e5.jpg?1",
             "name": "Abyssal Horror",
             "text": "",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "616c5add-4a91-5b0a-bc15-a3f01243f164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e6582d-e569-4131-b212-3ef1767be107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e6582d-e569-4131-b212-3ef1767be107.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter deals damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -7951,7 +7951,7 @@
         },
         {
             "id": "130e1923-55e1-5adb-9ad5-60a450495d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcfb1fb-8e04-4312-9a06-ed3fc2e86c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcfb1fb-8e04-4312-9a06-ed3fc2e86c22.jpg?1",
             "name": "Abyssal Specter",
             "text": "",
             "colours": [
@@ -7986,7 +7986,7 @@
         },
         {
             "id": "675284a1-f678-53c1-b12f-808d18704d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967e7ead-72a5-4f11-87a9-d9498e0d1a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967e7ead-72a5-4f11-87a9-d9498e0d1a6c.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand and choose two cards from it. Put them on top of that player's library in any order.",
             "colours": [
@@ -8019,7 +8019,7 @@
         },
         {
             "id": "4b875165-ca6e-5715-ba2c-dd5d88b6514c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0c1ee9-5ebc-466d-a163-74d207ef8fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0c1ee9-5ebc-466d-a163-74d207ef8fd5.jpg?1",
             "name": "Agonizing Memories",
             "text": "",
             "colours": [
@@ -8052,7 +8052,7 @@
         },
         {
             "id": "0baa852c-f346-58ac-b11e-b6e640f29245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db137-33b9-4cea-9193-4e637d2966f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db137-33b9-4cea-9193-4e637d2966f1.jpg?1",
             "name": "Befoul",
             "text": "Destroy target land or nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8085,7 +8085,7 @@
         },
         {
             "id": "1a1bdaa9-31a3-5013-8e43-fd586d3fde21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c92a967-ed52-44a8-a07b-04e643fb2e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c92a967-ed52-44a8-a07b-04e643fb2e78.jpg?1",
             "name": "Befoul",
             "text": "",
             "colours": [
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "0c496840-2ec8-5021-8d5b-f781f74e10f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0962d7-d797-4f07-bd73-9cd7a11ffad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0962d7-d797-4f07-bd73-9cd7a11ffad8.jpg?1",
             "name": "Bellowing Fiend",
             "text": "Flying\nWhenever Bellowing Fiend deals damage to a creature, Bellowing Fiend deals 3 damage to that creature's controller and 3 damage to you.",
             "colours": [
@@ -8153,7 +8153,7 @@
         },
         {
             "id": "4ee12947-a4f6-52cb-8344-8cc41f2fb5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d014dcd8-7132-48e2-b632-00fb0b5c372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d014dcd8-7132-48e2-b632-00fb0b5c372e.jpg?1",
             "name": "Bellowing Fiend",
             "text": "",
             "colours": [
@@ -8188,7 +8188,7 @@
         },
         {
             "id": "84c454b8-7be5-5f2f-9414-df3bf8280446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20daf7-9cdd-4694-8ed4-4c5dc9f9e7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20daf7-9cdd-4694-8ed4-4c5dc9f9e7b3.jpg?1",
             "name": "Bereavement",
             "text": "Whenever a green creature is put into a graveyard from play, its controller discards a card from his or her hand.",
             "colours": [
@@ -8221,7 +8221,7 @@
         },
         {
             "id": "738853b4-ea67-5932-a8c6-bc2e0ab40c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21138eb5-4eaa-4143-91a6-989fb0c39e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21138eb5-4eaa-4143-91a6-989fb0c39e40.jpg?1",
             "name": "Bereavement",
             "text": "",
             "colours": [
@@ -8254,7 +8254,7 @@
         },
         {
             "id": "1499dea2-3264-58cb-ad23-d00fcdb114cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff08225-82a5-4636-be6a-d38d32f5663f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff08225-82a5-4636-be6a-d38d32f5663f.jpg?1",
             "name": "Blood Pet",
             "text": "Sacrifice Blood Pet: Add o\nB to your mana pool.",
             "colours": [
@@ -8289,7 +8289,7 @@
         },
         {
             "id": "fa904eaa-a772-518e-9131-0a39057de427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e67191-0195-4af7-9566-59df8a24cb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e67191-0195-4af7-9566-59df8a24cb82.jpg?1",
             "name": "Blood Pet",
             "text": "",
             "colours": [
@@ -8324,7 +8324,7 @@
         },
         {
             "id": "75bd9baa-a7ee-53d7-8d80-cb25585e9b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e2c65-d2b0-4bf7-b302-d755e9259ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e2c65-d2b0-4bf7-b302-d755e9259ce2.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "cc473b5f-25db-53c3-9061-b3dc48ff1bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f70e3a-b094-45f9-8e34-02db116292ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f70e3a-b094-45f9-8e34-02db116292ce.jpg?1",
             "name": "Bog Imp",
             "text": "",
             "colours": [
@@ -8394,7 +8394,7 @@
         },
         {
             "id": "02a6c5ca-be4d-55d1-a841-cf44e141f608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5644b8a9-8777-49da-813a-61ce75324d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5644b8a9-8777-49da-813a-61ce75324d48.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "5f66be5b-54ba-51cc-822c-04aec97ce9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6fd6e1-58b0-4c98-b0ca-58409d3b2383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6fd6e1-58b0-4c98-b0ca-58409d3b2383.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -8464,7 +8464,7 @@
         },
         {
             "id": "6eff1f89-1eb6-5187-a956-7b398eaa6aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dc4337-86fd-49b4-8331-fcf44f9e7a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dc4337-86fd-49b4-8331-fcf44f9e7a74.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -8497,7 +8497,7 @@
         },
         {
             "id": "27accc75-a57b-5339-bc8f-bc9ed54e2c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fc008a-99cc-4f11-a47c-b7391249bdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fc008a-99cc-4f11-a47c-b7391249bdab.jpg?1",
             "name": "Corrupt",
             "text": "",
             "colours": [
@@ -8530,7 +8530,7 @@
         },
         {
             "id": "6588258f-88e7-516a-aa09-6efe71104a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2f697-01cc-4610-b4aa-cae83b38647a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2f697-01cc-4610-b4aa-cae83b38647a.jpg?1",
             "name": "Crypt Rats",
             "text": "oo\nX Crypt Rats deals X damage to each creature and each player. Spend only black mana this way.",
             "colours": [
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "d98b072b-ee39-5f6a-9839-56eea67a3ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce46b67-e0a2-47d6-b3b8-6acedfd7b40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce46b67-e0a2-47d6-b3b8-6acedfd7b40f.jpg?1",
             "name": "Crypt Rats",
             "text": "",
             "colours": [
@@ -8600,7 +8600,7 @@
         },
         {
             "id": "50f5074d-226f-5368-be88-5c500561b7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660cc594-63f5-4819-a556-7a9484145f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660cc594-63f5-4819-a556-7a9484145f72.jpg?1",
             "name": "Dakmor Lancer",
             "text": "When Dakmor Lancer comes into play, destroy target nonblack creature.",
             "colours": [
@@ -8636,7 +8636,7 @@
         },
         {
             "id": "c880c3d8-2d0c-572d-94d9-28df13d1d20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca0f0d-c47c-4c29-a47d-d44e2083c3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca0f0d-c47c-4c29-a47d-d44e2083c3d1.jpg?1",
             "name": "Dakmor Lancer",
             "text": "",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "ddb9bd32-d7d2-585d-bbb3-285ef3028a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d03720d-b0ca-4892-9ad1-52189f4a30a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d03720d-b0ca-4892-9ad1-52189f4a30a1.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "5cddadf4-5eff-5406-825d-ef690633e55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1d76a2-4f74-4d96-841a-3246922df92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1d76a2-4f74-4d96-841a-3246922df92e.jpg?1",
             "name": "Dark Banishing",
             "text": "",
             "colours": [
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "ba15d277-31ed-529f-8adc-963c70f316a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb0f91-2084-448a-8226-95d7c87dd6bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb0f91-2084-448a-8226-95d7c87dd6bb.jpg?1",
             "name": "Darkest Hour",
             "text": "All creatures are black.",
             "colours": [
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "b2170655-7d7d-5311-832d-332ad260ad00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad13e04-f099-40c8-a25d-fe2329b47170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad13e04-f099-40c8-a25d-fe2329b47170.jpg?1",
             "name": "Darkest Hour",
             "text": "",
             "colours": [
@@ -8804,7 +8804,7 @@
         },
         {
             "id": "0ec60407-f436-5269-b183-1fa8c216ca1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c4223d-8846-489d-abfc-8330dc58d12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c4223d-8846-489d-abfc-8330dc58d12b.jpg?1",
             "name": "Dregs of Sorrow",
             "text": "Destroy X target nonblack creatures. Draw X cards.",
             "colours": [
@@ -8837,7 +8837,7 @@
         },
         {
             "id": "99b5969c-ee75-56a4-8588-65b514fd1e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14c738-93cc-4c3a-8d59-6ef7fa22fb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14c738-93cc-4c3a-8d59-6ef7fa22fb1c.jpg?1",
             "name": "Dregs of Sorrow",
             "text": "",
             "colours": [
@@ -8870,7 +8870,7 @@
         },
         {
             "id": "5f8d6987-1f00-567b-8b91-fde23bc8b89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be76e8d0-70d3-4fc7-9320-e78ad93bd362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be76e8d0-70d3-4fc7-9320-e78ad93bd362.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate Drudge Skeletons.",
             "colours": [
@@ -8907,7 +8907,7 @@
         },
         {
             "id": "73449d07-4a1e-5e0c-ae9c-18116a7a85ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55407e4-9d86-4ac9-9360-e44335852a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55407e4-9d86-4ac9-9360-e44335852a29.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "c0faaa3b-ab51-5593-a1da-d99f612b52cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd5d6e8-7e7e-4eb2-8994-10610ebcdf4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd5d6e8-7e7e-4eb2-8994-10610ebcdf4c.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -8981,7 +8981,7 @@
         },
         {
             "id": "800ee05c-a08c-52c7-b539-c742285c26fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de18b04b-16d2-4f92-8b06-35e195ec7b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de18b04b-16d2-4f92-8b06-35e195ec7b58.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "850ac11d-2cc1-5009-bf0f-5bcfba8ede5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c8d82e-6e65-4d36-bf09-b24dde016581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c8d82e-6e65-4d36-bf09-b24dde016581.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. Choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "a1d63a07-098f-5702-9c1f-782659117d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08298bdd-38a4-43ef-a2b6-4d9b69b0d417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08298bdd-38a4-43ef-a2b6-4d9b69b0d417.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "9a96fb35-83ab-5112-90f5-b098fa732304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6dbd6e-c51f-427b-91ab-2d0988fb9966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6dbd6e-c51f-427b-91ab-2d0988fb9966.jpg?1",
             "name": "Eastern Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target green creature.",
             "colours": [
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "c720ab76-d8ff-5b80-9fc0-9f92f1a58315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4283a695-57fd-442c-906b-f88b039de79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4283a695-57fd-442c-906b-f88b039de79d.jpg?1",
             "name": "Eastern Paladin",
             "text": "",
             "colours": [
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "af2420e7-c928-5045-bd3e-c65868441704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669e43e-3b11-42c9-8f20-0acce129e63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669e43e-3b11-42c9-8f20-0acce129e63c.jpg?1",
             "name": "Engineered Plague",
             "text": "As Engineered Plague comes into play, choose a creature type.\nAll creatures of the chosen type get -1/-1.",
             "colours": [
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "3f47a76e-a3d4-53e8-a5ba-bbc5e49c31a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad057e-4314-47b3-ace8-e784635740db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad057e-4314-47b3-ace8-e784635740db.jpg?1",
             "name": "Engineered Plague",
             "text": "",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "06c44555-4838-59bc-8510-5e67398d816d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ecb2c-e732-40cc-9e92-d18b80a26c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ecb2c-e732-40cc-9e92-d18b80a26c4c.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "0d7bfe3c-6f0a-5059-925a-a988d98faa34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84fea71-0018-43b2-ba74-1612cca4ae96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84fea71-0018-43b2-ba74-1612cca4ae96.jpg?1",
             "name": "Fallen Angel",
             "text": "",
             "colours": [
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "10b93069-d761-5e55-b9fd-b7449d4306ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9036d3b2-f13d-4cfd-aab3-2dd1f0dd3479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9036d3b2-f13d-4cfd-aab3-2dd1f0dd3479.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature can't be blocked except by artifact creatures and/or black creatures.",
             "colours": [
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "e1da1e2a-5142-588b-9785-5507f8df26f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28b0f2-ea67-41ff-a187-356eef227bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28b0f2-ea67-41ff-a187-356eef227bc0.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "d2c6954d-8a23-556b-8fad-74848a4e2ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fed5a2-807c-45c0-8692-c9781bee2da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fed5a2-807c-45c0-8692-c9781bee2da9.jpg?1",
             "name": "Foul Imp",
             "text": "Flying\nWhen Foul Imp comes into play, you lose 2 life.",
             "colours": [
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "df90f6e7-c29a-5f84-a4c6-ddaec23a02e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3da66a-ac81-4300-80a1-f70cdb104a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3da66a-ac81-4300-80a1-f70cdb104a90.jpg?1",
             "name": "Foul Imp",
             "text": "",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "b7016653-a523-51f1-a26b-299dc2e3baf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee37df6-ca09-44f2-b4a4-ad21be4b2a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee37df6-ca09-44f2-b4a4-ad21be4b2a4d.jpg?1",
             "name": "Fugue",
             "text": "Target player discards three cards from his or her hand.",
             "colours": [
@@ -9467,7 +9467,7 @@
         },
         {
             "id": "85c4fcff-a522-53d4-9d59-746da69480e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5c89d-5f26-420e-b490-3d94239a6280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5c89d-5f26-420e-b490-3d94239a6280.jpg?1",
             "name": "Fugue",
             "text": "",
             "colours": [
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "ac4c6866-8a4f-51e8-a64e-65eec9d101f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d42a-85fc-4a25-aedc-719b938661e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d42a-85fc-4a25-aedc-719b938661e5.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "8cb3af5f-543d-5a5a-ba15-2aaeca958114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade86194-9b77-4175-8088-da784cbcfd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade86194-9b77-4175-8088-da784cbcfd49.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "8301f0e4-51a4-52d5-8ab8-1a36e3acc97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961dec46-b96e-486c-939f-9c11aa75bd04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961dec46-b96e-486c-939f-9c11aa75bd04.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "1281d54d-9e4d-5a54-b8b5-2c9932fad87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590a3850-c59e-4357-9f34-f7a57c4486e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590a3850-c59e-4357-9f34-f7a57c4486e0.jpg?1",
             "name": "Gravedigger",
             "text": "",
             "colours": [
@@ -9640,7 +9640,7 @@
         },
         {
             "id": "4682b02a-cf4d-5dbf-8bd4-aa67a2244b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06db06b-0780-41c7-9b6c-a688b0f5fa2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06db06b-0780-41c7-9b6c-a688b0f5fa2c.jpg?1",
             "name": "Greed",
             "text": "o\nB, Pay 2 life: Draw a card.",
             "colours": [
@@ -9673,7 +9673,7 @@
         },
         {
             "id": "1ea1a96f-8186-5272-aaea-c1111b04df32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51b23a-d67d-4ede-a1b2-1ba6dad9883e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51b23a-d67d-4ede-a1b2-1ba6dad9883e.jpg?1",
             "name": "Greed",
             "text": "",
             "colours": [
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "b7f1e009-fab6-5651-af8d-19aafdfe8b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e6ed54-a72c-413a-8038-a3ed571571bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e6ed54-a72c-413a-8038-a3ed571571bd.jpg?1",
             "name": "Hollow Dogs",
             "text": "Whenever Hollow Dogs attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -9743,7 +9743,7 @@
         },
         {
             "id": "526cddc6-4d79-5c0d-8109-d127b161ea9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c036abf0-9da3-4cc4-8aa1-92293fad77b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c036abf0-9da3-4cc4-8aa1-92293fad77b2.jpg?1",
             "name": "Hollow Dogs",
             "text": "",
             "colours": [
@@ -9780,7 +9780,7 @@
         },
         {
             "id": "6039c841-a107-5ef4-9a66-6c174c5e3f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fedf1b4-a3ee-410e-8b2b-ff848a8f60c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fedf1b4-a3ee-410e-8b2b-ff848a8f60c4.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -9813,7 +9813,7 @@
         },
         {
             "id": "78d7953b-79a5-5f44-b3a0-4494d78969e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd1202-ad8b-4526-ba6b-0460f56d91a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd1202-ad8b-4526-ba6b-0460f56d91a6.jpg?1",
             "name": "Howl from Beyond",
             "text": "",
             "colours": [
@@ -9846,7 +9846,7 @@
         },
         {
             "id": "c4120fa5-4784-5a3c-9f38-1bd6a041e261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f451a70f-1f1c-4fd6-ab0c-4b77a043c324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f451a70f-1f1c-4fd6-ab0c-4b77a043c324.jpg?1",
             "name": "Infernal Contract",
             "text": "Draw four cards. You lose half your life, rounded up.",
             "colours": [
@@ -9879,7 +9879,7 @@
         },
         {
             "id": "e660dfed-6933-56a4-9496-49fb57a4fb6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272ecc-33bd-4144-996a-9e0c9d0a9e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272ecc-33bd-4144-996a-9e0c9d0a9e20.jpg?1",
             "name": "Infernal Contract",
             "text": "",
             "colours": [
@@ -9912,7 +9912,7 @@
         },
         {
             "id": "85ddd0d4-6e75-5cd6-a21a-00697a8428c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d37d29-b667-4124-907d-5636a6db044f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d37d29-b667-4124-907d-5636a6db044f.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Enchanted creature has swampwalk. (It's unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "e6f69d8a-e701-528a-ae76-4f6ee0258d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2793f9ea-6a3d-4c02-92d2-0eb62a4dedb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2793f9ea-6a3d-4c02-92d2-0eb62a4dedb2.jpg?1",
             "name": "Leshrac's Rite",
             "text": "",
             "colours": [
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "7fceaa02-191a-57c1-99c1-d44e1c515a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c49d4b-cb89-4f63-ac94-a2075f79f628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c49d4b-cb89-4f63-ac94-a2075f79f628.jpg?1",
             "name": "Looming Shade",
             "text": "oo\nB Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10017,7 +10017,7 @@
         },
         {
             "id": "9edf00d1-99cc-569c-82d5-7251d2558972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184befc7-be32-47b2-a634-a6d474daa553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184befc7-be32-47b2-a634-a6d474daa553.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -10052,7 +10052,7 @@
         },
         {
             "id": "91aeb58c-7bc9-5a45-b9b6-2df666244f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4f01f9-a673-43df-a263-7c2269c2235e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4f01f9-a673-43df-a263-7c2269c2235e.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "4c5a817d-0afc-5622-ad97-46944e102ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d12b851-9b48-45ab-93fb-4236a63d59c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d12b851-9b48-45ab-93fb-4236a63d59c9.jpg?1",
             "name": "Megrim",
             "text": "",
             "colours": [
@@ -10118,7 +10118,7 @@
         },
         {
             "id": "bace477f-ae4b-5743-8040-573006a55464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681e85c-79d5-4300-bda6-4ae40bb7d5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681e85c-79d5-4300-bda6-4ae40bb7d5d4.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards from his or her hand.",
             "colours": [
@@ -10151,7 +10151,7 @@
         },
         {
             "id": "2266ff47-2ae8-51a9-b44d-062acff857a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7628b7e-7da8-4ef8-8be2-1865605a7589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7628b7e-7da8-4ef8-8be2-1865605a7589.jpg?1",
             "name": "Mind Rot",
             "text": "",
             "colours": [
@@ -10184,7 +10184,7 @@
         },
         {
             "id": "581ecd1a-27b8-5511-b492-1634be6e774d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71315e3-14c1-433b-97be-2cdf99213bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71315e3-14c1-433b-97be-2cdf99213bba.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -10217,7 +10217,7 @@
         },
         {
             "id": "22d9cf5a-eee8-572a-90e9-d4193a2f7711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32037f20-7443-464c-917f-b062f05f58c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32037f20-7443-464c-917f-b062f05f58c3.jpg?1",
             "name": "Nausea",
             "text": "",
             "colours": [
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "d730a4b1-8513-5483-8125-377ad39e8968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da145ff-8989-4457-b408-792d7ad10df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da145ff-8989-4457-b408-792d7ad10df9.jpg?1",
             "name": "Necrologia",
             "text": "Play Necrologia only during your end of turn step.\nAs an additional cost to play Necrologia, pay any amount of life.\nDraw cards equal to the life paid this way.",
             "colours": [
@@ -10283,7 +10283,7 @@
         },
         {
             "id": "70e0c537-df48-5c75-8cb7-82548f0fea4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb901bc0-e544-4e3a-b447-0eabe8710d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb901bc0-e544-4e3a-b447-0eabe8710d73.jpg?1",
             "name": "Necrologia",
             "text": "",
             "colours": [
@@ -10316,7 +10316,7 @@
         },
         {
             "id": "bd1e27ff-f860-5870-92b2-f8931c08500b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3779fda-5de0-4d80-8af0-95956e87d9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3779fda-5de0-4d80-8af0-95956e87d9e1.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of swamps you control.",
             "colours": [
@@ -10352,7 +10352,7 @@
         },
         {
             "id": "38498161-8bff-554c-83b6-ab24dbabddff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8817ef5f-39f0-4358-bc98-f512f9cce8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8817ef5f-39f0-4358-bc98-f512f9cce8f0.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -10388,7 +10388,7 @@
         },
         {
             "id": "e76dc89f-4205-5fda-9f54-654a69913b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77419949-7e62-48fe-b952-56d943ddd39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77419949-7e62-48fe-b952-56d943ddd39f.jpg?1",
             "name": "Nocturnal Raid",
             "text": "Black creatures get +2/+0 until end of turn.",
             "colours": [
@@ -10421,7 +10421,7 @@
         },
         {
             "id": "adc06ff6-a0ab-56e4-9627-8cf5e99a025d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b354cf4-ca4f-400c-ab74-ac80fe240b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b354cf4-ca4f-400c-ab74-ac80fe240b74.jpg?1",
             "name": "Nocturnal Raid",
             "text": "",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "de139d2f-e1bb-52e0-a58a-8d1548624ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac327f80-983e-4e28-96e8-91ff5377f5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac327f80-983e-4e28-96e8-91ff5377f5a3.jpg?1",
             "name": "Oppression",
             "text": "Whenever a player plays a spell, that player discards a card from his or her hand.",
             "colours": [
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "c9c55e4f-97ff-5ae4-b635-31c9f1c7bbaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc8791c-3d7a-4e61-ac5f-8aec5f44b12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc8791c-3d7a-4e61-ac5f-8aec5f44b12c.jpg?1",
             "name": "Oppression",
             "text": "",
             "colours": [
@@ -10520,7 +10520,7 @@
         },
         {
             "id": "1ce667c5-3b74-516d-b8b7-b27586b502ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdaffcc-59f6-4489-88bf-1061ad6b0512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdaffcc-59f6-4489-88bf-1061ad6b0512.jpg?1",
             "name": "Ostracize",
             "text": "Target opponent reveals his or her hand. Choose a creature card from it. That player discards that card.",
             "colours": [
@@ -10553,7 +10553,7 @@
         },
         {
             "id": "b33e9bcf-2660-5495-906c-cd729d5251fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02ee53c-74dc-487d-88dc-e62a533c63b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02ee53c-74dc-487d-88dc-e62a533c63b3.jpg?1",
             "name": "Ostracize",
             "text": "",
             "colours": [
@@ -10586,7 +10586,7 @@
         },
         {
             "id": "a56c8cc3-bc52-564d-92d1-53a0a93cb95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21334b-f06c-4525-89e1-dc3f148210ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21334b-f06c-4525-89e1-dc3f148210ef.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Target player reveals his or her hand and discards all cards of that color from it.",
             "colours": [
@@ -10619,7 +10619,7 @@
         },
         {
             "id": "e28faeed-a632-5fc4-b913-af61476650bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2385b6f1-e75c-41d3-9cab-39ae6c315b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2385b6f1-e75c-41d3-9cab-39ae6c315b93.jpg?1",
             "name": "Persecute",
             "text": "",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "f07490e6-85d2-5abb-8866-84be66b5ae64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dce7e-1de9-43c9-a29a-144c189873da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dce7e-1de9-43c9-a29a-144c189873da.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "04f52fb7-799d-5855-bb78-6763bc5b632e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91546e2-3384-40c0-a7b9-d83a7a642083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91546e2-3384-40c0-a7b9-d83a7a642083.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -10722,7 +10722,7 @@
         },
         {
             "id": "0aaecdea-6901-5217-983c-3f65db12fd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3809e6-41ac-47e8-80dc-9e9c8be1ed7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3809e6-41ac-47e8-80dc-9e9c8be1ed7a.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Target opponent reveals his or her hand and discards a creature card at random from it. Play this ability only during your turn.",
             "colours": [
@@ -10758,7 +10758,7 @@
         },
         {
             "id": "9d997f60-06ee-5904-a67b-49767bd632bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dd33f6-2b7b-483a-b38e-bcf8e69a935c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dd33f6-2b7b-483a-b38e-bcf8e69a935c.jpg?1",
             "name": "Rag Man",
             "text": "",
             "colours": [
@@ -10794,7 +10794,7 @@
         },
         {
             "id": "25fdc9a4-fe3c-5a51-b09c-d2b3420ec619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929cdbb4-d8b3-4e01-918c-2f46d74bb455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929cdbb4-d8b3-4e01-918c-2f46d74bb455.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -10829,7 +10829,7 @@
         },
         {
             "id": "f9223895-3828-5c5b-8d8e-6258a9753c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d936478a-c9a9-45b6-afd7-de30f1c3221f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d936478a-c9a9-45b6-afd7-de30f1c3221f.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -10864,7 +10864,7 @@
         },
         {
             "id": "b41379c9-ad2a-5d4a-973b-d6aabe1934a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb1c2e-49ae-4f26-9f7d-6643cb79eea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb1c2e-49ae-4f26-9f7d-6643cb79eea5.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -10899,7 +10899,7 @@
         },
         {
             "id": "f7731317-6e2c-587a-80b0-304df2d2973b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062f3566-ff6a-4f2a-9896-9547e46e6bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062f3566-ff6a-4f2a-9896-9547e46e6bac.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -10934,7 +10934,7 @@
         },
         {
             "id": "f7795041-1708-5b7a-9979-eebd38f242d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68064995-c1e4-4ea7-b6b7-246ce49e2cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68064995-c1e4-4ea7-b6b7-246ce49e2cf4.jpg?1",
             "name": "Razortooth Rats",
             "text": "Razortooth Rats can't be blocked except by artifact creatures and/or black creatures.",
             "colours": [
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "04a9d574-a7b3-5218-ab38-f1f1bcf725be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2145f-298b-4c27-b8b2-18f6975087dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2145f-298b-4c27-b8b2-18f6975087dd.jpg?1",
             "name": "Razortooth Rats",
             "text": "",
             "colours": [
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "666aad2b-feaf-58ef-939b-9ebc757c351a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc8c769-f2d1-4ef3-bbcc-277f39a10dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc8c769-f2d1-4ef3-bbcc-277f39a10dbd.jpg?1",
             "name": "Reprocess",
             "text": "Sacrifice any number of artifacts, creatures, and/or lands. Draw a card for each permanent sacrificed this way.",
             "colours": [
@@ -11037,7 +11037,7 @@
         },
         {
             "id": "e9f224cc-d94d-5049-b464-8d96dac87964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaac30c-9ae6-4788-b065-ae4095ee3097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaac30c-9ae6-4788-b065-ae4095ee3097.jpg?1",
             "name": "Reprocess",
             "text": "",
             "colours": [
@@ -11070,7 +11070,7 @@
         },
         {
             "id": "2da6eda0-7679-5d24-82b2-5b55436b4bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c75244-68b3-463d-aad3-2b22f1eaf717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c75244-68b3-463d-aad3-2b22f1eaf717.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -11105,7 +11105,7 @@
         },
         {
             "id": "237e7a69-c113-5572-96b3-ddc575949b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c979ec16-65f4-4afa-8e03-c05ce46337b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c979ec16-65f4-4afa-8e03-c05ce46337b0.jpg?1",
             "name": "Revenant",
             "text": "",
             "colours": [
@@ -11140,7 +11140,7 @@
         },
         {
             "id": "f7f1ae2c-2abb-5387-b2b0-587855c6fdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed515f6f-432e-4455-a871-5cefdd15a37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed515f6f-432e-4455-a871-5cefdd15a37c.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "338f7cd3-0bf3-535b-8728-12f15f3279ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7167902-939f-4aae-819a-8b941ce45cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7167902-939f-4aae-819a-8b941ce45cb1.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "11b1aeee-119a-5a76-b5f1-4fbdf732fa72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be514ca-dd8a-4b84-9125-03a0bf8a047d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be514ca-dd8a-4b84-9125-03a0bf8a047d.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11251,7 +11251,7 @@
         },
         {
             "id": "3f6f0f8d-b464-5b33-bf09-84a2bcfdd12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bddc0b-f000-4679-bbfd-ab7674e30343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bddc0b-f000-4679-bbfd-ab7674e30343.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11288,7 +11288,7 @@
         },
         {
             "id": "5862b060-f1c1-5405-b75e-60376605a8eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4470eb5d-a968-4e08-a96a-4e92ecc6d56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4470eb5d-a968-4e08-a96a-4e92ecc6d56c.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, you lose 3 life.",
             "colours": [
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "02cadd9f-e673-5e22-964f-022fbbe239a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138658d9-368e-46c6-b957-8bdb0699457d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138658d9-368e-46c6-b957-8bdb0699457d.jpg?1",
             "name": "Serpent Warrior",
             "text": "",
             "colours": [
@@ -11360,7 +11360,7 @@
         },
         {
             "id": "992a0698-7f7f-5679-8f0e-e5d88a2b51a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a273c4f4-b156-4bf5-a33d-656a4e49a0ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a273c4f4-b156-4bf5-a33d-656a4e49a0ff.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -11393,7 +11393,7 @@
         },
         {
             "id": "04931a02-a82a-5f59-9b62-57da7e28a15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e0586-dce6-47b5-adad-22d369d4c021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e0586-dce6-47b5-adad-22d369d4c021.jpg?1",
             "name": "Soul Feast",
             "text": "",
             "colours": [
@@ -11426,7 +11426,7 @@
         },
         {
             "id": "aeebc228-ffc6-5f1b-8fc9-2720a1da6257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c091d07-5813-47b9-b1da-d749e3f4e5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c091d07-5813-47b9-b1da-d749e3f4e5aa.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -11463,7 +11463,7 @@
         },
         {
             "id": "acc2544f-b6af-5194-8efb-a65872846b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7ec32-96ca-472f-9a2c-4b4b30cdcc98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7ec32-96ca-472f-9a2c-4b4b30cdcc98.jpg?1",
             "name": "Spineless Thug",
             "text": "",
             "colours": [
@@ -11500,7 +11500,7 @@
         },
         {
             "id": "9c541c1a-7f59-55ce-99d3-08b0bd279562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f6685d-eb5d-403f-b89a-b8b67900b602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f6685d-eb5d-403f-b89a-b8b67900b602.jpg?1",
             "name": "Strands of Night",
             "text": "o\nBo\nB, Pay 2 life, Sacrifice a swamp: Return target creature card from your graveyard to play.",
             "colours": [
@@ -11533,7 +11533,7 @@
         },
         {
             "id": "40b0416a-8888-5aa9-bf02-321d6e5a7f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79771-6bb8-4575-b9f4-bd1107a676c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79771-6bb8-4575-b9f4-bd1107a676c0.jpg?1",
             "name": "Strands of Night",
             "text": "",
             "colours": [
@@ -11566,7 +11566,7 @@
         },
         {
             "id": "9b1af246-8a99-56a1-ae3a-c03aa9ea96ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388ad92-fa79-4a1a-b75c-e340dba016f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388ad92-fa79-4a1a-b75c-e340dba016f4.jpg?1",
             "name": "Stronghold Assassin",
             "text": "oc\nT, Sacrifice a creature: Destroy target nonblack creature.",
             "colours": [
@@ -11603,7 +11603,7 @@
         },
         {
             "id": "dee3a7f1-f51f-5f27-b145-7ef7de8b6897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fba666-9648-44d8-9cbd-f98bca90fccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fba666-9648-44d8-9cbd-f98bca90fccb.jpg?1",
             "name": "Stronghold Assassin",
             "text": "",
             "colours": [
@@ -11640,7 +11640,7 @@
         },
         {
             "id": "2213f56b-2cc3-5484-8899-ccd4bc8e17db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838cffb6-8099-44d7-a127-b2ab3b53ea44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838cffb6-8099-44d7-a127-b2ab3b53ea44.jpg?1",
             "name": "Tainted Aether",
             "text": "Whenever a creature comes into play, its controller sacrifices a creature or land.",
             "colours": [
@@ -11673,7 +11673,7 @@
         },
         {
             "id": "dc3a9a3a-18a1-53e6-996c-a65ea9fc1101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca62508-4f7f-4dac-82ae-b978acb32c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca62508-4f7f-4dac-82ae-b978acb32c67.jpg?1",
             "name": "Tainted Aether",
             "text": "",
             "colours": [
@@ -11706,7 +11706,7 @@
         },
         {
             "id": "cec4371b-cc1c-5189-ba51-d6f93b9fd543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchanted creature gets +2/+1.",
             "colours": [
@@ -11741,7 +11741,7 @@
         },
         {
             "id": "9a40c67b-117f-560e-82f8-815ecb073f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42101792-83a7-492d-a5b0-34aab7db56d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42101792-83a7-492d-a5b0-34aab7db56d1.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -11776,7 +11776,7 @@
         },
         {
             "id": "530eb096-ec15-5414-9314-56237bbef6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5092f-a248-471e-87e0-8394d5e2d3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5092f-a248-471e-87e0-8394d5e2d3fe.jpg?1",
             "name": "Wall of Bone",
             "text": "(Walls can't attack.)\noo\nB Regenerate Wall of Bone.",
             "colours": [
@@ -11812,7 +11812,7 @@
         },
         {
             "id": "b6bd71ae-648c-5fab-b426-8484cf385c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb18ebfa-9a70-48c6-a906-149f0e7cd474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb18ebfa-9a70-48c6-a906-149f0e7cd474.jpg?1",
             "name": "Wall of Bone",
             "text": "",
             "colours": [
@@ -11848,7 +11848,7 @@
         },
         {
             "id": "9ff4881d-e500-5d01-934a-2cd683136da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4d19d4-a29b-4b1f-b29b-adcad557c3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4d19d4-a29b-4b1f-b29b-adcad557c3c7.jpg?1",
             "name": "Western Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target white creature.",
             "colours": [
@@ -11885,7 +11885,7 @@
         },
         {
             "id": "a25a0959-fd9d-56c5-aab5-a8049ca65f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9ad3e-f392-48ed-9f31-3a997a3b7358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9ad3e-f392-48ed-9f31-3a997a3b7358.jpg?1",
             "name": "Western Paladin",
             "text": "",
             "colours": [
@@ -11922,7 +11922,7 @@
         },
         {
             "id": "f287c781-840f-556d-84ae-d7fd8eefbb2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ed0e5-37a0-4909-a37e-ba4745bfae3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ed0e5-37a0-4909-a37e-ba4745bfae3b.jpg?1",
             "name": "Yawgmoth's Edict",
             "text": "Whenever an opponent plays a white spell, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -11955,7 +11955,7 @@
         },
         {
             "id": "74b31c78-56a4-5181-b723-7af590fb68d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2b1255-d917-4884-aa9e-4b1f92e88f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2b1255-d917-4884-aa9e-4b1f92e88f79.jpg?1",
             "name": "Yawgmoth's Edict",
             "text": "",
             "colours": [
@@ -11988,7 +11988,7 @@
         },
         {
             "id": "31eb6863-c020-501f-9090-1a187afb3f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f9197-e910-4c7a-bb4b-2c4a94903c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f9197-e910-4c7a-bb4b-2c4a94903c39.jpg?1",
             "name": "Aether Flash",
             "text": "Whenever a creature comes into play, \u00c6ther Flash deals 2 damage to it.",
             "colours": [
@@ -12021,7 +12021,7 @@
         },
         {
             "id": "8ee43db3-a2ff-5ef3-bcd6-4e2ef0970b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6b8fa-3546-415f-89f1-1176d22ad15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6b8fa-3546-415f-89f1-1176d22ad15e.jpg?1",
             "name": "Aether Flash",
             "text": "",
             "colours": [
@@ -12054,7 +12054,7 @@
         },
         {
             "id": "43e74954-68ea-5001-a2ed-be6e49cebdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2507e14-96d1-40e6-9379-4d4749d74e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2507e14-96d1-40e6-9379-4d4749d74e1d.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12090,7 +12090,7 @@
         },
         {
             "id": "d70572ec-dadd-5399-bfda-9a0a4d354ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c201ace3-4d99-467e-a558-7d22ad004cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c201ace3-4d99-467e-a558-7d22ad004cf2.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12126,7 +12126,7 @@
         },
         {
             "id": "35395ade-6181-5b51-bbc7-166ba98c9718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2788ec1a-930e-4a19-ad69-ea456c1390fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2788ec1a-930e-4a19-ad69-ea456c1390fd.jpg?1",
             "name": "Bedlam",
             "text": "Creatures can't block.",
             "colours": [
@@ -12159,7 +12159,7 @@
         },
         {
             "id": "ed671661-49f6-5c62-8888-eaec5bedb81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbcb398-85be-4923-9888-9dcca89a0b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbcb398-85be-4923-9888-9dcca89a0b59.jpg?1",
             "name": "Bedlam",
             "text": "",
             "colours": [
@@ -12192,7 +12192,7 @@
         },
         {
             "id": "21d76910-b7e2-59a8-b95e-40bcffbeccea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f8c6ab-ae62-4e2e-a5ba-2ec5bbe22445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f8c6ab-ae62-4e2e-a5ba-2ec5bbe22445.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -12225,7 +12225,7 @@
         },
         {
             "id": "d7df02ab-9e9f-55c7-ae16-d9f1f9e41aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a9a4ba-98ef-4eb1-a650-a77b84226701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a9a4ba-98ef-4eb1-a650-a77b84226701.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -12258,7 +12258,7 @@
         },
         {
             "id": "fcb50e71-6a4b-5eec-8691-68b2a8be7ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387dd482-c67d-43da-a4d0-582241431ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387dd482-c67d-43da-a4d0-582241431ffd.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "oc\nT, Sacrifice a creature: Bloodshot Cyclops deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -12294,7 +12294,7 @@
         },
         {
             "id": "442262b1-f7b7-5d9a-8b4c-a563514f2c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c07aa-beae-4818-9424-6dbfb30a428d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c07aa-beae-4818-9424-6dbfb30a428d.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "",
             "colours": [
@@ -12330,7 +12330,7 @@
         },
         {
             "id": "dbef4913-79fc-55d2-acc0-31029398f4d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52969d36-f392-4920-b998-589c8356b898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52969d36-f392-4920-b998-589c8356b898.jpg?1",
             "name": "Boil",
             "text": "Destroy all islands.",
             "colours": [
@@ -12363,7 +12363,7 @@
         },
         {
             "id": "6409bdc3-f0ab-5db3-83de-9bae5d9eb403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09b9aae-0f87-4b0e-b4b2-7961f1e7f2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09b9aae-0f87-4b0e-b4b2-7961f1e7f2e0.jpg?1",
             "name": "Boil",
             "text": "",
             "colours": [
@@ -12396,7 +12396,7 @@
         },
         {
             "id": "2709f74a-8ab0-519e-aea7-8a49e7bcbfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5451e44f-8dd2-48c6-ba67-5c62a04819ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5451e44f-8dd2-48c6-ba67-5c62a04819ef.jpg?1",
             "name": "Crimson Hellkite",
             "text": "Flying\no\nX, oc\nT: Crimson Hellkite deals X damage to target creature. Spend only red mana this way.",
             "colours": [
@@ -12431,7 +12431,7 @@
         },
         {
             "id": "0dd2d898-eba8-5db1-9f95-02e8cea5a97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ed1fde-817d-4e0a-8268-461a680aed96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ed1fde-817d-4e0a-8268-461a680aed96.jpg?1",
             "name": "Crimson Hellkite",
             "text": "",
             "colours": [
@@ -12466,7 +12466,7 @@
         },
         {
             "id": "4a02f6c6-449d-54cb-8225-9c01c2a9d973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d11422-60a9-4386-8e7f-dd7dcdac58d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d11422-60a9-4386-8e7f-dd7dcdac58d8.jpg?1",
             "name": "Disorder",
             "text": "Disorder deals 2 damage to each white creature and each player who controls a white creature.",
             "colours": [
@@ -12499,7 +12499,7 @@
         },
         {
             "id": "dcb171b1-a744-52d2-8ce3-ccef37b096c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569ca10-6c5e-44ea-810e-62082e589d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569ca10-6c5e-44ea-810e-62082e589d5a.jpg?1",
             "name": "Disorder",
             "text": "",
             "colours": [
@@ -12532,7 +12532,7 @@
         },
         {
             "id": "2b52d157-56e1-545b-90a7-097740137230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f04dc5c-2764-42d0-974e-6d902222c138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f04dc5c-2764-42d0-974e-6d902222c138.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -12565,7 +12565,7 @@
         },
         {
             "id": "fb67591e-b390-5ee0-8637-c51430b7fe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39fb5f-9eb7-4a4c-9382-80b5a9459afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39fb5f-9eb7-4a4c-9382-80b5a9459afc.jpg?1",
             "name": "Earthquake",
             "text": "",
             "colours": [
@@ -12598,7 +12598,7 @@
         },
         {
             "id": "ff8ac494-926d-52b5-90b3-bc4c6790b5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53834370-845c-4677-b665-e556eae8f9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53834370-845c-4677-b665-e556eae8f9de.jpg?1",
             "name": "Fervor",
             "text": "Creatures you control have haste. (They may attack and oc\nT the turn they come under your control.)",
             "colours": [
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "b12ea152-1a82-5673-afa7-07ae4af6609b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c955ff9-0615-4872-8a05-770558ff81dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c955ff9-0615-4872-8a05-770558ff81dd.jpg?1",
             "name": "Fervor",
             "text": "",
             "colours": [
@@ -12664,7 +12664,7 @@
         },
         {
             "id": "7cd22d3d-3cc9-52c0-80c2-17cd47a2daaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb80afc3-4887-42a0-afb2-7fa997981fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb80afc3-4887-42a0-afb2-7fa997981fb2.jpg?1",
             "name": "Final Fortune",
             "text": "Take an extra turn after this one. At the end of that turn, you lose the game.",
             "colours": [
@@ -12697,7 +12697,7 @@
         },
         {
             "id": "68a26e0b-c073-59f8-bb29-44f56ac0687a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60b7014-3e29-4308-976c-0d92df5cec3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60b7014-3e29-4308-976c-0d92df5cec3a.jpg?1",
             "name": "Final Fortune",
             "text": "",
             "colours": [
@@ -12730,7 +12730,7 @@
         },
         {
             "id": "9b6af124-6897-52d6-b1d6-5bc8617f1990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b57e53-220c-4181-80d3-8063864aefc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b57e53-220c-4181-80d3-8063864aefc2.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -12765,7 +12765,7 @@
         },
         {
             "id": "61647959-a65e-57a3-99e2-8c625d689e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b05f47-f86b-46e8-912f-b1273005d46d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b05f47-f86b-46e8-912f-b1273005d46d.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -12800,7 +12800,7 @@
         },
         {
             "id": "b07b8c61-b28a-5687-965a-4d02fde2365f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770cc34-0f38-4773-8633-6907f44436c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770cc34-0f38-4773-8633-6907f44436c4.jpg?1",
             "name": "Ghitu Fire-Eater",
             "text": "oc\nT, Sacrifice Ghitu Fire-Eater: Ghitu Fire-Eater deals damage equal to its power to target creature or player.",
             "colours": [
@@ -12836,7 +12836,7 @@
         },
         {
             "id": "4c6ad381-4174-5d3b-b8ee-77332d8610af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6976444-a076-4e67-80f7-014a1c955eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6976444-a076-4e67-80f7-014a1c955eed.jpg?1",
             "name": "Ghitu Fire-Eater",
             "text": "",
             "colours": [
@@ -12872,7 +12872,7 @@
         },
         {
             "id": "b0598837-3dfe-52e7-8fc3-c34da20ee86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7571801-c1df-4387-ae61-1fefd449ebf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7571801-c1df-4387-ae61-1fefd449ebf9.jpg?1",
             "name": "Goblin Chariot",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -12908,7 +12908,7 @@
         },
         {
             "id": "589d3d87-71b3-54b1-a930-35feea96c87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db520e2-9926-45d2-a140-37b119b88106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db520e2-9926-45d2-a140-37b119b88106.jpg?1",
             "name": "Goblin Chariot",
             "text": "",
             "colours": [
@@ -12944,7 +12944,7 @@
         },
         {
             "id": "ce078bfc-329f-5a9e-a247-3d18475f79bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000425a-4761-4370-95eb-6fe3df628482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000425a-4761-4370-95eb-6fe3df628482.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT, Sacrifice Goblin Digging Team: Destroy target Wall.",
             "colours": [
@@ -12979,7 +12979,7 @@
         },
         {
             "id": "49a4c04b-5a5a-5299-a1ac-1d22796270c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84e6b4-2f87-4662-843d-27d2eada54aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84e6b4-2f87-4662-843d-27d2eada54aa.jpg?1",
             "name": "Goblin Digging Team",
             "text": "",
             "colours": [
@@ -13014,7 +13014,7 @@
         },
         {
             "id": "21e49119-58dc-5898-9967-b15e62650153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5b7dfe-f24b-4d73-813f-f63c926f3672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5b7dfe-f24b-4d73-813f-f63c926f3672.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "Whenever Goblin Elite Infantry blocks or becomes blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -13050,7 +13050,7 @@
         },
         {
             "id": "1fd79e20-c1d4-58cc-8a8a-d73522a3fc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9facc1bf-b088-4be0-acce-be95c0a3e9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9facc1bf-b088-4be0-acce-be95c0a3e9e6.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "",
             "colours": [
@@ -13086,7 +13086,7 @@
         },
         {
             "id": "96dd6934-93f2-5aec-93c2-2504689cff27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5b02af-140e-404d-bf8a-6a706b323a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5b02af-140e-404d-bf8a-6a706b323a13.jpg?1",
             "name": "Goblin Gardener",
             "text": "When Goblin Gardener is put into a graveyard from play, destroy target land.",
             "colours": [
@@ -13121,7 +13121,7 @@
         },
         {
             "id": "6c8cb845-6c89-5689-91c6-165560c5f1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009c1788-a3ab-41cb-8f9a-d220c376953b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009c1788-a3ab-41cb-8f9a-d220c376953b.jpg?1",
             "name": "Goblin Gardener",
             "text": "",
             "colours": [
@@ -13156,7 +13156,7 @@
         },
         {
             "id": "fe10ac37-9967-554e-9fe1-b04108a51810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a7e39-8d98-4e84-8a5c-2b067c8654d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a7e39-8d98-4e84-8a5c-2b067c8654d5.jpg?1",
             "name": "Goblin Glider",
             "text": "Flying\nGoblin Glider can't block.",
             "colours": [
@@ -13191,7 +13191,7 @@
         },
         {
             "id": "7ca32d67-c67d-5edd-b96f-b595e7193267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8cf7c4-f217-42c8-a1ea-0866576b9524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8cf7c4-f217-42c8-a1ea-0866576b9524.jpg?1",
             "name": "Goblin Glider",
             "text": "",
             "colours": [
@@ -13226,7 +13226,7 @@
         },
         {
             "id": "6d4d2d26-dd6f-5f32-9b5e-d6b1cc14e998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77029a-7f00-490e-bf8b-dce192d72e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77029a-7f00-490e-bf8b-dce192d72e2f.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -13261,7 +13261,7 @@
         },
         {
             "id": "2dfa58ac-0663-5f60-9e4f-1e0f9b52ae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3637-ffc8-4bda-bfc1-912f5789b5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3637-ffc8-4bda-bfc1-912f5789b5ed.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -13296,7 +13296,7 @@
         },
         {
             "id": "277664ab-1726-522c-bb53-b3e25e77d43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862409e1-33e0-474c-8627-b03d25b654b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862409e1-33e0-474c-8627-b03d25b654b9.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron comes into play, you may search your library for a Goblin card. If you do, reveal that card and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -13331,7 +13331,7 @@
         },
         {
             "id": "5986b22a-fdee-5b8d-87ec-f0dbd684c378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a80d36-349d-4b49-9a0c-7e0a400abb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a80d36-349d-4b49-9a0c-7e0a400abb67.jpg?1",
             "name": "Goblin Matron",
             "text": "",
             "colours": [
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "7fc1b09a-429b-567b-a677-3371063281f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3315d75d-08dc-456c-a8e7-fe3136bf1a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3315d75d-08dc-456c-a8e7-fe3136bf1a6b.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -13402,7 +13402,7 @@
         },
         {
             "id": "9cf619d6-b382-5803-8c09-6f80c8cf8666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88af4784-e126-4628-b228-6c0a95f00a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88af4784-e126-4628-b228-6c0a95f00a25.jpg?1",
             "name": "Goblin Raider",
             "text": "",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "ffe8d2b0-4994-5990-bd9b-183e21abc670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4dfc6-8b3f-45fb-a1e2-b773f74cd9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4dfc6-8b3f-45fb-a1e2-b773f74cd9c2.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -13474,7 +13474,7 @@
         },
         {
             "id": "facfd06f-8f5f-563f-a9ec-93cd066939c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27f5299-696a-4e00-8221-f349f9b1d461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27f5299-696a-4e00-8221-f349f9b1d461.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "",
             "colours": [
@@ -13510,7 +13510,7 @@
         },
         {
             "id": "2de6975c-3796-5afa-8cee-276c20ba1fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b226987d-e271-483c-9d18-09c461ebbf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b226987d-e271-483c-9d18-09c461ebbf36.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each creature you control can't be blocked except by two or more creatures.",
             "colours": [
@@ -13543,7 +13543,7 @@
         },
         {
             "id": "2a0f3b09-f874-51ae-a67d-3fe33e7a1546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2de28d4-ab1d-4e4d-a8b9-6faa19f9d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2de28d4-ab1d-4e4d-a8b9-6faa19f9d283.jpg?1",
             "name": "Goblin War Drums",
             "text": "",
             "colours": [
@@ -13576,7 +13576,7 @@
         },
         {
             "id": "0c3c6be7-8622-5916-8d75-76a80648d782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908c8414-5eff-4887-9007-43050058c2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908c8414-5eff-4887-9007-43050058c2d0.jpg?1",
             "name": "Granite Grip",
             "text": "Enchanted creature gets +1/+0 for each mountain you control.",
             "colours": [
@@ -13611,7 +13611,7 @@
         },
         {
             "id": "5db693bf-e36b-5979-b45a-0ad90afb0b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb23039-0f38-44f9-845d-b76ca85e4761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb23039-0f38-44f9-845d-b76ca85e4761.jpg?1",
             "name": "Granite Grip",
             "text": "",
             "colours": [
@@ -13646,7 +13646,7 @@
         },
         {
             "id": "59d2de9c-e401-5463-97a7-736caf4064da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea1719-2bed-46f4-bb14-e3a4c87ce50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea1719-2bed-46f4-bb14-e3a4c87ce50a.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13681,7 +13681,7 @@
         },
         {
             "id": "8c1961c0-2fa9-58b7-9418-29771388efd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07724b6b-73e6-43b9-980f-149047c8e786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07724b6b-73e6-43b9-980f-149047c8e786.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13716,7 +13716,7 @@
         },
         {
             "id": "8cb1ea03-3b66-5f5f-a5d7-14bc8e27611d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11443908-358f-4886-a2da-9b98002a3a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11443908-358f-4886-a2da-9b98002a3a3a.jpg?1",
             "name": "Impatience",
             "text": "At the end of each player's turn, if that player didn't play a spell that turn, Impatience deals 2 damage to him or her.",
             "colours": [
@@ -13749,7 +13749,7 @@
         },
         {
             "id": "aae2c1d1-736b-5087-9ef0-64a34a87d351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c59ed1-ecc2-4f0b-a49a-473e797059e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c59ed1-ecc2-4f0b-a49a-473e797059e7.jpg?1",
             "name": "Impatience",
             "text": "",
             "colours": [
@@ -13782,7 +13782,7 @@
         },
         {
             "id": "37d4a707-f4e3-5226-8ce1-e7a46131a03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411b7b5-ab91-410a-af6d-b3a21a8e3b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411b7b5-ab91-410a-af6d-b3a21a8e3b70.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and each player.",
             "colours": [
@@ -13815,7 +13815,7 @@
         },
         {
             "id": "c2c66ad7-d4e0-5103-af88-07dfe672bead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0d589d-d539-453b-b401-14a74e3da4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0d589d-d539-453b-b401-14a74e3da4ea.jpg?1",
             "name": "Inferno",
             "text": "",
             "colours": [
@@ -13848,7 +13848,7 @@
         },
         {
             "id": "299714ff-b0fa-5ba3-841e-d128f2c931a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807e5102-1fab-4ff4-aad8-94defbbb8a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807e5102-1fab-4ff4-aad8-94defbbb8a6b.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -13881,7 +13881,7 @@
         },
         {
             "id": "f67c4dfe-4551-5a27-a8ed-7bb6927c3cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1292a1-3d0e-47a3-97ef-e4ffcdfb492e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1292a1-3d0e-47a3-97ef-e4ffcdfb492e.jpg?1",
             "name": "Lava Axe",
             "text": "",
             "colours": [
@@ -13914,7 +13914,7 @@
         },
         {
             "id": "9d23ae96-17bb-55c5-b84e-5164c2282771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e3c502-9e3c-41db-806c-538243dc0453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e3c502-9e3c-41db-806c-538243dc0453.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -13947,7 +13947,7 @@
         },
         {
             "id": "9af90d76-2d6d-5f91-9267-01e452f9b11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd40ef12-d3fd-4bb9-8990-aa967d8df2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd40ef12-d3fd-4bb9-8990-aa967d8df2dd.jpg?1",
             "name": "Lightning Blast",
             "text": "",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "d350a5a2-9ef5-52cb-be38-ca841c118c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df538e3-84c9-4580-85e9-8ac2f9a1294b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df538e3-84c9-4580-85e9-8ac2f9a1294b.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -14015,7 +14015,7 @@
         },
         {
             "id": "07d2cbac-a3ea-5eca-99c8-c5b158bc7556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d80a8-ac70-4847-b406-321af24de47c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d80a8-ac70-4847-b406-321af24de47c.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -14050,7 +14050,7 @@
         },
         {
             "id": "b6e0422c-ff02-50cc-88bf-c8c110b2d794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740b85ff-61a3-4de0-a055-60daad13ac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740b85ff-61a3-4de0-a055-60daad13ac2a.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
             "colours": [
@@ -14083,7 +14083,7 @@
         },
         {
             "id": "3f21f59a-5f67-5204-b2ca-1a4917baaca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c092c3-1fbe-4319-aefe-d5b819ee953f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c092c3-1fbe-4319-aefe-d5b819ee953f.jpg?1",
             "name": "Mana Clash",
             "text": "",
             "colours": [
@@ -14116,7 +14116,7 @@
         },
         {
             "id": "5b765390-8cda-5fd6-947b-0ccaae02c8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2229fe-5b8f-42c0-bfe6-2c0c3d84624a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2229fe-5b8f-42c0-bfe6-2c0c3d84624a.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -14151,7 +14151,7 @@
         },
         {
             "id": "4e62fad1-d925-5997-9111-23f9f35a1da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa53fb37-d746-491b-830f-46bd60bc2817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa53fb37-d746-491b-830f-46bd60bc2817.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "",
             "colours": [
@@ -14186,7 +14186,7 @@
         },
         {
             "id": "66ab234b-8078-5805-a1a9-a979bfa3f3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fd427-baec-435f-9dc7-339c93f43f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fd427-baec-435f-9dc7-339c93f43f89.jpg?1",
             "name": "Okk",
             "text": "Okk can't attack unless a creature with greater power also attacks.\nOkk can't block unless a creature with greater power also blocks.",
             "colours": [
@@ -14221,7 +14221,7 @@
         },
         {
             "id": "db0e65d3-dc87-5410-a18e-d9e1334d942f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c90704-063c-4774-b675-cb5727afa656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c90704-063c-4774-b675-cb5727afa656.jpg?1",
             "name": "Okk",
             "text": "",
             "colours": [
@@ -14256,7 +14256,7 @@
         },
         {
             "id": "da42d6f1-d546-545d-9e07-0a5179e07571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b13fc4-e26a-4a7c-bde2-ea3626da6aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b13fc4-e26a-4a7c-bde2-ea3626da6aa8.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -14292,7 +14292,7 @@
         },
         {
             "id": "780d4fe6-fc26-59d4-8ed8-83109bf0b2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42afac9-b9a4-4d02-b026-3d03c41d15c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42afac9-b9a4-4d02-b026-3d03c41d15c6.jpg?1",
             "name": "Orcish Artillery",
             "text": "",
             "colours": [
@@ -14328,7 +14328,7 @@
         },
         {
             "id": "9388a4f2-22ad-52ed-9531-47203c593809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45467389-980b-4eaf-9b4b-38fefb307a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45467389-980b-4eaf-9b4b-38fefb307a7c.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -14361,7 +14361,7 @@
         },
         {
             "id": "ae93014e-dbf2-5229-9374-df4fc807c70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10c2e08-c18a-4fc6-9e8b-120fb87c4f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10c2e08-c18a-4fc6-9e8b-120fb87c4f26.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "",
             "colours": [
@@ -14394,7 +14394,7 @@
         },
         {
             "id": "bc115d7b-875d-5b0f-98b7-1a609d93ea46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9792efaa-1f73-48de-8c10-5d20c2856f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9792efaa-1f73-48de-8c10-5d20c2856f3d.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -14427,7 +14427,7 @@
         },
         {
             "id": "ea63b091-9574-519d-985d-02ebd2a863e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4fc2a6-02ff-406c-8a8e-c97ea54b3f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4fc2a6-02ff-406c-8a8e-c97ea54b3f8b.jpg?1",
             "name": "Pillage",
             "text": "",
             "colours": [
@@ -14460,7 +14460,7 @@
         },
         {
             "id": "30e2940c-1871-5004-86c9-e62840065644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e01129-254c-4a16-9f11-21a7a9c66f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e01129-254c-4a16-9f11-21a7a9c66f32.jpg?1",
             "name": "Pygmy Pyrosaur",
             "text": "Pygmy Pyrosaur can't block.\noo\nR Pygmy Pyrosaur gets +1/+0 until end of turn.",
             "colours": [
@@ -14495,7 +14495,7 @@
         },
         {
             "id": "6d5f807b-6d2b-5392-bd4b-f078d5f5a852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57eab2ef-6c3c-4f0e-8566-113070604a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57eab2ef-6c3c-4f0e-8566-113070604a1d.jpg?1",
             "name": "Pygmy Pyrosaur",
             "text": "",
             "colours": [
@@ -14530,7 +14530,7 @@
         },
         {
             "id": "bced00fa-a3da-5bfe-bbc8-5e7c487dbc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afce33f-2ead-4943-9655-bff6eaa9fe6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afce33f-2ead-4943-9655-bff6eaa9fe6b.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -14563,7 +14563,7 @@
         },
         {
             "id": "bcf663d1-de58-50a1-b8f0-d682e6eb503e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964b8482-9154-4f26-9ae7-641d0c00ca99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964b8482-9154-4f26-9ae7-641d0c00ca99.jpg?1",
             "name": "Pyroclasm",
             "text": "",
             "colours": [
@@ -14596,7 +14596,7 @@
         },
         {
             "id": "25e81daf-d908-518e-8988-40f691fc3e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5d0adf-9368-4d7f-8bd0-76d0db95ba16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5d0adf-9368-4d7f-8bd0-76d0db95ba16.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -14629,7 +14629,7 @@
         },
         {
             "id": "6f28193f-9849-5935-b72b-2ea74cd033ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfea5f9-500e-45e8-80b0-9ff9bd09e07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfea5f9-500e-45e8-80b0-9ff9bd09e07a.jpg?1",
             "name": "Pyrotechnics",
             "text": "",
             "colours": [
@@ -14662,7 +14662,7 @@
         },
         {
             "id": "5359482c-87c5-5f9f-98d4-abcd7ae87999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657190fe-9c18-4134-a556-e081daff73cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657190fe-9c18-4134-a556-e081daff73cd.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -14698,7 +14698,7 @@
         },
         {
             "id": "11bfc211-af33-59fb-8f18-8984eec9abab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1c9bb-fa05-4947-9e03-6fe397157265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1c9bb-fa05-4947-9e03-6fe397157265.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -14734,7 +14734,7 @@
         },
         {
             "id": "2b914d35-baac-5974-a2f6-1ade5681ef15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f75ed4-b96c-444b-ac91-8aaa02f32f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f75ed4-b96c-444b-ac91-8aaa02f32f2d.jpg?1",
             "name": "Reckless Embermage",
             "text": "o1oo\nR Reckless Embermage deals 1 damage to target creature or player and 1 damage to itself.",
             "colours": [
@@ -14770,7 +14770,7 @@
         },
         {
             "id": "3a97b6ed-f25f-580c-bb92-0746578bf99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8a8bb2-e876-4e62-a437-96cc4dd6be89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8a8bb2-e876-4e62-a437-96cc4dd6be89.jpg?1",
             "name": "Reckless Embermage",
             "text": "",
             "colours": [
@@ -14806,7 +14806,7 @@
         },
         {
             "id": "ae2370a1-cede-5166-9456-77f013fe27ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc8ce35-589b-4903-8d52-8ccbea7b767b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc8ce35-589b-4903-8d52-8ccbea7b767b.jpg?1",
             "name": "Reflexes",
             "text": "Enchanted creature has first strike.",
             "colours": [
@@ -14841,7 +14841,7 @@
         },
         {
             "id": "260658e8-f823-5ca4-9eb8-d1fe69659225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f91d14-b409-44b6-bdfd-44427855373a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f91d14-b409-44b6-bdfd-44427855373a.jpg?1",
             "name": "Reflexes",
             "text": "",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "cf2276c3-2682-5179-963f-16034403c215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c48308-12e8-4b85-a5ef-1e0643bd814c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c48308-12e8-4b85-a5ef-1e0643bd814c.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You get an additional combat phase followed by an additional main phase this turn.",
             "colours": [
@@ -14909,7 +14909,7 @@
         },
         {
             "id": "5e21154b-f59a-577a-a9f0-11b2c6f08834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242d25fe-e03a-4fa9-8049-d1bb0aef3d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242d25fe-e03a-4fa9-8049-d1bb0aef3d07.jpg?1",
             "name": "Relentless Assault",
             "text": "",
             "colours": [
@@ -14942,7 +14942,7 @@
         },
         {
             "id": "f538335b-b3b5-5669-871f-e7aec35c7c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aee4a17-49da-446f-a134-1261980a249f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aee4a17-49da-446f-a134-1261980a249f.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -14977,7 +14977,7 @@
         },
         {
             "id": "2e19e6fa-6029-5ee8-a67c-ff3de6704e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d923644-3137-4e72-93d3-231066314d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d923644-3137-4e72-93d3-231066314d9b.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "",
             "colours": [
@@ -15012,7 +15012,7 @@
         },
         {
             "id": "794e45bf-7200-5765-a468-1df85e40ab8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d399a9ac-01da-44a4-8f81-084d41dfada8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d399a9ac-01da-44a4-8f81-084d41dfada8.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card from your hand: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -15045,7 +15045,7 @@
         },
         {
             "id": "5f22e249-fe19-5d1b-aa60-ddb77bb4cebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a994998-11b1-46fd-a877-d0b67fa8f777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a994998-11b1-46fd-a877-d0b67fa8f777.jpg?1",
             "name": "Seismic Assault",
             "text": "",
             "colours": [
@@ -15078,7 +15078,7 @@
         },
         {
             "id": "d51fa114-2f31-59bb-8462-63dd0b4df909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0017ebd-d672-4933-8136-d929737e5ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0017ebd-d672-4933-8136-d929737e5ecd.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "6d655976-503f-5d90-9e50-1d173a169ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142a7f05-df30-4bac-801d-06f125e7365f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142a7f05-df30-4bac-801d-06f125e7365f.jpg?1",
             "name": "Shatter",
             "text": "",
             "colours": [
@@ -15144,7 +15144,7 @@
         },
         {
             "id": "3cd07b68-5c96-54c1-ad7d-3bf84c44d72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fec2b71-8fa9-4818-9c4f-5d2dcd2af495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fec2b71-8fa9-4818-9c4f-5d2dcd2af495.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\noo\nR Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -15179,7 +15179,7 @@
         },
         {
             "id": "dc330428-8db9-56aa-8c3e-c743f0b46268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de98d9ad-d011-43de-92c8-f97037b42803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de98d9ad-d011-43de-92c8-f97037b42803.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -15214,7 +15214,7 @@
         },
         {
             "id": "e3e0b141-4097-5914-b6d7-04e66134531e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea653772-a5fe-4416-bef3-fd41133371db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea653772-a5fe-4416-bef3-fd41133371db.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "df9f8162-a41f-5e59-87af-0845fb5a089e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d1cef-c181-481b-912c-385b81efd972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d1cef-c181-481b-912c-385b81efd972.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -15280,7 +15280,7 @@
         },
         {
             "id": "daec60f9-555a-593e-9cb1-aa53822b54f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db01746-2734-4686-b443-52de8e379bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db01746-2734-4686-b443-52de8e379bbe.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals damage equal to the number of mountains you control to target creature.",
             "colours": [
@@ -15313,7 +15313,7 @@
         },
         {
             "id": "d9728beb-28e7-5527-bf48-a94d852d0d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724682ef-d591-4d99-8557-0c970a043bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724682ef-d591-4d99-8557-0c970a043bf7.jpg?1",
             "name": "Spitting Earth",
             "text": "",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "1effc43b-a903-524a-9610-f1ca4b9f5038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b70f97-441c-41ae-ab10-22ddd7bff28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b70f97-441c-41ae-ab10-22ddd7bff28d.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -15379,7 +15379,7 @@
         },
         {
             "id": "7d31456a-4530-5c76-b560-8005f6635dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc5314f-bfc1-4960-8a1f-80291e81b7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc5314f-bfc1-4960-8a1f-80291e81b7b9.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "49df6aff-363d-568d-b412-e983396314f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae941462-9086-47e5-8c04-01e53195584f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae941462-9086-47e5-8c04-01e53195584f.jpg?1",
             "name": "Storm Shaman",
             "text": "oo\nR Storm Shaman gets +1/+0 until end of turn.",
             "colours": [
@@ -15449,7 +15449,7 @@
         },
         {
             "id": "96ebe05b-e012-5d40-a494-737f1312a454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cee0af-29a3-48cc-8a81-c3dac65271d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cee0af-29a3-48cc-8a81-c3dac65271d6.jpg?1",
             "name": "Storm Shaman",
             "text": "",
             "colours": [
@@ -15486,7 +15486,7 @@
         },
         {
             "id": "8c86b102-43b2-578a-ac38-5e2ff3e2ec43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef178ad2-f0e1-4fbb-aada-dccc40463ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef178ad2-f0e1-4fbb-aada-dccc40463ece.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -15519,7 +15519,7 @@
         },
         {
             "id": "ae52e3b6-8e72-50e6-96c4-70624e13a98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c987fd13-c690-46f9-b3ed-d2fc052c45ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c987fd13-c690-46f9-b3ed-d2fc052c45ff.jpg?1",
             "name": "Sudden Impact",
             "text": "",
             "colours": [
@@ -15552,7 +15552,7 @@
         },
         {
             "id": "014b8875-c4c9-54a0-bb1d-4f795816108e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a83031-8b57-41d2-b586-bb4dcf16136a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a83031-8b57-41d2-b586-bb4dcf16136a.jpg?1",
             "name": "Trained Orgg",
             "text": "",
             "colours": [
@@ -15587,7 +15587,7 @@
         },
         {
             "id": "505f27f6-d10b-5dc3-b377-67a189caceb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81dc1a-6560-479b-8c6f-54d04b1853f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81dc1a-6560-479b-8c6f-54d04b1853f7.jpg?1",
             "name": "Trained Orgg",
             "text": "",
             "colours": [
@@ -15622,7 +15622,7 @@
         },
         {
             "id": "d3339a06-c9bf-5714-90f7-958697d0df3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281c013-b35a-4c4a-aaee-b6f93968485c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281c013-b35a-4c4a-aaee-b6f93968485c.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "67bc7b72-651a-5d90-937c-f2250fe439f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd43f654-081f-4ebb-b82e-02a2a8d959fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd43f654-081f-4ebb-b82e-02a2a8d959fa.jpg?1",
             "name": "Tremor",
             "text": "",
             "colours": [
@@ -15688,7 +15688,7 @@
         },
         {
             "id": "a2b9d218-264f-53c2-94b3-046ca16b5a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d93606-4864-4a5f-bcbf-8638211e979d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d93606-4864-4a5f-bcbf-8638211e979d.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to target creature or player.",
             "colours": [
@@ -15721,7 +15721,7 @@
         },
         {
             "id": "80be9379-9bdd-562a-b73d-f3f013d8abd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf796a-8d10-4c37-8fe3-789f99eb526b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf796a-8d10-4c37-8fe3-789f99eb526b.jpg?1",
             "name": "Volcanic Hammer",
             "text": "",
             "colours": [
@@ -15754,7 +15754,7 @@
         },
         {
             "id": "08019087-0b0e-5a6c-8fa1-56c1310eb815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35113d19-0d4a-4513-82f3-c8deaa1e4324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35113d19-0d4a-4513-82f3-c8deaa1e4324.jpg?1",
             "name": "Wall of Fire",
             "text": "(Walls can't attack.)\noo\nR Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -15789,7 +15789,7 @@
         },
         {
             "id": "c03ef4cf-894a-5402-b6e4-19239189becb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8374f-abdf-495e-a11d-6dd7c30a21f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8374f-abdf-495e-a11d-6dd7c30a21f7.jpg?1",
             "name": "Wall of Fire",
             "text": "",
             "colours": [
@@ -15824,7 +15824,7 @@
         },
         {
             "id": "1c03f121-cac7-55f2-ab28-9ff54fe11bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826fd527-9356-4eec-8542-781116f23eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826fd527-9356-4eec-8542-781116f23eb7.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands. Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -15857,7 +15857,7 @@
         },
         {
             "id": "7f2ae2a4-5504-53af-a1e3-b27779ec4ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997a6901-31f5-48d3-aa8d-44b34d5098ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997a6901-31f5-48d3-aa8d-44b34d5098ee.jpg?1",
             "name": "Wildfire",
             "text": "",
             "colours": [
@@ -15890,7 +15890,7 @@
         },
         {
             "id": "7a1e162d-f39c-53c1-8ce1-1a72329e7a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb01c40-8fd7-483f-a0da-e1a3db6c93ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb01c40-8fd7-483f-a0da-e1a3db6c93ef.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "915816a7-ff64-5049-b4a8-bd3e6a8a31f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccffce-5ebd-4aaa-be05-1c6537d211f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccffce-5ebd-4aaa-be05-1c6537d211f4.jpg?1",
             "name": "Anaconda",
             "text": "",
             "colours": [
@@ -15960,7 +15960,7 @@
         },
         {
             "id": "134915fa-9ab7-5f0b-9c04-271fd4d91cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8a99-b01d-4d0a-bf1c-a3cf08fbc469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8a99-b01d-4d0a-bf1c-a3cf08fbc469.jpg?1",
             "name": "Ancient Silverback",
             "text": "oo\nG Regenerate Ancient Silverback.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "13b283f5-061f-5826-9b73-828dcde96ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ebbf7d-30b6-4d57-a168-3b35c54fa8db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ebbf7d-30b6-4d57-a168-3b35c54fa8db.jpg?1",
             "name": "Ancient Silverback",
             "text": "",
             "colours": [
@@ -16030,7 +16030,7 @@
         },
         {
             "id": "743de9bb-11f9-5211-9b76-18924808afb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2985857-fee5-42a6-9b5d-e157ada52a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2985857-fee5-42a6-9b5d-e157ada52a03.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -16065,7 +16065,7 @@
         },
         {
             "id": "d38c9b9e-89a3-57fe-9549-6daedc854ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7106d8-ec4f-4bc2-aa39-9a605b04cf88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7106d8-ec4f-4bc2-aa39-9a605b04cf88.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -16100,7 +16100,7 @@
         },
         {
             "id": "ff56448e-57aa-55a2-82c1-9d0205e19375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ee5083-078f-4e76-a172-8f2edf98aa80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ee5083-078f-4e76-a172-8f2edf98aa80.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchanted creature gets +1/+1 for each forest you control.",
             "colours": [
@@ -16135,7 +16135,7 @@
         },
         {
             "id": "251777ef-c571-5560-a89d-78642d19be91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205388c-dd0d-48c0-809f-420312e54cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205388c-dd0d-48c0-809f-420312e54cca.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -16170,7 +16170,7 @@
         },
         {
             "id": "70ea977b-bdb2-527a-88b2-7064bce56320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044785ad-0f05-4944-aab3-49236727078d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044785ad-0f05-4944-aab3-49236727078d.jpg?1",
             "name": "Bull Hippo",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)",
             "colours": [
@@ -16205,7 +16205,7 @@
         },
         {
             "id": "10d5d75a-2e6f-54b1-bee4-c58fee725ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f345c8-1c0f-4ad0-bb56-0caf2bbc158f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f345c8-1c0f-4ad0-bb56-0caf2bbc158f.jpg?1",
             "name": "Bull Hippo",
             "text": "",
             "colours": [
@@ -16240,7 +16240,7 @@
         },
         {
             "id": "c00dbb2c-fa7b-50b0-bd78-b71f39f7e448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6a2b31-2601-4fdf-afc9-cceccf1b3379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6a2b31-2601-4fdf-afc9-cceccf1b3379.jpg?1",
             "name": "Canopy Spider",
             "text": "Canopy Spider may block as though it had flying.",
             "colours": [
@@ -16275,7 +16275,7 @@
         },
         {
             "id": "631cfe0e-895d-5dc1-9cb0-bd3231d7ab99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ad0711-a36d-4a3f-bbc5-00c9d8f7c448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ad0711-a36d-4a3f-bbc5-00c9d8f7c448.jpg?1",
             "name": "Canopy Spider",
             "text": "",
             "colours": [
@@ -16310,7 +16310,7 @@
         },
         {
             "id": "7f0ead0b-e5fe-5b4f-8978-9d314afba002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fc8eca-7549-45b5-b3db-89a58d7d2a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fc8eca-7549-45b5-b3db-89a58d7d2a4a.jpg?1",
             "name": "Compost",
             "text": "Whenever a black card is put into an opponent's graveyard, you may draw a card.",
             "colours": [
@@ -16343,7 +16343,7 @@
         },
         {
             "id": "ec8d1c26-12b5-5e4e-9bd2-434c5e4a1d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedbed40-f29f-4d5a-adea-8e13680ae671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedbed40-f29f-4d5a-adea-8e13680ae671.jpg?1",
             "name": "Compost",
             "text": "",
             "colours": [
@@ -16376,7 +16376,7 @@
         },
         {
             "id": "f2f97d03-908c-5b74-91f1-dee514bd2245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b589a6-46d7-45a2-8352-dd04338192df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b589a6-46d7-45a2-8352-dd04338192df.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -16409,7 +16409,7 @@
         },
         {
             "id": "76d25cca-de55-5a90-a61a-94eba8118682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02cb174-60eb-47fa-8870-684629c084c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02cb174-60eb-47fa-8870-684629c084c4.jpg?1",
             "name": "Creeping Mold",
             "text": "",
             "colours": [
@@ -16442,7 +16442,7 @@
         },
         {
             "id": "693906aa-1fe1-5456-9735-f0c5566cd50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcbd047-7757-45ea-abe3-1064881ec90b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcbd047-7757-45ea-abe3-1064881ec90b.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -16475,7 +16475,7 @@
         },
         {
             "id": "eb628988-d161-5be3-886d-a10d395768c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb10101-cbd5-4d79-9161-f518f34add11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb10101-cbd5-4d79-9161-f518f34add11.jpg?1",
             "name": "Early Harvest",
             "text": "",
             "colours": [
@@ -16508,7 +16508,7 @@
         },
         {
             "id": "42df5e2c-ad51-5581-a478-a16deb022a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88ff5b-44df-40eb-b0bb-37936ae0d854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88ff5b-44df-40eb-b0bb-37936ae0d854.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG, oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -16545,7 +16545,7 @@
         },
         {
             "id": "9fc618ba-4cd8-592b-9aff-17daa0835e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1540e-58c4-4bec-abc8-e3e2760fcb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1540e-58c4-4bec-abc8-e3e2760fcb1f.jpg?1",
             "name": "Elder Druid",
             "text": "",
             "colours": [
@@ -16582,7 +16582,7 @@
         },
         {
             "id": "add53430-3029-5762-be8b-7604f9ada4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8411c9-4f6f-4301-ac36-386016a32852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8411c9-4f6f-4301-ac36-386016a32852.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -16618,7 +16618,7 @@
         },
         {
             "id": "05e11719-ad64-50d0-b1b8-060c474960b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66166a6c-3127-4f17-99fb-f469c3da92fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66166a6c-3127-4f17-99fb-f469c3da92fb.jpg?1",
             "name": "Elvish Archers",
             "text": "",
             "colours": [
@@ -16654,7 +16654,7 @@
         },
         {
             "id": "cef0836c-c4f0-5490-94c4-374ebcec6536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d00f31-d8fd-4272-87ba-6bcb65c609c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d00f31-d8fd-4272-87ba-6bcb65c609c6.jpg?1",
             "name": "Elvish Champion",
             "text": "All Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -16689,7 +16689,7 @@
         },
         {
             "id": "a01bab37-30c3-594d-9d9d-0eda0e3f9bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6812ca1e-10d0-43ae-a6fc-5ab801539ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6812ca1e-10d0-43ae-a6fc-5ab801539ec9.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -16724,7 +16724,7 @@
         },
         {
             "id": "094783d9-0cde-59e9-989a-79a9d2ef3cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bab3e7-f2c8-4025-8463-9e4de10091e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bab3e7-f2c8-4025-8463-9e4de10091e7.jpg?1",
             "name": "Elvish Lyrist",
             "text": "o\nG, oc\nT, Sacrifice Elvish Lyrist: Destroy target enchantment.",
             "colours": [
@@ -16759,7 +16759,7 @@
         },
         {
             "id": "b6ac39b0-152d-539f-85da-005c9a5c7482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364e2f8-df18-4710-a588-00f1f00f22da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364e2f8-df18-4710-a588-00f1f00f22da.jpg?1",
             "name": "Elvish Lyrist",
             "text": "",
             "colours": [
@@ -16794,7 +16794,7 @@
         },
         {
             "id": "fca07076-c3eb-58f3-b6e3-5ba132f8aef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89476260-19b1-495c-b23e-6f206483e84a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89476260-19b1-495c-b23e-6f206483e84a.jpg?1",
             "name": "Elvish Piper",
             "text": "o\nG, oc\nT: Put a creature card from your hand into play.",
             "colours": [
@@ -16830,7 +16830,7 @@
         },
         {
             "id": "a53cbcd1-1bfa-529b-83a5-2ad9517c25e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7335452-36cc-4d76-bde5-4ca8761dc94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7335452-36cc-4d76-bde5-4ca8761dc94d.jpg?1",
             "name": "Elvish Piper",
             "text": "",
             "colours": [
@@ -16866,7 +16866,7 @@
         },
         {
             "id": "b32f249e-0304-516c-a328-b35d06667557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e990d-726c-4b3b-84b4-9c15a5c4be8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e990d-726c-4b3b-84b4-9c15a5c4be8c.jpg?1",
             "name": "Familiar Ground",
             "text": "Each creature you control can't be blocked by more than one creature.",
             "colours": [
@@ -16899,7 +16899,7 @@
         },
         {
             "id": "c55f3795-7831-5a79-86d6-438bd455ae28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5be1074-fd40-46ba-b3bb-fb3207d2d41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5be1074-fd40-46ba-b3bb-fb3207d2d41b.jpg?1",
             "name": "Familiar Ground",
             "text": "",
             "colours": [
@@ -16932,7 +16932,7 @@
         },
         {
             "id": "da71a626-2b71-5a88-bf76-62f74e4450bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed8a169-1f32-486c-9dfb-aa13fcf3c984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed8a169-1f32-486c-9dfb-aa13fcf3c984.jpg?1",
             "name": "Femeref Archers",
             "text": "oc\nT: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -16968,7 +16968,7 @@
         },
         {
             "id": "3053a8eb-9f0f-5aba-bafa-2f6e3509ef3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1096b-96b5-47c3-93ad-f36bdceb326e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1096b-96b5-47c3-93ad-f36bdceb326e.jpg?1",
             "name": "Femeref Archers",
             "text": "",
             "colours": [
@@ -17004,7 +17004,7 @@
         },
         {
             "id": "36330aaa-52d0-5452-9f81-8db0ece27bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6213c038-d231-4e61-b0ec-d1e39637e5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6213c038-d231-4e61-b0ec-d1e39637e5c3.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -17037,7 +17037,7 @@
         },
         {
             "id": "f510c9ba-f433-54e3-86fc-98c4d8bcf036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492699b8-0d03-474b-9b0f-569440387fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492699b8-0d03-474b-9b0f-569440387fb6.jpg?1",
             "name": "Fog",
             "text": "",
             "colours": [
@@ -17070,7 +17070,7 @@
         },
         {
             "id": "7d36bde4-b426-5230-ac63-fbeeba3bfb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1c3e8c-da95-4d27-9c60-5a2cdcff0b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1c3e8c-da95-4d27-9c60-5a2cdcff0b71.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool.",
             "colours": [
@@ -17106,7 +17106,7 @@
         },
         {
             "id": "f5fd39fe-298e-53c3-a2eb-1fea187b9774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d03d69-2f6f-4c72-93b5-10bb8a278e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d03d69-2f6f-4c72-93b5-10bb8a278e24.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "",
             "colours": [
@@ -17142,7 +17142,7 @@
         },
         {
             "id": "46fbfe02-5a2d-5cc6-97c5-65f0f8b098fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0a61c9-8b14-4255-8453-4b74d90fe0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0a61c9-8b14-4255-8453-4b74d90fe0a3.jpg?1",
             "name": "Gang of Elk",
             "text": "Whenever Gang of Elk becomes blocked, it gets +2/+2 until end of turn for each creature blocking it.",
             "colours": [
@@ -17178,7 +17178,7 @@
         },
         {
             "id": "19278566-f454-596a-a493-18bdb88a0a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91350320-6a51-42f0-b644-bc5ce2a80505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91350320-6a51-42f0-b644-bc5ce2a80505.jpg?1",
             "name": "Gang of Elk",
             "text": "",
             "colours": [
@@ -17214,7 +17214,7 @@
         },
         {
             "id": "a85c380d-cf20-5225-ac91-7ee21ed321d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade9b45-a1f5-4680-8d26-d2ae5879b1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade9b45-a1f5-4680-8d26-d2ae5879b1b6.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -17247,7 +17247,7 @@
         },
         {
             "id": "9f1fb3f9-baa4-5321-acfb-c676426898a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376a82b-ca41-4a75-9d8c-396477b2f340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376a82b-ca41-4a75-9d8c-396477b2f340.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -17280,7 +17280,7 @@
         },
         {
             "id": "e7b009e2-871a-5d15-be8f-75d0df78b969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bcde1e-d379-4b0c-8e59-01fbb3217f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bcde1e-d379-4b0c-8e59-01fbb3217f04.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider may block as though it had flying.",
             "colours": [
@@ -17315,7 +17315,7 @@
         },
         {
             "id": "70814eb2-acac-5f89-863a-255dfec0cf34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ad85b-162e-4dfb-99e5-97ef038cc69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ad85b-162e-4dfb-99e5-97ef038cc69d.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -17350,7 +17350,7 @@
         },
         {
             "id": "46f50f05-1fd8-546e-b41f-080d20dd0eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76185a-519f-4bec-b399-989ebddbab71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76185a-519f-4bec-b399-989ebddbab71.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1oo\nG Regenerate Gorilla Chieftain.",
             "colours": [
@@ -17385,7 +17385,7 @@
         },
         {
             "id": "1ba6a718-88be-5299-ab77-e7ab273c20b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb762ef0-59e9-4c64-b3cb-0f2596059307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb762ef0-59e9-4c64-b3cb-0f2596059307.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "",
             "colours": [
@@ -17420,7 +17420,7 @@
         },
         {
             "id": "8d4a7ebe-9953-59b0-93d2-b50e060bac1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8dadf2-d31a-4b24-a9a7-f7f511ba2867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8dadf2-d31a-4b24-a9a7-f7f511ba2867.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17455,7 +17455,7 @@
         },
         {
             "id": "97f28506-d212-5cff-ba87-825addbfd8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e3de06-572e-48c5-888b-2dac7fa9d0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e3de06-572e-48c5-888b-2dac7fa9d0d0.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17490,7 +17490,7 @@
         },
         {
             "id": "1a892e58-6837-5358-b2a9-9d7c166b6a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0526077-79b6-40ae-8178-8b97c33a53fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0526077-79b6-40ae-8178-8b97c33a53fb.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -17523,7 +17523,7 @@
         },
         {
             "id": "8d35c130-5727-5833-a53f-22952288c1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96005f68-1712-4818-ad31-a0e629c54d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96005f68-1712-4818-ad31-a0e629c54d36.jpg?1",
             "name": "Hurricane",
             "text": "",
             "colours": [
@@ -17556,7 +17556,7 @@
         },
         {
             "id": "bfc5cb0e-8be5-5194-a0cf-0e46391fd19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8a8cfd-baef-4198-b1f3-4926139588b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8a8cfd-baef-4198-b1f3-4926139588b2.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "83a482a2-16e4-52e0-a03a-bf1dd50e7987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fca5b76-2e0b-4557-91c6-283000d17849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fca5b76-2e0b-4557-91c6-283000d17849.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -17628,7 +17628,7 @@
         },
         {
             "id": "c492ac35-29da-521c-81a7-5b897d7c29ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f885c7-4947-4041-ab82-b5e8dc167f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f885c7-4947-4041-ab82-b5e8dc167f0d.jpg?1",
             "name": "Lone Wolf",
             "text": "You may have Lone Wolf deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -17663,7 +17663,7 @@
         },
         {
             "id": "8e6d15d8-947d-5439-b9d1-bc87e90e62b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afae9668-4131-4cf7-acf0-6e5684165896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afae9668-4131-4cf7-acf0-6e5684165896.jpg?1",
             "name": "Lone Wolf",
             "text": "",
             "colours": [
@@ -17698,7 +17698,7 @@
         },
         {
             "id": "ad66a906-0329-539e-8e27-b8b16a5666f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ebfea3-e671-4c75-b0a2-c310d07351a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ebfea3-e671-4c75-b0a2-c310d07351a6.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -17733,7 +17733,7 @@
         },
         {
             "id": "5381d4c8-57fb-5dff-b6bd-4eada2ce7aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9840d08e-cc99-4fe5-ad60-43833bf7d9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9840d08e-cc99-4fe5-ad60-43833bf7d9eb.jpg?1",
             "name": "Lure",
             "text": "",
             "colours": [
@@ -17768,7 +17768,7 @@
         },
         {
             "id": "0dc0c1b1-d8b1-5551-ae29-249bab7ed240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c3853c-8b41-4bce-b4e0-3824fc5888c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c3853c-8b41-4bce-b4e0-3824fc5888c4.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -17803,7 +17803,7 @@
         },
         {
             "id": "98f363d6-bd98-5600-a9eb-2ab911ad3e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc6b4e-a4a0-4658-ad96-1c70d0dd1297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc6b4e-a4a0-4658-ad96-1c70d0dd1297.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -17838,7 +17838,7 @@
         },
         {
             "id": "1abac968-f1b6-5a34-bafb-59cc85a47aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1bab68d-da36-43b9-9778-d385d81a0bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1bab68d-da36-43b9-9778-d385d81a0bc5.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -17871,7 +17871,7 @@
         },
         {
             "id": "ae89b641-ed0e-5cd5-ac12-ae28fc1e6d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a9e47-57a1-45f8-978c-48ef90703832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a9e47-57a1-45f8-978c-48ef90703832.jpg?1",
             "name": "Might of Oaks",
             "text": "",
             "colours": [
@@ -17904,7 +17904,7 @@
         },
         {
             "id": "ffe64fe7-f30e-5550-9ae0-40b271c3dfcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb56633e-692c-41bc-9253-ebd1528f4e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb56633e-692c-41bc-9253-ebd1528f4e99.jpg?1",
             "name": "Monstrous Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -17937,7 +17937,7 @@
         },
         {
             "id": "006a829f-5051-5a88-b2dd-3f809626a107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d911589-f2e8-4d9a-b339-5a5597a783fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d911589-f2e8-4d9a-b339-5a5597a783fd.jpg?1",
             "name": "Monstrous Growth",
             "text": "",
             "colours": [
@@ -17970,7 +17970,7 @@
         },
         {
             "id": "70656221-c651-557b-b87b-c3120e5b32bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287f9f55-829d-4b29-b1d2-34d20d23b3d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287f9f55-829d-4b29-b1d2-34d20d23b3d5.jpg?1",
             "name": "Nature's Resurgence",
             "text": "Each player draws a card for each creature card in his or her graveyard.",
             "colours": [
@@ -18003,7 +18003,7 @@
         },
         {
             "id": "35386ec3-4c45-5a1d-b607-a3aea70f491d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf5760-5da1-4c17-859e-baddd0ec62ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf5760-5da1-4c17-859e-baddd0ec62ae.jpg?1",
             "name": "Nature's Resurgence",
             "text": "",
             "colours": [
@@ -18036,7 +18036,7 @@
         },
         {
             "id": "07cc301f-1ecc-51d7-a8ad-77c52af9e19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c9b948-63f9-458d-82ae-69ebe2ac9fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c9b948-63f9-458d-82ae-69ebe2ac9fe0.jpg?1",
             "name": "Nature's Revolt",
             "text": "All lands are 2/2 creatures that are still lands.",
             "colours": [
@@ -18069,7 +18069,7 @@
         },
         {
             "id": "185a3c56-6fc7-5bf4-a2fe-ced9f5dde041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3f2a56-ec54-4983-9f09-aea67becec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3f2a56-ec54-4983-9f09-aea67becec68.jpg?1",
             "name": "Nature's Revolt",
             "text": "",
             "colours": [
@@ -18102,7 +18102,7 @@
         },
         {
             "id": "211384a5-77ef-547b-8cf3-f719ca8f3439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c3274b-3eb0-450a-88bf-fb378e6cf94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c3274b-3eb0-450a-88bf-fb378e6cf94a.jpg?1",
             "name": "Pride of Lions",
             "text": "You may have Pride of Lions deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -18137,7 +18137,7 @@
         },
         {
             "id": "a29ac9e6-8290-5e1d-a54c-d64d8aeddc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1673b038-97b6-4139-8468-9cbbd01dd239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1673b038-97b6-4139-8468-9cbbd01dd239.jpg?1",
             "name": "Pride of Lions",
             "text": "",
             "colours": [
@@ -18172,7 +18172,7 @@
         },
         {
             "id": "b528646f-aa04-5f1e-9936-91012976bf69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305376d-fcfb-48a1-947f-a9eec0dbc610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305376d-fcfb-48a1-947f-a9eec0dbc610.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -18205,7 +18205,7 @@
         },
         {
             "id": "9093e6ac-e1c4-5781-a3b7-9c7285b18951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb685db-bb38-4b78-ae1e-80817c852096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb685db-bb38-4b78-ae1e-80817c852096.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -18238,7 +18238,7 @@
         },
         {
             "id": "6b636201-56ab-5832-b073-e44b32150af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045e9ca4-ece8-49c2-b022-fb61f4b8b635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045e9ca4-ece8-49c2-b022-fb61f4b8b635.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -18271,7 +18271,7 @@
         },
         {
             "id": "cff32468-3aea-5788-abb3-948731c2250b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160e5d9e-b390-4a77-9435-f6cdc95ca728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160e5d9e-b390-4a77-9435-f6cdc95ca728.jpg?1",
             "name": "Reclaim",
             "text": "",
             "colours": [
@@ -18304,7 +18304,7 @@
         },
         {
             "id": "8d390207-46f9-5e85-bdc7-a47672bde77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc6d29d-2915-418d-856f-13b05430dfda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc6d29d-2915-418d-856f-13b05430dfda.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -18339,7 +18339,7 @@
         },
         {
             "id": "9301f4f6-7188-540b-9421-69327931ed97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb172a6d-0f4f-42bf-8add-bec0e00e8a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb172a6d-0f4f-42bf-8add-bec0e00e8a66.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -18374,7 +18374,7 @@
         },
         {
             "id": "ba1ab738-2284-59a8-9274-77f239ad415d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9ea671-f3e9-4e17-b98a-51fac48f875e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9ea671-f3e9-4e17-b98a-51fac48f875e.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -18409,7 +18409,7 @@
         },
         {
             "id": "f6ac5887-01ad-5f7d-8fcf-85d062baea34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fe41ad-722f-4330-b1ee-c6ca3f81ce86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fe41ad-722f-4330-b1ee-c6ca3f81ce86.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -18444,7 +18444,7 @@
         },
         {
             "id": "62e51ffb-4258-581c-aa3a-26b3ca40a8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc536ff-3e12-4e1b-b96f-b0c32dcb6734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc536ff-3e12-4e1b-b96f-b0c32dcb6734.jpg?1",
             "name": "Rowen",
             "text": "Reveal the first card you draw each turn. Whenever you reveal a basic land card this way, draw a card.",
             "colours": [
@@ -18477,7 +18477,7 @@
         },
         {
             "id": "8e83d7b3-81f6-5e39-943d-4fc8687b17f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7e6a58-eda0-4224-b517-ad6dfb721c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7e6a58-eda0-4224-b517-ad6dfb721c88.jpg?1",
             "name": "Rowen",
             "text": "",
             "colours": [
@@ -18510,7 +18510,7 @@
         },
         {
             "id": "c0eae17b-8048-5f55-a167-27c51538d683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff2dd57-9d8c-44ec-9705-70ed02bf0799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff2dd57-9d8c-44ec-9705-70ed02bf0799.jpg?1",
             "name": "Scavenger Folk",
             "text": "o\nG, oc\nT, Sacrifice Scavenger Folk: Destroy target artifact.",
             "colours": [
@@ -18545,7 +18545,7 @@
         },
         {
             "id": "611c1d3b-f140-58f4-a4b9-2f8a307e2d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9637b1e-3a78-4946-afd9-29d0d90df282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9637b1e-3a78-4946-afd9-29d0d90df282.jpg?1",
             "name": "Scavenger Folk",
             "text": "",
             "colours": [
@@ -18580,7 +18580,7 @@
         },
         {
             "id": "dbdaa6ae-71cc-5ea7-b8ed-e879074c38d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20175-8bfa-417a-912b-d6d472f091ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20175-8bfa-417a-912b-d6d472f091ab.jpg?1",
             "name": "Seeker of Skybreak",
             "text": "oc\nT: Untap target creature.",
             "colours": [
@@ -18615,7 +18615,7 @@
         },
         {
             "id": "62b88556-dd2b-5010-b585-ff6f0b687d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2c491a-1f86-4e44-8dc3-b8ba65f4017c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2c491a-1f86-4e44-8dc3-b8ba65f4017c.jpg?1",
             "name": "Seeker of Skybreak",
             "text": "",
             "colours": [
@@ -18650,7 +18650,7 @@
         },
         {
             "id": "83171929-75d0-57b7-9228-e5290bbd8b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90e8ff87-22e8-4c04-84bc-f0ea2c12a86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90e8ff87-22e8-4c04-84bc-f0ea2c12a86c.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -18686,7 +18686,7 @@
         },
         {
             "id": "bca7ca06-c224-5cd1-a209-f2571db6ecd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19f7690-87bf-4259-adc1-7e69cc3081a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19f7690-87bf-4259-adc1-7e69cc3081a9.jpg?1",
             "name": "Shanodin Dryads",
             "text": "",
             "colours": [
@@ -18722,7 +18722,7 @@
         },
         {
             "id": "66d67d15-756e-531c-a89c-5e48dc2a98bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6cb158-f66f-429b-ac73-bfea87f51def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6cb158-f66f-429b-ac73-bfea87f51def.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -18757,7 +18757,7 @@
         },
         {
             "id": "d83f5bbc-2121-5c5b-bc95-0b64505f0fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54a9970-cffa-43a4-8eeb-4330a3ea2e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54a9970-cffa-43a4-8eeb-4330a3ea2e82.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -18792,7 +18792,7 @@
         },
         {
             "id": "d8120d91-96cb-5dd3-b5bc-5f7f1217e69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46460e5f-2756-486b-99a6-c3a9a209bfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46460e5f-2756-486b-99a6-c3a9a209bfaa.jpg?1",
             "name": "Squall",
             "text": "Squall deals 2 damage to each creature with flying.",
             "colours": [
@@ -18825,7 +18825,7 @@
         },
         {
             "id": "ea03d98b-8ded-52b2-aced-9f68c4d1617b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e4e64-adf5-480c-b47b-c8eb03cb74c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e4e64-adf5-480c-b47b-c8eb03cb74c4.jpg?1",
             "name": "Squall",
             "text": "",
             "colours": [
@@ -18858,7 +18858,7 @@
         },
         {
             "id": "4aaa5731-0240-54d5-887e-4ed1d47647b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4405ab25-c001-4da8-ac72-2afcb01db200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4405ab25-c001-4da8-ac72-2afcb01db200.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -18891,7 +18891,7 @@
         },
         {
             "id": "8ce4b1e9-2f84-52aa-8ab8-78d0e938f3eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce87747f-4565-43f2-b966-8bef41ebbe03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce87747f-4565-43f2-b966-8bef41ebbe03.jpg?1",
             "name": "Stream of Life",
             "text": "",
             "colours": [
@@ -18924,7 +18924,7 @@
         },
         {
             "id": "a33ecd1c-8948-58c0-bb58-420509813a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bea52-3db1-4b61-8418-77ace9cd70b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bea52-3db1-4b61-8418-77ace9cd70b5.jpg?1",
             "name": "Thorn Elemental",
             "text": "You may have Thorn Elemental deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -18959,7 +18959,7 @@
         },
         {
             "id": "bf0c2b85-2e3d-5e12-80bb-c10a552feb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd239e3-dbe5-4a30-973d-9707de425a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd239e3-dbe5-4a30-973d-9707de425a33.jpg?1",
             "name": "Thorn Elemental",
             "text": "",
             "colours": [
@@ -18994,7 +18994,7 @@
         },
         {
             "id": "2feb18e3-3b85-55aa-b728-fff75a3a89bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e214df-93a2-4d21-8818-cc00bff1b318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e214df-93a2-4d21-8818-cc00bff1b318.jpg?1",
             "name": "Thoughtleech",
             "text": "Whenever an island an opponent controls becomes tapped, you may gain 1 life.",
             "colours": [
@@ -19027,7 +19027,7 @@
         },
         {
             "id": "4b3d9c80-3b6f-5b21-ac3e-45ca714f2c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f617305-8043-4576-bc79-67303b91bb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f617305-8043-4576-bc79-67303b91bb69.jpg?1",
             "name": "Thoughtleech",
             "text": "",
             "colours": [
@@ -19060,7 +19060,7 @@
         },
         {
             "id": "12ef7168-4a20-51be-bcba-a7953b26ad38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7c1774-908f-43ab-b589-e46606267381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7c1774-908f-43ab-b589-e46606267381.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19095,7 +19095,7 @@
         },
         {
             "id": "61161199-7a53-5449-837e-95d9f232a8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05381dc1-50e1-4ac4-8f35-46d0b2d0b42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05381dc1-50e1-4ac4-8f35-46d0b2d0b42d.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19130,7 +19130,7 @@
         },
         {
             "id": "a74377fc-f4b6-5a5b-b69f-188371848125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b3f289-7999-4e47-82c6-a7c96293d4f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b3f289-7999-4e47-82c6-a7c96293d4f8.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -19163,7 +19163,7 @@
         },
         {
             "id": "28816986-95d9-584c-b7c4-9a808c8ea037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf477ae-fc28-4c50-a41c-be6bfab489e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf477ae-fc28-4c50-a41c-be6bfab489e4.jpg?1",
             "name": "Tranquility",
             "text": "",
             "colours": [
@@ -19196,7 +19196,7 @@
         },
         {
             "id": "00f2d0d5-3571-5fd9-977d-c7d9f9d5f531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c275bdc-e960-4b6f-a8d3-b662739113c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c275bdc-e960-4b6f-a8d3-b662739113c1.jpg?1",
             "name": "Treefolk Seedlings",
             "text": "Treefolk Seedlings's toughness is equal to the number of forests you control.",
             "colours": [
@@ -19231,7 +19231,7 @@
         },
         {
             "id": "481b53b4-37ef-5cfe-b23e-6670c849ce18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf9a759-13aa-4a8e-bb53-3706c8c69bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf9a759-13aa-4a8e-bb53-3706c8c69bd0.jpg?1",
             "name": "Treefolk Seedlings",
             "text": "",
             "colours": [
@@ -19266,7 +19266,7 @@
         },
         {
             "id": "a9cd9d53-c299-5078-9c92-ff6407f1322c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700bb560-5a4a-4422-9158-1c2edad1913f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700bb560-5a4a-4422-9158-1c2edad1913f.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "Uktabi Wildcats's power and toughness are each equal to the number of forests you control.\no\nG, Sacrifice a forest: Regenerate Uktabi Wildcats.",
             "colours": [
@@ -19301,7 +19301,7 @@
         },
         {
             "id": "2df7635b-5a8f-5905-b117-eead5aa232bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23d1a8c-01cb-4dd3-8562-c3ce7bc88d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23d1a8c-01cb-4dd3-8562-c3ce7bc88d77.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "",
             "colours": [
@@ -19336,7 +19336,7 @@
         },
         {
             "id": "e844dcf5-a079-53ec-b776-c31bfab85cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba496182-b249-40fa-8fdf-9823d521fcd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba496182-b249-40fa-8fdf-9823d521fcd9.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a basic land card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -19369,7 +19369,7 @@
         },
         {
             "id": "a8f505c7-fc89-5302-8911-0e2c84d5a089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc908d9-2a08-4465-81cd-11199685c660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc908d9-2a08-4465-81cd-11199685c660.jpg?1",
             "name": "Untamed Wilds",
             "text": "",
             "colours": [
@@ -19402,7 +19402,7 @@
         },
         {
             "id": "aa3d11f3-ca06-5320-aaa5-b0778cbed821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f99fe-8d5f-4efe-af86-72031dfe562a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f99fe-8d5f-4efe-af86-72031dfe562a.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -19438,7 +19438,7 @@
         },
         {
             "id": "8deba6d1-08b6-56d6-879c-f613b7888daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b87a7f-41d0-4dd7-b479-f6bcccda54be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b87a7f-41d0-4dd7-b479-f6bcccda54be.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -19474,7 +19474,7 @@
         },
         {
             "id": "cbc551f5-8e1c-556a-ba13-0e9acb01c584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0368c8-8021-40c3-b42d-7320d956a84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0368c8-8021-40c3-b42d-7320d956a84f.jpg?1",
             "name": "Vernal Bloom",
             "text": "Whenever a forest is tapped for mana, its controller adds o\nG to his or her mana pool.",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "a6fbb0fc-fa13-5584-96a1-c71e4a4f0596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79ed17b-2a71-4146-8dd7-75faefdfa4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79ed17b-2a71-4146-8dd7-75faefdfa4fa.jpg?1",
             "name": "Vernal Bloom",
             "text": "",
             "colours": [
@@ -19540,7 +19540,7 @@
         },
         {
             "id": "fd54ad77-dcc9-5eb3-aa8d-51d5b0e63389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515daaba-c063-41d5-9539-25b8c8cb639c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515daaba-c063-41d5-9539-25b8c8cb639c.jpg?1",
             "name": "Wild Growth",
             "text": "Whenever enchanted land is tapped for mana, its controller adds o\nG to his or her mana pool.",
             "colours": [
@@ -19575,7 +19575,7 @@
         },
         {
             "id": "5800b2e8-35da-52f7-b11c-2b6db7500cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a02887-beb9-454b-8592-f551f48cd93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a02887-beb9-454b-8592-f551f48cd93c.jpg?1",
             "name": "Wild Growth",
             "text": "",
             "colours": [
@@ -19610,7 +19610,7 @@
         },
         {
             "id": "ef5aa013-a448-5cd8-bbed-c0f431a48e2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37ba325-5a14-473b-9def-6a4660a50d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37ba325-5a14-473b-9def-6a4660a50d7a.jpg?1",
             "name": "Wing Snare",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -19643,7 +19643,7 @@
         },
         {
             "id": "bf047b14-7990-5798-aaf3-522b826c27b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6a0916-c077-427f-983d-c595e8256507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6a0916-c077-427f-983d-c595e8256507.jpg?1",
             "name": "Wing Snare",
             "text": "",
             "colours": [
@@ -19676,7 +19676,7 @@
         },
         {
             "id": "3c90bd84-3653-5fad-b27a-1a505b93a8d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263feecf-a657-4892-a2bb-cd7080d283c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263feecf-a657-4892-a2bb-cd7080d283c2.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a forest card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -19712,7 +19712,7 @@
         },
         {
             "id": "f7906562-a439-5f6d-a2b3-a518781e7e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38082344-f739-495d-947a-74e247b17433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38082344-f739-495d-947a-74e247b17433.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -19748,7 +19748,7 @@
         },
         {
             "id": "aa6624a3-5c03-59e9-bb2a-1243f0cdd8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f45f1-9ed1-4ef2-8c2b-bab513d6a721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f45f1-9ed1-4ef2-8c2b-bab513d6a721.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -19784,7 +19784,7 @@
         },
         {
             "id": "201b7a07-31dc-5929-a8c6-922bcd099fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ec6cdd-11ba-4acd-9bbc-87f01f703642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ec6cdd-11ba-4acd-9bbc-87f01f703642.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "",
             "colours": [
@@ -19820,7 +19820,7 @@
         },
         {
             "id": "b7d61955-ec10-57d7-a5db-3d8df8229d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed511375-e445-4d81-818d-92a793d7deee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed511375-e445-4d81-818d-92a793d7deee.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -19849,7 +19849,7 @@
         },
         {
             "id": "02f98c6a-227a-5e52-bf8e-a6a8ce408e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75da20cc-2737-4a03-a75c-ed4f7b63cf95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75da20cc-2737-4a03-a75c-ed4f7b63cf95.jpg?1",
             "name": "Aladdin's Ring",
             "text": "",
             "colours": [],
@@ -19878,7 +19878,7 @@
         },
         {
             "id": "3082bf43-6ab0-5a90-ab4f-cd7168e33705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c3b59-bd04-4376-aec1-a77404c6072d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c3b59-bd04-4376-aec1-a77404c6072d.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden's power and toughness are each equal to the number of creatures in play.",
             "colours": [],
@@ -19910,7 +19910,7 @@
         },
         {
             "id": "f5fdc667-1877-5fde-ad47-61b59543623d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f92d6f-1d3a-495f-841d-75c6a046e27c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f92d6f-1d3a-495f-841d-75c6a046e27c.jpg?1",
             "name": "Beast of Burden",
             "text": "",
             "colours": [],
@@ -19942,7 +19942,7 @@
         },
         {
             "id": "009ef7b7-642c-55d1-a7ac-d632228708db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769b55a-a0a1-4b6f-8c80-669385a34425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769b55a-a0a1-4b6f-8c80-669385a34425.jpg?1",
             "name": "Caltrops",
             "text": "Whenever a creature attacks, Caltrops deals 1 damage to it.",
             "colours": [],
@@ -19971,7 +19971,7 @@
         },
         {
             "id": "e4e78644-42fe-5b64-b3a0-18072ed0eb51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf0d1da-7c16-4a9a-a71e-4805bd0c0995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf0d1da-7c16-4a9a-a71e-4805bd0c0995.jpg?1",
             "name": "Caltrops",
             "text": "",
             "colours": [],
@@ -20000,7 +20000,7 @@
         },
         {
             "id": "0f73a0c5-b79d-592f-9c52-7d984e70ae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c1d1d-e6e0-47fe-b642-b1ff0201bbf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c1d1d-e6e0-47fe-b642-b1ff0201bbf9.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond comes into play tapped.\noc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -20033,7 +20033,7 @@
         },
         {
             "id": "7e423224-c4cc-584b-a870-220de5e33bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaab01ef-f14b-4f42-ab51-b1537fa642d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaab01ef-f14b-4f42-ab51-b1537fa642d1.jpg?1",
             "name": "Charcoal Diamond",
             "text": "",
             "colours": [],
@@ -20066,7 +20066,7 @@
         },
         {
             "id": "cf36c43e-97b5-575a-8ec2-a1d4f913671d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52ecee5-ad2d-4f52-9845-f682119ee120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52ecee5-ad2d-4f52-9845-f682119ee120.jpg?1",
             "name": "Charcoal Diamond",
             "text": "",
             "colours": [],
@@ -20099,7 +20099,7 @@
         },
         {
             "id": "8fbdf541-e8b8-5a1b-9778-24135772790d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0ed0c-7092-4c5e-9b06-66ab4de157c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0ed0c-7092-4c5e-9b06-66ab4de157c6.jpg?1",
             "name": "Charcoal Diamond",
             "text": "",
             "colours": [],
@@ -20132,7 +20132,7 @@
         },
         {
             "id": "22aa5ec4-0cde-5f2b-b6ca-beb8b983c4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642852b-8736-4fce-9f91-37594cbc3f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642852b-8736-4fce-9f91-37594cbc3f71.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if there are three Goblins in play, each gets +2/+2.)",
             "colours": [],
@@ -20161,7 +20161,7 @@
         },
         {
             "id": "03e0ca2f-ee2c-54f8-b951-c9d2d47e68ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38ecdea-c269-4f0a-b297-e16a22410802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38ecdea-c269-4f0a-b297-e16a22410802.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -20190,7 +20190,7 @@
         },
         {
             "id": "891f9bdd-9edf-50ad-98af-a8647a8b4402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2017cded-4157-4ccb-80f0-e298aa89d17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2017cded-4157-4ccb-80f0-e298aa89d17d.jpg?1",
             "name": "Crystal Rod",
             "text": "Whenever a player plays a blue spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -20219,7 +20219,7 @@
         },
         {
             "id": "bb7b0cc9-b6b7-5c04-a738-784efb3cbdb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fab1f2d-445e-4feb-93de-c59e2655fa1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fab1f2d-445e-4feb-93de-c59e2655fa1d.jpg?1",
             "name": "Crystal Rod",
             "text": "",
             "colours": [],
@@ -20248,7 +20248,7 @@
         },
         {
             "id": "dd8e0b33-7629-5a17-a256-115c8b5caaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8534792b-96a7-45a6-b854-81066a2e5d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8534792b-96a7-45a6-b854-81066a2e5d90.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into a graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -20277,7 +20277,7 @@
         },
         {
             "id": "372c99bb-a258-5668-9ff2-164dfc0749ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812171e0-bc15-4eb3-924a-1c779414469b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812171e0-bc15-4eb3-924a-1c779414469b.jpg?1",
             "name": "Dingus Egg",
             "text": "",
             "colours": [],
@@ -20306,7 +20306,7 @@
         },
         {
             "id": "87ff3c6b-86ec-518e-8506-95b6de5f4344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94d6842-0b35-4493-8800-cf2b2138d656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94d6842-0b35-4493-8800-cf2b2138d656.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player discards a card from his or her hand. Play this ability only during your turn.",
             "colours": [],
@@ -20335,7 +20335,7 @@
         },
         {
             "id": "3b1163cf-cfe1-515a-bc6d-f558a82a7daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d47309-9595-4b19-bd9c-4973b87651eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d47309-9595-4b19-bd9c-4973b87651eb.jpg?1",
             "name": "Disrupting Scepter",
             "text": "",
             "colours": [],
@@ -20364,7 +20364,7 @@
         },
         {
             "id": "8cb61508-d315-5f8c-b862-ca2ffec20dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d4fb56-7f63-4087-9ab3-a0df66655886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d4fb56-7f63-4087-9ab3-a0df66655886.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -20393,7 +20393,7 @@
         },
         {
             "id": "bb57bd6c-cdb5-5e07-a5af-1653c8bfda31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0752f333-002c-4c77-bb96-a7bd2dd4ff5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0752f333-002c-4c77-bb96-a7bd2dd4ff5e.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "",
             "colours": [],
@@ -20422,7 +20422,7 @@
         },
         {
             "id": "c8dd2525-a5ca-5d8c-aa7f-4ae89783ab9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188b3863-fa7d-4fbb-b061-97580d394017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188b3863-fa7d-4fbb-b061-97580d394017.jpg?1",
             "name": "Feroz's Ban",
             "text": "Creature spells cost o2 more to play.",
             "colours": [],
@@ -20451,7 +20451,7 @@
         },
         {
             "id": "85fd7181-759c-55a4-8f34-a6c189828200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f6dea-3554-4649-966c-5f33229132d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f6dea-3554-4649-966c-5f33229132d4.jpg?1",
             "name": "Feroz's Ban",
             "text": "",
             "colours": [],
@@ -20480,7 +20480,7 @@
         },
         {
             "id": "ff71eca6-2114-5389-beeb-76a9fcee28f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a89ca2b-0cc9-421e-8dc0-1105879380a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a89ca2b-0cc9-421e-8dc0-1105879380a0.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond comes into play tapped.\noc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -20511,7 +20511,7 @@
         },
         {
             "id": "9e725ed7-72c1-535f-823c-867bbf2d3da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054ae635-1cc5-4367-9dd9-95acf8bfd937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054ae635-1cc5-4367-9dd9-95acf8bfd937.jpg?1",
             "name": "Fire Diamond",
             "text": "",
             "colours": [],
@@ -20542,7 +20542,7 @@
         },
         {
             "id": "0565de1f-31b9-58ee-b5df-abf1efcdff5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edcc350-ab84-4aff-a9f0-2cc05c7c43bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edcc350-ab84-4aff-a9f0-2cc05c7c43bb.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn.",
             "colours": [],
@@ -20571,7 +20571,7 @@
         },
         {
             "id": "dbead868-1819-5945-b008-4dc693992ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014b7a72-135e-4ed0-9b1c-0b836aaa260f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014b7a72-135e-4ed0-9b1c-0b836aaa260f.jpg?1",
             "name": "Flying Carpet",
             "text": "",
             "colours": [],
@@ -20600,7 +20600,7 @@
         },
         {
             "id": "174171b2-1833-536d-ac8f-27cce1edc17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff78a37-c321-4f02-bd10-e73823b954cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff78a37-c321-4f02-bd10-e73823b954cf.jpg?1",
             "name": "Grafted Skullcap",
             "text": "At the beginning of your draw step, draw a card.\nAt the end of your turn, discard your hand.",
             "colours": [],
@@ -20629,7 +20629,7 @@
         },
         {
             "id": "ed41cbf7-0aa6-525f-95b3-7ae91faa0b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac035e-06dc-4b37-9b84-26ff0d671564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac035e-06dc-4b37-9b84-26ff0d671564.jpg?1",
             "name": "Grafted Skullcap",
             "text": "",
             "colours": [],
@@ -20658,7 +20658,7 @@
         },
         {
             "id": "e589d63c-8cdf-5946-a9e5-806c6573a591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d63d66-5e59-4302-8b74-db1aa67f50c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d63d66-5e59-4302-8b74-db1aa67f50c5.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "oc\nT: Grapeshot Catapult deals 1 damage to target creature with flying.",
             "colours": [],
@@ -20690,7 +20690,7 @@
         },
         {
             "id": "967a5535-cbf8-5ee6-9c4f-fe431b5cdc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0067413-338a-4a24-afe2-010a9915e73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0067413-338a-4a24-afe2-010a9915e73e.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "",
             "colours": [],
@@ -20722,7 +20722,7 @@
         },
         {
             "id": "e5c90bd6-5681-55c2-9064-92c014d47b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd270d3-da58-4195-80f4-ade6ae32d092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd270d3-da58-4195-80f4-ade6ae32d092.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -20751,7 +20751,7 @@
         },
         {
             "id": "aec010c6-09b5-54ea-af53-46490864c7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d720e-68f9-464a-8b11-0f243f184ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d720e-68f9-464a-8b11-0f243f184ccf.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -20780,7 +20780,7 @@
         },
         {
             "id": "f1a80364-87b2-590e-8406-f1b215974129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da72ad2-1cdd-4505-b0f8-f036ac684776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da72ad2-1cdd-4505-b0f8-f036ac684776.jpg?1",
             "name": "Iron Star",
             "text": "Whenever a player plays a red spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -20809,7 +20809,7 @@
         },
         {
             "id": "a441454e-d26d-5376-a4d1-2e4239eaa254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c1995f-a22e-4b3d-9d3e-f6ed6e75a3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c1995f-a22e-4b3d-9d3e-f6ed6e75a3ea.jpg?1",
             "name": "Iron Star",
             "text": "",
             "colours": [],
@@ -20838,7 +20838,7 @@
         },
         {
             "id": "23cf1248-fe28-5dbd-acf1-2517c073c051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27a54e2-ac65-479a-adfc-8a2edad61e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27a54e2-ac65-479a-adfc-8a2edad61e81.jpg?1",
             "name": "Ivory Cup",
             "text": "Whenever a player plays a white spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -20867,7 +20867,7 @@
         },
         {
             "id": "83ad546a-f1ef-5a78-8eef-01c7d1b8a4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b89b134-f3b7-490a-ba79-d4cd5d82aadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b89b134-f3b7-490a-ba79-d4cd5d82aadc.jpg?1",
             "name": "Ivory Cup",
             "text": "",
             "colours": [],
@@ -20896,7 +20896,7 @@
         },
         {
             "id": "582f75a3-509d-523b-8f2c-282170eaea43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c76784-c4b2-48c8-9513-dd7196d27360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c76784-c4b2-48c8-9513-dd7196d27360.jpg?1",
             "name": "Jalum Tome",
             "text": "o2, oc\nT: Draw a card, then discard a card from your hand.",
             "colours": [],
@@ -20925,7 +20925,7 @@
         },
         {
             "id": "2bebc08b-4c8d-5209-9bbb-c4e9337f1436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38c5b83-449e-4503-a34e-94a302370606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38c5b83-449e-4503-a34e-94a302370606.jpg?1",
             "name": "Jalum Tome",
             "text": "",
             "colours": [],
@@ -20954,7 +20954,7 @@
         },
         {
             "id": "770d40a2-357c-5a70-b9e3-af3829f14f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f8d1ec-a55c-409f-be42-ae1c0f8c66e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f8d1ec-a55c-409f-be42-ae1c0f8c66e1.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3, oc\nT: Untap target creature.",
             "colours": [],
@@ -20983,7 +20983,7 @@
         },
         {
             "id": "5ccfd0ad-9d4d-54ab-9e47-8ceef229094a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb83a18-4efd-4e4e-99ad-bc6f09ddce6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb83a18-4efd-4e4e-99ad-bc6f09ddce6e.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "",
             "colours": [],
@@ -21012,7 +21012,7 @@
         },
         {
             "id": "c65c2d54-f4bd-510a-bc5c-83f16258b691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed9644-5dc1-4d1c-b60d-4bcf305f2d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed9644-5dc1-4d1c-b60d-4bcf305f2d0b.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw a card.",
             "colours": [],
@@ -21041,7 +21041,7 @@
         },
         {
             "id": "8d778f41-0f92-5538-b8cd-3af80450d4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d7ca08-92c3-42bb-98e3-d6d959d865d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d7ca08-92c3-42bb-98e3-d6d959d865d0.jpg?1",
             "name": "Jayemdae Tome",
             "text": "",
             "colours": [],
@@ -21070,7 +21070,7 @@
         },
         {
             "id": "2c188508-7f51-5fcd-90a8-d53ab9449e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90b2450-c814-47ee-8e85-d16e64d08af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90b2450-c814-47ee-8e85-d16e64d08af8.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond comes into play tapped.\noc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -21101,7 +21101,7 @@
         },
         {
             "id": "44f87dfc-77cb-5112-9c4a-c4f0218556cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8dbea9-25ef-4048-999f-d62ec7e1a13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8dbea9-25ef-4048-999f-d62ec7e1a13f.jpg?1",
             "name": "Marble Diamond",
             "text": "",
             "colours": [],
@@ -21132,7 +21132,7 @@
         },
         {
             "id": "826ac89e-5555-58d3-895a-7a795ddc9ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a691664-9275-4b89-a8e3-b99c88717ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a691664-9275-4b89-a8e3-b99c88717ffb.jpg?1",
             "name": "Meekstone",
             "text": "Creatures with power 3 or greater don't untap during their controllers' untap steps.",
             "colours": [],
@@ -21161,7 +21161,7 @@
         },
         {
             "id": "3c02eb3f-f45c-556e-9828-1a11c5dfac0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35fd53a-08ed-4f7c-937d-3dc6e834a481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35fd53a-08ed-4f7c-937d-3dc6e834a481.jpg?1",
             "name": "Meekstone",
             "text": "",
             "colours": [],
@@ -21190,7 +21190,7 @@
         },
         {
             "id": "310d2cb6-a7bf-5416-8482-0faa80f934c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da21381-38bf-49d0-98d3-81eb9c99ce82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da21381-38bf-49d0-98d3-81eb9c99ce82.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -21219,7 +21219,7 @@
         },
         {
             "id": "dcaa711f-5053-5112-b1c0-309e58e813b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d361c3-8aa7-4b3c-ae68-15910cc341ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d361c3-8aa7-4b3c-ae68-15910cc341ca.jpg?1",
             "name": "Millstone",
             "text": "",
             "colours": [],
@@ -21248,7 +21248,7 @@
         },
         {
             "id": "6c945aa0-3ada-51bf-b51a-ad3f99ebdcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4de9d3-56b2-40d9-adca-4fd2dadaaad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4de9d3-56b2-40d9-adca-4fd2dadaaad9.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond comes into play tapped.\noc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -21279,7 +21279,7 @@
         },
         {
             "id": "a1555632-8c66-5a51-81bf-ca8d02b7a2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76fd66-e91d-4f31-b393-465e9a7b795b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76fd66-e91d-4f31-b393-465e9a7b795b.jpg?1",
             "name": "Moss Diamond",
             "text": "",
             "colours": [],
@@ -21310,7 +21310,7 @@
         },
         {
             "id": "30bdd9bd-c75b-5839-a836-84c60c732086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90583dcc-6e0e-45e6-9209-8ad3a6c94555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90583dcc-6e0e-45e6-9209-8ad3a6c94555.jpg?1",
             "name": "Patagia Golem",
             "text": "o3: Patagia Golem gains flying until end of turn.",
             "colours": [],
@@ -21342,7 +21342,7 @@
         },
         {
             "id": "05f7775c-b51d-5500-9712-80dcd089690d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb501ad8-d2b2-454b-bda3-c28c618f2d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb501ad8-d2b2-454b-bda3-c28c618f2d4f.jpg?1",
             "name": "Patagia Golem",
             "text": "",
             "colours": [],
@@ -21374,7 +21374,7 @@
         },
         {
             "id": "108e7d76-cf44-58ec-83c2-db06c8e1d82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887b377f-4080-4cfa-a5a7-bab32b6891f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887b377f-4080-4cfa-a5a7-bab32b6891f9.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "Phyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
             "colours": [],
@@ -21407,7 +21407,7 @@
         },
         {
             "id": "6389c57a-8a66-539e-98cf-85dd9615fdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c279c5b-70c3-426a-86ad-2de1a8771ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c279c5b-70c3-426a-86ad-2de1a8771ae4.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "",
             "colours": [],
@@ -21440,7 +21440,7 @@
         },
         {
             "id": "eea7d506-8008-5fa0-8740-b4c583d4b7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e59c8b-735d-4796-b37c-619ee1782f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e59c8b-735d-4796-b37c-619ee1782f65.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21473,7 +21473,7 @@
         },
         {
             "id": "ef9f7258-d678-52d4-ba95-7d7656c27c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b3869-7305-49f9-9d21-795c94cc83f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b3869-7305-49f9-9d21-795c94cc83f5.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21506,7 +21506,7 @@
         },
         {
             "id": "ca846e2f-62a1-5d49-89d7-ff3387a3947b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc051a-df87-46d9-bc45-8b7b2721b374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc051a-df87-46d9-bc45-8b7b2721b374.jpg?1",
             "name": "Pit Trap",
             "text": "o2, oc\nT, Sacrifice Pit Trap: Destroy target attacking creature without flying. It can't be regenerated.",
             "colours": [],
@@ -21535,7 +21535,7 @@
         },
         {
             "id": "e2d4af39-bcc6-58fe-a3a2-bf09419dc9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e1d888-43e5-4476-98be-e251090cf662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e1d888-43e5-4476-98be-e251090cf662.jpg?1",
             "name": "Pit Trap",
             "text": "",
             "colours": [],
@@ -21564,7 +21564,7 @@
         },
         {
             "id": "de6ea6b2-9e1d-5610-ba8f-4402b29bcd86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68498f5c-4924-4a56-b6a7-40c5fb2d31c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68498f5c-4924-4a56-b6a7-40c5fb2d31c1.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -21593,7 +21593,7 @@
         },
         {
             "id": "03d160d4-29a0-5afd-b471-1be5a735e399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754d90bd-d08d-4510-ad3c-f6ed52a92d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754d90bd-d08d-4510-ad3c-f6ed52a92d6c.jpg?1",
             "name": "Rod of Ruin",
             "text": "",
             "colours": [],
@@ -21622,7 +21622,7 @@
         },
         {
             "id": "6380e2c6-e4dc-5186-a600-db45d9cb112d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae27220-2b62-4214-81b5-612dd770612b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae27220-2b62-4214-81b5-612dd770612b.jpg?1",
             "name": "Sisay's Ring",
             "text": "oc\nT: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -21651,7 +21651,7 @@
         },
         {
             "id": "28635258-6b17-581c-b087-d858b5371bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8383ff-76e5-43b3-99ac-8bdae9830aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8383ff-76e5-43b3-99ac-8bdae9830aca.jpg?1",
             "name": "Sisay's Ring",
             "text": "",
             "colours": [],
@@ -21680,7 +21680,7 @@
         },
         {
             "id": "9490369b-5fa5-5a33-89a0-66817715977a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b426b86d-b1d9-4aee-ac17-4eae7a3b69a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b426b86d-b1d9-4aee-ac17-4eae7a3b69a3.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond comes into play tapped.\noc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -21711,7 +21711,7 @@
         },
         {
             "id": "1beebc1a-b70a-5c23-aa62-1697d5d44e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e50b64-3527-4d28-92a0-a832436b6c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e50b64-3527-4d28-92a0-a832436b6c81.jpg?1",
             "name": "Sky Diamond",
             "text": "",
             "colours": [],
@@ -21742,7 +21742,7 @@
         },
         {
             "id": "90e12943-ea12-501b-9878-4ea20fd3dd16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e267df-22e1-422e-973b-d192b40d5f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e267df-22e1-422e-973b-d192b40d5f19.jpg?1",
             "name": "Soul Net",
             "text": "Whenever a creature is put into a graveyard from play, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -21771,7 +21771,7 @@
         },
         {
             "id": "eb9f9e21-60ba-594b-9a47-a1241dff94c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9454461-c2b4-45e0-8c99-ac8ea506e267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9454461-c2b4-45e0-8c99-ac8ea506e267.jpg?1",
             "name": "Soul Net",
             "text": "",
             "colours": [],
@@ -21800,7 +21800,7 @@
         },
         {
             "id": "8b7ac1f3-f256-5a91-a3a8-4efc1335694b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b6da4-89f8-442e-9c7a-2f60c180ef87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b6da4-89f8-442e-9c7a-2f60c180ef87.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -21829,7 +21829,7 @@
         },
         {
             "id": "e61175cf-c94c-57aa-9c35-16480362adbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55b4d06-43de-438a-8e75-736243b188e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55b4d06-43de-438a-8e75-736243b188e4.jpg?1",
             "name": "Spellbook",
             "text": "",
             "colours": [],
@@ -21858,7 +21858,7 @@
         },
         {
             "id": "11f41a90-38d7-554e-8f0e-c7db7732542d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf43b1-8d4e-4759-bb2d-0b2e03ba7012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf43b1-8d4e-4759-bb2d-0b2e03ba7012.jpg?1",
             "name": "Static Orb",
             "text": "If Static Orb is untapped, players can't untap more than two permanents during their untap steps.",
             "colours": [],
@@ -21887,7 +21887,7 @@
         },
         {
             "id": "fa1a23d6-2d7e-5fcf-b8c8-664bec1ff7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e0877-c792-45f2-9cc3-d86eaa90d85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e0877-c792-45f2-9cc3-d86eaa90d85c.jpg?1",
             "name": "Static Orb",
             "text": "",
             "colours": [],
@@ -21916,7 +21916,7 @@
         },
         {
             "id": "3f321706-0f62-5313-a57f-99f13f737370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb5bdd3-6ecd-49cd-bfa2-e7da1ee85d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb5bdd3-6ecd-49cd-bfa2-e7da1ee85d88.jpg?1",
             "name": "Storm Cauldron",
             "text": "Each player may play an additional land during each of his or her turns.\nWhenever a land is tapped for mana, return it to its owner's hand.",
             "colours": [],
@@ -21945,7 +21945,7 @@
         },
         {
             "id": "b8c6abb9-82fb-51d6-817a-6c29f2b89545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a458f9a-bde3-40ee-847d-aca216d215d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a458f9a-bde3-40ee-847d-aca216d215d4.jpg?1",
             "name": "Storm Cauldron",
             "text": "",
             "colours": [],
@@ -21974,7 +21974,7 @@
         },
         {
             "id": "d1de52d7-73d3-5260-b185-095a7a1235fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5463b9-2088-4ecb-acc3-c00ef54648af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5463b9-2088-4ecb-acc3-c00ef54648af.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in his or her hand on the bottom of his or her library in any order, then draws that many cards.",
             "colours": [],
@@ -22003,7 +22003,7 @@
         },
         {
             "id": "3c400693-5417-5f40-b29d-146724da7578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a784cae-4c1e-4813-8d13-3c435698f446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a784cae-4c1e-4813-8d13-3c435698f446.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -22032,7 +22032,7 @@
         },
         {
             "id": "fc973a5a-3385-52ed-9e7a-47d2a4d9fda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e90f7cf-efcb-48cc-b725-2f5fb6e37da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e90f7cf-efcb-48cc-b725-2f5fb6e37da9.jpg?1",
             "name": "Throne of Bone",
             "text": "Whenever a player plays a black spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -22061,7 +22061,7 @@
         },
         {
             "id": "2ac38dec-2621-5b92-825b-d3065e54b2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4337eed4-c219-4844-9620-980d2430a9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4337eed4-c219-4844-9620-980d2430a9bf.jpg?1",
             "name": "Throne of Bone",
             "text": "",
             "colours": [],
@@ -22090,7 +22090,7 @@
         },
         {
             "id": "9bf14608-569f-5771-8548-00d1d5bd9b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c94f13f-6e7a-4bb1-a9a0-5c885e231d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c94f13f-6e7a-4bb1-a9a0-5c885e231d5c.jpg?1",
             "name": "Wall of Spears",
             "text": "(Walls can't attack.)\nFirst strike",
             "colours": [],
@@ -22122,7 +22122,7 @@
         },
         {
             "id": "611e009c-8400-519b-b46f-718eb712b2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809e9c79-4acc-4933-8da5-993fd71164c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809e9c79-4acc-4933-8da5-993fd71164c4.jpg?1",
             "name": "Wall of Spears",
             "text": "",
             "colours": [],
@@ -22154,7 +22154,7 @@
         },
         {
             "id": "134b36c7-5234-5a5b-adfc-61d76697e7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e04657c-9a09-4e69-a884-39e083ad22b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e04657c-9a09-4e69-a884-39e083ad22b8.jpg?1",
             "name": "Wooden Sphere",
             "text": "Whenever a player plays a green spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -22183,7 +22183,7 @@
         },
         {
             "id": "3c129e3d-4c46-576b-a19b-e3628d40faf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452f2c4-1500-4301-8278-19922026fcaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452f2c4-1500-4301-8278-19922026fcaa.jpg?1",
             "name": "Wooden Sphere",
             "text": "",
             "colours": [],
@@ -22212,7 +22212,7 @@
         },
         {
             "id": "a0efaeb7-189b-5c75-a1e5-f3bf6f496c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd991b2-8c18-4c5f-9b70-461012fee61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd991b2-8c18-4c5f-9b70-461012fee61e.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -22244,7 +22244,7 @@
         },
         {
             "id": "2291e958-e466-5286-8cc5-614dff3c7a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0e5ea0-46f5-4a6c-8fa7-f851c97cb075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0e5ea0-46f5-4a6c-8fa7-f851c97cb075.jpg?1",
             "name": "Adarkar Wastes",
             "text": "",
             "colours": [],
@@ -22276,7 +22276,7 @@
         },
         {
             "id": "a32b1cb7-fa6a-5827-a993-0972315872da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b983b45-e8be-49e1-84c1-cec204395264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b983b45-e8be-49e1-84c1-cec204395264.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -22308,7 +22308,7 @@
         },
         {
             "id": "5d67d47c-1def-5bcc-be09-494b847df27f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3417c159-f524-42fe-93c4-f729cea41341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3417c159-f524-42fe-93c4-f729cea41341.jpg?1",
             "name": "Brushland",
             "text": "",
             "colours": [],
@@ -22340,7 +22340,7 @@
         },
         {
             "id": "1b2c8545-25f5-5736-bc98-0634b89d3036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac29c5c-3c55-4778-9bcd-642d38a0d3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac29c5c-3c55-4778-9bcd-642d38a0d3f9.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -22369,7 +22369,7 @@
         },
         {
             "id": "0b8c171b-40cc-516a-8481-3ccab4db5ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537af4fa-001c-4943-be6f-780d15b0584f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537af4fa-001c-4943-be6f-780d15b0584f.jpg?1",
             "name": "City of Brass",
             "text": "",
             "colours": [],
@@ -22398,7 +22398,7 @@
         },
         {
             "id": "fbf191b4-8074-542b-bf9b-5111dd3e718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6d68-19da-4b85-9852-681c0fc1e400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6d68-19da-4b85-9852-681c0fc1e400.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22439,7 +22439,7 @@
         },
         {
             "id": "b91da1b2-10e2-5e20-bb8b-587400019097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9730c936-a1fc-484d-a9ce-a91804a84609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9730c936-a1fc-484d-a9ce-a91804a84609.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22480,7 +22480,7 @@
         },
         {
             "id": "46caa683-bb63-501e-bb53-49d78d6e42cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def1ac1-652c-4160-9092-46549e577570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def1ac1-652c-4160-9092-46549e577570.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22521,7 +22521,7 @@
         },
         {
             "id": "bc014c8c-a647-5733-9186-42bb89dc06b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1de7-60d3-4bf3-8909-8f4fa5045479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1de7-60d3-4bf3-8909-8f4fa5045479.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22562,7 +22562,7 @@
         },
         {
             "id": "884207a8-3391-5578-b799-ca855a8ec46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172e55c6-b797-4b49-94f1-cc93e4f5b939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172e55c6-b797-4b49-94f1-cc93e4f5b939.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22603,7 +22603,7 @@
         },
         {
             "id": "b8d804f8-fe77-5694-b335-22ba6c8ee3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b7404-ae5a-4921-b70b-775deeb2c984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b7404-ae5a-4921-b70b-775deeb2c984.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22644,7 +22644,7 @@
         },
         {
             "id": "edf03820-7eaf-57bb-b040-b0c585e7b836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69545e9-7219-43f1-8a31-5035d87dca68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69545e9-7219-43f1-8a31-5035d87dca68.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22685,7 +22685,7 @@
         },
         {
             "id": "fa906109-3dca-5397-8e96-131111e115a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4321609-4f11-4066-9820-cbb483e9214a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4321609-4f11-4066-9820-cbb483e9214a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22726,7 +22726,7 @@
         },
         {
             "id": "24cdabfb-39a8-5149-88f8-23255bdd60a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45610b3-9e9b-4ef9-aab2-426f85a6cce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45610b3-9e9b-4ef9-aab2-426f85a6cce3.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -22767,7 +22767,7 @@
         },
         {
             "id": "10e716e6-62e8-5ee5-b7b8-1f2c4d465201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51487402-2a52-4117-ba88-327e863e5f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51487402-2a52-4117-ba88-327e863e5f56.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -22808,7 +22808,7 @@
         },
         {
             "id": "786a668b-ed48-5bea-99d3-0566a8c8ba07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a0a9ae-a1ae-41da-8308-d49e4afca3c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a0a9ae-a1ae-41da-8308-d49e4afca3c1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -22849,7 +22849,7 @@
         },
         {
             "id": "231f4dc0-9bd7-5f29-99df-c681018c8696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b02969-1959-4422-8e10-63ffb23192a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b02969-1959-4422-8e10-63ffb23192a2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -22890,7 +22890,7 @@
         },
         {
             "id": "d275904b-cdad-513f-83f9-ffae88dfad32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb83039-9a06-4d79-abcc-6f36eec6f29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb83039-9a06-4d79-abcc-6f36eec6f29e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -22931,7 +22931,7 @@
         },
         {
             "id": "6ac0b65f-3654-55d5-beba-06bc504ff2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea43ef7-99c5-40b6-9a59-9661b3b710cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea43ef7-99c5-40b6-9a59-9661b3b710cf.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "09b91fb1-2eae-5417-a1d0-1dd5a8d630dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff68b640-e194-4894-b9c0-76ed619c764d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff68b640-e194-4894-b9c0-76ed619c764d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23013,7 +23013,7 @@
         },
         {
             "id": "c7565c03-669b-534a-9ccb-12e443b29262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23b716f-51b2-402a-9a69-de190d3f6411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23b716f-51b2-402a-9a69-de190d3f6411.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23054,7 +23054,7 @@
         },
         {
             "id": "9e6d4c69-1041-5839-ae20-4a6d7ef2d79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c393b6f-2421-4d77-9025-dac9dfaaae36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c393b6f-2421-4d77-9025-dac9dfaaae36.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -23086,7 +23086,7 @@
         },
         {
             "id": "e42928ee-531e-5f6e-b551-ea8d04def518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c388f490-ee8d-495b-b400-9f83916f0fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c388f490-ee8d-495b-b400-9f83916f0fed.jpg?1",
             "name": "Karplusan Forest",
             "text": "",
             "colours": [],
@@ -23118,7 +23118,7 @@
         },
         {
             "id": "ab5229c3-c69e-5b84-8bcb-6056b7358283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe14fc96-f33a-4bd2-8b04-c339936d3c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe14fc96-f33a-4bd2-8b04-c339936d3c24.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23159,7 +23159,7 @@
         },
         {
             "id": "2faabb03-3dca-528c-8c1f-f5dd4b930d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16328444-5657-4f35-99c5-340d61472770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16328444-5657-4f35-99c5-340d61472770.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23200,7 +23200,7 @@
         },
         {
             "id": "3f1266ac-56a5-57d3-8f08-0069f26955c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01534212-5a65-4088-b45b-0823736a8fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01534212-5a65-4088-b45b-0823736a8fd5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23241,7 +23241,7 @@
         },
         {
             "id": "44f4d592-8068-54ce-95f5-73a5781778d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af90ad7-25e9-4a5c-9169-38f33d7640a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af90ad7-25e9-4a5c-9169-38f33d7640a6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23282,7 +23282,7 @@
         },
         {
             "id": "4c385d7f-14de-5d69-94a2-c8164d320fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae41792d-4aa0-42ae-a9e1-9261cf9181a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae41792d-4aa0-42ae-a9e1-9261cf9181a8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23323,7 +23323,7 @@
         },
         {
             "id": "ffe4be51-f7a3-550c-8061-310d11a76dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ade9a7-2a2e-4ec9-aa9c-20bc8caaf8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ade9a7-2a2e-4ec9-aa9c-20bc8caaf8a3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23364,7 +23364,7 @@
         },
         {
             "id": "d8e5df14-5a6a-5c9f-a257-400a816a0043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff951c38-6e02-40f0-9f54-13ac0915332b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff951c38-6e02-40f0-9f54-13ac0915332b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23405,7 +23405,7 @@
         },
         {
             "id": "61e77cbe-74e1-53c5-b16f-2f8ccd7b5b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f30404-4d66-4aa0-81d3-351820854eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f30404-4d66-4aa0-81d3-351820854eda.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23446,7 +23446,7 @@
         },
         {
             "id": "98fe6ac3-f7c9-59bf-8305-32202febba12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb482d-6279-48d6-baa3-047b48c3e5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb482d-6279-48d6-baa3-047b48c3e5df.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23487,7 +23487,7 @@
         },
         {
             "id": "370d437f-8111-54e9-9ed2-55cf66248de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a6a9b-c91d-4337-bc8c-411a50793385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a6a9b-c91d-4337-bc8c-411a50793385.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23528,7 +23528,7 @@
         },
         {
             "id": "1dd81c47-d8ce-52da-b19d-95a1f461f823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d13dbd6-6c6e-4120-a05a-e77f1e863b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d13dbd6-6c6e-4120-a05a-e77f1e863b35.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23569,7 +23569,7 @@
         },
         {
             "id": "96b07732-5db5-53b7-a8c2-116481fd733d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddcb7af-1f99-427f-971d-dd16b42d1914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddcb7af-1f99-427f-971d-dd16b42d1914.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23610,7 +23610,7 @@
         },
         {
             "id": "ff74969c-efbe-5202-89ca-49bc6899a7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb3ffc-9471-42c7-a1f4-66b6a8f9672c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb3ffc-9471-42c7-a1f4-66b6a8f9672c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23651,7 +23651,7 @@
         },
         {
             "id": "474cf6a0-9d91-59f1-aef8-2b0b8b5e23a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8bfc4f-ba82-462a-a5e6-5717de69414b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8bfc4f-ba82-462a-a5e6-5717de69414b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23692,7 +23692,7 @@
         },
         {
             "id": "48df8f1c-7ec0-5ead-8c56-7e02ede673d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43559560-354d-4147-977f-766b58bca9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43559560-354d-4147-977f-766b58bca9fa.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23733,7 +23733,7 @@
         },
         {
             "id": "270fec25-9e59-562b-81bd-810645b9b1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7604bd-b3b0-4e55-91c4-3717bae7e457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7604bd-b3b0-4e55-91c4-3717bae7e457.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23774,7 +23774,7 @@
         },
         {
             "id": "bcd8070d-ff15-59bf-80ba-72fcf5a2aaa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31327f6-f076-4366-9c7a-b084516ba215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31327f6-f076-4366-9c7a-b084516ba215.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -23806,7 +23806,7 @@
         },
         {
             "id": "1f358563-85e9-5aaf-b757-5100f0169caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3531a023-b37c-472c-9697-8b2c018139c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3531a023-b37c-472c-9697-8b2c018139c5.jpg?1",
             "name": "Sulfurous Springs",
             "text": "",
             "colours": [],
@@ -23838,7 +23838,7 @@
         },
         {
             "id": "e4e15dca-62b2-5f85-bf4b-cbcd280afdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7b6238-752d-49b7-8cdc-56587676e52d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7b6238-752d-49b7-8cdc-56587676e52d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23879,7 +23879,7 @@
         },
         {
             "id": "60f84c9d-c745-51c7-8689-d2cea6783c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40705a25-2de4-4a54-9fc4-02899085da27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40705a25-2de4-4a54-9fc4-02899085da27.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23920,7 +23920,7 @@
         },
         {
             "id": "703fb90f-02d8-57d5-93f0-4fa063e96845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfae795-d3d2-4758-9717-ed33cd0f3bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfae795-d3d2-4758-9717-ed33cd0f3bfb.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23961,7 +23961,7 @@
         },
         {
             "id": "0b3e0893-4955-5b0b-a2b7-e6c0f14fdd41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b65a1-314b-4c22-b942-38f60ba2c392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b65a1-314b-4c22-b942-38f60ba2c392.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -24002,7 +24002,7 @@
         },
         {
             "id": "53999dfd-8247-5fde-804b-0f5ae7a09df8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c956611e-5748-42ff-b8ea-bca0c3d94de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c956611e-5748-42ff-b8ea-bca0c3d94de4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -24043,7 +24043,7 @@
         },
         {
             "id": "60617c18-95fc-53b9-b718-efc8ca480615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cf9d05-153f-42c5-b48a-ad06da0ef4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cf9d05-153f-42c5-b48a-ad06da0ef4d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -24084,7 +24084,7 @@
         },
         {
             "id": "52488505-152f-50ac-abef-9a28b950478e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebdd6db-9434-4e60-bdf2-234e21ccbb10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebdd6db-9434-4e60-bdf2-234e21ccbb10.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -24125,7 +24125,7 @@
         },
         {
             "id": "39c3e8cf-9bb1-5fa6-b69a-5ad4c3bcbba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838fb77-a484-4323-aa62-c944f3fefa95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838fb77-a484-4323-aa62-c944f3fefa95.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -24166,7 +24166,7 @@
         },
         {
             "id": "d20aa985-2452-5f28-991f-b4964149c136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b496660-5a5d-4dec-93ca-60e6b1286221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b496660-5a5d-4dec-93ca-60e6b1286221.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -24198,7 +24198,7 @@
         },
         {
             "id": "f4ca5de5-d8f0-5e56-aaa4-bbdcee5eccfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f22de9-7cdb-464f-9354-61c5aa858c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f22de9-7cdb-464f-9354-61c5aa858c7a.jpg?1",
             "name": "Underground River",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/8ED.json
+++ b/Assets/Resources/Sets/8ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fa5ac0d2-e14b-537f-bad8-53e0c473c3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552cc36c-4d02-44ee-b36a-f58ff14c6f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552cc36c-4d02-44ee-b36a-f58ff14c6f3d.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "ff3276f4-392f-5656-9b3e-eb5110287bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f25bb-4e27-4e44-887a-f093dc14f861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f25bb-4e27-4e44-887a-f093dc14f861.jpg?1",
             "name": "Angel of Mercy",
             "text": "",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "105922a5-5ba9-5402-9675-671634af61e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a5ec5a-b490-456a-98e8-36cf4b836d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a5ec5a-b490-456a-98e8-36cf4b836d2a.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "f158a58f-02d6-534c-a1bc-6e221c4559a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a624f-3d5a-4519-8711-bd163da305c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a624f-3d5a-4519-8711-bd163da305c7.jpg?1",
             "name": "Angelic Page",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "855a5041-b13f-55ca-a09b-dda777c77599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78a4409-2e27-4c47-81c0-ff862ab7ca37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78a4409-2e27-4c47-81c0-ff862ab7ca37.jpg?1",
             "name": "Angelic Page",
             "text": "",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "f036e0f7-9618-5973-a2a0-7778ee04c895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a680ae-aa4f-4030-8032-113b2b80e1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a680ae-aa4f-4030-8032-113b2b80e1fb.jpg?1",
             "name": "Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "132deedd-dbd9-5fee-9d64-bbbb3ef4ab0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c78d392-9f2f-4241-9a10-6ac9b1e86154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c78d392-9f2f-4241-9a10-6ac9b1e86154.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "de0a98ed-456a-51fa-b212-374faae61aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5597d1e5-4a8c-426d-a2ad-f797f185ca36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5597d1e5-4a8c-426d-a2ad-f797f185ca36.jpg?1",
             "name": "Ardent Militia",
             "text": "",
             "colours": [
@@ -283,7 +283,7 @@
         },
         {
             "id": "93c34bc0-24c1-54f9-be71-b30d54344615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5131c74-a81b-4927-a1b9-98d2c714ab71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5131c74-a81b-4927-a1b9-98d2c714ab71.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "9297646e-dc0f-584e-9461-3addbf4235b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d9362-4f6a-43ad-9494-9c2014a4b5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d9362-4f6a-43ad-9494-9c2014a4b5ad.jpg?1",
             "name": "Avatar of Hope",
             "text": "If you have 3 life or less, Avatar of Hope costs {6} less to play.\nFlying (This creature can't be blocked except by creatures with flying.)\nAvatar of Hope may block any number of creatures.",
             "colours": [
@@ -351,7 +351,7 @@
         },
         {
             "id": "bc5ab0c5-b2de-5ea7-abe1-aa417bcb6c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747f55e1-e1a6-4cef-8326-7c8722ffe1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747f55e1-e1a6-4cef-8326-7c8722ffe1a0.jpg?1",
             "name": "Avatar of Hope",
             "text": "",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "4c85b5b0-8685-5a50-a606-abb7c01e7928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8cacd1-51e7-48af-a7ae-48832dc34a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8cacd1-51e7-48af-a7ae-48832dc34a92.jpg?1",
             "name": "Sea Eagle",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -419,7 +419,7 @@
         },
         {
             "id": "5a0b7932-0166-586c-ba5b-d4d996544222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03872618-1428-48c9-8f6d-8edc53560df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03872618-1428-48c9-8f6d-8edc53560df2.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "f76eaedc-0bc3-5c8a-b810-2b649c056c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11996023-ebf2-427f-ad36-9bf9c3c7949d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11996023-ebf2-427f-ad36-9bf9c3c7949d.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "59eae26c-f332-5a61-922c-34ed399b85a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168821ce-d77c-4294-a9fd-2a30852801ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168821ce-d77c-4294-a9fd-2a30852801ab.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "d896b2f7-86af-58c7-b5c8-6ca0edf5c277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa12005-465d-40b2-804b-a04cc2686ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa12005-465d-40b2-804b-a04cc2686ebd.jpg?1",
             "name": "Aven Flock",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{W}: Aven Flock gets +0/+1 until end of turn.",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "425250fd-feee-5ac8-8592-3984645293df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a12645d-eb05-4c31-b872-0ac35cbf06c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a12645d-eb05-4c31-b872-0ac35cbf06c6.jpg?1",
             "name": "Aven Flock",
             "text": "",
             "colours": [
@@ -597,7 +597,7 @@
         },
         {
             "id": "ed2e1705-1d1e-56dc-9600-ec7858b24606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9256cc2-d4b5-4103-bda8-2d9c98c4fd7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9256cc2-d4b5-4103-bda8-2d9c98c4fd7d.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "3705cd37-11b7-5e71-995a-344dc1306fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d854b-a165-4d40-86d7-d6a0aa17ce18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d854b-a165-4d40-86d7-d6a0aa17ce18.jpg?1",
             "name": "Blessed Reversal",
             "text": "You gain 3 life for each creature attacking you.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "96cbde2c-1e0f-595e-8161-1f56bb4821a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451e9163-d376-44dd-b3c3-c7ad661f4cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451e9163-d376-44dd-b3c3-c7ad661f4cf6.jpg?1",
             "name": "Blessed Reversal",
             "text": "",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "97d4fcb6-6949-5a03-ad0e-fbafe59e4257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b3156-975d-4f64-b19c-172cb21266c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b3156-975d-4f64-b19c-172cb21266c5.jpg?1",
             "name": "Silverback Ape",
             "text": "",
             "colours": [
@@ -729,7 +729,7 @@
         },
         {
             "id": "70687d62-433d-5d5f-b120-3ba0950208f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e502c5-ae2f-4d2e-b5d4-0e8f255eebcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e502c5-ae2f-4d2e-b5d4-0e8f255eebcc.jpg?1",
             "name": "Blinding Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Blinding Angel deals combat damage to a player, that player skips his or her next combat phase.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "eed275f6-fc0c-5363-a905-2df02f87cabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d860996a-6d22-4c35-b741-68337ff15bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d860996a-6d22-4c35-b741-68337ff15bf6.jpg?1",
             "name": "Blinding Angel",
             "text": "",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "2110183a-10c1-53c9-b74a-ee59d6372220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80972578-36fb-4bc2-9593-f9b10fb8424c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80972578-36fb-4bc2-9593-f9b10fb8424c.jpg?1",
             "name": "Chastise",
             "text": "Destroy target attacking creature. You gain life equal to its power.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "63a92b84-7770-5aca-b4da-d8d2c47c042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbdf926-95a5-4144-b707-85483a78f808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbdf926-95a5-4144-b707-85483a78f808.jpg?1",
             "name": "Chastise",
             "text": "",
             "colours": [
@@ -865,7 +865,7 @@
         },
         {
             "id": "c56da9fd-1076-5d94-8506-c968763529ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b5709c-d6bb-4866-a613-cbe93a918caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b5709c-d6bb-4866-a613-cbe93a918caa.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "{1}: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -898,7 +898,7 @@
         },
         {
             "id": "7bb07188-668d-5842-80ac-e2f5e120d23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71c65d-fc6d-4f7b-8054-657c2989db17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71c65d-fc6d-4f7b-8054-657c2989db17.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "",
             "colours": [
@@ -931,7 +931,7 @@
         },
         {
             "id": "3f0e1b38-925e-5374-b13a-c50467c883f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ced2118-dfb3-4f29-ad6b-454c0a8a094b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ced2118-dfb3-4f29-ad6b-454c0a8a094b.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "{1}: The next time a blue source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "8b6e5294-6985-5187-8123-9557d2085d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbfb6bf-efdd-454a-bc9d-e554f0b9bf13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbfb6bf-efdd-454a-bc9d-e554f0b9bf13.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "31e15b0d-22c9-517d-80f5-6de254e9e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc0e7d-a15b-4930-93d1-832c4fed733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc0e7d-a15b-4930-93d1-832c4fed733b.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "{1}: The next time a green source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1030,7 +1030,7 @@
         },
         {
             "id": "bf7820af-2491-57d6-ba03-1e83146f65f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c6a84-82ff-498e-bef1-4e39fa93be7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c6a84-82ff-498e-bef1-4e39fa93be7c.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "b2eac49f-9b23-5fbc-8e5f-e0803547c596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a719732d-4370-4338-9e5b-a0e17c3b6608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a719732d-4370-4338-9e5b-a0e17c3b6608.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "{1}: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "8837128c-0749-56ca-9e00-1cdd95fdc31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65217707-b67a-4d9b-9a6e-6d241e3d0350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65217707-b67a-4d9b-9a6e-6d241e3d0350.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "bc90d3cc-360c-5aa9-805b-c4e0211d7ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e64f2cc-67bd-482a-938b-8dca1a1c6ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e64f2cc-67bd-482a-938b-8dca1a1c6ac1.jpg?1",
             "name": "Circle of Protection: White",
             "text": "{1}: The next time a white source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "748ed56a-044b-5097-b6e6-446b488e5d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff6d61-fe4d-4fa0-a20b-00b9c0879cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff6d61-fe4d-4fa0-a20b-00b9c0879cb4.jpg?1",
             "name": "Circle of Protection: White",
             "text": "",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "8c15f862-30f3-577b-b6a0-fe9e999b0da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47101c-ead0-42a6-b37b-0e5d294959c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47101c-ead0-42a6-b37b-0e5d294959c9.jpg?1",
             "name": "Crossbow Infantry",
             "text": "{T}: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "4e6543b3-731b-5f61-a9f2-e5176d228787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf09dc8-ef87-4eed-801e-e4289985011f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf09dc8-ef87-4eed-801e-e4289985011f.jpg?1",
             "name": "Crossbow Infantry",
             "text": "",
             "colours": [
@@ -1269,7 +1269,7 @@
         },
         {
             "id": "282c84af-efc7-5196-bf30-c932a8660911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4907c728-f08d-4c14-96a2-c92f09dfa6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4907c728-f08d-4c14-96a2-c92f09dfa6d2.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "7005ce22-5464-543c-ae60-707f542fbae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8456c3-cdb0-46af-8884-e47cccd35cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8456c3-cdb0-46af-8884-e47cccd35cef.jpg?1",
             "name": "Demystify",
             "text": "",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "6e187702-8381-5a7d-88c0-225ab85e5661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb0854-87e7-4236-9791-8fe601704200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb0854-87e7-4236-9791-8fe601704200.jpg?1",
             "name": "Diving Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nAttacking doesn't cause Diving Griffin to tap.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "c450e020-dda4-59d0-a22e-c01549099ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1e4260-c555-48d4-b779-b97e3639e729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1e4260-c555-48d4-b779-b97e3639e729.jpg?1",
             "name": "Diving Griffin",
             "text": "",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "1c03f0f9-4d89-5c5b-a143-600e1246726f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2341478-2a91-4ce8-881a-21e826b55c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2341478-2a91-4ce8-881a-21e826b55c34.jpg?1",
             "name": "Elite Archers",
             "text": "{T}: Elite Archers deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -1442,7 +1442,7 @@
         },
         {
             "id": "39f52a25-1906-501f-9d2d-9dba319c6db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48af300f-ed3a-4b69-9bef-f568b27927c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48af300f-ed3a-4b69-9bef-f568b27927c4.jpg?1",
             "name": "Elite Archers",
             "text": "",
             "colours": [
@@ -1479,7 +1479,7 @@
         },
         {
             "id": "bab1c04c-6e4c-563a-8e76-2ccd994d53ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1839ea-567e-44eb-983f-c1a570ba5c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1839ea-567e-44eb-983f-c1a570ba5c82.jpg?1",
             "name": "Elite Javelineer",
             "text": "Whenever Elite Javelineer blocks, it deals 1 damage to target attacking creature.",
             "colours": [
@@ -1515,7 +1515,7 @@
         },
         {
             "id": "63718c02-2c75-5daa-84d6-401febbc3083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c82ae-1b19-48cf-9a7c-edf0f031e66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c82ae-1b19-48cf-9a7c-edf0f031e66e.jpg?1",
             "name": "Elite Javelineer",
             "text": "",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "c2dd11fd-4c50-5d6d-a90a-70a29eae3f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f95890-0258-431c-b639-c0aba27b8039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f95890-0258-431c-b639-c0aba27b8039.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1584,7 +1584,7 @@
         },
         {
             "id": "e1b35d25-26da-5788-a5bb-beaa164bd58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e550c04a-de51-46c0-a17b-3d2a61aedc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e550c04a-de51-46c0-a17b-3d2a61aedc7f.jpg?1",
             "name": "Glorious Anthem",
             "text": "",
             "colours": [
@@ -1617,7 +1617,7 @@
         },
         {
             "id": "ae5cc46e-cf69-5730-884d-8a188df6b477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502beb90-c562-470a-9315-bc1a1b11ea9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502beb90-c562-470a-9315-bc1a1b11ea9c.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1653,7 +1653,7 @@
         },
         {
             "id": "9ae2d013-0562-5db4-897c-912f3e35e232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e8b55c-231a-41bc-8f15-ad4b93f3d637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e8b55c-231a-41bc-8f15-ad4b93f3d637.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "4eabc2c4-cbd5-5e4d-9e85-e1405b73aad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41703ace-78e3-474e-b06a-43260c060471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41703ace-78e3-474e-b06a-43260c060471.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "aa7b7c8c-2ba4-5a4f-96bd-9e0882aaf38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292d118-5c47-4273-a2fe-d041de7e42e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292d118-5c47-4273-a2fe-d041de7e42e0.jpg?1",
             "name": "Healing Salve",
             "text": "",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "f43b30d4-c9f8-5a99-becb-8ce9f3e92f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72baf7-d9fe-41b4-862d-3709834ee46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72baf7-d9fe-41b4-862d-3709834ee46b.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "5cc6d6b9-792c-5af5-a888-6da27aeaf7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4061db-4d4a-43f3-bed5-51259b69be86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4061db-4d4a-43f3-bed5-51259b69be86.jpg?1",
             "name": "Holy Day",
             "text": "",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "f9d6161a-6e3f-572b-abe8-7ee78ca17973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0038c0e-071f-4fee-bf23-d50d00014703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0038c0e-071f-4fee-bf23-d50d00014703.jpg?1",
             "name": "Holy Strength",
             "text": "Enchanted creature gets +1/+2.",
             "colours": [
@@ -1856,7 +1856,7 @@
         },
         {
             "id": "5df7d717-06d2-5a65-839d-dedabeaa5bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f8a95-1c6a-4cb4-b504-55ac492c4d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f8a95-1c6a-4cb4-b504-55ac492c4d8a.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "e090efa0-5578-5712-a6c0-33a2a461a2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa797080-aa3b-4285-a47a-878a3e8e584f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa797080-aa3b-4285-a47a-878a3e8e584f.jpg?1",
             "name": "Honor Guard",
             "text": "{W}: Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "e7bcdbb4-f5aa-5dc6-a913-d32641b5248f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fa231-4aa4-46ef-917c-fbfcbb8714af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fa231-4aa4-46ef-917c-fbfcbb8714af.jpg?1",
             "name": "Honor Guard",
             "text": "",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "dad32183-6c5a-5f58-b931-04752490a561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d08a6-730c-45a3-9d17-d724d2bdfbcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d08a6-730c-45a3-9d17-d724d2bdfbcd.jpg?1",
             "name": "Intrepid Hero",
             "text": "{T}: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "8fb8650a-71e9-5232-a2ca-2fb6a20f8942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd392d6f-c45b-491f-8205-35c5bf4dab0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd392d6f-c45b-491f-8205-35c5bf4dab0d.jpg?1",
             "name": "Intrepid Hero",
             "text": "",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "f791b952-90c8-51cb-8269-cbd48a5bea3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51842cf5-a658-4522-a5e4-9c764ab1331e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51842cf5-a658-4522-a5e4-9c764ab1331e.jpg?1",
             "name": "Ivory Mask",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "8093e142-018e-5a7a-ac1f-a565fdac76cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3d0e39-8519-4a0b-ada1-15f8bb9f0b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3d0e39-8519-4a0b-ada1-15f8bb9f0b77.jpg?1",
             "name": "Ivory Mask",
             "text": "",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "8eede794-1f69-5c93-85f3-577ef1eea2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9df1cc-9de3-42a6-9c28-f2d8db75322a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9df1cc-9de3-42a6-9c28-f2d8db75322a.jpg?1",
             "name": "Karma",
             "text": "At the beginning of each player's upkeep, Karma deals damage to that player equal to the number of Swamps he or she controls. (Your upkeep step is after you untap and before you draw.)",
             "colours": [
@@ -2134,7 +2134,7 @@
         },
         {
             "id": "53a9707a-5c40-556e-b901-62560e027495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146f69a-f9d1-4124-a108-434a1cd913e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146f69a-f9d1-4124-a108-434a1cd913e9.jpg?1",
             "name": "Karma",
             "text": "",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "7328eece-3952-5df0-9b2b-55bc9cfb6ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc58f97-39ee-4d89-884f-88f9edc3459f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc58f97-39ee-4d89-884f-88f9edc3459f.jpg?1",
             "name": "Master Decoy",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "13c113a1-b389-5b00-a42e-7db29449d04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf99754a-620d-496a-bbc3-12a54f56d8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf99754a-620d-496a-bbc3-12a54f56d8df.jpg?1",
             "name": "Master Decoy",
             "text": "",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "d2178e44-3ec3-5a5c-8a84-052889cd989d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8acbfb-a836-44c4-b655-f5dc919941cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8acbfb-a836-44c4-b655-f5dc919941cc.jpg?1",
             "name": "Master Healer",
             "text": "{T}: Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2275,7 +2275,7 @@
         },
         {
             "id": "c45a67b9-6b8b-55c9-aba8-8c3689a05a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6717914-b2dd-4fb2-8e29-440444534de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6717914-b2dd-4fb2-8e29-440444534de8.jpg?1",
             "name": "Master Healer",
             "text": "",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "e6377278-b56e-584e-ad2e-17c8c8041c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35c327-1998-4331-9280-1617638c1031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35c327-1998-4331-9280-1617638c1031.jpg?1",
             "name": "Noble Purpose",
             "text": "Whenever a creature you control deals combat damage, you gain that much life.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "7466b64e-0524-5806-856a-34aef7196d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee27eef-d6c4-4b0f-b215-323856a055e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee27eef-d6c4-4b0f-b215-323856a055e1.jpg?1",
             "name": "Noble Purpose",
             "text": "",
             "colours": [
@@ -2377,7 +2377,7 @@
         },
         {
             "id": "25b97619-db02-5eaa-8516-59f9d926f3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc85607-dfdd-4989-b299-c68adb8c7159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc85607-dfdd-4989-b299-c68adb8c7159.jpg?1",
             "name": "Oracle's Attendants",
             "text": "{T}: All damage that would be dealt to target creature this turn by a source of your choice is dealt to Oracle's Attendants instead.",
             "colours": [
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "e72d19a1-d16b-5152-8c48-a78c1a776906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a2390-112b-4a60-91d9-c394e6a3e65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a2390-112b-4a60-91d9-c394e6a3e65d.jpg?1",
             "name": "Oracle's Attendants",
             "text": "",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "7c8a159a-9607-56ea-9ffe-90f9e4f9f74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a9d48-ca39-4275-ba1e-f584a3b647df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a9d48-ca39-4275-ba1e-f584a3b647df.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -2484,7 +2484,7 @@
         },
         {
             "id": "bade6410-8620-51cc-a7bf-de22465c1b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d9d474-d783-432e-b9bb-22514e9eab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d9d474-d783-432e-b9bb-22514e9eab57.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -2519,7 +2519,7 @@
         },
         {
             "id": "15b16c07-4b03-540e-9f56-f7bc6413ad6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05bd3b7-02fb-4d83-ab8f-fd056c7db2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05bd3b7-02fb-4d83-ab8f-fd056c7db2f1.jpg?1",
             "name": "Peach Garden Oath",
             "text": "You gain 2 life for each creature you control.",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "ff60e8f1-9ebf-5a95-9968-294be0961109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b16c3-0963-4cd7-a4c1-2d4de3bd885c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b16c3-0963-4cd7-a4c1-2d4de3bd885c.jpg?1",
             "name": "Peach Garden Oath",
             "text": "",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "47f77b8a-017f-518e-8cdc-291769097e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a25bf0b-7de0-4e71-ae3e-59a6665dc903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a25bf0b-7de0-4e71-ae3e-59a6665dc903.jpg?1",
             "name": "Rain of Blades",
             "text": "Rain of Blades deals 1 damage to each attacking creature.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "5dd94709-a788-5bf7-b19b-0603fa201ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39600c44-df38-455a-a06d-1bcac7c519cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39600c44-df38-455a-a06d-1bcac7c519cb.jpg?1",
             "name": "Rain of Blades",
             "text": "",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "fef08ac1-58a9-5900-b45a-4e440a08ae60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6023b3c7-53bc-4490-8f9b-beb858b068e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6023b3c7-53bc-4490-8f9b-beb858b068e8.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "02690b82-3f7e-5896-a907-f22f50f6bac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20a487a-cdf7-4ba9-84fd-ca8a91652223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20a487a-cdf7-4ba9-84fd-ca8a91652223.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "d9e27efe-e1ce-5a64-9158-b9af5f5d29a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ba3fde-f5ff-4e59-88a0-3c38fc5e75e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ba3fde-f5ff-4e59-88a0-3c38fc5e75e0.jpg?1",
             "name": "Redeem",
             "text": "Prevent all damage that would be dealt this turn to up to two target creatures.",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "65e4e800-6260-57eb-b85d-b82559750916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5425ad59-03bf-4c66-8286-3bcfc27fef0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5425ad59-03bf-4c66-8286-3bcfc27fef0c.jpg?1",
             "name": "Redeem",
             "text": "",
             "colours": [
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "a4c9ce2f-38ad-5d81-836d-d22c1903cfdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb50bf-7e77-4b8e-a030-e575d0418a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb50bf-7e77-4b8e-a030-e575d0418a00.jpg?1",
             "name": "Rolling Stones",
             "text": "Walls may attack as though they weren't Walls.",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "747763e9-e631-5e0b-b8ba-080316f48964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a931d691-3efc-4043-9e23-677f8bd949e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a931d691-3efc-4043-9e23-677f8bd949e1.jpg?1",
             "name": "Rolling Stones",
             "text": "",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "fdc2f0f8-0309-54c3-b100-36bbfb99861e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101e615-adf1-4b58-87b2-32832b30fabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101e615-adf1-4b58-87b2-32832b30fabb.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever a spell or ability an opponent controls causes a land to be put into your graveyard from play, return that land to play.",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "767e1e19-70bb-55fd-8086-dffac4d2f168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da33-7d58-4292-9827-a074ef123dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da33-7d58-4292-9827-a074ef123dc4.jpg?1",
             "name": "Sacred Ground",
             "text": "",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "b28781d2-8c65-5367-89ed-3843b29d2cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7417bbe7-c1b3-4046-98b3-7d6af9851ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7417bbe7-c1b3-4046-98b3-7d6af9851ab2.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -2952,7 +2952,7 @@
         },
         {
             "id": "84e0980d-9876-5c91-a015-700b357c9373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228f475-0a80-44c6-acd8-8d485a1bbed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228f475-0a80-44c6-acd8-8d485a1bbed2.jpg?1",
             "name": "Sacred Nectar",
             "text": "",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "7564e63b-4ffe-5a3b-97ac-e5a444635aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a93d628-0934-4ddb-bac1-b0ceafdb0ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a93d628-0934-4ddb-bac1-b0ceafdb0ba4.jpg?1",
             "name": "Samite Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "fc903e01-bc11-5537-8bc9-6ac538f30a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbcd61c-a5f7-4b68-a7e2-249ad84c7a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbcd61c-a5f7-4b68-a7e2-249ad84c7a4e.jpg?1",
             "name": "Samite Healer",
             "text": "",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "fd16141d-497c-5ef1-882a-300d33e1e4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74733902-f177-4551-bc39-72f58860c890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74733902-f177-4551-bc39-72f58860c890.jpg?1",
             "name": "Sanctimony",
             "text": "Whenever an opponent taps a Mountain for mana, you may gain 1 life.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "1dd3c084-6a52-53c9-945d-ed0eba81f808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fd979-7c4c-44e3-9324-a3dd4c29ff83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fd979-7c4c-44e3-9324-a3dd4c29ff83.jpg?1",
             "name": "Sanctimony",
             "text": "",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "3dc3faf8-efd4-54b9-b07c-1546dbb4085a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58dbcf3-f8ad-4e82-9515-0290fa5373f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58dbcf3-f8ad-4e82-9515-0290fa5373f7.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "2d7e052d-4743-5936-b8ab-79e1679e1df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea8d9f-2b77-4cff-8b96-387f43366c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea8d9f-2b77-4cff-8b96-387f43366c1a.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "c353d8c6-6c90-54c6-8e96-3d43fac212ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae1da2-f752-481c-a0e8-3c73f6b4ccbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae1da2-f752-481c-a0e8-3c73f6b4ccbe.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -3229,7 +3229,7 @@
         },
         {
             "id": "cb412893-7e48-57f8-bf21-024c123068fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7de3d2-3a98-49dd-810a-0dbba8f8e004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7de3d2-3a98-49dd-810a-0dbba8f8e004.jpg?1",
             "name": "Seasoned Marshal",
             "text": "",
             "colours": [
@@ -3265,7 +3265,7 @@
         },
         {
             "id": "7b066400-b3e1-527f-a7b1-820c90312a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b089b409-2156-4c94-890f-e8804ab5a50c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b089b409-2156-4c94-890f-e8804ab5a50c.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nAttacking doesn't cause Serra Angel to tap.",
             "colours": [
@@ -3300,7 +3300,7 @@
         },
         {
             "id": "a0dd0cea-f9dc-5427-b09b-711a0ba1084b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7b4cf-1413-4816-8bef-4e7ab101ccd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7b4cf-1413-4816-8bef-4e7ab101ccd2.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "6b30eea8-df6c-5149-9484-845d84fcec6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810eec1-9bb4-480f-9074-712ad9eb8fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810eec1-9bb4-480f-9074-712ad9eb8fba.jpg?1",
             "name": "Solidarity",
             "text": "Creatures you control get +0/+5 until end of turn.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "704b6666-7b3a-521b-b538-c153b2fba284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c75ac1-5b77-4dd1-a33b-7d95acf72f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c75ac1-5b77-4dd1-a33b-7d95acf72f5b.jpg?1",
             "name": "Solidarity",
             "text": "",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "4ebbc8c1-adb1-55d5-a641-44fab2686390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f4f0c-d17c-42b6-b216-1548c51b91f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f4f0c-d17c-42b6-b216-1548c51b91f5.jpg?1",
             "name": "Spirit Link",
             "text": "Whenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3436,7 +3436,7 @@
         },
         {
             "id": "73f03b0c-eff6-5a11-83bf-391c016c305d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b63b26-b7c5-4b18-8cf5-e00abe539b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b63b26-b7c5-4b18-8cf5-e00abe539b36.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "13860fdb-5e65-505b-bdf6-94e5bed5d836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013a1d59-af2a-4ae1-826e-88bd77c7ce5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013a1d59-af2a-4ae1-826e-88bd77c7ce5d.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking doesn't cause Standing Troops to tap.",
             "colours": [
@@ -3507,7 +3507,7 @@
         },
         {
             "id": "f6761742-79c4-524e-ba22-99f4cf8fa8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf40017-d331-4eac-90dc-9e7413f1c8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf40017-d331-4eac-90dc-9e7413f1c8ac.jpg?1",
             "name": "Standing Troops",
             "text": "",
             "colours": [
@@ -3543,7 +3543,7 @@
         },
         {
             "id": "a61ac001-f2a2-50ac-8aa3-1345f3a2c1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a162ae-dfe1-43e0-adf7-3d1365f3a681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a162ae-dfe1-43e0-adf7-3d1365f3a681.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, you gain 4 life.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "50fc86ec-b1ea-5af4-9e56-dc9b78a89dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b767ff-7a4a-499f-8608-aa7ae9139df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b767ff-7a4a-499f-8608-aa7ae9139df4.jpg?1",
             "name": "Staunch Defenders",
             "text": "",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "7e9b28ab-d853-59cd-afa1-9e1d5108b935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b383bd61-0f23-4d3e-a946-b8438a52234d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b383bd61-0f23-4d3e-a946-b8438a52234d.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "f7f19eef-c8cc-5e7f-8006-0647c42a2489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cebcd2-4199-425a-adfc-059f842259e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cebcd2-4199-425a-adfc-059f842259e4.jpg?1",
             "name": "Story Circle",
             "text": "",
             "colours": [
@@ -3681,7 +3681,7 @@
         },
         {
             "id": "4592ffa0-23f7-5daf-a584-9bff5bfbe96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69414b6a-421e-4895-9262-d3097078fb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69414b6a-421e-4895-9262-d3097078fb12.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -3716,7 +3716,7 @@
         },
         {
             "id": "07624a09-5464-51be-b0b2-cef2d231b37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba3c8ed-60df-4eca-95f6-6e38a3647e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba3c8ed-60df-4eca-95f6-6e38a3647e71.jpg?1",
             "name": "Suntail Hawk",
             "text": "",
             "colours": [
@@ -3751,7 +3751,7 @@
         },
         {
             "id": "05f130bf-c7cf-5461-a125-46dbf3888a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261bcea-27e0-417f-b3bf-7089c1e8bf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261bcea-27e0-417f-b3bf-7089c1e8bf1e.jpg?1",
             "name": "Sunweb",
             "text": "(Walls can't attack.)\nFlying (This creature may block creatures with flying.)\nSunweb can't block creatures with power 2 or less.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "2e05cd65-0d13-54d9-b859-8fed765aba2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ed97ad-8ff1-42fb-af77-a45e5d138c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ed97ad-8ff1-42fb-af77-a45e5d138c8b.jpg?1",
             "name": "Sunweb",
             "text": "",
             "colours": [
@@ -3821,7 +3821,7 @@
         },
         {
             "id": "3c738c78-6ac4-5054-83f8-8530d490cc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec270d53-042e-4b11-b0f4-6416348b8fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec270d53-042e-4b11-b0f4-6416348b8fff.jpg?1",
             "name": "Sword Dancer",
             "text": "{W}{W}: Target attacking creature gets -1/-0 until end of turn.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "04088f77-4423-5ca4-8875-dd49127c8de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25917af7-a35c-47fe-8374-952aaf865252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25917af7-a35c-47fe-8374-952aaf865252.jpg?1",
             "name": "Sword Dancer",
             "text": "",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "376d2e38-7676-5584-9b82-7b0ee7c59a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030d414a-5155-41cc-8b01-07d297254d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030d414a-5155-41cc-8b01-07d297254d1c.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "dd7bb79b-2f32-5673-ab36-97f45541fc50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b561f06-0c30-4b3b-b76e-3cbbd3dc0bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b561f06-0c30-4b3b-b76e-3cbbd3dc0bf6.jpg?1",
             "name": "Tundra Wolves",
             "text": "",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "b2d651ef-4080-5a14-bc85-753afbe19586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb78fad6-71d8-49a2-8e32-34675aaec796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb78fad6-71d8-49a2-8e32-34675aaec796.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "af029109-1261-5377-91ed-5d0ea2be15c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55caf83-8d60-4f22-ba42-086723e38daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55caf83-8d60-4f22-ba42-086723e38daf.jpg?1",
             "name": "Venerable Monk",
             "text": "",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "b41da309-1dc9-5f23-af0a-8d1c5168f7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcbe7e6-a584-4c9d-b319-40babff8ec26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcbe7e6-a584-4c9d-b319-40babff8ec26.jpg?1",
             "name": "Wall of Swords",
             "text": "(Walls can't attack.)\nFlying (This creature may block creatures with flying.)",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "a36cf26b-a334-5f8c-b691-8335b135af54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ae0268-e2de-45c5-8556-42455f66d646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ae0268-e2de-45c5-8556-42455f66d646.jpg?1",
             "name": "Wall of Swords",
             "text": "",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "ff74d471-5345-50ca-90e9-8be24f7134c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006c18cf-b6d2-4fba-b9da-c9762fb3885b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006c18cf-b6d2-4fba-b9da-c9762fb3885b.jpg?1",
             "name": "Worship",
             "text": "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "7ccc9c38-1aa6-5ba9-9ca7-72c7d1381bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258fb7d8-8ffd-48e7-94d2-bd6296a47e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258fb7d8-8ffd-48e7-94d2-bd6296a47e62.jpg?1",
             "name": "Worship",
             "text": "",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "78ec433a-1827-57f9-95e4-63f7ef8e8862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0619d670-7b53-4185-a25d-2fab5db1aab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0619d670-7b53-4185-a25d-2fab5db1aab5.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "573a1f79-c1c8-5965-a2b1-40bb61f3c2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d4d3-3edd-4d1c-9da5-a0892dae0393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d4d3-3edd-4d1c-9da5-a0892dae0393.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "15740177-1546-5f18-96c0-bfe2ba39b202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b15648c-1d88-42ec-b2f7-aab9a8c256a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b15648c-1d88-42ec-b2f7-aab9a8c256a2.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "3d9a8666-c1ee-5df3-98ae-e386e7bb56df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8235805-543a-422e-bd32-558d198e5686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8235805-543a-422e-bd32-558d198e5686.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "29c41b0f-55a3-5c4b-ab62-ff8517d352c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083507d3-b28f-4e84-909b-bca2a2131233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083507d3-b28f-4e84-909b-bca2a2131233.jpg?1",
             "name": "Archivist",
             "text": "{T}: Draw a card.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "6527a440-e362-53e4-92cb-e4c429fb51cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e98da9-809e-415b-bd2b-047fcdb620ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e98da9-809e-415b-bd2b-047fcdb620ac.jpg?1",
             "name": "Archivist",
             "text": "",
             "colours": [
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "a9ba7ba2-2e57-5824-ab5c-79c101a66fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfc5265-7e38-4f2e-85ae-08f34eaffb89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfc5265-7e38-4f2e-85ae-08f34eaffb89.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "75a6ea79-3f65-5470-ae9e-cb0dcb4cb0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2265d-e1dc-40f0-bfc0-c20d1d80dd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2265d-e1dc-40f0-bfc0-c20d1d80dd3c.jpg?1",
             "name": "Aven Fisher",
             "text": "",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "b1c45b97-2810-5b43-a832-fd61244f4709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f46988-c3ee-42e9-ade6-0b6302b8b952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f46988-c3ee-42e9-ade6-0b6302b8b952.jpg?1",
             "name": "Balance of Power",
             "text": "If target opponent has more cards in hand than you, draw cards equal to the difference.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "54aa7e0f-6aa4-5c35-83ee-eb6052bfe640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00d1b2-30c2-49c7-abe7-063120a622cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00d1b2-30c2-49c7-abe7-063120a622cb.jpg?1",
             "name": "Balance of Power",
             "text": "",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "6870b481-db06-5721-82bd-f43e8796c56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2275b0a5-7777-49cb-9056-aef0a82424db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2275b0a5-7777-49cb-9056-aef0a82424db.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -4552,7 +4552,7 @@
         },
         {
             "id": "f18f4bf1-b360-5def-a89c-f46edbf26653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09623b0c-a771-46e3-b7c0-d4097486f1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09623b0c-a771-46e3-b7c0-d4097486f1cd.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "7abbf954-2ff0-5c39-b969-973441636990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b099ef-4b43-4b63-a7fc-cec19cf29f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b099ef-4b43-4b63-a7fc-cec19cf29f4e.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card into play under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "d7a112d5-77a3-5d15-ab78-ef5d65ac1ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452456c-f828-4301-9b4f-8a0e77525d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452456c-f828-4301-9b4f-8a0e77525d5f.jpg?1",
             "name": "Bribery",
             "text": "",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "24e408ec-333c-5cab-8dc9-b5ca8db20b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b50620d-430e-4c38-a95d-3d69a4c29ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b50620d-430e-4c38-a95d-3d69a4c29ff9.jpg?1",
             "name": "Catalog",
             "text": "Draw two cards, then discard a card from your hand.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "1a66389a-253b-5ce3-a7bf-ac417b2cc2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9770db-ac79-4752-8671-47d0748f43a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9770db-ac79-4752-8671-47d0748f43a7.jpg?1",
             "name": "Catalog",
             "text": "",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "c9950776-6ca1-56b2-a705-613c55cb0f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b152c0d-ba43-49c6-9bb5-1d20a9f411f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b152c0d-ba43-49c6-9bb5-1d20a9f411f6.jpg?1",
             "name": "Coastal Hornclaw",
             "text": "Sacrifice a land: Coastal Hornclaw gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "41c741ff-0174-5225-8ca5-7a820ebbcc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee8c0f8-f673-471a-8728-1c33b70e5a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee8c0f8-f673-471a-8728-1c33b70e5a27.jpg?1",
             "name": "Coastal Hornclaw",
             "text": "",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "436c91a9-ae0d-5cae-85d4-a49793d41346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d65495-4d73-46fa-bd38-155f4639649a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d65495-4d73-46fa-bd38-155f4639649a.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "12fc6ad2-478e-5a91-acd3-4bc32c835dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6eaba7-9175-44a3-a4e4-b2da561864d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6eaba7-9175-44a3-a4e4-b2da561864d5.jpg?1",
             "name": "Coastal Piracy",
             "text": "",
             "colours": [
@@ -4853,7 +4853,7 @@
         },
         {
             "id": "3afb910d-06d5-520b-b5f6-d34c3be0f1bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed69afaf-74cc-4b4f-8794-751477231cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed69afaf-74cc-4b4f-8794-751477231cff.jpg?1",
             "name": "Concentrate",
             "text": "Draw three cards.",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "986d41c3-c83d-5e7f-bcd3-6e9840bd54b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e180558-6df5-47dd-af09-78a73dbe5cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e180558-6df5-47dd-af09-78a73dbe5cda.jpg?1",
             "name": "Concentrate",
             "text": "",
             "colours": [
@@ -4919,7 +4919,7 @@
         },
         {
             "id": "4fb2ec39-e049-5454-86e7-b666b5e5c768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48acfd80-eba3-4aa9-804c-563259ca84de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48acfd80-eba3-4aa9-804c-563259ca84de.jpg?1",
             "name": "Confiscate",
             "text": "You control enchanted permanent.",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "675fb2e5-9846-5d02-8cc6-3b98c9c542bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28eb01c-c08c-4f9b-bf67-d15b478b84f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28eb01c-c08c-4f9b-bf67-d15b478b84f0.jpg?1",
             "name": "Confiscate",
             "text": "",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "c9e1d63d-2497-5748-b743-235cc6885e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215244ee-0b78-4fd1-858f-d093a5d42939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215244ee-0b78-4fd1-858f-d093a5d42939.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "3c00e9a5-d0a0-5dc3-b2f3-418a6e6e17cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ac7010-0db0-4c77-a3e8-64c1a5c91d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ac7010-0db0-4c77-a3e8-64c1a5c91d51.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "5d1fed5c-6a76-5d9d-8a9b-7a08d705845e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71fe070-3656-4c69-84ae-dca3a8f7aa5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71fe070-3656-4c69-84ae-dca3a8f7aa5a.jpg?1",
             "name": "Cowardice",
             "text": "Whenever a creature becomes the target of a spell or ability, return that creature to its owner's hand. (It won't be affected by the spell or ability.)",
             "colours": [
@@ -5092,7 +5092,7 @@
         },
         {
             "id": "e5ddaf51-a149-59be-8481-aad83417026e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fc5ef-5196-495b-b56a-c360701462d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fc5ef-5196-495b-b56a-c360701462d7.jpg?1",
             "name": "Cowardice",
             "text": "",
             "colours": [
@@ -5125,7 +5125,7 @@
         },
         {
             "id": "a5471d2a-b1ef-5c81-be5f-7ba71277d990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abab-70b9-4eec-be61-80f41d6a275b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abab-70b9-4eec-be61-80f41d6a275b.jpg?1",
             "name": "Curiosity",
             "text": "Whenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "6cd50c88-0151-5777-ad95-d62b35842a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae15ef61-37dc-46a2-891f-7748996e399d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae15ef61-37dc-46a2-891f-7748996e399d.jpg?1",
             "name": "Curiosity",
             "text": "",
             "colours": [
@@ -5195,7 +5195,7 @@
         },
         {
             "id": "d62c02c1-4cfd-552c-a13d-a2a097b90e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbacff5-c650-4835-b5a1-f747a5db5fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbacff5-c650-4835-b5a1-f747a5db5fd6.jpg?1",
             "name": "Daring Apprentice",
             "text": "{T}, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "3f23eef2-4b55-5aa7-bc1e-54fb57833279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1413a8-dfe8-4b3a-a75e-35d70d8cf904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1413a8-dfe8-4b3a-a75e-35d70d8cf904.jpg?1",
             "name": "Daring Apprentice",
             "text": "",
             "colours": [
@@ -5267,7 +5267,7 @@
         },
         {
             "id": "06cbdac9-1f5e-5d68-bf14-ace1be9fdcf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c899e-f624-4791-af64-b1b1e2ac53cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c899e-f624-4791-af64-b1b1e2ac53cd.jpg?1",
             "name": "Deflection",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -5300,7 +5300,7 @@
         },
         {
             "id": "74eee7f7-c241-59c7-b774-8832a53b71ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e66c8-1061-43a6-a46f-7ef716225e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e66c8-1061-43a6-a46f-7ef716225e53.jpg?1",
             "name": "Deflection",
             "text": "",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "cfddaaf8-c35b-5d86-8db2-9b091b6c272d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce498a03-0b90-480d-9a77-d8db2b32d553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce498a03-0b90-480d-9a77-d8db2b32d553.jpg?1",
             "name": "Dehydration",
             "text": "Enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "81ceb86c-edec-59de-a42c-01d744a21e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd484166-56db-4300-8944-3055fc747f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd484166-56db-4300-8944-3055fc747f3d.jpg?1",
             "name": "Dehydration",
             "text": "",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "9a6f50ce-1910-5e21-8f38-6f8412dfb1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4f1796-765a-4c9d-af0c-7866b3ac96b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4f1796-765a-4c9d-af0c-7866b3ac96b0.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "461fad28-7bec-53f1-8ce0-16c9a20ec9f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba92987-0a10-42b6-a331-ec56f244c5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba92987-0a10-42b6-a331-ec56f244c5eb.jpg?1",
             "name": "Evacuation",
             "text": "",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "7b8ec349-39b3-5d3c-9ab3-83052e963c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0a102-b31c-4cbd-894b-44b1c1e677d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0a102-b31c-4cbd-894b-44b1c1e677d2.jpg?1",
             "name": "Fighting Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "bc27e70f-f729-550d-989d-ab92952a9c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3782fd74-5d94-483d-8c9a-76febdd4d796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3782fd74-5d94-483d-8c9a-76febdd4d796.jpg?1",
             "name": "Fighting Drake",
             "text": "",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "1a7a0578-9c4e-5f60-9938-cd07b1764764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14e61f-481a-4bfa-aca0-fb63dc952be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14e61f-481a-4bfa-aca0-fb63dc952be6.jpg?1",
             "name": "Flash Counter",
             "text": "Counter target instant spell.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "0da78c1e-bd8c-5026-85b2-2edfb903247b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a1aa47-bc73-45c0-b818-cf7175195484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a1aa47-bc73-45c0-b818-cf7175195484.jpg?1",
             "name": "Flash Counter",
             "text": "",
             "colours": [
@@ -5605,7 +5605,7 @@
         },
         {
             "id": "69892c53-abc4-5c97-b91a-78ee7ee75758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c53ee6-9fe0-459e-903f-214a25a07634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c53ee6-9fe0-459e-903f-214a25a07634.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{U}: Return Fleeting Image to its owner's hand.",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "ea2c5824-eb6b-538c-bc4e-88b1e3976a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fd1567-e878-44ea-a6eb-a042e95e3bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fd1567-e878-44ea-a6eb-a042e95e3bb5.jpg?1",
             "name": "Fleeting Image",
             "text": "",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "39a26cd1-20d4-54dc-8bb0-e216d881e1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a7d379-3fb5-40eb-ba3c-7b51b7c5f57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a7d379-3fb5-40eb-ba3c-7b51b7c5f57e.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature has flying. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -5710,7 +5710,7 @@
         },
         {
             "id": "13b0cda1-bfe3-52e2-87b0-cb76148177dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cb6bec-6640-4d7e-ac2f-cdcd4dc1a9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cb6bec-6640-4d7e-ac2f-cdcd4dc1a9f1.jpg?1",
             "name": "Flight",
             "text": "",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "85a348fd-a040-5e81-824b-756175d1420f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d745a5-1d5a-45ec-a662-c13cab70bfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d745a5-1d5a-45ec-a662-c13cab70bfcf.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "29183bb5-22a0-59a9-9e8d-497ce13c993d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc636b1-5fc5-422d-9722-5fa12c754d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc636b1-5fc5-422d-9722-5fa12c754d6c.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5817,7 +5817,7 @@
         },
         {
             "id": "03d9f613-a1ac-5932-b07f-370b66cdd411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33661f0-7dde-4b08-87da-1eeb723ddf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33661f0-7dde-4b08-87da-1eeb723ddf9f.jpg?1",
             "name": "Hibernation",
             "text": "Return all green permanents to their owners' hands.",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "28e17019-23fb-56f9-90f5-da510832d3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2fec63-0687-4e71-958e-31098c301e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2fec63-0687-4e71-958e-31098c301e24.jpg?1",
             "name": "Hibernation",
             "text": "",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "be0eac1e-58b0-5017-b443-e8039951fb86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3cb1a4-2552-4575-be8d-bef9d721cfc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3cb1a4-2552-4575-be8d-bef9d721cfc8.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5918,7 +5918,7 @@
         },
         {
             "id": "cba7f4b3-5f33-5f43-9d32-183fe3eb3b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69060684-8b35-4680-bbd2-994ff8fa2eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69060684-8b35-4680-bbd2-994ff8fa2eef.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "7b8dcd9c-89a8-5a72-9c61-e63c81df839e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64e0a7c-54a9-45b9-be46-ddf6755f1142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64e0a7c-54a9-45b9-be46-ddf6755f1142.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "b8da4aba-c415-559a-8ff2-0cf29b3a6d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645df9c5-3a0a-40b0-b898-7bcf28773366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645df9c5-3a0a-40b0-b898-7bcf28773366.jpg?1",
             "name": "Index",
             "text": "",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "538296ee-2fe7-5ebc-8023-184db280485f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be039716-30fc-4f84-8f84-6019065560e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be039716-30fc-4f84-8f84-6019065560e4.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "4c621024-222c-54be-aa31-5719d068d489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f806fa-11b7-43e1-a8dc-9a94a786f76b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f806fa-11b7-43e1-a8dc-9a94a786f76b.jpg?1",
             "name": "Inspiration",
             "text": "",
             "colours": [
@@ -6085,7 +6085,7 @@
         },
         {
             "id": "ae42016e-ff88-5685-aee8-d1a869818347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d62468e-ed9d-4932-bbbd-103b33b98b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d62468e-ed9d-4932-bbbd-103b33b98b25.jpg?1",
             "name": "Intruder Alarm",
             "text": "Creatures don't untap during their controllers' untap steps.\nWhenever a creature comes into play, untap all creatures.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "26488f6b-3bf8-58a3-aa69-443a134f625a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9ffa2e-ff31-4d42-a47e-ace1b1e68143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9ffa2e-ff31-4d42-a47e-ace1b1e68143.jpg?1",
             "name": "Intruder Alarm",
             "text": "",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "defca1fe-461d-52b5-9247-152d415f9c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d06b2b-9979-49b2-900f-795d1d5945e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d06b2b-9979-49b2-900f-795d1d5945e4.jpg?1",
             "name": "Invisibility",
             "text": "Enchanted creature can't be blocked except by Walls.",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "88bbf348-2556-5dd9-aed2-8568ad6f45f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e677860-dcee-444c-99fb-0c4ed99c1fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e677860-dcee-444c-99fb-0c4ed99c1fe0.jpg?1",
             "name": "Invisibility",
             "text": "",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "26069317-18be-58d0-a417-f058397f533e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c481454e-9544-4b8e-a1bc-d0bbc9fc64ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c481454e-9544-4b8e-a1bc-d0bbc9fc64ef.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "96ce8364-3915-514f-b37b-cc66ae445f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c863b128-0ae6-4811-895f-e4b2b7252714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c863b128-0ae6-4811-895f-e4b2b7252714.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "d5133565-3413-56a7-b38f-2fc0cbae160c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56707af4-eb74-4b33-8741-6cc9b547d919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56707af4-eb74-4b33-8741-6cc9b547d919.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "87d33f01-c5fa-58d7-9989-f817d370e3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0110d7-d3e8-4799-8368-a88b0beabd3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0110d7-d3e8-4799-8368-a88b0beabd3e.jpg?1",
             "name": "Mana Leak",
             "text": "",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "f93bf5cd-3cbb-5add-82c9-a67f73801eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e40516-99ec-45fb-be51-c8503fa4811e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e40516-99ec-45fb-be51-c8503fa4811e.jpg?1",
             "name": "Merchant of Secrets",
             "text": "When Merchant of Secrets comes into play, draw a card.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "10783989-ba88-5b0d-ac26-2cd9ed4f1b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98130e65-fe9e-4a48-a424-5855768e3cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98130e65-fe9e-4a48-a424-5855768e3cd2.jpg?1",
             "name": "Merchant of Secrets",
             "text": "",
             "colours": [
@@ -6429,7 +6429,7 @@
         },
         {
             "id": "9143c894-ecec-5b24-bb70-45050c3a0b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5385d2-ca5d-4fb9-934b-b7cc8b38ac89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5385d2-ca5d-4fb9-934b-b7cc8b38ac89.jpg?1",
             "name": "Merchant Scroll",
             "text": "Search your library for a blue instant card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "88c17866-f54e-52d7-b7a8-f9f511a49ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d32db5e-cf3f-40e9-88b2-e205fb185661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d32db5e-cf3f-40e9-88b2-e205fb185661.jpg?1",
             "name": "Merchant Scroll",
             "text": "",
             "colours": [
@@ -6495,7 +6495,7 @@
         },
         {
             "id": "a59a3519-0dc4-5aef-b83c-04603b46f7b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591db4b-8ce3-4842-bff3-a81e565b6bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591db4b-8ce3-4842-bff3-a81e565b6bf4.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"plainswalk.\" This effect doesn't end at end of turn.)",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "805da97e-cdf6-58ac-9b25-cc6f891eb067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d55cdde-5e6b-4cec-9862-84aa39c04082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d55cdde-5e6b-4cec-9862-84aa39c04082.jpg?1",
             "name": "Mind Bend",
             "text": "",
             "colours": [
@@ -6561,7 +6561,7 @@
         },
         {
             "id": "7304d518-b3ff-514c-aee3-757f038befa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef3f3aa-b54d-433f-9798-3b0fd1755094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef3f3aa-b54d-433f-9798-3b0fd1755094.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -6597,7 +6597,7 @@
         },
         {
             "id": "33a20fbc-0cf1-5f45-931f-224f554719d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700d79fa-9e6b-447e-9d64-af9666cc0b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700d79fa-9e6b-447e-9d64-af9666cc0b0b.jpg?1",
             "name": "Phantom Warrior",
             "text": "",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "bd88b81e-f1ac-563c-83d6-677d439dfc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeab5d7d-2f44-4372-8884-a5c847c92f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeab5d7d-2f44-4372-8884-a5c847c92f92.jpg?1",
             "name": "Puppeteer",
             "text": "{U}, {T}: Tap or untap target creature.",
             "colours": [
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "fce1386a-b467-5bab-becd-3ef810c1707f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451897d5-2600-4b92-87bd-8ff89d32febd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451897d5-2600-4b92-87bd-8ff89d32febd.jpg?1",
             "name": "Puppeteer",
             "text": "",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "4082061e-ac40-54c9-aa50-5b7b87ceba5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ff7228-3040-409e-865e-999bbb779f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ff7228-3040-409e-865e-999bbb779f19.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "3107ae4f-daac-5d10-ab50-c76124d0fd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d4289-d734-42d3-92c5-affdb21f719b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d4289-d734-42d3-92c5-affdb21f719b.jpg?1",
             "name": "Remove Soul",
             "text": "",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "e5dfdead-a4ad-5a46-9aef-814ef6075d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e92dcb1-f543-4d23-a96c-aed280077049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e92dcb1-f543-4d23-a96c-aed280077049.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell, then untap up to four lands.",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "1963a67b-d212-54e5-9522-316bee8435f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f87215-9278-4d1f-95b0-ffb3b1b1c896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f87215-9278-4d1f-95b0-ffb3b1b1c896.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -6837,7 +6837,7 @@
         },
         {
             "id": "8d5610bd-cc20-57d9-808f-2fe091319ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ac8823-9bc0-4d15-a7ab-0d106167a0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ac8823-9bc0-4d15-a7ab-0d106167a0e5.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "{T}, Sacrifice an artifact: Draw a card.",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "a45beb61-c447-5c90-93f9-466317adfb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ef926a-dabc-4120-8e91-6ebc5883d7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ef926a-dabc-4120-8e91-6ebc5883d7af.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "5258850b-8b2d-5fca-a5d3-066524218780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21f6c39-f879-452f-a643-f503d88206d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21f6c39-f879-452f-a643-f503d88206d6.jpg?1",
             "name": "Sage Owl",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Sage Owl comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "8f70843c-5ede-5844-9dba-4cf9c6c2688e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84531ce6-64cd-4d89-875b-7073f423dd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84531ce6-64cd-4d89-875b-7073f423dd41.jpg?1",
             "name": "Sage Owl",
             "text": "",
             "colours": [
@@ -6979,7 +6979,7 @@
         },
         {
             "id": "51ff21a2-e129-55c3-af03-988187d52110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5094b8-085f-4a68-81bf-b1a7ab423ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5094b8-085f-4a68-81bf-b1a7ab423ac4.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an Island.",
             "colours": [
@@ -7014,7 +7014,7 @@
         },
         {
             "id": "9863a6e5-412c-5e04-ad7c-3e44f04bfd61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ee578-1e36-4058-9ecf-ce488a4ef21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ee578-1e36-4058-9ecf-ce488a4ef21c.jpg?1",
             "name": "Sea Monster",
             "text": "",
             "colours": [
@@ -7049,7 +7049,7 @@
         },
         {
             "id": "8e726f51-901b-502b-8281-3967162f9027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed441d0-b8c8-4d63-80ff-cc4fb47d0b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed441d0-b8c8-4d63-80ff-cc4fb47d0b26.jpg?1",
             "name": "Shifting Sky",
             "text": "As Shifting Sky comes into play, choose a color.\nAll nonland permanents are the chosen color.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "dac0324d-fbdd-5dc1-b10b-825448913345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffece9-d4d4-4adb-a87c-8be464b9040f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffece9-d4d4-4adb-a87c-8be464b9040f.jpg?1",
             "name": "Shifting Sky",
             "text": "",
             "colours": [
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "2a43ebef-49e5-54df-9898-d8b0122beed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9020f16-4c26-4a7b-8b5c-1d8df3e910a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9020f16-4c26-4a7b-8b5c-1d8df3e910a9.jpg?1",
             "name": "Sneaky Homunculus",
             "text": "Sneaky Homunculus can't block or be blocked by creatures with power 2 or greater.",
             "colours": [
@@ -7151,7 +7151,7 @@
         },
         {
             "id": "145d5368-28e5-5d9e-88e4-888c062d4be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4e160-68e3-4ae1-999f-3553d73475ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4e160-68e3-4ae1-999f-3553d73475ef.jpg?1",
             "name": "Sneaky Homunculus",
             "text": "",
             "colours": [
@@ -7187,7 +7187,7 @@
         },
         {
             "id": "cb9fb9da-2c1e-5192-a795-4cfbeade699d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca0925d-c1e8-438c-9d40-c57ad974ed5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca0925d-c1e8-438c-9d40-c57ad974ed5b.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nSacrifice Spiketail Hatchling: Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "ea1dcc74-eebe-5027-bf40-02dd043c21cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7bd303-272e-46c9-b495-dcc18cdd7fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7bd303-272e-46c9-b495-dcc18cdd7fa5.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "85f02f2b-2b27-5ed4-a3ea-9fdfd1d89232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810f874e-98e1-402b-b48e-14c3e2a624f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810f874e-98e1-402b-b48e-14c3e2a624f0.jpg?1",
             "name": "Steal Artifact",
             "text": "You control enchanted artifact.",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "0061b979-fcca-5485-a9f2-444e48ebe88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d238d-4084-4561-a19a-a3a6d0326071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d238d-4084-4561-a19a-a3a6d0326071.jpg?1",
             "name": "Steal Artifact",
             "text": "",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "b535d9c2-add9-59ef-88a4-882826fd4ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6106d-6822-47b5-956e-20e17143a818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6106d-6822-47b5-956e-20e17143a818.jpg?1",
             "name": "Storm Crow",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "fc7e1deb-42ed-593a-b16d-f30eb295a891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5ae3a-e794-4af8-b4e4-d7724ebf30a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5ae3a-e794-4af8-b4e4-d7724ebf30a0.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "52c213fb-e6c7-5bfc-8035-507ae8d3275c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf72bddf-9006-4320-ab5f-6b3e5439d21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf72bddf-9006-4320-ab5f-6b3e5439d21c.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -7430,7 +7430,7 @@
         },
         {
             "id": "97426c64-e874-5dc2-b32c-0b4c54773fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01096c4-6722-40cd-a4dc-742243a346bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01096c4-6722-40cd-a4dc-742243a346bb.jpg?1",
             "name": "Telepathy",
             "text": "",
             "colours": [
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "a9f252c9-0aa5-5d90-9d05-0e685700de1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078e44c6-90bb-4294-9e0a-6194764af00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078e44c6-90bb-4294-9e0a-6194764af00c.jpg?1",
             "name": "Temporal Adept",
             "text": "{U}{U}{U}, {T}: Return target permanent to its owner's hand.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "8b29e069-13af-5318-ac37-d1d715dc5779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b3c184-0ebf-4dab-9433-d6db0a16ae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b3c184-0ebf-4dab-9433-d6db0a16ae8f.jpg?1",
             "name": "Temporal Adept",
             "text": "",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "51913a68-e417-503b-8108-7823284c940d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a1c44-4f2b-4277-935c-a337776c023a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a1c44-4f2b-4277-935c-a337776c023a.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "1aa36cdd-f1f1-52d4-908d-5f38d870d1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0931dc-c401-48e8-8ec2-19aa44cef58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0931dc-c401-48e8-8ec2-19aa44cef58c.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "8e9179b7-c860-597f-874b-374e89d36234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08147258-2319-49d5-bfb1-cc4f817d9c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08147258-2319-49d5-bfb1-cc4f817d9c72.jpg?1",
             "name": "Tidal Kraken",
             "text": "Tidal Kraken is unblockable.",
             "colours": [
@@ -7640,7 +7640,7 @@
         },
         {
             "id": "e9e7c5ca-5147-5c3a-82e9-4debb9c7b44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a82f2-0035-4501-b57e-9a4395d614f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a82f2-0035-4501-b57e-9a4395d614f9.jpg?1",
             "name": "Tidal Kraken",
             "text": "",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "689565a9-b5bc-5bfe-92d9-ab70de85c9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a23417-3419-4edc-a722-b695e676a3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a23417-3419-4edc-a722-b695e676a3ce.jpg?1",
             "name": "Trade Routes",
             "text": "{1}: Return target land you control to its owner's hand.\n{1}, Discard a land card from your hand: Draw a card.",
             "colours": [
@@ -7708,7 +7708,7 @@
         },
         {
             "id": "89a6e403-f541-52e7-a0c5-9d89f8c08d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f99f63-e0b4-48fe-8588-0531c5343a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f99f63-e0b4-48fe-8588-0531c5343a05.jpg?1",
             "name": "Trade Routes",
             "text": "",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "90d50a75-cfe8-5d03-a4b2-c32f33d9c694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f65e7a-be66-4a57-9e33-c1b02285f65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f65e7a-be66-4a57-9e33-c1b02285f65e.jpg?1",
             "name": "Treasure Trove",
             "text": "{2}{U}{U}: Draw a card.",
             "colours": [
@@ -7774,7 +7774,7 @@
         },
         {
             "id": "377cb12b-fd24-5ba5-98c6-bd4ac4707a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac22679-9cfc-47cf-bed6-945dbc0419b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac22679-9cfc-47cf-bed6-945dbc0419b2.jpg?1",
             "name": "Treasure Trove",
             "text": "",
             "colours": [
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "ceb0478b-0416-544e-9109-77a3168d8c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b25858a-ab2d-441a-a3fe-6d5ecd7f05be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b25858a-ab2d-441a-a3fe-6d5ecd7f05be.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7840,7 +7840,7 @@
         },
         {
             "id": "3a180132-6665-5161-990d-1002658725ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1178a-75d4-471c-9445-4ad623ebe65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1178a-75d4-471c-9445-4ad623ebe65c.jpg?1",
             "name": "Twiddle",
             "text": "",
             "colours": [
@@ -7873,7 +7873,7 @@
         },
         {
             "id": "364f1e07-634b-5801-bf9d-374b05f6a9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb14889-2992-4d99-a6fe-1e245475c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb14889-2992-4d99-a6fe-1e245475c758.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -7906,7 +7906,7 @@
         },
         {
             "id": "c9584153-38cb-523f-be09-61fb96f9e081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5785fc-676f-46da-92f3-59b32fc99933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5785fc-676f-46da-92f3-59b32fc99933.jpg?1",
             "name": "Unsummon",
             "text": "",
             "colours": [
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "b3412502-a38e-52e9-a299-69a84c0151f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e4b04-19dd-42e6-9af4-4cc88a1bfcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e4b04-19dd-42e6-9af4-4cc88a1bfcb4.jpg?1",
             "name": "Wall of Air",
             "text": "(Walls can't attack.)\nFlying (This creature may block creatures with flying.)",
             "colours": [
@@ -7974,7 +7974,7 @@
         },
         {
             "id": "aa3bc5d6-1c11-5c9d-aced-8823ef604642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9b147-5bc1-4f92-bd3b-ac4aff2f0190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9b147-5bc1-4f92-bd3b-ac4aff2f0190.jpg?1",
             "name": "Wall of Air",
             "text": "",
             "colours": [
@@ -8009,7 +8009,7 @@
         },
         {
             "id": "2ff04b54-9a62-5fac-a881-a780739b00ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a57368-881f-4f1b-8fdd-09e76836227e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a57368-881f-4f1b-8fdd-09e76836227e.jpg?1",
             "name": "Wind Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8044,7 +8044,7 @@
         },
         {
             "id": "080f5ca6-4fae-5b4b-96a8-1ff260ac9b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ead9a78-bf5d-4088-85da-e456dd1d6cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ead9a78-bf5d-4088-85da-e456dd1d6cc5.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -8079,7 +8079,7 @@
         },
         {
             "id": "fb3233f4-67c8-5ebe-bf71-e75343f5a917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0111ef4-f0be-4af3-981f-aa19a17a3d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0111ef4-f0be-4af3-981f-aa19a17a3d7b.jpg?1",
             "name": "Wrath of Marit Lage",
             "text": "When Wrath of Marit Lage comes into play, tap all red creatures.\nRed creatures don't untap during their controllers' untap steps.",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "bef65bc4-028b-5296-9b6d-a3d0781ad93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190aadce-a309-48fd-a6b0-97f978d7b1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190aadce-a309-48fd-a6b0-97f978d7b1c4.jpg?1",
             "name": "Wrath of Marit Lage",
             "text": "",
             "colours": [
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "d244ce6a-4c7b-5490-873e-1e4a16775995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c87689-c6bf-4097-adb7-8839cac61609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c87689-c6bf-4097-adb7-8839cac61609.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws the card.",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "67da8d25-7978-5b07-9cb4-f0b106a1a467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7e041b-72bf-4314-9c5c-ffb12fcf6a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7e041b-72bf-4314-9c5c-ffb12fcf6a7e.jpg?1",
             "name": "Zur's Weirding",
             "text": "",
             "colours": [
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "fee01716-cd49-5773-bef7-bd0f912f2be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68672104-44da-491b-930e-a5ec5740f9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68672104-44da-491b-930e-a5ec5740f9a4.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Abyssal Specter deals damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "72ee0214-d914-5b29-b0eb-c3fac832a7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa54bc77-d2cd-4000-bc3f-74075b84d77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa54bc77-d2cd-4000-bc3f-74075b84d77f.jpg?1",
             "name": "Abyssal Specter",
             "text": "",
             "colours": [
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "ff6bb5e1-e9d8-5955-8d97-105193d1ec45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705692ad-763b-42aa-8524-21dc32df3f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705692ad-763b-42aa-8524-21dc32df3f10.jpg?1",
             "name": "Ambition's Cost",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "0482dfe5-c5a9-5112-8dd7-4ea2e905c697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0408be33-ad74-4e27-a722-e85302ba8055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0408be33-ad74-4e27-a722-e85302ba8055.jpg?1",
             "name": "Ambition's Cost",
             "text": "",
             "colours": [
@@ -8347,7 +8347,7 @@
         },
         {
             "id": "4b119450-4a23-5606-abfa-52bb648fd1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94903771-d0d0-49dd-b28a-438ef4bdf416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94903771-d0d0-49dd-b28a-438ef4bdf416.jpg?1",
             "name": "Bog Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "d22cb09f-12cd-5b07-9df8-4178527e94cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79073387-b835-4079-aa22-76c866488fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79073387-b835-4079-aa22-76c866488fbe.jpg?1",
             "name": "Bog Imp",
             "text": "",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "82160e1e-d1d9-52ca-8232-91738e2dd07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d65c4-f471-4e05-84fd-cb83393bee49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d65c4-f471-4e05-84fd-cb83393bee49.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "a0d64c0b-9688-5f10-bd1c-f06de4b4446e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad174e5-b415-431c-bb6f-581a19558d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad174e5-b415-431c-bb6f-581a19558d69.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "37589d14-6e1f-527c-a8b5-83945dac1f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea9d0e-9188-4447-a9c9-8ed209121b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea9d0e-9188-4447-a9c9-8ed209121b43.jpg?1",
             "name": "Carrion Wall",
             "text": "(Walls can't attack.)\n{1}{B}: Regenerate Carrion Wall.",
             "colours": [
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "08e8cb95-f508-5ad6-9f98-80aabfabff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf312cf-fd6a-49a3-8bf0-338bbabc3381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf312cf-fd6a-49a3-8bf0-338bbabc3381.jpg?1",
             "name": "Carrion Wall",
             "text": "",
             "colours": [
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "20af1bd9-6d33-540e-8811-9d19b20bb3a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2f5ec5-84ee-4334-9049-9922591622cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2f5ec5-84ee-4334-9049-9922591622cb.jpg?1",
             "name": "Carrion Wall",
             "text": "",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "1e5c21c2-0549-5c89-b8dd-5f89250319b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5ac075-1796-484e-97b9-ddd00433a40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5ac075-1796-484e-97b9-ddd00433a40c.jpg?1",
             "name": "Carrion Wall",
             "text": "",
             "colours": [
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "c7f49b1b-06e9-5dc4-a382-625e66a0978b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5017726b-f884-4c63-b738-1eb0aacb441d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5017726b-f884-4c63-b738-1eb0aacb441d.jpg?1",
             "name": "Coercion",
             "text": "Target opponent reveals his or her hand. Choose a card from it. That player discards that card.",
             "colours": [
@@ -8668,7 +8668,7 @@
         },
         {
             "id": "bebee1df-2f5c-532e-85e6-7a36cc3252be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8156f4e8-29f8-48f7-8f6b-e00fa5c5a4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8156f4e8-29f8-48f7-8f6b-e00fa5c5a4a9.jpg?1",
             "name": "Coercion",
             "text": "",
             "colours": [
@@ -8701,7 +8701,7 @@
         },
         {
             "id": "1863943d-d72e-503d-bab8-f6417b96fa22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42a59e-f916-48a7-8721-091ee47a6ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42a59e-f916-48a7-8721-091ee47a6ea1.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "355150af-ce2e-5f6d-b09d-2385739488ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fef21d3-c1c5-41a0-913b-6cab2409ac1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fef21d3-c1c5-41a0-913b-6cab2409ac1c.jpg?1",
             "name": "Dark Banishing",
             "text": "",
             "colours": [
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "ac45a546-15e4-5262-8cdf-c849e19c95b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6404e26-353a-478e-81db-03499be8e24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6404e26-353a-478e-81db-03499be8e24b.jpg?1",
             "name": "Death Pit Offering",
             "text": "When Death Pit Offering comes into play, sacrifice all creatures you control.\nCreatures you control get +2/+2.",
             "colours": [
@@ -8800,7 +8800,7 @@
         },
         {
             "id": "d35e963c-5389-517e-ad8f-4cc8a39d51f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4558bef2-2c41-41a3-b248-b2c816d332a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4558bef2-2c41-41a3-b248-b2c816d332a4.jpg?1",
             "name": "Death Pit Offering",
             "text": "",
             "colours": [
@@ -8833,7 +8833,7 @@
         },
         {
             "id": "f8451336-5b7b-57d6-9c75-d8ed0a37b91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3f1b6e-6177-4e14-a51a-a01a44e357b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3f1b6e-6177-4e14-a51a-a01a44e357b2.jpg?1",
             "name": "Death Pits of Rath",
             "text": "Whenever a creature is dealt damage, destroy it. It can't be regenerated.",
             "colours": [
@@ -8868,7 +8868,7 @@
         },
         {
             "id": "2b10462a-0a93-5dbe-95b0-0c4f7f43d43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13af256-c9bd-4c44-b5f7-60b8d8efba75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13af256-c9bd-4c44-b5f7-60b8d8efba75.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "b373cb88-1776-51df-b03d-97e19e46a972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c30cf13-4be5-4ffd-a790-9fe3f5f71374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c30cf13-4be5-4ffd-a790-9fe3f5f71374.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8938,7 +8938,7 @@
         },
         {
             "id": "41a5bdb1-8546-5733-9988-1425ba6e8ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c01d707-36b4-44c8-b91a-3b059e69aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c01d707-36b4-44c8-b91a-3b059e69aacb.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8973,7 +8973,7 @@
         },
         {
             "id": "347a9766-ef3d-5916-87af-20b00ebb5a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a4e022-a5d9-4798-8f04-39c6ce627761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a4e022-a5d9-4798-8f04-39c6ce627761.jpg?1",
             "name": "Deathgazer",
             "text": "Whenever Deathgazer blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -9008,7 +9008,7 @@
         },
         {
             "id": "5f958e7f-85ec-5640-89b5-278537d2a7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dcc58fb-0c13-449c-b3ae-d4e009ea11e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dcc58fb-0c13-449c-b3ae-d4e009ea11e4.jpg?1",
             "name": "Deathgazer",
             "text": "",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "8a192613-0181-586d-a421-6bc25f67a790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4c5c2f-0c1e-44e8-a7f8-2dc2954eacd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4c5c2f-0c1e-44e8-a7f8-2dc2954eacd8.jpg?1",
             "name": "Deepwood Ghoul",
             "text": "Pay 2 life: Regenerate Deepwood Ghoul.",
             "colours": [
@@ -9078,7 +9078,7 @@
         },
         {
             "id": "f3501a5b-2f85-5706-b139-62a26b085569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8ac7d-beca-4ac1-b9f1-3a5a29ca901e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8ac7d-beca-4ac1-b9f1-3a5a29ca901e.jpg?1",
             "name": "Deepwood Ghoul",
             "text": "",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "8fa77e4a-0a34-586a-98bf-7e4d9aa1ae8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7e0f9b-2c02-4e9a-ab86-270fad193de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7e0f9b-2c02-4e9a-ab86-270fad193de0.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "c668e67e-4fde-5eb7-96b5-52c01e8d2caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ff789a-ce9f-489a-8c17-6eea0c947672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ff789a-ce9f-489a-8c17-6eea0c947672.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "65619b96-4f0a-5ce0-8399-f719a440e225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fef91f-3044-4c6e-b090-c3819ee61b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fef91f-3044-4c6e-b090-c3819ee61b9c.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons.",
             "colours": [
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "bc71203d-f8d2-5b4c-ac41-45242326d622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c1119-c273-4051-9093-780b1fc144ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c1119-c273-4051-9093-780b1fc144ad.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "8400ccf4-ad80-52ef-a58f-b9aebfc5bd44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf9c1bd-bbda-4b4f-8b72-c73d24018c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf9c1bd-bbda-4b4f-8b72-c73d24018c7a.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "d1b66230-5b20-51b6-af86-2ce4ae0d3a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7aa7d-0d68-4b53-981f-1505f0dab055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7aa7d-0d68-4b53-981f-1505f0dab055.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "bce3457c-5349-5cca-8644-11393af17c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0721a-dc1f-42e4-a12a-2ecb356f9339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0721a-dc1f-42e4-a12a-2ecb356f9339.jpg?1",
             "name": "Dusk Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "44745a7a-a961-5828-89cd-45f5c3d6056d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ad4029-6b87-4bf1-a221-1720cd85bea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ad4029-6b87-4bf1-a221-1720cd85bea0.jpg?1",
             "name": "Dusk Imp",
             "text": "",
             "colours": [
@@ -9397,7 +9397,7 @@
         },
         {
             "id": "6092cc73-31d0-53f5-b5fe-41c003419e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f7d29-9c73-4b5e-a6fd-5608bb737278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f7d29-9c73-4b5e-a6fd-5608bb737278.jpg?1",
             "name": "Eastern Paladin",
             "text": "{B}{B}, {T}: Destroy target green creature.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "73fcd1d2-a94a-50e7-8bec-623af0d06e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a3f4e-ceb9-43aa-9491-a5219a8744d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a3f4e-ceb9-43aa-9491-a5219a8744d3.jpg?1",
             "name": "Eastern Paladin",
             "text": "",
             "colours": [
@@ -9471,7 +9471,7 @@
         },
         {
             "id": "1df8fab1-2771-5356-b0a8-9ac2094e827b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ecbc8-767b-475c-bb74-2abc0da5d745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ecbc8-767b-475c-bb74-2abc0da5d745.jpg?1",
             "name": "Execute",
             "text": "Destroy target white creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "de35097f-8946-535a-a9fe-f12a42404528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e73d4-7e1c-48fd-8b6d-b66a2105a742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e73d4-7e1c-48fd-8b6d-b66a2105a742.jpg?1",
             "name": "Execute",
             "text": "",
             "colours": [
@@ -9537,7 +9537,7 @@
         },
         {
             "id": "12617181-75fb-5adf-9e20-e1bc392d86fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c574bf0-0fad-4cde-a75e-88d899a890ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c574bf0-0fad-4cde-a75e-88d899a890ee.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -9572,7 +9572,7 @@
         },
         {
             "id": "e3b13925-ff13-58e9-a311-c4e8da1830ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e4aa36-cf55-4c7c-94c3-337a3da10bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e4aa36-cf55-4c7c-94c3-337a3da10bb3.jpg?1",
             "name": "Fallen Angel",
             "text": "",
             "colours": [
@@ -9607,7 +9607,7 @@
         },
         {
             "id": "6abbfade-db22-51c5-bc21-dad7e68fde91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18630f0-29de-4437-9c69-5f61b6f6fda5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18630f0-29de-4437-9c69-5f61b6f6fda5.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9642,7 +9642,7 @@
         },
         {
             "id": "c9ed8bb9-ba92-5242-a6a7-f158cdcc17c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e5ccd6-8b39-4bbf-b2a1-901a6058498f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e5ccd6-8b39-4bbf-b2a1-901a6058498f.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -9677,7 +9677,7 @@
         },
         {
             "id": "0d73fa6f-f730-551d-a15a-09b4b1857f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b79ee0-0a1b-474c-b68c-6e4ec69c018c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b79ee0-0a1b-474c-b68c-6e4ec69c018c.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "610eda2b-adf4-5b0f-95b2-6daf3abb655d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2c5ede-4110-41c8-87f1-6552c1743223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2c5ede-4110-41c8-87f1-6552c1743223.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "9e629aaf-aa6c-5f2b-b6e9-99a80d8832c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4730915e-db5a-4a66-b570-aeaaa7c4ca3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4730915e-db5a-4a66-b570-aeaaa7c4ca3d.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "74580ec6-0bcf-554b-92f4-14cf3b55af0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce06092-a69c-4e4b-a8e7-b07b63f0d22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce06092-a69c-4e4b-a8e7-b07b63f0d22c.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "",
             "colours": [
@@ -9817,7 +9817,7 @@
         },
         {
             "id": "12772d61-645b-5a52-85bb-21775a99353e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87fe9b8-3dae-4b22-bceb-be48cd082921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87fe9b8-3dae-4b22-bceb-be48cd082921.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control is put into a graveyard from play, each other player sacrifices a creature.",
             "colours": [
@@ -9850,7 +9850,7 @@
         },
         {
             "id": "05196746-a8bb-5a5b-ad5d-d77173fe0235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655a654b-87e8-41af-b9db-54afee485946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655a654b-87e8-41af-b9db-54afee485946.jpg?1",
             "name": "Grave Pact",
             "text": "",
             "colours": [
@@ -9883,7 +9883,7 @@
         },
         {
             "id": "61af508f-8cc1-536e-bcec-93e95d4309fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679472e-39a5-4a28-a04e-962c393fbcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679472e-39a5-4a28-a04e-962c393fbcc4.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9918,7 +9918,7 @@
         },
         {
             "id": "bec4f032-a627-5ca2-bbd7-5804027073e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdf87dd-6a29-4312-9fd0-5493d65a5856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdf87dd-6a29-4312-9fd0-5493d65a5856.jpg?1",
             "name": "Gravedigger",
             "text": "",
             "colours": [
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "e3ef6198-c6cf-5976-a4cb-8b750c52d69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3eddb-cd89-4cec-92b4-4006dece36a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3eddb-cd89-4cec-92b4-4006dece36a8.jpg?1",
             "name": "Larceny",
             "text": "Whenever a creature you control deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "8ac9f35a-b63c-510b-8302-1b964b49b3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7c8012-1adf-4af7-88aa-09c1c608687f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7c8012-1adf-4af7-88aa-09c1c608687f.jpg?1",
             "name": "Larceny",
             "text": "",
             "colours": [
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "744c173f-9d20-5829-90d3-9318e578a75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf28d4-939c-495a-a6eb-e4f52a62e150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf28d4-939c-495a-a6eb-e4f52a62e150.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10054,7 +10054,7 @@
         },
         {
             "id": "97c8c9dc-d6ca-558c-9a37-c1ddbad45d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b500c957-0ca0-4f68-a046-74dedf960368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b500c957-0ca0-4f68-a046-74dedf960368.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "1d439ffa-c186-5df4-9888-c45502f6073c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d4b539-0e45-49ca-96fa-5df1ccb3b235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d4b539-0e45-49ca-96fa-5df1ccb3b235.jpg?1",
             "name": "Lord of the Undead",
             "text": "All Zombies get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -10124,7 +10124,7 @@
         },
         {
             "id": "ea810e66-baf0-54ba-9b8b-63d2d5c8074d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb669a-0475-44f1-9563-f877e577a07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb669a-0475-44f1-9563-f877e577a07a.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "d880727c-b545-5fe1-a142-38eb2f19a4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2ee72e-68d3-46b9-abc6-08532ce412b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2ee72e-68d3-46b9-abc6-08532ce412b2.jpg?1",
             "name": "Maggot Carrier",
             "text": "When Maggot Carrier comes into play, each player loses 1 life.",
             "colours": [
@@ -10194,7 +10194,7 @@
         },
         {
             "id": "a02edc5b-5eeb-5a49-bbf2-d3518082b715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa250a2-f3e2-42b0-aea0-7816f60f4d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa250a2-f3e2-42b0-aea0-7816f60f4d1d.jpg?1",
             "name": "Maggot Carrier",
             "text": "",
             "colours": [
@@ -10229,7 +10229,7 @@
         },
         {
             "id": "e980294c-3354-5499-9082-b3bc1792b862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d8a020-fa68-4db6-bbe8-671bff043e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d8a020-fa68-4db6-bbe8-671bff043e06.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card from his or her hand, Megrim deals 2 damage to that player.",
             "colours": [
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "e6c28b71-0ebd-5535-b0bd-18a702b0d9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d6f7d-ced6-414d-89d0-792975548cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d6f7d-ced6-414d-89d0-792975548cb7.jpg?1",
             "name": "Megrim",
             "text": "",
             "colours": [
@@ -10295,7 +10295,7 @@
         },
         {
             "id": "6d55a521-b18a-58ff-a31e-1d8a79e1dc36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b780692-9c74-4283-a1ca-63f991dcc2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b780692-9c74-4283-a1ca-63f991dcc2c3.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards from his or her hand.",
             "colours": [
@@ -10328,7 +10328,7 @@
         },
         {
             "id": "c999c2e5-06d4-5ac8-916e-73fe93cb12df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77bf706-ec76-429a-b103-35b7cb445a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77bf706-ec76-429a-b103-35b7cb445a62.jpg?1",
             "name": "Mind Rot",
             "text": "",
             "colours": [
@@ -10361,7 +10361,7 @@
         },
         {
             "id": "b614070c-0125-5dca-900a-446ad984c21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76da89df-edb9-482c-a3bb-e7cf650990cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76da89df-edb9-482c-a3bb-e7cf650990cc.jpg?1",
             "name": "Mind Slash",
             "text": "{B}, Sacrifice a creature: Target opponent reveals his or her hand. Choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -10394,7 +10394,7 @@
         },
         {
             "id": "ec1ccc56-f25e-5122-bbb3-925828e70c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf2d72-9661-4a6e-82cb-b2b2aabd3e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf2d72-9661-4a6e-82cb-b2b2aabd3e9c.jpg?1",
             "name": "Mind Slash",
             "text": "",
             "colours": [
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "1f1b2358-cd32-5d11-bdf3-d7351eca64b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86a26e9-e4cb-452a-9263-489d57233d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86a26e9-e4cb-452a-9263-489d57233d41.jpg?1",
             "name": "Mind Sludge",
             "text": "Target player discards a card from his or her hand for each Swamp you control.",
             "colours": [
@@ -10460,7 +10460,7 @@
         },
         {
             "id": "61c6803c-e2fc-5762-9c81-d0816b8cad28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd44da9-0f97-45f4-8f51-606af042549d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd44da9-0f97-45f4-8f51-606af042549d.jpg?1",
             "name": "Mind Sludge",
             "text": "",
             "colours": [
@@ -10493,7 +10493,7 @@
         },
         {
             "id": "24e21135-9288-5899-86d3-5340561bd4e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063ed19-494b-4199-9120-d479bfcb625a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063ed19-494b-4199-9120-d479bfcb625a.jpg?1",
             "name": "Murderous Betrayal",
             "text": "{B}{B}, Pay half your life rounded up: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -10526,7 +10526,7 @@
         },
         {
             "id": "f0a728b1-51fe-59de-b0be-41f8fdfaee23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a02af31-de74-4721-84b6-410ecced5fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a02af31-de74-4721-84b6-410ecced5fa8.jpg?1",
             "name": "Murderous Betrayal",
             "text": "",
             "colours": [
@@ -10559,7 +10559,7 @@
         },
         {
             "id": "d2143b22-d2cd-5e7b-9cce-06ede30e453f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358efb1e-0366-4943-9a25-6a356e48773c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358efb1e-0366-4943-9a25-6a356e48773c.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -10592,7 +10592,7 @@
         },
         {
             "id": "2a84f4b3-3c1e-55a8-b92b-b654cfbe961d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699bdf95-7202-48ee-a9c8-be34e77b4028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699bdf95-7202-48ee-a9c8-be34e77b4028.jpg?1",
             "name": "Nausea",
             "text": "",
             "colours": [
@@ -10625,7 +10625,7 @@
         },
         {
             "id": "f3c53ead-2f9b-5b45-92e8-689aaf03b8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0d60f-0824-4498-81da-2c65980e3f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0d60f-0824-4498-81da-2c65980e3f98.jpg?1",
             "name": "Nekrataal",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Nekrataal comes into play, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "420878e6-61f7-5953-a0ce-7cd142946a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d195ba-9e07-43b1-b49b-b5706cd14bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d195ba-9e07-43b1-b49b-b5706cd14bc5.jpg?1",
             "name": "Nekrataal",
             "text": "",
             "colours": [
@@ -10697,7 +10697,7 @@
         },
         {
             "id": "8e686f41-6493-561e-a0c9-e859e118db73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd088c4d-3e21-4979-b30f-4ec98a6c81df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd088c4d-3e21-4979-b30f-4ec98a6c81df.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -10733,7 +10733,7 @@
         },
         {
             "id": "101f243c-8c3b-5870-8fd1-deb4f44c00cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c79db0-731a-4aa5-b69f-f21e031815d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c79db0-731a-4aa5-b69f-f21e031815d4.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -10769,7 +10769,7 @@
         },
         {
             "id": "bafb3960-e71a-56a5-8330-18cdbfda63ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c39fda-9a33-4464-99b0-4dbbf5eb7e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c39fda-9a33-4464-99b0-4dbbf5eb7e2a.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Target player reveals his or her hand and discards all cards of that color from it.",
             "colours": [
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "1f1fbe61-6448-591e-86cb-d8a5a9e72c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a01c43-0c2f-4f47-a8c3-a3be83120ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a01c43-0c2f-4f47-a8c3-a3be83120ee1.jpg?1",
             "name": "Persecute",
             "text": "",
             "colours": [
@@ -10835,7 +10835,7 @@
         },
         {
             "id": "c37e6414-a26c-5c63-86ab-f7b436d10429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1cc51f-91bc-4c0a-8fee-84eef1479cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1cc51f-91bc-4c0a-8fee-84eef1479cd8.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life. (Your upkeep step is after you untap and before you draw.)",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "6d03e966-8912-558e-b729-3e759b082522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd89d691-fa7d-41d8-b21a-95749f5268cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd89d691-fa7d-41d8-b21a-95749f5268cf.jpg?1",
             "name": "Phyrexian Arena",
             "text": "",
             "colours": [
@@ -10901,7 +10901,7 @@
         },
         {
             "id": "08c6ad5a-1f57-5e85-8850-d371b38957be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284f9e91-9318-44d9-995b-8c00752a3b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284f9e91-9318-44d9-995b-8c00752a3b01.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "{T}, Sacrifice Phyrexian Plaguelord: Target creature gets -4/-4 until end of turn.\nSacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "20dc276a-cd1c-5dc4-a681-5c2a18867760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3e2495-f8c9-4fcf-9a25-7cb591b06752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3e2495-f8c9-4fcf-9a25-7cb591b06752.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "c5a3d86b-d03b-50e3-b2ff-f4cbf0a70631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1476320-efed-433c-adad-cda2d2a3997f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1476320-efed-433c-adad-cda2d2a3997f.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -11008,7 +11008,7 @@
         },
         {
             "id": "8f21b579-cf67-5e61-8f3d-f31bb16bf6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c651140-4407-49a4-b46d-ccdaebf76706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c651140-4407-49a4-b46d-ccdaebf76706.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -11043,7 +11043,7 @@
         },
         {
             "id": "c1411478-7542-5aab-a020-d1b48d14fb23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056be80b-54df-4a9e-8ccb-1e576a001d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056be80b-54df-4a9e-8ccb-1e576a001d7c.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -11076,7 +11076,7 @@
         },
         {
             "id": "d0b8655c-2bb2-51a7-b92a-249f02d02df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdc23b-5dea-423f-9d62-75d30edbcc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdc23b-5dea-423f-9d62-75d30edbcc23.jpg?1",
             "name": "Plague Wind",
             "text": "",
             "colours": [
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "24161e9f-37d4-52ca-8560-0d53f1c3a9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45931d2-3fbf-4509-aa41-13d7839578df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45931d2-3fbf-4509-aa41-13d7839578df.jpg?1",
             "name": "Primeval Shambler",
             "text": "{B}: Primeval Shambler gets +1/+1 until end of turn.",
             "colours": [
@@ -11145,7 +11145,7 @@
         },
         {
             "id": "19e5738d-81ec-524f-835e-63932cf46bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e061c1-cdfe-4c0c-9043-3976f2a6b561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e061c1-cdfe-4c0c-9043-3976f2a6b561.jpg?1",
             "name": "Primeval Shambler",
             "text": "",
             "colours": [
@@ -11181,7 +11181,7 @@
         },
         {
             "id": "e5eaf617-eb62-5982-a300-3eb7d14a1952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc29ec6b-555e-4472-8bd4-d7e898edabce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc29ec6b-555e-4472-8bd4-d7e898edabce.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "930e5242-c78a-5930-983c-f8ed44cb1181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0ceb70-e680-45b1-b168-d014ee25da8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0ceb70-e680-45b1-b168-d014ee25da8a.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -11247,7 +11247,7 @@
         },
         {
             "id": "98e532de-c3ef-52ea-927f-1d49ddb97c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0ece8-2598-40d4-a222-27e3b34c01a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0ece8-2598-40d4-a222-27e3b34c01a1.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card from his or her hand.",
             "colours": [
@@ -11282,7 +11282,7 @@
         },
         {
             "id": "996f6041-988e-56ce-a56e-900f5f4bdbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c971b-60f6-4757-bdb3-d43102f57f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c971b-60f6-4757-bdb3-d43102f57f3f.jpg?1",
             "name": "Ravenous Rats",
             "text": "",
             "colours": [
@@ -11317,7 +11317,7 @@
         },
         {
             "id": "027b35ca-813a-56cf-8a68-36fa735faa21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed8b7de-a72f-429f-a99c-438af59de19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed8b7de-a72f-429f-a99c-438af59de19e.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11353,7 +11353,7 @@
         },
         {
             "id": "d5c664f5-ccd0-523f-9374-0fef3275e8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb382c6-d027-4875-bc36-dc9631ba3c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb382c6-d027-4875-bc36-dc9631ba3c0a.jpg?1",
             "name": "Royal Assassin",
             "text": "",
             "colours": [
@@ -11389,7 +11389,7 @@
         },
         {
             "id": "bd75aa7f-b4f8-5b17-8c60-2b38fa957aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd1dae-ccad-4f05-b720-b4b8600a298b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd1dae-ccad-4f05-b720-b4b8600a298b.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11424,7 +11424,7 @@
         },
         {
             "id": "714c2a56-100c-5325-bd8e-9f1d7eb136ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26fc06-04c0-4e8a-a25d-ef4e85d847f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26fc06-04c0-4e8a-a25d-ef4e85d847f7.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11459,7 +11459,7 @@
         },
         {
             "id": "6a781c43-673c-5063-8141-3955e7df6918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf5fb1-391c-472a-8b06-503162e458d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf5fb1-391c-472a-8b06-503162e458d7.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, you lose 3 life.",
             "colours": [
@@ -11495,7 +11495,7 @@
         },
         {
             "id": "6b080a48-6b3a-555d-948a-8836b7c20a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249a548-0d1e-4965-8767-7e386203231c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249a548-0d1e-4965-8767-7e386203231c.jpg?1",
             "name": "Serpent Warrior",
             "text": "",
             "colours": [
@@ -11531,7 +11531,7 @@
         },
         {
             "id": "589687d7-79ff-5e79-9212-734b0a36b823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1cb775-3a45-4f2c-9c45-febda6434c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1cb775-3a45-4f2c-9c45-febda6434c59.jpg?1",
             "name": "Sever Soul",
             "text": "Destroy target nonblack creature. It can't be regenerated. You gain life equal to its toughness.",
             "colours": [
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "6d6a9e78-4edd-5c74-97d6-1f9130edac14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c25ea3-1f01-4dcd-9d2d-d7fb85712110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c25ea3-1f01-4dcd-9d2d-d7fb85712110.jpg?1",
             "name": "Sever Soul",
             "text": "",
             "colours": [
@@ -11597,7 +11597,7 @@
         },
         {
             "id": "a8adaf87-51d6-5e41-a7cc-2fb3fe137e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710a3e43-a56a-4a41-86b3-72d48d324bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710a3e43-a56a-4a41-86b3-72d48d324bf3.jpg?1",
             "name": "Severed Legion",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -11632,7 +11632,7 @@
         },
         {
             "id": "72676823-a499-5bde-a950-407ccdef5143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa369ce1-8440-48c0-96af-cda0e63ae1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa369ce1-8440-48c0-96af-cda0e63ae1e3.jpg?1",
             "name": "Severed Legion",
             "text": "",
             "colours": [
@@ -11667,7 +11667,7 @@
         },
         {
             "id": "3f281daa-6769-57d9-a224-f43ce20d98c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5a03c-8b5b-496e-81bf-0d6e36960907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5a03c-8b5b-496e-81bf-0d6e36960907.jpg?1",
             "name": "Slay",
             "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -11700,7 +11700,7 @@
         },
         {
             "id": "29884087-2b32-5722-93b3-a9753cb92e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b01f4-fa93-4aaf-9ea0-9a0a5f9e9783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b01f4-fa93-4aaf-9ea0-9a0a5f9e9783.jpg?1",
             "name": "Slay",
             "text": "",
             "colours": [
@@ -11733,7 +11733,7 @@
         },
         {
             "id": "0b3b0043-c820-5116-b70c-edbbd788891e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b341b3-88d3-4ddc-8fa8-b15596b1b475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b341b3-88d3-4ddc-8fa8-b15596b1b475.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -11766,7 +11766,7 @@
         },
         {
             "id": "407f6878-2ea8-5302-baa3-e533e7b1bdea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b144df1-ae8f-49d0-926c-0d2dfd53310b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b144df1-ae8f-49d0-926c-0d2dfd53310b.jpg?1",
             "name": "Soul Feast",
             "text": "",
             "colours": [
@@ -11799,7 +11799,7 @@
         },
         {
             "id": "4a0588f0-f90d-5b51-8b40-8957253777ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711dfcd8-3083-4876-ac3f-1f7c6924382a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711dfcd8-3083-4876-ac3f-1f7c6924382a.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -11836,7 +11836,7 @@
         },
         {
             "id": "5ad31076-f31a-5594-a8c5-c8887e12666f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf974056-2f7a-4b2c-8b39-a371a322037b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf974056-2f7a-4b2c-8b39-a371a322037b.jpg?1",
             "name": "Spineless Thug",
             "text": "",
             "colours": [
@@ -11873,7 +11873,7 @@
         },
         {
             "id": "d6472d57-e9b1-589d-ac87-7ee22ec5a15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2690a627-23c5-46a4-b508-a5bc6ecc08d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2690a627-23c5-46a4-b508-a5bc6ecc08d7.jpg?1",
             "name": "Swarm of Rats",
             "text": "Swarm of Rats's power is equal to the number of Rats you control.",
             "colours": [
@@ -11908,7 +11908,7 @@
         },
         {
             "id": "16b81bf6-835a-5bdd-8171-33a213f93fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6b7304-6b3f-4c1c-a936-d1a1e0ec21f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6b7304-6b3f-4c1c-a936-d1a1e0ec21f0.jpg?1",
             "name": "Swarm of Rats",
             "text": "",
             "colours": [
@@ -11943,7 +11943,7 @@
         },
         {
             "id": "1783edf1-8268-51db-9284-f43d41bf803f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda4c410-c19c-435d-bbb4-2448ea3eeb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda4c410-c19c-435d-bbb4-2448ea3eeb21.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -11976,7 +11976,7 @@
         },
         {
             "id": "7a793ec7-25c1-54ed-bc45-f5d6014b2c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f89e0-a577-4bd1-8cdf-9572896e6a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f89e0-a577-4bd1-8cdf-9572896e6a3d.jpg?1",
             "name": "Underworld Dreams",
             "text": "",
             "colours": [
@@ -12009,7 +12009,7 @@
         },
         {
             "id": "33538118-b109-5ecb-93cb-1ee5f964cc4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd14a78-d306-43b1-b824-e04c96ce9155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd14a78-d306-43b1-b824-e04c96ce9155.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchanted creature gets +2/+1.",
             "colours": [
@@ -12044,7 +12044,7 @@
         },
         {
             "id": "d43b1838-e3ee-5ad1-bfe7-441540e70d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f630bb-4880-4d19-8211-a035c4b38575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f630bb-4880-4d19-8211-a035c4b38575.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -12079,7 +12079,7 @@
         },
         {
             "id": "c056b8c6-3ada-51b8-af8f-aac2f1fa2b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5235e5-deb7-49eb-82a8-858d3ee7c91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5235e5-deb7-49eb-82a8-858d3ee7c91b.jpg?1",
             "name": "Vampiric Spirit",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Vampiric Spirit comes into play, you lose 4 life.",
             "colours": [
@@ -12114,7 +12114,7 @@
         },
         {
             "id": "da2c1120-a490-53d6-9af0-fc7cbac3cc06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4934546-a53c-41ee-98be-6bb6d9df1071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4934546-a53c-41ee-98be-6bb6d9df1071.jpg?1",
             "name": "Vampiric Spirit",
             "text": "",
             "colours": [
@@ -12149,7 +12149,7 @@
         },
         {
             "id": "56fefa97-dc6e-5a47-b999-e577f7ac8e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf7cf9e-cb8d-49ae-af5b-0da7f283e677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf7cf9e-cb8d-49ae-af5b-0da7f283e677.jpg?1",
             "name": "Vicious Hunger",
             "text": "Vicious Hunger deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -12182,7 +12182,7 @@
         },
         {
             "id": "bfa687e4-8ed1-54db-b68f-dbc8fb8794f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203c511-c149-4f37-ab89-7862a0cc7fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203c511-c149-4f37-ab89-7862a0cc7fa0.jpg?1",
             "name": "Vicious Hunger",
             "text": "",
             "colours": [
@@ -12215,7 +12215,7 @@
         },
         {
             "id": "c21e3947-024f-562d-94f3-02daa3338301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd41ebd-91a8-4972-8f93-3306e68519f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd41ebd-91a8-4972-8f93-3306e68519f9.jpg?1",
             "name": "Warped Devotion",
             "text": "Whenever a permanent is returned to a player's hand, that player discards a card from his or her hand.",
             "colours": [
@@ -12248,7 +12248,7 @@
         },
         {
             "id": "fc6683df-78ac-5636-be11-2e1f41e5091c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d889f-daba-494d-8e91-aa5c6e361f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d889f-daba-494d-8e91-aa5c6e361f3f.jpg?1",
             "name": "Warped Devotion",
             "text": "",
             "colours": [
@@ -12281,7 +12281,7 @@
         },
         {
             "id": "ae578b17-88b0-59af-89f4-bc4cd6732e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f829763-3dce-453f-a783-177ea085ee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f829763-3dce-453f-a783-177ea085ee01.jpg?1",
             "name": "Western Paladin",
             "text": "{B}{B}, {T}: Destroy target white creature.",
             "colours": [
@@ -12318,7 +12318,7 @@
         },
         {
             "id": "386e8533-09ef-5af9-a759-21221bf64204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015832d1-eed5-4b7c-98aa-8a985f733ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015832d1-eed5-4b7c-98aa-8a985f733ecb.jpg?1",
             "name": "Western Paladin",
             "text": "",
             "colours": [
@@ -12355,7 +12355,7 @@
         },
         {
             "id": "0d77168f-272a-5753-952c-a4294f1ee66a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed70fa9-b0ff-4874-ab81-75cd2f39cad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed70fa9-b0ff-4874-ab81-75cd2f39cad3.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -12388,7 +12388,7 @@
         },
         {
             "id": "b86b1746-f876-5f64-9d5b-05de2a29dbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f808f8-904d-48c3-a111-43425ab1b774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f808f8-904d-48c3-a111-43425ab1b774.jpg?1",
             "name": "Zombify",
             "text": "",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "2050d60c-5cc7-5c11-8a38-d270846a4803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c2a5d1-cdf0-4551-aad0-c6590fb3c018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c2a5d1-cdf0-4551-aad0-c6590fb3c018.jpg?1",
             "name": "Anaba Shaman",
             "text": "{R}, {T}: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -12457,7 +12457,7 @@
         },
         {
             "id": "dd9d287f-f544-5217-a401-9cf2c9d570cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142260bd-4e4f-4057-b124-4744cea698d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142260bd-4e4f-4057-b124-4744cea698d7.jpg?1",
             "name": "Anaba Shaman",
             "text": "",
             "colours": [
@@ -12493,7 +12493,7 @@
         },
         {
             "id": "74ef6c88-8717-53e5-b805-bcc6847283d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46092f3f-7ef9-4967-b47b-40747a8cf37d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46092f3f-7ef9-4967-b47b-40747a8cf37d.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12529,7 +12529,7 @@
         },
         {
             "id": "9b67a7a4-0360-540d-b3b1-b4406e5a69ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e1d65-c95d-4400-99a4-9aea1745e489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e1d65-c95d-4400-99a4-9aea1745e489.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12565,7 +12565,7 @@
         },
         {
             "id": "61101fe8-cd71-5562-8f95-2236634522ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de4525e-6c9d-4396-9280-6fed9802123a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de4525e-6c9d-4396-9280-6fed9802123a.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -12598,7 +12598,7 @@
         },
         {
             "id": "042e8ba3-3bb3-5b39-860b-193d2c873a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c16f310-a492-4cea-86d2-b0ba5df9891b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c16f310-a492-4cea-86d2-b0ba5df9891b.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "d5e20783-c30f-57d5-bbac-b2f297ed1698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d75a5e3-4bec-4c2c-a9ad-f894cde292fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d75a5e3-4bec-4c2c-a9ad-f894cde292fd.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -12664,7 +12664,7 @@
         },
         {
             "id": "c203a28d-5e6f-561a-91ff-c817187de495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf2de3-77ff-4dd6-882f-b8bebabb2374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf2de3-77ff-4dd6-882f-b8bebabb2374.jpg?1",
             "name": "Blood Moon",
             "text": "",
             "colours": [
@@ -12697,7 +12697,7 @@
         },
         {
             "id": "eda8364c-ea94-5303-b473-03bf98bb51cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b021f1ea-4db1-40fb-a5dc-af13be53ad15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b021f1ea-4db1-40fb-a5dc-af13be53ad15.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "{T}, Sacrifice a creature: Bloodshot Cyclops deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -12733,7 +12733,7 @@
         },
         {
             "id": "1de7eb80-648e-5860-8240-1cd94f8981d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a2cc8b-4244-46ba-bf58-c2005c3678e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a2cc8b-4244-46ba-bf58-c2005c3678e8.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "",
             "colours": [
@@ -12769,7 +12769,7 @@
         },
         {
             "id": "5f5757dc-f4e3-5ba1-bd44-9a0493c34ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0087c-4e0f-4547-b441-b5a517c00b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0087c-4e0f-4547-b441-b5a517c00b91.jpg?1",
             "name": "Boil",
             "text": "Destroy all Islands.",
             "colours": [
@@ -12802,7 +12802,7 @@
         },
         {
             "id": "714234db-493b-5fee-a437-c544333d9feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23ce7c-9b25-4858-8b59-643892ab0406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23ce7c-9b25-4858-8b59-643892ab0406.jpg?1",
             "name": "Boil",
             "text": "",
             "colours": [
@@ -12835,7 +12835,7 @@
         },
         {
             "id": "d52849d8-4547-539b-9ebc-980041e9c3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a761bfc-71dc-40be-8184-6e0be2f25d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a761bfc-71dc-40be-8184-6e0be2f25d07.jpg?1",
             "name": "Canyon Wildcat",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -12870,7 +12870,7 @@
         },
         {
             "id": "b0712c9f-a5d2-526f-b290-7718f48acde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acfd70-b866-44c8-862d-f66e28fb61bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acfd70-b866-44c8-862d-f66e28fb61bf.jpg?1",
             "name": "Canyon Wildcat",
             "text": "",
             "colours": [
@@ -12905,7 +12905,7 @@
         },
         {
             "id": "d0527d8b-afb4-5c39-919c-a703781bb536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654472-b9b7-48aa-98d3-611807cf6d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654472-b9b7-48aa-98d3-611807cf6d88.jpg?1",
             "name": "Cinder Wall",
             "text": "(Walls can't attack.)\nWhen Cinder Wall blocks, destroy it at end of combat.",
             "colours": [
@@ -12940,7 +12940,7 @@
         },
         {
             "id": "2f2eb43e-c490-59c0-9115-16d2f446bdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1aa661-e00f-4d53-adcc-717e26dc97be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1aa661-e00f-4d53-adcc-717e26dc97be.jpg?1",
             "name": "Cinder Wall",
             "text": "",
             "colours": [
@@ -12975,7 +12975,7 @@
         },
         {
             "id": "96d2c937-4149-5b18-be00-eef938df442c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09770e0-24c0-4842-b31b-61e746ed89d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09770e0-24c0-4842-b31b-61e746ed89d7.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -13008,7 +13008,7 @@
         },
         {
             "id": "3e38fcf7-dffe-5740-8245-aef48d2e7728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3248d216-24dc-4e1b-ac35-af2809259e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3248d216-24dc-4e1b-ac35-af2809259e27.jpg?1",
             "name": "Demolish",
             "text": "",
             "colours": [
@@ -13041,7 +13041,7 @@
         },
         {
             "id": "d0dc61d1-5e6e-55f8-9801-539a2bad0290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d17787-1f59-4e88-ba57-e69f02bb3ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d17787-1f59-4e88-ba57-e69f02bb3ffe.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "{T}: Destroy target Wall.",
             "colours": [
@@ -13076,7 +13076,7 @@
         },
         {
             "id": "1452240b-46bd-5b8c-8738-0fda1ad5c4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f154b0-0ff2-4238-83d6-c336c5625f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f154b0-0ff2-4238-83d6-c336c5625f27.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "",
             "colours": [
@@ -13111,7 +13111,7 @@
         },
         {
             "id": "4b1125a2-a6f9-5861-8092-dda22088ae9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1e6973-003a-4f3e-b793-2e59519b1b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1e6973-003a-4f3e-b793-2e59519b1b8c.jpg?1",
             "name": "Enrage",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -13144,7 +13144,7 @@
         },
         {
             "id": "2a76f7e3-2e78-5e0e-a1b4-7f321fbebd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a415934-9e8c-456a-9fa9-e46d81d997f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a415934-9e8c-456a-9fa9-e46d81d997f0.jpg?1",
             "name": "Enrage",
             "text": "",
             "colours": [
@@ -13177,7 +13177,7 @@
         },
         {
             "id": "0f0720f1-f61a-54a5-bcbf-81e336bc0a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827a2e80-68ef-4d13-ba89-a5ea33d70cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827a2e80-68ef-4d13-ba89-a5ea33d70cc4.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all Plains.",
             "colours": [
@@ -13210,7 +13210,7 @@
         },
         {
             "id": "87c65771-a310-5897-a1a1-496c867b72e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaf72c-8a3a-42fd-811d-25a5cd753da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaf72c-8a3a-42fd-811d-25a5cd753da0.jpg?1",
             "name": "Flashfires",
             "text": "",
             "colours": [
@@ -13243,7 +13243,7 @@
         },
         {
             "id": "f6b5899f-46af-5b8b-9230-49303ddf0c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b41e1a5-cd40-493a-af70-6820e92b2673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b41e1a5-cd40-493a-af70-6820e92b2673.jpg?1",
             "name": "Furnace of Rath",
             "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -13276,7 +13276,7 @@
         },
         {
             "id": "666dc2a8-24e7-565b-8d42-dc20671dc40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089d0d6e-f5fd-4c44-a2d0-b9e4670c4b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089d0d6e-f5fd-4c44-a2d0-b9e4670c4b66.jpg?1",
             "name": "Furnace of Rath",
             "text": "",
             "colours": [
@@ -13309,7 +13309,7 @@
         },
         {
             "id": "4787f38b-2c3f-57df-8631-954dc96817bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6590436-d0f9-4c50-bab4-f7a094aa6e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6590436-d0f9-4c50-bab4-f7a094aa6e1a.jpg?1",
             "name": "Goblin Chariot",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -13345,7 +13345,7 @@
         },
         {
             "id": "2a2041c3-e751-559e-ab9f-af2d488d64c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e3d7fc-0a31-4119-bac1-5ddc1b0aafe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e3d7fc-0a31-4119-bac1-5ddc1b0aafe5.jpg?1",
             "name": "Goblin Chariot",
             "text": "",
             "colours": [
@@ -13381,7 +13381,7 @@
         },
         {
             "id": "d02834db-3e8e-5a56-b570-c67c2bc86988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db30ff-5f50-41b1-acdf-0a0e1a364410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db30ff-5f50-41b1-acdf-0a0e1a364410.jpg?1",
             "name": "Goblin Glider",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nGoblin Glider can't block.",
             "colours": [
@@ -13416,7 +13416,7 @@
         },
         {
             "id": "d60687c5-6c21-5980-8d42-b24baf7707f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d24d46-25b6-422a-af9f-e389ba4ec397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d24d46-25b6-422a-af9f-e389ba4ec397.jpg?1",
             "name": "Goblin Glider",
             "text": "",
             "colours": [
@@ -13451,7 +13451,7 @@
         },
         {
             "id": "cb5b435f-d561-55cc-862d-c2082ad96eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5448159-0516-4f35-a212-c3e1efa84c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5448159-0516-4f35-a212-c3e1efa84c71.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -13486,7 +13486,7 @@
         },
         {
             "id": "d29f31ab-7032-5f9b-b218-0062b31db6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c9eaf-022c-4803-acd1-b312af6c9277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c9eaf-022c-4803-acd1-b312af6c9277.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -13521,7 +13521,7 @@
         },
         {
             "id": "bd9dc052-cb03-5282-84d4-e6aa49424005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0837dd6a-d413-40a4-a684-ec637a4f3d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0837dd6a-d413-40a4-a684-ec637a4f3d4a.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "55747639-8c17-55aa-a230-6139152c729d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d34c5-2a25-4b2c-80b2-1205d0580fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d34c5-2a25-4b2c-80b2-1205d0580fcc.jpg?1",
             "name": "Goblin Raider",
             "text": "",
             "colours": [
@@ -13593,7 +13593,7 @@
         },
         {
             "id": "610788ad-34f1-5659-aa44-3a37e68c0ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63535f0e-dc14-420e-bcb7-b5ef8fafb93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63535f0e-dc14-420e-bcb7-b5ef8fafb93f.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nWhen a spell or ability an opponent controls causes you to discard Guerrilla Tactics from your hand, Guerrilla Tactics deals 4 damage to target creature or player.",
             "colours": [
@@ -13626,7 +13626,7 @@
         },
         {
             "id": "56827ed2-61e8-5218-974a-78fd424191dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81348b40-0fc5-4aeb-b8fa-30eaa2d528f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81348b40-0fc5-4aeb-b8fa-30eaa2d528f9.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "",
             "colours": [
@@ -13659,7 +13659,7 @@
         },
         {
             "id": "96a7573a-9a6c-5fe7-9231-5be133896fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf6e6c0-ddea-4d15-ab1a-5c7d9fa69d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf6e6c0-ddea-4d15-ab1a-5c7d9fa69d51.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "Hammer of Bogardan deals 3 damage to target creature or player.\n{2}{R}{R}{R}: Return Hammer of Bogardan from your graveyard to your hand. Play this ability only during your upkeep. (Your upkeep step is after you untap and before you draw.)",
             "colours": [
@@ -13692,7 +13692,7 @@
         },
         {
             "id": "7272a096-6690-5131-be2e-8cb964fa493c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff985e4-915a-4790-a3a7-4013c2b7c3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff985e4-915a-4790-a3a7-4013c2b7c3a5.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "3e92291b-1713-5743-a6b8-5ace45fde148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3afb143-fd69-4197-96f4-62d5d90a894c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3afb143-fd69-4197-96f4-62d5d90a894c.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13760,7 +13760,7 @@
         },
         {
             "id": "cd0dd1ea-f5b9-58e8-bab4-b4a12df78dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833128ae-927e-4767-8937-19d4ef789a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833128ae-927e-4767-8937-19d4ef789a58.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13795,7 +13795,7 @@
         },
         {
             "id": "639579bd-9032-5f3a-8a70-d6d543edd8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1a5428-9bb4-4e2b-ba94-fccd321ce537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1a5428-9bb4-4e2b-ba94-fccd321ce537.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops can't block.",
             "colours": [
@@ -13830,7 +13830,7 @@
         },
         {
             "id": "44799782-0b42-535e-8d07-e713ce5e3b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e402d-cdde-43fd-9899-2ea5d04d29b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e402d-cdde-43fd-9899-2ea5d04d29b7.jpg?1",
             "name": "Hulking Cyclops",
             "text": "",
             "colours": [
@@ -13865,7 +13865,7 @@
         },
         {
             "id": "34e92ab4-409d-542e-a55a-f0000e523c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6895de-9c74-49a0-a71c-1e55a6897dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6895de-9c74-49a0-a71c-1e55a6897dfa.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and each player.",
             "colours": [
@@ -13898,7 +13898,7 @@
         },
         {
             "id": "98f86f82-c495-5d1f-964a-4f717050823b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98644803-d626-436e-a86f-457005a30da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98644803-d626-436e-a86f-457005a30da9.jpg?1",
             "name": "Inferno",
             "text": "",
             "colours": [
@@ -13931,7 +13931,7 @@
         },
         {
             "id": "10e8247f-9a37-5782-8f05-fab70b81d241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddcf8a1-7337-41e9-b3b1-013f23b92eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddcf8a1-7337-41e9-b3b1-013f23b92eb0.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "ac1337bb-aadb-5ada-9772-80940d374eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83376e9-f3ac-4548-a4de-d471c158b1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83376e9-f3ac-4548-a4de-d471c158b1f0.jpg?1",
             "name": "Lava Axe",
             "text": "",
             "colours": [
@@ -13997,7 +13997,7 @@
         },
         {
             "id": "bde21cc3-60b5-5aa9-b7f5-22d568b89a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf83d5c7-a17c-4350-9432-92a01421b39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf83d5c7-a17c-4350-9432-92a01421b39a.jpg?1",
             "name": "Lava Hounds",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nWhen Lava Hounds comes into play, it deals 4 damage to you.",
             "colours": [
@@ -14032,7 +14032,7 @@
         },
         {
             "id": "33cad935-f412-5aaa-83dd-92350e8c7164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2010739e-005c-4a26-b744-03b9072792a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2010739e-005c-4a26-b744-03b9072792a4.jpg?1",
             "name": "Lava Hounds",
             "text": "",
             "colours": [
@@ -14067,7 +14067,7 @@
         },
         {
             "id": "b5d0d7d3-3e0e-5a00-82e1-57b8cac09735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a1067-8dff-485a-8781-39d61585c521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a1067-8dff-485a-8781-39d61585c521.jpg?1",
             "name": "Lesser Gargadon",
             "text": "Whenever Lesser Gargadon attacks or blocks, sacrifice a land.",
             "colours": [
@@ -14102,7 +14102,7 @@
         },
         {
             "id": "969e7dd8-70f9-531e-8c6e-e90b4020520a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7329366-a32e-40a8-a438-b92336231ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7329366-a32e-40a8-a438-b92336231ce0.jpg?1",
             "name": "Lesser Gargadon",
             "text": "",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "4685e3dd-97cc-5cbc-9346-57b3606bd2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20fee0e-93b8-4dc0-b156-8237271ae66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20fee0e-93b8-4dc0-b156-8237271ae66c.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -14170,7 +14170,7 @@
         },
         {
             "id": "c0dd11c0-7dab-5d72-9e90-9db408c95f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419e447f-dc16-4b01-b701-145c75e6047c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419e447f-dc16-4b01-b701-145c75e6047c.jpg?1",
             "name": "Lightning Blast",
             "text": "",
             "colours": [
@@ -14203,7 +14203,7 @@
         },
         {
             "id": "3e9178f1-a2a7-5a83-8d96-67d950d0773d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf2252-5ead-47df-8150-06c81dc47584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf2252-5ead-47df-8150-06c81dc47584.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "b1b0061c-049a-50be-b27d-1b1eb29b8fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4902b4c-4842-45aa-a165-cef86afdd795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4902b4c-4842-45aa-a165-cef86afdd795.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -14273,7 +14273,7 @@
         },
         {
             "id": "fe5fad8c-8bfe-5cdc-9694-b79bebb3297d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1042a84-4550-4ff3-933e-a9c2d26d1bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1042a84-4550-4ff3-933e-a9c2d26d1bd3.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
             "colours": [
@@ -14306,7 +14306,7 @@
         },
         {
             "id": "75b0d036-3b52-567b-9f14-f3a0b12ad3d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a54ce6-d1a7-4c25-8210-3dbd98c46460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a54ce6-d1a7-4c25-8210-3dbd98c46460.jpg?1",
             "name": "Mana Clash",
             "text": "",
             "colours": [
@@ -14339,7 +14339,7 @@
         },
         {
             "id": "6c43cf92-f1b3-5a1a-b768-46cda9eeb395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e98c12-b5b3-4b0f-af4e-7f2d28dc8637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e98c12-b5b3-4b0f-af4e-7f2d28dc8637.jpg?1",
             "name": "Mogg Sentry",
             "text": "Whenever an opponent plays a spell, Mogg Sentry gets +2/+2 until end of turn.",
             "colours": [
@@ -14375,7 +14375,7 @@
         },
         {
             "id": "5076cebd-83f0-5058-b57c-08bc9e5e9367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d54f2-8a3c-4d9a-be05-bbb45cc88e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d54f2-8a3c-4d9a-be05-bbb45cc88e3b.jpg?1",
             "name": "Mogg Sentry",
             "text": "",
             "colours": [
@@ -14411,7 +14411,7 @@
         },
         {
             "id": "975c2a8b-c29f-5dbc-8c3d-fb4edf8b1931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85f9623-5900-473c-a3b1-f98473b9a545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85f9623-5900-473c-a3b1-f98473b9a545.jpg?1",
             "name": "Obliterate",
             "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "442daa4e-18d4-5ea5-90e6-1bcce35fe49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1021bcbd-566c-4f31-b148-0517b96a63db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1021bcbd-566c-4f31-b148-0517b96a63db.jpg?1",
             "name": "Obliterate",
             "text": "",
             "colours": [
@@ -14477,7 +14477,7 @@
         },
         {
             "id": "331318cf-7132-5ca7-8e5d-6382d28dd180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1765dee9-ab94-4ca5-9cd7-cf8e228fdd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1765dee9-ab94-4ca5-9cd7-cf8e228fdd68.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "11d3cd10-554d-5354-b7bf-1f97f96a60c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c31b9d-903c-4b37-9d61-3c2fb49ee1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c31b9d-903c-4b37-9d61-3c2fb49ee1c2.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "",
             "colours": [
@@ -14547,7 +14547,7 @@
         },
         {
             "id": "42492f04-f176-5aad-9589-9ae0666527c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42641800-e209-4326-ae28-77ec83ac4b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42641800-e209-4326-ae28-77ec83ac4b75.jpg?1",
             "name": "Okk",
             "text": "Okk can't attack unless a creature with greater power also attacks.\nOkk can't block unless a creature with greater power also blocks.",
             "colours": [
@@ -14582,7 +14582,7 @@
         },
         {
             "id": "135bb565-b66e-5112-a164-7632e4a78f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737c35a-3f90-4ed6-bce5-5761879c2185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737c35a-3f90-4ed6-bce5-5761879c2185.jpg?1",
             "name": "Okk",
             "text": "",
             "colours": [
@@ -14617,7 +14617,7 @@
         },
         {
             "id": "56d9f9f0-2aa5-5857-86ef-161eb2c95b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d114ae-f574-45dd-903b-7d46d1121294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d114ae-f574-45dd-903b-7d46d1121294.jpg?1",
             "name": "Orcish Artillery",
             "text": "{T}: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -14653,7 +14653,7 @@
         },
         {
             "id": "851afd13-c902-5218-9650-720969940ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096e808-64a3-43b7-8555-28576fc574c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096e808-64a3-43b7-8555-28576fc574c1.jpg?1",
             "name": "Orcish Artillery",
             "text": "",
             "colours": [
@@ -14689,7 +14689,7 @@
         },
         {
             "id": "b0300477-5a9c-5860-ba72-3c1ebb63fc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3948e0-8597-4927-90ce-affa949e3013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3948e0-8597-4927-90ce-affa949e3013.jpg?1",
             "name": "Orcish Spy",
             "text": "{T}: Look at the top three cards of target player's library. (Put them back in the same order.)",
             "colours": [
@@ -14725,7 +14725,7 @@
         },
         {
             "id": "015b3367-32b0-5c99-8bf6-54ef622deecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab96aa0-8df8-461b-8f7e-5932748b2f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab96aa0-8df8-461b-8f7e-5932748b2f2a.jpg?1",
             "name": "Orcish Spy",
             "text": "",
             "colours": [
@@ -14761,7 +14761,7 @@
         },
         {
             "id": "7b732f3a-6904-56db-9b45-a6a111df4026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b65b86b-a346-4b86-bca4-83dae3f14c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b65b86b-a346-4b86-bca4-83dae3f14c1b.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -14794,7 +14794,7 @@
         },
         {
             "id": "9b83fd03-d3cb-509c-bf1d-7030d702f293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f599bb-d545-4bec-a7ef-daec69524c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f599bb-d545-4bec-a7ef-daec69524c62.jpg?1",
             "name": "Panic Attack",
             "text": "",
             "colours": [
@@ -14827,7 +14827,7 @@
         },
         {
             "id": "af6f8a52-8e3d-54c6-87cd-5d76f563b492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec6e8f-a8be-4efe-8082-d807378066b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec6e8f-a8be-4efe-8082-d807378066b1.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -14860,7 +14860,7 @@
         },
         {
             "id": "9fba626c-a83f-595e-981c-dab948183fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc79823f-7ae1-4c22-9c11-8c729eea6c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc79823f-7ae1-4c22-9c11-8c729eea6c4f.jpg?1",
             "name": "Pyroclasm",
             "text": "",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "320cc2d3-657c-5184-87d9-ca569602c401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabea8c3-630f-4b19-8d1e-47998b39866f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabea8c3-630f-4b19-8d1e-47998b39866f.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -14926,7 +14926,7 @@
         },
         {
             "id": "842cde7e-154f-5950-9675-93f6edcf70f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447231d2-31b3-4e4c-bc2e-ab97203ab205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447231d2-31b3-4e4c-bc2e-ab97203ab205.jpg?1",
             "name": "Pyrotechnics",
             "text": "",
             "colours": [
@@ -14959,7 +14959,7 @@
         },
         {
             "id": "ca14cead-4e84-56ba-9107-dfe2e5cb55b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165dc9fc-22b3-48ac-b446-5599af75917e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165dc9fc-22b3-48ac-b446-5599af75917e.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "8b9fc22d-4964-5a2a-ab7e-e832d01e499c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646c62b6-1dec-4ecd-acf0-8833c9c7f265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646c62b6-1dec-4ecd-acf0-8833c9c7f265.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -15031,7 +15031,7 @@
         },
         {
             "id": "dd9a2cbd-a429-51be-b8d0-a9b3b65b8d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a406184-b678-4afd-9599-d1d4f9c1d147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a406184-b678-4afd-9599-d1d4f9c1d147.jpg?1",
             "name": "Reflexes",
             "text": "Enchanted creature has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -15066,7 +15066,7 @@
         },
         {
             "id": "4576fc83-a1a7-5dbf-92ab-d0dfe58e2165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880dd2cd-fb7f-4398-afb6-08587130fb7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880dd2cd-fb7f-4398-afb6-08587130fb7a.jpg?1",
             "name": "Reflexes",
             "text": "",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "189cbd4a-d448-526d-95c2-71a0bea89230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e23c4c-f1f3-417c-a430-957e246a98ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e23c4c-f1f3-417c-a430-957e246a98ec.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -15134,7 +15134,7 @@
         },
         {
             "id": "b23ed661-542b-5130-9769-80e74192fce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58edf9f7-8e6a-49de-a2c0-b2ba8a8493f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58edf9f7-8e6a-49de-a2c0-b2ba8a8493f5.jpg?1",
             "name": "Relentless Assault",
             "text": "",
             "colours": [
@@ -15167,7 +15167,7 @@
         },
         {
             "id": "79daf872-b5ad-5dc2-b210-bbc60c13d28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d9c248-2360-4fdc-9a0f-49d350c11e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d9c248-2360-4fdc-9a0f-49d350c11e95.jpg?1",
             "name": "Ridgeline Rager",
             "text": "{R}: Ridgeline Rager gets +1/+0 until end of turn.",
             "colours": [
@@ -15202,7 +15202,7 @@
         },
         {
             "id": "2aec9fb7-399d-5eeb-8093-4d98013493b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b58c329-bd50-4b7c-80c8-77eaf0b40a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b58c329-bd50-4b7c-80c8-77eaf0b40a20.jpg?1",
             "name": "Ridgeline Rager",
             "text": "",
             "colours": [
@@ -15237,7 +15237,7 @@
         },
         {
             "id": "075809e2-9009-52de-b3bb-f00d8a83d543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805f1f4-ac45-404d-b52c-4d5eb019e24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805f1f4-ac45-404d-b52c-4d5eb019e24a.jpg?1",
             "name": "Rukh Egg",
             "text": "When Rukh Egg is put into a graveyard from play, put a 4/4 red Rukh creature token with flying into play at end of turn.",
             "colours": [
@@ -15273,7 +15273,7 @@
         },
         {
             "id": "f92a53f8-48ab-58b9-9268-e9efd55bbf40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2fbef-a340-4c08-9c77-a157948cacdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2fbef-a340-4c08-9c77-a157948cacdf.jpg?1",
             "name": "Rukh Egg",
             "text": "",
             "colours": [
@@ -15309,7 +15309,7 @@
         },
         {
             "id": "0acff7d5-929e-53ae-b62c-929879110b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85964eb-c586-4e62-9a19-6a665e6ad98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85964eb-c586-4e62-9a19-6a665e6ad98d.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -15344,7 +15344,7 @@
         },
         {
             "id": "e0dbc60b-e5a2-5dbd-8abe-c9150930a5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda983ca-3439-4eab-a2a3-ba8a69e1116e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda983ca-3439-4eab-a2a3-ba8a69e1116e.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "",
             "colours": [
@@ -15379,7 +15379,7 @@
         },
         {
             "id": "19aa2efc-43d6-5f7d-9308-b83c5e16e0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61afd3c5-7103-4247-8bb9-747532ae4265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61afd3c5-7103-4247-8bb9-747532ae4265.jpg?1",
             "name": "Searing Wind",
             "text": "Searing Wind deals 10 damage to target creature or player.",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "774e9fbd-e2d3-5872-ae0a-e56fd3a38ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037b513-a733-4184-91f4-5e5848120dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037b513-a733-4184-91f4-5e5848120dd6.jpg?1",
             "name": "Searing Wind",
             "text": "",
             "colours": [
@@ -15445,7 +15445,7 @@
         },
         {
             "id": "868ba23a-06fa-524a-b24c-a10c2e2a39e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91464144-afb8-4fff-bf5c-2d9bfca408ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91464144-afb8-4fff-bf5c-2d9bfca408ca.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card from your hand: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -15478,7 +15478,7 @@
         },
         {
             "id": "9dc469c5-d01f-55fe-9d5e-130d9e129b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261ab03-6e00-41b8-a863-2b72d1ffbb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261ab03-6e00-41b8-a863-2b72d1ffbb9a.jpg?1",
             "name": "Seismic Assault",
             "text": "",
             "colours": [
@@ -15511,7 +15511,7 @@
         },
         {
             "id": "e8c34d79-b4e0-5335-8e2c-401250a5f2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818401a7-593d-4f04-a782-9fa486b8c2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818401a7-593d-4f04-a782-9fa486b8c2f6.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -15544,7 +15544,7 @@
         },
         {
             "id": "18cbab56-a7fc-5a14-870f-4323ac0ee7b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7333d1-ecc6-4f7e-80f3-4a3f3dcfe374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7333d1-ecc6-4f7e-80f3-4a3f3dcfe374.jpg?1",
             "name": "Shatter",
             "text": "",
             "colours": [
@@ -15577,7 +15577,7 @@
         },
         {
             "id": "e488cdcd-dd89-5604-ad02-7429ec387eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac007d-1616-449c-92d5-1d321235e733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac007d-1616-449c-92d5-1d321235e733.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -15612,7 +15612,7 @@
         },
         {
             "id": "3c6d1c33-3107-57b8-9af6-e7a7091f9171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08a0542-f72a-422d-a8cf-3d37fdb5d375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08a0542-f72a-422d-a8cf-3d37fdb5d375.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -15647,7 +15647,7 @@
         },
         {
             "id": "1b9c897b-892b-5d33-8068-07b2c4527613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daef5f10-ccb5-4304-b04f-b52a7d2f4158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daef5f10-ccb5-4304-b04f-b52a7d2f4158.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -15680,7 +15680,7 @@
         },
         {
             "id": "3e363d59-e7ff-5f55-8cd9-5029ab6f797e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f568875-9ccb-487f-8977-cce816bb3a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f568875-9ccb-487f-8977-cce816bb3a28.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -15713,7 +15713,7 @@
         },
         {
             "id": "324d046e-0244-59b3-bf5c-8c90b4a4bd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fe44af-5d8f-44ee-b767-2267917cf4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fe44af-5d8f-44ee-b767-2267917cf4bf.jpg?1",
             "name": "Shock Troops",
             "text": "Sacrifice Shock Troops: Shock Troops deals 2 damage to target creature or player.",
             "colours": [
@@ -15749,7 +15749,7 @@
         },
         {
             "id": "abca2a5e-769a-5e99-a75a-6cbde062a6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c749a38c-8c58-4fdf-903d-6e05eb993858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c749a38c-8c58-4fdf-903d-6e05eb993858.jpg?1",
             "name": "Shock Troops",
             "text": "",
             "colours": [
@@ -15785,7 +15785,7 @@
         },
         {
             "id": "74f81e08-a8d1-5d27-8086-520a328ea6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfe2a9-1323-4f15-b2ce-d8dd404b914d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfe2a9-1323-4f15-b2ce-d8dd404b914d.jpg?1",
             "name": "Sizzle",
             "text": "Sizzle deals 3 damage to each opponent.",
             "colours": [
@@ -15818,7 +15818,7 @@
         },
         {
             "id": "03b6c50d-85d2-5046-bf52-4bc0e2f6ac53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d39efe8-9676-4e82-8e5e-0ed2f4bcbcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d39efe8-9676-4e82-8e5e-0ed2f4bcbcac.jpg?1",
             "name": "Sizzle",
             "text": "",
             "colours": [
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "8b338d79-c1b9-5534-ba5d-090af3896416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bf7f43-c8db-417e-8600-3124f5fab097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bf7f43-c8db-417e-8600-3124f5fab097.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -15884,7 +15884,7 @@
         },
         {
             "id": "c015a4f5-d61d-51c0-95cd-44e6cf965f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266d561f-b161-4a0f-952f-cce631b54962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266d561f-b161-4a0f-952f-cce631b54962.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -15917,7 +15917,7 @@
         },
         {
             "id": "eaf52524-c51e-5836-90b9-c295c506e895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe1060-3069-46b7-9a84-916d87b30e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe1060-3069-46b7-9a84-916d87b30e6e.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -15950,7 +15950,7 @@
         },
         {
             "id": "59f60c7d-598d-5ae4-99e3-b462f292c462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58bee47e-cd0f-422a-855d-325fa49879a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58bee47e-cd0f-422a-855d-325fa49879a7.jpg?1",
             "name": "Sudden Impact",
             "text": "",
             "colours": [
@@ -15983,7 +15983,7 @@
         },
         {
             "id": "d920e87a-9935-5cbf-b8ab-6d9fc1b42d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8ad32-a701-4b77-bb7e-0e440e4072da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8ad32-a701-4b77-bb7e-0e440e4072da.jpg?1",
             "name": "Thieves' Auction",
             "text": "Set aside all cards in play. Starting with you, each player chooses one of the cards set aside and puts it into play tapped under his or her control. Repeat this process until all those cards have been chosen.",
             "colours": [
@@ -16016,7 +16016,7 @@
         },
         {
             "id": "f721ecdd-b88f-5cc8-a271-694f442eadb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7c571-ef39-4b99-b5e0-01c145672053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7c571-ef39-4b99-b5e0-01c145672053.jpg?1",
             "name": "Thieves' Auction",
             "text": "",
             "colours": [
@@ -16049,7 +16049,7 @@
         },
         {
             "id": "88f17190-244e-5079-ac0a-6454704304d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47f27d-5a25-4d2a-b2a2-027b579b881b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47f27d-5a25-4d2a-b2a2-027b579b881b.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -16082,7 +16082,7 @@
         },
         {
             "id": "915e499a-0e2f-54cf-8e5b-e274c209e2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fef4049-8ec2-49c0-8a0a-1b057c558695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fef4049-8ec2-49c0-8a0a-1b057c558695.jpg?1",
             "name": "Tremor",
             "text": "",
             "colours": [
@@ -16115,7 +16115,7 @@
         },
         {
             "id": "ba962a93-2444-52ad-a909-dffaf3cf3547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe7c1b5-6077-4b6c-a26b-8201f49dad10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe7c1b5-6077-4b6c-a26b-8201f49dad10.jpg?1",
             "name": "Two-Headed Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{R}: Two-Headed Dragon gets +2/+0 until end of turn.\nTwo-Headed Dragon can't be blocked except by two or more creatures.\nTwo-Headed Dragon may block an additional creature.",
             "colours": [
@@ -16150,7 +16150,7 @@
         },
         {
             "id": "3bfae294-16cb-5984-840d-a6d9039624aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105068c1-a5e5-4248-82b6-a521ba1e5205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105068c1-a5e5-4248-82b6-a521ba1e5205.jpg?1",
             "name": "Two-Headed Dragon",
             "text": "",
             "colours": [
@@ -16185,7 +16185,7 @@
         },
         {
             "id": "ed2a09fa-0fd7-565f-b93e-c3d11dcac0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e80de4-1d8f-4a4a-8108-5d3c36dce07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e80de4-1d8f-4a4a-8108-5d3c36dce07b.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nAt end of turn, return Viashino Sandstalker to its owner's hand. (Return it only if it's in play.)",
             "colours": [
@@ -16221,7 +16221,7 @@
         },
         {
             "id": "c99e54c8-20c8-5b52-8703-3fc13fa3abb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14230e3a-2088-4ebc-bf09-4b438ee894ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14230e3a-2088-4ebc-bf09-4b438ee894ed.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "",
             "colours": [
@@ -16257,7 +16257,7 @@
         },
         {
             "id": "78530e0c-9fcc-5700-bb9f-fc5640571fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c47e6a-71d8-4eba-ad05-0e6745f81600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c47e6a-71d8-4eba-ad05-0e6745f81600.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to target creature or player.",
             "colours": [
@@ -16290,7 +16290,7 @@
         },
         {
             "id": "4c2ae22b-6247-541c-9dc6-be3c62e456f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d539abc6-d00a-4969-ae0f-feb189b90428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d539abc6-d00a-4969-ae0f-feb189b90428.jpg?1",
             "name": "Volcanic Hammer",
             "text": "",
             "colours": [
@@ -16323,7 +16323,7 @@
         },
         {
             "id": "6a98dcae-27d4-5593-adff-db94e42770ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718da336-ad97-41a6-86bd-4f124e2cc716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718da336-ad97-41a6-86bd-4f124e2cc716.jpg?1",
             "name": "Wall of Stone",
             "text": "(Walls can't attack.)",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "bcf7037d-e6a5-5b3a-a8c3-5cbc9bf45cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ccff-aa99-43d5-a5f7-877bc285e6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ccff-aa99-43d5-a5f7-877bc285e6b3.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -16393,7 +16393,7 @@
         },
         {
             "id": "01812e4a-2749-5fd6-92cc-77036c897192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715eea77-a7d7-4731-b706-3ea17bded7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715eea77-a7d7-4731-b706-3ea17bded7fd.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -16428,7 +16428,7 @@
         },
         {
             "id": "a19ff013-8746-56b0-be68-f8acab247dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b2fa1-9f0c-44cc-9d4a-692ffe7d603c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b2fa1-9f0c-44cc-9d4a-692ffe7d603c.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -16463,7 +16463,7 @@
         },
         {
             "id": "83bafe96-1f74-5c35-bb86-fbd9f5f7ea30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a9d7b8-c77e-48f3-89ce-1d5a6dc735e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a9d7b8-c77e-48f3-89ce-1d5a6dc735e7.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -16498,7 +16498,7 @@
         },
         {
             "id": "b354114d-ad66-50ac-8b33-0777d46c9200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c975c324-c96b-461e-9098-d278c01d4a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c975c324-c96b-461e-9098-d278c01d4a6d.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -16533,7 +16533,7 @@
         },
         {
             "id": "416185e9-798c-523c-bee2-d232362950f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3332b35c-fd4f-4195-baee-e759dee6a682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3332b35c-fd4f-4195-baee-e759dee6a682.jpg?1",
             "name": "Call of the Wild",
             "text": "{2}{G}{G}: Reveal the top card of your library. If it's a creature card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -16566,7 +16566,7 @@
         },
         {
             "id": "4082c0cc-3eed-5542-aeb8-f2a72ff4a4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447492df-3564-4ab1-aa4a-d247697015fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447492df-3564-4ab1-aa4a-d247697015fe.jpg?1",
             "name": "Call of the Wild",
             "text": "",
             "colours": [
@@ -16599,7 +16599,7 @@
         },
         {
             "id": "3c5e3197-98e3-50e1-b6a3-fc9ca413b2f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def682d0-6091-49c8-ac46-da0884b8cdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def682d0-6091-49c8-ac46-da0884b8cdb3.jpg?1",
             "name": "Canopy Spider",
             "text": "Canopy Spider may block as though it had flying.",
             "colours": [
@@ -16634,7 +16634,7 @@
         },
         {
             "id": "55970af1-98de-5127-8807-cb15eee05d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e8f4bf-2634-4f9e-9898-7cbb618c8230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e8f4bf-2634-4f9e-9898-7cbb618c8230.jpg?1",
             "name": "Canopy Spider",
             "text": "",
             "colours": [
@@ -16669,7 +16669,7 @@
         },
         {
             "id": "7f81e7bd-59fa-5e07-8bb4-4a4d05be57ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce4bab-6eb1-421f-b425-7bb0076defc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce4bab-6eb1-421f-b425-7bb0076defc7.jpg?1",
             "name": "Choke",
             "text": "Islands don't untap during their controllers' untap steps.",
             "colours": [
@@ -16702,7 +16702,7 @@
         },
         {
             "id": "ce768205-bd8e-5456-a771-de3edf743c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f8570d-0e7c-401e-8648-63cf0a88d8f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f8570d-0e7c-401e-8648-63cf0a88d8f9.jpg?1",
             "name": "Choke",
             "text": "",
             "colours": [
@@ -16735,7 +16735,7 @@
         },
         {
             "id": "dbdb25fe-cd9e-5a05-8336-9999c108ad5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccce9141-6c73-4e33-a72c-caa87cea7888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccce9141-6c73-4e33-a72c-caa87cea7888.jpg?1",
             "name": "Collective Unconscious",
             "text": "Draw a card for each creature you control.",
             "colours": [
@@ -16768,7 +16768,7 @@
         },
         {
             "id": "9ae7d60f-9ad6-52bb-b19f-411ea1a576e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a616822b-592c-455d-b35e-71e099450e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a616822b-592c-455d-b35e-71e099450e1a.jpg?1",
             "name": "Collective Unconscious",
             "text": "",
             "colours": [
@@ -16801,7 +16801,7 @@
         },
         {
             "id": "4ac37fee-e7c1-595e-8983-37b5eb259215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edc5392-0529-471c-858f-5602aabb626c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edc5392-0529-471c-858f-5602aabb626c.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16836,7 +16836,7 @@
         },
         {
             "id": "315db43c-f8c5-5086-b269-9f48615743ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56659a8-ca72-4343-9f98-770abdd08502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56659a8-ca72-4343-9f98-770abdd08502.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16871,7 +16871,7 @@
         },
         {
             "id": "391ab6cf-8a2c-5df9-b63d-a0ad19a111f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a053c7-650b-4b4a-b54d-082a194e3cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a053c7-650b-4b4a-b54d-082a194e3cc2.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -16904,7 +16904,7 @@
         },
         {
             "id": "444012ab-6df9-56e4-9bf1-4e8721b8577a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c5b5b7-e223-41c0-86e0-ed636ab77ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c5b5b7-e223-41c0-86e0-ed636ab77ae9.jpg?1",
             "name": "Creeping Mold",
             "text": "",
             "colours": [
@@ -16937,7 +16937,7 @@
         },
         {
             "id": "2214fa52-4ced-5b59-843c-e5c6e2a8ca25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c329c4-6c40-467a-ab37-95896a0c1159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c329c4-6c40-467a-ab37-95896a0c1159.jpg?1",
             "name": "Elvish Champion",
             "text": "All Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "51729dab-95a0-59f0-a829-82dc2d748c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c47b726-66d1-4d40-a84c-3c782c9f566e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c47b726-66d1-4d40-a84c-3c782c9f566e.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -17007,7 +17007,7 @@
         },
         {
             "id": "e511e15f-a097-5a25-92b1-74f8ad90d698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1da8da-12b2-47aa-9565-92d305061798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1da8da-12b2-47aa-9565-92d305061798.jpg?1",
             "name": "Elvish Lyrist",
             "text": "{G}, {T}, Sacrifice Elvish Lyrist: Destroy target enchantment.",
             "colours": [
@@ -17042,7 +17042,7 @@
         },
         {
             "id": "0bf86d9e-f4c9-5c80-ad26-ff4ffae0f495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4580c08-939d-4c41-9f61-997584f191e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4580c08-939d-4c41-9f61-997584f191e9.jpg?1",
             "name": "Elvish Lyrist",
             "text": "",
             "colours": [
@@ -17077,7 +17077,7 @@
         },
         {
             "id": "5d6df8e3-84c4-5b6c-87b4-13e35285ba66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88244522-1cf3-40a6-9ff7-bb78f2151b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88244522-1cf3-40a6-9ff7-bb78f2151b60.jpg?1",
             "name": "Elvish Pioneer",
             "text": "When Elvish Pioneer comes into play, you may put a basic land card from your hand into play tapped.",
             "colours": [
@@ -17113,7 +17113,7 @@
         },
         {
             "id": "546f8833-2ca7-5cfe-9124-6d81d9f16435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7311553-f028-4246-94e3-7bcbf3870aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7311553-f028-4246-94e3-7bcbf3870aed.jpg?1",
             "name": "Elvish Pioneer",
             "text": "",
             "colours": [
@@ -17149,7 +17149,7 @@
         },
         {
             "id": "6d2edec0-cbf7-5b41-9c4c-1a9f1412ade5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7031bb78-d35c-4d69-b4d2-df0418add14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7031bb78-d35c-4d69-b4d2-df0418add14c.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: Put a creature card from your hand into play.",
             "colours": [
@@ -17185,7 +17185,7 @@
         },
         {
             "id": "4f93b2e4-6e2f-59c4-9fab-81ac55cf8c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efb9c7c-8215-4439-a5b5-6914c88dd47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efb9c7c-8215-4439-a5b5-6914c88dd47b.jpg?1",
             "name": "Elvish Piper",
             "text": "",
             "colours": [
@@ -17221,7 +17221,7 @@
         },
         {
             "id": "a2187fcf-8a7d-5a53-9c6e-13446b7c50a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ebab87-fd0c-43d0-bde1-e36065d764dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ebab87-fd0c-43d0-bde1-e36065d764dd.jpg?1",
             "name": "Elvish Scrapper",
             "text": "{G}, {T}, Sacrifice Elvish Scrapper: Destroy target artifact.",
             "colours": [
@@ -17256,7 +17256,7 @@
         },
         {
             "id": "c63f820d-b067-5a2b-aa2c-70ec0c741257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d85820-dded-4739-99c9-44ecfb0b3752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d85820-dded-4739-99c9-44ecfb0b3752.jpg?1",
             "name": "Elvish Scrapper",
             "text": "",
             "colours": [
@@ -17291,7 +17291,7 @@
         },
         {
             "id": "41367989-1e37-51d1-90ce-110fd629b693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c512d95-df1a-4712-8bba-7e20047d419f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c512d95-df1a-4712-8bba-7e20047d419f.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -17326,7 +17326,7 @@
         },
         {
             "id": "4850a0d4-90e6-5944-a906-0c1b5353b06f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88eb31da-b350-4cf7-b851-21e48e3270d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88eb31da-b350-4cf7-b851-21e48e3270d0.jpg?1",
             "name": "Emperor Crocodile",
             "text": "",
             "colours": [
@@ -17361,7 +17361,7 @@
         },
         {
             "id": "283944db-b538-513f-9269-0683f877c297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5be15b0-e754-4d1f-a36f-901c20641a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5be15b0-e754-4d1f-a36f-901c20641a40.jpg?1",
             "name": "Fecundity",
             "text": "Whenever a creature is put into a graveyard from play, that creature's controller may draw a card.",
             "colours": [
@@ -17394,7 +17394,7 @@
         },
         {
             "id": "7edabe04-3d12-507c-9b7e-91f7abe52387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde1e739-f086-4f26-997c-e4fe35f9930e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde1e739-f086-4f26-997c-e4fe35f9930e.jpg?1",
             "name": "Fecundity",
             "text": "",
             "colours": [
@@ -17427,7 +17427,7 @@
         },
         {
             "id": "b88a447f-fa97-5591-a9a3-5253f56016d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a4a86-b9ce-415c-9343-db4211cac7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a4a86-b9ce-415c-9343-db4211cac7b8.jpg?1",
             "name": "Fertile Ground",
             "text": "Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool.",
             "colours": [
@@ -17462,7 +17462,7 @@
         },
         {
             "id": "a5c6278c-305f-51fd-9edb-212dfb919ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b464b6e-7c75-4929-9cfe-f520cea16fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b464b6e-7c75-4929-9cfe-f520cea16fab.jpg?1",
             "name": "Fertile Ground",
             "text": "",
             "colours": [
@@ -17497,7 +17497,7 @@
         },
         {
             "id": "bed1cec4-85c0-531e-8cfc-e17c8b433985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d621fad-3a50-4910-a302-23ae9e77ebde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d621fad-3a50-4910-a302-23ae9e77ebde.jpg?1",
             "name": "Foratog",
             "text": "{G}, Sacrifice a Forest: Foratog gets +2/+2 until end of turn.",
             "colours": [
@@ -17532,7 +17532,7 @@
         },
         {
             "id": "7f1a6ce4-4c35-5c6e-9aac-31cc5c9443ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb6e41-bbbe-4f32-bb0a-9dc8295ff9c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb6e41-bbbe-4f32-bb0a-9dc8295ff9c8.jpg?1",
             "name": "Foratog",
             "text": "",
             "colours": [
@@ -17567,7 +17567,7 @@
         },
         {
             "id": "6ec720a5-92cb-564d-9346-ce7efc9525d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79324f73-25cd-477a-b4f0-fd3e1319e451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79324f73-25cd-477a-b4f0-fd3e1319e451.jpg?1",
             "name": "Fungusaur",
             "text": "Whenever Fungusaur is dealt damage, put a +1/+1 counter on it. (The damage is dealt before the counter is put on.)",
             "colours": [
@@ -17603,7 +17603,7 @@
         },
         {
             "id": "40c2653e-fc73-53ff-908e-cc3e3053f2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a3398-892c-4481-af2d-76ac437f9277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a3398-892c-4481-af2d-76ac437f9277.jpg?1",
             "name": "Fungusaur",
             "text": "",
             "colours": [
@@ -17639,7 +17639,7 @@
         },
         {
             "id": "f8a08794-ac85-5dcd-bf7b-4cff69306076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c125cd-ea49-4511-a78c-42c1f7ce802d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c125cd-ea49-4511-a78c-42c1f7ce802d.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "{T}: Add {G}{G} to your mana pool.",
             "colours": [
@@ -17675,7 +17675,7 @@
         },
         {
             "id": "e0d64dc1-93b9-5e2d-b13d-308c120e583c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871fbead-4a9f-4e6e-ac8d-bc872176b39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871fbead-4a9f-4e6e-ac8d-bc872176b39e.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "",
             "colours": [
@@ -17711,7 +17711,7 @@
         },
         {
             "id": "0c9bac39-ccc7-5074-92c5-7b9ab1f74583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab713e16-5103-4f37-b325-a30d3580b5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab713e16-5103-4f37-b325-a30d3580b5dd.jpg?1",
             "name": "Gaea's Herald",
             "text": "Creature spells can't be countered.",
             "colours": [
@@ -17746,7 +17746,7 @@
         },
         {
             "id": "f16b544e-22cc-5da8-be25-81ae8d0a8017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31e72a-5311-4f62-bfac-0d51263512fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31e72a-5311-4f62-bfac-0d51263512fc.jpg?1",
             "name": "Gaea's Herald",
             "text": "",
             "colours": [
@@ -17781,7 +17781,7 @@
         },
         {
             "id": "84681b6b-cc2f-5538-b698-ac307362b655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9dd66-8580-4c96-9ab9-cc392dc6ee74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9dd66-8580-4c96-9ab9-cc392dc6ee74.jpg?1",
             "name": "Giant Badger",
             "text": "Whenever Giant Badger blocks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -17816,7 +17816,7 @@
         },
         {
             "id": "dd00c9c8-ca70-5574-9335-6c05b1e7e1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5d5046-c23b-4414-a752-0f2a27abc745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5d5046-c23b-4414-a752-0f2a27abc745.jpg?1",
             "name": "Giant Badger",
             "text": "",
             "colours": [
@@ -17851,7 +17851,7 @@
         },
         {
             "id": "27da5926-3e3d-5d06-b642-cb5a32d7491c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1210c342-1473-44ae-bcaa-e6b3ef9aea90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1210c342-1473-44ae-bcaa-e6b3ef9aea90.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "d6aa7953-3573-5d37-88c6-54f2a54c07a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4adb1-85af-40ba-bd36-ccd2dc1cb227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4adb1-85af-40ba-bd36-ccd2dc1cb227.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -17917,7 +17917,7 @@
         },
         {
             "id": "24ce63a5-835b-5fb6-a252-74f679043557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4632f3d9-9cdf-4871-9771-e8a8b1eaed52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4632f3d9-9cdf-4871-9771-e8a8b1eaed52.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider may block as though it had flying.",
             "colours": [
@@ -17952,7 +17952,7 @@
         },
         {
             "id": "c704eb87-5bd9-5c3a-9f76-fcee77c325c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2be9ed-7bac-4b80-a03b-a08ec11a05f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2be9ed-7bac-4b80-a03b-a08ec11a05f4.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -17987,7 +17987,7 @@
         },
         {
             "id": "51398c1f-a508-5a5e-9ab7-8ab9e5b4df93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5d8b0-e22d-4bb3-9e36-5038601d22f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5d8b0-e22d-4bb3-9e36-5038601d22f7.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -18022,7 +18022,7 @@
         },
         {
             "id": "af19f25a-7862-5bff-97d6-9eb87e739fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e12ae6-6e75-4786-b881-f1b890363a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e12ae6-6e75-4786-b881-f1b890363a0b.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -18057,7 +18057,7 @@
         },
         {
             "id": "f8337b98-77ab-5e7f-b764-24668a5be221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffce2f7-b619-4483-a75e-916343194641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffce2f7-b619-4483-a75e-916343194641.jpg?1",
             "name": "Horned Troll",
             "text": "{G}: Regenerate Horned Troll.",
             "colours": [
@@ -18092,7 +18092,7 @@
         },
         {
             "id": "8026f32f-56f7-5637-9b76-bbb0351f2356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43c17e-c2b6-4435-b27a-93672537c471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43c17e-c2b6-4435-b27a-93672537c471.jpg?1",
             "name": "Horned Troll",
             "text": "",
             "colours": [
@@ -18127,7 +18127,7 @@
         },
         {
             "id": "b3087862-6832-5257-b5ba-400d3f7aa621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edda2de4-22f6-4d33-b182-3ae5d105f1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edda2de4-22f6-4d33-b182-3ae5d105f1f6.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play.",
             "colours": [
@@ -18162,7 +18162,7 @@
         },
         {
             "id": "1664cfb3-5e0d-537e-8d62-842fbd5c0c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03523c81-ab2e-4c15-97b0-d5b85d7c62b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03523c81-ab2e-4c15-97b0-d5b85d7c62b6.jpg?1",
             "name": "Hunted Wumpus",
             "text": "",
             "colours": [
@@ -18197,7 +18197,7 @@
         },
         {
             "id": "6d4faf3b-1fcb-566a-85d5-b8a9610478cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d664dc-4477-46b3-9dd7-022c94090254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d664dc-4477-46b3-9dd7-022c94090254.jpg?1",
             "name": "Lhurgoyf",
             "text": "Lhurgoyf's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -18232,7 +18232,7 @@
         },
         {
             "id": "61b19ecb-c1ce-5f54-a5f4-fd2f5c2078ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1d394-6135-4064-971b-8df515e7ba50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1d394-6135-4064-971b-8df515e7ba50.jpg?1",
             "name": "Lhurgoyf",
             "text": "",
             "colours": [
@@ -18267,7 +18267,7 @@
         },
         {
             "id": "89afe3ee-d887-5416-8d0b-e587a3c21f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a22646-0e36-491e-9b90-39fad60d64bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a22646-0e36-491e-9b90-39fad60d64bf.jpg?1",
             "name": "Living Terrain",
             "text": "Enchanted land is a 5/6 green Treefolk creature that's still a land.",
             "colours": [
@@ -18302,7 +18302,7 @@
         },
         {
             "id": "2ee19db9-a50a-54ad-b276-371945b27579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a94a14-bce3-465e-b16a-03466d1f5895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a94a14-bce3-465e-b16a-03466d1f5895.jpg?1",
             "name": "Living Terrain",
             "text": "",
             "colours": [
@@ -18337,7 +18337,7 @@
         },
         {
             "id": "f1f53537-e6f4-5850-8cb0-cf03443d73a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ce566a-9385-47a5-8420-f3ffcd88eae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ce566a-9385-47a5-8420-f3ffcd88eae9.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "Tap an untapped creature you control: Llanowar Behemoth gets +1/+1 until end of turn.",
             "colours": [
@@ -18372,7 +18372,7 @@
         },
         {
             "id": "ea728f80-f265-544c-a19c-679b6897b1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2115-c003-432d-8cef-b901cdaf3510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2115-c003-432d-8cef-b901cdaf3510.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "",
             "colours": [
@@ -18407,7 +18407,7 @@
         },
         {
             "id": "5960c8e2-6d35-5f20-aa5a-a5f7bed422e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309d32e9-c9b0-46bb-8d99-1ddd2e34a60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309d32e9-c9b0-46bb-8d99-1ddd2e34a60b.jpg?1",
             "name": "Lone Wolf",
             "text": "You may have Lone Wolf deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -18442,7 +18442,7 @@
         },
         {
             "id": "6aa0ea9c-71d0-5f75-a739-709bf451140f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0c0701-9e5f-42d1-b269-b33225d6a54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0c0701-9e5f-42d1-b269-b33225d6a54b.jpg?1",
             "name": "Lone Wolf",
             "text": "",
             "colours": [
@@ -18477,7 +18477,7 @@
         },
         {
             "id": "99035f4f-b4ba-5560-92de-261ad53b385b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5362cf9-a55b-4df5-941e-d738a68281cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5362cf9-a55b-4df5-941e-d738a68281cf.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -18512,7 +18512,7 @@
         },
         {
             "id": "e3a71d0e-df97-5e56-9450-9c3e596a95e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e502853e-5451-44c8-a42a-440f2387d604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e502853e-5451-44c8-a42a-440f2387d604.jpg?1",
             "name": "Lure",
             "text": "",
             "colours": [
@@ -18547,7 +18547,7 @@
         },
         {
             "id": "e217e06c-9dc1-5a5b-91bb-68f324f81a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728aea83-5817-4ec9-8d73-3043089c17d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728aea83-5817-4ec9-8d73-3043089c17d4.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -18582,7 +18582,7 @@
         },
         {
             "id": "9166d1fa-48c0-5b7d-b2cf-08beff292603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695a29d-fd19-422b-a5a7-15cd218c8876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695a29d-fd19-422b-a5a7-15cd218c8876.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -18617,7 +18617,7 @@
         },
         {
             "id": "fd197ea6-416b-5146-b9a4-8ff14fd73eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b136d50-732b-4265-97c4-1caaa4a54be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b136d50-732b-4265-97c4-1caaa4a54be1.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -18650,7 +18650,7 @@
         },
         {
             "id": "93296851-54b5-5e36-9976-0ff354eee29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dcea2c-147d-4610-a4d8-e305114deaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dcea2c-147d-4610-a4d8-e305114deaaa.jpg?1",
             "name": "Might of Oaks",
             "text": "",
             "colours": [
@@ -18683,7 +18683,7 @@
         },
         {
             "id": "2bfb3791-71c3-5937-8c4b-fb79075e5a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5a2687-af7a-42ad-8938-f3534c7da222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5a2687-af7a-42ad-8938-f3534c7da222.jpg?1",
             "name": "Monstrous Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -18716,7 +18716,7 @@
         },
         {
             "id": "64528ff6-1612-56df-aef2-fee59550057b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c31288-16a5-422b-b2e5-d23f424da826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c31288-16a5-422b-b2e5-d23f424da826.jpg?1",
             "name": "Monstrous Growth",
             "text": "",
             "colours": [
@@ -18749,7 +18749,7 @@
         },
         {
             "id": "dbf43e5e-8755-5fe1-b384-e2af4edac503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15511fda-92ae-4d27-8a83-37e821ec3adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15511fda-92ae-4d27-8a83-37e821ec3adf.jpg?1",
             "name": "Moss Monster",
             "text": "",
             "colours": [
@@ -18784,7 +18784,7 @@
         },
         {
             "id": "4f061ab3-1612-5264-a447-b26a53b07d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5673efb5-3198-470b-aca9-0f1358506d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5673efb5-3198-470b-aca9-0f1358506d3e.jpg?1",
             "name": "Moss Monster",
             "text": "",
             "colours": [
@@ -18819,7 +18819,7 @@
         },
         {
             "id": "a62e2112-eb80-5c55-9abf-95666caeb5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd6695-ee30-4ab1-a732-26b073c2fec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd6695-ee30-4ab1-a732-26b073c2fec6.jpg?1",
             "name": "Nantuko Disciple",
             "text": "{G}, {T}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -18855,7 +18855,7 @@
         },
         {
             "id": "69815bbf-6075-5cf2-8d94-9fa6b2916c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fcbd-814e-4277-8051-ceb04a4b667f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fcbd-814e-4277-8051-ceb04a4b667f.jpg?1",
             "name": "Nantuko Disciple",
             "text": "",
             "colours": [
@@ -18891,7 +18891,7 @@
         },
         {
             "id": "0b244ec7-716b-5eab-b537-0a24e92c20d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d782c5-1462-4533-8004-672450bf5c07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d782c5-1462-4533-8004-672450bf5c07.jpg?1",
             "name": "Natural Affinity",
             "text": "Until end of turn, all lands become 2/2 creatures that are still lands.",
             "colours": [
@@ -18924,7 +18924,7 @@
         },
         {
             "id": "0a9b04a0-78b6-5988-8594-3cf88b12cb03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e786ae-7f0e-46c0-afc7-758b92387fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e786ae-7f0e-46c0-afc7-758b92387fd2.jpg?1",
             "name": "Natural Affinity",
             "text": "",
             "colours": [
@@ -18957,7 +18957,7 @@
         },
         {
             "id": "2dd9f142-afee-5358-b9b2-0a10e78b32f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e905d-a911-40a7-a793-8535e840230e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e905d-a911-40a7-a793-8535e840230e.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -18990,7 +18990,7 @@
         },
         {
             "id": "689f7a4d-ab18-5c27-948c-d37092d98b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e4416-c820-4d3c-83a6-8f9de32dcfec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e4416-c820-4d3c-83a6-8f9de32dcfec.jpg?1",
             "name": "Naturalize",
             "text": "",
             "colours": [
@@ -19023,7 +19023,7 @@
         },
         {
             "id": "dd7882dc-71a0-518f-82b2-0ff666d25728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3415e3a7-99b2-44b5-93a3-fd07c4ecca4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3415e3a7-99b2-44b5-93a3-fd07c4ecca4d.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -19060,7 +19060,7 @@
         },
         {
             "id": "5a4a4ba9-7b74-56e7-89f7-54fdbe168f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56302f44-d9be-4453-8e01-b1c19979f521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56302f44-d9be-4453-8e01-b1c19979f521.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -19097,7 +19097,7 @@
         },
         {
             "id": "54692614-f938-5b59-bc23-148279439a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27128f26-0d89-4962-96e8-5fa343031a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27128f26-0d89-4962-96e8-5fa343031a26.jpg?1",
             "name": "Plow Under",
             "text": "Put two target lands on top of their owner's library.",
             "colours": [
@@ -19130,7 +19130,7 @@
         },
         {
             "id": "991757e7-feba-518e-89ac-c9fcae744c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e98212-08a8-4570-a291-61f22288066e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e98212-08a8-4570-a291-61f22288066e.jpg?1",
             "name": "Plow Under",
             "text": "",
             "colours": [
@@ -19163,7 +19163,7 @@
         },
         {
             "id": "11045076-124f-51e7-9de4-bc93ae9c5329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4e884-b36c-4fde-84bb-a19a3ce160ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4e884-b36c-4fde-84bb-a19a3ce160ae.jpg?1",
             "name": "Primeval Force",
             "text": "When Primeval Force comes into play, sacrifice it unless you sacrifice three Forests.",
             "colours": [
@@ -19198,7 +19198,7 @@
         },
         {
             "id": "9a39742b-5040-5585-8e5f-98763c5fe9a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61af954f-e0ee-43cb-830a-225c8fb46850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61af954f-e0ee-43cb-830a-225c8fb46850.jpg?1",
             "name": "Primeval Force",
             "text": "",
             "colours": [
@@ -19233,7 +19233,7 @@
         },
         {
             "id": "57aa4ee5-9ef4-5bb1-8fbe-785f6d47caf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d56cde-e186-41e7-bcb2-80736a989678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d56cde-e186-41e7-bcb2-80736a989678.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -19266,7 +19266,7 @@
         },
         {
             "id": "5c3c4e75-4e64-5170-96ea-888bad4f0b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336c1d89-7d7e-42f4-a1e1-55f85b3c47e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336c1d89-7d7e-42f4-a1e1-55f85b3c47e1.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -19299,7 +19299,7 @@
         },
         {
             "id": "3ef05c40-faa8-590e-9765-545665979740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a97c91d-66bd-417a-9c13-4ac4d9ddd7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a97c91d-66bd-417a-9c13-4ac4d9ddd7f7.jpg?1",
             "name": "Regeneration",
             "text": "{G}: Regenerate enchanted creature.",
             "colours": [
@@ -19334,7 +19334,7 @@
         },
         {
             "id": "fbbea028-c87a-5a8e-a1c6-115bf52ccda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d78aef4-a4cf-4a6a-80c0-0695a93d3342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d78aef4-a4cf-4a6a-80c0-0695a93d3342.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -19369,7 +19369,7 @@
         },
         {
             "id": "a12692aa-f735-5588-b3a2-0b37eb2bdcfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbd99aa-af0a-489d-9be1-d3aaa0a1f5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbd99aa-af0a-489d-9be1-d3aaa0a1f5a4.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -19402,7 +19402,7 @@
         },
         {
             "id": "18d5a802-9b29-5a71-8892-c55bac34c885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43832b4-c6f2-4296-b2b0-ddc0c39b322b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43832b4-c6f2-4296-b2b0-ddc0c39b322b.jpg?1",
             "name": "Revive",
             "text": "",
             "colours": [
@@ -19435,7 +19435,7 @@
         },
         {
             "id": "cfe8240f-7df7-53d7-9ace-316573b0bd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7e788-8fc7-49f3-804b-2d7f96852d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7e788-8fc7-49f3-804b-2d7f96852d4b.jpg?1",
             "name": "Rhox",
             "text": "You may have Rhox deal its combat damage to defending player as though it weren't blocked.\n{2}{G}: Regenerate Rhox.",
             "colours": [
@@ -19471,7 +19471,7 @@
         },
         {
             "id": "4e22f96d-9a64-5a20-888b-2342901e9d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6761729-b8e1-4a84-a4eb-3b5fc9485867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6761729-b8e1-4a84-a4eb-3b5fc9485867.jpg?1",
             "name": "Rhox",
             "text": "",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "b55647e7-4cb1-5a85-a1f7-d5d3206d71e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d62152d-463b-464d-b3c2-8b404ee1f80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d62152d-463b-464d-b3c2-8b404ee1f80e.jpg?1",
             "name": "Rushwood Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -19542,7 +19542,7 @@
         },
         {
             "id": "a8c3f22b-4856-5934-99a5-ea517c612cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61737f0-857b-48fd-aebe-3d7eea3bff50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61737f0-857b-48fd-aebe-3d7eea3bff50.jpg?1",
             "name": "Rushwood Dryad",
             "text": "",
             "colours": [
@@ -19577,7 +19577,7 @@
         },
         {
             "id": "86c3622d-a0bc-5dcc-a565-e45a5f0233c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba620b1b-d333-443b-961a-25f65ca49a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba620b1b-d333-443b-961a-25f65ca49a1e.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -19612,7 +19612,7 @@
         },
         {
             "id": "d29ae3d7-6393-52b9-8220-e18bc0f2df05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0627ac0e-f371-44fc-8cd9-987e02ed13ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0627ac0e-f371-44fc-8cd9-987e02ed13ec.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -19647,7 +19647,7 @@
         },
         {
             "id": "cb0dc3e7-c804-5081-b8b6-0a7d17584c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeeb515-7d3d-4678-a480-32485b197afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeeb515-7d3d-4678-a480-32485b197afb.jpg?1",
             "name": "Spitting Spider",
             "text": "Spitting Spider may block as though it had flying.\nSacrifice a land: Spitting Spider deals 1 damage to each creature with flying.",
             "colours": [
@@ -19682,7 +19682,7 @@
         },
         {
             "id": "f166914b-5fb5-56e7-a031-e01e486ea102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b8b3d8-aa1f-473b-a85f-912aea8fa207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b8b3d8-aa1f-473b-a85f-912aea8fa207.jpg?1",
             "name": "Spitting Spider",
             "text": "",
             "colours": [
@@ -19717,7 +19717,7 @@
         },
         {
             "id": "bd99e864-f136-54d3-b5c6-84ea60d5ab56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abaf631-ce63-47c8-8883-04f942f2e7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abaf631-ce63-47c8-8883-04f942f2e7ba.jpg?1",
             "name": "Spreading Algae",
             "text": "Spreading Algae can enchant only a Swamp.\nWhen enchanted land becomes tapped, destroy that land.\nWhen Spreading Algae is put into a graveyard from play, return Spreading Algae to its owner's hand.",
             "colours": [
@@ -19752,7 +19752,7 @@
         },
         {
             "id": "c41ae817-6a0b-5924-bcec-5aa621c1dcf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae057c0c-1993-4e1c-a7c3-a3be8fa5616d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae057c0c-1993-4e1c-a7c3-a3be8fa5616d.jpg?1",
             "name": "Spreading Algae",
             "text": "",
             "colours": [
@@ -19787,7 +19787,7 @@
         },
         {
             "id": "88391e16-5846-5866-9b50-06a860a234de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff34fb-7bc5-4484-ad73-067363a2cc16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff34fb-7bc5-4484-ad73-067363a2cc16.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -19820,7 +19820,7 @@
         },
         {
             "id": "6feb03f2-a6de-548d-a278-e96c91270485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9263d7-4825-4fd4-a6a7-d887cc3d8bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9263d7-4825-4fd4-a6a7-d887cc3d8bae.jpg?1",
             "name": "Stream of Life",
             "text": "",
             "colours": [
@@ -19853,7 +19853,7 @@
         },
         {
             "id": "b8fcc3b5-0e3a-576a-8419-e74d4f8c0796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa0c8c-f069-4f3b-b049-90e1089346ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa0c8c-f069-4f3b-b049-90e1089346ef.jpg?1",
             "name": "Thorn Elemental",
             "text": "You may have Thorn Elemental deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -19888,7 +19888,7 @@
         },
         {
             "id": "6161cec4-0065-5a07-8d65-9e310e1249f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9277322-b379-4d2f-bb39-ae448d414c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9277322-b379-4d2f-bb39-ae448d414c9c.jpg?1",
             "name": "Thorn Elemental",
             "text": "",
             "colours": [
@@ -19923,7 +19923,7 @@
         },
         {
             "id": "a1bb5f59-7e5c-55a0-b27f-00709db3e592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe86493d-e350-40c4-b65f-de63c2f0a91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe86493d-e350-40c4-b65f-de63c2f0a91a.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19958,7 +19958,7 @@
         },
         {
             "id": "90e6d57d-8f2b-5439-b74c-8229132b0d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9a16c6-f7d5-407e-b849-9d636419eedb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9a16c6-f7d5-407e-b849-9d636419eedb.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19993,7 +19993,7 @@
         },
         {
             "id": "6537dbdc-f336-5963-a6d0-9df01ca59c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff050e6-cd70-4289-bd15-e5c3437bef2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff050e6-cd70-4289-bd15-e5c3437bef2d.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -20029,7 +20029,7 @@
         },
         {
             "id": "d36f0554-5902-53c4-afc6-a3fa513fe271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01114884-50d2-434e-905f-20dad4b8dfbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01114884-50d2-434e-905f-20dad4b8dfbd.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -20065,7 +20065,7 @@
         },
         {
             "id": "749af365-1bca-53be-ac53-3ed2b3be3a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabb73c-e3d9-4ba1-9963-986e09ef49a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabb73c-e3d9-4ba1-9963-986e09ef49a7.jpg?1",
             "name": "Vernal Bloom",
             "text": "Whenever a Forest is tapped for mana, its controller adds {G} to his or her mana pool.",
             "colours": [
@@ -20098,7 +20098,7 @@
         },
         {
             "id": "9b76037f-36b4-5cf3-a6f9-08134adaaf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a54bd3f-0b44-487d-88ec-14365d43e8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a54bd3f-0b44-487d-88ec-14365d43e8e5.jpg?1",
             "name": "Vernal Bloom",
             "text": "",
             "colours": [
@@ -20131,7 +20131,7 @@
         },
         {
             "id": "35f7f57d-2e1e-5b07-a5cf-49ca568a061e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba462242-82de-4173-98d2-b1b7a1f3d8b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba462242-82de-4173-98d2-b1b7a1f3d8b4.jpg?1",
             "name": "Vine Trellis",
             "text": "(Walls can't attack.)\n{T}: Add {G} to your mana pool.",
             "colours": [
@@ -20167,7 +20167,7 @@
         },
         {
             "id": "6691b13c-c875-54f5-882c-c8c62344d7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded1c6d2-c0b8-4fb7-a377-cad62ff76599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded1c6d2-c0b8-4fb7-a377-cad62ff76599.jpg?1",
             "name": "Vine Trellis",
             "text": "",
             "colours": [
@@ -20203,7 +20203,7 @@
         },
         {
             "id": "d3592414-3444-5862-8a23-078908dd3957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5beaf0-21ca-4539-8773-8a9430af74b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5beaf0-21ca-4539-8773-8a9430af74b0.jpg?1",
             "name": "Wing Snare",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -20236,7 +20236,7 @@
         },
         {
             "id": "250d01a8-73f0-5c61-af27-be9c0ea99858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a0b4ae-0820-48a8-ba8d-a07eccfe90da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a0b4ae-0820-48a8-ba8d-a07eccfe90da.jpg?1",
             "name": "Wing Snare",
             "text": "",
             "colours": [
@@ -20269,7 +20269,7 @@
         },
         {
             "id": "77c9fa3d-3e54-5256-b221-0cbe776ec2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7aa861-556b-43a1-bf57-1efbbd438975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7aa861-556b-43a1-bf57-1efbbd438975.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a Forest card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -20305,7 +20305,7 @@
         },
         {
             "id": "b5ece50d-147e-5a24-b380-2002cd33498f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da2f237-5dc3-4fc7-a0c2-1a0d325ebfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da2f237-5dc3-4fc7-a0c2-1a0d325ebfbf.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -20341,7 +20341,7 @@
         },
         {
             "id": "ff8b09d7-81e7-50fa-bd12-a6674316aed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed4258-eeb8-4c50-9119-8c54331bd219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed4258-eeb8-4c50-9119-8c54331bd219.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -20377,7 +20377,7 @@
         },
         {
             "id": "69b2b749-5fb2-5370-93e4-e9d435d016e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b986f77f-e05b-4c31-824f-d6f746985de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b986f77f-e05b-4c31-824f-d6f746985de1.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "",
             "colours": [
@@ -20413,7 +20413,7 @@
         },
         {
             "id": "56896575-585a-5848-8393-816d3adaac1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffd2437-04e7-44e4-becc-15be62735b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffd2437-04e7-44e4-becc-15be62735b42.jpg?1",
             "name": "Aladdin's Ring",
             "text": "{8}, {T}: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -20442,7 +20442,7 @@
         },
         {
             "id": "786560c7-8cfd-507a-9317-b8cbd909b670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c025c-c30c-4e1f-a530-726fd742f663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c025c-c30c-4e1f-a530-726fd742f663.jpg?1",
             "name": "Aladdin's Ring",
             "text": "",
             "colours": [],
@@ -20471,7 +20471,7 @@
         },
         {
             "id": "573df73a-c8f6-53d3-98ef-8e344032d470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cc6efd-43cc-4350-bd44-9f20c5a4fdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cc6efd-43cc-4350-bd44-9f20c5a4fdd0.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden's power and toughness are each equal to the number of creatures in play.",
             "colours": [],
@@ -20503,7 +20503,7 @@
         },
         {
             "id": "d8a073a9-a4b3-5069-9f9d-4c226ccbde64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec1aa1c-0b44-49d6-9222-38edf04cd7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec1aa1c-0b44-49d6-9222-38edf04cd7f9.jpg?1",
             "name": "Beast of Burden",
             "text": "",
             "colours": [],
@@ -20535,7 +20535,7 @@
         },
         {
             "id": "cac7f534-7401-52ba-ab43-4de0a9cd17d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc61a67-7fab-484c-aa2b-615353138440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc61a67-7fab-484c-aa2b-615353138440.jpg?1",
             "name": "Brass Herald",
             "text": "As Brass Herald comes into play, choose a creature type.\nWhen Brass Herald comes into play, reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order.\nCreatures of the chosen type get +1/+1.",
             "colours": [],
@@ -20567,7 +20567,7 @@
         },
         {
             "id": "c742e854-a572-5bdd-b38d-3e6f8d1175f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34e9659-fc22-42f8-b118-6b46b4fab409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34e9659-fc22-42f8-b118-6b46b4fab409.jpg?1",
             "name": "Brass Herald",
             "text": "",
             "colours": [],
@@ -20599,7 +20599,7 @@
         },
         {
             "id": "fa068a36-bd6b-5037-ae96-ca785511b7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3995426-2baf-47aa-8111-de07e65f64b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3995426-2baf-47aa-8111-de07e65f64b4.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if there are three Goblins in play, each gets +2/+2.)",
             "colours": [],
@@ -20628,7 +20628,7 @@
         },
         {
             "id": "483a0465-c857-537e-b3dd-02024361e33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e554dd-32c8-4c22-9f3e-32d84cd9edef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e554dd-32c8-4c22-9f3e-32d84cd9edef.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -20657,7 +20657,7 @@
         },
         {
             "id": "2f18f154-0060-5bf5-90b7-ebec9b6848e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe82b91-69e2-4528-b80a-a61183c352ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe82b91-69e2-4528-b80a-a61183c352ad.jpg?1",
             "name": "Crystal Rod",
             "text": "Whenever a player plays a blue spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -20686,7 +20686,7 @@
         },
         {
             "id": "7ba814be-833b-5fbd-b11b-11022a909c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5966f78-198f-48d1-b0a7-cb590547b5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5966f78-198f-48d1-b0a7-cb590547b5f5.jpg?1",
             "name": "Crystal Rod",
             "text": "",
             "colours": [],
@@ -20715,7 +20715,7 @@
         },
         {
             "id": "3a54328a-52c9-59f3-b80e-8ccc4e7cb287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61527b06-bbc9-4f3c-a5db-98ef02063482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61527b06-bbc9-4f3c-a5db-98ef02063482.jpg?1",
             "name": "Defense Grid",
             "text": "During each player's turn, each other player's spells cost {3} more to play.",
             "colours": [],
@@ -20744,7 +20744,7 @@
         },
         {
             "id": "c4495825-0aad-5550-9a4f-b9feaac2c4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fc8efa-5955-4428-9491-66da5bea5e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fc8efa-5955-4428-9491-66da5bea5e0b.jpg?1",
             "name": "Defense Grid",
             "text": "",
             "colours": [],
@@ -20773,7 +20773,7 @@
         },
         {
             "id": "0a535be0-e62b-5a00-b002-e67665a4d3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d893a2-400c-459d-a26d-31f1f3b0642e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d893a2-400c-459d-a26d-31f1f3b0642e.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into a graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -20802,7 +20802,7 @@
         },
         {
             "id": "470c87a8-31ec-5c9e-be91-957f1673353b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6bf8b4-b3fe-437e-9c6b-f3f495c8c5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6bf8b4-b3fe-437e-9c6b-f3f495c8c5fc.jpg?1",
             "name": "Dingus Egg",
             "text": "",
             "colours": [],
@@ -20831,7 +20831,7 @@
         },
         {
             "id": "1ce47f82-c00e-53f7-9ccb-0369d596b82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1129d16c-de2b-4d21-a0fd-b63e4ba95d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1129d16c-de2b-4d21-a0fd-b63e4ba95d8d.jpg?1",
             "name": "Disrupting Scepter",
             "text": "{3}, {T}: Target player discards a card from his or her hand. Play this ability only during your turn.",
             "colours": [],
@@ -20860,7 +20860,7 @@
         },
         {
             "id": "8f0b0c58-9889-5af3-be81-cf0a14a16cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09ad3b6-fa9c-4983-9566-00cebd4ca320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09ad3b6-fa9c-4983-9566-00cebd4ca320.jpg?1",
             "name": "Disrupting Scepter",
             "text": "",
             "colours": [],
@@ -20889,7 +20889,7 @@
         },
         {
             "id": "bf92bde8-c8c5-5644-88a4-30c8d1064220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d82d9b7-4b1c-447c-8044-9e114604017e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d82d9b7-4b1c-447c-8044-9e114604017e.jpg?1",
             "name": "Distorting Lens",
             "text": "{T}: Target permanent becomes the color of your choice until end of turn.",
             "colours": [],
@@ -20918,7 +20918,7 @@
         },
         {
             "id": "ce32f0a1-8263-5ba0-b1fd-f6da509ce248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae751b9a-17f6-4180-989a-f91c34f431c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae751b9a-17f6-4180-989a-f91c34f431c9.jpg?1",
             "name": "Distorting Lens",
             "text": "",
             "colours": [],
@@ -20947,7 +20947,7 @@
         },
         {
             "id": "2847fcc5-0497-58c3-a75a-b73d30dc84d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dcf3e-9556-4e1e-929b-eff38abc989c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dcf3e-9556-4e1e-929b-eff38abc989c.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -20976,7 +20976,7 @@
         },
         {
             "id": "40e174e0-3b1a-5680-b67a-9a0a911c0aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058916e-98d5-4312-a845-1195bcff78db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058916e-98d5-4312-a845-1195bcff78db.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "",
             "colours": [],
@@ -21005,7 +21005,7 @@
         },
         {
             "id": "5082c65c-c845-5495-a186-c78af8930761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e5bc70-663f-41a5-a8d1-487c57a6f029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e5bc70-663f-41a5-a8d1-487c57a6f029.jpg?1",
             "name": "Flying Carpet",
             "text": "{2}, {T}: Target creature gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -21034,7 +21034,7 @@
         },
         {
             "id": "cf0ba323-0c64-5d6d-91a3-63135aa1fa44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50b56a-5b0a-4795-8100-df31818744d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50b56a-5b0a-4795-8100-df31818744d9.jpg?1",
             "name": "Flying Carpet",
             "text": "",
             "colours": [],
@@ -21063,7 +21063,7 @@
         },
         {
             "id": "ffb0ce14-b019-5aa8-a050-49a5d3297bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde003e6-d674-42cd-9537-91928730e7dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde003e6-d674-42cd-9537-91928730e7dd.jpg?1",
             "name": "Fodder Cannon",
             "text": "{4}, {T}, Sacrifice a creature: Fodder Cannon deals 4 damage to target creature.",
             "colours": [],
@@ -21092,7 +21092,7 @@
         },
         {
             "id": "1c15d87c-3833-5338-b14c-985b79a06071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42717c4-e5f5-42de-a29d-f74333131efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42717c4-e5f5-42de-a29d-f74333131efd.jpg?1",
             "name": "Fodder Cannon",
             "text": "",
             "colours": [],
@@ -21121,7 +21121,7 @@
         },
         {
             "id": "f4e68162-f43b-56e1-834f-31994218653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661236e2-a414-4a08-b7f7-704f1a2952a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661236e2-a414-4a08-b7f7-704f1a2952a8.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -21150,7 +21150,7 @@
         },
         {
             "id": "28f951ef-743b-5eb9-b36a-88227c7f2866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4f69-d4ff-4cd7-bbfe-f648efc89063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4f69-d4ff-4cd7-bbfe-f648efc89063.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -21179,7 +21179,7 @@
         },
         {
             "id": "8c715e7b-a7bf-552e-b468-18efd7f330da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6d1e6b-80af-4eb1-be3c-62ab74315777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6d1e6b-80af-4eb1-be3c-62ab74315777.jpg?1",
             "name": "Iron Star",
             "text": "Whenever a player plays a red spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -21208,7 +21208,7 @@
         },
         {
             "id": "9e8e0f11-4cea-5c2c-b47c-80cfb8fcb9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9df380-638b-4502-ba70-bfbb5217af27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9df380-638b-4502-ba70-bfbb5217af27.jpg?1",
             "name": "Iron Star",
             "text": "",
             "colours": [],
@@ -21237,7 +21237,7 @@
         },
         {
             "id": "8550f492-a15a-5efe-954f-335e8a7d4330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4cd379-caba-485c-8c0f-e59804c387c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4cd379-caba-485c-8c0f-e59804c387c6.jpg?1",
             "name": "Ivory Cup",
             "text": "Whenever a player plays a white spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -21266,7 +21266,7 @@
         },
         {
             "id": "e304b5e1-806b-5014-b09d-0e7b00b66efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6569df10-35da-4eb8-bc82-f4d937500fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6569df10-35da-4eb8-bc82-f4d937500fd2.jpg?1",
             "name": "Ivory Cup",
             "text": "",
             "colours": [],
@@ -21295,7 +21295,7 @@
         },
         {
             "id": "7c6cdb8a-1101-5c4c-ac0d-c6fd0c412949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73b31b1-c347-4f1c-af4f-8ffbf9e8bf8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73b31b1-c347-4f1c-af4f-8ffbf9e8bf8a.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -21324,7 +21324,7 @@
         },
         {
             "id": "8e9a5d31-60b3-5011-bff7-c590ca22a19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a1a95c-0283-4fc4-a2f5-03ff92385bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a1a95c-0283-4fc4-a2f5-03ff92385bec.jpg?1",
             "name": "Jayemdae Tome",
             "text": "",
             "colours": [],
@@ -21353,7 +21353,7 @@
         },
         {
             "id": "7c2944ab-162a-5346-9fb5-7a65e4610e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c28e220-77ed-466d-9f49-d93b61672ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c28e220-77ed-466d-9f49-d93b61672ee1.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -21382,7 +21382,7 @@
         },
         {
             "id": "832972e6-73ba-590a-a38d-6e980cd7db8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a315d584-2b11-4a1e-8529-5e0b536e06a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a315d584-2b11-4a1e-8529-5e0b536e06a4.jpg?1",
             "name": "Millstone",
             "text": "",
             "colours": [],
@@ -21411,7 +21411,7 @@
         },
         {
             "id": "d7f6c0f7-6905-5d5e-9a31-0faba1b8ffbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66c9c30-35c4-4813-a766-a54a418baf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66c9c30-35c4-4813-a766-a54a418baf8b.jpg?1",
             "name": "Patagia Golem",
             "text": "{3}: Patagia Golem gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -21443,7 +21443,7 @@
         },
         {
             "id": "ea79f7de-7198-518f-8f7a-7f4752605c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74b775-a011-41b6-8732-7a0cb91e030e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74b775-a011-41b6-8732-7a0cb91e030e.jpg?1",
             "name": "Patagia Golem",
             "text": "",
             "colours": [],
@@ -21475,7 +21475,7 @@
         },
         {
             "id": "48948b5e-affa-554d-b934-620f66330252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62f8d95-be99-4c3b-9c75-f5cc1cb43c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62f8d95-be99-4c3b-9c75-f5cc1cb43c44.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "Phyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
             "colours": [],
@@ -21508,7 +21508,7 @@
         },
         {
             "id": "4a9f183e-97d4-5811-b86c-e31d986b208e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203600a-470e-4631-abbc-2c5bf9aa3613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203600a-470e-4631-abbc-2c5bf9aa3613.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "",
             "colours": [],
@@ -21541,7 +21541,7 @@
         },
         {
             "id": "3f7efea1-62ca-568c-b233-64eeab74a1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64af09-2af7-4630-a3c4-e1aa90f2a9fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64af09-2af7-4630-a3c4-e1aa90f2a9fb.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21574,7 +21574,7 @@
         },
         {
             "id": "1f88b6fa-bc1d-558e-9036-b88660377f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a6662b-61eb-44dc-933f-e9246a5b9ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a6662b-61eb-44dc-933f-e9246a5b9ec0.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21607,7 +21607,7 @@
         },
         {
             "id": "3635135b-12a0-547a-8654-c23bb3d91c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8743b2ce-0e18-42c9-aee4-f13197a9c481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8743b2ce-0e18-42c9-aee4-f13197a9c481.jpg?1",
             "name": "Planar Portal",
             "text": "{6}, {T}: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -21636,7 +21636,7 @@
         },
         {
             "id": "84904a80-7433-52a2-b62e-c5e82971c8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90697c9-5be1-4387-9d56-73037223306a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90697c9-5be1-4387-9d56-73037223306a.jpg?1",
             "name": "Planar Portal",
             "text": "",
             "colours": [],
@@ -21665,7 +21665,7 @@
         },
         {
             "id": "634cb432-2462-5f5e-88ba-5767efbe20d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d652801-7f22-41b5-b19c-90efe5d8c0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d652801-7f22-41b5-b19c-90efe5d8c0a8.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -21694,7 +21694,7 @@
         },
         {
             "id": "06cff25a-3b40-5499-9339-7999b51404f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12200b-1d29-4f76-8131-6faae141492b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12200b-1d29-4f76-8131-6faae141492b.jpg?1",
             "name": "Rod of Ruin",
             "text": "",
             "colours": [],
@@ -21723,7 +21723,7 @@
         },
         {
             "id": "e08ea922-01c4-5222-8b92-c8646f86761b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3a7b4-ff44-4909-ab8d-35ba5d187815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3a7b4-ff44-4909-ab8d-35ba5d187815.jpg?1",
             "name": "Skull of Orm",
             "text": "{5}, {T}: Return target enchantment card from your graveyard to your hand.",
             "colours": [],
@@ -21752,7 +21752,7 @@
         },
         {
             "id": "fcfa00bb-b35a-5035-a683-4548bc82d429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5943e3-2c41-4d52-8e38-f5b60db6af7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5943e3-2c41-4d52-8e38-f5b60db6af7d.jpg?1",
             "name": "Skull of Orm",
             "text": "",
             "colours": [],
@@ -21781,7 +21781,7 @@
         },
         {
             "id": "3314166b-d88f-5bdf-9bdf-4c70ae724cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb99979-79f9-4ac0-9f8e-c36ed0a2cc85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb99979-79f9-4ac0-9f8e-c36ed0a2cc85.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -21810,7 +21810,7 @@
         },
         {
             "id": "ff45a073-758e-5cc4-aae2-c4b1b96fa714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c9145-f53a-45a5-91ac-99fefa8a6dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c9145-f53a-45a5-91ac-99fefa8a6dc1.jpg?1",
             "name": "Spellbook",
             "text": "",
             "colours": [],
@@ -21839,7 +21839,7 @@
         },
         {
             "id": "a18d01a3-e65b-5e8b-8ad1-ec8014151fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddaa2b-d836-49bd-9d2f-da2cc4a2bff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddaa2b-d836-49bd-9d2f-da2cc4a2bff4.jpg?1",
             "name": "Star Compass",
             "text": "Star Compass comes into play tapped.\n{T}: Add to your mana pool one mana of any color a basic land you control could produce.",
             "colours": [],
@@ -21868,7 +21868,7 @@
         },
         {
             "id": "cf7e1e3c-70d8-5683-a0a8-e3a1a1638a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cfc596-8857-4862-a404-e4a3f6710ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cfc596-8857-4862-a404-e4a3f6710ddb.jpg?1",
             "name": "Star Compass",
             "text": "",
             "colours": [],
@@ -21897,7 +21897,7 @@
         },
         {
             "id": "4d654a86-73d6-5b8b-90cb-dcadd276cc14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f536f5-0e91-4c78-bba4-036bfa877040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f536f5-0e91-4c78-bba4-036bfa877040.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in his or her hand on the bottom of his or her library in any order, then draws that many cards. (That player draws his or her card for the turn first.)",
             "colours": [],
@@ -21926,7 +21926,7 @@
         },
         {
             "id": "442a7857-0a0c-5b83-9551-897727b7f020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178da82b-161e-47f8-9458-a24926c33e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178da82b-161e-47f8-9458-a24926c33e66.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -21955,7 +21955,7 @@
         },
         {
             "id": "881e1266-3190-5ed9-9a01-d42b267b2b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ef3879-f708-4e2d-a1bc-6a75584fd8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ef3879-f708-4e2d-a1bc-6a75584fd8b1.jpg?1",
             "name": "Throne of Bone",
             "text": "Whenever a player plays a black spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -21984,7 +21984,7 @@
         },
         {
             "id": "32300e1f-b21a-57a5-b299-0be7ae03dbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5148acc2-ef45-40f8-b012-13ca0a16041a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5148acc2-ef45-40f8-b012-13ca0a16041a.jpg?1",
             "name": "Throne of Bone",
             "text": "",
             "colours": [],
@@ -22013,7 +22013,7 @@
         },
         {
             "id": "21dfd03f-5104-588b-acff-95c68bde4edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40375cf-8649-4f06-9e08-f0577f35d1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40375cf-8649-4f06-9e08-f0577f35d1bf.jpg?1",
             "name": "Urza's Armor",
             "text": "If a source would deal damage to you, prevent 1 of that damage.",
             "colours": [],
@@ -22042,7 +22042,7 @@
         },
         {
             "id": "acadc22b-c5f1-5ab3-b63c-92746817aa9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff64fe85-416b-4727-b04f-5c00ea010506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff64fe85-416b-4727-b04f-5c00ea010506.jpg?1",
             "name": "Urza's Armor",
             "text": "",
             "colours": [],
@@ -22071,7 +22071,7 @@
         },
         {
             "id": "d2e2cd58-55a0-5584-8c1e-f78acca37b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1e748b-c836-45f1-96af-ced0cc5aed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1e748b-c836-45f1-96af-ced0cc5aed9f.jpg?1",
             "name": "Vexing Arcanix",
             "text": "{3}, {T}: Target player names a card, then reveals the top card of his or her library. If it's the named card, the player puts it into his or her hand. Otherwise, the player puts it into his or her graveyard and Vexing Arcanix deals 2 damage to him or her.",
             "colours": [],
@@ -22100,7 +22100,7 @@
         },
         {
             "id": "011b843c-b978-5e2d-8ce5-26ad8b93c170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cd438-3d1f-4abe-a10a-90838b0eb6ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cd438-3d1f-4abe-a10a-90838b0eb6ff.jpg?1",
             "name": "Vexing Arcanix",
             "text": "",
             "colours": [],
@@ -22129,7 +22129,7 @@
         },
         {
             "id": "0245e766-b437-5a7f-b8c0-6f814265393f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f34f06-7f89-4f2b-8979-8219ac1c4560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f34f06-7f89-4f2b-8979-8219ac1c4560.jpg?1",
             "name": "Wall of Spears",
             "text": "(Walls can't attack.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -22161,7 +22161,7 @@
         },
         {
             "id": "27ef7ce3-9f26-5196-9942-2e9be5864fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dd88c-58e9-44c9-9ff0-d1844a23b6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dd88c-58e9-44c9-9ff0-d1844a23b6ee.jpg?1",
             "name": "Wall of Spears",
             "text": "",
             "colours": [],
@@ -22193,7 +22193,7 @@
         },
         {
             "id": "b20600a6-1cec-5e2a-b3d0-bcdbc3ed59dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5310b3a7-0a85-4469-be88-5c7ab1de4f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5310b3a7-0a85-4469-be88-5c7ab1de4f4a.jpg?1",
             "name": "Wooden Sphere",
             "text": "Whenever a player plays a green spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -22222,7 +22222,7 @@
         },
         {
             "id": "b74a060d-1de2-518b-98ae-359d593884f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068a6e48-e354-493a-9b28-1d667a58c326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068a6e48-e354-493a-9b28-1d667a58c326.jpg?1",
             "name": "Wooden Sphere",
             "text": "",
             "colours": [],
@@ -22251,7 +22251,7 @@
         },
         {
             "id": "ca450533-cdb5-56bf-b143-9bac47abdd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03220cab-fc78-4323-bd34-b8dbebe35597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03220cab-fc78-4323-bd34-b8dbebe35597.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -22280,7 +22280,7 @@
         },
         {
             "id": "9c6b7ec3-c8c8-5f69-b54c-64bce22d342a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf58637-1560-4851-b4f9-9fa564de4fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf58637-1560-4851-b4f9-9fa564de4fd6.jpg?1",
             "name": "City of Brass",
             "text": "",
             "colours": [],
@@ -22309,7 +22309,7 @@
         },
         {
             "id": "1e209a21-5886-5f25-8e13-8264174b09cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9513c206-b578-4973-93cc-077e5a6658b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9513c206-b578-4973-93cc-077e5a6658b0.jpg?1",
             "name": "Coastal Tower",
             "text": "Coastal Tower comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -22341,7 +22341,7 @@
         },
         {
             "id": "07a55fc6-8ad2-5539-9384-2fa9290e8bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25271fc6-a6dc-4761-8374-8a4c41702a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25271fc6-a6dc-4761-8374-8a4c41702a79.jpg?1",
             "name": "Coastal Tower",
             "text": "",
             "colours": [],
@@ -22373,7 +22373,7 @@
         },
         {
             "id": "ce905c1e-029d-54df-b632-680bfc71a49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e7061a-3b13-466e-b4d0-2769a179b985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e7061a-3b13-466e-b4d0-2769a179b985.jpg?1",
             "name": "Elfhame Palace",
             "text": "Elfhame Palace comes into play tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -22405,7 +22405,7 @@
         },
         {
             "id": "1871629d-3f00-524b-b2f0-80748336839c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2038371-f6c8-4676-97f3-9e878b096ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2038371-f6c8-4676-97f3-9e878b096ff7.jpg?1",
             "name": "Elfhame Palace",
             "text": "",
             "colours": [],
@@ -22437,7 +22437,7 @@
         },
         {
             "id": "585f8e80-3541-5f55-8ad4-6cb28ffa3e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac23896-d4c9-4543-9edc-1d1bb5c74611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac23896-d4c9-4543-9edc-1d1bb5c74611.jpg?1",
             "name": "Salt Marsh",
             "text": "Salt Marsh comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -22469,7 +22469,7 @@
         },
         {
             "id": "1ab0ab3b-1edd-51cb-a303-d5fa7c73dc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d850d74-d751-4644-b5bb-5dc62a00f42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d850d74-d751-4644-b5bb-5dc62a00f42c.jpg?1",
             "name": "Salt Marsh",
             "text": "",
             "colours": [],
@@ -22501,7 +22501,7 @@
         },
         {
             "id": "a1feac78-df8d-5370-8d04-41196ed024aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008d427-b029-409e-b93a-efa86c8777c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008d427-b029-409e-b93a-efa86c8777c3.jpg?1",
             "name": "Shivan Oasis",
             "text": "Shivan Oasis comes into play tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -22533,7 +22533,7 @@
         },
         {
             "id": "54d98deb-5b7f-5136-a5c7-88c0bdf729c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1690a710-e869-4d96-8aa2-991d73b1d46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1690a710-e869-4d96-8aa2-991d73b1d46a.jpg?1",
             "name": "Shivan Oasis",
             "text": "",
             "colours": [],
@@ -22565,7 +22565,7 @@
         },
         {
             "id": "eb0bf20e-ebae-556c-a2b7-c7d66affc645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f98c5c9-cd15-40f7-9aa1-575906df3eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f98c5c9-cd15-40f7-9aa1-575906df3eda.jpg?1",
             "name": "Urborg Volcano",
             "text": "Urborg Volcano comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -22597,7 +22597,7 @@
         },
         {
             "id": "e8bdd481-758e-5c51-bdb2-6bc65d310c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e652c20-78d6-4330-aa53-e393b775614d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e652c20-78d6-4330-aa53-e393b775614d.jpg?1",
             "name": "Urborg Volcano",
             "text": "",
             "colours": [],
@@ -22629,7 +22629,7 @@
         },
         {
             "id": "ed2911b2-bb08-5a26-89a9-dbe6c86acefe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eedb94c-058e-4c3a-96cf-e6624c03d26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eedb94c-058e-4c3a-96cf-e6624c03d26e.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Power-Plant and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22661,7 +22661,7 @@
         },
         {
             "id": "8bdfbeef-cc62-5eca-a05c-8785de78c4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cf2e06-90cc-4acc-8874-5cd4b2a4abf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cf2e06-90cc-4acc-8874-5cd4b2a4abf9.jpg?1",
             "name": "Urza's Mine",
             "text": "",
             "colours": [],
@@ -22693,7 +22693,7 @@
         },
         {
             "id": "97cf943c-def3-5ae7-826c-907ca0cc3a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4499c80b-72af-485c-9106-22967b5252cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4499c80b-72af-485c-9106-22967b5252cd.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22725,7 +22725,7 @@
         },
         {
             "id": "59c41603-efcb-5166-bbdc-2ecb0992db7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b1bbc3-eab3-4e30-8ebc-f4ef5ef0282b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b1bbc3-eab3-4e30-8ebc-f4ef5ef0282b.jpg?1",
             "name": "Urza's Power Plant",
             "text": "",
             "colours": [],
@@ -22757,7 +22757,7 @@
         },
         {
             "id": "f5fd6901-debd-5f07-b4bc-7e31f770ae79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c6dc88-ef09-4b37-b9e8-c483cccd0e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c6dc88-ef09-4b37-b9e8-c483cccd0e0e.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Power-Plant, add {3} to your mana pool instead.",
             "colours": [],
@@ -22789,7 +22789,7 @@
         },
         {
             "id": "c2149f4f-6cab-5cdc-8eb6-056575502548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce1817d-1870-4011-809f-aef3841e779a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce1817d-1870-4011-809f-aef3841e779a.jpg?1",
             "name": "Urza's Tower",
             "text": "",
             "colours": [],
@@ -22821,7 +22821,7 @@
         },
         {
             "id": "d4facd58-20e3-5032-ab7f-97b5478cfa15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c667a-f035-49b2-9f34-9831e186ae82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c667a-f035-49b2-9f34-9831e186ae82.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22862,7 +22862,7 @@
         },
         {
             "id": "e37eab30-b842-558e-9378-6db02acac4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8427be4a-126e-4188-9f3f-ad67b9d7fea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8427be4a-126e-4188-9f3f-ad67b9d7fea5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22903,7 +22903,7 @@
         },
         {
             "id": "c005f67e-6d2d-5524-bc4c-f9ce1818edd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c88ade7-4b1c-4380-a19a-8ba18fa4adaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c88ade7-4b1c-4380-a19a-8ba18fa4adaa.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22944,7 +22944,7 @@
         },
         {
             "id": "255b949b-48f2-5cb2-a8dd-ce61243f799b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5a611-ad7b-4654-a8f1-d024056c346e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5a611-ad7b-4654-a8f1-d024056c346e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22985,7 +22985,7 @@
         },
         {
             "id": "d845fcc0-55f8-5cf4-9600-22bfdfd19901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dd5b8c-2c2f-4185-b176-a94b43729a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dd5b8c-2c2f-4185-b176-a94b43729a29.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23026,7 +23026,7 @@
         },
         {
             "id": "1ec09c95-8523-5eb4-b27e-036306e677ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a34be94-2b31-45a8-9857-02a1cc29f4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a34be94-2b31-45a8-9857-02a1cc29f4cb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23067,7 +23067,7 @@
         },
         {
             "id": "6bfa3eca-3f4d-5bd4-af21-b4f4dd4540e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74b27d-2381-496d-a3ef-af3722c7b4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74b27d-2381-496d-a3ef-af3722c7b4e7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23108,7 +23108,7 @@
         },
         {
             "id": "eb74b1ce-66e5-56e9-b685-72b1762bf840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48af31-8309-46fb-b178-657c3e2fa05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48af31-8309-46fb-b178-657c3e2fa05a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23149,7 +23149,7 @@
         },
         {
             "id": "b3195a42-446c-5442-a7a6-46982eec1c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4146a316-c409-4121-931f-1d3b5ae63675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4146a316-c409-4121-931f-1d3b5ae63675.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23190,7 +23190,7 @@
         },
         {
             "id": "b32bb28d-640b-5f72-b4f0-9c6592788eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d01acc2-bafa-47c9-92ff-b737f1f31f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d01acc2-bafa-47c9-92ff-b737f1f31f16.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23231,7 +23231,7 @@
         },
         {
             "id": "da489e9d-efc8-5d6d-a31f-942e81daa139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f307e72-f33e-4fb1-b15f-a46ab389c20f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f307e72-f33e-4fb1-b15f-a46ab389c20f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23272,7 +23272,7 @@
         },
         {
             "id": "381ea7bb-61fc-5662-b4f2-cac949697d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4e347-90ad-43c7-a236-3ee4d887f069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4e347-90ad-43c7-a236-3ee4d887f069.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23313,7 +23313,7 @@
         },
         {
             "id": "4ee0292a-cd9b-5970-998b-f2e0dca31457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63bc639-5518-4103-8290-c781a6f53f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63bc639-5518-4103-8290-c781a6f53f81.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23354,7 +23354,7 @@
         },
         {
             "id": "20a6df8a-67a6-54ec-a5fa-48c90d34f4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed74e8a1-5636-4d96-aff4-4674494c5e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed74e8a1-5636-4d96-aff4-4674494c5e00.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23395,7 +23395,7 @@
         },
         {
             "id": "78e1fe2e-44c8-5b06-8068-27f943839aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6459577-6834-4f4e-ad7d-a506bef1d372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6459577-6834-4f4e-ad7d-a506bef1d372.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23436,7 +23436,7 @@
         },
         {
             "id": "5c7324ee-c68c-58e7-ad24-dc4b403b78ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e19-0692-4f09-bb99-1b864bfbb479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e19-0692-4f09-bb99-1b864bfbb479.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23477,7 +23477,7 @@
         },
         {
             "id": "c35f693f-8a24-53b9-8f57-167668e8627d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b5162-8724-4df3-a3d5-274036d0049d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b5162-8724-4df3-a3d5-274036d0049d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23518,7 +23518,7 @@
         },
         {
             "id": "66340be0-64dd-50f7-ba74-2b9c11552c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f59dee4-89d0-47bf-ace7-901944b7dcc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f59dee4-89d0-47bf-ace7-901944b7dcc3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23559,7 +23559,7 @@
         },
         {
             "id": "5a400b3d-c3db-5862-aa24-2ab93122f51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22687920-e310-4122-a01d-2aff720d2071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22687920-e310-4122-a01d-2aff720d2071.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23600,7 +23600,7 @@
         },
         {
             "id": "3b92db59-af74-5a61-8072-4731462aa00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88091ab-6fda-4516-b180-daff10cd2417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88091ab-6fda-4516-b180-daff10cd2417.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23641,7 +23641,7 @@
         },
         {
             "id": "577cd441-6ce4-5188-8263-92c79a3550ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f548a-9e41-4b95-812d-a739d945123f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f548a-9e41-4b95-812d-a739d945123f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23682,7 +23682,7 @@
         },
         {
             "id": "9ab66be7-f0d7-5aa9-8972-fba223ba37c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d56d1-ba2c-49d3-bbb9-2c29f09fd9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d56d1-ba2c-49d3-bbb9-2c29f09fd9b5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23723,7 +23723,7 @@
         },
         {
             "id": "a222f3d6-35b7-578d-9bec-29a50f0f50a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3125bc4d-7e9e-4133-8d11-1abf3dc2cec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3125bc4d-7e9e-4133-8d11-1abf3dc2cec9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23764,7 +23764,7 @@
         },
         {
             "id": "e459bfea-0abf-5067-9163-c0c1642e171c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8cdf65-0113-47c3-a0d5-e0b74c333c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8cdf65-0113-47c3-a0d5-e0b74c333c81.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23805,7 +23805,7 @@
         },
         {
             "id": "b37bd5f8-de0d-52f1-94b7-d44da96f4b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f243292a-e8a6-43c2-805c-15715fcebd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f243292a-e8a6-43c2-805c-15715fcebd67.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23846,7 +23846,7 @@
         },
         {
             "id": "aa9efc5e-f28a-57ea-b724-0832e62592ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32eb6ab0-831e-4a30-a2fc-5ea1cb40930c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32eb6ab0-831e-4a30-a2fc-5ea1cb40930c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23887,7 +23887,7 @@
         },
         {
             "id": "fdfd3590-38a7-5b7f-8462-035414c1912c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49c0db1-5acc-48ed-a0f0-0510433d6d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49c0db1-5acc-48ed-a0f0-0510433d6d34.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23928,7 +23928,7 @@
         },
         {
             "id": "5071ae7d-3a07-511e-ae55-bb498a8296cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62465f68-6a84-41ae-8a14-41f41e817eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62465f68-6a84-41ae-8a14-41f41e817eff.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23969,7 +23969,7 @@
         },
         {
             "id": "839104e3-a92c-5a1a-94f7-820347935993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5339dcb-2544-4f19-acf3-86f83793301c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5339dcb-2544-4f19-acf3-86f83793301c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -24010,7 +24010,7 @@
         },
         {
             "id": "72d25549-aac6-5cb5-b114-fd77f6752b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060a07b-7408-4b95-a546-e2b2010d7818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060a07b-7408-4b95-a546-e2b2010d7818.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -24051,7 +24051,7 @@
         },
         {
             "id": "223ea81d-512f-53b3-9dfe-b917d12af141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267a5fa-f9a9-4a7f-89f9-24889868ccff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267a5fa-f9a9-4a7f-89f9-24889868ccff.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -24092,7 +24092,7 @@
         },
         {
             "id": "d0ab9f0f-65a6-5923-86be-f8c69f000dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628ee82b-1f10-4466-bdca-75c0f89d49c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628ee82b-1f10-4466-bdca-75c0f89d49c9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -24133,7 +24133,7 @@
         },
         {
             "id": "5f10bbd8-c2e5-5e96-8545-4d3e77a02d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82d07b-f8f2-4cdd-b799-98d4dc228e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82d07b-f8f2-4cdd-b799-98d4dc228e5c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24174,7 +24174,7 @@
         },
         {
             "id": "44d1f231-23cd-5f6c-ad19-e8cc20e0308e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d62e37-c8ab-4768-9be2-24546d5ded8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d62e37-c8ab-4768-9be2-24546d5ded8c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24215,7 +24215,7 @@
         },
         {
             "id": "6d382bb5-924b-544f-b213-578561df1f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce08c3b-3d08-446e-9f78-4ec22e9308db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce08c3b-3d08-446e-9f78-4ec22e9308db.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24256,7 +24256,7 @@
         },
         {
             "id": "4732dfdc-928d-5b3b-8393-4930ccf3e87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7ca58-e8db-49f5-954a-c4f83fcb44b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7ca58-e8db-49f5-954a-c4f83fcb44b3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24297,7 +24297,7 @@
         },
         {
             "id": "5b8be905-a342-5e94-9f21-7d3f662f2820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee631d-de1e-4c6f-b60e-0e97a5e99fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee631d-de1e-4c6f-b60e-0e97a5e99fe6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24338,7 +24338,7 @@
         },
         {
             "id": "a3c75459-48f0-5fb6-b7a7-4300a4204d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdee883-2002-43c7-a0fd-29e7ada26963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdee883-2002-43c7-a0fd-29e7ada26963.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24379,7 +24379,7 @@
         },
         {
             "id": "0fa3aa1f-c80f-5f8c-b426-be545d4a92d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec41fec-d146-40cc-8d9f-633e913f3ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec41fec-d146-40cc-8d9f-633e913f3ab3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24420,7 +24420,7 @@
         },
         {
             "id": "1420738a-fc87-5f91-b51f-e7254dedbc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f0207-228e-4812-bc5b-ee22cd5fd51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f0207-228e-4812-bc5b-ee22cd5fd51e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/9ED.json
+++ b/Assets/Resources/Sets/9ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "61dbf877-9b49-58dc-b18f-5e8eb26c2dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112433-ae29-4f6a-9798-234c58ff5920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112433-ae29-4f6a-9798-234c58ff5920.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b70b6118-1c56-5b20-92c5-c16357f5d3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a4fffa-e21f-4470-9db8-1e7e218b02a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a4fffa-e21f-4470-9db8-1e7e218b02a2.jpg?1",
             "name": "Angel of Mercy",
             "text": "",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "10afa9c9-8d12-55c9-a4d1-bd9a5d6eaf46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0732d372-1000-435e-905b-4a6c852ba427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0732d372-1000-435e-905b-4a6c852ba427.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "dc256d28-7919-54e6-8b7c-e93d9deecc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490d714e-1ccb-4ad0-9854-f14da2e90f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490d714e-1ccb-4ad0-9854-f14da2e90f7c.jpg?1",
             "name": "Angelic Blessing",
             "text": "Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "f3ee008c-32cf-585a-b4c5-bdc961e5ca03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6d93a9-9cff-4e7c-9cf7-7e5167ac4d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6d93a9-9cff-4e7c-9cf7-7e5167ac4d91.jpg?1",
             "name": "Angelic Blessing",
             "text": "",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "db95d2fe-3ede-5b2f-8f2a-e5044a6533c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e7a88-d721-490f-8b62-23ce58092be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e7a88-d721-490f-8b62-23ce58092be8.jpg?1",
             "name": "Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "809ddea1-e0a6-5e90-b5a1-8d9312bdb61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17844d4-6316-4045-8fd3-194640b10bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17844d4-6316-4045-8fd3-194640b10bbe.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "7c810360-6601-5e1d-b391-bb5b4b7a8836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586e5a04-9edb-4d27-8018-256db22dc524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586e5a04-9edb-4d27-8018-256db22dc524.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "905acf47-97d7-5da3-b5d8-9860cbf34a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "81282847-ead5-562a-b5b3-a56731f62ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c97d63-d0f9-402d-948a-b73f73bed919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c97d63-d0f9-402d-948a-b73f73bed919.jpg?1",
             "name": "Aven Flock",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{W}: Aven Flock gets +0/+1 until end of turn.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "d41ef5b6-281d-5b7c-9898-db135d1967c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b5887e-ac30-4552-8457-01ae5a196c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b5887e-ac30-4552-8457-01ae5a196c1c.jpg?1",
             "name": "Aven Flock",
             "text": "",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "7836bea3-5344-5352-8a2f-2a62f90e652c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391d681-3530-4f6a-b421-12025e7c3b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391d681-3530-4f6a-b421-12025e7c3b89.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "2a3bf07f-3d91-5a9e-ab50-203de0f063be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb5923b-f2c1-47c4-af1f-af24ac7cb56b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb5923b-f2c1-47c4-af1f-af24ac7cb56b.jpg?1",
             "name": "Ballista Squad",
             "text": "{X}{W}, {T}: Ballista Squad deals X damage to target attacking or blocking creature.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "9ec0659e-ea83-5eda-88fb-6eb8224908cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede7b9ad-9c88-4319-a7f7-c9bee4be3c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede7b9ad-9c88-4319-a7f7-c9bee4be3c1c.jpg?1",
             "name": "Ballista Squad",
             "text": "",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "426b3a93-6494-5397-870a-9e02b81a95bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01491b39-283b-438f-8c7c-8df1285e9a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01491b39-283b-438f-8c7c-8df1285e9a83.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "7614f14d-e0d9-5553-9fc7-2db7ea5a96be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c044857-2124-44f4-aafb-495511f26b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c044857-2124-44f4-aafb-495511f26b3b.jpg?1",
             "name": "Blessed Orator",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -554,7 +554,7 @@
         },
         {
             "id": "e643802d-a1b6-582a-b3d1-3b5ef21b8083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379777a4-5704-4b5a-9916-7bab4d82eeab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379777a4-5704-4b5a-9916-7bab4d82eeab.jpg?1",
             "name": "Blessed Orator",
             "text": "",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "66104f32-e94e-578b-8928-7c97cad85d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04256f8-c275-4a24-8a95-371d424f7a01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04256f8-c275-4a24-8a95-371d424f7a01.jpg?1",
             "name": "Blinding Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Blinding Angel deals combat damage to a player, that player skips his or her next combat phase.",
             "colours": [
@@ -625,7 +625,7 @@
         },
         {
             "id": "dc40e046-0ac3-5a36-8944-ec0c51cce415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbba7702-6970-4501-918b-b262e0fa8b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbba7702-6970-4501-918b-b262e0fa8b28.jpg?1",
             "name": "Blinding Angel",
             "text": "",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "b5c3bbd2-b0dc-5169-a503-e65a686b2611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a82ffff-e02a-4ecb-a92d-8ed571beac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a82ffff-e02a-4ecb-a92d-8ed571beac46.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "f45d8c36-c5c9-595d-9892-cd6101f8c136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ac387-be1f-48e0-945e-cbb1254d395c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ac387-be1f-48e0-945e-cbb1254d395c.jpg?1",
             "name": "Blinking Spirit",
             "text": "{0}: Return Blinking Spirit to its owner's hand.",
             "colours": [
@@ -729,7 +729,7 @@
         },
         {
             "id": "9a568028-b633-508c-ba29-38883c0fcc86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b340426-b852-43a5-8868-d5dacfdaf031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b340426-b852-43a5-8868-d5dacfdaf031.jpg?1",
             "name": "Blinking Spirit",
             "text": "",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "3d3f2568-6dfc-5ae9-94ec-189adfb8e396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f026d65f-c365-475b-9454-e9935af00ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f026d65f-c365-475b-9454-e9935af00ec4.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -798,7 +798,7 @@
         },
         {
             "id": "ba1936c9-983c-5316-a2e9-8950cc6a094b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e0d3d9-8c28-46d7-9fab-c115e6c8682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e0d3d9-8c28-46d7-9fab-c115e6c8682f.jpg?1",
             "name": "Chastise",
             "text": "Destroy target attacking creature. You gain life equal to its power.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "31069c30-388f-58d5-93b9-a61f6183a5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe622c34-7b41-4855-a07f-a2ff773a2745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe622c34-7b41-4855-a07f-a2ff773a2745.jpg?1",
             "name": "Chastise",
             "text": "",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "9cc993d4-352b-5fa3-9e10-e4244f8621f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681faafe-68ce-4b71-bf23-a8028614ede5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681faafe-68ce-4b71-bf23-a8028614ede5.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -897,7 +897,7 @@
         },
         {
             "id": "d69b3de2-fe8a-51fb-ab11-8589e552dfb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab2933-5970-4a17-ac00-abcd2c048fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab2933-5970-4a17-ac00-abcd2c048fdc.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "{1}: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "17372879-175f-56c0-bb0d-f1a6c1bd6713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4945b-59fc-47aa-8f41-41d5afdf5775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4945b-59fc-47aa-8f41-41d5afdf5775.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "",
             "colours": [
@@ -963,7 +963,7 @@
         },
         {
             "id": "fe3440de-6184-5464-af4c-63f5d462b1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010c3ded-9df5-4880-b178-80f0e3c54731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010c3ded-9df5-4880-b178-80f0e3c54731.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "db283cdc-be8d-5065-acd6-09559065bf49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7920b6d-ff71-4802-9589-e1df0c58b9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7920b6d-ff71-4802-9589-e1df0c58b9ff.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "{1}: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "bc2ad842-8f54-5b5b-8dc4-798c1612dcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757645fa-5f76-4300-b46c-7cd84e9304f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757645fa-5f76-4300-b46c-7cd84e9304f8.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "c00ad957-9ccb-5fd2-b632-4350fba4eead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d962926a-e415-4075-b5dd-3db68526bdb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d962926a-e415-4075-b5dd-3db68526bdb9.jpg?1",
             "name": "Crossbow Infantry",
             "text": "{T}: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "836a381b-d524-5d24-bda8-c6e319277947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1",
             "name": "Crossbow Infantry",
             "text": "",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "0e8099a7-178d-51ed-b0b9-c442a9bef212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2f98f8-f345-4cd4-90c5-43bc4c4c165d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2f98f8-f345-4cd4-90c5-43bc4c4c165d.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "3326b69e-a683-5080-9705-8b6c106302e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eea828-1a88-4470-aa04-8003343cb92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eea828-1a88-4470-aa04-8003343cb92e.jpg?1",
             "name": "Demystify",
             "text": "",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "00f1c7dc-96b4-52c0-bc64-66b621c69330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baff03f3-a8ca-4c35-ae71-43b5d237b519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baff03f3-a8ca-4c35-ae71-43b5d237b519.jpg?1",
             "name": "Foot Soldiers",
             "text": "",
             "colours": [
@@ -1238,7 +1238,7 @@
         },
         {
             "id": "fc25d285-b294-5812-8f86-fc24177ec14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c39ff7-6234-4cc8-be5c-dd8ff9284a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c39ff7-6234-4cc8-be5c-dd8ff9284a07.jpg?1",
             "name": "Foot Soldiers",
             "text": "",
             "colours": [
@@ -1274,7 +1274,7 @@
         },
         {
             "id": "53020381-5933-53c0-8a79-964a456bc5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b109388-7988-4092-8cf4-c56668a4c66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b109388-7988-4092-8cf4-c56668a4c66b.jpg?1",
             "name": "Gift of Estates",
             "text": "If an opponent has more lands than you, search your library for up to three Plains cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "619d5559-c1c8-5b13-a9c3-e88a2dc8e641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896389ba-a509-4a9c-b35b-c2b122df3fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896389ba-a509-4a9c-b35b-c2b122df3fa4.jpg?1",
             "name": "Gift of Estates",
             "text": "",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "7a434b8e-8fa7-59ce-911a-77b000fa0cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a94e8-baba-42e1-8577-03bbaa8f5707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a94e8-baba-42e1-8577-03bbaa8f5707.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1373,7 +1373,7 @@
         },
         {
             "id": "38e06c9e-5b08-5485-85b6-ed5a75a2a6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f720431d-dbb6-42ed-ac4d-13e2b51c1ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f720431d-dbb6-42ed-ac4d-13e2b51c1ddf.jpg?1",
             "name": "Glorious Anthem",
             "text": "",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "c451546c-92d8-5f26-90d1-5c0f8bf1c791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979748a-4820-4c6a-b4b0-1bfb46e2817a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979748a-4820-4c6a-b4b0-1bfb46e2817a.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1442,7 +1442,7 @@
         },
         {
             "id": "9c92564f-6648-5561-a2ce-ba888bf95733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d275a-28fc-4c06-bd4d-a4f2e03574f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d275a-28fc-4c06-bd4d-a4f2e03574f6.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "f11ff4a2-8649-5a9d-b628-e282ae104060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adefbeb-c9fc-48b7-9030-cd0d367dd19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adefbeb-c9fc-48b7-9030-cd0d367dd19e.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "6e792158-58f3-55bb-9e06-6423701b70fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98746ce2-aa9d-4099-b25b-14f9f809d7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98746ce2-aa9d-4099-b25b-14f9f809d7ed.jpg?1",
             "name": "Holy Day",
             "text": "",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "e26e56ed-49b6-5781-a3fd-ff051390e830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7848f996-ea89-43fd-b0b3-4437f397531a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7848f996-ea89-43fd-b0b3-4437f397531a.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "175fa96e-41ae-57c1-9be4-151596f843ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb4a027-3d07-420a-b191-2172fe871c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb4a027-3d07-420a-b191-2172fe871c13.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "863213b2-843a-5dd3-81f0-47c152884c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f208a8-115a-4734-b56a-9330018cb269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f208a8-115a-4734-b56a-9330018cb269.jpg?1",
             "name": "Honor Guard",
             "text": "{W}: Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "85ca68f1-fec7-5b65-8aa0-8ceb0ab69c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ab7db-467f-483e-9bcd-3a484e1d0df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ab7db-467f-483e-9bcd-3a484e1d0df6.jpg?1",
             "name": "Honor Guard",
             "text": "",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "d5d8fcb0-d93d-5fb6-92eb-ec664fd21828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2b04aa-6643-4eae-9197-4acd7d3e3535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2b04aa-6643-4eae-9197-4acd7d3e3535.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "9c44790b-fa6c-58be-a665-06955e53548e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6692c670-d33c-4e6f-87db-4e9dcbc18ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6692c670-d33c-4e6f-87db-4e9dcbc18ab8.jpg?1",
             "name": "Infantry Veteran",
             "text": "",
             "colours": [
@@ -1758,7 +1758,7 @@
         },
         {
             "id": "9403430a-70b7-58f6-b5df-74affff4e75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d30356b-ab7b-4366-9f90-15703d5c3d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d30356b-ab7b-4366-9f90-15703d5c3d10.jpg?1",
             "name": "Inspirit",
             "text": "Untap target creature. It gets +2/+4 until end of turn.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "7029ca48-4f51-5bab-adcd-c84a7787de37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f13470-78c5-48e5-8ad2-23bf20843ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f13470-78c5-48e5-8ad2-23bf20843ebe.jpg?1",
             "name": "Inspirit",
             "text": "",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "d833132b-f40d-5c0f-bf59-551148c61070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02422f7-728b-481b-9eb1-34d17c696ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02422f7-728b-481b-9eb1-34d17c696ce6.jpg?1",
             "name": "Ivory Mask",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "d03f1f8c-ec53-5150-af5e-eeccfefcc948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15221c5b-543c-4f43-a02e-d07e84069f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15221c5b-543c-4f43-a02e-d07e84069f50.jpg?1",
             "name": "Ivory Mask",
             "text": "",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "18ee8a9d-387e-574e-a17d-e70c25f6c462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422fe3bd-d92e-4c91-8c30-3b5aec00201a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422fe3bd-d92e-4c91-8c30-3b5aec00201a.jpg?1",
             "name": "Kami of Old Stone",
             "text": "",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "554a0c49-9a67-5dc7-a3f8-3e75fe2832aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab27f51-230c-469d-9b8a-a21b9d0fccf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab27f51-230c-469d-9b8a-a21b9d0fccf5.jpg?1",
             "name": "Kami of Old Stone",
             "text": "",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "cb9865b4-f7eb-5549-8adf-c7cb247ae0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415fb9e-fe47-435d-b47d-b0e62f51d327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415fb9e-fe47-435d-b47d-b0e62f51d327.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "5dd7f286-bf6c-5625-bd4c-c2b67df57248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb06f76-cbf0-42bb-adc0-0811d077b3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb06f76-cbf0-42bb-adc0-0811d077b3e0.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "66b3fcf1-9e84-54ad-8975-a142e6d84adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4816f18-9f66-4539-9764-2f65f2826812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4816f18-9f66-4539-9764-2f65f2826812.jpg?1",
             "name": "Marble Titan",
             "text": "Creatures with power 3 or greater don't untap during their controllers' untap steps.",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "9231da68-6c9c-53f9-bf24-03751de46689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64b1fae-6e5a-46b4-8966-7e39c777604e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64b1fae-6e5a-46b4-8966-7e39c777604e.jpg?1",
             "name": "Marble Titan",
             "text": "",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "fa1fa246-c5ae-5604-94cd-2fe49a66ecb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a49276-fb02-4b8b-8b63-7477835fb809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a49276-fb02-4b8b-8b63-7477835fb809.jpg?1",
             "name": "Master Decoy",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "207429c1-edc4-59be-93f9-b269e69de3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce511578-8857-45a8-98fe-c8b0bfc54fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce511578-8857-45a8-98fe-c8b0bfc54fcb.jpg?1",
             "name": "Master Decoy",
             "text": "",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "5047bdae-a0ad-5eba-bf71-d5467393776d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a4a15d-9f16-4aa1-adc0-5d4c85991062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a4a15d-9f16-4aa1-adc0-5d4c85991062.jpg?1",
             "name": "Master Healer",
             "text": "{T}: Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2210,7 +2210,7 @@
         },
         {
             "id": "0d7c6f13-a0f3-58b5-b4e7-c157e76a499d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4145d8e-40cc-49ab-83c6-394d4595a1a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4145d8e-40cc-49ab-83c6-394d4595a1a4.jpg?1",
             "name": "Master Healer",
             "text": "",
             "colours": [
@@ -2246,7 +2246,7 @@
         },
         {
             "id": "c4b50fe2-1b65-5444-a56b-a806676a494e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53709642-9d61-425f-9bcf-0c579404b521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53709642-9d61-425f-9bcf-0c579404b521.jpg?1",
             "name": "Mending Hands",
             "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "2a37fb5b-b65e-5b7d-bdbf-f7a226c54329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad55756-15c6-4c07-8b1c-1b8327c40f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad55756-15c6-4c07-8b1c-1b8327c40f14.jpg?1",
             "name": "Mending Hands",
             "text": "",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "8678370b-c6d7-5dcc-98b9-561fbf014dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a180a4-bffc-4f4f-ae34-3afa4a565960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a180a4-bffc-4f4f-ae34-3afa4a565960.jpg?1",
             "name": "Oracle's Attendants",
             "text": "{T}: All damage that would be dealt to target creature this turn by a source of your choice is dealt to Oracle's Attendants instead.",
             "colours": [
@@ -2348,7 +2348,7 @@
         },
         {
             "id": "c8716743-fc3d-5168-b33c-78659a7bae12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b645a86e-2fca-451e-8bda-9f4bd0c5db04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b645a86e-2fca-451e-8bda-9f4bd0c5db04.jpg?1",
             "name": "Oracle's Attendants",
             "text": "",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "2be8be24-21a9-5faf-84bc-0a91efae0b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4f7e7-31fa-4009-9b23-cdc2060be8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4f7e7-31fa-4009-9b23-cdc2060be8b8.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature can't attack or block.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "62961390-072a-51c8-b8cf-f4443c6d3c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a91a5-b897-413e-8fd1-482448a92d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a91a5-b897-413e-8fd1-482448a92d83.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "a2dffd4d-d652-5f31-a738-d28c3d36f684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc33dd-0ad6-482c-b29f-71dad8b4166b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc33dd-0ad6-482c-b29f-71dad8b4166b.jpg?1",
             "name": "Paladin en-Vec",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from black, protection from red (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black or red.)",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "27acb0c6-070e-5e85-baeb-69c13accf05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05825222-8f73-460b-8066-1b77961325e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05825222-8f73-460b-8066-1b77961325e0.jpg?1",
             "name": "Paladin en-Vec",
             "text": "",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "76de0842-e7de-56ac-91cb-7a78916190c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b9e34-1ffb-4e46-b08c-d6587f350391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b9e34-1ffb-4e46-b08c-d6587f350391.jpg?1",
             "name": "Peace of Mind",
             "text": "{W}, Discard a card: You gain 3 life.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "b03090b9-d70d-5fe7-8f63-2a7f5210de18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ecac8-2061-4e4f-b178-6cfd2f429855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ecac8-2061-4e4f-b178-6cfd2f429855.jpg?1",
             "name": "Peace of Mind",
             "text": "",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "c134fe6c-eac8-59d3-918a-5a97e0d28ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0dee73-4df3-4b2f-9420-b23e6ced65c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0dee73-4df3-4b2f-9420-b23e6ced65c0.jpg?1",
             "name": "Pegasus Charger",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "085fc0ff-0528-50f4-b1d8-eacc86a900cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30e8bea-37f2-47da-baaa-d78fa342ea29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30e8bea-37f2-47da-baaa-d78fa342ea29.jpg?1",
             "name": "Pegasus Charger",
             "text": "",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "11d1ac84-f14c-586f-8fc3-dd16676d8f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f938c52-c7f6-41a4-b480-632b43b60b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f938c52-c7f6-41a4-b480-632b43b60b67.jpg?1",
             "name": "Reverse Damage",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain that much life.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "289af6b2-5104-5b02-97f1-754f332e5819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e5f9e-0693-415a-aad6-339581334e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e5f9e-0693-415a-aad6-339581334e66.jpg?1",
             "name": "Reverse Damage",
             "text": "",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "eb34db01-d6c1-5be1-8b00-e05667695537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dac325-73d7-4377-8f56-14342e7dacd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dac325-73d7-4377-8f56-14342e7dacd7.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "9f7d23f5-5aa4-5a16-883b-141d9c5357e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4b42e-8efd-4b30-932d-c49049e9aff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4b42e-8efd-4b30-932d-c49049e9aff7.jpg?1",
             "name": "Righteousness",
             "text": "",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "e7c687c0-64fc-54a7-9832-d373e78c81b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72dc68a-d6f9-4a18-8282-0f104999591f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72dc68a-d6f9-4a18-8282-0f104999591f.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever a spell or ability an opponent controls causes a land to be put into your graveyard from play, return that land to play.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "a3990c1f-9182-5d05-b5a8-10bd37ccea17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3adae5-0cdc-404c-bb4f-fdf1bc0332cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3adae5-0cdc-404c-bb4f-fdf1bc0332cc.jpg?1",
             "name": "Sacred Ground",
             "text": "",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "de3dacd2-3830-594c-8801-21613ca7a75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd5e1c-47db-4960-860c-2af14b734b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd5e1c-47db-4960-860c-2af14b734b59.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "b3e4d22c-3a45-5c81-9c85-2841d783d3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6b307-c648-4351-bcbd-afadf192ca6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6b307-c648-4351-bcbd-afadf192ca6f.jpg?1",
             "name": "Sacred Nectar",
             "text": "",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "0b262ee6-fb78-5ad3-83fe-acc8539fada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a74bec-ba6c-45f3-bc25-60cda8fa908b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a74bec-ba6c-45f3-bc25-60cda8fa908b.jpg?1",
             "name": "Samite Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "a51eecab-a643-50b6-b3eb-41cb5a237ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371cd55b-9f40-4730-83c1-5fee54d0d7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371cd55b-9f40-4730-83c1-5fee54d0d7f5.jpg?1",
             "name": "Samite Healer",
             "text": "",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "7a641315-66fd-5e82-8f76-da3a05ee9bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166cd9d3-7750-4f41-bffd-8f6739204d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166cd9d3-7750-4f41-bffd-8f6739204d2e.jpg?1",
             "name": "Sanctum Guardian",
             "text": "Sacrifice Sanctum Guardian: The next time a source of your choice would deal damage to target creature or player this turn, prevent that damage.",
             "colours": [
@@ -3034,7 +3034,7 @@
         },
         {
             "id": "cc058797-a069-5f47-bffb-734ead9b1344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab759df-5120-45a9-897e-4729fcbf6eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab759df-5120-45a9-897e-4729fcbf6eb9.jpg?1",
             "name": "Sanctum Guardian",
             "text": "",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "369232f4-85b1-5991-ae78-34d78e4d9b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9f9f3c-d024-4529-bffb-c7a5a3085e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9f9f3c-d024-4529-bffb-c7a5a3085e58.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "370f9f97-d0ee-5760-ae9b-d261990649e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2b107-1938-4d42-9bfa-0c88fd1e822a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2b107-1938-4d42-9bfa-0c88fd1e822a.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "40ba6ed0-96a0-5448-8dc5-d50441407386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed679-d66b-4f3c-83e4-e59ea106b00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed679-d66b-4f3c-83e4-e59ea106b00a.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "0b34180f-7761-5221-90f9-8e52fec70a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49dc8bb-6fde-426e-9779-813af21367ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49dc8bb-6fde-426e-9779-813af21367ef.jpg?1",
             "name": "Seasoned Marshal",
             "text": "",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "165a1bf7-e9fc-50ce-ad1a-3f971c3cad7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71567cb0-f4f3-4e86-a9d3-c207119a3185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71567cb0-f4f3-4e86-a9d3-c207119a3185.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "646a6755-dda4-5c76-b737-10f42738fb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cb23f-52d2-49b2-b07b-39679d695fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cb23f-52d2-49b2-b07b-39679d695fc1.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "ac5fecec-e4f3-54e8-b6a6-fc7e5cac6a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617547a7-087e-49b0-8c28-5aae457bec99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617547a7-087e-49b0-8c28-5aae457bec99.jpg?1",
             "name": "Serra's Blessing",
             "text": "Creatures you control have vigilance. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "acdd7051-cfe9-564d-b65a-d80821080c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f7aa-abc5-406f-99b5-093615981bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f7aa-abc5-406f-99b5-093615981bc7.jpg?1",
             "name": "Serra's Blessing",
             "text": "",
             "colours": [
@@ -3348,7 +3348,7 @@
         },
         {
             "id": "4f30adcf-bcd7-58ed-b032-e06487f60381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84f34ff-de33-4091-90b6-9de5336987f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84f34ff-de33-4091-90b6-9de5336987f0.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "c5c90b49-bdfc-5fcb-9f13-fc45824142c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bc2496-786d-4647-aa96-b49027b7e13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bc2496-786d-4647-aa96-b49027b7e13d.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "fc382582-2cc4-5869-aba2-eb6f2cfea24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d4f46-4cf7-40f6-9988-5103146f3ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d4f46-4cf7-40f6-9988-5103146f3ff2.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature comes into play, you gain 1 life.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "4b4370f3-fff3-5e2d-98e8-37e9f99a70aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5590a7-dca5-40e3-b760-4d68d99b8740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5590a7-dca5-40e3-b760-4d68d99b8740.jpg?1",
             "name": "Soul Warden",
             "text": "",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "75e4e476-5dab-5d1f-b4d1-4a3d662c096e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38906047-d692-46e4-a42d-08293b42f29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38906047-d692-46e4-a42d-08293b42f29c.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "b3240e85-7504-537f-9a87-d07318b6e100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3171f29-96f6-44cc-b246-fbb9e3ba833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3171f29-96f6-44cc-b246-fbb9e3ba833d.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "d4e4d3a3-4259-5c03-8bd6-1be9e4557c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2762550-6c20-4e76-9d6a-b7085e5baebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2762550-6c20-4e76-9d6a-b7085e5baebd.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "c9a61107-3c39-5251-af6e-729c0687cd16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8b339-2d1b-4f18-b9cb-08c4102df038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8b339-2d1b-4f18-b9cb-08c4102df038.jpg?1",
             "name": "Story Circle",
             "text": "",
             "colours": [
@@ -3628,7 +3628,7 @@
         },
         {
             "id": "4d7a623e-7260-5d6d-afe9-de2c9aa02594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff9c46b-51d3-44d7-8f27-1a466fa8ba3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff9c46b-51d3-44d7-8f27-1a466fa8ba3d.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "0d0d36ac-8fb8-5550-8b00-d1a542a6685b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9094c7-0033-494e-ae3b-37ee27be8968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9094c7-0033-494e-ae3b-37ee27be8968.jpg?1",
             "name": "Suntail Hawk",
             "text": "",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "61a4ce31-fa75-52c2-b7b5-65230608229a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c3e220-00c8-4afc-a8a3-e95e7c8c1629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c3e220-00c8-4afc-a8a3-e95e7c8c1629.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -3731,7 +3731,7 @@
         },
         {
             "id": "f0867558-e329-5b0a-8e7d-21357e478bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc53b0dc-1243-46e6-8cd9-eab3498a7102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc53b0dc-1243-46e6-8cd9-eab3498a7102.jpg?1",
             "name": "Tempest of Light",
             "text": "",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "9061cdac-b00e-5304-9d8b-e67c7ca8d023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c70b89-9b06-42fe-ba63-99f70642eaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c70b89-9b06-42fe-ba63-99f70642eaf4.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "dea55495-9abb-5069-b8ef-52050f896348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c1078-6c7b-41c6-9eca-eb2509ea7253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c1078-6c7b-41c6-9eca-eb2509ea7253.jpg?1",
             "name": "Venerable Monk",
             "text": "",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "6a1e26b9-3121-5dba-a5d5-02126542bab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31072355-0b20-4830-9d46-ca71783af84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31072355-0b20-4830-9d46-ca71783af84b.jpg?1",
             "name": "Veteran Cavalier",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "bafd5289-322a-52c5-bf42-d3e22a47fa92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b67b451-b2b6-4c3b-9578-3492bd85586e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b67b451-b2b6-4c3b-9578-3492bd85586e.jpg?1",
             "name": "Veteran Cavalier",
             "text": "",
             "colours": [
@@ -3910,7 +3910,7 @@
         },
         {
             "id": "b5e61673-7054-5825-b71b-6ded5335a2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9718a0-4e8d-4633-ab18-03ed51b9980c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9718a0-4e8d-4633-ab18-03ed51b9980c.jpg?1",
             "name": "Warrior's Honor",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "dfceeb9b-72bb-5c3a-b3b6-f16dd760f132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffc323f-ac91-46fe-a762-39dbe62c6662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffc323f-ac91-46fe-a762-39dbe62c6662.jpg?1",
             "name": "Warrior's Honor",
             "text": "",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "f7e1778a-df64-5615-82b1-b2e0a7c7fd67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4be040-27b1-4501-b3d4-f12976e568c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4be040-27b1-4501-b3d4-f12976e568c9.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library. Play this ability only if an opponent controls more lands than you.",
             "colours": [
@@ -4013,7 +4013,7 @@
         },
         {
             "id": "e3d5a6ad-3d31-547c-b64f-8644ffd271c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c469cc-1835-4913-8582-63e0fdbc6fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c469cc-1835-4913-8582-63e0fdbc6fce.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "476b70e8-3dd1-52f6-9b70-e7202b5ce198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad20044-8ed8-49ae-9a07-d4cb18527cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad20044-8ed8-49ae-9a07-d4cb18527cc7.jpg?1",
             "name": "Worship",
             "text": "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -4083,7 +4083,7 @@
         },
         {
             "id": "b54af2fd-5390-50b3-bcfd-53b8f27a6a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cc37c-5fad-4e92-a563-0f5a400f0d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cc37c-5fad-4e92-a563-0f5a400f0d1c.jpg?1",
             "name": "Worship",
             "text": "",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "55398f87-dac3-5348-8aa2-ebcf33da87fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c1e9e3-c947-47cc-ac60-dc032d984a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c1e9e3-c947-47cc-ac60-dc032d984a67.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -4149,7 +4149,7 @@
         },
         {
             "id": "a64d4d4d-56ce-5b43-9df3-6334958651b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c478aad9-f876-4c1f-9f04-851e6f0de58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c478aad9-f876-4c1f-9f04-851e6f0de58c.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "083856e8-0144-565a-bfbf-b49699f8693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7621b1af-fdbd-4604-b37c-04fb8f68c3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7621b1af-fdbd-4604-b37c-04fb8f68c3b6.jpg?1",
             "name": "Zealous Inquisitor",
             "text": "{1}{W}: The next 1 damage that would be dealt to Zealous Inquisitor this turn is dealt to target creature instead.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "fbf232b1-6977-51a0-8606-0552477edba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c1481-e29d-4f39-a9c1-cdfa16a6a377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c1481-e29d-4f39-a9c1-cdfa16a6a377.jpg?1",
             "name": "Zealous Inquisitor",
             "text": "",
             "colours": [
@@ -4254,7 +4254,7 @@
         },
         {
             "id": "7c1485bb-d341-5e11-9bdf-ac7b0d611b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0267612-fd15-497f-b6be-9e2797e6895d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0267612-fd15-497f-b6be-9e2797e6895d.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "347c768b-4226-5809-93d5-38362aa3fb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980f75a4-7145-43c0-867a-cafbfaa2944e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980f75a4-7145-43c0-867a-cafbfaa2944e.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "8c04f561-8152-58b6-92b9-e519f00811f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0df72c6-4f54-43ec-a4e0-5733003f4fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0df72c6-4f54-43ec-a4e0-5733003f4fd7.jpg?1",
             "name": "Annex",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nYou control enchanted land.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "d472a106-880f-5dcf-9f73-e2b6bd710667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f445aa-0e8c-4852-8d07-d9a2819a14a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f445aa-0e8c-4852-8d07-d9a2819a14a6.jpg?1",
             "name": "Annex",
             "text": "",
             "colours": [
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "cddf1582-5819-505d-bcef-02aa3f93c6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f025c11-feeb-429b-9518-f24d70596601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f025c11-feeb-429b-9518-f24d70596601.jpg?1",
             "name": "Archivist",
             "text": "{T}: Draw a card.",
             "colours": [
@@ -4430,7 +4430,7 @@
         },
         {
             "id": "9b1ecd6e-a78f-5eb8-ba78-685520d84304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e92e-6cc0-4e96-95f2-10ac610f8203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e92e-6cc0-4e96-95f2-10ac610f8203.jpg?1",
             "name": "Archivist",
             "text": "",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "e48efaab-e817-512e-ac01-91b87d3f7006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3d4fe-0f94-4989-892d-210ae0be67d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3d4fe-0f94-4989-892d-210ae0be67d8.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "8c71a2ff-b190-595f-a28d-166ba215dd83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac9b50-eb87-484b-bc80-a11d8e76e6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac9b50-eb87-484b-bc80-a11d8e76e6f0.jpg?1",
             "name": "Aven Fisher",
             "text": "",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "9b6e4bf2-0da6-5839-9792-62c6b54efe29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e017119-4040-4277-849f-3ed961c992c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e017119-4040-4277-849f-3ed961c992c6.jpg?1",
             "name": "Aven Windreader",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{U}: Target player reveals the top card of his or her library.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "82b5377d-fcdf-5df5-90c1-0149d3b7c9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688712e6-c17a-45e6-ab52-12ae7e68712b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688712e6-c17a-45e6-ab52-12ae7e68712b.jpg?1",
             "name": "Aven Windreader",
             "text": "",
             "colours": [
@@ -4612,7 +4612,7 @@
         },
         {
             "id": "e7b7d804-2b02-51b6-be91-5129a24094ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dab6a1-0f20-4e87-9cb1-8f97eb860999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dab6a1-0f20-4e87-9cb1-8f97eb860999.jpg?1",
             "name": "Azure Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "11820af5-5e2d-50b7-a712-1e1b46154567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc401172-a1dd-408e-8cf5-7a07ea8d6603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc401172-a1dd-408e-8cf5-7a07ea8d6603.jpg?1",
             "name": "Azure Drake",
             "text": "",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "03ef0ec5-f83c-5f4f-ab50-8f7105e38739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b1df0-1838-40df-af62-08a73c3d8033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b1df0-1838-40df-af62-08a73c3d8033.jpg?1",
             "name": "Baleful Stare",
             "text": "Target opponent reveals his or her hand. You draw a card for each Mountain and red card in it.",
             "colours": [
@@ -4715,7 +4715,7 @@
         },
         {
             "id": "8dec10f6-6a70-5164-a795-bf356178cf04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04fd23b-71f3-4035-a754-26ba6d14c2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04fd23b-71f3-4035-a754-26ba6d14c2e7.jpg?1",
             "name": "Baleful Stare",
             "text": "",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "9893ae41-e08d-5661-a8c8-4b3cad4b85a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b56b6c-1372-4e4b-afe0-6030777efc68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b56b6c-1372-4e4b-afe0-6030777efc68.jpg?1",
             "name": "Battle of Wits",
             "text": "At the beginning of your upkeep, if you have 200 or more cards in your library, you win the game.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "3b016b4c-e1db-5c9c-b413-86d9088439bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a188c7-bfda-4fc0-83dd-f3e47433fefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a188c7-bfda-4fc0-83dd-f3e47433fefd.jpg?1",
             "name": "Battle of Wits",
             "text": "",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "62172901-bdfc-5a1e-9a30-475f33edbede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac61a76-80a5-4bde-9ff3-c8971a218d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac61a76-80a5-4bde-9ff3-c8971a218d60.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -4847,7 +4847,7 @@
         },
         {
             "id": "67895c2c-d3ff-59ed-97b7-29fced207a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13bea02-835e-421d-a38b-8129ad916059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13bea02-835e-421d-a38b-8129ad916059.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "a7b171fb-8a03-5633-a413-bbcb901d4cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869f64b0-14ca-4171-8fde-1528bf7b9846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869f64b0-14ca-4171-8fde-1528bf7b9846.jpg?1",
             "name": "Clone",
             "text": "As Clone comes into play, you may choose a creature in play. If you do, Clone comes into play as a copy of that creature.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "e1da6d64-2d67-511d-b4de-94b6fd416823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb64c5b-06c9-4fc6-b08d-ca7078101cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb64c5b-06c9-4fc6-b08d-ca7078101cdb.jpg?1",
             "name": "Clone",
             "text": "",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "2e1b3917-049c-5ea9-b056-9ce6b55530e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095d77fd-c1d1-49e6-89f8-a272522e09fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095d77fd-c1d1-49e6-89f8-a272522e09fe.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent (Target a permanent as you play this. This card comes into play attached to that permanent.)\nYou control enchanted permanent.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "d8312d97-4771-58bf-9bb5-9989b24619d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a39ec-a66d-42aa-be3a-62551ad33f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a39ec-a66d-42aa-be3a-62551ad33f73.jpg?1",
             "name": "Confiscate",
             "text": "",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "9cbd2309-0a76-54a4-a170-f2ff24887c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ab2cb6-856c-4696-a17b-8f0002bd48ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ab2cb6-856c-4696-a17b-8f0002bd48ee.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "Draw two cards.",
             "colours": [
@@ -5053,7 +5053,7 @@
         },
         {
             "id": "b5ba51c4-6311-5ab2-9409-28844c810d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33f9573-3ca2-4d5f-82e1-ff3144e5803c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33f9573-3ca2-4d5f-82e1-ff3144e5803c.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "",
             "colours": [
@@ -5086,7 +5086,7 @@
         },
         {
             "id": "9463faa6-0114-5d8d-92fa-0a72297c521f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c3cf8f-c2f6-4ad0-83f9-960e5d74fc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c3cf8f-c2f6-4ad0-83f9-960e5d74fc3e.jpg?1",
             "name": "Cowardice",
             "text": "Whenever a creature becomes the target of a spell or ability, return that creature to its owner's hand. (It won't be affected by the spell or ability.)",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "34c7c425-a52e-5765-9243-563fbbfd36c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfa3bd-4f08-43c7-9ed3-314bc46a357e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfa3bd-4f08-43c7-9ed3-314bc46a357e.jpg?1",
             "name": "Cowardice",
             "text": "",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "0ea9f084-4e50-5d90-b4df-f004168aedcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb5c44-3a6f-49b9-a36a-63d0398a34a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb5c44-3a6f-49b9-a36a-63d0398a34a0.jpg?1",
             "name": "Crafty Pathmage",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -5188,7 +5188,7 @@
         },
         {
             "id": "f74b585d-199f-5f84-90c4-bd3216b8f360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0ab433-35ab-4e7d-a78e-e4b11fee773d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0ab433-35ab-4e7d-a78e-e4b11fee773d.jpg?1",
             "name": "Crafty Pathmage",
             "text": "",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "be08b4f5-582e-531c-852a-6bf60f3abe01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5becbf-77ac-4bd2-912d-7f7c944c2a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5becbf-77ac-4bd2-912d-7f7c944c2a0b.jpg?1",
             "name": "Daring Apprentice",
             "text": "{T}, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "e4175084-0468-5a0c-aa0f-aedca7eecfcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d512d6d-e92f-48a0-8182-b2936b321c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d512d6d-e92f-48a0-8182-b2936b321c91.jpg?1",
             "name": "Daring Apprentice",
             "text": "",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "d92fdc74-14c8-5c65-b160-b2215bd16a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2e44-e2e1-42b7-8f9f-0ce430af2359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2e44-e2e1-42b7-8f9f-0ce430af2359.jpg?1",
             "name": "Dehydration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "ef4b04e3-50b2-5af8-83b9-1d21c1712e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04337aee-6282-4d68-a12a-f71e7013f4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04337aee-6282-4d68-a12a-f71e7013f4c0.jpg?1",
             "name": "Dehydration",
             "text": "",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "d5ce32da-8399-595e-b1a4-b08aacb3a23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3327ff-89d4-40f5-8751-c6669d04fede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3327ff-89d4-40f5-8751-c6669d04fede.jpg?1",
             "name": "Dream Prowler",
             "text": "Dream Prowler is unblockable as long as it's attacking alone.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "cf116ff8-c924-59d5-b640-77e2cce14bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd52df-c78b-48e9-85b1-1e2fef6f9dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd52df-c78b-48e9-85b1-1e2fef6f9dc0.jpg?1",
             "name": "Dream Prowler",
             "text": "",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "058ea251-691b-5137-b562-62b25c8c2996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caccacb7-7d17-4b37-aee9-ba8ed8b90955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caccacb7-7d17-4b37-aee9-ba8ed8b90955.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "681c5ce2-e2c1-5b61-bb2f-c99fedbf9a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53611e65-4ca2-48e4-8fc1-19098c70894e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53611e65-4ca2-48e4-8fc1-19098c70894e.jpg?1",
             "name": "Evacuation",
             "text": "",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "607129fd-a0c5-58e7-b0c4-e08f09288888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae593a2e-42d9-47e3-b6cb-f2e2133944d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae593a2e-42d9-47e3-b6cb-f2e2133944d5.jpg?1",
             "name": "Exhaustion",
             "text": "Creatures and lands target opponent controls don't untap during his or her next untap step.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "9de1f1b5-d475-5e27-8a95-4fce011a7677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d304a85-3129-4230-9e3b-14a2b5bc81d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d304a85-3129-4230-9e3b-14a2b5bc81d9.jpg?1",
             "name": "Exhaustion",
             "text": "",
             "colours": [
@@ -5568,7 +5568,7 @@
         },
         {
             "id": "5000b9ed-30fc-5c34-b2d0-6e2ef8c59a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c4a1f4-0a8e-4e70-a2a8-ceebbca63b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c4a1f4-0a8e-4e70-a2a8-ceebbca63b6c.jpg?1",
             "name": "Fishliver Oil",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has islandwalk. (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "6d56b7ff-0c21-555a-87d5-ed9af1d11d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd83d056-05cd-4d57-9bfc-c9f006ee7d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd83d056-05cd-4d57-9bfc-c9f006ee7d89.jpg?1",
             "name": "Fishliver Oil",
             "text": "",
             "colours": [
@@ -5638,7 +5638,7 @@
         },
         {
             "id": "73613fca-e58b-5eac-ba11-cbd00d98b4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b8cc4-3392-4307-a5e4-5f04e52da3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b8cc4-3392-4307-a5e4-5f04e52da3ab.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{U}: Return Fleeting Image to its owner's hand.",
             "colours": [
@@ -5673,7 +5673,7 @@
         },
         {
             "id": "95ed44bd-a9db-5e35-a62a-4b39e6e789c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6475cfaa-2258-48e7-be21-a7d86a94dcf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6475cfaa-2258-48e7-be21-a7d86a94dcf1.jpg?1",
             "name": "Fleeting Image",
             "text": "",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "ac7f35b1-c168-52d5-8e55-addc27e3516c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f9c524-89ae-4776-a94d-ee89d57d3e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f9c524-89ae-4776-a94d-ee89d57d3e36.jpg?1",
             "name": "Flight",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has flying. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -5743,7 +5743,7 @@
         },
         {
             "id": "43c0994b-26ec-56fe-8f73-8ba708b7dd24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febc86-eb10-4975-b70c-f2f0fc3dc741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febc86-eb10-4975-b70c-f2f0fc3dc741.jpg?1",
             "name": "Flight",
             "text": "",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "7c3ea479-e463-58e7-b1b0-b217c77dae79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453fac7-10b9-49d7-8219-78faf9d92d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453fac7-10b9-49d7-8219-78faf9d92d0c.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "6a0b61c4-a509-5d0e-97c3-70ab8f3e14d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249904d-f917-4607-9dc3-82415e44cc91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249904d-f917-4607-9dc3-82415e44cc91.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "d6b194ec-c7bc-5416-89b9-2ce1656633d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d807c179-ca5e-4f8d-983f-b1d92eeef40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d807c179-ca5e-4f8d-983f-b1d92eeef40f.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5885,7 +5885,7 @@
         },
         {
             "id": "bf4eb9e8-14e2-550c-8f82-a7bf83a91a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3455682-6f46-4dc9-ae31-c12aa7633b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3455682-6f46-4dc9-ae31-c12aa7633b2a.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "7055f7ae-8eb6-598f-a187-33c761d5e1be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432d8827-e46d-4c0d-bde3-305594f20f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432d8827-e46d-4c0d-bde3-305594f20f19.jpg?1",
             "name": "Imaginary Pet",
             "text": "At the beginning of your upkeep, if you have a card in hand, return Imaginary Pet to its owner's hand.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "a081cae8-a856-5b84-9b50-a53d00fd8406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764702-05db-4d27-91a1-7ec2cbd69861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764702-05db-4d27-91a1-7ec2cbd69861.jpg?1",
             "name": "Imaginary Pet",
             "text": "",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "05e43c46-b937-5349-a521-614b9442bb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ae6722-cf51-4997-bfba-72dac1f33030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ae6722-cf51-4997-bfba-72dac1f33030.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying. (They can't be blocked except by creatures with flying.)",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "6b310995-509a-59d5-b427-f630b5146313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c5afdf-f45f-44a6-821a-25f2903ce0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c5afdf-f45f-44a6-821a-25f2903ce0c1.jpg?1",
             "name": "Levitation",
             "text": "",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "c28ed36f-837b-5e9d-8f83-7868b85aef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b0a060-8ab4-41d9-921d-db5a67fbfaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b0a060-8ab4-41d9-921d-db5a67fbfaa1.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "5f0d39f6-4eea-5e06-b9f9-c7e3bf6340e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f38d7-1b47-4440-a310-3a0eb8326363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f38d7-1b47-4440-a310-3a0eb8326363.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -6128,7 +6128,7 @@
         },
         {
             "id": "25c08211-9ca6-50c4-8544-1cd36066523e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1ef140-9198-4aed-a0cb-2946a87c93c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1ef140-9198-4aed-a0cb-2946a87c93c5.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -6163,7 +6163,7 @@
         },
         {
             "id": "ceaf8d54-38b5-56e7-8f05-f833360a4490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d7b478-b54f-4409-bca9-68cc98951699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d7b478-b54f-4409-bca9-68cc98951699.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -6198,7 +6198,7 @@
         },
         {
             "id": "60269545-b1fd-5816-a420-83e5a6ef6508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6486c-644f-4b32-b4e9-3ca29bbdb400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6486c-644f-4b32-b4e9-3ca29bbdb400.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -6231,7 +6231,7 @@
         },
         {
             "id": "9cbf605b-5a58-5d6a-8d8d-7115010b58ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217da74b-f139-4e62-8d91-34cadb678535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217da74b-f139-4e62-8d91-34cadb678535.jpg?1",
             "name": "Mana Leak",
             "text": "",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "572bcaac-efd4-564d-9670-eebf85ec1eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57982c7f-e306-426a-ac90-c2ee488b018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57982c7f-e306-426a-ac90-c2ee488b018e.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"plainswalk.\" This effect doesn't end at end of turn.)",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "9afac2ea-177e-5ba5-a116-3dbdfc07d5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8d98e6-3ec8-46a2-b1ae-aa164905d675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8d98e6-3ec8-46a2-b1ae-aa164905d675.jpg?1",
             "name": "Mind Bend",
             "text": "",
             "colours": [
@@ -6330,7 +6330,7 @@
         },
         {
             "id": "cb39f486-af83-55c5-b24e-85709df9ff75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d045ba0-86e9-444a-86df-6f1e5611429d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d045ba0-86e9-444a-86df-6f1e5611429d.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "566e6476-9ea4-545a-a568-458bd3c3a00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63c8900-28c3-4fd5-8159-5b362819ae9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63c8900-28c3-4fd5-8159-5b362819ae9a.jpg?1",
             "name": "Phantom Warrior",
             "text": "",
             "colours": [
@@ -6402,7 +6402,7 @@
         },
         {
             "id": "20d85b9c-9976-56ea-b507-d9b02b85a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eccbe9-f197-4ec0-b8c1-45a36a063e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eccbe9-f197-4ec0-b8c1-45a36a063e30.jpg?1",
             "name": "Plagiarize",
             "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "74a339a4-5ed9-5642-8f6b-043220bd05ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ddc456-9e31-423d-b2a1-7d48c02660a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ddc456-9e31-423d-b2a1-7d48c02660a4.jpg?1",
             "name": "Plagiarize",
             "text": "",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "a6205136-7faa-5f89-9e1e-58617e1ecc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a681a355-a5e8-4ed2-8983-9c29ab34819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a681a355-a5e8-4ed2-8983-9c29ab34819b.jpg?1",
             "name": "Polymorph",
             "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card into play and shuffles all other cards revealed this way into his or her library.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "c5e0739e-eb0b-5779-9163-51e996a4e041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0498b4-8c36-4463-a7d9-6b943a71b1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0498b4-8c36-4463-a7d9-6b943a71b1b1.jpg?1",
             "name": "Polymorph",
             "text": "",
             "colours": [
@@ -6534,7 +6534,7 @@
         },
         {
             "id": "8f4ef26c-5b52-5f4c-8ca4-1064d13e147e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0359e3-1b8e-4db7-8dec-2d50278e4b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0359e3-1b8e-4db7-8dec-2d50278e4b00.jpg?1",
             "name": "Puppeteer",
             "text": "{U}, {T}: Tap or untap target creature.",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "ccd6da1c-beba-593e-af05-1d76e8109a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098fca68-9ce1-4530-9a06-65a5adc16618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098fca68-9ce1-4530-9a06-65a5adc16618.jpg?1",
             "name": "Puppeteer",
             "text": "",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "05703c21-7ea6-525e-b979-7eb3340ebf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab3a79f-354f-49b9-b3c9-44880369ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab3a79f-354f-49b9-b3c9-44880369ced4.jpg?1",
             "name": "Reminisce",
             "text": "Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "20208aef-d14a-56ac-8c11-4be808a0c642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b22395-e0da-4d7e-b5fe-e233ceadc9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b22395-e0da-4d7e-b5fe-e233ceadc9b2.jpg?1",
             "name": "Reminisce",
             "text": "",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "56f368dd-d4a6-54fa-9674-6706d8239b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171fa545-724c-465e-96f6-dc738c0be59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171fa545-724c-465e-96f6-dc738c0be59d.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "74204831-4d69-5322-978a-a108a0266edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab415e3-2503-484e-bbe9-024db39f4a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab415e3-2503-484e-bbe9-024db39f4a34.jpg?1",
             "name": "Remove Soul",
             "text": "",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "02f2650c-0b31-5d6c-840c-6b85c4082390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a7176f-0e35-406b-819a-e91b42d07172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a7176f-0e35-406b-819a-e91b42d07172.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell, then untap up to four lands.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "e542484d-6de7-56cb-a2bf-04d2a570a076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df65c5f-1ee7-4c64-b417-20ba238e1432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df65c5f-1ee7-4c64-b417-20ba238e1432.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "3242c48c-bc46-5d7f-9f8c-f8fd42679315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af71e998-0ce3-4533-84cd-91cc6f288986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af71e998-0ce3-4533-84cd-91cc6f288986.jpg?1",
             "name": "Sage Aven",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Sage Aven comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "c6525682-47d2-55e4-af61-d8b81eb044ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77249403-7dd4-4696-aa26-b061a2a19bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77249403-7dd4-4696-aa26-b061a2a19bee.jpg?1",
             "name": "Sage Aven",
             "text": "",
             "colours": [
@@ -6876,7 +6876,7 @@
         },
         {
             "id": "6d7a3e19-51a3-5f42-903f-ba85989b59aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee7c3e0-e016-445f-ab3a-3e2d5c26bdac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee7c3e0-e016-445f-ab3a-3e2d5c26bdac.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an Island.",
             "colours": [
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "6066445c-2135-51ba-8ac5-2a0f5bc8f243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a14c14-7773-4cc5-be8e-505585496a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a14c14-7773-4cc5-be8e-505585496a7d.jpg?1",
             "name": "Sea Monster",
             "text": "",
             "colours": [
@@ -6946,7 +6946,7 @@
         },
         {
             "id": "b24c0bd4-b39c-52da-a415-8a50dc7a65fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e836c8-4371-402f-8f90-81325a9879b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e836c8-4371-402f-8f90-81325a9879b8.jpg?1",
             "name": "Sea's Claim",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nEnchanted land is an Island.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "dfddae22-ecc5-522a-aae8-7b726ae92e05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2aa85c-e34e-4747-82ed-7715c5dbb1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2aa85c-e34e-4747-82ed-7715c5dbb1e7.jpg?1",
             "name": "Sea's Claim",
             "text": "",
             "colours": [
@@ -7016,7 +7016,7 @@
         },
         {
             "id": "443cd7d3-09e2-5f42-a5f5-2576feb0ba39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d25807-75e1-41cf-b3e7-f9e42f06c5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d25807-75e1-41cf-b3e7-f9e42f06c5d3.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -7049,7 +7049,7 @@
         },
         {
             "id": "8bf71b4d-3a26-5c6d-ae4e-c471dccfdf02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1c40220-5cf8-49cf-8aa4-610dd2b12e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1c40220-5cf8-49cf-8aa4-610dd2b12e3f.jpg?1",
             "name": "Sift",
             "text": "",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "e23d6176-b1ea-5d9b-bc29-9c66f7d1af1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b72631-d537-46e1-b9b3-618fba8a4c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b72631-d537-46e1-b9b3-618fba8a4c46.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "6d85b3d4-a38a-51e8-92e3-a8fed52ab847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950d422f-8c76-423b-8cc2-3e597184d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950d422f-8c76-423b-8cc2-3e597184d58c.jpg?1",
             "name": "Sleight of Hand",
             "text": "",
             "colours": [
@@ -7148,7 +7148,7 @@
         },
         {
             "id": "76d51d19-83e7-5cbd-a413-9df695875ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036ef8c9-72ac-46ce-af07-83b79d736538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036ef8c9-72ac-46ce-af07-83b79d736538.jpg?1",
             "name": "Storm Crow",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -7183,7 +7183,7 @@
         },
         {
             "id": "d8203534-997c-5165-9d87-bd2c250955e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7841a-360c-4094-84e4-3b5bf17c5c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7841a-360c-4094-84e4-3b5bf17c5c1c.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "48de22e9-055f-5ece-aca0-760fc90cb152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b900c68f-4e10-459b-b28f-fea9a32e563b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b900c68f-4e10-459b-b28f-fea9a32e563b.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -7251,7 +7251,7 @@
         },
         {
             "id": "d172eafc-d4a2-58e4-b6cc-c106c6e5960b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8ca1b6-f022-4172-942c-9be4d619c675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8ca1b6-f022-4172-942c-9be4d619c675.jpg?1",
             "name": "Telepathy",
             "text": "",
             "colours": [
@@ -7284,7 +7284,7 @@
         },
         {
             "id": "213cdfb2-8fd1-5ae6-8467-056f5b0e805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2dfe6-dbc0-46c3-9d5c-9f0ba6f511ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2dfe6-dbc0-46c3-9d5c-9f0ba6f511ec.jpg?1",
             "name": "Temporal Adept",
             "text": "{U}{U}{U}, {T}: Return target permanent to its owner's hand.",
             "colours": [
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "4eaa10b0-8952-502f-a8f0-dd3947d2c867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b29df17-235c-408f-9e4b-2f18554e2154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b29df17-235c-408f-9e4b-2f18554e2154.jpg?1",
             "name": "Temporal Adept",
             "text": "",
             "colours": [
@@ -7356,7 +7356,7 @@
         },
         {
             "id": "12312158-2955-57f7-869e-e28abf04c9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3cfe-5bae-4eb7-81a3-744315093ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3cfe-5bae-4eb7-81a3-744315093ae1.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "78e69f9d-04df-5185-ae53-b541d301c066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ce8bbf-a487-4fe1-b378-440c20403544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ce8bbf-a487-4fe1-b378-440c20403544.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -7426,7 +7426,7 @@
         },
         {
             "id": "eefba0b1-7e1d-5a18-aac7-8213737d9011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d2542-501d-4dfe-8642-962d0299ca45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d2542-501d-4dfe-8642-962d0299ca45.jpg?1",
             "name": "Thought Courier",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "4ed08eac-51c5-5a0e-bfbd-33c610550729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5715ac13-453c-48ae-8c31-80b053e2cab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5715ac13-453c-48ae-8c31-80b053e2cab3.jpg?1",
             "name": "Thought Courier",
             "text": "",
             "colours": [
@@ -7498,7 +7498,7 @@
         },
         {
             "id": "38fc2d01-5ef4-5225-99f3-cfbfa501049b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569d1014-e04a-4f8d-a2b2-699b5be08d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569d1014-e04a-4f8d-a2b2-699b5be08d5d.jpg?1",
             "name": "Tidal Kraken",
             "text": "Tidal Kraken is unblockable.",
             "colours": [
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "fc4720fe-508f-533d-a241-4de9252788de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a8dc0b-4144-40d0-a898-d04669628cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a8dc0b-4144-40d0-a898-d04669628cb1.jpg?1",
             "name": "Tidal Kraken",
             "text": "",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "cca81b74-4814-5c4f-9874-c949c7969037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28e96c6-4c48-466a-81a0-1137269db529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28e96c6-4c48-466a-81a0-1137269db529.jpg?1",
             "name": "Tidings",
             "text": "Draw four cards.",
             "colours": [
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "f251b9fa-21ba-5026-87a9-6bc5cecf3242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42171ada-b287-4471-b5e1-4ebdf955c819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42171ada-b287-4471-b5e1-4ebdf955c819.jpg?1",
             "name": "Tidings",
             "text": "",
             "colours": [
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "cf59c107-d404-5044-b924-daae8a57f73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7952ea1-a574-4e0e-a3af-0977022c2dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7952ea1-a574-4e0e-a3af-0977022c2dfb.jpg?1",
             "name": "Time Ebb",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -7667,7 +7667,7 @@
         },
         {
             "id": "d8aa9fa2-80c4-5563-b467-6e11e2a040f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298be076-2c92-4299-a3b1-0ec68c59ef80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298be076-2c92-4299-a3b1-0ec68c59ef80.jpg?1",
             "name": "Time Ebb",
             "text": "",
             "colours": [
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "ff5312e4-755c-5b28-bffd-04776e295a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e5d7c9-36f7-4312-ada0-b6c2757487c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e5d7c9-36f7-4312-ada0-b6c2757487c8.jpg?1",
             "name": "Trade Routes",
             "text": "{1}: Return target land you control to its owner's hand.\n{1}, Discard a land card: Draw a card.",
             "colours": [
@@ -7733,7 +7733,7 @@
         },
         {
             "id": "ac78c993-7804-5be5-aacc-be6a5f9262f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047b93ed-c6d4-4ecc-8a25-e7b371f599c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047b93ed-c6d4-4ecc-8a25-e7b371f599c6.jpg?1",
             "name": "Trade Routes",
             "text": "",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "dcc6d37a-48a3-559f-9666-27efaa3f74db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a6e8cc-3989-40c4-a49c-cd30ccaba0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a6e8cc-3989-40c4-a49c-cd30ccaba0d5.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -7799,7 +7799,7 @@
         },
         {
             "id": "b6043c0c-d329-520c-9fa4-51f53f606622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f12d6-5612-42c8-809c-86a620ea8824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f12d6-5612-42c8-809c-86a620ea8824.jpg?1",
             "name": "Traumatize",
             "text": "",
             "colours": [
@@ -7832,7 +7832,7 @@
         },
         {
             "id": "f11b54b1-9c41-5ba4-8da1-012430471d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f145a7d4-151b-41dd-94f9-eda406080222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f145a7d4-151b-41dd-94f9-eda406080222.jpg?1",
             "name": "Treasure Trove",
             "text": "{2}{U}{U}: Draw a card.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "57b2131d-d1c3-58fa-a0f3-b049df26ee0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805701a-f98d-4b0c-97a1-901864d677c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805701a-f98d-4b0c-97a1-901864d677c5.jpg?1",
             "name": "Treasure Trove",
             "text": "",
             "colours": [
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "b4a7925c-07b8-5021-9a32-38b0a4ae1d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562a6a76-7242-4a22-9545-e6aa2dbd5564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562a6a76-7242-4a22-9545-e6aa2dbd5564.jpg?1",
             "name": "Wanderguard Sentry",
             "text": "When Wanderguard Sentry comes into play, look at target opponent's hand.",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "669cf8cc-fae3-5669-a568-55c577c903da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea3aa0-7766-4edc-9dea-c234c49edee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea3aa0-7766-4edc-9dea-c234c49edee3.jpg?1",
             "name": "Wanderguard Sentry",
             "text": "",
             "colours": [
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "3d59cfab-ef7e-5de7-afec-462315c6ca3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fed594b-9aa5-4bab-8066-58c3f795d940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fed594b-9aa5-4bab-8066-58c3f795d940.jpg?1",
             "name": "Wind Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "9d21bbc9-8882-55f1-83cf-f865a31cf6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0a7ab-715f-431f-824b-d6a3950e4b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0a7ab-715f-431f-824b-d6a3950e4b0d.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -8038,7 +8038,7 @@
         },
         {
             "id": "c53e4002-3e5d-5407-9ebc-b8922e67f249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25580a6-e687-4da5-85f4-07d940acda95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25580a6-e687-4da5-85f4-07d940acda95.jpg?1",
             "name": "Withering Gaze",
             "text": "Target opponent reveals his or her hand. You draw a card for each Forest and green card in it.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "0bb342ea-c791-5a9c-a07d-cdb9424d03ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867dd0d-4dca-43a1-b9ca-f52a610d083d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867dd0d-4dca-43a1-b9ca-f52a610d083d.jpg?1",
             "name": "Withering Gaze",
             "text": "",
             "colours": [
@@ -8104,7 +8104,7 @@
         },
         {
             "id": "9f56a34e-5121-51b7-af5f-728806ef9687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741612e3-fe3a-4099-9d2b-4a654c4ce949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741612e3-fe3a-4099-9d2b-4a654c4ce949.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws the card.",
             "colours": [
@@ -8137,7 +8137,7 @@
         },
         {
             "id": "2e7bab73-c007-584a-bf46-4c70dfc197d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f20b12-63a2-427e-b735-b114d3a4c297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f20b12-63a2-427e-b735-b114d3a4c297.jpg?1",
             "name": "Zur's Weirding",
             "text": "",
             "colours": [
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "a01c1b1b-b230-5472-8ccb-92a8d32cf64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053e7c76-16b7-44eb-9612-a6800ffb35f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053e7c76-16b7-44eb-9612-a6800ffb35f8.jpg?1",
             "name": "Blackmail",
             "text": "Target player reveals three cards from his or her hand and you choose one of them. That player discards that card.",
             "colours": [
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "ae57351b-fb63-5205-99ef-cdc6c286af87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e480ca-1417-407d-b506-763fd489c11d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e480ca-1417-407d-b506-763fd489c11d.jpg?1",
             "name": "Blackmail",
             "text": "",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "64e354f1-7d72-5aac-9ccb-13fc910b1876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f5cda-3d93-4dfd-b1c3-1dff7b814d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f5cda-3d93-4dfd-b1c3-1dff7b814d98.jpg?1",
             "name": "Bog Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8271,7 +8271,7 @@
         },
         {
             "id": "429b54c8-a009-5450-867a-1281ab54401d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa5efb5-d893-4126-af86-28a29e029ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa5efb5-d893-4126-af86-28a29e029ea8.jpg?1",
             "name": "Bog Imp",
             "text": "",
             "colours": [
@@ -8306,7 +8306,7 @@
         },
         {
             "id": "0459ca87-c43b-56b5-a717-874e71792586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5758d-665f-4585-887d-4bffaf2785a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5758d-665f-4585-887d-4bffaf2785a0.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -8341,7 +8341,7 @@
         },
         {
             "id": "c8d86e2f-be22-57cb-b098-2a803cce088a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49472cb8-e497-4070-8070-796b4f6f76b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49472cb8-e497-4070-8070-796b4f6f76b8.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "239e1bb3-187d-586b-9de9-23d919c47c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7a810f-de22-410a-aa08-333920ffdd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7a810f-de22-410a-aa08-333920ffdd1f.jpg?1",
             "name": "Coercion",
             "text": "Target opponent reveals his or her hand. Choose a card from it. That player discards that card.",
             "colours": [
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "2a18e138-8905-5cba-b15f-21ab1309a25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d7c880-17a4-4127-bbc6-072adbb17c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d7c880-17a4-4127-bbc6-072adbb17c40.jpg?1",
             "name": "Coercion",
             "text": "",
             "colours": [
@@ -8442,7 +8442,7 @@
         },
         {
             "id": "ba409b3c-9fbe-577f-895d-dfb32ab92e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe04e55-14b1-4d45-b265-68efdefb1c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe04e55-14b1-4d45-b265-68efdefb1c19.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player. You gain X life.",
             "colours": [
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "78069fda-4084-5b7d-8b62-2734c9376231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d742b1a5-d1f4-4249-80b0-01c4b37c35f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d742b1a5-d1f4-4249-80b0-01c4b37c35f6.jpg?1",
             "name": "Consume Spirit",
             "text": "",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "fcd497bc-4411-5e37-8e0c-10ea170394fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481e8dac-8292-4e8f-89a1-b396ce98d3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481e8dac-8292-4e8f-89a1-b396ce98d3ab.jpg?1",
             "name": "Contaminated Bond",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.",
             "colours": [
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "6702af76-b6a7-55b1-bc50-23504875a5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e966df7-83a3-41fe-a37e-66f73e6aaa36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e966df7-83a3-41fe-a37e-66f73e6aaa36.jpg?1",
             "name": "Contaminated Bond",
             "text": "",
             "colours": [
@@ -8578,7 +8578,7 @@
         },
         {
             "id": "1a52999a-025b-59ba-a146-25b54e4341f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dacf711-2cf7-4545-aea6-95b5f8aaa121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dacf711-2cf7-4545-aea6-95b5f8aaa121.jpg?1",
             "name": "Cruel Edict",
             "text": "Target opponent sacrifices a creature.",
             "colours": [
@@ -8611,7 +8611,7 @@
         },
         {
             "id": "f146f170-cd30-5843-beb8-17936112b0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921b2ea-8df3-40b2-8016-dbf5a0ec51a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921b2ea-8df3-40b2-8016-dbf5a0ec51a8.jpg?1",
             "name": "Cruel Edict",
             "text": "",
             "colours": [
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "96460e14-4d00-5e8a-b0b8-043bdfda63d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b6d545-2bef-4230-99ac-ee9bc3e9a53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b6d545-2bef-4230-99ac-ee9bc3e9a53d.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8677,7 +8677,7 @@
         },
         {
             "id": "3a4276d5-1795-5625-8c45-a70a2bd12831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94844334-4ec2-4e24-a39f-414f3f35d3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94844334-4ec2-4e24-a39f-414f3f35d3a4.jpg?1",
             "name": "Dark Banishing",
             "text": "",
             "colours": [
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "c7d54a7d-8ee9-53be-878e-b1ebdf9546c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6662873b-2c10-442f-9ab5-6f47a4cdb0ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6662873b-2c10-442f-9ab5-6f47a4cdb0ce.jpg?1",
             "name": "Death Pits of Rath",
             "text": "Whenever a creature is dealt damage, destroy it. It can't be regenerated.",
             "colours": [
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "63a5f0be-a5dd-5347-ac36-b4094cbb8a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40927-5d47-434d-a5a7-d4e5dcb611b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40927-5d47-434d-a5a7-d4e5dcb611b2.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "8b6256a1-b3bd-5cd1-ba94-a260cdcae925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76502ffc-a26b-4207-a565-044898875f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76502ffc-a26b-4207-a565-044898875f43.jpg?1",
             "name": "Deathgazer",
             "text": "Whenever Deathgazer blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "0fcc22b4-ac40-5a43-974b-e0fc72e621d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73838f5c-ee6c-4645-bbdb-5e3c8a61537c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73838f5c-ee6c-4645-bbdb-5e3c8a61537c.jpg?1",
             "name": "Deathgazer",
             "text": "",
             "colours": [
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "c3a47ebb-1a8b-5241-82c3-1a6bda764647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0035a78-44ff-4e3a-b297-20cac926c2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0035a78-44ff-4e3a-b297-20cac926c2fb.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "feb4c3b7-3f73-5c1e-8d5c-33ca53441ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23657b59-fbe9-4d88-8ba4-24776a0d6da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23657b59-fbe9-4d88-8ba4-24776a0d6da3.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "2cf1eaa5-c183-54cc-8b73-2fc2dfe2e7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddcfc-1e3e-4bf4-a464-1763bec4df35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddcfc-1e3e-4bf4-a464-1763bec4df35.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -8947,7 +8947,7 @@
         },
         {
             "id": "d36221a2-645a-5547-ae51-565f0a444042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013de212-bb3c-4499-8a14-e8f764dedca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013de212-bb3c-4499-8a14-e8f764dedca3.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -8982,7 +8982,7 @@
         },
         {
             "id": "569e4ff2-c8ec-52d7-91a0-1bdc3fc39de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adaf0bf-b26d-4166-8809-431283690de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adaf0bf-b26d-4166-8809-431283690de7.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "a43efef7-6ab1-5196-8faf-f0d5d9d89af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b593775-5900-44f3-98e9-1298ce07a1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b593775-5900-44f3-98e9-1298ce07a1f1.jpg?1",
             "name": "Enfeeblement",
             "text": "",
             "colours": [
@@ -9052,7 +9052,7 @@
         },
         {
             "id": "7b195a22-c037-5c99-9579-9522df862555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875500ff-bb15-4634-be05-0171cb0ac412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875500ff-bb15-4634-be05-0171cb0ac412.jpg?1",
             "name": "Execute",
             "text": "Destroy target white creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "836845b1-019a-5089-b7a0-e56db7fc2468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35119276-d461-4eb2-8b1b-fa73639fe1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35119276-d461-4eb2-8b1b-fa73639fe1de.jpg?1",
             "name": "Execute",
             "text": "",
             "colours": [
@@ -9118,7 +9118,7 @@
         },
         {
             "id": "55e5e981-86a2-5313-87d6-597e52e41603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f38700-502f-4442-8563-6f47fc71b272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f38700-502f-4442-8563-6f47fc71b272.jpg?1",
             "name": "Fear",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9153,7 +9153,7 @@
         },
         {
             "id": "ddc85657-2636-521b-9376-342793b5381a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847d8686-bed4-4f90-af4d-bdfc6195ed42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847d8686-bed4-4f90-af4d-bdfc6195ed42.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -9188,7 +9188,7 @@
         },
         {
             "id": "5ab43dc3-847c-5e97-ab8a-74e635ab92b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00444e40-7436-48c3-9cbb-e6d8b96c1a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00444e40-7436-48c3-9cbb-e6d8b96c1a3a.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "1a4156a1-e3c5-558b-ae1b-03f589ee2682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328cadf0-001f-47bd-9319-c74f8cc688c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328cadf0-001f-47bd-9319-c74f8cc688c2.jpg?1",
             "name": "Festering Goblin",
             "text": "",
             "colours": [
@@ -9260,7 +9260,7 @@
         },
         {
             "id": "4ffc2825-65a3-5c88-8579-8552f609a4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df60bb-3309-43e0-ab4a-cec1390fc7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df60bb-3309-43e0-ab4a-cec1390fc7cf.jpg?1",
             "name": "Final Punishment",
             "text": "Target player loses life equal to the damage already dealt to him or her this turn.",
             "colours": [
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "599cb34e-795d-5622-b1d5-3152e647ff9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ee758-cbf8-4b1a-acb1-1090d0b2b31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ee758-cbf8-4b1a-acb1-1090d0b2b31b.jpg?1",
             "name": "Final Punishment",
             "text": "",
             "colours": [
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "8d64f0d7-2a6c-5d19-9a6b-ccfbed150759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cc73b9-4a24-4a24-8a0e-76126605a3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cc73b9-4a24-4a24-8a0e-76126605a3e6.jpg?1",
             "name": "Foul Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Foul Imp comes into play, you lose 2 life.",
             "colours": [
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "769335cb-2461-5a91-adb7-50fca6382557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2845b54-7929-4407-9389-4a1e4dead4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2845b54-7929-4407-9389-4a1e4dead4b8.jpg?1",
             "name": "Foul Imp",
             "text": "",
             "colours": [
@@ -9396,7 +9396,7 @@
         },
         {
             "id": "ea77bab2-8a76-556a-9c31-9630346f567c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ca0c01-2e9f-4f1c-9078-f7a68559296d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ca0c01-2e9f-4f1c-9078-f7a68559296d.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "d086fbe8-f0d6-5198-a6a2-26a3ff7a2ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d366fd4c-e416-402b-aac9-6b5bd1feff2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d366fd4c-e416-402b-aac9-6b5bd1feff2e.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "dbf8450a-7757-5378-9a40-6314f2995baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7741c976-000d-476c-9b53-34ef1ee701e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7741c976-000d-476c-9b53-34ef1ee701e1.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9501,7 +9501,7 @@
         },
         {
             "id": "c56b22b2-972d-55ed-8bc9-322e988d588f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d85b52-4bd9-495b-9027-2bbd87309e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d85b52-4bd9-495b-9027-2bbd87309e6e.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "",
             "colours": [
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "3afcdc7c-b78a-5d6e-9425-9d0b50392803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291af6dc-9f71-4e8e-9ecc-24fa90aacb23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291af6dc-9f71-4e8e-9ecc-24fa90aacb23.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control is put into a graveyard from play, each other player sacrifices a creature.",
             "colours": [
@@ -9569,7 +9569,7 @@
         },
         {
             "id": "38a04db2-3b2e-5799-ab24-ff4e56ee0d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb9e6f-3c04-4b87-9d51-33516d0e9102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb9e6f-3c04-4b87-9d51-33516d0e9102.jpg?1",
             "name": "Grave Pact",
             "text": "",
             "colours": [
@@ -9602,7 +9602,7 @@
         },
         {
             "id": "5fb5787d-5505-5071-a9aa-d0fa905740bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1efc01-8dca-4e90-b5c4-14937d154fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1efc01-8dca-4e90-b5c4-14937d154fe4.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "0edb73c9-f6a7-53d7-96e6-a554e84e320a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5739e-caef-46f4-a083-25da30bf69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5739e-caef-46f4-a083-25da30bf69f4.jpg?1",
             "name": "Gravedigger",
             "text": "",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "254ed96e-f578-57ce-a699-65c8717fc909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6269968-0f58-4e20-94d0-678d39207988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6269968-0f58-4e20-94d0-678d39207988.jpg?1",
             "name": "Hell's Caretaker",
             "text": "{T}, Sacrifice a creature: Return target creature card from your graveyard to play. Play this ability only during your upkeep.",
             "colours": [
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "38681058-802d-5633-977d-0a31c5d34403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7babe0-0fa8-4224-af41-2f1e0c7315a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7babe0-0fa8-4224-af41-2f1e0c7315a3.jpg?1",
             "name": "Hell's Caretaker",
             "text": "",
             "colours": [
@@ -9742,7 +9742,7 @@
         },
         {
             "id": "abaa6528-3f66-5aa8-990d-cd3e646929ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3d34d2-d060-4690-aa67-af41117e7333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3d34d2-d060-4690-aa67-af41117e7333.jpg?1",
             "name": "Highway Robber",
             "text": "When Highway Robber comes into play, you gain 2 life and target opponent loses 2 life.",
             "colours": [
@@ -9778,7 +9778,7 @@
         },
         {
             "id": "6ab3ce26-8e09-52f8-be02-353ae4104aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a9ece9-3805-401a-bc83-7245342a42e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a9ece9-3805-401a-bc83-7245342a42e5.jpg?1",
             "name": "Highway Robber",
             "text": "",
             "colours": [
@@ -9814,7 +9814,7 @@
         },
         {
             "id": "977871c4-e750-5179-a01a-fa51ee166fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520fcafe-0c4a-49ca-8138-57a60506b0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520fcafe-0c4a-49ca-8138-57a60506b0cd.jpg?1",
             "name": "Hollow Dogs",
             "text": "Whenever Hollow Dogs attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "95f54395-7819-5082-9aae-f82693c6ea82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c431fff3-2189-42c8-b136-2d903c1e7f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c431fff3-2189-42c8-b136-2d903c1e7f1b.jpg?1",
             "name": "Hollow Dogs",
             "text": "",
             "colours": [
@@ -9888,7 +9888,7 @@
         },
         {
             "id": "d9ffa752-07b6-5b2e-a967-ec46998b2b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcae6a15-733d-44ae-ab23-a202ed071f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcae6a15-733d-44ae-ab23-a202ed071f28.jpg?1",
             "name": "Horror of Horrors",
             "text": "Sacrifice a Swamp: Regenerate target black creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -9921,7 +9921,7 @@
         },
         {
             "id": "62c57f06-8e09-5729-9bab-8be86a61ee90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ef53aa-e923-42c0-ac9b-4b712da6ce99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ef53aa-e923-42c0-ac9b-4b712da6ce99.jpg?1",
             "name": "Horror of Horrors",
             "text": "",
             "colours": [
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "350907dc-be3c-5345-aa74-4f5bb79ace50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205b6734-0205-4a57-ba55-2fd7ab40b8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205b6734-0205-4a57-ba55-2fd7ab40b8fa.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
             "colours": [
@@ -9989,7 +9989,7 @@
         },
         {
             "id": "23fd562b-dae4-5b08-9bee-aba21b1f8d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee325a6-0f87-4e14-89e2-2aba7cf0f441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee325a6-0f87-4e14-89e2-2aba7cf0f441.jpg?1",
             "name": "Hypnotic Specter",
             "text": "",
             "colours": [
@@ -10024,7 +10024,7 @@
         },
         {
             "id": "37b60281-a10e-5baa-9266-64a4a1292514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45304a48-f2a3-4a3c-b6ba-22d318fb0d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45304a48-f2a3-4a3c-b6ba-22d318fb0d8c.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10059,7 +10059,7 @@
         },
         {
             "id": "132a7b9d-6e23-501b-8623-5900f9830344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d02a18-7ebe-49ea-90c1-f4f11ef19592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d02a18-7ebe-49ea-90c1-f4f11ef19592.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -10094,7 +10094,7 @@
         },
         {
             "id": "881d0f2b-9bbd-5079-8465-2884902408d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29133d-74e5-4631-a283-22aa3c848d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29133d-74e5-4631-a283-22aa3c848d96.jpg?1",
             "name": "Lord of the Undead",
             "text": "Other Zombies get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -10129,7 +10129,7 @@
         },
         {
             "id": "b37ad916-5c10-5555-8b92-985af194ac89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9669b82-c461-4249-b906-09baa6d21925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9669b82-c461-4249-b906-09baa6d21925.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -10164,7 +10164,7 @@
         },
         {
             "id": "5bff7921-cdab-5b77-835a-42f8a393a1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02edaa79-2c99-4d37-a54f-0258476cd81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02edaa79-2c99-4d37-a54f-0258476cd81c.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -10197,7 +10197,7 @@
         },
         {
             "id": "da615318-51e7-5a39-ba1d-684aac76539b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb165f1-41ff-42c5-9789-234897373455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb165f1-41ff-42c5-9789-234897373455.jpg?1",
             "name": "Megrim",
             "text": "",
             "colours": [
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "21f4447c-73f4-5616-818e-5acf4b45d1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3234588-d421-4548-879e-32574b613707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3234588-d421-4548-879e-32574b613707.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -10263,7 +10263,7 @@
         },
         {
             "id": "580cc581-aec8-56ef-b99e-030536bbd2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6de68d6-9dad-4306-830a-2aab2e3dac7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6de68d6-9dad-4306-830a-2aab2e3dac7a.jpg?1",
             "name": "Mind Rot",
             "text": "",
             "colours": [
@@ -10296,7 +10296,7 @@
         },
         {
             "id": "b048428e-10ce-5426-a36a-5eb6d8814c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d5437b-158f-4a50-9397-bbde1c4a98d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d5437b-158f-4a50-9397-bbde1c4a98d5.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer is put into a graveyard from play, each player discards his or her hand.",
             "colours": [
@@ -10331,7 +10331,7 @@
         },
         {
             "id": "71177d00-a590-55a6-80f2-7fe6d20c12be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e704e8-1cb3-4c24-bdaa-e2528ffc7a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e704e8-1cb3-4c24-bdaa-e2528ffc7a8a.jpg?1",
             "name": "Mindslicer",
             "text": "",
             "colours": [
@@ -10366,7 +10366,7 @@
         },
         {
             "id": "51c5873c-4563-5afa-9a40-781b2654d0da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b2288c-e60e-48c3-8e53-62a47af6da92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b2288c-e60e-48c3-8e53-62a47af6da92.jpg?1",
             "name": "Mortivore",
             "text": "Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\n{B}: Regenerate Mortivore. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "f5d4f6c9-3935-5874-8f70-58a9b3b5f316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9639a0f1-12d3-4a37-890a-5fc48c56537d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9639a0f1-12d3-4a37-890a-5fc48c56537d.jpg?1",
             "name": "Mortivore",
             "text": "",
             "colours": [
@@ -10436,7 +10436,7 @@
         },
         {
             "id": "1e179619-d44f-56ca-95ef-c4665f7d190e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903c05c6-dca4-4094-ac59-0a7cb4d690f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903c05c6-dca4-4094-ac59-0a7cb4d690f6.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -10472,7 +10472,7 @@
         },
         {
             "id": "972d5750-11e4-56bc-b4c2-aa26008d54cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f59a79-47ac-4e50-b1db-8562fbfe0938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f59a79-47ac-4e50-b1db-8562fbfe0938.jpg?1",
             "name": "Nantuko Husk",
             "text": "",
             "colours": [
@@ -10508,7 +10508,7 @@
         },
         {
             "id": "e194f275-1490-56f0-a8e4-e9f21cfb79bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7d0ee9-3053-430a-a6a9-1202316f0648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7d0ee9-3053-430a-a6a9-1202316f0648.jpg?1",
             "name": "Nekrataal",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Nekrataal comes into play, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -10544,7 +10544,7 @@
         },
         {
             "id": "e0d28698-223a-5869-ab6d-b20ca8890c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb6a03-36cf-4368-831e-a33748dffd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb6a03-36cf-4368-831e-a33748dffd1b.jpg?1",
             "name": "Nekrataal",
             "text": "",
             "colours": [
@@ -10580,7 +10580,7 @@
         },
         {
             "id": "b8d688ee-3a4b-59cc-910c-3a10d5a7e882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6659c13-1858-4a66-a11f-e37416855951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6659c13-1858-4a66-a11f-e37416855951.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -10616,7 +10616,7 @@
         },
         {
             "id": "f2574d10-156f-5d30-87f8-fcb6fc39a066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3df8ed-ff36-478e-a4f4-bee041b77d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3df8ed-ff36-478e-a4f4-bee041b77d15.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "9eaef27b-7cb6-5150-b5b7-f3b73bf75976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af13f6-7a7b-431d-9dda-6492d135563f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af13f6-7a7b-431d-9dda-6492d135563f.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Target player reveals his or her hand and discards all cards of that color.",
             "colours": [
@@ -10685,7 +10685,7 @@
         },
         {
             "id": "112e93ce-500a-519d-8f91-32c97dbca5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4bf39b-32c4-4eb5-bc48-579fea72049b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4bf39b-32c4-4eb5-bc48-579fea72049b.jpg?1",
             "name": "Persecute",
             "text": "",
             "colours": [
@@ -10718,7 +10718,7 @@
         },
         {
             "id": "72c33715-8dff-50c6-8b57-0cc448f5529a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542370dc-0166-45b9-84bb-000cd97e80b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542370dc-0166-45b9-84bb-000cd97e80b9.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -10751,7 +10751,7 @@
         },
         {
             "id": "0f37ed63-fbac-5351-9601-62e49bbd86ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c25e492-2862-405b-ba1d-f58cb63294dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c25e492-2862-405b-ba1d-f58cb63294dd.jpg?1",
             "name": "Phyrexian Arena",
             "text": "",
             "colours": [
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "2f155825-ffc3-5cef-81df-de88ffea3fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f3d99d-f6e7-4633-948b-21dd64d918fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f3d99d-f6e7-4633-948b-21dd64d918fa.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua comes into play, you draw two cards and you lose 2 life.",
             "colours": [
@@ -10820,7 +10820,7 @@
         },
         {
             "id": "8df8376a-5fcf-5290-9329-29aab52629f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee9135-401c-4906-a844-d4b28ddfb029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee9135-401c-4906-a844-d4b28ddfb029.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "",
             "colours": [
@@ -10856,7 +10856,7 @@
         },
         {
             "id": "d207d4a6-1ec9-5477-aac5-645547f98cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16fc87c-ec62-4b62-9fb1-0fa5a73d1640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16fc87c-ec62-4b62-9fb1-0fa5a73d1640.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -10891,7 +10891,7 @@
         },
         {
             "id": "47de4c98-3dee-50ac-8f0c-a40b3f171d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f771905-27e2-4607-bfed-c40d2f3f9e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f771905-27e2-4607-bfed-c40d2f3f9e46.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -10926,7 +10926,7 @@
         },
         {
             "id": "3e10304e-2a48-5fd4-96a8-42dc5f6b058d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9c226b-0201-4af8-b164-5ca0fbdf52a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9c226b-0201-4af8-b164-5ca0fbdf52a9.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -10959,7 +10959,7 @@
         },
         {
             "id": "cb2e0ba4-b296-541d-ac70-6bdcd678356d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e420cd31-51db-479b-8b47-ed7b804d3ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e420cd31-51db-479b-8b47-ed7b804d3ae6.jpg?1",
             "name": "Plague Wind",
             "text": "",
             "colours": [
@@ -10992,7 +10992,7 @@
         },
         {
             "id": "3c24fc0a-6763-5b05-b967-e4b92aaca0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768e82c-82d8-4869-9284-7a9ec9d90967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768e82c-82d8-4869-9284-7a9ec9d90967.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -11025,7 +11025,7 @@
         },
         {
             "id": "21d6069f-2938-5848-92d3-a0951e5333f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81f75da-f37e-461b-9c3a-fffe759bc4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81f75da-f37e-461b-9c3a-fffe759bc4df.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "0a499ceb-cb0e-55d5-a712-436d89fa9cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b09e94-9504-444c-b002-7418962bf0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b09e94-9504-444c-b002-7418962bf0f9.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card.",
             "colours": [
@@ -11093,7 +11093,7 @@
         },
         {
             "id": "44c5f08e-d909-56f5-bc72-8e6419caa9bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7269485-ea4e-4560-994d-3788f89194dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7269485-ea4e-4560-994d-3788f89194dd.jpg?1",
             "name": "Ravenous Rats",
             "text": "",
             "colours": [
@@ -11128,7 +11128,7 @@
         },
         {
             "id": "4d8b2a65-85c9-5e62-a13c-2fa804e32354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92750247-eba4-4810-a758-f943cd8a16b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92750247-eba4-4810-a758-f943cd8a16b1.jpg?1",
             "name": "Razortooth Rats",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -11163,7 +11163,7 @@
         },
         {
             "id": "cca21704-d015-5c01-96dd-fbdd37aad31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f128936c-e46d-46fb-993f-6df172f9bb7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f128936c-e46d-46fb-993f-6df172f9bb7d.jpg?1",
             "name": "Razortooth Rats",
             "text": "",
             "colours": [
@@ -11198,7 +11198,7 @@
         },
         {
             "id": "07c0febc-64e5-515b-9f66-a31ebbb0e598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cd1ef7-e89f-444d-81a6-ead16462febc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cd1ef7-e89f-444d-81a6-ead16462febc.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11234,7 +11234,7 @@
         },
         {
             "id": "416c8d0e-f9d0-5235-85d0-6405d729ae7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560b9fd9-f78d-4e2f-84cc-ed9c7575b8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560b9fd9-f78d-4e2f-84cc-ed9c7575b8df.jpg?1",
             "name": "Royal Assassin",
             "text": "",
             "colours": [
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "66074bdb-7728-5f6f-a711-077e392e0e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54360cdf-ecbb-4a52-96a3-fd5d8f9b30bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54360cdf-ecbb-4a52-96a3-fd5d8f9b30bf.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11305,7 +11305,7 @@
         },
         {
             "id": "d3443c88-5e57-5478-a7c8-a9f9a26ba2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01326c97-d1f0-46cf-a84b-2a3d3420aa3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01326c97-d1f0-46cf-a84b-2a3d3420aa3d.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11340,7 +11340,7 @@
         },
         {
             "id": "fcc5a424-140b-56f4-9046-0215f5287b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fab1e55-6621-48a7-b2c6-1ef844362279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fab1e55-6621-48a7-b2c6-1ef844362279.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever a creature dealt damage by Sengir Vampire this turn is put into a graveyard, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -11375,7 +11375,7 @@
         },
         {
             "id": "291cf026-6b2f-5791-828f-2eaafcc5de6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def083a3-b292-44c1-83e4-0d03205b45ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def083a3-b292-44c1-83e4-0d03205b45ea.jpg?1",
             "name": "Sengir Vampire",
             "text": "",
             "colours": [
@@ -11410,7 +11410,7 @@
         },
         {
             "id": "98559b17-0bd6-5dcc-848e-3618844ca73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d825dc-c56b-4f59-aae0-ed960e18dfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d825dc-c56b-4f59-aae0-ed960e18dfab.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, you lose 3 life.",
             "colours": [
@@ -11446,7 +11446,7 @@
         },
         {
             "id": "80ffb8be-89f3-5e23-a5ab-1444251424b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc27d11e-b731-41cf-a756-fd6aca3643f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc27d11e-b731-41cf-a756-fd6aca3643f5.jpg?1",
             "name": "Serpent Warrior",
             "text": "",
             "colours": [
@@ -11482,7 +11482,7 @@
         },
         {
             "id": "2b38066e-ad95-587a-848e-fb28acb8951c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa460f4-9ae2-4c3a-aa1d-7e8bec9b313d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa460f4-9ae2-4c3a-aa1d-7e8bec9b313d.jpg?1",
             "name": "Slay",
             "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -11515,7 +11515,7 @@
         },
         {
             "id": "7a430370-f132-5a89-a1a9-2371760a634f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc91f16f-5022-4481-9578-3c3944b50f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc91f16f-5022-4481-9578-3c3944b50f5b.jpg?1",
             "name": "Slay",
             "text": "",
             "colours": [
@@ -11548,7 +11548,7 @@
         },
         {
             "id": "9963d137-e6e2-5545-b919-5f23c490063c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bb17f-e44a-4e2c-880e-733b6496576e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bb17f-e44a-4e2c-880e-733b6496576e.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -11581,7 +11581,7 @@
         },
         {
             "id": "ee440a33-8e74-5331-bd6e-dca8251037fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0963dbd8-6d02-4c84-8a4f-efe584c87f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0963dbd8-6d02-4c84-8a4f-efe584c87f54.jpg?1",
             "name": "Soul Feast",
             "text": "",
             "colours": [
@@ -11614,7 +11614,7 @@
         },
         {
             "id": "2a60bad7-f055-5902-bb68-992b3b258cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e11c98-e19f-4b38-acda-504d291c7f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e11c98-e19f-4b38-acda-504d291c7f42.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -11651,7 +11651,7 @@
         },
         {
             "id": "4650a3fd-c009-5665-bdd4-fbac640f1291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc0450a-c0e5-4609-9873-6ae08e8b8545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc0450a-c0e5-4609-9873-6ae08e8b8545.jpg?1",
             "name": "Spineless Thug",
             "text": "",
             "colours": [
@@ -11688,7 +11688,7 @@
         },
         {
             "id": "0893dec5-63c8-5777-af62-321871567bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1a92e2-6a8f-45fe-84cc-08fde6210077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1a92e2-6a8f-45fe-84cc-08fde6210077.jpg?1",
             "name": "Swarm of Rats",
             "text": "Swarm of Rats's power is equal to the number of Rats you control.",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "c947b1be-80aa-5ed1-b886-7cebfdcaedb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af6af6-c661-4d54-a8c3-cb67faec6708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af6af6-c661-4d54-a8c3-cb67faec6708.jpg?1",
             "name": "Swarm of Rats",
             "text": "",
             "colours": [
@@ -11758,7 +11758,7 @@
         },
         {
             "id": "090eac32-c495-50b4-a09f-4a51675f949d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1cbd83-c997-4c95-86a0-fe3c83d14975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1cbd83-c997-4c95-86a0-fe3c83d14975.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "88a443b6-50e6-5e4d-be67-3b9b25f73362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a3ca28-8b65-419f-9d37-4854ee92c6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a3ca28-8b65-419f-9d37-4854ee92c6d2.jpg?1",
             "name": "Underworld Dreams",
             "text": "",
             "colours": [
@@ -11824,7 +11824,7 @@
         },
         {
             "id": "955cf244-d726-503d-a97c-0a6ed032aeb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecf0be7-abf8-4681-bb7d-280a7dc5f761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecf0be7-abf8-4681-bb7d-280a7dc5f761.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "5a6cb257-ccfb-58d2-94fb-f41f507c189d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14121a8b-a41c-4213-82fc-c839b711f8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14121a8b-a41c-4213-82fc-c839b711f8f3.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -11894,7 +11894,7 @@
         },
         {
             "id": "d7b22aa2-a0b6-5c04-8271-f65f4ba5713b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb78e2-cb62-43dc-8f5b-bf81d2f02eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb78e2-cb62-43dc-8f5b-bf81d2f02eea.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{B}: Regenerate Will-o'-the-Wisp. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "bc95a234-7edf-5ade-afad-69042d9af8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074bf953-9a48-4768-b47f-9c9bb9d42874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074bf953-9a48-4768-b47f-9c9bb9d42874.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "",
             "colours": [
@@ -11964,7 +11964,7 @@
         },
         {
             "id": "7401c345-a479-5235-8100-5b5f53816b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a9fe1-ce63-4638-8793-5187fc726731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a9fe1-ce63-4638-8793-5187fc726731.jpg?1",
             "name": "Yawgmoth Demon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nFirst strike (This creature deals combat damage before creatures without first strike.)\nAt the beginning of your upkeep, you may sacrifice an artifact. If you don't, tap Yawgmoth Demon and it deals 2 damage to you.",
             "colours": [
@@ -12000,7 +12000,7 @@
         },
         {
             "id": "fc91b1e1-98d7-52e2-b5a4-8dc390460762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fc12d6-eb2b-467d-87e6-29ae54a7dc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fc12d6-eb2b-467d-87e6-29ae54a7dc6a.jpg?1",
             "name": "Yawgmoth Demon",
             "text": "",
             "colours": [
@@ -12036,7 +12036,7 @@
         },
         {
             "id": "c1596771-0d39-52e6-a3d0-622373594083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9af694a-6a96-494a-ab16-5c7c7e8e17a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9af694a-6a96-494a-ab16-5c7c7e8e17a9.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -12069,7 +12069,7 @@
         },
         {
             "id": "7505160a-b464-52ce-8058-1d284ecee708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c6bba-fdf2-4d8b-bd39-3b0cc071f880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c6bba-fdf2-4d8b-bd39-3b0cc071f880.jpg?1",
             "name": "Zombify",
             "text": "",
             "colours": [
@@ -12102,7 +12102,7 @@
         },
         {
             "id": "23abd431-25c3-5d8d-ae12-df5386312223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae202e-63f1-4d8b-bf85-2bf1a03c054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae202e-63f1-4d8b-bf85-2bf1a03c054c.jpg?1",
             "name": "Anaba Shaman",
             "text": "{R}, {T}: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -12138,7 +12138,7 @@
         },
         {
             "id": "7800a437-3a2b-5211-b3ab-121b1cd47b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca583969-51f1-489e-ae34-8bb997ee8a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca583969-51f1-489e-ae34-8bb997ee8a6c.jpg?1",
             "name": "Anaba Shaman",
             "text": "",
             "colours": [
@@ -12174,7 +12174,7 @@
         },
         {
             "id": "e4c42d25-15f1-5748-b20d-e0d38fcd639a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a989b0-4305-418c-a326-f89958f0c306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a989b0-4305-418c-a326-f89958f0c306.jpg?1",
             "name": "Anarchist",
             "text": "When Anarchist comes into play, you may return target sorcery card from your graveyard to your hand.",
             "colours": [
@@ -12210,7 +12210,7 @@
         },
         {
             "id": "59ddebf1-4b87-5512-9f70-bb3da7d0f47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ec860b-d8b4-4074-a6d9-eff31c856d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ec860b-d8b4-4074-a6d9-eff31c856d22.jpg?1",
             "name": "Anarchist",
             "text": "",
             "colours": [
@@ -12246,7 +12246,7 @@
         },
         {
             "id": "3e2ba5ef-5b7d-56b1-86e4-7d47b45a0f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caba00ff-df58-456e-8aeb-fc8b632018a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caba00ff-df58-456e-8aeb-fc8b632018a6.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12282,7 +12282,7 @@
         },
         {
             "id": "161823fe-0af1-54a2-9cd5-28b3152f5b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0961eff-e5a9-45cb-8394-c9c3717b9021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0961eff-e5a9-45cb-8394-c9c3717b9021.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12318,7 +12318,7 @@
         },
         {
             "id": "a07f6351-7f56-5a3e-843b-4998f60eb2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0313ea00-6c9f-4579-b322-4e37c093774c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0313ea00-6c9f-4579-b322-4e37c093774c.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -12351,7 +12351,7 @@
         },
         {
             "id": "1ef973a5-e5a6-5f04-907d-ea5d078f0a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47cbcb-7245-47d8-aa55-d6a5923f077a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47cbcb-7245-47d8-aa55-d6a5923f077a.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -12384,7 +12384,7 @@
         },
         {
             "id": "575aeeb4-0007-553e-962f-9244a6abad32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fec1a2-20b0-4412-9392-8a5004f9027e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fec1a2-20b0-4412-9392-8a5004f9027e.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -12417,7 +12417,7 @@
         },
         {
             "id": "f8e2e405-258a-5a03-92e6-82c0cfe216c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5bfc1d-1aef-4aef-afd7-05dab8553613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5bfc1d-1aef-4aef-afd7-05dab8553613.jpg?1",
             "name": "Blood Moon",
             "text": "",
             "colours": [
@@ -12450,7 +12450,7 @@
         },
         {
             "id": "4db99d78-e94b-5920-8541-82dfc23ba06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8fe3ff-535b-42d4-807f-0d458ebc8f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8fe3ff-535b-42d4-807f-0d458ebc8f54.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "{R}, Sacrifice Bloodfire Colossus: Bloodfire Colossus deals 6 damage to each creature and each player.",
             "colours": [
@@ -12485,7 +12485,7 @@
         },
         {
             "id": "b4c61d08-bbe1-5191-abfd-d49a22f2d2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9c8b8-4c32-4e87-a148-70d226eb9fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9c8b8-4c32-4e87-a148-70d226eb9fb7.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "",
             "colours": [
@@ -12520,7 +12520,7 @@
         },
         {
             "id": "51388bda-265f-51ca-aef2-49970498c08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08ff26e-c561-4b55-9745-50f896689d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08ff26e-c561-4b55-9745-50f896689d0d.jpg?1",
             "name": "Boiling Seas",
             "text": "Destroy all Islands.",
             "colours": [
@@ -12553,7 +12553,7 @@
         },
         {
             "id": "b2514634-d71d-5da0-8686-4da7903dfbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb1b9f8-7a15-4bcb-bcf4-015fe4f035d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb1b9f8-7a15-4bcb-bcf4-015fe4f035d0.jpg?1",
             "name": "Boiling Seas",
             "text": "",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "3303b992-50a1-5474-a977-1fef567ee04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fb13b-60f0-4b96-b63c-8a9df745bfca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fb13b-60f0-4b96-b63c-8a9df745bfca.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "184f3754-7a75-54e0-9fac-eaf77b02024b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0181e-dc38-40f1-9266-821f01c851a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0181e-dc38-40f1-9266-821f01c851a3.jpg?1",
             "name": "Demolish",
             "text": "",
             "colours": [
@@ -12652,7 +12652,7 @@
         },
         {
             "id": "71faf63d-bc42-5935-b17e-5ef305b1c225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f10e9f0-32c6-40cc-b16d-5590662cdb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f10e9f0-32c6-40cc-b16d-5590662cdb33.jpg?1",
             "name": "Enrage",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -12685,7 +12685,7 @@
         },
         {
             "id": "e8440979-4699-5c27-9dd1-aa688a63d4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df27923c-de30-4adf-821d-3edec4d3ba63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df27923c-de30-4adf-821d-3edec4d3ba63.jpg?1",
             "name": "Enrage",
             "text": "",
             "colours": [
@@ -12718,7 +12718,7 @@
         },
         {
             "id": "56f8e7d7-12c9-542b-85fb-d49eac0f05ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb31487e-72c6-4d11-a80d-1ff3a81e9cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb31487e-72c6-4d11-a80d-1ff3a81e9cd6.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -12753,7 +12753,7 @@
         },
         {
             "id": "d4868162-6d23-52d6-8692-9278565788ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70871e34-5659-4f08-ba43-765de400f262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70871e34-5659-4f08-ba43-765de400f262.jpg?1",
             "name": "Firebreathing",
             "text": "",
             "colours": [
@@ -12788,7 +12788,7 @@
         },
         {
             "id": "d6a0bf14-6b06-59cc-93c6-1b386c893be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce194b3b-a3e1-4a63-91c9-6454e5b41963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce194b3b-a3e1-4a63-91c9-6454e5b41963.jpg?1",
             "name": "Flame Wave",
             "text": "Flame Wave deals 4 damage to target player and each creature he or she controls.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "3dd60813-4f46-5681-9af1-4070988dd96e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edfd311-c8dd-4b54-b5f4-7020970adf1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edfd311-c8dd-4b54-b5f4-7020970adf1a.jpg?1",
             "name": "Flame Wave",
             "text": "",
             "colours": [
@@ -12854,7 +12854,7 @@
         },
         {
             "id": "f6bf3d03-5439-5ad4-9669-5956f9d9019b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e0846-237e-4117-bdd4-d2e4ae450d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e0846-237e-4117-bdd4-d2e4ae450d43.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all Plains.",
             "colours": [
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "5229aed1-c317-5db3-b37f-e99c670a2797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb40337-4bcc-457a-ada7-df93616ff74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb40337-4bcc-457a-ada7-df93616ff74f.jpg?1",
             "name": "Flashfires",
             "text": "",
             "colours": [
@@ -12920,7 +12920,7 @@
         },
         {
             "id": "46a4e728-eed6-5023-bc90-1ce0e8f2a2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd861b1c-8d91-4595-9fcd-b324234f2264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd861b1c-8d91-4595-9fcd-b324234f2264.jpg?1",
             "name": "Flowstone Crusher",
             "text": "{R}: Flowstone Crusher gets +1/-1 until end of turn.",
             "colours": [
@@ -12955,7 +12955,7 @@
         },
         {
             "id": "19730b05-bf76-53fd-87e8-00b9414e754c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec12624-348e-45b9-aab0-91c9f86614d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec12624-348e-45b9-aab0-91c9f86614d5.jpg?1",
             "name": "Flowstone Crusher",
             "text": "",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "83f82a97-cc73-5cd6-b599-a3bc71f81a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65669460-54e6-4358-83de-d7a576f9eea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65669460-54e6-4358-83de-d7a576f9eea3.jpg?1",
             "name": "Flowstone Shambler",
             "text": "{R}: Flowstone Shambler gets +1/-1 until end of turn.",
             "colours": [
@@ -13025,7 +13025,7 @@
         },
         {
             "id": "9ab55d06-ad47-5082-935a-91fc3765f2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2213001-44cf-4f54-8502-58865c1eb7b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2213001-44cf-4f54-8502-58865c1eb7b1.jpg?1",
             "name": "Flowstone Shambler",
             "text": "",
             "colours": [
@@ -13060,7 +13060,7 @@
         },
         {
             "id": "6c2b0297-b585-5fb3-a8a7-b85bf6c8339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66496fd3-6f2e-4d94-a60f-16f5691c3f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66496fd3-6f2e-4d94-a60f-16f5691c3f55.jpg?1",
             "name": "Flowstone Slide",
             "text": "All creatures get +X/-X until end of turn.",
             "colours": [
@@ -13093,7 +13093,7 @@
         },
         {
             "id": "7b0ee3ac-264a-5b7c-8756-c3156173c0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401a2be-cddb-4ebd-9679-eb7145d3d848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401a2be-cddb-4ebd-9679-eb7145d3d848.jpg?1",
             "name": "Flowstone Slide",
             "text": "",
             "colours": [
@@ -13126,7 +13126,7 @@
         },
         {
             "id": "2724eced-6464-5b31-b1ad-e353f83e92f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfc77f1-290a-4394-bc16-76f3659810f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfc77f1-290a-4394-bc16-76f3659810f0.jpg?1",
             "name": "Form of the Dragon",
             "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the end of each turn, your life total becomes 5.\nCreatures without flying can't attack you.",
             "colours": [
@@ -13159,7 +13159,7 @@
         },
         {
             "id": "000da741-09c0-511a-96fc-9668f310abd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274175ba-d079-49f6-83a3-d83f6650e903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274175ba-d079-49f6-83a3-d83f6650e903.jpg?1",
             "name": "Form of the Dragon",
             "text": "",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "1ad09995-cc27-5c15-8d38-e9e191fdcbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e139a085-d8fe-40a0-984d-4ce9378c48f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e139a085-d8fe-40a0-984d-4ce9378c48f7.jpg?1",
             "name": "Furnace of Rath",
             "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -13225,7 +13225,7 @@
         },
         {
             "id": "8bc5ff43-9405-592d-bd82-0bb30cc9dba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9cee2-c60e-4971-a69f-8af5c81ed5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9cee2-c60e-4971-a69f-8af5c81ed5d2.jpg?1",
             "name": "Furnace of Rath",
             "text": "",
             "colours": [
@@ -13258,7 +13258,7 @@
         },
         {
             "id": "21f33fc2-bf59-5a8d-b5ae-fcab0a52269b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059227f9-f6d7-45ab-8398-35e97b677a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059227f9-f6d7-45ab-8398-35e97b677a08.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "{R}: Goblin Balloon Brigade gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -13294,7 +13294,7 @@
         },
         {
             "id": "c22a9345-155e-553e-bab3-6dc3dd1224e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212459a3-0183-4346-8372-5b4d61bc7869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212459a3-0183-4346-8372-5b4d61bc7869.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "",
             "colours": [
@@ -13330,7 +13330,7 @@
         },
         {
             "id": "73a5dd77-916d-5cea-8d53-b6518e72a846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862a481a-f236-4e99-b4b9-086e6cb8f4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862a481a-f236-4e99-b4b9-086e6cb8f4de.jpg?1",
             "name": "Goblin Brigand",
             "text": "Goblin Brigand attacks each turn if able.",
             "colours": [
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "e25f2702-1c4f-5422-88e6-b9f0eb9e9fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43f6241-c629-4fd3-8781-30ed1903c1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43f6241-c629-4fd3-8781-30ed1903c1fe.jpg?1",
             "name": "Goblin Brigand",
             "text": "",
             "colours": [
@@ -13402,7 +13402,7 @@
         },
         {
             "id": "f93f3f97-e22a-5773-a97c-4c275c78f584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a15cb-9591-4521-a142-af766dd7eeef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a15cb-9591-4521-a142-af766dd7eeef.jpg?1",
             "name": "Goblin Chariot",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "d66345b1-192d-546e-b464-95328267a8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c36a55-a010-4661-af85-9f1344c108d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c36a55-a010-4661-af85-9f1344c108d3.jpg?1",
             "name": "Goblin Chariot",
             "text": "",
             "colours": [
@@ -13474,7 +13474,7 @@
         },
         {
             "id": "43d45036-682d-5aa6-acec-84f81ef17308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c68f83-5471-40b5-a673-84032ce24ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c68f83-5471-40b5-a673-84032ce24ba2.jpg?1",
             "name": "Goblin King",
             "text": "Other Goblins get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -13509,7 +13509,7 @@
         },
         {
             "id": "f02469e5-d2f8-5840-8eed-692ffd481d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09c6616-91d8-4257-9fb7-09ec9e52de78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09c6616-91d8-4257-9fb7-09ec9e52de78.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -13544,7 +13544,7 @@
         },
         {
             "id": "9295299f-9e19-5ceb-b317-b2dc9549d8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8754592a-2f9b-477c-a049-d9a3eed271e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8754592a-2f9b-477c-a049-d9a3eed271e5.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -13580,7 +13580,7 @@
         },
         {
             "id": "9d30e59e-0b0b-51c4-bccc-182321a98045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ce5e37-41dc-4479-8c0d-9d17240739ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ce5e37-41dc-4479-8c0d-9d17240739ed.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "",
             "colours": [
@@ -13616,7 +13616,7 @@
         },
         {
             "id": "2d567dd4-ebc8-5144-9b72-56a0201ec640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c86887-678a-4ba5-b0bb-243f4015ad80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c86887-678a-4ba5-b0bb-243f4015ad80.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -13652,7 +13652,7 @@
         },
         {
             "id": "d6e41224-39d2-5b49-aa97-d74f694ebf44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fffa95-95c8-47b5-a196-431f731781e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fffa95-95c8-47b5-a196-431f731781e6.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "61dbf371-7301-5ae3-ba4c-d5eb04800c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fa6280-5620-47d3-93c5-eaed1e5351d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fa6280-5620-47d3-93c5-eaed1e5351d2.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -13724,7 +13724,7 @@
         },
         {
             "id": "d7beab49-70e7-53b8-b023-e6e245062a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec7dd91-fc60-46f7-9dc4-fd3f00fb1f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec7dd91-fc60-46f7-9dc4-fd3f00fb1f29.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "",
             "colours": [
@@ -13760,7 +13760,7 @@
         },
         {
             "id": "e9844eaa-e142-5a73-8ed1-ac8dcf047e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f94743-c228-410a-9cb9-d00a1e55dfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f94743-c228-410a-9cb9-d00a1e55dfcf.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nWhen a spell or ability an opponent controls causes you to discard Guerrilla Tactics, Guerrilla Tactics deals 4 damage to target creature or player.",
             "colours": [
@@ -13793,7 +13793,7 @@
         },
         {
             "id": "85d648c2-47a4-55e5-a16f-5073e27e042e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b7c3d-bad2-495e-a568-ce79b019a188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b7c3d-bad2-495e-a568-ce79b019a188.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "",
             "colours": [
@@ -13826,7 +13826,7 @@
         },
         {
             "id": "6de78db1-9bfc-53ef-a436-136717234fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa75eaf-948f-4503-962d-95b0321b36d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa75eaf-948f-4503-962d-95b0321b36d9.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13861,7 +13861,7 @@
         },
         {
             "id": "401f933f-36a8-59b2-a290-701d844a82c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58968ba0-77a4-49fe-aa1d-0dc8a1db4923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58968ba0-77a4-49fe-aa1d-0dc8a1db4923.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13896,7 +13896,7 @@
         },
         {
             "id": "762dcec2-47b9-5ce7-8cc7-99cd3d5ca6cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad95118-104c-41d4-a393-941e7b97fd8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad95118-104c-41d4-a393-941e7b97fd8e.jpg?1",
             "name": "Karplusan Yeti",
             "text": "{T}: Karplusan Yeti deals damage equal to its power to target creature. That creature deals damage equal to its power to Karplusan Yeti.",
             "colours": [
@@ -13931,7 +13931,7 @@
         },
         {
             "id": "06266a9a-2a5d-5843-80e4-9cf6644171cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0535c-36d0-4e77-bf59-9c7a6c9b2ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0535c-36d0-4e77-bf59-9c7a6c9b2ddb.jpg?1",
             "name": "Karplusan Yeti",
             "text": "",
             "colours": [
@@ -13966,7 +13966,7 @@
         },
         {
             "id": "6faf816d-a5f5-51fb-a538-76b8f5d3d6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27423c7b-d1fd-471b-9648-8ea5ed9ebaf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27423c7b-d1fd-471b-9648-8ea5ed9ebaf2.jpg?1",
             "name": "Kird Ape",
             "text": "Kird Ape gets +1/+2 as long as you control a Forest.",
             "colours": [
@@ -14001,7 +14001,7 @@
         },
         {
             "id": "55420b2e-d57b-5cfa-8afc-1a91d1ccc7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0f90df-826c-422e-bfbf-4eb14f609c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0f90df-826c-422e-bfbf-4eb14f609c22.jpg?1",
             "name": "Kird Ape",
             "text": "",
             "colours": [
@@ -14036,7 +14036,7 @@
         },
         {
             "id": "9b030a32-eb41-5b72-8a03-9f74d1f55261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbcc027a-55c9-4baf-a801-8db805129d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbcc027a-55c9-4baf-a801-8db805129d5b.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -14069,7 +14069,7 @@
         },
         {
             "id": "a7c05935-275d-5a56-b09b-1cd4207e5a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d49083e-f4e0-4b31-8e65-273a62fab2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d49083e-f4e0-4b31-8e65-273a62fab2f2.jpg?1",
             "name": "Lava Axe",
             "text": "",
             "colours": [
@@ -14102,7 +14102,7 @@
         },
         {
             "id": "ccb4c345-857d-5c66-9a4c-892f12156854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a23bff-6d5a-4020-afec-874ca48765d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a23bff-6d5a-4020-afec-874ca48765d6.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "4c0a404c-7bce-5e26-a363-69231ea43a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb46346-d0e8-4e37-96b1-416c966f7a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb46346-d0e8-4e37-96b1-416c966f7a32.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -14172,7 +14172,7 @@
         },
         {
             "id": "84c891f2-68e7-5822-afce-064a2fcf8dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab077f67-09c3-43d0-ad27-d1e6255c4d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab077f67-09c3-43d0-ad27-d1e6255c4d55.jpg?1",
             "name": "Magnivore",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nMagnivore's power and toughness are each equal to the number of sorcery cards in all graveyards.",
             "colours": [
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "49c0df5c-af0d-57da-9e3c-2dc634a27c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79500942-8581-4114-99d3-317f77a2cdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79500942-8581-4114-99d3-317f77a2cdea.jpg?1",
             "name": "Magnivore",
             "text": "",
             "colours": [
@@ -14242,7 +14242,7 @@
         },
         {
             "id": "c3cfd994-cabb-5bec-a513-f026251d5596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41352f-617f-40f6-b612-11022180c18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41352f-617f-40f6-b612-11022180c18b.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
             "colours": [
@@ -14275,7 +14275,7 @@
         },
         {
             "id": "fc3978a6-90ad-5106-b169-98890c06cd70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004909d8-b362-44c4-ae6f-96b28546fb72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004909d8-b362-44c4-ae6f-96b28546fb72.jpg?1",
             "name": "Mana Clash",
             "text": "",
             "colours": [
@@ -14308,7 +14308,7 @@
         },
         {
             "id": "7ce5afb2-81bb-5c1c-9dbd-83555766b29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56100dd7-250d-4a3a-b719-b25fc73873dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56100dd7-250d-4a3a-b719-b25fc73873dc.jpg?1",
             "name": "Mogg Sentry",
             "text": "Whenever an opponent plays a spell, Mogg Sentry gets +2/+2 until end of turn.",
             "colours": [
@@ -14344,7 +14344,7 @@
         },
         {
             "id": "2a665db3-f072-5412-8c5f-a2e963c98087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d7fd07-cce7-4c5d-a86d-5e68361e52d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d7fd07-cce7-4c5d-a86d-5e68361e52d2.jpg?1",
             "name": "Mogg Sentry",
             "text": "",
             "colours": [
@@ -14380,7 +14380,7 @@
         },
         {
             "id": "46fb184e-fcf1-5fb1-aefb-8056403fea9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c08378-7344-4f11-8206-bec2a72f0570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c08378-7344-4f11-8206-bec2a72f0570.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "13f48af3-d354-59dc-a21e-7fda03bb696e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf0228b-43f5-492a-b3c4-10c9a58a2b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf0228b-43f5-492a-b3c4-10c9a58a2b6d.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "",
             "colours": [
@@ -14450,7 +14450,7 @@
         },
         {
             "id": "9475c46f-682a-5c3e-aa29-3d12e37ca44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14addda6-7f7c-4c7f-abfe-e647e0282936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14addda6-7f7c-4c7f-abfe-e647e0282936.jpg?1",
             "name": "Orcish Artillery",
             "text": "{T}: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -14486,7 +14486,7 @@
         },
         {
             "id": "9486e207-65e7-50ca-a4fb-0a2c162c040f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d6875-f17d-49cc-87b0-4308b0ee63e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d6875-f17d-49cc-87b0-4308b0ee63e4.jpg?1",
             "name": "Orcish Artillery",
             "text": "",
             "colours": [
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "622dace3-ee8d-5b92-bb35-a328c6ed0269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92688a63-ae5d-48ee-87ce-a8f163ee8650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92688a63-ae5d-48ee-87ce-a8f163ee8650.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -14555,7 +14555,7 @@
         },
         {
             "id": "6e0c9307-c414-522b-a7b8-9b46f695c4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc612c4-5af0-441a-bc21-5aa13cc13a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc612c4-5af0-441a-bc21-5aa13cc13a9b.jpg?1",
             "name": "Panic Attack",
             "text": "",
             "colours": [
@@ -14588,7 +14588,7 @@
         },
         {
             "id": "97ed11ce-bcbd-556a-9bb3-10776b535bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6df956-0dc0-41f4-bf37-c88bcd80cc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6df956-0dc0-41f4-bf37-c88bcd80cc95.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -14621,7 +14621,7 @@
         },
         {
             "id": "b991d85f-57f0-5245-94f2-4d2541cadcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bc456-41a1-471f-ab13-7d0575b0b295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bc456-41a1-471f-ab13-7d0575b0b295.jpg?1",
             "name": "Pyroclasm",
             "text": "",
             "colours": [
@@ -14654,7 +14654,7 @@
         },
         {
             "id": "05059f94-2937-5854-a284-850de639f801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47a96df-dce7-495b-acc0-5551641f5a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47a96df-dce7-495b-acc0-5551641f5a57.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14690,7 +14690,7 @@
         },
         {
             "id": "e8924f13-d2fd-5622-b672-b291eba17495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcea609-4a24-468d-a4fe-0524f53a7a01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcea609-4a24-468d-a4fe-0524f53a7a01.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -14726,7 +14726,7 @@
         },
         {
             "id": "c07d9e49-a7e0-5cdc-bf31-87bd2457c7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dbcf6c-d947-4d02-acfa-f14763785615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dbcf6c-d947-4d02-acfa-f14763785615.jpg?1",
             "name": "Rathi Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Rathi Dragon comes into play, sacrifice it unless you sacrifice two Mountains.",
             "colours": [
@@ -14761,7 +14761,7 @@
         },
         {
             "id": "c4520818-625e-5da4-84b5-bb94848817c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03882614-589a-4814-a8f7-f962a70d6bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03882614-589a-4814-a8f7-f962a70d6bb2.jpg?1",
             "name": "Rathi Dragon",
             "text": "",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "93e3e0fc-97e1-5e32-b3aa-99e136e863f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d9770-4316-4ac1-b235-5a1d6e15cece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d9770-4316-4ac1-b235-5a1d6e15cece.jpg?1",
             "name": "Reflexes",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -14831,7 +14831,7 @@
         },
         {
             "id": "28f6c664-eea8-557b-90aa-744ad5538ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac80159-e302-40d2-997e-44749053b162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac80159-e302-40d2-997e-44749053b162.jpg?1",
             "name": "Reflexes",
             "text": "",
             "colours": [
@@ -14866,7 +14866,7 @@
         },
         {
             "id": "2954a762-2f83-57d5-afda-801eac2d7fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b0e2ce-6168-456c-b960-83a21e968504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b0e2ce-6168-456c-b960-83a21e968504.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -14899,7 +14899,7 @@
         },
         {
             "id": "e3f46f91-4079-502b-a6cd-282c6143ff1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd1962-1d11-4d4c-a273-73a1384a88f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd1962-1d11-4d4c-a273-73a1384a88f1.jpg?1",
             "name": "Relentless Assault",
             "text": "",
             "colours": [
@@ -14932,7 +14932,7 @@
         },
         {
             "id": "c62d6cfb-8f1d-50b8-9ecc-ec74dd5238e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e565859-fb56-4287-a1c5-c50cfff4e8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e565859-fb56-4287-a1c5-c50cfff4e8e6.jpg?1",
             "name": "Rogue Kavu",
             "text": "Whenever Rogue Kavu attacks alone, it gets +2/+0 until end of turn.",
             "colours": [
@@ -14967,7 +14967,7 @@
         },
         {
             "id": "e527bae1-e121-50b1-abcc-2d56973f3f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1",
             "name": "Rogue Kavu",
             "text": "",
             "colours": [
@@ -15002,7 +15002,7 @@
         },
         {
             "id": "e1fbaa6d-3d00-551a-87a8-df9438130342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfc662-edfb-43ff-8022-1db971b1de22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfc662-edfb-43ff-8022-1db971b1de22.jpg?1",
             "name": "Rukh Egg",
             "text": "When Rukh Egg is put into a graveyard from play, put a 4/4 red Bird creature token with flying into play at end of turn.",
             "colours": [
@@ -15038,7 +15038,7 @@
         },
         {
             "id": "80227265-52bd-5b7e-9824-ce6afe6b78df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1098d-6d6e-444d-8307-508ffb2a9b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1098d-6d6e-444d-8307-508ffb2a9b4a.jpg?1",
             "name": "Rukh Egg",
             "text": "",
             "colours": [
@@ -15074,7 +15074,7 @@
         },
         {
             "id": "efe54fda-fa1c-5545-84a9-c76e83265f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df10856-6e72-4225-8185-abe359768575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df10856-6e72-4225-8185-abe359768575.jpg?1",
             "name": "Sandstone Warrior",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\n{R}: Sandstone Warrior gets +1/+0 until end of turn.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "3607620c-2179-57ae-83d0-ffe31a42837d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b4d36-b084-4fbc-abcc-d0e9c0ae4650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b4d36-b084-4fbc-abcc-d0e9c0ae4650.jpg?1",
             "name": "Sandstone Warrior",
             "text": "",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "8ab7927a-be62-5e52-96d6-46c34f42a53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10418027-7b05-49e7-8ff4-6a03e3fb656b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10418027-7b05-49e7-8ff4-6a03e3fb656b.jpg?1",
             "name": "Seething Song",
             "text": "Add {R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -15181,7 +15181,7 @@
         },
         {
             "id": "a1e7ac5b-e514-594c-b8bf-bedf1bdb9ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4d8327-49ed-40d0-ade3-459c9f9c4832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4d8327-49ed-40d0-ade3-459c9f9c4832.jpg?1",
             "name": "Seething Song",
             "text": "",
             "colours": [
@@ -15214,7 +15214,7 @@
         },
         {
             "id": "7afedade-6d52-505f-9f98-207f36b358e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d02731-bcdb-4447-adc8-06eea08725ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d02731-bcdb-4447-adc8-06eea08725ba.jpg?1",
             "name": "Shard Phoenix",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nSacrifice Shard Phoenix: Shard Phoenix deals 2 damage to each creature without flying.\n{R}{R}{R}: Return Shard Phoenix from your graveyard to your hand. Play this ability only during your upkeep.",
             "colours": [
@@ -15249,7 +15249,7 @@
         },
         {
             "id": "d0bb3ef8-3931-59cb-8df5-e9aa44daff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf506981-7f50-46e6-b84c-014637567b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf506981-7f50-46e6-b84c-014637567b74.jpg?1",
             "name": "Shard Phoenix",
             "text": "",
             "colours": [
@@ -15284,7 +15284,7 @@
         },
         {
             "id": "c0dd9507-0d92-5aad-be2f-f033e803cab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e79ce1-29d6-48d3-b7d5-8cd95cef3234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e79ce1-29d6-48d3-b7d5-8cd95cef3234.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -15317,7 +15317,7 @@
         },
         {
             "id": "d135a132-7655-5bd5-81c3-4ce869b94792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14bc5cc-2bff-4fb8-af13-143fee558a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14bc5cc-2bff-4fb8-af13-143fee558a8c.jpg?1",
             "name": "Shatter",
             "text": "",
             "colours": [
@@ -15350,7 +15350,7 @@
         },
         {
             "id": "05467b2d-03c5-50ed-852b-173020c23903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbf9dde-e396-43dc-8288-b39e63a23164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbf9dde-e396-43dc-8288-b39e63a23164.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -15385,7 +15385,7 @@
         },
         {
             "id": "0d4a8c12-971e-5c0f-b8be-292896cf60bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ef10a-4bbc-40ce-883d-f4aa471052fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ef10a-4bbc-40ce-883d-f4aa471052fc.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -15420,7 +15420,7 @@
         },
         {
             "id": "3383c075-bbf0-520e-9801-e526ab528ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b241a-a58e-440a-8591-91dce118bd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b241a-a58e-440a-8591-91dce118bd95.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -15453,7 +15453,7 @@
         },
         {
             "id": "4f1df72d-a22b-539f-8559-2a3892bf3750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8314410-53e1-4264-87f1-5c6484670693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8314410-53e1-4264-87f1-5c6484670693.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -15486,7 +15486,7 @@
         },
         {
             "id": "41bea4a3-19c6-53bb-a06d-2643f0265d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2334c10-fa96-4f8e-8187-c7ecc00cbac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2334c10-fa96-4f8e-8187-c7ecc00cbac8.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -15519,7 +15519,7 @@
         },
         {
             "id": "f2957c90-7d91-5862-ae2e-b61d88cf6e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9bd15ff-c52e-4caf-8146-e61469ad94a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9bd15ff-c52e-4caf-8146-e61469ad94a2.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -15552,7 +15552,7 @@
         },
         {
             "id": "b8a04fec-7e2f-5962-8c37-c8c9cfb6daf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823e98-e0ea-490d-8a32-8e657d766f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823e98-e0ea-490d-8a32-8e657d766f06.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -15585,7 +15585,7 @@
         },
         {
             "id": "f1c47a79-2be6-51e5-9acc-6976f66ab4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e993480b-5a9e-485e-9d21-d8d9ccfc0884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e993480b-5a9e-485e-9d21-d8d9ccfc0884.jpg?1",
             "name": "Sudden Impact",
             "text": "",
             "colours": [
@@ -15618,7 +15618,7 @@
         },
         {
             "id": "2df25a28-9ead-5688-8192-e3ef5fbbcce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31694de6-567f-449e-a5e5-54d2f62be205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31694de6-567f-449e-a5e5-54d2f62be205.jpg?1",
             "name": "Threaten",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. (It may attack this turn.)",
             "colours": [
@@ -15651,7 +15651,7 @@
         },
         {
             "id": "b23d78c2-9360-5cf2-bfb1-e68633975071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aded85-750e-4d28-9834-fc2e02fcecb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aded85-750e-4d28-9834-fc2e02fcecb2.jpg?1",
             "name": "Threaten",
             "text": "",
             "colours": [
@@ -15684,7 +15684,7 @@
         },
         {
             "id": "530922fb-4647-55fb-ba48-939009d3ef67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068c0c3-4ec9-4c02-84db-42b609df545f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068c0c3-4ec9-4c02-84db-42b609df545f.jpg?1",
             "name": "Thundermare",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nWhen Thundermare comes into play, tap all other creatures.",
             "colours": [
@@ -15720,7 +15720,7 @@
         },
         {
             "id": "3b932cad-1a13-55dd-b430-a55b5d70c854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325ebb1-7b3b-4380-90cb-e7158de23841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325ebb1-7b3b-4380-90cb-e7158de23841.jpg?1",
             "name": "Thundermare",
             "text": "",
             "colours": [
@@ -15756,7 +15756,7 @@
         },
         {
             "id": "7b5ce324-621e-54e6-aa23-273d6130a019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1954d2eb-c1d0-4b99-a89c-357beb710055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1954d2eb-c1d0-4b99-a89c-357beb710055.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nAt end of turn, return Viashino Sandstalker to its owner's hand. (Return it only if it's in play.)",
             "colours": [
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "06a52aaf-b824-581f-9e51-523ae70e90c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c31c75-f961-40a8-83ba-3ee5997b2b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c31c75-f961-40a8-83ba-3ee5997b2b52.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "",
             "colours": [
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "5fe3a0c8-e0e6-59fa-bd3b-bb2bf89496c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3f454-4aeb-4e48-b961-bea760ea8ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3f454-4aeb-4e48-b961-bea760ea8ddf.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to target creature or player.",
             "colours": [
@@ -15861,7 +15861,7 @@
         },
         {
             "id": "df9a0765-9b8f-5794-b8b1-cb43feeed981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6520a7-2a8e-4536-a124-9980d22c7756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6520a7-2a8e-4536-a124-9980d22c7756.jpg?1",
             "name": "Volcanic Hammer",
             "text": "",
             "colours": [
@@ -15894,7 +15894,7 @@
         },
         {
             "id": "db8b606d-f353-5f25-a250-f14e2f98831f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b672b-1e2b-4969-9b7e-ea44ef766113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b672b-1e2b-4969-9b7e-ea44ef766113.jpg?1",
             "name": "Whip Sergeant",
             "text": "{R}: Target creature gains haste until end of turn. (It may attack this turn.)",
             "colours": [
@@ -15930,7 +15930,7 @@
         },
         {
             "id": "f55ad19c-2ab4-5bbb-b2fd-209c7910f773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8651d50d-be71-4445-94f6-f1877d22816f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8651d50d-be71-4445-94f6-f1877d22816f.jpg?1",
             "name": "Whip Sergeant",
             "text": "",
             "colours": [
@@ -15966,7 +15966,7 @@
         },
         {
             "id": "c049c73e-d0a6-5c2f-b687-f1f6b160864c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db2609-b02f-4b46-8467-eac4c7022d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db2609-b02f-4b46-8467-eac4c7022d5c.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands. Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -15999,7 +15999,7 @@
         },
         {
             "id": "17246fb9-b8ff-544b-b922-51ff27de40ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f278246-fd11-48ba-8ec0-1a4511dfa6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f278246-fd11-48ba-8ec0-1a4511dfa6f4.jpg?1",
             "name": "Wildfire",
             "text": "",
             "colours": [
@@ -16032,7 +16032,7 @@
         },
         {
             "id": "81b9417a-132b-597c-8f55-d5bb548bf944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f57f8bf-228b-4da2-823c-67bce8b574cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f57f8bf-228b-4da2-823c-67bce8b574cd.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -16067,7 +16067,7 @@
         },
         {
             "id": "b135c20b-5683-5aa7-918f-7cda66d18299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d673f-89de-49c5-8391-dac8ae8ec45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d673f-89de-49c5-8391-dac8ae8ec45c.jpg?1",
             "name": "Anaconda",
             "text": "",
             "colours": [
@@ -16102,7 +16102,7 @@
         },
         {
             "id": "5748885e-acf6-5bba-8e65-687b21652fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818a0944-3534-49e4-8d93-274244043696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818a0944-3534-49e4-8d93-274244043696.jpg?1",
             "name": "Ancient Silverback",
             "text": "{G}: Regenerate Ancient Silverback. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -16137,7 +16137,7 @@
         },
         {
             "id": "3dea4cee-6841-5989-83d2-c0ede2948d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1fa5f-c7b6-4747-a4ef-f6bb4dc8ba53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1fa5f-c7b6-4747-a4ef-f6bb4dc8ba53.jpg?1",
             "name": "Ancient Silverback",
             "text": "",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "b5f155de-74c9-508b-98af-2f6ff818d91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d1a10f-ce21-4914-9984-c7c559161230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d1a10f-ce21-4914-9984-c7c559161230.jpg?1",
             "name": "Biorhythm",
             "text": "Each player's life total becomes the number of creatures he or she controls.",
             "colours": [
@@ -16205,7 +16205,7 @@
         },
         {
             "id": "98d93f33-81c3-5bb0-9d31-fa3b86328b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f844dc35-f063-4514-8d4b-82559ab0603f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f844dc35-f063-4514-8d4b-82559ab0603f.jpg?1",
             "name": "Biorhythm",
             "text": "",
             "colours": [
@@ -16238,7 +16238,7 @@
         },
         {
             "id": "5f551000-b982-588e-905b-68d8ea228266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e558f1-74ef-4d16-8135-2a8dc0c58fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e558f1-74ef-4d16-8135-2a8dc0c58fe9.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -16273,7 +16273,7 @@
         },
         {
             "id": "3cf17083-83ba-5be2-8f5a-b852e99c5bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1598d7-3c2f-406e-8e60-18b00233c7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1598d7-3c2f-406e-8e60-18b00233c7c0.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -16308,7 +16308,7 @@
         },
         {
             "id": "08f83f39-b386-5912-80e5-8226f3178c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eee2f9-676d-4d98-a19e-ff5d841c636f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eee2f9-676d-4d98-a19e-ff5d841c636f.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16343,7 +16343,7 @@
         },
         {
             "id": "366e193e-a797-533f-bde2-4c922afe5ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008307f-ca02-4c49-ad99-36bb0cb8775e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008307f-ca02-4c49-ad99-36bb0cb8775e.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16378,7 +16378,7 @@
         },
         {
             "id": "367e98a7-d5a6-5321-bc1e-96376a2545d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2a3193-8ef0-4c4d-b12c-06a5ef5bf95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2a3193-8ef0-4c4d-b12c-06a5ef5bf95e.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -16411,7 +16411,7 @@
         },
         {
             "id": "7302b198-e71d-50dd-bf57-fddb82d7333c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee13f28-2b0e-4939-b602-1be1552432a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee13f28-2b0e-4939-b602-1be1552432a5.jpg?1",
             "name": "Creeping Mold",
             "text": "",
             "colours": [
@@ -16444,7 +16444,7 @@
         },
         {
             "id": "40f1154a-2baf-5df4-9f43-3b44969d468e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22113d08-ecc9-4efd-90f1-00d699582ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22113d08-ecc9-4efd-90f1-00d699582ec3.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -16477,7 +16477,7 @@
         },
         {
             "id": "16b66af6-8c94-56d4-a875-b624b91a53cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a5ae9a-a0be-4b33-97f1-d38346560966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a5ae9a-a0be-4b33-97f1-d38346560966.jpg?1",
             "name": "Early Harvest",
             "text": "",
             "colours": [
@@ -16510,7 +16510,7 @@
         },
         {
             "id": "fe02e4dc-02e0-5dfa-b9b4-e088cee66b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fda362-63ee-4f0b-8faf-a9073e0d5fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fda362-63ee-4f0b-8faf-a9073e0d5fa0.jpg?1",
             "name": "Elvish Bard",
             "text": "All creatures able to block Elvish Bard do so.",
             "colours": [
@@ -16547,7 +16547,7 @@
         },
         {
             "id": "2a210565-6462-500b-9497-bf6c14bf4cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12f7bb0-d7cf-44e7-9ee3-c44daf87b0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12f7bb0-d7cf-44e7-9ee3-c44daf87b0d8.jpg?1",
             "name": "Elvish Bard",
             "text": "",
             "colours": [
@@ -16584,7 +16584,7 @@
         },
         {
             "id": "1dd71f68-07b4-5d23-95e7-3bd2867cb741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee84f5c-130b-4f44-a045-3e5728ce0950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee84f5c-130b-4f44-a045-3e5728ce0950.jpg?1",
             "name": "Elvish Berserker",
             "text": "Whenever Elvish Berserker becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -16620,7 +16620,7 @@
         },
         {
             "id": "227bcae4-71ee-5e75-b854-8d786536297e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b74e2c-9a79-4551-a433-e5393ccb4f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b74e2c-9a79-4551-a433-e5393ccb4f49.jpg?1",
             "name": "Elvish Berserker",
             "text": "",
             "colours": [
@@ -16656,7 +16656,7 @@
         },
         {
             "id": "30f7a452-47fc-5c42-868a-65f3cf19d7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec5af70-10f3-41fe-9548-e65da6ba852b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec5af70-10f3-41fe-9548-e65da6ba852b.jpg?1",
             "name": "Elvish Champion",
             "text": "Other Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -16691,7 +16691,7 @@
         },
         {
             "id": "b0aba720-ea08-5b72-b5dd-3773686f2c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08433b6b-f2af-4a52-abf8-3968d62d41fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08433b6b-f2af-4a52-abf8-3968d62d41fb.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -16726,7 +16726,7 @@
         },
         {
             "id": "5fe73932-e350-55cc-8694-368548de19e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb459fb2-b0d3-4be9-99cb-fcff4518abc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb459fb2-b0d3-4be9-99cb-fcff4518abc2.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: Put a creature card from your hand into play.",
             "colours": [
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "33fd1515-393f-5971-a784-9a48fbc3e0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f5e98-fd8e-410a-be94-c0fa1dc382e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f5e98-fd8e-410a-be94-c0fa1dc382e1.jpg?1",
             "name": "Elvish Piper",
             "text": "",
             "colours": [
@@ -16798,7 +16798,7 @@
         },
         {
             "id": "f82559db-bc3b-5bf8-ac14-788da23af3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18e79e9-39fc-426b-b64f-f20f6077a532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18e79e9-39fc-426b-b64f-f20f6077a532.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -16834,7 +16834,7 @@
         },
         {
             "id": "85e29f85-3549-5146-9f0c-39805ead2e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc321f-739a-42fe-bb51-d27511d2493b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc321f-739a-42fe-bb51-d27511d2493b.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -16870,7 +16870,7 @@
         },
         {
             "id": "b8d67bb5-1cc6-554b-bd7f-9a86910e984a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4bf2db-b282-4c9d-8afe-053204271996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4bf2db-b282-4c9d-8afe-053204271996.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -16905,7 +16905,7 @@
         },
         {
             "id": "786196bc-1c33-5d71-9ed4-86d37eb76fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32801a11-4605-46d3-8bb2-5cf5337b3f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32801a11-4605-46d3-8bb2-5cf5337b3f14.jpg?1",
             "name": "Emperor Crocodile",
             "text": "",
             "colours": [
@@ -16940,7 +16940,7 @@
         },
         {
             "id": "c69a06b2-8294-5bd0-9ac8-d540d4f4d037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f3103a-24e9-4462-bf52-8fa5e6214d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f3103a-24e9-4462-bf52-8fa5e6214d6d.jpg?1",
             "name": "Force of Nature",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nAt the beginning of your upkeep, Force of Nature deals 8 damage to you unless you pay {G}{G}{G}{G}.",
             "colours": [
@@ -16975,7 +16975,7 @@
         },
         {
             "id": "9dc8f690-a39a-5cd9-9842-aba89da731fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f733dc-41de-42f6-abdb-e27e369b6f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f733dc-41de-42f6-abdb-e27e369b6f3c.jpg?1",
             "name": "Force of Nature",
             "text": "",
             "colours": [
@@ -17010,7 +17010,7 @@
         },
         {
             "id": "23a4d01c-7896-5723-aee5-0a5333167193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b1a8a1-6777-4a00-ad3a-defc82bbac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b1a8a1-6777-4a00-ad3a-defc82bbac27.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -17043,7 +17043,7 @@
         },
         {
             "id": "5b0bd786-aa34-5701-9119-e0c53972d5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b604e2b2-2b8a-482a-9d2d-a7d171002016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b604e2b2-2b8a-482a-9d2d-a7d171002016.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -17076,7 +17076,7 @@
         },
         {
             "id": "40f8264e-48a0-504f-a486-013675c3ec00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072bcf42-6e13-4388-ac47-f91aaa7029d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072bcf42-6e13-4388-ac47-f91aaa7029d1.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can block as though it had flying.",
             "colours": [
@@ -17111,7 +17111,7 @@
         },
         {
             "id": "d1088e9a-905d-5c03-af50-840cbc56180b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389aec36-0b94-407e-bcbb-94adcdc96e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389aec36-0b94-407e-bcbb-94adcdc96e1a.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -17146,7 +17146,7 @@
         },
         {
             "id": "64519b41-0fc7-5711-8ae6-83d54fd8cae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153d7669-9063-4fc2-b53b-480b0e741f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153d7669-9063-4fc2-b53b-480b0e741f3f.jpg?1",
             "name": "Greater Good",
             "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then discard three cards.",
             "colours": [
@@ -17179,7 +17179,7 @@
         },
         {
             "id": "f629eb23-3dfe-591d-8405-1bdc71f283b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a327e66f-0cd7-46f7-b20f-35c5084b158c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a327e66f-0cd7-46f7-b20f-35c5084b158c.jpg?1",
             "name": "Greater Good",
             "text": "",
             "colours": [
@@ -17212,7 +17212,7 @@
         },
         {
             "id": "e596893f-2345-595e-ac96-edeab4fa783a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0264440-2325-4143-87a7-2af5a6b2a2f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0264440-2325-4143-87a7-2af5a6b2a2f9.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17247,7 +17247,7 @@
         },
         {
             "id": "8aaa58b9-dab6-5566-95b1-419a17af6b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea4f90b-f21b-4acd-934f-406eae274bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea4f90b-f21b-4acd-934f-406eae274bcf.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17282,7 +17282,7 @@
         },
         {
             "id": "1603c721-67a5-5be8-a9af-a8af9e4b356a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424d7132-0f7a-48c7-beb6-37fc114113da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424d7132-0f7a-48c7-beb6-37fc114113da.jpg?1",
             "name": "Groundskeeper",
             "text": "{1}{G}: Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -17318,7 +17318,7 @@
         },
         {
             "id": "5f83de75-66a4-51aa-8f9b-36ae1ddb42ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a282618-c229-4f82-815e-a2db0d0aef58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a282618-c229-4f82-815e-a2db0d0aef58.jpg?1",
             "name": "Groundskeeper",
             "text": "",
             "colours": [
@@ -17354,7 +17354,7 @@
         },
         {
             "id": "4a7eb265-d15d-53dc-8b81-7da2e726b5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238f33-bab3-4f30-9ed8-01589e77fa27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238f33-bab3-4f30-9ed8-01589e77fa27.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play.",
             "colours": [
@@ -17389,7 +17389,7 @@
         },
         {
             "id": "7648f93f-897a-5f9f-83a4-da4cb409ae14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de49e393-aba4-4f04-b30c-89a195bc340e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de49e393-aba4-4f04-b30c-89a195bc340e.jpg?1",
             "name": "Hunted Wumpus",
             "text": "",
             "colours": [
@@ -17424,7 +17424,7 @@
         },
         {
             "id": "e6f7e822-eee4-57ee-b0f1-16c646f30d69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1310a1e-8cb9-4f43-a627-c8d96d600c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1310a1e-8cb9-4f43-a627-c8d96d600c36.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber comes into play, draw a card.",
             "colours": [
@@ -17459,7 +17459,7 @@
         },
         {
             "id": "5a35072f-0d50-5c71-8cd0-e2fefbf7cf1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a24463-9228-4ec4-8c35-98b4d83721b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a24463-9228-4ec4-8c35-98b4d83721b1.jpg?1",
             "name": "Kavu Climber",
             "text": "",
             "colours": [
@@ -17494,7 +17494,7 @@
         },
         {
             "id": "b9f4cc39-5090-5621-a0cf-0c518cd7fdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc34b5-7558-41b1-97e4-1ee13527dec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc34b5-7558-41b1-97e4-1ee13527dec4.jpg?1",
             "name": "King Cheetah",
             "text": "You may play King Cheetah any time you could play an instant.",
             "colours": [
@@ -17529,7 +17529,7 @@
         },
         {
             "id": "f8351171-8912-5ab9-bf02-d26cf453c134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6450a333-9776-4cda-a369-f9342e5b0278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6450a333-9776-4cda-a369-f9342e5b0278.jpg?1",
             "name": "King Cheetah",
             "text": "",
             "colours": [
@@ -17564,7 +17564,7 @@
         },
         {
             "id": "78a36fc2-2d07-5d8c-9faa-e2b3646fb868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dac78d2-dd1b-412a-b1b4-4fef1a4fd583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dac78d2-dd1b-412a-b1b4-4fef1a4fd583.jpg?1",
             "name": "Ley Druid",
             "text": "{T}: Untap target land.",
             "colours": [
@@ -17600,7 +17600,7 @@
         },
         {
             "id": "b140d9f1-68bf-55c8-91df-48543a69859a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac100fb-b43c-4557-adae-484d2706d577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac100fb-b43c-4557-adae-484d2706d577.jpg?1",
             "name": "Ley Druid",
             "text": "",
             "colours": [
@@ -17636,7 +17636,7 @@
         },
         {
             "id": "18b06975-920b-54d3-ad95-8a5ab48268ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47054d9-ab6c-4d66-8744-b458721a6c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47054d9-ab6c-4d66-8744-b458721a6c98.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "Tap an untapped creature you control: Llanowar Behemoth gets +1/+1 until end of turn.",
             "colours": [
@@ -17671,7 +17671,7 @@
         },
         {
             "id": "2021fe5b-60c5-5375-9cce-b81ce90681d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f703c1-29c3-49f1-aa3e-bb1bab0ea040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f703c1-29c3-49f1-aa3e-bb1bab0ea040.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "",
             "colours": [
@@ -17706,7 +17706,7 @@
         },
         {
             "id": "42e38dc7-9bdf-5546-9454-e967bfce7767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913907e2-28dd-4080-b725-52a43868e060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913907e2-28dd-4080-b725-52a43868e060.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -17742,7 +17742,7 @@
         },
         {
             "id": "2c99f20b-3142-5f7d-9af0-29826737a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7bf82d-437a-4c28-98a4-4d092ba8d063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7bf82d-437a-4c28-98a4-4d092ba8d063.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -17778,7 +17778,7 @@
         },
         {
             "id": "9e76af1d-87ab-58b8-bbde-a33593719abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9159e250-4eec-4ec4-80e1-42259331b3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9159e250-4eec-4ec4-80e1-42259331b3b9.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -17813,7 +17813,7 @@
         },
         {
             "id": "1cc39187-4ab1-5a02-befc-2895f5d5d376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122852fa-e28d-4ed7-9bdf-7bd0f40450af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122852fa-e28d-4ed7-9bdf-7bd0f40450af.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -17848,7 +17848,7 @@
         },
         {
             "id": "4dac4f46-5663-5bc3-b56c-519e110d0e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d409378-ae02-4421-a866-df442d67032b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d409378-ae02-4421-a866-df442d67032b.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -17881,7 +17881,7 @@
         },
         {
             "id": "5c67dd02-bf01-598f-b0e8-ce4c4549acf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a24ad-8c67-4078-b110-0a198bcab29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a24ad-8c67-4078-b110-0a198bcab29e.jpg?1",
             "name": "Might of Oaks",
             "text": "",
             "colours": [
@@ -17914,7 +17914,7 @@
         },
         {
             "id": "40319bd0-154d-5ca5-ba90-c2684a226f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4847f8e8-9979-427e-999a-26711e542f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4847f8e8-9979-427e-999a-26711e542f82.jpg?1",
             "name": "Natural Affinity",
             "text": "Until end of turn, all lands become 2/2 creatures that are still lands.",
             "colours": [
@@ -17947,7 +17947,7 @@
         },
         {
             "id": "44ee475a-9acb-5b04-af66-25e42ca166d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee95dc2-ef83-4a2d-80d8-ab25ceb8739a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee95dc2-ef83-4a2d-80d8-ab25ceb8739a.jpg?1",
             "name": "Natural Affinity",
             "text": "",
             "colours": [
@@ -17980,7 +17980,7 @@
         },
         {
             "id": "3e8cc23b-ed6c-5f3e-847f-7dc89419a9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1986db3-dd6c-44f2-8d7a-a6b42d55a7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1986db3-dd6c-44f2-8d7a-a6b42d55a7c1.jpg?1",
             "name": "Natural Spring",
             "text": "Target player gains 8 life.",
             "colours": [
@@ -18013,7 +18013,7 @@
         },
         {
             "id": "15863a61-fb84-5a73-aa20-f6f45e51b9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23917a2c-e56c-461d-ba14-300015a54034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23917a2c-e56c-461d-ba14-300015a54034.jpg?1",
             "name": "Natural Spring",
             "text": "",
             "colours": [
@@ -18046,7 +18046,7 @@
         },
         {
             "id": "d834fd3e-9ba7-53ef-9547-1ae11a0a7bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f1019-2608-4d00-8b9b-7f22e87acd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f1019-2608-4d00-8b9b-7f22e87acd0d.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -18079,7 +18079,7 @@
         },
         {
             "id": "c7269572-c58b-5b13-9c25-b796259b11e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32504d-4032-4da1-8187-fd2637e3f76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32504d-4032-4da1-8187-fd2637e3f76e.jpg?1",
             "name": "Naturalize",
             "text": "",
             "colours": [
@@ -18112,7 +18112,7 @@
         },
         {
             "id": "08490f9e-3a32-563d-9261-a92e9cd5b19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bc178-f5ec-4e90-b8cf-2c7b00386c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bc178-f5ec-4e90-b8cf-2c7b00386c98.jpg?1",
             "name": "Needle Storm",
             "text": "Needle Storm deals 4 damage to each creature with flying.",
             "colours": [
@@ -18145,7 +18145,7 @@
         },
         {
             "id": "5bc5f70f-25d9-5973-a314-a18f083dd4a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c657c97-e8be-4798-b020-15e9e4acfc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c657c97-e8be-4798-b020-15e9e4acfc84.jpg?1",
             "name": "Needle Storm",
             "text": "",
             "colours": [
@@ -18178,7 +18178,7 @@
         },
         {
             "id": "813f2f9a-243e-5916-88e6-d3cb965c5277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf3a7c-e065-468b-a73c-6f986cde3a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf3a7c-e065-468b-a73c-6f986cde3a3d.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -18215,7 +18215,7 @@
         },
         {
             "id": "7c2e1507-e15d-5870-bf52-4b79b5c79405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b983cc1-d631-419b-96e5-02934dcb95f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b983cc1-d631-419b-96e5-02934dcb95f1.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -18252,7 +18252,7 @@
         },
         {
             "id": "f6a0ca24-673a-5f79-a522-a8654a333906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310500b2-8539-441e-af89-81ddfa8ef080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310500b2-8539-441e-af89-81ddfa8ef080.jpg?1",
             "name": "Order of the Sacred Bell",
             "text": "",
             "colours": [
@@ -18288,7 +18288,7 @@
         },
         {
             "id": "b03a711d-9aed-5a81-9147-ff34b79c84e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862a6fb-2aae-4b2a-86e1-4563de788d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862a6fb-2aae-4b2a-86e1-4563de788d7f.jpg?1",
             "name": "Order of the Sacred Bell",
             "text": "",
             "colours": [
@@ -18324,7 +18324,7 @@
         },
         {
             "id": "a8f41f2e-5625-570a-b818-270359fa40e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6da1dd-4172-48df-a3b2-c6d383053f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6da1dd-4172-48df-a3b2-c6d383053f4f.jpg?1",
             "name": "Overgrowth",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nWhenever enchanted land is tapped for mana, its controller adds {G}{G} to his or her mana pool.",
             "colours": [
@@ -18359,7 +18359,7 @@
         },
         {
             "id": "da1e35e3-ca99-58bf-b897-727976e0b6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27375bf-2492-4cbd-8b4b-96ed4c8533c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27375bf-2492-4cbd-8b4b-96ed4c8533c2.jpg?1",
             "name": "Overgrowth",
             "text": "",
             "colours": [
@@ -18394,7 +18394,7 @@
         },
         {
             "id": "19b75be2-7c68-59d3-8bf7-7f0b654429f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a429a983-d28e-46e7-816f-0398428db11a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a429a983-d28e-46e7-816f-0398428db11a.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -18427,7 +18427,7 @@
         },
         {
             "id": "5f021ca4-6926-5b1c-8ff0-9097a4793608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb82100d-cd49-420f-9aed-89db255d494b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb82100d-cd49-420f-9aed-89db255d494b.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -18460,7 +18460,7 @@
         },
         {
             "id": "aaf4747c-6168-5b95-b737-368ddd707180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a894efb2-7773-4b69-8289-e32d02f679ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a894efb2-7773-4b69-8289-e32d02f679ff.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -18493,7 +18493,7 @@
         },
         {
             "id": "226c81d2-b969-5774-82c5-0e5e2d67ff53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ded13d7-ef04-4fe5-b4df-4ea7c08ab208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ded13d7-ef04-4fe5-b4df-4ea7c08ab208.jpg?1",
             "name": "Reclaim",
             "text": "",
             "colours": [
@@ -18526,7 +18526,7 @@
         },
         {
             "id": "4909c493-72ee-52f9-9076-6e7e07ac8dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0bf1-0506-4d55-8e78-22d50a6edec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0bf1-0506-4d55-8e78-22d50a6edec4.jpg?1",
             "name": "Regeneration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{G}: Regenerate enchanted creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -18561,7 +18561,7 @@
         },
         {
             "id": "8f956756-abe5-5145-9531-44899daa9ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44381391-4a15-45a9-bb73-8b3553223ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44381391-4a15-45a9-bb73-8b3553223ca1.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -18596,7 +18596,7 @@
         },
         {
             "id": "d111ddbb-9e7b-5575-9c70-ef5f3e2b2f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bf281-80bc-4e85-9b8e-15577dfcdec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bf281-80bc-4e85-9b8e-15577dfcdec7.jpg?1",
             "name": "River Bear",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -18631,7 +18631,7 @@
         },
         {
             "id": "2e4b29aa-7202-5abf-be78-a59c11d05a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950f6ca6-31cc-44f0-a471-38f979f60a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950f6ca6-31cc-44f0-a471-38f979f60a6d.jpg?1",
             "name": "River Bear",
             "text": "",
             "colours": [
@@ -18666,7 +18666,7 @@
         },
         {
             "id": "eae066d5-ee3b-5edd-868e-93b6d16ccb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae084007-69ba-4857-9b0c-28455897f25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae084007-69ba-4857-9b0c-28455897f25c.jpg?1",
             "name": "Rootbreaker Wurm",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -18701,7 +18701,7 @@
         },
         {
             "id": "6c210a82-05cc-5619-884e-38dda7ac6042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a698a1-fcd6-407c-a63c-02c54f8f8e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a698a1-fcd6-407c-a63c-02c54f8f8e11.jpg?1",
             "name": "Rootbreaker Wurm",
             "text": "",
             "colours": [
@@ -18736,7 +18736,7 @@
         },
         {
             "id": "6792626c-f199-526e-841a-4f185bf71e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08436832-2aab-47b0-b0da-b1b153e4b200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08436832-2aab-47b0-b0da-b1b153e4b200.jpg?1",
             "name": "Rootwalla",
             "text": "{1}{G}: Rootwalla gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -18771,7 +18771,7 @@
         },
         {
             "id": "7e2ff066-bee6-531e-a1c4-5625593cb23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9995de-7829-4940-b534-cdac215b4826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9995de-7829-4940-b534-cdac215b4826.jpg?1",
             "name": "Rootwalla",
             "text": "",
             "colours": [
@@ -18806,7 +18806,7 @@
         },
         {
             "id": "7c371e2a-bfc7-51d3-9a4a-3d11ab5bd85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e37991-8f7a-4c24-9f94-45bb59dd30b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e37991-8f7a-4c24-9f94-45bb59dd30b6.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -18841,7 +18841,7 @@
         },
         {
             "id": "84052aaf-5295-51b4-9b63-2a5b68c4c602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33b00cb-81c8-4c0b-8361-279967a7ce3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33b00cb-81c8-4c0b-8361-279967a7ce3c.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -18876,7 +18876,7 @@
         },
         {
             "id": "d8b99405-c638-59c3-a9e7-6163a0873cf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1d0254-985c-4d44-9cce-1d563e11f0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1d0254-985c-4d44-9cce-1d563e11f0a4.jpg?1",
             "name": "Seedborn Muse",
             "text": "Untap all permanents you control during each other player's untap step.",
             "colours": [
@@ -18911,7 +18911,7 @@
         },
         {
             "id": "9f6ccea1-e96e-5555-a6e2-136ec3751b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5ff284-8212-4382-b66e-339dacd1f32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5ff284-8212-4382-b66e-339dacd1f32f.jpg?1",
             "name": "Seedborn Muse",
             "text": "",
             "colours": [
@@ -18946,7 +18946,7 @@
         },
         {
             "id": "01dbfe5f-8794-5cb6-8605-e40f651b51bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612fe88c-9c6e-42b4-8936-a9431c1808ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612fe88c-9c6e-42b4-8936-a9431c1808ea.jpg?1",
             "name": "Silklash Spider",
             "text": "Silklash Spider can block as though it had flying.\n{X}{G}{G}: Silklash Spider deals X damage to each creature with flying.",
             "colours": [
@@ -18981,7 +18981,7 @@
         },
         {
             "id": "9a697359-5968-551e-b31a-abb2de70d849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb89572c-9c1b-4d90-a378-d65cc6770ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb89572c-9c1b-4d90-a378-d65cc6770ffa.jpg?1",
             "name": "Silklash Spider",
             "text": "",
             "colours": [
@@ -19016,7 +19016,7 @@
         },
         {
             "id": "f8d062de-8988-5de6-a147-3a50939ebc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341aa1b2-e600-4580-b0cd-e1582b75dc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341aa1b2-e600-4580-b0cd-e1582b75dc81.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -19049,7 +19049,7 @@
         },
         {
             "id": "c4186097-a4ef-537b-b29d-038c03b9169f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beea9dbe-6f5f-4e6a-a9c7-e732ab8a77d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beea9dbe-6f5f-4e6a-a9c7-e732ab8a77d0.jpg?1",
             "name": "Stream of Life",
             "text": "",
             "colours": [
@@ -19082,7 +19082,7 @@
         },
         {
             "id": "08c2f55b-eb4d-59b4-9bf9-ab3c5c700299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ed9d7-012c-43d0-a8c0-e208b58cad6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ed9d7-012c-43d0-a8c0-e208b58cad6f.jpg?1",
             "name": "Summer Bloom",
             "text": "You may play up to three additional lands this turn.",
             "colours": [
@@ -19115,7 +19115,7 @@
         },
         {
             "id": "8dce0c71-e593-5f72-bd32-eef4e7a45f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6729d75-adc2-430c-a0f9-f2991a65bf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6729d75-adc2-430c-a0f9-f2991a65bf83.jpg?1",
             "name": "Summer Bloom",
             "text": "",
             "colours": [
@@ -19148,7 +19148,7 @@
         },
         {
             "id": "f8a3008d-3d96-5e92-a911-ccc5e47f7775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5855f7-b100-4338-bb30-203fa275cba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5855f7-b100-4338-bb30-203fa275cba3.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19183,7 +19183,7 @@
         },
         {
             "id": "5d0ed309-7125-5519-a131-929b217d4d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4af28e-246f-4660-9c29-406d880b128d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4af28e-246f-4660-9c29-406d880b128d.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19218,7 +19218,7 @@
         },
         {
             "id": "865221ae-ed86-5706-a9c1-0c683baafd8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4724d00a-b93b-43fd-9c86-56f127db450b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4724d00a-b93b-43fd-9c86-56f127db450b.jpg?1",
             "name": "Tree Monkey",
             "text": "Tree Monkey can block as though it had flying.",
             "colours": [
@@ -19253,7 +19253,7 @@
         },
         {
             "id": "f5914255-2ab1-531c-8c9b-37d151ea2ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705f54-f921-417f-9f56-53e6175aaf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705f54-f921-417f-9f56-53e6175aaf69.jpg?1",
             "name": "Tree Monkey",
             "text": "",
             "colours": [
@@ -19288,7 +19288,7 @@
         },
         {
             "id": "32ace6f2-a3a0-5373-a50c-2534f30aaa8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5312742c-0f35-4abc-97ec-fceda2658cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5312742c-0f35-4abc-97ec-fceda2658cec.jpg?1",
             "name": "Treetop Bracers",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 and can't be blocked except by creatures with flying.",
             "colours": [
@@ -19323,7 +19323,7 @@
         },
         {
             "id": "0bea003f-85c6-5def-82b4-69c5bef2bb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46626917-d46a-42a5-b79c-5e2eaa6ca94b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46626917-d46a-42a5-b79c-5e2eaa6ca94b.jpg?1",
             "name": "Treetop Bracers",
             "text": "",
             "colours": [
@@ -19358,7 +19358,7 @@
         },
         {
             "id": "aee0bc5b-6285-507b-80d9-64f4cbea4215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bed540-da8d-4148-8794-8e8d01ed5387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bed540-da8d-4148-8794-8e8d01ed5387.jpg?1",
             "name": "Utopia Tree",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -19393,7 +19393,7 @@
         },
         {
             "id": "d8a2ddd7-70a8-51f6-aad1-3f48986a7be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e20c289-2bfa-4e2f-9cb3-37642e9a4a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e20c289-2bfa-4e2f-9cb3-37642e9a4a88.jpg?1",
             "name": "Utopia Tree",
             "text": "",
             "colours": [
@@ -19428,7 +19428,7 @@
         },
         {
             "id": "0bf3bb23-fd97-5419-9bf2-6914ed070ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a5533f-d24d-4cca-a47e-0676c6061a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a5533f-d24d-4cca-a47e-0676c6061a35.jpg?1",
             "name": "Verdant Force",
             "text": "At the beginning of each player's upkeep, put a 1/1 green Saproling creature token into play under your control.",
             "colours": [
@@ -19463,7 +19463,7 @@
         },
         {
             "id": "3ac24baf-1488-51a2-a48b-df2c5b18d1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4e67cf-3c49-480c-b960-128b1ab2a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4e67cf-3c49-480c-b960-128b1ab2a716.jpg?1",
             "name": "Verdant Force",
             "text": "",
             "colours": [
@@ -19498,7 +19498,7 @@
         },
         {
             "id": "fcb70313-2540-5d93-a745-d94af930ee4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d5f1c2-9f9c-416e-a0a2-6534b243e799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d5f1c2-9f9c-416e-a0a2-6534b243e799.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -19534,7 +19534,7 @@
         },
         {
             "id": "dfa3eec5-208f-5eda-9eda-10b5b02119ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159af678-36cc-496e-8ca4-600f0ff629f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159af678-36cc-496e-8ca4-600f0ff629f7.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -19570,7 +19570,7 @@
         },
         {
             "id": "1d60a8ee-af45-5f13-b7b3-a43edc4f4d29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21971049-f988-40ec-b5ae-0ac0575f1939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21971049-f988-40ec-b5ae-0ac0575f1939.jpg?1",
             "name": "Viridian Shaman",
             "text": "When Viridian Shaman comes into play, destroy target artifact.",
             "colours": [
@@ -19606,7 +19606,7 @@
         },
         {
             "id": "baa65d84-96ac-50aa-8e80-b26248914eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740abd3-e264-49c6-aacd-ca192c388e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740abd3-e264-49c6-aacd-ca192c388e54.jpg?1",
             "name": "Viridian Shaman",
             "text": "",
             "colours": [
@@ -19642,7 +19642,7 @@
         },
         {
             "id": "37086380-0361-5da8-af1b-772e6b66c7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91173ce1-62a9-4d0e-8b2a-9bc33858c4fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91173ce1-62a9-4d0e-8b2a-9bc33858c4fc.jpg?1",
             "name": "Web",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +0/+2 and can block as though it had flying.",
             "colours": [
@@ -19677,7 +19677,7 @@
         },
         {
             "id": "c5301dfd-d5c5-5808-9359-565211581b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b15a1d5-a892-4d3b-a373-3a43424894c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b15a1d5-a892-4d3b-a373-3a43424894c3.jpg?1",
             "name": "Web",
             "text": "",
             "colours": [
@@ -19712,7 +19712,7 @@
         },
         {
             "id": "b475255d-3c21-5fec-8ca4-8980a0ff62f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd2c25-049a-4df2-bf8f-198d1b41b01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd2c25-049a-4df2-bf8f-198d1b41b01e.jpg?1",
             "name": "Weird Harvest",
             "text": "Each player may search his or her library for up to X creature cards, reveal those cards, and put them into his or her hand. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -19745,7 +19745,7 @@
         },
         {
             "id": "99b93237-139a-56c6-ae56-f89196e351f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759d87cf-4596-4a21-aa9d-48b426eda24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759d87cf-4596-4a21-aa9d-48b426eda24c.jpg?1",
             "name": "Weird Harvest",
             "text": "",
             "colours": [
@@ -19778,7 +19778,7 @@
         },
         {
             "id": "7ab99b79-d28b-5986-8f15-4c2359743f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cea55e-f85a-4f0f-b845-386d5c3fd9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cea55e-f85a-4f0f-b845-386d5c3fd9db.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a Forest card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -19814,7 +19814,7 @@
         },
         {
             "id": "efb46895-81d9-5ec2-8693-4acd43a8b797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4a34e-f1f0-480f-86b8-f2776c824261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4a34e-f1f0-480f-86b8-f2776c824261.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -19850,7 +19850,7 @@
         },
         {
             "id": "e12636fa-34eb-581e-a26f-2461227acbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18637e89-4794-46a8-bb80-b35211648d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18637e89-4794-46a8-bb80-b35211648d4f.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -19886,7 +19886,7 @@
         },
         {
             "id": "93f41570-1425-501d-b5a7-33b35340306f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa01c252-37f4-41af-b1a0-f30cdbdacf01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa01c252-37f4-41af-b1a0-f30cdbdacf01.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "",
             "colours": [
@@ -19922,7 +19922,7 @@
         },
         {
             "id": "ad06929e-df63-56b2-8c17-ab2e83671685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670108c-c3c8-4052-8f19-30dcb2266774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670108c-c3c8-4052-8f19-30dcb2266774.jpg?1",
             "name": "Zodiac Monkey",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -19957,7 +19957,7 @@
         },
         {
             "id": "f7b4e7a7-db9f-59fd-84bc-888d40eb5cf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58dddb-bcb9-444d-80a9-eb1fda23efa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58dddb-bcb9-444d-80a9-eb1fda23efa2.jpg?1",
             "name": "Zodiac Monkey",
             "text": "",
             "colours": [
@@ -19992,7 +19992,7 @@
         },
         {
             "id": "22fc1065-f041-57cd-931f-1ceb4b9a5745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7370d-8ab4-4506-b7dd-d02c1ba92032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7370d-8ab4-4506-b7dd-d02c1ba92032.jpg?1",
             "name": "Aladdin's Ring",
             "text": "{8}, {T}: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -20021,7 +20021,7 @@
         },
         {
             "id": "98fcbe88-c5a6-542c-9b9e-41c6b8b88cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b31ad9d-823b-4e74-a996-91f200ec72f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b31ad9d-823b-4e74-a996-91f200ec72f7.jpg?1",
             "name": "Aladdin's Ring",
             "text": "",
             "colours": [],
@@ -20050,7 +20050,7 @@
         },
         {
             "id": "0553ffec-eec1-5b7c-b93d-f7cdc64ad909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476f1233-7474-4c01-8e8b-be642a638a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476f1233-7474-4c01-8e8b-be642a638a61.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player plays a white spell, you may gain 1 life.",
             "colours": [],
@@ -20079,7 +20079,7 @@
         },
         {
             "id": "8bfe9730-52b3-5424-bb97-6ddb5fb99b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557d8283-596d-4480-8a9a-c026c2f68cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557d8283-596d-4480-8a9a-c026c2f68cc2.jpg?1",
             "name": "Angel's Feather",
             "text": "",
             "colours": [],
@@ -20108,7 +20108,7 @@
         },
         {
             "id": "35b6431a-f2df-5502-9358-76fac7e9e645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a19f6d-4fab-4be6-af9e-c66acc16e4f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a19f6d-4fab-4be6-af9e-c66acc16e4f8.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden's power and toughness are each equal to the number of creatures in play.",
             "colours": [],
@@ -20140,7 +20140,7 @@
         },
         {
             "id": "c84b3433-2ba5-5fc3-b663-e47f5a99fb88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5371e-6881-41be-8ed2-718dcf0446fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5371e-6881-41be-8ed2-718dcf0446fe.jpg?1",
             "name": "Beast of Burden",
             "text": "",
             "colours": [],
@@ -20172,7 +20172,7 @@
         },
         {
             "id": "4d56b072-1d85-53d4-b14b-b942077ea5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af0c9a0-0dfa-4245-8b29-7bd37982b7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af0c9a0-0dfa-4245-8b29-7bd37982b7d2.jpg?1",
             "name": "Booby Trap",
             "text": "As Booby Trap comes into play, name a card other than a basic land card and choose an opponent.\nThe chosen player reveals each card he or she draws.\nWhen the chosen player draws the named card, sacrifice Booby Trap. If you do, Booby Trap deals 10 damage to that player.",
             "colours": [],
@@ -20201,7 +20201,7 @@
         },
         {
             "id": "0e88e250-2d86-55d4-a9cd-747f62068101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bd218f-0e39-4456-a452-a4abfcb61450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bd218f-0e39-4456-a452-a4abfcb61450.jpg?1",
             "name": "Booby Trap",
             "text": "",
             "colours": [],
@@ -20230,7 +20230,7 @@
         },
         {
             "id": "af5b2663-b49a-5ae1-9d91-68f9096df374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d225c1-22f7-4c98-bba0-216724f2d587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d225c1-22f7-4c98-bba0-216724f2d587.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: You gain 3 life.",
             "colours": [],
@@ -20262,7 +20262,7 @@
         },
         {
             "id": "8b83a628-c2cf-57a0-9fc6-1a0a495a7527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8c6a-500e-4ec8-8c28-76c47126ed53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8c6a-500e-4ec8-8c28-76c47126ed53.jpg?1",
             "name": "Bottle Gnomes",
             "text": "",
             "colours": [],
@@ -20294,7 +20294,7 @@
         },
         {
             "id": "eba4ea5a-47ac-5292-80b3-8e223fa8c86d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf3074-da3b-47e1-9a2c-88cfb1918a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf3074-da3b-47e1-9a2c-88cfb1918a98.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if a Goblin Warrior, a Goblin Scout, and a Zombie Goblin are in play, each gets +2/+2.)",
             "colours": [],
@@ -20323,7 +20323,7 @@
         },
         {
             "id": "df0d06bf-c2d7-5613-8f1f-dd59e0169e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a9098-e181-4052-83e6-fcf1b209120f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a9098-e181-4052-83e6-fcf1b209120f.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -20352,7 +20352,7 @@
         },
         {
             "id": "7e4f8429-18ee-51bd-9195-84ef96ea1112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede26e9e-95b6-4dbc-9263-59f370c4f6a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede26e9e-95b6-4dbc-9263-59f370c4f6a3.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -20384,7 +20384,7 @@
         },
         {
             "id": "d68820e4-b2ea-5c70-8eca-1a56adb5374e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b760d5-60a3-4399-b1ae-faf68fd122c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b760d5-60a3-4399-b1ae-faf68fd122c6.jpg?1",
             "name": "Dancing Scimitar",
             "text": "",
             "colours": [],
@@ -20416,7 +20416,7 @@
         },
         {
             "id": "cd6c7fbb-d5d2-5be1-9469-405b962b7c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f939dac5-ad71-4163-adde-4f435412477c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f939dac5-ad71-4163-adde-4f435412477c.jpg?1",
             "name": "Defense Grid",
             "text": "During each player's turn, each other player's spells cost {3} more to play.",
             "colours": [],
@@ -20445,7 +20445,7 @@
         },
         {
             "id": "74b5eb29-1284-5cf7-adc1-6469d43c3102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe6283a-95da-4425-93db-e00e8e972ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe6283a-95da-4425-93db-e00e8e972ec0.jpg?1",
             "name": "Defense Grid",
             "text": "",
             "colours": [],
@@ -20474,7 +20474,7 @@
         },
         {
             "id": "caf362c1-709e-5fd9-bcc0-5dcac8b1ebe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98135714-7422-4b1f-94c4-f4ee980c94a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98135714-7422-4b1f-94c4-f4ee980c94a8.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player plays a black spell, you may gain 1 life.",
             "colours": [],
@@ -20503,7 +20503,7 @@
         },
         {
             "id": "51827110-aab9-599a-a1b4-619cd6198e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59923706-2110-4d71-92a2-4d0c4aeeff3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59923706-2110-4d71-92a2-4d0c4aeeff3c.jpg?1",
             "name": "Demon's Horn",
             "text": "",
             "colours": [],
@@ -20532,7 +20532,7 @@
         },
         {
             "id": "7b598ac4-96f2-5838-8813-fadb17a7b09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55be5981-5bbc-4621-9f53-fc4edd4fde7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55be5981-5bbc-4621-9f53-fc4edd4fde7e.jpg?1",
             "name": "Disrupting Scepter",
             "text": "{3}, {T}: Target player discards a card. Play this ability only during your turn.",
             "colours": [],
@@ -20561,7 +20561,7 @@
         },
         {
             "id": "1238f0d3-d5e9-5059-985f-f84de5e6d60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c74aa6b-6f35-420e-87eb-3f21f2259869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c74aa6b-6f35-420e-87eb-3f21f2259869.jpg?1",
             "name": "Disrupting Scepter",
             "text": "",
             "colours": [],
@@ -20590,7 +20590,7 @@
         },
         {
             "id": "17206311-c336-58b1-84ce-ca9b0de656e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd62ce2f-bf20-427a-9dbc-40732ff639ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd62ce2f-bf20-427a-9dbc-40732ff639ab.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player plays a red spell, you may gain 1 life.",
             "colours": [],
@@ -20619,7 +20619,7 @@
         },
         {
             "id": "76e3ddbb-2a66-5301-9e31-5409b52e1ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773ff8d2-29e0-49b3-b45e-673886a03f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773ff8d2-29e0-49b3-b45e-673886a03f88.jpg?1",
             "name": "Dragon's Claw",
             "text": "",
             "colours": [],
@@ -20648,7 +20648,7 @@
         },
         {
             "id": "9a79b91e-5c01-57be-8aff-81d34c5e963f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8fd20a-d26e-417f-b1b7-e7257cc5b22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8fd20a-d26e-417f-b1b7-e7257cc5b22b.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -20677,7 +20677,7 @@
         },
         {
             "id": "12e8eb0d-1e1d-543e-b58b-8740de4440b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d51bff-d11a-41ab-933e-943d111a9550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d51bff-d11a-41ab-933e-943d111a9550.jpg?1",
             "name": "Fellwar Stone",
             "text": "",
             "colours": [],
@@ -20706,7 +20706,7 @@
         },
         {
             "id": "f55193fc-9d18-579d-9252-da2ac50ce7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480f85b2-79bd-4f1c-a815-d101a678cf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480f85b2-79bd-4f1c-a815-d101a678cf27.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -20735,7 +20735,7 @@
         },
         {
             "id": "aa17d18e-d47d-5bf7-a9f7-5afba64b9722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8a7833-9420-4228-82ea-537e96c015fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8a7833-9420-4228-82ea-537e96c015fa.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -20764,7 +20764,7 @@
         },
         {
             "id": "aa3a8225-2c16-5b98-8177-08de33c74a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dec5eb-c391-4152-860d-68b2f09b8459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dec5eb-c391-4152-860d-68b2f09b8459.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -20793,7 +20793,7 @@
         },
         {
             "id": "b0d374b6-aa68-5e66-94b8-d77fc24d0526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a423b3-2e3a-4af0-a2bd-5f5dfdb055ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a423b3-2e3a-4af0-a2bd-5f5dfdb055ca.jpg?1",
             "name": "Icy Manipulator",
             "text": "",
             "colours": [],
@@ -20822,7 +20822,7 @@
         },
         {
             "id": "164bf392-82f2-5fc8-b350-9c029fe5f770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0495f8-4f18-4860-b1b4-58fa67414c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0495f8-4f18-4860-b1b4-58fa67414c8e.jpg?1",
             "name": "Jade Statue",
             "text": "{2}: Jade Statue becomes a 3/6 artifact creature until end of combat. Play this ability only during combat.",
             "colours": [],
@@ -20851,7 +20851,7 @@
         },
         {
             "id": "c2521d92-3ad1-581b-8bca-37ec9dd4723e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a739b-a942-4c75-9be9-1c8d2b99a486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a739b-a942-4c75-9be9-1c8d2b99a486.jpg?1",
             "name": "Jade Statue",
             "text": "",
             "colours": [],
@@ -20880,7 +20880,7 @@
         },
         {
             "id": "c264b344-330f-54e4-a658-724eb2383df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ede9d6b-3c7c-4a5f-a09b-80ec471692b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ede9d6b-3c7c-4a5f-a09b-80ec471692b6.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [],
@@ -20909,7 +20909,7 @@
         },
         {
             "id": "ecb7e097-9ef6-5703-81eb-4a8cc83f0c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5af13a-317e-4daa-9655-9f2d6d5c234f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5af13a-317e-4daa-9655-9f2d6d5c234f.jpg?1",
             "name": "Jester's Cap",
             "text": "",
             "colours": [],
@@ -20938,7 +20938,7 @@
         },
         {
             "id": "4b762fd5-4682-5488-b64f-e946bbccd4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80930e8-d2b4-4778-a958-9bf080cba1c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80930e8-d2b4-4778-a958-9bf080cba1c9.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player plays a blue spell, you may gain 1 life.",
             "colours": [],
@@ -20967,7 +20967,7 @@
         },
         {
             "id": "44afdbf9-cc87-5ee1-8004-a60ba32e6e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bf7266-bac5-47ab-8d35-24d19473c11b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bf7266-bac5-47ab-8d35-24d19473c11b.jpg?1",
             "name": "Kraken's Eye",
             "text": "",
             "colours": [],
@@ -20996,7 +20996,7 @@
         },
         {
             "id": "ac4d8786-9de7-57d9-a9bc-c3271bb8cb02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3569f5bd-4afc-455d-90e6-bfa08d505efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3569f5bd-4afc-455d-90e6-bfa08d505efe.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0, has trample, and has \"Whenever this creature deals damage, you gain that much life.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -21027,7 +21027,7 @@
         },
         {
             "id": "ef1ec66b-f9c5-5537-a5c5-6d162354a4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9ea7cf-90f6-4426-88b2-9e33fcb81669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9ea7cf-90f6-4426-88b2-9e33fcb81669.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "",
             "colours": [],
@@ -21058,7 +21058,7 @@
         },
         {
             "id": "9127a9fc-0e05-5226-94e2-ad1296fdd8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b3e79-6cec-4f2f-adaf-c368f099d7a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b3e79-6cec-4f2f-adaf-c368f099d7a5.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -21087,7 +21087,7 @@
         },
         {
             "id": "cc01ec9e-2c28-5c10-af0b-52dce65f705c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8c030-f549-4361-981c-db476b85a26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8c030-f549-4361-981c-db476b85a26d.jpg?1",
             "name": "Millstone",
             "text": "",
             "colours": [],
@@ -21116,7 +21116,7 @@
         },
         {
             "id": "f5be770b-6010-5c05-b1c6-98b9c59ef797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919bc14b-603d-42fa-91fe-58c4d4b3b27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919bc14b-603d-42fa-91fe-58c4d4b3b27f.jpg?1",
             "name": "Ornithopter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -21148,7 +21148,7 @@
         },
         {
             "id": "2976d99f-01fc-5e6f-8ed3-3e71bb72940e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6c46d6-aec8-420b-8018-7b2c3908e5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6c46d6-aec8-420b-8018-7b2c3908e5a0.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -21180,7 +21180,7 @@
         },
         {
             "id": "f8e1d486-e796-5b9e-91a8-b5977cc90c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d6e1ac-8346-464f-91ac-efc45d0c7294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d6e1ac-8346-464f-91ac-efc45d0c7294.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21213,7 +21213,7 @@
         },
         {
             "id": "7df78a4e-5668-53d3-a81a-55b3ed92ce03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ee39b3-80ef-4a48-8de2-57c8c6101775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ee39b3-80ef-4a48-8de2-57c8c6101775.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21246,7 +21246,7 @@
         },
         {
             "id": "7d08899a-9ac4-5301-8ba7-6ac19bdc2f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb737b9-e526-47f7-806a-794cad54b23f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb737b9-e526-47f7-806a-794cad54b23f.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -21275,7 +21275,7 @@
         },
         {
             "id": "863cab2f-5131-545a-816a-83274dc14c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f50433-9eea-4159-bf89-82258f04ab53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f50433-9eea-4159-bf89-82258f04ab53.jpg?1",
             "name": "Rod of Ruin",
             "text": "",
             "colours": [],
@@ -21304,7 +21304,7 @@
         },
         {
             "id": "daa7751d-22a4-5af2-a874-aa1d695525e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8ad821-853b-47d6-8ae1-c317460a646f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8ad821-853b-47d6-8ae1-c317460a646f.jpg?1",
             "name": "Slate of Ancestry",
             "text": "{4}, {T}, Discard your hand: Draw a card for each creature you control.",
             "colours": [],
@@ -21333,7 +21333,7 @@
         },
         {
             "id": "00b1eeb6-2145-5ea2-a240-08f05b181786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4083ed-e258-41df-b9e0-82435c185653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4083ed-e258-41df-b9e0-82435c185653.jpg?1",
             "name": "Slate of Ancestry",
             "text": "",
             "colours": [],
@@ -21362,7 +21362,7 @@
         },
         {
             "id": "4796c801-bf2b-51ad-a307-e838c91a31d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbc3e2c-f6a6-4e4a-adfe-97fbc1596ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbc3e2c-f6a6-4e4a-adfe-97fbc1596ac3.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -21391,7 +21391,7 @@
         },
         {
             "id": "09f4f45e-f453-51d8-8eb9-78544812ec22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e7d0a-b01f-479b-9bfb-c3e31ade1b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e7d0a-b01f-479b-9bfb-c3e31ade1b28.jpg?1",
             "name": "Spellbook",
             "text": "",
             "colours": [],
@@ -21420,7 +21420,7 @@
         },
         {
             "id": "53288df1-c683-50b3-af15-7c0681e9dffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa41221-ee75-4713-99bd-683013ba64de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa41221-ee75-4713-99bd-683013ba64de.jpg?1",
             "name": "Storage Matrix",
             "text": "As long as Storage Matrix is untapped, each player chooses artifact, creature, or land during his or her untap step. That player can untap only permanents of the chosen type this step.",
             "colours": [],
@@ -21449,7 +21449,7 @@
         },
         {
             "id": "f75086f5-f4f3-564b-bfa3-9cf1cb0722cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff70f2-780b-43a1-8618-66a9a298371f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff70f2-780b-43a1-8618-66a9a298371f.jpg?1",
             "name": "Storage Matrix",
             "text": "",
             "colours": [],
@@ -21478,7 +21478,7 @@
         },
         {
             "id": "2d651e9c-e58e-5a8d-9c76-88d8f22be366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8ff237-dac6-4c79-9d8c-b047d60083e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8ff237-dac6-4c79-9d8c-b047d60083e8.jpg?1",
             "name": "Tanglebloom",
             "text": "{1}, {T}: You gain 1 life.",
             "colours": [],
@@ -21507,7 +21507,7 @@
         },
         {
             "id": "50c15de4-645a-5cb2-b937-56383afe4c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1a41b-bdac-4164-ad6a-ade034a4f1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1a41b-bdac-4164-ad6a-ade034a4f1bf.jpg?1",
             "name": "Tanglebloom",
             "text": "",
             "colours": [],
@@ -21536,7 +21536,7 @@
         },
         {
             "id": "2c7bcb2b-51a9-504e-aab0-aae97be7a690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415e81e9-ca65-4bc0-8aab-d905d58fe6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415e81e9-ca65-4bc0-8aab-d905d58fe6cc.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in his or her hand on the bottom of his or her library in any order, then draws that many cards.",
             "colours": [],
@@ -21565,7 +21565,7 @@
         },
         {
             "id": "ae3474a8-1cc0-5ccd-9fb3-066c2aa41bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2257f28-0d42-4e83-a389-25efa1dc257b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2257f28-0d42-4e83-a389-25efa1dc257b.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -21594,7 +21594,7 @@
         },
         {
             "id": "fec76d0f-92ef-52f5-af20-393cfbcc272d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b390d5-ae5a-4ed7-b9af-01d504d0551a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b390d5-ae5a-4ed7-b9af-01d504d0551a.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -21626,7 +21626,7 @@
         },
         {
             "id": "75972426-24c0-50ae-b739-5636f9b629e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d40ce-868d-4825-b3a8-37798b062916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d40ce-868d-4825-b3a8-37798b062916.jpg?1",
             "name": "Thran Golem",
             "text": "",
             "colours": [],
@@ -21658,7 +21658,7 @@
         },
         {
             "id": "57aed26a-a1b5-529c-bb46-90c35c503825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50700965-7fac-4351-8967-8eafe5d68aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50700965-7fac-4351-8967-8eafe5d68aff.jpg?1",
             "name": "Ur-Golem's Eye",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -21687,7 +21687,7 @@
         },
         {
             "id": "c8bb909a-380b-5c45-b50e-5dd14bd5aa4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6768616-a677-4d0d-bab6-652968a32e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6768616-a677-4d0d-bab6-652968a32e2b.jpg?1",
             "name": "Ur-Golem's Eye",
             "text": "",
             "colours": [],
@@ -21716,7 +21716,7 @@
         },
         {
             "id": "08d5ba5c-3e09-5e98-9e61-54da70be4e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d5f79-2346-4150-9be9-ca49efa2652b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d5f79-2346-4150-9be9-ca49efa2652b.jpg?1",
             "name": "Vulshok Morningstar",
             "text": "Equipped creature gets +2/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -21747,7 +21747,7 @@
         },
         {
             "id": "59fdf42e-6e64-5aab-b8c7-eb0c680ed38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d515c5f2-d591-4a81-be38-604a0accac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d515c5f2-d591-4a81-be38-604a0accac46.jpg?1",
             "name": "Vulshok Morningstar",
             "text": "",
             "colours": [],
@@ -21778,7 +21778,7 @@
         },
         {
             "id": "680df9d5-8b98-5a21-a9dd-5eeb4bc77713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace337fe-900b-4582-9cbe-1b0473d2734c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace337fe-900b-4582-9cbe-1b0473d2734c.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player plays a green spell, you may gain 1 life.",
             "colours": [],
@@ -21807,7 +21807,7 @@
         },
         {
             "id": "f23c86b0-16eb-5284-8ea3-c0d703681b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3391b88-ec48-4d1f-bb68-23af792a67d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3391b88-ec48-4d1f-bb68-23af792a67d0.jpg?1",
             "name": "Wurm's Tooth",
             "text": "",
             "colours": [],
@@ -21836,7 +21836,7 @@
         },
         {
             "id": "e88bc31a-cce1-5a2f-9c0f-151a879700b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f61de1-4e49-4640-a495-5abefd96babf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f61de1-4e49-4640-a495-5abefd96babf.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -21868,7 +21868,7 @@
         },
         {
             "id": "c0e7f869-3e0e-5e19-bf3e-2bcb5c942796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f462b3f1-3e40-47a4-b1f6-7ab5b5dafbee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f462b3f1-3e40-47a4-b1f6-7ab5b5dafbee.jpg?1",
             "name": "Adarkar Wastes",
             "text": "",
             "colours": [],
@@ -21900,7 +21900,7 @@
         },
         {
             "id": "c5b2c9d8-3def-5788-ade3-98d0c57a94fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5064361-a8c7-4002-908a-992252641572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5064361-a8c7-4002-908a-992252641572.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -21932,7 +21932,7 @@
         },
         {
             "id": "bb52fb45-742f-5b11-a406-5a82571e8184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6cf4b8-875e-4bc8-bf57-24b7d2c6438e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6cf4b8-875e-4bc8-bf57-24b7d2c6438e.jpg?1",
             "name": "Battlefield Forge",
             "text": "",
             "colours": [],
@@ -21964,7 +21964,7 @@
         },
         {
             "id": "d0c7842e-caa6-5cdd-b9ad-859d7b1dee5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd3ea6a-84f7-41d0-8e4d-222809f1d484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd3ea6a-84f7-41d0-8e4d-222809f1d484.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -21996,7 +21996,7 @@
         },
         {
             "id": "b7ee5045-e89d-5470-bce4-2d6cd0e2c6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d182c97-2879-4f20-86e8-8e369dbb437e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d182c97-2879-4f20-86e8-8e369dbb437e.jpg?1",
             "name": "Brushland",
             "text": "",
             "colours": [],
@@ -22028,7 +22028,7 @@
         },
         {
             "id": "513987de-d3d5-56cc-8135-88c89f0dc52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693fbc6-78b0-4203-83f4-5352a997371e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693fbc6-78b0-4203-83f4-5352a997371e.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -22060,7 +22060,7 @@
         },
         {
             "id": "dcf2c1bb-aa03-5835-96b3-5e8880a816c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c33bd-cda4-4014-ae75-8eab8e8701e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c33bd-cda4-4014-ae75-8eab8e8701e9.jpg?1",
             "name": "Caves of Koilos",
             "text": "",
             "colours": [],
@@ -22092,7 +22092,7 @@
         },
         {
             "id": "040d8a8d-9462-5da3-917d-4f2dcfb82c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12ce05-cfc9-4628-a2a3-f207fd9b149a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12ce05-cfc9-4628-a2a3-f207fd9b149a.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -22124,7 +22124,7 @@
         },
         {
             "id": "07aa033b-77bd-55db-bf05-a38f88a476c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363dee3f-48d0-454d-81d3-9def5476a029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363dee3f-48d0-454d-81d3-9def5476a029.jpg?1",
             "name": "Karplusan Forest",
             "text": "",
             "colours": [],
@@ -22156,7 +22156,7 @@
         },
         {
             "id": "09c18e83-3d78-57b4-a124-8120aa5cc482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7218c70-b170-4d23-b98f-f8fa29312994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7218c70-b170-4d23-b98f-f8fa29312994.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -22188,7 +22188,7 @@
         },
         {
             "id": "0e20323f-d67a-5540-b51e-353e4d4adb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb5f66-d9f0-4af5-8d6b-14e1f3eef351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb5f66-d9f0-4af5-8d6b-14e1f3eef351.jpg?1",
             "name": "Llanowar Wastes",
             "text": "",
             "colours": [],
@@ -22220,7 +22220,7 @@
         },
         {
             "id": "0da14250-2d8b-50ff-a3c5-ecfb542a5beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c62bbe-aa06-4d1b-8338-ab270ab617e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c62bbe-aa06-4d1b-8338-ab270ab617e5.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -22249,7 +22249,7 @@
         },
         {
             "id": "58451e24-9652-5ad5-8cf3-d8cec3441f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8358766f-7501-435e-a10d-ff1be4acd7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8358766f-7501-435e-a10d-ff1be4acd7f0.jpg?1",
             "name": "Quicksand",
             "text": "",
             "colours": [],
@@ -22278,7 +22278,7 @@
         },
         {
             "id": "1edcb8b5-6049-5546-a8c1-c73f6735e03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea38777-e67d-40a5-9301-d4e6d3819899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea38777-e67d-40a5-9301-d4e6d3819899.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -22310,7 +22310,7 @@
         },
         {
             "id": "126feaef-8e03-5a29-9e76-b57f5530390e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749d16ac-cb54-42a4-ab26-1172e1465b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749d16ac-cb54-42a4-ab26-1172e1465b41.jpg?1",
             "name": "Shivan Reef",
             "text": "",
             "colours": [],
@@ -22342,7 +22342,7 @@
         },
         {
             "id": "402b4546-3a7c-5054-b864-b36fc84ba15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da34c3-53c7-401a-8f7e-f3cc8a42c888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da34c3-53c7-401a-8f7e-f3cc8a42c888.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -22374,7 +22374,7 @@
         },
         {
             "id": "099d0077-faa5-572b-81e2-07d846b45d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eeaf2fa-2f74-46f8-99fc-0e911cfc51dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eeaf2fa-2f74-46f8-99fc-0e911cfc51dd.jpg?1",
             "name": "Sulfurous Springs",
             "text": "",
             "colours": [],
@@ -22406,7 +22406,7 @@
         },
         {
             "id": "85c3a7f2-9c6c-5c2c-9ffe-e4ca81b118f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9395fc-ad8a-494a-a5bc-fea3f55b0e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9395fc-ad8a-494a-a5bc-fea3f55b0e2c.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -22438,7 +22438,7 @@
         },
         {
             "id": "4e8fb149-b3f0-5c50-8693-ca9b0a7c104c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52900300-dc28-4c2e-adfe-94c4de81ab02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52900300-dc28-4c2e-adfe-94c4de81ab02.jpg?1",
             "name": "Underground River",
             "text": "",
             "colours": [],
@@ -22470,7 +22470,7 @@
         },
         {
             "id": "3a0395a2-a4fb-51bf-81e9-dc720f5f747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a235785-b720-483b-bb28-6de440be2129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a235785-b720-483b-bb28-6de440be2129.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Power-Plant and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22502,7 +22502,7 @@
         },
         {
             "id": "36a53f88-aa71-54a3-831e-b96b616a6fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73bd2a6-676c-47cd-8608-1128cbd0c7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73bd2a6-676c-47cd-8608-1128cbd0c7cb.jpg?1",
             "name": "Urza's Mine",
             "text": "",
             "colours": [],
@@ -22534,7 +22534,7 @@
         },
         {
             "id": "4fb85e59-74c8-51a7-b49d-af15d4c62e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3115c04a-ac26-4361-aecd-c6fb5f03a96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3115c04a-ac26-4361-aecd-c6fb5f03a96f.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22566,7 +22566,7 @@
         },
         {
             "id": "a19e5a10-874e-50b6-b69c-5a80e10fd536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b23321-861f-4afa-904f-7c63e356f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b23321-861f-4afa-904f-7c63e356f10b.jpg?1",
             "name": "Urza's Power Plant",
             "text": "",
             "colours": [],
@@ -22598,7 +22598,7 @@
         },
         {
             "id": "c15a7b40-1c2d-552e-857b-f9e93292a7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e063c-b328-4e5f-8806-b232c38645f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e063c-b328-4e5f-8806-b232c38645f5.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Power-Plant, add {3} to your mana pool instead.",
             "colours": [],
@@ -22630,7 +22630,7 @@
         },
         {
             "id": "47561a0c-44fc-5c0c-87ab-8ed3199c2b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd1ab7-e11d-4206-8aad-c3de4e2da5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd1ab7-e11d-4206-8aad-c3de4e2da5ec.jpg?1",
             "name": "Urza's Tower",
             "text": "",
             "colours": [],
@@ -22662,7 +22662,7 @@
         },
         {
             "id": "43d47975-d274-56ed-9c4c-604f90fad653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2eff74-8dcc-4c4b-8d74-c93b12966e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2eff74-8dcc-4c4b-8d74-c93b12966e88.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -22694,7 +22694,7 @@
         },
         {
             "id": "a2f7313a-7846-5b3b-9ca3-a5b90cdc07ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b98751-20bc-4c71-a51e-35503b072044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b98751-20bc-4c71-a51e-35503b072044.jpg?1",
             "name": "Yavimaya Coast",
             "text": "",
             "colours": [],
@@ -22726,7 +22726,7 @@
         },
         {
             "id": "b945e43a-cccb-5468-a67e-369d004c2805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e639a9-6010-4453-9c25-4ab03664b9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e639a9-6010-4453-9c25-4ab03664b9b2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22767,7 +22767,7 @@
         },
         {
             "id": "15deb7a4-ec34-5cad-a8fd-b14c886fc5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40b8460-30ae-4390-8bc6-ef69ff048572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40b8460-30ae-4390-8bc6-ef69ff048572.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22808,7 +22808,7 @@
         },
         {
             "id": "e778bfe3-776a-565d-933a-4c8df6f8ec6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c96115-3728-4f3c-9438-d53550974363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c96115-3728-4f3c-9438-d53550974363.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22849,7 +22849,7 @@
         },
         {
             "id": "d0d7d38e-7b09-5f11-8e93-5af58cd614e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8b83f-b7c8-4a8b-9c5c-31c793c6d9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8b83f-b7c8-4a8b-9c5c-31c793c6d9f0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22890,7 +22890,7 @@
         },
         {
             "id": "2c52b625-c51b-5d49-96a0-972ac05a8238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8703ecd3-1ffa-489c-b8e1-f4d9b5ba2c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8703ecd3-1ffa-489c-b8e1-f4d9b5ba2c12.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22931,7 +22931,7 @@
         },
         {
             "id": "d25f765f-62a9-538c-ad3b-af09aed41814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13182c-0529-4da2-b5ae-9d61fe0a0f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13182c-0529-4da2-b5ae-9d61fe0a0f5f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "6d7699d9-885b-552f-b5e3-75779661a2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aae970-d66c-424e-8a23-577711af6eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aae970-d66c-424e-8a23-577711af6eab.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23013,7 +23013,7 @@
         },
         {
             "id": "238c9dbb-b606-59de-82ee-de53794d0b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d20b8a-0aa7-45f6-8c87-01d85beb2771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d20b8a-0aa7-45f6-8c87-01d85beb2771.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23054,7 +23054,7 @@
         },
         {
             "id": "c5745762-9012-5446-80d4-5974be9de1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0eac72f-915b-41a2-a9cf-1707b65d9ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0eac72f-915b-41a2-a9cf-1707b65d9ac9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23095,7 +23095,7 @@
         },
         {
             "id": "75b04cf4-e753-5fa3-b562-2556b6c95003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ddcce6-2f0f-4450-9aac-58b89ddc2e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ddcce6-2f0f-4450-9aac-58b89ddc2e50.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23136,7 +23136,7 @@
         },
         {
             "id": "70facbf8-ecc7-5b33-8c43-7b6d3180336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5ab443-b415-45e5-a9f7-539a5299bf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5ab443-b415-45e5-a9f7-539a5299bf27.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23177,7 +23177,7 @@
         },
         {
             "id": "8899ab1a-3831-5e23-ba22-6ddb86b1ca08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785f977-0635-4a20-ab8f-eab79659d16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785f977-0635-4a20-ab8f-eab79659d16e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23218,7 +23218,7 @@
         },
         {
             "id": "12546133-7808-5ed5-a8ef-5c521d31944a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d7f6bf-051c-45a4-b19e-2a50bbd6398e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d7f6bf-051c-45a4-b19e-2a50bbd6398e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23259,7 +23259,7 @@
         },
         {
             "id": "153d08d8-2466-59fb-9ebe-801aeda30d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434dc08b-0f4f-4230-bd39-7dc1c9d9cd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434dc08b-0f4f-4230-bd39-7dc1c9d9cd1e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23300,7 +23300,7 @@
         },
         {
             "id": "7b34d085-b477-56d2-bf1f-67400916fc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cf7cd5-3c25-4760-b783-36e7827154e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cf7cd5-3c25-4760-b783-36e7827154e2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23341,7 +23341,7 @@
         },
         {
             "id": "472a2552-d0ab-5414-9a65-0384278eaf88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e3f97-531a-4336-af16-e0f738ebb85e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e3f97-531a-4336-af16-e0f738ebb85e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23382,7 +23382,7 @@
         },
         {
             "id": "5e671add-0a87-52d2-8067-cd66f8b3823d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc9d935-2a33-4928-b4b2-25c48544bf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc9d935-2a33-4928-b4b2-25c48544bf24.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23423,7 +23423,7 @@
         },
         {
             "id": "d65d6a9f-e5fc-590a-a861-59ad74a62bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0daa93a-8cc3-4fa3-944b-5b0b41e88fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0daa93a-8cc3-4fa3-944b-5b0b41e88fa3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23464,7 +23464,7 @@
         },
         {
             "id": "6336246e-e896-5327-b80b-e7dddd0c19ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e964e2e-8bc5-423c-ac85-4f0c860afb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e964e2e-8bc5-423c-ac85-4f0c860afb8a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23505,7 +23505,7 @@
         },
         {
             "id": "d5fb6761-80e5-5744-8eb1-03b3d6972e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aca4e94-3e7f-462b-a900-84e1f3609ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aca4e94-3e7f-462b-a900-84e1f3609ed8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23546,7 +23546,7 @@
         },
         {
             "id": "58185414-50c8-560b-94cc-911813550c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a54b0-49e6-4f79-8379-ccb30d06fb60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a54b0-49e6-4f79-8379-ccb30d06fb60.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23587,7 +23587,7 @@
         },
         {
             "id": "64dd5c3d-c54a-52e8-8186-4c0301b26c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8def00d9-2e93-4d65-bba5-09c45258bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8def00d9-2e93-4d65-bba5-09c45258bf5e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23628,7 +23628,7 @@
         },
         {
             "id": "50b58fcb-faf2-512d-971e-55b1a03635b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6190620-f88c-4eaf-853f-bfa0ea8f96d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6190620-f88c-4eaf-853f-bfa0ea8f96d3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23669,7 +23669,7 @@
         },
         {
             "id": "02631ed2-f324-5f72-87d7-5e2c4d30d11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45919fc2-da64-4bfd-ba15-e61ed268b422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45919fc2-da64-4bfd-ba15-e61ed268b422.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23710,7 +23710,7 @@
         },
         {
             "id": "9e96846f-a6f3-5b86-99d3-822116f99311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e2ee4c-5548-4a17-bf27-e906d2825867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e2ee4c-5548-4a17-bf27-e906d2825867.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23751,7 +23751,7 @@
         },
         {
             "id": "8a497168-508e-5672-a8d1-eaf9163a0459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b9efbc-ab04-4438-81e2-a558a67cafd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b9efbc-ab04-4438-81e2-a558a67cafd0.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23792,7 +23792,7 @@
         },
         {
             "id": "d5bb8759-4736-5996-9692-471b010863e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41bb43-0328-4093-88c6-4dc00dfdfb7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41bb43-0328-4093-88c6-4dc00dfdfb7e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23833,7 +23833,7 @@
         },
         {
             "id": "eb92cd72-3967-5794-ab5d-c87988ff8848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a0f125-041e-4a5d-b100-3dbb6bf729a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a0f125-041e-4a5d-b100-3dbb6bf729a1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23874,7 +23874,7 @@
         },
         {
             "id": "c9e00be2-45c1-536d-a521-c6aecb4ee496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2655e7b-ae35-45f0-b86d-c2f74ef3ee04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2655e7b-ae35-45f0-b86d-c2f74ef3ee04.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23915,7 +23915,7 @@
         },
         {
             "id": "84c9f6a2-ec56-5d45-97eb-259a660b1d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb734fd1-7e4a-4d56-b85e-6638012cbda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb734fd1-7e4a-4d56-b85e-6638012cbda9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23956,7 +23956,7 @@
         },
         {
             "id": "02d2429d-bb88-5040-b8a4-d8c67eca5abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a6ddd-6684-49b1-8e2f-1516ca7a2a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a6ddd-6684-49b1-8e2f-1516ca7a2a34.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23997,7 +23997,7 @@
         },
         {
             "id": "82fc0b59-8d31-5036-822e-06933ca7d8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aec9409-1812-4f85-b396-39bd9783b65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aec9409-1812-4f85-b396-39bd9783b65e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -24038,7 +24038,7 @@
         },
         {
             "id": "cd239a7d-5d69-5d5e-aa91-743935b9522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5029a818-e076-4ae3-a246-693ec7615e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5029a818-e076-4ae3-a246-693ec7615e15.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24079,7 +24079,7 @@
         },
         {
             "id": "45ddb1bb-7232-58fc-b4fa-7a6ad4c88272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0df6e1-1945-49e0-8960-e7022d81cc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0df6e1-1945-49e0-8960-e7022d81cc4f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24120,7 +24120,7 @@
         },
         {
             "id": "a4a99f87-62f8-5533-9583-e291e322850a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbc9c84-348b-40f5-ab3d-bbe8c27529a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbc9c84-348b-40f5-ab3d-bbe8c27529a4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24161,7 +24161,7 @@
         },
         {
             "id": "2936dbe4-ec25-5a6f-ba0b-235f82b6ed1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0d673b-cd7d-4d8f-8c62-63c79531ff85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0d673b-cd7d-4d8f-8c62-63c79531ff85.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24202,7 +24202,7 @@
         },
         {
             "id": "9a71c5e5-4732-53f0-81cd-d567318e8083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aaaad-a217-490a-8a90-31ce592ad742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aaaad-a217-490a-8a90-31ce592ad742.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24243,7 +24243,7 @@
         },
         {
             "id": "75cf0d63-188a-597b-8f0a-4cb19e450c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f15b112-500e-42ad-bdaa-5dadcd4351e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f15b112-500e-42ad-bdaa-5dadcd4351e1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24284,7 +24284,7 @@
         },
         {
             "id": "d0cc9e31-977f-510d-a6da-af6b3562775f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e797e006-7379-45c2-a4b7-d0ef133379df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e797e006-7379-45c2-a4b7-d0ef133379df.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24325,7 +24325,7 @@
         },
         {
             "id": "04da863e-44fa-5f3c-9c9d-02ed9f06f1a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412103f2-fdc1-4205-8f96-831186b58513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412103f2-fdc1-4205-8f96-831186b58513.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/A25.json
+++ b/Assets/Resources/Sets/A25.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "36ec140e-8588-5daa-af1d-7638cee8c0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969860ba-6923-4715-b065-81803bba3dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969860ba-6923-4715-b065-81803bba3dd6.jpg?1",
             "name": "Act of Heroism",
             "text": "Untap target creature. It gets +2/+2 until end of turn and can block an additional creature this turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "83d4a1e2-c245-5f32-9183-bd9900f62aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9049ad-2bcd-4b5e-b09c-06424cf76cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9049ad-2bcd-4b5e-b09c-06424cf76cdc.jpg?1",
             "name": "Akroma, Angel of Wrath",
             "text": "Flying, first strike, vigilance, trample, haste, protection from black and from red",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "0e07bb7c-117e-5b1a-8f13-2af4a598b666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea781d-0aa1-4ccc-a48b-d4af7e5dfdd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea781d-0aa1-4ccc-a48b-d4af7e5dfdd5.jpg?1",
             "name": "Akroma's Vengeance",
             "text": "Destroy all artifacts, creatures, and enchantments.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "19083451-db64-52d8-826e-8f5811ecbf8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5022ca-9b8b-4d54-a4fa-706690b535d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5022ca-9b8b-4d54-a4fa-706690b535d4.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "b58854d2-c7af-5832-99d3-1b391ac27749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f1f6ac-983f-4f3e-8906-47f774e8367b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f1f6ac-983f-4f3e-8906-47f774e8367b.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "d12c29e5-7981-50fe-a92d-5bcd2bf11136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05fde4-a866-459c-9a24-2884116ab647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05fde4-a866-459c-9a24-2884116ab647.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "1a9806e2-28e2-54ff-a257-0e6ba75638ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b1e18f-f781-498c-ba84-cdee49c24230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b1e18f-f781-498c-ba84-cdee49c24230.jpg?1",
             "name": "Cloudshift",
             "text": "Exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "065d16f8-b517-5654-b5c5-db3feee06404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690166f-be52-48c4-9877-630b3f3dc614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690166f-be52-48c4-9877-630b3f3dc614.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -270,7 +270,7 @@
         },
         {
             "id": "4663ad3c-9657-5265-967f-196d4180652c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5f96a4-55e0-4ae3-bd78-f01703649e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5f96a4-55e0-4ae3-bd78-f01703649e9d.jpg?1",
             "name": "Darien, King of Kjeldor",
             "text": "Whenever you're dealt damage, you may create that many 1/1 white Soldier creature tokens.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "bea8cc6b-d8f5-58d5-b27c-c5b94222d794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b49b72c-16dc-45c7-ba76-545c4dec42d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b49b72c-16dc-45c7-ba76-545c4dec42d9.jpg?1",
             "name": "Dauntless Cathar",
             "text": "{1}{W}, Exile Dauntless Cathar from your graveyard: Create a 1/1 white Spirit creature token with flying. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "c22064c6-7fff-5018-a294-97c33acf67ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c236a8ab-51a6-4b48-8f33-de652a4c75f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c236a8ab-51a6-4b48-8f33-de652a4c75f2.jpg?1",
             "name": "Decree of Justice",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "c514087e-1252-591a-85c9-3cd9f3b2cac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a51270d-9143-46f5-a5d1-4ff3bf20ce34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a51270d-9143-46f5-a5d1-4ff3bf20ce34.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "c1ade745-3912-5508-9d7c-48b6b0002735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d074f-63b8-463f-b7e8-cc20e272208c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d074f-63b8-463f-b7e8-cc20e272208c.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "2158ed93-1afc-55b9-bde1-f1c7b3288bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99e7b7-f6ef-488d-ba85-a97c594cd664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99e7b7-f6ef-488d-ba85-a97c594cd664.jpg?1",
             "name": "Fiend Hunter",
             "text": "When Fiend Hunter enters the battlefield, you may exile another target creature.\nWhen Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "28d7ac1a-8652-5365-8899-4f392b48b304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd246d1-a7cb-45a0-b735-53509ba2d5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd246d1-a7cb-45a0-b735-53509ba2d5ca.jpg?1",
             "name": "Geist of the Moors",
             "text": "Flying",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "7e5df86d-f792-509f-ac0d-444ea3b2fe81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949e3977-8e67-421f-a2ff-a982b5a75714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949e3977-8e67-421f-a2ff-a982b5a75714.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1.",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "cd3ad779-3b76-55e2-8c15-3ad18cd0edfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6cb8ea-0dbf-45f8-b1e9-bd219de3fb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6cb8ea-0dbf-45f8-b1e9-bd219de3fb69.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "5f3d81ae-b4ad-5ce7-bfbc-de30b50ed713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29214308-711a-490f-8e93-bf61baf1749c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29214308-711a-490f-8e93-bf61baf1749c.jpg?1",
             "name": "Karona's Zealot",
             "text": "Morph {3}{W}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Karona's Zealot is turned face up, all damage that would be dealt to it this turn is dealt to target creature instead.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "ff40d959-d4f9-5bf6-9560-395fd31b73f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c908f812-a7ee-411e-89f1-1f84793d095d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c908f812-a7ee-411e-89f1-1f84793d095d.jpg?1",
             "name": "Knight of the Skyward Eye",
             "text": "{3}{G}: Knight of the Skyward Eye gets +3/+3 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "59cd4e91-3808-5bcc-83cb-598f3b8deb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c9e4fd-e987-4653-abb1-e32971745db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c9e4fd-e987-4653-abb1-e32971745db2.jpg?1",
             "name": "Kongming, \"Sleeping Dragon\"",
             "text": "Other creatures you control get +1/+1.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "7f114c73-ccc0-54c0-8fd3-1da8fb4e748a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd4a52-0c8f-4fca-b7dc-c2503794e5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd4a52-0c8f-4fca-b7dc-c2503794e5a4.jpg?1",
             "name": "Kor Firewalker",
             "text": "Protection from red\nWhenever a player casts a red spell, you may gain 1 life.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "b83df396-9f78-5440-b417-723b54084b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8854cc80-6201-4066-80c8-97c0fdc9baa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8854cc80-6201-4066-80c8-97c0fdc9baa8.jpg?1",
             "name": "Loyal Sentry",
             "text": "When Loyal Sentry blocks a creature, destroy that creature and Loyal Sentry.",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "ca728f3f-c50b-5b2c-bb27-c6bca2d6dd02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3770d86-4496-4c06-aab1-2917cfec100e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3770d86-4496-4c06-aab1-2917cfec100e.jpg?1",
             "name": "Luminarch Ascension",
             "text": "At the beginning of each opponent's end step, if you didn't lose life this turn, you may put a quest counter on Luminarch Ascension.\n{1}{W}: Create a 4/4 white Angel creature token with flying. Activate this ability only if Luminarch Ascension has four or more quest counters on it.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "49bb2c7a-5cf5-5eeb-933d-cad655b1c47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d63c045-5563-4ecd-804b-d4a77209501f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d63c045-5563-4ecd-804b-d4a77209501f.jpg?1",
             "name": "Lunarch Mantle",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}, Sacrifice a permanent: This creature gains flying until end of turn.\"",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "dc6d4c43-73e7-5e6b-ad58-27f1a9cad93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82073551-8106-4e88-8d55-913d86bbe48a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82073551-8106-4e88-8d55-913d86bbe48a.jpg?1",
             "name": "Noble Templar",
             "text": "Vigilance\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -856,7 +856,7 @@
         },
         {
             "id": "834400ad-461c-530f-9299-e86eabb7d017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad98e518-4ec9-403e-a978-217244262c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad98e518-4ec9-403e-a978-217244262c8f.jpg?1",
             "name": "Nyx-Fleece Ram",
             "text": "At the beginning of your upkeep, you gain 1 life.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "845f2242-de08-5d9e-af05-ae60cd878663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd652c85-f8ca-4e38-a21b-f21b729bcf92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd652c85-f8ca-4e38-a21b-f21b729bcf92.jpg?1",
             "name": "Ordeal of Heliod",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Heliod.\nWhen you sacrifice Ordeal of Heliod, you gain 10 life.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "3eafd0f4-6607-5ec4-a8c6-baf53d1408f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db339-9b27-404a-878d-16511b546862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db339-9b27-404a-878d-16511b546862.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "cd3f302b-02a3-5717-bf56-47b04a4020f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41369848-ba9a-40ef-931e-1a65bc979209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41369848-ba9a-40ef-931e-1a65bc979209.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy target creature. Its owner gains 4 life.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "79b0cec7-a435-571d-bdca-53672bca46ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba42cce-4555-4d21-ba8e-fc2ff1a995c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba42cce-4555-4d21-ba8e-fc2ff1a995c2.jpg?1",
             "name": "Promise of Bunrei",
             "text": "When a creature you control dies, sacrifice Promise of Bunrei. If you do, create four 1/1 colorless Spirit creature tokens.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "eb1b3ddb-12b8-5a15-87ad-0c01c5f1ae40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849b907-9d80-484d-bdfa-6d287f5bc2d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849b907-9d80-484d-bdfa-6d287f5bc2d6.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "8a0f5058-ec35-5ebc-80d2-1ffde2b91e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b39be-0fec-4647-ade1-8e1626dc5470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b39be-0fec-4647-ade1-8e1626dc5470.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all cards from all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "81a64794-b8a1-59ff-b53a-fe39329908c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9757246-e782-4d7a-8273-d9efe284edaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9757246-e782-4d7a-8273-d9efe284edaf.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "a4781937-3f77-5671-adc2-2a2fd79dc69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e81806d-5d87-4032-ad94-c2cdeabecdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e81806d-5d87-4032-ad94-c2cdeabecdbf.jpg?1",
             "name": "Squadron Hawk",
             "text": "Flying\nWhen Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "6221685c-1864-58ac-b873-295852f2b70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220accc-2095-43d9-9114-7599c1cb8e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220accc-2095-43d9-9114-7599c1cb8e41.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1187,7 +1187,7 @@
         },
         {
             "id": "bb57ece7-d091-5050-8ac4-a7a7dcfc87b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff44c9-6ff5-432d-9876-488c96833c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff44c9-6ff5-432d-9876-488c96833c39.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "39cc8148-f53f-5da1-992c-a423ae02d69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f41db0-335d-4745-8759-0129baf72992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f41db0-335d-4745-8759-0129baf72992.jpg?1",
             "name": "Urbis Protector",
             "text": "When Urbis Protector enters the battlefield, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "54630d68-fb81-546c-bf7e-b0ae21ad8224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2a3fe4-a0c3-4956-a52b-060c4538c0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2a3fe4-a0c3-4956-a52b-060c4538c0b2.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "3ce3ba4d-95f6-5f1b-aa4a-03bf6a0ad640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27394079-924a-4fdb-8be2-f853193eca80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27394079-924a-4fdb-8be2-f853193eca80.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "0e0c2332-70ae-5a6d-b1fa-e5278f194bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad88e5ee-0eee-47af-a7b4-9bac044e1c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad88e5ee-0eee-47af-a7b4-9bac044e1c8c.jpg?1",
             "name": "Accumulated Knowledge",
             "text": "Draw a card, then draw cards equal to the number of cards named Accumulated Knowledge in all graveyards.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "ea4122d2-2490-539d-b6a4-35eb86e7a873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1ffeb1-6c31-45f7-8140-913c397022a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1ffeb1-6c31-45f7-8140-913c397022a3.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "90dc896f-5228-5a4f-a8ca-969025362559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5903aac6-171c-48b7-984a-f074c176d179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5903aac6-171c-48b7-984a-f074c176d179.jpg?1",
             "name": "Bident of Thassa",
             "text": "Whenever a creature you control deals combat damage to a player, you may draw a card.\n{1}{U}, {T}: Creatures your opponents control attack this turn if able.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "9636d9c3-50e2-515d-b4d7-4a773985af89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f51f88f-f662-4572-a371-9a77718ed079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f51f88f-f662-4572-a371-9a77718ed079.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target red spell.\n\u2022 Destroy target red permanent.",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "5105c0e8-98b9-5ea9-8ab1-9cad812a0fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500a2aa4-712f-41be-920e-f2f448ff83d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500a2aa4-712f-41be-920e-f2f448ff83d0.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "be3524e4-b87a-50a7-ab8a-3233bfcaec08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26334142-e9a2-4bf0-983e-dca4b4d817d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26334142-e9a2-4bf0-983e-dca4b4d817d7.jpg?1",
             "name": "Borrowing 100,000 Arrows",
             "text": "Draw a card for each tapped creature target opponent controls.",
             "colours": [
@@ -1520,7 +1520,7 @@
         },
         {
             "id": "5013e019-bf84-53c9-b13a-70043673a95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea8d5cb-cf7e-4194-8019-812b3f56cf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea8d5cb-cf7e-4194-8019-812b3f56cf20.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "e820824c-fdf3-50d1-b994-847f5cafc936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a4eb0b-415f-4b62-8b66-83eae0626d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a4eb0b-415f-4b62-8b66-83eae0626d9f.jpg?1",
             "name": "Brine Elemental",
             "text": "Morph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Brine Elemental is turned face up, each opponent skips his or her next untap step.",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "271f6162-1e1a-51d4-9f35-3a6c05575e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14884e61-fb1e-4989-ae29-57dfd910b53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14884e61-fb1e-4989-ae29-57dfd910b53f.jpg?1",
             "name": "Choking Tethers",
             "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "7cace6fa-e530-5e38-95ac-83f90028bef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbfa0fa-da69-4d6b-a722-52856c20f4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbfa0fa-da69-4d6b-a722-52856c20f4f0.jpg?1",
             "name": "Coralhelm Guide",
             "text": "{4}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "a3b1904e-7d51-5bfe-83fa-1be9b20cbc43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca8eb95-d071-46a4-885c-3da25b401806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca8eb95-d071-46a4-885c-3da25b401806.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "0969dae1-e5ce-54b9-8468-2867e5537316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3843e98-192c-44a2-be54-9ba79e51657c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3843e98-192c-44a2-be54-9ba79e51657c.jpg?1",
             "name": "Court Hussar",
             "text": "Vigilance\nWhen Court Hussar enters the battlefield, look at the top three cards of your library, then put one of them into your hand and the rest on the bottom of your library in any order.\nWhen Court Hussar enters the battlefield, sacrifice it unless {W} was spent to cast it.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "69d59f07-ce11-5a3e-9fc8-f1f875e6c028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd040ac-7e96-4082-a2d9-13d7dd26829e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd040ac-7e96-4082-a2d9-13d7dd26829e.jpg?1",
             "name": "Curiosity",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -1756,7 +1756,7 @@
         },
         {
             "id": "82e2eb8e-f9c7-57c7-b702-a6f953676e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d257a3c9-443f-4899-badc-f075a14667c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d257a3c9-443f-4899-badc-f075a14667c5.jpg?1",
             "name": "Cursecatcher",
             "text": "Sacrifice Cursecatcher: Counter target instant or sorcery spell unless its controller pays {1}.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "169d666f-705e-58ff-86e1-c2da3012ddd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20656d9-cd4f-4694-8715-04c017eb6760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20656d9-cd4f-4694-8715-04c017eb6760.jpg?1",
             "name": "Dragon's Eye Savants",
             "text": "Morph\u2014\nReveal a blue card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Dragon's Eye Savants is turned face up, look at target opponent's hand.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "9d2eda38-4c6c-5772-bb61-9504c60f1066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a50f54-6363-41dd-88a7-9f9e820e7d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a50f54-6363-41dd-88a7-9f9e820e7d5f.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "6dcba420-1762-5c8c-a7de-6f6375eb85a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750fcc79-daee-47da-8e91-a1afe48b8474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750fcc79-daee-47da-8e91-a1afe48b8474.jpg?1",
             "name": "Fathom Seer",
             "text": "Morph\u2014\nReturn two Islands you control to their owner's hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Fathom Seer is turned face up, draw two cards.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "0b0e870c-d3bc-56a5-b3cd-43585627110a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31459c2-9656-4e9a-bb72-71a910e8570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31459c2-9656-4e9a-bb72-71a910e8570b.jpg?1",
             "name": "Flash",
             "text": "You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by up to {2}.",
             "colours": [
@@ -1924,7 +1924,7 @@
         },
         {
             "id": "4ffb4bfd-978e-51d5-84d0-021bd30a8a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ee6f6-50c1-4f56-b9ce-4c309bfb92ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ee6f6-50c1-4f56-b9ce-4c309bfb92ca.jpg?1",
             "name": "Freed from the Real",
             "text": "Enchant creature\n{U}: Tap enchanted creature.\n{U}: Untap enchanted creature.",
             "colours": [
@@ -1958,7 +1958,7 @@
         },
         {
             "id": "32bc77b3-8a23-5443-b4a4-cb1636501bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ba3a2f-0224-4ace-bb49-8dc41b34fb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ba3a2f-0224-4ace-bb49-8dc41b34fb57.jpg?1",
             "name": "Genju of the Falls",
             "text": "Enchant Island\n{2}: Enchanted Island becomes a 3/2 blue Spirit creature with flying until end of turn. It's still a land.\nWhen enchanted Island is put into a graveyard, you may return Genju of the Falls from your graveyard to your hand.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "a0578098-adcd-56fa-9c92-c7f0bf640cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76d9d80-b7fb-43ed-bc9c-767dd1613d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76d9d80-b7fb-43ed-bc9c-767dd1613d37.jpg?1",
             "name": "Ghost Ship",
             "text": "Flying\n{U}{U}{U}: Regenerate Ghost Ship.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "dbde8a37-2044-5266-a2e0-03bb5ff64e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f46cb4e-1bdf-4322-8df1-58a8887fb963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f46cb4e-1bdf-4322-8df1-58a8887fb963.jpg?1",
             "name": "Horseshoe Crab",
             "text": "{U}: Untap Horseshoe Crab.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "f888d8cc-55f9-52fe-a47b-a3abf0b875b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c057dc0d-4017-4e60-9c5e-45fc569a8d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c057dc0d-4017-4e60-9c5e-45fc569a8d31.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles his or her hand into his or her library.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "96658e4f-9064-58c3-95c3-ad672664d026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9719c8-2dfe-4141-9ede-2ee3a282b5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9719c8-2dfe-4141-9ede-2ee3a282b5e9.jpg?1",
             "name": "Jalira, Master Polymorphist",
             "text": "{2}{U}, {T}, Sacrifice another creature: Reveal cards from the top of your library until you reveal a nonlegendary creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "903080d0-32cb-5b8e-9d59-655917e83d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fac7b68-db59-4b38-80e6-fcba3e3c91bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fac7b68-db59-4b38-80e6-fcba3e3c91bf.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "130e20a8-846f-58a6-ac96-f951ef55614e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cae1a42-052e-4110-9afc-d3ec83b7c8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cae1a42-052e-4110-9afc-d3ec83b7c8a9.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2202,7 +2202,7 @@
         },
         {
             "id": "8f82f15f-3d6d-5ea5-9ca5-f74f5afaf1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603920d6-7b83-4e55-b6df-2056afc40108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603920d6-7b83-4e55-b6df-2056afc40108.jpg?1",
             "name": "Murder of Crows",
             "text": "Flying\nWhenever another creature dies, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "717df329-fbef-5840-b6da-b9018a48c08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45261b50-e7cc-40f6-9d0d-44b5ada45e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45261b50-e7cc-40f6-9d0d-44b5ada45e42.jpg?1",
             "name": "Mystic of the Hidden Way",
             "text": "Mystic of the Hidden Way can't be blocked.\nMorph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "e423c65c-5459-53bc-9b1e-94491c5fc9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd125949-38c4-470f-9128-b80c45621086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd125949-38c4-470f-9128-b80c45621086.jpg?1",
             "name": "Pact of Negation",
             "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "24410b81-f879-5d2d-b913-ebe776c770cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5e968-6ba4-44e9-9587-6ef456721b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5e968-6ba4-44e9-9587-6ef456721b97.jpg?1",
             "name": "Phantasmal Bear",
             "text": "When Phantasmal Bear becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "34aa1613-431f-56a4-b554-536268aebced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147eb02-4cfc-49ed-a5aa-dd6b3f3a2e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147eb02-4cfc-49ed-a5aa-dd6b3f3a2e51.jpg?1",
             "name": "Reef Worm",
             "text": "When Reef Worm dies, create a 3/3 blue Fish creature token with \"When this creature dies, create a 6/6 blue Whale creature token with \u2018\nWhen this creature dies, create a 9/9 blue Kraken creature token.'\"",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "4a0f2081-6fc0-5953-84ea-5582364eabcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa3fdd0-34d8-47b3-9753-d2929838732e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa3fdd0-34d8-47b3-9753-d2929838732e.jpg?1",
             "name": "Retraction Helix",
             "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "13fd8f25-20c1-5146-9b13-4699b690e6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9957cbe-da88-41fe-a4aa-e32ec9e7aa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9957cbe-da88-41fe-a4aa-e32ec9e7aa38.jpg?1",
             "name": "Shoreline Ranger",
             "text": "Flying\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "4cbc42e1-94d5-5e5c-a5fa-128ca29fe227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5296fbac-b86f-458e-bfd8-34d05e4e212c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5296fbac-b86f-458e-bfd8-34d05e4e212c.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "14cb2797-ec94-5709-b177-adb7b7b950d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa6ad7-9057-4339-bff3-1250d5b44493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa6ad7-9057-4339-bff3-1250d5b44493.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "a2fba370-cdfd-513a-987a-5d263b070090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c38f83-32af-4819-b259-a986860f484a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c38f83-32af-4819-b259-a986860f484a.jpg?1",
             "name": "Twisted Image",
             "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "f81b27c0-261c-57ae-81d2-3ed247b02620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd702cf1-10ca-4448-9fb1-b6de635e839c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd702cf1-10ca-4448-9fb1-b6de635e839c.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "cf8c2c84-1d2f-528b-910e-be55249081e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a131b03-f76b-455b-9e6e-0f30a42e04f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a131b03-f76b-455b-9e6e-0f30a42e04f1.jpg?1",
             "name": "Vesuvan Shapeshifter",
             "text": "As Vesuvan Shapeshifter enters the battlefield or is turned face up, you may choose another creature on the battlefield. If you do, until Vesuvan Shapeshifter is turned face down, it becomes a copy of that creature and gains \"At the beginning of your upkeep, you may turn this creature face down.\"\nMorph {1}{U}",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "deedf871-b391-5afa-8fb3-6deca8f251ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fac295-3563-4989-86b6-1672a4e97afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fac295-3563-4989-86b6-1672a4e97afd.jpg?1",
             "name": "Willbender",
             "text": "Morph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Willbender is turned face up, change the target of target spell or ability with a single target.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "961801d8-921c-57a4-81f9-271c9777ea91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20631989-64e7-4ad7-adf7-660033f893e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20631989-64e7-4ad7-adf7-660033f893e8.jpg?1",
             "name": "Ancient Craving",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "f25128c5-a235-5caa-a128-513f1d372ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd63bb3b-c927-4470-b308-6d4b51da1b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd63bb3b-c927-4470-b308-6d4b51da1b9c.jpg?1",
             "name": "Bloodhunter Bat",
             "text": "Flying\nWhen Bloodhunter Bat enters the battlefield, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2708,7 +2708,7 @@
         },
         {
             "id": "ae2f824a-0da6-5615-97b7-f680691743a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002443d-a296-4f68-8a94-991165e6ea38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002443d-a296-4f68-8a94-991165e6ea38.jpg?1",
             "name": "Caustic Tar",
             "text": "Enchant land\nEnchanted land has \"{T}: Target player loses 3 life.\"",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "dcfb5bf8-3c92-5d99-ae46-0a9d500b30e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f27eeb-6f14-4db3-adb9-9be5ed76b34b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f27eeb-6f14-4db3-adb9-9be5ed76b34b.jpg?1",
             "name": "Dark Ritual",
             "text": "Add {B}{B}{B} to your mana pool.",
             "colours": [
@@ -2774,7 +2774,7 @@
         },
         {
             "id": "b93bd88b-ba97-5ee8-90ad-af4e492a4bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbdf30e-effe-4008-ba9d-2157f6d21f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbdf30e-effe-4008-ba9d-2157f6d21f55.jpg?1",
             "name": "Deadly Designs",
             "text": "{2}: Put a plot counter on Deadly Designs. Any player may activate this ability.\nWhen there are five or more plot counters on Deadly Designs, sacrifice it. If you do, destroy up to two target creatures.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "91b29d94-dd0e-5567-8944-af8d09dc9d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426aeebc-3ff5-411d-b123-49a42e57e9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426aeebc-3ff5-411d-b123-49a42e57e9de.jpg?1",
             "name": "Death's-Head Buzzard",
             "text": "Flying\nWhen Death's-Head Buzzard dies, all creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "11acebd0-1432-5be6-ac70-bc9c98c57ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4992d2-8664-4179-a3f3-bfb2166484dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4992d2-8664-4179-a3f3-bfb2166484dd.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "14386065-4acf-5a84-8af8-83f3b24baee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69a1a58-6aab-4feb-850c-31fd2220bbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69a1a58-6aab-4feb-850c-31fd2220bbc0.jpg?1",
             "name": "Dirge of Dread",
             "text": "All creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)\nWhen you cycle Dirge of Dread, you may have target creature gain fear until end of turn.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "7a888e60-7991-5711-9d83-da9828b40965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a6be4-c9fa-4154-9e91-22eb939bfc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a6be4-c9fa-4154-9e91-22eb939bfc4f.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "68534bac-75d1-5e27-af48-99625ed58591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c73755-9678-467a-abd5-f8dd1556864e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c73755-9678-467a-abd5-f8dd1556864e.jpg?1",
             "name": "Doomsday",
             "text": "Search your library and graveyard for five cards and exile the rest. Put the chosen cards on top of your library in any order. You lose half your life, rounded up.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "31380b1d-7cd4-59d7-8f42-0efc59a8a654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9ef61-1c6d-49d1-b185-2b022482b442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9ef61-1c6d-49d1-b185-2b022482b442.jpg?1",
             "name": "Dusk Legion Zealot",
             "text": "When Dusk Legion Zealot enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "736514e3-5eb6-5751-9ee1-65fd43514311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29d88ad-5074-4f37-bb6a-2a7fe75c5771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29d88ad-5074-4f37-bb6a-2a7fe75c5771.jpg?1",
             "name": "Erg Raiders",
             "text": "At the beginning of your end step, if Erg Raiders didn't attack this turn, Erg Raiders deals 2 damage to you unless it came under your control this turn.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "992b0bcb-00a3-57b7-b62e-81a7cc4fb0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3baa621-1b50-4a7f-9ed4-4ae0e0e9e4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3baa621-1b50-4a7f-9ed4-4ae0e0e9e4e7.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "ff0353b4-4275-55f5-9e00-155add0f354d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a65ccf-37b6-48a3-9873-7a4cafef27cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a65ccf-37b6-48a3-9873-7a4cafef27cb.jpg?1",
             "name": "Hell's Caretaker",
             "text": "{T}, Sacrifice a creature: Return target creature card from your graveyard to the battlefield. Activate this ability only during your upkeep.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "4d8a30bc-8a79-57bc-bdec-9e7f64a4ceda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1f0958-5bf6-4a4f-a4bc-2943c93ba15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1f0958-5bf6-4a4f-a4bc-2943c93ba15e.jpg?1",
             "name": "Horror of the Broken Lands",
             "text": "Whenever you cycle or discard another card, Horror of the Broken Lands gets +2/+1 until end of turn.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "ca565281-e390-5763-9cd7-3a28816fe0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff128110-b87e-451c-a51d-9f116892e482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff128110-b87e-451c-a51d-9f116892e482.jpg?1",
             "name": "Ihsan's Shade",
             "text": "Protection from white",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "1aa8c5cf-9240-5d5d-8b56-4f5402083622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7ed355-894a-4592-9a64-ef061550d560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7ed355-894a-4592-9a64-ef061550d560.jpg?1",
             "name": "Laquatus's Champion",
             "text": "When Laquatus's Champion enters the battlefield, target player loses 6 life.\nWhen Laquatus's Champion leaves the battlefield, that player gains 6 life.\n{B}: Regenerate Laquatus's Champion.",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "e728eb32-6c88-5390-8a61-2bcbc5f8bb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2be583-2fa4-4ffe-9d89-c48a43d78a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2be583-2fa4-4ffe-9d89-c48a43d78a4e.jpg?1",
             "name": "Living Death",
             "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "49485f8b-7bc4-5711-8322-36b2f6506e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864930ce-7c56-4ad2-9b90-57b10e5a0842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864930ce-7c56-4ad2-9b90-57b10e5a0842.jpg?1",
             "name": "Mesmeric Fiend",
             "text": "When Mesmeric Fiend enters the battlefield, target opponent reveals his or her hand and you choose a nonland card from it. Exile that card.\nWhen Mesmeric Fiend leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -3279,7 +3279,7 @@
         },
         {
             "id": "18ee7f27-c1d3-55b7-944f-73f50bfa890d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c5d614-7b7a-4768-8e81-707f1f6bb34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c5d614-7b7a-4768-8e81-707f1f6bb34f.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3311,7 +3311,7 @@
         },
         {
             "id": "1ae04b12-3e65-5080-b064-8006732d0132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9c29bf-a177-40d5-9ade-129221222900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9c29bf-a177-40d5-9ade-129221222900.jpg?1",
             "name": "Nezumi Cutthroat",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nNezumi Cutthroat can't block.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "007b621a-9bd2-5ae8-8b8c-48ab926ecff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3c258-5d30-490f-9127-83d93d276345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3c258-5d30-490f-9127-83d93d276345.jpg?1",
             "name": "Phyrexian Ghoul",
             "text": "Sacrifice a creature: Phyrexian Ghoul gets +2/+2 until end of turn.",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "2e4c2ee7-6581-56c4-a291-450dc941b8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf5cbe2-84fa-46f4-a4f2-97b48ddf2d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf5cbe2-84fa-46f4-a4f2-97b48ddf2d39.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "17d53f15-6969-5cff-b3b4-eee8bc674933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d21d0d-7de7-4f03-8663-002c9290512f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d21d0d-7de7-4f03-8663-002c9290512f.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "137651a6-d349-561c-a505-29c185ae4226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cb08a7-cfcf-49ee-948b-4be859c1d256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cb08a7-cfcf-49ee-948b-4be859c1d256.jpg?1",
             "name": "Ratcatcher",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nAt the beginning of your upkeep, you may search your library for a Rat card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "ae247bb4-0565-5226-9571-45ce39dcf36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4846664-4463-4521-bb3f-3a4d00fa418d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4846664-4463-4521-bb3f-3a4d00fa418d.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -3518,7 +3518,7 @@
         },
         {
             "id": "606dc666-5318-59c8-9e71-3387b808876f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f47b6e-9557-4853-b8d6-7602a91c59a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f47b6e-9557-4853-b8d6-7602a91c59a7.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -3552,7 +3552,7 @@
         },
         {
             "id": "0530a1a0-7ba1-53fa-9bb1-75d5954e3b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa1dc6-b2e7-457b-9ad4-d024f21e8888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa1dc6-b2e7-457b-9ad4-d024f21e8888.jpg?1",
             "name": "Returned Phalanx",
             "text": "Defender\n{1}{U}: Returned Phalanx can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "0c3b767a-3b0b-5bb1-9d36-12eb337c8dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc78993c-ca67-43b3-a64d-ce0c3bc415bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc78993c-ca67-43b3-a64d-ce0c3bc415bc.jpg?1",
             "name": "Ruthless Ripper",
             "text": "Deathtouch\nMorph\u2014\nReveal a black card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Ruthless Ripper is turned face up, target player loses 2 life.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "8378b0fc-758a-5dbe-92d3-0b0032d9e6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81c6c07-0a76-4e43-a2ef-45ccffa7b0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81c6c07-0a76-4e43-a2ef-45ccffa7b0b8.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "09311699-945a-51be-9171-6931c711d482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f1b32-5546-40c5-9bfa-7af3dffb0a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f1b32-5546-40c5-9bfa-7af3dffb0a75.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "e51dcd48-fb42-53b3-941f-0218e9491d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813995f5-e49a-431d-8a3a-8ec569844e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813995f5-e49a-431d-8a3a-8ec569844e11.jpg?1",
             "name": "Triskaidekaphobia",
             "text": "At the beginning of your upkeep, choose one \u2014\n\u2022 Each player with exactly 13 life loses the game, then each player gains 1 life.\n\u2022 Each player with exactly 13 life loses the game, then each player loses 1 life.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "2e04d78f-d88d-52db-b455-b81ab1f354ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c276c8a7-2874-4ecb-9489-b1923d289510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c276c8a7-2874-4ecb-9489-b1923d289510.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -3756,7 +3756,7 @@
         },
         {
             "id": "7847db74-ebb4-5eda-adf6-be405484c397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bad2f48-9aa9-4f38-a22f-9b4802d0ee7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bad2f48-9aa9-4f38-a22f-9b4802d0ee7f.jpg?1",
             "name": "Undead Gladiator",
             "text": "{1}{B}, Discard a card: Return Undead Gladiator from your graveyard to your hand. Activate this ability only during your upkeep.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3791,7 +3791,7 @@
         },
         {
             "id": "fd9682a8-432c-506c-843b-8d3b39b3ee95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed268699-e1cc-4742-b19f-7f0ceaed2733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed268699-e1cc-4742-b19f-7f0ceaed2733.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3823,7 +3823,7 @@
         },
         {
             "id": "737f1e6d-fdc2-5b5e-a029-fd4aafc6fd75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c947c96-b4a5-4c3b-aacb-85ee0bf3afda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c947c96-b4a5-4c3b-aacb-85ee0bf3afda.jpg?1",
             "name": "Vampire Lacerator",
             "text": "At the beginning of your upkeep, you lose 1 life unless an opponent has 10 or less life.",
             "colours": [
@@ -3858,7 +3858,7 @@
         },
         {
             "id": "9a78c837-d705-53f7-8f69-be1591f9bb03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a1cd2-6778-45bb-84b8-4a9958cf10d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a1cd2-6778-45bb-84b8-4a9958cf10d7.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying\n{B}: Regenerate Will-o'-the-Wisp.",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "f83536e3-6b5a-5abd-b77c-30a3a8ed6437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9aa95-a8d5-42e6-b92e-b25b04b9ce8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9aa95-a8d5-42e6-b92e-b25b04b9ce8a.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3924,7 +3924,7 @@
         },
         {
             "id": "07c28e35-2175-5aa1-8e10-53163c57252d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43a15b7-e013-4353-8643-cbcc8263714e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43a15b7-e013-4353-8643-cbcc8263714e.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "0b714dd5-854d-5dbf-9911-8ddf79e77ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e05fce1-0092-497d-9b43-a130fea0e06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e05fce1-0092-497d-9b43-a130fea0e06c.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "f4e81d97-3c32-5a72-92a2-72283a999298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d471a-801e-4d79-8f5e-bc621868fa05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d471a-801e-4d79-8f5e-bc621868fa05.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "Akroma, Angel of Fury can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "d01abff4-c754-5c12-acd0-03f04c0ddca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f853-4afb-4a91-8b4c-0d647ce9c216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f853-4afb-4a91-8b4c-0d647ce9c216.jpg?1",
             "name": "Balduvian Horde",
             "text": "When Balduvian Horde enters the battlefield, sacrifice it unless you discard a card at random.",
             "colours": [
@@ -4063,7 +4063,7 @@
         },
         {
             "id": "0f1a3c09-a53a-5754-b378-a4d915ebad63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635f581e-3954-4e46-82ff-ca2de3d64af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635f581e-3954-4e46-82ff-ca2de3d64af6.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample, haste\nAt the beginning of the end step, sacrifice Ball Lightning.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "6473f08c-e611-54ce-9103-b7aa7c12f8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50988ad-a7dc-4ae3-bdd7-c4d6d3789bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50988ad-a7dc-4ae3-bdd7-c4d6d3789bf2.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "b9a6e006-3ace-5e99-bd30-27060209dc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e9f60-f8ea-4f29-b7e2-ca87f8336fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e9f60-f8ea-4f29-b7e2-ca87f8336fca.jpg?1",
             "name": "Browbeat",
             "text": "Any player may have Browbeat deal 5 damage to him or her. If no one does, target player draws three cards.",
             "colours": [
@@ -4161,7 +4161,7 @@
         },
         {
             "id": "70336e3c-a787-52a2-801c-37c25a62cd96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7be4d-e3e7-4dd4-99f9-d7bfe3ad1614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7be4d-e3e7-4dd4-99f9-d7bfe3ad1614.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4193,7 +4193,7 @@
         },
         {
             "id": "dce8e228-2e2a-566d-9c96-d7cd509f5b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a32ab2-cc55-43fb-82d8-c51a3849b344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a32ab2-cc55-43fb-82d8-c51a3849b344.jpg?1",
             "name": "Chartooth Cougar",
             "text": "{R}: Chartooth Cougar gets +1/+0 until end of turn.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "76212181-aaac-564e-86f2-07b700e6a2b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a5856-b8a4-445a-93d2-f3869a03031f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a5856-b8a4-445a-93d2-f3869a03031f.jpg?1",
             "name": "Cinder Storm",
             "text": "Cinder Storm deals 7 damage to target creature or player.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "3340e79c-5ee3-5d11-a370-6c673a0a411c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f544fa-170f-4da4-bd28-72f713a045ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f544fa-170f-4da4-bd28-72f713a045ba.jpg?1",
             "name": "Crimson Mage",
             "text": "{R}: Target creature you control gains haste until end of turn.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "46669750-20d3-58c4-b834-1afb6814f554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183ef738-0559-49ca-85b4-e6836521f203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183ef738-0559-49ca-85b4-e6836521f203.jpg?1",
             "name": "Eidolon of the Great Revel",
             "text": "Whenever a player casts a spell with converted mana cost 3 or less, Eidolon of the Great Revel deals 2 damage to that player.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "1171244e-8363-537a-8cb5-c088ddadc5c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623fbebb-a43a-487b-a8f6-57781e5d5199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623fbebb-a43a-487b-a8f6-57781e5d5199.jpg?1",
             "name": "Enthralling Victor",
             "text": "When Enthralling Victor enters the battlefield, gain control of target creature an opponent controls with power 2 or less until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "61236f07-99ad-5653-b9e6-d94a35a71a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9700b3c-c309-4305-8761-3cf3ec902639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9700b3c-c309-4305-8761-3cf3ec902639.jpg?1",
             "name": "Fortune Thief",
             "text": "Damage that would reduce your life total to less than 1 reduces it to 1 instead.\nMorph {R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4400,7 +4400,7 @@
         },
         {
             "id": "545f818e-76f5-5877-8d04-8df962c80b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b95c20-552a-41b9-8e65-bee9019d987f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b95c20-552a-41b9-8e65-bee9019d987f.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "2b2b6eff-585d-5c90-9773-c0414e6b0ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777cc6bb-638c-4535-8072-f8a2a1ba5b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777cc6bb-638c-4535-8072-f8a2a1ba5b45.jpg?1",
             "name": "Genju of the Spires",
             "text": "Enchant Mountain\n{2}: Enchanted Mountain becomes a 6/1 red Spirit creature until end of turn. It's still a land.\nWhen enchanted Mountain is put into a graveyard, you may return Genju of the Spires from your graveyard to your hand.",
             "colours": [
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "baea9eca-fd81-5ae8-adf3-85e8e5c69a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d18b250-cbfb-4248-96c6-c1b36f8299b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d18b250-cbfb-4248-96c6-c1b36f8299b8.jpg?1",
             "name": "Goblin War Drums",
             "text": "Creatures you control have menace.",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "b89eb386-4487-5f63-afe7-45c7a12a088d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4138531-ef42-4c56-864e-d3525a4f2082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4138531-ef42-4c56-864e-d3525a4f2082.jpg?1",
             "name": "Hordeling Outburst",
             "text": "Create three 1/1 red Goblin creature tokens.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "e17695d9-dfd5-5f42-a8e5-4d88e673db96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63be8070-b64d-443d-a00e-6495258688c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63be8070-b64d-443d-a00e-6495258688c7.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "4ade0c2f-99ee-5df4-9ec9-25ba1e730d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca0bc75-00a6-429a-bac9-5296e3146709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca0bc75-00a6-429a-bac9-5296e3146709.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "ff020c1a-d9e9-5ca5-9f67-2be10d7199d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea54760c-2cd3-43eb-bc45-adc0997b34b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea54760c-2cd3-43eb-bc45-adc0997b34b0.jpg?1",
             "name": "Ire Shaman",
             "text": "Menace\nMegamorph {R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ire Shaman is turned face up, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "09bde164-70f3-50b1-a93a-731cb03884f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc8fd50-b3be-49b0-9209-f5ce82d9868e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc8fd50-b3be-49b0-9209-f5ce82d9868e.jpg?1",
             "name": "Izzet Chemister",
             "text": "Haste\n{R}, {T}: Exile target instant or sorcery card from your graveyard.\n{1}{R}, {T}, Sacrifice Izzet Chemister: Cast any number of cards exiled with Izzet Chemister without paying their mana costs.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "ad349082-aed3-5dda-80fe-c9b68647e408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8743b2-30e3-4d15-89fc-72974747aec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8743b2-30e3-4d15-89fc-72974747aec5.jpg?1",
             "name": "Jackal Pup",
             "text": "Whenever Jackal Pup is dealt damage, it deals that much damage to you.",
             "colours": [
@@ -4707,7 +4707,7 @@
         },
         {
             "id": "77d44517-67d7-568f-9b06-4a089eb0b6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687518f-73ff-4813-a56f-5b5cc4f36e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687518f-73ff-4813-a56f-5b5cc4f36e7a.jpg?1",
             "name": "Kindle",
             "text": "Kindle deals X damage to target creature or player, where X is 2 plus the number of cards named Kindle in all graveyards.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "88d7451f-97a3-51cc-8e8e-722c951d783b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3285e6b-3e79-4d7c-bf96-d920f973b122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3285e6b-3e79-4d7c-bf96-d920f973b122.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "1454d3cc-e812-5914-8426-4d2969bf0971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b6dde7-77b7-4993-b983-4beb110b2d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b6dde7-77b7-4993-b983-4beb110b2d83.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards his or her hand, then draws seven cards.",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "498f983d-f71f-5f4c-9a2a-f1784b906454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507a123-cf1a-42e1-a8fa-221960c48c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507a123-cf1a-42e1-a8fa-221960c48c16.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies can't attack or block alone.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "22623546-4df3-5b6e-b615-b387b01059f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded44c07-ef04-4c2d-9b8d-5474de9d2ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded44c07-ef04-4c2d-9b8d-5474de9d2ec3.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "280c8a45-d4d7-59d7-ba57-d2744e98b92c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd970484-49b3-442a-806a-cabc56526ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd970484-49b3-442a-806a-cabc56526ee1.jpg?1",
             "name": "Pyre Hound",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on Pyre Hound.",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "ba39d106-f2eb-5603-aab2-1feff2623e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8f3b5e-71b4-42e0-9ddb-630e3dcf1be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8f3b5e-71b4-42e0-9ddb-630e3dcf1be7.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "a8550b67-801f-58ff-9641-d62089e4a2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a45e9b-699e-425a-9f3d-267274830d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a45e9b-699e-425a-9f3d-267274830d3e.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target blue spell.\n\u2022 Destroy target blue permanent.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "75138bb9-25b3-56b7-88ff-641e16eb2845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1ac65-aed8-4ac6-ba90-e088db6c1389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1ac65-aed8-4ac6-ba90-e088db6c1389.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "Exile Simian Spirit Guide from your hand: Add {R} to your mana pool.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "81d45be8-7e13-54dd-b089-fda2aee3675b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ce40e-23e3-47e7-a900-c77c12f122a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ce40e-23e3-47e7-a900-c77c12f122a5.jpg?1",
             "name": "Skeletonize",
             "text": "Skeletonize deals 3 damage to target creature. When a creature dealt damage this way dies this turn, create a 1/1 black Skeleton creature token with \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "ad1b7117-27e6-51d0-8e51-8a2331ce3d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259a6b6d-368a-4ee0-b0ed-b52301bfd78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259a6b6d-368a-4ee0-b0ed-b52301bfd78f.jpg?1",
             "name": "Skirk Commando",
             "text": "Whenever Skirk Commando deals combat damage to a player, you may have it deal 2 damage to target creature that player controls.\nMorph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "95e33f59-d967-53ba-8664-e7e6e4c54375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c52c8-a2c3-4f48-a5c3-2db92011e0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c52c8-a2c3-4f48-a5c3-2db92011e0cc.jpg?1",
             "name": "Soulbright Flamekin",
             "text": "{2}: Target creature gains trample until end of turn. If this is the third time this ability has resolved this turn, you may add {R}{R}{R}{R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "602de6fc-286a-594e-bc6b-3029bfc5ee0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b2651d-6418-42c6-abf4-e8cdb977833f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b2651d-6418-42c6-abf4-e8cdb977833f.jpg?1",
             "name": "Spikeshot Goblin",
             "text": "{R}, {T}: Spikeshot Goblin deals damage equal to its power to target creature or player.",
             "colours": [
@@ -5143,7 +5143,7 @@
         },
         {
             "id": "a712ff17-161d-556d-91b5-bbb43aacfd28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff0d9ba-100a-4f4a-b04b-1382ed912eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff0d9ba-100a-4f4a-b04b-1382ed912eaa.jpg?1",
             "name": "Thresher Lizard",
             "text": "Thresher Lizard gets +1/+2 as long as you have one or fewer cards in hand.",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "827c992c-59d1-59d3-8ecc-c7f02612978d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3e8c1c-481e-4f90-8eeb-29584d157f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3e8c1c-481e-4f90-8eeb-29584d157f1f.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5209,7 +5209,7 @@
         },
         {
             "id": "26fd6533-ed6c-544f-b02d-090dbad640bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b3375-f937-4d53-afa2-0711d8e59379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b3375-f937-4d53-afa2-0711d8e59379.jpg?1",
             "name": "Uncaged Fury",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "30d4d791-2d56-537e-86c8-e3d24f8d406b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa36309-4bcc-4455-813a-c0243b906792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa36309-4bcc-4455-813a-c0243b906792.jpg?1",
             "name": "Zada, Hedron Grinder",
             "text": "Whenever you cast an instant or sorcery spell that targets only Zada, Hedron Grinder, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "8119b27e-44e2-552d-8d6b-d0304fad978c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993399a-da99-4226-815c-55222684dfd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993399a-da99-4226-815c-55222684dfd8.jpg?1",
             "name": "Ainok Survivalist",
             "text": "Megamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ainok Survivalist is turned face up, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "5ac2489a-a5d0-50e6-9c4d-02feefc4629a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c05b3-ea23-477c-8a55-370cb6ae0941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c05b3-ea23-477c-8a55-370cb6ae0941.jpg?1",
             "name": "Ambassador Oak",
             "text": "When Ambassador Oak enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -5348,7 +5348,7 @@
         },
         {
             "id": "f5677206-e057-5b1b-9069-449e268d0857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea4a23-63fa-4d3d-90e3-c007ba0c0e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea4a23-63fa-4d3d-90e3-c007ba0c0e78.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "b959df3c-2bcd-5fcc-bfa5-20f937345d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81165e-f091-4211-8b47-5ea6868b0d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81165e-f091-4211-8b47-5ea6868b0d4c.jpg?1",
             "name": "Arbor Elf",
             "text": "{T}: Untap target Forest.",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "725a4c08-5b33-524d-b33c-5c4c4d589cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc38affd-b51d-4ea4-8198-d121c24ee5cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc38affd-b51d-4ea4-8198-d121c24ee5cf.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "dd8cd893-48bd-530e-9e03-149567c267a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b795f9-ee23-490b-af3d-de394ec07161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b795f9-ee23-490b-af3d-de394ec07161.jpg?1",
             "name": "Broodhatch Nantuko",
             "text": "Whenever Broodhatch Nantuko is dealt damage, you may create that many 1/1 green Insect creature tokens.\nMorph {2}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "30fe9cf6-a816-568d-96b5-dd83df74b67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0f3faf-c011-49b8-b604-d68a87615737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0f3faf-c011-49b8-b604-d68a87615737.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "c15cc5e9-e78c-5ae0-a433-e3839ee91102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8683a978-1bef-4b01-9361-56b1fc157d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8683a978-1bef-4b01-9361-56b1fc157d26.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library if it's a land card.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -5556,7 +5556,7 @@
         },
         {
             "id": "ae6eb4d0-b127-5e11-a8e5-01f7bca9fdf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419c85-c476-42b8-979f-143b45c6819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419c85-c476-42b8-979f-143b45c6819b.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "b380c3ba-e60d-5f54-815b-895707584ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04367e72-3f8c-4cba-8bdf-5a1ba9c9f01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04367e72-3f8c-4cba-8bdf-5a1ba9c9f01f.jpg?1",
             "name": "Echoing Courage",
             "text": "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
             "colours": [
@@ -5620,7 +5620,7 @@
         },
         {
             "id": "57c4f647-ed33-5c0a-93d6-bae1d326d3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a51425-d796-48b8-b68c-bc21fb465c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a51425-d796-48b8-b68c-bc21fb465c81.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G} to your mana pool.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "43a1476a-5993-5684-9f62-1ba41f324ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e47b9-6735-4e46-b3fd-ac69edc39745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e47b9-6735-4e46-b3fd-ac69edc39745.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "888c1784-cb44-53f1-a251-8192828e6bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3215b51-01df-4670-994d-b4d7a57b80f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3215b51-01df-4670-994d-b4d7a57b80f8.jpg?1",
             "name": "Ember Weaver",
             "text": "Reach\nAs long as you control a red permanent, Ember Weaver gets +1/+0 and has first strike.",
             "colours": [
@@ -5724,7 +5724,7 @@
         },
         {
             "id": "32f4b8c4-1cba-514e-b167-d1900896e531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ac4e89-d5fa-4f1b-bd61-be15eb322f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ac4e89-d5fa-4f1b-bd61-be15eb322f40.jpg?1",
             "name": "Epic Confrontation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control.",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "5f0a1f9b-7da2-5aaa-8db8-a70a3bda4601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c2fdf5-2cff-4c27-875f-450cc382fe8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c2fdf5-2cff-4c27-875f-450cc382fe8c.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "37eba0cc-2e11-5d9d-96a3-0b60bbf18aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b712e6e-eb48-4a71-b95d-ce343966b236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b712e6e-eb48-4a71-b95d-ce343966b236.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5822,7 +5822,7 @@
         },
         {
             "id": "c4e338d2-e574-5db7-9db2-9ca14cf947e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678c71b-585b-41ba-a038-8027f818e839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678c71b-585b-41ba-a038-8027f818e839.jpg?1",
             "name": "Invigorate",
             "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "8036298f-c426-53d8-ab1b-318f911e9e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c05f3bf-5785-4a53-9c34-cffd7783d107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c05f3bf-5785-4a53-9c34-cffd7783d107.jpg?1",
             "name": "Iwamori of the Open Fist",
             "text": "Trample\nWhen Iwamori of the Open Fist enters the battlefield, each opponent may put a legendary creature card from his or her hand onto the battlefield.",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "45184045-287d-5d61-bf06-3a45fff5f02f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da95f41d-ad5a-4861-94e2-a564dbf4f3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da95f41d-ad5a-4861-94e2-a564dbf4f3c9.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber enters the battlefield, draw a card.",
             "colours": [
@@ -5925,7 +5925,7 @@
         },
         {
             "id": "3e99907a-55c3-505c-b661-6b4be77f0c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8728ed5-02cc-4094-9278-48d22f9568dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8728ed5-02cc-4094-9278-48d22f9568dc.jpg?1",
             "name": "Kavu Predator",
             "text": "Trample\nWhenever an opponent gains life, put that many +1/+1 counters on Kavu Predator.",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "e8b4c834-0f37-5086-996f-33c4a9c26e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f41b01b-0c19-4f3f-93e5-d3df52fdd576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f41b01b-0c19-4f3f-93e5-d3df52fdd576.jpg?1",
             "name": "Krosan Colossus",
             "text": "Morph {6}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5993,7 +5993,7 @@
         },
         {
             "id": "fb984c2b-8c80-5703-8d31-cb49e0e69c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ab2ac7-f6bd-4f47-8bd4-128bf64f8768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ab2ac7-f6bd-4f47-8bd4-128bf64f8768.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle your library. (Do this before you draw.)",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "389a541e-237e-5211-bb02-e39b28198d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d505d319-093d-47af-8ee9-fafae3885aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d505d319-093d-47af-8ee9-fafae3885aa0.jpg?1",
             "name": "Living Wish",
             "text": "You may choose a creature or land card you own from outside the game, reveal that card, and put it into your hand. Exile Living Wish.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "0a52d36c-b2b7-5394-b82f-ef646aaff8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb38b2-3eba-4b2e-b5d8-58e9ad799d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb38b2-3eba-4b2e-b5d8-58e9ad799d1f.jpg?1",
             "name": "Lull",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "fc012bfd-64de-542a-999a-2a1ab163c1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c56fda1-d286-46b1-9617-4f7c430abb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c56fda1-d286-46b1-9617-4f7c430abb79.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "At the beginning of your upkeep, create a 2/2 green Wolf creature token.\n{T}: Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves.",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "80242932-23d6-557a-809b-db244a38705d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f290ed2-d1a8-4a90-a3a7-8240652dc109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f290ed2-d1a8-4a90-a3a7-8240652dc109.jpg?1",
             "name": "Nettle Sentinel",
             "text": "Nettle Sentinel doesn't untap during your untap step.\nWhenever you cast a green spell, you may untap Nettle Sentinel.",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "562f9059-38f3-56ab-bc2c-c43797dd7ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8abe42-32c2-41c5-b2ea-f1fb51fc5629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8abe42-32c2-41c5-b2ea-f1fb51fc5629.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "658df6d5-3752-5dd7-a26c-baf5e0491c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922cf7de-3c37-4f4d-ae1a-7a14234a6dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922cf7de-3c37-4f4d-ae1a-7a14234a6dab.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Create a 1/1 green Elf Warrior creature token.\"",
             "colours": [
@@ -6228,7 +6228,7 @@
         },
         {
             "id": "1682dd99-ad66-5481-9a87-94f4a1548d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f0c4714-b9cd-48a3-8a2a-72860d0ac000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f0c4714-b9cd-48a3-8a2a-72860d0ac000.jpg?1",
             "name": "Protean Hulk",
             "text": "When Protean Hulk dies, search your library for any number of creature cards with total converted mana cost 6 or less and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "6b7347b3-a8a5-5039-9609-08e1882eb912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4d8527-af29-408d-a3a3-6781db0cf439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4d8527-af29-408d-a3a3-6781db0cf439.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -6296,7 +6296,7 @@
         },
         {
             "id": "8455a8aa-ee01-5f1e-9a81-760ed8d0a445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb187bce-54fe-4adb-bf67-ad588d38ee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb187bce-54fe-4adb-bf67-ad588d38ee66.jpg?1",
             "name": "Regrowth",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "0f0d2d5d-8bd0-5ca7-aeba-5b63f7b8aa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35390394-013f-4996-9d1a-e4c53de941ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35390394-013f-4996-9d1a-e4c53de941ba.jpg?1",
             "name": "Stampede Driver",
             "text": "{1}{G}, {T}, Discard a card: Creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -6363,7 +6363,7 @@
         },
         {
             "id": "f0539351-4d80-550f-ba7d-f5585ef587e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4550b26a-3a73-4724-99d5-1e0a52c36701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4550b26a-3a73-4724-99d5-1e0a52c36701.jpg?1",
             "name": "Summoner's Pact",
             "text": "Search your library for a green creature card, reveal it, put it into your hand, then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "eb987b52-cfc8-5eff-bdf2-476453d36dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3d1b54-ceef-425d-a349-80a49ac5d879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3d1b54-ceef-425d-a349-80a49ac5d879.jpg?1",
             "name": "Timberpack Wolf",
             "text": "Timberpack Wolf gets +1/+1 for each other creature you control named Timberpack Wolf.",
             "colours": [
@@ -6429,7 +6429,7 @@
         },
         {
             "id": "106d8207-2525-5cf5-b57e-8167ae21ccb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39cc3c8-79c2-4593-8340-c3285f3a4c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39cc3c8-79c2-4593-8340-c3285f3a4c3a.jpg?1",
             "name": "Tree of Redemption",
             "text": "Defender\n{T}: Exchange your life total with Tree of Redemption's toughness.",
             "colours": [
@@ -6463,7 +6463,7 @@
         },
         {
             "id": "c243f49e-ea0d-5764-b4ec-d09761e1a435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625580-3cbd-459c-a667-87efdcdaf2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625580-3cbd-459c-a667-87efdcdaf2b2.jpg?1",
             "name": "Utopia Sprawl",
             "text": "Enchant Forest\nAs Utopia Sprawl enters the battlefield, choose a color.\nWhenever enchanted Forest is tapped for mana, its controller adds one mana of the chosen color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -6497,7 +6497,7 @@
         },
         {
             "id": "d0f3a062-b4fb-589d-a757-9ba050605b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d502ecf-b3a5-4657-8718-104e8f0ab9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d502ecf-b3a5-4657-8718-104e8f0ab9af.jpg?1",
             "name": "Vessel of Nascency",
             "text": "{1}{G}, Sacrifice Vessel of Nascency: Reveal the top four cards of your library. You may put an artifact, creature, enchantment, land, or planeswalker card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "ed96a192-54f2-5303-bdfc-d32669fac8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07e9ea5-0e50-4efc-a294-06aedc19de65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07e9ea5-0e50-4efc-a294-06aedc19de65.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "59fd94b5-aea6-5ad7-97f2-698caf224b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ea1434-16c4-4b1a-8728-806360131587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ea1434-16c4-4b1a-8728-806360131587.jpg?1",
             "name": "Woolly Loxodon",
             "text": "Morph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6599,7 +6599,7 @@
         },
         {
             "id": "e6bfbfbd-9bc9-5788-9211-37a4e9c6bcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df98d4a-0f11-4064-a113-54ab14b9b3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df98d4a-0f11-4064-a113-54ab14b9b3eb.jpg?1",
             "name": "Animar, Soul of Elements",
             "text": "Protection from white and from black\nWhenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.\nCreature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "c71772e7-0497-5336-b8db-7a0b9c3b74c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100855e6-ac3e-481f-a462-afb5fcb5d476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100855e6-ac3e-481f-a462-afb5fcb5d476.jpg?1",
             "name": "Baloth Null",
             "text": "When Baloth Null enters the battlefield, return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -6676,7 +6676,7 @@
         },
         {
             "id": "6dc51b0d-c353-58f4-a817-29ab30f1bb58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf0f075-4401-41da-a17f-a209d6a03782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf0f075-4401-41da-a17f-a209d6a03782.jpg?1",
             "name": "Blightning",
             "text": "Blightning deals 3 damage to target player. That player discards two cards.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "1d3895f6-fc93-5387-825e-ad75a1d761d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e601a7-c542-4843-98c6-e0a38aaf6cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e601a7-c542-4843-98c6-e0a38aaf6cab.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014\n\u2022 Boros Charm deals 4 damage to target player.\n\u2022 Permanents you control gain indestructible until end of turn.\n\u2022 Target creature gains double strike until end of turn.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "eb4d3494-4399-539d-8aac-7ec38ad9e4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b097c70a-d1d6-4972-b94d-d7d8a6f443e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b097c70a-d1d6-4972-b94d-d7d8a6f443e2.jpg?1",
             "name": "Brion Stoutarm",
             "text": "Lifelink\n{R}, {T}, Sacrifice another creature: Brion Stoutarm deals damage equal to the sacrificed creature's power to target player.",
             "colours": [
@@ -6783,7 +6783,7 @@
         },
         {
             "id": "ec92d49c-7afa-5f7d-844a-7cc8e5056f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00b58c-785d-481d-9c8a-f329672a117f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00b58c-785d-481d-9c8a-f329672a117f.jpg?1",
             "name": "Cloudblazer",
             "text": "Flying\nWhen Cloudblazer enters the battlefield, you gain 2 life and draw two cards.",
             "colours": [
@@ -6820,7 +6820,7 @@
         },
         {
             "id": "414bfe34-a7e1-5de8-bc80-b50bce222149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83777ac9-93d9-4097-96ca-a8a6a79b84e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83777ac9-93d9-4097-96ca-a8a6a79b84e2.jpg?1",
             "name": "Conflux",
             "text": "Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "3b8e99e7-d8b7-5277-b7be-061c749ea188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42936b12-df0c-4332-a91f-2da2acc36dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42936b12-df0c-4332-a91f-2da2acc36dd7.jpg?1",
             "name": "Eladamri's Call",
             "text": "Search your library for a creature card, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "2ca198e7-8ea4-50ee-81c3-bdf170514d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d039ff5-907f-4c27-8941-83e5e75bd19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d039ff5-907f-4c27-8941-83e5e75bd19d.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "0d1ebaf1-3f77-5d10-876b-a3ba4b133f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19c383-88bd-4bde-ac81-c0eb6d5b5bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19c383-88bd-4bde-ac81-c0eb6d5b5bd4.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "Grenzo, Dungeon Warden enters the battlefield with X +1/+1 counters on it.\n{2}: Put the bottom card of your library into your graveyard. If it's a creature card with power less than or equal to Grenzo's power, put it onto the battlefield.",
             "colours": [
@@ -6971,7 +6971,7 @@
         },
         {
             "id": "c9763078-d9e8-5f38-870b-0a549a1858a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed9d83-cbf4-4ebe-af20-915752233fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed9d83-cbf4-4ebe-af20-915752233fc9.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -7010,7 +7010,7 @@
         },
         {
             "id": "54ee3de4-6488-577c-8853-cfe481f645c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae50a9a-1589-43fe-87a6-7b2c96745392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae50a9a-1589-43fe-87a6-7b2c96745392.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, you may put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -7046,7 +7046,7 @@
         },
         {
             "id": "87170beb-2a6d-56c6-b709-c2dcbd5e095e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4bacd1-b602-4bcc-9aea-1229949a7d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4bacd1-b602-4bcc-9aea-1229949a7d20.jpg?1",
             "name": "Mystic Snake",
             "text": "Flash\nWhen Mystic Snake enters the battlefield, counter target spell.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "2503411e-e8c0-509a-8284-98c62025dd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e92ba96-372c-418d-b271-45e1bf5c7af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e92ba96-372c-418d-b271-45e1bf5c7af5.jpg?1",
             "name": "Nicol Bolas",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Nicol Bolas unless you pay {U}{B}{R}.\nWhenever Nicol Bolas deals damage to an opponent, that player discards his or her hand.",
             "colours": [
@@ -7123,7 +7123,7 @@
         },
         {
             "id": "a52083a9-ae15-5c54-8fbd-7d63534fb5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029dd036-abda-4b5d-806d-8b39357edf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029dd036-abda-4b5d-806d-8b39357edf1e.jpg?1",
             "name": "Niv-Mizzet, the Firemind",
             "text": "Flying\nWhenever you draw a card, Niv-Mizzet, the Firemind deals 1 damage to target creature or player.\n{T}: Draw a card.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "71206f12-a91a-5bb3-89c7-c38aa94b181f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be530d89-6735-4bd3-9369-22432fe6affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be530d89-6735-4bd3-9369-22432fe6affb.jpg?1",
             "name": "Notion Thief",
             "text": "Flash\nIf an opponent would draw a card except the first one he or she draws in each of his or her draw steps, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -7199,7 +7199,7 @@
         },
         {
             "id": "7dff1d33-6976-5edc-91ca-2c3acfe6bbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8652e3a1-bcd4-4c0c-a085-34f19702df26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8652e3a1-bcd4-4c0c-a085-34f19702df26.jpg?1",
             "name": "Pernicious Deed",
             "text": "{X}, Sacrifice Pernicious Deed: Destroy each artifact, creature, and enchantment with converted mana cost X or less.",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "f35a62b2-1353-5a76-8df3-03ce995bbac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc97379-91aa-4bba-80af-8980eeb57630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc97379-91aa-4bba-80af-8980eeb57630.jpg?1",
             "name": "Pillory of the Sleepless",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"At the beginning of your upkeep, you lose 1 life.\"",
             "colours": [
@@ -7269,7 +7269,7 @@
         },
         {
             "id": "cee2f9b2-9147-52ab-bb64-86320112d376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889c1a0f-7df2-4497-8058-04358173d7e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889c1a0f-7df2-4497-8058-04358173d7e8.jpg?1",
             "name": "Prossh, Skyraider of Kher",
             "text": "Flying\nWhen you cast Prossh, Skyraider of Kher, create X 0/1 red Kobold creature tokens named Kobolds of Kher Keep, where X is the amount of mana spent to cast Prossh.\nSacrifice another creature: Prossh gets +1/+0 until end of turn.",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "251f3da8-48cf-55fd-9e08-ff3b8d95b19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a376f7a3-50fa-4be9-830c-102507682256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a376f7a3-50fa-4be9-830c-102507682256.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target player. You draw a card.\"",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "e19795b0-d09f-56f6-8109-6d1d9e22be3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59221f7c-c950-4d66-b166-a2d8f8d0e959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59221f7c-c950-4d66-b166-a2d8f8d0e959.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each combat if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "a0bfbb71-a550-5f4f-b842-21ccfeec7e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31120987-4b68-4d0e-917f-b8f2ca050090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31120987-4b68-4d0e-917f-b8f2ca050090.jpg?1",
             "name": "Shadowmage Infiltrator",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever Shadowmage Infiltrator deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -7421,7 +7421,7 @@
         },
         {
             "id": "6921cc3f-3cb8-511d-9625-e518701cac8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23f846e-b5e6-48c2-afea-c9be7fc8b7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23f846e-b5e6-48c2-afea-c9be7fc8b7c3.jpg?1",
             "name": "Stangg",
             "text": "When Stangg enters the battlefield, create a legendary 3/4 red and green Human Warrior creature token named Stangg Twin. Exile that token when Stangg leaves the battlefield. Sacrifice Stangg when that token leaves the battlefield.",
             "colours": [
@@ -7460,7 +7460,7 @@
         },
         {
             "id": "68b9188b-fddb-544d-976a-50d8398ae747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1658f12b-8ac5-4d29-86d5-f20c4d5f7e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1658f12b-8ac5-4d29-86d5-f20c4d5f7e48.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "9c69ff74-cf17-51d7-99c2-5217808578c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682af5e9-26b5-4f88-99e1-ab2aa34fba86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682af5e9-26b5-4f88-99e1-ab2aa34fba86.jpg?1",
             "name": "Watchwolf",
             "text": "",
             "colours": [
@@ -7530,7 +7530,7 @@
         },
         {
             "id": "dd08f688-a559-55b6-87b3-07220b2b20b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a288d2-de94-4c49-a17e-5b0ed0281a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a288d2-de94-4c49-a17e-5b0ed0281a5b.jpg?1",
             "name": "Assembly-Worker",
             "text": "{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -7561,7 +7561,7 @@
         },
         {
             "id": "3298e1e3-7d8a-5766-b796-59f04b9a7ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0d2e8e-c8f2-4b31-a6ba-6283fc8740d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0d2e8e-c8f2-4b31-a6ba-6283fc8740d4.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "544a848c-9f66-562d-bc77-966931a5cd2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c532e8-21f1-4d6f-a931-1ea48a6aeea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c532e8-21f1-4d6f-a931-1ea48a6aeea2.jpg?1",
             "name": "Coalition Relic",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color to your mana pool for each charge counter removed this way.",
             "colours": [],
@@ -7617,7 +7617,7 @@
         },
         {
             "id": "c8db9cf7-4609-5f66-b3a2-47a3641e06ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8dc8a5-3b53-4860-af60-6386e8c0010f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8dc8a5-3b53-4860-af60-6386e8c0010f.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -7645,7 +7645,7 @@
         },
         {
             "id": "04fc8717-0437-5eba-b6c0-7397c7b0e6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813fae24-ff38-45e8-8ab9-d539d4494435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813fae24-ff38-45e8-8ab9-d539d4494435.jpg?1",
             "name": "Heavy Arbalest",
             "text": "Equipped creature doesn't untap during its controller's untap step.\nEquipped creature has \"{T}: This creature deals 2 damage to target creature or player.\"\nEquip {4}",
             "colours": [],
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "cc7dafec-5283-59d7-a59f-ca33644f8246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5892a23-efae-4731-9b8f-41c87960fe93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5892a23-efae-4731-9b8f-41c87960fe93.jpg?1",
             "name": "Nihil Spellbomb",
             "text": "{T}, Sacrifice Nihil Spellbomb: Exile all cards from target player's graveyard.\nWhen Nihil Spellbomb is put into a graveyard from the battlefield, you may pay {B}. If you do, draw a card.",
             "colours": [],
@@ -7705,7 +7705,7 @@
         },
         {
             "id": "2352dea9-08dd-5e16-915e-439febcfd0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33823e16-810e-4138-950b-e18ef1204438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33823e16-810e-4138-950b-e18ef1204438.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr dies, it deals 2 damage to target creature or player.",
             "colours": [],
@@ -7737,7 +7737,7 @@
         },
         {
             "id": "8a9fe3b3-6f4a-5a34-ad58-e616d6fdb5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e51f1b3-d8a3-4746-b0db-67d5ec71fb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e51f1b3-d8a3-4746-b0db-67d5ec71fb17.jpg?1",
             "name": "Primal Clay",
             "text": "As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types.",
             "colours": [],
@@ -7768,7 +7768,7 @@
         },
         {
             "id": "a9f1d857-71aa-506f-a1e2-d615910a11be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecd6741-bab2-4921-b961-ea1584213558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecd6741-bab2-4921-b961-ea1584213558.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "6a25cce1-658c-5d71-ab3e-752e20109ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77812f-fe6c-4d26-9c34-c51cb05fd43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77812f-fe6c-4d26-9c34-c51cb05fd43a.jpg?1",
             "name": "Sai of the Shinobi",
             "text": "Equipped creature gets +1/+1.\nWhenever a creature enters the battlefield under your control, you may attach Sai of the Shinobi to it.\nEquip {2}",
             "colours": [],
@@ -7826,7 +7826,7 @@
         },
         {
             "id": "8a68e614-cdf5-589f-b010-dea4e25d6c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86ba613-29bd-45d8-b5ed-f8fe8323fe75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86ba613-29bd-45d8-b5ed-f8fe8323fe75.jpg?1",
             "name": "Self-Assembler",
             "text": "When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "7ebf6a23-8aa7-5a6e-b89c-2cf71f498749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccbd2c4-ffe0-4992-88d9-5be1adb3bda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccbd2c4-ffe0-4992-88d9-5be1adb3bda6.jpg?1",
             "name": "Strionic Resonator",
             "text": "{2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy.",
             "colours": [],
@@ -7885,7 +7885,7 @@
         },
         {
             "id": "b2fad72d-f89f-5cf7-b2b5-bf9030361e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0263c742-345b-4425-8326-75bfa60e08ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0263c742-345b-4425-8326-75bfa60e08ea.jpg?1",
             "name": "Sundering Titan",
             "text": "When Sundering Titan enters the battlefield or leaves the battlefield, choose a land of each basic land type, then destroy those lands.",
             "colours": [],
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "dd9a53c1-0f4a-5bd6-8e75-7741d7189d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae09e17-b881-492c-ba47-8f381c09755d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae09e17-b881-492c-ba47-8f381c09755d.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "b56e76b5-780c-5fbb-99ca-365e537ac432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fca48f-790e-4293-b456-84f36ca95924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fca48f-790e-4293-b456-84f36ca95924.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with converted mana cost 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -7977,7 +7977,7 @@
         },
         {
             "id": "6808b404-501f-5ea9-8927-0a73f3fd7993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f20e43-55f9-46a2-bee2-46a747584d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f20e43-55f9-46a2-bee2-46a747584d75.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C} to your mana pool.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [],
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "3fd09e7e-e707-52b5-82e7-75d763e37211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bd7f43-a0ed-4601-a6d8-f87e7bbd269d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bd7f43-a0ed-4601-a6d8-f87e7bbd269d.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {C} to your mana pool.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "ea3d087f-91e0-5538-935f-1785da6b5acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0547b3a-dc3e-42ba-bb80-1815ee62e9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0547b3a-dc3e-42ba-bb80-1815ee62e9f1.jpg?1",
             "name": "Fetid Heath",
             "text": "{T}: Add {C} to your mana pool.\n{WB}, {T}: Add {W}{W}, {W}{B}, or {B}{B} to your mana pool.",
             "colours": [],
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "a4653182-0d79-5bee-8e4a-17e3c00244b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9272917e-3ccd-4494-9e3f-91bc86b784d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9272917e-3ccd-4494-9e3f-91bc86b784d5.jpg?1",
             "name": "Flooded Grove",
             "text": "{T}: Add {C} to your mana pool.\n{GW}, {T}: Add {G}{G}, {G}{U}, or {U}{U} to your mana pool.",
             "colours": [],
@@ -8098,7 +8098,7 @@
         },
         {
             "id": "b12f74e7-f609-591c-9609-278cad688635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ef3b0-5b73-4bf2-bbae-0e419bd498c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ef3b0-5b73-4bf2-bbae-0e419bd498c9.jpg?1",
             "name": "Haunted Fengraf",
             "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
             "colours": [],
@@ -8126,7 +8126,7 @@
         },
         {
             "id": "c718ff20-21bf-5a9d-864e-807052d26a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7033a4c-a2de-45d0-a6a6-1db028baf40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7033a4c-a2de-45d0-a6a6-1db028baf40b.jpg?1",
             "name": "Mikokoro, Center of the Sea",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Each player draws a card.",
             "colours": [],
@@ -8156,7 +8156,7 @@
         },
         {
             "id": "bde5bcc7-7736-50c7-930b-63e050a09ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245cdc59-d560-4c10-b721-f51cc312e370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245cdc59-d560-4c10-b721-f51cc312e370.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -8184,7 +8184,7 @@
         },
         {
             "id": "9b09beac-2f0b-5200-b14e-72464b8c9184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f364d5-8257-4d5e-9ed9-d363a7fdaf16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f364d5-8257-4d5e-9ed9-d363a7fdaf16.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8212,7 +8212,7 @@
         },
         {
             "id": "7017e055-26da-508d-888f-40f6fc251cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf85879-4d14-4d86-978c-b155c47b7dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf85879-4d14-4d86-978c-b155c47b7dcd.jpg?1",
             "name": "Pendelhaven",
             "text": "{T}: Add {G} to your mana pool.\n{T}: Target 1/1 creature gets +1/+2 until end of turn.",
             "colours": [],
@@ -8244,7 +8244,7 @@
         },
         {
             "id": "07d64f06-e936-5609-891d-87b970f09c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce833a90-7c1d-4c05-ace3-57e974c0769b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce833a90-7c1d-4c05-ace3-57e974c0769b.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -8272,7 +8272,7 @@
         },
         {
             "id": "69b87a87-3cbf-5fa9-abe9-6438a59d4954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2507bc2-da17-4e46-b4c5-ba0080ce2c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2507bc2-da17-4e46-b4c5-ba0080ce2c6f.jpg?1",
             "name": "Rishadan Port",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Tap target land.",
             "colours": [],
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "e686fb05-d412-513e-8e78-164533aaa22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ccc48-879b-4ff0-81ed-66aa2843d286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ccc48-879b-4ff0-81ed-66aa2843d286.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {C} to your mana pool.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W} to your mana pool.",
             "colours": [],
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "e34ca8d2-5902-55be-af49-5c09dca7e346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f7d8f4-0452-4163-960c-499ce07933eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f7d8f4-0452-4163-960c-499ce07933eb.jpg?1",
             "name": "Twilight Mire",
             "text": "{T}: Add {C} to your mana pool.\n{BG}, {T}: Add {B}{B}, {B}{G}, or {G}{G} to your mana pool.",
             "colours": [],
@@ -8362,7 +8362,7 @@
         },
         {
             "id": "9f2e22bb-3613-523b-9256-09355ad48722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16964263-61fc-40f2-b206-4f69060affba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16964263-61fc-40f2-b206-4f69060affba.jpg?1",
             "name": "Zoetic Cavern",
             "text": "{T}: Add {C} to your mana pool.\nMorph {2} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "32016ad6-ef16-52de-854b-17f428fcaecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef264a95-afe4-4b8c-9648-e8f95bfaed2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef264a95-afe4-4b8c-9648-e8f95bfaed2a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -8420,7 +8420,7 @@
         },
         {
             "id": "a7aa4057-37c7-5ade-8897-7d6a2cffbef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1671013a-2c15-44f0-b4bc-057eb5f727db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1671013a-2c15-44f0-b4bc-057eb5f727db.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8454,7 +8454,7 @@
         },
         {
             "id": "35a7681e-d9c9-5147-bde8-e7353bf31a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227a4e23-ff87-486b-aba1-32f1d8c33592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227a4e23-ff87-486b-aba1-32f1d8c33592.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8488,7 +8488,7 @@
         },
         {
             "id": "55748f9d-28c4-5f68-8f42-8a7f8ad3381a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070b2ce3-33a7-42a5-b4c2-6b0ed2bf926a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070b2ce3-33a7-42a5-b4c2-6b0ed2bf926a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8522,7 +8522,7 @@
         },
         {
             "id": "aa821c4e-0561-5ad5-a9b3-c326a3bfcbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9badcaa0-8abb-4654-b947-b5ff254a8d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9badcaa0-8abb-4654-b947-b5ff254a8d19.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "dc740497-2711-5203-b204-272381eae905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg?1",
             "name": "Fish // Kraken",
             "text": "",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "5aac3b9e-2b4f-577d-8cac-47dcfbf2aa3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg?1",
             "name": "Fish // Kraken",
             "text": "",
             "colours": [
@@ -8624,7 +8624,7 @@
         },
         {
             "id": "87734902-9648-5791-873f-5c366c38aef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622397a1-6513-44b9-928a-388be06d4022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622397a1-6513-44b9-928a-388be06d4022.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "f08192e3-745c-5f8c-91c5-7da8649604af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3331a0-5840-439d-9553-d4489c343f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3331a0-5840-439d-9553-d4489c343f21.jpg?1",
             "name": "Whale",
             "text": "",
             "colours": [
@@ -8692,7 +8692,7 @@
         },
         {
             "id": "fbda3073-ceef-5d65-8622-e2185199b506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb1ab0-f8f4-44e8-b8a7-df37a8782e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb1ab0-f8f4-44e8-b8a7-df37a8782e76.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -8726,7 +8726,7 @@
         },
         {
             "id": "0b453fff-0b78-54f9-894c-d7c1398dc3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7913ab41-f5d1-43d3-85e3-451befc97753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7913ab41-f5d1-43d3-85e3-451befc97753.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8760,7 +8760,7 @@
         },
         {
             "id": "ce3f64ac-f4d1-5c1e-bda1-bcb0bcf376d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc03591-1114-4e36-a397-0bb3db8a153c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc03591-1114-4e36-a397-0bb3db8a153c.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -8794,7 +8794,7 @@
         },
         {
             "id": "cbb556b6-7460-520e-ae74-94492cb0646d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ed4bf-b276-45ed-b44d-c757e9c25846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ed4bf-b276-45ed-b44d-c757e9c25846.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -8829,7 +8829,7 @@
         },
         {
             "id": "0a6d2b2d-3dc9-5175-9e18-dbf1463d8124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d7c6dc-4d0b-4a05-8b79-5dd728a74bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d7c6dc-4d0b-4a05-8b79-5dd728a74bb3.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8863,7 +8863,7 @@
         },
         {
             "id": "0fda6a57-5bf8-5a18-aaca-152041cb86c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff5727c-7001-45db-9e0c-771824e849b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff5727c-7001-45db-9e0c-771824e849b0.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8897,7 +8897,7 @@
         },
         {
             "id": "382fab3e-a008-5648-a93c-23591b97da58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba90d37-d7ac-4097-a04d-1f27e4c9e5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba90d37-d7ac-4097-a04d-1f27e4c9e5de.jpg?1",
             "name": "Stangg Twin",
             "text": "",
             "colours": [
@@ -8936,7 +8936,7 @@
         },
         {
             "id": "0d854bcb-6335-5040-a1e6-3f19a590a625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0b42a0-5e08-406d-82b0-be5f72870c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0b42a0-5e08-406d-82b0-be5f72870c47.jpg?1",
             "name": "Morph",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ACR.json
+++ b/Assets/Resources/Sets/ACR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d1c00a42-14a5-5480-a704-b1c457f177db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1b63ce-47d3-4633-9062-3fecd810e85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1b63ce-47d3-4633-9062-3fecd810e85f.jpg?1",
             "name": "The Capitoline Triad",
             "text": "Those Who Came Before \u2014 This spell costs {1} less to cast for each historic card in your graveyard. (Artifacts, legendaries, and Sagas are historic.)\nExile any number of historic cards from your graveyard with total mana value 30 or greater: You get an emblem with \"Creatures you control have base power and toughness 9/9.\"",
             "colours": [],
@@ -40,7 +40,7 @@
         },
         {
             "id": "c74344f2-826e-58de-8f98-b27a5937bd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60f18e-4709-4b91-a342-74eb3fca71e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60f18e-4709-4b91-a342-74eb3fca71e1.jpg?1",
             "name": "Caduceus, Staff of Hermes",
             "text": "Equipped creature has lifelink.\nAs long as you have 30 or more life, equipped creature gets +5/+5 and has indestructible and \"Prevent all damage that would be dealt to this creature.\"\nEquip {W}{W}",
             "colours": [
@@ -79,7 +79,7 @@
         },
         {
             "id": "842a0043-af21-5929-bf42-b3421c7e4426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5554433e-0dee-4960-a58c-c4a24e01a989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5554433e-0dee-4960-a58c-c4a24e01a989.jpg?1",
             "name": "Distract the Guards",
             "text": "Freerunning {1}{W} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nCreate three 1/1 white Human Rogue creature tokens.",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "3a46c2ac-08cb-53e2-be70-de41ad59e799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a8c84b-7d6c-4068-97b1-bc5dec46732c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a8c84b-7d6c-4068-97b1-bc5dec46732c.jpg?1",
             "name": "Fall of the First Civilization",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You and target opponent each draw two cards.\nII \u2014 Exile target artifact an opponent controls.\nIII \u2014 Each player chooses three nonland permanents they control. Destroy all other nonland permanents.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "fef6159b-39a0-5ed6-b3af-1c84556df9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e791f0-297b-46bf-acd5-f62458009d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e791f0-297b-46bf-acd5-f62458009d76.jpg?1",
             "name": "Haystack",
             "text": "{2}, {T}: Target creature you control phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "b9fc31c7-eb8c-599c-877d-3a478bbd53b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17eca56-f658-410f-b505-8cbc87d4f253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17eca56-f658-410f-b505-8cbc87d4f253.jpg?1",
             "name": "Hookblade",
             "text": "When Hookblade enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0.\nAs long as it's your turn, equipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "34de6edc-e1f6-5ec2-bc79-388d0125984c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2278d97e-791a-4843-a385-65bac79bde7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2278d97e-791a-4843-a385-65bac79bde7a.jpg?1",
             "name": "Layla Hassan",
             "text": "First strike\nWhen Layla Hassan enters the battlefield and whenever one or more Assassins you control deal combat damage to a player, return target historic card from your graveyard to your hand.",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "eeadf819-cd5b-5a33-8749-4e6cea87618c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671a03d-0858-41e7-976c-60825c29af04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671a03d-0858-41e7-976c-60825c29af04.jpg?1",
             "name": "Senu, Keen-Eyed Protector",
             "text": "Flying, vigilance\n{T}, Exile Senu, Keen-Eyed Protector: You gain 2 life and scry 2.\nWhen a legendary creature you control attacks and isn't blocked, if Senu is exiled, put it onto the battlefield attacking.",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "7d2389a4-0528-51f8-abfd-18c217b9831d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300b5af-9223-4e97-9d33-a9226bd900f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300b5af-9223-4e97-9d33-a9226bd900f3.jpg?1",
             "name": "Tax Collector",
             "text": "When Tax Collector enters the battlefield, choose one \u2014\n\u2022 Tax \u2014 Until your next turn, spells your opponents cast cost {1} more to cast.\n\u2022 Arrest \u2014 Detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "418e44c5-e8be-5043-9029-3ebe63aba585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a1bec-9128-4c5e-98c3-317424f892d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a1bec-9128-4c5e-98c3-317424f892d1.jpg?1",
             "name": "Templar Knight",
             "text": "Vigilance\n{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Templar Knight.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "0aeb8e51-4fc9-5043-b2f3-12aed233eca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe034544-e13f-45fc-ae43-83d0f399ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe034544-e13f-45fc-ae43-83d0f399ed33.jpg?1",
             "name": "What Must Be Done",
             "text": "Choose one \u2014\n\u2022 Let the World Burn \u2014 Destroy all artifacts and creatures.\n\u2022 Release Juno \u2014 Return target historic permanent card from your graveyard to the battlefield. It enters with two additional +1/+1 counters on it if it's a creature. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "e56a9799-27a3-592b-a318-491d37f00567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ebdd18-7f07-417c-8f30-470c1f14dfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ebdd18-7f07-417c-8f30-470c1f14dfae.jpg?1",
             "name": "Assassin Gauntlet",
             "text": "When Assassin Gauntlet enters the battlefield, attach it to up to one target creature you control. Tap all creatures target opponent controls.\nEquipped creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, draw a card, then discard a card.\"\nEquip {2}",
             "colours": [
@@ -442,7 +442,7 @@
         },
         {
             "id": "04e18c9d-660a-533a-b7fc-2a91fdcb91ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6b1b2f-903c-438c-baba-a3b3e60b1d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6b1b2f-903c-438c-baba-a3b3e60b1d4f.jpg?1",
             "name": "Ballad of the Black Flag",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Mill three cards. You may put a historic card from among them into your hand. (Artifacts, legendaries, and Sagas are historic.)\nIV \u2014 Historic spells you cast this turn cost {2} less to cast.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "22b7a077-12c6-5a72-99de-5f6547730d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321777f-399b-4f80-9baf-da6a0aaa325a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321777f-399b-4f80-9baf-da6a0aaa325a.jpg?1",
             "name": "Become Anonymous",
             "text": "Exile target nontoken creature you own and the top two cards of your library in a face-down pile, shuffle that pile, then cloak those cards. They enter the battlefield tapped. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "f8c0d132-cde9-5230-876f-4edcda507553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10fa72b-6742-4b65-8654-ac70b6240e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10fa72b-6742-4b65-8654-ac70b6240e38.jpg?1",
             "name": "Crystal Skull, Isu Spyglass",
             "text": "You may look at the top card of your library any time.\nYou may play historic lands and cast historic spells from the top of your library. (Artifacts, legendaries, and Sagas are historic.)\n{T}: Add {U}.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "f52ce968-e98f-5643-8921-ed28d6d108bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd3561-0143-40b7-81bc-640a978b8b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd3561-0143-40b7-81bc-640a978b8b15.jpg?1",
             "name": "Desynchronization",
             "text": "Return each nonland permanent that's not historic to its owner's hand. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "036fed43-7ffb-5ffe-bb9b-2932e9d8926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5197e8d6-cbfe-4469-95e1-f17eeb4715f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5197e8d6-cbfe-4469-95e1-f17eeb4715f1.jpg?1",
             "name": "Eagle Vision",
             "text": "Freerunning {1}{U} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nDraw three cards.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "37abf786-299c-5094-969c-9aa2bfc2d200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec676a8f-612d-4ef4-a370-6208407a86af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec676a8f-612d-4ef4-a370-6208407a86af.jpg?1",
             "name": "Escape Detection",
             "text": "Freerunning\u2014\nReturn a blue creature you control to its owner's hand. (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "33bd36d5-2089-5acd-8a80-9c3d0db442a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f1ff84-d363-4aa2-b884-e9640cf62537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f1ff84-d363-4aa2-b884-e9640cf62537.jpg?1",
             "name": "Evie Frye",
             "text": "Partner with Jacob Frye (When this creature enters the battlefield, target player may put Jacob into their hand from their library, then shuffle.)\n{1}, {T}: Draw a card, then discard a card. When you discard a creature card this way, target creature you control can't be blocked this turn.",
             "colours": [
@@ -690,7 +690,7 @@
         },
         {
             "id": "642b71eb-8669-5621-9b0a-a09c8d1ebac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d04a5-3639-42de-b940-ffa7e609e527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d04a5-3639-42de-b940-ffa7e609e527.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "{3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.\n{2}{U}, {T}: Draw a card, then discard a card. If the discarded card was an artifact card, exile it from your graveyard. If you do, create a token that's a copy of it, except it's a 0/2 Thopter artifact creature with flying in addition to its other types.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "c2cf66fd-efc4-5a81-812b-49f2f3cf4e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1e598a-840c-4166-88a6-92a8b9958536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1e598a-840c-4166-88a6-92a8b9958536.jpg?1",
             "name": "Loyal Inventor",
             "text": "Vigilance\nWhen Loyal Inventor enters the battlefield, you may search your library for an artifact card, reveal it, then shuffle. Put that card into your hand if you control an Assassin. Otherwise, put that card on top of your library.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "18299f1a-7573-5895-9463-cdb29164e6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4e330-d878-48f3-b9fe-3158d69f2da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4e330-d878-48f3-b9fe-3158d69f2da2.jpg?1",
             "name": "Assassin Initiate",
             "text": "{1}: Assassin Initiate gains your choice of flying, deathtouch, or lifelink until end of turn.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "fe7e007e-6584-5748-bc81-96f0c8ffdf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bcd9c9-5957-48ee-9c12-f659c5fd07d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bcd9c9-5957-48ee-9c12-f659c5fd07d0.jpg?1",
             "name": "Chain Assassination",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nDestroy target creature. If another creature died this turn, draw a card.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "08d90b17-1130-5861-b18a-d5e5b9dd001f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9523cd1-c3cf-4745-af09-77c1a83ac86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9523cd1-c3cf-4745-af09-77c1a83ac86f.jpg?1",
             "name": "Desmond Miles",
             "text": "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "044e7db1-a470-5c5d-812c-5ebfdfacb1b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae9ee75-30b8-4e24-af8b-031c816d3221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae9ee75-30b8-4e24-af8b-031c816d3221.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}. (You may cast a spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "12f63700-5bee-5e2a-b790-f086c066eb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea6cde3-a4e6-4052-aca3-4d209be15db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea6cde3-a4e6-4052-aca3-4d209be15db3.jpg?1",
             "name": "Hemlock Vial",
             "text": "When Hemlock Vial enters the battlefield, you draw a card and you lose 1 life.\n{B}, {T}, Sacrifice Hemlock Vial: Each equipped creature and Equipment you control gains deathtouch until end of turn.",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "ba1c2c64-3f12-5312-93a2-b8782a2e298d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23422e75-e1c7-484b-aa1f-155ef9a998ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23422e75-e1c7-484b-aa1f-155ef9a998ec.jpg?1",
             "name": "Jacob Frye",
             "text": "Partner with Evie Frye (When this creature enters the battlefield, target player may put Evie into their hand from their library, then shuffle.)\nWhenever one or more Assassins you control deal combat damage to a player, exile up to one target Assassin card or card with freerunning from your graveyard. If you do, copy it. You may cast the copy.",
             "colours": [
@@ -999,7 +999,7 @@
         },
         {
             "id": "5e25eeda-84fc-5ead-8ffb-fa436b25f5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45abc0a4-ae33-470f-9a39-2dd776dd6adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45abc0a4-ae33-470f-9a39-2dd776dd6adb.jpg?1",
             "name": "Petty Larceny",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nLook at the top two cards of target opponent's library and exile those cards face down. You may play those cards for as long as they remain exiled, and mana of any type can be spent to cast them. Create a Treasure token.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "c3aa1b31-ed33-5aa1-9aa3-913cb14f61ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5ec61b-5393-422b-b021-46b80bb42ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5ec61b-5393-422b-b021-46b80bb42ac4.jpg?1",
             "name": "Phantom Blade",
             "text": "When Phantom Blade enters the battlefield, attach it to up to one target creature you control. Destroy up to one other target creature.\nEquipped creature gets +1/+1 and has menace. (It can't be blocked except by two or more creatures.)\nEquip {2}",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "ddebbe77-4556-5a60-8a2e-195d1a5eaea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2b1b20-e5fd-4ccb-8529-12dbde0e0811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2b1b20-e5fd-4ccb-8529-12dbde0e0811.jpg?1",
             "name": "Restart Sequence",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "4266dc7c-2f92-5aa1-9bfb-8cb8f95d137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed77def5-ac92-4907-805d-261cae0db357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed77def5-ac92-4907-805d-261cae0db357.jpg?1",
             "name": "The Revelations of Ezio",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target tapped creature an opponent controls.\nII \u2014 Whenever an Assassin you control attacks this turn, put a +1/+1 counter on it.\nIII \u2014 Return target Assassin creature card from your graveyard to the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "48fd9ee2-f829-520f-b58c-df45d8547a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17e6aa-8be5-40ea-a627-783c478c8eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17e6aa-8be5-40ea-a627-783c478c8eda.jpg?1",
             "name": "Roshan, Hidden Magister",
             "text": "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "f637722b-5640-51de-897d-3b2deda9db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81b94b2-4052-4686-a788-9baf0fa0f81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81b94b2-4052-4686-a788-9baf0fa0f81a.jpg?1",
             "name": "Alexios, Deimos of Kosmos",
             "text": "Trample\nAlexios, Deimos of Kosmos attacks each combat if able, can't be sacrificed, and can't attack its owner.\nAt the beginning of each player's upkeep, that player gains control of Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "43489133-525e-5062-85e2-a346b1e68977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188fe5a-92ac-4c1c-a9a4-2dd5912cc14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188fe5a-92ac-4c1c-a9a4-2dd5912cc14e.jpg?1",
             "name": "Hidden Footblade",
             "text": "Flash\nWhen Hidden Footblade enters the battlefield, attach it to target creature you control. That creature gains first strike until end of turn.\nEquipped creature gets +1/+0 and has haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "811c1125-8a49-523d-89fd-2bb988e47ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2e91f0-3a4e-4388-9460-6756f758316b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2e91f0-3a4e-4388-9460-6756f758316b.jpg?1",
             "name": "Monastery Raid",
             "text": "Freerunning {X}{R} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nExile the top two cards of your library. If this spell's freerunning cost was paid, exile the top X cards of your library instead. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "60d92288-1042-5986-b09a-8bf706446aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da80cd-d0b8-4094-bfe7-28811d655f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da80cd-d0b8-4094-bfe7-28811d655f8b.jpg?1",
             "name": "Origin of the Hidden Ones",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Origin of the Hidden Ones deals 4 damage to any target.\nII \u2014 Create two 1/1 black Assassin creature tokens with menace.\nIII \u2014 Whenever an Assassin you control attacks this turn, create a 1/1 black Assassin creature token with menace that's tapped and attacking.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "abf8d16c-1600-5ff9-9228-cca6dfd00fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ad338e-88ee-4919-aec4-320071a7cfb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ad338e-88ee-4919-aec4-320071a7cfb5.jpg?1",
             "name": "Overpowering Attack",
             "text": "Freerunning {2}{R} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nUntap all creatures you control that attacked this turn. If it's your main phase, there is an additional combat phase after this phase, followed by an additional main phase.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "635fd929-0d93-5485-9fa0-962cccac7a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d6ce7-2452-41a2-aa70-41e1b8045c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d6ce7-2452-41a2-aa70-41e1b8045c54.jpg?1",
             "name": "The Spear of Leonidas",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Bull Rush \u2014 It gains double strike until end of turn.\n\u2022 Summon \u2014 Create Phobos, a legendary 3/2 red Horse creature token.\n\u2022 Revelation \u2014 Discard two cards, then draw two cards.\nEquip {2}",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "4e1dd242-f3cf-5a4a-b019-63f9a2e65b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbcea0-53ba-444d-b2e0-6d184f945f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbcea0-53ba-444d-b2e0-6d184f945f92.jpg?1",
             "name": "The Aesir Escape Valhalla",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile a permanent card from your graveyard. You gain life equal to its mana value.\nII \u2014 Put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card.\nIII \u2014 Return The Aesir Escape Valhalla and the exiled card to their owner's hand.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "5701878f-b6a3-59b0-ae35-fc6403194f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3b4f73-e241-4d60-a877-25327092c291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3b4f73-e241-4d60-a877-25327092c291.jpg?1",
             "name": "Aveline de Grandpr\u00e9",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, put that many +1/+1 counters on that creature.\nDisguise {B}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "516bec9e-8423-59ec-b39e-01b1daf375eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2765df-edff-4607-843c-8528d5d4fce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2765df-edff-4607-843c-8528d5d4fce9.jpg?1",
             "name": "Hunter's Bow",
             "text": "When Hunter's Bow enters the battlefield, attach it to target creature you control. That creature deals damage equal to its power to up to one target creature you don't control.\nEquipped creature has reach and ward {2}.\nEquip {1}",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "28dcb5e9-c462-5eab-a81f-5a937745b90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37a14c4-5398-491b-8b37-8c4eeff3054f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37a14c4-5398-491b-8b37-8c4eeff3054f.jpg?1",
             "name": "Palazzo Archers",
             "text": "Reach\nWhenever a creature with flying attacks you or a planeswalker you control, Palazzo Archers deals damage equal to its power to that creature.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "a2a92868-a19e-5af0-bd19-d13a5062e44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f10999-c7c2-462e-bd75-e3710f7a3364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f10999-c7c2-462e-bd75-e3710f7a3364.jpg?1",
             "name": "Viewpoint Synchronization",
             "text": "Freerunning {2}{G} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nSearch your library for up to three basic land cards and reveal them. Put two of them onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "2760a719-9788-5dc5-afae-d7e7cdf24a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914efc24-5c3a-4d22-9d77-fce337a08d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914efc24-5c3a-4d22-9d77-fce337a08d4d.jpg?1",
             "name": "Ad\u00e9wal\u00e9, Breaker of Chains",
             "text": "When Ad\u00e9wal\u00e9 enters the battlefield, reveal the top six cards of your library. Put an Assassin, Pirate, or Vehicle card from among them into your hand and the rest on the bottom of your library in a random order.\nWhenever a Vehicle you control deals combat damage to a player, you may return Ad\u00e9wal\u00e9 from your graveyard to your hand.",
             "colours": [
@@ -1619,7 +1619,7 @@
         },
         {
             "id": "6a29a32b-9446-5f96-be64-b28ee4b1f62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358026de-ab7c-4a17-8cac-cfbee391b127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358026de-ab7c-4a17-8cac-cfbee391b127.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "First strike\nWhenever Alta\u00efr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.",
             "colours": [
@@ -1664,7 +1664,7 @@
         },
         {
             "id": "94913857-2f9e-5ba0-885b-9687b278f036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7187506-4af3-47e9-bad0-4ce8c78ccc10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7187506-4af3-47e9-bad0-4ce8c78ccc10.jpg?1",
             "name": "Arbaaz Mir",
             "text": "Whenever Arbaaz Mir or another nontoken historic permanent enters the battlefield under your control, Arbaaz Mir deals 1 damage to each opponent and you gain 1 life. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "2c24b224-f991-580a-bad8-0a95a1cf1696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41142b10-a493-499a-9fc5-043eeca5d1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41142b10-a493-499a-9fc5-043eeca5d1ee.jpg?1",
             "name": "Arno Dorian",
             "text": "Deathtouch\nOther Assassins you control get +2/+0.\nDisguise {B}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "afb9b6a6-b6c0-56fe-a891-0a6df63efab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd1928-18ec-4f55-acd8-9a62f9869fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd1928-18ec-4f55-acd8-9a62f9869fff.jpg?1",
             "name": "Aya of Alexandria",
             "text": "Menace, lifelink\nWhenever a historic creature you control deals combat damage to a player, create a 1/1 black Assassin creature token with menace. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "79f2af42-ba37-5b3f-9d29-6eb309914b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8aa19c1-4e87-4f42-814c-490e75565f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8aa19c1-4e87-4f42-814c-490e75565f6e.jpg?1",
             "name": "Basim Ibn Ishaq",
             "text": "Whenever you cast a historic spell, draw a card. Basim Ibn Ishaq can't be blocked this turn. This ability triggers only once each turn. (Artifacts, legendaries, and Sagas are historic.)\nWhenever Basim Ibn Ishaq deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "2167b2d3-79e0-5319-8912-d1788184ce0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4510e9-dc3f-4403-ae52-348d2a3eef84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4510e9-dc3f-4403-ae52-348d2a3eef84.jpg?1",
             "name": "Bayek of Siwa",
             "text": "Double strike\nAs long as it's your turn, other historic creatures you control have double strike.\nDisguise {1}{R}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "3ccfbdf1-72f4-51dd-9e12-94157813be94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e942730-712a-42b2-8683-a18702d685f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e942730-712a-42b2-8683-a18702d685f6.jpg?1",
             "name": "Bleeding Effect",
             "text": "At the beginning of combat on your turn, creatures you control gain flying until end of turn if a creature card in your graveyard has flying. The same is true for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "5ac15833-1fc9-5f9e-857d-cc1d945dc204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769bbbb3-37e9-47ec-9cee-db63672275e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769bbbb3-37e9-47ec-9cee-db63672275e6.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "Allies \u2014 At the beginning of your end step, put a +1/+1 counter on each of up to two other target legendary creatures.\nBetrayal \u2014 Whenever a legendary creature with counters on it dies, draw a card for each counter on it. You lose 2 life.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "d9a0e7ee-e8ad-511c-86c9-1b68979f79ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472be1e-388c-45fe-a18d-35b2cb12dc5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472be1e-388c-45fe-a18d-35b2cb12dc5f.jpg?1",
             "name": "Edward Kenway",
             "text": "At the beginning of your end step, create a Treasure token for each tapped Assassin, Pirate, and/or Vehicle you control.\nWhenever a Vehicle you control deals combat damage to a player, look at the top card of that player's library, then exile it face down. You may play that card for as long as it remains exiled.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "33af6163-a388-5d71-852d-4025824f463f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88667198-3bec-413c-b41e-de96abc8db7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88667198-3bec-413c-b41e-de96abc8db7b.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "Trample, haste\nWhenever Eivor, Wolf-Kissed deals combat damage to a player, you mill that many cards. You may put a Saga card and/or a land card from among them onto the battlefield.",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "3527cf2a-15fe-5ffe-9dc4-afbe964fa1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3351cae2-87be-4438-ba58-f4f4aff2416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3351cae2-87be-4438-ba58-f4f4aff2416c.jpg?1",
             "name": "Ezio, Brash Novice",
             "text": "Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "f4c3e698-5d50-5c36-be96-05b163e2a3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c44cc99-eb71-4be3-89f2-74473f2717d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c44cc99-eb71-4be3-89f2-74473f2717d3.jpg?1",
             "name": "Havi, the All-Father",
             "text": "Havi, the All-Father has indestructible as long as there are four or more historic cards in your graveyard. (Artifacts, legendaries, and Sagas are historic.)\nSage Project \u2014 Whenever Havi or another legendary creature you control dies, return target legendary creature card with lesser mana value from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "8f64b2a4-8895-5270-8bdf-5cbfb4215021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73468f53-7de5-4a64-8f83-c0376f1d1f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73468f53-7de5-4a64-8f83-c0376f1d1f3f.jpg?1",
             "name": "Haytham Kenway",
             "text": "Protection from Assassins\nOther Knights you control get +2/+2 and have protection from Assassins.\nWhen Haytham Kenway enters the battlefield, for each opponent, exile up to one target creature that player controls until Haytham Kenway leaves the battlefield.",
             "colours": [
@@ -2172,7 +2172,7 @@
         },
         {
             "id": "1a426f2c-1b45-5eab-99d7-f5c5382367f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056bb9-e825-418a-a8ff-692980aa65fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056bb9-e825-418a-a8ff-692980aa65fe.jpg?1",
             "name": "Jackdaw",
             "text": "Whenever Jackdaw deals combat damage to a player, you may discard your hand. If you do, draw a card for each artifact you control.\nCrew 3",
             "colours": [
@@ -2213,7 +2213,7 @@
         },
         {
             "id": "f71bca21-126f-594f-bf7c-4d019d4686d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e127a40c-90c8-4c2d-aff4-daab1c56a4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e127a40c-90c8-4c2d-aff4-daab1c56a4c5.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "Haste\nWhen Kassandra enters the battlefield, search your graveyard, hand, and library for a card named The Spear of Leonidas, put it onto the battlefield, then shuffle.\nWhenever a creature you control with a legendary Equipment attached to it deals combat damage to a player, draw a card.",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "1c66ab59-8956-52a8-8466-d378100bfa08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6c700-f961-484a-8fe2-57107f5b7717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6c700-f961-484a-8fe2-57107f5b7717.jpg?1",
             "name": "Lydia Frye",
             "text": "Lydia Frye can't be blocked by creatures with power 3 or greater.\nAt the beginning of your end step, surveil X, where X is the number of tapped Assassins you control. (Look at the top X cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "d241cf76-ded0-5f4f-87b0-bb8b9ef02b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116bf8c6-8488-4eff-b350-b3ea821353b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116bf8c6-8488-4eff-b350-b3ea821353b1.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "Haste\n{T}: Draw a card, then discard a card.\nWhenever you discard an Island, Pirate, or Vehicle card, create a tapped Treasure token.",
             "colours": [
@@ -2343,7 +2343,7 @@
         },
         {
             "id": "d7b08679-a433-595e-80b0-2a86c4ddc900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b16a212-602c-4839-9e34-fc5c5b0388f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b16a212-602c-4839-9e34-fc5c5b0388f0.jpg?1",
             "name": "Ratonhnhak\u00e9\ua789ton",
             "text": "As long as Ratonhnhak\u00e9:ton hasn't dealt damage yet, it has hexproof and can't be blocked.\nWhenever Ratonhnhak\u00e9:ton deals combat damage to a player, create a 1/1 black Assassin creature token with menace. When you do, return target Equipment card from your graveyard to the battlefield, then attach it to that token.",
             "colours": [
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "0406352f-6f2e-583e-b197-19581339eb7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085568e5-d622-45ff-9a31-52eaa513ff31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085568e5-d622-45ff-9a31-52eaa513ff31.jpg?1",
             "name": "Shao Jun",
             "text": "Leap Strike \u2014 As long as it's your turn, Shao Jun has flying and first strike.\nRope Dart \u2014 Tap two untapped artifacts you control: Shao Jun deals 1 damage to each opponent.",
             "colours": [
@@ -2429,7 +2429,7 @@
         },
         {
             "id": "14979f66-946a-5e30-8e3c-30132a4d0b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90080ea-062b-4b92-89e7-b6dcb2c70a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90080ea-062b-4b92-89e7-b6dcb2c70a8c.jpg?1",
             "name": "Shaun & Rebecca, Agents",
             "text": "Vigilance\nWhen Shaun & Rebecca, Agents enters the battlefield, search your graveyard, hand, and library for a card named The Animus and put it onto the battlefield, then shuffle.\n{T}: Add {C}. When you do, mill two cards.",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "538847a0-69d4-537d-a5de-cf80f4964f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ca7f13-df00-4904-a7be-44f94272bfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ca7f13-df00-4904-a7be-44f94272bfee.jpg?1",
             "name": "Shay Cormac",
             "text": "{1}: Permanents your opponents control lose hexproof, indestructible, protection, shroud, and ward until end of turn.\nWhenever a creature an opponent controls becomes the target of a spell or ability you control, put a bounty counter on that creature.\nWhenever a creature with a bounty counter on it dies, put two +1/+1 counters on Shay Cormac.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "29da401e-8289-5b45-8d81-30a492b9dacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ceade9-f12a-4724-b198-312fb4b1210b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ceade9-f12a-4724-b198-312fb4b1210b.jpg?1",
             "name": "Sigurd, Jarl of Ravensthorpe",
             "text": "Vigilance, trample, lifelink\nBoast \u2014 {1}: Put a lore counter on target Saga you control or remove one from it. (Activate only if this creature attacked this turn and only once each turn.)\nWhenever you put a lore counter on a Saga you control, put a +1/+1 counter on up to one other target creature.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "3e6b7e28-1c27-576b-96ef-a2a20c22e5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9266244-e8bc-47f8-a440-55d208b961df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9266244-e8bc-47f8-a440-55d208b961df.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "Defender\nSokrates, Athenian Teacher has hexproof as long as it's untapped.\nSokratic Dialogue \u2014 {T}: Until end of turn, target creature gains \"If this creature would deal combat damage to a player, prevent that damage. This creature's controller and that player each draw half that many cards, rounded down.\"",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "37863bed-f1bd-572f-9481-57849aab91db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d878fc-cc21-407f-b3cc-95bf2d717a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d878fc-cc21-407f-b3cc-95bf2d717a80.jpg?1",
             "name": "Adrestia",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Adrestia attacks, if an Assassin crewed it this turn, draw a card. Adrestia becomes an Assassin in addition to its other types until end of turn.\nCrew 1",
             "colours": [],
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "a9358013-ba0f-5be0-85ea-a6f55fc071e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad574010-01ee-4bbc-87c5-4b04338b6ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad574010-01ee-4bbc-87c5-4b04338b6ef6.jpg?1",
             "name": "The Animus",
             "text": "At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.",
             "colours": [],
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "8abf19be-1771-5c28-b1b9-2c12cb6925e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17dd0b7f-bd26-4a46-a7a1-bc65138d54ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17dd0b7f-bd26-4a46-a7a1-bc65138d54ed.jpg?1",
             "name": "Apple of Eden, Isu Relic",
             "text": "{T}, Pay 4 life, Sacrifice Apple of Eden: Look at target opponent's hand and exile those cards face down. You may play those cards this turn, and mana of any type can be spent to cast them. Until end of turn, whenever you play a land or cast a spell this way, its owner draws a card. At the beginning of the next end step, return the exiled cards to their owner's hand. Activate only as a sorcery.",
             "colours": [],
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "defdc406-2dae-592a-aee3-44de66b9a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6439a6-288d-427e-b14b-a99e8ef8c5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6439a6-288d-427e-b14b-a99e8ef8c5cd.jpg?1",
             "name": "Brotherhood Regalia",
             "text": "Equipped creature has ward {2}, is an Assassin in addition to its other types, and can't be blocked.\nEquip legendary creature {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "bb5870ed-c581-5bdc-ba67-1eda2e2edcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dbf574-3193-413e-a982-4b9d27dafaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dbf574-3193-413e-a982-4b9d27dafaf5.jpg?1",
             "name": "Excalibur, Sword of Eden",
             "text": "This spell costs {X} less to cast, where X is the total mana value of historic permanents you control. (Artifacts, legendaries, and Sagas are historic.)\nEquipped creature gets +10/+0 and has vigilance.\nEquip legendary creature {2}",
             "colours": [],
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "1ebf6afe-2107-5cf5-a775-d0a9bf4c1e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a488f-cb64-4f4c-9c2e-6cdb5d563f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a488f-cb64-4f4c-9c2e-6cdb5d563f13.jpg?1",
             "name": "Hidden Blade",
             "text": "Flash\nWhen Hidden Blade enters the battlefield, attach it to target creature you control. If that creature is an Assassin, it gains deathtouch until end of turn.\nEquipped creature gets +1/+0 and has first strike.\nEquip {2}",
             "colours": [],
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "f2793080-9c48-5c31-9e41-73aad3e340f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df09fc8c-e008-427b-b007-ceec9a4aa4ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df09fc8c-e008-427b-b007-ceec9a4aa4ab.jpg?1",
             "name": "Mj\u00f6lnir, Storm Hammer",
             "text": "When Mj\u00f6lnir enters the battlefield, attach it to target legendary creature you control.\nWhenever equipped creature attacks, tap target creature defending player controls and put a stun counter on it. Then Mj\u00f6lnir deals damage to each opponent equal to the number of tapped creatures that opponent controls.\nEquip {4}",
             "colours": [],
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "f8f3c9dd-b674-5639-85f0-a112663e96c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4330d8ce-3b82-4297-ad5f-c63b54b6665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4330d8ce-3b82-4297-ad5f-c63b54b6665a.jpg?1",
             "name": "Smoke Bomb",
             "text": "Flash\nAll creatures have shroud. (They can't be the targets of spells or abilities.)\nAt the beginning of your upkeep, sacrifice Smoke Bomb. When you do, target creature you control can't be blocked this turn.",
             "colours": [],
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "b7d2ae50-13b8-5937-81ae-5c08b729be70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ce94a9-d6f4-432d-9447-e6d1446c393b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ce94a9-d6f4-432d-9447-e6d1446c393b.jpg?1",
             "name": "Staff of Eden, Vault's Key",
             "text": "When Staff of Eden, Vault's Key enters the battlefield, put target legendary permanent card not named Staff of Eden, Vault's Key from a graveyard onto the battlefield under your control.\n{T}: Draw a card for each permanent you control but don't own.",
             "colours": [],
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "269c7f75-2a41-5e97-ba18-23afee521931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19115bf-562c-4bef-967d-52ec1e54c82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19115bf-562c-4bef-967d-52ec1e54c82e.jpg?1",
             "name": "Towering Viewpoint",
             "text": "Defender, reach\nLeap of Faith \u2014 {3}: Target creature gains flying until end of turn.",
             "colours": [],
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "3be55569-8dea-538b-9058-46c8d2c4fdfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240a9ef-06cd-4c48-ba97-fea1e55f20e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240a9ef-06cd-4c48-ba97-fea1e55f20e2.jpg?1",
             "name": "Yggdrasil, Rebirth Engine",
             "text": "When Yggdrasil, Rebirth Engine enters the battlefield, exile all creature cards from your graveyard.\n{T}: Exile the top three cards of your library.\n{4}, {T}: Put a creature card exiled with Yggdrasil onto the battlefield under your control. It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "b4afed83-eb85-5f52-83ff-ac5d7e59ee89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d197866-7633-493c-80dd-ec3a09165934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d197866-7633-493c-80dd-ec3a09165934.jpg?1",
             "name": "Abstergo Entertainment",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Exile Abstergo Entertainment: Return up to one target historic card from your graveyard to your hand, then exile all graveyards. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "d7dec264-9d8e-5321-bdc4-23614b484e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535f43c4-8926-4981-967d-f681f98e07d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535f43c4-8926-4981-967d-f681f98e07d9.jpg?1",
             "name": "Brotherhood Headquarters",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast an Assassin spell or a spell that has freerunning, or to activate an ability of an Assassin source.",
             "colours": [],
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "9a2713fa-a33a-5ee6-b8ca-fc4cc3c96dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4ed445-7b35-4090-9d0e-92532b07c8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4ed445-7b35-4090-9d0e-92532b07c8c7.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "c34068c2-2f05-5321-aa61-abf749de46df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f203ce7d-a079-44b8-bfda-4c63ec79b82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f203ce7d-a079-44b8-bfda-4c63ec79b82d.jpg?1",
             "name": "Reconnaissance",
             "text": "{0}: Remove target attacking creature you control from combat and untap it. (If you activate during end of combat, the creature will untap after it deals combat damage.)",
             "colours": [
@@ -3099,7 +3099,7 @@
         },
         {
             "id": "db967b87-874a-5d71-8461-1e47a576d513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98040e14-8182-4a94-9322-bbd967dc4dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98040e14-8182-4a94-9322-bbd967dc4dfe.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "8e190b39-c89e-51cc-b16b-a1ab1760f18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdc8ac7-a9aa-4323-84c9-fa0cade02bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdc8ac7-a9aa-4323-84c9-fa0cade02bd1.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "9c99fcd4-233e-5313-8dc0-6f41e2e92485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7c9072-d14c-442c-a386-bfdc0cbe110d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7c9072-d14c-442c-a386-bfdc0cbe110d.jpg?1",
             "name": "Propaganda",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "bbb3f072-ddb6-5fd2-8343-a4098a85b4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7385611f-d26f-4a6e-b141-adcf3dbfc438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7385611f-d26f-4a6e-b141-adcf3dbfc438.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "2a47cc9b-4e34-59b4-aea5-4f0aadfcc8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac8176-d0db-4397-820d-acbdd3264377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac8176-d0db-4397-820d-acbdd3264377.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life. (It has every creature type.)",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "dd06ebaf-9904-529e-8db7-7188b86e3aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3cbcbb-d865-42df-88e1-0c9bd24b5c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3cbcbb-d865-42df-88e1-0c9bd24b5c79.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy enters the battlefield, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "2102c8d0-9626-5e13-88af-efba071f2be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512263f7-975a-4107-b58f-6c8ec85e375e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512263f7-975a-4107-b58f-6c8ec85e375e.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness enters the battlefield, choose a creature type.\nCreatures of the chosen type have fear. (They can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "f9b3659b-6284-582f-8ef2-30cead5cfa30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6949e85-2db2-43a7-93bd-485c7b196298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6949e85-2db2-43a7-93bd-485c7b196298.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has mana value 2 or less.\nRevolt \u2014 Destroy that creature if it has mana value 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "41a688c3-18d7-5b48-9a75-e40f3d9c20e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f95ad5d-d0c7-4a65-9e46-1d33abbf77aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f95ad5d-d0c7-4a65-9e46-1d33abbf77aa.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "53784d39-0b6c-5841-8ef4-24f1ba667f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d73f4c-0bbd-4616-81a6-102db6cd7db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d73f4c-0bbd-4616-81a6-102db6cd7db9.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "7b2fb092-f2b2-5539-b247-e39ea59bd486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18205d-cce3-4aef-90bd-06cfb4d8387f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18205d-cce3-4aef-90bd-06cfb4d8387f.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "ae38dbc4-5521-58dc-b088-fabcce4a50d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aaab05-db3b-4317-ae32-553c76f6bade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aaab05-db3b-4317-ae32-553c76f6bade.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "737693d7-3d57-58b0-9534-76b4de1aacb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def90432-6d13-4d28-aa27-f75dd26456bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def90432-6d13-4d28-aa27-f75dd26456bb.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "20971247-7460-5f11-ad6d-e46c81fe976a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11de7338-243a-40e2-84e3-c31240840768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11de7338-243a-40e2-84e3-c31240840768.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "25f9ef1c-302b-5193-bbaf-b8315a694392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80d4e1-8883-4951-8081-a444ab26c5d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80d4e1-8883-4951-8081-a444ab26c5d7.jpg?1",
             "name": "Reconstruct History",
             "text": "Return up to one target artifact card, up to one target enchantment card, up to one target instant card, up to one target sorcery card, and up to one target planeswalker card from your graveyard to your hand.\nExile Reconstruct History.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "ea176650-2db7-5803-8a9b-29cc3ef02a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c38679-5563-4390-ba1f-804731953206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c38679-5563-4390-ba1f-804731953206.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "2b2fcd0f-dc50-53ee-b3e9-5649df64111d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6176a-3938-4c59-b485-8751969358ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6176a-3938-4c59-b485-8751969358ad.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "7f0e9d3b-2a10-5591-bdcb-b933ec18d6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4b10aa-47ff-4897-b56a-00c8b19a2d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4b10aa-47ff-4897-b56a-00c8b19a2d34.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "ea6dae5e-70f6-58c7-a0e3-25226fb35755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ad5a57-7296-43cb-b477-826e65d37222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ad5a57-7296-43cb-b477-826e65d37222.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "11dcc90b-4828-54e7-beaf-7d61f3cc0075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578c984-afb6-4532-b5be-093ed4ecb8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578c984-afb6-4532-b5be-093ed4ecb8b9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "fc1261e4-f172-5af7-b5e3-7028e874af78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22426c4-914a-4e0b-a28a-b8573b63e320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22426c4-914a-4e0b-a28a-b8573b63e320.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "f5db7d4b-1379-57fd-b703-4ad150932827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76f785d-1972-4bd6-8a43-848d51068712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76f785d-1972-4bd6-8a43-848d51068712.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3876,7 +3876,7 @@
         },
         {
             "id": "2bf3a763-313e-5aed-a77d-941a4b0b8435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163a697-01ee-4a55-814f-b0ba79be3a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163a697-01ee-4a55-814f-b0ba79be3a7f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "b413a424-453c-5853-8cfd-2243e7df4f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a6df7a-a080-4aef-9a76-5b08bbc4e762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a6df7a-a080-4aef-9a76-5b08bbc4e762.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "a33bf20c-ee53-51e6-8e33-2196cfb6b14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a534ae1-4e6f-43ae-a8ad-89e306f11f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a534ae1-4e6f-43ae-a8ad-89e306f11f21.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "11627c7f-0d83-5fc8-ac17-18b91c911818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a55d99-d668-4621-bb14-f7df210adbe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a55d99-d668-4621-bb14-f7df210adbe4.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "654bf456-d9aa-5df6-a887-86ac18778808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a081ef-a2d4-4989-8b06-721f8b2c9798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a081ef-a2d4-4989-8b06-721f8b2c9798.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "efb9c7f1-f5af-517f-9971-b84d027ce832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650e47f3-476f-4b32-b892-c1a01335d0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650e47f3-476f-4b32-b892-c1a01335d0fe.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "1f255c5d-2764-5771-b0f5-812d36905876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5b2ce3-3cf0-47dd-9b76-940ae7eb8498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5b2ce3-3cf0-47dd-9b76-940ae7eb8498.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "{T}, Pay 1 life: Add {R} or {W}.\n{1}, {T}, Sacrifice Sunbaked Canyon: Draw a card.",
             "colours": [],
@@ -4127,7 +4127,7 @@
         },
         {
             "id": "c950cc64-4e68-553a-8b9f-2f5b523c8bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73be68-aec6-4033-9cdd-bc473d7db93a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73be68-aec6-4033-9cdd-bc473d7db93a.jpg?1",
             "name": "Fiery Islet",
             "text": "{T}, Pay 1 life: Add {U} or {R}.\n{1}, {T}, Sacrifice Fiery Islet: Draw a card.",
             "colours": [],
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "b9d7ce32-fbeb-51eb-9754-2227f3aee9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4c94f-a38a-461c-9bb8-aadc587a1ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4c94f-a38a-461c-9bb8-aadc587a1ae6.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}.\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "c87de66a-d87a-5b7b-a425-48e31d914f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b80c5-fe04-4e5e-9637-b745c2c8956b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b80c5-fe04-4e5e-9637-b745c2c8956b.jpg?1",
             "name": "Nurturing Peatland",
             "text": "{T}, Pay 1 life: Add {B} or {G}.\n{1}, {T}, Sacrifice Nurturing Peatland: Draw a card.",
             "colours": [],
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "5dca83ba-09f1-5376-a675-cc105a92d69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de40ccf-5db9-4e4f-b61b-8fc4454209ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de40ccf-5db9-4e4f-b61b-8fc4454209ae.jpg?1",
             "name": "Silent Clearing",
             "text": "{T}, Pay 1 life: Add {W} or {B}.\n{1}, {T}, Sacrifice Silent Clearing: Draw a card.",
             "colours": [],
@@ -4266,7 +4266,7 @@
         },
         {
             "id": "b40e392f-f15b-5279-8923-26f695a7ff14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6631b9b3-57fb-45d0-94fc-7d07556c8f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6631b9b3-57fb-45d0-94fc-7d07556c8f7f.jpg?1",
             "name": "Waterlogged Grove",
             "text": "{T}, Pay 1 life: Add {G} or {U}.\n{1}, {T}, Sacrifice Waterlogged Grove: Draw a card.",
             "colours": [],
@@ -4297,7 +4297,7 @@
         },
         {
             "id": "990914c7-ad7e-5084-a8e7-683c6ada07ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0f02da-62b2-424a-9f1d-6b6b387c15cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0f02da-62b2-424a-9f1d-6b6b387c15cd.jpg?1",
             "name": "The Capitoline Triad",
             "text": "Those Who Came Before \u2014 This spell costs {1} less to cast for each historic card in your graveyard.\nExile any number of historic cards from your graveyard with total mana value 30 or greater: You get an emblem with \"Creatures you control have base power and toughness 9/9.\"",
             "colours": [],
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "011ed5e4-d86e-5430-84a6-6f7fa5b20586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba0ca29-99a7-4cfd-8e16-e32ccaa5ee1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba0ca29-99a7-4cfd-8e16-e32ccaa5ee1e.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "{3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.\n{2}{U}, {T}: Draw a card, then discard a card. If the discarded card was an artifact card, exile it from your graveyard. If you do, create a token that's a copy of it, except it's a 0/2 Thopter artifact creature with flying in addition to its other types.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "0de2f82c-0b21-554f-93ac-b58789e7c58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f82c4-7223-4dae-b037-aac96a32212f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f82c4-7223-4dae-b037-aac96a32212f.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "11d81177-1155-54f8-8c46-bbb37eeaf45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52adcfc1-d8eb-4753-b6fd-a093b6d23637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52adcfc1-d8eb-4753-b6fd-a093b6d23637.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "Allies \u2014 At the beginning of your end step, put a +1/+1 counter on each of up to two other target legendary creatures.\nBetrayal \u2014 Whenever a legendary creature with counters on it dies, draw a card for each counter on it. You lose 2 life.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "61dad622-041e-5731-9206-9f4cc5dcf01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a19dd-2ead-4712-928e-008a75c64fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a19dd-2ead-4712-928e-008a75c64fe2.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "Haste\n{T}: Draw a card, then discard a card.\nWhenever you discard an Island, Pirate, or Vehicle card, create a tapped Treasure token.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "6b51adea-f6a8-5992-810d-1497197fe2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4bfe8-c213-4cff-80fd-824b8f2c6f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4bfe8-c213-4cff-80fd-824b8f2c6f8f.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "",
             "colours": [
@@ -4545,7 +4545,7 @@
         },
         {
             "id": "de4745d5-5342-59fd-8865-20d278088990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b107dc-387e-4c92-a273-6cb44a485caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b107dc-387e-4c92-a273-6cb44a485caa.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "Defender\nSokrates, Athenian Teacher has hexproof as long as it's untapped.\nSokratic Dialogue \u2014 {T}: Until end of turn, target creature gains \"If this creature would deal combat damage to a player, prevent that damage. This creature's controller and that player each draw half that many cards, rounded down.\"",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "8253fa2d-3581-5b3e-ab02-969fedee3d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b2ac8-5bb6-4d40-abd5-e885e1e1fa7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b2ac8-5bb6-4d40-abd5-e885e1e1fa7b.jpg?1",
             "name": "Apple of Eden, Isu Relic",
             "text": "{T}, Pay 4 life, Sacrifice Apple of Eden: Look at target opponent's hand and exile those cards face down. You may play those cards this turn, and mana of any type can be spent to cast them. Until end of turn, whenever you play a land or cast a spell this way, its owner draws a card. At the beginning of the next end step, return the exiled cards to their owner's hand. Activate only as a sorcery.",
             "colours": [],
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "39810c68-6851-5620-8199-9717f9026341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e0225-e272-4a25-a32b-085c4b950597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e0225-e272-4a25-a32b-085c4b950597.jpg?1",
             "name": "Staff of Eden, Vault's Key",
             "text": "When Staff of Eden, Vault's Key enters the battlefield, put target legendary permanent card not named Staff of Eden, Vault's Key from a graveyard onto the battlefield under your control.\n{T}: Draw a card for each permanent you control but don't own.",
             "colours": [],
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "fccf7056-f59b-5ad6-81ab-23e076254752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba4c892-fe7e-4d0c-bce4-724eb4744831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba4c892-fe7e-4d0c-bce4-724eb4744831.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "cb39bfda-40b0-57af-87b1-387508d6ccb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7736bed-b0db-435d-86b3-fa860dbf55f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7736bed-b0db-435d-86b3-fa860dbf55f0.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "8a729352-aa51-57cf-bf76-0778b11324c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c563a0e0-0f9b-450d-8840-728429b9f4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c563a0e0-0f9b-450d-8840-728429b9f4d6.jpg?1",
             "name": "Yggdrasil, Rebirth Engine",
             "text": "When Yggdrasil, Rebirth Engine enters the battlefield, exile all creature cards from your graveyard.\n{T}: Exile the top three cards of your library.\n{4}, {T}: Put a creature card exiled with Yggdrasil onto the battlefield under your control. It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "cd3fcfc7-bb54-5269-a229-26f0635a0bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597080d9-72a2-4da8-bcd5-53ac01da8503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597080d9-72a2-4da8-bcd5-53ac01da8503.jpg?1",
             "name": "Layla Hassan",
             "text": "First strike\nWhen Layla Hassan enters the battlefield and whenever one or more Assassins you control deal combat damage to a player, return target historic card from your graveyard to your hand.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "98ac78e2-5d50-5eb5-aae8-9e4279d13ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f9ff05-8a97-425e-b556-cc658630c869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f9ff05-8a97-425e-b556-cc658630c869.jpg?1",
             "name": "Senu, Keen-Eyed Protector",
             "text": "Flying, vigilance\n{T}, Exile Senu, Keen-Eyed Protector: You gain 2 life and scry 2.\nWhen a legendary creature you control attacks and isn't blocked, if Senu is exiled, put it onto the battlefield attacking.",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "aff18ad5-b2dc-5966-90e4-c3e5af041f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fb3313-b171-4264-81b7-8c043ddcacda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fb3313-b171-4264-81b7-8c043ddcacda.jpg?1",
             "name": "Evie Frye",
             "text": "Partner with Jacob Frye\n{1}, {T}: Draw a card, then discard a card. When you discard a creature card this way, target creature you control can't be blocked this turn.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "f5023414-ef15-50e5-8b6f-61bbc17ad92b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31006604-83cf-4d8d-bf68-bc2ebb2fb5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31006604-83cf-4d8d-bf68-bc2ebb2fb5a0.jpg?1",
             "name": "Desmond Miles",
             "text": "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
             "colours": [
@@ -4913,7 +4913,7 @@
         },
         {
             "id": "5edbb947-0379-5f3b-8953-40de7d223191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ce00ad-acb5-4418-9ea1-50eaf2273242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ce00ad-acb5-4418-9ea1-50eaf2273242.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}.\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "dd4fe600-9a59-5aa8-a4a1-a1c049f9aac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd5f46-2a61-4553-8469-fd69cccec9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd5f46-2a61-4553-8469-fd69cccec9d8.jpg?1",
             "name": "Jacob Frye",
             "text": "Partner with Evie Frye\nWhenever one or more Assassins you control deal combat damage to a player, exile up to one target Assassin card or card with freerunning from your graveyard. If you do, copy it. You may cast the copy.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "1b70d3f5-940f-5e72-8732-495c9339a292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca1f92-2b5c-4d16-be17-6ba450b43ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca1f92-2b5c-4d16-be17-6ba450b43ea3.jpg?1",
             "name": "Roshan, Hidden Magister",
             "text": "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "0a6197eb-a7f4-5099-8fc4-9d1d6bc9e89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab907c09-56c0-40ed-aebd-63b64c7e1c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab907c09-56c0-40ed-aebd-63b64c7e1c2e.jpg?1",
             "name": "Alexios, Deimos of Kosmos",
             "text": "Trample\nAlexios, Deimos of Kosmos attacks each combat if able, can't be sacrificed, and can't attack its owner.\nAt the beginning of each player's upkeep, that player gains control of Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "10f16bc4-697d-5014-b437-dbe943ff63c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba9494-1443-4043-8cb9-3b3f18cd6676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba9494-1443-4043-8cb9-3b3f18cd6676.jpg?1",
             "name": "Aveline de Grandpr\u00e9",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, put that many +1/+1 counters on that creature.\nDisguise {B}{G}",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "359ff7ef-46c3-5883-9c63-f283b94240d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e0ee24-94fc-4042-b3cf-a5a8a2432ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e0ee24-94fc-4042-b3cf-a5a8a2432ba4.jpg?1",
             "name": "Ad\u00e9wal\u00e9, Breaker of Chains",
             "text": "When Ad\u00e9wal\u00e9 enters the battlefield, reveal the top six cards of your library. Put an Assassin, Pirate, or Vehicle card from among them into your hand and the rest on the bottom of your library in a random order.\nWhenever a Vehicle you control deals combat damage to a player, you may return Ad\u00e9wal\u00e9 from your graveyard to your hand.",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "45845ce5-72b4-527d-a245-fe9428c6de6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96abfdf-21fa-46dc-9632-37add4c10c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96abfdf-21fa-46dc-9632-37add4c10c2a.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "First strike\nWhenever Alta\u00efr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.",
             "colours": [
@@ -5208,7 +5208,7 @@
         },
         {
             "id": "c8890551-9f28-52ff-be60-16420cd0caf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458bf178-a2d8-4f7d-afed-48a7e2bbf246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458bf178-a2d8-4f7d-afed-48a7e2bbf246.jpg?1",
             "name": "Arbaaz Mir",
             "text": "Whenever Arbaaz Mir or another nontoken historic permanent enters the battlefield under your control, Arbaaz Mir deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "1fc6e930-e126-53ae-b853-fa51f1c8a05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a97041-4c09-46f2-b979-e4f63c676fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a97041-4c09-46f2-b979-e4f63c676fb4.jpg?1",
             "name": "Arno Dorian",
             "text": "Deathtouch\nOther Assassins you control get +2/+0.\nDisguise {B}{R}",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "5840b55b-7254-5456-ac31-d893ec292cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720096c1-cbbc-4a2f-b585-899c3b87032c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720096c1-cbbc-4a2f-b585-899c3b87032c.jpg?1",
             "name": "Aya of Alexandria",
             "text": "Menace, lifelink\nWhenever a historic creature you control deals combat damage to a player, create a 1/1 black Assassin creature token with menace.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "bd0dc1fa-3819-529b-9f7f-56e4cb280aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e74cc38-108d-46d4-9d4b-43ed5653982a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e74cc38-108d-46d4-9d4b-43ed5653982a.jpg?1",
             "name": "Basim Ibn Ishaq",
             "text": "Whenever you cast a historic spell, draw a card. Basim Ibn Ishaq can't be blocked this turn. This ability triggers only once each turn.\nWhenever Basim Ibn Ishaq deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -5376,7 +5376,7 @@
         },
         {
             "id": "fc4d20a3-2e75-59e1-a7f8-c947abbecb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d27847-42d8-442d-9c3d-7e58f7d1ec5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d27847-42d8-442d-9c3d-7e58f7d1ec5b.jpg?1",
             "name": "Bayek of Siwa",
             "text": "Double strike\nAs long as it's your turn, other historic creatures you control have double strike.\nDisguise {1}{R}{W}",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "9274e184-95b7-584f-a9f7-9a84d880563d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181f4713-6167-4a79-8584-30cb87e6f92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181f4713-6167-4a79-8584-30cb87e6f92b.jpg?1",
             "name": "Edward Kenway",
             "text": "At the beginning of your end step, create a Treasure token for each tapped Assassin, Pirate, and/or Vehicle you control.\nWhenever a Vehicle you control deals combat damage to a player, look at the top card of that player's library, then exile it face down. You may play that card for as long as it remains exiled.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "ad05cc8c-5da8-5670-b4bc-048db81a3752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f45655-c9c9-4adc-a263-106dcca97c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f45655-c9c9-4adc-a263-106dcca97c69.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "Trample, haste\nWhenever Eivor, Wolf-Kissed deals combat damage to a player, you mill that many cards. You may put a Saga card and/or a land card from among them onto the battlefield.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "03c4ab37-59d0-579b-afb9-e07046fe9a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f4e32b-9252-42a9-a259-cd9a68cb3f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f4e32b-9252-42a9-a259-cd9a68cb3f4a.jpg?1",
             "name": "Ezio, Brash Novice",
             "text": "Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "0eb039ac-2810-5fd2-9139-dbb5c5f0d78c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffdd5a9-bc4f-48de-b87b-8087241f6d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffdd5a9-bc4f-48de-b87b-8087241f6d41.jpg?1",
             "name": "Havi, the All-Father",
             "text": "Havi, the All-Father has indestructible as long as there are four or more historic cards in your graveyard.\nSage Project \u2014 Whenever Havi or another legendary creature you control dies, return target legendary creature card with lesser mana value from your graveyard to the battlefield tapped.",
             "colours": [
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "e50c06c7-c7e7-55eb-809b-09c1004949f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23aa895d-659f-49cb-82af-fd8fa491004f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23aa895d-659f-49cb-82af-fd8fa491004f.jpg?1",
             "name": "Haytham Kenway",
             "text": "Protection from Assassins\nOther Knights you control get +2/+2 and have protection from Assassins.\nWhen Haytham Kenway enters the battlefield, for each opponent, exile up to one target creature that player controls until Haytham Kenway leaves the battlefield.",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "c9c24337-d5cb-5c92-ad0a-bafc171e6934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7016d0a-0352-4955-86af-949cf6ba6a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7016d0a-0352-4955-86af-949cf6ba6a3f.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "Haste\nWhen Kassandra enters the battlefield, search your graveyard, hand, and library for a card named The Spear of Leonidas, put it onto the battlefield, then shuffle.\nWhenever a creature you control with a legendary Equipment attached to it deals combat damage to a player, draw a card.",
             "colours": [
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "e89eb8da-247e-5e93-8caf-c92d3c4fa675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910570c8-c868-4513-8b27-22268d0cff68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910570c8-c868-4513-8b27-22268d0cff68.jpg?1",
             "name": "Lydia Frye",
             "text": "Lydia Frye can't be blocked by creatures with power 3 or greater.\nAt the beginning of your end step, surveil X, where X is the number of tapped Assassins you control.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "7eee0881-fb69-5d38-ba10-af707ef0a37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0e1e27-9a74-4151-8902-aacd12897946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0e1e27-9a74-4151-8902-aacd12897946.jpg?1",
             "name": "Ratonhnhak\u00e9\ua789ton",
             "text": "As long as Ratonhnhak\u00e9:ton hasn't dealt damage yet, it has hexproof and can't be blocked.\nWhenever Ratonhnhak\u00e9:ton deals combat damage to a player, create a 1/1 black Assassin creature token with menace. When you do, return target Equipment card from your graveyard to the battlefield, then attach it to that token.",
             "colours": [
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "6ad210df-5121-5341-89af-7bdd6bd4babb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9313f099-7f76-4b3e-af6a-f62b13cad7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9313f099-7f76-4b3e-af6a-f62b13cad7b8.jpg?1",
             "name": "Shao Jun",
             "text": "Leap Strike \u2014 As long as it's your turn, Shao Jun has flying and first strike.\nRope Dart \u2014 Tap two untapped artifacts you control: Shao Jun deals 1 damage to each opponent.",
             "colours": [
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "a4779279-cb32-5492-a468-0475439bccef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5395d40f-75ae-4198-bb8a-c91265bcf824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5395d40f-75ae-4198-bb8a-c91265bcf824.jpg?1",
             "name": "Shaun & Rebecca, Agents",
             "text": "Vigilance\nWhen Shaun & Rebecca, Agents enters the battlefield, search your graveyard, hand, and library for a card named The Animus and put it onto the battlefield, then shuffle.\n{T}: Add {C}. When you do, mill two cards.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "43b9750c-3075-589f-af91-b61835a746f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3012ba-1537-4f54-bb4a-65b909b87e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3012ba-1537-4f54-bb4a-65b909b87e59.jpg?1",
             "name": "Shay Cormac",
             "text": "{1}: Permanents your opponents control lose hexproof, indestructible, protection, shroud, and ward until end of turn.\nWhenever a creature an opponent controls becomes the target of a spell or ability you control, put a bounty counter on that creature.\nWhenever a creature with a bounty counter on it dies, put two +1/+1 counters on Shay Cormac.",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "2ce9bb49-fe5f-5eb9-b8ec-a3434a8d3f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769bc61-cde4-4033-9bbe-e01bc9574261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769bc61-cde4-4033-9bbe-e01bc9574261.jpg?1",
             "name": "Sigurd, Jarl of Ravensthorpe",
             "text": "Vigilance, trample, lifelink\nBoast \u2014 {1}: Put a lore counter on target Saga you control or remove one from it.\nWhenever you put a lore counter on a Saga you control, put a +1/+1 counter on up to one other target creature.",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "79802e2a-a81b-5bc0-afcb-f9456212aada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badfc613-88d9-4a81-a525-1ef74f3ac420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badfc613-88d9-4a81-a525-1ef74f3ac420.jpg?1",
             "name": "Caduceus, Staff of Hermes",
             "text": "Equipped creature has lifelink.\nAs long as you have 30 or more life, equipped creature gets +5/+5 and has indestructible and \"Prevent all damage that would be dealt to this creature.\"\nEquip {W}{W}",
             "colours": [
@@ -5980,7 +5980,7 @@
         },
         {
             "id": "8184f3b4-ab00-58a3-80e5-31db9236e44a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9bf9e0-cb43-411c-a955-dc8e2f331e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9bf9e0-cb43-411c-a955-dc8e2f331e2d.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -6015,7 +6015,7 @@
         },
         {
             "id": "345d4071-04f3-59ca-b38f-af937403c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5f9cb4-a912-4117-97c8-ffe3f5c88eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5f9cb4-a912-4117-97c8-ffe3f5c88eed.jpg?1",
             "name": "What Must Be Done",
             "text": "Choose one \u2014\n\u2022 Let the World Burn \u2014 Destroy all artifacts and creatures.\n\u2022 Release Juno \u2014 Return target historic permanent card from your graveyard to the battlefield. It enters with two additional +1/+1 counters on it if it's a creature.",
             "colours": [
@@ -6050,7 +6050,7 @@
         },
         {
             "id": "a533c237-518d-52ef-ab34-4132846086a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1068ed8a-a062-4249-802d-6f4070992de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1068ed8a-a062-4249-802d-6f4070992de0.jpg?1",
             "name": "Crystal Skull, Isu Spyglass",
             "text": "You may look at the top card of your library any time.\nYou may play historic lands and cast historic spells from the top of your library.\n{T}: Add {U}.",
             "colours": [
@@ -6087,7 +6087,7 @@
         },
         {
             "id": "415f7101-fb2c-5d99-bf40-eec1ec53961b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096632a-a156-4aa5-9b09-f222939ab574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096632a-a156-4aa5-9b09-f222939ab574.jpg?1",
             "name": "Desynchronization",
             "text": "Return each nonland permanent that's not historic to its owner's hand.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "b13c6e9a-8e4d-57d3-a6b3-a9dfacdb5650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edb50b3-27dd-4d1b-b811-8a2ea5bead1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edb50b3-27dd-4d1b-b811-8a2ea5bead1f.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -6157,7 +6157,7 @@
         },
         {
             "id": "f4d74de7-8e09-5d62-be98-bc08684746c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318f8ec3-0613-448d-87d2-0bcc9e95da64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318f8ec3-0613-448d-87d2-0bcc9e95da64.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.",
             "colours": [
@@ -6192,7 +6192,7 @@
         },
         {
             "id": "129625c3-9a66-5f32-812a-98c4922c0973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6aeb38-811c-4b5b-8bdd-876f41211035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6aeb38-811c-4b5b-8bdd-876f41211035.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy enters the battlefield, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "bf9acae6-7ce6-5ffd-b139-0ae6d5a161f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40c2274-250c-4aa1-8c28-7d963d31435f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40c2274-250c-4aa1-8c28-7d963d31435f.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness enters the battlefield, choose a creature type.\nCreatures of the chosen type have fear.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "e0c5a035-50d2-5388-8a82-0855111f3b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae86188f-dcee-4d19-b5b0-e0d18df4f081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae86188f-dcee-4d19-b5b0-e0d18df4f081.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "52ffb332-d8dd-5c31-b671-0cb9f8de7a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b729699-efb7-4769-a166-29aaadef335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b729699-efb7-4769-a166-29aaadef335b.jpg?1",
             "name": "The Spear of Leonidas",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Bull Rush \u2014 It gains double strike until end of turn.\n\u2022 Summon \u2014 Create Phobos, a legendary 3/2 red Horse creature token.\n\u2022 Revelation \u2014 Discard two cards, then draw two cards.\nEquip {2}",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "0973b0d5-9403-5672-8d7e-56d81684f291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4c0e5f-3437-4fae-ab9f-36a36a086e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4c0e5f-3437-4fae-ab9f-36a36a086e88.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "ac2f90cc-5fa4-5508-93cb-dbfacee60426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55196729-4a74-49b9-acd0-07b8f2d632bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55196729-4a74-49b9-acd0-07b8f2d632bb.jpg?1",
             "name": "Jackdaw",
             "text": "Whenever Jackdaw deals combat damage to a player, you may discard your hand. If you do, draw a card for each artifact you control.\nCrew 3",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "eefdb304-9368-53d4-95f7-6eb0aa2a7e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330dfd52-5e11-4df3-b2e6-7160c940e4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330dfd52-5e11-4df3-b2e6-7160c940e4cb.jpg?1",
             "name": "The Animus",
             "text": "At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.",
             "colours": [],
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "8036f324-72da-540f-a477-7a87af0cd27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f36b1-9f73-490e-87df-c17434113dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f36b1-9f73-490e-87df-c17434113dfd.jpg?1",
             "name": "Excalibur, Sword of Eden",
             "text": "This spell costs {X} less to cast, where X is the total mana value of historic permanents you control.\nEquipped creature gets +10/+0 and has vigilance.\nEquip legendary creature {2}",
             "colours": [],
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "c42edd5b-2fc3-548e-85de-299672ba8f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f43e214-2e20-4168-abff-e5abefc5b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f43e214-2e20-4168-abff-e5abefc5b009.jpg?1",
             "name": "Mj\u00f6lnir, Storm Hammer",
             "text": "When Mj\u00f6lnir enters the battlefield, attach it to target legendary creature you control.\nWhenever equipped creature attacks, tap target creature defending player controls and put a stun counter on it. Then Mj\u00f6lnir deals damage to each opponent equal to the number of tapped creatures that opponent controls.\nEquip {4}",
             "colours": [],
@@ -6521,7 +6521,7 @@
         },
         {
             "id": "7e1dbedf-3af8-573c-af04-51f3241be5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760d9a05-e0b9-4c26-b994-6b0eaf0af90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760d9a05-e0b9-4c26-b994-6b0eaf0af90e.jpg?1",
             "name": "Abstergo Entertainment",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Exile Abstergo Entertainment: Return up to one target historic card from your graveyard to your hand, then exile all graveyards.",
             "colours": [],
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "4f356dd4-0e39-5869-a06d-4a6fdf068fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa62c7e-7f03-42c0-b761-1fdeb3c9e4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa62c7e-7f03-42c0-b761-1fdeb3c9e4ee.jpg?1",
             "name": "The Capitoline Triad",
             "text": "Those Who Came Before \u2014 This spell costs {1} less to cast for each historic card in your graveyard.\nExile any number of historic cards from your graveyard with total mana value 30 or greater: You get an emblem with \"Creatures you control have base power and toughness 9/9.\"",
             "colours": [],
@@ -6589,7 +6589,7 @@
         },
         {
             "id": "facef648-f308-5e1d-9057-83e9dab21276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42db7f-b1f3-4588-9ff5-4f4bc3f53ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42db7f-b1f3-4588-9ff5-4f4bc3f53ee4.jpg?1",
             "name": "Caduceus, Staff of Hermes",
             "text": "Equipped creature has lifelink.\nAs long as you have 30 or more life, equipped creature gets +5/+5 and has indestructible and \"Prevent all damage that would be dealt to this creature.\"\nEquip {W}{W}",
             "colours": [
@@ -6627,7 +6627,7 @@
         },
         {
             "id": "95d86261-2ceb-503f-83ab-f7e86256acf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2285f6e4-99bd-4f61-9788-0107c119753e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2285f6e4-99bd-4f61-9788-0107c119753e.jpg?1",
             "name": "Distract the Guards",
             "text": "Freerunning {1}{W}\nCreate three 1/1 white Human Rogue creature tokens.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "918d67e7-1be3-50fe-9530-c10810dd4a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fffb8d-e639-4863-84a1-37cd330a3226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fffb8d-e639-4863-84a1-37cd330a3226.jpg?1",
             "name": "Haystack",
             "text": "{2}, {T}: Target creature you control phases out.",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "da4297c4-3427-5cb9-9e6c-2820f2a8125a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b283b1-a3df-48f8-b1e6-a97a1aa1dcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b283b1-a3df-48f8-b1e6-a97a1aa1dcc6.jpg?1",
             "name": "Hookblade",
             "text": "When Hookblade enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0.\nAs long as it's your turn, equipped creature has flying.\nEquip {2}",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "27e4e9cd-e41e-5cf3-b848-b5a48e586867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67367ca8-0a23-4192-bca5-08dbd655f0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67367ca8-0a23-4192-bca5-08dbd655f0ba.jpg?1",
             "name": "Layla Hassan",
             "text": "First strike\nWhen Layla Hassan enters the battlefield and whenever one or more Assassins you control deal combat damage to a player, return target historic card from your graveyard to your hand.",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "34a6d039-4b61-5c4b-9f31-1ec649a6db7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f532fa8-9a97-4d9d-b6aa-f9d356721459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f532fa8-9a97-4d9d-b6aa-f9d356721459.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "2f592fa6-58cc-581c-a211-1966d7953b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9c27c-d73a-4c8e-a396-4348a2695edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9c27c-d73a-4c8e-a396-4348a2695edb.jpg?1",
             "name": "Reconnaissance",
             "text": "{0}: Remove target attacking creature you control from combat and untap it. (If you activate during end of combat, the creature will untap after it deals combat damage.)",
             "colours": [
@@ -6833,7 +6833,7 @@
         },
         {
             "id": "f4fcba81-44bb-52e1-9181-2d66a923c74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9648392a-78a2-4ae5-a218-cfd2bcd9bc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9648392a-78a2-4ae5-a218-cfd2bcd9bc5d.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "872216e7-c662-5b47-a9ac-6219d2165af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca84e5a-4ce8-47fa-98b8-9d2dc65dd6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca84e5a-4ce8-47fa-98b8-9d2dc65dd6c8.jpg?1",
             "name": "Senu, Keen-Eyed Protector",
             "text": "Flying, vigilance\n{T}, Exile Senu, Keen-Eyed Protector: You gain 2 life and scry 2.\nWhen a legendary creature you control attacks and isn't blocked, if Senu is exiled, put it onto the battlefield attacking.",
             "colours": [
@@ -6906,7 +6906,7 @@
         },
         {
             "id": "3db8b1fc-4847-52b5-9401-6453ec2f300c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825615d2-2bb9-486e-8a05-4244b7ba66c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825615d2-2bb9-486e-8a05-4244b7ba66c3.jpg?1",
             "name": "Tax Collector",
             "text": "When Tax Collector enters the battlefield, choose one \u2014\n\u2022 Tax \u2014 Until your next turn, spells your opponents cast cost {1} more to cast.\n\u2022 Arrest \u2014 Detain target creature an opponent controls.",
             "colours": [
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "b79d4445-2619-5faf-8fb2-9adfba9a0f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4107fda1-ed94-4920-95c9-329d243fdc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4107fda1-ed94-4920-95c9-329d243fdc01.jpg?1",
             "name": "Templar Knight",
             "text": "Vigilance\n{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Templar Knight.",
             "colours": [
@@ -6978,7 +6978,7 @@
         },
         {
             "id": "8692f1db-648f-57b3-83ce-9bee6974c053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9cdb95-d110-4cc8-bfb0-665539fb4712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9cdb95-d110-4cc8-bfb0-665539fb4712.jpg?1",
             "name": "What Must Be Done",
             "text": "Choose one \u2014\n\u2022 Let the World Burn \u2014 Destroy all artifacts and creatures.\n\u2022 Release Juno \u2014 Return target historic permanent card from your graveyard to the battlefield. It enters with two additional +1/+1 counters on it if it's a creature.",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "9b393510-dbd9-587a-b55b-f6b7e7f623b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede0e73-35ae-42f2-af1d-db1a346743ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede0e73-35ae-42f2-af1d-db1a346743ad.jpg?1",
             "name": "Assassin Gauntlet",
             "text": "When Assassin Gauntlet enters the battlefield, attach it to up to one target creature you control. Tap all creatures target opponent controls.\nEquipped creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, draw a card, then discard a card.\"\nEquip {2}",
             "colours": [
@@ -7047,7 +7047,7 @@
         },
         {
             "id": "dc6dd1cd-5bf6-5408-a2a3-e694b4d129ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4c9ebe-996a-44ae-9f97-46f0e8096da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4c9ebe-996a-44ae-9f97-46f0e8096da4.jpg?1",
             "name": "Become Anonymous",
             "text": "Exile target creature you control and the top two cards of your library in a face-down pile, shuffle that pile, then cloak those cards. They enter the battlefield tapped.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "c54598fc-706c-5f1e-8f3e-900e75599a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c07fa3-a823-420a-b9c5-72f0b9766bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c07fa3-a823-420a-b9c5-72f0b9766bb4.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "fb8743b6-eeab-5494-bf8a-5dda76074bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be26a459-2595-44ed-a875-1163942b3656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be26a459-2595-44ed-a875-1163942b3656.jpg?1",
             "name": "Crystal Skull, Isu Spyglass",
             "text": "You may look at the top card of your library any time.\nYou may play historic lands and cast historic spells from the top of your library.\n{T}: Add {U}.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "0d55740d-e7fe-5d00-825e-833810cb5c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeb049f-6d05-47c5-9f6c-e0f1547e3638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeb049f-6d05-47c5-9f6c-e0f1547e3638.jpg?1",
             "name": "Desynchronization",
             "text": "Return each nonland permanent that's not historic to its owner's hand.",
             "colours": [
@@ -7183,7 +7183,7 @@
         },
         {
             "id": "f7999a2c-65c5-5613-b5ee-e9f4e163c875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab7020-bd24-4c43-9c7c-5a283d6f650d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab7020-bd24-4c43-9c7c-5a283d6f650d.jpg?1",
             "name": "Eagle Vision",
             "text": "Freerunning {1}{U}\nDraw three cards.",
             "colours": [
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "f6fb398c-ffcc-547c-8eec-cf08b0bd465b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726bf33c-1555-4056-9544-e7477659726b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726bf33c-1555-4056-9544-e7477659726b.jpg?1",
             "name": "Escape Detection",
             "text": "Freerunning\u2014\nReturn a blue creature you control to its owner's hand.\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -7249,7 +7249,7 @@
         },
         {
             "id": "24cf4664-ea6a-5481-bc37-e1429e331ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d942a-8f41-49fb-982e-152001855ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d942a-8f41-49fb-982e-152001855ee0.jpg?1",
             "name": "Evie Frye",
             "text": "Partner with Jacob Frye\n{1}, {T}: Draw a card, then discard a card. When you discard a creature card this way, target creature you control can't be blocked this turn.",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "9a255a00-bd42-5132-a203-e85bacd90fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f8996b-bb80-4722-9b47-3b54472155e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f8996b-bb80-4722-9b47-3b54472155e0.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "{3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.\n{2}{U}, {T}: Draw a card, then discard a card. If the discarded card was an artifact card, exile it from your graveyard. If you do, create a token that's a copy of it, except it's a 0/2 Thopter artifact creature with flying in addition to its other types.",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "3fcacf40-a94f-5767-86a6-a69c39b3b19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317cb518-1b76-4402-93b5-01c971a5dc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317cb518-1b76-4402-93b5-01c971a5dc55.jpg?1",
             "name": "Loyal Inventor",
             "text": "Vigilance\nWhen Loyal Inventor enters the battlefield, you may search your library for an artifact card, reveal it, then shuffle. Put that card into your hand if you control an Assassin. Otherwise, put that card on top of your library.",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "abf69e85-cbf4-5c50-9690-2823e6d65eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c8a2b-dbba-423d-8f86-7c5ec184bfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c8a2b-dbba-423d-8f86-7c5ec184bfcf.jpg?1",
             "name": "Propaganda",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "50396ff3-7d08-5d0d-8a34-365b979f9d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c42842-d844-4b3b-bef3-dc7da7d2efb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c42842-d844-4b3b-bef3-dc7da7d2efb8.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "1b444658-e303-597a-8a77-9253c60c6d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653745b0-4e3b-4147-8b48-16560e706055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653745b0-4e3b-4147-8b48-16560e706055.jpg?1",
             "name": "Assassin Initiate",
             "text": "{1}: Assassin Initiate gains your choice of flying, deathtouch, or lifelink until end of turn.",
             "colours": [
@@ -7467,7 +7467,7 @@
         },
         {
             "id": "7f2535b8-0796-5431-9828-46ffd49f0ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c3514a-5e57-44b5-867d-cbfb66a90dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c3514a-5e57-44b5-867d-cbfb66a90dfb.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.",
             "colours": [
@@ -7501,7 +7501,7 @@
         },
         {
             "id": "9f65a921-9b01-54b4-b975-ac767ad683db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11374a-183c-454a-882b-cbc2059dba26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11374a-183c-454a-882b-cbc2059dba26.jpg?1",
             "name": "Chain Assassination",
             "text": "Freerunning {1}{B}\nDestroy target creature. If another creature died this turn, draw a card.",
             "colours": [
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "991dacbd-b2b3-5966-be06-1aa85e63aada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454aa2e5-fc90-4338-a319-010d4d706ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454aa2e5-fc90-4338-a319-010d4d706ae7.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy enters the battlefield, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "bece0746-8a9c-56bd-af40-1639dde7ef20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90bbc98-f3ae-4963-910d-f5c8d9a0ba72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90bbc98-f3ae-4963-910d-f5c8d9a0ba72.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness enters the battlefield, choose a creature type.\nCreatures of the chosen type have fear.",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "5f421a6f-c65a-54b7-b9b3-37a54d1c517a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c1e9c6-a9ec-4aca-a80d-9a00b05c1218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c1e9c6-a9ec-4aca-a80d-9a00b05c1218.jpg?1",
             "name": "Desmond Miles",
             "text": "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
             "colours": [
@@ -7641,7 +7641,7 @@
         },
         {
             "id": "8160561f-90a6-53e8-ac8b-76a2d7d9ca12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5184ac-f73a-4fdc-a531-0f577892997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5184ac-f73a-4fdc-a531-0f577892997a.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}.\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "7667622e-3052-59fe-bb82-5372531d83bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841fefda-5da3-455e-9f11-1ef5c97c1b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841fefda-5da3-455e-9f11-1ef5c97c1b0d.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has mana value 2 or less.\nRevolt \u2014 Destroy that creature if it has mana value 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "3ade7430-eb68-5774-9d7c-26cd7874d0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbeed2f0-f42a-4f1f-a9a3-12140f4842f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbeed2f0-f42a-4f1f-a9a3-12140f4842f6.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "e34dbea2-e978-52fd-9690-049353330a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fb6b8-7c74-42f7-82f2-33503c1f910a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fb6b8-7c74-42f7-82f2-33503c1f910a.jpg?1",
             "name": "Hemlock Vial",
             "text": "When Hemlock Vial enters the battlefield, you draw a card and you lose 1 life.\n{B}, {T}, Sacrifice Hemlock Vial: Each equipped creature and Equipment you control gains deathtouch until end of turn.",
             "colours": [
@@ -7785,7 +7785,7 @@
         },
         {
             "id": "d017ee66-09ea-59cc-93d8-a3c423a5ed85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666fafa-54b5-495e-8168-c579fd901b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666fafa-54b5-495e-8168-c579fd901b58.jpg?1",
             "name": "Jacob Frye",
             "text": "Partner with Evie Frye\nWhenever one or more Assassins you control deal combat damage to a player, exile up to one target Assassin card or card with freerunning from your graveyard. If you do, copy it. You may cast the copy.",
             "colours": [
@@ -7824,7 +7824,7 @@
         },
         {
             "id": "91fbf840-4b5e-5c06-b29d-4141ff6b73c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e18830-3668-4c23-96aa-d241f79adbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e18830-3668-4c23-96aa-d241f79adbd5.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "2025d6c5-73e2-5ecf-906d-4313b1e979eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec58f0-494d-46bb-a49e-265a6d852244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec58f0-494d-46bb-a49e-265a6d852244.jpg?1",
             "name": "Petty Larceny",
             "text": "Freerunning {1}{B}\nLook at the top two cards of target opponent's library and exile those cards face down. You may play those cards for as long as they remain exiled, and mana of any type can be spent to cast them. Create a Treasure token.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "5548605f-e576-51b2-ba71-ca0f196f1c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b5257-f171-4bd5-80db-f5a627fd337d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b5257-f171-4bd5-80db-f5a627fd337d.jpg?1",
             "name": "Phantom Blade",
             "text": "When Phantom Blade enters the battlefield, attach it to up to one target creature you control. Destroy up to one other target creature.\nEquipped creature gets +1/+1 and has menace.\nEquip {2}",
             "colours": [
@@ -7925,7 +7925,7 @@
         },
         {
             "id": "0dfe1c5a-bb20-53ab-b632-a94af7d743d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e71c-e401-4e5b-a4b9-d67c21bd1b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e71c-e401-4e5b-a4b9-d67c21bd1b7c.jpg?1",
             "name": "Restart Sequence",
             "text": "Freerunning {1}{B}\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -7958,7 +7958,7 @@
         },
         {
             "id": "5b469aab-2a43-5833-b2eb-d4ab5920f49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ddae3-192e-4b88-836b-b0e3defd2e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ddae3-192e-4b88-836b-b0e3defd2e99.jpg?1",
             "name": "Roshan, Hidden Magister",
             "text": "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
             "colours": [
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "a748cf5e-5bdb-58d1-9858-3328e829eed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319a380-974a-486f-9b1e-495383c58d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319a380-974a-486f-9b1e-495383c58d82.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -8035,7 +8035,7 @@
         },
         {
             "id": "5502dc77-ab44-5c80-86d3-ad5247fb8020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d6fad-24c7-47dc-8feb-de58c8e51c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d6fad-24c7-47dc-8feb-de58c8e51c33.jpg?1",
             "name": "Alexios, Deimos of Kosmos",
             "text": "Trample\nAlexios, Deimos of Kosmos attacks each combat if able, can't be sacrificed, and can't attack its owner.\nAt the beginning of each player's upkeep, that player gains control of Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -8074,7 +8074,7 @@
         },
         {
             "id": "24db147d-fb61-5b6f-89ea-852c318c8a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16abb80e-12ef-48a2-855e-c237c10a3f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16abb80e-12ef-48a2-855e-c237c10a3f92.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "ced0c00d-9a6a-5aaa-903d-6cadac149722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c014fb8d-748d-4a58-9065-17937fd4a9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c014fb8d-748d-4a58-9065-17937fd4a9f2.jpg?1",
             "name": "Hidden Footblade",
             "text": "Flash\nWhen Hidden Footblade enters the battlefield, attach it to target creature you control. That creature gains first strike until end of turn.\nEquipped creature gets +1/+0 and has haste.\nEquip {2}",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "c6ac9fcc-67ab-5a9c-9c4b-9fd5bacd155c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30933821-a64e-4c15-a7aa-e13cb89f46f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30933821-a64e-4c15-a7aa-e13cb89f46f5.jpg?1",
             "name": "Monastery Raid",
             "text": "Freerunning {X}{R}\nExile the top two cards of your library. If this spell's freerunning cost was paid, exile the top X cards of your library instead. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -8175,7 +8175,7 @@
         },
         {
             "id": "6efd980c-0dca-5fdb-8381-793743ce137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62be00b-b6cb-47df-aa60-7c77c2f15fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62be00b-b6cb-47df-aa60-7c77c2f15fd3.jpg?1",
             "name": "Overpowering Attack",
             "text": "Freerunning {2}{R}\nUntap all creatures you control that attacked this turn. If it's your main phase, there is an additional combat phase after this phase, followed by an additional main phase.",
             "colours": [
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "144b4b8f-0eaf-50bc-86bf-802ce7019464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a71cfd0-0e24-4ae4-9a7e-a5ab5fea46c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a71cfd0-0e24-4ae4-9a7e-a5ab5fea46c8.jpg?1",
             "name": "The Spear of Leonidas",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Bull Rush \u2014 It gains double strike until end of turn.\n\u2022 Summon \u2014 Create Phobos, a legendary 3/2 red Horse creature token.\n\u2022 Revelation \u2014 Discard two cards, then draw two cards.\nEquip {2}",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "62e0d0fa-3209-531d-8877-6715d62cb06e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f97fbc-2abd-4496-a29e-4cecac1440c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f97fbc-2abd-4496-a29e-4cecac1440c1.jpg?1",
             "name": "Aveline de Grandpr\u00e9",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, put that many +1/+1 counters on that creature.\nDisguise {B}{G}",
             "colours": [
@@ -8286,7 +8286,7 @@
         },
         {
             "id": "3bdc41d3-d7a2-5ad4-9e0d-dea4c41a9503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1cc216-14b3-4870-8162-18c646f958f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1cc216-14b3-4870-8162-18c646f958f4.jpg?1",
             "name": "Hunter's Bow",
             "text": "When Hunter's Bow enters the battlefield, attach it to target creature you control. That creature deals damage equal to its power to up to one target creature you don't control.\nEquipped creature has reach and ward {2}.\nEquip {1}",
             "colours": [
@@ -8321,7 +8321,7 @@
         },
         {
             "id": "188ac3e0-9a67-5298-94f4-ac5f88f3b50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262c036d-4c44-48e7-a6df-f54442d93386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262c036d-4c44-48e7-a6df-f54442d93386.jpg?1",
             "name": "Palazzo Archers",
             "text": "Reach\nWhenever a creature with flying attacks you or a planeswalker you control, Palazzo Archers deals damage equal to its power to that creature.",
             "colours": [
@@ -8357,7 +8357,7 @@
         },
         {
             "id": "04914ed7-746b-52b3-86a9-56b1e711abf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa22038-6b13-422c-a07c-41e233b7405b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa22038-6b13-422c-a07c-41e233b7405b.jpg?1",
             "name": "Viewpoint Synchronization",
             "text": "Freerunning {2}{G}\nSearch your library for up to three basic land cards and reveal them. Put two of them onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "4310b6d6-adb7-58e7-be57-b43c230224f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb23cf5-f046-4310-853b-e5995693f2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb23cf5-f046-4310-853b-e5995693f2dd.jpg?1",
             "name": "Ad\u00e9wal\u00e9, Breaker of Chains",
             "text": "When Ad\u00e9wal\u00e9 enters the battlefield, reveal the top six cards of your library. Put an Assassin, Pirate, or Vehicle card from among them into your hand and the rest on the bottom of your library in a random order.\nWhenever a Vehicle you control deals combat damage to a player, you may return Ad\u00e9wal\u00e9 from your graveyard to your hand.",
             "colours": [
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "7c661814-c828-564f-97cc-056015029d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba4aba6-6ed8-46cc-89eb-ce546940e250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba4aba6-6ed8-46cc-89eb-ce546940e250.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "First strike\nWhenever Alta\u00efr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.",
             "colours": [
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "e35d0b7c-7c9e-577f-bb7c-1d23259f289f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c92faf6-1fbb-4e5e-93d8-22da66886f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c92faf6-1fbb-4e5e-93d8-22da66886f33.jpg?1",
             "name": "Arbaaz Mir",
             "text": "Whenever Arbaaz Mir or another nontoken historic permanent enters the battlefield under your control, Arbaaz Mir deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -8517,7 +8517,7 @@
         },
         {
             "id": "cf9e937f-64c2-5ea8-935e-dcab50c5c890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd4a-861c-4df4-a34b-f1a49a8e74fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd4a-861c-4df4-a34b-f1a49a8e74fa.jpg?1",
             "name": "Arno Dorian",
             "text": "Deathtouch\nOther Assassins you control get +2/+0.\nDisguise {B}{R}",
             "colours": [
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "7160c82d-2845-598c-8f6b-25464fc28ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66da05e-b3a7-4557-a7c3-97051ba24cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66da05e-b3a7-4557-a7c3-97051ba24cab.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -8594,7 +8594,7 @@
         },
         {
             "id": "b4d5eede-5cec-5ee8-8639-c44218626450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8afbe-1c29-4b23-9832-5656ac60acea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8afbe-1c29-4b23-9832-5656ac60acea.jpg?1",
             "name": "Aya of Alexandria",
             "text": "Menace, lifelink\nWhenever a historic creature you control deals combat damage to a player, create a 1/1 black Assassin creature token with menace.",
             "colours": [
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "3abdaa2a-a2f0-58f6-a348-12db3d2fbea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2146945f-efdc-4612-a341-acadb4bb36f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2146945f-efdc-4612-a341-acadb4bb36f2.jpg?1",
             "name": "Basim Ibn Ishaq",
             "text": "Whenever you cast a historic spell, draw a card. Basim Ibn Ishaq can't be blocked this turn. This ability triggers only once each turn.\nWhenever Basim Ibn Ishaq deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -8676,7 +8676,7 @@
         },
         {
             "id": "408a98a2-f25d-5f60-bb76-74abbeb004c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381497ac-653e-4c98-be03-2192d42885f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381497ac-653e-4c98-be03-2192d42885f5.jpg?1",
             "name": "Bayek of Siwa",
             "text": "Double strike\nAs long as it's your turn, other historic creatures you control have double strike.\nDisguise {1}{R}{W}",
             "colours": [
@@ -8717,7 +8717,7 @@
         },
         {
             "id": "20d84a9f-7de5-52d6-8e99-e175d1bec323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829debdc-862d-4277-9c87-1e5966e4837d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829debdc-862d-4277-9c87-1e5966e4837d.jpg?1",
             "name": "Bleeding Effect",
             "text": "At the beginning of combat on your turn, creatures you control gain flying until end of turn if a creature card in your graveyard has flying. The same is true for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -8752,7 +8752,7 @@
         },
         {
             "id": "cdf666b7-d602-5ebb-bc61-c81f93ee848a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef2b03a-0956-4086-85cf-c32cce09d6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef2b03a-0956-4086-85cf-c32cce09d6ef.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "Allies \u2014 At the beginning of your end step, put a +1/+1 counter on each of up to two other target legendary creatures.\nBetrayal \u2014 Whenever a legendary creature with counters on it dies, draw a card for each counter on it. You lose 2 life.",
             "colours": [
@@ -8794,7 +8794,7 @@
         },
         {
             "id": "fd7f4263-d662-5869-80ed-c9a05cd78d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0ce737-8066-444b-ae33-c84713305b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0ce737-8066-444b-ae33-c84713305b1a.jpg?1",
             "name": "Edward Kenway",
             "text": "At the beginning of your end step, create a Treasure token for each tapped Assassin, Pirate, and/or Vehicle you control.\nWhenever a Vehicle you control deals combat damage to a player, look at the top card of that player's library, then exile it face down. You may play that card for as long as it remains exiled.",
             "colours": [
@@ -8839,7 +8839,7 @@
         },
         {
             "id": "32008df4-a00c-57d5-9fc7-c7b2d5f02de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad1af4d-9643-46da-a91b-e85d56829c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad1af4d-9643-46da-a91b-e85d56829c43.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "Trample, haste\nWhenever Eivor, Wolf-Kissed deals combat damage to a player, you mill that many cards. You may put a Saga card and/or a land card from among them onto the battlefield.",
             "colours": [
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "1958464f-ff48-5dd8-abae-48d67f5c1990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e48432-2e3a-4673-aa08-1d1d4ed2f472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e48432-2e3a-4673-aa08-1d1d4ed2f472.jpg?1",
             "name": "Ezio, Brash Novice",
             "text": "Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.",
             "colours": [
@@ -8924,7 +8924,7 @@
         },
         {
             "id": "171c996e-03c2-5b64-9324-8303530ae03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99b18c2-3732-4e3c-a553-d2cb833f5eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99b18c2-3732-4e3c-a553-d2cb833f5eb5.jpg?1",
             "name": "Havi, the All-Father",
             "text": "Havi, the All-Father has indestructible as long as there are four or more historic cards in your graveyard.\nSage Project \u2014 Whenever Havi or another legendary creature you control dies, return target legendary creature card with lesser mana value from your graveyard to the battlefield tapped.",
             "colours": [
@@ -8967,7 +8967,7 @@
         },
         {
             "id": "8358f0f6-c319-5c22-9030-8a8e5360cfe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba72b7f-7dd2-47cf-a0fc-d14662878db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba72b7f-7dd2-47cf-a0fc-d14662878db8.jpg?1",
             "name": "Haytham Kenway",
             "text": "Protection from Assassins\nOther Knights you control get +2/+2 and have protection from Assassins.\nWhen Haytham Kenway enters the battlefield, for each opponent, exile up to one target creature that player controls until Haytham Kenway leaves the battlefield.",
             "colours": [
@@ -9008,7 +9008,7 @@
         },
         {
             "id": "a478eb48-7973-56b8-b579-ec60bc969630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4e1b9a-ac75-441c-bfdc-2dd7fc07d2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4e1b9a-ac75-441c-bfdc-2dd7fc07d2c2.jpg?1",
             "name": "Jackdaw",
             "text": "Whenever Jackdaw deals combat damage to a player, you may discard your hand. If you do, draw a card for each artifact you control.\nCrew 3",
             "colours": [
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "9111a371-26ba-5f19-a10f-9fb4a5a4f5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c803e701-61d5-4f13-a0c4-78f00af1a4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c803e701-61d5-4f13-a0c4-78f00af1a4ea.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "Haste\nWhen Kassandra enters the battlefield, search your graveyard, hand, and library for a card named The Spear of Leonidas, put it onto the battlefield, then shuffle.\nWhenever a creature you control with a legendary Equipment attached to it deals combat damage to a player, draw a card.",
             "colours": [
@@ -9091,7 +9091,7 @@
         },
         {
             "id": "c7a54d0e-ecd3-5f90-a5f9-bf49a247a90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88081ed8-0416-4c1b-bd59-5bf9fdc3cc5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88081ed8-0416-4c1b-bd59-5bf9fdc3cc5f.jpg?1",
             "name": "Lydia Frye",
             "text": "Lydia Frye can't be blocked by creatures with power 3 or greater.\nAt the beginning of your end step, surveil X, where X is the number of tapped Assassins you control.",
             "colours": [
@@ -9132,7 +9132,7 @@
         },
         {
             "id": "3e6ca01b-2c53-503f-b5c1-f4fb5eb787a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b07542-b347-43ca-8203-cbf648d5426c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b07542-b347-43ca-8203-cbf648d5426c.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "Haste\n{T}: Draw a card, then discard a card.\nWhenever you discard an Island, Pirate, or Vehicle card, create a tapped Treasure token.",
             "colours": [
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "cf578fcd-0e44-5daf-99bf-41a7be1b6b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96eb5dd-e846-433d-9cad-15c309c1ab75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96eb5dd-e846-433d-9cad-15c309c1ab75.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "5c57fb2f-488f-5425-8224-372dcaa13fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6133c3ab-9552-4b02-8c07-4128773a78b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6133c3ab-9552-4b02-8c07-4128773a78b9.jpg?1",
             "name": "Ratonhnhak\u00e9\ua789ton",
             "text": "As long as Ratonhnhak\u00e9:ton hasn't dealt damage yet, it has hexproof and can't be blocked.\nWhenever Ratonhnhak\u00e9:ton deals combat damage to a player, create a 1/1 black Assassin creature token with menace. When you do, return target Equipment card from your graveyard to the battlefield, then attach it to that token.",
             "colours": [
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "e3323e5a-8d74-5ff5-9dcd-bf66982b803b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d341e9-4d06-48fe-b668-3bd883c1bbe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d341e9-4d06-48fe-b668-3bd883c1bbe8.jpg?1",
             "name": "Reconstruct History",
             "text": "Return up to one target artifact card, up to one target enchantment card, up to one target instant card, up to one target sorcery card, and up to one target planeswalker card from your graveyard to your hand.\nExile Reconstruct History.",
             "colours": [
@@ -9288,7 +9288,7 @@
         },
         {
             "id": "edac2aac-66dc-51d5-a59d-df07384c1f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f07870-359c-4f7a-8287-b5f59b7dc72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f07870-359c-4f7a-8287-b5f59b7dc72b.jpg?1",
             "name": "Shao Jun",
             "text": "Leap Strike \u2014 As long as it's your turn, Shao Jun has flying and first strike.\nRope Dart \u2014 Tap two untapped artifacts you control: Shao Jun deals 1 damage to each opponent.",
             "colours": [
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "b1704986-eb4e-5718-aef0-f4421f6b4691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375bfc8-9272-4421-96cb-80bd8759db47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375bfc8-9272-4421-96cb-80bd8759db47.jpg?1",
             "name": "Shaun & Rebecca, Agents",
             "text": "Vigilance\nWhen Shaun & Rebecca, Agents enters the battlefield, search your graveyard, hand, and library for a card named The Animus and put it onto the battlefield, then shuffle.\n{T}: Add {C}. When you do, mill two cards.",
             "colours": [
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "62814d9c-45d6-564c-a9b9-1b76cfed9a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3293c01a-5b3d-4405-979c-726c0a6b0e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3293c01a-5b3d-4405-979c-726c0a6b0e97.jpg?1",
             "name": "Shay Cormac",
             "text": "{1}: Permanents your opponents control lose hexproof, indestructible, protection, shroud, and ward until end of turn.\nWhenever a creature an opponent controls becomes the target of a spell or ability you control, put a bounty counter on that creature.\nWhenever a creature with a bounty counter on it dies, put two +1/+1 counters on Shay Cormac.",
             "colours": [
@@ -9415,7 +9415,7 @@
         },
         {
             "id": "9ce0d1f4-f5cf-5a8d-819f-85748af59594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c62a9-65b7-4ad8-a276-568c2a3d8cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c62a9-65b7-4ad8-a276-568c2a3d8cff.jpg?1",
             "name": "Sigurd, Jarl of Ravensthorpe",
             "text": "Vigilance, trample, lifelink\nBoast \u2014 {1}: Put a lore counter on target Saga you control or remove one from it.\nWhenever you put a lore counter on a Saga you control, put a +1/+1 counter on up to one other target creature.",
             "colours": [
@@ -9458,7 +9458,7 @@
         },
         {
             "id": "d75eb381-e3e5-5b59-89ea-5fb9abb04a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b54844c-f757-426c-8d4b-5636673cb87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b54844c-f757-426c-8d4b-5636673cb87a.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "Defender\nSokrates, Athenian Teacher has hexproof as long as it's untapped.\nSokratic Dialogue \u2014 {T}: Until end of turn, target creature gains \"If this creature would deal combat damage to a player, prevent that damage. This creature's controller and that player each draw half that many cards, rounded down.\"",
             "colours": [
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "4f2704ed-b629-50c1-9f60-6dad08a35fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d640f44-7521-4e36-ba27-cb1c94507d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d640f44-7521-4e36-ba27-cb1c94507d0e.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "29c3a43d-5d6b-543a-a7e4-03b4d7222ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42de1eb-0d5a-406d-ab09-2913d59b9788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42de1eb-0d5a-406d-ab09-2913d59b9788.jpg?1",
             "name": "Adrestia",
             "text": "Islandwalk\nWhenever Adrestia attacks, if an Assassin crewed it this turn, draw a card. Adrestia becomes an Assassin in addition to its other types until end of turn.\nCrew 1",
             "colours": [],
@@ -9568,7 +9568,7 @@
         },
         {
             "id": "081906d3-3a5a-5a14-85f0-073e461d3bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a84bf5-bb15-4a6e-b4c7-7218967b33f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a84bf5-bb15-4a6e-b4c7-7218967b33f2.jpg?1",
             "name": "The Animus",
             "text": "At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.",
             "colours": [],
@@ -9600,7 +9600,7 @@
         },
         {
             "id": "a81ebf5f-5682-519a-9b3b-7b27f916a144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f7995-1817-46e9-93ba-6f10051d3865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f7995-1817-46e9-93ba-6f10051d3865.jpg?1",
             "name": "Apple of Eden, Isu Relic",
             "text": "{T}, Pay 4 life, Sacrifice Apple of Eden: Look at target opponent's hand and exile those cards face down. You may play those cards this turn, and mana of any type can be spent to cast them. Until end of turn, whenever you play a land or cast a spell this way, its owner draws a card. At the beginning of the next end step, return the exiled cards to their owner's hand. Activate only as a sorcery.",
             "colours": [],
@@ -9632,7 +9632,7 @@
         },
         {
             "id": "8821299f-2a47-5d6c-af04-008ec09956a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2e512d-0aa2-4a1e-82cc-8ed60129bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2e512d-0aa2-4a1e-82cc-8ed60129bf5e.jpg?1",
             "name": "Brotherhood Regalia",
             "text": "Equipped creature has ward {2}, is an Assassin in addition to its other types, and can't be blocked.\nEquip legendary creature {1}\nEquip {3}",
             "colours": [],
@@ -9663,7 +9663,7 @@
         },
         {
             "id": "2537bd68-d651-5c0d-8595-e023ef491fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e357b2d-a3c1-490e-a37c-cdf42abcfa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e357b2d-a3c1-490e-a37c-cdf42abcfa60.jpg?1",
             "name": "Excalibur, Sword of Eden",
             "text": "This spell costs {X} less to cast, where X is the total mana value of historic permanents you control.\nEquipped creature gets +10/+0 and has vigilance.\nEquip legendary creature {2}",
             "colours": [],
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "7140383c-9942-54aa-99aa-dff7c10054a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5986796-08a5-4bbb-992e-5fb8cdf2864a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5986796-08a5-4bbb-992e-5fb8cdf2864a.jpg?1",
             "name": "Hidden Blade",
             "text": "Flash\nWhen Hidden Blade enters the battlefield, attach it to target creature you control. If that creature is an Assassin, it gains deathtouch until end of turn.\nEquipped creature gets +1/+0 and has first strike.\nEquip {2}",
             "colours": [],
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "e480cd0b-d129-5b41-acc6-4721c4253096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb2f71-f973-4565-9c24-dab21da80b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb2f71-f973-4565-9c24-dab21da80b14.jpg?1",
             "name": "Mj\u00f6lnir, Storm Hammer",
             "text": "When Mj\u00f6lnir enters the battlefield, attach it to target legendary creature you control.\nWhenever equipped creature attacks, tap target creature defending player controls and put a stun counter on it. Then Mj\u00f6lnir deals damage to each opponent equal to the number of tapped creatures that opponent controls.\nEquip {4}",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "72cd52ba-6979-5da8-a0db-b0459a107a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd57bdd4-9b93-4a0c-8c80-46bc02af9a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd57bdd4-9b93-4a0c-8c80-46bc02af9a3c.jpg?1",
             "name": "Smoke Bomb",
             "text": "Flash\nAll creatures have shroud.\nAt the beginning of your upkeep, sacrifice Smoke Bomb. When you do, target creature you control can't be blocked this turn.",
             "colours": [],
@@ -9792,7 +9792,7 @@
         },
         {
             "id": "e00c737a-9769-5a25-a420-7184c4c1e0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63c09d-2898-4ebb-b88e-b5962d427abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63c09d-2898-4ebb-b88e-b5962d427abc.jpg?1",
             "name": "Staff of Eden, Vault's Key",
             "text": "When Staff of Eden, Vault's Key enters the battlefield, put target legendary permanent card not named Staff of Eden, Vault's Key from a graveyard onto the battlefield under your control.\n{T}: Draw a card for each permanent you control but don't own.",
             "colours": [],
@@ -9824,7 +9824,7 @@
         },
         {
             "id": "1562c3ca-83bb-525f-920c-4c4361fe4ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c187b0-f196-4180-bbe0-d7f470974880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c187b0-f196-4180-bbe0-d7f470974880.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -9856,7 +9856,7 @@
         },
         {
             "id": "39203528-aa58-5cf1-bc12-cb37a08f014d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef2d91d-97fc-4523-8471-511e6376ce64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef2d91d-97fc-4523-8471-511e6376ce64.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -9888,7 +9888,7 @@
         },
         {
             "id": "d9224ee7-da7a-5b95-ad6d-9afb901f974d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e84b05-15fe-4335-a5fd-a26d1905f313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e84b05-15fe-4335-a5fd-a26d1905f313.jpg?1",
             "name": "Towering Viewpoint",
             "text": "Defender, reach\nLeap of Faith \u2014 {3}: Target creature gains flying until end of turn.",
             "colours": [],
@@ -9920,7 +9920,7 @@
         },
         {
             "id": "5b7355f0-b82b-56cb-91ee-02d28de637e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef1c0fa-590b-437e-992c-811577e14e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef1c0fa-590b-437e-992c-811577e14e58.jpg?1",
             "name": "Yggdrasil, Rebirth Engine",
             "text": "When Yggdrasil, Rebirth Engine enters the battlefield, exile all creature cards from your graveyard.\n{T}: Exile the top three cards of your library.\n{4}, {T}: Put a creature card exiled with Yggdrasil onto the battlefield under your control. It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "4e40f59b-b1c7-5c1b-800a-757390c28071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9f47d4-44fc-4278-8cc8-8914e9a9e565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9f47d4-44fc-4278-8cc8-8914e9a9e565.jpg?1",
             "name": "Abstergo Entertainment",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Exile Abstergo Entertainment: Return up to one target historic card from your graveyard to your hand, then exile all graveyards.",
             "colours": [],
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "8fd3ab39-e1e4-52b0-a79e-c1921304e2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e43b4-2208-4df0-a8b2-380cfd22dde5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e43b4-2208-4df0-a8b2-380cfd22dde5.jpg?1",
             "name": "Brotherhood Headquarters",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast an Assassin spell or a spell that has freerunning, or to activate an ability of an Assassin source.",
             "colours": [],
@@ -10013,7 +10013,7 @@
         },
         {
             "id": "52ee09de-468a-5a6b-8cdb-e96498e7c0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282a9380-01a1-4fc6-bcd4-2c8543a75eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282a9380-01a1-4fc6-bcd4-2c8543a75eba.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "",
             "colours": [
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "c484ba92-cf15-568f-98fa-c40886b209d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f92d7b6-58c8-485c-86ff-d63f1d3dd481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f92d7b6-58c8-485c-86ff-d63f1d3dd481.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "",
             "colours": [
@@ -10102,7 +10102,7 @@
         },
         {
             "id": "3646421f-71bf-5ec4-b3f1-3064772bd4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f4e4d-e3ed-483f-b9af-2f4072524742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f4e4d-e3ed-483f-b9af-2f4072524742.jpg?1",
             "name": "Edward Kenway",
             "text": "",
             "colours": [
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "936baacb-9eb5-50a2-acf6-51c378601611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fcb189-1a34-4bf5-8bde-3846eec88172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fcb189-1a34-4bf5-8bde-3846eec88172.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "",
             "colours": [
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "c9747c67-1734-5ab2-b742-2d5980403c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f053676-de35-4465-b3b2-ce6050055e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f053676-de35-4465-b3b2-ce6050055e85.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "",
             "colours": [
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "aba94376-4071-51d9-a063-f407ac03e016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2036b2e-89d6-448a-bfcb-50b2247ee17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2036b2e-89d6-448a-bfcb-50b2247ee17a.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "",
             "colours": [
@@ -10277,7 +10277,7 @@
         },
         {
             "id": "3c389f9c-e459-5b16-87b5-d51644f05b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a5db83-0098-4e2b-bf23-146e88b9cca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a5db83-0098-4e2b-bf23-146e88b9cca9.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "",
             "colours": [
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "d921ca62-c66b-5133-a74b-9240bbff9a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4242961d-87e8-4dd2-bdea-5d765a5cf136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4242961d-87e8-4dd2-bdea-5d765a5cf136.jpg?1",
             "name": "Eivor, Battle-Ready",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nHaste (This creature can attack as soon as it comes under your control.)\nWhenever Eivor, Battle-Ready attacks, it deals damage equal to the number of Equipment you control to each opponent.",
             "colours": [
@@ -10358,7 +10358,7 @@
         },
         {
             "id": "05acdbd7-bed4-55c2-8bff-3e56d74ef76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdc8019-9b5e-4d9a-a09b-2a14f41ddfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdc8019-9b5e-4d9a-a09b-2a14f41ddfe1.jpg?1",
             "name": "Ezio, Blade of Vengeance",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever an Assassin you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -10396,7 +10396,7 @@
         },
         {
             "id": "5e62a0e8-e94f-54ad-9bab-87e6afb62ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cf2cd1-f7b3-4a23-a23a-6eb0af5451cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cf2cd1-f7b3-4a23-a23a-6eb0af5451cf.jpg?1",
             "name": "Battlefield Improvisation",
             "text": "Target creature gets +2/+2 until end of turn. If that creature is attacking, you may attach any number of Equipment you control to it.",
             "colours": [
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "30d659fd-5603-591d-9979-e724561a33f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe06e87f-8915-4fc2-81fd-168a371dc407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe06e87f-8915-4fc2-81fd-168a371dc407.jpg?1",
             "name": "Detained by Legionnaires",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -10460,7 +10460,7 @@
         },
         {
             "id": "f04f0cf2-8e4e-52f7-a9aa-ceb6269a1763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c9e60-fc14-48fe-bca9-b74f82301835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c9e60-fc14-48fe-bca9-b74f82301835.jpg?1",
             "name": "Escarpment Fortress",
             "text": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)\nOther creatures you control get +1/+0.\nWhenever you attack with two or more creatures, draw a card.",
             "colours": [
@@ -10493,7 +10493,7 @@
         },
         {
             "id": "130e7e0b-2ca6-5245-91ab-36a677802e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda99319-9312-42c4-adc0-77b49768d014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda99319-9312-42c4-adc0-77b49768d014.jpg?1",
             "name": "Keen-Eyed Raven",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Keen-Eyed Raven enters the battlefield, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -10526,7 +10526,7 @@
         },
         {
             "id": "fd9801ef-2774-5745-9c99-3752d2990dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301310b3-c031-4fd3-a47e-9645b6177329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301310b3-c031-4fd3-a47e-9645b6177329.jpg?1",
             "name": "Settlement Blacksmith",
             "text": "When Settlement Blacksmith enters the battlefield, if you control an Equipment, draw a card.",
             "colours": [
@@ -10560,7 +10560,7 @@
         },
         {
             "id": "fce9a5eb-e510-56bd-9408-84906d7879fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef45be55-42d7-475c-b405-78e856530277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef45be55-42d7-475c-b405-78e856530277.jpg?1",
             "name": "Assassin Den",
             "text": "Defender (This creature can't attack.)\n{3}{U}: Put a +1/+1 counter on target creature you control. It can't be blocked this turn. Activate only as a sorcery.",
             "colours": [
@@ -10593,7 +10593,7 @@
         },
         {
             "id": "6f2063a0-3b72-522c-80c8-b362be13aa13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0157325c-b064-4c0a-9b5d-ecdf0ed15d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0157325c-b064-4c0a-9b5d-ecdf0ed15d9c.jpg?1",
             "name": "Brotherhood Spy",
             "text": "At the beginning of combat on your turn, if you control a legendary Assassin, Brotherhood Spy gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -10627,7 +10627,7 @@
         },
         {
             "id": "f5c72d3c-bb9c-55ee-9014-041eb0bf417e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551d1f1e-8bc0-4196-8998-0aa7db23b388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551d1f1e-8bc0-4196-8998-0aa7db23b388.jpg?1",
             "name": "Hookblade Veteran",
             "text": "As long as it's your turn, Hookblade Veteran has flying. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "3cc8fd5e-3326-5a2e-a265-974c2e6a638a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ad4bd6-c6a5-420f-8491-7696f9850a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ad4bd6-c6a5-420f-8491-7696f9850a05.jpg?1",
             "name": "Tranquilize",
             "text": "Tap target creature an opponent controls and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "126bd3d0-2ca2-53b2-b4df-38068c7d4782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef922e-81b4-47e6-bd37-8ec0cb29700a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef922e-81b4-47e6-bd37-8ec0cb29700a.jpg?1",
             "name": "Brotherhood Ambushers",
             "text": "Freerunning {3}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)",
             "colours": [
@@ -10726,7 +10726,7 @@
         },
         {
             "id": "55855d9a-9530-5433-bca9-5c6495247075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b79ee23-d917-48f3-b014-d513f1c5ff54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b79ee23-d917-48f3-b014-d513f1c5ff54.jpg?1",
             "name": "Brotherhood Patriarch",
             "text": "When Brotherhood Patriarch dies, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -10760,7 +10760,7 @@
         },
         {
             "id": "bb207ae4-a434-5dd6-8fb6-85a3f1224b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb19a35-7224-4fe2-a0c0-17b93d2837ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb19a35-7224-4fe2-a0c0-17b93d2837ad.jpg?1",
             "name": "Merciless Harlequin",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nWhen Merciless Harlequin enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -10794,7 +10794,7 @@
         },
         {
             "id": "4749c4cd-9a7f-54aa-9ae9-8ec3b4a639da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3efb96a-a722-493a-be0e-a64583f8c3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3efb96a-a722-493a-be0e-a64583f8c3df.jpg?1",
             "name": "Poison-Blade Mentor",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Poison-Blade Mentor attacks, another target Assassin you control gains deathtouch until end of turn.",
             "colours": [
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "a91d1445-90f7-562b-a285-0a5249e52f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbf2a-46d5-4371-b4eb-a8dbebe18dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbf2a-46d5-4371-b4eb-a8dbebe18dcc.jpg?1",
             "name": "Headsplitter",
             "text": "When Headsplitter enters the battlefield, create a 1/1 black Assassin creature token with menace, then attach Headsplitter to it.\nEquipped creature gets +1/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -10861,7 +10861,7 @@
         },
         {
             "id": "630d2b52-7fe4-55a8-9e5e-df80eb51288a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc770fd-d513-420b-94f8-f2d28d8ed8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc770fd-d513-420b-94f8-f2d28d8ed8d1.jpg?1",
             "name": "Labyrinth Adversary",
             "text": "Trample (This creature can deal excess combat damage to the player it's attacking.)\nWhenever you attack, you may pay {1}{R}. When you do, target creature can't block this turn.",
             "colours": [
@@ -10894,7 +10894,7 @@
         },
         {
             "id": "6ad57373-188a-52f5-b352-fb7002f637e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34a45ab-793e-4198-8327-e13287e0b74c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34a45ab-793e-4198-8327-e13287e0b74c.jpg?1",
             "name": "Misthios's Fury",
             "text": "Misthios's Fury deals 3 damage to target creature. If you control an Equipment, Misthios's Fury also deals 2 damage to that creature's controller.",
             "colours": [
@@ -10925,7 +10925,7 @@
         },
         {
             "id": "791a866a-2585-5d98-8eb7-df759c7f4f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16fba05-25d7-4495-a9f6-cec6b3aabbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16fba05-25d7-4495-a9f6-cec6b3aabbbd.jpg?1",
             "name": "Spartan Veteran",
             "text": "As long as it's your turn, Spartan Veteran has first strike. (It deals combat damage before creatures without first strike.)\n{2}: Spartan Veteran gets +1/+0 until end of turn.",
             "colours": [
@@ -10959,7 +10959,7 @@
         },
         {
             "id": "e164db71-817b-5084-baf6-445ef8626fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be38985c-f7a9-4885-9035-09390b4b754a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be38985c-f7a9-4885-9035-09390b4b754a.jpg?1",
             "name": "Surtr, Fiery J\u00f6tun",
             "text": "Trample (This creature can deal excess combat damage to the player it's attacking.)\nWhenever you cast a historic spell, Surtr, Fiery J\u00f6tun deals 3 damage to any target. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -10996,7 +10996,7 @@
         },
         {
             "id": "46eb0998-287a-541b-bd7f-72218e46baa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ead24c-dd4a-40cd-839e-de08017a7c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ead24c-dd4a-40cd-839e-de08017a7c29.jpg?1",
             "name": "Achilles Davenport",
             "text": "Freerunning {U}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nMenace (This creature can't be blocked except by two or more creatures.)\nOther Assassins you control get +1/+1.",
             "colours": [
@@ -11034,7 +11034,7 @@
         },
         {
             "id": "d87b7f60-2895-5f42-8a78-ad99ea555344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7426f3dc-385b-42ea-85cb-853e6035ca6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7426f3dc-385b-42ea-85cb-853e6035ca6f.jpg?1",
             "name": "Auditore Ambush",
             "text": "Choose one or both \u2014\n\u2022 Return target creature to its owner's hand.\n\u2022 Target player searches their library and/or graveyard for a card named Ezio, Blade of Vengeance, reveals it, and puts it into their hand. If they search their library this way, they shuffle.",
             "colours": [
@@ -11067,7 +11067,7 @@
         },
         {
             "id": "35eb64ff-95a9-55b8-83db-e33adbf8ea46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58766566-6e19-4f74-bfce-5a61429ffaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58766566-6e19-4f74-bfce-5a61429ffaa9.jpg?1",
             "name": "Bureau Headmaster",
             "text": "Equipment spells you cast cost {1} less to cast.\nEquip abilities you activate cost {1} less to activate.",
             "colours": [
@@ -11103,7 +11103,7 @@
         },
         {
             "id": "0106a121-4fea-501f-a115-fea4e027534e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01de51d1-bbea-407c-b19e-dfef7fce1510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01de51d1-bbea-407c-b19e-dfef7fce1510.jpg?1",
             "name": "Raven Clan War-Axe",
             "text": "When Raven Clan War-Axe enters the battlefield, you may search your library and/or graveyard for a card named Eivor, Battle-Ready, reveal it, and put it into your hand. If you search your library this way, shuffle.\nEquipped creature gets +2/+0 and has trample.\nEquip {2}",
             "colours": [
@@ -11138,7 +11138,7 @@
         },
         {
             "id": "b1542cb2-548b-5854-a049-0a4171928ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef0eb-5b11-49e8-b2b2-a9e0422f6e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef0eb-5b11-49e8-b2b2-a9e0422f6e65.jpg?1",
             "name": "Rooftop Bypass",
             "text": "Whenever one or more nontoken creatures you control deal combat damage to a player, create a 1/1 black Assassin creature token with menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "51e8cfb8-e8e2-5a4f-b1df-66d9ab9ecaeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac703b47-398c-42cd-8d30-99c398cf734e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac703b47-398c-42cd-8d30-99c398cf734e.jpg?1",
             "name": "Hired Blade",
             "text": "Flash (You may cast this spell any time you could cast an instant.)",
             "colours": [
@@ -11205,7 +11205,7 @@
         },
         {
             "id": "ac8d7020-32a7-57c4-9e88-6d0e2df9a75a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e66e29-ef63-4faa-b60f-8a128800e093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e66e29-ef63-4faa-b60f-8a128800e093.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11235,7 +11235,7 @@
         },
         {
             "id": "5c5563e2-bf21-5e24-b108-070c5e4d266a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f04f32-f672-443a-86c0-63f5f4747c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f04f32-f672-443a-86c0-63f5f4747c67.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11265,7 +11265,7 @@
         },
         {
             "id": "7b39bb1f-fbce-51f3-9404-f3b1198b9d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3df51a-d173-44c8-9630-4652630cc544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3df51a-d173-44c8-9630-4652630cc544.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11301,7 +11301,7 @@
         },
         {
             "id": "b47c160c-6a16-5ede-a9cf-21969fe48b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dbf10c-a813-4f76-9066-b3cdd9cfd5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dbf10c-a813-4f76-9066-b3cdd9cfd5d4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11337,7 +11337,7 @@
         },
         {
             "id": "7ecd9dac-93b0-5970-b617-6637d290c912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36aaa8d9-4b03-4dd2-9b3c-d8b3bf19da73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36aaa8d9-4b03-4dd2-9b3c-d8b3bf19da73.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11373,7 +11373,7 @@
         },
         {
             "id": "3783bb90-249d-5cc4-987f-90073cf3412e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b469d5fa-89c2-4e5e-9c1d-c3edb80f7b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b469d5fa-89c2-4e5e-9c1d-c3edb80f7b59.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11409,7 +11409,7 @@
         },
         {
             "id": "79b3b784-ab4f-558b-b076-a9a74d4debfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d9cde9-8937-4861-8eec-17a94e1602c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d9cde9-8937-4861-8eec-17a94e1602c7.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11447,7 +11447,7 @@
         },
         {
             "id": "950f2739-8761-5141-a790-fd29f83541c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2d197-48bf-4df1-bcd3-caf07339e383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2d197-48bf-4df1-bcd3-caf07339e383.jpg?1",
             "name": "Hidden Blade",
             "text": "Flash\nWhen Hidden Blade enters the battlefield, attach it to target creature you control. If that creature is an Assassin, it gains deathtouch until end of turn.\nEquipped creature gets +1/+0 and has first strike.\nEquip {2}",
             "colours": [],
@@ -11479,7 +11479,7 @@
         },
         {
             "id": "35d765d0-3113-5bc3-b38c-e3ca22b91300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31d4312-08cd-4f1e-9d8f-72cbe4abb285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31d4312-08cd-4f1e-9d8f-72cbe4abb285.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -11507,7 +11507,7 @@
         },
         {
             "id": "b8a61b58-bb26-509f-b7c8-9630d88432ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20ad1e6-d698-4a0a-8ed5-903e1d463004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20ad1e6-d698-4a0a-8ed5-903e1d463004.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -11538,7 +11538,7 @@
         },
         {
             "id": "2f673f4d-2464-52f6-9d47-acc9143eac7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05946b39-0b54-4f63-b521-4d5deb238541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05946b39-0b54-4f63-b521-4d5deb238541.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "9d84f8de-71d4-53d2-a181-97cec6d4f132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cb2062-86f0-4ce3-b5fb-d3c310f36ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cb2062-86f0-4ce3-b5fb-d3c310f36ec3.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -11609,7 +11609,7 @@
         },
         {
             "id": "d34384d2-c8cc-578e-9af7-29d2b2407858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447bd736-6b47-440c-86ed-db54bd655274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447bd736-6b47-440c-86ed-db54bd655274.jpg?1",
             "name": "Phobos",
             "text": "",
             "colours": [
@@ -11646,7 +11646,7 @@
         },
         {
             "id": "8988fa56-4617-5970-b299-76994fefa25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536a82d3-f5e2-46b7-969e-84683f937b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536a82d3-f5e2-46b7-969e-84683f937b38.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -11677,7 +11677,7 @@
         },
         {
             "id": "7a5976fa-5339-58e6-bd9b-623bc67d2544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05402b51-8cf9-4f69-aa12-8a9d5981f8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05402b51-8cf9-4f69-aa12-8a9d5981f8b1.jpg?1",
             "name": "The Capitoline Triad Emblem",
             "text": "",
             "colours": [],
@@ -11705,7 +11705,7 @@
         },
         {
             "id": "786e800f-ce0f-50d5-b942-c99bc8430f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76a6163-6fd9-4cdf-9b14-07f75c2f0fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76a6163-6fd9-4cdf-9b14-07f75c2f0fa1.jpg?1",
             "name": "A Mysterious Creature",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/AER.json
+++ b/Assets/Resources/Sets/AER.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "83d72830-8e68-5d6c-a8b7-69d8ff0e7d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89cab47-25fb-49ea-bb43-90a0089b6b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89cab47-25fb-49ea-bb43-90a0089b6b20.jpg?1",
             "name": "Aerial Modification",
             "text": "Enchant creature or Vehicle\nAs long as enchanted permanent is a Vehicle, it's a creature in addition to its other types.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "97ab0c37-14e0-542a-adcc-fb1cbfd6f19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff15c06c-160d-4960-92d5-6f8e7b33f051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff15c06c-160d-4960-92d5-6f8e7b33f051.jpg?1",
             "name": "Aeronaut Admiral",
             "text": "Flying\nVehicles you control have flying.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "a24b9a7a-bc77-5a5e-a0cf-2bbddd89361e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dcbe97-d582-464e-98e7-dd06d8652606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dcbe97-d582-464e-98e7-dd06d8652606.jpg?1",
             "name": "Aether Inspector",
             "text": "Vigilance\nWhen Aether Inspector enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Inspector attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "b3cc53e5-e841-5766-810e-f9f71877cffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bb3abd-ebaf-4dc2-97eb-ed4a2b005177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bb3abd-ebaf-4dc2-97eb-ed4a2b005177.jpg?1",
             "name": "Aethergeode Miner",
             "text": "Whenever Aethergeode Miner attacks, you get {E}{E} (two energy counters).\nPay {E}{E}: Exile Aethergeode Miner, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "576ad40f-7821-5632-bb10-1d089cf88cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49827a57-cf10-4a44-a1fd-ac611da39dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49827a57-cf10-4a44-a1fd-ac611da39dc9.jpg?1",
             "name": "Airdrop Aeronauts",
             "text": "Flying\nRevolt \u2014 When Airdrop Aeronauts enters the battlefield, if a permanent you controlled left the battlefield this turn, you gain 5 life.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "91d3b1ee-0a95-5556-a7c5-a94f8b69f76a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc10173d-25ff-4734-b8f2-84f94fe52b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc10173d-25ff-4734-b8f2-84f94fe52b17.jpg?1",
             "name": "Alley Evasion",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+2 until end of turn.\n\u2022 Return target creature you control to its owner's hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "16ec2ade-7f83-578f-a1f1-c1f418d44e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a348bb-cdc5-4e2a-933f-21f91faab891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a348bb-cdc5-4e2a-933f-21f91faab891.jpg?1",
             "name": "Audacious Infiltrator",
             "text": "Audacious Infiltrator can't be blocked by artifact creatures.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "deacc32c-f796-517f-8167-a70237e8f4cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b9c0f7-d49b-4d74-9038-44954054ce21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b9c0f7-d49b-4d74-9038-44954054ce21.jpg?1",
             "name": "Bastion Enforcer",
             "text": "",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "3ae5d1d7-08a7-5b4c-a78f-ee0dfeb3dcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeca4557-98aa-433b-a3ee-050e4a3e6d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeca4557-98aa-433b-a3ee-050e4a3e6d88.jpg?1",
             "name": "Call for Unity",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a unity counter on Call for Unity.\nCreatures you control get +1/+1 for each unity counter on Call for Unity.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "9821480d-37a7-5ee5-9cc3-385cd3f6f41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5bea27-d825-4691-8ae0-c4831574ec53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5bea27-d825-4691-8ae0-c4831574ec53.jpg?1",
             "name": "Caught in the Brights",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen a Vehicle you control attacks, exile enchanted creature.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "95c70089-9408-5fba-b498-a72655ba3561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb7a26-fbf0-4b91-847b-cfc46e01a342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb7a26-fbf0-4b91-847b-cfc46e01a342.jpg?1",
             "name": "Consulate Crackdown",
             "text": "When Consulate Crackdown enters the battlefield, exile all artifacts your opponents control until Consulate Crackdown leaves the battlefield.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "1827ebd4-bb59-5bea-bde7-68bf12dcb7f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f805e97-c28b-4780-b204-74514c0c47d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f805e97-c28b-4780-b204-74514c0c47d2.jpg?1",
             "name": "Conviction",
             "text": "Enchant creature\nEnchanted creature gets +1/+3.\n{W}: Return Conviction to its owner's hand.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "26a44e5b-ba2a-54c8-b033-79b6d48d50f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d6f334-0040-42b1-9c72-362e4dcaa65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d6f334-0040-42b1-9c72-362e4dcaa65e.jpg?1",
             "name": "Countless Gears Renegade",
             "text": "Revolt \u2014 When Countless Gears Renegade enters the battlefield, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "e0982339-8666-5af8-9e59-799dc635c8cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7113ddc-cb3c-46da-a6c7-2567bd0affa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7113ddc-cb3c-46da-a6c7-2567bd0affa9.jpg?1",
             "name": "Dawnfeather Eagle",
             "text": "Flying\nWhen Dawnfeather Eagle enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "e8590620-0370-5e57-afb1-b965fca731d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccd6864-1404-43c2-aa59-ccc8b3529a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccd6864-1404-43c2-aa59-ccc8b3529a62.jpg?1",
             "name": "Dawnfeather Eagle",
             "text": "",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "51765bb0-0fc2-5c10-aeb3-94198e7aef0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018decf-25e1-45fc-be7d-2523dcfb7a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018decf-25e1-45fc-be7d-2523dcfb7a4c.jpg?1",
             "name": "Deadeye Harpooner",
             "text": "Revolt \u2014 When Deadeye Harpooner enters the battlefield, if a permanent you controlled left the battlefield this turn, destroy target tapped creature an opponent controls.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "89dc417b-c18b-5490-9448-e80426fb1827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cca66e9-be21-4fc7-8951-cd99e9b213dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cca66e9-be21-4fc7-8951-cd99e9b213dc.jpg?1",
             "name": "Decommission",
             "text": "Destroy target artifact or enchantment.\nRevolt \u2014 If a permanent you controlled left the battlefield this turn, you gain 3 life.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "85d602a8-8ac7-539d-978a-c97b01cf4d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb26d5b-ffeb-4dac-ad61-f85e5e7b1675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb26d5b-ffeb-4dac-ad61-f85e5e7b1675.jpg?1",
             "name": "Deft Dismissal",
             "text": "Deft Dismissal deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "5c1eb6b6-410b-56fb-99be-27d49cc61662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04018c9-510c-4610-9daa-677434628805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04018c9-510c-4610-9daa-677434628805.jpg?1",
             "name": "Exquisite Archangel",
             "text": "Flying\nIf you would lose the game, instead exile Exquisite Archangel and your life total becomes equal to your starting life total.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "482f8766-a32d-597e-b36d-1a471dcc1912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bdbed8-5d21-4bf5-8a32-9623b1139c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bdbed8-5d21-4bf5-8a32-9623b1139c85.jpg?1",
             "name": "Felidar Guardian",
             "text": "When Felidar Guardian enters the battlefield, you may exile another target permanent you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "4026b5c8-38dd-51b3-9179-279ebb71f485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2186f382-2d68-4191-b490-a072f49eaabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2186f382-2d68-4191-b490-a072f49eaabf.jpg?1",
             "name": "Ghirapur Osprey",
             "text": "Flying",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "9d917b2e-a5ba-5152-b46b-18bb62cd363e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63682db3-1a56-4d8e-a9b7-04465a577518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63682db3-1a56-4d8e-a9b7-04465a577518.jpg?1",
             "name": "Restoration Specialist",
             "text": "{W}, Sacrifice Restoration Specialist: Return up to one target artifact card and up to one target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "b0a5baa5-d847-5b67-ac23-2082bdfeadcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5990c2f1-94d7-4d2e-b1ad-6406c25b91aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5990c2f1-94d7-4d2e-b1ad-6406c25b91aa.jpg?1",
             "name": "Solemn Recruit",
             "text": "Double strike\nRevolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on Solemn Recruit.",
             "colours": [
@@ -790,7 +790,7 @@
         },
         {
             "id": "b70763ed-0964-50e2-ac75-8063f4895e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b323e2c-59dd-4d70-9a48-b10f807bb818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b323e2c-59dd-4d70-9a48-b10f807bb818.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
             "colours": [
@@ -827,7 +827,7 @@
         },
         {
             "id": "7443dc50-ea28-5931-b6b0-e1ce2d45248a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6d47b0-4c19-4c19-9e21-54cd87a5e34d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6d47b0-4c19-4c19-9e21-54cd87a5e34d.jpg?1",
             "name": "Sram's Expertise",
             "text": "Create three 1/1 colorless Servo artifact creature tokens.\nYou may cast a card with converted mana cost 3 or less from your hand without paying its mana cost.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "0372c930-c948-531c-a2a6-8e8bb11768fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e738cb-e4ea-41c2-99a1-55b6167eccb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e738cb-e4ea-41c2-99a1-55b6167eccb0.jpg?1",
             "name": "Thopter Arrest",
             "text": "When Thopter Arrest enters the battlefield, exile target artifact or creature an opponent controls until Thopter Arrest leaves the battlefield.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "76bf628b-13ec-5914-91ff-8ceb2ee70cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c34dbe3-3a66-40b3-a5c2-c2d6acb47773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c34dbe3-3a66-40b3-a5c2-c2d6acb47773.jpg?1",
             "name": "Aether Swooper",
             "text": "Flying\nWhen Aether Swooper enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Swooper attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "8edddeca-a7d4-51cf-9244-467f93eb0f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38722c25-13a7-47af-a4cd-90722f289499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38722c25-13a7-47af-a4cd-90722f289499.jpg?1",
             "name": "Aethertide Whale",
             "text": "Flying\nWhen Aethertide Whale enters the battlefield, you get {E}{E}{E}{E}{E}{E} (six energy counters).\nPay {E}{E}{E}{E}: Return Aethertide Whale to its owner's hand.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "0730e14e-7a5d-57de-a9fb-f6b761376a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e16d94-1166-4050-8554-686e153a7f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e16d94-1166-4050-8554-686e153a7f80.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "6077079d-260a-5c32-8a9d-204f3be27497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d273f5b7-b3a3-485a-acc8-34e10a504646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d273f5b7-b3a3-485a-acc8-34e10a504646.jpg?1",
             "name": "Baral's Expertise",
             "text": "Return up to three target artifacts and/or creatures to their owners' hands.\nYou may cast a card with converted mana cost 4 or less from your hand without paying its mana cost.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "aa4a672f-942b-5811-9c0b-c42994ddc15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856f804d-0213-4b86-bc6a-6a0a1147c4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856f804d-0213-4b86-bc6a-6a0a1147c4f9.jpg?1",
             "name": "Bastion Inventor",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "a6a473d2-b12e-50df-a99a-667a20d8ade2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f05814-a5a5-460f-9d29-0ab03efecf4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f05814-a5a5-460f-9d29-0ab03efecf4c.jpg?1",
             "name": "Disallow",
             "text": "Counter target spell, activated ability, or triggered ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "912f8708-c8fb-58a0-9585-6016a4789628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d93a915-ffea-4f50-88ac-2b3253f7dfdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d93a915-ffea-4f50-88ac-2b3253f7dfdf.jpg?1",
             "name": "Dispersal Technician",
             "text": "When Dispersal Technician enters the battlefield, you may return target artifact to its owner's hand.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "9c785fb7-9080-598e-afe8-1c36bdc6e2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfbe1d5-beb7-49b8-a504-f1cc47ee4731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfbe1d5-beb7-49b8-a504-f1cc47ee4731.jpg?1",
             "name": "Efficient Construction",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "c6aa7290-e9af-585a-a1b0-6e790acfaaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418448d0-3e8d-4581-b598-696165775d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418448d0-3e8d-4581-b598-696165775d23.jpg?1",
             "name": "Hinterland Drake",
             "text": "Flying\nHinterland Drake can't block artifact creatures.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "11ca36b9-658f-5f73-8162-dc12b53fed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01d2835-060c-4ac3-b586-84811878a64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01d2835-060c-4ac3-b586-84811878a64d.jpg?1",
             "name": "Ice Over",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "79a4cb21-9197-59b2-a99a-b33b180b7d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eede83-6f1b-4054-b01c-0da17b197bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eede83-6f1b-4054-b01c-0da17b197bad.jpg?1",
             "name": "Illusionist's Stratagem",
             "text": "Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.\nDraw a card.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "e20ef810-082c-522e-9df1-4293ba013ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c01bd77-beb0-4a26-858d-022311e550bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c01bd77-beb0-4a26-858d-022311e550bf.jpg?1",
             "name": "Leave in the Dust",
             "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "9a18d69c-59c3-5d55-a9b6-cc0e7eedaaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235dd8f1-215a-4b0a-9e94-0d0d5a3c730b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235dd8f1-215a-4b0a-9e94-0d0d5a3c730b.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "5563f8ef-6989-5372-8a2c-06e2eb02ba7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f712ac26-dca4-459b-84c1-010597007f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f712ac26-dca4-459b-84c1-010597007f60.jpg?1",
             "name": "Metallic Rebuke",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "fc6d69aa-36bd-5e60-89cd-9d40d6f195b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb142515-0856-441d-84d4-9c9d450a86e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb142515-0856-441d-84d4-9c9d450a86e9.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "f9884ad2-0701-5c01-948b-0363e40c1767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f922e87-1744-4966-9e3a-54917f7f3d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f922e87-1744-4966-9e3a-54917f7f3d9e.jpg?1",
             "name": "Quicksmith Spy",
             "text": "When Quicksmith Spy enters the battlefield, target artifact you control gains \"{T}: Draw a card\" for as long as you control Quicksmith Spy.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "2705ce57-4edf-5a1b-83fc-87bb3b6f9b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56f8cca-6b8f-45ea-926f-161938716ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56f8cca-6b8f-45ea-926f-161938716ee9.jpg?1",
             "name": "Reverse Engineer",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "792f7587-0a70-5e6b-a906-c96d8a322469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480be626-cf37-410d-a9c7-e5464345085f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480be626-cf37-410d-a9c7-e5464345085f.jpg?1",
             "name": "Salvage Scuttler",
             "text": "Whenever Salvage Scuttler attacks, return an artifact you control to its owner's hand.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "e9411f46-db6b-5424-9d38-a8a2e3a075c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34be31b-eeb4-40e5-acf7-6cd0ba6d4bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34be31b-eeb4-40e5-acf7-6cd0ba6d4bcf.jpg?1",
             "name": "Shielded Aether Thief",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever Shielded Aether Thief blocks, you get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Draw a card.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "8f2f0414-ad17-5cd4-b099-cdb250ed1b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c6de3-4e09-40d9-afdb-89ff08e1844b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c6de3-4e09-40d9-afdb-89ff08e1844b.jpg?1",
             "name": "Shipwreck Moray",
             "text": "When Shipwreck Moray enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}: Shipwreck Moray gets +2/-2 until end of turn.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "95c429a6-cacf-5ebd-911c-7353cc5ee6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fedbc91-67e4-40d6-b307-7e6197f47c6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fedbc91-67e4-40d6-b307-7e6197f47c6e.jpg?1",
             "name": "Skyship Plunderer",
             "text": "Flying\nWhenever Skyship Plunderer deals combat damage to a player, for each kind of counter on target permanent or player, give that permanent or player another counter of that kind.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "b9a4ff4c-8d4a-524a-856b-54434337acf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b412718a-7bc7-4b16-af60-1b955c820b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b412718a-7bc7-4b16-af60-1b955c820b0f.jpg?1",
             "name": "Take into Custody",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "362b0a88-7c7a-53d7-b6e5-ab0331d2ce27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19754fe4-2f61-42a3-afa2-3a6a8257b81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19754fe4-2f61-42a3-afa2-3a6a8257b81b.jpg?1",
             "name": "Trophy Mage",
             "text": "When Trophy Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 3, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "28a0672e-1c94-5f14-8dcf-835a39e0a82e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279fd3c-9252-4958-9d7a-5f33aa25907e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279fd3c-9252-4958-9d7a-5f33aa25907e.jpg?1",
             "name": "Whir of Invention",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nSearch your library for an artifact card with converted mana cost X or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "f8fd0d59-a4d4-51ce-8ea2-fd31b651052a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfaa040-61fd-4705-a7ee-c67b49f740e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfaa040-61fd-4705-a7ee-c67b49f740e3.jpg?1",
             "name": "Wind-Kin Raiders",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFlying",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "842d7264-6b7c-5e50-8ea3-0d3e06dc3d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b217f1-1621-40d1-8a98-24c1f7cba800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b217f1-1621-40d1-8a98-24c1f7cba800.jpg?1",
             "name": "Aether Poisoner",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Aether Poisoner enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Poisoner attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "62cdb518-f3d5-55a6-a6c3-83c2aca18af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131d558-5f6b-448b-a378-1882e2d02bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131d558-5f6b-448b-a378-1882e2d02bd2.jpg?1",
             "name": "Alley Strangler",
             "text": "Menace",
             "colours": [
@@ -1804,7 +1804,7 @@
         },
         {
             "id": "24d3dea3-444a-5bbe-bc8d-733fd1d4a9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b97fa0-4c5b-4211-9c8d-99197dc20636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b97fa0-4c5b-4211-9c8d-99197dc20636.jpg?1",
             "name": "Alley Strangler",
             "text": "",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "999c088e-db4e-51b8-900a-1f04361904cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d8b644-4cca-451e-a46c-5237c13bf373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d8b644-4cca-451e-a46c-5237c13bf373.jpg?1",
             "name": "Battle at the Bridge",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nTarget creature gets -X/-X until end of turn. You gain X life.",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "f88c421a-1456-5ba0-9c67-d77a8383824e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c22e911-cf40-4ed8-b075-186f2b1393db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c22e911-cf40-4ed8-b075-186f2b1393db.jpg?1",
             "name": "Cruel Finality",
             "text": "Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "6aaf7352-c868-5594-8883-7b90f04ad793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6378898-50b7-47c9-8c25-dc660606be9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6378898-50b7-47c9-8c25-dc660606be9f.jpg?1",
             "name": "Daring Demolition",
             "text": "Destroy target creature or Vehicle.",
             "colours": [
@@ -1936,7 +1936,7 @@
         },
         {
             "id": "e52111bb-bd8e-53e4-99aa-984c8c9efc99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afbfb2c-3f1a-4ef9-9f61-6ca51af853d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afbfb2c-3f1a-4ef9-9f61-6ca51af853d8.jpg?1",
             "name": "Defiant Salvager",
             "text": "Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "5f7a211c-5ef9-54a5-8b70-4016f8783c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e81649-9954-424c-89d1-f87d73b66047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e81649-9954-424c-89d1-f87d73b66047.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt \u2014 Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "456b4e7c-fe5f-50e5-8814-4a69aa830c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ef4616-e3c2-4448-83b1-f7d439705eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ef4616-e3c2-4448-83b1-f7d439705eaf.jpg?1",
             "name": "Fen Hauler",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFen Hauler can't be blocked by artifact creatures.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "3206c375-bb45-5043-813b-24a2f436d022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dc7865-16ed-4d12-bdb4-d40fbdd48a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dc7865-16ed-4d12-bdb4-d40fbdd48a23.jpg?1",
             "name": "Foundry Hornet",
             "text": "Flying\nWhen Foundry Hornet enters the battlefield, if you control a creature with a +1/+1 counter on it, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2071,7 +2071,7 @@
         },
         {
             "id": "679b5c02-a328-567d-9e34-2b4c2aefbeff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73aaaa09-c985-42f8-b426-06fd3b8de66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73aaaa09-c985-42f8-b426-06fd3b8de66d.jpg?1",
             "name": "Fourth Bridge Prowler",
             "text": "When Fourth Bridge Prowler enters the battlefield, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -2106,7 +2106,7 @@
         },
         {
             "id": "79a81861-cc00-592a-add7-31182cf30c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abceb4fd-e3c5-400d-af7a-6dd17108a4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abceb4fd-e3c5-400d-af7a-6dd17108a4b4.jpg?1",
             "name": "Gifted Aetherborn",
             "text": "Deathtouch, lifelink",
             "colours": [
@@ -2141,7 +2141,7 @@
         },
         {
             "id": "401a0efa-e2cc-5804-80f7-bb158d9f3ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315976db-4cab-4393-8386-ce3b0ae3f490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315976db-4cab-4393-8386-ce3b0ae3f490.jpg?1",
             "name": "Glint-Sleeve Siphoner",
             "text": "Menace\nWhenever Glint-Sleeve Siphoner enters the battlefield or attacks, you get {E} (an energy counter).\nAt the beginning of your upkeep, you may pay {E}{E}. If you do, you draw a card and you lose 1 life.",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "ee7bc90f-d66e-5747-8141-1ed1176e5cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c97f5a9-6e04-45c3-aa8d-dcf0fd81d5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c97f5a9-6e04-45c3-aa8d-dcf0fd81d5b9.jpg?1",
             "name": "Gonti's Machinations",
             "text": "Whenever you lose life for the first time each turn, you get {E}. (You get an energy counter. Damage causes loss of life.)\nPay {E}{E}, Sacrifice Gonti's Machinations: Each opponent loses 3 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "6f943929-a257-5cb3-bbb4-5a62434dab28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a69ebe-4229-4067-8414-381b123fe63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a69ebe-4229-4067-8414-381b123fe63c.jpg?1",
             "name": "Herald of Anguish",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFlying\nAt the beginning of your end step, each opponent discards a card.\n{1}{B}, Sacrifice an artifact: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2242,7 +2242,7 @@
         },
         {
             "id": "6e139c36-628b-5459-a68f-2668a7435181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a5535b-b1d1-4648-aa72-4f64e9fcd95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a5535b-b1d1-4648-aa72-4f64e9fcd95d.jpg?1",
             "name": "Ironclad Revolutionary",
             "text": "When Ironclad Revolutionary enters the battlefield, you may sacrifice an artifact. If you do, put two +1/+1 counters on Ironclad Revolutionary and each opponent loses 2 life.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "4f04727b-4549-5b3e-ab3a-560a2acba291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2838c6dd-d816-4363-a861-f2f8052d1430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2838c6dd-d816-4363-a861-f2f8052d1430.jpg?1",
             "name": "Midnight Entourage",
             "text": "Other Aetherborn you control get +1/+1.\nWhenever Midnight Entourage or another Aetherborn you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "9e6fc9b4-d5bd-57fa-a166-47b74d4f4780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2637f860-01dd-4559-97b3-71c2e7cdbca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2637f860-01dd-4559-97b3-71c2e7cdbca4.jpg?1",
             "name": "Night Market Aeronaut",
             "text": "Flying\nRevolt \u2014 Night Market Aeronaut enters the battlefield with a +1/+1 counter on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "0c1f81d5-e61e-5299-a72e-015ae4679f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0edc708-0c76-4fcd-a175-d9c6f1ca3ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0edc708-0c76-4fcd-a175-d9c6f1ca3ac1.jpg?1",
             "name": "Perilous Predicament",
             "text": "Each opponent sacrifices an artifact creature and a nonartifact creature.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "c089c3a0-61a2-5a19-8c3e-1f056c263952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b0a5d5-99d7-492b-bd85-77c3cee12c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b0a5d5-99d7-492b-bd85-77c3cee12c8d.jpg?1",
             "name": "Renegade's Getaway",
             "text": "Target permanent gains indestructible until end of turn. Create a 1/1 colorless Servo artifact creature token. (Effects that say \"destroy\" don't destroy a permanent with indestructible, and if it's a creature, it can't be destroyed by damage.)",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "e8eeb39e-1b1e-5ec3-a2c1-55770fd6e5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f57d0b-ab6a-4074-885d-678659729b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f57d0b-ab6a-4074-885d-678659729b8a.jpg?1",
             "name": "Resourceful Return",
             "text": "Return target creature card from your graveyard to your hand. If you control an artifact, draw a card.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "29c679f5-7145-5ac5-b819-fefe8b7160a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b9f3e2-b5e8-4234-aaf3-5f1938a20c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b9f3e2-b5e8-4234-aaf3-5f1938a20c78.jpg?1",
             "name": "Secret Salvage",
             "text": "Exile target nonland card from your graveyard. Search your library for any number of cards with the same name as that card, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "6f61a7fe-78be-5fc4-ab31-b7a166f69ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d05324-6d85-40da-a087-b5822bc8f42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d05324-6d85-40da-a087-b5822bc8f42e.jpg?1",
             "name": "Sly Requisitioner",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nWhenever a nontoken artifact you control is put into a graveyard from the battlefield, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "f0e11711-4d28-5f0b-9b0b-17c328b05004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e34edfc-77fc-43b5-bad6-1c4c2a76c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e34edfc-77fc-43b5-bad6-1c4c2a76c8c3.jpg?1",
             "name": "Vengeful Rebel",
             "text": "Revolt \u2014 When Vengeful Rebel enters the battlefield, if a permanent you controlled left the battlefield this turn, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "7513c7d8-b727-58ae-afbc-eed3b09c8eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37e2466-57c3-453f-aebe-340995f2eca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37e2466-57c3-453f-aebe-340995f2eca7.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "10b75d6c-a45a-5ba1-89ce-bdb83b63abc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f28735-122c-45ba-bde5-decfd9b11b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f28735-122c-45ba-bde5-decfd9b11b32.jpg?1",
             "name": "Yahenni's Expertise",
             "text": "All creatures get -3/-3 until end of turn.\nYou may cast a card with converted mana cost 3 or less from your hand without paying its mana cost.",
             "colours": [
@@ -2614,7 +2614,7 @@
         },
         {
             "id": "db7de268-b5fc-5151-b520-58480ac0952b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290cde84-d97a-4737-aff2-c443a4e43f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290cde84-d97a-4737-aff2-c443a4e43f7d.jpg?1",
             "name": "Aether Chaser",
             "text": "First strike\nWhen Aether Chaser enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Chaser attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -2649,7 +2649,7 @@
         },
         {
             "id": "c2beb4f5-0cfc-50c6-a60f-70fb7dd8343a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcee99c-72a0-4db1-b4c9-65c878284450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcee99c-72a0-4db1-b4c9-65c878284450.jpg?1",
             "name": "Chandra's Revolution",
             "text": "Chandra's Revolution deals 4 damage to target creature. Tap target land. That land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2681,7 +2681,7 @@
         },
         {
             "id": "172e82ea-2b8e-5a9d-a8b7-d9e2ea25b9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1",
             "name": "Destructive Tampering",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Creatures without flying can't block this turn.",
             "colours": [
@@ -2713,7 +2713,7 @@
         },
         {
             "id": "8915d7e1-191a-54ac-9412-eebd13d2692d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad5c175-581c-4fdd-b008-e7d10b0928c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad5c175-581c-4fdd-b008-e7d10b0928c7.jpg?1",
             "name": "Embraal Gear-Smasher",
             "text": "{T}, Sacrifice an artifact: Embraal Gear-Smasher deals 2 damage to each opponent.",
             "colours": [
@@ -2748,7 +2748,7 @@
         },
         {
             "id": "e705af06-5dab-5723-bd90-edcde8dd667b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc3b59-baae-4bf0-b5ce-fa9a915af066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc3b59-baae-4bf0-b5ce-fa9a915af066.jpg?1",
             "name": "Enraged Giant",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nTrample, haste",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "0dff43b7-c8bc-5777-881c-291a8cd7c070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b5147f-b422-47d3-98a0-dcc2d6f4e17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b5147f-b422-47d3-98a0-dcc2d6f4e17a.jpg?1",
             "name": "Freejam Regent",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFlying\n{1}{R}: Freejam Regent gets +2/+0 until end of turn.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "22dcc93d-0cfa-567a-97c5-cb3968d4731c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742738a-2663-474d-b75a-28f1f67dc335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742738a-2663-474d-b75a-28f1f67dc335.jpg?1",
             "name": "Frontline Rebel",
             "text": "Frontline Rebel attacks each combat if able.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "0c912843-46e4-5741-8a75-26e6105c7b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51438f5-c4d4-434a-b7ea-dee0b60303e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51438f5-c4d4-434a-b7ea-dee0b60303e4.jpg?1",
             "name": "Gremlin Infestation",
             "text": "Enchant artifact\nAt the beginning of your end step, Gremlin Infestation deals 2 damage to enchanted artifact's controller.\nWhen enchanted artifact is put into a graveyard, create a 2/2 red Gremlin creature token.",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "66f41cea-6e1d-5959-b8dc-5fa8289cd1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca23676-f36f-4266-ba4f-5e9ebf3adb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca23676-f36f-4266-ba4f-5e9ebf3adb57.jpg?1",
             "name": "Hungry Flames",
             "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player.",
             "colours": [
@@ -2917,7 +2917,7 @@
         },
         {
             "id": "882d5d61-d560-5e48-bfcc-dbfbbb048ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd00e45-2ae1-4cd0-92a1-155c95f8dc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd00e45-2ae1-4cd0-92a1-155c95f8dc72.jpg?1",
             "name": "Indomitable Creativity",
             "text": "Destroy X target artifacts and/or creatures. For each permanent destroyed this way, its controller reveals cards from the top of his or her library until an artifact or creature card is revealed and exiles that card. Those players put the exiled cards onto the battlefield, then shuffle their libraries.",
             "colours": [
@@ -2949,7 +2949,7 @@
         },
         {
             "id": "0b95e521-1159-53d9-bbde-5b187f4003ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1d1727-99d4-4aee-b6f5-8399ac1d0184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1d1727-99d4-4aee-b6f5-8399ac1d0184.jpg?1",
             "name": "Invigorated Rampage",
             "text": "Choose one \u2014\n\u2022 Target creature gets +4/+0 and gains trample until end of turn.\n\u2022 Two target creatures each get +2/+0 and gain trample until end of turn.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "e3f86614-17b1-51b3-87ec-b223f9eca7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72495879-39ce-449d-ad2f-ef32ea46f3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72495879-39ce-449d-ad2f-ef32ea46f3aa.jpg?1",
             "name": "Kari Zev, Skyship Raider",
             "text": "First strike, menace\nWhenever Kari Zev, Skyship Raider attacks, create a legendary 2/1 red Monkey creature token named Ragavan that's tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "b8266e5b-a310-54bf-ad25-b7dd9423e147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c7400-6307-4c51-88b8-9c0232110714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c7400-6307-4c51-88b8-9c0232110714.jpg?1",
             "name": "Kari Zev's Expertise",
             "text": "Gain control of target creature or Vehicle until end of turn. Untap it. It gains haste until end of turn.\nYou may cast a card with converted mana cost 2 or less from your hand without paying its mana cost.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "810b4255-4470-5336-99f0-a5e053837d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33998799-f31b-4522-93b2-0c34c570ebf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33998799-f31b-4522-93b2-0c34c570ebf7.jpg?1",
             "name": "Lathnu Sailback",
             "text": "",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "d2133ec8-fed4-5505-ba8b-2c9833b022f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d9c7eb-dca4-4471-a91f-a5aad3a69c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d9c7eb-dca4-4471-a91f-a5aad3a69c2f.jpg?1",
             "name": "Lightning Runner",
             "text": "Double strike, haste\nWhenever Lightning Runner attacks, you get {E}{E} (two energy counters), then you may pay {E}{E}{E}{E}{E}{E}{E}{E}. If you pay, untap all creatures you control, and after this phase, there is an additional combat phase.",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "d0cf7797-966a-573d-bbe6-c2007e5dd7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da6ff6-4d81-488e-83ff-8758f6c7bb9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da6ff6-4d81-488e-83ff-8758f6c7bb9f.jpg?1",
             "name": "Pia's Revolution",
             "text": "Whenever a nontoken artifact is put into your graveyard from the battlefield, return that card to your hand unless target opponent has Pia's Revolution deal 3 damage to him or her.",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "2b844e4f-f252-560e-b1a7-cbf586ae5e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd2e7ab-b63e-48e8-a32a-6ff8673241d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd2e7ab-b63e-48e8-a32a-6ff8673241d9.jpg?1",
             "name": "Precise Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "e368709d-693e-5acc-9972-c8ba8e40e07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5f9755-b137-439c-9b54-1ad71ec1f9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5f9755-b137-439c-9b54-1ad71ec1f9ec.jpg?1",
             "name": "Quicksmith Rebel",
             "text": "When Quicksmith Rebel enters the battlefield, target artifact you control gains \"{T}: This artifact deals 2 damage to target creature or player\" for as long as you control Quicksmith Rebel.",
             "colours": [
@@ -3218,7 +3218,7 @@
         },
         {
             "id": "5466107e-8570-5d93-a3a6-fb22d6ee6511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd793778-f099-4b8e-af19-fc0ec4292824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd793778-f099-4b8e-af19-fc0ec4292824.jpg?1",
             "name": "Ravenous Intruder",
             "text": "Sacrifice an artifact: Ravenous Intruder gets +2/+2 until end of turn.",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "90c374a2-49a2-5961-9630-5f2a5ee782ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0afd6-1242-42bf-a13f-9f218c9d9dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0afd6-1242-42bf-a13f-9f218c9d9dfc.jpg?1",
             "name": "Reckless Racer",
             "text": "First strike\nWhenever Reckless Racer becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3287,7 +3287,7 @@
         },
         {
             "id": "3eb17ee4-2d8d-5b60-a0b1-a45f209a702f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ba75be-2428-45aa-bf02-75c379a5dfa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ba75be-2428-45aa-bf02-75c379a5dfa2.jpg?1",
             "name": "Release the Gremlins",
             "text": "Destroy X target artifacts. Create X 2/2 red Gremlin creature tokens.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "9f83d4e5-ccfa-52a0-ac12-4a390c6147b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ef25c-e9cf-4801-a753-2c329c2a8bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ef25c-e9cf-4801-a753-2c329c2a8bdb.jpg?1",
             "name": "Scrapper Champion",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nWhen Scrapper Champion enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Scrapper Champion attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "8f37f2bc-62ee-56bd-ad7e-3b694253b236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "17bb8f8c-190f-51d7-aea6-e2b3e1ee2ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a4e33f-53f0-4919-98a1-c832dcd32efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a4e33f-53f0-4919-98a1-c832dcd32efb.jpg?1",
             "name": "Siege Modification",
             "text": "Enchant creature or Vehicle\nAs long as enchanted permanent is a Vehicle, it's a creature in addition to its other types.\nEnchanted creature gets +3/+0 and has first strike.",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "281c3006-75de-5c4f-951e-eff99e9a8eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b477d12a-9ba5-4302-a3f0-af0afb5d87f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b477d12a-9ba5-4302-a3f0-af0afb5d87f4.jpg?1",
             "name": "Sweatworks Brawler",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nMenace",
             "colours": [
@@ -3455,7 +3455,7 @@
         },
         {
             "id": "4827b797-7ef2-547b-9174-a954ebdf5be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea93a49-5a7c-4d15-8548-a57c9460e0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea93a49-5a7c-4d15-8548-a57c9460e0f0.jpg?1",
             "name": "Wrangle",
             "text": "Gain control of target creature with power 4 or less until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "6b6f85f5-6bf0-502f-bc9e-d7f03577b780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ba0db-4276-45aa-91ed-52f6ffbc6ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ba0db-4276-45aa-91ed-52f6ffbc6ad3.jpg?1",
             "name": "Wrangle",
             "text": "",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "8ef5929c-d224-54f3-a299-b4d1088d2a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8744a31-451b-4349-8f62-e2392a72a154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8744a31-451b-4349-8f62-e2392a72a154.jpg?1",
             "name": "Aether Herder",
             "text": "When Aether Herder enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Herder attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "b795d78c-c194-51b9-96cf-21c6d59580f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3a727a-5eca-44de-aa8f-0d2573db83eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3a727a-5eca-44de-aa8f-0d2573db83eb.jpg?1",
             "name": "Aetherstream Leopard",
             "text": "Trample\nWhen Aetherstream Leopard enters the battlefield, you get {E} (an energy counter).\nWhenever Aetherstream Leopard attacks, you may pay {E}. If you do, it gets +2/+0 until end of turn.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "00596d10-05fa-501c-8e39-fd61c94ca525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04d5fa-6ba2-4833-8ea0-1941a03bd3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04d5fa-6ba2-4833-8ea0-1941a03bd3e9.jpg?1",
             "name": "Aetherwind Basker",
             "text": "Trample\nWhenever Aetherwind Basker enters the battlefield or attacks, you get {E} (an energy counter) for each creature you control.\nPay {E}: Aetherwind Basker gets +1/+1 until end of turn.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "3b677162-6dad-5b4c-96c5-deeb6b0b650f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565cb7fc-cf90-4020-84fe-05ec7b18709d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565cb7fc-cf90-4020-84fe-05ec7b18709d.jpg?1",
             "name": "Aid from the Cowl",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, reveal the top card of your library. If it's a permanent card, you may put it onto the battlefield. Otherwise, you may put it on the bottom of your library.",
             "colours": [
@@ -3658,7 +3658,7 @@
         },
         {
             "id": "66abd889-b8d9-52e5-a6c1-2fc07b7b6b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683f79b-0330-4fac-8279-6c0d888414b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683f79b-0330-4fac-8279-6c0d888414b8.jpg?1",
             "name": "Druid of the Cowl",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "47a2ecf7-cb22-5560-a683-71dc0e6faa7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f06124-bcc4-48c0-a7a6-a461c7485ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f06124-bcc4-48c0-a7a6-a461c7485ecd.jpg?1",
             "name": "Greenbelt Rampager",
             "text": "When Greenbelt Rampager enters the battlefield, pay {E}{E} (two energy counters). If you can't, return Greenbelt Rampager to its owner's hand and you get {E}.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "cd504c1b-0ab8-5668-9627-7219e32c1fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad9bf0f-4271-497f-8d67-3c7bf09342dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad9bf0f-4271-497f-8d67-3c7bf09342dc.jpg?1",
             "name": "Greenwheel Liberator",
             "text": "Revolt \u2014 Greenwheel Liberator enters the battlefield with two +1/+1 counters on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "f346aef2-e827-5a6c-95a5-07ecc1106aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5a620c-fde7-4b72-bf8a-efc4f14560c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5a620c-fde7-4b72-bf8a-efc4f14560c5.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "67b701ce-6b07-5a2e-92ee-1c552a5720d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8db01-415e-42a1-8eb2-57280d58b38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8db01-415e-42a1-8eb2-57280d58b38e.jpg?1",
             "name": "Hidden Herbalists",
             "text": "Revolt \u2014 When Hidden Herbalists enters the battlefield, if a permanent you controlled left the battlefield this turn, add {G}{G} to your mana pool.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "c5c5eca4-0078-57aa-b0ab-cf4a99558bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08325c39-0eeb-4bd0-9adc-2892c1c6637e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08325c39-0eeb-4bd0-9adc-2892c1c6637e.jpg?1",
             "name": "Highspire Infusion",
             "text": "Target creature gets +3/+3 until end of turn. You get {E}{E} (two energy counters).",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "dd579469-f222-5203-bb63-ef323c9c44eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bc60c8-f0a3-4bbf-b570-7d98d0a3e2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bc60c8-f0a3-4bbf-b570-7d98d0a3e2b0.jpg?1",
             "name": "Lifecraft Awakening",
             "text": "Put X +1/+1 counters on target artifact you control. If it isn't a creature or Vehicle, it becomes a 0/0 Construct artifact creature.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "ac0c1f0b-2950-5176-aa43-5d551c40ec05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a92a03-4e1d-4b79-ad75-a29db2ea5495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a92a03-4e1d-4b79-ad75-a29db2ea5495.jpg?1",
             "name": "Lifecraft Cavalry",
             "text": "Trample\nRevolt \u2014 Lifecraft Cavalry enters the battlefield with two +1/+1 counters on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "d4b50b2b-b40e-5f13-a34c-1bc833bfa5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759f13b-e755-495d-87df-a685455cdf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759f13b-e755-495d-87df-a685455cdf33.jpg?1",
             "name": "Lifecrafter's Gift",
             "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "ad3b07a0-ab0e-5197-9d70-310c2e71f943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dcdba-419b-41e1-8c9d-8bca6fe2752b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dcdba-419b-41e1-8c9d-8bca6fe2752b.jpg?1",
             "name": "Maulfist Revolutionary",
             "text": "Trample\nWhen Maulfist Revolutionary enters the battlefield or dies, for each kind of counter on target permanent or player, give that permanent or player another counter of that kind.",
             "colours": [
@@ -3995,7 +3995,7 @@
         },
         {
             "id": "9b790496-b33f-5031-9975-f3e4caf530be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebf95d-a231-402a-8888-9c50889a9556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebf95d-a231-402a-8888-9c50889a9556.jpg?1",
             "name": "Monstrous Onslaught",
             "text": "Monstrous Onslaught deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast Monstrous Onslaught.",
             "colours": [
@@ -4027,7 +4027,7 @@
         },
         {
             "id": "0db7f377-0b88-5957-a8b9-54c028ef874b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041cc6b1-61c8-4c34-86fc-d647ce306f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041cc6b1-61c8-4c34-86fc-d647ce306f59.jpg?1",
             "name": "Narnam Renegade",
             "text": "Deathtouch\nRevolt \u2014 Narnam Renegade enters the battlefield with a +1/+1 counter on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -4062,7 +4062,7 @@
         },
         {
             "id": "c155028c-6418-53ba-9b59-70f990063540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff693e03-4cc6-4903-8fc4-388d23c2f92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff693e03-4cc6-4903-8fc4-388d23c2f92f.jpg?1",
             "name": "Natural Obsolescence",
             "text": "Put target artifact on the bottom of its owner's library.",
             "colours": [
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "48543fad-44f8-5296-bc3b-5d36558e2b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1bc709-2157-4711-a027-c0ff00ff2728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1bc709-2157-4711-a027-c0ff00ff2728.jpg?1",
             "name": "Peema Aether-Seer",
             "text": "When Peema Aether-Seer enters the battlefield, you get an amount of {E} (energy counters) equal to the greatest power among creatures you control.\nPay {E}{E}{E}: Target creature blocks this turn if able.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "bfc3fd94-6712-5e2f-9f7d-bb07290bb6bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166f0a2d-d660-4ea2-8b2f-143dc1fc0a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166f0a2d-d660-4ea2-8b2f-143dc1fc0a8e.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4161,7 +4161,7 @@
         },
         {
             "id": "29d33524-7d3e-5ca2-b022-308c7ba364be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b689cc-35ef-4a23-bb1e-4d81b9fb8455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b689cc-35ef-4a23-bb1e-4d81b9fb8455.jpg?1",
             "name": "Ridgescale Tusker",
             "text": "When Ridgescale Tusker enters the battlefield, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "b03bd941-3c16-519c-874e-7bbfd2ccbab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cff0dc6-5455-4dea-940b-dff7fe88dc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cff0dc6-5455-4dea-940b-dff7fe88dc5d.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G} to your mana pool.\"",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "eb5e9477-99e7-5ff5-ab81-39724834b70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58ba68-05c1-4cd8-a93d-321cd1739ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58ba68-05c1-4cd8-a93d-321cd1739ccb.jpg?1",
             "name": "Rishkar's Expertise",
             "text": "Draw cards equal to the greatest power among creatures you control.\nYou may cast a card with converted mana cost 5 or less from your hand without paying its mana cost.",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "258cdba8-0ce3-55b7-88c1-1ad657cb42f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a11a7-175d-440d-b09d-918572c8e5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a11a7-175d-440d-b09d-918572c8e5d3.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "3b6381c6-a0b8-5a7e-90ab-f9541af3fce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10938c8-6fc4-495f-912a-1d3f12278f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10938c8-6fc4-495f-912a-1d3f12278f78.jpg?1",
             "name": "Silkweaver Elite",
             "text": "Reach (This creature can block creatures with flying.)\nRevolt \u2014 When Silkweaver Elite enters the battlefield, if a permanent you controlled left the battlefield this turn, draw a card.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "3c89c610-030b-5a4e-9580-b2794af62229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc419-a6ce-447d-9994-744cf41f9a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc419-a6ce-447d-9994-744cf41f9a27.jpg?1",
             "name": "Unbridled Growth",
             "text": "Enchant land\nEnchanted land has \"{T}: Add one mana of any color to your mana pool.\"\nSacrifice Unbridled Growth: Draw a card.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "c1c970e9-5586-5990-865d-ee8a22f9ca18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b82ee9-2ac6-4b81-8c64-dd4f47c2d8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b82ee9-2ac6-4b81-8c64-dd4f47c2d8cb.jpg?1",
             "name": "Ajani Unyielding",
             "text": "+2: Reveal the top three cards of your library. Put all nonland permanent cards revealed this way into your hand and the rest on the bottom of your library in any order.\n\u22122: Exile target creature. Its controller gains life equal to its power.\n\u22129: Put five +1/+1 counters on each creature you control and five loyalty counters on each other planeswalker you control.",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "f7bffe4f-03e3-5fd0-99db-8e0e8ffe4245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8f103c-a688-4f22-ae59-2bce1db9d44a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8f103c-a688-4f22-ae59-2bce1db9d44a.jpg?1",
             "name": "Dark Intimations",
             "text": "Each opponent sacrifices a creature or planeswalker, then discards a card. You return a creature or planeswalker card from your graveyard to your hand, then draw a card.\nWhen you cast a Bolas planeswalker spell, exile Dark Intimations from your graveyard. That planeswalker enters the battlefield with an additional loyalty counter on it.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "6cb2fe85-24ed-5d2e-817d-2d62431002a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2176a5-66f8-4a21-bbe2-969c82ca36bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2176a5-66f8-4a21-bbe2-969c82ca36bd.jpg?1",
             "name": "Hidden Stockpile",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.\n{1}, Sacrifice a creature: Scry 1.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "fff52524-bc7c-5c5d-b790-22b5b32bb5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad17d67-538e-4c60-a582-a394032a5112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad17d67-538e-4c60-a582-a394032a5112.jpg?1",
             "name": "Maverick Thopterist",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nWhen Maverick Thopterist enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.",
             "colours": [
@@ -4514,7 +4514,7 @@
         },
         {
             "id": "b5dfc5f2-7feb-59e6-b187-04e57d0d30e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7d5a-b037-4ff7-b6d2-df00adf5691b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7d5a-b037-4ff7-b6d2-df00adf5691b.jpg?1",
             "name": "Oath of Ajani",
             "text": "When Oath of Ajani enters the battlefield, put a +1/+1 counter on each creature you control.\nPlaneswalker spells you cast cost {1} less to cast.",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "6a3c3612-48ff-525c-9764-bc63aeecbf41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135912b3-978b-4a9b-8758-7b138b190232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135912b3-978b-4a9b-8758-7b138b190232.jpg?1",
             "name": "Outland Boar",
             "text": "Outland Boar can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "1352572f-329f-58f7-a329-824779fde7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90bad312-80e3-45b0-9556-60ce06808a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90bad312-80e3-45b0-9556-60ce06808a47.jpg?1",
             "name": "Renegade Rallier",
             "text": "Revolt \u2014 When Renegade Rallier enters the battlefield, if a permanent you controlled left the battlefield this turn, return target permanent card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "e3988591-59fc-5086-b4dc-b879218beeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956a341-10fd-48af-b382-88c2b2934a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956a341-10fd-48af-b382-88c2b2934a3e.jpg?1",
             "name": "Renegade Wheelsmith",
             "text": "Whenever Renegade Wheelsmith becomes tapped, target creature can't block this turn.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "3e963d28-149b-598e-aca8-89d381537791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618652b4-7ce9-4994-9d16-68d2cc8644ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618652b4-7ce9-4994-9d16-68d2cc8644ef.jpg?1",
             "name": "Rogue Refiner",
             "text": "When Rogue Refiner enters the battlefield, draw a card and you get {E}{E} (two energy counters).",
             "colours": [
@@ -4697,7 +4697,7 @@
         },
         {
             "id": "84bf86c1-913a-530d-b3e8-b1ad48fa0eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daaf494-70af-4a8d-836f-f6a9d6c1f080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daaf494-70af-4a8d-836f-f6a9d6c1f080.jpg?1",
             "name": "Spire Patrol",
             "text": "Flying\nWhen Spire Patrol enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "4638d349-694a-5a28-b0de-a9da22a3c9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58265203-bc16-41d2-875c-2ff3b4870824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58265203-bc16-41d2-875c-2ff3b4870824.jpg?1",
             "name": "Tezzeret the Schemer",
             "text": "+1: Create a colorless artifact token named Etherium Cell with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\n\u22122: Target creature gets +X/-X until end of turn, where X is the number of artifacts you control.\n\u22127: You get an emblem with \"At the beginning of combat on your turn, target artifact you control becomes an artifact creature with base power and toughness 5/5.\"",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "8102d464-c3c7-5b3d-ae67-4fd70cf9d018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2e917f-734e-4b8b-abc6-ea33c0fc722e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2e917f-734e-4b8b-abc6-ea33c0fc722e.jpg?1",
             "name": "Tezzeret's Touch",
             "text": "Enchant artifact\nEnchanted artifact is a creature with base power and toughness 5/5 in addition to its other types.\nWhen enchanted artifact is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -4808,7 +4808,7 @@
         },
         {
             "id": "4ef622c2-c217-58a5-a260-f22f52bbe19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51464df6-557f-47e5-838e-2a30145511f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51464df6-557f-47e5-838e-2a30145511f0.jpg?1",
             "name": "Weldfast Engineer",
             "text": "At the beginning of combat on your turn, target artifact creature you control gets +2/+0 until end of turn.",
             "colours": [
@@ -4845,7 +4845,7 @@
         },
         {
             "id": "41cc95b5-d68b-50cc-85bc-40c3b0e8e385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c8aa8-c8f8-4cbf-821b-bd2cb33354f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c8aa8-c8f8-4cbf-821b-bd2cb33354f0.jpg?1",
             "name": "Winding Constrictor",
             "text": "If one or more counters would be placed on an artifact or creature you control, that many of those counters plus one are placed on that permanent instead.\nIf you would get one or more counters, you get that many of those counters plus one instead.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "1f9f70c9-d667-51eb-8cb5-728a27993e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f9fa2d-4bf4-4fcb-9b76-fd4a9ff5a58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f9fa2d-4bf4-4fcb-9b76-fd4a9ff5a58c.jpg?1",
             "name": "Aegis Automaton",
             "text": "{4}{W}: Return another target creature you control to its owner's hand.",
             "colours": [],
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "b211495f-7ff6-55d7-8a1e-d6b4075b2963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4160bb5f-4b49-4535-94f5-776d7abd1d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4160bb5f-4b49-4535-94f5-776d7abd1d1a.jpg?1",
             "name": "Aethersphere Harvester",
             "text": "Flying\nWhen Aethersphere Harvester enters the battlefield, you get {E}{E} (two energy counters).\nPay {E}: Aethersphere Harvester gains lifelink until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -4944,7 +4944,7 @@
         },
         {
             "id": "25b2ec2e-d371-5472-9501-2cc18f1301d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d017798-8278-4f9c-a691-912935c10c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d017798-8278-4f9c-a691-912935c10c20.jpg?1",
             "name": "Augmenting Automaton",
             "text": "{1}{B}: Augmenting Automaton gets +1/+1 until end of turn.",
             "colours": [],
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "4593845a-06d0-5b87-b15f-6b4480c0dfbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc81a94-955d-4734-b056-9b9a86cae60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc81a94-955d-4734-b056-9b9a86cae60b.jpg?1",
             "name": "Barricade Breaker",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nBarricade Breaker attacks each combat if able.",
             "colours": [],
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "7a3414dd-20f3-5601-a13d-c57064181f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddacdd-bbc4-4f9b-be1c-5f2c64be3cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddacdd-bbc4-4f9b-be1c-5f2c64be3cbc.jpg?1",
             "name": "Cogwork Assembler",
             "text": "{7}: Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "744b6792-c02e-5bcd-b4b0-2b4e833401b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11eff338-1940-4684-94c7-ef90e56dea99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11eff338-1940-4684-94c7-ef90e56dea99.jpg?1",
             "name": "Consulate Dreadnought",
             "text": "Crew 6 (Tap any number of creatures you control with total power 6 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "d2ec4c40-979b-5cfb-b474-7ca78a3cb279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c55b5b-58fd-4340-b089-8e271633e8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c55b5b-58fd-4340-b089-8e271633e8dd.jpg?1",
             "name": "Consulate Turret",
             "text": "{T}: You get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Consulate Turret deals 2 damage to target player.",
             "colours": [],
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "7691a620-fce5-548e-b12d-3eda96de3abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993bc69a-b615-48c5-af81-252a73384e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993bc69a-b615-48c5-af81-252a73384e8c.jpg?1",
             "name": "Crackdown Construct",
             "text": "Whenever you activate an ability of an artifact or creature that isn't a mana ability, Crackdown Construct gets +1/+1 until end of turn.",
             "colours": [],
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "d59c5598-db1d-5d72-a698-38b099947529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bbbc98-0806-4226-8fd1-16b812334cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bbbc98-0806-4226-8fd1-16b812334cee.jpg?1",
             "name": "Daredevil Dragster",
             "text": "At end of combat, if Daredevil Dragster attacked or blocked this combat, put a velocity counter on it. Then if it has two or more velocity counters on it, sacrifice it and draw two cards.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "a52bf074-e6fb-5115-a7b0-7c7f9023e0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e817c-079e-4e7c-a8ca-54634f30bf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e817c-079e-4e7c-a8ca-54634f30bf36.jpg?1",
             "name": "Filigree Crawler",
             "text": "When Filigree Crawler dies, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [],
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "c98d181e-1d46-5888-9f56-a4a7e70112f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a2862-a2d7-4d87-a4b8-def9f441f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a2862-a2d7-4d87-a4b8-def9f441f5fa.jpg?1",
             "name": "Foundry Assembler",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "660c1062-ea7b-5239-898e-398a2b4bf822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4fc5ed-e90d-4965-985a-ed126a713506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4fc5ed-e90d-4965-985a-ed126a713506.jpg?1",
             "name": "Gonti's Aether Heart",
             "text": "Whenever Gonti's Aether Heart or another artifact enters the battlefield under your control, you get {E}{E} (two energy counters).\nPay {E}{E}{E}{E}{E}{E}{E}{E}, Exile Gonti's Aether Heart: Take an extra turn after this one.",
             "colours": [],
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "931b78e6-7d7e-5b80-be11-f2169716ba0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e847c44-1849-4251-9075-88ed5c7792a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e847c44-1849-4251-9075-88ed5c7792a6.jpg?1",
             "name": "Heart of Kiran",
             "text": "Flying, vigilance\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nYou may remove a loyalty counter from a planeswalker you control rather than pay Heart of Kiran's crew cost.",
             "colours": [],
@@ -5282,7 +5282,7 @@
         },
         {
             "id": "525e2be4-336b-5b55-85cf-87d47ad6ab62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4bcadd-7eff-4294-94d5-52482a734d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4bcadd-7eff-4294-94d5-52482a734d5b.jpg?1",
             "name": "Hope of Ghirapur",
             "text": "Flying\nSacrifice Hope of Ghirapur: Until your next turn, target player who was dealt combat damage by Hope of Ghirapur this turn can't cast noncreature spells.",
             "colours": [],
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "ad016c99-f85c-56c6-a294-84b9ab090e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b1c8da-604a-42f0-8658-82580700dd31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b1c8da-604a-42f0-8658-82580700dd31.jpg?1",
             "name": "Implement of Combustion",
             "text": "{R}, Sacrifice Implement of Combustion: It deals 1 damage to target player.\nWhen Implement of Combustion is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "48ef1e75-c9a5-5c14-8fe2-5832e15a98b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a791aa71-00db-422d-a78a-53b121c24db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a791aa71-00db-422d-a78a-53b121c24db5.jpg?1",
             "name": "Implement of Examination",
             "text": "{U}, Sacrifice Implement of Examination: Draw a card.\nWhen Implement of Examination is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5375,7 +5375,7 @@
         },
         {
             "id": "9387d36e-26ab-5866-a5ab-91df5290f2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdee084-0d1a-486a-8361-680d394a5e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdee084-0d1a-486a-8361-680d394a5e23.jpg?1",
             "name": "Implement of Ferocity",
             "text": "{G}, Sacrifice Implement of Ferocity: Put a +1/+1 counter on target creature. Activate this ability only any time you could cast a sorcery.\nWhen Implement of Ferocity is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "2d4c110b-df9a-521c-bd78-041bf33cb7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8eb0c-d7fa-4229-ae65-1890c77b2c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8eb0c-d7fa-4229-ae65-1890c77b2c7c.jpg?1",
             "name": "Implement of Improvement",
             "text": "{W}, Sacrifice Implement of Improvement: You gain 2 life.\nWhen Implement of Improvement is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "5dd673fe-dbcc-5fb7-a86a-901f4056ad68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e45ca82-e387-4df0-890d-d53a7d0dadf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e45ca82-e387-4df0-890d-d53a7d0dadf7.jpg?1",
             "name": "Implement of Malice",
             "text": "{B}, Sacrifice Implement of Malice: Target player discards a card. Activate this ability only any time you could cast a sorcery.\nWhen Implement of Malice is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5465,7 +5465,7 @@
         },
         {
             "id": "674183c4-4a97-5685-9d09-38b0e93d148e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2564f-0066-41e0-a767-13ef33a17024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2564f-0066-41e0-a767-13ef33a17024.jpg?1",
             "name": "Inspiring Statuary",
             "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "ba7f265c-8599-578d-adc8-a689a20b205a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81873223-29c7-466b-b922-6717ec84afff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81873223-29c7-466b-b922-6717ec84afff.jpg?1",
             "name": "Irontread Crusher",
             "text": "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "fe7f4628-fa11-5219-9774-a165234005ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439a855-4041-4d14-8edf-6741a734e55d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439a855-4041-4d14-8edf-6741a734e55d.jpg?1",
             "name": "Lifecrafter's Bestiary",
             "text": "At the beginning of your upkeep, scry 1.\nWhenever you cast a creature spell, you may pay {G}. If you do, draw a card.",
             "colours": [],
@@ -5553,7 +5553,7 @@
         },
         {
             "id": "64cfec52-7c50-53d5-a953-4da6e82728f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955b4bc9-1ded-4f23-b415-ab968c681eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955b4bc9-1ded-4f23-b415-ab968c681eb7.jpg?1",
             "name": "Merchant's Dockhand",
             "text": "{3}{U}, {T}, Tap X untapped artifacts you control: Look at the top X cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [],
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "006708ff-3943-5b2e-bbb3-c8456b3c3223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4eba9-9e91-4beb-9296-a18baa73a318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4eba9-9e91-4beb-9296-a18baa73a318.jpg?1",
             "name": "Metallic Mimic",
             "text": "As Metallic Mimic enters the battlefield, choose a creature type.\nMetallic Mimic is the chosen type in addition to its other types.\nEach other creature you control of the chosen type enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [],
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "9a07ae79-5dc9-5067-8242-01b01618bc00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da443378-f5cb-4240-9524-2c40ec17c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da443378-f5cb-4240-9524-2c40ec17c933.jpg?1",
             "name": "Mobile Garrison",
             "text": "Whenever Mobile Garrison attacks, untap another target artifact or creature you control.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "3aab726c-a42b-5f7b-83bc-571ab642a72f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae03e5c-9655-425c-90ef-b70a0e66868d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae03e5c-9655-425c-90ef-b70a0e66868d.jpg?1",
             "name": "Night Market Guard",
             "text": "Night Market Guard can block an additional creature each combat.",
             "colours": [],
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "c2bb7b92-204e-5d41-8989-c34679ac0be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb96645-44d2-426c-90cb-3186297a8728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb96645-44d2-426c-90cb-3186297a8728.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "2310e67d-5282-57ab-a45e-6c1a87c5a63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed742a-a12a-4728-a771-07e3d1417419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed742a-a12a-4728-a771-07e3d1417419.jpg?1",
             "name": "Pacification Array",
             "text": "{2}, {T}: Tap target artifact or creature.",
             "colours": [],
@@ -5737,7 +5737,7 @@
         },
         {
             "id": "88e86b72-397f-5199-9b97-52c2dc877b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ccd81-9e11-47fa-8e16-064c52c24506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ccd81-9e11-47fa-8e16-064c52c24506.jpg?1",
             "name": "Paradox Engine",
             "text": "Whenever you cast a spell, untap all nonland permanents you control.",
             "colours": [],
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "58cdf4ec-71bb-5433-b2a0-e889dcfec7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1599b545-6b8e-4350-980a-59349374400d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1599b545-6b8e-4350-980a-59349374400d.jpg?1",
             "name": "Peacewalker Colossus",
             "text": "{1}{W}: Another target Vehicle you control becomes an artifact creature until end of turn.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5799,7 +5799,7 @@
         },
         {
             "id": "c671cd1d-addf-501d-b560-e419ec7aee22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991397cf-5c7d-4e8a-8f46-8e2e0ed29eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991397cf-5c7d-4e8a-8f46-8e2e0ed29eff.jpg?1",
             "name": "Planar Bridge",
             "text": "{8}, {T}: Search your library for a permanent card, put it onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "57b1eb85-9a64-5d8d-93d8-eb85a910b24f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e389c92-b54b-46b3-a7ab-b8a5a2a7d380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e389c92-b54b-46b3-a7ab-b8a5a2a7d380.jpg?1",
             "name": "Prizefighter Construct",
             "text": "",
             "colours": [],
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "02bb4f24-51a9-5962-9b5d-066a866fab68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac063445-d0e2-4015-96dc-97098433f30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac063445-d0e2-4015-96dc-97098433f30a.jpg?1",
             "name": "Renegade Map",
             "text": "Renegade Map enters the battlefield tapped.\n{T}, Sacrifice Renegade Map: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -5888,7 +5888,7 @@
         },
         {
             "id": "7de3669e-21ae-5668-ac88-16d5e153add0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afe3be3-b0bc-4617-b4de-f60d14f1b91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afe3be3-b0bc-4617-b4de-f60d14f1b91d.jpg?1",
             "name": "Reservoir Walker",
             "text": "When Reservoir Walker enters the battlefield, you gain 3 life and get {E}{E}{E} (three energy counters).",
             "colours": [],
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "2601421d-0a60-50f4-8d39-ef17f576eb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68abc75f-596f-4169-96fc-ada941ef47ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68abc75f-596f-4169-96fc-ada941ef47ed.jpg?1",
             "name": "Scrap Trawler",
             "text": "Whenever Scrap Trawler or another artifact you control is put into a graveyard from the battlefield, return to your hand target artifact card in your graveyard with lesser converted mana cost.",
             "colours": [],
@@ -5950,7 +5950,7 @@
         },
         {
             "id": "558e9886-81e3-51e6-bcf5-076400067ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2299e0-d31f-4ec4-9497-16e494ee21e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2299e0-d31f-4ec4-9497-16e494ee21e6.jpg?1",
             "name": "Servo Schematic",
             "text": "When Servo Schematic enters the battlefield or is put into a graveyard from the battlefield, create a 1/1 colorless Servo artifact creature token.",
             "colours": [],
@@ -5978,7 +5978,7 @@
         },
         {
             "id": "6179872c-ba31-51c0-8461-0530cb117de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5d73d2-60cc-4b64-8274-4ba1bb98b6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5d73d2-60cc-4b64-8274-4ba1bb98b6fa.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with converted mana cost 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "87689662-83a0-59f8-9e50-285f1f327823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b66b2-12b2-497b-a328-b43630c79e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b66b2-12b2-497b-a328-b43630c79e73.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "60f6d339-1bf5-532d-920e-38b857f2d155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba729d8-fd5e-4183-806a-0997f443a58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba729d8-fd5e-4183-806a-0997f443a58f.jpg?1",
             "name": "Untethered Express",
             "text": "Trample\nWhenever Untethered Express attacks, put a +1/+1 counter on it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6067,7 +6067,7 @@
         },
         {
             "id": "9563e007-cc92-5c6b-9ded-9b3805021280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c66c5a-0b1b-4936-9e07-2d169f16c1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c66c5a-0b1b-4936-9e07-2d169f16c1a6.jpg?1",
             "name": "Verdant Automaton",
             "text": "{3}{G}: Put a +1/+1 counter on Verdant Automaton.",
             "colours": [],
@@ -6100,7 +6100,7 @@
         },
         {
             "id": "b1f6b291-19de-505c-827d-8a96bf48b7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329a8738-3e17-403a-857a-0ba529ce8cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329a8738-3e17-403a-857a-0ba529ce8cd1.jpg?1",
             "name": "Walking Ballista",
             "text": "Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to target creature or player.",
             "colours": [],
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "aeccbb0a-91d7-542a-acc6-616dda8a6bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138b5fde-417d-4860-aca9-eae7f78b5768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138b5fde-417d-4860-aca9-eae7f78b5768.jpg?1",
             "name": "Watchful Automaton",
             "text": "{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "8ff75d91-fd63-5070-a44f-99dd9ae7d7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b5bae4-be97-4c10-b222-e1e317a8ffbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b5bae4-be97-4c10-b222-e1e317a8ffbc.jpg?1",
             "name": "Welder Automaton",
             "text": "{3}{R}: Welder Automaton deals 1 damage to each opponent.",
             "colours": [],
@@ -6197,7 +6197,7 @@
         },
         {
             "id": "7cdb28c5-cd41-5e8e-ba99-40134798cfe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331724d-6fab-454a-b06c-b06e499fa552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331724d-6fab-454a-b06c-b06e499fa552.jpg?1",
             "name": "Spire of Industry",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add one mana of any color to your mana pool. Activate this ability only if you control an artifact.",
             "colours": [],
@@ -6225,7 +6225,7 @@
         },
         {
             "id": "4a254341-f3dc-51e0-860f-b8f66eb55431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fdd9a-0ab6-4db9-84f9-859d2d862518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fdd9a-0ab6-4db9-84f9-859d2d862518.jpg?1",
             "name": "Ajani, Valiant Protector",
             "text": "+2: Put two +1/+1 counters on up to one target creature.\n+1: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.\n\u221211: Put X +1/+1 counters on target creature, where X is your life total. That creature gains trample until end of turn.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "2bbd85a2-ab7e-5bb4-97f7-991b44d8ec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef9708e-bfe4-4d24-8304-1618daa1c3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef9708e-bfe4-4d24-8304-1618daa1c3ee.jpg?1",
             "name": "Inspiring Roar",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "f932464a-6213-50e1-9d83-bd701aabe45d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bebef1c-2f03-4e0a-b3ba-861546ebf8a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bebef1c-2f03-4e0a-b3ba-861546ebf8a6.jpg?1",
             "name": "Ajani's Comrade",
             "text": "Trample\nAt the beginning of combat on your turn, if you control an Ajani planeswalker, put a +1/+1 counter on Ajani's Comrade.",
             "colours": [
@@ -6327,7 +6327,7 @@
         },
         {
             "id": "6cfa9c06-ee5b-54c1-8a93-cb371c60a8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7026c374-0776-403b-86fd-5092677fd5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7026c374-0776-403b-86fd-5092677fd5c9.jpg?1",
             "name": "Ajani's Aid",
             "text": "When Ajani's Aid enters the battlefield, you may search your library and/or graveyard for a card named Ajani, Valiant Protector, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nSacrifice Ajani's Aid: Prevent all combat damage a creature of your choice would deal this turn.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "f8f03132-aaef-58b8-ac50-3208bab2200d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea97c40-310e-4774-ae56-d4c0500a6189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea97c40-310e-4774-ae56-d4c0500a6189.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -6390,7 +6390,7 @@
         },
         {
             "id": "d06214d2-4c33-55ce-a497-88a1608a0b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c6614c-cc2b-4e5b-9c0d-ce8e4b2d8ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c6614c-cc2b-4e5b-9c0d-ce8e4b2d8ea7.jpg?1",
             "name": "Tezzeret, Master of Metal",
             "text": "+1: Reveal cards from the top of your library until you reveal an artifact card. Put that card into your hand and the rest on the bottom of your library in a random order.\n\u22123: Target opponent loses life equal to the number of artifacts you control.\n\u22128: Gain control of all artifacts and creatures target opponent controls.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "aaeaf498-6159-5a47-aadf-a3c936d469b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d71efa6-5de8-476f-86ce-0790956e574f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d71efa6-5de8-476f-86ce-0790956e574f.jpg?1",
             "name": "Tezzeret's Betrayal",
             "text": "Destroy target creature. You may search your library and/or graveyard for a card named Tezzeret, Master of Metal, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "9de2cedc-c9f4-5946-8afb-f0bd7b937d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19751aa-823e-4a0f-a004-dee333b34327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19751aa-823e-4a0f-a004-dee333b34327.jpg?1",
             "name": "Pendulum of Patterns",
             "text": "When Pendulum of Patterns enters the battlefield, you gain 3 life.\n{5}, {T}, Sacrifice Pendulum of Patterns: Draw a card.",
             "colours": [],
@@ -6487,7 +6487,7 @@
         },
         {
             "id": "c7510a7c-e7e4-565f-9a29-dd964eed6384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eacfeec-a341-45bc-bf95-e3df0094505a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eacfeec-a341-45bc-bf95-e3df0094505a.jpg?1",
             "name": "Tezzeret's Simulacrum",
             "text": "{T}: Target opponent loses 1 life. If you control a Tezzeret planeswalker, that player loses 3 life instead.",
             "colours": [],
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "7ea12951-7dd1-5f9f-bdc3-328392bb8b93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd7aab-c0ac-4566-bf99-c49931eeea2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd7aab-c0ac-4566-bf99-c49931eeea2a.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "8bc7da35-6721-5652-bcee-d69bfe27b90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6071fed-39c1-4f3b-a821-1611aedd8054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6071fed-39c1-4f3b-a821-1611aedd8054.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -6581,7 +6581,7 @@
         },
         {
             "id": "c7192a84-4ec9-557f-b467-9937ad9930b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebc91a9-23e0-4ca1-bc6d-e710ad2efb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebc91a9-23e0-4ca1-bc6d-e710ad2efb31.jpg?1",
             "name": "Ragavan",
             "text": "",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "1efcee85-7d6b-5bb3-98ef-dd925b820808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9616ca53-ea6a-4fc1-8e01-94e0fb47e5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9616ca53-ea6a-4fc1-8e01-94e0fb47e5ed.jpg?1",
             "name": "Etherium Cell",
             "text": "",
             "colours": [],
@@ -6645,7 +6645,7 @@
         },
         {
             "id": "eb01613c-a4d9-55db-b2c9-d7c0b43a5d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f136537-1ebe-4018-b406-44ef32ceef04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f136537-1ebe-4018-b406-44ef32ceef04.jpg?1",
             "name": "Tezzeret the Schemer Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/AFR.json
+++ b/Assets/Resources/Sets/AFR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "84d2e61d-46ef-5fa7-aeff-7a4cd8db71c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882c9f9-bf30-46b6-bedc-379d2c80e5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882c9f9-bf30-46b6-bedc-379d2c80e5cb.jpg?1",
             "name": "+2 Mace",
             "text": "",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "6d3bc1d2-45a5-5010-b36b-6cc33c962d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc45c9d4-ecc7-4a9d-9efe-f4b7d697dd97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc45c9d4-ecc7-4a9d-9efe-f4b7d697dd97.jpg?1",
             "name": "Arborea Pegasus",
             "text": "Flying\nWhen Arborea Pegasus enters the battlefield, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "567a3bb4-1ad0-529f-9e0b-fe882f560c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc040492-7fb7-4fdb-aafe-8179e5f2b28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc040492-7fb7-4fdb-aafe-8179e5f2b28c.jpg?1",
             "name": "Blink Dog",
             "text": "Double strike\nTeleport \u2014 {3}{W}: Blink Dog phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "e5465719-ba59-52ef-b475-f553e6fc57f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1899bb1-dd8e-4437-8ea3-4ad637eabf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1899bb1-dd8e-4437-8ea3-4ad637eabf2b.jpg?1",
             "name": "The Book of Exalted Deeds",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, create a 3/3 white Angel creature token with flying.\n{W}{W}{W}, {T}, Exile The Book of Exalted Deeds: Put an enlightened counter on target Angel. It gains \"You can't lose the game and your opponents can't win the game.\" Activate only as a sorcery.",
             "colours": [
@@ -146,7 +146,7 @@
         },
         {
             "id": "c228e9d4-2a6c-5f5c-bf27-93b3a8bd0852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d68812-8862-4e34-a992-7d6bbadaf316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d68812-8862-4e34-a992-7d6bbadaf316.jpg?1",
             "name": "Celestial Unicorn",
             "text": "Whenever you gain life, put a +1/+1 counter on Celestial Unicorn.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "f17eebae-bc94-5f8f-90a0-1959b8eb94e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ce8b7e-d8e1-489a-a69e-99089eeb8739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ce8b7e-d8e1-489a-a69e-99089eeb8739.jpg?1",
             "name": "Cleric Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nIf you would gain life, you gain that much life plus 1 instead.\n{3}{W}: Level 2\n//Level_2//\nWhenever you gain life, put a +1/+1 counter on target creature you control.\n{4}{W}: Level 3\n//Level_3//\nWhen this Class becomes level 3, return target creature card from your graveyard to the battlefield. You gain life equal to its toughness.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "c844fdc1-48ae-5811-9b85-7fd1ffc3a185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297bf274-d13d-4b75-b251-2d004b16b431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297bf274-d13d-4b75-b251-2d004b16b431.jpg?1",
             "name": "Cloister Gargoyle",
             "text": "When Cloister Gargoyle enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nAs long as you've completed a dungeon, Cloister Gargoyle gets +3/+0 and has flying.",
             "colours": [
@@ -253,7 +253,7 @@
         },
         {
             "id": "88ee70f1-7bf9-59d3-8a76-3ac5c4a18c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b16a4-c35a-4eec-94ed-8df6720240e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b16a4-c35a-4eec-94ed-8df6720240e0.jpg?1",
             "name": "A-Cloister Gargoyle",
             "text": "",
             "colours": [
@@ -287,7 +287,7 @@
         },
         {
             "id": "bf36f3bd-23d3-5c20-a9f1-978014e233ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3d7824-1297-408c-a11f-0622cab9c4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3d7824-1297-408c-a11f-0622cab9c4c3.jpg?1",
             "name": "Dancing Sword",
             "text": "Equipped creature gets +2/+1.\nWhen equipped creature dies, you may have Dancing Sword become a 2/1 Construct artifact creature with flying and ward {1}. If you do, it isn't an Equipment.\nEquip {1}",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "d7b3475e-801c-57da-b83f-2c3aa6a52c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00856f7-fef5-4ba5-9079-59a81d452c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00856f7-fef5-4ba5-9079-59a81d452c82.jpg?1",
             "name": "Dawnbringer Cleric",
             "text": "When Dawnbringer Cleric enters the battlefield, choose one \u2014\n\u2022 Cure Wounds \u2014 You gain 2 life.\n\u2022 Dispel Magic \u2014 Destroy target enchantment.\n\u2022 Gentle Repose \u2014 Exile target card from a graveyard.",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "11dacbba-07d1-5e52-8bc9-3adf00352234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53df7b80-71bf-4013-ad44-f76eae8ac81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53df7b80-71bf-4013-ad44-f76eae8ac81b.jpg?1",
             "name": "Delver's Torch",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, venture into the dungeon. (Enter the first room or advance to the next room.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "dcd89f7d-3b62-5b8c-aa57-d74f0cf858fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3620ed96-1d15-4942-b9e5-9f9a64b0cab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3620ed96-1d15-4942-b9e5-9f9a64b0cab4.jpg?1",
             "name": "Devoted Paladin",
             "text": "Beacon of Hope \u2014 When Devoted Paladin enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "c1ec41d7-43c7-52ec-a449-716175cd2b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d0852-4df3-4b29-830d-c6975265ef53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d0852-4df3-4b29-830d-c6975265ef53.jpg?1",
             "name": "Divine Smite",
             "text": "Target creature or planeswalker an opponent controls phases out. If that permanent is black, exile it instead. (If it phases out, treat it and anything attached to it as though they don't exist until its controller's next turn.)",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "c851a84d-4e49-543c-913c-61805d8ce89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e6b78-3e99-49f5-9eaf-bbb2e9789fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e6b78-3e99-49f5-9eaf-bbb2e9789fbe.jpg?1",
             "name": "Dragon's Disciple",
             "text": "As Dragon's Disciple enters the battlefield, you may reveal a Dragon card from your hand. If you do or if you control a Dragon, Dragon's Disciple enters the battlefield with a +1/+1 counter on it.\nDragons you control have ward {1}. (Whenever a Dragon you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -494,7 +494,7 @@
         },
         {
             "id": "cb121a4d-6362-5168-8cc5-60785696e27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2404a028-05f5-469b-80e0-e820721ff266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2404a028-05f5-469b-80e0-e820721ff266.jpg?1",
             "name": "Dwarfhold Champion",
             "text": "As long as Dwarfhold Champion is equipped, it gets +0/+2.",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "01076b72-fd33-5cdd-97ae-9935fcbd3a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191a73b3-9efc-4f79-bf10-e8e2d6951c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191a73b3-9efc-4f79-bf10-e8e2d6951c6c.jpg?1",
             "name": "A-Dwarfhold Champion",
             "text": "",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "76fa6f2a-2ff5-5816-a84e-a42100e64366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc86e78-8911-4a0d-ba3a-7802f8d991ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc86e78-8911-4a0d-ba3a-7802f8d991ef.jpg?1",
             "name": "Flumph",
             "text": "Defender, flying\nWhenever Flumph is dealt damage, you and target opponent each draw a card.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "e7b65025-b095-54d0-aada-fab46a112bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388722ad-dcc6-41b9-afd8-a93be91b30e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388722ad-dcc6-41b9-afd8-a93be91b30e0.jpg?1",
             "name": "Gloom Stalker",
             "text": "As long as you've completed a dungeon, Gloom Stalker has double strike.",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "fcb329b5-43b5-57d6-b7e5-5bb216cf05ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca4ffff-404e-4e8e-8fd6-4e64d4828fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca4ffff-404e-4e8e-8fd6-4e64d4828fc7.jpg?1",
             "name": "Grand Master of Flowers",
             "text": "As long as Grand Master of Flowers has seven or more loyalty counters on him, he's a 7/7 Dragon God creature with flying and indestructible.\n+1: Target creature without first strike, double strike, or vigilance can't attack or block until your next turn.\n+1: Search your library and/or graveyard for a card named Monk of the Open Hand, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "b2f6e00d-cb79-56d7-83f8-2087e3d5def2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3dda1-a1d3-48c9-8c81-da7eae20ac8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3dda1-a1d3-48c9-8c81-da7eae20ac8a.jpg?1",
             "name": "Guardian of Faith",
             "text": "Flash\nVigilance\nWhen Guardian of Faith enters the battlefield, any number of other target creatures you control phase out. (Treat them and anything attached to them as though they don't exist until their controller's next turn.)",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "9c8ddf4b-2120-5183-b5ec-a15bda5d755b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10f1687-fb20-4ad2-bad7-52e4470b35e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10f1687-fb20-4ad2-bad7-52e4470b35e4.jpg?1",
             "name": "Half-Elf Monk",
             "text": "Vigilance\nStunning Strike \u2014 {1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "c65c30e4-9046-584a-bfd8-d73f27140c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b0e68a-9d4e-42ea-8dac-c47cbed0c6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b0e68a-9d4e-42ea-8dac-c47cbed0c6ad.jpg?1",
             "name": "Icingdeath, Frost Tyrant",
             "text": "Flying, vigilance\nWhen Icingdeath, Frost Tyrant dies, create Icingdeath, Frost Tongue, a legendary white Equipment artifact token with \"Equipped creature gets +2/+0,\" \"Whenever equipped creature attacks, tap target creature defending player controls,\" and equip {2}.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "8cd37e6b-3866-5a7d-b155-7d3aa5013b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad29773-7c1b-410d-9f69-7aa751f6ebca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad29773-7c1b-410d-9f69-7aa751f6ebca.jpg?1",
             "name": "Ingenious Smith",
             "text": "When Ingenious Smith enters the battlefield, look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nWhenever one or more artifacts enter the battlefield under your control, put a +1/+1 counter on Ingenious Smith. This ability triggers only once each turn.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "a2f470ee-0d84-51f7-b8b1-d712c5ece2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de169d64-8242-4f57-980e-47f901fd57ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de169d64-8242-4f57-980e-47f901fd57ab.jpg?1",
             "name": "Keen-Eared Sentry",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\nEach opponent can't venture into the dungeon more than once each turn.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "35645741-09eb-52ae-baa5-337af54b9f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f408c5e4-e18d-4e4d-959a-f41df4c3019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f408c5e4-e18d-4e4d-959a-f41df4c3019c.jpg?1",
             "name": "Loyal Warhound",
             "text": "Vigilance\nWhen Loyal Warhound enters the battlefield, if an opponent controls more lands than you, search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -889,7 +889,7 @@
         },
         {
             "id": "da0c3781-fcee-593a-a9cd-4458f7b5782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0556f0d9-50d2-4c67-8522-de366d96500a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0556f0d9-50d2-4c67-8522-de366d96500a.jpg?1",
             "name": "Minimus Containment",
             "text": "Enchant nonland permanent\nEnchanted permanent is a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other abilities. (If it was a creature, it's no longer a creature.)",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "d767e021-9ad1-538e-9660-8045f86ff981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d934765f-f490-4e8d-843d-b2b559ee0418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d934765f-f490-4e8d-843d-b2b559ee0418.jpg?1",
             "name": "Monk of the Open Hand",
             "text": "Flurry of Blows \u2014 Whenever you cast your second spell each turn, put a +1/+1 counter on Monk of the Open Hand.",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "b531ede1-1dae-5ef0-b2da-c75205f45d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7fea79-9600-41d2-84d2-34a61a08a0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7fea79-9600-41d2-84d2-34a61a08a0d4.jpg?1",
             "name": "Moon-Blessed Cleric",
             "text": "Divine Intervention \u2014 When Moon-Blessed Cleric enters the battlefield, you may search your library for an enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "b03d91e9-f7b1-5db3-8611-383d70cc12d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878a0d8c-11c1-4c65-9051-78e036ac496f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878a0d8c-11c1-4c65-9051-78e036ac496f.jpg?1",
             "name": "Nadaar, Selfless Paladin",
             "text": "Vigilance\nWhenever Nadaar, Selfless Paladin enters the battlefield or attacks, venture into the dungeon. (Enter the first room or advance to the next room.)\nOther creatures you control get +1/+1 as long as you've completed a dungeon.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "abe6ed57-43fa-5c01-a7bf-aee87a786fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba1650f-eddf-49a9-820e-489cb8d5b6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba1650f-eddf-49a9-820e-489cb8d5b6fa.jpg?1",
             "name": "Oswald Fiddlebender",
             "text": "Magical Tinkering \u2014 {W}, {T}, Sacrifice an artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "899f8454-af79-5f96-9d7d-51f9c2f0fc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf81fb1-7992-4ae9-b1a8-80c31579a2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf81fb1-7992-4ae9-b1a8-80c31579a2bf.jpg?1",
             "name": "Paladin Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nSpells your opponents cast during your turn cost {1} more to cast.\n{2}{W}: Level 2\n//Level_2//\nCreatures you control get +1/+1.\n{4}{W}: Level 3\n//Level_3//\nWhenever you attack, until end of turn, target attacking creature gets +1/+1 for each other attacking creature and gains double strike.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "d2f6bef8-a422-5c2a-81b8-0cea3b504033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e13b103-202f-41d7-a855-a6807e5fb4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e13b103-202f-41d7-a855-a6807e5fb4b7.jpg?1",
             "name": "Paladin's Shield",
             "text": "Flash\nWhen Paladin's Shield enters the battlefield, attach it to target creature you control.\nEquipped creature gets +0/+2.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1140,7 +1140,7 @@
         },
         {
             "id": "6e30c4e6-42d6-586b-9122-3bb3d290d55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e7457a-8ab4-4f3c-a2d8-2da4d81b7470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e7457a-8ab4-4f3c-a2d8-2da4d81b7470.jpg?1",
             "name": "Planar Ally",
             "text": "Flying\nWhenever Planar Ally attacks, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "eedd8fc2-48c8-57fe-91aa-b64ae75b5e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad447e50-cfb1-40df-ae01-a65c46f2f572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad447e50-cfb1-40df-ae01-a65c46f2f572.jpg?1",
             "name": "Plate Armor",
             "text": "Equipped creature gets +3/+3 and has ward {1}. (Whenever equipped creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nEquip {3}. This ability costs {1} less to activate for each other Equipment you control.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "a26ef69b-d755-5df9-9691-410691a8bdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594323b6-558d-4597-beb8-5346599ea571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594323b6-558d-4597-beb8-5346599ea571.jpg?1",
             "name": "A-Plate Armor",
             "text": "",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "06bd6912-deef-5163-8f5e-ade2cf7ba95f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fca8c0-ae3e-439e-b202-228b9f360e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fca8c0-ae3e-439e-b202-228b9f360e9a.jpg?1",
             "name": "Portable Hole",
             "text": "When Portable Hole enters the battlefield, exile target nonland permanent an opponent controls with mana value 2 or less until Portable Hole leaves the battlefield.",
             "colours": [
@@ -1275,7 +1275,7 @@
         },
         {
             "id": "4b5bdccf-d218-56c9-99b1-415778cd65bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5edb608-c7d7-4fa9-b969-262c9789fc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5edb608-c7d7-4fa9-b969-262c9789fc17.jpg?1",
             "name": "Potion of Healing",
             "text": "When Potion of Healing enters the battlefield, draw a card.\n{W}, {T}, Sacrifice Potion of Healing: You gain 3 life.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "4838b7ef-da7b-50ac-a5a2-239a7c41d4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10caff0-701a-48d8-a943-f947482e795a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10caff0-701a-48d8-a943-f947482e795a.jpg?1",
             "name": "Priest of Ancient Lore",
             "text": "When Priest of Ancient Lore enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "580e6e67-a2da-58b5-8342-d7793278de8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926ce53e-8e30-4018-a9e7-7266791b5d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926ce53e-8e30-4018-a9e7-7266791b5d27.jpg?1",
             "name": "Rally Maneuver",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn. Up to one other target creature gets +0/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "bda23a83-f6c7-5465-b862-b0af319d87fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a7744-e49d-4b4e-b6ae-7fc6d2892cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a7744-e49d-4b4e-b6ae-7fc6d2892cef.jpg?1",
             "name": "Ranger's Hawk",
             "text": "Flying\n{3}, {T}, Tap another untapped creature you control: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "f0084dc6-1982-5965-beab-805d40f72183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c06b6e-faf5-467d-bfe1-9ff00be9e2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c06b6e-faf5-467d-bfe1-9ff00be9e2f5.jpg?1",
             "name": "Steadfast Paladin",
             "text": "Lifelink",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "35f87929-b34f-560c-83cb-c692280dd87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90140bc0-4a9c-4422-b07c-3400c7ccde56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90140bc0-4a9c-4422-b07c-3400c7ccde56.jpg?1",
             "name": "Teleportation Circle",
             "text": "At the beginning of your end step, exile up to one target artifact or creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "645015fb-8771-51ca-8d2c-6beb24d4a079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe33b3-afaf-4a98-ae64-7d7e0eabe993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe33b3-afaf-4a98-ae64-7d7e0eabe993.jpg?1",
             "name": "Veteran Dungeoneer",
             "text": "When Veteran Dungeoneer enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1512,7 +1512,7 @@
         },
         {
             "id": "61853856-abd2-5ad7-a1e2-72444bb6e6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e290c4-6c94-472a-9dec-6994aade29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e290c4-6c94-472a-9dec-6994aade29c2.jpg?1",
             "name": "White Dragon",
             "text": "Flying\nCold Breath \u2014 When White Dragon enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "80e2626e-6553-5977-b747-f9af228f5c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e939ab-9d0c-4685-805c-c8bc4e6af163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e939ab-9d0c-4685-805c-c8bc4e6af163.jpg?1",
             "name": "You Hear Something on Watch",
             "text": "Choose one \u2014\n\u2022 Rouse the Party \u2014 Creatures you control get +1/+1 until end of turn.\n\u2022 Set Off Traps \u2014 This spell deals 5 damage to target attacking creature.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "297cc57b-125b-51cc-b268-9a9c6d7cb74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726da84a-fdd4-46df-8ba4-f94d582bcce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726da84a-fdd4-46df-8ba4-f94d582bcce4.jpg?1",
             "name": "You're Ambushed on the Road",
             "text": "Choose one \u2014\n\u2022 Make a Retreat \u2014 Return target creature you control to its owner's hand.\n\u2022 Stand and Fight \u2014 Target creature gets +1/+3 until end of turn.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "1fc1b94c-fdf8-5006-ab2e-bdfe43986c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c6401a-e152-4acf-a2ca-75c484f296d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c6401a-e152-4acf-a2ca-75c484f296d5.jpg?1",
             "name": "Aberrant Mind Sorcerer",
             "text": "Psionic Spells \u2014 When Aberrant Mind Sorcerer enters the battlefield, choose target instant or sorcery card in your graveyard, then roll a d20.\n1\u20139 | You may put that card on top of your library.\n10\u201320 | Return that card to your hand.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "78287b02-d01a-51ff-8dc6-6e1670f0f47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba82564-a9a9-4ded-a5fa-0e5fab2a3faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba82564-a9a9-4ded-a5fa-0e5fab2a3faa.jpg?1",
             "name": "Air-Cult Elemental",
             "text": "Flying\nWhirlwind \u2014 When Air-Cult Elemental enters the battlefield, return up to one other target creature to its owner's hand.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "7f1e78e9-ef2e-5fe5-987d-16af8cff0f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc457520-9947-4f65-bbe7-9b95bd2c23af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc457520-9947-4f65-bbe7-9b95bd2c23af.jpg?1",
             "name": "Arcane Investigator",
             "text": "Search the Room \u2014 {5}{U}: Roll a d20.\n1\u20139 | Draw a card.\n10\u201320 | Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "6a24eca5-1dff-5007-b7e5-9427a657451a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b1e53f-1384-4860-9944-e68922afc65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b1e53f-1384-4860-9944-e68922afc65c.jpg?1",
             "name": "Bar the Gate",
             "text": "Counter target creature or planeswalker spell. Venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "e40944a0-a800-5547-975c-74e4a93b6197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317cbf3-13a1-4471-a23c-de429941e8a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317cbf3-13a1-4471-a23c-de429941e8a4.jpg?1",
             "name": "The Blackstaff of Waterdeep",
             "text": "You may choose not to untap The Blackstaff of Waterdeep during your untap step.\nAnimate Walking Statue \u2014 {1}{U}, {T}: Another target nontoken artifact you control becomes a 4/4 artifact creature for as long as The Blackstaff of Waterdeep remains tapped. Activate only as a sorcery.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "d2e35f3a-b4d4-500b-8eac-8e331703542a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98dea71b-2778-4374-8ea2-7fa82f0f6110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98dea71b-2778-4374-8ea2-7fa82f0f6110.jpg?1",
             "name": "Blue Dragon",
             "text": "Flying\nLightning Breath \u2014 When Blue Dragon enters the battlefield, until your next turn, target creature an opponent controls gets -3/-0, up to one other target creature gets -2/-0, and up to one other target creature gets -1/-0.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "8915342f-a13c-57cd-a477-e96ec7e00f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238ad00-af9c-4535-a589-c5afb0d2ec57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238ad00-af9c-4535-a589-c5afb0d2ec57.jpg?1",
             "name": "Charmed Sleep",
             "text": "Enchant creature\nWhen Charmed Sleep enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "eb25a48a-6516-5e50-a3c2-86723bfa08d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9784c97-3839-4a4b-ae8a-965844dbeb70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9784c97-3839-4a4b-ae8a-965844dbeb70.jpg?1",
             "name": "Clever Conjurer",
             "text": "Mage Hand \u2014 {T}: Untap target permanent not named Clever Conjurer. Activate only as a sorcery.",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "01060037-0fa1-501a-99cf-f4e2db926237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fefb38-c6f2-43c4-a6b9-ac82f8827bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fefb38-c6f2-43c4-a6b9-ac82f8827bc2.jpg?1",
             "name": "Contact Other Plane",
             "text": "Roll a d20.\n1\u20139 | Draw two cards.\n10\u201319 | Scry 2, then draw two cards.\n20 | Scry 3, then draw three cards.",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "7aef98ff-f51e-5a0b-9adf-7d41ca99b5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1351ed-b9df-4a6d-aaa1-ec6db673d265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1351ed-b9df-4a6d-aaa1-ec6db673d265.jpg?1",
             "name": "Demilich",
             "text": "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn.\nWhenever Demilich attacks, exile up to one target instant or sorcery card from your graveyard. Copy it. You may cast the copy.\nYou may cast Demilich from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "ba8f67a1-86c5-51a1-b6c6-559608da7820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8f1-3738-4db4-a2b3-7aeb4c2fd59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8f1-3738-4db4-a2b3-7aeb4c2fd59b.jpg?1",
             "name": "A-Demilich",
             "text": "",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "9a8fd651-d7bd-5e0a-b91c-9dc8ccf81a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d5c36c-bcc8-459c-9f4b-b265ccdb1f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d5c36c-bcc8-459c-9f4b-b265ccdb1f06.jpg?1",
             "name": "Displacer Beast",
             "text": "When Displacer Beast enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nDisplacement \u2014 {3}{U}: Return Displacer Beast to its owner's hand.",
             "colours": [
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "c60d0c0b-ba48-535f-8065-ff69981e874e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a42698-bf3b-4352-8178-9c98abfc5b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a42698-bf3b-4352-8178-9c98abfc5b09.jpg?1",
             "name": "Djinni Windseer",
             "text": "Flying\nWhen Djinni Windseer enters the battlefield, roll a d20.\n1\u20139 | Scry 1.\n10\u201319 | Scry 2.\n20 | Scry 3.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "cf713528-5222-5099-bdcf-9bdfe018aab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d436ba80-386f-40ad-b0ca-a98cc50de964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d436ba80-386f-40ad-b0ca-a98cc50de964.jpg?1",
             "name": "Dragon Turtle",
             "text": "Flash\nDrag Below \u2014 When Dragon Turtle enters the battlefield, tap it and up to one target creature an opponent controls. They don't untap during their controllers' next untap steps.",
             "colours": [
@@ -2103,7 +2103,7 @@
         },
         {
             "id": "7be456da-7ee8-5b46-ba63-eab6fd8cccfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa08ac-9a94-4e22-91bb-c6966cd0a0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa08ac-9a94-4e22-91bb-c6966cd0a0de.jpg?1",
             "name": "Eccentric Apprentice",
             "text": "Flying\nWhen Eccentric Apprentice enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nAt the beginning of combat on your turn, if you've completed a dungeon, up to one target creature becomes a Bird with base power and toughness 1/1 and flying until end of turn.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "b2ae9acd-2d87-5e06-ba25-72de5c74f55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93e0296-69e0-45e0-a1c2-0214a53c52d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93e0296-69e0-45e0-a1c2-0214a53c52d0.jpg?1",
             "name": "Feywild Trickster",
             "text": "Whenever you roll one or more dice, create a 1/1 blue Faerie Dragon creature token with flying.",
             "colours": [
@@ -2173,7 +2173,7 @@
         },
         {
             "id": "004f96ed-3950-5989-9b7e-eec980dac3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a91cc6-67e1-4f1b-86e2-eb388a75d6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a91cc6-67e1-4f1b-86e2-eb388a75d6ad.jpg?1",
             "name": "Fly",
             "text": "Enchant creature\nEnchanted creature has flying and \"Whenever this creature deals combat damage to a player, venture into the dungeon.\" (Enter the first room or advance to the next room.)",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "288f6728-bfa5-5618-aea3-25dbac4fbdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cca453-4611-4f3d-85d8-d74d260c7598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cca453-4611-4f3d-85d8-d74d260c7598.jpg?1",
             "name": "Grazilaxx, Illithid Scholar",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "8f753719-f926-515f-955b-d1bcc362c0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4348ec-fdb1-4c3b-bec5-42513c6c0662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4348ec-fdb1-4c3b-bec5-42513c6c0662.jpg?1",
             "name": "Guild Thief",
             "text": "Whenever Guild Thief deals combat damage to a player, put a +1/+1 counter on it.\nCunning Action \u2014 {3}{U}: Guild Thief can't be blocked this turn.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "aa7aaea3-07a0-5d21-9b2a-7399f530e3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e6025d-d273-4ae4-9929-5e588612f1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e6025d-d273-4ae4-9929-5e588612f1b3.jpg?1",
             "name": "Iymrith, Desert Doom",
             "text": "Flying\nIymrith, Desert Doom has ward {4} as long as it's untapped.\nWhenever Iymrith deals combat damage to a player, draw a card. Then if you have fewer than three cards in hand, draw cards equal to the difference.",
             "colours": [
@@ -2318,7 +2318,7 @@
         },
         {
             "id": "ef295af2-dcbc-5045-83bd-a31bac6f0cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ac797-a186-4224-94e1-9bb9dca4b029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ac797-a186-4224-94e1-9bb9dca4b029.jpg?1",
             "name": "Mind Flayer",
             "text": "Dominate Monster \u2014 When Mind Flayer enters the battlefield, gain control of target creature for as long as you control Mind Flayer.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "01b81265-d14d-53ed-9d1c-a3db1896b055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5e4c7-12fa-4ec4-bd4b-752e367306c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5e4c7-12fa-4ec4-bd4b-752e367306c7.jpg?1",
             "name": "Mordenkainen",
             "text": "+2: Draw two cards, then put a card from your hand on the bottom of your library.\n\u22122: Create a blue Dog Illusion creature token with \"This creature's power and toughness are each equal to twice the number of cards in your hand.\"\n\u221210: Exchange your hand and library, then shuffle. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "7520da57-eb4d-5ccc-bbf6-6facb30e284e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6551442-d74c-4f16-a9de-0cfdc88208a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6551442-d74c-4f16-a9de-0cfdc88208a5.jpg?1",
             "name": "Mordenkainen's Polymorph",
             "text": "Until end of turn, target creature becomes a Dragon with base power and toughness 4/4 and gains flying. (It loses all other creature types.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "fb85ea00-52bc-526f-8f9f-c7db5c71a318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65631b9-ca62-4851-9eca-9c760fb1a177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65631b9-ca62-4851-9eca-9c760fb1a177.jpg?1",
             "name": "Pixie Guide",
             "text": "Flying\nGrant an Advantage \u2014 If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "32ddf2da-bb81-58c8-99b1-b0d9080fe208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d84cb72-d0a0-4af0-aded-47e5fb7addef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d84cb72-d0a0-4af0-aded-47e5fb7addef.jpg?1",
             "name": "Power of Persuasion",
             "text": "Choose target creature an opponent controls, then roll a d20.\n1\u20139 | Return it to its owner's hand.\n10\u201319 | Its owner puts it on the top or bottom of their library.\n20 | Gain control of it until the end of your next turn.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "e004d31b-cce6-5146-a386-1c4179c9d0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edd5058-a964-4288-937b-84df6e9ba7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edd5058-a964-4288-937b-84df6e9ba7c4.jpg?1",
             "name": "Ray of Frost",
             "text": "Flash\nEnchant creature\nWhen Ray of Frost enters the battlefield, if enchanted creature is red, tap it.\nAs long as enchanted creature is red, it loses all abilities.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "f576f880-f951-5755-a9c9-6706a35c02df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767b499e-3bdb-4809-b430-6e965bd100d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767b499e-3bdb-4809-b430-6e965bd100d4.jpg?1",
             "name": "Rimeshield Frost Giant",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "79677dd7-db55-5b2d-a1a1-7778ec1df2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0abdb4-4898-4818-b7e2-24a90f15e49d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0abdb4-4898-4818-b7e2-24a90f15e49d.jpg?1",
             "name": "Scion of Stygia",
             "text": "Flash\nCone of Cold \u2014 When Scion of Stygia enters the battlefield, choose target creature an opponent controls, then roll a d20.\n1\u20139 | Tap that creature.\n10\u201320 | Tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "356d5bbc-ccd3-5c34-8c75-9222693d1b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191e400-aa4e-4955-aca0-ecbe63ea240f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191e400-aa4e-4955-aca0-ecbe63ea240f.jpg?1",
             "name": "Secret Door",
             "text": "Defender\n{4}{U}: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "4bb6e122-bb02-589b-a9ef-0a61373fb6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95fe13-c09b-4eed-aeae-fb1c5b6eb476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95fe13-c09b-4eed-aeae-fb1c5b6eb476.jpg?1",
             "name": "Shocking Grasp",
             "text": "Target creature gets -2/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2665,7 +2665,7 @@
         },
         {
             "id": "9088f568-0ea7-5d2a-9c3a-4c96ac184460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d2635-c4f4-44cd-8f82-37e3016e421e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d2635-c4f4-44cd-8f82-37e3016e421e.jpg?1",
             "name": "Shortcut Seeker",
             "text": "Whenever Shortcut Seeker deals combat damage to a player, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "9b6e0133-7a33-55ce-91b7-5aad074841f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a671ec19-32f4-4fde-8ee0-1224471e79db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a671ec19-32f4-4fde-8ee0-1224471e79db.jpg?1",
             "name": "Silver Raven",
             "text": "Flying\nWhen Silver Raven enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "fb81a0ca-771b-53b9-b1d2-413d784dd70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c7c23-d418-42f0-b497-50c39e5321ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c7c23-d418-42f0-b497-50c39e5321ad.jpg?1",
             "name": "Soulknife Spy",
             "text": "Whenever Soulknife Spy deals combat damage to a player, draw a card.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "9698e68c-2e32-56da-9b88-43425599280f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a0a96-f90a-4852-9a92-848795518e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a0a96-f90a-4852-9a92-848795518e0a.jpg?1",
             "name": "Split the Party",
             "text": "Choose target player. Return half the creatures they control to their owner's hand, rounded up.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "600da950-44c0-5779-9a75-dc2fc8f0e3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec3c87-d5aa-4f8a-a9bf-ef4e38e21ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec3c87-d5aa-4f8a-a9bf-ef4e38e21ad1.jpg?1",
             "name": "Sudden Insight",
             "text": "Draw a card for each different mana value among nonland cards in your graveyard.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "1856e137-f857-5f62-ae24-0d54b0637136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4932113-904f-427a-9566-509cc008f3ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4932113-904f-427a-9566-509cc008f3ef.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "Each opponent exiles cards from the top of their library until that player has exiled cards with total mana value 20 or more.",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "fadc99f4-201f-51d8-aefa-9802f153f220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cb9973-c9ce-48f1-9972-651092624751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cb9973-c9ce-48f1-9972-651092624751.jpg?1",
             "name": "Trickster's Talisman",
             "text": "Invoke Duplicity \u2014 Equipped creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, you may sacrifice Trickster's Talisman. If you do, create a token that's a copy of this creature.\"\nEquip {2}",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "530e6d78-a560-5ccd-b2c3-48992a3c128f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a1f384-9266-425c-b739-09d74871fc7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a1f384-9266-425c-b739-09d74871fc7b.jpg?1",
             "name": "True Polymorph",
             "text": "Target artifact or creature becomes a copy of another target artifact or creature.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "ba15381c-f047-5a1d-b3ed-d8323e2c0c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f629fb-b097-4240-8560-ef47f5678f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f629fb-b097-4240-8560-ef47f5678f48.jpg?1",
             "name": "Wizard Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nYou have no maximum hand size.\n{2}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, draw two cards.\n{4}{U}: Level 3\n//Level_3//\nWhenever you draw a card, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "03e93041-9a58-5019-b8e4-b88c150d941e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab73fa2c-b89f-4f1c-b8bf-f00c024a00bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab73fa2c-b89f-4f1c-b8bf-f00c024a00bd.jpg?1",
             "name": "A-Wizard Class",
             "text": "",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "6c8872f8-e479-50cc-9ae6-53920725df73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed0a4c-0234-4341-8dcb-5eea6a9632e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed0a4c-0234-4341-8dcb-5eea6a9632e7.jpg?1",
             "name": "Wizard's Spellbook",
             "text": "{T}: Exile target instant or sorcery card from a graveyard. Roll a d20. Activate only as a sorcery.\n1\u20139 | Copy that card. You may cast the copy.\n10\u201319 | Copy that card. You may cast the copy by paying {1} rather than paying its mana cost.\n20 | Copy each card exiled with Wizard's Spellbook. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "abb683c4-b785-50b9-b49a-ace63ad485d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf9bab7-98a0-4394-90c0-e7c52e14eb37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf9bab7-98a0-4394-90c0-e7c52e14eb37.jpg?1",
             "name": "You Come to a River",
             "text": "Choose one \u2014\n\u2022 Fight the Current \u2014 Return target nonland permanent to its owner's hand.\n\u2022 Find a Crossing \u2014 Target creature gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "8815e98a-6d2a-5a08-a03d-9b9978c3dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6704458-6e9e-4795-a56d-25b68fbf9672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6704458-6e9e-4795-a56d-25b68fbf9672.jpg?1",
             "name": "You Find the Villains' Lair",
             "text": "Choose one \u2014\n\u2022 Foil Their Scheme \u2014 Counter target spell.\n\u2022 Learn Their Secrets \u2014 Draw two cards, then discard two cards.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "29c3b987-75de-5a70-a021-799395a57a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c5fd8e-753a-45e1-bcdd-fb6e072ffbb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c5fd8e-753a-45e1-bcdd-fb6e072ffbb0.jpg?1",
             "name": "You See a Guard Approach",
             "text": "Choose one \u2014\n\u2022 Distract the Guard \u2014 Tap target creature.\n\u2022 Hide \u2014 Target creature you control gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "b2d123e1-4368-5a0e-bb5d-030dca899907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f51afd9-7093-4aa3-ad5b-7383684d6285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f51afd9-7093-4aa3-ad5b-7383684d6285.jpg?1",
             "name": "Yuan-Ti Malison",
             "text": "Yuan-Ti Malison can't be blocked as long as it's attacking alone.\nWhenever Yuan-Ti Malison deals combat damage to a player, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "732fd43f-9dd5-54ab-84ac-cf62ea3b6c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52d0bd-3abd-401c-9f56-ee911613da3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52d0bd-3abd-401c-9f56-ee911613da3b.jpg?1",
             "name": "Acererak the Archlich",
             "text": "When Acererak the Archlich enters the battlefield, if you haven't completed Tomb of Annihilation, return Acererak the Archlich to its owner's hand and venture into the dungeon.\nWhenever Acererak the Archlich attacks, for each opponent, you create a 2/2 black Zombie creature token unless that player sacrifices a creature.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "ee850195-8744-5177-8419-b56b4ecd7bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb363654-2004-4db8-bbd2-5b121da4f2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb363654-2004-4db8-bbd2-5b121da4f2a0.jpg?1",
             "name": "A-Acererak the Archlich",
             "text": "",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "70e61f81-2036-51f4-805a-71dc9265da98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6b864-58e7-43b9-9d79-1d0361340960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6b864-58e7-43b9-9d79-1d0361340960.jpg?1",
             "name": "Asmodeus the Archfiend",
             "text": "Binding Contract \u2014 If you would draw a card, exile the top card of your library face down instead.\n{B}{B}{B}: Draw seven cards.\n{B}: Return all cards exiled with Asmodeus the Archfiend to their owner's hand and you lose that much life.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "cf476891-4ff5-575c-94ba-29656db9b3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d6ef6-d8a3-4288-8917-4c0a179ed4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d6ef6-d8a3-4288-8917-4c0a179ed4e0.jpg?1",
             "name": "Baleful Beholder",
             "text": "When Baleful Beholder enters the battlefield, choose one \u2014\n\u2022 Antimagic Cone \u2014 Each opponent sacrifices an enchantment.\n\u2022 Fear Ray \u2014 Creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "ed8922d9-88e9-5e0a-8b8a-82e6382c1676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca283a-39f1-4ae7-98fb-7821a927ef86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca283a-39f1-4ae7-98fb-7821a927ef86.jpg?1",
             "name": "Black Dragon",
             "text": "Flying\nAcid Breath \u2014 When Black Dragon enters the battlefield, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "323cd41d-5080-53f6-b4bb-8c014872c9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05dcff61-8c48-401f-a31f-5fc53a298356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05dcff61-8c48-401f-a31f-5fc53a298356.jpg?1",
             "name": "The Book of Vile Darkness",
             "text": "At the beginning of your end step, if you lost 2 or more life this turn, create a 2/2 black Zombie creature token.\n{T}, Exile The Book of Vile Darkness and artifacts you control named Eye of Vecna and Hand of Vecna: Create Vecna, a legendary 8/8 black Zombie God creature token with indestructible. It gains all triggered abilities of the exiled cards.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "11426a68-91cf-51b1-ba4b-ae7c32d96ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f58ea8a-30ac-45b0-a701-8b8d8262cfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f58ea8a-30ac-45b0-a701-8b8d8262cfcf.jpg?1",
             "name": "Check for Traps",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If an instant card or a card with flash is exiled this way, they lose 1 life. Otherwise, you lose 1 life.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "10cf68ba-9c72-562a-9c97-4c8db9e24645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac0b2b-d4d3-4977-b241-7788239362de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac0b2b-d4d3-4977-b241-7788239362de.jpg?1",
             "name": "Clattering Skeletons",
             "text": "When Clattering Skeletons dies, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "ce2ff8be-efc7-56b7-89ad-0c9d2a5d49a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7373fe95-ad1c-44b9-8c7f-464ce8cbffc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7373fe95-ad1c-44b9-8c7f-464ce8cbffc6.jpg?1",
             "name": "Deadly Dispute",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "9ec4dbea-2cb5-5364-9f07-31fde3fd5043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126b2636-030a-4a0e-9307-54c3372afb52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126b2636-030a-4a0e-9307-54c3372afb52.jpg?1",
             "name": "Death-Priest of Myrkul",
             "text": "Skeletons, Vampires, and Zombies you control get +1/+1.\nAt the beginning of your end step, if a creature died this turn, you may pay {1}. If you do, create a 1/1 black Skeleton creature token.",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "563992c1-5a64-5f3b-9286-ab80e13aa9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f756f0c8-bab6-45cf-a433-409b3c999263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f756f0c8-bab6-45cf-a433-409b3c999263.jpg?1",
             "name": "A-Death-Priest of Myrkul",
             "text": "",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "6a2bfb66-7b12-55c3-a216-34a63be21138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e7ac6-65e5-4a16-ab0b-0988c3a3cfea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e7ac6-65e5-4a16-ab0b-0988c3a3cfea.jpg?1",
             "name": "Demogorgon's Clutches",
             "text": "Target opponent discards two cards, mills two cards, and loses 2 life. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "051c5c0a-a27b-5658-b396-43fc1a0224ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c34f2d-2eac-4241-8b23-9cab3268c254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c34f2d-2eac-4241-8b23-9cab3268c254.jpg?1",
             "name": "Devour Intellect",
             "text": "Target opponent discards a card. If mana from a Treasure was spent to cast this spell, instead that player reveals their hand, you choose a nonland card from it, then that player discards that card.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "aca3bc38-5d58-5232-93dd-8d277a2e8abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc06a88-1eb6-4edb-8f03-d8274560cc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc06a88-1eb6-4edb-8f03-d8274560cc41.jpg?1",
             "name": "Drider",
             "text": "Reach\nWhenever Drider deals combat damage to a player, create a 2/1 black Spider creature token with menace and reach.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "eaf97c2d-7bf1-5f08-af56-4fddbd437343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138b66d-cf18-42a5-8522-241bd3969624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138b66d-cf18-42a5-8522-241bd3969624.jpg?1",
             "name": "Dungeon Crawler",
             "text": "Dungeon Crawler enters the battlefield tapped.\nWhenever you complete a dungeon, you may return Dungeon Crawler from your graveyard to your hand.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "337f7563-4636-5f32-a818-186dbcd2ac1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3f460-92ba-4af0-aad9-cf86615d4177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3f460-92ba-4af0-aad9-cf86615d4177.jpg?1",
             "name": "Ebondeath, Dracolich",
             "text": "Flash\nFlying\nEbondeath, Dracolich enters the battlefield tapped.\nYou may cast Ebondeath, Dracolich from your graveyard if a creature not named Ebondeath, Dracolich died this turn.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "04870bbc-4ac2-554b-99cf-9b9b53348413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9e5402-690f-497d-ada3-aa41fa900fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9e5402-690f-497d-ada3-aa41fa900fdd.jpg?1",
             "name": "Eyes of the Beholder",
             "text": "Target creature gets -11/-11 until end of turn.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "75b004de-ff34-53e7-84d4-33b85e85cf5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ff3d76-e985-4d8d-837e-89360cc23824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ff3d76-e985-4d8d-837e-89360cc23824.jpg?1",
             "name": "Fates' Reversal",
             "text": "Return up to one target creature card from your graveyard to your hand. Venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "81581ca7-994a-534e-a420-8e1bfc912aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca09f699-c3e9-436e-b1b3-0fcd1ef3273f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca09f699-c3e9-436e-b1b3-0fcd1ef3273f.jpg?1",
             "name": "A-Fates' Reversal",
             "text": "",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "69d73377-2b6c-51a7-b693-1b82bf75bc3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af7061-fca6-4a06-be3c-01881e6b96f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af7061-fca6-4a06-be3c-01881e6b96f7.jpg?1",
             "name": "Feign Death",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "1f0291a0-9b05-54f8-bde8-5c6706165b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acaf396-f950-42da-85ab-149ffb31fee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acaf396-f950-42da-85ab-149ffb31fee6.jpg?1",
             "name": "Forsworn Paladin",
             "text": "Menace\n{1}{B}, {T}, Pay 1 life: Create a Treasure token.\n{2}{B}: Target creature gets +2/+0 until end of turn. If mana from a Treasure was spent to activate this ability, that creature also gains deathtouch until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "6ff02819-54cc-557f-a5ae-abb4aa0afa76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c472e70-300c-4881-86e7-c5ca690ab9b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c472e70-300c-4881-86e7-c5ca690ab9b6.jpg?1",
             "name": "Gelatinous Cube",
             "text": "Engulf \u2014 When Gelatinous Cube enters the battlefield, exile target non-Ooze creature an opponent controls until Gelatinous Cube leaves the battlefield.\nDissolve \u2014 {X}{B}: Put target creature card with mana value X exiled with Gelatinous Cube into its owner's graveyard.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "d31dc231-0556-52e8-8d0b-b8b94aacb042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98e0ab1-dea8-492b-a712-2057f2b1d020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98e0ab1-dea8-492b-a712-2057f2b1d020.jpg?1",
             "name": "Grim Bounty",
             "text": "Destroy target creature or planeswalker. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "34c64088-eed6-5177-ac49-689cde3f52ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e339f0f7-a79d-4947-a9c4-b9a0949dd06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e339f0f7-a79d-4947-a9c4-b9a0949dd06a.jpg?1",
             "name": "Grim Wanderer",
             "text": "Flash\nTragic Backstory \u2014 Cast this spell only if a creature died this turn.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "768fd46f-3c36-54ea-8b22-0d9421066615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa74204-2593-4468-856d-a5791336126a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa74204-2593-4468-856d-a5791336126a.jpg?1",
             "name": "Herald of Hadar",
             "text": "Circle of Death \u2014 {5}{B}: Roll a d20.\n1\u20139 | Each opponent loses 2 life.\n10\u201319 | Each opponent loses 2 life and you gain 2 life.\n20 | Each opponent loses 2 life and you gain 2 life. Create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "7527157a-21fc-5876-a489-dfc268144cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cbf01-90d0-4962-92d5-5e1566e8ef4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cbf01-90d0-4962-92d5-5e1566e8ef4b.jpg?1",
             "name": "Hired Hexblade",
             "text": "When Hired Hexblade enters the battlefield, if mana from a Treasure was spent to cast it, you draw a card and you lose 1 life.",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "e1e38eaa-bbd6-501a-bfec-30d7d9faeb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b723d9cd-05f5-4894-9f2b-52a434a3019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b723d9cd-05f5-4894-9f2b-52a434a3019c.jpg?1",
             "name": "Hoard Robber",
             "text": "Whenever Hoard Robber deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "510ac995-ace6-551b-b093-a493fd3cfc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f88de61-8dee-46b3-91b2-d4cdb4db36bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f88de61-8dee-46b3-91b2-d4cdb4db36bf.jpg?1",
             "name": "Lightfoot Rogue",
             "text": "Sneak Attack \u2014 Whenever Lightfoot Rogue attacks, roll a d20.\n1\u20139 | Lightfoot Rogue gains deathtouch until end of turn.\n10\u201319 | It gets +1/+0 and gains deathtouch until end of turn.\n20 | It gets +3/+0 and gains first strike and deathtouch until end of turn.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "62a32218-36da-5a88-8873-00b54b752f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420a5689-d73e-4dda-82fd-8b8897ff5b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420a5689-d73e-4dda-82fd-8b8897ff5b55.jpg?1",
             "name": "Lolth, Spider Queen",
             "text": "Whenever a creature you control dies, put a loyalty counter on Lolth, Spider Queen.\n0: You draw a card and you lose 1 life.\n\u22123: Create two 2/1 black Spider creature tokens with menace and reach.\n\u22128: You get an emblem with \"Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference.\"",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "1ff334b3-8af0-5f6a-a4d1-154d010eed53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d9117-724a-4b67-be27-142b9c283788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d9117-724a-4b67-be27-142b9c283788.jpg?1",
             "name": "Manticore",
             "text": "Flash\nFlying\nTail Spikes \u2014 When Manticore enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "05fd7c0e-9965-5b81-b982-c59681d98d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395b6ce4-143f-4eed-b565-98aa3d6208ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395b6ce4-143f-4eed-b565-98aa3d6208ef.jpg?1",
             "name": "Power Word Kill",
             "text": "Destroy target non-Angel, non-Demon, non-Devil, non-Dragon creature.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "258184db-3658-58ac-a0ac-e91966e3468d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7293f9b4-565a-4065-940b-543f76ebecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7293f9b4-565a-4065-940b-543f76ebecae.jpg?1",
             "name": "Precipitous Drop",
             "text": "Enchant creature\nWhen Precipitous Drop enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nEnchanted creature gets -2/-2. It gets -5/-5 instead as long as you've completed a dungeon.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "747815de-0316-5e3e-b88b-6c111ff7c1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77808663-2511-4495-a779-d4294a621c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77808663-2511-4495-a779-d4294a621c7f.jpg?1",
             "name": "A-Precipitous Drop",
             "text": "",
             "colours": [
@@ -4317,7 +4317,7 @@
         },
         {
             "id": "70ba8c5c-6833-582e-92a7-6345b56b2d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5d948b-fd89-4b90-9b63-ad7da13b5f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5d948b-fd89-4b90-9b63-ad7da13b5f0e.jpg?1",
             "name": "Ray of Enfeeblement",
             "text": "Target creature gets -4/-1 until end of turn. If that creature is white, it gets -4/-4 until end of turn instead.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "bdf1d766-617c-50d2-93c2-ef47caa29e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b68168-e77d-4745-9393-726ef9fb72ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b68168-e77d-4745-9393-726ef9fb72ec.jpg?1",
             "name": "Reaper's Talisman",
             "text": "Whenever equipped creature attacks, it gains deathtouch until end of turn.\nWhenever equipped creature attacks alone, defending player loses 2 life and you gain 2 life.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "38a438c7-9f83-52c7-bf66-db0d3aa1dbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b302bc8-683f-4a26-ab86-87eaa19dce4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b302bc8-683f-4a26-ab86-87eaa19dce4d.jpg?1",
             "name": "Sepulcher Ghoul",
             "text": "Sacrifice another creature: Sepulcher Ghoul gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "07b79f04-d641-5b87-9ede-ab6ab093e371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af167ef-40f9-4734-a14b-6024ddf93871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af167ef-40f9-4734-a14b-6024ddf93871.jpg?1",
             "name": "A-Sepulcher Ghoul",
             "text": "",
             "colours": [
@@ -4450,7 +4450,7 @@
         },
         {
             "id": "9f9b3530-ee98-56f9-bf30-e6bd31dc6c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96198a7-dd19-4940-bf8f-23135011fc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96198a7-dd19-4940-bf8f-23135011fc84.jpg?1",
             "name": "Shambling Ghast",
             "text": "When Shambling Ghast dies, choose one \u2014\n\u2022 Brave the Stench \u2014 Target creature an opponent controls gets -1/-1 until end of turn.\n\u2022 Search the Body \u2014 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "810c5a9c-2047-5470-9ff1-f11b7187374f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb8865-dc37-4d56-9a2d-a92f7462c338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb8865-dc37-4d56-9a2d-a92f7462c338.jpg?1",
             "name": "Skullport Merchant",
             "text": "When Skullport Merchant enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{1}{B}, Sacrifice another creature or a Treasure: Draw a card.",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "4e092a3d-d58a-5040-8619-94937696dff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2315a9-584b-4c59-af43-dd38bcb6c322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2315a9-584b-4c59-af43-dd38bcb6c322.jpg?1",
             "name": "Sphere of Annihilation",
             "text": "Sphere of Annihilation enters the battlefield with X void counters on it.\nAt the beginning of your upkeep, exile Sphere of Annihilation, all creatures and planeswalkers with mana value less than or equal to the number of void counters on it, and all creature and planeswalker cards in graveyards with mana value less than or equal to the number of void counters on it.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "d62f9016-8491-55c8-a588-fd18c21a8a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b922e-32dd-4645-b6f4-c07d1a0c70fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b922e-32dd-4645-b6f4-c07d1a0c70fc.jpg?1",
             "name": "Thieves' Tools",
             "text": "When Thieves' Tools enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature can't be blocked as long as its power is 3 or less.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "f77bcd4a-eb30-535b-bf2d-ad5de7273336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8975c72-b2ec-4c5f-86a4-4e1e3bb41c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8975c72-b2ec-4c5f-86a4-4e1e3bb41c15.jpg?1",
             "name": "Vampire Spawn",
             "text": "When Vampire Spawn enters the battlefield, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "e7d85626-4781-5372-ac5e-ae715d0b3587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7adbe69f-326d-4b4f-850f-c57a1860d17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7adbe69f-326d-4b4f-850f-c57a1860d17c.jpg?1",
             "name": "Vorpal Sword",
             "text": "Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains \"Whenever equipped creature deals combat damage to a player, that player loses the game.\"\nEquip {B}{B}",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "67788daf-fa5d-5e95-bfa3-a91515600170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7faf899-96b7-454e-b634-6684c2d72f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7faf899-96b7-454e-b634-6684c2d72f26.jpg?1",
             "name": "Warlock Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nAt the beginning of your end step, if a creature died this turn, each opponent loses 1 life.\n{1}{B}: Level 2\n//Level_2//\nWhen this Class becomes level 2, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n{6}{B}: Level 3\n//Level_3//\nAt the beginning of your end step, each opponent loses life equal to the life they lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "6713fd53-4a86-5ee2-b4c0-2d0fa44b4b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e757cc7d-b9cc-4ef1-80c9-a22755a6d271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e757cc7d-b9cc-4ef1-80c9-a22755a6d271.jpg?1",
             "name": "Westgate Regent",
             "text": "Flying\nWard\u2014\nDiscard a card. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player discards a card.)\nWhenever Westgate Regent deals combat damage to a player, put that many +1/+1 counters on it.",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "e90d59a4-1624-57fe-a72e-a5740cd2cf04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62abe9c-7599-433b-a964-10d6641f3586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62abe9c-7599-433b-a964-10d6641f3586.jpg?1",
             "name": "Wight",
             "text": "Wight enters the battlefield tapped.\nLife Drain \u2014 Whenever a creature dealt damage by Wight this turn dies, create a tapped 2/2 black Zombie creature token and exile that card.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "9b234f2c-385e-5f1e-84f7-fefa4b04ccc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e0e09c-ed43-4a37-85f2-c60bdfdb2624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e0e09c-ed43-4a37-85f2-c60bdfdb2624.jpg?1",
             "name": "Yuan-Ti Fang-Blade",
             "text": "Deathtouch\nWhenever Yuan-Ti Fang-Blade deals combat damage to a player, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "f4797ad6-2ad2-54e0-b7ec-df4b787a0169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dbed36-190c-4748-b282-409a2fb5d134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dbed36-190c-4748-b282-409a2fb5d134.jpg?1",
             "name": "Zombie Ogre",
             "text": "At the beginning of your end step, if a creature died this turn, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "463bdf2d-e1b8-519d-bcac-52b271b75984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177f57e-c239-47e8-ae50-5f593f6d54ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177f57e-c239-47e8-ae50-5f593f6d54ec.jpg?1",
             "name": "Armory Veteran",
             "text": "As long as Armory Veteran is equipped, it has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "fab07f09-5524-5819-b55a-cb8e0cd28255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f13ba-e165-4add-9935-d88503e1e761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f13ba-e165-4add-9935-d88503e1e761.jpg?1",
             "name": "A-Armory Veteran",
             "text": "",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "b0273110-eb0a-5739-9eee-651b7a3105c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647c2269-bdc7-4455-9158-73abbff6e50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647c2269-bdc7-4455-9158-73abbff6e50e.jpg?1",
             "name": "Barbarian Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nIf you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\n{1}{R}: Level 2\n//Level_2//\nWhenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn.\n{2}{R}: Level 3\n//Level_3//\nCreatures you control have haste.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "5b9f1b27-625b-5570-97fc-e66eb9a9210a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9766a427-2bb3-4028-a502-d1194cdc93aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9766a427-2bb3-4028-a502-d1194cdc93aa.jpg?1",
             "name": "Battle Cry Goblin",
             "text": "{1}{R}: Goblins you control get +1/+0 and gain haste until end of turn.\nPack tactics \u2014 Whenever Battle Cry Goblin attacks, if you attacked with creatures with total power 6 or greater this combat, create a 1/1 red Goblin creature token that's tapped and attacking.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "3765a967-9dfe-5231-81bb-ca7c0f3eab16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9913-3d4f-4f47-ba3a-6586a50ddbd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9913-3d4f-4f47-ba3a-6586a50ddbd7.jpg?1",
             "name": "Boots of Speed",
             "text": "Equipped creature gets +1/+0 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "0d504cc0-0529-5958-818d-f3fce3da8e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3658e65b-df54-4327-9104-c2f3dd65df85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3658e65b-df54-4327-9104-c2f3dd65df85.jpg?1",
             "name": "Brazen Dwarf",
             "text": "Whenever you roll one or more dice, Brazen Dwarf deals 1 damage to each opponent.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "237ef449-554e-5fe3-9a35-723cb586dc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e2d723-3fa0-4411-8f98-e4e6b3a5e6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e2d723-3fa0-4411-8f98-e4e6b3a5e6df.jpg?1",
             "name": "Burning Hands",
             "text": "Burning Hands deals 2 damage to target creature or planeswalker. If that permanent is green, Burning Hands deals 6 damage instead.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "0548f416-ba0f-5dc2-a1f1-67174b2799d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb587-f732-42c9-a2a7-152629889997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb587-f732-42c9-a2a7-152629889997.jpg?1",
             "name": "Chaos Channeler",
             "text": "Wild Magic Surge \u2014 Whenever Chaos Channeler attacks, roll a d20.\n1\u20139 | Exile the top card of your library. You may play it this turn.\n10\u201319 | Exile the top two cards of your library. You may play them this turn.\n20 | Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "c4afaccb-e720-532a-942e-340dfc79864f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9aaaf-0b51-4721-b75c-923892a41743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9aaaf-0b51-4721-b75c-923892a41743.jpg?1",
             "name": "Critical Hit",
             "text": "Target creature gains double strike until end of turn.\nWhen you roll a natural 20, return Critical Hit from your graveyard to your hand. (A natural 20 is a roll that displays 20 on the die.)",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "50dfb676-1b9c-59e4-be6b-5c9c928e5f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87459aa-af8f-4bd2-a310-151353083a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87459aa-af8f-4bd2-a310-151353083a2e.jpg?1",
             "name": "Delina, Wild Mage",
             "text": "Whenever Delina, Wild Mage attacks, choose target creature you control, then roll a d20.\n1\u201314 | Create a tapped and attacking token that's a copy of that creature, except it's not legendary and it has \"Exile this creature at end of combat.\"\n15\u201320 | Create one of those tokens. Roll again.",
             "colours": [
@@ -5179,7 +5179,7 @@
         },
         {
             "id": "e92523cc-b633-5bc9-9013-4b427c72b9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666987a-5267-46d3-9b00-31baa92a9cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666987a-5267-46d3-9b00-31baa92a9cbc.jpg?1",
             "name": "Dragon's Fire",
             "text": "As an additional cost to cast this spell, you may reveal a Dragon card from your hand or choose a Dragon you control.\nDragon's Fire deals 3 damage to target creature or planeswalker. If you revealed a Dragon card or chose a Dragon as you cast this spell, Dragon's Fire deals damage equal to the power of that card or creature instead.",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "6c996341-be3c-5b0b-9ec7-7ea0c732b5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c304118a-c83b-490a-b0e2-721734a996ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c304118a-c83b-490a-b0e2-721734a996ee.jpg?1",
             "name": "Dueling Rapier",
             "text": "Flash\nWhen Dueling Rapier enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "e41145ff-bd05-591a-abe8-596cb6856fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa05f317-b2f8-4eea-951b-0c374774764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa05f317-b2f8-4eea-951b-0c374774764b.jpg?1",
             "name": "Earth-Cult Elemental",
             "text": "Siege Monster \u2014 When Earth-Cult Elemental enters the battlefield, roll a d20.\n1\u20139 | Each player sacrifices a permanent.\n10\u201319 | Each opponent sacrifices a permanent.\n20 | Each opponent sacrifices two permanents.",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "5d9ca8ca-3f86-5345-83aa-c3c25097f0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a46987-f05a-4b83-af56-f18000874e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a46987-f05a-4b83-af56-f18000874e65.jpg?1",
             "name": "Farideh's Fireball",
             "text": "Farideh's Fireball deals 5 damage to target creature or planeswalker. Roll a d20.\n1\u20139 | Farideh's Fireball deals 2 damage to each player.\n10\u201320 | Farideh's Fireball deals 2 damage to each opponent.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "d9e04a19-9770-5501-8042-ee5c04de1fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3f766-4098-4023-9a23-e9ff6722b66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3f766-4098-4023-9a23-e9ff6722b66d.jpg?1",
             "name": "Flameskull",
             "text": "Flying\nFlameskull can't block.\nRejuvenation \u2014 When Flameskull dies, exile it. If you do, exile the top card of your library. Until the end of your next turn, you may play one of those cards. (If you cast Flameskull this way, you can't play the other card, and vice versa.)",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "267025df-3279-555c-8b2e-5d45a2ddde5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3f1b-40cb-413d-adb9-0809e4a2abdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3f1b-40cb-413d-adb9-0809e4a2abdd.jpg?1",
             "name": "Goblin Javelineer",
             "text": "Haste\nWhenever Goblin Javelineer becomes blocked, it deals 1 damage to target creature blocking it.",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "edb843a4-64ba-5c4d-826d-8cdc662491d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998f3785-c806-4848-adcb-d89ea51159c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998f3785-c806-4848-adcb-d89ea51159c5.jpg?1",
             "name": "Goblin Morningstar",
             "text": "Equipped creature gets +1/+0 and has trample.\nEquip {1}{R}\nWhen Goblin Morningstar enters the battlefield, roll a d20.\n1\u20139 | Create a 1/1 red Goblin creature token.\n10\u201320 | Create a 1/1 red Goblin creature token, then attach Goblin Morningstar to it.",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "2ad4c22c-c17a-554e-8b30-4aa9e3313586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df39eaac-b13f-4cb3-960d-8f7a0d590663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df39eaac-b13f-4cb3-960d-8f7a0d590663.jpg?1",
             "name": "Hoarding Ogre",
             "text": "Whenever Hoarding Ogre attacks, roll a d20.\n1\u20139 | Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n10\u201319 | Create two Treasure tokens.\n20 | Create three Treasure tokens.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "c3ac4c31-5b04-5473-8f33-ebf235a60a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e9dc36-f2d8-4384-98cb-e44c00b02433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e9dc36-f2d8-4384-98cb-e44c00b02433.jpg?1",
             "name": "Hobgoblin Bandit Lord",
             "text": "Other Goblins you control get +1/+1.\n{R}, {T}: Hobgoblin Bandit Lord deals damage equal to the number of Goblins that entered the battlefield under your control this turn to any target.",
             "colours": [
@@ -5489,7 +5489,7 @@
         },
         {
             "id": "09676604-3492-5f86-b952-611438d92f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0aa86-fd3b-4e0f-9d37-ce1ea8922243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0aa86-fd3b-4e0f-9d37-ce1ea8922243.jpg?1",
             "name": "Hobgoblin Captain",
             "text": "Pack tactics \u2014 Whenever Hobgoblin Captain attacks, if you attacked with creatures with total power 6 or greater this combat, Hobgoblin Captain gains first strike until end of turn.",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "e7ca8bc3-0bf2-5df0-a40e-c655250a597d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55d43d4-5f63-45c3-b8f8-0aebd23750a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55d43d4-5f63-45c3-b8f8-0aebd23750a5.jpg?1",
             "name": "Hulking Bugbear",
             "text": "Haste",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "bed203af-7d49-56f2-9460-fcdc5af98c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d5fd00-c616-4079-a91e-4da0bcaf9120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d5fd00-c616-4079-a91e-4da0bcaf9120.jpg?1",
             "name": "Improvised Weaponry",
             "text": "Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5592,7 +5592,7 @@
         },
         {
             "id": "7c9417e3-8e35-57f4-9711-b74af2edb06f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c788c6a6-20d9-4a93-a898-330b085226c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c788c6a6-20d9-4a93-a898-330b085226c4.jpg?1",
             "name": "Inferno of the Star Mounts",
             "text": "This spell can't be countered.\nFlying, haste\n{R}: Inferno of the Star Mounts gets +1/+0 until end of turn. When its power becomes 20 this way, it deals 20 damage to any target.",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "f1b0ac92-4a0a-5808-9abb-0f1f30b860f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5219c0-fb43-47b1-b682-131ba7c70990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5219c0-fb43-47b1-b682-131ba7c70990.jpg?1",
             "name": "Jaded Sell-Sword",
             "text": "When Jaded Sell-Sword enters the battlefield, if mana from a Treasure was spent to cast it, it gains first strike and haste until end of turn.",
             "colours": [
@@ -5665,7 +5665,7 @@
         },
         {
             "id": "01733566-8103-56e1-b06c-7cdc35bb7000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222102d0-fed3-41fd-87b0-f6d22766d7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222102d0-fed3-41fd-87b0-f6d22766d7fd.jpg?1",
             "name": "Kick in the Door",
             "text": "Put a +1/+1 counter on target creature. That creature gains haste until end of turn and can't be blocked by Walls this turn. Venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "9e85e1d8-b32a-5e36-b269-726960011cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c814ac58-8826-48cd-8209-4af6803866e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c814ac58-8826-48cd-8209-4af6803866e3.jpg?1",
             "name": "Magic Missile",
             "text": "This spell can't be countered.\nMagic Missile deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -5731,7 +5731,7 @@
         },
         {
             "id": "ffdcd935-8e9f-5da3-b765-09a227de4c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f5e669-4e69-4763-bbb9-e9685bde912c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f5e669-4e69-4763-bbb9-e9685bde912c.jpg?1",
             "name": "Meteor Swarm",
             "text": "Meteor Swarm deals 8 damage divided as you choose among X target creatures and/or planeswalkers.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "861e78d4-7e1e-516e-ab6a-df04413f1da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0a827-778b-48c3-bb85-4b4acef351d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0a827-778b-48c3-bb85-4b4acef351d6.jpg?1",
             "name": "Minion of the Mighty",
             "text": "Menace\nPack tactics \u2014 Whenever Minion of the Mighty attacks, if you attacked with creatures with total power 6 or greater this combat, you may put a Dragon creature card from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "217ea53c-ffe3-5e9d-a9fd-65fc2f1e5f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1c2cdd-353c-4747-bf0e-b995dd37ffca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1c2cdd-353c-4747-bf0e-b995dd37ffca.jpg?1",
             "name": "Orb of Dragonkind",
             "text": "{1}, {T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon spells or activate abilities of Dragons.\n{R}, {T}, Sacrifice Orb of Dragonkind: Look at the top seven cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "c434b3b6-b98c-5c01-ba74-20d4b6d7a894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d875881c-c285-47f1-8a37-e4a0239d47ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d875881c-c285-47f1-8a37-e4a0239d47ec.jpg?1",
             "name": "Plundering Barbarian",
             "text": "When Plundering Barbarian enters the battlefield, choose one \u2014\n\u2022 Smash the Chest \u2014 Destroy target artifact.\n\u2022 Pry It Open \u2014 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "5b009797-55f1-5ead-a52d-231b0d26cd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47634528-cc34-406a-8572-812a41d6a86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47634528-cc34-406a-8572-812a41d6a86a.jpg?1",
             "name": "Price of Loyalty",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If mana from a Treasure was spent to cast this spell, that creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "945abbff-d223-586f-8f6c-4d10312e011d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf57369-b8e2-481c-89d4-c83c617499a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf57369-b8e2-481c-89d4-c83c617499a3.jpg?1",
             "name": "Red Dragon",
             "text": "Flying\nFire Breath \u2014 When Red Dragon enters the battlefield, it deals 4 damage to each opponent.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "b572fbf5-1a5e-5ac4-af7c-80272793d8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c6b2c-9ba0-4fc1-9922-0988acf2dfde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c6b2c-9ba0-4fc1-9922-0988acf2dfde.jpg?1",
             "name": "Rust Monster",
             "text": "First strike\nSacrifice an artifact: Rust Monster gets +2/+0 until end of turn.",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "0f031188-8df3-5514-ba93-7cd433d7ccbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623c1d1b-69a4-4bc4-b388-17a7600fd960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623c1d1b-69a4-4bc4-b388-17a7600fd960.jpg?1",
             "name": "Swarming Goblins",
             "text": "When Swarming Goblins enters the battlefield, roll a d20.\n1\u20139 | Create a 1/1 red Goblin creature token.\n10\u201319 | Create two of those tokens.\n20 | Create three of those tokens.",
             "colours": [
@@ -6008,7 +6008,7 @@
         },
         {
             "id": "18c9db6f-1ca9-50fa-a674-eb5f2053cb05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0c229-aa31-4c79-bafe-28a8d8e64c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0c229-aa31-4c79-bafe-28a8d8e64c61.jpg?1",
             "name": "Tiger-Tribe Hunter",
             "text": "Trample\nPack tactics \u2014 Whenever Tiger-Tribe Hunter attacks, if you attacked with creatures with total power 6 or greater this combat, you may sacrifice another creature. When you do, Tiger-Tribe Hunter deals damage equal to the sacrificed creature's power to target creature.",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "5686f3cc-2746-597f-9082-b7756ed11bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6a5fb-39f5-4cf8-85f7-661cb4570507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6a5fb-39f5-4cf8-85f7-661cb4570507.jpg?1",
             "name": "Unexpected Windfall",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "9ac9bceb-4766-5de9-bc46-4d89eea4aaa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bc162c-bdf1-43f7-882f-d8cee4f3f415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bc162c-bdf1-43f7-882f-d8cee4f3f415.jpg?1",
             "name": "Valor Singer",
             "text": "Combat Inspiration \u2014\u00a0\nAt the beginning of combat on your turn, target creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "9ad6656c-8260-512a-abb6-8bc1f1d1b37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed021d2-e2bc-44b3-8934-4bd02e0a42ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed021d2-e2bc-44b3-8934-4bd02e0a42ec.jpg?1",
             "name": "Wish",
             "text": "You may play a card you own from outside the game this turn.",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "fc3d9bc3-028e-5a9f-8a9a-a0cefcf3776a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73fdf76-e3a6-49d0-bfb0-4b7cdbd4271e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73fdf76-e3a6-49d0-bfb0-4b7cdbd4271e.jpg?1",
             "name": "Xorn",
             "text": "If you would create one or more Treasure tokens, instead create those tokens plus an additional Treasure token.",
             "colours": [
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "212bc754-794a-5233-b50d-2108921020c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893613-423e-409b-9334-292bd252405b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893613-423e-409b-9334-292bd252405b.jpg?1",
             "name": "You Come to the Gnoll Camp",
             "text": "Choose one \u2014\n\u2022 Intimidate Them \u2014 Up to two target creatures can't block this turn.\n\u2022 Fend Them Off \u2014 Target creature gets +3/+1 until end of turn.",
             "colours": [
@@ -6212,7 +6212,7 @@
         },
         {
             "id": "376c062b-e9fc-5a83-84f7-fe1a4e6c5790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a95ae-feb2-42c3-99b4-9ea7a491d326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a95ae-feb2-42c3-99b4-9ea7a491d326.jpg?1",
             "name": "You Find Some Prisoners",
             "text": "Choose one \u2014\n\u2022 Break Their Chains \u2014 Destroy target artifact.\n\u2022 Interrogate Them \u2014 Exile the top three cards of target opponent's library. Choose one of them. Until the end of your next turn, you may play that card, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "0747baf0-032d-5255-8b94-2352087f85f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e7200-96ea-4455-83cc-0a497d56efe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e7200-96ea-4455-83cc-0a497d56efe5.jpg?1",
             "name": "You See a Pair of Goblins",
             "text": "Choose one \u2014\n\u2022 Charge Them \u2014 Creatures you control get +2/+0 until end of turn.\n\u2022 Befriend Them \u2014 Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -6276,7 +6276,7 @@
         },
         {
             "id": "1022040a-1c4e-5845-a3c7-8c968398e932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6da066-accb-4c09-9acb-4de263dadad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6da066-accb-4c09-9acb-4de263dadad3.jpg?1",
             "name": "Zalto, Fire Giant Duke",
             "text": "Trample\nWhenever Zalto, Fire Giant Duke is dealt damage, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "cabe2e74-11e5-5d13-94db-6eace2ac964d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5b866-d479-4698-98b2-87a973f6b8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5b866-d479-4698-98b2-87a973f6b8f6.jpg?1",
             "name": "Zariel, Archduke of Avernus",
             "text": "+1: Creatures you control get +1/+0 and gain haste until end of turn.\n0: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22126: You get an emblem with \"At the end of the first combat phase on your turn, untap target creature you control. After this phase, there is an additional combat phase.\"",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "0fbc9cdf-081c-56c9-9644-90d47b2488bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206a9e7b-45c1-4213-8fc4-27d90e2ab0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206a9e7b-45c1-4213-8fc4-27d90e2ab0e9.jpg?1",
             "name": "Bulette",
             "text": "At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on Bulette.",
             "colours": [
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "5e79ffa0-396e-5189-8109-b41507e8af2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092cab70-c771-4c96-a5ce-22f2e32e3ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092cab70-c771-4c96-a5ce-22f2e32e3ea8.jpg?1",
             "name": "Bull's Strength",
             "text": "Target creature gets +2/+2 and gains trample until end of turn. Untap it.",
             "colours": [
@@ -6421,7 +6421,7 @@
         },
         {
             "id": "774d9a90-1980-5931-8b63-9ee246e54ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213726e4-e2f5-4e52-b05a-21c4bab9927c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213726e4-e2f5-4e52-b05a-21c4bab9927c.jpg?1",
             "name": "Choose Your Weapon",
             "text": "Choose one \u2014\n\u2022 Two-Weapon Fighting \u2014 Double target creature's power and toughness until end of turn.\n\u2022 Archery \u2014 This spell deals 5 damage to target creature with flying.",
             "colours": [
@@ -6453,7 +6453,7 @@
         },
         {
             "id": "d91e85f3-25d4-5084-8393-06f3350f53e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6fdec0-a2c4-4da2-ae14-961185eaee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6fdec0-a2c4-4da2-ae14-961185eaee66.jpg?1",
             "name": "Circle of Dreams Druid",
             "text": "{T}: Add {G} for each creature you control.",
             "colours": [
@@ -6490,7 +6490,7 @@
         },
         {
             "id": "cc5bf1a4-63ab-5dec-9f8e-81278f82e4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700c9ed8-6bfe-4f1e-855a-5f31e0d2fc9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700c9ed8-6bfe-4f1e-855a-5f31e0d2fc9b.jpg?1",
             "name": "Circle of the Moon Druid",
             "text": "Bear Form \u2014 As long as it's your turn, Circle of the Moon Druid is a Bear with base power and toughness 4/2. (It loses all other creature types.)",
             "colours": [
@@ -6526,7 +6526,7 @@
         },
         {
             "id": "bc02d308-fd82-516f-98ed-715a60a68be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7e501d-943e-4e6d-9d8e-6bedc32a0dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7e501d-943e-4e6d-9d8e-6bedc32a0dd8.jpg?1",
             "name": "Compelled Duel",
             "text": "Target creature gets +3/+3 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "c31b441c-4d5b-5b42-8861-9a39c2545150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4769d-31ba-40d3-9375-494b93f01183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4769d-31ba-40d3-9375-494b93f01183.jpg?1",
             "name": "Dire Wolf Prowler",
             "text": "{1}{G}: Dire Wolf Prowler gets +2/+2 and gains haste until end of turn. Activate only once each turn.",
             "colours": [
@@ -6594,7 +6594,7 @@
         },
         {
             "id": "2737a540-8d73-55f6-ae84-bccb67ea8014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09278e95-eaae-4cd4-a0d8-a2d15b0abb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09278e95-eaae-4cd4-a0d8-a2d15b0abb58.jpg?1",
             "name": "Druid Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever a land enters the battlefield under your control, you gain 1 life.\n{2}{G}: Level 2\n//Level_2//\nYou may play an additional land on each of your turns.\n{4}{G}: Level 3\n//Level_3//\nWhen this Class becomes level 3, target land you control becomes a creature with haste and \"This creature's power and toughness are each equal to the number of lands you control.\" It's still a land.",
             "colours": [
@@ -6628,7 +6628,7 @@
         },
         {
             "id": "22ad51a3-5cb9-5450-8ad9-618ae5ca99ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbd3554-0096-470d-ba9d-011f5c8212c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbd3554-0096-470d-ba9d-011f5c8212c4.jpg?1",
             "name": "A-Druid Class",
             "text": "",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "90ebc623-874c-5938-a3ba-187d4cf70990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab81bc0-0369-469e-9296-6d9681697b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab81bc0-0369-469e-9296-6d9681697b21.jpg?1",
             "name": "Ellywick Tumblestrum",
             "text": "+1: Venture into the dungeon. (Enter the first room or advance to the next room.)\n\u22122: Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. If it's legendary, you gain 3 life. Put the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Creatures you control have trample and haste and get +2/+2 for each differently named dungeon you've completed.\"",
             "colours": [
@@ -6699,7 +6699,7 @@
         },
         {
             "id": "7bd30146-08e5-56c0-ae62-d33d169932f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49215be1-88ed-4302-a708-99496d90d175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49215be1-88ed-4302-a708-99496d90d175.jpg?1",
             "name": "A-Ellywick Tumblestrum",
             "text": "",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "eff3e47b-9d7c-5747-be21-db4d578764b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6898737-957f-44a6-bef7-fb196658176f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6898737-957f-44a6-bef7-fb196658176f.jpg?1",
             "name": "Elturgard Ranger",
             "text": "Reach\nWhen Elturgard Ranger enters the battlefield, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -6770,7 +6770,7 @@
         },
         {
             "id": "d2d646fe-a6dd-5dce-af60-ae44bff7a019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afe37a0-ccc3-467a-b787-304465b38355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afe37a0-ccc3-467a-b787-304465b38355.jpg?1",
             "name": "Find the Path",
             "text": "Enchant land\nWhen Find the Path enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nEnchanted land has \"{T}: Add {G}{G}.\"",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "933a00f3-1281-5784-9c70-e7355fc9223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a223fc-ded8-4675-a72a-74ca6a44a642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a223fc-ded8-4675-a72a-74ca6a44a642.jpg?1",
             "name": "A-Find the Path",
             "text": "",
             "colours": [
@@ -6837,7 +6837,7 @@
         },
         {
             "id": "af5bdb09-136a-5888-babe-6af35b3e0f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e9567-2585-4c03-99a5-3e84fd8044d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e9567-2585-4c03-99a5-3e84fd8044d2.jpg?1",
             "name": "Froghemoth",
             "text": "Trample, haste\nWhenever Froghemoth deals combat damage to a player, exile up to that many target cards from their graveyard. Put a +1/+1 counter on Froghemoth for each creature card exiled this way. You gain 1 life for each noncreature card exiled this way.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "64ce89c2-5e2d-5b90-9fa9-1ab9c2ed1e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0634cb-e973-4f05-965e-d39b09fe57a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0634cb-e973-4f05-965e-d39b09fe57a9.jpg?1",
             "name": "Gnoll Hunter",
             "text": "Pack tactics \u2014 Whenever Gnoll Hunter attacks, if you attacked with creatures with total power 6 or greater this combat, put a +1/+1 counter on Gnoll Hunter.",
             "colours": [
@@ -6910,7 +6910,7 @@
         },
         {
             "id": "e518d8f6-3cf5-5d38-92f1-247baf331de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45804134-cc04-4587-9674-2c884964083d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45804134-cc04-4587-9674-2c884964083d.jpg?1",
             "name": "Green Dragon",
             "text": "Flying\nPoison Breath \u2014 When Green Dragon enters the battlefield, until end of turn, whenever a creature an opponent controls is dealt damage, destroy it.",
             "colours": [
@@ -6946,7 +6946,7 @@
         },
         {
             "id": "33ff348f-dd6e-55fe-9f6b-feeea41d10d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69315cc-c230-4704-9d66-411f624f3e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69315cc-c230-4704-9d66-411f624f3e49.jpg?1",
             "name": "Hill Giant Herdgorger",
             "text": "When Hill Giant Herdgorger enters the battlefield, you gain 3 life.",
             "colours": [
@@ -6980,7 +6980,7 @@
         },
         {
             "id": "4f256c46-dbfa-5cc3-8283-7ce24f74e446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62023c58-8b94-4a81-a259-a047e1edd342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62023c58-8b94-4a81-a259-a047e1edd342.jpg?1",
             "name": "Hunter's Mark",
             "text": "This spell costs {3} less to cast if it targets a blue permanent you don't control.\nThis spell can't be countered.\nTarget creature you control gets +1/+1 until end of turn. Then it deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "38cd5e2d-327f-587d-8e7a-e3a20ef1b264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33db66-d205-4164-b168-6084df562ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33db66-d205-4164-b168-6084df562ebb.jpg?1",
             "name": "Inspiring Bard",
             "text": "When Inspiring Bard enters the battlefield, choose one \u2014\n\u2022 Bardic Inspiration \u2014 Target creature gets +2/+2 until end of turn.\n\u2022 Song of Rest \u2014 You gain 3 life.",
             "colours": [
@@ -7047,7 +7047,7 @@
         },
         {
             "id": "776d1f63-fdd1-51c8-acef-d5f42a856970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58486dc-3e78-4649-89c7-46f6210ff80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58486dc-3e78-4649-89c7-46f6210ff80f.jpg?1",
             "name": "Instrument of the Bards",
             "text": "At the beginning of your upkeep, you may put a harmony counter on Instrument of the Bards.\n{3}{G}, {T}: Search your library for a creature card with mana value equal to the number of harmony counters on Instrument of the Bards, reveal it, and put it into your hand. If that card is legendary, create a Treasure token. Then shuffle.",
             "colours": [
@@ -7083,7 +7083,7 @@
         },
         {
             "id": "2eddc82c-79a2-596a-bedb-bac138ab5be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b00777-d921-4264-9faf-5c048b656210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b00777-d921-4264-9faf-5c048b656210.jpg?1",
             "name": "Intrepid Outlander",
             "text": "Reach\nPack tactics \u2014 Whenever Intrepid Outlander attacks, if you attacked with creatures with total power 6 or greater this combat, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -7118,7 +7118,7 @@
         },
         {
             "id": "772e12dd-6d3d-532f-8d7f-e19493147199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ac66df-760d-495d-a067-13114071b7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ac66df-760d-495d-a067-13114071b7b8.jpg?1",
             "name": "Loathsome Troll",
             "text": "{3}{G}: Roll a d20. Activate only if Loathsome Troll is in your graveyard.\n1\u20139 | Put Loathsome Troll on top of your library.\n10\u201319 | Return Loathsome Troll to your hand.\n20 | Return Loathsome Troll to the battlefield tapped.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "fc58a2a4-367b-5002-beb9-7726b2182a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e930-3b6b-4b2f-a09c-0730d491545c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e930-3b6b-4b2f-a09c-0730d491545c.jpg?1",
             "name": "Long Rest",
             "text": "Return X target cards with different mana values from your graveyard to your hand. If eight or more cards were returned to your hand this way, your life total becomes equal to your starting life total. Exile Long Rest.",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "b9004b46-fa3e-5ea2-a262-3d2f2ac77b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce25d7-3f22-48ce-9428-184e661696b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce25d7-3f22-48ce-9428-184e661696b9.jpg?1",
             "name": "Lurking Roper",
             "text": "Lurking Roper doesn't untap during your untap step.\nWhenever you gain life, untap Lurking Roper.",
             "colours": [
@@ -7224,7 +7224,7 @@
         },
         {
             "id": "25ba960a-f764-5e53-8048-c7210e2f0085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d7cc7-bbdd-4db3-906e-a2f7672e0f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d7cc7-bbdd-4db3-906e-a2f7672e0f67.jpg?1",
             "name": "Neverwinter Dryad",
             "text": "{2}, Sacrifice Neverwinter Dryad: Search your library for a basic Forest card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7260,7 +7260,7 @@
         },
         {
             "id": "345acc61-1b81-5201-ab44-8cec4c6751b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23cfb7-c6b6-4f04-abba-5b2a6117ea12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23cfb7-c6b6-4f04-abba-5b2a6117ea12.jpg?1",
             "name": "Ochre Jelly",
             "text": "Trample\nOchre Jelly enters the battlefield with X +1/+1 counters on it.\nSplit \u2014 When Ochre Jelly dies, if it had two or more +1/+1 counters on it, create a token that's a copy of it at the beginning of the next end step. The token enters the battlefield with half that many +1/+1 counters on it, rounded down.",
             "colours": [
@@ -7296,7 +7296,7 @@
         },
         {
             "id": "becbf226-d80d-5f2a-b8e1-20c6eef78ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e499ccce-359a-45ac-a09b-5e4ca96ac1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e499ccce-359a-45ac-a09b-5e4ca96ac1cd.jpg?1",
             "name": "A-Ochre Jelly",
             "text": "",
             "colours": [
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "368b7d4d-232d-5488-a100-2c9697d5837c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ceba8b-de19-4db8-b5a7-f5df49bf241f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ceba8b-de19-4db8-b5a7-f5df49bf241f.jpg?1",
             "name": "Old Gnawbone",
             "text": "Flying\nWhenever a creature you control deals combat damage to a player, create that many Treasure tokens.",
             "colours": [
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "6fabca4e-6b8d-5c0d-897d-6398de7a1a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e8a00f-8131-470d-8072-4c23b812281a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e8a00f-8131-470d-8072-4c23b812281a.jpg?1",
             "name": "Owlbear",
             "text": "Trample\nKeen Senses \u2014 When Owlbear enters the battlefield, draw a card.",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "6602a099-6507-5b20-854f-75bd8beff0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be85ceb-be98-43ce-9565-a72990797437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be85ceb-be98-43ce-9565-a72990797437.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "fd83a9cc-1068-5315-afe2-cd004fd75284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096d3c0c-98e2-4cfc-a6e1-fddb0359c63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096d3c0c-98e2-4cfc-a6e1-fddb0359c63f.jpg?1",
             "name": "Prosperous Innkeeper",
             "text": "When Prosperous Innkeeper enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "198a4589-345d-5547-8d0d-01bb03d970ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419d58b-6241-4892-9080-f6894ac7ba89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419d58b-6241-4892-9080-f6894ac7ba89.jpg?1",
             "name": "Purple Worm",
             "text": "This spell costs {2} less to cast if a creature died this turn.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -7509,7 +7509,7 @@
         },
         {
             "id": "8bfe2b13-9a56-5a6e-a8b6-25fdc75a000d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca392ca-3219-4694-9a74-aa079c76b91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca392ca-3219-4694-9a74-aa079c76b91e.jpg?1",
             "name": "Ranger Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Ranger Class enters the battlefield, create a 2/2 green Wolf creature token.\n{1}{G}: Level 2\n//Level_2//\nWhenever you attack, put a +1/+1 counter on target attacking creature.\n{3}{G}: Level 3\n//Level_3//\nYou may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.",
             "colours": [
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "9b0bd4e2-e31f-540b-96ee-f2191da43e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c99b32-353c-4930-a6ee-3fb44cf70253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c99b32-353c-4930-a6ee-3fb44cf70253.jpg?1",
             "name": "Ranger's Longbow",
             "text": "Equipped creature gets +2/+1 and has reach.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7577,7 +7577,7 @@
         },
         {
             "id": "6673dea6-1e31-5d8d-a5c3-ec5467e3ba94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb05274-5a94-44e3-889a-667cba1da033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb05274-5a94-44e3-889a-667cba1da033.jpg?1",
             "name": "Scaled Herbalist",
             "text": "{T}: You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -7612,7 +7612,7 @@
         },
         {
             "id": "d9737a9f-891f-5464-ba48-f895b6c084b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfdfd4-8621-40ef-a60f-74e9c107bbaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfdfd4-8621-40ef-a60f-74e9c107bbaf.jpg?1",
             "name": "Spoils of the Hunt",
             "text": "Target creature you control gets +1/+0 until end of turn for each mana from a Treasure that was spent to cast this spell. Then that creature deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -7644,7 +7644,7 @@
         },
         {
             "id": "87ce91e2-f5e7-54a9-841d-f15c402ce0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d608fb-35b0-498e-988a-f53986b59dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d608fb-35b0-498e-988a-f53986b59dd2.jpg?1",
             "name": "Sylvan Shepherd",
             "text": "Vigilance\nWhenever Sylvan Shepherd attacks, roll a d20.\n1\u20139 | You gain 1 life.\n10\u201319 | You gain 2 life.\n20 | You gain 5 life.",
             "colours": [
@@ -7679,7 +7679,7 @@
         },
         {
             "id": "124bc00f-7aa5-5499-8c4c-b47cc22730fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26fa15-d81f-4152-ae33-e91aa276b3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26fa15-d81f-4152-ae33-e91aa276b3fc.jpg?1",
             "name": "The Tarrasque",
             "text": "The Tarrasque has haste and ward {1}0 as long as it was cast.\nWhenever The Tarrasque attacks, it fights target creature defending player controls.",
             "colours": [
@@ -7717,7 +7717,7 @@
         },
         {
             "id": "5f02ee59-47d1-5041-8aff-948133d24c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed220158-e4e3-4d46-8098-7b940a923ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed220158-e4e3-4d46-8098-7b940a923ce9.jpg?1",
             "name": "Underdark Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -7753,7 +7753,7 @@
         },
         {
             "id": "c09ccc28-da73-55ce-80db-a5506f5a253b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bd3ea9-f06d-4df7-8b8d-ac6a0e591b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bd3ea9-f06d-4df7-8b8d-ac6a0e591b09.jpg?1",
             "name": "Varis, Silverymoon Ranger",
             "text": "Reach, ward {1}\nWhenever you cast a creature or planeswalker spell, venture into the dungeon. This ability triggers only once each turn. (To venture into the dungeon, enter the first room or advance to the next room.)\nWhenever you complete a dungeon, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -7793,7 +7793,7 @@
         },
         {
             "id": "902704a3-38ea-5f4c-9c1e-dd444344bbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c7f123-31c8-469b-85e5-d20c4d21b2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c7f123-31c8-469b-85e5-d20c4d21b2a0.jpg?1",
             "name": "Wandering Troubadour",
             "text": "At the beginning of your end step, if you had a land enter the battlefield under your control this turn, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "0d76a462-45ec-57e2-aea7-3741b4117a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88e6b39-bb4d-4d69-8007-d42f31bcbc29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88e6b39-bb4d-4d69-8007-d42f31bcbc29.jpg?1",
             "name": "Werewolf Pack Leader",
             "text": "Pack tactics \u2014 Whenever Werewolf Pack Leader attacks, if you attacked with creatures with total power 6 or greater this combat, draw a card.\n{3}{G}: Until end of turn, Werewolf Pack Leader has base power and toughness 5/3, gains trample, and isn't a Human.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "f7be14f3-7f0b-5860-8a20-4b426f14ee12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9738f1-b2e7-45a5-b235-290256aabed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9738f1-b2e7-45a5-b235-290256aabed0.jpg?1",
             "name": "Wild Shape",
             "text": "Choose one. Until end of turn, target creature you control has that base power and toughness, becomes that creature type, and gains that ability.\n\u2022 1/3 Turtle with hexproof.\n\u2022 1/5 Spider with reach.\n\u2022 3/3 Elephant with trample.",
             "colours": [
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "60353423-6d1a-5ecf-b466-b5d02a921ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb5671a-942a-4730-9756-32fe600e0528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb5671a-942a-4730-9756-32fe600e0528.jpg?1",
             "name": "You Find a Cursed Idol",
             "text": "Choose one \u2014\n\u2022 Smash It \u2014 Destroy target artifact.\n\u2022 Lift the Curse \u2014 Destroy target enchantment.\n\u2022 Steal Its Eyes \u2014 Create a Treasure token and venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "6d8d1cb1-e066-568e-9ded-a90687c4bf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae7693-a6b5-42f8-9f05-c0643b95a710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae7693-a6b5-42f8-9f05-c0643b95a710.jpg?1",
             "name": "You Happen On a Glade",
             "text": "Choose one \u2014\n\u2022 Journey On \u2014 Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Make Camp \u2014 Return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -7961,7 +7961,7 @@
         },
         {
             "id": "b1a1da21-c81f-524e-ad6b-e6a98d874d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593aa59a-4025-4df8-9f27-188fc7712fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593aa59a-4025-4df8-9f27-188fc7712fde.jpg?1",
             "name": "You Meet in a Tavern",
             "text": "Choose one \u2014\n\u2022 Form a Party \u2014 Look at the top five cards of your library. You may reveal any number of creature cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.\n\u2022 Start a Brawl \u2014 Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "d26f2bf9-ea90-52e4-beb4-c86c6fe67638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a76010-d932-4727-8b5e-b8e2d14e1362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a76010-d932-4727-8b5e-b8e2d14e1362.jpg?1",
             "name": "Adult Gold Dragon",
             "text": "Flying, lifelink, haste",
             "colours": [
@@ -8031,7 +8031,7 @@
         },
         {
             "id": "9a6aa7c5-70d0-596b-8097-c105713ecc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d6343a-c514-4ca6-a415-62d1a473ae20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d6343a-c514-4ca6-a415-62d1a473ae20.jpg?1",
             "name": "Bard Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nLegendary creatures you control enter the battlefield with an additional +1/+1 counter on them.\n{R}{G}: Level 2\n//Level_2//\nLegendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\n{3}{R}{G}: Level 3\n//Level_3//\nWhenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "6fac771e-016f-5d32-ac95-86ed7e18b859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6896c311-5593-4437-b945-43ade9665e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6896c311-5593-4437-b945-43ade9665e43.jpg?1",
             "name": "Barrowin of Clan Undurr",
             "text": "When Barrowin of Clan Undurr enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nWhenever Barrowin of Clan Undurr attacks, return up to one creature card with mana value 3 or less from your graveyard to the battlefield if you've completed a dungeon.",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "6d12aa8d-1c5d-5871-8da3-ee08421a3a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e1eb00-412e-4c25-bc7b-6d074330fd97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e1eb00-412e-4c25-bc7b-6d074330fd97.jpg?1",
             "name": "Bruenor Battlehammer",
             "text": "Each creature you control gets +2/+0 for each Equipment attached to it.\nYou may pay {0} rather than pay the equip cost of the first equip ability you activate each turn.",
             "colours": [
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "75cb418b-fb04-5966-9590-992afb043989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad77890-cf97-4707-ab31-be0f5be0e120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad77890-cf97-4707-ab31-be0f5be0e120.jpg?1",
             "name": "A-Bruenor Battlehammer",
             "text": "",
             "colours": [
@@ -8187,7 +8187,7 @@
         },
         {
             "id": "989de269-08a7-5ddd-9ccb-9485c32636f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e3259e-93c2-48c0-8b96-835cdb883383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e3259e-93c2-48c0-8b96-835cdb883383.jpg?1",
             "name": "Drizzt Do'Urden",
             "text": "Double strike\nWhen Drizzt Do'Urden enters the battlefield, create Guenhwyvar, a legendary 4/1 green Cat creature token with trample.\nWhenever a creature dies, if it had power greater than Drizzt's power, put a number of +1/+1 counters on Drizzt equal to the difference.",
             "colours": [
@@ -8228,7 +8228,7 @@
         },
         {
             "id": "ec35e110-cdde-5e7d-91c1-60a068298206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ff142-029b-4446-960a-2ff200fb9aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ff142-029b-4446-960a-2ff200fb9aee.jpg?1",
             "name": "Farideh, Devil's Chosen",
             "text": "Dark One's Own Luck \u2014 Whenever you roll one or more dice, Farideh, Devil's Chosen gains flying and menace until end of turn. If any of those results was 10 or higher, draw a card.",
             "colours": [
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "f3b2af35-b189-525a-80f0-06c8628d863c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54a8329-b940-42c9-8ace-1d74407d14cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54a8329-b940-42c9-8ace-1d74407d14cb.jpg?1",
             "name": "Fighter Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Fighter Class enters the battlefield, search your library for an Equipment card, reveal it, put it into your hand, then shuffle.\n{1}{R}{W}: Level 2\n//Level_2//\nEquip abilities you activate cost {2} less to activate.\n{3}{R}{W}: Level 3\n//Level_3//\nWhenever a creature you control attacks, up to one target creature blocks it this combat if able.",
             "colours": [
@@ -8305,7 +8305,7 @@
         },
         {
             "id": "62e115a1-4bb6-538e-ac9e-49a42fd238f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8b248e-1460-4650-9721-85c134c21b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8b248e-1460-4650-9721-85c134c21b89.jpg?1",
             "name": "Gretchen Titchwillow",
             "text": "{2}{G}{U}: Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "8a4bc11a-b683-5c8e-b11d-7f67beacbf1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b8eb2e-73ac-4ad6-9ab6-4f8da7b41020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b8eb2e-73ac-4ad6-9ab6-4f8da7b41020.jpg?1",
             "name": "Hama Pashar, Ruin Seeker",
             "text": "Room abilities of dungeons you own trigger an additional time.",
             "colours": [
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "9f0e609f-ce30-53d3-b4c4-12bb6be77cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45e9552-7737-4c61-89b0-5a3bec3c8f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45e9552-7737-4c61-89b0-5a3bec3c8f34.jpg?1",
             "name": "Kalain, Reclusive Painter",
             "text": "When Kalain, Reclusive Painter enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nOther creatures you control enter the battlefield with an additional +1/+1 counter on them for each mana from a Treasure spent to cast them.",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "cd1609d4-eb90-5467-afe7-44feb2d35fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f4d622-2d50-4e6e-87a5-5a1cc65d6919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f4d622-2d50-4e6e-87a5-5a1cc65d6919.jpg?1",
             "name": "Krydle of Baldur's Gate",
             "text": "Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, you may pay {2}. If you do, target creature can't be blocked this turn.",
             "colours": [
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "be5a1f46-7327-5dae-bf9b-ac764b95514b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72405607-a60e-42af-b523-64008d3f89b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72405607-a60e-42af-b523-64008d3f89b9.jpg?1",
             "name": "Minsc, Beloved Ranger",
             "text": "When Minsc, Beloved Ranger enters the battlefield, create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n{X}: Until end of turn, target creature you control has base power and toughness X/X and becomes a Giant in addition to its other types. Activate only as a sorcery.",
             "colours": [
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "a9e22ac9-240b-57ef-b2b3-2b5639f659f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2edd708-46ee-4963-b7e6-b631616d78fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2edd708-46ee-4963-b7e6-b631616d78fe.jpg?1",
             "name": "Monk Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nThe second spell you cast each turn costs {1} less to cast.\n{W}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, return up to one target nonland permanent to its owner's hand.\n{1}{W}{U}: Level 3\n//Level_3//\nAt the beginning of your upkeep, exile the top card of your library. For as long as it remains exiled, it has \"You may cast this card from exile as long as you've cast another spell this turn.\"",
             "colours": [
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "d1d00ca5-0006-5753-b03f-c83b27c75bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f5c6d3-fb04-4a2e-87b6-9ed2314085a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f5c6d3-fb04-4a2e-87b6-9ed2314085a8.jpg?1",
             "name": "Orcus, Prince of Undeath",
             "text": "Flying, trample\nWhen Orcus, Prince of Undeath enters the battlefield, choose one \u2014\n\u2022 Each other creature gets -X/-X until end of turn. You lose X life.\n\u2022 Return up to X target creature cards with total mana value X or less from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "6b281540-866e-54f3-9891-7d45d1bca7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0727f65b-cfbe-47d5-87c6-239cf8d93ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0727f65b-cfbe-47d5-87c6-239cf8d93ca6.jpg?1",
             "name": "Rogue Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever a creature you control deals combat damage to a player, exile the top card of that player's library face down. You may look at it for as long as it remains exiled.\n{1}{U}{B}: Level 2\n//Level_2//\nCreatures you control have menace.\n{2}{U}{B}: Level 3\n//Level_3//\nYou may play cards exiled with Rogue Class, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "fe529b21-f370-5686-a79a-dab440712998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ca5fef-af21-4e2b-9efa-61e08a638a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ca5fef-af21-4e2b-9efa-61e08a638a1f.jpg?1",
             "name": "Shessra, Death's Whisper",
             "text": "Bewitching Whispers \u2014 When Shessra, Death's Whisper enters the battlefield, target creature blocks this turn if able.\nWhispers of the Grave \u2014 At the beginning of your end step, if a creature died this turn, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -8668,7 +8668,7 @@
         },
         {
             "id": "ede12ddf-a43f-5383-964b-8f4e38453885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef5fb8c-ee26-464e-bc89-47b2e4c39222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef5fb8c-ee26-464e-bc89-47b2e4c39222.jpg?1",
             "name": "A-Shessra, Death's Whisper",
             "text": "",
             "colours": [
@@ -8707,7 +8707,7 @@
         },
         {
             "id": "44dd475f-50d0-5a5d-bdaf-9bbbcdab9bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768ac68-0d87-4f99-aa77-2d009df0a567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768ac68-0d87-4f99-aa77-2d009df0a567.jpg?1",
             "name": "Skeletal Swarming",
             "text": "Each Skeleton you control has trample, attacks each combat if able, and gets +X/+0, where X is the number of other Skeletons you control.\nAt the beginning of your end step, create a tapped 1/1 black Skeleton creature token. If a creature died this turn, create two of those tokens instead.",
             "colours": [
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "d29aac9c-8149-5a6c-91f1-f5babb31058b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754b385-a28d-48de-a91f-2b4f33cc47f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754b385-a28d-48de-a91f-2b4f33cc47f7.jpg?1",
             "name": "Sorcerer Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Sorcerer Class enters the battlefield, draw two cards, then discard two cards.\n{U}{R}: Level 2\n//Level_2//\nCreatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\"\n{3}{U}{R}: Level 3\n//Level_3//\nWhenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.",
             "colours": [
@@ -8779,7 +8779,7 @@
         },
         {
             "id": "cce3ede4-0d00-59a5-8eea-5b8e9625f0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67afa501-d561-4a02-9321-351d19daa10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67afa501-d561-4a02-9321-351d19daa10d.jpg?1",
             "name": "A-Sorcerer Class",
             "text": "",
             "colours": [
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "8c2aaa45-de1e-5f78-ac2b-99ef91d4a0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe57856-9d35-470e-9138-360b02ac0c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe57856-9d35-470e-9138-360b02ac0c90.jpg?1",
             "name": "Targ Nar, Demon-Fang Gnoll",
             "text": "Pack tactics \u2014 Whenever Targ Nar, Demon-Fang Gnoll attacks, if you attacked with creatures with total power 6 or greater this combat, attacking creatures get +1/+0 until end of turn.\n{2}{R}{G}: Double Targ Nar's power and toughness until end of turn.",
             "colours": [
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "e79b9335-6a28-52e2-8758-b150b3568967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0b9b0-55f4-4ce7-a916-6f23687f3fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0b9b0-55f4-4ce7-a916-6f23687f3fe4.jpg?1",
             "name": "Tiamat",
             "text": "Flying\nWhen Tiamat enters the battlefield, if you cast it, search your library for up to five Dragon cards not named Tiamat that each have different names, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -8899,7 +8899,7 @@
         },
         {
             "id": "61ff7c1c-6ca3-5a84-9e68-2b0b13d14e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4b54c-a8fa-464e-a3dd-f3f3a08606f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4b54c-a8fa-464e-a3dd-f3f3a08606f5.jpg?1",
             "name": "Trelasarra, Moon Dancer",
             "text": "Whenever you gain life, put a +1/+1 counter on Trelasarra, Moon Dancer and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "320cabf7-0dc7-54ae-81f0-de0be7b8243f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214d3167-4eea-42a1-a464-ddff59843142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214d3167-4eea-42a1-a464-ddff59843142.jpg?1",
             "name": "Triumphant Adventurer",
             "text": "Deathtouch\nAs long as it's your turn, Triumphant Adventurer has first strike.\nWhenever Triumphant Adventurer attacks, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "5c8de630-f70b-5fde-9f54-be31c99e7a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a95341-168b-4a97-90dc-9a444f5de8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a95341-168b-4a97-90dc-9a444f5de8e6.jpg?1",
             "name": "A-Triumphant Adventurer",
             "text": "",
             "colours": [
@@ -9015,7 +9015,7 @@
         },
         {
             "id": "605463ee-269f-5c8d-a150-4b2e4dc99b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ae01f9-7461-47b4-aa1e-93bd6ff1bf9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ae01f9-7461-47b4-aa1e-93bd6ff1bf9e.jpg?1",
             "name": "Volo, Guide to Monsters",
             "text": "Whenever you cast a creature spell that doesn't share a creature type with a creature you control or a creature card in your graveyard, copy that spell. (A copy of a creature spell becomes a token.)",
             "colours": [
@@ -9056,7 +9056,7 @@
         },
         {
             "id": "ba9c72e5-95b2-5ae1-bbfb-a9b8cbf087cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58050-a615-4090-9cf5-cd49ccb4e2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58050-a615-4090-9cf5-cd49ccb4e2c6.jpg?1",
             "name": "Xanathar, Guild Kingpin",
             "text": "At the beginning of your upkeep, choose target opponent. Until end of turn, that player can't cast spells, you may look at the top card of their library any time, you may play the top card of their library, and you may spend mana as though it were mana of any color to cast spells this way.",
             "colours": [
@@ -9096,7 +9096,7 @@
         },
         {
             "id": "51b02894-e05f-5d8e-b048-865a4bd61844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5e4e9-491b-4c80-8801-f4cd5225c601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5e4e9-491b-4c80-8801-f4cd5225c601.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -9124,7 +9124,7 @@
         },
         {
             "id": "c44f435a-5983-5244-91b9-49440b51c0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddbdc6-0757-43cb-bb41-dc83c6cf42ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddbdc6-0757-43cb-bb41-dc83c6cf42ea.jpg?1",
             "name": "The Deck of Many Things",
             "text": "{2}, {T}: Roll a d20 and subtract the number of cards in your hand. If the result is 0 or less, discard your hand.\n1\u20139 | Return a card at random from your graveyard to your hand.\n10\u201319 | Draw two cards.\n20 | Put a creature card from any graveyard onto the battlefield under your control. When that creature dies, its owner loses the game.",
             "colours": [],
@@ -9156,7 +9156,7 @@
         },
         {
             "id": "4df4a564-0f40-5889-8903-32a2a888ae2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028506ad-ad36-44e5-b488-d038e2d2445f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028506ad-ad36-44e5-b488-d038e2d2445f.jpg?1",
             "name": "Dungeon Map",
             "text": "{T}: Add {C}.\n{3}, {T}: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [],
@@ -9184,7 +9184,7 @@
         },
         {
             "id": "202c72ae-9def-5241-8a50-7b58eb361039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91e2431-500e-441a-881d-094ebef62283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91e2431-500e-441a-881d-094ebef62283.jpg?1",
             "name": "Eye of Vecna",
             "text": "When Eye of Vecna enters the battlefield, you draw a card and you lose 2 life.\nAt the beginning of your upkeep, you may pay {2}. If you do, you draw a card and you lose 2 life.",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "5e002689-44c9-5ee3-bf0d-88513e865e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7ebe7b-732f-4245-a194-e087c3878f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7ebe7b-732f-4245-a194-e087c3878f61.jpg?1",
             "name": "Fifty Feet of Rope",
             "text": "Climb Over \u2014 {T}: Target Wall can't block this turn.\nTie Up \u2014 {3}, {T}: Target creature doesn't untap during its controller's next untap step.\nRappel Down \u2014 {4}, {T}: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [],
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "828e50c3-fb21-5db2-82a5-2134412fed18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e840aef6-eec4-40dd-bbc4-6fd0b2b57805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e840aef6-eec4-40dd-bbc4-6fd0b2b57805.jpg?1",
             "name": "Greataxe",
             "text": "Equipped creature gets +4/+0.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "9812417d-9bae-525a-9cd4-e28db7e6e902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd0beb7-80dc-4665-bab2-747c795d97db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd0beb7-80dc-4665-bab2-747c795d97db.jpg?1",
             "name": "Hand of Vecna",
             "text": "At the beginning of combat on your turn, equipped creature or a creature you control named Vecna gets +X/+X until end of turn, where X is the number of cards in your hand.\nEquip\u2014\nPay 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -9308,7 +9308,7 @@
         },
         {
             "id": "20d4baa6-d11f-5c39-b750-791d57604a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae24ef5-b12c-48ee-935a-00e048fb8d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae24ef5-b12c-48ee-935a-00e048fb8d0f.jpg?1",
             "name": "Iron Golem",
             "text": "Vigilance\nIron Golem attacks or blocks each combat if able.",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "36e691e3-76e5-5fa4-bc3f-101c1c34ceed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62d4e76-cdb0-48c7-aa1c-b1f514057b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62d4e76-cdb0-48c7-aa1c-b1f514057b68.jpg?1",
             "name": "Leather Armor",
             "text": "Equipped creature gets +0/+1 and has ward {1}. (Whenever equipped creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nEquip {0}. Activate only once each turn.",
             "colours": [],
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "67ff69bb-5ed7-549d-aae9-abf5babad432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da96aab-cf84-4150-b9d0-a4b84fcf585f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da96aab-cf84-4150-b9d0-a4b84fcf585f.jpg?1",
             "name": "Mimic",
             "text": "{T}, Sacrifice Mimic: Add one mana of any color.\n{2}: Mimic becomes a Shapeshifter artifact creature with base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -9403,7 +9403,7 @@
         },
         {
             "id": "58aa877a-de5a-5092-9a29-2db08e4fd884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6b0291-00f8-45bf-9f3a-ee43739c2b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6b0291-00f8-45bf-9f3a-ee43739c2b77.jpg?1",
             "name": "Spare Dagger",
             "text": "Equipped creature gets +1/+0 and has \"Whenever this creature attacks, you may sacrifice Spare Dagger. When you do, this creature deals 1 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "5d2a08ce-6893-5e36-9e53-03ebfdde491a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fbf45a-23b4-4d06-abd9-4cc3895cb29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fbf45a-23b4-4d06-abd9-4cc3895cb29d.jpg?1",
             "name": "Spiked Pit Trap",
             "text": "Flash\n{5}, {T}, Sacrifice Spiked Pit Trap: Choose target creature, then roll a d20.\n1\u20139 | Spiked Pit Trap deals 5 damage to that creature.\n10\u201320 | Spiked Pit Trap deals 5 damage to that creature. Create a Treasure token.",
             "colours": [],
@@ -9461,7 +9461,7 @@
         },
         {
             "id": "902a5cc6-7325-5e1e-a894-d975ff5d91d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecbeb07-0f45-49bf-9a12-f4ca09969122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecbeb07-0f45-49bf-9a12-f4ca09969122.jpg?1",
             "name": "Treasure Chest",
             "text": "{4}, Sacrifice Treasure Chest: Roll a d20.\n1 | Trapped \u2014 You lose 3 life.\n2\u20139 | Create five Treasure tokens.\n10\u201319 | You gain 3 life and draw three cards.\n20 | Search your library for a card. If it's an artifact card, you may put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "dc26d551-ab4c-51df-8c19-5b1c1b4393c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb41396-5008-4a5f-92ca-54ecac42e926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb41396-5008-4a5f-92ca-54ecac42e926.jpg?1",
             "name": "Cave of the Frost Dragon",
             "text": "If you control two or more other lands, Cave of the Frost Dragon enters the battlefield tapped.\n{T}: Add {W}.\n{4}{W}: Cave of the Frost Dragon becomes a 3/4 white Dragon creature with flying until end of turn. It's still a land.",
             "colours": [],
@@ -9524,7 +9524,7 @@
         },
         {
             "id": "4d6d76bc-9f24-5b4d-be18-28d209c5e8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231caf8-56c0-4719-a90d-5e5efbee3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231caf8-56c0-4719-a90d-5e5efbee3148.jpg?1",
             "name": "Den of the Bugbear",
             "text": "If you control two or more other lands, Den of the Bugbear enters the battlefield tapped.\n{T}: Add {R}.\n{3}{R}: Until end of turn, Den of the Bugbear becomes a 3/2 red Goblin creature with \"Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\" It's still a land.",
             "colours": [],
@@ -9556,7 +9556,7 @@
         },
         {
             "id": "d6c17748-199a-581f-8d3a-f94d86ff4c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4cccdbc-f4f4-42b6-9747-6ef703ff949a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4cccdbc-f4f4-42b6-9747-6ef703ff949a.jpg?1",
             "name": "Dungeon Descent",
             "text": "Dungeon Descent enters the battlefield tapped.\n{T}: Add {C}.\n{4}, {T}, Tap an untapped legendary creature you control: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [],
@@ -9586,7 +9586,7 @@
         },
         {
             "id": "9a1ee072-4f15-5730-b992-94eb1c5b4bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7673def9-9f27-4382-b65b-ec616fae1768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7673def9-9f27-4382-b65b-ec616fae1768.jpg?1",
             "name": "A-Dungeon Descent",
             "text": "",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "0b4202f9-eb96-523f-95a5-9fe4576de393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71afb548-691d-4c72-b369-85f9b451c71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71afb548-691d-4c72-b369-85f9b451c71d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9643,7 +9643,7 @@
         },
         {
             "id": "a82c2976-1ad3-5af2-8112-35c223b4beee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8f052d-8840-4905-a807-9a305f4fd8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8f052d-8840-4905-a807-9a305f4fd8f7.jpg?1",
             "name": "Hall of Storm Giants",
             "text": "If you control two or more other lands, Hall of Storm Giants enters the battlefield tapped.\n{T}: Add {U}.\n{5}{U}: Until end of turn, Hall of Storm Giants becomes a 7/7 blue Giant creature with ward {3}. It's still a land. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)",
             "colours": [],
@@ -9675,7 +9675,7 @@
         },
         {
             "id": "6a6c5e71-4425-51a3-90b9-e898fbba61ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb391dc-0378-4793-a5de-899b09792a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb391dc-0378-4793-a5de-899b09792a4b.jpg?1",
             "name": "Hive of the Eye Tyrant",
             "text": "If you control two or more other lands, Hive of the Eye Tyrant enters the battlefield tapped.\n{T}: Add {B}.\n{3}{B}: Until end of turn, Hive of the Eye Tyrant becomes a 3/3 black Beholder creature with menace and \"Whenever this creature attacks, exile target card from defending player's graveyard.\" It's still a land.",
             "colours": [],
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "33ea16d3-6837-5c1b-b4e6-ecdefec8f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670bb0f-680f-4036-bdb6-ac73e866a398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670bb0f-680f-4036-bdb6-ac73e866a398.jpg?1",
             "name": "Lair of the Hydra",
             "text": "If you control two or more other lands, Lair of the Hydra enters the battlefield tapped.\n{T}: Add {G}.\n{X}{G}: Until end of turn, Lair of the Hydra becomes an X/X green Hydra creature. It's still a land. X can't be 0.",
             "colours": [],
@@ -9739,7 +9739,7 @@
         },
         {
             "id": "a497720c-037e-5f0c-b4e5-5a8cf1a4f085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79b3c6-ccbe-48ae-a1f7-ddfd37ecdbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79b3c6-ccbe-48ae-a1f7-ddfd37ecdbf5.jpg?1",
             "name": "Temple of the Dragon Queen",
             "text": "As Temple of the Dragon Queen enters the battlefield, you may reveal a Dragon card from your hand. Temple of the Dragon Queen enters the battlefield tapped unless you revealed a Dragon card this way or you control a Dragon.\nAs Temple of the Dragon Queen enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9769,7 +9769,7 @@
         },
         {
             "id": "dc349524-d18d-56cf-8029-814939734b61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0931eb3-b403-4b1a-ad46-a7b0a51bb9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0931eb3-b403-4b1a-ad46-a7b0a51bb9a4.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "4d253d2e-5d59-54bf-9b40-460d06f964ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879f7f54-25a3-440b-848d-0e780277a681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879f7f54-25a3-440b-848d-0e780277a681.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "57b88f59-c0c3-519b-89da-5fb7e568a2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4f4abf-841b-4fae-9a53-505a2f8dc1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4f4abf-841b-4fae-9a53-505a2f8dc1ff.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9876,7 +9876,7 @@
         },
         {
             "id": "72b8be9b-f238-5350-b5f8-0cdba3e492d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d1a81e-6710-4922-ba0a-510966c39449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d1a81e-6710-4922-ba0a-510966c39449.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9914,7 +9914,7 @@
         },
         {
             "id": "ba560387-2a12-58b7-a56f-eab4ca57deda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86626d69-78e0-42b9-81ed-fef46e3a89f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86626d69-78e0-42b9-81ed-fef46e3a89f7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "df708cfb-2c50-53e1-aa99-67e1257016b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e70c602-cb80-472b-9c8d-9625de084fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e70c602-cb80-472b-9c8d-9625de084fe7.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9990,7 +9990,7 @@
         },
         {
             "id": "6adf644c-3d6c-572d-bacb-bcdac7d81f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d575fc-037b-421a-a205-12d492e9361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d575fc-037b-421a-a205-12d492e9361e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10028,7 +10028,7 @@
         },
         {
             "id": "602e2e28-318e-56c9-be1f-4c7a4cd08ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d04a06f-06a7-410d-a714-3b8b96ee3319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d04a06f-06a7-410d-a714-3b8b96ee3319.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10066,7 +10066,7 @@
         },
         {
             "id": "e7fe7a5b-883b-574c-8ec5-99933e3f033f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa60b6-cd0d-4c23-af81-88049ea45475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa60b6-cd0d-4c23-af81-88049ea45475.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10104,7 +10104,7 @@
         },
         {
             "id": "5da121e9-b0d1-52e6-a038-138a94fc5304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab950987-d88c-4326-98f4-1b1195788921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab950987-d88c-4326-98f4-1b1195788921.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "21ef560e-6bf8-5db7-883e-71e18b6d79f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea640731-b367-4ece-934e-6d86634fc1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea640731-b367-4ece-934e-6d86634fc1c8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10180,7 +10180,7 @@
         },
         {
             "id": "a59480e0-7654-58ee-9dd1-af8d796ed3c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f8def9-ee46-4abf-9059-7d1ec6f24951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f8def9-ee46-4abf-9059-7d1ec6f24951.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10218,7 +10218,7 @@
         },
         {
             "id": "5a47c1cb-e072-5a2a-8c01-e3a2b6568353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166fc328-20d1-4158-bcb6-3cebcf788ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166fc328-20d1-4158-bcb6-3cebcf788ef5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10256,7 +10256,7 @@
         },
         {
             "id": "dbb15a2e-b99d-5120-857c-fa67d0035f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc558-2c54-4c7b-a6fa-1e75ddcf12f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc558-2c54-4c7b-a6fa-1e75ddcf12f9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "0502177c-e69d-5fb0-aaec-621ac75acde1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e313f-ba75-4324-b1ac-f2bbae99f7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e313f-ba75-4324-b1ac-f2bbae99f7ab.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10332,7 +10332,7 @@
         },
         {
             "id": "269ae981-1dda-58c6-a973-7752d5e91bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d1c48f-1ca3-43ea-8109-964b29bb2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d1c48f-1ca3-43ea-8109-964b29bb2d50.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "fee4df77-3874-5dcc-bd70-c27bb1cc0373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9095db-44ad-444b-bd9d-4a06102fe230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9095db-44ad-444b-bd9d-4a06102fe230.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "0fd18bfb-3c45-5d74-ba52-28f0be493e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a46b11-3225-45aa-b54e-4d19d81b51cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a46b11-3225-45aa-b54e-4d19d81b51cf.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "5ab8a1d8-48ab-5e70-bd65-9229fe35ddce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1cc13-8959-4914-afe8-58daf9529f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1cc13-8959-4914-afe8-58daf9529f61.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "bb7a2bde-75b1-5f03-84f0-383a6eae1c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdc5ca9-6d01-4ee3-8117-3c1e74320553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdc5ca9-6d01-4ee3-8117-3c1e74320553.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10522,7 +10522,7 @@
         },
         {
             "id": "d12d8c26-f579-54ef-8102-f1222e423037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee856e7a-37ee-435c-80e8-d0ac6f15892f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee856e7a-37ee-435c-80e8-d0ac6f15892f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10560,7 +10560,7 @@
         },
         {
             "id": "899dce33-13fc-5b42-85be-6a302a0bffbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020d8b5-3173-4219-b063-f36a27e2004b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020d8b5-3173-4219-b063-f36a27e2004b.jpg?1",
             "name": "Grand Master of Flowers",
             "text": "As long as Grand Master of Flowers has seven or more loyalty counters on him, he's a 7/7 Dragon God creature with flying and indestructible.\n+1: Target creature without first strike, double strike, or vigilance can't attack or block until your next turn.\n+1: Search your library and/or graveyard for a card named Monk of the Open Hand, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "323cb1ec-100c-5884-93be-d06c5a70a765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8df51c3-cd9c-45eb-ac70-d13976e0e1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8df51c3-cd9c-45eb-ac70-d13976e0e1c4.jpg?1",
             "name": "Mordenkainen",
             "text": "+2: Draw two cards, then put a card from your hand on the bottom of your library.\n\u22122: Create a blue Dog Illusion creature token with \"This creature's power and toughness are each equal to twice the number of cards in your hand.\"\n\u221210: Exchange your hand and library, then shuffle. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -10636,7 +10636,7 @@
         },
         {
             "id": "45167e93-3d84-53ae-a860-e2865ca22668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e1624-06f6-4377-96a4-842adfa78778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e1624-06f6-4377-96a4-842adfa78778.jpg?1",
             "name": "Lolth, Spider Queen",
             "text": "Whenever a creature you control dies, put a loyalty counter on Lolth, Spider Queen.\n0: You draw a card and you lose 1 life.\n\u22123: Create two 2/1 black Spider creature tokens with menace and reach.\n\u22128: You get an emblem with \"Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference.\"",
             "colours": [
@@ -10674,7 +10674,7 @@
         },
         {
             "id": "41a850d8-5f11-5335-9422-df7d768b84eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad8828d-96b8-432f-bcee-3a60b6ef1270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad8828d-96b8-432f-bcee-3a60b6ef1270.jpg?1",
             "name": "Zariel, Archduke of Avernus",
             "text": "+1: Creatures you control get +1/+0 and gain haste until end of turn.\n0: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22126: You get an emblem with \"At the end of the first combat phase on your turn, untap target creature you control. After this phase, there is an additional combat phase.\"",
             "colours": [
@@ -10712,7 +10712,7 @@
         },
         {
             "id": "fc418565-4781-507f-9074-f14cda6219d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c97e5-87b2-4534-af7c-f4772f61469c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c97e5-87b2-4534-af7c-f4772f61469c.jpg?1",
             "name": "Ellywick Tumblestrum",
             "text": "+1: Venture into the dungeon.\n\u22122: Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. If it's legendary, you gain 3 life. Put the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Creatures you control have trample and haste and get +2/+2 for each differently named dungeon you've completed.\"",
             "colours": [
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "ec24e831-46c9-5cf9-9d08-db194f069384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b030b-4284-418b-889b-b705e7379d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b030b-4284-418b-889b-b705e7379d66.jpg?1",
             "name": "Icingdeath, Frost Tyrant",
             "text": "Flying, vigilance\nWhen Icingdeath, Frost Tyrant dies, create Icingdeath, Frost Tongue, a legendary white Equipment artifact token with \"Equipped creature gets +2/+0,\" \"Whenever equipped creature attacks, tap target creature defending player controls,\" and equip {2}.",
             "colours": [
@@ -10788,7 +10788,7 @@
         },
         {
             "id": "aba7e9d5-4638-510e-85cd-41f6ecc08c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e55e7-1d31-450e-bade-7bebe131ccfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e55e7-1d31-450e-bade-7bebe131ccfa.jpg?1",
             "name": "White Dragon",
             "text": "Flying\nCold Breath \u2014 When White Dragon enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -10824,7 +10824,7 @@
         },
         {
             "id": "6a45fe36-a432-5ba9-8447-a32b7b598458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9efd57-f894-4ce8-9fb0-6f06ec3da5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9efd57-f894-4ce8-9fb0-6f06ec3da5a8.jpg?1",
             "name": "Blue Dragon",
             "text": "Flying\nLightning Breath \u2014 When Blue Dragon enters the battlefield, until your next turn, target creature an opponent controls gets -3/-0, up to one other target creature gets -2/-0, and up to one other target creature gets -1/-0.",
             "colours": [
@@ -10860,7 +10860,7 @@
         },
         {
             "id": "1a0264fd-a917-515e-8768-5105b39d2ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd111eb2-cce5-413d-816a-f821771a1fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd111eb2-cce5-413d-816a-f821771a1fa6.jpg?1",
             "name": "Iymrith, Desert Doom",
             "text": "Flying\nIymrith, Desert Doom has ward {4} as long as it's untapped.\nWhenever Iymrith deals combat damage to a player, draw a card. Then if you have fewer than three cards in hand, draw cards equal to the difference.",
             "colours": [
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "c21f7c91-4fb3-5678-82ee-793b7703c068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c4c732-46b4-43f6-9466-fcfc86a99df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c4c732-46b4-43f6-9466-fcfc86a99df3.jpg?1",
             "name": "Black Dragon",
             "text": "Flying\nAcid Breath \u2014 When Black Dragon enters the battlefield, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -10934,7 +10934,7 @@
         },
         {
             "id": "e41949e0-9382-5561-aca4-cb2286e545cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed78a14-8c51-444c-a451-9a57e895c86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed78a14-8c51-444c-a451-9a57e895c86d.jpg?1",
             "name": "Ebondeath, Dracolich",
             "text": "Flash\nFlying\nEbondeath, Dracolich enters the battlefield tapped.\nYou may cast Ebondeath, Dracolich from your graveyard if a creature not named Ebondeath, Dracolich died this turn.",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "8937d320-f3ff-5646-81c0-65bdf0a6c1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45a5d3-8393-4506-b2e9-f9106ec80607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45a5d3-8393-4506-b2e9-f9106ec80607.jpg?1",
             "name": "Inferno of the Star Mounts",
             "text": "This spell can't be countered.\nFlying, haste\n{R}: Inferno of the Star Mounts gets +1/+0 until end of turn. When its power becomes 20 this way, it deals 20 damage to any target.",
             "colours": [
@@ -11011,7 +11011,7 @@
         },
         {
             "id": "2be7f77d-8b27-5b86-877f-117587f33e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ffffa9-c6ca-4752-bb56-3cedeadaabba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ffffa9-c6ca-4752-bb56-3cedeadaabba.jpg?1",
             "name": "Red Dragon",
             "text": "Flying\nFire Breath \u2014 When Red Dragon enters the battlefield, it deals 4 damage to each opponent.",
             "colours": [
@@ -11047,7 +11047,7 @@
         },
         {
             "id": "ccd336ae-5b5e-5fe2-ae72-314edaa5fb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798c207-c9cf-48c5-a5cd-0cf7d392115a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798c207-c9cf-48c5-a5cd-0cf7d392115a.jpg?1",
             "name": "Green Dragon",
             "text": "Flying\nPoison Breath \u2014 When Green Dragon enters the battlefield, until end of turn, whenever a creature an opponent controls is dealt damage, destroy it.",
             "colours": [
@@ -11083,7 +11083,7 @@
         },
         {
             "id": "0745868c-d0ef-529a-9265-50bf531d4492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ead969-8ba4-4587-a68d-47730943605e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ead969-8ba4-4587-a68d-47730943605e.jpg?1",
             "name": "Old Gnawbone",
             "text": "Flying\nWhenever a creature you control deals combat damage to a player, create that many Treasure tokens.",
             "colours": [
@@ -11121,7 +11121,7 @@
         },
         {
             "id": "9e39cc78-616e-594e-bfc4-4f9fb33d8728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62906879-fcc3-4ede-aa9e-b63d963d331a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62906879-fcc3-4ede-aa9e-b63d963d331a.jpg?1",
             "name": "Adult Gold Dragon",
             "text": "Flying, lifelink, haste",
             "colours": [
@@ -11159,7 +11159,7 @@
         },
         {
             "id": "8e287cf6-0244-5091-bca3-6732410c5afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fe79b-7af2-4911-8497-cbee8d529d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fe79b-7af2-4911-8497-cbee8d529d18.jpg?1",
             "name": "Tiamat",
             "text": "Flying\nWhen Tiamat enters the battlefield, if you cast it, search your library for up to five Dragon cards not named Tiamat that each have different names, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -11206,7 +11206,7 @@
         },
         {
             "id": "245a7947-877e-5b5d-b523-69bdf17a0950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf942df-d30b-4d1b-8a46-bca4abaeb147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf942df-d30b-4d1b-8a46-bca4abaeb147.jpg?1",
             "name": "Arborea Pegasus",
             "text": "Flying\nWhen Arborea Pegasus enters the battlefield, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -11242,7 +11242,7 @@
         },
         {
             "id": "196318b1-4d1a-5f41-a024-256e63c89a55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcf1082-25ac-4537-9fd9-631f834097ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcf1082-25ac-4537-9fd9-631f834097ad.jpg?1",
             "name": "Blink Dog",
             "text": "Double strike\nTeleport \u2014 {3}{W}: Blink Dog phases out.",
             "colours": [
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "80a6282b-7e49-583e-b725-7d0d4ba8a13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bba29a-6d7c-4f53-a4ad-e27a33fe19cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bba29a-6d7c-4f53-a4ad-e27a33fe19cc.jpg?1",
             "name": "Celestial Unicorn",
             "text": "Whenever you gain life, put a +1/+1 counter on Celestial Unicorn.",
             "colours": [
@@ -11314,7 +11314,7 @@
         },
         {
             "id": "da05016e-bcb0-5b9f-9d06-86fec4704641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab380bf5-2202-4098-b850-2cb660ec5351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab380bf5-2202-4098-b850-2cb660ec5351.jpg?1",
             "name": "Cloister Gargoyle",
             "text": "When Cloister Gargoyle enters the battlefield, venture into the dungeon.\nAs long as you've completed a dungeon, Cloister Gargoyle gets +3/+0 and has flying.",
             "colours": [
@@ -11351,7 +11351,7 @@
         },
         {
             "id": "2b2aa8f4-174f-5681-98de-e49547c43bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbd2a5-1d12-4900-8487-92912d66c059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbd2a5-1d12-4900-8487-92912d66c059.jpg?1",
             "name": "Nadaar, Selfless Paladin",
             "text": "Vigilance\nWhenever Nadaar, Selfless Paladin enters the battlefield or attacks, venture into the dungeon.\nOther creatures you control get +1/+1 as long as you've completed a dungeon.",
             "colours": [
@@ -11390,7 +11390,7 @@
         },
         {
             "id": "61cd845e-1870-5441-9031-cc0217b2a948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853c9db7-504e-4dfb-8067-abd2a36f6a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853c9db7-504e-4dfb-8067-abd2a36f6a1a.jpg?1",
             "name": "Oswald Fiddlebender",
             "text": "Magical Tinkering \u2014 {W}, {T}, Sacrifice an artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -11429,7 +11429,7 @@
         },
         {
             "id": "5778c32e-9afd-5931-bda5-3969f05fa7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8646ae5c-e757-4d16-bf2a-d48770d620fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8646ae5c-e757-4d16-bf2a-d48770d620fa.jpg?1",
             "name": "Displacer Beast",
             "text": "When Displacer Beast enters the battlefield, venture into the dungeon.\nDisplacement \u2014 {3}{U}: Return Displacer Beast to its owner's hand.",
             "colours": [
@@ -11466,7 +11466,7 @@
         },
         {
             "id": "d5f29a23-7938-5572-969e-2dfbbfef4976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7cd8c3-8365-4e40-a089-02bc9b93581a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7cd8c3-8365-4e40-a089-02bc9b93581a.jpg?1",
             "name": "Djinni Windseer",
             "text": "Flying\nWhen Djinni Windseer enters the battlefield, roll a d20.\n1\u20139 | Scry 1.\n10\u201319 | Scry 2.\n20 | Scry 3.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "9264f46d-a0bb-5a22-900a-5234cbb473e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f70431-12c9-4530-b51b-d85c38746989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f70431-12c9-4530-b51b-d85c38746989.jpg?1",
             "name": "Dragon Turtle",
             "text": "Flash\nDrag Below \u2014 When Dragon Turtle enters the battlefield, tap it and up to one target creature an opponent controls. They don't untap during their controllers' next untap steps.",
             "colours": [
@@ -11539,7 +11539,7 @@
         },
         {
             "id": "7454d5fd-6e9b-5933-b35e-b55642ebb122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc1142e-ccf6-42bb-9d56-d74344ce8f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc1142e-ccf6-42bb-9d56-d74344ce8f97.jpg?1",
             "name": "Mind Flayer",
             "text": "Dominate Monster \u2014 When Mind Flayer enters the battlefield, gain control of target creature for as long as you control Mind Flayer.",
             "colours": [
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "11d40f29-e683-5bdc-a488-4389abb31d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2074a9-8b6f-4904-bb8c-ae705d31f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2074a9-8b6f-4904-bb8c-ae705d31f2f1.jpg?1",
             "name": "Pixie Guide",
             "text": "Flying\nGrant an Advantage \u2014 If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
             "colours": [
@@ -11611,7 +11611,7 @@
         },
         {
             "id": "88e8bea8-8e78-5650-97de-c71820a67c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1fc7-be88-46a3-8bd9-3f16332c2bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1fc7-be88-46a3-8bd9-3f16332c2bd8.jpg?1",
             "name": "Rimeshield Frost Giant",
             "text": "Ward {3}",
             "colours": [
@@ -11648,7 +11648,7 @@
         },
         {
             "id": "2ab4f75a-db73-5acf-b7cf-79c0f87439a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f3cba-df13-4c89-b92d-47ee3be6809c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f3cba-df13-4c89-b92d-47ee3be6809c.jpg?1",
             "name": "Baleful Beholder",
             "text": "When Baleful Beholder enters the battlefield, choose one \u2014\n\u2022 Antimagic Cone \u2014 Each opponent sacrifices an enchantment.\n\u2022 Fear Ray \u2014 Creatures you control gain menace until end of turn.",
             "colours": [
@@ -11684,7 +11684,7 @@
         },
         {
             "id": "58fa6612-3319-5050-a007-19faefbda947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1090e40c-c04b-4ee2-aa12-1575f896d31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1090e40c-c04b-4ee2-aa12-1575f896d31a.jpg?1",
             "name": "Clattering Skeletons",
             "text": "When Clattering Skeletons dies, venture into the dungeon.",
             "colours": [
@@ -11720,7 +11720,7 @@
         },
         {
             "id": "1fdb2eee-52af-5ba9-9eb9-6d16bea57bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f99dbef-9f38-4ef1-8b4e-03385edf3339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f99dbef-9f38-4ef1-8b4e-03385edf3339.jpg?1",
             "name": "Gelatinous Cube",
             "text": "Engulf \u2014 When Gelatinous Cube enters the battlefield, exile target non-Ooze creature an opponent controls until Gelatinous Cube leaves the battlefield.\nDissolve \u2014 {X}{B}: Put target creature card with mana value X exiled with Gelatinous Cube into its owner's graveyard.",
             "colours": [
@@ -11756,7 +11756,7 @@
         },
         {
             "id": "d02f16bf-bdb8-54e9-b219-df6718b3b694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6730db48-3884-45bd-b514-7738c5c36b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6730db48-3884-45bd-b514-7738c5c36b97.jpg?1",
             "name": "Manticore",
             "text": "Flash\nFlying\nTail Spikes \u2014 When Manticore enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -11792,7 +11792,7 @@
         },
         {
             "id": "8ae19b3d-99f1-51a0-96a4-f12cdb706cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b32f97-327c-403c-8fdf-f614bf8fe198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b32f97-327c-403c-8fdf-f614bf8fe198.jpg?1",
             "name": "Westgate Regent",
             "text": "Flying\nWard\u2014\nDiscard a card.\nWhenever Westgate Regent deals combat damage to a player, put that many +1/+1 counters on it.",
             "colours": [
@@ -11828,7 +11828,7 @@
         },
         {
             "id": "64c39ed1-0b57-5a2c-b8bb-b20df9f855de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c5b88-4cca-410a-8464-5111b4eaa3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c5b88-4cca-410a-8464-5111b4eaa3b6.jpg?1",
             "name": "Wight",
             "text": "Wight enters the battlefield tapped.\nLife Drain \u2014 Whenever a creature dealt damage by Wight this turn dies, create a tapped 2/2 black Zombie creature token and exile that card.",
             "colours": [
@@ -11865,7 +11865,7 @@
         },
         {
             "id": "1044d399-82ed-55ae-bb8d-8b892e45cf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1dc68-868b-4f3f-b10a-62842d88edc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1dc68-868b-4f3f-b10a-62842d88edc4.jpg?1",
             "name": "Delina, Wild Mage",
             "text": "Whenever Delina, Wild Mage attacks, choose target creature you control, then roll a d20.\n1\u201314 | Create a tapped and attacking token that's a copy of that creature, except it's not legendary and it has \"Exile this creature at end of combat.\"\n15\u201320 | Create one of those tokens. Roll again.",
             "colours": [
@@ -11904,7 +11904,7 @@
         },
         {
             "id": "bca09977-8755-591d-a62b-38f5b8c77661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf573ba-6471-434b-88fd-c9caa539515a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf573ba-6471-434b-88fd-c9caa539515a.jpg?1",
             "name": "Goblin Javelineer",
             "text": "Haste\nWhenever Goblin Javelineer becomes blocked, it deals 1 damage to target creature blocking it.",
             "colours": [
@@ -11941,7 +11941,7 @@
         },
         {
             "id": "18f6eac2-73da-5139-9a65-706c83b68e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a081f0aa-65ad-4483-991f-1d6159b7560a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a081f0aa-65ad-4483-991f-1d6159b7560a.jpg?1",
             "name": "Hulking Bugbear",
             "text": "Haste",
             "colours": [
@@ -11977,7 +11977,7 @@
         },
         {
             "id": "4121f2bb-91e3-5880-86e9-f500684dc228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e763a-ba7d-4e32-a5f1-87a457b12db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e763a-ba7d-4e32-a5f1-87a457b12db2.jpg?1",
             "name": "Minion of the Mighty",
             "text": "Menace\nPack tactics \u2014 Whenever Minion of the Mighty attacks, if you attacked with creatures with total power 6 or greater this combat, you may put a Dragon creature card from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "0e4ee5d1-ffcf-5da0-8e1f-739e2bf8e5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf004dae-c411-4b0e-b695-fd727f475948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf004dae-c411-4b0e-b695-fd727f475948.jpg?1",
             "name": "Rust Monster",
             "text": "First strike\nSacrifice an artifact: Rust Monster gets +2/+0 until end of turn.",
             "colours": [
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "cd7ac4cf-6d4c-582d-bfd2-b12cb97fc8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a6502-5239-449a-b04a-c82d525f9916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a6502-5239-449a-b04a-c82d525f9916.jpg?1",
             "name": "Xorn",
             "text": "If you would create one or more Treasure tokens, instead create those tokens plus an additional Treasure token.",
             "colours": [
@@ -12085,7 +12085,7 @@
         },
         {
             "id": "7bd7421a-cd26-58f4-b207-a683ed833eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f43-ea54-4ab3-afd5-683e4bd0d3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f43-ea54-4ab3-afd5-683e4bd0d3e0.jpg?1",
             "name": "Zalto, Fire Giant Duke",
             "text": "Trample\nWhenever Zalto, Fire Giant Duke is dealt damage, venture into the dungeon.",
             "colours": [
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "f960ea96-128f-50bd-8ae4-ecc2cc39c400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76c993-7cc5-428f-bfbc-7747c6a566d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76c993-7cc5-428f-bfbc-7747c6a566d0.jpg?1",
             "name": "Bulette",
             "text": "At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on Bulette.",
             "colours": [
@@ -12160,7 +12160,7 @@
         },
         {
             "id": "07dd3038-2292-53ea-af35-46670148b89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7669e373-0173-43db-8b86-abc319c9e8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7669e373-0173-43db-8b86-abc319c9e8fc.jpg?1",
             "name": "Dire Wolf Prowler",
             "text": "{1}{G}: Dire Wolf Prowler gets +2/+2 and gains haste until end of turn. Activate only once each turn.",
             "colours": [
@@ -12196,7 +12196,7 @@
         },
         {
             "id": "6036298d-36e4-57ab-9e0b-480e42b33c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b8a1e6-a649-4be1-8899-104fffdb2dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b8a1e6-a649-4be1-8899-104fffdb2dff.jpg?1",
             "name": "Gnoll Hunter",
             "text": "Pack tactics \u2014 Whenever Gnoll Hunter attacks, if you attacked with creatures with total power 6 or greater this combat, put a +1/+1 counter on Gnoll Hunter.",
             "colours": [
@@ -12232,7 +12232,7 @@
         },
         {
             "id": "1c50d443-921f-557c-9313-01a4c0518365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0505a8a-841b-471b-970d-125583b9ba9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0505a8a-841b-471b-970d-125583b9ba9d.jpg?1",
             "name": "Loathsome Troll",
             "text": "{3}{G}: Roll a d20. Activate only if Loathsome Troll is in your graveyard.\n1\u20139 | Put Loathsome Troll on top of your library.\n10\u201319 | Return Loathsome Troll to your hand.\n20 | Return Loathsome Troll to the battlefield tapped.",
             "colours": [
@@ -12268,7 +12268,7 @@
         },
         {
             "id": "2bb659fe-5f4c-5fe3-8192-f02439eba791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f3b766-3c2a-41fa-8614-015fdc83c98c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f3b766-3c2a-41fa-8614-015fdc83c98c.jpg?1",
             "name": "Lurking Roper",
             "text": "Lurking Roper doesn't untap during your untap step.\nWhenever you gain life, untap Lurking Roper.",
             "colours": [
@@ -12304,7 +12304,7 @@
         },
         {
             "id": "e041bb48-9f4b-54fc-9496-d651ab0a3a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01234d4c-ff3d-40a8-8404-9790d3ee3620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01234d4c-ff3d-40a8-8404-9790d3ee3620.jpg?1",
             "name": "Neverwinter Dryad",
             "text": "{2}, Sacrifice Neverwinter Dryad: Search your library for a basic Forest card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "75adc8ae-f127-57fa-92f2-3beee573907a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60bdf5-d954-4e28-9858-d3780c1b5b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60bdf5-d954-4e28-9858-d3780c1b5b41.jpg?1",
             "name": "Ochre Jelly",
             "text": "Trample\nOchre Jelly enters the battlefield with X +1/+1 counters on it.\nSplit \u2014 When Ochre Jelly dies, if it had two or more +1/+1 counters on it, create a token that's a copy of it at the beginning of the next end step. The token enters the battlefield with half that many +1/+1 counters on it, rounded down.",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "9e24da46-619b-576e-b218-39f2f3c77e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b19309-a7f6-44da-b856-d12da11156e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b19309-a7f6-44da-b856-d12da11156e8.jpg?1",
             "name": "Owlbear",
             "text": "Trample\nKeen Senses \u2014 When Owlbear enters the battlefield, draw a card.",
             "colours": [
@@ -12413,7 +12413,7 @@
         },
         {
             "id": "c0b1a688-ac2b-524b-b7af-c3a0e546c09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4bad2-1e56-44f4-beef-59edafcc9d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4bad2-1e56-44f4-beef-59edafcc9d95.jpg?1",
             "name": "Purple Worm",
             "text": "This spell costs {2} less to cast if a creature died this turn.\nWard {2}",
             "colours": [
@@ -12449,7 +12449,7 @@
         },
         {
             "id": "007e6de3-9a15-57bb-a0db-ed255243adfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785d199-3e8a-494a-9fd7-5215eb6b3eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785d199-3e8a-494a-9fd7-5215eb6b3eea.jpg?1",
             "name": "The Tarrasque",
             "text": "The Tarrasque has haste and ward {1}0 as long as it was cast.\nWhenever The Tarrasque attacks, it fights target creature defending player controls.",
             "colours": [
@@ -12487,7 +12487,7 @@
         },
         {
             "id": "10582c26-4734-51d3-8d35-e5f734fa9fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96116efa-b580-4764-aba5-09cb8ce24806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96116efa-b580-4764-aba5-09cb8ce24806.jpg?1",
             "name": "Underdark Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -12523,7 +12523,7 @@
         },
         {
             "id": "5d2934cc-d160-56a5-9f9c-9b07d6c43079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051be39-298e-44dc-8fd9-bfbecdf98a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051be39-298e-44dc-8fd9-bfbecdf98a58.jpg?1",
             "name": "Varis, Silverymoon Ranger",
             "text": "Reach, ward {1}\nWhenever you cast a creature or planeswalker spell, venture into the dungeon. This ability triggers only once each turn.\nWhenever you complete a dungeon, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -12563,7 +12563,7 @@
         },
         {
             "id": "95453148-bccc-5d77-b932-6cccdf473d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38ce406d-8253-48f8-a146-8302518c5187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38ce406d-8253-48f8-a146-8302518c5187.jpg?1",
             "name": "Barrowin of Clan Undurr",
             "text": "When Barrowin of Clan Undurr enters the battlefield, venture into the dungeon.\nWhenever Barrowin of Clan Undurr attacks, return up to one creature card with mana value 3 or less from your graveyard to the battlefield if you've completed a dungeon.",
             "colours": [
@@ -12604,7 +12604,7 @@
         },
         {
             "id": "b11d179d-52be-5ed8-85c1-8788cf9f9171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e7d7-60f8-452b-9563-5624791ae893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e7d7-60f8-452b-9563-5624791ae893.jpg?1",
             "name": "Bruenor Battlehammer",
             "text": "Each creature you control gets +2/+0 for each Equipment attached to it.\nYou may pay {0} rather than pay the equip cost of the first equip ability you activate each turn.",
             "colours": [
@@ -12645,7 +12645,7 @@
         },
         {
             "id": "28cd45eb-bfa4-5405-9208-16c9e6f240d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcd9221-c59b-4c92-b6fc-972a17e2dd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcd9221-c59b-4c92-b6fc-972a17e2dd0e.jpg?1",
             "name": "Drizzt Do'Urden",
             "text": "Double strike\nWhen Drizzt Do'Urden enters the battlefield, create Guenhwyvar, a legendary 4/1 green Cat creature token with trample.\nWhenever a creature dies, if it had power greater than Drizzt's power, put a number of +1/+1 counters on Drizzt equal to the difference.",
             "colours": [
@@ -12686,7 +12686,7 @@
         },
         {
             "id": "617cc46e-c80c-55dd-9059-e9ea037b4efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f83fa5-c77b-4a70-a6cf-2c8e196b6f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f83fa5-c77b-4a70-a6cf-2c8e196b6f3f.jpg?1",
             "name": "Farideh, Devil's Chosen",
             "text": "Dark One's Own Luck \u2014 Whenever you roll one or more dice, Farideh, Devil's Chosen gains flying and menace until end of turn. If any of those results was 10 or higher, draw a card.",
             "colours": [
@@ -12727,7 +12727,7 @@
         },
         {
             "id": "3bb59b6f-8a31-58d1-9239-0475966a8c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c41d97-7c2f-4d8b-a35d-40d98329a728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c41d97-7c2f-4d8b-a35d-40d98329a728.jpg?1",
             "name": "Gretchen Titchwillow",
             "text": "{2}{G}{U}: Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -12768,7 +12768,7 @@
         },
         {
             "id": "5083ee72-600a-5ff9-a1df-d4a320067428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a71cdb-d97c-449e-a7cb-af7030164ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a71cdb-d97c-449e-a7cb-af7030164ff4.jpg?1",
             "name": "Hama Pashar, Ruin Seeker",
             "text": "Room abilities of dungeons you own trigger an additional time.",
             "colours": [
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "03236afc-1e37-505c-94ca-9cfd42da8c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df8cb7c-ad05-473b-9deb-7ce56c6799b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df8cb7c-ad05-473b-9deb-7ce56c6799b8.jpg?1",
             "name": "Kalain, Reclusive Painter",
             "text": "When Kalain, Reclusive Painter enters the battlefield, create a Treasure token.\nOther creatures you control enter the battlefield with an additional +1/+1 counter on them for each mana from a Treasure spent to cast them.",
             "colours": [
@@ -12851,7 +12851,7 @@
         },
         {
             "id": "dad2113e-40c0-5710-aaa6-43c97e8af1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f77be2-2333-4b3a-9954-15f4de7a61c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f77be2-2333-4b3a-9954-15f4de7a61c0.jpg?1",
             "name": "Krydle of Baldur's Gate",
             "text": "Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, you may pay {2}. If you do, target creature can't be blocked this turn.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "b3134e1a-86ef-51ca-b037-dd0e25f2e30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034f75c7-bb57-426a-8e3f-4b7f0110f02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034f75c7-bb57-426a-8e3f-4b7f0110f02b.jpg?1",
             "name": "Minsc, Beloved Ranger",
             "text": "When Minsc, Beloved Ranger enters the battlefield, create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n{X}: Until end of turn, target creature you control has base power and toughness X/X and becomes a Giant in addition to its other types. Activate only as a sorcery.",
             "colours": [
@@ -12936,7 +12936,7 @@
         },
         {
             "id": "c6c19a89-a749-55ae-b770-a57db659b657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a98a2d-a837-4911-b726-b2cee17cf450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a98a2d-a837-4911-b726-b2cee17cf450.jpg?1",
             "name": "Shessra, Death's Whisper",
             "text": "Bewitching Whispers \u2014 When Shessra, Death's Whisper enters the battlefield, target creature blocks this turn if able.\nWhispers of the Grave \u2014 At the beginning of your end step, if a creature died this turn, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -12978,7 +12978,7 @@
         },
         {
             "id": "ab079d5d-105c-57ed-bc97-f93d14b20500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e3a2-3d8d-458d-960b-ded60d2ad4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e3a2-3d8d-458d-960b-ded60d2ad4a1.jpg?1",
             "name": "Trelasarra, Moon Dancer",
             "text": "Whenever you gain life, put a +1/+1 counter on Trelasarra, Moon Dancer and scry 1.",
             "colours": [
@@ -13019,7 +13019,7 @@
         },
         {
             "id": "3eff2c57-aa8a-5747-a213-9d8746ad30b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f910f2-a7ed-4535-b554-d672ba49f38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f910f2-a7ed-4535-b554-d672ba49f38c.jpg?1",
             "name": "Volo, Guide to Monsters",
             "text": "Whenever you cast a creature spell that doesn't share a creature type with a creature you control or a creature card in your graveyard, copy that spell. (A copy of a creature spell becomes a token.)",
             "colours": [
@@ -13060,7 +13060,7 @@
         },
         {
             "id": "32cdeba8-d0c1-55c4-87d0-404305e77dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47852cc6-a6de-4aed-9650-0c7ce346c3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47852cc6-a6de-4aed-9650-0c7ce346c3b9.jpg?1",
             "name": "Iron Golem",
             "text": "Vigilance\nIron Golem attacks or blocks each combat if able.",
             "colours": [],
@@ -13093,7 +13093,7 @@
         },
         {
             "id": "73ce4804-3da8-5345-9631-fb5a36c01bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059c316-2be1-4f66-9888-d31714280a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059c316-2be1-4f66-9888-d31714280a5e.jpg?1",
             "name": "Mimic",
             "text": "{T}, Sacrifice Mimic: Add one mana of any color.\n{2}: Mimic becomes a Shapeshifter artifact creature with base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -13125,7 +13125,7 @@
         },
         {
             "id": "8edf5a3f-eae0-58e0-a871-70ebbf23c2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c35234-2518-494c-8c1e-fd5702145967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c35234-2518-494c-8c1e-fd5702145967.jpg?1",
             "name": "Cave of the Frost Dragon",
             "text": "If you control two or more other lands, Cave of the Frost Dragon enters the battlefield tapped.\n{T}: Add {W}.\n{4}{W}: Cave of the Frost Dragon becomes a 3/4 white Dragon creature with flying until end of turn. It's still a land.",
             "colours": [],
@@ -13157,7 +13157,7 @@
         },
         {
             "id": "64e31d5f-41f7-5476-9ad7-51da7bbfa26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565be37a-4c14-420b-a07c-18e21f7fd731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565be37a-4c14-420b-a07c-18e21f7fd731.jpg?1",
             "name": "Den of the Bugbear",
             "text": "If you control two or more other lands, Den of the Bugbear enters the battlefield tapped.\n{T}: Add {R}.\n{3}{R}: Until end of turn, Den of the Bugbear becomes a 3/2 red Goblin creature with \"Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\" It's still a land.",
             "colours": [],
@@ -13189,7 +13189,7 @@
         },
         {
             "id": "3e1bf33d-e7c0-56cd-9d3a-9097c462798c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c7b02d-ac45-45b1-9f1b-2dbd2b5c3cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c7b02d-ac45-45b1-9f1b-2dbd2b5c3cdc.jpg?1",
             "name": "Dungeon Descent",
             "text": "Dungeon Descent enters the battlefield tapped.\n{T}: Add {C}.\n{4}, {T}, Tap an untapped legendary creature you control: Venture into the dungeon. Activate only as a sorcery.",
             "colours": [],
@@ -13219,7 +13219,7 @@
         },
         {
             "id": "9aa88c25-0525-5817-a227-7ff2aeb23b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6069f2-7a32-4cb7-b2ab-ea6b51267cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6069f2-7a32-4cb7-b2ab-ea6b51267cca.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -13249,7 +13249,7 @@
         },
         {
             "id": "cb23ca0a-da9b-5c7d-a6ef-ddf08e4ed1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d959ee0b-9fb1-4e32-ad45-f04cdd5c678a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d959ee0b-9fb1-4e32-ad45-f04cdd5c678a.jpg?1",
             "name": "Hall of Storm Giants",
             "text": "If you control two or more other lands, Hall of Storm Giants enters the battlefield tapped.\n{T}: Add {U}.\n{5}{U}: Until end of turn, Hall of Storm Giants becomes a 7/7 blue Giant creature with ward {3}. It's still a land.",
             "colours": [],
@@ -13281,7 +13281,7 @@
         },
         {
             "id": "1343e3f6-b68e-56f2-9195-71cbe43e2213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b9d17d-3ab0-4755-b396-391df50e70dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b9d17d-3ab0-4755-b396-391df50e70dd.jpg?1",
             "name": "Hive of the Eye Tyrant",
             "text": "If you control two or more other lands, Hive of the Eye Tyrant enters the battlefield tapped.\n{T}: Add {B}.\n{3}{B}: Until end of turn, Hive of the Eye Tyrant becomes a 3/3 black Beholder creature with menace and \"Whenever this creature attacks, exile target card from defending player's graveyard.\" It's still a land.",
             "colours": [],
@@ -13313,7 +13313,7 @@
         },
         {
             "id": "0702e5b3-3e6e-5c45-b2b5-7d7d77613b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10d359-543a-4d2e-9bbe-23f93a14aa2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10d359-543a-4d2e-9bbe-23f93a14aa2d.jpg?1",
             "name": "Lair of the Hydra",
             "text": "If you control two or more other lands, Lair of the Hydra enters the battlefield tapped.\n{T}: Add {G}.\n{X}{G}: Until end of turn, Lair of the Hydra becomes an X/X green Hydra creature. It's still a land. X can't be 0.",
             "colours": [],
@@ -13345,7 +13345,7 @@
         },
         {
             "id": "5a91508d-d5b9-5897-a4ce-bb763e3b650e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01054cee-3105-4e80-9ded-0ae57db5c159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01054cee-3105-4e80-9ded-0ae57db5c159.jpg?1",
             "name": "Temple of the Dragon Queen",
             "text": "As Temple of the Dragon Queen enters the battlefield, you may reveal a Dragon card from your hand. Temple of the Dragon Queen enters the battlefield tapped unless you revealed a Dragon card this way or you control a Dragon.\nAs Temple of the Dragon Queen enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -13375,7 +13375,7 @@
         },
         {
             "id": "125ffb5a-124f-54b9-bfef-6da5713e9441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d75f53d-d105-4973-ab2e-58cdf3a41eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d75f53d-d105-4973-ab2e-58cdf3a41eed.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -13406,7 +13406,7 @@
         },
         {
             "id": "5031765f-0bd8-5866-89ac-2e9a3ec1b7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c795f284-4d77-474b-a546-afb0def84d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c795f284-4d77-474b-a546-afb0def84d4f.jpg?1",
             "name": "The Book of Exalted Deeds",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, create a 3/3 white Angel creature token with flying.\n{W}{W}{W}, {T}, Exile The Book of Exalted Deeds: Put an enlightened counter on target Angel. It gains \"You can't lose the game and your opponents can't win the game.\" Activate only as a sorcery.",
             "colours": [
@@ -13442,7 +13442,7 @@
         },
         {
             "id": "3d27450b-fbd7-5a63-ad1b-dee86bf4db03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8b5883-b2e7-4c56-89b5-b40fb8416a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8b5883-b2e7-4c56-89b5-b40fb8416a3a.jpg?1",
             "name": "Dancing Sword",
             "text": "Equipped creature gets +2/+1.\nWhen equipped creature dies, you may have Dancing Sword become a 2/1 Construct artifact creature with flying and ward {1}. If you do, it isn't an Equipment.\nEquip {1}",
             "colours": [
@@ -13478,7 +13478,7 @@
         },
         {
             "id": "78519a87-1993-5add-a65f-dbcc6be65d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263501c5-dec0-4c01-8129-61f9fdd22b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263501c5-dec0-4c01-8129-61f9fdd22b54.jpg?1",
             "name": "Flumph",
             "text": "Defender, flying\nWhenever Flumph is dealt damage, you and target opponent each draw a card.",
             "colours": [
@@ -13514,7 +13514,7 @@
         },
         {
             "id": "0b6be946-55fb-53da-bf48-047b0960cede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363a43f-d9aa-4196-bde5-2d98ad377e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363a43f-d9aa-4196-bde5-2d98ad377e48.jpg?1",
             "name": "Guardian of Faith",
             "text": "Flash\nVigilance\nWhen Guardian of Faith enters the battlefield, any number of other target creatures you control phase out.",
             "colours": [
@@ -13551,7 +13551,7 @@
         },
         {
             "id": "31c37543-73c8-5471-b3e2-544e9d5ff7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce58575-7607-49a4-a7c9-b23b715c3bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce58575-7607-49a4-a7c9-b23b715c3bf5.jpg?1",
             "name": "Loyal Warhound",
             "text": "Vigilance\nWhen Loyal Warhound enters the battlefield, if an opponent controls more lands than you, search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13587,7 +13587,7 @@
         },
         {
             "id": "5b217df5-6601-525d-90dc-c6eadb1017db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc13fd-8e08-4846-87ef-0562bdd3ba93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc13fd-8e08-4846-87ef-0562bdd3ba93.jpg?1",
             "name": "Teleportation Circle",
             "text": "At the beginning of your end step, exile up to one target artifact or creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -13621,7 +13621,7 @@
         },
         {
             "id": "60af052c-0278-5876-876f-13c0988d7876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcf9cf4-73d3-4212-b29a-660c3d3f537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcf9cf4-73d3-4212-b29a-660c3d3f537f.jpg?1",
             "name": "The Blackstaff of Waterdeep",
             "text": "You may choose not to untap The Blackstaff of Waterdeep during your untap step.\nAnimate Walking Statue \u2014 {1}{U}, {T}: Another target nontoken artifact you control becomes a 4/4 artifact creature for as long as The Blackstaff of Waterdeep remains tapped. Activate only as a sorcery.",
             "colours": [
@@ -13657,7 +13657,7 @@
         },
         {
             "id": "466bafac-7fd5-5fed-8236-41b669e8566c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a5b2f1-4bf7-48c4-ab56-e03b35ea3f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a5b2f1-4bf7-48c4-ab56-e03b35ea3f21.jpg?1",
             "name": "Demilich",
             "text": "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn.\nWhenever Demilich attacks, exile up to one target instant or sorcery card from your graveyard. Copy it. You may cast the copy.\nYou may cast Demilich from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.",
             "colours": [
@@ -13694,7 +13694,7 @@
         },
         {
             "id": "03a3e10f-dd7d-5816-9bca-3db1c448646e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480d92e-5c03-49b8-8bdd-fbcce80de998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480d92e-5c03-49b8-8bdd-fbcce80de998.jpg?1",
             "name": "Grazilaxx, Illithid Scholar",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -13732,7 +13732,7 @@
         },
         {
             "id": "6707e88a-9751-533d-a474-8640f413564e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9667e453-5dc1-4ee7-82e4-edfc41db1151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9667e453-5dc1-4ee7-82e4-edfc41db1151.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "Each opponent exiles cards from the top of their library until that player has exiled cards with total mana value 20 or more.",
             "colours": [
@@ -13766,7 +13766,7 @@
         },
         {
             "id": "58fe404f-94bd-53bf-9fc3-1bb6ba9f8770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7667ac49-09b8-424f-8310-a5576977745b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7667ac49-09b8-424f-8310-a5576977745b.jpg?1",
             "name": "True Polymorph",
             "text": "Target artifact or creature becomes a copy of another target artifact or creature.",
             "colours": [
@@ -13800,7 +13800,7 @@
         },
         {
             "id": "ac8950b0-60dd-52af-85cf-1f04b55f67c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c470b5-91d7-4cf2-b6c0-61280a63bce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c470b5-91d7-4cf2-b6c0-61280a63bce1.jpg?1",
             "name": "Wizard's Spellbook",
             "text": "{T}: Exile target instant or sorcery card from a graveyard. Roll a d20. Activate only as a sorcery.\n1\u20139 | Copy that card. You may cast the copy.\n10\u201319 | Copy that card. You may cast the copy by paying {1} rather than paying its mana cost.\n20 | Copy each card exiled with Wizard's Spellbook. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -13834,7 +13834,7 @@
         },
         {
             "id": "89c068b9-b595-51f4-a78a-6d7c664239fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9043519d-c9d8-4d08-b4a9-feaf792bc7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9043519d-c9d8-4d08-b4a9-feaf792bc7a4.jpg?1",
             "name": "Yuan-Ti Malison",
             "text": "Yuan-Ti Malison can't be blocked as long as it's attacking alone.\nWhenever Yuan-Ti Malison deals combat damage to a player, venture into the dungeon.",
             "colours": [
@@ -13871,7 +13871,7 @@
         },
         {
             "id": "11d68034-56a0-5251-8d0e-f56206f7dfc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376b3cee-9386-41b0-a5d9-f60d147caff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376b3cee-9386-41b0-a5d9-f60d147caff7.jpg?1",
             "name": "Acererak the Archlich",
             "text": "When Acererak the Archlich enters the battlefield, if you haven't completed Tomb of Annihilation, return Acererak the Archlich to its owner's hand and venture into the dungeon.\nWhenever Acererak the Archlich attacks, for each opponent, you create a 2/2 black Zombie creature token unless that player sacrifices a creature.",
             "colours": [
@@ -13910,7 +13910,7 @@
         },
         {
             "id": "bdaf3b11-9f44-58ce-a7fc-d28e4a5487a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0bbab6-b9ad-456d-ab4a-485dd8d89b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0bbab6-b9ad-456d-ab4a-485dd8d89b35.jpg?1",
             "name": "Asmodeus the Archfiend",
             "text": "Binding Contract \u2014 If you would draw a card, exile the top card of your library face down instead.\n{B}{B}{B}: Draw seven cards.\n{B}: Return all cards exiled with Asmodeus the Archfiend to their owner's hand and you lose that much life.",
             "colours": [
@@ -13949,7 +13949,7 @@
         },
         {
             "id": "d215087e-1292-5888-bae8-b52a7e5c0c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe97c8c-6bb0-4456-aa99-91c721f19777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe97c8c-6bb0-4456-aa99-91c721f19777.jpg?1",
             "name": "The Book of Vile Darkness",
             "text": "At the beginning of your end step, if you lost 2 or more life this turn, create a 2/2 black Zombie creature token.\n{T}, Exile The Book of Vile Darkness and artifacts you control named Eye of Vecna and Hand of Vecna: Create Vecna, a legendary 8/8 black Zombie God creature token with indestructible. It gains all triggered abilities of the exiled cards.",
             "colours": [
@@ -13985,7 +13985,7 @@
         },
         {
             "id": "53538eee-50d2-5812-b542-730d337f8ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa3a489-5fa3-421e-9655-755f31414f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa3a489-5fa3-421e-9655-755f31414f3d.jpg?1",
             "name": "Forsworn Paladin",
             "text": "Menace\n{1}{B}, {T}, Pay 1 life: Create a Treasure token.\n{2}{B}: Target creature gets +2/+0 until end of turn. If mana from a Treasure was spent to activate this ability, that creature also gains deathtouch until end of turn.",
             "colours": [
@@ -14022,7 +14022,7 @@
         },
         {
             "id": "11d8235a-1c64-592f-9262-df2fe165bb9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af7ba0-3d14-4d29-9434-395a1f9f3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af7ba0-3d14-4d29-9434-395a1f9f3148.jpg?1",
             "name": "Sphere of Annihilation",
             "text": "Sphere of Annihilation enters the battlefield with X void counters on it.\nAt the beginning of your upkeep, exile Sphere of Annihilation, all creatures and planeswalkers with mana value less than or equal to the number of void counters on it, and all creature and planeswalker cards in graveyards with mana value less than or equal to the number of void counters on it.",
             "colours": [
@@ -14056,7 +14056,7 @@
         },
         {
             "id": "3f586cac-5221-5b6f-aa0f-5ba2d0ed6293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f98860-d51a-4873-ab14-98f29b4eee5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f98860-d51a-4873-ab14-98f29b4eee5d.jpg?1",
             "name": "Vorpal Sword",
             "text": "Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains \"Whenever equipped creature deals combat damage to a player, that player loses the game.\"\nEquip {B}{B}",
             "colours": [
@@ -14093,7 +14093,7 @@
         },
         {
             "id": "29c24ffd-f0f7-5a70-a4cd-4b89f015a15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8826a883-197b-48e9-bd07-e2c8ce361fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8826a883-197b-48e9-bd07-e2c8ce361fcf.jpg?1",
             "name": "Flameskull",
             "text": "Flying\nFlameskull can't block.\nRejuvenation \u2014 When Flameskull dies, exile it. If you do, exile the top card of your library. Until the end of your next turn, you may play one of those cards. (If you cast Flameskull this way, you can't play the other card, and vice versa.)",
             "colours": [
@@ -14129,7 +14129,7 @@
         },
         {
             "id": "67ed296e-d745-5ef3-9a57-f3c21c5c5112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da8e543-c9ef-4f2d-99e4-ef6ba496ae75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da8e543-c9ef-4f2d-99e4-ef6ba496ae75.jpg?1",
             "name": "Hobgoblin Bandit Lord",
             "text": "Other Goblins you control get +1/+1.\n{R}, {T}: Hobgoblin Bandit Lord deals damage equal to the number of Goblins that entered the battlefield under your control this turn to any target.",
             "colours": [
@@ -14166,7 +14166,7 @@
         },
         {
             "id": "0cd488e5-2edb-5c78-ba72-219db718e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a44f5-1f19-4218-95fc-8765b058778b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a44f5-1f19-4218-95fc-8765b058778b.jpg?1",
             "name": "Meteor Swarm",
             "text": "Meteor Swarm deals 8 damage divided as you choose among X target creatures and/or planeswalkers.",
             "colours": [
@@ -14200,7 +14200,7 @@
         },
         {
             "id": "9ab1b833-7629-5f0c-a53c-d4d652a2ec08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a7c198-da05-434f-bbef-4b5e8f0597cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a7c198-da05-434f-bbef-4b5e8f0597cd.jpg?1",
             "name": "Orb of Dragonkind",
             "text": "{1}, {T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon spells or activate abilities of Dragons.\n{R}, {T}, Sacrifice Orb of Dragonkind: Look at the top seven cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14234,7 +14234,7 @@
         },
         {
             "id": "4209e887-b83d-593f-8a1c-381e4c8b8521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c2d90f-bd33-402d-b5fd-ee1ae62b59cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c2d90f-bd33-402d-b5fd-ee1ae62b59cf.jpg?1",
             "name": "Wish",
             "text": "You may play a card you own from outside the game this turn.",
             "colours": [
@@ -14268,7 +14268,7 @@
         },
         {
             "id": "1f0cf29d-0239-55a8-81ab-0065cc93752f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d206f867-c41b-4dad-be1e-c00851f56983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d206f867-c41b-4dad-be1e-c00851f56983.jpg?1",
             "name": "Circle of Dreams Druid",
             "text": "{T}: Add {G} for each creature you control.",
             "colours": [
@@ -14305,7 +14305,7 @@
         },
         {
             "id": "bf2a5a56-3a19-56ff-ade3-4321b1baa079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2064ba7-a03e-4beb-b251-9383154dbfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2064ba7-a03e-4beb-b251-9383154dbfaa.jpg?1",
             "name": "Froghemoth",
             "text": "Trample, haste\nWhenever Froghemoth deals combat damage to a player, exile up to that many target cards from their graveyard. Put a +1/+1 counter on Froghemoth for each creature card exiled this way. You gain 1 life for each noncreature card exiled this way.",
             "colours": [
@@ -14342,7 +14342,7 @@
         },
         {
             "id": "04caa0c9-48fc-5fe1-b449-fa8c7bf6e806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100fad49-3eac-4a9a-bf39-5b50c995126d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100fad49-3eac-4a9a-bf39-5b50c995126d.jpg?1",
             "name": "Instrument of the Bards",
             "text": "At the beginning of your upkeep, you may put a harmony counter on Instrument of the Bards.\n{3}{G}, {T}: Search your library for a creature card with mana value equal to the number of harmony counters on Instrument of the Bards, reveal it, and put it into your hand. If that card is legendary, create a Treasure token. Then shuffle.",
             "colours": [
@@ -14378,7 +14378,7 @@
         },
         {
             "id": "daf17990-e965-5ab1-8a6c-b59712596782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3876bba-75d3-46be-994a-878048573286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3876bba-75d3-46be-994a-878048573286.jpg?1",
             "name": "Long Rest",
             "text": "Return X target cards with different mana values from your graveyard to your hand. If eight or more cards were returned to your hand this way, your life total becomes equal to your starting life total. Exile Long Rest.",
             "colours": [
@@ -14412,7 +14412,7 @@
         },
         {
             "id": "7331c7fa-d876-51ea-9079-9475d112ad49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212a090-a9dc-4fd4-b138-34f3d8f1f563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212a090-a9dc-4fd4-b138-34f3d8f1f563.jpg?1",
             "name": "Werewolf Pack Leader",
             "text": "Pack tactics \u2014 Whenever Werewolf Pack Leader attacks, if you attacked with creatures with total power 6 or greater this combat, draw a card.\n{3}{G}: Until end of turn, Werewolf Pack Leader has base power and toughness 5/3, gains trample, and isn't a Human.",
             "colours": [
@@ -14449,7 +14449,7 @@
         },
         {
             "id": "2732175b-a9e0-5f1f-8be7-fca50d8826f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8e32bc-33b4-447c-a99d-295d10ef2aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8e32bc-33b4-447c-a99d-295d10ef2aeb.jpg?1",
             "name": "Orcus, Prince of Undeath",
             "text": "Flying, trample\nWhen Orcus, Prince of Undeath enters the battlefield, choose one \u2014\n\u2022 Each other creature gets -X/-X until end of turn. You lose X life.\n\u2022 Return up to X target creature cards with total mana value X or less from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -14489,7 +14489,7 @@
         },
         {
             "id": "d538ed37-32c2-5cef-9b40-21aa0857439d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a56df59-3e7b-40b5-a28c-10508bb7036f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a56df59-3e7b-40b5-a28c-10508bb7036f.jpg?1",
             "name": "Skeletal Swarming",
             "text": "Each Skeleton you control has trample, attacks each combat if able, and gets +X/+0, where X is the number of other Skeletons you control.\nAt the beginning of your end step, create a tapped 1/1 black Skeleton creature token. If a creature died this turn, create two of those tokens instead.",
             "colours": [
@@ -14525,7 +14525,7 @@
         },
         {
             "id": "bca813ca-03bb-5344-9ac7-71910f772a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38da306-c1d3-4fa4-aae5-0354fb3b2dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38da306-c1d3-4fa4-aae5-0354fb3b2dfd.jpg?1",
             "name": "Triumphant Adventurer",
             "text": "Deathtouch\nAs long as it's your turn, Triumphant Adventurer has first strike.\nWhenever Triumphant Adventurer attacks, venture into the dungeon.",
             "colours": [
@@ -14564,7 +14564,7 @@
         },
         {
             "id": "d2cac61f-9254-568f-9080-2283cadc3a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d4caf8-06cf-4320-a744-988a551d23e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d4caf8-06cf-4320-a744-988a551d23e5.jpg?1",
             "name": "Xanathar, Guild Kingpin",
             "text": "At the beginning of your upkeep, choose target opponent. Until end of turn, that player can't cast spells, you may look at the top card of their library any time, you may play the top card of their library, and you may spend mana as though it were mana of any color to cast spells this way.",
             "colours": [
@@ -14604,7 +14604,7 @@
         },
         {
             "id": "54ebf301-3886-5528-a724-d95cafb00004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484d4d-6000-4e7b-87cf-cabfe4e19b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484d4d-6000-4e7b-87cf-cabfe4e19b0e.jpg?1",
             "name": "The Deck of Many Things",
             "text": "{2}, {T}: Roll a d20 and subtract the number of cards in your hand. If the result is 0 or less, discard your hand.\n1\u20139 | Return a card at random from your graveyard to your hand.\n10\u201319 | Draw two cards.\n20 | Put a creature card from any graveyard onto the battlefield under your control. When that creature dies, its owner loses the game.",
             "colours": [],
@@ -14636,7 +14636,7 @@
         },
         {
             "id": "660ab36d-c49e-5c90-a7b2-479a52b6e2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f305d0-f610-400d-a365-6d9afcfb6ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f305d0-f610-400d-a365-6d9afcfb6ab8.jpg?1",
             "name": "Eye of Vecna",
             "text": "When Eye of Vecna enters the battlefield, you draw a card and you lose 2 life.\nAt the beginning of your upkeep, you may pay {2}. If you do, you draw a card and you lose 2 life.",
             "colours": [],
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "ce758da1-a482-5e75-bd0e-0cb31ab18977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0502e4-508a-4d78-b987-0801e6b0978c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0502e4-508a-4d78-b987-0801e6b0978c.jpg?1",
             "name": "Hand of Vecna",
             "text": "At the beginning of combat on your turn, equipped creature or a creature you control named Vecna gets +X/+X until end of turn, where X is the number of cards in your hand.\nEquip\u2014\nPay 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -14702,7 +14702,7 @@
         },
         {
             "id": "f3329c77-496d-5fa7-be3f-d8dfd0187c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91174da-4cfb-4440-8f1e-8216ec21f725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91174da-4cfb-4440-8f1e-8216ec21f725.jpg?1",
             "name": "Treasure Chest",
             "text": "{4}, Sacrifice Treasure Chest: Roll a d20.\n1 | Trapped \u2014 You lose 3 life.\n2\u20139 | Create five Treasure tokens.\n10\u201319 | You gain 3 life and draw three cards.\n20 | Search your library for a card. If it's an artifact card, you may put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -14733,7 +14733,7 @@
         },
         {
             "id": "e1a64d19-7157-5967-a5c8-641926c05c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88527eb2-7264-4128-8bdf-df80b4053a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88527eb2-7264-4128-8bdf-df80b4053a48.jpg?1",
             "name": "Vorpal Sword",
             "text": "Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains \"Whenever equipped creature deals combat damage to a player, that player loses the game.\"\nEquip {B}{B}",
             "colours": [
@@ -14769,7 +14769,7 @@
         },
         {
             "id": "aa88ec58-662d-5c34-b261-fc988ba8a133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ae20c0-b056-4c4f-a6d0-bbd72c37d0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ae20c0-b056-4c4f-a6d0-bbd72c37d0fc.jpg?1",
             "name": "Treasure Chest",
             "text": "{4}, Sacrifice Treasure Chest: Roll a d20.\n1 | Trapped \u2014 You lose 3 life.\n2\u20139 | Create five Treasure tokens.\n10\u201319 | You gain 3 life and draw three cards.\n20 | Search your library for a card. If it's an artifact card, you may put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -14799,7 +14799,7 @@
         },
         {
             "id": "7c1a4894-9704-5068-9c76-9831181ac184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8898d1fe-f4fe-4978-bcbc-f514ac2e73b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8898d1fe-f4fe-4978-bcbc-f514ac2e73b9.jpg?1",
             "name": "Portable Hole",
             "text": "",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "d85660ff-6f74-5dbe-8faa-2a7aab7d695c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1accce8c-7ca4-4cc5-bd8a-26b19622984b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1accce8c-7ca4-4cc5-bd8a-26b19622984b.jpg?1",
             "name": "You Find the Villains' Lair",
             "text": "",
             "colours": [
@@ -14867,7 +14867,7 @@
         },
         {
             "id": "ffd68558-8dcb-5e4b-be4d-612d35f1ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3febf51-6f40-478c-8b71-c529be420ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3febf51-6f40-478c-8b71-c529be420ff7.jpg?1",
             "name": "Power Word Kill",
             "text": "",
             "colours": [
@@ -14901,7 +14901,7 @@
         },
         {
             "id": "242d3e99-e775-5775-9a4c-b8096a02049f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13045ec-27e4-497a-bbc4-134cf46b7b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13045ec-27e4-497a-bbc4-134cf46b7b89.jpg?1",
             "name": "Magic Missile",
             "text": "",
             "colours": [
@@ -14935,7 +14935,7 @@
         },
         {
             "id": "0a80399a-7244-52e1-bac3-bcff3acc0857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea414698-5f87-461b-b1b2-b317b929280f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea414698-5f87-461b-b1b2-b317b929280f.jpg?1",
             "name": "Prosperous Innkeeper",
             "text": "",
             "colours": [
@@ -14972,7 +14972,7 @@
         },
         {
             "id": "d3d27491-b15c-5475-9f2e-73ad7064b00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323dd323-2ca2-4c85-9ef6-34341cd40d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323dd323-2ca2-4c85-9ef6-34341cd40d96.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -15007,7 +15007,7 @@
         },
         {
             "id": "2e465b1c-3018-571c-a2bc-3bdbf839b631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c981c9-3376-4f6e-b30d-859e5fc7347e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c981c9-3376-4f6e-b30d-859e5fc7347e.jpg?1",
             "name": "Icingdeath, Frost Tongue",
             "text": "",
             "colours": [
@@ -15044,7 +15044,7 @@
         },
         {
             "id": "25d3b098-e75c-5393-8f9b-d0e142c4c5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3c0bd9-8a37-4164-9937-f35d1c210fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3c0bd9-8a37-4164-9937-f35d1c210fe8.jpg?1",
             "name": "Dog Illusion",
             "text": "",
             "colours": [
@@ -15080,7 +15080,7 @@
         },
         {
             "id": "a6f382cb-a984-502b-a750-6ebfd49c0dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb6e0c-3630-46bf-b124-1ff2ddddf63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb6e0c-3630-46bf-b124-1ff2ddddf63e.jpg?1",
             "name": "Faerie Dragon",
             "text": "",
             "colours": [
@@ -15116,7 +15116,7 @@
         },
         {
             "id": "959ea7b6-fdde-57d0-b137-2a1fa11b39dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f8e40f-fb5e-4ab8-add3-a8b87e7bcdd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f8e40f-fb5e-4ab8-add3-a8b87e7bcdd9.jpg?1",
             "name": "The Atropal",
             "text": "",
             "colours": [
@@ -15154,7 +15154,7 @@
         },
         {
             "id": "81944633-42a8-59d8-a7ee-f3fe9a78670d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6fdb57-82f3-4695-b1fa-1f301ea4ef83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6fdb57-82f3-4695-b1fa-1f301ea4ef83.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -15189,7 +15189,7 @@
         },
         {
             "id": "32e9dfb0-c0f4-5aee-87d9-aab57cecb719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124e0b03-d9fb-44f1-9e3c-3462aabdd42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124e0b03-d9fb-44f1-9e3c-3462aabdd42e.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -15224,7 +15224,7 @@
         },
         {
             "id": "24276f6c-70a9-50f5-83bc-818575dda480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86881c5f-df5e-4f50-b554-e4c49d5316f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86881c5f-df5e-4f50-b554-e4c49d5316f9.jpg?1",
             "name": "Vecna",
             "text": "",
             "colours": [
@@ -15262,7 +15262,7 @@
         },
         {
             "id": "f3e2ed5c-6482-53b9-bbbb-a519f69103dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08d210-01cb-46c5-9150-4dfb47f50ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08d210-01cb-46c5-9150-4dfb47f50ae7.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -15297,7 +15297,7 @@
         },
         {
             "id": "37221bba-4459-5a1a-9b22-382c2f961d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e8e79-8673-41c2-a1ad-273c37e27aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e8e79-8673-41c2-a1ad-273c37e27aca.jpg?1",
             "name": "Boo",
             "text": "",
             "colours": [
@@ -15334,7 +15334,7 @@
         },
         {
             "id": "de807b5d-5a96-5bd8-ba32-ddcaf8ecac0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbc2ca1-4aad-4dfa-9eab-e783f5802078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbc2ca1-4aad-4dfa-9eab-e783f5802078.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -15369,7 +15369,7 @@
         },
         {
             "id": "cebf210a-3fd8-57f0-a1fa-f95900d45a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1425e965-7eea-419c-a7ec-c8169fa9edbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1425e965-7eea-419c-a7ec-c8169fa9edbf.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -15404,7 +15404,7 @@
         },
         {
             "id": "fda93a46-0633-58b7-a7e3-757852f6e47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c8f52-1580-42d5-8434-c4c70e31e31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c8f52-1580-42d5-8434-c4c70e31e31b.jpg?1",
             "name": "Guenhwyvar",
             "text": "",
             "colours": [
@@ -15441,7 +15441,7 @@
         },
         {
             "id": "dcef956d-cd2a-5cda-b6a4-90d79c7ee812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864d5b9-7151-42f0-8d37-8c319c3ab264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864d5b9-7151-42f0-8d37-8c319c3ab264.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -15476,7 +15476,7 @@
         },
         {
             "id": "6a613aa7-be49-5cc5-abd3-4fab87bb0065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a684b7-27e0-4d9e-a064-9e03c6e50c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a684b7-27e0-4d9e-a064-9e03c6e50c89.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -15507,7 +15507,7 @@
         },
         {
             "id": "fc04e76b-ec4f-5e4f-bf47-c4e529329e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289bd243-8754-49f8-a4f9-0be477c84ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289bd243-8754-49f8-a4f9-0be477c84ee1.jpg?1",
             "name": "Ellywick Tumblestrum Emblem",
             "text": "",
             "colours": [],
@@ -15537,7 +15537,7 @@
         },
         {
             "id": "3073a46e-c831-5525-b99e-f4edb3c3b627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34001fd-0e9b-445b-9c0b-381721dfebc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34001fd-0e9b-445b-9c0b-381721dfebc2.jpg?1",
             "name": "Lolth, Spider Queen Emblem",
             "text": "",
             "colours": [],
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "5c91cc3b-7faa-5025-a819-4ef25d33d1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c63f14a-db47-46aa-addf-7c6fc40169b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c63f14a-db47-46aa-addf-7c6fc40169b9.jpg?1",
             "name": "Mordenkainen Emblem",
             "text": "",
             "colours": [],
@@ -15597,7 +15597,7 @@
         },
         {
             "id": "e4f80f25-1d66-5ceb-9e51-c6d1bfd6e2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36520c3-627a-40b9-a5c7-42cc4c813b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36520c3-627a-40b9-a5c7-42cc4c813b67.jpg?1",
             "name": "Zariel, Archduke of Avernus Emblem",
             "text": "",
             "colours": [],
@@ -15627,7 +15627,7 @@
         },
         {
             "id": "aa281821-2a70-5b23-8a0d-a5874c753e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f509dbe-6ec7-4438-ab36-e20be46c9922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f509dbe-6ec7-4438-ab36-e20be46c9922.jpg?1",
             "name": "Dungeon of the Mad Mage",
             "text": "",
             "colours": [],
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "deb0e4bd-0431-526c-8ad7-d10716d4d58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b11ff8-f118-4978-87dd-509dc0c8c932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b11ff8-f118-4978-87dd-509dc0c8c932.jpg?1",
             "name": "Lost Mine of Phandelver",
             "text": "",
             "colours": [],
@@ -15683,7 +15683,7 @@
         },
         {
             "id": "a7f3efba-4ee7-57b3-94c3-8bc4e91ae75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b284bd-7a8f-4b60-8238-f746bdc5b236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b284bd-7a8f-4b60-8238-f746bdc5b236.jpg?1",
             "name": "Tomb of Annihilation",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/AKH.json
+++ b/Assets/Resources/Sets/AKH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c2a33099-bf35-558d-aace-6cf79cb5c60a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1cbf0-1273-406a-bc99-ce20ce53e5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1cbf0-1273-406a-bc99-ce20ce53e5aa.jpg?1",
             "name": "Angel of Sanctions",
             "text": "Flying\nWhen Angel of Sanctions enters the battlefield, you may exile target nonland permanent an opponent controls until Angel of Sanctions leaves the battlefield.\nEmbalm {5}{W} ({5}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Angel with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "9b73cac8-070f-5fe6-82f9-0f0e22ff7ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52c265-6920-4929-ba0a-70da08df01f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52c265-6920-4929-ba0a-70da08df01f1.jpg?1",
             "name": "Anointed Procession",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "c6d9875e-b051-565a-b086-ecb59fb867ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f922231-bf41-47d3-8fa3-13b9baf4a0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f922231-bf41-47d3-8fa3-13b9baf4a0f3.jpg?1",
             "name": "Anointer Priest",
             "text": "Whenever a creature token enters the battlefield under your control, you gain 1 life.\nEmbalm {3}{W} ({3}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Cleric with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "82178cbf-23b5-504a-9354-52d8304efb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf59a6e-7708-45a1-884d-d12e9f7b9ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf59a6e-7708-45a1-884d-d12e9f7b9ed9.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "If Approach of the Second Sun was cast from your hand and you've cast another spell named Approach of the Second Sun this game, you win the game. Otherwise, put Approach of the Second Sun into its owner's library seventh from the top and you gain 7 life.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "c5b49b82-a868-5741-bc75-9210e38a8004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a50cc-fa16-42a4-b9f2-d8327e5d1bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a50cc-fa16-42a4-b9f2-d8327e5d1bb6.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "95fd40bf-5f44-5877-90fb-e76e5eb67842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae54072-ae27-4aae-a2b7-71f4551934f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae54072-ae27-4aae-a2b7-71f4551934f6.jpg?1",
             "name": "Binding Mummy",
             "text": "Whenever another Zombie enters the battlefield under your control, you may tap target artifact or creature.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "332a0db5-a42f-5fdb-8567-20725f1449de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eaf94e-85a7-4958-aa58-8e2fe44db58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eaf94e-85a7-4958-aa58-8e2fe44db58d.jpg?1",
             "name": "Cartouche of Solidarity",
             "text": "Enchant creature you control\nWhen Cartouche of Solidarity enters the battlefield, create a 1/1 white Warrior creature token with vigilance.\nEnchanted creature gets +1/+1 and has first strike.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "3cb49aaa-3869-583f-a354-b41065798dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ff0dd0-489e-4773-93f6-b77fc3b8ef2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ff0dd0-489e-4773-93f6-b77fc3b8ef2e.jpg?1",
             "name": "Cast Out",
             "text": "Flash\nWhen Cast Out enters the battlefield, exile target nonland permanent an opponent controls until Cast Out leaves the battlefield.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "fb3fccf7-76be-5f2c-a4cb-0479c1071bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cb3a5b-beee-4f53-a6b5-e9b5603546fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cb3a5b-beee-4f53-a6b5-e9b5603546fa.jpg?1",
             "name": "Compulsory Rest",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"{2}, Sacrifice this creature: You gain 2 life.\"",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "76963fc6-e573-51ef-9ca7-9e9c130c74d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3677f10-b530-4606-b7c8-a72dd2131160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3677f10-b530-4606-b7c8-a72dd2131160.jpg?1",
             "name": "Devoted Crop-Mate",
             "text": "You may exert Devoted Crop-Mate as it attacks. When you do, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "96ba344c-00bd-5832-aa69-2156a464bdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad60ebb9-4acc-41a8-90d9-04d55e414ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad60ebb9-4acc-41a8-90d9-04d55e414ed1.jpg?1",
             "name": "Djeru's Resolve",
             "text": "Untap target creature. Prevent all damage that would be dealt to it this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "71eb6d19-3d57-5181-8fc3-972e431dbb40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cec477-f86f-4ccf-aa57-b6b7ade46eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cec477-f86f-4ccf-aa57-b6b7ade46eed.jpg?1",
             "name": "Fan Bearer",
             "text": "{2}, {T}: Tap target creature.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "99e89213-dd32-5166-a6bf-70571fbf41b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca4e95e-f14e-4cfa-918a-cfb15f912293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca4e95e-f14e-4cfa-918a-cfb15f912293.jpg?1",
             "name": "Forsake the Worldly",
             "text": "Exile target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -440,7 +440,7 @@
         },
         {
             "id": "e3c7bcc3-5545-541e-b3ef-f32f15053735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ce13f-519f-4472-bbd1-f26a972723d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ce13f-519f-4472-bbd1-f26a972723d7.jpg?1",
             "name": "Gideon of the Trials",
             "text": "+1: Until your next turn, prevent all damage target permanent would deal.\n0: Until end of turn, Gideon of the Trials becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n0: You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\"",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "36322139-3574-5789-9e7e-23c42ea92e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2524fb-ec90-4f8e-b851-f78034edef3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2524fb-ec90-4f8e-b851-f78034edef3f.jpg?1",
             "name": "Gideon's Intervention",
             "text": "As Gideon's Intervention enters the battlefield, choose a card name.\nYour opponents can't cast spells with the chosen name.\nPrevent all damage that would be dealt to you and permanents you control by sources with the chosen name.",
             "colours": [
@@ -508,7 +508,7 @@
         },
         {
             "id": "ccbf43c8-f296-5989-b81f-d7637dc72c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e23a06-4ed3-4948-aca5-fbdda03f4f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e23a06-4ed3-4948-aca5-fbdda03f4f2a.jpg?1",
             "name": "Glory-Bound Initiate",
             "text": "You may exert Glory-Bound Initiate as it attacks. When you do, it gets +1/+3 and gains lifelink until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "c5c0d76d-90a0-5b21-b73a-10de83a321c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49307ab6-392e-4b61-ad60-e6ea53da39f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49307ab6-392e-4b61-ad60-e6ea53da39f7.jpg?1",
             "name": "Gust Walker",
             "text": "You may exert Gust Walker as it attacks. When you do, it gets +1/+1 and gains flying until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "fe7b4a74-be76-5f96-91f2-ffa4dbc354d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98cee1e-64d8-4662-a911-009b031dc888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98cee1e-64d8-4662-a911-009b031dc888.jpg?1",
             "name": "Impeccable Timing",
             "text": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "fe848efd-88ca-52bf-8b09-046972865b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf535ef-79ee-4a31-a614-f6c77fea72b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf535ef-79ee-4a31-a614-f6c77fea72b5.jpg?1",
             "name": "In Oketra's Name",
             "text": "Zombies you control get +2/+1 until end of turn. Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "6d5c6b78-4376-575c-b2d9-b86cc3f016f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13692658-051b-44ea-bc23-aa33ce6385d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13692658-051b-44ea-bc23-aa33ce6385d3.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -674,7 +674,7 @@
         },
         {
             "id": "aae892ba-cd35-549d-bc99-9e21ec77d422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cc79cf-d4db-4236-b3e2-fd12662b2a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cc79cf-d4db-4236-b3e2-fd12662b2a74.jpg?1",
             "name": "Oketra the True",
             "text": "Double strike, indestructible\nOketra the True can't attack or block unless you control at least three other creatures.\n{3}{W}: Create a 1/1 white Warrior creature token with vigilance.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "a902baac-4c88-597c-bfcb-51606aae6b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6074fe64-8a2d-411e-8d33-97b1c60633e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6074fe64-8a2d-411e-8d33-97b1c60633e4.jpg?1",
             "name": "Oketra's Attendant",
             "text": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)\nEmbalm {3}{W}{W} ({3}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Soldier with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "e5dd9049-3459-5957-a2a3-e206662ffd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d01e04-7c40-4af0-b5bd-5fa267d10378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d01e04-7c40-4af0-b5bd-5fa267d10378.jpg?1",
             "name": "Protection of the Hekma",
             "text": "If a source an opponent controls would deal damage to you, prevent 1 of that damage.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "ad861664-559c-5293-a04b-e78ec2f6260f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd349f95-3eae-4ef2-abf8-e911bb8e93e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd349f95-3eae-4ef2-abf8-e911bb8e93e5.jpg?1",
             "name": "Regal Caracal",
             "text": "Other Cats you control get +1/+1 and have lifelink.\nWhen Regal Caracal enters the battlefield, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "4e88a28d-3da0-55d9-85bd-a9963f80265f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08abfd48-abd5-4b91-bcac-745b76aeb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08abfd48-abd5-4b91-bcac-745b76aeb775.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "96b26caf-3f6b-5b39-aefd-440f2b4c210c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcfc2d3-8719-4ba1-b4c5-b2f8f6bab634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcfc2d3-8719-4ba1-b4c5-b2f8f6bab634.jpg?1",
             "name": "Rhet-Crop Spearmaster",
             "text": "You may exert Rhet-Crop Spearmaster as it attacks. When you do, it gets +1/+0 and gains first strike until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "f377cbcf-5dbc-5b11-82f8-40f6ad3b52e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08891c78-13c1-4d84-aa9c-78346b3b7d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08891c78-13c1-4d84-aa9c-78346b3b7d18.jpg?1",
             "name": "Sacred Cat",
             "text": "Lifelink\nEmbalm {W} ({W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Cat with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "a11eed8e-90f4-5b1e-bdf1-94260eaa9772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dc4ed8-4674-44a1-8a06-ecce72c85e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dc4ed8-4674-44a1-8a06-ecce72c85e60.jpg?1",
             "name": "Seraph of the Suns",
             "text": "Flying\nIndestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "030a7cfc-af3f-5f1b-b5e6-c093e85ab35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec1587-0405-4b4d-96b5-1ac2c5a7c9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec1587-0405-4b4d-96b5-1ac2c5a7c9dc.jpg?1",
             "name": "Sparring Mummy",
             "text": "When Sparring Mummy enters the battlefield, untap target creature.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "5a25b6d6-a640-5aa4-ba99-183736aad45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d247bd88-9593-462c-8f9e-28e29c064c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d247bd88-9593-462c-8f9e-28e29c064c10.jpg?1",
             "name": "Supply Caravan",
             "text": "When Supply Caravan enters the battlefield, if you control a tapped creature, create a 1/1 white Warrior creature token with vigilance.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "f349dfe0-3d94-5acc-bca7-9d1a7a36cc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8dda75-a196-47bc-98d8-522eb35e7d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8dda75-a196-47bc-98d8-522eb35e7d1a.jpg?1",
             "name": "Tah-Crop Elite",
             "text": "Flying\nYou may exert Tah-Crop Elite as it attacks. When you do, creatures you control get +1/+1 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "dec041c3-42ab-5f10-9847-a74642b6cdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f27dd9-7ee4-4cdc-8f65-a4349b6aa47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f27dd9-7ee4-4cdc-8f65-a4349b6aa47f.jpg?1",
             "name": "Those Who Serve",
             "text": "",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "da164767-d036-5634-a102-dfdf001611a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60ec4f7-7cf1-4b97-906b-536ab89b12be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60ec4f7-7cf1-4b97-906b-536ab89b12be.jpg?1",
             "name": "Time to Reflect",
             "text": "Exile target creature that blocked or was blocked by a Zombie this turn.",
             "colours": [
@@ -1115,7 +1115,7 @@
         },
         {
             "id": "5440b2f4-9dc7-5538-bbe7-2dbc149f4c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2604d43-a105-440b-86b1-60d1d0c04339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2604d43-a105-440b-86b1-60d1d0c04339.jpg?1",
             "name": "Trial of Solidarity",
             "text": "When Trial of Solidarity enters the battlefield, creatures you control get +2/+1 and gain vigilance until end of turn.\nWhen a Cartouche enters the battlefield under your control, return Trial of Solidarity to its owner's hand.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "e9ff496f-3677-5548-9471-ef7b9f562e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628f5230-6c0d-4f24-b89a-7f3d443511f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628f5230-6c0d-4f24-b89a-7f3d443511f3.jpg?1",
             "name": "Trueheart Duelist",
             "text": "Trueheart Duelist can block an additional creature each combat.\nEmbalm {2}{W} ({2}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "96db7e3b-d6e2-5016-922d-a169cb56bcc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73fe35-68d6-4882-aeab-5c1e7b97b938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73fe35-68d6-4882-aeab-5c1e7b97b938.jpg?1",
             "name": "Unwavering Initiate",
             "text": "Vigilance\nEmbalm {4}{W} ({4}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "9233e310-1c11-5d02-8125-e6d89e8bcbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684f2e5-e3f9-4277-94a1-aba6913ac53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684f2e5-e3f9-4277-94a1-aba6913ac53b.jpg?1",
             "name": "Vizier of Deferment",
             "text": "Flash\nWhen Vizier of Deferment enters the battlefield, you may exile target creature if it attacked or blocked this turn. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "77a316ec-bd8a-5c4a-bbf6-20042f1ea6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ab760e-93e0-4dbc-aaa1-02316f62ed3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ab760e-93e0-4dbc-aaa1-02316f62ed3f.jpg?1",
             "name": "Vizier of Remedies",
             "text": "If one or more -1/-1 counters would be put on a creature you control, that many -1/-1 counters minus one are put on it instead.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "1dadec4d-18b0-5483-bf20-68c419ab9600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04301470-82d9-43c7-aaf1-a41e185cb109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04301470-82d9-43c7-aaf1-a41e185cb109.jpg?1",
             "name": "Winged Shepherd",
             "text": "Flying, vigilance\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "da3bf502-5014-5f7d-9000-eea73db91fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2ca68b-15fb-4691-b549-268df92ca413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2ca68b-15fb-4691-b549-268df92ca413.jpg?1",
             "name": "Ancient Crab",
             "text": "",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "59720bf9-6333-56a2-bb6f-23b6dd87ed3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14c753e-c5bf-4c34-b408-ac367b6ca6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14c753e-c5bf-4c34-b408-ac367b6ca6ab.jpg?1",
             "name": "Angler Drake",
             "text": "Flying\nWhen Angler Drake enters the battlefield, you may return target creature to its owner's hand.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "7795998a-9626-50ef-b52c-62a1d9c292d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f91d225-788e-42fc-9d01-8668f672b717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f91d225-788e-42fc-9d01-8668f672b717.jpg?1",
             "name": "As Foretold",
             "text": "At the beginning of your upkeep, put a time counter on As Foretold.\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast with converted mana cost X or less, where X is the number of time counters on As Foretold.",
             "colours": [
@@ -1421,7 +1421,7 @@
         },
         {
             "id": "82061a2f-26c0-5df1-a0a1-c8e3066db42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61203781-24ad-4bc9-9b69-97149f3043bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61203781-24ad-4bc9-9b69-97149f3043bc.jpg?1",
             "name": "Aven Initiate",
             "text": "Flying\nEmbalm {6}{U} ({6}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "6517ce7c-7b98-53b9-bd4c-41ce66d55bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7258e651-868a-4f63-9454-6c6c95d25387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7258e651-868a-4f63-9454-6c6c95d25387.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "baa6116a-3d95-5dc3-af8d-a82ab0eaf680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d806458e-81cd-4413-bba0-14d957bece79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d806458e-81cd-4413-bba0-14d957bece79.jpg?1",
             "name": "Cartouche of Knowledge",
             "text": "Enchant creature you control\nWhen Cartouche of Knowledge enters the battlefield, draw a card.\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "164da53b-655a-51b5-a19a-6b385e945ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb4e315-1a77-479a-9f15-fb23575de805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb4e315-1a77-479a-9f15-fb23575de805.jpg?1",
             "name": "Censor",
             "text": "Counter target spell unless its controller pays {1}.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1555,7 +1555,7 @@
         },
         {
             "id": "005aef37-8ff5-5483-857f-950295e056d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c35f4d5-2337-4ea0-a571-5a73e2d0d54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c35f4d5-2337-4ea0-a571-5a73e2d0d54a.jpg?1",
             "name": "Compelling Argument",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "7db99049-f10d-55ae-b39c-a43e6da89c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d11a24-8abf-46ff-8cc6-57b8ac3013f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d11a24-8abf-46ff-8cc6-57b8ac3013f6.jpg?1",
             "name": "Cryptic Serpent",
             "text": "Cryptic Serpent costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "9d0933d1-d7c8-5f69-8bfc-7531f2864db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16caa0b6-dba9-4f93-bf8d-3b339474cbf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16caa0b6-dba9-4f93-bf8d-3b339474cbf1.jpg?1",
             "name": "Curator of Mysteries",
             "text": "Flying\nWhenever you cycle or discard another card, scry 1.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "5bfe6f32-d1e0-5784-9b84-01873737273b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eb8d39-9eb8-4592-ab74-54cdc2460e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eb8d39-9eb8-4592-ab74-54cdc2460e62.jpg?1",
             "name": "Decision Paralysis",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "46cbf022-2f42-5fa6-8b7d-ac45a7eb901a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4318da9d-dadf-444b-a0d4-fd270b216f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4318da9d-dadf-444b-a0d4-fd270b216f5b.jpg?1",
             "name": "Drake Haven",
             "text": "Whenever you cycle or discard a card, you may pay {1}. If you do, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "0d03b2a6-3b2f-5e59-bcd0-66c6027bcc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e325e1-f1f9-4448-84e3-1fd929b0bc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e325e1-f1f9-4448-84e3-1fd929b0bc12.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "6c0f7682-30c2-5a32-a7d6-048ecc6bdba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a211df0-fe9e-4d2c-9e0e-c7be50e6b906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a211df0-fe9e-4d2c-9e0e-c7be50e6b906.jpg?1",
             "name": "Floodwaters",
             "text": "Return up to two target creatures to their owners' hands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "bff10aaf-ec1e-5b31-9725-ebd917af6987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe6633a-dee9-4840-9a18-ab4a511eb4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe6633a-dee9-4840-9a18-ab4a511eb4c4.jpg?1",
             "name": "Galestrike",
             "text": "Return target tapped creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "ac5c4243-1389-5783-9481-c9db6213ffa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2663738-1688-4306-be6d-6a1f94a2319c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2663738-1688-4306-be6d-6a1f94a2319c.jpg?1",
             "name": "Glyph Keeper",
             "text": "Flying\nWhenever Glyph Keeper becomes the target of a spell or ability for the first time each turn, counter that spell or ability.\nEmbalm {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Sphinx with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1849,7 +1849,7 @@
         },
         {
             "id": "eae49f2f-7d5a-570c-b461-e71224683997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7e690-e5f7-4d6e-b756-22aea959a612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7e690-e5f7-4d6e-b756-22aea959a612.jpg?1",
             "name": "Hekma Sentinels",
             "text": "Whenever you cycle or discard a card, Hekma Sentinels gets +1/+1 until end of turn.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "ed6348df-986b-5509-a286-5637ea73422c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a0e75-53bb-43e4-890f-0e1972a7e0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a0e75-53bb-43e4-890f-0e1972a7e0b9.jpg?1",
             "name": "Hieroglyphic Illumination",
             "text": "Draw two cards.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1916,7 +1916,7 @@
         },
         {
             "id": "88ee1d6d-07c3-53d5-9d59-410bb5ac2af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67aefde-2c91-4974-b89d-84333a2874eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67aefde-2c91-4974-b89d-84333a2874eb.jpg?1",
             "name": "Illusory Wrappings",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/2.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "c937b801-ba50-5506-bd7c-73a16aba7644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbda3b24-f2a6-4bcf-9a0a-bab69ffa8069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbda3b24-f2a6-4bcf-9a0a-bab69ffa8069.jpg?1",
             "name": "Kefnet the Mindful",
             "text": "Flying, indestructible\nKefnet the Mindful can't attack or block unless you have seven or more cards in hand.\n{3}{U}: Draw a card, then you may return a land you control to its owner's hand.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "995e3a1d-9bc4-5e8b-b328-59b8a74c93c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17921573-e3d1-45a7-b7e5-a27ae1fa3c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17921573-e3d1-45a7-b7e5-a27ae1fa3c2c.jpg?1",
             "name": "Labyrinth Guardian",
             "text": "When Labyrinth Guardian becomes the target of a spell, sacrifice it.\nEmbalm {3}{U} ({3}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Illusion Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "642d2955-88df-578b-888b-9d0d161a23fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0e741f-0448-4a95-9178-074356e50426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0e741f-0448-4a95-9178-074356e50426.jpg?1",
             "name": "Lay Claim",
             "text": "Enchant permanent\nYou control enchanted permanent.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "323f6f74-f5aa-5c9f-8f09-1121d495a701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9060b7b5-3ef1-443e-8f8a-450cc42c43a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9060b7b5-3ef1-443e-8f8a-450cc42c43a6.jpg?1",
             "name": "Naga Oracle",
             "text": "When Naga Oracle enters the battlefield, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "ab71fffa-100e-57cd-8fdc-fdd0611f01f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b5290-997d-44de-ac83-4bc9a9911858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b5290-997d-44de-ac83-4bc9a9911858.jpg?1",
             "name": "New Perspectives",
             "text": "When New Perspectives enters the battlefield, draw three cards.\nAs long as you have seven or more cards in hand, you may pay {0} rather than pay cycling costs.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "502323b5-12d5-5312-843e-8d42fe639cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df4db1e-f2a7-44e7-9b8d-fecf73d1e01c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df4db1e-f2a7-44e7-9b8d-fecf73d1e01c.jpg?1",
             "name": "Open into Wonder",
             "text": "X target creatures can't be blocked this turn. Until end of turn, those creatures gain \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "996d1bc9-e4e7-581b-b1b2-17335e263f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1eccf27-c934-45fb-87ae-67006cd4e0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1eccf27-c934-45fb-87ae-67006cd4e0ed.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "72b1d05a-f36f-5c64-92d8-9d16413e496d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89500ba-8256-4002-a9f2-62d529e9886b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89500ba-8256-4002-a9f2-62d529e9886b.jpg?1",
             "name": "River Serpent",
             "text": "River Serpent can't attack unless there are five or more cards in your graveyard.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "776621e6-810e-5c69-8414-c8d4998b878f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc2ab27-0f68-480c-99c9-53243c1ab0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc2ab27-0f68-480c-99c9-53243c1ab0ac.jpg?1",
             "name": "Sacred Excavation",
             "text": "Return up to two target cards with cycling from your graveyard to your hand.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "bb1562d6-544c-5034-b963-2c6f2793c6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ffaefe-1b9e-418d-9760-b7d546f03542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ffaefe-1b9e-418d-9760-b7d546f03542.jpg?1",
             "name": "Scribe of the Mindful",
             "text": "{1}, {T}, Sacrifice Scribe of the Mindful: Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "aa86b45a-b297-5fc4-9e97-c4dec9eeb652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0b7bfc-f126-4885-a663-6f8dcc52e663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0b7bfc-f126-4885-a663-6f8dcc52e663.jpg?1",
             "name": "Seeker of Insight",
             "text": "{T}: Draw a card, then discard a card. Activate this ability only if you've cast a noncreature spell this turn.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "93b78fbe-8961-5ea6-a4dd-360e2b3d64ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb13075-0ea0-480a-84c0-8eec3119db45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb13075-0ea0-480a-84c0-8eec3119db45.jpg?1",
             "name": "Shimmerscale Drake",
             "text": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "fdc3e63f-c755-5a0a-85dc-4a013b2e8f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf067e-4d76-4676-85fa-ebfb0755440a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf067e-4d76-4676-85fa-ebfb0755440a.jpg?1",
             "name": "Slither Blade",
             "text": "Slither Blade can't be blocked.",
             "colours": [
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "52f64f13-6a66-5631-a80b-b5de2f26340c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0429ec-0809-4e68-9790-8c21bde201a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0429ec-0809-4e68-9790-8c21bde201a2.jpg?1",
             "name": "Tah-Crop Skirmisher",
             "text": "Embalm {3}{U} ({3}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Naga Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "2c38b0a0-178a-5a87-a4f5-5716697ad272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89020c72-4cda-4634-8475-6d16a02236f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89020c72-4cda-4634-8475-6d16a02236f1.jpg?1",
             "name": "Trial of Knowledge",
             "text": "When Trial of Knowledge enters the battlefield, draw three cards, then discard a card.\nWhen a Cartouche enters the battlefield under your control, return Trial of Knowledge to its owner's hand.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "079aa73f-980c-553e-8644-c6e4b98162c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2781c44-aa90-4a37-a812-33c643ba4deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2781c44-aa90-4a37-a812-33c643ba4deb.jpg?1",
             "name": "Vizier of Many Faces",
             "text": "You may have Vizier of Many Faces enter the battlefield as a copy of any creature on the battlefield, except if Vizier of Many Faces was embalmed, the token has no mana cost, it's white, and it's a Zombie in addition to its other types.\nEmbalm {3}{U}{U}",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "fbc11c7a-07be-5326-99be-9608900baf30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ff0f5-abee-4f3e-89ae-1b7ee771ec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ff0f5-abee-4f3e-89ae-1b7ee771ec68.jpg?1",
             "name": "Vizier of Tumbling Sands",
             "text": "{T}: Untap another target permanent.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Vizier of Tumbling Sands, untap target permanent.",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "30d5ad6b-6404-5c1a-aebe-358ee34c4145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2718457-1e3b-48bc-99fe-2300277ee1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2718457-1e3b-48bc-99fe-2300277ee1e0.jpg?1",
             "name": "Winds of Rebuke",
             "text": "Return target nonland permanent to its owner's hand. Each player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "cba6ac44-b847-5df4-8cdb-584fcbfa3f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b711b5-aeec-47c4-a718-6bf43e561944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b711b5-aeec-47c4-a718-6bf43e561944.jpg?1",
             "name": "Zenith Seeker",
             "text": "Flying\nWhenever you cycle or discard a card, target creature gains flying until end of turn.",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "8f3c761b-f380-5a21-86dd-6bb878d30018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33176679-d571-47a1-ae05-bed9b748491d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33176679-d571-47a1-ae05-bed9b748491d.jpg?1",
             "name": "Archfiend of Ifnir",
             "text": "Flying\nWhenever you cycle or discard another card, put a -1/-1 counter on each creature your opponents control.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "3f39981b-6475-546c-9047-8f52ede1d8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb662d58-ae50-423d-b1c5-abd45baca12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb662d58-ae50-423d-b1c5-abd45baca12b.jpg?1",
             "name": "Baleful Ammit",
             "text": "Lifelink\nWhen Baleful Ammit enters the battlefield, put a -1/-1 counter on target creature you control.",
             "colours": [
@@ -2664,7 +2664,7 @@
         },
         {
             "id": "92ce39fc-734f-5f08-b6d0-8069dceca0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da308e9-1862-46c1-a62a-90720b484d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da308e9-1862-46c1-a62a-90720b484d91.jpg?1",
             "name": "Blighted Bat",
             "text": "Flying\n{1}: Blighted Bat gains haste until end of turn.",
             "colours": [
@@ -2699,7 +2699,7 @@
         },
         {
             "id": "dad332dd-d57a-57f6-80aa-abfe5b98b5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6a825-43f7-40a4-95f0-335dc538b6cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6a825-43f7-40a4-95f0-335dc538b6cd.jpg?1",
             "name": "Bone Picker",
             "text": "Bone Picker costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "952ca62d-4d6f-5270-ad1a-b35cf48abd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07386-909f-4946-9120-3acb58622e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07386-909f-4946-9120-3acb58622e2f.jpg?1",
             "name": "Bontu the Glorified",
             "text": "Menace, indestructible\nBontu the Glorified can't attack or block unless a creature died under your control this turn.\n{1}{B}, Sacrifice another creature: Scry 1. Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "503ac325-e50a-5cfb-a113-1265db00e8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b96b1-b75e-4ee1-a6d7-6545a34fef9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b96b1-b75e-4ee1-a6d7-6545a34fef9b.jpg?1",
             "name": "Cartouche of Ambition",
             "text": "Enchant creature you control\nWhen Cartouche of Ambition enters the battlefield, you may put a -1/-1 counter on target creature.\nEnchanted creature gets +1/+1 and has lifelink.",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "692d8686-73df-51fe-8258-8d8642bd007d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a91cf5-4eab-4d9b-90bd-fb933bb00540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a91cf5-4eab-4d9b-90bd-fb933bb00540.jpg?1",
             "name": "Cruel Reality",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player sacrifices a creature or planeswalker. If the player can't, he or she loses 5 life.",
             "colours": [
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "b22d3025-1aa5-57ce-8d61-216a35d8927c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3990d2f-39d9-49f9-936f-1d40adcf295c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3990d2f-39d9-49f9-936f-1d40adcf295c.jpg?1",
             "name": "Cursed Minotaur",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2874,7 +2874,7 @@
         },
         {
             "id": "4ed5df52-a63e-573c-9002-873710159ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb88be3-f790-45d7-a6d1-c78f6ba00208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb88be3-f790-45d7-a6d1-c78f6ba00208.jpg?1",
             "name": "Dispossess",
             "text": "Choose an artifact card name. Search target opponent's graveyard, hand, and library for any number of cards with the chosen name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "2d932232-5d1f-5fb5-aff0-ed3eccfe6b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "747d5ce9-b2f3-5c64-8f84-41b85ca75982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343fc82d-7d10-4489-8f7e-9995322114e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343fc82d-7d10-4489-8f7e-9995322114e2.jpg?1",
             "name": "Dread Wanderer",
             "text": "Dread Wanderer enters the battlefield tapped.\n{2}{B}: Return Dread Wanderer from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery and only if you have one or fewer cards in hand.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "62f9d4d5-7005-5a29-a87c-26419acd2ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cb904-c725-4d57-bc17-7aa87a7cd8e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cb904-c725-4d57-bc17-7aa87a7cd8e0.jpg?1",
             "name": "Dune Beetle",
             "text": "",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "79606c89-ebf4-53a8-9761-3f3433b063d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26e0e0-d157-4d63-bebe-b02d208c5572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26e0e0-d157-4d63-bebe-b02d208c5572.jpg?1",
             "name": "Faith of the Devoted",
             "text": "Whenever you cycle or discard a card, you may pay {1}. If you do, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "8d486592-aea9-5693-a2c9-f966a6eb5167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906c4c95-5815-44c8-8d3c-b0fda9db55a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906c4c95-5815-44c8-8d3c-b0fda9db55a1.jpg?1",
             "name": "Festering Mummy",
             "text": "When Festering Mummy dies, you may put a -1/-1 counter on target creature.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "1c3e9ad8-27ff-5b24-9b45-6b0cfef1dcdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f202f6b-710f-4376-a49c-e5f135b26eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f202f6b-710f-4376-a49c-e5f135b26eaf.jpg?1",
             "name": "Final Reward",
             "text": "Exile target creature.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "3a72e135-4ed8-564d-ae62-e46becdd15da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606f1ce-afeb-4fc5-bd4c-2484cd232924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606f1ce-afeb-4fc5-bd4c-2484cd232924.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "f63f4a78-3882-5817-92e5-698ebf09c9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ae6769-2b2b-48e3-9503-e9744984743a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ae6769-2b2b-48e3-9503-e9744984743a.jpg?1",
             "name": "Grim Strider",
             "text": "Grim Strider gets -1/-1 for each card in your hand.",
             "colours": [
@@ -3175,7 +3175,7 @@
         },
         {
             "id": "1f6c8446-6c59-516a-9474-a4c9de2aeb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35828576-124a-45d6-ad4c-af2926314953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35828576-124a-45d6-ad4c-af2926314953.jpg?1",
             "name": "Horror of the Broken Lands",
             "text": "Whenever you cycle or discard another card, Horror of the Broken Lands gets +2/+1 until end of turn.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "26df36e6-21ac-588c-9c61-3ee13f463a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b76ff8-b26c-4567-9339-bb6a37713f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b76ff8-b26c-4567-9339-bb6a37713f4b.jpg?1",
             "name": "Lay Bare the Heart",
             "text": "Target opponent reveals his or her hand. You choose a nonlegendary, nonland card from it. That player discards that card.",
             "colours": [
@@ -3241,7 +3241,7 @@
         },
         {
             "id": "e9b3f7f3-acaa-54b2-a8b5-599991e1e57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d8f490-f04d-4d59-9ab0-a977527fd529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d8f490-f04d-4d59-9ab0-a977527fd529.jpg?1",
             "name": "Liliana, Death's Majesty",
             "text": "+1: Create a 2/2 black Zombie creature token. Put the top two cards of your library into your graveyard.\n\u22123: Return target creature card from your graveyard to the battlefield. That creature is a black Zombie in addition to its other colors and types.\n\u22127: Destroy all non-Zombie creatures.",
             "colours": [
@@ -3277,7 +3277,7 @@
         },
         {
             "id": "2cb71270-7f90-5164-a813-b716015c1caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c57b3b8-71f1-479c-b7f7-508fee2b5b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c57b3b8-71f1-479c-b7f7-508fee2b5b0f.jpg?1",
             "name": "Liliana's Mastery",
             "text": "Zombies you control get +1/+1.\nWhen Liliana's Mastery enters the battlefield, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "200526e9-8753-56d2-8d72-4841c768f8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941562d-3e39-4746-9a18-d3aa6d3468b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941562d-3e39-4746-9a18-d3aa6d3468b0.jpg?1",
             "name": "Lord of the Accursed",
             "text": "Other Zombies you control get +1/+1.\n{1}{B}, {T}: All Zombies gain menace until end of turn.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "42c85bf2-7d42-5f63-8b5d-919dc9330a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ef9e66-678c-4e8d-9ca7-3f2b72b9468c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ef9e66-678c-4e8d-9ca7-3f2b72b9468c.jpg?1",
             "name": "Miasmic Mummy",
             "text": "When Miasmic Mummy enters the battlefield, each player discards a card.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "06c9712f-5dc5-5662-98a2-8034a69eef85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa6b45-055a-411e-b2db-b373a4d3826d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa6b45-055a-411e-b2db-b373a4d3826d.jpg?1",
             "name": "Nest of Scarabs",
             "text": "Whenever you put one or more -1/-1 counters on a creature, create that many 1/1 black Insect creature tokens.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "1f4cd12f-9623-5f52-99c8-b0e6d87abe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becbd481-311d-4f85-aacd-df1f7d7ef587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becbd481-311d-4f85-aacd-df1f7d7ef587.jpg?1",
             "name": "Painful Lesson",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "5f843823-994b-5df3-93a0-7bb472d079aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eb0615-d1b2-4128-bad5-bcff83672f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eb0615-d1b2-4128-bad5-bcff83672f6b.jpg?1",
             "name": "Pitiless Vizier",
             "text": "Whenever you cycle or discard a card, Pitiless Vizier gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "0dfbe265-9114-5b35-a06e-632a81cb5c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280ae211-f025-4971-83e6-118ca08a1911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280ae211-f025-4971-83e6-118ca08a1911.jpg?1",
             "name": "Plague Belcher",
             "text": "Menace\nWhen Plague Belcher enters the battlefield, put two -1/-1 counters on target creature you control.\nWhenever another Zombie you control dies, each opponent loses 1 life.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "ba7fd652-bb94-50a2-9999-132b5e32c948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d916306a-5cb3-4a38-9038-a433525c5b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d916306a-5cb3-4a38-9038-a433525c5b7b.jpg?1",
             "name": "Ruthless Sniper",
             "text": "Whenever you cycle or discard a card, you may pay {1}. If you do, put a -1/-1 counter on target creature.",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "0005f481-f2d4-53fa-ba37-cfcf5a5f87f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7540895c-cbbc-46ac-ba96-882628358865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7540895c-cbbc-46ac-ba96-882628358865.jpg?1",
             "name": "Scarab Feast",
             "text": "Exile up to three target cards from a single graveyard.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "0e155b44-c358-5233-afdd-4b5a5c001baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0205cb-c163-4332-9624-394e1024bf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0205cb-c163-4332-9624-394e1024bf6a.jpg?1",
             "name": "Shadow of the Grave",
             "text": "Return to your hand all cards in your graveyard that you cycled or discarded this turn.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "bedeb789-ef10-55d4-8b25-613426676893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0504be31-eaab-4b3e-8cfb-274e46d3d67a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0504be31-eaab-4b3e-8cfb-274e46d3d67a.jpg?1",
             "name": "Soulstinger",
             "text": "When Soulstinger enters the battlefield, put two -1/-1 counters on target creature you control.\nWhen Soulstinger dies, you may put a -1/-1 counter on target creature for each -1/-1 counter on Soulstinger.",
             "colours": [
@@ -3646,7 +3646,7 @@
         },
         {
             "id": "b379037b-798b-5b47-8d0d-737a9238262d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d38abd-116d-4015-91e4-3fc267ad099d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d38abd-116d-4015-91e4-3fc267ad099d.jpg?1",
             "name": "Splendid Agony",
             "text": "Distribute two -1/-1 counters among one or two target creatures.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "53473058-9745-53a1-b7cc-71826e3a98a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb84193-9648-46e5-a34d-c12cc3f1d7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb84193-9648-46e5-a34d-c12cc3f1d7f2.jpg?1",
             "name": "Stir the Sands",
             "text": "Create three 2/2 black Zombie creature tokens.\nCycling {3}{B} ({3}{B}, Discard this card: Draw a card.)\nWhen you cycle Stir the Sands, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "d8f89a91-587a-5b20-8cf0-90636cd81d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cac5753-54e7-45a8-b486-4860533ce93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cac5753-54e7-45a8-b486-4860533ce93c.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "4c9f6b90-d443-5b29-b13e-1bdfb8925e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef4c59-ab84-4d84-b795-015b21ae3fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef4c59-ab84-4d84-b795-015b21ae3fe0.jpg?1",
             "name": "Trespasser's Curse",
             "text": "Enchant player\nWhenever a creature enters the battlefield under enchanted player's control, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "64b2cc0c-f1e0-51a4-8ea1-f57761b32934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1e79b7-931d-49bf-8c2c-d42c55a93c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1e79b7-931d-49bf-8c2c-d42c55a93c74.jpg?1",
             "name": "Trial of Ambition",
             "text": "When Trial of Ambition enters the battlefield, target opponent sacrifices a creature.\nWhen a Cartouche enters the battlefield under your control, return Trial of Ambition to its owner's hand.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "11725a41-f9b7-5e8c-8583-f125748db4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d81da3-dc88-4cf7-ab9a-c8ade2cfa0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d81da3-dc88-4cf7-ab9a-c8ade2cfa0e1.jpg?1",
             "name": "Unburden",
             "text": "Target player discards two cards.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "70968a28-1e8e-5293-b75d-cb4150899c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea7ad5c-d9b9-4b12-90dd-c02399d73b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea7ad5c-d9b9-4b12-90dd-c02399d73b26.jpg?1",
             "name": "Wander in Death",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "2dd79a90-2e31-5396-988d-26d42ae47399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bab1782-498c-40fc-bf2e-5c991d0c3501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bab1782-498c-40fc-bf2e-5c991d0c3501.jpg?1",
             "name": "Wasteland Scorpion",
             "text": "Deathtouch\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "c4568563-ee1d-5410-a320-125786944f37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5db68c-24d5-44ce-9809-e446f26fac5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5db68c-24d5-44ce-9809-e446f26fac5d.jpg?1",
             "name": "Ahn-Crop Crasher",
             "text": "Haste\nYou may exert Ahn-Crop Crasher as it attacks. When you do, target creature can't block this turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -3942,7 +3942,7 @@
         },
         {
             "id": "f882d34b-9b47-575a-a80d-64e004427bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb1a40-8239-4544-96a1-a4acaf7e2054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb1a40-8239-4544-96a1-a4acaf7e2054.jpg?1",
             "name": "Battlefield Scavenger",
             "text": "You may exert Battlefield Scavenger as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "ce356909-1daf-5df2-9265-8d305759a75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba450179-4591-4e8a-b6ca-66cbef1817f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba450179-4591-4e8a-b6ca-66cbef1817f2.jpg?1",
             "name": "Blazing Volley",
             "text": "Blazing Volley deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "13a091b1-8327-56c2-90b9-e1fe586850a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cd0757-1b06-4e1b-a236-31271bd0d9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cd0757-1b06-4e1b-a236-31271bd0d9a3.jpg?1",
             "name": "Bloodlust Inciter",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4044,7 +4044,7 @@
         },
         {
             "id": "8758ea0c-ff14-5a34-b206-221198c5ce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6080f9e-2415-4e05-97a1-0fe4ad4fdf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6080f9e-2415-4e05-97a1-0fe4ad4fdf3b.jpg?1",
             "name": "Bloodrage Brawler",
             "text": "When Bloodrage Brawler enters the battlefield, discard a card.",
             "colours": [
@@ -4079,7 +4079,7 @@
         },
         {
             "id": "91110dcb-704a-580c-9f89-9a8127275694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7bd68d-02eb-44ec-955f-08b328e1b6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7bd68d-02eb-44ec-955f-08b328e1b6d3.jpg?1",
             "name": "Brute Strength",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "d1635228-e8f6-56c0-9f4a-014a349cfb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cdfdb2-b47f-446d-9850-8581bd1d806c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cdfdb2-b47f-446d-9850-8581bd1d806c.jpg?1",
             "name": "By Force",
             "text": "Destroy X target artifacts.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "6a2dab65-1b9a-51db-84e3-7a338b28ca4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09b2d9-b944-480b-93f9-76fc9bc319ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09b2d9-b944-480b-93f9-76fc9bc319ce.jpg?1",
             "name": "Cartouche of Zeal",
             "text": "Enchant creature you control\nWhen Cartouche of Zeal enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "c3a83ff8-a54d-54c1-ae07-165ff654036d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b63c3d-2e55-4343-b49a-11fa602ec473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b63c3d-2e55-4343-b49a-11fa602ec473.jpg?1",
             "name": "Combat Celebrant",
             "text": "If Combat Celebrant hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4213,7 +4213,7 @@
         },
         {
             "id": "86aa0619-3589-555f-95a4-a7224e06739c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529d230-89b0-453b-987b-a47e15bc3830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529d230-89b0-453b-987b-a47e15bc3830.jpg?1",
             "name": "Consuming Fervor",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has \"At the beginning of your upkeep, put a -1/-1 counter on this creature.\"",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "d337ad6c-7737-5500-b63b-c0e8bfcffdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2ed5f-62b8-4308-a656-f273f62f6ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2ed5f-62b8-4308-a656-f273f62f6ab8.jpg?1",
             "name": "Deem Worthy",
             "text": "Deem Worthy deals 7 damage to target creature.\nCycling {3}{R} ({3}{R}, Discard this card: Draw a card.)\nWhen you cycle Deem Worthy, you may have it deal 2 damage to target creature.",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "c4060679-9d28-5b2a-a7e6-48eb7fc83fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047c2e5-8b3b-4c6b-91cf-3484f21e52f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047c2e5-8b3b-4c6b-91cf-3484f21e52f0.jpg?1",
             "name": "Desert Cerodon",
             "text": "Cycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "b415d4b8-1587-57be-8440-53a338192cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c67128-2e5a-4c97-b265-6f3c73b4997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c67128-2e5a-4c97-b265-6f3c73b4997a.jpg?1",
             "name": "Electrify",
             "text": "Electrify deals 4 damage to target creature.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "07dd7930-b400-5dea-a310-a1d3cc9d0bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7aeca-eaba-4d9a-b061-0d9a63b03b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7aeca-eaba-4d9a-b061-0d9a63b03b3a.jpg?1",
             "name": "Emberhorn Minotaur",
             "text": "You may exert Emberhorn Minotaur as it attacks. When you do, it gets +1/+1 and gains menace until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "3c88ce22-77a6-5a1e-bab7-8820102d8705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f974d05a-3b31-4661-af18-58d87b76f19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f974d05a-3b31-4661-af18-58d87b76f19e.jpg?1",
             "name": "Flameblade Adept",
             "text": "Menace\nWhenever you cycle or discard a card, Flameblade Adept gets +1/+0 until end of turn.",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "ca5c7cb1-d5d3-5d39-b66e-6f6db1bba081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02363a7-4455-4571-bfff-4ce94c7c1e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02363a7-4455-4571-bfff-4ce94c7c1e3b.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -4447,7 +4447,7 @@
         },
         {
             "id": "faa7bb16-f96f-5515-b849-60e1a3d69c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2922b976-7beb-4c68-b39e-1b66d5c6f65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2922b976-7beb-4c68-b39e-1b66d5c6f65e.jpg?1",
             "name": "Glorious End",
             "text": "End the turn. (Exile all spells and abilities on the stack, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)\nAt the beginning of your next end step, you lose the game.",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "12854d7a-9434-5c46-b2ce-7dd4eac954d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3277ad99-5682-4baa-b106-de15721876a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3277ad99-5682-4baa-b106-de15721876a6.jpg?1",
             "name": "Glorybringer",
             "text": "Flying, haste\nYou may exert Glorybringer as it attacks. When you do, it deals 4 damage to target non-Dragon creature an opponent controls. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "19949cdb-ecfe-5cb7-b44d-416f3fbb8ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936bf9d-c973-4bce-b5c2-2a01b7953638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936bf9d-c973-4bce-b5c2-2a01b7953638.jpg?1",
             "name": "Harsh Mentor",
             "text": "Whenever an opponent activates an ability of an artifact, creature, or land on the battlefield, if it isn't a mana ability, Harsh Mentor deals 2 damage to that player.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "30e45bd0-8fa1-51bc-a968-443e225e0a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ed9f9d-99a7-49f4-b0ad-d71355809d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ed9f9d-99a7-49f4-b0ad-d71355809d32.jpg?1",
             "name": "Hazoret the Fervent",
             "text": "Indestructible, haste\nHazoret the Fervent can't attack or block unless you have one or fewer cards in hand.\n{2}{R}, Discard a card: Hazoret deals 2 damage to each opponent.",
             "colours": [
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "44e03ee8-7536-5603-b1c9-1d9fe0091587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b467412-c06b-4cd9-a877-7722051fb758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b467412-c06b-4cd9-a877-7722051fb758.jpg?1",
             "name": "Hazoret's Favor",
             "text": "At the beginning of combat on your turn, you may have target creature you control get +2/+0 and gain haste until end of turn. If you do, sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4616,7 +4616,7 @@
         },
         {
             "id": "cfce9dfc-6b1e-5d64-a360-14a8c7fd751c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64160a-96e0-4593-ba42-c5e8bbfa0b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64160a-96e0-4593-ba42-c5e8bbfa0b15.jpg?1",
             "name": "Heart-Piercer Manticore",
             "text": "When Heart-Piercer Manticore enters the battlefield, you may sacrifice another creature. When you do, Heart-Piercer Manticore deals damage equal to that creature's power to target creature or player.\nEmbalm {5}{R} ({5}{R}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Manticore with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "5a9e9993-1216-55cf-9c6d-ac6412009469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fa8351-567e-4ef4-8346-c58e50c778a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fa8351-567e-4ef4-8346-c58e50c778a6.jpg?1",
             "name": "Hyena Pack",
             "text": "",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "cb04f12f-81ab-5a51-a33a-0b451b4dab9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95cb6a18-1222-4e56-8466-0f7bd634ef3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95cb6a18-1222-4e56-8466-0f7bd634ef3d.jpg?1",
             "name": "Limits of Solidarity",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "1791de6f-2605-55b7-aee5-c58745283f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a7993-eb7d-4ae2-8a22-1676f517558b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a7993-eb7d-4ae2-8a22-1676f517558b.jpg?1",
             "name": "Magma Spray",
             "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "eb9f6dab-cf68-5f5f-a910-a553fbad85e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b6ece3-1574-4634-b940-829e54c4f78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b6ece3-1574-4634-b940-829e54c4f78d.jpg?1",
             "name": "Manticore of the Gauntlet",
             "text": "When Manticore of the Gauntlet enters the battlefield, put a -1/-1 counter on target creature you control. Manticore of the Gauntlet deals 3 damage to target opponent.",
             "colours": [
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "26b26cf2-df02-5561-83d7-1360fbc80a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777b98c3-d0b8-4ee3-9d89-e86344269ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777b98c3-d0b8-4ee3-9d89-e86344269ff1.jpg?1",
             "name": "Minotaur Sureshot",
             "text": "Reach (This creature can block creatures with flying.)\n{1}{R}: Minotaur Sureshot gets +1/+0 until end of turn.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "d14c9473-11dd-5407-8d0a-54846d5efcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96569dc0-ea94-4a43-b002-85c5066e5386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96569dc0-ea94-4a43-b002-85c5066e5386.jpg?1",
             "name": "Nef-Crop Entangler",
             "text": "Trample\nYou may exert Nef-Crop Entangler as it attacks. When you do, it gets +1/+2 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4852,7 +4852,7 @@
         },
         {
             "id": "3d676361-6155-593a-9e21-b418d31974a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36a17b-89d6-4de9-867b-9762afedb4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36a17b-89d6-4de9-867b-9762afedb4f1.jpg?1",
             "name": "Nimble-Blade Khenra",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "5f319a58-e0c7-558d-baa4-56c7f1511996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc6b34-aaa7-4ec1-9f37-b03f9b5919f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc6b34-aaa7-4ec1-9f37-b03f9b5919f2.jpg?1",
             "name": "Pathmaker Initiate",
             "text": "{T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "5b1e80dd-a9e0-5769-916f-36c0f8152d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5668ae2-fa74-47c9-877e-5326cac67659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5668ae2-fa74-47c9-877e-5326cac67659.jpg?1",
             "name": "Pursue Glory",
             "text": "Attacking creatures get +2/+0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "0db88cd3-9c93-5943-97b1-ec35d8493cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg?1",
             "name": "Soul-Scar Mage",
             "text": "Prowess\nIf a source you control would deal noncombat damage to a creature an opponent controls, put that many -1/-1 counters on that creature instead.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "922bd54f-c131-5eb5-a80e-1d9190dc726e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg?1",
             "name": "Sweltering Suns",
             "text": "Sweltering Suns deals 3 damage to each creature.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -5021,7 +5021,7 @@
         },
         {
             "id": "d6928a9c-b908-5cf6-ae22-f4e6b8a58370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642c5f4-4229-47c4-ac44-7feb5ee9cf9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642c5f4-4229-47c4-ac44-7feb5ee9cf9e.jpg?1",
             "name": "Thresher Lizard",
             "text": "Thresher Lizard gets +1/+2 as long as you have one or fewer cards in hand.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "128be3a1-6667-5baa-af15-0b718bd4e3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5fbcb-b1fb-4ded-a48d-4fcb501c6b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5fbcb-b1fb-4ded-a48d-4fcb501c6b68.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "5fe7c1b6-532d-5e0d-9205-b7446288bc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543539ce-af50-4bbe-82aa-f35fd2c2a256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543539ce-af50-4bbe-82aa-f35fd2c2a256.jpg?1",
             "name": "Trial of Zeal",
             "text": "When Trial of Zeal enters the battlefield, it deals 3 damage to target creature or player.\nWhen a Cartouche enters the battlefield under your control, return Trial of Zeal to its owner's hand.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "b0b44daa-4f68-5a82-9342-aba2935a5b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac510911-1a65-4509-b6c9-ddac1950c838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac510911-1a65-4509-b6c9-ddac1950c838.jpg?1",
             "name": "Trueheart Twins",
             "text": "You may exert Trueheart Twins as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "d7eb31ab-f719-5866-8f6c-fbdcf23719ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b8673a-ce93-4881-b712-8db82446d83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b8673a-ce93-4881-b712-8db82446d83c.jpg?1",
             "name": "Violent Impact",
             "text": "Destroy target artifact or land.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5186,7 +5186,7 @@
         },
         {
             "id": "d6439c71-c0fb-523e-885c-19bc4b655b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce75b3c-4f83-4c09-9361-d7463e4921e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce75b3c-4f83-4c09-9361-d7463e4921e6.jpg?1",
             "name": "Warfire Javelineer",
             "text": "When Warfire Javelineer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "a07d2923-c3ce-5237-ac63-9cf9e7d31ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc98fcdd-8482-4462-ab71-935cea48e409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc98fcdd-8482-4462-ab71-935cea48e409.jpg?1",
             "name": "Benefaction of Rhonas",
             "text": "Reveal the top five cards of your library. You may put a creature card and/or an enchantment card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "68168d37-a913-59e3-b644-d732fa18b0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54edbb-c35d-4f7f-b5ce-d39b0f766ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54edbb-c35d-4f7f-b5ce-d39b0f766ab8.jpg?1",
             "name": "Bitterblade Warrior",
             "text": "You may exert Bitterblade Warrior as it attacks. When you do, it gets +1/+0 and gains deathtouch until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -5288,7 +5288,7 @@
         },
         {
             "id": "b4480a77-6450-5869-934a-446634f249ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb237c-4e39-4879-90b4-2f507a90d3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb237c-4e39-4879-90b4-2f507a90d3d7.jpg?1",
             "name": "Cartouche of Strength",
             "text": "Enchant creature you control\nWhen Cartouche of Strength enters the battlefield, you may have enchanted creature fight target creature an opponent controls. (Each deals damage equal to its power to the other.)\nEnchanted creature gets +1/+1 and has trample.",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "eeb99780-406e-5b22-acf1-6dd8ee6c4fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b185b24d-ae33-48ca-966a-511627fdac6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b185b24d-ae33-48ca-966a-511627fdac6d.jpg?1",
             "name": "Champion of Rhonas",
             "text": "You may exert Champion of Rhonas as it attacks. When you do, you may put a creature card from your hand onto the battlefield. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -5358,7 +5358,7 @@
         },
         {
             "id": "d0cbff55-40eb-5d50-85d8-2376c181662b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef38c5a-07fc-477f-a1c0-70cc3ad64f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef38c5a-07fc-477f-a1c0-70cc3ad64f96.jpg?1",
             "name": "Channeler Initiate",
             "text": "When Channeler Initiate enters the battlefield, put three -1/-1 counters on target creature you control.\n{T}, Remove a -1/-1 counter from Channeler Initiate: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "d52be47f-a398-50e1-8d9d-14886b07d334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg?1",
             "name": "Colossapede",
             "text": "",
             "colours": [
@@ -5427,7 +5427,7 @@
         },
         {
             "id": "57ed2278-3c90-55f7-b058-6b5e79976cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f64ca9c-99c4-45d4-bd21-3ede61702250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f64ca9c-99c4-45d4-bd21-3ede61702250.jpg?1",
             "name": "Crocodile of the Crossing",
             "text": "Haste\nWhen Crocodile of the Crossing enters the battlefield, put a -1/-1 counter on target creature you control.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "6dd41a0e-bbfc-5f28-8cac-e84d40fae967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74cb0ba-c691-4823-aa94-399b1aaeaf0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74cb0ba-c691-4823-aa94-399b1aaeaf0b.jpg?1",
             "name": "Defiant Greatmaw",
             "text": "When Defiant Greatmaw enters the battlefield, put two -1/-1 counters on target creature you control.\nWhenever you put one or more -1/-1 counters on Defiant Greatmaw, remove a -1/-1 counter from another target creature you control.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "90e2aa2c-8d50-58a3-9ac7-55a0581566b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543eb854-bac7-468f-b3b0-d9987cfac318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543eb854-bac7-468f-b3b0-d9987cfac318.jpg?1",
             "name": "Dissenter's Deliverance",
             "text": "Destroy target artifact.\nCycling {G} ({G}, Discard this card: Draw a card.)",
             "colours": [
@@ -5527,7 +5527,7 @@
         },
         {
             "id": "6b3870e5-1591-5e5b-b125-8e1d24ed6b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30501c5-f6d9-47b3-b12b-8bd1c5ea6a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30501c5-f6d9-47b3-b12b-8bd1c5ea6a9b.jpg?1",
             "name": "Exemplar of Strength",
             "text": "When Exemplar of Strength enters the battlefield, put three -1/-1 counters on target creature you control.\nWhenever Exemplar of Strength attacks, remove a -1/-1 counter from it. If you do, you gain 1 life.",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "29e77fda-9720-5332-886d-0465286fed98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f99a5-40be-4fb1-bd9b-96a9adc5c2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f99a5-40be-4fb1-bd9b-96a9adc5c2af.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "8d086328-43e6-5341-9d5f-0f4979f78e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a2b15f-c289-4270-830c-50577325b97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a2b15f-c289-4270-830c-50577325b97a.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "45c02b17-f530-5f63-9734-3ae9b34ed08b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411d177-45fd-4193-8414-0f7e7846d2b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411d177-45fd-4193-8414-0f7e7846d2b9.jpg?1",
             "name": "Greater Sandwurm",
             "text": "Greater Sandwurm can't be blocked by creatures with power 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "d58fa55e-5cda-59b8-b65a-904d46997382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199d6a8d-008d-4495-9cbc-b8d680fab13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199d6a8d-008d-4495-9cbc-b8d680fab13c.jpg?1",
             "name": "Hapatra's Mark",
             "text": "Target creature you control gains hexproof until end of turn. Remove all -1/-1 counters from it. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "09721960-d398-5377-9614-262a77dea577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18e745-a925-477f-a50f-3ec7fba22d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18e745-a925-477f-a50f-3ec7fba22d88.jpg?1",
             "name": "Harvest Season",
             "text": "Search your library for up to X basic land cards, where X is the number of tapped creatures you control, and put those cards onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "cd16cb2e-dc7b-5723-9ee6-83527b8a45a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636925d-1c32-4fdc-b814-e6111393d04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636925d-1c32-4fdc-b814-e6111393d04e.jpg?1",
             "name": "Haze of Pollen",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "425f5587-3f81-5b11-87c8-b3fd4458cead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c33902-a06a-4321-bdf4-cea5494fda63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c33902-a06a-4321-bdf4-cea5494fda63.jpg?1",
             "name": "Honored Hydra",
             "text": "Trample\nEmbalm {3}{G} ({3}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Snake Hydra with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -5795,7 +5795,7 @@
         },
         {
             "id": "65e636c7-1ccb-5de8-88e9-b043e8c0dff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4dab03-abf1-4c8f-983e-77dffcfb1578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4dab03-abf1-4c8f-983e-77dffcfb1578.jpg?1",
             "name": "Hooded Brawler",
             "text": "You may exert Hooded Brawler as it attacks. When you do, it gets +2/+2 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "80d454f2-31ff-57dd-99f5-515715ac7d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0046b802-bc71-44af-8925-666684d5fc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0046b802-bc71-44af-8925-666684d5fc87.jpg?1",
             "name": "Initiate's Companion",
             "text": "Whenever Initiate's Companion deals combat damage to a player, untap target creature or land.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "d5fa338a-9c26-5168-b5fe-0f3f3381797f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa3a844-97e6-4f5d-a36f-56fea4e06932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa3a844-97e6-4f5d-a36f-56fea4e06932.jpg?1",
             "name": "Manglehorn",
             "text": "When Manglehorn enters the battlefield, you may destroy target artifact.\nArtifacts your opponents control enter the battlefield tapped.",
             "colours": [
@@ -5898,7 +5898,7 @@
         },
         {
             "id": "fc3139c4-cab8-5733-a2a7-1c837da03297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a8551-8788-47ea-b774-477f0f3ff22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a8551-8788-47ea-b774-477f0f3ff22a.jpg?1",
             "name": "Naga Vitalist",
             "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "cf14fdb6-7c02-5174-8095-3d4d017e3fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10be36-8e57-4b08-bc3b-e69769e0908a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10be36-8e57-4b08-bc3b-e69769e0908a.jpg?1",
             "name": "Oashra Cultivator",
             "text": "{2}{G}, {T}, Sacrifice Oashra Cultivator: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5968,7 +5968,7 @@
         },
         {
             "id": "cc773e67-031f-5fa0-91fc-f6f315a5a322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1d3a1-8c1b-4b77-b149-13d5ad9f125a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1d3a1-8c1b-4b77-b149-13d5ad9f125a.jpg?1",
             "name": "Ornery Kudu",
             "text": "When Ornery Kudu enters the battlefield, put a -1/-1 counter on target creature you control.",
             "colours": [
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "8a6863cf-8b44-581f-8e29-670bd97e8fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a590-75c1-4e85-b8b7-8c0c0f18b96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a590-75c1-4e85-b8b7-8c0c0f18b96e.jpg?1",
             "name": "Pouncing Cheetah",
             "text": "Flash",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "788b6610-767e-5a75-b875-62a25836e41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92921fc1-11d0-41a9-b9b2-b44fd0913d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92921fc1-11d0-41a9-b9b2-b44fd0913d31.jpg?1",
             "name": "Prowling Serpopard",
             "text": "Prowling Serpopard can't be countered.\nCreature spells you control can't be countered.",
             "colours": [
@@ -6071,7 +6071,7 @@
         },
         {
             "id": "2deccebb-9105-53ec-8e30-39a0fcab837a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2877c5-7680-4c2d-8e46-1d4548f0b03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2877c5-7680-4c2d-8e46-1d4548f0b03a.jpg?1",
             "name": "Quarry Hauler",
             "text": "When Quarry Hauler enters the battlefield, for each kind of counter on target permanent, put another counter of that kind on it or remove one from it.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "58ab9067-e604-5cf8-b4f1-8f2282398399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f23c47-278c-4188-8fb4-ae20a0c423c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f23c47-278c-4188-8fb4-ae20a0c423c5.jpg?1",
             "name": "Rhonas the Indomitable",
             "text": "Deathtouch, indestructible\nRhonas the Indomitable can't attack or block unless you control another creature with power 4 or greater.\n{2}{G}: Another target creature gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "89185033-6416-5df9-b6fe-ccd31531f0d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bd2c5-e3db-4fde-a695-9e67a7e937be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bd2c5-e3db-4fde-a695-9e67a7e937be.jpg?1",
             "name": "Sandwurm Convergence",
             "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "f9a752dc-125f-57e9-a43e-333ab909684f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c05a60f-660a-42d3-82b3-06984366afb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c05a60f-660a-42d3-82b3-06984366afb4.jpg?1",
             "name": "Scaled Behemoth",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6207,7 +6207,7 @@
         },
         {
             "id": "3aa09054-4724-590a-9929-40393a6cf72a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81803f44-6260-4df9-b566-2a2694d4deb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81803f44-6260-4df9-b566-2a2694d4deb0.jpg?1",
             "name": "Shed Weakness",
             "text": "Target creature gets +2/+2 until end of turn. You may remove a -1/-1 counter from it.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "bc421f4a-b0eb-515f-88e8-09fab1283d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ef62-875a-4735-9a63-6f3152d10d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ef62-875a-4735-9a63-6f3152d10d61.jpg?1",
             "name": "Shefet Monitor",
             "text": "Cycling {3}{G} ({3}{G}, Discard this card: Draw a card.)\nWhen you cycle Shefet Monitor, you may search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle your library. (Do this before you draw.)",
             "colours": [
@@ -6273,7 +6273,7 @@
         },
         {
             "id": "8e7310af-f8ba-5910-b3b1-3c63658afab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e564db6b-0b8b-4c67-9135-5da76d2225fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e564db6b-0b8b-4c67-9135-5da76d2225fe.jpg?1",
             "name": "Sixth Sense",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, you may draw a card.\"",
             "colours": [
@@ -6307,7 +6307,7 @@
         },
         {
             "id": "398a6c04-42b4-555e-8a91-c9cf94a2ca94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c64b40f-f99a-4e35-821f-9d87b4c759a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c64b40f-f99a-4e35-821f-9d87b4c759a7.jpg?1",
             "name": "Spidery Grasp",
             "text": "Untap target creature. It gets +2/+4 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -6339,7 +6339,7 @@
         },
         {
             "id": "df78347b-8605-5c6e-a436-0274729db3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c4c26-1118-41fa-aec8-1b43a7792e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c4c26-1118-41fa-aec8-1b43a7792e59.jpg?1",
             "name": "Stinging Shot",
             "text": "Put three -1/-1 counters on target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "47686906-0b0b-5130-8bfc-e7e83385d399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb09d11-5a6d-498f-9173-3539760b19fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb09d11-5a6d-498f-9173-3539760b19fb.jpg?1",
             "name": "Synchronized Strike",
             "text": "Untap up to two target creatures. They each get +2/+2 until end of turn.",
             "colours": [
@@ -6403,7 +6403,7 @@
         },
         {
             "id": "1a437a44-0231-505b-8855-4833ae2a9538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadb754-4a3b-4633-b784-252c0e1ab650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadb754-4a3b-4633-b784-252c0e1ab650.jpg?1",
             "name": "Trial of Strength",
             "text": "When Trial of Strength enters the battlefield, create a 4/2 green Beast creature token.\nWhen a Cartouche enters the battlefield under your control, return Trial of Strength to its owner's hand.",
             "colours": [
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "cf726ed6-9243-540c-a87d-df84025b75f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca204351-7a7e-4e4b-8c2b-f90fa0f9d724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca204351-7a7e-4e4b-8c2b-f90fa0f9d724.jpg?1",
             "name": "Vizier of the Menagerie",
             "text": "You may look at the top card of your library. (You may do this at any time.)\nYou may cast the top card of your library if it's a creature card.\nYou may spend mana as though it were mana of any type to cast creature spells.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "e0b8138e-0eeb-5fdf-9a2a-f2d92c4824e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae361e-20e2-4388-bd82-ce041f427495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae361e-20e2-4388-bd82-ce041f427495.jpg?1",
             "name": "Watchful Naga",
             "text": "You may exert Watchful Naga as it attacks. When you do, draw a card. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -6505,7 +6505,7 @@
         },
         {
             "id": "058a3fc5-9de1-5c00-ad92-ba268774dbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddda94a-4b2d-47b0-8d2c-3ad70a0d5584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddda94a-4b2d-47b0-8d2c-3ad70a0d5584.jpg?1",
             "name": "Ahn-Crop Champion",
             "text": "You may exert Ahn-Crop Champion as it attacks. When you do, untap all other creatures you control. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -6542,7 +6542,7 @@
         },
         {
             "id": "d76c32fd-f022-508d-9519-45dc23a5d2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bc716-2b1b-4731-bd0c-f4a5caf26e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bc716-2b1b-4731-bd0c-f4a5caf26e40.jpg?1",
             "name": "Aven Wind Guide",
             "text": "Flying, vigilance\nCreature tokens you control have flying and vigilance.\nEmbalm {4}{W}{U} ({4}{W}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -6579,7 +6579,7 @@
         },
         {
             "id": "3e9e6924-e13f-5f39-b32c-f30ee37f3f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574dab03-b8e6-4051-9dd5-31439c817223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574dab03-b8e6-4051-9dd5-31439c817223.jpg?1",
             "name": "Bounty of the Luxa",
             "text": "At the beginning of your precombat main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U} to your mana pool.",
             "colours": [
@@ -6613,7 +6613,7 @@
         },
         {
             "id": "e312c3b5-4605-527b-992f-36ff87ad39d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75e834-fa46-4833-ae9f-1bc2809ece2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75e834-fa46-4833-ae9f-1bc2809ece2f.jpg?1",
             "name": "Decimator Beetle",
             "text": "When Decimator Beetle enters the battlefield, put a -1/-1 counter on target creature you control.\nWhenever Decimator Beetle attacks, remove a -1/-1 counter from target creature you control and put a -1/-1 counter on up to one target creature defending player controls.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "4c94dd1a-dff7-54d6-8693-fa88cf57798f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66286631-c16e-410c-b963-25cfe8005d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66286631-c16e-410c-b963-25cfe8005d8f.jpg?1",
             "name": "Enigma Drake",
             "text": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -6685,7 +6685,7 @@
         },
         {
             "id": "9e98ed00-0adc-57b5-a0da-2d0b0967b949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fbbcc9-db23-4902-b0f7-cea78a2a36af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fbbcc9-db23-4902-b0f7-cea78a2a36af.jpg?1",
             "name": "Hapatra, Vizier of Poisons",
             "text": "Whenever Hapatra, Vizier of Poisons deals combat damage to a player, you may put a -1/-1 counter on target creature.\nWhenever you put one or more -1/-1 counters on a creature, create a 1/1 green Snake creature token with deathtouch.",
             "colours": [
@@ -6724,7 +6724,7 @@
         },
         {
             "id": "33aff80b-017a-54f7-b7b2-e9e967eb8e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b44194-fed5-491c-a791-80b986dd66d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b44194-fed5-491c-a791-80b986dd66d6.jpg?1",
             "name": "Honored Crop-Captain",
             "text": "Whenever Honored Crop-Captain attacks, other attacking creatures get +1/+0 until end of turn.",
             "colours": [
@@ -6761,7 +6761,7 @@
         },
         {
             "id": "dd482df2-3f88-5d7a-8982-0e2d32cc21ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab1454e-3c69-4450-bd4c-934af2ff2bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab1454e-3c69-4450-bd4c-934af2ff2bcb.jpg?1",
             "name": "Khenra Charioteer",
             "text": "Trample\nOther creatures you control have trample.",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "ed74a8e7-de70-53a1-8081-78285dc2e269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0e8c57-3046-414d-be00-39bfb2537026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0e8c57-3046-414d-be00-39bfb2537026.jpg?1",
             "name": "Merciless Javelineer",
             "text": "{2}, Discard a card: Put a -1/-1 counter on target creature. That creature can't block this turn.",
             "colours": [
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "9ed535d4-d77f-5553-94bf-8c7e1073ce32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d5fb-c6b3-4d24-b9d3-97a4378161fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d5fb-c6b3-4d24-b9d3-97a4378161fd.jpg?1",
             "name": "Neheb, the Worthy",
             "text": "First strike\nOther Minotaurs you control have first strike.\nAs long as you have one or fewer cards in hand, Minotaurs you control get +2/+0.\nWhenever Neheb, the Worthy deals combat damage to a player, each player discards a card.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "a037ae21-92f8-56cd-91c3-5575933b531f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79036a1-2239-4d4f-8b58-6cf9ac4863fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79036a1-2239-4d4f-8b58-6cf9ac4863fc.jpg?1",
             "name": "Nissa, Steward of Elements",
             "text": "+2: Scry 2.\n0: Look at the top card of your library. If it's a land card or a creature card with converted mana cost less than or equal to the number of loyalty counters on Nissa, Steward of Elements, you may put that card onto the battlefield.\n\u22126: Untap up to two target lands you control. They become 5/5 Elemental creatures with flying and haste until end of turn. They're still lands.",
             "colours": [
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "afad7b5a-566b-53dc-a3ba-7b5d143c6a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f2d8f1-43a9-438a-830c-9d6b5701f950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f2d8f1-43a9-438a-830c-9d6b5701f950.jpg?1",
             "name": "Samut, Voice of Dissent",
             "text": "Flash\nDouble strike, vigilance, haste\nOther creatures you control have haste.\n{W}, {T}: Untap another target creature.",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "f09ff657-f627-559e-af9b-27fe0ec5a294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea72b393-e47c-46de-a458-624ef0227486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea72b393-e47c-46de-a458-624ef0227486.jpg?1",
             "name": "Shadowstorm Vizier",
             "text": "Flying\nWhenever you cycle or discard a card, Shadowstorm Vizier gets +1/+1 until end of turn.",
             "colours": [
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "923ad903-d63c-5555-b874-9c6848bd73f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af12a34-52a1-4940-a8d5-9e9811fcd59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af12a34-52a1-4940-a8d5-9e9811fcd59f.jpg?1",
             "name": "Temmet, Vizier of Naktamun",
             "text": "At the beginning of combat on your turn, target creature token you control gets +1/+1 until end of turn and can't be blocked this turn.\nEmbalm {3}{W}{U} ({3}{W}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Cleric with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "74654008-bd71-58d5-9e40-f4faa588ebe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e00112-8c6c-4551-ad68-389e315fe148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e00112-8c6c-4551-ad68-389e315fe148.jpg?1",
             "name": "Wayward Servant",
             "text": "Whenever another Zombie enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "adfaed49-f240-51bc-9ae0-b63a745fca6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac35181-baae-4c50-b397-a10b234833e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac35181-baae-4c50-b397-a10b234833e5.jpg?1",
             "name": "Weaver of Currents",
             "text": "{T}: Add {C}{C} to your mana pool.",
             "colours": [
@@ -7101,7 +7101,7 @@
         },
         {
             "id": "f9f10d34-071c-57a6-b58c-7553abad5c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Destroy all creatures with power 3 or greater.",
             "colours": [
@@ -7133,7 +7133,7 @@
         },
         {
             "id": "87f0062a-8321-5c16-960e-a12ce1df5839",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nReturn all creature cards with power 2 or less from your graveyard to your hand.",
             "colours": [
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "71a0621f-32a6-5450-8ad8-6cdae505cf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg?1",
             "name": "Commit // Memory",
             "text": "Put target spell or nonland permanent into its owner's library second from the top.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "95a37a67-eac8-5ae2-9a50-31f81f810f18",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg?1",
             "name": "Commit // Memory",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles his or her hand and graveyard into his or her library, then draws seven cards.",
             "colours": [
@@ -7229,7 +7229,7 @@
         },
         {
             "id": "875ba98c-721c-537b-b326-22d803fab7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg?1",
             "name": "Never // Return",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "6acc8501-aa59-5777-a7d0-e3ef66a609ea",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg?1",
             "name": "Never // Return",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile target card from a graveyard. Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "8c8d3c24-09c9-5d5a-879c-00cca5d29410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg?1",
             "name": "Insult // Injury",
             "text": "Damage can't be prevented this turn. If a source you control would deal damage this turn, it deals double that damage instead.",
             "colours": [
@@ -7325,7 +7325,7 @@
         },
         {
             "id": "c44192e3-0732-528d-a4c4-b27a49d8ebe4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg?1",
             "name": "Insult // Injury",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nInjury deals 2 damage to target creature and 2 damage to target player.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "6298d70e-4ecc-5cff-9221-aeb532c33e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg?1",
             "name": "Mouth // Feed",
             "text": "Create a 3/3 green Hippo creature token.",
             "colours": [
@@ -7389,7 +7389,7 @@
         },
         {
             "id": "e765058a-4a7c-513f-bb97-cb7d3aa56218",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg?1",
             "name": "Mouth // Feed",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw a card for each creature you control with power 3 or greater.",
             "colours": [
@@ -7421,7 +7421,7 @@
         },
         {
             "id": "17100b0d-3b74-5329-a832-dfad07d5c35b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg?1",
             "name": "Start // Finish",
             "text": "Create two 1/1 white Warrior creature tokens with vigilance.",
             "colours": [
@@ -7454,7 +7454,7 @@
         },
         {
             "id": "93de0571-9509-5933-b298-2660f5f97f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg?1",
             "name": "Start // Finish",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAs an additional cost to cast Finish, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -7487,7 +7487,7 @@
         },
         {
             "id": "c1640f4d-6d39-5634-8e9b-32b9ddf5f5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg?1",
             "name": "Reduce // Rubble",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "57aa1356-3638-57b6-9b4f-4ef1f77de5df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg?1",
             "name": "Reduce // Rubble",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nUp to three target lands don't untap during their controller's next untap step.",
             "colours": [
@@ -7553,7 +7553,7 @@
         },
         {
             "id": "7684c16e-2758-5fc8-9bd9-cff4a7ca4c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg?1",
             "name": "Destined // Lead",
             "text": "Target creature gets +1/+0 and gains indestructible until end of turn.",
             "colours": [
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "a241affc-f016-5e33-94c2-c4e9b95b1cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg?1",
             "name": "Destined // Lead",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAll creatures able to block target creature this turn do so.",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "ce891eb4-0423-53ab-aed8-5964f57dd50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg?1",
             "name": "Onward // Victory",
             "text": "Target creature gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -7652,7 +7652,7 @@
         },
         {
             "id": "d683ca15-e3af-5170-bf22-109b3393696d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg?1",
             "name": "Onward // Victory",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gains double strike until end of turn.",
             "colours": [
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "9e5fa4dc-893e-5ab3-aa77-f23bbde12f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg?1",
             "name": "Spring // Mind",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "26a57e19-d546-56d2-aa5d-1a78eb1fa265",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg?1",
             "name": "Spring // Mind",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards.",
             "colours": [
@@ -7751,7 +7751,7 @@
         },
         {
             "id": "b7820f85-71f4-5eca-8aa8-67279ef3fd8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg?1",
             "name": "Prepare // Fight",
             "text": "Untap target creature. It gets +2/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -7784,7 +7784,7 @@
         },
         {
             "id": "d74c9178-45df-57ea-91a8-c24a2f1d7f05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg?1",
             "name": "Prepare // Fight",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature you control fights target creature an opponent controls.",
             "colours": [
@@ -7817,7 +7817,7 @@
         },
         {
             "id": "4e870ad1-5290-5c84-801a-b52bd1ff522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg?1",
             "name": "Failure // Comply",
             "text": "Return target spell to its owner's hand.",
             "colours": [
@@ -7850,7 +7850,7 @@
         },
         {
             "id": "dfe9df6b-4995-5516-8f4c-435d6e34b724",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg?1",
             "name": "Failure // Comply",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nChoose a card name. Until your next turn, your opponents can't cast spells with the chosen name.",
             "colours": [
@@ -7883,7 +7883,7 @@
         },
         {
             "id": "bb0a0546-ccc4-5f0b-b157-f10814fb09ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg?1",
             "name": "Rags // Riches",
             "text": "All creatures get -2/-2 until end of turn.",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "07e3e8eb-c75a-5281-b69a-29d4b69536ff",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg?1",
             "name": "Rags // Riches",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent chooses a creature he or she controls. You gain control of those creatures.",
             "colours": [
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "69e2ed1a-fa4a-5513-9a8f-28f61263d37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg?1",
             "name": "Cut // Ribbons",
             "text": "Cut deals 4 damage to target creature.",
             "colours": [
@@ -7982,7 +7982,7 @@
         },
         {
             "id": "a6b57044-acd3-5380-8da8-12b349ace615",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg?1",
             "name": "Cut // Ribbons",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent loses X life.",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "f1523235-010a-5014-85fc-94de770e6793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg?1",
             "name": "Heaven // Earth",
             "text": "Heaven deals X damage to each creature with flying.",
             "colours": [
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "a0f3e7c6-46c8-505a-8f6c-15bd4286167d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg?1",
             "name": "Heaven // Earth",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEarth deals X damage to each creature without flying.",
             "colours": [
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "b7fba506-eaa8-509d-b3c1-b31446650859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b00377-9acc-47c4-ae2f-b396d7050a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b00377-9acc-47c4-ae2f-b396d7050a15.jpg?1",
             "name": "Bontu's Monument",
             "text": "Black creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, each opponent loses 1 life and you gain 1 life.",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "4a32d9d3-45a0-5f85-94ac-09d8da42a120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e6fa29-087f-4da6-9114-30feec708560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e6fa29-087f-4da6-9114-30feec708560.jpg?1",
             "name": "Edifice of Authority",
             "text": "{1}, {T}: Target creature can't attack this turn. Put a brick counter on Edifice of Authority.\n{1}, {T}: Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate this ability only if there are three or more brick counters on Edifice of Authority.",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "58dc60a3-8446-50e2-8898-e44cedf8064e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c044f47-7435-4cb4-b4ad-48bb146daa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c044f47-7435-4cb4-b4ad-48bb146daa9f.jpg?1",
             "name": "Embalmer's Tools",
             "text": "Activated abilities of creature cards in your graveyard cost {1} less to activate.\nTap an untapped Zombie you control: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -8167,7 +8167,7 @@
         },
         {
             "id": "ed9d1e09-0064-5d4a-84f2-66309372907b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b544a59-86b9-447d-b54d-b94a262b6866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b544a59-86b9-447d-b54d-b94a262b6866.jpg?1",
             "name": "Gate to the Afterlife",
             "text": "Whenever a nontoken creature you control dies, you gain 1 life. Then you may draw a card. If you do, discard a card.\n{2}, {T}, Sacrifice Gate to the Afterlife: Search your graveyard, hand, and/or library for a card named God-Pharaoh's Gift and put it onto the battlefield. If you search your library this way, shuffle it. Activate this ability only if there are six or more creature cards in your graveyard.",
             "colours": [],
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "db634f35-5ec7-56d6-86b8-ad03e7de0ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0a70f2-f2cb-4a08-a1a7-95c8fc3de6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0a70f2-f2cb-4a08-a1a7-95c8fc3de6e3.jpg?1",
             "name": "Hazoret's Monument",
             "text": "Red creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, you may discard a card. If you do, draw a card.",
             "colours": [],
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "d5bd7921-052c-5b78-81b1-946ea354c0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d80b98-baa2-48ea-9611-96e64d7cb950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d80b98-baa2-48ea-9611-96e64d7cb950.jpg?1",
             "name": "Honed Khopesh",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8255,7 +8255,7 @@
         },
         {
             "id": "9a23052b-af27-5cc8-a306-90c1f3ef2d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d20f0a-aa7c-4d40-acb2-2b86666afd53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d20f0a-aa7c-4d40-acb2-2b86666afd53.jpg?1",
             "name": "Kefnet's Monument",
             "text": "Blue creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, target creature an opponent controls doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -8285,7 +8285,7 @@
         },
         {
             "id": "b4610f0a-31f7-523e-bdac-234fdf0991f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f43dc6f-910c-42a1-b329-038e20dfb264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f43dc6f-910c-42a1-b329-038e20dfb264.jpg?1",
             "name": "Luxa River Shrine",
             "text": "{1}, {T}: You gain 1 life. Put a brick counter on Luxa River Shrine.\n{T}: You gain 2 life. Activate this ability only if there are three or more brick counters on Luxa River Shrine.",
             "colours": [],
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "e61404bb-0543-5100-bf0c-2b8b934fce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104503a6-bca5-48d7-88b1-424f98985d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104503a6-bca5-48d7-88b1-424f98985d75.jpg?1",
             "name": "Oketra's Monument",
             "text": "White creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, create a 1/1 white Warrior creature token with vigilance.",
             "colours": [],
@@ -8343,7 +8343,7 @@
         },
         {
             "id": "727daa7f-d3f5-5c92-8152-cfca01356242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fcc4a5-3ab0-4344-85af-d80aae293b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fcc4a5-3ab0-4344-85af-d80aae293b75.jpg?1",
             "name": "Oracle's Vault",
             "text": "{2}, {T}: Exile the top card of your library. Until end of turn, you may play that card. Put a brick counter on Oracle's Vault.\n{T}: Exile the top card of your library. Until end of turn, you may play that card without paying its mana cost. Activate this ability only if there are three or more brick counters on Oracle's Vault.",
             "colours": [],
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "145da165-5178-5d38-ad6e-52f713c0c208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef335b2-8086-4b29-b8e3-47de6faa1334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef335b2-8086-4b29-b8e3-47de6faa1334.jpg?1",
             "name": "Pyramid of the Pantheon",
             "text": "{2}, {T}: Add one mana of any color to your mana pool. Put a brick counter on Pyramid of the Pantheon.\n{T}: Add three mana of any one color to your mana pool. Activate this ability only if there are three or more brick counters on Pyramid of the Pantheon.",
             "colours": [],
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "4f84c687-636f-5423-9cec-a22c866e2338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d2260a-e001-4d03-a108-759591e4d233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d2260a-e001-4d03-a108-759591e4d233.jpg?1",
             "name": "Rhonas's Monument",
             "text": "Green creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, target creature you control gets +2/+2 and gains trample until end of turn.",
             "colours": [],
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "d236a672-fbf8-5cd3-9efa-1c1d6bcd5e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe402b8e-f966-4971-90a5-950d8cff5025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe402b8e-f966-4971-90a5-950d8cff5025.jpg?1",
             "name": "Throne of the God-Pharaoh",
             "text": "At the beginning of your end step, each opponent loses life equal to the number of tapped creatures you control.",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "f3ac3d25-7d7d-59c2-b6c1-6c6c86186881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30efc831-3673-4bc1-8a25-150c0349253a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30efc831-3673-4bc1-8a25-150c0349253a.jpg?1",
             "name": "Watchers of the Dead",
             "text": "Exile Watchers of the Dead: Each opponent chooses two cards in his or her graveyard and exiles the rest.",
             "colours": [],
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "710b7eae-b659-5282-acfd-298ea3f6d199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb273d9-466d-416d-b27d-d1bc8a249076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb273d9-466d-416d-b27d-d1bc8a249076.jpg?1",
             "name": "Canyon Slough",
             "text": "({T}: Add {B} or {R} to your mana pool.)\nCanyon Slough enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "01b5693f-bc43-5fa2-91ba-30cae4128c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778739db-4431-4e58-91de-d2619aeef3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778739db-4431-4e58-91de-d2619aeef3ce.jpg?1",
             "name": "Cascading Cataracts",
             "text": "Indestructible\n{T}: Add {C} to your mana pool.\n{5}, {T}: Add five mana in any combination of colors to your mana pool.",
             "colours": [],
@@ -8552,7 +8552,7 @@
         },
         {
             "id": "b5659a6b-4d05-5d07-a6d4-e00698237ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41713e82-c3d3-4c2f-b075-f684cbd68ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41713e82-c3d3-4c2f-b075-f684cbd68ce8.jpg?1",
             "name": "Cradle of the Accursed",
             "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Cradle of the Accursed: Create a 2/2 black Zombie creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "86a3c113-a3f2-527a-9fe7-bcfb46bf0f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b39e1c7-b175-462e-83ab-dd67abec6bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b39e1c7-b175-462e-83ab-dd67abec6bfb.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "7d9b629b-d35f-53dc-a09c-199704886f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae703d94-6f1f-463b-ab25-1b3f462e7e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae703d94-6f1f-463b-ab25-1b3f462e7e78.jpg?1",
             "name": "Fetid Pools",
             "text": "({T}: Add {U} or {B} to your mana pool.)\nFetid Pools enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "224a7bc8-d2c2-5980-ae70-b79c5b86ca63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fcc939-6a31-4fb3-abe7-7663b85868dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fcc939-6a31-4fb3-abe7-7663b85868dd.jpg?1",
             "name": "Grasping Dunes",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Grasping Dunes: Put a -1/-1 counter on target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -8674,7 +8674,7 @@
         },
         {
             "id": "84cd6d95-c30b-5475-bfe3-72a07b7e603b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d87fcc0-cef5-4410-adf1-91c5f50c1d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d87fcc0-cef5-4410-adf1-91c5f50c1d01.jpg?1",
             "name": "Irrigated Farmland",
             "text": "({T}: Add {W} or {U} to your mana pool.)\nIrrigated Farmland enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8708,7 +8708,7 @@
         },
         {
             "id": "3336a1a3-42a5-5bf2-b42c-f75ddae5b15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b373131-2a1d-4710-8a11-c1b366a174d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b373131-2a1d-4710-8a11-c1b366a174d4.jpg?1",
             "name": "Painted Bluffs",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "79924f36-d5e8-5747-bd4f-7197ca31939a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb541aa-3bf6-41f3-89e5-9c6c56ea210a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb541aa-3bf6-41f3-89e5-9c6c56ea210a.jpg?1",
             "name": "Scattered Groves",
             "text": "({T}: Add {G} or {W} to your mana pool.)\nScattered Groves enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8772,7 +8772,7 @@
         },
         {
             "id": "bfea94a8-75a9-5de5-95c0-d41c6f93236c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23cd764-3f5c-4c93-ba83-e5ff397003a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23cd764-3f5c-4c93-ba83-e5ff397003a2.jpg?1",
             "name": "Sheltered Thicket",
             "text": "({T}: Add {R} or {G} to your mana pool.)\nSheltered Thicket enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "848879b0-667b-5c83-849f-82cda8ed76e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405434c7-9206-45b7-af0f-d59aae294d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405434c7-9206-45b7-af0f-d59aae294d39.jpg?1",
             "name": "Sunscorched Desert",
             "text": "When Sunscorched Desert enters the battlefield, it deals 1 damage to target player.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "5f55da7f-dea7-5eea-b801-47453ee40198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7191d23-b68f-406b-8c28-8dadbaef6562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7191d23-b68f-406b-8c28-8dadbaef6562.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "af070e79-f9a2-5fb0-ae31-a11740c9b6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec6fced-62bb-4a99-9ea1-374056b5781b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec6fced-62bb-4a99-9ea1-374056b5781b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "b243d6b5-d619-54d1-94de-fe3224f57d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7c997-e520-4ff6-8b3b-705c2f12a9d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7c997-e520-4ff6-8b3b-705c2f12a9d4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8950,7 +8950,7 @@
         },
         {
             "id": "0bdf65c2-e1f7-5ceb-ac1c-743a6d8229f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3112990-3919-46b0-b927-14566c689a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3112990-3919-46b0-b927-14566c689a81.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "d7dd6951-74bd-5b71-92ab-469fcaae2712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fc9f7-21af-4416-abf5-6fcb4f543680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fc9f7-21af-4416-abf5-6fcb4f543680.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "db1660c3-22cc-556b-beed-189c96812159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0422da01-0252-4f3b-b2e5-9f5b2c0b94ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0422da01-0252-4f3b-b2e5-9f5b2c0b94ae.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9064,7 +9064,7 @@
         },
         {
             "id": "7a3f9218-4d70-599c-bb9d-d8e160be77e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba708fff-a428-4783-b405-4c7e6ea72fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba708fff-a428-4783-b405-4c7e6ea72fd3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "757d2a8a-cc33-5b25-a8d9-e602e07925d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4734a7c-67d0-4124-b76e-d53634557c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4734a7c-67d0-4124-b76e-d53634557c7d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9140,7 +9140,7 @@
         },
         {
             "id": "1e9e330f-9cca-5b29-85c7-cae1bc03aa5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559fc49-54f3-426f-b2d2-525790a249a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559fc49-54f3-426f-b2d2-525790a249a5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9178,7 +9178,7 @@
         },
         {
             "id": "bba24995-7ce5-596d-a6da-3043284df24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177da89-184b-4ecd-ae08-a074ac4862e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177da89-184b-4ecd-ae08-a074ac4862e1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "c5242ee8-096a-563f-a6b5-7a4612d96a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61c6c6c-319f-4636-8482-26b6909f7b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61c6c6c-319f-4636-8482-26b6909f7b8e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9254,7 +9254,7 @@
         },
         {
             "id": "c895c3a3-9096-5aa1-a683-95fed4a2766e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dbed02-6871-4830-8308-9f2f48e6730d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dbed02-6871-4830-8308-9f2f48e6730d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9292,7 +9292,7 @@
         },
         {
             "id": "ba2e12fe-c9bc-5392-91ca-6aec6f468cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6566108-ccc7-4fac-b935-1eb212889543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6566108-ccc7-4fac-b935-1eb212889543.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9330,7 +9330,7 @@
         },
         {
             "id": "5ed035a2-6b02-53a6-86f7-84459c3a512e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be28351-642c-4ed1-9041-e99ecb79cba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be28351-642c-4ed1-9041-e99ecb79cba8.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9368,7 +9368,7 @@
         },
         {
             "id": "ceb6d29d-d752-55f6-9a66-40e0fbf21add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37827425-f304-43eb-979b-1ec5b923a2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37827425-f304-43eb-979b-1ec5b923a2b5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9406,7 +9406,7 @@
         },
         {
             "id": "bc2d3e38-a147-5d66-b251-d5ce17da922b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eced8a4-67ce-403c-a567-82ace69d1cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eced8a4-67ce-403c-a567-82ace69d1cf1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "897ffccd-d859-5d59-9ab8-359f5ab880e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb742de-57fa-49f5-977e-bee1b8186e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb742de-57fa-49f5-977e-bee1b8186e9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9482,7 +9482,7 @@
         },
         {
             "id": "6473a050-03c6-59e8-9c1d-550e3e858d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f4e594-01e5-40ae-903c-f55aad740de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f4e594-01e5-40ae-903c-f55aad740de0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9520,7 +9520,7 @@
         },
         {
             "id": "bdebae8c-28cc-51c9-88db-2874cfbda5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c94463-31e8-4a2e-b879-d096a27cc60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c94463-31e8-4a2e-b879-d096a27cc60e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9558,7 +9558,7 @@
         },
         {
             "id": "26710a14-b4d1-5da8-8e97-6546206e8ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3b0668-0a4c-489f-aa2b-4faa8ef3e429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3b0668-0a4c-489f-aa2b-4faa8ef3e429.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9596,7 +9596,7 @@
         },
         {
             "id": "003d9ecd-53bc-55c7-993f-26ec405f71e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c057ca8-9811-4dc3-9b0e-f9f69f752d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c057ca8-9811-4dc3-9b0e-f9f69f752d1d.jpg?1",
             "name": "Gideon, Martial Paragon",
             "text": "+2: Untap all creatures you control. Those creatures get +1/+1 until end of turn.\n0: Until end of turn, Gideon, Martial Paragon becomes a 5/5 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n\u221210: Creatures you control get +2/+2 until end of turn. Tap all creatures your opponents control.",
             "colours": [
@@ -9631,7 +9631,7 @@
         },
         {
             "id": "fffa4546-e7ac-5291-b878-2e66ea1b1dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ac220-058f-4212-ba8b-a389bb0528bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ac220-058f-4212-ba8b-a389bb0528bd.jpg?1",
             "name": "Companion of the Trials",
             "text": "Flying\n{1}{W}: Untap target creature. Activate this ability only if you control a Gideon planeswalker.",
             "colours": [
@@ -9665,7 +9665,7 @@
         },
         {
             "id": "c643b97e-6c04-5ad8-b12c-484d8c988b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b8c40-39ac-423f-b7da-845a16cd1b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b8c40-39ac-423f-b7da-845a16cd1b63.jpg?1",
             "name": "Gideon's Resolve",
             "text": "When Gideon's Resolve enters the battlefield, you may search your library and/or graveyard for a card named Gideon, Martial Paragon, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nCreatures you control get +1/+1.",
             "colours": [
@@ -9696,7 +9696,7 @@
         },
         {
             "id": "fa770156-9edf-5018-aa54-9c1b574acb48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42ba8bf-9fc1-4d57-9c80-42491d18d929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42ba8bf-9fc1-4d57-9c80-42491d18d929.jpg?1",
             "name": "Graceful Cat",
             "text": "Whenever Graceful Cat attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "2aa0d087-6996-56ac-98f7-95a0a5bc395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2280a5db-72be-4c13-8e15-8d40b7d9f9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2280a5db-72be-4c13-8e15-8d40b7d9f9e7.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -9759,7 +9759,7 @@
         },
         {
             "id": "4ea1e23e-5c15-5488-9ea9-20646c48eb89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac79d8f6-7c36-4eb9-8bda-3b813c634399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac79d8f6-7c36-4eb9-8bda-3b813c634399.jpg?1",
             "name": "Liliana, Death Wielder",
             "text": "+2: Put a -1/-1 counter on up to one target creature.\n\u22123: Destroy target creature with a -1/-1 counter on it.\n\u221210: Return all creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -9794,7 +9794,7 @@
         },
         {
             "id": "9e509550-4c0e-5a81-95ca-13c17617e9fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f31e96-bb66-4b28-b14a-426d1d5839a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f31e96-bb66-4b28-b14a-426d1d5839a6.jpg?1",
             "name": "Desiccated Naga",
             "text": "{3}{B}: Target opponent loses 2 life and you gain 2 life. Activate this ability only if you control a Liliana planeswalker.",
             "colours": [
@@ -9828,7 +9828,7 @@
         },
         {
             "id": "d07e8986-d359-5216-8273-3465f0c859c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cdf48e-e0d4-45ca-b48d-74ada54ba62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cdf48e-e0d4-45ca-b48d-74ada54ba62e.jpg?1",
             "name": "Liliana's Influence",
             "text": "Put a -1/-1 counter on each creature you don't control. You may search your library and/or graveyard for a card named Liliana, Death Wielder, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "2ef18e21-8b43-547c-b21f-da0b080f1078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a5267-eb90-43bc-bf92-fcfb06821bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a5267-eb90-43bc-bf92-fcfb06821bae.jpg?1",
             "name": "Tattered Mummy",
             "text": "When Tattered Mummy dies, each opponent loses 2 life.",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "939293e4-06aa-5902-a3e6-df3332dd2dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81435771-2f13-4e53-9a5f-4a4e4ad735ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81435771-2f13-4e53-9a5f-4a4e4ad735ac.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -9923,7 +9923,7 @@
         },
         {
             "id": "709b1a04-0ded-5b6b-8ed7-d027682c4241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12fa835-c13d-4d73-9d26-97bc2268e971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12fa835-c13d-4d73-9d26-97bc2268e971.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "e597d40a-20f0-5af6-ac4f-f994070a05f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7795db-c96a-4f94-bcc8-6977e38d0fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7795db-c96a-4f94-bcc8-6977e38d0fe2.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "edbe8c50-ff87-5895-81cb-bc344feb8c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b64bd5c-d014-4a5e-bb71-7cee8756ae8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b64bd5c-d014-4a5e-bb71-7cee8756ae8c.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -10013,7 +10013,7 @@
         },
         {
             "id": "7ececcea-605b-5cf1-8506-cb35c55a4ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745525ff-4afe-4a81-8c9d-5e6b9cca1eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745525ff-4afe-4a81-8c9d-5e6b9cca1eba.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -10043,7 +10043,7 @@
         },
         {
             "id": "7a1ef1af-fd2a-5b65-9b23-5f6dc776f306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e966e-cb51-461a-9089-25054dec57fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e966e-cb51-461a-9089-25054dec57fb.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -10073,7 +10073,7 @@
         },
         {
             "id": "9a9496e9-7aeb-52e7-ad13-6ceb234b2c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81ae262-fe8d-4c78-8604-711fb8d366d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81ae262-fe8d-4c78-8604-711fb8d366d8.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -10103,7 +10103,7 @@
         },
         {
             "id": "e91277c4-d0fc-58ee-a50f-4e9ace2c7dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6054534-a926-460e-8d3c-db8b576b1352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6054534-a926-460e-8d3c-db8b576b1352.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -10133,7 +10133,7 @@
         },
         {
             "id": "814fad14-2734-5fe1-a433-8cf34c83af59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff0f82-1326-479c-ba88-8cc85c56d883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff0f82-1326-479c-ba88-8cc85c56d883.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -10163,7 +10163,7 @@
         },
         {
             "id": "5d60c9c8-5f5a-58b1-9271-410bd0879b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1786cb3-6f38-4f10-b5f1-8feb20e3baaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1786cb3-6f38-4f10-b5f1-8feb20e3baaf.jpg?1",
             "name": "Angel of Sanctions",
             "text": "",
             "colours": [
@@ -10198,7 +10198,7 @@
         },
         {
             "id": "ffea7959-8128-5703-b08d-0456bc5e59e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98956e73-04e4-4d7f-bda5-cfa78eb71350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98956e73-04e4-4d7f-bda5-cfa78eb71350.jpg?1",
             "name": "Anointer Priest",
             "text": "",
             "colours": [
@@ -10234,7 +10234,7 @@
         },
         {
             "id": "766616ef-47e2-5ca9-90d6-c30f1cfaab20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3814e3-7ad2-4c87-8630-ab56e13b6ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3814e3-7ad2-4c87-8630-ab56e13b6ee9.jpg?1",
             "name": "Aven Initiate",
             "text": "",
             "colours": [
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "7993f19a-e1ab-55be-a5be-82cfbd6dceac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f339c6-2c0d-4631-849b-44d4360b5131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f339c6-2c0d-4631-849b-44d4360b5131.jpg?1",
             "name": "Aven Wind Guide",
             "text": "",
             "colours": [
@@ -10306,7 +10306,7 @@
         },
         {
             "id": "7de9db3f-95d8-5e17-bba0-864b205da459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d97a02-9187-4dbc-a511-2a15ca840cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d97a02-9187-4dbc-a511-2a15ca840cda.jpg?1",
             "name": "Glyph Keeper",
             "text": "",
             "colours": [
@@ -10341,7 +10341,7 @@
         },
         {
             "id": "d221c39f-0f44-5d8b-a246-e5bb061b466a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e534d68-a97f-4ae1-b202-31c7a5366b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e534d68-a97f-4ae1-b202-31c7a5366b58.jpg?1",
             "name": "Heart-Piercer Manticore",
             "text": "",
             "colours": [
@@ -10376,7 +10376,7 @@
         },
         {
             "id": "ec0ab5d6-95e0-5d59-ac3f-6d6f69ab109e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365ffff-b171-4275-9fdb-e622f8456858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365ffff-b171-4275-9fdb-e622f8456858.jpg?1",
             "name": "Honored Hydra",
             "text": "",
             "colours": [
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "95acee24-bd84-578d-9bdb-6740843423e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754eeff5-b495-4aa5-94ce-ff20216c952b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754eeff5-b495-4aa5-94ce-ff20216c952b.jpg?1",
             "name": "Labyrinth Guardian",
             "text": "",
             "colours": [
@@ -10448,7 +10448,7 @@
         },
         {
             "id": "5769a877-f6e1-5479-8679-44e2a655b3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5fedcd-e5d5-4250-b64e-a04772cb9025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5fedcd-e5d5-4250-b64e-a04772cb9025.jpg?1",
             "name": "Oketra's Attendant",
             "text": "",
             "colours": [
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "455416fe-e5a6-57bd-8f3b-f0d24770cff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea5f68-3818-43d3-9b7b-c344305a8423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea5f68-3818-43d3-9b7b-c344305a8423.jpg?1",
             "name": "Sacred Cat",
             "text": "",
             "colours": [
@@ -10519,7 +10519,7 @@
         },
         {
             "id": "d21fa0d2-7baa-5abc-b7f7-866f7c71197c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e835c-0f39-4fd1-a839-125bee0c9dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e835c-0f39-4fd1-a839-125bee0c9dbc.jpg?1",
             "name": "Tah-Crop Skirmisher",
             "text": "",
             "colours": [
@@ -10555,7 +10555,7 @@
         },
         {
             "id": "6041f40e-4280-5861-916b-0e93b2f4a80d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6201e6-7dcd-40b1-97aa-fd9c860cea97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6201e6-7dcd-40b1-97aa-fd9c860cea97.jpg?1",
             "name": "Temmet, Vizier of Naktamun",
             "text": "",
             "colours": [
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "7636b4d6-167c-599c-bbd5-c9902a8264b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c770d91c-b7d1-44ef-922d-128cb3faef08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c770d91c-b7d1-44ef-922d-128cb3faef08.jpg?1",
             "name": "Trueheart Duelist",
             "text": "",
             "colours": [
@@ -10627,7 +10627,7 @@
         },
         {
             "id": "15035eeb-889c-512f-9b16-5532d151b56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab720d-40fc-4315-bc8d-c7073cea588b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab720d-40fc-4315-bc8d-c7073cea588b.jpg?1",
             "name": "Unwavering Initiate",
             "text": "",
             "colours": [
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "d2f89cc8-d965-508e-b98d-c2bb51b5d8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39520c16-1f4b-4f15-aeb4-53c91e8ecfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39520c16-1f4b-4f15-aeb4-53c91e8ecfcc.jpg?1",
             "name": "Vizier of Many Faces",
             "text": "",
             "colours": [
@@ -10699,7 +10699,7 @@
         },
         {
             "id": "909fb00f-9bf6-563a-9dab-1a1ec252d97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -10733,7 +10733,7 @@
         },
         {
             "id": "9100049f-4585-5c92-8a35-98ae8a4effb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1446ed-f114-421d-bb60-9aeb655e5adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1446ed-f114-421d-bb60-9aeb655e5adb.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "2311a216-8dd8-52b4-b96c-45bc5579862c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65844e72-aa84-483f-b07e-9e34e798aaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65844e72-aa84-483f-b07e-9e34e798aaec.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "161588d4-baa0-5561-ad4b-a1107639c5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242c381e-df58-4365-a68c-add1127a83cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242c381e-df58-4365-a68c-add1127a83cc.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -10835,7 +10835,7 @@
         },
         {
             "id": "95f36818-6a89-5a1e-9821-03016d94f604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -10869,7 +10869,7 @@
         },
         {
             "id": "f46a6204-28fa-5704-8b0f-f13a2f8e23ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7ecd1-c70e-467c-a9ea-99c2668c3405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7ecd1-c70e-467c-a9ea-99c2668c3405.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -10903,7 +10903,7 @@
         },
         {
             "id": "2851fca7-1dd8-52e3-81ea-2ac617521b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00.jpg?1",
             "name": "Hippo",
             "text": "",
             "colours": [
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "cf497fe2-7f92-5fcf-bd9f-9e0831988e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8539-8d21-4da1-8410-d4354078390f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8539-8d21-4da1-8410-d4354078390f.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -10971,7 +10971,7 @@
         },
         {
             "id": "59e3bd40-8468-5afc-b33f-8464378c862a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c01a7-6399-496b-a5a3-8be45475ce33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c01a7-6399-496b-a5a3-8be45475ce33.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -11005,7 +11005,7 @@
         },
         {
             "id": "84f5dfde-13b4-5244-9a34-938d9e470857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbebd89c-0b29-44c7-bc99-53dd4b836520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbebd89c-0b29-44c7-bc99-53dd4b836520.jpg?1",
             "name": "Gideon of the Trials Emblem",
             "text": "",
             "colours": [],
@@ -11034,7 +11034,7 @@
         },
         {
             "id": "b80a2d58-5c15-5c6f-89f4-e2635d621dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b4bfd-c5c1-4d0e-b7ff-7615245f9df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b4bfd-c5c1-4d0e-b7ff-7615245f9df8.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],
@@ -11061,7 +11061,7 @@
         },
         {
             "id": "157abc21-4a8e-5712-95df-152191e7adf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca931b5-6e12-468c-a1d1-e01363b872b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca931b5-6e12-468c-a1d1-e01363b872b1.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ALA.json
+++ b/Assets/Resources/Sets/ALA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3550ed10-1448-56a9-9340-39560975af48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc045-b938-4321-aec3-51685cbbaa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc045-b938-4321-aec3-51685cbbaa52.jpg?1",
             "name": "Akrasan Squire",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b0c72592-e426-599d-8757-f86a638fdc24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36197ed0-4382-4de3-8359-73cb74edc78b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36197ed0-4382-4de3-8359-73cb74edc78b.jpg?1",
             "name": "Angel's Herald",
             "text": "{2}{W}, {T}, Sacrifice a green creature, a white creature, and a blue creature: Search your library for a card named Empyrial Archangel and put it into play. Then shuffle your library.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "a4c8a4d2-d052-5cbd-a238-3d74b03bf91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b9071-7dde-4128-8b18-1d7b07904638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b9071-7dde-4128-8b18-1d7b07904638.jpg?1",
             "name": "Angelic Benediction",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may tap target creature.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "3cf60faa-c154-5a9d-8980-0fbfa23a1fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0832e87f-afef-41a5-ba36-3eaf65551576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0832e87f-afef-41a5-ba36-3eaf65551576.jpg?1",
             "name": "Angelsong",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "2ae2a6e1-b9c6-55bc-9d79-bf5b2b776df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c597b1d-d8b5-4922-a3f2-1f173a73ea2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c597b1d-d8b5-4922-a3f2-1f173a73ea2a.jpg?1",
             "name": "Bant Battlemage",
             "text": "{G}, {T}: Target creature gains trample until end of turn.\n{U}, {T}: Target creature gains flying until end of turn.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "0d381488-9d11-5a96-a29a-1630984cab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1142-3ba8-4915-9541-757e59ed046c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1142-3ba8-4915-9541-757e59ed046c.jpg?1",
             "name": "Battlegrace Angel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains lifelink until end of turn.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "cadc1cf1-c97c-5731-a796-275277a0bfca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e54ce5-b496-4669-af2b-04a41ba20423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e54ce5-b496-4669-af2b-04a41ba20423.jpg?1",
             "name": "Cradle of Vitality",
             "text": "Whenever you gain life, you may pay {1}{W}. If you do, put a +1/+1 counter on target creature for each 1 life you gained.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "b409c487-3607-5611-b979-edca1be89ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cf0771-10d6-427a-b4e5-3e1d4db14667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cf0771-10d6-427a-b4e5-3e1d4db14667.jpg?1",
             "name": "Dispeller's Capsule",
             "text": "{2}{W}, {T}, Sacrifice Dispeller's Capsule: Destroy target artifact or enchantment.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "b7e1c806-feff-58ef-8fb9-d5178187a05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c52e52-2b1c-4ca8-ab6d-20d97a342704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c52e52-2b1c-4ca8-ab6d-20d97a342704.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "+1: Put a 1/1 white Soldier creature token into play.\n+1: Target creature gets +3/+3 and gains flying until end of turn.\n-8: For the rest of the game, artifacts, creatures, enchantments, and lands you control are indestructible.",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "b51d1cd4-98e2-57ea-8247-b36cedf72b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebe7a8-b982-4be4-83ca-3594e8f606b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebe7a8-b982-4be4-83ca-3594e8f606b4.jpg?1",
             "name": "Ethersworn Canonist",
             "text": "Each player who has played a nonartifact spell this turn can't play additional nonartifact spells.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "a4759480-4519-5613-8a47-2a0b6509d992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe080bc-e642-4fce-b4ee-bbe25d735673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe080bc-e642-4fce-b4ee-bbe25d735673.jpg?1",
             "name": "Excommunicate",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "fe4d0be3-1d63-5a13-933b-e0dfda6f09f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f718030-cc41-4e0d-a1ca-a33f577dc1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f718030-cc41-4e0d-a1ca-a33f577dc1fb.jpg?1",
             "name": "Guardians of Akrasa",
             "text": "Defender\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "41ed29f2-535c-5207-b7bf-0004351d8e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5343e6f2-7db7-4731-8e1b-70bf74316a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5343e6f2-7db7-4731-8e1b-70bf74316a79.jpg?1",
             "name": "Gustrider Exuberant",
             "text": "Flying\nSacrifice Gustrider Exuberant: Creatures you control with power 5 or greater gain flying until end of turn.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "4235ea07-62c9-542b-97b2-839b4649cd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c64bc-ba0c-4bab-9329-54805f4efa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c64bc-ba0c-4bab-9329-54805f4efa8a.jpg?1",
             "name": "Invincible Hymn",
             "text": "Count the number of cards in your library. Your life total becomes that number.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "0e0b0712-9a36-5fe8-b751-02da8a00c454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d56e2bf-1937-42c1-8f61-1fd93e84cef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d56e2bf-1937-42c1-8f61-1fd93e84cef7.jpg?1",
             "name": "Knight of the Skyward Eye",
             "text": "{3}{G}: Knight of the Skyward Eye gets +3/+3 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "9d97de87-334b-5b8b-98a6-ffb895980605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c6354-4dab-45c9-a1a6-57bd16f16e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c6354-4dab-45c9-a1a6-57bd16f16e30.jpg?1",
             "name": "Knight of the White Orchid",
             "text": "First strike\nWhen Knight of the White Orchid comes into play, if an opponent controls more lands than you, you may search your library for a Plains card, put it into play, then shuffle your library.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "12083d67-aa70-5e95-bb4a-ecc1fd5f2319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg?1",
             "name": "Knight-Captain of Eos",
             "text": "When Knight-Captain of Eos comes into play, put two 1/1 white Soldier creature tokens into play.\n{W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "ea409957-eaf7-5f77-aeed-d03fe0a08344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76e9580-9154-476b-923f-b23bf55db026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76e9580-9154-476b-923f-b23bf55db026.jpg?1",
             "name": "Marble Chalice",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "2431356a-11c8-5cb4-b1bf-0153da269162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad9f9d5-62c1-4dae-a2c8-5552210a70a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad9f9d5-62c1-4dae-a2c8-5552210a70a4.jpg?1",
             "name": "Metallurgeon",
             "text": "{W}, {T}: Regenerate target artifact.",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "a89e24d5-04c8-51da-a9a8-834872bdd323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895c270d-84d8-4c7f-9df3-5a595e113dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895c270d-84d8-4c7f-9df3-5a595e113dd7.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring comes into play, remove another target nonland permanent from the game.\nWhen Oblivion Ring leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -685,7 +685,7 @@
         },
         {
             "id": "6811dccc-8160-5a7d-9572-ec55f669c142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30ee26-5f78-4ac2-9105-1baa9ece8a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30ee26-5f78-4ac2-9105-1baa9ece8a21.jpg?1",
             "name": "Ranger of Eos",
             "text": "When Ranger of Eos comes into play, you may search your library for up to two creature cards with converted mana cost 1 or less, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "8327aaa4-bba0-52b8-b302-6140e2856792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3b0908-5408-41fd-8e69-2bc785e19304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3b0908-5408-41fd-8e69-2bc785e19304.jpg?1",
             "name": "Resounding Silence",
             "text": "Remove target attacking creature from the game.\nCycling {5}{G}{W}{U} ({5}{G}{W}{U}, Discard this card: Draw a card.)\nWhen you cycle Resounding Silence, remove up to two target attacking creatures from the game.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "900ce6bf-a910-5a64-9443-3a5808a09683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab62812-acc5-4b4b-97d3-106e399d69da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab62812-acc5-4b4b-97d3-106e399d69da.jpg?1",
             "name": "Rockcaster Platoon",
             "text": "{4}{G}: Rockcaster Platoon deals 2 damage to each creature with flying and each player.",
             "colours": [
@@ -791,7 +791,7 @@
         },
         {
             "id": "0ff583cd-f479-5cbd-819d-9cb78212310d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da1a2d5-d1fe-4aa2-aa83-64d6c269f7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da1a2d5-d1fe-4aa2-aa83-64d6c269f7bc.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle comes into play, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -826,7 +826,7 @@
         },
         {
             "id": "370405b0-e132-5b82-a8a4-fae2d9145569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8993b57-3060-45ca-80ed-3366784ec61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8993b57-3060-45ca-80ed-3366784ec61d.jpg?1",
             "name": "Scourglass",
             "text": "{T}, Sacrifice Scourglass: Destroy all permanents except for artifacts and lands. Play this ability only during your upkeep.",
             "colours": [
@@ -858,7 +858,7 @@
         },
         {
             "id": "26ebb1c0-3a17-52db-b6f6-26c83295ed14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07e2d4c-a33b-42b1-9576-2269d137a868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07e2d4c-a33b-42b1-9576-2269d137a868.jpg?1",
             "name": "Sighted-Caste Sorcerer",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{U}: Sighted-Caste Sorcerer gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -894,7 +894,7 @@
         },
         {
             "id": "ad021abd-8583-508c-afb1-cd1edb429edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b22520d-c495-4528-9b24-4aa19e046a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b22520d-c495-4528-9b24-4aa19e046a9e.jpg?1",
             "name": "Sigiled Paladin",
             "text": "First strike\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "f9a6edc0-08be-58c1-be48-0ef27881d266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2e8701-f2c3-4cc1-ac81-ba1987d80fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2e8701-f2c3-4cc1-ac81-ba1987d80fec.jpg?1",
             "name": "Soul's Grace",
             "text": "You gain life equal to target creature's power.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "ef56081d-4c94-5ec4-b4fa-a78380c7abf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44447e-09d1-450f-907f-42f79b004fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44447e-09d1-450f-907f-42f79b004fe7.jpg?1",
             "name": "Sunseed Nurturer",
             "text": "At the end of your turn, if you control a creature with power 5 or greater, you may gain 2 life.\n{T}: Add {1} to your mana pool.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "dbb243d7-7ce3-5ec3-a374-e0432a320fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198363f2-1a19-4954-b527-6d10ac277719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198363f2-1a19-4954-b527-6d10ac277719.jpg?1",
             "name": "Welkin Guide",
             "text": "Flying\nWhen Welkin Guide comes into play, target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "842b9905-8c3b-570b-b67a-4217a8ac0fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbbc7dc-efdf-46e8-bf19-0daa4034f6ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbbc7dc-efdf-46e8-bf19-0daa4034f6ec.jpg?1",
             "name": "Yoked Plowbeast",
             "text": "Cycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "a8a16a53-46c3-5d63-84e7-9a1bb4939036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0206c951-e38f-43ae-b4d2-0c71b6ccf8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0206c951-e38f-43ae-b4d2-0c71b6ccf8b1.jpg?1",
             "name": "Call to Heel",
             "text": "Return target creature to its owner's hand. Its controller draws a card.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "e4d7cd3c-7fbe-5057-9159-38c3a5f5ad79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479f56c2-8256-4325-909a-bf460505dbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479f56c2-8256-4325-909a-bf460505dbc5.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "4fe11754-cb6c-52e8-8257-7b9c629ce724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e63626d-f55c-4155-9712-511f591c0614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e63626d-f55c-4155-9712-511f591c0614.jpg?1",
             "name": "Cathartic Adept",
             "text": "{T}: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "58053228-c880-5db0-a2ed-a14ec32971d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f71ec76-47e1-4f55-bc57-e7b1c88baedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f71ec76-47e1-4f55-bc57-e7b1c88baedd.jpg?1",
             "name": "Cloudheath Drake",
             "text": "Flying\n{1}{W}: Cloudheath Drake gains vigilance until end of turn.",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "52bec705-35ab-577d-9b98-35b24428e4cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b820c-fd07-4e1f-9451-da9267347acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b820c-fd07-4e1f-9451-da9267347acd.jpg?1",
             "name": "Coma Veil",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -1235,7 +1235,7 @@
         },
         {
             "id": "0ce1ef37-cbe4-56c4-abcc-9cecfa8ca338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ae12ff-8039-4aac-aa50-f879376888a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ae12ff-8039-4aac-aa50-f879376888a1.jpg?1",
             "name": "Courier's Capsule",
             "text": "{1}{U}, {T}, Sacrifice Courier's Capsule: Draw two cards.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "55330417-236a-5e31-9043-c3a39dc38ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef9a534-8938-4f73-aa62-dd4d81a18cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef9a534-8938-4f73-aa62-dd4d81a18cc1.jpg?1",
             "name": "Covenant of Minds",
             "text": "Reveal the top three cards of your library. Target opponent may choose to put those cards into your hand. If he or she doesn't, put those cards into your graveyard and draw five cards.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "28ad9087-964c-5883-9fb3-7fc172b0e7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c1ff65-8ad5-42e0-9e4c-1caf83ab86e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c1ff65-8ad5-42e0-9e4c-1caf83ab86e0.jpg?1",
             "name": "Dawnray Archer",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{W}, {T}: Dawnray Archer deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "613bf8de-dcc6-5668-8813-19cf7e654ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac0076-8bd5-4fe2-bac8-fd102688fdcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac0076-8bd5-4fe2-bac8-fd102688fdcb.jpg?1",
             "name": "Esper Battlemage",
             "text": "{W}, {T}: Prevent the next 2 damage that would be dealt to you this turn.\n{B}, {T}: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -1373,7 +1373,7 @@
         },
         {
             "id": "6e513830-1f48-5b13-b660-8e4780e3d755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60731c6-7a25-4f2b-8ed1-2469a2d300c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60731c6-7a25-4f2b-8ed1-2469a2d300c6.jpg?1",
             "name": "Etherium Astrolabe",
             "text": "Flash\n{B}, {T}, Sacrifice an artifact: Draw a card.",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "f88c3bcd-18a0-567b-baf1-c65eb40c2600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d050f2d-bd65-4ab9-9ea6-9deba91b2792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d050f2d-bd65-4ab9-9ea6-9deba91b2792.jpg?1",
             "name": "Etherium Sculptor",
             "text": "Artifact spells you play cost {1} less to play.",
             "colours": [
@@ -1442,7 +1442,7 @@
         },
         {
             "id": "cdcf6faa-e84d-5e45-9b79-330a920796e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4becff-8280-4e29-a370-bf82fb6734d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4becff-8280-4e29-a370-bf82fb6734d5.jpg?1",
             "name": "Fatestitcher",
             "text": "{T}: You may tap or untap another target permanent.\nUnearth {U} ({U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "b94975e4-7252-5bd7-9cd7-a09f403487ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08790aaf-0142-4b20-89cf-cdaffeea4582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08790aaf-0142-4b20-89cf-cdaffeea4582.jpg?1",
             "name": "Filigree Sages",
             "text": "{2}{U}: Untap target artifact.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "d1cf4186-5ccc-58ef-9b28-fa070e3bf39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbadf982-f22e-4f4f-b5c9-ac387f25c15f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbadf982-f22e-4f4f-b5c9-ac387f25c15f.jpg?1",
             "name": "Gather Specimens",
             "text": "If a creature would come into play under an opponent's control this turn, it comes into play under your control instead.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "a08108e1-4de6-5c76-ae28-faa8d9f9fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55b1b92-575e-4b6f-9179-21d0bc1acd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55b1b92-575e-4b6f-9179-21d0bc1acd11.jpg?1",
             "name": "Jhessian Lookout",
             "text": "",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "a20e71ad-3bad-5d9f-9253-2707cc6d8d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150cf865-79e2-4f74-a872-44e1e5bc73c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150cf865-79e2-4f74-a872-44e1e5bc73c4.jpg?1",
             "name": "Kathari Screecher",
             "text": "Flying\nUnearth {2}{U} ({2}{U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "ca966e80-295a-5c38-8990-56154d5bab4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e04b01-ba98-4b69-976e-9ab8be3b5f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e04b01-ba98-4b69-976e-9ab8be3b5f7a.jpg?1",
             "name": "Kederekt Leviathan",
             "text": "When Kederekt Leviathan comes into play, return all other nonland permanents to their owners' hands.\nUnearth {6}{U} ({6}{U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "71bda905-471b-56e5-83e7-06e8a3246c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322cdf67-5b36-43f9-99b3-f0e24d423314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322cdf67-5b36-43f9-99b3-f0e24d423314.jpg?1",
             "name": "Master of Etherium",
             "text": "Master of Etherium's power and toughness are each equal to the number of artifacts you control.\nOther artifact creatures you control get +1/+1.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "89a7c985-3b15-50e6-8318-a6d082736b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fcee4c-58f4-43c6-832b-ca04ded704c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fcee4c-58f4-43c6-832b-ca04ded704c7.jpg?1",
             "name": "Memory Erosion",
             "text": "Whenever an opponent plays a spell, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "d38a31c2-c280-5582-b491-9bebe9a2a2ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c84e9f-ccbb-4fbc-98e1-4072968a1f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c84e9f-ccbb-4fbc-98e1-4072968a1f8a.jpg?1",
             "name": "Mindlock Orb",
             "text": "Players can't search libraries.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "35009170-a07b-567f-8961-c42775deea39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b681c8-6d20-4e43-95f8-e83d34626145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b681c8-6d20-4e43-95f8-e83d34626145.jpg?1",
             "name": "Outrider of Jhess",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "04e2ad23-644b-50cc-86b3-f7c756ed3109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273e2198-5549-4e82-8580-8769284d729d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273e2198-5549-4e82-8580-8769284d729d.jpg?1",
             "name": "Protomatter Powder",
             "text": "{4}{W}, {T}, Sacrifice Protomatter Powder: Return target artifact card from your graveyard to play.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "a0ec676d-e3c4-5039-8fd1-fd4bdc02edb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eca679-076d-42f0-9ec0-b8116a94e373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eca679-076d-42f0-9ec0-b8116a94e373.jpg?1",
             "name": "Resounding Wave",
             "text": "Return target permanent to its owner's hand.\nCycling {5}{W}{U}{B} ({5}{W}{U}{B}, Discard this card: Draw a card.)\nWhen you cycle Resounding Wave, return two target permanents to their owners' hands.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "5c494767-64be-5eeb-8619-44962c19706a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1722d394-ef72-4265-bc5b-eed7b91f5cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1722d394-ef72-4265-bc5b-eed7b91f5cb4.jpg?1",
             "name": "Sharding Sphinx",
             "text": "Flying\nWhenever an artifact creature you control deals combat damage to a player, you may put a 1/1 blue Thopter artifact creature token with flying into play.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "a1e35fb7-0614-5790-8605-304cecdf6811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ac7c8-8e01-4f80-a3fa-d533cb594d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ac7c8-8e01-4f80-a3fa-d533cb594d7c.jpg?1",
             "name": "Skill Borrower",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is an artifact or creature card, Skill Borrower has all activated abilities of that card. (If any of the abilities use that card's name, use this creature's name instead.)",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "4cebcfeb-1ebc-58ad-8668-ce25ea9203b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6870203-ece9-4fe0-912b-2dcf685f3eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6870203-ece9-4fe0-912b-2dcf685f3eb0.jpg?1",
             "name": "Spell Snip",
             "text": "Counter target spell unless its controller pays {1}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "5217edb4-01b9-5599-86cf-b9d8bbe1ccca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7e2501-2d36-41eb-a77a-747b62affc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7e2501-2d36-41eb-a77a-747b62affc09.jpg?1",
             "name": "Sphinx's Herald",
             "text": "{2}{U}, {T}, Sacrifice a white creature, a blue creature, and a black creature: Search your library for a card named Sphinx Sovereign and put it into play. Then shuffle your library.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "8198e8f0-60b2-5da7-bae9-c3ecf9d8ce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b02044-f3b4-425c-8e6c-697fff2c4ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b02044-f3b4-425c-8e6c-697fff2c4ef7.jpg?1",
             "name": "Steelclad Serpent",
             "text": "Steelclad Serpent can't attack unless you control another artifact.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "0c9c632a-0611-5bdb-931b-6524c02d252b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b214b6f-4734-4200-8467-92d7e3469b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b214b6f-4734-4200-8467-92d7e3469b5d.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "+1: Untap up to two target artifacts.\n-X: Search your library for an artifact card with converted mana cost X or less and put it into play. Then shuffle your library.\n-5: Artifacts you control become 5/5 artifact creatures until end of turn.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "f1889b36-2576-571f-bab9-a1e7728ffbdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ff8324-42b8-4eeb-8d0b-ea679c984933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ff8324-42b8-4eeb-8d0b-ea679c984933.jpg?1",
             "name": "Tortoise Formation",
             "text": "Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "f1711ec3-674b-5ae2-b5b6-ab151e2ec9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0198220-073f-4479-a1c4-1bd626891e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0198220-073f-4479-a1c4-1bd626891e28.jpg?1",
             "name": "Vectis Silencers",
             "text": "{2}{B}: Vectis Silencers gains deathtouch until end of turn. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "6deaff86-d4d7-5002-8c5e-5fc6d8365902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4ce4a1-65e3-4b40-be35-8fc55a968ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4ce4a1-65e3-4b40-be35-8fc55a968ec8.jpg?1",
             "name": "Ad Nauseam",
             "text": "Reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost. You may repeat this process any number of times.",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "851b7f1c-b7e6-5fcc-9348-ef4d7180a227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg?1",
             "name": "Archdemon of Unx",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a non-Zombie creature, then put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "e3578338-48ea-5f84-bf6e-314d18fd61b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef85030-d591-407d-8045-c595326dd6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef85030-d591-407d-8045-c595326dd6fa.jpg?1",
             "name": "Banewasp Affliction",
             "text": "Enchant creature\nWhen enchanted creature is put into a graveyard, that creature's controller loses life equal to its toughness.",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "2ba9fa75-10aa-55fa-a606-5f6786036313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f42bdeb-5a51-4303-96d8-9722f95d2905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f42bdeb-5a51-4303-96d8-9722f95d2905.jpg?1",
             "name": "Blister Beetle",
             "text": "When Blister Beetle comes into play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "6c15935d-d44f-5920-a681-4ca14f5a0560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a4b3a3-b7ae-4210-8037-098fdf5808d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a4b3a3-b7ae-4210-8037-098fdf5808d0.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to play Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "01a122bf-ae5d-5c8b-ac72-e2b216a4f1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feecfe75-ca1e-4e89-af2f-0e4ed2df1ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feecfe75-ca1e-4e89-af2f-0e4ed2df1ead.jpg?1",
             "name": "Corpse Connoisseur",
             "text": "When Corpse Connoisseur comes into play, you may search your library for a creature card and put that card into your graveyard. If you do, shuffle your library.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "9ec56341-c2b4-518f-b844-933269b5a308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972891e6-6a23-40df-af22-adf8cd7ea582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972891e6-6a23-40df-af22-adf8cd7ea582.jpg?1",
             "name": "Cunning Lethemancer",
             "text": "At the beginning of your upkeep, each player discards a card.",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "d3070188-507a-5d5b-9fd3-c10666ddc9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d59b5e5-fc16-4f1a-9f17-f42908473531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d59b5e5-fc16-4f1a-9f17-f42908473531.jpg?1",
             "name": "Death Baron",
             "text": "Skeleton creatures you control and other Zombie creatures you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "e20248f3-642c-5e92-bc60-0b1496370650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de74fa19-943e-4606-a793-ab5ccbe8db4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de74fa19-943e-4606-a793-ab5ccbe8db4a.jpg?1",
             "name": "Deathgreeter",
             "text": "Whenever another creature is put into a graveyard from play, you may gain 1 life.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "9b9459e1-b5d4-5435-b1b0-388e7597645d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aa309e-5df3-4419-9e9c-3fd928c1e360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aa309e-5df3-4419-9e9c-3fd928c1e360.jpg?1",
             "name": "Demon's Herald",
             "text": "{2}{B}, {T}, Sacrifice a blue creature, a black creature, and a red creature: Search your library for a card named Prince of Thralls and put it into play. Then shuffle your library.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "6902eda5-909b-5495-a4c7-018cf861e382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7771eba-bc2d-40f2-bab4-5e9cc4fe8f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7771eba-bc2d-40f2-bab4-5e9cc4fe8f34.jpg?1",
             "name": "Dreg Reaver",
             "text": "",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "4ceec1db-4f8b-565b-9df7-c47435089d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65b7ad-4ab0-4622-81f4-434254625a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65b7ad-4ab0-4622-81f4-434254625a1e.jpg?1",
             "name": "Dregscape Zombie",
             "text": "Unearth {B} ({B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "8e447aad-49b8-5786-8eb0-296a4d20a025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185059-fff9-47b0-9774-ad37dee345ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185059-fff9-47b0-9774-ad37dee345ed.jpg?1",
             "name": "Executioner's Capsule",
             "text": "{1}{B}, {T}, Sacrifice Executioner's Capsule: Destroy target nonblack creature.",
             "colours": [
@@ -2572,7 +2572,7 @@
         },
         {
             "id": "58f6dcbd-9072-59d3-9206-88a96c782e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71e4391-04a8-4df8-9d52-3a3480bcd5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71e4391-04a8-4df8-9d52-3a3480bcd5b6.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder comes into play, each player sacrifices a creature.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "f5e04b6b-8d68-5e41-a7db-1208c4ef70f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e030fb1-12a8-4c28-836f-8097ec753271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e030fb1-12a8-4c28-836f-8097ec753271.jpg?1",
             "name": "Glaze Fiend",
             "text": "Flying\nWhenever another artifact comes into play under your control, Glaze Fiend gets +2/+2 until end of turn.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "4210b7dd-5a20-52e2-88b8-18225ebb7eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd260c-a625-42a4-8192-27e42e18ac0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd260c-a625-42a4-8192-27e42e18ac0f.jpg?1",
             "name": "Grixis Battlemage",
             "text": "{U}, {T}: Draw a card, then discard a card.\n{R}, {T}: Target creature can't block this turn.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "a0f9c7d5-74c8-50c6-812e-d43a33eb3009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79ec57-7c45-4ef9-9051-449d473b65ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79ec57-7c45-4ef9-9051-449d473b65ea.jpg?1",
             "name": "Immortal Coil",
             "text": "{T}, Remove two cards in your graveyard from the game: Draw a card.\nIf damage would be dealt to you, prevent that damage. Remove a card in your graveyard from the game for each 1 damage prevented this way.\nWhen there are no cards in your graveyard, you lose the game.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "69bbddaa-a79f-5491-bb07-8bd562d04992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9dd080-5e13-4334-8614-8eec41ae89c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9dd080-5e13-4334-8614-8eec41ae89c2.jpg?1",
             "name": "Infest",
             "text": "All creatures get -2/-2 until end of turn.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "56fcf4a7-be80-5e28-91c7-eec968ce0c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3686eb57-e9c8-480f-8ab4-2894e1b5fe20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3686eb57-e9c8-480f-8ab4-2894e1b5fe20.jpg?1",
             "name": "Onyx Goblet",
             "text": "{T}: Target player loses 1 life.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "0035c018-9dcc-51f3-ab3f-ff49d4bfe405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ee904-95ca-4ec3-ad7d-ee084aa0c00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ee904-95ca-4ec3-ad7d-ee084aa0c00f.jpg?1",
             "name": "Puppet Conjurer",
             "text": "{U}, {T}: Put a 0/1 blue Homunculus artifact creature token into play.\nAt the beginning of your upkeep, sacrifice a Homunculus.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "d66459b5-6fd4-5ec2-854b-2e8d1646c774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d27eb7-2d3b-4daf-9cf6-c254fdacceb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d27eb7-2d3b-4daf-9cf6-c254fdacceb0.jpg?1",
             "name": "Resounding Scream",
             "text": "Target player discards a card at random.\nCycling {5}{U}{B}{R} ({5}{U}{B}{R}, Discard this card: Draw a card.)\nWhen you cycle Resounding Scream, target player discards two cards at random.",
             "colours": [
@@ -2846,7 +2846,7 @@
         },
         {
             "id": "bbe043b0-6545-5e8e-92e3-aa4abfcae36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b02c538-c2f9-47ef-9a07-8a41fe172d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b02c538-c2f9-47ef-9a07-8a41fe172d10.jpg?1",
             "name": "Salvage Titan",
             "text": "You may sacrifice three artifacts rather than pay Salvage Titan's mana cost.\nRemove three artifact cards in your graveyard from the game: Return Salvage Titan from your graveyard to your hand.",
             "colours": [
@@ -2881,7 +2881,7 @@
         },
         {
             "id": "ea3e987f-c7f4-5c0e-867f-c98d27ae6035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b7806f-c28f-40d4-b79e-f5a7725db298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b7806f-c28f-40d4-b79e-f5a7725db298.jpg?1",
             "name": "Scavenger Drake",
             "text": "Flying\nWhenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Scavenger Drake.",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "ccbd4119-63bd-5996-ae5d-36d116fe3a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ccd8c7-7472-47df-9d3e-1b5fb1431118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ccd8c7-7472-47df-9d3e-1b5fb1431118.jpg?1",
             "name": "Shadowfeed",
             "text": "Remove target card in a graveyard from the game. You gain 3 life.",
             "colours": [
@@ -2947,7 +2947,7 @@
         },
         {
             "id": "f9286a74-4fd0-5d18-a0ab-b614f54fd323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e5763-4892-47e4-8fd5-f576844c0a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e5763-4892-47e4-8fd5-f576844c0a0d.jpg?1",
             "name": "Shore Snapper",
             "text": "{U}: Shore Snapper gains islandwalk until end of turn.",
             "colours": [
@@ -2982,7 +2982,7 @@
         },
         {
             "id": "1a530311-5d85-5722-a7ed-31c2e8e3f2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e7e593-e5b0-4348-b8e5-20173d41aa39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e7e593-e5b0-4348-b8e5-20173d41aa39.jpg?1",
             "name": "Skeletal Kathari",
             "text": "Flying\n{B}, Sacrifice a creature: Regenerate Skeletal Kathari.",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "f067ce32-7790-519e-bdee-efb29b666692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1903f8-2863-4203-9552-a75759fa8c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1903f8-2863-4203-9552-a75759fa8c94.jpg?1",
             "name": "Tar Fiend",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\nWhen Tar Fiend comes into play, target player discards a card for each creature it devoured.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "1689a0af-78a2-57f1-b99a-f378a1010ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab9a62a-5503-430d-8b67-061a46b5c22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab9a62a-5503-430d-8b67-061a46b5c22c.jpg?1",
             "name": "Undead Leotau",
             "text": "{R}: Undead Leotau gets +1/-1 until end of turn.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3087,7 +3087,7 @@
         },
         {
             "id": "0fe80296-0168-5b6d-8b3b-d0cc8ccb917f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6402470-d829-4b9a-840c-1f97d6fd786f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6402470-d829-4b9a-840c-1f97d6fd786f.jpg?1",
             "name": "Vein Drinker",
             "text": "Flying\n{R}, {T}: Vein Drinker deals damage equal to its power to target creature. That creature deals damage equal to its power to Vein Drinker.\nWhenever a creature dealt damage by Vein Drinker this turn is put into a graveyard, put a +1/+1 counter on Vein Drinker.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "400f7219-1c7e-5bfd-b69d-749f691272af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d2d84-7141-4485-8379-b3c71af47cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d2d84-7141-4485-8379-b3c71af47cd1.jpg?1",
             "name": "Viscera Dragger",
             "text": "Cycling {2} ({2}, Discard this card: Draw a card.)\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "6f86e8e3-d587-5748-8f1a-3f48080e8610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e39677-5e04-45af-8f4c-1d4b6e737213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e39677-5e04-45af-8f4c-1d4b6e737213.jpg?1",
             "name": "Bloodpyre Elemental",
             "text": "Sacrifice Bloodpyre Elemental: Bloodpyre Elemental deals 4 damage to target creature. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -3192,7 +3192,7 @@
         },
         {
             "id": "6bc4439b-6861-5d62-a292-ccdafcbaa82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769e8f6-15ad-4f1b-bb4d-848ae6b7549e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769e8f6-15ad-4f1b-bb4d-848ae6b7549e.jpg?1",
             "name": "Bloodthorn Taunter",
             "text": "Haste\n{T}: Target creature with power 5 or greater gains haste until end of turn.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "032469db-9fb8-51ce-81b1-d3c115ad7476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg?1",
             "name": "Caldera Hellion",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nWhen Caldera Hellion comes into play, it deals 3 damage to each creature.",
             "colours": [
@@ -3261,7 +3261,7 @@
         },
         {
             "id": "8c5c6f0a-7ca3-5ad2-a606-359705e76dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a2d4ba-7bd0-4852-aad3-dfdaf5368e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a2d4ba-7bd0-4852-aad3-dfdaf5368e3e.jpg?1",
             "name": "Crucible of Fire",
             "text": "Dragon creatures you control get +3/+3.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "bbdc9bb3-6870-5cc3-a7fa-8d17728097aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab4120-e7d8-4132-a304-30b88e3175e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab4120-e7d8-4132-a304-30b88e3175e2.jpg?1",
             "name": "Dragon Fodder",
             "text": "Put two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -3325,7 +3325,7 @@
         },
         {
             "id": "2fa731b0-775e-5c92-a486-2f1c784d5491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5873e8-ba15-4a24-aab8-91f1f390d821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5873e8-ba15-4a24-aab8-91f1f390d821.jpg?1",
             "name": "Dragon's Herald",
             "text": "{2}{R}, {T}, Sacrifice a black creature, a red creature, and a green creature: Search your library for a card named Hellkite Overlord and put it into play. Then shuffle your library.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "d1ba0674-c8d0-507a-9cd4-e7c55d7572b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c08845-d195-447e-9e4d-020dcab5f80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c08845-d195-447e-9e4d-020dcab5f80f.jpg?1",
             "name": "Exuberant Firestoker",
             "text": "At the end of your turn, if you control a creature with power 5 or greater, you may have Exuberant Firestoker deal 2 damage to target player.\n{T}: Add {1} to your mana pool.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "f94eec89-7f0e-5bdd-9ae3-f6d215be498e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544b26b-0bc4-4c1b-9616-613e9bf08557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544b26b-0bc4-4c1b-9616-613e9bf08557.jpg?1",
             "name": "Flameblast Dragon",
             "text": "Flying\nWhenever Flameblast Dragon attacks, you may pay {X}{R}. If you do, Flameblast Dragon deals X damage to target creature or player.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "75e11199-6b16-5736-a259-be171e25dfa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039402e-2c74-4bea-b360-b93979b52698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039402e-2c74-4bea-b360-b93979b52698.jpg?1",
             "name": "Goblin Assault",
             "text": "At the beginning of your upkeep, put a 1/1 red Goblin creature token with haste into play.\nGoblin creatures attack each turn if able.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "fbf969f5-00e9-5557-94e1-4e6e88d7449b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa1475-797d-4cdc-93d6-e186c25e0bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa1475-797d-4cdc-93d6-e186c25e0bf5.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "Mountainwalk",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "88c01b4b-01f1-5298-9303-7ed9fc8337ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848f6c49-0913-4f12-886d-8b6defe8bfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848f6c49-0913-4f12-886d-8b6defe8bfab.jpg?1",
             "name": "Hell's Thunder",
             "text": "Flying, haste\nAt end of turn, sacrifice Hell's Thunder.\nUnearth {4}{R} ({4}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "e06729b0-7a65-5754-a1fd-cb55244ad1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8b8b90-cb6e-4910-bc40-d96b78b0d70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8b8b90-cb6e-4910-bc40-d96b78b0d70c.jpg?1",
             "name": "Hissing Iguanar",
             "text": "Whenever another creature is put into a graveyard from play, you may have Hissing Iguanar deal 1 damage to target player.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "30d80e43-e7ad-55df-94b0-98a7f90dccce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad3381e-ae2f-40cf-8a7b-62375e9f453e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad3381e-ae2f-40cf-8a7b-62375e9f453e.jpg?1",
             "name": "Incurable Ogre",
             "text": "",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "e6f68e20-811a-59c1-aa83-9523f2ae500b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8c962f-11b0-48f7-bbba-a2212e41990f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8c962f-11b0-48f7-bbba-a2212e41990f.jpg?1",
             "name": "Jund Battlemage",
             "text": "{B}, {T}: Target player loses 1 life.\n{G}, {T}: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "2137909f-6350-5746-952d-18ee646a01a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc1ad4c-b394-48b9-9a5a-ec9f42bf6a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc1ad4c-b394-48b9-9a5a-ec9f42bf6a00.jpg?1",
             "name": "Lightning Talons",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and has first strike.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "b2d01a66-68f4-53a9-8819-333c4d5a6feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708ec768-f455-48e4-b834-e0a2b3768c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708ec768-f455-48e4-b834-e0a2b3768c45.jpg?1",
             "name": "Magma Spray",
             "text": "Magma Spray deals 2 damage to target creature. If that creature would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "6e1b969d-27e4-510b-a2ac-79e047221419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg?1",
             "name": "Predator Dragon",
             "text": "Flying, haste\nDevour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "efcff0f2-cff3-577d-b7c8-31fc3a9ba81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7955-d939-4195-aba8-b46a8c925616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7955-d939-4195-aba8-b46a8c925616.jpg?1",
             "name": "Resounding Thunder",
             "text": "Resounding Thunder deals 3 damage to target creature or player.\nCycling {5}{B}{R}{G} ({5}{B}{R}{G}, Discard this card: Draw a card.)\nWhen you cycle Resounding Thunder, it deals 6 damage to target creature or player.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "dac9b025-3a49-5ce3-87c1-d100ccfb1e85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4275a8dd-f777-4160-b773-9a868e743218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4275a8dd-f777-4160-b773-9a868e743218.jpg?1",
             "name": "Ridge Rannet",
             "text": "Cycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "414cb7e6-bd56-5109-b32f-ac14f7709705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f26025-8777-41a2-a871-ea8d1af164ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f26025-8777-41a2-a871-ea8d1af164ae.jpg?1",
             "name": "Rockslide Elemental",
             "text": "First strike\nWhenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Rockslide Elemental.",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "64387a8c-ada7-5d39-a2ca-df87721aff40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e2ba9-8d23-4aca-8b50-4beb598d4a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e2ba9-8d23-4aca-8b50-4beb598d4a60.jpg?1",
             "name": "Scourge Devil",
             "text": "When Scourge Devil comes into play, creatures you control get +1/+0 until end of turn.\nUnearth {2}{R} ({2}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "dd7e6f86-0dfd-5969-81e0-e2d2f66ea95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c7f048-3e2b-4e97-a900-36da9b6ee2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c7f048-3e2b-4e97-a900-36da9b6ee2a8.jpg?1",
             "name": "Skeletonize",
             "text": "Skeletonize deals 3 damage to target creature. When a creature dealt damage this way is put into a graveyard this turn, put a 1/1 black Skeleton creature token into play with \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "1fc454c6-7f23-5b04-af04-1aaf15b01b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59a0305-65f8-45c4-859e-6c73544dfa3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59a0305-65f8-45c4-859e-6c73544dfa3e.jpg?1",
             "name": "Soul's Fire",
             "text": "Target creature you control in play deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "a0a76682-f9b2-516e-b6de-d64f22591ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7987de9-d812-4615-845a-3a90572d9b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7987de9-d812-4615-845a-3a90572d9b44.jpg?1",
             "name": "Thorn-Thrash Viashino",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\n{G}: Thorn-Thrash Viashino gains trample until end of turn.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "9d328c03-b945-5cd1-8276-9e22e9846122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552da28-01a3-4277-9e69-b297c3874ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552da28-01a3-4277-9e69-b297c3874ea4.jpg?1",
             "name": "Thunder-Thrash Elder",
             "text": "Devour 3 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with three times that many +1/+1 counters on it.)",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "553dcdb7-1198-51db-b9c7-f6225b87d665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9451a62-31a4-4aaf-beef-2bf149f25ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9451a62-31a4-4aaf-beef-2bf149f25ae3.jpg?1",
             "name": "Viashino Skeleton",
             "text": "{1}{B}, Discard a card: Regenerate Viashino Skeleton.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "7511cfb7-63a5-54cb-a741-ccac0e802724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d040791e-eee4-4eef-ace1-507216a5d268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d040791e-eee4-4eef-ace1-507216a5d268.jpg?1",
             "name": "Vicious Shadows",
             "text": "Whenever a creature is put into a graveyard from play, you may have Vicious Shadows deal damage to target player equal to the number of cards in that player's hand.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "b92a27ee-512d-5a6b-b62a-3c6525db82fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf290e2f-2c78-4cf5-8925-0c598ec0d60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf290e2f-2c78-4cf5-8925-0c598ec0d60e.jpg?1",
             "name": "Vithian Stinger",
             "text": "{T}: Vithian Stinger deals 1 damage to target creature or player.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -4112,7 +4112,7 @@
         },
         {
             "id": "d21faaf9-d6ed-52c3-941f-6a8974b83ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec1f1fa-41c9-4bc0-9171-902cd456aa73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec1f1fa-41c9-4bc0-9171-902cd456aa73.jpg?1",
             "name": "Volcanic Submersion",
             "text": "Destroy target artifact or land.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "09fe49d9-eb70-5e88-ae4f-b22b5a404013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e3faa-9573-4639-be99-517708c06218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e3faa-9573-4639-be99-517708c06218.jpg?1",
             "name": "Where Ancients Tread",
             "text": "Whenever a creature with power 5 or greater comes into play under your control, you may have Where Ancients Tread deal 5 damage to target creature or player.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "e38cfb30-6835-5d11-b81d-de07d6b44e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946e08b5-1c99-467c-abba-07ddede07a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946e08b5-1c99-467c-abba-07ddede07a6c.jpg?1",
             "name": "Algae Gharial",
             "text": "Shroud\nWhenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Algae Gharial.",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "daca1ad3-e80d-501a-a5f4-1d2520da41ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51e84d7-bf9f-454f-bdcd-a2458b1b5b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51e84d7-bf9f-454f-bdcd-a2458b1b5b33.jpg?1",
             "name": "Behemoth's Herald",
             "text": "{2}{G}, {T}, Sacrifice a red creature, a green creature, and a white creature: Search your library for a card named Godsire and put it into play. Then shuffle your library.",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "7cbb7cbb-9b54-5877-a996-2cd6eaf8d1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34748acb-7045-42b6-a93f-a3f11a1bc839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34748acb-7045-42b6-a93f-a3f11a1bc839.jpg?1",
             "name": "Cavern Thoctar",
             "text": "{1}{R}: Cavern Thoctar gets +1/+0 until end of turn.",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "34516754-941e-5a8a-9ae5-ed51b7d98532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3776b1c-4a3f-43b9-962e-64010f286ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3776b1c-4a3f-43b9-962e-64010f286ba5.jpg?1",
             "name": "Court Archers",
             "text": "Reach (This can block creatures with flying.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "9cd890c2-33b8-51cb-a328-e0f18d3c37bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3afaab6-4768-4852-a0b6-4e6a0295bde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3afaab6-4768-4852-a0b6-4e6a0295bde7.jpg?1",
             "name": "Cylian Elf",
             "text": "",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "8e867e59-a493-5d0d-baec-45c33fc62e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de32bf78-73c2-4cd4-b3b3-ef8be53e1e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de32bf78-73c2-4cd4-b3b3-ef8be53e1e5e.jpg?1",
             "name": "Druid of the Anima",
             "text": "{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [
@@ -4387,7 +4387,7 @@
         },
         {
             "id": "737c3399-e2ef-52e6-898d-19755f054569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83b664-a17e-4a48-8b9a-bd3af2d9cd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83b664-a17e-4a48-8b9a-bd3af2d9cd87.jpg?1",
             "name": "Drumhunter",
             "text": "At the end of your turn, if you control a creature with power 5 or greater, you may draw a card.\n{T}: Add {1} to your mana pool.",
             "colours": [
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "1da2555f-8856-585e-bc39-50a78ad255d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faccfa5f-4d89-4a86-92d7-36cb5a16c5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faccfa5f-4d89-4a86-92d7-36cb5a16c5c9.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary comes into play, draw a card.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "1dc6ea2d-4468-50ec-b63e-c9efff20d9f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f76986-e9fb-4c51-b946-880b501775b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f76986-e9fb-4c51-b946-880b501775b0.jpg?1",
             "name": "Feral Hydra",
             "text": "Feral Hydra comes into play with X +1/+1 counters on it.\n{3}: Put a +1/+1 counter on Feral Hydra. Any player may play this ability.",
             "colours": [
@@ -4493,7 +4493,7 @@
         },
         {
             "id": "6bcb67f6-1c60-51f6-b450-740b41238d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850be87-54de-49b3-a407-6fb2b278b25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850be87-54de-49b3-a407-6fb2b278b25c.jpg?1",
             "name": "Gift of the Gargantuan",
             "text": "Look at the top four cards of your library. You may reveal a creature card and/or a land card from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "015cccc3-0056-5702-a430-98d78b72d4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032059cb-c1ad-4cc9-a89d-d68289800312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032059cb-c1ad-4cc9-a89d-d68289800312.jpg?1",
             "name": "Godtoucher",
             "text": "{1}{W}, {T}: Prevent all damage that would be dealt to target creature with power 5 or greater this turn.",
             "colours": [
@@ -4561,7 +4561,7 @@
         },
         {
             "id": "269dc5f8-829c-5295-9f62-c51db15a234f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46870b-3d8d-4aae-8d59-6bd88a50b37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46870b-3d8d-4aae-8d59-6bd88a50b37c.jpg?1",
             "name": "Jungle Weaver",
             "text": "Reach (This can block creatures with flying.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4595,7 +4595,7 @@
         },
         {
             "id": "d533c498-b61e-5c92-a58c-f4ca9aadc03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb023a2-e929-47e9-bd58-cbc6f241e7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb023a2-e929-47e9-bd58-cbc6f241e7a4.jpg?1",
             "name": "Keeper of Progenitus",
             "text": "Whenever a player taps a Mountain, Forest, or Plains for mana, that player adds one mana to his or her mana pool of any type that land produced.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "a93a7753-f0e6-558f-aa81-a4468ca391ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62047f2-a41f-44b5-a6bc-28e35fad093b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62047f2-a41f-44b5-a6bc-28e35fad093b.jpg?1",
             "name": "Lush Growth",
             "text": "Enchant land\nEnchanted land is a Mountain, Forest, and Plains.",
             "colours": [
@@ -4664,7 +4664,7 @@
         },
         {
             "id": "37e877fd-b36a-5a4c-81a5-6fd941ac925a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee66318-4dbb-49a3-a3c8-ee0e1a9f02b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee66318-4dbb-49a3-a3c8-ee0e1a9f02b7.jpg?1",
             "name": "Mighty Emergence",
             "text": "Whenever a creature with power 5 or greater comes into play under your control, you may put two +1/+1 counters on it.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "9567fd12-cb9b-500b-81a1-dda9fc0df459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d2cc1-9868-4509-a541-728faf355b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d2cc1-9868-4509-a541-728faf355b6d.jpg?1",
             "name": "Manaplasm",
             "text": "Whenever you play a spell, Manaplasm gets +X/+X until end of turn, where X is that spell's converted mana cost.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "8bd306d1-e302-59ce-9547-1baad4dfde1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05afd921-ef3b-40fe-a1a8-582ee94ed3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05afd921-ef3b-40fe-a1a8-582ee94ed3f0.jpg?1",
             "name": "Mosstodon",
             "text": "{1}: Target creature with power 5 or greater gains trample until end of turn.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "185138b8-1a8f-53fd-8e48-56e4a0f82fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15360a16-b785-4ffe-bfa8-6c7f6a37455d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15360a16-b785-4ffe-bfa8-6c7f6a37455d.jpg?1",
             "name": "Mycoloth",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\nAt the beginning of your upkeep, put a 1/1 green Saproling creature token into play for each +1/+1 counter on Mycoloth.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "5f04f940-c5d4-5c4d-a710-f0b7b0a59bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7531879b-d5fd-4b60-b838-733883571473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7531879b-d5fd-4b60-b838-733883571473.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4831,7 +4831,7 @@
         },
         {
             "id": "650bbbd5-5ae4-5909-842f-c2ae291a1054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe73f62-2e80-4d5f-b7b5-c54c895a3e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe73f62-2e80-4d5f-b7b5-c54c895a3e4d.jpg?1",
             "name": "Naya Battlemage",
             "text": "{R}, {T}: Target creature gets +2/+0 until end of turn.\n{W}, {T}: Tap target creature.",
             "colours": [
@@ -4868,7 +4868,7 @@
         },
         {
             "id": "0dc236a3-d886-596c-b208-389708e5aeb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623e57ed-7ed7-4283-b48f-77ecacad70b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623e57ed-7ed7-4283-b48f-77ecacad70b0.jpg?1",
             "name": "Ooze Garden",
             "text": "{1}{G}, Sacrifice a non-Ooze creature: Put an X/X green Ooze creature token into play, where X is the sacrificed creature's power. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "843b9e6e-4ef9-55d8-880d-7c670134c937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217bf237-a758-4500-b221-5e88fed9d0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217bf237-a758-4500-b221-5e88fed9d0fc.jpg?1",
             "name": "Resounding Roar",
             "text": "Target creature gets +3/+3 until end of turn.\nCycling {5}{R}{G}{W} ({5}{R}{G}{W}, Discard this card: Draw a card.)\nWhen you cycle Resounding Roar, target creature gets +6/+6 until end of turn.",
             "colours": [
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "ba10cfcf-26d1-5693-92b7-28b80020b8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaae6a3-ae3c-4b7e-82e8-69147f61ee18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaae6a3-ae3c-4b7e-82e8-69147f61ee18.jpg?1",
             "name": "Rhox Charger",
             "text": "Trample\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4969,7 +4969,7 @@
         },
         {
             "id": "9f019054-8d92-5efa-8cc7-5f3f02da475e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad80819-22d4-43a8-97b2-7cf20f61bca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad80819-22d4-43a8-97b2-7cf20f61bca5.jpg?1",
             "name": "Sacellum Godspeaker",
             "text": "{T}: Reveal any number of creature cards with power 5 or greater from your hand. Add {G} to your mana pool for each card revealed this way.",
             "colours": [
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "b09839d4-4cfd-5320-ac4c-ae85d598359d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0367fac8-6990-4544-ac7d-ed363b55a9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0367fac8-6990-4544-ac7d-ed363b55a9cf.jpg?1",
             "name": "Savage Hunger",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has trample.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5038,7 +5038,7 @@
         },
         {
             "id": "572b841d-429b-58dc-a6a1-b7cc728d5e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5178576-573d-4da8-97ae-a684e1e95fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5178576-573d-4da8-97ae-a684e1e95fa4.jpg?1",
             "name": "Skullmulcher",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nWhen Skullmulcher comes into play, draw a card for each creature it devoured.",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "51da6e6f-1361-55ee-82e8-6826794c623c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ef536d-d55b-447a-b6ab-04123f1cfaa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ef536d-d55b-447a-b6ab-04123f1cfaa3.jpg?1",
             "name": "Soul's Might",
             "text": "Put X +1/+1 counters on target creature, where X is that creature's power.",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "9d39f8cf-27e8-58e3-9ba4-9cb66edeca73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132367ee-22e9-48e2-82e0-62ad9aaa62f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132367ee-22e9-48e2-82e0-62ad9aaa62f3.jpg?1",
             "name": "Spearbreaker Behemoth",
             "text": "Spearbreaker Behemoth is indestructible.\n{1}: Target creature with power 5 or greater is indestructible this turn.",
             "colours": [
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "5c2af4fe-8cda-50f8-9004-59d81da92335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0952ed-efc7-4ff5-a233-e64c0f11119b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0952ed-efc7-4ff5-a233-e64c0f11119b.jpg?1",
             "name": "Topan Ascetic",
             "text": "Tap an untapped creature you control: Topan Ascetic gets +1/+1 until end of turn.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "6c9b2396-b8aa-5013-956c-cb0796411472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb18038-eb6a-4d27-ba52-52a1cee6b512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb18038-eb6a-4d27-ba52-52a1cee6b512.jpg?1",
             "name": "Wild Nacatl",
             "text": "Wild Nacatl gets +1/+1 as long as you control a Mountain.\nWild Nacatl gets +1/+1 as long as you control a Plains.",
             "colours": [
@@ -5208,7 +5208,7 @@
         },
         {
             "id": "2dd0754e-f50a-5074-aa0f-ed97a70e775a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e246294f-7614-48e9-a655-647faf0bf697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e246294f-7614-48e9-a655-647faf0bf697.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "726e5400-7359-59f4-81dd-a23b91c85488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc108a3-15e5-44ab-a6e2-182b309f9c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc108a3-15e5-44ab-a6e2-182b309f9c0c.jpg?1",
             "name": "Ajani Vengeant",
             "text": "+1: Target permanent doesn't untap during its controller's next untap step.\n-2: Ajani Vengeant deals 3 damage to target creature or player and you gain 3 life.\n-7: Destroy all lands target player controls.",
             "colours": [
@@ -5280,7 +5280,7 @@
         },
         {
             "id": "697d6989-aac9-5160-88b3-64b31caf1997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b65c87-b084-44aa-b841-411a3c73e234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b65c87-b084-44aa-b841-411a3c73e234.jpg?1",
             "name": "Bant Charm",
             "text": "Choose one Destroy target artifact; or put target creature on the bottom of its owner's library; or counter target instant spell.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "8f5f7ba2-1fa4-5259-bb0c-06666e93eff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c05e8a2-b7d0-4f24-b2ae-8e4db30e5842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c05e8a2-b7d0-4f24-b2ae-8e4db30e5842.jpg?1",
             "name": "Blightning",
             "text": "Blightning deals 3 damage to target player. That player discards two cards.",
             "colours": [
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "8b39aa36-e553-559c-a5a7-99d2cfd20490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb468da0-b72b-4b46-994a-20677206ffb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb468da0-b72b-4b46-994a-20677206ffb7.jpg?1",
             "name": "Blood Cultist",
             "text": "{T}: Blood Cultist deals 1 damage to target creature.\nWhenever a creature dealt damage by Blood Cultist this turn is put into a graveyard, put a +1/+1 counter on Blood Cultist.",
             "colours": [
@@ -5387,7 +5387,7 @@
         },
         {
             "id": "28f377fe-a392-5784-adca-d540adc7bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7468876-f401-4a75-81c0-bed09cdda3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7468876-f401-4a75-81c0-bed09cdda3e1.jpg?1",
             "name": "Branching Bolt",
             "text": "Choose one or both Branching Bolt deals 3 damage to target creature with flying; and/or Branching Bolt deals 3 damage to target creature without flying.",
             "colours": [
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "d370ddcb-3c24-5fa9-95b1-062ab677f0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593409fd-26ef-463e-9101-ec5ad53dfd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593409fd-26ef-463e-9101-ec5ad53dfd67.jpg?1",
             "name": "Brilliant Ultimatum",
             "text": "Remove the top five cards of your library from the game. An opponent separates those cards into two piles. You may play any number of cards from one of those piles without paying their mana costs.",
             "colours": [
@@ -5457,7 +5457,7 @@
         },
         {
             "id": "4581b6e0-8653-5274-96eb-87718fa0e267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1360e-7c6b-400c-893a-82d93e53101e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1360e-7c6b-400c-893a-82d93e53101e.jpg?1",
             "name": "Broodmate Dragon",
             "text": "Flying\nWhen Broodmate Dragon comes into play, put a 4/4 red Dragon creature token with flying into play.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "fefeefc6-8e67-51a3-a144-4475d76b56d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae0fe2-5d52-434c-8ad1-4a5e42f4b7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae0fe2-5d52-434c-8ad1-4a5e42f4b7c4.jpg?1",
             "name": "Bull Cerodon",
             "text": "Vigilance, haste",
             "colours": [
@@ -5531,7 +5531,7 @@
         },
         {
             "id": "808b0592-a5c5-55f8-ba8e-e3d4a2f87669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c7b9e-eb80-4842-8aa3-1d0c46d9677e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c7b9e-eb80-4842-8aa3-1d0c46d9677e.jpg?1",
             "name": "Carrion Thrash",
             "text": "When Carrion Thrash is put into a graveyard from play, you may pay {2}. If you do, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "88df3b21-3898-5baa-b560-30bcdf6d3cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e8bf21-0baf-4ee9-b224-b9eee50df280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e8bf21-0baf-4ee9-b224-b9eee50df280.jpg?1",
             "name": "Clarion Ultimatum",
             "text": "Choose five permanents you control. For each of those permanents, you may search your library for a card with the same name as that permanent. Put those cards into play tapped, then shuffle your library.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "84a1e895-67d8-50a8-84c3-6a873daece9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d267804-23de-4521-ae64-4dd5cd836c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d267804-23de-4521-ae64-4dd5cd836c6c.jpg?1",
             "name": "Cruel Ultimatum",
             "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "5ea5f834-4687-53bc-9036-7cb6df98a8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4885a83-9410-4c88-b45e-1e1626fe90ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4885a83-9410-4c88-b45e-1e1626fe90ea.jpg?1",
             "name": "Deft Duelist",
             "text": "First strike\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -5679,7 +5679,7 @@
         },
         {
             "id": "d0271649-5c3a-5fa0-9ccf-4a13875c0629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b789ea-df50-49a5-bd64-3b74b4042f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b789ea-df50-49a5-bd64-3b74b4042f83.jpg?1",
             "name": "Empyrial Archangel",
             "text": "Flying, shroud\nAll damage that would be dealt to you is dealt to Empyrial Archangel instead.",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "bc4e162f-7978-5df5-81d1-b51d2a95752c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d70a07-8d91-462c-aa96-901cc9a81531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d70a07-8d91-462c-aa96-901cc9a81531.jpg?1",
             "name": "Esper Charm",
             "text": "Choose one Destroy target enchantment; or draw two cards; or target player discards two cards.",
             "colours": [
@@ -5753,7 +5753,7 @@
         },
         {
             "id": "8abfaf81-8d7e-5762-96fa-ded92fa9f4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70db6085-9707-4902-966d-b13bb6a0f62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70db6085-9707-4902-966d-b13bb6a0f62f.jpg?1",
             "name": "Fire-Field Ogre",
             "text": "First strike\nUnearth {U}{B}{R} ({U}{B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "fea4f333-e0ba-50f8-aac0-428e5211ff1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fd1253-1af1-42a7-9875-4d6ac9ce722c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fd1253-1af1-42a7-9875-4d6ac9ce722c.jpg?1",
             "name": "Goblin Deathraiders",
             "text": "Trample",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "b20e873f-1d00-5acd-82a4-0d29d67d455b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2539ff7-2b7d-47e3-bd77-3138a6c42d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2539ff7-2b7d-47e3-bd77-3138a6c42d2b.jpg?1",
             "name": "Godsire",
             "text": "Vigilance\n{T}: Put an 8/8 Beast creature token into play that's red, green, and white.",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "a963bd60-c7a4-5724-a79d-6af3d001fb42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a6695-44ce-445f-b476-e18a0b5dd8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a6695-44ce-445f-b476-e18a0b5dd8f2.jpg?1",
             "name": "Grixis Charm",
             "text": "Choose one Return target permanent to its owner's hand; or target creature gets -4/-4 until end of turn; or creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "a57bfd6f-3205-5d22-b473-f4ea30677431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89185829-5c93-4fd9-8c56-11820be6a970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89185829-5c93-4fd9-8c56-11820be6a970.jpg?1",
             "name": "Hellkite Overlord",
             "text": "Flying, trample, haste\n{R}: Hellkite Overlord gets +1/+0 until end of turn.\n{B}{G}: Regenerate Hellkite Overlord.",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "d1636960-1147-5937-9bd8-8fae33a4978f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e43870-4bed-4d76-a633-a6326c736d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e43870-4bed-4d76-a633-a6326c736d22.jpg?1",
             "name": "Hindering Light",
             "text": "Counter target spell that targets you or a permanent you control.\nDraw a card.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "3d2c92b6-18f1-5863-95ca-c1db14d20c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1761d867-2eb0-406b-b175-97a90c457844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1761d867-2eb0-406b-b175-97a90c457844.jpg?1",
             "name": "Jhessian Infiltrator",
             "text": "Jhessian Infiltrator is unblockable.",
             "colours": [
@@ -6012,7 +6012,7 @@
         },
         {
             "id": "3810b9f6-0ea7-545e-855a-95b84ecc4be9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ddf00-926c-4283-a8b2-daa02fa99b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ddf00-926c-4283-a8b2-daa02fa99b8b.jpg?1",
             "name": "Jund Charm",
             "text": "Choose one Remove target player's graveyard from the game; or Jund Charm deals 2 damage to each creature; or put two +1/+1 counters on target creature.",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "04337c9d-2158-5d25-bd60-84bf270aba1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701498e5-1d4d-42f4-9dd0-5d4cf78f0e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701498e5-1d4d-42f4-9dd0-5d4cf78f0e68.jpg?1",
             "name": "Kederekt Creeper",
             "text": "Deathtouch (Whenever this creature deals damage to a creature, destroy that creature.)\nKederekt Creeper can't be blocked except by two or more creatures.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "d5cfe434-6b6a-50f7-a44e-360a3d41acc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b094f-1d43-4240-9333-398464fc1ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b094f-1d43-4240-9333-398464fc1ac6.jpg?1",
             "name": "Kiss of the Amesha",
             "text": "Target player gains 7 life and draws two cards.",
             "colours": [
@@ -6120,7 +6120,7 @@
         },
         {
             "id": "59f46ccf-da29-5e0d-9b6d-a32132e1bf4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485fe46-ed24-4b55-8ddc-ac2fdf4eec93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485fe46-ed24-4b55-8ddc-ac2fdf4eec93.jpg?1",
             "name": "Kresh the Bloodbraided",
             "text": "Whenever another creature is put into a graveyard from play, you may put X +1/+1 counters on Kresh the Bloodbraided, where X is that creature's power.",
             "colours": [
@@ -6161,7 +6161,7 @@
         },
         {
             "id": "c016f269-0761-5dda-ae2e-e3d105eb4777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316b1fd1-5ec4-4bdc-938b-cbace1bb3f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316b1fd1-5ec4-4bdc-938b-cbace1bb3f42.jpg?1",
             "name": "Mayael the Anima",
             "text": "{3}{R}{G}{W}, {T}: Look at the top five cards of your library. You may put a creature card with power 5 or greater from among them into play. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "780e59ed-f13c-5ef2-9eb6-390b482544ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47748c3a-c60a-4f2e-9eb8-2675c067bb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47748c3a-c60a-4f2e-9eb8-2675c067bb9c.jpg?1",
             "name": "Naya Charm",
             "text": "Choose one Naya Charm deals 3 damage to target creature; or return target card in a graveyard to its owner's hand; or tap all creatures target player controls.",
             "colours": [
@@ -6238,7 +6238,7 @@
         },
         {
             "id": "77358242-1cff-5044-95ba-c01022ba44d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3ea5f-1261-4f27-a87a-2b4475ad6a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3ea5f-1261-4f27-a87a-2b4475ad6a4b.jpg?1",
             "name": "Necrogenesis",
             "text": "{2}: Remove target creature card in a graveyard from the game. Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "ce7ff7e5-c4e5-57c7-8b18-bb3d5bcb1a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d6e8a2-d1b0-4aae-95f5-6ecc5718d454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d6e8a2-d1b0-4aae-95f5-6ecc5718d454.jpg?1",
             "name": "Prince of Thralls",
             "text": "Whenever a permanent an opponent controls is put into a graveyard, put that card into play under your control unless that opponent pays 3 life.",
             "colours": [
@@ -6310,7 +6310,7 @@
         },
         {
             "id": "b56b01f3-576c-5307-a463-db5009913000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc37d01-ffe5-4dfe-b59e-204df82d1d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc37d01-ffe5-4dfe-b59e-204df82d1d36.jpg?1",
             "name": "Punish Ignorance",
             "text": "Counter target spell. Its controller loses 3 life and you gain 3 life.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "bde234d9-db51-58d1-a19f-ff981e1ad048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e1284-eea2-4fc4-99e4-ed53176939ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e1284-eea2-4fc4-99e4-ed53176939ba.jpg?1",
             "name": "Qasali Ambusher",
             "text": "Reach\nIf a creature is attacking you and you control a Forest and a Plains, you may play Qasali Ambusher without paying its mana cost and as though it had flash.",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "91ab4603-562c-59b7-8337-6c5ef922477a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c188d-c11d-46f7-a2d8-a67df4ba401b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c188d-c11d-46f7-a2d8-a67df4ba401b.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -6426,7 +6426,7 @@
         },
         {
             "id": "34b6adf4-3e43-5724-bb2a-5c5b10714c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995ab8-7382-4c2a-b8c7-8b9272cab4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995ab8-7382-4c2a-b8c7-8b9272cab4fb.jpg?1",
             "name": "Rakeclaw Gargantuan",
             "text": "{1}: Target creature with power 5 or greater gains first strike until end of turn.",
             "colours": [
@@ -6464,7 +6464,7 @@
         },
         {
             "id": "9681fb76-bc23-50c6-99e8-7ca130f855e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ecfc6-1f9e-443e-a445-51df518025a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ecfc6-1f9e-443e-a445-51df518025a5.jpg?1",
             "name": "Realm Razer",
             "text": "When Realm Razer comes into play, remove all lands from the game.\nWhen Realm Razer leaves play, return the removed cards to play tapped under their owners' control.",
             "colours": [
@@ -6502,7 +6502,7 @@
         },
         {
             "id": "ff970dc0-db93-5832-a398-9b8ff796e8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb67e1-b791-4246-aebc-49fcf0f92c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb67e1-b791-4246-aebc-49fcf0f92c6c.jpg?1",
             "name": "Rhox War Monk",
             "text": "Lifelink",
             "colours": [
@@ -6541,7 +6541,7 @@
         },
         {
             "id": "84fab52d-144d-5ec3-a647-51ff85a0e10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d61c4a0-054b-479e-82d9-dc60c5c708e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d61c4a0-054b-479e-82d9-dc60c5c708e2.jpg?1",
             "name": "Rip-Clan Crasher",
             "text": "Haste",
             "colours": [
@@ -6578,7 +6578,7 @@
         },
         {
             "id": "3d491719-44f6-5498-a5a0-a24eea9a1790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4527e-e449-45d0-a551-634e2ceb21c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4527e-e449-45d0-a551-634e2ceb21c4.jpg?1",
             "name": "Sangrite Surge",
             "text": "Target creature gets +3/+3 and gains double strike until end of turn.",
             "colours": [
@@ -6612,7 +6612,7 @@
         },
         {
             "id": "f56c7b74-9f65-538f-a06f-79b477636b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89ded2-db31-43c0-b00c-999d5d3fa5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89ded2-db31-43c0-b00c-999d5d3fa5c6.jpg?1",
             "name": "Sarkhan Vol",
             "text": "+1: Creatures you control get +1/+1 and gain haste until end of turn.\n-2: Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n-6: Put five 4/4 red Dragon creature tokens with flying into play.",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "8e2d580b-b198-58e6-9314-d45f6f09be21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ca8f2a-ee0e-4708-97d8-c1836d824d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ca8f2a-ee0e-4708-97d8-c1836d824d4e.jpg?1",
             "name": "Sedraxis Specter",
             "text": "Flying\nWhenever Sedraxis Specter deals combat damage to a player, that player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "da710717-1785-5d97-8532-064eb21ce7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70206cff-9f54-4e27-982c-b0093a51d358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70206cff-9f54-4e27-982c-b0093a51d358.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to play. The creature gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -6729,7 +6729,7 @@
         },
         {
             "id": "cdebe993-317c-5139-9c9a-c67126b907c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589eaa8-95ec-4c97-8155-185487560ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589eaa8-95ec-4c97-8155-185487560ae6.jpg?1",
             "name": "Sharuum the Hegemon",
             "text": "Flying\nWhen Sharuum the Hegemon comes into play, you may return target artifact card from your graveyard to play.",
             "colours": [
@@ -6770,7 +6770,7 @@
         },
         {
             "id": "247d0eb6-6d5d-599e-a5fc-d022325b8efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae9ce20-d283-4d29-8140-bc4cf8de66df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae9ce20-d283-4d29-8140-bc4cf8de66df.jpg?1",
             "name": "Sigil Blessing",
             "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "a6529835-b028-5fac-8ec7-a3b6979e8a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fc130e-57ed-40a7-a9ba-d689e7dc3698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fc130e-57ed-40a7-a9ba-d689e7dc3698.jpg?1",
             "name": "Sphinx Sovereign",
             "text": "Flying\nAt the end of your turn, you gain 3 life if Sphinx Sovereign is untapped. Otherwise, each opponent loses 3 life.",
             "colours": [
@@ -6843,7 +6843,7 @@
         },
         {
             "id": "dfa09747-4701-5a53-a575-05ce49c034d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8950df86-1e27-4b6b-8b5c-25298a3bda85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8950df86-1e27-4b6b-8b5c-25298a3bda85.jpg?1",
             "name": "Sprouting Thrinax",
             "text": "When Sprouting Thrinax is put into a graveyard from play, put three 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -6881,7 +6881,7 @@
         },
         {
             "id": "73910073-be5d-5e1f-8932-4874fd95678b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e21ff9-0030-4e53-8ddf-86d8e78e347f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e21ff9-0030-4e53-8ddf-86d8e78e347f.jpg?1",
             "name": "Steward of Valeron",
             "text": "Vigilance\n{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6919,7 +6919,7 @@
         },
         {
             "id": "d15a77d4-e09b-598a-bcac-16bb0ebdf2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d559e0-ae4e-4e21-bd3b-726fffb87d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d559e0-ae4e-4e21-bd3b-726fffb87d2b.jpg?1",
             "name": "Stoic Angel",
             "text": "Flying, vigilance\nPlayers can't untap more than one creature during their untap steps.",
             "colours": [
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "6d1cb59d-0569-520e-824f-9b21cb46a79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10affb59-7c57-4b72-892b-d813f385f4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10affb59-7c57-4b72-892b-d813f385f4a9.jpg?1",
             "name": "Swerve",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "d3195ab6-95a3-5284-a36b-e928638a2888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9af048-43c2-44ff-9ca0-2a81609a4e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9af048-43c2-44ff-9ca0-2a81609a4e91.jpg?1",
             "name": "Thoughtcutter Agent",
             "text": "{U}{B}, {T}: Target player loses 1 life and reveals his or her hand.",
             "colours": [
@@ -7029,7 +7029,7 @@
         },
         {
             "id": "d96b7e36-63b3-5ba1-b817-f97ff929dfe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abecc77-07f2-43e4-8585-0a8199cdcf01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abecc77-07f2-43e4-8585-0a8199cdcf01.jpg?1",
             "name": "Tidehollow Sculler",
             "text": "When Tidehollow Sculler comes into play, target opponent reveals his or her hand and you choose a nonland card from it. Remove that card from the game.\nWhen Tidehollow Sculler leaves play, return the removed card to its owner's hand.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "b18d3df9-ba28-5f21-9ed9-d978bdcfd53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aafc65d-faa8-4bfe-83ac-7714c969022b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aafc65d-faa8-4bfe-83ac-7714c969022b.jpg?1",
             "name": "Tidehollow Strix",
             "text": "Flying\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -7103,7 +7103,7 @@
         },
         {
             "id": "f335ad3a-d7b3-526c-bad7-a092b53bb30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d28fd77-1f7c-47b4-b9ff-55835a7f2526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d28fd77-1f7c-47b4-b9ff-55835a7f2526.jpg?1",
             "name": "Titanic Ultimatum",
             "text": "Until end of turn, creatures you control get +5/+5 and gain first strike, lifelink, and trample.",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "374521b1-28bf-596b-b875-67da4564f9f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10504d1b-8d3e-411a-bf40-51a8e7a863a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10504d1b-8d3e-411a-bf40-51a8e7a863a0.jpg?1",
             "name": "Tower Gargoyle",
             "text": "Flying",
             "colours": [
@@ -7178,7 +7178,7 @@
         },
         {
             "id": "88593e5b-ab39-58c0-81f4-5172f3fecc08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6ac9ce-e163-426f-8fbd-5ee1ec177dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6ac9ce-e163-426f-8fbd-5ee1ec177dc1.jpg?1",
             "name": "Violent Ultimatum",
             "text": "Destroy three target permanents.",
             "colours": [
@@ -7214,7 +7214,7 @@
         },
         {
             "id": "64dad49d-44a1-55bc-a75e-2f5d209c34ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75ebcb4-5db8-4c72-9f65-8ee8f2c893ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75ebcb4-5db8-4c72-9f65-8ee8f2c893ea.jpg?1",
             "name": "Waveskimmer Aven",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -7253,7 +7253,7 @@
         },
         {
             "id": "71e72a68-6b5f-50c7-bec8-99fdf936f3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0e7d-9146-402f-898e-16a0ff08d368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0e7d-9146-402f-898e-16a0ff08d368.jpg?1",
             "name": "Windwright Mage",
             "text": "Lifelink (Whenever this creature deals damage, you gain that much life.)\nWindwright Mage has flying as long as an artifact card is in your graveyard.",
             "colours": [
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "01bc9e62-f8b9-5ecd-84fb-7af022492617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5907d5-ae5c-4c9d-a5df-61f1c94f979d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5907d5-ae5c-4c9d-a5df-61f1c94f979d.jpg?1",
             "name": "Woolly Thoctar",
             "text": "",
             "colours": [
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "94b40729-8d60-5d41-b65e-5ef1c927909e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78aa9a89-b7bf-49bc-a6e8-793d52120a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78aa9a89-b7bf-49bc-a6e8-793d52120a22.jpg?1",
             "name": "Lich's Mirror",
             "text": "If you would lose the game, instead shuffle your hand, your graveyard, and all permanents you own into your library, then draw seven cards and your life total becomes 20.",
             "colours": [],
@@ -7359,7 +7359,7 @@
         },
         {
             "id": "bf059961-8133-5dd1-83e0-98ee903310d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a48f9-4f14-4d19-b3dc-3bf3fafac32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a48f9-4f14-4d19-b3dc-3bf3fafac32d.jpg?1",
             "name": "Minion Reflector",
             "text": "Whenever a nontoken creature comes into play under your control, you may pay {2}. If you do, put a token into play that's a copy of that creature. That token has haste and \"At end of turn, sacrifice this permanent.\"",
             "colours": [],
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "6b9b966e-e28f-55ee-b86e-7b927d9aab9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cefe6ab-c018-4b87-8948-295a28f63cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cefe6ab-c018-4b87-8948-295a28f63cb1.jpg?1",
             "name": "Obelisk of Bant",
             "text": "{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [],
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "8e39d5b8-c326-5e69-82a9-c2a36796a513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19869e75-0925-45dc-b5d9-6968fbfb35b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19869e75-0925-45dc-b5d9-6968fbfb35b5.jpg?1",
             "name": "Obelisk of Esper",
             "text": "{T}: Add {W}, {U}, or {B} to your mana pool.",
             "colours": [],
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "863a9b29-b699-588e-828e-dd0c95d2ecf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200e41f-fe10-4c39-ab12-c6e13fb81a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200e41f-fe10-4c39-ab12-c6e13fb81a3d.jpg?1",
             "name": "Obelisk of Grixis",
             "text": "{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7483,7 +7483,7 @@
         },
         {
             "id": "6a3f7df6-2a19-519b-8350-1b36e62debe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe1a49a-5c1c-4274-a2ed-9a8a44abfaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe1a49a-5c1c-4274-a2ed-9a8a44abfaa6.jpg?1",
             "name": "Obelisk of Jund",
             "text": "{T}: Add {B}, {R}, or {G} to your mana pool.",
             "colours": [],
@@ -7515,7 +7515,7 @@
         },
         {
             "id": "3880e794-6024-525b-8e65-29255a7d5c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6317b0-15fd-4924-9302-41bed2354546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6317b0-15fd-4924-9302-41bed2354546.jpg?1",
             "name": "Obelisk of Naya",
             "text": "{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [],
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "f22a3c3c-fad2-53d5-97d2-fd7f924c937d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d1b27-fb90-4649-a905-f8e90d4a1852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d1b27-fb90-4649-a905-f8e90d4a1852.jpg?1",
             "name": "Quietus Spike",
             "text": "Equipped creature has deathtouch.\nWhenever equipped creature deals combat damage to a player, that player loses half his or her life, rounded up.\nEquip {3}",
             "colours": [],
@@ -7577,7 +7577,7 @@
         },
         {
             "id": "f2ac8a61-cd66-5a26-b235-e53b497c5fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c41192-64ef-43aa-9af0-75f0d3f56688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c41192-64ef-43aa-9af0-75f0d3f56688.jpg?1",
             "name": "Relic of Progenitus",
             "text": "{T}: Target player removes a card in his or her graveyard from the game.\n{1}, Remove Relic of Progenitus from the game: Remove all graveyards from the game. Draw a card.",
             "colours": [],
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "f1b2db02-3202-5897-b76d-727c64a88b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac2d98-bc5d-4823-9903-b880988ff0f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac2d98-bc5d-4823-9903-b880988ff0f4.jpg?1",
             "name": "Sigil of Distinction",
             "text": "Sigil of Distinction comes into play with X charge counters on it.\nEquipped creature gets +1/+1 for each charge counter on Sigil of Distinction.\nEquip\u2014\nRemove a charge counter from Sigil of Distinction.",
             "colours": [],
@@ -7635,7 +7635,7 @@
         },
         {
             "id": "7771916d-6540-5894-b03c-ba6bc70040f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edc0681-4252-4d3d-baf3-f03c22af1208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edc0681-4252-4d3d-baf3-f03c22af1208.jpg?1",
             "name": "Arcane Sanctum",
             "text": "Arcane Sanctum comes into play tapped.\n{T}: Add {W}, {U}, or {B} to your mana pool.",
             "colours": [],
@@ -7667,7 +7667,7 @@
         },
         {
             "id": "0c5d1d3b-484a-593b-805f-63ca0eab0ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c6b34-0066-47f8-8062-9363c024fa56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c6b34-0066-47f8-8062-9363c024fa56.jpg?1",
             "name": "Bant Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Bant Panorama: Search your library for a basic Forest, Plains, or Island card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7695,7 +7695,7 @@
         },
         {
             "id": "2165c158-4c3a-55fe-a896-710a4442a2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94da8e38-77a4-4d25-9e1f-f33c246f60c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94da8e38-77a4-4d25-9e1f-f33c246f60c8.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "Crumbling Necropolis comes into play tapped.\n{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "015b2039-2985-5e79-bf02-3f5c73f1687d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03324b45-dd69-45d2-a1c0-e3cc4cf1eaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03324b45-dd69-45d2-a1c0-e3cc4cf1eaf5.jpg?1",
             "name": "Esper Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Esper Panorama: Search your library for a basic Plains, Island, or Swamp card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "66192c87-6509-5ada-8e90-9f682d4b4984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca30ea9e-9302-4dd0-a572-b5c6e6894851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca30ea9e-9302-4dd0-a572-b5c6e6894851.jpg?1",
             "name": "Grixis Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Grixis Panorama: Search your library for a basic Island, Swamp, or Mountain card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "67315436-4f4d-5470-9836-0bd48632da59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b31fcd-43eb-44ad-b63e-4f2e6984963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b31fcd-43eb-44ad-b63e-4f2e6984963c.jpg?1",
             "name": "Jund Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Jund Panorama: Search your library for a basic Swamp, Mountain, or Forest card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "f2d014f8-3641-5ad6-8dc7-108b563743aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine comes into play tapped.\n{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [],
@@ -7843,7 +7843,7 @@
         },
         {
             "id": "1962172e-244e-5135-82c2-165f6bbe5290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba31e86-0924-424d-b4e3-41a878e3e0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba31e86-0924-424d-b4e3-41a878e3e0e1.jpg?1",
             "name": "Naya Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Naya Panorama: Search your library for a basic Mountain, Forest, or Plains card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "e3b4dc9f-7074-5c8d-b2f8-0f64503ac3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bcded3-6eea-4533-a855-e03d4c4620d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bcded3-6eea-4533-a855-e03d4c4620d6.jpg?1",
             "name": "Savage Lands",
             "text": "Savage Lands comes into play tapped.\n{T}: Add {B}, {R}, or {G} to your mana pool.",
             "colours": [],
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "f34d3f11-9b48-5a23-8915-586a230ce2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1995d2a-4550-4c84-ad44-183b06579e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1995d2a-4550-4c84-ad44-183b06579e98.jpg?1",
             "name": "Seaside Citadel",
             "text": "Seaside Citadel comes into play tapped.\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [],
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "80e1113b-ba55-5026-a221-eb97d0d1441b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e2710-7b95-46d0-8261-0afa6b192e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e2710-7b95-46d0-8261-0afa6b192e70.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "f61366f9-cc2e-52e1-afa7-57ecbb72472b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef285a1-dbd0-4e41-9f04-a9120a0421f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef285a1-dbd0-4e41-9f04-a9120a0421f7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8011,7 +8011,7 @@
         },
         {
             "id": "a276b18e-9f96-56b9-a60a-2155f039946a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd1595-d94d-46b1-b87f-b910ae35fa3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd1595-d94d-46b1-b87f-b910ae35fa3a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "d6b2d79d-d5ba-5c42-932e-460ed84e9e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aec487-ac03-4912-969b-f537864902ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aec487-ac03-4912-969b-f537864902ce.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8087,7 +8087,7 @@
         },
         {
             "id": "7cc0f7a3-770a-5da4-94be-f8875ef0b8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdcf679-4269-4ed9-84f1-1ac7a513f475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdcf679-4269-4ed9-84f1-1ac7a513f475.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "87d18412-d5d1-5021-b653-55efed8d020f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e659905-5f87-4181-8fc8-59ab2138b7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e659905-5f87-4181-8fc8-59ab2138b7fc.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "ddbf57b2-3b87-5923-827a-78f81c68ef8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf6f14a-99d1-4abd-b36f-a5819718a43f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf6f14a-99d1-4abd-b36f-a5819718a43f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "57f533cc-97fe-57c6-865a-594af5edc9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb31304-eff0-44f9-b240-b7fa631ea4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb31304-eff0-44f9-b240-b7fa631ea4ce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "936b1a90-e718-56b7-b212-ec394144061a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbe554-ffdc-4de6-bf27-57790b71effb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbe554-ffdc-4de6-bf27-57790b71effb.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "a1cf29d8-331c-5877-8e01-7095c54b7390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e809db1f-12d7-4556-bdd2-db832f991cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e809db1f-12d7-4556-bdd2-db832f991cd0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8315,7 +8315,7 @@
         },
         {
             "id": "be5ed61f-3d14-5356-8d1e-5be6a8875592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ec4ca-ab4c-4d5f-98df-aa166b60bb1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ec4ca-ab4c-4d5f-98df-aa166b60bb1d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "30f98b02-abcd-5b08-91db-80b13ca6cf0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3133726-0eda-480c-9d67-64719cb77f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3133726-0eda-480c-9d67-64719cb77f1d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "a6768016-14b4-5dde-a17d-12a22fd53aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2cc19c-84ce-4c0b-b56f-7a2b3878a26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2cc19c-84ce-4c0b-b56f-7a2b3878a26e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "b553531d-25aa-506f-a990-4e2ff3258ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfb1db3-c0ea-4f8d-8208-5f8895ff686d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfb1db3-c0ea-4f8d-8208-5f8895ff686d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "77058e43-ac8d-54e6-8264-d9656e8d5168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969d5979-8ae8-4442-a3a5-3412ffeb5af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969d5979-8ae8-4442-a3a5-3412ffeb5af8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "3738c7a7-6e82-53ca-b45a-36caa3f02213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e4622-e905-49da-948f-aeba1ba674ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e4622-e905-49da-948f-aeba1ba674ce.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "e0cfd303-b175-5646-888a-8c90bf555d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12495cfa-ab19-4e9e-a49e-a94499f664a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12495cfa-ab19-4e9e-a49e-a94499f664a2.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "b807bb5a-1ecc-512a-a26a-1d332a30d4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8a605e-73a6-4666-ae08-ec6e9845e629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8a605e-73a6-4666-ae08-ec6e9845e629.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "0716a7c6-ae72-55de-9229-6635555da05c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368be73f-24d2-44db-a55e-d04176db3142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368be73f-24d2-44db-a55e-d04176db3142.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8657,7 +8657,7 @@
         },
         {
             "id": "0e17ef07-92d3-5717-8841-bc0206c9e5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bc8e3-b106-43bb-acf6-885328d24a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bc8e3-b106-43bb-acf6-885328d24a65.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "96472135-42b3-5127-8e18-240d592cce1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e181878-d9fb-44d5-98ce-2899793ab2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e181878-d9fb-44d5-98ce-2899793ab2e7.jpg?1",
             "name": "Rafiq of the Many",
             "text": "",
             "colours": [
@@ -8737,7 +8737,7 @@
         },
         {
             "id": "cc38a9ca-b576-5193-aa82-324eac09d676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "f11ebafa-5f5f-5ae3-9d32-a18e812e74b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3546df95-926d-421d-a763-e559a1847273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3546df95-926d-421d-a763-e559a1847273.jpg?1",
             "name": "Homunculus",
             "text": "",
             "colours": [
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "8cc5adc3-60ab-5f43-a619-e0eb073dcbc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510a8b-a5a2-421b-a8b4-5ab60c848628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510a8b-a5a2-421b-a8b4-5ab60c848628.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "e916c0a8-79eb-5b79-9143-8f5f8237fa9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894192e-782b-49ef-b9fc-28b76e2268ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894192e-782b-49ef-b9fc-28b76e2268ab.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "3e71087a-c958-51d8-b915-14a23d6c660f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "7c8f18d1-8d46-5d55-89f2-0441c12fd638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "86b88555-4c47-554d-a097-dfb4854bb61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2b01b8-3dcb-4eab-9402-0db343543c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2b01b8-3dcb-4eab-9402-0db343543c38.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "8d4c65cf-be37-53bc-a823-5a87eb5f2521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4b6d1-c5f5-4a2d-a00c-97f6395c941b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4b6d1-c5f5-4a2d-a00c-97f6395c941b.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "c0edfb5e-e4bc-52df-aa04-92671cb93cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9045,7 +9045,7 @@
         },
         {
             "id": "e73801f6-f0d4-5bce-b7ef-b559c990a996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7382e4b-43dc-4b35-8a9e-ab886ea0a981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7382e4b-43dc-4b35-8a9e-ab886ea0a981.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/ALL.json
+++ b/Assets/Resources/Sets/ALL.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fdac1889-3454-5860-9899-9dc7bf20e058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5543b08d-d470-435e-83d9-a3a84c1cc2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5543b08d-d470-435e-83d9-a3a84c1cc2e6.jpg?1",
             "name": "Carrier Pigeons",
             "text": "Flying\nDraw a card at the beginning of the upkeep of the turn after Carrier Pigeons comes into play.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "e43ab3e7-0296-52f9-881d-a1010b200493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68befe-78bc-4d9c-968b-f7e6b3042f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68befe-78bc-4d9c-968b-f7e6b3042f27.jpg?1",
             "name": "Carrier Pigeons",
             "text": "Flying\nDraw a card at the beginning of the upkeep of the turn after Carrier Pigeons comes into play.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "23aaaf1c-be7d-5398-9d5e-c752de17f5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3c539b-4039-45c2-8d43-80648d946e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3c539b-4039-45c2-8d43-80648d946e91.jpg?1",
             "name": "Errand of Duty",
             "text": "Put a Knight token into play. Treat this token as a 1/1 white creature with banding.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "1299ff49-3c05-5a40-b03f-19c6786fb010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7362e2-8dc0-4d76-a4eb-55ed56b1cd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7362e2-8dc0-4d76-a4eb-55ed56b1cd66.jpg?1",
             "name": "Errand of Duty",
             "text": "Put a Knight token into play. Treat this token as a 1/1 white creature with banding.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "52fdc2da-8152-538b-be8f-f9aadcbe9a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b85ff-ed03-4b3e-872f-1cad1a27b930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b85ff-ed03-4b3e-872f-1cad1a27b930.jpg?1",
             "name": "Exile",
             "text": "Remove target non-white attacking creature from the game. Gain life equal to that creature's toughness.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "56531814-5941-5e9b-8a28-6f3a71a0f7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe88de7-b226-4a43-9662-8b408e4281d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe88de7-b226-4a43-9662-8b408e4281d3.jpg?1",
             "name": "Inheritance",
             "text": "o3: Draw a card. Use this ability only when a creature is put into the graveyard from play, and only once for each creature put into the graveyard.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "d6bab378-ba71-563e-89e2-bb8fdaba707e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365820e4-7b43-423b-98ce-f383eb4d2a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365820e4-7b43-423b-98ce-f383eb4d2a96.jpg?1",
             "name": "Ivory Gargoyle",
             "text": "Flying\nIf Ivory Gargoyle is put into the graveyard from play, put it into play under owner's control at end of turn and skip your next draw phase.\no4o\nW: Remove Ivory Gargoyle from the game.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "aa214087-ddbf-56a4-b267-dbd5a7eba82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d10f-7368-4b40-b4a6-baf46c616c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d10f-7368-4b40-b4a6-baf46c616c34.jpg?1",
             "name": "Juniper Order Advocate",
             "text": "As long as Juniper Order Advocate is untapped, all green creatures you control get +1/+1.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "e56ad485-0b14-5c78-8875-2d899d51310d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7536a-5417-4de0-9a48-82a5f82d9af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7536a-5417-4de0-9a48-82a5f82d9af4.jpg?1",
             "name": "Kjeldoran Escort",
             "text": "Banding",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "a7daa7b9-93fc-5b52-bedd-3d2689117d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f54ca5-1f1b-40c7-ad0b-569c54d1b5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f54ca5-1f1b-40c7-ad0b-569c54d1b5aa.jpg?1",
             "name": "Kjeldoran Escort",
             "text": "Banding",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "ce976068-66ea-53fd-ba96-0a0d1dc17e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d16f9-848f-44ca-8e85-d01a58558077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d16f9-848f-44ca-8e85-d01a58558077.jpg?1",
             "name": "Kjeldoran Home Guard",
             "text": "At the end of any combat in which Kjeldoran Home Guard attacked or blocked, put a -0/-1 counter on Kjeldoran Home Guard and put a Deserter token into play. Treat this token as a 0/1 white creature.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "33aa3b02-e2cb-5b4d-9517-38ef709eb0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0acdf4d-6fdd-4430-9204-9c80dc8fb387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0acdf4d-6fdd-4430-9204-9c80dc8fb387.jpg?1",
             "name": "Kjeldoran Pride",
             "text": "Enchanted creature gets +1/+2.\no2o\nU: Switch Kjeldoran Pride from creature it enchants to another creature. Kjeldoran Pride's new target must be legal. Treat Kjeldoran Pride as though it were just cast on the new target.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "00f811a9-f7e1-5956-88ce-93d0312674b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88d1c1a-b53e-459b-8a83-4d559177188a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88d1c1a-b53e-459b-8a83-4d559177188a.jpg?1",
             "name": "Kjeldoran Pride",
             "text": "Enchanted creature gets +1/+2.\no2o\nU: Switch Kjeldoran Pride from creature it enchants to another creature. Kjeldoran Pride's new target must be legal. Treat Kjeldoran Pride as though it were just cast on the new target.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "8be7755b-fcd9-5ada-9526-bd93f2dbcae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab5775a-7138-4526-83fe-350127695224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab5775a-7138-4526-83fe-350127695224.jpg?1",
             "name": "Martyrdom",
             "text": "Until end of turn, you may redirect to target creature you control any amount of damage.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "16d098dc-40a6-5610-ba62-1125513ea093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f91817-8e79-4885-a57b-d26241c4791f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f91817-8e79-4885-a57b-d26241c4791f.jpg?1",
             "name": "Martyrdom",
             "text": "Until end of turn, you may redirect to target creature you control any amount of damage.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "ce8bd807-d92a-5cd6-baa6-f80a2b98cbdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a35751-a232-40ba-a73b-d3ca7a44867d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a35751-a232-40ba-a73b-d3ca7a44867d.jpg?1",
             "name": "Noble Steeds",
             "text": "o1o\nW: Target creature gains first strike until end of turn.",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "a3aa07a1-553e-5b70-a6f1-a5257247524c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bc5b2-c5fb-4340-9c11-73891adb4b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bc5b2-c5fb-4340-9c11-73891adb4b93.jpg?1",
             "name": "Noble Steeds",
             "text": "o1o\nW: Target creature gains first strike until end of turn.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "63edf68b-588c-5732-9b8f-21c89e6cff63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d734086b-a0fb-4504-96e5-89842aa587b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d734086b-a0fb-4504-96e5-89842aa587b3.jpg?1",
             "name": "Reinforcements",
             "text": "Put up to three target creature cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "13ad77f4-59ef-567f-9d13-35f6b5ec6274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b26881-3ad7-4d70-8051-a7e222d910bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b26881-3ad7-4d70-8051-a7e222d910bf.jpg?1",
             "name": "Reinforcements",
             "text": "Put up to three target creature cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "a4ffe3b0-55a6-52e6-9a5b-29dd55585da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179f50be-6658-42f4-b9b9-c97c7d3f239a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179f50be-6658-42f4-b9b9-c97c7d3f239a.jpg?1",
             "name": "Reprisal",
             "text": "Bury target creature with power 4 or greater.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "935eddd3-c047-5d3c-aa22-eb77f411cdf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839df85a-1aca-4d4b-b327-2778caa6d289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839df85a-1aca-4d4b-b327-2778caa6d289.jpg?1",
             "name": "Reprisal",
             "text": "Bury target creature with power 4 or greater.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "28c6ea87-7f8d-5794-b2b6-a92c1edd1481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22231f5-30af-4f46-b2c9-0b71124c6939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22231f5-30af-4f46-b2c9-0b71124c6939.jpg?1",
             "name": "Royal Decree",
             "text": "Cumulative Upkeep: o\nW\nWhenever a swamp, mountain, black permanent, or red permanent becomes tapped, Royal Decree deals 1 damage to that permanent's controller.",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "567aded4-6a5a-5b47-b563-00f5b9062e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027e03e1-1a39-47ba-b206-44d022b4c346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027e03e1-1a39-47ba-b206-44d022b4c346.jpg?1",
             "name": "Royal Herbalist",
             "text": "o2: Remove the top card of your library from the game to gain 1 life.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "82aa7009-5782-548e-922a-f145bd59addf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6456ee12-7c09-434e-9028-613506ef7ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6456ee12-7c09-434e-9028-613506ef7ff6.jpg?1",
             "name": "Royal Herbalist",
             "text": "o2: Remove the top card of your library from the game to gain 1 life.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "4c8d3de1-4626-57da-9a26-261a0998ed8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632870c3-7c0b-48ad-865d-95f8c4e887d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632870c3-7c0b-48ad-865d-95f8c4e887d0.jpg?1",
             "name": "Scars of the Veteran",
             "text": "You may remove a white card in your hand from the game instead of paying Scars of the Veteran's casting cost.\nPrevent up to 7 damage to target creature or player. For each 1 damage to a creature prevented by Scars of the Veteran, put a +0/+1 counter on that creature at end of turn.",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "ac424936-0598-5298-8d85-c38144d9f4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8be4b6b-23a2-42d2-911d-fa14f7f5a95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8be4b6b-23a2-42d2-911d-fa14f7f5a95b.jpg?1",
             "name": "Seasoned Tactician",
             "text": "o3: Remove the top four cards of your library from the game to prevent all damage to you from one source.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "06ac3cbe-0b3a-5c14-bdd2-122fec0cdd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecf91a-9ce1-44a1-8859-7163d32cfba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecf91a-9ce1-44a1-8859-7163d32cfba6.jpg?1",
             "name": "Sustaining Spirit",
             "text": "Cumulative Upkeep: o1o\nW\nAny damage that would reduce your life total to less than 1 instead reduces it to 1.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "d01679ad-e2d7-54a7-8e5a-d3f0b8863f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328e6ceb-30f7-415e-93b4-7075af0fed89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328e6ceb-30f7-415e-93b4-7075af0fed89.jpg?1",
             "name": "Sworn Defender",
             "text": "o1: Change Sworn Defender's power to the toughness of target creature blocking or being blocked by Sworn Defender, minus 1, until end of turn. Change Sworn Defender's toughness to 1 plus the power of that creature, until end of turn.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "51b8e655-e99f-5965-bb7a-e2b20fb980d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d2c73-1934-4504-bbfb-62ba82e0a0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d2c73-1934-4504-bbfb-62ba82e0a0e3.jpg?1",
             "name": "Unlikely Alliance",
             "text": "o1o\nW: Target non-attacking, non-blocking creature gets +0/+2 until end of turn.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "8d67c057-3b49-5ceb-bb88-116d0e97563e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0decda-d77a-4b7b-8ca4-08528d476f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0decda-d77a-4b7b-8ca4-08528d476f51.jpg?1",
             "name": "Wild Aesthir",
             "text": "Flying, first strike\no\nWo\nW: +2/+0 until end of turn. You cannot spend more than o\nWo\nW in this way each turn.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "858dddc4-8308-5f6f-920b-ccf7f0c2c7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffecf097-a5b1-4bd9-ac3f-784bd44e447c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffecf097-a5b1-4bd9-ac3f-784bd44e447c.jpg?1",
             "name": "Wild Aesthir",
             "text": "Flying, first strike\no\nWo\nW: +2/+0 until end of turn. You cannot spend more than o\nWo\nW in this way each turn.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "e8db1150-b771-56d3-8040-4b84ddbe39d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c5728e-43e7-417a-ba18-5038345cec67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c5728e-43e7-417a-ba18-5038345cec67.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. That spell's caster may draw up to two cards at the beginning of the next turn's upkeep.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "825770fb-6760-5b0d-993f-0dfe58b55aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a3104-90e6-4235-b67f-69337c7fe714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a3104-90e6-4235-b67f-69337c7fe714.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. That spell's caster may draw up to two cards at the beginning of the next turn's upkeep.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "0552859b-7408-5f6a-969e-dfd367796fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80017e84-87bc-4eb8-a663-5c263d8df812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80017e84-87bc-4eb8-a663-5c263d8df812.jpg?1",
             "name": "Awesome Presence",
             "text": "Enchanted creature cannot be blocked unless defending player pays an additional o3 for each creature assigned to block enchanted creature.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "3ba29eaf-b8f4-59da-b3ec-e3ab5a3d89d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8a120-5c13-4852-bdc8-80ae50a6e3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8a120-5c13-4852-bdc8-80ae50a6e3d3.jpg?1",
             "name": "Awesome Presence",
             "text": "Enchanted creature cannot be blocked unless defending player pays an additional o3 for each creature assigned to block enchanted creature.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "c51ae66a-1de7-5569-a7ae-2d5c18fa9f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146eb650-92c8-48a9-a40d-e7bba6545f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146eb650-92c8-48a9-a40d-e7bba6545f36.jpg?1",
             "name": "Benthic Explorers",
             "text": "oc\nT: Untap target tapped land an opponent controls to add one mana of any type that land produces to your mana pool.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "14baaad6-3504-5f4b-8c60-df275b1c89b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397d7602-d374-484c-aab2-3e57f12ceaa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397d7602-d374-484c-aab2-3e57f12ceaa4.jpg?1",
             "name": "Benthic Explorers",
             "text": "oc\nT: Untap target tapped land an opponent controls to add one mana of any type that land produces to your mana pool.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "6f17b55f-3144-5528-8a7c-086d1699baaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578549f0-5643-4891-b467-2d1cb49fe4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578549f0-5643-4891-b467-2d1cb49fe4ea.jpg?1",
             "name": "Browse",
             "text": "o2o\nUo\nU: Look at the top five cards of your library and put one of them into your hand. Remove the remaining four from the game.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "10c5f3d9-8531-553e-ba33-0fcf07f59866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375ec24-4841-4792-ad58-f29cdf0d1bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375ec24-4841-4792-ad58-f29cdf0d1bbb.jpg?1",
             "name": "Diminishing Returns",
             "text": "Each player shuffles his or her hand and graveyard into his or her library. Remove the top ten cards of your library from the game. Each player draws up to seven cards.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "ec74fd98-0487-539a-a4a9-4b46462d5533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69773e2b-bfee-449d-b8e8-5646442f5487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69773e2b-bfee-449d-b8e8-5646442f5487.jpg?1",
             "name": "False Demise",
             "text": "If enchanted creature is put into the graveyard, return that creature to play under your control as though it were just cast.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "771f2ce8-6590-534e-88ce-d783f50888b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e844464-cf1b-4a34-ac37-3a4da858c6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e844464-cf1b-4a34-ac37-3a4da858c6bf.jpg?1",
             "name": "False Demise",
             "text": "If enchanted creature is put into the graveyard, return that creature to play under your control as though it were just cast.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "804ddf5e-9a08-51c7-af44-491e487cee4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a879b60-4381-447d-8a5a-8e0b6a1d49ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a879b60-4381-447d-8a5a-8e0b6a1d49ca.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and remove a blue card in your hand from the game instead of paying Force of Will's casting cost. Effects that prevent or redirect damage cannot be used to counter this loss of life.\nCounter target spell.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "b6432856-d0b5-580e-8058-3c4f2d476359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12e624c-8879-4e60-a1be-286abc5e0106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12e624c-8879-4e60-a1be-286abc5e0106.jpg?1",
             "name": "Foresight",
             "text": "Search your library for any three cards and remove them from the game. Shuffle your library afterwards.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "1902d567-81ea-5399-921d-e5a2fa9134f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fe74e0-bcde-4176-8da5-38e78daad5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fe74e0-bcde-4176-8da5-38e78daad5e5.jpg?1",
             "name": "Foresight",
             "text": "Search your library for any three cards and remove them from the game. Shuffle your library afterwards.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "8389620a-4077-5f56-9d56-19cdafb322fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3420b-424e-4c30-b329-bc4447f121d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3420b-424e-4c30-b329-bc4447f121d3.jpg?1",
             "name": "Lat-Nam's Legacy",
             "text": "Choose a card from your hand and shuffle that card into your library to draw two cards at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1518,7 +1518,7 @@
         },
         {
             "id": "f663d93f-b36d-52f5-b33a-851e0ec3c4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3b0741-dd5e-4d98-a50b-19a0f20dd72c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3b0741-dd5e-4d98-a50b-19a0f20dd72c.jpg?1",
             "name": "Lat-Nam's Legacy",
             "text": "Choose a card from your hand and shuffle that card into your library to draw two cards at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "45fb073d-5dd7-521c-92b4-6f2e0d77909b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5fa739-e8d4-4e1d-8b6b-c334d1e91bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5fa739-e8d4-4e1d-8b6b-c334d1e91bef.jpg?1",
             "name": "Library of Lat-Nam",
             "text": "Target opponent chooses one: you draw three cards at the beginning of the next turn's upkeep; or you search your library for a card, put it into your hand, and then shuffle your library.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "3ed62ab5-c4d7-581f-9afa-4edba59ed519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84617c7-c70a-497c-b834-3d98346180cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84617c7-c70a-497c-b834-3d98346180cf.jpg?1",
             "name": "Phantasmal Sphere",
             "text": "Flying\nAt the beginning of your upkeep, put a +1/+1 counter on Phantasmal Sphere. During your upkeep, pay o1 for each of these +1/+1 counters or bury Phantasmal Sphere.\nIf Phantasmal Sphere leaves play, put an Orb token into play under target opponent's control. Treat this token as a */* blue creature with flying, where * is equal to the number of these +1/+1 counters on Phantasmal Sphere.",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "9ca59128-cd47-51e6-8dfe-e5db4d08d2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46accc8-b926-4443-bc12-dfd5870b2d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46accc8-b926-4443-bc12-dfd5870b2d2e.jpg?1",
             "name": "Soldevi Heretic",
             "text": "o\nW, oc\nT: Prevent up to 2 damage to any creature. Target opponent may draw a card.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "774184b6-ec2e-5557-b5f6-a05792d11611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9613ca47-c9d1-4485-b0bd-71b0b587567e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9613ca47-c9d1-4485-b0bd-71b0b587567e.jpg?1",
             "name": "Soldevi Heretic",
             "text": "o\nW, oc\nT: Prevent up to 2 damage to any creature. Target opponent may draw a card.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "3fff50ac-faaf-5718-b978-9b0d40f35c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392841-2df5-47f1-9868-edae3376e35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392841-2df5-47f1-9868-edae3376e35a.jpg?1",
             "name": "Soldevi Sage",
             "text": "oc\nT: Sacrifice two lands to draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "f37d4358-4531-501d-a67c-58a11c2936bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53dc5902-817c-4a85-a0b9-20555574fad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53dc5902-817c-4a85-a0b9-20555574fad1.jpg?1",
             "name": "Soldevi Sage",
             "text": "oc\nT: Sacrifice two lands to draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "732d9004-c6c0-5c6c-891f-29f2a7d2418a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4242dda-6078-481d-a068-e7b10c873b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4242dda-6078-481d-a068-e7b10c873b89.jpg?1",
             "name": "Spiny Starfish",
             "text": "o\nU: Regenerate\nAt the end of any turn in which Spiny Starfish regenerated, put a Starfish token into play for each time it regenerated that turn. Treat these tokens as 0/1 blue creatures.",
             "colours": [
@@ -1794,7 +1794,7 @@
         },
         {
             "id": "143207e5-b63d-5ff5-ae7c-254d02912a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ea78-16f1-46ac-8a60-db20c37aad5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ea78-16f1-46ac-8a60-db20c37aad5e.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "d5c5a847-944e-5c9c-bb53-88f51446f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbf72f7-2360-4105-beae-946556884e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbf72f7-2360-4105-beae-946556884e40.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "b51c6ae8-e690-5646-bf60-f6b929afb92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24de2b5e-78b1-490d-ac47-67f7076bc6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24de2b5e-78b1-490d-ac47-67f7076bc6b6.jpg?1",
             "name": "Storm Elemental",
             "text": "Flying\no\nU: Remove the top card of your library from the game to tap target creature with flying.\no\nU: Remove the top card of your library from the game. If that card is a snow-covered land, Storm Elemental gets +1/+1 until end of turn.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "20f2b1ab-5df2-55d4-b668-f4f474432ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22104df-8147-45fd-897a-f99a815be062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22104df-8147-45fd-897a-f99a815be062.jpg?1",
             "name": "Suffocation",
             "text": "Play only when a red sorcery or instant deals damage to you. Suffocation deals 4 damage to that spell's caster.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1928,7 +1928,7 @@
         },
         {
             "id": "b0e3b786-769c-5039-8004-ff17f1338ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bbac1-ca51-4c72-9f1f-5fc6c82a4a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bbac1-ca51-4c72-9f1f-5fc6c82a4a27.jpg?1",
             "name": "Thought Lash",
             "text": "Cumulative Upkeep: Remove the top card of your library from the game. If you do not, remove your library from the game and bury Thought Lash.\no0: Remove the top card of your library from the game to prevent 1 damage to you.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "8e9e7c5f-9420-51e7-a4e4-556fe45fcb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7b7d-3d37-4bb6-ab48-1fec2bfb4fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7b7d-3d37-4bb6-ab48-1fec2bfb4fdc.jpg?1",
             "name": "Tidal Control",
             "text": "Cumulative Upkeep: o2\nAny player may pay o2 or 2 life to counter target red or green spell. Play this ability as an interrupt. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "cc5b1957-ff14-5af3-852e-a3eb99f9a78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c3f55a-5aa7-42e1-9aab-168a7e61c112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c3f55a-5aa7-42e1-9aab-168a7e61c112.jpg?1",
             "name": "Viscerid Armor",
             "text": "Enchanted creature gets +1/+1.\no1o\nU: Return Viscerid Armor to owner's hand.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "b0d688ef-0246-596a-a1fb-e8c2eccce6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b719f89d-2a2c-460c-95e4-ada21353b340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b719f89d-2a2c-460c-95e4-ada21353b340.jpg?1",
             "name": "Viscerid Armor",
             "text": "Enchanted creature gets +1/+1.\no1o\nU: Return Viscerid Armor to owner's hand.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "a44218f0-7b2e-58ed-8443-b213864c37c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccd245f-e374-4bb8-8ac9-743b27ecf817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccd245f-e374-4bb8-8ac9-743b27ecf817.jpg?1",
             "name": "Viscerid Drone",
             "text": "oc\nT: Sacrifice a creature and a swamp to bury target non-artifact creature.\noc\nT: Sacrifice a creature and a snow-covered swamp to bury target creature.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "dfebf396-adbf-5d5c-8653-17a34e89218f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac1875a-feab-4213-aa15-69892b7df58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac1875a-feab-4213-aa15-69892b7df58b.jpg?1",
             "name": "Balduvian Dead",
             "text": "o2o\nR: Remove target summon card in your graveyard from the game to put a Graveborn token into play. Treat this token as a 3/1 black and red creature that can attack the turn it comes into play. Bury Graveborn token at end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "bbad8fb1-0dcb-57e5-83e8-0bc45593d85b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e823c295-b66e-41c3-bd77-1a13f95e69c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e823c295-b66e-41c3-bd77-1a13f95e69c3.jpg?1",
             "name": "Casting of Bones",
             "text": "If enchanted creature is put into the graveyard, draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "6d148149-9b44-5c2b-b46f-d4b6d92899a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88442ddf-c12b-4a25-804d-29fef5a90a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88442ddf-c12b-4a25-804d-29fef5a90a0c.jpg?1",
             "name": "Casting of Bones",
             "text": "If enchanted creature is put into the graveyard, draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -2198,7 +2198,7 @@
         },
         {
             "id": "4b6b7ee4-8b72-5faa-89f3-13fdc923fa88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8f94a-7690-47f5-b664-61411a32ab74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8f94a-7690-47f5-b664-61411a32ab74.jpg?1",
             "name": "Contagion",
             "text": "You may pay 1 life and remove a black card in your hand from the game instead of paying Contagion's casting cost. Effects that prevent or redirect damage cannot be used to counter this loss of life. Put two -2/-1 counters, distributed any way you choose, on any number of target creatures.",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "9d3730b5-54a1-545e-abb1-4cc93b9c6b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39703080-524d-4aa1-8c58-d512c41ae5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39703080-524d-4aa1-8c58-d512c41ae5d4.jpg?1",
             "name": "Diseased Vermin",
             "text": "During your upkeep, Diseased Vermin deals 1 damage to a single target opponent it has previously damaged for each infection counter on Diseased Vermin.\nIf Diseased Vermin damages a player in combat, put an infection counter on it.",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "f1c75d21-8922-57d9-a726-5ac3b6e5934c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bb451-706d-44ff-bbad-9ddc6f9f786a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bb451-706d-44ff-bbad-9ddc6f9f786a.jpg?1",
             "name": "Dystopia",
             "text": "Cumulative Upkeep: 1 life\nDuring each player's upkeep, if that player controls any green or white permanents, he or she sacrifices a green or white permanent.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "e80ae691-5537-5c22-963e-35f4b071923f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ba0b83-9671-4ee7-996d-57a3616b9c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ba0b83-9671-4ee7-996d-57a3616b9c66.jpg?1",
             "name": "Fatal Lore",
             "text": "Target opponent chooses one: you draw three cards; or you choose and bury up to two target creatures that opponent controls and he or she draws up to three cards.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "c41d14ca-f687-51c3-8861-0ec3c93470c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c185b4d-8da5-4b8a-85f0-5f0622c7bade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c185b4d-8da5-4b8a-85f0-5f0622c7bade.jpg?1",
             "name": "Feast or Famine",
             "text": "Bury target non-black, non-artifact creature or put a Zombie token into play. Treat this token as a 2/2 black creature.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "ba2be988-dafb-5b10-a77f-0ff3567c3018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac1586-c3d5-4add-bade-b527dcf4a391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac1586-c3d5-4add-bade-b527dcf4a391.jpg?1",
             "name": "Feast or Famine",
             "text": "Bury target non-black, non-artifact creature or put a Zombie token into play. Treat this token as a 2/2 black creature.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "44495054-e580-514d-8f35-3a804029df9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e53d6c-67f5-4d74-8205-6325c75d1d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e53d6c-67f5-4d74-8205-6325c75d1d07.jpg?1",
             "name": "Fevered Strength",
             "text": "Target creature gets +2/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "5cba17d9-c520-53fa-a133-ed094fdea680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca621684-1e0d-44d3-8bc4-f77e354b9ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca621684-1e0d-44d3-8bc4-f77e354b9ab4.jpg?1",
             "name": "Fevered Strength",
             "text": "Target creature gets +2/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "a4c76392-3396-5188-b075-4e4895d2a44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfb7c7e-5a0a-4d4d-be98-ffed0386592b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfb7c7e-5a0a-4d4d-be98-ffed0386592b.jpg?1",
             "name": "Insidious Bookworms",
             "text": "o1o\nB: Target player discards a card at random from his or her hand. Use this ability only when Insidious Bookworms is put into the graveyard from play. You cannot spend more than o1o\nB in this way each turn.",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "1d6f45ab-e845-55c9-85e9-388b47007b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043cc2-1bd4-4b44-ba23-d2585ffc3841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043cc2-1bd4-4b44-ba23-d2585ffc3841.jpg?1",
             "name": "Insidious Bookworms",
             "text": "o1o\nB: Target player discards a card at random from his or her hand. Use this ability only when Insidious Bookworms is put into the graveyard from play. You cannot spend more than o1o\nB in this way each turn.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "158bc6bb-6abe-529a-b17a-6a60f901aa3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf8b0ec-f81a-488c-850c-098a8a3119e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf8b0ec-f81a-488c-850c-098a8a3119e5.jpg?1",
             "name": "Keeper of Tresserhorn",
             "text": "If Keeper of Tresserhorn attacks and is not blocked, it deals no damage to defending player this turn and that player loses 2 life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "3d0c202b-eca8-5ad7-8936-0d8215536888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3cb1c-6bde-4b55-b5bc-5b64b56930f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3cb1c-6bde-4b55-b5bc-5b64b56930f2.jpg?1",
             "name": "Krovikan Horror",
             "text": "At the end of any turn, if Krovikan Horror is in your graveyard with a summon card directly above it, you may put Krovikan Horror into your hand.\no1: Sacrifice a creature to have Krovikan Horror deal 1 damage to target creature or player.",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "f005d409-2b6a-509e-a18c-7198fc6c4448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b258e192-20af-4a45-981f-05181f4cd997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b258e192-20af-4a45-981f-05181f4cd997.jpg?1",
             "name": "Krovikan Plague",
             "text": "Play on a non-wall creature you control.\nDraw a card at the beginning of the upkeep of the turn after Krovikan Plague comes into play.\no0: Tap enchanted creature to have Krovikan Plague deal 1 damage to target creature or player. Put a -0/-1 counter on enchanted creature.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "3278d50f-d35a-5da4-a7c5-07f7c808e69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5afe9b5-3be8-472a-95c3-2c34231bc042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5afe9b5-3be8-472a-95c3-2c34231bc042.jpg?1",
             "name": "Lim-D\u00fbl's High Guard",
             "text": "First strike\no1o\nB: Regenerate",
             "colours": [
@@ -2661,7 +2661,7 @@
         },
         {
             "id": "4464aba0-c86e-5d5e-8aff-57d42acb6b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470fce6-30cf-43bd-a258-a9fde4be0be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470fce6-30cf-43bd-a258-a9fde4be0be8.jpg?1",
             "name": "Lim-D\u00fbl's High Guard",
             "text": "First strike\no1o\nB: Regenerate",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "5274c64d-b450-544b-abf0-76cbfe7368fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8638df-7915-4867-882a-95439486bd7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8638df-7915-4867-882a-95439486bd7b.jpg?1",
             "name": "Misinformation",
             "text": "Put up to three target cards from an opponent's graveyard on top of his or her library in any order.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "6677bdaf-704b-52e6-8f73-71a7d788a37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a05d428-7c70-4813-8e6c-20278cc0b0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a05d428-7c70-4813-8e6c-20278cc0b0bd.jpg?1",
             "name": "Phantasmal Fiend",
             "text": "o\nB: +1/-1 until end of turn\no1o\nU: Switch Phantasmal Fiend's power and toughness until end of turn. Effects that alter Phantasmal Fiend's power alter its toughness instead, and vice versa.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "6dee161b-7fcc-58f5-aa17-0997a5ceb846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2842a1-25b8-4c4b-b5f8-496929288ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2842a1-25b8-4c4b-b5f8-496929288ff3.jpg?1",
             "name": "Phantasmal Fiend",
             "text": "o\nB: +1/-1 until end of turn\no1o\nU: Switch Phantasmal Fiend's power and toughness until end of turn. Effects that alter Phantasmal Fiend's power alter its toughness instead, and vice versa.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "f32df083-3e01-5de3-8db5-88dcb9a7aaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9734708-d8e3-4d72-86b9-dd91fcfab5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9734708-d8e3-4d72-86b9-dd91fcfab5b4.jpg?1",
             "name": "Phyrexian Boon",
             "text": "As long as enchanted creature is black, it gets +2/+1; otherwise, it gets -1/-2.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "960e6281-13cd-546c-a673-04e23b41f4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f82668b-50b3-4746-b7fd-82f8560ebd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f82668b-50b3-4746-b7fd-82f8560ebd95.jpg?1",
             "name": "Phyrexian Boon",
             "text": "As long as enchanted creature is black, it gets +2/+1; otherwise, it gets -1/-2.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "6821924b-fea1-522f-952f-77103810d0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b4109-ae7c-451a-8576-97f817a70d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b4109-ae7c-451a-8576-97f817a70d75.jpg?1",
             "name": "Ritual of the Machine",
             "text": "Sacrifice a creature to gain control of target non-black, non-artifact creature.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "25213b29-35dd-5ca7-8511-393d3e68ce4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2651b0-1ab2-4d7e-834f-7505797da474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2651b0-1ab2-4d7e-834f-7505797da474.jpg?1",
             "name": "Soldevi Adnate",
             "text": "oc\nT: Sacrifice a black or artifact creature to add an amount of o\nB equal to that creature's casting cost to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "853a5287-06c3-52cd-8e5b-4ecb0ca95916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80812871-d9a7-40de-94a5-b854e55409db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80812871-d9a7-40de-94a5-b854e55409db.jpg?1",
             "name": "Soldevi Adnate",
             "text": "oc\nT: Sacrifice a black or artifact creature to add an amount of o\nB equal to that creature's casting cost to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2972,7 +2972,7 @@
         },
         {
             "id": "bee771c0-8dce-5d16-8659-1753d337a4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a45644-549a-4eaa-8367-b170027bd5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a45644-549a-4eaa-8367-b170027bd5a2.jpg?1",
             "name": "Stench of Decay",
             "text": "All non-artifact creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "6502c706-8cf1-5afb-a085-826a0c1e2a52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b93845-f17a-4892-a1ce-a4630dced218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b93845-f17a-4892-a1ce-a4630dced218.jpg?1",
             "name": "Stench of Decay",
             "text": "All non-artifact creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "b740442e-1776-52be-a648-7efdd7d6baf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cecc-449f-4cc6-ac4d-440722df0ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cecc-449f-4cc6-ac4d-440722df0ab9.jpg?1",
             "name": "Stromgald Spy",
             "text": "If Stromgald Spy attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, defending player must play with his or her hand face up on the table until Stromgald Spy leaves play.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "22868fb0-aa0f-570a-8851-2d98d8ac74be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21961b79-637a-4aa5-89b5-4e6e9f60d4d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21961b79-637a-4aa5-89b5-4e6e9f60d4d1.jpg?1",
             "name": "Swamp Mosquito",
             "text": "Flying\nIf Swamp Mosquito attacks and is not blocked, defending player gets a poison counter. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "ce98b81e-712a-5140-81fb-79d10a98c02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2fbe77-8757-4333-a083-975d5c3c6433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2fbe77-8757-4333-a083-975d5c3c6433.jpg?1",
             "name": "Swamp Mosquito",
             "text": "Flying\nIf Swamp Mosquito attacks and is not blocked, defending player gets a poison counter. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "330baca6-81d9-531a-9e05-90fef79776e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7506f8-cf09-46ca-ad80-3c398c487ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7506f8-cf09-46ca-ad80-3c398c487ae2.jpg?1",
             "name": "Agent of Stromgald",
             "text": "o\nR: Add o\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -3179,7 +3179,7 @@
         },
         {
             "id": "df54abe8-ff7e-5b90-bd59-990d95a26018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9236d75-1724-4121-9fa9-57fa96b19361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9236d75-1724-4121-9fa9-57fa96b19361.jpg?1",
             "name": "Agent of Stromgald",
             "text": "o\nR: Add o\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "50b29747-09b9-5a6a-b382-fbcc69e71241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e167a6c-05f8-4d90-9f6b-eb0f1046d54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e167a6c-05f8-4d90-9f6b-eb0f1046d54a.jpg?1",
             "name": "Balduvian Horde",
             "text": "When Balduvian Horde comes into play, discard a card at random from your hand or bury Balduvian Horde.",
             "colours": [
@@ -3250,7 +3250,7 @@
         },
         {
             "id": "2e4959d4-d55c-5aea-8556-b7396ae373c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fd561e-6a26-4140-a033-1204f5dda5f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fd561e-6a26-4140-a033-1204f5dda5f3.jpg?1",
             "name": "Balduvian War-Makers",
             "text": "Rampage: 1\nBalduvian War-Makers can attack the turn it comes into play on your side.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "e4a3e2fa-034c-59cb-9c28-053570d1cbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada7aeb-0062-4fb2-8bcb-abdd75029fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada7aeb-0062-4fb2-8bcb-abdd75029fb2.jpg?1",
             "name": "Balduvian War-Makers",
             "text": "Rampage: 1\nBalduvian War-Makers can attack the turn it comes into play on your side.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "0f74c9e0-6ba0-5e9b-8bf9-b30dc838b96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626225b9-2cfd-4cf5-b11c-89e5a231b09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626225b9-2cfd-4cf5-b11c-89e5a231b09e.jpg?1",
             "name": "Bestial Fury",
             "text": "Draw a card at the beginning of the upkeep of the turn after Bestial Fury comes into play.\nIf enchanted creature attacks and is blocked, it gains trample and gets +4/+0 until end of turn.",
             "colours": [
@@ -3357,7 +3357,7 @@
         },
         {
             "id": "5dab5156-b4e0-5a8b-84b9-d839c2c4cb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271e0d7-0c55-4020-97de-b8a27ba51d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271e0d7-0c55-4020-97de-b8a27ba51d4b.jpg?1",
             "name": "Bestial Fury",
             "text": "Draw a card at the beginning of the upkeep of the turn after Bestial Fury comes into play.\nIf enchanted creature attacks and is blocked, it gains trample and gets +4/+0 until end of turn.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "36433d34-3713-55be-b9d6-c5edffa80637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8f5a18-e490-4010-ac1c-c74a5f2dcbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8f5a18-e490-4010-ac1c-c74a5f2dcbda.jpg?1",
             "name": "Burnout",
             "text": "Counter target interrupt spell if it is blue.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "8b2cc088-a54b-5972-bb26-5714280dcbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7d7c80-4e3c-454e-b2ed-6f0436df19c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7d7c80-4e3c-454e-b2ed-6f0436df19c9.jpg?1",
             "name": "Chaos Harlequin",
             "text": "o\nR: Remove the top card of your library from the game. If that card is a land, Chaos Harlequin gets -4/-0 until end of turn; otherwise, Chaos Harlequin gets +2/+0 until end of turn.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "285e4018-126d-52df-8bfd-f88dc64b93c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba841b44-475c-402c-ac11-763de0cf27d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba841b44-475c-402c-ac11-763de0cf27d9.jpg?1",
             "name": "Death Spark",
             "text": "Death Spark deals 1 damage to target creature or player.\nAt the end of your upkeep, if Death Spark is in your graveyard with a creature card directly above it, you may pay o1 to put Death Spark into your hand.",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "9fe797ee-5e0e-5204-9bd2-aa0d5ea39916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea21414e-65f7-4d65-b0dc-7fec7b9b416d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea21414e-65f7-4d65-b0dc-7fec7b9b416d.jpg?1",
             "name": "Enslaved Scout",
             "text": "o2: Mountainwalk until end of turn",
             "colours": [
@@ -3523,7 +3523,7 @@
         },
         {
             "id": "bc297d5e-8b78-50af-b0d6-2f7731b7f500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac0e04a-d223-426b-b856-2829dbdffda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac0e04a-d223-426b-b856-2829dbdffda0.jpg?1",
             "name": "Enslaved Scout",
             "text": "o2: Mountainwalk until end of turn",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "e09f2c53-0cf2-5d39-a69b-6000c8876942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8b213e-31ca-4eb5-bf0b-515a0ad4fd31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8b213e-31ca-4eb5-bf0b-515a0ad4fd31.jpg?1",
             "name": "Gorilla Shaman",
             "text": "o\nXo\nXo1: Destroy target non-creature artifact with casting cost equal to X.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "13d8d421-6ef4-586d-8908-f3108bd2e45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a16231c-1f73-4dec-9d88-e3d62e93a70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a16231c-1f73-4dec-9d88-e3d62e93a70f.jpg?1",
             "name": "Gorilla Shaman",
             "text": "o\nXo\nXo1: Destroy target non-creature artifact with casting cost equal to X.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "9166f85a-6c02-53e5-ab79-ffc8fcbe04fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613762ea-6111-4f74-bea2-c13b76e0751c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613762ea-6111-4f74-bea2-c13b76e0751c.jpg?1",
             "name": "Gorilla War Cry",
             "text": "Attacking creatures cannot be blocked by only one creature this turn. Play only during combat before defense is chosen.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "f71d7928-24d2-57eb-bb7d-5aebbb4311a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14752ef-bebf-4c31-b130-32167473482f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14752ef-bebf-4c31-b130-32167473482f.jpg?1",
             "name": "Gorilla War Cry",
             "text": "Attacking creatures cannot be blocked by only one creature this turn. Play only during combat before defense is chosen.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "2329888a-a475-5a90-abc5-ec1f50fff880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51811f2a-7002-4ba7-98d8-5b09d887975c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51811f2a-7002-4ba7-98d8-5b09d887975c.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nIf a spell or effect controlled by an opponent causes you to discard Guerrilla Tactics from your hand, reveal Guerrilla Tactics to all players, and it deals 4 damage to target creature or player.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "d0b66433-284d-589d-8369-372dc8544da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c005ca3-0508-4ac2-afec-3d4a27334c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c005ca3-0508-4ac2-afec-3d4a27334c31.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nIf a spell or effect controlled by an opponent causes you to discard Guerrilla Tactics from your hand, reveal Guerrilla Tactics to all players, and it deals 4 damage to target creature or player.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "7aae0493-78de-5681-8aa7-46ae5ca30dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c724b46-6e17-4bee-9bc6-e9fc5a379dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c724b46-6e17-4bee-9bc6-e9fc5a379dd7.jpg?1",
             "name": "Omen of Fire",
             "text": "Return all islands to their owners' hands. Each player sacrifices a plains or a white permanent for each white permanent he or she controls.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "245f051c-58e8-5fab-88a6-6c42ff44e14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389ecb50-b007-4086-89fb-ec2daa5afdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389ecb50-b007-4086-89fb-ec2daa5afdcf.jpg?1",
             "name": "Pillage",
             "text": "Bury target artifact or land.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "2b37c0a8-1520-5737-9411-6d0c6d20972f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b7829b-2a10-47e7-9cf9-8ae49d2b398a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b7829b-2a10-47e7-9cf9-8ae49d2b398a.jpg?1",
             "name": "Primitive Justice",
             "text": "Destroy target artifact.\nDestroy a target artifact for each o1o\nR you pay in addition to the casting cost.\nDestroy a target artifact and gain 1 life for each o1o\nG you pay in addition to the casting cost.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "e303165a-5c77-5d68-aa87-897cf608a8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a5e85-6cbc-43c1-9362-4056ad017ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a5e85-6cbc-43c1-9362-4056ad017ef0.jpg?1",
             "name": "Pyrokinesis",
             "text": "You may remove a red card in your hand from the game instead of paying Pyrokinesis's casting cost. Pyrokinesis deals 4 damage, divided any way you choose among any number of target creatures.",
             "colours": [
@@ -3888,7 +3888,7 @@
         },
         {
             "id": "47473373-9c52-5844-8ad4-9eb226e3380d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aebf3b-e77d-4d18-b58b-117ae91792e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aebf3b-e77d-4d18-b58b-117ae91792e2.jpg?1",
             "name": "Rogue Skycaptain",
             "text": "Flying\nAt the beginning of your upkeep, put a wage counter on Rogue Skycaptain. During your upkeep, pay o2 for each wage counter on Rogue Skycaptain, or remove all wage counters from Rogue Skycaptain and target opponent gains control of Rogue Skycaptain.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "0a8d5d40-6b40-5eb3-a980-569cfe3ccc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c05f46-2081-4ebb-a758-894ac040ea2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c05f46-2081-4ebb-a758-894ac040ea2a.jpg?1",
             "name": "Soldier of Fortune",
             "text": "o\nR, oc\nT: Target player shuffles his or her library.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "9340c3de-3d93-518c-b8e1-0d7a70cc9b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c30a0a-3083-4d9f-9fe0-de5d6294f80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c30a0a-3083-4d9f-9fe0-de5d6294f80e.jpg?1",
             "name": "Storm Shaman",
             "text": "o\nR: +1/+0 until end of turn",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "5de21b71-d898-5582-a016-ae1dd7f67909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8f1150-6306-42a6-84e1-7dd5bfef6d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8f1150-6306-42a6-84e1-7dd5bfef6d14.jpg?1",
             "name": "Storm Shaman",
             "text": "o\nR: +1/+0 until end of turn",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "2a799687-45b8-5d6f-b57b-54b8d5c79437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ade7ad-ce32-4296-8cec-20bd79c7b16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ade7ad-ce32-4296-8cec-20bd79c7b16a.jpg?1",
             "name": "Varchild's Crusader",
             "text": "o0: Varchild's Crusader cannot be blocked except by walls this turn. Bury Varchild's Crusader at end of turn.",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "9302b8dc-ee10-5b54-8e1b-b1cbee26ea3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730611f-ad45-40b7-80c8-5decf2627e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730611f-ad45-40b7-80c8-5decf2627e79.jpg?1",
             "name": "Varchild's Crusader",
             "text": "o0: Varchild's Crusader cannot be blocked except by walls this turn. Bury Varchild's Crusader at end of turn.",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "b89f8b59-f675-5748-a88a-498e993afca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1d41da-aa72-434b-811f-95d4bae4ba5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1d41da-aa72-434b-811f-95d4bae4ba5c.jpg?1",
             "name": "Varchild's War-Riders",
             "text": "Trample, rampage: 1\nCumulative Upkeep: Put a Survivor token into play under target opponent's control. Treat this token as a 1/1 red creature.",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "29d23063-854c-5a16-8d14-5fc47ead825f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93babf85-eb13-4e06-b45b-8927791bcde5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93babf85-eb13-4e06-b45b-8927791bcde5.jpg?1",
             "name": "Veteran's Voice",
             "text": "Play on a creature you control.\no0: Tap enchanted creature to give any other target creature +2/+1 until end of turn.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "7afe2f25-ef95-51e3-a2ef-0579290bab9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1ecb9a-7443-49cb-8197-ef180124aabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1ecb9a-7443-49cb-8197-ef180124aabb.jpg?1",
             "name": "Veteran's Voice",
             "text": "Play on a creature you control.\no0: Tap enchanted creature to give any other target creature +2/+1 until end of turn.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "6194acb4-b45b-550f-9726-6a89d0483543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed522a-cf5a-41e1-9677-1226f689ec9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed522a-cf5a-41e1-9677-1226f689ec9c.jpg?1",
             "name": "Bounty of the Hunt",
             "text": "You may remove a green card in your hand from the game instead of paying Bounty of the Hunt's casting cost.\nPut three +1/+1 counters, distributed any way you choose, on any number of target creatures. Remove these counters at end of turn.",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "8ffcd600-e746-55d3-bd50-1ab64fd7c7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add1b999-5c3f-4187-adac-ed1037406b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add1b999-5c3f-4187-adac-ed1037406b3f.jpg?1",
             "name": "Deadly Insect",
             "text": "Cannot be the target of spells or effects.",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "f27cf285-184f-547c-8f73-e6c5ee62242f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030963d9-b59f-4ccb-abed-d817a4bc4e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030963d9-b59f-4ccb-abed-d817a4bc4e05.jpg?1",
             "name": "Deadly Insect",
             "text": "Cannot be the target of spells or effects.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "187189d7-613f-5256-84dc-60499000105d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62261004-ed32-4865-824a-4320548f4234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62261004-ed32-4865-824a-4320548f4234.jpg?1",
             "name": "Elvish Bard",
             "text": "All creatures able to block Elvish Bard do so. If this forces a creature to block more attackers than allowed, defending player assigns that creature to block as many of those attackers as allowed.",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "3c0c4763-047b-5c1e-bf09-f17a2beecbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9f1b09-73c2-43c5-a28b-4a40fff7b727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9f1b09-73c2-43c5-a28b-4a40fff7b727.jpg?1",
             "name": "Elvish Ranger",
             "text": "",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "f87bc0f2-31d5-5d49-aa79-1857bc70d268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b08a164-d6f4-423e-8666-e4a4c2d21045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b08a164-d6f4-423e-8666-e4a4c2d21045.jpg?1",
             "name": "Elvish Ranger",
             "text": "",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "b67fd7f0-d9b1-58f1-8857-071beae61650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b94f37f-ebdf-4b79-a615-58331d27cf4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b94f37f-ebdf-4b79-a615-58331d27cf4e.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "If Elvish Spirit Guide is in your hand, you may remove it from the game to add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "69e5a6b5-01dc-5468-b995-ae8682cc7376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778b028f-fa4e-4638-82b4-fb287223ea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778b028f-fa4e-4638-82b4-fb287223ea20.jpg?1",
             "name": "Fyndhorn Druid",
             "text": "If Fyndhorn Druid is put into the graveyard the same turn it was blocked, gain 4 life.",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "ef785048-9e3a-5175-8f7f-a8b9819e0403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d880c-0052-4e2c-92aa-bf3cbd107cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d880c-0052-4e2c-92aa-bf3cbd107cbd.jpg?1",
             "name": "Fyndhorn Druid",
             "text": "If Fyndhorn Druid is put into the graveyard the same turn it was blocked, gain 4 life.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "4fd5fa6c-de49-51f7-ad3a-1f8df1043d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f367c2-f47e-43e1-9936-4324be664475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f367c2-f47e-43e1-9936-4324be664475.jpg?1",
             "name": "Gargantuan Gorilla",
             "text": "During your upkeep, sacrifice a forest, or bury Gargantuan Gorilla and Gargantuan Gorilla deals 7 damage to you. If you sacrifice a snow-covered forest in this way, Gargantuan Gorilla gains trample until end of turn.\noc\nT: Gargantuan Gorilla deals an amount of damage equal to its power to any other target creature. That creature deals an amount of damage equal to its power to Gargantuan Gorilla.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "7a7e5fac-bfb8-542f-91cf-56f375d87fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da48976b-667d-4a1e-92de-9c3cb25dfd21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da48976b-667d-4a1e-92de-9c3cb25dfd21.jpg?1",
             "name": "Gift of the Woods",
             "text": "If enchanted creature blocks or is blocked by any creatures, enchanted creature gets +0/+3 until end of turn and you gain 1 life.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "c47505c4-92a8-5515-bd98-c4fc823a82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0df4e9-b201-4fc7-8e37-59d99b583f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0df4e9-b201-4fc7-8e37-59d99b583f76.jpg?1",
             "name": "Gift of the Woods",
             "text": "If enchanted creature blocks or is blocked by any creatures, enchanted creature gets +0/+3 until end of turn and you gain 1 life.",
             "colours": [
@@ -4624,7 +4624,7 @@
         },
         {
             "id": "987b6034-3edd-58f3-9e78-a6605ab84340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344b4613-17f8-4c8b-b5bc-f773a8f8007a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344b4613-17f8-4c8b-b5bc-f773a8f8007a.jpg?1",
             "name": "Gorilla Berserkers",
             "text": "Trample, rampage: 2\nCannot be blocked by fewer than three creatures.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "c45d0d3e-8479-5457-a265-78b227e0b43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c32b65-58e7-455b-9a30-7a2edcc27b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c32b65-58e7-455b-9a30-7a2edcc27b9d.jpg?1",
             "name": "Gorilla Berserkers",
             "text": "Trample, rampage: 2\nCannot be blocked by fewer than three creatures.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "f13d761d-eff4-5726-8d5d-37581a171598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f1eedd-7021-4cce-a808-2e9384a5ef15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f1eedd-7021-4cce-a808-2e9384a5ef15.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1o\nG: Regenerate",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "874f902e-fb80-539f-9ee9-3f1cf2ad7a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdde5d2-3dd2-4eaa-9c52-4ad400b56ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdde5d2-3dd2-4eaa-9c52-4ad400b56ed1.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1o\nG: Regenerate",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "ce806604-58c6-59ee-8817-5f526306f6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e9d786-4e9b-447b-a5dc-ca117c4961c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e9d786-4e9b-447b-a5dc-ca117c4961c5.jpg?1",
             "name": "Hail Storm",
             "text": "Hail Storm deals 2 damage to each attacking creature and 1 damage to you and each creature you control.",
             "colours": [
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "b032c906-f72b-5ab4-94cd-1bbf4d41be7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4b6daf-cf37-43c6-9446-3aa0de222ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4b6daf-cf37-43c6-9446-3aa0de222ac4.jpg?1",
             "name": "Kaysa",
             "text": "All green creatures you control get +1/+1.",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "03016d28-cf16-5325-8c38-77cb502f1fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0b831-9d7e-40ce-8514-e852daee1a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0b831-9d7e-40ce-8514-e852daee1a9e.jpg?1",
             "name": "Nature's Chosen",
             "text": "Play on a creature you control.\no0: Untap enchanted creature. Use this ability only during your turn and only once each turn.\no0: Tap enchanted creature to untap target artifact, creature, or land. Use this ability only if enchanted creature is white and only once each turn.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "dbeb30f2-5f3c-539b-b8a0-55976492c3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450759f0-5d60-4f05-9011-b0b66dbb06a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450759f0-5d60-4f05-9011-b0b66dbb06a7.jpg?1",
             "name": "Nature's Wrath",
             "text": "During your upkeep, pay o\nG or bury Nature's Wrath.\nWhenever a player puts a swamp or black permanent into play, he or she sacrifices a swamp or black permanent.\nWhenever a player puts an island or a blue permanent into play, he or she sacrifices an island or blue permanent.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "38685a11-4b2d-50fa-b236-1ae3737987ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afa94e5-fef6-4f3a-9196-d7aa6dd841c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afa94e5-fef6-4f3a-9196-d7aa6dd841c2.jpg?1",
             "name": "Splintering Wind",
             "text": "o2o\nG: Splintering Wind deals 1 damage to target creature. Put a Splinter token into play. Treat this token as a 1/1 green creature with flying and Cumulative Upkeep: o\nG.\nIf this token leaves play, it deals 1 damage to you and to each creature you control.",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "4e62e057-32c2-55e6-bbe7-ddf0d0391d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9248694-88fa-4fe1-9902-f03a41100cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9248694-88fa-4fe1-9902-f03a41100cd6.jpg?1",
             "name": "Taste of Paradise",
             "text": "Gain 3 life.\nGain 3 life for each o1o\nG you pay in addition to the casting cost.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "11b6715d-1e71-50db-9102-6d33d27024fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a774c426-ec0e-48de-b00f-5a05cc6dc34b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a774c426-ec0e-48de-b00f-5a05cc6dc34b.jpg?1",
             "name": "Taste of Paradise",
             "text": "Gain 3 life.\nGain 3 life for each o1o\nG you pay in addition to the casting cost.",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "5027dc75-2914-5ffa-8ce5-fe02f83795e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fd58e4-eb9a-4a12-8914-0a9a8300626c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fd58e4-eb9a-4a12-8914-0a9a8300626c.jpg?1",
             "name": "Tornado",
             "text": "Cumulative Upkeep: o\nG\no2o\nG: Pay 3 life for each velocity counter on Tornado. Destroy target permanent and put a velocity counter on Tornado. Use this ability only once each turn. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "4aaa15e3-ea14-5c88-9d23-ba10bd695407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade0829-8b90-4ed2-99f3-dd748e7706b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade0829-8b90-4ed2-99f3-dd748e7706b8.jpg?1",
             "name": "Undergrowth",
             "text": "No creatures deal damage in combat this turn. If you pay o2o\nR in addition to the casting cost, Undergrowth does not affect red creatures.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "3a1b1f76-4e8e-5992-9181-e142e084cd5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b07df91-49be-4a50-9d3b-ddde0e6c1be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b07df91-49be-4a50-9d3b-ddde0e6c1be9.jpg?1",
             "name": "Undergrowth",
             "text": "No creatures deal damage in combat this turn. If you pay o2o\nR in addition to the casting cost, Undergrowth does not affect red creatures.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "445345b8-0a1e-5091-9ff8-b7d5c1650493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66b9fe-47f1-4786-96d5-981d62012663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66b9fe-47f1-4786-96d5-981d62012663.jpg?1",
             "name": "Whip Vine",
             "text": "Can block creatures with flying.\nYou may choose not to untap Whip Vine during your untap phase.\noc\nT: Tap target creature with flying blocked by Whip Vine. That creature does not untap during its controller's untap phase as long as Whip Vine remains tapped.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "a4db117d-2118-5541-be17-1189fe3b4906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ee1c89-d7df-4ee7-b403-24dfabae38a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ee1c89-d7df-4ee7-b403-24dfabae38a0.jpg?1",
             "name": "Whip Vine",
             "text": "Can block creatures with flying. You may choose not to untap Whip Vine during your untap phase.\noc\nT: Tap target creature with flying blocked by Whip Vine. That creature does not untap during its controller's untap phase as long as Whip Vine remains tapped.",
             "colours": [
@@ -5165,7 +5165,7 @@
         },
         {
             "id": "79afaef4-a2a4-5961-8f27-bbbace2e4e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fc4db5-08e5-4cf8-bf47-f7c6a58162b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fc4db5-08e5-4cf8-bf47-f7c6a58162b2.jpg?1",
             "name": "Yavimaya Ancients",
             "text": "o\nG: +1/-2 until end of turn",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "0826319e-e518-5239-a2bb-8fc42a78cc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91708e45-f9a1-4c2e-973d-bfc294926c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91708e45-f9a1-4c2e-973d-bfc294926c93.jpg?1",
             "name": "Yavimaya Ancients",
             "text": "o\nG: +1/-2 until end of turn",
             "colours": [
@@ -5235,7 +5235,7 @@
         },
         {
             "id": "6d3e9607-fa70-5d6b-b9c2-f43dd65b47e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ded1c83-a289-4951-b72a-477a041610d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ded1c83-a289-4951-b72a-477a041610d3.jpg?1",
             "name": "Yavimaya Ants",
             "text": "Trample\nCumulative Upkeep: o\nGo\nG\nYavimaya Ants can attack the turn it comes into play on your side.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "f4de3ab7-7de0-5ed9-a7f8-30f1c90a275b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81cd99e-902a-44dd-8928-803a96fe25c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81cd99e-902a-44dd-8928-803a96fe25c4.jpg?1",
             "name": "Energy Arc",
             "text": "Untap any number of target creatures. Those creatures neither deal nor receive damage in combat this turn.",
             "colours": [
@@ -5301,7 +5301,7 @@
         },
         {
             "id": "36a70bd8-be17-56ed-84e3-911d69ee19b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b0164c-2d4e-48ab-addd-322d9b504739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b0164c-2d4e-48ab-addd-322d9b504739.jpg?1",
             "name": "Lim-D\u00fbl's Vault",
             "text": "Look at the top five cards of your library. As many times as you choose, you may pay 1 life to put those cards on the bottom of your library and look at the top five cards of your library.\nShuffle all but the top five cards of your library; put those five on top of your library in any order. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "a4a28fe3-72b9-5cc9-a0a6-a6d4361064db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44be2d66-359e-4cc1-9670-119cb9c7d5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44be2d66-359e-4cc1-9670-119cb9c7d5f5.jpg?1",
             "name": "Lim-D\u00fbl's Paladin",
             "text": "Trample\nDuring your upkeep, choose and discard a card from your hand, or bury Lim-D\u00fbl's Paladin and draw a card.\nIf any creatures are assigned to block it, Lim-D\u00fbl's Paladin gets +6/+3 until end of turn.\nIf Lim-D\u00fbl's Paladin attacks and is not blocked, it deals no damage to defending player this turn and that player loses 4 life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "fc0d0551-abdd-5b1f-a6b2-8b25cf735302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff700-af02-4861-b7ed-be9950e69bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff700-af02-4861-b7ed-be9950e69bf1.jpg?1",
             "name": "Surge of Strength",
             "text": "Choose and discard a red or green card from your hand to have target creature gain trample and get +X/+0 until end of turn, where X is equal to that creature's casting cost.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "9e733a65-8484-50f8-84b9-32a36c3f3b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba0e677-361d-4e03-9c2c-018d1c383456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba0e677-361d-4e03-9c2c-018d1c383456.jpg?1",
             "name": "Nature's Blessing",
             "text": "o\nWo\nG: Choose and discard a card from your hand to have target creature gain banding, first strike, or trample or get a +1/+1 counter.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "88a9647d-be75-576a-8d2a-a5e7a1a6dfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b1b6c-1f02-4918-bb5c-2dbcdb0997ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b1b6c-1f02-4918-bb5c-2dbcdb0997ec.jpg?1",
             "name": "Wandering Mage",
             "text": "o\nW: Pay 1 life to prevent up to 2 damage to any creature. Effects that prevent or redirect damage cannot be used to counter this loss of life.\no\nU: Prevent 1 damage to any Cleric or Wizard.\no\nB: Put a -1/-1 counter on target creature you control to prevent up to 2 damage to any player.",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "e56d7b2e-de14-54d3-8f5a-79de24b6a3d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc9497a-42bf-4d78-afaf-67645514ade4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc9497a-42bf-4d78-afaf-67645514ade4.jpg?1",
             "name": "Lord of Tresserhorn",
             "text": "When Lord of Tresserhorn comes into play, pay 2 life and sacrifice two creatures, and target opponent draws two cards. Effects that prevent or redirect damage cannot be used to counter this loss of life.\no\nB: Regenerate",
             "colours": [
@@ -5514,7 +5514,7 @@
         },
         {
             "id": "bc77ddc5-76b3-5a6f-b30f-123131a4bc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14cc32a-eb4f-4690-aceb-160780743ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14cc32a-eb4f-4690-aceb-160780743ebe.jpg?1",
             "name": "Misfortune",
             "text": "Target opponent chooses one: you put a +1/+1 counter on each creature you control and gain 4 life; or you put a -1/-1 counter on each creature that opponent controls and Misfortune deals 4 damage to him or her.",
             "colours": [
@@ -5549,7 +5549,7 @@
         },
         {
             "id": "834fa6fe-12ad-5d80-b9af-76e2eda43754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f020ebc-4950-4407-8cb8-7630cad226f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f020ebc-4950-4407-8cb8-7630cad226f6.jpg?1",
             "name": "Winter's Night",
             "text": "Whenever a snow-covered land is tapped for mana, it produces one additional mana of the same type and does not untap during its controller's next untap phase.",
             "colours": [
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "f973ff23-32f3-5bcf-84ca-616b7a2626e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9631cb2-d53b-4401-b53b-29d27bdefc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9631cb2-d53b-4401-b53b-29d27bdefc44.jpg?1",
             "name": "Phelddagrif",
             "text": "o\nW: Flying until end of turn. Target opponent gains 2 life.\no\nU: Return Phelddagrif to owner's hand. Target opponent may draw a card.\no\nG: Trample until end of turn. Put a Hippo token into play under target opponent's control. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "781c7c6f-12a8-5ce4-adc0-0f12cedb6975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a8080f-ca3c-46fe-81cf-003ac7ba7f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a8080f-ca3c-46fe-81cf-003ac7ba7f24.jpg?1",
             "name": "Aesthir Glider",
             "text": "Flying\nCannot be assigned to block.",
             "colours": [],
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "ec6d8d5f-4c6a-52cf-a8ce-6cab82b82d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b78cb-5acc-4d14-966f-979322d99114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b78cb-5acc-4d14-966f-979322d99114.jpg?1",
             "name": "Aesthir Glider",
             "text": "Flying\nCannot be assigned to block.",
             "colours": [],
@@ -5691,7 +5691,7 @@
         },
         {
             "id": "4b17878f-2c7b-50f0-b3c0-7e840036e9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84e6fcf-4745-4dfb-9103-17beec4e45b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84e6fcf-4745-4dfb-9103-17beec4e45b6.jpg?1",
             "name": "Ashnod's Cylix",
             "text": "o3, oc\nT: Target player looks at the top three cards of his or her library and puts one of them on top of that library. Remove the remaining two from the game.",
             "colours": [],
@@ -5718,7 +5718,7 @@
         },
         {
             "id": "b8f8c42e-360f-5878-848f-d99cfd3b0f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97ad2d4-0660-4503-9f16-246dae87601c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97ad2d4-0660-4503-9f16-246dae87601c.jpg?1",
             "name": "Astrolabe",
             "text": "o1, oc\nT: Sacrifice Astrolabe to add two mana of any one color to your mana pool. Play this ability as an interrupt. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "94c7eac3-2683-5fbf-9273-68b208c79a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3a4e30-f919-4c96-89f2-467355135f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3a4e30-f919-4c96-89f2-467355135f8f.jpg?1",
             "name": "Astrolabe",
             "text": "o1, oc\nT: Sacrifice Astrolabe to add two mana of any one color to your mana pool. Play this ability as an interrupt. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -5776,7 +5776,7 @@
         },
         {
             "id": "bdb4c6cf-163b-5105-ad6b-1489c5f48b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d272c3cb-0b68-4693-abef-8a5375b2463e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d272c3cb-0b68-4693-abef-8a5375b2463e.jpg?1",
             "name": "Floodwater Dam",
             "text": "o\nXo\nXo1, oc\nT: Tap X target lands.",
             "colours": [],
@@ -5803,7 +5803,7 @@
         },
         {
             "id": "7fe93d78-2228-5997-bdbe-3a7b86c05738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797c84fa-3704-4fec-bd72-468d6415ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797c84fa-3704-4fec-bd72-468d6415ae70.jpg?1",
             "name": "Gustha's Scepter",
             "text": "If Gustha's Scepter leaves play or you lose control of it, put all cards under Gustha's Scepter into your graveyard.\noc\nT: Put any card from your hand face down under Gustha's Scepter. You may look at that card at any time.\noc\nT: Return any card under Gustha's Scepter to your hand.",
             "colours": [],
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "e7526623-beef-5a28-9361-fead1983c57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17e9216-b1ed-4101-a04e-2bb139ccfa55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17e9216-b1ed-4101-a04e-2bb139ccfa55.jpg?1",
             "name": "Helm of Obedience",
             "text": "o\nX, oc\nT: Put the top card of target opponent's library into his or her graveyard. Continue doing this until you have put X cards or a creature card into that graveyard, whichever occurs first. If the last card put into the graveyard is a creature card, bury Helm of Obedience and put that creature into play under your control as though it were just cast. X cannot be equal to 0.",
             "colours": [],
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "aff0ea48-612f-5a96-a02b-d3c3eda15a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d88a33-3990-4044-a5fe-4123d5781f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d88a33-3990-4044-a5fe-4123d5781f18.jpg?1",
             "name": "Lodestone Bauble",
             "text": "o1, oc\nT: Sacrifice Lodestone Bauble to put up to four target basic lands from any player's graveyard on top of his or her library in any order. That player draws a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "ea074234-63c8-5a2a-8ffb-cc09767a7f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2dc26-30aa-4e20-84b0-ea4be8894475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2dc26-30aa-4e20-84b0-ea4be8894475.jpg?1",
             "name": "Mishra's Groundbreaker",
             "text": "oc\nT: Sacrifice Mishra's Groundbreaker. Target land becomes a 3/3 artifact creature. That creature still counts as a land.",
             "colours": [],
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "707b55a5-9eb4-500e-ae08-374db8d42874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53ba3a-f2f7-4ea6-a2f6-dd5b87029e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53ba3a-f2f7-4ea6-a2f6-dd5b87029e58.jpg?1",
             "name": "Mystic Compass",
             "text": "o1, oc\nT: Target mana-producing land becomes a basic land type of your choice until end of turn.",
             "colours": [],
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "ddfc0a06-6fbb-56d0-8ff3-b2a56f61b588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319430fa-11e4-426e-8297-67df8474c3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319430fa-11e4-426e-8297-67df8474c3cc.jpg?1",
             "name": "Phyrexian Devourer",
             "text": "If Phyrexian Devourer's power is 7 or greater, bury it.\no0: Remove the top card of your library from the game to put a +X/+X counter on Phyrexian Devourer, where X is equal to that card's casting cost.",
             "colours": [],
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "82e97677-fa05-58e4-bd15-e7ab978d2917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f77387-1239-4ad2-b59f-d13e317477ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f77387-1239-4ad2-b59f-d13e317477ba.jpg?1",
             "name": "Phyrexian Portal",
             "text": "o3: Target opponent looks at the top ten cards of your library and separates them into two face-down piles. Choose one of those piles and remove it from the game. Search the remaining pile and put one of those cards into your hand. Shuffle the remaining cards into your library. Ignore this effect if you have fewer than ten cards in your library.",
             "colours": [],
@@ -5996,7 +5996,7 @@
         },
         {
             "id": "33c6db6f-40b7-5118-9f34-11512947c820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a83384-8762-4028-8cab-b690593790a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a83384-8762-4028-8cab-b690593790a6.jpg?1",
             "name": "Phyrexian War Beast",
             "text": "If Phyrexian War Beast leaves play, sacrifice a land, and Phyrexian War Beast deals 1 damage to you.",
             "colours": [],
@@ -6029,7 +6029,7 @@
         },
         {
             "id": "2e32d22e-49be-54de-8e20-6bb3280fd938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d651f6-50be-4df9-80f8-4c62bb860e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d651f6-50be-4df9-80f8-4c62bb860e71.jpg?1",
             "name": "Phyrexian War Beast",
             "text": "If Phyrexian War Beast leaves play, sacrifice a land, and Phyrexian War Beast deals 1 damage to you.",
             "colours": [],
@@ -6062,7 +6062,7 @@
         },
         {
             "id": "3b97f299-b292-5608-80e3-be4feaef7932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da1c71-6059-4e4e-933d-dbca1cc4bd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da1c71-6059-4e4e-933d-dbca1cc4bd15.jpg?1",
             "name": "Scarab of the Unseen",
             "text": "oc\nT: Sacrifice Scarab of the Unseen to return all enchantments on target permanent you own to their owners' hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "8d5bb4f9-f2cc-5859-9898-ec3a48c21bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1730d219-a28f-4930-8088-4cfcb627f157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1730d219-a28f-4930-8088-4cfcb627f157.jpg?1",
             "name": "Shield Sphere",
             "text": "Counts as a wall\nIf Shield Sphere is assigned as a blocker, put a -0/-1 counter on it.",
             "colours": [],
@@ -6119,7 +6119,7 @@
         },
         {
             "id": "5e25c508-173e-5092-8dee-5686f12e600a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62652722-e345-4670-9547-d9579efa227d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62652722-e345-4670-9547-d9579efa227d.jpg?1",
             "name": "Sol Grail",
             "text": "When Sol Grail comes into play, choose a color.\noc\nT: Add one mana of the chosen color to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -6146,7 +6146,7 @@
         },
         {
             "id": "df2ca800-e1fb-5c69-a716-d77325bd6385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a0ab4-e8ef-45fd-9a73-86d1ee30cb48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a0ab4-e8ef-45fd-9a73-86d1ee30cb48.jpg?1",
             "name": "Soldevi Digger",
             "text": "o2: Put the top card of your graveyard on the bottom of your library.",
             "colours": [],
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "23151c29-7d47-5240-91b2-74e0b3c6db02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85976b5c-4eed-4cf9-b2b0-a8421a97ab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85976b5c-4eed-4cf9-b2b0-a8421a97ab2a.jpg?1",
             "name": "Soldevi Sentry",
             "text": "o1: Regenerate. Target opponent may draw a card.",
             "colours": [],
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "772b3250-9063-5588-96e5-5a5d51260e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2a84d7-3f49-4652-bb31-4be7e3474e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2a84d7-3f49-4652-bb31-4be7e3474e26.jpg?1",
             "name": "Soldevi Sentry",
             "text": "o1: Regenerate. Target opponent may draw a card.",
             "colours": [],
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "05e25387-b88b-5e11-9e3a-5608490a4e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead79d2c-170e-4106-962d-d69c4b5fead0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead79d2c-170e-4106-962d-d69c4b5fead0.jpg?1",
             "name": "Soldevi Steam Beast",
             "text": "Whenever Soldevi Steam Beast becomes tapped, target opponent gains 2 life.\no2: Regenerate",
             "colours": [],
@@ -6269,7 +6269,7 @@
         },
         {
             "id": "52051e5b-03b5-5012-b0e9-ae8e6426c65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5e730-1d5c-4326-b3fc-2f0f97edc07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5e730-1d5c-4326-b3fc-2f0f97edc07e.jpg?1",
             "name": "Soldevi Steam Beast",
             "text": "Whenever Soldevi Steam Beast becomes tapped, target opponent gains 2 life.\no2: Regenerate",
             "colours": [],
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "f1f319f1-2d7b-56eb-8875-7397cd83128f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68b531-a3f2-4830-b170-fb8a1195c149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68b531-a3f2-4830-b170-fb8a1195c149.jpg?1",
             "name": "Storm Cauldron",
             "text": "During each player's turn, that player may put one additional land into play.\nWhenever a land is tapped for mana, return that land to owner's hand.",
             "colours": [],
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "db7acb9e-34a9-5ea4-b0eb-f4845fae0307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b54c3-325b-4f2e-857b-fc1d59b6b3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b54c3-325b-4f2e-857b-fc1d59b6b3c5.jpg?1",
             "name": "Urza's Engine",
             "text": "Trample\no3: Banding until end of turn\no3: All creatures banded with Urza's Engine gain trample until end of turn.",
             "colours": [],
@@ -6358,7 +6358,7 @@
         },
         {
             "id": "1622e8a7-767e-577e-8182-9129e6169937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6206d65a-6907-4d11-acb0-8820277f2cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6206d65a-6907-4d11-acb0-8820277f2cf2.jpg?1",
             "name": "Whirling Catapult",
             "text": "o2: Remove the top two cards of your library from the game to have Whirling Catapult deal 1 damage to each creature with flying and each player.",
             "colours": [],
@@ -6385,7 +6385,7 @@
         },
         {
             "id": "201c58eb-3d9a-51f5-8bd0-a47acb4f3a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a329ff98-36fd-44c3-b037-dcc6e78ee61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a329ff98-36fd-44c3-b037-dcc6e78ee61e.jpg?1",
             "name": "Balduvian Trading Post",
             "text": "When Balduvian Trading Post comes into play, sacrifice an untapped mountain or bury Balduvian Trading Post.\noc\nT: Add o1o\nR to your mana pool.\no1, oc\nT: Balduvian Trading Post deals 1 damage to target attacking creature.",
             "colours": [],
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "3962f72f-ad7a-5201-8266-dae2c1499cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c59cb9-559b-4716-9bd7-c818b3f46f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c59cb9-559b-4716-9bd7-c818b3f46f1d.jpg?1",
             "name": "Heart of Yavimaya",
             "text": "When Heart of Yavimaya comes into play, sacrifice a forest or bury Heart of Yavimaya.\noc\nT: Add o\nG to your mana pool.\noc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "b40957c0-8c24-5e43-b186-178b65cf0eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769fc7-50b5-4b49-8aff-af04536288fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769fc7-50b5-4b49-8aff-af04536288fb.jpg?1",
             "name": "Kjeldoran Outpost",
             "text": "When Kjeldoran Outpost comes into play, sacrifice a plains or bury Kjeldoran Outpost.\noc\nT: Add o\nW to your mana pool.\no1o\nW, oc\nT: Put a Soldier token into play. Treat this token as a 1/1 white creature.",
             "colours": [],
@@ -6472,7 +6472,7 @@
         },
         {
             "id": "4643ebd2-ff72-5e68-8941-379cc9685afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee806ce-effa-4244-9659-43246e944d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee806ce-effa-4244-9659-43246e944d80.jpg?1",
             "name": "Lake of the Dead",
             "text": "When Lake of the Dead comes into play, sacrifice a swamp or bury Lake of the Dead.\noc\nT: Add o\nB to your mana pool.\noc\nT: Sacrifice a swamp to add o\nBo\nBo\nBo\nB to your mana pool.",
             "colours": [],
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "dbdabd7f-2a71-5897-9ed3-08e37b6a02af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1438606d-556d-4b96-9662-fcac051af045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1438606d-556d-4b96-9662-fcac051af045.jpg?1",
             "name": "School of the Unseen",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "aeb620bb-abf7-51bc-b33b-2bf2c12c627d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049d7a08-1605-4ce2-b8c5-634ce2a261e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049d7a08-1605-4ce2-b8c5-634ce2a261e0.jpg?1",
             "name": "Sheltered Valley",
             "text": "When Sheltered Valley comes into play, bury any other Sheltered Valley you control.\nDuring your upkeep, if you control three or fewer lands, gain 1 life.\noc\nT: Add one colorless mana to your mana pool.",
             "colours": [],
@@ -6555,7 +6555,7 @@
         },
         {
             "id": "d233f799-1bb5-59b8-a551-299e964a222c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbda146-ed0a-4bf6-b99d-dc6d59bd9447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbda146-ed0a-4bf6-b99d-dc6d59bd9447.jpg?1",
             "name": "Soldevi Excavations",
             "text": "When Soldevi Excavations comes into play, sacrifice an untapped island or bury Soldevi Excavations.\noc\nT: Add o1o\nU to your mana pool.\no1, oc\nT: Look at the top card of your library. You may put that card on the bottom of your library.",
             "colours": [],
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "89749851-59f7-5f14-b938-9708a7bc257e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411a8c6-010f-4863-a0fa-bbebe09d5c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411a8c6-010f-4863-a0fa-bbebe09d5c34.jpg?1",
             "name": "Thawing Glaciers",
             "text": "Comes into play tapped.\no1, oc\nT: Search your library for a basic land and put it into play tapped. This does not count towards your one land per turn limit. Shuffle your library afterwards. At end of turn, return Thawing Glaciers to owner's hand.",
             "colours": [],

--- a/Assets/Resources/Sets/ANB.json
+++ b/Assets/Resources/Sets/ANB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "cb13f155-d2ec-501c-b1fd-7863f74b2dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf7d90-74f4-4a69-8783-699fa3a1b0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf7d90-74f4-4a69-8783-699fa3a1b0e2.jpg?1",
             "name": "Angel of Vitality",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nAngel of Vitality gets +2/+2 as long as you have 25 or more life.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "3889222e-3e34-5aad-9793-6a2984a33a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51b95b-c491-49de-95bd-7ac5f8f89836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51b95b-c491-49de-95bd-7ac5f8f89836.jpg?1",
             "name": "Angelic Guardian",
             "text": "Flying\nWhenever one or more creatures you control attack, they gain indestructible until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "12a9f318-65d4-5c84-9bef-aaf7819c08e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05a2131-d367-483a-bada-54a484bfe75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05a2131-d367-483a-bada-54a484bfe75e.jpg?1",
             "name": "Angelic Reward",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has flying.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "1de52b70-805b-59de-8572-a83c8855afc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948351f2-2273-4cad-acfd-b7b4643beb7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948351f2-2273-4cad-acfd-b7b4643beb7b.jpg?1",
             "name": "Bond of Discipline",
             "text": "Tap all creatures your opponents control. Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "bcb83398-97bf-5600-a781-2b66dcbf2eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667d7ba8-f48a-4ac7-b27f-1893778a760f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667d7ba8-f48a-4ac7-b27f-1893778a760f.jpg?1",
             "name": "Charmed Stray",
             "text": "Lifelink\nWhen Charmed Stray enters the battlefield, put a +1/+1 counter on each other creature you control named Charmed Stray.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "fb315b59-19f1-536b-8b25-ae3e72164a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87673b63-cacb-43b3-8723-924a7d5aed0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87673b63-cacb-43b3-8723-924a7d5aed0c.jpg?1",
             "name": "Confront the Assault",
             "text": "Cast this spell only if a creature is attacking you.\nCreate three 1/1 white Spirit creature tokens with flying.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "a9cd265a-33a3-5fa2-83f7-17675306e34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ba9f0-588d-4d4a-afe5-b188ba79aa70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ba9f0-588d-4d4a-afe5-b188ba79aa70.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -232,7 +232,7 @@
         },
         {
             "id": "937660aa-32d3-5634-9f05-7a7971ed0755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dcc4a4-f426-469d-b2af-1cd516177ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dcc4a4-f426-469d-b2af-1cd516177ef7.jpg?1",
             "name": "Goring Ceratops",
             "text": "Double strike\nWhenever Goring Ceratops attacks, other creatures you control gain double strike until end of turn.",
             "colours": [
@@ -265,7 +265,7 @@
         },
         {
             "id": "4df82244-824b-595e-b31f-3ba61206e160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26899e78-fa6f-49fa-bb9b-be1c432612ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26899e78-fa6f-49fa-bb9b-be1c432612ee.jpg?1",
             "name": "Hallowed Priest",
             "text": "Whenever you gain life, put a +1/+1 counter on Hallowed Priest.",
             "colours": [
@@ -299,7 +299,7 @@
         },
         {
             "id": "f18094aa-3328-5216-acf0-6e17225bcb9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20726907-ee1f-49ef-a694-7d3f53ee1e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20726907-ee1f-49ef-a694-7d3f53ee1e2d.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -333,7 +333,7 @@
         },
         {
             "id": "84aad5cc-588d-5a6d-b606-6ec941677145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47eafcb-3f6c-4c84-a93d-d59178ff4828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47eafcb-3f6c-4c84-a93d-d59178ff4828.jpg?1",
             "name": "Inspiring Commander",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -367,7 +367,7 @@
         },
         {
             "id": "7f5d7e70-fae4-5fc7-9478-07d12b47baca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b3432-fa06-43d2-9112-b5ad23e02ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b3432-fa06-43d2-9112-b5ad23e02ccc.jpg?1",
             "name": "Knight's Pledge",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -400,7 +400,7 @@
         },
         {
             "id": "2954289b-60b3-519d-9514-972630e8b2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387c4ae-1a45-4ea5-875a-5a6c1d6a7846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387c4ae-1a45-4ea5-875a-5a6c1d6a7846.jpg?1",
             "name": "Leonin Warleader",
             "text": "Whenever Leonin Warleader attacks, create two 1/1 white Cat creature tokens with lifelink that are tapped and attacking.",
             "colours": [
@@ -434,7 +434,7 @@
         },
         {
             "id": "916381e6-9019-57ef-a754-ea3b8e2e8a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087f35cc-ccb4-479a-baf2-8249a58e4a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087f35cc-ccb4-479a-baf2-8249a58e4a68.jpg?1",
             "name": "Loxodon Line Breaker",
             "text": "",
             "colours": [
@@ -468,7 +468,7 @@
         },
         {
             "id": "83dbacc0-8e84-551c-85f0-2a83082c5203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e6b88e-a7fc-495a-ac8c-7ccb243164ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e6b88e-a7fc-495a-ac8c-7ccb243164ee.jpg?1",
             "name": "Moorland Inquisitor",
             "text": "{2}{W}: Moorland Inquisitor gains first strike until end of turn.",
             "colours": [
@@ -502,7 +502,7 @@
         },
         {
             "id": "5fe132e0-9ebb-5e23-b9a0-a5b8e503fa2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0671ff-ad06-43ae-87cd-06a1341e971b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0671ff-ad06-43ae-87cd-06a1341e971b.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -535,7 +535,7 @@
         },
         {
             "id": "c9deb5ef-2557-5f7b-9f9d-e3043ce90437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61170c40-1e85-4fc2-804a-7fdc7062ac55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61170c40-1e85-4fc2-804a-7fdc7062ac55.jpg?1",
             "name": "Sanctuary Cat",
             "text": "",
             "colours": [
@@ -568,7 +568,7 @@
         },
         {
             "id": "868341f7-7866-5a1f-b774-a60d8b29648a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97ae05c-4186-4b76-b674-d1aebd25ba46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97ae05c-4186-4b76-b674-d1aebd25ba46.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -601,7 +601,7 @@
         },
         {
             "id": "e2863fa3-e174-51f9-bb47-c8d72aa04819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2d3642-3eda-4b15-96dd-b0f0f9680bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2d3642-3eda-4b15-96dd-b0f0f9680bd7.jpg?1",
             "name": "Shrine Keeper",
             "text": "",
             "colours": [
@@ -635,7 +635,7 @@
         },
         {
             "id": "ab83926d-e05a-53a7-a0ad-8fb30d75ca4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f519ff42-3737-4242-b097-f8a3442b9123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f519ff42-3737-4242-b097-f8a3442b9123.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -669,7 +669,7 @@
         },
         {
             "id": "246fba94-126b-57e9-9cb0-060cdf8d08f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadcfcf-f093-44e9-a632-fcc719c570d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadcfcf-f093-44e9-a632-fcc719c570d7.jpg?1",
             "name": "Spiritual Guardian",
             "text": "When Spiritual Guardian enters the battlefield, you gain 4 life.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "0c55568b-815d-5239-b1c5-e956d5d38286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1274d0f3-2b5c-45f6-827f-3548e63f3692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1274d0f3-2b5c-45f6-827f-3548e63f3692.jpg?1",
             "name": "Tactical Advantage",
             "text": "Target blocking or blocked creature you control gets +2/+2 until end of turn.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "6b84de55-eadd-5a3b-92ef-be727332618c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28b4c7a-42d8-413e-a349-5a2d589e54f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28b4c7a-42d8-413e-a349-5a2d589e54f5.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "619823fd-4cf6-5935-9c19-e6178f342dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a783f2-04d3-42fc-acc1-5f2974f9aca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a783f2-04d3-42fc-acc1-5f2974f9aca2.jpg?1",
             "name": "Armored Whirl Turtle",
             "text": "",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "8247ee21-825f-537d-ad9c-0b20b19b92e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8cddc6-fcbf-47d3-8068-5c0f1123b558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8cddc6-fcbf-47d3-8068-5c0f1123b558.jpg?1",
             "name": "Cloudkin Seer",
             "text": "Flying\nWhen Cloudkin Seer enters the battlefield, draw a card.",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "2c4d138a-8fd6-5c6b-b498-f6dd1088a0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467a49ef-39e4-431b-9b4a-2c329d3a1edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467a49ef-39e4-431b-9b4a-2c329d3a1edb.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -866,7 +866,7 @@
         },
         {
             "id": "3a682c9f-b6e2-52d3-94ec-207c2d7d52ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e82bd0d-647f-42bd-b6d2-9a5d2a7bcd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e82bd0d-647f-42bd-b6d2-9a5d2a7bcd2f.jpg?1",
             "name": "Frilled Sea Serpent",
             "text": "{5}{U}{U}: Frilled Sea Serpent can't be blocked this turn.",
             "colours": [
@@ -899,7 +899,7 @@
         },
         {
             "id": "42430f27-2a2f-5406-a203-ef3ed9c04bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9db535-6279-4b5e-87c3-15c1321b50c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9db535-6279-4b5e-87c3-15c1321b50c8.jpg?1",
             "name": "Glint",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "74be9b88-a716-5160-9562-f5bc45e5d384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec0a0fc-7b82-4812-b8cc-cbfba4987142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec0a0fc-7b82-4812-b8cc-cbfba4987142.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2.",
             "colours": [
@@ -963,7 +963,7 @@
         },
         {
             "id": "4e6dfdf4-bb79-5b99-a836-40ab234791c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83443ce0-61d7-484d-b6b2-aaf35fb81fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83443ce0-61d7-484d-b6b2-aaf35fb81fea.jpg?1",
             "name": "Overflowing Insight",
             "text": "Target player draws seven cards.",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "e0f894ad-459a-5fb6-9442-bf82998a5cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e480ab2-d862-4620-8369-18af0577278b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e480ab2-d862-4620-8369-18af0577278b.jpg?1",
             "name": "Riddlemaster Sphinx",
             "text": "Flying\nWhen Riddlemaster Sphinx enters the battlefield, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1027,7 +1027,7 @@
         },
         {
             "id": "dd80be47-06cd-5fe8-8172-0add21d815fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6d038a-706a-4a93-bcab-4533340fb960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6d038a-706a-4a93-bcab-4533340fb960.jpg?1",
             "name": "River's Favor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "3b31a8e1-d3bf-5e97-af54-e52e1c063758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d899e1-bded-4e16-8ecc-cc07784af4bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d899e1-bded-4e16-8ecc-cc07784af4bb.jpg?1",
             "name": "Shorecomber Crab",
             "text": "",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "8b3e2da4-8d61-52a5-9bba-d6f4b6a9cad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959aeb66-311d-4a73-9120-e73692cb252c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959aeb66-311d-4a73-9120-e73692cb252c.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "f41f11d0-d03a-5893-93b8-90d9ac8902e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7631df-2e6c-4472-8dd6-8b07fcc545fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7631df-2e6c-4472-8dd6-8b07fcc545fb.jpg?1",
             "name": "Soulblade Djinn",
             "text": "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "768cd238-f7f2-591c-8404-8f233437dfa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a86fb-3652-4ac7-a879-c78899c493d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a86fb-3652-4ac7-a879-c78899c493d6.jpg?1",
             "name": "Sworn Guardian",
             "text": "",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "b14bc833-95e8-58e2-ad16-a00780103d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824cebc-6b5f-4e2a-95a1-8bfc2032ed21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824cebc-6b5f-4e2a-95a1-8bfc2032ed21.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "8249ce5c-7e8a-595d-ad62-976a517ba1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50691365-dde3-4956-bc7d-3d0b05d32c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50691365-dde3-4956-bc7d-3d0b05d32c73.jpg?1",
             "name": "Wall of Runes",
             "text": "Defender\nWhen Wall of Runes enters the battlefield, scry 1.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "26a6fa2c-8891-5125-88b7-a4f30f237b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0daadff-ac69-48e7-9889-81aa624486b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0daadff-ac69-48e7-9889-81aa624486b1.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "9d9a9760-503d-5882-8815-569f8911c32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d5581-68c8-4e78-aa80-69dd0d62b08d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d5581-68c8-4e78-aa80-69dd0d62b08d.jpg?1",
             "name": "Waterkin Shaman",
             "text": "Whenever a creature with flying enters the battlefield under your control, Waterkin Shaman gets +1/+1 until end of turn.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "b04d31dd-0001-53d1-9e55-67d9a353f554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d53c5ec-eb0b-48cc-b244-99cb42d61b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d53c5ec-eb0b-48cc-b244-99cb42d61b4a.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "61a763d5-5102-5554-a8c2-7a89838a2a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a391d1-5916-4396-98c3-8a954d736eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a391d1-5916-4396-98c3-8a954d736eda.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "068163e5-91a2-5741-bbd9-5a5a3ae6ca7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40dae56-be19-4b64-b99d-f45b7f816287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40dae56-be19-4b64-b99d-f45b7f816287.jpg?1",
             "name": "Windstorm Drake",
             "text": "Flying\nOther creatures you control with flying get +1/+0.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "1ee639cb-e8f4-5fc7-ba3e-a1f0941a1e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3449f98f-92d2-4be4-a596-fefa8843b6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3449f98f-92d2-4be4-a596-fefa8843b6fd.jpg?1",
             "name": "Winged Words",
             "text": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "3ee9a045-cf21-5768-b105-7bc7896162fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626e13bc-c7d4-405f-b365-54264676d49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626e13bc-c7d4-405f-b365-54264676d49c.jpg?1",
             "name": "Zephyr Gull",
             "text": "Flying",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "47165480-bed6-5155-a666-a39cb93c1ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73d8462-6901-47c4-99e8-93efb5d54737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73d8462-6901-47c4-99e8-93efb5d54737.jpg?1",
             "name": "Bad Deal",
             "text": "You draw two cards and each opponent discards two cards. Each player loses 2 life.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "8a282f4a-c2ab-5607-852d-79bdc69f3a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3d009-6cd3-4a2a-9154-954812097069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3d009-6cd3-4a2a-9154-954812097069.jpg?1",
             "name": "Compound Fracture",
             "text": "Target creature gets -1/-1 until end of turn. It gets an additional -1/-1 until end of turn for each card named Compound Fracture in your graveyard.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "10f8d33f-fb69-5bbf-b0bd-70a17163a363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343bba3d-d235-4855-8ab2-cb715f29fb60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343bba3d-d235-4855-8ab2-cb715f29fb60.jpg?1",
             "name": "Cruel Cut",
             "text": "Destroy target creature with power 2 or less.",
             "colours": [
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "90c38782-d935-5744-945a-4101ed1f6294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827efbc-70a4-413d-bb73-41661c1a9830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827efbc-70a4-413d-bb73-41661c1a9830.jpg?1",
             "name": "Demon of Loathing",
             "text": "Flying, trample\nWhenever Demon of Loathing deals combat damage to a player, that player sacrifices a creature.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "e1e56b48-f7ad-51a5-bb1c-bb0e9dded764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48fe5e5-0a24-4231-af68-f99158ebbea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48fe5e5-0a24-4231-af68-f99158ebbea5.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "40eafc47-2865-51b2-97c3-69969bed5e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b672836-dba8-4a32-ac04-616644268534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b672836-dba8-4a32-ac04-616644268534.jpg?1",
             "name": "Krovikan Scoundrel",
             "text": "",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "77a35ade-f4b5-5638-b766-0c296582bbaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b89c0a7-9fb6-4930-a110-f33915ce93c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b89c0a7-9fb6-4930-a110-f33915ce93c3.jpg?1",
             "name": "Malakir Cullblade",
             "text": "Whenever a creature an opponent controls dies, put a +1/+1 counter on Malakir Cullblade.",
             "colours": [
@@ -1713,7 +1713,7 @@
         },
         {
             "id": "9ddc62bb-fa37-5178-a0ef-412989f2a266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0afbaf-2a0b-4f2f-9649-662923713d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0afbaf-2a0b-4f2f-9649-662923713d8b.jpg?1",
             "name": "Mardu Outrider",
             "text": "As an additional cost to cast this spell, discard a card.",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "5d7a1418-36a5-594e-a636-cf9eb138bfee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cffe0-0a60-406c-9dab-8c065cd798e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cffe0-0a60-406c-9dab-8c065cd798e9.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "fc090d6c-614d-5f43-8fad-3cbe7ee66413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1871e0-623b-4543-8b3c-3e54137cfe43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1871e0-623b-4543-8b3c-3e54137cfe43.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "36e9eca9-7697-5757-b72a-301f0dd0d427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706a38f3-8e7a-4ce5-9af9-e9f4c8afc9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706a38f3-8e7a-4ce5-9af9-e9f4c8afc9ec.jpg?1",
             "name": "Nimble Pilferer",
             "text": "Flash",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "06b462bf-dd61-51b8-94fa-bbe145d70245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fdb3d-cb34-4691-ada3-ff47b6802363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fdb3d-cb34-4691-ada3-ff47b6802363.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "776568cd-6c66-59ef-98fe-8d72a2bc5696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4139383e-6c7c-4053-8e89-8b601e4ae98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4139383e-6c7c-4053-8e89-8b601e4ae98e.jpg?1",
             "name": "Rise from the Grave",
             "text": "",
             "colours": [
@@ -1908,7 +1908,7 @@
         },
         {
             "id": "38f6476d-ac22-5164-9728-19edb7de0e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ed607-2338-4119-b24c-7657133dc6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ed607-2338-4119-b24c-7657133dc6be.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "371bb42c-fe39-5f26-9b99-c85e86c42e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee2735e-05a8-4e3b-a44c-4e7532f1d312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee2735e-05a8-4e3b-a44c-4e7532f1d312.jpg?1",
             "name": "Savage Gorger",
             "text": "Flying\nAt the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on Savage Gorger. (Damage causes loss of life.)",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "5d6b03a7-be45-5374-b800-497131375fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa1144a-6110-408d-9d4b-2bfe6aebd7e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa1144a-6110-408d-9d4b-2bfe6aebd7e0.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -2007,7 +2007,7 @@
         },
         {
             "id": "2a30127b-4fff-59b5-aa0f-7ef9d642e0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00508913-ba8c-4985-9547-d74e07e1cc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00508913-ba8c-4985-9547-d74e07e1cc6b.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "a949bb21-567d-5864-92a8-138fc82e70ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd1af7-6094-46f3-8894-9add826b1031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd1af7-6094-46f3-8894-9add826b1031.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "5ee50241-4f51-59c1-9ce1-03f6c9d117be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16537b4c-5dd8-4d38-a1ce-7ac803c3f48a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16537b4c-5dd8-4d38-a1ce-7ac803c3f48a.jpg?1",
             "name": "Soulhunter Rakshasa",
             "text": "Soulhunter Rakshasa can't block.\nWhen Soulhunter Rakshasa enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "de43ebd4-822e-5ead-aa30-57d1308b9877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4985d1-f311-4132-8d32-0a76ee53392e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4985d1-f311-4132-8d32-0a76ee53392e.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "f1a19b29-95ad-5917-9255-e398016c9186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf7a3f-35df-4322-a61e-e0e4f47da623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf7a3f-35df-4322-a61e-e0e4f47da623.jpg?1",
             "name": "Unlikely Aid",
             "text": "Target creature gets +2/+0 and gains indestructible until end of turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "5a7d10e2-c45f-5818-9b19-5dad54400b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982538c4-0b93-416d-9110-e0d2602d70aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982538c4-0b93-416d-9110-e0d2602d70aa.jpg?1",
             "name": "Vampire Opportunist",
             "text": "{6}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "5f90a657-b5a1-5015-a7dd-e940896949ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1f9bd-2891-4338-bcce-c55e55e6c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1f9bd-2891-4338-bcce-c55e55e6c933.jpg?1",
             "name": "Witch's Familiar",
             "text": "",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "e4a1e9a5-8d53-5b8a-8df5-85e9cef5cdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af04ac4f-7588-4fbb-95a7-78b3b6a5c209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af04ac4f-7588-4fbb-95a7-78b3b6a5c209.jpg?1",
             "name": "Bombard",
             "text": "Bombard deals 4 damage to target creature.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "193812f4-8645-5cc7-83c1-e228cfaca777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d007b-2db1-4e58-9281-5ade8d81ecf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d007b-2db1-4e58-9281-5ade8d81ecf9.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "11f526a9-c55d-55e0-99e1-cacbfc803800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9351dc-9af0-48d1-9012-7c478fdc34e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9351dc-9af0-48d1-9012-7c478fdc34e1.jpg?1",
             "name": "Fearless Halberdier",
             "text": "",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "ffe762bf-b14f-5f58-a4fc-5d9e0dc0f291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ebf8-5616-4cff-81d9-cd20b20102ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ebf8-5616-4cff-81d9-cd20b20102ee.jpg?1",
             "name": "Goblin Gang Leader",
             "text": "When Goblin Gang Leader enters the battlefield, create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "5bd2796c-e9dc-5d7b-a9ae-fd7041d75836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599032a9-4652-46c5-bdf4-43be00e25db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599032a9-4652-46c5-bdf4-43be00e25db3.jpg?1",
             "name": "Goblin Gathering",
             "text": "Create a number of 1/1 red Goblin creature tokens equal to two plus the number of cards named Goblin Gathering in your graveyard.",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "e8755a49-c8d6-5d36-bb60-6c11bc876c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f95fec8-99f6-4ce5-bfc3-426a568ee053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f95fec8-99f6-4ce5-bfc3-426a568ee053.jpg?1",
             "name": "Goblin Trashmaster",
             "text": "Other Goblins you control get +1/+1.\nSacrifice a Goblin: Destroy target artifact.",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "e1ac69ef-6880-572a-a2a0-9234b269a239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd7f3f-ca38-46cc-a2f6-1970b7cdec1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd7f3f-ca38-46cc-a2f6-1970b7cdec1f.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "c6a1e89c-efa4-5f92-b322-41d4f8daa662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb64a1-3791-4b39-b68d-2ea4459d5a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb64a1-3791-4b39-b68d-2ea4459d5a72.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "be0c3509-4eaa-5243-a20e-06522586320b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7701e2d1-ebc2-4c2d-bb50-25ce73d9c59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7701e2d1-ebc2-4c2d-bb50-25ce73d9c59a.jpg?1",
             "name": "Immortal Phoenix",
             "text": "Flying\nWhen Immortal Phoenix dies, return it to its owner's hand.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "48bf2e6c-e0df-5e87-896c-8a3fa934dda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e77225-3b31-49ba-909c-b0c2b3aaeb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e77225-3b31-49ba-909c-b0c2b3aaeb9b.jpg?1",
             "name": "Inescapable Blaze",
             "text": "This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "7b54b98d-444b-5803-879b-a210373d9252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f9ee1b-6002-4ebb-b755-f1a3ef5810cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f9ee1b-6002-4ebb-b755-f1a3ef5810cf.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "e6887992-8739-518c-a87d-a671f94c16bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cd434c-a04c-4ac8-9b1a-a79903d84060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cd434c-a04c-4ac8-9b1a-a79903d84060.jpg?1",
             "name": "Molten Ravager",
             "text": "{R}: Molten Ravager gets +1/+0 until end of turn.",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "e0d54f4e-70a1-5e50-a1c9-b8a8dfcb7f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48165add-7fef-456b-a703-be548df3e972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48165add-7fef-456b-a703-be548df3e972.jpg?1",
             "name": "Nest Robber",
             "text": "Haste",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "0a806a85-4fe9-526b-a1ed-86188787b428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe6f1c-bd4c-412a-af18-228319dc8e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe6f1c-bd4c-412a-af18-228319dc8e87.jpg?1",
             "name": "Ogre Battledriver",
             "text": "Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "a915042e-9583-546a-8baf-bf2395d50044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae1f0-60b6-4c4a-975b-13e659a33f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae1f0-60b6-4c4a-975b-13e659a33f50.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste",
             "colours": [
@@ -2730,7 +2730,7 @@
         },
         {
             "id": "daf5518f-0033-53ee-aad5-e0865b9052e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce45801e-2fca-435c-833f-dd1b8f11f308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce45801e-2fca-435c-833f-dd1b8f11f308.jpg?1",
             "name": "Raid Bombardment",
             "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to the player or planeswalker that creature is attacking.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "3467e666-b717-5102-baea-e46eb97867f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c978c53c-1b27-4c8d-8b01-5646ee1bdb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c978c53c-1b27-4c8d-8b01-5646ee1bdb1c.jpg?1",
             "name": "Reduce to Ashes",
             "text": "Reduce to Ashes deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e7ad0c62-682a-5bcd-a5a4-528c3ed75699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c146ec-3006-4ac1-b2b6-fe0f9e879dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c146ec-3006-4ac1-b2b6-fe0f9e879dc9.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "9e321e64-0bd9-57a1-b30f-a5771cd96da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67baa699-de43-4100-8a5a-82e39eec11f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67baa699-de43-4100-8a5a-82e39eec11f5.jpg?1",
             "name": "Siege Dragon",
             "text": "Flying\nWhen Siege Dragon enters the battlefield, destroy all Walls your opponents control.\nWhenever Siege Dragon attacks, if defending player controls no Walls, it deals 2 damage to each creature without flying that player controls.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "ae774d91-4735-5467-9672-35f9dff57a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3da54f-b4ee-4e9a-929e-619094691434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3da54f-b4ee-4e9a-929e-619094691434.jpg?1",
             "name": "Storm Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "37c2a5d0-120a-5d49-a362-b71c2935cc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26307e83-66ae-4def-9532-dd874fd39efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26307e83-66ae-4def-9532-dd874fd39efc.jpg?1",
             "name": "Tin Street Cadet",
             "text": "Whenever Tin Street Cadet becomes blocked, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "7c61972b-505c-5315-9ea3-5ebe2efcd11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afac4b5-2148-489e-b3dd-01388a234a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afac4b5-2148-489e-b3dd-01388a234a90.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying, haste",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "91af4939-2ee7-5439-ae01-ec166b29eb97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123bc3aa-d959-47e8-b160-1443b2cd41ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123bc3aa-d959-47e8-b160-1443b2cd41ce.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "2dd705bc-aa36-5a6a-9d42-cc689eef8b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b22c5d-3b29-47c1-8a04-13586461a143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b22c5d-3b29-47c1-8a04-13586461a143.jpg?1",
             "name": "Baloth Packhunter",
             "text": "Trample\nWhen Baloth Packhunter enters the battlefield, put two +1/+1 counters on each other creature you control named Baloth Packhunter.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "0241228b-7e18-5a66-9f11-9411e8670bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66feeb05-7adc-4a0e-ba2e-24781e5a291a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66feeb05-7adc-4a0e-ba2e-24781e5a291a.jpg?1",
             "name": "Charging Badger",
             "text": "Trample",
             "colours": [
@@ -3052,7 +3052,7 @@
         },
         {
             "id": "e69f515c-81c7-54ee-b048-69030816e408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44353b14-f3ab-4371-adb0-70e49dc6764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44353b14-f3ab-4371-adb0-70e49dc6764b.jpg?1",
             "name": "Colossal Majesty",
             "text": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "1325f67f-5313-59e6-9d34-06a720a1bea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3783bbed-5ae8-4d62-b39e-99136c42eeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3783bbed-5ae8-4d62-b39e-99136c42eeb6.jpg?1",
             "name": "Epic Proportions",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +5/+5 and has trample.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "7bb67b40-4978-52d0-b458-44937d87a258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f39c3fd-8ada-46e5-b247-428f7f2fe60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f39c3fd-8ada-46e5-b247-428f7f2fe60c.jpg?1",
             "name": "Feral Roar",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "5ae97426-172e-5922-b682-4fcb10a15e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b74b7-9d2d-4d91-a036-e9a3dc49bc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b74b7-9d2d-4d91-a036-e9a3dc49bc7f.jpg?1",
             "name": "Generous Stray",
             "text": "When Generous Stray enters the battlefield, draw a card.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "434d9ac8-3b3b-5536-a2e9-12342f3544cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600c2484-7d1a-4acd-9cc7-82bf70ace19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600c2484-7d1a-4acd-9cc7-82bf70ace19e.jpg?1",
             "name": "Gigantosaurus",
             "text": "",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "c07c88c7-4655-5394-9083-41c07a32fda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a50513-8570-47f0-9c57-6a775f0d2cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a50513-8570-47f0-9c57-6a775f0d2cf2.jpg?1",
             "name": "Greenwood Sentinel",
             "text": "Vigilance",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "cf6363f2-854c-5cf9-bcba-50dac2618585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cd7334-d55a-4e0d-aa25-a403c6e24a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cd7334-d55a-4e0d-aa25-a403c6e24a53.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "ddb6b0d5-9770-534a-ae31-0fff222bf616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fd403a-397e-423e-979a-69cf7a6096d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fd403a-397e-423e-979a-69cf7a6096d8.jpg?1",
             "name": "Jungle Delver",
             "text": "{3}{G}: Put a +1/+1 counter on Jungle Delver.",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "6a9cdb21-7ae0-5da9-91a0-9fe6bf36d35b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757d1e9b-4292-4dcc-ae52-d9f60aa6694d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757d1e9b-4292-4dcc-ae52-d9f60aa6694d.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "5d7f84b8-2743-5ddf-a039-20200bd4a477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41754001-4d64-4aa2-a273-aca4a1d323d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41754001-4d64-4aa2-a273-aca4a1d323d0.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "9f2eb732-0204-5806-919f-b37a3c926d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797dcbaa-d41b-4059-92fa-4a804e16a2ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797dcbaa-d41b-4059-92fa-4a804e16a2ce.jpg?1",
             "name": "Rampaging Brontodon",
             "text": "Trample\nWhenever Rampaging Brontodon attacks, it gets +1/+1 until end of turn for each land you control.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "f4e1d075-3d62-5852-8f2f-fa1022fb4b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28b7565-3da0-4878-bf5d-188f7019d47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28b7565-3da0-4878-bf5d-188f7019d47f.jpg?1",
             "name": "Rumbling Baloth",
             "text": "",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "12c4a78e-53ca-5d01-b593-4e0dfc1e0b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bdafb1-abb9-4020-8f74-18f9321de90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bdafb1-abb9-4020-8f74-18f9321de90a.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "e9827d5d-c385-5259-abfc-e271dce84189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0597ce-f91a-43a0-aad6-fbb2a4d9fe57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0597ce-f91a-43a0-aad6-fbb2a4d9fe57.jpg?1",
             "name": "Stony Strength",
             "text": "Put a +1/+1 counter on target creature you control. Untap that creature.",
             "colours": [
@@ -3508,7 +3508,7 @@
         },
         {
             "id": "c33b720f-76ed-5e87-ae07-8b319636a319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e463fb-f861-4042-a6ef-8961968624f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e463fb-f861-4042-a6ef-8961968624f1.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "3460704e-3a79-5884-ac55-a8f2fdde2479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c42e1a-9a4d-4630-b6c2-749d76c4cafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c42e1a-9a4d-4630-b6c2-749d76c4cafb.jpg?1",
             "name": "Treetop Warden",
             "text": "",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "bcff940d-22e1-5580-9811-e0eaa5f03db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193031-f981-4ca5-96e5-df1a5ffee246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193031-f981-4ca5-96e5-df1a5ffee246.jpg?1",
             "name": "Wildwood Patrol",
             "text": "Trample",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "9a0ee7cc-6961-5c04-aab1-2fdb822f6151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c9a583-2356-47ec-b908-c77d6acf24b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c9a583-2356-47ec-b908-c77d6acf24b8.jpg?1",
             "name": "Woodland Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "dc1653ba-a177-5f4e-b113-b2e17fa1a12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc05f8d-7f92-4f54-8d12-ab51030a15a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc05f8d-7f92-4f54-8d12-ab51030a15a6.jpg?1",
             "name": "World Shaper",
             "text": "Whenever World Shaper attacks, you may mill three cards.\nWhen World Shaper dies, return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3675,7 +3675,7 @@
         },
         {
             "id": "55045a71-ec8c-59d9-8eb4-4ae40ca0c5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c1f416-95e1-4d94-9ea5-e74da7071223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c1f416-95e1-4d94-9ea5-e74da7071223.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "ed40a1e5-455f-5eb1-9b00-2d3283b4defc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef83f4c-d3ff-4905-a16d-f2bae673a5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef83f4c-d3ff-4905-a16d-f2bae673a5b2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "5a838d65-5bc8-5c52-8637-c20e3ad686a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8550f5-cf3c-4061-8010-74b3d8709c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8550f5-cf3c-4061-8010-74b3d8709c68.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "258b4dde-8428-5431-b9df-bb97c71fe532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330e5230-7c5a-4720-b582-1087e5aa0cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330e5230-7c5a-4720-b582-1087e5aa0cf8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "a8f6bc20-f48c-5c84-a096-47e03f8481e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f284507-5cdc-48ee-9bc8-724045814664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f284507-5cdc-48ee-9bc8-724045814664.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "8b238069-cd13-525b-b597-36d22c5a823d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f796dc-7a6b-4652-9268-3523d7b54e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f796dc-7a6b-4652-9268-3523d7b54e94.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "6d223288-3e3b-5382-ba61-1f27e2ae3f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae6e393-315b-4f70-9da2-c58003e2813d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae6e393-315b-4f70-9da2-c58003e2813d.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "484cbb6b-e7b6-53e7-a3cf-945a5515b994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde73c08-40f6-42bd-9c38-348fcef97aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde73c08-40f6-42bd-9c38-348fcef97aa5.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],

--- a/Assets/Resources/Sets/APC.json
+++ b/Assets/Resources/Sets/APC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "55b7fa67-2e15-5238-91af-eec9756df435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7af8350-9a51-437c-a55e-19f3e07acfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7af8350-9a51-437c-a55e-19f3e07acfa9.jpg?1",
             "name": "Angelfire Crusader",
             "text": "o\nR: Angelfire Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "0d6779fd-6d98-507a-9e9c-7aae8522da87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e417461-a230-4548-bcc1-71377487f21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e417461-a230-4548-bcc1-71377487f21b.jpg?1",
             "name": "Coalition Flag",
             "text": "Coalition Flag can enchant only a creature you control.\nEnchanted creature's type is Flagbearer.\nIf an opponent plays a spell or ability that could target a Flagbearer in play, that player chooses at least one Flagbearer as a target.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "50bcc84e-38d9-50d4-8c19-2af36f46e763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b7be3e-b4af-46d4-bcc6-b44c651f2012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b7be3e-b4af-46d4-bcc6-b44c651f2012.jpg?1",
             "name": "Coalition Honor Guard",
             "text": "If an opponent plays a spell or ability that could target a Flagbearer in play, that player chooses at least one Flagbearer as a target.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "5a786323-8603-546a-b277-bf6203471d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9cd7d9-8aad-4607-890c-9c8efe016a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9cd7d9-8aad-4607-890c-9c8efe016a92.jpg?1",
             "name": "Dega Disciple",
             "text": "o\nB, oc\nT: Target creature gets -2/-0 until end of turn.\no\nR, oc\nT: Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "d078a5c3-46ae-59c1-ac7b-f3eb012b3b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ddfdb5-3981-4954-af5f-2459d22ec575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ddfdb5-3981-4954-af5f-2459d22ec575.jpg?1",
             "name": "Dega Sanctuary",
             "text": "At the beginning of your upkeep, if you control a black or red permanent, you gain 2 life. If you control a black permanent and a red permanent, you gain 4 life instead.",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "29712086-42f9-5366-8003-9fdba2f25777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a52c3a-2f58-4b4d-b3c6-f9a08e25c7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a52c3a-2f58-4b4d-b3c6-f9a08e25c7de.jpg?1",
             "name": "Degavolver",
             "text": "Kicker o1o\nB and/or o\nR\nIf you paid the o1o\nB kicker cost, Degavolver comes into play with two +1/+1 counters on it and has \"Pay 3 life: Regenerate Degavolver.\"\nIf you paid the o\nR kicker cost, Degavolver comes into play with a +1/+1 counter on it and has first strike.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "d41a29f3-099e-5ae8-b15d-6aa1d6ace507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5061e4-a76d-4a7c-b196-96c81f94e0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5061e4-a76d-4a7c-b196-96c81f94e0e5.jpg?1",
             "name": "Diversionary Tactics",
             "text": "Tap two untapped creatures you control: Tap target creature.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "7b13aa63-a4e1-59f1-9a77-2763752d0936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f596ce1-b754-4e34-98e3-e1ddda2fd9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f596ce1-b754-4e34-98e3-e1ddda2fd9b0.jpg?1",
             "name": "Divine Light",
             "text": "Prevent all damage that would be dealt this turn to creatures you control.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "0ac5051c-2784-5eeb-b542-93fb5a5ef6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38138bb4-25ea-4aaf-8b1c-e9e60678fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38138bb4-25ea-4aaf-8b1c-e9e60678fc6b.jpg?1",
             "name": "Enlistment Officer",
             "text": "First strike\nWhen Enlistment Officer comes into play, reveal the top four cards of your library. Put all Soldier cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "add7f8fe-721b-5c72-8e5a-3c8aee5cf0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695e0ba-005a-4652-aea7-e1d1f9ff5d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695e0ba-005a-4652-aea7-e1d1f9ff5d66.jpg?1",
             "name": "False Dawn",
             "text": "Colored mana symbols on all permanents you control and on all cards you own that aren't in play become o\nW until end of turn.\nDraw a card.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "ffe26573-a49b-554c-9ee4-38e273e80ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca800f-e850-4bec-95d0-70280b51b7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca800f-e850-4bec-95d0-70280b51b7a7.jpg?1",
             "name": "Gerrard Capashen",
             "text": "At the beginning of your upkeep, you gain 1 life for each card in target opponent's hand.\no3o\nW: Tap target creature. Play this ability only if Gerrard Capashen is attacking.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "11cf5b54-b939-5edd-8c26-8744618cbe44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d2d11b-12e4-4810-a32d-8f1cdda3ec49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d2d11b-12e4-4810-a32d-8f1cdda3ec49.jpg?1",
             "name": "Haunted Angel",
             "text": "Flying\nWhen Haunted Angel is put into a graveyard from play, remove Haunted Angel from the game and each other player puts a 3/3 black Angel creature token with flying into play.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "33968db0-33fc-5c47-9284-c33b9271c671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4d395e-d7d6-4e93-9761-b0bae63b7b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4d395e-d7d6-4e93-9761-b0bae63b7b1c.jpg?1",
             "name": "Helionaut",
             "text": "Flying\no1, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "a5619b62-7c1d-5e54-97b9-b752c999c64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da5010-78b6-426f-aeb4-73c21d2af581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da5010-78b6-426f-aeb4-73c21d2af581.jpg?1",
             "name": "Manacles of Decay",
             "text": "Enchanted creature can't attack.\no\nB: Enchanted creature gets -1/-1 until end of turn.\no\nR: Enchanted creature can't block this turn.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "2efc772b-c0a2-5205-9a6a-e81dcccf4f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bf192-4baf-46ba-947b-a22d07635b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bf192-4baf-46ba-947b-a22d07635b04.jpg?1",
             "name": "Orim's Thunder",
             "text": "Kicker o\nR (You may pay an additional o\nR as you play this spell.)\nDestroy target artifact or enchantment. If you paid the kicker cost, Orim's Thunder deals damage equal to that artifact or enchantment's converted mana cost to target creature.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "513b7f07-c48e-5bd1-bd9d-8dce24e9f855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddf4ee0-75d6-48a5-955c-97faf73b899f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddf4ee0-75d6-48a5-955c-97faf73b899f.jpg?1",
             "name": "Shield of Duty and Reason",
             "text": "Enchanted creature has protection from green and from blue.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "dcda054a-ce64-5d45-914c-ce43eaf8b81d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13099abe-721e-42b4-9666-9e6b5f1d75c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13099abe-721e-42b4-9666-9e6b5f1d75c9.jpg?1",
             "name": "Spectral Lynx",
             "text": "Protection from green\no\nB: Regenerate Spectral Lynx.",
             "colours": [
@@ -591,7 +591,7 @@
         },
         {
             "id": "521bd8d3-d5ab-5e65-993b-037cfab6007f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f8e16a-55f0-4147-a01a-dba7938f31c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f8e16a-55f0-4147-a01a-dba7938f31c4.jpg?1",
             "name": "Standard Bearer",
             "text": "If an opponent plays a spell or ability that could target a Flagbearer in play, that player chooses at least one Flagbearer as a target.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "61c04e81-2f9f-5e6c-bf20-6b21b5bc5dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c40c26-3b82-4f72-acb5-85fbdd51665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c40c26-3b82-4f72-acb5-85fbdd51665a.jpg?1",
             "name": "Ceta Disciple",
             "text": "o\nR, oc\nT: Target creature gets +2/+0 until end of turn.\no\nG, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "233784b1-3db1-5ed6-9262-04c55217c7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cec6f3-295a-45e3-8466-e35fb043a596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cec6f3-295a-45e3-8466-e35fb043a596.jpg?1",
             "name": "Ceta Sanctuary",
             "text": "At the beginning of your upkeep, if you control a red or green permanent, draw a card, then discard a card from your hand. If you control a red permanent and a green permanent, instead draw two cards, then discard a card from your hand.",
             "colours": [
@@ -695,7 +695,7 @@
         },
         {
             "id": "260b9135-d37b-58a7-baa5-025bb6572f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69063cc2-4f6e-4cce-bb09-ccd57b69b993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69063cc2-4f6e-4cce-bb09-ccd57b69b993.jpg?1",
             "name": "Cetavolver",
             "text": "Kicker o1o\nR and/or o\nG\nIf you paid the o1o\nR kicker cost, Cetavolver comes into play with two +1/+1 counters on it and has first strike.\nIf you paid the o\nG kicker cost, Cetavolver comes into play with a +1/+1 counter on it and has trample.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "ecc640cc-b043-5b59-a631-2b6b44a0a5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87aaa74-26c6-4057-84b9-a007383684a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87aaa74-26c6-4057-84b9-a007383684a5.jpg?1",
             "name": "Coastal Drake",
             "text": "Flying\no1o\nU, oc\nT: Return target Kavu to its owner's hand.",
             "colours": [
@@ -765,7 +765,7 @@
         },
         {
             "id": "7a0ed27c-e704-5308-8bc6-75f53bfbf60f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b4f29-ada4-41d2-8292-b5af537c6fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b4f29-ada4-41d2-8292-b5af537c6fd2.jpg?1",
             "name": "Evasive Action",
             "text": "Counter target spell unless its controller pays o1 for each basic land type among lands you control.",
             "colours": [
@@ -797,7 +797,7 @@
         },
         {
             "id": "4bba59e6-8f80-51f9-84e5-35c04e304cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2877c2-4426-4c07-92a2-8ba5107d5e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2877c2-4426-4c07-92a2-8ba5107d5e7e.jpg?1",
             "name": "Ice Cave",
             "text": "Whenever a player plays a spell, any other player may pay that spell's mana cost. If a player does, counter the spell. (Mana cost includes color.)",
             "colours": [
@@ -829,7 +829,7 @@
         },
         {
             "id": "4a9b9eff-cb90-507c-8d02-222a093f2e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd57-ba92-48ff-9ad4-d40dad2ff418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd57-ba92-48ff-9ad4-d40dad2ff418.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "919eef1a-8343-58ce-9462-e8a4fe36e3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ab1f0-4e75-4165-85bc-6f838c221d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ab1f0-4e75-4165-85bc-6f838c221d6a.jpg?1",
             "name": "Jaded Response",
             "text": "Counter target spell if it shares a color with a creature you control.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "45bddd32-1b38-5eb3-a5ef-514d043592b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a010d2b1-960d-4032-a47a-61fe0998bee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a010d2b1-960d-4032-a47a-61fe0998bee3.jpg?1",
             "name": "Jilt",
             "text": "Kicker o1o\nR (You may pay an additional o1o\nR as you play this spell.)\nReturn target creature to its owner's hand. If you paid the kicker cost, Jilt deals 2 damage to another target creature.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "25d7e557-6a54-5be1-99b6-fe951d3eafce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0441eef-392e-4af4-b189-2f1fb8bf3fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0441eef-392e-4af4-b189-2f1fb8bf3fca.jpg?1",
             "name": "Living Airship",
             "text": "Flying\no2o\nG: Regenerate Living Airship.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "3470dcab-0237-51f8-b58d-e66f071f17fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f56714-0baa-48f9-8da1-50d9279e759c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f56714-0baa-48f9-8da1-50d9279e759c.jpg?1",
             "name": "Reef Shaman",
             "text": "oc\nT: Target land's type becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "4e3e7c1e-7161-537e-bcce-e248ee400b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7263e20e-5473-42e9-90c3-3bcd848644ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7263e20e-5473-42e9-90c3-3bcd848644ca.jpg?1",
             "name": "Shimmering Mirage",
             "text": "Target land's type becomes the basic land type of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "2d88affb-fffd-5b92-b2b6-b0c5cd137de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7cd5d-e81a-4729-b5d3-45587756413a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7cd5d-e81a-4729-b5d3-45587756413a.jpg?1",
             "name": "Tidal Courier",
             "text": "When Tidal Courier comes into play, reveal the top four cards of your library. Put all Merfolk cards revealed this way into your hand and the rest on the bottom of your library.\no3o\nU: Tidal Courier gains flying until end of turn.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "4fc558c2-9712-59d5-b2e1-34aeff7a3453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575e2cb-3990-4c73-b81c-e16311ec6bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575e2cb-3990-4c73-b81c-e16311ec6bbb.jpg?1",
             "name": "Unnatural Selection",
             "text": "o1: Choose a creature type other than Wall. Target creature's type becomes that type until end of turn.",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "378842d7-d4b0-5a56-ae91-17fbd19a801d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ec203a-067e-4360-9b4d-2d67db472aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ec203a-067e-4360-9b4d-2d67db472aab.jpg?1",
             "name": "Vodalian Mystic",
             "text": "oc\nT: Target instant or sorcery spell becomes the color of your choice.",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "ceca5400-1485-5bb4-bdd5-da1d42d5aa76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e866093-89a3-458d-8ebc-de805ef7885e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e866093-89a3-458d-8ebc-de805ef7885e.jpg?1",
             "name": "Whirlpool Drake",
             "text": "Flying\nWhen Whirlpool Drake comes into play, shuffle the cards from your hand into your library, then draw that many cards.\nWhen Whirlpool Drake is put into a graveyard from play, shuffle the cards from your hand into your library, then draw that many cards.",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "1ca74389-9e30-5f63-9108-b5dc3cfe23c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de47f44-8c5e-4114-9064-145d2d8813c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de47f44-8c5e-4114-9064-145d2d8813c6.jpg?1",
             "name": "Whirlpool Rider",
             "text": "When Whirlpool Rider comes into play, shuffle the cards from your hand into your library, then draw that many cards.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "4e54bd45-bc1e-57f6-aa53-00ea6dcd0c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f891ca-4e6a-4710-b1cf-5dabb5e1ad93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f891ca-4e6a-4710-b1cf-5dabb5e1ad93.jpg?1",
             "name": "Whirlpool Warrior",
             "text": "When Whirlpool Warrior comes into play, shuffle the cards from your hand into your library, then draw that many cards.\no\nR, Sacrifice Whirlpool Warrior: Each player shuffles the cards from his or her hand into his or her library, then draws that many cards.",
             "colours": [
@@ -1233,7 +1233,7 @@
         },
         {
             "id": "51884ace-d80d-5392-8bdd-dcc44893444a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78028c-3ebd-432d-b628-e1fa284f08f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78028c-3ebd-432d-b628-e1fa284f08f3.jpg?1",
             "name": "Dead Ringers",
             "text": "Destroy two target nonblack creatures unless either one is a color the other isn't. They can't be regenerated.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "635d60ae-3b6b-5770-b49e-1185da31b8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445127d4-8afb-47cf-b2a1-564540b1fdae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445127d4-8afb-47cf-b2a1-564540b1fdae.jpg?1",
             "name": "Desolation Angel",
             "text": "Kicker o\nWo\nW (You may pay an additional o\nWo\nW as you play this spell.)\nFlying\nWhen Desolation Angel comes into play, destroy all lands you control. If you paid the kicker cost, destroy all lands instead.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "2b825a40-3d20-593a-96a5-48ee813580be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a6fa8-d422-4e56-9e7b-2ff2fc8aecfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a6fa8-d422-4e56-9e7b-2ff2fc8aecfe.jpg?1",
             "name": "Foul Presence",
             "text": "Enchanted creature gets -1/-1 and has \"oc\nT: Target creature gets -1/-1 until end of turn.\"",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "7aa610be-b103-5c50-85d4-f9088c26d51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f76edc-6067-43bd-9582-1d59caf91597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f76edc-6067-43bd-9582-1d59caf91597.jpg?1",
             "name": "Grave Defiler",
             "text": "When Grave Defiler comes into play, reveal the top four cards of your library. Put all Zombie cards revealed this way into your hand and the rest on the bottom of your library.\no1o\nB: Regenerate Grave Defiler.",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "954fd56c-5830-563f-a158-33bf96225b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12317075-92a2-4b3a-a694-3b764132beaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12317075-92a2-4b3a-a694-3b764132beaf.jpg?1",
             "name": "Last Caress",
             "text": "Target player loses 1 life and you gain 1 life.\nDraw a card.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "0ddffc82-4945-584f-8510-c69dd41adaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d77ddcc-e66b-4036-8a55-ec42953918d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d77ddcc-e66b-4036-8a55-ec42953918d1.jpg?1",
             "name": "Mind Extraction",
             "text": "As an additional cost to play Mind Extraction, sacrifice a creature.\nTarget player reveals his or her hand and discards all cards of each of the sacrificed creature's colors from it.",
             "colours": [
@@ -1432,7 +1432,7 @@
         },
         {
             "id": "0dc91e96-a634-547b-b789-429939978527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba12fb1-de8c-46c6-b33f-e0580ed2a3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba12fb1-de8c-46c6-b33f-e0580ed2a3ee.jpg?1",
             "name": "Mournful Zombie",
             "text": "o\nW, oc\nT: Target player gains 1 life.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "f144ded4-0597-5eda-9c60-cd99148cfbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a771f-bd21-4388-857f-08160b24e26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a771f-bd21-4388-857f-08160b24e26e.jpg?1",
             "name": "Necra Disciple",
             "text": "o\nG, oc\nT: Add one mana of any color to your mana pool.\no\nW, oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "244c8fbd-2a3c-545e-b07a-532535e6ed9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0bf165-d7eb-4ae6-b30a-4e9fd55f401d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0bf165-d7eb-4ae6-b30a-4e9fd55f401d.jpg?1",
             "name": "Necra Sanctuary",
             "text": "At the beginning of your upkeep, if you control a green or white permanent, target player loses 1 life. If you control a green permanent and a white permanent, that player loses 3 life instead.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "fe3e9de7-cfd8-5e59-8431-8483b1354fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232c32d9-9b0c-458d-b1b3-e4219bd34c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232c32d9-9b0c-458d-b1b3-e4219bd34c82.jpg?1",
             "name": "Necravolver",
             "text": "Kicker o1o\nG and/or o\nW\nIf you paid the o1o\nG kicker cost, Necravolver comes into play with two +1/+1 counters on it and has trample.\nIf you paid the o\nW kicker cost, Necravolver comes into play with a +1/+1 counter on it and has \"Whenever Necravolver deals damage, you gain that much life.\"",
             "colours": [
@@ -1572,7 +1572,7 @@
         },
         {
             "id": "f63fdeae-9ebc-571b-a6c9-6d9c36fd265b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e19975-e3e1-453b-b902-a1b1fc1d8504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e19975-e3e1-453b-b902-a1b1fc1d8504.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -1604,7 +1604,7 @@
         },
         {
             "id": "47a266f8-7f58-5c28-a722-445c2a828c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c80cdd-4287-4ecb-992b-f265cd422098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c80cdd-4287-4ecb-992b-f265cd422098.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua comes into play, you draw two cards and you lose 2 life.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "953d8f58-f865-5074-b1ca-9b01c575cd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3addf34c-ea54-42a3-bccd-b73453d964d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3addf34c-ea54-42a3-bccd-b73453d964d2.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager comes into play, you draw a card and you lose 1 life.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "6a1358a9-9258-581c-8ea2-a98df9b8c2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a92d454-3f23-45bf-921f-25b0da4ce138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a92d454-3f23-45bf-921f-25b0da4ce138.jpg?1",
             "name": "Planar Despair",
             "text": "All creatures get -1/-1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "a80cde27-06b0-54a4-b5bd-e5d148308f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a75a004-d150-4fc1-a9a9-3b337a63e3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a75a004-d150-4fc1-a9a9-3b337a63e3e5.jpg?1",
             "name": "Quagmire Druid",
             "text": "o\nG, oc\nT, Sacrifice a creature: Destroy target enchantment.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "ec54e6fa-27ba-5e39-8b5b-8b6b75371db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642eefde-8727-44ff-9e04-373abfcd0679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642eefde-8727-44ff-9e04-373abfcd0679.jpg?1",
             "name": "Suppress",
             "text": "Target player removes all cards in his or her hand from the game face down. At the end of that player's next turn, that player returns those cards to his or her hand.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "3b1b0612-e90c-5e66-b542-e2f488350cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961619e3-f48b-4099-8a33-ca1e294085dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961619e3-f48b-4099-8a33-ca1e294085dd.jpg?1",
             "name": "Urborg Uprising",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -1806,7 +1806,7 @@
         },
         {
             "id": "b1b1fcac-d1fd-51ac-8980-5cdbeed31679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb8c277-3154-47c9-835f-327cac297a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb8c277-3154-47c9-835f-327cac297a5e.jpg?1",
             "name": "Zombie Boa",
             "text": "o1o\nB: Choose a color. Whenever Zombie Boa becomes blocked by a creature of that color this turn, destroy that creature. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1841,7 +1841,7 @@
         },
         {
             "id": "44a9e486-0a26-533f-ade9-b326127a0f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518145f3-9919-4ed6-9e2e-772ee349ea57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518145f3-9919-4ed6-9e2e-772ee349ea57.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "o\nR, Sacrifice Bloodfire Colossus: Bloodfire Colossus deals 6 damage to each creature and each player.",
             "colours": [
@@ -1875,7 +1875,7 @@
         },
         {
             "id": "202f0775-a748-5f52-9a19-1f9441bd7630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b5c38e-7d74-4862-8187-f5db4a3d1e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b5c38e-7d74-4862-8187-f5db4a3d1e0f.jpg?1",
             "name": "Bloodfire Dwarf",
             "text": "o\nR, Sacrifice Bloodfire Dwarf: Bloodfire Dwarf deals 1 damage to each creature without flying.",
             "colours": [
@@ -1909,7 +1909,7 @@
         },
         {
             "id": "1b6124b1-cd37-5d63-9636-4f49ecc8d9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2639e9b7-ed8c-48fd-a8b7-b99d8dad4bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2639e9b7-ed8c-48fd-a8b7-b99d8dad4bc0.jpg?1",
             "name": "Bloodfire Infusion",
             "text": "Bloodfire Infusion can enchant only a creature you control.\no\nR, Sacrifice enchanted creature: Bloodfire Infusion deals damage equal to the enchanted creature's power to each creature.",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "b68c0685-d18e-51c5-ad86-523d9d94f1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1442b1f3-8c2c-4553-906f-c864fcdc6ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1442b1f3-8c2c-4553-906f-c864fcdc6ae5.jpg?1",
             "name": "Bloodfire Kavu",
             "text": "o\nR, Sacrifice Bloodfire Kavu: Bloodfire Kavu deals 2 damage to each creature.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "3ae995bf-9a22-56df-b7bf-f14e48a15761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7291da-1d14-4763-8691-c67136ab67c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7291da-1d14-4763-8691-c67136ab67c7.jpg?1",
             "name": "Desolation Giant",
             "text": "Kicker o\nWo\nW (You may pay an additional o\nWo\nW as you play this spell.)\nWhen Desolation Giant comes into play, destroy all other creatures you control. If you paid the kicker cost, destroy all other creatures instead.",
             "colours": [
@@ -2012,7 +2012,7 @@
         },
         {
             "id": "664f77f4-1678-5c9e-8b22-e6e002682702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab243e-d08d-4ece-9725-4bb5f67b1c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab243e-d08d-4ece-9725-4bb5f67b1c92.jpg?1",
             "name": "Dwarven Landslide",
             "text": "Kicker\u2014o2o\nR, Sacrifice a land. (You may pay o2o\nR and sacrifice a land in addition to any other costs as you play this spell.)\nDestroy target land. If you paid the kicker cost, destroy another target land.",
             "colours": [
@@ -2044,7 +2044,7 @@
         },
         {
             "id": "cb9d86b5-34ff-5f0b-9b23-48e4783c7127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c08df5-f5e7-4498-ac80-25ccbe304b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c08df5-f5e7-4498-ac80-25ccbe304b26.jpg?1",
             "name": "Dwarven Patrol",
             "text": "Dwarven Patrol doesn't untap during your untap step.\nWhenever you play a nonred spell, untap Dwarven Patrol.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "6862c1c4-ef6a-57f1-979c-37baad31b281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b2cd77-9552-48b1-80cb-26966323c1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b2cd77-9552-48b1-80cb-26966323c1ea.jpg?1",
             "name": "Goblin Ringleader",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhen Goblin Ringleader comes into play, reveal the top four cards of your library. Put all Goblin cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "659bd22b-2199-5b1f-8b9c-b85fb6a0f9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceef2761-7301-42de-8f54-49b8cd1e457b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceef2761-7301-42de-8f54-49b8cd1e457b.jpg?1",
             "name": "Illuminate",
             "text": "Kicker o2o\nR and/or o3o\nU (You may pay an additional o2o\nR and/or o3o\nU as you play this spell.)\nIlluminate deals X damage to target creature. If you paid the o2o\nR kicker cost, Illuminate deals X damage to that creature's controller. If you paid the o3o\nU kicker cost, you draw X cards.",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "a273da3a-558f-5c31-b2a1-45887f86ab95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aa5a8-2769-4a8a-b457-001abc862b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aa5a8-2769-4a8a-b457-001abc862b35.jpg?1",
             "name": "Kavu Glider",
             "text": "o\nW: Kavu Glider gets +0/+1 until end of turn.\no\nU: Kavu Glider gains flying until end of turn.",
             "colours": [
@@ -2181,7 +2181,7 @@
         },
         {
             "id": "0c18b569-5fd3-5ddb-814f-1725aa222a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097decb6-03bd-4a84-ab9a-75becf85cae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097decb6-03bd-4a84-ab9a-75becf85cae8.jpg?1",
             "name": "Minotaur Tactician",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nMinotaur Tactician gets +1/+1 as long as you control a white creature.\nMinotaur Tactician gets +1/+1 as long as you control a blue creature.",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "319b6a71-0daa-52ea-91e6-b00c2b15eb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41462d43-4f9f-46ba-b79d-434597e74b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41462d43-4f9f-46ba-b79d-434597e74b6b.jpg?1",
             "name": "Raka Disciple",
             "text": "o\nW, oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\no\nU, oc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "a01114b6-aa26-568d-9413-d78a0743c79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cab0be-589c-42a0-a297-1faaec46c73f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cab0be-589c-42a0-a297-1faaec46c73f.jpg?1",
             "name": "Raka Sanctuary",
             "text": "At the beginning of your upkeep, if you control a white or blue permanent, Raka Sanctuary deals 1 damage to target creature. If you control a white permanent and a blue permanent, Raka Sanctuary deals 3 damage to that creature instead.",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "c3aff943-ee8c-5178-9f31-4568afc00392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787e24-0b7d-4005-8db4-68544476bd34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787e24-0b7d-4005-8db4-68544476bd34.jpg?1",
             "name": "Rakavolver",
             "text": "Kicker o1o\nW and/or o\nU\nIf you paid the o1o\nW kicker cost, Rakavolver comes into play with two +1/+1 counters on it and has \"Whenever Rakavolver deals damage, you gain that much life.\"\nIf you paid the o\nU kicker cost, Rakavolver comes into play with a +1/+1 counter on it and has flying.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "ee2bf9cb-8171-506d-b2f2-202489a0e20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c869c-74c2-42b6-bb23-a2f481c4b673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c869c-74c2-42b6-bb23-a2f481c4b673.jpg?1",
             "name": "Smash",
             "text": "Destroy target artifact.\nDraw a card.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "f64e0857-e4a0-542e-8b91-a08be2ca4dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442a4331-99ce-405e-b261-19b7f3375ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442a4331-99ce-405e-b261-19b7f3375ddf.jpg?1",
             "name": "Tahngarth's Glare",
             "text": "Look at the top three cards of target opponent's library, then put them back in any order. That player looks at the top three cards of your library, then puts them back in any order.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "9035ffec-861f-5861-b253-bc6dfd889011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc34e735-ac3c-4954-a4c8-3ed55d811715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc34e735-ac3c-4954-a4c8-3ed55d811715.jpg?1",
             "name": "Tundra Kavu",
             "text": "oc\nT: Target land becomes a plains or an island until end of turn.",
             "colours": [
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "8654f834-9e11-5028-b261-a75c0ac6d970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f00e6f1-e854-40b0-855d-7e0d7d233850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f00e6f1-e854-40b0-855d-7e0d7d233850.jpg?1",
             "name": "Wild Research",
             "text": "o1o\nW: Search your library for an enchantment card and reveal that card. Put it into your hand, then discard a card at random from your hand. Then shuffle your library.\no1o\nU: Search your library for an instant card and reveal that card. Put it into your hand, then discard a card at random from your hand. Then shuffle your library.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "267481bc-1240-5af2-9cb0-0cba903cbfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efe00f9-bf42-4d6f-9a22-b357b1c1e092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efe00f9-bf42-4d6f-9a22-b357b1c1e092.jpg?1",
             "name": "Ana Disciple",
             "text": "o\nU, oc\nT: Target creature gains flying until end of turn.\no\nB, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "0ab00963-09a9-5176-a194-c92fd4abeb6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1599bb-4f43-4ab3-985a-8be5219f2195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1599bb-4f43-4ab3-985a-8be5219f2195.jpg?1",
             "name": "Ana Sanctuary",
             "text": "At the beginning of your upkeep, if you control a blue or black permanent, target creature gets +1/+1 until end of turn. If you control a blue permanent and a black permanent, that creature gets +5/+5 until end of turn instead.",
             "colours": [
@@ -2521,7 +2521,7 @@
         },
         {
             "id": "81001cb3-2910-570f-a4bf-2581f54de86e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e685a8c-fba6-495f-ac0f-1ff5456b22d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e685a8c-fba6-495f-ac0f-1ff5456b22d0.jpg?1",
             "name": "Anavolver",
             "text": "Kicker o1o\nU and/or o\nB\nIf you paid the o1o\nU kicker cost, Anavolver comes into play with two +1/+1 counters on it and has flying.\nIf you paid the o\nB kicker cost, Anavolver comes into play with a +1/+1 counter on it and has \"Pay 3 life: Regenerate Anavolver.\"",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "3cfc10c0-781b-5560-8715-83339ede5311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f230831-023c-41aa-832e-16ac81e68588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f230831-023c-41aa-832e-16ac81e68588.jpg?1",
             "name": "Bog Gnarr",
             "text": "Whenever a player plays a black spell, Bog Gnarr gets +2/+2 until end of turn.",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "a79b69f6-b752-51a2-90f1-08e9631935f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ffc5f8-ff1c-4733-b046-8679fa16371b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ffc5f8-ff1c-4733-b046-8679fa16371b.jpg?1",
             "name": "Gaea's Balance",
             "text": "As an additional cost to play Gaea's Balance, sacrifice five lands.\nSearch your library for a land card of each basic land type and put them into play. Then shuffle your library.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "05fe4d46-3938-57e6-9de1-e225fcaaa22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38eeae-918b-4d19-b37a-175ac5db37a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38eeae-918b-4d19-b37a-175ac5db37a4.jpg?1",
             "name": "Glade Gnarr",
             "text": "Whenever a player plays a blue spell, Glade Gnarr gets +2/+2 until end of turn.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "53b014d6-74dc-5bc6-8135-5ba58dc7304c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf502f-445d-4724-b7d0-8fdd5bf557a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf502f-445d-4724-b7d0-8fdd5bf557a8.jpg?1",
             "name": "Kavu Howler",
             "text": "When Kavu Howler comes into play, reveal the top four cards of your library. Put all Kavu cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "98adfd5a-d320-5e60-b4a4-a49c2af1b682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79adc3af-5fa3-4cb6-9bbc-52ede0c69263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79adc3af-5fa3-4cb6-9bbc-52ede0c69263.jpg?1",
             "name": "Kavu Mauler",
             "text": "Trample\nWhenever Kavu Mauler attacks, it gets +1/+1 until end of turn for each other attacking Kavu.",
             "colours": [
@@ -2725,7 +2725,7 @@
         },
         {
             "id": "20761409-7b67-50e9-b89a-d16eded91e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b10608-8917-4337-ad60-ab31ab8c0fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b10608-8917-4337-ad60-ab31ab8c0fc4.jpg?1",
             "name": "Lay of the Land",
             "text": "Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "c249a421-7c8a-5083-a98f-1bd691c5c51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21049fee-a748-4856-99ae-3a225a168532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21049fee-a748-4856-99ae-3a225a168532.jpg?1",
             "name": "Penumbra Bobcat",
             "text": "When Penumbra Bobcat is put into a graveyard from play, put a 2/1 black Cat creature token into play.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "f6f425bc-a5d8-56f1-8286-887d13bd2838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee334211-4109-46ff-8676-856048221a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee334211-4109-46ff-8676-856048221a1c.jpg?1",
             "name": "Penumbra Kavu",
             "text": "When Penumbra Kavu is put into a graveyard from play, put a 3/3 black Kavu creature token into play.",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "7bd760e0-5297-5c22-8309-e07bff62030f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3dffe7-ecaf-4cf0-a43e-8e2746282992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3dffe7-ecaf-4cf0-a43e-8e2746282992.jpg?1",
             "name": "Penumbra Wurm",
             "text": "Trample\nWhen Penumbra Wurm is put into a graveyard from play, put a 6/6 black Wurm creature token with trample into play.",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "68d9deb6-ea2b-5793-aebd-22003fa1ae5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ad3f87-9f25-455f-9933-3b0b0eaad467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ad3f87-9f25-455f-9933-3b0b0eaad467.jpg?1",
             "name": "Savage Gorilla",
             "text": "o\nUo\nB, oc\nT, Sacrifice Savage Gorilla: Target creature gets -3/-3 until end of turn. Draw a card.",
             "colours": [
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "aa8a7eac-a6be-554b-8e43-26ed6ada3561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87aab031-4e44-44cd-89a7-6cffc7288cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87aab031-4e44-44cd-89a7-6cffc7288cd1.jpg?1",
             "name": "Strength of Night",
             "text": "Kicker o\nB (You may pay an additional o\nB as you play this spell.)\nCreatures you control get +1/+1 until end of turn. If you paid the kicker cost, Zombies you control get an additional +2/+2 until end of turn.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "b0108a70-7e3c-5526-bc86-8cb592d739da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg?1",
             "name": "Sylvan Messenger",
             "text": "Trample\nWhen Sylvan Messenger comes into play, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "91350bec-12f0-5648-8e6f-4907f542cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e2b7e9-d52b-478e-b118-e890a81fd471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e2b7e9-d52b-478e-b118-e890a81fd471.jpg?1",
             "name": "Symbiotic Deployment",
             "text": "Skip your draw step.\no1, Tap two untapped creatures you control: Draw a card.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "dafc274c-c5d1-5502-9873-31fc2287e7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8c059-3309-49a5-ae97-c048aefc922f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8c059-3309-49a5-ae97-c048aefc922f.jpg?1",
             "name": "Tranquil Path",
             "text": "Destroy all enchantments.\nDraw a card.",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "79dee1b4-7ba5-5ef1-b37a-98ebdb7a6716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8521bf-d026-4d26-831e-a2f253307c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8521bf-d026-4d26-831e-a2f253307c93.jpg?1",
             "name": "Urborg Elf",
             "text": "oc\nT: Add o\nG, o\nU, or o\nB to your mana pool.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "109075ca-ff7d-5151-a44e-9412b58947e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9507116-ede8-40a1-8fa3-705e6f6f64c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9507116-ede8-40a1-8fa3-705e6f6f64c0.jpg?1",
             "name": "Aether Mutation",
             "text": "Return target creature to its owner's hand. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "d04846b3-96f1-582c-a481-ebdc68c2acfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb50813c-72df-49e7-bac5-e6e247649241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb50813c-72df-49e7-bac5-e6e247649241.jpg?1",
             "name": "Captain's Maneuver",
             "text": "The next X damage that would be dealt to target creature or player this turn is dealt to another target creature or player instead.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "c39353a0-4a03-5918-adf5-40bec83a0571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f005fc90-7e81-4bd4-a479-438337110979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f005fc90-7e81-4bd4-a479-438337110979.jpg?1",
             "name": "Consume Strength",
             "text": "Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "1a55f93a-033a-50e7-8b8c-ac66cf4ccdb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9e0a23-d2a8-40a6-9076-ed6fb539141b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9e0a23-d2a8-40a6-9076-ed6fb539141b.jpg?1",
             "name": "Cromat",
             "text": "o\nWo\nB: Destroy target creature blocking or blocked by Cromat.\no\nUo\nR: Cromat gains flying until end of turn.\no\nBo\nG: Regenerate Cromat.\no\nRo\nW: Cromat gets +1/+1 until end of turn.\no\nGo\nU: Put Cromat on top of its owner's library.",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "a4695791-baa3-5979-9cc5-b774b6689122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893dd4-8c37-496e-bc39-cd83d42b4cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893dd4-8c37-496e-bc39-cd83d42b4cc4.jpg?1",
             "name": "Death Grasp",
             "text": "Death Grasp deals X damage to target creature or player. You gain X life.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "7f79047c-86f4-5c13-a193-32cbf2eeadfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c643d87-50bc-4380-b1d6-0a465eef5dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c643d87-50bc-4380-b1d6-0a465eef5dbf.jpg?1",
             "name": "Death Mutation",
             "text": "Destroy target nonblack creature. It can't be regenerated. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -3277,7 +3277,7 @@
         },
         {
             "id": "459f99fd-5c6b-52f7-8a61-afbc007d93d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85dadb-351f-4975-a2c3-febf5e80bc85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85dadb-351f-4975-a2c3-febf5e80bc85.jpg?1",
             "name": "Ebony Treefolk",
             "text": "o\nBo\nG: Ebony Treefolk gets +1/+1 until end of turn.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "a8cdf5a6-83ac-5df6-9ee8-7aff8eb35bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d610a9d5-c650-45ad-a9b0-b55113701e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d610a9d5-c650-45ad-a9b0-b55113701e05.jpg?1",
             "name": "Fervent Charge",
             "text": "Whenever a creature you control attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "ffad7fea-19b9-5143-bba5-7db1c074fb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57abdab-d99c-418c-818d-b06a8722d733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57abdab-d99c-418c-818d-b06a8722d733.jpg?1",
             "name": "Flowstone Charger",
             "text": "Whenever Flowstone Charger attacks, it gets +3/-3 until end of turn.",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "b52296f8-55d9-5703-96f2-3e64fbb4c952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b65f96b-019b-40a9-9b4d-acd4abf4a0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b65f96b-019b-40a9-9b4d-acd4abf4a0f9.jpg?1",
             "name": "Fungal Shambler",
             "text": "Trample\nWhenever Fungal Shambler deals damage to an opponent, you draw a card and that opponent discards a card from his or her hand.",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "eaa17629-3042-51e3-93b9-8d1492b6e62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a564432-c2b3-4cf6-b4bc-2e2600b92911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a564432-c2b3-4cf6-b4bc-2e2600b92911.jpg?1",
             "name": "Gaea's Skyfolk",
             "text": "Flying",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "05078a00-a5b3-555c-9738-650747befd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583740c0-68cf-4205-b682-2f97c0880d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583740c0-68cf-4205-b682-2f97c0880d42.jpg?1",
             "name": "Gerrard's Verdict",
             "text": "Target player discards two cards from his or her hand. You gain 3 life for each land card discarded this way.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "855a67eb-5387-54b4-af62-3f4c0f96bf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c684407e-277a-4e32-a978-cdac9548acce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c684407e-277a-4e32-a978-cdac9548acce.jpg?1",
             "name": "Goblin Legionnaire",
             "text": "o\nR, Sacrifice Goblin Legionnaire: Goblin Legionnaire deals 2 damage to target creature or player.\no\nW, Sacrifice Goblin Legionnaire: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "270cd359-5064-5017-ac0e-c31242000fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100844c-6a41-40f5-b7f8-9b426d5a6945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100844c-6a41-40f5-b7f8-9b426d5a6945.jpg?1",
             "name": "Goblin Trenches",
             "text": "o2, Sacrifice a land: Put two 1/1 red and white Goblin Soldier creature tokens into play.",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "f2bdcc24-d758-546f-8ff5-c38d57425a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e8e58-aee1-4882-943a-17a6af2f8410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e8e58-aee1-4882-943a-17a6af2f8410.jpg?1",
             "name": "Guided Passage",
             "text": "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle your library.",
             "colours": [
@@ -3602,7 +3602,7 @@
         },
         {
             "id": "e75e287f-e978-5cab-af70-7ca290e22568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb114a4-44e5-4375-92b8-00a0b0acbe94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb114a4-44e5-4375-92b8-00a0b0acbe94.jpg?1",
             "name": "Jungle Barrier",
             "text": "(Walls can't attack.)\nWhen Jungle Barrier comes into play, draw a card.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "1dd7d663-8f2a-5a4b-b387-f2a629bc33a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc3d054-6266-4ce0-89ed-f8b170794f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc3d054-6266-4ce0-89ed-f8b170794f2e.jpg?1",
             "name": "Last Stand",
             "text": "Target opponent loses 2 life for each swamp you control. Last Stand deals damage equal to the number of mountains you control to target creature. Put a 1/1 green Saproling creature token into play for each forest you control. You gain 2 life for each plains you control. Draw a card for each island you control, then discard that many cards from your hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "d8f562d8-1f92-5b2d-b556-b38e6c75f43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518d0c5-58ee-4089-bf19-5030d4319681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518d0c5-58ee-4089-bf19-5030d4319681.jpg?1",
             "name": "Lightning Angel",
             "text": "Flying; haste (This creature may attack and oc\nT the turn it comes under your control.)\nAttacking doesn't cause Lightning Angel to tap.",
             "colours": [
@@ -3717,7 +3717,7 @@
         },
         {
             "id": "b20e3cb2-d4d2-5be6-bc32-f59ad717e8f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271969e-1529-42d1-878b-011f80ab0f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271969e-1529-42d1-878b-011f80ab0f05.jpg?1",
             "name": "Llanowar Dead",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "03fa0618-f64f-5929-8109-5572b485608e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906a775-7c2d-47b7-a20e-a325dd28d0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906a775-7c2d-47b7-a20e-a325dd28d0bd.jpg?1",
             "name": "Martyrs' Tomb",
             "text": "Pay 2 life: Prevent the next 1 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "753ab4f3-dffc-5cb5-8e1f-59e3467c236d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a49d29-6d01-4b1d-80c8-9e5378a76878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a49d29-6d01-4b1d-80c8-9e5378a76878.jpg?1",
             "name": "Minotaur Illusionist",
             "text": "o1o\nU: Minotaur Illusionist can't be the target of spells or abilities this turn.\no\nR, Sacrifice Minotaur Illusionist: Minotaur Illusionist deals damage equal to its power to target creature.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "9dc6586f-4586-515f-aac4-44f123f7ae99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098a28c-5f9b-4a2c-b109-c342365eb948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098a28c-5f9b-4a2c-b109-c342365eb948.jpg?1",
             "name": "Mystic Snake",
             "text": "You may play Mystic Snake any time you could play an instant.\nWhen Mystic Snake comes into play, counter target spell.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "db74f0af-d839-5a3c-8437-b4cd1fa451a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c48c58-3532-4022-9eec-1a870385cbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c48c58-3532-4022-9eec-1a870385cbf3.jpg?1",
             "name": "Overgrown Estate",
             "text": "Sacrifice a land: You gain 3 life.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "c33a5b05-e38d-5482-8a94-290735648a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cbb33-4947-49f0-b612-a92141fbfaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cbb33-4947-49f0-b612-a92141fbfaa6.jpg?1",
             "name": "Pernicious Deed",
             "text": "o\nX, Sacrifice Pernicious Deed: Destroy each artifact, creature, and enchantment with converted mana cost X or less.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "feb8889f-5478-5724-9970-ca58c72dec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17807b9-8feb-48ac-813a-829577f5b9e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17807b9-8feb-48ac-813a-829577f5b9e8.jpg?1",
             "name": "Powerstone Minefield",
             "text": "Whenever a creature attacks or blocks, Powerstone Minefield deals 2 damage to it.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "35600a9f-d7b3-5c9c-b3bc-1e8e33a87bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f74291-c452-4a60-bf5f-73efad6583d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f74291-c452-4a60-bf5f-73efad6583d4.jpg?1",
             "name": "Prophetic Bolt",
             "text": "Prophetic Bolt deals 4 damage to target creature or player. Look at the top four cards of your library. Put one of those cards into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "4f47321c-8730-5870-b3d9-b6a67c15c161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fce298-3338-4f41-8156-ab6322951a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fce298-3338-4f41-8156-ab6322951a76.jpg?1",
             "name": "Putrid Warrior",
             "text": "Whenever Putrid Warrior deals damage, choose one each player loses 1 life; or each player gains 1 life.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "6f86c7b0-fc44-5f49-a9d5-e130c582e21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74012-6060-4fad-aa73-6e6afd33c482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74012-6060-4fad-aa73-6e6afd33c482.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchanted creature has \"oc\nT: This creature deals 1 damage to target player. You draw a card.\"",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "cf2363a3-b01f-5a7e-af17-776559b67283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99829552-917a-4373-9772-4255dff542d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99829552-917a-4373-9772-4255dff542d6.jpg?1",
             "name": "Razorfin Hunter",
             "text": "oc\nT: Razorfin Hunter deals 1 damage to target creature or player.",
             "colours": [
@@ -4110,7 +4110,7 @@
         },
         {
             "id": "4bb74cb6-eefb-55ab-9dd3-2a40fe9c9d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425e0ca4-8592-4802-b7c4-6e3323edd78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425e0ca4-8592-4802-b7c4-6e3323edd78c.jpg?1",
             "name": "Soul Link",
             "text": "Whenever enchanted creature deals or is dealt damage, you gain that much life.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "b8d2adc8-f064-5585-8c91-f9e02c6e8ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6e67-f690-4f19-bb25-a7c2d2aaf42f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6e67-f690-4f19-bb25-a7c2d2aaf42f.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\no\nB: Regenerate Spiritmonger.\no\nG: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "c928f9c1-7f97-58f8-a42c-2b3dc7f891ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682a705-9341-4d1e-a9c5-d428e50b9a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682a705-9341-4d1e-a9c5-d428e50b9a03.jpg?1",
             "name": "Squee's Embrace",
             "text": "Enchanted creature gets +2/+2.\nWhen enchanted creature is put into a graveyard, return that creature card to its owner's hand.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "a2613de0-790f-5feb-a500-fd9e2ad6dc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b391ee3-c1cd-47bc-9540-977cbc32913e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b391ee3-c1cd-47bc-9540-977cbc32913e.jpg?1",
             "name": "Squee's Revenge",
             "text": "Choose a number. Flip a coin that many times or until you lose a flip, whichever comes first. If you win all the flips, draw two cards for each flip.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "1d0c1abf-b90f-561a-9fd8-a6d1a64717bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a70297-2a7b-4a0c-ace5-cd61bfe6dafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a70297-2a7b-4a0c-ace5-cd61bfe6dafd.jpg?1",
             "name": "Suffocating Blast",
             "text": "Counter target spell and Suffocating Blast deals 3 damage to target creature.",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "8a8003ae-8001-561c-9273-02af92c33779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b584dfd1-a56c-406e-8504-47ea136dc102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b584dfd1-a56c-406e-8504-47ea136dc102.jpg?1",
             "name": "Temporal Spring",
             "text": "Put target permanent on top of its owner's library.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "a1cdbff7-0dec-5ffe-8131-63ac68359871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1bfefd-dae8-49e9-9d56-cc852e3dc93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1bfefd-dae8-49e9-9d56-cc852e3dc93b.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -4354,7 +4354,7 @@
         },
         {
             "id": "262a6c4c-b778-58f5-afdf-0a05457d39f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b41ff1-240a-447b-bb47-1b9be53ab3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b41ff1-240a-447b-bb47-1b9be53ab3e6.jpg?1",
             "name": "Yavimaya's Embrace",
             "text": "You control enchanted creature.\nEnchanted creature gets +2/+2 and has trample.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "0ad9df53-068e-5bbd-9a83-d0dc4168ce6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "d6bfcef0-7cb3-5651-b110-0e6ff432a887",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "e1daff6e-043f-5374-b908-a70cf713e3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg?1",
             "name": "Illusion // Reality",
             "text": "Destroy target artifact.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "88381ee9-f96c-5a37-abcd-16bf7d34e3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg?1",
             "name": "Illusion // Reality",
             "text": "Destroy target artifact.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "875e0cd8-096a-5a4a-a09d-504f8f587a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg?1",
             "name": "Life // Death",
             "text": "Return target creature card from your graveyard to play. You lose life equal to its converted mana cost.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "7ee304fd-fec1-587c-93e2-cbf32930d585",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg?1",
             "name": "Life // Death",
             "text": "Return target creature card from your graveyard to play. You lose life equal to its converted mana cost.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "0a18d581-5298-5a3a-9608-236e52a15ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg?1",
             "name": "Night // Day",
             "text": "Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "b316580d-53d1-5225-b8d6-641753983ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg?1",
             "name": "Night // Day",
             "text": "Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "b09c1874-9f3e-5afe-bcd6-a4c70f42fae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg?1",
             "name": "Order // Chaos",
             "text": "Remove target attacking creature from the game.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "dad3e574-dee5-5161-9d6e-cac54f13f597",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg?1",
             "name": "Order // Chaos",
             "text": "Remove target attacking creature from the game.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "759a2e06-256d-5574-9468-f8778b9d7f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd60a7-2ba4-4fce-bf74-2ea9b8fd4dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd60a7-2ba4-4fce-bf74-2ea9b8fd4dbe.jpg?1",
             "name": "Brass Herald",
             "text": "As Brass Herald comes into play, choose a creature type.\nWhen Brass Herald comes into play, reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library.\nCreatures of the chosen type get +1/+1.",
             "colours": [],
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "73f898f4-1210-54aa-b024-755106239774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded8b992-a1c2-4e43-ad0a-ea3995a3c8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded8b992-a1c2-4e43-ad0a-ea3995a3c8b8.jpg?1",
             "name": "Dodecapod",
             "text": "If a spell or ability an opponent controls causes you to discard Dodecapod from your hand, put it into play with two +1/+1 counters on it instead of putting it into your graveyard.",
             "colours": [],
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "a99629b9-dc40-5037-8abb-5b6071511eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec581b8-e509-420c-b142-afaa6dd06cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec581b8-e509-420c-b142-afaa6dd06cc8.jpg?1",
             "name": "Dragon Arch",
             "text": "o2, oc\nT: Put a multicolored creature card from your hand into play.",
             "colours": [],
@@ -4810,7 +4810,7 @@
         },
         {
             "id": "8ff06e32-6f85-5614-8c91-b56fcecea8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527fc6-4f4c-4ded-9e72-49186b7e5bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527fc6-4f4c-4ded-9e72-49186b7e5bd3.jpg?1",
             "name": "Emblazoned Golem",
             "text": "Kicker o\nX (You may pay an additional o\nX as you play this spell.)\nSpend only colored mana on X. No more than one mana of each color may be spent this way.\nIf you paid the kicker cost, Emblazoned Golem comes into play with X +1/+1 counters on it.",
             "colours": [],
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "74bfe9ec-9aca-552e-b8e9-10a763d518c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385d8691-b9bd-4b4d-86db-7a7cc6181104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385d8691-b9bd-4b4d-86db-7a7cc6181104.jpg?1",
             "name": "Legacy Weapon",
             "text": "o\nWo\nUo\nBo\nRo\nG: Remove target permanent from the game.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "de3e1298-8494-54ca-9bf2-a33d85755ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f623ae51-5f15-4153-b2ed-d03b57b7db54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f623ae51-5f15-4153-b2ed-d03b57b7db54.jpg?1",
             "name": "Mask of Intolerance",
             "text": "At the beginning of each player's upkeep, if there are four or more basic land types among lands that player controls, Mask of Intolerance deals 3 damage to him or her.",
             "colours": [],
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "bacd573c-9949-5bcd-8471-4d0a0228574d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c25e71-0140-48fe-8b9e-33b4b50c5c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c25e71-0140-48fe-8b9e-33b4b50c5c12.jpg?1",
             "name": "Battlefield Forge",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nW to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -4936,7 +4936,7 @@
         },
         {
             "id": "a77e52c8-f5db-532d-9b02-e21111c029d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144dd08e-451e-4438-b572-7a138e1a15f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144dd08e-451e-4438-b572-7a138e1a15f3.jpg?1",
             "name": "Caves of Koilos",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nB to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -4967,7 +4967,7 @@
         },
         {
             "id": "c48818a8-e169-50e3-84c4-9983b2f61e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610b7cd5-5532-45a9-acfe-24a818034d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610b7cd5-5532-45a9-acfe-24a818034d1c.jpg?1",
             "name": "Llanowar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nG to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "ee471a9f-4835-5d09-aaca-57d6663957b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3403143-2b4e-4408-b138-c856bbc1e9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3403143-2b4e-4408-b138-c856bbc1e9a5.jpg?1",
             "name": "Shivan Reef",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nR to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -5029,7 +5029,7 @@
         },
         {
             "id": "2eb56c36-3797-5001-95e9-33227a67ff74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ee102-d981-4fc3-9f09-9dd07755f22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ee102-d981-4fc3-9f09-9dd07755f22c.jpg?1",
             "name": "Yavimaya Coast",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nU to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],

--- a/Assets/Resources/Sets/ARB.json
+++ b/Assets/Resources/Sets/ARB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e1001f62-0c7f-544e-8905-738feb82bf88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d521737-ee07-4387-bc07-5ced53db374d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d521737-ee07-4387-bc07-5ced53db374d.jpg?1",
             "name": "Ardent Plea",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "e61536eb-5acb-54cd-90d9-476f86d9a50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49876185-e23d-4137-8612-1347da3a1df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49876185-e23d-4137-8612-1347da3a1df6.jpg?1",
             "name": "Aven Mimeomancer",
             "text": "Flying\nAt the beginning of your upkeep, you may put a feather counter on target creature. If you do, that creature is 3/1 and has flying as long as it has a feather counter on it.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "68787d65-0187-56fe-80a6-b3f82ea1d19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094a235d-a5b8-434e-b4b0-c982da45a54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094a235d-a5b8-434e-b4b0-c982da45a54d.jpg?1",
             "name": "Ethercaste Knight",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "aae5b8a2-d311-5212-8589-be08548728fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5340e18-faed-4787-a42c-c12935bb0646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5340e18-faed-4787-a42c-c12935bb0646.jpg?1",
             "name": "Ethersworn Shieldmage",
             "text": "Flash\nWhen Ethersworn Shieldmage comes into play, prevent all damage that would be dealt to artifact creatures this turn.",
             "colours": [
@@ -151,7 +151,7 @@
         },
         {
             "id": "22d7eec3-b2a2-537b-8865-f4e050b7b496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9650a717-b1e4-4cd2-894d-766f6b311369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9650a717-b1e4-4cd2-894d-766f6b311369.jpg?1",
             "name": "Fieldmist Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Fieldmist Borderpost's mana cost.\nFieldmist Borderpost comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "0a07a3e8-f503-5d94-8aea-0e934cc5bae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c7a2a-85c1-4b20-95b9-04aab0bd0d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c7a2a-85c1-4b20-95b9-04aab0bd0d3b.jpg?1",
             "name": "Filigree Angel",
             "text": "Flying\nWhen Filigree Angel comes into play, you gain 3 life for each artifact you control.",
             "colours": [
@@ -222,7 +222,7 @@
         },
         {
             "id": "99c42685-c894-57fe-bffb-4913ed88634e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397e6ff5-f5ee-4963-9942-4aa25f5eb64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397e6ff5-f5ee-4963-9942-4aa25f5eb64a.jpg?1",
             "name": "Glassdust Hulk",
             "text": "Whenever another artifact comes into play under your control, Glassdust Hulk gets +1/+1 until end of turn and is unblockable this turn.\nCycling {WU} ({WU}, Discard this card: Draw a card.)",
             "colours": [
@@ -259,7 +259,7 @@
         },
         {
             "id": "3c7cf112-ba65-595e-a43e-b5e1cb1cddf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55308b-5772-430a-93e4-b65c416b86cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55308b-5772-430a-93e4-b65c416b86cf.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage comes into play, name a nonland card.\nThe named card can't be played.",
             "colours": [
@@ -296,7 +296,7 @@
         },
         {
             "id": "937ea00a-f4ab-5bd6-8bda-750fc653ff1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260fe443-ca03-42b1-bcee-86e5173c1aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260fe443-ca03-42b1-bcee-86e5173c1aaf.jpg?1",
             "name": "Offering to Asha",
             "text": "Counter target spell unless its controller pays {4}. You gain 4 life.",
             "colours": [
@@ -330,7 +330,7 @@
         },
         {
             "id": "d780941a-b8f3-5540-aa62-f57d2bf9d9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73887514-7644-4b2b-8c67-4b7e64150478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73887514-7644-4b2b-8c67-4b7e64150478.jpg?1",
             "name": "Sanctum Plowbeast",
             "text": "Defender\nPlainscycling {2}, islandcycling {2} ({2}, Discard this card: Search your library for a Plains or Island card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -367,7 +367,7 @@
         },
         {
             "id": "82c1c8e6-6264-553f-8a3d-f6b2deaa504c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6474b6-1e1a-4c29-8f01-1cabf729b34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6474b6-1e1a-4c29-8f01-1cabf729b34f.jpg?1",
             "name": "Shield of the Righteous",
             "text": "Equipped creature gets +0/+2 and has vigilance.\nWhenever equipped creature blocks a creature, that creature doesn't untap during its controller's next untap step.\nEquip {2}",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "6e1cdea9-8c02-5987-974c-9ed00cade0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a9e7e-649f-457b-aba7-9c74c2704adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a9e7e-649f-457b-aba7-9c74c2704adf.jpg?1",
             "name": "Sovereigns of Lost Alara",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may search your library for an Aura card that could enchant that creature, put it into play attached to that creature, then shuffle your library.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "f916a802-d4ff-532c-b2e6-579d7684611f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15931d65-9b4e-4506-8f1d-714d06f9c2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15931d65-9b4e-4506-8f1d-714d06f9c2f3.jpg?1",
             "name": "Stormcaller's Boon",
             "text": "Sacrifice Stormcaller's Boon: Creatures you control gain flying until end of turn.\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "7c581212-e99c-5d37-8b44-e5cfb474377f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a6a0d-5c56-47f5-92d0-f883f1bb7630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a6a0d-5c56-47f5-92d0-f883f1bb7630.jpg?1",
             "name": "Talon Trooper",
             "text": "Flying",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "e716bf6b-4443-541a-9460-18a8032e7f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac7672c-c75f-4ce4-8f28-2c5db623e752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac7672c-c75f-4ce4-8f28-2c5db623e752.jpg?1",
             "name": "Unbender Tine",
             "text": "{T}: Untap another target permanent.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "0166bc69-b44f-54e5-9b8d-de967e61f41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd66cb50-6ef5-4b1f-b6c3-ad1210d2d380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd66cb50-6ef5-4b1f-b6c3-ad1210d2d380.jpg?1",
             "name": "Wall of Denial",
             "text": "Defender, flying, shroud",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "1093e390-b8c8-5099-903b-f191b98cf1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd69ea7-aab6-4f30-98f4-640cb0a6046c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd69ea7-aab6-4f30-98f4-640cb0a6046c.jpg?1",
             "name": "Architects of Will",
             "text": "When Architects of Will comes into play, look at the top three cards of target player's library, then put them back in any order.\nCycling {UB} ({UB}, Discard this card: Draw a card.)",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "8dfa4834-6958-5cad-93c1-5cb0964ce5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c08bd-120d-49a5-a258-bda3859c1d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c08bd-120d-49a5-a258-bda3859c1d4c.jpg?1",
             "name": "Brainbite",
             "text": "Target opponent reveals his or her hand. You choose a card from it. That player discards that card.\nDraw a card.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "ab593973-79da-5ceb-9883-b0d5e8495c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f138fe9f-3cb9-4f16-adc4-76fcb0c7e064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f138fe9f-3cb9-4f16-adc4-76fcb0c7e064.jpg?1",
             "name": "Deny Reality",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "6492d27e-7cce-5870-a39d-6a50c0d22928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbd63-d6ff-4da5-868f-ed68cbc12d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbd63-d6ff-4da5-868f-ed68cbc12d43.jpg?1",
             "name": "Etherium Abomination",
             "text": "Unearth {1}{U}{B} ({1}{U}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -723,7 +723,7 @@
         },
         {
             "id": "6e8b7817-f770-53e4-bbde-a641c55ebf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d69f7f-ac70-477b-9246-8d81fef7d335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d69f7f-ac70-477b-9246-8d81fef7d335.jpg?1",
             "name": "Illusory Demon",
             "text": "Flying\nWhen you play a spell, sacrifice Illusory Demon.",
             "colours": [
@@ -760,7 +760,7 @@
         },
         {
             "id": "fa50ab73-24af-5210-aec2-cde30c0d77b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d3f7fd-f414-4c17-ad63-c8b39bde301d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d3f7fd-f414-4c17-ad63-c8b39bde301d.jpg?1",
             "name": "Jhessian Zombies",
             "text": "Fear\nIslandcycling {2}, swampcycling {2} ({2}, Discard this card: Search your library for an Island or Swamp card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "8b7f5c31-28de-59e0-832f-9dacfbae85c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c56c6-fd72-4917-96d1-d7f9f8236fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c56c6-fd72-4917-96d1-d7f9f8236fa2.jpg?1",
             "name": "Kathari Remnant",
             "text": "Flying\n{B}: Regenerate Kathari Remnant.\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "d203ccdf-1e89-58ba-b1e0-785c8632a383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df38c422-7830-4f25-b74b-ed90b7047f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df38c422-7830-4f25-b74b-ed90b7047f53.jpg?1",
             "name": "Lich Lord of Unx",
             "text": "{U}{B}, {T}: Put a 1/1 blue and black Zombie Wizard creature token into play.\n{U}{U}{B}{B}: Target player loses X life and puts the top X cards of his or her library into his or her graveyard, where X is the number of Zombies you control.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "de64875c-ae9b-5ed6-bef2-7121c9cabbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc0c40f-1d6c-4940-9c0a-566458a8ab04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc0c40f-1d6c-4940-9c0a-566458a8ab04.jpg?1",
             "name": "Mask of Riddles",
             "text": "Equipped creature has fear.\nWhenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2}",
             "colours": [
@@ -906,7 +906,7 @@
         },
         {
             "id": "710d511a-9abb-571f-a7cc-fe38cac9060a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335168b9-bc12-4459-9b7e-56f568a8887a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335168b9-bc12-4459-9b7e-56f568a8887a.jpg?1",
             "name": "Mind Funeral",
             "text": "Target opponent reveals cards from the top of his or her library until four land cards are revealed. That player puts all cards revealed this way into his or her graveyard.",
             "colours": [
@@ -940,7 +940,7 @@
         },
         {
             "id": "b57c7f60-0b92-5f30-b513-1329a37a49c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974a0de-6c14-431d-bfdb-2e76a1778ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974a0de-6c14-431d-bfdb-2e76a1778ad0.jpg?1",
             "name": "Mistvein Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Mistvein Borderpost's mana cost.\nMistvein Borderpost comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [
@@ -974,7 +974,7 @@
         },
         {
             "id": "d93534d9-42d2-5e9e-80f4-0911ac184127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105176cc-26b0-42a8-8913-5540f54656f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105176cc-26b0-42a8-8913-5540f54656f7.jpg?1",
             "name": "Nemesis of Reason",
             "text": "Whenever Nemesis of Reason attacks, defending player puts the top ten cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "77dffba4-077a-5793-b6de-e3db43da68d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd3cb05-c6f9-435a-a0e7-1f85da4a36eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd3cb05-c6f9-435a-a0e7-1f85da4a36eb.jpg?1",
             "name": "Soul Manipulation",
             "text": "Choose one or both \u2014 Counter target creature spell; and/or return target creature card in your graveyard to your hand.",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "37c8db5b-ef13-5a75-88b0-1adf28364546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a7470-b93e-4c3a-ab1c-0a4dd401e95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a7470-b93e-4c3a-ab1c-0a4dd401e95a.jpg?1",
             "name": "Soulquake",
             "text": "Return all creatures in play and all creature cards in graveyards to their owners' hands.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "a62a2d91-f525-531d-a7bc-194de3ec7dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e565-f5e1-467c-a1d1-8d05228b2f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e565-f5e1-467c-a1d1-8d05228b2f37.jpg?1",
             "name": "Time Sieve",
             "text": "{T}, Sacrifice five artifacts: Take an extra turn after this one.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "c4eab165-fd56-5de8-a649-7f1bed11077e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01072149-fe5e-4139-b3b2-3810fd220c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01072149-fe5e-4139-b3b2-3810fd220c8e.jpg?1",
             "name": "Vedalken Ghoul",
             "text": "Whenever Vedalken Ghoul becomes blocked, defending player loses 4 life.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "1c389a04-0cfa-59a8-b67a-6c7a98b6e292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab106855-bd85-4c00-b596-c46d34f8cdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab106855-bd85-4c00-b596-c46d34f8cdd0.jpg?1",
             "name": "Anathemancer",
             "text": "When Anathemancer comes into play, it deals damage to target player equal to the number of nonbasic lands that player controls.\nUnearth {5}{B}{R} ({5}{B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1187,7 +1187,7 @@
         },
         {
             "id": "85616586-607d-5b3b-bb52-45334ed7dd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6a3c48-b01e-4462-a4a1-8d5009a6a844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6a3c48-b01e-4462-a4a1-8d5009a6a844.jpg?1",
             "name": "Bituminous Blast",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nBituminous Blast deals 4 damage to target creature.",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "574cdd9f-e3a0-5ad9-b2c6-3b34092b54fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a12e4d0-8471-46ac-85e4-a2ea5be8bf8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a12e4d0-8471-46ac-85e4-a2ea5be8bf8f.jpg?1",
             "name": "Breath of Malfegor",
             "text": "Breath of Malfegor deals 5 damage to each opponent.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "acc8caba-1faa-541b-a3d3-29d7c4ae8b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09f166f-dd3c-4cf5-b5f9-3989f46f050c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09f166f-dd3c-4cf5-b5f9-3989f46f050c.jpg?1",
             "name": "Deathbringer Thoctar",
             "text": "Whenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Deathbringer Thoctar.\nRemove a +1/+1 counter from Deathbringer Thoctar: Deathbringer Thoctar deals 1 damage to target creature or player.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "35ccb77c-54ad-5692-a801-eaf464a28a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e8b418-04af-4b99-b8fd-deb1fe21a61c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e8b418-04af-4b99-b8fd-deb1fe21a61c.jpg?1",
             "name": "Defiler of Souls",
             "text": "Flying\nAt the beginning of each player's upkeep, that player sacrifices a monocolored creature.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "bad4daed-7888-5e70-85f4-aed9ccc12b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb81132e-ab33-435f-ade4-af4416d36044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb81132e-ab33-435f-ade4-af4416d36044.jpg?1",
             "name": "Demonic Dread",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nTarget creature can't block this turn.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "580ae286-03cd-5217-9d33-50e61df6f602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a4434-0d5e-4ba8-8d10-cba9b4db5713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a4434-0d5e-4ba8-8d10-cba9b4db5713.jpg?1",
             "name": "Demonspine Whip",
             "text": "{X}: Equipped creature gets +X/+0 until end of turn.\nEquip {1}",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "82c2253a-2274-50ac-b84d-77010ae3f81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d59b32-d47f-4b05-87eb-58ffb8006fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d59b32-d47f-4b05-87eb-58ffb8006fa8.jpg?1",
             "name": "Igneous Pouncer",
             "text": "Haste\nSwampcycling {2}, mountaincycling {2} ({2}, Discard this card: Search your library for a Swamp or Mountain card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1434,7 +1434,7 @@
         },
         {
             "id": "7e970360-8b64-5d31-9acf-990f87f8b646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0d4f83-6319-4d40-9fee-6a44b05c8e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0d4f83-6319-4d40-9fee-6a44b05c8e9e.jpg?1",
             "name": "Kathari Bomber",
             "text": "Flying\nWhen Kathari Bomber deals combat damage to a player, put two 1/1 red Goblin creature tokens into play and sacrifice Kathari Bomber.\nUnearth {3}{B}{R} ({3}{B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "57e01cfd-bdd7-5953-b1c9-ab053b74f030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0860d-d3b9-4a00-a8cb-617bc317b93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0860d-d3b9-4a00-a8cb-617bc317b93d.jpg?1",
             "name": "Lightning Reaver",
             "text": "Fear, haste\nWhenever Lightning Reaver deals combat damage to a player, put a charge counter on it.\nAt the end of your turn, Lightning Reaver deals damage equal to the number of charge counters on it to each opponent.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "1b6edd72-e2ee-58af-97d5-1a139d5a8bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e668d-02ca-4164-88ee-c7ea6c665975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e668d-02ca-4164-88ee-c7ea6c665975.jpg?1",
             "name": "Monstrous Carabid",
             "text": "Monstrous Carabid attacks each turn if able.\nCycling {BR} ({BR}, Discard this card: Draw a card.)",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "60184302-f250-5a8a-be69-a90a39fdf11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c088d28d-16c2-4dd2-b036-946dfdb8ec98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c088d28d-16c2-4dd2-b036-946dfdb8ec98.jpg?1",
             "name": "Sanity Gnawers",
             "text": "When Sanity Gnawers comes into play, target player discards a card at random.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "a5414dea-6bed-5276-8600-63946c2c934a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1564d7-43fe-4072-91a6-622713848b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1564d7-43fe-4072-91a6-622713848b7e.jpg?1",
             "name": "Singe-Mind Ogre",
             "text": "When Singe-Mind Ogre comes into play, target player reveals a card at random from his or her hand, then loses life equal to that card's converted mana cost.",
             "colours": [
@@ -1617,7 +1617,7 @@
         },
         {
             "id": "c4320d6f-8955-5c69-8512-d57b9494331c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8acab8-4469-4baa-af2f-a3f49b841a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8acab8-4469-4baa-af2f-a3f49b841a55.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -1651,7 +1651,7 @@
         },
         {
             "id": "78d48bdc-78cd-584d-92d2-2d95e68a266b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b38a7e-d7c4-40c2-ba54-ae5649589cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b38a7e-d7c4-40c2-ba54-ae5649589cc9.jpg?1",
             "name": "Thought Hemorrhage",
             "text": "Name a nonland card. Target player reveals his or her hand. Thought Hemorrhage deals 3 damage to that player for each card with that name revealed this way. Search that player's graveyard, hand, and library for all cards with that name and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "577e54e6-a84b-53da-bf21-4c7a39bc83f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ad0cc1-66bd-43c3-a296-c36cf9a64e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ad0cc1-66bd-43c3-a296-c36cf9a64e85.jpg?1",
             "name": "Veinfire Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Veinfire Borderpost's mana cost.\nVeinfire Borderpost comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "aa5e05ee-265b-55ad-9871-a9583709a963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4a16be-ab3b-4020-9f26-631c0ee6730a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4a16be-ab3b-4020-9f26-631c0ee6730a.jpg?1",
             "name": "Blitz Hellion",
             "text": "Trample, haste\nAt end of turn, Blitz Hellion's owner shuffles it into his or her library.",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "6e177b7e-e008-52aa-91ce-cbd5e1977232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef67487-c8e5-49bb-b0f7-e073ff2e31f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef67487-c8e5-49bb-b0f7-e073ff2e31f1.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "34330743-fd16-5c17-8bac-4796bd1b9958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294330bb-3e77-4524-be2c-3299cf6f841f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294330bb-3e77-4524-be2c-3299cf6f841f.jpg?1",
             "name": "Colossal Might",
             "text": "Target creature gets +4/+2 and gains trample until end of turn.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "0003d249-25d9-5223-af1e-1130f09622a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aacb131b-74c9-4e6c-9466-27710bc9441f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aacb131b-74c9-4e6c-9466-27710bc9441f.jpg?1",
             "name": "Deadshot Minotaur",
             "text": "When Deadshot Minotaur comes into play, it deals 3 damage to target creature with flying.\nCycling {RG} ({RG}, Discard this card: Draw a card.)",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "9bee1432-76d0-51a8-b133-9b6869534311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f99431-ae43-4b68-82f0-faf940216c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f99431-ae43-4b68-82f0-faf940216c91.jpg?1",
             "name": "Dragon Broodmother",
             "text": "Flying\nAt the beginning of each upkeep, put a 1/1 red and green Dragon creature token with flying and devour 2 into play. (As the token comes into play, you may sacrifice any number of creatures. It comes into play with twice that many +1/+1 counters on it.)",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "ede81bb9-5212-5e0c-9ccf-4d767a9cb296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb37a8bd-6b6c-47f3-b7a0-5a20fa2d507c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb37a8bd-6b6c-47f3-b7a0-5a20fa2d507c.jpg?1",
             "name": "Firewild Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Firewild Borderpost's mana cost.\nFirewild Borderpost comes into play tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "4647038f-8118-5ba8-af41-664bf9e9737d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3fb7a-3eed-4b0a-9de0-ed8b7cf03533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3fb7a-3eed-4b0a-9de0-ed8b7cf03533.jpg?1",
             "name": "Godtracker of Jund",
             "text": "Whenever a creature with power 5 or greater comes into play under your control, you may put a +1/+1 counter on Godtracker of Jund.",
             "colours": [
@@ -1969,7 +1969,7 @@
         },
         {
             "id": "4a258abc-8ede-5f95-ad78-332d11e3f5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e5a9be-bfb2-466b-b0fe-3b24694e9f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e5a9be-bfb2-466b-b0fe-3b24694e9f84.jpg?1",
             "name": "Gorger Wurm",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "5396538f-d9f4-5d08-98ad-c95e52c3d897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0bfe8c-120c-4c4b-8709-efe40e26a35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0bfe8c-120c-4c4b-8709-efe40e26a35c.jpg?1",
             "name": "Mage Slayer",
             "text": "Whenever equipped creature attacks, it deals damage equal to its power to defending player.\nEquip {3}",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "e79c7009-8762-55bd-a383-ffaeba6d9bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595ae3af-cc28-407a-a045-a6d71cd6be60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595ae3af-cc28-407a-a045-a6d71cd6be60.jpg?1",
             "name": "Predatory Advantage",
             "text": "At the end of each opponent's turn, if that player didn't play a creature spell this turn, put a 2/2 green Lizard creature token into play.",
             "colours": [
@@ -2075,7 +2075,7 @@
         },
         {
             "id": "6e6d6b86-e967-548a-85fc-b51b082f8b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237de286-5bf0-4c8e-8504-2d01d3133b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237de286-5bf0-4c8e-8504-2d01d3133b55.jpg?1",
             "name": "Rhox Brute",
             "text": "",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "51ed4bec-6b5f-5720-830c-0c5298d1166a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a197e3f2-e69f-4716-9979-a304a87506c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a197e3f2-e69f-4716-9979-a304a87506c3.jpg?1",
             "name": "Spellbreaker Behemoth",
             "text": "Spellbreaker Behemoth can't be countered.\nCreature spells you control with power 5 or greater can't be countered.",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "af72ecf0-310e-508c-a1bb-b16e5035c067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2027335a-224b-411d-a59f-f4ad39b38a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2027335a-224b-411d-a59f-f4ad39b38a69.jpg?1",
             "name": "Valley Rannet",
             "text": "Mountaincycling {2}, forestcycling {2} ({2}, Discard this card: Search your library for a Mountain or Forest card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "69281173-cfe0-548c-b0f5-7fa32d8c545d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a504fb-b3ce-40f9-8fcb-86d5ad038e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a504fb-b3ce-40f9-8fcb-86d5ad038e5d.jpg?1",
             "name": "Vengeful Rebirth",
             "text": "Return target card from your graveyard to your hand. If you return a nonland card to your hand this way, Vengeful Rebirth deals damage equal to that card's converted mana cost to target creature or player.\nRemove Vengeful Rebirth from the game.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "a9f5cce0-fc4d-5b13-a782-5cd7587ade1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b58856a-f88e-4625-8636-62b5c717b956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b58856a-f88e-4625-8636-62b5c717b956.jpg?1",
             "name": "Violent Outburst",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nCreatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "b71dc8cf-95c2-5ba0-818a-53eb6925162b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7459a075-1a5d-4053-ab49-21bb696b6400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7459a075-1a5d-4053-ab49-21bb696b6400.jpg?1",
             "name": "Vithian Renegades",
             "text": "When Vithian Renegades comes into play, destroy target artifact.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "1706c3a6-5b31-5c3c-a7a6-6086aaca2e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a224-2db7-47d0-ba8b-98aeb50ad5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a224-2db7-47d0-ba8b-98aeb50ad5d3.jpg?1",
             "name": "Behemoth Sledge",
             "text": "Equipped creature gets +2/+2 and has lifelink and trample.\nEquip {3}",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "59e0f8a3-0271-5e21-a252-f8a479d85cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcafc9eb-efa3-4f6c-a2ca-aec8692fddc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcafc9eb-efa3-4f6c-a2ca-aec8692fddc1.jpg?1",
             "name": "Captured Sunlight",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nYou gain 4 life.",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "b2c9407d-7890-55ed-90fc-917567c054e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832309e0-c047-4c82-baa3-16f3c76e4b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832309e0-c047-4c82-baa3-16f3c76e4b6f.jpg?1",
             "name": "Dauntless Escort",
             "text": "Sacrifice Dauntless Escort: Creatures you control are indestructible this turn.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "7630e262-02a5-5df5-a3ff-9e4d6d08d2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605149-3959-4a51-8400-350e6fac2ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605149-3959-4a51-8400-350e6fac2ab2.jpg?1",
             "name": "Enlisted Wurm",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "6c975c50-ddac-5f21-a6f4-e5cdb6991d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b388381-9e13-4ce7-b5b3-56a74cc23d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b388381-9e13-4ce7-b5b3-56a74cc23d93.jpg?1",
             "name": "Grizzled Leotau",
             "text": "",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "17b348b7-0f90-5c55-afc0-b5ce751ada66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3fc235-d0d7-41f8-b35a-6e08761f7fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3fc235-d0d7-41f8-b35a-6e08761f7fa4.jpg?1",
             "name": "Knight of New Alara",
             "text": "Each other multicolored creature you control gets +1/+1 for each of its colors.",
             "colours": [
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "26f2ec96-6c71-5b12-a3a3-8beb3b56020e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a715673f-77f1-46d6-91ae-01fb3af54760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a715673f-77f1-46d6-91ae-01fb3af54760.jpg?1",
             "name": "Knotvine Paladin",
             "text": "Whenever Knotvine Paladin attacks, it gets +1/+1 until end of turn for each untapped creature you control.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "0f383a3f-c413-5f00-af35-dfd161cfc407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a57cdbd-3cd2-47c1-aec8-7f4fd7a7b804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a57cdbd-3cd2-47c1-aec8-7f4fd7a7b804.jpg?1",
             "name": "Leonin Armorguard",
             "text": "When Leonin Armorguard comes into play, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "05a2a90a-085d-5d11-8c0f-f1fa52e9a695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331079e-0193-4243-9db9-ec7762a27633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331079e-0193-4243-9db9-ec7762a27633.jpg?1",
             "name": "Mycoid Shepherd",
             "text": "Whenever Mycoid Shepherd or another creature you control with power 5 or greater is put into a graveyard from play, you may gain 5 life.",
             "colours": [
@@ -2615,7 +2615,7 @@
         },
         {
             "id": "05d6d9b6-96c8-571a-9dbb-1cbc18ae09f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fad19c-fd45-45cf-b58c-82cdcdf49b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fad19c-fd45-45cf-b58c-82cdcdf49b06.jpg?1",
             "name": "Pale Recluse",
             "text": "Reach (This can block creatures with flying.)\nForestcycling {2}, plainscycling {2} ({2}, Discard this card: Search your library for a Forest or Plains card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "1a5d1058-a7c2-56a7-9bba-e129945ad15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75256550-bbe0-499d-909e-af10691749c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75256550-bbe0-499d-909e-af10691749c2.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "8149e83e-8881-5560-afce-45cdcfd7281c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038868-6278-4d8c-a107-35aa85b5648f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038868-6278-4d8c-a107-35aa85b5648f.jpg?1",
             "name": "Reborn Hope",
             "text": "Return target multicolored card from your graveyard to your hand.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "7a0094a0-d8b4-5799-a135-268f9200f98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f767f262-57fd-4479-b719-189942ddfd9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f767f262-57fd-4479-b719-189942ddfd9e.jpg?1",
             "name": "Sigil Captain",
             "text": "Whenever a creature comes into play under your control, if that creature is 1/1, put two +1/+1 counters on it.",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "af341369-eed7-575f-ab7c-43dd6a2ed386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a856dec4-fe4f-477c-9300-e9de86d3cc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a856dec4-fe4f-477c-9300-e9de86d3cc95.jpg?1",
             "name": "Sigil of the Nayan Gods",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each creature you control.\nCycling {RW} ({RW}, Discard this card: Draw a card.)",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "ab220b48-3bfa-5e4d-bb5d-6d69d6765b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0195ee6-c5d9-402e-8339-2caa50c4e46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0195ee6-c5d9-402e-8339-2caa50c4e46b.jpg?1",
             "name": "Sigiled Behemoth",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "f7d9d3db-69a2-54ce-b69d-352e0c30a0f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a788e7-f3c8-41cc-9f1a-2e9f58aabc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a788e7-f3c8-41cc-9f1a-2e9f58aabc0e.jpg?1",
             "name": "Wildfield Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Wildfield Borderpost's mana cost.\nWildfield Borderpost comes into play tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "8cf1527f-f8b7-5c5a-851a-b682f7fd2686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d0de1-39af-4b08-81a3-2cca8aae5d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d0de1-39af-4b08-81a3-2cca8aae5d40.jpg?1",
             "name": "Identity Crisis",
             "text": "Remove all cards in target player's hand and graveyard from the game.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "414fd82a-04f2-53da-b5f6-358f46f94450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e39147-6261-4e49-b6f2-28584582489f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e39147-6261-4e49-b6f2-28584582489f.jpg?1",
             "name": "Necromancer's Covenant",
             "text": "When Necromancer's Covenant comes into play, remove all creature cards in target player's graveyard from the game, then put a 2/2 black Zombie creature token into play for each card removed this way.\nZombies you control have lifelink.",
             "colours": [
@@ -2933,7 +2933,7 @@
         },
         {
             "id": "4c548969-c030-576b-af09-8728885ab21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcf3694-d6b0-459d-8c3a-1532237b487a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcf3694-d6b0-459d-8c3a-1532237b487a.jpg?1",
             "name": "Tainted Sigil",
             "text": "{T}, Sacrifice Tainted Sigil: You gain life equal to the total life lost by all players this turn. (Damage causes loss of life.)",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "b36af59d-5597-520a-a958-c4b1bd6c4fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb7589-a53e-4580-bd92-641fd4785934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb7589-a53e-4580-bd92-641fd4785934.jpg?1",
             "name": "Vectis Dominator",
             "text": "{T}: Tap target creature unless its controller pays 2 life.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "8386f2a2-7f87-5db8-9d3f-6440ed826f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8ae46-14ec-4878-ba8a-a47d4508c6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8ae46-14ec-4878-ba8a-a47d4508c6d7.jpg?1",
             "name": "Zealous Persecution",
             "text": "Until end of turn, creatures you control get +1/+1 and creatures your opponents control get -1/-1.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "43149872-866a-51a8-800d-a3a7303bd051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62ee3ea-8b85-4b14-87ae-7fca1d98b98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62ee3ea-8b85-4b14-87ae-7fca1d98b98b.jpg?1",
             "name": "Cloven Casting",
             "text": "Whenever you play a multicolored instant or sorcery spell, you may pay {1}. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "f7b766bd-bd75-5d64-b975-ea7c538ac820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e3c58-3cda-4891-8b3d-33bb21568cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e3c58-3cda-4891-8b3d-33bb21568cf5.jpg?1",
             "name": "Double Negative",
             "text": "Counter up to two target spells.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "28f19755-8cc9-5def-b90f-cf2b3ff4515d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18c2d9-60c4-454b-b6c7-7c22ed2985fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18c2d9-60c4-454b-b6c7-7c22ed2985fb.jpg?1",
             "name": "Magefire Wings",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has flying.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "53fa6e06-2aef-55e2-888e-991ef1dae055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafde9c4-57c0-4ae5-a4db-38aae434ddcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafde9c4-57c0-4ae5-a4db-38aae434ddcd.jpg?1",
             "name": "Skyclaw Thrash",
             "text": "Whenever Skyclaw Thrash attacks, flip a coin. If you win the flip, Skyclaw Thrash gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "6fd61cc7-9f32-5f5e-b371-bed650ce2c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551518b7-1b71-4fa6-8828-5ae08eab1887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551518b7-1b71-4fa6-8828-5ae08eab1887.jpg?1",
             "name": "Spellbound Dragon",
             "text": "Flying\nWhenever Spellbound Dragon attacks, draw a card, then discard a card. Spellbound Dragon gets +X/+0 until end of turn, where X is the discarded card's converted mana cost.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "bd9a7f82-541e-5a2d-9bb9-2617d52f6b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf60d69-fc68-4b23-a9e8-9d310c00a865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf60d69-fc68-4b23-a9e8-9d310c00a865.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "d48cbd22-7443-5b8d-bcd0-7d560958958b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb651c3a-cb27-4b73-8eb6-b87d65211097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb651c3a-cb27-4b73-8eb6-b87d65211097.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -3287,7 +3287,7 @@
         },
         {
             "id": "4c142e32-5aa8-56e0-9b7b-73d8a146fb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31a32e7-e709-4524-8752-ad0ec8c77fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31a32e7-e709-4524-8752-ad0ec8c77fde.jpg?1",
             "name": "Marrow Chomper",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\nWhen Marrow Chomper comes into play, you gain 2 life for each creature it devoured.",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "4692c0b7-4f00-5511-b2a9-1a552fbc686c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ebc3a-e3b4-4dee-92ff-4a85556e0571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ebc3a-e3b4-4dee-92ff-4a85556e0571.jpg?1",
             "name": "Morbid Bloom",
             "text": "Remove target creature card in a graveyard from the game, then put X 1/1 green Saproling creature tokens into play, where X is the removed card's toughness.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "d5b7fefe-c5c4-556c-b3b7-41d87fee0647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa47568-5668-4a9f-ad1c-9a13010ffc2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa47568-5668-4a9f-ad1c-9a13010ffc2b.jpg?1",
             "name": "Putrid Leech",
             "text": "Pay 2 life: Putrid Leech gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "8e39ab08-7028-5a0a-9645-e0e64a1a5148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a85165-5aed-4e26-a314-1370d4638deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a85165-5aed-4e26-a314-1370d4638deb.jpg?1",
             "name": "Cerodon Yearling",
             "text": "Vigilance, haste",
             "colours": [
@@ -3431,7 +3431,7 @@
         },
         {
             "id": "b869023b-921c-5471-8489-4d2b2bbd85da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552ca9b-0245-4f91-9646-a5b5443863a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552ca9b-0245-4f91-9646-a5b5443863a2.jpg?1",
             "name": "Fight to the Death",
             "text": "Destroy all blocking creatures and all blocked creatures.",
             "colours": [
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "6dc47332-8701-5274-ba71-4128466921a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6117bf5-4084-45bd-82aa-81cf6d9b7eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6117bf5-4084-45bd-82aa-81cf6d9b7eb4.jpg?1",
             "name": "Glory of Warfare",
             "text": "As long as it's your turn, creatures you control get +2/+0.\nAs long as it's not your turn, creatures you control get +0/+2.",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "5dbb5c0f-16f6-593a-91b3-56c1fb0799da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e4fb54-9f31-4d75-b4ab-7b11f745b807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e4fb54-9f31-4d75-b4ab-7b11f745b807.jpg?1",
             "name": "Intimidation Bolt",
             "text": "Intimidation Bolt deals 3 damage to target creature. Other creatures can't attack this turn.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "64b23a0b-b9d4-5240-b354-b985c66cf04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f413258e-2915-41e1-ba0d-98d9d0673ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f413258e-2915-41e1-ba0d-98d9d0673ab2.jpg?1",
             "name": "Stun Sniper",
             "text": "{1}, {T}: Stun Sniper deals 1 damage to target creature. Tap that creature.",
             "colours": [
@@ -3570,7 +3570,7 @@
         },
         {
             "id": "0ffeeb3e-a514-50b8-ae7c-6da6c12eb55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81c31c9-d7d7-4b45-893e-7e36d26c645f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81c31c9-d7d7-4b45-893e-7e36d26c645f.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, you may put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "9eb3fe8e-d37d-558f-b6df-848f36da110e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263f594-621e-46af-8561-f7eee565a19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263f594-621e-46af-8561-f7eee565a19a.jpg?1",
             "name": "Nulltread Gargantuan",
             "text": "When Nulltread Gargantuan comes into play, put a creature you control on top of its owner's library.",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "5ed9e023-d658-5506-8f98-e94a9af84812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a21af-cd1a-4438-a4c2-0c92ad92efef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a21af-cd1a-4438-a4c2-0c92ad92efef.jpg?1",
             "name": "Sages of the Anima",
             "text": "If you would draw a card, instead reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "378fa6e1-5590-5ecd-9cdc-82f493b1e30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab2ba75-e52e-46f5-8a34-3fe1e07446fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab2ba75-e52e-46f5-8a34-3fe1e07446fd.jpg?1",
             "name": "Vedalken Heretic",
             "text": "Whenever Vedalken Heretic deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -3716,7 +3716,7 @@
         },
         {
             "id": "80d91515-e7af-5572-8970-250e3f568e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23ae2b-9f69-4d8d-87f9-ebcbccd67342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23ae2b-9f69-4d8d-87f9-ebcbccd67342.jpg?1",
             "name": "Winged Coatl",
             "text": "Flash\nFlying\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "7a64b3ad-237d-5e93-9f8e-bbaea92bfd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe9da-4c82-4476-8e83-24297fe5c176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe9da-4c82-4476-8e83-24297fe5c176.jpg?1",
             "name": "Enigma Sphinx",
             "text": "Flying\nWhen Enigma Sphinx is put into your graveyard from play, put it into your library third from the top.\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -3791,7 +3791,7 @@
         },
         {
             "id": "ceedc6a5-a4e3-59c4-884d-d85076d8616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896d502a-d9c3-4101-92af-a8c9d945f47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896d502a-d9c3-4101-92af-a8c9d945f47b.jpg?1",
             "name": "Esper Sojourners",
             "text": "When you cycle Esper Sojourners or it's put into a graveyard from play, you may tap or untap target permanent.\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "525ae369-3389-593c-8125-01d32b560816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568785f1-47c7-4011-926f-44693f7e0233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568785f1-47c7-4011-926f-44693f7e0233.jpg?1",
             "name": "Etherwrought Page",
             "text": "At the beginning of your upkeep, choose one \u2014 You gain 2 life; or look at the top card of your library, then you may put that card into your graveyard; or each opponent loses 1 life.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "deddcbd4-7339-5831-98e3-bfa0af5a933e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418f8ecb-544b-430c-8ae9-61aaaf2dfba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418f8ecb-544b-430c-8ae9-61aaaf2dfba6.jpg?1",
             "name": "Sen Triplets",
             "text": "At the beginning of your upkeep, choose target opponent. This turn, that player can't play spells or activated abilities and plays with his or her hand revealed. You can play cards from that player's hand this turn.",
             "colours": [
@@ -3909,7 +3909,7 @@
         },
         {
             "id": "4a97bd0f-71a3-5d2f-91c6-786cea92ffd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c860cf0f-ef68-455f-9c71-a6dd25b51d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c860cf0f-ef68-455f-9c71-a6dd25b51d71.jpg?1",
             "name": "Sphinx of the Steel Wind",
             "text": "Flying, first strike, vigilance, lifelink, protection from red and from green",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "5ea81320-eb12-5452-baf0-b4314a884ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f430-d6a5-4380-95f2-9e0fc9e81597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f430-d6a5-4380-95f2-9e0fc9e81597.jpg?1",
             "name": "Drastic Revelation",
             "text": "Discard your hand. Draw seven cards, then discard three cards at random.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "66c99f1c-f0b9-5030-82c2-b4b887846fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde5f43-0b91-45c9-9382-20ea6328266f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde5f43-0b91-45c9-9382-20ea6328266f.jpg?1",
             "name": "Grixis Sojourners",
             "text": "When you cycle Grixis Sojourners or it's put into a graveyard from play, you may remove target card in a graveyard from the game.\nCycling {2}{B} ({2}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "93c79e90-353d-5aa8-a733-03b24bf1bd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1a69e5-d099-4b13-8072-f341430f31a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1a69e5-d099-4b13-8072-f341430f31a1.jpg?1",
             "name": "Thraximundar",
             "text": "Haste\nWhenever Thraximundar attacks, defending player sacrifices a creature.\nWhenever a player sacrifices a creature, you may put a +1/+1 counter on Thraximundar.",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "36180107-f73d-5491-9c78-4558000a4bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc647ef4-1f17-4b8b-a312-60d548347d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc647ef4-1f17-4b8b-a312-60d548347d12.jpg?1",
             "name": "Unscythe, Killer of Kings",
             "text": "Equipped creature gets +3/+3 and has first strike.\nWhenever a creature dealt damage by equipped creature this turn is put into a graveyard, you may remove that card from the game. If you do, put a 2/2 black Zombie creature token into play.\nEquip {2}",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "2db5c43b-db34-557c-9e75-6a1f0b3e1e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8fb53-000a-4a04-afdf-38f2cd052c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8fb53-000a-4a04-afdf-38f2cd052c72.jpg?1",
             "name": "Dragon Appeasement",
             "text": "Skip your draw step.\nWhenever you sacrifice a creature, you may draw a card.",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "3f56a477-a38e-5082-8d0b-a052ad270f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893c08b2-1391-4aaf-b79c-d1125b232f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893c08b2-1391-4aaf-b79c-d1125b232f73.jpg?1",
             "name": "Jund Sojourners",
             "text": "When you cycle Jund Sojourners or it's put into a graveyard from play, you may have it deal 1 damage to target creature or player.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "c8adb099-2652-5244-bc13-1a10a2ef3637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956a90f-e27b-4d5a-bc23-70e878b2dfeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956a90f-e27b-4d5a-bc23-70e878b2dfeb.jpg?1",
             "name": "Karrthus, Tyrant of Jund",
             "text": "Flying, haste\nWhen Karrthus, Tyrant of Jund comes into play, gain control of all Dragons, then untap all Dragons.\nOther Dragon creatures you control have haste.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "27d4105b-b02a-5e3a-9be6-1442e34f87ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749981d6-78e7-4f53-80a8-f211e61bd532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749981d6-78e7-4f53-80a8-f211e61bd532.jpg?1",
             "name": "Lavalanche",
             "text": "Lavalanche deals X damage to target player and each creature he or she controls.",
             "colours": [
@@ -4255,7 +4255,7 @@
         },
         {
             "id": "d610e906-2c57-51ea-8f76-5bdf87f9fd76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4fd58-2052-4f97-b634-f89e2139d980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4fd58-2052-4f97-b634-f89e2139d980.jpg?1",
             "name": "Madrush Cyclops",
             "text": "Creatures you control have haste.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "1448fcd6-401d-5ba4-a014-631a8a88041c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02e9e6-4cff-404a-94a3-e844ef7cadee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02e9e6-4cff-404a-94a3-e844ef7cadee.jpg?1",
             "name": "Gloryscale Viashino",
             "text": "Whenever you play a multicolored spell, Gloryscale Viashino gets +3/+3 until end of turn.",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "14b2300a-b015-54d4-8cb1-e5d5f649b7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6f5dc-2fa6-450a-a1b1-6b6e31773365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6f5dc-2fa6-450a-a1b1-6b6e31773365.jpg?1",
             "name": "Mayael's Aria",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "ddb0a229-2d2d-59a6-8c4f-7bbc6de86dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2de336-8c61-45b1-affd-6322530b91ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2de336-8c61-45b1-affd-6322530b91ca.jpg?1",
             "name": "Naya Sojourners",
             "text": "When you cycle Naya Sojourners or it's put into a graveyard from play, you may put a +1/+1 counter on target creature.\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "c26fa6c5-81da-599e-802c-1f42a5028828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289adeb9-952d-437e-aa66-358a780dc083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289adeb9-952d-437e-aa66-358a780dc083.jpg?1",
             "name": "Retaliator Griffin",
             "text": "Flying\nWhenever a source an opponent controls deals damage to you, you may put that many +1/+1 counters on Retaliator Griffin.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "6a4ace05-7105-5d5b-a561-805d371ff386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e22185-47d0-465b-8181-afe194af5cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e22185-47d0-465b-8181-afe194af5cac.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "Uril, the Miststalker can't be the target of spells or abilities your opponents control.\nUril gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "da070dce-a395-5be1-b389-8a32982ae5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff007af-0329-4872-8621-41e90d9f06e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff007af-0329-4872-8621-41e90d9f06e6.jpg?1",
             "name": "Bant Sojourners",
             "text": "When you cycle Bant Sojourners or it's put into a graveyard from play, you may put a 1/1 white Soldier creature token into play.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "578bd4d0-112d-5b3c-864e-df296a83e461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bb726e-e561-4a14-913d-afde1964c64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bb726e-e561-4a14-913d-afde1964c64a.jpg?1",
             "name": "Finest Hour",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, if it's the first combat phase of the turn, untap that creature. After this phase, there is an additional combat phase.",
             "colours": [
@@ -4561,7 +4561,7 @@
         },
         {
             "id": "4db28cdf-f2be-5316-ab34-dcbaf335d3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbabaf1d-0220-438d-8263-e23d8010fe24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbabaf1d-0220-438d-8263-e23d8010fe24.jpg?1",
             "name": "Flurry of Wings",
             "text": "Put X 1/1 white Bird Soldier creature tokens with flying into play, where X is the number of attacking creatures.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "2b09d1ec-4ba1-5765-81de-17d134724c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d643c335-e3a7-461d-a024-095795ab6770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d643c335-e3a7-461d-a024-095795ab6770.jpg?1",
             "name": "Jenara, Asura of War",
             "text": "Flying\n{1}{W}: Put a +1/+1 counter on Jenara, Asura of War.",
             "colours": [
@@ -4637,7 +4637,7 @@
         },
         {
             "id": "fd8b252a-4f41-5abd-bc56-503c4ada4204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4fe11d-c404-489a-b17f-34f33b1597e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4fe11d-c404-489a-b17f-34f33b1597e8.jpg?1",
             "name": "Wargate",
             "text": "Search your library for a permanent card with converted mana cost X or less, put it into play, then shuffle your library.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "ea6a6ffb-d7e6-546b-8c29-2a404153bdc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b3c5b-de65-46b2-b26d-347cc31beb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b3c5b-de65-46b2-b26d-347cc31beb4c.jpg?1",
             "name": "Maelstrom Nexus",
             "text": "The first spell you play each turn has cascade. (When you play your first spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "8994c60a-d4da-5fd5-9f73-6a3daa76497f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c72f4-fbce-41c5-a46f-bfe4d1833965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c72f4-fbce-41c5-a46f-bfe4d1833965.jpg?1",
             "name": "Arsenal Thresher",
             "text": "As Arsenal Thresher comes into play, you may reveal any number of other artifact cards from your hand. Arsenal Thresher comes into play with a +1/+1 counter on it for each card revealed this way.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "1bd70fc8-5715-54de-9e7f-bf0c663bf609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ac6f0-fdec-4e2c-86c6-02d36c7bbaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ac6f0-fdec-4e2c-86c6-02d36c7bbaf5.jpg?1",
             "name": "Esper Stormblade",
             "text": "As long as you control another multicolored permanent, Esper Stormblade gets +1/+1 and has flying.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "fed9edac-7a75-5a91-9781-9dd8331f9aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8d797-b01d-49cf-9818-d84bba17029d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8d797-b01d-49cf-9818-d84bba17029d.jpg?1",
             "name": "Thopter Foundry",
             "text": "{1}, Sacrifice a nontoken artifact: Put a 1/1 blue Thopter artifact creature token with flying into play. You gain 1 life.",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "be3e4139-85d8-5802-9f1e-ad06ccb8b910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbcb812-15ad-4878-9968-cfa65a352703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbcb812-15ad-4878-9968-cfa65a352703.jpg?1",
             "name": "Grixis Grimblade",
             "text": "As long as you control another multicolored permanent, Grixis Grimblade gets +1/+1 and has deathtouch. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "e0d7cb90-c354-5aca-8762-dd9c36c6e227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf97c08-e074-4353-b9fa-c79793622585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf97c08-e074-4353-b9fa-c79793622585.jpg?1",
             "name": "Sewn-Eye Drake",
             "text": "Flying, haste",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "33fa641c-4195-5c55-a317-8a38ad060edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc177ec-dcd5-409d-a278-d84c3e6d28fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc177ec-dcd5-409d-a278-d84c3e6d28fa.jpg?1",
             "name": "Slave of Bolas",
             "text": "Gain control of target creature. Untap that creature. It gains haste until end of turn. Sacrifice it at end of turn.",
             "colours": [
@@ -4942,7 +4942,7 @@
         },
         {
             "id": "1958a923-a7a4-541a-b3d0-fe090d292175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6782d0-5399-4853-ae6f-0d05372dbf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6782d0-5399-4853-ae6f-0d05372dbf34.jpg?1",
             "name": "Giant Ambush Beetle",
             "text": "Haste\nWhen Giant Ambush Beetle comes into play, you may have target creature block it this turn if able.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "cef53ce6-83cc-5445-90fc-46f835baf27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e3b73a-598b-4854-b811-2fd40fbce2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e3b73a-598b-4854-b811-2fd40fbce2d0.jpg?1",
             "name": "Jund Hackblade",
             "text": "As long as you control another multicolored permanent, Jund Hackblade gets +1/+1 and has haste.",
             "colours": [
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "9e09d571-eb38-5e44-b23d-46d817ea63be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56b15e-d02d-4306-82a6-ced778fee90f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56b15e-d02d-4306-82a6-ced778fee90f.jpg?1",
             "name": "Sangrite Backlash",
             "text": "Enchant creature\nEnchanted creature gets +3/-3.",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "9e5ea807-8675-5511-9206-b46af6a2741c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadf8cc5-ea30-46b6-99b4-e6f19eb46306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadf8cc5-ea30-46b6-99b4-e6f19eb46306.jpg?1",
             "name": "Marisi's Twinclaws",
             "text": "Double strike",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "e088c95d-7a75-5ffe-985f-58a936e4f4e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eed1b7f-0672-4066-9e21-c5252f6dc482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eed1b7f-0672-4066-9e21-c5252f6dc482.jpg?1",
             "name": "Naya Hushblade",
             "text": "As long as you control another multicolored permanent, Naya Hushblade gets +1/+1 and has shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "468da9c7-a72f-5fdc-8aa8-df6edc9e3b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151001a-cf4b-4f95-a986-7181313e2224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151001a-cf4b-4f95-a986-7181313e2224.jpg?1",
             "name": "Trace of Abundance",
             "text": "Enchant land\nEnchanted land has shroud. (It can't be the target of spells or abilities.)\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "442c0494-c204-52c2-ba85-340b7cc7ba0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162feb2b-e641-4338-bcf1-1f7e7a11bb9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162feb2b-e641-4338-bcf1-1f7e7a11bb9d.jpg?1",
             "name": "Bant Sureblade",
             "text": "As long as you control another multicolored permanent, Bant Sureblade gets +1/+1 and has first strike.",
             "colours": [
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "d1db0102-f0db-55b0-a976-11e09b8af829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e1b-bd37-43a7-abd3-4582315a268d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e1b-bd37-43a7-abd3-4582315a268d.jpg?1",
             "name": "Crystallization",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen enchanted creature becomes the target of a spell or ability, remove that creature from the game.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "3d070d03-d43e-596d-a08a-e6dd793956c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f088f625-9c72-4949-8e53-c2313397a197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f088f625-9c72-4949-8e53-c2313397a197.jpg?1",
             "name": "Messenger Falcons",
             "text": "Flying\nWhen Messenger Falcons comes into play, draw a card.",
             "colours": [
@@ -5288,7 +5288,7 @@
         },
         {
             "id": "ba9ae285-6acc-5b86-b278-e08a9343f03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b55dcf-ae63-4b84-8d39-80b5a6de3c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b55dcf-ae63-4b84-8d39-80b5a6de3c1a.jpg?1",
             "name": "Bird Soldier",
             "text": "",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "f0c20d71-8d21-5252-abbe-0e52f758a157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83790fd3-f371-494c-97a2-3aa469a399f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83790fd3-f371-494c-97a2-3aa469a399f1.jpg?1",
             "name": "Lizard",
             "text": "",
             "colours": [
@@ -5357,7 +5357,7 @@
         },
         {
             "id": "ad66a158-b3c3-5194-98b2-a8b263cc9d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb628da-a02f-4d3e-b919-0c03821dd5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb628da-a02f-4d3e-b919-0c03821dd5f2.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "80cadb0d-9c14-5cfa-a90f-76310cc9e4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde17901-35fb-4045-8ba5-deab046cd44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde17901-35fb-4045-8ba5-deab046cd44f.jpg?1",
             "name": "Zombie Wizard",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/ARN.json
+++ b/Assets/Resources/Sets/ARN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3dd0bd56-5340-5542-8457-646b9acd58ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9ad288-d164-44a6-96ec-4185a1587f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9ad288-d164-44a6-96ec-4185a1587f1a.jpg?1",
             "name": "Abu Ja'far",
             "text": "If Abu dies without regenerating while participating in an attack or defense,all creatures Abu is blocking or being blocked by are also killed and may not regenerate.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "ab071a55-aec9-5b7c-8f8e-133f1f902152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d170015-b125-49a6-a15e-8fd116bbcb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d170015-b125-49a6-a15e-8fd116bbcb14.jpg?1",
             "name": "Army of Allah",
             "text": "All attacking creatures gain +2/+0 until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "7a5ab36e-15b0-51d1-87c0-b4b3a5cd93a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9899352a-a4c9-47bf-b9cb-0c34060ae1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9899352a-a4c9-47bf-b9cb-0c34060ae1c4.jpg?1",
             "name": "Army of Allah",
             "text": "All attacking creatures gain +2/+0 until end of turn.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "e452b3bc-4618-538f-80a1-403b65eed48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0078aa8-bfb8-43b0-a6b7-1991596c21e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0078aa8-bfb8-43b0-a6b7-1991596c21e1.jpg?1",
             "name": "Camel",
             "text": "Bands\nAll creatures attacking in a band with Camel are immune to damage done by Deserts.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "5bac4ab4-6e72-5240-9cb8-a5fd3bc55ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933ca2a-097b-44f4-ae56-ad524d26fd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933ca2a-097b-44f4-ae56-ad524d26fd06.jpg?1",
             "name": "Eye for an Eye",
             "text": "Can be cast only when a creature or spell does damage to you. Eye for an Eye does an equal amount of damage to the controller of that creature or spell. If some spell or effect reduces the amount of damage you receive, it does not reduce the damage dealt by Eye for an Eye.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "911ef63f-9f56-55b5-bc10-f95a68245a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c7705a-2987-4ef1-92b1-2c55d989ec6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c7705a-2987-4ef1-92b1-2c55d989ec6f.jpg?1",
             "name": "Jihad",
             "text": "Choose a color. As long as opponent has cards of this color in play, all white creatures gain +2/+1. Jihad must be discarded immediately if at any time opponent has no cards of this color in play.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "14c38b2a-106d-5e58-82ab-34669ca24741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3dce0f-2168-4f63-b2f9-156a11beeea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3dce0f-2168-4f63-b2f9-156a11beeea7.jpg?1",
             "name": "King Suleiman",
             "text": "Tap to destroy an Efreet or Djinn.",
             "colours": [
@@ -232,7 +232,7 @@
         },
         {
             "id": "3f2c1f58-94af-54c1-8b29-7f2fd879e4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f0781-7614-4779-a58d-f13ce96bdf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f0781-7614-4779-a58d-f13ce96bdf33.jpg?1",
             "name": "Moorish Cavalry",
             "text": "Trample",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "3e40ff4f-332a-54c5-a1a0-7a342906e706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113a6b31-3748-48c1-a915-ab0b613eabb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113a6b31-3748-48c1-a915-ab0b613eabb3.jpg?1",
             "name": "Moorish Cavalry",
             "text": "Trample",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "d81c7077-759e-5442-99a9-23606c4ff053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649c571-d7ec-4ebc-9e18-b0657cab495b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649c571-d7ec-4ebc-9e18-b0657cab495b.jpg?1",
             "name": "Piety",
             "text": "All defending creatures gain +0/+3 until end of turn.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "6b868997-8c1d-5064-9ac5-8d7c7dbb1f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a1a13-dfc8-49b7-9b17-3f0c5ca1b8be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a1a13-dfc8-49b7-9b17-3f0c5ca1b8be.jpg?1",
             "name": "Piety",
             "text": "All defending creatures gain +0/+3 until end of turn.",
             "colours": [
@@ -370,7 +370,7 @@
         },
         {
             "id": "fadb8147-0294-52c1-8f3b-5866c2dd846d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc30b6-1355-425b-a86f-18f59f83141c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc30b6-1355-425b-a86f-18f59f83141c.jpg?1",
             "name": "Repentant Blacksmith",
             "text": "Protection from red",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "e730794a-1d40-5f1b-ae09-0f6f5981de85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1",
             "name": "Shahrazad",
             "text": "Players must leave game in progress as it is and use the cards left in their libraries as decks with which to play a subgame of Magic. When subgame is over, players shuffle these cards, return them to libraries, and resume game in progress, with any loser of subgame halving his or her remaining life points, rounding down. Effects that prevent damage may not be used to counter this loss of life. The subgame has no ante; using less than forty cards may be necessary.",
             "colours": [
@@ -434,7 +434,7 @@
         },
         {
             "id": "6f1e6bbc-3493-523c-946d-c228c41cfed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c366-95cc-4799-b6c6-34d8fad8c202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c366-95cc-4799-b6c6-34d8fad8c202.jpg?1",
             "name": "War Elephant",
             "text": "Trample, bands",
             "colours": [
@@ -469,7 +469,7 @@
         },
         {
             "id": "22d06541-1812-5b49-8d64-98e79286f45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87344d-9113-4fec-9a93-38bc1abe2af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87344d-9113-4fec-9a93-38bc1abe2af5.jpg?1",
             "name": "War Elephant",
             "text": "Trample, bands",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "adb34839-4a26-5be9-a584-2a0b3557cd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414d3cae-b8cf-4d53-bd6b-1aa83a828ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414d3cae-b8cf-4d53-bd6b-1aa83a828ba9.jpg?1",
             "name": "Dand\u00e2n",
             "text": "Dand\u00e2n cannot attack unless opponent has islands in play. Dand\u00e2n is destroyed immediately if at any time you have no islands in play.",
             "colours": [
@@ -537,7 +537,7 @@
         },
         {
             "id": "d3fa5b26-f3a6-5c51-8d50-289238027741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb6ed87-aa07-4b5e-ac40-1e16dc2a817a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb6ed87-aa07-4b5e-ac40-1e16dc2a817a.jpg?1",
             "name": "Fishliver Oil",
             "text": "Target creature gains islandwalk ability.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "313c0e3b-f824-5e66-a5f3-e8122fcf9d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c066c452-1d87-4946-8d3b-6cc160a82282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c066c452-1d87-4946-8d3b-6cc160a82282.jpg?1",
             "name": "Fishliver Oil",
             "text": "Target creature gains islandwalk ability.",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "46656b4e-38a5-573e-97ea-ee947398ca7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ab9a2b-e248-4ae2-aac3-b49fdb3e260a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ab9a2b-e248-4ae2-aac3-b49fdb3e260a.jpg?1",
             "name": "Flying Men",
             "text": "Flying",
             "colours": [
@@ -640,7 +640,7 @@
         },
         {
             "id": "8d6993cf-f4d3-54b8-8a21-7f5ca5845b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096f7ac8-c639-4347-9767-7305eaf490ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096f7ac8-c639-4347-9767-7305eaf490ba.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gains +0/+3 while untapped.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "c8784a69-7358-5e22-8f37-584d42ad75d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170fa026-c17b-4731-b520-455c39ccbe6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170fa026-c17b-4731-b520-455c39ccbe6d.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gains +0/+3 while untapped.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "5463c1fa-1357-5e07-931a-e7eb6779f267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8537cb0f-4821-417b-80cc-ea57d51ee9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8537cb0f-4821-417b-80cc-ea57d51ee9b8.jpg?1",
             "name": "Island Fish Jasconius",
             "text": "You must pay o\nUo\nUo\nU during your untap phase to untap Island Fish. Island Fish cannot attack unless opponent has islands in play. Island Fish is destroyed immediately if at any time you have no islands in play.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "911cf5ad-d656-5c73-8020-3eb9857d09c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b827094-fb2c-46db-b898-02e0c308601f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b827094-fb2c-46db-b898-02e0c308601f.jpg?1",
             "name": "Merchant Ship",
             "text": "If Merchant Ship attacks and is not blocked, you gain 2 life. Merchant Ship cannot attack unless opponent has islands in play. Merchant Ship is destroyed immediately if at any time you have no islands in play.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "2a5daf35-e227-51e4-8144-5c466ba107ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10f8a05-78b0-42a7-adcd-83f6bafe5417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10f8a05-78b0-42a7-adcd-83f6bafe5417.jpg?1",
             "name": "Old Man of the Sea",
             "text": "Tap to gain control of a creature with power no greater than Old Man's power. If Old Man becomes untapped, you lose control of this creature; you may choose not to untap Old Man as normal. You also lose control of the creature if Old Man dies or if the creature's power becomes greater than Old Man's.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "3af4abdc-fc31-5e2f-b86a-a40a7e71afb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0458b733-d689-4cb5-8970-3b675c67fc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0458b733-d689-4cb5-8970-3b675c67fc4d.jpg?1",
             "name": "Serendib Djinn",
             "text": "Flying\nDuring your upkeep, you must choose one of your own lands and destroy it. If you destroy an island in this manner, Serendib Djinn does 3 damage to you. Serendib Djinn is destroyed immediately if at any time you have no land in play.",
             "colours": [
@@ -842,7 +842,7 @@
         },
         {
             "id": "cfe0c113-a1b7-5314-b984-ed92b2c24994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf56e862-3169-4f63-acd0-731080fa32f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf56e862-3169-4f63-acd0-731080fa32f2.jpg?1",
             "name": "Serendib Efreet",
             "text": "Flying\nSerendib Efreet does 1 damage to you during your upkeep.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "681fc62c-b87a-54cd-a0b4-69971e0fab39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b112a10-ac40-4353-bbdd-e5efd4546330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b112a10-ac40-4353-bbdd-e5efd4546330.jpg?1",
             "name": "Sindbad",
             "text": "Tap to draw a card from your library, but discard that card if it is not a land.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "93382e50-2240-5a3b-93cc-0761dd4e4e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79e9236-a39e-471a-b18a-2c2ba16e7774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79e9236-a39e-471a-b18a-2c2ba16e7774.jpg?1",
             "name": "Unstable Mutation",
             "text": "Target creature gains +3/+3. Each round, put a -1/-1 counter on the creature during its controller's upkeep. These counters remain even if this enchantment is removed before the creature dies.",
             "colours": [
@@ -941,7 +941,7 @@
         },
         {
             "id": "304c2a53-39cb-5c1c-b9fa-45dc5af82e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7995c3f9-a147-43c9-9f82-470924818a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7995c3f9-a147-43c9-9f82-470924818a4c.jpg?1",
             "name": "Cuombajj Witches",
             "text": "Tap to do 1 damage to any target; opponent may also do 1 damage to any target. You choose your target before opponent does, but damage is inflicted simultaneously.",
             "colours": [
@@ -975,7 +975,7 @@
         },
         {
             "id": "85941dd6-d6ff-59cb-8fc9-bc194f745bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b610d3-2005-4347-bcda-c30b5b7972e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b610d3-2005-4347-bcda-c30b5b7972e5.jpg?1",
             "name": "El-Hajj\u00e2j",
             "text": "You gain 1 life for every point of damage El-Hajj\u00e2j inflicts.",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "0924b359-5336-5655-8f5c-40ff1ec9d0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c73a97-531d-4dd5-8236-39b89c183c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c73a97-531d-4dd5-8236-39b89c183c38.jpg?1",
             "name": "Erg Raiders",
             "text": "If you do not attack with Raiders, they do 2 damage to you at end of turn. Raiders do no damage to you during the turn in which they are summoned.",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "ecc4ff59-82ba-50f2-ac8f-18d74af2e503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2717b2e2-bea8-4ba8-9ad1-abb60abf6e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2717b2e2-bea8-4ba8-9ad1-abb60abf6e4c.jpg?1",
             "name": "Erg Raiders",
             "text": "If you do not attack with Raiders, they do 2 damage to you at end of turn. Raiders do no damage to you during the turn in which they are summoned.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "451f9c5d-455a-57da-994b-e94ceef4ee06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9941f83b-2903-4eab-ac6d-5313e3978fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9941f83b-2903-4eab-ac6d-5313e3978fa3.jpg?1",
             "name": "Guardian Beast",
             "text": "As long as Guardian Beast is untapped, your non-creature artifacts cannot be further enchanted, destroyed, or taken under someone else's control. If something occurs that would destroy the Guardian Beast and artifacts simultaneously, the Guardian Beast is destroyed but your artifacts are not. If an artifact is enchanted or stolen while Guardian Beast is tapped, it remains so when Guardian Beast becomes untapped.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "e507abdf-7351-5061-92d7-e6d13d899845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f310cf5-0985-4826-9779-19a713089d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f310cf5-0985-4826-9779-19a713089d6d.jpg?1",
             "name": "Hasran Ogress",
             "text": "Unless you pay o2 each time Hasran Ogress\nattacks, Hasran Ogress does 3 damage to you.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "a36afedf-54d1-5bcd-9a6f-cfc3eea08966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fcc83f-c67f-46a2-bb0e-dafbf0a2bfc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fcc83f-c67f-46a2-bb0e-dafbf0a2bfc0.jpg?1",
             "name": "Hasran Ogress",
             "text": "Unless you pay o2 each time Hasran Ogress\nattacks, Hasran Ogress does 3 damage to you.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "39ade5ff-a12f-5fc2-abd5-8b31e5de33ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46783a-b91e-4829-a173-5515b09ca615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46783a-b91e-4829-a173-5515b09ca615.jpg?1",
             "name": "Jun\u00fan Efreet",
             "text": "Flying\nYou must pay o\nBo\nB during your upkeep or Jun\u00fan Efreet is destroyed and may not regenerate.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "b9c5eb58-53a7-5ace-8110-59a3637e7f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bf3f14-b5df-498b-a1bb-965885c82401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bf3f14-b5df-498b-a1bb-965885c82401.jpg?1",
             "name": "Juz\u00e1m Djinn",
             "text": "Juz\u00e1m Djinn does 1 damage to you during your upkeep.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "f386d40e-bb91-52c7-9019-93f876ecd5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18607bf6-ce11-41cb-b001-0c9538406ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18607bf6-ce11-41cb-b001-0c9538406ba0.jpg?1",
             "name": "Khab\u00e1l Ghoul",
             "text": "At the end of each turn, put a +1/+1 counter on Khab\u00e1l Ghoul for each other creature that died during the turn and was not regenerated.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "184eabef-2042-5e2d-a2b3-96921e251de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1450f-2909-410e-9920-731278fa74de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1450f-2909-410e-9920-731278fa74de.jpg?1",
             "name": "Oubliette",
             "text": "Select a creature in play when Oubliette is cast. That creature is considered out of play as long as Oubliette is in play. Hence the creature cannot be the target of spells and cannot receive damage, use special powers, attack, or defend. All counters and enchantments on the creature remain but are also out of play. If Oubliette is removed, creature returns to play tapped.",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "a9464941-0d21-5d3f-a797-0202e6ae9fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d74d1d-3f68-4cab-903e-e146a33258f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d74d1d-3f68-4cab-903e-e146a33258f3.jpg?1",
             "name": "Oubliette",
             "text": "Select a creature in play when Oubliette is cast. That creature is considered out of play as long as Oubliette is in play. Hence the creature cannot be the target of spells and cannot receive damage, use special powers, attack, or defend. All counters and enchantments on the creature remain but are also out of play. If Oubliette is removed, creature returns to play tapped.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "95734514-50f1-580b-9079-837f933ddbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94742003-f0f1-4483-b1a0-e7163995db1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94742003-f0f1-4483-b1a0-e7163995db1b.jpg?1",
             "name": "Sorceress Queen",
             "text": "Tap to make another creature 0/2 until end of turn. Treat this exactly as if the numbers in the lower right of the target card were 0/2. All special characteristics and enchantments on the creature are unaffected.",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "3979048d-1b6b-56d5-b1b5-d3b601d2a1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c387dd-1347-4443-91ce-b71f7ccdceba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c387dd-1347-4443-91ce-b71f7ccdceba.jpg?1",
             "name": "Stone-Throwing Devils",
             "text": "First strike",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "14f305bb-b59e-524d-ad10-c189334727bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0b28ac-144e-43c5-84f3-d4a2a229f49b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0b28ac-144e-43c5-84f3-d4a2a229f49b.jpg?1",
             "name": "Stone-Throwing Devils",
             "text": "First strike",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "cf727891-b246-533c-8bfa-410247ccb352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db52bad2-a3ec-4f6f-9418-12e8c40703f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db52bad2-a3ec-4f6f-9418-12e8c40703f6.jpg?1",
             "name": "Aladdin",
             "text": "o1o\nRo\nR and tap to take control of an artifact from opponent. Artifact is returned when Aladdin is removed from play or when game ends.",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "f1c3f7ed-329c-524f-9c5a-ea3cf1ef40a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7064-3703-43e0-8702-d1ba13703fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7064-3703-43e0-8702-d1ba13703fd8.jpg?1",
             "name": "Ali Baba",
             "text": "oo\nR Tap a wall.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "a2daba07-3fb1-5526-8896-e49d97b9f404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42027613-d261-4ce2-8ba1-7a2480c660f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42027613-d261-4ce2-8ba1-7a2480c660f8.jpg?1",
             "name": "Ali from Cairo",
             "text": "While Ali is in play, damage that would reduce you to less than 1 life lowers you to 1 life. All further damage is prevented.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "59936d4a-cad3-5df6-b7d9-9dd2998d0a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba0b9-db01-447f-90cc-a2fc2c24146e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba0b9-db01-447f-90cc-a2fc2c24146e.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "78493c6a-deff-5c94-a7a6-a3924bad0212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709532d8-cd3e-4844-b580-e6925ce837ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709532d8-cd3e-4844-b580-e6925ce837ff.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "c8754dc9-a9be-5a36-be01-1548c7a9b269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d0c10-ec09-48ba-9e93-1392dca8111a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d0c10-ec09-48ba-9e93-1392dca8111a.jpg?1",
             "name": "Desert Nomads",
             "text": "Desertwalk\nDesert Nomads are immune to damage done by Deserts.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "580c9965-81cc-5651-b5f4-371124c6f813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4aadda8-8577-480d-8186-532d2b173c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4aadda8-8577-480d-8186-532d2b173c15.jpg?1",
             "name": "Hurr Jackal",
             "text": "Tap to prevent a target creature from regenerating for the remainder of the turn.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "c712ec7b-f4aa-507c-85b5-b666f35c6fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe8845e-df1c-481c-949c-aab84af99a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe8845e-df1c-481c-949c-aab84af99a05.jpg?1",
             "name": "Kird Ape",
             "text": "Kird Ape gains +1/+2 if you have any forests in play.",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "ee8575a8-5f9f-5ad3-9009-de194816dc56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95fde48b-e40a-4183-b324-1ec276dde015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95fde48b-e40a-4183-b324-1ec276dde015.jpg?1",
             "name": "Magnetic Mountain",
             "text": "Blue creatures do not untap as normal. During their untap phases, players must spend o4 for each blue creature they wish to untap. This cost must be paid in addition to any other untap cost a given blue creature may already require.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "7231c384-3377-5826-9173-1585b2b61e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ddbe51-cd1a-4b2c-849a-7c82d622122a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ddbe51-cd1a-4b2c-849a-7c82d622122a.jpg?1",
             "name": "Mijae Djinn",
             "text": "If you choose to attack with Mijae Djinn, flip a coin immediately after attack is announced; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Mijae Djinn is tapped but does not attack.",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "6c80baa9-109a-50e1-8f3c-aebee456ef27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28f9e63-e5e4-44b5-a17e-8301ff17c623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28f9e63-e5e4-44b5-a17e-8301ff17c623.jpg?1",
             "name": "Rukh Egg",
             "text": "If Rukh Egg goes to the graveyard, a Rukh\u2014a 4/4 red flying creature\u2014comes into play on your side at the end of that turn. Use a counter to represent Rukh. Rukh is treated exactly like a normal creature except that if it leaves play it is removed from the game entirely.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "6e806a18-e9eb-5f58-aff0-d847c85889ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4defc2-b1a2-4ae2-bda0-24ecd4ff8181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4defc2-b1a2-4ae2-bda0-24ecd4ff8181.jpg?1",
             "name": "Rukh Egg",
             "text": "If Rukh Egg goes to the graveyard, a Rukh\u2014a 4/4 red flying creature\u2014comes into play on your side at the end of that turn. Use a counter to represent Rukh. Rukh is treated exactly like a normal creature except that if it leaves play it is removed from the game entirely.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "43be57eb-8bb1-5cdb-a80f-a38fb2e740e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdba2a9-d171-45ed-8dd4-9d0046128f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdba2a9-d171-45ed-8dd4-9d0046128f68.jpg?1",
             "name": "Ydwen Efreet",
             "text": "If you choose to block with Ydwen Efreet, flip a coin immediately after defense is announced; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Ydwen Efreet cannot block this turn.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "b9f4fd87-fdf7-5b6c-8db5-829d4d348b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11684d6-5b74-47a7-a2d0-256c9e437aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11684d6-5b74-47a7-a2d0-256c9e437aa6.jpg?1",
             "name": "Cyclone",
             "text": "Put one chip on Cyclone each round during your upkeep, then pay o\nG for each chip or discard Cyclone. If not discarded, Cyclone immediately does 1 damage per chip to each player and each creature in play.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "54398c43-042c-5add-822a-b18b0d854d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d77c149-cca2-45c7-bc83-5ba1872ad5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d77c149-cca2-45c7-bc83-5ba1872ad5e0.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy any card in play.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "d046eec4-3167-5074-974f-4110f7329097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e090d4-e7fe-403c-9aca-05c1b45ed238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e090d4-e7fe-403c-9aca-05c1b45ed238.jpg?1",
             "name": "Drop of Honey",
             "text": "During your upkeep, the creature in play with the lowest power is destroyed and cannot be regenerated. If there is a tie you choose which to destroy. Drop of Honey must be discarded if there are no creatures in play.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "c36fd58a-cce8-528c-8a16-88b34360071d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bc0c3f-0a52-4bdc-83da-6484bf3102f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bc0c3f-0a52-4bdc-83da-6484bf3102f3.jpg?1",
             "name": "Erhnam Djinn",
             "text": "During your upkeep, you must choose one of opponent's non-wall creatures in play. Until your next upkeep, that creature gains the forestwalk ability. If opponent has no creatures, ignore this effect.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "1c7bc984-4bdd-5f3a-9966-0bd28f8bcbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d613d5-36a2-4633-b5af-64511bb29cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d613d5-36a2-4633-b5af-64511bb29cc2.jpg?1",
             "name": "Ghazb\u00e1n Ogre",
             "text": "During its current controller's upkeep, the player with the highest life total takes control of Ghazb\u00e1n Ogre.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "0086e71c-3c89-519b-976c-b721515b112b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b10fb7-8667-42bf-aeb6-35767a82917b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b10fb7-8667-42bf-aeb6-35767a82917b.jpg?1",
             "name": "Ifh-B\u00edff Efreet",
             "text": "Flying\nWhile Ifh-B\u00edff Efreet is in play, any player can pay o\nG to have Ifh-B\u00edff Efreet do 1 damage to each player and each flying creature in play. This ability does not tap the Ifh-B\u00edff Efreet, and can be used as soon as it is successfully summoned.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "8352dcb3-1f22-50c7-ad90-730a33545344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc6cfc3-b232-40bf-bc0c-4618f6f5c9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc6cfc3-b232-40bf-bc0c-4618f6f5c9a5.jpg?1",
             "name": "Metamorphosis",
             "text": "Sacrifice a creature of yours in play for an amount of mana equal to its casting cost plus 1. This mana can be of any one color, and can only be used to summon creatures.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "b76531a6-b2f0-5d2f-a9fc-b86a18423c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965f722c-2b18-4c22-8c30-12552def5940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965f722c-2b18-4c22-8c30-12552def5940.jpg?1",
             "name": "Nafs Asp",
             "text": "If Asp inflicts any damage on your opponent, your opponent must spend o1 before the draw phase of his or her next turn or lose an additional 1 life.",
             "colours": [
@@ -2153,7 +2153,7 @@
         },
         {
             "id": "aa392433-d212-5011-9575-09d62b0167fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecc8d7c-c64f-4ada-b389-756728401b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecc8d7c-c64f-4ada-b389-756728401b64.jpg?1",
             "name": "Nafs Asp",
             "text": "If Asp inflicts any damage on your opponent, your opponent must spend o1 before the draw phase of his or her next turn or lose an additional 1 life.",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "3646247d-762b-5205-85ea-43fc33d49543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cba9cd-73d9-442e-bd99-9cba9f398b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cba9cd-73d9-442e-bd99-9cba9f398b64.jpg?1",
             "name": "Sandstorm",
             "text": "All attacking creatures suffer 1 damage.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "21173f54-3bf7-5212-b71f-8125583ef0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3003bf1e-8085-45d8-882b-c449109e7631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3003bf1e-8085-45d8-882b-c449109e7631.jpg?1",
             "name": "Singing Tree",
             "text": "Tap to reduce an attacking creature's power to 0.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "b179db24-7a93-5c35-b3a8-e42cd11d9051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ccebe1-ef08-4805-a65f-a1c57abed9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ccebe1-ef08-4805-a65f-a1c57abed9f2.jpg?1",
             "name": "Wyluli Wolf",
             "text": "Tap to give any creature in play +1/+1 until end of turn.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "d429117f-4b10-5e66-ad2f-e233252a034a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc1188c-4331-41dc-a577-bd4bedd7ca76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc1188c-4331-41dc-a577-bd4bedd7ca76.jpg?1",
             "name": "Wyluli Wolf",
             "text": "Tap to give any creature in play +1/+1 until end of turn.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "2b337664-eea0-5df5-976c-4ae0b93156bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fecc5d2-5298-4d47-b085-f160603f220e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fecc5d2-5298-4d47-b085-f160603f220e.jpg?1",
             "name": "Aladdin's Lamp",
             "text": "oo\nX Instead of drawing a card from the top of your library, draw X cards but choose only one to put in your hand. You must shuffle the leftover cards and put them at the bottom of your library.",
             "colours": [],
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "6e6b0872-4d06-55de-acca-bf3d3d25581e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2b74a2-cb74-4b54-b9c6-78c63f14cf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2b74a2-cb74-4b54-b9c6-78c63f14cf5b.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8: Do 4 damage to any target.",
             "colours": [],
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "680b0beb-bf12-54ca-808e-142a45f06982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474cd6b-5610-49eb-ac98-918d900efe8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474cd6b-5610-49eb-ac98-918d900efe8b.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o4: Flip a coin, with opponent calling heads or tails while coin is in the air. If the flip ends up in opponent's favor, Bottle of Suleiman does 5 damage to you. Otherwise, a 5/5 flying Djinn immediately comes into play on your side. Use a counter to represent Djinn. Djinn is treated exactly like a normal artifact creature except that if it leaves play it is removed from the game entirely. No matter how the flip turns out, Bottle of Suleiman is discarded after use.",
             "colours": [],
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "e574a9f4-5ccd-5b92-87af-ddf36a03e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a364362-e42b-415c-9d95-b6ec7139f5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a364362-e42b-415c-9d95-b6ec7139f5e7.jpg?1",
             "name": "Brass Man",
             "text": "Brass Man does not untap as normal; you must pay o1 during your untap phase to untap it.",
             "colours": [],
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "dc2a3373-3c26-5443-a826-c92c7fc03c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598b346-a47d-4c4c-9571-156824e86b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598b346-a47d-4c4c-9571-156824e86b9c.jpg?1",
             "name": "City in a Bottle",
             "text": "All cards from Arabian Nights must be discarded from play, except for City in a Bottle. While City in a Bottle is in play, no further cards from Arabian Nights can be played.",
             "colours": [],
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "78a0788b-a066-5a59-b735-732f2939c85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2e494-1414-4d1f-91d2-7cb20acdb128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2e494-1414-4d1f-91d2-7cb20acdb128.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "813f76c9-46ba-50e7-9b58-14739fb6e31c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae81ec7-2b7d-4301-8114-032be5e6b663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae81ec7-2b7d-4301-8114-032be5e6b663.jpg?1",
             "name": "Ebony Horse",
             "text": "o2: Remove one of your attacking creatures from combat. Treat this as if the creature never attacked, except that defenders assigned to block it cannot choose to block another creature.",
             "colours": [],
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "3bb554dc-a247-5ed2-84a3-d454fe4774d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b71ff49-ee0a-4065-9131-380468d62a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b71ff49-ee0a-4065-9131-380468d62a30.jpg?1",
             "name": "Flying Carpet",
             "text": "o2: Gives one creature flying ability until end of turn. If that creature is destroyed before end of turn, so is Flying Carpet.",
             "colours": [],
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "975fa200-a4a1-5be4-ba79-eadc78d20993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71504078-a16f-4dc4-9626-0ecc42b1e93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71504078-a16f-4dc4-9626-0ecc42b1e93b.jpg?1",
             "name": "Jandor's Ring",
             "text": "o2: Discard a card you just drew from your library, and draw another card to replace it.",
             "colours": [],
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "a2e03391-2efc-5cb3-950b-cc7dcea942ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b92-7d4e-4b03-8cb4-e6b356c338b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b92-7d4e-4b03-8cb4-e6b356c338b4.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3: Untap a creature.",
             "colours": [],
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "0440e3de-3b4f-5480-83f8-18576526ebc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfffb65d-851d-4dc9-9233-d53abf955dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfffb65d-851d-4dc9-9233-d53abf955dcd.jpg?1",
             "name": "Jeweled Bird",
             "text": "Draw a card, and exchange Jeweled Bird for your contribution to the ante. Your former contribution goes to your graveyard. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [],
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "5d4c0c95-dc55-57e6-8f3a-a319ddf42497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9decf-47b7-44e0-b380-8055b6011021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9decf-47b7-44e0-b380-8055b6011021.jpg?1",
             "name": "Pyramids",
             "text": "o2: Prevents a land from being destroyed, or removes an enchantment from any land.",
             "colours": [],
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "dcf0f844-f329-5063-85f4-6037e1965e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc1004f-7cee-420a-9f0e-2986ed3ab852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc1004f-7cee-420a-9f0e-2986ed3ab852.jpg?1",
             "name": "Ring of Ma'r\u00fbf",
             "text": "o5: Instead of drawing a card from the top of your library, select one of your cards from outside the game. This card can be any card you have that you're not using in your deck or that for some reason has left the game. Ring of Ma'r\u00fbf is removed from the game entirely after use.",
             "colours": [],
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "9b9d06e9-049f-5cac-8775-5cf26e4febb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99a520-b8a9-40b0-9854-48aac297c5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99a520-b8a9-40b0-9854-48aac297c5ee.jpg?1",
             "name": "Sandals of Abdallah",
             "text": "o2: Gives one creature islandwalk ability until end of turn. If that creature is destroyed before end of turn, so are Sandals.",
             "colours": [],
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "be687077-8e91-50bf-b44b-3e52d2d22a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff37b863-f8c4-4584-8cc2-ac0e096e583f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff37b863-f8c4-4584-8cc2-ac0e096e583f.jpg?1",
             "name": "Bazaar of Baghdad",
             "text": "Tap to take two cards from your library, after which you must immediately discard three from your hand to your graveyard. If you don't have three or more cards in your hand, discard your whole hand. No spells may be cast between drawing and discarding cards.",
             "colours": [],
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "711d99ff-bcab-52ad-9f34-c6960eb0da48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e32327-380d-471e-813b-4c27477787ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e32327-380d-471e-813b-4c27477787ce.jpg?1",
             "name": "City of Brass",
             "text": "Tap to add 1 mana of any color to your mana pool. You suffer 1 damage whenever City of Brass becomes tapped.",
             "colours": [],
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "d432c1bb-b3a1-5725-8884-70dea10a2633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201155ea-f474-4e13-acda-cb071a6ca977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201155ea-f474-4e13-acda-cb071a6ca977.jpg?1",
             "name": "Desert",
             "text": "Tap to add 1 colorless mana to your mana pool or do 1 damage to an attacking creature after it deals its damage.",
             "colours": [],
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "a6b37a73-e152-5416-af8f-f35c1c3c4d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f6f21-15a0-4a36-be95-5a0299cd01a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f6f21-15a0-4a36-be95-5a0299cd01a5.jpg?1",
             "name": "Diamond Valley",
             "text": "Tap to sacrifice one of your creatures in exchange for a number of life points equal to its toughness. Note that this ability may be used after blocking has been declared.",
             "colours": [],
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "3848de3a-5625-52d6-be9c-5cfe84c3843b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18348df2-9037-4db4-bddb-76dc933229bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18348df2-9037-4db4-bddb-76dc933229bf.jpg?1",
             "name": "Elephant Graveyard",
             "text": "Tap to add 1 colorless mana to your mana pool or regenerate an Elephant or Mammoth.",
             "colours": [],
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "d763a70c-4caf-5fdf-aa87-185fc25fb1be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09cbd18-79f1-49a0-a3bd-b380ff5ecf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09cbd18-79f1-49a0-a3bd-b380ff5ecf03.jpg?1",
             "name": "Island of Wak-Wak",
             "text": "Tap to reduce target flying creature's power to 0.",
             "colours": [],
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "c395c80e-298a-5870-8877-cd0a7e273146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee266113-34ce-4189-84e7-ee2c86a2722c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee266113-34ce-4189-84e7-ee2c86a2722c.jpg?1",
             "name": "Library of Alexandria",
             "text": "Tap to add 1 colorless mana to your mana pool or draw a card from your library; you may use the card-drawing ability only if you have exactly seven cards in your hand.",
             "colours": [],
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "e7ef4860-f739-52cc-b84a-388e3de3c0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c321d0e1-ff30-4424-979b-25e1a33e45d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c321d0e1-ff30-4424-979b-25e1a33e45d5.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -2930,7 +2930,7 @@
         },
         {
             "id": "aceae48d-9e48-5983-8baf-32ff5b97281e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38565e-88b9-433d-b0e9-a3b9734f183f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38565e-88b9-433d-b0e9-a3b9734f183f.jpg?1",
             "name": "Oasis",
             "text": "Tap to prevent 1 damage to any creature.",
             "colours": [],

--- a/Assets/Resources/Sets/ATQ.json
+++ b/Assets/Resources/Sets/ATQ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2172f6a4-a1a1-5c61-bcb3-393b381e7a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83a3cb-467d-44f6-a051-4855c8cf52a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83a3cb-467d-44f6-a051-4855c8cf52a6.jpg?1",
             "name": "Argivian Archaeologist",
             "text": "o\nWoo\nW Tap to bring one artifact from your graveyard to your hand.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "c43e408c-64cf-57c8-8c4f-acdd4a9fa912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f604338-5ee4-4c47-ad5a-5c805c96c8de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f604338-5ee4-4c47-ad5a-5c805c96c8de.jpg?1",
             "name": "Argivian Blacksmith",
             "text": "Tap to prevent up to 2 damage to target artifact creature.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "93a5a9ef-4f3d-5413-bbff-1b3dca579da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5101a-ec66-4658-950c-9ad49c29b836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5101a-ec66-4658-950c-9ad49c29b836.jpg?1",
             "name": "Artifact Ward",
             "text": "Target creature cannot be blocked by artifact creatures, and any damage taken from an artifact source is reduced to 0. Target creature is unaffected by any artifact effects that target it.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "fc1966ef-41bd-5f01-bc79-ae706037eb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ebd5a3-fef8-4097-b038-89a6cb38227d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ebd5a3-fef8-4097-b038-89a6cb38227d.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "o2: Prevents all damage against you from any one artifact source. If a source does damage to you more than once in a turn, you must pay o2 each time you want to prevent the damage.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "8a03a3b6-6f37-578c-9f72-fe141793c957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ab9836-bc90-4d92-a86d-b8e1b7671aa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ab9836-bc90-4d92-a86d-b8e1b7671aa7.jpg?1",
             "name": "Damping Field",
             "text": "Players may not untap more than one artifact during each of their own untap phases.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "a4c662b9-3a91-59b6-98fd-45fd1763860e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde037b9-4947-4ff7-8ea4-e9f1a7e4ab88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde037b9-4947-4ff7-8ea4-e9f1a7e4ab88.jpg?1",
             "name": "Martyrs of Korlis",
             "text": "Unless Martyrs of Korlis is tapped, any damage done to you by artifacts is instead applied to Martyrs of Korlis. You may not take this damage yourself, though you may prevent it if possible. No more than one Bodyguard of your choice can take damage for you in this manner each turn.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "62ba1509-14a9-5fdb-a6ed-40c76fe7d711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7ed8ba-3886-4779-a9b3-6892a7ed3527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7ed8ba-3886-4779-a9b3-6892a7ed3527.jpg?1",
             "name": "Reverse Polarity",
             "text": "All damage done to you so far this turn by artifacts is retroactively added to your life total instead of subtracted. Further damage this turn is treated normally.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "44f6abee-a596-5e23-93f9-234bb96bf1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be2aa3b-207b-4d21-abfb-6788520c7676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be2aa3b-207b-4d21-abfb-6788520c7676.jpg?1",
             "name": "Drafna's Restoration",
             "text": "Take any number of artifacts of your choice from target player's graveyard and place them on top of that player's library, in any order.",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "1fc46567-9a43-543f-bd97-391e2adb2f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1f624b-e8f2-462f-838a-7cb9e8fda988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1f624b-e8f2-462f-838a-7cb9e8fda988.jpg?1",
             "name": "Energy Flux",
             "text": "All artifacts in play now require an upkeep cost of o2 in addition to any other upkeep costs they may have. If the upkeep cost for an artifact is not paid, the artifact must be discarded.",
             "colours": [
@@ -293,7 +293,7 @@
         },
         {
             "id": "31ce9fd3-2c07-5362-b628-be49b29e59d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32373dd-06d8-45d1-8777-3b1411bcb30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32373dd-06d8-45d1-8777-3b1411bcb30a.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "All artifacts in play owned by target player are returned to target player's hand. Any enchantments on those artifacts are discarded. Cannot be played during the damage-dealing phase of an attack.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "ec79b3db-99bd-536b-b09d-5438bac5536e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48bc89e-6da5-43da-b4e0-60d5f850199c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48bc89e-6da5-43da-b4e0-60d5f850199c.jpg?1",
             "name": "Power Artifact",
             "text": "The activation cost of target artifact is reduced by o2. If this would reduce target artifact's activation cost below o1, target artifact's activation cost becomes o1. Power Artifact has no effect on artifacts that have no activation cost or whose activation cost is o0.",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "7b3f65b8-2dd9-5026-be22-ef18aa7f21b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa2d27b-cc25-4baa-86f4-4db45b30e2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa2d27b-cc25-4baa-86f4-4db45b30e2a4.jpg?1",
             "name": "Reconstruction",
             "text": "Bring one artifact from your graveyard to your hand.",
             "colours": [
@@ -388,7 +388,7 @@
         },
         {
             "id": "8ea7d80c-110e-55ae-bbf6-38d6861a559a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff60ce-073c-46b8-807c-8b40467b960c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff60ce-073c-46b8-807c-8b40467b960c.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "Tap to draw a card from your library. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "98893d8a-85dc-5429-9648-c93feda4873e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eab6765-eba3-4844-81ca-ae37a6e903df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eab6765-eba3-4844-81ca-ae37a6e903df.jpg?1",
             "name": "Transmute Artifact",
             "text": "Search through your library for one artifact and immediately place it into play; also, choose any artifact in play that you control and place it in its owner's graveyard. If the new artifact has a casting cost greater than that of the discarded one, you must pay the difference or Transmute Artifact fails and both artifacts are discarded. Shuffle your library after playing this card.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "2c5aef2a-628a-56a7-92df-97fbc176df8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587d6ac8-fad8-49e0-862e-636e06628ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587d6ac8-fad8-49e0-862e-636e06628ff9.jpg?1",
             "name": "Artifact Possession",
             "text": "Artifact Possession does 2 damage to target artifact's controller each time target artifact is tapped or its activation cost is paid. Has no effect if cast on a continuous artifact.",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "ca6c9d78-48ad-5ce6-a8ff-55c699fd6a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f372950-6693-4838-80ef-8fd9aa3e0349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f372950-6693-4838-80ef-8fd9aa3e0349.jpg?1",
             "name": "Gate to Phyrexia",
             "text": "Sacrifice one of your creatures during your upkeep to destroy any one artifact. You may not sacrifice a creature that is already on its way to the graveyard.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "b2a0023e-3ae7-5d59-a33f-2af006890b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f6ef2f-a3a2-4e1f-b7eb-59abc8414114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f6ef2f-a3a2-4e1f-b7eb-59abc8414114.jpg?1",
             "name": "Haunting Wind",
             "text": "Each time an artifact in play is tapped or its activation cost is paid, Haunting Wind does 1 damage to that artifact's controller. Is not triggered by continuous artifacts.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "0a53e07a-4fae-56a5-9976-be85f7da6bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a985a9-5612-4844-982e-fd1aa6249770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a985a9-5612-4844-982e-fd1aa6249770.jpg?1",
             "name": "Phyrexian Gremlins",
             "text": "Tap Gremlins to tap an artifact. As long as Gremlins remain tapped and in play, that artifact does not untap as normal during its controller's untap phase. You may choose not to untap Gremlins during your untap phase.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "d5e8a38a-5439-511c-8fff-35616be82a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fd4054-42fc-4f95-a6f7-369a5da43dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fd4054-42fc-4f95-a6f7-369a5da43dd5.jpg?1",
             "name": "Priest of Yawgmoth",
             "text": "Tap to add an amount of black mana equal to target artifact's casting cost to your mana pool. This effect is played as an interrupt. Target artifact, which must belong to you, is discarded. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "6fc80bbd-ee58-5515-86cb-918583d6e465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5149ffff-d38f-458e-bcfa-a4b6b332a0b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5149ffff-d38f-458e-bcfa-a4b6b332a0b4.jpg?1",
             "name": "Xenic Poltergeist",
             "text": "Tap to turn target non-creature artifact into an artifact creature with both power and toughness equal to its casting cost. This transformation lasts until your next upkeep; target retains all its original abilities as well.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "c6e4d57e-e983-58ba-bd0b-b440e9a95166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bbd231-0d5f-4cbf-92a7-10d2c5c4b82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bbd231-0d5f-4cbf-92a7-10d2c5c4b82c.jpg?1",
             "name": "Yawgmoth Demon",
             "text": "Flying, first strike\nDuring your upkeep, choose one of your artifacts in play and place it in the graveyard, or Yawgmoth Demon becomes tapped and deals 2 points of damage to you. Artifact creatures destroyed this way may not be regenerated.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "8d049b0a-7571-57bc-853a-d1fb8232fec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1506d99d-7b2e-4101-84a5-c950dadb263a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1506d99d-7b2e-4101-84a5-c950dadb263a.jpg?1",
             "name": "Artifact Blast",
             "text": "Counters any artifact as it is being cast.",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "062dec00-8d7e-51f2-ba8d-ea6f930ffcf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2249fc40-4412-48fd-800a-7ea3678aee3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2249fc40-4412-48fd-800a-7ea3678aee3f.jpg?1",
             "name": "Atog",
             "text": "o0: +2/+2 until end of turn. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "79afd8d0-d940-561d-8485-d57e3c9ca1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77fda65-f70d-44b1-89db-910d2761b81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77fda65-f70d-44b1-89db-910d2761b81c.jpg?1",
             "name": "Atog",
             "text": "",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "24c4d57a-3560-564d-8404-5b1e746606c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd7eb90-ae95-49df-898a-9510187bce1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd7eb90-ae95-49df-898a-9510187bce1c.jpg?1",
             "name": "Detonate",
             "text": "Targets any artifact; X is the casting cost of target artifact. Target artifact is destroyed, and Detonate does X points of damage to artifact's controller. Artifact creatures destroyed in this manner may not be regenerated.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "9b1fe74e-ec49-5c02-b0be-c382c3d8e5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0848d94a-2704-460f-986b-b192dd6d26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0848d94a-2704-460f-986b-b192dd6d26b7.jpg?1",
             "name": "Dwarven Weaponsmith",
             "text": "Tap during your upkeep to add a permanent +1/+1 counter to any creature. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed in this way may not be regenerated.",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "4a8ced8a-e033-5a50-a50f-2b628fb60818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6669d96e-9a7b-4427-a477-f4e76831f593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6669d96e-9a7b-4427-a477-f4e76831f593.jpg?1",
             "name": "Goblin Artisans",
             "text": "You may tap Goblin Artisans as you cast an artifact. Then flip a coin; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, your artifact is countered. Otherwise, draw another card from your library. You can only use this ability once for each time you cast an artifact.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "03014f7c-5ed1-5eaa-b405-53e66a114061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e34fc6b-5f00-4a22-9ee2-afc1caf99961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e34fc6b-5f00-4a22-9ee2-afc1caf99961.jpg?1",
             "name": "Orcish Mechanics",
             "text": "Tap to do 2 points of damage to any target. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "37cb60a3-9bbf-5035-b542-cc86387fe39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987461a-45c0-4956-8627-cd27a7e038d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987461a-45c0-4956-8627-cd27a7e038d0.jpg?1",
             "name": "Shatterstorm",
             "text": "All artifacts in play are discarded.\nArtifact creatures cannot be regenerated.",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "3e7ed4d3-43e8-5ab2-b343-2bd0cd564a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5712e87a-2381-4f5b-a853-6973841f9bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5712e87a-2381-4f5b-a853-6973841f9bf1.jpg?1",
             "name": "Argothian Pixies",
             "text": "Cannot be blocked by artifact creatures. Any damage Argothian Pixies take from artifact creatures is reduced to 0.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "24a035d4-f042-51f8-b018-31697d0ae891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db8882e-4db6-4e3c-9e9e-8c71d557a071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db8882e-4db6-4e3c-9e9e-8c71d557a071.jpg?1",
             "name": "Argothian Treefolk",
             "text": "Any damage Argothian Treefolk take from an artifact source is reduced to 0.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "6360649f-b0d4-5d11-8d4a-4481b3f2d8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a130dc-3b1f-4fae-8459-b26bb5647fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a130dc-3b1f-4fae-8459-b26bb5647fec.jpg?1",
             "name": "Citanul Druid",
             "text": "Druid gains a +1/+1 counter each time opponent casts an artifact.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "3a12cebc-8f57-5bd8-82f0-a947038da26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2101f86-8d3c-4ba8-ac42-bd3df0644280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2101f86-8d3c-4ba8-ac42-bd3df0644280.jpg?1",
             "name": "Crumble",
             "text": "Destroy target artifact; artifact creatures may not regenerate. Artifact's controller gains life points equal to target artifact's casting cost.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "f00a51ae-00ac-560a-8e98-e59bd69d1cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d763bd-b0a9-46ba-bcd2-9304063446f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d763bd-b0a9-46ba-bcd2-9304063446f2.jpg?1",
             "name": "Gaea's Avenger",
             "text": "The *s below are the number of artifacts opponent has in play.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "546a88d7-1cda-5567-8721-cf58d21609f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1d7b09-3a1f-410f-b330-04ae768b0455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1d7b09-3a1f-410f-b330-04ae768b0455.jpg?1",
             "name": "Powerleech",
             "text": "Gain 1 life whenever one of opponent's artifacts becomes tapped, or whenever the activation cost of one of opponent's artifacts is paid. Is not triggered by continuous artifacts.",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "61475d58-937f-5116-b319-03779a9cc58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a53af-2e2a-4f3f-8eab-bd874c6ed80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a53af-2e2a-4f3f-8eab-bd874c6ed80a.jpg?1",
             "name": "Titania's Song",
             "text": "All non-creature artifacts in play lose all their usual abilities and become artifact creatures with toughness and power both equal to their casting costs. If Titania's Song leaves play, artifacts return to normal just before the untap phase of the next turn.",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "06d37a54-ac63-5960-a952-a896193c3995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b094f8dd-0184-41a2-9767-e848a6e4eac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b094f8dd-0184-41a2-9767-e848a6e4eac1.jpg?1",
             "name": "Amulet of Kroog",
             "text": "o2: Prevent 1 damage to any target.",
             "colours": [],
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "85cc73a1-602e-57dd-b4df-8ccc47bf2cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a31889-6a8d-450c-a73d-381a7ff28bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a31889-6a8d-450c-a73d-381a7ff28bf9.jpg?1",
             "name": "Armageddon Clock",
             "text": "Put one counter on Armageddon Clock during each of your upkeeps. At the end of your upkeep, each player takes damage equal to the number of counters on the Clock. Any player may spend o4 during any upkeep to remove a counter.",
             "colours": [],
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "3108f008-0f9f-51f2-9f35-e0facff6e640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcccb0f-ce96-453b-9e82-41d87f52e58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcccb0f-ce96-453b-9e82-41d87f52e58b.jpg?1",
             "name": "Ashnod's Altar",
             "text": "o0: Sacrifice one of your creatures to add 2 colorless mana to your mana pool. This effect is played as an interrupt. You may not sacrifice a creature that is already on its way to the graveyard.",
             "colours": [],
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "89582854-9011-5b30-a8c7-88ef6103914f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeec853-dd3f-4ac3-8b20-c07fada8888f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeec853-dd3f-4ac3-8b20-c07fada8888f.jpg?1",
             "name": "Ashnod's Battle Gear",
             "text": "o2: Give a creature of yours +2/-2 as long as Ashnod's Battle Gear is tapped. You may choose not to untap Ashnod's Battle Gear during untap phase.",
             "colours": [],
@@ -1282,7 +1282,7 @@
         },
         {
             "id": "eb81a30d-0113-5c65-b177-d5201be5e269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5b289-36ba-49b1-a5ac-f23bf71f8241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5b289-36ba-49b1-a5ac-f23bf71f8241.jpg?1",
             "name": "Ashnod's Transmogrant",
             "text": "Target non-artifact creature gains +1/+1 and is now considered an artifact creature, though it retains its original color. Discard Ashnod's Transmogrant after it is used.",
             "colours": [],
@@ -1309,7 +1309,7 @@
         },
         {
             "id": "45b2a364-e246-5f74-8d90-e742370a4cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a69e35-d209-41c0-aa3c-c78414617075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a69e35-d209-41c0-aa3c-c78414617075.jpg?1",
             "name": "Battering Ram",
             "text": "Bands, but only when attacking. Any wall blocking Battering Ram is destroyed. Walls destroyed this way deal their damage before dying.",
             "colours": [],
@@ -1339,7 +1339,7 @@
         },
         {
             "id": "47a60b39-e13f-5741-a332-bab38681d506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb10552-dd47-4f8a-ac7c-8c2b61e56736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb10552-dd47-4f8a-ac7c-8c2b61e56736.jpg?1",
             "name": "Bronze Tablet",
             "text": "o4: Target any card opponent has in play; remove it and Bronze Tablet from game. You become owner of that card, and your opponent becomes owner of Bronze Tablet. Exchange is permanent; play as interrupt. Opponent can prevent exchange by spending 10 life; this discards Bronze Tablet. Damage-preventing effects cannot counter such loss of life. Bronze Tablet comes into play tapped. Remove this card from deck if not playing for ante.",
             "colours": [],
@@ -1366,7 +1366,7 @@
         },
         {
             "id": "c30b2434-0f06-53e1-b79b-e98fc6c0024a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a335bf-7358-460f-b7c9-1e8bc4300f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a335bf-7358-460f-b7c9-1e8bc4300f64.jpg?1",
             "name": "Candelabra of Tawnos",
             "text": "oo\nX Untap X separate lands.",
             "colours": [],
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "ed4beaef-692d-5825-8a3c-faba028d397d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64975352-8d35-4d02-94ac-fa0c6ee12409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64975352-8d35-4d02-94ac-fa0c6ee12409.jpg?1",
             "name": "Clay Statue",
             "text": "o2: Regenerates",
             "colours": [],
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "f35653fe-6fa3-5565-9677-04e07742c570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dea8c2f-4aea-478d-aee7-cba1f74edd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dea8c2f-4aea-478d-aee7-cba1f74edd6c.jpg?1",
             "name": "Clockwork Avian",
             "text": "Flying\nPut four +1/+0 counters on Avian. After Avian attacks or blocks a creature, discard a counter.\nDuring his or her upkeep, controller may buy back lost counters for o1 per counter; this taps Avian.",
             "colours": [],
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "9edc0231-4585-5908-91bc-530b5e37c41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c44e9-1b23-42fd-9acb-daafb62c32a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c44e9-1b23-42fd-9acb-daafb62c32a2.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample\nColossus does not untap normally during untap phase; you may spend o9 during your upkeep phase to untap Colossus.",
             "colours": [],
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "ee5206cd-b4f0-5f2b-b4a0-50f2bf298ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6df9db-0a46-40a5-ae9d-59f47dae9056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6df9db-0a46-40a5-ae9d-59f47dae9056.jpg?1",
             "name": "Coral Helm",
             "text": "o3: Give target creature +2/+2 until end of turn. Each time you use this ability, you must discard one card at random from your hand. Coral Helm cannot be used if you have no cards in your hand.",
             "colours": [],
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "e5a4cd29-5cce-5fa0-80a7-44f06589505b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720d871d-1e7b-482e-bd1e-8ec79519fb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720d871d-1e7b-482e-bd1e-8ec79519fb86.jpg?1",
             "name": "Cursed Rack",
             "text": "Opponent must discard down to four cards during his or her discard phase.",
             "colours": [],
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "f8a02129-c89c-5f6a-b255-0501f8604783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07793a71-1106-4303-b620-e403bd378020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07793a71-1106-4303-b620-e403bd378020.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: +1/+0 until end of turn.",
             "colours": [],
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "a4c55bc8-a284-516a-838e-30a689e0ccf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6af436-bcfd-4d47-a1aa-e84b587a725a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6af436-bcfd-4d47-a1aa-e84b587a725a.jpg?1",
             "name": "Feldon's Cane",
             "text": "o0: Reshuffle your graveyard into your library. If Feldon's Cane is used, remove it from the game, returning it to its owner's deck only when the game is over.",
             "colours": [],
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "81388425-7e8b-56a8-b7d9-10369e1840fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856be1dd-a20b-49c2-be9d-7db76c7efd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856be1dd-a20b-49c2-be9d-7db76c7efd8b.jpg?1",
             "name": "Golgothian Sylex",
             "text": "o1: All cards from the Antiquities expansion, including Golgothian Sylex, must be discarded from play.",
             "colours": [],
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "5b2752e8-947a-562f-85ac-9238d11f689e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a7348-c82e-453c-975c-e5365e152a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a7348-c82e-453c-975c-e5365e152a3a.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "Tap to deal 1 damage to target flying creature.",
             "colours": [],
@@ -1651,7 +1651,7 @@
         },
         {
             "id": "5658fb05-55d8-51ee-96c6-f11a95491c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f23039-45ca-4c15-af50-bfd40ea26453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f23039-45ca-4c15-af50-bfd40ea26453.jpg?1",
             "name": "Ivory Tower",
             "text": "During your upkeep phase, gain 1 life for each card in your hand above four.",
             "colours": [],
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "27b3d07b-e9bf-581d-ab94-1b7a150cdceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7c5a-ee63-4a1b-9a0f-fb0a309168df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7c5a-ee63-4a1b-9a0f-fb0a309168df.jpg?1",
             "name": "Jalum Tome",
             "text": "o2: Draw a card from your library, then immediately discard a card of your choice to your graveyard.",
             "colours": [],
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "5d492ae6-cb7c-5c83-bb72-9dba7e91822a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ba599-5299-4831-a118-1712ada10ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ba599-5299-4831-a118-1712ada10ef6.jpg?1",
             "name": "Mightstone",
             "text": "All attacking creatures gain +1/+0.",
             "colours": [],
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "aae274de-d935-5ca7-a450-6812bceaf87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107646bc-2181-49f4-8821-1eaa46291855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107646bc-2181-49f4-8821-1eaa46291855.jpg?1",
             "name": "Millstone",
             "text": "o2: Take the top two cards from target player's library and put them in target player's graveyard.",
             "colours": [],
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "18295dd4-f5a8-594a-8655-2e6e6b17f603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b4652-a1d4-418f-a89b-6a977a920a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b4652-a1d4-418f-a89b-6a977a920a9e.jpg?1",
             "name": "Mishra's War Machine",
             "text": "Bands\nDuring your upkeep, discard one card of your choice from your hand, or Mishra's War Machine becomes tapped and does 3 points of damage to you.",
             "colours": [],
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "770e06ad-a595-539c-99e6-1d43f663c337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba61ccd-4429-4f7c-b9f3-30867878d88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba61ccd-4429-4f7c-b9f3-30867878d88e.jpg?1",
             "name": "Obelisk of Undoing",
             "text": "o6: Return any of your permanents in play to your hand; enchantments on that permanent are discarded. Can be used only on permanents you cast.",
             "colours": [],
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "d9e1f806-d023-5989-9340-2ee737f03025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77fe8e2-8438-473e-ace5-01baddd2c4ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77fe8e2-8438-473e-ace5-01baddd2c4ed.jpg?1",
             "name": "Onulet",
             "text": "If Onulet goes to the graveyard, its controller gains 2 life.",
             "colours": [],
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "bf1fa173-654a-5aff-a402-4d4614e03421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cc9bdb-7cf2-4795-bac7-ffff605c9eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cc9bdb-7cf2-4795-bac7-ffff605c9eb0.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "90ccad0a-0c43-5ecc-9f58-efb7c6311dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9d0e3f-cf7c-41f8-bcd7-bb08ea8cc2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9d0e3f-cf7c-41f8-bcd7-bb08ea8cc2f8.jpg?1",
             "name": "Primal Clay",
             "text": "When you cast Primal Clay, you must choose whether to make it a 1/6 wall, a 3/3 creature, or a 2/2 flying creature. Primal Clay then remains in this form until altered by another card or removed from play.",
             "colours": [],
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "5cfae833-52ae-52d7-9141-fc6efcc66275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7c711-3ff4-4691-914f-242e6737066c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7c711-3ff4-4691-914f-242e6737066c.jpg?1",
             "name": "Rakalite",
             "text": "o2: Prevent 1 damage to any target. If Rakalite is used, it returns to its owner's hand at end of turn; all enchantments on Rakalite are then discarded.",
             "colours": [],
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "12a49ccf-364a-5252-89ae-39cf5c847ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bb2093-78a8-4a6c-abe7-9a5afc181ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bb2093-78a8-4a6c-abe7-9a5afc181ec5.jpg?1",
             "name": "Rocket Launcher",
             "text": "o2: Do 1 damage to any target. Rocket Launcher may not be used until it begins a turn in play on your side. If it is used, Rocket Launcher is destroyed at end of turn.",
             "colours": [],
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "484f1f05-d8e9-5ef3-a8b8-07a9edc23f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc278af4-b60d-41b7-b9d7-36c8aefca1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc278af4-b60d-41b7-b9d7-36c8aefca1a7.jpg?1",
             "name": "Shapeshifter",
             "text": "The *s below represent any number from 0 to 6. You set * when Shapeshifter is cast, and you may change it during your upkeep.",
             "colours": [],
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "476d2ec1-6212-5308-a718-72a5850c31e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bf858d-bba9-4a16-9045-55384b1de633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bf858d-bba9-4a16-9045-55384b1de633.jpg?1",
             "name": "Staff of Zegon",
             "text": "o3: Target creature loses -2/-0 until end of turn. Creatures with power less than 1 deal no damage.",
             "colours": [],
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "685c9d21-bac0-545f-a6cc-c1041add2225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d4f93-0c04-4078-aec0-7e9de92f260f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d4f93-0c04-4078-aec0-7e9de92f260f.jpg?1",
             "name": "Su-Chi",
             "text": "If Su-Chi goes to the graveyard, its controller gains 4 colorless mana.",
             "colours": [],
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "ea0f41f1-0e3e-566e-9ad1-b796c970fcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7a2718-301f-4191-b348-0c44c7c07d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7a2718-301f-4191-b348-0c44c7c07d43.jpg?1",
             "name": "Tablet of Epityr",
             "text": "o1: You gain 1 life every time one of your artifacts goes to the graveyard. Can only give 1 life each time an artifact reaches the graveyard.",
             "colours": [],
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "81527540-94fa-5e90-8853-7d0b9ac68a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27bc1de-8246-4dc8-af51-ec21def9e226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27bc1de-8246-4dc8-af51-ec21def9e226.jpg?1",
             "name": "Tawnos's Coffin",
             "text": "o3: Select a creature in play; that creature is considered out of play as long as Coffin remains tapped. Hence the creature cannot be the target of spells and cannot receive damage, use special powers, attack, or defend. All counters and enchantments on the creature remain but are also out of play. If Coffin is untapped or removed, creature returns to play tapped. You may choose not to untap Coffin during the untap phase.",
             "colours": [],
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "9e44fef0-b169-5493-b274-a13cf27d4f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f09dd-121a-4da5-ba16-5c03fbdce084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f09dd-121a-4da5-ba16-5c03fbdce084.jpg?1",
             "name": "Tawnos's Wand",
             "text": "o2: Make a creature of power no greater than 2 unblockable by all creatures except artifact creatures until end of turn. Other cards may be used to increase target creature's power beyond 2 after defense is chosen.",
             "colours": [],
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "2012a5ac-9d24-5d6e-9931-7435a3d26903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035cead-a501-4204-9154-5fd648577d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035cead-a501-4204-9154-5fd648577d32.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "o2: Target creature gains +1/+1 as long as Tawnos's Weaponry remains tapped. You may choose not to untap Tawnos's Weaponry during untap phase.",
             "colours": [],
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "38792f46-6fa4-5afb-aca9-db8d4732fd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca371f0-e7c9-4154-8e1d-47576c0202bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca371f0-e7c9-4154-8e1d-47576c0202bc.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "",
             "colours": [],
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "23d749b2-d958-51e5-a251-9ae96ae09bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb19f9-2e8f-4bf0-9bf8-868e6da70e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb19f9-2e8f-4bf0-9bf8-868e6da70e2d.jpg?1",
             "name": "Tetravus",
             "text": "Flying\nTetravus gets three +1/+1 counters when cast. During your upkeep, you may move each of these counters on or off Tetravus.  Counters moved off of Tetravus become independent 1/1 flying artifact creatures.  If such a creature dies, the counter is removed from play.  Such creatures may not have enchantments cast on them, and they do not share any enchantments on Tetravus.",
             "colours": [],
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "8282dfbf-e403-599c-88f9-89b77a95c303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0686ba-1277-4412-a397-7a6227808311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0686ba-1277-4412-a397-7a6227808311.jpg?1",
             "name": "The Rack",
             "text": "If opponent has fewer than three cards in hand during his or her upkeep, the Rack does 1 damage to opponent for each card fewer than three.",
             "colours": [],
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "93b4c02e-bca7-52e7-9cdf-5e5bb924315a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c99e1-722a-44b6-8fa3-2be3f0c193d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c99e1-722a-44b6-8fa3-2be3f0c193d8.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion gets three +1/+1 counters when cast. Controller may discard a +1/+1 counter at any time to do 1 damage to any target.",
             "colours": [],
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "d1454386-64d1-52f3-b1be-baf1786ddc17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448e1811-fb16-4390-ac22-b7066a4a019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448e1811-fb16-4390-ac22-b7066a4a019c.jpg?1",
             "name": "Urza's Avenger",
             "text": "o0: Avenger loses -1/-1 and gains one of your choice of flying, banding, first strike, or trample until end of turn. Attribute losses and ability gains are cumulative.",
             "colours": [],
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "e11d3332-fa89-5f0c-bbc0-916b89e52fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3728537-86d3-42be-9046-90bba1bfafc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3728537-86d3-42be-9046-90bba1bfafc1.jpg?1",
             "name": "Urza's Chalice",
             "text": "o1: Any artifact cast by any player gives you 1 life. Can only give 1 life each time an artifact is cast.",
             "colours": [],
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "14f6fa46-4534-5a82-b31d-ec7b428e76e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438f0c61-a61d-4a9e-b21f-4e86420c7913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438f0c61-a61d-4a9e-b21f-4e86420c7913.jpg?1",
             "name": "Urza's Miter",
             "text": "o3: Draw one card from your library every time an artifact of yours goes to the graveyard. Can only let you draw one card per artifact destruction. May not be used when you destroy an artifact to gain benefits from another card.",
             "colours": [],
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "c526289b-a705-5350-a7fe-d72b312c6f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dda179-c49a-4995-ba5a-db93ac43dbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dda179-c49a-4995-ba5a-db93ac43dbe7.jpg?1",
             "name": "Wall of Spears",
             "text": "First strike, counts as a wall.",
             "colours": [],
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "a072feb1-0ada-594c-be41-88f7b72618f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46adf48f-99d2-440e-9129-794584c1ea21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46adf48f-99d2-440e-9129-794584c1ea21.jpg?1",
             "name": "Weakstone",
             "text": "All attacking creatures lose -1/-0. Creatures with power less than 1 deal no damage.",
             "colours": [],
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "bb438a2c-feba-5e98-841b-dcce02d063b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27cf53e3-76f6-4831-800e-1259394d779d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27cf53e3-76f6-4831-800e-1259394d779d.jpg?1",
             "name": "Yotian Soldier",
             "text": "Attacking does not cause Yotian Soldier to tap.",
             "colours": [],
@@ -2444,7 +2444,7 @@
         },
         {
             "id": "927c9c55-20a2-5ae1-a64f-31495b5d4d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a696c5b6-f216-454d-8029-74e84bbd1428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a696c5b6-f216-454d-8029-74e84bbd1428.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "d947adc6-97e9-5acf-be62-3ebd8b00c7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4047df9c-335c-4c1a-968d-00f40e2e7386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4047df9c-335c-4c1a-968d-00f40e2e7386.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "d8ad1e4e-4bc5-5c9f-a860-f5a48b02e9f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44669b2-bf9a-41c3-91c7-d845b0061fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44669b2-bf9a-41c3-91c7-d845b0061fbf.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "a29a3bd1-465b-5c6c-9220-24f433f38f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac09a506-427f-4636-bcfd-b40f8d511905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac09a506-427f-4636-bcfd-b40f8d511905.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "4938b0bf-0804-58a4-b08c-28eaa0d50b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135de5c7-6ac9-4b68-8f1a-97f120a4b125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135de5c7-6ac9-4b68-8f1a-97f120a4b125.jpg?1",
             "name": "Mishra's Workshop",
             "text": "Tap to add 3 colorless mana to your mana pool. This mana may only be used to cast artifacts.",
             "colours": [],
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "b769fe08-b7ac-55ac-a271-5071c335cd45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7880157-7f27-4f1b-9cdc-ab36a6252376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7880157-7f27-4f1b-9cdc-ab36a6252376.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "51340ce9-e346-5866-850b-44a8c939cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48bd745-5e9f-4807-97b0-29222a5b838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48bd745-5e9f-4807-97b0-29222a5b838d.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "5c14e66e-3a74-57bf-916e-07bd777346b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e98db-a0c4-4836-9e4b-3fda142eedf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e98db-a0c4-4836-9e4b-3fda142eedf6.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "4506940f-2074-5217-9e4c-d0686f89d7e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f6a92f-edd8-4cb6-be91-f3ec229b20a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f6a92f-edd8-4cb6-be91-f3ec229b20a6.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2719,7 +2719,7 @@
         },
         {
             "id": "07fff1b2-e42f-57fb-bb5b-f2d7811b849e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf85792-470b-4b42-99ac-9cb43a575523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf85792-470b-4b42-99ac-9cb43a575523.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "c3209e37-85dd-51dc-911d-d56541017839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27886da1-9161-4bed-81b5-06da21a25f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27886da1-9161-4bed-81b5-06da21a25f91.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "b283ac99-3b95-55be-9c4d-c93cf9d3bde3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da68a5c0-84fe-4a8f-93b2-790eca3cc95c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da68a5c0-84fe-4a8f-93b2-790eca3cc95c.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2821,7 +2821,7 @@
         },
         {
             "id": "a41407e3-c878-50bf-8b99-6423266b923e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8617d2-a0e9-4fb4-85da-2c7e385be3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8617d2-a0e9-4fb4-85da-2c7e385be3f6.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2855,7 +2855,7 @@
         },
         {
             "id": "dd2315b3-8e04-5f9e-bcb8-1802eeac49d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94896e0b-859c-47e4-bf27-35ed37b841e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94896e0b-859c-47e4-bf27-35ed37b841e0.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "04f6bbac-81d2-5ae7-ae0d-e18ef003760c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e237d921-6d84-402e-b5e3-6bbdb3028f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e237d921-6d84-402e-b5e3-6bbdb3028f57.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "21491a40-9e69-5c60-9594-44f62f44a6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc02459-83ae-4b6c-85a1-26eeaf7a2ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc02459-83ae-4b6c-85a1-26eeaf7a2ee7.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "a38bd19b-0272-5b82-9f7c-be82514e5bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bbe643-3e07-4541-a2e6-45c63a5133cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bbe643-3e07-4541-a2e6-45c63a5133cf.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "e555dd4a-3b70-5579-b4e0-5ed49b9892b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed85655-fc59-4a57-bcf9-75e1899dff78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed85655-fc59-4a57-bcf9-75e1899dff78.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "82c21ea8-a057-55f0-bab1-7ead4bee5ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aba1f0f-73b0-4898-8d07-43322e43d74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aba1f0f-73b0-4898-8d07-43322e43d74e.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],
@@ -3059,7 +3059,7 @@
         },
         {
             "id": "5d31d685-4a95-5674-a175-398ce3e2feed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a03554a-0ee7-4106-b3e4-4bc51f48032d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a03554a-0ee7-4106-b3e4-4bc51f48032d.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "7d956150-e28d-5468-ab92-95f38675ddb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78f2e5-c02b-4f58-8510-660ca27d9a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78f2e5-c02b-4f58-8510-660ca27d9a71.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/AVR.json
+++ b/Assets/Resources/Sets/AVR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1bb3e236-992e-51f8-95f4-c61a89901a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8be765-0949-491c-875c-0385fb83e4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8be765-0949-491c-875c-0385fb83e4b9.jpg?1",
             "name": "Angel of Glory's Rise",
             "text": "Flying\nWhen Angel of Glory's Rise enters the battlefield, exile all Zombies, then return all Human creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "ccaa2df4-67e5-5e73-b5c6-d07a769b14a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5dfed-4dee-4e48-a445-89f03d7794e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5dfed-4dee-4e48-a445-89f03d7794e6.jpg?1",
             "name": "Angel of Jubilation",
             "text": "Flying\nOther nonblack creatures you control get +1/+1.\nPlayers can't pay life or sacrifice creatures to cast spells or activate abilities.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "5d324527-2765-5ac0-94da-4a8e623a432d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a437999-26ae-49fa-8647-c8c2b4640702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a437999-26ae-49fa-8647-c8c2b4640702.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "e7ce43af-ce65-5ba7-b913-168148343a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b2450d-87a7-46dc-b43a-2db2abeca44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b2450d-87a7-46dc-b43a-2db2abeca44f.jpg?1",
             "name": "Angelic Wall",
             "text": "Defender, flying",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "d0f7989f-fb29-59d9-9da6-a19e9157f8f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741b2a7-7bda-481a-b8f8-9b04c96035b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741b2a7-7bda-481a-b8f8-9b04c96035b0.jpg?1",
             "name": "Archangel",
             "text": "Flying, vigilance",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "2ed7c882-83c3-5867-87bc-5a6c8e69db56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba149706-cd17-4da6-8403-ccfe2d6cb437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba149706-cd17-4da6-8403-ccfe2d6cb437.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance\nAvacyn, Angel of Hope and other permanents you control are indestructible.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "ca0faf82-518f-5642-a609-71fef4f59f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238d8437-1abd-4bb7-8b5b-54f959bc2c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238d8437-1abd-4bb7-8b5b-54f959bc2c79.jpg?1",
             "name": "Banishing Stroke",
             "text": "Put target artifact, creature, or enchantment on the bottom of its owner's library.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "fb8f7089-f6ba-5e4b-a2a3-45c2a0354323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad27af1-b482-40d5-9dbb-11201ffa0410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad27af1-b482-40d5-9dbb-11201ffa0410.jpg?1",
             "name": "Builder's Blessing",
             "text": "Untapped creatures you control get +0/+2.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "a92899bd-56fd-5d64-9824-df755deb1038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4a3e80-6e95-4346-8ab8-eecc1a09ca24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4a3e80-6e95-4346-8ab8-eecc1a09ca24.jpg?1",
             "name": "Call to Serve",
             "text": "Enchant nonblack creature\nEnchanted creature gets +1/+2, has flying, and is an Angel in addition to its other types.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "13af6bdd-a412-5eef-9f41-328314b9f007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78154978-9e7d-44e9-a03f-c578072a8ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78154978-9e7d-44e9-a03f-c578072a8ff7.jpg?1",
             "name": "Cathars' Crusade",
             "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "3f2aa9f7-85e8-5586-866d-a9ed46ddd923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cac47a-9e83-4039-8d80-fa9bdadb7527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cac47a-9e83-4039-8d80-fa9bdadb7527.jpg?1",
             "name": "Cathedral Sanctifier",
             "text": "When Cathedral Sanctifier enters the battlefield, you gain 3 life.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "3e2a0249-7f9f-5487-accf-4be7bd5000c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b06c8f-5f08-43bd-a548-2a98ba30fd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b06c8f-5f08-43bd-a548-2a98ba30fd41.jpg?1",
             "name": "Cloudshift",
             "text": "Exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -405,7 +405,7 @@
         },
         {
             "id": "679c2039-414f-59bc-b6a4-5c940402e8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ef4383-11e7-4426-a04a-058570f46e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ef4383-11e7-4426-a04a-058570f46e47.jpg?1",
             "name": "Commander's Authority",
             "text": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, put a 1/1 white Human creature token onto the battlefield.\"",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "0c857ed6-0c8b-5634-9107-22a39768e521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71a0883-316c-4870-a029-25f16952fbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71a0883-316c-4870-a029-25f16952fbc0.jpg?1",
             "name": "Cursebreak",
             "text": "Destroy target enchantment. You gain 2 life.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "e334cdc8-2614-5d3d-abdf-c1f28f3a0a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12fee0b-c237-4188-a718-1572f72c63ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12fee0b-c237-4188-a718-1572f72c63ba.jpg?1",
             "name": "Defang",
             "text": "Enchant creature\nPrevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -505,7 +505,7 @@
         },
         {
             "id": "241a806b-e40c-55ef-8546-1eaf93d53aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028028d7-80ff-4d63-8b84-795f257a3456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028028d7-80ff-4d63-8b84-795f257a3456.jpg?1",
             "name": "Defy Death",
             "text": "Return target creature card from your graveyard to the battlefield. If it's an Angel, put two +1/+1 counters on it.",
             "colours": [
@@ -537,7 +537,7 @@
         },
         {
             "id": "b88706af-5749-5f33-88e6-f8948542d171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ceb7f1-14b7-4102-ade2-fbeb835d3804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ceb7f1-14b7-4102-ade2-fbeb835d3804.jpg?1",
             "name": "Devout Chaplain",
             "text": "{T}, Tap two untapped Humans you control: Exile target artifact or enchantment.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "92cdca9e-ba50-50ba-abbe-31122727c4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec06e42f-e294-44ef-8fa8-1d1a4c2090d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec06e42f-e294-44ef-8fa8-1d1a4c2090d8.jpg?1",
             "name": "Divine Deflection",
             "text": "Prevent the next X damage that would be dealt to you and/or permanents you control this turn. If damage is prevented this way, Divine Deflection deals that much damage to target creature or player.",
             "colours": [
@@ -604,7 +604,7 @@
         },
         {
             "id": "f88e24d3-1606-5cb8-ac7d-9162d5a59104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bc00e-28ca-4152-b832-f36425d2b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bc00e-28ca-4152-b832-f36425d2b615.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -638,7 +638,7 @@
         },
         {
             "id": "93d5fc46-7b67-5524-a364-83938e9bb944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31292616-70e6-4d19-a883-e63ad860f50c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31292616-70e6-4d19-a883-e63ad860f50c.jpg?1",
             "name": "Entreat the Angels",
             "text": "Put X 4/4 white Angel creature tokens with flying onto the battlefield.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -670,7 +670,7 @@
         },
         {
             "id": "7078f0b7-6fe4-5dfe-ac09-3b96ebfac7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489c6a2f-38b4-4ff9-95f7-431384480ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489c6a2f-38b4-4ff9-95f7-431384480ed9.jpg?1",
             "name": "Farbog Explorer",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "eb14ee08-8ea5-5c82-b25f-587e368a8a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ebec82-9d4a-4e78-b923-37c3a52133e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ebec82-9d4a-4e78-b923-37c3a52133e7.jpg?1",
             "name": "Goldnight Commander",
             "text": "Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "98f51f50-4cdc-57c0-a8fe-0713d01dce57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5656e3-5f53-41f8-9f24-04caad5e4ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5656e3-5f53-41f8-9f24-04caad5e4ca3.jpg?1",
             "name": "Goldnight Redeemer",
             "text": "Flying\nWhen Goldnight Redeemer enters the battlefield, you gain 2 life for each other creature you control.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "66e00850-7250-5e0a-91c5-a5c94a19874b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e92bbb-c22d-4879-9437-b87a3ff70a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e92bbb-c22d-4879-9437-b87a3ff70a2d.jpg?1",
             "name": "Herald of War",
             "text": "Flying\nWhenever Herald of War attacks, put a +1/+1 counter on it.\nAngel spells and Human spells you cast cost {1} less to cast for each +1/+1 counter on Herald of War.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "0b9025d0-02fb-558f-b69e-aeb6cfa78deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cad49-1db3-4611-a80d-7ce95f000fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cad49-1db3-4611-a80d-7ce95f000fad.jpg?1",
             "name": "Holy Justiciar",
             "text": "{2}{W}, {T}: Tap target creature. If that creature is a Zombie, exile it.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "74153b9c-af8a-5f75-8754-be7fea4be20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba52aed-440c-4b32-8f25-0c5364441712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba52aed-440c-4b32-8f25-0c5364441712.jpg?1",
             "name": "Leap of Faith",
             "text": "Target creature gains flying until end of turn. Prevent all damage that would be dealt to that creature this turn.",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "856cb03c-92dd-5224-b366-2913185e978a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371bd0c-ca38-4a62-b525-bef4d1ca0646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371bd0c-ca38-4a62-b525-bef4d1ca0646.jpg?1",
             "name": "Midnight Duelist",
             "text": "Protection from Vampires",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "95192ca6-1a79-51be-8029-ca1aef4d1abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6214f-90cb-4575-b221-3c8d0ed65ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6214f-90cb-4575-b221-3c8d0ed65ffe.jpg?1",
             "name": "Midvast Protector",
             "text": "When Midvast Protector enters the battlefield, target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "290044cc-ace2-5249-a621-41534dddc016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf4c4cf-df35-4725-81ca-d62b70b8d0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf4c4cf-df35-4725-81ca-d62b70b8d0dd.jpg?1",
             "name": "Moonlight Geist",
             "text": "Flying\n{3}{W}: Prevent all combat damage that would be dealt to and dealt by Moonlight Geist this turn.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "0a5e4992-aa45-5d93-8b01-466a46cca2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dbbea-9995-4e4b-ba5c-d6d5597e4ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dbbea-9995-4e4b-ba5c-d6d5597e4ace.jpg?1",
             "name": "Moorland Inquisitor",
             "text": "{2}{W}: Moorland Inquisitor gains first strike until end of turn.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "39d1390d-3ff7-5c7b-a50c-caf2ff262ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81d6fe0-c7c2-46a6-811c-f121284937ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81d6fe0-c7c2-46a6-811c-f121284937ea.jpg?1",
             "name": "Nearheath Pilgrim",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Nearheath Pilgrim is paired with another creature, both creatures have lifelink.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "c091d31c-9544-57df-acbe-7b055b56b1b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8639-e586-47f4-baca-2a1af5aa281b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8639-e586-47f4-baca-2a1af5aa281b.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "0c336c62-4316-5b92-9220-578bf7bf70c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1647b-9271-4426-9938-7eb620ad0769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1647b-9271-4426-9938-7eb620ad0769.jpg?1",
             "name": "Riders of Gavony",
             "text": "Vigilance\nAs Riders of Gavony enters the battlefield, choose a creature type.\nHuman creatures you control have protection from creatures of the chosen type.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "5eb5afc7-9629-5f9d-bfce-c0b36cd520ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b640fdc-7a19-475e-858f-e159f61e154e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b640fdc-7a19-475e-858f-e159f61e154e.jpg?1",
             "name": "Righteous Blow",
             "text": "Righteous Blow deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -1151,7 +1151,7 @@
         },
         {
             "id": "7ca912a5-4157-5d84-b537-cbf6db3830df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da345bd-8f2b-4966-97f5-c0e4c6cfe3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da345bd-8f2b-4966-97f5-c0e4c6cfe3b7.jpg?1",
             "name": "Seraph of Dawn",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "85d54976-1824-5f99-86e7-a1d481eb045a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16298ca0-80d4-4299-a550-500b7ef6ac67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16298ca0-80d4-4299-a550-500b7ef6ac67.jpg?1",
             "name": "Silverblade Paladin",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Silverblade Paladin is paired with another creature, both creatures have double strike.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "08cf2f7c-45bd-5ebe-8293-30932fb07c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f774e0eb-5c05-4a9e-8ab7-9ee4c7741591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f774e0eb-5c05-4a9e-8ab7-9ee4c7741591.jpg?1",
             "name": "Spectral Gateguards",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Spectral Gateguards is paired with another creature, both creatures have vigilance.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "6c4a281a-bcb7-5207-838c-fd5737b5bca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0982ea7e-05a4-4e40-98ab-ea9aa6c7342e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0982ea7e-05a4-4e40-98ab-ea9aa6c7342e.jpg?1",
             "name": "Terminus",
             "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "e3318fe1-0b3d-52ce-87fc-5ae920ccd84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20558f69-9240-49b9-9695-caf75ee2db1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20558f69-9240-49b9-9695-caf75ee2db1b.jpg?1",
             "name": "Thraben Valiant",
             "text": "Vigilance",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "810198a7-1d0b-5430-a9e0-29f9c1397df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b785276b-3778-49f3-b46f-a1f3d91db097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b785276b-3778-49f3-b46f-a1f3d91db097.jpg?1",
             "name": "Voice of the Provinces",
             "text": "Flying\nWhen Voice of the Provinces enters the battlefield, put a 1/1 white Human creature token onto the battlefield.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "321f0392-0cf0-51b8-9c1a-bab1b777f146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a01fb-dd47-44de-b528-8b7ca4b3388b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a01fb-dd47-44de-b528-8b7ca4b3388b.jpg?1",
             "name": "Zealous Strike",
             "text": "Target creature gets +2/+2 and gains first strike until end of turn.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "7993d5ce-462a-5224-b02b-202fd4826abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abba67-1241-4fb3-88b5-4c4668ec5f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abba67-1241-4fb3-88b5-4c4668ec5f25.jpg?1",
             "name": "Alchemist's Apprentice",
             "text": "Sacrifice Alchemist's Apprentice: Draw a card.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "d335e275-d305-5b83-9afe-2fc247b4e58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b48d60-fc99-4d21-9293-4f7ce1c02928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b48d60-fc99-4d21-9293-4f7ce1c02928.jpg?1",
             "name": "Amass the Components",
             "text": "Draw three cards, then put a card from your hand on the bottom of your library.",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "4e0997a5-a04f-5960-b114-61d0af9372a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32355574-34ed-4427-86d9-72295d32ac4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32355574-34ed-4427-86d9-72295d32ac4f.jpg?1",
             "name": "Arcane Melee",
             "text": "Instant and sorcery spells cost {2} less to cast.",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "a773aba9-a7b2-5c94-9196-0bcadcbe21d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43aa68e-a182-4006-b4d6-b4fc67e68583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43aa68e-a182-4006-b4d6-b4fc67e68583.jpg?1",
             "name": "Captain of the Mists",
             "text": "Whenever another Human enters the battlefield under your control, untap Captain of the Mists.\n{1}{U}, {T}: You may tap or untap target permanent.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "dbc34186-3499-5a03-b655-e434bfbc132e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79791bd9-aded-48d9-866d-9f7bd6848905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79791bd9-aded-48d9-866d-9f7bd6848905.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "66867265-8e32-534c-9195-e7322be214f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa94262b-f740-48fb-a937-75776864c9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa94262b-f740-48fb-a937-75776864c9ee.jpg?1",
             "name": "Deadeye Navigator",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Deadeye Navigator is paired with another creature, each of those creatures has \"{1}{U}: Exile this creature, then return it to the battlefield under your control.\"",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "2bc136dd-bec0-52a2-ab88-3b4f1c6c221a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b62be6-1a80-4f16-a94a-374203052662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b62be6-1a80-4f16-a94a-374203052662.jpg?1",
             "name": "Devastation Tide",
             "text": "Return all nonland permanents to their owners' hands.\nMiracle {1}{U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "dbb38f70-ab7b-5dc7-aff6-97ce07576cf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88245a41-d4d5-46bf-969f-48d4dd540e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88245a41-d4d5-46bf-969f-48d4dd540e2c.jpg?1",
             "name": "Dreadwaters",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of lands you control.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "1162119e-537d-55cd-8c1f-8c130944da62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d376ef-c900-4abb-9a0b-5eb9369f5739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d376ef-c900-4abb-9a0b-5eb9369f5739.jpg?1",
             "name": "Elgaud Shieldmate",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Elgaud Shieldmate is paired with another creature, both creatures have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "707a90f7-d5f7-5f6e-b1d2-d885104ab5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg?1",
             "name": "Favorable Winds",
             "text": "Creatures you control with flying get +1/+1.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "978246c2-aaff-58a8-b742-d8095dc041ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e89ef0e-1bfe-4e12-90ee-38f993cd8110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e89ef0e-1bfe-4e12-90ee-38f993cd8110.jpg?1",
             "name": "Fettergeist",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Fettergeist unless you pay {1} for each other creature you control.",
             "colours": [
@@ -1753,7 +1753,7 @@
         },
         {
             "id": "1451f183-4a75-5409-af6b-9a4789a3d470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba49d16-e3e4-470a-8ca2-a93a5b358f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba49d16-e3e4-470a-8ca2-a93a5b358f6e.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "57ffd28a-f8a6-584d-8b33-38f4c9b8fd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e24d65-0e6f-4978-8de1-c5e4acac12fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e24d65-0e6f-4978-8de1-c5e4acac12fb.jpg?1",
             "name": "Galvanic Alchemist",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Galvanic Alchemist is paired with another creature, each of those creatures has \"{2}{U}: Untap this creature.\"",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "cd8ee5b9-9402-565e-b921-02baf2db6d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dac5db-ef96-4bd5-aabc-e5ae2b95c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dac5db-ef96-4bd5-aabc-e5ae2b95c8c3.jpg?1",
             "name": "Geist Snatch",
             "text": "Counter target creature spell. Put a 1/1 blue Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "c0bb7489-ebcd-5a3f-996d-a08bd92c97c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg?1",
             "name": "Ghostform",
             "text": "Up to two target creatures are unblockable this turn.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "f4cc10e0-3c88-5854-ab91-4de1386cfae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a44373-0c50-4e14-a7c6-0de66796b81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a44373-0c50-4e14-a7c6-0de66796b81e.jpg?1",
             "name": "Ghostly Flicker",
             "text": "Exile two target artifacts, creatures, and/or lands you control, then return those cards to the battlefield under your control.",
             "colours": [
@@ -1916,7 +1916,7 @@
         },
         {
             "id": "617728e3-514b-530a-a563-2986df4c6798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebae54a-47e0-4e82-8a29-b5d9354a748b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebae54a-47e0-4e82-8a29-b5d9354a748b.jpg?1",
             "name": "Ghostly Touch",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, you may tap or untap target permanent.\"",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "3f8fece2-0a15-5df4-8258-7f3b88e81890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7238136-c8de-4949-9b54-ff75094e0569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7238136-c8de-4949-9b54-ff75094e0569.jpg?1",
             "name": "Gryff Vanguard",
             "text": "Flying\nWhen Gryff Vanguard enters the battlefield, draw a card.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "7de9703e-6b9c-5652-898b-1bd9ee8c8249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7ff97f-fb06-4a61-98cd-50965a6522d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7ff97f-fb06-4a61-98cd-50965a6522d4.jpg?1",
             "name": "Havengul Skaab",
             "text": "Whenever Havengul Skaab attacks, return another creature you control to its owner's hand.",
             "colours": [
@@ -2020,7 +2020,7 @@
         },
         {
             "id": "000ed184-57ec-5b1e-a900-5d770a945999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42506c54-e9bf-4d0f-8dd5-8b218668c925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42506c54-e9bf-4d0f-8dd5-8b218668c925.jpg?1",
             "name": "Infinite Reflection",
             "text": "Enchant creature\nWhen Infinite Reflection enters the battlefield attached to a creature, each other nontoken creature you control becomes a copy of that creature.\nNontoken creatures you control enter the battlefield as a copy of enchanted creature.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "3b58a9b0-2455-5529-a416-2eac4a012bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddd1050-8abd-4dfe-9e52-5b56af358653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddd1050-8abd-4dfe-9e52-5b56af358653.jpg?1",
             "name": "Into the Void",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "5360a47e-419c-5812-bef4-a380ad0ed900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e7589-9cee-4d57-8648-ce733781bfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e7589-9cee-4d57-8648-ce733781bfb2.jpg?1",
             "name": "Latch Seeker",
             "text": "Latch Seeker is unblockable.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "531df4fa-eb0a-5063-ae9e-41132abc5bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e12186e-9c93-4136-9ea3-e8d2ae1ee2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e12186e-9c93-4136-9ea3-e8d2ae1ee2e5.jpg?1",
             "name": "Lone Revenant",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Lone Revenant deals combat damage to a player, if you control no other creatures, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "aa30f137-99f5-5536-8a2c-dcebbfd6b7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346d236-528c-4164-9995-74cdc56597a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346d236-528c-4164-9995-74cdc56597a9.jpg?1",
             "name": "Lunar Mystic",
             "text": "Whenever you cast an instant spell, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "ebd0e2c0-bf16-57e3-b9ff-3e56f5626343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9ae51-fd2b-45ca-a780-725f51f897b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9ae51-fd2b-45ca-a780-725f51f897b2.jpg?1",
             "name": "Mass Appeal",
             "text": "Draw a card for each Human you control.",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "a9de2b4a-59f1-55cc-82df-3aa990c6ada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f0c4-021a-407a-8b0c-5500d804f959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f0c4-021a-407a-8b0c-5500d804f959.jpg?1",
             "name": "Mist Raven",
             "text": "Flying\nWhen Mist Raven enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "913a1d0f-fb29-57f2-9156-5ac27f377467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db4fe28-e580-479b-910f-b719d69468b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db4fe28-e580-479b-910f-b719d69468b1.jpg?1",
             "name": "Misthollow Griffin",
             "text": "Flying\nYou may cast Misthollow Griffin from exile.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "b13ddad1-affc-515b-b802-bc794eb5a27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a531b2f-2a9e-4cc9-aea6-9dce239f5511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a531b2f-2a9e-4cc9-aea6-9dce239f5511.jpg?1",
             "name": "Nephalia Smuggler",
             "text": "{3}{U}, {T}: Exile another target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "46294611-e685-5f2e-b100-be327c720fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429f7cf0-579a-4003-b5cf-4baf5d420796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429f7cf0-579a-4003-b5cf-4baf5d420796.jpg?1",
             "name": "Outwit",
             "text": "Counter target spell that targets a player.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "b15e5ead-4055-539e-9833-8a768ab682cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41285b-5961-4653-96a0-fb6d27111390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41285b-5961-4653-96a0-fb6d27111390.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "efe4c9a5-29ca-5629-be93-fdc7c6341e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b5ba6-0de1-4f5c-867b-57e2c10bde8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b5ba6-0de1-4f5c-867b-57e2c10bde8e.jpg?1",
             "name": "Rotcrown Ghoul",
             "text": "When Rotcrown Ghoul dies, target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2422,7 +2422,7 @@
         },
         {
             "id": "33c712ec-25cc-5127-a6f7-765c97c77349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f03bae-1d23-43ea-9079-4b09d61bbadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f03bae-1d23-43ea-9079-4b09d61bbadd.jpg?1",
             "name": "Scrapskin Drake",
             "text": "Flying\nScrapskin Drake can block only creatures with flying.",
             "colours": [
@@ -2457,7 +2457,7 @@
         },
         {
             "id": "792de4bb-9c00-5afa-9819-8688f1865e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d22d093-8e89-4d54-ac04-14c8759de3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d22d093-8e89-4d54-ac04-14c8759de3ea.jpg?1",
             "name": "Second Guess",
             "text": "Counter target spell that's the second spell cast this turn.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "4632015d-608b-5a42-b27c-f604b80fd0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d141bc-7307-40c2-a7ed-427caaec5efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d141bc-7307-40c2-a7ed-427caaec5efc.jpg?1",
             "name": "Spectral Prison",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nWhen enchanted creature becomes the target of a spell, sacrifice Spectral Prison.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "279edbfa-2d00-5e0f-ab43-668387d6491f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8823bdc-0467-47f1-9bef-a281b4a7071d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8823bdc-0467-47f1-9bef-a281b4a7071d.jpg?1",
             "name": "Spirit Away",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "d3cda24d-3839-5116-ad15-957e66a6c76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe4d34f-68f0-4d79-9aab-58c5304224d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe4d34f-68f0-4d79-9aab-58c5304224d9.jpg?1",
             "name": "Stern Mentor",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Stern Mentor is paired with another creature, each of those creatures has \"{T}: Target player puts the top two cards of his or her library into his or her graveyard.\"",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "c774c073-74c4-595d-ba1b-666d7dee2c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53203dfc-5ad5-4c17-9802-ca2f874d327a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53203dfc-5ad5-4c17-9802-ca2f874d327a.jpg?1",
             "name": "Stolen Goods",
             "text": "Target opponent exiles cards from the top of his or her library until he or she exiles a nonland card. Until end of turn, you may cast that card without paying its mana cost.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "b1639e5a-3436-52b2-b977-bab544345fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9398926-13b9-47b8-b66b-1ab9d06bb704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9398926-13b9-47b8-b66b-1ab9d06bb704.jpg?1",
             "name": "Tamiyo, the Moon Sage",
             "text": "+1: Tap target permanent. It doesn't untap during its controller's next untap step.\n-2: Draw a card for each tapped creature target player controls.\n-8: You get an emblem with \"You have no maximum hand size\" and \"Whenever a card is put into your graveyard from anywhere, you may return it to your hand.\"",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "33b275b6-d040-5851-920b-40bc7d4d3e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83564e67-2677-4955-a3b9-3b221dbb100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83564e67-2677-4955-a3b9-3b221dbb100b.jpg?1",
             "name": "Tandem Lookout",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Tandem Lookout is paired with another creature, each of those creatures has \"Whenever this creature deals damage to an opponent, draw a card.\"",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "19b07896-e129-5fcf-841d-8abc2b23be0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266e5267-2288-4bb0-8c54-0c556521cec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266e5267-2288-4bb0-8c54-0c556521cec3.jpg?1",
             "name": "Temporal Mastery",
             "text": "Take an extra turn after this one. Exile Temporal Mastery.\nMiracle {1}{U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "f45d0f07-1dfd-50df-9ea5-10a6f25d01ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece40c1-790c-4471-a790-1d356b345603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece40c1-790c-4471-a790-1d356b345603.jpg?1",
             "name": "Vanishment",
             "text": "Put target nonland permanent on top of its owner's library.\nMiracle {U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "3ed34ffa-4dce-584a-80f7-130865c22d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a3059f-92f2-4163-b79a-154118a4e36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a3059f-92f2-4163-b79a-154118a4e36d.jpg?1",
             "name": "Wingcrafter",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Wingcrafter is paired with another creature, both creatures have flying.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "ec25d579-bd75-55f0-8016-c1d081d271cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062ee892-cce7-42bd-97c7-032cec61faca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062ee892-cce7-42bd-97c7-032cec61faca.jpg?1",
             "name": "Appetite for Brains",
             "text": "Target opponent reveals his or her hand. You choose a card from it with converted mana cost 4 or greater and exile that card.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "505f1717-370e-5b3f-82bf-9a8f7c8a1644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b4fab6-73ce-4a56-a305-4d2e93dbb4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b4fab6-73ce-4a56-a305-4d2e93dbb4ee.jpg?1",
             "name": "Barter in Blood",
             "text": "Each player sacrifices two creatures.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "493ee06d-f040-5e78-9f7e-75f19d556238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1fb442-68ff-4249-8e44-87edf6fae211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1fb442-68ff-4249-8e44-87edf6fae211.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "4d2e5601-07dc-5729-ba78-1ed0add3c3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97485dbf-2f31-4ed2-a6cd-529ca22c9ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97485dbf-2f31-4ed2-a6cd-529ca22c9ac5.jpg?1",
             "name": "Bloodflow Connoisseur",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "1b6aae59-3454-5081-be2e-b7b64e2f461a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387eda28-f35b-48b0-ba59-773d82902327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387eda28-f35b-48b0-ba59-773d82902327.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "511986a6-5629-54d9-982b-27b38331e58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg?1",
             "name": "Butcher Ghoul",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2992,7 +2992,7 @@
         },
         {
             "id": "8b184e27-d0d6-513b-893f-2c9658095cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3eed10-7a8f-4c89-8be8-389f979e10b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3eed10-7a8f-4c89-8be8-389f979e10b7.jpg?1",
             "name": "Corpse Traders",
             "text": "{2}{B}, Sacrifice a creature: Target opponent reveals his or her hand. You choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "a1415a83-cf21-5d47-8089-edd899bd7912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0382cb94-0836-4e23-99b7-034faa363203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0382cb94-0836-4e23-99b7-034faa363203.jpg?1",
             "name": "Crypt Creeper",
             "text": "Sacrifice Crypt Creeper: Exile target card from a graveyard.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "89b2a84b-0367-5d77-a4f5-12dde8a488d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5e8815-cda8-407d-847c-968b72c061e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5e8815-cda8-407d-847c-968b72c061e8.jpg?1",
             "name": "Dark Impostor",
             "text": "{4}{B}{B}: Exile target creature and put a +1/+1 counter on Dark Impostor.\nDark Impostor has all activated abilities of all creature cards exiled with it.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "5e0333c5-b3ef-5d4f-9706-0707d81b152a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a0961-cca5-4d63-867f-7426dbef8639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a0961-cca5-4d63-867f-7426dbef8639.jpg?1",
             "name": "Death Wind",
             "text": "Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "c983a7eb-9b50-5a7f-8d44-0f91463c31ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2136a82-b535-47f6-9eee-5b7585ac5cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2136a82-b535-47f6-9eee-5b7585ac5cf1.jpg?1",
             "name": "Demonic Rising",
             "text": "At the beginning of your end step, if you control exactly one creature, put a 5/5 black Demon creature token with flying onto the battlefield.",
             "colours": [
@@ -3160,7 +3160,7 @@
         },
         {
             "id": "ec037ce2-3c7e-53c6-858f-b04919b875ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5d6266-30a7-4360-84bc-22b52fb782b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5d6266-30a7-4360-84bc-22b52fb782b3.jpg?1",
             "name": "Demonic Taskmaster",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice a creature other than Demonic Taskmaster.",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "dc387c49-263d-5845-b9aa-3a5a32b1db42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785da9a3-09af-45aa-bc04-4ab69cfb2ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785da9a3-09af-45aa-bc04-4ab69cfb2ba4.jpg?1",
             "name": "Demonlord of Ashmouth",
             "text": "Flying\nWhen Demonlord of Ashmouth enters the battlefield, exile it unless you sacrifice another creature.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "5a6d6302-914c-56e5-b9fc-74437be02942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa016bb7-ad8b-40d5-90db-412a9cf19e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa016bb7-ad8b-40d5-90db-412a9cf19e4e.jpg?1",
             "name": "Descent into Madness",
             "text": "At the beginning of your upkeep, put a despair counter on Descent into Madness, then each player exiles X permanents he or she controls and/or cards from his or her hand, where X is the number of despair counters on Descent into Madness.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "d08e9fc9-9599-5ce1-bddd-2f0be9efecb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a3abd-a4a2-48e6-b709-1c0240a76c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a3abd-a4a2-48e6-b709-1c0240a76c5e.jpg?1",
             "name": "Dread Slaver",
             "text": "Whenever a creature dealt damage by Dread Slaver this turn dies, return it to the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "3bf2d69a-ea05-54d2-a8e7-6b30de5a2579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56113cde-4210-46be-bd53-8966c36ef2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56113cde-4210-46be-bd53-8966c36ef2a3.jpg?1",
             "name": "Driver of the Dead",
             "text": "When Driver of the Dead dies, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "de2cfdb0-bddc-5b81-8a02-db653fd63d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3fac03-a019-4faa-bc1c-09e3a394fff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3fac03-a019-4faa-bc1c-09e3a394fff7.jpg?1",
             "name": "Essence Harvest",
             "text": "Target player loses X life and you gain X life, where X is the greatest power among creatures you control.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "3b44c831-6bf0-581b-99fc-6b648a52476f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1091fadf-97c4-4f87-8466-6a1246a72226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1091fadf-97c4-4f87-8466-6a1246a72226.jpg?1",
             "name": "Evernight Shade",
             "text": "{B}: Evernight Shade gets +1/+1 until end of turn.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "feb5dd4f-57f0-54c4-acb9-cca2d402fd9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd54279-57f5-4cd9-b524-4f094bd2fc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd54279-57f5-4cd9-b524-4f094bd2fc36.jpg?1",
             "name": "Exquisite Blood",
             "text": "Whenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "70e540dd-65d2-5cca-b331-d1ff1d41e3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eed3d1b-3142-437c-99e9-85ba76e23e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eed3d1b-3142-437c-99e9-85ba76e23e6d.jpg?1",
             "name": "Ghoulflesh",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 and is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "15294074-17ad-5bd3-9202-3bf7dc8763aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00c711-007d-4c85-9dd9-dd9d52f1649d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00c711-007d-4c85-9dd9-dd9d52f1649d.jpg?1",
             "name": "Gloom Surgeon",
             "text": "If combat damage would be dealt to Gloom Surgeon, prevent that damage and exile that many cards from the top of your library.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "fc00c8b7-b4c7-5940-bb66-15bfe0ef28c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f420c4-801b-48e7-a10b-de44a2417265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f420c4-801b-48e7-a10b-de44a2417265.jpg?1",
             "name": "Grave Exchange",
             "text": "Return target creature card from your graveyard to your hand. Target player sacrifices a creature.",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "4917126a-6d6a-5084-af17-59784e760b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51666ae-2aef-4cb1-9cd4-44aec81530f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51666ae-2aef-4cb1-9cd4-44aec81530f8.jpg?1",
             "name": "Griselbrand",
             "text": "Flying, lifelink\nPay 7 life: Draw seven cards.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "f3c51097-28a6-550b-9321-d2fd0e5966b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c0d25-dc1f-402e-9183-01c273efe0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c0d25-dc1f-402e-9183-01c273efe0e1.jpg?1",
             "name": "Harvester of Souls",
             "text": "Deathtouch\nWhenever another nontoken creature dies, you may draw a card.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "c23cbd68-7e1e-587a-823c-191675648f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022960a1-8223-4b83-aea2-85359c39f3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022960a1-8223-4b83-aea2-85359c39f3b8.jpg?1",
             "name": "Homicidal Seclusion",
             "text": "As long as you control exactly one creature, that creature gets +3/+1 and has lifelink.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "5f9e3769-4dc9-5ac0-99ac-60c279edd163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1de712-86ac-4c03-be86-2403cd121f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1de712-86ac-4c03-be86-2403cd121f66.jpg?1",
             "name": "Human Frailty",
             "text": "Destroy target Human creature.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "be24332d-ebb2-5f4a-a343-d223845fe610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb443cf7-70bd-4df7-b446-107e099c19e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb443cf7-70bd-4df7-b446-107e099c19e3.jpg?1",
             "name": "Hunted Ghoul",
             "text": "Hunted Ghoul can't block Humans.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "957cc636-3b72-5422-8efb-2ef5d81051b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg?1",
             "name": "Killing Wave",
             "text": "For each creature, its controller sacrifices it unless he or she pays X life.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "d7aa8f82-365d-59ef-a6ae-04638933318d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63dd203-bce9-4ab7-8a0c-059d19d384e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63dd203-bce9-4ab7-8a0c-059d19d384e9.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When Maalfeld Twins dies, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "10b43c03-2e7b-5a96-b167-45997a98fca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38dcbad0-267e-411f-8e99-5d90b537bf9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38dcbad0-267e-411f-8e99-5d90b537bf9b.jpg?1",
             "name": "Marrow Bats",
             "text": "Flying\nPay 4 life: Regenerate Marrow Bats.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "73c4d41f-495e-522c-a724-a13cd357c007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8a1d51-aa7f-41fd-b97d-56bc48221615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8a1d51-aa7f-41fd-b97d-56bc48221615.jpg?1",
             "name": "Mental Agony",
             "text": "Target player discards two cards and loses 2 life.",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "44c58a00-bd3d-5ddc-b198-f8e0b8027d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59918-cf12-4d73-a4e0-31f38e792dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59918-cf12-4d73-a4e0-31f38e792dc4.jpg?1",
             "name": "Necrobite",
             "text": "Target creature gains deathtouch until end of turn. Regenerate it.",
             "colours": [
@@ -3860,7 +3860,7 @@
         },
         {
             "id": "3e8e0af3-ebe2-5dc5-959a-2dd9936c562d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036c1954-37d3-4787-8df8-f2d0dd39058a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036c1954-37d3-4787-8df8-f2d0dd39058a.jpg?1",
             "name": "Polluted Dead",
             "text": "When Polluted Dead dies, destroy target land.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "9f1d8760-0803-5b9a-83ad-dbb118aeafd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88810a96-d5f8-4030-93f1-e2ad0d480317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88810a96-d5f8-4030-93f1-e2ad0d480317.jpg?1",
             "name": "Predator's Gambit",
             "text": "Enchant creature\nEnchanted creature gets +2/+1.\nEnchanted creature has intimidate as long as its controller controls no other creatures. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "85ea88a7-afcd-5964-bec0-26ace610cb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395696f8-9be2-4925-852f-b783850e1ca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395696f8-9be2-4925-852f-b783850e1ca2.jpg?1",
             "name": "Renegade Demon",
             "text": "",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "3e6313e3-0fe2-5a2f-939a-012dbd1dd4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dc1a94-0193-464e-a481-730b34b57db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dc1a94-0193-464e-a481-730b34b57db5.jpg?1",
             "name": "Searchlight Geist",
             "text": "Flying\n{3}{B}: Searchlight Geist gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "444e8d0a-cb7e-5224-b34b-34ceac505fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce1b1d3-9602-42bf-b341-d96976ff1e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce1b1d3-9602-42bf-b341-d96976ff1e60.jpg?1",
             "name": "Soulcage Fiend",
             "text": "When Soulcage Fiend dies, each player loses 3 life.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "4d2c25e8-068a-5aff-93c3-d69c5bfa8b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec7dfd7-d7b2-44fa-b351-022a19fe81b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec7dfd7-d7b2-44fa-b351-022a19fe81b8.jpg?1",
             "name": "Treacherous Pit-Dweller",
             "text": "When Treacherous Pit-Dweller enters the battlefield from a graveyard, target opponent gains control of it.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "9fed4335-91c3-57fe-8b7c-6f9a5805a9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906618e2-2638-4017-9d6e-e6f282967a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906618e2-2638-4017-9d6e-e6f282967a81.jpg?1",
             "name": "Triumph of Cruelty",
             "text": "At the beginning of your upkeep, target opponent discards a card if you control the creature with the greatest power or tied for the greatest power.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "3fa0263e-0720-5173-b10e-d389232ddd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d330058-16af-4486-aa89-b6be759e35d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d330058-16af-4486-aa89-b6be759e35d4.jpg?1",
             "name": "Undead Executioner",
             "text": "When Undead Executioner dies, you may have target creature get -2/-2 until end of turn.",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "4d4c9bf9-a245-59d0-9c43-359fdf0edbe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26d73e6-9138-43b2-8031-6e3b25fa33f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26d73e6-9138-43b2-8031-6e3b25fa33f9.jpg?1",
             "name": "Unhallowed Pact",
             "text": "Enchant creature\nWhen enchanted creature dies, return that card to the battlefield under your control.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "80cc0bb1-f0a2-5cd7-afab-6a4125374665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999f40a7-b723-42e1-83c1-f45a72a26dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999f40a7-b723-42e1-83c1-f45a72a26dd4.jpg?1",
             "name": "Aggravate",
             "text": "Aggravate deals 1 damage to each creature target player controls. Each creature dealt damage this way attacks this turn if able.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "9daa0e09-e1c5-5ab9-8797-687032f1237d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg?1",
             "name": "Archwing Dragon",
             "text": "Flying, haste\nAt the beginning of the end step, return Archwing Dragon to its owner's hand.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "8e71cbe4-1c73-54e0-a37b-a76910051d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7792df3-e2ab-4e60-abee-f24b72807107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7792df3-e2ab-4e60-abee-f24b72807107.jpg?1",
             "name": "Banners Raised",
             "text": "Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "e1ec1f88-d986-5fab-a881-e818eb8630a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5d46e-7054-44f8-9a14-b412f2f0ab86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5d46e-7054-44f8-9a14-b412f2f0ab86.jpg?1",
             "name": "Battle Hymn",
             "text": "Add {R} to your mana pool for each creature you control.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "1635df5b-d2d6-5083-82bc-d6633b10f8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60610fe-891d-46de-b556-d03b637dccec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60610fe-891d-46de-b556-d03b637dccec.jpg?1",
             "name": "Bonfire of the Damned",
             "text": "Bonfire of the Damned deals X damage to target player and each creature he or she controls.\nMiracle {X}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "523f4a1a-e308-5ebc-bb1a-f2b4e6490da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46e9902-81fb-4a3c-9f2f-d3faf031631d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46e9902-81fb-4a3c-9f2f-d3faf031631d.jpg?1",
             "name": "Burn at the Stake",
             "text": "As an additional cost to cast Burn at the Stake, tap any number of untapped creatures you control.\nBurn at the Stake deals damage to target creature or player equal to three times the number of creatures tapped this way.",
             "colours": [
@@ -4358,7 +4358,7 @@
         },
         {
             "id": "5433da49-2a85-5dbd-b2d4-25f615d23e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c4042-703f-4548-9a0f-cb550c468bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c4042-703f-4548-9a0f-cb550c468bf9.jpg?1",
             "name": "Dangerous Wager",
             "text": "Discard your hand, then draw two cards.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "93afdba0-696e-5e76-8be6-917c15d0e147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4657aa15-8274-4bd7-afe4-504693064373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4657aa15-8274-4bd7-afe4-504693064373.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "f75df442-b3c7-5e58-9650-b98cfcaa785d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa45bfd-7075-470d-8aaa-16e34109eb5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa45bfd-7075-470d-8aaa-16e34109eb5a.jpg?1",
             "name": "Dual Casting",
             "text": "Enchant creature\nEnchanted creature has \"{R}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\"",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "c8809724-7402-5a10-9043-1dfacefa2454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e23909-7e08-4686-ae59-e18e7d4cfd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e23909-7e08-4686-ae59-e18e7d4cfd3c.jpg?1",
             "name": "Falkenrath Exterminator",
             "text": "Whenever Falkenrath Exterminator deals combat damage to a player, put a +1/+1 counter on it.\n{2}{R}: Falkenrath Exterminator deals damage to target creature equal to the number of +1/+1 counters on Falkenrath Exterminator.",
             "colours": [
@@ -4491,7 +4491,7 @@
         },
         {
             "id": "83422d16-cca5-5fa9-ae0b-0f9b0b31b51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fceeb14-a22a-4ab6-9e6d-ba375b6865c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fceeb14-a22a-4ab6-9e6d-ba375b6865c0.jpg?1",
             "name": "Fervent Cathar",
             "text": "Haste\nWhen Fervent Cathar enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "25884608-5fc6-5bc8-b742-b42ea9faf121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430b9fa-3bc6-4183-ad5b-d70ad401fa97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430b9fa-3bc6-4183-ad5b-d70ad401fa97.jpg?1",
             "name": "Gang of Devils",
             "text": "When Gang of Devils dies, it deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "303db6d0-28a7-5d7d-a8b6-55aa950462df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb10d42-fa19-400c-bad8-ec3827f077bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb10d42-fa19-400c-bad8-ec3827f077bc.jpg?1",
             "name": "Guise of Fire",
             "text": "Enchant creature\nEnchanted creature gets +1/-1 and attacks each turn if able.",
             "colours": [
@@ -4594,7 +4594,7 @@
         },
         {
             "id": "ef334544-24c3-5c82-b913-b68c516344db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73884fd1-5be9-4ad5-8c72-c0fbe27ad4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73884fd1-5be9-4ad5-8c72-c0fbe27ad4c1.jpg?1",
             "name": "Hanweir Lancer",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Hanweir Lancer is paired with another creature, both creatures have first strike.",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "bb84ea43-98af-56a8-926e-bff858d1b7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc09839-1463-40b8-86bd-fb96797b2633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc09839-1463-40b8-86bd-fb96797b2633.jpg?1",
             "name": "Havengul Vampire",
             "text": "Whenever Havengul Vampire deals combat damage to a player, put a +1/+1 counter on it.\nWhenever another creature dies, put a +1/+1 counter on Havengul Vampire.",
             "colours": [
@@ -4663,7 +4663,7 @@
         },
         {
             "id": "736e27c2-6df7-5dfa-8bb6-eddd6c430de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff89ad3b-b154-49e2-a0fd-135279512250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff89ad3b-b154-49e2-a0fd-135279512250.jpg?1",
             "name": "Heirs of Stromkirk",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever Heirs of Stromkirk deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4697,7 +4697,7 @@
         },
         {
             "id": "41faa04c-2fd2-5bee-b749-22eaad9e0bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg?1",
             "name": "Hound of Griselbrand",
             "text": "Double strike\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4732,7 +4732,7 @@
         },
         {
             "id": "f01eaedc-de56-54db-8db3-3daaa25854ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce9a30f-a850-4826-a255-ce511d567b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce9a30f-a850-4826-a255-ce511d567b60.jpg?1",
             "name": "Kessig Malcontents",
             "text": "When Kessig Malcontents enters the battlefield, it deals damage to target player equal to the number of Humans you control.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "891c9563-cc22-5e9e-8044-ac28c351275c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e72249-84ea-4e9c-9f64-b67b02ffdf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e72249-84ea-4e9c-9f64-b67b02ffdf3a.jpg?1",
             "name": "Kruin Striker",
             "text": "Whenever another creature enters the battlefield under your control, Kruin Striker gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -4802,7 +4802,7 @@
         },
         {
             "id": "1394293b-5ec7-588f-ae89-5e4d65fd9be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241cc968-b93e-4fe3-a66d-7776d29aa023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241cc968-b93e-4fe3-a66d-7776d29aa023.jpg?1",
             "name": "Lightning Mauler",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Lightning Mauler is paired with another creature, both creatures have haste.",
             "colours": [
@@ -4837,7 +4837,7 @@
         },
         {
             "id": "13bc6593-397b-5fd3-94b0-57400f5e62f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5578e3e2-2460-4dfb-9016-527463f2d918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5578e3e2-2460-4dfb-9016-527463f2d918.jpg?1",
             "name": "Lightning Prowess",
             "text": "Enchant creature\nEnchanted creature has haste and \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "d4dcb2af-c4b0-5581-9045-f73dd9405a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172383d9-9135-4daa-a647-9d76435d3158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172383d9-9135-4daa-a647-9d76435d3158.jpg?1",
             "name": "Mad Prophet",
             "text": "Haste\n{T}, Discard a card: Draw a card.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "0a13a00d-4209-53f5-b3cc-97073844fb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dda42d-55eb-46fc-89da-17cc5bfaa823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dda42d-55eb-46fc-89da-17cc5bfaa823.jpg?1",
             "name": "Malicious Intent",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Target creature can't block this turn.\"",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "723d56f2-6b9e-558f-be5a-873186087137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7000-4a1d-4cd4-a85e-4b7b20d8e543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7000-4a1d-4cd4-a85e-4b7b20d8e543.jpg?1",
             "name": "Malignus",
             "text": "Malignus's power and toughness are each equal to half the highest life total among your opponents, rounded up.\nDamage that would be dealt by Malignus can't be prevented.",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "181188e3-2e18-5c20-a120-3f7114113f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c983e879-d9d2-47cc-9958-506711ca80cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c983e879-d9d2-47cc-9958-506711ca80cd.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "e932ffcc-00cb-5403-9707-1ee2a6e6a4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78833788-ffb2-43fc-9345-975f1cd46f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78833788-ffb2-43fc-9345-975f1cd46f38.jpg?1",
             "name": "Raging Poltergeist",
             "text": "",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "3cf44c9d-bd28-5c4c-aaeb-d7c69793a28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36506caa-2630-46ec-9aa0-e1885749ad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36506caa-2630-46ec-9aa0-e1885749ad90.jpg?1",
             "name": "Reforge the Soul",
             "text": "Each player discards his or her hand and draws seven cards.\nMiracle {1}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "8c20905d-6e48-513c-b366-69e3fd2809d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c043f30b-548f-4c31-a415-0e59c2841dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c043f30b-548f-4c31-a415-0e59c2841dcf.jpg?1",
             "name": "Riot Ringleader",
             "text": "Whenever Riot Ringleader attacks, Human creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "3ac2ecee-ab8b-5069-b435-b648aaa4c72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e7fec3-94b5-411e-aeb0-44a64f517986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e7fec3-94b5-411e-aeb0-44a64f517986.jpg?1",
             "name": "Rite of Ruin",
             "text": "Choose an order for artifacts, creatures, and lands. Each player sacrifices one permanent of the first type, sacrifices two of the second type, then sacrifices three of the third type.",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "040f4f73-8993-5859-a45f-071efe987c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2884824-d138-47f2-913b-32cd475e9584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2884824-d138-47f2-913b-32cd475e9584.jpg?1",
             "name": "Rush of Blood",
             "text": "Target creature gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -5172,7 +5172,7 @@
         },
         {
             "id": "c36baa0c-faf7-5c98-9856-541e9218e0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe49a97-dac8-4273-b4dc-45cdf8f5a6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe49a97-dac8-4273-b4dc-45cdf8f5a6e0.jpg?1",
             "name": "Scalding Devil",
             "text": "{2}{R}: Scalding Devil deals 1 damage to target player.",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "f8c98d46-64e1-5add-98d1-f6153d26266c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69eb29-a7e4-4826-9535-9a073136c688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69eb29-a7e4-4826-9535-9a073136c688.jpg?1",
             "name": "Somberwald Vigilante",
             "text": "Whenever Somberwald Vigilante becomes blocked by a creature, Somberwald Vigilante deals 1 damage to that creature.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "ce147123-e51b-53b2-822d-e50348b43aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9564d79d-5f4d-4192-94ee-5e5998011266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9564d79d-5f4d-4192-94ee-5e5998011266.jpg?1",
             "name": "Stonewright",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Stonewright is paired with another creature, each of those creatures has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "b08db5c5-cf17-521f-aa88-5a3ff5798f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28bd68-47a8-47c6-be16-75ae622daf0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28bd68-47a8-47c6-be16-75ae622daf0a.jpg?1",
             "name": "Thatcher Revolt",
             "text": "Put three 1/1 red Human creature tokens with haste onto the battlefield. Sacrifice those tokens at the beginning of the next end step.",
             "colours": [
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "23ff9637-0ccc-5c99-9b63-b7669fe5badf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5845a5bc-6b7d-4bbb-80b3-a0f877b95553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5845a5bc-6b7d-4bbb-80b3-a0f877b95553.jpg?1",
             "name": "Thunderbolt",
             "text": "Choose one \u2014 Thunderbolt deals 3 damage to target player; or Thunderbolt deals 4 damage to target creature with flying.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "cfbbffc0-a0f3-5693-b3db-d71b701e59b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa39826-7f89-41cb-a7fe-7f7be817d5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa39826-7f89-41cb-a7fe-7f7be817d5cd.jpg?1",
             "name": "Thunderous Wrath",
             "text": "Thunderous Wrath deals 5 damage to target creature or player.\nMiracle {R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "17997927-44ed-5e4e-8034-d99d1548a82e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddb3936-8f5a-498d-a46c-27eb9546c76c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddb3936-8f5a-498d-a46c-27eb9546c76c.jpg?1",
             "name": "Tibalt, the Fiend-Blooded",
             "text": "+1: Draw a card, then discard a card at random.\n-4: Tibalt, the Fiend-Blooded deals damage equal to the number of cards in target player's hand to that player.\n-6: Gain control of all creatures until end of turn. Untap them. They gain haste until end of turn.",
             "colours": [
@@ -5408,7 +5408,7 @@
         },
         {
             "id": "a0eeeef6-dfd2-57fd-82ae-0ad8d46e281f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7c8ea-e9c1-4d78-972c-15c4014915a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7c8ea-e9c1-4d78-972c-15c4014915a0.jpg?1",
             "name": "Tyrant of Discord",
             "text": "When Tyrant of Discord enters the battlefield, target opponent chooses a permanent he or she controls at random and sacrifices it. If a nonland permanent is sacrificed this way, repeat this process.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "e6aedc3d-2a7c-5b04-af22-d0e0d3b1469b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b747e-446a-4c25-9834-0be8476dc22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b747e-446a-4c25-9834-0be8476dc22d.jpg?1",
             "name": "Uncanny Speed",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "4d2c0af5-fd0d-59e0-a2db-593acef98ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbefd98-4b17-4cc2-9ef9-8807f594cb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbefd98-4b17-4cc2-9ef9-8807f594cb16.jpg?1",
             "name": "Vexing Devil",
             "text": "When Vexing Devil enters the battlefield, any opponent may have it deal 4 damage to him or her. If a player does, sacrifice Vexing Devil.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "f9180e42-860f-5eb4-ac6c-f0d6b3696c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9db329b-6248-4082-bfc8-5d2c0db43338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9db329b-6248-4082-bfc8-5d2c0db43338.jpg?1",
             "name": "Vigilante Justice",
             "text": "Whenever a Human enters the battlefield under your control, Vigilante Justice deals 1 damage to target creature or player.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "64993ef4-95be-5ed7-8770-3516d2fcd291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027b11-1ecc-430d-a862-586a14bb23c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027b11-1ecc-430d-a862-586a14bb23c3.jpg?1",
             "name": "Zealous Conscripts",
             "text": "Haste\nWhen Zealous Conscripts enters the battlefield, gain control of target permanent until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "4f0b1302-bc1c-5a7c-94eb-67fe2f802729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbc8fd0-dc15-4ac9-b97b-173f7fb66ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbc8fd0-dc15-4ac9-b97b-173f7fb66ed7.jpg?1",
             "name": "Abundant Growth",
             "text": "Enchant land\nWhen Abundant Growth enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "b3c4c464-7207-5cb6-bc64-c444de0687eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16453f1-c6ca-4288-ab72-315ed9bb0ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16453f1-c6ca-4288-ab72-315ed9bb0ab0.jpg?1",
             "name": "Blessings of Nature",
             "text": "Distribute four +1/+1 counters among any number of target creatures.\nMiracle {G} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "0a4bb4fa-982d-5cc3-8698-0e3688ba28f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f067c26-c51d-44d0-a0af-106b5778f06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f067c26-c51d-44d0-a0af-106b5778f06a.jpg?1",
             "name": "Borderland Ranger",
             "text": "When Borderland Ranger enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "5e8b5e6c-c996-5e8f-b4e5-979e874d3125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f0048f-aaa0-4597-b898-ee754d0bbe4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f0048f-aaa0-4597-b898-ee754d0bbe4b.jpg?1",
             "name": "Bower Passage",
             "text": "Creatures with flying can't block creatures you control.",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "c2b3fd2a-1afa-5a8d-8c81-7385bdc9837e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ab9cd3-2faf-4500-a2ee-90b3a8d559c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ab9cd3-2faf-4500-a2ee-90b3a8d559c4.jpg?1",
             "name": "Champion of Lambholt",
             "text": "Creatures with power less than Champion of Lambholt's power can't block creatures you control.\nWhenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "5c5b6753-0cfd-5c8e-9ba5-c31c0b0be3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249be17-73ed-4108-89c0-f7e87939beb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249be17-73ed-4108-89c0-f7e87939beb8.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "9a020248-cb6b-5113-b8ea-38c48d39b0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada93208-5cda-4e2d-b9a7-15345e30b831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada93208-5cda-4e2d-b9a7-15345e30b831.jpg?1",
             "name": "Descendants' Path",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card that shares a creature type with a creature you control, you may cast that card without paying its mana cost. Otherwise, put that card on the bottom of your library.",
             "colours": [
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "29b920b1-f6fb-5272-8283-49cbf34cf396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640e21ad-5064-41bc-886e-2c997f69a3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640e21ad-5064-41bc-886e-2c997f69a3f5.jpg?1",
             "name": "Diregraf Escort",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Diregraf Escort is paired with another creature, both creatures have protection from Zombies.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "8f0e63c2-b748-52dc-8fdf-ae9fb3663c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8c794a-7964-41f0-bc9c-27af7cf87aaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8c794a-7964-41f0-bc9c-27af7cf87aaa.jpg?1",
             "name": "Druid's Familiar",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Druid's Familiar is paired with another creature, each of those creatures gets +2/+2.",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "f829c4c3-3636-5fcd-bcea-0263a1db7c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6fb62-7ee3-444d-8fd4-c1f44014a05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6fb62-7ee3-444d-8fd4-c1f44014a05c.jpg?1",
             "name": "Druids' Repository",
             "text": "Whenever a creature you control attacks, put a charge counter on Druids' Repository.\nRemove a charge counter from Druids' Repository: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "fd5beded-104f-53f6-95bb-fa7a10be31cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efea1b1-f212-4b97-98dd-922f85ab191f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efea1b1-f212-4b97-98dd-922f85ab191f.jpg?1",
             "name": "Eaten by Spiders",
             "text": "Destroy target creature with flying and all Equipment attached to that creature.",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "27e86bb2-ff97-5502-8d16-0dba06b945b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fa2ddc-142b-4562-8812-ecb72e3bae57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fa2ddc-142b-4562-8812-ecb72e3bae57.jpg?1",
             "name": "Flowering Lumberknot",
             "text": "Flowering Lumberknot can't attack or block unless it's paired with a creature with soulbond.",
             "colours": [
@@ -5977,7 +5977,7 @@
         },
         {
             "id": "03e0b91b-c149-5cb6-ba8f-ada3ad1069d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f00a18-0ff7-42e4-be16-aa34fe27093b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f00a18-0ff7-42e4-be16-aa34fe27093b.jpg?1",
             "name": "Geist Trappers",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Geist Trappers is paired with another creature, both creatures have reach.",
             "colours": [
@@ -6012,7 +6012,7 @@
         },
         {
             "id": "d5e16585-f5ce-5bf6-b970-428f123653d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a016c872-09bd-42e1-94da-f587e8252492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a016c872-09bd-42e1-94da-f587e8252492.jpg?1",
             "name": "Gloomwidow",
             "text": "Reach\nGloomwidow can block only creatures with flying.",
             "colours": [
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "372493ae-5b51-55a6-ade3-5d85841541b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4982f0-0ede-4846-82c8-bcf7ad63d099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4982f0-0ede-4846-82c8-bcf7ad63d099.jpg?1",
             "name": "Grounded",
             "text": "Enchant creature\nEnchanted creature loses flying.",
             "colours": [
@@ -6080,7 +6080,7 @@
         },
         {
             "id": "30409c33-1c56-5b5c-86bd-bbf805f39ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad60d45-1c99-41d1-a237-c0ee18ce5361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad60d45-1c99-41d1-a237-c0ee18ce5361.jpg?1",
             "name": "Howlgeist",
             "text": "Creatures with power less than Howlgeist's power can't block it.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "9d1dec3b-43b8-58f2-b09f-63660a66b84a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6516c7c6-d49b-49c5-8968-563622c2c8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6516c7c6-d49b-49c5-8968-563622c2c8c1.jpg?1",
             "name": "Joint Assault",
             "text": "Target creature gets +2/+2 until end of turn. If it's paired with a creature, that creature also gets +2/+2 until end of turn.",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "8b524d36-72ec-52f1-bed0-7d819b12c218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604948d8-6224-45ca-9ebb-d716644bbfd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604948d8-6224-45ca-9ebb-d716644bbfd0.jpg?1",
             "name": "Lair Delve",
             "text": "Reveal the top two cards of your library. Put all creature and land cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "57490094-c06a-56e3-a0bf-d55ab5b06b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d25235-de1c-4b67-9712-24f0564bd2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d25235-de1c-4b67-9712-24f0564bd2bf.jpg?1",
             "name": "Natural End",
             "text": "Destroy target artifact or enchantment. You gain 3 life.",
             "colours": [
@@ -6211,7 +6211,7 @@
         },
         {
             "id": "d4d5d4bc-c1d3-58c0-b221-99cf5a8d7f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75935f0e-9086-485b-b3e6-1a958fd0f2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75935f0e-9086-485b-b3e6-1a958fd0f2af.jpg?1",
             "name": "Nettle Swine",
             "text": "",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "7a84911c-515c-5e89-892b-f0587f5362b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3de66c-2283-458f-9d0d-943027520aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3de66c-2283-458f-9d0d-943027520aa2.jpg?1",
             "name": "Nightshade Peddler",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Nightshade Peddler is paired with another creature, both creatures have deathtouch.",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "4b120470-2494-5e93-abf6-4640dd3aecd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65eded-37ef-4cf0-b55c-390d34aab7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65eded-37ef-4cf0-b55c-390d34aab7b8.jpg?1",
             "name": "Pathbreaker Wurm",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Pathbreaker Wurm is paired with another creature, both creatures have trample.",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "6e2ddd84-2d72-5b9c-b5b6-d020a45c91b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278f7bd-afff-4a1d-a0bb-bf9ce3ad5a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278f7bd-afff-4a1d-a0bb-bf9ce3ad5a2e.jpg?1",
             "name": "Primal Surge",
             "text": "Exile the top card of your library. If it's a permanent card, you may put it onto the battlefield. If you do, repeat this process.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "947064bc-9c8a-5566-895f-f8346a0fd30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1cb530-b9d5-4386-b89e-2acecc8294c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1cb530-b9d5-4386-b89e-2acecc8294c8.jpg?1",
             "name": "Rain of Thorns",
             "text": "Choose one or more \u2014 Destroy target artifact; destroy target enchantment; and/or destroy target land.",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "6ce2576a-8eb1-50d9-a09c-0db945403d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7d663-115c-4ad0-a072-633df054cce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7d663-115c-4ad0-a072-633df054cce4.jpg?1",
             "name": "Revenge of the Hunted",
             "text": "Until end of turn, target creature gets +6/+6 and gains trample, and all creatures able to block it this turn do so.\nMiracle {G} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -6410,7 +6410,7 @@
         },
         {
             "id": "9339bb8b-6f07-50bb-8129-16118b1b6485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cd9be4-1ce4-4a7c-b2a6-98d3fde0a92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cd9be4-1ce4-4a7c-b2a6-98d3fde0a92b.jpg?1",
             "name": "Sheltering Word",
             "text": "Target creature you control gains hexproof until end of turn. You gain life equal to that creature's toughness. (A creature with hexproof can't be the target of spells or abilities opponents control.)",
             "colours": [
@@ -6442,7 +6442,7 @@
         },
         {
             "id": "893948a1-b43f-5c9d-a099-9ccd0f481292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f75827-a144-4fe2-a713-4439ae7567eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f75827-a144-4fe2-a713-4439ae7567eb.jpg?1",
             "name": "Snare the Skies",
             "text": "Target creature gets +1/+1 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "6017e59d-9271-57ed-b267-f3aa46345515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c0272-7a43-4a6c-ab3f-740397b1f5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c0272-7a43-4a6c-ab3f-740397b1f5c8.jpg?1",
             "name": "Somberwald Sage",
             "text": "{T}: Add three mana of any one color to your mana pool. Spend this mana only to cast creature spells.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "bab0d449-ffc6-5b12-a361-4c339ace82b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078f5e79-18dd-44e5-a930-8dc288f0b535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078f5e79-18dd-44e5-a930-8dc288f0b535.jpg?1",
             "name": "Soul of the Harvest",
             "text": "Trample\nWhenever another nontoken creature enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "6c06c4c2-49a7-5b2f-9ef8-2d22eeb6eebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8d0a22-f31b-45c0-85c7-0101aa63c77b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8d0a22-f31b-45c0-85c7-0101aa63c77b.jpg?1",
             "name": "Terrifying Presence",
             "text": "Prevent all combat damage that would be dealt by creatures other than target creature this turn.",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "c62d8e90-abeb-5ae4-990b-a5c861d93f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae80fefb-af78-4f98-8058-71b61e91842f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae80fefb-af78-4f98-8058-71b61e91842f.jpg?1",
             "name": "Timberland Guide",
             "text": "When Timberland Guide enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -6610,7 +6610,7 @@
         },
         {
             "id": "619b4420-a8ea-5706-860b-6405aa15d3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb41fa6-0cc6-43e5-9aa8-fcd9c781f4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb41fa6-0cc6-43e5-9aa8-fcd9c781f4ce.jpg?1",
             "name": "Triumph of Ferocity",
             "text": "At the beginning of your upkeep, draw a card if you control the creature with the greatest power or tied for the greatest power.",
             "colours": [
@@ -6642,7 +6642,7 @@
         },
         {
             "id": "da01fdcf-47f7-5077-9134-35d932a7d229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee66ef9-10a7-4aab-88f7-84956811cc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee66ef9-10a7-4aab-88f7-84956811cc6c.jpg?1",
             "name": "Trusted Forcemage",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Trusted Forcemage is paired with another creature, each of those creatures gets +1/+1.",
             "colours": [
@@ -6677,7 +6677,7 @@
         },
         {
             "id": "e452ea08-40aa-563e-8660-a2d11ae66fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46199391-a4f5-4532-b89c-b7691b229bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46199391-a4f5-4532-b89c-b7691b229bd0.jpg?1",
             "name": "Ulvenwald Tracker",
             "text": "{1}{G}, {T}: Target creature you control fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "1f595939-3051-52be-86fe-923cacf3660e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg?1",
             "name": "Vorstclaw",
             "text": "",
             "colours": [
@@ -6747,7 +6747,7 @@
         },
         {
             "id": "f311c85b-ebae-532c-8844-4ef45b615398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac606ad5-b8d0-4c93-a9de-5e41229a8229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac606ad5-b8d0-4c93-a9de-5e41229a8229.jpg?1",
             "name": "Wandering Wolf",
             "text": "Creatures with power less than Wandering Wolf's power can't block it.",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "658073a4-d810-5700-a0f6-4f5d293b0ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaa6be7-2c6f-4442-85d1-ae31ad87fd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaa6be7-2c6f-4442-85d1-ae31ad87fd98.jpg?1",
             "name": "Wild Defiance",
             "text": "Whenever a creature you control becomes the target of an instant or sorcery spell, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "a22efafc-0a30-52ea-8c00-c88d0858161f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4658b4b2-7043-4ca2-96fd-4f663c20c80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4658b4b2-7043-4ca2-96fd-4f663c20c80f.jpg?1",
             "name": "Wildwood Geist",
             "text": "Wildwood Geist gets +2/+2 as long as it's your turn.",
             "colours": [
@@ -6847,7 +6847,7 @@
         },
         {
             "id": "ec6da448-8d30-5606-a758-8462c1bbd3ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cc00e5-9683-4ccc-a914-c422b76f6014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cc00e5-9683-4ccc-a914-c422b76f6014.jpg?1",
             "name": "Wolfir Avenger",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\n{1}{G}: Regenerate Wolfir Avenger.",
             "colours": [
@@ -6882,7 +6882,7 @@
         },
         {
             "id": "f5572a23-e3bf-57e2-936c-c39fdf754fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8629c598-11c8-4911-acfb-0643e5feffa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8629c598-11c8-4911-acfb-0643e5feffa8.jpg?1",
             "name": "Wolfir Silverheart",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Wolfir Silverheart is paired with another creature, each of those creatures gets +4/+4.",
             "colours": [
@@ -6917,7 +6917,7 @@
         },
         {
             "id": "e35300ad-acc7-5c7c-950b-dc3795c59cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9320432-4f89-4363-91e6-2e740535cc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9320432-4f89-4363-91e6-2e740535cc2e.jpg?1",
             "name": "Yew Spirit",
             "text": "{2}{G}{G}: Yew Spirit gets +X/+X until end of turn, where X is its power.",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "325f9795-56e3-559c-acab-6162a3e23096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e390bc78-31ad-4131-a9e4-93ee0c7c2f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e390bc78-31ad-4131-a9e4-93ee0c7c2f34.jpg?1",
             "name": "Bruna, Light of Alabaster",
             "text": "Flying, vigilance\nWhenever Bruna, Light of Alabaster attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "53c760d7-6971-5eec-8c29-fbbffaacedfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7208fcb8-83e6-44ce-af9a-ca1566825018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7208fcb8-83e6-44ce-af9a-ca1566825018.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "9ee79691-5b8c-516a-84f1-3c20818d5605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feccd0e2-fae6-4ced-acdf-4252ed5c56e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feccd0e2-fae6-4ced-acdf-4252ed5c56e7.jpg?1",
             "name": "Sigarda, Host of Herons",
             "text": "Flying, hexproof\nSpells and abilities your opponents control can't cause you to sacrifice permanents.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "f8c9bb51-fe6a-5492-9dd8-b9518568a72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28226303-7e67-4b88-adae-2386aff033ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28226303-7e67-4b88-adae-2386aff033ec.jpg?1",
             "name": "Angel's Tomb",
             "text": "Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.",
             "colours": [],
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "66cba7ff-5c5d-590b-9a29-8402227c78eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa99b48-469d-4112-bdfd-2391fa439514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa99b48-469d-4112-bdfd-2391fa439514.jpg?1",
             "name": "Angelic Armaments",
             "text": "Equipped creature gets +2/+2, has flying, and is a white Angel in addition to its other colors and types.\nEquip {4}",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "63cc10bd-5c44-5020-ade2-76e917203d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a5116-043c-46aa-880e-be8dcb1618bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a5116-043c-46aa-880e-be8dcb1618bc.jpg?1",
             "name": "Bladed Bracers",
             "text": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human or an Angel, it has vigilance.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "d3c594a6-8d14-5cef-9b84-10fc40f3b28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7378e998-0382-42fc-8606-c6e7fc04b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7378e998-0382-42fc-8606-c6e7fc04b6a4.jpg?1",
             "name": "Conjurer's Closet",
             "text": "At the beginning of your end step, you may exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [],
@@ -7182,7 +7182,7 @@
         },
         {
             "id": "3b4a6307-7020-573b-93c5-71be8ad329d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a840ee7-5728-4b1b-92ac-54612e5397b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a840ee7-5728-4b1b-92ac-54612e5397b3.jpg?1",
             "name": "Gallows at Willow Hill",
             "text": "{3}, {T}, Tap three untapped Humans you control: Destroy target creature. Its controller puts a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [],
@@ -7210,7 +7210,7 @@
         },
         {
             "id": "c31e61ac-7bcf-5f08-a2d5-42d2694be2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d97f8b8-bdb0-4d4b-b077-9affe2f9cd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d97f8b8-bdb0-4d4b-b077-9affe2f9cd91.jpg?1",
             "name": "Haunted Guardian",
             "text": "Defender, first strike",
             "colours": [],
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "98425373-4063-54cf-baa2-f5496cd75fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5efb85-1e5f-40ba-97b1-0ef6ac680330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5efb85-1e5f-40ba-97b1-0ef6ac680330.jpg?1",
             "name": "Moonsilver Spear",
             "text": "Equipped creature has first strike.\nWhenever equipped creature attacks, put a 4/4 white Angel creature token with flying onto the battlefield.\nEquip {4}",
             "colours": [],
@@ -7271,7 +7271,7 @@
         },
         {
             "id": "58872471-37fa-531d-b6c1-7a86f912ce9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f808ed9b-95ac-4069-bdca-b100bc816b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f808ed9b-95ac-4069-bdca-b100bc816b5b.jpg?1",
             "name": "Narstad Scrapper",
             "text": "{2}: Narstad Scrapper gets +1/+0 until end of turn.",
             "colours": [],
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "0179ce30-51c8-57f1-be93-b56a660a6d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e4aa67-4643-42ff-8172-200498686494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e4aa67-4643-42ff-8172-200498686494.jpg?1",
             "name": "Otherworld Atlas",
             "text": "{T}: Put a charge counter on Otherworld Atlas.\n{T}: Each player draws a card for each charge counter on Otherworld Atlas.",
             "colours": [],
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "298c74c0-5b87-5603-971b-e283761188b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871e6e2a-7e45-446b-b964-94377eb6ca92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871e6e2a-7e45-446b-b964-94377eb6ca92.jpg?1",
             "name": "Scroll of Avacyn",
             "text": "{1}, Sacrifice Scroll of Avacyn: Draw a card. If you control an Angel, you gain 5 life.",
             "colours": [],
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "a4175f04-18e8-576d-9f1a-329b667d28c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2263ceaf-49d2-40fe-86b8-146271b11e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2263ceaf-49d2-40fe-86b8-146271b11e46.jpg?1",
             "name": "Scroll of Griselbrand",
             "text": "{1}, Sacrifice Scroll of Griselbrand: Target opponent discards a card. If you control a Demon, that player loses 3 life.",
             "colours": [],
@@ -7386,7 +7386,7 @@
         },
         {
             "id": "a0dc02da-49a2-509f-a658-7e562886f5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543d454-27d6-42ba-aad8-54811d180cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543d454-27d6-42ba-aad8-54811d180cfb.jpg?1",
             "name": "Tormentor's Trident",
             "text": "Equipped creature gets +3/+0 and attacks each turn if able.\nEquip {3}",
             "colours": [],
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "9eec313d-6653-5ace-acdd-6156f0f613e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8d9db6-5737-4a1f-ae4e-75821a602784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8d9db6-5737-4a1f-ae4e-75821a602784.jpg?1",
             "name": "Vanguard's Shield",
             "text": "Equipped creature gets +0/+3 and can block an additional creature.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7446,7 +7446,7 @@
         },
         {
             "id": "9773d59f-982d-51d6-8d01-805ffdbc66d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec733373-3f68-47ad-ac35-6f39092f1e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec733373-3f68-47ad-ac35-6f39092f1e26.jpg?1",
             "name": "Vessel of Endless Rest",
             "text": "When Vessel of Endless Rest enters the battlefield, put target card from a graveyard on the bottom of its owner's library.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "2a5f85b7-cde5-5436-b175-216dbf0801c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c767a897-52e3-4401-8104-930157bb2b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c767a897-52e3-4401-8104-930157bb2b02.jpg?1",
             "name": "Alchemist's Refuge",
             "text": "{T}: Add {1} to your mana pool.\n{G}{U}, {T}: You may cast nonland cards this turn as though they had flash.",
             "colours": [],
@@ -7505,7 +7505,7 @@
         },
         {
             "id": "0034b3e0-5f1d-56fc-99f1-0b8f60a5ddf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381c8f1-a292-4bdf-b20c-a5c2a169ee84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381c8f1-a292-4bdf-b20c-a5c2a169ee84.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "1fd4e4be-dec0-5a90-8e5e-9d112ca26255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fb45bc-6152-4b01-9831-a8e80b1c1852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fb45bc-6152-4b01-9831-a8e80b1c1852.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -7564,7 +7564,7 @@
         },
         {
             "id": "9a4f986b-a710-58f9-90bb-2246f7d430b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f903b04a-2733-4ce7-9d83-9db8d5e1e10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f903b04a-2733-4ce7-9d83-9db8d5e1e10d.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "When Seraph Sanctuary enters the battlefield, you gain 1 life.\nWhenever an Angel enters the battlefield under your control, you gain 1 life.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "0e7dbab6-611c-521e-a397-e4c322df1a2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a4351-3ec7-4e6c-8cdd-766bfd670391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a4351-3ec7-4e6c-8cdd-766bfd670391.jpg?1",
             "name": "Slayers' Stronghold",
             "text": "{T}: Add {1} to your mana pool.\n{R}{W}, {T}: Target creature gets +2/+0 and gains vigilance and haste until end of turn.",
             "colours": [],
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "7c7df70c-3bbf-549c-aadf-376bd5697e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f090db87-b7a9-4c88-a211-495b27ae37c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f090db87-b7a9-4c88-a211-495b27ae37c9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7660,7 +7660,7 @@
         },
         {
             "id": "b35af7d3-d686-5aa9-bbdf-6b95daa879b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91348123-e2d0-4acb-ab4e-ec17652b7853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91348123-e2d0-4acb-ab4e-ec17652b7853.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7697,7 +7697,7 @@
         },
         {
             "id": "a95de563-b7b0-5afc-8ec3-ee7eb4541e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca16bd5-e261-4229-a92d-7cd55654dd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca16bd5-e261-4229-a92d-7cd55654dd11.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7734,7 +7734,7 @@
         },
         {
             "id": "bee5dfaa-da2d-5e31-9166-2ad7efb01e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25934479-a47e-45b8-bc35-fc4b659b0d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25934479-a47e-45b8-bc35-fc4b659b0d68.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7771,7 +7771,7 @@
         },
         {
             "id": "7f9fec7e-b46d-5172-bb6f-c71787797df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f920a5-74ea-4b94-8822-5867e6d5017a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f920a5-74ea-4b94-8822-5867e6d5017a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "18ad4b57-245e-51bb-928e-8f6d7960bec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3685e-0ed3-4dc3-9033-8faa10b17c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3685e-0ed3-4dc3-9033-8faa10b17c27.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "ee435f53-78df-506c-b872-218310db1abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339c3f05-444c-4e0a-a556-fc09417ee984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339c3f05-444c-4e0a-a556-fc09417ee984.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7882,7 +7882,7 @@
         },
         {
             "id": "0cd389b6-198d-5838-96b7-86877bdbda2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c57bee-2810-467c-8ed7-6cecb5cbc379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c57bee-2810-467c-8ed7-6cecb5cbc379.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7919,7 +7919,7 @@
         },
         {
             "id": "c3ffc16f-2be6-5c54-a393-6dc6620d1502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a570b2-bcab-4500-b790-252baaf1f6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a570b2-bcab-4500-b790-252baaf1f6d8.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7956,7 +7956,7 @@
         },
         {
             "id": "db12fd6d-5933-5e4f-ab45-341014e0261c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53b7e7e-494b-4346-b18e-0e879bba7cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53b7e7e-494b-4346-b18e-0e879bba7cec.jpg?1",
             "name": "Mountain",
             "text": "B",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "3912e456-0f8b-5492-8572-6c1263c174fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b728a4-c3a9-408e-8333-8266a02c64fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b728a4-c3a9-408e-8333-8266a02c64fa.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "c767168d-690f-5c90-b54e-02742df4e673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e468809-d639-43f0-8834-16e921547dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e468809-d639-43f0-8834-16e921547dee.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "8333c8a3-b761-5053-bb7c-b1359ac9d545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097c9ce-8fe9-4150-9810-52f6c92c6099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097c9ce-8fe9-4150-9810-52f6c92c6099.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8104,7 +8104,7 @@
         },
         {
             "id": "6154b8c2-bb17-5903-9e5f-c23a67ef52c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104987-f678-4ba4-b7f5-69ae7fdc01a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104987-f678-4ba4-b7f5-69ae7fdc01a3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8141,7 +8141,7 @@
         },
         {
             "id": "a31867ec-1cb5-52ed-8245-dfa975640cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4974-fcef-46d1-8baa-6a215f7f3292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4974-fcef-46d1-8baa-6a215f7f3292.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "42d30cfb-64e6-5daf-bec6-fed19aa86fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dd1682-a5d5-4323-b876-66a86c311c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dd1682-a5d5-4323-b876-66a86c311c43.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8212,7 +8212,7 @@
         },
         {
             "id": "1f71dbee-03ad-5988-8f49-4dd36f705b39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894949b-f190-461e-996a-cf2b39f08a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894949b-f190-461e-996a-cf2b39f08a5d.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "ce2518f9-9b10-5646-b0c0-66fe6e097d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e79ba0-33c8-46c8-8694-8bf854345fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e79ba0-33c8-46c8-8694-8bf854345fe7.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8280,7 +8280,7 @@
         },
         {
             "id": "c992e266-a14b-5f4f-90dd-0b271c54c87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c14591-f807-40cf-9c00-4c94b85fff44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c14591-f807-40cf-9c00-4c94b85fff44.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "aad5a6cd-c4be-5a78-8702-7fa09025f049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3fc83f-ab02-4a44-910a-bfadc71cf162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3fc83f-ab02-4a44-910a-bfadc71cf162.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -8348,7 +8348,7 @@
         },
         {
             "id": "ec9a4944-adaf-511f-a79e-40eb615aa5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b877c19d-6022-4377-92e7-4511e24eb98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b877c19d-6022-4377-92e7-4511e24eb98e.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "e4207f06-6f40-59b1-b699-f6e453af79db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef9d-878a-49d8-afe5-86ad18e30c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef9d-878a-49d8-afe5-86ad18e30c3d.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "0675aa73-0756-581d-b2d7-10712b724ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7547c-6d3d-4586-83b2-3d208113b045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7547c-6d3d-4586-83b2-3d208113b045.jpg?1",
             "name": "Tamiyo, the Moon Sage Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/BFZ.json
+++ b/Assets/Resources/Sets/BFZ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a6ff733f-5c9d-54a5-8476-63223b2a1c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741e62a-4b86-46ff-a7df-a8ceaf3b9a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741e62a-4b86-46ff-a7df-a8ceaf3b9a0c.jpg?1",
             "name": "Bane of Bala Ged",
             "text": "Whenever Bane of Bala Ged attacks, defending player exiles two permanents he or she controls.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "dfa8ba79-c270-52ef-9e56-098d0c663265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3a74-ff78-4041-8137-93356d370ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3a74-ff78-4041-8137-93356d370ece.jpg?1",
             "name": "Blight Herder",
             "text": "When you cast Blight Herder, you may put two cards your opponents own from exile into their owners' graveyards. If you do, put three 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "ea3cfe5f-b709-51bd-8c2d-4f364a9e2229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784e843e-7010-466d-adbd-1dd1595aead1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784e843e-7010-466d-adbd-1dd1595aead1.jpg?1",
             "name": "Breaker of Armies",
             "text": "All creatures able to block Breaker of Armies do so.",
             "colours": [],
@@ -95,7 +95,7 @@
         },
         {
             "id": "74850cf9-020c-5005-9c22-add1ae4358ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc855d3-817c-4748-a7f5-1533d8b0e930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc855d3-817c-4748-a7f5-1533d8b0e930.jpg?1",
             "name": "Conduit of Ruin",
             "text": "When you cast Conduit of Ruin, you may search your library for a colorless creature card with converted mana cost 7 or greater, reveal it, then shuffle your library and put that card on top of it.\nThe first creature spell you cast each turn costs {2} less to cast.",
             "colours": [],
@@ -125,7 +125,7 @@
         },
         {
             "id": "22b1f1d9-1142-5f22-bde1-2a5cbe5accb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f1df-f99a-43c5-81cd-9d333226857a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f1df-f99a-43c5-81cd-9d333226857a.jpg?1",
             "name": "Deathless Behemoth",
             "text": "Vigilance\nSacrifice two Eldrazi Scions: Return Deathless Behemoth from your graveyard to your hand. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -155,7 +155,7 @@
         },
         {
             "id": "733e82d7-3bfc-5f41-a026-0cbfb81535a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d229d8d-5e64-4403-a4ae-a0a186a83935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d229d8d-5e64-4403-a4ae-a0a186a83935.jpg?1",
             "name": "Desolation Twin",
             "text": "When you cast Desolation Twin, put a 10/10 colorless Eldrazi creature token onto the battlefield.",
             "colours": [],
@@ -185,7 +185,7 @@
         },
         {
             "id": "5914c6df-b12d-57e6-857b-ad6f8bcc3f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b13e32-01b9-4a86-a3df-ca8b784c6a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b13e32-01b9-4a86-a3df-ca8b784c6a6c.jpg?1",
             "name": "Eldrazi Devastator",
             "text": "Trample",
             "colours": [],
@@ -215,7 +215,7 @@
         },
         {
             "id": "5b4fa9ae-e76e-5ffd-bea5-9bd730bb3e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64820f4f-1f78-4338-beb8-5ed5a447cfe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64820f4f-1f78-4338-beb8-5ed5a447cfe4.jpg?1",
             "name": "Endless One",
             "text": "Endless One enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -245,7 +245,7 @@
         },
         {
             "id": "30e73d85-2e53-522d-bade-b92843c93a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3e464c-3032-4579-8840-4fe75474e3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3e464c-3032-4579-8840-4fe75474e3fb.jpg?1",
             "name": "Gruesome Slaughter",
             "text": "Until end of turn, colorless creatures you control gain \"{T}: This creature deals damage equal to its power to target creature.\"",
             "colours": [],
@@ -273,7 +273,7 @@
         },
         {
             "id": "4f56bba5-16c8-539d-88b0-e19fffc5e2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c550d179-32ec-4ad8-91c2-d79320a21cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c550d179-32ec-4ad8-91c2-d79320a21cba.jpg?1",
             "name": "Kozilek's Channeler",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -303,7 +303,7 @@
         },
         {
             "id": "81daa4ac-86a9-5830-bad2-625006d4e496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e07a4d-8096-4532-bb00-e6e66f1c6843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e07a4d-8096-4532-bb00-e6e66f1c6843.jpg?1",
             "name": "Oblivion Sower",
             "text": "When you cast Oblivion Sower, target opponent exiles the top four cards of his or her library, then you may put any number of land cards that player owns from exile onto the battlefield under your control.",
             "colours": [],
@@ -333,7 +333,7 @@
         },
         {
             "id": "94f4e266-6ecc-5ac6-903f-57dc7100d634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d997088b-f8f9-4e4c-ba64-aa7f43cc7505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d997088b-f8f9-4e4c-ba64-aa7f43cc7505.jpg?1",
             "name": "Ruin Processor",
             "text": "When you cast Ruin Processor, you may put a card an opponent owns from exile into that player's graveyard. If you do, you gain 5 life.",
             "colours": [],
@@ -364,7 +364,7 @@
         },
         {
             "id": "ffbff514-ea66-5ee4-9377-949b381453ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e47edb2-e43d-479f-a911-e72b67a06c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e47edb2-e43d-479f-a911-e72b67a06c3b.jpg?1",
             "name": "Scour from Existence",
             "text": "Exile target permanent.",
             "colours": [],
@@ -392,7 +392,7 @@
         },
         {
             "id": "226047a2-94a3-555d-95eb-e9faa639ac5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d5e3ab-9719-4918-af4f-25bda5401191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d5e3ab-9719-4918-af4f-25bda5401191.jpg?1",
             "name": "Titan's Presence",
             "text": "As an additional cost to cast Titan's Presence, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
             "colours": [],
@@ -420,7 +420,7 @@
         },
         {
             "id": "47cdfd09-d0c8-59b8-ac7b-9856d2813903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1192f7a9-102e-4b3a-b154-18c8eb332217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1192f7a9-102e-4b3a-b154-18c8eb332217.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast Ulamog, the Ceaseless Hunger, exile two target permanents.\nIndestructible\nWhenever Ulamog attacks, defending player exiles the top twenty cards of his or her library.",
             "colours": [],
@@ -452,7 +452,7 @@
         },
         {
             "id": "66919e34-982f-52c8-bbc9-0dbfc8482054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b6b7f0-d7fc-46b6-99ff-ba8206ecd628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b6b7f0-d7fc-46b6-99ff-ba8206ecd628.jpg?1",
             "name": "Ulamog's Despoiler",
             "text": "As Ulamog's Despoiler enters the battlefield, you may put two cards your opponents own from exile into their owners' graveyards. If you do, Ulamog's Despoiler enters the battlefield with four +1/+1 counters on it.",
             "colours": [],
@@ -483,7 +483,7 @@
         },
         {
             "id": "f6333177-12a3-5271-8b7a-fe553cfca48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbedb0a-34ca-4d42-bb43-cbea0f3c6d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbedb0a-34ca-4d42-bb43-cbea0f3c6d02.jpg?1",
             "name": "Void Winnower",
             "text": "Your opponents can't cast spells with even converted mana costs. (Zero is even.)\nYour opponents can't block with creatures with even converted mana costs.",
             "colours": [],
@@ -513,7 +513,7 @@
         },
         {
             "id": "43b74fa9-d360-5966-9a7e-e26c9885d52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f882ac2-3cbc-4548-8c83-d2a7443991df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f882ac2-3cbc-4548-8c83-d2a7443991df.jpg?1",
             "name": "Angel of Renewal",
             "text": "Flying\nWhen Angel of Renewal enters the battlefield, you gain 1 life for each creature you control.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "cd246617-b8c8-5a0d-94da-fcb1e7d8a9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941246b-7d6a-4b2d-8144-f36ac890a389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941246b-7d6a-4b2d-8144-f36ac890a389.jpg?1",
             "name": "Angelic Gift",
             "text": "Enchant creature\nWhen Angelic Gift enters the battlefield, draw a card.\nEnchanted creature has flying.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "d41249df-9e1e-565d-a2ae-e1b9e120f7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c755ae6-badc-4dc8-bfa6-fdebcb00bfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c755ae6-badc-4dc8-bfa6-fdebcb00bfba.jpg?1",
             "name": "Cliffside Lookout",
             "text": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "d7612e06-8c7a-52bb-944a-b545df4d1634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3afc71-f5db-45c3-96b2-8454b7f33542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3afc71-f5db-45c3-96b2-8454b7f33542.jpg?1",
             "name": "Courier Griffin",
             "text": "Flying\nWhen Courier Griffin enters the battlefield, you gain 2 life.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "e95e4214-1529-5977-a231-94ad4dca9583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c366f25-93c7-4088-88a4-64d3ee18a89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c366f25-93c7-4088-88a4-64d3ee18a89a.jpg?1",
             "name": "Emeria Shepherd",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may return target nonland permanent card from your graveyard to your hand. If that land is a Plains, you may return that nonland permanent card to the battlefield instead.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "bb01e473-ad7d-5c9d-b612-29e52fd034fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575da7cb-6715-43df-a7b4-a4ca00216a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575da7cb-6715-43df-a7b4-a4ca00216a1d.jpg?1",
             "name": "Encircling Fissure",
             "text": "Prevent all combat damage that would be dealt this turn by creatures target opponent controls.\nAwaken 2\u2014{4}{W} (If you cast this spell for {4}{W}, also put two +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "ea6bee58-8333-525b-a3a3-e8ec96fe0af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41193ef1-1619-4448-9905-26b05079c79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41193ef1-1619-4448-9905-26b05079c79a.jpg?1",
             "name": "Expedition Envoy",
             "text": "",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "56cb424c-d22d-5242-b2ba-4d1b7f6b8240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea76a183-e15c-4968-b29d-91c074aa8681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea76a183-e15c-4968-b29d-91c074aa8681.jpg?1",
             "name": "Felidar Cub",
             "text": "Sacrifice Felidar Cub: Destroy target enchantment.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "64bebf91-9dd4-5d30-9639-47eee3135ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039499c3-0b35-4e8e-b0c9-bdf0b4cd90d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039499c3-0b35-4e8e-b0c9-bdf0b4cd90d5.jpg?1",
             "name": "Felidar Sovereign",
             "text": "Vigilance, lifelink\nAt the beginning of your upkeep, if you have 40 or more life, you win the game.",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "319fc57c-4e44-522a-b05d-6b11d59bee70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e2ab-a7f5-45bc-8b2f-31198ea27bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e2ab-a7f5-45bc-8b2f-31198ea27bba.jpg?1",
             "name": "Fortified Rampart",
             "text": "Defender",
             "colours": [
@@ -858,7 +858,7 @@
         },
         {
             "id": "1bb77732-ad50-5a75-b6f5-67845d1df3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de867066-df5c-4412-9d51-56626b6d0220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de867066-df5c-4412-9d51-56626b6d0220.jpg?1",
             "name": "Ghostly Sentinel",
             "text": "Flying, vigilance",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "5ae34679-cf9a-5de0-a03f-aeb166372c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e887c-c39d-4d25-a506-cdc95fc70316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e887c-c39d-4d25-a506-cdc95fc70316.jpg?1",
             "name": "Gideon, Ally of Zendikar",
             "text": "+1: Until end of turn, Gideon, Ally of Zendikar becomes a 5/5 Human Soldier Ally creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.0: Put a 2/2 white Knight Ally creature token onto the battlefield.\u22124: You get an emblem with \"Creatures you control get +1/+1.\"",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "fe1e7965-df83-5529-9b8e-d9db02130632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d8ec3-15ae-4851-9efb-161ca2ee6019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d8ec3-15ae-4851-9efb-161ca2ee6019.jpg?1",
             "name": "Gideon's Reproach",
             "text": "Gideon's Reproach deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "93c31117-0853-5c86-8982-0b370420155c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg?1",
             "name": "Hero of Goma Fada",
             "text": "Rally \u2014 Whenever Hero of Goma Fada or another Ally enters the battlefield under your control, creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "79e09113-a77e-557c-ba0b-8327f8fdf97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b42ef87-8147-4124-9086-0279d42589c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b42ef87-8147-4124-9086-0279d42589c9.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "aeea404b-c58d-54c0-afdf-17356001e6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a07aad-4ed5-47ae-b04c-9b9919000f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a07aad-4ed5-47ae-b04c-9b9919000f6c.jpg?1",
             "name": "Kitesail Scout",
             "text": "Flying",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "06b1a136-55ab-5f1b-b353-82f115781795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b12c7-df11-4450-95e1-b9a5aa97af0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b12c7-df11-4450-95e1-b9a5aa97af0e.jpg?1",
             "name": "Kor Bladewhirl",
             "text": "Rally \u2014 Whenever Kor Bladewhirl or another Ally enters the battlefield under your control, creatures you control gain first strike until end of turn.",
             "colours": [
@@ -1100,7 +1100,7 @@
         },
         {
             "id": "1f511aee-e57f-52c1-9519-0a88594bcd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db2f0e-d7d4-417b-9b94-5ade727907e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db2f0e-d7d4-417b-9b94-5ade727907e9.jpg?1",
             "name": "Kor Castigator",
             "text": "Kor Castigator can't be blocked by Eldrazi Scions.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "9e72e4b5-48b6-5c2d-83fe-6da3716884d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039ead5-2afa-49d6-ae4a-45ae2118188a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039ead5-2afa-49d6-ae4a-45ae2118188a.jpg?1",
             "name": "Kor Entanglers",
             "text": "Rally \u2014 Whenever Kor Entanglers or another Ally enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -1172,7 +1172,7 @@
         },
         {
             "id": "8621fc9c-e4d6-5978-89e6-46c39c3b8c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg?1",
             "name": "Lantern Scout",
             "text": "Rally \u2014 Whenever Lantern Scout or another Ally enters the battlefield under your control, creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "9c35e8f9-1de6-597c-a134-6a13a24e90ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5a1376-88b3-4bdc-9ce9-e90617e6c55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5a1376-88b3-4bdc-9ce9-e90617e6c55e.jpg?1",
             "name": "Lithomancer's Focus",
             "text": "Target creature gets +2/+2 until end of turn. Prevent all damage that would be dealt to that creature this turn by colorless sources.",
             "colours": [
@@ -1240,7 +1240,7 @@
         },
         {
             "id": "c1b1dbe6-61ed-5357-849d-78c61cc63c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae03f018-3062-4b1c-99b8-13fcffd70b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae03f018-3062-4b1c-99b8-13fcffd70b49.jpg?1",
             "name": "Makindi Patrol",
             "text": "Rally \u2014 Whenever Makindi Patrol or another Ally enters the battlefield under your control, creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "b3af1e61-18ff-56a8-ac44-8014b90cddcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9668e-05dc-41c4-9326-ef4c0e15dd80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9668e-05dc-41c4-9326-ef4c0e15dd80.jpg?1",
             "name": "Ondu Greathorn",
             "text": "First strike\nLandfall \u2014 Whenever a land enters the battlefield under your control, Ondu Greathorn gets +2/+2 until end of turn.",
             "colours": [
@@ -1310,7 +1310,7 @@
         },
         {
             "id": "c333b4a4-caae-5cb2-b767-b66e7b20bb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb9f87-7ba4-408c-952d-fc9a7611df42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb9f87-7ba4-408c-952d-fc9a7611df42.jpg?1",
             "name": "Ondu Rising",
             "text": "Whenever a creature attacks this turn, it gains lifelink until end of turn.\nAwaken 4\u2014{4}{W} (If you cast this spell for {4}{W}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "2b5a89d3-c7ee-5259-b24f-d5c5a47d9151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34f930-a7c6-400d-b6e8-b9908e0f0404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34f930-a7c6-400d-b6e8-b9908e0f0404.jpg?1",
             "name": "Planar Outburst",
             "text": "Destroy all nonland creatures.\nAwaken 4\u2014{5}{W}{W}{W} (If you cast this spell for {5}{W}{W}{W}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "ed5c62fa-15b7-5667-98da-3cf51e57877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c525ab-08d5-4d29-aef1-01b0c75ee8d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c525ab-08d5-4d29-aef1-01b0c75ee8d9.jpg?1",
             "name": "Quarantine Field",
             "text": "Quarantine Field enters the battlefield with X isolation counters on it.\nWhen Quarantine Field enters the battlefield, for each isolation counter on it, exile up to one target nonland permanent an opponent controls until Quarantine Field leaves the battlefield.",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "02cfd7ad-d706-5b6d-86e6-863fb2a89440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65101f-808a-40b8-8864-ee84c00d2496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65101f-808a-40b8-8864-ee84c00d2496.jpg?1",
             "name": "Retreat to Emeria",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Put a 1/1 white Kor Ally creature token onto the battlefield.\u2022 Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1438,7 +1438,7 @@
         },
         {
             "id": "d0d7b48c-5445-5b0b-898f-ee585f5f32de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de575e-d955-48da-8fc8-05d7398bd261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de575e-d955-48da-8fc8-05d7398bd261.jpg?1",
             "name": "Roil's Retribution",
             "text": "Roil's Retribution deals 5 damage divided as you choose among any number of target attacking or blocking creatures.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "bd8043ee-4f9a-5581-91a2-d95b74688c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f5dd4-4dc7-4e2c-a30b-9286499433d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f5dd4-4dc7-4e2c-a30b-9286499433d8.jpg?1",
             "name": "Serene Steward",
             "text": "Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature.",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "e8c97e17-0abf-590f-be45-cd217091ca6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ffaf62-2e12-4b1d-a590-f63aacb4a30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ffaf62-2e12-4b1d-a590-f63aacb4a30b.jpg?1",
             "name": "Shadow Glider",
             "text": "Flying",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "4be2fbd7-598f-50ce-adb5-a53e083798aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c85fa4-862d-4f94-9531-b62775838ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c85fa4-862d-4f94-9531-b62775838ab9.jpg?1",
             "name": "Sheer Drop",
             "text": "Destroy target tapped creature.\nAwaken 3\u2014{5}{W} (If you cast this spell for {5}{W}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -1573,7 +1573,7 @@
         },
         {
             "id": "fcc0142b-86c9-5853-a828-0998960045df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766aad27-e987-45ab-82aa-e5f44fcc34ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766aad27-e987-45ab-82aa-e5f44fcc34ef.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "0cb375bd-61ef-5b65-916a-8ddcb190fa17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff820544-f4a3-40c4-a48e-84b5e2d06caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff820544-f4a3-40c4-a48e-84b5e2d06caa.jpg?1",
             "name": "Stasis Snare",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Stasis Snare enters the battlefield, exile target creature an opponent controls until Stasis Snare leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -1637,7 +1637,7 @@
         },
         {
             "id": "f21c499f-9625-5db5-8a06-fb5b5bbea838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956563b-bde3-4aec-93fe-e03bade49458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956563b-bde3-4aec-93fe-e03bade49458.jpg?1",
             "name": "Stone Haven Medic",
             "text": "{W}, {T}: You gain 1 life.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "292a2a85-f6af-570d-b7ee-5929dde7cf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8aaf9c-9aa5-44db-9610-402389a3ddc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8aaf9c-9aa5-44db-9610-402389a3ddc5.jpg?1",
             "name": "Tandem Tactics",
             "text": "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "0fdd8e35-479d-5601-baac-d8152ca67831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53472387-6909-462e-8183-02fd1d45126e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53472387-6909-462e-8183-02fd1d45126e.jpg?1",
             "name": "Unified Front",
             "text": "Converge \u2014 Put a 1/1 white Kor Ally creature token onto the battlefield for each color of mana spent to cast Unified Front.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "09ebac3a-adde-538f-8474-b7aee7e969ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d86e0b-294f-41b8-a5cd-d3144a019334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d86e0b-294f-41b8-a5cd-d3144a019334.jpg?1",
             "name": "Adverse Conditions",
             "text": "Devoid (This card has no color.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step. Put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "b7c3fa8e-e293-594b-b248-e9ea65a9dacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380ae58-08cc-42df-ac74-3c6890a62463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380ae58-08cc-42df-ac74-3c6890a62463.jpg?1",
             "name": "Benthic Infiltrator",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)Benthic Infiltrator can't be blocked.",
             "colours": [],
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "b9f6dde8-f31e-5724-b8f3-7ad2fe10e33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2061f7-5e51-4862-9650-0005002d04b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2061f7-5e51-4862-9650-0005002d04b6.jpg?1",
             "name": "Cryptic Cruiser",
             "text": "Devoid (This card has no color.){2}{U}, Put a card an opponent owns from exile into that player's graveyard: Tap target creature.",
             "colours": [],
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "16b90cb9-0828-5dbb-a14b-2702648ff916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd5b48c-6850-47d4-8106-297be6c8f708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd5b48c-6850-47d4-8106-297be6c8f708.jpg?1",
             "name": "Drowner of Hope",
             "text": "Devoid (This card has no color.)\nWhen Drowner of Hope enters the battlefield, put two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"Sacrifice an Eldrazi Scion: Tap target creature.",
             "colours": [],
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "d062850a-9a8a-55d0-a9ae-47372b26ac5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9c1a10-446e-492a-95cc-a459dc6c08a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9c1a10-446e-492a-95cc-a459dc6c08a0.jpg?1",
             "name": "Eldrazi Skyspawner",
             "text": "Devoid (This card has no color.)\nFlying\nWhen Eldrazi Skyspawner enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "37ad78fc-7305-53fa-b4aa-7b8c1c329d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd05532-686e-40dc-858b-8a77a3628c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd05532-686e-40dc-858b-8a77a3628c99.jpg?1",
             "name": "Horribly Awry",
             "text": "Devoid (This card has no color.)\nCounter target creature spell with converted mana cost 4 or less. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [],
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "46046801-f5fd-5282-b0c5-a1c217a546a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0855762-7068-4111-a6bf-fe6d5b092c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0855762-7068-4111-a6bf-fe6d5b092c74.jpg?1",
             "name": "Incubator Drone",
             "text": "Devoid (This card has no color.)\nWhen Incubator Drone enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "e6871bbd-d7f6-50b8-910f-8c3463e7a315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2e662-d8c3-44d4-b666-fe0d4a046271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2e662-d8c3-44d4-b666-fe0d4a046271.jpg?1",
             "name": "Mist Intruder",
             "text": "Devoid (This card has no color.)\nFlying\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)",
             "colours": [],
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "9294216c-a013-5a6c-940d-f225529856da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130849ba-3893-490d-bfb0-51c76e53cf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130849ba-3893-490d-bfb0-51c76e53cf62.jpg?1",
             "name": "Murk Strider",
             "text": "Devoid (This card has no color.)\nWhen Murk Strider enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target creature to its owner's hand.",
             "colours": [],
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "9dc8043d-f71f-576c-b312-01773b7a14c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c121d73-0c87-4a3f-b013-4f9314e22606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c121d73-0c87-4a3f-b013-4f9314e22606.jpg?1",
             "name": "Oracle of Dust",
             "text": "Devoid (This card has no color.){2}, Put a card an opponent owns from exile into that player's graveyard: Draw a card, then discard a card.",
             "colours": [],
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "a587b7b9-abea-5c98-a499-8957ce40ecad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bdbe64-d985-4bc5-bb1d-4cbf12ef60b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bdbe64-d985-4bc5-bb1d-4cbf12ef60b2.jpg?1",
             "name": "Ruination Guide",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)\nOther colorless creatures you control get +1/+0.",
             "colours": [],
@@ -2092,7 +2092,7 @@
         },
         {
             "id": "36ff2e8a-e476-52ed-acf8-3b0b88a2ddbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8ce2a9-9d8e-442b-bc12-74545ceb65bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8ce2a9-9d8e-442b-bc12-74545ceb65bd.jpg?1",
             "name": "Salvage Drone",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)\nWhen Salvage Drone dies, you may draw a card. If you do, discard a card.",
             "colours": [],
@@ -2125,7 +2125,7 @@
         },
         {
             "id": "f7ad5416-3578-577d-be73-4ace38e9d537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa110cb-f091-48f0-bc62-80f5f18568e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa110cb-f091-48f0-bc62-80f5f18568e8.jpg?1",
             "name": "Spell Shrivel",
             "text": "Devoid (This card has no color.)\nCounter target spell unless its controller pays {4}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [],
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "7a344106-1a72-5048-a19c-89cea1eeb1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c590579-e0ef-4839-8f67-f52813cd9fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c590579-e0ef-4839-8f67-f52813cd9fe7.jpg?1",
             "name": "Tide Drifter",
             "text": "Devoid (This card has no color.)\nOther colorless creatures you control get +0/+1.",
             "colours": [],
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "b7349964-9cc0-5ff9-9eb5-13ba259794c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a237a6-0e72-47ce-b28d-a0260963f406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a237a6-0e72-47ce-b28d-a0260963f406.jpg?1",
             "name": "Ulamog's Reclaimer",
             "text": "Devoid (This card has no color.)\nWhen Ulamog's Reclaimer enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [],
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "460dd1b7-8bd3-59b1-941e-0507a57fddba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c1931-06b4-4c69-9c2f-0dee3543c632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c1931-06b4-4c69-9c2f-0dee3543c632.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "1dea24c8-febb-559a-bf7a-a889ab562df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc4013b-fb4f-4bbe-a15c-488f89545695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc4013b-fb4f-4bbe-a15c-488f89545695.jpg?1",
             "name": "Brilliant Spectrum",
             "text": "Converge \u2014 Draw X cards, where X is the number of colors of mana spent to cast Brilliant Spectrum. Then discard two cards.",
             "colours": [
@@ -2285,7 +2285,7 @@
         },
         {
             "id": "e394f64e-1a56-5b6b-a4e4-56aeed9e7c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1854f819-d08e-4a23-bedb-4618b79623e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1854f819-d08e-4a23-bedb-4618b79623e9.jpg?1",
             "name": "Cloud Manta",
             "text": "Flying",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "012f4e74-fade-55ce-bfab-57630b5b15df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d20f482-e0b2-4e4a-be32-347ab112912c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d20f482-e0b2-4e4a-be32-347ab112912c.jpg?1",
             "name": "Clutch of Currents",
             "text": "Return target creature to its owner's hand.\nAwaken 3\u2014{4}{U} (If you cast this spell for {4}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "9986f842-3fea-5b21-b199-62e59ba65c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df2411-0b0d-4b93-bf30-a22487b3c6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df2411-0b0d-4b93-bf30-a22487b3c6ef.jpg?1",
             "name": "Coastal Discovery",
             "text": "Draw two cards.\nAwaken 4\u2014{5}{U} (If you cast this spell for {5}{U}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2383,7 +2383,7 @@
         },
         {
             "id": "d3e0cbea-70d8-5ec3-bbfa-20d18b9b9243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33787a5b-d1d1-4d60-ba09-d9c98025e9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33787a5b-d1d1-4d60-ba09-d9c98025e9b3.jpg?1",
             "name": "Coralhelm Guide",
             "text": "{4}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "043a8620-eddc-5113-8a54-9d4e607b7ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4393f6-54d7-4963-a3c0-b3a083c2440c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4393f6-54d7-4963-a3c0-b3a083c2440c.jpg?1",
             "name": "Dampening Pulse",
             "text": "Creatures your opponents control get -1/-0.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "918e460b-cd42-5ad6-b32f-fcdcead639c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceab6b3-6b64-4964-a501-ce806a6c13ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceab6b3-6b64-4964-a501-ce806a6c13ad.jpg?1",
             "name": "Dispel",
             "text": "Counter target instant spell.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "77eee0f0-5559-5933-abc0-22924a0518d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35e9d13-ee4b-42f1-a154-18ab32947ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35e9d13-ee4b-42f1-a154-18ab32947ad3.jpg?1",
             "name": "Exert Influence",
             "text": "Converge \u2014 Gain control of target creature if its power is less than or equal to the number of colors of mana spent to cast Exert Influence.",
             "colours": [
@@ -2515,7 +2515,7 @@
         },
         {
             "id": "9863ad0b-e3d0-5213-9663-49181c5c2ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b55cf5e-4499-4e3a-9748-7b1568286b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b55cf5e-4499-4e3a-9748-7b1568286b5a.jpg?1",
             "name": "Guardian of Tazeem",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, tap target creature an opponent controls. If that land is an Island, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2549,7 +2549,7 @@
         },
         {
             "id": "93594dcc-64e7-54ac-89e0-dfd9bafbfb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3e3b18-bf00-4f1a-9918-9a0e9d75b747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3e3b18-bf00-4f1a-9918-9a0e9d75b747.jpg?1",
             "name": "Halimar Tidecaller",
             "text": "When Halimar Tidecaller enters the battlefield, you may return target card with awaken from your graveyard to your hand.\nLand creatures you control have flying.",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "5ca42991-3cd7-5fce-b55d-23809e7f6bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fe992f-0441-42be-89f9-2387b4bc24ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fe992f-0441-42be-89f9-2387b4bc24ce.jpg?1",
             "name": "Part the Waterveil",
             "text": "Take an extra turn after this one. Exile Part the Waterveil.\nAwaken 6\u2014{6}{U}{U}{U} (If you cast this spell for {6}{U}{U}{U}, also put six +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2617,7 +2617,7 @@
         },
         {
             "id": "811dbd1e-76db-5ff7-8eca-2660d519079a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18c46d-dd6b-4feb-9eb3-3d52985ce6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18c46d-dd6b-4feb-9eb3-3d52985ce6e1.jpg?1",
             "name": "Prism Array",
             "text": "Converge \u2014 Prism Array enters the battlefield with a crystal counter on it for each color of mana spent to cast it.\nRemove a crystal counter from Prism Array: Tap target creature.{W}{U}{B}{R}{G}: Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2653,7 +2653,7 @@
         },
         {
             "id": "e8e6086b-0eb7-5b13-a282-39491756e293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68684c8e-dc19-4a56-b511-4e21140b137f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68684c8e-dc19-4a56-b511-4e21140b137f.jpg?1",
             "name": "Retreat to Coralhelm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 You may tap or untap target creature.\u2022 Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "8e97d084-6f32-5001-ac7e-8cd71a8ef373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2194713-c08c-4fba-8e31-bb67c9932173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2194713-c08c-4fba-8e31-bb67c9932173.jpg?1",
             "name": "Roilmage's Trick",
             "text": "Converge \u2014 Creatures your opponents control get -X/-0 until end of turn, where X is the number of colors of mana spent to cast Roilmage's Trick.\nDraw a card.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "9cd805da-cbae-5ebc-91ce-694f35d201c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae6f63-d1b2-4bf9-a423-ed6fbb540d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae6f63-d1b2-4bf9-a423-ed6fbb540d4b.jpg?1",
             "name": "Rush of Ice",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nAwaken 3\u2014{4}{U} (If you cast this spell for {4}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "c73c4631-2d1d-52cd-9875-2f54c22f3eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ad49f-fe15-4fe5-9731-fd71d31c1e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ad49f-fe15-4fe5-9731-fd71d31c1e7f.jpg?1",
             "name": "Scatter to the Winds",
             "text": "Counter target spell.\nAwaken 3\u2014{4}{U}{U} (If you cast this spell for {4}{U}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "405dea5b-b3b6-50d9-9cd0-c1d58a7050f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a014dd06-626d-4917-8981-e0064718b571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a014dd06-626d-4917-8981-e0064718b571.jpg?1",
             "name": "Tightening Coils",
             "text": "Enchant creature\nEnchanted creature gets -6/-0 and loses flying.",
             "colours": [
@@ -2815,7 +2815,7 @@
         },
         {
             "id": "76a49258-76a8-5f0c-ac22-dd89196ecb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37d5938-9c8f-4203-8f3f-d6e89ced28ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37d5938-9c8f-4203-8f3f-d6e89ced28ef.jpg?1",
             "name": "Ugin's Insight",
             "text": "Scry X, where X is the highest converted mana cost among permanents you control, then draw three cards.",
             "colours": [
@@ -2847,7 +2847,7 @@
         },
         {
             "id": "c0a41f1b-c030-5670-b85c-0193b8d2ac94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b45809-87fc-409d-942a-1f31f68d27ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b45809-87fc-409d-942a-1f31f68d27ac.jpg?1",
             "name": "Wave-Wing Elemental",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, Wave-Wing Elemental gets +2/+2 until end of turn.",
             "colours": [
@@ -2881,7 +2881,7 @@
         },
         {
             "id": "ae31b545-785d-5e81-a391-a49d9ce4eb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac7b904-7658-4248-a75c-b3a862bde196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac7b904-7658-4248-a75c-b3a862bde196.jpg?1",
             "name": "Windrider Patrol",
             "text": "Flying\nWhenever Windrider Patrol deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "d9e912ef-b482-565d-a408-cac504037632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d94e878-6c49-4420-9d34-f9ee64e811ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d94e878-6c49-4420-9d34-f9ee64e811ba.jpg?1",
             "name": "Complete Disregard",
             "text": "Devoid (This card has no color.)\nExile target creature with power 3 or less.",
             "colours": [],
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "fd1183ad-ae98-5c4b-b93d-97d32b74d999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a623415-46c0-45aa-ab75-1e2d9708013a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a623415-46c0-45aa-ab75-1e2d9708013a.jpg?1",
             "name": "Culling Drone",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)",
             "colours": [],
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "05767988-710c-54ed-a1f0-6b2f4361ac90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e7e2b5-3141-4a19-aa49-91ab7e5c211c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e7e2b5-3141-4a19-aa49-91ab7e5c211c.jpg?1",
             "name": "Dominator Drone",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)\nWhen Dominator Drone enters the battlefield, if you control another colorless creature, each opponent loses 2 life.",
             "colours": [],
@@ -3012,7 +3012,7 @@
         },
         {
             "id": "40c0003b-32d8-5fec-8baa-46c53acb1f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e996a30-3a4d-4a26-8386-f9eb9c999dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e996a30-3a4d-4a26-8386-f9eb9c999dc0.jpg?1",
             "name": "Grave Birthing",
             "text": "Devoid (This card has no color.)\nTarget opponent exiles a card from his or her graveyard. You put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"Draw a card.",
             "colours": [],
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "d68066e4-c4e0-5b47-8a21-d19ed3a449c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850b388a-c188-433a-8124-1d51b43a4e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850b388a-c188-433a-8124-1d51b43a4e51.jpg?1",
             "name": "Grip of Desolation",
             "text": "Devoid (This card has no color.)\nExile target creature and target land.",
             "colours": [],
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "09be79b7-c83b-5faa-9d91-b64a57079fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d07fea-e16a-45e3-a172-9d726cd42769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d07fea-e16a-45e3-a172-9d726cd42769.jpg?1",
             "name": "Mind Raker",
             "text": "Devoid (This card has no color.)\nWhen Mind Raker enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, each opponent discards a card.",
             "colours": [],
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "159409a6-59e0-5622-bd86-75387c21c12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b715fc0-9c36-4619-8d65-6d1064ed8a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b715fc0-9c36-4619-8d65-6d1064ed8a32.jpg?1",
             "name": "Silent Skimmer",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever Silent Skimmer attacks, defending player loses 2 life.",
             "colours": [],
@@ -3138,7 +3138,7 @@
         },
         {
             "id": "949be71e-35f7-5253-9645-698dfb0986a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cbecdc-bc30-4797-bf6f-a7a61db05b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cbecdc-bc30-4797-bf6f-a7a61db05b48.jpg?1",
             "name": "Skitterskin",
             "text": "Devoid (This card has no color.)Skitterskin can't block.{1}{B}: Regenerate Skitterskin. Activate this ability only if you control another colorless creature.",
             "colours": [],
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "c58bda48-7dc3-5c01-b63f-58d011ef32dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9782b463-0677-40f4-ab2c-4c3ff19f1168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9782b463-0677-40f4-ab2c-4c3ff19f1168.jpg?1",
             "name": "Sludge Crawler",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.){2}: Sludge Crawler gets +1/+1 until end of turn.",
             "colours": [],
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "46b65a4d-396b-55ff-a408-8c9c7c1b1471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81d0de-01a3-4f28-8a2b-c2e6f36a03c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81d0de-01a3-4f28-8a2b-c2e6f36a03c4.jpg?1",
             "name": "Smothering Abomination",
             "text": "Devoid (This card has no color.)\nFlying\nAt the beginning of your upkeep, sacrifice a creature.\nWhenever you sacrifice a creature, draw a card.",
             "colours": [],
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "8d2a80df-9144-547a-8a6f-51ab63fc9271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837287cc-f3a4-4ba7-8518-9b1e4a53acda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837287cc-f3a4-4ba7-8518-9b1e4a53acda.jpg?1",
             "name": "Swarm Surge",
             "text": "Devoid (This card has no color.)\nCreatures you control get +2/+0 until end of turn. Colorless creatures you control also gain first strike until end of turn.",
             "colours": [],
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "29ba7037-2b75-5c93-96c4-0f6be2cf6520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5742910-3d0f-4710-a5f5-f7a7908833dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5742910-3d0f-4710-a5f5-f7a7908833dc.jpg?1",
             "name": "Transgress the Mind",
             "text": "Devoid (This card has no color.)\nTarget player reveals his or her hand. You choose a card from it with converted mana cost 3 or greater and exile that card.",
             "colours": [],
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "b2b9b572-8bc5-5958-95c6-00e80d4ae100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e215ab0-efd6-4ea2-8bd2-0a93865e1e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e215ab0-efd6-4ea2-8bd2-0a93865e1e3c.jpg?1",
             "name": "Wasteland Strangler",
             "text": "Devoid (This card has no color.)\nWhen Wasteland Strangler enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, target creature gets -3/-3 until end of turn.",
             "colours": [],
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "c1f29695-767f-5b55-ba3d-ec61c93d2312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ca3f24-eb14-46fe-9a7a-3752f706d067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ca3f24-eb14-46fe-9a7a-3752f706d067.jpg?1",
             "name": "Altar's Reap",
             "text": "As an additional cost to cast Altar's Reap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "1785dbb1-354e-50cb-b2c4-b9116c1c2d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca31ce70-24c5-4fb2-8d88-c9ffa8474c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca31ce70-24c5-4fb2-8d88-c9ffa8474c8f.jpg?1",
             "name": "Bloodbond Vampire",
             "text": "Whenever you gain life, put a +1/+1 counter on Bloodbond Vampire.",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "4bd12a68-fa94-53f8-90ff-071224fc4131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74780faa-1c64-4d73-8d09-53b47ba02d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74780faa-1c64-4d73-8d09-53b47ba02d7a.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "8ac00196-9b73-5a9d-b889-d2507f8e0b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2ab895-9225-4eba-90c3-4023db4f8b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2ab895-9225-4eba-90c3-4023db4f8b70.jpg?1",
             "name": "Carrier Thrall",
             "text": "When Carrier Thrall dies, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "386c74f0-9b01-508e-86bf-2e1f0713a2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b5dd64-9e58-4f22-9d86-7a518d976037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b5dd64-9e58-4f22-9d86-7a518d976037.jpg?1",
             "name": "Defiant Bloodlord",
             "text": "Flying\nWhenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "9c72b004-a983-5593-a568-f1905ec3ed8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff953948-db26-43af-9905-7d387769b4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff953948-db26-43af-9905-7d387769b4a9.jpg?1",
             "name": "Demon's Grasp",
             "text": "Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "66555fc7-38c6-5c1d-863a-7642fe6e5e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f6ed18-eb6f-4d07-8660-cf7c074c87cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f6ed18-eb6f-4d07-8660-cf7c074c87cd.jpg?1",
             "name": "Drana, Liberator of Malakir",
             "text": "Flying, first strike\nWhenever Drana, Liberator of Malakir deals combat damage to a player, put a +1/+1 counter on each attacking creature you control.",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "af4fa59c-8f63-556d-8a4b-10814caf68f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d6cb71-c911-4f82-93e9-654e8ffa85c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d6cb71-c911-4f82-93e9-654e8ffa85c9.jpg?1",
             "name": "Dutiful Return",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "e424a07f-69e2-508b-8af6-901bed70099b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d1e1e1-fa24-4e78-a77c-4d41a58b8aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d1e1e1-fa24-4e78-a77c-4d41a58b8aa0.jpg?1",
             "name": "Geyserfield Stalker",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, Geyserfield Stalker gets +2/+2 until end of turn.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "6e5616f0-efde-5360-bd5b-c37b9ab8d93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793bb4e0-8fdd-440e-9e6e-92a899794cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793bb4e0-8fdd-440e-9e6e-92a899794cae.jpg?1",
             "name": "Guul Draz Overseer",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, other creatures you control get +1/+0 until end of turn. If that land is a Swamp, those creatures get +2/+0 until end of turn instead.",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "83f1ff24-22b0-586a-81fa-d7baa6cebd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706b2e3-bd0e-4111-8b68-976869c7d707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706b2e3-bd0e-4111-8b68-976869c7d707.jpg?1",
             "name": "Hagra Sharpshooter",
             "text": "{4}{B}: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "51aa0f08-ace5-593b-ac45-3ffe2fdd34d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c21cb3-21f4-4a8d-8068-52649f2a1846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c21cb3-21f4-4a8d-8068-52649f2a1846.jpg?1",
             "name": "Kalastria Healer",
             "text": "Rally \u2014 Whenever Kalastria Healer or another Ally enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "b2b8310d-5533-56eb-b20c-1cb818fd7edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13989bf2-fd02-4702-9170-4b066837de65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13989bf2-fd02-4702-9170-4b066837de65.jpg?1",
             "name": "Kalastria Nightwatch",
             "text": "Whenever you gain life, Kalastria Nightwatch gains flying until end of turn.",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "bbc49cb1-bfac-5144-a227-d37c24191a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f03b00a-f6d0-419a-abfd-fa8bc63226db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f03b00a-f6d0-419a-abfd-fa8bc63226db.jpg?1",
             "name": "Malakir Familiar",
             "text": "Flying, deathtouch\nWhenever you gain life, Malakir Familiar gets +1/+1 until end of turn.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "64362925-f2b4-5d79-b29d-9ac7728fcf4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d737fb-fd09-4483-8128-8897cbcdc4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d737fb-fd09-4483-8128-8897cbcdc4f5.jpg?1",
             "name": "Mire's Malice",
             "text": "Target opponent discards two cards.\nAwaken 3\u2014{5}{B} (If you cast this spell for {5}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "3c670188-d515-5967-94c9-d0de8c1fcd5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca43ea1-ba7b-4dc7-b6f6-a0c92321ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca43ea1-ba7b-4dc7-b6f6-a0c92321ebe1.jpg?1",
             "name": "Nirkana Assassin",
             "text": "Whenever you gain life, Nirkana Assassin gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3876,7 +3876,7 @@
         },
         {
             "id": "84682207-f123-57a0-af12-22750a232488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b2d6e9-2a43-4ebe-9ae8-944375b46cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b2d6e9-2a43-4ebe-9ae8-944375b46cce.jpg?1",
             "name": "Ob Nixilis Reignited",
             "text": "+1: You draw a card and you lose 1 life.\u22123: Destroy target creature.\u22128: Target opponent gets an emblem with \"Whenever a player draws a card, you lose 2 life.\"",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "a3cccf34-9318-5d47-9907-814ad54c0e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a3afdb-aeb2-4699-91f9-5c42284b3a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a3afdb-aeb2-4699-91f9-5c42284b3a4a.jpg?1",
             "name": "Painful Truths",
             "text": "Converge \u2014 You draw X cards and you lose X life, where X is the number of colors of mana spent to cast Painful Truths.",
             "colours": [
@@ -3944,7 +3944,7 @@
         },
         {
             "id": "8d2a7c53-d986-5521-82b5-de480219e9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48505c90-ee73-40ad-b774-a6f4bfffff4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48505c90-ee73-40ad-b774-a6f4bfffff4b.jpg?1",
             "name": "Retreat to Hagra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Target creature gets +1/+0 and gains deathtouch until end of turn.\u2022 Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "a1e0d3b2-8b76-5727-9e27-a8048c8a5030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9a8e87-3b8b-4dbf-9c1e-0a3290a33a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9a8e87-3b8b-4dbf-9c1e-0a3290a33a0b.jpg?1",
             "name": "Rising Miasma",
             "text": "All creatures get -2/-2 until end of turn.\nAwaken 3\u2014{5}{B}{B} (If you cast this spell for {5}{B}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "07f02c9c-6fbe-57c7-8cd0-ba7ea8d0f111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709ab9cf-eed8-4d73-b10d-c7f6d8750328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709ab9cf-eed8-4d73-b10d-c7f6d8750328.jpg?1",
             "name": "Ruinous Path",
             "text": "Destroy target creature or planeswalker.\nAwaken 4\u2014{5}{B}{B} (If you cast this spell for {5}{B}{B}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "92f64c2a-78a6-59bb-ad03-ec150a705fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416309a-5824-48f5-876e-00e0f180acf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416309a-5824-48f5-876e-00e0f180acf9.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "d714c755-d296-52bf-aa44-8414a1ffb9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74364056-f4ee-46d3-834d-a5157ec312b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74364056-f4ee-46d3-834d-a5157ec312b9.jpg?1",
             "name": "Voracious Null",
             "text": "{1}{B}, Sacrifice another creature: Put two +1/+1 counters on Voracious Null. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "db9ec4e8-d4e6-57e7-9aaa-c02b56875a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c963d97-c948-45d9-84cc-58e246d35970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c963d97-c948-45d9-84cc-58e246d35970.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "f9b10401-1ce7-5bc1-989d-831356ef6306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a83120-c0c5-4277-acae-6ecb6f6bf3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a83120-c0c5-4277-acae-6ecb6f6bf3e1.jpg?1",
             "name": "Barrage Tyrant",
             "text": "Devoid (This card has no color.){2}{R}, Sacrifice another colorless creature: Barrage Tyrant deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [],
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "978dc2b1-19ef-559f-9180-9db0e789b0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63352c11-807d-4878-a975-02ef451c3184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63352c11-807d-4878-a975-02ef451c3184.jpg?1",
             "name": "Crumble to Dust",
             "text": "Devoid (This card has no color.)\nExile target nonbasic land. Search its controller's graveyard, hand, and library for any number of cards with the same name as that land and exile them. Then that player shuffles his or her library.",
             "colours": [],
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "bfc55522-1119-5b1f-9e27-485da5d54712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c6a0f-3f75-45ff-aae9-5c866be279d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c6a0f-3f75-45ff-aae9-5c866be279d0.jpg?1",
             "name": "Kozilek's Sentinel",
             "text": "Devoid (This card has no color.)\nWhenever you cast a colorless spell, Kozilek's Sentinel gets +1/+0 until end of turn.",
             "colours": [],
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "e5c95e71-5b8d-5f51-a3db-7d6ac988b7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8aaf5-e2bf-40ea-bd5d-663017cfd4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8aaf5-e2bf-40ea-bd5d-663017cfd4a6.jpg?1",
             "name": "Molten Nursery",
             "text": "Devoid (This card has no color.)\nWhenever you cast a colorless spell, Molten Nursery deals 1 damage to target creature or player.",
             "colours": [],
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "5d94a7f2-930d-5b52-aaf4-433cc89432d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e633833a-cc4b-4c8c-a0d3-cd263e09df81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e633833a-cc4b-4c8c-a0d3-cd263e09df81.jpg?1",
             "name": "Nettle Drone",
             "text": "Devoid (This card has no color.){T}: Nettle Drone deals 1 damage to each opponent.\nWhenever you cast a colorless spell, untap Nettle Drone.",
             "colours": [],
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "9c58bb8b-769d-5b0c-96a9-79eb248ac5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a689975-d27b-4b8f-8d46-6e97c754ae81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a689975-d27b-4b8f-8d46-6e97c754ae81.jpg?1",
             "name": "Processor Assault",
             "text": "Devoid (This card has no color.)\nAs an additional cost to cast Processor Assault, put a card an opponent owns from exile into that player's graveyard.Processor Assault deals 5 damage to target creature.",
             "colours": [],
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "cbbdc21a-853d-5a71-a45f-8c7d3c7d31be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53222f33-6d18-4008-a38d-6f7995691260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53222f33-6d18-4008-a38d-6f7995691260.jpg?1",
             "name": "Serpentine Spike",
             "text": "Devoid (This card has no color.)Serpentine Spike deals 2 damage to target creature, 3 damage to another target creature, and 4 damage to a third target creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [],
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "5749a517-a4be-5f11-b3ba-c0d62e585378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006ead4a-dc57-4856-8e13-235ba55483e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006ead4a-dc57-4856-8e13-235ba55483e6.jpg?1",
             "name": "Touch of the Void",
             "text": "Devoid (This card has no color.)Touch of the Void deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [],
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "5ddb2bad-e84c-5034-b3bb-a53e614f28c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de8ef35-f141-4bc6-8ea1-f87aa6f5ecd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de8ef35-f141-4bc6-8ea1-f87aa6f5ecd7.jpg?1",
             "name": "Turn Against",
             "text": "Devoid (This card has no color.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [],
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "596bc95b-8993-5bc6-a740-09f68331a6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d84986-64a1-4bd1-a4f6-3eb147aca357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d84986-64a1-4bd1-a4f6-3eb147aca357.jpg?1",
             "name": "Vestige of Emrakul",
             "text": "Devoid (This card has no color.)\nTrample",
             "colours": [],
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "29d10c5f-ed45-55fc-aadc-027f1bafaa98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec66525-a7e9-450f-83df-03d9957837d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec66525-a7e9-450f-83df-03d9957837d5.jpg?1",
             "name": "Vile Aggregate",
             "text": "Devoid (This card has no color.)Vile Aggregate's power is equal to the number of colorless creatures you control.\nTrample\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)",
             "colours": [],
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "ae2cba2e-b82b-54fe-a3a3-643da5c075d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304a2e4c-da2c-43fb-b44d-9db55ff94f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304a2e4c-da2c-43fb-b44d-9db55ff94f04.jpg?1",
             "name": "Akoum Firebird",
             "text": "Flying, hasteAkoum Firebird attacks each turn if able.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may pay {4}{R}{R}. If you do, return Akoum Firebird from your graveyard to the battlefield.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "da3e0034-0da0-571a-9ffa-9cefd2543284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce837a65-a588-4b50-b298-f4ca37dbd06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce837a65-a588-4b50-b298-f4ca37dbd06d.jpg?1",
             "name": "Akoum Hellkite",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, Akoum Hellkite deals 1 damage to target creature or player. If that land is a Mountain, Akoum Hellkite deals 2 damage to that creature or player instead.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "bc787458-d536-52d2-b1d3-388272573021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ab7b5-6a29-463e-b294-3cb0efaccddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ab7b5-6a29-463e-b294-3cb0efaccddb.jpg?1",
             "name": "Akoum Stonewaker",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {2}{R}. If you do, put a 3/1 red Elemental creature token with trample and haste onto the battlefield. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "7ccf707b-6177-5ea8-b517-da993ae2b654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b5b7d2-acb8-4aca-b9e7-67e59aeb384b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b5b7d2-acb8-4aca-b9e7-67e59aeb384b.jpg?1",
             "name": "Belligerent Whiptail",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Belligerent Whiptail gains first strike until end of turn.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "9e2eef4e-7b72-5bbd-b612-e6fbfc7c5da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaab44c-4ce1-43fb-915c-c687fe8559ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaab44c-4ce1-43fb-915c-c687fe8559ce.jpg?1",
             "name": "Boiling Earth",
             "text": "Boiling Earth deals 1 damage to each creature your opponents control.\nAwaken 4\u2014{6}{R} (If you cast this spell for {6}{R}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "218af701-ab0d-56a7-9ff2-5a1b8f20026a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd0fad7-264d-40fc-a616-a88dc94fa4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd0fad7-264d-40fc-a616-a88dc94fa4d7.jpg?1",
             "name": "Chasm Guide",
             "text": "Rally \u2014 Whenever Chasm Guide or another Ally enters the battlefield under your control, creatures you control gain haste until end of turn.",
             "colours": [
@@ -4691,7 +4691,7 @@
         },
         {
             "id": "75b796f3-2b2a-57e6-9eac-1f4a06e26495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d1424-03c8-443b-a3bc-14bb168e32c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d1424-03c8-443b-a3bc-14bb168e32c9.jpg?1",
             "name": "Dragonmaster Outcast",
             "text": "At the beginning of your upkeep, if you control six or more lands, put a 5/5 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "aded6d73-f61b-528c-ad3e-ce93213b37de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197411bf-3307-4056-a7d4-31db0d4b8f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197411bf-3307-4056-a7d4-31db0d4b8f9a.jpg?1",
             "name": "Firemantle Mage",
             "text": "Rally \u2014 Whenever Firemantle Mage or another Ally enters the battlefield under your control, creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "b42b488c-41d3-520c-b330-ab0a857a0690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ff3183-c273-4a61-ad25-526db29111c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ff3183-c273-4a61-ad25-526db29111c8.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -4796,7 +4796,7 @@
         },
         {
             "id": "0b19e75f-d1e6-5c97-be4d-4703bd5708a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428f13f-c445-4eb4-bab1-309f27cab208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428f13f-c445-4eb4-bab1-309f27cab208.jpg?1",
             "name": "Lavastep Raider",
             "text": "{2}{R}: Lavastep Raider gets +2/+0 until end of turn.",
             "colours": [
@@ -4831,7 +4831,7 @@
         },
         {
             "id": "b173eab2-c7c5-5f66-89a9-1e7dc63116f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6da400-ee4e-44d1-887d-1e2fb59b9322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6da400-ee4e-44d1-887d-1e2fb59b9322.jpg?1",
             "name": "Makindi Sliderunner",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Makindi Sliderunner gets +1/+1 until end of turn.",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "c667bddb-a65b-539e-a6ae-2465e0179b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708e1979-902b-410a-ae46-3fd1d2acc31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708e1979-902b-410a-ae46-3fd1d2acc31d.jpg?1",
             "name": "Ondu Champion",
             "text": "Rally \u2014 Whenever Ondu Champion or another Ally enters the battlefield under your control, creatures you control gain trample until end of turn.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "b0409791-7818-5225-b284-9efa9655fa81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3373281-7319-4320-8afb-4546fb55ab4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3373281-7319-4320-8afb-4546fb55ab4c.jpg?1",
             "name": "Outnumber",
             "text": "Outnumber deals damage to target creature equal to the number of creatures you control.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "2a98eb58-b457-58ca-8d33-6fcf4a6ee760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f4fe69-c541-4320-9074-9c6a3bc70ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f4fe69-c541-4320-9074-9c6a3bc70ea3.jpg?1",
             "name": "Radiant Flames",
             "text": "Converge \u2014 Radiant Flames deals X damage to each creature, where X is the number of colors of mana spent to cast Radiant Flames.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "6a5ef048-6f1f-507b-984d-2cf81a9c69c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a4cdec-e5fc-4ea8-a7bc-f1109fadae3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a4cdec-e5fc-4ea8-a7bc-f1109fadae3c.jpg?1",
             "name": "Reckless Cohort",
             "text": "Reckless Cohort attacks each combat if able unless you control another Ally.",
             "colours": [
@@ -5001,7 +5001,7 @@
         },
         {
             "id": "b96581dc-d1bf-5bc6-845d-f7e9155050fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a9ce97-ef6d-468c-b389-8d19c76174c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a9ce97-ef6d-468c-b389-8d19c76174c2.jpg?1",
             "name": "Retreat to Valakut",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Target creature gets +2/+0 until end of turn.\u2022 Target creature can't block this turn.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "395a846d-cafd-52e5-9f1e-53d1f12e5650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd980d5-c6d1-4834-977b-22e80f0b449d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd980d5-c6d1-4834-977b-22e80f0b449d.jpg?1",
             "name": "Rolling Thunder",
             "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -5065,7 +5065,7 @@
         },
         {
             "id": "d4b85f47-ff11-5e40-9d93-764aba27b829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8add5f2-4ccf-4505-86f6-cc36aff1c3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8add5f2-4ccf-4505-86f6-cc36aff1c3fe.jpg?1",
             "name": "Shatterskull Recruit",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "bf1f7056-7817-5e20-be04-5df4f0a1ea4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa37f74-50dd-4013-b48a-c33f1dbfb3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa37f74-50dd-4013-b48a-c33f1dbfb3e1.jpg?1",
             "name": "Stonefury",
             "text": "Stonefury deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "1486be6e-ac9e-58a1-9c36-e69e0586f6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074dd176-4608-42ca-8fc3-c7040cd7b32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074dd176-4608-42ca-8fc3-c7040cd7b32e.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5165,7 +5165,7 @@
         },
         {
             "id": "cf311ba7-a31d-53bb-a4c9-17f51d4c0b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4071152-5e64-4133-88a2-8fa5cb0eeb6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4071152-5e64-4133-88a2-8fa5cb0eeb6c.jpg?1",
             "name": "Tunneling Geopede",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Tunneling Geopede deals 1 damage to each opponent.",
             "colours": [
@@ -5199,7 +5199,7 @@
         },
         {
             "id": "74409194-5905-5fd7-88f9-bfd1ae0994b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178c66b8-c577-49c6-9efc-7bab740e66b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178c66b8-c577-49c6-9efc-7bab740e66b6.jpg?1",
             "name": "Valakut Invoker",
             "text": "{8}: Valakut Invoker deals 3 damage to target creature or player.",
             "colours": [
@@ -5234,7 +5234,7 @@
         },
         {
             "id": "5eb08c49-5bd7-58ba-8496-46821cc4fbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318272-8192-4d6d-a22a-eca87abb480d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318272-8192-4d6d-a22a-eca87abb480d.jpg?1",
             "name": "Valakut Predator",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Valakut Predator gets +2/+2 until end of turn.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "40744aa7-10b3-55ec-9d24-206c4b525179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90bd68-0521-4db3-b590-a4e007da9f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90bd68-0521-4db3-b590-a4e007da9f2e.jpg?1",
             "name": "Volcanic Upheaval",
             "text": "Destroy target land.",
             "colours": [
@@ -5300,7 +5300,7 @@
         },
         {
             "id": "eb609609-d23a-5122-ba01-9048da9f3cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0969f1-92a0-47c3-8eff-d106fbef2f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0969f1-92a0-47c3-8eff-d106fbef2f7e.jpg?1",
             "name": "Zada, Hedron Grinder",
             "text": "Whenever you cast an instant or sorcery spell that targets only Zada, Hedron Grinder, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -5337,7 +5337,7 @@
         },
         {
             "id": "6da6feb9-664d-58cc-9316-0c053b9207a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f1803-634a-41b0-ae21-484d6f914a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f1803-634a-41b0-ae21-484d6f914a0d.jpg?1",
             "name": "Blisterpod",
             "text": "Devoid (This card has no color.)\nWhen Blisterpod dies, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "2f531a70-c9cd-5e78-8125-620d2b8d4862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d4a49-8681-4f95-8718-96648bf73c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d4a49-8681-4f95-8718-96648bf73c39.jpg?1",
             "name": "Brood Monitor",
             "text": "Devoid (This card has no color.)\nWhen Brood Monitor enters the battlefield, put three 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "bc1b432c-c353-5b51-9281-f47d5838278b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d248ed0-c2b4-4558-9a09-ace8fd4b0599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d248ed0-c2b4-4558-9a09-ace8fd4b0599.jpg?1",
             "name": "Call the Scions",
             "text": "Devoid (This card has no color.)\nPut two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5433,7 +5433,7 @@
         },
         {
             "id": "dd8c98bb-94fe-5567-917f-da7d68ea0ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d949d0e-baf7-4573-bb15-7e30e3e9b202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d949d0e-baf7-4573-bb15-7e30e3e9b202.jpg?1",
             "name": "Eyeless Watcher",
             "text": "Devoid (This card has no color.)\nWhen Eyeless Watcher enters the battlefield, put two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "41c7cbc1-f44f-585f-9343-3e35404bc263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5559960-e306-4992-b607-9654327c4507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5559960-e306-4992-b607-9654327c4507.jpg?1",
             "name": "From Beyond",
             "text": "Devoid (This card has no color.)\nAt the beginning of your upkeep, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"{1}{G}, Sacrifice From Beyond: Search your library for an Eldrazi card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "bd092a4c-fe09-522e-8631-48446b664b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8293c66d-9a9b-4817-9bc3-ffd57fda290c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8293c66d-9a9b-4817-9bc3-ffd57fda290c.jpg?1",
             "name": "Unnatural Aggression",
             "text": "Devoid (This card has no color.)\nTarget creature you control fights target creature an opponent controls. If the creature an opponent controls would die this turn, exile it instead.",
             "colours": [],
@@ -5526,7 +5526,7 @@
         },
         {
             "id": "59ac3c52-803d-561b-975a-231ffd06f3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f66eb97-b151-48b1-aff0-f1280af66291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f66eb97-b151-48b1-aff0-f1280af66291.jpg?1",
             "name": "Void Attendant",
             "text": "Devoid (This card has no color.){1}{G}, Put a card an opponent owns from exile into that player's graveyard: Put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "cbeda0c1-e3f8-5fbd-ab69-f287510faa5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg?1",
             "name": "Beastcaller Savant",
             "text": "Haste{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell.",
             "colours": [
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "f84fccd1-742a-5170-b8aa-3cf3996f2c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c852d-9c7c-4d9b-8e79-70ea5ac865df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c852d-9c7c-4d9b-8e79-70ea5ac865df.jpg?1",
             "name": "Broodhunter Wurm",
             "text": "",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "28ddd278-0257-5ba4-a893-b9c4f6f85313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadc77d8-ef1c-431d-8716-9583f4fad33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadc77d8-ef1c-431d-8716-9583f4fad33f.jpg?1",
             "name": "Earthen Arms",
             "text": "Put two +1/+1 counters on target permanent.\nAwaken 4\u2014{6}{G} (If you cast this spell for {6}{G}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "f4fa1bce-ccc1-5bc3-9fa9-e444db16d4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98518e4a-d1d0-4e41-bae7-242c779f06a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98518e4a-d1d0-4e41-bae7-242c779f06a1.jpg?1",
             "name": "Giant Mantis",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "552b1b4d-cfdd-5fb2-bc1a-f28b74aacab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b03132c-0bb7-48f9-babd-6e106d8f202c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b03132c-0bb7-48f9-babd-6e106d8f202c.jpg?1",
             "name": "Greenwarden of Murasa",
             "text": "When Greenwarden of Murasa enters the battlefield, you may return target card from your graveyard to your hand.\nWhen Greenwarden of Murasa dies, you may exile it. If you do, return target card from your graveyard to your hand.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "96047e5c-03a7-564b-8afe-09e32d7b72b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec25fe4-7967-42e2-8790-593738991eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec25fe4-7967-42e2-8790-593738991eaa.jpg?1",
             "name": "Infuse with the Elements",
             "text": "Converge \u2014 Put X +1/+1 counters on target creature, where X is the number of colors of mana spent to cast Infuse with the Elements. That creature gains trample until end of turn.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "8f10015a-c0b6-5866-8f71-dc150a5ae6b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca704d5-b6e0-4726-8856-0b3a6732bbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca704d5-b6e0-4726-8856-0b3a6732bbd8.jpg?1",
             "name": "Jaddi Offshoot",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -5795,7 +5795,7 @@
         },
         {
             "id": "10514861-104b-570f-b9f0-3abf39df02cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657719-7d4d-46db-a5f4-699ee2032ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657719-7d4d-46db-a5f4-699ee2032ebe.jpg?1",
             "name": "Lifespring Druid",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "18519e03-bb0e-5cad-bc45-7e7d1b59a6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a3c02b-b576-4099-9016-15449f93bb09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a3c02b-b576-4099-9016-15449f93bb09.jpg?1",
             "name": "Murasa Ranger",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {3}{G}. If you do, put two +1/+1 counters on Murasa Ranger.",
             "colours": [
@@ -5866,7 +5866,7 @@
         },
         {
             "id": "591ea105-8628-58fb-960d-a6828b65681a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11cd83-5930-4cff-8f9b-55337ed263b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11cd83-5930-4cff-8f9b-55337ed263b7.jpg?1",
             "name": "Natural Connection",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5898,7 +5898,7 @@
         },
         {
             "id": "8a875707-0430-5823-be7b-3b6b89d9f3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91aa2ff1-12ea-4896-a955-a9cd76c3b49d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91aa2ff1-12ea-4896-a955-a9cd76c3b49d.jpg?1",
             "name": "Nissa's Renewal",
             "text": "Search your library for up to three basic land cards, put them onto the battlefield tapped, then shuffle your library. You gain 7 life.",
             "colours": [
@@ -5930,7 +5930,7 @@
         },
         {
             "id": "be4a442c-5ce0-52f6-8a97-ffc70d7bef7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3276b-2cbc-4266-b16a-bf72c044d95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3276b-2cbc-4266-b16a-bf72c044d95b.jpg?1",
             "name": "Oran-Rief Hydra",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Oran-Rief Hydra. If that land is a Forest, put two +1/+1 counters on Oran-Rief Hydra instead.",
             "colours": [
@@ -5964,7 +5964,7 @@
         },
         {
             "id": "a6b192fc-1807-5080-b84f-bc52aab40689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957875c-e1a2-4d14-8b61-c806903fc760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957875c-e1a2-4d14-8b61-c806903fc760.jpg?1",
             "name": "Oran-Rief Invoker",
             "text": "{8}: Oran-Rief Invoker gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "849870a1-602a-50c0-8fa8-e5ae20070864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd68e01c-4a09-450b-bfa0-8fbac8721764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd68e01c-4a09-450b-bfa0-8fbac8721764.jpg?1",
             "name": "Plated Crusher",
             "text": "Trample, hexproof",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "358c5647-9f47-5f5d-9497-36336d8c7bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6acb5b-b087-4cad-b40f-2de37029847c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6acb5b-b087-4cad-b40f-2de37029847c.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "7ef05352-671b-5ec7-bc9c-3b5e068c24cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be4c1a-58d7-409e-b7e0-aadb5ccf814d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be4c1a-58d7-409e-b7e0-aadb5ccf814d.jpg?1",
             "name": "Reclaiming Vines",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "a5faa897-92ec-5c69-bb77-3d1e4ae94f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53884f2a-6749-4d85-be64-82919eb30e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53884f2a-6749-4d85-be64-82919eb30e39.jpg?1",
             "name": "Retreat to Kazandu",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Put a +1/+1 counter on target creature.\u2022 You gain 2 life.",
             "colours": [
@@ -6129,7 +6129,7 @@
         },
         {
             "id": "14f53506-a55f-55ef-9cf6-68dd1c9ce627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a403b28-f91a-4637-af72-d6fc86c3bb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a403b28-f91a-4637-af72-d6fc86c3bb9a.jpg?1",
             "name": "Rot Shambler",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Rot Shambler.",
             "colours": [
@@ -6163,7 +6163,7 @@
         },
         {
             "id": "10d02e48-d21d-5d78-9e1a-301fcf9f32ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ef0054-a290-4c41-846d-12f8119c52ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ef0054-a290-4c41-846d-12f8119c52ae.jpg?1",
             "name": "Scythe Leopard",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Scythe Leopard gets +1/+1 until end of turn.",
             "colours": [
@@ -6197,7 +6197,7 @@
         },
         {
             "id": "6399d8b6-961d-51a7-af33-f3f9c178661f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824f44fe-ee16-4b15-a308-5c620cfd3d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824f44fe-ee16-4b15-a308-5c620cfd3d93.jpg?1",
             "name": "Seek the Wilds",
             "text": "Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "440da4e4-09a4-566e-bcaa-f543efd024e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834409e3-134e-4a34-89cb-53e2a039e980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834409e3-134e-4a34-89cb-53e2a039e980.jpg?1",
             "name": "Snapping Gnarlid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Snapping Gnarlid gets +1/+1 until end of turn.",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "2f7a3d18-d9d1-54ec-8b8b-d2ff5d642f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06da6fe-57bf-437e-8589-7e57a5881801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06da6fe-57bf-437e-8589-7e57a5881801.jpg?1",
             "name": "Swell of Growth",
             "text": "Target creature gets +2/+2 until end of turn. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -6295,7 +6295,7 @@
         },
         {
             "id": "bee997d6-12f5-5a5a-90a9-fc90a219cd78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b93087-e6a0-4ba9-83ba-a0ed2e396dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b93087-e6a0-4ba9-83ba-a0ed2e396dc7.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -6327,7 +6327,7 @@
         },
         {
             "id": "83989f1c-8e82-5480-b2b3-e79da4259290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447b4af-2eb2-48ae-a12e-2fdf83d4cb70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447b4af-2eb2-48ae-a12e-2fdf83d4cb70.jpg?1",
             "name": "Tajuru Beastmaster",
             "text": "Rally \u2014 Whenever Tajuru Beastmaster or another Ally enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6363,7 +6363,7 @@
         },
         {
             "id": "9c0dbaf9-d112-52e8-92f5-87393ac65661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f916220b-a942-41af-8949-aa384fa7857d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f916220b-a942-41af-8949-aa384fa7857d.jpg?1",
             "name": "Tajuru Stalwart",
             "text": "Converge \u2014 Tajuru Stalwart enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -6399,7 +6399,7 @@
         },
         {
             "id": "2952141f-7ba3-51e8-997c-a68c0c2bcf16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762501fe-5102-4c21-8ad5-430590a59830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762501fe-5102-4c21-8ad5-430590a59830.jpg?1",
             "name": "Tajuru Warcaller",
             "text": "Rally \u2014 Whenever Tajuru Warcaller or another Ally enters the battlefield under your control, creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "9aec098c-3cbd-5812-b191-7476a953220d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d4afc-5bb7-4159-9a11-f9c989dd9043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d4afc-5bb7-4159-9a11-f9c989dd9043.jpg?1",
             "name": "Territorial Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Territorial Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -6469,7 +6469,7 @@
         },
         {
             "id": "27017d06-7614-54fb-b814-f16ba45b555f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53104d8-5b9a-45b6-a2f9-b2c5d231a03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53104d8-5b9a-45b6-a2f9-b2c5d231a03d.jpg?1",
             "name": "Undergrowth Champion",
             "text": "If damage would be dealt to Undergrowth Champion while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from Undergrowth Champion.\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Undergrowth Champion.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "ce7ec50e-3713-53ad-b938-01ec900b59cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1e6db8-5093-44e4-95d7-3fdf8c55c1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1e6db8-5093-44e4-95d7-3fdf8c55c1dd.jpg?1",
             "name": "Woodland Wanderer",
             "text": "Vigilance, trample\nConverge \u2014 Woodland Wanderer enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "cb4f4636-1820-5b6d-92fa-a917efa4b43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f60fdd6-bc18-4c04-83d8-c204f2b35ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f60fdd6-bc18-4c04-83d8-c204f2b35ff1.jpg?1",
             "name": "Brood Butcher",
             "text": "Devoid (This card has no color.)\nWhen Brood Butcher enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"{B}{G}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.",
             "colours": [],
@@ -6571,7 +6571,7 @@
         },
         {
             "id": "52c4de18-7e50-5d0a-82b1-a9a570d86be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0eb64b-a463-4f25-9278-340051139f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0eb64b-a463-4f25-9278-340051139f0e.jpg?1",
             "name": "Brutal Expulsion",
             "text": "Devoid (This card has no color.)\nChoose one or both \u2014\u2022 Return target spell or creature to its owner's hand.\u2022 Brutal Expulsion deals 2 damage to target creature or planeswalker. If that permanent would be put into a graveyard this turn, exile it instead.",
             "colours": [],
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "c0c192d8-f3f6-57cc-98d4-4bf9011e9391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3b220b-e699-45b0-8ec1-1022c1f50329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3b220b-e699-45b0-8ec1-1022c1f50329.jpg?1",
             "name": "Catacomb Sifter",
             "text": "Devoid (This card has no color.)\nWhen Catacomb Sifter enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"Whenever another creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "430abad5-8262-5bce-af98-b152fd055f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2322e8c3-a983-4b3d-b6fa-f6b67f6fa8cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2322e8c3-a983-4b3d-b6fa-f6b67f6fa8cc.jpg?1",
             "name": "Dust Stalker",
             "text": "Devoid (This card has no color.)\nHaste\nAt the beginning of each end step, if you control no other colorless creatures, return Dust Stalker to its owner's hand.",
             "colours": [],
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "b9628192-c7b3-5f7d-ab72-904a390420a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b080ed31-db68-4e3c-8bf6-48b53d3ba622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b080ed31-db68-4e3c-8bf6-48b53d3ba622.jpg?1",
             "name": "Fathom Feeder",
             "text": "Devoid (This card has no color.)\nDeathtouch\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.){3}{U}{B}: Draw a card. Each opponent exiles the top card of his or her library.",
             "colours": [],
@@ -6703,7 +6703,7 @@
         },
         {
             "id": "d48b30e9-1737-5442-a5f2-ce6060051610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38aba41-a83f-47ef-9fc9-ea3424fc6d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38aba41-a83f-47ef-9fc9-ea3424fc6d64.jpg?1",
             "name": "Forerunner of Slaughter",
             "text": "Devoid (This card has no color.){1}: Target colorless creature gains haste until end of turn.",
             "colours": [],
@@ -6737,7 +6737,7 @@
         },
         {
             "id": "69947233-8afc-596e-b8e7-409152bea516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4180ae-1fd9-4185-b4f0-9e8f668a5737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4180ae-1fd9-4185-b4f0-9e8f668a5737.jpg?1",
             "name": "Herald of Kozilek",
             "text": "Devoid (This card has no color.)\nColorless spells you cast cost {1} less to cast.",
             "colours": [],
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "3bd3caf0-376f-5f45-af7d-13b952e23aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6252913-7b8e-4746-91e0-658ce13cdf18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6252913-7b8e-4746-91e0-658ce13cdf18.jpg?1",
             "name": "Sire of Stagnation",
             "text": "Devoid (This card has no color.)\nWhenever a land enters the battlefield under an opponent's control, that player exiles the top two cards of his or her library and you draw two cards.",
             "colours": [],
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "0d38df89-3436-55de-8929-56eb980d3296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd482ad-ca4a-470f-8a76-14ec7b58316a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd482ad-ca4a-470f-8a76-14ec7b58316a.jpg?1",
             "name": "Ulamog's Nullifier",
             "text": "Devoid (This card has no color.)\nFlash\nFlying\nWhen Ulamog's Nullifier enters the battlefield, you may put two cards your opponents own from exile into their owners' graveyards. If you do, counter target spell.",
             "colours": [],
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "1513b563-34ab-547c-b214-ee43a35fad06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0baf56-816a-4e0a-beb3-73b51487ff00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0baf56-816a-4e0a-beb3-73b51487ff00.jpg?1",
             "name": "Angelic Captain",
             "text": "Flying\nWhenever Angelic Captain attacks, it gets +1/+1 until end of turn for each other attacking Ally.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "25c7623a-8ca2-5aeb-b75d-c6a716f61887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25b13a4-6282-4426-8b01-9550f7d52d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25b13a4-6282-4426-8b01-9550f7d52d16.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with converted mana cost less than or equal to the number of colors of mana spent to cast Bring to Light, exile that card, then shuffle your library. You may cast that card without paying its mana cost.",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "212aa446-00ab-505e-aa41-7625ad8b5ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e82d47-9bbb-4bf9-a935-2c0b27b64a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e82d47-9bbb-4bf9-a935-2c0b27b64a84.jpg?1",
             "name": "Drana's Emissary",
             "text": "Flying\nAt the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "4a22edf4-4436-59c1-9862-a8750c982bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012b8eff-cdf3-423e-ae17-72a909e7ebd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012b8eff-cdf3-423e-ae17-72a909e7ebd3.jpg?1",
             "name": "Grove Rumbler",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Grove Rumbler gets +2/+2 until end of turn.",
             "colours": [
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "bfddf344-8d13-5927-809a-618e80067700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2fd3a4-e09a-4fe5-93eb-2276a65c4911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2fd3a4-e09a-4fe5-93eb-2276a65c4911.jpg?1",
             "name": "Grovetender Druids",
             "text": "Rally \u2014 Whenever Grovetender Druids or another Ally enters the battlefield under your control, you may pay {1}. If you do, put a 1/1 green Plant creature token onto the battlefield.",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "ad179bc3-62b6-5bac-8e46-c8ee7ac803c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b63c228-3265-4029-9bc0-36b3e31dfb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b63c228-3265-4029-9bc0-36b3e31dfb53.jpg?1",
             "name": "Kiora, Master of the Depths",
             "text": "+1: Untap up to one target creature and up to one target land.\u22122: Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.\u22128: You get an emblem with \"Whenever a creature enters the battlefield under your control, you may have it fight target creature.\" Then put three 8/8 blue Octopus creature tokens onto the battlefield.",
             "colours": [
@@ -7059,7 +7059,7 @@
         },
         {
             "id": "35f539dc-08e8-54e5-9b94-24781c6540f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dd138-fc8e-4a24-ad6d-2df71f94c0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dd138-fc8e-4a24-ad6d-2df71f94c0c0.jpg?1",
             "name": "March from the Tomb",
             "text": "Return any number of target Ally creature cards with total converted mana cost 8 or less from your graveyard to the battlefield.",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "6e0ce847-038d-5926-baaf-38c2e6aef0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee09fe-46d7-492b-a2f3-3fb0c3f83f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee09fe-46d7-492b-a2f3-3fb0c3f83f07.jpg?1",
             "name": "Munda, Ambush Leader",
             "text": "Haste\nRally \u2014 Whenever Munda, Ambush Leader or another Ally enters the battlefield under your control, you may look at the top four cards of your library. If you do, reveal any number of Ally cards from among them, then put those cards on top of your library in any order and the rest on the bottom in any order.",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "f66bc103-f7d5-54f2-b713-78444647684c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a66fc-e7aa-42df-a622-50743cb20183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a66fc-e7aa-42df-a622-50743cb20183.jpg?1",
             "name": "Noyan Dar, Roil Shaper",
             "text": "Whenever you cast an instant or sorcery spell, you may put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.",
             "colours": [
@@ -7171,7 +7171,7 @@
         },
         {
             "id": "f2c042ad-bf9d-593a-bfaf-0270f8b13a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f311e7-7ebf-4428-b5a3-154255eb3ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f311e7-7ebf-4428-b5a3-154255eb3ba1.jpg?1",
             "name": "Omnath, Locus of Rage",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a 5/5 red and green Elemental creature token onto the battlefield.\nWhenever Omnath, Locus of Rage or another Elemental you control dies, Omnath deals 3 damage to target creature or player.",
             "colours": [
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "9262ce4a-7cdc-5c01-b558-e5ec1f5eb3f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea96f8d-0c57-448d-8145-51f9cca04432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea96f8d-0c57-448d-8145-51f9cca04432.jpg?1",
             "name": "Resolute Blademaster",
             "text": "Rally \u2014 Whenever Resolute Blademaster or another Ally enters the battlefield under your control, creatures you control gain double strike until end of turn.",
             "colours": [
@@ -7247,7 +7247,7 @@
         },
         {
             "id": "c203fa16-4251-58a5-bc2f-7e1f96b39d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fdecc-ba16-4aa2-9c20-7c2942ec143e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fdecc-ba16-4aa2-9c20-7c2942ec143e.jpg?1",
             "name": "Roil Spout",
             "text": "Put target creature on top of its owner's library.\nAwaken 4\u2014{4}{W}{U} (If you cast this spell for {4}{W}{U}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "25a9d37f-3829-5eb5-8e04-8eabcb76f2c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eb787-aec7-43fd-9813-184111d9dcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eb787-aec7-43fd-9813-184111d9dcc5.jpg?1",
             "name": "Skyrider Elf",
             "text": "Flying\nConverge \u2014 Skyrider Elf enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -7319,7 +7319,7 @@
         },
         {
             "id": "83a355fb-47b1-5e5f-94ff-3258457315f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c7f3e0-b23a-4786-b452-583d905113e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c7f3e0-b23a-4786-b452-583d905113e2.jpg?1",
             "name": "Veteran Warleader",
             "text": "Veteran Warleader's power and toughness are each equal to the number of creatures you control.\nTap another untapped Ally you control: Veteran Warleader gains your choice of first strike, vigilance, or trample until end of turn.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "8f60f432-da18-574a-aa16-172dab38de32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef436b-e82e-4e1f-9da0-5e35f0c37bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef436b-e82e-4e1f-9da0-5e35f0c37bde.jpg?1",
             "name": "Aligned Hedron Network",
             "text": "When Aligned Hedron Network enters the battlefield, exile all creatures with power 5 or greater until Aligned Hedron Network leaves the battlefield. (Those creatures return under their owners' control.)",
             "colours": [],
@@ -7385,7 +7385,7 @@
         },
         {
             "id": "af52679e-36b4-5aa1-9a42-a32373eab1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519149c-f8a3-413f-b7b2-cd596970be4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519149c-f8a3-413f-b7b2-cd596970be4c.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {2} to your mana pool.{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "f2fb747c-c254-5c3c-8919-7127ba2a99ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87242e1d-babe-4b0d-aa1f-ab62e0bc4ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87242e1d-babe-4b0d-aa1f-ab62e0bc4ab7.jpg?1",
             "name": "Hedron Blade",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature becomes blocked by one or more colorless creatures, it gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "719ebada-27f5-5438-8b5f-a633a2fb9b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b98611-a6f7-498c-87e3-893a3f4b4f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b98611-a6f7-498c-87e3-893a3f4b4f73.jpg?1",
             "name": "Pathway Arrows",
             "text": "Equipped creature has \"{2}, {T}: This creature deals 1 damage to target creature. If a colorless creature is dealt damage this way, tap it.\"Equip {2}",
             "colours": [],
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "aa7ea9fb-b60c-5ca1-83d5-4b4c3943d9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dbd56-95a0-4697-9599-3f6110daf6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dbd56-95a0-4697-9599-3f6110daf6bc.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "45618248-64b5-5284-b462-e23231df105d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c64671-9bdd-475f-8def-7575775bf900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c64671-9bdd-475f-8def-7575775bf900.jpg?1",
             "name": "Slab Hammer",
             "text": "Whenever equipped creature attacks, you may return a land you control to its owner's hand. If you do, the creature gets +2/+2 until end of turn.\nEquip {2}",
             "colours": [],
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "3693b1dc-a948-5190-92f4-2efd4c8183af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb7124c-ba69-4da8-ad81-58f00fd0181d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb7124c-ba69-4da8-ad81-58f00fd0181d.jpg?1",
             "name": "Ally Encampment",
             "text": "{T}: Add {1} to your mana pool.{T}: Add one mana of any color to your mana pool. Spend this mana only to cast an Ally spell.{1}, {T}, Sacrifice Ally Encampment: Return target Ally you control to its owner's hand.",
             "colours": [],
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "94dedca4-6b21-5b0d-b355-174774f3ecc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8908b6b0-a488-426c-954d-458456be0651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8908b6b0-a488-426c-954d-458456be0651.jpg?1",
             "name": "Blighted Cataract",
             "text": "{T}: Add {1} to your mana pool.{5}{U}, {T}, Sacrifice Blighted Cataract: Draw two cards.",
             "colours": [],
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "1bf5439b-3653-5d1a-bd73-ac90da653c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d02950-cd50-4662-97af-3106598dc3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d02950-cd50-4662-97af-3106598dc3c4.jpg?1",
             "name": "Blighted Fen",
             "text": "{T}: Add {1} to your mana pool.{4}{B}, {T}, Sacrifice Blighted Fen: Target opponent sacrifices a creature.",
             "colours": [],
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "c869f59a-8742-59ad-bdb9-03ffd6f48b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cbfe5d-79b7-45db-b3cd-4ae7a9964a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cbfe5d-79b7-45db-b3cd-4ae7a9964a37.jpg?1",
             "name": "Blighted Gorge",
             "text": "{T}: Add {1} to your mana pool.{4}{R}, {T}, Sacrifice Blighted Gorge: Blighted Gorge deals 2 damage to target creature or player.",
             "colours": [],
@@ -7652,7 +7652,7 @@
         },
         {
             "id": "ae3428c8-260b-567d-8472-aa791b63cb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43df8ee-d3e4-419e-aed0-1059d95f9cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43df8ee-d3e4-419e-aed0-1059d95f9cab.jpg?1",
             "name": "Blighted Steppe",
             "text": "{T}: Add {1} to your mana pool.{3}{W}, {T}, Sacrifice Blighted Steppe: You gain 2 life for each creature you control.",
             "colours": [],
@@ -7682,7 +7682,7 @@
         },
         {
             "id": "87bd7efa-2795-5978-bfe8-83517309df15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7508d531-da52-41fb-a729-3f5704c9a194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7508d531-da52-41fb-a729-3f5704c9a194.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {1} to your mana pool.{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "2d227ca6-e593-50d1-b45a-1dd7df241b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3262c7f-4fdf-4648-ba59-9279c75d222d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3262c7f-4fdf-4648-ba59-9279c75d222d.jpg?1",
             "name": "Canopy Vista",
             "text": "({T}: Add {G} or {W} to your mana pool.)Canopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -7746,7 +7746,7 @@
         },
         {
             "id": "34869c66-7413-539a-8e9a-e373f15d15e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfabc340-0391-4019-8e96-f010177b1d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfabc340-0391-4019-8e96-f010177b1d68.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G} to your mana pool.)Cinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "3df7b6b6-604c-5912-8f8c-2faeb153bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8c9ac8-0741-4261-b43b-d745839e11f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8c9ac8-0741-4261-b43b-d745839e11f5.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "81677e7c-039c-5069-bcc4-4397bc124d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15231a9b-1956-4ff6-b637-942444d3349f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15231a9b-1956-4ff6-b637-942444d3349f.jpg?1",
             "name": "Fertile Thicket",
             "text": "Fertile Thicket enters the battlefield tapped.\nWhen Fertile Thicket enters the battlefield, you may look at the top five cards of your library. If you do, reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom in any order.{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "0b1514fc-b521-584a-b592-85f753d8d3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88177a2-de41-417d-a8f1-07edf005b453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88177a2-de41-417d-a8f1-07edf005b453.jpg?1",
             "name": "Looming Spires",
             "text": "Looming Spires enters the battlefield tapped.\nWhen Looming Spires enters the battlefield, target creature gets +1/+1 and gains first strike until end of turn.{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -7868,7 +7868,7 @@
         },
         {
             "id": "80fe085a-b9b5-52c8-9bbd-dce15a436799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8d2e4-3ebe-4311-b99e-dea9fb0b20ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8d2e4-3ebe-4311-b99e-dea9fb0b20ac.jpg?1",
             "name": "Lumbering Falls",
             "text": "Lumbering Falls enters the battlefield tapped.{T}: Add {G} or {U} to your mana pool.{2}{G}{U}: Lumbering Falls becomes a 3/3 green and blue Elemental creature with hexproof until end of turn. It's still a land.",
             "colours": [],
@@ -7899,7 +7899,7 @@
         },
         {
             "id": "f58a735a-468b-5df0-ac01-12a275872de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b31722-9626-4fea-9971-54c9aa8238e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b31722-9626-4fea-9971-54c9aa8238e8.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "2b7b34f3-0516-5994-b0ba-11e85a900226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625911f-1dd3-4044-ac06-3c0c3198b6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625911f-1dd3-4044-ac06-3c0c3198b6fd.jpg?1",
             "name": "Prairie Stream",
             "text": "({T}: Add {W} or {U} to your mana pool.)Prairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "76f3a630-b104-55a3-9996-7aeb9e19a62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86798d03-9f2d-46bd-a660-13c8dd5535ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86798d03-9f2d-46bd-a660-13c8dd5535ce.jpg?1",
             "name": "Sanctum of Ugin",
             "text": "{T}: Add {1} to your mana pool.\nWhenever you cast a colorless spell with converted mana cost 7 or greater, you may sacrifice Sanctum of Ugin. If you do, search your library for a colorless creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7991,7 +7991,7 @@
         },
         {
             "id": "18558289-3fcf-5ea4-b90e-ac72d2c9f309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781e932-4605-47aa-add1-4ee62f4e7ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781e932-4605-47aa-add1-4ee62f4e7ead.jpg?1",
             "name": "Sandstone Bridge",
             "text": "Sandstone Bridge enters the battlefield tapped.\nWhen Sandstone Bridge enters the battlefield, target creature gets +1/+1 and gains vigilance until end of turn.{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "37b25995-9d68-58c8-877f-c2a5a5fe1964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a73816-1f33-4798-a9d6-5f0410d19625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a73816-1f33-4798-a9d6-5f0410d19625.jpg?1",
             "name": "Shambling Vent",
             "text": "Shambling Vent enters the battlefield tapped.{T}: Add {W} or {B} to your mana pool.{1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.",
             "colours": [],
@@ -8052,7 +8052,7 @@
         },
         {
             "id": "4110badb-44f8-5e6c-a244-83cd2b208375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da2af9a-28c4-4edd-95c4-cc09c2de4adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da2af9a-28c4-4edd-95c4-cc09c2de4adc.jpg?1",
             "name": "Shrine of the Forsaken Gods",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {2} to your mana pool. Spend this mana only to cast colorless spells. Activate this ability only if you control seven or more lands.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "164fd70a-e44a-5380-8a71-efd0a5c8ce2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b0027d-c232-4cdd-89c4-75947687aa71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b0027d-c232-4cdd-89c4-75947687aa71.jpg?1",
             "name": "Skyline Cascade",
             "text": "Skyline Cascade enters the battlefield tapped.\nWhen Skyline Cascade enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "0aeaa88a-ae66-5d20-ba07-41174eda8c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b189d-aa51-4e90-820a-e79884562e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b189d-aa51-4e90-820a-e79884562e34.jpg?1",
             "name": "Smoldering Marsh",
             "text": "({T}: Add {B} or {R} to your mana pool.)Smoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "1938b5c0-6de4-5c99-b012-c84e96cfcb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a532b2-de88-40af-8961-b01eada05bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a532b2-de88-40af-8961-b01eada05bd3.jpg?1",
             "name": "Spawning Bed",
             "text": "{T}: Add {1} to your mana pool.{6}, {T}, Sacrifice Spawning Bed: Put three 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "71be7e0d-4fb9-51a3-80f6-4e455d1acec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B} to your mana pool.)Sunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -8206,7 +8206,7 @@
         },
         {
             "id": "2bf40901-e276-5177-96f5-3df0a68d7367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a735c9-08a1-4950-bf8c-ed1cfba76765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a735c9-08a1-4950-bf8c-ed1cfba76765.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "50f86fcd-9add-5ba5-8a19-73786e42e87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84908444-ee0f-430b-9a5e-f6810aa8bce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84908444-ee0f-430b-9a5e-f6810aa8bce1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "895d2006-13ac-5f34-9600-0a916efc939c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8279b9-c1dd-43db-a01b-89567bb43374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8279b9-c1dd-43db-a01b-89567bb43374.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8337,7 +8337,7 @@
         },
         {
             "id": "c79a58de-24f7-5f5c-aadd-50a01cb773f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b0679c-e7cd-43e0-bf8b-4518734f946b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b0679c-e7cd-43e0-bf8b-4518734f946b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8380,7 +8380,7 @@
         },
         {
             "id": "9c343f93-45da-5857-b351-3ca85192790f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143c32-d78b-40ee-8d2b-a8ce303162d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143c32-d78b-40ee-8d2b-a8ce303162d6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "e632a414-f788-5484-bdbb-2acaf5bf7ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405b531e-0f43-479c-9f8e-cf83f7b943a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405b531e-0f43-479c-9f8e-cf83f7b943a4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "0909f672-15bf-5ae1-84e8-8829101bc685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11c9a26-3234-480b-94cf-49f15f2b0002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11c9a26-3234-480b-94cf-49f15f2b0002.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8511,7 +8511,7 @@
         },
         {
             "id": "60c16888-7e54-585a-996b-cf0675ebde9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75d8ab6-0391-4bd7-9861-d2f6dd745a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75d8ab6-0391-4bd7-9861-d2f6dd745a51.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "f583c6b9-1a76-5a6c-ad59-87548f51855e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3138154c-5763-4105-a635-b697fe4c1e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3138154c-5763-4105-a635-b697fe4c1e52.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "77b5bdd8-aecc-5e22-8625-c387294a43ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77ab1-aae2-44b4-94a8-74819db16363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77ab1-aae2-44b4-94a8-74819db16363.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "cb840982-18eb-5e51-a8ef-a07bc64abfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8490261d-4246-4232-b7fc-23204c14a7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8490261d-4246-4232-b7fc-23204c14a7b5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8685,7 +8685,7 @@
         },
         {
             "id": "5e81770c-676a-5b1d-81a9-463d6bddddbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52db5b6-59bb-4215-9bdb-ba3dde3e5e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52db5b6-59bb-4215-9bdb-ba3dde3e5e4b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8728,7 +8728,7 @@
         },
         {
             "id": "55e2239b-5a24-58d3-b217-00fc0afb5462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde9dcf-f0b4-4e76-ac4e-d4a8ac355fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde9dcf-f0b4-4e76-ac4e-d4a8ac355fbe.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8772,7 +8772,7 @@
         },
         {
             "id": "16630c23-bfe9-5a6d-81df-c3edf2331e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7661ef-9119-4fe3-8363-b0c3b1d75cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7661ef-9119-4fe3-8363-b0c3b1d75cd7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "4b46a11f-3ac1-5499-993d-b58c4f4e83b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41579-5cbf-41c8-ac1b-e6256220087d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41579-5cbf-41c8-ac1b-e6256220087d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "601c9535-9dfe-584c-96e7-ab4a4524b1f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf86c2b-f3f5-45e7-8fa5-da279f652e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf86c2b-f3f5-45e7-8fa5-da279f652e32.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8902,7 +8902,7 @@
         },
         {
             "id": "11b57177-56d7-52cb-88fa-c7e7cdf67bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f7519-b011-4a86-9226-80c2d9747a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f7519-b011-4a86-9226-80c2d9747a42.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8946,7 +8946,7 @@
         },
         {
             "id": "c524d256-e22f-5969-a767-42415a34a2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab4a950-c558-42fc-ad9b-ce72b7dff817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab4a950-c558-42fc-ad9b-ce72b7dff817.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "ac02394c-0ae0-508b-8306-46af71c883df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71207752-0d8a-4ab5-be64-cca600608e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71207752-0d8a-4ab5-be64-cca600608e76.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9033,7 +9033,7 @@
         },
         {
             "id": "44f2955f-ed35-5a11-b90f-6cf527707897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e862d50-8fa5-4b6e-af19-a161dc4c251d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e862d50-8fa5-4b6e-af19-a161dc4c251d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "65561ead-b578-5e3f-8ed0-8e3adc66d00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132155ae-f7a4-4957-91cb-e51ff52716f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132155ae-f7a4-4957-91cb-e51ff52716f9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "10dac5ea-cb96-59a7-9be6-538369bbff65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20e773f-9220-4212-b39a-eaccb1c265c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20e773f-9220-4212-b39a-eaccb1c265c6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9163,7 +9163,7 @@
         },
         {
             "id": "d9a15b93-2fd4-5a74-af21-5acbb4a8d1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8594426-c965-4187-a72d-7582f21b0ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8594426-c965-4187-a72d-7582f21b0ea1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9207,7 +9207,7 @@
         },
         {
             "id": "18000881-a730-510f-a0c6-5cd0c020548b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44092af-f1a0-4018-a77b-d9ef2a9579ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44092af-f1a0-4018-a77b-d9ef2a9579ca.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9250,7 +9250,7 @@
         },
         {
             "id": "e8675f08-fd0d-5129-900d-1a7df0f53fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5452c8e4-3463-4ae3-a9d1-5947bea4684e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5452c8e4-3463-4ae3-a9d1-5947bea4684e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "46658f14-1abd-5cd2-86a3-75cb392912ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4d0d7a-0ab1-45c6-95a5-308b89e8d197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4d0d7a-0ab1-45c6-95a5-308b89e8d197.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9337,7 +9337,7 @@
         },
         {
             "id": "9466c7c2-d80c-5993-bec6-166c16fb7acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0aaac-fc82-4ce9-87d1-8dead8ec29fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0aaac-fc82-4ce9-87d1-8dead8ec29fd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9381,7 +9381,7 @@
         },
         {
             "id": "31407797-89b5-5998-8e74-d64ac9909168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6d08cf-a746-4147-91e3-180646de7158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6d08cf-a746-4147-91e3-180646de7158.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9424,7 +9424,7 @@
         },
         {
             "id": "00631b32-5cfa-551a-9b2d-5c1ad960f368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c590ebb-1e3a-4861-b8f2-aef9c4259efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c590ebb-1e3a-4861-b8f2-aef9c4259efd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "7344d22a-6c88-54ad-a88b-1d56ce7da9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8728eb-ae5e-4ff6-8012-5e30d88a04db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8728eb-ae5e-4ff6-8012-5e30d88a04db.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9511,7 +9511,7 @@
         },
         {
             "id": "3e948f92-a0c4-5d78-91a4-1074d8cb12f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9cbae1-6b04-4408-82fe-3fcf61dffbe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9cbae1-6b04-4408-82fe-3fcf61dffbe2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "ae367089-e41a-56b2-b4d6-dcefda260007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e2923f-a585-4096-8268-1136655bbf3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e2923f-a585-4096-8268-1136655bbf3c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9598,7 +9598,7 @@
         },
         {
             "id": "a877b90f-6730-5fd1-8c2c-2c9dc236186e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a42ac42-b21a-449b-abda-6906f06e8120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a42ac42-b21a-449b-abda-6906f06e8120.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9642,7 +9642,7 @@
         },
         {
             "id": "4098268a-1987-59bd-9149-6e1429b90af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7d9208-883e-4fce-8750-c694398c4ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7d9208-883e-4fce-8750-c694398c4ea2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9685,7 +9685,7 @@
         },
         {
             "id": "2d82d469-61fc-5f68-996c-32a2da66a96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37acb733-b3bd-4140-915d-b2c0989208aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37acb733-b3bd-4140-915d-b2c0989208aa.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "bb6480a6-2eb6-521a-938c-0e74dc3d7138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cac2df-9964-4931-9e03-7bc43395b88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cac2df-9964-4931-9e03-7bc43395b88c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9772,7 +9772,7 @@
         },
         {
             "id": "5ff238cf-f2b0-5c6c-b631-808d67c86343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c94acd-ad60-4aec-b11b-f4dc4a9adfbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c94acd-ad60-4aec-b11b-f4dc4a9adfbc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9816,7 +9816,7 @@
         },
         {
             "id": "6d725517-619a-5fdf-9c1a-45cf0f8c26ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261592a-82d1-46dd-964f-a0a1cf22808f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261592a-82d1-46dd-964f-a0a1cf22808f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "2e41e90e-72de-527e-bc24-a607f6ad5c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cecf0db-0e0e-4329-b055-bb9dad912ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cecf0db-0e0e-4329-b055-bb9dad912ca8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9903,7 +9903,7 @@
         },
         {
             "id": "544aee98-a48a-5b2a-9397-180bb885388d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea6d05f-dfeb-4d1b-b9ad-d006ec2437f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea6d05f-dfeb-4d1b-b9ad-d006ec2437f8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9946,7 +9946,7 @@
         },
         {
             "id": "b692617a-216d-59ca-94fe-2c7f459e72ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642102a2-abde-4e76-a6d6-08f7befe1196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642102a2-abde-4e76-a6d6-08f7befe1196.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9990,7 +9990,7 @@
         },
         {
             "id": "0161f9f2-9d93-51b5-a5be-902ed5089e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f865d8-fced-4763-b73e-fd40e9387e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f865d8-fced-4763-b73e-fd40e9387e45.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "04e11f16-cb1c-5820-a26d-ef423db74f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b26e4-1d52-457c-a00c-bdee127f8a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b26e4-1d52-457c-a00c-bdee127f8a97.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10077,7 +10077,7 @@
         },
         {
             "id": "5675b6f8-ca15-5455-aaf7-56dfb038ec52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131ab8d-c884-4430-8059-9e3e1d16c747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131ab8d-c884-4430-8059-9e3e1d16c747.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10120,7 +10120,7 @@
         },
         {
             "id": "e45a60bb-8ce4-5ddd-9501-5cce67a487b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3a6ecf-323d-4650-aabf-92995e3c72c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3a6ecf-323d-4650-aabf-92995e3c72c6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10164,7 +10164,7 @@
         },
         {
             "id": "6511454a-5465-5e76-9957-f69012f90878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76349ec5-a7ad-45cf-a6b8-1f71d7e6f74d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76349ec5-a7ad-45cf-a6b8-1f71d7e6f74d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10207,7 +10207,7 @@
         },
         {
             "id": "86634289-9488-5ce8-a4e0-4a6579aa47be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f206a-7b5e-4fd5-8c9e-d665ac3f7dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f206a-7b5e-4fd5-8c9e-d665ac3f7dea.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "fe928dc1-7594-53ca-9de5-53e0a1711b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f909e5-f993-467d-be46-10d8a67ee9f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f909e5-f993-467d-be46-10d8a67ee9f4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "25504530-b778-5120-85c6-ce6808ad7c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c70181e-7b28-46b1-a51a-ba99e58e8566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c70181e-7b28-46b1-a51a-ba99e58e8566.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10338,7 +10338,7 @@
         },
         {
             "id": "4fb5d3f7-cc7b-5502-8906-555ba919bd02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbf7cc-f20c-49d3-85ff-406dd32f6444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbf7cc-f20c-49d3-85ff-406dd32f6444.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "c2fb5049-79aa-5d1b-98a8-b8e5a2997ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff04d5-ecaf-4be2-94f4-d5409f1c1e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff04d5-ecaf-4be2-94f4-d5409f1c1e4e.jpg?1",
             "name": "Eldrazi",
             "text": "",
             "colours": [],
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "108b11f1-acda-5ea3-bda7-dc1f7a48b9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999a0fe-d2d0-4367-9abb-6ce5f3764f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999a0fe-d2d0-4367-9abb-6ce5f3764f19.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -10442,7 +10442,7 @@
         },
         {
             "id": "4b047f53-a4fb-5a40-b690-c43f2afb0356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcdf03d-d237-4ceb-91fa-8f95341af369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcdf03d-d237-4ceb-91fa-8f95341af369.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -10473,7 +10473,7 @@
         },
         {
             "id": "71f5dc54-b903-5d65-a988-781176660519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5c74d5-b219-4514-8fd6-62705459422c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5c74d5-b219-4514-8fd6-62705459422c.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -10504,7 +10504,7 @@
         },
         {
             "id": "e31700d9-327d-5e8e-b8d9-c7527922db9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0419a202-6e32-4f0a-a032-72f6c00cae5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0419a202-6e32-4f0a-a032-72f6c00cae5e.jpg?1",
             "name": "Knight Ally",
             "text": "",
             "colours": [
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "f3e2cc8f-c56e-550d-9604-c52722e1d945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be224180-a482-4b94-8a9d-3a92ee0eb34b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be224180-a482-4b94-8a9d-3a92ee0eb34b.jpg?1",
             "name": "Kor Ally",
             "text": "",
             "colours": [
@@ -10574,7 +10574,7 @@
         },
         {
             "id": "054c2216-1a1d-5e06-af97-fd864688227e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ac0a35-fae7-49f9-ae96-4406df992dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ac0a35-fae7-49f9-ae96-4406df992dc9.jpg?1",
             "name": "Octopus",
             "text": "",
             "colours": [
@@ -10608,7 +10608,7 @@
         },
         {
             "id": "a8ae86dd-06bb-5c57-8e78-e86ede39d412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e4b631-7374-4503-aa66-2a45a41972d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e4b631-7374-4503-aa66-2a45a41972d3.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -10642,7 +10642,7 @@
         },
         {
             "id": "22800811-dd59-5787-bb06-d9bdd23eacf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cb10f5-e22a-4ccd-a1b0-c6f245b15f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cb10f5-e22a-4ccd-a1b0-c6f245b15f64.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "0c4a1f92-77f2-5332-a3d6-e6d087c915d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a63c10-9bf9-4e0f-831c-830d7994a62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a63c10-9bf9-4e0f-831c-830d7994a62a.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "1fe99bbe-0572-5f86-9a6d-31c15cd68542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed666385-a2e7-4e1f-ad2c-babbfc0c50b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed666385-a2e7-4e1f-ad2c-babbfc0c50b3.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "0345e01d-3065-59fe-9326-cccd3b49ff26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8be597-f402-4fb0-9135-897c4a0946f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8be597-f402-4fb0-9135-897c4a0946f6.jpg?1",
             "name": "Gideon, Ally of Zendikar Emblem",
             "text": "",
             "colours": [],
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "b4c96854-da57-5211-975f-8dc9debcbff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a77885-c0de-4487-a920-6fb9ea9bc408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a77885-c0de-4487-a920-6fb9ea9bc408.jpg?1",
             "name": "Ob Nixilis Reignited Emblem",
             "text": "",
             "colours": [],
@@ -10804,7 +10804,7 @@
         },
         {
             "id": "7512bead-cee3-56fc-8619-83840027c735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55952cc8-09d8-4260-8387-284df7223d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55952cc8-09d8-4260-8387-284df7223d74.jpg?1",
             "name": "Kiora, Master of the Depths Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/BIG.json
+++ b/Assets/Resources/Sets/BIG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8b959fa6-401f-56dc-bc55-4474bcfa3a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg?1",
             "name": "Collector's Cage",
             "text": "Hideaway 5 (When this artifact enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\n{1}, {T}: Put a +1/+1 counter on target creature you control. Then if you control three or more creatures with different powers, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "825bfaec-78b2-5df0-837a-f9c075c72494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -77,7 +77,7 @@
         },
         {
             "id": "fca1ea22-e5d4-5f09-9859-7cab8662912b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg?1",
             "name": "Oltec Matterweaver",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Create a 1/1 colorless Gnome artifact creature token.\n\u2022 Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -115,7 +115,7 @@
         },
         {
             "id": "7ab95887-888b-571c-882f-3003a165dd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d108c2b1-236e-4b8d-8445-d9749ccc4fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d108c2b1-236e-4b8d-8445-d9749ccc4fea.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -150,7 +150,7 @@
         },
         {
             "id": "8cee956e-4c65-5d1f-b6d1-077c393981d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dbb2755-97d9-492e-8697-5548160678c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dbb2755-97d9-492e-8697-5548160678c8.jpg?1",
             "name": "Esoteric Duplicator",
             "text": "Whenever you sacrifice Esoteric Duplicator or another artifact, you may pay {2}. If you do, at the beginning of the next end step, create a token that's a copy of that artifact.\n{2}, Sacrifice Esoteric Duplicator: Draw a card.",
             "colours": [
@@ -187,7 +187,7 @@
         },
         {
             "id": "30466b24-10b4-5a9c-8eae-5df40e9cf1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg?1",
             "name": "Simulacrum Synthesizer",
             "text": "When Simulacrum Synthesizer enters the battlefield, scry 2.\nWhenever another artifact with mana value 3 or greater enters the battlefield under your control, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [
@@ -222,7 +222,7 @@
         },
         {
             "id": "3eba9b11-1208-5a0e-a445-e533d6455c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg?1",
             "name": "Worldwalker Helm",
             "text": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "b1aebc89-6fff-59ed-967b-afbe112aafc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b60a1a6-b2ca-4dc2-a6d9-eff97092079a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b60a1a6-b2ca-4dc2-a6d9-eff97092079a.jpg?1",
             "name": "Greed's Gambit",
             "text": "When Greed's Gambit enters the battlefield, you draw three cards, gain 6 life, and create three 2/1 black Bat creature tokens with flying.\nAt the beginning of your end step, you discard a card, lose 2 life, and sacrifice a creature.\nWhen Greed's Gambit leaves the battlefield, you discard three cards, lose 6 life, and sacrifice three creatures.",
             "colours": [
@@ -292,7 +292,7 @@
         },
         {
             "id": "60eff4be-2617-51fc-bc8d-aa5f755dcdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg?1",
             "name": "Harvester of Misery",
             "text": "Menace\nWhen Harvester of Misery enters the battlefield, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard Harvester of Misery: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -329,7 +329,7 @@
         },
         {
             "id": "82e030cc-eab3-5b89-8756-f3089d96928b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg?1",
             "name": "Hostile Investigator",
             "text": "When Hostile Investigator enters the battlefield, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "75a96eed-9b8e-5289-8158-034d40a8bdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg?1",
             "name": "Generous Plunderer",
             "text": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "4fdb4bf6-d3cd-56fc-82eb-b1d665f9f668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg?1",
             "name": "Legion Extruder",
             "text": "When Legion Extruder enters the battlefield, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "5b2daf16-28fc-5f5c-a5b2-eee8a3d3c5ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg?1",
             "name": "Memory Vessel",
             "text": "{T}, Exile Memory Vessel: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "abe15199-46ff-563f-9aac-e944549ab9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg?1",
             "name": "Molten Duplication",
             "text": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "8cdcf11a-b5b3-5402-b648-e1d0fd7a98e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71059bc8-f63a-4d9c-9d08-2e995e74cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71059bc8-f63a-4d9c-9d08-2e995e74cc59.jpg?1",
             "name": "Territory Forge",
             "text": "When Territory Forge enters the battlefield, if you cast it, exile target artifact or land.\nTerritory Forge has all activated abilities of the exiled card.",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "92071066-e49e-548c-b1f6-d0bea2532388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg?1",
             "name": "Ancient Cornucopia",
             "text": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "371dfc14-724a-5d81-99eb-d1154c96f16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498c4de-5e80-4baa-9fcb-70f164880c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498c4de-5e80-4baa-9fcb-70f164880c84.jpg?1",
             "name": "Bristlebud Farmer",
             "text": "Trample\nWhen Bristlebud Farmer enters the battlefield, create two Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.",
             "colours": [
@@ -619,7 +619,7 @@
         },
         {
             "id": "67f8fc77-6145-511d-b8ef-5d3ae29e77ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49c9b72-61c0-4e3a-a3a6-994b149398a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49c9b72-61c0-4e3a-a3a6-994b149398a9.jpg?1",
             "name": "Omenpath Journey",
             "text": "When Omenpath Journey enters the battlefield, search your library for up to five land cards that have different names, exile them, then shuffle.\nAt the beginning of your end step, choose a card at random exiled with Omenpath Journey and put it onto the battlefield tapped.",
             "colours": [
@@ -654,7 +654,7 @@
         },
         {
             "id": "0ac3a104-8c33-5ed1-b9ea-39053932ac70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg?1",
             "name": "Sandstorm Salvager",
             "text": "When Sandstorm Salvager enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
             "colours": [
@@ -692,7 +692,7 @@
         },
         {
             "id": "fa6828ad-a350-58d0-abf9-b802b1e11b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b3f560-262b-4bc3-9aef-535fd7082c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b3f560-262b-4bc3-9aef-535fd7082c28.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.",
             "colours": [
@@ -730,7 +730,7 @@
         },
         {
             "id": "e65aaef6-bb56-5a20-9bee-d6a08b6392c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb169fa2-c92e-45f7-89a2-0ca0e3910a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb169fa2-c92e-45f7-89a2-0ca0e3910a1c.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "c8a71468-a0c7-5443-96a1-c63789ffb638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a01b92-dafb-4ea6-8eff-29f881f6be24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a01b92-dafb-4ea6-8eff-29f881f6be24.jpg?1",
             "name": "Pest Control",
             "text": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "063797b3-2776-535c-bbd7-9cf9a5a2e649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936504c-4e90-408f-ba98-0fb8c0378471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936504c-4e90-408f-ba98-0fb8c0378471.jpg?1",
             "name": "Lost Jitte",
             "text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one \u2014\n\u2022 Untap target land.\n\u2022 Target creature can't block this turn.\n\u2022 Put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [],
@@ -847,7 +847,7 @@
         },
         {
             "id": "a8c83c7a-c0b8-587f-a51b-a0df78eb3f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02267717-66e0-41f7-8009-75586a4aa4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02267717-66e0-41f7-8009-75586a4aa4be.jpg?1",
             "name": "Lotus Ring",
             "text": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
             "colours": [],
@@ -881,7 +881,7 @@
         },
         {
             "id": "e5b0214e-9c5a-558f-baac-e003a2a8a4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f61742-522c-4b36-97db-41d0c412a072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f61742-522c-4b36-97db-41d0c412a072.jpg?1",
             "name": "Nexus of Becoming",
             "text": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
             "colours": [],
@@ -912,7 +912,7 @@
         },
         {
             "id": "b4672eaf-4004-5721-9587-e5d304b79acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9e5041-3c05-4a8a-9f00-081b01685d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9e5041-3c05-4a8a-9f00-081b01685d0c.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
             "colours": [],
@@ -946,7 +946,7 @@
         },
         {
             "id": "60917bf0-4a28-511a-af9a-a762c98febd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf02a38-d10d-463e-ab99-e7fd848a1bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf02a38-d10d-463e-ab99-e7fd848a1bd3.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -977,7 +977,7 @@
         },
         {
             "id": "19ccb9c7-cf07-55c2-babc-6723942e07d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe673-d688-499a-882b-4fe5418739e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe673-d688-499a-882b-4fe5418739e3.jpg?1",
             "name": "Transmutation Font",
             "text": "{T}: Create your choice of a Blood token, a Clue token, or a Food token.\n{3}, {T}, Sacrifice three artifact tokens with different names: Search your library for an artifact card, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [],
@@ -1008,7 +1008,7 @@
         },
         {
             "id": "acc256d0-870e-5266-a8e5-d6a14f289b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5433b98-4657-4bbe-9e72-d3c94c6aa8ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5433b98-4657-4bbe-9e72-d3c94c6aa8ef.jpg?1",
             "name": "Fomori Vault",
             "text": "{T}: Add {C}.\n{3}, {T}, Discard a card: Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -1039,7 +1039,7 @@
         },
         {
             "id": "f1f86ff4-a918-513f-81fd-add1ce12df51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962552a1-ec34-49e2-a23d-85dfb405d5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962552a1-ec34-49e2-a23d-85dfb405d5e0.jpg?1",
             "name": "Tarnation Vista",
             "text": "Tarnation Vista enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{1}, {T}: For each color among monocolored permanents you control, add one mana of that color.",
             "colours": [],
@@ -1071,7 +1071,7 @@
         },
         {
             "id": "b7045ad4-a28e-54a0-9318-f4bd2c42ae20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8391dbb8-3c8d-42c3-892b-b85e40bb28e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8391dbb8-3c8d-42c3-892b-b85e40bb28e0.jpg?1",
             "name": "Collector's Cage",
             "text": "Hideaway 5\n{1}, {T}: Put a +1/+1 counter on target creature you control. Then if you control three or more creatures with different powers, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "f97bb97e-653d-532a-8d91-082b88ad9025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03304c72-fe8e-42af-96ae-1e64ba0105b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03304c72-fe8e-42af-96ae-1e64ba0105b3.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -1144,7 +1144,7 @@
         },
         {
             "id": "601dc4a0-946e-502d-b7c7-e69bb45a71d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e068335-92f9-4ebd-bb00-f4ff741e3d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e068335-92f9-4ebd-bb00-f4ff741e3d7d.jpg?1",
             "name": "Oltec Matterweaver",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Create a 1/1 colorless Gnome artifact creature token.\n\u2022 Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "c8076b17-ccc2-5f97-a149-c87a9418000f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ef698-caad-47cd-ba35-41be64a58c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ef698-caad-47cd-ba35-41be64a58c99.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "fc5f3a0c-271b-5763-a3e5-31ca11bf784e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4b7ac-d45a-4ce9-97b4-35789df8a162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4b7ac-d45a-4ce9-97b4-35789df8a162.jpg?1",
             "name": "Esoteric Duplicator",
             "text": "Whenever you sacrifice Esoteric Duplicator or another artifact, you may pay {2}. If you do, at the beginning of the next end step, create a token that's a copy of that artifact.\n{2}, Sacrifice Esoteric Duplicator: Draw a card.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "73030017-9483-5f73-b4be-0660e1a5c1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a11489-11c5-4018-aab8-c9d036638414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a11489-11c5-4018-aab8-c9d036638414.jpg?1",
             "name": "Simulacrum Synthesizer",
             "text": "When Simulacrum Synthesizer enters the battlefield, scry 2.\nWhenever another artifact with mana value 3 or greater enters the battlefield under your control, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "25bd235a-f251-5da8-95de-afba45cc38da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abd5601-c8b4-4ac8-aab0-be5c7b3aaf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abd5601-c8b4-4ac8-aab0-be5c7b3aaf56.jpg?1",
             "name": "Worldwalker Helm",
             "text": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token.\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "9f34964f-f02b-5ad0-bc15-f44d167cb67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cb3add-c39c-4124-a028-87333aab0929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cb3add-c39c-4124-a028-87333aab0929.jpg?1",
             "name": "Greed's Gambit",
             "text": "When Greed's Gambit enters the battlefield, you draw three cards, gain 6 life, and create three 2/1 black Bat creature tokens with flying.\nAt the beginning of your end step, you discard a card, lose 2 life, and sacrifice a creature.\nWhen Greed's Gambit leaves the battlefield, you discard three cards, lose 6 life, and sacrifice three creatures.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "11df0150-4ded-54ea-bd5d-77bce572d502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e81c9e-02f4-4c18-9326-127e08c9b47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e81c9e-02f4-4c18-9326-127e08c9b47f.jpg?1",
             "name": "Harvester of Misery",
             "text": "Menace\nWhen Harvester of Misery enters the battlefield, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard Harvester of Misery: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "9079f8fd-1e9e-53da-8b9d-6832313dd265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cd1d1b-dbde-4a2c-94ed-58395867799c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cd1d1b-dbde-4a2c-94ed-58395867799c.jpg?1",
             "name": "Hostile Investigator",
             "text": "When Hostile Investigator enters the battlefield, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "1b0d880e-fdfb-5905-9a74-7d6742fb1774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351eea06-f5be-4044-b3b3-cc6bf805abb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351eea06-f5be-4044-b3b3-cc6bf805abb1.jpg?1",
             "name": "Generous Plunderer",
             "text": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
             "colours": [
@@ -1473,7 +1473,7 @@
         },
         {
             "id": "7691ba3c-4844-54b2-8571-e73e4b6c7ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d67fd7-30c8-4cd7-ab1a-97225b9c9437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d67fd7-30c8-4cd7-ab1a-97225b9c9437.jpg?1",
             "name": "Legion Extruder",
             "text": "When Legion Extruder enters the battlefield, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "b0a74035-98d2-55f0-b5a8-5c4204aadb32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db47f1bc-7f50-493f-bb3f-c1285cbaf244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db47f1bc-7f50-493f-bb3f-c1285cbaf244.jpg?1",
             "name": "Memory Vessel",
             "text": "{T}, Exile Memory Vessel: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "f72327f3-9884-5390-b3d2-0bb5d8299449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4ba0c9-ec77-4406-a62a-82a550791e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4ba0c9-ec77-4406-a62a-82a550791e61.jpg?1",
             "name": "Molten Duplication",
             "text": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "cd4c50f2-a945-5c43-8410-6151da7b8bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd6bde-29ec-4de2-b369-bb3e1d2714d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd6bde-29ec-4de2-b369-bb3e1d2714d9.jpg?1",
             "name": "Territory Forge",
             "text": "When Territory Forge enters the battlefield, if you cast it, exile target artifact or land.\nTerritory Forge has all activated abilities of the exiled card.",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "c3084caa-ba9d-5984-a79b-2dd9aece669a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f23dffc-c76b-4f01-98c2-67dae3b3114b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f23dffc-c76b-4f01-98c2-67dae3b3114b.jpg?1",
             "name": "Ancient Cornucopia",
             "text": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "f7155008-08c2-57cc-aeeb-8c60ffe6a84a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713be7b8-e73f-4ed1-8a14-cc1c144e844e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713be7b8-e73f-4ed1-8a14-cc1c144e844e.jpg?1",
             "name": "Bristlebud Farmer",
             "text": "Trample\nWhen Bristlebud Farmer enters the battlefield, create two Food tokens.\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "388ac8d4-0add-529e-ae3e-7da222d478c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385e6c23-0eab-4bc9-8b30-524879051ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385e6c23-0eab-4bc9-8b30-524879051ce9.jpg?1",
             "name": "Omenpath Journey",
             "text": "When Omenpath Journey enters the battlefield, search your library for up to five land cards that have different names, exile them, then shuffle.\nAt the beginning of your end step, choose a card at random exiled with Omenpath Journey and put it onto the battlefield tapped.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "16133d48-d867-56d2-b103-75c657260ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613173-2892-47d7-8a09-2102f2f0965f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613173-2892-47d7-8a09-2102f2f0965f.jpg?1",
             "name": "Sandstorm Salvager",
             "text": "When Sandstorm Salvager enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "1ff3d49d-979d-5237-b2dd-28f4da08401a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f0544c-0124-497c-a8f1-5d5fb959ca39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f0544c-0124-497c-a8f1-5d5fb959ca39.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "be7910d3-5594-5ecd-b300-ab3917bf2ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3db1928-86f2-4606-ad2d-4b7dfd7e5d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3db1928-86f2-4606-ad2d-4b7dfd7e5d6b.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
             "colours": [
@@ -1842,7 +1842,7 @@
         },
         {
             "id": "d43c007b-ed48-5345-a141-ed45d68b4bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d67c7fb-043f-4984-a700-5e8aa44c90aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d67c7fb-043f-4984-a700-5e8aa44c90aa.jpg?1",
             "name": "Pest Control",
             "text": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2}",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "d8155cfe-316d-58c1-a728-510d8b0b5cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc679a0e-bf7b-40b5-b904-9c2d3508fa83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc679a0e-bf7b-40b5-b904-9c2d3508fa83.jpg?1",
             "name": "Lost Jitte",
             "text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one \u2014\n\u2022 Untap target land.\n\u2022 Target creature can't block this turn.\n\u2022 Put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [],
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "53906ad8-855f-56ff-aee3-865b69a25575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fb925a-5845-4d73-8122-6e7a36a9bd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fb925a-5845-4d73-8122-6e7a36a9bd0d.jpg?1",
             "name": "Lotus Ring",
             "text": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
             "colours": [],
@@ -1948,7 +1948,7 @@
         },
         {
             "id": "4c3fb2ad-f882-50ff-a955-73f81e21522e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f329b59c-1c1d-4a0a-89b4-c3fc4a8074bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f329b59c-1c1d-4a0a-89b4-c3fc4a8074bc.jpg?1",
             "name": "Nexus of Becoming",
             "text": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
             "colours": [],
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "3594daed-c644-5230-9138-d6407092e183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf08dd1-3d35-4842-807d-37f94b9ba578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf08dd1-3d35-4842-807d-37f94b9ba578.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
             "colours": [],
@@ -2013,7 +2013,7 @@
         },
         {
             "id": "d7068cbb-25ca-5cd0-ae7f-2788a710898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc2948-f185-4c3f-b80e-2bc8f47825c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc2948-f185-4c3f-b80e-2bc8f47825c9.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -2044,7 +2044,7 @@
         },
         {
             "id": "aba80c2e-54e7-53df-af5f-74f47a494282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7227906c-043b-4742-8141-694f7811dc06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7227906c-043b-4742-8141-694f7811dc06.jpg?1",
             "name": "Transmutation Font",
             "text": "{T}: Create your choice of a Blood token, a Clue token, or a Food token.\n{3}, {T}, Sacrifice three artifact tokens with different names: Search your library for an artifact card, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [],
@@ -2075,7 +2075,7 @@
         },
         {
             "id": "40ccc7b4-6dc5-5f4c-839a-ff2cbc821660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad282dc0-6310-47ab-99cd-90f34168bd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad282dc0-6310-47ab-99cd-90f34168bd27.jpg?1",
             "name": "Fomori Vault",
             "text": "{T}: Add {C}.\n{3}, {T}, Discard a card: Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -2106,7 +2106,7 @@
         },
         {
             "id": "bd01e647-7d11-5440-9192-35aa97124486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad49fd74-db70-49c0-8ad9-1185e2b0787d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad49fd74-db70-49c0-8ad9-1185e2b0787d.jpg?1",
             "name": "Tarnation Vista",
             "text": "Tarnation Vista enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{1}, {T}: For each color among monocolored permanents you control, add one mana of that color.",
             "colours": [],
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "109bba79-b3ec-5ff9-8641-26e47148d6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba9e2cc-e0a3-4c5a-9ca0-f683ff8b5c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba9e2cc-e0a3-4c5a-9ca0-f683ff8b5c94.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "b04b2cdb-9115-5ae0-9545-ad4d8c8a7819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18fa57-fab9-48f6-b80a-d03fb89d2683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18fa57-fab9-48f6-b80a-d03fb89d2683.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "62567c60-1e1a-5ec8-b4fc-93a8453e2796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa77cff4-0f0a-430a-b0c8-aab82299c570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa77cff4-0f0a-430a-b0c8-aab82299c570.jpg?1",
             "name": "Lotus Ring",
             "text": "",
             "colours": [],
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "cc00fbf0-4b78-5ba7-bef9-f9e3aa2bb421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59193e1f-7231-4967-82eb-1cb0b5494dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59193e1f-7231-4967-82eb-1cb0b5494dc7.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "",
             "colours": [],
@@ -2285,7 +2285,7 @@
         },
         {
             "id": "3115f5e2-aa7b-5a03-9540-e8044a0c38f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad50cee8-0f7f-4058-8fe1-5d7156c2429b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad50cee8-0f7f-4058-8fe1-5d7156c2429b.jpg?1",
             "name": "Tarnation Vista",
             "text": "",
             "colours": [],
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "ec5277f0-1e92-58f1-90a8-131fac302520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f40f6a3-5f38-498e-99fe-e60e93d7a05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f40f6a3-5f38-498e-99fe-e60e93d7a05c.jpg?1",
             "name": "Collector's Cage",
             "text": "Hideaway 5\n{1}, {T}: Put a +1/+1 counter on target creature you control. Then if you control three or more creatures with different powers, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "7cafe33b-979f-55a1-80eb-4858385a6b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439551c-6764-4c35-a5ba-c7adb727cf7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439551c-6764-4c35-a5ba-c7adb727cf7a.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "82e69281-20b3-5b27-b2c0-1495e449522e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1617d39d-4989-4ac4-8cd0-ac1b4e7312df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1617d39d-4989-4ac4-8cd0-ac1b4e7312df.jpg?1",
             "name": "Oltec Matterweaver",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Create a 1/1 colorless Gnome artifact creature token.\n\u2022 Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "56ef73df-6329-574c-89f6-c71833b30690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a52b1bc-cf29-49bd-a877-03a21fe8a6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a52b1bc-cf29-49bd-a877-03a21fe8a6c5.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "8e837162-2843-536a-86e2-74d23007b1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba1736b-9e11-4169-9525-1540a64a3188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba1736b-9e11-4169-9525-1540a64a3188.jpg?1",
             "name": "Esoteric Duplicator",
             "text": "Whenever you sacrifice Esoteric Duplicator or another artifact, you may pay {2}. If you do, at the beginning of the next end step, create a token that's a copy of that artifact.\n{2}, Sacrifice Esoteric Duplicator: Draw a card.",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "c3cfc938-9b15-5ca1-9361-e89523d310dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e003f9-2fad-48b4-8e5b-4cda8612ecd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e003f9-2fad-48b4-8e5b-4cda8612ecd2.jpg?1",
             "name": "Simulacrum Synthesizer",
             "text": "When Simulacrum Synthesizer enters the battlefield, scry 2.\nWhenever another artifact with mana value 3 or greater enters the battlefield under your control, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "d37798bc-b707-50df-9101-c543bedc0060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db3d9f-d95e-4854-8ea6-7970877221d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db3d9f-d95e-4854-8ea6-7970877221d6.jpg?1",
             "name": "Worldwalker Helm",
             "text": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token.\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -2569,7 +2569,7 @@
         },
         {
             "id": "2edf98ba-c6ea-5860-86b7-f650bec76557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c57172-6de4-421f-93d8-be1c601c1d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c57172-6de4-421f-93d8-be1c601c1d0b.jpg?1",
             "name": "Greed's Gambit",
             "text": "When Greed's Gambit enters the battlefield, you draw three cards, gain 6 life, and create three 2/1 black Bat creature tokens with flying.\nAt the beginning of your end step, you discard a card, lose 2 life, and sacrifice a creature.\nWhen Greed's Gambit leaves the battlefield, you discard three cards, lose 6 life, and sacrifice three creatures.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "402daa86-3f2e-5628-aa16-e76b04ba9d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2adbac7-e479-4c73-8978-f7fde9f6e14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2adbac7-e479-4c73-8978-f7fde9f6e14d.jpg?1",
             "name": "Harvester of Misery",
             "text": "Menace\nWhen Harvester of Misery enters the battlefield, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard Harvester of Misery: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "a1f3a6a7-78d5-5b45-890c-a144b2644cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c9365-af51-4874-be5b-57d0514825fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c9365-af51-4874-be5b-57d0514825fe.jpg?1",
             "name": "Hostile Investigator",
             "text": "When Hostile Investigator enters the battlefield, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn.",
             "colours": [
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "1b925c9d-4bf8-50d1-8858-6ddda3710521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393bf5fc-0ad2-4116-83b4-346d61ac2911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393bf5fc-0ad2-4116-83b4-346d61ac2911.jpg?1",
             "name": "Generous Plunderer",
             "text": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "ad9a9ad4-a5ae-5656-a0e7-8805cc145719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffddccb-4195-4c8b-b2b3-5c545c656fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffddccb-4195-4c8b-b2b3-5c545c656fee.jpg?1",
             "name": "Legion Extruder",
             "text": "When Legion Extruder enters the battlefield, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "710280ef-b562-587c-bdeb-659d0e916455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9f1d0c-6f99-4b34-a367-052dd612ecda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9f1d0c-6f99-4b34-a367-052dd612ecda.jpg?1",
             "name": "Memory Vessel",
             "text": "{T}, Exile Memory Vessel: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "b3544854-6769-5c74-aa07-4a7df696e259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fbf320-63e1-461e-9696-561a2d6f554a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fbf320-63e1-461e-9696-561a2d6f554a.jpg?1",
             "name": "Molten Duplication",
             "text": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "17b01af4-9ce9-5d36-9d54-a520261624ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5999e2ac-7111-470a-b597-4c751ffecbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5999e2ac-7111-470a-b597-4c751ffecbfd.jpg?1",
             "name": "Territory Forge",
             "text": "When Territory Forge enters the battlefield, if you cast it, exile target artifact or land.\nTerritory Forge has all activated abilities of the exiled card.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "b81f887f-4215-5d20-8f13-af2f6de239f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b9c600-72e2-4648-9276-99b21cec00dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b9c600-72e2-4648-9276-99b21cec00dd.jpg?1",
             "name": "Ancient Cornucopia",
             "text": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "38d75be4-1864-5794-8867-c50119746f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa29302-65bb-4852-94dd-9c5f5477f94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa29302-65bb-4852-94dd-9c5f5477f94f.jpg?1",
             "name": "Bristlebud Farmer",
             "text": "Trample\nWhen Bristlebud Farmer enters the battlefield, create two Food tokens.\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "2a6ce767-3e3f-5917-b7f1-ec24cb2c4efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e6422-801a-48ec-8fb7-ff59e1fed25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e6422-801a-48ec-8fb7-ff59e1fed25c.jpg?1",
             "name": "Omenpath Journey",
             "text": "When Omenpath Journey enters the battlefield, search your library for up to five land cards that have different names, exile them, then shuffle.\nAt the beginning of your end step, choose a card at random exiled with Omenpath Journey and put it onto the battlefield tapped.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "817df7eb-fe55-52ca-8a40-bca55c2435c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c96b72-b0e1-4ea3-9984-5a67718d070d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c96b72-b0e1-4ea3-9984-5a67718d070d.jpg?1",
             "name": "Sandstorm Salvager",
             "text": "When Sandstorm Salvager enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "34140249-3c3f-5c18-99d6-c1f4f21632de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca436a-e992-40a9-978a-501a82e443ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca436a-e992-40a9-978a-501a82e443ed.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "3ec753c7-3c00-501e-9e68-0d438a377bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db35dae-6701-45a1-97c4-3e3049b45555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db35dae-6701-45a1-97c4-3e3049b45555.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
             "colours": [
@@ -3087,7 +3087,7 @@
         },
         {
             "id": "57bc0a37-1f46-5a43-9259-c8f2d804d171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d62921-f76d-436a-ae8b-c3a52715b47d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d62921-f76d-436a-ae8b-c3a52715b47d.jpg?1",
             "name": "Pest Control",
             "text": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2}",
             "colours": [
@@ -3124,7 +3124,7 @@
         },
         {
             "id": "6232a2a9-0d22-58d3-b80e-64ffc5d9319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a723b3-e93b-499e-a5cf-f79a3634d4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a723b3-e93b-499e-a5cf-f79a3634d4da.jpg?1",
             "name": "Lost Jitte",
             "text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one \u2014\n\u2022 Untap target land.\n\u2022 Target creature can't block this turn.\n\u2022 Put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [],
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "17bf0ea6-715f-5a2c-ab21-231e0d0fae77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d0c7a2-9614-4e72-a18f-7187de102dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d0c7a2-9614-4e72-a18f-7187de102dc3.jpg?1",
             "name": "Lotus Ring",
             "text": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
             "colours": [],
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "b991f38f-86c3-5a89-a5f4-4f91b4c0dfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb8d780-ed74-4084-ac3b-245af39d00da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb8d780-ed74-4084-ac3b-245af39d00da.jpg?1",
             "name": "Nexus of Becoming",
             "text": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
             "colours": [],
@@ -3224,7 +3224,7 @@
         },
         {
             "id": "1aa0c4aa-017c-5d6d-b2a5-316e0f0cfc55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdcd21-55a3-4cad-8b73-3d6f85a69ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdcd21-55a3-4cad-8b73-3d6f85a69ce1.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
             "colours": [],
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "eec50a2e-2e7c-529b-9c14-0f7c64b32c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034bf77-38dc-4b43-9a00-831d89af437a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034bf77-38dc-4b43-9a00-831d89af437a.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "adc75fcb-2b7c-5fb3-a0eb-9253e52af69d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2058a-24a7-4b10-a1d5-0b69e94c8688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2058a-24a7-4b10-a1d5-0b69e94c8688.jpg?1",
             "name": "Transmutation Font",
             "text": "{T}: Create your choice of a Blood token, a Clue token, or a Food token.\n{3}, {T}, Sacrifice three artifact tokens with different names: Search your library for an artifact card, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [],
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "0d0b10ee-f9c8-5a50-ae58-138f8d18a32e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419022-bed8-425c-99a9-fc288446efd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419022-bed8-425c-99a9-fc288446efd1.jpg?1",
             "name": "Fomori Vault",
             "text": "{T}: Add {C}.\n{3}, {T}, Discard a card: Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "61f2ac50-f6ba-51d9-b93b-76db551df577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b85d6ea-e312-48b9-9c22-398454d9a45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b85d6ea-e312-48b9-9c22-398454d9a45c.jpg?1",
             "name": "Tarnation Vista",
             "text": "Tarnation Vista enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{1}, {T}: For each color among monocolored permanents you control, add one mana of that color.",
             "colours": [],
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "b27f7542-51ce-5c9b-8042-37377b10d01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f138e5-501d-486f-b9a0-3f37640398a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f138e5-501d-486f-b9a0-3f37640398a0.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "309ddf88-4480-5518-8c98-1f1e60b013dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0753c3b5-6127-4e42-a029-b165d5f8170c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0753c3b5-6127-4e42-a029-b165d5f8170c.jpg?1",
             "name": "Blood",
             "text": "",
             "colours": [],
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "c0107955-7c56-5df9-9df1-740a54f52416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "9300919a-d231-50be-9f4b-3ed4a4258350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e3af6-7904-4214-8141-e145c48e2687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e3af6-7904-4214-8141-e145c48e2687.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "f407d357-2a03-5d42-8567-c942802d7ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a257ae72-2a82-4861-a2fb-a0a09be00646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a257ae72-2a82-4861-a2fb-a0a09be00646.jpg?1",
             "name": "Gnome",
             "text": "",
             "colours": [],
@@ -3544,7 +3544,7 @@
         },
         {
             "id": "a890ea09-dc01-5f95-8ccd-bbcae0d2bb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "ca9e0bcd-65f0-57dd-b5a1-eb8dac469f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03516d49-0613-46f7-8d88-3bf26d2c8659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03516d49-0613-46f7-8d88-3bf26d2c8659.jpg?1",
             "name": "Map",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/BLB.json
+++ b/Assets/Resources/Sets/BLB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "43463b33-91c0-5c9a-afbd-16348aee95f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a06f82-ebdb-4dd6-bfe8-958018ce557c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a06f82-ebdb-4dd6-bfe8-958018ce557c.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "d32ba1b1-d971-575a-a7c6-4723ca7859f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc310a26-b6a0-4e42-98ab-bdfd7b06cb63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc310a26-b6a0-4e42-98ab-bdfd7b06cb63.jpg?1",
             "name": "Beza, the Bounding Spring",
             "text": "When Beza, the Bounding Spring enters, create a Treasure token if an opponent controls more lands than you. You gain 4 life if an opponent has more life than you. Create two 1/1 blue Fish creature tokens if an opponent controls more creatures than you. Draw a card if an opponent has more cards in hand than you.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "60ca340a-dae9-59eb-b478-ed1a4cbb1544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd4693-424d-4d6e-86cf-24401a23d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd4693-424d-4d6e-86cf-24401a23d6b1.jpg?1",
             "name": "Brave-Kin Duo",
             "text": "{1}, {T}: Target creature gets +1/+1 until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "a8a20283-129e-5418-99d2-a02aaab2252b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7fea2e-7414-4bc8-adb0-9342e174c009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7fea2e-7414-4bc8-adb0-9342e174c009.jpg?1",
             "name": "Brightblade Stoat",
             "text": "First strike, lifelink",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "55164590-76b4-5111-a850-7d3fbc6bb1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fa581a-724e-4196-a9a3-ff84c54bdb7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fa581a-724e-4196-a9a3-ff84c54bdb7d.jpg?1",
             "name": "Builder's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Builder's Talent enters, create a 0/4 white Wall creature token with defender.\n{W}: Level 2\n//Level_2//\nWhenever one or more noncreature, nonland permanents you control enter, put a +1/+1 counter on target creature you control.\n{4}{W}: Level 3\n//Level_3//\nWhen this Class becomes level 3, return target noncreature, nonland permanent card from your graveyard to the battlefield.",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "8bbc28f3-0f0b-5418-8f23-52b4aea94e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ea98a-e36e-4ab9-b4da-cc572f3777db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ea98a-e36e-4ab9-b4da-cc572f3777db.jpg?1",
             "name": "Caretaker's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever one or more tokens you control enter, draw a card. This ability triggers only once each turn.\n{W}: Level 2\n//Level_2//\nWhen this Class becomes level 2, create a token that's a copy of target token you control.\n{3}{W}: Level 3\n//Level_3//\nCreature tokens you control get +2/+2.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "06ee1d2b-9cb8-5aa6-93b5-fdf8c2c90ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb03bb4f-8b4b-417e-bfc6-294cd2186b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb03bb4f-8b4b-417e-bfc6-294cd2186b2e.jpg?1",
             "name": "Carrot Cake",
             "text": "When Carrot Cake enters and when you sacrifice it, create a 1/1 white Rabbit creature token and scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{2}, {T}, Sacrifice Carrot Cake: You gain 3 life.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "89648894-3761-5c3a-bc7a-00408aaa6de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7b3b25-d4b3-4451-9f5c-6eb369541175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7b3b25-d4b3-4451-9f5c-6eb369541175.jpg?1",
             "name": "Crumb and Get It",
             "text": "Gift a Food (You may promise an opponent a gift as you cast this spell. If you do, they create a Food token before its other effects. It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nTarget creature you control gets +2/+2 until end of turn. If the gift was promised, that creature also gains indestructible until end of turn.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "411b89a3-9905-5e86-ad59-6d0bcdef526f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72bfa0-efef-48ce-aff8-d5818ed71ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72bfa0-efef-48ce-aff8-d5818ed71ba6.jpg?1",
             "name": "Dawn's Truce",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nYou and permanents you control gain hexproof until end of turn. If the gift was promised, permanents you control also gain indestructible until end of turn.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "8454441c-3070-53d5-bfbc-f37dc6f5fcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666aefc2-44e0-4c27-88d5-7906f245a71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666aefc2-44e0-4c27-88d5-7906f245a71f.jpg?1",
             "name": "Dewdrop Cure",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn up to two target creature cards each with mana value 2 or less from your graveyard to the battlefield. If the gift was promised, instead return up to three target creature cards each with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "d1655fc0-abe9-57d0-8ddc-cdc64a8b582c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ab2de3-3aea-461a-a74f-fb742cf8a198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ab2de3-3aea-461a-a74f-fb742cf8a198.jpg?1",
             "name": "Driftgloom Coyote",
             "text": "When Driftgloom Coyote enters, exile target creature an opponent controls until Driftgloom Coyote leaves the battlefield. If that creature had power 2 or less, put a +1/+1 counter on Driftgloom Coyote.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "030d297d-c2c6-51d2-b51e-fc50ad3983c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf7e4c-4d5d-4acc-a834-e6c4a7629408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf7e4c-4d5d-4acc-a834-e6c4a7629408.jpg?1",
             "name": "Essence Channeler",
             "text": "As long as you've lost life this turn, Essence Channeler has flying and vigilance.\nWhenever you gain life, put a +1/+1 counter on Essence Channeler.\nWhen Essence Channeler dies, put its counters on target creature you control.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "c22733cb-1827-5cf1-acd3-f3b40f991ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb41503-8632-4bf1-9bfe-6d9b9993c337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb41503-8632-4bf1-9bfe-6d9b9993c337.jpg?1",
             "name": "Feather of Flight",
             "text": "Flash\nEnchant creature\nWhen Feather of Flight enters, draw a card.\nEnchanted creature gets +1/+0 and has flying.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "2bbf8952-5e38-5653-89f1-ed1d65ac28da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff118f-9c3c-43a2-8085-980c7fe7d227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff118f-9c3c-43a2-8085-980c7fe7d227.jpg?1",
             "name": "Flowerfoot Swordmaster",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nValiant \u2014 Whenever this creature becomes the target of a spell or ability you control for the first time each turn, Mice you control get +1/+0 until end of turn.",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "4174a7d3-37ad-5b7b-aba5-9a0e16e48e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41762689-0c13-4d45-9d81-ba2afad980f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41762689-0c13-4d45-9d81-ba2afad980f8.jpg?1",
             "name": "Harvestrite Host",
             "text": "Whenever Harvestrite Host or another Rabbit you control enters, target creature you control gets +1/+0 until end of turn. Then draw a card if this is the second time this ability has resolved this turn.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "5f1915e5-2cbd-5178-be2b-b244d4e88be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7207f8-5daa-42af-aeea-7a489047110b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7207f8-5daa-42af-aeea-7a489047110b.jpg?1",
             "name": "Hop to It",
             "text": "Create three 1/1 white Rabbit creature tokens.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "0e9c0952-72c4-5ded-bdfa-9ec5d5c899ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d70b99d-c8bf-4a56-8957-cf587fe60b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d70b99d-c8bf-4a56-8957-cf587fe60b81.jpg?1",
             "name": "Intrepid Rabbit",
             "text": "Offspring {1} (You may pay an additional {1} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "4502bd7c-49ad-516b-bc55-e98a95d625c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121af600-6143-450a-9f87-12ce4833f1ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121af600-6143-450a-9f87-12ce4833f1ec.jpg?1",
             "name": "Jackdaw Savior",
             "text": "Flying\nWhenever Jackdaw Savior or another creature you control with flying dies, return another target creature card with lesser mana value from your graveyard to the battlefield.",
             "colours": [
@@ -627,7 +627,7 @@
         },
         {
             "id": "0bbf1c63-e1b9-5ce1-b8e5-25654f106798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eab51d6-ba17-4a8c-8834-25db363f2b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eab51d6-ba17-4a8c-8834-25db363f2b6b.jpg?1",
             "name": "Jolly Gerbils",
             "text": "Whenever you give a gift, draw a card.",
             "colours": [
@@ -662,7 +662,7 @@
         },
         {
             "id": "5e029c84-b08b-5548-af4b-17d0956cce42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca543405-5e12-48a0-9a77-082ac9bcb2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca543405-5e12-48a0-9a77-082ac9bcb2f2.jpg?1",
             "name": "Lifecreed Duo",
             "text": "Flying\nWhenever another creature you control enters, you gain 1 life.",
             "colours": [
@@ -697,7 +697,7 @@
         },
         {
             "id": "29a310b0-918a-59e7-a30c-aa7db1b32811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfcf83f-089c-4e35-855e-b61b98bb1cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfcf83f-089c-4e35-855e-b61b98bb1cd8.jpg?1",
             "name": "Mabel's Mettle",
             "text": "Target creature gets +2/+2 until end of turn. Up to one other target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -729,7 +729,7 @@
         },
         {
             "id": "a8d4ff66-893b-5d7c-bdd7-2af337d5af9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1bc5a-03e7-44ec-893e-44042cbc02ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1bc5a-03e7-44ec-893e-44042cbc02ef.jpg?1",
             "name": "Mouse Trapper",
             "text": "Flash\nValiant \u2014 Whenever Mouse Trapper becomes the target of a spell or ability you control for the first time each turn, tap target creature an opponent controls.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "a902dba4-1c65-5a5b-a2bc-6ca48131da7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c3cc3-2aa2-453e-a17c-2baeeaabe0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c3cc3-2aa2-453e-a17c-2baeeaabe0a9.jpg?1",
             "name": "Nettle Guard",
             "text": "Valiant \u2014 Whenever Nettle Guard becomes the target of a spell or ability you control for the first time each turn, it gets +0/+2 until end of turn.\n{1}, Sacrifice Nettle Guard: Destroy target artifact or enchantment.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "3db803d4-f111-54e3-be00-d3b1c64025a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1086e826-94b8-4398-8a38-d8eacca56a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1086e826-94b8-4398-8a38-d8eacca56a43.jpg?1",
             "name": "Parting Gust",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nExile target nontoken creature. If the gift wasn't promised, return that creature to the battlefield under its owner's control with a +1/+1 counter on it at the beginning of the next end step.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "3d62cdb2-06cf-5a56-9037-7b823d5e8545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae442cd6-c4df-4aad-9b1d-ccd936c5ec96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae442cd6-c4df-4aad-9b1d-ccd936c5ec96.jpg?1",
             "name": "Pileated Provisioner",
             "text": "Flying\nWhen Pileated Provisioner enters, put a +1/+1 counter on target creature you control without flying.",
             "colours": [
@@ -866,7 +866,7 @@
         },
         {
             "id": "56fb4235-0a6a-5752-b6b1-2cc2a49d1e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ded450-346d-4917-917a-b62bc0267509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ded450-346d-4917-917a-b62bc0267509.jpg?1",
             "name": "Rabbit Response",
             "text": "Creatures you control get +2/+1 until end of turn. If you control a Rabbit, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
             "colours": [
@@ -898,7 +898,7 @@
         },
         {
             "id": "21513c17-e7d0-5aea-8f6a-cf641af659a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d068192a-6270-4981-819d-4945fa4a2b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d068192a-6270-4981-819d-4945fa4a2b83.jpg?1",
             "name": "Repel Calamity",
             "text": "Destroy target creature with power or toughness 4 or greater.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "1f654bec-85ba-5d89-b735-d3e9b3e9df59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2656160-d319-4530-a6e5-c418596c3f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2656160-d319-4530-a6e5-c418596c3f12.jpg?1",
             "name": "Salvation Swan",
             "text": "Flash\nFlying\nWhenever Salvation Swan or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "c467fb82-19c8-5f90-a4bf-093da8183330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf9c60-4e58-48a4-8e53-abef7ab3b671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf9c60-4e58-48a4-8e53-abef7ab3b671.jpg?1",
             "name": "Season of the Burrow",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a 1/1 white Rabbit creature token.\n{Paw Print}{Paw Print} \u2014 Exile target nonland permanent. Its controller draws a card.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return target permanent card with mana value 3 or less from your graveyard to the battlefield with an indestructible counter on it.",
             "colours": [
@@ -1001,7 +1001,7 @@
         },
         {
             "id": "9fbacd89-01c6-5df4-b63f-3590d05bee5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90873995-876f-4e89-8bc7-41a74f4d931f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90873995-876f-4e89-8bc7-41a74f4d931f.jpg?1",
             "name": "Seasoned Warrenguard",
             "text": "Whenever Seasoned Warrenguard attacks while you control a token, Seasoned Warrenguard gets +2/+0 until end of turn.",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "f2bd680c-c60d-5189-8fb2-82b169ed31c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306fec2c-d8b7-4f4b-8f58-10e3b9f3158f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306fec2c-d8b7-4f4b-8f58-10e3b9f3158f.jpg?1",
             "name": "Shrike Force",
             "text": "Flying, double strike, vigilance",
             "colours": [
@@ -1071,7 +1071,7 @@
         },
         {
             "id": "922a88c7-456f-59ce-963e-8d9bd3974978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50da179-751f-47a8-a547-8c4a291ed381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50da179-751f-47a8-a547-8c4a291ed381.jpg?1",
             "name": "Sonar Strike",
             "text": "Sonar Strike deals 4 damage to target attacking, blocking, or tapped creature. You gain 3 life if you control a Bat.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "664f2845-7239-5250-81ec-73aae3669ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e209237-00f7-4bf0-8287-ccde02ce8e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e209237-00f7-4bf0-8287-ccde02ce8e8d.jpg?1",
             "name": "Star Charter",
             "text": "Flying\nAt the beginning of your end step, if you gained or lost life this turn, look at the top four cards of your library. You may reveal a creature card with power 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1138,7 +1138,7 @@
         },
         {
             "id": "19f24ef3-a354-5158-9ca5-a68105890961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aea38e6-ec58-4091-b27c-2761bdd12b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aea38e6-ec58-4091-b27c-2761bdd12b13.jpg?1",
             "name": "Starfall Invocation",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nDestroy all creatures. If the gift was promised, return a creature card put into your graveyard this way to the battlefield under your control.",
             "colours": [
@@ -1172,7 +1172,7 @@
         },
         {
             "id": "579f8dec-429c-5538-9044-b0c53c9fb950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa8d83f-8586-4127-8b55-9715e9547488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa8d83f-8586-4127-8b55-9715e9547488.jpg?1",
             "name": "Thistledown Players",
             "text": "Whenever Thistledown Players attacks, untap target nonland permanent.",
             "colours": [
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "88e5e27c-9dc6-52b6-8c7a-1a8c5e066a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba629ca8-a368-4282-8a61-9bf6a5c217f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba629ca8-a368-4282-8a61-9bf6a5c217f0.jpg?1",
             "name": "Valley Questcaller",
             "text": "Whenever one or more other Rabbits, Bats, Birds, and/or Mice you control enter, scry 1.\nOther Rabbits, Bats, Birds, and Mice you control get +1/+1.",
             "colours": [
@@ -1244,7 +1244,7 @@
         },
         {
             "id": "53e060fd-774c-56a7-a9ef-572a12321c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf20069-5a20-4f95-976b-6af2b69f3ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf20069-5a20-4f95-976b-6af2b69f3ad0.jpg?1",
             "name": "Warren Elder",
             "text": "{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1279,7 +1279,7 @@
         },
         {
             "id": "d95721eb-7505-501b-81e4-346394de4c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5237a0-5ac3-4ded-9f92-5f782a7bbbd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5237a0-5ac3-4ded-9f92-5f782a7bbbd7.jpg?1",
             "name": "Warren Warleader",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhenever you attack, choose one \u2014\n\u2022 Create a 1/1 white Rabbit creature token that's tapped and attacking.\n\u2022 Attacking creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "33471dcc-2afe-59d8-872c-336bb71e6d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90ea719-5320-46c6-a347-161853a14776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90ea719-5320-46c6-a347-161853a14776.jpg?1",
             "name": "Wax-Wane Witness",
             "text": "Flying, vigilance\nWhenever you gain or lose life during your turn, Wax-Wane Witness gets +1/+0 until end of turn.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "973fbc4a-d667-5971-aff2-ed5ea05b47eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a78d59-af31-4af9-95aa-2573fe553925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a78d59-af31-4af9-95aa-2573fe553925.jpg?1",
             "name": "Whiskervale Forerunner",
             "text": "Valiant \u2014 Whenever Whiskervale Forerunner becomes the target of a spell or ability you control for the first time each turn, look at the top five cards of your library. You may reveal a creature card with mana value 3 or less from among them. You may put it onto the battlefield if it's your turn. If you don't put it onto the battlefield, put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "4f2dac19-98f3-5837-a0e5-e3f5b845c8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211af1bf-910b-41a5-b928-f378188d1871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211af1bf-910b-41a5-b928-f378188d1871.jpg?1",
             "name": "Azure Beastbinder",
             "text": "Vigilance\nAzure Beastbinder can't be blocked by creatures with power 2 or greater.\nWhenever Azure Beastbinder attacks, up to one target artifact, creature, or planeswalker an opponent controls loses all abilities until your next turn. If it's a creature, it also has base power and toughness 2/2 until your next turn.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "0fac1752-c0c3-522a-9831-d708d1e2592c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2215dd-6300-49cf-b9b2-3a840b786c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2215dd-6300-49cf-b9b2-3a840b786c31.jpg?1",
             "name": "Bellowing Crier",
             "text": "When Bellowing Crier enters, draw a card, then discard a card.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "17da92d5-8c1a-5100-971a-f8430ff2b94a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bc8b2-ffa0-4549-aead-aacb3db3cf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bc8b2-ffa0-4549-aead-aacb3db3cf19.jpg?1",
             "name": "Calamitous Tide",
             "text": "Return up to two target creatures to their owners' hands. Draw two cards, then discard a card.",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "8dde85b7-9c48-5bbc-b1ce-1518eb5f58a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19422406-0c1a-497e-bed1-708bc556491a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19422406-0c1a-497e-bed1-708bc556491a.jpg?1",
             "name": "Daring Waverider",
             "text": "When Daring Waverider enters, you may cast target instant or sorcery card with mana value 4 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "ab1ab4dd-b944-5b45-bb8c-bb39b5222bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8739f1ac-2e57-4b52-a7ff-cc8df5936aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8739f1ac-2e57-4b52-a7ff-cc8df5936aad.jpg?1",
             "name": "Dazzling Denial",
             "text": "Counter target spell unless its controller pays {2}. If you control a Bird, counter that spell unless its controller pays {4} instead.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "b5bbc0f6-2a01-5d9c-a919-4c17419dfae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1931f22-974c-43ad-911e-684bf3f9995d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1931f22-974c-43ad-911e-684bf3f9995d.jpg?1",
             "name": "Dire Downdraft",
             "text": "This spell costs {1} less to cast if it targets an attacking or tapped creature.\nTarget creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "1adefd64-8d6a-5639-95af-5f2f0c846484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6402133e-eed1-4a46-9667-8b7a310362c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6402133e-eed1-4a46-9667-8b7a310362c1.jpg?1",
             "name": "Dour Port-Mage",
             "text": "Whenever one or more other creatures you control leave the battlefield without dying, draw a card.\n{1}{U}, {T}: Return another target creature you control to its owner's hand.",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "6dfc336f-dc24-5d20-9643-9f2a09ad284e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d45abe-4962-47d9-a54e-7e623ea8647c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d45abe-4962-47d9-a54e-7e623ea8647c.jpg?1",
             "name": "Eddymurk Crab",
             "text": "Flash\nThis spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nEddymurk Crab enters tapped if it's not your turn.\nWhen Eddymurk Crab enters, tap up to two target creatures.",
             "colours": [
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "63eb7424-ca13-5d17-9b8a-e47838772dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2bf6ba-cd1a-4382-9572-6dfbcf6ed0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2bf6ba-cd1a-4382-9572-6dfbcf6ed0c6.jpg?1",
             "name": "Eluge, the Shoreless Sea",
             "text": "Eluge's power and toughness are each equal to the number of Islands you control.\nWhenever Eluge enters or attacks, put a flood counter on target land. It's an Island in addition to its other types for as long as it has a flood counter on it.\nThe first instant or sorcery spell you cast each turn costs {U} (or {1}) less to cast for each land you control with a flood counter on it.",
             "colours": [
@@ -1702,7 +1702,7 @@
         },
         {
             "id": "f44925a9-4f22-571f-bb89-094e2b0984b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c671eab-d1ef-4d79-94eb-8b85f0d18699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c671eab-d1ef-4d79-94eb-8b85f0d18699.jpg?1",
             "name": "Finch Formation",
             "text": "Offspring {3} (You may pay an additional {3} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nFlying\nWhen this creature enters, target creature you control gains flying until end of turn.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "c522938e-c76a-5d8a-9cb2-00a36af806f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b299889a-03d6-4659-b0e1-f0830842e40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b299889a-03d6-4659-b0e1-f0830842e40f.jpg?1",
             "name": "Gossip's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever a creature you control enters, surveil 1.\n{1}{U}: Level 2\n//Level_2//\nWhenever you attack, target attacking creature with power 3 or less can't be blocked this turn.\n{3}{U}: Level 3\n//Level_3//\nWhenever a creature you control deals combat damage to a player, you may exile it, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1771,7 +1771,7 @@
         },
         {
             "id": "0b38336b-a943-5b9f-9760-3e265299e271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9575a-53d9-4df7-b86c-cda021107d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9575a-53d9-4df7-b86c-cda021107d3f.jpg?1",
             "name": "Into the Flood Maw",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nReturn target creature an opponent controls to its owner's hand. If the gift was promised, instead return target nonland permanent an opponent controls to its owner's hand.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "0a1b8142-e685-5050-a747-84b40c70d7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085be5d1-fd85-46d1-ad39-a8aa75a06a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085be5d1-fd85-46d1-ad39-a8aa75a06a96.jpg?1",
             "name": "Kitnap",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they draw a card.)\nEnchant creature\nWhen Kitnap enters, tap enchanted creature. If the gift wasn't promised, put three stun counters on it.\nYou control enchanted creature.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "a1ff23cd-4083-5567-a61b-dfd0dd6359a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff751a-ec64-41d5-b22c-2a483ad9a9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff751a-ec64-41d5-b22c-2a483ad9a9b2.jpg?1",
             "name": "Kitsa, Otterball Elite",
             "text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{T}: Draw a card, then discard a card.\n{2}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy. Activate only if Kitsa's power is 3 or greater.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "d7f8fc02-958f-5418-b540-3643d249747d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fb7f4f-2153-4527-8f11-adbf508d3533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fb7f4f-2153-4527-8f11-adbf508d3533.jpg?1",
             "name": "Knightfisher",
             "text": "Flying\nWhenever another nontoken Bird you control enters, create a 1/1 blue Fish creature token.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "d900dd42-d9ba-5495-87d4-5ddf83367af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00c834-b4a9-45b8-bb3f-22c2a42314a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00c834-b4a9-45b8-bb3f-22c2a42314a0.jpg?1",
             "name": "Lightshell Duo",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Lightshell Duo enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1948,7 +1948,7 @@
         },
         {
             "id": "d9657403-90a5-5621-a37e-f0cff934bfc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c267719-cd03-4003-b281-e732d5e42a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c267719-cd03-4003-b281-e732d5e42a1e.jpg?1",
             "name": "Long River Lurker",
             "text": "Ward {1}\nOther Frogs you control have ward {1}.\nWhen Long River Lurker enters, target creature you control can't be blocked this turn. Whenever that creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "c7ffede4-35e7-5c43-9f00-842cff5470ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c81d0fa-81a1-4f9b-a5fd-5a648fd01dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c81d0fa-81a1-4f9b-a5fd-5a648fd01dea.jpg?1",
             "name": "Long River's Pull",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nCounter target creature spell. If the gift was promised, instead counter target spell.",
             "colours": [
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "b3f48cee-6b67-54f2-909b-1412606c6d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e24fe6a-607b-49b8-9fca-cecb1e40de7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e24fe6a-607b-49b8-9fca-cecb1e40de7f.jpg?1",
             "name": "Mind Spiral",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nTarget player draws three cards. If the gift was promised, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "44cf98b4-8067-5fcf-8571-07652861dde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa10f34-5bfd-4d87-8f07-58de3b0f5663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa10f34-5bfd-4d87-8f07-58de3b0f5663.jpg?1",
             "name": "Mindwhisker",
             "text": "At the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nThreshold \u2014 As long as seven or more cards are in your graveyard, creatures your opponents control get -1/-0.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "a01673a3-0a53-5599-82fe-b7f0c536dfbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade32396-8841-4ba4-8852-d11146607f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade32396-8841-4ba4-8852-d11146607f21.jpg?1",
             "name": "Mockingbird",
             "text": "Flying\nYou may have Mockingbird enter as a copy of any creature on the battlefield with mana value less than or equal to the amount of mana spent to cast Mockingbird, except it's a Bird in addition to its other types and it has flying.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "b083e825-83c8-5b47-9cbf-cc26cfb0a56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0928e04f-2568-41e8-b603-7a25cf5f94d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0928e04f-2568-41e8-b603-7a25cf5f94d0.jpg?1",
             "name": "Nightwhorl Hermit",
             "text": "Vigilance\nThreshold \u2014 As long as seven or more cards are in your graveyard, Nightwhorl Hermit gets +1/+0 and can't be blocked.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "54fbb709-a8e3-540f-ab22-a02ec6994371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff83ff7-e428-4ccc-8341-f223dab76bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff83ff7-e428-4ccc-8341-f223dab76bd1.jpg?1",
             "name": "Otterball Antics",
             "text": "Create a 1/1 blue and red Otter creature token with prowess. If this spell was cast from anywhere other than your hand, put a +1/+1 counter on that creature. (Whenever you cast a noncreature spell, a creature with prowess gets +1/+1 until end of turn.)\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "2068caf3-2429-5a98-a0db-f798f01fb716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb9575-1138-4f99-8e90-0eaf00bdf4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb9575-1138-4f99-8e90-0eaf00bdf4a1.jpg?1",
             "name": "Pearl of Wisdom",
             "text": "This spell costs {1} less to cast if you control an Otter.\nDraw two cards.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "32e8669c-b544-5bed-8da7-fbc1a2a7bc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71320ed-2f30-49ce-bcb0-19aebba3f0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71320ed-2f30-49ce-bcb0-19aebba3f0e8.jpg?1",
             "name": "Plumecreed Escort",
             "text": "Flash\nFlying\nWhen Plumecreed Escort enters, target creature you control gains hexproof until end of turn.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "73472084-a1fa-51ea-b3cf-815a9a6bc374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8599e2dd-9164-4da3-814f-adccef3b9497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8599e2dd-9164-4da3-814f-adccef3b9497.jpg?1",
             "name": "Portent of Calamity",
             "text": "Reveal the top X cards of your library. For each card type, you may exile a card of that type from among them. Put the rest into your graveyard. You may cast a spell from among the exiled cards without paying its mana cost if you exiled four or more cards this way. Then put the rest of the exiled cards into your hand.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "a747a12c-3789-5186-9f97-ffed149735c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb7ec70-a5a4-4188-ba1a-e88b81bdbad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb7ec70-a5a4-4188-ba1a-e88b81bdbad0.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "119697c2-da08-5655-8103-d3e8725ed718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5713bb4-bdd9-4253-b6b9-e590532ed773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5713bb4-bdd9-4253-b6b9-e590532ed773.jpg?1",
             "name": "Season of Weaving",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Draw a card.\n{Paw Print}{Paw Print} \u2014 Choose an artifact or creature you control. Create a token that's a copy of it.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return each nonland, nontoken permanent to its owner's hand.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "cd39dec1-f987-5bb3-bcb0-03bfdfe87ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3b49e-3674-494c-bdea-4374cefd10f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3b49e-3674-494c-bdea-4374cefd10f4.jpg?1",
             "name": "Shore Up",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "dc494320-fa3c-5ca6-a4da-122629bbe077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bf8cf0-419a-4dc9-9342-aad55c1af05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bf8cf0-419a-4dc9-9342-aad55c1af05a.jpg?1",
             "name": "Shoreline Looter",
             "text": "Shoreline Looter can't be blocked.\nThreshold \u2014 Whenever Shoreline Looter deals combat damage to a player, draw a card. Then discard a card unless seven or more cards are in your graveyard.",
             "colours": [
@@ -2422,7 +2422,7 @@
         },
         {
             "id": "a1bc029c-fcd7-5157-ac77-871ab74e21cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6844bad-ffbe-4c6e-b438-08562eccea52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6844bad-ffbe-4c6e-b438-08562eccea52.jpg?1",
             "name": "Skyskipper Duo",
             "text": "Flying\nWhen Skyskipper Duo enters, exile up to one other target creature you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -2457,7 +2457,7 @@
         },
         {
             "id": "2fff7e2b-5a58-5444-8460-5f7ba9df1134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6620a-1d40-429d-9a0c-aaeb62adaa71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6620a-1d40-429d-9a0c-aaeb62adaa71.jpg?1",
             "name": "Spellgyre",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Surveil 2, then draw two cards. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "7c8f3415-c496-5fef-940f-86be5df5ea8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ee125-35a0-46cd-a201-e6797d12d33a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ee125-35a0-46cd-a201-e6797d12d33a.jpg?1",
             "name": "Splash Lasher",
             "text": "Offspring {1}{U} (You may pay an additional {1}{U} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, tap up to one target creature and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "eea16815-4f89-5f27-804b-08b4771ce130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbaa356-28ba-487f-930a-a957d9960ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbaa356-28ba-487f-930a-a957d9960ab0.jpg?1",
             "name": "Splash Portal",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control. If that creature is a Bird, Frog, Otter, or Rat, draw a card.",
             "colours": [
@@ -2556,7 +2556,7 @@
         },
         {
             "id": "777bfc89-21ee-54ca-886c-db6421d785ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36e682d-b43d-4e08-bf5b-70d7e924dbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36e682d-b43d-4e08-bf5b-70d7e924dbe5.jpg?1",
             "name": "Stormchaser's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Stormchaser's Talent enters, create a 1/1 blue and red Otter creature token with prowess.\n{3}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, return target instant or sorcery card from your graveyard to your hand.\n{5}{U}: Level 3\n//Level_3//\nWhenever you cast an instant or sorcery spell, create a 1/1 blue and red Otter creature token with prowess.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "c1ca3fc4-6a3e-5c0d-a26c-c04944e26fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcacbe71-efb0-49e1-b2d0-3ee65ec6cf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcacbe71-efb0-49e1-b2d0-3ee65ec6cf8b.jpg?1",
             "name": "Sugar Coat",
             "text": "Flash\nEnchant creature or Food\nEnchanted permanent is a colorless Food artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life\" and loses all other card types and abilities.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "f11cc39c-03bc-50c0-b00c-00e57039b7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0d83b-cc41-4f82-892c-ef6d3293228a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0d83b-cc41-4f82-892c-ef6d3293228a.jpg?1",
             "name": "Thought Shucker",
             "text": "Threshold \u2014 {1}{U}: Put a +1/+1 counter on Thought Shucker and draw a card. Activate only if seven or more cards are in your graveyard and only once.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "ba4bcc94-0edf-526f-8730-2d10e01be0a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf3af94-b7c8-415c-a5a1-d89967fd0bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf3af94-b7c8-415c-a5a1-d89967fd0bba.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "Offspring {4} (You may pay an additional {4} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "26392e57-b17f-5326-8a3b-e910def5c57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b12da0-f666-471d-95f5-15d8c9b31c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b12da0-f666-471d-95f5-15d8c9b31c92.jpg?1",
             "name": "Valley Floodcaller",
             "text": "Flash\nYou may cast noncreature spells as though they had flash.\nWhenever you cast a noncreature spell, Birds, Frogs, Otters, and Rats you control get +1/+1 until end of turn. Untap them.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "331ab074-0ae4-5324-81af-234bc5cbeada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35898b39-98e2-405b-8f18-0e054bd2c29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35898b39-98e2-405b-8f18-0e054bd2c29e.jpg?1",
             "name": "Waterspout Warden",
             "text": "Whenever Waterspout Warden attacks, if another creature entered the battlefield under your control this turn, Waterspout Warden gains flying until end of turn.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "30e880b1-e2ec-54aa-98ea-39e289dac445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeb20aa-b253-49b8-9947-c397a3a4002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeb20aa-b253-49b8-9947-c397a3a4002a.jpg?1",
             "name": "Wishing Well",
             "text": "{T}: Put a coin counter on Wishing Well. When you do, you may cast target instant or sorcery card with mana value equal to the number of coin counters on Wishing Well from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -2803,7 +2803,7 @@
         },
         {
             "id": "5fd9f8ad-3260-58a8-aa89-8fa6f5f8088b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ebb84a-1c52-4b07-9bd0-b360523b3a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ebb84a-1c52-4b07-9bd0-b360523b3a5b.jpg?1",
             "name": "Agate-Blade Assassin",
             "text": "Whenever Agate-Blade Assassin attacks, defending player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "68d3eae5-3c81-55dd-b4ce-6bc08b382624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485dc8d8-9e44-4a0f-9ff6-fa448e232290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485dc8d8-9e44-4a0f-9ff6-fa448e232290.jpg?1",
             "name": "Bandit's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Bandit's Talent enters, each opponent discards two cards unless they discard a nonland card.\n{B}: Level 2\n//Level_2//\nAt the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, they lose 2 life.\n{3}{B}: Level 3\n//Level_3//\nAt the beginning of your draw step, draw an additional card for each opponent who has one or fewer cards in hand.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "04c6c11d-d510-566e-b2bd-5a99929818e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf226fa-ca09-4468-8804-87b2a7de2c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf226fa-ca09-4468-8804-87b2a7de2c66.jpg?1",
             "name": "Bonebind Orator",
             "text": "{3}{B}, Exile Bonebind Orator from your graveyard: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "f0036c9a-34bc-533a-9c3e-69f275b846b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82defb87-237f-4b77-9673-5bf00607148f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82defb87-237f-4b77-9673-5bf00607148f.jpg?1",
             "name": "Bonecache Overseer",
             "text": "{T}, Pay 1 life: Draw a card. Activate only if three or more cards left your graveyard this turn or if you've sacrificed a Food this turn.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "f8400fd6-198e-5d45-8c27-aca70c1945a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d5de3e-0440-4dd1-899c-ab40c0752343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d5de3e-0440-4dd1-899c-ab40c0752343.jpg?1",
             "name": "Coiling Rebirth",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn target creature card from your graveyard to the battlefield. Then if the gift was promised and that creature isn't legendary, create a token that's a copy of that creature, except it's 1/1.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "6465bfe9-4675-54a6-99be-8c85dd5c20a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50acc41-3517-42db-b1d3-1bdfd7294d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50acc41-3517-42db-b1d3-1bdfd7294d84.jpg?1",
             "name": "Consumed by Greed",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nTarget opponent sacrifices a creature with the greatest power among creatures they control. If the gift was promised, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "0932fc55-6cba-5414-92d0-72a044bee59c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4539a-0157-4cbe-b50f-6e2575df74e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4539a-0157-4cbe-b50f-6e2575df74e9.jpg?1",
             "name": "Cruelclaw's Heist",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nTarget opponent reveals their hand. You choose a nonland card from it. Exile that card. If the gift was promised, you may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "d48e8250-7c66-57e3-90ef-998b61ce97ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2bb34-e328-44fb-918a-72208c9457e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2bb34-e328-44fb-918a-72208c9457e4.jpg?1",
             "name": "Daggerfang Duo",
             "text": "Deathtouch\nWhen Daggerfang Duo enters, you may mill two cards. (You may put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "ddd52317-1405-5fd3-87c4-4c482804941e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c603751-1e2b-4c8e-a8d2-5c0876e7254f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c603751-1e2b-4c8e-a8d2-5c0876e7254f.jpg?1",
             "name": "Darkstar Augur",
             "text": "Offspring {B} (You may pay an additional {B} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nFlying\nAt the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "83705c4b-ac3a-5096-bd9a-28f2015ca814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fada29c0-5293-40a4-b36d-d073ee99e650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fada29c0-5293-40a4-b36d-d073ee99e650.jpg?1",
             "name": "Diresight",
             "text": "Surveil 2, then draw two cards. You lose 2 life. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "4462068a-630b-5aa4-b8d9-2a2de921eaa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cfd628-933a-4d3d-b2e5-70bc86960d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cfd628-933a-4d3d-b2e5-70bc86960d1c.jpg?1",
             "name": "Downwind Ambusher",
             "text": "Flash\nWhen Downwind Ambusher enters, choose one \u2014\n\u2022 Target creature an opponent controls gets -1/-1 until end of turn.\n\u2022 Destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "eeaa199c-d233-556e-a8bf-b8e49df95d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5030e6ac-211d-4145-8c87-998a8351a467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5030e6ac-211d-4145-8c87-998a8351a467.jpg?1",
             "name": "Early Winter",
             "text": "Choose one \u2014\n\u2022 Exile target creature.\n\u2022 Target opponent exiles an enchantment they control.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "4598827b-2aa5-5d51-bc77-3a6a24df7e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e017ff8-2936-4a1b-bece-00004cfbad06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e017ff8-2936-4a1b-bece-00004cfbad06.jpg?1",
             "name": "Feed the Cycle",
             "text": "As an additional cost to cast this spell, forage or pay {B}. (To forage, exile three cards from your graveyard or sacrifice a Food.)\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "d145e5da-cffb-5475-b668-c8d19cbf7d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96ac326-de44-470b-a592-a4c2a052c091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96ac326-de44-470b-a592-a4c2a052c091.jpg?1",
             "name": "Fell",
             "text": "Destroy target creature.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "e669918a-2ac3-528f-ab35-dbfb6c794f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4831e7ae-54e3-4bd9-b5af-52dc29f81715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4831e7ae-54e3-4bd9-b5af-52dc29f81715.jpg?1",
             "name": "Glidedive Duo",
             "text": "Flying\nWhen Glidedive Duo enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "c4276d74-1ac6-5a53-a63b-4d6b548a536f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239363df-4de8-4b64-80fc-a1f4b5c36027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239363df-4de8-4b64-80fc-a1f4b5c36027.jpg?1",
             "name": "Hazel's Nocturne",
             "text": "Return up to two target creature cards from your graveyard to your hand. Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "bbf269d6-56ec-53ff-aa27-8d5c28887b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f61d7-4eb0-41c5-8a34-a0793c2abc51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f61d7-4eb0-41c5-8a34-a0793c2abc51.jpg?1",
             "name": "Huskburster Swarm",
             "text": "This spell costs {1} less to cast for each creature card you own in exile and in your graveyard.\nMenace, deathtouch",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "9dfd7a3a-67f6-5211-bd6a-26bb78e03cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bc854c-4e72-48e0-a098-e3451d6e511d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bc854c-4e72-48e0-a098-e3451d6e511d.jpg?1",
             "name": "Iridescent Vinelasher",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nLandfall \u2014 Whenever a land you control enters, this creature deals 1 damage to target opponent.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "1f64bc9e-23c2-5f50-a6e4-2d84b4fee207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3320ec-c4e8-405a-982d-e009c58c9e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3320ec-c4e8-405a-982d-e009c58c9e21.jpg?1",
             "name": "Maha, Its Feathers Night",
             "text": "Flying, trample\nWard\u2014\nDiscard a card.\nCreatures your opponents control have base toughness 1.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "e9816c69-f879-5d06-87ba-416ebd0aa9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e4aa8d-1d06-48db-b205-aa2f1392bbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e4aa8d-1d06-48db-b205-aa2f1392bbcb.jpg?1",
             "name": "Moonstone Harbinger",
             "text": "Flying, deathtouch\nWhenever you gain or lose life during your turn, Bats you control get +1/+0 and gain deathtouch until end of turn. This ability triggers only once each turn.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "c29b4d3c-5229-53e2-b927-7b6235504608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742c0409-9abd-4559-b52e-932cc90c531a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742c0409-9abd-4559-b52e-932cc90c531a.jpg?1",
             "name": "Nocturnal Hunger",
             "text": "Gift a Food (You may promise an opponent a gift as you cast this spell. If you do, they create a Food token before its other effects. It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nDestroy target creature. If the gift wasn't promised, you lose 2 life.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "503d35f7-5656-5187-97c7-6b218c6d818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8238dd-858f-466c-96de-986bd66861d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8238dd-858f-466c-96de-986bd66861d7.jpg?1",
             "name": "Osteomancer Adept",
             "text": "Deathtouch\n{T}: Until end of turn, you may cast creature spells from your graveyard by foraging in addition to paying their other costs. If you cast a spell this way, that creature enters with a finality counter on it. (To forage, exile three cards from your graveyard or sacrifice a Food. If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "7ea58d34-cf25-55ea-b471-efdc6992f2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b900c71-713b-4b7e-b4be-ad9f4aa0c139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b900c71-713b-4b7e-b4be-ad9f4aa0c139.jpg?1",
             "name": "Persistent Marshstalker",
             "text": "Persistent Marshstalker gets +1/+0 for each other Rat you control.\nThreshold \u2014 Whenever you attack with one or more Rats, if seven or more cards are in your graveyard, you may pay {2}{B}. If you do, return Persistent Marshstalker from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "71a359f1-6e5f-5526-b303-11afdb64ac1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df900308-8432-4a0a-be21-17482026012b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df900308-8432-4a0a-be21-17482026012b.jpg?1",
             "name": "Psychic Whorl",
             "text": "Target opponent discards two cards. Then if you control a Rat, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "957dca38-5366-58dd-b7bc-71f7e90c0922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874510be-7ecd-4eff-abad-b9594eb4821a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874510be-7ecd-4eff-abad-b9594eb4821a.jpg?1",
             "name": "Ravine Raider",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{1}{B}: Ravine Raider gets +1/+1 until end of turn.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "4ddc306f-e695-577a-b8b5-e169db27908f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735e79b1-a3a9-4ddf-8bbc-f756c8a0452b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735e79b1-a3a9-4ddf-8bbc-f756c8a0452b.jpg?1",
             "name": "Rottenmouth Viper",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of nonland permanents. This spell costs {1} less to cast for each permanent sacrificed this way.\nWhenever Rottenmouth Viper enters or attacks, put a blight counter on it. Then for each blight counter on it, each opponent loses 4 life unless that player sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -3701,7 +3701,7 @@
         },
         {
             "id": "aff2aa75-2f60-5ab2-972b-835a6083b3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4360c-8d68-4058-b9ec-da9948cb060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4360c-8d68-4058-b9ec-da9948cb060d.jpg?1",
             "name": "Ruthless Negotiation",
             "text": "Target opponent exiles a card from their hand. If this spell was cast from a graveyard, draw a card.\nFlashback {4}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "2cfd460b-1df1-5ec9-8dc2-ed21fb6c53d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397f689-dca1-4d35-864b-92c5606afb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397f689-dca1-4d35-864b-92c5606afb9a.jpg?1",
             "name": "Savor",
             "text": "Target creature gets -2/-2 until end of turn. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "924378a0-8cff-5d4a-808c-a1e1ea121af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae14276-dbbd-4257-80e9-accd6c19f5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae14276-dbbd-4257-80e9-accd6c19f5b2.jpg?1",
             "name": "Scales of Shale",
             "text": "This spell costs {1} less to cast for each Lizard you control.\nTarget creature gets +2/+0 and gains lifelink and indestructible until end of turn.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "ea34c9e8-404f-5564-b7ba-3e0940472894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52b7fe-87ae-425b-85fd-b24e6e0395f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52b7fe-87ae-425b-85fd-b24e6e0395f1.jpg?1",
             "name": "Scavenger's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever one or more creatures you control die, create a Food token. This ability triggers only once each turn.\n{1}{B}: Level 2\n//Level_2//\nWhenever you sacrifice a permanent, target player mills two cards.\n{2}{B}: Level 3\n//Level_3//\nAt the beginning of your end step, you may sacrifice three other nonland permanents. If you do, return a creature card from your graveyard to the battlefield with a finality counter on it.",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "f4489d5c-12aa-5ba9-8118-66ad64f2f2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc540652-916b-45c5-ae5a-0a0bc557cee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc540652-916b-45c5-ae5a-0a0bc557cee1.jpg?1",
             "name": "Season of Loss",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Each player sacrifices a creature.\n{Paw Print}{Paw Print} \u2014 Draw a card for each creature you controlled that died this turn.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Each opponent loses X life, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "a5c081b3-33ce-5211-b127-7ff0aec6d7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a15e06c-2608-4e7a-a16c-d35417669d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a15e06c-2608-4e7a-a16c-d35417669d86.jpg?1",
             "name": "Sinister Monolith",
             "text": "At the beginning of combat on your turn, each opponent loses 1 life and you gain 1 life.\n{T}, Pay 2 life, Sacrifice Sinister Monolith: Draw two cards. Activate only as a sorcery.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "810c7391-a41f-529f-a989-c7031b86151d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fc599-8de7-44d2-8fdd-9bddf5948a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fc599-8de7-44d2-8fdd-9bddf5948a0c.jpg?1",
             "name": "Stargaze",
             "text": "Look at twice X cards from the top of your library. Put X cards from among them into your hand and the rest into your graveyard. You lose X life.",
             "colours": [
@@ -3929,7 +3929,7 @@
         },
         {
             "id": "c3dbe13b-2651-5d44-bae5-398cb9058f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c1eca-2991-438f-b5d2-cd2529b9c9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c1eca-2991-438f-b5d2-cd2529b9c9b4.jpg?1",
             "name": "Starlit Soothsayer",
             "text": "Flying\nAt the beginning of your end step, if you gained or lost life this turn, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3964,7 +3964,7 @@
         },
         {
             "id": "9364f011-5bac-52fe-883f-5467a18aa340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a938a7-0154-4350-87cb-00da24ec3824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a938a7-0154-4350-87cb-00da24ec3824.jpg?1",
             "name": "Starscape Cleric",
             "text": "Offspring {2}{B} (You may pay an additional {2}{B} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nFlying\nThis creature can't block.\nWhenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "45b18826-29ad-5ccb-9b86-59080da9e772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f66c4a-feaa-4ba6-aa56-955b43329a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f66c4a-feaa-4ba6-aa56-955b43329a9e.jpg?1",
             "name": "Thornplate Intimidator",
             "text": "Offspring {3} (You may pay an additional {3} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, target opponent loses 3 life unless they sacrifice a nonland permanent or discard a card.",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "1a13f516-3670-5fed-b8fe-490a87dfab3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e80284-d489-493b-ae92-95b742d07cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e80284-d489-493b-ae92-95b742d07cb3.jpg?1",
             "name": "Thought-Stalker Warlock",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Thought-Stalker Warlock enters, choose target opponent. If they lost life this turn, they reveal their hand, you choose a nonland card from it, and they discard that card. Otherwise, they discard a card.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "7c42140c-4161-53a2-a160-f7f8d0b9a96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da80a9a-b1d5-4fc5-92f7-36946195d0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da80a9a-b1d5-4fc5-92f7-36946195d0c7.jpg?1",
             "name": "Valley Rotcaller",
             "text": "Menace\nWhenever Valley Rotcaller attacks, each opponent loses X life and you gain X life, where X is the number of other Squirrels, Bats, Lizards, and Rats you control.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "a41a71cb-cdb1-51c5-9c5d-23d7f846e574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29089810-d7fb-4abe-b729-bfabed6aed2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29089810-d7fb-4abe-b729-bfabed6aed2b.jpg?1",
             "name": "Wick, the Whorled Mind",
             "text": "Whenever Wick or another Rat you control enters, create a 1/1 black Snail creature token if you don't control a Snail. Otherwise, put a +1/+1 counter on a Snail you control.\n{U}{B}{R}, Sacrifice a Snail: Wick deals damage equal to the sacrificed creature's power to each opponent. Then draw cards equal to the sacrificed creature's power.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "34089d93-c8c7-56f3-a75e-8fed780dd67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa0c53d-fe7b-4b8b-ad81-7967ca318ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa0c53d-fe7b-4b8b-ad81-7967ca318ff7.jpg?1",
             "name": "Wick's Patrol",
             "text": "When Wick's Patrol enters, mill three cards. When you do, target creature an opponent controls gets -X/-X until end of turn, where X is the greatest mana value among cards in your graveyard.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "66e5a5c4-80ee-5a13-88d8-bac05995e364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9946b-515e-4e0d-9da2-711e126e9fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9946b-515e-4e0d-9da2-711e126e9fa6.jpg?1",
             "name": "Agate Assault",
             "text": "Choose one \u2014\n\u2022 Agate Assault deals 4 damage to target creature. If that creature would die this turn, exile it instead.\n\u2022 Exile target artifact.",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "f3cdf530-dbd6-5b1f-b12b-6817d24e67c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3871fe6-e26e-4ab4-bd81-7e3c7b8135c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3871fe6-e26e-4ab4-bd81-7e3c7b8135c1.jpg?1",
             "name": "Alania's Pathmaker",
             "text": "When Alania's Pathmaker enters, exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "1611c55a-ccc9-5a63-aeaa-c1ec3de4a3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e51d9-189b-4dd6-87cb-628ea6373e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e51d9-189b-4dd6-87cb-628ea6373e81.jpg?1",
             "name": "Artist's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever you cast a noncreature spell, you may discard a card. If you do, draw a card.\n{2}{R}: Level 2\n//Level_2//\nNoncreature spells you cast cost {1} less to cast.\n{2}{R}: Level 3\n//Level_3//\nIf a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "f3a4cc06-146c-5f09-9570-23028b0b653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb318fa-481d-40a7-978e-f01b49101ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb318fa-481d-40a7-978e-f01b49101ae0.jpg?1",
             "name": "Blacksmith's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Blacksmith's Talent enters, create a colorless Equipment artifact token named Sword with \"Equipped creature gets +1/+1\" and equip {2}.\n{2}{R}: Level 2\n//Level_2//\nAt the beginning of combat on your turn, attach target Equipment you control to up to one target creature you control.\n{3}{R}: Level 3\n//Level_3//\nDuring your turn, equipped creatures you control have double strike and haste.",
             "colours": [
@@ -4317,7 +4317,7 @@
         },
         {
             "id": "05b32d66-15ba-5f84-bf56-10a690cdcf56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd92a83-cec3-4085-a929-3f204e3e0140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd92a83-cec3-4085-a929-3f204e3e0140.jpg?1",
             "name": "Blooming Blast",
             "text": "Gift a Treasure (You may promise an opponent a gift as you cast this spell. If you do, they create a Treasure token before its other effects. It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nBlooming Blast deals 2 damage to target creature. If the gift was promised, Blooming Blast also deals 3 damage to that creature's controller.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "72da7eef-6f31-5784-93ab-d1bd79c1d1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8bf-f2f3-4157-8e04-02baf07a963e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8bf-f2f3-4157-8e04-02baf07a963e.jpg?1",
             "name": "Brambleguard Captain",
             "text": "At the beginning of combat on your turn, target creature you control gets +X/+0 until end of turn, where X is Brambleguard Captain's power.",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "f34a9827-7dc9-55da-8943-7e506b95f162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b55a58-c669-4dc6-aa63-5d9dff52e613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b55a58-c669-4dc6-aa63-5d9dff52e613.jpg?1",
             "name": "Brazen Collector",
             "text": "First strike\nWhenever Brazen Collector attacks, add {R}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -4419,7 +4419,7 @@
         },
         {
             "id": "8d0a7cd0-563c-54e5-95fe-e7e1b55084b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41fc718-641b-4f32-a8c1-3e5591a05bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41fc718-641b-4f32-a8c1-3e5591a05bf8.jpg?1",
             "name": "Byway Barterer",
             "text": "Menace\nWhenever you expend 4, you may discard your hand. If you do, draw two cards. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "1a8a18d6-a40b-58a7-a9d8-8e72116ea1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f373dd6-2412-453c-85ba-10230dfe473a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f373dd6-2412-453c-85ba-10230dfe473a.jpg?1",
             "name": "Conduct Electricity",
             "text": "Conduct Electricity deals 6 damage to target creature and 2 damage to up to one target creature token.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "cef659a5-d62c-5149-8604-f2679bba4303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2c1de0-6233-469a-be72-a050b97d2c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2c1de0-6233-469a-be72-a050b97d2c8f.jpg?1",
             "name": "Coruscation Mage",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhenever you cast a noncreature spell, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "a0ccbe49-01e7-59e1-a5c5-c0cc3df0b13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659789c-6a2c-439f-a348-b9b1b06c55b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659789c-6a2c-439f-a348-b9b1b06c55b8.jpg?1",
             "name": "Dragonhawk, Fate's Tempest",
             "text": "Flying\nWhenever Dragonhawk enters or attacks, exile the top X cards of your library, where X is the number of creatures you control with power 4 or greater. You may play those cards until your next end step. At the beginning of your next end step, Dragonhawk deals 2 damage to each opponent for each of those cards that are still exiled.",
             "colours": [
@@ -4562,7 +4562,7 @@
         },
         {
             "id": "77db8a79-101c-5c7c-ab69-768f9086bfc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035082e-bb86-4f95-be48-ffc87fe5286d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035082e-bb86-4f95-be48-ffc87fe5286d.jpg?1",
             "name": "Emberheart Challenger",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nValiant \u2014 Whenever Emberheart Challenger becomes the target of a spell or ability you control for the first time each turn, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "a86f8c6c-c670-5fa9-afb0-f2852e7b585a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433ee12-2013-4fdc-979f-ae065f63a527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433ee12-2013-4fdc-979f-ae065f63a527.jpg?1",
             "name": "Festival of Embers",
             "text": "During your turn, you may cast instant and sorcery spells from your graveyard by paying 1 life in addition to their other costs.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.\n{1}{R}: Sacrifice Festival of Embers.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "6a6bd527-1732-5333-9c73-6998f428dea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8e7c97-8393-41b8-bb0b-3983dcc5e7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8e7c97-8393-41b8-bb0b-3983dcc5e7f4.jpg?1",
             "name": "Flamecache Gecko",
             "text": "When Flamecache Gecko enters, if an opponent lost life this turn, add {B}{R}.\n{1}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "3b07085d-394a-5aa4-9645-c5525a05192d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bbd6d-e329-42cf-963d-88d1ce8fe51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bbd6d-e329-42cf-963d-88d1ce8fe51e.jpg?1",
             "name": "Frilled Sparkshooter",
             "text": "Menace, reach\nFrilled Sparkshooter enters with a +1/+1 counter on it if an opponent lost life this turn.",
             "colours": [
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "6ccc1247-bae7-5040-9efa-fbbd309f3858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56beeb6-88ca-475e-8654-1d4e8b4aa3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56beeb6-88ca-475e-8654-1d4e8b4aa3c0.jpg?1",
             "name": "Harnesser of Storms",
             "text": "Whenever you cast a noncreature or Otter spell, you may exile the top card of your library. Until end of turn, you may play that card. This ability triggers only once each turn.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "15193a55-e85a-551a-a60e-c2e8b26cdb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ace959-66b2-40c8-9bff-fd7ed9c99a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ace959-66b2-40c8-9bff-fd7ed9c99a82.jpg?1",
             "name": "Heartfire Hero",
             "text": "Valiant \u2014 Whenever Heartfire Hero becomes the target of a spell or ability you control for the first time each turn, put a +1/+1 counter on it.\nWhen Heartfire Hero dies, it deals damage equal to its power to each opponent.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "17d424cf-aa86-5f3f-a319-842236f1857e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1cf5c-9738-4062-8cb1-87a372d36687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1cf5c-9738-4062-8cb1-87a372d36687.jpg?1",
             "name": "Hearthborn Battler",
             "text": "Haste\nWhenever a player casts their second spell each turn, Hearthborn Battler deals 2 damage to target opponent.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "636c6c93-07fb-533d-98de-60435646eab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae41080-0d67-4719-adb2-49bf2a268b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae41080-0d67-4719-adb2-49bf2a268b6c.jpg?1",
             "name": "Hired Claw",
             "text": "Whenever you attack with one or more Lizards, Hired Claw deals 1 damage to target opponent.\n{1}{R}: Put a +1/+1 counter on Hired Claw. Activate only if an opponent lost life this turn and only once each turn.",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "8e910181-bb43-5354-97fa-368fc42fbc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ed5079-07b4-4575-a2c8-5f0cbff888c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ed5079-07b4-4575-a2c8-5f0cbff888c3.jpg?1",
             "name": "Hoarder's Overflow",
             "text": "When Hoarder's Overflow enters and whenever you expend 4, put a stash counter on it. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)\n{1}{R}, Sacrifice Hoarder's Overflow: Discard your hand, then draw cards equal to the number of stash counters on Hoarder's Overflow.",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "93162d80-023e-57c5-a5d6-9b8bc33c6619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a839fba3-1b66-4dd1-bf43-9b015b44fc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a839fba3-1b66-4dd1-bf43-9b015b44fc81.jpg?1",
             "name": "Kindlespark Duo",
             "text": "{T}: Kindlespark Duo deals 1 damage to target opponent.\nWhenever you cast a noncreature spell, untap Kindlespark Duo.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "96b27fad-9db3-5a74-b1f3-65e1d50f5317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3832b5-e83f-4569-bd49-fb7b86fa2d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3832b5-e83f-4569-bd49-fb7b86fa2d47.jpg?1",
             "name": "Manifold Mouse",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nAt the beginning of combat on your turn, target Mouse you control gains your choice of double strike or trample until end of turn.",
             "colours": [
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "a7f5d753-3c0a-5638-8fc7-01a150c0ba31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509bf254-8a2b-4dfa-9ae5-386321b35e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509bf254-8a2b-4dfa-9ae5-386321b35e8b.jpg?1",
             "name": "Might of the Meek",
             "text": "Target creature gains trample until end of turn. It also gets +1/+0 until end of turn if you control a Mouse.\nDraw a card.",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "8fdb5cef-b2e3-53df-a77b-17e7616e9a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07956edf-34c1-4218-9784-ddbca13e380c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07956edf-34c1-4218-9784-ddbca13e380c.jpg?1",
             "name": "Playful Shove",
             "text": "Playful Shove deals 1 damage to any target.\nDraw a card.",
             "colours": [
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "f5fc9879-6e76-5e0e-be99-0a7097d270fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b7fd3-a139-49ea-8a89-b64261e868ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b7fd3-a139-49ea-8a89-b64261e868ef.jpg?1",
             "name": "Quaketusk Boar",
             "text": "Reach, trample, haste",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "932a29a6-13cb-5141-b893-76ffa3b9795f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f815bae-820a-49f6-8eed-46f658e7b6ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f815bae-820a-49f6-8eed-46f658e7b6ff.jpg?1",
             "name": "Rabid Gnaw",
             "text": "Target creature you control gets +1/+0 until end of turn. Then it deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "0303bce7-92ec-53d3-8dc4-d27dceab6c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b5180f-5a1c-4df8-9019-195e65a50ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b5180f-5a1c-4df8-9019-195e65a50ce3.jpg?1",
             "name": "Raccoon Rallier",
             "text": "{T}: Target creature you control gains haste until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -5118,7 +5118,7 @@
         },
         {
             "id": "6dc2b83c-6d75-5c6e-8fc9-3d6ee3a27c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dec453-c9d7-42cb-980a-c82f82bede76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dec453-c9d7-42cb-980a-c82f82bede76.jpg?1",
             "name": "Reptilian Recruiter",
             "text": "Trample\nWhen Reptilian Recruiter enters, choose target creature. If that creature's power is 2 or less or if you control another Lizard, gain control of that creature until end of turn, untap it, and it gains haste until end of turn.",
             "colours": [
@@ -5153,7 +5153,7 @@
         },
         {
             "id": "35c09b80-0047-576f-bfd6-8a921a291c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cdcfb9-a247-4c2d-a098-5b57570f8cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cdcfb9-a247-4c2d-a098-5b57570f8cd5.jpg?1",
             "name": "Roughshod Duo",
             "text": "Trample\nWhenever you expend 4, target creature you control gets +1/+1 and gains trample until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5188,7 +5188,7 @@
         },
         {
             "id": "999118a8-e125-5ddb-8f46-d35268d3e4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963080-b3ec-467d-82f7-39db6ecd6bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963080-b3ec-467d-82f7-39db6ecd6bbc.jpg?1",
             "name": "Sazacap's Brew",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nAs an additional cost to cast this spell, discard a card.\nTarget player draws two cards. If the gift was promised, target creature you control gets +2/+0 until end of turn.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "0956b5e6-d46e-5b5e-8f04-12be740b0e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84352565-558b-4f9b-a411-532147806a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84352565-558b-4f9b-a411-532147806a78.jpg?1",
             "name": "Season of the Bold",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a tapped Treasure token.\n{Paw Print}{Paw Print} \u2014 Exile the top two cards of your library. Until the end of your next turn, you may play them.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Until the end of your next turn, whenever you cast a spell, Season of the Bold deals 2 damage to up to one target creature.",
             "colours": [
@@ -5254,7 +5254,7 @@
         },
         {
             "id": "23eace4a-db0c-5a65-b5c8-1fee2c7024ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf1296-e347-4070-8c6f-5c362c2f9364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf1296-e347-4070-8c6f-5c362c2f9364.jpg?1",
             "name": "Steampath Charger",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature dies, it deals 1 damage to target player.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "e5c8c953-c55d-5cd8-bcdc-13591dbcc59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f214d3-6b93-40db-a693-55e491c8a283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f214d3-6b93-40db-a693-55e491c8a283.jpg?1",
             "name": "Stormsplitter",
             "text": "Haste\nWhenever you cast an instant or sorcery spell, create a token that's a copy of Stormsplitter. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "74d6878d-e2df-59aa-a34f-9a71262a1796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8995ceaf-b7e0-423c-8f3e-25212d522502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8995ceaf-b7e0-423c-8f3e-25212d522502.jpg?1",
             "name": "Sunspine Lynx",
             "text": "Players can't gain life.\nDamage can't be prevented.\nWhen Sunspine Lynx enters, it deals damage to each player equal to the number of nonbasic lands that player controls.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "1adc1f7e-4bbf-5370-8d20-020cf0099932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c6f00-af4c-4d35-b682-6c0e759df9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c6f00-af4c-4d35-b682-6c0e759df9a5.jpg?1",
             "name": "Take Out the Trash",
             "text": "Take Out the Trash deals 3 damage to target creature or planeswalker. If you control a Raccoon, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "f27db4c9-42b6-5500-bed5-0433bef426c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30506844-349f-4b68-8cc1-d028c1611cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30506844-349f-4b68-8cc1-d028c1611cc7.jpg?1",
             "name": "Teapot Slinger",
             "text": "Menace\nWhenever you expend 4, Teapot Slinger deals 2 damage to each opponent. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "b62a2d33-dac1-5f62-bc14-72f354ca45a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0812db4-b7d1-4cf7-aaa5-9c0e784079a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0812db4-b7d1-4cf7-aaa5-9c0e784079a1.jpg?1",
             "name": "Valley Flamecaller",
             "text": "If a Lizard, Mouse, Otter, or Raccoon you control would deal damage to a permanent or player, it deals that much damage plus 1 instead.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "88ba0f66-a005-5bbe-a7cd-3da23d66e86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6178258-1ad6-4122-a56f-6eb7d0611e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6178258-1ad6-4122-a56f-6eb7d0611e84.jpg?1",
             "name": "Valley Rally",
             "text": "Gift a Food (You may promise an opponent a gift as you cast this spell. If you do, they create a Food token before its other effects. It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nCreatures you control get +2/+0 until end of turn. If the gift was promised, target creature you control gains first strike until end of turn.",
             "colours": [
@@ -5499,7 +5499,7 @@
         },
         {
             "id": "723ee39b-f071-5eee-a588-346be06a3d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105964a7-88b7-4340-aa66-e908189a3638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105964a7-88b7-4340-aa66-e908189a3638.jpg?1",
             "name": "War Squeak",
             "text": "Enchant creature\nWhen War Squeak enters, target creature an opponent controls can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "1fd1de57-85ca-560d-8795-f0169b732cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da653996-9bd4-40bd-afb4-48c7e070a269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da653996-9bd4-40bd-afb4-48c7e070a269.jpg?1",
             "name": "Whiskerquill Scribe",
             "text": "Valiant \u2014 Whenever Whiskerquill Scribe becomes the target of a spell or ability you control for the first time each turn, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5568,7 +5568,7 @@
         },
         {
             "id": "d3b93838-3ac2-5a98-ad6e-7f782352c20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7392d397-9836-4df2-944d-c930c9566811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7392d397-9836-4df2-944d-c930c9566811.jpg?1",
             "name": "Wildfire Howl",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nWildfire Howl deals 2 damage to each creature. If the gift was promised, instead Wildfire Howl deals 1 damage to any target and 2 damage to each creature.",
             "colours": [
@@ -5600,7 +5600,7 @@
         },
         {
             "id": "10519632-c4ea-5b56-b6f3-cf4208da4a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5309354f-1ff4-4fa9-9141-01ea2f7588ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5309354f-1ff4-4fa9-9141-01ea2f7588ab.jpg?1",
             "name": "Bakersbane Duo",
             "text": "When Bakersbane Duo enters, create a Food token.\nWhenever you expend 4, Bakersbane Duo gets +1/+1 until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "8804ad80-48bd-5c2c-8195-71cdbbadebd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582637a9-6aa0-4824-bed7-d5fc91bda35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582637a9-6aa0-4824-bed7-d5fc91bda35e.jpg?1",
             "name": "Bark-Knuckle Boxer",
             "text": "Whenever you expend 4, Bark-Knuckle Boxer gains indestructible until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "c5b3cb79-ea28-53ec-b456-d2b919613f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac9f6f8-6797-4580-9fc4-9a825872e017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac9f6f8-6797-4580-9fc4-9a825872e017.jpg?1",
             "name": "Brambleguard Veteran",
             "text": "Whenever you expend 4, Raccoons you control get +1/+1 and gain vigilance until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5705,7 +5705,7 @@
         },
         {
             "id": "ae7bdf47-28e2-5272-9bf4-1759372f759b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de60cf7-fa82-4b6f-9f88-6590fba5c863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de60cf7-fa82-4b6f-9f88-6590fba5c863.jpg?1",
             "name": "Bushy Bodyguard",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, you may forage. If you do, put two +1/+1 counters on it. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "8133451f-5768-5a50-b187-b7549a7ac502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd977dc-a7c3-4d0a-aca7-b25bd154e963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd977dc-a7c3-4d0a-aca7-b25bd154e963.jpg?1",
             "name": "Cache Grab",
             "text": "Mill four cards. You may put a permanent card from among the cards milled this way into your hand. If you control a Squirrel or returned a Squirrel card to your hand this way, create a Food token. (To mill four cards, put the top four cards of your library into your graveyard. A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -5772,7 +5772,7 @@
         },
         {
             "id": "8472521e-ffc7-5f36-bf79-53917c714f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d3bcc-65f3-4c69-8ea1-446870a1193d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d3bcc-65f3-4c69-8ea1-446870a1193d.jpg?1",
             "name": "Clifftop Lookout",
             "text": "Reach\nWhen Clifftop Lookout enters, reveal cards from the top of your library until you reveal a land card. Put that card onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "67608a58-3aa2-5d37-b222-cde5f14951fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64653b4a-e139-45f9-a915-ab49afb6b795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64653b4a-e139-45f9-a915-ab49afb6b795.jpg?1",
             "name": "Curious Forager",
             "text": "When Curious Forager enters, you may forage. When you do, return target permanent card from your graveyard to your hand. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "b6e12e36-0aa1-5979-9b28-0a213ad9a1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b485cf7-bad0-4824-9ba7-cb112ce4769f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b485cf7-bad0-4824-9ba7-cb112ce4769f.jpg?1",
             "name": "Druid of the Spade",
             "text": "As long as you control a token, Druid of the Spade gets +2/+0 and has trample.",
             "colours": [
@@ -5877,7 +5877,7 @@
         },
         {
             "id": "81d46f95-4241-503b-83d1-86d08d381e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b3e815-0e2e-4325-b1d5-5531b7b92da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b3e815-0e2e-4325-b1d5-5531b7b92da6.jpg?1",
             "name": "Fecund Greenshell",
             "text": "Reach\nAs long as you control ten or more lands, creatures you control get +2/+2.\nWhenever Fecund Greenshell or another creature you control with toughness greater than its power enters, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. Otherwise, put it into your hand.",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "23095f59-1d57-55c1-a3a3-e416b3e5c368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec72a27-b622-47d7-bdf3-970ccaef0d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec72a27-b622-47d7-bdf3-970ccaef0d2a.jpg?1",
             "name": "For the Common Good",
             "text": "Create X tokens that are copies of target token you control. Then tokens you control gain indestructible until your next turn. You gain 1 life for each token you control.",
             "colours": [
@@ -5948,7 +5948,7 @@
         },
         {
             "id": "0dd7f131-2db2-5fad-8f3a-ee0d05981973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58706bd8-558a-43b9-9f1e-c1ff0044203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58706bd8-558a-43b9-9f1e-c1ff0044203b.jpg?1",
             "name": "Galewind Moose",
             "text": "Flash\nVigilance, reach, trample",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "d609bc43-5a24-51a0-b9df-893b77409d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2882982-b3a3-4762-a550-6b82db1038e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2882982-b3a3-4762-a550-6b82db1038e8.jpg?1",
             "name": "Hazardroot Herbalist",
             "text": "Whenever you attack, target creature you control gets +1/+0 until end of turn. If that creature is a token, it also gains deathtouch until end of turn.",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "af24c4f8-56a0-5e8d-afaa-77af56a2b00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5349db-0e0a-4b15-886e-0db403ef49cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5349db-0e0a-4b15-886e-0db403ef49cb.jpg?1",
             "name": "Heaped Harvest",
             "text": "When Heaped Harvest enters and when you sacrifice it, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{2}, {T}, Sacrifice Heaped Harvest: You gain 3 life.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "1842f195-9f82-5c17-9fc3-53c3fd3a4577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8cf4b-8e65-4a1c-b458-28b5ab56b390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8cf4b-8e65-4a1c-b458-28b5ab56b390.jpg?1",
             "name": "High Stride",
             "text": "Target creature gets +1/+3 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "dfd67618-c7b5-5933-8341-4549be2a8dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821970a3-a291-4fe9-bb13-dfc54f9c3caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821970a3-a291-4fe9-bb13-dfc54f9c3caf.jpg?1",
             "name": "Hivespine Wolverine",
             "text": "When Hivespine Wolverine enters, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Hivespine Wolverine fights target creature token.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -6119,7 +6119,7 @@
         },
         {
             "id": "7b087864-462e-5095-9646-a2143cba2fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ee537-52e1-474a-9326-dfacc2a758ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ee537-52e1-474a-9326-dfacc2a758ab.jpg?1",
             "name": "Honored Dreyleader",
             "text": "Trample\nWhen Honored Dreyleader enters, put a +1/+1 counter on it for each other Squirrel and/or Food you control.\nWhenever another Squirrel or Food you control enters, put a +1/+1 counter on Honored Dreyleader.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "2af284c7-e3c3-510a-ba7d-90da9e070180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a31863-9649-4a4f-99e4-c93729938bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a31863-9649-4a4f-99e4-c93729938bd7.jpg?1",
             "name": "Hunter's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Hunter's Talent enters, target creature you control deals damage equal to its power to target creature you don't control.\n{1}{G}: Level 2\n//Level_2//\nWhenever you attack, target attacking creature gets +1/+0 and gains trample until end of turn.\n{3}{G}: Level 3\n//Level_3//\nAt the beginning of your end step, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "97fadbaf-7cd0-5347-847a-d78751dd588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b0afc-0e8f-45f2-ae7f-07595e164611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b0afc-0e8f-45f2-ae7f-07595e164611.jpg?1",
             "name": "Innkeeper's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\n{G}: Level 2\n//Level_2//\nPermanents you control with counters on them have ward {1}.\n{3}{G}: Level 3\n//Level_3//\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
             "colours": [
@@ -6222,7 +6222,7 @@
         },
         {
             "id": "394e9a47-0cd5-5f67-94c7-a624b79b9ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf33d80-0704-4dc4-8e8d-1dcbcbc35add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf33d80-0704-4dc4-8e8d-1dcbcbc35add.jpg?1",
             "name": "Keen-Eyed Curator",
             "text": "As long as there are four or more card types among cards exiled with Keen-Eyed Curator, it gets +4/+4 and has trample.\n{1}: Exile target card from a graveyard.",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "622c45b4-f041-51e8-ac77-a824b951f03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef748c-b5e5-4e7d-bf2e-d3e6c08edb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef748c-b5e5-4e7d-bf2e-d3e6c08edb42.jpg?1",
             "name": "Longstalk Brawl",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nChoose target creature you control and target creature you don't control. Put a +1/+1 counter on the creature you control if the gift was promised. Then those creatures fight each other.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "2c6d7ee7-b635-584f-b96f-59979998134f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f3aaf-3960-48cd-b34b-32e4ae5ae088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f3aaf-3960-48cd-b34b-32e4ae5ae088.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "f10e6c50-6024-5ca0-9383-b425a3b1c4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5246540-5a84-41d8-9e30-8e7a6c0e84e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5246540-5a84-41d8-9e30-8e7a6c0e84e1.jpg?1",
             "name": "Mistbreath Elder",
             "text": "At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on Mistbreath Elder. Otherwise, you may return Mistbreath Elder to its owner's hand.",
             "colours": [
@@ -6369,7 +6369,7 @@
         },
         {
             "id": "1bdacfb0-dff7-5c96-aaae-887e9cf1b594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e979f-b618-4625-989c-e0ea5b61ed8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e979f-b618-4625-989c-e0ea5b61ed8a.jpg?1",
             "name": "Overprotect",
             "text": "Target creature you control gets +3/+3 and gains trample, hexproof, and indestructible until end of turn.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "8052bbb4-017b-5562-8410-b11967b1073a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c20ad-0f69-4822-ae76-770832cccdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c20ad-0f69-4822-ae76-770832cccdf7.jpg?1",
             "name": "Pawpatch Formation",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.\n\u2022 Draw a card. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "f85c443e-61d8-5924-ba72-f9810608aea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4d88ba-0ee4-4f66-995b-2e50614f50ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4d88ba-0ee4-4f66-995b-2e50614f50ee.jpg?1",
             "name": "Pawpatch Recruit",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nTrample\nWhenever a creature you control becomes the target of a spell or ability an opponent controls, put a +1/+1 counter on target creature you control other than that creature.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "386589f0-aee0-51f0-af74-6a4d7082c6ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72466c-505b-4371-9366-0fde525a37e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72466c-505b-4371-9366-0fde525a37e6.jpg?1",
             "name": "Peerless Recycling",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn target permanent card from your graveyard to your hand. If the gift was promised, instead return two target permanent cards from your graveyard to your hand.",
             "colours": [
@@ -6502,7 +6502,7 @@
         },
         {
             "id": "6e85ca17-65f2-5300-bdd6-012d957e6987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc4963c-d90b-4588-bdb7-85956e42a623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc4963c-d90b-4588-bdb7-85956e42a623.jpg?1",
             "name": "Polliwallop",
             "text": "This spell costs {1} less to cast for each Frog you control.\nTarget creature you control deals damage equal to twice its power to target creature you don't control.",
             "colours": [
@@ -6534,7 +6534,7 @@
         },
         {
             "id": "93d470a3-356f-5a70-9100-9e5ccfb31978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96b01f5-83de-4237-a68d-f946c53e31a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96b01f5-83de-4237-a68d-f946c53e31a6.jpg?1",
             "name": "Rust-Shield Rampager",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nThis creature can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "655a9a51-91e9-5608-9933-3e3ebbd11c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42ab407-e72d-4c48-9a9e-2055b5e71c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42ab407-e72d-4c48-9a9e-2055b5e71c69.jpg?1",
             "name": "Scrapshooter",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they draw a card.)\nReach\nWhen Scrapshooter enters, if the gift was promised, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "ced02e60-d7a4-5c48-8e39-b3352ea11659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dd3c27-e0d5-434e-a0f3-4a95245e21c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dd3c27-e0d5-434e-a0f3-4a95245e21c2.jpg?1",
             "name": "Season of Gathering",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Put a +1/+1 counter on a creature you control. It gains vigilance and trample until end of turn.\n{Paw Print}{Paw Print} \u2014 Choose artifact or enchantment. Destroy all permanents of the chosen type.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Draw cards equal to the greatest power among creatures you control.",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "f592629d-ff40-5c2d-8b4c-168412ce2ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fa9651-b217-4f93-9c46-9bdb11feedcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fa9651-b217-4f93-9c46-9bdb11feedcb.jpg?1",
             "name": "Stickytongue Sentinel",
             "text": "Reach\nWhen Stickytongue Sentinel enters, return up to one other target permanent you control to its owner's hand.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "ed4fcbc7-fc0e-5dbe-b005-db5f61fa87a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e95c7b-f0b2-4276-8c5e-4191b7ba35d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e95c7b-f0b2-4276-8c5e-4191b7ba35d1.jpg?1",
             "name": "Stocking the Pantry",
             "text": "Whenever you put one or more +1/+1 counters on a creature you control, put a supply counter on Stocking the Pantry.\n{2}, Remove a supply counter from Stocking the Pantry: Draw a card.",
             "colours": [
@@ -6707,7 +6707,7 @@
         },
         {
             "id": "617ea1e5-e438-5572-81dd-6bd41ab1f70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740abc5-54e1-478d-966e-0fa64e727995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740abc5-54e1-478d-966e-0fa64e727995.jpg?1",
             "name": "Sunshower Druid",
             "text": "When Sunshower Druid enters, put a +1/+1 counter on target creature and you gain 1 life.",
             "colours": [
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "6dafe5d8-4c94-5415-a57f-45514282048d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8bfa91-adb0-4596-8c16-d8bb64fdb26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8bfa91-adb0-4596-8c16-d8bb64fdb26d.jpg?1",
             "name": "Tender Wildguide",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\n{T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -6779,7 +6779,7 @@
         },
         {
             "id": "90493523-1401-5e97-9c82-83f375875c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2d6b02-a453-40f9-992a-5c5542987cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2d6b02-a453-40f9-992a-5c5542987cfb.jpg?1",
             "name": "Thornvault Forager",
             "text": "{T}: Add {G}.\n{T}, Forage: Add two mana in any combination of colors. (To forage, exile three cards from your graveyard or sacrifice a Food.)\n{3}{G}, {T}: Search your library for a Squirrel card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6816,7 +6816,7 @@
         },
         {
             "id": "d0e195ea-4fb1-5124-9a89-7214fc1eeab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ab6e14-26e0-4174-b5c6-bc0f5c26b177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ab6e14-26e0-4174-b5c6-bc0f5c26b177.jpg?1",
             "name": "Three Tree Rootweaver",
             "text": "{T}: Add one mana of any color.",
             "colours": [
@@ -6851,7 +6851,7 @@
         },
         {
             "id": "a16d0fa8-1a9b-57e8-acaa-94d309302b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ca1b3-4c1a-4be5-b321-f57db5ff0528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ca1b3-4c1a-4be5-b321-f57db5ff0528.jpg?1",
             "name": "Three Tree Scribe",
             "text": "Whenever Three Tree Scribe or another creature you control leaves the battlefield without dying, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -6886,7 +6886,7 @@
         },
         {
             "id": "908a367b-0dfa-5874-8af2-18bdb3f1f2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c8456e-c971-42b7-abf3-ff5ae1320abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c8456e-c971-42b7-abf3-ff5ae1320abe.jpg?1",
             "name": "Treeguard Duo",
             "text": "When Treeguard Duo enters, until end of turn, target creature you control gains vigilance and gets +X/+X, where X is the number of creatures you control.",
             "colours": [
@@ -6921,7 +6921,7 @@
         },
         {
             "id": "902df20c-532a-5b64-80e8-293d28c9edb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d4d6e-1fe5-4ff6-9877-8c849a24f5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d4d6e-1fe5-4ff6-9877-8c849a24f5e0.jpg?1",
             "name": "Treetop Sentries",
             "text": "Reach\nWhen Treetop Sentries enters, you may forage. If you do, draw a card. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -6956,7 +6956,7 @@
         },
         {
             "id": "9e04936a-e8a3-5fe6-b7f3-7ba2eb37c2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7256451f-0122-452a-88e8-0fb0f6bea3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7256451f-0122-452a-88e8-0fb0f6bea3f3.jpg?1",
             "name": "Valley Mightcaller",
             "text": "Trample\nWhenever another Frog, Rabbit, Raccoon, or Squirrel you control enters, put a +1/+1 counter on Valley Mightcaller.",
             "colours": [
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "3742aaef-7d0d-5a68-af05-0d07bf6d9758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded2b83-3b7d-4c8c-83c4-0624a1069628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded2b83-3b7d-4c8c-83c4-0624a1069628.jpg?1",
             "name": "Wear Down",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nDestroy target artifact or enchantment. If the gift was promised, instead destroy two target artifacts and/or enchantments.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "501fe30c-0e8a-5be5-829d-4a0f3378bec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436d6a84-4cea-4ca7-94aa-9d08280652af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436d6a84-4cea-4ca7-94aa-9d08280652af.jpg?1",
             "name": "Alania, Divergent Storm",
             "text": "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "61794ed1-64cd-5b87-8c61-47f7e9fa67c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e93be2-e06b-4774-8ba5-ccf82a6da1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e93be2-e06b-4774-8ba5-ccf82a6da1d8.jpg?1",
             "name": "Baylen, the Haymaker",
             "text": "Tap two untapped tokens you control: Add one mana of any color.\nTap three untapped tokens you control: Draw a card.\nTap four untapped tokens you control: Put three +1/+1 counters on Baylen, the Haymaker. It gains trample until end of turn.",
             "colours": [
@@ -7112,7 +7112,7 @@
         },
         {
             "id": "97c389c1-ab1b-5965-b49b-1a62a538e76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87138ace-3594-499e-bad5-ec76148613ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87138ace-3594-499e-bad5-ec76148613ea.jpg?1",
             "name": "Burrowguard Mentor",
             "text": "Trample\nBurrowguard Mentor's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "57a3b0f4-d10b-590f-9de0-6d0df0b521cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c16eaec-924c-42f6-9fea-07edd7ed93b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c16eaec-924c-42f6-9fea-07edd7ed93b9.jpg?1",
             "name": "Camellia, the Seedmiser",
             "text": "Menace\nOther Squirrels you control have menace.\nWhenever you sacrifice one or more Foods, create a 1/1 green Squirrel creature token.\n{2}, Forage: Put a +1/+1 counter on each other Squirrel you control. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "930a4f3b-6905-59f8-993c-20cd32b2ffa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ea10dd-21ea-4622-be27-79d03a802b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ea10dd-21ea-4622-be27-79d03a802b85.jpg?1",
             "name": "Cindering Cutthroat",
             "text": "Cindering Cutthroat enters with a +1/+1 counter on it if an opponent lost life this turn.\n{1}{BR}: Cindering Cutthroat gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "b681f5f3-3509-5445-a648-bd45fa864865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028130c-c91d-4bf7-b0b0-450f71107d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028130c-c91d-4bf7-b0b0-450f71107d7a.jpg?1",
             "name": "Clement, the Worrywort",
             "text": "Vigilance\nWhenever Clement, the Worrywort or another creature you control enters, return up to one target creature you control with lesser mana value to its owner's hand.\nFrogs you control have \"{T}: Add {G} or {U}. Spend this mana only to cast a creature spell.\"",
             "colours": [
@@ -7270,7 +7270,7 @@
         },
         {
             "id": "2380a1a6-aa65-5d47-8aef-0e23e543a403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c911a759-ed7b-452b-88a3-663478357610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c911a759-ed7b-452b-88a3-663478357610.jpg?1",
             "name": "Corpseberry Cultivator",
             "text": "At the beginning of combat on your turn, you may forage. (Exile three cards from your graveyard or sacrifice a Food.)\nWhenever you forage, put a +1/+1 counter on Corpseberry Cultivator.",
             "colours": [
@@ -7307,7 +7307,7 @@
         },
         {
             "id": "17c21423-3502-5c5f-9ac0-7da2859c613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bd6b0d-8606-4a37-8be3-a852f1a8e99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bd6b0d-8606-4a37-8be3-a852f1a8e99c.jpg?1",
             "name": "Dreamdew Entrancer",
             "text": "Reach\nWhen Dreamdew Entrancer enters, tap up to one target creature and put three stun counters on it. If you control that creature, draw two cards.",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "63ceb0db-c869-59a2-a991-55ef153ae668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee197d-c313-4364-b52c-f83d5f579bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee197d-c313-4364-b52c-f83d5f579bc3.jpg?1",
             "name": "Finneas, Ace Archer",
             "text": "Vigilance, reach\nWhenever Finneas, Ace Archer attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "774ece02-5471-56e6-b802-26a718dfce90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78fbaa3-c580-4290-9c28-b74169aab2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78fbaa3-c580-4290-9c28-b74169aab2fc.jpg?1",
             "name": "Fireglass Mentor",
             "text": "At the beginning of your second main phase, if an opponent lost life this turn, exile the top two cards of your library. Choose one of them. Until end of turn, you may play that card.",
             "colours": [
@@ -7425,7 +7425,7 @@
         },
         {
             "id": "508f76fa-05ec-5114-b2af-476807379444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131ea976-289e-4f32-896d-27bbfd423ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131ea976-289e-4f32-896d-27bbfd423ba9.jpg?1",
             "name": "Gev, Scaled Scorch",
             "text": "Ward\u2014\nPay 2 life.\nOther creatures you control enter with an additional +1/+1 counter on them for each opponent who lost life this turn.\nWhenever you cast a Lizard spell, Gev, Scaled Scorch deals 1 damage to target opponent.",
             "colours": [
@@ -7466,7 +7466,7 @@
         },
         {
             "id": "e45ea350-e4be-5fda-8c4e-365beee24879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc70b2d-5a3a-49ea-97db-175a62248302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc70b2d-5a3a-49ea-97db-175a62248302.jpg?1",
             "name": "Glarb, Calamity's Augur",
             "text": "Deathtouch\nYou may look at the top card of your library any time.\nYou may play lands and cast spells with mana value 4 or greater from the top of your library.\n{T}: Surveil 2.",
             "colours": [
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "a340b1db-1f86-5135-84af-f3743143cda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc20157-edd3-484d-8864-925c071c0551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc20157-edd3-484d-8864-925c071c0551.jpg?1",
             "name": "Head of the Homestead",
             "text": "When Head of the Homestead enters, create two 1/1 white Rabbit creature tokens.",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "f776c069-4c14-55fc-86d5-2936a0fe67df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40339715-22d0-4f99-822b-a00d9824f27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40339715-22d0-4f99-822b-a00d9824f27a.jpg?1",
             "name": "Helga, Skittish Seer",
             "text": "Whenever you cast a creature spell with mana value 4 or greater, you draw a card, gain 1 life, and put a +1/+1 counter on Helga, Skittish Seer.\n{T}: Add X mana of any one color, where X is Helga, Skittish Seer's power. Spend this mana only to cast creature spells with mana value 4 or greater or creature spells with {X} in their mana costs.",
             "colours": [
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "c08421e1-e91c-5b5e-925a-d491f69b3e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d7f4a-c947-4389-befa-1d547d0d1237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d7f4a-c947-4389-befa-1d547d0d1237.jpg?1",
             "name": "Hugs, Grisly Guardian",
             "text": "Trample\nWhen Hugs, Grisly Guardian enters, exile the top X cards of your library. Until the end of your next turn, you may play those cards.\nYou may play an additional land on each of your turns.",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "8e32c59f-a70f-5bdf-b3a3-cc141a754d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6c9196-6d28-4cc2-9748-60e9632a502b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6c9196-6d28-4cc2-9748-60e9632a502b.jpg?1",
             "name": "The Infamous Cruelclaw",
             "text": "Menace\nWhenever The Infamous Cruelclaw deals combat damage to a player, exile cards from the top of your library until you exile a nonland card. You may cast that card by discarding a card rather than paying its mana cost.",
             "colours": [
@@ -7672,7 +7672,7 @@
         },
         {
             "id": "f561a611-9914-588f-b53e-5d07e2c71d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918fd89b-5ab7-4ae2-920c-faca5e9da7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918fd89b-5ab7-4ae2-920c-faca5e9da7b9.jpg?1",
             "name": "Junkblade Bruiser",
             "text": "Trample\nWhenever you expend 4, Junkblade Bruiser gets +2/+1 until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "e5056616-d943-5a5b-97f4-1ea6a7854322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf68793-22a2-4a59-9d37-6791584edca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf68793-22a2-4a59-9d37-6791584edca1.jpg?1",
             "name": "Kastral, the Windcrested",
             "text": "Flying\nWhenever one or more Birds you control deal combat damage to a player, choose one \u2014\n\u2022 You may put a Bird creature card from your hand or graveyard onto the battlefield with a finality counter on it.\n\u2022 Put a +1/+1 counter on each Bird you control.\n\u2022 Draw a card.",
             "colours": [
@@ -7751,7 +7751,7 @@
         },
         {
             "id": "6daa593b-1c16-55a9-94d6-d2196277692a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64de7b1f-a03e-4407-91f1-e108a2f26735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64de7b1f-a03e-4407-91f1-e108a2f26735.jpg?1",
             "name": "Lilysplash Mentor",
             "text": "Reach\n{1}{G}{U}: Exile another target creature you control, then return it to the battlefield under its owner's control with a +1/+1 counter on it. Activate only as a sorcery.",
             "colours": [
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "c734001a-0dab-5d0a-a109-e7c2d208b945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ee50d4-c878-457b-964d-29c039ce9852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ee50d4-c878-457b-964d-29c039ce9852.jpg?1",
             "name": "Lunar Convocation",
             "text": "At the beginning of your end step, if you gained life this turn, each opponent loses 1 life.\nAt the beginning of your end step, if you gained and lost life this turn, create a 1/1 black Bat creature token with flying.\n{1}{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -7824,7 +7824,7 @@
         },
         {
             "id": "7d22b1e6-c247-511e-86c3-8c27aa87b17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6627fd-729d-44f2-b6bf-5299f49d1e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6627fd-729d-44f2-b6bf-5299f49d1e3d.jpg?1",
             "name": "Mabel, Heir to Cragflame",
             "text": "Other Mice you control get +1/+1.\nWhen Mabel, Heir to Cragflame enters, create Cragflame, a legendary colorless Equipment artifact token with \"Equipped creature gets +1/+1 and has vigilance, trample, and haste\" and equip {2}.",
             "colours": [
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "b9a24d9d-e6e4-5bb1-b9fb-9d0fc28a2c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507ba708-ca9b-453e-b4c2-23b6650eb5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507ba708-ca9b-453e-b4c2-23b6650eb5a8.jpg?1",
             "name": "Mind Drill Assailant",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Mind Drill Assailant gets +3/+0.\n{2}{UB}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "1c8bb701-040c-5db1-be28-0d1887909e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f2a71f-31e8-4b51-9dd4-51a5336b3b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f2a71f-31e8-4b51-9dd4-51a5336b3b86.jpg?1",
             "name": "Moonrise Cleric",
             "text": "Flying\nWhenever Moonrise Cleric attacks, you gain 1 life.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "fa85b556-4969-5d6e-9180-a676e2853518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40e4658-fd68-46d0-9a89-25570a023d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40e4658-fd68-46d0-9a89-25570a023d19.jpg?1",
             "name": "Muerra, Trash Tactician",
             "text": "At the beginning of your first main phase, add {R} or {G} for each Raccoon you control.\nWhenever you expend 4, you gain 3 life. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)\nWhenever you expend 8, exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "647205f1-10f0-566b-ba52-374dba97f400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa988f-547e-449a-9f1a-296c01d68d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa988f-547e-449a-9f1a-296c01d68d96.jpg?1",
             "name": "Plumecreed Mentor",
             "text": "Flying\nWhenever Plumecreed Mentor or another creature you control with flying enters, put a +1/+1 counter on target creature you control without flying.",
             "colours": [
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "f5653433-93e1-5ec9-ab13-0ef16d82fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb959e74-61ea-453d-bb9f-ad0183c0e1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb959e74-61ea-453d-bb9f-ad0183c0e1b1.jpg?1",
             "name": "Pond Prophet",
             "text": "When Pond Prophet enters, draw a card.",
             "colours": [
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "aa9d0afa-4410-5199-9c5a-3d1f5f289825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfde780-899a-4c5b-a39b-f4a3ff129103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfde780-899a-4c5b-a39b-f4a3ff129103.jpg?1",
             "name": "Ral, Crackling Wit",
             "text": "Whenever you cast a noncreature spell, put a loyalty counter on Ral, Crackling Wit.\n+1: Create a 1/1 blue and red Otter creature token with prowess.\n\u22123: Draw three cards, then discard two cards.\n\u221210: Draw three cards. You get an emblem with \"Instant and sorcery spells you cast have storm.\" (Whenever you cast an instant or sorcery spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -8096,7 +8096,7 @@
         },
         {
             "id": "19a61260-efef-5c6e-9f79-331732a07d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c3e41-0636-49a3-8c9c-384c5e5c9c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c3e41-0636-49a3-8c9c-384c5e5c9c3e.jpg?1",
             "name": "Seedglaive Mentor",
             "text": "Vigilance, haste\nValiant \u2014 Whenever Seedglaive Mentor becomes the target of a spell or ability you control for the first time each turn, put a +1/+1 counter on it.",
             "colours": [
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "bf4f26e0-d6a1-5ca2-813a-46d0fd5d5b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3684577-51ce-490e-9b59-b19c733be466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3684577-51ce-490e-9b59-b19c733be466.jpg?1",
             "name": "Seedpod Squire",
             "text": "Flying\nWhenever Seedpod Squire attacks, target creature you control without flying gets +1/+1 until end of turn.",
             "colours": [
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "a3b19e2a-bf09-5501-b2bd-fa39aa7a7ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f6dc5-9fe8-49c1-b24c-1d99ce1da619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f6dc5-9fe8-49c1-b24c-1d99ce1da619.jpg?1",
             "name": "Starseer Mentor",
             "text": "Flying, vigilance\nAt the beginning of your end step, if you gained or lost life this turn, target opponent loses 3 life unless they sacrifice a nonland permanent or discard a card.",
             "colours": [
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "05a75131-677a-5006-bd71-afdebf85e8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99754055-6d67-4fde-aff3-41f6af6ea764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99754055-6d67-4fde-aff3-41f6af6ea764.jpg?1",
             "name": "Stormcatch Mentor",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "039d071b-cfed-55df-ba49-51b2094c28e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850daae4-f0b7-4604-95e7-ad044ec165c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850daae4-f0b7-4604-95e7-ad044ec165c3.jpg?1",
             "name": "Tempest Angler",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Tempest Angler.",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "423b3520-924b-5474-9a10-87e7d3c26bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa10ffac-7cc2-41ef-b8a0-9431923c0542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa10ffac-7cc2-41ef-b8a0-9431923c0542.jpg?1",
             "name": "Tidecaller Mentor",
             "text": "Menace\nThreshold \u2014 When Tidecaller Mentor enters, if seven or more cards are in your graveyard, return up to one target nonland permanent to its owner's hand.",
             "colours": [
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "7b858680-8602-592b-9b80-988b5e9dac95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db43c46-b616-4ef8-80ed-0fab345ab3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db43c46-b616-4ef8-80ed-0fab345ab3d0.jpg?1",
             "name": "Veteran Guardmouse",
             "text": "Valiant \u2014 Whenever Veteran Guardmouse becomes the target of a spell or ability you control for the first time each turn, it gets +1/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -8357,7 +8357,7 @@
         },
         {
             "id": "faf49a49-ada3-5ca5-b0ad-c3e4ff9b5c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b615ba-45c4-42a1-8525-1535f0b55300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b615ba-45c4-42a1-8525-1535f0b55300.jpg?1",
             "name": "Vinereap Mentor",
             "text": "When Vinereap Mentor enters or dies, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -8394,7 +8394,7 @@
         },
         {
             "id": "4af2dbb1-cf54-5958-a289-c81b311cc793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506277d-f031-4db5-9d16-bf2389094785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506277d-f031-4db5-9d16-bf2389094785.jpg?1",
             "name": "Vren, the Relentless",
             "text": "Ward {2}\nIf a creature an opponent controls would die, exile it instead.\nAt the beginning of each end step, create X 1/1 black Rat creature tokens with \"This creature gets +1/+1 for each other Rat you control,\" where X is the number of creatures your opponents controlled that were exiled this turn.",
             "colours": [
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "92e7f651-af8f-54cb-8dc6-99044483b0e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c399a55-d02e-41ed-b827-8784b738c118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c399a55-d02e-41ed-b827-8784b738c118.jpg?1",
             "name": "Wandertale Mentor",
             "text": "Whenever you expend 4, put a +1/+1 counter on Wandertale Mentor. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)\n{T}: Add {R} or {G}.",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "8691865e-524b-5ee6-b6a3-75a2a7070034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ac7673-eae8-4c4b-889e-5025213a6151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ac7673-eae8-4c4b-889e-5025213a6151.jpg?1",
             "name": "Ygra, Eater of All",
             "text": "Ward\u2014\nSacrifice a Food.\nOther creatures are Food artifacts in addition to their other types and have \"{2}, {T}, Sacrifice this permanent: You gain 3 life.\"\nWhenever a Food is put into a graveyard from the battlefield, put two +1/+1 counters on Ygra, Eater of All.",
             "colours": [
@@ -8513,7 +8513,7 @@
         },
         {
             "id": "7f0a2429-2d70-595e-8bb9-d7596cc05895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f99fd5-5298-4b27-923d-9d31203c931a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f99fd5-5298-4b27-923d-9d31203c931a.jpg?1",
             "name": "Zoraline, Cosmos Caller",
             "text": "Flying, vigilance\nWhenever a Bat you control attacks, you gain 1 life.\nWhenever Zoraline enters or attacks, you may pay {W}{B} and 2 life. When you do, return target nonland permanent card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.",
             "colours": [
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "9b9e4069-0dbb-54f8-a063-9483fa1ff7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77049a6-0f22-415b-bc89-20bcb32accf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77049a6-0f22-415b-bc89-20bcb32accf6.jpg?1",
             "name": "Barkform Harvester",
             "text": "Changeling (This card is every creature type.)\nReach\n{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -8585,7 +8585,7 @@
         },
         {
             "id": "66e214d2-f7c4-55f1-a96d-b21b6805803e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0affd5-5dcd-4dd1-a694-37a9aedf4084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0affd5-5dcd-4dd1-a694-37a9aedf4084.jpg?1",
             "name": "Bumbleflower's Sharepot",
             "text": "When Bumbleflower's Sharepot enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{5}, {T}, Sacrifice Bumbleflower's Sharepot: Destroy target nonland permanent. Activate only as a sorcery.",
             "colours": [],
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "aff0f307-047c-5454-bce3-780878a03e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c94bc0-a49d-451b-8e8d-64d46b8b8603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c94bc0-a49d-451b-8e8d-64d46b8b8603.jpg?1",
             "name": "Fountainport Bell",
             "text": "When Fountainport Bell enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.\n{1}, Sacrifice Fountainport Bell: Draw a card.",
             "colours": [],
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "ba4da240-f920-5bee-a5e5-2ec2768aaaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7839ce48-0175-494a-ab89-9bdfb7a50cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7839ce48-0175-494a-ab89-9bdfb7a50cb1.jpg?1",
             "name": "Heirloom Epic",
             "text": "{4}, {T}: Draw a card. For each mana in this ability's activation cost, you may tap an untapped creature you control rather than pay that mana. Activate only as a sorcery.",
             "colours": [],
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "f6a25449-d5d7-5a3c-88a3-29b8bc156e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a982c8-bc08-44ba-b3ed-9e4b124615d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a982c8-bc08-44ba-b3ed-9e4b124615d6.jpg?1",
             "name": "Patchwork Banner",
             "text": "As Patchwork Banner enters, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "c831abb5-53fd-5d08-b671-6e13d8a20662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8b72b-fa8f-48d3-bddc-d3ce9b8ba2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8b72b-fa8f-48d3-bddc-d3ce9b8ba2ea.jpg?1",
             "name": "Short Bow",
             "text": "Equipped creature gets +1/+1 and has vigilance and reach.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "5edae66d-00cb-5af9-ba54-2288ee536a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23d8e96-b972-4c6c-b0c4-b6627621f048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23d8e96-b972-4c6c-b0c4-b6627621f048.jpg?1",
             "name": "Starforged Sword",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they create a tapped 1/1 blue Fish creature token.)\nWhen Starforged Sword enters, if the gift was promised, attach Starforged Sword to target creature you control.\nEquipped creature gets +3/+3 and loses flying.\nEquip {3}",
             "colours": [],
@@ -8757,7 +8757,7 @@
         },
         {
             "id": "30e474a4-85ae-58c7-ae87-680dbe94a4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258ef349-5042-4992-bae9-9f8f54b55db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258ef349-5042-4992-bae9-9f8f54b55db0.jpg?1",
             "name": "Tangle Tumbler",
             "text": "Vigilance\n{3}, {T}: Put a +1/+1 counter on target creature.\nTap two untapped tokens you control: Tangle Tumbler becomes an artifact creature until end of turn.",
             "colours": [],
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "c64cd705-540d-5019-bd42-7b827ecb200c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaced75b-6e07-457c-8ea2-f74d99710d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaced75b-6e07-457c-8ea2-f74d99710d15.jpg?1",
             "name": "Three Tree Mascot",
             "text": "Changeling (This card is every creature type.)\n{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "47d266fb-dcb1-5696-9b20-72d885220658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8809830f-d8e1-4603-9652-0ad8b00234e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8809830f-d8e1-4603-9652-0ad8b00234e9.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -8848,7 +8848,7 @@
         },
         {
             "id": "2c7cf757-d382-581b-9ff3-de3d38f2ed47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658cfcb7-81b7-48c6-9dd2-1663d06108cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658cfcb7-81b7-48c6-9dd2-1663d06108cf.jpg?1",
             "name": "Fountainport",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a token: Draw a card.\n{3}, {T}, Pay 1 life: Create a 1/1 blue Fish creature token.\n{4}, {T}: Create a Treasure token.",
             "colours": [],
@@ -8878,7 +8878,7 @@
         },
         {
             "id": "e473b0b8-76c0-5904-bc67-dadc7aee1497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8f2e7-8357-4862-97dc-1942d066023a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8f2e7-8357-4862-97dc-1942d066023a.jpg?1",
             "name": "Hidden Grotto",
             "text": "When Hidden Grotto enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "f65c0023-ea13-50a1-ad2c-fc2384cd8ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e95a7cc-ed77-4ca4-80db-61c0fc68bf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e95a7cc-ed77-4ca4-80db-61c0fc68bf50.jpg?1",
             "name": "Lilypad Village",
             "text": "{T}: Add {C}.\n{T}: Add {U}. Spend this mana only to cast a creature spell.\n{U}, {T}: Surveil 2. Activate only if a Bird, Frog, Otter, or Rat entered the battlefield under your control this turn.",
             "colours": [],
@@ -8936,7 +8936,7 @@
         },
         {
             "id": "e3ce094a-3db0-5567-bf05-b97d5bee94e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab9d56f-9178-4ec9-a5f6-b934f50d8d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab9d56f-9178-4ec9-a5f6-b934f50d8d9d.jpg?1",
             "name": "Lupinflower Village",
             "text": "{T}: Add {C}.\n{T}: Add {W}. Spend this mana only to cast a creature spell.\n{1}{W}, {T}, Sacrifice Lupinflower Village: Look at the top six cards of your library. You may reveal a Bat, Bird, Mouse, or Rabbit card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8966,7 +8966,7 @@
         },
         {
             "id": "11995b50-3d97-50c9-8a8c-7e31da946086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4ad3-9cf0-4f1b-a9db-d63feee594ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4ad3-9cf0-4f1b-a9db-d63feee594ab.jpg?1",
             "name": "Mudflat Village",
             "text": "{T}: Add {C}.\n{T}: Add {B}. Spend this mana only to cast a creature spell.\n{1}{B}, {T}, Sacrifice Mudflat Village: Return target Bat, Lizard, Rat, or Squirrel card from your graveyard to your hand.",
             "colours": [],
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "ca257ece-6379-5d4b-b007-6312e228f2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49b016-b02b-459f-85e9-c04f6bdcb94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49b016-b02b-459f-85e9-c04f6bdcb94e.jpg?1",
             "name": "Oakhollow Village",
             "text": "{T}: Add {C}.\n{T}: Add {G}. Spend this mana only to cast a creature spell.\n{G}, {T}: Put a +1/+1 counter on each Frog, Rabbit, Raccoon, or Squirrel you control that entered the battlefield this turn.",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "daeafe9e-c593-5020-be6f-1d5be4f7cefc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62799d24-39a6-4e66-8ac3-7cafa99e6e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62799d24-39a6-4e66-8ac3-7cafa99e6e6d.jpg?1",
             "name": "Rockface Village",
             "text": "{T}: Add {C}.\n{T}: Add {R}. Spend this mana only to cast a creature spell.\n{R}, {T}: Target Lizard, Mouse, Otter, or Raccoon you control gets +1/+0 and gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -9056,7 +9056,7 @@
         },
         {
             "id": "fc09ab40-43a2-5195-80db-ec9328370356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f88a48-cced-4a9d-8c19-e4f105f0d8a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f88a48-cced-4a9d-8c19-e4f105f0d8a2.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -9091,7 +9091,7 @@
         },
         {
             "id": "8f1bb2aa-8e64-5269-be16-55e2de73d533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b90f54-d629-4126-82cc-13b51d6c1c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b90f54-d629-4126-82cc-13b51d6c1c3e.jpg?1",
             "name": "Uncharted Haven",
             "text": "Uncharted Haven enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9119,7 +9119,7 @@
         },
         {
             "id": "7fd6af75-a023-50ec-9fe7-ede1dafd7e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663ff0c-d02f-49ac-bb88-6f0dbd684337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663ff0c-d02f-49ac-bb88-6f0dbd684337.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9159,7 +9159,7 @@
         },
         {
             "id": "80e1a433-5304-585c-83e0-8d6914c038e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab53b300-38b2-436c-834c-b0162dd3b757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab53b300-38b2-436c-834c-b0162dd3b757.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9199,7 +9199,7 @@
         },
         {
             "id": "97c5fb07-ca38-5bda-aad8-4fea46d0afb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f04188d-9a76-495d-b3a7-ee44810cf671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f04188d-9a76-495d-b3a7-ee44810cf671.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "71f4abb3-cdf4-50d5-b518-b3700ae6bbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94c04-b6d3-4118-b252-5146eedae4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94c04-b6d3-4118-b252-5146eedae4e8.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "c2ae9b30-b202-5105-acfa-c0df262b9138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106a5332-0104-4ec9-9e1f-806381ae4cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106a5332-0104-4ec9-9e1f-806381ae4cad.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9319,7 +9319,7 @@
         },
         {
             "id": "42225ec3-8c45-5af4-87ca-e076a10a3bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b92adb-a384-4e03-8ba7-1e41b9fb2516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b92adb-a384-4e03-8ba7-1e41b9fb2516.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "e86450f3-acad-53ee-a3bf-5231427e1a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408eb23f-13fa-4f98-b316-18e3057f9136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408eb23f-13fa-4f98-b316-18e3057f9136.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "7a75f632-6b9a-530c-b933-72dd498d6beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9db98e-9f1d-4139-95c5-49f9d17a2107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9db98e-9f1d-4139-95c5-49f9d17a2107.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9439,7 +9439,7 @@
         },
         {
             "id": "804c7373-dfb5-5d37-aebb-6c10dc2ae42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa54bef-c90e-4e9b-b94b-942ea829e0d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa54bef-c90e-4e9b-b94b-942ea829e0d2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "21dbe39b-fe7b-5f8f-bd39-2044049f180f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbc78a-7854-4a66-911f-a40b33e25f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbc78a-7854-4a66-911f-a40b33e25f39.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9519,7 +9519,7 @@
         },
         {
             "id": "9acab90e-5a23-5f01-a726-7bbab4623e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0223cf7f-4c6e-487f-babb-a740a15e1f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0223cf7f-4c6e-487f-babb-a740a15e1f0c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9559,7 +9559,7 @@
         },
         {
             "id": "5f999834-95b3-5a21-b254-1c5496940804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4650ebaf-8e9f-431c-998d-e0f426b24d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4650ebaf-8e9f-431c-998d-e0f426b24d41.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9599,7 +9599,7 @@
         },
         {
             "id": "f83a0b58-4096-5eea-bec9-5f6471f11b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bba8fb-d763-4efa-8db1-e5e81994b5f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bba8fb-d763-4efa-8db1-e5e81994b5f9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "b6137def-ebe0-51ae-844a-cc013dfbd146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02244055-cbeb-4074-9482-42ec20721312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02244055-cbeb-4074-9482-42ec20721312.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "d4b36d6f-8766-5509-99c2-b2f5ab35ed8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b384d24-8771-4860-8fc1-1b74217f1c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b384d24-8771-4860-8fc1-1b74217f1c4c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9719,7 +9719,7 @@
         },
         {
             "id": "67b0cd1e-0afa-595f-b402-8939691f0470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38bea4-2d1b-442b-aad5-ab1a0ae67aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38bea4-2d1b-442b-aad5-ab1a0ae67aac.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9759,7 +9759,7 @@
         },
         {
             "id": "e48cc37d-b7a9-56f2-9815-d1e5e14496c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791876a-f3fb-45b8-90a9-af846d8b8f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791876a-f3fb-45b8-90a9-af846d8b8f74.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "79b116c7-2a3a-52fc-8055-a3a46fe9aa55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a2a54-47e1-4694-b4f6-b7d659bb2b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a2a54-47e1-4694-b4f6-b7d659bb2b1f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9839,7 +9839,7 @@
         },
         {
             "id": "d072fad7-a565-581a-8c2e-78325ca3911d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000419b-0bba-4488-8f7a-6194544ce91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000419b-0bba-4488-8f7a-6194544ce91e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9879,7 +9879,7 @@
         },
         {
             "id": "5d467433-dcb0-526e-94ca-49a2c2b37104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208014f4-eed8-4856-a9d9-dbac10c4aa6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208014f4-eed8-4856-a9d9-dbac10c4aa6a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "a2e0ba05-45c7-5071-aa41-04588e778a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba10fbc2-193a-4516-a8dd-8b5f8b33a9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba10fbc2-193a-4516-a8dd-8b5f8b33a9de.jpg?1",
             "name": "Season of the Burrow",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a 1/1 white Rabbit creature token.\n{Paw Print}{Paw Print} \u2014 Exile target nonland permanent. Its controller draws a card.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return target permanent card with mana value 3 or less from your graveyard to the battlefield with an indestructible counter on it.",
             "colours": [
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "af4147bf-9775-56c6-9149-0e567bea1366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61da9522-3844-4753-8122-d11ae2780a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61da9522-3844-4753-8122-d11ae2780a4c.jpg?1",
             "name": "Season of Weaving",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Draw a card.\n{Paw Print}{Paw Print} \u2014 Choose an artifact or creature you control. Create a token that's a copy of it.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return each nonland, nontoken permanent to its owner's hand.",
             "colours": [
@@ -9987,7 +9987,7 @@
         },
         {
             "id": "fe59ca69-41b0-5484-a26e-e859f1553480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a428d58-b376-489e-8224-17a41ef6e81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a428d58-b376-489e-8224-17a41ef6e81b.jpg?1",
             "name": "Season of Loss",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Each player sacrifices a creature.\n{Paw Print}{Paw Print} \u2014 Draw a card for each creature you controlled that died this turn.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Each opponent loses X life, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "c0082986-56b8-5ea8-a664-d1522c23b5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d88763-35bd-472a-810e-02c795d0c873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d88763-35bd-472a-810e-02c795d0c873.jpg?1",
             "name": "Season of the Bold",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a tapped Treasure token.\n{Paw Print}{Paw Print} \u2014 Exile the top two cards of your library. Until the end of your next turn, you may play them.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Until the end of your next turn, whenever you cast a spell, Season of the Bold deals 2 damage to up to one target creature.",
             "colours": [
@@ -10055,7 +10055,7 @@
         },
         {
             "id": "042cb735-0e69-5448-8ec4-488cef1a3b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e99fa55-2594-434b-9396-95b8f661bd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e99fa55-2594-434b-9396-95b8f661bd0d.jpg?1",
             "name": "Season of Gathering",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Put a +1/+1 counter on a creature you control. It gains vigilance and trample until end of turn.\n{Paw Print}{Paw Print} \u2014 Choose artifact or enchantment. Destroy all permanents of the chosen type.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Draw cards equal to the greatest power among creatures you control.",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "733cd23e-f49d-538a-b633-4ea7efbc719e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc98b72-d268-4ce5-93b4-57c812a24eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc98b72-d268-4ce5-93b4-57c812a24eff.jpg?1",
             "name": "Beza, the Bounding Spring",
             "text": "When Beza, the Bounding Spring enters, create a Treasure token if an opponent controls more lands than you. You gain 4 life if an opponent has more life than you. Create two 1/1 blue Fish creature tokens if an opponent controls more creatures than you. Draw a card if an opponent has more cards in hand than you.",
             "colours": [
@@ -10128,7 +10128,7 @@
         },
         {
             "id": "880d82eb-d340-5d30-b55d-b7d1b4e52a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9da428-3af7-4027-b3f0-9138d953c37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9da428-3af7-4027-b3f0-9138d953c37b.jpg?1",
             "name": "Eluge, the Shoreless Sea",
             "text": "Eluge's power and toughness are each equal to the number of Islands you control.\nWhenever Eluge enters or attacks, put a flood counter on target land. It's an Island in addition to its other types for as long as it has a flood counter on it.\nThe first instant or sorcery spell you cast each turn costs {U} (or {1}) less to cast for each land you control with a flood counter on it.",
             "colours": [
@@ -10167,7 +10167,7 @@
         },
         {
             "id": "ce805977-0855-5e86-9b75-bca727f57c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd53428-56c3-4c99-828d-665e3c2d15a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd53428-56c3-4c99-828d-665e3c2d15a8.jpg?1",
             "name": "Maha, Its Feathers Night",
             "text": "Flying, trample\nWard\u2014\nDiscard a card.\nCreatures your opponents control have base toughness 1.",
             "colours": [
@@ -10206,7 +10206,7 @@
         },
         {
             "id": "58ea6e49-f0e6-5537-8754-b71ce82e03f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bad7555-3e5d-4096-a671-184630d38113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bad7555-3e5d-4096-a671-184630d38113.jpg?1",
             "name": "Rottenmouth Viper",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of nonland permanents. This spell costs {1} less to cast for each permanent sacrificed this way.\nWhenever Rottenmouth Viper enters or attacks, put a blight counter on it. Then for each blight counter on it, each opponent loses 4 life unless that player sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -10243,7 +10243,7 @@
         },
         {
             "id": "86bf9358-93a7-5f41-b367-f7f2c8cbaf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ef78d-ba5e-415e-9684-816464c5611a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ef78d-ba5e-415e-9684-816464c5611a.jpg?1",
             "name": "Dragonhawk, Fate's Tempest",
             "text": "Flying\nWhenever Dragonhawk enters or attacks, exile the top X cards of your library, where X is the number of creatures you control with power 4 or greater. You may play those cards until your next end step. At the beginning of your next end step, Dragonhawk deals 2 damage to each opponent for each of those cards that are still exiled.",
             "colours": [
@@ -10282,7 +10282,7 @@
         },
         {
             "id": "f000f599-57df-56c5-861e-dd291777306d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c414b4-3374-44e4-98b4-03193e701eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c414b4-3374-44e4-98b4-03193e701eb1.jpg?1",
             "name": "Sunspine Lynx",
             "text": "Players can't gain life.\nDamage can't be prevented.\nWhen Sunspine Lynx enters, it deals damage to each player equal to the number of nonbasic lands that player controls.",
             "colours": [
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "f4816114-a089-5bbd-a451-5eef36e7ce2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99587a-7fb1-41fc-b7ea-1178f9625081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99587a-7fb1-41fc-b7ea-1178f9625081.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "a9231445-d673-54d5-97d2-c6eb87d5a3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0d6ca-eed9-4b57-a34a-0105c41b20b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0d6ca-eed9-4b57-a34a-0105c41b20b9.jpg?1",
             "name": "Ygra, Eater of All",
             "text": "Ward\u2014\nSacrifice a Food.\nOther creatures are Food artifacts in addition to their other types and have \"{2}, {T}, Sacrifice this permanent: You gain 3 life.\"\nWhenever a Food is put into a graveyard from the battlefield, put two +1/+1 counters on Ygra, Eater of All.",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "420748e7-0567-58f5-829b-6e6b00d6cb14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce7aec-f9b0-461b-8245-5286b741409d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce7aec-f9b0-461b-8245-5286b741409d.jpg?1",
             "name": "Dawn's Truce",
             "text": "Gift a card\nYou and permanents you control gain hexproof until end of turn. If the gift was promised, permanents you control also gain indestructible until end of turn.",
             "colours": [
@@ -10435,7 +10435,7 @@
         },
         {
             "id": "9e69eab6-92db-5a4e-8a78-845a3e8d190a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4411204e-8387-4f1c-bfb3-1e3092d07937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4411204e-8387-4f1c-bfb3-1e3092d07937.jpg?1",
             "name": "Jackdaw Savior",
             "text": "Flying\nWhenever Jackdaw Savior or another creature you control with flying dies, return another target creature card with lesser mana value from your graveyard to the battlefield.",
             "colours": [
@@ -10472,7 +10472,7 @@
         },
         {
             "id": "beb18ed9-82a1-5917-adae-41c2a016150d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25e2bd6-c95b-422f-b6c2-d687c0745ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25e2bd6-c95b-422f-b6c2-d687c0745ecb.jpg?1",
             "name": "Salvation Swan",
             "text": "Flash\nFlying\nWhenever Salvation Swan or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.",
             "colours": [
@@ -10509,7 +10509,7 @@
         },
         {
             "id": "169c31b7-95b0-5ca0-b6f0-2ede9062a23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fe9b09-383a-4cf6-9e2c-bd00499e5eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fe9b09-383a-4cf6-9e2c-bd00499e5eb0.jpg?1",
             "name": "Starfall Invocation",
             "text": "Gift a card\nDestroy all creatures. If the gift was promised, return a creature card put into your graveyard this way to the battlefield under your control.",
             "colours": [
@@ -10543,7 +10543,7 @@
         },
         {
             "id": "7e0e6ab8-108f-509c-ba07-35ae67b29a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f25130-678d-4338-8eb4-b20d2da5bc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f25130-678d-4338-8eb4-b20d2da5bc74.jpg?1",
             "name": "Valley Questcaller",
             "text": "Whenever one or more other Rabbits, Bats, Birds, and/or Mice you control enter, scry 1.\nOther Rabbits, Bats, Birds, and Mice you control get +1/+1.",
             "colours": [
@@ -10580,7 +10580,7 @@
         },
         {
             "id": "7fc9a20f-437b-53f4-aa55-658478694269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48062f31-167a-4f16-9453-7c41f026ca96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48062f31-167a-4f16-9453-7c41f026ca96.jpg?1",
             "name": "Warren Warleader",
             "text": "Offspring {2}\nWhenever you attack, choose one \u2014\n\u2022 Create a 1/1 white Rabbit creature token that's tapped and attacking.\n\u2022 Attacking creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -10617,7 +10617,7 @@
         },
         {
             "id": "3485ecbd-b74a-5f23-af9b-541bf5009703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea69966-8961-4447-bd39-70d3d8d48ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea69966-8961-4447-bd39-70d3d8d48ede.jpg?1",
             "name": "Whiskervale Forerunner",
             "text": "Valiant \u2014 Whenever Whiskervale Forerunner becomes the target of a spell or ability you control for the first time each turn, look at the top five cards of your library. You may reveal a creature card with mana value 3 or less from among them. You may put it onto the battlefield if it's your turn. If you don't put it onto the battlefield, put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10654,7 +10654,7 @@
         },
         {
             "id": "c1f23801-ecd0-5fcd-8a00-c69c07f10187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493ef3c-673b-4e70-b957-0ee7b6d38216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493ef3c-673b-4e70-b957-0ee7b6d38216.jpg?1",
             "name": "Azure Beastbinder",
             "text": "Vigilance\nAzure Beastbinder can't be blocked by creatures with power 2 or greater.\nWhenever Azure Beastbinder attacks, up to one target artifact, creature, or planeswalker an opponent controls loses all abilities until your next turn. If it's a creature, it also has base power and toughness 2/2 until your next turn.",
             "colours": [
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "aa049f9f-e45c-5ec3-a50e-959ebf803ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e407118-95b7-4e62-a4f0-dbd8b6b80830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e407118-95b7-4e62-a4f0-dbd8b6b80830.jpg?1",
             "name": "Dour Port-Mage",
             "text": "Whenever one or more other creatures you control leave the battlefield without dying, draw a card.\n{1}{U}, {T}: Return another target creature you control to its owner's hand.",
             "colours": [
@@ -10728,7 +10728,7 @@
         },
         {
             "id": "b11a10df-905d-5ad0-9ae4-9d5f5dbb67f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bbfdc9-8d68-4b4e-ac68-ac165cdc168d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bbfdc9-8d68-4b4e-ac68-ac165cdc168d.jpg?1",
             "name": "Kitsa, Otterball Elite",
             "text": "Vigilance\nProwess\n{T}: Draw a card, then discard a card.\n{2}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy. Activate only if Kitsa's power is 3 or greater.",
             "colours": [
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "0d480bf9-d6b9-5bcb-b4a9-aa70d1b53144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed827d1-a374-48b4-8b65-abec9044de85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed827d1-a374-48b4-8b65-abec9044de85.jpg?1",
             "name": "Mockingbird",
             "text": "Flying\nYou may have Mockingbird enter as a copy of any creature on the battlefield with mana value less than or equal to the amount of mana spent to cast Mockingbird, except it's a Bird in addition to its other types and it has flying.",
             "colours": [
@@ -10804,7 +10804,7 @@
         },
         {
             "id": "9c9211a9-b0d8-5a6e-afb1-9ce2216a850f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb6618b-276b-4ce1-873f-eace471fafde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb6618b-276b-4ce1-873f-eace471fafde.jpg?1",
             "name": "Portent of Calamity",
             "text": "Reveal the top X cards of your library. For each card type, you may exile a card of that type from among them. Put the rest into your graveyard. You may cast a spell from among the exiled cards without paying its mana cost if you exiled four or more cards this way. Then put the rest of the exiled cards into your hand.",
             "colours": [
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "9e8d8a93-f5f4-5dbb-a10d-76391f6dd422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ec3510-c168-4acc-aee8-65529d0f5ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ec3510-c168-4acc-aee8-65529d0f5ad7.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "Offspring {4}\nWhen this creature enters, look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10876,7 +10876,7 @@
         },
         {
             "id": "6fcb8e40-a95b-5f61-89c5-9eaabe7a6cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c744764-3b54-49a0-aa68-1fb22d8162a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c744764-3b54-49a0-aa68-1fb22d8162a9.jpg?1",
             "name": "Valley Floodcaller",
             "text": "Flash\nYou may cast noncreature spells as though they had flash.\nWhenever you cast a noncreature spell, Birds, Frogs, Otters, and Rats you control get +1/+1 until end of turn. Untap them.",
             "colours": [
@@ -10913,7 +10913,7 @@
         },
         {
             "id": "c1b065d1-ed40-5d5f-8435-987e85b16734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640725a5-8251-4f7a-b1e3-481519c85b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640725a5-8251-4f7a-b1e3-481519c85b5d.jpg?1",
             "name": "Coiling Rebirth",
             "text": "Gift a card\nReturn target creature card from your graveyard to the battlefield. Then if the gift was promised and that creature isn't legendary, create a token that's a copy of that creature, except it's 1/1.",
             "colours": [
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "8ed0ead7-8570-504f-a111-7d96514d23c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ec21-3eb1-4f4c-a74a-84408fd1dce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ec21-3eb1-4f4c-a74a-84408fd1dce6.jpg?1",
             "name": "Cruelclaw's Heist",
             "text": "Gift a card\nTarget opponent reveals their hand. You choose a nonland card from it. Exile that card. If the gift was promised, you may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -10981,7 +10981,7 @@
         },
         {
             "id": "6d3ea749-8643-5517-9697-91f3a715374f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9abfd1-59ba-46f4-ad1d-cf0e125dd4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9abfd1-59ba-46f4-ad1d-cf0e125dd4b9.jpg?1",
             "name": "Darkstar Augur",
             "text": "Offspring {B}\nFlying\nAt the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
             "colours": [
@@ -11018,7 +11018,7 @@
         },
         {
             "id": "bd58ff64-32ed-503f-9898-d6feb805b9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4532d-63ea-4a70-86b3-58327b7e9706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4532d-63ea-4a70-86b3-58327b7e9706.jpg?1",
             "name": "Osteomancer Adept",
             "text": "Deathtouch\n{T}: Until end of turn, you may cast creature spells from your graveyard by foraging in addition to paying their other costs. If you cast a spell this way, that creature enters with a finality counter on it.",
             "colours": [
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "663ee619-ce60-5097-b99e-2f4608f24997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278a127-5f3c-4948-88bd-2af4f6834a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278a127-5f3c-4948-88bd-2af4f6834a03.jpg?1",
             "name": "Valley Rotcaller",
             "text": "Menace\nWhenever Valley Rotcaller attacks, each opponent loses X life and you gain X life, where X is the number of other Squirrels, Bats, Lizards, and Rats you control.",
             "colours": [
@@ -11092,7 +11092,7 @@
         },
         {
             "id": "3a94a428-be15-514f-b9d9-5f73598974fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a9d17-2b19-4e17-9b7e-667bf2285950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a9d17-2b19-4e17-9b7e-667bf2285950.jpg?1",
             "name": "Wick, the Whorled Mind",
             "text": "Whenever Wick or another Rat you control enters, create a 1/1 black Snail creature token if you don't control a Snail. Otherwise, put a +1/+1 counter on a Snail you control.\n{U}{B}{R}, Sacrifice a Snail: Wick deals damage equal to the sacrificed creature's power to each opponent. Then draw cards equal to the sacrificed creature's power.",
             "colours": [
@@ -11133,7 +11133,7 @@
         },
         {
             "id": "95a46554-7b71-5daa-a806-2dc29e5411c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde5980-ad2c-4ddf-8244-f9688a6225f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde5980-ad2c-4ddf-8244-f9688a6225f2.jpg?1",
             "name": "Emberheart Challenger",
             "text": "Haste\nProwess\nValiant \u2014 Whenever Emberheart Challenger becomes the target of a spell or ability you control for the first time each turn, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -11170,7 +11170,7 @@
         },
         {
             "id": "ca1b3d9d-8bbd-5553-8e8a-95821b3dfced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02134775-9c86-4f1a-af2e-5c1f531038fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02134775-9c86-4f1a-af2e-5c1f531038fe.jpg?1",
             "name": "Festival of Embers",
             "text": "During your turn, you may cast instant and sorcery spells from your graveyard by paying 1 life in addition to their other costs.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.\n{1}{R}: Sacrifice Festival of Embers.",
             "colours": [
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "75d372ee-7457-5374-863d-17d1d35348b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda3d3ef-c858-4707-9c3f-be1b775eb8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda3d3ef-c858-4707-9c3f-be1b775eb8c1.jpg?1",
             "name": "Hired Claw",
             "text": "Whenever you attack with one or more Lizards, Hired Claw deals 1 damage to target opponent.\n{1}{R}: Put a +1/+1 counter on Hired Claw. Activate only if an opponent lost life this turn and only once each turn.",
             "colours": [
@@ -11241,7 +11241,7 @@
         },
         {
             "id": "d9185ba1-e49b-5fcb-bb57-11e7a4f7982a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a990c-6ee9-44e1-85f9-83b261507308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a990c-6ee9-44e1-85f9-83b261507308.jpg?1",
             "name": "Manifold Mouse",
             "text": "Offspring {2}\nAt the beginning of combat on your turn, target Mouse you control gains your choice of double strike or trample until end of turn.",
             "colours": [
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "f78215fc-26b3-587c-88d3-fae9f4a27c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5235d-46a2-4b04-97fc-b8eb0f1ba14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5235d-46a2-4b04-97fc-b8eb0f1ba14a.jpg?1",
             "name": "Stormsplitter",
             "text": "Haste\nWhenever you cast an instant or sorcery spell, create a token that's a copy of Stormsplitter. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -11315,7 +11315,7 @@
         },
         {
             "id": "4430b18b-cd4f-5dda-90cc-217dc962f272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f266f6da-93b0-4036-b7df-be5eac4e1135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f266f6da-93b0-4036-b7df-be5eac4e1135.jpg?1",
             "name": "Valley Flamecaller",
             "text": "If a Lizard, Mouse, Otter, or Raccoon you control would deal damage to a permanent or player, it deals that much damage plus 1 instead.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "d4d7718e-573b-56c1-9aa6-3b72220daf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d1e35e-f5c8-422d-83d2-839ab7766f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d1e35e-f5c8-422d-83d2-839ab7766f25.jpg?1",
             "name": "For the Common Good",
             "text": "Create X tokens that are copies of target token you control. Then tokens you control gain indestructible until your next turn. You gain 1 life for each token you control.",
             "colours": [
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "4f919ce3-d185-52bd-8852-ebf3f3e0707d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004a67ce-60ef-4cc2-9f4d-f30e3029d80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004a67ce-60ef-4cc2-9f4d-f30e3029d80a.jpg?1",
             "name": "Keen-Eyed Curator",
             "text": "As long as there are four or more card types among cards exiled with Keen-Eyed Curator, it gets +4/+4 and has trample.\n{1}: Exile target card from a graveyard.",
             "colours": [
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "87069759-97b4-5fcf-8a58-af1dcb76ce08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ed58e4-b612-483e-9c0e-f1fbfaa5950c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ed58e4-b612-483e-9c0e-f1fbfaa5950c.jpg?1",
             "name": "Mistbreath Elder",
             "text": "At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on Mistbreath Elder. Otherwise, you may return Mistbreath Elder to its owner's hand.",
             "colours": [
@@ -11460,7 +11460,7 @@
         },
         {
             "id": "ba549ac6-fb7f-5328-9afd-eeeb59154365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afd22ab-64e7-4b85-804d-faccd4452487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afd22ab-64e7-4b85-804d-faccd4452487.jpg?1",
             "name": "Scrapshooter",
             "text": "Gift a card\nReach\nWhen Scrapshooter enters, if the gift was promised, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -11497,7 +11497,7 @@
         },
         {
             "id": "1a7509de-37c4-58ef-aeb7-fa2a297c8d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc164c8-62ca-4d59-ae1c-ef273fde9d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc164c8-62ca-4d59-ae1c-ef273fde9d10.jpg?1",
             "name": "Tender Wildguide",
             "text": "Offspring {2}\n{T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -11534,7 +11534,7 @@
         },
         {
             "id": "84008bd6-54f6-5114-be43-14c014d2d4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31330554-1824-436b-aee5-931a7b652ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31330554-1824-436b-aee5-931a7b652ddf.jpg?1",
             "name": "Valley Mightcaller",
             "text": "Trample\nWhenever another Frog, Rabbit, Raccoon, or Squirrel you control enters, put a +1/+1 counter on Valley Mightcaller.",
             "colours": [
@@ -11571,7 +11571,7 @@
         },
         {
             "id": "66076563-e3e4-5d1f-b8b7-356f88e54f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dc7b8e-d381-49a0-a7f8-c8cd9acadc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dc7b8e-d381-49a0-a7f8-c8cd9acadc54.jpg?1",
             "name": "Alania, Divergent Storm",
             "text": "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -11613,7 +11613,7 @@
         },
         {
             "id": "7cb0a1f7-c402-5fec-b5b7-014a1b0342ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ea9ca9-3dff-4d5d-92ec-3475234b4713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ea9ca9-3dff-4d5d-92ec-3475234b4713.jpg?1",
             "name": "Camellia, the Seedmiser",
             "text": "Menace\nOther Squirrels you control have menace.\nWhenever you sacrifice one or more Foods, create a 1/1 green Squirrel creature token.\n{2}, Forage: Put a +1/+1 counter on each other Squirrel you control.",
             "colours": [
@@ -11655,7 +11655,7 @@
         },
         {
             "id": "bf8db8db-412e-554f-9db2-e74c6de2bca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a68d51-cd4e-4ee3-abc7-01435085aa26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a68d51-cd4e-4ee3-abc7-01435085aa26.jpg?1",
             "name": "Clement, the Worrywort",
             "text": "Vigilance\nWhenever Clement, the Worrywort or another creature you control enters, return up to one target creature you control with lesser mana value to its owner's hand.\nFrogs you control have \"{T}: Add {G} or {U}. Spend this mana only to cast a creature spell.\"",
             "colours": [
@@ -11697,7 +11697,7 @@
         },
         {
             "id": "9b636c36-85de-5c85-842b-12f2936b67ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77374ac-3456-48a3-a412-4474547d437c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77374ac-3456-48a3-a412-4474547d437c.jpg?1",
             "name": "Finneas, Ace Archer",
             "text": "Vigilance, reach\nWhenever Finneas, Ace Archer attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
             "colours": [
@@ -11739,7 +11739,7 @@
         },
         {
             "id": "0e3b50ec-85b2-512b-8a71-4cc7b9ff7194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fab12e-0f81-4728-9a35-4dc896ba3744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fab12e-0f81-4728-9a35-4dc896ba3744.jpg?1",
             "name": "Glarb, Calamity's Augur",
             "text": "Deathtouch\nYou may look at the top card of your library any time.\nYou may play lands and cast spells with mana value 4 or greater from the top of your library.\n{T}: Surveil 2.",
             "colours": [
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "0585bfc3-1e14-55c5-9b83-21ccf2662107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768ef947-85fc-4fb2-bda9-e0e446cd8886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768ef947-85fc-4fb2-bda9-e0e446cd8886.jpg?1",
             "name": "Helga, Skittish Seer",
             "text": "Whenever you cast a creature spell with mana value 4 or greater, you draw a card, gain 1 life, and put a +1/+1 counter on Helga, Skittish Seer.\n{T}: Add X mana of any one color, where X is Helga, Skittish Seer's power. Spend this mana only to cast creature spells with mana value 4 or greater or creature spells with {X} in their mana costs.",
             "colours": [
@@ -11826,7 +11826,7 @@
         },
         {
             "id": "ae9e4bc4-c9f2-538e-abcf-1ecefbbe24d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b2be42-467d-4210-b9bf-4d09ee504a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b2be42-467d-4210-b9bf-4d09ee504a22.jpg?1",
             "name": "Hugs, Grisly Guardian",
             "text": "Trample\nWhen Hugs, Grisly Guardian enters, exile the top X cards of your library. Until the end of your next turn, you may play those cards.\nYou may play an additional land on each of your turns.",
             "colours": [
@@ -11867,7 +11867,7 @@
         },
         {
             "id": "17b629ea-bb6b-5430-930b-849206cc3499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc26a7-f47e-44d7-a42b-b5415fc86f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc26a7-f47e-44d7-a42b-b5415fc86f8f.jpg?1",
             "name": "The Infamous Cruelclaw",
             "text": "Menace\nWhenever The Infamous Cruelclaw deals combat damage to a player, exile cards from the top of your library until you exile a nonland card. You may cast that card by discarding a card rather than paying its mana cost.",
             "colours": [
@@ -11908,7 +11908,7 @@
         },
         {
             "id": "0a7e24ad-9a28-5ed2-ad23-77ec6f076efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a84790-665b-4a23-a00f-84d1009e3d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a84790-665b-4a23-a00f-84d1009e3d28.jpg?1",
             "name": "Kastral, the Windcrested",
             "text": "Flying\nWhenever one or more Birds you control deal combat damage to a player, choose one \u2014\n\u2022 You may put a Bird creature card from your hand or graveyard onto the battlefield with a finality counter on it.\n\u2022 Put a +1/+1 counter on each Bird you control.\n\u2022 Draw a card.",
             "colours": [
@@ -11950,7 +11950,7 @@
         },
         {
             "id": "cd1816ac-7dd4-5b47-8c12-529b596e1e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1696453f-a678-47ff-b583-53c2130b7d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1696453f-a678-47ff-b583-53c2130b7d49.jpg?1",
             "name": "Mabel, Heir to Cragflame",
             "text": "Other Mice you control get +1/+1.\nWhen Mabel, Heir to Cragflame enters, create Cragflame, a legendary colorless Equipment artifact token with \"Equipped creature gets +1/+1 and has vigilance, trample, and haste\" and equip {2}.",
             "colours": [
@@ -11992,7 +11992,7 @@
         },
         {
             "id": "c61a003a-45bc-591d-86b2-2745583327e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b0f9e-fa3b-4a40-acea-b6ecc584a79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b0f9e-fa3b-4a40-acea-b6ecc584a79f.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12027,7 +12027,7 @@
         },
         {
             "id": "f7190d6f-6dfb-584a-8cff-4896159464de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06008bcb-ce6b-482c-9253-f5b9b5e0718e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06008bcb-ce6b-482c-9253-f5b9b5e0718e.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12062,7 +12062,7 @@
         },
         {
             "id": "9d360dcf-3cf4-545c-98d3-ff6409cef25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e1d8486-370a-49b6-9145-060814f38677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e1d8486-370a-49b6-9145-060814f38677.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12097,7 +12097,7 @@
         },
         {
             "id": "1db2d22a-e9d1-5f3e-93ea-e452e539930e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb16046-10bf-433a-acaf-7127c0954a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb16046-10bf-433a-acaf-7127c0954a1c.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12132,7 +12132,7 @@
         },
         {
             "id": "1a3d6192-8dd0-552b-a460-dfcac3c02826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a74dbdd-5baa-4896-80d4-1a9743410d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a74dbdd-5baa-4896-80d4-1a9743410d4c.jpg?1",
             "name": "Ral, Crackling Wit",
             "text": "Whenever you cast a noncreature spell, put a loyalty counter on Ral, Crackling Wit.\n+1: Create a 1/1 blue and red Otter creature token with prowess.\n\u22123: Draw three cards, then discard two cards.\n\u221210: Draw three cards. You get an emblem with \"Instant and sorcery spells you cast have storm.\"",
             "colours": [
@@ -12173,7 +12173,7 @@
         },
         {
             "id": "7d95bac2-c3d1-5784-879e-daf2b2e41655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b3c33-aa44-4001-87ff-695bf04f51be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b3c33-aa44-4001-87ff-695bf04f51be.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -12214,7 +12214,7 @@
         },
         {
             "id": "947e7baa-d2ec-50f9-9d1e-f5a33caa344c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487cfce-2b73-4082-a1f2-dea263811516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487cfce-2b73-4082-a1f2-dea263811516.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -12254,7 +12254,7 @@
         },
         {
             "id": "a8afcf4b-d76b-5b7a-9df0-d9298aceb455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ace81d-823f-43d1-902e-345418cd8fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ace81d-823f-43d1-902e-345418cd8fd2.jpg?1",
             "name": "Alania, Divergent Storm",
             "text": "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -12295,7 +12295,7 @@
         },
         {
             "id": "03966aa5-83c2-59bd-990a-ae36d79c5a5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b511524-e628-41d4-b0dc-d98961d4e9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b511524-e628-41d4-b0dc-d98961d4e9e1.jpg?1",
             "name": "Baylen, the Haymaker",
             "text": "Tap two untapped tokens you control: Add one mana of any color.\nTap three untapped tokens you control: Draw a card.\nTap four untapped tokens you control: Put three +1/+1 counters on Baylen, the Haymaker. It gains trample until end of turn.",
             "colours": [
@@ -12337,7 +12337,7 @@
         },
         {
             "id": "567ac1f0-7343-5904-ba46-33f4c3de7734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f59ece-1ba5-422b-820d-e80c83f46290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f59ece-1ba5-422b-820d-e80c83f46290.jpg?1",
             "name": "Camellia, the Seedmiser",
             "text": "Menace\nOther Squirrels you control have menace.\nWhenever you sacrifice one or more Foods, create a 1/1 green Squirrel creature token.\n{2}, Forage: Put a +1/+1 counter on each other Squirrel you control.",
             "colours": [
@@ -12378,7 +12378,7 @@
         },
         {
             "id": "9053974b-4479-5f53-9645-b7f0ecdc2981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfe689-83d4-4dcb-810c-d618a39c5ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfe689-83d4-4dcb-810c-d618a39c5ab9.jpg?1",
             "name": "Clement, the Worrywort",
             "text": "Vigilance\nWhenever Clement, the Worrywort or another creature you control enters, return up to one target creature you control with lesser mana value to its owner's hand.\nFrogs you control have \"{T}: Add {G} or {U}. Spend this mana only to cast a creature spell.\"",
             "colours": [
@@ -12419,7 +12419,7 @@
         },
         {
             "id": "72f9bea4-4e3c-5d10-aad7-82a2dc0403d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d99aec-c114-4287-ab61-a34e5adab5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d99aec-c114-4287-ab61-a34e5adab5ab.jpg?1",
             "name": "Finneas, Ace Archer",
             "text": "Vigilance, reach\nWhenever Finneas, Ace Archer attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
             "colours": [
@@ -12460,7 +12460,7 @@
         },
         {
             "id": "e1f36337-1100-5bcb-9105-052f99f8b9b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad70a0b-3845-4b92-9c15-985a3fe0e1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad70a0b-3845-4b92-9c15-985a3fe0e1f2.jpg?1",
             "name": "Gev, Scaled Scorch",
             "text": "Ward\u2014\nPay 2 life.\nOther creatures you control enter with an additional +1/+1 counter on them for each opponent who lost life this turn.\nWhenever you cast a Lizard spell, Gev, Scaled Scorch deals 1 damage to target opponent.",
             "colours": [
@@ -12500,7 +12500,7 @@
         },
         {
             "id": "bd425e97-68db-59c5-a878-6c3b9753b6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6d51dc-ca49-417c-8b5a-fcb5cd669c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6d51dc-ca49-417c-8b5a-fcb5cd669c6f.jpg?1",
             "name": "Kastral, the Windcrested",
             "text": "Flying\nWhenever one or more Birds you control deal combat damage to a player, choose one \u2014\n\u2022 You may put a Bird creature card from your hand or graveyard onto the battlefield with a finality counter on it.\n\u2022 Put a +1/+1 counter on each Bird you control.\n\u2022 Draw a card.",
             "colours": [
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "194af200-8013-56d1-bc65-0565521fb37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbdaae3-acba-44e1-bdd6-9c7066143d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbdaae3-acba-44e1-bdd6-9c7066143d33.jpg?1",
             "name": "Mabel, Heir to Cragflame",
             "text": "Other Mice you control get +1/+1.\nWhen Mabel, Heir to Cragflame enters, create Cragflame, a legendary colorless Equipment artifact token with \"Equipped creature gets +1/+1 and has vigilance, trample, and haste\" and equip {2}.",
             "colours": [
@@ -12582,7 +12582,7 @@
         },
         {
             "id": "23889ad9-537a-5a0e-979a-15d11a5c1318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b4e695-5ec4-4821-8637-8df501ba0653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b4e695-5ec4-4821-8637-8df501ba0653.jpg?1",
             "name": "Muerra, Trash Tactician",
             "text": "At the beginning of your first main phase, add {R} or {G} for each Raccoon you control.\nWhenever you expend 4, you gain 3 life.\nWhenever you expend 8, exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -12622,7 +12622,7 @@
         },
         {
             "id": "b78e915c-cb64-5144-b5d1-41b02ba68796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c496c-c70e-46f0-b161-661620767de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c496c-c70e-46f0-b161-661620767de5.jpg?1",
             "name": "Ral, Crackling Wit",
             "text": "Whenever you cast a noncreature spell, put a loyalty counter on Ral, Crackling Wit.\n+1: Create a 1/1 blue and red Otter creature token with prowess.\n\u22123: Draw three cards, then discard two cards.\n\u221210: Draw three cards. You get an emblem with \"Instant and sorcery spells you cast have storm.\"",
             "colours": [
@@ -12662,7 +12662,7 @@
         },
         {
             "id": "c705867f-fbdc-5331-9aff-80ee95d6b4ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca7c86-92d8-4a24-81b1-9eb11392160d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca7c86-92d8-4a24-81b1-9eb11392160d.jpg?1",
             "name": "Vren, the Relentless",
             "text": "Ward {2}\nIf a creature an opponent controls would die, exile it instead.\nAt the beginning of each end step, create X 1/1 black Rat creature tokens with \"This creature gets +1/+1 for each other Rat you control,\" where X is the number of creatures your opponents controlled that were exiled this turn.",
             "colours": [
@@ -12702,7 +12702,7 @@
         },
         {
             "id": "a634a2c2-dcb6-560d-a7d8-f1e9d84964a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34690573-d8d6-471e-9878-cf5d931d9f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34690573-d8d6-471e-9878-cf5d931d9f55.jpg?1",
             "name": "Zoraline, Cosmos Caller",
             "text": "Flying, vigilance\nWhenever a Bat you control attacks, you gain 1 life.\nWhenever Zoraline enters or attacks, you may pay {W}{B} and 2 life. When you do, return target nonland permanent card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.",
             "colours": [
@@ -12742,7 +12742,7 @@
         },
         {
             "id": "8707a4b0-c722-5124-a174-08ab86a6114d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5c86a-0991-4322-a0a2-48424c4be2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5c86a-0991-4322-a0a2-48424c4be2af.jpg?1",
             "name": "Essence Channeler",
             "text": "As long as you've lost life this turn, Essence Channeler has flying and vigilance.\nWhenever you gain life, put a +1/+1 counter on Essence Channeler.\nWhen Essence Channeler dies, put its counters on target creature you control.",
             "colours": [
@@ -12779,7 +12779,7 @@
         },
         {
             "id": "d722ca3e-5b47-5ebd-837f-b8b74427423e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f3b75d-87d6-42dc-8096-41f5480b12fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f3b75d-87d6-42dc-8096-41f5480b12fa.jpg?1",
             "name": "Kitnap",
             "text": "Gift a card\nEnchant creature\nWhen Kitnap enters, tap enchanted creature. If the gift wasn't promised, put three stun counters on it.\nYou control enchanted creature.",
             "colours": [
@@ -12815,7 +12815,7 @@
         },
         {
             "id": "45bd58ea-7b75-5776-a40a-d762b1b24cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e054e77f-94b9-4c43-94a4-75a7a5d1bd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e054e77f-94b9-4c43-94a4-75a7a5d1bd30.jpg?1",
             "name": "Wishing Well",
             "text": "{T}: Put a coin counter on Wishing Well. When you do, you may cast target instant or sorcery card with mana value equal to the number of coin counters on Wishing Well from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -12849,7 +12849,7 @@
         },
         {
             "id": "cf8492ea-d3a4-5d4e-b27c-76d9a671e061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e34b4-6762-465f-a5c7-24e42e112fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e34b4-6762-465f-a5c7-24e42e112fbe.jpg?1",
             "name": "Iridescent Vinelasher",
             "text": "Offspring {2}\nLandfall \u2014 Whenever a land you control enters, this creature deals 1 damage to target opponent.",
             "colours": [
@@ -12886,7 +12886,7 @@
         },
         {
             "id": "94734754-74e4-5710-8815-8d9fc9ab7364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aebd0f9-fa08-407f-b3d3-fb4b13b1ea97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aebd0f9-fa08-407f-b3d3-fb4b13b1ea97.jpg?1",
             "name": "Byway Barterer",
             "text": "Menace\nWhenever you expend 4, you may discard your hand. If you do, draw two cards.",
             "colours": [
@@ -12923,7 +12923,7 @@
         },
         {
             "id": "4d433efd-f4e5-52f9-ae0e-634d10467a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a10a11-a21f-4e93-8771-8d971c158911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a10a11-a21f-4e93-8771-8d971c158911.jpg?1",
             "name": "Hearthborn Battler",
             "text": "Haste\nWhenever a player casts their second spell each turn, Hearthborn Battler deals 2 damage to target opponent.",
             "colours": [
@@ -12960,7 +12960,7 @@
         },
         {
             "id": "d8b4b907-dcf5-5b86-bf33-037687c4bbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56301392-3496-48d0-8d91-6b82e1164c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56301392-3496-48d0-8d91-6b82e1164c98.jpg?1",
             "name": "Fecund Greenshell",
             "text": "Reach\nAs long as you control ten or more lands, creatures you control get +2/+2.\nWhenever Fecund Greenshell or another creature you control with toughness greater than its power enters, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. Otherwise, put it into your hand.",
             "colours": [
@@ -12997,7 +12997,7 @@
         },
         {
             "id": "8ced1bf6-e33d-581a-8f3e-8a87b7438a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc5b558-4470-4bd7-9458-fbd275ded168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc5b558-4470-4bd7-9458-fbd275ded168.jpg?1",
             "name": "Pawpatch Recruit",
             "text": "Offspring {2}\nTrample\nWhenever a creature you control becomes the target of a spell or ability an opponent controls, put a +1/+1 counter on target creature you control other than that creature.",
             "colours": [
@@ -13034,7 +13034,7 @@
         },
         {
             "id": "f8efff88-b5c7-5bb4-884f-f0f6b68870e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ffe1ab-df93-4017-bb29-bb214c86d73a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ffe1ab-df93-4017-bb29-bb214c86d73a.jpg?1",
             "name": "Thornvault Forager",
             "text": "{T}: Add {G}.\n{T}, Forage: Add two mana in any combination of colors.\n{3}{G}, {T}: Search your library for a Squirrel card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -13071,7 +13071,7 @@
         },
         {
             "id": "5423288a-f88f-5312-ad67-c7199bf21c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2efb27-c181-43f7-93fe-a8c4d286f8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2efb27-c181-43f7-93fe-a8c4d286f8ad.jpg?1",
             "name": "Dreamdew Entrancer",
             "text": "Reach\nWhen Dreamdew Entrancer enters, tap up to one target creature and put three stun counters on it. If you control that creature, draw two cards.",
             "colours": [
@@ -13110,7 +13110,7 @@
         },
         {
             "id": "8b36f850-9288-52ee-8df9-c9e996d85443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396e4c7-660d-4055-bc94-4ccea95223b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396e4c7-660d-4055-bc94-4ccea95223b7.jpg?1",
             "name": "Lunar Convocation",
             "text": "At the beginning of your end step, if you gained life this turn, each opponent loses 1 life.\nAt the beginning of your end step, if you gained and lost life this turn, create a 1/1 black Bat creature token with flying.\n{1}{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -13146,7 +13146,7 @@
         },
         {
             "id": "a8ab5ba9-bc91-568a-acee-1e125a4e6fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda8a2e-6bf1-4d8c-b71b-bbc8d8130fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda8a2e-6bf1-4d8c-b71b-bbc8d8130fff.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -13176,7 +13176,7 @@
         },
         {
             "id": "35dc150c-0e17-5148-8778-6ab6c29bf351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd04367b-59d8-4ee6-8b5a-abfb1373c226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd04367b-59d8-4ee6-8b5a-abfb1373c226.jpg?1",
             "name": "Fountainport",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a token: Draw a card.\n{3}, {T}, Pay 1 life: Create a 1/1 blue Fish creature token.\n{4}, {T}: Create a Treasure token.",
             "colours": [],
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "06649302-997a-58e6-8d80-21ced2f30252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449d4122-ee9d-477c-976a-809ba8cb1443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449d4122-ee9d-477c-976a-809ba8cb1443.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -13246,7 +13246,7 @@
         },
         {
             "id": "7897f1f5-3d18-57a0-9710-838d4e7d886e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b61a1-db66-416d-8187-edc32123131f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b61a1-db66-416d-8187-edc32123131f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -13286,7 +13286,7 @@
         },
         {
             "id": "1195f7e4-455a-5e3f-964e-77e638e0b960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46848fc2-ba58-4738-b4ce-0399d9053f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46848fc2-ba58-4738-b4ce-0399d9053f48.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13326,7 +13326,7 @@
         },
         {
             "id": "59c80579-10b2-5a53-b42c-086be6a12076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10125dab-fe82-4796-b5db-3bd6ad389e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10125dab-fe82-4796-b5db-3bd6ad389e1d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "ce543f0d-5c7b-5ff5-b618-9b1373bb5439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6125ffe3-4e48-4e0f-8390-7462446fc8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6125ffe3-4e48-4e0f-8390-7462446fc8bf.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13406,7 +13406,7 @@
         },
         {
             "id": "1df5f06a-420d-5e39-8a8b-83c8cbbe44f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbfdbdd-6322-4ea6-9680-d4e480d78437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbfdbdd-6322-4ea6-9680-d4e480d78437.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13446,7 +13446,7 @@
         },
         {
             "id": "e3d57a49-793d-5ddd-99a4-b0ab1a79de53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b827c54-8bfe-4ef5-830e-e17b8690bbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b827c54-8bfe-4ef5-830e-e17b8690bbe7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -13486,7 +13486,7 @@
         },
         {
             "id": "9951ede6-9c13-515c-b9b1-5dd498b73360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62aaa129-69ff-4e22-861e-b2efd1cd5a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62aaa129-69ff-4e22-861e-b2efd1cd5a10.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -13526,7 +13526,7 @@
         },
         {
             "id": "7edb292e-d32c-5cf8-ae5b-fac3aef0d394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b3be4a-973d-4aeb-a94e-37e2710ac178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b3be4a-973d-4aeb-a94e-37e2710ac178.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -13566,7 +13566,7 @@
         },
         {
             "id": "23a4a236-daa6-57c8-bdc3-3a9d7b4db18d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddc66f7-4e94-4857-ba7d-6b0083d0bfa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddc66f7-4e94-4857-ba7d-6b0083d0bfa0.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -13606,7 +13606,7 @@
         },
         {
             "id": "e991d23a-8f81-5fbe-861e-ea50ac11b324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c96b3-68da-4a42-89ab-d9ccc79ce0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c96b3-68da-4a42-89ab-d9ccc79ce0dd.jpg?1",
             "name": "Bria, Riptide Rogue",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nOther creatures you control have prowess. (If a creature has multiple instances of prowess, each triggers separately.)\nWhenever you cast a noncreature spell, target creature you control can't be blocked this turn.",
             "colours": [
@@ -13645,7 +13645,7 @@
         },
         {
             "id": "06b266a0-7c12-5c37-b027-c16aa3b225fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6441abd3-320b-424a-9753-61e3581fe1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6441abd3-320b-424a-9753-61e3581fe1a9.jpg?1",
             "name": "Byrke, Long Ear of the Law",
             "text": "Vigilance\nWhen Byrke, Long Ear of the Law enters, put a +1/+1 counter on each of up to two target creatures.\nWhenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it.",
             "colours": [
@@ -13684,7 +13684,7 @@
         },
         {
             "id": "413733c3-e799-51b3-bec4-cde87a64cb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684614e3-5454-4e68-87da-a2027b6af6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684614e3-5454-4e68-87da-a2027b6af6d7.jpg?1",
             "name": "Hop to It",
             "text": "Create three 1/1 white Rabbit creature tokens.",
             "colours": [
@@ -13718,7 +13718,7 @@
         },
         {
             "id": "92900508-75e7-5a15-b09c-56135dd11b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb0b3c-a403-4212-93d3-3340c3f1e9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb0b3c-a403-4212-93d3-3340c3f1e9db.jpg?1",
             "name": "Shoreline Looter",
             "text": "Shoreline Looter can't be blocked.\nThreshold \u2014 Whenever Shoreline Looter deals combat damage to a player, draw a card. Then discard a card unless seven or more cards are in your graveyard.",
             "colours": [
@@ -13755,7 +13755,7 @@
         },
         {
             "id": "b6ff9221-6d14-5ca5-a19d-58ea15a40f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bb137-2639-4158-a24b-93c8e4f4cc21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bb137-2639-4158-a24b-93c8e4f4cc21.jpg?1",
             "name": "Fell",
             "text": "Destroy target creature.",
             "colours": [
@@ -13789,7 +13789,7 @@
         },
         {
             "id": "d3da415c-1de6-5da8-9b1a-28ff0328f38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c394081-0292-49f8-8a6f-213956754020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c394081-0292-49f8-8a6f-213956754020.jpg?1",
             "name": "Wear Down",
             "text": "Gift a card\nDestroy target artifact or enchantment. If the gift was promised, instead destroy two target artifacts and/or enchantments.",
             "colours": [
@@ -13823,7 +13823,7 @@
         },
         {
             "id": "5bc391f5-126a-52ab-bb4a-c68dc93dab8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e5a7a1-4ac5-4d9f-8d27-0877efca47f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e5a7a1-4ac5-4d9f-8d27-0877efca47f1.jpg?1",
             "name": "Stormcatch Mentor",
             "text": "Haste, prowess\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -13862,7 +13862,7 @@
         },
         {
             "id": "0353d774-65f7-5470-9725-5f937a2145f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52caa08-34ae-4c74-83ad-008d17005576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52caa08-34ae-4c74-83ad-008d17005576.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "Offspring {4} (You may pay an additional {4} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13900,7 +13900,7 @@
         },
         {
             "id": "34144cef-a2e3-5e5e-8614-eacf17bfe99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9aef-bd9c-4332-ace4-b5b065bac6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9aef-bd9c-4332-ace4-b5b065bac6d8.jpg?1",
             "name": "Serra Redeemer",
             "text": "Flying\nWhenever another creature you control with power 2 or less enters, put two +1/+1 counters on that creature.",
             "colours": [
@@ -13934,7 +13934,7 @@
         },
         {
             "id": "e76de6e8-86f2-5c46-99d4-cb153ce60781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d171802-2604-45a5-a0f2-ab5afa1db5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d171802-2604-45a5-a0f2-ab5afa1db5d5.jpg?1",
             "name": "Charmed Sleep",
             "text": "Enchant creature\nWhen Charmed Sleep enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "5e245e76-e789-5efb-9025-7f0cd44b38e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7d174-eb7c-41ad-a241-cfbfdc71e3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7d174-eb7c-41ad-a241-cfbfdc71e3a7.jpg?1",
             "name": "Mind Spring",
             "text": "Draw X cards.",
             "colours": [
@@ -13998,7 +13998,7 @@
         },
         {
             "id": "bf1cc7cd-a29b-5100-8fa2-42c4544c7341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a258be-39e3-4689-b2d0-7c353ce7d574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a258be-39e3-4689-b2d0-7c353ce7d574.jpg?1",
             "name": "Thieving Otter",
             "text": "Whenever Thieving Otter deals damage to an opponent, draw a card.",
             "colours": [
@@ -14031,7 +14031,7 @@
         },
         {
             "id": "dbc7797b-a323-5c7d-82d9-0f24102626da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6440439-7178-4a97-9e18-7fdef4b02678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6440439-7178-4a97-9e18-7fdef4b02678.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to any target.",
             "colours": [
@@ -14062,7 +14062,7 @@
         },
         {
             "id": "ccd8353f-04d2-5135-b03b-8fde30911b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cad902-ffd2-4bab-b114-b4b6df2ac6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cad902-ffd2-4bab-b114-b4b6df2ac6b3.jpg?1",
             "name": "Colossification",
             "text": "Enchant creature\nWhen Colossification enters, tap enchanted creature.\nEnchanted creature gets +20/+20.",
             "colours": [
@@ -14095,7 +14095,7 @@
         },
         {
             "id": "5c279393-7e27-59cf-b752-159df8ca0b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70722d6-b4d5-45c2-9488-9a5eb0bdb9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70722d6-b4d5-45c2-9488-9a5eb0bdb9bd.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -14126,7 +14126,7 @@
         },
         {
             "id": "d0765684-8596-56a2-92a4-effcf953c613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a73200-b798-4bfd-a431-8b94e17b70be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a73200-b798-4bfd-a431-8b94e17b70be.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -14157,7 +14157,7 @@
         },
         {
             "id": "3ab85213-6185-5609-949e-e3f05cf2d8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b5fc1-7611-44ac-ad8d-1f0c6d4fc9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b5fc1-7611-44ac-ad8d-1f0c6d4fc9a3.jpg?1",
             "name": "Sword of Vengeance",
             "text": "Equipped creature gets +2/+0 and has first strike, vigilance, trample, and haste.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -14186,7 +14186,7 @@
         },
         {
             "id": "61eae6a4-5cb6-5233-9601-e8357b6a7acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa2cc9-e427-4104-bad7-b0294e392b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa2cc9-e427-4104-bad7-b0294e392b1f.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters tapped.\nWhen Blossoming Sands enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -14216,7 +14216,7 @@
         },
         {
             "id": "37bb3fc2-f4a3-50a6-ab56-a55b3f618e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e43510-c444-4b2e-b2a0-528dcc09c899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e43510-c444-4b2e-b2a0-528dcc09c899.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters tapped.\nWhen Swiftwater Cliffs enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -14246,7 +14246,7 @@
         },
         {
             "id": "e0711851-a9c9-59a1-94c7-ff70ddc0d4ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c977b7-12cb-4e6f-8260-a7399b60940f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c977b7-12cb-4e6f-8260-a7399b60940f.jpg?1",
             "name": "Flowerfoot Swordmaster",
             "text": "",
             "colours": [
@@ -14282,7 +14282,7 @@
         },
         {
             "id": "69e8d088-1553-55bb-9ac9-25a259d91ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1cd58d-c0bc-48e5-b6fa-fb222fba77ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1cd58d-c0bc-48e5-b6fa-fb222fba77ab.jpg?1",
             "name": "Intrepid Rabbit",
             "text": "",
             "colours": [
@@ -14318,7 +14318,7 @@
         },
         {
             "id": "9a2bfa2b-416f-59d3-b8ae-10bc73d26c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg?1",
             "name": "Rabbit",
             "text": "",
             "colours": [
@@ -14353,7 +14353,7 @@
         },
         {
             "id": "5c11257f-fd89-5f00-87c8-ff8fad9fb5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a41de-91dd-4696-bfc1-10d702787c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a41de-91dd-4696-bfc1-10d702787c3e.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -14388,7 +14388,7 @@
         },
         {
             "id": "997e530b-8b57-558f-8318-6e9f69c6c975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc9b628-0a3a-4d09-ae4a-57c7f6f9ac36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc9b628-0a3a-4d09-ae4a-57c7f6f9ac36.jpg?1",
             "name": "Warren Warleader",
             "text": "",
             "colours": [
@@ -14424,7 +14424,7 @@
         },
         {
             "id": "52e2005b-645c-51c3-9533-9e29812c015a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8be9b74-6f1a-4692-a09a-1013cae4da18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8be9b74-6f1a-4692-a09a-1013cae4da18.jpg?1",
             "name": "Finch Formation",
             "text": "",
             "colours": [
@@ -14460,7 +14460,7 @@
         },
         {
             "id": "abb2d41a-24fb-50ae-a778-b6177b7bc6ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -14495,7 +14495,7 @@
         },
         {
             "id": "45010c8a-c3b4-5ded-968b-1e3cc19b919f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53065735-c427-458e-ade4-ec2d81c8d277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53065735-c427-458e-ade4-ec2d81c8d277.jpg?1",
             "name": "Splash Lasher",
             "text": "",
             "colours": [
@@ -14531,7 +14531,7 @@
         },
         {
             "id": "8bb6cfe7-742d-5e76-9608-3326ead39b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bcbe35-7764-4c75-b954-cbba11372dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bcbe35-7764-4c75-b954-cbba11372dec.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "",
             "colours": [
@@ -14567,7 +14567,7 @@
         },
         {
             "id": "ee795bc4-13de-5a15-a292-714c3056d705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100c0127-49dd-4a78-9c88-1881e7923674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100c0127-49dd-4a78-9c88-1881e7923674.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "66c5362f-7915-51e3-b392-ce1205324ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b55966-0910-484d-9b2b-0a59233c44c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b55966-0910-484d-9b2b-0a59233c44c4.jpg?1",
             "name": "Darkstar Augur",
             "text": "",
             "colours": [
@@ -14638,7 +14638,7 @@
         },
         {
             "id": "c39bbf40-9bf9-5400-8be3-0fb961f0a643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55c677-dc14-4ae3-9518-0d80b528c3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55c677-dc14-4ae3-9518-0d80b528c3fb.jpg?1",
             "name": "Iridescent Vinelasher",
             "text": "",
             "colours": [
@@ -14674,7 +14674,7 @@
         },
         {
             "id": "debc732d-24ac-5768-8a05-db5eaca77802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0977b2-3342-4b7e-b1c7-f06bd8ab7fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0977b2-3342-4b7e-b1c7-f06bd8ab7fbf.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -14709,7 +14709,7 @@
         },
         {
             "id": "3f9392c7-5385-5776-ab98-b3baee335282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9bb0a91-b73e-465b-8c0e-50fc28e66fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9bb0a91-b73e-465b-8c0e-50fc28e66fda.jpg?1",
             "name": "Snail",
             "text": "",
             "colours": [
@@ -14744,7 +14744,7 @@
         },
         {
             "id": "c4a30fa6-79cc-5cc5-a1ce-4a4cb6ccec1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5379a77e-4b98-4abc-b967-fbc76bb85fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5379a77e-4b98-4abc-b967-fbc76bb85fc6.jpg?1",
             "name": "Starscape Cleric",
             "text": "",
             "colours": [
@@ -14780,7 +14780,7 @@
         },
         {
             "id": "c962ed7f-456a-5fd7-a214-95b61fcb6bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd3dd0-81b6-4f4a-86e6-920170017c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd3dd0-81b6-4f4a-86e6-920170017c92.jpg?1",
             "name": "Thornplate Intimidator",
             "text": "",
             "colours": [
@@ -14816,7 +14816,7 @@
         },
         {
             "id": "cecb15c5-7b41-5362-b4d1-8c271f7d3d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c208-4d8d-4833-bee2-bfc87c93049d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c208-4d8d-4833-bee2-bfc87c93049d.jpg?1",
             "name": "Coruscation Mage",
             "text": "",
             "colours": [
@@ -14852,7 +14852,7 @@
         },
         {
             "id": "97fedff9-99d6-5997-916e-a218e9ead776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5067c54-0f31-40e6-9ead-5d0183c9f00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5067c54-0f31-40e6-9ead-5d0183c9f00a.jpg?1",
             "name": "Manifold Mouse",
             "text": "",
             "colours": [
@@ -14888,7 +14888,7 @@
         },
         {
             "id": "52a3babf-c034-5160-859d-a260dfe110f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a41850-49d2-4c1f-84df-cc7f7fb951f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a41850-49d2-4c1f-84df-cc7f7fb951f8.jpg?1",
             "name": "Steampath Charger",
             "text": "",
             "colours": [
@@ -14924,7 +14924,7 @@
         },
         {
             "id": "25699c57-043c-5fef-9a11-681a0fa05445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c247d48f-d1e9-4b28-b372-bf4eea67cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c247d48f-d1e9-4b28-b372-bf4eea67cb8c.jpg?1",
             "name": "Bushy Bodyguard",
             "text": "",
             "colours": [
@@ -14960,7 +14960,7 @@
         },
         {
             "id": "9a82dac7-6859-5b38-8c39-b3190b8e4f64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdd8679-93a7-4e58-a6f3-b48897697e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdd8679-93a7-4e58-a6f3-b48897697e89.jpg?1",
             "name": "Pawpatch Recruit",
             "text": "",
             "colours": [
@@ -14996,7 +14996,7 @@
         },
         {
             "id": "446e12f8-083c-56f0-8428-16ad6df13ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dd6325-e3d8-4816-ac52-8838c12b4922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dd6325-e3d8-4816-ac52-8838c12b4922.jpg?1",
             "name": "Rust-Shield Rampager",
             "text": "",
             "colours": [
@@ -15032,7 +15032,7 @@
         },
         {
             "id": "da457623-e6de-51b0-a22f-e279640934a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6ec62e-0e9b-4312-bfe8-cc85d76fd9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6ec62e-0e9b-4312-bfe8-cc85d76fd9e0.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -15067,7 +15067,7 @@
         },
         {
             "id": "9349efc1-c80a-5adb-9635-6da39593ee3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4e41-7ce4-45ca-b365-fcde289ffe8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4e41-7ce4-45ca-b365-fcde289ffe8c.jpg?1",
             "name": "Tender Wildguide",
             "text": "",
             "colours": [
@@ -15103,7 +15103,7 @@
         },
         {
             "id": "49481296-5e87-500b-9d95-8011f432466a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b2c465-c446-4dee-9101-763105dcf813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b2c465-c446-4dee-9101-763105dcf813.jpg?1",
             "name": "Otter",
             "text": "",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "524e2513-4a49-53bf-a5fa-150dc718c5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76fa1c6-6000-47b2-9188-9c15b2c73f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76fa1c6-6000-47b2-9188-9c15b2c73f8f.jpg?1",
             "name": "Cragflame",
             "text": "",
             "colours": [],
@@ -15173,7 +15173,7 @@
         },
         {
             "id": "08ce3bb9-14a8-554b-8d2f-328f500a2379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce2241-e58b-41d4-b57c-9794fc8ee004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce2241-e58b-41d4-b57c-9794fc8ee004.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -15204,7 +15204,7 @@
         },
         {
             "id": "7d7a7feb-09d6-55fb-b019-c2736adb8ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1e78e6-a9e7-48a4-9231-61fb331c5837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1e78e6-a9e7-48a4-9231-61fb331c5837.jpg?1",
             "name": "Sword",
             "text": "",
             "colours": [],
@@ -15235,7 +15235,7 @@
         },
         {
             "id": "4811acb4-e116-5e6b-8d42-707057b51299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0357fb-d90c-49c7-b16a-8b52ac686c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0357fb-d90c-49c7-b16a-8b52ac686c3b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -15266,7 +15266,7 @@
         },
         {
             "id": "412c22db-2a44-59b4-bfcf-55d7996307fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4c9934-fe82-4560-b0bf-0ebc863ff0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4c9934-fe82-4560-b0bf-0ebc863ff0d1.jpg?1",
             "name": "Ral, Crackling Wit Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/BNG.json
+++ b/Assets/Resources/Sets/BNG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f51fea6e-e9f1-5704-94ca-954ee1d619e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8980af-c3fa-4027-917a-4a3d441c0a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8980af-c3fa-4027-917a-4a3d441c0a75.jpg?1",
             "name": "Acolyte's Reward",
             "text": "Prevent the next X damage that would be dealt to target creature this turn, where X is your devotion to white. If damage is prevented this way, Acolyte's Reward deals that much damage to target creature or player. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "0b2170d9-78f5-5fcb-8eb3-52f14505eafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe23019a-e432-4a27-8acb-b17728a1e8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe23019a-e432-4a27-8acb-b17728a1e8b0.jpg?1",
             "name": "Akroan Phalanx",
             "text": "Vigilance\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "8f1d4633-bf42-518f-827d-5284b0f3c079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55e85c3-234e-49c4-a307-96fb4497eea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55e85c3-234e-49c4-a307-96fb4497eea8.jpg?1",
             "name": "Akroan Skyguard",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Akroan Skyguard, put a +1/+1 counter on Akroan Skyguard.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "910b07c9-ea52-5962-9095-f00e16d1f0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6c4afb-6a94-4519-91c6-9824fed2892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6c4afb-6a94-4519-91c6-9824fed2892c.jpg?1",
             "name": "Archetype of Courage",
             "text": "Creatures you control have first strike.\nCreatures your opponents control lose first strike and can't have or gain first strike.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "e14067e8-9800-5a96-9838-1e7635c86bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54eb705-6326-4bac-bf0e-68d42db7a270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54eb705-6326-4bac-bf0e-68d42db7a270.jpg?1",
             "name": "Brimaz, King of Oreskos",
             "text": "Vigilance\nWhenever Brimaz, King of Oreskos attacks, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield attacking.\nWhenever Brimaz blocks a creature, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield blocking that creature.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "2616cfdc-3cc8-5721-8fad-ad27e42843f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026ee3ff-bfd3-42d7-a4fa-2a6372599aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026ee3ff-bfd3-42d7-a4fa-2a6372599aef.jpg?1",
             "name": "Dawn to Dusk",
             "text": "Choose one or both \u2014 Return target enchantment card from your graveyard to your hand; and/or destroy target enchantment.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "5f6e46ac-59e1-56bd-8816-383d6096fe0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d16283b-b5bb-48e8-8c97-db5ad74fd544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d16283b-b5bb-48e8-8c97-db5ad74fd544.jpg?1",
             "name": "Eidolon of Countless Battles",
             "text": "Bestow {2}{W}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEidolon of Countless Battles and enchanted creature each get +1/+1 for each creature you control and +1/+1 for each Aura you control.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "5266d7b9-8268-5d87-9aab-08ac7c10a902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982eed00-e9fe-4d0f-a2b7-9606aa7926a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982eed00-e9fe-4d0f-a2b7-9606aa7926a1.jpg?1",
             "name": "Elite Skirmisher",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Elite Skirmisher, you may tap target creature.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "105c0e7b-a92d-51c2-b09c-f0b74b155c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0741582-0c7b-4d5b-83a9-dd8862de1f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0741582-0c7b-4d5b-83a9-dd8862de1f24.jpg?1",
             "name": "Ephara's Radiance",
             "text": "Enchant creature\nEnchanted creature has \"{1}{W}, {T}: You gain 3 life.\"",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "97811d02-86ad-5926-89b3-87c311031434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5023a5-b77c-48c6-9e84-ef525300ecdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5023a5-b77c-48c6-9e84-ef525300ecdf.jpg?1",
             "name": "Excoriate",
             "text": "Exile target tapped creature.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "daaa442d-0e80-555d-a263-c79bbd591028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8158b330-2868-4147-907e-4d86e44cfaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8158b330-2868-4147-907e-4d86e44cfaad.jpg?1",
             "name": "Fated Retribution",
             "text": "Destroy all creatures and planeswalkers. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "a2720973-1cee-596f-a095-a6525b3d3e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b1e720-c7cd-450a-a8af-61fcbca7eb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b1e720-c7cd-450a-a8af-61fcbca7eb24.jpg?1",
             "name": "Ghostblade Eidolon",
             "text": "Bestow {5}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nDouble strike (This creature deals both first-strike and regular combat damage.)\nEnchanted creature gets +1/+1 and has double strike.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "cf1a82da-9760-5e3e-94d3-4ded410d8e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f241e5f7-3168-4bd2-b586-185aad3ae9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f241e5f7-3168-4bd2-b586-185aad3ae9d9.jpg?1",
             "name": "Glimpse the Sun God",
             "text": "Tap X target creatures. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "bf975bdb-30e7-52b1-9588-f645822c1c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c2db0-5a79-47b8-8a42-5674c6d9d0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c2db0-5a79-47b8-8a42-5674c6d9d0fd.jpg?1",
             "name": "God-Favored General",
             "text": "Inspired \u2014 Whenever God-Favored General becomes untapped, you may pay {2}{W}. If you do, put two 1/1 white Soldier enchantment creature tokens onto the battlefield.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "569d7d52-6b9d-5b4c-8ddc-d6d1673150c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cd7d2b-e9c4-4900-89a0-f6eb0c6cb22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cd7d2b-e9c4-4900-89a0-f6eb0c6cb22b.jpg?1",
             "name": "Great Hart",
             "text": "",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "6ce716e6-8daa-57fc-bcdb-8a97ef330c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b569fadd-d9ca-4b0d-bee2-9d45574e56f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b569fadd-d9ca-4b0d-bee2-9d45574e56f0.jpg?1",
             "name": "Griffin Dreamfinder",
             "text": "Flying\nWhen Griffin Dreamfinder enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "1c063f16-66c9-55fd-b680-8f010f7dda36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7917f2ee-f093-4ffb-83ed-a181b14b5957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7917f2ee-f093-4ffb-83ed-a181b14b5957.jpg?1",
             "name": "Hero of Iroas",
             "text": "Aura spells you cast cost {1} less to cast.\nHeroic \u2014 Whenever you cast a spell that targets Hero of Iroas, put a +1/+1 counter on Hero of Iroas.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "cab3cdd9-35ee-5553-ae56-5e1581ab5559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeb407d-6a42-488a-9869-83da3047e45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeb407d-6a42-488a-9869-83da3047e45d.jpg?1",
             "name": "Hold at Bay",
             "text": "Prevent the next 7 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "172047ef-c75d-593e-84fd-64791b20af42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b29f36-e84d-402e-9ab7-935fd2e7532d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b29f36-e84d-402e-9ab7-935fd2e7532d.jpg?1",
             "name": "Loyal Pegasus",
             "text": "Flying\nLoyal Pegasus can't attack or block alone.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "afbe3475-3e99-5e5b-a4d8-28089c0924dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f95c-aeed-4cb6-a43b-2748a5dd6138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f95c-aeed-4cb6-a43b-2748a5dd6138.jpg?1",
             "name": "Mortal's Ardor",
             "text": "Target creature gets +1/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "ae6371f7-3b66-53e1-b894-285e9a8eee01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64204816-6e1d-4bf8-acd0-8f83ca7eb8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64204816-6e1d-4bf8-acd0-8f83ca7eb8c7.jpg?1",
             "name": "Nyxborn Shieldmate",
             "text": "Bestow {2}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "380d04d7-afe2-5a7a-a32e-ead0dd32abed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064435e7-20ea-4ba4-b039-a945afeeb5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064435e7-20ea-4ba4-b039-a945afeeb5c6.jpg?1",
             "name": "Oreskos Sun Guide",
             "text": "Inspired \u2014 Whenever Oreskos Sun Guide becomes untapped, you gain 2 life.",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "374719f3-ef9d-546b-a84d-1abe6585b75b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a0bf4-10c7-4afa-8cf6-e31196cc2bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a0bf4-10c7-4afa-8cf6-e31196cc2bd5.jpg?1",
             "name": "Ornitharch",
             "text": "Flying\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Ornitharch enters the battlefield, if tribute wasn't paid, put two 1/1 white Bird creature tokens with flying onto the battlefield.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "5575bd84-ad1c-5c54-9580-756143ef657b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1d6d76-f399-475a-b5cd-544bd7c6d967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1d6d76-f399-475a-b5cd-544bd7c6d967.jpg?1",
             "name": "Plea for Guidance",
             "text": "Search your library for up to two enchantment cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "3948f89f-dac5-55c2-89a5-fa21d8e4f943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597916e4-0294-4911-98e0-6ac5993533ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597916e4-0294-4911-98e0-6ac5993533ae.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "bb46c51e-ceca-5297-80bf-7f712e361b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ece7c-b979-4a31-ba5f-6a8a382f2862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ece7c-b979-4a31-ba5f-6a8a382f2862.jpg?1",
             "name": "Silent Sentinel",
             "text": "Flying\nWhenever Silent Sentinel attacks, you may return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "bfde9cbf-5460-5023-8373-50de45de0430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e5128-e146-4e46-b313-a40d82719d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e5128-e146-4e46-b313-a40d82719d1d.jpg?1",
             "name": "Spirit of the Labyrinth",
             "text": "Each player can't draw more than one card each turn.",
             "colours": [
@@ -921,7 +921,7 @@
         },
         {
             "id": "89d87907-8b01-5c28-95d7-4e658c9d14e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f14bbff-8a3c-4aa0-a5aa-0dd6cb23b2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f14bbff-8a3c-4aa0-a5aa-0dd6cb23b2a3.jpg?1",
             "name": "Sunbond",
             "text": "Enchant creature\nEnchanted creature has \"Whenever you gain life, put that many +1/+1 counters on this creature.\"",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "c16334d9-522a-5da1-b4e8-758b164487d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb38717-97d5-4763-9e6c-46251df704ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb38717-97d5-4763-9e6c-46251df704ed.jpg?1",
             "name": "Vanguard of Brimaz",
             "text": "Vigilance\nHeroic \u2014 Whenever you cast a spell that targets Vanguard of Brimaz, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "146d79e6-93fb-56a0-a7cc-21ef59ed3ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c8b3b9-f0fb-4cc1-8916-82ee2c74f089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c8b3b9-f0fb-4cc1-8916-82ee2c74f089.jpg?1",
             "name": "Aerie Worshippers",
             "text": "Inspired \u2014 Whenever Aerie Worshippers becomes untapped, you may pay {2}{U}. If you do, put a 2/2 blue Bird enchantment creature token with flying onto the battlefield.",
             "colours": [
@@ -1025,7 +1025,7 @@
         },
         {
             "id": "cd069255-5bb7-54ae-8443-d01befc602aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e58ba3-4202-4f91-b27f-7528d27c1d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e58ba3-4202-4f91-b27f-7528d27c1d5c.jpg?1",
             "name": "Arbiter of the Ideal",
             "text": "Flying\nInspired \u2014 Whenever Arbiter of the Ideal becomes untapped, reveal the top card of your library. If it's an artifact, creature, or land card, you may put it onto the battlefield with a manifestation counter on it. That permanent is an enchantment in addition to its other types.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "885b846c-226e-502b-bd64-f964c16810cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de0f770-b62b-4a9d-bea7-6bb7bc2020ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de0f770-b62b-4a9d-bea7-6bb7bc2020ad.jpg?1",
             "name": "Archetype of Imagination",
             "text": "Creatures you control have flying.\nCreatures your opponents control lose flying and can't have or gain flying.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "6f65cc73-3281-5023-8053-32db67449d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e576f7a-0390-4514-aaed-20406fe6acdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e576f7a-0390-4514-aaed-20406fe6acdf.jpg?1",
             "name": "Chorus of the Tides",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Chorus of the Tides, scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "9d5cbccb-6b03-5451-a26a-f8131a1e1c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd445b01-34af-4132-a9fe-a03858624492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd445b01-34af-4132-a9fe-a03858624492.jpg?1",
             "name": "Crypsis",
             "text": "Target creature you control gains protection from creatures your opponents control until end of turn. Untap it.",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "53d0fab6-cb40-5486-80fe-a28cc9849d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab7c6a7-8214-4644-8f2e-ec74d2aff27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab7c6a7-8214-4644-8f2e-ec74d2aff27e.jpg?1",
             "name": "Deepwater Hypnotist",
             "text": "Inspired \u2014 Whenever Deepwater Hypnotist becomes untapped, target creature an opponent controls gets -3/-0 until end of turn.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "e633c125-086f-5260-934c-f8010450ddb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9964e-cfe0-4400-b903-3f590889f88d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9964e-cfe0-4400-b903-3f590889f88d.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "f1decf52-9245-5349-b838-1a4195849da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa167147-68ca-49af-98d3-538474ea1158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa167147-68ca-49af-98d3-538474ea1158.jpg?1",
             "name": "Eternity Snare",
             "text": "Enchant creature\nWhen Eternity Snare enters the battlefield, draw a card.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "07c7acfd-0b2e-5da6-b973-1e36b20a7791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38cfe97-77b3-4423-95ac-88eb850cf854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38cfe97-77b3-4423-95ac-88eb850cf854.jpg?1",
             "name": "Evanescent Intellect",
             "text": "Enchant creature\nEnchanted creature has \"{1}{U}, {T}: Target player puts the top three cards of his or her library into his or her graveyard.\"",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "897f3f55-71ba-50c4-9eeb-78e7cb4ede55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ba99d-d95d-4a3b-b6b6-a5e2589d538e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ba99d-d95d-4a3b-b6b6-a5e2589d538e.jpg?1",
             "name": "Fated Infatuation",
             "text": "Put a token onto the battlefield that's a copy of target creature you control. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "54e57d9c-7026-56b3-ab95-5599e1da7e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a79cee0-6023-42bc-a934-69b99fd5fb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a79cee0-6023-42bc-a934-69b99fd5fb02.jpg?1",
             "name": "Flitterstep Eidolon",
             "text": "Bestow {5}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlitterstep Eidolon can't be blocked.\nEnchanted creature gets +1/+1 and can't be blocked.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "429adf18-6881-54b0-965c-09900e3630b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2a4b24-096a-4d36-a872-73fa4552bb35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2a4b24-096a-4d36-a872-73fa4552bb35.jpg?1",
             "name": "Floodtide Serpent",
             "text": "Floodtide Serpent can't attack unless you return an enchantment you control to its owner's hand. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -1397,7 +1397,7 @@
         },
         {
             "id": "69ff93ac-7cee-50a9-a60f-079f2b967e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ae69b3-afa5-4763-a0c8-c3d9d96f6ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ae69b3-afa5-4763-a0c8-c3d9d96f6ddc.jpg?1",
             "name": "Kraken of the Straits",
             "text": "Creatures with power less than the number of Islands you control can't block Kraken of the Straits.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "19497ced-163e-5dff-ba2c-2c2d314e88d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9adca9-3e69-474f-896d-bb05b1d67252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9adca9-3e69-474f-896d-bb05b1d67252.jpg?1",
             "name": "Meletis Astronomer",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Meletis Astronomer, look at the top three cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1466,7 +1466,7 @@
         },
         {
             "id": "a2a2fd79-f87d-5fdc-91d1-9294684467a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87912ae7-3edc-4ea2-9b4b-caf2bc149ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87912ae7-3edc-4ea2-9b4b-caf2bc149ad1.jpg?1",
             "name": "Mindreaver",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Mindreaver, exile the top three cards of target player's library.\n{U}{U}, Sacrifice Mindreaver: Counter target spell with the same name as a card exiled with Mindreaver.",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "794160c7-5fc8-5078-93a5-1ceb21f31e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940d859-3fb1-4946-8277-b7c503605b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940d859-3fb1-4946-8277-b7c503605b1e.jpg?1",
             "name": "Nullify",
             "text": "Counter target creature or Aura spell.",
             "colours": [
@@ -1533,7 +1533,7 @@
         },
         {
             "id": "aeeba675-bd88-5344-800f-7ae6964dd61a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65371de6-13a2-401f-9334-ae9e19619487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65371de6-13a2-401f-9334-ae9e19619487.jpg?1",
             "name": "Nyxborn Triton",
             "text": "Bestow {4}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +2/+3.",
             "colours": [
@@ -1568,7 +1568,7 @@
         },
         {
             "id": "98178ddc-ddb7-53bf-8257-514f52b55b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546dae51-070c-4f3f-b0b4-6b88ff314af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546dae51-070c-4f3f-b0b4-6b88ff314af1.jpg?1",
             "name": "Oracle's Insight",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Scry 1, then draw a card.\" (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "0eb32ad2-4528-5ea3-ad77-76407333c37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cff40b-9cae-47d0-8df4-c287a17a33e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cff40b-9cae-47d0-8df4-c287a17a33e4.jpg?1",
             "name": "Perplexing Chimera",
             "text": "Whenever an opponent casts a spell, you may exchange control of Perplexing Chimera and that spell. If you do, you may choose new targets for the spell. (If the spell becomes a permanent, you control that permanent.)",
             "colours": [
@@ -1637,7 +1637,7 @@
         },
         {
             "id": "1c0b124b-80bc-5058-9e98-267dfcd9540d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe8c0b9-fdf4-4fc0-aa7c-774546cdd792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe8c0b9-fdf4-4fc0-aa7c-774546cdd792.jpg?1",
             "name": "Retraction Helix",
             "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
             "colours": [
@@ -1669,7 +1669,7 @@
         },
         {
             "id": "c70016bb-e74c-54fa-9832-7075d5cce176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba93d9a-94cd-4d90-860a-f567793a5be4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba93d9a-94cd-4d90-860a-f567793a5be4.jpg?1",
             "name": "Siren of the Fanged Coast",
             "text": "Flying\nTribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Siren of the Fanged Coast enters the battlefield, if tribute wasn't paid, gain control of target creature.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "56b3abec-0acb-5fca-bcfe-d5a24b421445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba33f00d-dbed-4bfb-a295-90f729be98de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba33f00d-dbed-4bfb-a295-90f729be98de.jpg?1",
             "name": "Sphinx's Disciple",
             "text": "Flying\nInspired \u2014 Whenever Sphinx's Disciple becomes untapped, draw a card.",
             "colours": [
@@ -1738,7 +1738,7 @@
         },
         {
             "id": "fe18128c-f52a-542c-a96d-ebce0fb03aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg?1",
             "name": "Stratus Walk",
             "text": "Enchant creature\nWhen Stratus Walk enters the battlefield, draw a card.\nEnchanted creature has flying.\nEnchanted creature can block only creatures with flying.",
             "colours": [
@@ -1772,7 +1772,7 @@
         },
         {
             "id": "6cf10253-e02f-5ede-a9d0-a73dbb79ed0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6beffc33-58fd-4364-b87b-d4573ecaf4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6beffc33-58fd-4364-b87b-d4573ecaf4bd.jpg?1",
             "name": "Sudden Storm",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controllers' next untap steps. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1804,7 +1804,7 @@
         },
         {
             "id": "24866092-ab5c-571a-9012-4dccbb1ea7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816a6ff7-cede-4346-b3e6-aee33aefac3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816a6ff7-cede-4346-b3e6-aee33aefac3a.jpg?1",
             "name": "Thassa's Rebuff",
             "text": "Counter target spell unless its controller pays {X}, where X is your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "38757d7d-b090-5835-b640-411f21d9fccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fcad7f-2740-49ff-a448-4b232c456e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fcad7f-2740-49ff-a448-4b232c456e16.jpg?1",
             "name": "Tromokratis",
             "text": "Tromokratis has hexproof unless it's attacking or blocking.\nTromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "be95e88d-362b-586c-961c-08bf7f334e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb7ca2b-c5de-4c8a-91cb-8dd8ab5387d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb7ca2b-c5de-4c8a-91cb-8dd8ab5387d8.jpg?1",
             "name": "Vortex Elemental",
             "text": "{U}: Put Vortex Elemental and each creature blocking or blocked by it on top of their owners' libraries, then those players shuffle their libraries.\n{3}{U}{U}: Target creature blocks Vortex Elemental this turn if able.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "d46367c1-29b1-5be7-80af-759f76df3c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcabd4c7-093f-4ef6-8b89-b08565c48e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcabd4c7-093f-4ef6-8b89-b08565c48e3c.jpg?1",
             "name": "Whelming Wave",
             "text": "Return all creatures to their owners' hands except for Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "850f1669-d953-5b98-9f16-9940beb40301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b9c5-063b-4c53-a696-11cd89fc88d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b9c5-063b-4c53-a696-11cd89fc88d8.jpg?1",
             "name": "Archetype of Finality",
             "text": "Creatures you control have deathtouch.\nCreatures your opponents control lose deathtouch and can't have or gain deathtouch.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "533a23c6-a209-55bd-8ef3-b2bb14c8fdbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86acd1cc-5238-4734-a324-b4cecffc0bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86acd1cc-5238-4734-a324-b4cecffc0bab.jpg?1",
             "name": "Ashiok's Adept",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Ashiok's Adept, each opponent discards a card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "032f150d-0b3c-5489-bfd2-42a75831ff95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894f3f5f-586d-45e4-9af7-4de80e44dfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894f3f5f-586d-45e4-9af7-4de80e44dfae.jpg?1",
             "name": "Asphyxiate",
             "text": "Destroy target untapped creature.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "b4108175-5a2d-53b7-8f0e-da892063641a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca11057-e50a-4817-924a-5bb504d0780f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca11057-e50a-4817-924a-5bb504d0780f.jpg?1",
             "name": "Bile Blight",
             "text": "Target creature and all other creatures with the same name as that creature get -3/-3 until end of turn.",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "9dab9aa7-bc53-5809-87c1-8bd0bbe74bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e9195-a711-4f4d-9d53-d5d230c092ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e9195-a711-4f4d-9d53-d5d230c092ef.jpg?1",
             "name": "Black Oak of Odunos",
             "text": "Defender\n{B}, Tap another untapped creature you control: Black Oak of Odunos gets +1/+1 until end of turn.",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "efbd4008-42c4-5423-aa6d-2e8650c6b8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342196b9-ab65-4922-864e-00f067153261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342196b9-ab65-4922-864e-00f067153261.jpg?1",
             "name": "Champion of Stray Souls",
             "text": "{3}{B}{B}, {T}, Sacrifice X other creatures: Return X target creature cards from your graveyard to the battlefield.\n{5}{B}{B}: Put Champion of Stray Souls on top of your library from your graveyard.",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "d62e384d-d8b6-5e8f-be35-aa8ddd2fb581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51db556-b3e8-4628-9e39-6353023b0696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51db556-b3e8-4628-9e39-6353023b0696.jpg?1",
             "name": "Claim of Erebos",
             "text": "Enchant creature\nEnchanted creature has \"{1}{B}, {T}: Target player loses 2 life.\"",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "794b3d74-f101-5d0e-912f-b49688d1f91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c7570-8080-43dc-a586-963e15566446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c7570-8080-43dc-a586-963e15566446.jpg?1",
             "name": "Drown in Sorrow",
             "text": "All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "04002005-a950-5884-8060-7a849694516f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75f3d3f-925d-45ef-92e6-22aca22e5451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75f3d3f-925d-45ef-92e6-22aca22e5451.jpg?1",
             "name": "Eater of Hope",
             "text": "Flying\n{B}, Sacrifice another creature: Regenerate Eater of Hope.\n{2}{B}, Sacrifice two other creatures: Destroy target creature.",
             "colours": [
@@ -2242,7 +2242,7 @@
         },
         {
             "id": "4400ce8e-36c4-5293-ab4b-0aebba5b0695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d4eb34-0529-48a0-ac52-b57cead7b651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d4eb34-0529-48a0-ac52-b57cead7b651.jpg?1",
             "name": "Eye Gouge",
             "text": "Target creature gets -1/-1 until end of turn. If it's a Cyclops, destroy it.",
             "colours": [
@@ -2274,7 +2274,7 @@
         },
         {
             "id": "3325c2de-62f1-5331-95ff-7f107a053a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15cd233-e27b-4cfd-aa4e-18040d1de22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15cd233-e27b-4cfd-aa4e-18040d1de22f.jpg?1",
             "name": "Fate Unraveler",
             "text": "Whenever an opponent draws a card, Fate Unraveler deals 1 damage to that player.",
             "colours": [
@@ -2309,7 +2309,7 @@
         },
         {
             "id": "996a3776-3720-5266-8155-ff6165ef10f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55878ec-a903-4694-8709-e29fa88b2c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55878ec-a903-4694-8709-e29fa88b2c28.jpg?1",
             "name": "Fated Return",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "0b6b2de4-3de0-5f57-8d41-9a330eaaa85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a829bb0-6a84-46de-9c2d-14176cf542e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a829bb0-6a84-46de-9c2d-14176cf542e6.jpg?1",
             "name": "Felhide Brawler",
             "text": "Felhide Brawler can't block unless you control another Minotaur.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "9a53c891-07c7-557e-9e00-7f284973f11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c236a33-fb20-41f4-8946-beb65d1cf684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c236a33-fb20-41f4-8946-beb65d1cf684.jpg?1",
             "name": "Forlorn Pseudamma",
             "text": "Intimidate\nInspired \u2014 Whenever Forlorn Pseudamma becomes untapped, you may pay {2}{B}. If you do, put a 2/2 black Zombie enchantment creature token onto the battlefield.",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "c1b68600-ccfa-51ab-bf2e-c2203833aeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05445d18-3590-4216-9392-9438d9f9395d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05445d18-3590-4216-9392-9438d9f9395d.jpg?1",
             "name": "Forsaken Drifters",
             "text": "When Forsaken Drifters dies, put the top four cards of your library into your graveyard.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "6e3fa07d-33f5-52e4-b0ea-529470a13b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5e6c4-02c8-4602-96d6-19dad34f7804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5e6c4-02c8-4602-96d6-19dad34f7804.jpg?1",
             "name": "Gild",
             "text": "Exile target creature. Put a colorless artifact token named Gold onto the battlefield. It has \"Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "d3020f61-95d8-5f1c-838e-4824fda1ab7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb0ce84-560f-4e39-a0ab-7bd710d541cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb0ce84-560f-4e39-a0ab-7bd710d541cc.jpg?1",
             "name": "Grisly Transformation",
             "text": "Enchant creature\nWhen Grisly Transformation enters the battlefield, draw a card.\nEnchanted creature has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2509,7 +2509,7 @@
         },
         {
             "id": "a8d73b0d-8335-5aed-be3d-5395be3d824e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7e5ab-57d7-4a86-b7c2-262932ac3344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7e5ab-57d7-4a86-b7c2-262932ac3344.jpg?1",
             "name": "Herald of Torment",
             "text": "Bestow {3}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying\nAt the beginning of your upkeep, you lose 1 life.\nEnchanted creature gets +3/+3 and has flying.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "16be6641-34b0-58b6-b026-99398d712ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093d2e4c-f2c4-4d4e-a1b7-200327ce23b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093d2e4c-f2c4-4d4e-a1b7-200327ce23b0.jpg?1",
             "name": "Marshmist Titan",
             "text": "Marshmist Titan costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "db2e0e64-49a8-5b4e-9586-064f74ace51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0955932-8ca9-4896-882c-2969fe7c7818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0955932-8ca9-4896-882c-2969fe7c7818.jpg?1",
             "name": "Necrobite",
             "text": "Target creature gains deathtouch until end of turn. Regenerate it.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "2655e65f-f32a-5cce-b22a-1ba7be18f2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f79804-cd90-472b-9d09-3c71e4c6be22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f79804-cd90-472b-9d09-3c71e4c6be22.jpg?1",
             "name": "Nyxborn Eidolon",
             "text": "Bestow {4}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "824c82e0-56da-5fb2-9c15-5ce0fda87a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d1eda4-ac34-4905-9022-59f91d38dbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d1eda4-ac34-4905-9022-59f91d38dbb3.jpg?1",
             "name": "Odunos River Trawler",
             "text": "When Odunos River Trawler enters the battlefield, return target enchantment creature card from your graveyard to your hand.\n{W}, Sacrifice Odunos River Trawler: Return target enchantment creature card from your graveyard to your hand.",
             "colours": [
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "5a778e7a-e79f-572b-a6bf-2dda9d2a5bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8891f-b44c-4be4-878e-9fc45a9dc9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8891f-b44c-4be4-878e-9fc45a9dc9cb.jpg?1",
             "name": "Pain Seer",
             "text": "Inspired \u2014 Whenever Pain Seer becomes untapped, reveal the top card of your library and put that card into your hand. You lose life equal to that card's converted mana cost.",
             "colours": [
@@ -2715,7 +2715,7 @@
         },
         {
             "id": "5b8e6756-ffe6-549e-9cb2-e0461d7797a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb129def-4055-4b12-9944-39406b451553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb129def-4055-4b12-9944-39406b451553.jpg?1",
             "name": "Sanguimancy",
             "text": "You draw X cards and you lose X life, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2747,7 +2747,7 @@
         },
         {
             "id": "222a5c67-6f16-5365-bc3a-7d43d50bb7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb16d4f-ed42-4b19-9e45-330db88eea9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb16d4f-ed42-4b19-9e45-330db88eea9b.jpg?1",
             "name": "Servant of Tymaret",
             "text": "Inspired \u2014 Whenever Servant of Tymaret becomes untapped, each opponent loses 1 life. You gain life equal to the life lost this way.\n{2}{B}: Regenerate Servant of Tymaret.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "42fb4556-4584-5a55-bcdc-508be0072f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b1eeb-6cc9-48a7-a068-afa1011c45f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b1eeb-6cc9-48a7-a068-afa1011c45f2.jpg?1",
             "name": "Shrike Harpy",
             "text": "Flying\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Shrike Harpy enters the battlefield, if tribute wasn't paid, target opponent sacrifices a creature.",
             "colours": [
@@ -2815,7 +2815,7 @@
         },
         {
             "id": "0ca8cfb0-bd3a-5acd-8d0d-49d68bba711b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017e8cfb-7cb0-403c-b8be-abee22369661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017e8cfb-7cb0-403c-b8be-abee22369661.jpg?1",
             "name": "Spiteful Returned",
             "text": "Bestow {3}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhenever Spiteful Returned or enchanted creature attacks, defending player loses 2 life.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2850,7 +2850,7 @@
         },
         {
             "id": "3c30d366-7938-5cc6-a1c3-b4926d277999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757948b3-8cb2-4709-9bbf-031c2bf6d4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757948b3-8cb2-4709-9bbf-031c2bf6d4c5.jpg?1",
             "name": "Warchanter of Mogis",
             "text": "Inspired \u2014 Whenever Warchanter of Mogis becomes untapped, target creature you control gains intimidate until end of turn. (A creature with intimidate can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "f9da3720-9dc4-5564-8691-e1fd803a2274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg?1",
             "name": "Weight of the Underworld",
             "text": "Enchant creature\nEnchanted creature gets -3/-2.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "2c35587d-17ae-5641-85ab-e996ad401b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb529f-44fd-409d-932f-be9c403f12f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb529f-44fd-409d-932f-be9c403f12f6.jpg?1",
             "name": "Akroan Conscriptor",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Conscriptor, gain control of another target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "f62a85eb-65c0-5af4-96ce-fb57875e2340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13946413-c76d-41a8-a699-404fd56b2067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13946413-c76d-41a8-a699-404fd56b2067.jpg?1",
             "name": "Archetype of Aggression",
             "text": "Creatures you control have trample.\nCreatures your opponents control lose trample and can't have or gain trample.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "4cc5e33e-9a6e-595f-871a-5cc1cb43844b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df70b14-5d67-4a92-aaba-72480c621d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df70b14-5d67-4a92-aaba-72480c621d10.jpg?1",
             "name": "Bolt of Keranos",
             "text": "Bolt of Keranos deals 3 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "1a068201-08b7-5e60-9570-bfc00284ca19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a25c69-8e57-4a44-955a-da1541bbe0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a25c69-8e57-4a44-955a-da1541bbe0fe.jpg?1",
             "name": "Cyclops of One-Eyed Pass",
             "text": "",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "3f58f691-aa7d-5622-9df2-92c3b796118d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a0128-4499-498d-9721-b1fd70ea84b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a0128-4499-498d-9721-b1fd70ea84b4.jpg?1",
             "name": "Epiphany Storm",
             "text": "Enchant creature\nEnchanted creature has \"{R}, {T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "b0e8f09f-8ed7-5673-ad3a-adc1dba03324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018d5ea-5229-40ca-b7c5-31d3e8ebb894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018d5ea-5229-40ca-b7c5-31d3e8ebb894.jpg?1",
             "name": "Everflame Eidolon",
             "text": "Bestow {2}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\n{R}: Everflame Eidolon gets +1/+0 until end of turn. If it's an Aura, enchanted creature gets +1/+0 until end of turn instead.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -3125,7 +3125,7 @@
         },
         {
             "id": "6aa7cb07-f01a-58a4-b5a9-f3eab81ac4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1a4b-db3b-4dfc-8d3a-cc73b011a5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1a4b-db3b-4dfc-8d3a-cc73b011a5dd.jpg?1",
             "name": "Fall of the Hammer",
             "text": "Target creature you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "d085cab1-bfe8-5bc1-8cd5-226744d3f3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ea1aeb-bd42-4960-b40f-e7c2fd1efb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ea1aeb-bd42-4960-b40f-e7c2fd1efb5c.jpg?1",
             "name": "Fated Conflagration",
             "text": "Fated Conflagration deals 5 damage to target creature or planeswalker. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3189,7 +3189,7 @@
         },
         {
             "id": "65c167f0-d98a-51fc-98bc-24a41ad8fb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e7884c-2d66-42d1-87d1-1341a6fa52d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e7884c-2d66-42d1-87d1-1341a6fa52d8.jpg?1",
             "name": "Fearsome Temper",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{2}{R}: Target creature can't block this creature this turn.\"",
             "colours": [
@@ -3223,7 +3223,7 @@
         },
         {
             "id": "d7adc072-e896-559d-8d68-12b5925e4375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbe4ce-d6a6-428d-aeee-1c316f358777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbe4ce-d6a6-428d-aeee-1c316f358777.jpg?1",
             "name": "Felhide Spiritbinder",
             "text": "Inspired \u2014 Whenever Felhide Spiritbinder becomes untapped, you may pay {1}{R}. If you do, put a token onto the battlefield that's a copy of another target creature except it's an enchantment in addition to its other types. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "867f7bf6-8c71-517d-b467-3cafd61cdabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36bca58-e92f-4496-92d6-5ecba7a0424d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36bca58-e92f-4496-92d6-5ecba7a0424d.jpg?1",
             "name": "Flame-Wreathed Phoenix",
             "text": "Flying\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Flame-Wreathed Phoenix enters the battlefield, if tribute wasn't paid, it gains haste and \"When this creature dies, return it to its owner's hand.\"",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "7042f764-fd09-500c-bd3d-64c572a516c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd44170-ded7-4895-8950-bfa9d19e471d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd44170-ded7-4895-8950-bfa9d19e471d.jpg?1",
             "name": "Forgestoker Dragon",
             "text": "Flying\n{1}{R}: Forgestoker Dragon deals 1 damage to target creature. That creature can't block this combat. Activate this ability only if Forgestoker Dragon is attacking.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "5ccfe18e-1ec9-5f5d-a74c-3dd7310b52b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d4c13b-95ef-49df-b349-26e0fec109ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d4c13b-95ef-49df-b349-26e0fec109ad.jpg?1",
             "name": "Impetuous Sunchaser",
             "text": "Flying, haste\nImpetuous Sunchaser attacks each turn if able.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "02603a60-b864-5455-ad31-b59f844a5f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d1dcab-7e46-4ff1-91f6-77352ef0cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d1dcab-7e46-4ff1-91f6-77352ef0cd90.jpg?1",
             "name": "Kragma Butcher",
             "text": "Inspired \u2014 Whenever Kragma Butcher becomes untapped, it gets +2/+0 until end of turn.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "b972c1aa-98a7-59bc-8781-630ff55635d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af8746-033d-4a8a-b62d-ab5addb33d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af8746-033d-4a8a-b62d-ab5addb33d4d.jpg?1",
             "name": "Lightning Volley",
             "text": "Until end of turn, creatures you control gain \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "909de1d7-4e56-5e47-ab35-2efe95e4e82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2081bf0-09f5-4c95-b4cc-48a8784294d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2081bf0-09f5-4c95-b4cc-48a8784294d4.jpg?1",
             "name": "Nyxborn Rollicker",
             "text": "Bestow {1}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "00af3c5b-10f5-5717-b693-f7694e0cf04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb1931e-c282-47a7-9382-608de6ec8efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb1931e-c282-47a7-9382-608de6ec8efa.jpg?1",
             "name": "Oracle of Bones",
             "text": "Haste\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Oracle of Bones enters the battlefield, if tribute wasn't paid, you may cast an instant or sorcery card from your hand without paying its mana cost.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "b9e2d3bd-3c60-5094-80bb-693a9a6d3bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef1b9b-58f1-40af-a7c2-06cdaf1ec974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef1b9b-58f1-40af-a7c2-06cdaf1ec974.jpg?1",
             "name": "Pharagax Giant",
             "text": "Tribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Pharagax Giant enters the battlefield, if tribute wasn't paid, Pharagax Giant deals 5 damage to each opponent.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "e1223246-d1d2-5f8a-b7e3-39388113d2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26ff2fa-82de-4831-9341-a446abf9ed03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26ff2fa-82de-4831-9341-a446abf9ed03.jpg?1",
             "name": "Pinnacle of Rage",
             "text": "Pinnacle of Rage deals 3 damage to each of two target creatures and/or players.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "3719fe63-11be-58f9-a273-64954247e800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188adefd-a808-4991-80be-53249c24df8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188adefd-a808-4991-80be-53249c24df8f.jpg?1",
             "name": "Reckless Reveler",
             "text": "{R}, Sacrifice Reckless Reveler: Destroy target artifact.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "063c1bcc-e0aa-594e-8951-8a3784cf2cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c656ad1b-e85b-4b0c-b538-506afe4a9da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c656ad1b-e85b-4b0c-b538-506afe4a9da5.jpg?1",
             "name": "Rise to the Challenge",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "696dcf3e-f699-539b-a55b-d7fff1fbd7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc6a735-cbf5-4af2-b15c-7ced82f0d9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc6a735-cbf5-4af2-b15c-7ced82f0d9da.jpg?1",
             "name": "Satyr Firedancer",
             "text": "Whenever an instant or sorcery spell you control deals damage to an opponent, Satyr Firedancer deals that much damage to target creature that player controls.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "b574f80d-ec4b-5c69-abda-1ed52c1d2cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2c65e-3cba-4813-9949-87e15f592247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2c65e-3cba-4813-9949-87e15f592247.jpg?1",
             "name": "Satyr Nyx-Smith",
             "text": "Haste\nInspired \u2014 Whenever Satyr Nyx-Smith becomes untapped, you may pay {2}{R}. If you do, put a 3/1 red Elemental enchantment creature token with haste onto the battlefield.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "08a176d1-54d1-55ea-97fe-47abf3779ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273f25fc-9c9f-4b73-a28b-1461d8fcd443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273f25fc-9c9f-4b73-a28b-1461d8fcd443.jpg?1",
             "name": "Scouring Sands",
             "text": "Scouring Sands deals 1 damage to each creature your opponents control. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "922ca516-0583-5f72-a6f1-25d5c238bd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb43fd07-d281-447d-88bf-c53498c2cf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb43fd07-d281-447d-88bf-c53498c2cf20.jpg?1",
             "name": "Searing Blood",
             "text": "Searing Blood deals 2 damage to target creature. When that creature dies this turn, Searing Blood deals 3 damage to the creature's controller.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "37390117-7a90-5db7-bc2d-1b1fec3e3d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397bdc3-a866-45be-8740-185d9ccf29c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397bdc3-a866-45be-8740-185d9ccf29c4.jpg?1",
             "name": "Stormcaller of Keranos",
             "text": "Haste\n{1}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "a2788f9a-3555-52d6-a888-25a9ed7dec73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fa4f8-4b87-41dc-802d-dfd160ccf1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fa4f8-4b87-41dc-802d-dfd160ccf1a8.jpg?1",
             "name": "Thunder Brute",
             "text": "Trample\nTribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Thunder Brute enters the battlefield, if tribute wasn't paid, it gains haste until end of turn.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "dea8afd8-dba7-5506-98a6-5b0143874bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d361851d-e2d4-4912-ba08-81913f6b6e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d361851d-e2d4-4912-ba08-81913f6b6e08.jpg?1",
             "name": "Thunderous Might",
             "text": "Enchant creature\nWhenever enchanted creature attacks, it gets +X/+0 until end of turn, where X is your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "7cc99945-396b-5962-b6c1-6cc03e9d7c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ef2fc3-0072-450b-acab-7d19c4903128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ef2fc3-0072-450b-acab-7d19c4903128.jpg?1",
             "name": "Whims of the Fates",
             "text": "Starting with you, each player separates all permanents he or she controls into three piles. Then each player chooses one of his or her piles at random and sacrifices those permanents. (Piles can be empty.)",
             "colours": [
@@ -3900,7 +3900,7 @@
         },
         {
             "id": "b3e3f707-d114-5407-bacb-6f9c58223ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3145ca68-7a9d-4161-9456-518591251b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3145ca68-7a9d-4161-9456-518591251b56.jpg?1",
             "name": "Archetype of Endurance",
             "text": "Creatures you control have hexproof.\nCreatures your opponents control lose hexproof and can't have or gain hexproof.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "b345370e-820c-5cca-97ae-d69240c29bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19353629-07be-47e2-a7d5-3a5e5e1120c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19353629-07be-47e2-a7d5-3a5e5e1120c8.jpg?1",
             "name": "Aspect of Hydra",
             "text": "Target creature gets +X/+X until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "7e2daa7c-5ba0-58b4-b73e-d06cfe8a62bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d88ad54-43fc-45e0-8e00-db6be0c021ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d88ad54-43fc-45e0-8e00-db6be0c021ea.jpg?1",
             "name": "Charging Badger",
             "text": "Trample",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "897132b6-0460-510a-a3c0-8cc688f72d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5a807f-58e8-4d92-a61c-47bb9b28977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5a807f-58e8-4d92-a61c-47bb9b28977f.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library if it's a land card.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -4036,7 +4036,7 @@
         },
         {
             "id": "95c4d602-bcc8-5e42-9667-1d4761712595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c45eda-9f00-4b40-b91d-0ed00151923c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c45eda-9f00-4b40-b91d-0ed00151923c.jpg?1",
             "name": "Culling Mark",
             "text": "Target creature blocks this turn if able.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "ade2ef5f-321a-5b77-b75e-75f15108e83b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e1afc-0d06-4c01-abef-3b3e93bd21c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e1afc-0d06-4c01-abef-3b3e93bd21c3.jpg?1",
             "name": "Fated Intervention",
             "text": "Put two 3/3 green Centaur enchantment creature tokens onto the battlefield. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "2c70d499-da91-5b27-acf8-9d1619d0baa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41810472-ba24-44b6-886c-f8906ff0a7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41810472-ba24-44b6-886c-f8906ff0a7df.jpg?1",
             "name": "Graverobber Spider",
             "text": "Reach\n{3}{B}: Graverobber Spider gets +X/+X until end of turn, where X is the number of creature cards in your graveyard. Activate this ability only once each turn.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "ed88ce51-91c6-5956-b18a-ec4b4f5dc979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f022c0c3-6331-47be-b07f-9768930afd3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f022c0c3-6331-47be-b07f-9768930afd3a.jpg?1",
             "name": "Hero of Leina Tower",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Hero of Leina Tower, you may pay {X}. If you do, put X +1/+1 counters on Hero of Leina Tower.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "3688309e-9583-573c-a0a3-741c6c63b75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2323c-3e35-4ac6-9f07-2c0584371f9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2323c-3e35-4ac6-9f07-2c0584371f9e.jpg?1",
             "name": "Hunter's Prowess",
             "text": "Until end of turn, target creature gets +3/+3 and gains trample and \"Whenever this creature deals combat damage to a player, draw that many cards.\"",
             "colours": [
@@ -4202,7 +4202,7 @@
         },
         {
             "id": "f2e31c93-659f-56ad-9342-57b22603bfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc036932-38c2-42df-9922-2d901028f2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc036932-38c2-42df-9922-2d901028f2b8.jpg?1",
             "name": "Karametra's Favor",
             "text": "Enchant creature\nWhen Karametra's Favor enters the battlefield, draw a card.\nEnchanted creature has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -4236,7 +4236,7 @@
         },
         {
             "id": "f9a71860-d8c2-5b42-bf31-4ed94ef91be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daa44b4-5c30-41d8-b4d6-6219c5729a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daa44b4-5c30-41d8-b4d6-6219c5729a5f.jpg?1",
             "name": "Mischief and Mayhem",
             "text": "Up to two target creatures each get +4/+4 until end of turn.",
             "colours": [
@@ -4268,7 +4268,7 @@
         },
         {
             "id": "84b83d03-2307-5540-83f4-ac1f793a8609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a96b4-393d-4e8e-9b6a-f15f3804febb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a96b4-393d-4e8e-9b6a-f15f3804febb.jpg?1",
             "name": "Mortal's Resolve",
             "text": "Target creature gets +1/+1 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "72aa5025-b6c3-5afb-b07a-0d7451814d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0683b2-8bc2-4c6a-964e-b909693b68c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0683b2-8bc2-4c6a-964e-b909693b68c1.jpg?1",
             "name": "Nessian Demolok",
             "text": "Tribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Nessian Demolok enters the battlefield, if tribute wasn't paid, destroy target noncreature permanent.",
             "colours": [
@@ -4334,7 +4334,7 @@
         },
         {
             "id": "cd257775-3720-5e3b-8427-088b53b6c5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65368cf0-7d92-4248-b930-633fd023065b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65368cf0-7d92-4248-b930-633fd023065b.jpg?1",
             "name": "Nessian Wilds Ravager",
             "text": "Tribute 6 (As this creature enters the battlefield, an opponent of your choice may place six +1/+1 counters on it.)\nWhen Nessian Wilds Ravager enters the battlefield, if tribute wasn't paid, you may have Nessian Wilds Ravager fight another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4368,7 +4368,7 @@
         },
         {
             "id": "ff5d9e61-8404-5b9c-9997-540f212f1c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8447c3-4fce-4971-a3d7-e5671fe269f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8447c3-4fce-4971-a3d7-e5671fe269f5.jpg?1",
             "name": "Noble Quarry",
             "text": "Bestow {5}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nAll creatures able to block Noble Quarry or enchanted creature do so.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "1daddee5-4014-58ef-87a7-ce55c7d7fb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a78895-5e09-46a5-8a74-a07f0befc4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a78895-5e09-46a5-8a74-a07f0befc4e5.jpg?1",
             "name": "Nyxborn Wolf",
             "text": "Bestow {4}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "df31913c-4c8b-5afa-ac2a-c9722e18d23f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03835e3e-9fd1-47c7-86a5-a5481420f2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03835e3e-9fd1-47c7-86a5-a5481420f2d3.jpg?1",
             "name": "Peregrination",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle your library, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4470,7 +4470,7 @@
         },
         {
             "id": "99fc35eb-aa50-5a35-9305-a9b0cacc7d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80856020-f569-4d73-8c44-7b48535a69e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80856020-f569-4d73-8c44-7b48535a69e8.jpg?1",
             "name": "Pheres-Band Raiders",
             "text": "Inspired \u2014 Whenever Pheres-Band Raiders becomes untapped, you may pay {2}{G}. If you do, put a 3/3 green Centaur enchantment creature token onto the battlefield.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "84cc01d8-5c49-585e-ae20-660f46366a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d7e7d1-70ee-450b-8018-ff373cc91c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d7e7d1-70ee-450b-8018-ff373cc91c68.jpg?1",
             "name": "Pheres-Band Tromper",
             "text": "Inspired \u2014 Whenever Pheres-Band Tromper becomes untapped, put a +1/+1 counter on it.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "f6b00717-3490-58ed-9069-493513cbe8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaace7-86e2-427e-97b1-b09dfdd30fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaace7-86e2-427e-97b1-b09dfdd30fee.jpg?1",
             "name": "Raised by Wolves",
             "text": "Enchant creature\nWhen Raised by Wolves enters the battlefield, put two 2/2 green Wolf creature tokens onto the battlefield.\nEnchanted creature gets +1/+1 for each Wolf you control.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "5b845020-6cac-5603-951f-6065c8d5ef61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c5a1ce-932a-4b3d-8b86-ed920e646afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c5a1ce-932a-4b3d-8b86-ed920e646afc.jpg?1",
             "name": "Satyr Wayfinder",
             "text": "When Satyr Wayfinder enters the battlefield, reveal the top four cards of your library. You may put a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "3661b920-66cc-5996-8245-883bbdb949ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef76dc-7cef-449b-b8a7-e038887129d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef76dc-7cef-449b-b8a7-e038887129d9.jpg?1",
             "name": "Scourge of Skola Vale",
             "text": "Trample\nScourge of Skola Vale enters the battlefield with two +1/+1 counters on it.\n{T}, Sacrifice another creature: Put a number of +1/+1 counters on Scourge of Skola Vale equal to the sacrificed creature's toughness.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "a9065f87-1497-5341-8320-9657e782d44a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5579755-4718-406a-bba6-27f1f2811e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5579755-4718-406a-bba6-27f1f2811e59.jpg?1",
             "name": "Setessan Oathsworn",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Setessan Oathsworn, put two +1/+1 counters on Setessan Oathsworn.",
             "colours": [
@@ -4677,7 +4677,7 @@
         },
         {
             "id": "1cc722ee-57e2-511c-b66a-88c5f7626ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03af8b3b-a897-43e2-a87d-833da93edc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03af8b3b-a897-43e2-a87d-833da93edc41.jpg?1",
             "name": "Setessan Starbreaker",
             "text": "When Setessan Starbreaker enters the battlefield, you may destroy target Aura.",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "15e465fc-65b9-5536-8bd3-0334ecf1ee1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb76b3-b527-4ed8-8ce3-d3de48562b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb76b3-b527-4ed8-8ce3-d3de48562b6e.jpg?1",
             "name": "Skyreaping",
             "text": "Skyreaping deals damage to each creature with flying equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -4744,7 +4744,7 @@
         },
         {
             "id": "37ab165d-3c3b-5dcb-ba42-afb95a2072d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b10bd7-3f8b-426f-acdf-5a9559b9bc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b10bd7-3f8b-426f-acdf-5a9559b9bc7d.jpg?1",
             "name": "Snake of the Golden Grove",
             "text": "Tribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Snake of the Golden Grove enters the battlefield, if tribute wasn't paid, you gain 4 life.",
             "colours": [
@@ -4778,7 +4778,7 @@
         },
         {
             "id": "5d2d0e87-9222-576f-99f2-42f38223f048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776ebd7-91fc-49e1-a978-f2012162d1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776ebd7-91fc-49e1-a978-f2012162d1cf.jpg?1",
             "name": "Swordwise Centaur",
             "text": "",
             "colours": [
@@ -4813,7 +4813,7 @@
         },
         {
             "id": "d86e50e4-c17f-59e7-9822-09b23e4c1a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5584c26f-62ac-4d0b-9142-5159f2a05734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5584c26f-62ac-4d0b-9142-5159f2a05734.jpg?1",
             "name": "Unravel the Aether",
             "text": "Choose target artifact or enchantment. Its owner shuffles it into his or her library.",
             "colours": [
@@ -4845,7 +4845,7 @@
         },
         {
             "id": "6ed339bb-b893-5023-9f11-64eca630cd7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d171b46-69e7-4e39-b3b2-97ed022cd933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d171b46-69e7-4e39-b3b2-97ed022cd933.jpg?1",
             "name": "Chromanticore",
             "text": "Bestow {2}{W}{U}{B}{R}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying, first strike, vigilance, trample, lifelink\nEnchanted creature gets +4/+4 and has flying, first strike, vigilance, trample, and lifelink.",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "a89eaec2-e0a0-5b81-a9c8-5c0573ce812c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6832e495-7ee9-43e0-94ea-03c88344080e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6832e495-7ee9-43e0-94ea-03c88344080e.jpg?1",
             "name": "Ephara, God of the Polis",
             "text": "Indestructible\nAs long as your devotion to white and blue is less than seven, Ephara isn't a creature.\nAt the beginning of each upkeep, if you had another creature enter the battlefield under your control last turn, draw a card.",
             "colours": [
@@ -4927,7 +4927,7 @@
         },
         {
             "id": "8d832a0c-f85b-52e7-b190-cdc8e4052089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e480d04-9a35-463e-928e-8da3556629e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e480d04-9a35-463e-928e-8da3556629e6.jpg?1",
             "name": "Ephara's Enlightenment",
             "text": "Enchant creature\nWhen Ephara's Enlightenment enters the battlefield, put a +1/+1 counter on enchanted creature.\nEnchanted creature has flying.\nWhenever a creature enters the battlefield under your control, you may return Ephara's Enlightenment to its owner's hand.",
             "colours": [
@@ -4963,7 +4963,7 @@
         },
         {
             "id": "d09dfc5c-83e1-5b3f-911b-bfb0b5c21602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3687799c-81bd-4c49-902a-2a96863629c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3687799c-81bd-4c49-902a-2a96863629c3.jpg?1",
             "name": "Fanatic of Xenagos",
             "text": "Trample\nTribute 1 (As this creature enters the battlefield, an opponent of your choice may place a +1/+1 counter on it.)\nWhen Fanatic of Xenagos enters the battlefield, if tribute wasn't paid, it gets +1/+1 and gains haste until end of turn.",
             "colours": [
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "02766927-49dc-5d68-814a-9a7cad3c4d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74050cb3-ba99-475d-9124-726e498fb68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74050cb3-ba99-475d-9124-726e498fb68e.jpg?1",
             "name": "Karametra, God of Harvests",
             "text": "Indestructible\nAs long as your devotion to green and white is less than seven, Karametra isn't a creature.\nWhenever you cast a creature spell, you may search your library for a Forest or Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "b772d54e-ad34-53fa-a92a-e413fbb06eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77ac7fa-718d-425f-a0aa-2f8e2bfc0950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77ac7fa-718d-425f-a0aa-2f8e2bfc0950.jpg?1",
             "name": "Kiora, the Crashing Wave",
             "text": "+1: Until your next turn, prevent all damage that would be dealt to and dealt by target permanent an opponent controls.\n-1: Draw a card. You may play an additional land this turn.\n-5: You get an emblem with \"At the beginning of your end step, put a 9/9 blue Kraken creature token onto the battlefield.\"",
             "colours": [
@@ -5077,7 +5077,7 @@
         },
         {
             "id": "8f87b5e9-eb91-57e4-8b26-f2746125992c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ce307-8ec3-4db6-a4a3-49f92ebcc783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ce307-8ec3-4db6-a4a3-49f92ebcc783.jpg?1",
             "name": "Kiora's Follower",
             "text": "{T}: Untap another target permanent.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "fdf8e38f-b2e8-55b9-8ef4-3308d81d99b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0417bf-b735-46d7-9985-2d991051020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0417bf-b735-46d7-9985-2d991051020f.jpg?1",
             "name": "Mogis, God of Slaughter",
             "text": "Indestructible\nAs long as your devotion to black and red is less than seven, Mogis isn't a creature.\nAt the beginning of each opponent's upkeep, Mogis deals 2 damage to that player unless he or she sacrifices a creature.",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "af4897c3-9895-5af4-b16b-3d458618d3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfcb129-4665-40e4-b5cb-a79f3f40ae5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfcb129-4665-40e4-b5cb-a79f3f40ae5c.jpg?1",
             "name": "Phenax, God of Deception",
             "text": "Indestructible\nAs long as your devotion to blue and black is less than seven, Phenax isn't a creature.\nCreatures you control have \"{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is this creature's toughness.\"",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "224b8893-d896-5aa7-a8dd-fbb8bfb2751a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb6eda2-e3df-440a-8900-8310f11db6e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb6eda2-e3df-440a-8900-8310f11db6e9.jpg?1",
             "name": "Ragemonger",
             "text": "Minotaur spells you cast cost {B}{R} less to cast. This effect reduces only the amount of colored mana you pay. (For example, if you cast a Minotaur spell with mana cost {2}{R}, it costs {2} to cast.)",
             "colours": [
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "1d034529-2a15-51e0-82d6-9ccf51cd11a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120babed-841f-4bf1-ac2d-3ab097c0760b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120babed-841f-4bf1-ac2d-3ab097c0760b.jpg?1",
             "name": "Reap What Is Sown",
             "text": "Put a +1/+1 counter on each of up to three target creatures.",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "a6e41a1d-de32-5038-8e3d-1310461840df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4438-aa74-4460-8bac-93480d0bb0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4438-aa74-4460-8bac-93480d0bb0dc.jpg?1",
             "name": "Siren of the Silent Song",
             "text": "Flying\nInspired \u2014 Whenever Siren of the Silent Song becomes untapped, each opponent discards a card, then puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "e2b02aff-5f55-580b-8cd0-2f809a7d0661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3184b138-1109-4195-9d96-4f190164e98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3184b138-1109-4195-9d96-4f190164e98b.jpg?1",
             "name": "Xenagos, God of Revels",
             "text": "Indestructible\nAs long as your devotion to red and green is less than seven, Xenagos isn't a creature.\nAt the beginning of combat on your turn, another target creature you control gains haste and gets +X/+X until end of turn, where X is that creature's power.",
             "colours": [
@@ -5338,7 +5338,7 @@
         },
         {
             "id": "51d295e7-3633-5a64-aca8-bdf63a4cb0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b8011-c712-418f-869e-42fda3dc0830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b8011-c712-418f-869e-42fda3dc0830.jpg?1",
             "name": "Astral Cornucopia",
             "text": "Astral Cornucopia enters the battlefield with X charge counters on it.\n{T}: Choose a color. Add one mana of that color to your mana pool for each charge counter on Astral Cornucopia.",
             "colours": [],
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "dc9db0bf-b559-51ad-82b8-b37b12f15f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745dd92-9f7a-44a4-a27f-2ff17753db1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745dd92-9f7a-44a4-a27f-2ff17753db1c.jpg?1",
             "name": "Gorgon's Head",
             "text": "Equipped creature has deathtouch.\nEquip {2}",
             "colours": [],
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "2a939a80-1e1d-5c58-b521-8841e31f672d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb14f9-343c-4672-b4ee-db7f1d1a98ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb14f9-343c-4672-b4ee-db7f1d1a98ff.jpg?1",
             "name": "Heroes' Podium",
             "text": "Each legendary creature you control gets +1/+1 for each other legendary creature you control.\n{X}, {T}: Look at the top X cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "32bf336e-56d3-5a7d-abd3-ec151ec4562b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c1371b-ffec-41c7-8fc1-acb2bd538080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c1371b-ffec-41c7-8fc1-acb2bd538080.jpg?1",
             "name": "Pillar of War",
             "text": "Defender\nAs long as Pillar of War is enchanted, it can attack as though it didn't have defender.",
             "colours": [],
@@ -5457,7 +5457,7 @@
         },
         {
             "id": "09ca1b6a-51f9-57b8-914c-e360fabe1866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfeca720-3163-4391-b90d-5f7aa5f5987b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfeca720-3163-4391-b90d-5f7aa5f5987b.jpg?1",
             "name": "Siren Song Lyre",
             "text": "Equipped creature has \"{2}, {T}: Tap target creature.\"\nEquip {2}",
             "colours": [],
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "adc5b382-479d-534d-9c2d-b17c9e0c6d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9d645-0220-4a65-bbc7-abc64ded548e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9d645-0220-4a65-bbc7-abc64ded548e.jpg?1",
             "name": "Springleaf Drum",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5515,7 +5515,7 @@
         },
         {
             "id": "d14a1b79-8da7-5133-bda5-bfd54d5afa97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c657a645-f454-4eaf-be0d-15c9989fa4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c657a645-f454-4eaf-be0d-15c9989fa4ef.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -5546,7 +5546,7 @@
         },
         {
             "id": "2673338f-90cb-5133-85be-b6c8669048a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f50818-aede-4667-883a-e0339d86d870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f50818-aede-4667-883a-e0339d86d870.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "9f0b77e5-1875-5c2d-bb5a-7feb8a1ad33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0830054-b140-49c3-90cb-24e2502757be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0830054-b140-49c3-90cb-24e2502757be.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "5be401dd-cfeb-5052-bd97-62670082329d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862470b-f273-4e01-945b-bf3697cd1359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862470b-f273-4e01-945b-bf3697cd1359.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "d8a7431e-3edd-5b15-8b6f-e62203a3ae4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921d6192-6b6d-4aa1-be80-bc0b9f503e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921d6192-6b6d-4aa1-be80-bc0b9f503e33.jpg?1",
             "name": "Cat Soldier",
             "text": "",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "f004576c-fc48-53cb-88a9-56b336d0576a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f90245-fa63-48b2-a20a-8a6f00dd5853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f90245-fa63-48b2-a20a-8a6f00dd5853.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "2fb5a9ca-1d6f-5b51-9a54-a1d765e9a33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6ce21f-2a29-480e-91f9-b089232863ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6ce21f-2a29-480e-91f9-b089232863ff.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "ed4c8fc4-0156-5a7d-afa1-5291f3850694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9576efe-03eb-49da-bb00-5bf8e50877fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9576efe-03eb-49da-bb00-5bf8e50877fb.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "109dee31-0fa6-5f4a-b5c4-3ae29a8a79ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa525567-24f3-4ad4-b0b2-3b09d87cd106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa525567-24f3-4ad4-b0b2-3b09d87cd106.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "ba2d3c4f-49dd-56d4-bb45-bccd35b323a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e5fee3-6dd9-4bbe-b64d-ddfa4b9d4256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e5fee3-6dd9-4bbe-b64d-ddfa4b9d4256.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "f71ba2ee-cd84-56f4-9735-017ede02cedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985be507-6125-4db2-b99f-8b61149ffeeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985be507-6125-4db2-b99f-8b61149ffeeb.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -5886,7 +5886,7 @@
         },
         {
             "id": "54343ae9-3769-5833-a9fd-e4f53a0f17fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8958b650-c831-4499-813b-5699954ab2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8958b650-c831-4499-813b-5699954ab2f0.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "22a28f99-386e-5b4c-98b1-ce589600b6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8298e-5ce6-4ff6-9563-fcd158ce841e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8298e-5ce6-4ff6-9563-fcd158ce841e.jpg?1",
             "name": "Gold",
             "text": "",
             "colours": [],
@@ -5950,7 +5950,7 @@
         },
         {
             "id": "77f2b6f0-6c4b-54ad-82fc-81f979872e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45f7850-2ebb-4530-9859-f87b4e0e27be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45f7850-2ebb-4530-9859-f87b4e0e27be.jpg?1",
             "name": "Kiora, the Crashing Wave Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/BOK.json
+++ b/Assets/Resources/Sets/BOK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "44e15b78-f2ee-5eba-b6cc-e0b2b3ee6026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f49ff1-54f6-4825-987b-c50a152f7275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f49ff1-54f6-4825-987b-c50a152f7275.jpg?1",
             "name": "Day of Destiny",
             "text": "Legendary creatures you control get +2/+2.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "0e8f777c-b8b6-50b0-91a8-c186be7ecb90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c2e405-afe2-4de2-9e45-c5f357d788ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c2e405-afe2-4de2-9e45-c5f357d788ac.jpg?1",
             "name": "Empty-Shrine Kannushi",
             "text": "Empty-Shrine Kannushi has protection from the colors of permanents you control.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "7472759d-0b05-53ef-8053-951448d5d2c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg?1",
             "name": "Faithful Squire // Kaiso, Memory of Loyalty",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Faithful Squire.\nAt end of turn, if there are two or more ki counters on Faithful Squire, you may flip it.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "74d83cb0-c66c-56e3-9f04-c73e54e5d855",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg?1",
             "name": "Faithful Squire // Kaiso, Memory of Loyalty",
             "text": "Flying\nRemove a ki counter from Kaiso, Memory of Loyalty: Prevent all damage that would be dealt to target creature this turn.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "e9af55f4-8aca-5d98-b19f-371b64d9bb35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2503e136-031f-498a-b042-4077baebe8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2503e136-031f-498a-b042-4077baebe8f8.jpg?1",
             "name": "Final Judgment",
             "text": "Remove all creatures from the game.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "4b69e6f6-0cbc-5b49-bc9f-91135635105a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cf9142-be8e-48d8-a1b4-9a7fb71718d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cf9142-be8e-48d8-a1b4-9a7fb71718d0.jpg?1",
             "name": "Genju of the Fields",
             "text": "{2}: Until end of turn, enchanted Plains becomes a 2/5 white Spirit creature with \"Whenever this creature deals damage, you gain that much life.\" It's still a land.\nWhen enchanted Plains is put into a graveyard, you may return Genju of the Fields from your graveyard to your hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "abb0aa58-dbb2-5e82-b39e-868662b172bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8566f5e-0ec5-4c9b-8b5b-4e580b20522a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8566f5e-0ec5-4c9b-8b5b-4e580b20522a.jpg?1",
             "name": "Heart of Light",
             "text": "Prevent all damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "65e745cd-f2e9-528a-8563-01748c8d669f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a03f5d5-d5c3-4a7d-8d44-e60b498b4ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a03f5d5-d5c3-4a7d-8d44-e60b498b4ed5.jpg?1",
             "name": "Hokori, Dust Drinker",
             "text": "Lands don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player untaps a land he or she controls.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "c9711bcb-fd9a-58a4-9a33-694bd789747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed548e0-9196-4bfc-9cfd-149abb945574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed548e0-9196-4bfc-9cfd-149abb945574.jpg?1",
             "name": "Hundred-Talon Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nSplice onto Arcane\u2014\nTap an untapped white creature you control. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "3a0665bc-c6b4-5be0-bb0f-e9d478b49148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb03bc2b-6d39-4315-964c-ca7db2db054a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb03bc2b-6d39-4315-964c-ca7db2db054a.jpg?1",
             "name": "Indebted Samurai",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever a Samurai you control is put into a graveyard from play, you may put a +1/+1 counter on Indebted Samurai.",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "e3d31de2-7ce0-55e0-b8b7-59b7590f97ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e4f5e6-935e-429f-89b4-4571376f442e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e4f5e6-935e-429f-89b4-4571376f442e.jpg?1",
             "name": "Kami of False Hope",
             "text": "Sacrifice Kami of False Hope: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "42cf19d0-174e-53ee-a5bf-d5143a1043cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6deb57-4ee3-4716-8644-28283704f994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6deb57-4ee3-4716-8644-28283704f994.jpg?1",
             "name": "Kami of Tattered Shoji",
             "text": "Whenever you play a Spirit or Arcane spell, Kami of Tattered Shoji gains flying until end of turn.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "728fa79b-9561-5ffe-bbfd-22fbe85bd79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e53299-f480-4769-bfc6-86fb19964280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e53299-f480-4769-bfc6-86fb19964280.jpg?1",
             "name": "Kami of the Honored Dead",
             "text": "Flying\nWhenever Kami of the Honored Dead is dealt damage, you gain that much life.\nSoulshift 6 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 6 or less from your graveyard to your hand.)",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "81b0531a-f530-5711-9d73-940db29f6b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcea3b3-5852-4ae1-a952-7b392564cb9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcea3b3-5852-4ae1-a952-7b392564cb9d.jpg?1",
             "name": "Kentaro, the Smiling Cat",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nYou may pay {X} rather than pay the mana cost for Samurai spells you play, where X is that spell's converted mana cost.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "a1d9bd80-5870-5ebc-9b00-ff2bdd261aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb981f8b-4f03-4fd2-a255-b10635958bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb981f8b-4f03-4fd2-a255-b10635958bfd.jpg?1",
             "name": "Kitsune Palliator",
             "text": "{T}: Prevent the next 1 damage that would be dealt to each creature and each player this turn.",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "29af53f2-90a2-50a1-9357-e11ff4c65f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ba253-fb50-4240-8129-6b86895d1ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ba253-fb50-4240-8129-6b86895d1ff9.jpg?1",
             "name": "Mending Hands",
             "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "95b3b9a4-dddf-5b57-b298-d9241c6dbc23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d39ff1-402c-4218-ad42-276a22c087a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d39ff1-402c-4218-ad42-276a22c087a7.jpg?1",
             "name": "Moonlit Strider",
             "text": "Sacrifice Moonlit Strider: Target creature you control gains protection from the color of your choice until end of turn.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "993307b6-316d-5211-a43f-060f00f5a88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08d5618-4fe0-4ae5-af16-696467aae02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08d5618-4fe0-4ae5-af16-696467aae02d.jpg?1",
             "name": "Opal-Eye, Konda's Yojimbo",
             "text": "Bushido 1; defender (This creature can't attack.)\n{T}: The next time a source of your choice would deal damage this turn, that damage is dealt to Opal-Eye, Konda's Yojimbo instead.\n{1}{W}: Prevent the next 1 damage that would be dealt to Opal-Eye this turn.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "7963d18a-6f55-5173-b56b-1c24e4674598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313bd276-2f69-447e-a2b1-240cf839614a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313bd276-2f69-447e-a2b1-240cf839614a.jpg?1",
             "name": "Oyobi, Who Split the Heavens",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, put a 3/3 white Spirit creature token with flying into play.",
             "colours": [
@@ -662,7 +662,7 @@
         },
         {
             "id": "1b175fa3-cc00-5c29-abda-72798d30b66e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102ee72e-5fb8-4059-9dfa-98004e222c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102ee72e-5fb8-4059-9dfa-98004e222c27.jpg?1",
             "name": "Patron of the Kitsune",
             "text": "Fox offering (You may play this card any time you could play an instant by sacrificing a Fox and paying the difference in mana costs between this and the sacrificed Fox. Mana cost includes color.)\nWhenever a creature attacks, you may gain 1 life.",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "bda909b3-68b4-5e1a-82ed-a40601fb0133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cac762-7482-471f-b4de-e0cb6da5451c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cac762-7482-471f-b4de-e0cb6da5451c.jpg?1",
             "name": "Scour",
             "text": "Remove target enchantment from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that enchantment and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -730,7 +730,7 @@
         },
         {
             "id": "b454bcac-bed7-5773-81fd-cf2b58527f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca16f8-336a-444b-9f78-e97a3f20a3bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca16f8-336a-444b-9f78-e97a3f20a3bc.jpg?1",
             "name": "Shining Shoal",
             "text": "You may remove a white card with converted mana cost X in your hand from the game rather than pay Shining Shoal's mana cost.\nThe next X damage that a source of your choice would deal to you or a creature you control this turn is dealt to target creature or player instead.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "30faa8a4-318e-5515-ba06-ab5c887f37d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2a6d9-5848-4481-a0f9-42320ff2c230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2a6d9-5848-4481-a0f9-42320ff2c230.jpg?1",
             "name": "Silverstorm Samurai",
             "text": "You may play Silverstorm Samurai any time you could play an instant.\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "1ccf0336-a4c5-5e61-91e9-ebc0e7020b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0528fe29-f3c1-4d10-9030-053c3de57b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0528fe29-f3c1-4d10-9030-053c3de57b7b.jpg?1",
             "name": "Split-Tail Miko",
             "text": "{W}, {T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -834,7 +834,7 @@
         },
         {
             "id": "96e884ad-a136-5ef6-aad6-d2082cd37c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf9cd2e-5cf6-4959-abf2-56b686b636a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf9cd2e-5cf6-4959-abf2-56b686b636a3.jpg?1",
             "name": "Takeno's Cavalry",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{T}: Takeno's Cavalry deals 1 damage to target attacking or blocking Spirit.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "57909662-b038-5cb0-9912-b29b20e42fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018aa51-d75e-4d94-b4b3-0cd14fc87d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018aa51-d75e-4d94-b4b3-0cd14fc87d44.jpg?1",
             "name": "Tallowisp",
             "text": "Whenever you play a Spirit or Arcane spell, you may search your library for an enchant creature card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "f4e88aaf-1522-526b-bf3e-a3ae2c06d9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63cfebd-8cab-48b4-814a-4d8751dd1b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63cfebd-8cab-48b4-814a-4d8751dd1b57.jpg?1",
             "name": "Terashi's Grasp",
             "text": "Destroy target artifact or enchantment. You gain life equal to its converted mana cost.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "30e7c67c-2b64-5b17-bc88-ba114c2acea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fa34b-95c6-4e02-9e15-3f595f744741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fa34b-95c6-4e02-9e15-3f595f744741.jpg?1",
             "name": "Terashi's Verdict",
             "text": "Destroy target attacking creature with power 3 or less.",
             "colours": [
@@ -972,7 +972,7 @@
         },
         {
             "id": "004ea5e7-bd25-5fcc-a4bb-c7f619068867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73acef0c-34b1-4e04-8569-4f8d754585df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73acef0c-34b1-4e04-8569-4f8d754585df.jpg?1",
             "name": "Ward of Piety",
             "text": "{1}{W}: The next 1 damage that would be dealt to enchanted creature this turn is dealt to target creature or player instead.",
             "colours": [
@@ -1006,7 +1006,7 @@
         },
         {
             "id": "cb69d8aa-780a-5151-a403-4a4a74c3cde8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e084a-f5cb-49f5-8de2-5729d00e1aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e084a-f5cb-49f5-8de2-5729d00e1aba.jpg?1",
             "name": "Waxmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Waxmane Baku.\n{1}, Remove X ki counters from Waxmane Baku: Tap X target creatures.",
             "colours": [
@@ -1040,7 +1040,7 @@
         },
         {
             "id": "cc5d61c3-3d2a-54c4-a6ee-fc8872a3e42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f611af49-3c59-4365-a398-93f7e05ff0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f611af49-3c59-4365-a398-93f7e05ff0d0.jpg?1",
             "name": "Yomiji, Who Bars the Way",
             "text": "Whenever a legendary permanent other than Yomiji, Who Bars the Way is put into a graveyard from play, return that card to its owner's hand.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "0fe8e5c4-25ec-587a-bc60-83510ae6f2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg?1",
             "name": "Callow Jushi // Jaraku the Interloper",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Callow Jushi.\nAt end of turn, if there are two or more ki counters on Callow Jushi, you may flip it.",
             "colours": [
@@ -1111,7 +1111,7 @@
         },
         {
             "id": "54001e85-889a-5723-9998-91ec33094946",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg?1",
             "name": "Callow Jushi // Jaraku the Interloper",
             "text": "Remove a ki counter from Jaraku the Interloper: Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "e1b666a5-3dbd-58d9-ba70-d85435cc1156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c359b1a-d441-4763-96c7-e5c010eae53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c359b1a-d441-4763-96c7-e5c010eae53f.jpg?1",
             "name": "Chisei, Heart of Oceans",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Chisei, Heart of Oceans unless you remove a counter from a permanent you control.",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "4d63dd59-42e1-55d3-bba3-0c3333944234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15589745-4c0a-4edf-ad45-3b7fa45e70c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15589745-4c0a-4edf-ad45-3b7fa45e70c5.jpg?1",
             "name": "Disrupting Shoal",
             "text": "You may remove a blue card with converted mana cost X in your hand from the game rather than pay Disrupting Shoal's mana cost.\nCounter target spell if its converted mana cost is X.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "49fd6ce2-86ed-5cde-86ba-415e5ee472dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0058be07-a8a1-448e-8c3d-61718cb384ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0058be07-a8a1-448e-8c3d-61718cb384ec.jpg?1",
             "name": "Floodbringer",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Tap target land.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "bad9761e-36b3-540f-928f-9f97c8a0f154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776f97c-bd9c-4c7b-be1c-93802ce6ff6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776f97c-bd9c-4c7b-be1c-93802ce6ff6a.jpg?1",
             "name": "Genju of the Falls",
             "text": "{2}: Enchanted Island becomes a 3/2 blue Spirit creature with flying until end of turn. It's still a land.\nWhen enchanted Island is put into a graveyard, you may return Genju of the Falls from your graveyard to your hand.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "c68e6d8b-db02-519b-b272-3fe619235f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb953ffc-0e73-42a2-a026-e6d3041fd8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb953ffc-0e73-42a2-a026-e6d3041fd8ec.jpg?1",
             "name": "Heed the Mists",
             "text": "Put the top card of your library into your graveyard, then draw cards equal to that card's converted mana cost.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "3f65f1fa-2198-53a1-b0e2-488efadef92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f3cf5-f8aa-49d4-947d-76b91799547a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f3cf5-f8aa-49d4-947d-76b91799547a.jpg?1",
             "name": "Higure, the Still Wind",
             "text": "Ninjutsu {2}{U}{U} ({2}{U}{U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Higure deals combat damage to a player, you may search your library for a Ninja card, reveal it, and put it into your hand. If you do, shuffle your library.\n{2}: Target Ninja is unblockable this turn.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "dff1d79f-f144-5310-8bda-7e34fb2b7082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3015369-df39-44cb-ba16-533f7ad5824d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3015369-df39-44cb-ba16-533f7ad5824d.jpg?1",
             "name": "Jetting Glasskite",
             "text": "Flying\nWhenever Jetting Glasskite becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "72e59b01-d6fd-5ef7-a81e-40fbf47e25f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e177ce-98bf-4fbc-83d1-1f64ca5d86c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e177ce-98bf-4fbc-83d1-1f64ca5d86c6.jpg?1",
             "name": "Kaijin of the Vanishing Touch",
             "text": "Defender (This creature can't attack.)\nWhenever Kaijin of the Vanishing Touch blocks a creature, return that creature to its owner's hand at end of combat. (Return it only if it's in play.)",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "70cf308a-bdc9-563c-8ab4-dafb048bb686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc73a66f-4745-40c2-9c90-96396f6e7bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc73a66f-4745-40c2-9c90-96396f6e7bce.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.\"",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "bd249b1d-8956-5376-adfd-9ff8301a6b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93382c5e-082e-4a51-a3ec-b659cb503747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93382c5e-082e-4a51-a3ec-b659cb503747.jpg?1",
             "name": "Minamo Sightbender",
             "text": "{X}, {T}: Target creature with power X or less is unblockable this turn.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "eff51563-1a20-5bcb-925e-608eaea1b915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502c4aca-98f8-4c7d-89fd-ee42c938fac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502c4aca-98f8-4c7d-89fd-ee42c938fac7.jpg?1",
             "name": "Minamo's Meddling",
             "text": "Counter target spell. That spell's controller reveals his or her hand, then discards each card with the same name as a card spliced onto that spell.",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "3bed5fa4-4985-58b9-b7de-ff6809aff53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06f58f-0419-4637-8060-4a93670a4c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06f58f-0419-4637-8060-4a93670a4c68.jpg?1",
             "name": "Mistblade Shinobi",
             "text": "Ninjutsu {U} ({U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Mistblade Shinobi deals combat damage to a player, you may return target creature that player controls to its owner's hand.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "fcdf57bd-60ec-57f7-9699-f299f48bce75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367a67c7-54db-4336-b55a-3fa27625172a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367a67c7-54db-4336-b55a-3fa27625172a.jpg?1",
             "name": "Ninja of the Deep Hours",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Ninja of the Deep Hours deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "07d85d05-3b69-5ec6-a3a3-579f39634bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5fcd6f-1653-44bf-a796-4c9ff9adf390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5fcd6f-1653-44bf-a796-4c9ff9adf390.jpg?1",
             "name": "Patron of the Moon",
             "text": "Moonfolk offering (You may play this card any time you could play an instant by sacrificing a Moonfolk and paying the difference in mana costs between this and the sacrificed Moonfolk. Mana cost includes color.)\nFlying\n{1}: Put up to two land cards from your hand into play tapped.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "7517a4d7-45e1-5900-a7bc-00b5527f08ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96e5a18-5958-426e-892f-5c68f44c1b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96e5a18-5958-426e-892f-5c68f44c1b41.jpg?1",
             "name": "Phantom Wings",
             "text": "Enchanted creature has flying.\nSacrifice Phantom Wings: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -1668,7 +1668,7 @@
         },
         {
             "id": "ee07613c-9d1a-56e8-a49e-4db799072f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca8c31-a9ea-4388-b257-951c1c68b86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca8c31-a9ea-4388-b257-951c1c68b86d.jpg?1",
             "name": "Quash",
             "text": "Counter target instant or sorcery spell. Search its controller's graveyard, hand, and library for all cards with the same name as that spell and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "a2dc0f0a-df18-5c40-a9bd-6a3d2329a9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9140fc-9d50-4e63-aae6-1ba2974a25a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9140fc-9d50-4e63-aae6-1ba2974a25a3.jpg?1",
             "name": "Quillmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Quillmane Baku.\n{1}, {T}, Remove X ki counters from Quillmane Baku: Return target creature with converted mana cost X or less to its owner's hand.",
             "colours": [
@@ -1734,7 +1734,7 @@
         },
         {
             "id": "5b69031b-544e-5788-973c-6e633f8d29b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10962b1b-4039-4d8a-88e0-fc67537920a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10962b1b-4039-4d8a-88e0-fc67537920a9.jpg?1",
             "name": "Reduce to Dreams",
             "text": "Return all artifacts and enchantments to their owners' hands.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "d467bbe2-43cc-5625-8f2c-5c9b5733699a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a3b0da-026e-4ea9-8035-38c909e5f9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a3b0da-026e-4ea9-8035-38c909e5f9a4.jpg?1",
             "name": "Ribbons of the Reikai",
             "text": "Draw a card for each Spirit you control.",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "7fcb4df9-a6fa-53ba-b776-d4a163efe409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bfedca-5a85-41e9-94be-67ed16bd634e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bfedca-5a85-41e9-94be-67ed16bd634e.jpg?1",
             "name": "Shimmering Glasskite",
             "text": "Flying\nWhenever Shimmering Glasskite becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.",
             "colours": [
@@ -1834,7 +1834,7 @@
         },
         {
             "id": "574b3a8e-8827-5525-a62d-3b8b5602bfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c71d1c3-7a8f-404f-a448-cd5cf97ec7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c71d1c3-7a8f-404f-a448-cd5cf97ec7de.jpg?1",
             "name": "Soratami Mindsweeper",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "aeed80e7-2c70-50ba-b765-572281a3075c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499be0ce-928b-496f-9d81-4ef39752377c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499be0ce-928b-496f-9d81-4ef39752377c.jpg?1",
             "name": "Stream of Consciousness",
             "text": "Target player shuffles up to four target cards from his or her graveyard into his or her library.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "a8dd679e-ca61-5163-baf6-8ac9c0e89e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb58d9e-d181-4167-8b80-64b238183bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb58d9e-d181-4167-8b80-64b238183bdb.jpg?1",
             "name": "Sway of the Stars",
             "text": "Each player shuffles his or her hand, graveyard, and permanents he or she owns into his or her library, then draws seven cards. Each player's life total becomes 7.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "811d59a4-ff57-524d-9eae-3e9acca81ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b015ae03-c083-4e4a-b4a2-88e55aef9001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b015ae03-c083-4e4a-b4a2-88e55aef9001.jpg?1",
             "name": "Teardrop Kami",
             "text": "Sacrifice Teardrop Kami: Tap or untap target creature.",
             "colours": [
@@ -1969,7 +1969,7 @@
         },
         {
             "id": "dfc4b171-c703-5b52-b28f-aadc6d8a7453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999440a5-9659-4218-8594-1950f1155975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999440a5-9659-4218-8594-1950f1155975.jpg?1",
             "name": "Threads of Disloyalty",
             "text": "Threads of Disloyalty can enchant only a creature with converted mana cost 2 or less.\nYou control enchanted creature.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "c86bb471-cbaa-5c23-b734-a4bef4535fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0881f8bf-5c28-4f54-9080-9612790ffa83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0881f8bf-5c28-4f54-9080-9612790ffa83.jpg?1",
             "name": "Toils of Night and Day",
             "text": "Tap or untap target permanent, then tap or untap another target permanent.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "da9b0852-7f62-51cc-81a6-5de216eebbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095813f9-d559-40bd-a50f-7c1f6e494e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095813f9-d559-40bd-a50f-7c1f6e494e60.jpg?1",
             "name": "Tomorrow, Azami's Familiar",
             "text": "If you would draw a card, look at the top three cards of your library instead. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "8a32eab4-f2c9-56a1-8762-c231a28174b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ae5c2-4f97-4315-b03f-c061eed3ed79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ae5c2-4f97-4315-b03f-c061eed3ed79.jpg?1",
             "name": "Veil of Secrecy",
             "text": "Target creature is unblockable and can't be the target of spells or abilities this turn.\nSplice onto Arcane\u2014\nReturn a blue creature you control to its owner's hand. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "1fae63ea-331a-5901-ab78-a7ce51f3001d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34469923-9a48-4fa5-aff8-4e09926f039f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34469923-9a48-4fa5-aff8-4e09926f039f.jpg?1",
             "name": "Walker of Secret Ways",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Walker of Secret Ways deals combat damage to a player, look at that player's hand.\n{1}{U}: Return target Ninja you control to its owner's hand. Play this ability only during your turn.",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "9403bc97-1283-591e-8e7e-299894bed009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801c2b46-c7a7-44d6-ae38-5d34bf00c404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801c2b46-c7a7-44d6-ae38-5d34bf00c404.jpg?1",
             "name": "Bile Urchin",
             "text": "Sacrifice Bile Urchin: Target player loses 1 life.",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "cb030931-f7b2-5032-aed3-aa7003844163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba1cf-d913-4285-9d8b-38acf78cc45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba1cf-d913-4285-9d8b-38acf78cc45e.jpg?1",
             "name": "Blessing of Leeches",
             "text": "You may play Blessing of Leeches any time you could play an instant.\nAt the beginning of your upkeep, you lose 1 life.\n{0}: Regenerate enchanted creature.",
             "colours": [
@@ -2210,7 +2210,7 @@
         },
         {
             "id": "6abd8532-677d-59d2-8bd7-dfde3b1f90c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ed26-8036-4505-83d3-b782e7e1fb45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ed26-8036-4505-83d3-b782e7e1fb45.jpg?1",
             "name": "Call for Blood",
             "text": "As an additional cost to play Call for Blood, sacrifice a creature.\nTarget creature gets -X/-X until end of turn, where X is the sacrificed creature's power.",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "25993f5e-061e-53d2-933e-c606f84c5793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c735bda-5454-4177-a23a-f9f00b7480d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c735bda-5454-4177-a23a-f9f00b7480d2.jpg?1",
             "name": "Crawling Filth",
             "text": "Fear\nSoulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -2278,7 +2278,7 @@
         },
         {
             "id": "a59f0cd4-2bf4-5208-9fc1-d53d83b3293b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e0e5-798c-4791-85fe-24d0838df8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e0e5-798c-4791-85fe-24d0838df8f4.jpg?1",
             "name": "Eradicate",
             "text": "Remove target nonblack creature from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that creature and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "de39f9db-fef0-5eda-8fa6-d8965938f102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924fa2d7-ec9b-4b82-8384-0f904cb624f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924fa2d7-ec9b-4b82-8384-0f904cb624f7.jpg?1",
             "name": "Genju of the Fens",
             "text": "{2}: Until end of turn, enchanted Swamp becomes a 2/2 black Spirit creature with \"{B}: This creature gets +1/+1 until end of turn.\" It's still a land.\nWhen enchanted Swamp is put into a graveyard, you may return Genju of the Fens from your graveyard to your hand.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "a3781a4d-b87f-56e5-a686-020c23a068f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027e6c5-eed3-44e7-bb12-67569721af99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027e6c5-eed3-44e7-bb12-67569721af99.jpg?1",
             "name": "Goryo's Vengeance",
             "text": "Return target legendary creature card from your graveyard to play. That creature gains haste. Remove it from the game at end of turn.\nSplice onto Arcane {2}{B} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "4d3561d8-1289-5b13-9cf9-08c89de95e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22dd514-814f-4a62-926d-fef311896c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22dd514-814f-4a62-926d-fef311896c02.jpg?1",
             "name": "Hero's Demise",
             "text": "Destroy target legendary creature.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "f4989495-0939-544f-9b84-d7b82cb1fdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg?1",
             "name": "Hired Muscle // Scarmaker",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Hired Muscle.\nAt end of turn, if there are two or more ki counters on Hired Muscle, you may flip it.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "e417dba8-bcac-55c8-ba01-aa75de3edf73",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg?1",
             "name": "Hired Muscle // Scarmaker",
             "text": "Remove a ki counter from Scarmaker: Target creature gains fear until end of turn.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "8394398a-bddf-561f-836f-51ac3a871ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aad5179-4b73-498e-85c5-1fc363d26223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aad5179-4b73-498e-85c5-1fc363d26223.jpg?1",
             "name": "Horobi's Whisper",
             "text": "If you control a Swamp, destroy target nonblack creature.\nSplice onto Arcane\u2014\nRemove four cards in your graveyard from the game. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2515,7 +2515,7 @@
         },
         {
             "id": "ab8486a9-7eaa-5c49-a8cc-8aa32eeb13dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386d391d-a3f8-49a4-802a-409944b2acf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386d391d-a3f8-49a4-802a-409944b2acf3.jpg?1",
             "name": "Ink-Eyes, Servant of Oni",
             "text": "Ninjutsu {3}{B}{B} ({3}{B}{B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Ink-Eyes, Servant of Oni deals combat damage to a player, you may put target creature card from that player's graveyard into play under your control.\n{1}{B}: Regenerate Ink-Eyes.",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "bf08d1ec-b389-5c64-a61c-a3ea915ea019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0969e6-f667-4e29-a038-8569022cce32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0969e6-f667-4e29-a038-8569022cce32.jpg?1",
             "name": "Kyoki, Sanity's Eclipse",
             "text": "Whenever you play a Spirit or Arcane spell, target opponent removes a card in his or her hand from the game.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "ef2704d4-77e2-5711-823a-7b4c8073b191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632679e5-7368-4660-a765-07be196c3c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632679e5-7368-4660-a765-07be196c3c35.jpg?1",
             "name": "Mark of the Oni",
             "text": "You control enchanted creature.\nAt end of turn, if you control no Demons, sacrifice Mark of the Oni.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "6eac5714-9caf-5ec2-9a56-09661d9a4276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bdcdce-68fb-460b-874d-40df7afd99ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bdcdce-68fb-460b-874d-40df7afd99ca.jpg?1",
             "name": "Nezumi Shadow-Watcher",
             "text": "Sacrifice Nezumi Shadow-Watcher: Destroy target Ninja.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "2bcd8e2e-f9ec-5c6c-961b-4eba5c916a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f083bd50-d171-4e49-b8e6-972802879c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f083bd50-d171-4e49-b8e6-972802879c24.jpg?1",
             "name": "Ogre Marauder",
             "text": "Whenever Ogre Marauder attacks, it can't be blocked this turn unless defending player sacrifices a creature.",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "025600ee-74dc-515f-a985-c62a2d8ce55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9297e-301e-4e70-af9b-3218eacacf8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9297e-301e-4e70-af9b-3218eacacf8d.jpg?1",
             "name": "Okiba-Gang Shinobi",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Okiba-Gang Shinobi deals combat damage to a player, that player discards two cards.",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "4ab7451e-554f-5f51-94a6-f608e9d18343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e5d64-11ec-4eb5-8160-b2fb8a333812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e5d64-11ec-4eb5-8160-b2fb8a333812.jpg?1",
             "name": "Patron of the Nezumi",
             "text": "Rat offering (You may play this card any time you could play an instant by sacrificing a Rat and paying the difference in mana costs between this and the sacrificed Rat. Mana cost includes color.)\nWhenever a permanent is put into an opponent's graveyard, that player loses 1 life.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "081719ae-fd27-594d-996f-fe85b07242e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2f024b-e77e-426b-930e-85b87e046f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2f024b-e77e-426b-930e-85b87e046f9b.jpg?1",
             "name": "Psychic Spear",
             "text": "Target player reveals his or her hand. Choose a Spirit or Arcane card from it. That player discards that card.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "078d944e-7f95-53bf-b24d-5249edd81591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f142dea-4751-453f-93a5-c8fdaba8a1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f142dea-4751-453f-93a5-c8fdaba8a1b3.jpg?1",
             "name": "Pus Kami",
             "text": "{B}, Sacrifice Pus Kami: Destroy target nonblack creature.\nSoulshift 6 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 6 or less from your graveyard to your hand.)",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "76f8e324-724e-5f08-a584-8ca5a770c077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7692ef1-bfae-411d-a589-f493128ef44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7692ef1-bfae-411d-a589-f493128ef44b.jpg?1",
             "name": "Scourge of Numai",
             "text": "At the beginning of your upkeep, you lose 2 life if you don't control an Ogre.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "a3d5df6e-a033-5d35-a246-13e2a8e809c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7ced3-08b8-4599-9f44-3c6c8f905c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7ced3-08b8-4599-9f44-3c6c8f905c9b.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from play, you may return that creature card to play under your control at end of turn if Shirei, Shizo's Caretaker is still in play.",
             "colours": [
@@ -2901,7 +2901,7 @@
         },
         {
             "id": "8fd32306-3d4e-5efa-a38b-02488df0d191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f4129-19fc-4ee9-9e3d-77fcf1563e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f4129-19fc-4ee9-9e3d-77fcf1563e4b.jpg?1",
             "name": "Sickening Shoal",
             "text": "You may remove a black card with converted mana cost X in your hand from the game rather than pay Sickening Shoal's mana cost.\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "83562f98-7742-5fa7-a02b-8f9c4f696bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005edd3a-238d-471a-8d5b-2df735c49f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005edd3a-238d-471a-8d5b-2df735c49f67.jpg?1",
             "name": "Skullmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Skullmane Baku.\n{1}, {T}, Remove X ki counters from Skullmane Baku: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "2f901215-d9b1-538e-99d6-910285ead4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb76fa1-a930-468d-bfd4-dd06c2a9fe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb76fa1-a930-468d-bfd4-dd06c2a9fe9e.jpg?1",
             "name": "Skullsnatcher",
             "text": "Ninjutsu {B} ({B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Skullsnatcher deals combat damage to a player, remove up to two target cards in that player's graveyard from the game.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "a1a3ab11-d14a-5ad8-8f9f-9b5bfa1517cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7287f68f-f2e2-4e6f-a772-29a629bb9ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7287f68f-f2e2-4e6f-a772-29a629bb9ccd.jpg?1",
             "name": "Stir the Grave",
             "text": "Return target creature card with converted mana cost X or less from your graveyard to play.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "ac287583-8089-5722-847c-7fd1ce923679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa3d318-83ff-41db-b33a-e4f5b7cd7a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa3d318-83ff-41db-b33a-e4f5b7cd7a77.jpg?1",
             "name": "Takenuma Bleeder",
             "text": "Whenever Takenuma Bleeder attacks or blocks, you lose 1 life if you don't control a Demon.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "70c17494-4219-55dd-90be-a9525f6603a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acaa44-15d5-4760-9aa8-b44eda9ed98a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acaa44-15d5-4760-9aa8-b44eda9ed98a.jpg?1",
             "name": "Three Tragedies",
             "text": "Target player discards three cards.",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "70394da4-2fb8-5ad8-8d04-006b6e0fbc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dcfdb4-c2ff-4fc5-aa2a-0c6e311d2910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dcfdb4-c2ff-4fc5-aa2a-0c6e311d2910.jpg?1",
             "name": "Throat Slitter",
             "text": "Ninjutsu {2}{B} ({2}{B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Throat Slitter deals combat damage to a player, destroy target nonblack creature that player controls.",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "6703071b-6e24-54dd-9054-b0cc0e7ffc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e767e07-febd-4025-bf03-d4d816bc1d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e767e07-febd-4025-bf03-d4d816bc1d3d.jpg?1",
             "name": "Toshiro Umezawa",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever a creature an opponent controls is put into a graveyard from play, you may play target instant card in your graveyard. If that card would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "b0ddfd27-8b31-547d-9199-abf8a02f8f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aeca31-1175-4d2d-adc3-e3682d7e9e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aeca31-1175-4d2d-adc3-e3682d7e9e07.jpg?1",
             "name": "Yukora, the Prisoner",
             "text": "When Yukora, the Prisoner leaves play, sacrifice all non-Ogre creatures you control.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "37b03848-9740-5383-aa22-f05f0762395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1ee90-67d1-4e83-ae1e-3bd71069aae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1ee90-67d1-4e83-ae1e-3bd71069aae4.jpg?1",
             "name": "Akki Blizzard-Herder",
             "text": "When Akki Blizzard-Herder is put into a graveyard from play, each player sacrifices a land.",
             "colours": [
@@ -3249,7 +3249,7 @@
         },
         {
             "id": "5dab75b5-a0c0-5bc6-a152-756d18f88c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fb34ae-157c-4f4b-bb47-2a9dc394a20c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fb34ae-157c-4f4b-bb47-2a9dc394a20c.jpg?1",
             "name": "Akki Raider",
             "text": "Whenever a land is put into a graveyard from play, Akki Raider gets +1/+0 until end of turn.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "5379eadc-493f-5575-bdd2-2a5d6c15080d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3218e3-4640-4f73-a52b-f11ea5ea23a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3218e3-4640-4f73-a52b-f11ea5ea23a9.jpg?1",
             "name": "Ashen Monstrosity",
             "text": "Haste\nAshen Monstrosity attacks each turn if able.",
             "colours": [
@@ -3318,7 +3318,7 @@
         },
         {
             "id": "5610d52b-9e10-5b00-b323-8adc82f0162f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132af2c2-2bae-4c05-9d61-a5777818a057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132af2c2-2bae-4c05-9d61-a5777818a057.jpg?1",
             "name": "Aura Barbs",
             "text": "Each enchantment deals 2 damage to its controller, then each enchantment enchanting a creature deals 2 damage to the creature it's enchanting.",
             "colours": [
@@ -3352,7 +3352,7 @@
         },
         {
             "id": "1e6a92c5-4b61-5560-b982-c2b00f6393ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bfd388-3648-4bc3-8c10-d6b3b79a9479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bfd388-3648-4bc3-8c10-d6b3b79a9479.jpg?1",
             "name": "Blademane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Blademane Baku.\n{1}, Remove X ki counters from Blademane Baku: For each counter removed, Blademane Baku gets +2/+0 until end of turn.",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "1885479d-9ce3-52f8-a853-1cb28cc17c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b915daa-d239-4460-bd6b-e1327fdf7f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b915daa-d239-4460-bd6b-e1327fdf7f51.jpg?1",
             "name": "Blazing Shoal",
             "text": "You may remove a red card with converted mana cost X in your hand from the game rather than pay Blazing Shoal's mana cost.\nTarget creature gets +X/+0 until end of turn.",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "28925ce5-4641-5440-90d7-e624aa999d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dcfb2-6088-49c9-89b2-88d63c9add53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dcfb2-6088-49c9-89b2-88d63c9add53.jpg?1",
             "name": "Clash of Realities",
             "text": "All Spirits have \"When this creature comes into play, you may have it deal 3 damage to target non-Spirit creature.\"\nAll non-Spirit creatures have \"When this creature comes into play, you may have it deal 3 damage to target Spirit.\"",
             "colours": [
@@ -3452,7 +3452,7 @@
         },
         {
             "id": "42116b64-2e16-5ca4-9913-04a6951303fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab16152-4617-4deb-b995-195e21f8f485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab16152-4617-4deb-b995-195e21f8f485.jpg?1",
             "name": "Crack the Earth",
             "text": "Each player sacrifices a permanent.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "7734be83-3d66-5900-b4aa-09824a5a59c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg?1",
             "name": "Cunning Bandit // Azamuki, Treachery Incarnate",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Cunning Bandit.\nAt end of turn, if there are two or more ki counters on Cunning Bandit, you may flip it.",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "a51e78e2-0401-5796-a2d3-1d21cbd8b5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg?1",
             "name": "Cunning Bandit // Azamuki, Treachery Incarnate",
             "text": "Remove a ki counter from Azamuki, Treachery Incarnate: Gain control of target creature until end of turn.",
             "colours": [
@@ -3557,7 +3557,7 @@
         },
         {
             "id": "2c1d39f6-7c7b-5c16-8807-0a2f734d2c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e5e360-ed47-40c1-8ad7-57645c2854ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e5e360-ed47-40c1-8ad7-57645c2854ca.jpg?1",
             "name": "First Volley",
             "text": "First Volley deals 1 damage to target creature and 1 damage to that creature's controller.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "b4544c9f-4594-5247-ad0f-091fdc937e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79701b4-d220-4c3e-b96c-7a77a22ba899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79701b4-d220-4c3e-b96c-7a77a22ba899.jpg?1",
             "name": "Flames of the Blood Hand",
             "text": "Flames of the Blood Hand deals 4 damage to target player. The damage can't be prevented. If that player would gain life this turn, that player gains no life instead.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "02cc3e00-1bc5-5143-aa84-7ee2c0331656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91e5f1-9179-4763-b7c9-b7ad5451f6d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91e5f1-9179-4763-b7c9-b7ad5451f6d0.jpg?1",
             "name": "Frost Ogre",
             "text": "",
             "colours": [
@@ -3658,7 +3658,7 @@
         },
         {
             "id": "83d04883-4bbd-509e-b89b-a5f87ae2d9e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bb08f9-355d-443e-8f08-a20ef7322e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bb08f9-355d-443e-8f08-a20ef7322e78.jpg?1",
             "name": "Frostling",
             "text": "Sacrifice Frostling: Frostling deals 1 damage to target creature.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "27865a76-588b-5b9b-a2c7-97fb59d36ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482678b8-bce6-4847-9f43-1761d61645d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482678b8-bce6-4847-9f43-1761d61645d8.jpg?1",
             "name": "Fumiko the Lowblood",
             "text": "Fumiko the Lowblood has bushido X, where X is the number of attacking creatures. (When this blocks or becomes blocked, it gets +X/+X until end of turn.)\nCreatures your opponents control attack each turn if able.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "8be51286-18d1-539b-8dbb-9081bd9e7e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4302b20-d445-4ef4-a6b7-6db311aa24a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4302b20-d445-4ef4-a6b7-6db311aa24a2.jpg?1",
             "name": "Genju of the Spires",
             "text": "{2}: Enchanted Mountain becomes a 6/1 red Spirit creature until end of turn. It's still a land.\nWhen enchanted Mountain is put into a graveyard, you may return Genju of the Spires from your graveyard to your hand.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "c9c2c24f-22c5-54b1-9f09-287594a690de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8964afec-50a9-45c4-bd2b-d06f8e75f4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8964afec-50a9-45c4-bd2b-d06f8e75f4ae.jpg?1",
             "name": "Goblin Cohort",
             "text": "Goblin Cohort can't attack unless you've played a creature spell this turn.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "ddc1705d-2f11-5413-bc7a-89237fe362a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ab177-d9ab-46bf-bd92-20a9ecf2d0ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ab177-d9ab-46bf-bd92-20a9ecf2d0ad.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "{T}: Heartless Hidetsugu deals to each player damage equal to half that player's life total, rounded down.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "965f4919-189c-5fe3-a428-0b09dd5cb5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12b7124-d9d0-480c-b622-777a74d4f679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12b7124-d9d0-480c-b622-777a74d4f679.jpg?1",
             "name": "In the Web of War",
             "text": "Whenever a creature comes into play under your control, it gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "c2027f5a-8b9f-5e33-a204-1a154577c03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b927e30-3508-4daf-91ce-8978b04062cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b927e30-3508-4daf-91ce-8978b04062cb.jpg?1",
             "name": "Ire of Kaminari",
             "text": "Ire of Kaminari deals damage to target creature or player equal to the number of Arcane cards in your graveyard.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "79fae3b5-7d9c-58e3-bd39-0514cf732fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e94fec2-dc56-4961-ba80-b9c904a345ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e94fec2-dc56-4961-ba80-b9c904a345ab.jpg?1",
             "name": "Ishi-Ishi, Akki Crackshot",
             "text": "Whenever an opponent plays a Spirit or Arcane spell, Ishi-Ishi, Akki Crackshot deals 2 damage to that player.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "ec76d3aa-b501-572e-8c3e-2525d695f1a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f0d9aa-4270-41cd-8993-765354c03d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f0d9aa-4270-41cd-8993-765354c03d03.jpg?1",
             "name": "Kumano's Blessing",
             "text": "You may play Kumano's Blessing any time you could play an instant.\nIf a creature dealt damage by enchanted creature this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "3f812e5e-0df8-59e3-85e5-65e6590b1c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b403bdbb-13ab-43dd-a994-d45b994f6e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b403bdbb-13ab-43dd-a994-d45b994f6e0e.jpg?1",
             "name": "Mannichi, the Fevered Dream",
             "text": "{1}{R}: Switch each creature's power and toughness until end of turn.",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "0d6f7756-6501-532b-8f2b-d61d40fee3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa425203-71fc-4d19-8014-871d16b11bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa425203-71fc-4d19-8014-871d16b11bfd.jpg?1",
             "name": "Ogre Recluse",
             "text": "Whenever a player plays a spell, tap Ogre Recluse.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "3b921b2e-6388-58f7-a84d-41f1c8338c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97040b82-ad9e-4c06-a9ac-74d0688279f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97040b82-ad9e-4c06-a9ac-74d0688279f9.jpg?1",
             "name": "Overblaze",
             "text": "Each time target permanent would deal damage to a creature or player this turn, it deals double that damage to that creature or player instead.\nSplice onto Arcane {2}{R}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "4ec8baf0-5481-5917-9a46-6d868ad41dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18325283-ace8-414b-bf48-2ed36b5a9c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18325283-ace8-414b-bf48-2ed36b5a9c24.jpg?1",
             "name": "Patron of the Akki",
             "text": "Goblin offering (You may play this card any time you could play an instant by sacrificing a Goblin and paying the difference in mana costs between this and the sacrificed Goblin. Mana cost includes color.)\nWhenever Patron of the Akki attacks, creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "bb8886f1-64ae-5632-9d0d-c5be19f7bf8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f12b75-af29-49ea-a23d-915052db9fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f12b75-af29-49ea-a23d-915052db9fef.jpg?1",
             "name": "Ronin Cliffrider",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever Ronin Cliffrider attacks, you may have it deal 1 damage to each creature defending player controls.",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "0b5d2e04-2fd0-5054-a291-415885e7a147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdaf49b-9524-4824-807e-c40fcb381742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdaf49b-9524-4824-807e-c40fcb381742.jpg?1",
             "name": "Shinka Gatekeeper",
             "text": "Whenever Shinka Gatekeeper is dealt damage, it deals that much damage to you.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "106c2cf6-1a70-5043-a070-8c589d323c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd243ce5-152b-4d9c-991e-be56b6731d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd243ce5-152b-4d9c-991e-be56b6731d99.jpg?1",
             "name": "Sowing Salt",
             "text": "Remove target nonbasic land from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that land and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "fc4c0e16-568d-5209-9fd1-e56ff479d963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716ae2ca-800a-4cc0-8cb1-fe8d6495306f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716ae2ca-800a-4cc0-8cb1-fe8d6495306f.jpg?1",
             "name": "Torrent of Stone",
             "text": "Torrent of Stone deals 4 damage to target creature.\nSplice onto Arcane\u2014\nSacrifice two mountains. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "ed6638a8-b432-579f-be54-58bcc915ef73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b6607c-0c34-4ffc-b1b7-154417492766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b6607c-0c34-4ffc-b1b7-154417492766.jpg?1",
             "name": "Twist Allegiance",
             "text": "You and target opponent each gain control of all creatures the other controls until end of turn. Untap those creatures. Those creatures gain haste until end of turn.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "0e4a2501-afb8-5915-ada3-0dfff5c88877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe8e0-23ab-4fe7-8a48-1902be142c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe8e0-23ab-4fe7-8a48-1902be142c6a.jpg?1",
             "name": "Body of Jukai",
             "text": "Trample\nSoulshift 8 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 8 or less from your graveyard to your hand.)",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "2185cdf1-2279-5cf6-911d-2eb98bb6e153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg?1",
             "name": "Budoka Pupil // Ichiga, Who Topples Oaks",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Budoka Pupil.\nAt end of turn, if there are two or more ki counters on Budoka Pupil, you may flip it.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "50d83b31-5be7-5752-a2ca-8a2033883849",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg?1",
             "name": "Budoka Pupil // Ichiga, Who Topples Oaks",
             "text": "Trample\nRemove a ki counter from Ichiga, Who Topples Oaks: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -4386,7 +4386,7 @@
         },
         {
             "id": "25ca66d8-c42b-5b61-822a-e057c9e9429e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32c342f-ee1a-461c-9082-d2f6d9412f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32c342f-ee1a-461c-9082-d2f6d9412f54.jpg?1",
             "name": "Child of Thorns",
             "text": "Sacrifice Child of Thorns: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "4df77839-0ccd-53da-aa5f-8d426af7b05f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeefab6e-582a-42bb-bb27-d6aadd1d35c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeefab6e-582a-42bb-bb27-d6aadd1d35c5.jpg?1",
             "name": "Enshrined Memories",
             "text": "Reveal the top X cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "282d6da0-8c42-57e5-b39f-832147a6eb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff39ae5-a241-4607-903e-201f56c675f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff39ae5-a241-4607-903e-201f56c675f9.jpg?1",
             "name": "Forked-Branch Garami",
             "text": "Soulshift 4, soulshift 4 (When this is put into a graveyard from play, you may return up to two target Spirit cards with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "2c2d00fd-a4d9-5282-9648-f8cb83bc8993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d621b82-c863-437b-b42c-31a0872be6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d621b82-c863-437b-b42c-31a0872be6d4.jpg?1",
             "name": "Genju of the Cedars",
             "text": "{2}: Enchanted Forest becomes a 4/4 green Spirit creature until end of turn. It's still a land.\nWhen enchanted Forest is put into a graveyard, you may return Genju of the Cedars from your graveyard to your hand.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "74ddca44-cc62-5a47-a6c9-0524ac4d4227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c28728d-4839-4cdf-91d4-b9fb4b5d0449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c28728d-4839-4cdf-91d4-b9fb4b5d0449.jpg?1",
             "name": "Gnarled Mass",
             "text": "",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "38520521-3e27-5914-a7cb-4097caec89f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fd23b5-5e57-44dc-8248-c4b9eb71c4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fd23b5-5e57-44dc-8248-c4b9eb71c4f3.jpg?1",
             "name": "Harbinger of Spring",
             "text": "Protection from non-Spirit creatures\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "d4ff7d8c-abd2-5e91-9710-253472e01af6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90334b59-73d8-4459-af59-d7a0539e2cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90334b59-73d8-4459-af59-d7a0539e2cc5.jpg?1",
             "name": "Isao, Enlightened Bushi",
             "text": "Isao, Enlightened Bushi can't be countered.\nBushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{2}: Regenerate target Samurai.",
             "colours": [
@@ -4625,7 +4625,7 @@
         },
         {
             "id": "9bc681b5-8e9a-5120-82c2-d8aec6511529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c51fcf-ab5c-46fa-aa4b-14cd01c7a577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c51fcf-ab5c-46fa-aa4b-14cd01c7a577.jpg?1",
             "name": "Iwamori of the Open Fist",
             "text": "Trample\nWhen Iwamori of the Open Fist comes into play, each opponent may put a legendary creature card from his or her hand into play.",
             "colours": [
@@ -4662,7 +4662,7 @@
         },
         {
             "id": "7ec146dc-4692-52a2-a694-91db8d02d3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9264c5-1ecd-48cc-a12d-d4bd8050cfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9264c5-1ecd-48cc-a12d-d4bd8050cfae.jpg?1",
             "name": "Kodama of the Center Tree",
             "text": "Kodama of the Center Tree's power and toughness are each equal to the number of Spirits you control.\nKodama of the Center Tree has soulshift X, where X is the number of Spirits you control.",
             "colours": [
@@ -4698,7 +4698,7 @@
         },
         {
             "id": "7bafd9e0-6d35-5ff8-a145-2fa293cd585f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eaba1c-3137-4419-bf90-eb287a7c736e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eaba1c-3137-4419-bf90-eb287a7c736e.jpg?1",
             "name": "Lifegift",
             "text": "Whenever a land comes into play, you may gain 1 life.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "7c35c5f7-9b55-5d53-a7f5-dbdb679d204b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a83083-f7c6-4ddf-aee9-538a1778697d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a83083-f7c6-4ddf-aee9-538a1778697d.jpg?1",
             "name": "Lifespinner",
             "text": "{T}, Sacrifice three Spirits: Search your library for a legendary Spirit card and put it into play. Then shuffle your library.",
             "colours": [
@@ -4764,7 +4764,7 @@
         },
         {
             "id": "ae7e25f2-4073-5006-a034-5bbf2d49ebd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f635b35-48c8-43e8-9d74-c01d3c0c74e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f635b35-48c8-43e8-9d74-c01d3c0c74e1.jpg?1",
             "name": "Loam Dweller",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a land card from your hand into play tapped.",
             "colours": [
@@ -4798,7 +4798,7 @@
         },
         {
             "id": "89b77f5a-128a-56b6-950e-3d30ee9d956e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7611a97d-6500-4311-baa1-be3ee0791f3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7611a97d-6500-4311-baa1-be3ee0791f3a.jpg?1",
             "name": "Mark of Sakiko",
             "text": "Enchanted creature has \"Whenever this creature deals combat damage to a player, add that much {G} to your mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from your mana pool as phases end.\"",
             "colours": [
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "696add83-f7a6-5e83-be33-8b79adb726fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143af295-040d-400e-ae23-59abd2f88e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143af295-040d-400e-ae23-59abd2f88e11.jpg?1",
             "name": "Matsu-Tribe Sniper",
             "text": "{T}: Matsu-Tribe Sniper deals 1 damage to target creature with flying.\nWhenever Matsu-Tribe Sniper deals damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4868,7 +4868,7 @@
         },
         {
             "id": "ee40ce0c-63e8-5901-aebf-fdf97d522960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6af212-2a94-4ddf-acdc-d70fafa1c5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6af212-2a94-4ddf-acdc-d70fafa1c5ee.jpg?1",
             "name": "Nourishing Shoal",
             "text": "You may remove a green card with converted mana cost X in your hand from the game rather than pay Nourishing Shoal's mana cost.\nYou gain X life.",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "44d727b7-3cd6-5fb9-bd4b-97f3b29eef06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6787c4-170a-45b6-8792-af3ea32ef538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6787c4-170a-45b6-8792-af3ea32ef538.jpg?1",
             "name": "Patron of the Orochi",
             "text": "Snake offering (You may play this card any time you could play an instant by sacrificing a Snake and paying the difference in mana costs between this and the sacrificed Snake. Mana cost includes color.)\n{T}: Untap all Forests and all green creatures. Play this ability only once each turn.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "9f0da37c-ccba-599d-bc20-7844cea69fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7ba032-66d6-41bd-af4f-9853b031a474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7ba032-66d6-41bd-af4f-9853b031a474.jpg?1",
             "name": "Petalmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Petalmane Baku.\n{1}, Remove X ki counters from Petalmane Baku: Add X mana of any one color to your mana pool.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "e74ea3e4-8f9b-5a6f-85b6-0110aa9501bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b70649-12f8-47b9-9959-40323684a777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b70649-12f8-47b9-9959-40323684a777.jpg?1",
             "name": "Roar of Jukai",
             "text": "If you control a Forest, each blocked creature gets +2/+2 until end of turn.\nSplice onto Arcane\u2014\nAn opponent gains 5 life. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "a9bd8c82-007c-51de-8228-1d885fb8d19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774ec405-5127-4475-8c74-b8858bd84379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774ec405-5127-4475-8c74-b8858bd84379.jpg?1",
             "name": "Sakiko, Mother of Summer",
             "text": "Whenever a creature you control deals combat damage to a player, add that much {G} to your mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from your mana pool as phases end.",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "01aa2246-6cf0-563c-8aad-ad3663ca1571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ca7687-ba90-4479-8c6e-ece3f29fff12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ca7687-ba90-4479-8c6e-ece3f29fff12.jpg?1",
             "name": "Sakura-Tribe Springcaller",
             "text": "At the beginning of your upkeep, add {G} to your mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from your mana pool as phases end.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "649be30d-ad1b-5acc-a049-b164bd45b11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b27457e-2c40-4983-9680-b7292db4c668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b27457e-2c40-4983-9680-b7292db4c668.jpg?1",
             "name": "Scaled Hulk",
             "text": "Whenever you play a Spirit or Arcane spell, Scaled Hulk gets +2/+2 until end of turn.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "31bca2b6-d965-5ed2-a914-996ded55df31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab9407d-9389-4ec9-963c-80de095a6812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab9407d-9389-4ec9-963c-80de095a6812.jpg?1",
             "name": "Shizuko, Caller of Autumn",
             "text": "At the beginning of each player's upkeep, that player adds {G}{G}{G} to his or her mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from that player's mana pool as phases end.",
             "colours": [
@@ -5149,7 +5149,7 @@
         },
         {
             "id": "9f97dd03-059d-5dd4-a14c-cc8f8776873f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42359e94-9f57-45ae-ae39-d4b939813015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42359e94-9f57-45ae-ae39-d4b939813015.jpg?1",
             "name": "Sosuke's Summons",
             "text": "Put two 1/1 green Snake creature tokens into play.\nWhenever a nontoken Snake comes into play under your control, you may return Sosuke's Summons from your graveyard to your hand.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "cb1f644a-f2bb-5143-b769-d158beb23cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc210b-e37e-463c-8fd4-83e5113429a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc210b-e37e-463c-8fd4-83e5113429a9.jpg?1",
             "name": "Splinter",
             "text": "Remove target artifact from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that artifact and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "85fa4483-92c3-51cd-9e03-b0de5aff27b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65aabe-5fd8-4b62-b13c-12e4bb91aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65aabe-5fd8-4b62-b13c-12e4bb91aacb.jpg?1",
             "name": "Traproot Kami",
             "text": "Defender (This creature can't attack.)\nTraproot Kami's toughness is equal to the number of Forests in play.\nTraproot Kami may block as though it had flying.",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "fbd61c9e-d2fa-5f07-8a88-e14413ea556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7791182-fe63-47bc-9fdf-ef346d6ad4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7791182-fe63-47bc-9fdf-ef346d6ad4b5.jpg?1",
             "name": "Unchecked Growth",
             "text": "Target creature gets +4/+4 until end of turn. If it's a Spirit, it gains trample until end of turn.",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "fc6c03de-81f8-5590-8ed9-3ebec766b571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88357572-0edd-4115-93c3-49f6f5a191b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88357572-0edd-4115-93c3-49f6f5a191b4.jpg?1",
             "name": "Uproot",
             "text": "Put target land on top of its owner's library.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "e9a36e8f-d95c-59ea-931e-291d7c64a1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba28f326-67d1-4afb-90fe-e9f036210942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba28f326-67d1-4afb-90fe-e9f036210942.jpg?1",
             "name": "Vital Surge",
             "text": "You gain 3 life.\nSplice onto Arcane {1}{G} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5349,7 +5349,7 @@
         },
         {
             "id": "11e3e65c-8e89-5720-ba7d-830520453a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9eb7b9b-5189-4d20-8dec-e9d3df63e26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9eb7b9b-5189-4d20-8dec-e9d3df63e26e.jpg?1",
             "name": "Genju of the Realm",
             "text": "{2}: Enchanted land becomes a legendary 8/12 Spirit creature with trample until end of turn. It's still a land.\nWhen enchanted land is put into a graveyard, you may return Genju of the Realm from your graveyard to your hand.",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "ce15fb9c-7433-5ce3-9d75-c72c4179a7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1dbb8-3df8-4e7e-b74b-baab7d6f97c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1dbb8-3df8-4e7e-b74b-baab7d6f97c1.jpg?1",
             "name": "Baku Altar",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Baku Altar.\n{2}, {T}, Remove a ki counter from Baku Altar: Put a 1/1 colorless Spirit creature token into play.",
             "colours": [],
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "400b1730-8c5c-514f-96f9-e0a9844c34d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097fbb8-0db5-4ceb-8972-dcd21b3fb4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097fbb8-0db5-4ceb-8972-dcd21b3fb4d5.jpg?1",
             "name": "Blinding Powder",
             "text": "Equipped creature has \"Unattach Blinding Powder: Prevent all combat damage that would be dealt to this creature this turn.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "37bcaa96-96bf-5f0d-87f1-c4b3f1fc739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00beba34-54cc-4a30-8424-71a1215647a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00beba34-54cc-4a30-8424-71a1215647a6.jpg?1",
             "name": "Mirror Gallery",
             "text": "The \"legend rule\" doesn't apply.",
             "colours": [],
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "ef98cea0-1808-5fef-b589-c431dfc5093a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13884a26-1e30-40d7-ae38-494154a5cf85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13884a26-1e30-40d7-ae38-494154a5cf85.jpg?1",
             "name": "Neko-Te",
             "text": "Whenever equipped creature deals damage to a creature, tap that creature. As long as Neko-Te remains in play, that creature doesn't untap during its controller's untap step.\nWhenever equipped creature deals damage to a player, that player loses 1 life.\nEquip {2}",
             "colours": [],
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "3326b2ec-a5b6-5a4f-9d9a-71a0213c8113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbe52a3-f85e-4b3a-a345-413b64d69c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbe52a3-f85e-4b3a-a345-413b64d69c49.jpg?1",
             "name": "Orb of Dreams",
             "text": "Permanents come into play tapped.",
             "colours": [],
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "9dd9fba2-04cc-53be-96ef-7a53cba8dede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb4c10-59cb-4bc1-b824-6ec8edd6f45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb4c10-59cb-4bc1-b824-6ec8edd6f45e.jpg?1",
             "name": "Ornate Kanzashi",
             "text": "{2}, {T}: Target opponent removes the top card of his or her library from the game. You may play that card this turn.",
             "colours": [],
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "8aa78369-15c8-5d5d-8d4a-aa6f3050f87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad31cd-38dc-4fd3-b9e4-8988f4898719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad31cd-38dc-4fd3-b9e4-8988f4898719.jpg?1",
             "name": "Ronin Warclub",
             "text": "Equipped creature gets +2/+1.\nWhenever a creature comes into play under your control, attach Ronin Warclub to that creature.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "ea8cf134-a05a-512d-a364-d9a133db2a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47456b8-cef8-4085-90b1-92788e16fd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47456b8-cef8-4085-90b1-92788e16fd27.jpg?1",
             "name": "Shuko",
             "text": "Equipped creature gets +1/+0.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "f9641e79-b81e-5901-bdcc-927146582e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e7f3b-55a4-41bf-b7ec-81114f2c63c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e7f3b-55a4-41bf-b7ec-81114f2c63c4.jpg?1",
             "name": "Shuriken",
             "text": "Equipped creature has \"{T}, Unattach Shuriken: Shuriken deals 2 damage to target creature. That creature's controller gains control of Shuriken unless it was unattached from a Ninja.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "9d7f00b9-bc10-51ff-b650-a29a67dcf896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32ac983-a909-4342-882e-f3b7e2e064d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32ac983-a909-4342-882e-f3b7e2e064d8.jpg?1",
             "name": "Slumbering Tora",
             "text": "{2}, Discard a Spirit or Arcane card: Slumbering Tora becomes an X/X artifact creature until end of turn, where X is the discarded card's converted mana cost.",
             "colours": [],
@@ -5683,7 +5683,7 @@
         },
         {
             "id": "3026e795-cf34-5d30-88cc-54429dc4dd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80c84ad-171f-42c3-94b4-a9fe25b877e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80c84ad-171f-42c3-94b4-a9fe25b877e7.jpg?1",
             "name": "That Which Was Taken",
             "text": "{4}, {T}: Put a divinity counter on target permanent other than That Which Was Taken.\nEach permanent with a divinity counter on it is indestructible.",
             "colours": [],
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "b9eb9778-51c7-5c12-8524-4aaaf14c68c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6e5956-f795-451b-bb24-56462d1ced27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6e5956-f795-451b-bb24-56462d1ced27.jpg?1",
             "name": "Umezawa's Jitte",
             "text": "Whenever equipped creature deals combat damage, put two charge counters on Umezawa's Jitte.\nRemove a charge counter from Umezawa's Jitte: Choose one Equipped creature gets +2/+2 until end of turn; or target creature gets -1/-1 until end of turn; or you gain 2 life.\nEquip {2}",
             "colours": [],
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "670f1af5-e33b-583e-ab46-fe2270b03f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc33a21-d196-4c17-a296-87ff08e7ef69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc33a21-d196-4c17-a296-87ff08e7ef69.jpg?1",
             "name": "Gods' Eye, Gate to the Reikai",
             "text": "{T}: Add {1} to your mana pool.\nWhen Gods' Eye, Gate to the Reikai is put into a graveyard from play, put a 1/1 colorless Spirit creature token into play.",
             "colours": [],
@@ -5775,7 +5775,7 @@
         },
         {
             "id": "34e99f42-adcb-5c48-9ab8-433a5b351d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d246f521-b9a0-4b4f-b38c-0e4eb4066212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d246f521-b9a0-4b4f-b38c-0e4eb4066212.jpg?1",
             "name": "Tendo Ice Bridge",
             "text": "Tendo Ice Bridge comes into play with a charge counter on it.\n{T}: Add {1} to your mana pool.\n{T}, Remove a charge counter from Tendo Ice Bridge: Add one mana of any color to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/BRO.json
+++ b/Assets/Resources/Sets/BRO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6ff98307-b89c-5a43-bc3c-3f81d803617d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a62bb2-bc33-44d4-9a7e-92c9ea7d3c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a62bb2-bc33-44d4-9a7e-92c9ea7d3c2c.jpg?1",
             "name": "Aeronaut Cavalry",
             "text": "Flying\nWhen Aeronaut Cavalry enters the battlefield, put a +1/+1 counter on another target Soldier you control.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "e4d66ec1-7ba2-5c80-a9c1-e33500cfdbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad55575-6053-43b1-9496-bcb1ea25e2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad55575-6053-43b1-9496-bcb1ea25e2a1.jpg?1",
             "name": "Airlift Chaplain",
             "text": "Flying\nWhen Airlift Chaplain enters the battlefield, mill three cards. You may put a Plains card or a creature card with mana value 3 or less from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Airlift Chaplain. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "8d065ec5-4e7f-50f6-92c8-277673a6fb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa00c0e-163d-4f59-b8b9-3ee9143d27bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa00c0e-163d-4f59-b8b9-3ee9143d27bb.jpg?1",
             "name": "Ambush Paratrooper",
             "text": "Flash\nFlying\n{5}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "45e16536-c429-54c9-906e-43b9f9ee83b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013bed2b-25db-4dfc-9283-e80c9ac6c841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013bed2b-25db-4dfc-9283-e80c9ac6c841.jpg?1",
             "name": "Calamity's Wake",
             "text": "Exile all graveyards. Players can't cast noncreature spells this turn. Exile Calamity's Wake.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "d184bcd7-1c35-558f-8fd4-c2065a349018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eca0ae-d400-4afb-9a45-7100f4cd7149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eca0ae-d400-4afb-9a45-7100f4cd7149.jpg?1",
             "name": "Deadly Riposte",
             "text": "Deadly Riposte deals 3 damage to target tapped creature and you gain 2 life.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "6efabf68-3dc3-5c60-9446-6525679733ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658c5caa-d739-4d30-a512-43ac4de900cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658c5caa-d739-4d30-a512-43ac4de900cb.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "51aecba1-d4b9-596f-9037-3ef33dca9816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc83d586-bf46-437f-a5a3-996bd62d5866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc83d586-bf46-437f-a5a3-996bd62d5866.jpg?1",
             "name": "Great Desert Prospector",
             "text": "When Great Desert Prospector enters the battlefield, create a tapped Powerstone token for each other creature you control. (They're artifacts with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "ada20bab-ada6-5bed-9d45-d87790233c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ff86e9-1ce6-43cc-8135-f2adb1b6c5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ff86e9-1ce6-43cc-8135-f2adb1b6c5a7.jpg?1",
             "name": "In the Trenches",
             "text": "Creatures you control get +1/+1.\n{5}{W}: Exile target nonland permanent you don't control until In the Trenches leaves the battlefield. Activate only as a sorcery and only once.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "64155ae3-130f-5da4-9360-ee9bb617e25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0737dbec-1646-41a0-adbf-706c9bd4fc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0737dbec-1646-41a0-adbf-706c9bd4fc7a.jpg?1",
             "name": "Kayla's Command",
             "text": "Choose two \u2014\n\u2022 Create a 2/2 colorless Construct artifact creature token.\n\u2022 Put a +1/+1 counter on a creature you control. It gains double strike until end of turn.\n\u2022 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n\u2022 You gain 2 life and scry 2.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "47fd005b-6e60-5024-a08a-428a150f89ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb84e72-0231-461a-a230-d8afa6e54289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb84e72-0231-461a-a230-d8afa6e54289.jpg?1",
             "name": "Kayla's Reconstruction",
             "text": "Look at the top seven cards of your library. Put up to X artifact and/or creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "75daa469-6ba9-5c9b-a5e3-9509cfb6cf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5649ee5a-4485-40a2-96d1-2e061905a71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5649ee5a-4485-40a2-96d1-2e061905a71e.jpg?1",
             "name": "Lay Down Arms",
             "text": "Exile target creature with mana value less than or equal to the number of Plains you control. Its controller gains 3 life.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "04e54bdf-b04f-52d8-8503-4ca1fce8688e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59faa45d-868b-4bc7-934c-0e077642e129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59faa45d-868b-4bc7-934c-0e077642e129.jpg?1",
             "name": "Loran of the Third Path",
             "text": "Vigilance\nWhen Loran of the Third Path enters the battlefield, destroy up to one target artifact or enchantment.\n{T}: You and target opponent each draw a card.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "7fba79dd-5f55-5549-9e57-d99aaddea2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9998f898-1f08-481b-8505-b890f0fec5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9998f898-1f08-481b-8505-b890f0fec5e0.jpg?1",
             "name": "Loran, Disciple of History",
             "text": "Whenever Loran, Disciple of History or another legendary creature enters the battlefield under your control, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "ec4978dd-5363-5d7c-8ce2-27406d933598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3765610d-a0c1-4de9-a81b-ffa3eb06454b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3765610d-a0c1-4de9-a81b-ffa3eb06454b.jpg?1",
             "name": "Loran's Escape",
             "text": "Target artifact or creature gains hexproof and indestructible until end of turn. Scry 1.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "750e9798-2294-5b8f-9022-e90b37f8e65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a08b7-dd30-446e-a8a7-2e084bbb9586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a08b7-dd30-446e-a8a7-2e084bbb9586.jpg?1",
             "name": "Mass Production",
             "text": "Create four 1/1 colorless Soldier artifact creature tokens.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "8c24486d-4d6b-5c3e-a78a-26057db06745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811461a-6a90-416f-940c-c9579659ae0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811461a-6a90-416f-940c-c9579659ae0c.jpg?1",
             "name": "Meticulous Excavation",
             "text": "{2}{W}: Return target permanent you control to its owner's hand. If it has unearth, instead exile it, then return that card to its owner's hand. Activate only during your turn.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "082e9de2-d7d0-59d7-8dbf-c7bf8a8509ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94778e17-87c4-4765-b2f0-40455069f2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94778e17-87c4-4765-b2f0-40455069f2c4.jpg?1",
             "name": "Military Discipline",
             "text": "Flash\nEnchant creature\nWhen Military Discipline enters the battlefield, enchanted creature gains first strike until end of turn.\nEnchanted creature gets +1/+0.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "7e666059-3fbc-59ca-ade0-0ed75abb1584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e632ed57-bb00-4493-adef-7b4805edd7ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e632ed57-bb00-4493-adef-7b4805edd7ea.jpg?1",
             "name": "Myrel, Shield of Argive",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.\nWhenever Myrel, Shield of Argive attacks, create X 1/1 colorless Soldier artifact creature tokens, where X is the number of Soldiers you control.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "5fbfd67f-dd8a-5e5c-9a83-93701d1ccf49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abe2af7-deba-4569-822a-2d9309aeaadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abe2af7-deba-4569-822a-2d9309aeaadd.jpg?1",
             "name": "Phalanx Vanguard",
             "text": "Vigilance\nWhenever an artifact enters the battlefield under your control, Phalanx Vanguard gets +1/+0 until end of turn.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "0b629b0e-376d-5259-a000-308f8cdf0dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2901c5f6-5d83-437d-b434-d9beb115dd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2901c5f6-5d83-437d-b434-d9beb115dd82.jpg?1",
             "name": "Powerstone Engineer",
             "text": "When Powerstone Engineer dies, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "047b6ef3-a654-5d6c-8378-057d3555c403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76832ca8-95b2-4bc8-a191-9e2f50b77626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76832ca8-95b2-4bc8-a191-9e2f50b77626.jpg?1",
             "name": "Prison Sentence",
             "text": "Enchant creature\nWhen Prison Sentence enters the battlefield, scry 2.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -725,7 +725,7 @@
         },
         {
             "id": "afbdb5e1-6bcf-5953-867f-e7611515ba93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a64e330-1257-4ec3-9a75-889cdcac3ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a64e330-1257-4ec3-9a75-889cdcac3ade.jpg?1",
             "name": "Recommission",
             "text": "Return target artifact or creature card with mana value 3 or less from your graveyard to the battlefield. If a creature enters the battlefield this way, it enters with an additional +1/+1 counter on it.",
             "colours": [
@@ -757,7 +757,7 @@
         },
         {
             "id": "9e9dbe89-2cd8-5e3c-9e2f-09f7171993aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c226656b-68d5-4df2-b313-a323a728c520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c226656b-68d5-4df2-b313-a323a728c520.jpg?1",
             "name": "Recruitment Officer",
             "text": "{3}{W}: Look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -792,7 +792,7 @@
         },
         {
             "id": "6473c629-d525-55ca-b36d-0d0abaa9d8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff4a4b-4e86-41d1-a6b6-312aac0d3e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff4a4b-4e86-41d1-a6b6-312aac0d3e1a.jpg?1",
             "name": "Repair and Recharge",
             "text": "Return target artifact, enchantment, or planeswalker card from your graveyard to the battlefield. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "b6be96d4-e937-59b7-bd1b-a1edf15e3eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57e2a32-6e52-4f6e-96ec-55f5b7ba77e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57e2a32-6e52-4f6e-96ec-55f5b7ba77e0.jpg?1",
             "name": "Siege Veteran",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\nWhenever another nontoken Soldier you control dies, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "c26dd17d-fdbc-5c78-bc0e-75037167eeee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bb8ec0-9729-4aa1-8ce4-a3a5598b0d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bb8ec0-9729-4aa1-8ce4-a3a5598b0d70.jpg?1",
             "name": "Soul Partition",
             "text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may play it. A spell cast by an opponent this way costs {2} more to cast.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "09371945-5baf-5ec4-8f9c-7836bfe41789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab5cb30-3ced-4450-a3c4-b519f3762620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab5cb30-3ced-4450-a3c4-b519f3762620.jpg?1",
             "name": "Static Net",
             "text": "When Static Net enters the battlefield, exile target nonland permanent an opponent controls until Static Net leaves the battlefield.\nWhen Static Net enters the battlefield, you gain 2 life and create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -927,7 +927,7 @@
         },
         {
             "id": "81154bf5-29b5-559b-adad-9e73fe6fd62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817bcc8d-a5b7-448c-a3eb-825dc65944ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817bcc8d-a5b7-448c-a3eb-825dc65944ec.jpg?1",
             "name": "Survivor of Korlis",
             "text": "First strike\n{1}{W}, Exile Survivor of Korlis from your graveyard: Scry 2.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "52ac19cc-f469-59cc-bac2-21a416227986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61017325-cec0-46ac-aa32-5855e5904888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61017325-cec0-46ac-aa32-5855e5904888.jpg?1",
             "name": "Thopter Architect",
             "text": "Whenever an artifact enters the battlefield under your control, target creature gains flying until end of turn.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "7d046c74-975d-5346-bdb9-6a5b562dcc06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cd89f1-f9f4-4cb5-a573-79809d0b6dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cd89f1-f9f4-4cb5-a573-79809d0b6dfd.jpg?1",
             "name": "Tocasia's Welcome",
             "text": "Whenever one or more creatures with mana value 3 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "6d5efcac-b2df-57d9-b0f0-a69d3e909994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486a0745-7360-4cc9-9cc2-30c0eda6e00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486a0745-7360-4cc9-9cc2-30c0eda6e00c.jpg?1",
             "name": "Union of the Third Path",
             "text": "Draw a card, then you gain life equal to the number of cards in your hand.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "a4aa5ae5-0639-5ff9-adce-76f84c188bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873cc9e-30b6-498e-b008-9d11a8bbf9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873cc9e-30b6-498e-b008-9d11a8bbf9b9.jpg?1",
             "name": "Warlord's Elite",
             "text": "As an additional cost to cast this spell, tap two untapped artifacts, creatures, and/or lands you control.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "bfdcdca9-9049-55ab-835a-2d0014f37f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b9c48-6eca-4677-961b-614f5ec594ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b9c48-6eca-4677-961b-614f5ec594ce.jpg?1",
             "name": "Yotian Medic",
             "text": "Lifelink",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "5530e090-4ccf-5586-820f-155ef62f98dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dee863-e6ef-4061-a877-ddd3c4dbe87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dee863-e6ef-4061-a877-ddd3c4dbe87e.jpg?1",
             "name": "Autonomous Assembler",
             "text": "Vigilance\n{1}, {T}: Put a +1/+1 counter on target Assembly-Worker you control.\n//PRT-Prototype_\nMech//\n{1}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "3fd79852-cf48-50bb-90b8-15ddc84ef25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dfabfd-e13b-4512-a733-abe514be6404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dfabfd-e13b-4512-a733-abe514be6404.jpg?1",
             "name": "Combat Thresher",
             "text": "Double strike\nWhen Combat Thresher enters the battlefield, draw a card.\n//PRT-Prototype_\nMech//\n{2}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/1",
             "colours": [],
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "26fa24a0-20f0-525c-903b-d50a0e0aa680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4825e3-c549-4bcb-84b5-2d0782c5c4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4825e3-c549-4bcb-84b5-2d0782c5c4e5.jpg?1",
             "name": "Platoon Dispenser",
             "text": "At the beginning of your end step, if you control two or more other creatures, draw a card.\n{3}{W}: Create a 1/1 colorless Soldier artifact creature token.\nUnearth {2}{W}{W}",
             "colours": [],
@@ -1237,7 +1237,7 @@
         },
         {
             "id": "7b7d0872-b1c9-5f44-94a2-309fca1b2c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b0f17e-603a-4840-b2c3-381ec6f102f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b0f17e-603a-4840-b2c3-381ec6f102f3.jpg?1",
             "name": "Scrapwork Cohort",
             "text": "When Scrapwork Cohort enters the battlefield, create a 1/1 colorless Soldier artifact creature token.\nUnearth {2}{W} ({2}{W}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -1270,7 +1270,7 @@
         },
         {
             "id": "d9f29611-757d-594b-85d4-b6b6e0359e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ef5f5-4058-4f89-a573-9e2da87a9f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ef5f5-4058-4f89-a573-9e2da87a9f2e.jpg?1",
             "name": "Steel Seraph",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gains your choice of flying, vigilance, or lifelink until end of turn.\n//PRT-Prototype_\nMech//\n{1}{W}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "8ac41de4-ab58-52eb-8dbf-6d1ee421ce35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4abf2fb-f78a-4e75-b46f-524d3d7405db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4abf2fb-f78a-4e75-b46f-524d3d7405db.jpg?1",
             "name": "Tocasia's Onulet",
             "text": "When Tocasia's Onulet leaves the battlefield, you gain 2 life.\nUnearth {3}{W} ({3}{W}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -1338,7 +1338,7 @@
         },
         {
             "id": "4690bfdc-d744-562f-ae90-4151108eb0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3000d1c6-dbb3-4e65-b428-dbf167bb8797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3000d1c6-dbb3-4e65-b428-dbf167bb8797.jpg?1",
             "name": "Urza's Sylex",
             "text": "{2}{W}{W}, {T}, Exile Urza's Sylex: Each player chooses six lands they control. Destroy all other permanents. Activate only as a sorcery.\nWhen Urza's Sylex is put into exile from the battlefield, you may pay {2}. If you do, search your library for a planeswalker card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -1372,7 +1372,7 @@
         },
         {
             "id": "4cb62e4e-d548-57c6-b130-da8f8e0599fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d823e1-a7d6-4296-94c8-b8ba9b4daa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d823e1-a7d6-4296-94c8-b8ba9b4daa38.jpg?1",
             "name": "Veteran's Powerblade",
             "text": "Equipped creature gets +2/+0.\nEquip Soldier {W}\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "6249d867-06d9-5d40-b0d3-53281b51ca7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa05d1e-6728-4e77-bfb2-da0b9598e44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa05d1e-6728-4e77-bfb2-da0b9598e44b.jpg?1",
             "name": "Yotian Frontliner",
             "text": "Whenever Yotian Frontliner attacks, another target creature you control gets +1/+1 until end of turn.\nUnearth {W} ({W}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "9e0911c6-a7cf-577b-ab8f-c539c2565c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991e1a6c-914b-45c8-9170-c09e72696117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991e1a6c-914b-45c8-9170-c09e72696117.jpg?1",
             "name": "Air Marshal",
             "text": "{3}: Target Soldier gains flying until end of turn.",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "4e78becd-1c9b-552d-a630-af3d48c28a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8c3fc8-c1cc-4dfc-94cb-1538bff9d09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8c3fc8-c1cc-4dfc-94cb-1538bff9d09a.jpg?1",
             "name": "Curate",
             "text": "Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nDraw a card.",
             "colours": [
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "24a41773-df24-5ee8-8b13-136c4e1e2d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd32168-0b9c-4633-adec-d41cf125cc35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd32168-0b9c-4633-adec-d41cf125cc35.jpg?1",
             "name": "Defabricate",
             "text": "Choose one \u2014\n\u2022 Counter target artifact or enchantment spell. If a spell is countered this way, exile it instead of putting it into its owner's graveyard.\n\u2022 Counter target activated or triggered ability.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "ea8c71d1-140e-5763-8e18-e6c704cdc2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e101e5-2b20-48dd-aac4-15a3c32a7441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e101e5-2b20-48dd-aac4-15a3c32a7441.jpg?1",
             "name": "Desynchronize",
             "text": "Target nonland permanent's owner puts it on the top or bottom of their library. Scry 2.",
             "colours": [
@@ -1568,7 +1568,7 @@
         },
         {
             "id": "0774f54e-77f9-5aa3-bf8d-0a542c420607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7355905-2b3b-4191-a89c-a0fc1494928b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7355905-2b3b-4191-a89c-a0fc1494928b.jpg?1",
             "name": "Drafna, Founder of Lat-Nam",
             "text": "{1}{U}: Return target artifact you control to its owner's hand.\n{3}, {T}: Copy target artifact spell you control. (The copy becomes a token.)",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "9b10b4f9-a266-574f-a26a-29737fcf6316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eab397-25a6-4377-8e12-e8acef9675cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eab397-25a6-4377-8e12-e8acef9675cf.jpg?1",
             "name": "Fallaji Archaeologist",
             "text": "When Fallaji Archaeologist enters the battlefield, mill three cards. You may put a noncreature, nonland card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Fallaji Archaeologist. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "eac32d48-3333-5a71-8c03-a62bedebfd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea316f3-4a68-4cd4-a388-da9d0455d0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea316f3-4a68-4cd4-a388-da9d0455d0a9.jpg?1",
             "name": "Flow of Knowledge",
             "text": "Draw a card for each Island you control, then discard two cards.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "7208c427-c7cd-5062-a864-a0408f593fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057f6add-1f1d-4cce-9c9d-5e59fb74d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057f6add-1f1d-4cce-9c9d-5e59fb74d78e.jpg?1",
             "name": "Forging the Anchor",
             "text": "Look at the top five cards of your library. You may reveal any number of artifact cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "d8a5211c-798e-5ac8-b096-ff71914c06fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcee066-425f-4341-bde5-13a5bdf06f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcee066-425f-4341-bde5-13a5bdf06f2a.jpg?1",
             "name": "Hurkyl, Master Wizard",
             "text": "At the beginning of your end step, if you've cast a noncreature spell this turn, reveal the top five cards of your library. For each card type among noncreature spells you've cast this turn, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "9c5059ff-b8f5-5005-8172-25c21cf3a8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577f345-9577-42f8-b244-089b9a7c2e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577f345-9577-42f8-b244-089b9a7c2e56.jpg?1",
             "name": "Hurkyl's Final Meditation",
             "text": "As long as it's not your turn, this spell costs {3} more to cast.\nReturn all nonland permanents to their owners' hands. End the turn. (Exile all spells and abilities from the stack, including this card. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "5f337d77-c71c-53a2-b97e-96e76fe93a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fcaf6d-6491-4459-98b0-b3c7d43df59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fcaf6d-6491-4459-98b0-b3c7d43df59e.jpg?1",
             "name": "Involuntary Cooldown",
             "text": "Tap up to two target artifacts and/or creatures. Put two stun counters on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "bb2294ea-049d-5ae0-a51d-848a29dbc4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09200388-47c9-4472-ac9e-98f57653e084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09200388-47c9-4472-ac9e-98f57653e084.jpg?1",
             "name": "Keeper of the Cadence",
             "text": "{3}: Put target artifact, instant, or sorcery card from a graveyard on the bottom of its owner's library.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "00b98aba-64c7-5ed2-b913-ec4d8220cd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdbcb87-c6ea-477f-a560-c175d99e21b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdbcb87-c6ea-477f-a560-c175d99e21b8.jpg?1",
             "name": "Koilos Roc",
             "text": "Flash\nFlying\nWhen Koilos Roc enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "4f8688b3-9df6-50f0-94f4-7d873db143bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e088de-e99f-4706-89e0-a7efdaf9403a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e088de-e99f-4706-89e0-a7efdaf9403a.jpg?1",
             "name": "Lat-Nam Adept",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on Lat-Nam Adept.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "738721a0-c730-508d-ac2d-86be3d63c80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08eadf5-a86d-4e8d-b65d-79b4f88477b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08eadf5-a86d-4e8d-b65d-79b4f88477b9.jpg?1",
             "name": "Machine Over Matter",
             "text": "This spell costs {1} less to cast if you control an artifact creature.\nReturn target nonland permanent to its owner's hand.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "1d8cbd80-5292-5212-86dc-3f5547e5eedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c540e42-22e2-4127-bbd9-2e9200023fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c540e42-22e2-4127-bbd9-2e9200023fec.jpg?1",
             "name": "Mightstone's Animation",
             "text": "Enchant artifact\nWhen Mightstone's Animation enters the battlefield, draw a card.\nEnchanted artifact is a creature with base power and toughness 4/4 in addition to its other types.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "91f74e4d-1391-53fe-a12b-20f721a6a813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7868529f-8abb-4b1d-9c04-e628f81e08d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7868529f-8abb-4b1d-9c04-e628f81e08d2.jpg?1",
             "name": "One with the Multiverse",
             "text": "You may look at the top card of your library any time.\nYou may play lands and cast spells from the top of your library.\nOnce during each of your turns, you may cast a spell from your hand or the top of your library without paying its mana cost.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "2366b4b7-b042-5b9b-b52c-df6c99d4ee82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333a7b1-936e-42f3-ba22-2c76dd2f1c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333a7b1-936e-42f3-ba22-2c76dd2f1c9a.jpg?1",
             "name": "Retrieval Agent",
             "text": "{2}: Retrieval Agent gets +1/-1 until end of turn.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "b137f7d6-407d-5802-a771-48908e2aecc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2852c9-d566-4824-836a-2f4c7a5148a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2852c9-d566-4824-836a-2f4c7a5148a1.jpg?1",
             "name": "Scatter Ray",
             "text": "Counter target artifact or creature spell unless its controller pays {4}.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "8a42bf3e-cdc4-53a1-8563-df025b229066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925fa343-d9c3-4ed9-bd1f-aaa31c0badd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925fa343-d9c3-4ed9-bd1f-aaa31c0badd7.jpg?1",
             "name": "Skystrike Officer",
             "text": "Flying\nWhenever Skystrike Officer attacks, create a 1/1 colorless Soldier artifact creature token.\nTap three untapped Soldiers you control: Draw a card.",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "9ae558eb-5fc1-5d96-8a27-7ca1723003cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569dab90-a0d8-4c0a-8e32-b2cb3aec39a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569dab90-a0d8-4c0a-8e32-b2cb3aec39a6.jpg?1",
             "name": "Splitting the Powerstone",
             "text": "As an additional cost to cast this spell, sacrifice an artifact.\nCreate two tapped Powerstone tokens. If the sacrificed artifact was legendary, draw a card. (The tokens are artifacts with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "3eee28ec-10fb-5f37-9abc-6b6a7a6463ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151caa2-10ed-4f30-83eb-cd1bd3f642ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151caa2-10ed-4f30-83eb-cd1bd3f642ce.jpg?1",
             "name": "Stern Lesson",
             "text": "Draw two cards, then discard a card. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "33fd266e-62df-5296-a2d5-322b216670a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2108e-e45e-4b21-a03b-5f644b6043be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2108e-e45e-4b21-a03b-5f644b6043be.jpg?1",
             "name": "Take Flight",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has flying and \"Whenever this creature attacks, draw a card.\"",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "835faa90-e4a1-5564-a88e-6b61c63f70d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4f1ec-eadf-4f1e-8821-f22293ad2580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4f1ec-eadf-4f1e-8821-f22293ad2580.jpg?1",
             "name": "Teferi, Temporal Pilgrim",
             "text": "Whenever you draw a card, put a loyalty counter on Teferi, Temporal Pilgrim.\n0: Draw a card.\n\u22122: Create a 2/2 blue Spirit creature token with vigilance and \"Whenever you draw a card, put a +1/+1 counter on this creature.\"\n\u221212: Target opponent chooses a permanent they control and returns it to its owner's hand. Then they shuffle each nonland permanent they control into its owner's library.",
             "colours": [
@@ -2259,7 +2259,7 @@
         },
         {
             "id": "b70f3d29-fdf8-5203-8adc-51c918e2fdbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793a51ab-59fb-424f-a315-3f63e8990322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793a51ab-59fb-424f-a315-3f63e8990322.jpg?1",
             "name": "Third Path Savant",
             "text": "{7}: Draw two cards.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "0aa26dee-74d7-504a-a080-7af3dce0ada1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577b5c7-91ed-4201-bdfd-0919142124eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577b5c7-91ed-4201-bdfd-0919142124eb.jpg?1",
             "name": "Thopter Mechanic",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on Thopter Mechanic.\nWhen Thopter Mechanic dies, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -2329,7 +2329,7 @@
         },
         {
             "id": "8bae54a4-9288-5ea9-aa63-b1628df29522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445f897e-a059-4cd5-bfd2-302dc7a4c8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445f897e-a059-4cd5-bfd2-302dc7a4c8e2.jpg?1",
             "name": "Urza, Powerstone Prodigy",
             "text": "Vigilance\n{1}, {T}: Draw a card, then discard a card.\nWhenever you discard one or more artifact cards, create a tapped Powerstone token. This ability triggers only once each turn. (The token is an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "0f4988ce-d720-536c-a7e8-b237e474f5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b4a02c-e57f-4287-943e-6bc859ac149e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b4a02c-e57f-4287-943e-6bc859ac149e.jpg?1",
             "name": "Urza's Command",
             "text": "Choose two \u2014\n\u2022 Creatures you don't control get -2/-0 until end of turn.\n\u2022 Create a tapped Powerstone token.\n\u2022 Create a tapped 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\n\u2022 Scry 1, then draw a card.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "1130add5-7160-5229-8478-4914bb83cd8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6f90b3-450c-490a-b6d0-2393c4646c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6f90b3-450c-490a-b6d0-2393c4646c85.jpg?1",
             "name": "Urza's Rebuff",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Tap up to two target creatures.",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "aadf7223-9df6-541d-8c72-64d2b6335aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef93ac79-8575-40f8-a222-63c2ffb30f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef93ac79-8575-40f8-a222-63c2ffb30f60.jpg?1",
             "name": "Weakstone's Subjugation",
             "text": "Enchant artifact or creature\nWhen Weakstone's Subjugation enters the battlefield, you may pay {3}. If you do, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "968b7463-a420-590b-a0cb-2c2292248804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e640c3-02bb-453c-a609-05d8214e2e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e640c3-02bb-453c-a609-05d8214e2e2e.jpg?1",
             "name": "Wing Commando",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "429a6c4c-de20-5bbd-af08-e3938f47441d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935adbb-d2e3-48d0-b38c-41f3b583fecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935adbb-d2e3-48d0-b38c-41f3b583fecb.jpg?1",
             "name": "Zephyr Sentinel",
             "text": "Flash\nFlying\nWhen Zephyr Sentinel enters the battlefield, return up to one other target creature you control to its owner's hand. If it was a Soldier, put a +1/+1 counter on Zephyr Sentinel.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "7047d44f-0eb7-5a0b-9a2b-7ef51448bb16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d74d2e-7382-4fe3-ac3e-6906203ffcc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d74d2e-7382-4fe3-ac3e-6906203ffcc7.jpg?1",
             "name": "Arcane Proxy",
             "text": "When Arcane Proxy enters the battlefield, if you cast it, exile target instant or sorcery card with mana value less than or equal to Arcane Proxy's power from your graveyard. Copy that card. You may cast the copy without paying its mana cost.\n//PRT-Prototype_\nMech//\n{1}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/1",
             "colours": [],
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "19e99524-d1f6-5fd2-a771-02c3bff68e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24567f8-d195-4547-bba4-7a8131dc7889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24567f8-d195-4547-bba4-7a8131dc7889.jpg?1",
             "name": "Coastal Bulwark",
             "text": "Defender\nCoastal Bulwark gets +2/+0 as long as you control an Island.\n{2}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [],
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "15f083e6-50d8-5ae8-a989-e9ae292d5dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171edf80-ffc1-4894-9be5-c3e93a96f734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171edf80-ffc1-4894-9be5-c3e93a96f734.jpg?1",
             "name": "Combat Courier",
             "text": "{2}, Sacrifice Combat Courier: Draw a card.\nUnearth {U} ({U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "49a88f40-39fe-5132-8ea3-8723902b2799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e09173-a92d-4cc3-9d02-bf18ab0850ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e09173-a92d-4cc3-9d02-bf18ab0850ec.jpg?1",
             "name": "Depth Charge Colossus",
             "text": "Depth Charge Colossus doesn't untap during your untap step.\n{3}: Untap Depth Charge Colossus.\n//PRT-Prototype_\nMech//\n{4}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n6/6",
             "colours": [],
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "019970ca-fe45-5866-bc30-d7978b9ce8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f0b81-8b87-4854-9dc4-6da84cc38623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f0b81-8b87-4854-9dc4-6da84cc38623.jpg?1",
             "name": "Hulking Metamorph",
             "text": "You may have Hulking Metamorph enter the battlefield as a copy of an artifact or creature you control, except it's an artifact creature in addition to its other types, and its power and toughness are equal to Hulking Metamorph's power and toughness.\n//PRT-Prototype_\nMech//\n{2}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "9130bfbc-ce82-5bb0-bb01-b8d324281643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90175ae-4109-4845-b3ff-1531fb67a0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90175ae-4109-4845-b3ff-1531fb67a0e1.jpg?1",
             "name": "Spotter Thopter",
             "text": "Flying\nWhen Spotter Thopter enters the battlefield, scry X, where X is its power.\n//PRT-Prototype_\nMech//\n{3}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/3",
             "colours": [],
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "cb94121c-119f-599a-86d2-b3bb975c36ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c9c5-e992-4f1c-a779-124176c3aade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c9c5-e992-4f1c-a779-124176c3aade.jpg?1",
             "name": "Surge Engine",
             "text": "Defender\n{U}: Surge Engine loses defender and gains \"This creature can't be blocked.\"\n{2}{U}: Surge Engine becomes blue and has base power and toughness 5/4. Activate only if Surge Engine doesn't have defender.\n{4}{U}{U}: Draw three cards. Activate only if Surge Engine is blue and only once.",
             "colours": [],
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "48ae69fb-5a74-5ce1-ab9b-27f0380c2f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a212d59-b72e-4939-a757-c131ca4323ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a212d59-b72e-4939-a757-c131ca4323ce.jpg?1",
             "name": "The Temporal Anchor",
             "text": "At the beginning of your upkeep, scry 2.\nWhenever you choose to put one or more cards on the bottom of your library while scrying, exile that many cards from the bottom of your library.\nDuring your turn, you may play cards exiled with The Temporal Anchor.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "4fec2fa3-1a45-52f1-8b81-24c0d1239793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd86daf-7cee-454c-8d4d-97f59fe36958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd86daf-7cee-454c-8d4d-97f59fe36958.jpg?1",
             "name": "Terisian Mindbreaker",
             "text": "Whenever Terisian Mindbreaker attacks, defending player mills half their library, rounded up.\nUnearth {1}{U}{U}{U} ({1}{U}{U}{U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "ee495376-282a-5d74-9c39-c6dea2be21ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb43c15-50a9-488f-b0be-84a5e0a6d10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb43c15-50a9-488f-b0be-84a5e0a6d10b.jpg?1",
             "name": "Ashnod, Flesh Mechanist",
             "text": "Deathtouch\nWhenever Ashnod, Flesh Mechanist attacks, you may sacrifice another creature. If you do, create a tapped Powerstone token.\n{5}, Exile a creature card from your graveyard: Create a tapped 3/3 colorless Zombie artifact creature token.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "feb12e81-c070-5a1c-b96e-178a908b34f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf491db-d12b-4c58-9c05-085cac34a73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf491db-d12b-4c58-9c05-085cac34a73e.jpg?1",
             "name": "Ashnod's Intervention",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies or is put into exile from the battlefield, return it to its owner's hand.\"",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "6d208bed-b342-59e4-919c-94713a1b57aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c47e31-d4f6-46f3-94b7-1726c4a4a8eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c47e31-d4f6-46f3-94b7-1726c4a4a8eb.jpg?1",
             "name": "Battlefield Butcher",
             "text": "{5}, {T}: Each opponent loses 2 life. This ability costs {1} less to activate for each creature card in your graveyard.",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "1900591f-6ce8-57c8-8f1e-e44f1fff6da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759acb8-82c0-479f-86f3-f22ca7a2006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759acb8-82c0-479f-86f3-f22ca7a2006c.jpg?1",
             "name": "Carrion Locust",
             "text": "Flying\nWhen Carrion Locust enters the battlefield, exile target card from an opponent's graveyard. If it was a creature card, that player loses 1 life.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "05d760c0-3e76-597c-9881-9f204d345d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ea561-80da-4fe1-ad87-ce47d9eb80bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ea561-80da-4fe1-ad87-ce47d9eb80bc.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "7c7b5d32-5d02-54d8-bd2d-14617045d866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72ab698-de67-4ca8-8e42-b05346bf52fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72ab698-de67-4ca8-8e42-b05346bf52fa.jpg?1",
             "name": "Diabolic Intent",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "29eb43ae-adbc-516e-835a-da3f9ecec5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d356456-865d-4c92-8923-ce7384e29a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d356456-865d-4c92-8923-ce7384e29a79.jpg?1",
             "name": "Disciples of Gix",
             "text": "When Disciples of Gix enters the battlefield, search your library for up to three artifact cards, put them into your graveyard, then shuffle.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "7989250b-642f-5867-b353-045e61465145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9c6f1-3938-448b-bdc3-22420c5984d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9c6f1-3938-448b-bdc3-22420c5984d3.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "dffa810f-3e01-592e-ba31-8cad64602e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ac92e-c61a-4c11-aa6a-9ae1cb703e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ac92e-c61a-4c11-aa6a-9ae1cb703e5c.jpg?1",
             "name": "Dreams of Steel and Oil",
             "text": "Target opponent reveals their hand. You choose an artifact or creature card from it, then choose an artifact or creature card from their graveyard. Exile the chosen cards.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "c96c9548-88e1-5f09-b75c-7385a1ae706e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec94d440-3922-4588-bf7b-d8670f81ef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec94d440-3922-4588-bf7b-d8670f81ef4e.jpg?1",
             "name": "Emergency Weld",
             "text": "Return target artifact or creature card from your graveyard to your hand. Create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "72b41357-920e-5eef-b950-407073dbf5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbed8f9-3615-428b-8d0d-18291c5a99be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbed8f9-3615-428b-8d0d-18291c5a99be.jpg?1",
             "name": "Fateful Handoff",
             "text": "Draw cards equal to the mana value of target artifact or creature you control. An opponent gains control of that permanent.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "e9b50125-62d1-5dea-bc7c-5ed5c1ca239c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c76f7e0-37e7-4e87-93a3-a25ba0674645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c76f7e0-37e7-4e87-93a3-a25ba0674645.jpg?1",
             "name": "Gix, Yawgmoth Praetor",
             "text": "Whenever a creature deals combat damage to one of your opponents, its controller may pay 1 life. If they do, they draw a card.\n{4}{B}{B}{B}, Discard X cards: Exile the top X cards of target opponent's library. You may play lands and cast spells from among cards exiled this way without paying their mana costs.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "5840eb1f-563f-546d-b532-a6e2b2386bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1140cb9-6c48-4054-966e-5cc02aa7d5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1140cb9-6c48-4054-966e-5cc02aa7d5a4.jpg?1",
             "name": "Gix's Caress",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nCreate a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "c9fdec83-848c-5f75-938a-51bcffa70524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606de75-c25f-411b-a271-258ac5a60987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606de75-c25f-411b-a271-258ac5a60987.jpg?1",
             "name": "Gix's Command",
             "text": "Choose two \u2014\n\u2022 Put two +1/+1 counters on up to one creature. It gains lifelink until end of turn.\n\u2022 Destroy each creature with power 2 or less.\n\u2022 Return up to two creature cards from your graveyard to your hand.\n\u2022 Each opponent sacrifices a creature with the highest power among creatures they control.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "e0a113c6-8557-5796-8783-7ca191ff1cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a3317-7d1f-4f29-8353-180f1ab48d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a3317-7d1f-4f29-8353-180f1ab48d18.jpg?1",
             "name": "Gixian Infiltrator",
             "text": "Whenever you sacrifice another permanent, put a +1/+1 counter on Gixian Infiltrator.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "8525e87c-d49c-5ecf-840c-0e1674c96470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc86e18-ffbc-4c5f-a694-922332b146cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc86e18-ffbc-4c5f-a694-922332b146cc.jpg?1",
             "name": "Gixian Puppeteer",
             "text": "Whenever you draw your second card each turn, each opponent loses 2 life and you gain 2 life.\nWhen Gixian Puppeteer dies, return another target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "3e161a51-8262-5aae-b456-fa1f3e89f2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdcf02b-1876-44d7-8a22-679ea1272856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdcf02b-1876-44d7-8a22-679ea1272856.jpg?1",
             "name": "Gixian Skullflayer",
             "text": "At the beginning of your upkeep, if there are three or more creature cards in your graveyard, put a +1/+1 counter on Gixian Skullflayer.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "d934252a-9310-51b2-8934-7f8209deb5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa2fa48-ddb7-45f0-b183-4186df98f7cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa2fa48-ddb7-45f0-b183-4186df98f7cc.jpg?1",
             "name": "Gnawing Vermin",
             "text": "When Gnawing Vermin enters the battlefield, target player mills two cards.\nWhen Gnawing Vermin dies, target creature you don't control gets -1/-1 until end of turn.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "67542236-53d8-5f03-bdf4-0b100361890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94117b09-d852-4f2e-be8e-68ee0ee3c3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94117b09-d852-4f2e-be8e-68ee0ee3c3d8.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "cdb0ebd6-e07a-5e88-8eb7-a45eb09c8d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cd0ece-a267-42ab-b95a-6e7931bd837a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cd0ece-a267-42ab-b95a-6e7931bd837a.jpg?1",
             "name": "Gruesome Realization",
             "text": "Choose one \u2014\n\u2022 You draw two cards and you lose 2 life.\n\u2022 Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "06ac58c4-0646-5424-a9b7-c73b1a4990d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0d139-2bea-48df-a007-cee7c8ce07bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0d139-2bea-48df-a007-cee7c8ce07bd.jpg?1",
             "name": "Gurgling Anointer",
             "text": "Flying\nWhenever you draw your second card each turn, put a +1/+1 counter on Gurgling Anointer.\nWhen Gurgling Anointer dies, return another target creature card with mana value less than or equal to Gurgling Anointer's power from your graveyard to the battlefield.",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "209c7eb3-cc3c-560f-b734-14c567184d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f827a9a0-7b72-49e2-85fa-adcce1e8fdda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f827a9a0-7b72-49e2-85fa-adcce1e8fdda.jpg?1",
             "name": "Hostile Negotiations",
             "text": "Exile the top three cards of your library in a face-down pile, then exile the top three cards of your library in another face-down pile. Look at the cards in each pile, then turn a pile of your choice face up. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. You lose 3 life.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "186ddb34-0355-5c13-b6ed-2c28d1a38ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f97974-bb65-46b0-a710-12fa4b9343ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f97974-bb65-46b0-a710-12fa4b9343ac.jpg?1",
             "name": "Kill-Zone Acrobat",
             "text": "Whenever Kill-Zone Acrobat attacks, you may sacrifice another creature or artifact. If you do, Kill-Zone Acrobat gains flying until end of turn.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "f4f98343-a7e3-5c64-9e09-39ee25c248e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c5e77-9ecc-41c9-b104-76343601fafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c5e77-9ecc-41c9-b104-76343601fafb.jpg?1",
             "name": "Misery's Shadow",
             "text": "If a creature an opponent controls would die, exile it instead.\n{1}: Misery's Shadow gets +1/+1 until end of turn.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "78b1e3b4-256b-5657-82d5-af3431c17d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e99fb27-a1e9-491f-ab2a-3ccb493168cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e99fb27-a1e9-491f-ab2a-3ccb493168cb.jpg?1",
             "name": "Moment of Defiance",
             "text": "Target creature gets +2/+1 and gains lifelink until end of turn.\nDraw a card.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "a188e94b-90ab-53f0-b052-ff841258730b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7e030c-98d1-452c-8020-cd92a3ef02c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7e030c-98d1-452c-8020-cd92a3ef02c3.jpg?1",
             "name": "No One Left Behind",
             "text": "This spell costs {3} less to cast if it targets a creature card with mana value 3 or less.\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "080beaae-6561-5edd-b687-da779a3a85ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202cbfa4-3b3d-47fd-84a6-892692c906d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202cbfa4-3b3d-47fd-84a6-892692c906d6.jpg?1",
             "name": "Overwhelming Remorse",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nExile target creature or planeswalker.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "4ee85284-88e4-5168-aa63-9ab8cb74c7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed5e030-874f-4a00-8544-78ba04033f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed5e030-874f-4a00-8544-78ba04033f53.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless they discard a card.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "94c34e6e-a652-5351-ab53-f16a6358afc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323301f-565a-4c0f-bffd-18386ccd1f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323301f-565a-4c0f-bffd-18386ccd1f7a.jpg?1",
             "name": "Powerstone Fracture",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "912af102-4fc5-510f-83fc-99f62841b6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fee3328-75c2-4d13-86e1-bf3a40fbf538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fee3328-75c2-4d13-86e1-bf3a40fbf538.jpg?1",
             "name": "Ravenous Gigamole",
             "text": "When Ravenous Gigamole enters the battlefield, mill three cards. You may put a creature card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Ravenous Gigamole. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "9d287ad5-77e3-5ab8-a3c2-0d32032e25b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faed400-0712-4fc1-b710-144db40a5e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faed400-0712-4fc1-b710-144db40a5e11.jpg?1",
             "name": "Thran Vigil",
             "text": "Whenever one or more artifact and/or creature cards leave your graveyard during your turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "055805a3-7883-5fc0-b8de-c03af6d48525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc59ca3b-d417-4cf2-99a3-89816bf2bd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc59ca3b-d417-4cf2-99a3-89816bf2bd09.jpg?1",
             "name": "Thraxodemon",
             "text": "{3}, {T}, Sacrifice another creature or artifact: Draw a card.",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "3e21addf-0613-56bb-bc9a-3043ccb3cb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1b987a-a3b9-4cd1-85b0-e58df4130934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1b987a-a3b9-4cd1-85b0-e58df4130934.jpg?1",
             "name": "Trench Stalker",
             "text": "As long as you've drawn two or more cards this turn, Trench Stalker has deathtouch and lifelink.",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "b712d4de-7f45-5c43-9762-43886a709ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58baa977-16c1-4983-8343-dbd65e98ddb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58baa977-16c1-4983-8343-dbd65e98ddb7.jpg?1",
             "name": "Ashnod's Harvester",
             "text": "Whenever Ashnod's Harvester attacks, exile target card from a graveyard.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "5c159b6b-bc26-5704-870e-fae650100a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc295bac-5031-46c8-8d9a-368656bcf6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc295bac-5031-46c8-8d9a-368656bcf6d3.jpg?1",
             "name": "Clay Revenant",
             "text": "Clay Revenant enters the battlefield tapped.\n{2}{B}: Return Clay Revenant from your graveyard to your hand.",
             "colours": [],
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "afd6f93b-9f42-5bf5-8020-bd4961dbb56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e133a2-631f-43f6-9fdd-e542d4d15e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e133a2-631f-43f6-9fdd-e542d4d15e10.jpg?1",
             "name": "Dredging Claw",
             "text": "Equipped creature gets +1/+0 and has menace. (It can't be blocked except by two or more creatures.)\nWhenever a creature enters the battlefield from your graveyard, you may attach Dredging Claw to it.\nEquip {1}{B} ({1}{B}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "e0d3fa69-dd19-5086-9ba2-d25997a9a240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d927dfd-ae66-4235-a61b-39c85d0c1222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d927dfd-ae66-4235-a61b-39c85d0c1222.jpg?1",
             "name": "Goring Warplow",
             "text": "Deathtouch\n//PRT-Prototype_\nMech//\n{1}{B}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/1",
             "colours": [],
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "a2729f74-a4cd-5e76-b2b7-2c7552ce41d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d37423-3445-412a-9abd-0480da404637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d37423-3445-412a-9abd-0480da404637.jpg?1",
             "name": "Phyrexian Fleshgorger",
             "text": "Menace, lifelink\nWard\u2014\nPay life equal to Phyrexian Fleshgorger's power.\n//PRT-Prototype_\nMech//\n{1}{B}{B}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "c6dc221e-bf69-5e21-8878-610217966484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfaf8cc-7819-4ec2-8d79-e3b0c1814590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfaf8cc-7819-4ec2-8d79-e3b0c1814590.jpg?1",
             "name": "Razorlash Transmogrant",
             "text": "Razorlash Transmogrant can't block.\n{4}{B}{B}: Return Razorlash Transmogrant from your graveyard to the battlefield with a +1/+1 counter on it. This ability costs {4} less to activate if an opponent controls four or more nonbasic lands.",
             "colours": [],
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "cf3cea5e-c033-5414-9295-d5cb884b614a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de770-7975-4aa9-b656-e7dbe6bff290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de770-7975-4aa9-b656-e7dbe6bff290.jpg?1",
             "name": "Scrapwork Rager",
             "text": "When Scrapwork Rager enters the battlefield, you draw a card and you lose 1 life.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -4199,7 +4199,7 @@
         },
         {
             "id": "6f2000fe-162c-539a-a481-e72c664473f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca28d210-a35d-491e-beda-76b95d09dc2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca28d210-a35d-491e-beda-76b95d09dc2d.jpg?1",
             "name": "Transmogrant Altar",
             "text": "{B}, {T}, Sacrifice a creature: Add {C}{C}{C}.\n{2}, {T}, Sacrifice a creature: Create a 3/3 colorless Zombie artifact creature token. Activate only as a sorcery.",
             "colours": [],
@@ -4229,7 +4229,7 @@
         },
         {
             "id": "b048468a-ae5e-5a2a-8944-543736e6df6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc913ed6-3032-4b45-a6c1-6a4208a7e00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc913ed6-3032-4b45-a6c1-6a4208a7e00a.jpg?1",
             "name": "Transmogrant's Crown",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, draw a card.\nEquip {2} or {B}",
             "colours": [],
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "10477d89-b01c-5096-a6b2-181c64b4b881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd83b2c3-bb06-42db-83bf-8903a126512c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd83b2c3-bb06-42db-83bf-8903a126512c.jpg?1",
             "name": "Arms Race",
             "text": "{3}{R}: You may put an artifact card from your hand onto the battlefield. That artifact gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "bb4c6914-7243-5321-bb6b-e1658cc7a9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345a1c80-41d6-43b1-83ab-1aa56dd06b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345a1c80-41d6-43b1-83ab-1aa56dd06b1b.jpg?1",
             "name": "Bitter Reunion",
             "text": "When Bitter Reunion enters the battlefield, you may discard a card. If you do, draw two cards.\n{1}, Sacrifice Bitter Reunion: Creatures you control gain haste until end of turn.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "75f61232-8129-5ca8-8a8b-4f997eece2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7666d-0d60-4fe5-b144-286d4e47b704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7666d-0d60-4fe5-b144-286d4e47b704.jpg?1",
             "name": "Brotherhood's End",
             "text": "Choose one \u2014\n\u2022 Brotherhood's End deals 3 damage to each creature and each planeswalker.\n\u2022 Destroy all artifacts with mana value 3 or less.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "141932e4-29ee-5bd9-962e-ffb0f05b6d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b0449-8ff7-4549-893b-aeca93720c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b0449-8ff7-4549-893b-aeca93720c64.jpg?1",
             "name": "Conscripted Infantry",
             "text": "When Conscripted Infantry dies, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "436e7988-635e-53f0-92ff-388e110a89b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71240ad-1daf-419a-aaeb-5f9d5079c3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71240ad-1daf-419a-aaeb-5f9d5079c3dd.jpg?1",
             "name": "Draconic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying, haste, and \"{1}: This creature gets +1/+0 until end of turn.\" It's a Dragon in addition to its other types.\nWhen enchanted creature dies, return Draconic Destiny to its owner's hand.",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "361051ec-1c5a-5b94-a9ea-e0cecdae4029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd6a95a-11b9-43aa-b293-20a3102bae71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd6a95a-11b9-43aa-b293-20a3102bae71.jpg?1",
             "name": "Dwarven Forge-Chanter",
             "text": "Ward\u2014\nPay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "5831d344-544b-5181-a190-59543831a3f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a169612e-f5de-4653-bc31-9ede8c5bdc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a169612e-f5de-4653-bc31-9ede8c5bdc75.jpg?1",
             "name": "Excavation Explosion",
             "text": "Excavation Explosion deals 3 damage to any target. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "731cdeaa-0788-59a2-9316-cafad78d902d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f454583d-d227-4fc8-842e-128e025880e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f454583d-d227-4fc8-842e-128e025880e4.jpg?1",
             "name": "The Fall of Kroog",
             "text": "Choose target opponent. Destroy target land that player controls. The Fall of Kroog deals 3 damage to that player and 1 damage to each creature they control.",
             "colours": [
@@ -4531,7 +4531,7 @@
         },
         {
             "id": "852af449-1fb2-5a2c-8fc5-09e12fc31d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2da75-160d-47f9-b978-e153262ec1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2da75-160d-47f9-b978-e153262ec1fc.jpg?1",
             "name": "Fallaji Chaindancer",
             "text": "{2}: Fallaji Chaindancer gains double strike until end of turn.",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "b466129f-9f09-5f8e-ae20-15dd8f846303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca4cb0e-63ad-4275-a27f-da476260b467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca4cb0e-63ad-4275-a27f-da476260b467.jpg?1",
             "name": "Feldon, Ronom Excavator",
             "text": "Haste\nFeldon, Ronom Excavator can't block.\nWhenever Feldon is dealt damage, exile that many cards from the top of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "82228a95-1f9a-5357-82f7-8c59738744c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349465f-d29f-4d4b-a653-f4388574c336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349465f-d29f-4d4b-a653-f4388574c336.jpg?1",
             "name": "Giant Cindermaw",
             "text": "Trample\nPlayers can't gain life.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "13a116b6-cd94-5edb-a0a0-a0e8a8a480c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd77c575-93a4-44ec-8940-adcbfc6e7a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd77c575-93a4-44ec-8940-adcbfc6e7a84.jpg?1",
             "name": "Goblin Blast-Runner",
             "text": "Goblin Blast-Runner gets +2/+0 and has menace as long as you sacrificed a permanent this turn.",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "d4a7c7a8-4560-5154-b1d5-0c47e497abca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd965a9-caa2-42a3-b2f9-e4f57341ac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd965a9-caa2-42a3-b2f9-e4f57341ac27.jpg?1",
             "name": "Horned Stoneseeker",
             "text": "Menace\nWhen Horned Stoneseeker enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\nWhen Horned Stoneseeker leaves the battlefield, sacrifice a Powerstone.",
             "colours": [
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "f4a94ab7-9014-59d3-96ea-7958a4aea87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2d026f-bdca-4376-9d70-c81c707598e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2d026f-bdca-4376-9d70-c81c707598e8.jpg?1",
             "name": "Mechanized Warfare",
             "text": "If a red or artifact source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -4742,7 +4742,7 @@
         },
         {
             "id": "27af9f0f-bba8-59e0-ad46-9e826774a976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d02416-8578-40a5-bf31-d1ef9b8764f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d02416-8578-40a5-bf31-d1ef9b8764f1.jpg?1",
             "name": "Mishra, Excavation Prodigy",
             "text": "Haste\n{1}, {T}, Discard a card: Draw a card.\nWhenever you discard one or more artifact cards, add {R}{R}. This ability triggers only once each turn.",
             "colours": [
@@ -4779,7 +4779,7 @@
         },
         {
             "id": "a08863ce-af1c-50e6-8094-54e53ec56859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d2e518-30c6-480c-aaf4-b7596c9479e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d2e518-30c6-480c-aaf4-b7596c9479e4.jpg?1",
             "name": "Mishra's Command",
             "text": "Choose two \u2014\n\u2022 Choose target player. They may discard up to X cards. Then they draw a card for each card discarded this way.\n\u2022 This spell deals X damage to target creature.\n\u2022 This spell deals X damage to target planeswalker.\n\u2022 Target creature gets +X/+0 and gains haste until end of turn.",
             "colours": [
@@ -4813,7 +4813,7 @@
         },
         {
             "id": "04e5b7b9-6c39-52f4-8e08-76e8266d80e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c71fb1-a30b-4e0e-a6d6-4656cfff2da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c71fb1-a30b-4e0e-a6d6-4656cfff2da1.jpg?1",
             "name": "Mishra's Domination",
             "text": "Enchant creature\nAs long as you control enchanted creature, it gets +2/+2. Otherwise, it can't block.",
             "colours": [
@@ -4847,7 +4847,7 @@
         },
         {
             "id": "b7ebaeff-7a7b-5d65-809b-772627c10206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda82e38-c1d4-4019-8f79-f91602d941b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda82e38-c1d4-4019-8f79-f91602d941b0.jpg?1",
             "name": "Mishra's Onslaught",
             "text": "Choose one \u2014\n\u2022 Create two 1/1 colorless Soldier artifact creature tokens.\n\u2022 Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4879,7 +4879,7 @@
         },
         {
             "id": "7a8bbb63-420b-5c84-be26-79a871ee1415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfa227-4309-40ed-952c-279595eab17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfa227-4309-40ed-952c-279595eab17e.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "4f5cf6bd-9492-5b05-b521-09a475e567dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f886411-8216-4fb7-9172-a408c39043ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f886411-8216-4fb7-9172-a408c39043ee.jpg?1",
             "name": "Obliterating Bolt",
             "text": "Obliterating Bolt deals 4 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "0703631b-8ad9-59e8-a462-e59e05600520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01eb9702-55c5-41b2-8bef-63d33dafa599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01eb9702-55c5-41b2-8bef-63d33dafa599.jpg?1",
             "name": "Over the Top",
             "text": "Each player reveals a number of cards from the top of their library equal to the number of nonland permanents they control, puts all permanent cards they revealed this way onto the battlefield, and puts the rest into their graveyard.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "0328369b-ccca-54ca-8379-57be49826b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2deb43-7134-4f9c-b02d-78407a8986b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2deb43-7134-4f9c-b02d-78407a8986b1.jpg?1",
             "name": "Penregon Strongbull",
             "text": "{1}, Sacrifice an artifact: Penregon Strongbull gets +1/+1 until end of turn and deals 1 damage to each opponent.",
             "colours": [
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "1fdc7357-e19a-55e4-9369-2260c7d90f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a523d5a7-58b1-45a3-81a7-078da02fda16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a523d5a7-58b1-45a3-81a7-078da02fda16.jpg?1",
             "name": "Pyrrhic Blast",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nPyrrhic Blast deals damage equal to the sacrificed creature's power to any target. Draw a card.",
             "colours": [
@@ -5046,7 +5046,7 @@
         },
         {
             "id": "427d4499-1504-5f0f-90fa-34897c7e3579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b25d2-7615-4375-a5e6-3d762c9072a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b25d2-7615-4375-a5e6-3d762c9072a5.jpg?1",
             "name": "Raze to the Ground",
             "text": "This spell can't be countered.\nDestroy target artifact. If its mana value was 1 or less, draw a card.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "a9aa5ab4-6a56-50b1-adc5-439501659132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8b2f2b-6f19-47f7-bb65-00665989bc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8b2f2b-6f19-47f7-bb65-00665989bc30.jpg?1",
             "name": "Roc Hunter",
             "text": "Reach",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "d5bee0a3-7e2b-5266-88f1-0383cc31aeba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c42d56-5b0e-4624-8831-77280f8d56cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c42d56-5b0e-4624-8831-77280f8d56cf.jpg?1",
             "name": "Sardian Cliffstomper",
             "text": "As long as it's your turn and you control four or more Mountains, Sardian Cliffstomper gets +X/+0, where X is the number of Mountains you control.",
             "colours": [
@@ -5150,7 +5150,7 @@
         },
         {
             "id": "a042d331-b476-5474-8a11-fcb23278d97c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44b24de-60b4-4855-9111-f1237f71bc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44b24de-60b4-4855-9111-f1237f71bc4d.jpg?1",
             "name": "Sibling Rivalry",
             "text": "Gain control of target artifact or creature until end of turn. Untap it. It gains haste until end of turn. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "d2753000-fcdd-5e40-861b-655f88702140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d462d30c-9060-46d6-b5b3-cac476ee2ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d462d30c-9060-46d6-b5b3-cac476ee2ce1.jpg?1",
             "name": "Tomakul Scrapsmith",
             "text": "When Tomakul Scrapsmith enters the battlefield, mill three cards. You may put an artifact card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Tomakul Scrapsmith. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "e3f37554-cdb7-5053-9526-5b4a102a590c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg?1",
             "name": "Tyrant of Kher Ridges",
             "text": "Flying\nWhen Tyrant of Kher Ridges enters the battlefield, it deals 4 damage to any target.\n{R}: Tyrant of Kher Ridges gets +1/+0 until end of turn.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "e6ab5bd7-c7cd-5217-882d-c3ae7f44bb05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be13abf-b717-4122-ab2b-7e597a251d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be13abf-b717-4122-ab2b-7e597a251d52.jpg?1",
             "name": "Unleash Shell",
             "text": "Unleash Shell deals 5 damage to target creature or planeswalker and 2 damage to that permanent's controller.",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "7fb9f9e3-df5d-57ec-bbc2-aff651002431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e922ef35-b62a-4cf8-9282-319f6de150b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e922ef35-b62a-4cf8-9282-319f6de150b0.jpg?1",
             "name": "Visions of Phyrexia",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "086fa39d-8406-5503-a2ae-bd90b4ac878e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17950ae-43aa-4d03-a41e-726ca96eb1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17950ae-43aa-4d03-a41e-726ca96eb1ba.jpg?1",
             "name": "Whirling Strike",
             "text": "Target creature gets +2/+0 and gains first strike and trample until end of turn.",
             "colours": [
@@ -5351,7 +5351,7 @@
         },
         {
             "id": "b6c4533d-f98e-5288-b55d-1f214323c5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e5529a-848b-486c-97fb-1def35df7837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e5529a-848b-486c-97fb-1def35df7837.jpg?1",
             "name": "Blitz Automaton",
             "text": "Haste\n//PRT-Prototype_\nMech//\n{2}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/2",
             "colours": [],
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "fd946a7d-759e-58c5-92d9-8824fb360bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7761ed0-a784-4dfb-ab6c-0f4b9a411cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7761ed0-a784-4dfb-ab6c-0f4b9a411cf3.jpg?1",
             "name": "Fallaji Dragon Engine",
             "text": "Flying\n{2}: Fallaji Dragon Engine gets +1/+0 until end of turn.\n//PRT-Prototype_\nMech//\n{2}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/3",
             "colours": [],
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "62074b30-e6cf-5120-9316-874abd2db2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72de800-b28e-42c4-a3ca-5ec3a765d807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72de800-b28e-42c4-a3ca-5ec3a765d807.jpg?1",
             "name": "Heavyweight Demolisher",
             "text": "Menace\nAt the beginning of your upkeep, tap Heavyweight Demolisher unless you pay {3}.\nUnearth {6}{R}{R} ({6}{R}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "0389cce5-ceeb-5f1b-a9ec-3033872af362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30457c3-57df-4720-8b45-962f16316d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30457c3-57df-4720-8b45-962f16316d17.jpg?1",
             "name": "Mishra's Juggernaut",
             "text": "Trample\nMishra's Juggernaut attacks each combat if able.\nUnearth {5}{R} ({5}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5483,7 +5483,7 @@
         },
         {
             "id": "6d4c37b1-193d-55f4-874f-58e9d934641d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb142d99-b210-47c8-897c-be62f90d2192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb142d99-b210-47c8-897c-be62f90d2192.jpg?1",
             "name": "Mishra's Research Desk",
             "text": "{1}, {T}, Sacrifice Mishra's Research Desk: Exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to the battlefield. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "1fed551b-5e52-56bb-943d-0d42937e98bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b826be-4256-4fd6-ad4d-6c80933ee940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b826be-4256-4fd6-ad4d-6c80933ee940.jpg?1",
             "name": "Phyrexian Dragon Engine // Mishra, Lost to Phyrexia",
             "text": "Double strike\nWhen Phyrexian Dragon Engine enters the battlefield from your graveyard, you may discard your hand. If you do, draw three cards.\nUnearth {3}{R}{R}\n(Melds with Mishra, Claimed by Gix.)",
             "colours": [],
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "a36682d1-8f05-5039-a892-9ce0072591cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0220c1e9-07bc-44f0-b39e-ca345ec4ea28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0220c1e9-07bc-44f0-b39e-ca345ec4ea28.jpg?1",
             "name": "Mishra, Lost to Phyrexia",
             "text": "Double strike\nWhen Phyrexian Dragon Engine enters the battlefield from your graveyard, you may discard your hand. If you do, draw three cards.\nUnearth {3}{R}{R}\n(Melds with Mishra, Claimed by Gix.)",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "40fd4f3f-e274-56c3-bd09-16c0366dca3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4742800a-4872-4c2d-b884-01e0ba16950c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4742800a-4872-4c2d-b884-01e0ba16950c.jpg?1",
             "name": "Scrapwork Mutt",
             "text": "When Scrapwork Mutt enters the battlefield, you may discard a card. If you do, draw a card.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5620,7 +5620,7 @@
         },
         {
             "id": "bcdfe769-d83d-5680-901a-27a6e4dd161f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc1715-4ddb-4404-83c6-0b8a61922578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc1715-4ddb-4404-83c6-0b8a61922578.jpg?1",
             "name": "Skitterbeam Battalion",
             "text": "Trample, haste\nWhen Skitterbeam Battalion enters the battlefield, if you cast it, create two tokens that are copies of it.\n//PRT-Prototype_\nMech//\n{3}{R}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "da278dac-f4fc-5b5f-8973-24d4067c0285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a49b18-a339-401c-ab77-fcd04772cf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a49b18-a339-401c-ab77-fcd04772cf69.jpg?1",
             "name": "Alloy Animist",
             "text": "{2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "97ae6f61-f18a-591b-b3e4-e695792465c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22586ce-efcc-4b20-83f9-c23b8eeaa88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22586ce-efcc-4b20-83f9-c23b8eeaa88c.jpg?1",
             "name": "Argothian Opportunist",
             "text": "When Argothian Opportunist enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "bf113b54-578e-5a44-a10c-2b4192fe3f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbc383-7e08-4701-8d4a-6b99b74fe358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbc383-7e08-4701-8d4a-6b99b74fe358.jpg?1",
             "name": "Argothian Sprite",
             "text": "Argothian Sprite can't be blocked by artifact creatures.\n{7}: Put two +1/+1 counters on Argothian Sprite.",
             "colours": [
@@ -5759,7 +5759,7 @@
         },
         {
             "id": "6f546755-0a79-57c7-98da-3e672031d255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b0813a-38cf-4a07-81d6-91d24af8b549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b0813a-38cf-4a07-81d6-91d24af8b549.jpg?1",
             "name": "Audacity",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Audacity is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "314fc60c-69ab-593d-8b90-2607bfc9bc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c95f8b8-faba-4412-8d8f-093e2ec903f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c95f8b8-faba-4412-8d8f-093e2ec903f0.jpg?1",
             "name": "Awaken the Woods",
             "text": "Create X 1/1 green Forest Dryad land creature tokens. (They're affected by summoning sickness.)",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "0c193a0e-6d64-5231-a8cc-cf77cb65c1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c0a68-53be-4905-8ed3-79b4782dfd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c0a68-53be-4905-8ed3-79b4782dfd6e.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "7247d9dc-4a21-5445-8581-863a0d1ad376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6988b6-ade0-4cd5-b27c-146e5e7ae91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6988b6-ade0-4cd5-b27c-146e5e7ae91f.jpg?1",
             "name": "Blanchwood Prowler",
             "text": "When Blanchwood Prowler enters the battlefield, mill three cards. You may put a land card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Blanchwood Prowler. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "93f5f893-8ae2-5de7-811c-ac29676e64e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c8c73c-ee2e-4aa9-aa6c-42cf9d58d9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c8c73c-ee2e-4aa9-aa6c-42cf9d58d9cc.jpg?1",
             "name": "Burrowing Razormaw",
             "text": "When Burrowing Razormaw dies, mill four cards. (Put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -5931,7 +5931,7 @@
         },
         {
             "id": "e3a4342f-3269-5a42-8649-66f3aba2b352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712a0640-d9c8-46fc-b38b-bf20a40fa902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712a0640-d9c8-46fc-b38b-bf20a40fa902.jpg?1",
             "name": "Bushwhack",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n\u2022 Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "3e05e119-95ff-515a-98c4-216571e85b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a842a945-21d9-432c-b970-6da65b16f309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a842a945-21d9-432c-b970-6da65b16f309.jpg?1",
             "name": "Citanul Stalwart",
             "text": "{T}, Tap an untapped artifact or creature you control: Add one mana of any color.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "23ef6d8a-0429-5197-89f1-f7d1c7b28c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ba6c05-a4c2-422b-a4cb-852b3aef77a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ba6c05-a4c2-422b-a4cb-852b3aef77a5.jpg?1",
             "name": "Epic Confrontation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "caf578d5-3349-5335-a06f-bcc5d5d9c1e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f13f67-e852-4a6a-8f32-b16195e53ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f13f67-e852-4a6a-8f32-b16195e53ec3.jpg?1",
             "name": "Fade from History",
             "text": "Each player who controls an artifact or enchantment creates a 2/2 green Bear creature token. Then destroy all artifacts and enchantments.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "42c97eed-5a55-5c54-9b20-56f9dab23a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac75c41f-82dc-4b06-a233-9b74ea177a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac75c41f-82dc-4b06-a233-9b74ea177a3d.jpg?1",
             "name": "Fallaji Excavation",
             "text": "Create three tapped Powerstone tokens. You gain 3 life. (The tokens are artifacts with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "61fdcf9c-4ed3-51e6-ba87-f643b2ae83ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b906eb-3223-474c-9b74-eda2c280f9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b906eb-3223-474c-9b74-eda2c280f9c5.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "a07b5281-2d89-5962-a8d5-6e6966a4d266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37096c19-32c9-448a-94e9-f5fe2d74e3a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37096c19-32c9-448a-94e9-f5fe2d74e3a3.jpg?1",
             "name": "Fog of War",
             "text": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn by creatures with power 3 or less.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "b8718011-8424-5f62-868d-6ca6a25a4183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0b94e5-d270-4820-83b9-1d346d378ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0b94e5-d270-4820-83b9-1d346d378ff8.jpg?1",
             "name": "Gaea's Courser",
             "text": "Whenever Gaea's Courser attacks, if there are three or more creature cards in your graveyard, draw a card.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "d1117672-0188-5448-8816-e1c05e115cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5503186a-46fe-4956-8ae3-5ab3343f8a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5503186a-46fe-4956-8ae3-5ab3343f8a93.jpg?1",
             "name": "Gaea's Gift",
             "text": "Put a +1/+1 counter on target creature you control. It gains reach, trample, hexproof, and indestructible until end of turn. (It can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -6233,7 +6233,7 @@
         },
         {
             "id": "5bf95967-9b61-556d-ab34-e5f95409a41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeece336-e5e8-4455-a297-c3739198d011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeece336-e5e8-4455-a297-c3739198d011.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6265,7 +6265,7 @@
         },
         {
             "id": "a64ade57-b73e-530c-9e20-2c3bb09c094b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7382154-ac8f-40ca-94e4-2f0533c0cf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7382154-ac8f-40ca-94e4-2f0533c0cf20.jpg?1",
             "name": "Gnarlroot Pallbearer",
             "text": "Trample\nWhen Gnarlroot Pallbearer enters the battlefield, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -6300,7 +6300,7 @@
         },
         {
             "id": "20c40ff1-79fe-54c2-9fd9-e291a958710d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee387b7-18e4-41b7-aefe-f2b5954e3051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee387b7-18e4-41b7-aefe-f2b5954e3051.jpg?1",
             "name": "Gwenna, Eyes of Gaea",
             "text": "{T}: Add two mana in any combination of colors. Spend this mana only to cast creature spells or activate abilities of a creature or creature card.\nWhenever you cast a creature spell with power 5 or greater, put a +1/+1 counter on Gwenna, Eyes of Gaea and untap it.",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "b55af31c-cfb7-5158-be43-c3ce69e765d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559afec-6bb8-4501-8805-4eb108443048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559afec-6bb8-4501-8805-4eb108443048.jpg?1",
             "name": "Hoarding Recluse",
             "text": "Reach, deathtouch\nWhen Hoarding Recluse dies, put up to one other target card from a graveyard on the bottom of its owner's library.",
             "colours": [
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "09d8ecde-d26b-55da-9840-16fc25b0bd5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b7809f-f3a3-439e-8bae-c083842de1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b7809f-f3a3-439e-8bae-c083842de1bf.jpg?1",
             "name": "Obstinate Baloth",
             "text": "When Obstinate Baloth enters the battlefield, you gain 4 life.\nIf a spell or ability an opponent controls causes you to discard Obstinate Baloth, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6408,7 +6408,7 @@
         },
         {
             "id": "49246e91-908f-57d0-8984-c1ae5d4988aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4719bc1-4c27-45d8-89f7-8c76ccf946d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4719bc1-4c27-45d8-89f7-8c76ccf946d2.jpg?1",
             "name": "Perimeter Patrol",
             "text": "Whenever an artifact enters the battlefield under your control, Perimeter Patrol gets +1/+0 until end of turn.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "8b1e24f2-e131-54b6-adbe-2607d3d6f3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96761b2-eb9c-4963-a496-ba53a01f4b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96761b2-eb9c-4963-a496-ba53a01f4b17.jpg?1",
             "name": "Sarinth Steelseeker",
             "text": "Whenever an artifact enters the battlefield under your control, look at the top card of your library. If it's a land card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [
@@ -6479,7 +6479,7 @@
         },
         {
             "id": "40bf36df-6265-571f-8d67-4f8101fa9be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20014a1c-197c-4e04-94b2-874886183e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20014a1c-197c-4e04-94b2-874886183e2f.jpg?1",
             "name": "Shoot Down",
             "text": "Exile target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -6511,7 +6511,7 @@
         },
         {
             "id": "cbf28c20-39fe-5b7f-8e58-e6152b3ac1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbd975d-52f8-4fba-bf97-b8837413edd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbd975d-52f8-4fba-bf97-b8837413edd8.jpg?1",
             "name": "Tawnos's Tinkering",
             "text": "Put two +1/+1 counters on target artifact, creature, or land you control. Untap that permanent. If it isn't a creature, it becomes a 0/0 creature in addition to its other types.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "2bc9fb4b-da7f-56dc-a166-20b2facf2dcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2350027a-f3a4-4cba-9dfc-27e33bddb3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2350027a-f3a4-4cba-9dfc-27e33bddb3be.jpg?1",
             "name": "Teething Wurmlet",
             "text": "Teething Wurmlet has deathtouch as long as you control three or more artifacts.\nWhenever an artifact enters the battlefield under your control, you gain 1 life. If this is the first time this ability has resolved this turn, put a +1/+1 counter on Teething Wurmlet.",
             "colours": [
@@ -6579,7 +6579,7 @@
         },
         {
             "id": "0790c50f-12b7-5cfb-9527-17e0ffc97580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb6a21-23b0-44f1-b70e-5899bb9d4a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb6a21-23b0-44f1-b70e-5899bb9d4a84.jpg?1",
             "name": "Titania, Voice of Gaea // Titania, Gaea Incarnate",
             "text": "Reach\nWhenever one or more land cards are put into your graveyard from anywhere, you gain 2 life.\nAt the beginning of your upkeep, if there are four or more land cards in your graveyard and you both own and control Titania, Voice of Gaea and a land named Argoth, Sanctum of Nature, exile them, then meld them into Titania, Gaea Incarnate.",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "e56f4544-f67c-5233-b921-19333dbf47f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753567c7-c484-4c0d-8128-7710e23c428f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753567c7-c484-4c0d-8128-7710e23c428f.jpg?1",
             "name": "Titania's Command",
             "text": "Choose two \u2014\n\u2022 Exile target player's graveyard. You gain 1 life for each card exiled this way.\n\u2022 Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle.\n\u2022 Create two 2/2 green Bear creature tokens.\n\u2022 Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "0b3eebce-033c-5e33-9d9b-6275c0a92b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7745439-f40b-4647-8bff-53751d511bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7745439-f40b-4647-8bff-53751d511bbd.jpg?1",
             "name": "Tomakul Honor Guard",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "532b5cb0-f0ba-5625-8707-cadcfb27283e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a0c819-36d1-442b-bec5-e6df58a122c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a0c819-36d1-442b-bec5-e6df58a122c0.jpg?1",
             "name": "Wasteful Harvest",
             "text": "Mill five cards. You may put a permanent card from among the cards milled this way into your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -6716,7 +6716,7 @@
         },
         {
             "id": "fb9f08cf-aa64-5f98-b70d-67b29d033ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6e5338-9b95-4ac7-a57c-5efaa6423531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6e5338-9b95-4ac7-a57c-5efaa6423531.jpg?1",
             "name": "Boulderbranch Golem",
             "text": "When Boulderbranch Golem enters the battlefield, you gain life equal to its power.\n//PRT-Prototype_\nMech//\n{3}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -6749,7 +6749,7 @@
         },
         {
             "id": "2cf7fc0a-0543-559f-ab34-4fbc00528e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc9b90-792e-4cf7-ab8c-cb616d94092a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc9b90-792e-4cf7-ab8c-cb616d94092a.jpg?1",
             "name": "Cradle Clearcutter",
             "text": "{T}: Add an amount of {G} equal to Cradle Clearcutter's power.\n//PRT-Prototype_\nMech//\n{2}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/3",
             "colours": [],
@@ -6782,7 +6782,7 @@
         },
         {
             "id": "4cc2e974-bd0c-5568-9ac0-537368c3042a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847a175e-ead1-4596-baf3-5f7f57859e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847a175e-ead1-4596-baf3-5f7f57859e0b.jpg?1",
             "name": "Haywire Mite",
             "text": "When Haywire Mite dies, you gain 2 life.\n{G}, Sacrifice Haywire Mite: Exile target noncreature artifact or noncreature enchantment.",
             "colours": [],
@@ -6815,7 +6815,7 @@
         },
         {
             "id": "0d9b74f3-200b-56a7-87f2-ef9f6686860c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2ec10-f45f-46ef-a076-52425bf3fe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2ec10-f45f-46ef-a076-52425bf3fe3b.jpg?1",
             "name": "Iron-Craw Crusher",
             "text": "Whenever Iron-Craw Crusher attacks, target attacking creature gets +X/+0 until end of turn, where X is Iron-Craw Crusher's power.\n//PRT-Prototype_\nMech//\n{2}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/5",
             "colours": [],
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "fe27490c-9c04-5a9a-bab8-2c7a51484463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db83275-bfd2-42c2-8d0f-e8a9b4f60e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db83275-bfd2-42c2-8d0f-e8a9b4f60e78.jpg?1",
             "name": "Mask of the Jadecrafter",
             "text": "{X}, {T}, Sacrifice Mask of the Jadecrafter: Create an X/X colorless Golem artifact creature token. Activate only as a sorcery.\nUnearth {2}{G} ({2}{G}: Return this card from your graveyard to the battlefield. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -6878,7 +6878,7 @@
         },
         {
             "id": "89919133-f7c6-5da5-b9d5-6e50f2da65e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb74e91-f7e5-49dd-8aa8-83a679f88a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb74e91-f7e5-49dd-8aa8-83a679f88a21.jpg?1",
             "name": "Perennial Behemoth",
             "text": "You may play lands from your graveyard.\nUnearth {G}{G} ({G}{G}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "5ea8ee46-f5ce-53a8-8465-4b6addb949bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2498b591-4a80-459f-a639-fe4cf8880be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2498b591-4a80-459f-a639-fe4cf8880be2.jpg?1",
             "name": "Rootwire Amalgam",
             "text": "{3}{G}{G}, Sacrifice Rootwire Amalgam: Create an X/X colorless Golem artifact creature token, where X is three times Rootwire Amalgam's power. It gains haste until end of turn. Activate only as a sorcery.\n//PRT-Prototype_\nMech//\n{1}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/3",
             "colours": [],
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "184e1578-4318-568c-9bd7-121f98ca9d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8348f73d-4226-4296-9d51-a2c497ee8270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8348f73d-4226-4296-9d51-a2c497ee8270.jpg?1",
             "name": "Rust Goliath",
             "text": "Reach, trample\n//PRT-Prototype_\nMech//\n{3}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/5",
             "colours": [],
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "5154d2db-cc4c-52a7-b9a9-86d1ea614496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85e2a35-cb55-434c-bbd7-54c3438345c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85e2a35-cb55-434c-bbd7-54c3438345c1.jpg?1",
             "name": "Simian Simulacrum",
             "text": "When Simian Simulacrum enters the battlefield, put two +1/+1 counters on target creature you control.\nUnearth {2}{G}{G} ({2}{G}{G}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -7016,7 +7016,7 @@
         },
         {
             "id": "1f28a30c-885f-5d5b-922f-68b19bcf27cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df343bf9-f535-42c7-a2d0-8adfd068b354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df343bf9-f535-42c7-a2d0-8adfd068b354.jpg?1",
             "name": "Arbalest Engineers",
             "text": "When Arbalest Engineers enters the battlefield, choose one \u2014\n\u2022 Arbalest Engineers deals 1 damage to any target.\n\u2022 Put a +1/+1 counter on target creature. It gains trample and haste until end of turn.\n\u2022 Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "ad9ae075-3e9c-5369-92c7-878ceaa1b800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5306d6-0f08-429a-8590-1b8136f953a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5306d6-0f08-429a-8590-1b8136f953a9.jpg?1",
             "name": "Battery Bearer",
             "text": "Creatures you control have \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\"\nWhenever you cast an artifact spell with mana value 6 or greater, draw a card.",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "a7e21039-ff09-50c7-8299-1ea8a3cdc6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ff816d-1eb7-4985-90ec-f44802a696fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ff816d-1eb7-4985-90ec-f44802a696fc.jpg?1",
             "name": "Deathbloom Ritualist",
             "text": "{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "16b1dd47-c8b3-5add-aa98-dd636dbc1ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b60003-a987-49b0-a0f8-bb825c97da4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b60003-a987-49b0-a0f8-bb825c97da4d.jpg?1",
             "name": "Evangel of Synthesis",
             "text": "When Evangel of Synthesis enters the battlefield, draw a card, then discard a card.\nAs long as you've drawn two or more cards this turn, Evangel of Synthesis gets +1/+0 and has menace.",
             "colours": [
@@ -7167,7 +7167,7 @@
         },
         {
             "id": "d2d93bbc-2060-528c-98a6-f8085f346f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe9ee1c-5eb3-4d63-a641-0ec5adf7b058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe9ee1c-5eb3-4d63-a641-0ec5adf7b058.jpg?1",
             "name": "Fallaji Vanguard",
             "text": "First strike\nWhenever Fallaji Vanguard or another creature enters the battlefield under your control, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "b8b76c44-86c5-5fbf-9ae7-b2fee43d4b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0a2f82-57d3-45d8-b1c8-357883c62728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0a2f82-57d3-45d8-b1c8-357883c62728.jpg?1",
             "name": "Hajar, Loyal Bodyguard",
             "text": "Sacrifice Hajar, Loyal Bodyguard: Legendary creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -7245,7 +7245,7 @@
         },
         {
             "id": "8f457986-a684-5af9-aef6-5cd93ffe6157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b88be69-3201-4345-a193-cc21bd066d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b88be69-3201-4345-a193-cc21bd066d15.jpg?1",
             "name": "Harbin, Vanguard Aviator",
             "text": "Flying\nWhenever you attack with five or more Soldiers, creatures you control get +1/+1 and gain flying until end of turn.",
             "colours": [
@@ -7286,7 +7286,7 @@
         },
         {
             "id": "192fee3d-a7e0-53c8-a9ac-24d3f7686ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c72d5-f08e-4e46-a5cb-26d1fc0a71c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c72d5-f08e-4e46-a5cb-26d1fc0a71c8.jpg?1",
             "name": "Hero of the Dunes",
             "text": "When Hero of the Dunes enters the battlefield, return target artifact or creature card with mana value 3 or less from your graveyard to the battlefield.\nCreatures you control with mana value 3 or less get +1/+0.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "edde2c6d-4d34-5af5-be7e-c5c209dbd25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15b0676-b698-4160-8d2f-a22a1011bac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15b0676-b698-4160-8d2f-a22a1011bac0.jpg?1",
             "name": "Junkyard Genius",
             "text": "When Junkyard Genius enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n{1}{B}{R}, Sacrifice another creature or artifact: Until end of turn, other creatures you control get +1/+0 and gain menace and haste.",
             "colours": [
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "22d70591-589f-5189-8c4e-e0f7ac5294d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94faea39-4540-4adc-b9bd-78fefd09ecdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94faea39-4540-4adc-b9bd-78fefd09ecdf.jpg?1",
             "name": "Legions to Ashes",
             "text": "Exile target nonland permanent an opponent controls and all tokens that player controls with the same name as that permanent.",
             "colours": [
@@ -7396,7 +7396,7 @@
         },
         {
             "id": "a0befb3c-dd24-5fc6-98a5-ebaff509e262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a469d7ec-42de-45de-9d8f-469bb979de58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a469d7ec-42de-45de-9d8f-469bb979de58.jpg?1",
             "name": "Mishra, Claimed by Gix // Mishra, Lost to Phyrexia",
             "text": "Whenever you attack, each opponent loses X life and you gain X life, where X is the number of attacking creatures. If Mishra, Claimed by Gix and a creature named Phyrexian Dragon Engine are attacking, and you both own and control them, exile them, then meld them into Mishra, Lost to Phyrexia. It enters the battlefield tapped and attacking.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "89b49f3f-7ad9-56b4-86e7-05abffd49eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585a753d-a692-474a-bc28-48dd93b73ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585a753d-a692-474a-bc28-48dd93b73ace.jpg?1",
             "name": "Mishra, Tamer of Mak Fawa",
             "text": "Permanents you control have \"Ward\u2014\nSacrifice a permanent.\"\nEach artifact card in your graveyard has unearth {1}{B}{R}. ({1}{B}{R}: Return the card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -7477,7 +7477,7 @@
         },
         {
             "id": "0f6d154d-92b2-5bfe-b455-a0b71c09250d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685c9767-eaa7-4e16-b245-816181e2fc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685c9767-eaa7-4e16-b245-816181e2fc36.jpg?1",
             "name": "Queen Kayla bin-Kroog",
             "text": "{4}, {T}: Discard all the cards in your hand, then draw that many cards. You may choose an artifact or creature card with mana value 1 you discarded this way, then do the same for artifact or creature cards with mana values 2 and 3. Return those cards to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "afc2ada3-6503-526b-9797-66372368c1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657562-323c-40d0-a261-d029ed549695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657562-323c-40d0-a261-d029ed549695.jpg?1",
             "name": "Saheeli, Filigree Master",
             "text": "+1: Scry 1. You may tap an untapped artifact you control. If you do, draw a card.\n\u22122: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n\u22124: You get an emblem with \"Artifact creatures you control get +1/+1\" and \"Artifact spells you cast cost {1} less to cast.\"",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "c6714756-ee82-5b3b-b803-3cff347bde81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee6fcb-23de-4347-84b6-1e9849a537fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee6fcb-23de-4347-84b6-1e9849a537fc.jpg?1",
             "name": "Sarinth Greatwurm",
             "text": "Trample\nWhenever a land enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -7597,7 +7597,7 @@
         },
         {
             "id": "e967f647-227f-53c7-a2fa-a4d61f7feebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87300ac8-8b6f-4c37-8058-beb59eaa66be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87300ac8-8b6f-4c37-8058-beb59eaa66be.jpg?1",
             "name": "Skyfisher Spider",
             "text": "Reach\nWhen Skyfisher Spider enters the battlefield, you may sacrifice another creature. When you do, destroy target nonland permanent.\nWhen Skyfisher Spider dies, you may gain 1 life for each creature card in your graveyard. If you do, exile Skyfisher Spider from your graveyard.",
             "colours": [
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "cc0643ac-cd6b-54bd-ae75-4e766d666352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f855a7e-3a97-4b62-a2a7-06ff1fbb2c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f855a7e-3a97-4b62-a2a7-06ff1fbb2c4c.jpg?1",
             "name": "Tawnos, the Toymaker",
             "text": "Whenever you cast a Beast or Bird creature spell, you may copy it, except the copy is an artifact in addition to its other types. (The copy becomes a token.)",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "5ff62b2f-368e-56e6-9004-645edce1f8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a21287-e244-4960-84fb-c4f6e5c346d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a21287-e244-4960-84fb-c4f6e5c346d9.jpg?1",
             "name": "Third Path Iconoclast",
             "text": "Whenever you cast a noncreature spell, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "cd6e6c26-d3e1-5107-b2da-fc434fb9ab9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919a32a6-b66d-4a75-a02f-fa1c4c87b738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919a32a6-b66d-4a75-a02f-fa1c4c87b738.jpg?1",
             "name": "Tocasia, Dig Site Mentor",
             "text": "Creatures you control have vigilance and \"{T}: Surveil 1.\" (To surveil 1, look at the top card of your library. You may put that card into your graveyard.)\n{2}{G}{G}{W}{W}{U}{U}, Exile Tocasia, Dig Site Mentor from your graveyard: Return any number of target artifact cards with total mana value 10 or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "a7bf10ae-b926-5ecd-9060-8d4f4931e6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aefe8bd-216a-4ec1-9362-3f9dbf7fd083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aefe8bd-216a-4ec1-9362-3f9dbf7fd083.jpg?1",
             "name": "Urza, Lord Protector // Urza, Planeswalker",
             "text": "Artifact, instant, and sorcery spells you cast cost {1} less to cast.\n{7}: If you both own and control Urza, Lord Protector and an artifact named The Mightstone and Weakstone, exile them, then meld them into Urza, Planeswalker. Activate only as a sorcery.",
             "colours": [
@@ -7793,7 +7793,7 @@
         },
         {
             "id": "09f6f5ad-b643-523f-a061-6f2e63ad4d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7329cd-95af-4d71-984f-f5f28982520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7329cd-95af-4d71-984f-f5f28982520c.jpg?1",
             "name": "Urza, Prince of Kroog",
             "text": "Artifact creatures you control get +2/+2.\n{6}: Create a token that's a copy of target artifact you control, except it's a 1/1 Soldier creature in addition to its other types.",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "9563f5e5-965f-53f4-8c7e-a4f52cae3815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb02f00-c188-4193-a049-d26f7643e5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb02f00-c188-4193-a049-d26f7643e5da.jpg?1",
             "name": "Yotian Dissident",
             "text": "Whenever an artifact enters the battlefield under your control, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "b852123c-17f5-5080-937e-fd24bbd119be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760c0369-c2e4-4bd7-a301-9f707f5f48a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760c0369-c2e4-4bd7-a301-9f707f5f48a8.jpg?1",
             "name": "Yotian Tactician",
             "text": "Other Soldiers you control get +1/+1.",
             "colours": [
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "90babbf8-48bd-5261-9b87-3e6a882cbf63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5a528-d16d-4cb9-b532-b85648c8395a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5a528-d16d-4cb9-b532-b85648c8395a.jpg?1",
             "name": "Bladecoil Serpent",
             "text": "When Bladecoil Serpent enters the battlefield, for each {U}{U} spent to cast it, draw a card.\nWhen Bladecoil Serpent enters the battlefield, for each {B}{B} spent to cast it, each opponent discards a card.\nWhen Bladecoil Serpent enters the battlefield, for each {R}{R} spent to cast it, it gets +1/+0 and gains trample and haste until end of turn.",
             "colours": [],
@@ -7945,7 +7945,7 @@
         },
         {
             "id": "ff9ce47a-8c7c-52a7-a78e-de84fadc9726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625f3b20-4b9a-4f61-8afe-31a761711b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625f3b20-4b9a-4f61-8afe-31a761711b43.jpg?1",
             "name": "Clay Champion",
             "text": "Clay Champion enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.\nWhen Clay Champion enters the battlefield, choose up to two other target creatures you control. For each {W}{W} spent to cast Clay Champion, put a +1/+1 counter on each of them.",
             "colours": [],
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "88a2f1d1-3885-50d2-9b07-b6a7a9bb2aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc65821-e4e7-471c-941c-9d3e25ae8bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc65821-e4e7-471c-941c-9d3e25ae8bb9.jpg?1",
             "name": "Aeronaut's Wings",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8011,7 +8011,7 @@
         },
         {
             "id": "5e50d57d-75bd-5617-b0df-b2d2baf82b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e3bf5a-0a90-46d3-bcfe-9a47df41b72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e3bf5a-0a90-46d3-bcfe-9a47df41b72b.jpg?1",
             "name": "Argivian Avenger",
             "text": "{1}: Until end of turn, Argivian Avenger gets -1/-1 and gains your choice of flying, vigilance, deathtouch, or haste.",
             "colours": [],
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "37fac802-b4f8-5546-9d40-73130868cea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a87278-4c82-4056-8354-253d86b0ef3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a87278-4c82-4056-8354-253d86b0ef3d.jpg?1",
             "name": "Cityscape Leveler",
             "text": "Trample\nWhen you cast this spell and whenever Cityscape Leveler attacks, destroy up to one target nonland permanent. Its controller creates a tapped Powerstone token.\nUnearth {8}",
             "colours": [],
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "8d96f7f1-a839-56a3-acf7-1c092bff6b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a81fb-5045-4b7b-8cfb-b90c4f4a1f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a81fb-5045-4b7b-8cfb-b90c4f4a1f51.jpg?1",
             "name": "Energy Refractor",
             "text": "When Energy Refractor enters the battlefield, draw a card.\n{2}: Add one mana of any color.",
             "colours": [],
@@ -8103,7 +8103,7 @@
         },
         {
             "id": "4ef34f7f-63a1-5e81-bc5b-d684165bdd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba00d0f-0ea5-417c-a792-06b3b9d1c8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba00d0f-0ea5-417c-a792-06b3b9d1c8f1.jpg?1",
             "name": "Goblin Firebomb",
             "text": "Flash\n{7}, {T}, Sacrifice Goblin Firebomb: Destroy target permanent.",
             "colours": [],
@@ -8131,7 +8131,7 @@
         },
         {
             "id": "cbfddd32-d5dc-51dc-8dca-37d37b3315e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a17e2-e019-4686-9795-651da2d2955c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a17e2-e019-4686-9795-651da2d2955c.jpg?1",
             "name": "Levitating Statue",
             "text": "Flying\nWhenever you cast a noncreature spell, put a +1/+1 counter on Levitating Statue.\n{2}: Levitating Statue becomes a 1/1 Construct artifact creature until end of turn.",
             "colours": [],
@@ -8159,7 +8159,7 @@
         },
         {
             "id": "b632b5df-ae5e-57c7-82cf-95d6ba5d7614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6768-bcab-43c4-bfc1-76e961689ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6768-bcab-43c4-bfc1-76e961689ae9.jpg?1",
             "name": "Liberator, Urza's Battlethopter",
             "text": "Flash\nFlying\nYou may cast colorless spells and artifact spells as though they had flash.\nWhenever you cast a spell, if the amount of mana spent to cast that spell is greater than Liberator, Urza's Battlethopter's power, put a +1/+1 counter on Liberator.",
             "colours": [],
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "c65122ae-e701-568a-b243-15e7b0c35dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02aea379-b444-46a3-82f4-3038f698d4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02aea379-b444-46a3-82f4-3038f698d4f4.jpg?1",
             "name": "The Mightstone and Weakstone // Urza, Planeswalker",
             "text": "When The Mightstone and Weakstone enters the battlefield, choose one \u2014\n\u2022 Draw two cards.\n\u2022 Target creature gets -5/-5 until end of turn.\n{T}: Add {C}{C}. This mana can't be spent to cast nonartifact spells.\n(Melds with Urza, Lord Protector.)",
             "colours": [],
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "286fd366-82c8-5948-8101-d10bcf67fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a01679-3224-427e-bd1d-b797b0ab68b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a01679-3224-427e-bd1d-b797b0ab68b7.jpg?1",
             "name": "Urza, Planeswalker",
             "text": "When The Mightstone and Weakstone enters the battlefield, choose one \u2014\n\u2022 Draw two cards.\n\u2022 Target creature gets -5/-5 until end of turn.\n{T}: Add {C}{C}. This mana can't be spent to cast nonartifact spells.\n(Melds with Urza, Lord Protector.)",
             "colours": [
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "ca11a65f-4f32-5548-b507-af7484ca98b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa63321-aa28-449d-a31f-869a98c5a6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa63321-aa28-449d-a31f-869a98c5a6be.jpg?1",
             "name": "Mine Worker",
             "text": "{T}: You gain 1 life. If you control creatures named Power Plant Worker and Tower Worker, you gain 3 life instead.",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "a275f01f-6b25-5ce6-bd51-9153b1c7f94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608efc-0dbc-4cc3-aadd-ed473bfc29ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608efc-0dbc-4cc3-aadd-ed473bfc29ab.jpg?1",
             "name": "Portal to Phyrexia",
             "text": "When Portal to Phyrexia enters the battlefield, each opponent sacrifices three creatures.\nAt the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control. It's a Phyrexian in addition to its other types.",
             "colours": [],
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "a2598db8-76dc-542a-a56c-c99af0a101a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99965310-e4bd-40d9-80f5-3fd1754c61c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99965310-e4bd-40d9-80f5-3fd1754c61c5.jpg?1",
             "name": "Power Plant Worker",
             "text": "{3}: Power Plant Worker gets +2/+2 until end of turn. If you control creatures named Mine Worker and Tower Worker, put two +1/+1 counters on Power Plant Worker instead. Activate only once each turn.",
             "colours": [],
@@ -8356,7 +8356,7 @@
         },
         {
             "id": "fd8a3125-d584-5d26-9aea-c257e971a938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc8a8d8-6d8e-44b3-a29b-5fa4a851a25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc8a8d8-6d8e-44b3-a29b-5fa4a851a25b.jpg?1",
             "name": "Reconstructed Thopter",
             "text": "Flying\nUnearth {2} ({2}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "74de0397-b875-5f40-93c0-5d5ac07c2154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbfa72-2025-455c-8cc4-afbf6c8e141a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbfa72-2025-455c-8cc4-afbf6c8e141a.jpg?1",
             "name": "Slagstone Refinery",
             "text": "Whenever Slagstone Refinery or another nontoken artifact you control is put into a graveyard from the battlefield or is put into exile from the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [],
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "13aeee91-aa42-562c-a501-873274e3d203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cbe05-7b36-4569-94f3-671c28c7468a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cbe05-7b36-4569-94f3-671c28c7468a.jpg?1",
             "name": "Spectrum Sentinel",
             "text": "Protection from multicolored (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything multicolored.)\nWhenever a nonbasic land enters the battlefield under an opponent's control, you gain 1 life.",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "4b8a9ed6-0ace-5791-8355-369b54e27e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45537ac3-fc61-4253-a782-7f3e436b2aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45537ac3-fc61-4253-a782-7f3e436b2aa6.jpg?1",
             "name": "The Stasis Coffin",
             "text": "{2}, {T}, Exile The Stasis Coffin: You gain protection from everything until your next turn.",
             "colours": [],
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "20e2afbc-32a0-504c-8320-c6775f2d6633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386c139a-13fc-49ca-923d-45faca4f9a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386c139a-13fc-49ca-923d-45faca4f9a2f.jpg?1",
             "name": "Steel Exemplar",
             "text": "Trample\nSteel Exemplar enters the battlefield with two +1/+1 counters on it unless two or more colors of mana were spent to cast it.",
             "colours": [],
@@ -8509,7 +8509,7 @@
         },
         {
             "id": "23bdec55-7f79-5517-a5f8-c029016e7bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570ebf2-a94c-4621-8808-b06e6e830c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570ebf2-a94c-4621-8808-b06e6e830c06.jpg?1",
             "name": "The Stone Brain",
             "text": "{2}, {T}, Exile The Stone Brain: Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way. Activate only as a sorcery.",
             "colours": [],
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "5e13f63c-637e-5bba-8224-6c3883fd6f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a36d1f-f6cc-4962-9ad6-589f7b3e5f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a36d1f-f6cc-4962-9ad6-589f7b3e5f95.jpg?1",
             "name": "Stone Retrieval Unit",
             "text": "When Stone Retrieval Unit enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [],
@@ -8572,7 +8572,7 @@
         },
         {
             "id": "b97d4f4c-8626-579f-b8f6-6ab638abbde4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb04dad2-4561-4cef-9cee-80d6f1a44bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb04dad2-4561-4cef-9cee-80d6f1a44bee.jpg?1",
             "name": "Su-Chi Cave Guard",
             "text": "Vigilance\nWard {4} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {4}.)\nWhen Su-Chi Cave Guard dies, add eight {C}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -8603,7 +8603,7 @@
         },
         {
             "id": "8b4513b5-ca5f-5b2b-b6aa-5a99fba37c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a5d3e9-bada-448b-894d-9d4e7e0463c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a5d3e9-bada-448b-894d-9d4e7e0463c7.jpg?1",
             "name": "Supply Drop",
             "text": "Flash\nWhen Supply Drop enters the battlefield, target creature you control gets +2/+2 until end of turn.\n{4}, {T}, Sacrifice Supply Drop: Draw a card.",
             "colours": [],
@@ -8631,7 +8631,7 @@
         },
         {
             "id": "db63275f-5242-5c0d-8e47-8548f2a75a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ae38a2-2f95-4750-9b59-53eb1771e5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ae38a2-2f95-4750-9b59-53eb1771e5ab.jpg?1",
             "name": "Swiftgear Drake",
             "text": "Flying, haste\nWhen Swiftgear Drake enters the battlefield, put up to one target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "88e78772-4102-563a-a56d-5cb178adacac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786bce65-1c04-45fc-b81b-e7590afbd117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786bce65-1c04-45fc-b81b-e7590afbd117.jpg?1",
             "name": "Symmetry Matrix",
             "text": "Whenever a creature with power equal to its toughness enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [],
@@ -8690,7 +8690,7 @@
         },
         {
             "id": "37d12ab5-9cd2-5342-ae01-e6714f4c18d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bfb8c5-9105-41e4-a58f-9c9eee32b18a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bfb8c5-9105-41e4-a58f-9c9eee32b18a.jpg?1",
             "name": "Thran Power Suit",
             "text": "Equipped creature gets +1/+1 for each Aura and Equipment attached to it and has ward {2}. (Whenever equipped creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "372e83af-fdcf-539e-8357-ceec0a7f8662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e0ddb-3dd4-4db3-aa05-dec8691432a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e0ddb-3dd4-4db3-aa05-dec8691432a0.jpg?1",
             "name": "Thran Spider",
             "text": "Reach\nWhen Thran Spider enters the battlefield, you and target opponent each create a tapped Powerstone token.\n{7}: Look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8753,7 +8753,7 @@
         },
         {
             "id": "9deb8927-52f0-5ba8-a1f4-105b0abbc8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bd134-22c8-4031-8f85-ac0855914d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bd134-22c8-4031-8f85-ac0855914d11.jpg?1",
             "name": "Tower Worker",
             "text": "Reach\n{T}: Add {C}. If you control creatures named Mine Worker and Power Plant Worker, add {C}{C}{C} instead.",
             "colours": [],
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "39396ccd-e82b-59a3-9bdf-764cc8c17f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29c9e4f-7b98-4610-a681-ae6297e8fc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29c9e4f-7b98-4610-a681-ae6297e8fc72.jpg?1",
             "name": "Argoth, Sanctum of Nature // Titania, Gaea Incarnate",
             "text": "Argoth, Sanctum of Nature enters the battlefield tapped unless you control a legendary green creature.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Create a 2/2 green Bear creature token, then mill three cards. Activate only as a sorcery.\n(Melds with Titania, Voice of Gaea.)",
             "colours": [],
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "8736023c-a553-572a-a00c-07fca44030a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414b9230-9d25-4bdf-8b1e-b4fa2035b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414b9230-9d25-4bdf-8b1e-b4fa2035b6a4.jpg?1",
             "name": "Titania, Gaea Incarnate",
             "text": "Argoth, Sanctum of Nature enters the battlefield tapped unless you control a legendary green creature.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Create a 2/2 green Bear creature token, then mill three cards. Activate only as a sorcery.\n(Melds with Titania, Voice of Gaea.)",
             "colours": [
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "cf5c593c-e1fc-5eb7-b6a6-dbee9d8d65d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642584bb-7586-4796-9b94-f01ec5bd9e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642584bb-7586-4796-9b94-f01ec5bd9e9f.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "dccb779e-5a01-586d-9902-27e20ce8ba98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e911be-8166-4263-8c57-e86358b8ceb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e911be-8166-4263-8c57-e86358b8ceb8.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -8914,7 +8914,7 @@
         },
         {
             "id": "727a1c9a-40f0-5c81-b069-b7d401e49e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d236ce-3b78-403a-b5f9-4fb44123d85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d236ce-3b78-403a-b5f9-4fb44123d85b.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {W}. Brushland deals 1 damage to you.",
             "colours": [],
@@ -8947,7 +8947,7 @@
         },
         {
             "id": "eb840c40-ae48-5964-a12b-7f59708f34e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c88546-13c9-4d7e-a618-cb2ccd1dbc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c88546-13c9-4d7e-a618-cb2ccd1dbc0f.jpg?1",
             "name": "Demolition Field",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Demolition Field: Destroy target nonbasic land an opponent controls. That land's controller may search their library for a basic land card, put it onto the battlefield, then shuffle. You may search your library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "a1897b41-e40b-557a-83cc-3207a114890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238de888-b1bd-4cce-9aa2-d0dd69ae7f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238de888-b1bd-4cce-9aa2-d0dd69ae7f0d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9003,7 +9003,7 @@
         },
         {
             "id": "d6d6bf3d-8b9d-5f5a-9d59-bd27c5a7c780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e248204c-865d-42d9-b745-8ff73225b4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e248204c-865d-42d9-b745-8ff73225b4a1.jpg?1",
             "name": "Fortified Beachhead",
             "text": "As Fortified Beachhead enters the battlefield, you may reveal a Soldier card from your hand. Fortified Beachhead enters the battlefield tapped unless you revealed a Soldier card this way or you control a Soldier.\n{T}: Add {W} or {U}.\n{5}, {T}: Soldiers you control get +1/+1 until end of turn.",
             "colours": [],
@@ -9036,7 +9036,7 @@
         },
         {
             "id": "88ca67b5-006e-5901-bdba-383f75973ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8007012-39c5-4247-ba77-1cfcaade37fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8007012-39c5-4247-ba77-1cfcaade37fa.jpg?1",
             "name": "Hall of Tagsin",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}: Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [],
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "152d799e-5eae-534c-aee1-d37786f3eadd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10716909-1254-4b2b-997e-23a18994a98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10716909-1254-4b2b-997e-23a18994a98d.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "ff2169a0-a9f2-5b5a-9cc8-6892aa68fba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7699b2-e1af-4bc0-8c5b-84ba3e868d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7699b2-e1af-4bc0-8c5b-84ba3e868d7c.jpg?1",
             "name": "Mishra's Foundry",
             "text": "{T}: Add {C}.\n{2}: Mishra's Foundry becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
             "colours": [],
@@ -9130,7 +9130,7 @@
         },
         {
             "id": "da276698-7a48-58fc-839f-332a8506e850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d4b90c-95b1-4828-bc08-7067da0d5364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d4b90c-95b1-4828-bc08-7067da0d5364.jpg?1",
             "name": "Tocasia's Dig Site",
             "text": "{T}: Add {C}.\n{3}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [],
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "64a65d7e-44b3-5ac8-98c1-d02338a1cdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb52820c-8660-4c4a-bb64-5b2fc580b6a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb52820c-8660-4c4a-bb64-5b2fc580b6a3.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Underground River deals 1 damage to you.",
             "colours": [],
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "9ae1ab61-b907-5f63-992c-424bf6bcd3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22de1edc-ec67-4694-ab88-2a679c8a450f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22de1edc-ec67-4694-ab88-2a679c8a450f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "8b72255b-bf4f-5191-b99d-41718b0c6892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd136b1-c276-41f9-98ee-3e07eb87bacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd136b1-c276-41f9-98ee-3e07eb87bacb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9267,7 +9267,7 @@
         },
         {
             "id": "02dec623-655b-5a5a-9869-f97d19cbeb5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee75629-86b4-40b0-884a-22646ebf6e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee75629-86b4-40b0-884a-22646ebf6e27.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "ab4ab447-e7d7-5847-9ea6-b970ef9bc917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35ed4f-fa34-4fd6-b7d8-3c4aeda1e9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35ed4f-fa34-4fd6-b7d8-3c4aeda1e9ea.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9343,7 +9343,7 @@
         },
         {
             "id": "752304e1-c429-5e37-b7d0-961c6061f03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c90f777-2f98-4010-80a3-5fe395747e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c90f777-2f98-4010-80a3-5fe395747e5f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9381,7 +9381,7 @@
         },
         {
             "id": "21a2532d-1274-526b-8a5c-bc6697c74502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcf9b0-ee35-4911-b515-7182e703beba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcf9b0-ee35-4911-b515-7182e703beba.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "3c268a24-8845-5c9e-88d0-56c4377c6e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95083e1d-faf5-40e4-9be5-909cd01cc2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95083e1d-faf5-40e4-9be5-909cd01cc2b5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "e0e70bea-af7e-5e64-bd1c-a3bd21a7b5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf2ec64-a850-47e3-91a8-7323e04a5f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf2ec64-a850-47e3-91a8-7323e04a5f4a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9495,7 +9495,7 @@
         },
         {
             "id": "2c28ab78-255f-538a-af7a-6153c75718cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63eab07-46e5-4b75-954f-b5a9f1f451cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63eab07-46e5-4b75-954f-b5a9f1f451cd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9533,7 +9533,7 @@
         },
         {
             "id": "2a980176-aa7f-5adf-8dda-03381fc12295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73d19b-72e3-4944-ac20-5b4c7b54c2aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73d19b-72e3-4944-ac20-5b4c7b54c2aa.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9571,7 +9571,7 @@
         },
         {
             "id": "01536373-791b-5b3d-8552-7f913bf3229e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e134268-9ce9-4192-b548-90bedbfe654e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e134268-9ce9-4192-b548-90bedbfe654e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9609,7 +9609,7 @@
         },
         {
             "id": "e6f6c943-e131-597f-b8af-f1278c770725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b6636d-a342-4d49-9d1a-ab15b3d837c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b6636d-a342-4d49-9d1a-ab15b3d837c5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9647,7 +9647,7 @@
         },
         {
             "id": "d6a46536-5dcf-5b89-a382-0070a2cd4f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d36d3-9373-407c-91fd-975d8ee9e4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d36d3-9373-407c-91fd-975d8ee9e4fe.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9685,7 +9685,7 @@
         },
         {
             "id": "175704bb-12d2-5d7a-9d1c-1eef3b02d3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20af588-2ce3-4e5a-9ab3-949401ead071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20af588-2ce3-4e5a-9ab3-949401ead071.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9723,7 +9723,7 @@
         },
         {
             "id": "f3d2fe2d-46b9-5e21-bffa-4d5e5be8f2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabe866d-01c3-4ec5-9d41-70305208c2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabe866d-01c3-4ec5-9d41-70305208c2b1.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9761,7 +9761,7 @@
         },
         {
             "id": "11324c99-a07b-5f8f-b1b2-67802e5a254a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7232adef-c8eb-461f-b563-cb54cdeb22d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7232adef-c8eb-461f-b563-cb54cdeb22d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "3fa31ad3-44af-5fba-b955-2b42a9954bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b81a-3d91-4d07-bc9d-6756780417e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b81a-3d91-4d07-bc9d-6756780417e3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "2cdc66e7-edc9-531f-8a3a-f3fd34e9f881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd757142-45b7-40db-80f2-fe161379aa4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd757142-45b7-40db-80f2-fe161379aa4e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9875,7 +9875,7 @@
         },
         {
             "id": "22f0524a-7d97-5a61-b802-0b99dc79a11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b7277-0c09-42ab-aa6b-542a1e402580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b7277-0c09-42ab-aa6b-542a1e402580.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9913,7 +9913,7 @@
         },
         {
             "id": "e8a22501-2304-5dd8-b7c8-ab755ef9caef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c2a41c-e974-4c14-8d01-d278ecdb31bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c2a41c-e974-4c14-8d01-d278ecdb31bc.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9951,7 +9951,7 @@
         },
         {
             "id": "421fb941-5bb8-582b-99e7-d59aa251f2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598def2c-003c-4aa4-ac7c-44ffd9639fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598def2c-003c-4aa4-ac7c-44ffd9639fdc.jpg?1",
             "name": "Rescue Retriever",
             "text": "Flash\nWhen Rescue Retriever enters the battlefield, put a +1/+1 counter on each other Soldier you control.\nPrevent all damage that would be dealt to other attacking Soldiers you control.",
             "colours": [
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "00a2b46d-8f74-56e1-bee2-6d7a7b9c323e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb1f21c-60fa-4fcc-844b-25bf5b47fd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb1f21c-60fa-4fcc-844b-25bf5b47fd1f.jpg?1",
             "name": "Geology Enthusiast",
             "text": "At the beginning of your end step, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n{6}: Draw a card and put a +1/+1 counter on Geology Enthusiast.",
             "colours": [
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "d3ef8a19-4b2a-5ca6-a08a-e93915119d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31215674-0bcd-46f1-b8a1-5415f8b674d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31215674-0bcd-46f1-b8a1-5415f8b674d1.jpg?1",
             "name": "Terror Ballista",
             "text": "Menace\nWhenever Terror Ballista attacks, you may sacrifice another creature. When you do, destroy target creature an opponent controls.\nUnearth {3}{B}{B} ({3}{B}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -10060,7 +10060,7 @@
         },
         {
             "id": "5228982e-997d-5edc-9d3d-a29252504277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd88d6c-7d3a-45b1-85b4-b390d60cae14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd88d6c-7d3a-45b1-85b4-b390d60cae14.jpg?1",
             "name": "Artificer's Dragon",
             "text": "Flying\n{R}: Artifact creatures you control get +1/+0 until end of turn.\nUnearth {3}{R}{R} ({3}{R}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -10095,7 +10095,7 @@
         },
         {
             "id": "a89e0ffd-5b3b-5227-8818-e4270e8f06d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0418156-bcba-4edc-8ea5-ce9ca9b979bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0418156-bcba-4edc-8ea5-ce9ca9b979bd.jpg?1",
             "name": "Woodcaller Automaton",
             "text": "When Woodcaller Automaton enters the battlefield, if you cast it, untap target land you control. It becomes a Treefolk creature with haste and base power and toughness equal to Woodcaller Automaton's power and toughness. It's still a land.\n//PRT-Prototype_\nMech//\n{2}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -10130,7 +10130,7 @@
         },
         {
             "id": "5f68bc3e-b091-5664-852a-77a5b76da717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee692dd-4030-4783-92a8-21304e40533a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee692dd-4030-4783-92a8-21304e40533a.jpg?1",
             "name": "Teferi, Temporal Pilgrim",
             "text": "Whenever you draw a card, put a loyalty counter on Teferi, Temporal Pilgrim.\n0: Draw a card.\n\u22122: Create a 2/2 blue Spirit creature token with vigilance and \"Whenever you draw a card, put a +1/+1 counter on this creature.\"\n\u221212: Target opponent chooses a permanent they control and returns it to its owner's hand. Then they shuffle each nonland permanent they control into its owner's library.",
             "colours": [
@@ -10168,7 +10168,7 @@
         },
         {
             "id": "2fcf94ae-3197-595e-ab1b-c2e5ce1bdc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d40063a-7397-49a5-80c6-6e4f245e1e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d40063a-7397-49a5-80c6-6e4f245e1e2e.jpg?1",
             "name": "Saheeli, Filigree Master",
             "text": "+1: Scry 1. You may tap an untapped artifact you control. If you do, draw a card.\n\u22122: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n\u22124: You get an emblem with \"Artifact creatures you control get +1/+1\" and \"Artifact spells you cast cost {1} less to cast.\"",
             "colours": [
@@ -10208,7 +10208,7 @@
         },
         {
             "id": "7644f06e-d2b5-5c2b-9e79-74423cc282e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81aac1-4d23-4826-912e-6355d8ccb3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81aac1-4d23-4826-912e-6355d8ccb3ee.jpg?1",
             "name": "Mishra, Tamer of Mak Fawa",
             "text": "Permanents you control have \"Ward\u2014\nSacrifice a permanent.\"\nEach artifact card in your graveyard has unearth {1}{B}{R}.",
             "colours": [
@@ -10249,7 +10249,7 @@
         },
         {
             "id": "9dd2f168-d9d5-5e65-a488-0d49e3453c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f944c2f-c84f-4986-9e6f-ec8e171298c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f944c2f-c84f-4986-9e6f-ec8e171298c6.jpg?1",
             "name": "Urza, Prince of Kroog",
             "text": "Artifact creatures you control get +2/+2.\n{6}: Create a token that's a copy of target artifact you control, except it's a 1/1 Soldier creature in addition to its other types.",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "45879fad-95e2-56b7-8c66-f6418fd71c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd1d94-9ae2-46dc-9ece-26e72a323fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd1d94-9ae2-46dc-9ece-26e72a323fd1.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -10323,7 +10323,7 @@
         },
         {
             "id": "31471d99-2558-5cca-a3c0-d3e9c9205d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98178c9d-e113-4f0e-9a7b-3ebfaafe2503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98178c9d-e113-4f0e-9a7b-3ebfaafe2503.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {W}. Brushland deals 1 damage to you.",
             "colours": [],
@@ -10356,7 +10356,7 @@
         },
         {
             "id": "e305d472-817d-5df3-bfa6-99ddd364aff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8528e41-299d-461e-83c6-04ba3da6b17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8528e41-299d-461e-83c6-04ba3da6b17d.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -10389,7 +10389,7 @@
         },
         {
             "id": "0ae3a904-ab32-52c3-a419-4253baa2805e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4fa784-010d-4b27-9e35-43ad78e1ed5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4fa784-010d-4b27-9e35-43ad78e1ed5e.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Underground River deals 1 damage to you.",
             "colours": [],
@@ -10422,7 +10422,7 @@
         },
         {
             "id": "521456b0-a324-5792-b178-b829a3694544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257ab263-a9f2-4376-ad43-46150a39fcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257ab263-a9f2-4376-ad43-46150a39fcdb.jpg?1",
             "name": "In the Trenches",
             "text": "Creatures you control get +1/+1.\n{5}{W}: Exile target nonland permanent you don't control until In the Trenches leaves the battlefield. Activate only as a sorcery and only once.",
             "colours": [
@@ -10456,7 +10456,7 @@
         },
         {
             "id": "7e776c0c-cd71-5916-be3d-0bd009990d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed2cec-7935-49b8-9fdf-5168e228edb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed2cec-7935-49b8-9fdf-5168e228edb7.jpg?1",
             "name": "Kayla's Command",
             "text": "Choose two \u2014\n\u2022 Create a 2/2 colorless Construct artifact creature token.\n\u2022 Put a +1/+1 counter on a creature you control. It gains double strike until end of turn.\n\u2022 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n\u2022 You gain 2 life and scry 2.",
             "colours": [
@@ -10490,7 +10490,7 @@
         },
         {
             "id": "d325ae4a-84ec-5348-add0-99ae78d85ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63feee-550c-4d6c-a50b-9340b12832e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63feee-550c-4d6c-a50b-9340b12832e4.jpg?1",
             "name": "Kayla's Reconstruction",
             "text": "Look at the top seven cards of your library. Put up to X artifact and/or creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10524,7 +10524,7 @@
         },
         {
             "id": "bd7e5700-5ffc-5434-a0d0-75877b5a5a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35a0fc1-790e-4f47-b756-a6b4b298e299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35a0fc1-790e-4f47-b756-a6b4b298e299.jpg?1",
             "name": "Loran of the Third Path",
             "text": "Vigilance\nWhen Loran of the Third Path enters the battlefield, destroy up to one target artifact or enchantment.\n{T}: You and target opponent each draw a card.",
             "colours": [
@@ -10563,7 +10563,7 @@
         },
         {
             "id": "13581180-e40f-5482-9e82-8b1d4e4332e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977da60c-073a-42d1-b9f5-789a2b7071b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977da60c-073a-42d1-b9f5-789a2b7071b8.jpg?1",
             "name": "Myrel, Shield of Argive",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.\nWhenever Myrel, Shield of Argive attacks, create X 1/1 colorless Soldier artifact creature tokens, where X is the number of Soldiers you control.",
             "colours": [
@@ -10602,7 +10602,7 @@
         },
         {
             "id": "4189b180-4dcf-5de5-a98c-7bd168f7feef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b4140-ba70-4860-b6cc-cb307da3793a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b4140-ba70-4860-b6cc-cb307da3793a.jpg?1",
             "name": "Siege Veteran",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\nWhenever another nontoken Soldier you control dies, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "212ffd05-1709-5367-974d-de45edf2148f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798bdb6-a04e-4dce-bd4a-f54b907b9f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798bdb6-a04e-4dce-bd4a-f54b907b9f36.jpg?1",
             "name": "Soul Partition",
             "text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may play it. A spell cast by an opponent this way costs {2} more to cast.",
             "colours": [
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "5b6ee7f1-4b45-53d9-b09a-e604743f1cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedc76a2-f0b2-4cb3-8662-88537b7474cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedc76a2-f0b2-4cb3-8662-88537b7474cc.jpg?1",
             "name": "Tocasia's Welcome",
             "text": "Whenever one or more creatures with mana value 3 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -10707,7 +10707,7 @@
         },
         {
             "id": "d6e86456-532a-5fde-8356-a1cf3fb20bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a6c36-7ca2-433c-95f4-b9b4d9f638b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a6c36-7ca2-433c-95f4-b9b4d9f638b1.jpg?1",
             "name": "Autonomous Assembler",
             "text": "Vigilance\n{1}, {T}: Put a +1/+1 counter on target Assembly-Worker you control.\n//PRT-Prototype_\nMech//\n{1}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -10742,7 +10742,7 @@
         },
         {
             "id": "896211d1-4b92-5bc5-8e0c-2a5abee89f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1549221a-9b37-44a9-af36-9c2e6c99684e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1549221a-9b37-44a9-af36-9c2e6c99684e.jpg?1",
             "name": "Platoon Dispenser",
             "text": "At the beginning of your end step, if you control two or more other creatures, draw a card.\n{3}{W}: Create a 1/1 colorless Soldier artifact creature token.\nUnearth {2}{W}{W}",
             "colours": [],
@@ -10777,7 +10777,7 @@
         },
         {
             "id": "24e509f5-73ee-5c78-b869-35d5ea33e7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a0d3d-58a7-42e3-923b-cc14b85716f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a0d3d-58a7-42e3-923b-cc14b85716f6.jpg?1",
             "name": "Steel Seraph",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gains your choice of flying, vigilance, or lifelink until end of turn.\n//PRT-Prototype_\nMech//\n{1}{W}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -10812,7 +10812,7 @@
         },
         {
             "id": "776f4f5e-39df-524e-b162-f379c6b729dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01c3c7c-d9a0-421b-8174-310b3e3cb163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01c3c7c-d9a0-421b-8174-310b3e3cb163.jpg?1",
             "name": "Urza's Sylex",
             "text": "{2}{W}{W}, {T}, Exile Urza's Sylex: Each player chooses six lands they control. Destroy all other permanents. Activate only as a sorcery.\nWhen Urza's Sylex is put into exile from the battlefield, you may pay {2}. If you do, search your library for a planeswalker card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -10846,7 +10846,7 @@
         },
         {
             "id": "a7d33e0d-857d-557a-b664-525e89d5a4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f9fd87-5c9b-4732-b8a5-f6be360a5fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f9fd87-5c9b-4732-b8a5-f6be360a5fa5.jpg?1",
             "name": "Drafna, Founder of Lat-Nam",
             "text": "{1}{U}: Return target artifact you control to its owner's hand.\n{3}, {T}: Copy target artifact spell you control.",
             "colours": [
@@ -10886,7 +10886,7 @@
         },
         {
             "id": "1c6cf0f6-2b76-5672-a128-bd465c129a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9392a373-0629-4f58-905f-292f3e069127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9392a373-0629-4f58-905f-292f3e069127.jpg?1",
             "name": "Hurkyl, Master Wizard",
             "text": "At the beginning of your end step, if you've cast a noncreature spell this turn, reveal the top five cards of your library. For each card type among noncreature spells you've cast this turn, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10926,7 +10926,7 @@
         },
         {
             "id": "c43526cb-fc87-52d6-81ef-7b598e041b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00e1564-f11e-44b9-b4ac-7a327a854e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00e1564-f11e-44b9-b4ac-7a327a854e6b.jpg?1",
             "name": "Hurkyl's Final Meditation",
             "text": "As long as it's not your turn, this spell costs {3} more to cast.\nReturn all nonland permanents to their owners' hands. End the turn.",
             "colours": [
@@ -10960,7 +10960,7 @@
         },
         {
             "id": "000fe506-f3b7-5c10-98ed-9c77aa47f90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e44a396-d09d-4f87-9c04-0f74d94a3dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e44a396-d09d-4f87-9c04-0f74d94a3dcd.jpg?1",
             "name": "One with the Multiverse",
             "text": "You may look at the top card of your library any time.\nYou may play lands and cast spells from the top of your library.\nOnce during each of your turns, you may cast a spell from your hand or the top of your library without paying its mana cost.",
             "colours": [
@@ -10994,7 +10994,7 @@
         },
         {
             "id": "4106a07d-e28a-584f-91a7-2cb9dc194a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d01c40-d5fe-4dc5-9358-02dac8542509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d01c40-d5fe-4dc5-9358-02dac8542509.jpg?1",
             "name": "Skystrike Officer",
             "text": "Flying\nWhenever Skystrike Officer attacks, create a 1/1 colorless Soldier artifact creature token.\nTap three untapped Soldiers you control: Draw a card.",
             "colours": [
@@ -11031,7 +11031,7 @@
         },
         {
             "id": "bb182d22-cb99-5aa1-bb16-12c05bd34f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1511ad30-16fb-48d9-887e-fce5caede441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1511ad30-16fb-48d9-887e-fce5caede441.jpg?1",
             "name": "Urza's Command",
             "text": "Choose two \u2014\n\u2022 Creatures you don't control get -2/-0 until end of turn.\n\u2022 Create a tapped Powerstone token.\n\u2022 Create a tapped 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\n\u2022 Scry 1, then draw a card.",
             "colours": [
@@ -11065,7 +11065,7 @@
         },
         {
             "id": "7a16b020-5aef-5d65-bcae-69de05097a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57ef48e-66e6-4395-9cf2-6eb634523874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57ef48e-66e6-4395-9cf2-6eb634523874.jpg?1",
             "name": "Arcane Proxy",
             "text": "When Arcane Proxy enters the battlefield, if you cast it, exile target instant or sorcery card with mana value less than or equal to Arcane Proxy's power from your graveyard. Copy that card. You may cast the copy without paying its mana cost.\n//PRT-Prototype_\nMech//\n{1}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/1",
             "colours": [],
@@ -11100,7 +11100,7 @@
         },
         {
             "id": "6a59fbee-ff2e-507f-812a-23cd707579c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a4b87-59fd-45fd-a6ea-598e49fc2cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a4b87-59fd-45fd-a6ea-598e49fc2cc5.jpg?1",
             "name": "Surge Engine",
             "text": "Defender\n{U}: Surge Engine loses defender and gains \"This creature can't be blocked.\"\n{2}{U}: Surge Engine becomes blue and has base power and toughness 5/4. Activate only if Surge Engine doesn't have defender.\n{4}{U}{U}: Draw three cards. Activate only if Surge Engine is blue and only once.",
             "colours": [],
@@ -11135,7 +11135,7 @@
         },
         {
             "id": "1cb4597b-95e2-5ec8-b550-f8079fba21f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72c739-9897-4d50-8232-45027869e4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72c739-9897-4d50-8232-45027869e4c3.jpg?1",
             "name": "The Temporal Anchor",
             "text": "At the beginning of your upkeep, scry 2.\nWhenever you choose to put one or more cards on the bottom of your library while scrying, exile that many cards from the bottom of your library.\nDuring your turn, you may play cards exiled with The Temporal Anchor.",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "808a3a0c-9764-51d2-a179-bae8f1acbfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfc1f6e-9a93-4608-905f-f1fe7d1a9ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfc1f6e-9a93-4608-905f-f1fe7d1a9ee1.jpg?1",
             "name": "Terisian Mindbreaker",
             "text": "Whenever Terisian Mindbreaker attacks, defending player mills half their library, rounded up.\nUnearth {1}{U}{U}{U}",
             "colours": [],
@@ -11206,7 +11206,7 @@
         },
         {
             "id": "b874e3fe-1a87-5974-a757-ee9f4f87db96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e6775a-f711-4709-a4c7-ae159023f0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e6775a-f711-4709-a4c7-ae159023f0fd.jpg?1",
             "name": "Ashnod, Flesh Mechanist",
             "text": "Deathtouch\nWhenever Ashnod, Flesh Mechanist attacks, you may sacrifice another creature. If you do, create a tapped Powerstone token.\n{5}, Exile a creature card from your graveyard: Create a tapped 3/3 colorless Zombie artifact creature token.",
             "colours": [
@@ -11245,7 +11245,7 @@
         },
         {
             "id": "e54be92e-5052-5a31-874c-4224fc5e9e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a21794-dea0-46c8-a575-c41527ea46b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a21794-dea0-46c8-a575-c41527ea46b5.jpg?1",
             "name": "Diabolic Intent",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -11279,7 +11279,7 @@
         },
         {
             "id": "53d494ab-cbc8-56f1-9228-af413b29f3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15095c3-b9a1-43e2-8140-2a73a89336de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15095c3-b9a1-43e2-8140-2a73a89336de.jpg?1",
             "name": "Fateful Handoff",
             "text": "Draw cards equal to the mana value of target artifact or creature you control. An opponent gains control of that permanent.",
             "colours": [
@@ -11313,7 +11313,7 @@
         },
         {
             "id": "676270f1-744d-5dfe-b46f-7d415bc75bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87dbd3-1b80-4c91-b4f7-b13bdd885c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87dbd3-1b80-4c91-b4f7-b13bdd885c3c.jpg?1",
             "name": "Gix, Yawgmoth Praetor",
             "text": "Whenever a creature deals combat damage to one of your opponents, its controller may pay 1 life. If they do, they draw a card.\n{4}{B}{B}{B}, Discard X cards: Exile the top X cards of target opponent's library. You may play lands and cast spells from among cards exiled this way without paying their mana costs.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "c0417813-e68a-5dd7-9062-20d26db306ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2495b60a-7cd0-4514-84ff-f82f28602d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2495b60a-7cd0-4514-84ff-f82f28602d42.jpg?1",
             "name": "Gix's Command",
             "text": "Choose two \u2014\n\u2022 Put two +1/+1 counters on up to one creature. It gains lifelink until end of turn.\n\u2022 Destroy each creature with power 2 or less.\n\u2022 Return up to two creature cards from your graveyard to your hand.\n\u2022 Each opponent sacrifices a creature with the highest power among creatures they control.",
             "colours": [
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "8637f38e-2e68-5264-a019-c8d49eb255ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a114052-6cd1-4f88-ab5a-0828f7fd3bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a114052-6cd1-4f88-ab5a-0828f7fd3bf2.jpg?1",
             "name": "Gixian Puppeteer",
             "text": "Whenever you draw your second card each turn, each opponent loses 2 life and you gain 2 life.\nWhen Gixian Puppeteer dies, return another target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "7cd0a1de-2e2d-5bc2-bf6f-f37e7a0f8318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9525527a-1f4d-4050-893a-cbeca21dceeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9525527a-1f4d-4050-893a-cbeca21dceeb.jpg?1",
             "name": "Hostile Negotiations",
             "text": "Exile the top three cards of your library in a face-down pile, then exile the top three cards of your library in another face-down pile. Look at the cards in each pile, then turn a pile of your choice face up. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. You lose 3 life.",
             "colours": [
@@ -11457,7 +11457,7 @@
         },
         {
             "id": "1d951dc7-36de-5196-b9b1-a018eeadddf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ed1ad1-f28b-4de3-8df6-ad5bdcf393c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ed1ad1-f28b-4de3-8df6-ad5bdcf393c1.jpg?1",
             "name": "Misery's Shadow",
             "text": "If a creature an opponent controls would die, exile it instead.\n{1}: Misery's Shadow gets +1/+1 until end of turn.",
             "colours": [
@@ -11493,7 +11493,7 @@
         },
         {
             "id": "0050066b-8882-5a39-8c5a-232f02ee7a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97467f7-01a9-46c8-8e1c-7ebc5f65a0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97467f7-01a9-46c8-8e1c-7ebc5f65a0c1.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless they discard a card.",
             "colours": [
@@ -11527,7 +11527,7 @@
         },
         {
             "id": "751e08c6-2cdf-5200-891d-64cbadc68fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dc4676-5e8e-4ce8-a7f7-8cb956bd5a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dc4676-5e8e-4ce8-a7f7-8cb956bd5a10.jpg?1",
             "name": "Phyrexian Fleshgorger",
             "text": "Menace, lifelink\nWard\u2014\nPay life equal to Phyrexian Fleshgorger's power.\n//PRT-Prototype_\nMech//\n{1}{B}{B}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -11563,7 +11563,7 @@
         },
         {
             "id": "bfa1c763-6166-5487-a4b7-93b0eab62bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e021e750-74f3-466a-b670-f5cd9cebb84a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e021e750-74f3-466a-b670-f5cd9cebb84a.jpg?1",
             "name": "Razorlash Transmogrant",
             "text": "Razorlash Transmogrant can't block.\n{4}{B}{B}: Return Razorlash Transmogrant from your graveyard to the battlefield with a +1/+1 counter on it. This ability costs {4} less to activate if an opponent controls four or more nonbasic lands.",
             "colours": [],
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "f3f71420-d2bb-53d3-a37a-27a8cc3fcf97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c99eb4-0c18-461c-ad26-0351adbf0a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c99eb4-0c18-461c-ad26-0351adbf0a3c.jpg?1",
             "name": "Transmogrant's Crown",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, draw a card.\nEquip {2} or {B}",
             "colours": [],
@@ -11632,7 +11632,7 @@
         },
         {
             "id": "ee202a92-b224-5b8f-ab58-78aa261086a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c3d2cc-e2d8-4b44-9f87-17d25b5918a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c3d2cc-e2d8-4b44-9f87-17d25b5918a1.jpg?1",
             "name": "Brotherhood's End",
             "text": "Choose one \u2014\n\u2022 Brotherhood's End deals 3 damage to each creature and each planeswalker.\n\u2022 Destroy all artifacts with mana value 3 or less.",
             "colours": [
@@ -11666,7 +11666,7 @@
         },
         {
             "id": "54d9f51f-3ce4-59d8-9b29-a19ad0473e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce511-ecc3-48f7-80ec-66f3367998ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce511-ecc3-48f7-80ec-66f3367998ff.jpg?1",
             "name": "Draconic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying, haste, and \"{1}: This creature gets +1/+0 until end of turn.\" It's a Dragon in addition to its other types.\nWhen enchanted creature dies, return Draconic Destiny to its owner's hand.",
             "colours": [
@@ -11702,7 +11702,7 @@
         },
         {
             "id": "42b513b4-1eb0-5b70-866d-56fd0a454dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5e5ae-e35a-4be0-bc13-0d7f41506a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5e5ae-e35a-4be0-bc13-0d7f41506a26.jpg?1",
             "name": "Feldon, Ronom Excavator",
             "text": "Haste\nFeldon, Ronom Excavator can't block.\nWhenever Feldon is dealt damage, exile that many cards from the top of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -11741,7 +11741,7 @@
         },
         {
             "id": "456a210c-cdef-55e9-b223-acfcaea7e206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887679d-0319-4907-abdb-a8b813ff27d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887679d-0319-4907-abdb-a8b813ff27d8.jpg?1",
             "name": "Mechanized Warfare",
             "text": "If a red or artifact source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -11775,7 +11775,7 @@
         },
         {
             "id": "7dd2f582-55f8-5fb5-a5ec-a70ce47c0991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c64a7f-7cce-43d1-8356-e9ad1d4e6f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c64a7f-7cce-43d1-8356-e9ad1d4e6f12.jpg?1",
             "name": "Mishra's Command",
             "text": "Choose two \u2014\n\u2022 Choose target player. They may discard up to X cards. Then they draw a card for each card discarded this way.\n\u2022 This spell deals X damage to target creature.\n\u2022 This spell deals X damage to target planeswalker.\n\u2022 Target creature gets +X/+0 and gains haste until end of turn.",
             "colours": [
@@ -11809,7 +11809,7 @@
         },
         {
             "id": "f6f8e31b-f2a8-57e6-bafa-a8b8d58f6326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913dba9-70ca-4ba3-a7b8-876843b1b1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913dba9-70ca-4ba3-a7b8-876843b1b1df.jpg?1",
             "name": "Over the Top",
             "text": "Each player reveals a number of cards from the top of their library equal to the number of nonland permanents they control, puts all permanent cards they revealed this way onto the battlefield, and puts the rest into their graveyard.",
             "colours": [
@@ -11843,7 +11843,7 @@
         },
         {
             "id": "c68c04c2-a257-56c9-ae40-ea190a06bbe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aff76d6-336a-4746-9002-4daefef44984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aff76d6-336a-4746-9002-4daefef44984.jpg?1",
             "name": "Tyrant of Kher Ridges",
             "text": "Flying\nWhen Tyrant of Kher Ridges enters the battlefield, it deals 4 damage to any target.\n{R}: Tyrant of Kher Ridges gets +1/+0 until end of turn.",
             "colours": [
@@ -11879,7 +11879,7 @@
         },
         {
             "id": "1327d9f3-ce82-50ea-943b-fcd26096de79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c493e826-121f-4445-94db-5c75e5d16f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c493e826-121f-4445-94db-5c75e5d16f75.jpg?1",
             "name": "Visions of Phyrexia",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token.",
             "colours": [
@@ -11913,7 +11913,7 @@
         },
         {
             "id": "ecf1f452-515b-5a57-8688-3cd6412a20d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fb5c7-f3e7-4c98-a5a4-3cf0571b6334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fb5c7-f3e7-4c98-a5a4-3cf0571b6334.jpg?1",
             "name": "Skitterbeam Battalion",
             "text": "Trample, haste\nWhen Skitterbeam Battalion enters the battlefield, if you cast it, create two tokens that are copies of it.\n//PRT-Prototype_\nMech//\n{3}{R}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "4bfcab29-0538-5f3d-b3a1-814d35f19006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d661aa8e-46fd-4f47-ade7-99c9142f3733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d661aa8e-46fd-4f47-ade7-99c9142f3733.jpg?1",
             "name": "Awaken the Woods",
             "text": "Create X 1/1 green Forest Dryad land creature tokens. (They're affected by summoning sickness.)",
             "colours": [
@@ -11982,7 +11982,7 @@
         },
         {
             "id": "886dc66e-b737-550a-b3f6-142732fed9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92646d9a-67ea-40b0-9b92-c8e1cbd31e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92646d9a-67ea-40b0-9b92-c8e1cbd31e4b.jpg?1",
             "name": "Fade from History",
             "text": "Each player who controls an artifact or enchantment creates a 2/2 green Bear creature token. Then destroy all artifacts and enchantments.",
             "colours": [
@@ -12016,7 +12016,7 @@
         },
         {
             "id": "b94baf78-bd7a-5696-8cb4-8276dd31672b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeed580-d00d-4d8c-a137-18b0f354933d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeed580-d00d-4d8c-a137-18b0f354933d.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -12053,7 +12053,7 @@
         },
         {
             "id": "6ae32945-b108-5460-8a42-077950b75ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4774554-1de5-4011-bd74-d3982bf33971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4774554-1de5-4011-bd74-d3982bf33971.jpg?1",
             "name": "Gwenna, Eyes of Gaea",
             "text": "{T}: Add two mana in any combination of colors. Spend this mana only to cast creature spells or activate abilities of a creature or creature card.\nWhenever you cast a creature spell with power 5 or greater, put a +1/+1 counter on Gwenna, Eyes of Gaea and untap it.",
             "colours": [
@@ -12093,7 +12093,7 @@
         },
         {
             "id": "11b6c124-2b87-582e-9996-d8bb4566e3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f19007-b501-44e6-8f86-51493dc69da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f19007-b501-44e6-8f86-51493dc69da3.jpg?1",
             "name": "Teething Wurmlet",
             "text": "Teething Wurmlet has deathtouch as long as you control three or more artifacts.\nWhenever an artifact enters the battlefield under your control, you gain 1 life. If this is the first time this ability has resolved this turn, put a +1/+1 counter on Teething Wurmlet.",
             "colours": [
@@ -12129,7 +12129,7 @@
         },
         {
             "id": "cb2c157b-cb5f-543d-be8a-fd4b69f8dcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c29a0-b7ea-433f-b342-a3228de0e092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c29a0-b7ea-433f-b342-a3228de0e092.jpg?1",
             "name": "Titania's Command",
             "text": "Choose two \u2014\n\u2022 Exile target player's graveyard. You gain 1 life for each card exiled this way.\n\u2022 Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle.\n\u2022 Create two 2/2 green Bear creature tokens.\n\u2022 Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -12163,7 +12163,7 @@
         },
         {
             "id": "ab92af48-0ed7-5c79-a992-60f973716cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4815d9a-0c59-4446-8cd8-416f8cd43a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4815d9a-0c59-4446-8cd8-416f8cd43a60.jpg?1",
             "name": "Perennial Behemoth",
             "text": "You may play lands from your graveyard.\nUnearth {G}{G}",
             "colours": [],
@@ -12198,7 +12198,7 @@
         },
         {
             "id": "a13f2b56-7a8f-5ad4-8407-6820dc9dd81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c4622d-eecb-449c-acd4-c05ed4094b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c4622d-eecb-449c-acd4-c05ed4094b20.jpg?1",
             "name": "Rootwire Amalgam",
             "text": "{3}{G}{G}, Sacrifice Rootwire Amalgam: Create an X/X colorless Golem artifact creature token, where X is three times Rootwire Amalgam's power. It gains haste until end of turn. Activate only as a sorcery.\n//PRT-Prototype_\nMech//\n{1}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/3",
             "colours": [],
@@ -12233,7 +12233,7 @@
         },
         {
             "id": "473fb80b-21ed-5f92-a214-b767a1ece03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036eee90-b002-4d9a-a72e-56cef7cc8648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036eee90-b002-4d9a-a72e-56cef7cc8648.jpg?1",
             "name": "Simian Simulacrum",
             "text": "When Simian Simulacrum enters the battlefield, put two +1/+1 counters on target creature you control.\nUnearth {2}{G}{G}",
             "colours": [],
@@ -12268,7 +12268,7 @@
         },
         {
             "id": "d203789a-6051-5b44-933a-c26cf6e54b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e988c8-c70f-4995-b500-8bc0fa580f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e988c8-c70f-4995-b500-8bc0fa580f1d.jpg?1",
             "name": "Deathbloom Ritualist",
             "text": "{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -12307,7 +12307,7 @@
         },
         {
             "id": "4ebefaf9-7cf9-5ce6-bec4-13cd8f6e94eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f42a51-02a0-4915-a459-887ac787a90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f42a51-02a0-4915-a459-887ac787a90e.jpg?1",
             "name": "Hajar, Loyal Bodyguard",
             "text": "Sacrifice Hajar, Loyal Bodyguard: Legendary creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -12348,7 +12348,7 @@
         },
         {
             "id": "14c3df66-3f32-5f21-b5da-cbb3a50b8d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d3faf-73fc-4f2d-8d88-2b15298461ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d3faf-73fc-4f2d-8d88-2b15298461ce.jpg?1",
             "name": "Harbin, Vanguard Aviator",
             "text": "Flying\nWhenever you attack with five or more Soldiers, creatures you control get +1/+1 and gain flying until end of turn.",
             "colours": [
@@ -12389,7 +12389,7 @@
         },
         {
             "id": "547786b0-c9c4-5d9f-8174-dc7760e64c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a5af15-86cf-48c7-8743-6b13295db41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a5af15-86cf-48c7-8743-6b13295db41e.jpg?1",
             "name": "Legions to Ashes",
             "text": "Exile target nonland permanent an opponent controls and all tokens that player controls with the same name as that permanent.",
             "colours": [
@@ -12425,7 +12425,7 @@
         },
         {
             "id": "506eb59d-2ac5-539e-ba44-731ad4f62423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bdc53f-03af-404f-b62d-f59dda792887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bdc53f-03af-404f-b62d-f59dda792887.jpg?1",
             "name": "Queen Kayla bin-Kroog",
             "text": "{4}, {T}: Discard all the cards in your hand, then draw that many cards. You may choose an artifact or creature card with mana value 1 you discarded this way, then do the same for artifact or creature cards with mana values 2 and 3. Return those cards to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -12467,7 +12467,7 @@
         },
         {
             "id": "0e1cbcc8-2229-5957-bcec-3ba9a4a07a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659b228-67e9-4cf6-be90-810d0393720a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659b228-67e9-4cf6-be90-810d0393720a.jpg?1",
             "name": "Sarinth Greatwurm",
             "text": "Trample\nWhenever a land enters the battlefield, create a tapped Powerstone token.",
             "colours": [
@@ -12505,7 +12505,7 @@
         },
         {
             "id": "2363e96a-f42b-573a-918c-a59e9e5b826a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8cde13-e7c8-4781-acf0-56f522afe425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8cde13-e7c8-4781-acf0-56f522afe425.jpg?1",
             "name": "Tawnos, the Toymaker",
             "text": "Whenever you cast a Beast or Bird creature spell, you may copy it, except the copy is an artifact in addition to its other types.",
             "colours": [
@@ -12546,7 +12546,7 @@
         },
         {
             "id": "16175410-1879-524e-bfe1-21d48bba6e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d759dc-0501-481a-8330-005f83b999d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d759dc-0501-481a-8330-005f83b999d7.jpg?1",
             "name": "Tocasia, Dig Site Mentor",
             "text": "Creatures you control have vigilance and \"{T}: Surveil 1.\"\n{2}{G}{G}{W}{W}{U}{U}, Exile Tocasia, Dig Site Mentor from your graveyard: Return any number of target artifact cards with total mana value 10 or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -12589,7 +12589,7 @@
         },
         {
             "id": "f7c07bb4-b739-5cf5-ac6b-93b59512bb35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10471a6-38ee-4a84-986a-779bdf4f1464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10471a6-38ee-4a84-986a-779bdf4f1464.jpg?1",
             "name": "Bladecoil Serpent",
             "text": "When Bladecoil Serpent enters the battlefield, for each {U}{U} spent to cast it, draw a card.\nWhen Bladecoil Serpent enters the battlefield, for each {B}{B} spent to cast it, each opponent discards a card.\nWhen Bladecoil Serpent enters the battlefield, for each {R}{R} spent to cast it, it gets +1/+0 and gains trample and haste until end of turn.",
             "colours": [],
@@ -12626,7 +12626,7 @@
         },
         {
             "id": "e0f5e194-4001-5cd2-87df-572972627587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bca059b-e5ea-42f3-adad-cb1801ddf3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bca059b-e5ea-42f3-adad-cb1801ddf3cb.jpg?1",
             "name": "Clay Champion",
             "text": "Clay Champion enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.\nWhen Clay Champion enters the battlefield, choose up to two other target creatures you control. For each {W}{W} spent to cast Clay Champion, put a +1/+1 counter on each of them.",
             "colours": [],
@@ -12662,7 +12662,7 @@
         },
         {
             "id": "c2e83103-ed7a-5f00-a9f0-ab48a39cc412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2bcd1-3ed3-4b99-9bb6-d0fa0a9f2ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2bcd1-3ed3-4b99-9bb6-d0fa0a9f2ea1.jpg?1",
             "name": "Cityscape Leveler",
             "text": "Trample\nWhen you cast this spell and whenever Cityscape Leveler attacks, destroy up to one target nonland permanent. Its controller creates a tapped Powerstone token.\nUnearth {8}",
             "colours": [],
@@ -12695,7 +12695,7 @@
         },
         {
             "id": "23c396d1-fa5f-53b9-aa4b-6e84d40cad00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04acd5af-bd55-4c16-9b6d-10822d564c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04acd5af-bd55-4c16-9b6d-10822d564c14.jpg?1",
             "name": "Liberator, Urza's Battlethopter",
             "text": "Flash\nFlying\nYou may cast colorless spells and artifact spells as though they had flash.\nWhenever you cast a spell, if the amount of mana spent to cast that spell is greater than Liberator, Urza's Battlethopter's power, put a +1/+1 counter on Liberator.",
             "colours": [],
@@ -12730,7 +12730,7 @@
         },
         {
             "id": "22b9ee49-fd8b-5953-89c4-1054e70c3fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05bda29-654a-4f4f-9296-702ccda7f800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05bda29-654a-4f4f-9296-702ccda7f800.jpg?1",
             "name": "Portal to Phyrexia",
             "text": "When Portal to Phyrexia enters the battlefield, each opponent sacrifices three creatures.\nAt the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control. It's a Phyrexian in addition to its other types.",
             "colours": [],
@@ -12760,7 +12760,7 @@
         },
         {
             "id": "cfa9495d-30ce-532a-9c9e-5b91068c091f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41793ef-73a3-41fc-8efc-df0d72ede984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41793ef-73a3-41fc-8efc-df0d72ede984.jpg?1",
             "name": "The Stasis Coffin",
             "text": "{2}, {T}, Exile The Stasis Coffin: You gain protection from everything until your next turn.",
             "colours": [],
@@ -12792,7 +12792,7 @@
         },
         {
             "id": "3f5f7024-cfe0-5a01-ac7c-7f6cedd53282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913460c0-2482-4d1b-9235-1cecfee653cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913460c0-2482-4d1b-9235-1cecfee653cb.jpg?1",
             "name": "The Stone Brain",
             "text": "{2}, {T}, Exile The Stone Brain: Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way. Activate only as a sorcery.",
             "colours": [],
@@ -12824,7 +12824,7 @@
         },
         {
             "id": "bed93d30-21e0-5685-8691-94fe13808ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c400de-25cb-4865-ad1b-9a8a8da3da55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c400de-25cb-4865-ad1b-9a8a8da3da55.jpg?1",
             "name": "Thran Spider",
             "text": "Reach\nWhen Thran Spider enters the battlefield, you and target opponent each create a tapped Powerstone token.\n{7}: Look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -12857,7 +12857,7 @@
         },
         {
             "id": "a665883a-8366-580f-b6f8-ffce2eb0f158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9b863-10b7-46d6-badd-97381e6c7c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9b863-10b7-46d6-badd-97381e6c7c5e.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "d094af49-3bf5-5292-a067-903b053bdf4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60a5e3-7b37-4363-ab22-c30a6fcf5716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60a5e3-7b37-4363-ab22-c30a6fcf5716.jpg?1",
             "name": "Fortified Beachhead",
             "text": "As Fortified Beachhead enters the battlefield, you may reveal a Soldier card from your hand. Fortified Beachhead enters the battlefield tapped unless you revealed a Soldier card this way or you control a Soldier.\n{T}: Add {W} or {U}.\n{5}, {T}: Soldiers you control get +1/+1 until end of turn.",
             "colours": [],
@@ -12920,7 +12920,7 @@
         },
         {
             "id": "1b500c45-9741-5329-b4fb-5025d5be25ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a4e7-317e-480e-9d38-da1c42c47521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a4e7-317e-480e-9d38-da1c42c47521.jpg?1",
             "name": "Hall of Tagsin",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}: Create a tapped Powerstone token.",
             "colours": [],
@@ -12950,7 +12950,7 @@
         },
         {
             "id": "cf38aff6-92f1-5ab5-babc-7bb0198fee70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493bc22-2e38-4459-81f1-37cd1ce921cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493bc22-2e38-4459-81f1-37cd1ce921cf.jpg?1",
             "name": "Mishra's Foundry",
             "text": "{T}: Add {C}.\n{2}: Mishra's Foundry becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
             "colours": [],
@@ -12981,7 +12981,7 @@
         },
         {
             "id": "5f38f91c-3102-5120-bf3c-4d45a646a6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dde654-5bde-47f9-8e90-4f38dddc07b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dde654-5bde-47f9-8e90-4f38dddc07b3.jpg?1",
             "name": "Rescue Retriever",
             "text": "Flash\nWhen Rescue Retriever enters the battlefield, put a +1/+1 counter on each other Soldier you control.\nPrevent all damage that would be dealt to other attacking Soldiers you control.",
             "colours": [
@@ -13018,7 +13018,7 @@
         },
         {
             "id": "fe567e51-0b96-5551-b347-abfdf0ea4cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae85295-9bad-4f5b-9935-7242632e9008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae85295-9bad-4f5b-9935-7242632e9008.jpg?1",
             "name": "Geology Enthusiast",
             "text": "At the beginning of your end step, create a tapped Powerstone token.\n{6}: Draw a card and put a +1/+1 counter on Geology Enthusiast.",
             "colours": [
@@ -13055,7 +13055,7 @@
         },
         {
             "id": "69bb1966-c092-5656-8c4c-b925cbe0ae13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef8698-982d-4c35-b3a0-99788fc2f8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef8698-982d-4c35-b3a0-99788fc2f8a0.jpg?1",
             "name": "Terror Ballista",
             "text": "Menace\nWhenever Terror Ballista attacks, you may sacrifice another creature. When you do, destroy target creature an opponent controls.\nUnearth {3}{B}{B}",
             "colours": [],
@@ -13090,7 +13090,7 @@
         },
         {
             "id": "c4a8e16e-d4cc-5e46-945e-7717007d6b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e71c3b-4c97-4eac-9ac9-c97cd6253849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e71c3b-4c97-4eac-9ac9-c97cd6253849.jpg?1",
             "name": "Artificer's Dragon",
             "text": "Flying\n{R}: Artifact creatures you control get +1/+0 until end of turn.\nUnearth {3}{R}{R}",
             "colours": [],
@@ -13125,7 +13125,7 @@
         },
         {
             "id": "135aeec4-f811-5944-afca-a45f163cbae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37065a61-3883-49fa-a931-8f1566451795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37065a61-3883-49fa-a931-8f1566451795.jpg?1",
             "name": "Woodcaller Automaton",
             "text": "When Woodcaller Automaton enters the battlefield, if you cast it, untap target land you control. It becomes a Treefolk creature with haste and base power and toughness equal to Woodcaller Automaton's power and toughness. It's still a land.\n//PRT-Prototype_\nMech//\n{2}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -13160,7 +13160,7 @@
         },
         {
             "id": "dfa66ff6-f403-5e8a-837b-9fa1bbdb6dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91f9a1e-809b-4bc0-afca-c0c3755d130f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91f9a1e-809b-4bc0-afca-c0c3755d130f.jpg?1",
             "name": "Mishra's Foundry",
             "text": "{T}: Add {C}.\n{2}: Mishra's Foundry becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
             "colours": [],
@@ -13190,7 +13190,7 @@
         },
         {
             "id": "9862ad68-fe97-55e9-9884-9dc2c236eef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d8c862-47e9-4cc5-833c-0e762ee2a670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d8c862-47e9-4cc5-833c-0e762ee2a670.jpg?1",
             "name": "Queen Kayla bin-Kroog",
             "text": "{4}, {T}: Discard all the cards in your hand, then draw that many cards. You may choose an artifact or creature card with mana value 1 you discarded this way, then do the same for artifact or creature cards with mana values 2 and 3. Return those cards to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -13231,7 +13231,7 @@
         },
         {
             "id": "c0712b85-a002-5e55-98e9-902bb3776977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8340f-19ca-40d2-ae8e-68bba18e918b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8340f-19ca-40d2-ae8e-68bba18e918b.jpg?1",
             "name": "Lay Down Arms",
             "text": "Exile target creature with mana value less than or equal to the number of Plains you control. Its controller gains 3 life.",
             "colours": [
@@ -13265,7 +13265,7 @@
         },
         {
             "id": "8dd8300a-ab15-5eee-be5e-583438b5184a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de8324f-07ee-4dd1-9547-1a1cfb361ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de8324f-07ee-4dd1-9547-1a1cfb361ff5.jpg?1",
             "name": "Flow of Knowledge",
             "text": "Draw a card for each Island you control, then discard two cards.",
             "colours": [
@@ -13299,7 +13299,7 @@
         },
         {
             "id": "281cc1c7-b5c3-5784-b1d0-7916b18598b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7c6f6f-9516-4cfd-830f-5910a25bd1a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7c6f6f-9516-4cfd-830f-5910a25bd1a2.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -13333,7 +13333,7 @@
         },
         {
             "id": "6999b379-736a-5b82-832d-df979909dbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b86f24-de8c-40f5-9486-119a366c42e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b86f24-de8c-40f5-9486-119a366c42e1.jpg?1",
             "name": "Sardian Cliffstomper",
             "text": "As long as it's your turn and you control four or more Mountains, Sardian Cliffstomper gets +X/+0, where X is the number of Mountains you control.",
             "colours": [
@@ -13370,7 +13370,7 @@
         },
         {
             "id": "8eadb239-db1e-5c89-8111-a31136c9f448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9755c1da-f1ed-4328-b85f-e905b7468504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9755c1da-f1ed-4328-b85f-e905b7468504.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -13406,7 +13406,7 @@
         },
         {
             "id": "60494a81-fb59-5124-8026-50238c0b9308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e3241-8f9d-4c52-9848-e01b575fd372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e3241-8f9d-4c52-9848-e01b575fd372.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -13441,7 +13441,7 @@
         },
         {
             "id": "3f82c456-50fe-51af-9b92-369d7df9e749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772dac39-269b-4a35-aad3-320279af833f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772dac39-269b-4a35-aad3-320279af833f.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -13476,7 +13476,7 @@
         },
         {
             "id": "6405b3fc-e11e-57cb-acdc-52ecdd339108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de70f2-93b6-4fc5-8c4d-464f880d3c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de70f2-93b6-4fc5-8c4d-464f880d3c54.jpg?1",
             "name": "Forest Dryad",
             "text": "",
             "colours": [
@@ -13513,7 +13513,7 @@
         },
         {
             "id": "a528342a-7f6f-5f00-9703-fa3582eb99ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087ab398-474f-4455-bef4-ea42c6913486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087ab398-474f-4455-bef4-ea42c6913486.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -13545,7 +13545,7 @@
         },
         {
             "id": "f304a222-6ed8-55dd-ab01-607fc5e3ee7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914fecab-24c0-4179-84d6-ded78c29134f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914fecab-24c0-4179-84d6-ded78c29134f.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -13577,7 +13577,7 @@
         },
         {
             "id": "e9d4c9dd-aabd-5b24-9c12-495ba9642306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474c8cfe-71ce-46c7-8cf4-dfeae3c0e73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474c8cfe-71ce-46c7-8cf4-dfeae3c0e73b.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -13609,7 +13609,7 @@
         },
         {
             "id": "af8db311-3520-5cf7-8410-7390c29da873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fe4b6-aeaf-4f84-b660-c7b482ed8512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fe4b6-aeaf-4f84-b660-c7b482ed8512.jpg?1",
             "name": "Powerstone",
             "text": "",
             "colours": [],
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "435879cb-6a56-5018-990c-71480a1da759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37da5b54-ec55-46e3-9f0b-565cbbe1ac7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37da5b54-ec55-46e3-9f0b-565cbbe1ac7a.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [],
@@ -13672,7 +13672,7 @@
         },
         {
             "id": "ef3f1a25-63d2-52cc-ac87-7b72b26cee32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83981313-ff55-4030-ac82-d6a3087cf675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83981313-ff55-4030-ac82-d6a3087cf675.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [],
@@ -13704,7 +13704,7 @@
         },
         {
             "id": "f282f43b-3966-5b9c-b2da-bbb804c11b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4501d15d-d306-4372-9516-bd63cf788f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4501d15d-d306-4372-9516-bd63cf788f45.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -13736,7 +13736,7 @@
         },
         {
             "id": "5aa6ab25-11cf-5cac-830f-9d255c06bd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef47d03-9050-48ed-994f-f72582967dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef47d03-9050-48ed-994f-f72582967dbd.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [],
@@ -13768,7 +13768,7 @@
         },
         {
             "id": "86fd16f7-1f35-539d-b47d-0c9d07d63850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020571d-97fb-4f46-85ec-6cb3141bfc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020571d-97fb-4f46-85ec-6cb3141bfc87.jpg?1",
             "name": "Saheeli, Filigree Master Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/CHK.json
+++ b/Assets/Resources/Sets/CHK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "59681d76-e221-525d-8c12-b775856afe7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2d8650-b8c3-4e89-9aa2-424a98715c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2d8650-b8c3-4e89-9aa2-424a98715c38.jpg?1",
             "name": "Blessed Breath",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nSplice onto Arcane {W} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "0587fcbb-8caa-5469-bfa5-62e5d599c933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg?1",
             "name": "Bushi Tenderfoot // Kenzo the Hardhearted",
             "text": "When a creature dealt damage by Bushi Tenderfoot this turn is put into a graveyard, flip Bushi Tenderfoot.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "911287a8-f255-5af7-a53f-fc56f215dd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg?1",
             "name": "Bushi Tenderfoot // Kenzo the Hardhearted",
             "text": "Double strike; bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "3f2ed15b-b7d4-5a51-8ac5-cc65e68994d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a80b6a-90ed-482f-9714-eb856269e9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a80b6a-90ed-482f-9714-eb856269e9d3.jpg?1",
             "name": "Cage of Hands",
             "text": "Enchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "cca39489-af45-573b-bf88-014a1f7727d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fcfe4-0347-4ac6-8e29-f945cb1d7295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fcfe4-0347-4ac6-8e29-f945cb1d7295.jpg?1",
             "name": "Call to Glory",
             "text": "Untap all creatures you control. Samurai you control get +1/+1 until end of turn.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "f920de35-353c-5ad0-9127-ebc7dabf3aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758d20f-6f0f-462e-a7ec-2511c146983d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758d20f-6f0f-462e-a7ec-2511c146983d.jpg?1",
             "name": "Candles' Glow",
             "text": "Prevent the next 3 damage that would be dealt to target creature or player this turn. You gain 1 life for each damage prevented this way.\nSplice onto Arcane {1}{W} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "cbc25f97-1c2c-59e1-9067-9a2b8b6b9980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897707f-9669-4d44-8607-cba569da73e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897707f-9669-4d44-8607-cba569da73e0.jpg?1",
             "name": "Cleanfall",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "bc84980c-3b29-5d77-b493-cccc5d336d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc41d6d6-d7e5-4874-b6e2-fa4c72454f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc41d6d6-d7e5-4874-b6e2-fa4c72454f15.jpg?1",
             "name": "Devoted Retainer",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "971bfb78-f275-51df-b1cd-f887e51a68ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc72076-fb6c-420b-9c88-faabb9b91a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc72076-fb6c-420b-9c88-faabb9b91a03.jpg?1",
             "name": "Eight-and-a-Half-Tails",
             "text": "{1}{W}: Target permanent you control gains protection from white until end of turn.\n{1}: Target spell or permanent becomes white until end of turn.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "0f610e65-4d15-506d-b8a1-27d242f89d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1996af-5f15-447f-9b1d-98a7e97df53a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1996af-5f15-447f-9b1d-98a7e97df53a.jpg?1",
             "name": "Ethereal Haze",
             "text": "Prevent all damage that would be dealt by creatures this turn.",
             "colours": [
@@ -350,7 +350,7 @@
         },
         {
             "id": "2deee42f-c529-531c-a36c-f0e750625c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d7de2b-c909-48dc-9ab7-c4a8328e37bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d7de2b-c909-48dc-9ab7-c4a8328e37bb.jpg?1",
             "name": "Ghostly Prison",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature attacking you. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "364a0a3c-0eaf-5dc7-ab81-2f03745ba24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e19753-b94b-458f-a51b-c8ec8fbec6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e19753-b94b-458f-a51b-c8ec8fbec6c8.jpg?1",
             "name": "Harsh Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, untap Harsh Deceiver and it gets +1/+1 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -416,7 +416,7 @@
         },
         {
             "id": "71533159-1c83-5856-ad59-b059cdced62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc7ba1-6194-45ba-97c5-ad14331cc3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc7ba1-6194-45ba-97c5-ad14331cc3a6.jpg?1",
             "name": "Hikari, Twilight Guardian",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may remove Hikari, Twilight Guardian from the game. If you do, return it to play under its owner's control at end of turn.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "e536ca09-ab21-58c3-9837-b158fbf716da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de34d107-8a28-4e88-919e-c7ccf984bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de34d107-8a28-4e88-919e-c7ccf984bcda.jpg?1",
             "name": "Hold the Line",
             "text": "Blocking creatures get +7/+7 until end of turn.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "880d7558-143b-5848-bb03-987994d5521a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463f598a-7de0-4691-a61a-fe24c29f9e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463f598a-7de0-4691-a61a-fe24c29f9e1b.jpg?1",
             "name": "Honden of Cleansing Fire",
             "text": "At the beginning of your upkeep, you gain 2 life for each Shrine you control.",
             "colours": [
@@ -520,7 +520,7 @@
         },
         {
             "id": "ad48ee01-9338-5eca-af18-911aae691480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6317b9-a426-453b-a82a-e63905a77019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6317b9-a426-453b-a82a-e63905a77019.jpg?1",
             "name": "Horizon Seed",
             "text": "Whenever you play a Spirit or Arcane spell, regenerate target creature.",
             "colours": [
@@ -554,7 +554,7 @@
         },
         {
             "id": "1269707b-e642-59e9-959b-2d28282d1a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b2892a-5c16-4624-9a47-6a47f10e2466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b2892a-5c16-4624-9a47-6a47f10e2466.jpg?1",
             "name": "Hundred-Talon Kami",
             "text": "Flying\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -588,7 +588,7 @@
         },
         {
             "id": "af638154-c327-5cf3-93c6-27d2741b2f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73263906-c66b-4f85-b138-0b5deda64ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73263906-c66b-4f85-b138-0b5deda64ab1.jpg?1",
             "name": "Indomitable Will",
             "text": "You may play Indomitable Will any time you could play an instant.\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "13298cf8-bd62-5d20-bebc-47da3162da26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df62efbb-2313-4667-82e6-3b474d998ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df62efbb-2313-4667-82e6-3b474d998ef5.jpg?1",
             "name": "Innocence Kami",
             "text": "{W}, {T}: Tap target creature.\nWhenever you play a Spirit or Arcane spell, untap Innocence Kami.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "c81ea548-0fc6-5cec-b041-8782a80701d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f9919-0713-4ef9-96eb-3e0c444e47f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f9919-0713-4ef9-96eb-3e0c444e47f4.jpg?1",
             "name": "Isamaru, Hound of Konda",
             "text": "",
             "colours": [
@@ -692,7 +692,7 @@
         },
         {
             "id": "098326ed-fc28-5cb9-95e5-19d05d6187f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3ccd16-bb1b-40d5-87a6-47a6132e0143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3ccd16-bb1b-40d5-87a6-47a6132e0143.jpg?1",
             "name": "Kabuto Moth",
             "text": "Flying\n{T}: Target creature gets +1/+2 until end of turn.",
             "colours": [
@@ -726,7 +726,7 @@
         },
         {
             "id": "6558fb89-301c-5f7f-8bc5-6dec683caf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cb7fdc-fa47-4485-b268-7c2ddff28568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cb7fdc-fa47-4485-b268-7c2ddff28568.jpg?1",
             "name": "Kami of Ancient Law",
             "text": "Sacrifice Kami of Ancient Law: Destroy target enchantment.",
             "colours": [
@@ -760,7 +760,7 @@
         },
         {
             "id": "5920398d-9131-5015-8bc8-d72014fb10ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815cad73-1d46-4d2b-9dd8-edcd6abc6cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815cad73-1d46-4d2b-9dd8-edcd6abc6cbe.jpg?1",
             "name": "Kami of Old Stone",
             "text": "",
             "colours": [
@@ -794,7 +794,7 @@
         },
         {
             "id": "0dd55d02-0dd5-59e2-bf9a-f603cfc0aa7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068739c-0a6a-49a1-88c3-68d7abc58ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068739c-0a6a-49a1-88c3-68d7abc58ee2.jpg?1",
             "name": "Kami of the Painted Road",
             "text": "Whenever you play a Spirit or Arcane spell, Kami of the Painted Road gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -828,7 +828,7 @@
         },
         {
             "id": "c36fe777-5667-5690-9376-aba1112d2879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690980ce-bbdc-4d52-b34e-2bad11e436a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690980ce-bbdc-4d52-b34e-2bad11e436a1.jpg?1",
             "name": "Kami of the Palace Fields",
             "text": "Flying, first strike\nSoulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -862,7 +862,7 @@
         },
         {
             "id": "cdf28191-2045-5517-b46f-6cdc5b5d911e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9d108d-ee19-4b1d-9d4b-b4c4d9b8ad0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9d108d-ee19-4b1d-9d4b-b4c4d9b8ad0d.jpg?1",
             "name": "Kitsune Blademaster",
             "text": "First strike\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -897,7 +897,7 @@
         },
         {
             "id": "183c8aeb-e585-5d81-97d2-a2dbac3ffea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50fb007-d1fd-4b61-91c3-4863e40472ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50fb007-d1fd-4b61-91c3-4863e40472ed.jpg?1",
             "name": "Kitsune Diviner",
             "text": "{T}: Tap target Spirit.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "c8f830b9-849f-5be1-9fbc-3fb4b119fc24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bb6894-b56a-4a63-859a-65a0c2d160fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bb6894-b56a-4a63-859a-65a0c2d160fc.jpg?1",
             "name": "Kitsune Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\n{T}: Prevent all damage that would be dealt to target legendary creature this turn.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "a0bd4b3d-44ed-5c12-99ce-c6822e88a15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg?1",
             "name": "Kitsune Mystic // Autumn-Tail, Kitsune Sage",
             "text": "At end of turn, if Kitsune Mystic is enchanted by two or more enchantments, flip it.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "8613f299-d2d6-5dcb-bdd4-08f143102e13",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg?1",
             "name": "Kitsune Mystic // Autumn-Tail, Kitsune Sage",
             "text": "{1}: Move target enchantment enchanting a creature to another creature.",
             "colours": [
@@ -1039,7 +1039,7 @@
         },
         {
             "id": "f4b90261-27d2-5e5f-967e-09f17b31aba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f545d9d0-52d8-4b90-a8bb-178f4ba3c4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f545d9d0-52d8-4b90-a8bb-178f4ba3c4b7.jpg?1",
             "name": "Kitsune Riftwalker",
             "text": "Protection from Spirits and from Arcane",
             "colours": [
@@ -1074,7 +1074,7 @@
         },
         {
             "id": "5a3603e3-6560-5fc4-b695-344f2d0b88e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg?1",
             "name": "Konda, Lord of Eiganjo",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nBushido 5 (When this blocks or becomes blocked, it gets +5/+5 until end of turn.)\nKonda, Lord of Eiganjo is indestructible.",
             "colours": [
@@ -1111,7 +1111,7 @@
         },
         {
             "id": "de8f8b6c-d5b8-56f0-a517-4ece4e0f3048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cf6-f6ad-4302-8f07-099eabdd4b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cf6-f6ad-4302-8f07-099eabdd4b40.jpg?1",
             "name": "Konda's Hatamoto",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nAs long as you control a legendary Samurai, Konda's Hatamoto gets +1/+2 and has vigilance. (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "4d56bf38-0694-5542-a5c9-d84a8926f75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99625787-f184-48a5-a678-e30b7024c7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99625787-f184-48a5-a678-e30b7024c7bb.jpg?1",
             "name": "Lantern Kami",
             "text": "Flying",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "9b0efd08-9e9a-550a-a5a2-8c4cd357c3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2507f-4035-47d5-8295-0a3773f187fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2507f-4035-47d5-8295-0a3773f187fb.jpg?1",
             "name": "Masako the Humorless",
             "text": "You may play Masako the Humorless any time you could play an instant.\nTapped creatures you control may block as though they were untapped.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "6c22631e-8ae2-506e-848a-7a6579a2a33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a236f7-f008-4eb8-91d9-31ea8589cf0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a236f7-f008-4eb8-91d9-31ea8589cf0c.jpg?1",
             "name": "Mothrider Samurai",
             "text": "Flying\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "163cbec7-6e2c-5372-87b4-593a02dd787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0570ba0-2877-46f6-acea-6913f8915d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0570ba0-2877-46f6-acea-6913f8915d6d.jpg?1",
             "name": "Myojin of Cleansing Fire",
             "text": "Myojin of Cleansing Fire comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Cleansing Fire is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Cleansing Fire: Destroy each other creature.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "e571ccd1-f93d-5a01-a0ed-90adb6d2177e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45258f4-c36d-46cc-80e8-cc458351e003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45258f4-c36d-46cc-80e8-cc458351e003.jpg?1",
             "name": "Nagao, Bound by Honor",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever Nagao, Bound by Honor attacks, Samurai you control get +1/+1 until end of turn.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "8fc64558-cb7f-5ae2-b34b-7daa69d3cf73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a293db52-49f2-4a9c-8ee0-054d994b7299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a293db52-49f2-4a9c-8ee0-054d994b7299.jpg?1",
             "name": "Otherworldly Journey",
             "text": "Remove target creature from the game. At end of turn, return that creature to play under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "733224c7-1b0c-58c5-8cc4-6e8507c55b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4124b9-5169-471e-b805-ceeffeec9184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4124b9-5169-471e-b805-ceeffeec9184.jpg?1",
             "name": "Pious Kitsune",
             "text": "At the beginning of your upkeep, put a devotion counter on Pious Kitsune. Then if a creature named Eight-and-a-Half-Tails is in play, you gain 1 life for each devotion counter on Pious Kitsune.\n{T}, Remove a devotion counter from Pious Kitsune: You gain 1 life.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "37817393-5a5a-5f05-a148-e0cfcd701930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd4d7cd-12a9-49f2-912d-2a6024112d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd4d7cd-12a9-49f2-912d-2a6024112d13.jpg?1",
             "name": "Quiet Purity",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "b0bb4ecc-98d3-55ba-ad95-fc1630d6bc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c835f8-9269-4950-95c9-125d58b7b19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c835f8-9269-4950-95c9-125d58b7b19e.jpg?1",
             "name": "Reciprocate",
             "text": "Remove from the game target creature that dealt damage to you this turn.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "4f7dd03e-6703-520f-9668-9c6eab5393d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae9c988-5e8c-4d3a-af6d-8ac083698159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae9c988-5e8c-4d3a-af6d-8ac083698159.jpg?1",
             "name": "Reverse the Sands",
             "text": "Redistribute any number of players' life totals. (Each of those players gets one life total back.)",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "3dd3c2e2-c681-5d3d-aa6b-28631661e246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2be3fe-87a2-47b2-8af1-b99a48622c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2be3fe-87a2-47b2-8af1-b99a48622c7b.jpg?1",
             "name": "Samurai Enforcers",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "3aa2b361-a9a8-544e-a5fc-beef1a7cc23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead15cf8-f692-4cb9-ac86-0dff00236145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead15cf8-f692-4cb9-ac86-0dff00236145.jpg?1",
             "name": "Samurai of the Pale Curtain",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf a permanent would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "72de7408-0aed-5169-aa17-d47d1078ebb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93dd897-3fb5-48b1-bdff-9383ce1feb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93dd897-3fb5-48b1-bdff-9383ce1feb21.jpg?1",
             "name": "Sensei Golden-Tail",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{1}{W}, {T}: Put a training counter on target creature. That creature gains bushido 1 and becomes a Samurai in addition to its other creature types. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1599,7 +1599,7 @@
         },
         {
             "id": "97c1bed6-9796-5bb7-a655-cf2be05e3351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272dfee6-9c90-4409-9289-f451261909e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272dfee6-9c90-4409-9289-f451261909e7.jpg?1",
             "name": "Silent-Chant Zubera",
             "text": "When Silent-Chant Zubera is put into a graveyard from play, you gain 2 life for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "9c3b4078-b1f3-5bc4-83ee-5a62984f9848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d038df46-4a30-4125-be0e-8781b16b523e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d038df46-4a30-4125-be0e-8781b16b523e.jpg?1",
             "name": "Takeno, Samurai General",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\nEach other Samurai you control gets +1/+1 for each point of bushido it has.",
             "colours": [
@@ -1671,7 +1671,7 @@
         },
         {
             "id": "e6eb4a22-2253-5802-a237-7732c0bcead7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7176139f-8a9a-4ee4-a56d-672fd09390e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7176139f-8a9a-4ee4-a56d-672fd09390e4.jpg?1",
             "name": "Terashi's Cry",
             "text": "Tap up to three target creatures.",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "038d1b1d-cd84-539c-9395-bfc3497437d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef25165-2458-4c00-8b7c-0ad6fd98e3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef25165-2458-4c00-8b7c-0ad6fd98e3af.jpg?1",
             "name": "Vassal's Duty",
             "text": "{1}: The next 1 damage that would be dealt to target legendary creature you control this turn is dealt to you instead.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "dae584af-f082-5567-a2ca-9ce29c84bb9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24dc353-abc9-430a-a7f5-5da3b38cd411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24dc353-abc9-430a-a7f5-5da3b38cd411.jpg?1",
             "name": "Vigilance",
             "text": "Enchanted creature has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -1771,7 +1771,7 @@
         },
         {
             "id": "5121c22c-ddf9-554f-b18d-05b6a97a5702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b38f14a-bd10-47c1-8772-5abe0a0b243f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b38f14a-bd10-47c1-8772-5abe0a0b243f.jpg?1",
             "name": "Yosei, the Morning Star",
             "text": "Flying\nWhen Yosei, the Morning Star is put into a graveyard from play, target player skips his or her next untap step. Tap up to five target permanents that player controls.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "fa61fa37-6146-5c70-baed-a777f6436713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26913c27-5794-42c7-a2a2-af565ce84fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26913c27-5794-42c7-a2a2-af565ce84fd1.jpg?1",
             "name": "Aura of Dominion",
             "text": "{1}, Tap an untapped creature you control: Untap enchanted creature.",
             "colours": [
@@ -1842,7 +1842,7 @@
         },
         {
             "id": "563b6bed-a458-576c-9ff3-cd8a482bd164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ea91b1-f2ff-4b99-8148-333aa27ea8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ea91b1-f2ff-4b99-8148-333aa27ea8cd.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "b73c882f-4eae-5ce0-afd5-7b704bfe7cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628d3058-d32e-438c-9a86-3e9c2be73c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628d3058-d32e-438c-9a86-3e9c2be73c4a.jpg?1",
             "name": "Callous Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Callous Deceiver gets +1/+0 and gains flying until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "abe9c41f-6451-55ef-b5cb-e86f5ed4c66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee99c-74ca-4d78-ade2-c6a93b0bd4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee99c-74ca-4d78-ade2-c6a93b0bd4fd.jpg?1",
             "name": "Consuming Vortex",
             "text": "Return target creature to its owner's hand.\nSplice onto Arcane {3}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1947,7 +1947,7 @@
         },
         {
             "id": "3caae284-7f5a-525f-b576-109187699e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401911c-bfb0-4c94-9fc1-49198ccecc94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401911c-bfb0-4c94-9fc1-49198ccecc94.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "Draw two cards.",
             "colours": [
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "1114ab88-a865-5077-a7e7-a4bbf0a1ff04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff18307-9ef8-4e3a-89e9-cb8c04997222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff18307-9ef8-4e3a-89e9-cb8c04997222.jpg?1",
             "name": "Cut the Tethers",
             "text": "For each Spirit, return it to its owner's hand unless that player pays {3}.",
             "colours": [
@@ -2011,7 +2011,7 @@
         },
         {
             "id": "cc30989a-c329-50cc-9d36-8d32cd359a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4806218-ff27-4df3-922d-5a085ffa44a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4806218-ff27-4df3-922d-5a085ffa44a6.jpg?1",
             "name": "Dampen Thought",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard.\nSplice onto Arcane {1}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "c0761af0-a771-5ac2-978b-e2107cae233a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af326c1-fcc8-45c3-b75e-ae4dbbd59ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af326c1-fcc8-45c3-b75e-ae4dbbd59ced.jpg?1",
             "name": "Eerie Procession",
             "text": "Search your library for an Arcane card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -2079,7 +2079,7 @@
         },
         {
             "id": "c538167c-c1cc-5356-8a8a-0185b02a7ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b307af89-1890-4fac-a12e-f8a678f1101f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b307af89-1890-4fac-a12e-f8a678f1101f.jpg?1",
             "name": "Eye of Nowhere",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -2113,7 +2113,7 @@
         },
         {
             "id": "e89d8bfb-66e8-574d-a389-f5fc7299676c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c6fc-324b-4cff-9109-6d817767865f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c6fc-324b-4cff-9109-6d817767865f.jpg?1",
             "name": "Field of Reality",
             "text": "Enchanted creature can't be blocked by Spirits.\n{1}{U}: Return Field of Reality to its owner's hand.",
             "colours": [
@@ -2147,7 +2147,7 @@
         },
         {
             "id": "5886dced-e60d-5574-b6e2-fad4352e84a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55a8-6c21-4cc1-a2c4-86cd60cddced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55a8-6c21-4cc1-a2c4-86cd60cddced.jpg?1",
             "name": "Floating-Dream Zubera",
             "text": "When Floating-Dream Zubera is put into a graveyard from play, draw a card for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "750e54a9-d3d0-5e32-bd61-e3a618491445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b91eb5-ea53-4a21-a2e5-9c545a42fa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b91eb5-ea53-4a21-a2e5-9c545a42fa30.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -2214,7 +2214,7 @@
         },
         {
             "id": "2cba7299-4295-5889-9a4a-148fc3aeb46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648430cc-80d1-479f-ae31-76687d2eb57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648430cc-80d1-479f-ae31-76687d2eb57c.jpg?1",
             "name": "Graceful Adept",
             "text": "You have no maximum hand size.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "59b57b9c-606c-51dc-b7ad-1c48a6610c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d16011-956b-40ac-afb6-6c7ad774802f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d16011-956b-40ac-afb6-6c7ad774802f.jpg?1",
             "name": "Guardian of Solitude",
             "text": "Whenever you play a Spirit or Arcane spell, target creature gains flying until end of turn.",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "4409747b-156f-5451-b35e-fe788cfc477f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7befed-805b-4a02-a87d-7df3a95db8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7befed-805b-4a02-a87d-7df3a95db8a0.jpg?1",
             "name": "Hinder",
             "text": "Counter target spell. If it's countered this way, put that card on the top or bottom of its owner's library instead of that player's graveyard.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "6ede2ca4-0a25-54f1-837e-f82b631efec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87aea05-5970-455e-a728-668cf23940a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87aea05-5970-455e-a728-668cf23940a6.jpg?1",
             "name": "Hisoka, Minamo Sensei",
             "text": "{2}{U}, Discard a card: Counter target spell if it has the same converted mana cost as the discarded card.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "9cc7cd5a-955a-5db6-a3e8-9cc5c70aade0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd4d01-1204-46a3-b237-45c37985acac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd4d01-1204-46a3-b237-45c37985acac.jpg?1",
             "name": "Hisoka's Defiance",
             "text": "Counter target Spirit or Arcane spell.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "f51b54e6-dd32-5e7f-a5bc-0060416e3860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7aec86-7b12-4025-af06-1c1928e56c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7aec86-7b12-4025-af06-1c1928e56c19.jpg?1",
             "name": "Hisoka's Guard",
             "text": "You may choose not to untap Hisoka's Guard during your untap step.\n{1}{U}, {T}: As long as Hisoka's Guard remains tapped, target creature you control other than Hisoka's Guard can't be the target of spells or abilities.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "d09cb0c3-7870-5af3-85a2-4888fc5dbaf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad732186-eeb9-4edb-a17a-51f8bac71802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad732186-eeb9-4edb-a17a-51f8bac71802.jpg?1",
             "name": "Honden of Seeing Winds",
             "text": "At the beginning of your upkeep, draw a card for each Shrine you control.",
             "colours": [
@@ -2455,7 +2455,7 @@
         },
         {
             "id": "8afd5f86-6980-5487-af73-84e843f88751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg?1",
             "name": "Jushi Apprentice // Tomoya the Revealer",
             "text": "{2}{U}, {T}: Draw a card. If you have nine or more cards in hand, flip Jushi Apprentice.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "cac83f97-0eb4-5ddb-84dc-622734b13134",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg?1",
             "name": "Jushi Apprentice // Tomoya the Revealer",
             "text": "{3}{U}{U}, {T}: Target player draws X cards, where X is the number of cards in your hand.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "7c647122-6c79-5ad8-bde1-2ecb12d0c035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf1b2f-933f-4ad3-a816-2797d96ff37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf1b2f-933f-4ad3-a816-2797d96ff37f.jpg?1",
             "name": "Kami of Twisted Reflection",
             "text": "Sacrifice Kami of Twisted Reflection: Return target creature you control to its owner's hand.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "3ec11245-5aa9-531e-b60c-389f4e83f13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea83eaeb-cf82-406b-977f-2bac41925739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea83eaeb-cf82-406b-977f-2bac41925739.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star is put into a graveyard from play, gain control of target creature.",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "d5960bb5-0fd6-5d40-9175-08411d04afd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f08f3d-82ef-4c3f-af2d-a3c834e22b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f08f3d-82ef-4c3f-af2d-a3c834e22b99.jpg?1",
             "name": "Lifted by Clouds",
             "text": "Target creature gains flying until end of turn.\nSplice onto Arcane {1}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "eee3a30f-be71-5158-bdee-cd8013fe779c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caaa733-6d4c-4e18-a64e-f95851c7063b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caaa733-6d4c-4e18-a64e-f95851c7063b.jpg?1",
             "name": "Meloku the Clouded Mirror",
             "text": "Flying\n{1}, Return a land you control to its owner's hand: Put a 1/1 blue Illusion creature token with flying into play.",
             "colours": [
@@ -2669,7 +2669,7 @@
         },
         {
             "id": "8d04764c-973d-5117-8b74-f29678d54110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5f8d3a-95e7-4dd9-8510-43517eb02693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5f8d3a-95e7-4dd9-8510-43517eb02693.jpg?1",
             "name": "Myojin of Seeing Winds",
             "text": "Myojin of Seeing Winds comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Seeing Winds is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Seeing Winds: Draw a card for each permanent you control.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "8293c8ea-120a-5b12-b6a2-428212554436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc4428-3f86-4359-927d-4009ada52c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc4428-3f86-4359-927d-4009ada52c5d.jpg?1",
             "name": "Mystic Restraints",
             "text": "You may play Mystic Restraints any time you could play an instant.\nWhen Mystic Restraints comes into play, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "80d81097-2fb1-50ab-9b27-1e382ed7afe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d870e607-1607-46f3-bc9f-925d0164bcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d870e607-1607-46f3-bc9f-925d0164bcf9.jpg?1",
             "name": "Part the Veil",
             "text": "Return all creatures you control to their owner's hand.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "c1c64348-9d29-5996-a767-823d6ca6a4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be02570-b840-46cc-af54-5279463fdcab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be02570-b840-46cc-af54-5279463fdcab.jpg?1",
             "name": "Peer Through Depths",
             "text": "Look at the top five cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "d7239e79-b951-56cd-8660-0091915493fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f59a16-45a8-4b52-a8df-ea96abafd8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f59a16-45a8-4b52-a8df-ea96abafd8ff.jpg?1",
             "name": "Petals of Insight",
             "text": "Look at the top three cards of your library. You may put those cards on the bottom of your library in any order. If you do, return Petals of Insight to its owner's hand. Otherwise, draw three cards.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "1d636ebe-e83a-5e28-ab30-a42f33bbfe06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e341d6b-f4b0-4347-8055-f5fab756334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e341d6b-f4b0-4347-8055-f5fab756334c.jpg?1",
             "name": "Psychic Puppetry",
             "text": "Tap or untap target permanent.\nSplice onto Arcane {U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2875,7 +2875,7 @@
         },
         {
             "id": "b130874a-63d4-540e-a13e-612eb5040d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63a2cd-dd67-4692-9baf-520ebf6ab331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63a2cd-dd67-4692-9baf-520ebf6ab331.jpg?1",
             "name": "Reach Through Mists",
             "text": "Draw a card.",
             "colours": [
@@ -2909,7 +2909,7 @@
         },
         {
             "id": "71d3c3a9-170a-5869-b264-55eef08358c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff68016-80b4-4801-b796-5c5fdbc8faa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff68016-80b4-4801-b796-5c5fdbc8faa1.jpg?1",
             "name": "Reweave",
             "text": "Target permanent's controller sacrifices it. That player reveals cards from the top of his or her library until he or she reveals a card that shares a card type with the sacrificed permanent. The player puts that card into play, then shuffles his or her library.\nSplice onto Arcane {2}{U}{U}",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "9a5b54c3-9b71-51d7-a43c-8ec570e625e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e403cad6-84b0-4a6b-a2d8-cb572ec09932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e403cad6-84b0-4a6b-a2d8-cb572ec09932.jpg?1",
             "name": "River Kaijin",
             "text": "",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "39514909-56f3-5a74-ba89-bbffba1a92db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bde4d-4cdb-42db-acc5-441ed8fa4a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bde4d-4cdb-42db-acc5-441ed8fa4a5b.jpg?1",
             "name": "Sift Through Sands",
             "text": "Draw two cards, then discard a card.\nIf you played a spell named Peer Through Depths and a spell named Reach Through Mists this turn, you may search your library for a card named The Unspeakable, put it into play, then shuffle your library.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "39a1cd64-5baa-5ecf-9210-be662455a95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e76d003-2d15-43d7-9cbb-e00564d0cabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e76d003-2d15-43d7-9cbb-e00564d0cabf.jpg?1",
             "name": "Sire of the Storm",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may draw a card.",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "8a47e710-b73f-5029-9a4b-f6dd5c88e3c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3d3024-bef2-4b50-ab84-8ae2a23cdf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3d3024-bef2-4b50-ab84-8ae2a23cdf27.jpg?1",
             "name": "Soratami Cloudskater",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Draw a card, then discard a card.",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "69eaadb9-57a1-5bb0-a943-4827ad2cd2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff8968b-cd96-4f44-85f8-2af20d61d7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff8968b-cd96-4f44-85f8-2af20d61d7cb.jpg?1",
             "name": "Soratami Mirror-Guard",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "84a4cfe3-745d-53a8-a364-8a9fdc6682fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215209b1-1a5d-48f4-9eca-19a9848b2fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215209b1-1a5d-48f4-9eca-19a9848b2fed.jpg?1",
             "name": "Soratami Mirror-Mage",
             "text": "Flying\n{3}, Return three lands you control to their owner's hand: Return target creature to its owner's hand.",
             "colours": [
@@ -3150,7 +3150,7 @@
         },
         {
             "id": "4657e057-ac11-534c-8b0b-e317eed68ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b942ee46-c78b-414a-9de7-4376370532fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b942ee46-c78b-414a-9de7-4376370532fa.jpg?1",
             "name": "Soratami Rainshaper",
             "text": "Flying\n{3}, Return a land you control to its owner's hand: Target creature you control can't be the target of spells or abilities this turn.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "b6758b32-6bb7-53dd-83db-a7bd87f0a70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ea2db8-67c6-4bcd-8ba1-f620b8e8a8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ea2db8-67c6-4bcd-8ba1-f620b8e8a8c4.jpg?1",
             "name": "Soratami Savant",
             "text": "Flying\n{3}, Return a land you control to its owner's hand: Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "d46d58e1-ab32-52d5-8268-c6429f7fd2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a861d-e5c5-48b1-95c0-3ef04b690eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a861d-e5c5-48b1-95c0-3ef04b690eac.jpg?1",
             "name": "Soratami Seer",
             "text": "Flying\n{4}, Return two lands you control to their owner's hand: Discard your hand, then draw that many cards.",
             "colours": [
@@ -3255,7 +3255,7 @@
         },
         {
             "id": "ba7baec1-2870-559f-bd33-6c36f8aa8362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29421dd2-70a7-4623-afe0-ca4cb415ec87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29421dd2-70a7-4623-afe0-ca4cb415ec87.jpg?1",
             "name": "Squelch",
             "text": "Counter target activated ability. (Mana abilities can't be targeted.)\nDraw a card.",
             "colours": [
@@ -3287,7 +3287,7 @@
         },
         {
             "id": "453533eb-3f36-5715-a6ff-a405167e69f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg?1",
             "name": "Student of Elements // Tobita, Master of Winds",
             "text": "When Student of Elements has flying, flip it.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "b4634985-8eba-5f39-a99d-7af5d87af8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg?1",
             "name": "Student of Elements // Tobita, Master of Winds",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "fa075c7a-d012-5458-a709-735047ab77fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea50e09-4ab3-439e-83d7-d584f8af8f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea50e09-4ab3-439e-83d7-d584f8af8f16.jpg?1",
             "name": "Swirl the Mists",
             "text": "As Swirl the Mists comes into play, choose a color word.\nAll instances of color words on spells and permanents become the chosen color word.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "db9316ff-7374-5125-935d-ce89ec0cc6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c914db7d-c907-4d25-a180-f68b274a5cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c914db7d-c907-4d25-a180-f68b274a5cb7.jpg?1",
             "name": "Teller of Tales",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, tap or untap target creature.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "df9fc4a1-8a2e-5b8e-8a46-17ac1ec559a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7919cf41-67bb-4dc4-90de-cf3fa2096c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7919cf41-67bb-4dc4-90de-cf3fa2096c2e.jpg?1",
             "name": "Thoughtbind",
             "text": "Counter target spell with converted mana cost 4 or less.",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "03dd60b2-6186-5415-a1b5-334888d91b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f968c5e9-12a8-4542-90b4-84e0238fa375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f968c5e9-12a8-4542-90b4-84e0238fa375.jpg?1",
             "name": "Time Stop",
             "text": "End the turn. (Remove all spells and abilities on the stack from the game, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "39eceb36-9351-5192-9347-d6714c1e7009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bd3e-e8d8-483e-871b-29fd378f817e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bd3e-e8d8-483e-871b-29fd378f817e.jpg?1",
             "name": "The Unspeakable",
             "text": "Flying, trample\nWhenever The Unspeakable deals combat damage to a player, you may return target Arcane card from your graveyard to your hand.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "a6d77b5a-be43-54f2-b001-360b4972340f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbfb3c53-1e68-48ce-8008-93bc49e188dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbfb3c53-1e68-48ce-8008-93bc49e188dd.jpg?1",
             "name": "Uyo, Silent Prophet",
             "text": "Flying\n{2}, Return two lands you control to their owner's hand: Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "39668d00-1aa9-59a3-9ae0-dce7fc119a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f973d6b-4a34-4b0e-b092-ead05bf2e535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f973d6b-4a34-4b0e-b092-ead05bf2e535.jpg?1",
             "name": "Wandering Ones",
             "text": "",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "01631cb7-e30e-5be8-87ba-00afce115628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee88d-849d-4715-ad88-7cdb855a3088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee88d-849d-4715-ad88-7cdb855a3088.jpg?1",
             "name": "Ashen-Skin Zubera",
             "text": "When Ashen-Skin Zubera is put into a graveyard from play, target opponent discards a card for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "0f72e445-d433-5083-93dc-4a33c4835b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfff5d3-1433-4a24-83e6-6361a446b974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfff5d3-1433-4a24-83e6-6361a446b974.jpg?1",
             "name": "Befoul",
             "text": "Destroy target land or nonblack creature. It can't be regenerated.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "7d40e039-e287-53e8-8b55-08a425c62aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f218bb94-d5a2-41f6-8bca-b689dcd09a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f218bb94-d5a2-41f6-8bca-b689dcd09a43.jpg?1",
             "name": "Blood Speaker",
             "text": "At the beginning of your upkeep, you may sacrifice Blood Speaker. If you do, search your library for a Demon card, reveal that card, and put it into your hand. Then shuffle your library.\nWhenever a Demon comes into play under your control, return Blood Speaker from your graveyard to your hand.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "7241f895-28e8-5a0d-b56e-74dac36e758c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557f035-f93b-41ce-b8de-dea79dcf15be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557f035-f93b-41ce-b8de-dea79dcf15be.jpg?1",
             "name": "Bloodthirsty Ogre",
             "text": "{T}: Put a devotion counter on Bloodthirsty Ogre.\n{T}: Target creature gets -X/-X until end of turn, where X is the number of devotion counters on Bloodthirsty Ogre. Play this ability only if you control a Demon.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "2752eee9-5af7-514c-b8af-8642b5747a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cad7a3-777e-4c84-b404-5f504844ab3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cad7a3-777e-4c84-b404-5f504844ab3b.jpg?1",
             "name": "Cranial Extraction",
             "text": "Name a nonland card. Search target player's graveyard, hand, and library for all cards with that name and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "9069e675-35af-53e1-9cc9-d01445165fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6972a-5305-423f-a936-16ee0fbf9200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6972a-5305-423f-a936-16ee0fbf9200.jpg?1",
             "name": "Cruel Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Cruel Deceiver gains \"Whenever Cruel Deceiver deals damage to a creature, destroy that creature\" until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "0ed0e641-0d49-58c9-8004-47a467ae62f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f24fe9-22c4-4e53-9d7a-3cbf5533ac9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f24fe9-22c4-4e53-9d7a-3cbf5533ac9b.jpg?1",
             "name": "Cursed Ronin",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{B}: Cursed Ronin gets +1/+1 until end of turn.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "072b5d8d-0398-5f57-9d1f-a77e68376dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a1b403-776f-4fd7-a77a-b73946ab179d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a1b403-776f-4fd7-a77a-b73946ab179d.jpg?1",
             "name": "Dance of Shadows",
             "text": "Creatures you control get +1/+0 and gain fear until end of turn.",
             "colours": [
@@ -3871,7 +3871,7 @@
         },
         {
             "id": "9b432e1f-f41b-50a3-916b-3d7e062ea072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bd3c73-fff4-40e8-b9db-80a010a4dd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bd3c73-fff4-40e8-b9db-80a010a4dd37.jpg?1",
             "name": "Deathcurse Ogre",
             "text": "When Deathcurse Ogre is put into a graveyard from play, each player loses 3 life.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "cec183d4-1ad1-55ee-a8ea-9a0f9de4b136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a72347d-91cd-45a8-a026-a655e5507322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a72347d-91cd-45a8-a026-a655e5507322.jpg?1",
             "name": "Devouring Greed",
             "text": "As an additional cost to play Devouring Greed, you may sacrifice any number of Spirits.\nTarget player loses 2 life plus 2 life for each Spirit sacrificed this way. You gain that much life.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "fc66ca1a-b171-587d-bd29-f4ddd34d46ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8130a902-3a03-4473-a64f-84cf3590f4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8130a902-3a03-4473-a64f-84cf3590f4c6.jpg?1",
             "name": "Distress",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "c8b741cd-28fa-58ce-ae8b-b44f973f0b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3e988f-314c-4e83-b279-c2a736933e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3e988f-314c-4e83-b279-c2a736933e64.jpg?1",
             "name": "Gibbering Kami",
             "text": "Flying\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "54360fc9-8f6e-5fb4-a004-080493df924b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7698a5da-5c70-4818-927b-3a923314e537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7698a5da-5c70-4818-927b-3a923314e537.jpg?1",
             "name": "Gutwrencher Oni",
             "text": "Trample\nAt the beginning of your upkeep, discard a card if you don't control an Ogre.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "6605d255-9a80-52f5-9085-a6d345f04a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf0f8d-f988-45ec-b75b-d97206326cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf0f8d-f988-45ec-b75b-d97206326cfb.jpg?1",
             "name": "He Who Hungers",
             "text": "Flying\n{1}, Sacrifice a Spirit: Target opponent reveals his or her hand. Choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.\nSoulshift 4",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "367f3cb8-6b07-5183-8d4a-425cacbe24a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941fd135-1c5a-4650-8faf-dfa2c93ec8c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941fd135-1c5a-4650-8faf-dfa2c93ec8c9.jpg?1",
             "name": "Hideous Laughter",
             "text": "All creatures get -2/-2 until end of turn.\nSplice onto Arcane {3}{B}{B} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "3eede8c6-ccb4-5aac-9d8a-f71e772139ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526419ae-5a49-40e8-ac45-f213a76c7326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526419ae-5a49-40e8-ac45-f213a76c7326.jpg?1",
             "name": "Honden of Night's Reach",
             "text": "At the beginning of your upkeep, target opponent discards a card for each Shrine you control.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "688620fc-1f8d-5478-a278-3b03aa712251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41983cb-c4e4-4384-bd69-df3fc6e74cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41983cb-c4e4-4384-bd69-df3fc6e74cd0.jpg?1",
             "name": "Horobi, Death's Wail",
             "text": "Flying\nWhenever a creature becomes the target of a spell or ability, destroy that creature.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "e3a5a99c-6c22-546a-b8f0-c5e7964aed40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd67e11-3dad-4e59-b15d-02911e53fbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd67e11-3dad-4e59-b15d-02911e53fbbf.jpg?1",
             "name": "Iname, Death Aspect",
             "text": "When Iname, Death Aspect comes into play, you may search your library for any number of Spirit cards and put them into your graveyard. If you do, shuffle your library.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "49866d76-aa9d-51b4-b745-5e7d9bb0ee77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baef070-d265-4c6d-9b4b-3cafbd3b34c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baef070-d265-4c6d-9b4b-3cafbd3b34c3.jpg?1",
             "name": "Kami of Lunacy",
             "text": "Flying\nSoulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "e84caa99-ad1e-5fe8-ae21-60e3434a1032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a395a6-b1f5-4b7f-87cc-c77b4d497e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a395a6-b1f5-4b7f-87cc-c77b4d497e9a.jpg?1",
             "name": "Kami of the Waning Moon",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, target creature gains fear until end of turn.",
             "colours": [
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "e522c443-2bdf-5b03-b32d-276593c9390c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e18994-d08b-4a8e-abfb-b5531fd6f816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e18994-d08b-4a8e-abfb-b5531fd6f816.jpg?1",
             "name": "Kiku, Night's Flower",
             "text": "{2}{B}{B}, {T}: Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "eea786c2-ee22-5b8d-8faa-4dbfa32c53cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63dc0698-e92f-4134-80e4-5cc37b80e37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63dc0698-e92f-4134-80e4-5cc37b80e37c.jpg?1",
             "name": "Kokusho, the Evening Star",
             "text": "Flying\nWhen Kokusho, the Evening Star is put into a graveyard from play, each opponent loses 5 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "e2aff046-d957-5e58-941e-86b51d487deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d23ff5-849d-4032-9c70-8e9effcbac81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d23ff5-849d-4032-9c70-8e9effcbac81.jpg?1",
             "name": "Kuro, Pitlord",
             "text": "At the beginning of your upkeep, sacrifice Kuro, Pitlord unless you pay {B}{B}{B}{B}.\nPay 1 life: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "9227808c-c937-5440-bd55-d2e7cff77bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e4548b-c171-4f10-b896-af37543dcf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e4548b-c171-4f10-b896-af37543dcf0f.jpg?1",
             "name": "Marrow-Gnawer",
             "text": "All Rats have fear.\n{T}, Sacrifice a Rat: Put X 1/1 black Rat creature tokens into play, where X is the number of Rats you control.",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "ea1e9831-0d6f-5f98-b469-375a95323eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d797e91-3fc7-4f62-8cd8-dbd5f445e69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d797e91-3fc7-4f62-8cd8-dbd5f445e69c.jpg?1",
             "name": "Midnight Covenant",
             "text": "Enchanted creature has \"{B}: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "c69ac42a-d22f-5abb-a849-0f092d9d57f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a295b0-535e-4c2d-879d-62603d1f2f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a295b0-535e-4c2d-879d-62603d1f2f1b.jpg?1",
             "name": "Myojin of Night's Reach",
             "text": "Myojin of Night's Reach comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Night's Reach is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Night's Reach: Each opponent discards his or her hand.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "625b5929-508d-57d5-9fb8-bb1e6774901d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f27ff7-c7e4-4099-b3ac-6560c6ccba41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f27ff7-c7e4-4099-b3ac-6560c6ccba41.jpg?1",
             "name": "Nezumi Bone-Reader",
             "text": "{B}, Sacrifice a creature: Target player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "d412abac-ef2c-5b10-9e4a-c7062911f9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166af8cd-9690-4741-ade3-5d5f9723c431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166af8cd-9690-4741-ade3-5d5f9723c431.jpg?1",
             "name": "Nezumi Cutthroat",
             "text": "Fear\nNezumi Cutthroat can't block.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "bce68d4d-0332-5be5-86e0-bf9d214fa8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg?1",
             "name": "Nezumi Graverobber // Nighteyes the Desecrator",
             "text": "{1}{B}: Remove target card in an opponent's graveyard from the game. If no cards are in that graveyard, flip Nezumi Graverobber.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "c81c2f3d-eebe-59ea-b7e8-c3f91908eadd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg?1",
             "name": "Nezumi Graverobber // Nighteyes the Desecrator",
             "text": "{4}{B}: Put target creature card in a graveyard into play under your control.",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "50b1de8e-ddfa-57e9-a6a8-52d164e55f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b8d6f-c60a-4107-b931-31b10f497237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b8d6f-c60a-4107-b931-31b10f497237.jpg?1",
             "name": "Nezumi Ronin",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "a888a494-31c0-592a-bc4a-b4a9c9181ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg?1",
             "name": "Nezumi Shortfang // Stabwhisker the Odious",
             "text": "{1}{B}, {T}: Target opponent discards a card. Then if that player has no cards in hand, flip Nezumi Shortfang.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "996c7cc2-9201-5f7c-ba67-f62158d6bcb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg?1",
             "name": "Nezumi Shortfang // Stabwhisker the Odious",
             "text": "At the beginning of each opponent's upkeep, that player loses 1 life for each card fewer than three in his or her hand.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "f7a4a9d3-a921-56fa-8d81-f54a8138aade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d012ee-9523-469f-8ddb-f4b664093c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d012ee-9523-469f-8ddb-f4b664093c13.jpg?1",
             "name": "Night Dealings",
             "text": "Whenever a source you control deals damage to another player, put that many theft counters on Night Dealings.\n{2}{B}{B}, Remove X theft counters from Night Dealings: Search your library for a nonland card with converted mana cost X, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "0b43426f-d3da-5656-9186-57abc2693be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce44980-0540-4b31-9a81-35357a4382fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce44980-0540-4b31-9a81-35357a4382fa.jpg?1",
             "name": "Night of Souls' Betrayal",
             "text": "All creatures get -1/-1.",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "dbd0b8c0-4eb0-595f-a992-e25b56513de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b878d1c2-34ce-4cb4-9ea3-8d7cd2028484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b878d1c2-34ce-4cb4-9ea3-8d7cd2028484.jpg?1",
             "name": "Numai Outcast",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{B}, Pay 5 life: Regenerate Numai Outcast.",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "ba229631-4b4d-55be-a2a3-ef4aabc10a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f122d-e1b7-4dd4-a770-a8f206ba42da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f122d-e1b7-4dd4-a770-a8f206ba42da.jpg?1",
             "name": "Oni Possession",
             "text": "At the beginning of your upkeep, sacrifice a creature.\nEnchanted creature gets +3/+3 and has trample.\nEnchanted creature is a Demon Spirit.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "48c35ae3-82d0-519f-ba4e-6a4f22c20e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b371b32-7758-4dc9-b4c5-1d1df1f1826a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b371b32-7758-4dc9-b4c5-1d1df1f1826a.jpg?1",
             "name": "Painwracker Oni",
             "text": "Fear\nAt the beginning of your upkeep, sacrifice a creature if you don't control an Ogre.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "4f33d2b8-d6d3-5ef5-9eba-f1187b910ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016afdaa-29bf-4690-bdfe-9074087a191c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016afdaa-29bf-4690-bdfe-9074087a191c.jpg?1",
             "name": "Pull Under",
             "text": "Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "53fc5dd8-dd48-5096-9ae1-8e10d48f9028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ef007a-fcf4-4293-933e-4f9f7f602002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ef007a-fcf4-4293-933e-4f9f7f602002.jpg?1",
             "name": "Rag Dealer",
             "text": "{2}{B}, {T}: Remove up to three target cards in a single graveyard from the game.",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "4f074153-39c7-5f93-b131-b00b97abf074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f3312f-71d0-4dfd-ba39-c2a2ff8d5bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f3312f-71d0-4dfd-ba39-c2a2ff8d5bd0.jpg?1",
             "name": "Ragged Veins",
             "text": "You may play Ragged Veins any time you could play an instant.\nWhenever enchanted creature is dealt damage, its controller loses that much life.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "8a8c3be1-6736-5bee-b29c-b1e068b9e57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b300a3-e6a8-4ca9-bb26-03f57b5ff6ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b300a3-e6a8-4ca9-bb26-03f57b5ff6ec.jpg?1",
             "name": "Rend Flesh",
             "text": "Destroy target non-Spirit creature.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "1026cf1b-cccb-5672-ad2f-a30cf80fb309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0235-a7fe-4e23-b154-3d30668a29a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0235-a7fe-4e23-b154-3d30668a29a7.jpg?1",
             "name": "Rend Spirit",
             "text": "Destroy target Spirit.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "f04e1ce3-8056-5827-965b-83a6a09bbf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d9bf4e-3bb1-4154-b1ff-a3d8a2810c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d9bf4e-3bb1-4154-b1ff-a3d8a2810c1b.jpg?1",
             "name": "Scuttling Death",
             "text": "Sacrifice Scuttling Death: Target creature gets -1/-1 until end of turn.\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "9ae1b13e-bcee-56b4-99d9-097fef1c9ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e61750-f7d7-4e6d-9d68-e1e357868a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e61750-f7d7-4e6d-9d68-e1e357868a8d.jpg?1",
             "name": "Seizan, Perverter of Truth",
             "text": "At the beginning of each player's upkeep, that player loses 2 life and draws two cards.",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "f4b63a47-eac8-5d53-9da8-3cd85a4a811f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36712c-1ccb-4efe-8db8-823b9b80a99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36712c-1ccb-4efe-8db8-823b9b80a99f.jpg?1",
             "name": "Soulless Revival",
             "text": "Return target creature card from your graveyard to your hand.\nSplice onto Arcane {1}{B} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5198,7 +5198,7 @@
         },
         {
             "id": "00cd486e-5d5f-50ca-b522-49400e412b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba827c43-5dd5-471f-83b2-cb5428fcd063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba827c43-5dd5-471f-83b2-cb5428fcd063.jpg?1",
             "name": "Struggle for Sanity",
             "text": "Target opponent reveals his or her hand. That player sets aside a card from it, then you set aside a card from it. Repeat this process until all cards in that hand have been set aside. That player returns the cards he or she set aside to his or her hand and puts the rest into his or her graveyard.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "21d70727-d5e6-5f57-b878-f90fdba5cd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac549d51-3862-4eb0-9951-f13a8ba28822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac549d51-3862-4eb0-9951-f13a8ba28822.jpg?1",
             "name": "Swallowing Plague",
             "text": "Swallowing Plague deals X damage to target creature and you gain X life.",
             "colours": [
@@ -5264,7 +5264,7 @@
         },
         {
             "id": "8dc5a3e7-6230-5dda-a8fa-e1fceffb4d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3029b8-01e2-4419-817e-318f23d6ce04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3029b8-01e2-4419-817e-318f23d6ce04.jpg?1",
             "name": "Thief of Hope",
             "text": "Whenever you play a Spirit or Arcane spell, target opponent loses 1 life and you gain 1 life.\nSoulshift 2 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 2 or less from your graveyard to your hand.)",
             "colours": [
@@ -5298,7 +5298,7 @@
         },
         {
             "id": "97715cb8-2dbd-5d70-b548-4c1ca8ed0c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c1ba-eae4-442b-8b80-20869ba20568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c1ba-eae4-442b-8b80-20869ba20568.jpg?1",
             "name": "Villainous Ogre",
             "text": "Villainous Ogre can't block.\nAs long as you control a Demon, Villainous Ogre has \"{B}: Regenerate Villainous Ogre.\"",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "ae4f8627-af5f-5b4d-8170-f89c11a96e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b892f31-816e-47c0-98b9-d71008bb6af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b892f31-816e-47c0-98b9-d71008bb6af4.jpg?1",
             "name": "Waking Nightmare",
             "text": "Target player discards two cards.",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "d0f12dcc-e8a3-5e3e-87c6-08221ad1f3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3172965-6057-472f-9712-1dd23d25d1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3172965-6057-472f-9712-1dd23d25d1a7.jpg?1",
             "name": "Wicked Akuba",
             "text": "{B}: Target player dealt damage by Wicked Akuba this turn loses 1 life.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "7021c457-18a6-5dd5-bcd8-3c98ff283d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfef6acb-a11c-4a3f-9cfb-9394dece2675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfef6acb-a11c-4a3f-9cfb-9394dece2675.jpg?1",
             "name": "Akki Avalanchers",
             "text": "Sacrifice a land: Akki Avalanchers gets +2/+0 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "798956d8-3d5e-5b15-9ac8-5b69d2d2384c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3793580a-052b-4e33-83ab-290086511a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3793580a-052b-4e33-83ab-290086511a21.jpg?1",
             "name": "Akki Coalflinger",
             "text": "First strike\n{R}, {T}: Attacking creatures gain first strike until end of turn.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "26ec184a-58f2-54bf-b6d3-c82c6aaea1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg?1",
             "name": "Akki Lavarunner // Tok-Tok, Volcano Born",
             "text": "Haste\nWhenever Akki Lavarunner deals damage to an opponent, flip it.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "c5e0b33c-79ea-5650-851c-94eff9bcd7f8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg?1",
             "name": "Akki Lavarunner // Tok-Tok, Volcano Born",
             "text": "Protection from red\nIf a red source would deal damage to a player, it deals that much damage plus 1 to that player instead.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "af841b07-2d78-5662-beae-aae51af6d3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8b6685-2c74-4026-aef0-73ca7bc43306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8b6685-2c74-4026-aef0-73ca7bc43306.jpg?1",
             "name": "Akki Rockspeaker",
             "text": "When Akki Rockspeaker comes into play, add {R} to your mana pool.",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "8cc5cbec-c6c9-5f65-a577-aab17476396d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdd1e22-d68d-4858-b253-80071d26d50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdd1e22-d68d-4858-b253-80071d26d50e.jpg?1",
             "name": "Akki Underminer",
             "text": "Whenever Akki Underminer deals combat damage to a player, that player sacrifices a permanent.",
             "colours": [
@@ -5614,7 +5614,7 @@
         },
         {
             "id": "125af987-62ba-526c-8d6c-885e42c49bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e4394a-fa91-4cf9-99c1-dc0bc1011c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e4394a-fa91-4cf9-99c1-dc0bc1011c5b.jpg?1",
             "name": "Battle-Mad Ronin",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\nBattle-Mad Ronin attacks each turn if able.",
             "colours": [
@@ -5649,7 +5649,7 @@
         },
         {
             "id": "497dce11-4a3e-5c1e-b999-ba355ec2d8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c015a6-4d7d-421b-84fa-30bf070cff83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c015a6-4d7d-421b-84fa-30bf070cff83.jpg?1",
             "name": "Ben-Ben, Akki Hermit",
             "text": "{T}: Ben-Ben, Akki Hermit deals damage to target attacking creature equal to the number of untapped Mountains you control.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "4eadac49-a360-56a9-8b7b-37b3382b22c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50a0fe0-249d-4a88-a538-cdf622388ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50a0fe0-249d-4a88-a538-cdf622388ce2.jpg?1",
             "name": "Blind with Anger",
             "text": "Untap target nonlegendary creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -5720,7 +5720,7 @@
         },
         {
             "id": "c701003d-8bc2-526a-b9d8-3da2d3fcd5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af8cd97-28cb-4499-a197-687e8f31644a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af8cd97-28cb-4499-a197-687e8f31644a.jpg?1",
             "name": "Blood Rites",
             "text": "{1}{R}, Sacrifice a creature: Blood Rites deals 2 damage to target creature or player.",
             "colours": [
@@ -5752,7 +5752,7 @@
         },
         {
             "id": "a7d7f03a-d876-52aa-97f6-44d371226533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef8c94-469b-4a76-b507-25b51f2501ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef8c94-469b-4a76-b507-25b51f2501ab.jpg?1",
             "name": "Brothers Yamazaki",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf there are exactly two permanents named Brothers Yamazaki in play, the \"legend rule\" doesn't apply to them.\nEach other creature named Brothers Yamazaki gets +2/+2 and has haste.",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "aacfd47d-9b20-52ad-a62c-cba3414357ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d854a02-661c-4071-9a92-a97a3ad607b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d854a02-661c-4071-9a92-a97a3ad607b3.jpg?1",
             "name": "Brothers Yamazaki",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf there are exactly two permanents named Brothers Yamazaki in play, the \"legend rule\" doesn't apply to them.\nEach other creature named Brothers Yamazaki gets +2/+2 and has haste.",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "141aa7e5-7473-518f-a4b9-9208deb92782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d532b3-4bd6-4c1d-974d-789976117497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d532b3-4bd6-4c1d-974d-789976117497.jpg?1",
             "name": "Brutal Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Brutal Deceiver gets +1/+0 and gains first strike until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "360b24a1-46a6-5c87-81ff-adf3071744b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58b4374-1a50-4574-8493-f5535c1020e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58b4374-1a50-4574-8493-f5535c1020e8.jpg?1",
             "name": "Crushing Pain",
             "text": "Crushing Pain deals 6 damage to target creature that was dealt damage this turn.",
             "colours": [
@@ -5898,7 +5898,7 @@
         },
         {
             "id": "e34d6af7-7a99-5c74-9c2b-e47b29b9896e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bdb92a-7bdb-434b-8cc0-873969faf566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bdb92a-7bdb-434b-8cc0-873969faf566.jpg?1",
             "name": "Desperate Ritual",
             "text": "Add {R}{R}{R} to your mana pool.\nSplice onto Arcane {1}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "1517e3c7-bf17-5551-a27e-609e6535e0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608a6e1e-3e95-4ce4-aaf6-5f14c0456850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608a6e1e-3e95-4ce4-aaf6-5f14c0456850.jpg?1",
             "name": "Devouring Rage",
             "text": "As an additional cost to play Devouring Rage, you may sacrifice any number of Spirits.\nTarget creature gets +3/+0 until end of turn. For each Spirit sacrificed this way, that creature gets an additional +3/+0 until end of turn.",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "9592a215-745d-519c-bbf8-6ef468d41fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b47a9-c21e-4c0a-9c70-38b8ebbffab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b47a9-c21e-4c0a-9c70-38b8ebbffab3.jpg?1",
             "name": "Earthshaker",
             "text": "Whenever you play a Spirit or Arcane spell, Earthshaker deals 2 damage to each creature without flying.",
             "colours": [
@@ -6000,7 +6000,7 @@
         },
         {
             "id": "a7a49856-51a6-59ef-987b-2a37ead25b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150e3f0-237e-4669-9401-d2cd08e86387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150e3f0-237e-4669-9401-d2cd08e86387.jpg?1",
             "name": "Ember-Fist Zubera",
             "text": "When Ember-Fist Zubera is put into a graveyard from play, it deals damage to target creature or player equal to the number of Zubera put into all graveyards from play this turn.",
             "colours": [
@@ -6035,7 +6035,7 @@
         },
         {
             "id": "d75640b0-e469-570b-af09-11684a6696d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54df527-6949-4b74-821b-b051f493f3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54df527-6949-4b74-821b-b051f493f3c5.jpg?1",
             "name": "Frostwielder",
             "text": "{T}: Frostwielder deals 1 damage to target creature or player.\nIf a creature dealt damage by Frostwielder this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "5dd488ee-cd93-54ae-996e-f4658b971bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5637a3b0-6204-4893-878e-c34babeab2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5637a3b0-6204-4893-878e-c34babeab2e6.jpg?1",
             "name": "Glacial Ray",
             "text": "Glacial Ray deals 2 damage to target creature or player.\nSplice onto Arcane {1}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -6104,7 +6104,7 @@
         },
         {
             "id": "79ac4dcb-ba4a-5947-a4d0-45382564a49c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcff0b92-edd0-4197-965b-3fd86bc884d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcff0b92-edd0-4197-965b-3fd86bc884d8.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord comes into play, you may search your library for an Equipment card and put it into play. If you do, shuffle your library.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, you get an additional combat phase.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "47e4af50-e87a-5c6c-975e-d48dcee6cb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881fecf4-8c14-4614-84bd-c1a3dcdbb5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881fecf4-8c14-4614-84bd-c1a3dcdbb5ff.jpg?1",
             "name": "Hanabi Blast",
             "text": "Hanabi Blast deals 2 damage to target creature or player. Return Hanabi Blast to its owner's hand, then discard a card at random.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "482c941a-1b19-5888-aba2-7e269cf4ec0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7361289-5111-49c2-a786-b7181384596b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7361289-5111-49c2-a786-b7181384596b.jpg?1",
             "name": "Hearth Kami",
             "text": "{X}, Sacrifice Hearth Kami: Destroy target artifact with converted mana cost X.",
             "colours": [
@@ -6207,7 +6207,7 @@
         },
         {
             "id": "db80a87a-4e9b-5d47-bfa8-37026dbbb42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b254f341-aac1-433b-a739-fee8bd7fdf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b254f341-aac1-433b-a739-fee8bd7fdf69.jpg?1",
             "name": "Honden of Infinite Rage",
             "text": "At the beginning of your upkeep, Honden of Infinite Rage deals damage to target creature or player equal to the number of Shrines you control.",
             "colours": [
@@ -6243,7 +6243,7 @@
         },
         {
             "id": "82b31423-2fe1-5c9e-b27b-704f70a4b300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg?1",
             "name": "Initiate of Blood // Goka the Unjust",
             "text": "{T}: Initiate of Blood deals 1 damage to target creature that was dealt damage this turn. When that creature is put into a graveyard this turn, flip Initiate of Blood.",
             "colours": [
@@ -6278,7 +6278,7 @@
         },
         {
             "id": "491c88ad-5ae6-510b-870c-db5e3c9d913d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg?1",
             "name": "Initiate of Blood // Goka the Unjust",
             "text": "{T}: Goka the Unjust deals 4 damage to target creature that was dealt damage this turn.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "6ec7ae63-f9e2-5dc3-a795-1b5caea5b11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4380118d-f209-446d-829b-3564796e0219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4380118d-f209-446d-829b-3564796e0219.jpg?1",
             "name": "Kami of Fire's Roar",
             "text": "Whenever you play a Spirit or Arcane spell, target creature can't block this turn.",
             "colours": [
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "0e5c49fe-778f-5d24-86c5-6c11477d4dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162018eb-5483-4fa2-9c5a-abb639eecf91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162018eb-5483-4fa2-9c5a-abb639eecf91.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Put a creature token into play that's a copy of target nonlegendary creature you control. That creature token has haste. Sacrifice it at end of turn.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "8080c7bb-3bf9-5aac-8aca-ccacdb86c2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93870f9-343f-43e7-8ae8-e7aaa56aacca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93870f9-343f-43e7-8ae8-e7aaa56aacca.jpg?1",
             "name": "Kumano, Master Yamabushi",
             "text": "{1}{R}: Kumano, Master Yamabushi deals 1 damage to target creature or player.\nIf a creature dealt damage by Kumano this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -6423,7 +6423,7 @@
         },
         {
             "id": "a473b4f0-ea3d-5d2d-a4a1-47423f0f2e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62b233e-95fe-4cfd-ad89-86e07656bf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62b233e-95fe-4cfd-ad89-86e07656bf8b.jpg?1",
             "name": "Kumano's Pupils",
             "text": "If a creature dealt damage by Kumano's Pupils this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "53e6b34f-4cb2-5294-afd0-1affd40d2fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b2fae1-242b-45e0-a757-b1adc02c06f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b2fae1-242b-45e0-a757-b1adc02c06f3.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player.",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "1bb6e20b-2573-5c3d-9cd9-0c0e5e5aff29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bde4cba-57b2-485f-9724-0f79d156d664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bde4cba-57b2-485f-9724-0f79d156d664.jpg?1",
             "name": "Mana Seism",
             "text": "Sacrifice any number of lands. Add {1} to your mana pool for each land sacrificed this way.",
             "colours": [
@@ -6524,7 +6524,7 @@
         },
         {
             "id": "5ff62879-e528-5bb6-a11e-fd7bc0fa9adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59418766-5567-4ec4-af1f-1cb2db2958d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59418766-5567-4ec4-af1f-1cb2db2958d0.jpg?1",
             "name": "Mindblaze",
             "text": "Name a nonland card and choose a number greater than 0. Target player reveals his or her library. If that library contains exactly the chosen number of the named card, Mindblaze deals 8 damage to that player. Then that player shuffles his or her library.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "4e9d5e36-f68d-52fd-991e-1b40cd2577a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df630ae9-aa17-46e9-95e7-4980f4a76ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df630ae9-aa17-46e9-95e7-4980f4a76ade.jpg?1",
             "name": "Myojin of Infinite Rage",
             "text": "Myojin of Infinite Rage comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Infinite Rage is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Infinite Rage: Destroy all lands.",
             "colours": [
@@ -6592,7 +6592,7 @@
         },
         {
             "id": "c9319a64-1a1b-55c5-8767-1877f762b134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc8bbb9-d6a1-474b-8f34-594b5a9d4178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc8bbb9-d6a1-474b-8f34-594b5a9d4178.jpg?1",
             "name": "Ore Gorger",
             "text": "Whenever you play a Spirit or Arcane spell, you may destroy target nonbasic land.",
             "colours": [
@@ -6626,7 +6626,7 @@
         },
         {
             "id": "6eccfad1-02e6-5591-bf72-92246b0f9f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693317ea-0237-4b65-812f-b31a6427b2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693317ea-0237-4b65-812f-b31a6427b2a3.jpg?1",
             "name": "Pain Kami",
             "text": "{X}{R}, Sacrifice Pain Kami: Pain Kami deals X damage to target creature.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "80a52ed9-92c8-5a82-b752-71d5f84fdfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614ead7b-1975-4a99-bdc2-f8afc6cf92d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614ead7b-1975-4a99-bdc2-f8afc6cf92d7.jpg?1",
             "name": "Ronin Houndmaster",
             "text": "Haste\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "797075fb-e4be-5f28-b34b-b1e4f5880d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17898412-6275-4762-a03b-04daf30fee7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17898412-6275-4762-a03b-04daf30fee7f.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star is put into a graveyard from play, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "040ebbe1-21f9-5029-80e5-4867f007fa34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de0e2c-61ca-496e-8990-ed0e6f6521a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de0e2c-61ca-496e-8990-ed0e6f6521a6.jpg?1",
             "name": "Shimatsu the Bloodcloaked",
             "text": "As Shimatsu the Bloodcloaked comes into play, sacrifice any number of permanents. Shimatsu comes into play with that many +1/+1 counters on it.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "9361d03d-9548-5b43-b6db-fc675f47393e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd611b7-7bd3-4a76-bd69-34a7235965ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd611b7-7bd3-4a76-bd69-34a7235965ae.jpg?1",
             "name": "Sideswipe",
             "text": "You may change any targets of target Arcane spell.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "77cea115-7942-5ec4-9e10-3b3b45db42ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d147088-2191-49e8-9c0b-419d4048604a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d147088-2191-49e8-9c0b-419d4048604a.jpg?1",
             "name": "Sokenzan Bruiser",
             "text": "Mountainwalk",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "fa7ac9d4-e8fd-5330-aa83-1cf6fe94ff21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b20126-da96-4d79-8d3f-8d7da8e94f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b20126-da96-4d79-8d3f-8d7da8e94f4a.jpg?1",
             "name": "Soul of Magma",
             "text": "Whenever you play a Spirit or Arcane spell, Soul of Magma deals 1 damage to target creature.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "736adf06-5ebb-5b0d-8807-af0a5e24796a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fe38cc-2b12-4491-8deb-fbcb306febf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fe38cc-2b12-4491-8deb-fbcb306febf2.jpg?1",
             "name": "Soulblast",
             "text": "As an additional cost to play Soulblast, sacrifice all creatures you control.\nSoulblast deals damage to target creature or player equal to the total power of the sacrificed creatures.",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "db54ce97-88a5-55f0-a38b-2c8debff6c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ac6701-f522-4ded-89bb-d8cce7fa2b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ac6701-f522-4ded-89bb-d8cce7fa2b40.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "2f504f37-c070-546e-852e-f6bc733f9ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a78af-a991-4a5e-bdc2-f39947b89bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a78af-a991-4a5e-bdc2-f39947b89bb2.jpg?1",
             "name": "Strange Inversion",
             "text": "Switch target creature's power and toughness until end of turn.\nSplice onto Arcane {1}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -6968,7 +6968,7 @@
         },
         {
             "id": "740d74ee-384a-5bd5-8fd2-a80d018956c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09e6a-2965-4855-bd41-41b41ba188fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09e6a-2965-4855-bd41-41b41ba188fb.jpg?1",
             "name": "Through the Breach",
             "text": "Put a creature card from your hand into play. That creature has haste. Sacrifice that creature at end of turn.\nSplice onto Arcane {2}{R}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "9c2262b0-336b-576b-9a54-5c1735cfced3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5bd60-87ed-41d2-bbcb-bd4a40a772c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5bd60-87ed-41d2-bbcb-bd4a40a772c9.jpg?1",
             "name": "Tide of War",
             "text": "Whenever one or more creatures blocks, flip a coin. If you win the flip, the defending player sacrifices all blocking creatures. Otherwise, the attacking player sacrifices the blocked creatures.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "1b207d9c-2363-5dc3-8f4f-04ea32737a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fca4fa-d0e1-41c4-999a-9804786eacbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fca4fa-d0e1-41c4-999a-9804786eacbb.jpg?1",
             "name": "Uncontrollable Anger",
             "text": "You may play Uncontrollable Anger any time you could play an instant.\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -7068,7 +7068,7 @@
         },
         {
             "id": "fe43c56e-0c31-5db7-bef4-21a533634920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034ad87-fd28-4c23-b897-1d6343ce8282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034ad87-fd28-4c23-b897-1d6343ce8282.jpg?1",
             "name": "Unearthly Blizzard",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -7102,7 +7102,7 @@
         },
         {
             "id": "3e610bd1-66ea-55d2-a3cc-41a5e3c9c082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a542b1f4-82f8-471a-b0a6-7ead9167da27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a542b1f4-82f8-471a-b0a6-7ead9167da27.jpg?1",
             "name": "Unnatural Speed",
             "text": "Target creature gains haste until end of turn.",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "9bd75f47-9310-5975-bebc-fa99890ecec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9bacba-55c4-4b92-bdd9-01b6035ed1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9bacba-55c4-4b92-bdd9-01b6035ed1b2.jpg?1",
             "name": "Yamabushi's Flame",
             "text": "Yamabushi's Flame deals 3 damage to target creature or player. If a creature dealt damage this way would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "36d7f024-42cf-5d90-9b1c-2e30671f99bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a930d-ae59-47e2-9b98-f703e308b5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a930d-ae59-47e2-9b98-f703e308b5c0.jpg?1",
             "name": "Yamabushi's Storm",
             "text": "Yamabushi's Storm deals 1 damage to each creature. If a creature dealt damage this way would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -7200,7 +7200,7 @@
         },
         {
             "id": "c32a5de3-1455-5ce5-8bc9-cd14b2a39f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4666b6-76f2-4c25-989e-d6a0e50be94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4666b6-76f2-4c25-989e-d6a0e50be94d.jpg?1",
             "name": "Zo-Zu the Punisher",
             "text": "Whenever a land comes into play, Zo-Zu the Punisher deals 2 damage to that land's controller.",
             "colours": [
@@ -7237,7 +7237,7 @@
         },
         {
             "id": "bf97b65e-82cc-5a1b-bd97-1c011a004215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed862a2-d3e2-4543-81a6-453a96399d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed862a2-d3e2-4543-81a6-453a96399d14.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "b435b1ae-d180-51ad-a1e0-d4895a513ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg?1",
             "name": "Budoka Gardener // Dokai, Weaver of Life",
             "text": "{T}: You may put a land card from your hand into play. If you control ten or more lands, flip Budoka Gardener.",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "aca801cc-39a9-5cab-968c-d841914212fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg?1",
             "name": "Budoka Gardener // Dokai, Weaver of Life",
             "text": "{4}{G}{G}, {T}: Put an X/X green Elemental creature token into play, where X is the number of lands you control.",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "12026c02-7a3d-51bb-b67a-7fece779cace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935e52a1-a651-4d88-99a8-7de074a01576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935e52a1-a651-4d88-99a8-7de074a01576.jpg?1",
             "name": "Burr Grafter",
             "text": "Sacrifice Burr Grafter: Target creature gets +2/+2 until end of turn.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -7380,7 +7380,7 @@
         },
         {
             "id": "d5c7f588-6451-54be-b371-eb6d7f22b47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0b706e-017d-4f82-b280-cf9fdf75aef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0b706e-017d-4f82-b280-cf9fdf75aef8.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "db0a589c-5e41-5a6d-97dc-6b58af6459de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb190db-48fc-4c39-ae9f-5e304eabb4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb190db-48fc-4c39-ae9f-5e304eabb4f4.jpg?1",
             "name": "Dosan the Falling Leaf",
             "text": "Players can play spells only during their own turns.",
             "colours": [
@@ -7449,7 +7449,7 @@
         },
         {
             "id": "49c1e833-173d-59a5-a62d-c7ec585adc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e752b762-38b7-463c-aa09-37fecfe71a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e752b762-38b7-463c-aa09-37fecfe71a53.jpg?1",
             "name": "Dripping-Tongue Zubera",
             "text": "When Dripping-Tongue Zubera is put into a graveyard from play, put a 1/1 colorless Spirit creature token into play for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "116530b5-f830-5141-9f11-23eaa6ac3c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33119e6a-d69b-4039-add2-97fe35a89e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33119e6a-d69b-4039-add2-97fe35a89e8e.jpg?1",
             "name": "Feast of Worms",
             "text": "Destroy target land. If that land is legendary, its controller sacrifices another land.",
             "colours": [
@@ -7518,7 +7518,7 @@
         },
         {
             "id": "61b3cff8-e060-54ba-93a0-78f716d11b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49d705-9b0c-4c2e-9c27-46eec35deb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49d705-9b0c-4c2e-9c27-46eec35deb92.jpg?1",
             "name": "Feral Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Feral Deceiver gets +2/+2 and gains trample until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "c5949c79-9754-5645-849f-d02712af32db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5c233-a373-4ac4-9b99-81ed97df1f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5c233-a373-4ac4-9b99-81ed97df1f9b.jpg?1",
             "name": "Gale Force",
             "text": "Gale Force deals 5 damage to each creature with flying.",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "b8aba793-aec1-56da-b2c5-be55deb63e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddcd76b-a7a1-4ae6-bf4a-f929c6574bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddcd76b-a7a1-4ae6-bf4a-f929c6574bdc.jpg?1",
             "name": "Glimpse of Nature",
             "text": "Whenever you play a creature spell this turn, draw a card.",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "c442fafe-07cd-52a0-980d-5bef433f88f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8304b24-4db8-4082-bdb7-7010bf35e416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8304b24-4db8-4082-bdb7-7010bf35e416.jpg?1",
             "name": "Hana Kami",
             "text": "{1}{G}, Sacrifice Hana Kami: Return target Arcane card from your graveyard to your hand.",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "5f76e7d2-c6cf-594e-a6e5-cb78c76ef324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3ba05-dce0-463b-bfe6-d51df63cc1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3ba05-dce0-463b-bfe6-d51df63cc1a8.jpg?1",
             "name": "Heartbeat of Spring",
             "text": "Whenever a player taps a land for mana, that player adds one mana of that type to his or her mana pool.",
             "colours": [
@@ -7682,7 +7682,7 @@
         },
         {
             "id": "85c7758d-cef3-53f4-a081-ff6ab6d63b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c618af6-b02e-448f-9131-3c50ef0d433b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c618af6-b02e-448f-9131-3c50ef0d433b.jpg?1",
             "name": "Honden of Life's Web",
             "text": "At the beginning of your upkeep, put a 1/1 colorless Spirit creature token into play for each Shrine you control.",
             "colours": [
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "fcff8760-57de-526a-a671-ce261718cd16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bbc89-d5ee-4813-9ebe-ac5b998b076b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bbc89-d5ee-4813-9ebe-ac5b998b076b.jpg?1",
             "name": "Humble Budoka",
             "text": "Humble Budoka can't be the target of spells or abilities.",
             "colours": [
@@ -7753,7 +7753,7 @@
         },
         {
             "id": "62a1c11c-3b51-5f23-a42f-58e2632b7ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be027e3c-8891-46f0-bca7-d28a94ca281a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be027e3c-8891-46f0-bca7-d28a94ca281a.jpg?1",
             "name": "Iname, Life Aspect",
             "text": "When Iname, Life Aspect is put into a graveyard from play, you may remove Iname, Life Aspect from the game. If you do, return any number of target Spirit cards from your graveyard to your hand.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "8ada7358-608b-56fa-9dec-7806e70276e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e33847f-fa55-4b2e-9d88-9a9e118b5cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e33847f-fa55-4b2e-9d88-9a9e118b5cc8.jpg?1",
             "name": "Joyous Respite",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -7823,7 +7823,7 @@
         },
         {
             "id": "6ca0435f-cfd4-5ca9-9cba-08d55ef5e534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77814d-c594-45a8-845f-79f608b8cde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77814d-c594-45a8-845f-79f608b8cde7.jpg?1",
             "name": "Jugan, the Rising Star",
             "text": "Flying\nWhen Jugan, the Rising Star is put into a graveyard from play, you may distribute five +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -7860,7 +7860,7 @@
         },
         {
             "id": "0a9bda6f-8456-5b57-9bfb-3eacf161404d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e1967e-5bc5-47e7-9998-7fcfdffc3bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e1967e-5bc5-47e7-9998-7fcfdffc3bb1.jpg?1",
             "name": "Jukai Messenger",
             "text": "Forestwalk",
             "colours": [
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "d948c001-2920-5147-b83e-c1ed57be321b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ace3c4e-3287-4975-b4d0-91f009c0cf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ace3c4e-3287-4975-b4d0-91f009c0cf5b.jpg?1",
             "name": "Kami of the Hunt",
             "text": "Whenever you play a Spirit or Arcane spell, Kami of the Hunt gets +1/+1 until end of turn.",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "ce19f7c4-ac9f-55b0-95c0-6e67f87859f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d417f90-10e9-4c41-ac3b-1a861147d69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d417f90-10e9-4c41-ac3b-1a861147d69e.jpg?1",
             "name": "Kashi-Tribe Reaver",
             "text": "Whenever Kashi-Tribe Reaver deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\n{1}{G}: Regenerate Kashi-Tribe Reaver.",
             "colours": [
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "4d1fddd6-72d0-5b3e-88e4-e1782105041d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd4df4a-fbab-4598-ad8e-b24ed0bb4497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd4df4a-fbab-4598-ad8e-b24ed0bb4497.jpg?1",
             "name": "Kashi-Tribe Warriors",
             "text": "Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -7999,7 +7999,7 @@
         },
         {
             "id": "e8fdac0a-1f7f-5032-a311-e6ad3ce10492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b5c33-63c4-4ddd-9f04-37bb36970b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b5c33-63c4-4ddd-9f04-37bb36970b43.jpg?1",
             "name": "Kodama of the North Tree",
             "text": "Trample\nKodama of the North Tree can't be the target of spells or abilities.",
             "colours": [
@@ -8035,7 +8035,7 @@
         },
         {
             "id": "dff2c6cd-e60e-5e36-ad71-2d21138d5846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120c05f1-5ec3-4a0f-8628-6919e393104a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120c05f1-5ec3-4a0f-8628-6919e393104a.jpg?1",
             "name": "Kodama of the South Tree",
             "text": "Whenever you play a Spirit or Arcane spell, each other creature you control gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "6fc8e5fb-ef1e-5475-a78a-f8c475a5fe2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ef91bb-ec25-463f-9fc9-f0f9c0652cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ef91bb-ec25-463f-9fc9-f0f9c0652cf5.jpg?1",
             "name": "Kodama's Might",
             "text": "Target creature gets +2/+2 until end of turn.\nSplice onto Arcane {G} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -8105,7 +8105,7 @@
         },
         {
             "id": "d06c407b-1688-5f2e-a97c-f5e12d4fe2fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d207ac-0680-47ef-85d9-4323c1321d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d207ac-0680-47ef-85d9-4323c1321d6f.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for two basic land cards, reveal those cards, and put one into play tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "a5f90bbd-1459-5ffd-9068-5fd1d10d8181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c193e4-4484-46c1-83ce-c421d47bed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c193e4-4484-46c1-83ce-c421d47bed9f.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "dce7f6e2-b811-5e7e-bfb0-6bc7a2f7353a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bf9bec-9a5d-48a6-941b-95e1633b9484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bf9bec-9a5d-48a6-941b-95e1633b9484.jpg?1",
             "name": "Matsu-Tribe Decoy",
             "text": "{2}{G}: Target creature blocks Matsu-Tribe Decoy this turn if able.\nWhenever Matsu-Tribe Decoy deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "4742d542-7650-5444-9426-dc8cce9e047c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a437cde4-c40b-40a3-bc19-e461c98186dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a437cde4-c40b-40a3-bc19-e461c98186dc.jpg?1",
             "name": "Moss Kami",
             "text": "Trample",
             "colours": [
@@ -8242,7 +8242,7 @@
         },
         {
             "id": "c28294fb-a052-521e-a295-4d565732a9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb926ad-e762-4883-8841-73e034d8e21e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb926ad-e762-4883-8841-73e034d8e21e.jpg?1",
             "name": "Myojin of Life's Web",
             "text": "Myojin of Life's Web comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Life's Web is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Life's Web: Put any number of creature cards from your hand into play.",
             "colours": [
@@ -8278,7 +8278,7 @@
         },
         {
             "id": "fda5c6bf-62cd-5eb3-99cc-8ba317b707d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a291a0-db0d-4ccc-b7ae-240cafa41883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a291a0-db0d-4ccc-b7ae-240cafa41883.jpg?1",
             "name": "Nature's Will",
             "text": "Whenever one or more creatures you control deal combat damage to a player, tap all lands that player controls and untap all lands you control.",
             "colours": [
@@ -8310,7 +8310,7 @@
         },
         {
             "id": "cd6fcb4b-6809-535d-bcbb-82b873d7a2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8f0459-a839-4820-8f99-58da5851ff36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8f0459-a839-4820-8f99-58da5851ff36.jpg?1",
             "name": "Orbweaver Kumo",
             "text": "Orbweaver Kumo may block as though it had flying.\nWhenever you play a Spirit or Arcane spell, Orbweaver Kumo gains forestwalk until end of turn.",
             "colours": [
@@ -8344,7 +8344,7 @@
         },
         {
             "id": "d1dfb8ad-5448-5cdc-8ae7-28390a643015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9093a-4397-432f-b9e3-3693efcaec20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9093a-4397-432f-b9e3-3693efcaec20.jpg?1",
             "name": "Order of the Sacred Bell",
             "text": "",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "d4de80b3-5f95-5cee-8001-7309b101275f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg?1",
             "name": "Orochi Eggwatcher // Shidako, Broodmistress",
             "text": "{2}{G}, {T}: Put a 1/1 green Snake creature token into play. If you control ten or more creatures, flip Orochi Eggwatcher.",
             "colours": [
@@ -8414,7 +8414,7 @@
         },
         {
             "id": "9fd475be-e75e-56eb-9ec3-b4fb7b4bccee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg?1",
             "name": "Orochi Eggwatcher // Shidako, Broodmistress",
             "text": "{G}, Sacrifice a creature: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -8451,7 +8451,7 @@
         },
         {
             "id": "3b80264a-a943-5128-934e-ae6258266846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c39031-1c49-4c1e-83df-66c3795ddc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c39031-1c49-4c1e-83df-66c3795ddc72.jpg?1",
             "name": "Orochi Leafcaller",
             "text": "{G}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "77e0c4e9-d1e3-5b9a-96e8-7c13e0e2969b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc216f-4447-4370-b31a-18304507669b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc216f-4447-4370-b31a-18304507669b.jpg?1",
             "name": "Orochi Ranger",
             "text": "Whenever Orochi Ranger deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -8522,7 +8522,7 @@
         },
         {
             "id": "7e38f33f-2af8-586b-ab93-57b21e707883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40d7a-f2d3-4c9a-a1ab-6b08bd143fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40d7a-f2d3-4c9a-a1ab-6b08bd143fe5.jpg?1",
             "name": "Orochi Sustainer",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "c71fe36a-2f74-5607-8e55-1bfa9fcb4bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5502b-acae-4320-ac01-4d711cb2c49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5502b-acae-4320-ac01-4d711cb2c49a.jpg?1",
             "name": "Rootrunner",
             "text": "{G}{G}, Sacrifice Rootrunner: Put target land on the top of its owner's library.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "c548ee02-e0aa-52f4-8cd6-f4faea86d55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b36f-b879-417c-b284-0176990fb9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b36f-b879-417c-b284-0176990fb9f9.jpg?1",
             "name": "Sachi, Daughter of Seshiro",
             "text": "Other Snakes you control get +0/+1.\nShamans you control have \"{T}: Add {G}{G} to your mana pool.\"",
             "colours": [
@@ -8628,7 +8628,7 @@
         },
         {
             "id": "1a5ca13c-903a-55e9-a80d-e6bdb47e25b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7707a-bae0-4196-bf26-d276f57b7369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7707a-bae0-4196-bf26-d276f57b7369.jpg?1",
             "name": "Sakura-Tribe Elder",
             "text": "Sacrifice Sakura-Tribe Elder: Search your library for a basic land card, put that card into play tapped, then shuffle your library.",
             "colours": [
@@ -8663,7 +8663,7 @@
         },
         {
             "id": "0c9ef020-8877-52b3-a80a-63cbeca91e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5722d9-d1a4-4ad2-bf85-db666d4a30d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5722d9-d1a4-4ad2-bf85-db666d4a30d9.jpg?1",
             "name": "Serpent Skin",
             "text": "You may play Serpent Skin any time you could play an instant.\nEnchanted creature gets +1/+1.\n{G}: Regenerate enchanted creature.",
             "colours": [
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "e047d7bd-cddd-5c7f-bfd5-b207466037b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg?1",
             "name": "Seshiro the Anointed",
             "text": "Other Snakes you control get +2/+2.\nWhenever a Snake you control deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "5a69cb21-b91e-5995-9df6-d9d56a9b7157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc79c9c-f776-4c55-a7d1-9fac33f14630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc79c9c-f776-4c55-a7d1-9fac33f14630.jpg?1",
             "name": "Shisato, Whispering Hunter",
             "text": "At the beginning of your upkeep, sacrifice a Snake.\nWhenever Shisato, Whispering Hunter deals combat damage to a player, that player skips his or her next untap step.",
             "colours": [
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "eeab6527-a1db-5bac-a7b0-a4c569a2c1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4066c3-bcb0-41c4-a4d3-a22bd186fd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4066c3-bcb0-41c4-a4d3-a22bd186fd13.jpg?1",
             "name": "Soilshaper",
             "text": "Whenever you play a Spirit or Arcane spell, target land becomes a 3/3 creature until end of turn. It's still a land.",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "52d71abf-a55d-5f47-b321-0be28d8681ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa2451-e4f0-423b-826e-ae1f93b99e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa2451-e4f0-423b-826e-ae1f93b99e07.jpg?1",
             "name": "Sosuke, Son of Seshiro",
             "text": "Other Snakes you control get +1/+0.\nWhenever a Warrior you control deals combat damage to a creature, destroy that creature at end of combat.",
             "colours": [
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "7ca888e4-dffb-5fac-a82d-e678c372af48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ab46f5-d3e1-403f-92e7-f40de51a3d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ab46f5-d3e1-403f-92e7-f40de51a3d4d.jpg?1",
             "name": "Strength of Cedars",
             "text": "Target creature gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -8876,7 +8876,7 @@
         },
         {
             "id": "6c6f32af-6ef5-55ab-880a-8c7e14b21a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88355e-dff0-4d51-a33c-08e14d6217d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88355e-dff0-4d51-a33c-08e14d6217d4.jpg?1",
             "name": "Thousand-legged Kami",
             "text": "Soulshift 7 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 7 or less from your graveyard to your hand.)",
             "colours": [
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "2d44a299-6f81-52c2-81d9-a85930531b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514577a5-c7ae-4cfc-872a-e3786d78a6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514577a5-c7ae-4cfc-872a-e3786d78a6c3.jpg?1",
             "name": "Time of Need",
             "text": "Search your library for a legendary creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "7bd4dab5-fff9-5003-97af-d76871935567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308566ed-18cc-4e3b-b5ab-d5b17795f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308566ed-18cc-4e3b-b5ab-d5b17795f2f1.jpg?1",
             "name": "Venerable Kumo",
             "text": "Venerable Kumo may block as though it had flying.\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "97b39b66-d97d-5983-a382-4ddb7863f815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5241c8-7f50-413e-9ac0-9ab0ad5c884c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5241c8-7f50-413e-9ac0-9ab0ad5c884c.jpg?1",
             "name": "Vine Kami",
             "text": "Vine Kami can't be blocked except by two or more creatures.\nSoulshift 6 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 6 or less from your graveyard to your hand.)",
             "colours": [
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "b16cb9d4-f9c6-5a01-87d2-370824d987b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e809799-ce47-4eaf-b2c2-2c8807182532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e809799-ce47-4eaf-b2c2-2c8807182532.jpg?1",
             "name": "Wear Away",
             "text": "Destroy target artifact or enchantment.\nSplice onto Arcane {3}{G} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "a87103f7-84f4-52d8-ad80-084a3a023f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1382c339-256f-4ba1-a4cc-6307d0859964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1382c339-256f-4ba1-a4cc-6307d0859964.jpg?1",
             "name": "General's Kabuto",
             "text": "Equipped creature can't be the target of spells or abilities.\nPrevent all combat damage that would be dealt to equipped creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "9976b721-0517-5e66-9ad7-4e7423a36de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5354475-6a0b-4b1f-b94c-7c103d99e88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5354475-6a0b-4b1f-b94c-7c103d99e88b.jpg?1",
             "name": "Hair-Strung Koto",
             "text": "Tap an untapped creature you control: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "e485aa4c-09a4-5cdd-a142-5e360807512a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22a88a-4f04-4500-9e05-909b54ad43e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22a88a-4f04-4500-9e05-909b54ad43e3.jpg?1",
             "name": "Hankyu",
             "text": "Equipped creature has \"{T}: Put an aim counter on Hankyu\" and \"{T}, Remove all aim counters from Hankyu: This creature deals damage to target creature or player equal to the number of aim counters removed.\"\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9132,7 +9132,7 @@
         },
         {
             "id": "46bec07e-c9a4-57b3-8b6c-c215540a18ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babe91f2-06be-4501-a95b-20968e906e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babe91f2-06be-4501-a95b-20968e906e1b.jpg?1",
             "name": "Honor-Worn Shaku",
             "text": "{T}: Add {1} to your mana pool.\nTap an untapped legendary permanent you control: Untap Honor-Worn Shaku.",
             "colours": [],
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "66809300-e7c9-5ea0-94fc-24b5f8cca195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c33332-8a72-4b81-a8e9-a73aaac6013c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c33332-8a72-4b81-a8e9-a73aaac6013c.jpg?1",
             "name": "Imi Statue",
             "text": "Players can't untap more than one artifact during their untap steps.",
             "colours": [],
@@ -9188,7 +9188,7 @@
         },
         {
             "id": "c3edae41-7135-5098-9228-d8df5cae67b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58f63c5-cdc5-4079-a727-cff45668d546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58f63c5-cdc5-4079-a727-cff45668d546.jpg?1",
             "name": "Jade Idol",
             "text": "Whenever you play a Spirit or Arcane spell, Jade Idol becomes a 4/4 Spirit artifact creature until end of turn.",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "f14ad054-5460-5e7f-9e10-da0c15d3197d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa17062-4355-468f-b8ba-352b7511b847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa17062-4355-468f-b8ba-352b7511b847.jpg?1",
             "name": "Journeyer's Kite",
             "text": "{3}, {T}: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "ab151a7f-fe66-5a97-b289-eb6223df611c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd002c7-21ec-4f77-81be-2788fa267f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd002c7-21ec-4f77-81be-2788fa267f21.jpg?1",
             "name": "Junkyo Bell",
             "text": "At the beginning of your upkeep, you may have target creature you control get +X/+X until end of turn, where X is the number of creatures you control. If you do, sacrifice that creature at end of turn.",
             "colours": [],
@@ -9272,7 +9272,7 @@
         },
         {
             "id": "46852e55-a17a-55b6-b5b2-82f329450ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759b2f39-e1b1-44aa-b49a-00ef6926a6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759b2f39-e1b1-44aa-b49a-00ef6926a6ac.jpg?1",
             "name": "Konda's Banner",
             "text": "Konda's Banner can be attached only to a legendary creature.\nCreatures that share a color with equipped creature get +1/+1.\nCreatures that share a creature type with equipped creature get +1/+1.\nEquip {2}",
             "colours": [],
@@ -9304,7 +9304,7 @@
         },
         {
             "id": "d65ca207-723a-5f35-a603-9ce7f23afed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a700bd-6424-4a0c-b055-e8b64cf430ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a700bd-6424-4a0c-b055-e8b64cf430ec.jpg?1",
             "name": "Kusari-Gama",
             "text": "Equipped creature has \"{2}: This creature gets +1/+0 until end of turn.\"\nWhenever equipped creature deals damage to a blocking creature, Kusari-Gama deals that much damage to each other creature defending player controls.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9334,7 +9334,7 @@
         },
         {
             "id": "2548cd2e-7e72-570e-89fb-c21d44d1d25f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc4b500-ca74-4b90-9a8c-d4efa80ebe2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc4b500-ca74-4b90-9a8c-d4efa80ebe2c.jpg?1",
             "name": "Long-Forgotten Gohei",
             "text": "Arcane spells you play cost {1} less to play.\nSpirits you control get +1/+1.",
             "colours": [],
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "b9de8479-b8ac-5fde-a3d0-f1053b08034a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d36357a-97f6-4b2f-abbf-43f84c29609d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d36357a-97f6-4b2f-abbf-43f84c29609d.jpg?1",
             "name": "Moonring Mirror",
             "text": "Whenever you draw a card, remove the top card of your library from the game face down.\nAt the beginning of your upkeep, you may remove your hand from the game face down. If you do, put into your hand all other cards you own removed from the game with Moonring Mirror.",
             "colours": [],
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "83bac8e6-2f16-5cc1-aa7a-877d963aeb68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e60aa-1a0a-499e-9887-7d17a1f80a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e60aa-1a0a-499e-9887-7d17a1f80a02.jpg?1",
             "name": "Nine-Ringed Bo",
             "text": "{T}: Nine-Ringed Bo deals 1 damage to target Spirit. If that creature would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [],
@@ -9418,7 +9418,7 @@
         },
         {
             "id": "436cf76a-d188-53d4-8e09-4fc0f5cf14db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6061a8-d27f-4258-9e95-cd12365c4248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6061a8-d27f-4258-9e95-cd12365c4248.jpg?1",
             "name": "No-Dachi",
             "text": "Equipped creature gets +2/+0 and has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9448,7 +9448,7 @@
         },
         {
             "id": "682de493-27af-5283-abb8-1b5d9eac8297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b7c8e4-db88-48f3-bfd5-8d990f449b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b7c8e4-db88-48f3-bfd5-8d990f449b1c.jpg?1",
             "name": "Oathkeeper, Takeno's Daisho",
             "text": "Equipped creature gets +3/+1.\nWhenever equipped creature is put into a graveyard from play, return that card to play under your control if it's a Samurai.\nWhen Oathkeeper, Takeno's Daisho is put into a graveyard from play, remove equipped creature from the game.\nEquip {2}",
             "colours": [],
@@ -9480,7 +9480,7 @@
         },
         {
             "id": "476f3549-8dd6-5486-b80a-9c86c61781ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e662e2e-f706-4d79-86ed-48b60787a5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e662e2e-f706-4d79-86ed-48b60787a5d0.jpg?1",
             "name": "Orochi Hatchery",
             "text": "Orochi Hatchery comes into play with X charge counters on it.\n{5}, {T}: Put a 1/1 green Snake creature token into play for each charge counter on Orochi Hatchery.",
             "colours": [],
@@ -9508,7 +9508,7 @@
         },
         {
             "id": "2bed78b4-d862-50a6-a4da-fd18b914f161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eba910-852b-47e0-b4cd-07f30d80f921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eba910-852b-47e0-b4cd-07f30d80f921.jpg?1",
             "name": "Reito Lantern",
             "text": "{3}: Put target card in a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "005d7725-aae9-516b-9b4d-59f6fdd2d686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a08ca06-58db-4ce6-b490-be4bea8956a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a08ca06-58db-4ce6-b490-be4bea8956a1.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -9564,7 +9564,7 @@
         },
         {
             "id": "cad67ee8-2d44-5eb6-8f08-0e876240a137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80f3e7-c3f0-462f-8ae9-8b27a7c15fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80f3e7-c3f0-462f-8ae9-8b27a7c15fcd.jpg?1",
             "name": "Shell of the Last Kappa",
             "text": "{3}, {T}: Remove from the game target instant or sorcery spell that targets you. (The spell has no effect.)\n{3}, {T}, Sacrifice Shell of the Last Kappa: You may play a card removed from the game with Shell of the Last Kappa without paying its mana cost.",
             "colours": [],
@@ -9594,7 +9594,7 @@
         },
         {
             "id": "3ccae0ba-6ac4-58f1-93fb-beb82469867b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d3bc63-8814-46e7-a6ee-dd5b94a8257e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d3bc63-8814-46e7-a6ee-dd5b94a8257e.jpg?1",
             "name": "Tatsumasa, the Dragon's Fang",
             "text": "Equipped creature gets +5/+5.\n{6}, Remove Tatsumasa, the Dragon's Fang from the game: Put a 5/5 blue Dragon Spirit creature token with flying into play. Return Tatsumasa to play under its owner's control when that token is put into a graveyard.\nEquip {3}",
             "colours": [],
@@ -9626,7 +9626,7 @@
         },
         {
             "id": "f0e7be60-a430-5b8d-8048-f6b1d06ad225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1aa03d7-ac4f-4793-8f8d-5ffd2f8f38b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1aa03d7-ac4f-4793-8f8d-5ffd2f8f38b1.jpg?1",
             "name": "Tenza, Godo's Maul",
             "text": "Equipped creature gets +1/+1. As long as it's legendary, it gets an additional +2/+2. As long as it's red, it has trample.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9658,7 +9658,7 @@
         },
         {
             "id": "1fd3c028-5846-5c44-9385-e9e6afea502a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ecb4e-d08f-4fac-8842-c3e772b95bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ecb4e-d08f-4fac-8842-c3e772b95bd5.jpg?1",
             "name": "Uba Mask",
             "text": "If a player would draw a card, that player removes that card from the game face up instead.\nEach player may play cards he or she removed from the game with Uba Mask this turn.",
             "colours": [],
@@ -9686,7 +9686,7 @@
         },
         {
             "id": "f03dc40e-5b23-5364-ab57-06d16c889ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0180d9a8-992c-4d55-8ac4-33a587786993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0180d9a8-992c-4d55-8ac4-33a587786993.jpg?1",
             "name": "Boseiju, Who Shelters All",
             "text": "Boseiju, Who Shelters All comes into play tapped.\n{T}, Pay 2 life: Add {1} to your mana pool. If that mana is spent on an instant or sorcery spell, that spell can't be countered by spells or abilities.",
             "colours": [],
@@ -9716,7 +9716,7 @@
         },
         {
             "id": "352fa09e-8ed4-5584-84b2-ba442d55e3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcbd030-762e-4754-ae95-685d59ccdfb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcbd030-762e-4754-ae95-685d59ccdfb9.jpg?1",
             "name": "Cloudcrest Lake",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Cloudcrest Lake doesn't untap during your next untap step.",
             "colours": [],
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "6557c919-4e9e-52dd-98a6-d6b5624096fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c1d76-40cf-4edf-8145-e6cec8ca39ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c1d76-40cf-4edf-8145-e6cec8ca39ad.jpg?1",
             "name": "Eiganjo Castle",
             "text": "{T}: Add {W} to your mana pool.\n{W}, {T}: Prevent the next 2 damage that would be dealt to target legendary creature this turn.",
             "colours": [],
@@ -9779,7 +9779,7 @@
         },
         {
             "id": "fc46e4b0-3a8e-5c4a-be87-5d303d9f54c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d78261-c8c9-4e0e-b157-f70ed46c3a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d78261-c8c9-4e0e-b157-f70ed46c3a25.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color to your mana pool.\nWhenever you tap Forbidden Orchard for mana, put a 1/1 colorless Spirit creature token into play under target opponent's control.",
             "colours": [],
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "e40b1b21-a91c-5ccb-82f0-005435a9a019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa5bab-8626-4b45-a3a3-621f6d9509ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa5bab-8626-4b45-a3a3-621f6d9509ab.jpg?1",
             "name": "Hall of the Bandit Lord",
             "text": "Hall of the Bandit Lord comes into play tapped.\n{T}, Pay 3 life: Add {1} to your mana pool. If that mana is spent on a creature spell, that creature has haste.",
             "colours": [],
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "976c640a-f112-5935-97fa-e5ce487b7cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a7675-787f-49be-9b44-edd0a7d73812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a7675-787f-49be-9b44-edd0a7d73812.jpg?1",
             "name": "Lantern-Lit Graveyard",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Lantern-Lit Graveyard doesn't untap during your next untap step.",
             "colours": [],
@@ -9868,7 +9868,7 @@
         },
         {
             "id": "1db4eb74-9208-5f8f-86e5-8b49a592da2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536292c-da25-41c8-ba28-1e35758a7f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536292c-da25-41c8-ba28-1e35758a7f3d.jpg?1",
             "name": "Minamo, School at Water's Edge",
             "text": "{T}: Add {U} to your mana pool.\n{U}, {T}: Untap target legendary permanent.",
             "colours": [],
@@ -9900,7 +9900,7 @@
         },
         {
             "id": "ee85824a-2994-5f42-980a-760d17de3995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8cf7aa-388c-47ec-be59-6ba98f3853cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8cf7aa-388c-47ec-be59-6ba98f3853cb.jpg?1",
             "name": "Okina, Temple to the Grandfathers",
             "text": "{T}: Add {G} to your mana pool.\n{G}, {T}: Target legendary creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -9932,7 +9932,7 @@
         },
         {
             "id": "c265e2d4-cdea-5e55-8166-cfd0f768c33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900552f-6147-49ec-8c02-f253e4896c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900552f-6147-49ec-8c02-f253e4896c4d.jpg?1",
             "name": "Pinecrest Ridge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Pinecrest Ridge doesn't untap during your next untap step.",
             "colours": [],
@@ -9963,7 +9963,7 @@
         },
         {
             "id": "4985bf15-2714-5a93-841f-42e3f6cf0fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f30e-cc3a-46c1-82a9-2cd73705b2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f30e-cc3a-46c1-82a9-2cd73705b2f5.jpg?1",
             "name": "Shinka, the Bloodsoaked Keep",
             "text": "{T}: Add {R} to your mana pool.\n{R}, {T}: Target legendary creature gains first strike until end of turn.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "e649bbf4-7653-5c0b-a0b2-3c6cda41843c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de9a046-3db1-436e-b666-ba96e2e8c5db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de9a046-3db1-436e-b666-ba96e2e8c5db.jpg?1",
             "name": "Shizo, Death's Storehouse",
             "text": "{T}: Add {B} to your mana pool.\n{B}, {T}: Target legendary creature gains fear until end of turn.",
             "colours": [],
@@ -10027,7 +10027,7 @@
         },
         {
             "id": "c02ef97d-a53a-5fe3-9248-fce09c932184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112b6577-fbd6-46dd-b77d-37df0abe9845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112b6577-fbd6-46dd-b77d-37df0abe9845.jpg?1",
             "name": "Tranquil Garden",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Tranquil Garden doesn't untap during your next untap step.",
             "colours": [],
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "1b2a2aa9-a1c7-5d9b-89ca-e1060f5004db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c571f66-7a00-4cb0-9da9-8271083f49d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c571f66-7a00-4cb0-9da9-8271083f49d3.jpg?1",
             "name": "Untaidake, the Cloud Keeper",
             "text": "Untaidake, the Cloud Keeper comes into play tapped.\n{T}, Pay 2 life: Add {2} to your mana pool. Spend this mana only to play legendary spells.",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "354f7fa8-3be5-5271-89f8-e546c0422ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405805e0-07f6-420f-86f9-5bde822caa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405805e0-07f6-420f-86f9-5bde822caa5c.jpg?1",
             "name": "Waterveil Cavern",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Waterveil Cavern doesn't untap during your next untap step.",
             "colours": [],
@@ -10119,7 +10119,7 @@
         },
         {
             "id": "4eecab9a-8d08-596d-98fe-ca05a8c9479a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deff6a75-2ecd-49d6-b58b-a9d24615f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deff6a75-2ecd-49d6-b58b-a9d24615f9b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "afe0de65-02a8-55e6-89ba-ac8518c1b596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4add62bc-d24c-4a1f-81bc-e3a6befe3f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4add62bc-d24c-4a1f-81bc-e3a6befe3f0d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10195,7 +10195,7 @@
         },
         {
             "id": "fdeec99d-e25d-576b-b760-14df70c8a2e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fae600-d829-412a-8f77-3f25a106f574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fae600-d829-412a-8f77-3f25a106f574.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10233,7 +10233,7 @@
         },
         {
             "id": "ac18e09d-8f1a-5e47-b90f-f3e29edbf83a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e590059d-57e5-4696-9bb1-30d8d35c4329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e590059d-57e5-4696-9bb1-30d8d35c4329.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10271,7 +10271,7 @@
         },
         {
             "id": "3fbe38f5-5483-553b-87f9-bbe9050f8d89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5170ce9-2463-4fec-945b-6c2f23eb7e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5170ce9-2463-4fec-945b-6c2f23eb7e22.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "059b05c1-e603-5c4f-a499-d8e3875ea0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12c5ae3-8c55-4bd9-a64f-3960d45c0563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12c5ae3-8c55-4bd9-a64f-3960d45c0563.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "e7b98d23-82bf-5a78-b84c-1a7bc1a7b842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d141922-570d-4652-9620-2b53eb68294a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d141922-570d-4652-9620-2b53eb68294a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "75e6a8a3-99ae-58a9-bae2-7341a58fed96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c20f8b-6ad1-4aa2-94d3-7bd42562a1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c20f8b-6ad1-4aa2-94d3-7bd42562a1ac.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10423,7 +10423,7 @@
         },
         {
             "id": "50064480-8581-566b-ab66-b62b87cd6f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d376282-adf0-4d37-b9a4-1329cd496516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d376282-adf0-4d37-b9a4-1329cd496516.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10461,7 +10461,7 @@
         },
         {
             "id": "d82cec4f-bca5-59bb-bc22-650cc3400d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a6fa7-58e7-459c-8e2e-be5a4692450b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a6fa7-58e7-459c-8e2e-be5a4692450b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10499,7 +10499,7 @@
         },
         {
             "id": "3591f751-8ef3-5e9d-8218-cba928260ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0878ac9-6a80-4412-999d-4c6549b9afd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0878ac9-6a80-4412-999d-4c6549b9afd4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10537,7 +10537,7 @@
         },
         {
             "id": "72afed2e-7bea-5390-8212-f5e54d742141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d03a6-35bf-415e-9faa-972edff92777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d03a6-35bf-415e-9faa-972edff92777.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10575,7 +10575,7 @@
         },
         {
             "id": "73aba641-5707-5de0-9274-bfe3153a613e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22262a3a-c2e0-4639-9002-361b39ea9b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22262a3a-c2e0-4639-9002-361b39ea9b3a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10613,7 +10613,7 @@
         },
         {
             "id": "ca8ecbd8-6afb-582b-bf55-7ed3c3082850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a514a-076a-40c0-a756-c6fdd261c3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a514a-076a-40c0-a756-c6fdd261c3cb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "4bd8a0df-50c1-5fa4-90c6-d44dedf403a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1a59c7-53d9-4e2c-9596-c64394838575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1a59c7-53d9-4e2c-9596-c64394838575.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "3593ffc5-5999-51dc-b458-8603ba47077d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e5767-64e1-4f4e-a02e-1143db0f648e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e5767-64e1-4f4e-a02e-1143db0f648e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10727,7 +10727,7 @@
         },
         {
             "id": "7bfd0b79-2a67-5dcf-97d6-021ef4a45fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3209b22-56af-45ac-9224-67574c035638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3209b22-56af-45ac-9224-67574c035638.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10765,7 +10765,7 @@
         },
         {
             "id": "5aba50b9-1c8c-5bc2-ba1e-310ea8ca3404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf9a4b-be51-4f5d-ac0e-e4f79bbfaecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf9a4b-be51-4f5d-ac0e-e4f79bbfaecd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10803,7 +10803,7 @@
         },
         {
             "id": "ddbc18af-8340-5e53-9006-5e67f30772ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1629dba-02af-4586-ba59-58faac7cf59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1629dba-02af-4586-ba59-58faac7cf59b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "132961e0-9295-5a7b-b67e-f7c9f850ab4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f06e37-f113-4865-9ad9-13483dd15084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f06e37-f113-4865-9ad9-13483dd15084.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/CLB.json
+++ b/Assets/Resources/Sets/CLB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ad82cd8d-c3e4-5c4d-9a01-a7d74086bbed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25564fba-5765-457b-8dd3-f26b877221b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25564fba-5765-457b-8dd3-f26b877221b8.jpg?1",
             "name": "Faceless One",
             "text": "If Faceless One is your commander, choose a color before the game begins. Faceless One is the chosen color.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "ae83f439-f05e-5d15-849a-808b8c8c8098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f9198-67b6-45d8-91b4-dc853bff9623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f9198-67b6-45d8-91b4-dc853bff9623.jpg?1",
             "name": "Abdel Adrian, Gorion's Ward",
             "text": "When Abdel Adrian, Gorion's Ward enters the battlefield, exile any number of other nonland permanents you control until Abdel Adrian leaves the battlefield. Create a 1/1 white Soldier creature token for each permanent exiled this way.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "76a4bc4d-2691-5281-a1c8-103eee5b2aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421395b1-2694-42fd-bb90-0007e78adefc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421395b1-2694-42fd-bb90-0007e78adefc.jpg?1",
             "name": "Ancient Gold Dragon",
             "text": "Flying\nWhenever Ancient Gold Dragon deals combat damage to a player, roll a d20. You create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to the result.",
             "colours": [
@@ -114,7 +114,7 @@
         },
         {
             "id": "bce001b0-6b2f-5382-94ec-283c71e067c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6589e02-8c84-4069-88d1-ebcc8520cae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6589e02-8c84-4069-88d1-ebcc8520cae1.jpg?1",
             "name": "Archivist of Oghma",
             "text": "Flash\nWhenever an opponent searches their library, you gain 1 life and draw a card.",
             "colours": [
@@ -151,7 +151,7 @@
         },
         {
             "id": "71ec06b8-cd44-539a-9812-6337bfdd7ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26c05b-f166-40ab-9693-2129b4bf75e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26c05b-f166-40ab-9693-2129b4bf75e9.jpg?1",
             "name": "Ascend from Avernus",
             "text": "Return all creature and planeswalker cards with mana value X or less from your graveyard to the battlefield. Exile Ascend from Avernus.",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "81e7bf2b-d41e-5574-9130-2d1cfce4c50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe66d8-1b35-49f1-9bc0-74c5861e5abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe66d8-1b35-49f1-9bc0-74c5861e5abf.jpg?1",
             "name": "Astral Confrontation",
             "text": "This spell costs {1} less to cast for each opponent you're attacking.\nExile target creature.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "5f11f412-2b58-5971-849e-0eca2e54ebdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164a728-131f-41ce-9346-8036c86543e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164a728-131f-41ce-9346-8036c86543e2.jpg?1",
             "name": "Bane's Invoker",
             "text": "Wind Walk \u2014 {8}: Up to two target creatures each get +2/+2 and gain flying until end of turn.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "505e9f9f-8d76-5741-b441-4ff197d62f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71caadb-31ab-4b7f-b304-e7d3e8f9d132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71caadb-31ab-4b7f-b304-e7d3e8f9d132.jpg?1",
             "name": "Banishment",
             "text": "Flash\nWhen Banishment enters the battlefield, exile target nonland permanent an opponent controls and all other nonland permanents your opponents control with the same name as that permanent until Banishment leaves the battlefield.",
             "colours": [
@@ -284,7 +284,7 @@
         },
         {
             "id": "7c8eae3a-ada2-51dd-abe9-5dd83b5b53f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c91dbf4-94fa-45d0-b8ed-a778b11d789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c91dbf4-94fa-45d0-b8ed-a778b11d789b.jpg?1",
             "name": "Battle Angels of Tyr",
             "text": "Flying, myriad\nWhenever Battle Angels of Tyr deals combat damage to a player, draw a card if that player has more cards in hand than each other player. Then you create a Treasure token if that player controls more lands than each other player. Then you gain 3 life if that player has more life than each other player.",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "4703046e-388a-5105-bab8-72f66a94b5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02d647-b95b-4442-a924-64a4c94a4e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02d647-b95b-4442-a924-64a4c94a4e8d.jpg?1",
             "name": "Beckoning Will-o'-Wisp",
             "text": "Flying\nLure the Unwary \u2014 At the beginning of combat on your turn, choose an opponent.\nCreatures attacking the last chosen player get +1/+0.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "0bb794fb-e218-5535-8887-fa2c74e5b3bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg?1",
             "name": "Blessed Hippogriff // Tyr's Blessing",
             "text": "Flying\nWhenever Blessed Hippogriff attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "c33a4c6b-58e1-5784-ad20-1145c0f7e911",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg?1",
             "name": "Blessed Hippogriff // Tyr's Blessing",
             "text": "Target creature gains indestructible until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "e6a6f418-31d8-53cc-9876-f5433c4f097e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59299b0-91d9-4131-b8d9-614088e1ccaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59299b0-91d9-4131-b8d9-614088e1ccaf.jpg?1",
             "name": "Contraband Livestock",
             "text": "Exile target creature, then roll a d20.\n1\u20139 | Its controller creates a 4/4 green Ox creature token.\n10\u201319 | Its controller creates a 2/2 green Boar creature token.\n20 | Its controller creates a 0/1 white Goat creature token.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "6d36c15b-3cef-593d-9c82-21650129e2f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg?1",
             "name": "Crystal Dragon // Rob the Hoard",
             "text": "Flying, vigilance",
             "colours": [
@@ -489,7 +489,7 @@
         },
         {
             "id": "17f80c87-d7a2-5a80-ad45-6db1e70599bc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg?1",
             "name": "Crystal Dragon // Rob the Hoard",
             "text": "Return target artifact, enchantment, or legendary card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "feb7dc7b-1e1e-510d-9ca8-ddea39cdce89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846a4d-da81-41e0-89a9-6685c821dbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846a4d-da81-41e0-89a9-6685c821dbb4.jpg?1",
             "name": "Cut a Deal",
             "text": "Each opponent draws a card, then you draw a card for each opponent who drew a card this way.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "393f5784-7ca4-56b1-a183-07eb98ee5005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f06ef-c180-4ce3-afaf-bec3b14c0222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f06ef-c180-4ce3-afaf-bec3b14c0222.jpg?1",
             "name": "Dawnbringer Cleric",
             "text": "When Dawnbringer Cleric enters the battlefield, choose one \u2014\n\u2022 Cure Wounds \u2014 You gain 2 life.\n\u2022 Dispel Magic \u2014 Destroy target enchantment.\n\u2022 Gentle Repose \u2014 Exile target card from a graveyard.",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "5f80576b-43e4-5e5b-8e45-8974e6b2d3bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a038dbc9-0da1-4e65-9369-45c614f285f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a038dbc9-0da1-4e65-9369-45c614f285f8.jpg?1",
             "name": "Ellyn Harbreeze, Busybody",
             "text": "{T}: Look at the top X cards of your library, where X is the number of tokens you created this turn. Put one of those cards into your hand and the rest on the bottom of your library in a random order.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "4d23e669-328f-5358-ac91-814fd3ba585b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabc3688-2362-4757-a5be-087e577c4691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabc3688-2362-4757-a5be-087e577c4691.jpg?1",
             "name": "Far Traveler",
             "text": "Commander creatures you own have \"At the beginning of your end step, exile up to one target tapped creature you control, then return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "3aed8cfc-6268-5427-826a-9deafb6d4264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122c9f-5513-4ba7-ae04-3c2060121d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122c9f-5513-4ba7-ae04-3c2060121d73.jpg?1",
             "name": "Flaming Fist",
             "text": "Commander creatures you own have \"Whenever this creature attacks, it gains double strike until end of turn.\"",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "c0146296-83c3-5d69-b0d2-cfb67a4d2672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98722a04-0674-4083-b6f5-51bb88a99814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98722a04-0674-4083-b6f5-51bb88a99814.jpg?1",
             "name": "Flaming Fist Officer",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Flaming Fist Officer.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "13777428-31a5-5599-939b-8301d09fe2f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a088ea-c397-4bdd-8779-59561ff73ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a088ea-c397-4bdd-8779-59561ff73ec2.jpg?1",
             "name": "Githzerai Monk",
             "text": "Flash\nFlying\nPsychic Defense \u2014 When Githzerai Monk enters the battlefield, tap all creatures you don't control.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "469024d1-6550-52aa-97b3-b75533b4d561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8324aa-f356-42bc-9664-46803bc8a93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8324aa-f356-42bc-9664-46803bc8a93b.jpg?1",
             "name": "Goliath Paladin",
             "text": "Vigilance\nWhen Goliath Paladin enters the battlefield, you take the initiative.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "aedbb333-d691-598e-abf9-9449206b05d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50088a60-642b-47ed-a289-ef0b617b688f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50088a60-642b-47ed-a289-ef0b617b688f.jpg?1",
             "name": "Greatsword of Tyr",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on it and tap up to one target creature defending player controls.\nEquip {W} ({W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "79cfe8ae-2f9c-566e-b1a4-a6374d0cbca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg?1",
             "name": "Guardian Naga // Banishing Coils",
             "text": "Vigilance\nAs long as it's your turn, prevent all damage that would be dealt to Guardian Naga.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "2ad179c1-6110-511a-8b10-fa3418667f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg?1",
             "name": "Guardian Naga // Banishing Coils",
             "text": "Exile target artifact or enchantment. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "7b24729e-18d7-5438-a928-ae600d47cf87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd552f81-1947-47e0-beee-f04e73551055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd552f81-1947-47e0-beee-f04e73551055.jpg?1",
             "name": "Guiding Bolt",
             "text": "Destroy target creature with power 4 or greater.\nScry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "62b89699-43cb-5f9a-bd43-6aa396841eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7429a5b-5579-4c4e-89ff-ee7f43db37e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7429a5b-5579-4c4e-89ff-ee7f43db37e4.jpg?1",
             "name": "Hammers of Moradin",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\nWhenever Hammers of Moradin attacks, for each opponent, tap up to one target creature that player controls.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "7b48e7c0-4331-5eb2-8fb9-72290988af54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {3}",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "9a34b0b7-b1a1-5d75-8ff7-75d16bfc60a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Create X 1/1 white Soldier creature tokens. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "d9d757e0-9195-5bcb-b5ce-e619af772182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb153e2-345d-4993-9f2d-f0d0ddfbc8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb153e2-345d-4993-9f2d-f0d0ddfbc8a7.jpg?1",
             "name": "Icewind Stalwart",
             "text": "Protection Fighting Style \u2014 When Icewind Stalwart enters the battlefield, exile up to one target non-Warrior creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "42bffcd2-a19e-53f6-98d9-e12ded5a858b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6eb9f3-0f7b-4623-806e-5e604a05d470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6eb9f3-0f7b-4623-806e-5e604a05d470.jpg?1",
             "name": "Inspiring Leader",
             "text": "Commander creatures you own have \"Creature tokens you control get +2/+2.\"",
             "colours": [
@@ -1125,7 +1125,7 @@
         },
         {
             "id": "b531ba67-f3ba-505b-a89e-39b630c3e322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a93f587-ab72-42da-88c4-31af1c9cdf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a93f587-ab72-42da-88c4-31af1c9cdf1b.jpg?1",
             "name": "Lae'zel, Vlaakith's Champion",
             "text": "If you would put one or more counters on a creature or planeswalker you control or on yourself, put that many plus one of each of those kinds of counters on that permanent or player instead.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "19ec4a9a-b080-5b84-b6f9-910f627c7eee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d102241-4463-437f-b2bb-f574d9dbbd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d102241-4463-437f-b2bb-f574d9dbbd1e.jpg?1",
             "name": "Lae'zel's Acrobatics",
             "text": "Exile all nontoken creatures you control, then roll a d20.\n1\u20139 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10\u201320 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "a8ad8c55-eafe-5a24-a940-92871d30c96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9158965b-b705-4922-8ea9-9e3a93838eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9158965b-b705-4922-8ea9-9e3a93838eab.jpg?1",
             "name": "Legion Loyalty",
             "text": "Creatures you control have myriad. (Whenever a creature with myriad attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1233,7 +1233,7 @@
         },
         {
             "id": "74e43e52-e062-5a89-9a2e-e1d27900e873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d67e95e-c4a7-45bc-ae83-0b532ad530db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d67e95e-c4a7-45bc-ae83-0b532ad530db.jpg?1",
             "name": "Lulu, Loyal Hollyphant",
             "text": "Flying\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on each tapped creature you control, then untap them.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "7720372b-a010-5d70-84d0-3fcf97ae9e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e520fcba-3503-4d7d-aba9-7ed8c064700d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e520fcba-3503-4d7d-aba9-7ed8c064700d.jpg?1",
             "name": "Martial Impetus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, each other creature that's attacking one of your opponents gets +1/+1 until end of turn.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "45d26744-2b19-506e-967a-da8f75eae9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874b3590-932a-46b7-a7aa-e3e864ec22d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874b3590-932a-46b7-a7aa-e3e864ec22d1.jpg?1",
             "name": "Minimus Containment",
             "text": "Enchant nonland permanent\nEnchanted permanent is a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other abilities. (If it was a creature, it's no longer a creature.)",
             "colours": [
@@ -1341,7 +1341,7 @@
         },
         {
             "id": "4f3fc13f-0309-5d36-9fb6-313ff153a498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e49fd5a-6893-4a06-b835-4bf611c9ada1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e49fd5a-6893-4a06-b835-4bf611c9ada1.jpg?1",
             "name": "Noble Heritage",
             "text": "Commander creatures you own have \"When this creature enters the battlefield and at the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. For each opponent who does, you gain protection from that player until your next turn.\" (You can't be targeted, dealt damage, or enchanted by anything controlled by that player.)",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "133de4c8-7502-5405-ae5e-a4ad6ba541bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg?1",
             "name": "Pegasus Guardian // Rescue the Foal",
             "text": "Flying\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 white Pegasus creature token with flying.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "8deafd61-a408-516e-8263-76fbb7b11c31",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg?1",
             "name": "Pegasus Guardian // Rescue the Foal",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "51f0a76f-ce93-5a67-83a2-bf90c4499d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6597ec7-0fc8-4aa5-a8a6-ea5f95f4ce15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6597ec7-0fc8-4aa5-a8a6-ea5f95f4ce15.jpg?1",
             "name": "Rasaad yn Bashir",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\nWhenever Rasaad yn Bashir attacks, if you have the initiative, double the toughness of each creature you control until end of turn.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "e4bb2c30-5c12-53ed-9451-959045b30b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbd2822-d161-41df-9f48-abecd5da19c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbd2822-d161-41df-9f48-abecd5da19c4.jpg?1",
             "name": "Recruitment Drive",
             "text": "Roll a d20.\n1\u20139 | Create two 1/1 white Soldier creature tokens.\n10\u201319 | Create two 2/2 white Knight creature tokens.\n20 | Create three 2/2 white Knight creature tokens.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "d2ef53c6-b53d-53f6-bc35-50d08e44aca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b17c29-c796-460b-a0c6-7638fb80e397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b17c29-c796-460b-a0c6-7638fb80e397.jpg?1",
             "name": "Rescuer Chwinga",
             "text": "Flash\nNatural Shelter \u2014 When Rescuer Chwinga enters the battlefield, you may return another permanent you control to its owner's hand.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "4291229b-7b88-5779-94a1-c97b8afc4aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b0ed9c-9a99-4a50-80a9-396420a8dcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b0ed9c-9a99-4a50-80a9-396420a8dcf9.jpg?1",
             "name": "Roving Harper",
             "text": "When Roving Harper enters the battlefield, draw a card.",
             "colours": [
@@ -1589,7 +1589,7 @@
         },
         {
             "id": "d7c5c51b-2494-5221-a3db-09050e086ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2209e-7a5c-4394-876c-e0f68cfba9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2209e-7a5c-4394-876c-e0f68cfba9ca.jpg?1",
             "name": "Scouting Hawk",
             "text": "Flying\nKeen Sight \u2014 When Scouting Hawk enters the battlefield, if an opponent controls more lands than you, search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "b21ef30e-735f-5269-873e-94284ce8bfd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16d8fe-a770-4bbd-bf20-447c0165de5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16d8fe-a770-4bbd-bf20-447c0165de5a.jpg?1",
             "name": "Sculpted Sunburst",
             "text": "Choose a creature you control, then each opponent chooses a creature they control with equal or lesser power. If you chose a creature this way, exile each creature not chosen by any player this way.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "cc08658d-b115-5da7-9e04-6779b7b3615f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9f8aea-0c9a-4686-b551-35e2a72ef701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9f8aea-0c9a-4686-b551-35e2a72ef701.jpg?1",
             "name": "Slaughter the Strong",
             "text": "Each player chooses any number of creatures they control with total power 4 or less, then sacrifices all other creatures they control.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "9d4ea403-b585-5b75-9c94-e7f1f7fd5446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13762890-6c5e-44e4-9bd8-998bd054db20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13762890-6c5e-44e4-9bd8-998bd054db20.jpg?1",
             "name": "Steadfast Unicorn",
             "text": "{3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn.",
             "colours": [
@@ -1723,7 +1723,7 @@
         },
         {
             "id": "b822fe73-218b-5f38-b68f-40ce73e81e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b9fdaa-9da9-48ff-b271-e6a41aabf073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b9fdaa-9da9-48ff-b271-e6a41aabf073.jpg?1",
             "name": "Stoneskin",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +0/+10.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "d4d23986-7a54-58b8-8075-03223bfe5021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e38761-70e0-4f6e-a4c2-7c9a17557d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e38761-70e0-4f6e-a4c2-7c9a17557d25.jpg?1",
             "name": "Tabaxi Toucaneers",
             "text": "Flying\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "0b9b12f5-b9d8-545f-9a8c-92334f518414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca369b-4e04-4c80-923b-1212183419d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca369b-4e04-4c80-923b-1212183419d8.jpg?1",
             "name": "Undercellar Sweep",
             "text": "When Undercellar Sweep enters the battlefield, you take the initiative.\nWhenever you attack, if you or a player you're attacking has the initiative, you create two 1/1 white Soldier creature tokens that are tapped and attacking.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "595dbf61-b9c8-5633-8d65-68f0c6fe5869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f074e-914e-4924-8b5e-b80b247bc341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f074e-914e-4924-8b5e-b80b247bc341.jpg?1",
             "name": "Veteran Soldier",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, for each opponent, create a 1/1 white Soldier creature token that's tapped and attacking that player.\"",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "d26aa5e3-a966-5330-8ccc-d66b23a6a706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256ddc8-8b12-434c-a610-1a872e948f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256ddc8-8b12-434c-a610-1a872e948f2f.jpg?1",
             "name": "White Plume Adventurer",
             "text": "When White Plume Adventurer enters the battlefield, you take the initiative.\nAt the beginning of each opponent's upkeep, untap a creature you control. If you've completed a dungeon, untap all creatures you control instead.",
             "colours": [
@@ -1899,7 +1899,7 @@
         },
         {
             "id": "87544546-1980-5b59-a61e-637aa72d577e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2f5-6d8b-4321-9aa1-d84c291a5c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2f5-6d8b-4321-9aa1-d84c291a5c20.jpg?1",
             "name": "Windshaper Planetar",
             "text": "Flash\nFlying\nWhen Windshaper Planetar enters the battlefield during the declare attackers step, for each attacking creature, you may reselect which player or planeswalker that creature is attacking. (It can't attack its controller or its controller's planeswalkers.)",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "e40d27c1-f3de-5463-88a2-0b1ad69f7d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00a57fc-b4a6-48fa-a20c-864c10099e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00a57fc-b4a6-48fa-a20c-864c10099e4b.jpg?1",
             "name": "Wyrm's Crossing Patrol",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1970,7 +1970,7 @@
         },
         {
             "id": "f881ddfc-180f-59bf-acd0-48dafdfea8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad8aa76-b643-4bd2-aaeb-036c1d50db54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad8aa76-b643-4bd2-aaeb-036c1d50db54.jpg?1",
             "name": "Your Temple Is Under Attack",
             "text": "Choose one \u2014\n\u2022 Pray for Protection \u2014 Creatures you control gain indestructible until end of turn.\n\u2022 Strike a Deal \u2014 You and target opponent each draw two cards.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "fdc1d084-cfb7-56ce-b7d4-727eb74ea6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76e5d23-a45f-4100-8638-fce33f290fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76e5d23-a45f-4100-8638-fce33f290fc6.jpg?1",
             "name": "You're Confronted by Robbers",
             "text": "Choose one \u2014\n\u2022 Stall for Time \u2014 Tap up to three target creatures.\n\u2022 Call for Aid \u2014 Create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "b99eb1ea-43ad-5b7d-9549-aee93e555009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83882c-3e03-4e85-aaac-97fa1d08a772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83882c-3e03-4e85-aaac-97fa1d08a772.jpg?1",
             "name": "Aarakocra Sneak",
             "text": "Flying\nWhen Aarakocra Sneak enters the battlefield, you take the initiative.",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "e3a75e01-cf18-5619-a245-86e8624bc220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c779b-d1d8-4b1e-bb06-ed7071a5ec0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c779b-d1d8-4b1e-bb06-ed7071a5ec0b.jpg?1",
             "name": "Alora, Merry Thief",
             "text": "Whenever you attack, up to one target attacking creature can't be blocked this turn. Return that creature to its owner's hand at the beginning of the next end step.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "1961bcf7-f26f-5bdb-b0ff-b54a3c9af1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced18935-4ce9-466e-a88d-2b14ff8f989f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced18935-4ce9-466e-a88d-2b14ff8f989f.jpg?1",
             "name": "Ancient Silver Dragon",
             "text": "Flying\nWhenever Ancient Silver Dragon deals combat damage to a player, roll a d20. Draw cards equal to the result. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -2147,7 +2147,7 @@
         },
         {
             "id": "8cee6780-ca8d-5a80-a771-024e08b2bd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f81099-f657-4f7d-84ad-f472ae87d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f81099-f657-4f7d-84ad-f472ae87d9c5.jpg?1",
             "name": "Bane's Contingency",
             "text": "Counter target spell. If that spell targets a commander you control, instead counter that spell, scry 2, then draw a card.",
             "colours": [
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "56688ea9-6cbb-5c0e-8996-817cc776250f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a43413-3ab0-4ef6-83de-192a11d48f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a43413-3ab0-4ef6-83de-192a11d48f00.jpg?1",
             "name": "Blur",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "2f93c0e3-61e0-59c1-8813-ad0ceb8bd1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33464767-45f3-42b8-8d83-33b090eead93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33464767-45f3-42b8-8d83-33b090eead93.jpg?1",
             "name": "Candlekeep Inspiration",
             "text": "Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards you own in exile and in your graveyard that are instant cards, are sorcery cards, and/or have an Adventure.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "ef7f8b49-533a-58fb-88f0-517271ba423d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f706ac3-0ad8-44ac-a99e-21c04075951d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f706ac3-0ad8-44ac-a99e-21c04075951d.jpg?1",
             "name": "Candlekeep Sage",
             "text": "Commander creatures you own have \"When this creature enters or leaves the battlefield, draw a card.\"",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "65a247a0-b5e5-50e6-b1b3-542c44f2bc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d010948a-d3f8-4ce3-9c9b-6e905a3f7087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d010948a-d3f8-4ce3-9c9b-6e905a3f7087.jpg?1",
             "name": "Cone of Cold",
             "text": "Roll a d20.\n1\u20139 | Tap all creatures your opponents control.\n10\u201319 | Tap all creatures your opponents control. Those creatures don't untap during their controllers' next untap steps.\n20 | Tap all creatures your opponents control. Those creatures don't untap during their controllers' next untap steps. Until your next turn, creatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -2313,7 +2313,7 @@
         },
         {
             "id": "a724e0b8-3fee-5530-9c15-ce580242569a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5d9323-ddf4-49b0-9d39-c2249c50f1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5d9323-ddf4-49b0-9d39-c2249c50f1e3.jpg?1",
             "name": "Contact Other Plane",
             "text": "Roll a d20.\n1\u20139 | Draw two cards.\n10\u201319 | Scry 2, then draw two cards.\n20 | Scry 3, then draw three cards.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "18c3a658-eda3-53cb-ad3e-3a16c8f5da6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a401b8-29fb-46ef-a663-427f66724d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a401b8-29fb-46ef-a663-427f66724d5c.jpg?1",
             "name": "Displacer Kitten",
             "text": "Avoidance \u2014 Whenever you cast a noncreature spell, exile up to one target nonland permanent you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "4673f0e5-58db-5327-93cc-9b49603e4d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557f2aa6-0b82-4f60-9617-610b613c2a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557f2aa6-0b82-4f60-9617-610b613c2a48.jpg?1",
             "name": "Draconic Lore",
             "text": "This spell costs {2} less to cast if you control a Dragon.\nDraw three cards.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "c709a8f8-e945-55b6-8989-bf188df76a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570e8aaa-5273-42f4-b151-51976ab7730c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570e8aaa-5273-42f4-b151-51976ab7730c.jpg?1",
             "name": "Dragonborn Looter",
             "text": "{1}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "6751b0cd-371b-5fa5-be42-d353381e360f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daca6a57-38b7-4547-9174-a7f548ea1258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daca6a57-38b7-4547-9174-a7f548ea1258.jpg?1",
             "name": "Dream Fracture",
             "text": "Counter target spell. Its controller draws a card.\nDraw a card.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "80c5cc6f-89be-571e-b24c-a037ca60f0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba131bb-b8b3-4577-9f41-4700d9985134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba131bb-b8b3-4577-9f41-4700d9985134.jpg?1",
             "name": "Dungeon Delver",
             "text": "Commander creatures you own have \"Room abilities of dungeons you own trigger an additional time.\"",
             "colours": [
@@ -2519,7 +2519,7 @@
         },
         {
             "id": "da65c2fc-8d78-5384-bdd4-46f404a8ff3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a6e6a-758d-417d-82c9-2c78db37d91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a6e6a-758d-417d-82c9-2c78db37d91e.jpg?1",
             "name": "Elminster's Simulacrum",
             "text": "For each opponent, you create a token that's a copy of up to one target creature that player controls.",
             "colours": [
@@ -2553,7 +2553,7 @@
         },
         {
             "id": "b0ef51a7-cf1c-5f4c-b123-df445679cf4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c959ab97-0727-4589-bfd9-d78dd8ebd86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c959ab97-0727-4589-bfd9-d78dd8ebd86b.jpg?1",
             "name": "Feywild Caretaker",
             "text": "When Feywild Caretaker enters the battlefield, you take the initiative.\nAt the beginning of your end step, if you have the initiative, create a 1/1 blue Faerie Dragon creature token with flying.",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "e275a1d6-4569-58b0-8fc9-5a4046063fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e833a9-d82f-4942-a488-67d9c02817db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e833a9-d82f-4942-a488-67d9c02817db.jpg?1",
             "name": "Feywild Visitor",
             "text": "Commander creatures you own have \"Whenever one or more nontoken creatures you control deal combat damage to a player, you create a 1/1 blue Faerie Dragon creature token with flying.\"",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "1f644c2b-c820-5029-903e-269b9a836e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137ee879-bbc3-4e11-b103-3cc604867b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137ee879-bbc3-4e11-b103-3cc604867b1c.jpg?1",
             "name": "Font of Magic",
             "text": "Instant and sorcery spells you cast cost {1} less to cast for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "9c23fad6-2b6d-5702-8b06-6521fa3f5a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edf31f-ed67-4617-bf73-28a939a232a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edf31f-ed67-4617-bf73-28a939a232a7.jpg?1",
             "name": "Gale, Waterdeep Prodigy",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast up to one target card of the other type from your graveyard. If a spell cast from your graveyard this way would be put into your graveyard, exile it instead.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "784ca4f3-95a3-592f-8f01-6600ed54ba38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5ddcf8-c87b-4a26-b226-8593f517a74a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5ddcf8-c87b-4a26-b226-8593f517a74a.jpg?1",
             "name": "Gale's Redirection",
             "text": "Exile target spell, then roll a d20 and add that spell's mana value.\n1\u201314 | You may cast the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\n15+ | You may cast the exiled card without paying its mana cost for as long as it remains exiled.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "e43e91f3-0d97-522a-abdb-5b24fdf9877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2aa14-4b8d-4f33-856d-296bc59a0ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2aa14-4b8d-4f33-856d-296bc59a0ade.jpg?1",
             "name": "Goggles of Night",
             "text": "Whenever equipped creature deals combat damage to a player, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "23a0ac18-71ef-5ad7-a172-0d7c3be6f288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b211832-907e-43d6-81af-c58fdd427303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b211832-907e-43d6-81af-c58fdd427303.jpg?1",
             "name": "Gray Harbor Merfolk",
             "text": "Gray Harbor Merfolk can't be blocked.\nGray Harbor Merfolk gets +2/+0 as long as you control a commander that's a creature or planeswalker.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "5507f7dd-0153-5a75-b609-498fe1d0b26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Ceremorphosis \u2014 When Illithid Harvester enters the battlefield, turn any number of target tapped nontoken creatures face down. They're 2/2 Horror creatures.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "3069507a-dfa8-58c9-af86-0f017b01746a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Tap X target creatures. They don't untap during their controllers' next untap steps. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "f403aa76-d362-5f6b-9828-8ccaaca112ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097264b-e383-4864-a587-dc7d5468f359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097264b-e383-4864-a587-dc7d5468f359.jpg?1",
             "name": "Imoen, Mystic Trickster",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your end step, if you have the initiative, draw a card. Draw another card if you've completed a dungeon.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -2918,7 +2918,7 @@
         },
         {
             "id": "e3765622-998d-5e75-a5bd-159d82ac3856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a791df-2483-406d-90b0-a8d402d615d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a791df-2483-406d-90b0-a8d402d615d6.jpg?1",
             "name": "Irenicus's Vile Duplication",
             "text": "Create a token that's a copy of target creature you control, except the token has flying and isn't legendary if that creature is legendary.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "e3e9f065-cb54-5495-8ddd-9d1982d5830c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc26897-4644-4af5-ac37-099e641c27d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc26897-4644-4af5-ac37-099e641c27d1.jpg?1",
             "name": "Juvenile Mist Dragon",
             "text": "Flying\nConfounding Clouds \u2014 When Juvenile Mist Dragon enters the battlefield, for each opponent, tap up to one target creature that player controls. Each of those creatures doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2984,7 +2984,7 @@
         },
         {
             "id": "ad4790ac-f425-5bee-b99a-333af8d64ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f30aca-5055-45f1-9121-e7a5675f07e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f30aca-5055-45f1-9121-e7a5675f07e4.jpg?1",
             "name": "Kenku Artificer",
             "text": "Homunculus Servant \u2014 When Kenku Artificer enters the battlefield, put three +1/+1 counters on up to one target noncreature artifact. That artifact becomes a 0/0 Homunculus artifact creature with flying.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "fa61c7d5-d000-5e34-a3b1-8e6bf2a8fb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5462e9-c602-4431-a845-f7c6cafbc3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5462e9-c602-4431-a845-f7c6cafbc3cf.jpg?1",
             "name": "Kindred Discovery",
             "text": "As Kindred Discovery enters the battlefield, choose a creature type.\nWhenever a creature you control of the chosen type enters the battlefield or attacks, draw a card.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "71dac0a3-47ee-562b-ba52-f6d28a7e4619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ed684b-e3a1-421d-8cfd-c5eee673a3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ed684b-e3a1-421d-8cfd-c5eee673a3a1.jpg?1",
             "name": "Lapis Orb of Dragonkind",
             "text": "{T}: Add {U}. When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "0544ab2f-dd54-54a6-966e-7b64369ff467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f915b034-ab16-48a6-a151-71eaa0b542f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f915b034-ab16-48a6-a151-71eaa0b542f9.jpg?1",
             "name": "Modify Memory",
             "text": "Exchange control of two target creatures controlled by different players. If you control neither creature, draw three cards.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "64ac35f3-8619-503f-b8dc-3bbbf96c4e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg?1",
             "name": "Moonshae Pixie // Pixie Dust",
             "text": "Flying\nWhen Moonshae Pixie enters the battlefield, draw cards equal to the number of opponents who were dealt combat damage this turn.",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "88389f1e-689f-5911-b1da-d5c187b9f440",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg?1",
             "name": "Moonshae Pixie // Pixie Dust",
             "text": "Up to three target creatures gain flying until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "3d6e12ce-3302-56e5-9b07-19774c6803dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894a0f5-2e1d-474f-9400-bdaa91b19fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894a0f5-2e1d-474f-9400-bdaa91b19fda.jpg?1",
             "name": "Mystery Key",
             "text": "When equipped creature deals combat damage to a player, sacrifice Mystery Key. If you do, draw three cards.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "3b6f4751-d9a1-5513-9491-1f02d5458469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df69a02-0b89-46af-abbc-51d1c419daed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df69a02-0b89-46af-abbc-51d1c419daed.jpg?1",
             "name": "Nimbleclaw Adept",
             "text": "Bigby's Hand \u2014 {T}: Untap two other target permanents. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "14b0e058-0eeb-5f5f-977a-6051f56dd493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fda8b66-fdf1-43e9-9d65-60b991348aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fda8b66-fdf1-43e9-9d65-60b991348aac.jpg?1",
             "name": "Oceanus Dragon",
             "text": "Flying\nWhen Oceanus Dragon enters the battlefield, tap target creature an opponent controls. Goad it. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "f6101041-6b04-54f0-a46a-300be575f668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d69ee8-a616-4191-b111-1330dfb24f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d69ee8-a616-4191-b111-1330dfb24f72.jpg?1",
             "name": "Pseudodragon Familiar",
             "text": "Flying\n{2}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "cf5ea39b-3d96-5298-8ed3-f01877107b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288e811e-7beb-4379-95a3-e5f4e759aa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288e811e-7beb-4379-95a3-e5f4e759aa9d.jpg?1",
             "name": "Psychic Impetus",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, you scry 2.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "571809e7-c3c8-5999-b964-6d95b4b21f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c044363-d661-4703-841c-8279fa4aa5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c044363-d661-4703-841c-8279fa4aa5e5.jpg?1",
             "name": "Renari, Merchant of Marvels",
             "text": "You may cast Dragon spells and artifact spells as though they had flash.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "8f16722f-b34d-5598-b6fd-73dbfa8886b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb29b-5169-44d7-bded-c2c94718e61f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb29b-5169-44d7-bded-c2c94718e61f.jpg?1",
             "name": "Robe of the Archmagi",
             "text": "Whenever equipped creature deals combat damage to a player, you draw that many cards.\nEquip {4}\nEquip Shaman, Warlock, or Wizard {1}",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "72d6bc22-33fd-5eb0-b37a-8297affe40e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6427-6d7d-4a90-b4b9-529895082d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6427-6d7d-4a90-b4b9-529895082d60.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "3a646511-132d-558f-8dc1-863dac4db7c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d175a716-5b69-401b-9902-684a30810288.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d175a716-5b69-401b-9902-684a30810288.jpg?1",
             "name": "Sailors' Bane",
             "text": "This spell costs {1} less to cast for each card you own in exile and in your graveyard that's an instant card, a sorcery card, or a card that has an Adventure.\nWard {4} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {4}.)",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "83c235e0-fd57-547f-8742-cea364f00db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg?1",
             "name": "Sapphire Dragon // Psionic Pulse",
             "text": "Flying\nWhenever Sapphire Dragon attacks or blocks, scry 2.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "4c9c8560-aca8-5646-8442-27bcd339977e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg?1",
             "name": "Sapphire Dragon // Psionic Pulse",
             "text": "Counter target noncreature spell. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "2d344f1d-82fd-5789-848a-742019f84d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg?1",
             "name": "Sea Hag // Aquatic Ingress",
             "text": "When Sea Hag enters the battlefield, creatures your opponents control get -4/-0 until end of turn.",
             "colours": [
@@ -3601,7 +3601,7 @@
         },
         {
             "id": "994cec17-a263-517d-9b8c-32bf25b3ea6c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg?1",
             "name": "Sea Hag // Aquatic Ingress",
             "text": "Up to two target creatures each get +1/+0 until end of turn and can't be blocked this turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "ce73bee9-5e3e-5d14-8e9c-c63f4d38ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65ad0e2-8f78-4e60-a97e-1cd20901680f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65ad0e2-8f78-4e60-a97e-1cd20901680f.jpg?1",
             "name": "Shameless Charlatan",
             "text": "Commander creatures you own have \"{2}{U}: This creature becomes a copy of another target creature.\"",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "a3e3f62e-d2cc-5901-9880-fe6ca75a32fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582dffab-2851-4498-ad69-c4d072617f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582dffab-2851-4498-ad69-c4d072617f32.jpg?1",
             "name": "Stunning Strike",
             "text": "Flash\nEnchant creature\nWhen Stunning Strike enters the battlefield, tap enchanted creature and remove it from combat.\nAs long as enchanted creature isn't legendary, it doesn't untap during its controller's untap step.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "123c67de-5aa9-5ee2-82f3-50770f3dd8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704f8ab7-63fd-4963-bacd-0076fffb34a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704f8ab7-63fd-4963-bacd-0076fffb34a1.jpg?1",
             "name": "Sword Coast Sailor",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, this creature can't be blocked this turn.\"",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "3a7d60ac-4a4c-576d-a5de-ea4f64646361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg?1",
             "name": "Sword Coast Serpent // Capsizing Wave",
             "text": "Sword Coast Serpent can't be blocked as long as you've cast a noncreature spell this turn.",
             "colours": [
@@ -3780,7 +3780,7 @@
         },
         {
             "id": "8f7f0242-131a-5da4-a6f2-3ce82aa139e1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg?1",
             "name": "Sword Coast Serpent // Capsizing Wave",
             "text": "Return target creature to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3814,7 +3814,7 @@
         },
         {
             "id": "7ab6a783-6229-5473-946e-096d79f09854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b5bf0c-e617-4a41-bfaa-2b299728a93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b5bf0c-e617-4a41-bfaa-2b299728a93f.jpg?1",
             "name": "Tomb of Horrors Adventurer",
             "text": "When Tomb of Horrors Adventurer enters the battlefield, you take the initiative.\nWhenever you cast your second spell each turn, copy it. If you've completed a dungeon, copy that spell twice instead. You may choose new targets for the copies. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "422b39fa-0761-5b2d-ab89-ece79e222db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5535db-696f-4c43-a8b9-c8e521b62c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5535db-696f-4c43-a8b9-c8e521b62c9c.jpg?1",
             "name": "Tymora's Invoker",
             "text": "Sleight of Hand \u2014 {8}: Draw two cards.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "5ce88808-7f7c-5caa-8ae6-dbcfec2a5bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46738fb3-ab5e-486c-b66a-1526ba1cdfa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46738fb3-ab5e-486c-b66a-1526ba1cdfa8.jpg?1",
             "name": "Vhal, Candlekeep Researcher",
             "text": "Vigilance\n{T}: Add an amount of {C} equal to Vhal, Candlekeep Researcher's toughness. This mana can't be spent to cast spells from your hand.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "be98a8ed-15dc-59c5-b5ef-6519a62c6b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862b6d5e-548f-4765-9d39-08d6115b4012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862b6d5e-548f-4765-9d39-08d6115b4012.jpg?1",
             "name": "Volo, Itinerant Scholar",
             "text": "When Volo enters the battlefield, create Volo's Journal, a legendary colorless artifact token with hexproof and \"Whenever you cast a creature spell, note one of its creature types that hasn't been noted for this artifact.\"\n{2}, {T}: Draw a card for each creature type noted for target permanent you control named Volo's Journal.\nChoose a Background",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "c5a930b9-503a-50af-b577-dea64805cd37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9afba96-2ec7-45f2-9ddd-31ec27a423ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9afba96-2ec7-45f2-9ddd-31ec27a423ca.jpg?1",
             "name": "Winter Eladrin",
             "text": "Gust of Wind \u2014 When Winter Eladrin enters the battlefield, return up to one other target creature to its owner's hand.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "918b4cb6-270c-543d-bd73-08164d62588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952e4e6b-fe74-4f3c-95d1-8e043f72072c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952e4e6b-fe74-4f3c-95d1-8e043f72072c.jpg?1",
             "name": "Wizards of Thay",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\nInstant and sorcery spells you cast cost {1} less to cast.\nYou may cast sorcery spells as though they had flash.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "9ca136f0-d4a1-575a-a394-7db7f580b006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg?1",
             "name": "Young Blue Dragon // Sand Augury",
             "text": "Flying",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "95b6fd24-b01d-5c93-b2c3-840b1d844ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg?1",
             "name": "Young Blue Dragon // Sand Augury",
             "text": "Scry 1, then draw a card. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "6ec171fe-fa65-548e-8104-72c515b73242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5984d3-1e76-4d97-9373-b59cfa9c38ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5984d3-1e76-4d97-9373-b59cfa9c38ae.jpg?1",
             "name": "Agent of the Iron Throne",
             "text": "Commander creatures you own have \"Whenever an artifact or creature you control is put into a graveyard from the battlefield, each opponent loses 1 life.\"",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "98de5916-f93d-5530-bab9-c60ed54a0698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50448e9-afe4-4d4e-b027-bbb855f17aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50448e9-afe4-4d4e-b027-bbb855f17aeb.jpg?1",
             "name": "Agent of the Shadow Thieves",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, put a +1/+1 counter on this creature. It gains deathtouch and indestructible until end of turn.\"",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "085285a3-7b25-564e-8bb6-b8972b0324b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "{2}{B}, {T}, Exile a creature you control: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "7d4c6fc2-5039-5673-b147-7b70b6c556e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "Create a tapped 4/1 black Skeleton creature token with menace. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "8ff967b4-e34f-5691-b99b-2eb1d35df45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e0bfe-fa2d-43a1-a880-2d2083aa559a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e0bfe-fa2d-43a1-a880-2d2083aa559a.jpg?1",
             "name": "Ambition's Cost",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "c495dcb1-3054-5eb4-a11c-b68b6288fdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430c61b-407d-471d-9012-07f1ddef28aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430c61b-407d-471d-9012-07f1ddef28aa.jpg?1",
             "name": "Ancient Brass Dragon",
             "text": "Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "c1cf3bc9-9ea8-56e9-8e0c-bc6a932d1f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f5d5be-777f-4e7b-b18c-ce4a9cedb7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f5d5be-777f-4e7b-b18c-ce4a9cedb7d0.jpg?1",
             "name": "Armor of Shadows",
             "text": "Until end of turn, target creature gets +1/+0 and gains indestructible. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "f7c70cd6-01db-52cc-9a3b-6d6d24c194e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fd431-8f6d-4ca5-bc0c-53881c500da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fd431-8f6d-4ca5-bc0c-53881c500da1.jpg?1",
             "name": "Arms of Hadar",
             "text": "Creatures target player controls get -2/-2 until end of turn.",
             "colours": [
@@ -4387,7 +4387,7 @@
         },
         {
             "id": "8ad09c17-b1cb-5aa0-9c92-f36478551290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366640a-ca4a-4325-8578-1ec78d0382cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366640a-ca4a-4325-8578-1ec78d0382cc.jpg?1",
             "name": "Astarion's Thirst",
             "text": "Exile target creature. Put X +1/+1 counters on a commander creature you control, where X is the power of the creature exiled this way.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "f006c0c7-78c3-57bc-90b1-3acbbeaf2158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6098b4a-a92f-4477-8122-5913ac9247f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6098b4a-a92f-4477-8122-5913ac9247f8.jpg?1",
             "name": "Atrocious Experiment",
             "text": "Target player mills two cards, draws two cards, and loses 2 life. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "011ed823-a276-51d1-b1cc-f187a2c22f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45c18c-b8eb-465c-8dfc-fd6da73e25b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45c18c-b8eb-465c-8dfc-fd6da73e25b5.jpg?1",
             "name": "Blood Money",
             "text": "Destroy all creatures. For each nontoken creature destroyed this way, you create a tapped Treasure token.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "2445b81f-642c-5bc7-8609-51ef1c402687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f411d0-c796-443f-b957-c632aa23deb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f411d0-c796-443f-b957-c632aa23deb0.jpg?1",
             "name": "Bonecaller Cleric",
             "text": "{3}{B}, Sacrifice Bonecaller Cleric: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "a3db8b74-bab9-51ed-be8d-acde4cafc6a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836cfea-c203-49f4-b8d1-f1e8aa790db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836cfea-c203-49f4-b8d1-f1e8aa790db5.jpg?1",
             "name": "Call to the Void",
             "text": "Each player secretly chooses a creature they control and a creature they don't control. Then those choices are revealed. Destroy each creature chosen this way.",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "11a7f6d8-f3eb-5368-9df9-610791fca2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba79021-39af-4e74-beb5-f2f508c865b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba79021-39af-4e74-beb5-f2f508c865b2.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "87086ecb-94dd-58f6-9ea8-9da9780d9f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b434c1d-792e-4ca7-aea0-938e85fe167c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b434c1d-792e-4ca7-aea0-938e85fe167c.jpg?1",
             "name": "Chain Devil",
             "text": "Animate Chains \u2014 When Chain Devil enters the battlefield, each player sacrifices a nontoken creature.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "66892dc4-e99e-58f8-ae3f-2ef9fac0a9e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71b2b8-f5ef-4885-9f8d-284fe335d184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71b2b8-f5ef-4885-9f8d-284fe335d184.jpg?1",
             "name": "Cloudkill",
             "text": "All creatures get -X/-X until end of turn, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "eab73edd-71ce-5559-a56e-c0902b220a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6410a2a2-48d9-4032-b585-4eaa5bc06581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6410a2a2-48d9-4032-b585-4eaa5bc06581.jpg?1",
             "name": "Criminal Past",
             "text": "Commander creatures you own have menace and \"This creature gets +X/+0, where X is the number of creature cards in your graveyard.\" (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "91565789-4c60-5191-ac06-92d342832ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7b4af-d521-4f4f-8910-7e05f2f60eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7b4af-d521-4f4f-8910-7e05f2f60eb6.jpg?1",
             "name": "Cultist of the Absolute",
             "text": "Commander creatures you own get +3/+3 and have flying, deathtouch, \"Ward\u2014\nPay 3 life,\" and \"At the beginning of your upkeep, sacrifice a creature.\"",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "cf74ff29-ad21-5614-a2dd-e2efe814a9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5172be3-4379-43fc-98bd-e77c579dea55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5172be3-4379-43fc-98bd-e77c579dea55.jpg?1",
             "name": "Deadly Dispute",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "c9cbfe17-d564-521c-8f28-e5f56e7dc9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82a13bf-da32-4c12-a9dd-271d8ca45c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82a13bf-da32-4c12-a9dd-271d8ca45c21.jpg?1",
             "name": "Elder Brain",
             "text": "Menace\nWhenever Elder Brain attacks a player, exile all cards from that player's hand, then they draw that many cards. You may play lands and cast spells from among the exiled cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "737b60e5-0a32-53ec-9d0f-8d056e5a87ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d578bdc3-1edf-4267-b612-2236b54329c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d578bdc3-1edf-4267-b612-2236b54329c6.jpg?1",
             "name": "Eldritch Pact",
             "text": "Target player draws X cards and loses X life, where X is the number of cards in their graveyard.",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "714b9ade-1ccb-56b6-8abc-bd0e8dc6a188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564728ed-dbf0-471c-a34a-5bd3b486b7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564728ed-dbf0-471c-a34a-5bd3b486b7e5.jpg?1",
             "name": "Ghastly Death Tyrant",
             "text": "When Ghastly Death Tyrant enters the battlefield, choose one \u2014\n\u2022 Disintegration Ray \u2014 Destroy target enchantment an opponent controls. You lose life equal to its mana value.\n\u2022 Death Ray \u2014 Creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -4868,7 +4868,7 @@
         },
         {
             "id": "ca2431c4-58d4-5eb0-bf40-acf75820e58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg?1",
             "name": "Ghost Lantern // Bind Spirit",
             "text": "Whenever a creature you control dies, put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "04e80805-510c-5a39-8b90-994547e8e1fe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg?1",
             "name": "Ghost Lantern // Bind Spirit",
             "text": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -4936,7 +4936,7 @@
         },
         {
             "id": "5f6a6bfe-07f9-542e-b81f-58aaac735dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg?1",
             "name": "Gray Slaad // Entropic Decay",
             "text": "As long as there are four or more creature cards in your graveyard, Gray Slaad has menace and deathtouch.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "18a5ef60-3657-5da2-a0e0-235667c6b57a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg?1",
             "name": "Gray Slaad // Entropic Decay",
             "text": "Mill four cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "8e1bbbdf-5a39-531e-99c0-a35eb2a7f520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7efb10f-c760-431c-8ac6-904965d850dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7efb10f-c760-431c-8ac6-904965d850dc.jpg?1",
             "name": "Guildsworn Prowler",
             "text": "Deathtouch\nWhen Guildsworn Prowler dies, if it wasn't blocking, draw a card.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "22aa6943-3508-509a-a55d-a274db0ada30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg?1",
             "name": "Hezrou // Demonic Stench",
             "text": "Whenever one or more creatures you control become blocked, each blocking creature gets -1/-1 until end of turn.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "55c1311a-d982-5041-91e4-314c4e7972f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg?1",
             "name": "Hezrou // Demonic Stench",
             "text": "Each creature that blocked this turn gets -1/-1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "66185cd3-e33c-59d8-a74e-e709aadcb7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52d30a3-a436-4854-91e9-2c359c40457b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52d30a3-a436-4854-91e9-2c359c40457b.jpg?1",
             "name": "Intellect Devourer",
             "text": "Devour Intellect \u2014 When Intellect Devourer enters the battlefield, each opponent exiles a card from their hand until Intellect Devourer leaves the battlefield.\nBody Thief \u2014 You may play lands and cast spells from among cards exiled with Intellect Devourer. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "ccca8a51-02f8-5611-817b-7da9a994d9fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5da403-d791-4ad4-a949-e8a56459cac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5da403-d791-4ad4-a949-e8a56459cac1.jpg?1",
             "name": "Mold Folk",
             "text": "Lifelink\nMold Harvest \u2014 {1}, Sacrifice another creature or an artifact: Put a +1/+1 counter on Mold Folk.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "26268b82-2e06-5e79-938a-92caad06f69a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdef7fea-2bd0-42a2-96f6-6def18bd7f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdef7fea-2bd0-42a2-96f6-6def18bd7f0c.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "43b75666-c115-535e-ba79-3b547861e53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7c427-aa31-4077-8397-74a9a3802ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7c427-aa31-4077-8397-74a9a3802ee7.jpg?1",
             "name": "Myrkul's Edict",
             "text": "Roll a d20.\n1\u20139 | Choose an opponent. That player sacrifices a creature.\n10\u201319 | Each opponent sacrifices a creature.\n20 | Each opponent sacrifices a creature with the greatest power among creatures that player controls.",
             "colours": [
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "ab09d7c6-2970-5687-be8f-c11bae8c08cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca67faa9-2c23-4cc5-b77f-ff75cf0349f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca67faa9-2c23-4cc5-b77f-ff75cf0349f3.jpg?1",
             "name": "Myrkul's Invoker",
             "text": "Psychic Blades \u2014 {8}: Creatures you control get +2/+0 and gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5280,7 +5280,7 @@
         },
         {
             "id": "8039b8fd-6f62-58da-9df3-1f018b4429da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc61b93-b87a-47f4-b5b5-eedb1db48288.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc61b93-b87a-47f4-b5b5-eedb1db48288.jpg?1",
             "name": "Nefarious Imp",
             "text": "Flying\nWhenever one or more permanents you control leave the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5314,7 +5314,7 @@
         },
         {
             "id": "388d0789-2953-58e7-9f4d-e957bcdfd9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9fd859-577f-4836-b785-1cf11808b892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9fd859-577f-4836-b785-1cf11808b892.jpg?1",
             "name": "Nothic",
             "text": "Weird Insight \u2014 When Nothic dies, roll a d20.\n1\u20139 | You draw a card and you lose 1 life.\n10\u201319 | You draw two cards and you lose 2 life.\n20 | You draw seven cards and you lose 7 life.",
             "colours": [
@@ -5348,7 +5348,7 @@
         },
         {
             "id": "b1ed22b5-5d98-51ff-964f-2def15e32a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b0cf66-c6ec-4ff6-96a5-334e2c9c7818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b0cf66-c6ec-4ff6-96a5-334e2c9c7818.jpg?1",
             "name": "Pact Weapon",
             "text": "As long as Pact Weapon is attached to a creature, you don't lose the game for having 0 or less life.\nWhenever equipped creature attacks, draw a card and reveal it. The creature gets +X/+X until end of turn and you lose X life, where X is that card's mana value.\nEquip\u2014\nDiscard a card.",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "4bc9a69f-36f4-504c-9897-4cc924fae5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82958da6-71d5-4ad3-a149-aaa31f25e7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82958da6-71d5-4ad3-a149-aaa31f25e7cf.jpg?1",
             "name": "Parasitic Impetus",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "78ca12bb-c8f6-5847-b936-2cef3eb19cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeee54a-5e16-4519-b04a-49eaaf896b9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeee54a-5e16-4519-b04a-49eaaf896b9a.jpg?1",
             "name": "Passageway Seer",
             "text": "Lifelink\nWhen Passageway Seer enters the battlefield, you take the initiative.\nAt the beginning of your end step, if you have the initiative, put a +1/+1 counter on Passageway Seer.",
             "colours": [
@@ -5453,7 +5453,7 @@
         },
         {
             "id": "56fa204d-a348-51f8-a345-e3637d8b0dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e27c36-d883-4681-8430-b4d0ad7f1df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e27c36-d883-4681-8430-b4d0ad7f1df0.jpg?1",
             "name": "Ravenloft Adventurer",
             "text": "When Ravenloft Adventurer enters the battlefield, you take the initiative.\nIf a creature an opponent controls would die, instead exile it and put a hit counter on it.\nWhenever Ravenloft Adventurer attacks, if you've completed a dungeon, defending player loses 1 life for each card they own in exile with a hit counter on it.",
             "colours": [
@@ -5491,7 +5491,7 @@
         },
         {
             "id": "ec5e569a-d99a-536c-aab1-2aa47054c40c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9367f66-6556-459c-a43d-5ba7a84b568d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9367f66-6556-459c-a43d-5ba7a84b568d.jpg?1",
             "name": "Safana, Calimport Cutthroat",
             "text": "Menace\nAt the beginning of your end step, if you have the initiative, create a Treasure token. Create three of those tokens instead if you've completed a dungeon.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5531,7 +5531,7 @@
         },
         {
             "id": "52f095f3-a87d-5155-a4a5-6d2743c4be32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009d5ab-945d-43c3-9077-f10f96249fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009d5ab-945d-43c3-9077-f10f96249fc4.jpg?1",
             "name": "Sarevok, Deathbringer",
             "text": "At the beginning of each player's end step, if no permanents left the battlefield this turn, that player loses X life, where X is Sarevok's power.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "8a089e1e-8363-5970-903e-ad8bf29c50c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c876f9b3-b4f6-4177-9c43-443ae2a028d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c876f9b3-b4f6-4177-9c43-443ae2a028d0.jpg?1",
             "name": "Scion of Halaster",
             "text": "Commander creatures you own have \"The first time you would draw a card each turn, instead look at the top two cards of your library. Put one of them into your graveyard and the other back on top of your library. Then draw a card.\"",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "c955cdd5-9b39-5af7-b823-6055b093dacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a0913d-776b-4ef8-adef-8861349df2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a0913d-776b-4ef8-adef-8861349df2b5.jpg?1",
             "name": "Shadowheart, Dark Justiciar",
             "text": "{1}{B}, {T}, Sacrifice another creature: Draw X cards, where X is that creature's power.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5650,7 +5650,7 @@
         },
         {
             "id": "4bb5c10d-601d-5ea8-97a4-596f3157f963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fdf8bd-1893-4599-936a-fe0d6a87545f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fdf8bd-1893-4599-936a-fe0d6a87545f.jpg?1",
             "name": "Sigil of Myrkul",
             "text": "At the beginning of combat on your turn, mill a card. When you do, if there are four or more creature cards in your graveyard, put a +1/+1 counter on target creature you control and it gains deathtouch until end of turn. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "da4c39ba-5d0d-5be2-a6be-404d7a0bd859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bc010-5b60-4075-be12-0b36f41f32c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bc010-5b60-4075-be12-0b36f41f32c6.jpg?1",
             "name": "Sivriss, Nightmare Speaker",
             "text": "{T}, Sacrifice another creature or an artifact: For each opponent, you mill a card, then return that card from your graveyard to your hand unless that player pays 3 life. (To mill a card, put the top card of your library into your graveyard.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "dcc4090d-c03e-5eba-9d2a-2b6960953949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3362080e-57e9-4da1-9065-d28932869fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3362080e-57e9-4da1-9065-d28932869fe5.jpg?1",
             "name": "Skullport Merchant",
             "text": "When Skullport Merchant enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{1}{B}, Sacrifice another creature or a Treasure: Draw a card.",
             "colours": [
@@ -5758,7 +5758,7 @@
         },
         {
             "id": "9296b40a-80b4-5cfc-b6c2-205e68b305b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d59fb-c3ff-4995-a695-51f2a4dae404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d59fb-c3ff-4995-a695-51f2a4dae404.jpg?1",
             "name": "Stirge",
             "text": "Flying\nStirge can't block.\nBlood Drain \u2014 {1}{B}, Pay 1 life, Sacrifice Stirge: Draw a card.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "30a89a22-83ab-5349-8608-7170c5fa74eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278f7705-01a4-4baf-929b-b93e538a8d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278f7705-01a4-4baf-929b-b93e538a8d77.jpg?1",
             "name": "Summon Undead",
             "text": "You may mill three cards. Then return a creature card from your graveyard to the battlefield. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "9ac264cd-eb35-5d0e-bbae-b887fb10b179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bf4ee1-b6a8-4a69-adab-6839c1786cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bf4ee1-b6a8-4a69-adab-6839c1786cc9.jpg?1",
             "name": "Thieves' Tools",
             "text": "When Thieves' Tools enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature can't be blocked as long as its power is 3 or less.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5859,7 +5859,7 @@
         },
         {
             "id": "18918c76-eab3-546c-b063-2dce39a1542f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg?1",
             "name": "Topaz Dragon // Entropic Cloud",
             "text": "Flying, deathtouch",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "2ea932c1-0a1a-5df8-b4dd-5bbab65683d7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg?1",
             "name": "Topaz Dragon // Entropic Cloud",
             "text": "Creatures you control gain deathtouch until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "f2206082-b5b7-5597-839e-9ff2d8d91dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bf9736-b5f5-4fd4-8406-9f57fefd86e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bf9736-b5f5-4fd4-8406-9f57fefd86e7.jpg?1",
             "name": "Underdark Explorer",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Underdark Explorer enters the battlefield, you take the initiative.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "ffacac1a-8fdc-5452-a61c-386ff95c744f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f939d8-3d41-4d8b-baea-7f022104c704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f939d8-3d41-4d8b-baea-7f022104c704.jpg?1",
             "name": "Vicious Battlerager",
             "text": "When Vicious Battlerager enters the battlefield, you take the initiative.\nSpiked Retribution \u2014 Whenever Vicious Battlerager becomes blocked by a creature, that creature's controller loses 5 life.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "9e611995-bb58-52ea-9cda-ad47c4a58e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631762a-e833-40a5-a6e9-b6cde38f62f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631762a-e833-40a5-a6e9-b6cde38f62f0.jpg?1",
             "name": "Viconia, Drow Apostate",
             "text": "At the beginning of your upkeep, if there are four or more creature cards in your graveyard, return a creature card at random from your graveyard to your hand.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "d8e61eb7-14b3-50f4-b94e-dfc42ab546e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5111905c-3d19-4a06-b8c6-a253260b5d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5111905c-3d19-4a06-b8c6-a253260b5d24.jpg?1",
             "name": "Vrock",
             "text": "Flying\nToxic Spores \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, each opponent loses 3 life.",
             "colours": [
@@ -6072,7 +6072,7 @@
         },
         {
             "id": "fb0aef8c-da27-5afa-849a-7e296e982d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1a27c1-ff44-47a7-991d-c294e30eea34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1a27c1-ff44-47a7-991d-c294e30eea34.jpg?1",
             "name": "Zhentarim Bandit",
             "text": "Whenever Zhentarim Bandit attacks, you may pay 1 life. If you do, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6107,7 +6107,7 @@
         },
         {
             "id": "d8c8cb32-02e1-500f-a2a9-55a59e2ba40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34806912-daf8-4e5c-804f-af0858500438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34806912-daf8-4e5c-804f-af0858500438.jpg?1",
             "name": "Amber Gristle O'Maul",
             "text": "Haste\nWhenever Amber Gristle O'Maul attacks, you may discard your hand. If you do, draw a card for each player being attacked.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "4e5ae695-dbb1-5f98-9333-e3b926d23d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg?1",
             "name": "Amethyst Dragon // Explosive Crystal",
             "text": "Flying, haste",
             "colours": [
@@ -6181,7 +6181,7 @@
         },
         {
             "id": "de522e4d-8725-5844-b304-6487d46a94d9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg?1",
             "name": "Amethyst Dragon // Explosive Crystal",
             "text": "Explosive Crystal deals 4 damage divided as you choose among any number of targets. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "a572dff6-b14d-5771-8fac-aa2f585b3fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836dddd-a7e4-499f-ad49-ce298aa65720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836dddd-a7e4-499f-ad49-ce298aa65720.jpg?1",
             "name": "Ancient Copper Dragon",
             "text": "Flying\nWhenever Ancient Copper Dragon deals combat damage to a player, roll a d20. You create a number of Treasure tokens equal to the result.",
             "colours": [
@@ -6253,7 +6253,7 @@
         },
         {
             "id": "c340cb90-d1fe-5bf9-b4bd-df8d2447082a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1b3da-e8e6-4118-a268-1e3871e6ffee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1b3da-e8e6-4118-a268-1e3871e6ffee.jpg?1",
             "name": "Balor",
             "text": "Flying\nWhenever Balor attacks or dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent draws three cards, then discards three cards at random.\n\u2022 Target opponent sacrifices a nontoken artifact.\n\u2022 Balor deals damage to target opponent equal to the number of cards in their hand.",
             "colours": [
@@ -6289,7 +6289,7 @@
         },
         {
             "id": "b8cdc67a-9f65-5b8b-ab9f-a15f8295df81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd3e535-8412-4f79-a2b1-dfda9db1c496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd3e535-8412-4f79-a2b1-dfda9db1c496.jpg?1",
             "name": "Bhaal's Invoker",
             "text": "Scorching Ray \u2014 {8}: Bhaal's Invoker deals 4 damage to each opponent.",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "9700953a-7e55-5edc-b349-f2e327b5adbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdf1222-2fc5-4dae-a7a5-6ba774b02843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdf1222-2fc5-4dae-a7a5-6ba774b02843.jpg?1",
             "name": "Bloodboil Sorcerer",
             "text": "Whenever Bloodboil Sorcerer enters the battlefield, you take the initiative.\nCrown of Madness \u2014 {1}{R}, Sacrifice an artifact or creature: Goad target creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -6359,7 +6359,7 @@
         },
         {
             "id": "b6b44716-1af2-5251-b171-71870a19444e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0174e40a-0ef5-4439-91e6-3fc39f482520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0174e40a-0ef5-4439-91e6-3fc39f482520.jpg?1",
             "name": "Breath Weapon",
             "text": "Breath Weapon deals 2 damage to each non-Dragon creature.",
             "colours": [
@@ -6391,7 +6391,7 @@
         },
         {
             "id": "d54c35d4-fc61-5911-b17e-ad8c319da052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e41166-bdaa-4aed-986a-7be1d043240c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e41166-bdaa-4aed-986a-7be1d043240c.jpg?1",
             "name": "Carnelian Orb of Dragonkind",
             "text": "{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.",
             "colours": [
@@ -6423,7 +6423,7 @@
         },
         {
             "id": "b817292b-7be6-5d61-b536-eb1c167c7255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09abb6df-2aa1-4999-b550-db2892faa8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09abb6df-2aa1-4999-b550-db2892faa8c7.jpg?1",
             "name": "Caves of Chaos Adventurer",
             "text": "Trample\nWhen Caves of Chaos Adventurer enters the battlefield, you take the initiative.\nWhenever Caves of Chaos Adventurer attacks, exile the top card of your library. If you've completed a dungeon, you may play that card this turn without paying its mana cost. Otherwise, you may play that card this turn.",
             "colours": [
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "01aa8e2a-19e8-516b-bcbc-7eae368c6c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8647092a-9d09-42cb-bcda-4e5e7a6c8a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8647092a-9d09-42cb-bcda-4e5e7a6c8a1c.jpg?1",
             "name": "Coronation of Chaos",
             "text": "Up to three target creatures can't block this turn. Goad them. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "95ceba8e-bd76-55ae-91fc-ce294525e541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faadf72f-b2d5-4271-8d5c-a586acf63453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faadf72f-b2d5-4271-8d5c-a586acf63453.jpg?1",
             "name": "Descent into Avernus",
             "text": "At the beginning of your upkeep, put two descent counters on Descent into Avernus. Then each player creates X Treasure tokens and Descent into Avernus deals X damage to each player, where X is the number of descent counters on Descent into Avernus.",
             "colours": [
@@ -6526,7 +6526,7 @@
         },
         {
             "id": "5d06c6e2-573f-5abb-9bce-20a0924efd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06ad968-ca7a-470b-ba3b-e0afc597b2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06ad968-ca7a-470b-ba3b-e0afc597b2cd.jpg?1",
             "name": "Dragon Cultist",
             "text": "Commander creatures you own have \"At the beginning of your end step, if a source you controlled dealt 5 or more damage this turn, create a 4/4 red Dragon creature token with flying.\"",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "3ff54cbe-639f-5bf5-8ca7-210a04077c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f700c6-7591-481d-b223-21f5b820e831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f700c6-7591-481d-b223-21f5b820e831.jpg?1",
             "name": "Earth Tremor",
             "text": "Earth Tremor deals damage to target creature or planeswalker equal to the number of lands you control.",
             "colours": [
@@ -6596,7 +6596,7 @@
         },
         {
             "id": "68bd10a5-0e58-50ba-b874-a7218170c3c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e376b59a-5702-4706-b713-01cab4e253cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e376b59a-5702-4706-b713-01cab4e253cc.jpg?1",
             "name": "Elturel Survivors",
             "text": "Trample, myriad\nAs long as Elturel Survivors is attacking, it gets +X/+0, where X is the number of lands defending player controls.",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "2a8633f8-a360-554b-9e36-09003d871471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg?1",
             "name": "Fang Dragon // Forktail Sweep",
             "text": "Flying",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "30e5e727-c609-5806-83a9-a7094aa2691d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg?1",
             "name": "Fang Dragon // Forktail Sweep",
             "text": "Forktail Sweep deals 1 damage to each creature you don't control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6701,7 +6701,7 @@
         },
         {
             "id": "d487cb7a-be2c-5b5e-8b3b-f8f2faaf1760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255900-11ac-4a82-bd30-2dc24addd8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255900-11ac-4a82-bd30-2dc24addd8e6.jpg?1",
             "name": "Firbolg Flutist",
             "text": "Enthralling Performance \u2014 When Firbolg Flutist enters the battlefield, gain control of target creature you don't control until end of turn. Untap it. It gains haste and myriad until end of turn. (Whenever it attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "43c95dcf-bf6d-50cc-9f92-e8e1f8cc8e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45a43e-a5b7-4fd4-873b-7b3c021be198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45a43e-a5b7-4fd4-873b-7b3c021be198.jpg?1",
             "name": "Fireball",
             "text": "This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.",
             "colours": [
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "ee6a1494-cca9-5775-915d-be1e920ced90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5bb319-29b2-4a7c-82e9-f8b5e47909a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5bb319-29b2-4a7c-82e9-f8b5e47909a1.jpg?1",
             "name": "Ganax, Astral Hunter",
             "text": "Flying\nWhenever Ganax, Astral Hunter or another Dragon enters the battlefield under your control, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "0e8a3d85-b127-5933-ad0d-fa1d191b7c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac424e1-7806-46ee-84a9-ca2f0dd468a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac424e1-7806-46ee-84a9-ca2f0dd468a4.jpg?1",
             "name": "Genasi Enforcers",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\n{1}{R}: Creatures you control named Genasi Enforcers get +1/+0 until end of turn.",
             "colours": [
@@ -6846,7 +6846,7 @@
         },
         {
             "id": "e9ee87bb-561c-5f7e-a97c-ebd9425c9f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfecffd-33af-43a9-b26c-f1ff193c6323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfecffd-33af-43a9-b26c-f1ff193c6323.jpg?1",
             "name": "Gnoll War Band",
             "text": "This spell costs {1} less to cast for each opponent who was dealt damage this turn.\nMenace\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "45164d97-93a1-5616-8949-74d5236bd61d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe5cc84-db39-4f64-b877-599880a8729a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe5cc84-db39-4f64-b877-599880a8729a.jpg?1",
             "name": "Guild Artisan",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, you create two Treasure tokens.\" (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6918,7 +6918,7 @@
         },
         {
             "id": "063508e0-d066-54cf-bed2-683a6d214bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ca18d-9099-4f1e-95c1-f04da58a26bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ca18d-9099-4f1e-95c1-f04da58a26bd.jpg?1",
             "name": "Gut, True Soul Zealot",
             "text": "Whenever you attack, you may sacrifice another creature or an artifact. If you do, create a 4/1 black Skeleton creature token with menace that's tapped and attacking. (It can't be blocked except by two or more creatures.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "b71d968b-7199-5268-9356-7d8c78986992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746fec80-5ddb-42b8-bc54-728bcd3863b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746fec80-5ddb-42b8-bc54-728bcd3863b3.jpg?1",
             "name": "Hoarding Ogre",
             "text": "Whenever Hoarding Ogre attacks, roll a d20.\n1\u20139 | Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n10\u201319 | Create two Treasure tokens.\n20 | Create three Treasure tokens.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "dacc4f49-b5cf-5c38-8b70-296576dc134c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8dd6c3-3699-4dd1-a019-fdb569eaf722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8dd6c3-3699-4dd1-a019-fdb569eaf722.jpg?1",
             "name": "Ingenious Artillerist",
             "text": "Whenever one or more artifacts enter the battlefield under your control, Ingenious Artillerist deals that much damage to each opponent.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "31ced9ec-c7cd-5c58-82b6-7df4dcc437b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e6b1d3-1ac2-4f20-997e-25c93f1f7897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e6b1d3-1ac2-4f20-997e-25c93f1f7897.jpg?1",
             "name": "Inspired Tinkering",
             "text": "Exile the top three cards of your library. Until the end of your next turn, you may play those cards.\nCreate three Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7059,7 +7059,7 @@
         },
         {
             "id": "6f230290-cf21-59ca-becb-c065ab82ce84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f401e-1403-49f8-a39e-1eed05b41c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f401e-1403-49f8-a39e-1eed05b41c34.jpg?1",
             "name": "Insufferable Balladeer",
             "text": "Vicious Mockery \u2014 When Insufferable Balladeer enters the battlefield, target creature an opponent controls can't block this turn. Goad it. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "d116ccf0-3589-5932-89b4-7fa77b5ef22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d2f660-97f9-404b-82bb-37e396602580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d2f660-97f9-404b-82bb-37e396602580.jpg?1",
             "name": "Javelin of Lightning",
             "text": "Flash\nWhen Javelin of Lightning enters the battlefield, attach it to target creature you control.\nAs long as it's your turn, equipped creature gets +2/+0 and has first strike.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "beb54d94-c11e-5da2-a0c7-194fdb7d83a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775480ed-f574-40cb-bd9b-21102eaaff63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775480ed-f574-40cb-bd9b-21102eaaff63.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "Whenever you attack, if it's the first combat phase of the turn, untap all attacking creatures. They gain first strike until end of turn. After this phase, there is an additional combat phase.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "0b0ac66e-a46b-5a7d-ba53-07d6c06e9561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5f9fb1-5a55-4db3-98a1-2628e3598c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5f9fb1-5a55-4db3-98a1-2628e3598c18.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "a45cf3ab-8c12-568c-9b06-e9c2d4eb1673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c5b52-94bc-48e3-8e4f-e2db1eca7536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c5b52-94bc-48e3-8e4f-e2db1eca7536.jpg?1",
             "name": "Livaan, Cultist of Tiamat",
             "text": "Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "4c97f86d-bcad-5bb4-ad5b-537d015c9088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743840f-fe99-4cb4-a558-1763b605b35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743840f-fe99-4cb4-a558-1763b605b35f.jpg?1",
             "name": "Nemesis Phoenix",
             "text": "Flying\n{2}{R}: Return Nemesis Phoenix from your graveyard to the battlefield tapped and attacking. Activate only during the declare attackers step and only if you're attacking two or more opponents.",
             "colours": [
@@ -7278,7 +7278,7 @@
         },
         {
             "id": "a36ea1a4-c1a3-5aae-acbe-bf862bfbb50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef30c5-a6a6-4cd9-805f-dc6f66f28997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef30c5-a6a6-4cd9-805f-dc6f66f28997.jpg?1",
             "name": "Pack Attack",
             "text": "Attacking creatures get +X/+0 until end of turn, where X is the number of players being attacked.\nDraw a card.",
             "colours": [
@@ -7310,7 +7310,7 @@
         },
         {
             "id": "fecdfc35-bdb2-53d4-88d8-552f7219c702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b2b8ca-7433-4bfe-abab-e19128e46a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b2b8ca-7433-4bfe-abab-e19128e46a1d.jpg?1",
             "name": "Patron of the Arts",
             "text": "When Patron of the Arts enters the battlefield or dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "654c3801-fd3c-5eb8-96bd-f9e533e640f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91844266-8b2f-421f-a944-544c51734e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91844266-8b2f-421f-a944-544c51734e64.jpg?1",
             "name": "Popular Entertainer",
             "text": "Commander creatures you own have \"Whenever one or more creatures you control deal combat damage to a player, goad target creature that player controls.\" (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -7383,7 +7383,7 @@
         },
         {
             "id": "01a0b782-8cc6-5e7c-83a9-92172b06f43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c912e984-1d27-4da2-9733-d56e437bcf58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c912e984-1d27-4da2-9733-d56e437bcf58.jpg?1",
             "name": "Reckless Barbarian",
             "text": "Sacrifice Reckless Barbarian: Add {R}{R}.",
             "colours": [
@@ -7418,7 +7418,7 @@
         },
         {
             "id": "0964a722-400a-5345-ba32-1c4394a0cafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57520d99-744f-41bb-9134-f28397a5cb2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57520d99-744f-41bb-9134-f28397a5cb2a.jpg?1",
             "name": "Shiny Impetus",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7452,7 +7452,7 @@
         },
         {
             "id": "295f998b-6ef9-579b-9d9a-320b80bab605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d9d83-d1e6-4499-a1ac-6f865159f6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d9d83-d1e6-4499-a1ac-6f865159f6b6.jpg?1",
             "name": "Stirring Bard",
             "text": "Defender\nWhen Stirring Bard enters the battlefield, you take the initiative.\nMantle of Inspiration \u2014 {T}: Target creature gains menace and haste until end of turn.",
             "colours": [
@@ -7487,7 +7487,7 @@
         },
         {
             "id": "3ad747df-19d1-5500-a769-7ab7e436a9e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a655b3-969f-40d7-9d69-61abf338df86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a655b3-969f-40d7-9d69-61abf338df86.jpg?1",
             "name": "Storm King's Thunder",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell X times. You may choose new targets for the copies.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "8d20ee56-9995-5186-916b-63276e5109d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5249c-52b6-4349-adcd-dafdc21f572b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5249c-52b6-4349-adcd-dafdc21f572b.jpg?1",
             "name": "Street Urchin",
             "text": "Commander creatures you own have \"{1}, Sacrifice another creature or an artifact: This creature deals 1 damage to any target.\"",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "c702239b-94f5-5cea-8f82-f89bbf3504fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06604f3-c70c-44d6-b1b9-e915552084e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06604f3-c70c-44d6-b1b9-e915552084e0.jpg?1",
             "name": "Swashbuckler Extraordinaire",
             "text": "When Swashbuckler Extraordinaire enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever you attack, you may sacrifice one or more Treasures. When you do, up to that many target creatures gain double strike until end of turn.",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "efbd66ff-810b-5205-9d5a-432a152af3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149c2a-503b-46e0-9a7f-cc40a9507883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149c2a-503b-46e0-9a7f-cc40a9507883.jpg?1",
             "name": "Taunting Kobold",
             "text": "Haste\nWhenever Taunting Kobold attacks, goad target creature an opponent controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "99217a70-db44-5613-8cfd-1b21718f56fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07f8fc3-83a5-4e0a-b87f-ce415292c790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07f8fc3-83a5-4e0a-b87f-ce415292c790.jpg?1",
             "name": "Tavern Brawler",
             "text": "Commander creatures you own have \"At the beginning of your upkeep, exile the top card of your library. This creature gets +X/+0 until end of turn, where X is that card's mana value. You may play that card this turn.\"",
             "colours": [
@@ -7669,7 +7669,7 @@
         },
         {
             "id": "3fbe3439-b59e-59d1-99b2-a5ca39b8dd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9531098-63ea-4568-81e9-80e00a5f8995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9531098-63ea-4568-81e9-80e00a5f8995.jpg?1",
             "name": "Thunderwave",
             "text": "Roll a d20.\n1\u20139 | Thunderwave deals 3 damage to each creature.\n10\u201319 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.\n20 | Thunderwave deals 6 damage to each creature your opponents control.",
             "colours": [
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "9ba7a104-1520-5b6d-85d3-8ccf815bacdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279c2ec3-abfc-4054-bdd9-3c8fa7d8b426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279c2ec3-abfc-4054-bdd9-3c8fa7d8b426.jpg?1",
             "name": "Tiamat's Fanatics",
             "text": "Haste\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -7736,7 +7736,7 @@
         },
         {
             "id": "bcb60fa7-8613-52f7-8dc4-bd209608dc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg?1",
             "name": "Two-Handed Axe // Sweeping Cleave",
             "text": "Whenever equipped creature attacks, double its power until end of turn.\nEquip {1}{R}",
             "colours": [
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "971c286f-9458-5288-9ed0-7a763a62906c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg?1",
             "name": "Two-Handed Axe // Sweeping Cleave",
             "text": "Target creature you control gains double strike until end of turn. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "a391e0a5-bd49-53cc-aa81-4282a035e998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df67ec01-9d4c-4ae1-9c8a-f94d649c81bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df67ec01-9d4c-4ae1-9c8a-f94d649c81bc.jpg?1",
             "name": "Wand of Wonder",
             "text": "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1\u20139 | X is one.\n10\u201319 | X is two.\n20 | X is three.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "d8824837-e01b-5154-9ea2-b5cc2fd295cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7a5951-4f71-47a0-ad80-f236f61d3f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7a5951-4f71-47a0-ad80-f236f61d3f22.jpg?1",
             "name": "Warehouse Thief",
             "text": "{2}, {T}, Sacrifice an artifact or creature: Exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -7874,7 +7874,7 @@
         },
         {
             "id": "9be143bb-a097-588b-b78e-141df7afaea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c89d88-9d40-46b6-bee0-6bc2e2ca8ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c89d88-9d40-46b6-bee0-6bc2e2ca8ba1.jpg?1",
             "name": "Wild Magic Surge",
             "text": "Destroy target permanent an opponent controls. Its controller reveals cards from the top of their library until they reveal a permanent card that shares a card type with that permanent. They put that card onto the battlefield and the rest on the bottom of their library in a random order.",
             "colours": [
@@ -7906,7 +7906,7 @@
         },
         {
             "id": "b1bccb2f-9028-5247-870f-f65066298317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd207de-eec3-4d82-b8b9-b1e60a7bad12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd207de-eec3-4d82-b8b9-b1e60a7bad12.jpg?1",
             "name": "Wrathful Red Dragon",
             "text": "Flying\nWhenever a Dragon you control is dealt damage, it deals that much damage to any target that isn't a Dragon.",
             "colours": [
@@ -7942,7 +7942,7 @@
         },
         {
             "id": "0760b7dd-4c1e-5294-91e9-58ce0d9ef66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9d4562-964d-48ce-b03f-7cb491fa040d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9d4562-964d-48ce-b03f-7cb491fa040d.jpg?1",
             "name": "Wyll, Blade of Frontiers",
             "text": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\nWhenever you roll one or more dice, put a +1/+1 counter on Wyll, Blade of Frontiers.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -7982,7 +7982,7 @@
         },
         {
             "id": "5c5a2561-82cc-55d5-b8d3-7a82b771ae72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8df219-1da0-4311-b9bb-c74b5fa55293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8df219-1da0-4311-b9bb-c74b5fa55293.jpg?1",
             "name": "Wyll's Reversal",
             "text": "Choose target spell or ability with one or more targets. Roll a d20 and add the greatest power among creatures you control.\n1\u201314 | You may choose new targets for that spell or ability.\n15+ | You may choose new targets for that spell or ability. Then copy it. You may choose new targets for the copy.",
             "colours": [
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "b9d9cc91-5c8e-56b8-b7fc-abb41e5644f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg?1",
             "name": "Young Red Dragon // Bathe in Gold",
             "text": "Flying\nYoung Red Dragon can't block.",
             "colours": [
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "6472915d-6d47-5a27-ba15-65f4d793ea7e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg?1",
             "name": "Young Red Dragon // Bathe in Gold",
             "text": "Create a Treasure token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8084,7 +8084,7 @@
         },
         {
             "id": "fc7b703a-d727-5e13-a10c-55c0f7d85423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82730ad9-26d1-4349-a1f0-10307d76ad97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82730ad9-26d1-4349-a1f0-10307d76ad97.jpg?1",
             "name": "You've Been Caught Stealing",
             "text": "Choose one \u2014\n\u2022 Threaten the Merchant \u2014 Each creature blocks this turn if able.\n\u2022 Bribe the Guards \u2014 You create a Treasure token for each opponent who was dealt damage this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "6764837c-0e0b-5c6f-b689-a1aa007a221f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0260e1f-ff6a-4ef3-bef7-8c77f8413500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0260e1f-ff6a-4ef3-bef7-8c77f8413500.jpg?1",
             "name": "Acolyte of Bahamut",
             "text": "Commander creatures you own have \"The first Dragon spell you cast each turn costs {2} less to cast.\"",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "869c508b-2596-582a-86ce-4444a44d5712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e56a516-d71a-49c4-a929-9a8973125d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e56a516-d71a-49c4-a929-9a8973125d3c.jpg?1",
             "name": "Ambitious Dragonborn",
             "text": "Ambitious Dragonborn enters the battlefield with X +1/+1 counters on it, where X is the greatest power among creatures you control and creature cards in your graveyard.",
             "colours": [
@@ -8189,7 +8189,7 @@
         },
         {
             "id": "6609150b-1381-586c-b83b-cb64dc4dfb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781af4dd-9e3c-48af-80e9-b52c427d2120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781af4dd-9e3c-48af-80e9-b52c427d2120.jpg?1",
             "name": "Ancient Bronze Dragon",
             "text": "Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.",
             "colours": [
@@ -8227,7 +8227,7 @@
         },
         {
             "id": "d0ac15f2-0d57-5d5c-b3ba-987d6603e101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4072640-0f9b-4f0a-84cc-eda415cc92e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4072640-0f9b-4f0a-84cc-eda415cc92e7.jpg?1",
             "name": "Avenging Hunter",
             "text": "Trample\nWhen Avenging Hunter enters the battlefield, you take the initiative.",
             "colours": [
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "0df799a1-6e04-5ace-874a-96d4f0339170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c454312c-ba0d-4b93-a3f5-e7764fcfbe20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c454312c-ba0d-4b93-a3f5-e7764fcfbe20.jpg?1",
             "name": "Band Together",
             "text": "Up to two target creatures you control each deal damage equal to their power to another target creature.",
             "colours": [
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "2226feb7-ae16-5ef5-b446-849d79f693ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452a08e-1a04-432f-9c35-11699d7d44fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452a08e-1a04-432f-9c35-11699d7d44fe.jpg?1",
             "name": "Barroom Brawl",
             "text": "Target creature you control fights target creature the opponent to your left controls. Then that player may copy this spell and may choose new targets for the copy.",
             "colours": [
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "c9590242-c4cd-5dfe-a9eb-13b31e618863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fae6a19-6a16-443e-adae-78a7380ee012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fae6a19-6a16-443e-adae-78a7380ee012.jpg?1",
             "name": "Bramble Sovereign",
             "text": "Whenever another nontoken creature enters the battlefield, you may pay {1}{G}. If you do, that creature's controller creates a token that's a copy of that creature.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "6661999f-70c6-5c99-aa7e-cb0d6e5046de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8d2b97-72b9-4bde-ad31-fd9562512d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8d2b97-72b9-4bde-ad31-fd9562512d30.jpg?1",
             "name": "Carefree Swinemaster",
             "text": "Whenever Carefree Swinemaster attacks, you may pay {1}{G}. If you do, create a 2/2 green Boar creature token that's tapped and attacking.",
             "colours": [
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "f408ac5a-8311-5211-97f3-02102eb65741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e84fc74-5b33-423a-82c7-983320fce7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e84fc74-5b33-423a-82c7-983320fce7a3.jpg?1",
             "name": "Circle of the Land Druid",
             "text": "When Circle of the Land Druid enters the battlefield, you may mill four cards. (You may put the top four cards of your library into your graveyard.)\nNatural Recovery \u2014 When Circle of the Land Druid dies, return target land card from your graveyard to your hand.",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "1a245e18-75a4-519c-9e1b-9dadd8114a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8689d-a0c1-4041-bead-7b512fe25663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8689d-a0c1-4041-bead-7b512fe25663.jpg?1",
             "name": "Cloakwood Hermit",
             "text": "Commander creatures you own have \"At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens.\"",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "b2354898-392f-5754-930c-de3761fe4805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6918a85-1a10-4a73-917c-23bd0a877a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6918a85-1a10-4a73-917c-23bd0a877a04.jpg?1",
             "name": "Cloakwood Swarmkeeper",
             "text": "Gathered Swarm \u2014 Whenever one or more tokens enter the battlefield under your control, put a +1/+1 counter on Cloakwood Swarmkeeper.",
             "colours": [
@@ -8507,7 +8507,7 @@
         },
         {
             "id": "2f64353f-2221-55e3-8483-2b69f13f1917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg?1",
             "name": "Colossal Badger // Dig Deep",
             "text": "When Colossal Badger enters the battlefield, you gain 3 life.",
             "colours": [
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "9c27836f-06bc-5254-95d6-5c52937c1ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg?1",
             "name": "Colossal Badger // Dig Deep",
             "text": "Choose target creature. Mill four cards, then put a +1/+1 counter on that creature for each creature card milled this way.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "0a3c96df-591f-5780-8890-ce6bc6f72714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9bf864-1f93-4d73-a212-f71265411768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9bf864-1f93-4d73-a212-f71265411768.jpg?1",
             "name": "Draconic Muralists",
             "text": "When Draconic Muralists dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "86de47d2-867a-550c-8bac-02ed760141e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg?1",
             "name": "Dread Linnorm // Scale Deflection",
             "text": "Dread Linnorm can't be blocked by creatures with power 3 or less.",
             "colours": [
@@ -8645,7 +8645,7 @@
         },
         {
             "id": "556875d8-6386-59a2-879a-b2b34963a140",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg?1",
             "name": "Dread Linnorm // Scale Deflection",
             "text": "Put two +1/+1 counters on target creature and untap it. It gains hexproof until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8679,7 +8679,7 @@
         },
         {
             "id": "22550aeb-12c0-551f-a491-761440edc7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a270d07-29da-4c31-ae6a-5f60c162f508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a270d07-29da-4c31-ae6a-5f60c162f508.jpg?1",
             "name": "Druid of the Emerald Grove",
             "text": "When Druid of the Emerald Grove enters the battlefield, search your library for up to two basic land cards and reveal them, then roll a d20.\n1\u20139 | Put those cards into your hand, then shuffle.\n10\u201319 | Put one of those cards onto the battlefield tapped and the other into your hand, then shuffle.\n20 | Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -8714,7 +8714,7 @@
         },
         {
             "id": "465ed5b6-5a09-5a54-8986-826f4b604091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54935597-b5d0-476d-82f3-42a9201e4556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54935597-b5d0-476d-82f3-42a9201e4556.jpg?1",
             "name": "Druidic Ritual",
             "text": "You may mill three cards. Then return up to one creature card and up to one land card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "ffa22e79-07f0-58ae-9178-bfdff14d495a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedfd30-8075-429e-a0fa-4919920c8632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedfd30-8075-429e-a0fa-4919920c8632.jpg?1",
             "name": "Earthquake Dragon",
             "text": "This spell costs {X} less to cast, where X is the total mana value of Dragons you control.\nFlying, trample\n{2}{G}, Sacrifice a land: Return Earthquake Dragon from your graveyard to your hand.",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "d8404b87-e9ab-5e32-8256-fa5d6f198a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg?1",
             "name": "Emerald Dragon // Dissonant Wave",
             "text": "Flying, trample",
             "colours": [
@@ -8817,7 +8817,7 @@
         },
         {
             "id": "a4c9a58e-6406-5b6c-a3ff-b796036434f1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg?1",
             "name": "Emerald Dragon // Dissonant Wave",
             "text": "Counter target activated or triggered ability from a noncreature source. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "81629b7c-4a6f-556f-91b4-54986a456628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7d041-957a-4b19-9517-214689dadd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7d041-957a-4b19-9517-214689dadd45.jpg?1",
             "name": "Erinis, Gloom Stalker",
             "text": "Deathtouch\nWhenever Erinis, Gloom Stalker attacks, return target land card from your graveyard to the battlefield.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "64a44ebb-09f5-5b3a-96b6-fe422ca2a3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg?1",
             "name": "Ettercap // Web Shot",
             "text": "Reach",
             "colours": [
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "53b24747-3f62-56c8-b6b1-f270be4b9fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg?1",
             "name": "Ettercap // Web Shot",
             "text": "Destroy target creature with flying. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "ce188c75-4ed3-5d69-a040-c47cf855849d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbf06f5-d1c7-474c-8f09-72f5ad0c8120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbf06f5-d1c7-474c-8f09-72f5ad0c8120.jpg?1",
             "name": "Explore the Underdark",
             "text": "Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle.\nYou take the initiative.",
             "colours": [
@@ -8992,7 +8992,7 @@
         },
         {
             "id": "e7c5354b-19e2-5767-b206-d7521a659072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc420f2c-09fa-4f90-a1c3-7d151ecaa8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc420f2c-09fa-4f90-a1c3-7d151ecaa8b3.jpg?1",
             "name": "Giant Ankheg",
             "text": "Trample\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nOther creatures you control have trample and ward {2}.",
             "colours": [
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "cfeadd68-f55d-5024-b407-0480cc6a8020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e5c-b6f9-4d36-a6b1-d7315de38fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e5c-b6f9-4d36-a6b1-d7315de38fca.jpg?1",
             "name": "Halsin, Emerald Archdruid",
             "text": "{1}: Until end of turn, target token you control becomes a green Bear creature with base power and toughness 4/4 in addition to its other colors and types.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "0f691067-55bd-5cce-a9dd-0ba04d3cea27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44498893-3ff8-4d1e-abdf-4579e0c67020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44498893-3ff8-4d1e-abdf-4579e0c67020.jpg?1",
             "name": "Hardy Outlander",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, another target creature you control gets +X/+X until end of turn, where X is this creature's power.\"",
             "colours": [
@@ -9104,7 +9104,7 @@
         },
         {
             "id": "a3299285-dbe1-57a0-84ad-9851e3b8e695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b32bae4-65e4-4bdb-8bc5-b98a5aac1568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b32bae4-65e4-4bdb-8bc5-b98a5aac1568.jpg?1",
             "name": "Jade Orb of Dragonkind",
             "text": "{T}: Add {G}. When you spend this mana to cast a Dragon creature spell, it enters the battlefield with an additional +1/+1 counter on it and gains hexproof until your next turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "3a780e9f-15db-5a8f-88ea-bbeba2b38ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb7ad1b-4466-48f7-b46d-cc83d4e22b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb7ad1b-4466-48f7-b46d-cc83d4e22b51.jpg?1",
             "name": "Jaheira, Friend of the Forest",
             "text": "Tokens you control have \"{T}: Add {G}.\"\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -9177,7 +9177,7 @@
         },
         {
             "id": "842680e2-6d37-52ff-ad28-1858a354202e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ce0b01-7b52-4cb9-86ea-13395cf52312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ce0b01-7b52-4cb9-86ea-13395cf52312.jpg?1",
             "name": "Jaheira's Respite",
             "text": "Search your library for up to X basic land cards, where X is the number of creatures attacking you, put those cards onto the battlefield tapped, then shuffle.\nPrevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -9211,7 +9211,7 @@
         },
         {
             "id": "a509a8dd-b1ce-521c-8bb5-d281210460cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de5a3e-7b08-438b-866e-9fce1a36b243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de5a3e-7b08-438b-866e-9fce1a36b243.jpg?1",
             "name": "Lurking Green Dragon",
             "text": "Flying\nLurking Green Dragon can't attack unless defending player controls a creature with flying.",
             "colours": [
@@ -9245,7 +9245,7 @@
         },
         {
             "id": "f031f0f5-cbee-5d8d-9b50-a9d8d82f11fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaadb067-4a77-4d6e-931d-447bd0c06594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaadb067-4a77-4d6e-931d-447bd0c06594.jpg?1",
             "name": "Majestic Genesis",
             "text": "Reveal the top X cards of your library, where X is the greatest mana value of a commander you own on the battlefield or in the command zone. You may put any number of permanent cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "da1b7343-372d-5f94-b391-a4a4f89accb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b534b1cb-0cd7-4b8c-bb25-42207fcba209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b534b1cb-0cd7-4b8c-bb25-42207fcba209.jpg?1",
             "name": "Master Chef",
             "text": "Commander creatures you own have \"This creature enters the battlefield with an additional +1/+1 counter on it\" and \"Other creatures you control enter the battlefield with an additional +1/+1 counter on them.\"",
             "colours": [
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "18f53fac-dbd3-57a9-b7b3-caf6466706bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "{1}{G}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -9351,7 +9351,7 @@
         },
         {
             "id": "80779d61-8562-5cf8-b3d6-396d92672243",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "Mill five cards, then return a creature card milled this way to your hand. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "c6a1dae6-26b9-5092-a1e5-0a2b5102189a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70408d70-1e4b-41f0-80b1-0d37b3a3918c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70408d70-1e4b-41f0-80b1-0d37b3a3918c.jpg?1",
             "name": "Myconid Spore Tender",
             "text": "Infesting Spores \u2014 When Myconid Spore Tender enters the battlefield, destroy up to one target artifact or enchantment.",
             "colours": [
@@ -9421,7 +9421,7 @@
         },
         {
             "id": "6d74aa93-3527-5b4e-a67a-4269ee38eb74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d1e79-cac6-455c-9fda-f13c849579d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d1e79-cac6-455c-9fda-f13c849579d6.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -9453,7 +9453,7 @@
         },
         {
             "id": "ea499ec3-74bd-5767-90f6-ea8c7f869f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c498c-ac7c-4e58-8789-9bde047c2d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c498c-ac7c-4e58-8789-9bde047c2d47.jpg?1",
             "name": "Overwhelming Encounter",
             "text": "Creatures you control gain vigilance and trample until end of turn. Roll a d20.\n1\u20139 | Creatures you control get +2/+2 until end of turn.\n10\u201319 | Put two +1/+1 counters on each creature you control.\n20 | Put four +1/+1 counters on each creature you control.",
             "colours": [
@@ -9485,7 +9485,7 @@
         },
         {
             "id": "e532d3de-58aa-501c-9811-b51aa47662ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be177b66-dab3-47ef-bcdf-8d99eb57e19f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be177b66-dab3-47ef-bcdf-8d99eb57e19f.jpg?1",
             "name": "Owlbear Cub",
             "text": "Mama's Coming \u2014 Whenever Owlbear Cub attacks a player who controls eight or more lands, look at the top eight cards of your library. You may put a creature card from among them onto the battlefield tapped and attacking that player. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "d90081fe-23a5-5f7c-b608-27e72d5ff7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4813b2-3fd7-4a2b-b87a-9ce5bb18bdd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4813b2-3fd7-4a2b-b87a-9ce5bb18bdd4.jpg?1",
             "name": "Owlbear Shepherd",
             "text": "At the beginning of your end step, if creatures you control have total power 8 or greater, draw a card.",
             "colours": [
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "af0e7f5e-c353-5e5c-8124-0e515547d701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4bf10-a502-4748-9118-5459684542a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4bf10-a502-4748-9118-5459684542a7.jpg?1",
             "name": "Poison the Blade",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -9589,7 +9589,7 @@
         },
         {
             "id": "3395d70e-516e-5b9e-aabd-acb21ff85ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0077099d-aafa-46b3-ab64-e1915a9dda70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0077099d-aafa-46b3-ab64-e1915a9dda70.jpg?1",
             "name": "Predatory Impetus",
             "text": "Enchant creature\nEnchanted creature gets +3/+3, must be blocked if able, and is goaded. (It attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "95278a38-f476-5697-97fc-0484b160479b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c93414-935e-462b-ad89-27ca21d01bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c93414-935e-462b-ad89-27ca21d01bf9.jpg?1",
             "name": "Raised by Giants",
             "text": "Commander creatures you own have base power and toughness 10/10 and are Giants in addition to their other types.",
             "colours": [
@@ -9661,7 +9661,7 @@
         },
         {
             "id": "aa09cf65-7bff-5165-8b42-43a15d2d5ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc8d802-33bd-48c1-bb4f-31fefac85a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc8d802-33bd-48c1-bb4f-31fefac85a5a.jpg?1",
             "name": "Saddle of the Cavalier",
             "text": "Equipped creature gets +3/+3 and can't be blocked by creatures with power 3 or less.\nEquip {3}",
             "colours": [
@@ -9695,7 +9695,7 @@
         },
         {
             "id": "91e46046-44fd-583c-953b-2019d24711b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae5a76-b8b9-431d-8060-a6a96f5d1e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae5a76-b8b9-431d-8060-a6a96f5d1e0b.jpg?1",
             "name": "Scaled Nurturer",
             "text": "{T}: Add {G}. When you spend this mana to cast a Dragon creature spell, you gain 2 life.",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "63f9b5af-d4a3-5141-af6b-b004d82319bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcd60dc-9534-412d-af48-31fcd8ea0843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcd60dc-9534-412d-af48-31fcd8ea0843.jpg?1",
             "name": "Sharpshooter Elf",
             "text": "Reach\nSharpshooter Elf's power is equal to the number of creatures you control.\nWhen Sharpshooter Elf enters the battlefield, it deals damage equal to its power to target creature with flying an opponent controls.",
             "colours": [
@@ -9765,7 +9765,7 @@
         },
         {
             "id": "d77f96f6-fef4-52ff-a9d6-a5d6ae77a234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd1bb8-013b-4028-becd-e0cb4b84f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd1bb8-013b-4028-becd-e0cb4b84f1ad.jpg?1",
             "name": "Silvanus's Invoker",
             "text": "Conjure Elemental \u2014 {8}: Untap target land you control. It becomes an 8/8 Elemental creature with trample and haste until end of turn. It's still a land.",
             "colours": [
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "0b3482ad-c206-5b61-9314-315d9013227e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9233c-9d9f-480b-89fb-54d74d63a17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9233c-9d9f-480b-89fb-54d74d63a17a.jpg?1",
             "name": "Skanos Dragonheart",
             "text": "Whenever Skanos Dragonheart attacks, it gets +X/+X until end of turn, where X is the greatest power among other Dragons you control and Dragon cards in your graveyard.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "54d86ba7-e113-504c-9f4b-29661fb37d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d406ed-bf60-4adc-9721-e64d1313f6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d406ed-bf60-4adc-9721-e64d1313f6b7.jpg?1",
             "name": "Skullwinder",
             "text": "Deathtouch\nWhen Skullwinder enters the battlefield, return target card from your graveyard to your hand, then choose an opponent. That player returns a card from their graveyard to their hand.",
             "colours": [
@@ -9874,7 +9874,7 @@
         },
         {
             "id": "e9d8aa9d-d611-5ce9-b2db-3a3bba20d17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55893f8b-0fea-40a5-b96d-954c99938810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55893f8b-0fea-40a5-b96d-954c99938810.jpg?1",
             "name": "Split the Spoils",
             "text": "Exile up to five target permanent cards from your graveyard and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)",
             "colours": [
@@ -9906,7 +9906,7 @@
         },
         {
             "id": "98097480-e58f-5003-9512-1852b2da9a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef192364-713a-42ff-8249-69a73ae61bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef192364-713a-42ff-8249-69a73ae61bd8.jpg?1",
             "name": "Traverse the Outlands",
             "text": "Search your library for up to X basic land cards, where X is the greatest power among creatures you control. Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -9940,7 +9940,7 @@
         },
         {
             "id": "db5ff9c5-0eb7-5524-b868-47b54e9d7897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c5b3e-737f-4794-b482-af5f0ee901e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c5b3e-737f-4794-b482-af5f0ee901e5.jpg?1",
             "name": "Undercellar Myconid",
             "text": "Whenever Undercellar Myconid enters the battlefield or dies, create a 1/1 green Saproling creature token.\n{T}: Add one mana of any color.",
             "colours": [
@@ -9974,7 +9974,7 @@
         },
         {
             "id": "3c0fd201-237f-5ec0-bb29-58b0ec1b7721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f53a3-521f-4463-a0b6-758a45d8f661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f53a3-521f-4463-a0b6-758a45d8f661.jpg?1",
             "name": "Undermountain Adventurer",
             "text": "Vigilance\nWhen Undermountain Adventurer enters the battlefield, you take the initiative.\n{T}: Add {G}{G}. If you've completed a dungeon, add six {G} instead.",
             "colours": [
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "81a24226-1309-54cf-9b4b-2b5a905a0b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe0daf8-43da-484b-baa1-76f8313c5a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe0daf8-43da-484b-baa1-76f8313c5a0c.jpg?1",
             "name": "Wilson, Refined Grizzly",
             "text": "This spell can't be countered.\nVigilance, reach, trample\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -10051,7 +10051,7 @@
         },
         {
             "id": "f351451b-724b-5685-a262-94a3881979bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f00a908-1898-48e9-8b04-88c2450b2dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f00a908-1898-48e9-8b04-88c2450b2dd3.jpg?1",
             "name": "You Look Upon the Tarrasque",
             "text": "Choose one \u2014\n\u2022 Run and Hide \u2014 Prevent all combat damage that would be dealt to you and creatures you control this turn.\n\u2022 Gather Your Courage \u2014 Target creature gets +5/+5 and gains indestructible until end of turn. All creatures your opponents control able to block that creature this turn do so.",
             "colours": [
@@ -10083,7 +10083,7 @@
         },
         {
             "id": "622288e4-52c2-5026-9dc7-7201b630558f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddbd7a-799c-4432-810c-d839c5c354b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddbd7a-799c-4432-810c-d839c5c354b9.jpg?1",
             "name": "You Meet in a Tavern",
             "text": "Choose one \u2014\n\u2022 Form a Party \u2014 Look at the top five cards of your library. You may reveal any number of creature cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.\n\u2022 Start a Brawl \u2014 Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -10115,7 +10115,7 @@
         },
         {
             "id": "c1233ea7-dd70-5c29-960f-791a366042df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c33bb-47fe-4334-9105-00f4b87811bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c33bb-47fe-4334-9105-00f4b87811bd.jpg?1",
             "name": "Alaundo the Seer",
             "text": "{T}: Draw a card, then exile a card from your hand and put a number of time counters on it equal to its mana value. It gains \"When the last time counter is removed from this card, if it's exiled, you may cast it without paying its mana cost. If you cast a creature spell this way, it gains haste until end of turn.\" Then remove a time counter from each other card you own in exile.",
             "colours": [
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "6fb43831-6b0a-5218-9de2-d00db14a18d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d932b9-5682-4427-a871-7d452a488674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d932b9-5682-4427-a871-7d452a488674.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "Deathtouch, lifelink\nAt the beginning of your end step, choose one \u2014\n\u2022 Feed \u2014 Target opponent loses life equal to the amount of life they lost this turn.\n\u2022 Friends \u2014 You gain life equal to the amount of life you gained this turn.",
             "colours": [
@@ -10200,7 +10200,7 @@
         },
         {
             "id": "d65a0708-7309-508c-a088-98c86392b5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef42c3f-f22e-4e99-adb0-9e8f8d442347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef42c3f-f22e-4e99-adb0-9e8f8d442347.jpg?1",
             "name": "Baba Lysaga, Night Witch",
             "text": "{T}, Sacrifice up to three permanents: If there were three or more card types among the sacrificed permanents, each opponent loses 3 life, you gain 3 life, and you draw three cards.",
             "colours": [
@@ -10242,7 +10242,7 @@
         },
         {
             "id": "facfdd97-3e6a-5491-8837-a6cf430838bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a576d17-693d-4cc1-bb5b-bf81c74de03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a576d17-693d-4cc1-bb5b-bf81c74de03b.jpg?1",
             "name": "Bane, Lord of Darkness",
             "text": "As long as your life total is less than or equal to half your starting life total, Bane, Lord of Darkness has indestructible.\nWhenever another nontoken creature you control dies, target opponent may have you draw a card. If they don't, you may put a creature card with equal or lesser toughness from your hand onto the battlefield.",
             "colours": [
@@ -10285,7 +10285,7 @@
         },
         {
             "id": "7f531935-7985-580c-a932-6272e5baef73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b11da8-f9af-4ef3-9bc2-c28f0a8a5dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b11da8-f9af-4ef3-9bc2-c28f0a8a5dd1.jpg?1",
             "name": "Bhaal, Lord of Murder",
             "text": "As long as your life total is less than or equal to half your starting life total, Bhaal, Lord of Murder has indestructible.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on target creature and goad it.",
             "colours": [
@@ -10328,7 +10328,7 @@
         },
         {
             "id": "6b42c91e-effc-5a31-be3d-0b46cd489840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75994e0b-b0c7-4b0d-8f48-4be303429bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75994e0b-b0c7-4b0d-8f48-4be303429bd6.jpg?1",
             "name": "Cadira, Caller of the Small",
             "text": "Trample\nWhenever Cadira, Caller of the Small deals combat damage to a player, for each token you control, create a 1/1 white Rabbit creature token.",
             "colours": [
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "938f21bc-21b9-5d11-ac38-fe71a513b311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8b247-455e-4a3f-9f88-b20918c36cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8b247-455e-4a3f-9f88-b20918c36cc3.jpg?1",
             "name": "Commander Liara Portyr",
             "text": "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards.",
             "colours": [
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "01ad1b3d-4372-53e8-8e3e-5ec04e442b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0873cfa8-046c-4b14-ae22-3fd6a691f763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0873cfa8-046c-4b14-ae22-3fd6a691f763.jpg?1",
             "name": "The Council of Four",
             "text": "Whenever a player draws their second card during their turn, you draw a card.\nWhenever a player casts their second spell during their turn, you create a 2/2 white Knight creature token.",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "5b513a4d-1a3d-5fca-a496-20c186819c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a8ffc-a052-498f-b457-8d70ea18a943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a8ffc-a052-498f-b457-8d70ea18a943.jpg?1",
             "name": "Duke Ulder Ravengard",
             "text": "At the beginning of combat on your turn, another target creature you control gains haste and myriad until end of turn. (Whenever it attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -10497,7 +10497,7 @@
         },
         {
             "id": "02947ad3-ba99-524f-8bf0-072a1c2f7b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c301b389-d802-4a8b-8681-9b50c8667423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c301b389-d802-4a8b-8681-9b50c8667423.jpg?1",
             "name": "Dynaheir, Invoker Adept",
             "text": "Haste\nYou may activate abilities of other creatures you control as though those creatures had haste.\n{T}: When you next activate an ability this turn by spending four or more mana to activate it, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "e7d3c679-75eb-59df-8a67-2c7fd924b9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eac2b49-6cb6-4ff4-8fac-2ba669326640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eac2b49-6cb6-4ff4-8fac-2ba669326640.jpg?1",
             "name": "Elminster",
             "text": "Whenever you scry, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of cards looked at while scrying this way.\n+2: Draw a card, then scry 2.\n\u22123: Exile the top card of your library. Create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to that card's mana value.\nElminster can be your commander.",
             "colours": [
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "e87d6797-99c2-5fbb-bbc4-8bbe9a9f456c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e889a-5865-4464-9923-bffa25c50cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e889a-5865-4464-9923-bffa25c50cd2.jpg?1",
             "name": "Gluntch, the Bestower",
             "text": "Flying\nAt the beginning of your end step, choose a player. They put two +1/+1 counters on a creature they control. Choose a second player to draw a card. Then choose a third player to create two Treasure tokens.",
             "colours": [
@@ -10622,7 +10622,7 @@
         },
         {
             "id": "717adb2e-cd70-5719-92ce-0fc510fbb42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1",
             "name": "Gorion, Wise Mentor",
             "text": "Vigilance\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
             "colours": [
@@ -10666,7 +10666,7 @@
         },
         {
             "id": "9f61e784-3be7-5e33-bbad-9eee0d2e6622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215a08-41db-4440-8e33-34a84a33db50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215a08-41db-4440-8e33-34a84a33db50.jpg?1",
             "name": "Jan Jansen, Chaos Crafter",
             "text": "Haste\n{T}, Sacrifice an artifact creature: Create two Treasure tokens.\n{T}, Sacrifice a noncreature artifact: Create two 1/1 colorless Construct artifact creature tokens.",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "efe9e85b-ea47-54e3-90ea-62d1947ef775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfddb61e-986f-4557-819d-d6c0ca85c74a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfddb61e-986f-4557-819d-d6c0ca85c74a.jpg?1",
             "name": "Jon Irenicus, Shattered One",
             "text": "At the beginning of your end step, target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it. It's goaded for the rest of the game and it gains \"This creature can't be sacrificed.\" (It attacks each combat if able and attacks a player other than you if able.)\nWhenever a creature you own but don't control attacks, you draw a card.",
             "colours": [
@@ -10752,7 +10752,7 @@
         },
         {
             "id": "fabbb438-d392-5458-97f1-d118210601fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6351adc8-2e44-4e5c-ae58-975b7332155e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6351adc8-2e44-4e5c-ae58-975b7332155e.jpg?1",
             "name": "Kagha, Shadow Archdruid",
             "text": "Whenever Kagha, Shadow Archdruid attacks, it gains deathtouch until end of turn. Mill two cards. (Put the top two cards of your library into your graveyard.)\nOnce during each of your turns, you may play a land or cast a permanent spell from among cards in your graveyard that were put there from your library this turn.",
             "colours": [
@@ -10794,7 +10794,7 @@
         },
         {
             "id": "63c311b5-e5ae-5974-8e0e-547f9ed39c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d08ac-6c24-4158-87a1-c59d1cd447a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d08ac-6c24-4158-87a1-c59d1cd447a8.jpg?1",
             "name": "Korlessa, Scale Singer",
             "text": "You may look at the top card of your library any time.\nYou may cast Dragon spells from the top of your library.",
             "colours": [
@@ -10836,7 +10836,7 @@
         },
         {
             "id": "a132296c-32ae-587f-8636-64cc3548bb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe604232-19da-4331-a6f2-ddb004f1dd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe604232-19da-4331-a6f2-ddb004f1dd90.jpg?1",
             "name": "Lozhan, Dragons' Legacy",
             "text": "Flying\nWhenever you cast an Adventure or Dragon spell, Lozhan, Dragons' Legacy deals damage equal to that spell's mana value to any target that isn't a commander.",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "166538c6-5136-59f8-a24c-684e908f91ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3da2b1a-76c5-4d36-bdf8-025b86f61eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3da2b1a-76c5-4d36-bdf8-025b86f61eb5.jpg?1",
             "name": "Mahadi, Emporium Master",
             "text": "At the beginning of your end step, create a Treasure token for each creature that died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -10919,7 +10919,7 @@
         },
         {
             "id": "c734994c-41aa-57ce-8d59-b014d47bae19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d79c221-e07a-41e1-b92f-dc057802449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d79c221-e07a-41e1-b92f-dc057802449c.jpg?1",
             "name": "Mazzy, Truesword Paladin",
             "text": "Whenever an enchanted creature attacks one of your opponents, it gets +2/+0 and gains trample until end of turn.\nWhenever an Aura you control is put into your graveyard from the battlefield, exile it. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -10963,7 +10963,7 @@
         },
         {
             "id": "325c59d6-e30e-5622-8776-45d2a821efe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a934590b-5c70-4f07-af67-fbe817a99531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a934590b-5c70-4f07-af67-fbe817a99531.jpg?1",
             "name": "Miirym, Sentinel Wyrm",
             "text": "Flying, ward {2}\nWhenever another nontoken Dragon enters the battlefield under your control, create a token that's a copy of it, except the token isn't legendary if that Dragon is legendary.",
             "colours": [
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "cfe9ad7d-67c3-56c1-b9f4-83eb9b4aa803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928036c9-11b8-493e-b9f2-8fbd3487cd19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928036c9-11b8-493e-b9f2-8fbd3487cd19.jpg?1",
             "name": "Minsc & Boo, Timeless Heroes",
             "text": "When Minsc & Boo, Timeless Heroes enters the battlefield and at the beginning of your upkeep, you may create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n+1: Put three +1/+1 counters on up to one target creature with trample or haste.\n\u22122: Sacrifice a creature. When you do, Minsc & Boo, Timeless Heroes deals X damage to any target, where X is that creature's power. If the sacrificed creature was a Hamster, draw X cards.\nMinsc & Boo, Timeless Heroes can be your commander.",
             "colours": [
@@ -11047,7 +11047,7 @@
         },
         {
             "id": "bde4774c-6945-5483-b5a6-08350f250d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9e944b-98fa-4aea-825d-b8b8a9d7ed47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9e944b-98fa-4aea-825d-b8b8a9d7ed47.jpg?1",
             "name": "Minthara, Merciless Soul",
             "text": "Ward {X}, where X is the number of experience counters you have.\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, you get an experience counter.\nCreatures you control get +1/+0 for each experience counter you have.",
             "colours": [
@@ -11089,7 +11089,7 @@
         },
         {
             "id": "6d5cf048-d915-5f14-8b26-2bb7caa4fffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82824d05-5215-459a-aa73-3c5a6be3d464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82824d05-5215-459a-aa73-3c5a6be3d464.jpg?1",
             "name": "Myrkul, Lord of Bones",
             "text": "As long as your life total is less than or equal to half your starting life total, Myrkul, Lord of Bones has indestructible.\nWhenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that card, except it's an enchantment and loses all other card types.",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "573ee749-6d2d-5109-8e4e-e564b777656c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5431f73-9a70-47dc-b5d4-7f43e41b878e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5431f73-9a70-47dc-b5d4-7f43e41b878e.jpg?1",
             "name": "Neera, Wild Mage",
             "text": "Whenever you cast a spell, you may put it on the bottom of its owner's library. If you do, reveal cards from the top of your library until you reveal a nonland card. You may cast that card without paying its mana cost. Then put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
             "colours": [
@@ -11175,7 +11175,7 @@
         },
         {
             "id": "649b9a67-a844-597d-816e-4928c03a9053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480ac0a-883a-4f73-8e7c-56d64be410a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480ac0a-883a-4f73-8e7c-56d64be410a3.jpg?1",
             "name": "Nine-Fingers Keene",
             "text": "Menace\nWard\u2014\nPay 9 life.\nWhenever Nine-Fingers Keene deals combat damage to a player, look at the top nine cards of your library. You may put a Gate card from among them onto the battlefield. Then if you control nine or more Gates, put the rest into your hand. Otherwise, put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11219,7 +11219,7 @@
         },
         {
             "id": "67c6cb58-8004-5cbb-a343-d69b56a83e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13129e63-558d-415d-87eb-616868205341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13129e63-558d-415d-87eb-616868205341.jpg?1",
             "name": "Oji, the Exquisite Blade",
             "text": "When Oji, the Exquisite Blade enters the battlefield, you gain 2 life and scry 2.\nWhenever you cast your second spell each turn, exile up to one target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -11261,7 +11261,7 @@
         },
         {
             "id": "9dbfc52d-c4da-54e4-9578-949ece69a060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1166ce2a-4e0b-4a57-929d-566f461a6282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1166ce2a-4e0b-4a57-929d-566f461a6282.jpg?1",
             "name": "Raggadragga, Goreguts Boss",
             "text": "Each creature you control with a mana ability gets +2/+2.\nWhenever a creature you control with a mana ability attacks, untap it.\nWhenever you cast a spell, if at least seven mana was spent to cast it, untap target creature. It gets +7/+7 and gains trample until end of turn.",
             "colours": [
@@ -11303,7 +11303,7 @@
         },
         {
             "id": "564f739c-222b-57aa-be67-c6a984fa8ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6902a4-2db0-47fe-ace8-0c890675bf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6902a4-2db0-47fe-ace8-0c890675bf19.jpg?1",
             "name": "Raphael, Fiendish Savior",
             "text": "Flying\nOther Demons, Devils, Imps, and Tieflings you control get +1/+1 and have lifelink.\nAt the beginning of each end step, if a creature card was put into your graveyard from anywhere this turn, create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -11345,7 +11345,7 @@
         },
         {
             "id": "e54aa6cb-c2ca-5371-b167-b49e60b51dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54484439-6f8a-47f1-8d62-4689af7f00c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54484439-6f8a-47f1-8d62-4689af7f00c2.jpg?1",
             "name": "Rilsa Rael, Kingpin",
             "text": "Deathtouch\nWhen Rilsa Rael, Kingpin enters the battlefield, you take the initiative.\nWhenever you attack, target attacking creature gains deathtouch until end of turn. If you've completed a dungeon, that creature also gets +5/+0 and gains first strike and menace until end of turn.",
             "colours": [
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "a848ea78-29b9-5ff9-89a8-bbdf5c39c4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c5f679-82d0-4434-9f13-d39ad57282b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c5f679-82d0-4434-9f13-d39ad57282b8.jpg?1",
             "name": "Tasha, the Witch Queen",
             "text": "Whenever you cast a spell you don't own, create a 3/3 black Demon creature token.\n+1: Draw a card. For each opponent, exile up to one target instant or sorcery card from that player's graveyard and put a page counter on it.\n\u22123: You may cast a spell from among cards in exile with page counters on them without paying its mana cost.\nTasha, the Witch Queen can be your commander.",
             "colours": [
@@ -11427,7 +11427,7 @@
         },
         {
             "id": "28243440-30c8-512f-91fa-db25c7775b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2255d1e4-f387-4187-8c10-7d0009f6ec79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2255d1e4-f387-4187-8c10-7d0009f6ec79.jpg?1",
             "name": "Thrakkus the Butcher",
             "text": "Trample\nWhenever Thrakkus the Butcher attacks, double the power of each Dragon you control until end of turn.",
             "colours": [
@@ -11469,7 +11469,7 @@
         },
         {
             "id": "1a23c5b1-233b-5875-9e39-77c94484e96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e51138-9745-465d-84dd-27605f8a2264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e51138-9745-465d-84dd-27605f8a2264.jpg?1",
             "name": "Zevlor, Elturel Exile",
             "text": "Haste\n{2}, {T}: When you next cast an instant or sorcery spell that targets a single opponent or a single permanent an opponent controls this turn, for each other opponent, choose that player or a permanent they control, copy that spell, and the copy targets the chosen player or permanent.",
             "colours": [
@@ -11513,7 +11513,7 @@
         },
         {
             "id": "8dc68bf3-47e9-547d-b5b1-2712e94224dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ff4cb8-a0e0-4527-a77d-03394065ffe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ff4cb8-a0e0-4527-a77d-03394065ffe0.jpg?1",
             "name": "Arcane Encyclopedia",
             "text": "{3}, {T}: Draw a card.",
             "colours": [],
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "7710df94-7399-5c1d-bed7-8b14d9cba963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b245a5b-5a99-4d22-99ef-3f5bf49c3262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b245a5b-5a99-4d22-99ef-3f5bf49c3262.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -11569,7 +11569,7 @@
         },
         {
             "id": "e65945c6-69bd-5a99-92ac-8098385ce3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f4b4f-4f48-4031-b62a-91a0d6716ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f4b4f-4f48-4031-b62a-91a0d6716ddd.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -11597,7 +11597,7 @@
         },
         {
             "id": "82066678-8c6e-512c-8c1b-f60002ba5c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a55efe-a870-4cd7-b22b-37c917065653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a55efe-a870-4cd7-b22b-37c917065653.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -11629,7 +11629,7 @@
         },
         {
             "id": "64abd632-6566-5173-93e0-810de62ba5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3367f8-5f5a-4205-909a-247b92a9c082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3367f8-5f5a-4205-909a-247b92a9c082.jpg?1",
             "name": "Blade of Selves",
             "text": "Equipped creature has myriad. (Whenever it attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\nEquip {4}",
             "colours": [],
@@ -11661,7 +11661,7 @@
         },
         {
             "id": "3e59ac89-490e-51bd-b725-7e003a8acb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cfd2c0-2110-47f1-809e-487b9b0a1043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cfd2c0-2110-47f1-809e-487b9b0a1043.jpg?1",
             "name": "Bronze Walrus",
             "text": "When Bronze Walrus enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{T}: Add one mana of any color.",
             "colours": [],
@@ -11692,7 +11692,7 @@
         },
         {
             "id": "49396d26-86fe-5189-8d1f-4ce48ab4150b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c3f711-7191-4621-b36e-6c1e281216e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c3f711-7191-4621-b36e-6c1e281216e2.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "53455dfe-459c-5030-9f6e-f2d919d26820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba581225-0966-4ff0-be04-1ad11f37937f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba581225-0966-4ff0-be04-1ad11f37937f.jpg?1",
             "name": "Campfire",
             "text": "{1}, {T}: You gain 2 life.\n{2}, {T}, Exile Campfire: Put all commanders you own from the command zone and from your graveyard into your hand. Then shuffle your graveyard into your library.",
             "colours": [],
@@ -11751,7 +11751,7 @@
         },
         {
             "id": "89139d12-93d0-5248-80cb-5ae9b4610348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0475c79-bc7f-4de8-a020-226bc658d303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0475c79-bc7f-4de8-a020-226bc658d303.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "c5e6fc51-05f3-559b-aa10-c87fbb8daed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a950d8be-dcf7-4253-a3cc-c040ba632355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a950d8be-dcf7-4253-a3cc-c040ba632355.jpg?1",
             "name": "Chardalyn Dragon",
             "text": "Flying",
             "colours": [],
@@ -11814,7 +11814,7 @@
         },
         {
             "id": "da59f561-53fb-580a-acc9-485f9e10cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f508a65-ff32-480a-b9c6-075074d0c3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f508a65-ff32-480a-b9c6-075074d0c3c3.jpg?1",
             "name": "Cloak of the Bat",
             "text": "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11846,7 +11846,7 @@
         },
         {
             "id": "aa033eca-ac9d-59c6-a398-f2c8097d6008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbb37d7-7053-4b1f-b899-91695f88f7e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbb37d7-7053-4b1f-b899-91695f88f7e0.jpg?1",
             "name": "Clockwork Fox",
             "text": "When Clockwork Fox leaves the battlefield, you draw two cards and each opponent draws a card.",
             "colours": [],
@@ -11877,7 +11877,7 @@
         },
         {
             "id": "9e8adabe-f191-59a4-a8c8-6c7b5d94973a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bbc36-58ea-44c4-a857-75a3aff058f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bbc36-58ea-44c4-a857-75a3aff058f5.jpg?1",
             "name": "Decanter of Endless Water",
             "text": "You have no maximum hand size.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -11907,7 +11907,7 @@
         },
         {
             "id": "921b22ac-5021-5355-a3f6-875349cb425b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e29bae1-0643-4781-9edc-50a8e6d1a3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e29bae1-0643-4781-9edc-50a8e6d1a3a1.jpg?1",
             "name": "Dire Mimic",
             "text": "Flash\n{T}, Sacrifice Dire Mimic: Add one mana of any color.\n{3}: Dire Mimic becomes a Shapeshifter artifact creature with base power and toughness 5/5 until end of turn.",
             "colours": [],
@@ -11937,7 +11937,7 @@
         },
         {
             "id": "46d5290a-27b5-508b-830a-3e21239f92ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9803002e-08f8-4533-b645-7e54d18bbc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9803002e-08f8-4533-b645-7e54d18bbc54.jpg?1",
             "name": "Drillworks Mole",
             "text": "{2}, {T}: Put a +1/+1 counter on Drillworks Mole and a +1/+1 counter on up to one target commander creature you control.",
             "colours": [],
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "4314997f-29ac-5d05-94aa-cbe658c0b61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74e656-480a-4c1b-963d-1b207075c27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74e656-480a-4c1b-963d-1b207075c27f.jpg?1",
             "name": "Dungeoneer's Pack",
             "text": "Dungeoneer's Pack enters the battlefield tapped.\n{2}, {T}, Sacrifice Dungeoneer's Pack: You take the initiative, gain 3 life, draw a card, and create a Treasure token. Activate only as a sorcery. (A Treasure token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -11996,7 +11996,7 @@
         },
         {
             "id": "3eb6a40c-e9c9-5bcb-a9f1-2b2b67422041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561484-438b-4ce9-911e-97078ac5b0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561484-438b-4ce9-911e-97078ac5b0fa.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -12028,7 +12028,7 @@
         },
         {
             "id": "44122479-67d1-5a15-9c86-2a52a5472361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bf7702-c97d-4b88-b815-769c4906e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bf7702-c97d-4b88-b815-769c4906e014.jpg?1",
             "name": "Fraying Line",
             "text": "When Fraying Line enters the battlefield, put a rope counter on target creature you control.\nAt the beginning of each player's upkeep, that player may pay {2}. If they do, they put a rope counter on a creature they control. Otherwise, exile Fraying Line and each creature without a rope counter on it, then remove all rope counters from all creatures.",
             "colours": [],
@@ -12058,7 +12058,7 @@
         },
         {
             "id": "2fed6927-fc89-5dc6-a5ba-026cb3cb594c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2318e7-250d-4a30-8b45-55d4c1db68e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2318e7-250d-4a30-8b45-55d4c1db68e9.jpg?1",
             "name": "Gate Colossus",
             "text": "This spell costs {1} less to cast for each Gate you control.\nGate Colossus can't be blocked by creatures with power 2 or less.\nWhenever a Gate enters the battlefield under your control, you may put Gate Colossus from your graveyard on top of your library.",
             "colours": [],
@@ -12089,7 +12089,7 @@
         },
         {
             "id": "36757f1a-3132-5010-947c-e33ab03987ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdc8f60-fa67-4dd6-94af-8250eb7f7141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdc8f60-fa67-4dd6-94af-8250eb7f7141.jpg?1",
             "name": "Geode Golem",
             "text": "Trample\nWhenever Geode Golem deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost. (You still pay any additional costs.)",
             "colours": [],
@@ -12120,7 +12120,7 @@
         },
         {
             "id": "101833ff-36e9-5570-87bd-6e342f03fff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633151-d704-42a4-b1c6-66446bf48bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633151-d704-42a4-b1c6-66446bf48bee.jpg?1",
             "name": "Iron Mastiff",
             "text": "Whenever Iron Mastiff attacks, roll a d20 for each player being attacked and ignore all but the highest roll.\n1\u20139 | Iron Mastiff deals damage equal to its power to you.\n10\u201319 | Iron Mastiff deals damage equal to its power to defending player.\n20 | Iron Mastiff deals damage equal to its power to each opponent.",
             "colours": [],
@@ -12151,7 +12151,7 @@
         },
         {
             "id": "3140c896-09f0-521b-80fd-6f13345ef412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43d21a-4400-4770-95a9-ce074ee68232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43d21a-4400-4770-95a9-ce074ee68232.jpg?1",
             "name": "Lantern of Revealing",
             "text": "{T}: Add one mana of any color.\n{4}, {T}: Look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you don't put the card onto the battlefield, you may put it on the bottom of your library.",
             "colours": [],
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "5be13068-c9e5-5c33-af84-e39518641b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a15cd-a359-48c9-9280-ce139f1fb061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a15cd-a359-48c9-9280-ce139f1fb061.jpg?1",
             "name": "Manifold Key",
             "text": "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -12207,7 +12207,7 @@
         },
         {
             "id": "d5514901-4a08-5dbc-a75a-3aea3b5e2a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0930f71c-c3c8-4bdd-8468-6a61349cc8ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0930f71c-c3c8-4bdd-8468-6a61349cc8ca.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "866ce491-3f71-5034-b3ff-5ef871cdb1d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e46fc-1ebc-4151-bfd3-333fa6b77816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e46fc-1ebc-4151-bfd3-333fa6b77816.jpg?1",
             "name": "Marching Duodrone",
             "text": "Whenever Marching Duodrone attacks, each player creates a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12272,7 +12272,7 @@
         },
         {
             "id": "f83c8b23-049d-5494-9e6b-dda57de0e994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce857f-2870-4dc9-a763-9ce710e4b375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce857f-2870-4dc9-a763-9ce710e4b375.jpg?1",
             "name": "Marut",
             "text": "Trample\nWhen Marut enters the battlefield, if mana from a Treasure was spent to cast it, create a Treasure token for each mana from a Treasure spent to cast it. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12303,7 +12303,7 @@
         },
         {
             "id": "8d2b0b35-b12f-5673-abdf-518942bc0ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e17f8c-c705-43ab-ae1a-cde48aceca0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e17f8c-c705-43ab-ae1a-cde48aceca0a.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -12334,7 +12334,7 @@
         },
         {
             "id": "8f84ff81-4006-569c-9018-ae2fc3ea29cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257f12c2-db58-413f-9896-6e556bd9c0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257f12c2-db58-413f-9896-6e556bd9c0d9.jpg?1",
             "name": "Mighty Servant of Leuk-o",
             "text": "Trample\nWard\u2014\nDiscard a card.\nWhenever Mighty Servant of Leuk-o becomes crewed for the first time each turn, if it was crewed by exactly two creatures, it gains \"Whenever this creature deals combat damage to a player, draw two cards\" until end of turn.\nCrew 4",
             "colours": [],
@@ -12366,7 +12366,7 @@
         },
         {
             "id": "942054f5-de20-582f-bad6-dd4b48aee4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1969ddc0-ee6c-4c3d-a9dd-7f1c491609be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1969ddc0-ee6c-4c3d-a9dd-7f1c491609be.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -12394,7 +12394,7 @@
         },
         {
             "id": "ef12e1e4-78e0-5356-9067-19fd575c3340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0937a60-887b-46d0-b573-099626d57bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0937a60-887b-46d0-b573-099626d57bcf.jpg?1",
             "name": "Mirror of Life Trapping",
             "text": "Whenever a creature enters the battlefield, if it was cast, exile it, then return all other permanent cards exiled with Mirror of Life Trapping to the battlefield under their owners' control.",
             "colours": [],
@@ -12424,7 +12424,7 @@
         },
         {
             "id": "51189d62-339b-57b4-b975-53b6eed2cf0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcae3a-d58c-4832-8280-3f65b5dfd853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcae3a-d58c-4832-8280-3f65b5dfd853.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "e5318909-f30c-565c-bdf1-a2462265abce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e2f75e-75f3-4255-969f-0eab32f7bd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e2f75e-75f3-4255-969f-0eab32f7bd1e.jpg?1",
             "name": "Nautiloid Ship",
             "text": "Flying\nWhen Nautiloid Ship enters the battlefield, exile target player's graveyard.\nWhenever Nautiloid Ship deals combat damage to a player, you may put a creature card exiled with Nautiloid Ship onto the battlefield under your control.\nCrew 3",
             "colours": [],
@@ -12488,7 +12488,7 @@
         },
         {
             "id": "1eabe002-f573-52a0-bd39-c3a6dac5012a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512a77e-2435-4695-9408-df8e17dd1fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512a77e-2435-4695-9408-df8e17dd1fbd.jpg?1",
             "name": "Navigation Orb",
             "text": "{2}, {T}, Sacrifice Navigation Orb: Search your library for up to two basic land cards and/or Gate cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [],
@@ -12516,7 +12516,7 @@
         },
         {
             "id": "c1ecbbe2-2cfd-5e0d-b239-43ed95b6b29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34282856-c0f1-4845-bfc8-537466c6a5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34282856-c0f1-4845-bfc8-537466c6a5bb.jpg?1",
             "name": "Nimblewright Schematic",
             "text": "When Nimblewright Schematic enters the battlefield or is put into a graveyard from the battlefield, create a 1/1 colorless Construct artifact creature token.",
             "colours": [],
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "a48a127b-20cc-5751-8750-bcb2b8cc0e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be533558-3b16-4df0-a0ca-faa1ebf2e641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be533558-3b16-4df0-a0ca-faa1ebf2e641.jpg?1",
             "name": "Noble's Purse",
             "text": "Noble's Purse enters the battlefield tapped and with three coin counters on it.\n{T}, Remove a coin counter from Noble's Purse: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12572,7 +12572,7 @@
         },
         {
             "id": "e0768e86-f3f9-56c5-ae1e-a54fd94f3628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f920f0-4dfc-477b-af7e-a17dfc9ba455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f920f0-4dfc-477b-af7e-a17dfc9ba455.jpg?1",
             "name": "Patriar's Seal",
             "text": "{T}: Add one mana of any color.\n{1}, {T}: Untap target legendary creature you control.",
             "colours": [],
@@ -12600,7 +12600,7 @@
         },
         {
             "id": "45d603e2-b224-5cf6-979c-e2c6a1c078cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32161267-e12b-454f-a7e1-94e078566ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32161267-e12b-454f-a7e1-94e078566ffa.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "bfb4ec15-5a21-5a64-b074-278d11061802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a49829-c354-4823-8cc1-a159fc46c0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a49829-c354-4823-8cc1-a159fc46c0d7.jpg?1",
             "name": "Prized Statue",
             "text": "When Prized Statue enters the battlefield or is put into a graveyard from the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12659,7 +12659,7 @@
         },
         {
             "id": "343a24fe-4ed9-52a1-b4e6-820f91d3bc02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b837b21-9165-4965-a7b5-c59811647951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b837b21-9165-4965-a7b5-c59811647951.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -12687,7 +12687,7 @@
         },
         {
             "id": "a2ed009a-cef6-5427-998d-e30a38d863e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73d1cb0-d0dc-4f2a-9cf2-954d5889dd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73d1cb0-d0dc-4f2a-9cf2-954d5889dd08.jpg?1",
             "name": "Rug of Smothering",
             "text": "Flying\nWhenever a player casts a spell, they lose 1 life for each spell they've cast this turn.",
             "colours": [],
@@ -12718,7 +12718,7 @@
         },
         {
             "id": "42d54111-0701-5f4c-9317-6f1ec12ed4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47abfb2-9bcf-485c-9bd4-2c09b714eb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47abfb2-9bcf-485c-9bd4-2c09b714eb32.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -12750,7 +12750,7 @@
         },
         {
             "id": "f986a7d8-4e97-5ffe-a18c-4e186c30c324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99e6e1-3b88-4d2f-bc5d-70439585a063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99e6e1-3b88-4d2f-bc5d-70439585a063.jpg?1",
             "name": "Stonespeaker Crystal",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Stonespeaker Crystal: Exile any number of target players' graveyards. Draw a card.",
             "colours": [],
@@ -12780,7 +12780,7 @@
         },
         {
             "id": "e4536570-e3dc-58dd-8283-aaaa6f8fb711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c23cde-e1c0-4cdf-ae59-18d64db518d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c23cde-e1c0-4cdf-ae59-18d64db518d4.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control.)\nEquip {1}",
             "colours": [],
@@ -12810,7 +12810,7 @@
         },
         {
             "id": "ba09fff6-1806-5c4e-909e-ae6b863c90b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f76ae-e93b-4ca1-ac62-753707f6319e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f76ae-e93b-4ca1-ac62-753707f6319e.jpg?1",
             "name": "Trailblazer's Torch",
             "text": "When Trailblazer's Torch enters the battlefield, you take the initiative.\nWhenever equipped creature becomes blocked, it deals 2 damage to each creature blocking it.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -12840,7 +12840,7 @@
         },
         {
             "id": "53f30027-a7da-57f6-8f7d-7715bf0b1f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68ab416-3394-4cb6-bfc6-33e62964dd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68ab416-3394-4cb6-bfc6-33e62964dd1c.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "b6fd7400-b8c2-58f3-9270-447c65e8fa67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e142122f-3a04-436e-a958-dc2224b4fc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e142122f-3a04-436e-a958-dc2224b4fc6d.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -12899,7 +12899,7 @@
         },
         {
             "id": "967feb0f-473a-5069-9a9e-b98118fd2b94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c477fb1a-5aac-4722-80d8-7570a8b09e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c477fb1a-5aac-4722-80d8-7570a8b09e44.jpg?1",
             "name": "Vexing Puzzlebox",
             "text": "Whenever you roll one or more dice, put a number of charge counters on Vexing Puzzlebox equal to the result.\n{T}: Add one mana of any color. Roll a d20.\n{T}, Remove 100 charge counters from Vexing Puzzlebox: Search your library for an artifact card, put that card onto the battlefield, then shuffle.",
             "colours": [],
@@ -12929,7 +12929,7 @@
         },
         {
             "id": "338911db-75ba-53cd-97db-99e259c15ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b865d247-fe0a-4583-b088-ae900ffe521b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b865d247-fe0a-4583-b088-ae900ffe521b.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -12957,7 +12957,7 @@
         },
         {
             "id": "7c7e4dd6-cff8-54d5-b154-fae5305a5c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2436aa14-9200-4295-8041-b682cf3c4216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2436aa14-9200-4295-8041-b682cf3c4216.jpg?1",
             "name": "Baldur's Gate",
             "text": "{T}: Add {C}.\n{2}, {T}: Add X mana of any one color, where X is the number of other Gates you control.",
             "colours": [],
@@ -12991,7 +12991,7 @@
         },
         {
             "id": "f36e1636-5351-5e49-956b-face4d7a1d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a306025-d429-4006-b7ed-bdb287e83f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a306025-d429-4006-b7ed-bdb287e83f57.jpg?1",
             "name": "Basilisk Gate",
             "text": "{T}: Add {C}.\n{2}, {T}: Target creature gets +X/+X until end of turn, where X is the number of Gates you control. Activate only as a sorcery.",
             "colours": [],
@@ -13021,7 +13021,7 @@
         },
         {
             "id": "068a80ec-e8e1-5400-9b6b-efd632f98686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ceb589-c741-44ac-98c8-3d997953ee61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ceb589-c741-44ac-98c8-3d997953ee61.jpg?1",
             "name": "Black Dragon Gate",
             "text": "Black Dragon Gate enters the battlefield tapped.\nAs Black Dragon Gate enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -13053,7 +13053,7 @@
         },
         {
             "id": "9fbf898a-2da6-50a3-9287-fbdef18ded25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5125a8d8-344d-4419-b37a-ddf343493c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5125a8d8-344d-4419-b37a-ddf343493c5f.jpg?1",
             "name": "Bountiful Promenade",
             "text": "Bountiful Promenade enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -13086,7 +13086,7 @@
         },
         {
             "id": "eb7a79c3-3940-5954-af28-c941f404c33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e6f002-9a10-49a1-8604-2b8ff57732dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e6f002-9a10-49a1-8604-2b8ff57732dd.jpg?1",
             "name": "Citadel Gate",
             "text": "Citadel Gate enters the battlefield tapped.\nAs Citadel Gate enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -13118,7 +13118,7 @@
         },
         {
             "id": "e9a0e341-2650-5558-b5dd-f19febe3b331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557470dc-c594-4b26-81b9-356bedb0c215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557470dc-c594-4b26-81b9-356bedb0c215.jpg?1",
             "name": "Cliffgate",
             "text": "Cliffgate enters the battlefield tapped.\nAs Cliffgate enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -13150,7 +13150,7 @@
         },
         {
             "id": "2cd4fbb8-4382-59aa-a513-78384b4f400f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eafe88e-ab38-442c-b147-bb01cc81178d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eafe88e-ab38-442c-b147-bb01cc81178d.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "d513feaa-fc49-5793-a35d-c38ccae8f41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc8841a-0f6e-4078-a0b9-a4bda642182e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc8841a-0f6e-4078-a0b9-a4bda642182e.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "4f40e20d-0c6c-529d-a576-98bb8a422c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746672d9-7c6b-415e-9f34-3cc3ac557008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746672d9-7c6b-415e-9f34-3cc3ac557008.jpg?1",
             "name": "Gond Gate",
             "text": "Gates you control enter the battlefield untapped.\n{T}: Add {C}.\n{T}: Add one mana of any color that a Gate you control could produce.",
             "colours": [],
@@ -13236,7 +13236,7 @@
         },
         {
             "id": "3bc0d4d3-c159-5a4d-a975-44918739253f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68489d65-1978-48b1-a903-2ef38c583239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68489d65-1978-48b1-a903-2ef38c583239.jpg?1",
             "name": "Heap Gate",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{1}, {T}, Tap an untapped Gate you control: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -13266,7 +13266,7 @@
         },
         {
             "id": "f4a7c548-ed29-5ac6-b85c-15eb4f724e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc5fc38-4054-4663-9061-df5455788c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc5fc38-4054-4663-9061-df5455788c4a.jpg?1",
             "name": "Luxury Suite",
             "text": "Luxury Suite enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -13299,7 +13299,7 @@
         },
         {
             "id": "d44813aa-8337-5737-a9db-b761a96c0dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793d4978-9e00-453d-8dc2-6d51ad6c26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793d4978-9e00-453d-8dc2-6d51ad6c26b7.jpg?1",
             "name": "Manor Gate",
             "text": "Manor Gate enters the battlefield tapped.\nAs Manor Gate enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -13331,7 +13331,7 @@
         },
         {
             "id": "1df5c3cc-2b34-5e67-90d2-8917199cca9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e40927-dd87-42ed-b805-0ae8ba81f5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e40927-dd87-42ed-b805-0ae8ba81f5fb.jpg?1",
             "name": "Morphic Pool",
             "text": "Morphic Pool enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -13364,7 +13364,7 @@
         },
         {
             "id": "a8d6eea3-57ee-56dc-bb2a-1bc063e4696e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1b3f5-473d-45ca-be0d-e67e77ba30ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1b3f5-473d-45ca-be0d-e67e77ba30ce.jpg?1",
             "name": "Reflecting Pool",
             "text": "{T}: Add one mana of any type that a land you control could produce.",
             "colours": [],
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "1d01a42a-812e-5c47-a5ef-1a54de71b068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f31e1-bcaf-4316-a2de-49e2cf7566ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f31e1-bcaf-4316-a2de-49e2cf7566ec.jpg?1",
             "name": "Sea Gate",
             "text": "Sea Gate enters the battlefield tapped.\nAs Sea Gate enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "9ead4c9d-27e2-5638-abea-c770532af319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fb722f-40af-4bd1-b660-e8186b98f233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fb722f-40af-4bd1-b660-e8186b98f233.jpg?1",
             "name": "Sea of Clouds",
             "text": "Sea of Clouds enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -13459,7 +13459,7 @@
         },
         {
             "id": "c0ab1d25-1263-5b55-8c2b-d92b96c014de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72aed540-7833-4442-90a9-aa5468014c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72aed540-7833-4442-90a9-aa5468014c65.jpg?1",
             "name": "Spire Garden",
             "text": "Spire Garden enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -13492,7 +13492,7 @@
         },
         {
             "id": "350929d4-a62a-5d53-921f-3f0d42f70fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06700514-b19c-4fc8-beb1-2c801f320b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06700514-b19c-4fc8-beb1-2c801f320b25.jpg?1",
             "name": "Elminster",
             "text": "Whenever you scry, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of cards looked at while scrying this way.\n+2: Draw a card, then scry 2.\n\u22123: Exile the top card of your library. Create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to that card's mana value.\nElminster can be your commander.",
             "colours": [
@@ -13532,7 +13532,7 @@
         },
         {
             "id": "5228c703-170a-53e4-9013-a9edcd5074b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e308b016-5611-450c-a2ea-906647d1b7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e308b016-5611-450c-a2ea-906647d1b7e3.jpg?1",
             "name": "Minsc & Boo, Timeless Heroes",
             "text": "When Minsc & Boo, Timeless Heroes enters the battlefield and at the beginning of your upkeep, you may create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n+1: Put three +1/+1 counters on up to one target creature with trample or haste.\n\u22122: Sacrifice a creature. When you do, Minsc & Boo, Timeless Heroes deals X damage to any target, where X is that creature's power. If the sacrificed creature was a Hamster, draw X cards.\nMinsc & Boo, Timeless Heroes can be your commander.",
             "colours": [
@@ -13572,7 +13572,7 @@
         },
         {
             "id": "0599538e-1e54-5765-900f-50505149d509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce387e9c-2d0e-4314-ac8d-4b7c93286fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce387e9c-2d0e-4314-ac8d-4b7c93286fb2.jpg?1",
             "name": "Tasha, the Witch Queen",
             "text": "Whenever you cast a spell you don't own, create a 3/3 black Demon creature token.\n+1: Draw a card. For each opponent, exile up to one target instant or sorcery card from that player's graveyard and put a page counter on it.\n\u22123: You may cast a spell from among cards in exile with page counters on them without paying its mana cost.\nTasha, the Witch Queen can be your commander.",
             "colours": [
@@ -13612,7 +13612,7 @@
         },
         {
             "id": "3118aa84-4308-59d2-995f-40ef202bdec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ae6ea-fc0b-4ff0-92bc-4a20c7ba7e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ae6ea-fc0b-4ff0-92bc-4a20c7ba7e38.jpg?1",
             "name": "Ancient Gold Dragon",
             "text": "Flying\nWhenever Ancient Gold Dragon deals combat damage to a player, roll a d20. You create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to the result.",
             "colours": [
@@ -13650,7 +13650,7 @@
         },
         {
             "id": "a189db9a-fba5-5b38-8462-94a54ded2654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34761bda-03f9-4607-bb01-10b1598509f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34761bda-03f9-4607-bb01-10b1598509f7.jpg?1",
             "name": "Ancient Silver Dragon",
             "text": "Flying\nWhenever Ancient Silver Dragon deals combat damage to a player, roll a d20. Draw cards equal to the result. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "5db10c51-7ca6-5847-863c-53793cea171e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631a9966-b5d2-4696-a2f1-2d56fccad9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631a9966-b5d2-4696-a2f1-2d56fccad9b2.jpg?1",
             "name": "Ancient Brass Dragon",
             "text": "Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.",
             "colours": [
@@ -13726,7 +13726,7 @@
         },
         {
             "id": "b54df50e-f837-554e-8d84-f062be364763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ac08c-11ce-4e8a-8ea8-c18cfc745ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ac08c-11ce-4e8a-8ea8-c18cfc745ac7.jpg?1",
             "name": "Ancient Copper Dragon",
             "text": "Flying\nWhenever Ancient Copper Dragon deals combat damage to a player, roll a d20. You create a number of Treasure tokens equal to the result.",
             "colours": [
@@ -13764,7 +13764,7 @@
         },
         {
             "id": "7b06d589-d4ed-5521-bdb5-009cc54f619c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b957a1f-6d26-47bb-84ba-81acc01a8dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b957a1f-6d26-47bb-84ba-81acc01a8dae.jpg?1",
             "name": "Ancient Bronze Dragon",
             "text": "Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.",
             "colours": [
@@ -13802,7 +13802,7 @@
         },
         {
             "id": "2da6f6d0-af3e-5d00-bc70-e73db9869e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd40caa-0cbb-426d-a988-1d826988e707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd40caa-0cbb-426d-a988-1d826988e707.jpg?1",
             "name": "Battle Angels of Tyr",
             "text": "Flying, myriad\nWhenever Battle Angels of Tyr deals combat damage to a player, draw a card if that player has more cards in hand than each other player. Then you create a Treasure token if that player controls more lands than each other player. Then you gain 3 life if that player has more life than each other player.",
             "colours": [
@@ -13839,7 +13839,7 @@
         },
         {
             "id": "3bf1732e-b93b-5110-a074-800e44b63333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06408b0-3ae9-46f9-ae6f-cd50c88147bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06408b0-3ae9-46f9-ae6f-cd50c88147bc.jpg?1",
             "name": "Legion Loyalty",
             "text": "Creatures you control have myriad.",
             "colours": [
@@ -13873,7 +13873,7 @@
         },
         {
             "id": "742e363d-b6f4-5b02-952b-9d2c0e72a493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763fde16-5de2-4541-90f1-a6efee920e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763fde16-5de2-4541-90f1-a6efee920e28.jpg?1",
             "name": "Bramble Sovereign",
             "text": "Whenever another nontoken creature enters the battlefield, you may pay {1}{G}. If you do, that creature's controller creates a token that's a copy of that creature.",
             "colours": [
@@ -13909,7 +13909,7 @@
         },
         {
             "id": "7d73dadc-636f-5f2d-9f97-86e94e53a840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91758c02-b2d1-4821-a29f-0154a611a904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91758c02-b2d1-4821-a29f-0154a611a904.jpg?1",
             "name": "Nautiloid Ship",
             "text": "Flying\nWhen Nautiloid Ship enters the battlefield, exile target player's graveyard.\nWhenever Nautiloid Ship deals combat damage to a player, you may put a creature card exiled with Nautiloid Ship onto the battlefield under your control.\nCrew 3",
             "colours": [],
@@ -13941,7 +13941,7 @@
         },
         {
             "id": "7fc5694b-b161-54d1-8c49-06f9d86f5892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49084bff-baef-4b73-ae5b-325bd6a81958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49084bff-baef-4b73-ae5b-325bd6a81958.jpg?1",
             "name": "Vexing Puzzlebox",
             "text": "Whenever you roll one or more dice, put a number of charge counters on Vexing Puzzlebox equal to the result.\n{T}: Add one mana of any color. Roll a d20.\n{T}, Remove 100 charge counters from Vexing Puzzlebox: Search your library for an artifact card, put that card onto the battlefield, then shuffle.",
             "colours": [],
@@ -13971,7 +13971,7 @@
         },
         {
             "id": "bb0f7485-1506-558e-a40f-95dbffd890b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4857125b-bd0f-4f09-9d6c-56544834a359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4857125b-bd0f-4f09-9d6c-56544834a359.jpg?1",
             "name": "Abdel Adrian, Gorion's Ward",
             "text": "When Abdel Adrian, Gorion's Ward enters the battlefield, exile any number of other nonland permanents you control until Abdel Adrian leaves the battlefield. Create a 1/1 white Soldier creature token for each permanent exiled this way.\nChoose a Background",
             "colours": [
@@ -14011,7 +14011,7 @@
         },
         {
             "id": "d7e41904-d19d-5b27-9dea-a89d62351397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f53d47-fd5c-41de-8d7a-490c1b529f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f53d47-fd5c-41de-8d7a-490c1b529f4f.jpg?1",
             "name": "Ancient Gold Dragon",
             "text": "Flying\nWhenever Ancient Gold Dragon deals combat damage to a player, roll a d20. You create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to the result.",
             "colours": [
@@ -14049,7 +14049,7 @@
         },
         {
             "id": "aac1a6bf-1076-5407-9fc2-f0481043bb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249bc870-e945-466c-81cd-8b9e9b7ac4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249bc870-e945-466c-81cd-8b9e9b7ac4ac.jpg?1",
             "name": "Ellyn Harbreeze, Busybody",
             "text": "{T}: Look at the top X cards of your library, where X is the number of tokens you created this turn. Put one of those cards into your hand and the rest on the bottom of your library in a random order.\nChoose a Background",
             "colours": [
@@ -14089,7 +14089,7 @@
         },
         {
             "id": "7b371c99-bc96-5828-b67d-a81b7bb4f5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44927f22-0017-4c19-bd0a-41f09c0ce19f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44927f22-0017-4c19-bd0a-41f09c0ce19f.jpg?1",
             "name": "Lae'zel, Vlaakith's Champion",
             "text": "If you would put one or more counters on a creature or planeswalker you control or on yourself, put that many plus one of each of those kinds of counters on that permanent or player instead.\nChoose a Background",
             "colours": [
@@ -14129,7 +14129,7 @@
         },
         {
             "id": "4ae70a29-24b5-5a82-9323-f16e17d3feca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0447c-9077-4d63-9d5e-f012f912e862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0447c-9077-4d63-9d5e-f012f912e862.jpg?1",
             "name": "Lulu, Loyal Hollyphant",
             "text": "Flying\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on each tapped creature you control, then untap them.\nChoose a Background",
             "colours": [
@@ -14169,7 +14169,7 @@
         },
         {
             "id": "83096478-032c-5a81-b219-5115a2989811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b634d96-62ae-46d2-b77f-7148837346b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b634d96-62ae-46d2-b77f-7148837346b2.jpg?1",
             "name": "Rasaad yn Bashir",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\nWhenever Rasaad yn Bashir attacks, if you have the initiative, double the toughness of each creature you control until end of turn.\nChoose a Background",
             "colours": [
@@ -14209,7 +14209,7 @@
         },
         {
             "id": "a71e50ee-7d5c-5665-a46e-574cc3c5f5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7777a4f-0fc6-4231-b2a4-503f3820c0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7777a4f-0fc6-4231-b2a4-503f3820c0f6.jpg?1",
             "name": "Alora, Merry Thief",
             "text": "Whenever you attack, up to one target attacking creature can't be blocked this turn. Return that creature to its owner's hand at the beginning of the next end step.\nChoose a Background",
             "colours": [
@@ -14249,7 +14249,7 @@
         },
         {
             "id": "0c118423-e082-52fe-a23a-0ada212c49ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d9a4d3-e1d2-42ae-bca4-02bc2cf69c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d9a4d3-e1d2-42ae-bca4-02bc2cf69c9d.jpg?1",
             "name": "Ancient Silver Dragon",
             "text": "Flying\nWhenever Ancient Silver Dragon deals combat damage to a player, roll a d20. Draw cards equal to the result. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -14287,7 +14287,7 @@
         },
         {
             "id": "22cef728-5985-5903-ab3c-6b9a3cb1ad4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cd3224-c392-4c33-aa7b-d2e7041c0d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cd3224-c392-4c33-aa7b-d2e7041c0d89.jpg?1",
             "name": "Gale, Waterdeep Prodigy",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast up to one target card of the other type from your graveyard. If a spell cast from your graveyard this way would be put into your graveyard, exile it instead.\nChoose a Background",
             "colours": [
@@ -14327,7 +14327,7 @@
         },
         {
             "id": "1e193e98-9e4c-52f5-ac05-a3691c821951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753e654-f02c-46eb-b5f5-cba1a99a0253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753e654-f02c-46eb-b5f5-cba1a99a0253.jpg?1",
             "name": "Goggles of Night",
             "text": "Whenever equipped creature deals combat damage to a player, scry 1, then draw a card.\nEquip {2}",
             "colours": [
@@ -14363,7 +14363,7 @@
         },
         {
             "id": "ac9de9a8-df53-5269-8788-5ab02cd467dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce62167-bd2c-4192-9ce4-dd19a1080db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce62167-bd2c-4192-9ce4-dd19a1080db6.jpg?1",
             "name": "Imoen, Mystic Trickster",
             "text": "Ward {2}\nAt the beginning of your end step, if you have the initiative, draw a card. Draw another card if you've completed a dungeon.\nChoose a Background",
             "colours": [
@@ -14404,7 +14404,7 @@
         },
         {
             "id": "173a6c95-2459-544d-b685-3daa1eac1032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff38ea-53e4-49e3-bf54-233100107fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff38ea-53e4-49e3-bf54-233100107fee.jpg?1",
             "name": "Renari, Merchant of Marvels",
             "text": "You may cast Dragon spells and artifact spells as though they had flash.\nChoose a Background",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "fec1a995-870d-5ba5-92fd-a830c48a1d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a373d7-43b8-4037-828d-080ecb5c2a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a373d7-43b8-4037-828d-080ecb5c2a08.jpg?1",
             "name": "Vhal, Candlekeep Researcher",
             "text": "Vigilance\n{T}: Add an amount of {C} equal to Vhal, Candlekeep Researcher's toughness. This mana can't be spent to cast spells from your hand.\nChoose a Background",
             "colours": [
@@ -14484,7 +14484,7 @@
         },
         {
             "id": "8005e72f-5513-5b4f-95e7-b9da3f4a970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8772547-79b8-4516-8d75-9b85202d9c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8772547-79b8-4516-8d75-9b85202d9c32.jpg?1",
             "name": "Volo, Itinerant Scholar",
             "text": "When Volo enters the battlefield, create Volo's Journal, a legendary colorless artifact token with hexproof and \"Whenever you cast a creature spell, note one of its creature types that hasn't been noted for this artifact.\"\n{2}, {T}: Draw a card for each creature type noted for target permanent you control named Volo's Journal.\nChoose a Background",
             "colours": [
@@ -14524,7 +14524,7 @@
         },
         {
             "id": "2fa2ff2e-45e9-51ea-8fbe-031eb4755cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d7fcb-e5f0-4438-8d35-8beb4cc015e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d7fcb-e5f0-4438-8d35-8beb4cc015e4.jpg?1",
             "name": "Ancient Brass Dragon",
             "text": "Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.",
             "colours": [
@@ -14562,7 +14562,7 @@
         },
         {
             "id": "0578af5c-1a9e-58a4-86c3-df5bb5d88afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356440f-6d49-481e-8332-1a675a48a94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356440f-6d49-481e-8332-1a675a48a94e.jpg?1",
             "name": "Safana, Calimport Cutthroat",
             "text": "Menace\nAt the beginning of your end step, if you have the initiative, create a Treasure token. Create three of those tokens instead if you've completed a dungeon.\nChoose a Background",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "20afdf59-9211-50f6-9bdb-9d983d989960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff9756-12cc-4144-a815-a244fbe13b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff9756-12cc-4144-a815-a244fbe13b72.jpg?1",
             "name": "Sarevok, Deathbringer",
             "text": "At the beginning of each player's end step, if no permanents left the battlefield this turn, that player loses X life, where X is Sarevok's power.\nChoose a Background",
             "colours": [
@@ -14642,7 +14642,7 @@
         },
         {
             "id": "39bf319a-9512-57f0-b7f5-4be66cafdb7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94951251-91a2-4b71-9346-903d400cc28e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94951251-91a2-4b71-9346-903d400cc28e.jpg?1",
             "name": "Shadowheart, Dark Justiciar",
             "text": "{1}{B}, {T}, Sacrifice another creature: Draw X cards, where X is that creature's power.\nChoose a Background",
             "colours": [
@@ -14683,7 +14683,7 @@
         },
         {
             "id": "5b3884ec-42a4-5f16-a604-2b05e0f81588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9af754-e96a-46b5-9c28-3420a447b098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9af754-e96a-46b5-9c28-3420a447b098.jpg?1",
             "name": "Sivriss, Nightmare Speaker",
             "text": "{T}, Sacrifice another creature or an artifact: For each opponent, you mill a card, then return that card from your graveyard to your hand unless that player pays 3 life.\nChoose a Background",
             "colours": [
@@ -14724,7 +14724,7 @@
         },
         {
             "id": "852835ff-0ab2-507f-835e-695b56331412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99ecf8e-3819-4a14-b2e8-8fcd3fef5846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99ecf8e-3819-4a14-b2e8-8fcd3fef5846.jpg?1",
             "name": "Viconia, Drow Apostate",
             "text": "At the beginning of your upkeep, if there are four or more creature cards in your graveyard, return a creature card at random from your graveyard to your hand.\nChoose a Background",
             "colours": [
@@ -14764,7 +14764,7 @@
         },
         {
             "id": "a882292a-028c-5367-b494-8fb7125ca086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1272ef5-4ceb-4b07-a9af-393113b58ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1272ef5-4ceb-4b07-a9af-393113b58ef4.jpg?1",
             "name": "Amber Gristle O'Maul",
             "text": "Haste\nWhenever Amber Gristle O'Maul attacks, you may discard your hand. If you do, draw a card for each player being attacked.\nChoose a Background",
             "colours": [
@@ -14804,7 +14804,7 @@
         },
         {
             "id": "6a3a2f98-ec89-552c-a179-719b081f001e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12d32a7-60b4-4e49-b279-970b170c1a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12d32a7-60b4-4e49-b279-970b170c1a9c.jpg?1",
             "name": "Ancient Copper Dragon",
             "text": "Flying\nWhenever Ancient Copper Dragon deals combat damage to a player, roll a d20. You create a number of Treasure tokens equal to the result.",
             "colours": [
@@ -14842,7 +14842,7 @@
         },
         {
             "id": "356725cb-a908-5bd9-be49-e6941eeaebb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a97aae-d8a7-4451-a47e-ea878dea6e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a97aae-d8a7-4451-a47e-ea878dea6e4c.jpg?1",
             "name": "Fireball",
             "text": "This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "f5b22c63-6587-535b-84be-ce8585c3bd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3347e3-df90-465d-9346-77d3b4fead10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3347e3-df90-465d-9346-77d3b4fead10.jpg?1",
             "name": "Ganax, Astral Hunter",
             "text": "Flying\nWhenever Ganax, Astral Hunter or another Dragon enters the battlefield under your control, create a Treasure token.\nChoose a Background",
             "colours": [
@@ -14915,7 +14915,7 @@
         },
         {
             "id": "07e3082c-07ca-5e55-b6c6-319a4b3f20ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6988467-8552-4ab9-9472-c5c536ed7bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6988467-8552-4ab9-9472-c5c536ed7bae.jpg?1",
             "name": "Gut, True Soul Zealot",
             "text": "Whenever you attack, you may sacrifice another creature or an artifact. If you do, create a 4/1 black Skeleton creature token with menace that's tapped and attacking.\nChoose a Background",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "df1cbea9-2fa3-55fa-a673-1d407ed3d266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b123fa-c232-4bb4-ba9d-2cde4a0eef99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b123fa-c232-4bb4-ba9d-2cde4a0eef99.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "Whenever you attack, if it's the first combat phase of the turn, untap all attacking creatures. They gain first strike until end of turn. After this phase, there is an additional combat phase.\nChoose a Background",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "578de53b-151a-5082-9c0a-81409d544162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69f668b-cf28-495a-bbe1-24e9d0089fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69f668b-cf28-495a-bbe1-24e9d0089fa1.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -15029,7 +15029,7 @@
         },
         {
             "id": "87edfc52-85a5-5ba1-ac38-71e59e533172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcc2a8-c7be-45c8-8048-e81638558d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcc2a8-c7be-45c8-8048-e81638558d66.jpg?1",
             "name": "Livaan, Cultist of Tiamat",
             "text": "Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.\nChoose a Background",
             "colours": [
@@ -15069,7 +15069,7 @@
         },
         {
             "id": "963cd782-ce81-5382-a7c7-c62f043d1d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d0aded-3db0-45a7-b9ab-5831c714096f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d0aded-3db0-45a7-b9ab-5831c714096f.jpg?1",
             "name": "Nemesis Phoenix",
             "text": "Flying\n{2}{R}: Return Nemesis Phoenix from your graveyard to the battlefield tapped and attacking. Activate only during the declare attackers step and only if you're attacking two or more opponents.",
             "colours": [
@@ -15105,7 +15105,7 @@
         },
         {
             "id": "b23d88fc-8046-51fb-a2d0-9fb99630617f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d4f041-c485-464e-91b1-73597b1e7f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d4f041-c485-464e-91b1-73597b1e7f73.jpg?1",
             "name": "Taunting Kobold",
             "text": "Haste\nWhenever Taunting Kobold attacks, goad target creature an opponent controls.",
             "colours": [
@@ -15141,7 +15141,7 @@
         },
         {
             "id": "d3fef082-c891-5926-9d59-42994fca074b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589fdaa-9a0c-4bee-b991-38977255f0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589fdaa-9a0c-4bee-b991-38977255f0d5.jpg?1",
             "name": "Wyll, Blade of Frontiers",
             "text": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\nWhenever you roll one or more dice, put a +1/+1 counter on Wyll, Blade of Frontiers.\nChoose a Background",
             "colours": [
@@ -15181,7 +15181,7 @@
         },
         {
             "id": "91831817-2f92-5c56-a4f1-8360af5823c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261fba2-0420-4271-87f4-f168a1e74c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261fba2-0420-4271-87f4-f168a1e74c9b.jpg?1",
             "name": "Ancient Bronze Dragon",
             "text": "Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.",
             "colours": [
@@ -15219,7 +15219,7 @@
         },
         {
             "id": "4f577f2f-13a9-589e-b772-91d933ef97db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73d15f7-d36c-45b8-a933-dac17040c9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73d15f7-d36c-45b8-a933-dac17040c9ee.jpg?1",
             "name": "Erinis, Gloom Stalker",
             "text": "Deathtouch\nWhenever Erinis, Gloom Stalker attacks, return target land card from your graveyard to the battlefield.\nChoose a Background",
             "colours": [
@@ -15259,7 +15259,7 @@
         },
         {
             "id": "8f7575d8-4bca-532a-99a9-5b824cbea161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cdc433-a41b-4f45-b40f-3618c399e196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cdc433-a41b-4f45-b40f-3618c399e196.jpg?1",
             "name": "Halsin, Emerald Archdruid",
             "text": "{1}: Until end of turn, target token you control becomes a green Bear creature with base power and toughness 4/4 in addition to its other colors and types.\nChoose a Background",
             "colours": [
@@ -15299,7 +15299,7 @@
         },
         {
             "id": "4fcd0460-82c3-516c-adfd-1b9b897f9340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4de176-0f2e-4d8c-b3ac-ef2e626b4aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4de176-0f2e-4d8c-b3ac-ef2e626b4aac.jpg?1",
             "name": "Jaheira, Friend of the Forest",
             "text": "Tokens you control have \"{T}: Add {G}.\"\nChoose a Background",
             "colours": [
@@ -15340,7 +15340,7 @@
         },
         {
             "id": "a6a92ab0-5374-5a6b-9cc5-fdb015ad54f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda500f-4c54-4e0a-b4c7-e604d1e72d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda500f-4c54-4e0a-b4c7-e604d1e72d77.jpg?1",
             "name": "Skanos Dragonheart",
             "text": "Whenever Skanos Dragonheart attacks, it gets +X/+X until end of turn, where X is the greatest power among other Dragons you control and Dragon cards in your graveyard.\nChoose a Background",
             "colours": [
@@ -15380,7 +15380,7 @@
         },
         {
             "id": "7bb48689-6f0f-546e-b89d-43ea320d20d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ebc0c-ae58-46c9-addc-a91d32201a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ebc0c-ae58-46c9-addc-a91d32201a95.jpg?1",
             "name": "Wilson, Refined Grizzly",
             "text": "This spell can't be countered.\nVigilance, reach, trample, ward {2}\nChoose a Background",
             "colours": [
@@ -15420,7 +15420,7 @@
         },
         {
             "id": "1781279b-c12c-51b7-b3c0-680eb3984094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95de91-03bf-48a2-9947-b818ac78dec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95de91-03bf-48a2-9947-b818ac78dec6.jpg?1",
             "name": "Alaundo the Seer",
             "text": "{T}: Draw a card, then exile a card from your hand and put a number of time counters on it equal to its mana value. It gains \"When the last time counter is removed from this card, if it's exiled, you may cast it without paying its mana cost. If you cast a creature spell this way, it gains haste until end of turn.\" Then remove a time counter from each other card you own in exile.",
             "colours": [
@@ -15462,7 +15462,7 @@
         },
         {
             "id": "c0df5565-cb89-5aaf-b0a2-e74522a46034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f6ae-cd25-4c98-9700-be2f40a0a37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f6ae-cd25-4c98-9700-be2f40a0a37b.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "Deathtouch, lifelink\nAt the beginning of your end step, choose one \u2014\n\u2022 Feed \u2014 Target opponent loses life equal to the amount of life they lost this turn.\n\u2022 Friends \u2014 You gain life equal to the amount of life you gained this turn.",
             "colours": [
@@ -15505,7 +15505,7 @@
         },
         {
             "id": "56bc7464-4105-56da-8219-607388f6d531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f293aa-dca1-48c2-9f48-069d32b89f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f293aa-dca1-48c2-9f48-069d32b89f3b.jpg?1",
             "name": "Baba Lysaga, Night Witch",
             "text": "{T}, Sacrifice up to three permanents: If there were three or more card types among the sacrificed permanents, each opponent loses 3 life, you gain 3 life, and you draw three cards.",
             "colours": [
@@ -15547,7 +15547,7 @@
         },
         {
             "id": "6f340973-743a-57b6-ba19-dc6aeb76f3ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4ab793-0dac-4b38-ae43-2e3fe454a6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4ab793-0dac-4b38-ae43-2e3fe454a6b2.jpg?1",
             "name": "Bane, Lord of Darkness",
             "text": "As long as your life total is less than or equal to half your starting life total, Bane, Lord of Darkness has indestructible.\nWhenever another nontoken creature you control dies, target opponent may have you draw a card. If they don't, you may put a creature card with equal or lesser toughness from your hand onto the battlefield.",
             "colours": [
@@ -15590,7 +15590,7 @@
         },
         {
             "id": "d1fe2535-b045-53e6-81fa-1cd1be311e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fef6465-987c-461b-8177-b6b7332bbe4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fef6465-987c-461b-8177-b6b7332bbe4e.jpg?1",
             "name": "Bhaal, Lord of Murder",
             "text": "As long as your life total is less than or equal to half your starting life total, Bhaal, Lord of Murder has indestructible.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on target creature and goad it.",
             "colours": [
@@ -15633,7 +15633,7 @@
         },
         {
             "id": "a44e607d-3821-51ee-bf10-54db0c79ca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101af06e-24fa-40e5-9e53-77ef571b7f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101af06e-24fa-40e5-9e53-77ef571b7f71.jpg?1",
             "name": "Cadira, Caller of the Small",
             "text": "Trample\nWhenever Cadira, Caller of the Small deals combat damage to a player, for each token you control, create a 1/1 white Rabbit creature token.",
             "colours": [
@@ -15675,7 +15675,7 @@
         },
         {
             "id": "3002b209-0f1d-53e3-8fba-2d110829f656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb052fe-c834-4c72-a6b1-4cb64505e3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb052fe-c834-4c72-a6b1-4cb64505e3ee.jpg?1",
             "name": "Commander Liara Portyr",
             "text": "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards.",
             "colours": [
@@ -15717,7 +15717,7 @@
         },
         {
             "id": "396625ff-207b-5faa-be58-c97fbe595632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba6df0f-d190-4683-b2fe-567e20c54028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba6df0f-d190-4683-b2fe-567e20c54028.jpg?1",
             "name": "The Council of Four",
             "text": "Whenever a player draws their second card during their turn, you draw a card.\nWhenever a player casts their second spell during their turn, you create a 2/2 white Knight creature token.",
             "colours": [
@@ -15759,7 +15759,7 @@
         },
         {
             "id": "c870021b-4958-5f88-8846-53a99063cf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd153bb9-6b47-4d27-9928-82b6cc3d6d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd153bb9-6b47-4d27-9928-82b6cc3d6d02.jpg?1",
             "name": "Duke Ulder Ravengard",
             "text": "At the beginning of combat on your turn, another target creature you control gains haste and myriad until end of turn.",
             "colours": [
@@ -15802,7 +15802,7 @@
         },
         {
             "id": "73525228-be5e-5579-806f-342df8259109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09541c8e-5a75-4833-aa9c-b90834f9b242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09541c8e-5a75-4833-aa9c-b90834f9b242.jpg?1",
             "name": "Dynaheir, Invoker Adept",
             "text": "Haste\nYou may activate abilities of other creatures you control as though those creatures had haste.\n{T}: When you next activate an ability this turn by spending four or more mana to activate it, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -15846,7 +15846,7 @@
         },
         {
             "id": "1e2051ce-7eb8-5d2f-887d-aa743bcfce84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836e3cf0-7335-481d-a9df-386cb1371657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836e3cf0-7335-481d-a9df-386cb1371657.jpg?1",
             "name": "Gluntch, the Bestower",
             "text": "Flying\nAt the beginning of your end step, choose a player. They put two +1/+1 counters on a creature they control. Choose a second player to draw a card. Then choose a third player to create two Treasure tokens.",
             "colours": [
@@ -15887,7 +15887,7 @@
         },
         {
             "id": "93a371c5-b928-5ffc-ae23-e4e81bcfae1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31a975-a4a1-4288-b781-6614eb9acf68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31a975-a4a1-4288-b781-6614eb9acf68.jpg?1",
             "name": "Gorion, Wise Mentor",
             "text": "Vigilance\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
             "colours": [
@@ -15931,7 +15931,7 @@
         },
         {
             "id": "0c3a9c69-b246-5122-b6ef-b8abc078dfee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cb9ff-9f85-44e0-90b4-574814868a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cb9ff-9f85-44e0-90b4-574814868a25.jpg?1",
             "name": "Jan Jansen, Chaos Crafter",
             "text": "Haste\n{T}, Sacrifice an artifact creature: Create two Treasure tokens.\n{T}, Sacrifice a noncreature artifact: Create two 1/1 colorless Construct artifact creature tokens.",
             "colours": [
@@ -15975,7 +15975,7 @@
         },
         {
             "id": "4d8a646a-e605-5e4c-9ff3-5c121693fec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca5d83a-04d8-4828-a63a-432f8ef39b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca5d83a-04d8-4828-a63a-432f8ef39b50.jpg?1",
             "name": "Jon Irenicus, Shattered One",
             "text": "At the beginning of your end step, target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it. It's goaded for the rest of the game and it gains \"This creature can't be sacrificed.\"\nWhenever a creature you own but don't control attacks, you draw a card.",
             "colours": [
@@ -16017,7 +16017,7 @@
         },
         {
             "id": "4e13d91f-d598-541b-8097-2b406fa90d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a8926b-15f5-422b-b6cf-66d71f2c86dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a8926b-15f5-422b-b6cf-66d71f2c86dc.jpg?1",
             "name": "Kagha, Shadow Archdruid",
             "text": "Whenever Kagha, Shadow Archdruid attacks, it gains deathtouch until end of turn. Mill two cards.\nOnce during each of your turns, you may play a land or cast a permanent spell from among cards in your graveyard that were put there from your library this turn.",
             "colours": [
@@ -16059,7 +16059,7 @@
         },
         {
             "id": "6bd296d6-8f88-5480-9da1-d25125025262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a453d55e-9a50-4339-ad7c-387f67179fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a453d55e-9a50-4339-ad7c-387f67179fe7.jpg?1",
             "name": "Korlessa, Scale Singer",
             "text": "You may look at the top card of your library any time.\nYou may cast Dragon spells from the top of your library.",
             "colours": [
@@ -16101,7 +16101,7 @@
         },
         {
             "id": "d606d446-3a10-542b-a046-7a43cc7b5b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49228e0-b944-458d-a832-8d374efb69df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49228e0-b944-458d-a832-8d374efb69df.jpg?1",
             "name": "Lozhan, Dragons' Legacy",
             "text": "Flying\nWhenever you cast an Adventure or Dragon spell, Lozhan, Dragons' Legacy deals damage equal to that spell's mana value to any target that isn't a commander.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "736bc8ae-e898-5c7a-9245-a3045e8fa42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4dad0e-4a4e-4898-a786-efcbceb4d70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4dad0e-4a4e-4898-a786-efcbceb4d70b.jpg?1",
             "name": "Mahadi, Emporium Master",
             "text": "At the beginning of your end step, create a Treasure token for each creature that died this turn.",
             "colours": [
@@ -16184,7 +16184,7 @@
         },
         {
             "id": "56d8114e-ff51-51b4-bc27-718a476030d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47b5f9c-4db8-4257-8999-18b9210c5708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47b5f9c-4db8-4257-8999-18b9210c5708.jpg?1",
             "name": "Mazzy, Truesword Paladin",
             "text": "Whenever an enchanted creature attacks one of your opponents, it gets +2/+0 and gains trample until end of turn.\nWhenever an Aura you control is put into your graveyard from the battlefield, exile it. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -16228,7 +16228,7 @@
         },
         {
             "id": "57f03a8f-bcaa-5eed-ad2c-b4b4d7109506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0daf2-36c5-4b3e-ab81-7317682a406b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0daf2-36c5-4b3e-ab81-7317682a406b.jpg?1",
             "name": "Miirym, Sentinel Wyrm",
             "text": "Flying, ward {2}\nWhenever another nontoken Dragon enters the battlefield under your control, create a token that's a copy of it, except the token isn't legendary if that Dragon is legendary.",
             "colours": [
@@ -16272,7 +16272,7 @@
         },
         {
             "id": "14d027ad-79a5-558d-9e57-765c30c49f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64395505-914c-4e10-aed1-818425709b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64395505-914c-4e10-aed1-818425709b12.jpg?1",
             "name": "Minthara, Merciless Soul",
             "text": "Ward {X}, where X is the number of experience counters you have.\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, you get an experience counter.\nCreatures you control get +1/+0 for each experience counter you have.",
             "colours": [
@@ -16314,7 +16314,7 @@
         },
         {
             "id": "e541b123-ba4f-5bc7-a6ff-4fea06d092a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f2783f-9512-4cfe-9e95-ab943afd4e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f2783f-9512-4cfe-9e95-ab943afd4e53.jpg?1",
             "name": "Myrkul, Lord of Bones",
             "text": "As long as your life total is less than or equal to half your starting life total, Myrkul, Lord of Bones has indestructible.\nWhenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that card, except it's an enchantment and loses all other card types.",
             "colours": [
@@ -16357,7 +16357,7 @@
         },
         {
             "id": "25da518a-da3a-5ff7-9da0-621b2a0b7b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499bd497-4c72-4a61-88c8-abe2d379fe41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499bd497-4c72-4a61-88c8-abe2d379fe41.jpg?1",
             "name": "Neera, Wild Mage",
             "text": "Whenever you cast a spell, you may put it on the bottom of its owner's library. If you do, reveal cards from the top of your library until you reveal a nonland card. You may cast that card without paying its mana cost. Then put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
             "colours": [
@@ -16400,7 +16400,7 @@
         },
         {
             "id": "466ebb0c-8370-5c71-b060-e66f27b04427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac9e11-0fa8-4a58-8268-b46ad18c75c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac9e11-0fa8-4a58-8268-b46ad18c75c2.jpg?1",
             "name": "Nine-Fingers Keene",
             "text": "Menace\nWard\u2014\nPay 9 life.\nWhenever Nine-Fingers Keene deals combat damage to a player, look at the top nine cards of your library. You may put a Gate card from among them onto the battlefield. Then if you control nine or more Gates, put the rest into your hand. Otherwise, put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -16444,7 +16444,7 @@
         },
         {
             "id": "457cb4e3-6936-5ace-8e2e-6ce8dfb928af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d41d4f-d2e0-490c-bde0-ce57eb8fda22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d41d4f-d2e0-490c-bde0-ce57eb8fda22.jpg?1",
             "name": "Oji, the Exquisite Blade",
             "text": "When Oji, the Exquisite Blade enters the battlefield, you gain 2 life and scry 2.\nWhenever you cast your second spell each turn, exile up to one target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -16486,7 +16486,7 @@
         },
         {
             "id": "702116c7-51c8-5280-a5cd-44e9f5310a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d8f9c5-b5b6-451c-be60-ce8d16423f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d8f9c5-b5b6-451c-be60-ce8d16423f31.jpg?1",
             "name": "Raggadragga, Goreguts Boss",
             "text": "Each creature you control with a mana ability gets +2/+2.\nWhenever a creature you control with a mana ability attacks, untap it.\nWhenever you cast a spell, if at least seven mana was spent to cast it, untap target creature. It gets +7/+7 and gains trample until end of turn.",
             "colours": [
@@ -16528,7 +16528,7 @@
         },
         {
             "id": "44f4e6bb-a3b8-5121-b78b-53cc75bae520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daf0dab-7660-49bc-a959-1906a2796c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daf0dab-7660-49bc-a959-1906a2796c01.jpg?1",
             "name": "Raphael, Fiendish Savior",
             "text": "Flying\nOther Demons, Devils, Imps, and Tieflings you control get +1/+1 and have lifelink.\nAt the beginning of each end step, if a creature card was put into your graveyard from anywhere this turn, create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -16570,7 +16570,7 @@
         },
         {
             "id": "7807cb4c-ee3e-5307-8334-94c2d2be3431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a599ba-c16b-4ce0-a995-e30974bcc423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a599ba-c16b-4ce0-a995-e30974bcc423.jpg?1",
             "name": "Rilsa Rael, Kingpin",
             "text": "Deathtouch\nWhen Rilsa Rael, Kingpin enters the battlefield, you take the initiative.\nWhenever you attack, target attacking creature gains deathtouch until end of turn. If you've completed a dungeon, that creature also gets +5/+0 and gains first strike and menace until end of turn.",
             "colours": [
@@ -16612,7 +16612,7 @@
         },
         {
             "id": "2a5b897e-e0e2-54d1-b388-040b1efd5afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3f56b9-7460-49b6-8f6d-48cccd7978fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3f56b9-7460-49b6-8f6d-48cccd7978fd.jpg?1",
             "name": "Thrakkus the Butcher",
             "text": "Trample\nWhenever Thrakkus the Butcher attacks, double the power of each Dragon you control until end of turn.",
             "colours": [
@@ -16654,7 +16654,7 @@
         },
         {
             "id": "0e281a21-3911-55b6-98c7-8ba3896cc657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abfec4f-54b8-427e-9abf-6209aa659994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abfec4f-54b8-427e-9abf-6209aa659994.jpg?1",
             "name": "Zevlor, Elturel Exile",
             "text": "Haste\n{2}, {T}: When you next cast an instant or sorcery spell that targets a single opponent or a single permanent an opponent controls this turn, for each other opponent, choose that player or a permanent they control, copy that spell, and the copy targets the chosen player or permanent.",
             "colours": [
@@ -16698,7 +16698,7 @@
         },
         {
             "id": "283bd001-766d-58a4-8b82-49fef09464bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c435b6-4010-4bb6-b645-67732b1ebeab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c435b6-4010-4bb6-b645-67732b1ebeab.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "dd218720-ea2c-58c0-b6ca-148ee47ca57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea5a5f3-7147-4abd-af8d-8baab4c2aa06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea5a5f3-7147-4abd-af8d-8baab4c2aa06.jpg?1",
             "name": "Cloak of the Bat",
             "text": "Equipped creature has flying and haste.\nEquip {2}",
             "colours": [],
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "9b81c60a-dc52-5f00-8cdd-6236be41e77e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914b42b3-03af-4945-9f1f-46c09a1a2314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914b42b3-03af-4945-9f1f-46c09a1a2314.jpg?1",
             "name": "Decanter of Endless Water",
             "text": "You have no maximum hand size.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -16792,7 +16792,7 @@
         },
         {
             "id": "c52cb7ec-28b2-5428-96bf-1e5856e248f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fa8865-c600-4d8d-976d-789cd565802e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fa8865-c600-4d8d-976d-789cd565802e.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -16824,7 +16824,7 @@
         },
         {
             "id": "6b2e3e0b-d976-59bf-b2d6-cb4d3b20c655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6efa9-f198-4d8c-8a30-36a620679477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6efa9-f198-4d8c-8a30-36a620679477.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -16856,7 +16856,7 @@
         },
         {
             "id": "10f49ac1-8265-5728-ad52-3194a68e68d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec4350-cd61-4520-98a4-4a14fcbc226f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec4350-cd61-4520-98a4-4a14fcbc226f.jpg?1",
             "name": "Marching Duodrone",
             "text": "Whenever Marching Duodrone attacks, each player creates a Treasure token.",
             "colours": [],
@@ -16889,7 +16889,7 @@
         },
         {
             "id": "1935156b-2b53-58f3-8edd-b5e67f4b58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89149fb5-3afd-4da0-9a44-9366feb20804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89149fb5-3afd-4da0-9a44-9366feb20804.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -16921,7 +16921,7 @@
         },
         {
             "id": "3463de27-a942-507a-9520-e0432f951b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b21297-be34-445e-8a5a-6c297ab0ee77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b21297-be34-445e-8a5a-6c297ab0ee77.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -16953,7 +16953,7 @@
         },
         {
             "id": "6c89618e-cd50-53c0-81aa-10b302a6cc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7654eb50-4ac1-4388-aea6-373aa2b361ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7654eb50-4ac1-4388-aea6-373aa2b361ae.jpg?1",
             "name": "Stonespeaker Crystal",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Stonespeaker Crystal: Exile any number of target players' graveyards. Draw a card.",
             "colours": [],
@@ -16983,7 +16983,7 @@
         },
         {
             "id": "b6e3d141-a5a0-58ce-820b-a61bbf2bbf78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f5f561-39fd-4cdf-b22e-40cfd6a19d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f5f561-39fd-4cdf-b22e-40cfd6a19d12.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17021,7 +17021,7 @@
         },
         {
             "id": "02c66102-489c-5543-a451-dcad813a98e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be390eb-3470-4f36-9bf4-3f9f8e5d5b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be390eb-3470-4f36-9bf4-3f9f8e5d5b31.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17059,7 +17059,7 @@
         },
         {
             "id": "1a77214d-2ae5-54cc-93e0-c5ff05b59e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524ff04c-932e-4441-a2a7-1416cd43d232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524ff04c-932e-4441-a2a7-1416cd43d232.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17097,7 +17097,7 @@
         },
         {
             "id": "0341170c-2d9a-5e69-8bbe-bbec969ab74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f55597c-f265-4c4b-a5f1-cc58da609534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f55597c-f265-4c4b-a5f1-cc58da609534.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17135,7 +17135,7 @@
         },
         {
             "id": "0b582562-e380-558b-afeb-9a7f21ef5888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3ffe47-53a3-42ec-ae89-afc79793380d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3ffe47-53a3-42ec-ae89-afc79793380d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17173,7 +17173,7 @@
         },
         {
             "id": "2b891378-a0d3-532a-84ce-e03446a90ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b99a83-bfe4-4149-b626-269953c5ac51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b99a83-bfe4-4149-b626-269953c5ac51.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17211,7 +17211,7 @@
         },
         {
             "id": "38ae0023-429f-5ea0-b83e-72f2dbdb26ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995e06d-8145-485e-aeed-3da27a07545b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995e06d-8145-485e-aeed-3da27a07545b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17249,7 +17249,7 @@
         },
         {
             "id": "39f54b10-791b-5677-8a2f-f5b05dc0de0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c9ea23-93c5-4aae-9786-3b3c03a07778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c9ea23-93c5-4aae-9786-3b3c03a07778.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17287,7 +17287,7 @@
         },
         {
             "id": "63e134c8-d2cb-57e2-a78f-4bdef3e8cf92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4111be-6dae-4ca5-bd58-c1ce7cfa9cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4111be-6dae-4ca5-bd58-c1ce7cfa9cf6.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17325,7 +17325,7 @@
         },
         {
             "id": "0eb01d56-20c6-5737-a81d-fb72c07e2a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0866a19-429b-43e4-a4a1-338fe12ead42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0866a19-429b-43e4-a4a1-338fe12ead42.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17363,7 +17363,7 @@
         },
         {
             "id": "6516d981-cce0-5613-9de5-22fad2396c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716460ce-2602-476c-aa53-40d1f22ea7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716460ce-2602-476c-aa53-40d1f22ea7c8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17401,7 +17401,7 @@
         },
         {
             "id": "a9404f0e-8c15-5f20-aad4-0ecdf06ae707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c03592-debd-4b4f-a5ea-a31ce63f5d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c03592-debd-4b4f-a5ea-a31ce63f5d23.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17439,7 +17439,7 @@
         },
         {
             "id": "9d4104c4-bdc1-5a60-94f6-cb31e7ef18ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab63e49-0869-4c7c-a033-d8e50032dd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab63e49-0869-4c7c-a033-d8e50032dd13.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17477,7 +17477,7 @@
         },
         {
             "id": "5f3e9f14-0f1b-5b85-a7dd-ff2043381f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4376426-c901-44eb-8186-c009a3657893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4376426-c901-44eb-8186-c009a3657893.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17515,7 +17515,7 @@
         },
         {
             "id": "efbad82c-56f8-5629-a664-141023fc6ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0333e39b-45e7-46df-908c-0748092ce8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0333e39b-45e7-46df-908c-0748092ce8c1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17553,7 +17553,7 @@
         },
         {
             "id": "d60b336c-10e1-5da1-af88-ab65cb33111b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35132c99-01b9-463c-a00d-6f125893c870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35132c99-01b9-463c-a00d-6f125893c870.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17591,7 +17591,7 @@
         },
         {
             "id": "a0bdc942-0c19-5fa0-be0b-682faab0fe82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf23791-1b15-43ee-b81a-5fe068709bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf23791-1b15-43ee-b81a-5fe068709bc1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17629,7 +17629,7 @@
         },
         {
             "id": "42dd32ec-1107-51fc-b229-b12a0f2a459c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b86b3a4-981e-497a-b78b-30b2dbc5ea7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b86b3a4-981e-497a-b78b-30b2dbc5ea7a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17667,7 +17667,7 @@
         },
         {
             "id": "a7a0181b-2441-590e-83d9-ce5e976600c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca33d91-3c1a-4351-9d9d-d46a6e3de084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca33d91-3c1a-4351-9d9d-d46a6e3de084.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17705,7 +17705,7 @@
         },
         {
             "id": "d2ca566c-ccc4-5d97-84b2-0fbe9f440819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3812e162-3511-4988-b2a1-3bc6945ac45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3812e162-3511-4988-b2a1-3bc6945ac45b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17743,7 +17743,7 @@
         },
         {
             "id": "79bc740b-edab-5413-9297-7674c979b6c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cb7668-e07d-4551-9525-68974b33ad87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cb7668-e07d-4551-9525-68974b33ad87.jpg?1",
             "name": "Abdel Adrian, Gorion's Ward",
             "text": "",
             "colours": [
@@ -17782,7 +17782,7 @@
         },
         {
             "id": "7f9415f8-0c4e-5cde-b1d2-f7e659680a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6e8f9-d6e3-46e0-8e5e-2fe7a7c7efbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6e8f9-d6e3-46e0-8e5e-2fe7a7c7efbe.jpg?1",
             "name": "Ellyn Harbreeze, Busybody",
             "text": "",
             "colours": [
@@ -17821,7 +17821,7 @@
         },
         {
             "id": "5a716ab5-3d3c-5761-af8a-0563d5075d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d826e586-8efd-4725-9d0c-22a7cb7baed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d826e586-8efd-4725-9d0c-22a7cb7baed9.jpg?1",
             "name": "Far Traveler",
             "text": "",
             "colours": [
@@ -17858,7 +17858,7 @@
         },
         {
             "id": "738b2466-2892-5e19-94dd-b8f95d198850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80415872-e35d-4798-a021-b4690d9f78a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80415872-e35d-4798-a021-b4690d9f78a0.jpg?1",
             "name": "Flaming Fist",
             "text": "",
             "colours": [
@@ -17895,7 +17895,7 @@
         },
         {
             "id": "c3680f83-8203-5b96-9e06-e733b013e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394f432d-e59f-44ce-a166-1a939a648cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394f432d-e59f-44ce-a166-1a939a648cbd.jpg?1",
             "name": "Inspiring Leader",
             "text": "",
             "colours": [
@@ -17932,7 +17932,7 @@
         },
         {
             "id": "c9bcf65f-6d29-5f90-8a05-5dbaf8266a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4833ef6c-3ff8-4a3c-826b-58e4a27480a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4833ef6c-3ff8-4a3c-826b-58e4a27480a3.jpg?1",
             "name": "Lae'zel, Vlaakith's Champion",
             "text": "",
             "colours": [
@@ -17971,7 +17971,7 @@
         },
         {
             "id": "0d07aaa5-14d5-54a8-9f89-2eb47bc5406f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2eda80a-14d3-47ab-8133-cafd15a8c17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2eda80a-14d3-47ab-8133-cafd15a8c17c.jpg?1",
             "name": "Lulu, Loyal Hollyphant",
             "text": "",
             "colours": [
@@ -18010,7 +18010,7 @@
         },
         {
             "id": "e7f74101-2890-5951-90d9-2ec10542e67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d11a8-5e1f-41c3-a5a3-1ccd2a2782bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d11a8-5e1f-41c3-a5a3-1ccd2a2782bb.jpg?1",
             "name": "Noble Heritage",
             "text": "",
             "colours": [
@@ -18047,7 +18047,7 @@
         },
         {
             "id": "203f046f-5706-56ea-8765-193bc189ef68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba007e7-e18c-405e-b7ea-6d8a240e68b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba007e7-e18c-405e-b7ea-6d8a240e68b2.jpg?1",
             "name": "Rasaad yn Bashir",
             "text": "",
             "colours": [
@@ -18086,7 +18086,7 @@
         },
         {
             "id": "c3023c8f-9dc4-56dd-9897-8f533b3add33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e011dd48-9238-4e4b-a915-b7ac5fa9b78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e011dd48-9238-4e4b-a915-b7ac5fa9b78f.jpg?1",
             "name": "Veteran Soldier",
             "text": "",
             "colours": [
@@ -18123,7 +18123,7 @@
         },
         {
             "id": "b653a414-0a71-5235-8dab-268d91bce14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b896c-24f1-41d5-9aae-070d8e96fd35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b896c-24f1-41d5-9aae-070d8e96fd35.jpg?1",
             "name": "Alora, Merry Thief",
             "text": "",
             "colours": [
@@ -18162,7 +18162,7 @@
         },
         {
             "id": "26eedfc5-459e-5292-8b40-92ae55f5292d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbcce-bcce-4806-9c73-e4a82a630b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbcce-bcce-4806-9c73-e4a82a630b76.jpg?1",
             "name": "Candlekeep Sage",
             "text": "",
             "colours": [
@@ -18199,7 +18199,7 @@
         },
         {
             "id": "432667b9-8d25-5e92-bd7f-225bc88f0190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a772b9d-2331-4444-a897-c78196ce4836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a772b9d-2331-4444-a897-c78196ce4836.jpg?1",
             "name": "Dungeon Delver",
             "text": "",
             "colours": [
@@ -18236,7 +18236,7 @@
         },
         {
             "id": "ff070d05-c901-58e1-9796-97e3f82b07df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23cdac1-bf6f-46d4-a8f8-d4d30cd0a4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23cdac1-bf6f-46d4-a8f8-d4d30cd0a4f1.jpg?1",
             "name": "Feywild Visitor",
             "text": "",
             "colours": [
@@ -18273,7 +18273,7 @@
         },
         {
             "id": "a46f071e-9b06-5aa3-959d-c48edd96ce55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe5a61-b636-4f4a-a9bb-f26ab430fd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe5a61-b636-4f4a-a9bb-f26ab430fd92.jpg?1",
             "name": "Gale, Waterdeep Prodigy",
             "text": "",
             "colours": [
@@ -18312,7 +18312,7 @@
         },
         {
             "id": "8ba59d29-a503-53cc-ad5b-f146d5aae063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07f957-ad7b-463f-b642-b5d47eadf37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07f957-ad7b-463f-b642-b5d47eadf37a.jpg?1",
             "name": "Imoen, Mystic Trickster",
             "text": "",
             "colours": [
@@ -18352,7 +18352,7 @@
         },
         {
             "id": "6c5aae1c-14db-5300-a3b7-52f186c7ba3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80290716-17c3-41e4-8ef8-814dd25b11e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80290716-17c3-41e4-8ef8-814dd25b11e4.jpg?1",
             "name": "Renari, Merchant of Marvels",
             "text": "",
             "colours": [
@@ -18391,7 +18391,7 @@
         },
         {
             "id": "7d28999e-259d-5d00-a469-3eb216feb49a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f962b9a9-612e-4355-8ab0-a6e41ea4c026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f962b9a9-612e-4355-8ab0-a6e41ea4c026.jpg?1",
             "name": "Shameless Charlatan",
             "text": "",
             "colours": [
@@ -18428,7 +18428,7 @@
         },
         {
             "id": "5b85b3bc-c3f0-5fef-abe4-be15c629e073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d172475f-7063-44fe-ad11-56852d2e86da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d172475f-7063-44fe-ad11-56852d2e86da.jpg?1",
             "name": "Sword Coast Sailor",
             "text": "",
             "colours": [
@@ -18465,7 +18465,7 @@
         },
         {
             "id": "01a2637c-3bd8-51d9-85c1-1dee1ff3354e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73b53a4-11f9-417f-b568-a3e48e0548f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73b53a4-11f9-417f-b568-a3e48e0548f8.jpg?1",
             "name": "Vhal, Candlekeep Researcher",
             "text": "",
             "colours": [
@@ -18504,7 +18504,7 @@
         },
         {
             "id": "48fd4c07-42a6-5280-8e16-c315a052b996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f77bd3a-b9a5-4330-9397-3992a28d157e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f77bd3a-b9a5-4330-9397-3992a28d157e.jpg?1",
             "name": "Volo, Itinerant Scholar",
             "text": "",
             "colours": [
@@ -18543,7 +18543,7 @@
         },
         {
             "id": "fb212980-e0a1-5ac1-9c3d-f539c451eafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82bfc55-8ebd-4a0f-b301-027b76416f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82bfc55-8ebd-4a0f-b301-027b76416f7d.jpg?1",
             "name": "Agent of the Iron Throne",
             "text": "",
             "colours": [
@@ -18580,7 +18580,7 @@
         },
         {
             "id": "499ba51a-b971-5398-a9ba-bd5e6f61195c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae796b5c-1979-4dd2-9539-4b9e18903834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae796b5c-1979-4dd2-9539-4b9e18903834.jpg?1",
             "name": "Agent of the Shadow Thieves",
             "text": "",
             "colours": [
@@ -18617,7 +18617,7 @@
         },
         {
             "id": "5fd68534-0370-5d78-b224-895704b62980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf8122-e282-4def-9f17-b930238bc7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf8122-e282-4def-9f17-b930238bc7d2.jpg?1",
             "name": "Criminal Past",
             "text": "",
             "colours": [
@@ -18654,7 +18654,7 @@
         },
         {
             "id": "5c916b9b-adac-5c56-a7bc-75425528a772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b11ac-187c-4cda-9197-93244d6906c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b11ac-187c-4cda-9197-93244d6906c8.jpg?1",
             "name": "Cultist of the Absolute",
             "text": "",
             "colours": [
@@ -18691,7 +18691,7 @@
         },
         {
             "id": "04f3b78a-2443-52db-887c-b850708aa8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb19fe09-d1d9-40bc-9af7-b19d129f5519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb19fe09-d1d9-40bc-9af7-b19d129f5519.jpg?1",
             "name": "Safana, Calimport Cutthroat",
             "text": "",
             "colours": [
@@ -18730,7 +18730,7 @@
         },
         {
             "id": "6f74423a-0b0a-5b56-a2df-1d204ccaf62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162db102-5675-4827-a668-27a8561b18d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162db102-5675-4827-a668-27a8561b18d1.jpg?1",
             "name": "Sarevok, Deathbringer",
             "text": "",
             "colours": [
@@ -18769,7 +18769,7 @@
         },
         {
             "id": "8f82d67a-4fba-53e8-94a1-f7bdf350335f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7ce463-6427-4040-baec-c5fa361db806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7ce463-6427-4040-baec-c5fa361db806.jpg?1",
             "name": "Scion of Halaster",
             "text": "",
             "colours": [
@@ -18806,7 +18806,7 @@
         },
         {
             "id": "4891513e-aaf6-5d84-82fd-a329678b8864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e13ed-54f9-43f9-ae44-285037e8f074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e13ed-54f9-43f9-ae44-285037e8f074.jpg?1",
             "name": "Shadowheart, Dark Justiciar",
             "text": "",
             "colours": [
@@ -18846,7 +18846,7 @@
         },
         {
             "id": "f159c699-165b-578a-b9ca-49b2d43e8725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d27849-e6a5-44e9-8d7e-a742351d2a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d27849-e6a5-44e9-8d7e-a742351d2a05.jpg?1",
             "name": "Sivriss, Nightmare Speaker",
             "text": "",
             "colours": [
@@ -18886,7 +18886,7 @@
         },
         {
             "id": "6978ec5b-ef10-5749-96d6-499fd1ec2bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842b106-0b54-485e-bb30-72ea6c4370fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842b106-0b54-485e-bb30-72ea6c4370fd.jpg?1",
             "name": "Viconia, Drow Apostate",
             "text": "",
             "colours": [
@@ -18925,7 +18925,7 @@
         },
         {
             "id": "7f27978a-d9f5-5d55-8cca-ff06f3207b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff35b8d7-d6e5-4474-8648-79f2c538a434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff35b8d7-d6e5-4474-8648-79f2c538a434.jpg?1",
             "name": "Amber Gristle O'Maul",
             "text": "",
             "colours": [
@@ -18964,7 +18964,7 @@
         },
         {
             "id": "ee86be06-ffc1-5473-9080-fdb4a1202eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465cb37e-627d-44ec-9d2d-6a630b14c25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465cb37e-627d-44ec-9d2d-6a630b14c25f.jpg?1",
             "name": "Dragon Cultist",
             "text": "",
             "colours": [
@@ -19001,7 +19001,7 @@
         },
         {
             "id": "3e96b757-9222-5156-b91f-9c334368cf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb28cc-67bd-4e1f-933a-3b859f38ea64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb28cc-67bd-4e1f-933a-3b859f38ea64.jpg?1",
             "name": "Ganax, Astral Hunter",
             "text": "",
             "colours": [
@@ -19039,7 +19039,7 @@
         },
         {
             "id": "dcca6ca6-ed0f-5983-97f8-a6908a894805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a331542-11e4-49dc-be2f-ee56f07ccee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a331542-11e4-49dc-be2f-ee56f07ccee0.jpg?1",
             "name": "Guild Artisan",
             "text": "",
             "colours": [
@@ -19076,7 +19076,7 @@
         },
         {
             "id": "23e80ec1-4dfc-5fa9-a730-ce27a1e701d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163a7729-b115-46dd-afb4-7a5df89c3ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163a7729-b115-46dd-afb4-7a5df89c3ed1.jpg?1",
             "name": "Gut, True Soul Zealot",
             "text": "",
             "colours": [
@@ -19115,7 +19115,7 @@
         },
         {
             "id": "f1cc4434-2d9f-59f8-b365-81794909ce60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231621a3-01dc-41af-827a-94aaa63179ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231621a3-01dc-41af-827a-94aaa63179ae.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "",
             "colours": [
@@ -19154,7 +19154,7 @@
         },
         {
             "id": "f99956ea-01e9-5129-b894-56364204693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515eb7b-d42b-4a3d-880d-d4dec99db4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515eb7b-d42b-4a3d-880d-d4dec99db4b2.jpg?1",
             "name": "Livaan, Cultist of Tiamat",
             "text": "",
             "colours": [
@@ -19193,7 +19193,7 @@
         },
         {
             "id": "837fa2a2-c3db-53db-9199-a44f256a28e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98fe671-e358-43f6-8f85-a84668be3a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98fe671-e358-43f6-8f85-a84668be3a5d.jpg?1",
             "name": "Popular Entertainer",
             "text": "",
             "colours": [
@@ -19230,7 +19230,7 @@
         },
         {
             "id": "e3207772-927c-5d1d-975a-2b71ac2f7c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c393ffd7-18e6-4399-ba6f-5e211c669113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c393ffd7-18e6-4399-ba6f-5e211c669113.jpg?1",
             "name": "Street Urchin",
             "text": "",
             "colours": [
@@ -19267,7 +19267,7 @@
         },
         {
             "id": "0169b206-2c44-581f-bc1a-10d801718d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f74187e-64ac-4685-ad21-0746cb2b61f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f74187e-64ac-4685-ad21-0746cb2b61f4.jpg?1",
             "name": "Tavern Brawler",
             "text": "",
             "colours": [
@@ -19304,7 +19304,7 @@
         },
         {
             "id": "135bc328-a39a-5218-bb02-f56ee03605df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e01be28-d138-4204-b425-a9922448d97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e01be28-d138-4204-b425-a9922448d97c.jpg?1",
             "name": "Wyll, Blade of Frontiers",
             "text": "",
             "colours": [
@@ -19343,7 +19343,7 @@
         },
         {
             "id": "20bbbd6a-2314-5877-854d-9df7f06dddf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddd9b4f-621a-40d2-bc46-08d5adc3571f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddd9b4f-621a-40d2-bc46-08d5adc3571f.jpg?1",
             "name": "Acolyte of Bahamut",
             "text": "",
             "colours": [
@@ -19380,7 +19380,7 @@
         },
         {
             "id": "56c863e1-fbcb-55c7-b173-a223cd86b4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bfbfaa-d66c-48d2-938e-024ef8c33c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bfbfaa-d66c-48d2-938e-024ef8c33c32.jpg?1",
             "name": "Cloakwood Hermit",
             "text": "",
             "colours": [
@@ -19417,7 +19417,7 @@
         },
         {
             "id": "b986c71f-1963-5bb8-9885-e9200f6fd1e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07efa583-c8ef-4d02-a548-1b4186790470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07efa583-c8ef-4d02-a548-1b4186790470.jpg?1",
             "name": "Erinis, Gloom Stalker",
             "text": "",
             "colours": [
@@ -19456,7 +19456,7 @@
         },
         {
             "id": "02469c04-a421-5fe5-b56e-5ff7bf989b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f546b455-20b5-4970-adb8-24d469842298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f546b455-20b5-4970-adb8-24d469842298.jpg?1",
             "name": "Halsin, Emerald Archdruid",
             "text": "",
             "colours": [
@@ -19495,7 +19495,7 @@
         },
         {
             "id": "585a91e6-2ca9-5536-a1b6-0aeb8098131e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d418c62c-ba1f-4399-a06c-cc3a0d23b117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d418c62c-ba1f-4399-a06c-cc3a0d23b117.jpg?1",
             "name": "Hardy Outlander",
             "text": "",
             "colours": [
@@ -19532,7 +19532,7 @@
         },
         {
             "id": "fbf1db14-47b1-51ba-814b-bf10bf95f8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27186d29-7b24-40f9-909f-456e0e3d8847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27186d29-7b24-40f9-909f-456e0e3d8847.jpg?1",
             "name": "Jaheira, Friend of the Forest",
             "text": "",
             "colours": [
@@ -19572,7 +19572,7 @@
         },
         {
             "id": "25957c3a-5ce0-5274-90a3-3f496bc34ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd941ff-b423-4379-91c3-7c3d95a4b0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd941ff-b423-4379-91c3-7c3d95a4b0cb.jpg?1",
             "name": "Master Chef",
             "text": "",
             "colours": [
@@ -19609,7 +19609,7 @@
         },
         {
             "id": "d6f9df44-26c0-52e0-b2f4-0816f59f527b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9caae7-fb67-42bf-bee0-b935a1b88d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9caae7-fb67-42bf-bee0-b935a1b88d79.jpg?1",
             "name": "Raised by Giants",
             "text": "",
             "colours": [
@@ -19646,7 +19646,7 @@
         },
         {
             "id": "60ede1c7-e412-5bde-b2ac-c727fc259e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7bfe9-1abb-4562-9182-eb37460a1c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7bfe9-1abb-4562-9182-eb37460a1c6c.jpg?1",
             "name": "Skanos Dragonheart",
             "text": "",
             "colours": [
@@ -19685,7 +19685,7 @@
         },
         {
             "id": "d3c30744-71fe-5389-accc-faa106d53a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91422b68-b4a8-4138-8aee-bc98d33d6a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91422b68-b4a8-4138-8aee-bc98d33d6a6c.jpg?1",
             "name": "Wilson, Refined Grizzly",
             "text": "",
             "colours": [
@@ -19724,7 +19724,7 @@
         },
         {
             "id": "2d781461-95c5-5c5a-b8ed-51e4e879834d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e31d6fa-187f-4163-af23-aea86bc2e5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e31d6fa-187f-4163-af23-aea86bc2e5cb.jpg?1",
             "name": "Alaundo the Seer",
             "text": "",
             "colours": [
@@ -19765,7 +19765,7 @@
         },
         {
             "id": "bc64f7a0-2b66-5bde-9cce-58f832e6ab4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87edd00-062d-48b8-b212-cc0073fe05ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87edd00-062d-48b8-b212-cc0073fe05ea.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "",
             "colours": [
@@ -19807,7 +19807,7 @@
         },
         {
             "id": "7b2e076e-9b85-5c58-8f12-f856382b737d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b330c216-4c1f-4318-8add-20b766afd94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b330c216-4c1f-4318-8add-20b766afd94c.jpg?1",
             "name": "Baba Lysaga, Night Witch",
             "text": "",
             "colours": [
@@ -19848,7 +19848,7 @@
         },
         {
             "id": "8b476199-0d26-5e4e-9d9f-a225583db3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5176ed32-2548-41cb-8128-28a9a73acdf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5176ed32-2548-41cb-8128-28a9a73acdf9.jpg?1",
             "name": "Bane, Lord of Darkness",
             "text": "",
             "colours": [
@@ -19890,7 +19890,7 @@
         },
         {
             "id": "2a82b602-1707-548f-bf83-91d436b67d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a5e627-69a5-4e31-9744-97d4589d606b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a5e627-69a5-4e31-9744-97d4589d606b.jpg?1",
             "name": "Bhaal, Lord of Murder",
             "text": "",
             "colours": [
@@ -19932,7 +19932,7 @@
         },
         {
             "id": "159e1095-755a-56e6-a7ef-df7683fedb33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb03f28-f327-4071-b08e-b72df6e69137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb03f28-f327-4071-b08e-b72df6e69137.jpg?1",
             "name": "Cadira, Caller of the Small",
             "text": "",
             "colours": [
@@ -19973,7 +19973,7 @@
         },
         {
             "id": "03d8d7f5-5b95-5108-8310-7f4351c7a161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11466e07-ba23-4058-8490-28b144ab39ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11466e07-ba23-4058-8490-28b144ab39ae.jpg?1",
             "name": "Commander Liara Portyr",
             "text": "",
             "colours": [
@@ -20014,7 +20014,7 @@
         },
         {
             "id": "67e640bb-9639-55f6-9ea4-ebc1e5159eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1610d8b1-6b4c-450a-96c2-b56fd08b3f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1610d8b1-6b4c-450a-96c2-b56fd08b3f86.jpg?1",
             "name": "The Council of Four",
             "text": "",
             "colours": [
@@ -20055,7 +20055,7 @@
         },
         {
             "id": "cf7ee656-49bb-532b-b702-316637b6fe80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b8a4a3-20c5-4c6c-85ae-e9e3f5724859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b8a4a3-20c5-4c6c-85ae-e9e3f5724859.jpg?1",
             "name": "Duke Ulder Ravengard",
             "text": "",
             "colours": [
@@ -20097,7 +20097,7 @@
         },
         {
             "id": "0f0a6029-d1b8-500d-b162-f57026fca6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c92d2a9-a4f9-4fff-a57f-9cd2370bb5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c92d2a9-a4f9-4fff-a57f-9cd2370bb5bf.jpg?1",
             "name": "Dynaheir, Invoker Adept",
             "text": "",
             "colours": [
@@ -20140,7 +20140,7 @@
         },
         {
             "id": "028c2d88-0ab0-55d6-967d-5b3236a9ca7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836d7e5-98cd-4f1e-9a66-150b80cd0325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836d7e5-98cd-4f1e-9a66-150b80cd0325.jpg?1",
             "name": "Gluntch, the Bestower",
             "text": "",
             "colours": [
@@ -20180,7 +20180,7 @@
         },
         {
             "id": "103cc44a-2fcf-505b-acd8-2a32230933cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec0854e-5005-45e6-be3f-008c5d7b85f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec0854e-5005-45e6-be3f-008c5d7b85f0.jpg?1",
             "name": "Gorion, Wise Mentor",
             "text": "",
             "colours": [
@@ -20223,7 +20223,7 @@
         },
         {
             "id": "9f2035ec-71bf-55d6-9b6e-c8779e62b2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e19be3-8bf7-4f20-926b-76aa69fe36d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e19be3-8bf7-4f20-926b-76aa69fe36d3.jpg?1",
             "name": "Jan Jansen, Chaos Crafter",
             "text": "",
             "colours": [
@@ -20266,7 +20266,7 @@
         },
         {
             "id": "35c9967f-09ba-5758-813a-6b294de7868e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41796670-081a-41e9-8c1c-e6cf391b5896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41796670-081a-41e9-8c1c-e6cf391b5896.jpg?1",
             "name": "Jon Irenicus, Shattered One",
             "text": "",
             "colours": [
@@ -20307,7 +20307,7 @@
         },
         {
             "id": "c7f310a3-62be-5025-a378-38991cef8d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dfb05a-e88c-426c-999c-1a9871ec4197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dfb05a-e88c-426c-999c-1a9871ec4197.jpg?1",
             "name": "Kagha, Shadow Archdruid",
             "text": "",
             "colours": [
@@ -20348,7 +20348,7 @@
         },
         {
             "id": "c070e8aa-e72e-54ee-b98f-ed1c8f238ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bae554-6c95-4d83-a85b-163b5dfbf4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bae554-6c95-4d83-a85b-163b5dfbf4ff.jpg?1",
             "name": "Korlessa, Scale Singer",
             "text": "",
             "colours": [
@@ -20389,7 +20389,7 @@
         },
         {
             "id": "6e2d8cf9-6c16-54f5-926f-7cee98a1c5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24ed5b7-2f71-4f11-a787-fa683216469c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24ed5b7-2f71-4f11-a787-fa683216469c.jpg?1",
             "name": "Lozhan, Dragons' Legacy",
             "text": "",
             "colours": [
@@ -20430,7 +20430,7 @@
         },
         {
             "id": "f4f74cb1-48b4-5746-9aec-d38993944b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c502480-111e-46a3-9f2f-9c4901d88323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c502480-111e-46a3-9f2f-9c4901d88323.jpg?1",
             "name": "Mahadi, Emporium Master",
             "text": "",
             "colours": [
@@ -20470,7 +20470,7 @@
         },
         {
             "id": "346b434b-1c81-522f-a6fa-de5e1074c369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f41f17-ba7c-4028-b4b6-3a47fa63ac58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f41f17-ba7c-4028-b4b6-3a47fa63ac58.jpg?1",
             "name": "Mazzy, Truesword Paladin",
             "text": "",
             "colours": [
@@ -20513,7 +20513,7 @@
         },
         {
             "id": "bf160340-e15a-51a6-94ef-944a5ffe18df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179cada0-44d5-40f6-8c50-42e56a595fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179cada0-44d5-40f6-8c50-42e56a595fb3.jpg?1",
             "name": "Miirym, Sentinel Wyrm",
             "text": "",
             "colours": [
@@ -20556,7 +20556,7 @@
         },
         {
             "id": "2f48280a-4770-5bfa-a508-88554e516bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09de7bd-ad2a-46c0-bdfb-f529d7f9ebc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09de7bd-ad2a-46c0-bdfb-f529d7f9ebc6.jpg?1",
             "name": "Minthara, Merciless Soul",
             "text": "",
             "colours": [
@@ -20597,7 +20597,7 @@
         },
         {
             "id": "a7f40136-227d-5d1f-9d54-94ed98721af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd790307-9926-4b7c-a90d-ca844adbe0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd790307-9926-4b7c-a90d-ca844adbe0ba.jpg?1",
             "name": "Myrkul, Lord of Bones",
             "text": "",
             "colours": [
@@ -20639,7 +20639,7 @@
         },
         {
             "id": "caa41e61-147e-551e-9fa7-a34d0fb5899c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55339f7c-667b-471c-8ed3-41c368bcfc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55339f7c-667b-471c-8ed3-41c368bcfc49.jpg?1",
             "name": "Neera, Wild Mage",
             "text": "",
             "colours": [
@@ -20681,7 +20681,7 @@
         },
         {
             "id": "099acbee-cb02-50fe-8592-a0cdc9fff85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223ccdc-abf2-42b5-a8b3-c5afbf843552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223ccdc-abf2-42b5-a8b3-c5afbf843552.jpg?1",
             "name": "Nine-Fingers Keene",
             "text": "",
             "colours": [
@@ -20724,7 +20724,7 @@
         },
         {
             "id": "eb4dd12e-d86f-532d-9d0c-84f0f34d4ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e8e3ba-692c-4ad8-8b89-75de05c0488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e8e3ba-692c-4ad8-8b89-75de05c0488a.jpg?1",
             "name": "Oji, the Exquisite Blade",
             "text": "",
             "colours": [
@@ -20765,7 +20765,7 @@
         },
         {
             "id": "210a4563-272e-5290-b793-4db6abfb6fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc26ee-5a1e-4fbb-b104-f454fd9dc7e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc26ee-5a1e-4fbb-b104-f454fd9dc7e9.jpg?1",
             "name": "Raggadragga, Goreguts Boss",
             "text": "",
             "colours": [
@@ -20806,7 +20806,7 @@
         },
         {
             "id": "cd640b8a-4848-5ee2-a0ce-cde99ae31d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee93ebf-710c-4c8b-a62b-26c41d8a5406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee93ebf-710c-4c8b-a62b-26c41d8a5406.jpg?1",
             "name": "Raphael, Fiendish Savior",
             "text": "",
             "colours": [
@@ -20847,7 +20847,7 @@
         },
         {
             "id": "2574c3b0-27b1-52f7-9a42-535bfd56662b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c909c8d2-72c3-40b5-a74c-e78b0e8fceda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c909c8d2-72c3-40b5-a74c-e78b0e8fceda.jpg?1",
             "name": "Rilsa Rael, Kingpin",
             "text": "",
             "colours": [
@@ -20888,7 +20888,7 @@
         },
         {
             "id": "876bc8de-4757-5b95-b9b3-5bf35320bfd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa117d-2404-418d-8d5b-0a68550c1e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa117d-2404-418d-8d5b-0a68550c1e9b.jpg?1",
             "name": "Thrakkus the Butcher",
             "text": "",
             "colours": [
@@ -20929,7 +20929,7 @@
         },
         {
             "id": "edc2eb71-560c-5cbd-bf33-642689a83ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4c302c-47d6-42af-9fdd-e13f11d803a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4c302c-47d6-42af-9fdd-e13f11d803a5.jpg?1",
             "name": "Zevlor, Elturel Exile",
             "text": "",
             "colours": [
@@ -20972,7 +20972,7 @@
         },
         {
             "id": "ea110350-353e-5823-a0d1-ef672e0c5113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67ef30-a8ef-4437-8c9a-d125a98fbd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67ef30-a8ef-4437-8c9a-d125a98fbd6b.jpg?1",
             "name": "Archivist of Oghma",
             "text": "Flash\nWhenever an opponent searches their library, you gain 1 life and draw a card.",
             "colours": [
@@ -21009,7 +21009,7 @@
         },
         {
             "id": "98800342-0d4f-5dcf-8b09-054499d8539b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe418c35-b0f1-4322-8ade-c5fe574de878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe418c35-b0f1-4322-8ade-c5fe574de878.jpg?1",
             "name": "Ascend from Avernus",
             "text": "Return all creature and planeswalker cards with mana value X or less from your graveyard to the battlefield. Exile Ascend from Avernus.",
             "colours": [
@@ -21043,7 +21043,7 @@
         },
         {
             "id": "88516c02-5bb1-5604-880f-f21f7f7ad2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {3}",
             "colours": [
@@ -21079,7 +21079,7 @@
         },
         {
             "id": "08646398-5418-57f2-bc71-e07a666544a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Create X 1/1 white Soldier creature tokens. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -21115,7 +21115,7 @@
         },
         {
             "id": "a3d4cf00-d8da-59b2-b220-d14810c18e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d9db1-c3e9-4efa-a095-9c2b8a61dcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d9db1-c3e9-4efa-a095-9c2b8a61dcec.jpg?1",
             "name": "Lae'zel's Acrobatics",
             "text": "Exile all nontoken creatures you control, then roll a d20.\n1\u20139 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10\u201320 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -21149,7 +21149,7 @@
         },
         {
             "id": "edea17cc-fdfe-5045-9684-7cd8ba60faf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6087b40-4fd5-4fbc-8599-e67a5cb76832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6087b40-4fd5-4fbc-8599-e67a5cb76832.jpg?1",
             "name": "Sculpted Sunburst",
             "text": "Choose a creature you control, then each opponent chooses a creature they control with equal or lesser power. If you chose a creature this way, exile each creature not chosen by any player this way.",
             "colours": [
@@ -21183,7 +21183,7 @@
         },
         {
             "id": "fd3fb8aa-7755-52e6-adb8-6f7fd53eccb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b944490b-4366-46d1-b499-9c3f66c9ba35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b944490b-4366-46d1-b499-9c3f66c9ba35.jpg?1",
             "name": "White Plume Adventurer",
             "text": "When White Plume Adventurer enters the battlefield, you take the initiative.\nAt the beginning of each opponent's upkeep, untap a creature you control. If you've completed a dungeon, untap all creatures you control instead.",
             "colours": [
@@ -21220,7 +21220,7 @@
         },
         {
             "id": "3de2f75a-e661-5e21-beaa-7125ea4dc690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36216a6-e043-42f5-96d2-e0844055c83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36216a6-e043-42f5-96d2-e0844055c83a.jpg?1",
             "name": "Windshaper Planetar",
             "text": "Flash\nFlying\nWhen Windshaper Planetar enters the battlefield during the declare attackers step, for each attacking creature, you may reselect which player or planeswalker that creature is attacking.",
             "colours": [
@@ -21256,7 +21256,7 @@
         },
         {
             "id": "8fad51e2-d244-5e96-802d-3fd261d7573b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a53e8fc-bfd2-4866-a61c-f3204b0a98bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a53e8fc-bfd2-4866-a61c-f3204b0a98bf.jpg?1",
             "name": "Displacer Kitten",
             "text": "Avoidance \u2014 Whenever you cast a noncreature spell, exile up to one target nonland permanent you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -21293,7 +21293,7 @@
         },
         {
             "id": "69f80a8b-f0f8-55ad-84a1-4dad0695a18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3184cbb-71d4-4b33-ae5d-f8d18b36ba22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3184cbb-71d4-4b33-ae5d-f8d18b36ba22.jpg?1",
             "name": "Elminster's Simulacrum",
             "text": "For each opponent, you create a token that's a copy of up to one target creature that player controls.",
             "colours": [
@@ -21327,7 +21327,7 @@
         },
         {
             "id": "3608a839-e667-5b54-9b30-b93337410083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f204b1-73cb-4d51-8003-97e83d6b52b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f204b1-73cb-4d51-8003-97e83d6b52b8.jpg?1",
             "name": "Font of Magic",
             "text": "Instant and sorcery spells you cast cost {1} less to cast for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -21361,7 +21361,7 @@
         },
         {
             "id": "35cc2be2-9d3a-5e3f-9d24-3923c3b7a10b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaaa47-236e-48ff-a601-a454afc0250f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaaa47-236e-48ff-a601-a454afc0250f.jpg?1",
             "name": "Gale's Redirection",
             "text": "Exile target spell, then roll a d20 and add that spell's mana value.\n1\u201314 | You may cast the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\n15+ | You may cast the exiled card without paying its mana cost for as long as it remains exiled.",
             "colours": [
@@ -21395,7 +21395,7 @@
         },
         {
             "id": "14c4e5fc-8545-56aa-b73f-58e07a1f5814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Ceremorphosis \u2014 When Illithid Harvester enters the battlefield, turn any number of target tapped nontoken creatures face down. They're 2/2 Horror creatures.",
             "colours": [
@@ -21431,7 +21431,7 @@
         },
         {
             "id": "38a2308c-57be-5bf4-bf9d-fcd7cbcb90ea",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Tap X target creatures. They don't untap during their controllers' next untap steps. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -21467,7 +21467,7 @@
         },
         {
             "id": "2bc6ddd4-53cc-5b51-b3df-9f363a59b6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f744b4e-18be-4d41-8ea5-eac47a32cfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f744b4e-18be-4d41-8ea5-eac47a32cfcf.jpg?1",
             "name": "Kindred Discovery",
             "text": "As Kindred Discovery enters the battlefield, choose a creature type.\nWhenever a creature you control of the chosen type enters the battlefield or attacks, draw a card.",
             "colours": [
@@ -21501,7 +21501,7 @@
         },
         {
             "id": "7049f82f-0335-59b6-a85e-98cc8d84c5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76c7f02-43dd-437d-82c7-79ef7de5b916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76c7f02-43dd-437d-82c7-79ef7de5b916.jpg?1",
             "name": "Robe of the Archmagi",
             "text": "Whenever equipped creature deals combat damage to a player, you draw that many cards.\nEquip {4}\nEquip Shaman, Warlock, or Wizard {1}",
             "colours": [
@@ -21537,7 +21537,7 @@
         },
         {
             "id": "b3ccef91-fd62-5fbe-8be9-d7e3cc1818ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4cbadb-ca60-4a4b-97d3-c9133feefb54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4cbadb-ca60-4a4b-97d3-c9133feefb54.jpg?1",
             "name": "Tomb of Horrors Adventurer",
             "text": "When Tomb of Horrors Adventurer enters the battlefield, you take the initiative.\nWhenever you cast your second spell each turn, copy it. If you've completed a dungeon, copy that spell twice instead. You may choose new targets for the copies.",
             "colours": [
@@ -21574,7 +21574,7 @@
         },
         {
             "id": "a0199f3d-8ca3-5ce6-9eb0-74b98a3641dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c434dcde-8745-447f-8675-03ae6b57ec3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c434dcde-8745-447f-8675-03ae6b57ec3b.jpg?1",
             "name": "Wizards of Thay",
             "text": "Myriad\nInstant and sorcery spells you cast cost {1} less to cast.\nYou may cast sorcery spells as though they had flash.",
             "colours": [
@@ -21611,7 +21611,7 @@
         },
         {
             "id": "041c3653-d6ef-52b5-9225-c127aba299b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "{2}{B}, {T}, Exile a creature you control: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -21645,7 +21645,7 @@
         },
         {
             "id": "104260ef-d40f-53cf-9dc1-e20f477625e8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "Create a tapped 4/1 black Skeleton creature token with menace. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -21681,7 +21681,7 @@
         },
         {
             "id": "50073cee-07f8-52d9-8141-3c52ef28018e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653436b2-899c-48e9-b069-1ec84844cc48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653436b2-899c-48e9-b069-1ec84844cc48.jpg?1",
             "name": "Astarion's Thirst",
             "text": "Exile target creature. Put X +1/+1 counters on a commander creature you control, where X is the power of the creature exiled this way.",
             "colours": [
@@ -21715,7 +21715,7 @@
         },
         {
             "id": "caa90052-1b45-5720-849d-e83fc8b3da08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9875dc-b271-40a6-b6e1-f9f0fbb00db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9875dc-b271-40a6-b6e1-f9f0fbb00db7.jpg?1",
             "name": "Blood Money",
             "text": "Destroy all creatures. For each nontoken creature destroyed this way, you create a tapped Treasure token.",
             "colours": [
@@ -21749,7 +21749,7 @@
         },
         {
             "id": "dcc8b391-16f1-56e9-add3-887c04f46419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d7a1c-2f9a-4af7-9795-4046ac96347a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d7a1c-2f9a-4af7-9795-4046ac96347a.jpg?1",
             "name": "Call to the Void",
             "text": "Each player secretly chooses a creature they control and a creature they don't control. Then those choices are revealed. Destroy each creature chosen this way.",
             "colours": [
@@ -21783,7 +21783,7 @@
         },
         {
             "id": "67cf0ca6-5b62-567f-8089-383aa7623ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e49d20-170a-4b6a-ac82-d3ceaab226ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e49d20-170a-4b6a-ac82-d3ceaab226ea.jpg?1",
             "name": "Elder Brain",
             "text": "Menace\nWhenever Elder Brain attacks a player, exile all cards from that player's hand, then they draw that many cards. You may play lands and cast spells from among the exiled cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -21820,7 +21820,7 @@
         },
         {
             "id": "293dcfea-6224-5821-9e84-242cbab84138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a741f-288c-4f19-b200-cacef57674e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a741f-288c-4f19-b200-cacef57674e9.jpg?1",
             "name": "Eldritch Pact",
             "text": "Target player draws X cards and loses X life, where X is the number of cards in their graveyard.",
             "colours": [
@@ -21854,7 +21854,7 @@
         },
         {
             "id": "24a2f4b3-99a5-5932-a97b-9149c36be3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73342536-fd44-4958-b77e-56eec222252e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73342536-fd44-4958-b77e-56eec222252e.jpg?1",
             "name": "Intellect Devourer",
             "text": "Devour Intellect \u2014 When Intellect Devourer enters the battlefield, each opponent exiles a card from their hand until Intellect Devourer leaves the battlefield.\nBody Thief \u2014 You may play lands and cast spells from among cards exiled with Intellect Devourer. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -21890,7 +21890,7 @@
         },
         {
             "id": "a297d7a8-ee4a-5af4-8671-6a59ca63970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdfbc37-f259-42c0-a8cd-c772a0343257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdfbc37-f259-42c0-a8cd-c772a0343257.jpg?1",
             "name": "Pact Weapon",
             "text": "As long as Pact Weapon is attached to a creature, you don't lose the game for having 0 or less life.\nWhenever equipped creature attacks, draw a card and reveal it. The creature gets +X/+X until end of turn and you lose X life, where X is that card's mana value.\nEquip\u2014\nDiscard a card.",
             "colours": [
@@ -21926,7 +21926,7 @@
         },
         {
             "id": "e55b66c6-dde8-5e62-ab79-ac461f0eaba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057dedd1-6632-4d87-a5bb-8c66c7492857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057dedd1-6632-4d87-a5bb-8c66c7492857.jpg?1",
             "name": "Ravenloft Adventurer",
             "text": "When Ravenloft Adventurer enters the battlefield, you take the initiative.\nIf a creature an opponent controls would die, instead exile it and put a hit counter on it.\nWhenever Ravenloft Adventurer attacks, if you've completed a dungeon, defending player loses 1 life for each card they own in exile with a hit counter on it.",
             "colours": [
@@ -21964,7 +21964,7 @@
         },
         {
             "id": "4e7537da-57b4-5e83-9a0f-e75fe9034553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc9987-73f6-4cbe-9965-1894deabd080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc9987-73f6-4cbe-9965-1894deabd080.jpg?1",
             "name": "Balor",
             "text": "Flying\nWhenever Balor attacks or dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent draws three cards, then discards three cards at random.\n\u2022 Target opponent sacrifices a nontoken artifact.\n\u2022 Balor deals damage to target opponent equal to the number of cards in their hand.",
             "colours": [
@@ -22000,7 +22000,7 @@
         },
         {
             "id": "fd6760cb-b48b-5c43-8e70-3e6859555f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb5d440-8f2c-4b21-8fdb-fd40e5710475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb5d440-8f2c-4b21-8fdb-fd40e5710475.jpg?1",
             "name": "Caves of Chaos Adventurer",
             "text": "Trample\nWhen Caves of Chaos Adventurer enters the battlefield, you take the initiative.\nWhenever Caves of Chaos Adventurer attacks, exile the top card of your library. If you've completed a dungeon, you may play that card this turn without paying its mana cost. Otherwise, you may play that card this turn.",
             "colours": [
@@ -22037,7 +22037,7 @@
         },
         {
             "id": "84b4d9c3-1f42-51ad-b303-a0833ad24c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75e9d08-489d-42ee-9513-0984d25d8c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75e9d08-489d-42ee-9513-0984d25d8c4a.jpg?1",
             "name": "Descent into Avernus",
             "text": "At the beginning of your upkeep, put two descent counters on Descent into Avernus. Then each player creates X Treasure tokens and Descent into Avernus deals X damage to each player, where X is the number of descent counters on Descent into Avernus.",
             "colours": [
@@ -22071,7 +22071,7 @@
         },
         {
             "id": "dd62e7b7-1e49-5723-9320-c1d75e1caac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7828e-3e92-4a94-9090-24353fc2e670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7828e-3e92-4a94-9090-24353fc2e670.jpg?1",
             "name": "Elturel Survivors",
             "text": "Trample, myriad\nAs long as Elturel Survivors is attacking, it gets +X/+0, where X is the number of lands defending player controls.",
             "colours": [
@@ -22108,7 +22108,7 @@
         },
         {
             "id": "ea66057a-1ede-5934-82d5-e37d832150dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738abf75-009d-439d-91d5-07545bccdb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738abf75-009d-439d-91d5-07545bccdb1f.jpg?1",
             "name": "Firbolg Flutist",
             "text": "Enthralling Performance \u2014 When Firbolg Flutist enters the battlefield, gain control of target creature you don't control until end of turn. Untap it. It gains haste and myriad until end of turn.",
             "colours": [
@@ -22145,7 +22145,7 @@
         },
         {
             "id": "2d6523c3-5a13-5401-bd3c-cbe93515239c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4096d51-2b96-489f-9fb9-631f47706fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4096d51-2b96-489f-9fb9-631f47706fd0.jpg?1",
             "name": "Storm King's Thunder",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell X times. You may choose new targets for the copies.",
             "colours": [
@@ -22179,7 +22179,7 @@
         },
         {
             "id": "e495c38d-479e-5df0-ba5d-7fd1bdfa20bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fffd5-dba1-4987-ac99-7d516dcd203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fffd5-dba1-4987-ac99-7d516dcd203b.jpg?1",
             "name": "Wand of Wonder",
             "text": "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1\u20139 | X is one.\n10\u201319 | X is two.\n20 | X is three.",
             "colours": [
@@ -22214,7 +22214,7 @@
         },
         {
             "id": "2ad75ba1-4a60-5863-8395-be3a6a00f88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8965c80-dece-4f36-aa75-c2b5ced40800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8965c80-dece-4f36-aa75-c2b5ced40800.jpg?1",
             "name": "Wrathful Red Dragon",
             "text": "Flying\nWhenever a Dragon you control is dealt damage, it deals that much damage to any target that isn't a Dragon.",
             "colours": [
@@ -22250,7 +22250,7 @@
         },
         {
             "id": "c3039b8f-d4c6-5b12-8d8c-589aad375f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4070ed-146e-490e-ae76-bfaa26b13b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4070ed-146e-490e-ae76-bfaa26b13b18.jpg?1",
             "name": "Wyll's Reversal",
             "text": "Choose target spell or ability with one or more targets. Roll a d20 and add the greatest power among creatures you control.\n1\u201314 | You may choose new targets for that spell or ability.\n15+ | You may choose new targets for that spell or ability. Then copy it. You may choose new targets for the copy.",
             "colours": [
@@ -22284,7 +22284,7 @@
         },
         {
             "id": "e531f8bb-480b-56d4-9d3a-d6cc8c6ee45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84188f7b-0338-4313-a794-8e858736dff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84188f7b-0338-4313-a794-8e858736dff9.jpg?1",
             "name": "Barroom Brawl",
             "text": "Target creature you control fights target creature the opponent to your left controls. Then that player may copy this spell and may choose new targets for the copy.",
             "colours": [
@@ -22318,7 +22318,7 @@
         },
         {
             "id": "80a8975d-abae-5329-8b47-a5d5ceea4b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edfb64-2177-442d-bd10-7ed1fdaa3537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edfb64-2177-442d-bd10-7ed1fdaa3537.jpg?1",
             "name": "Earthquake Dragon",
             "text": "This spell costs {X} less to cast, where X is the total mana value of Dragons you control.\nFlying, trample\n{2}{G}, Sacrifice a land: Return Earthquake Dragon from your graveyard to your hand.",
             "colours": [
@@ -22355,7 +22355,7 @@
         },
         {
             "id": "9a264dc2-dc9b-5da7-9264-2e28dbea7bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0a6836-6b45-4528-85bd-1de8b28ab4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0a6836-6b45-4528-85bd-1de8b28ab4d8.jpg?1",
             "name": "Jaheira's Respite",
             "text": "Search your library for up to X basic land cards, where X is the number of creatures attacking you, put those cards onto the battlefield tapped, then shuffle.\nPrevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -22389,7 +22389,7 @@
         },
         {
             "id": "0846ff07-76e5-56b2-9466-85b56c2512a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528ef70f-4844-48fa-a768-4003c6ee6dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528ef70f-4844-48fa-a768-4003c6ee6dae.jpg?1",
             "name": "Majestic Genesis",
             "text": "Reveal the top X cards of your library, where X is the greatest mana value of a commander you own on the battlefield or in the command zone. You may put any number of permanent cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -22423,7 +22423,7 @@
         },
         {
             "id": "0d90e36f-1a0e-5373-af4b-02ac1d113590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -22457,7 +22457,7 @@
         },
         {
             "id": "a99ecdf6-e82d-565c-8be7-3ec2ffe08328",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -22493,7 +22493,7 @@
         },
         {
             "id": "46c4fef8-49da-5b32-bd78-93bbcbf4f458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc39cc-c5ae-4e6e-ba31-f30841d49351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc39cc-c5ae-4e6e-ba31-f30841d49351.jpg?1",
             "name": "Owlbear Cub",
             "text": "Mama's Coming \u2014 Whenever Owlbear Cub attacks a player who controls eight or more lands, look at the top eight cards of your library. You may put a creature card from among them onto the battlefield tapped and attacking that player. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -22530,7 +22530,7 @@
         },
         {
             "id": "74fd2993-652c-5841-8e93-7693f2becd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba004fc5-c144-41fa-abc1-531a977378a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba004fc5-c144-41fa-abc1-531a977378a8.jpg?1",
             "name": "Traverse the Outlands",
             "text": "Search your library for up to X basic land cards, where X is the greatest power among creatures you control. Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22564,7 +22564,7 @@
         },
         {
             "id": "f3263161-b7d7-5044-9bc9-324bd8276fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f3d5a-2d94-4765-bf51-192d7f6021b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f3d5a-2d94-4765-bf51-192d7f6021b1.jpg?1",
             "name": "Undermountain Adventurer",
             "text": "Vigilance\nWhen Undermountain Adventurer enters the battlefield, you take the initiative.\n{T}: Add {G}{G}. If you've completed a dungeon, add six {G} instead.",
             "colours": [
@@ -22601,7 +22601,7 @@
         },
         {
             "id": "67f3c313-9f7d-5ca0-93c7-569dc4371c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0225d038-bba4-4965-8f90-5d9d2e6dcf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0225d038-bba4-4965-8f90-5d9d2e6dcf70.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -22633,7 +22633,7 @@
         },
         {
             "id": "e616594a-0780-57b6-b2ad-e3962db7aeb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbaaf68-c97f-443b-9be9-e6567925eddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbaaf68-c97f-443b-9be9-e6567925eddc.jpg?1",
             "name": "Blade of Selves",
             "text": "Equipped creature has myriad.\nEquip {4}",
             "colours": [],
@@ -22665,7 +22665,7 @@
         },
         {
             "id": "05bb1145-702f-59ca-9ec2-6b4222b4cac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f831e-3ed1-464f-8b7a-dbbff0733f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f831e-3ed1-464f-8b7a-dbbff0733f81.jpg?1",
             "name": "Fraying Line",
             "text": "When Fraying Line enters the battlefield, put a rope counter on target creature you control.\nAt the beginning of each player's upkeep, that player may pay {2}. If they do, they put a rope counter on a creature they control. Otherwise, exile Fraying Line and each creature without a rope counter on it, then remove all rope counters from all creatures.",
             "colours": [],
@@ -22695,7 +22695,7 @@
         },
         {
             "id": "777bbd42-57a1-594f-af45-48644b9ab016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c420e-5abe-4339-a47f-bcbf756045a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c420e-5abe-4339-a47f-bcbf756045a2.jpg?1",
             "name": "Mighty Servant of Leuk-o",
             "text": "Trample\nWard\u2014\nDiscard a card.\nWhenever Mighty Servant of Leuk-o becomes crewed for the first time each turn, if it was crewed by exactly two creatures, it gains \"Whenever this creature deals combat damage to a player, draw two cards\" until end of turn.\nCrew 4",
             "colours": [],
@@ -22727,7 +22727,7 @@
         },
         {
             "id": "24602bc7-f2df-5217-9075-6091f72f8fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2f8bc-a907-4511-87be-9f8a87b4a1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2f8bc-a907-4511-87be-9f8a87b4a1f0.jpg?1",
             "name": "Mirror of Life Trapping",
             "text": "Whenever a creature enters the battlefield, if it was cast, exile it, then return all other permanent cards exiled with Mirror of Life Trapping to the battlefield under their owners' control.",
             "colours": [],
@@ -22757,7 +22757,7 @@
         },
         {
             "id": "49c06f60-75ae-5220-8710-2c9472e95007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890abef-5291-4ffd-9c15-41c776ea9a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890abef-5291-4ffd-9c15-41c776ea9a00.jpg?1",
             "name": "Baldur's Gate",
             "text": "{T}: Add {C}.\n{2}, {T}: Add X mana of any one color, where X is the number of other Gates you control.",
             "colours": [],
@@ -22791,7 +22791,7 @@
         },
         {
             "id": "11db9b17-0dc2-5270-800e-ff0eb4f2ab79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cad6ad-9548-4732-81b3-97cf15a544ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cad6ad-9548-4732-81b3-97cf15a544ab.jpg?1",
             "name": "Bountiful Promenade",
             "text": "Bountiful Promenade enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -22824,7 +22824,7 @@
         },
         {
             "id": "06484fe5-7fc6-5bbe-8feb-f6befce09b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f76198-f04c-433b-823f-e99ea54c01ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f76198-f04c-433b-823f-e99ea54c01ee.jpg?1",
             "name": "Luxury Suite",
             "text": "Luxury Suite enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -22857,7 +22857,7 @@
         },
         {
             "id": "63a5546f-82af-5c7d-821c-4f9ad9f12877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c569b0-f011-4570-9eb8-b819f8fe54f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c569b0-f011-4570-9eb8-b819f8fe54f6.jpg?1",
             "name": "Morphic Pool",
             "text": "Morphic Pool enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -22890,7 +22890,7 @@
         },
         {
             "id": "7bf02b86-7f75-5879-8aa0-7d6a14ba0883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6509467-3acf-4e53-9087-b6bc18bf0fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6509467-3acf-4e53-9087-b6bc18bf0fd1.jpg?1",
             "name": "Reflecting Pool",
             "text": "{T}: Add one mana of any type that a land you control could produce.",
             "colours": [],
@@ -22920,7 +22920,7 @@
         },
         {
             "id": "e9e62a6c-6fa4-57b5-91aa-b1d993246744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521f3f6-f90c-4fde-9b53-0e7301a5f8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521f3f6-f90c-4fde-9b53-0e7301a5f8b7.jpg?1",
             "name": "Sea of Clouds",
             "text": "Sea of Clouds enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -22953,7 +22953,7 @@
         },
         {
             "id": "1096d743-cf8c-5017-ae56-fbff42d44d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0df5f8-6660-4908-bc00-2fd4c270ab6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0df5f8-6660-4908-bc00-2fd4c270ab6e.jpg?1",
             "name": "Spire Garden",
             "text": "Spire Garden enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -22986,7 +22986,7 @@
         },
         {
             "id": "55ae184b-85cf-508e-ba89-adcf46ac7771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac23a376-4b3a-4316-b3e2-2e25ca2b5e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac23a376-4b3a-4316-b3e2-2e25ca2b5e76.jpg?1",
             "name": "Deep Gnome Terramancer",
             "text": "Flash\nMold Earth \u2014 Whenever one or more lands enter the battlefield under an opponent's control without being played, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle. Do this only once each turn.",
             "colours": [
@@ -23022,7 +23022,7 @@
         },
         {
             "id": "af586419-db68-58a4-abe5-d518cd8a8a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848c10bc-3d08-4706-ab8e-e9c84a0c0c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848c10bc-3d08-4706-ab8e-e9c84a0c0c3d.jpg?1",
             "name": "Folk Hero",
             "text": "Commander creatures you own have \"Whenever you cast a spell that shares a creature type with this creature, draw a card. This ability triggers only once each turn.\"",
             "colours": [
@@ -23060,7 +23060,7 @@
         },
         {
             "id": "dc36dccf-6a97-5993-8ab0-981685ebbd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7166157a-cea9-4dd8-8bac-c3790da6a942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7166157a-cea9-4dd8-8bac-c3790da6a942.jpg?1",
             "name": "Harper Recruiter",
             "text": "Flying\nWhenever Harper Recruiter attacks, look at the top four cards of your library. You may reveal a Cleric card, a Rogue card, a Warrior card, and/or a Wizard card from among them and put those cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -23097,7 +23097,7 @@
         },
         {
             "id": "70284b7a-2b5c-5719-ac74-1dd9c6700c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648d9da3-5790-4d64-8b52-83141d2faf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648d9da3-5790-4d64-8b52-83141d2faf36.jpg?1",
             "name": "Seasoned Dungeoneer",
             "text": "When Seasoned Dungeoneer enters the battlefield, you take the initiative.\nWhenever you attack, target attacking Cleric, Rogue, Warrior, or Wizard gains protection from creatures until end of turn. It explores.",
             "colours": [
@@ -23133,7 +23133,7 @@
         },
         {
             "id": "468cb4ca-9e3d-54fc-83d6-1acde7171fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0870aef-cae2-4670-a866-28cad523ca39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0870aef-cae2-4670-a866-28cad523ca39.jpg?1",
             "name": "Stick Together",
             "text": "Each player chooses a party from among creatures they control, then sacrifices the rest. (To choose a party, choose up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -23167,7 +23167,7 @@
         },
         {
             "id": "9267a5e5-e49e-5070-9dba-21f45ed02451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01693860-2f79-4777-b2f5-5ebfbff8ad42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01693860-2f79-4777-b2f5-5ebfbff8ad42.jpg?1",
             "name": "Aboleth Spawn",
             "text": "Flash\nWard {2}\nProbing Telepathy \u2014 Whenever a creature entering the battlefield under an opponent's control causes a triggered ability of that creature to trigger, you may copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -23203,7 +23203,7 @@
         },
         {
             "id": "38ac640b-9d90-5486-934c-822719cc8053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf8b03-1f5c-46c5-a684-ae5c04630286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf8b03-1f5c-46c5-a684-ae5c04630286.jpg?1",
             "name": "Astral Dragon",
             "text": "Flying\nProject Image \u2014 When Astral Dragon enters the battlefield, create two tokens that are copies of target noncreature permanent, except they're 3/3 Dragon creatures in addition to their other types, and they have flying.",
             "colours": [
@@ -23238,7 +23238,7 @@
         },
         {
             "id": "44aa4dd5-9cd7-5355-be97-31180b76de98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef54f6-c7d0-42ac-86f1-80457cb3241e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef54f6-c7d0-42ac-86f1-80457cb3241e.jpg?1",
             "name": "Clan Crafter",
             "text": "Commander creatures you own have \"{2}, Sacrifice an artifact: Put a +1/+1 counter on this creature and draw a card.\"",
             "colours": [
@@ -23276,7 +23276,7 @@
         },
         {
             "id": "735e577a-142c-5d64-a5a4-ba980467f5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428343cf-54e6-42df-aee3-d85e6874e437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428343cf-54e6-42df-aee3-d85e6874e437.jpg?1",
             "name": "Endless Evil",
             "text": "Enchant creature you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except the token is 1/1.\nWhen enchanted creature dies, if that creature was a Horror, return Endless Evil to its owner's hand.",
             "colours": [
@@ -23311,7 +23311,7 @@
         },
         {
             "id": "4946fb87-fbfd-5fce-82a1-ac3c7da74d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ca0ae3-0529-49b1-aff7-d3a05eae45ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ca0ae3-0529-49b1-aff7-d3a05eae45ba.jpg?1",
             "name": "Grell Philosopher",
             "text": "Aberrant Tinkering \u2014 When Grell Philosopher enters the battlefield and at the beginning of your upkeep, each Horror you control gains all activated abilities of target artifact an opponent controls until end of turn. You may spend blue mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -23347,7 +23347,7 @@
         },
         {
             "id": "289f657d-c064-5f6f-a614-49f26781148a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb48ed1-6386-4f3f-8413-671b59eb7b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb48ed1-6386-4f3f-8413-671b59eb7b96.jpg?1",
             "name": "Mocking Doppelganger",
             "text": "Flash\nYou may have Mocking Doppelganger enter the battlefield as a copy of a creature an opponent controls, except it has \"Other creatures with the same name as this creature are goaded.\"",
             "colours": [
@@ -23382,7 +23382,7 @@
         },
         {
             "id": "1a7d2a9c-2cf5-51eb-9aaa-f984cc2b1368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b5739a-e228-4b9a-871b-0d4684d5cf89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b5739a-e228-4b9a-871b-0d4684d5cf89.jpg?1",
             "name": "Psionic Ritual",
             "text": "Replicate\u2014\nTap an untapped Horror you control.\nExile target instant or sorcery card from a graveyard and copy it. You may cast the copy without paying its mana cost.\nExile Psionic Ritual.",
             "colours": [
@@ -23415,7 +23415,7 @@
         },
         {
             "id": "1c8a73ce-dd4e-520c-8e63-72e47fad4d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba00ab71-f686-46eb-af3a-7d70f22e13b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba00ab71-f686-46eb-af3a-7d70f22e13b6.jpg?1",
             "name": "Zellix, Sanity Flayer",
             "text": "Hive Mind \u2014 Whenever a player mills one or more creature cards, you create a 1/1 black Horror creature token.\n{1}, {T}: Target player mills three cards.\nChoose a Background",
             "colours": [
@@ -23453,7 +23453,7 @@
         },
         {
             "id": "d285f4d8-b5b6-514a-86d5-e7866fe54f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b28572c-d2ba-4834-8630-3d82202ebb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b28572c-d2ba-4834-8630-3d82202ebb6f.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.",
             "colours": [
@@ -23486,7 +23486,7 @@
         },
         {
             "id": "128d4dac-b685-548e-a1dc-6403141d2196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdeda32b-9c70-47c6-bfbe-06b651af1ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdeda32b-9c70-47c6-bfbe-06b651af1ce1.jpg?1",
             "name": "Brainstealer Dragon",
             "text": "Flying\nAt the beginning of your end step, exile the top card of each opponent's library. You may play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.\nWhenever a nonland permanent an opponent owns enters the battlefield under your control, they lose life equal to its mana value.",
             "colours": [
@@ -23522,7 +23522,7 @@
         },
         {
             "id": "dc96dfbb-10e9-553d-8007-448c7eeeff7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acd5ba4-444e-4ac7-a888-6230be54374d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acd5ba4-444e-4ac7-a888-6230be54374d.jpg?1",
             "name": "Burakos, Party Leader",
             "text": "Burakos, Party Leader is also a Cleric, Rogue, Warrior, and Wizard.\nWhenever Burakos attacks, defending player loses X life and you create X Treasure tokens, where X is the number of creatures in your party.\nChoose a Background",
             "colours": [
@@ -23560,7 +23560,7 @@
         },
         {
             "id": "2fcfa363-39f4-54f9-bfae-585e04667e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df4c09f-0140-4b7c-85f8-c3d9e5b91638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df4c09f-0140-4b7c-85f8-c3d9e5b91638.jpg?1",
             "name": "From the Catacombs",
             "text": "Put target creature card from a graveyard onto the battlefield under your control with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.\nYou take the initiative.\nEscape\u2014{3}{B}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -23593,7 +23593,7 @@
         },
         {
             "id": "89f18945-73e4-5460-a8f4-676b6bf01b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb9b67c-b0e4-4c62-8332-74a53b67f3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb9b67c-b0e4-4c62-8332-74a53b67f3bb.jpg?1",
             "name": "Haunted One",
             "text": "Commander creatures you own have \"Whenever this creature becomes tapped, it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn.\"",
             "colours": [
@@ -23631,7 +23631,7 @@
         },
         {
             "id": "eb9438f3-96b5-5fa1-ad63-8905500a9c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a013f6d-e8ac-4fed-8e9f-a616881b0404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a013f6d-e8ac-4fed-8e9f-a616881b0404.jpg?1",
             "name": "Solemn Doomguide",
             "text": "Flying\nEach creature card in your graveyard that's a Cleric, Rogue, Warrior, and/or Wizard has unearth {1}{B}.",
             "colours": [
@@ -23667,7 +23667,7 @@
         },
         {
             "id": "f04aad36-a84b-53a9-aba4-d7f25ce2009c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893a0e6-bac4-4758-a0f9-42521e5d0777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893a0e6-bac4-4758-a0f9-42521e5d0777.jpg?1",
             "name": "Uchuulon",
             "text": "Uchuulon's power is equal to the number of Crabs, Oozes, and/or Horrors you control.\nHorrific Symbiosis \u2014 At the beginning of your end step, exile up to one target creature card from an opponent's graveyard. If you do, create a token that's a copy of Uchuulon.",
             "colours": [
@@ -23704,7 +23704,7 @@
         },
         {
             "id": "754b99fd-8db6-5346-a1d5-78e013411fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c1e006-77bf-4adb-bb65-23262edfaf6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c1e006-77bf-4adb-bb65-23262edfaf6d.jpg?1",
             "name": "Baeloth Barrityl, Entertainer",
             "text": "Creatures your opponents control with power less than Baeloth Barrityl's power are goaded.\nWhenever a goaded attacking or blocking creature dies, you create a Treasure token.\nChoose a Background",
             "colours": [
@@ -23743,7 +23743,7 @@
         },
         {
             "id": "31627de1-382c-5894-a71e-16ae3498977a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37544c90-371a-42c2-910d-d0f4de5c8537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37544c90-371a-42c2-910d-d0f4de5c8537.jpg?1",
             "name": "Bothersome Quasit",
             "text": "Menace\nGoaded creatures your opponents control can't block.\nWhenever you cast a noncreature spell, goad target creature an opponent controls.",
             "colours": [
@@ -23778,7 +23778,7 @@
         },
         {
             "id": "6715f995-eca8-5eea-a24e-e63631e8758f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0c414b-4345-4787-8a9e-d9f82c5ba9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0c414b-4345-4787-8a9e-d9f82c5ba9b9.jpg?1",
             "name": "Death Kiss",
             "text": "Whenever a creature an opponent controls attacks one of your opponents, double its power until end of turn.\n{X}{X}{R}: Monstrosity X.\nWhen Death Kiss becomes monstrous, goad up to X target creatures your opponents control.",
             "colours": [
@@ -23813,7 +23813,7 @@
         },
         {
             "id": "24c82576-7a3b-5e20-b77f-ba48b4140a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400c76c6-f677-4e7e-87ad-2e526d4b498a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400c76c6-f677-4e7e-87ad-2e526d4b498a.jpg?1",
             "name": "Delayed Blast Fireball",
             "text": "Delayed Blast Fireball deals 2 damage to each opponent and each creature they control. If this spell was cast from exile, it deals 5 damage to each opponent and each creature they control instead.\nForetell {4}{R}{R}",
             "colours": [
@@ -23846,7 +23846,7 @@
         },
         {
             "id": "a407c97e-0328-5792-941f-7e8039826b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a225e62-e95d-4b9b-aab7-25925e35b925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a225e62-e95d-4b9b-aab7-25925e35b925.jpg?1",
             "name": "Loot Dispute",
             "text": "When Loot Dispute enters the battlefield, you take the initiative and create a Treasure token.\nWhenever you attack the player who has the initiative, create a Treasure token.\nLoud Ruckus \u2014 Whenever you complete a dungeon, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -23879,7 +23879,7 @@
         },
         {
             "id": "c7f36ea4-b3c8-5e2d-aa4e-97ed36de133d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e3b25f-beb1-4688-8b14-be597b9aee81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e3b25f-beb1-4688-8b14-be597b9aee81.jpg?1",
             "name": "Nalfeshnee",
             "text": "Flying\nWhenever you cast a spell from exile, copy it. You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\"",
             "colours": [
@@ -23915,7 +23915,7 @@
         },
         {
             "id": "3a532aa6-591a-5aa8-8f86-19485642e741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b515f-732d-415a-bc1e-6f1022150ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b515f-732d-415a-bc1e-6f1022150ebd.jpg?1",
             "name": "Passionate Archaeologist",
             "text": "Commander creatures you own have \"Whenever you cast a spell from exile, this creature deals damage equal to that spell's mana value to target opponent.\"",
             "colours": [
@@ -23953,7 +23953,7 @@
         },
         {
             "id": "25775b9f-c7a3-5423-9e38-fa52638a4cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0036977-7dc3-4147-9303-4060694c5db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0036977-7dc3-4147-9303-4060694c5db4.jpg?1",
             "name": "Spectacular Showdown",
             "text": "Put a double strike counter on target creature, then goad each creature that had a double strike counter put on it this way.\nOverload {4}{R}{R}{R}",
             "colours": [
@@ -23986,7 +23986,7 @@
         },
         {
             "id": "c3c48205-222a-5355-b250-63d8ebf6c298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2347c1fd-9a7d-470b-9e8e-d75b6a5b7f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2347c1fd-9a7d-470b-9e8e-d75b6a5b7f23.jpg?1",
             "name": "Durnan of the Yawning Portal",
             "text": "Whenever Durnan attacks, look at the top four cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in any order. For as long as that card remains exiled, you may cast it. That spell has undaunted.\nChoose a Background",
             "colours": [
@@ -24025,7 +24025,7 @@
         },
         {
             "id": "0fe67e17-2e14-5bfe-b88b-7aa96b11b69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f700972f-2c26-443b-9af0-72a4b5d4d723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f700972f-2c26-443b-9af0-72a4b5d4d723.jpg?1",
             "name": "Green Slime",
             "text": "Flash\nWhen Green Slime enters the battlefield, counter target activated or triggered ability from an artifact or enchantment source. If a permanent's ability is countered this way, destroy that permanent.\nForetell {G}",
             "colours": [
@@ -24060,7 +24060,7 @@
         },
         {
             "id": "6a25f8d2-5f25-5e5b-baff-094bd694862a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0a5d1d-0aa2-4655-96ce-156eb82d7afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0a5d1d-0aa2-4655-96ce-156eb82d7afa.jpg?1",
             "name": "Journey to the Lost City",
             "text": "At the beginning of your upkeep, exile the top four cards of your library, then roll a d20.\n1\u20139 | You may put a land card from among those cards onto the battlefield.\n10\u201319 | Create a 2/2 green Wolf creature token, then put a +1/+1 counter on it for each creature card among those cards.\n20 | Put all permanent cards exiled with Journey to the Lost City onto the battlefield, then sacrifice it.",
             "colours": [
@@ -24093,7 +24093,7 @@
         },
         {
             "id": "35b4d9b2-ea75-51b2-8d39-7626a550aebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Trample\nOnce each turn, you may pay {0} rather than pay the mana cost for a creature spell you cast from exile.",
             "colours": [
@@ -24129,7 +24129,7 @@
         },
         {
             "id": "84a4e1dd-5150-5ee0-a427-899c4d681c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Exile target creature card from your graveyard. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -24164,7 +24164,7 @@
         },
         {
             "id": "520b5930-93bf-55ba-900a-845ab1d01950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05987b6e-beb6-4ab0-9cd4-b9928959625c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05987b6e-beb6-4ab0-9cd4-b9928959625c.jpg?1",
             "name": "Venture Forth",
             "text": "Exile cards from the top of your library until you exile a land card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Exile Venture Forth with three time counters on it.\nSuspend 3\u2014{1}{G}",
             "colours": [
@@ -24197,7 +24197,7 @@
         },
         {
             "id": "be1a3f7b-4fa6-5dc8-ad1d-df07eb678786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512c364-9512-4566-aa96-4a2884ec6230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512c364-9512-4566-aa96-4a2884ec6230.jpg?1",
             "name": "Captain N'ghathrod",
             "text": "Horrors you control have menace.\nWhenever a Horror you control deals combat damage to a player, that player mills that many cards.\nAt the beginning of your end step, choose target artifact or creature card in an opponent's graveyard that was put there from their library this turn. Put it onto the battlefield under your control.",
             "colours": [
@@ -24239,7 +24239,7 @@
         },
         {
             "id": "46d0aa00-b0b0-5437-8258-324e956c56e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba78cd7-a3b6-4ef2-b6b7-3416c0ba61f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba78cd7-a3b6-4ef2-b6b7-3416c0ba61f1.jpg?1",
             "name": "Faldorn, Dread Wolf Herald",
             "text": "Whenever you cast a spell from exile or a land enters the battlefield under your control from exile, create a 2/2 green Wolf creature token.\n{1}, {T}, Discard a card: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -24281,7 +24281,7 @@
         },
         {
             "id": "41340e62-61bd-5ee7-9d9d-14a307f2a27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7b14d-c860-448e-8d7b-66ea05be281c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7b14d-c860-448e-8d7b-66ea05be281c.jpg?1",
             "name": "Firkraag, Cunning Instigator",
             "text": "Flying, haste\nWhenever one or more Dragons you control attack an opponent, goad target creature that player controls.\nWhenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag, Cunning Instigator and you draw a card.",
             "colours": [
@@ -24322,7 +24322,7 @@
         },
         {
             "id": "7d9c82e6-7ae0-5320-9e29-f9e5c9530972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee97908-314a-4704-a8bd-962fcb4db947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee97908-314a-4704-a8bd-962fcb4db947.jpg?1",
             "name": "Nalia de'Arnise",
             "text": "You may look at the top card of your library any time.\nYou may cast Cleric, Rogue, Warrior, and Wizard spells from the top of your library.\nAt the beginning of combat on your turn, if you have a full party, put a +1/+1 counter on each creature you control and those creatures gain deathtouch until end of turn.",
             "colours": [
@@ -24364,7 +24364,7 @@
         },
         {
             "id": "ba4862bb-ef92-5de6-9bb1-92f503198809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1feb99-eb5d-454a-b1bc-0ffb4778d5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1feb99-eb5d-454a-b1bc-0ffb4778d5f4.jpg?1",
             "name": "Multiclass Baldric",
             "text": "Equipped creature has lifelink if you control a Cleric, deathtouch if you control a Rogue, haste if you control a Warrior, and flying if you control a Wizard.\nAs long as you have a full party, prevent all damage that would be dealt to equipped creature.\nEquip {2}",
             "colours": [],
@@ -24395,7 +24395,7 @@
         },
         {
             "id": "86d96c11-21d7-59cc-b91e-bdaf1b583c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12794c31-8aea-4cd9-9534-e890fe3ebc8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12794c31-8aea-4cd9-9534-e890fe3ebc8c.jpg?1",
             "name": "Sarevok's Tome",
             "text": "When Sarevok's Tome enters the battlefield, you take the initiative.\n{T}: Add {C}. If you have the initiative, add {C}{C} instead.\n{3}, {T}: Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Activate only if you've completed a dungeon.",
             "colours": [],
@@ -24424,7 +24424,7 @@
         },
         {
             "id": "8e550aec-dc64-5866-ba6c-2c63109ac095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c02dc8-0743-400c-b334-ca029caf0463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c02dc8-0743-400c-b334-ca029caf0463.jpg?1",
             "name": "Captain N'ghathrod",
             "text": "Horrors you control have menace.\nWhenever a Horror you control deals combat damage to a player, that player mills that many cards.\nAt the beginning of your end step, choose target artifact or creature card in an opponent's graveyard that was put there from their library this turn. Put it onto the battlefield under your control.",
             "colours": [
@@ -24465,7 +24465,7 @@
         },
         {
             "id": "d52c2867-1d6d-5441-9516-8dc7ebf9d927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213e530e-33a9-4358-b43b-4a276a7e7190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213e530e-33a9-4358-b43b-4a276a7e7190.jpg?1",
             "name": "Faldorn, Dread Wolf Herald",
             "text": "Whenever you cast a spell from exile or a land enters the battlefield under your control from exile, create a 2/2 green Wolf creature token.\n{1}, {T}, Discard a card: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -24506,7 +24506,7 @@
         },
         {
             "id": "0c50a986-8548-54df-b226-58db7d66b4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55e624b-6f6a-42ae-89aa-0cc62ee55a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55e624b-6f6a-42ae-89aa-0cc62ee55a31.jpg?1",
             "name": "Firkraag, Cunning Instigator",
             "text": "Flying, haste\nWhenever one or more Dragons you control attack an opponent, goad target creature that player controls.\nWhenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag, Cunning Instigator and you draw a card.",
             "colours": [
@@ -24546,7 +24546,7 @@
         },
         {
             "id": "e2f5403b-1e5b-5764-8862-8e26c91a12bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1294fd-9885-4dfd-8192-0ca074fc83f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1294fd-9885-4dfd-8192-0ca074fc83f7.jpg?1",
             "name": "Nalia de'Arnise",
             "text": "You may look at the top card of your library any time.\nYou may cast Cleric, Rogue, Warrior, and Wizard spells from the top of your library.\nAt the beginning of combat on your turn, if you have a full party, put a +1/+1 counter on each creature you control and those creatures gain deathtouch until end of turn.",
             "colours": [
@@ -24587,7 +24587,7 @@
         },
         {
             "id": "2ccd7f84-1faf-5bda-b964-79b9627de768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3aae8-fc36-45ed-84ed-efb8f543cada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3aae8-fc36-45ed-84ed-efb8f543cada.jpg?1",
             "name": "Folk Hero",
             "text": "Commander creatures you own have \"Whenever you cast a spell that shares a creature type with this creature, draw a card. This ability triggers only once each turn.\"",
             "colours": [
@@ -24624,7 +24624,7 @@
         },
         {
             "id": "ecae572d-ae94-5cc0-9ed2-b52d7252d91b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82f96f-bd2b-4672-b729-c44c943fcac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82f96f-bd2b-4672-b729-c44c943fcac9.jpg?1",
             "name": "Clan Crafter",
             "text": "Commander creatures you own have \"{2}, Sacrifice an artifact: Put a +1/+1 counter on this creature and draw a card.\"",
             "colours": [
@@ -24661,7 +24661,7 @@
         },
         {
             "id": "d5241add-b1c7-5791-b90d-c3fc96b163b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d57db6-0aa5-4e28-b156-e97b74af2cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d57db6-0aa5-4e28-b156-e97b74af2cee.jpg?1",
             "name": "Zellix, Sanity Flayer",
             "text": "Hive Mind \u2014 Whenever a player mills one or more creature cards, you create a 1/1 black Horror creature token.\n{1}, {T}: Target player mills three cards.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24698,7 +24698,7 @@
         },
         {
             "id": "0964bdbf-acd7-516e-8c89-f0a116c0da3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899e278d-5d4e-461a-9878-2b85de16b38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899e278d-5d4e-461a-9878-2b85de16b38d.jpg?1",
             "name": "Burakos, Party Leader",
             "text": "Burakos, Party Leader is also a Cleric, Rogue, Warrior, and Wizard.\nWhenever Burakos attacks, defending player loses X life and you create X Treasure tokens, where X is the number of creatures in your party.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24735,7 +24735,7 @@
         },
         {
             "id": "b71e22a3-ce32-568f-8ca3-2b9fca42e2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53b1af-0f4a-4475-a131-27cb5d5b0cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53b1af-0f4a-4475-a131-27cb5d5b0cf1.jpg?1",
             "name": "Haunted One",
             "text": "Commander creatures you own have \"Whenever this creature becomes tapped, it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn.\" (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -24772,7 +24772,7 @@
         },
         {
             "id": "d6ea03ac-d31f-533a-beea-fa7c852ee243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec983aac-9eda-4086-ad7e-34da9b2987cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec983aac-9eda-4086-ad7e-34da9b2987cc.jpg?1",
             "name": "Baeloth Barrityl, Entertainer",
             "text": "Creatures your opponents control with power less than Baeloth Barrityl's power are goaded. (They attack each combat if able and attack a player other than you if able.)\nWhenever a goaded attacking or blocking creature dies, you create a Treasure token.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24810,7 +24810,7 @@
         },
         {
             "id": "ad096140-4909-5e9c-b57f-60c4cfd9d57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5bbfa6-e5f4-413d-b132-ebae32d38657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5bbfa6-e5f4-413d-b132-ebae32d38657.jpg?1",
             "name": "Passionate Archaeologist",
             "text": "Commander creatures you own have \"Whenever you cast a spell from exile, this creature deals damage equal to that spell's mana value to target opponent.\"",
             "colours": [
@@ -24847,7 +24847,7 @@
         },
         {
             "id": "439fedf1-5870-5db4-90e0-5229e212fffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f287c1-bd17-43fd-b0e3-b52472b0aa70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f287c1-bd17-43fd-b0e3-b52472b0aa70.jpg?1",
             "name": "Durnan of the Yawning Portal",
             "text": "Whenever Durnan attacks, look at the top four cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in any order. For as long as that card remains exiled, you may cast it. That spell has undaunted. (It costs {1}\u200b less to cast for each opponent.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24885,7 +24885,7 @@
         },
         {
             "id": "abfa3d39-f72e-5ee4-a66b-e0764612aafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75f9f1-5873-450f-a0b2-871b55036954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75f9f1-5873-450f-a0b2-871b55036954.jpg?1",
             "name": "Deep Gnome Terramancer",
             "text": "Flash\nMold Earth \u2014 Whenever one or more lands enter the battlefield under an opponent's control without being played, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle. Do this only once each turn.",
             "colours": [
@@ -24921,7 +24921,7 @@
         },
         {
             "id": "934f0ef4-db2f-57fc-b6a3-c28569b3371e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb131fd-d96f-43e0-a40d-fa6394a4b75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb131fd-d96f-43e0-a40d-fa6394a4b75c.jpg?1",
             "name": "Harper Recruiter",
             "text": "Flying\nWhenever Harper Recruiter attacks, look at the top four cards of your library. You may reveal a Cleric card, a Rogue card, a Warrior card, and/or a Wizard card from among them and put those cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -24957,7 +24957,7 @@
         },
         {
             "id": "472e2abd-2edd-5369-9a0d-6b843361361e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee3f76-20a8-4621-84fb-ddf79c955532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee3f76-20a8-4621-84fb-ddf79c955532.jpg?1",
             "name": "Seasoned Dungeoneer",
             "text": "When Seasoned Dungeoneer enters the battlefield, you take the initiative.\nWhenever you attack, target attacking Cleric, Rogue, Warrior, or Wizard gains protection from creatures until end of turn. It explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -24993,7 +24993,7 @@
         },
         {
             "id": "b7f444ac-9398-5977-a593-1b34152e2e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d77a57a-e30b-46d7-acb8-1d164c7dff78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d77a57a-e30b-46d7-acb8-1d164c7dff78.jpg?1",
             "name": "Stick Together",
             "text": "Each player chooses a party from among creatures they control, then sacrifices the rest. (To choose a party, choose up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -25026,7 +25026,7 @@
         },
         {
             "id": "f31ba484-a049-5cb0-b950-dbda72a48283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51889b3f-082a-40e9-8be7-11f8c1a7a9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51889b3f-082a-40e9-8be7-11f8c1a7a9a8.jpg?1",
             "name": "Aboleth Spawn",
             "text": "Flash\nWard {2}\nProbing Telepathy \u2014 Whenever a creature entering the battlefield under an opponent's control causes a triggered ability of that creature to trigger, you may copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -25062,7 +25062,7 @@
         },
         {
             "id": "c9d9960d-9c6c-513b-84c8-c0a3895da6ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4e9335-06e3-4b27-8fd8-3e44ece89a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4e9335-06e3-4b27-8fd8-3e44ece89a36.jpg?1",
             "name": "Artificer Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nThe first artifact spell you cast each turn costs {1} less to cast.\n{1}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, reveal cards from the top of your library until you reveal an artifact card. Put that card into your hand and the rest on the bottom of your library in a random order.\n{5}{U}: Level 3\n//Level_3//\nAt the beginning of your end step, create a token that's a copy of target artifact you control.",
             "colours": [
@@ -25095,7 +25095,7 @@
         },
         {
             "id": "6d4252de-fef7-56f9-91b9-a5ede197111e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670fbc63-4c9b-4e57-b53e-4ca4d7a224ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670fbc63-4c9b-4e57-b53e-4ca4d7a224ba.jpg?1",
             "name": "Astral Dragon",
             "text": "Flying\nProject Image \u2014 When Astral Dragon enters the battlefield, create two tokens that are copies of target noncreature permanent, except they're 3/3 Dragon creatures in addition to their other types, and they have flying.",
             "colours": [
@@ -25130,7 +25130,7 @@
         },
         {
             "id": "2ac896b8-7810-5c5f-87ac-34fb034ce2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804b3378-b330-45d2-9e2c-602ec080f285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804b3378-b330-45d2-9e2c-602ec080f285.jpg?1",
             "name": "Endless Evil",
             "text": "Enchant creature you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except the token is 1/1.\nWhen enchanted creature dies, if that creature was a Horror, return Endless Evil to its owner's hand.",
             "colours": [
@@ -25165,7 +25165,7 @@
         },
         {
             "id": "4bf61d4f-dde5-542b-aab8-b2b9517d7f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18bb373-a0bb-4e3c-b7db-83f747820fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18bb373-a0bb-4e3c-b7db-83f747820fcd.jpg?1",
             "name": "Grell Philosopher",
             "text": "Aberrant Tinkering \u2014 When Grell Philosopher enters the battlefield and at the beginning of your upkeep, each Horror you control gains all activated abilities of target artifact an opponent controls until end of turn. You may spend blue mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -25201,7 +25201,7 @@
         },
         {
             "id": "f2ea2b35-2781-52e6-a376-b5aa88d926aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5f81d8-b189-4f6e-872f-a237bb872aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5f81d8-b189-4f6e-872f-a237bb872aa9.jpg?1",
             "name": "Mocking Doppelganger",
             "text": "Flash\nYou may have Mocking Doppelganger enter the battlefield as a copy of a creature an opponent controls, except it has \"Other creatures with the same name as this creature are goaded.\" (They attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -25236,7 +25236,7 @@
         },
         {
             "id": "2bcaff64-7dc2-5116-9407-bc2d3ccea92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb36d21-0136-4fee-a348-92a99b7c5305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb36d21-0136-4fee-a348-92a99b7c5305.jpg?1",
             "name": "Psionic Ritual",
             "text": "Replicate\u2014\nTap an untapped Horror you control. (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nExile target instant or sorcery card from a graveyard and copy it. You may cast the copy without paying its mana cost.\nExile Psionic Ritual.",
             "colours": [
@@ -25269,7 +25269,7 @@
         },
         {
             "id": "1fdeefbb-8c55-5b8c-93ad-5318228dc031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb0d3-3452-4c1f-81ec-024b4c45bbad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb0d3-3452-4c1f-81ec-024b4c45bbad.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life. (It has every creature type.)",
             "colours": [
@@ -25302,7 +25302,7 @@
         },
         {
             "id": "fb6ce31f-4dbc-5470-8899-7942167deca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984b1f1-dfc8-4cb9-90a3-e084950438bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984b1f1-dfc8-4cb9-90a3-e084950438bf.jpg?1",
             "name": "Brainstealer Dragon",
             "text": "Flying\nAt the beginning of your end step, exile the top card of each opponent's library. You may play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.\nWhenever a nonland permanent an opponent owns enters the battlefield under your control, they lose life equal to its mana value.",
             "colours": [
@@ -25338,7 +25338,7 @@
         },
         {
             "id": "b9f86790-237c-5e1f-8f68-332b9917bd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08737950-4662-4d36-a1ea-6fd87e38c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08737950-4662-4d36-a1ea-6fd87e38c02b.jpg?1",
             "name": "From the Catacombs",
             "text": "Put target creature card from a graveyard onto the battlefield under your control with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.\nYou take the initiative.\nEscape\u2014{3}{B}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -25371,7 +25371,7 @@
         },
         {
             "id": "88808ec3-1f06-5552-b891-d828de1078a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b467929d-5fc3-4104-8a29-a8157835f274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b467929d-5fc3-4104-8a29-a8157835f274.jpg?1",
             "name": "Solemn Doomguide",
             "text": "Flying\nEach creature card in your graveyard that's a Cleric, Rogue, Warrior, and/or Wizard has unearth {1}{B}. ({1}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -25407,7 +25407,7 @@
         },
         {
             "id": "111bf9ce-7e9f-5ee2-9956-7371bc75e8f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecef5fca-72ec-4aee-af6e-ee5d6f6bc567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecef5fca-72ec-4aee-af6e-ee5d6f6bc567.jpg?1",
             "name": "Uchuulon",
             "text": "Uchuulon's power is equal to the number of Crabs, Oozes, and/or Horrors you control.\nHorrific Symbiosis \u2014 At the beginning of your end step, exile up to one target creature card from an opponent's graveyard. If you do, create a token that's a copy of Uchuulon.",
             "colours": [
@@ -25444,7 +25444,7 @@
         },
         {
             "id": "52813751-2932-5189-bb2a-3b16a408e5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a0a23-cd62-4762-b751-ac0159a1b3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a0a23-cd62-4762-b751-ac0159a1b3c5.jpg?1",
             "name": "Bothersome Quasit",
             "text": "Menace\nGoaded creatures your opponents control can't block.\nWhenever you cast a noncreature spell, goad target creature an opponent controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -25479,7 +25479,7 @@
         },
         {
             "id": "1d915c91-fa7e-5c17-8b74-54edd5e7b33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b9888-70c5-4bee-8f26-d1457fdf1167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b9888-70c5-4bee-8f26-d1457fdf1167.jpg?1",
             "name": "Death Kiss",
             "text": "Whenever a creature an opponent controls attacks one of your opponents, double its power until end of turn.\n{X}{X}{R}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen Death Kiss becomes monstrous, goad up to X target creatures your opponents control.",
             "colours": [
@@ -25514,7 +25514,7 @@
         },
         {
             "id": "91f07837-84a7-5cc9-bc54-8b858fb8ed6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59903e3-a344-4218-9d41-8b19a9bc8311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59903e3-a344-4218-9d41-8b19a9bc8311.jpg?1",
             "name": "Delayed Blast Fireball",
             "text": "Delayed Blast Fireball deals 2 damage to each opponent and each creature they control. If this spell was cast from exile, it deals 5 damage to each opponent and each creature they control instead.\nForetell {4}{R}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -25547,7 +25547,7 @@
         },
         {
             "id": "01ae00d7-95ab-5949-9d50-990af0544ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669a2bb-11c7-45d8-9299-09246ff4e72c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669a2bb-11c7-45d8-9299-09246ff4e72c.jpg?1",
             "name": "Loot Dispute",
             "text": "When Loot Dispute enters the battlefield, you take the initiative and create a Treasure token.\nWhenever you attack the player who has the initiative, create a Treasure token.\nLoud Ruckus \u2014 Whenever you complete a dungeon, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -25580,7 +25580,7 @@
         },
         {
             "id": "991f9b3e-0537-5376-a15b-5f43b2699a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7717617-706a-4338-a207-dd8c08feb1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7717617-706a-4338-a207-dd8c08feb1c3.jpg?1",
             "name": "Nalfeshnee",
             "text": "Flying\nWhenever you cast a spell from exile, copy it. You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\" (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -25616,7 +25616,7 @@
         },
         {
             "id": "a378ad7f-0d23-5d84-81b0-d07d02338374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b1cbee-528f-48f7-b7c9-16aa3dab850a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b1cbee-528f-48f7-b7c9-16aa3dab850a.jpg?1",
             "name": "Spectacular Showdown",
             "text": "Put a double strike counter on target creature, then goad each creature that had a double strike counter put on it this way. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)\nOverload {4}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -25649,7 +25649,7 @@
         },
         {
             "id": "ace028e6-85de-56c0-a767-bc9e976794b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1beaaae-9406-4beb-8e74-d278822434c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1beaaae-9406-4beb-8e74-d278822434c7.jpg?1",
             "name": "Green Slime",
             "text": "Flash\nWhen Green Slime enters the battlefield, counter target activated or triggered ability from an artifact or enchantment source. If a permanent's ability is countered this way, destroy that permanent.\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -25684,7 +25684,7 @@
         },
         {
             "id": "8434e8a1-b452-5494-a178-df77cdd40267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b19ce-062d-470c-8716-425a8dec0e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b19ce-062d-470c-8716-425a8dec0e18.jpg?1",
             "name": "Journey to the Lost City",
             "text": "At the beginning of your upkeep, exile the top four cards of your library, then roll a d20.\n1\u20139 | You may put a land card from among those cards onto the battlefield.\n10\u201319 | Create a 2/2 green Wolf creature token, then put a +1/+1 counter on it for each creature card among those cards.\n20 | Put all permanent cards exiled with Journey to the Lost City onto the battlefield, then sacrifice it.",
             "colours": [
@@ -25717,7 +25717,7 @@
         },
         {
             "id": "ba051050-32bb-5e45-9cab-e10c8fc570af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Trample\nOnce each turn, you may pay {0} rather than pay the mana cost for a creature spell you cast from exile.",
             "colours": [
@@ -25753,7 +25753,7 @@
         },
         {
             "id": "450d88c9-a04d-5eea-8607-81315b4cd77e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Exile target creature card from your graveyard. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -25788,7 +25788,7 @@
         },
         {
             "id": "c5204d0e-11d0-5927-95fe-56d093a28eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4db814-3821-47ea-9e33-0e9f49128a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4db814-3821-47ea-9e33-0e9f49128a36.jpg?1",
             "name": "Venture Forth",
             "text": "Exile cards from the top of your library until you exile a land card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Exile Venture Forth with three time counters on it.\nSuspend 3\u2014{1}{G}",
             "colours": [
@@ -25821,7 +25821,7 @@
         },
         {
             "id": "ae46ab07-b385-54cd-938e-98d1f02912c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb7927d-c3c4-4464-8ada-bcd8466b2012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb7927d-c3c4-4464-8ada-bcd8466b2012.jpg?1",
             "name": "Multiclass Baldric",
             "text": "Equipped creature has lifelink if you control a Cleric, deathtouch if you control a Rogue, haste if you control a Warrior, and flying if you control a Wizard.\nAs long as you have a full party, prevent all damage that would be dealt to equipped creature.\nEquip {2}",
             "colours": [],
@@ -25852,7 +25852,7 @@
         },
         {
             "id": "ef52e455-d25a-5b3f-8ab0-e5672751f711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a470690-a05d-4311-963c-50cbf779846d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a470690-a05d-4311-963c-50cbf779846d.jpg?1",
             "name": "Sarevok's Tome",
             "text": "When Sarevok's Tome enters the battlefield, you take the initiative.\n{T}: Add {C}. If you have the initiative, add {C}{C} instead.\n{3}, {T}: Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Activate only if you've completed a dungeon.",
             "colours": [],
@@ -25881,7 +25881,7 @@
         },
         {
             "id": "8126fb0a-86e4-565e-9fd7-53527c47ff07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0b1acd-68e5-4922-8b51-06fa7eda984c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0b1acd-68e5-4922-8b51-06fa7eda984c.jpg?1",
             "name": "Archpriest of Iona",
             "text": "Archpriest of Iona's power is equal to the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -25915,7 +25915,7 @@
         },
         {
             "id": "d554842a-8c87-56e5-8fc5-5b76e09d0b5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24036e-075f-4991-a740-a9d943722ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24036e-075f-4991-a740-a9d943722ad2.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with mana value 3 or less.\n\u2022 Destroy all creatures with mana value 4 or greater.",
             "colours": [
@@ -25946,7 +25946,7 @@
         },
         {
             "id": "446672fd-cc44-53cd-92d5-0e0944267035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cf468f-4e9d-4551-a0ed-10bd6a2316ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cf468f-4e9d-4551-a0ed-10bd6a2316ad.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -25980,7 +25980,7 @@
         },
         {
             "id": "0edfb705-d0b3-57a1-946d-ed84054a1a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf879fc7-9f84-40a7-a7be-9cc98a720af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf879fc7-9f84-40a7-a7be-9cc98a720af5.jpg?1",
             "name": "Bygone Bishop",
             "text": "Flying\nWhenever you cast a creature spell with mana value 3 or less, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -26014,7 +26014,7 @@
         },
         {
             "id": "d58df723-44cf-5654-b100-c14f8f4f19a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13559d7-f86c-4958-a649-7f81bfb154a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13559d7-f86c-4958-a649-7f81bfb154a0.jpg?1",
             "name": "Crib Swap",
             "text": "Changeling (This card is every creature type.)\nExile target creature. Its controller creates a 1/1 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -26048,7 +26048,7 @@
         },
         {
             "id": "354e4511-fbdb-5868-b7b7-58e4f5bc582a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Destroy all creatures with power 3 or greater.",
             "colours": [
@@ -26079,7 +26079,7 @@
         },
         {
             "id": "f0173228-f822-549e-908b-38fd3bc0e215",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nReturn all creature cards with power 2 or less from your graveyard to your hand.",
             "colours": [
@@ -26110,7 +26110,7 @@
         },
         {
             "id": "0185409e-1856-5191-ab84-de2fc48873f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef722374-0305-4c30-ab45-cb772b252faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef722374-0305-4c30-ab45-cb772b252faf.jpg?1",
             "name": "Eight-and-a-Half-Tails",
             "text": "{1}{W}: Target permanent you control gains protection from white until end of turn.\n{1}: Target spell or permanent becomes white until end of turn.",
             "colours": [
@@ -26146,7 +26146,7 @@
         },
         {
             "id": "b033b9ea-2a1b-5b95-bba7-e4517f0ecbf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9ad9ce-f862-4663-9a36-caf0844eb416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9ad9ce-f862-4663-9a36-caf0844eb416.jpg?1",
             "name": "Frontline Medic",
             "text": "Battalion \u2014 Whenever Frontline Medic and at least two other creatures attack, creatures you control gain indestructible until end of turn.\nSacrifice Frontline Medic: Counter target spell with {X} in its mana cost unless its controller pays {3}.",
             "colours": [
@@ -26180,7 +26180,7 @@
         },
         {
             "id": "7017e37f-0d94-56a9-8d19-c3ce81f3641c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222b4c5a-2cd0-4851-9f2f-8685a658ebb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222b4c5a-2cd0-4851-9f2f-8685a658ebb4.jpg?1",
             "name": "Galepowder Mage",
             "text": "Flying\nWhenever Galepowder Mage attacks, exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -26214,7 +26214,7 @@
         },
         {
             "id": "5a86ebac-63f9-5a1a-b30e-47ec1ef7fa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e63385a-e32f-4abc-aff6-bb022b2f56f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e63385a-e32f-4abc-aff6-bb022b2f56f7.jpg?1",
             "name": "Glorious Protector",
             "text": "Flash\nFlying\nWhen Glorious Protector enters the battlefield, you may exile any number of non-Angel creatures you control until Glorious Protector leaves the battlefield.\nForetell {2}{W}",
             "colours": [
@@ -26248,7 +26248,7 @@
         },
         {
             "id": "7ec6f2fa-7a16-5ea6-a3ba-b0e10d4b2a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61775227-34ad-469a-a4d4-ee8ce69dd10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61775227-34ad-469a-a4d4-ee8ce69dd10f.jpg?1",
             "name": "Irregular Cohort",
             "text": "Changeling (This card is every creature type.)\nWhen Irregular Cohort enters the battlefield, create a 2/2 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -26281,7 +26281,7 @@
         },
         {
             "id": "57a0f3c0-4044-5f6b-97bf-e5c8fb8b8d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d17b05a-7753-451b-a7b4-ee1fe3b51110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d17b05a-7753-451b-a7b4-ee1fe3b51110.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -26317,7 +26317,7 @@
         },
         {
             "id": "d8633eab-2795-5e7a-8985-b7bb0d172976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7039d47-276b-4c7c-acc3-94a9baae97e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7039d47-276b-4c7c-acc3-94a9baae97e5.jpg?1",
             "name": "Mage's Attendant",
             "text": "When Mage's Attendant enters the battlefield, create a 1/1 blue Wizard creature token with \"{1}, Sacrifice this creature: Counter target noncreature spell unless its controller pays {1}.\"",
             "colours": [
@@ -26351,7 +26351,7 @@
         },
         {
             "id": "a0679bda-50b6-5db6-a1bc-6f9bb433f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63074e4-2c4c-411c-b320-c90d3a4a96d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63074e4-2c4c-411c-b320-c90d3a4a96d0.jpg?1",
             "name": "Magus of the Balance",
             "text": "{4}{W}, {T}, Sacrifice Magus of the Balance: Each player chooses a number of lands they control equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.",
             "colours": [
@@ -26385,7 +26385,7 @@
         },
         {
             "id": "f1df5d12-2876-5dba-8d68-db95abf6b0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f18de2a-4aab-47a1-b162-6b8cf18e7bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f18de2a-4aab-47a1-b162-6b8cf18e7bbf.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -26421,7 +26421,7 @@
         },
         {
             "id": "9afd5bc2-7c5d-522b-afae-825a51a229ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9149ed-0e59-48b3-b48c-d5ea77b7239e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9149ed-0e59-48b3-b48c-d5ea77b7239e.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
             "colours": [
@@ -26454,7 +26454,7 @@
         },
         {
             "id": "f12c07b2-a058-5b5e-a7cd-09037a735f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e19147-e459-43a6-8ef0-e37968a462e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e19147-e459-43a6-8ef0-e37968a462e3.jpg?1",
             "name": "Mother of Runes",
             "text": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -26488,7 +26488,7 @@
         },
         {
             "id": "6ce2b050-ebdf-5b6c-8696-934ad14397e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaa62f-4959-4321-a2d5-dc255f1e5eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaa62f-4959-4321-a2d5-dc255f1e5eaf.jpg?1",
             "name": "Order of Whiteclay",
             "text": "{1}{W}{W}, {Q}: Return target creature card with mana value 3 or less from your graveyard to the battlefield. ({Q} is the untap symbol.)",
             "colours": [
@@ -26522,7 +26522,7 @@
         },
         {
             "id": "0864d5a0-85ba-5363-b682-67fe94ecf404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6f7b89-1648-4c2b-8d68-88ad43267c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6f7b89-1648-4c2b-8d68-88ad43267c6f.jpg?1",
             "name": "Priest of Ancient Lore",
             "text": "When Priest of Ancient Lore enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -26556,7 +26556,7 @@
         },
         {
             "id": "74ca1404-5409-5910-bfe8-3c7e6afcaaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7782044-616e-4d4f-b38f-93320ba19797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7782044-616e-4d4f-b38f-93320ba19797.jpg?1",
             "name": "Rumor Gatherer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, scry 1. If this is the second time this ability has resolved this turn, draw a card instead.",
             "colours": [
@@ -26590,7 +26590,7 @@
         },
         {
             "id": "1d5f394f-4d40-5efa-9a92-31a5c9e97f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d8d0c-cb0e-4745-a0fb-d556c9324428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d8d0c-cb0e-4745-a0fb-d556c9324428.jpg?1",
             "name": "Selfless Spirit",
             "text": "Flying\nSacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -26624,7 +26624,7 @@
         },
         {
             "id": "4924a247-0a7a-569b-8876-23ce6af5baae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458db878-07ba-42cc-9bee-910957685596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458db878-07ba-42cc-9bee-910957685596.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -26655,7 +26655,7 @@
         },
         {
             "id": "dbdd4eb0-5f0f-5686-acf3-38cbe448f22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b93ee66-bc1d-42ad-8839-d77ab5992f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b93ee66-bc1d-42ad-8839-d77ab5992f14.jpg?1",
             "name": "Solemn Recruit",
             "text": "Double strike\nRevolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on Solemn Recruit.",
             "colours": [
@@ -26689,7 +26689,7 @@
         },
         {
             "id": "3e0e2fa8-b198-5fa8-a8d1-5e6726d79d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5390bbf3-9906-46a9-81d3-60e23eb89ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5390bbf3-9906-46a9-81d3-60e23eb89ca1.jpg?1",
             "name": "Squad Commander",
             "text": "When Squad Commander enters the battlefield, create a 1/1 white Kor Warrior creature token for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -26723,7 +26723,7 @@
         },
         {
             "id": "9fa9432d-bc3e-5384-8dca-677de072ab9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123ae9bd-896c-4f50-afe3-880cea85eee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123ae9bd-896c-4f50-afe3-880cea85eee0.jpg?1",
             "name": "Unbreakable Formation",
             "text": "Creatures you control gain indestructible until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, put a +1/+1 counter on each of those creatures and they gain vigilance until end of turn.",
             "colours": [
@@ -26754,7 +26754,7 @@
         },
         {
             "id": "d128cd33-31ec-51e6-928e-2396df11e99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014fbb81-5d54-4f8f-8c91-071521b9cd33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014fbb81-5d54-4f8f-8c91-071521b9cd33.jpg?1",
             "name": "Valiant Changeling",
             "text": "This spell costs {1} less to cast for each creature type among creatures you control. This effect can't reduce the amount of mana this spell costs by more than {5}.\nChangeling (This card is every creature type.)\nDouble strike",
             "colours": [
@@ -26787,7 +26787,7 @@
         },
         {
             "id": "ed7b7bb4-38ae-5596-b1fe-a933f9d77383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd153e03-4fe1-477d-9e7f-ee5c432a4285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd153e03-4fe1-477d-9e7f-ee5c432a4285.jpg?1",
             "name": "Aether Gale",
             "text": "Return six target nonland permanents to their owners' hands.",
             "colours": [
@@ -26818,7 +26818,7 @@
         },
         {
             "id": "d0935e66-c11d-5877-8443-2e521a4ae90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8d57fc-9695-45df-8b88-0048330608bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8d57fc-9695-45df-8b88-0048330608bd.jpg?1",
             "name": "Angler Turtle",
             "text": "Hexproof\nCreatures your opponents control attack each combat if able.",
             "colours": [
@@ -26851,7 +26851,7 @@
         },
         {
             "id": "26ff52e3-8275-51db-b666-bc36f4af9a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72c6461-8ba4-4ee7-b2c4-0f8d396ce585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72c6461-8ba4-4ee7-b2c4-0f8d396ce585.jpg?1",
             "name": "Chasm Skulker",
             "text": "Whenever you draw a card, put a +1/+1 counter on Chasm Skulker.\nWhen Chasm Skulker dies, create X 1/1 blue Squid creature tokens with islandwalk, where X is the number of +1/+1 counters on Chasm Skulker. (They can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -26885,7 +26885,7 @@
         },
         {
             "id": "cda3b812-62e3-56aa-9d00-97fcef3808b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bc62c8-c795-4e4a-a57c-a5f34121b5d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bc62c8-c795-4e4a-a57c-a5f34121b5d1.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless they discard a land card.",
             "colours": [
@@ -26916,7 +26916,7 @@
         },
         {
             "id": "f9933949-d487-5eb7-ab1a-ad4dacf84556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ef264e-f987-422e-aac1-ae4963c797f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ef264e-f987-422e-aac1-ae4963c797f5.jpg?1",
             "name": "Curse of the Swine",
             "text": "Exile X target creatures. For each creature exiled this way, its controller creates a 2/2 green Boar creature token.",
             "colours": [
@@ -26947,7 +26947,7 @@
         },
         {
             "id": "d0c18842-9d74-5b4f-a0a9-f7a595ae2bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff611add-0b1b-4008-a78b-e793ccb38260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff611add-0b1b-4008-a78b-e793ccb38260.jpg?1",
             "name": "Curse of Verbosity",
             "text": "Enchant player\nWhenever enchanted player is attacked, you draw a card. Each opponent attacking that player does the same.",
             "colours": [
@@ -26981,7 +26981,7 @@
         },
         {
             "id": "ab94fb46-dafb-559d-a482-012eb296360d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2d9f47-2bd2-4a97-90c7-beca18a8e7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2d9f47-2bd2-4a97-90c7-beca18a8e7fa.jpg?1",
             "name": "Dissipation Field",
             "text": "Whenever a permanent deals damage to you, return it to its owner's hand.",
             "colours": [
@@ -27012,7 +27012,7 @@
         },
         {
             "id": "59db6c85-ada9-5d2b-9404-8417ab0b2e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c3836d-a08b-424c-aefe-e1585161edf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c3836d-a08b-424c-aefe-e1585161edf7.jpg?1",
             "name": "Domineering Will",
             "text": "Target player gains control of up to three target nonattacking creatures until end of turn. Untap those creatures. They block this turn if able.",
             "colours": [
@@ -27043,7 +27043,7 @@
         },
         {
             "id": "b6e335fe-16bc-53a7-81f8-c555e9f3ab37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d5a3ec-eb03-47c1-9570-98832ebf8898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d5a3ec-eb03-47c1-9570-98832ebf8898.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -27074,7 +27074,7 @@
         },
         {
             "id": "06d5396c-ebcd-52c0-af27-f9e7efc8a36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d314354-1fb1-498c-8342-ecafac9ff37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d314354-1fb1-498c-8342-ecafac9ff37a.jpg?1",
             "name": "Forgotten Creation",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nAt the beginning of your upkeep, you may discard all the cards in your hand. If you do, draw that many cards.",
             "colours": [
@@ -27108,7 +27108,7 @@
         },
         {
             "id": "e680b1b2-ac9b-511d-a602-3f0a8c0af590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81875876-c1a0-4f64-8dfc-39217b5e4020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81875876-c1a0-4f64-8dfc-39217b5e4020.jpg?1",
             "name": "Fractured Sanity",
             "text": "Each opponent mills fourteen cards.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Fractured Sanity, each opponent mills four cards.",
             "colours": [
@@ -27139,7 +27139,7 @@
         },
         {
             "id": "881c85fe-d947-5f5c-a26c-c16ff481cc2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de11222-c2fa-4544-a501-a02b31797259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de11222-c2fa-4544-a501-a02b31797259.jpg?1",
             "name": "Grazilaxx, Illithid Scholar",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -27174,7 +27174,7 @@
         },
         {
             "id": "2858bbfa-2720-5fb6-8436-2a3899ae41c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf786c50-1ba1-4f81-a800-bc98189040dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf786c50-1ba1-4f81-a800-bc98189040dd.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -27208,7 +27208,7 @@
         },
         {
             "id": "14c8a4a2-55fb-5903-a25b-59dd067296bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d544dc-1d2a-4b33-ae62-d0e0217db0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d544dc-1d2a-4b33-ae62-d0e0217db0a2.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star dies, gain control of target creature.",
             "colours": [
@@ -27244,7 +27244,7 @@
         },
         {
             "id": "3c2e575a-e579-5faa-91c2-4c94858d80ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57bdaa1-ce8a-4103-8598-fee751e65a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57bdaa1-ce8a-4103-8598-fee751e65a53.jpg?1",
             "name": "Leyline of Anticipation",
             "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast spells as though they had flash.",
             "colours": [
@@ -27275,7 +27275,7 @@
         },
         {
             "id": "4e87fe54-15f4-50e3-82a4-f15e13974033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ca85ed-3870-4ba4-abe7-cdcab3cad122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ca85ed-3870-4ba4-abe7-cdcab3cad122.jpg?1",
             "name": "Midnight Clock",
             "text": "{T}: Add {U}.\n{2}{U}: Put an hour counter on Midnight Clock.\nAt the beginning of each upkeep, put an hour counter on Midnight Clock.\nWhen the twelfth hour counter is put on Midnight Clock, shuffle your hand and graveyard into your library, then draw seven cards. Exile Midnight Clock.",
             "colours": [
@@ -27306,7 +27306,7 @@
         },
         {
             "id": "4b557015-28ce-5d0f-b627-afb6ff6e5fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cb10f5-ee9f-49e6-826a-a2a2395daa92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cb10f5-ee9f-49e6-826a-a2a2395daa92.jpg?1",
             "name": "Mind Flayer",
             "text": "Dominate Monster \u2014 When Mind Flayer enters the battlefield, gain control of target creature for as long as you control Mind Flayer.",
             "colours": [
@@ -27339,7 +27339,7 @@
         },
         {
             "id": "f24571f0-d39b-52d7-82e5-06d08ebdfd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065a3c0-c5bd-4817-be7b-efcd750332b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065a3c0-c5bd-4817-be7b-efcd750332b9.jpg?1",
             "name": "Overcharged Amalgam",
             "text": "Flash\nFlying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Overcharged Amalgam exploits a creature, counter target spell, activated ability, or triggered ability.",
             "colours": [
@@ -27373,7 +27373,7 @@
         },
         {
             "id": "2e01dec8-f905-55c3-b3bd-cd256ac1c24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f293d7-9c2b-41cb-8e3c-dfc1daa6635f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f293d7-9c2b-41cb-8e3c-dfc1daa6635f.jpg?1",
             "name": "Propaganda",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -27404,7 +27404,7 @@
         },
         {
             "id": "947578d5-edb7-5f3d-8f77-a9b5f5bf2e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d91bf6-25c7-4478-854a-e35290b6b049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d91bf6-25c7-4478-854a-e35290b6b049.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -27435,7 +27435,7 @@
         },
         {
             "id": "072f3c73-6601-5d7e-88d4-435a229369db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba925b-9216-4e37-814d-b061950b3998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba925b-9216-4e37-814d-b061950b3998.jpg?1",
             "name": "Pursued Whale",
             "text": "When Pursued Whale enters the battlefield, each opponent creates a 1/1 red Pirate creature token with \"This creature can't block\" and \"Creatures you control attack each combat if able.\"\nSpells your opponents cast that target Pursued Whale cost {3} more to cast.",
             "colours": [
@@ -27468,7 +27468,7 @@
         },
         {
             "id": "3c987ef6-a7c8-575f-a395-c0833f73e071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af34c32-22dc-41d3-8946-b5f77ef577ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af34c32-22dc-41d3-8946-b5f77ef577ff.jpg?1",
             "name": "Reflections of Littjara",
             "text": "As Reflections of Littjara enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, copy that spell. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -27499,7 +27499,7 @@
         },
         {
             "id": "13c07c2b-1207-557d-8c02-217b1c3eff97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5730aa-c74a-4c74-bb1b-a133a3c353ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5730aa-c74a-4c74-bb1b-a133a3c353ec.jpg?1",
             "name": "Reins of Power",
             "text": "Untap all creatures you control and all creatures target opponent controls. You and that opponent each gain control of all creatures the other controls until end of turn. Those creatures gain haste until end of turn.",
             "colours": [
@@ -27530,7 +27530,7 @@
         },
         {
             "id": "5bc1d316-514f-58dc-bf88-ce2749031785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32be366-d86e-48aa-8257-ca8afb87ba18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32be366-d86e-48aa-8257-ca8afb87ba18.jpg?1",
             "name": "Sludge Monster",
             "text": "Whenever Sludge Monster enters the battlefield or attacks, put a slime counter on up to one other target creature.\nNon-Horror creatures with slime counters on them lose all abilities and have base power and toughness 2/2.",
             "colours": [
@@ -27563,7 +27563,7 @@
         },
         {
             "id": "1e8c2af6-8398-5939-9bdd-a0cdba4ffadd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ed183a-a78a-4934-9317-9f16b29e69a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ed183a-a78a-4934-9317-9f16b29e69a2.jpg?1",
             "name": "Sly Instigator",
             "text": "{U}, {T}: Until your next turn, target creature an opponent controls can't be blocked. Goad that creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -27597,7 +27597,7 @@
         },
         {
             "id": "4fb4d644-455b-5f9d-820f-9fef89453f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b434ba9e-528c-43b4-a463-0e697dce8d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b434ba9e-528c-43b4-a463-0e697dce8d5d.jpg?1",
             "name": "Wharf Infiltrator",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhenever Wharf Infiltrator deals combat damage to a player, you may draw a card. If you do, discard a card.\nWhenever you discard a creature card, you may pay {2}. If you do, create a 3/2 colorless Eldrazi Horror creature token.",
             "colours": [
@@ -27631,7 +27631,7 @@
         },
         {
             "id": "3153fa80-c3ce-5ae4-881c-5cf812d121a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406a3ae5-f57e-40ff-8eac-a01781f2329f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406a3ae5-f57e-40ff-8eac-a01781f2329f.jpg?1",
             "name": "Will Kenrith",
             "text": "+2: Until your next turn, up to two target creatures each have base power and toughness 0/3 and lose all abilities.\n\u22122: Target player draws two cards. Until your next turn, instant, sorcery, and planeswalker spells that player casts cost {2} less to cast.\n\u22128: Target player gets an emblem with \"Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy.\"\nPartner with Rowan Kenrith\nWill Kenrith can be your commander.",
             "colours": [
@@ -27666,7 +27666,7 @@
         },
         {
             "id": "8f22f3a8-52de-5e36-b641-612d1977eb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c80c6d-f3ae-48d3-ba6a-b9b738e1affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c80c6d-f3ae-48d3-ba6a-b9b738e1affb.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -27697,7 +27697,7 @@
         },
         {
             "id": "a0dfcbe0-12b7-5d1a-8176-88ba08fd62fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d6137-5eff-4e82-8232-64e8679bc11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d6137-5eff-4e82-8232-64e8679bc11c.jpg?1",
             "name": "Bloodsoaked Champion",
             "text": "Bloodsoaked Champion can't block.\nRaid \u2014 {1}{B}: Return Bloodsoaked Champion from your graveyard to the battlefield. Activate only if you attacked this turn.",
             "colours": [
@@ -27731,7 +27731,7 @@
         },
         {
             "id": "ace33997-552e-5033-ac5c-980d641c392e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c18f8-a19f-406a-ad60-491087f9d660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c18f8-a19f-406a-ad60-491087f9d660.jpg?1",
             "name": "Butcher of Malakir",
             "text": "Flying\nWhenever Butcher of Malakir or another creature you control dies, each opponent sacrifices a creature.",
             "colours": [
@@ -27765,7 +27765,7 @@
         },
         {
             "id": "edbb76fe-26aa-571d-ac02-96b1815b5216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dccdab-9dda-4964-9b1a-eec6d31c7995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dccdab-9dda-4964-9b1a-eec6d31c7995.jpg?1",
             "name": "Calculating Lich",
             "text": "Menace\nWhenever a creature attacks one of your opponents, that player loses 1 life.",
             "colours": [
@@ -27799,7 +27799,7 @@
         },
         {
             "id": "7007e513-d465-5ec8-ac56-d1699ef86164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2c053f-0ef8-45f2-b2af-24cbb9a7fec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2c053f-0ef8-45f2-b2af-24cbb9a7fec4.jpg?1",
             "name": "Changeling Outcast",
             "text": "Changeling (This card is every creature type.)\nChangeling Outcast can't block and can't be blocked.",
             "colours": [
@@ -27832,7 +27832,7 @@
         },
         {
             "id": "afbf6bdd-2fb6-5675-ac35-82c2a2163c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600eaa36-5497-42dc-8d21-a5fcdd01fa79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600eaa36-5497-42dc-8d21-a5fcdd01fa79.jpg?1",
             "name": "Corpse Augur",
             "text": "When Corpse Augur dies, you draw X cards and you lose X life, where X is the number of creature cards in target player's graveyard.",
             "colours": [
@@ -27866,7 +27866,7 @@
         },
         {
             "id": "3e756452-18f2-548f-a494-4f6405c8ebab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5bc7db-0627-410b-bc27-970e1fa6789e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5bc7db-0627-410b-bc27-970e1fa6789e.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -27897,7 +27897,7 @@
         },
         {
             "id": "fb8183dc-e7ef-57fa-a11a-34fa5b39c741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2f493d-34d1-4fea-b5d0-b4a965aaf32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2f493d-34d1-4fea-b5d0-b4a965aaf32e.jpg?1",
             "name": "Curtains' Call",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
             "colours": [
@@ -27928,7 +27928,7 @@
         },
         {
             "id": "cc7bef21-22af-5a14-a935-bb650a7c33fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133e9654-74a3-4997-b371-7f36b5d9c4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133e9654-74a3-4997-b371-7f36b5d9c4f1.jpg?1",
             "name": "Dark Hatchling",
             "text": "Flying\nWhen Dark Hatchling enters the battlefield, destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -27961,7 +27961,7 @@
         },
         {
             "id": "3d60fad2-0bda-534d-949f-76d02ff592a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c41afe6-7eed-4cf5-9bbb-ccc9f82cb4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c41afe6-7eed-4cf5-9bbb-ccc9f82cb4fa.jpg?1",
             "name": "Dauthi Horror",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Horror can't be blocked by white creatures.",
             "colours": [
@@ -27995,7 +27995,7 @@
         },
         {
             "id": "81dc6131-9a2d-56fd-9ebe-0162d00763b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887384de-403c-4cca-b542-ce0303100d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887384de-403c-4cca-b542-ce0303100d42.jpg?1",
             "name": "Dire Fleet Ravager",
             "text": "Menace, deathtouch\nWhen Dire Fleet Ravager enters the battlefield, each player loses a third of their life, rounded up.",
             "colours": [
@@ -28030,7 +28030,7 @@
         },
         {
             "id": "56909fc1-2b86-5886-9b6f-6411eb0bdb90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f77a00-1880-416c-813b-c6a870dd5f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f77a00-1880-416c-813b-c6a870dd5f58.jpg?1",
             "name": "Dross Harvester",
             "text": "Protection from white\nAt the beginning of your end step, you lose 4 life.\nWhenever a creature dies, you gain 2 life.",
             "colours": [
@@ -28063,7 +28063,7 @@
         },
         {
             "id": "a9942adc-8e35-5a6c-ada0-6f94682cde1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed473b7d-2078-424e-b1a0-a58e04bf9cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed473b7d-2078-424e-b1a0-a58e04bf9cc2.jpg?1",
             "name": "Dusk Mangler",
             "text": "As an additional cost to cast this spell, sacrifice a creature, discard a card, or pay 4 life.\nWhen Dusk Mangler enters the battlefield, each opponent sacrifices a creature, discards a card, and loses 4 life.",
             "colours": [
@@ -28096,7 +28096,7 @@
         },
         {
             "id": "63c7ea40-33cc-5a5e-a361-85ad39cdc197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86c30e0-35f3-4da8-a28c-722254b1bbe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86c30e0-35f3-4da8-a28c-722254b1bbe4.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
             "colours": [
@@ -28127,7 +28127,7 @@
         },
         {
             "id": "5ae30776-1969-5157-910f-4eb7011d797d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedbfd3-907f-4042-98c1-6fe3fb8cbc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedbfd3-907f-4042-98c1-6fe3fb8cbc01.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -28163,7 +28163,7 @@
         },
         {
             "id": "0376d4e2-fa87-534f-b845-48a371965eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c19b87-e114-46d4-9f6c-c02e838a08dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c19b87-e114-46d4-9f6c-c02e838a08dd.jpg?1",
             "name": "Grim Haruspex",
             "text": "Morph {B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever another nontoken creature you control dies, draw a card.",
             "colours": [
@@ -28197,7 +28197,7 @@
         },
         {
             "id": "db0d1c45-9184-5e2f-95ab-4945ab6e3606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38326f48-548c-4b18-9ad2-0b7c23385deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38326f48-548c-4b18-9ad2-0b7c23385deb.jpg?1",
             "name": "Grim Hireling",
             "text": "Whenever one or more creatures you control deal combat damage to a player, create two Treasure tokens.\n{B}, Sacrifice X Treasures: Target creature gets -X/-X until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -28231,7 +28231,7 @@
         },
         {
             "id": "e5ba1ce1-8f67-5392-afe9-3dbdbb6fbe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8276b064-60ba-4079-b790-e2eea831e35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8276b064-60ba-4079-b790-e2eea831e35e.jpg?1",
             "name": "Guiltfeeder",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever Guiltfeeder attacks and isn't blocked, defending player loses 1 life for each card in their graveyard.",
             "colours": [
@@ -28264,7 +28264,7 @@
         },
         {
             "id": "d0b45b51-ae3d-5bf2-843a-d7150dd78678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c38f3-4b5c-4e7f-af66-e410dea19314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c38f3-4b5c-4e7f-af66-e410dea19314.jpg?1",
             "name": "Hex",
             "text": "Destroy six target creatures.",
             "colours": [
@@ -28295,7 +28295,7 @@
         },
         {
             "id": "49962639-905e-5d36-a1ab-31fec11aaf02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f74866-d0ea-42ce-bc44-500219fb73d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f74866-d0ea-42ce-bc44-500219fb73d4.jpg?1",
             "name": "Hunted Horror",
             "text": "Trample\nWhen Hunted Horror enters the battlefield, target opponent creates two 3/3 green Centaur creature tokens with protection from black.",
             "colours": [
@@ -28328,7 +28328,7 @@
         },
         {
             "id": "ced34cd2-3671-506e-afd3-4b59a09bff05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a6f727-8239-45e6-9dbb-67d2d3c9239d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a6f727-8239-45e6-9dbb-67d2d3c9239d.jpg?1",
             "name": "In Garruk's Wake",
             "text": "Destroy all creatures you don't control and all planeswalkers you don't control.",
             "colours": [
@@ -28359,7 +28359,7 @@
         },
         {
             "id": "62a9bad8-334e-5934-9dad-883b5522f151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbd64da-6071-49f4-87aa-066209ec1ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbd64da-6071-49f4-87aa-066209ec1ae9.jpg?1",
             "name": "Malakir Blood-Priest",
             "text": "When Malakir Blood-Priest enters the battlefield, each opponent loses X life and you gain X life, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -28393,7 +28393,7 @@
         },
         {
             "id": "38c99152-e933-5115-8071-b092bae20902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ed059-9bd1-4a18-ac85-7b00b8057426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ed059-9bd1-4a18-ac85-7b00b8057426.jpg?1",
             "name": "Mardu Strike Leader",
             "text": "Whenever Mardu Strike Leader attacks, create a 2/1 black Warrior creature token.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -28427,7 +28427,7 @@
         },
         {
             "id": "91ba0822-e763-5fe0-be74-785704d31214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c5f18-13a3-42c9-b9d7-bf789eefe249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c5f18-13a3-42c9-b9d7-bf789eefe249.jpg?1",
             "name": "Mindblade Render",
             "text": "Whenever your opponents are dealt combat damage, if any of that damage was dealt by a Warrior, you draw a card and you lose 1 life.",
             "colours": [
@@ -28461,7 +28461,7 @@
         },
         {
             "id": "5cf978fd-2be9-537e-a6cf-45694f11d94b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf5e98-9d40-4cb0-83de-043751b1382f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf5e98-9d40-4cb0-83de-043751b1382f.jpg?1",
             "name": "Nighthawk Scavenger",
             "text": "Flying, deathtouch, lifelink\nNighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards.",
             "colours": [
@@ -28495,7 +28495,7 @@
         },
         {
             "id": "2d3cfb80-ae97-56b6-bf30-1111056b9fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76dab3d-1788-4ab7-8d2b-70f7787cf935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76dab3d-1788-4ab7-8d2b-70f7787cf935.jpg?1",
             "name": "Nighthowler",
             "text": "Bestow {2}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nNighthowler and enchanted creature each get +X/+X, where X is the number of creature cards in all graveyards.",
             "colours": [
@@ -28529,7 +28529,7 @@
         },
         {
             "id": "d0a6f024-f021-59da-9117-d17115443044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598900a0-e244-45e3-a04a-685837fb1867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598900a0-e244-45e3-a04a-685837fb1867.jpg?1",
             "name": "Nihilith",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nSuspend 7\u2014{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with seven time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Nihilith is suspended, you may remove a time counter from Nihilith.",
             "colours": [
@@ -28562,7 +28562,7 @@
         },
         {
             "id": "66658304-8f6b-528d-bfc4-6dcce3e179fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a530be-8527-46f9-b1e9-725915fd6d5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a530be-8527-46f9-b1e9-725915fd6d5e.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -28596,7 +28596,7 @@
         },
         {
             "id": "c31ecb4c-f0b9-5451-8d75-051fb34bc788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82559e5-110b-4c6a-956a-7cba83788dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82559e5-110b-4c6a-956a-7cba83788dc8.jpg?1",
             "name": "Plague Spitter",
             "text": "At the beginning of your upkeep, Plague Spitter deals 1 damage to each creature and each player.\nWhen Plague Spitter dies, Plague Spitter deals 1 damage to each creature and each player.",
             "colours": [
@@ -28630,7 +28630,7 @@
         },
         {
             "id": "6e2d9439-ae98-52f6-837d-bd0392139ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04c8f5-e174-4055-a98c-efec2f064d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04c8f5-e174-4055-a98c-efec2f064d69.jpg?1",
             "name": "Pontiff of Blight",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nOther creatures you control have extort. (If a creature has multiple instances of extort, each triggers separately.)",
             "colours": [
@@ -28664,7 +28664,7 @@
         },
         {
             "id": "8e3708d0-28dd-56e5-8dd7-10be6d052c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fd8dba-0aca-4b47-9b4b-19d5c77cf8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fd8dba-0aca-4b47-9b4b-19d5c77cf8f3.jpg?1",
             "name": "Puppeteer Clique",
             "text": "Flying\nWhen Puppeteer Clique enters the battlefield, put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. At the beginning of your next end step, exile it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -28698,7 +28698,7 @@
         },
         {
             "id": "6ea4f86f-474e-5dec-b077-bf52d8729708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de4804-d330-403a-9ab0-e8be78655618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de4804-d330-403a-9ab0-e8be78655618.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -28732,7 +28732,7 @@
         },
         {
             "id": "24155829-61ab-546d-abc0-7c203de54135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8d320-fecc-42c2-b9d8-a9f6dd44b36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8d320-fecc-42c2-b9d8-a9f6dd44b36d.jpg?1",
             "name": "Sewer Nemesis",
             "text": "As Sewer Nemesis enters the battlefield, choose a player.\nSewer Nemesis's power and toughness are each equal to the number of cards in the chosen player's graveyard.\nWhenever the chosen player casts a spell, that player mills a card.",
             "colours": [
@@ -28765,7 +28765,7 @@
         },
         {
             "id": "9268d590-0055-58f1-8f69-0290b2c8bbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187502d9-c751-4967-adff-09d7a300d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187502d9-c751-4967-adff-09d7a300d935.jpg?1",
             "name": "Syphon Mind",
             "text": "Each other player discards a card. You draw a card for each card discarded this way.",
             "colours": [
@@ -28796,7 +28796,7 @@
         },
         {
             "id": "cdee006e-0a8c-559c-8a09-be02f2a8c53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc339d3b-9c89-4679-bc83-8399d9a864c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc339d3b-9c89-4679-bc83-8399d9a864c7.jpg?1",
             "name": "Thwart the Grave",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nReturn target creature card and up to one target Cleric, Rogue, Warrior, or Wizard creature card from your graveyard to the battlefield.",
             "colours": [
@@ -28827,7 +28827,7 @@
         },
         {
             "id": "0009093e-de41-5432-9815-8d1f2efe16dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6c62a-b149-4cc2-9210-6420f31a6781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6c62a-b149-4cc2-9210-6420f31a6781.jpg?1",
             "name": "Woe Strider",
             "text": "When Woe Strider enters the battlefield, create a 0/1 white Goat creature token.\nSacrifice another creature: Scry 1.\nEscape\u2014{3}{B}{B}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nWoe Strider escapes with two +1/+1 counters on it.",
             "colours": [
@@ -28860,7 +28860,7 @@
         },
         {
             "id": "8d70d27d-faf5-5229-8bdf-fb88eeb6fbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ef00c1-613a-4cbd-8972-77c41f649431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ef00c1-613a-4cbd-8972-77c41f649431.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -28895,7 +28895,7 @@
         },
         {
             "id": "3c366b0b-4501-5937-80a4-235f635d2722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e885f56a-a1e8-4289-bbf5-3b156e53f7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e885f56a-a1e8-4289-bbf5-3b156e53f7db.jpg?1",
             "name": "Agitator Ant",
             "text": "At the beginning of your end step, each player may put two +1/+1 counters on a creature they control. Goad each creature that had counters put on it this way. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -28928,7 +28928,7 @@
         },
         {
             "id": "cb2e41c0-10cd-55af-b4d4-d1167bcd5055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78161e60-878a-45a2-aced-40b739bd0a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78161e60-878a-45a2-aced-40b739bd0a07.jpg?1",
             "name": "The Akroan War",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Gain control of target creature for as long as The Akroan War remains on the battlefield.\nII \u2014 Until your next turn, creatures your opponents control attack each combat if able.\nIII \u2014 Each tapped creature deals damage to itself equal to its power.",
             "colours": [
@@ -28961,7 +28961,7 @@
         },
         {
             "id": "64c86dd9-3cfd-5730-9480-e64f2933a178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a9e74f-8090-4314-9361-97777fb7b63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a9e74f-8090-4314-9361-97777fb7b63a.jpg?1",
             "name": "Aurora Phoenix",
             "text": "Flying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nWhenever you cast a spell with cascade, return Aurora Phoenix from your graveyard to your hand.",
             "colours": [
@@ -28994,7 +28994,7 @@
         },
         {
             "id": "a659e4b8-120e-5a75-b746-78638b79daad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7951ef42-8e14-4920-bf8a-75ab48e8645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7951ef42-8e14-4920-bf8a-75ab48e8645a.jpg?1",
             "name": "Avatar of Slaughter",
             "text": "All creatures have double strike and attack each combat if able.",
             "colours": [
@@ -29027,7 +29027,7 @@
         },
         {
             "id": "7f9c1b40-f4bd-5e0a-9e30-b5c14a3db22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba975f60-ca29-4fc8-b2f0-416be395f200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba975f60-ca29-4fc8-b2f0-416be395f200.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -29058,7 +29058,7 @@
         },
         {
             "id": "70bd0fe2-10e7-5a35-97b5-32c981340284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Whenever Bonecrusher Giant becomes the target of a spell, Bonecrusher Giant deals 2 damage to that spell's controller.",
             "colours": [
@@ -29091,7 +29091,7 @@
         },
         {
             "id": "c23a1071-887a-5dc1-91f0-6a27d3f5bb33",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Damage can't be prevented this turn. Stomp deals 2 damage to any target.",
             "colours": [
@@ -29124,7 +29124,7 @@
         },
         {
             "id": "6bf9b79d-7228-50e2-9317-89fcf7ee4227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1480f99-83f8-48e7-ba52-9a3f3a9a24f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1480f99-83f8-48e7-ba52-9a3f3a9a24f3.jpg?1",
             "name": "Brash Taunter",
             "text": "Indestructible\nWhenever Brash Taunter is dealt damage, it deals that much damage to target opponent.\n{2}{R}, {T}: Brash Taunter fights another target creature.",
             "colours": [
@@ -29157,7 +29157,7 @@
         },
         {
             "id": "9096adac-6652-5a79-ae59-bcacf367cc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ca793e-a54a-4e8f-a87d-f0dc4f178412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ca793e-a54a-4e8f-a87d-f0dc4f178412.jpg?1",
             "name": "Chain Reaction",
             "text": "Chain Reaction deals X damage to each creature, where X is the number of creatures on the battlefield.",
             "colours": [
@@ -29188,7 +29188,7 @@
         },
         {
             "id": "a7cd2c5f-b09f-502d-a3d8-ae381f8fd4fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08219fbc-c155-4d1d-a08c-d2546c44bccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08219fbc-c155-4d1d-a08c-d2546c44bccc.jpg?1",
             "name": "Chaos Dragon",
             "text": "Flying, haste\nChaos Dragon attacks each combat if able.\nAt the beginning of combat on your turn, each player rolls a d20. If one or more opponents had the highest result, Chaos Dragon can't attack those players or planeswalkers they control this combat.",
             "colours": [
@@ -29221,7 +29221,7 @@
         },
         {
             "id": "07bce218-ea7c-5895-a4d8-563011de5bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ee7b0-ea23-4657-a171-ac8a1308cc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ee7b0-ea23-4657-a171-ac8a1308cc4d.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -29252,7 +29252,7 @@
         },
         {
             "id": "b0a0f8f4-f728-5ebb-9687-a6b4ebfe4e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440acae3-aadb-40f0-a608-d1d93578c6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440acae3-aadb-40f0-a608-d1d93578c6b0.jpg?1",
             "name": "Curse of Opulence",
             "text": "Enchant player\nWhenever enchanted player is attacked, create a Gold token. Each opponent attacking that player does the same. (A Gold token is an artifact with \"Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -29286,7 +29286,7 @@
         },
         {
             "id": "c9b435c8-a93a-57e0-9373-6f72496beaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c43bf24-399e-407a-a563-bb04f93a0497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c43bf24-399e-407a-a563-bb04f93a0497.jpg?1",
             "name": "Demon Bolt",
             "text": "Demon Bolt deals 4 damage to target creature or planeswalker.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -29317,7 +29317,7 @@
         },
         {
             "id": "39a0ec8c-ac37-5827-9f75-fbfded7b7138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfc626c-1a03-4346-ba07-e26385ec0fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfc626c-1a03-4346-ba07-e26385ec0fd8.jpg?1",
             "name": "Dire Fleet Daredevil",
             "text": "First strike\nWhen Dire Fleet Daredevil enters the battlefield, exile target instant or sorcery card from an opponent's graveyard. You may cast it this turn, and you may spend mana as though it were mana of any type to cast that spell. If that spell would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -29351,7 +29351,7 @@
         },
         {
             "id": "a0015b18-56c5-5970-96d8-8c15dcc72165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc692-f994-4975-acae-4440e9e5857c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc692-f994-4975-acae-4440e9e5857c.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -29382,7 +29382,7 @@
         },
         {
             "id": "496bdde3-98ba-5f7e-8d9f-6544e6d2f790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8429f1-1a91-4f29-8d56-4c061f21c183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8429f1-1a91-4f29-8d56-4c061f21c183.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -29417,7 +29417,7 @@
         },
         {
             "id": "3b105a95-3353-5ae0-9d2a-19da607623aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c8d00f-23f3-429a-a99a-a6f3ec21c137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c8d00f-23f3-429a-a99a-a6f3ec21c137.jpg?1",
             "name": "Dream Pillager",
             "text": "Flying\nWhenever Dream Pillager deals combat damage to a player, exile that many cards from the top of your library. Until end of turn, you may cast spells from among those exiled cards.",
             "colours": [
@@ -29450,7 +29450,7 @@
         },
         {
             "id": "c09ddaef-592a-537b-a585-c31e2ee84a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -29484,7 +29484,7 @@
         },
         {
             "id": "cafef292-7128-5281-9fd2-9d4bdfc07cef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "Destroy target artifact. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -29517,7 +29517,7 @@
         },
         {
             "id": "14e3b9a0-8ff2-51ab-b4b1-9103dfb76bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc068c30-d677-4a7d-815f-f976e4787f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc068c30-d677-4a7d-815f-f976e4787f4b.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -29553,7 +29553,7 @@
         },
         {
             "id": "9b7f52c7-7c19-5276-b26a-8d7aa15504b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5974dd-78fc-4bfb-8678-72041c797584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5974dd-78fc-4bfb-8678-72041c797584.jpg?1",
             "name": "Geode Rager",
             "text": "First strike\nLandfall \u2014 Whenever a land enters the battlefield under your control, goad each creature target player controls. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -29586,7 +29586,7 @@
         },
         {
             "id": "fba57d1d-7c34-57fe-afe9-4314de9956cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687ea64-fcc0-4bd8-aa7e-3c893d4ef2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687ea64-fcc0-4bd8-aa7e-3c893d4ef2a8.jpg?1",
             "name": "Goblin Spymaster",
             "text": "First strike\nAt the beginning of each opponent's end step, that player creates a 1/1 red Goblin creature token with \"Creatures you control attack each combat if able.\"",
             "colours": [
@@ -29620,7 +29620,7 @@
         },
         {
             "id": "c128f951-15d2-58e6-9f66-8e09c2c50ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574fd1ec-fb73-4bf1-b3e4-5f976bf40a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574fd1ec-fb73-4bf1-b3e4-5f976bf40a62.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate only if Greater Gargadon is suspended.",
             "colours": [
@@ -29653,7 +29653,7 @@
         },
         {
             "id": "dce1c183-20a8-5850-863c-d46791595516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e82d3c-a7ec-4e0d-a17e-51ebd2f3f331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e82d3c-a7ec-4e0d-a17e-51ebd2f3f331.jpg?1",
             "name": "Ignite the Future",
             "text": "Exile the top three cards of your library. Until the end of your next turn, you may play those cards. If this spell was cast from a graveyard, you may play cards this way without paying their mana costs.\nFlashback {7}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -29684,7 +29684,7 @@
         },
         {
             "id": "ac501c73-a639-5304-9bd3-1926d275ffa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970c679-562b-48ee-b631-2e3016f4f37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970c679-562b-48ee-b631-2e3016f4f37c.jpg?1",
             "name": "Izzet Chemister",
             "text": "Haste\n{R}, {T}: Exile target instant or sorcery card from your graveyard.\n{1}{R}, {T}, Sacrifice Izzet Chemister: Cast any number of cards exiled with Izzet Chemister without paying their mana costs.",
             "colours": [
@@ -29718,7 +29718,7 @@
         },
         {
             "id": "e5cc2047-1816-5a46-8e29-fed0ec8478e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3308993d-8bfb-477a-887a-89ed35577f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3308993d-8bfb-477a-887a-89ed35577f57.jpg?1",
             "name": "Jeska's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Add {R} for each card in target opponent's hand.\n\u2022 Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -29749,7 +29749,7 @@
         },
         {
             "id": "1252dfea-a391-5551-ad8a-831d4703f995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce569cd-964e-44d6-a155-5a853ccc1478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce569cd-964e-44d6-a155-5a853ccc1478.jpg?1",
             "name": "Kazuul, Tyrant of the Cliffs",
             "text": "Whenever a creature an opponent controls attacks, if you're the defending player, create a 3/3 red Ogre creature token unless that creature's controller pays {3}.",
             "colours": [
@@ -29785,7 +29785,7 @@
         },
         {
             "id": "7a1203db-3ceb-5184-8342-dd5a4daf0599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e90b9b2-8e8e-4b00-b3a0-b26dd4551550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e90b9b2-8e8e-4b00-b3a0-b26dd4551550.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -29821,7 +29821,7 @@
         },
         {
             "id": "1ffbc473-f096-52db-844b-6cfdaaabf946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7034ff11-f7c7-4f33-be89-491ffec84833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7034ff11-f7c7-4f33-be89-491ffec84833.jpg?1",
             "name": "Light Up the Stage",
             "text": "Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nExile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -29852,7 +29852,7 @@
         },
         {
             "id": "bdaf543b-7840-5ad1-8070-ef0518ee95ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b2931-0af1-4743-b7c1-91e1dc9294d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b2931-0af1-4743-b7c1-91e1dc9294d5.jpg?1",
             "name": "Mizzium Mortars",
             "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -29883,7 +29883,7 @@
         },
         {
             "id": "6b44ed08-f63d-5e54-9d15-f49726cbe4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f75fce-f0a1-4dec-982d-a86925c6e9d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f75fce-f0a1-4dec-982d-a86925c6e9d4.jpg?1",
             "name": "Outpost Siege",
             "text": "As Outpost Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your upkeep, exile the top card of your library. Until end of turn, you may play that card.\n\u2022 Dragons \u2014 Whenever a creature you control leaves the battlefield, Outpost Siege deals 1 damage to any target.",
             "colours": [
@@ -29914,7 +29914,7 @@
         },
         {
             "id": "3ab16b2b-d171-5fb5-a293-7b429a57934a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf0514e-63b3-4695-93ae-527524d48c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf0514e-63b3-4695-93ae-527524d48c25.jpg?1",
             "name": "Rowan Kenrith",
             "text": "+2: During target player's next turn, each creature that player controls attacks if able.\n\u22122: Rowan Kenrith deals 3 damage to each tapped creature target player controls.\n\u22128: Target player gets an emblem with \"Whenever you activate an ability that isn't a mana ability, copy it. You may choose new targets for the copy.\"\nPartner with Will Kenrith\nRowan Kenrith can be your commander.",
             "colours": [
@@ -29949,7 +29949,7 @@
         },
         {
             "id": "7c955ef0-6cd7-5d8c-a1e9-8abefc1261e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -29985,7 +29985,7 @@
         },
         {
             "id": "e6780cf7-5ed0-5ce7-9be2-3dd30c6a6647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e37dde2-2ad4-46c6-ab69-8487f8a2bdb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e37dde2-2ad4-46c6-ab69-8487f8a2bdb6.jpg?1",
             "name": "Stolen Strategy",
             "text": "At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -30016,7 +30016,7 @@
         },
         {
             "id": "e769225f-97c4-5424-8804-0f2cf2c9b09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ec9d7-9784-481d-91d9-3dd1f666f7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ec9d7-9784-481d-91d9-3dd1f666f7d1.jpg?1",
             "name": "Tectonic Giant",
             "text": "Whenever Tectonic Giant attacks or becomes the target of a spell an opponent controls, choose one \u2014\n\u2022 Tectonic Giant deals 3 damage to each opponent.\n\u2022 Exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -30050,7 +30050,7 @@
         },
         {
             "id": "692c5baa-98e1-5797-8d8e-43029ca10b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21618490-f33b-4607-ac61-25df8cb096a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21618490-f33b-4607-ac61-25df8cb096a1.jpg?1",
             "name": "Territorial Hellkite",
             "text": "Flying, haste\nAt the beginning of combat on your turn, choose an opponent at random that Territorial Hellkite didn't attack during your last combat. Territorial Hellkite attacks that player this combat if able. If you can't choose an opponent this way, tap Territorial Hellkite.",
             "colours": [
@@ -30083,7 +30083,7 @@
         },
         {
             "id": "b854e2fa-353e-5864-a08d-2f99612379d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff75ff4-495f-4a0c-9d98-69eff1b3fa32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff75ff4-495f-4a0c-9d98-69eff1b3fa32.jpg?1",
             "name": "Thunder Dragon",
             "text": "Flying\nWhen Thunder Dragon enters the battlefield, it deals 3 damage to each creature without flying.",
             "colours": [
@@ -30116,7 +30116,7 @@
         },
         {
             "id": "49a24cda-4f82-562a-93d2-847c9c527443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93970fae-19f7-41dd-9750-ca428ae1de7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93970fae-19f7-41dd-9750-ca428ae1de7a.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "Creatures you control have haste.\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -30152,7 +30152,7 @@
         },
         {
             "id": "8181667b-c383-5241-a0ce-fdab85c0ed1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dabc03-a706-4e84-83e4-dbd405dfb025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dabc03-a706-4e84-83e4-dbd405dfb025.jpg?1",
             "name": "Vengeful Ancestor",
             "text": "Flying\nWhenever Vengeful Ancestor enters the battlefield or attacks, goad target creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)\nWhenever a goaded creature attacks, it deals 1 damage to its controller.",
             "colours": [
@@ -30186,7 +30186,7 @@
         },
         {
             "id": "584406e2-c514-5e8b-82a6-57a37459c910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fb4747-6734-4fbf-ab45-6d6e67f41be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fb4747-6734-4fbf-ab45-6d6e67f41be7.jpg?1",
             "name": "Volcanic Torrent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nVolcanic Torrent deals X damage to each creature and planeswalker your opponents control, where X is the number of spells you've cast this turn.",
             "colours": [
@@ -30217,7 +30217,7 @@
         },
         {
             "id": "d0922e63-c69c-512e-a433-d1d1221ea50d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedbf64-cd51-4f40-9735-272bd86fdf84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedbf64-cd51-4f40-9735-272bd86fdf84.jpg?1",
             "name": "Warmonger Hellkite",
             "text": "Flying\nAll creatures attack each combat if able.\n{1}{R}: Attacking creatures get +1/+0 until end of turn.",
             "colours": [
@@ -30250,7 +30250,7 @@
         },
         {
             "id": "d9f790e3-843a-5bcd-856b-a9acdd39492a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe1bfe0-0be7-496d-94db-e8028d4d9493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe1bfe0-0be7-496d-94db-e8028d4d9493.jpg?1",
             "name": "Warstorm Surge",
             "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to any target.",
             "colours": [
@@ -30281,7 +30281,7 @@
         },
         {
             "id": "e580066a-1722-581d-8636-4add7389ff12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5de7331-d0c6-46a5-b08d-0e032db63223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5de7331-d0c6-46a5-b08d-0e032db63223.jpg?1",
             "name": "Wild-Magic Sorcerer",
             "text": "The first spell you cast from exile each turn has cascade. (When you cast your first spell from exile, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -30315,7 +30315,7 @@
         },
         {
             "id": "3778ec72-5044-535d-88dc-90aaa4719552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/558b6db8-4a54-4d25-98e7-e27efc1cab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/558b6db8-4a54-4d25-98e7-e27efc1cab38.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -30351,7 +30351,7 @@
         },
         {
             "id": "5a6c79a9-5dd7-5a7f-8f08-5d86d73950a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70dc42-a28c-41f3-8d3b-5a0375aab326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70dc42-a28c-41f3-8d3b-5a0375aab326.jpg?1",
             "name": "Battle Mammoth",
             "text": "Trample\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\nForetell {2}{G}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -30384,7 +30384,7 @@
         },
         {
             "id": "46d1f9ed-163a-5675-89d1-939eea286f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Beanstalk Giant's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -30417,7 +30417,7 @@
         },
         {
             "id": "a606d74d-ba6e-5733-99cc-40e4329972d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -30450,7 +30450,7 @@
         },
         {
             "id": "d948fa72-473a-5c7b-abc4-4f74e3dad041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2fba2-fa50-4e69-aadb-d28479f821b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2fba2-fa50-4e69-aadb-d28479f821b9.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Beast creature token.",
             "colours": [
@@ -30481,7 +30481,7 @@
         },
         {
             "id": "f0460ab5-3c50-5b05-a549-4c02d8e49a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960ee5f-1109-4569-9191-be68a2c0f7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960ee5f-1109-4569-9191-be68a2c0f7d5.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -30512,7 +30512,7 @@
         },
         {
             "id": "878657fa-d4b4-52b7-8c14-a25e87cc5f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a74813-6d8b-4b11-8a5e-5b83d2d98c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a74813-6d8b-4b11-8a5e-5b83d2d98c34.jpg?1",
             "name": "End-Raze Forerunners",
             "text": "Vigilance, trample, haste\nWhen End-Raze Forerunners enters the battlefield, other creatures you control get +2/+2 and gain vigilance and trample until end of turn.",
             "colours": [
@@ -30545,7 +30545,7 @@
         },
         {
             "id": "03e71b88-3b25-5cf0-8fb0-4870d56bf24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a70945-8f8b-4dc7-a78b-d285694f9f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a70945-8f8b-4dc7-a78b-d285694f9f50.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -30576,7 +30576,7 @@
         },
         {
             "id": "9e4f1485-2297-5f36-93ed-3bf55a465f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dbfc25-f06e-4b5f-848f-6dd4cb72079e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dbfc25-f06e-4b5f-848f-6dd4cb72079e.jpg?1",
             "name": "Ezuri's Predation",
             "text": "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures.",
             "colours": [
@@ -30607,7 +30607,7 @@
         },
         {
             "id": "86097cef-0931-5579-9ad3-4ed81334d75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7c1a5-eb4e-4f75-ad41-1b84741ecab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7c1a5-eb4e-4f75-ad41-1b84741ecab1.jpg?1",
             "name": "Hornet Queen",
             "text": "Flying, deathtouch\nWhen Hornet Queen enters the battlefield, create four 1/1 green Insect creature tokens with flying and deathtouch.",
             "colours": [
@@ -30640,7 +30640,7 @@
         },
         {
             "id": "3e2b4766-02b3-5a38-8dd9-7f3168611c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979741db-e720-4efd-bc8e-2bf47e777ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979741db-e720-4efd-bc8e-2bf47e777ab3.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -30673,7 +30673,7 @@
         },
         {
             "id": "98c3870d-ffb4-55ae-9e14-7d2fca76e9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Lovestruck Beast can't attack unless you control a 1/1 creature.",
             "colours": [
@@ -30707,7 +30707,7 @@
         },
         {
             "id": "582c3888-8a93-5643-9f1d-6acd5b5565de",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Create a 1/1 white Human creature token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -30740,7 +30740,7 @@
         },
         {
             "id": "5a90edfc-7557-5eb3-944d-19a702d749a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330aefb9-629f-4d07-94d4-7252f17f85ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330aefb9-629f-4d07-94d4-7252f17f85ba.jpg?1",
             "name": "Managorger Hydra",
             "text": "Trample\nWhenever a player casts a spell, put a +1/+1 counter on Managorger Hydra.",
             "colours": [
@@ -30773,7 +30773,7 @@
         },
         {
             "id": "2d744cd9-d10e-5e79-a3c3-cb62ec0ab0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c4fc42-e5c6-438b-a4b7-1f77e818597f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c4fc42-e5c6-438b-a4b7-1f77e818597f.jpg?1",
             "name": "Natural Reclamation",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -30804,7 +30804,7 @@
         },
         {
             "id": "1a24b2fd-0631-5e66-b50e-fa36df50588c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9e943-9650-434c-a540-35ca7c96365b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9e943-9650-434c-a540-35ca7c96365b.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nWhenever a land enters the battlefield under your control, you gain 3 life.",
             "colours": [
@@ -30835,7 +30835,7 @@
         },
         {
             "id": "14c09a3b-bcde-5065-b0b8-432093579f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e0861-7934-4141-9ef5-120339ac83a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e0861-7934-4141-9ef5-120339ac83a5.jpg?1",
             "name": "Return of the Wildspeaker",
             "text": "Choose one \u2014\n\u2022 Draw cards equal to the greatest power among non-Human creatures you control.\n\u2022 Non-Human creatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -30866,7 +30866,7 @@
         },
         {
             "id": "bcbdaa13-0d0a-5c61-a55a-3a69b0b6145a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec23f98d-1bfd-4957-92b6-0a1da823db0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec23f98d-1bfd-4957-92b6-0a1da823db0f.jpg?1",
             "name": "Sakura-Tribe Elder",
             "text": "Sacrifice Sakura-Tribe Elder: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -30900,7 +30900,7 @@
         },
         {
             "id": "2681cd9c-3f33-534b-923a-677fd87aae1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d2a7e4-acc9-4236-a78f-c3171fd0c9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d2a7e4-acc9-4236-a78f-c3171fd0c9ec.jpg?1",
             "name": "Sandwurm Convergence",
             "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
             "colours": [
@@ -30931,7 +30931,7 @@
         },
         {
             "id": "d1b3ecec-e96b-5d88-b6f0-b3f7c3b91bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5e2fbf-87fe-48cd-aeca-e37f0a388a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5e2fbf-87fe-48cd-aeca-e37f0a388a30.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -30962,7 +30962,7 @@
         },
         {
             "id": "4fb11b2f-7090-53a7-969e-b8a0319c92cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c6325-450d-47f3-a69b-cdfc25ae65e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c6325-450d-47f3-a69b-cdfc25ae65e6.jpg?1",
             "name": "Sweet-Gum Recluse",
             "text": "Flash\nCascade\nReach\nWhen Sweet-Gum Recluse enters the battlefield, put three +1/+1 counters on each of any number of target creatures that entered the battlefield this turn.",
             "colours": [
@@ -30995,7 +30995,7 @@
         },
         {
             "id": "0975a650-91aa-583a-afbe-d04a5d4fad88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7b2ac-1263-402a-b2a0-bc31f61e66b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7b2ac-1263-402a-b2a0-bc31f61e66b5.jpg?1",
             "name": "Terramorph",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -31026,7 +31026,7 @@
         },
         {
             "id": "50d790fa-9183-59bb-986a-3d971ee74ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad698c3-687e-4b73-88d2-fd0ac7d755c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad698c3-687e-4b73-88d2-fd0ac7d755c5.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -31057,7 +31057,7 @@
         },
         {
             "id": "e07a64d3-dfc8-550b-9192-375e0df04679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11dc967-ae38-4c19-bf54-b3209e203b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11dc967-ae38-4c19-bf54-b3209e203b39.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "You may cast creature spells as though they had flash.\n+1: Until your next turn, up to one target creature gains vigilance and reach.\n\u22122: Look at the top three cards of your library. Exile one face down and put the rest on the bottom of your library in any order. For as long as it remains exiled, you may look at that card and you may cast it if it's a creature spell.",
             "colours": [
@@ -31092,7 +31092,7 @@
         },
         {
             "id": "81faa2d5-bd53-5ffa-8713-2f9d734666a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8174d8dc-ae0f-469f-a773-cb294540ea25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8174d8dc-ae0f-469f-a773-cb294540ea25.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -31128,7 +31128,7 @@
         },
         {
             "id": "803af955-50b7-5105-adcb-f016d25a2546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464dbaf6-8430-45af-b982-9099e6c6e8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464dbaf6-8430-45af-b982-9099e6c6e8a7.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -31163,7 +31163,7 @@
         },
         {
             "id": "ef54ac89-9b82-549a-81ad-9995b6f0a7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83902f7a-b675-45a6-8d03-a4e82335547a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83902f7a-b675-45a6-8d03-a4e82335547a.jpg?1",
             "name": "Despark",
             "text": "Exile target permanent with mana value 4 or greater.",
             "colours": [
@@ -31196,7 +31196,7 @@
         },
         {
             "id": "fcbfde25-901a-5a95-91f1-fb82960f78dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b9762-740b-4c1c-a411-20dbf023aea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b9762-740b-4c1c-a411-20dbf023aea5.jpg?1",
             "name": "Drown in the Loch",
             "text": "Choose one \u2014\n\u2022 Counter target spell with mana value less than or equal to the number of cards in its controller's graveyard.\n\u2022 Destroy target creature with mana value less than or equal to the number of cards in its controller's graveyard.",
             "colours": [
@@ -31229,7 +31229,7 @@
         },
         {
             "id": "fed0603e-eab0-5b04-b581-89162965393a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d58c2d-2bff-4d25-a023-0a6342167f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d58c2d-2bff-4d25-a023-0a6342167f5f.jpg?1",
             "name": "Escape to the Wilds",
             "text": "Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn.\nYou may play an additional land this turn.",
             "colours": [
@@ -31262,7 +31262,7 @@
         },
         {
             "id": "af81f38a-40cd-55db-b97c-6e4231e2172d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc868df-df15-4927-88dc-9b4d38d28c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc868df-df15-4927-88dc-9b4d38d28c5f.jpg?1",
             "name": "Extract from Darkness",
             "text": "Each player mills two cards. Then you put a creature card from a graveyard onto the battlefield under your control. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -31295,7 +31295,7 @@
         },
         {
             "id": "9fea787a-3f31-5c46-b9a9-e0648fe005bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8abf0-e8c3-4c19-bdf1-18aabe75a3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8abf0-e8c3-4c19-bdf1-18aabe75a3de.jpg?1",
             "name": "Felisa, Fang of Silverquill",
             "text": "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhenever a nontoken creature you control dies, if it had counters on it, create X tapped 2/1 white and black Inkling creature tokens with flying, where X is the number of counters it had on it.",
             "colours": [
@@ -31333,7 +31333,7 @@
         },
         {
             "id": "6bf47bc6-d821-5555-8af9-6c0530862f43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1bbe5-c63e-4a8d-b79a-0dcca221a726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1bbe5-c63e-4a8d-b79a-0dcca221a726.jpg?1",
             "name": "Firja's Retribution",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 4/4 white Angel Warrior creature token with flying and vigilance.\nII \u2014 Until end of turn, Angels you control gain \"{T}: Destroy target creature with power less than this creature's power.\"\nIII \u2014 Angels you control gain double strike until end of turn.",
             "colours": [
@@ -31368,7 +31368,7 @@
         },
         {
             "id": "5c91e955-6404-5828-a79e-3cda4dbd2c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa40ce2-76df-43bd-a59e-7cf6e4f46a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa40ce2-76df-43bd-a59e-7cf6e4f46a1d.jpg?1",
             "name": "Grumgully, the Generous",
             "text": "Each other non-Human creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -31406,7 +31406,7 @@
         },
         {
             "id": "11afb26a-2b2a-51e8-9956-1b6db8a58004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc264fad-c541-4cc6-8b56-44abf3f1e8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc264fad-c541-4cc6-8b56-44abf3f1e8a0.jpg?1",
             "name": "High Priest of Penance",
             "text": "Whenever High Priest of Penance is dealt damage, you may destroy target nonland permanent.",
             "colours": [
@@ -31442,7 +31442,7 @@
         },
         {
             "id": "77bfee50-63fb-5549-941e-61eee6107ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9b3d8d-4941-44ca-b829-d53242feba1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9b3d8d-4941-44ca-b829-d53242feba1e.jpg?1",
             "name": "Memory Plunder",
             "text": "You may cast target instant or sorcery card from an opponent's graveyard without paying its mana cost.",
             "colours": [
@@ -31475,7 +31475,7 @@
         },
         {
             "id": "10a08c70-dea4-5d0a-ae51-fa50f52c145a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022aacc6-2d82-43c0-ac08-ba9b20578929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022aacc6-2d82-43c0-ac08-ba9b20578929.jpg?1",
             "name": "Nemesis of Reason",
             "text": "Whenever Nemesis of Reason attacks, defending player mills ten cards.",
             "colours": [
@@ -31511,7 +31511,7 @@
         },
         {
             "id": "0c2cbf05-c0c8-5011-931b-ea010d463dac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035a97f-5104-4b56-84a4-5206e75607fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035a97f-5104-4b56-84a4-5206e75607fc.jpg?1",
             "name": "Niv-Mizzet, Parun",
             "text": "This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.",
             "colours": [
@@ -31549,7 +31549,7 @@
         },
         {
             "id": "5d1512be-667f-5658-aedd-8e0c79140295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361385d8-d9c7-4de8-a5c8-683e682779f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361385d8-d9c7-4de8-a5c8-683e682779f4.jpg?1",
             "name": "Sprite Dragon",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on Sprite Dragon.",
             "colours": [
@@ -31585,7 +31585,7 @@
         },
         {
             "id": "98f6e07e-3c17-5cb6-b9dc-1aba32e2aa0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfd90ee-a142-4a80-b383-802bbee2cef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfd90ee-a142-4a80-b383-802bbee2cef1.jpg?1",
             "name": "Xenagos, the Reveler",
             "text": "+1: Add X mana in any combination of {R} and/or {G}, where X is the number of creatures you control.\n0: Create a 2/2 red and green Satyr creature token with haste.\n\u22126: Exile the top seven cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield.",
             "colours": [
@@ -31622,7 +31622,7 @@
         },
         {
             "id": "9f43ae71-39bb-545b-b01e-f8e526c707f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe00149-b9ca-43d9-aff1-5c2da4dc7753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe00149-b9ca-43d9-aff1-5c2da4dc7753.jpg?1",
             "name": "Bloodthirsty Blade",
             "text": "Equipped creature gets +2/+0 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\n{1}: Attach Bloodthirsty Blade to target creature an opponent controls. Activate only as a sorcery.",
             "colours": [],
@@ -31651,7 +31651,7 @@
         },
         {
             "id": "d4d7eded-81a0-5767-91f7-cfc233c2f047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e065e040-80c1-47d3-a425-28381e5a29f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e065e040-80c1-47d3-a425-28381e5a29f2.jpg?1",
             "name": "Chaos Wand",
             "text": "{4}, {T}: Target opponent exiles cards from the top of their library until they exile an instant or sorcery card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of that library in a random order.",
             "colours": [],
@@ -31678,7 +31678,7 @@
         },
         {
             "id": "b08f32f6-574b-51c1-b61e-1a1ca0c2ed71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d1dd6c-21d3-4fe8-af1b-7088dcceef08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d1dd6c-21d3-4fe8-af1b-7088dcceef08.jpg?1",
             "name": "Dimir Keyrune",
             "text": "{T}: Add {U} or {B}.\n{U}{B}: Dimir Keyrune becomes a 2/2 blue and black Horror artifact creature until end of turn and can't be blocked this turn.",
             "colours": [],
@@ -31708,7 +31708,7 @@
         },
         {
             "id": "ee47885a-1b8a-5e90-a937-a7330c7987d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0ff83-04a7-4d5a-b901-6b8a698c5a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0ff83-04a7-4d5a-b901-6b8a698c5a4d.jpg?1",
             "name": "Dimir Signet",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -31738,7 +31738,7 @@
         },
         {
             "id": "76bcc90f-bfef-5900-a0d8-1ca3973e4584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b6f0a8-b6c2-49fc-880c-01ad63213271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b6f0a8-b6c2-49fc-880c-01ad63213271.jpg?1",
             "name": "Dragon's Hoard",
             "text": "Whenever a Dragon enters the battlefield under your control, put a gold counter on Dragon's Hoard.\n{T}, Remove a gold counter from Dragon's Hoard: Draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -31765,7 +31765,7 @@
         },
         {
             "id": "944c30a9-e029-5345-99a3-6825f9eb13ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c235-7749-4016-917c-dd8b586ac819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c235-7749-4016-917c-dd8b586ac819.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -31792,7 +31792,7 @@
         },
         {
             "id": "1d8db14d-1e8d-5c3d-90ae-4641687dfc54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bca6877-4e1d-4ecb-8812-d75d3470ffee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bca6877-4e1d-4ecb-8812-d75d3470ffee.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -31819,7 +31819,7 @@
         },
         {
             "id": "af84ebcc-e015-5787-a208-93d0defd9ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d76d25c-b962-43e4-aa6f-7c6e3bd79f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d76d25c-b962-43e4-aa6f-7c6e3bd79f16.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -31846,7 +31846,7 @@
         },
         {
             "id": "d4c41f1f-253c-562f-930f-a6a736c61bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178274fd-8b9b-4d69-a47e-31b29b776742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178274fd-8b9b-4d69-a47e-31b29b776742.jpg?1",
             "name": "Herald's Horn",
             "text": "As Herald's Horn enters the battlefield, choose a creature type.\nCreature spells you cast of the chosen type cost {1} less to cast.\nAt the beginning of your upkeep, look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand.",
             "colours": [],
@@ -31873,7 +31873,7 @@
         },
         {
             "id": "17d7a21a-72fa-5113-834a-db4985b30e16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc741b-18d8-41b1-b61b-e2249cad8526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc741b-18d8-41b1-b61b-e2249cad8526.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -31903,7 +31903,7 @@
         },
         {
             "id": "45973b43-e3b2-5368-a64d-6b97000693bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f47af-5929-44f4-bc6b-3ac7e521177d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f47af-5929-44f4-bc6b-3ac7e521177d.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -31932,7 +31932,7 @@
         },
         {
             "id": "283d02a3-377d-5bd6-9091-3ca72985f38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1246c42d-57c0-4cba-959a-15ad89d8a50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1246c42d-57c0-4cba-959a-15ad89d8a50b.jpg?1",
             "name": "Maskwood Nexus",
             "text": "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling. (It is every creature type.)",
             "colours": [],
@@ -31959,7 +31959,7 @@
         },
         {
             "id": "b18f5598-b3cd-5559-ba6b-671b007b33f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8858a941-8175-476d-8177-2db4ffdcb3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8858a941-8175-476d-8177-2db4ffdcb3ad.jpg?1",
             "name": "Mindcrank",
             "text": "Whenever an opponent loses life, that player mills that many cards. (Damage causes loss of life.)",
             "colours": [],
@@ -31986,7 +31986,7 @@
         },
         {
             "id": "6cca813c-235f-5574-b029-943e1766e5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb325f3-3c39-410b-b7a6-1615a7c4fe54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb325f3-3c39-410b-b7a6-1615a7c4fe54.jpg?1",
             "name": "Orzhov Signet",
             "text": "{1}, {T}: Add {W}{B}.",
             "colours": [],
@@ -32016,7 +32016,7 @@
         },
         {
             "id": "b8bb05dc-fa55-5946-8e4d-8779330a1a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ef9f3b-d6f8-4795-ba96-2f92b8792360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ef9f3b-d6f8-4795-ba96-2f92b8792360.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, choose a nonland card name.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -32047,7 +32047,7 @@
         },
         {
             "id": "837cd9e6-164a-5874-bb48-16f088eea0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe2c9e8-e35a-47a4-bcad-7c1c16dcdfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe2c9e8-e35a-47a4-bcad-7c1c16dcdfcf.jpg?1",
             "name": "Psychosis Crawler",
             "text": "Psychosis Crawler's power and toughness are each equal to the number of cards in your hand.\nWhenever you draw a card, each opponent loses 1 life.",
             "colours": [],
@@ -32078,7 +32078,7 @@
         },
         {
             "id": "57e3760f-4d20-5dcc-95ca-ad8e05871d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1877be5-fb98-4bd2-a754-dda1132ef8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1877be5-fb98-4bd2-a754-dda1132ef8a0.jpg?1",
             "name": "Skullclamp",
             "text": "Equipped creature gets +1/-1.\nWhenever equipped creature dies, draw two cards.\nEquip {1}",
             "colours": [],
@@ -32107,7 +32107,7 @@
         },
         {
             "id": "926332b2-d527-5eeb-9779-fb158ed79a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199cde21-5bc3-49cd-acd4-bae3af6e5881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199cde21-5bc3-49cd-acd4-bae3af6e5881.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -32134,7 +32134,7 @@
         },
         {
             "id": "e0442292-c3e6-5bff-bdca-bd9e6973df65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec09ec-a300-4d3c-8054-0250bb70b93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec09ec-a300-4d3c-8054-0250bb70b93b.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -32164,7 +32164,7 @@
         },
         {
             "id": "757889e8-a12e-5acd-96b9-a5beed31d51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72204934-f5aa-4559-8f7e-7b0b223580d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72204934-f5aa-4559-8f7e-7b0b223580d0.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -32197,7 +32197,7 @@
         },
         {
             "id": "3f45e8ed-4670-5f9b-b35c-3188655e7185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8823b43b-8a30-4226-b5a7-ac1c06ba146b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8823b43b-8a30-4226-b5a7-ac1c06ba146b.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: Steel Hellkite gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with mana value X whose controller was dealt combat damage by Steel Hellkite this turn. Activate only once each turn.",
             "colours": [],
@@ -32227,7 +32227,7 @@
         },
         {
             "id": "255c39b7-2794-5794-9add-df3342d294f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978c2c7d-6898-4be2-aed7-e673210ce654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978c2c7d-6898-4be2-aed7-e673210ce654.jpg?1",
             "name": "Stuffy Doll",
             "text": "Indestructible\nAs Stuffy Doll enters the battlefield, choose a player.\nWhenever Stuffy Doll is dealt damage, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -32257,7 +32257,7 @@
         },
         {
             "id": "9be41ccb-f0bb-5d01-be8e-0827508812f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b4fea5-aa7b-40e7-a3c4-cb467af16b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b4fea5-aa7b-40e7-a3c4-cb467af16b42.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -32287,7 +32287,7 @@
         },
         {
             "id": "2571255b-abe5-5736-95f2-94f5e31b4dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca2a0f9-b403-4d1e-961c-32b64bab81d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca2a0f9-b403-4d1e-961c-32b64bab81d0.jpg?1",
             "name": "Talisman of Dominance",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Talisman of Dominance deals 1 damage to you.",
             "colours": [],
@@ -32317,7 +32317,7 @@
         },
         {
             "id": "1a8ee515-ed9e-5acc-96fd-a69757a0ffef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299c93e-f3a6-4b41-857b-e3d1aff0f622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299c93e-f3a6-4b41-857b-e3d1aff0f622.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Talisman of Hierarchy deals 1 damage to you.",
             "colours": [],
@@ -32347,7 +32347,7 @@
         },
         {
             "id": "18ec150c-a0c2-558e-a9a6-34dcf670627d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9cbf2-99ed-4f70-8744-b9a08a5f5f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9cbf2-99ed-4f70-8744-b9a08a5f5f42.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -32374,7 +32374,7 @@
         },
         {
             "id": "116688b9-0238-506e-b269-5ebaf736d06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71aebf-f5d3-45ee-91a4-51088f7141ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71aebf-f5d3-45ee-91a4-51088f7141ec.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -32401,7 +32401,7 @@
         },
         {
             "id": "bc2b9d73-6282-5b1c-86ed-d587162d81ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e0ad38-31b3-46ba-9999-9b6ff57906ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e0ad38-31b3-46ba-9999-9b6ff57906ae.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {C}.\n{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -32430,7 +32430,7 @@
         },
         {
             "id": "00a32502-6419-5f9d-be14-bafba69f4a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1c157-cebc-45fe-9caa-1ea4b305ccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1c157-cebc-45fe-9caa-1ea4b305ccfc.jpg?1",
             "name": "Bojuka Bog",
             "text": "Bojuka Bog enters the battlefield tapped.\nWhen Bojuka Bog enters the battlefield, exile target player's graveyard.\n{T}: Add {B}.",
             "colours": [],
@@ -32459,7 +32459,7 @@
         },
         {
             "id": "62d8b41b-c7c3-55e6-9a43-9a9f8d1568f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4126a6-5f79-4dad-8d18-e279ca19d2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4126a6-5f79-4dad-8d18-e279ca19d2b2.jpg?1",
             "name": "Castle Embereth",
             "text": "Castle Embereth enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -32488,7 +32488,7 @@
         },
         {
             "id": "0f918ffb-a0f0-560b-a4e5-0253929615f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19336e3a-2242-4a30-a563-32f2e4fc18e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19336e3a-2242-4a30-a563-32f2e4fc18e9.jpg?1",
             "name": "Castle Locthwain",
             "text": "Castle Locthwain enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{1}{B}{B}, {T}: Draw a card, then you lose life equal to the number of cards in your hand.",
             "colours": [],
@@ -32517,7 +32517,7 @@
         },
         {
             "id": "f4d0b5ef-7600-5d77-8860-46368e5445f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf70844-18b1-4046-ae1d-ef41790bdcde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf70844-18b1-4046-ae1d-ef41790bdcde.jpg?1",
             "name": "Castle Vantress",
             "text": "Castle Vantress enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{2}{U}{U}, {T}: Scry 2.",
             "colours": [],
@@ -32546,7 +32546,7 @@
         },
         {
             "id": "2b4a3fd9-c551-5d53-a825-91db6fa30697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11cf7c-f71c-4416-acbc-d3d5807a7625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11cf7c-f71c-4416-acbc-d3d5807a7625.jpg?1",
             "name": "Choked Estuary",
             "text": "As Choked Estuary enters the battlefield, you may reveal an Island or Swamp card from your hand. If you don't, Choked Estuary enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -32576,7 +32576,7 @@
         },
         {
             "id": "88239a7d-eadd-5c43-8984-2b681a8a55b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b5a17-491e-416f-990d-187fce6c4ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b5a17-491e-416f-990d-187fce6c4ce4.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G}.)\nCinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -32609,7 +32609,7 @@
         },
         {
             "id": "2818fca3-9b31-53a3-b134-62350ee517d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f60e172-fcdc-4699-a212-815201375d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f60e172-fcdc-4699-a212-815201375d47.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{1}{U}{B}: Creeping Tar Pit becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land.",
             "colours": [],
@@ -32639,7 +32639,7 @@
         },
         {
             "id": "a8d10eff-f675-5dd4-bf0e-d24f0e8e72f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dbc012-8b38-4089-947a-c309d02ad1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dbc012-8b38-4089-947a-c309d02ad1b1.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -32669,7 +32669,7 @@
         },
         {
             "id": "3d67f177-fc66-56a5-bdad-a311973ddd2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7f5239-29d3-4b2b-b464-7e43107b1348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7f5239-29d3-4b2b-b464-7e43107b1348.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "{T}: Add {C}.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -32699,7 +32699,7 @@
         },
         {
             "id": "4bd5da26-26c2-559f-9679-2de3f16a71ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7552d5-ec37-4599-8789-fe20b6d4b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7552d5-ec37-4599-8789-fe20b6d4b7bf.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B}.",
             "colours": [],
@@ -32729,7 +32729,7 @@
         },
         {
             "id": "d86276ad-224b-5c06-99fb-7facc4e2ce83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c61b1b-d8fa-4c8b-9ddb-ca2682a3f5ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c61b1b-d8fa-4c8b-9ddb-ca2682a3f5ef.jpg?1",
             "name": "Drownyard Temple",
             "text": "{T}: Add {C}.\n{3}: Return Drownyard Temple from your graveyard to the battlefield tapped.",
             "colours": [],
@@ -32756,7 +32756,7 @@
         },
         {
             "id": "3687b0d8-c3b6-5991-84be-e1624e594e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de15320-485c-4191-8f15-12f9d1b340ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de15320-485c-4191-8f15-12f9d1b340ba.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -32783,7 +32783,7 @@
         },
         {
             "id": "350a36a5-6704-58b5-a3be-6e39a0cd1784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104635cd-b75f-4111-a948-50740f9cfff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104635cd-b75f-4111-a948-50740f9cfff8.jpg?1",
             "name": "Game Trail",
             "text": "As Game Trail enters the battlefield, you may reveal a Mountain or Forest card from your hand. If you don't, Game Trail enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -32813,7 +32813,7 @@
         },
         {
             "id": "96960450-b6dc-5f7b-927d-c69089a08f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104961dc-6684-474e-b126-4fcd95849f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104961dc-6684-474e-b126-4fcd95849f98.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G}.",
             "colours": [],
@@ -32843,7 +32843,7 @@
         },
         {
             "id": "b27156d6-f24a-5b47-ba74-f746058d2c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f64a32-c364-4750-94ed-d4d71c1a3511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f64a32-c364-4750-94ed-d4d71c1a3511.jpg?1",
             "name": "Highland Forest",
             "text": "({T}: Add {R} or {G}.)\nHighland Forest enters the battlefield tapped.",
             "colours": [],
@@ -32878,7 +32878,7 @@
         },
         {
             "id": "5159c30d-db2a-567f-a1fe-6a05a148b1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86e42c6-342b-443f-9b99-a68cf536ff45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86e42c6-342b-443f-9b99-a68cf536ff45.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R}.",
             "colours": [],
@@ -32908,7 +32908,7 @@
         },
         {
             "id": "2dedca1c-9af0-51b0-bff2-895ea769bc85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814e1393-34e1-4a31-98c5-97a3290a105b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814e1393-34e1-4a31-98c5-97a3290a105b.jpg?1",
             "name": "Kessig Wolf Run",
             "text": "{T}: Add {C}.\n{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",
             "colours": [],
@@ -32938,7 +32938,7 @@
         },
         {
             "id": "39720c3c-7d73-5cc7-957d-f34e23c48a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44bba8e-59e9-4a06-b845-c3ba7625ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44bba8e-59e9-4a06-b845-c3ba7625ff58.jpg?1",
             "name": "Kher Keep",
             "text": "{T}: Add {C}.\n{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep.",
             "colours": [],
@@ -32969,7 +32969,7 @@
         },
         {
             "id": "0384e066-cdf8-5742-b12e-c1a6c541ba31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058f30e5-64a9-4d6b-b7a6-0fd95d460cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058f30e5-64a9-4d6b-b7a6-0fd95d460cae.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.\n{T}: Add {B}.",
             "colours": [],
@@ -32998,7 +32998,7 @@
         },
         {
             "id": "0c7cbe57-cd4e-5953-bd0a-dca5220a3f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4581f-382c-420b-a2aa-bc8010b48c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4581f-382c-420b-a2aa-bc8010b48c7d.jpg?1",
             "name": "Mossfire Valley",
             "text": "{1}, {T}: Add {R}{G}.",
             "colours": [],
@@ -33028,7 +33028,7 @@
         },
         {
             "id": "a79cf7ea-2094-5614-acc7-75f9cbcfc67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d3a6d-4e6a-42ac-84de-3a3868ca026d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d3a6d-4e6a-42ac-84de-3a3868ca026d.jpg?1",
             "name": "Mosswort Bridge",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nMosswort Bridge enters the battlefield tapped.\n{T}: Add {G}.\n{G}, {T}: You may play the exiled card without paying its mana cost if creatures you control have total power 10 or greater.",
             "colours": [],
@@ -33057,7 +33057,7 @@
         },
         {
             "id": "0da85651-c287-5591-a627-be87d1516f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc2f10-142d-4e6a-984e-b25f566cc960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc2f10-142d-4e6a-984e-b25f566cc960.jpg?1",
             "name": "Mutavault",
             "text": "{T}: Add {C}.\n{1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -33084,7 +33084,7 @@
         },
         {
             "id": "2cfbafd5-8511-539c-ab6d-b8029152b2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f49f9-019b-44cb-a551-0fba9851ecc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f49f9-019b-44cb-a551-0fba9851ecc7.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -33111,7 +33111,7 @@
         },
         {
             "id": "4c4d83bf-3d5f-51ee-8ea3-f941cd845999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e332d52-7533-4d71-a4ba-36874f5ea3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e332d52-7533-4d71-a4ba-36874f5ea3fa.jpg?1",
             "name": "Nephalia Drownyard",
             "text": "{T}: Add {C}.\n{1}{U}{B}, {T}: Target player mills three cards.",
             "colours": [],
@@ -33141,7 +33141,7 @@
         },
         {
             "id": "74030271-746a-5574-a3e8-7b5408b1d093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ed0bb4-91b8-4144-b3d6-f92d6821d979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ed0bb4-91b8-4144-b3d6-f92d6821d979.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -33171,7 +33171,7 @@
         },
         {
             "id": "d0165038-8212-5cab-97d4-869502dab1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43710f35-c43f-48bf-82e1-64ba5c3fa03e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43710f35-c43f-48bf-82e1-64ba5c3fa03e.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -33198,7 +33198,7 @@
         },
         {
             "id": "f926a337-17fe-52ea-be1f-52bb926127ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62711f58-c52e-4493-b641-a77352bd4ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62711f58-c52e-4493-b641-a77352bd4ff8.jpg?1",
             "name": "Port of Karfell",
             "text": "Port of Karfell enters the battlefield tapped.\n{T}: Add {U}.\n{3}{U}{B}{B}, {T}, Sacrifice Port of Karfell: Mill four cards, then return a creature card from your graveyard to the battlefield tapped. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -33228,7 +33228,7 @@
         },
         {
             "id": "2f874eb3-7ce9-5687-b10a-05d517f5b7d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf90c219-508f-49af-a7f9-540021d49d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf90c219-508f-49af-a7f9-540021d49d8c.jpg?1",
             "name": "Prismari Campus",
             "text": "Prismari Campus enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -33258,7 +33258,7 @@
         },
         {
             "id": "cf8e5cd0-f29e-5c62-a9a5-e548b3be776f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c981c0-3e40-4339-a4c8-ad96c7fb68d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c981c0-3e40-4339-a4c8-ad96c7fb68d2.jpg?1",
             "name": "Raging Ravine",
             "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
             "colours": [],
@@ -33288,7 +33288,7 @@
         },
         {
             "id": "b83ba0d8-255f-576c-afa1-376e7bde6f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1241912a-92d6-4942-b97b-f795e702c4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1241912a-92d6-4942-b97b-f795e702c4ca.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -33315,7 +33315,7 @@
         },
         {
             "id": "145ddffd-ddc0-573e-9128-97971e1d0269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8a98a9-864c-4ea5-842b-ca4ddf5571cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8a98a9-864c-4ea5-842b-ca4ddf5571cd.jpg?1",
             "name": "River of Tears",
             "text": "{T}: Add {U}. If you played a land this turn, add {B} instead.",
             "colours": [],
@@ -33345,7 +33345,7 @@
         },
         {
             "id": "bdeb828f-4247-52f6-985b-65fee8fb0c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1dd27-be41-4bfa-b59d-3a002647f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1dd27-be41-4bfa-b59d-3a002647f1ad.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -33372,7 +33372,7 @@
         },
         {
             "id": "3cd57812-aea8-541b-9249-be38f95bcf05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5bf05a-04a1-4dde-845b-eced21a785fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5bf05a-04a1-4dde-845b-eced21a785fa.jpg?1",
             "name": "Shambling Vent",
             "text": "Shambling Vent enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.",
             "colours": [],
@@ -33402,7 +33402,7 @@
         },
         {
             "id": "f12c1ddf-dd97-5471-985c-581eacdc5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6e17f2-b1e4-4189-a02f-92fa4b13a1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6e17f2-b1e4-4189-a02f-92fa4b13a1ed.jpg?1",
             "name": "Snowfield Sinkhole",
             "text": "({T}: Add {W} or {B}.)\nSnowfield Sinkhole enters the battlefield tapped.",
             "colours": [],
@@ -33437,7 +33437,7 @@
         },
         {
             "id": "ddb1f664-7768-558e-95c4-de2feef60b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5d990f-0eb4-4634-a446-7783915e8eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5d990f-0eb4-4634-a446-7783915e8eec.jpg?1",
             "name": "Spinerock Knoll",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nSpinerock Knoll enters the battlefield tapped.\n{T}: Add {R}.\n{R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
             "colours": [],
@@ -33466,7 +33466,7 @@
         },
         {
             "id": "356d3453-6406-532b-b915-2d731736060e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5774836-0140-420a-9a0f-8ba291cc5ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5774836-0140-420a-9a0f-8ba291cc5ca8.jpg?1",
             "name": "Starlit Sanctum",
             "text": "{T}: Add {C}.\n{W}, {T}, Sacrifice a Cleric creature: You gain life equal to the sacrificed creature's toughness.\n{B}, {T}, Sacrifice a Cleric creature: Target player loses life equal to the sacrificed creature's power.",
             "colours": [],
@@ -33496,7 +33496,7 @@
         },
         {
             "id": "763645bd-ca52-5278-bbe2-4f4a6ca88ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c1fd3e-e899-4d66-8ad1-fdfbcdd70e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c1fd3e-e899-4d66-8ad1-fdfbcdd70e8b.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B}.)\nSunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -33529,7 +33529,7 @@
         },
         {
             "id": "113c3059-d85c-5c85-9e3c-13bfdf55fb80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f04e85-1b2b-4eb6-8332-4c13c2149d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f04e85-1b2b-4eb6-8332-4c13c2149d39.jpg?1",
             "name": "Tainted Field",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -33559,7 +33559,7 @@
         },
         {
             "id": "b8a723e7-4be4-5f20-8f15-b8d5a64619e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e376192-6dd2-4af0-b129-3751c8e3a8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e376192-6dd2-4af0-b129-3751c8e3a8bf.jpg?1",
             "name": "Tainted Isle",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -33589,7 +33589,7 @@
         },
         {
             "id": "fefaf0df-f938-574a-96d0-e518ba21b77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e544fd20-019a-4f96-891a-6eab4d6a01d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e544fd20-019a-4f96-891a-6eab4d6a01d7.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -33619,7 +33619,7 @@
         },
         {
             "id": "d1e50193-19ac-54e8-b898-9abf1990ccf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e3214a-0f76-4c60-8df9-4984b8d56d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e3214a-0f76-4c60-8df9-4984b8d56d89.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -33649,7 +33649,7 @@
         },
         {
             "id": "ca36c862-7e30-5794-b550-7efdc682dd58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3692d4-be30-4b23-b6e7-0c4af8c034a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3692d4-be30-4b23-b6e7-0c4af8c034a2.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -33679,7 +33679,7 @@
         },
         {
             "id": "b79f9ebd-f893-534e-a2a1-af3bd5e195c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3288ba-038c-4d8e-939d-c513a76fbfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3288ba-038c-4d8e-939d-c513a76fbfbf.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -33709,7 +33709,7 @@
         },
         {
             "id": "050fcd45-341f-5835-89f2-0891b5291647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8b9fd8-ece4-45ba-9fdf-4cb715bcd843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8b9fd8-ece4-45ba-9fdf-4cb715bcd843.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {C}{C}. Activate only if you control five or more lands.",
             "colours": [],
@@ -33736,7 +33736,7 @@
         },
         {
             "id": "a366d66b-a8a5-5fbe-9b2c-53fad1978db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40e9f0f-8c0d-4bfd-9872-370ce3763006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40e9f0f-8c0d-4bfd-9872-370ce3763006.jpg?1",
             "name": "Terrain Generator",
             "text": "{T}: Add {C}.\n{2}, {T}: You may put a basic land card from your hand onto the battlefield tapped.",
             "colours": [],
@@ -33763,7 +33763,7 @@
         },
         {
             "id": "1affea5f-336c-515b-b836-6ae6d109b977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004cea-51d4-4d69-ad98-37a2e02492e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004cea-51d4-4d69-ad98-37a2e02492e0.jpg?1",
             "name": "Vault of the Archangel",
             "text": "{T}: Add {C}.\n{2}{W}{B}, {T}: Creatures you control gain deathtouch and lifelink until end of turn.",
             "colours": [],
@@ -33793,7 +33793,7 @@
         },
         {
             "id": "e0509173-f469-5df1-9cda-a7fb7d823929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a6a8e-a01e-4d14-a6e5-c02c8205c749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a6a8e-a01e-4d14-a6e5-c02c8205c749.jpg?1",
             "name": "Wandering Fumarole",
             "text": "Wandering Fumarole enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with \"{0}: Switch this creature's power and toughness until end of turn.\" It's still a land.",
             "colours": [],
@@ -33823,7 +33823,7 @@
         },
         {
             "id": "d627814b-d437-531e-a1f6-24cc531da45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5cebc0-6a58-468d-a75e-46087ea2eb46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5cebc0-6a58-468d-a75e-46087ea2eb46.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -33850,7 +33850,7 @@
         },
         {
             "id": "a7b468d7-a408-5fc1-a258-8a109291b33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4aa7d1-e168-4fa0-baf0-1102086dc717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4aa7d1-e168-4fa0-baf0-1102086dc717.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWindbrisk Heights enters the battlefield tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -33879,7 +33879,7 @@
         },
         {
             "id": "945120e9-f362-5544-8ba3-3aa8a407a246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa652e2-caa6-4b48-bd04-67354380a761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa652e2-caa6-4b48-bd04-67354380a761.jpg?1",
             "name": "Captain N'ghathrod",
             "text": "Horrors you control have menace.\nWhenever a Horror you control deals combat damage to a player, that player mills that many cards.\nAt the beginning of your end step, choose target artifact or creature card in an opponent's graveyard that was put there from their library this turn. Put it onto the battlefield under your control.",
             "colours": [
@@ -33920,7 +33920,7 @@
         },
         {
             "id": "9dc2878d-0f28-5aba-a731-239d4895312a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dfa8eb-df44-4dcb-ad4f-4d548474eda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dfa8eb-df44-4dcb-ad4f-4d548474eda6.jpg?1",
             "name": "Faldorn, Dread Wolf Herald",
             "text": "Whenever you cast a spell from exile or a land enters the battlefield under your control from exile, create a 2/2 green Wolf creature token.\n{1}, {T}, Discard a card: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -33961,7 +33961,7 @@
         },
         {
             "id": "d1f9ce9d-46a6-5e81-abbe-0dfed1ae2141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee54e6d-e657-4eab-b937-1df6f0dd2b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee54e6d-e657-4eab-b937-1df6f0dd2b6b.jpg?1",
             "name": "Firkraag, Cunning Instigator",
             "text": "Flying, haste\nWhenever one or more Dragons you control attack an opponent, goad target creature that player controls.\nWhenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag, Cunning Instigator and you draw a card.",
             "colours": [
@@ -34001,7 +34001,7 @@
         },
         {
             "id": "67053319-c00d-5b46-bfdc-b9ceff85bafa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa32d2-e49a-4a06-a40f-ac41d1ceef39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa32d2-e49a-4a06-a40f-ac41d1ceef39.jpg?1",
             "name": "Nalia de'Arnise",
             "text": "You may look at the top card of your library any time.\nYou may cast Cleric, Rogue, Warrior, and Wizard spells from the top of your library.\nAt the beginning of combat on your turn, if you have a full party, put a +1/+1 counter on each creature you control and those creatures gain deathtouch until end of turn.",
             "colours": [
@@ -34042,7 +34042,7 @@
         },
         {
             "id": "5c1e4c62-9598-508c-9c2e-28dd6e8c7f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f79ec90-9fa7-4414-8eba-e2c890a91a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f79ec90-9fa7-4414-8eba-e2c890a91a70.jpg?1",
             "name": "Wand of Wonder",
             "text": "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1\u20139 | X is one.\n10\u201319 | X is two.\n20 | X is three.",
             "colours": [
@@ -34076,7 +34076,7 @@
         },
         {
             "id": "d639ee06-feaa-5f20-bb53-cf85348ebe9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f68bfe-1da0-41ec-b18d-92dc82d0217e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f68bfe-1da0-41ec-b18d-92dc82d0217e.jpg?1",
             "name": "Elder Brain",
             "text": "Menace\nWhenever Elder Brain attacks a player, exile all cards from that player's hand, then they draw that many cards. You may play lands and cast spells from among the exiled cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -34112,7 +34112,7 @@
         },
         {
             "id": "e5d042b4-3ce3-5aed-a1f4-5521484e37da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d56324-8293-4500-a9ad-fed351ccf966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d56324-8293-4500-a9ad-fed351ccf966.jpg?1",
             "name": "Baldur's Gate Wilderness",
             "text": "",
             "colours": [],
@@ -34139,7 +34139,7 @@
         },
         {
             "id": "0d657a73-829c-597f-89eb-ceb62ac7bcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce4f2b0-d63e-4f65-8261-ae61a8c9f591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce4f2b0-d63e-4f65-8261-ae61a8c9f591.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -34174,7 +34174,7 @@
         },
         {
             "id": "3f618808-a33a-5ed8-8f01-6d2edd98f875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633bba-9402-4d8c-a277-c370f25bd01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633bba-9402-4d8c-a277-c370f25bd01f.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -34209,7 +34209,7 @@
         },
         {
             "id": "5ddc1a52-47ba-55f1-b125-b370a47ac01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b0ed9-a4c0-4c58-978a-918ca266c699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b0ed9-a4c0-4c58-978a-918ca266c699.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -34244,7 +34244,7 @@
         },
         {
             "id": "757d445d-7e7c-5c31-a4c2-7993764da291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ca55e0-d269-4178-bc90-920a12066e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ca55e0-d269-4178-bc90-920a12066e4f.jpg?1",
             "name": "Rabbit",
             "text": "",
             "colours": [
@@ -34279,7 +34279,7 @@
         },
         {
             "id": "8e4feafb-d457-5954-9d4c-acb3b30eb384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5000cf8-2104-4d85-95df-29efa92256f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5000cf8-2104-4d85-95df-29efa92256f6.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -34314,7 +34314,7 @@
         },
         {
             "id": "94fd9955-060a-561a-8c4a-2b7d4ab105f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1eb498-8496-4234-8e87-78dc3f647534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1eb498-8496-4234-8e87-78dc3f647534.jpg?1",
             "name": "Faerie Dragon",
             "text": "",
             "colours": [
@@ -34350,7 +34350,7 @@
         },
         {
             "id": "2cdb5ae3-cf29-521f-b22a-e31e1daf73fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d744d755-ac09-4511-8664-5ff973e92fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d744d755-ac09-4511-8664-5ff973e92fc5.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -34385,7 +34385,7 @@
         },
         {
             "id": "3e6b7f39-90ba-5ebb-9727-ab997d006897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c245f-af2f-46a7-81f3-670a04940901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c245f-af2f-46a7-81f3-670a04940901.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -34420,7 +34420,7 @@
         },
         {
             "id": "477cb973-0ce1-5729-9f93-10f29fed22cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0475e9-68ae-4553-a5ef-650091e04967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0475e9-68ae-4553-a5ef-650091e04967.jpg?1",
             "name": "Boo",
             "text": "",
             "colours": [
@@ -34457,7 +34457,7 @@
         },
         {
             "id": "efeccbc7-bff1-5698-8377-783048680330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895df6af-6799-4ec6-b8f4-912b06f30ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895df6af-6799-4ec6-b8f4-912b06f30ed2.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -34492,7 +34492,7 @@
         },
         {
             "id": "3efec4a7-cadf-5ce8-b302-7a3cb149f404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32b97de-9cbb-40a2-ba3b-54e861023df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32b97de-9cbb-40a2-ba3b-54e861023df0.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -34527,7 +34527,7 @@
         },
         {
             "id": "51573dff-8abe-52bf-be05-04519caa5949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb796a0-4eb0-4fc5-bf84-92a71bec4466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb796a0-4eb0-4fc5-bf84-92a71bec4466.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -34562,7 +34562,7 @@
         },
         {
             "id": "6eff2377-e886-54a6-bcaa-b9757116853c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6655f22c-963f-42d6-b45c-8ea5fb256785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6655f22c-963f-42d6-b45c-8ea5fb256785.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -34597,7 +34597,7 @@
         },
         {
             "id": "94e7154b-94e6-5f1c-a43e-b0199ee94b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cbc9fc-42d2-4d1a-b6c0-29a35cfd1588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cbc9fc-42d2-4d1a-b6c0-29a35cfd1588.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -34632,7 +34632,7 @@
         },
         {
             "id": "350a7767-3ea5-5755-8e65-c8737275e503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380330b4-2d01-4042-97ac-41d9c60c982d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380330b4-2d01-4042-97ac-41d9c60c982d.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -34667,7 +34667,7 @@
         },
         {
             "id": "ee753323-2089-5cb6-9410-a0b89a596a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5715cf-fbf6-4b13-af91-525edc7706ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5715cf-fbf6-4b13-af91-525edc7706ea.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -34699,7 +34699,7 @@
         },
         {
             "id": "7fb44e8f-f3f6-5834-b4ef-a0249adacc31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770b988d-4f31-4746-8c23-4ed8d9a6b393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770b988d-4f31-4746-8c23-4ed8d9a6b393.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -34730,7 +34730,7 @@
         },
         {
             "id": "356c13a7-56ea-54b1-a904-6946c10ebd75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0fe7c9-b0ab-4d48-94d0-99e7bee0c0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0fe7c9-b0ab-4d48-94d0-99e7bee0c0de.jpg?1",
             "name": "Volo's Journal",
             "text": "",
             "colours": [],
@@ -34761,7 +34761,7 @@
         },
         {
             "id": "20210bc2-0b4a-55fc-bfd3-fc4abe806d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d7dc49-7116-489b-a719-7b293a513cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d7dc49-7116-489b-a719-7b293a513cdc.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -34789,7 +34789,7 @@
         },
         {
             "id": "3e24568b-33d4-5e56-8e89-8a2e545ae88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg?1",
             "name": "Undercity // The Initiative",
             "text": "",
             "colours": [],
@@ -34819,7 +34819,7 @@
         },
         {
             "id": "0fb61d8a-f3c2-5b88-ae63-6bf564498528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg?1",
             "name": "Undercity // The Initiative",
             "text": "",
             "colours": [],
@@ -34847,7 +34847,7 @@
         },
         {
             "id": "09c25ab4-3ed8-587d-918c-a7b71f984620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60abe28a-342e-49d0-80f6-6b3ce041372b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60abe28a-342e-49d0-80f6-6b3ce041372b.jpg?1",
             "name": "Eldrazi Horror",
             "text": "",
             "colours": [],
@@ -34878,7 +34878,7 @@
         },
         {
             "id": "2f8ad9ad-6ea8-5326-a8f3-03d7d8d1db8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bde9bf-fffc-4b86-9698-d5620b21d6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bde9bf-fffc-4b86-9698-d5620b21d6b8.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -34908,7 +34908,7 @@
         },
         {
             "id": "cadb4b9f-11fb-52c1-a2f4-7c74aa810aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd65e932-8ed6-424b-958f-d8edad2aa2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd65e932-8ed6-424b-958f-d8edad2aa2f4.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -34938,7 +34938,7 @@
         },
         {
             "id": "c799cc36-8f2b-5f7e-b81b-9a7c853afae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1186b536-e6c8-433d-a906-b29f334d619c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1186b536-e6c8-433d-a906-b29f334d619c.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -34968,7 +34968,7 @@
         },
         {
             "id": "b859c19a-c41b-52dc-b630-c3a35fda1743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2db6fe1-b6ec-43ca-933f-dbab4cd08064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2db6fe1-b6ec-43ca-933f-dbab4cd08064.jpg?1",
             "name": "Angel Warrior",
             "text": "",
             "colours": [
@@ -35003,7 +35003,7 @@
         },
         {
             "id": "10538b40-ba95-5a8e-bb63-e1d43dec0066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dad439-cae3-4f65-b6fb-c737321d322c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dad439-cae3-4f65-b6fb-c737321d322c.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -35037,7 +35037,7 @@
         },
         {
             "id": "d597aedf-6bd9-5d51-a9f0-d59010988656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138b304-4dc0-48bb-a043-6246abafef53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138b304-4dc0-48bb-a043-6246abafef53.jpg?1",
             "name": "Kor Warrior",
             "text": "",
             "colours": [
@@ -35072,7 +35072,7 @@
         },
         {
             "id": "5590d878-c28a-5c12-b61d-065c7c8e7a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce94fb42-cde4-4637-b938-13f17793bf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce94fb42-cde4-4637-b938-13f17793bf1f.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [
@@ -35106,7 +35106,7 @@
         },
         {
             "id": "70a05fe8-0f85-55f5-b3dc-b630d5457d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743688fa-ca30-4a4b-92ec-6708af8692db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743688fa-ca30-4a4b-92ec-6708af8692db.jpg?1",
             "name": "Squid",
             "text": "",
             "colours": [
@@ -35140,7 +35140,7 @@
         },
         {
             "id": "c510f2dd-8d22-5882-b4df-6ccb807b39d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53eb7d1-9c36-4184-b411-ebe65aa64230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53eb7d1-9c36-4184-b411-ebe65aa64230.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -35174,7 +35174,7 @@
         },
         {
             "id": "4960f41c-d50d-552c-a20e-79e7fe7e0566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddf9fb5-473f-44a2-98bd-93b4f7478d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddf9fb5-473f-44a2-98bd-93b4f7478d4f.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [
@@ -35208,7 +35208,7 @@
         },
         {
             "id": "1c17a5be-dc89-57f7-901b-7fd2520b4de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883ac854-ee35-418a-9d4e-c30ba2a5ade8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883ac854-ee35-418a-9d4e-c30ba2a5ade8.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -35242,7 +35242,7 @@
         },
         {
             "id": "feea9589-40b1-5e56-b7bd-3c91bf3133dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87386f2-5e90-4efd-a5d7-4716220d6ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87386f2-5e90-4efd-a5d7-4716220d6ab7.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -35276,7 +35276,7 @@
         },
         {
             "id": "fd1a2863-d5ce-5ad5-953d-18f8613d8f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db51576-a755-45de-b37b-f16b27e8f3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db51576-a755-45de-b37b-f16b27e8f3a1.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -35310,7 +35310,7 @@
         },
         {
             "id": "caf943a4-435e-548a-9081-161b0834d11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9bfd0a-9a31-4191-a615-a747cbca2015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9bfd0a-9a31-4191-a615-a747cbca2015.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -35344,7 +35344,7 @@
         },
         {
             "id": "ccd91ef2-6318-5c07-95dd-21435dbc55ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d725a8-daff-4458-aab0-06803ae33be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d725a8-daff-4458-aab0-06803ae33be3.jpg?1",
             "name": "Ogre",
             "text": "",
             "colours": [
@@ -35378,7 +35378,7 @@
         },
         {
             "id": "855bb2c7-8aa9-56b2-b9fc-a04788cc1c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42248cea-29e8-4ebe-ad64-e87e216b55d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42248cea-29e8-4ebe-ad64-e87e216b55d6.jpg?1",
             "name": "Pirate",
             "text": "",
             "colours": [
@@ -35412,7 +35412,7 @@
         },
         {
             "id": "2a3aa42b-6284-5143-9ab2-0f0bf6a49092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e095bd-091c-442f-aa21-0826c40acb6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e095bd-091c-442f-aa21-0826c40acb6c.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -35446,7 +35446,7 @@
         },
         {
             "id": "1ab1d189-ff59-5430-a10d-6221a4842c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd41697-6fe6-423c-a04a-035a3d4f8fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd41697-6fe6-423c-a04a-035a3d4f8fd2.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -35480,7 +35480,7 @@
         },
         {
             "id": "321db9fd-973a-5c69-aafe-6ac2fdedb3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca5cf3c-18f8-430a-a20f-2226d9cac387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca5cf3c-18f8-430a-a20f-2226d9cac387.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -35514,7 +35514,7 @@
         },
         {
             "id": "08b5de20-9d0a-5f95-9294-40bc92f051f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f64d14-c203-4401-a379-c6227d1cbac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f64d14-c203-4401-a379-c6227d1cbac2.jpg?1",
             "name": "Phyrexian Beast",
             "text": "",
             "colours": [
@@ -35549,7 +35549,7 @@
         },
         {
             "id": "16a543d2-390b-5eb2-81bd-b72b8acd4660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab34a7-0d18-4a6c-ac40-3b9901ff841b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab34a7-0d18-4a6c-ac40-3b9901ff841b.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -35583,7 +35583,7 @@
         },
         {
             "id": "a140e094-ab54-580d-bd5f-5fc47ab04de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81605b8d-cf1d-49dc-aebb-a857d6796a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81605b8d-cf1d-49dc-aebb-a857d6796a77.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -35617,7 +35617,7 @@
         },
         {
             "id": "91faceb7-2d3c-5282-84ec-6a739f964fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54afe5d9-a6b6-46a2-89e9-470ad9e44a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54afe5d9-a6b6-46a2-89e9-470ad9e44a06.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -35651,7 +35651,7 @@
         },
         {
             "id": "a5f2f661-0af5-5e6b-9478-b7f5a1748209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b57d024-2ff6-467f-bb4e-37270be60104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b57d024-2ff6-467f-bb4e-37270be60104.jpg?1",
             "name": "Inkling",
             "text": "",
             "colours": [
@@ -35687,7 +35687,7 @@
         },
         {
             "id": "fa454d81-8f62-5119-8cf8-01ff30476681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831fbc86-e328-4c26-a8b2-35feb24f6430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831fbc86-e328-4c26-a8b2-35feb24f6430.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -35723,7 +35723,7 @@
         },
         {
             "id": "baed3045-80da-57c5-b3f8-948a60b0ee0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25234a6-cb8d-479a-90f5-9d1a1084277b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25234a6-cb8d-479a-90f5-9d1a1084277b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -35753,7 +35753,7 @@
         },
         {
             "id": "6c4de848-5258-50e6-9a57-ceccc81aefce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b15a8a-58bd-4b7e-9b7f-e143c90f35d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b15a8a-58bd-4b7e-9b7f-e143c90f35d7.jpg?1",
             "name": "Gold",
             "text": "",
             "colours": [],
@@ -35783,7 +35783,7 @@
         },
         {
             "id": "c7221a00-3fe3-5573-8418-d7f62770b7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2f81ee-f258-40c4-abc6-0c80421b0837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2f81ee-f258-40c4-abc6-0c80421b0837.jpg?1",
             "name": "Rowan Kenrith Emblem",
             "text": "",
             "colours": [],
@@ -35812,7 +35812,7 @@
         },
         {
             "id": "d8e56fc8-229f-53d6-b9d5-6d60cc361700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de08752-9fc4-4e6b-b30b-2d9d33a1e37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de08752-9fc4-4e6b-b30b-2d9d33a1e37b.jpg?1",
             "name": "Will Kenrith Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/CMM.json
+++ b/Assets/Resources/Sets/CMM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1c8d3f82-7b94-5fc0-80d5-60a8d6363bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78c2713-39e7-4a6e-a132-027099a89665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78c2713-39e7-4a6e-a132-027099a89665.jpg?1",
             "name": "The Prismatic Piper",
             "text": "If The Prismatic Piper is your commander, choose a color before the game begins. The Prismatic Piper is the chosen color.\nPartner (You can have two commanders if both have partner.)",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "eb6d32be-f67d-5e7e-86ad-a118ef00c49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41554e7-2a07-4cc7-b01b-44deed08e588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41554e7-2a07-4cc7-b01b-44deed08e588.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -71,7 +71,7 @@
         },
         {
             "id": "2db25501-acbd-5eb3-bf02-20e9aaa3d132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84238335-e08c-421c-b9b9-70a679ff2967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84238335-e08c-421c-b9b9-70a679ff2967.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -113,7 +113,7 @@
         },
         {
             "id": "5eaa4ed1-5fac-517f-bdf5-c04b256c282d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1d4d8-7df9-41e0-b2d9-dbca9c9f6994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1d4d8-7df9-41e0-b2d9-dbca9c9f6994.jpg?1",
             "name": "Pathrazer of Ulamog",
             "text": "Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents.)\nPathrazer of Ulamog can't be blocked except by three or more creatures.",
             "colours": [],
@@ -143,7 +143,7 @@
         },
         {
             "id": "54cabf20-978c-5367-aff0-2b135dba2708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74ae706-b3b3-4097-a387-6f6c38a9b603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74ae706-b3b3-4097-a387-6f6c38a9b603.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -179,7 +179,7 @@
         },
         {
             "id": "0399c0d4-640d-5afa-8152-0df22386acc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699c0f6f-b26b-4741-8140-8a6030cad127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699c0f6f-b26b-4741-8140-8a6030cad127.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each combat if able.",
             "colours": [],
@@ -209,7 +209,7 @@
         },
         {
             "id": "cad13cc2-1785-51e1-aeb5-bf43b2cb7eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956c523-507c-4256-88b8-58a8a108c79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956c523-507c-4256-88b8-58a8a108c79f.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "dea6b3af-65eb-52a5-9bca-2b9008c2649f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdf5020-ea97-4f95-a096-cb5688dad2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdf5020-ea97-4f95-a096-cb5688dad2e2.jpg?1",
             "name": "Alharu, Solemn Ritualist",
             "text": "When Alharu, Solemn Ritualist enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.\nWhenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white Spirit creature token with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -281,7 +281,7 @@
         },
         {
             "id": "c29c0ca7-5b6e-50ee-9fb9-46a22d0b4fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0b82a-f943-4330-b9e7-bb4527354bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0b82a-f943-4330-b9e7-bb4527354bfd.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "39b6ca2c-4a04-51ec-882e-33708a2fd32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ac07a-a30f-4ebf-8877-27cd9ebe2f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ac07a-a30f-4ebf-8877-27cd9ebe2f71.jpg?1",
             "name": "Alms Collector",
             "text": "Flash\nIf an opponent would draw two or more cards, instead you and that player each draw a card.",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "602dd155-9bf3-5f29-8af2-91186ba3efc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1717da7b-9e87-4694-873b-abd4e3bcd5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1717da7b-9e87-4694-873b-abd4e3bcd5e2.jpg?1",
             "name": "Anafenza, Kin-Tree Spirit",
             "text": "Whenever another nontoken creature enters the battlefield under your control, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "f7ba57be-c558-5443-babc-25ee81b890cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24705dee-027c-42a2-8505-66c0a34a4a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24705dee-027c-42a2-8505-66c0a34a4a58.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "622099c4-1c5d-5de9-847a-d18b5bd95a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496e9fe2-843c-4dfe-b94a-b542a2ddaae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496e9fe2-843c-4dfe-b94a-b542a2ddaae4.jpg?1",
             "name": "Angelic Field Marshal",
             "text": "Flying\nLieutenant \u2014 As long as you control your commander, Angelic Field Marshal gets +2/+2 and creatures you control have vigilance.",
             "colours": [
@@ -461,7 +461,7 @@
         },
         {
             "id": "6a06d42a-2000-54eb-ba2b-435f06ad8335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1133-7cf8-4b7a-919e-88c45f8c2c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1133-7cf8-4b7a-919e-88c45f8c2c3a.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -499,7 +499,7 @@
         },
         {
             "id": "02a784bc-b61d-5e59-9178-7321a4e03973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bbe20b-0d39-46fc-a09a-fc8c676f1fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bbe20b-0d39-46fc-a09a-fc8c676f1fe7.jpg?1",
             "name": "Baird, Steward of Argive",
             "text": "Vigilance\nCreatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -536,7 +536,7 @@
         },
         {
             "id": "4d2b7017-bf6c-54fc-82d9-da231b348f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ebad9-bf65-48e2-9640-c11b5f04e38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ebad9-bf65-48e2-9640-c11b5f04e38b.jpg?1",
             "name": "Balan, Wandering Knight",
             "text": "First strike\nBalan, Wandering Knight has double strike as long as two or more Equipment are attached to it.\n{1}{W}: Attach all Equipment you control to Balan.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "977b8e46-a963-5482-9481-8b7e5b3a592c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90301f8c-f7af-4179-8faf-9901931bba8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90301f8c-f7af-4179-8faf-9901931bba8d.jpg?1",
             "name": "Battle Screech",
             "text": "Create two 1/1 white Bird creature tokens with flying.\nFlashback\u2014\nTap three untapped white creatures you control. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "c9c078d1-bbfb-503e-8e00-ece365a071f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d0b07f-9823-45b7-89bb-0a2a71833d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d0b07f-9823-45b7-89bb-0a2a71833d46.jpg?1",
             "name": "Cartographer's Hawk",
             "text": "Flying\nWhen Cartographer's Hawk deals combat damage to a player who controls more lands than you, return it to its owner's hand. If you do, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "ea5c735e-99fb-5077-b102-bf9e4daa10c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1771d71b-18b1-44dd-b413-4319519b0778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1771d71b-18b1-44dd-b413-4319519b0778.jpg?1",
             "name": "Custodi Squire",
             "text": "Flying\nWill of the council \u2014 When Custodi Squire enters the battlefield, starting with you, each player votes for an artifact, creature, or enchantment card in your graveyard. Return each card with the most votes or tied for most votes to your hand.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "f2acfed9-fa4a-5052-85ed-b67004eddc52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f77e4-edb6-43c6-b8ca-d4f62d26d0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f77e4-edb6-43c6-b8ca-d4f62d26d0c0.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "7ca00d58-bcb6-5450-9c02-845eabe3490b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47a6750-4fdd-44e2-86ae-5bc4d414bf42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47a6750-4fdd-44e2-86ae-5bc4d414bf42.jpg?1",
             "name": "Darksteel Mutation",
             "text": "Enchant creature\nEnchanted creature is an Insect artifact creature with base power and toughness 0/1 and has indestructible, and it loses all other abilities, card types, and creature types.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "c294b39d-9f36-57fb-8206-c0a5988c6a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ca5bcc-f49f-4370-9f95-031836bb771b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ca5bcc-f49f-4370-9f95-031836bb771b.jpg?1",
             "name": "Elite Scaleguard",
             "text": "When Elite Scaleguard enters the battlefield, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)\nWhenever a creature you control with a +1/+1 counter on it attacks, tap target creature defending player controls.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "c82a7a42-018e-5acd-99ed-5fa4d5355762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994094f8-e175-4e2e-aa39-c096f0ed9e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994094f8-e175-4e2e-aa39-c096f0ed9e6a.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "e3d57f06-9bde-5f66-878c-f963361bbc3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab12f69e-1491-47a8-8c46-d85bbf637ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab12f69e-1491-47a8-8c46-d85bbf637ff6.jpg?1",
             "name": "Flawless Maneuver",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCreatures you control gain indestructible until end of turn.",
             "colours": [
@@ -854,7 +854,7 @@
         },
         {
             "id": "9fbef1d5-be5a-5f2e-bd3d-7b21a331f428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d78a93-1a9f-4bc1-82b4-d3434367d27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d78a93-1a9f-4bc1-82b4-d3434367d27b.jpg?1",
             "name": "Gavony Silversmith",
             "text": "When Gavony Silversmith enters the battlefield, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -889,7 +889,7 @@
         },
         {
             "id": "838b2819-6dcf-57ae-bcfe-233fde8ac904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8c02ab-6348-4b04-8ce0-b36309a14a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8c02ab-6348-4b04-8ce0-b36309a14a5e.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "b4e3f2ac-efd1-5b39-bb11-aff92ab6589b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e30ca4-1769-4686-aa18-31610246cd80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e30ca4-1769-4686-aa18-31610246cd80.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "fb58ce8e-db0e-51f3-ad0b-d149ce33faaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f34f41-bbd8-4424-88a3-b97a795b6daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f34f41-bbd8-4424-88a3-b97a795b6daf.jpg?1",
             "name": "Heavenly Blademaster",
             "text": "Flying, double strike\nWhen Heavenly Blademaster enters the battlefield, you may attach any number of Auras and Equipment you control to it.\nOther creatures you control get +1/+1 for each Aura and Equipment attached to Heavenly Blademaster.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "18331c2c-9d4c-51b1-aadc-fc5ca4d337f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3245ff74-1f9c-4518-a23f-1579f338f232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3245ff74-1f9c-4518-a23f-1579f338f232.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nWhenever you gain life, put a +1/+1 counter on target creature or enchantment you control.\n{1}{W}: Another target creature gains lifelink until end of turn.",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "fccf0fe7-6880-5997-a15f-7281e2fd8a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d57d75-275d-45c8-85f4-aab230af35b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d57d75-275d-45c8-85f4-aab230af35b2.jpg?1",
             "name": "Herald of the Host",
             "text": "Flying, vigilance\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "e835a5b7-8da9-5219-972c-89f0fdd7ef7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d251846-7aa5-4318-a96b-fbd9daf691f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d251846-7aa5-4318-a96b-fbd9daf691f9.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "cd2af96f-607a-5fb7-90f3-8d6faf63bed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616d54a1-33f7-47c9-852f-4f3a07309f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616d54a1-33f7-47c9-852f-4f3a07309f27.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -1141,7 +1141,7 @@
         },
         {
             "id": "1c86bb93-0166-5ece-9b9c-49a3360f7024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc95324a-9a7f-4ed9-a3da-36a3eca91936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc95324a-9a7f-4ed9-a3da-36a3eca91936.jpg?1",
             "name": "Keleth, Sunmane Familiar",
             "text": "Whenever a commander you control attacks, put a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "14995e68-e2a7-5dbb-88c1-b8258b7f788e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacc4290-6a72-4c00-8bdd-e40ae28885a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacc4290-6a72-4c00-8bdd-e40ae28885a8.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, create a 2/2 white Cat creature token for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "693f54a4-9e3e-5de0-b58b-79b53302bcd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbbbbf7-eaae-462e-a8eb-7f6a97703600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbbbbf7-eaae-462e-a8eb-7f6a97703600.jpg?1",
             "name": "Kirtar's Wrath",
             "text": "Destroy all creatures. They can't be regenerated.\nThreshold \u2014 If seven or more cards are in your graveyard, instead destroy all creatures, then create two 1/1 white Spirit creature tokens with flying. Creatures destroyed this way can't be regenerated.",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "c35ff682-9d2f-5b0c-b7bd-857856e4884f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0489ee-96b6-4437-a716-ee07ecbd4cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0489ee-96b6-4437-a716-ee07ecbd4cb7.jpg?1",
             "name": "Knighted Myr",
             "text": "{2}{W}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Knighted Myr, it gains double strike until end of turn.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "5837f5f2-6207-535c-88bd-5d11396800e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9258ad10-cbe6-4676-93b4-6ef4a33f12ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9258ad10-cbe6-4676-93b4-6ef4a33f12ee.jpg?1",
             "name": "Land Tax",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "8ebe69b1-4460-5480-bf88-75f880411e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6b54de-8e79-4f60-b642-3d259bf74ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6b54de-8e79-4f60-b642-3d259bf74ea0.jpg?1",
             "name": "Losheel, Clockwork Scholar",
             "text": "Prevent all combat damage that would be dealt to attacking artifact creatures you control.\nWhenever one or more artifact creatures enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "d4673c28-b6c3-528b-adb1-bfb2d3d1c5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b35e70-9a0e-4204-9454-a1f2c58eb0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b35e70-9a0e-4204-9454-a1f2c58eb0e0.jpg?1",
             "name": "Loyal Retainers",
             "text": "Sacrifice Loyal Retainers: Return target legendary creature card from your graveyard to the battlefield. Activate only during your turn, before attackers are declared.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "2bbe3232-0914-5e1d-975f-dd6743cddb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d7203b-55ed-4d08-ac2e-2c4b4b93c274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d7203b-55ed-4d08-ac2e-2c4b4b93c274.jpg?1",
             "name": "Loyal Unicorn",
             "text": "Vigilance\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn. Other creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "a8bafd39-7c53-5aa6-b260-25ed0afbf65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a08aff-3a50-4f2e-97a1-f1d79d5c4ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a08aff-3a50-4f2e-97a1-f1d79d5c4ade.jpg?1",
             "name": "Mace of the Valiant",
             "text": "Equipped creature gets +1/+1 for each charge counter on Mace of the Valiant and has vigilance.\nWhenever a creature enters the battlefield under your control, put a charge counter on Mace of the Valiant.\nEquip {3}",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "9f2e198d-ae73-53db-a651-4e576ff79152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e77ae5-a1a6-4e51-9853-10e81ca2dd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e77ae5-a1a6-4e51-9853-10e81ca2dd2c.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -1499,7 +1499,7 @@
         },
         {
             "id": "0fbae37d-f612-5b7d-a955-5ee09b748063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d9c9db-28a0-47fa-b561-6040e47c2392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d9c9db-28a0-47fa-b561-6040e47c2392.jpg?1",
             "name": "Ministrant of Obligation",
             "text": "Afterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -1534,7 +1534,7 @@
         },
         {
             "id": "46b2319b-e5c9-5e73-91f8-b474bb57b8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea3e84-2d78-489f-875a-48e58c956451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea3e84-2d78-489f-875a-48e58c956451.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, create a 1/1 colorless Myr artifact creature token.",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "e2976694-f753-50e5-9cae-eb43a29522ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b074e60a-6f9b-4679-9617-261e2e15e1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b074e60a-6f9b-4679-9617-261e2e15e1e8.jpg?1",
             "name": "Nahiri, the Lithomancer",
             "text": "+2: Create a 1/1 white Kor Soldier creature token. You may attach an Equipment you control to it.\n\u22122: You may put an Equipment card from your hand or graveyard onto the battlefield.\n\u221210: Create a colorless Equipment artifact token named Stoneforged Blade. It has indestructible, \"Equipped creature gets +5/+5 and has double strike,\" and equip {0}.\nNahiri, the Lithomancer can be your commander.",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "2c3549e7-e311-5d16-b4c6-ddbde1d1dbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bfcec9-a789-41f1-aa3d-4e4cdd7555b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bfcec9-a789-41f1-aa3d-4e4cdd7555b2.jpg?1",
             "name": "Odric, Master Tactician",
             "text": "First strike\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "803ba915-a741-5426-bcda-a4c464e5c74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ee31a-e80f-481a-b2e7-7a6c68eb1efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ee31a-e80f-481a-b2e7-7a6c68eb1efb.jpg?1",
             "name": "Palace Jailer",
             "text": "When Palace Jailer enters the battlefield, you become the monarch.\nWhen Palace Jailer enters the battlefield, exile target creature an opponent controls until an opponent becomes the monarch.",
             "colours": [
@@ -1681,7 +1681,7 @@
         },
         {
             "id": "709ba022-04cf-5148-9de8-9a6ead666942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0bbbe0-e6cf-43df-9c44-b6bbfa9c9af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0bbbe0-e6cf-43df-9c44-b6bbfa9c9af7.jpg?1",
             "name": "Palace Sentinels",
             "text": "When Palace Sentinels enters the battlefield, you become the monarch.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "89af9c87-295b-579e-84fa-7bbf3ad23ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970389b-08f4-4a15-a128-954b072a8137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970389b-08f4-4a15-a128-954b072a8137.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "36349731-08cf-5cf7-86e9-6f5730b89ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ebb129-aa8d-4107-8e74-0b04525d76e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ebb129-aa8d-4107-8e74-0b04525d76e0.jpg?1",
             "name": "Pianna, Nomad Captain",
             "text": "Whenever Pianna, Nomad Captain attacks, attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "d6d49893-84f8-57cf-99a3-7cb4bced1413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f8a324-006d-4cb8-9816-620a603b4229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f8a324-006d-4cb8-9816-620a603b4229.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "034508d3-0aeb-5515-b39a-7cffd9dc67c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57ba1d-2b43-4839-b77d-38fee2e81bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57ba1d-2b43-4839-b77d-38fee2e81bf6.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "99742e09-2242-5dd9-ba64-0194848f7468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2faf6-e65b-4962-82d4-0294912c2ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2faf6-e65b-4962-82d4-0294912c2ddb.jpg?1",
             "name": "Righteous Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Create a 2/2 white Knight creature token with vigilance.\n\u2022 Exile target enchantment.\n\u2022 You gain 5 life.",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "b0e03074-8387-50fd-a44f-3e6b88ab6f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729ee848-6c27-4202-b2bc-605f45209468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729ee848-6c27-4202-b2bc-605f45209468.jpg?1",
             "name": "Sephara, Sky's Blade",
             "text": "You may pay {W} and tap four untapped creatures you control with flying rather than pay this spell's mana cost.\nFlying, lifelink\nOther creatures you control with flying have indestructible.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "1e699fc6-6edd-5a49-b310-e3e0e3a0cb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51647010-99f0-4b02-8c91-fdd826db130d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51647010-99f0-4b02-8c91-fdd826db130d.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "fec3e760-7f6d-5c02-b8d6-cc046b49bdc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fedc9-6dd1-4190-a0c9-e9d10fd91315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fedc9-6dd1-4190-a0c9-e9d10fd91315.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "56c915af-68f7-59cf-b4dd-ac8722abf010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861b5889-0183-4bee-afeb-a4b2aa700a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861b5889-0183-4bee-afeb-a4b2aa700a8e.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "4c2f088a-c4b9-5947-9ec1-f20113883c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3cce9-d570-4a45-b484-089849a91b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3cce9-d570-4a45-b484-089849a91b6c.jpg?1",
             "name": "Spectral Grasp",
             "text": "Enchant creature\nEnchanted creature can't attack you or planeswalkers you control.\nEnchanted creature can't block creatures you control.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "878844f2-1f7e-5da7-95f0-c8c90d34af3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d61383-b739-4422-a76c-d8cbca13c5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d61383-b739-4422-a76c-d8cbca13c5b2.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "7c7d11b5-dafa-50bc-a690-e13d4cb5f7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8f810f-844b-4ebd-b28c-46432cf0203d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8f810f-844b-4ebd-b28c-46432cf0203d.jpg?1",
             "name": "Sublime Exhalation",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy all creatures.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "2f66b5c8-8569-5f23-9475-f3d77b47cfcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407041c4-0154-42ee-a736-7815024d1719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407041c4-0154-42ee-a736-7815024d1719.jpg?1",
             "name": "Sunblade Angel",
             "text": "Flying, first strike, vigilance, lifelink",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "200ed638-c337-5aa2-b8db-f8a45f0154f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303df3ba-1258-4141-ace2-577f9e89a14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303df3ba-1258-4141-ace2-577f9e89a14c.jpg?1",
             "name": "Sunspear Shikari",
             "text": "As long as Sunspear Shikari is equipped, it has first strike and lifelink.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "d87a39a0-8a96-5a13-b06a-321edb81e073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbc3b-a2e9-4a14-a603-581413bc0b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbc3b-a2e9-4a14-a603-581413bc0b17.jpg?1",
             "name": "Supply Runners",
             "text": "When Supply Runners enters the battlefield, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "2bcd66f5-9e7c-550b-90a4-a59c2ebdfc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d70dcbe-0b90-40b4-8a54-e5218b7135b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d70dcbe-0b90-40b4-8a54-e5218b7135b1.jpg?1",
             "name": "Swift Response",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "1d80cade-17cc-5f55-9604-543553c3800d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9b45b-d466-4c06-9a25-6edb6e8f6f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9b45b-d466-4c06-9a25-6edb6e8f6f2f.jpg?1",
             "name": "Teshar, Ancestor's Apostle",
             "text": "Flying\nWhenever you cast a historic spell, return target creature card with mana value 3 or less from your graveyard to the battlefield. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "e6ac24d0-74d7-5a64-85ce-cb03262cf861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299cc386-2ed5-4504-9ba6-17a52e0c9a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299cc386-2ed5-4504-9ba6-17a52e0c9a0c.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "e015da42-3fe6-565d-8b56-bf767d0bf44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732c3b63-5e15-4510-813c-58e20cd9833f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732c3b63-5e15-4510-813c-58e20cd9833f.jpg?1",
             "name": "Unbounded Potential",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on each of up to two target creatures.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEntwine {3}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "9cee1fc0-7b60-57fe-ae41-abfa409d10d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b3918-94f7-4981-9702-f01970fac37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b3918-94f7-4981-9702-f01970fac37c.jpg?1",
             "name": "Wakening Sun's Avatar",
             "text": "When Wakening Sun's Avatar enters the battlefield, if you cast it from your hand, destroy all non-Dinosaur creatures.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "51ee1a3e-7fb8-5f78-96ab-fbc141865d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb14b6-1fd8-49be-bf95-f147f48b072c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb14b6-1fd8-49be-bf95-f147f48b072c.jpg?1",
             "name": "Wanderer's Strike",
             "text": "Exile target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "68855283-bd13-5794-94d7-8b21b2dc4320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537d2b05-3f52-45d6-8fe3-26282085d0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537d2b05-3f52-45d6-8fe3-26282085d0c6.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "545e863f-7054-5849-a6f0-35204d0bc268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3425c9-9bec-40e4-a2e9-ce8ac4281688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3425c9-9bec-40e4-a2e9-ce8ac4281688.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "222d6470-0c0a-56e8-99e7-eda2cf0de494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792ebc50-909f-4b81-a2cd-0da1ba36a0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792ebc50-909f-4b81-a2cd-0da1ba36a0d3.jpg?1",
             "name": "Aether Gale",
             "text": "Return six target nonland permanents to their owners' hands.",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "b96d409e-2d32-5fc6-9997-9209e7744021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92496b98-b533-4d34-aa79-cad0805c984b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92496b98-b533-4d34-aa79-cad0805c984b.jpg?1",
             "name": "Aminatou's Augury",
             "text": "Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a spell of that type from among the exiled cards without paying its mana cost.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "58c3b291-d23b-5974-8d9f-fc10be3b9d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa727656-fb33-485b-9378-18b80cad42b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa727656-fb33-485b-9378-18b80cad42b9.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "87368c4a-3889-5b3f-b362-fcdd179370d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d434b49-c3e8-4b4d-b573-c144ba78e98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d434b49-c3e8-4b4d-b573-c144ba78e98b.jpg?1",
             "name": "Body Double",
             "text": "You may have Body Double enter the battlefield as a copy of any creature card in a graveyard.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "78580561-e67a-557b-97f6-f85269087aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea0a701-1349-4d32-9fe7-8a2563c9613d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea0a701-1349-4d32-9fe7-8a2563c9613d.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from their hand onto the battlefield.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "c547b61c-d368-5a60-a6ce-59a7a3bb3367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fd737a-d7da-421b-a741-d6d0d213299f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fd737a-d7da-421b-a741-d6d0d213299f.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "e77f3c72-8bf8-577e-9a56-4242d4b1b2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606f8ea-815b-4308-8f1d-3dad4f45f70e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606f8ea-815b-4308-8f1d-3dad4f45f70e.jpg?1",
             "name": "Brinelin, the Moon Kraken",
             "text": "When Brinelin, the Moon Kraken enters the battlefield and whenever you cast a spell with mana value 6 or greater, you may return target nonland permanent to its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "7bf1379a-31a7-52ad-be47-19850a6a7e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87d0298-f76b-4ea8-82c4-5861c4539d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87d0298-f76b-4ea8-82c4-5861c4539d8b.jpg?1",
             "name": "Capture of Jingzhou",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "3a18adc1-afa2-512b-ab83-664705bf3153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca0a9a8-5ebc-43a3-8450-420ab6b7b76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca0a9a8-5ebc-43a3-8450-420ab6b7b76e.jpg?1",
             "name": "Commandeer",
             "text": "You may exile two blue cards from your hand rather than pay this spell's mana cost.\nGain control of target noncreature spell. You may choose new targets for it. (If that spell is an artifact, enchantment, or planeswalker, the permanent enters the battlefield under your control.)",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "33ae707b-b9ae-556e-ad6a-943ee2ef3094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8493131c-0a7b-4be6-a8a2-0b425f4f67fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8493131c-0a7b-4be6-a8a2-0b425f4f67fb.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "58807b0d-dcd7-5cfc-8562-0295eb435282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15935478-c2e1-4fb5-b6ba-0969ea5a0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15935478-c2e1-4fb5-b6ba-0969ea5a0e81.jpg?1",
             "name": "Coveted Peacock",
             "text": "Flying\nWhenever Coveted Peacock attacks, you may goad target creature defending player controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -2901,7 +2901,7 @@
         },
         {
             "id": "4ee64dc2-7c46-5ccc-8cbe-8a2f35d250b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1af32a-dba2-4c2f-b0ee-9c83849fda53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1af32a-dba2-4c2f-b0ee-9c83849fda53.jpg?1",
             "name": "Cryptic Serpent",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "3dba32f6-a18a-5485-a8ad-ac0c25ade224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77ebe57-ea56-4300-b293-6260c4c01a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77ebe57-ea56-4300-b293-6260c4c01a43.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "c6916d25-2ac1-54e9-9a5d-df58dd0f7c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac13a82d-43f5-4b96-bf5f-18e33fae921b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac13a82d-43f5-4b96-bf5f-18e33fae921b.jpg?1",
             "name": "Day's Undoing",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities from the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "22ef6efb-9962-5cab-827f-b5fc8e975d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479ce7-4617-4c7c-93f2-cf8c9c5e1dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479ce7-4617-4c7c-93f2-cf8c9c5e1dac.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "6498d01d-6f16-5efb-9a70-fa2e92d20384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee8f524-f45d-49ff-a472-a47441eee279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee8f524-f45d-49ff-a472-a47441eee279.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "86a02da0-2a10-5927-92ae-c4adc057bcd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d2f70-816c-4410-b3a3-9b9a4b69df52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d2f70-816c-4410-b3a3-9b9a4b69df52.jpg?1",
             "name": "Efficient Construction",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "fe1b2313-a9bd-59b1-9cbb-29c836a54bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e3c91a-d702-4fa2-864c-9f7067a88752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e3c91a-d702-4fa2-864c-9f7067a88752.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "b51468bb-5d46-5e06-918f-f3b083b4468c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bc5a5-4483-42e9-9c14-1ad229b28eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bc5a5-4483-42e9-9c14-1ad229b28eb7.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "efb1d4d2-4265-599a-86c0-1e738165a50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04588d2f-9e90-4f83-b85e-67e4bc222a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04588d2f-9e90-4f83-b85e-67e4bc222a62.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "7d9438f3-8c6b-55da-850f-1873713ead44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaada60d-1857-4fc2-a997-d7775565221a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaada60d-1857-4fc2-a997-d7775565221a.jpg?1",
             "name": "Faerie Artisans",
             "text": "Flying\nWhenever a nontoken creature enters the battlefield under an opponent's control, create a token that's a copy of that creature except it's an artifact in addition to its other types. Then exile all other tokens created with Faerie Artisans.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "5161052e-c70a-5eee-91be-7fb339aad791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29679998-2fb4-4fb4-9048-27b6bf6b79e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29679998-2fb4-4fb4-9048-27b6bf6b79e8.jpg?1",
             "name": "Fall from Favor",
             "text": "Enchant creature\nWhen Fall from Favor enters the battlefield, tap enchanted creature and you become the monarch.\nEnchanted creature doesn't untap during its controller's untap step unless that player is the monarch.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "bdf4ac41-38e1-58d2-9112-c18e55236aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3dd95-bd14-4e0f-a388-444f9cf1b0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3dd95-bd14-4e0f-a388-444f9cf1b0dc.jpg?1",
             "name": "Fierce Guardianship",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCounter target noncreature spell.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "da000bc4-3756-58a5-96a3-0cae50b19f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75600598-f988-49fc-ba86-692367c007b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75600598-f988-49fc-ba86-692367c007b4.jpg?1",
             "name": "Filigree Attendant",
             "text": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "175ed2d0-10bf-58da-8df9-7f2a180d1a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb00e3c-b67a-44c7-ae61-23ecf4d4971a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb00e3c-b67a-44c7-ae61-23ecf4d4971a.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "3779f08b-0d52-5a18-8dff-5ec15e13c170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daab8ff-443d-4292-80f3-63b621ad1c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daab8ff-443d-4292-80f3-63b621ad1c88.jpg?1",
             "name": "Ghost of Ramirez DePietro",
             "text": "Ghost of Ramirez DePietro can't be blocked by creatures with toughness 3 or greater.\nWhenever Ghost of Ramirez DePietro deals combat damage to a player, choose up to one target card in a graveyard that was discarded or put there from a library this turn. Put that card into its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3414,7 +3414,7 @@
         },
         {
             "id": "c4290205-6066-589d-92b5-d928ab185df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc143ba3-2a58-4980-9fa0-a05a9e9ed082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc143ba3-2a58-4980-9fa0-a05a9e9ed082.jpg?1",
             "name": "Ghostly Flicker",
             "text": "Exile two target artifacts, creatures, and/or lands you control, then return those cards to the battlefield under your control.",
             "colours": [
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "67a55223-8aea-5210-8877-fc79e151ee45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374cddb8-b360-4c7b-8911-a6a1b401ffdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374cddb8-b360-4c7b-8911-a6a1b401ffdd.jpg?1",
             "name": "Goliath Sphinx",
             "text": "Flying",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "de1c4167-8469-523d-a9c1-e8d1eb39fb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c190eceb-f6d8-408f-bbc4-df0fefb778ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c190eceb-f6d8-408f-bbc4-df0fefb778ad.jpg?1",
             "name": "Inga Rune-Eyes",
             "text": "When Inga Rune-Eyes enters the battlefield, scry 3.\nWhen Inga Rune-Eyes dies, draw three cards if three or more creatures died this turn.",
             "colours": [
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "406cd151-af6f-5069-a15b-a296cf6b0d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5ad263-6b0d-4eaa-bc5a-16f5077206e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5ad263-6b0d-4eaa-bc5a-16f5077206e1.jpg?1",
             "name": "Kaho, Minamo Historian",
             "text": "When Kaho, Minamo Historian enters the battlefield, search your library for up to three instant cards, exile them, then shuffle.\n{X}, {T}: You may cast a spell with mana value X from among cards exiled with Kaho without paying its mana cost.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "51e27b99-0015-5e4d-aeb1-f91c3e8c1231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7083c77c-166f-4c6f-a2ca-dd1b877ff5f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7083c77c-166f-4c6f-a2ca-dd1b877ff5f7.jpg?1",
             "name": "Looter il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Looter il-Kor deals damage to an opponent, draw a card, then discard a card.",
             "colours": [
@@ -3589,7 +3589,7 @@
         },
         {
             "id": "d3f63c49-956e-5741-b37c-fc35405eaf99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7a64cf-3c7a-4dfc-ae44-8413def80ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7a64cf-3c7a-4dfc-ae44-8413def80ce2.jpg?1",
             "name": "Lorthos, the Tidemaker",
             "text": "Whenever Lorthos, the Tidemaker attacks, you may pay {8}. If you do, tap up to eight target permanents. Those permanents don't untap during their controllers' next untap steps.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "ecc7d9a7-2d27-5c88-8de2-407447fbc0f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d827bb89-4e28-4b77-94c0-10f79ec9099a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d827bb89-4e28-4b77-94c0-10f79ec9099a.jpg?1",
             "name": "Loyal Drake",
             "text": "Flying\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, draw a card.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "43cf0df8-64aa-5720-8912-2f4ead5733bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacc197-7c22-444d-8e6e-950dca63eb2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacc197-7c22-444d-8e6e-950dca63eb2c.jpg?1",
             "name": "Minds Aglow",
             "text": "Join forces \u2014 Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "75debaa1-18c1-57ed-8e30-52ea81817c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7dc810-c4cb-4dca-ae06-d79daf8e1477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7dc810-c4cb-4dca-ae06-d79daf8e1477.jpg?1",
             "name": "Murder of Crows",
             "text": "Flying\nWhenever another creature dies, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "370e0ad2-958d-5480-bf5e-216ff5168038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f19337d-0824-442d-bb67-748a9980e816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f19337d-0824-442d-bb67-748a9980e816.jpg?1",
             "name": "Murmuring Mystic",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 blue Bird Illusion creature token with flying.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "224f78a2-a709-5761-84d3-398e365667d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5d409-c0b6-4123-802d-eb32f223bd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5d409-c0b6-4123-802d-eb32f223bd1a.jpg?1",
             "name": "Mystic Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Return target creature to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "1750b69e-d38d-5db1-96ef-226ea08b3609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4aef8-64fc-4e9d-adac-ef4c85d40b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4aef8-64fc-4e9d-adac-ef4c85d40b4a.jpg?1",
             "name": "Padeem, Consul of Innovation",
             "text": "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the highest mana value or tied for the highest mana value, draw a card.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "8c1d5421-00b2-530f-bed6-15c3647b1ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2887fc25-22cd-48c9-ad2b-6539c8139e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2887fc25-22cd-48c9-ad2b-6539c8139e27.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -3870,7 +3870,7 @@
         },
         {
             "id": "1fa3d9ed-938e-582a-9355-90c50c27e976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fcefb3c-2581-4dfa-96c5-36a17d762526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fcefb3c-2581-4dfa-96c5-36a17d762526.jpg?1",
             "name": "Phyrexian Ingester",
             "text": "Imprint \u2014 When Phyrexian Ingester enters the battlefield, you may exile target nontoken creature.\nPhyrexian Ingester gets +X/+Y, where X is the exiled creature card's power and Y is its toughness.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "49f7cfc9-7c0c-5144-9e6c-9e9df9a670ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9924a6-2470-44b6-9f54-766996aef57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9924a6-2470-44b6-9f54-766996aef57f.jpg?1",
             "name": "Portal Mage",
             "text": "Flash\nWhen Portal Mage enters the battlefield during the declare attackers step, you may reselect which player or permanent target attacking creature is attacking. (It can't attack its controller or their permanents.)",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "5b39f496-6489-5239-958b-482a8184fce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0850a187-ba95-46f2-aa81-397b45460bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0850a187-ba95-46f2-aa81-397b45460bbc.jpg?1",
             "name": "Reality Shift",
             "text": "Exile target creature. Its controller manifests the top card of their library. (That player puts the top card of their library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "e36825ed-a4fd-5b85-a46e-c5445b447d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a397298-9d7d-495f-983a-1683291a7b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a397298-9d7d-495f-983a-1683291a7b9f.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "ee419f05-8dd8-5c7d-b8e1-853703076481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c7819-7e53-4793-bc4f-3dd489a25d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c7819-7e53-4793-bc4f-3dd489a25d63.jpg?1",
             "name": "Resculpt",
             "text": "Exile target artifact or creature. Its controller creates a 4/4 blue and red Elemental creature token.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "0e95305c-0400-5c15-83a3-d8dfe2b9cf7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fff0a3-1315-42f7-9d36-4f5eaad0c62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fff0a3-1315-42f7-9d36-4f5eaad0c62e.jpg?1",
             "name": "Reverse Engineer",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "392028ef-d381-5c50-ae00-0b191c6dbf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6378465-0f28-46b6-8464-ff57b77d50e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6378465-0f28-46b6-8464-ff57b77d50e8.jpg?1",
             "name": "Rise from the Tides",
             "text": "Create a tapped 2/2 black Zombie creature token for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "3361904e-a25c-5809-b0b0-e325fa29a83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b5c09-5075-408e-84c5-1095354ac53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b5c09-5075-408e-84c5-1095354ac53e.jpg?1",
             "name": "Sai, Master Thopterist",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{U}, Sacrifice two artifacts: Draw a card.",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "371fa758-fda3-5605-874c-7eefdb79f19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce24e4-78cf-4550-866e-108706e82b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce24e4-78cf-4550-866e-108706e82b99.jpg?1",
             "name": "Shipwreck Dowser",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Shipwreck Dowser enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "537ddaad-df59-5f53-8e18-c29b1e7faa26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749c591-2fbe-41d8-ac5b-56ebce82d33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749c591-2fbe-41d8-ac5b-56ebce82d33e.jpg?1",
             "name": "Spellseeker",
             "text": "When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with mana value 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "94fa8d95-a99a-5f61-90b4-729bd1cd9700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ce6c30-a301-4a8a-ac3a-abacaf358a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ce6c30-a301-4a8a-ac3a-abacaf358a56.jpg?1",
             "name": "Stitcher Geralf",
             "text": "{2}{U}, {T}: Each player mills three cards. Exile up to two creature cards put into graveyards this way. Create an X/X blue Zombie creature token, where X is the total power of the cards exiled this way.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "c6518620-2274-51f3-9f76-732c959d4d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525d742f-dadb-4a59-b70d-3b328bf99cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525d742f-dadb-4a59-b70d-3b328bf99cca.jpg?1",
             "name": "Stormsurge Kraken",
             "text": "Hexproof\nLieutenant \u2014 As long as you control your commander, Stormsurge Kraken gets +2/+2 and has \"Whenever Stormsurge Kraken becomes blocked, you may draw two cards.\"",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "b2cf7276-650c-5d9c-bdc0-a687fd7d029f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c71971-fa26-4ae6-aa6f-a401e5285b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c71971-fa26-4ae6-aa6f-a401e5285b76.jpg?1",
             "name": "Sun Quan, Lord of Wu",
             "text": "Creatures you control have horsemanship. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [
@@ -4331,7 +4331,7 @@
         },
         {
             "id": "9ad49447-3310-5f9a-839f-67d06a22600b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc649f1b-b713-4c1f-9e05-4984b8cbfc63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc649f1b-b713-4c1f-9e05-4984b8cbfc63.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "5a7be855-d2ea-53e1-ba44-0644e8fcd272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368c6e60-804c-447c-bc2b-ac9dc4cab5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368c6e60-804c-447c-bc2b-ac9dc4cab5e7.jpg?1",
             "name": "Teferi, Temporal Archmage",
             "text": "+1: Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\n\u22121: Untap up to four target permanents.\n\u221210: You get an emblem with \"You may activate loyalty abilities of planeswalkers you control on any player's turn any time you could cast an instant.\"\nTeferi, Temporal Archmage can be your commander.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "40af42b7-269e-51f8-93f0-0afcbe68d8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f03792-5d06-45f4-ab19-5a415abbc382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f03792-5d06-45f4-ab19-5a415abbc382.jpg?1",
             "name": "Tetsuko Umezawa, Fugitive",
             "text": "Creatures you control with power or toughness 1 or less can't be blocked.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "90d17434-6d47-5fe5-a5e9-d19311ec4321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbdae80-1481-4a8c-b3c3-f4224204d29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbdae80-1481-4a8c-b3c3-f4224204d29d.jpg?1",
             "name": "Thryx, the Sudden Storm",
             "text": "Flash\nFlying\nSpells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.",
             "colours": [
@@ -4483,7 +4483,7 @@
         },
         {
             "id": "aa56ae88-6ca8-58d9-9693-c44de1dbf6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92872fea-2fb4-4154-815e-cad9d966e60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92872fea-2fb4-4154-815e-cad9d966e60f.jpg?1",
             "name": "Torrential Gearhulk",
             "text": "Flash\nWhen Torrential Gearhulk enters the battlefield, you may cast target instant card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "b22bd4e8-3cec-5855-b8ae-8214584313d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ad933-ddd9-4975-a222-21fe3305137c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ad933-ddd9-4975-a222-21fe3305137c.jpg?1",
             "name": "Tromokratis",
             "text": "Tromokratis has hexproof unless it's attacking or blocking.\nTromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "6780bf07-c1a5-57cf-8533-3a7c5d25980a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a348a-51f7-4dc5-8fe7-1c70fea5e050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a348a-51f7-4dc5-8fe7-1c70fea5e050.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "dfa2b7dc-157c-50ec-8e25-0e530c3c6a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9aef509-50f0-4848-87d5-3c169453186f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9aef509-50f0-4848-87d5-3c169453186f.jpg?1",
             "name": "Vizier of Tumbling Sands",
             "text": "{T}: Untap another target permanent.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Vizier of Tumbling Sands, untap target permanent.",
             "colours": [
@@ -4632,7 +4632,7 @@
         },
         {
             "id": "b8322339-5056-5056-a5dd-bcc785af1a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e85ad25-7496-4832-b945-e7a39582faaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e85ad25-7496-4832-b945-e7a39582faaa.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "01f35f71-d5fa-5275-bc33-b7925b764106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1e538-9e68-4481-9bd6-3d37e20645f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1e538-9e68-4481-9bd6-3d37e20645f2.jpg?1",
             "name": "Windcaller Aven",
             "text": "Flying\nCycling {U} ({U}, Discard this card: Draw a card.)\nWhen you cycle Windcaller Aven, target creature gains flying until end of turn.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "c93a4eaf-c2c8-5535-9591-53b099390bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c2c48-146d-49f6-bc10-2eed733184b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c2c48-146d-49f6-bc10-2eed733184b4.jpg?1",
             "name": "Windrider Wizard",
             "text": "Flying\nWhenever you cast an instant, sorcery, or Wizard spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "ccc85884-8138-543e-a5dd-c7a1cf890aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f028cd-1cb4-4a5b-b989-4acd8777ac5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f028cd-1cb4-4a5b-b989-4acd8777ac5c.jpg?1",
             "name": "Witching Well",
             "text": "When Witching Well enters the battlefield, scry 2.\n{3}{U}, Sacrifice Witching Well: Draw two cards.",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "228fa2ce-9b21-5bbf-8e3b-f5b2e5ea6971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880fc139-4200-483f-bdb1-dc9ef32d63a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880fc139-4200-483f-bdb1-dc9ef32d63a5.jpg?1",
             "name": "Zahid, Djinn of the Lamp",
             "text": "You may pay {3}{U} and tap an untapped artifact you control rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "3d095e14-8264-5cde-8028-2d5e8d15a451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d1e901-cef9-45ca-a946-a4a9cba6702d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d1e901-cef9-45ca-a946-a4a9cba6702d.jpg?1",
             "name": "Archfiend of Despair",
             "text": "Flying\nYour opponents can't gain life.\nAt the beginning of each end step, each opponent loses life equal to the life that player lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "b95298c9-88dc-56c9-b126-8ab355da5998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa32ff-3ced-405c-8508-7dd35cd20f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa32ff-3ced-405c-8508-7dd35cd20f02.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "When Bastion of Remembrance enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "0e3473db-c646-5dad-b725-8a6bd7d03552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56d1535-d9de-459f-bc31-0923f621e0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56d1535-d9de-459f-bc31-0923f621e0e9.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "ee4d4ca2-9601-5322-8808-ecb172e6b4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9a1276-5ad5-44ee-83e5-2d1ab728946e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9a1276-5ad5-44ee-83e5-2d1ab728946e.jpg?1",
             "name": "Cabal Patriarch",
             "text": "{2}{B}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.\n{2}{B}, Exile a creature card from your graveyard: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "32acf87f-13f5-5ece-abb0-fba9c80b59e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06ab823-9591-460d-a896-3073d9843df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06ab823-9591-460d-a896-3073d9843df0.jpg?1",
             "name": "Cadaver Imp",
             "text": "Flying\nWhen Cadaver Imp enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "c467c4b3-0a20-5337-9ede-c2c7b37a0a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e551c-0b47-4ccb-8893-f192de92908e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e551c-0b47-4ccb-8893-f192de92908e.jpg?1",
             "name": "Carrier Thrall",
             "text": "When Carrier Thrall dies, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "2dbd4449-1f76-59b2-8dd9-1ff8461e2807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d485efd-667f-4561-b747-7605bf1ebc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d485efd-667f-4561-b747-7605bf1ebc09.jpg?1",
             "name": "Carrion Grub",
             "text": "Carrion Grub gets +X/+0, where X is the greatest power among creature cards in your graveyard.\nWhen Carrion Grub enters the battlefield, mill four cards. (Put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "465cf455-f620-5e61-955d-d7a7bef25416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186c30e6-2b84-415d-83e4-ecddaeb11ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186c30e6-2b84-415d-83e4-ecddaeb11ca1.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "e21e20c3-6abc-5e64-b6b4-a7a8e614c963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0dfb-663a-4713-902e-96dbecc404b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0dfb-663a-4713-902e-96dbecc404b7.jpg?1",
             "name": "Corpse Augur",
             "text": "When Corpse Augur dies, you draw X cards and you lose X life, where X is the number of creature cards in target player's graveyard.",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "87205ff5-3455-56db-ae1e-3b12fc3fe58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d3f1b5-b41c-4181-8c14-d0f2f4ba0710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d3f1b5-b41c-4181-8c14-d0f2f4ba0710.jpg?1",
             "name": "Curtains' Call",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "b291eecb-9fe2-5df1-bf73-78a21643d6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13f735-54fa-42b6-aea4-ced33811d7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13f735-54fa-42b6-aea4-ced33811d7d4.jpg?1",
             "name": "Deadly Rollick",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nExile target creature.",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "d160dcdd-208c-57eb-96a8-5b77731cd07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6702a-a7d9-4d86-8ba2-364417a31dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6702a-a7d9-4d86-8ba2-364417a31dbb.jpg?1",
             "name": "Decree of Pain",
             "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "4d2cfc03-e301-500f-b33d-e014447aca3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7f2ce1-b442-4051-b1fe-90efde9bc181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7f2ce1-b442-4051-b1fe-90efde9bc181.jpg?1",
             "name": "Demon's Disciple",
             "text": "When Demon's Disciple enters the battlefield, each player sacrifices a creature or planeswalker.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "ac58f1a8-27ae-5dd4-9ed6-9aaf145dc8ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24b4cb6-cebb-428b-8654-74347a6a8d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24b4cb6-cebb-428b-8654-74347a6a8d63.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "7257317a-e719-5ca3-8573-5f7c0825040e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07114d8-40b3-4102-8d70-e3ed94a7f515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07114d8-40b3-4102-8d70-e3ed94a7f515.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "Flying, trample\nWhen Demonlord Belzenlok enters the battlefield, exile cards from the top of your library until you exile a nonland card, then put that card into your hand. If the card's mana value is 4 or greater, repeat this process. Demonlord Belzenlok deals 1 damage to you for each card put into your hand this way.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "cd9a3378-5ad3-5546-9b66-a7c6a536c245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ef119f-e777-42e7-be43-ea1f31d7ce59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ef119f-e777-42e7-be43-ea1f31d7ce59.jpg?1",
             "name": "Dread Drone",
             "text": "When Dread Drone enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "b394d224-87f5-537c-92b4-36e09540f25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a87901-98bb-41dd-b566-bcb510c20022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a87901-98bb-41dd-b566-bcb510c20022.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "2e4aa19d-218a-5411-9b97-363a539312a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512357b-0d08-4996-9301-5853eae1ea64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512357b-0d08-4996-9301-5853eae1ea64.jpg?1",
             "name": "Drown in Sorrow",
             "text": "All creatures get -2/-2 until end of turn. Scry 1.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "ef24b787-536c-55d7-9980-074e78c4e06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123490fb-5908-45f2-b376-7959ccdf9c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123490fb-5908-45f2-b376-7959ccdf9c3e.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you cast a creature spell, create X 1/1 black Thrull creature tokens, where X is that spell's mana value.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "1e7d2dec-5813-5e6b-99b4-6542020f67d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5352af-e275-4186-a265-2fd3c2c47c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5352af-e275-4186-a265-2fd3c2c47c6a.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "60491339-7c40-5c6b-a535-5d4ba77dc1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1888ac60-a885-43a7-8e95-9523a0213644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1888ac60-a885-43a7-8e95-9523a0213644.jpg?1",
             "name": "Extinguish All Hope",
             "text": "Destroy all nonenchantment creatures.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "35f828d6-26af-5cbb-ab60-3e5ffba34e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f15c50-cfb2-4567-bad5-3d18a2d7d0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f15c50-cfb2-4567-bad5-3d18a2d7d0aa.jpg?1",
             "name": "Feast of Succession",
             "text": "All creatures get -4/-4 until end of turn. You become the monarch.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "744cb1c5-a938-54a4-95e8-a855167aa7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840d02c6-3d9c-47cd-9307-978d03380d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840d02c6-3d9c-47cd-9307-978d03380d0f.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "0fded734-6930-5105-92a3-f475a99896f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f24b7c-4952-4abc-aaba-22a529012468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f24b7c-4952-4abc-aaba-22a529012468.jpg?1",
             "name": "Final Parting",
             "text": "Search your library for two cards. Put one into your hand and the other into your graveyard. Then shuffle.",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "8e1a1a65-f1e9-5def-9568-00173248fa73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d7906e-8a89-4644-acb5-46fbe97ab39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d7906e-8a89-4644-acb5-46fbe97ab39f.jpg?1",
             "name": "Ghoulcaller Gisa",
             "text": "{B}, {T}, Sacrifice another creature: Create X 2/2 black Zombie creature tokens, where X is the sacrificed creature's power.",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "f54efde0-8d8d-53f0-a33c-1591a0bbd58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01852cd2-16e4-4518-b5d5-b9a378b8664d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01852cd2-16e4-4518-b5d5-b9a378b8664d.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "4af34644-f169-5671-b5d3-db309080b138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad6c2f-9c26-496d-9079-adf1fec08a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad6c2f-9c26-496d-9079-adf1fec08a59.jpg?1",
             "name": "Goremand",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample\nWhen Goremand enters the battlefield, each opponent sacrifices a creature.",
             "colours": [
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "f1e30223-11b6-5fcf-adeb-858fad5f252c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12615d0d-e38c-4e7b-918e-33e88299d1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12615d0d-e38c-4e7b-918e-33e88299d1f9.jpg?1",
             "name": "Gorex, the Tombshell",
             "text": "As an additional cost to cast this spell, you may exile any number of creature cards from your graveyard. This spell costs {2} less to cast for each card exiled this way.\nDeathtouch\nWhenever Gorex, the Tombshell attacks or dies, choose a card at random exiled with Gorex and put that card into its owner's hand.",
             "colours": [
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "a8601dea-b8a2-5685-8333-dcd1963cde0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4970b-2ba6-4c91-a301-369369cdf360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4970b-2ba6-4c91-a301-369369cdf360.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -5818,7 +5818,7 @@
         },
         {
             "id": "dad47f02-0cda-5034-97a2-a6ebde9b5c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11dea2a-fe20-4e1b-9e1e-8759e0950f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11dea2a-fe20-4e1b-9e1e-8759e0950f0a.jpg?1",
             "name": "Heartless Act",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with no counters on it.\n\u2022 Remove up to three counters from target creature.",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "ff5986b7-ba79-5f73-aaee-c4aa1ef23266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb0e8e7-266f-441e-b1cd-12b8ec3f7d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb0e8e7-266f-441e-b1cd-12b8ec3f7d71.jpg?1",
             "name": "Imp's Mischief",
             "text": "Change the target of target spell with a single target. You lose life equal to that spell's mana value.",
             "colours": [
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "84fea78d-fa0d-5a63-a0ed-74e43dedfd79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5de9b95-1c20-4d1a-be7d-4307ec2803ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5de9b95-1c20-4d1a-be7d-4307ec2803ba.jpg?1",
             "name": "Isareth the Awakener",
             "text": "Deathtouch\nWhenever Isareth the Awakener attacks, you may pay {X}. When you do, return target creature card with mana value X from your graveyard to the battlefield with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "476881ff-2cc1-5658-a336-07b971969120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af613b69-b9f6-4221-a21b-c8e4b0f010f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af613b69-b9f6-4221-a21b-c8e4b0f010f1.jpg?1",
             "name": "Kindred Dominance",
             "text": "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
             "colours": [
@@ -5956,7 +5956,7 @@
         },
         {
             "id": "ab9dd048-6204-53d0-a732-a94927b65a69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ea9ea5-acf1-4980-b7e5-083da455adb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ea9ea5-acf1-4980-b7e5-083da455adb0.jpg?1",
             "name": "Legion Vanguard",
             "text": "{1}, Sacrifice another creature: Legion Vanguard explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "95a1bc40-d3c9-51f4-bdbe-bbbeab93b359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09237f1b-eff6-45bf-bd7d-a883deda122a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09237f1b-eff6-45bf-bd7d-a883deda122a.jpg?1",
             "name": "Lotleth Giant",
             "text": "Undergrowth \u2014 When Lotleth Giant enters the battlefield, it deals 1 damage to target opponent for each creature card in your graveyard.",
             "colours": [
@@ -6026,7 +6026,7 @@
         },
         {
             "id": "3fe187b0-2cbc-52d9-8229-6adeea4e11f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1949469a-faa5-4bff-8b0f-0a1bc7ca87da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1949469a-faa5-4bff-8b0f-0a1bc7ca87da.jpg?1",
             "name": "Loyal Subordinate",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, each opponent loses 3 life.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "36e148a6-d412-5c09-9793-593cebce3a2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1f42a2-fe11-45da-9552-069803b4068a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1f42a2-fe11-45da-9552-069803b4068a.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -6101,7 +6101,7 @@
         },
         {
             "id": "c7bccae8-c561-5026-be98-e04dac1e681f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a070b7af-7c85-4129-81ca-e2ec0540085e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a070b7af-7c85-4129-81ca-e2ec0540085e.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "533f897b-c929-5d8c-89d3-1ff019d41eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd606c3-795a-49d8-8b75-6a3aacb4a72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd606c3-795a-49d8-8b75-6a3aacb4a72f.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "554c3ed5-c6e8-5c08-81d3-376b71fbeca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4e4509-ffd8-4fd0-a678-19c9975d571b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4e4509-ffd8-4fd0-a678-19c9975d571b.jpg?1",
             "name": "Ob Nixilis of the Black Oath",
             "text": "+2: Each opponent loses 1 life. You gain life equal to the life lost this way.\n\u22122: Create a 5/5 black Demon creature token with flying. You lose 2 life.\n\u22128: You get an emblem with \"{1}{B}, Sacrifice a creature: You gain X life and draw X cards, where X is the sacrificed creature's power.\"\nOb Nixilis of the Black Oath can be your commander.",
             "colours": [
@@ -6211,7 +6211,7 @@
         },
         {
             "id": "4853b865-ff09-50f1-b73a-1560c9e04573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2373e57c-01bb-4d49-94ad-b9ff75335cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2373e57c-01bb-4d49-94ad-b9ff75335cb7.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "498ac274-b2a2-5c4d-a459-837bbc5eb9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08648c0a-e075-45ac-ad8c-80c425d3487e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08648c0a-e075-45ac-ad8c-80c425d3487e.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "edb15404-87c2-527c-ae22-af3df243d5f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14db0f35-905b-45c9-a0cc-1c47720380eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14db0f35-905b-45c9-a0cc-1c47720380eb.jpg?1",
             "name": "Priest of the Blood Rite",
             "text": "When Priest of the Blood Rite enters the battlefield, create a 5/5 black Demon creature token with flying.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "ca653ed6-97c7-5b1f-b7d1-1dd33969955c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32399c54-632f-434e-bd5a-81b6a7c4fe9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32399c54-632f-434e-bd5a-81b6a7c4fe9b.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "Flying, haste\nWhenever Rankle, Master of Pranks deals combat damage to a player, choose any number \u2014\n\u2022 Each player discards a card.\n\u2022 Each player loses 1 life and draws a card.\n\u2022 Each player sacrifices a creature.",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "949ee1b8-1964-5150-900b-2c2c5071d87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb956d-0df6-4910-9320-55f2c5674d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb956d-0df6-4910-9320-55f2c5674d98.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "Flying, trample\nPay 2 life, Sacrifice another creature: Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "df475c83-e44d-56b9-97f2-b073e6d3ff96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c66076-fb85-4a5e-8cd0-d103834b3cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c66076-fb85-4a5e-8cd0-d103834b3cd1.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "7cfe7cd6-6878-56ba-a024-d5910aa4f7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00566375-e976-4e96-b751-cf0430452c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00566375-e976-4e96-b751-cf0430452c9c.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "b4a825ed-c14e-5b61-ade2-7ef212f456d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d67da-4fc9-4d4a-95e4-0303c5404705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d67da-4fc9-4d4a-95e4-0303c5404705.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -6498,7 +6498,7 @@
         },
         {
             "id": "faa5ed8b-fa41-5d2d-a401-69f3bd6bedc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78509763-4bb8-4030-b205-76917de75c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78509763-4bb8-4030-b205-76917de75c57.jpg?1",
             "name": "Serrated Scorpion",
             "text": "When Serrated Scorpion dies, it deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -6532,7 +6532,7 @@
         },
         {
             "id": "a25fe32d-a6d5-5d2e-8294-b94e70a364da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69848ec1-dba7-419f-a5f9-f934bebeeaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69848ec1-dba7-419f-a5f9-f934bebeeaa6.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from the battlefield, you may return that card to the battlefield at the beginning of the next end step if Shirei, Shizo's Caretaker is still on the battlefield.",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "d9962425-24e7-5cc5-aeef-16c6c88f20c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532301e-9005-4770-9e04-868f69f6becf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532301e-9005-4770-9e04-868f69f6becf.jpg?1",
             "name": "Sower of Discord",
             "text": "Flying\nAs Sower of Discord enters the battlefield, choose two players.\nWhenever damage is dealt to one of the chosen players, the other chosen player also loses that much life.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "cacf6f06-dca7-5a6f-b835-bccdd06e37a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b349b4b-f08d-45e8-81f6-3467a02e6d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b349b4b-f08d-45e8-81f6-3467a02e6d23.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "ba3cca4a-5a59-5a0f-a118-95363f54cc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bb6abe-3844-4399-b38a-1d6dd81a6c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bb6abe-3844-4399-b38a-1d6dd81a6c78.jpg?1",
             "name": "Taborax, Hope's Demise",
             "text": "Flying\nTaborax, Hope's Demise has lifelink as long as it has five or more +1/+1 counters on it.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on Taborax. If that creature was a Cleric, you may draw a card. If you do, you lose 1 life.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "f798000a-d416-539c-b614-50bc37eda013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b266e2-1cad-40df-bc0e-3e1464b299b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b266e2-1cad-40df-bc0e-3e1464b299b3.jpg?1",
             "name": "Thorn of the Black Rose",
             "text": "Deathtouch\nWhen Thorn of the Black Rose enters the battlefield, you become the monarch.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "b501d7a4-7b75-5aa1-9d29-36bb7cfc30c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6fdd97-a896-4110-b48f-a6c49394f854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6fdd97-a896-4110-b48f-a6c49394f854.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "064c9a03-a224-50bd-80f0-654f34bbb88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588332da-8ec5-49d1-a365-455beb7913a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588332da-8ec5-49d1-a365-455beb7913a2.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "110cef60-4539-5690-9a5a-b38a1008715b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74353dcc-7653-4c5a-b621-ae587c448657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74353dcc-7653-4c5a-b621-ae587c448657.jpg?1",
             "name": "Twilight Prophet",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, if you have the city's blessing, reveal the top card of your library and put it into your hand. Each opponent loses X life and you gain X life, where X is that card's mana value.",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "64488805-c07c-517a-b7ce-f74bf7da06b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcaee2c-fad7-4ee2-8fe7-20b2c1eee5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcaee2c-fad7-4ee2-8fe7-20b2c1eee5c5.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "f1f58e9d-1223-57c7-87d7-b69123162ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e4993e-154c-4ac4-8927-6352b8816f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e4993e-154c-4ac4-8927-6352b8816f58.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "775a5140-c383-5b3f-acf6-1e667a69fd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120b644-477d-4297-b94f-56120a384bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120b644-477d-4297-b94f-56120a384bc2.jpg?1",
             "name": "Vindictive Lich",
             "text": "When Vindictive Lich dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent sacrifices a creature.\n\u2022 Target opponent discards two cards.\n\u2022 Target opponent loses 5 life.",
             "colours": [
@@ -6917,7 +6917,7 @@
         },
         {
             "id": "dc54f37f-8a32-5215-8fde-5325c69ebd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1780be8-26f6-4f33-9bc6-ecafc3751c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1780be8-26f6-4f33-9bc6-ecafc3751c8e.jpg?1",
             "name": "Wake the Dead",
             "text": "Cast this spell only during combat on an opponent's turn.\nReturn X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step.",
             "colours": [
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "a3039ef7-9f76-515a-a336-5f7f59fc03b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ce13b0-372d-4664-a888-85f4c72e030d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ce13b0-372d-4664-a888-85f4c72e030d.jpg?1",
             "name": "Whisper, Blood Liturgist",
             "text": "{T}, Sacrifice two creatures: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -6988,7 +6988,7 @@
         },
         {
             "id": "749d5ecf-6830-5384-94da-bb58890cd7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c15046-dd24-41aa-96f3-fb008a6988dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c15046-dd24-41aa-96f3-fb008a6988dd.jpg?1",
             "name": "Witch's Cauldron",
             "text": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -7020,7 +7020,7 @@
         },
         {
             "id": "71003b91-0d37-5529-86ec-52f63152b515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20203edb-1363-4ed3-8c5b-b1d96ff2b7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20203edb-1363-4ed3-8c5b-b1d96ff2b7c0.jpg?1",
             "name": "Wretched Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target creature gets -2/-2 until end of turn.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "009e66bb-9437-5a19-bc28-a2d3b474006d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c19c3-0ea6-4b05-9cde-e9863b1fbe04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c19c3-0ea6-4b05-9cde-e9863b1fbe04.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "c3188424-75c2-52c2-9f05-8a911a8fa7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8febc0fe-c52d-4b6a-9d18-e1e4a43b6dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8febc0fe-c52d-4b6a-9d18-e1e4a43b6dc3.jpg?1",
             "name": "Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "31ceb167-81b1-560d-bba5-db556b8b593f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d9e279-61c1-4567-9f54-50a7138fb36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d9e279-61c1-4567-9f54-50a7138fb36d.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -7160,7 +7160,7 @@
         },
         {
             "id": "00315f0b-da57-5d01-a114-bb439a7bf95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad107ae0-2540-46f8-9970-72983b87ba04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad107ae0-2540-46f8-9970-72983b87ba04.jpg?1",
             "name": "Anax, Hardened in the Forge",
             "text": "Anax's power is equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)\nWhenever Anax or another nontoken creature you control dies, create a 1/1 red Satyr creature token with \"This creature can't block.\" If the creature had power 4 or greater, create two of those tokens instead.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "6f0c4ced-bf75-54ec-aa54-ef06f7062e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c687123-6c34-4aef-8350-70a72b5fb58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c687123-6c34-4aef-8350-70a72b5fb58f.jpg?1",
             "name": "Ashling the Pilgrim",
             "text": "{1}{R}: Put a +1/+1 counter on Ashling the Pilgrim. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling the Pilgrim, and it deals that much damage to each creature and each player.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "12db4189-7580-5c4f-9ef6-3fd2ff28cce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dd6cc-53e8-4c67-8838-180b19f02088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dd6cc-53e8-4c67-8838-180b19f02088.jpg?1",
             "name": "Avatar of Slaughter",
             "text": "All creatures have double strike and attack each combat if able.",
             "colours": [
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "b264084b-418c-509f-8501-4b9230e48620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37def363-c431-43b4-8c5f-933941507681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37def363-c431-43b4-8c5f-933941507681.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "bdf97011-a290-589e-92d1-7a4b95138b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075947cd-2e06-486a-83a7-97321445a679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075947cd-2e06-486a-83a7-97321445a679.jpg?1",
             "name": "Blood Aspirant",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Blood Aspirant.\n{1}{R}, {T}, Sacrifice a creature or enchantment: Blood Aspirant deals 1 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "99a388eb-27c0-57b5-b24a-ff77f7004aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d640bc10-51ce-48e9-bceb-c3e69d7eae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d640bc10-51ce-48e9-bceb-c3e69d7eae31.jpg?1",
             "name": "Captain Ripley Vance",
             "text": "Whenever you cast your third spell each turn, put a +1/+1 counter on Captain Ripley Vance, then it deals damage equal to its power to any target.",
             "colours": [
@@ -7381,7 +7381,7 @@
         },
         {
             "id": "7ac1e47b-ced8-5792-8abf-bd9e5fa7c32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203dba7d-5e89-4a5a-998a-c26bf17c92f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203dba7d-5e89-4a5a-998a-c26bf17c92f9.jpg?1",
             "name": "Champion of the Flame",
             "text": "Trample\nChampion of the Flame gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "a2f675bf-5a41-566c-b3e0-b68749b9a509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf54657-5943-4a45-a296-dc91c41109d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf54657-5943-4a45-a296-dc91c41109d4.jpg?1",
             "name": "Crimson Fleet Commodore",
             "text": "Trample\nWhen Crimson Fleet Commodore enters the battlefield, you become the monarch.",
             "colours": [
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "a0002ef7-6eb4-5abc-a6b9-73a329ef591f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd56c7dd-8388-400c-a8fb-bc6a69655c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd56c7dd-8388-400c-a8fb-bc6a69655c56.jpg?1",
             "name": "Cyclops Electromancer",
             "text": "When Cyclops Electromancer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "08e0022f-b5eb-5060-87fa-e7c49c80cfca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb9d4a0-66bd-454d-b676-80192a96c723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb9d4a0-66bd-454d-b676-80192a96c723.jpg?1",
             "name": "Daretti, Scrap Savant",
             "text": "+2: Discard up to two cards, then draw that many cards.\n\u22122: Sacrifice an artifact. If you do, return target artifact card from your graveyard to the battlefield.\n\u221210: You get an emblem with \"Whenever an artifact is put into your graveyard from the battlefield, return that card to the battlefield at the beginning of the next end step.\"\nDaretti, Scrap Savant can be your commander.",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "6ecd7308-462f-5856-9f92-38b0ecee9034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b36435-55b3-4615-8812-af41d4fc64d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b36435-55b3-4615-8812-af41d4fc64d9.jpg?1",
             "name": "Deflecting Swat",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nYou may choose new targets for target spell or ability.",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "f147a476-32d2-50eb-a57d-4c689caf3a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50359328-9378-448d-9817-805503186a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50359328-9378-448d-9817-805503186a55.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -7594,7 +7594,7 @@
         },
         {
             "id": "901098bd-d213-5bda-903e-244f73b619f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd7456-71dd-463f-98a2-2d6a9cfb7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd7456-71dd-463f-98a2-2d6a9cfb7395.jpg?1",
             "name": "Divergent Transformations",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nExile two target creatures. For each of those creatures, its controller reveals cards from the top of their library until they reveal a creature card, puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -7628,7 +7628,7 @@
         },
         {
             "id": "b1b07da4-39f0-53d3-92f5-f3169ffafef8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f4777d-ea0e-408c-961e-eef7b3ffe51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f4777d-ea0e-408c-961e-eef7b3ffe51d.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -7660,7 +7660,7 @@
         },
         {
             "id": "42509787-6ebb-54b9-bfaa-a806bcac9e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe78a66-2e72-4bd8-b8a4-db77a63f36b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe78a66-2e72-4bd8-b8a4-db77a63f36b3.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "12c250ab-1cc0-5edd-a953-640f93e0196b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47f7ea0-3cda-4e62-bd10-32854ed2e260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47f7ea0-3cda-4e62-bd10-32854ed2e260.jpg?1",
             "name": "Dwarven Hammer",
             "text": "When Dwarven Hammer enters the battlefield, you may pay {2}. If you do, create a 2/1 red Dwarf Berserker creature token, then attach Dwarven Hammer to it.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "aa7685d4-86c0-575d-99a8-383dc3314d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf84ec7-a202-41fe-baa7-0b921bc67d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf84ec7-a202-41fe-baa7-0b921bc67d1b.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "7d2539be-243e-5cf4-a3c2-1fba0d1daad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6fab0-7872-445d-a514-774ecccd2355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6fab0-7872-445d-a514-774ecccd2355.jpg?1",
             "name": "Fiendlash",
             "text": "Equipped creature gets +2/+0 and has reach.\nWhenever equipped creature is dealt damage, it deals damage equal to its power to target player or planeswalker.\nEquip {2}{R}",
             "colours": [
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "91ed52b5-7b65-542d-ad1a-d3c7746402c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed7ef7f-bb40-4e1b-8635-e2226a05ac38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed7ef7f-bb40-4e1b-8635-e2226a05ac38.jpg?1",
             "name": "Fiery Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Fiery Confluence deals 1 damage to each creature.\n\u2022 Fiery Confluence deals 2 damage to each opponent.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "f00018bc-b7ab-5d7c-886c-88fb9b0a6cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b34af88-bc4e-4ca8-8662-7dc4050c62c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b34af88-bc4e-4ca8-8662-7dc4050c62c5.jpg?1",
             "name": "Fists of Flame",
             "text": "Draw a card. Until end of turn, target creature gains trample and gets +1/+0 for each card you've drawn this turn.",
             "colours": [
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "aa1a1659-27eb-5405-bd6a-87c6306519ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39282507-8921-43e3-a836-f73ba6da5623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39282507-8921-43e3-a836-f73ba6da5623.jpg?1",
             "name": "Frontier Warmonger",
             "text": "Whenever one or more creatures attack one of your opponents or a planeswalker they control, those creatures gain menace until end of turn.",
             "colours": [
@@ -7901,7 +7901,7 @@
         },
         {
             "id": "e595d9bf-236c-5687-a791-a4e391be0728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5da1ab-d720-4140-8121-89de760d020c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5da1ab-d720-4140-8121-89de760d020c.jpg?1",
             "name": "Furious Rise",
             "text": "At the beginning of your end step, if you control a creature with power 4 or greater, exile the top card of your library. You may play that card until you exile another card with Furious Rise.",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "196e2a38-0a97-57f4-b2d2-7fae9843abb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079d5536-1b2e-4d5b-bae9-9fd14562087a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079d5536-1b2e-4d5b-bae9-9fd14562087a.jpg?1",
             "name": "Gargadon",
             "text": "Trample\nSuspend 4\u2014{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "818c0bc2-d82b-567b-aed7-18ae89aa3728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d566cf-cb32-461d-8afe-b0f3f4c24160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d566cf-cb32-461d-8afe-b0f3f4c24160.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card, put it onto the battlefield, then shuffle.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -8006,7 +8006,7 @@
         },
         {
             "id": "c9bae6df-c03e-509d-afc9-0c82fe7876d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e4a51-e7ab-4107-b458-771e6d31d110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e4a51-e7ab-4107-b458-771e6d31d110.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "Whenever a creature you control deals combat damage to a player, choose one \u2014\n\u2022 Goad target creature that player controls.\n\u2022 Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "162b809f-ebec-579f-a56c-6c60df2a810b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4276d10-d163-4068-a6db-5bb0a1ac88e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4276d10-d163-4068-a6db-5bb0a1ac88e3.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "23882eae-26f6-5bb8-a1ae-7c2157fcff0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7790d21-4751-4f1b-a7f4-2bbcf842b0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7790d21-4751-4f1b-a7f4-2bbcf842b0b6.jpg?1",
             "name": "Havoc Jester",
             "text": "Whenever you sacrifice a permanent, Havoc Jester deals 1 damage to any target.",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "d67e79ed-8dc8-5242-b107-d3e4fd193532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ff07c-9653-4197-ad3d-638e712e8465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ff07c-9653-4197-ad3d-638e712e8465.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "{T}: Heartless Hidetsugu deals damage to each player equal to half that player's life total, rounded down.",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "fc201530-28b1-52a7-90ca-9176ec70b5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836c646-83ff-4bf8-96dd-4cbdd6c7e861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836c646-83ff-4bf8-96dd-4cbdd6c7e861.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -8190,7 +8190,7 @@
         },
         {
             "id": "ecc61756-9f8e-5484-b3be-d561e0d0305f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42363046-28d4-4540-a0d0-3635459ba769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42363046-28d4-4540-a0d0-3635459ba769.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle.\nWhen Hoarding Dragon dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -8224,7 +8224,7 @@
         },
         {
             "id": "4c4b4433-f669-59ad-8ab2-f7c1efb3593f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea2e32d-d711-40ae-87d5-c16893bfc8ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea2e32d-d711-40ae-87d5-c16893bfc8ca.jpg?1",
             "name": "Impulsive Pilferer",
             "text": "When Impulsive Pilferer dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEncore {3}{R} ({3}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -8259,7 +8259,7 @@
         },
         {
             "id": "74270beb-ebb9-58f2-8bf4-3fee9b7a1d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee80c14-5857-4752-b958-a51cf6706c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee80c14-5857-4752-b958-a51cf6706c96.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "4536616a-e272-50d7-abaa-1621e967f2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a0a8c-1953-46e6-9da5-b4c20909ce1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a0a8c-1953-46e6-9da5-b4c20909ce1c.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -8330,7 +8330,7 @@
         },
         {
             "id": "618ec973-5e89-5b2b-bde0-9d0786180ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7c54ed-594d-40d7-a64a-a57db6d5ba16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7c54ed-594d-40d7-a64a-a57db6d5ba16.jpg?1",
             "name": "Kazuul, Tyrant of the Cliffs",
             "text": "Whenever a creature an opponent controls attacks, if you're the defending player, create a 3/3 red Ogre creature token unless that creature's controller pays {3}.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "fab36c87-62c2-56a5-9e8c-2fe8b3416ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27141cae-3ca1-4a4f-933f-9608bbcf9bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27141cae-3ca1-4a4f-933f-9608bbcf9bd9.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "0865e53b-b7c9-517b-a5e5-7fc78b752ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457dc72b-e97a-4308-855f-a1aa528423e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457dc72b-e97a-4308-855f-a1aa528423e0.jpg?1",
             "name": "Living Lightning",
             "text": "When Living Lightning dies, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "6dd1af5d-faf4-5dda-8692-9596ceaa8642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a692fb-7ef7-4fae-b258-8719711cf38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a692fb-7ef7-4fae-b258-8719711cf38c.jpg?1",
             "name": "Loyal Apprentice",
             "text": "Haste\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.",
             "colours": [
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "25db473e-65d8-51f8-a88a-f8f78e1853ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952dd9-ef09-40f0-993f-eb3a1516616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952dd9-ef09-40f0-993f-eb3a1516616a.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards their hand, then draws seven cards.",
             "colours": [
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "3124c117-d66e-5849-bb04-eeeb8184120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60715b6d-b223-431a-85d8-27d7c05469b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60715b6d-b223-431a-85d8-27d7c05469b2.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "b340a216-21fe-5dd3-8e02-6484474804b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502ba85-7246-4652-9ab6-5672f7e490bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502ba85-7246-4652-9ab6-5672f7e490bb.jpg?1",
             "name": "Meteoric Mace",
             "text": "Equipped creature gets +4/+0 and has trample.\nEquip {4}\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "a436f325-8f07-50c4-a804-a52818e9b3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98695d3-a8ec-43f0-9a2a-fef4566f3a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98695d3-a8ec-43f0-9a2a-fef4566f3a2f.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "0cde0ce5-a769-59fb-ae5d-1caba21a2be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72e980-6c07-46cd-ae25-d7e92fd94277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72e980-6c07-46cd-ae25-d7e92fd94277.jpg?1",
             "name": "Nesting Dragon",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, create a 0/2 red Dragon Egg creature token with defender and \"When this creature dies, create a 2/2 red Dragon creature token with flying and \u2018{R}: This creature gets +1/+0 until end of turn.'\"",
             "colours": [
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "7a349723-04dc-5b42-818c-94361e485199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736a2c4-c89c-48db-a104-6303e7e2eee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736a2c4-c89c-48db-a104-6303e7e2eee8.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "d868e3f7-7ebb-544a-9a4c-1007fdb21dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd36b274-5b76-44ec-8d62-069b08debe89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd36b274-5b76-44ec-8d62-069b08debe89.jpg?1",
             "name": "Rakka Mar",
             "text": "Haste\n{R}, {T}: Create a 3/1 red Elemental creature token with haste.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "19e15b36-d9e6-52d1-a43e-71185a2bf2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4020485e-aacc-45dc-bdc0-9f70e35b88b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4020485e-aacc-45dc-bdc0-9f70e35b88b2.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "c4a8775c-7576-5373-a75d-882d45496158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8e2ef7-fabd-4ae9-8224-5acb3fd7d1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8e2ef7-fabd-4ae9-8224-5acb3fd7d1ae.jpg?1",
             "name": "Rapacious One",
             "text": "Trample\nWhenever Rapacious One deals combat damage to a player, create that many 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -8803,7 +8803,7 @@
         },
         {
             "id": "4f492fc4-d234-562b-ba76-5e1faf41a613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae28c04c-d208-4949-a3ec-7d549f5740c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae28c04c-d208-4949-a3ec-7d549f5740c3.jpg?1",
             "name": "Ravaging Blaze",
             "text": "Ravaging Blaze deals X damage to target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Ravaging Blaze also deals X damage to that creature's controller.",
             "colours": [
@@ -8835,7 +8835,7 @@
         },
         {
             "id": "1ddedc75-a0d4-5c7a-abb7-f182fbdfa965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32668329-2f62-48ed-8da3-3cb0c3692ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32668329-2f62-48ed-8da3-3cb0c3692ed9.jpg?1",
             "name": "Rorix Bladewing",
             "text": "Flying, haste",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "86f0738f-18ba-50b0-a395-b787db1ab38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c979cab-3ae6-43b1-b067-1e5abfc2e2ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c979cab-3ae6-43b1-b067-1e5abfc2e2ed.jpg?1",
             "name": "Savage Beating",
             "text": "Cast this spell only during your turn and only during combat.\nChoose one \u2014\n\u2022 Creatures you control gain double strike until end of turn.\n\u2022 Untap all creatures you control. After this phase, there is an additional combat phase.\nEntwine {1}{R}",
             "colours": [
@@ -8905,7 +8905,7 @@
         },
         {
             "id": "ae86e80c-c068-56ff-9c03-c065740ea7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37af681-e7a2-48ff-a069-26cb149e5e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37af681-e7a2-48ff-a069-26cb149e5e8e.jpg?1",
             "name": "Scourge of the Throne",
             "text": "Flying\nDethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nWhenever Scourge of the Throne attacks for the first time each turn, if it's attacking the player with the most life or tied for most life, untap all attacking creatures. After this phase, there is an additional combat phase.",
             "colours": [
@@ -8941,7 +8941,7 @@
         },
         {
             "id": "a78ed458-a672-5ac0-91ab-237d8025efbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e080dc5-361e-4e0b-b0d6-9ca060edceed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e080dc5-361e-4e0b-b0d6-9ca060edceed.jpg?1",
             "name": "Skyline Despot",
             "text": "Flying\nWhen Skyline Despot enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if you're the monarch, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "55b0ca0d-35f0-55b8-93e0-43d4d593ed9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad077c9-abc7-4296-a5d1-9441aa6c38c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad077c9-abc7-4296-a5d1-9441aa6c38c0.jpg?1",
             "name": "Slice and Dice",
             "text": "Slice and Dice deals 4 damage to each creature.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
             "colours": [
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "41007287-4046-58fb-8d54-4192c8fef4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae922301-181d-4824-802d-e3ba1714cade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae922301-181d-4824-802d-e3ba1714cade.jpg?1",
             "name": "Spikeshot Goblin",
             "text": "{R}, {T}: Spikeshot Goblin deals damage equal to its power to any target.",
             "colours": [
@@ -9042,7 +9042,7 @@
         },
         {
             "id": "6493a3a2-5e66-54ef-9295-fde6e94e1ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c0bea-c956-412a-b30b-9f75207cd493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c0bea-c956-412a-b30b-9f75207cd493.jpg?1",
             "name": "Spitebellows",
             "text": "When Spitebellows leaves the battlefield, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "79aa8e2f-064e-5ebf-9085-07ecd1b8369c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d6d674-40aa-42d7-88b3-f65603ecaa1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d6d674-40aa-42d7-88b3-f65603ecaa1e.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -9112,7 +9112,7 @@
         },
         {
             "id": "94cc5db1-b1fd-5b35-b2f6-faa7d248b5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526d13cb-3616-4ac8-9ac0-04c729d447b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526d13cb-3616-4ac8-9ac0-04c729d447b2.jpg?1",
             "name": "Star of Extinction",
             "text": "Destroy target land. Star of Extinction deals 20 damage to each creature and each planeswalker.",
             "colours": [
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "d8a86c0b-08b1-5a65-ba7e-9524b70a3892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69825b24-f469-4b6a-890b-bfa571c9013b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69825b24-f469-4b6a-890b-bfa571c9013b.jpg?1",
             "name": "Storm-Kiln Artist",
             "text": "Storm-Kiln Artist gets +1/+0 for each artifact you control.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a Treasure token.",
             "colours": [
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "b0a761be-dda2-5cd7-8e5f-393f4935d3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62b97e-e4cd-462d-9ab9-2230ca360c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62b97e-e4cd-462d-9ab9-2230ca360c32.jpg?1",
             "name": "Subira, Tulzidi Caravanner",
             "text": "Haste\n{1}: Another target creature with power 2 or less can't be blocked this turn.\n{1}{R}, {T}, Discard your hand: Until end of turn, whenever a creature you control with power 2 or less deals combat damage to a player, draw a card.",
             "colours": [
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "7caba302-bece-58e9-a986-6a06348e0c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabae267-54fa-4e6d-8f7d-15152fe37397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabae267-54fa-4e6d-8f7d-15152fe37397.jpg?1",
             "name": "Sulfurous Blast",
             "text": "Sulfurous Blast deals 2 damage to each creature and each player. If you cast this spell during your main phase, Sulfurous Blast deals 3 damage to each creature and each player instead.",
             "colours": [
@@ -9252,7 +9252,7 @@
         },
         {
             "id": "db63d06e-4da0-5840-ac9f-da696bd1fb5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808af8d4-1872-466e-a2d2-e73ecef09ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808af8d4-1872-466e-a2d2-e73ecef09ed7.jpg?1",
             "name": "Tempt with Vengeance",
             "text": "Tempting offer \u2014 Create X 1/1 red Elemental creature tokens with haste. Each opponent may create X 1/1 red Elemental creature tokens with haste. For each opponent who does, create X 1/1 red Elemental creature tokens with haste.",
             "colours": [
@@ -9286,7 +9286,7 @@
         },
         {
             "id": "9baa8609-6f2c-57b8-9ea0-8d3d30903a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375bc646-942e-4bf5-9c71-2c5471828e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375bc646-942e-4bf5-9c71-2c5471828e35.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -9318,7 +9318,7 @@
         },
         {
             "id": "20450753-2ebe-5b81-809a-1ffec65453f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5facc43f-f865-45ad-888b-398f6e07b947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5facc43f-f865-45ad-888b-398f6e07b947.jpg?1",
             "name": "Treasure Nabber",
             "text": "Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.",
             "colours": [
@@ -9356,7 +9356,7 @@
         },
         {
             "id": "db2bb2a3-a009-5f56-be6e-0d0fe814ffc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1bd49-e059-401e-b999-63166f9bc1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1bd49-e059-401e-b999-63166f9bc1fe.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "d90a94c2-0059-5cda-a3e6-388a7a6aa13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afc402-ddc4-4819-bc2a-584a43b9b60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afc402-ddc4-4819-bc2a-584a43b9b60e.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -9427,7 +9427,7 @@
         },
         {
             "id": "ddf1ef4f-61d8-5799-b841-44b916418445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4520cdcc-a10f-4b39-9c6f-ba86f6aa2c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4520cdcc-a10f-4b39-9c6f-ba86f6aa2c87.jpg?1",
             "name": "Zada, Hedron Grinder",
             "text": "Whenever you cast an instant or sorcery spell that targets only Zada, Hedron Grinder, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "8860eb37-5303-5751-8144-fe416ec2e17a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e137a-d9d9-4ba7-89fb-e680ddb2c2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e137a-d9d9-4ba7-89fb-e680ddb2c2d1.jpg?1",
             "name": "Abundant Harvest",
             "text": "Choose land or nonland. Reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9496,7 +9496,7 @@
         },
         {
             "id": "ca2b7746-6988-5c2e-bbe3-675e6b0082b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d48fb-42b5-4aaa-a91c-d35cdb5e41a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d48fb-42b5-4aaa-a91c-d35cdb5e41a3.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -9530,7 +9530,7 @@
         },
         {
             "id": "c66a242e-091c-5dc0-a6c2-f3b4b9d28f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64860ab-9b10-4587-a1db-05b3797df3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64860ab-9b10-4587-a1db-05b3797df3a7.jpg?1",
             "name": "Animal Magnetism",
             "text": "Reveal the top five cards of your library. An opponent chooses a creature card from among them. Put that card onto the battlefield and the rest into your graveyard.",
             "colours": [
@@ -9562,7 +9562,7 @@
         },
         {
             "id": "465133cf-04e8-5af1-bc51-902e76bd07df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6b1fd8-7c0b-4736-a100-cabd82052227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6b1fd8-7c0b-4736-a100-cabd82052227.jpg?1",
             "name": "Arachnogenesis",
             "text": "Create X 1/2 green Spider creature tokens with reach, where X is the number of creatures attacking you. Prevent all combat damage that would be dealt this turn by non-Spider creatures.",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "c6796791-19fa-537c-a5fa-00c5d00322b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b76074c-65ca-40e9-b125-4668d3431820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b76074c-65ca-40e9-b125-4668d3431820.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -9632,7 +9632,7 @@
         },
         {
             "id": "be4ccc29-2e1a-55e6-a4c2-6918dfa38580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe97fbe-a6d6-4e96-8c26-f81bcdf579a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe97fbe-a6d6-4e96-8c26-f81bcdf579a1.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "764674fe-532b-53fe-b080-15bbdfe96041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Beanstalk Giant's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "ead99fc7-12b0-574e-9e11-69f250ccac15",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "d1504c58-633c-5a33-8327-5e5c830f4916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efe9126-15ba-468e-a15a-7f9cbb779cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efe9126-15ba-468e-a15a-7f9cbb779cf6.jpg?1",
             "name": "Bloodspore Thrinax",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nEach other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on Bloodspore Thrinax.",
             "colours": [
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "973f756e-7248-5f45-b133-bb231f3022f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e5d6f-c050-44d9-8a5c-09c07786b6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e5d6f-c050-44d9-8a5c-09c07786b6ab.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -9808,7 +9808,7 @@
         },
         {
             "id": "01cf163b-b021-59fa-949d-7664c65a01bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b836b0a9-c38b-423a-bf22-c9041acf1952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b836b0a9-c38b-423a-bf22-c9041acf1952.jpg?1",
             "name": "Courage in Crisis",
             "text": "Put a +1/+1 counter on target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "683473e2-ac10-53aa-8d92-09a4d007b14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b17222-db06-41cc-a4d2-aae625cb1929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b17222-db06-41cc-a4d2-aae625cb1929.jpg?1",
             "name": "Crash of Rhino Beetles",
             "text": "Trample\nCrash of Rhino Beetles gets +10/+10 as long as you control ten or more lands.",
             "colours": [
@@ -9874,7 +9874,7 @@
         },
         {
             "id": "3197d177-fc7d-543a-8476-36943b206d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f4435a-8604-45b5-a537-dfdfcb922e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f4435a-8604-45b5-a537-dfdfcb922e16.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -9910,7 +9910,7 @@
         },
         {
             "id": "5140cff1-4e42-5095-a8b6-3436771d0513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a404d9b-02dd-45bc-b3eb-bc28452da22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a404d9b-02dd-45bc-b3eb-bc28452da22e.jpg?1",
             "name": "Crawling Infestation",
             "text": "At the beginning of your upkeep, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nWhenever one or more creature cards are put into your graveyard from anywhere during your turn, create a 1/1 green Insect creature token. This ability triggers only once each turn.",
             "colours": [
@@ -9942,7 +9942,7 @@
         },
         {
             "id": "c436ccd3-bfe1-519e-b766-ec6ee77ab135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d432d17e-052b-4a81-bad8-14babf6e593f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d432d17e-052b-4a81-bad8-14babf6e593f.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach, deathtouch",
             "colours": [
@@ -9976,7 +9976,7 @@
         },
         {
             "id": "acfb59a2-0430-55c6-84bb-fd78dd2e4f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdd8e69-5a71-4933-914e-dfede7b1ac93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdd8e69-5a71-4933-914e-dfede7b1ac93.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -10010,7 +10010,7 @@
         },
         {
             "id": "0ad90a3e-a850-554b-bfb0-e8d06cf9dfe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75918859-c93f-41b4-9ad0-a4a96c389f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75918859-c93f-41b4-9ad0-a4a96c389f0d.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "004ac549-3b39-5821-ad89-8095dd63669e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78075b31-8145-4053-90dd-6a34bd48fa7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78075b31-8145-4053-90dd-6a34bd48fa7c.jpg?1",
             "name": "Entourage of Trest",
             "text": "When Entourage of Trest enters the battlefield, you become the monarch.\nEntourage of Trest can block an additional creature each combat as long as you're the monarch.",
             "colours": [
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "4b565a55-06b2-5d57-a734-6d4a557bd0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39704000-65d3-4d39-849e-a3b617376bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39704000-65d3-4d39-849e-a3b617376bbc.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "f2d7ee8f-f031-5fda-ae70-2ca615da2989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea020a19-2907-4627-8a3b-d481404f5aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea020a19-2907-4627-8a3b-d481404f5aca.jpg?1",
             "name": "Ezuri's Predation",
             "text": "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures.",
             "colours": [
@@ -10151,7 +10151,7 @@
         },
         {
             "id": "7969dd80-f378-535d-8c1e-39f522558687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a8684b-5164-4313-ab3e-4c5b4f52bc7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a8684b-5164-4313-ab3e-4c5b4f52bc7e.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with mana value 6 or greater, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "b5f945c6-379f-5502-995c-6beb3310e3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10d99bf-b2ce-4443-b924-ff0eb8be1033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10d99bf-b2ce-4443-b924-ff0eb8be1033.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -10220,7 +10220,7 @@
         },
         {
             "id": "ea0d6426-7ccd-5e16-9faa-9511777e36a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52311be7-b484-4b14-a091-904c6b0c83d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52311be7-b484-4b14-a091-904c6b0c83d1.jpg?1",
             "name": "Freyalise, Llanowar's Fury",
             "text": "+2: Create a 1/1 green Elf Druid creature token with \"{T}: Add {G}.\"\n\u22122: Destroy target artifact or enchantment.\n\u22126: Draw a card for each green creature you control.\nFreyalise, Llanowar's Fury can be your commander.",
             "colours": [
@@ -10258,7 +10258,7 @@
         },
         {
             "id": "d0fb42b5-cabd-5cb7-8f8b-2ca882b6395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fb92d-6de6-49f5-a204-5bcf577c9640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fb92d-6de6-49f5-a204-5bcf577c9640.jpg?1",
             "name": "Fungal Plots",
             "text": "{1}{G}, Exile a creature card from your graveyard: Create a 1/1 green Saproling creature token.\nSacrifice two Saprolings: You gain 2 life and draw a card.",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "e0a20e88-f4f2-5855-b202-97192e6a5c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54872e72-41dc-4092-8169-ce13498beb30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54872e72-41dc-4092-8169-ce13498beb30.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "3dcc21c0-e898-5fc9-b5f7-9ee0179021b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee47f23a-3ba9-4615-b170-c89d8ab99d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee47f23a-3ba9-4615-b170-c89d8ab99d78.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "Creature spells you cast with power 4 or greater cost {2} less to cast.\nWhenever Goreclaw, Terror of Qal Sisma attacks, each creature you control with power 4 or greater gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -10365,7 +10365,7 @@
         },
         {
             "id": "8e764183-99b2-5032-b78b-b71718414b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6340e0f3-7f9c-4d71-8daf-e1be5505eb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6340e0f3-7f9c-4d71-8daf-e1be5505eb5b.jpg?1",
             "name": "The Great Henge",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\n{T}: Add {G}{G}. You gain 2 life.\nWhenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "61d247fa-9e29-5d63-8d0d-543c88100bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32c67d1-187f-40df-b3b3-6036f5c92834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32c67d1-187f-40df-b3b3-6036f5c92834.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -10435,7 +10435,7 @@
         },
         {
             "id": "4fcbb2ca-213d-5b00-a383-882d2b876ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de399acd-e792-4f4a-8025-434f1080c0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de399acd-e792-4f4a-8025-434f1080c0fc.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -10467,7 +10467,7 @@
         },
         {
             "id": "c8b425bf-c4e9-5b16-920c-e0aefa6c7252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65137-c9d6-4352-b7a0-f3968b167233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65137-c9d6-4352-b7a0-f3968b167233.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "4693bf2c-13c8-54f5-b73a-03a21941296f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995140fa-dc1f-4b75-9cea-079ea03c485f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995140fa-dc1f-4b75-9cea-079ea03c485f.jpg?1",
             "name": "Jade Mage",
             "text": "{2}{G}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -10536,7 +10536,7 @@
         },
         {
             "id": "1f0571cf-6e01-5af8-b4a6-80d6d303bf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c66316-a4cc-43e9-b354-03a34c1b12a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c66316-a4cc-43e9-b354-03a34c1b12a7.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -10575,7 +10575,7 @@
         },
         {
             "id": "e3d1ca10-7a79-53c7-be8e-036082d28142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ababe16b-9359-44cb-81fb-e0b3a42b46bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ababe16b-9359-44cb-81fb-e0b3a42b46bd.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -10611,7 +10611,7 @@
         },
         {
             "id": "4b109ba8-e5bb-5150-9ded-74efc76af3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa828bc7-0f5a-45de-9608-da42dda8f3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa828bc7-0f5a-45de-9608-da42dda8f3f9.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -10646,7 +10646,7 @@
         },
         {
             "id": "b2d35251-6ad6-51eb-93c3-e4f17a4cb850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a368f72-cc88-4f32-aad4-22d92c4d032d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a368f72-cc88-4f32-aad4-22d92c4d032d.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle. (Do this before you draw.)",
             "colours": [
@@ -10681,7 +10681,7 @@
         },
         {
             "id": "49d93c76-d786-55b2-8de3-3b4ad8b1ea78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b726c03-07e8-4a9b-bdac-dc50218626a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b726c03-07e8-4a9b-bdac-dc50218626a3.jpg?1",
             "name": "Lifeblood Hydra",
             "text": "Trample\nLifeblood Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Lifeblood Hydra dies, you gain life and draw cards equal to its power.",
             "colours": [
@@ -10717,7 +10717,7 @@
         },
         {
             "id": "c71b4a1a-aafa-5d6e-8e83-8b4c0197f9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08edd941-5ecc-4015-bd5d-e2eebfbf2ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08edd941-5ecc-4015-bd5d-e2eebfbf2ba6.jpg?1",
             "name": "Loyal Guardian",
             "text": "Trample\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10751,7 +10751,7 @@
         },
         {
             "id": "83305056-aadf-5ea6-b133-08c8b818bb6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5d3eba-e456-47c2-992b-a97ba66e9676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5d3eba-e456-47c2-992b-a97ba66e9676.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -10787,7 +10787,7 @@
         },
         {
             "id": "cee9bc62-848d-5d32-b14e-0bd93a065917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e50ae-39e6-435b-95e7-885f2b314ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e50ae-39e6-435b-95e7-885f2b314ecf.jpg?1",
             "name": "Mowu, Loyal Companion",
             "text": "Vigilance, trample\nIf one or more +1/+1 counters would be put on Mowu, Loyal Companion, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -10823,7 +10823,7 @@
         },
         {
             "id": "08460125-cd86-5631-862b-04f2a6a6e587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60e3465-46ae-486f-8deb-6e2f1ac71a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60e3465-46ae-486f-8deb-6e2f1ac71a1b.jpg?1",
             "name": "Nemata, Grove Guardian",
             "text": "{2}{G}: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Saproling creatures get +1/+1 until end of turn.",
             "colours": [
@@ -10859,7 +10859,7 @@
         },
         {
             "id": "3fa38898-63f8-5b84-ad85-860285d33f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8e59c-edf1-4b4d-982d-3c891e7b96ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8e59c-edf1-4b4d-982d-3c891e7b96ba.jpg?1",
             "name": "Obscuring Haze",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nPrevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -10894,7 +10894,7 @@
         },
         {
             "id": "b24cc349-a11b-5a42-8d5c-4d38a6acd7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2fbeb1-6446-48ca-afe1-d1869a36e389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2fbeb1-6446-48ca-afe1-d1869a36e389.jpg?1",
             "name": "Ohran Frostfang",
             "text": "Attacking creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -10933,7 +10933,7 @@
         },
         {
             "id": "f737f745-8bb8-5d89-baac-31d45ff83213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cab3-da50-4561-8797-cd179af39216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cab3-da50-4561-8797-cd179af39216.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "2ea9fcc8-964b-570a-b356-c95e5ab442c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7938b15-7585-43fb-897f-a57e820665b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7938b15-7585-43fb-897f-a57e820665b3.jpg?1",
             "name": "Oviya Pashiri, Sage Lifecrafter",
             "text": "{2}{G}, {T}: Create a 1/1 colorless Servo artifact creature token.\n{4}{G}, {T}: Create an X/X colorless Construct artifact creature token, where X is the number of creatures you control.",
             "colours": [
@@ -11010,7 +11010,7 @@
         },
         {
             "id": "7482a379-28c9-5682-b2a5-561eee54cbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8215686-bf19-4090-87c1-dd4f691f2ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8215686-bf19-4090-87c1-dd4f691f2ae7.jpg?1",
             "name": "Pollenbright Druid",
             "text": "When Pollenbright Druid enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11045,7 +11045,7 @@
         },
         {
             "id": "d1da6370-bbd1-582c-9e50-578c3b6d3bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2078908d-63ab-47f3-b01c-7c84e3f578b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2078908d-63ab-47f3-b01c-7c84e3f578b8.jpg?1",
             "name": "Predatory Rampage",
             "text": "Creatures you control get +3/+3 until end of turn. Each creature your opponents control blocks this turn if able.",
             "colours": [
@@ -11077,7 +11077,7 @@
         },
         {
             "id": "5f20ff8f-cf45-5b73-bb8b-aec8fd31a25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44063a90-e4cf-4bcd-a128-792de15371a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44063a90-e4cf-4bcd-a128-792de15371a7.jpg?1",
             "name": "Ram Through",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "116c8868-64c6-5e34-aaef-6723adc34110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961e92f3-2e58-49ad-9bd6-4e3c58dd26dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961e92f3-2e58-49ad-9bd6-4e3c58dd26dc.jpg?1",
             "name": "Rampaging Brontodon",
             "text": "Trample\nWhenever Rampaging Brontodon attacks, it gets +1/+1 until end of turn for each land you control.",
             "colours": [
@@ -11143,7 +11143,7 @@
         },
         {
             "id": "4ad2df37-9b42-5f40-ac87-a4dd89634c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9510e5ff-901a-42c9-b11f-5f71e2475504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9510e5ff-901a-42c9-b11f-5f71e2475504.jpg?1",
             "name": "Regal Behemoth",
             "text": "Trample\nWhen Regal Behemoth enters the battlefield, you become the monarch.\nWhenever you tap a land for mana while you're the monarch, add an additional one mana of any color.",
             "colours": [
@@ -11180,7 +11180,7 @@
         },
         {
             "id": "39e46a1b-73e4-5444-a399-cf010039abc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f4aecc-b728-4960-8131-1e5aa6c3c030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f4aecc-b728-4960-8131-1e5aa6c3c030.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -11217,7 +11217,7 @@
         },
         {
             "id": "df9b51de-5b1e-5f32-a845-acd1eb4b28c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e13e1c2-376f-4ce6-bdc0-e000e99e5b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e13e1c2-376f-4ce6-bdc0-e000e99e5b9c.jpg?1",
             "name": "Rot Shambler",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Rot Shambler.",
             "colours": [
@@ -11251,7 +11251,7 @@
         },
         {
             "id": "a479ed18-533c-547e-97db-c5ca433f5083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdb5f5-cd6e-47cd-b83d-ff71b00c369e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdb5f5-cd6e-47cd-b83d-ff71b00c369e.jpg?1",
             "name": "Sakiko, Mother of Summer",
             "text": "Whenever a creature you control deals combat damage to a player, add that much {G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -11290,7 +11290,7 @@
         },
         {
             "id": "c0586aac-4cc7-5627-a191-42a26732210d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d711cb2-4f34-4792-90d7-2be5d329a347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d711cb2-4f34-4792-90d7-2be5d329a347.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -11331,7 +11331,7 @@
         },
         {
             "id": "1df6b182-e3c7-5010-b4a8-9e5f9a207cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e12f0e-ab41-4413-8b88-9bde907fab22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e12f0e-ab41-4413-8b88-9bde907fab22.jpg?1",
             "name": "Skyshroud Claim",
             "text": "Search your library for up to two Forest cards, put them onto the battlefield, then shuffle.",
             "colours": [
@@ -11363,7 +11363,7 @@
         },
         {
             "id": "23d4d870-6d36-5e82-acbd-e17aa80605db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff737c53-9489-4a8c-8fa1-5d108222ae3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff737c53-9489-4a8c-8fa1-5d108222ae3f.jpg?1",
             "name": "Skysnare Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -11397,7 +11397,7 @@
         },
         {
             "id": "4f1e16d5-95ef-5b80-a92c-3abb5b30febc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad012c2-e6d9-448f-b204-14a2c55ff74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad012c2-e6d9-448f-b204-14a2c55ff74f.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -11429,7 +11429,7 @@
         },
         {
             "id": "c769a5e3-03db-5606-a324-e558903190e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/161e66e3-0339-495c-bd06-0a799a254906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/161e66e3-0339-495c-bd06-0a799a254906.jpg?1",
             "name": "Song of the Dryads",
             "text": "Enchant permanent\nEnchanted permanent is a colorless Forest land.",
             "colours": [
@@ -11465,7 +11465,7 @@
         },
         {
             "id": "ef3ad082-8864-5f72-bb4b-332312cfe328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3451dd0f-8cea-409f-8d56-f13e6aa424f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3451dd0f-8cea-409f-8d56-f13e6aa424f6.jpg?1",
             "name": "Stonehoof Chieftain",
             "text": "Trample, indestructible\nWhenever another creature you control attacks, it gains trample and indestructible until end of turn.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "154ad801-002d-5091-9bd7-465695a70542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71590b6f-9f38-4c5d-8431-50e5f02f8c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71590b6f-9f38-4c5d-8431-50e5f02f8c93.jpg?1",
             "name": "Surrak, the Hunt Caller",
             "text": "Formidable \u2014 At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn.",
             "colours": [
@@ -11539,7 +11539,7 @@
         },
         {
             "id": "429c70b8-258f-549a-b749-a8ceb349407a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df359b98-9f8f-4f32-82c6-f10ca0f81032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df359b98-9f8f-4f32-82c6-f10ca0f81032.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014\n\u2022 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n\u2022 Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "247b8e5f-1907-5628-b36b-df3a7a73c5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1165a2-e697-4ceb-91ba-693a3a006f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1165a2-e697-4ceb-91ba-693a3a006f27.jpg?1",
             "name": "Tuskguard Captain",
             "text": "Outlast {G} ({G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -11609,7 +11609,7 @@
         },
         {
             "id": "9f7a0bab-8f82-5bbe-a670-c55bea5908c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f3b28-ea20-4bad-8fab-5996e0fc1b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f3b28-ea20-4bad-8fab-5996e0fc1b62.jpg?1",
             "name": "Verdant Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Return target permanent card from your graveyard to your hand.\n\u2022 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -11643,7 +11643,7 @@
         },
         {
             "id": "9396d50f-8ad5-5e75-92f0-cc9665807518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b31eb-a9cd-44d2-8755-9323bb4de2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b31eb-a9cd-44d2-8755-9323bb4de2f0.jpg?1",
             "name": "Verdeloth the Ancient",
             "text": "Kicker {X} (You may pay an additional {X} as you cast this spell.)\nSaproling creatures and other Treefolk creatures get +1/+1.\nWhen Verdeloth the Ancient enters the battlefield, if it was kicked, create X 1/1 green Saproling creature tokens.",
             "colours": [
@@ -11679,7 +11679,7 @@
         },
         {
             "id": "4883e2e1-8725-5d07-9667-eb13bbbfb01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b4ee8-2457-4db4-a8fa-c87e2db0c265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b4ee8-2457-4db4-a8fa-c87e2db0c265.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.",
             "colours": [
@@ -11715,7 +11715,7 @@
         },
         {
             "id": "e2350dfd-0b79-5125-a9c9-e4d7ecd3afb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb35e40f-bbcf-4e2b-9603-7719c74dc076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb35e40f-bbcf-4e2b-9603-7719c74dc076.jpg?1",
             "name": "Wildwood Scourge",
             "text": "Wildwood Scourge enters the battlefield with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on Wildwood Scourge.",
             "colours": [
@@ -11749,7 +11749,7 @@
         },
         {
             "id": "d2f54503-d0eb-5a45-853a-91020c3183a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9808d-1d47-417d-bba8-06694a83d88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9808d-1d47-417d-bba8-06694a83d88e.jpg?1",
             "name": "Yedora, Grave Gardener",
             "text": "Whenever another nontoken creature you control dies, you may return it to the battlefield face down under its owner's control. It's a Forest land. (It has no other types or abilities.)",
             "colours": [
@@ -11786,7 +11786,7 @@
         },
         {
             "id": "418ce8bd-a1c3-5344-8006-fbdf22de24b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e3a130-deeb-4bf4-a1f6-9219c3d8c373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e3a130-deeb-4bf4-a1f6-9219c3d8c373.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "{2}{G}, {T}, Put a verse counter on Yisan, the Wanderer Bard: Search your library for a creature card with mana value equal to the number of verse counters on Yisan, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -11826,7 +11826,7 @@
         },
         {
             "id": "89dcd821-c2ab-529d-9848-f889eaa69e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa135775-abcd-4a21-abb7-3aeb5a39df28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa135775-abcd-4a21-abb7-3aeb5a39df28.jpg?1",
             "name": "Akiri, Fearless Voyager",
             "text": "Whenever you attack a player with one or more equipped creatures, draw a card.\n{W}: You may unattach an Equipment from a creature you control. If you do, tap that creature and it gains indestructible until end of turn.",
             "colours": [
@@ -11865,7 +11865,7 @@
         },
         {
             "id": "dd959064-26ef-5a88-a335-249e4adc76c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216d7afe-3acf-4293-b474-8b27730cdefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216d7afe-3acf-4293-b474-8b27730cdefb.jpg?1",
             "name": "Aryel, Knight of Windgrace",
             "text": "Vigilance\n{2}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.\n{B}, {T}, Tap X untapped Knights you control: Destroy target creature with power X or less.",
             "colours": [
@@ -11904,7 +11904,7 @@
         },
         {
             "id": "39e21815-1140-5718-9391-86c4e601989b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d938197-2557-421a-985e-5add932d4bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d938197-2557-421a-985e-5add932d4bac.jpg?1",
             "name": "Experiment Kraj",
             "text": "Experiment Kraj has all activated abilities of each other creature with a +1/+1 counter on it.\n{T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -11945,7 +11945,7 @@
         },
         {
             "id": "89c6ba4d-0bd0-5b51-bf0c-42b63d74dfeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40ba800-4423-4fd9-94c7-a9019c857af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40ba800-4423-4fd9-94c7-a9019c857af6.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -11986,7 +11986,7 @@
         },
         {
             "id": "83dd3aef-7a87-576b-ad74-14ef3e14de10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7f8f3-140d-4dd0-aacc-b81b2b93eb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7f8f3-140d-4dd0-aacc-b81b2b93eb67.jpg?1",
             "name": "Hamza, Guardian of Arashin",
             "text": "This spell costs {1} less to cast for each creature you control with a +1/+1 counter on it.\nCreature spells you cast cost {1} less to cast for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -12025,7 +12025,7 @@
         },
         {
             "id": "cbe4b3ee-2fe0-52e5-834c-f195594f7ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b41982-6e79-4e04-a0f3-d985da92e8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b41982-6e79-4e04-a0f3-d985da92e8c1.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -12066,7 +12066,7 @@
         },
         {
             "id": "c42518fc-ab78-5c5f-8473-40ae6cd74b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb929c-1b8d-4d1d-aa69-ac6189cd7ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb929c-1b8d-4d1d-aa69-ac6189cd7ebf.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -12105,7 +12105,7 @@
         },
         {
             "id": "72e81d7b-1547-5a73-b895-1eda35a1e378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d128887-13fb-4e54-90f2-d3c46b7b29d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d128887-13fb-4e54-90f2-d3c46b7b29d7.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -12148,7 +12148,7 @@
         },
         {
             "id": "f3f719fd-4771-5651-855e-0aeb3460a548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb034c8-bae0-4f66-98f1-1b3cdc072f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb034c8-bae0-4f66-98f1-1b3cdc072f17.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -12192,7 +12192,7 @@
         },
         {
             "id": "dc12a595-46ae-5bc5-aecb-82961a562888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c58b3-180f-420b-b091-114fda000360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c58b3-180f-420b-b091-114fda000360.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -12235,7 +12235,7 @@
         },
         {
             "id": "6edbda1a-7894-5dcd-88d5-126ed55fe657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66011fe8-8c5d-4990-a324-5839515dcacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66011fe8-8c5d-4990-a324-5839515dcacb.jpg?1",
             "name": "Melek, Izzet Paragon",
             "text": "Play with the top card of your library revealed.\nYou may cast instant and sorcery spells from the top of your library.\nWhenever you cast an instant or sorcery spell from your library, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -12274,7 +12274,7 @@
         },
         {
             "id": "04d63900-ba1a-5237-a697-1f18d1a164bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d627b3-a6d0-4f5f-b7c2-351a07318966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d627b3-a6d0-4f5f-b7c2-351a07318966.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "Whenever another creature you control dies, you get an experience counter.\nAt the beginning of your end step, choose target creature card in your graveyard. If that card's mana value is less than or equal to the number of experience counters you have, return it to the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -12316,7 +12316,7 @@
         },
         {
             "id": "11fb80e5-d5d8-5b9f-bd9f-2500b6203846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db44fe95-6a32-4d6f-a32f-72491381f495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db44fe95-6a32-4d6f-a32f-72491381f495.jpg?1",
             "name": "Mirri, Weatherlight Duelist",
             "text": "First strike\nWhenever Mirri, Weatherlight Duelist attacks, each opponent can't block with more than one creature this combat.\nAs long as Mirri, Weatherlight Duelist is tapped, no more than one creature can attack you each combat.",
             "colours": [
@@ -12357,7 +12357,7 @@
         },
         {
             "id": "f644a4c4-98bd-556f-b2bd-e7185cb0db6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f949d0-41a0-4491-9057-bfb2bb20bdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f949d0-41a0-4491-9057-bfb2bb20bdb3.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -12398,7 +12398,7 @@
         },
         {
             "id": "0312d1b7-934a-5074-9154-27aa75df52f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afdc65d-3c97-47af-83fa-df340389802e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afdc65d-3c97-47af-83fa-df340389802e.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nWhenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "773d700c-d34f-502d-ac8e-ebdb066a84a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567697db-8d47-404f-b0da-b00409431f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567697db-8d47-404f-b0da-b00409431f28.jpg?1",
             "name": "Queen Marchesa",
             "text": "Deathtouch, haste\nWhen Queen Marchesa enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with deathtouch and haste.",
             "colours": [
@@ -12484,7 +12484,7 @@
         },
         {
             "id": "ab8f58fa-6f9d-5661-8238-f54a6892cb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c681e33b-3d60-4aaa-8186-51866d8b79d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c681e33b-3d60-4aaa-8186-51866d8b79d1.jpg?1",
             "name": "Raff Capashen, Ship's Mage",
             "text": "Flash\nFlying\nYou may cast historic spells as though they had flash. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -12523,7 +12523,7 @@
         },
         {
             "id": "f3bbc8e8-7571-5439-9482-4370e7a05e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdd967d-b364-47ad-a1c2-49b155f72c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdd967d-b364-47ad-a1c2-49b155f72c5b.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "fc30a1d0-e861-5e13-9956-195eb16268f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f414ef-84a2-4694-9e98-51bee4576c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f414ef-84a2-4694-9e98-51bee4576c84.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -12606,7 +12606,7 @@
         },
         {
             "id": "13e88c76-9ab7-5da7-939b-6812bc95530b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873dbe5-d95a-4ecb-ac0a-8dc6c40f3576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873dbe5-d95a-4ecb-ac0a-8dc6c40f3576.jpg?1",
             "name": "Sek'Kuar, Deathkeeper",
             "text": "Whenever another nontoken creature you control dies, create a 3/1 black and red Graveborn creature token with haste.",
             "colours": [
@@ -12649,7 +12649,7 @@
         },
         {
             "id": "3324a005-1119-5195-afa4-0023a257cfd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8e44d4-db67-4bf4-97c0-ffe6a0eb2954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8e44d4-db67-4bf4-97c0-ffe6a0eb2954.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -12692,7 +12692,7 @@
         },
         {
             "id": "9b955b3f-2232-5165-841c-cacd3f47336d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb12173d-3afb-4e8b-b612-fa7737a8c6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb12173d-3afb-4e8b-b612-fa7737a8c6c2.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -12732,7 +12732,7 @@
         },
         {
             "id": "ce94e4f5-fab5-5c69-a14b-72f58755299b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6336b0af-3c7d-4b8e-a0e7-d4d15078fc04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6336b0af-3c7d-4b8e-a0e7-d4d15078fc04.jpg?1",
             "name": "Taigam, Sidisi's Hand",
             "text": "Skip your draw step.\nAt the beginning of your upkeep, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n{B}, {T}, Exile X cards from your graveyard: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -12771,7 +12771,7 @@
         },
         {
             "id": "ff4a112d-29cc-59e3-88ce-a426ea7af4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd82bff9-8061-48c0-a7c3-fee17acee22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd82bff9-8061-48c0-a7c3-fee17acee22a.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -12812,7 +12812,7 @@
         },
         {
             "id": "36a9af11-0631-52a3-9ae6-921feca3fca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd14f1ce-7fcd-485c-b7ca-01c5b45fdc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd14f1ce-7fcd-485c-b7ca-01c5b45fdc01.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -12854,7 +12854,7 @@
         },
         {
             "id": "9321d260-7794-577f-868b-6d98ce6a337d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146e10c-3104-442d-9383-0f670960180d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146e10c-3104-442d-9383-0f670960180d.jpg?1",
             "name": "Tuya Bearclaw",
             "text": "Whenever Tuya Bearclaw attacks, it gets +X/+X until end of turn, where X is the greatest power among other creatures you control.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "fd8576b0-4ebe-58f3-8f01-93f15f751f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d42b35-844f-4a64-9981-c6118d45e826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d42b35-844f-4a64-9981-c6118d45e826.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -12942,7 +12942,7 @@
         },
         {
             "id": "dc56dd69-b320-5f8d-ae34-073470c506da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91316746-ec2b-4c1a-b9c4-a870d6318c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91316746-ec2b-4c1a-b9c4-a870d6318c33.jpg?1",
             "name": "Xantcha, Sleeper Agent",
             "text": "Xantcha, Sleeper Agent enters the battlefield under the control of an opponent of your choice.\nXantcha attacks each combat if able and can't attack its owner or planeswalkers its owner controls.\n{3}: Xantcha's controller loses 2 life and you draw a card. Any player may activate this ability.",
             "colours": [
@@ -12983,7 +12983,7 @@
         },
         {
             "id": "6ff5fbfc-b048-5bb3-a1ae-af219563ec5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee11c9-fa23-4863-8a18-25a008f18da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee11c9-fa23-4863-8a18-25a008f18da5.jpg?1",
             "name": "Yennett, Cryptic Sovereign",
             "text": "Flying, vigilance, menace\nWhenever Yennett, Cryptic Sovereign attacks, reveal the top card of your library. You may cast it without paying its mana cost if its mana value is odd. If you don't cast it, draw a card.",
             "colours": [
@@ -13025,7 +13025,7 @@
         },
         {
             "id": "3d7a32d2-75fb-5bb3-9e6e-7704dd6655bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9be3e0-076c-4703-9750-2a6b0a178bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9be3e0-076c-4703-9750-2a6b0a178bc9.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's mana value.",
             "colours": [
@@ -13067,7 +13067,7 @@
         },
         {
             "id": "db36370b-bfc2-5e54-9619-f39e72461825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9224660-d547-4373-8493-42ffb364ee0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9224660-d547-4373-8493-42ffb364ee0b.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -13111,7 +13111,7 @@
         },
         {
             "id": "ca5e7e6d-850d-540a-a747-9867dda8706d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4e130-df21-4491-97c3-1b643d7e57ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4e130-df21-4491-97c3-1b643d7e57ef.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "Trample\nLethal damage dealt to creatures you control is determined by their power rather than their toughness.",
             "colours": [
@@ -13151,7 +13151,7 @@
         },
         {
             "id": "a40e0401-d3f5-5dc4-b645-a3f02c4dd4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b83c-4459-41b5-a001-d15a1c9ddf23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b83c-4459-41b5-a001-d15a1c9ddf23.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "de6eb217-97cb-51cb-b901-471a9a3be4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f7157-a375-499c-92c7-d47d2e95dbad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f7157-a375-499c-92c7-d47d2e95dbad.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add {C}{C}.",
             "colours": [],
@@ -13209,7 +13209,7 @@
         },
         {
             "id": "851e14b7-66a9-5a53-8181-71730e1f7941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b22076-b04e-4d65-9d9c-d3e4c7a3cf1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b22076-b04e-4d65-9d9c-d3e4c7a3cf1c.jpg?1",
             "name": "Assault Suit",
             "text": "Equipped creature gets +2/+2, has haste, can't attack you or planeswalkers you control, and can't be sacrificed.\nAt the beginning of each opponent's upkeep, you may have that player gain control of equipped creature until end of turn. If you do, untap it.\nEquip {3}",
             "colours": [],
@@ -13239,7 +13239,7 @@
         },
         {
             "id": "4f2315ad-cb56-54fe-9c7b-d78fc7a9a004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89486719-4aba-4465-986b-fecbe4d409a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89486719-4aba-4465-986b-fecbe4d409a1.jpg?1",
             "name": "Bonder's Ornament",
             "text": "{T}: Add one mana of any color.\n{4}, {T}: Each player who controls a permanent named Bonder's Ornament draws a card.",
             "colours": [],
@@ -13267,7 +13267,7 @@
         },
         {
             "id": "614368b1-f583-540d-93c9-583a6b017c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe710f-5e92-4be9-9f2f-363af767a91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe710f-5e92-4be9-9f2f-363af767a91e.jpg?1",
             "name": "Boompile",
             "text": "{T}: Flip a coin. If you win the flip, destroy all nonland permanents.",
             "colours": [],
@@ -13297,7 +13297,7 @@
         },
         {
             "id": "100b3b9b-9de2-54ff-a388-89918ae874fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f4448c-a946-45a3-9bce-0d82105e7cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f4448c-a946-45a3-9bce-0d82105e7cc1.jpg?1",
             "name": "Brass Knuckles",
             "text": "When you cast this spell, copy it. (The copy becomes a token.)\nEquipped creature has double strike as long as two or more Equipment are attached to it.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13327,7 +13327,7 @@
         },
         {
             "id": "532c9846-da35-53e2-961f-a6b55df26883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a97d2d-a5b7-4424-a703-c43ed887c888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a97d2d-a5b7-4424-a703-c43ed887c888.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -13358,7 +13358,7 @@
         },
         {
             "id": "1ab353e3-b780-52af-bf57-849707066c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b64d10-c012-4370-b475-755c4025a348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b64d10-c012-4370-b475-755c4025a348.jpg?1",
             "name": "Campfire",
             "text": "{1}, {T}: You gain 2 life.\n{2}, {T}, Exile Campfire: Put all commanders you own from the command zone and from your graveyard into your hand. Then shuffle your graveyard into your library.",
             "colours": [],
@@ -13386,7 +13386,7 @@
         },
         {
             "id": "5b2ad845-619b-56fb-bd0d-1d021f242c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6548a30-577a-47e7-aa6e-8f6db1f7b78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6548a30-577a-47e7-aa6e-8f6db1f7b78e.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -13419,7 +13419,7 @@
         },
         {
             "id": "5b1941f4-12b5-51d2-b51e-ce26a140e6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3969c209-09f3-4429-91c1-d5aeab9de2ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3969c209-09f3-4429-91c1-d5aeab9de2ec.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
             "colours": [],
@@ -13449,7 +13449,7 @@
         },
         {
             "id": "ae8b4a98-e59d-5662-b5b7-91a582467ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f432741-54b3-499e-9809-5a670433a297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f432741-54b3-499e-9809-5a670433a297.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -13479,7 +13479,7 @@
         },
         {
             "id": "5531d239-ee22-59b8-8afa-eee14739bdf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc439e0-59a8-4eb3-ac54-ab908c4ec50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc439e0-59a8-4eb3-ac54-ab908c4ec50b.jpg?1",
             "name": "Darksteel Ingot",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.)\n{T}: Add one mana of any color.",
             "colours": [],
@@ -13507,7 +13507,7 @@
         },
         {
             "id": "afd1bf73-4125-5d06-860a-60d823074d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba578d94-6f49-45f5-b6e2-1090c05acc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba578d94-6f49-45f5-b6e2-1090c05acc4a.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -13537,7 +13537,7 @@
         },
         {
             "id": "f10f1bd7-c102-50c6-acce-d4cee5d16797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be120499-fe2f-4c21-982c-566d0dbbddff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be120499-fe2f-4c21-982c-566d0dbbddff.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13567,7 +13567,7 @@
         },
         {
             "id": "5cf977d2-fd09-5d3d-829c-ca01acecae4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f050a675-c6a2-4d0d-bac6-1d8c51ecf824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f050a675-c6a2-4d0d-bac6-1d8c51ecf824.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint \u2014 When Extraplanar Lens enters the battlefield, you may exile target land you control.\nWhenever a land with the same name as the exiled card is tapped for mana, its controller adds one mana of any type that land produced.",
             "colours": [],
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "8bd5b29e-3f81-5c4a-b37c-366fa7cc5adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad9cac1-8b2b-42d6-9f0b-d679689ba862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad9cac1-8b2b-42d6-9f0b-d679689ba862.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -13628,7 +13628,7 @@
         },
         {
             "id": "bc25aa62-7f9b-5beb-b5c0-30b2bcbef444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165eee28-202d-4543-87b4-b9d39e8c8472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165eee28-202d-4543-87b4-b9d39e8c8472.jpg?1",
             "name": "Firemind Vessel",
             "text": "Firemind Vessel enters the battlefield tapped.\n{T}: Add two mana of different colors.",
             "colours": [],
@@ -13656,7 +13656,7 @@
         },
         {
             "id": "0cca8b99-5566-5808-ba2c-848fabda4f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2570fb88-358f-4f36-87e3-d8375824d126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2570fb88-358f-4f36-87e3-d8375824d126.jpg?1",
             "name": "Forebear's Blade",
             "text": "Equipped creature gets +3/+0 and has vigilance and trample.\nWhenever equipped creature dies, attach Forebear's Blade to target creature you control.\nEquip {3}",
             "colours": [],
@@ -13686,7 +13686,7 @@
         },
         {
             "id": "8775ed15-5c2f-50a6-bc42-d8a32f18974d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16debeb1-fb2b-4172-b6da-726416d4fb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16debeb1-fb2b-4172-b6da-726416d4fb38.jpg?1",
             "name": "Foundry Inspector",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [],
@@ -13717,7 +13717,7 @@
         },
         {
             "id": "e40c59ea-5df8-5f4d-a5cc-6636b7416ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa912283-c28e-4594-aca9-21d82d8cf006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa912283-c28e-4594-aca9-21d82d8cf006.jpg?1",
             "name": "Geode Golem",
             "text": "Trample\nWhenever Geode Golem deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost. (You still pay any additional costs.)",
             "colours": [],
@@ -13748,7 +13748,7 @@
         },
         {
             "id": "442e2f90-894b-5bdf-848c-1258686ae523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7554e-be86-4d0f-8e80-0ccb4c2cd2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7554e-be86-4d0f-8e80-0ccb4c2cd2f1.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -13778,7 +13778,7 @@
         },
         {
             "id": "ebdce1cd-a426-5a33-8f36-6ea2c57d5593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8ac1-f40d-423e-a0b3-0a8e236a6c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8ac1-f40d-423e-a0b3-0a8e236a6c1e.jpg?1",
             "name": "Hammer of Nazahn",
             "text": "Whenever Hammer of Nazahn or another Equipment enters the battlefield under your control, you may attach that Equipment to target creature you control.\nEquipped creature gets +2/+0 and has indestructible.\nEquip {4}",
             "colours": [],
@@ -13812,7 +13812,7 @@
         },
         {
             "id": "ccbd603f-ac26-5584-bf52-7f4abdea564a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abffd0a3-ea7a-43cf-b92d-d9f436bef58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abffd0a3-ea7a-43cf-b92d-d9f436bef58e.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13842,7 +13842,7 @@
         },
         {
             "id": "c54cdd5f-f61e-5dd0-a95f-98decf46d406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a42c6-fc98-4993-891c-7ac6a0735543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a42c6-fc98-4993-891c-7ac6a0735543.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13872,7 +13872,7 @@
         },
         {
             "id": "32494c60-5702-5097-9901-510a201c40a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da612ec-983b-4a7b-8d52-b853a4c565de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da612ec-983b-4a7b-8d52-b853a4c565de.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4}",
             "colours": [],
@@ -13902,7 +13902,7 @@
         },
         {
             "id": "71cd4003-c6bf-52f9-932c-f78edec24e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8235349d-0f92-4af4-ab8d-2f645fe32934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8235349d-0f92-4af4-ab8d-2f645fe32934.jpg?1",
             "name": "Idol of Oblivion",
             "text": "{T}: Draw a card. Activate only if you created a token this turn.\n{8}, {T}, Sacrifice Idol of Oblivion: Create a 10/10 colorless Eldrazi creature token.",
             "colours": [],
@@ -13932,7 +13932,7 @@
         },
         {
             "id": "f6033118-a5a1-5411-99de-fc8690d5d02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f68d45-a6cd-437d-a4b1-2787891f0128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f68d45-a6cd-437d-a4b1-2787891f0128.jpg?1",
             "name": "The Immortal Sun",
             "text": "Players can't activate planeswalkers' loyalty abilities.\nAt the beginning of your draw step, draw an additional card.\nSpells you cast cost {1} less to cast.\nCreatures you control get +1/+1.",
             "colours": [],
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "53c83162-2fc7-5ff6-a787-be6a629e0403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18446a7-68db-4a0a-9f36-ddf840c3e2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18446a7-68db-4a0a-9f36-ddf840c3e2c8.jpg?1",
             "name": "Inspiring Statuary",
             "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -13994,7 +13994,7 @@
         },
         {
             "id": "2580d6a1-4ae0-5535-a199-92c23f343169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58662f26-dd75-45a0-86cf-5949fbb76210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58662f26-dd75-45a0-86cf-5949fbb76210.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14024,7 +14024,7 @@
         },
         {
             "id": "6745f76e-60bb-5d27-9f55-85522c1846c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7183700-6941-4a3d-a581-4f33bea795e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7183700-6941-4a3d-a581-4f33bea795e9.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -14056,7 +14056,7 @@
         },
         {
             "id": "e232640e-bc27-51a6-a298-9d5f3004ed09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae094ace-1760-4bdd-a513-04616fb0deeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae094ace-1760-4bdd-a513-04616fb0deeb.jpg?1",
             "name": "Letter of Acceptance",
             "text": "{T}: Add one mana of any color.\n{2}, {T}, Sacrifice Letter of Acceptance: Draw a card.",
             "colours": [],
@@ -14084,7 +14084,7 @@
         },
         {
             "id": "3114c290-1673-526d-8675-d665e77a38d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331013f6-976a-4dac-9939-1006e474e108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331013f6-976a-4dac-9939-1006e474e108.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -14114,7 +14114,7 @@
         },
         {
             "id": "c780ee62-83c6-5dbe-819c-9014c3205687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7af704-a770-4f90-8fe8-a45457785a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7af704-a770-4f90-8fe8-a45457785a35.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -14145,7 +14145,7 @@
         },
         {
             "id": "1e88d648-6e90-582d-8fe3-f18b43a6b527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ba43d1-e879-40e0-b49c-e009deb7e3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ba43d1-e879-40e0-b49c-e009deb7e3aa.jpg?1",
             "name": "Myr Sire",
             "text": "When Myr Sire dies, create a 1/1 colorless Phyrexian Myr artifact creature token.",
             "colours": [],
@@ -14177,7 +14177,7 @@
         },
         {
             "id": "aa3bc273-6781-51e4-9b97-2293fc57a02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f256e868-92b5-4506-b409-9e1190b049dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f256e868-92b5-4506-b409-9e1190b049dd.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "db019a90-80d6-57c6-9bd0-e3992dda3089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc25b-f73c-431c-b173-adcd65c5d491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc25b-f73c-431c-b173-adcd65c5d491.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "c5acc23e-cbdd-5798-bfa6-e937e4fca51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8768a5-eba6-4585-a59b-19d1036cbfc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8768a5-eba6-4585-a59b-19d1036cbfc0.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -14266,7 +14266,7 @@
         },
         {
             "id": "704c28ae-2939-5c29-b1cf-3176e2dd0804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbd46d2-b4f2-48d0-a1c4-87ea625ec8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbd46d2-b4f2-48d0-a1c4-87ea625ec8bc.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "39f2878d-fe47-570b-8db9-8dbe01cdc843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2feac9d-560e-4854-82ed-78a3088c3788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2feac9d-560e-4854-82ed-78a3088c3788.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14324,7 +14324,7 @@
         },
         {
             "id": "19308bb9-982e-54b8-a791-550e8f409a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7333ea3-2c98-405a-a5cc-eecba9b14a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7333ea3-2c98-405a-a5cc-eecba9b14a00.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "768425b7-a38d-5c4b-9673-b6e45aa26118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed34e8de-d63a-4e4f-b9d4-80f66bb20641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed34e8de-d63a-4e4f-b9d4-80f66bb20641.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14385,7 +14385,7 @@
         },
         {
             "id": "d6c95194-8005-5b27-9655-494ae3eb6949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fc07f5-170f-43a1-9f65-a3f702655226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fc07f5-170f-43a1-9f65-a3f702655226.jpg?1",
             "name": "Scytheclaw",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, that player loses half their life, rounded up.\nEquip {3}",
             "colours": [],
@@ -14417,7 +14417,7 @@
         },
         {
             "id": "48f9b3d5-706b-56e8-ac84-c2323c36ddef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f61479b-05e1-4c89-bf11-b79c06ace5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f61479b-05e1-4c89-bf11-b79c06ace5e2.jpg?1",
             "name": "Shimmer Myr",
             "text": "Flash\nYou may cast artifact spells as though they had flash.",
             "colours": [],
@@ -14448,7 +14448,7 @@
         },
         {
             "id": "01b47f91-ffff-5954-af7a-add84b7c513c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ca0b66-a000-4483-b916-f5b89e710244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ca0b66-a000-4483-b916-f5b89e710244.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -14478,7 +14478,7 @@
         },
         {
             "id": "c764bed0-10c2-5b37-9b4c-975b4ab1b534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542eed4a-8a15-4829-8bc3-5637574e1398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542eed4a-8a15-4829-8bc3-5637574e1398.jpg?1",
             "name": "Spectral Searchlight",
             "text": "{T}: Choose a player. That player adds one mana of any color they choose.",
             "colours": [],
@@ -14506,7 +14506,7 @@
         },
         {
             "id": "f20b0218-6773-50e5-ada3-0cc1f38e8d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60160a6-8786-4488-b373-6599221341e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60160a6-8786-4488-b373-6599221341e5.jpg?1",
             "name": "Staunch Throneguard",
             "text": "Vigilance\nWhen Staunch Throneguard enters the battlefield, you become the monarch.",
             "colours": [],
@@ -14537,7 +14537,7 @@
         },
         {
             "id": "69fa3d87-fe94-565f-816f-9493e9e519b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64401acc-d080-4763-b67a-95164c11c69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64401acc-d080-4763-b67a-95164c11c69e.jpg?1",
             "name": "Sword of the Animist",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nEquip {2}",
             "colours": [],
@@ -14571,7 +14571,7 @@
         },
         {
             "id": "3e082326-5f7b-56ef-9e79-f980ab8b0e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfc5847-c3b4-41e7-8087-73ac4850bc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfc5847-c3b4-41e7-8087-73ac4850bc1b.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -14599,7 +14599,7 @@
         },
         {
             "id": "8cea0a37-a620-5baf-bd2f-39c29971c777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce5f12e-fc02-42f8-a5ca-b523050d4650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce5f12e-fc02-42f8-a5ca-b523050d4650.jpg?1",
             "name": "Thran Dynamo",
             "text": "{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -14629,7 +14629,7 @@
         },
         {
             "id": "005cbc0b-840c-54b5-a81d-1bfe7ca1f9cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eba26e-7c9e-46f3-ad13-aa684f3365cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eba26e-7c9e-46f3-ad13-aa684f3365cb.jpg?1",
             "name": "Unstable Obelisk",
             "text": "{T}: Add {C}.\n{7}, {T}, Sacrifice Unstable Obelisk: Destroy target permanent.",
             "colours": [],
@@ -14657,7 +14657,7 @@
         },
         {
             "id": "0e959712-a21f-5df8-bd5d-de2e1eb2be97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c924502b-a49e-4bf6-9e1a-9aa83f279228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c924502b-a49e-4bf6-9e1a-9aa83f279228.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.",
             "colours": [],
@@ -14685,7 +14685,7 @@
         },
         {
             "id": "1acf4647-3594-5474-9b3b-719b9ed1cdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363acf3-eff9-4f57-8b8a-683256d279e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363acf3-eff9-4f57-8b8a-683256d279e0.jpg?1",
             "name": "Vulshok Battlegear",
             "text": "Equipped creature gets +3/+3.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "2f3d3170-7866-547d-b0fd-0f8ed40ac554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0693ae-55f9-4864-b5db-383715a04d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0693ae-55f9-4864-b5db-383715a04d21.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "2c57ec2f-0b3d-5dba-9a34-2d11e698cba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14019383-0327-404b-ab4d-c65c3fa8c50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14019383-0327-404b-ab4d-c65c3fa8c50d.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -14773,7 +14773,7 @@
         },
         {
             "id": "161f91d3-00fd-53dc-b286-a4729a53dc02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643f0ee9-9eba-4aa8-9f68-1f57313fc030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643f0ee9-9eba-4aa8-9f68-1f57313fc030.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -14803,7 +14803,7 @@
         },
         {
             "id": "704c14dd-3a00-5939-948d-ab64b44d6ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ed120-1e33-4e31-8f16-ba56497c3c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ed120-1e33-4e31-8f16-ba56497c3c84.jpg?1",
             "name": "Opal Palace",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
             "colours": [],
@@ -14831,7 +14831,7 @@
         },
         {
             "id": "10ddeaf2-e40d-55c7-bbf0-017edc60c2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42522c12-874e-450f-bdea-901646eb2821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42522c12-874e-450f-bdea-901646eb2821.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -14861,7 +14861,7 @@
         },
         {
             "id": "044dd684-f0fc-5014-9951-597c868d8149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455be293-80cf-4bc6-8904-8dd21a2b9d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455be293-80cf-4bc6-8904-8dd21a2b9d19.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -14895,7 +14895,7 @@
         },
         {
             "id": "04ba8c90-9c0d-515d-a8af-17ef83aa6710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1d8a99-8a06-4e51-9277-96edb6899b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1d8a99-8a06-4e51-9277-96edb6899b29.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -14925,7 +14925,7 @@
         },
         {
             "id": "3bd6b564-00c2-59f5-9f03-bf2008dc0898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c877e-0188-427f-8de2-25ad82d7cadb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c877e-0188-427f-8de2-25ad82d7cadb.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -14953,7 +14953,7 @@
         },
         {
             "id": "5d0f837e-da40-5960-9850-a6c5762a4585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3140f-d5c8-45ff-8be4-622b1a129b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3140f-d5c8-45ff-8be4-622b1a129b3d.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -14987,7 +14987,7 @@
         },
         {
             "id": "edf8948d-988b-52b7-ba5b-1349a53c38e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04f0013-097c-46ec-9424-d5f417e6a9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04f0013-097c-46ec-9424-d5f417e6a9cf.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -15015,7 +15015,7 @@
         },
         {
             "id": "e41bc507-f77e-5571-b0bd-5c3819e75742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1270be49-a0d7-46cc-bf53-8172a3b5c6a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1270be49-a0d7-46cc-bf53-8172a3b5c6a6.jpg?1",
             "name": "Thriving Bluff",
             "text": "Thriving Bluff enters the battlefield tapped.\nAs Thriving Bluff enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -15045,7 +15045,7 @@
         },
         {
             "id": "01e65175-c64b-5344-89e6-85092c7b9aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343a1153-03d7-46d5-ad9a-65760eabed55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343a1153-03d7-46d5-ad9a-65760eabed55.jpg?1",
             "name": "Thriving Grove",
             "text": "Thriving Grove enters the battlefield tapped.\nAs Thriving Grove enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -15075,7 +15075,7 @@
         },
         {
             "id": "cd05ab9b-ceb6-566a-b758-ebbb9afc39a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f9b70-998c-4ecd-9094-f505692070de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f9b70-998c-4ecd-9094-f505692070de.jpg?1",
             "name": "Thriving Heath",
             "text": "Thriving Heath enters the battlefield tapped.\nAs Thriving Heath enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -15105,7 +15105,7 @@
         },
         {
             "id": "4d413f2d-a6b6-5a33-96d2-67afe3ba19f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2592bd6b-aea8-4fac-ad52-1801fcc7abe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2592bd6b-aea8-4fac-ad52-1801fcc7abe5.jpg?1",
             "name": "Thriving Isle",
             "text": "Thriving Isle enters the battlefield tapped.\nAs Thriving Isle enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -15135,7 +15135,7 @@
         },
         {
             "id": "3e7df581-2adf-5fa8-8844-04ee8cae0c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80fcc-b457-49c6-8c3a-0c5f58d74b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80fcc-b457-49c6-8c3a-0c5f58d74b2d.jpg?1",
             "name": "Thriving Moor",
             "text": "Thriving Moor enters the battlefield tapped.\nAs Thriving Moor enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -15165,7 +15165,7 @@
         },
         {
             "id": "582c07d9-b5ab-5759-8e49-e625c0ff7a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a39d22-5e3b-4ba0-b728-dbf16b61fc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a39d22-5e3b-4ba0-b728-dbf16b61fc8f.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -15199,7 +15199,7 @@
         },
         {
             "id": "eeda77e2-8b4a-51ba-84a1-92848a342c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae16c7da-912c-4d66-b1e7-17480cd3af99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae16c7da-912c-4d66-b1e7-17480cd3af99.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -15233,7 +15233,7 @@
         },
         {
             "id": "0da0740b-f737-5c91-b61b-5b79a36778c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafd7db6-b04e-4fa2-bccd-981211132a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafd7db6-b04e-4fa2-bccd-981211132a93.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -15267,7 +15267,7 @@
         },
         {
             "id": "5cdf576f-0b27-584e-bffb-00bb49afeb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614c9269-77c6-4cef-a987-8ef4c14fcebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614c9269-77c6-4cef-a987-8ef4c14fcebc.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15309,7 +15309,7 @@
         },
         {
             "id": "75afbeca-d7f8-562e-a4af-0ed77fa1e2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3344d18-e7b6-43ad-ab59-9ceaf49269f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3344d18-e7b6-43ad-ab59-9ceaf49269f7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15351,7 +15351,7 @@
         },
         {
             "id": "2829c6c7-1491-599c-bcc0-42968740f097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3036bd-95f0-403f-a6ba-b3b05f81a3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3036bd-95f0-403f-a6ba-b3b05f81a3c9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15393,7 +15393,7 @@
         },
         {
             "id": "ff920770-0574-5bb4-9055-34ba3fdc95c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63d4b-0bca-4b8e-bed0-0dc29ad0bac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63d4b-0bca-4b8e-bed0-0dc29ad0bac3.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15433,7 +15433,7 @@
         },
         {
             "id": "c19d92b6-5318-5a23-9501-5dd4fc934c60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75edde64-3589-424d-bfe1-714c4eaba019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75edde64-3589-424d-bfe1-714c4eaba019.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15473,7 +15473,7 @@
         },
         {
             "id": "9e7a56e1-3201-5346-b986-0e4c589a4816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b28bdb-e0d1-4d24-8199-8cd7ac12c30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b28bdb-e0d1-4d24-8199-8cd7ac12c30f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "0e6499ee-81e4-5c17-89fa-52202a9f461c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490452a3-22fb-4c75-9bf2-5cd6d6719446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490452a3-22fb-4c75-9bf2-5cd6d6719446.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15553,7 +15553,7 @@
         },
         {
             "id": "4e0477df-0e91-5cdd-8e7a-e907851f4688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e5571-866b-4b19-b786-e57781353913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e5571-866b-4b19-b786-e57781353913.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15593,7 +15593,7 @@
         },
         {
             "id": "eea131a5-5f7d-5129-abaf-18d5d1b99fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71891b-9980-4b71-8301-e92288d33235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71891b-9980-4b71-8301-e92288d33235.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15633,7 +15633,7 @@
         },
         {
             "id": "923778fe-8050-56c2-a816-bd40a23f75a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836071c-9ee3-4dc0-95b6-28d0c5de76f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836071c-9ee3-4dc0-95b6-28d0c5de76f3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15673,7 +15673,7 @@
         },
         {
             "id": "98f12d1c-c3f5-555f-999c-eb7c1a38849e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95315204-a5f7-4d20-bda3-957029da29fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95315204-a5f7-4d20-bda3-957029da29fe.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15713,7 +15713,7 @@
         },
         {
             "id": "fc17f8e8-13bb-5cf8-8646-e6148b76a84f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbecd1f-81ad-427e-a50d-64b9ec029c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbecd1f-81ad-427e-a50d-64b9ec029c3c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15753,7 +15753,7 @@
         },
         {
             "id": "fff69c55-d36f-56e7-94f6-4d8fe36bffa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974535c-d99b-4d69-a21d-63359e40d385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974535c-d99b-4d69-a21d-63359e40d385.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "2f46f9f0-f6bc-5a2a-9a29-dcfa7e237f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e574ee5-d33d-4054-9884-fdb5fe9d73bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e574ee5-d33d-4054-9884-fdb5fe9d73bd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15833,7 +15833,7 @@
         },
         {
             "id": "253cfd47-8ca4-55ed-aa12-9d2cab62e8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be6c40e-5669-417e-a655-b32b5f2bfd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be6c40e-5669-417e-a655-b32b5f2bfd11.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15873,7 +15873,7 @@
         },
         {
             "id": "7ac39b70-ce8c-5ec1-aa4c-c1568d881821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1185bb-b12e-47b5-9230-368ac9c91c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1185bb-b12e-47b5-9230-368ac9c91c1d.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -15908,7 +15908,7 @@
         },
         {
             "id": "0d5918a8-24cd-57dc-877d-17028d53f18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf0e27d-9b68-44dc-82ff-53d6817fb9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf0e27d-9b68-44dc-82ff-53d6817fb9d5.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -15949,7 +15949,7 @@
         },
         {
             "id": "5da69907-dedd-5991-824c-7c5ace6e8008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c90289-05ba-45fc-8f60-7e200cb11762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c90289-05ba-45fc-8f60-7e200cb11762.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -15984,7 +15984,7 @@
         },
         {
             "id": "6e3ea000-018e-5c20-b391-8a52759e6018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483b3056-8ced-4ec1-9182-e7b8183f1939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483b3056-8ced-4ec1-9182-e7b8183f1939.jpg?1",
             "name": "Alms Collector",
             "text": "Flash\nIf an opponent would draw two or more cards, instead you and that player each draw a card.",
             "colours": [
@@ -16020,7 +16020,7 @@
         },
         {
             "id": "181a97f6-4703-5335-934e-5c9e5f45383c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b9c34-48f1-475c-81f8-a74672ed5c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b9c34-48f1-475c-81f8-a74672ed5c89.jpg?1",
             "name": "Angelic Field Marshal",
             "text": "Flying\nLieutenant \u2014 As long as you control your commander, Angelic Field Marshal gets +2/+2 and creatures you control have vigilance.",
             "colours": [
@@ -16055,7 +16055,7 @@
         },
         {
             "id": "11752a33-ba97-548c-9742-ecb8fcbe2a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fbdbe3-04d3-45e2-bff3-60349552f127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fbdbe3-04d3-45e2-bff3-60349552f127.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -16092,7 +16092,7 @@
         },
         {
             "id": "5f1a19d9-e36b-5ebf-8344-ac24f0fa6f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ed2bf7-23d1-47a2-90c8-ae00d596a392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ed2bf7-23d1-47a2-90c8-ae00d596a392.jpg?1",
             "name": "Balan, Wandering Knight",
             "text": "First strike\nBalan, Wandering Knight has double strike as long as two or more Equipment are attached to it.\n{1}{W}: Attach all Equipment you control to Balan.",
             "colours": [
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "ca6a2a9f-5228-5aa2-a97a-fc79a5b57e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2129252-fa14-49d2-9662-8dc804ddf4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2129252-fa14-49d2-9662-8dc804ddf4fb.jpg?1",
             "name": "Flawless Maneuver",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCreatures you control gain indestructible until end of turn.",
             "colours": [
@@ -16164,7 +16164,7 @@
         },
         {
             "id": "a440db6e-5990-5789-9edd-7a488ecc46e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565b0c50-4754-4867-a38d-e7d6b6475793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565b0c50-4754-4867-a38d-e7d6b6475793.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "1f38bfe4-d51d-53a6-8d08-a34dedbe01b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacd747-e422-47c0-8022-075f01390663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacd747-e422-47c0-8022-075f01390663.jpg?1",
             "name": "Heavenly Blademaster",
             "text": "Flying, double strike\nWhen Heavenly Blademaster enters the battlefield, you may attach any number of Auras and Equipment you control to it.\nOther creatures you control get +1/+1 for each Aura and Equipment attached to Heavenly Blademaster.",
             "colours": [
@@ -16236,7 +16236,7 @@
         },
         {
             "id": "5b525cd1-64d9-52c5-94d3-a83eb62eb4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b82143-e721-40c4-b67a-5430824f0eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b82143-e721-40c4-b67a-5430824f0eed.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nWhenever you gain life, put a +1/+1 counter on target creature or enchantment you control.\n{1}{W}: Another target creature gains lifelink until end of turn.",
             "colours": [
@@ -16274,7 +16274,7 @@
         },
         {
             "id": "7203910b-4f87-589c-8cbe-c19e7a6b846c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83ab91c-6e82-4a97-b602-40826d73b2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83ab91c-6e82-4a97-b602-40826d73b2ae.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -16312,7 +16312,7 @@
         },
         {
             "id": "285c3cf1-8e67-5cd0-b640-3c263edcd203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9071c93f-d5c6-4ca2-bac6-15fe96d03178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9071c93f-d5c6-4ca2-bac6-15fe96d03178.jpg?1",
             "name": "Land Tax",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -16345,7 +16345,7 @@
         },
         {
             "id": "88292ef4-309b-5759-8b31-ab4303d51cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097705d-af48-44d7-9ae7-21c4f4df55cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097705d-af48-44d7-9ae7-21c4f4df55cd.jpg?1",
             "name": "Loyal Retainers",
             "text": "Sacrifice Loyal Retainers: Return target legendary creature card from your graveyard to the battlefield. Activate only during your turn, before attackers are declared.",
             "colours": [
@@ -16381,7 +16381,7 @@
         },
         {
             "id": "ad7ea748-75bf-5458-853b-fff899ab0885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f14e5-6d0b-4687-a4c7-5f199ba24a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f14e5-6d0b-4687-a4c7-5f199ba24a55.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -16419,7 +16419,7 @@
         },
         {
             "id": "46090dc1-251f-5fa4-8760-3db71dd1e64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b60107-441d-4390-b433-adb6ce1e616d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b60107-441d-4390-b433-adb6ce1e616d.jpg?1",
             "name": "Nahiri, the Lithomancer",
             "text": "+2: Create a 1/1 white Kor Soldier creature token. You may attach an Equipment you control to it.\n\u22122: You may put an Equipment card from your hand or graveyard onto the battlefield.\n\u221210: Create a colorless Equipment artifact token named Stoneforged Blade. It has indestructible, \"Equipped creature gets +5/+5 and has double strike,\" and equip {0}.\nNahiri, the Lithomancer can be your commander.",
             "colours": [
@@ -16456,7 +16456,7 @@
         },
         {
             "id": "c56a3634-7dcf-5aeb-ab45-79ef7ce30562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765f5235-a2f0-4402-8630-ca701ad7f540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765f5235-a2f0-4402-8630-ca701ad7f540.jpg?1",
             "name": "Odric, Master Tactician",
             "text": "First strike\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
             "colours": [
@@ -16494,7 +16494,7 @@
         },
         {
             "id": "3ff589e5-29b4-5496-a541-9c577b032301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43eb2ff-a3c4-449d-8ad3-17c41d5c764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43eb2ff-a3c4-449d-8ad3-17c41d5c764b.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -16531,7 +16531,7 @@
         },
         {
             "id": "bfbb1943-836e-5270-8af9-25d4e392ecf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7c2bb4-3156-4563-be23-65139fbad96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7c2bb4-3156-4563-be23-65139fbad96c.jpg?1",
             "name": "Righteous Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Create a 2/2 white Knight creature token with vigilance.\n\u2022 Exile target enchantment.\n\u2022 You gain 5 life.",
             "colours": [
@@ -16564,7 +16564,7 @@
         },
         {
             "id": "1a3a6f6a-b734-5a52-abeb-96a3f7c67e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781a59d4-383a-4251-a3d8-a1d233688661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781a59d4-383a-4251-a3d8-a1d233688661.jpg?1",
             "name": "Sephara, Sky's Blade",
             "text": "You may pay {W} and tap four untapped creatures you control with flying rather than pay this spell's mana cost.\nFlying, lifelink\nOther creatures you control with flying have indestructible.",
             "colours": [
@@ -16601,7 +16601,7 @@
         },
         {
             "id": "12dc3b20-84b2-54b0-91c1-714818bc9517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18140c53-e8ce-4fce-b302-f56fb0e87380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18140c53-e8ce-4fce-b302-f56fb0e87380.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -16634,7 +16634,7 @@
         },
         {
             "id": "5c23cf65-990f-5393-b2cc-6893085f76f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2309fb66-3aa0-4ec5-9a8e-5a0caa19c270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2309fb66-3aa0-4ec5-9a8e-5a0caa19c270.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -16668,7 +16668,7 @@
         },
         {
             "id": "9e8c4193-344c-564f-a72e-42af3bff8577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db6b514-2a89-425d-aef3-b338ce971763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db6b514-2a89-425d-aef3-b338ce971763.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -16702,7 +16702,7 @@
         },
         {
             "id": "58217a77-ab36-5cd0-bd01-3611ceb6d84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb014a3-2e76-41ce-9e26-401a05609975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb014a3-2e76-41ce-9e26-401a05609975.jpg?1",
             "name": "Sublime Exhalation",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy all creatures.",
             "colours": [
@@ -16735,7 +16735,7 @@
         },
         {
             "id": "0bb928fc-98b7-5f5b-a7c6-debd2500413c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a38d3-9adf-43c4-9fc5-8791ce7d4579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a38d3-9adf-43c4-9fc5-8791ce7d4579.jpg?1",
             "name": "Wakening Sun's Avatar",
             "text": "When Wakening Sun's Avatar enters the battlefield, if you cast it from your hand, destroy all non-Dinosaur creatures.",
             "colours": [
@@ -16771,7 +16771,7 @@
         },
         {
             "id": "2cd442d1-40ed-5fe5-8d7d-dae7bffb393d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc86f1d-577b-4ae0-89ec-04f5f647dacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc86f1d-577b-4ae0-89ec-04f5f647dacb.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -16804,7 +16804,7 @@
         },
         {
             "id": "5952db9b-b41e-5776-99aa-3d1669bfa728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e0232d-5eec-4ff1-93db-1adad8167c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e0232d-5eec-4ff1-93db-1adad8167c3a.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -16842,7 +16842,7 @@
         },
         {
             "id": "b0172dfd-7de5-5e26-907a-a4ceaa09ec51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f6663e-3ac0-40da-a27f-90b25488881f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f6663e-3ac0-40da-a27f-90b25488881f.jpg?1",
             "name": "Aminatou's Augury",
             "text": "Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a spell of that type from among the exiled cards without paying its mana cost.",
             "colours": [
@@ -16875,7 +16875,7 @@
         },
         {
             "id": "627d5e63-adc2-516c-90f5-03fbdc2368a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af3dc3b-18c6-4446-a2f8-1f13edc2a650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af3dc3b-18c6-4446-a2f8-1f13edc2a650.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -16914,7 +16914,7 @@
         },
         {
             "id": "dcf2ea18-e15a-51a0-b3d6-6db3c8df1076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5db271-9b38-44ad-943f-785c8f4d04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5db271-9b38-44ad-943f-785c8f4d04a0.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from their hand onto the battlefield.",
             "colours": [
@@ -16952,7 +16952,7 @@
         },
         {
             "id": "8c439562-b548-5d2e-a8f2-37938d0a9579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70f54e4-3297-4bf4-8aa8-e4be4965e961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70f54e4-3297-4bf4-8aa8-e4be4965e961.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -16985,7 +16985,7 @@
         },
         {
             "id": "0661035f-c5fb-524b-a7a4-fee14ddcce4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0776e0fa-1d9c-4721-99c6-a04eabec84d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0776e0fa-1d9c-4721-99c6-a04eabec84d0.jpg?1",
             "name": "Capture of Jingzhou",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -17018,7 +17018,7 @@
         },
         {
             "id": "45adaaa0-1e4a-5657-a1a6-a7129714b776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43836f8b-bf83-4d33-a244-c1713175dc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43836f8b-bf83-4d33-a244-c1713175dc28.jpg?1",
             "name": "Commandeer",
             "text": "You may exile two blue cards from your hand rather than pay this spell's mana cost.\nGain control of target noncreature spell. You may choose new targets for it.",
             "colours": [
@@ -17051,7 +17051,7 @@
         },
         {
             "id": "b6ea4c10-fb9d-54bc-a45c-f947c44fe22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810a95a-e1e1-4655-a508-dfbc83d4d527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810a95a-e1e1-4655-a508-dfbc83d4d527.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -17084,7 +17084,7 @@
         },
         {
             "id": "0701e50d-c0a4-5fd5-aef3-766ca674e739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a82c8-3d6f-483a-96c3-38baf54390b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a82c8-3d6f-483a-96c3-38baf54390b4.jpg?1",
             "name": "Day's Undoing",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities from the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -17117,7 +17117,7 @@
         },
         {
             "id": "4c63893e-477e-5fa5-9b3f-7746e240eb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad123d-36cd-4b97-9e1c-eec2fa3bd4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad123d-36cd-4b97-9e1c-eec2fa3bd4c3.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -17150,7 +17150,7 @@
         },
         {
             "id": "c91cbcd7-8727-5f1d-b5ab-0e41d72ec939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdd3fd7-1a91-411c-a747-68942d2ad5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdd3fd7-1a91-411c-a747-68942d2ad5b9.jpg?1",
             "name": "Faerie Artisans",
             "text": "Flying\nWhenever a nontoken creature enters the battlefield under an opponent's control, create a token that's a copy of that creature except it's an artifact in addition to its other types. Then exile all other tokens created with Faerie Artisans.",
             "colours": [
@@ -17186,7 +17186,7 @@
         },
         {
             "id": "5f2d1478-f355-5f55-8da1-43cdf69a2361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8678852-7f4a-4b30-9f0b-0719489f442e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8678852-7f4a-4b30-9f0b-0719489f442e.jpg?1",
             "name": "Fierce Guardianship",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCounter target noncreature spell.",
             "colours": [
@@ -17220,7 +17220,7 @@
         },
         {
             "id": "f5e8be45-27e6-59d6-85b1-9e346ce4c41e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18c9963-c3e1-4877-9df5-18f52e287206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18c9963-c3e1-4877-9df5-18f52e287206.jpg?1",
             "name": "Lorthos, the Tidemaker",
             "text": "Whenever Lorthos, the Tidemaker attacks, you may pay {8}. If you do, tap up to eight target permanents. Those permanents don't untap during their controllers' next untap steps.",
             "colours": [
@@ -17257,7 +17257,7 @@
         },
         {
             "id": "d27fe5b9-1f38-5148-a56a-ed342faacd3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6305be5e-9b96-4132-b240-432549af999e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6305be5e-9b96-4132-b240-432549af999e.jpg?1",
             "name": "Minds Aglow",
             "text": "Join forces \u2014 Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.",
             "colours": [
@@ -17290,7 +17290,7 @@
         },
         {
             "id": "e128863b-de5c-5ab3-91e8-96f7acd306c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dd8d84-2bbc-4068-9b93-0250b793b622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dd8d84-2bbc-4068-9b93-0250b793b622.jpg?1",
             "name": "Mystic Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Return target creature to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -17323,7 +17323,7 @@
         },
         {
             "id": "4a21d861-d14d-5094-91f9-453b8b4fe119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893944f-35f1-47d2-87e1-c24a1d1938bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893944f-35f1-47d2-87e1-c24a1d1938bc.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -17357,7 +17357,7 @@
         },
         {
             "id": "73f69044-197c-5409-9c37-33e12fa32bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c2725-afd6-480d-bd6b-3dc30f76248d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c2725-afd6-480d-bd6b-3dc30f76248d.jpg?1",
             "name": "Sai, Master Thopterist",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{U}, Sacrifice two artifacts: Draw a card.",
             "colours": [
@@ -17395,7 +17395,7 @@
         },
         {
             "id": "1d4d1ba7-911f-538b-a5d3-28f6572e05df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae281cc-cd22-4e14-a80c-08777e1703ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae281cc-cd22-4e14-a80c-08777e1703ae.jpg?1",
             "name": "Spellseeker",
             "text": "When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with mana value 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -17432,7 +17432,7 @@
         },
         {
             "id": "faaeabfd-ac34-501f-8385-43eec0071813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef3fec7-2d32-439d-a956-1982d82f1450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef3fec7-2d32-439d-a956-1982d82f1450.jpg?1",
             "name": "Stitcher Geralf",
             "text": "{2}{U}, {T}: Each player mills three cards. Exile up to two creature cards put into graveyards this way. Create an X/X blue Zombie creature token, where X is the total power of the cards exiled this way.",
             "colours": [
@@ -17470,7 +17470,7 @@
         },
         {
             "id": "e20cd3cb-d0fb-58d3-81c8-14bc624f7d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9056efed-307d-4986-9cf1-f7bf34e18fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9056efed-307d-4986-9cf1-f7bf34e18fc1.jpg?1",
             "name": "Stormsurge Kraken",
             "text": "Hexproof\nLieutenant \u2014 As long as you control your commander, Stormsurge Kraken gets +2/+2 and has \"Whenever Stormsurge Kraken becomes blocked, you may draw two cards.\"",
             "colours": [
@@ -17505,7 +17505,7 @@
         },
         {
             "id": "a8c5d58f-c03a-57c5-b1f3-855d9249b2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf311a8-5c3b-4473-9732-d0ddb1d42644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf311a8-5c3b-4473-9732-d0ddb1d42644.jpg?1",
             "name": "Sun Quan, Lord of Wu",
             "text": "Creatures you control have horsemanship. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [
@@ -17543,7 +17543,7 @@
         },
         {
             "id": "c5c7fd34-0069-5efb-9ffc-0bb079b82304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df88b6-f7a4-49a9-a93a-9f6cb83fd8da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df88b6-f7a4-49a9-a93a-9f6cb83fd8da.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -17582,7 +17582,7 @@
         },
         {
             "id": "a44cc9f7-d0c5-5a2f-a005-28410e25c7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba86947e-5d7c-4cf1-9d33-98b289d56108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba86947e-5d7c-4cf1-9d33-98b289d56108.jpg?1",
             "name": "Teferi, Temporal Archmage",
             "text": "+1: Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\n\u22121: Untap up to four target permanents.\n\u221210: You get an emblem with \"You may activate loyalty abilities of planeswalkers you control on any player's turn any time you could cast an instant.\"\nTeferi, Temporal Archmage can be your commander.",
             "colours": [
@@ -17619,7 +17619,7 @@
         },
         {
             "id": "60898550-2b90-5315-839c-5809c3d01e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa9a1-1e34-48d6-a6ec-244844810f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa9a1-1e34-48d6-a6ec-244844810f87.jpg?1",
             "name": "Torrential Gearhulk",
             "text": "Flash\nWhen Torrential Gearhulk enters the battlefield, you may cast target instant card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -17655,7 +17655,7 @@
         },
         {
             "id": "026f6621-ec0f-538e-89dd-cf40f71b8bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ab9672-8d85-41f6-9016-20c2988b037c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ab9672-8d85-41f6-9016-20c2988b037c.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -17695,7 +17695,7 @@
         },
         {
             "id": "b43f0bcb-2434-5c51-8f60-c13416e186bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afce9284-9d3a-4ab9-8dd0-8fda1ee0c64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afce9284-9d3a-4ab9-8dd0-8fda1ee0c64f.jpg?1",
             "name": "Archfiend of Despair",
             "text": "Flying\nYour opponents can't gain life.\nAt the beginning of each end step, each opponent loses life equal to the life that player lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -17730,7 +17730,7 @@
         },
         {
             "id": "162f6861-97d3-5e37-88f5-59a13090c5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dd3973-d029-4ec9-b52d-c26f1e7333ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dd3973-d029-4ec9-b52d-c26f1e7333ad.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -17764,7 +17764,7 @@
         },
         {
             "id": "a3fe5fe2-c26f-5825-a8e9-9740782ba2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f59ff-b72b-4113-8d7c-3d820b2f8549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f59ff-b72b-4113-8d7c-3d820b2f8549.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -17802,7 +17802,7 @@
         },
         {
             "id": "7b5ce7ae-8a85-54dd-9835-9a4622e2d336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16d6716-c8f8-4743-9a77-af8e15818690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16d6716-c8f8-4743-9a77-af8e15818690.jpg?1",
             "name": "Curtains' Call",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
             "colours": [
@@ -17835,7 +17835,7 @@
         },
         {
             "id": "0a164751-e60c-5016-a4d1-dde754119742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fc8546-60a7-470b-942a-189850eea15f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fc8546-60a7-470b-942a-189850eea15f.jpg?1",
             "name": "Deadly Rollick",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nExile target creature.",
             "colours": [
@@ -17869,7 +17869,7 @@
         },
         {
             "id": "e9e360c5-80a3-5e2a-a343-70ea7dc3d121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74c32e0-769c-401b-a35c-672973ed49f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74c32e0-769c-401b-a35c-672973ed49f3.jpg?1",
             "name": "Decree of Pain",
             "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
             "colours": [
@@ -17902,7 +17902,7 @@
         },
         {
             "id": "dbebd322-bd7b-5192-aa42-d50e91bc4991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89153e75-2333-42e8-bc28-1b3d1e4726dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89153e75-2333-42e8-bc28-1b3d1e4726dd.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -17936,7 +17936,7 @@
         },
         {
             "id": "9ec1fb8a-1257-5821-85f7-138ff370ccd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b9933d-5c10-4fca-988e-3f00d7356231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b9933d-5c10-4fca-988e-3f00d7356231.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "Flying, trample\nWhen Demonlord Belzenlok enters the battlefield, exile cards from the top of your library until you exile a nonland card, then put that card into your hand. If the card's mana value is 4 or greater, repeat this process. Demonlord Belzenlok deals 1 damage to you for each card put into your hand this way.",
             "colours": [
@@ -17974,7 +17974,7 @@
         },
         {
             "id": "c4fe4ac5-1145-52ab-ac71-30ecd1a29fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227276da-caa5-4b24-a534-48a7ca650c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227276da-caa5-4b24-a534-48a7ca650c2b.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you cast a creature spell, create X 1/1 black Thrull creature tokens, where X is that spell's mana value.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -18012,7 +18012,7 @@
         },
         {
             "id": "c055e72c-5a52-5172-8ef7-6ab55a48c9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5219ed86-eb4e-43f5-9c75-f3b24abe42a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5219ed86-eb4e-43f5-9c75-f3b24abe42a5.jpg?1",
             "name": "Ghoulcaller Gisa",
             "text": "{B}, {T}, Sacrifice another creature: Create X 2/2 black Zombie creature tokens, where X is the sacrificed creature's power.",
             "colours": [
@@ -18050,7 +18050,7 @@
         },
         {
             "id": "3f875b22-38a2-5756-96b0-ba54073326a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a394c-aa7e-40a7-958d-ed89e82bd473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a394c-aa7e-40a7-958d-ed89e82bd473.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -18084,7 +18084,7 @@
         },
         {
             "id": "daa14381-82d5-5a59-81ba-ad057ae15f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46c03ac-5efb-4d5d-9987-aa5e4da0a9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46c03ac-5efb-4d5d-9987-aa5e4da0a9c4.jpg?1",
             "name": "Imp's Mischief",
             "text": "Change the target of target spell with a single target. You lose life equal to that spell's mana value.",
             "colours": [
@@ -18117,7 +18117,7 @@
         },
         {
             "id": "261277de-b881-59b4-a0aa-d5269da56c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a495624a-2877-4e04-89da-9ef52569b7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a495624a-2877-4e04-89da-9ef52569b7c6.jpg?1",
             "name": "Kindred Dominance",
             "text": "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
             "colours": [
@@ -18151,7 +18151,7 @@
         },
         {
             "id": "f08e9fdd-bac1-5bc5-9121-da5008563be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e40f1c-e67e-4c21-8704-f6b723771bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e40f1c-e67e-4c21-8704-f6b723771bf3.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -18191,7 +18191,7 @@
         },
         {
             "id": "2d169a4f-70fd-506a-99a2-200071fbe633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf7f29-c53a-4567-aa13-ea0e3ad8f857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf7f29-c53a-4567-aa13-ea0e3ad8f857.jpg?1",
             "name": "Ob Nixilis of the Black Oath",
             "text": "+2: Each opponent loses 1 life. You gain life equal to the life lost this way.\n\u22122: Create a 5/5 black Demon creature token with flying. You lose 2 life.\n\u22128: You get an emblem with \"{1}{B}, Sacrifice a creature: You gain X life and draw X cards, where X is the sacrificed creature's power.\"\nOb Nixilis of the Black Oath can be your commander.",
             "colours": [
@@ -18228,7 +18228,7 @@
         },
         {
             "id": "0ab84ae3-281b-559e-9305-7fd9e10c5a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f88ed-b3bb-4cdf-a9dd-2ef79a84fd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f88ed-b3bb-4cdf-a9dd-2ef79a84fd29.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -18264,7 +18264,7 @@
         },
         {
             "id": "dd28adea-38d9-51e2-8aad-9b9a809ee6c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e793c0f-22f9-4ed5-9fb8-bd29f540ee7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e793c0f-22f9-4ed5-9fb8-bd29f540ee7c.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "Flying, haste\nWhenever Rankle, Master of Pranks deals combat damage to a player, choose any number \u2014\n\u2022 Each player discards a card.\n\u2022 Each player loses 1 life and draws a card.\n\u2022 Each player sacrifices a creature.",
             "colours": [
@@ -18302,7 +18302,7 @@
         },
         {
             "id": "67fc6663-3658-574b-b9f9-21e50523decd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411091f6-45c3-4d7e-a7a6-4c65e4571c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411091f6-45c3-4d7e-a7a6-4c65e4571c11.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "Flying, trample\nPay 2 life, Sacrifice another creature: Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -18339,7 +18339,7 @@
         },
         {
             "id": "5da29731-ff5c-5ad8-a4b3-0a40705dc4e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248db43d-8432-47c9-ab01-ce476377cdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248db43d-8432-47c9-ab01-ce476377cdb3.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -18374,7 +18374,7 @@
         },
         {
             "id": "b7212092-c02c-5827-b351-fc3c900ab226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa4b610-f138-4383-acf4-c4170648022c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa4b610-f138-4383-acf4-c4170648022c.jpg?1",
             "name": "Sower of Discord",
             "text": "Flying\nAs Sower of Discord enters the battlefield, choose two players.\nWhenever damage is dealt to one of the chosen players, the other chosen player also loses that much life.",
             "colours": [
@@ -18409,7 +18409,7 @@
         },
         {
             "id": "8c0b270e-1510-500a-b8ee-9eef054b9b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7c713e-0ec3-44c8-8643-dba5a130d6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7c713e-0ec3-44c8-8643-dba5a130d6b0.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -18442,7 +18442,7 @@
         },
         {
             "id": "cab85137-5f4e-5ef1-af09-17eaf29b0ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbb9ce0-8701-4400-8569-642ce5a0dbff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbb9ce0-8701-4400-8569-642ce5a0dbff.jpg?1",
             "name": "Twilight Prophet",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, if you have the city's blessing, reveal the top card of your library and put it into your hand. Each opponent loses X life and you gain X life, where X is that card's mana value.",
             "colours": [
@@ -18478,7 +18478,7 @@
         },
         {
             "id": "a06a3b13-acb5-55e8-8f22-0577f442aee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd338362-b793-431f-9a03-84693ec45883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd338362-b793-431f-9a03-84693ec45883.jpg?1",
             "name": "Vindictive Lich",
             "text": "When Vindictive Lich dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent sacrifices a creature.\n\u2022 Target opponent discards two cards.\n\u2022 Target opponent loses 5 life.",
             "colours": [
@@ -18514,7 +18514,7 @@
         },
         {
             "id": "c99e6976-4531-55f6-8ee4-eecd78cd9e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9baedc-84ea-43ef-877d-f88209bb3fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9baedc-84ea-43ef-877d-f88209bb3fba.jpg?1",
             "name": "Wake the Dead",
             "text": "Cast this spell only during combat on an opponent's turn.\nReturn X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step.",
             "colours": [
@@ -18547,7 +18547,7 @@
         },
         {
             "id": "0658653b-dc74-5d5a-8b0e-5549ca502139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800bfbbe-9d63-49f9-8e19-793afb1c29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800bfbbe-9d63-49f9-8e19-793afb1c29c2.jpg?1",
             "name": "Wretched Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target creature gets -2/-2 until end of turn.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -18580,7 +18580,7 @@
         },
         {
             "id": "522b8709-6788-5be1-81b9-628f223802fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b0e93-b8ae-49b3-9ddb-c1b66313c535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b0e93-b8ae-49b3-9ddb-c1b66313c535.jpg?1",
             "name": "Ashling the Pilgrim",
             "text": "{1}{R}: Put a +1/+1 counter on Ashling the Pilgrim. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling the Pilgrim, and it deals that much damage to each creature and each player.",
             "colours": [
@@ -18618,7 +18618,7 @@
         },
         {
             "id": "83d5d774-c5e4-5f83-87e5-2fbdcb0f647c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831b5124-e5cf-463d-b58e-f03b63ce495b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831b5124-e5cf-463d-b58e-f03b63ce495b.jpg?1",
             "name": "Avatar of Slaughter",
             "text": "All creatures have double strike and attack each combat if able.",
             "colours": [
@@ -18653,7 +18653,7 @@
         },
         {
             "id": "14c3a714-3d49-52d8-a952-60bed649aba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc65edbb-9690-4dd9-8542-10419729b92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc65edbb-9690-4dd9-8542-10419729b92a.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -18689,7 +18689,7 @@
         },
         {
             "id": "2f668c0a-63cf-5925-8e80-0800e231ee09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e32a0f-a9ce-4c0e-a305-bf3fa783ce4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e32a0f-a9ce-4c0e-a305-bf3fa783ce4f.jpg?1",
             "name": "Daretti, Scrap Savant",
             "text": "+2: Discard up to two cards, then draw that many cards.\n\u22122: Sacrifice an artifact. If you do, return target artifact card from your graveyard to the battlefield.\n\u221210: You get an emblem with \"Whenever an artifact is put into your graveyard from the battlefield, return that card to the battlefield at the beginning of the next end step.\"\nDaretti, Scrap Savant can be your commander.",
             "colours": [
@@ -18726,7 +18726,7 @@
         },
         {
             "id": "7e976ebb-95b4-549c-ae59-b16f5d2425d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a7ae1-467c-4eca-9ce2-39692804e492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a7ae1-467c-4eca-9ce2-39692804e492.jpg?1",
             "name": "Deflecting Swat",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nYou may choose new targets for target spell or ability.",
             "colours": [
@@ -18760,7 +18760,7 @@
         },
         {
             "id": "b905e0eb-f35d-56a9-828e-8f4a6775cb4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165796ce-6f0c-4af6-bb0c-a8b1160e0a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165796ce-6f0c-4af6-bb0c-a8b1160e0a76.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -18794,7 +18794,7 @@
         },
         {
             "id": "530e2aff-f50e-5feb-99b6-6cfb0341bd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86b6e0-782c-49ce-8c99-133eb9192572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86b6e0-782c-49ce-8c99-133eb9192572.jpg?1",
             "name": "Divergent Transformations",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nExile two target creatures. For each of those creatures, its controller reveals cards from the top of their library until they reveal a creature card, puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -18827,7 +18827,7 @@
         },
         {
             "id": "c8d2a5c5-bc0e-5433-98f3-bf4a8748aedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34ec655-4210-4237-92e4-c9adf207e2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34ec655-4210-4237-92e4-c9adf207e2e0.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -18864,7 +18864,7 @@
         },
         {
             "id": "f2fbcbf5-e74b-52d0-aea0-a3dd5623f09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01299fc5-6143-47ab-a63d-f3f1fe21de10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01299fc5-6143-47ab-a63d-f3f1fe21de10.jpg?1",
             "name": "Fiery Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Fiery Confluence deals 1 damage to each creature.\n\u2022 Fiery Confluence deals 2 damage to each opponent.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -18897,7 +18897,7 @@
         },
         {
             "id": "6c5ef5e8-797b-5114-a4e4-0282e57d6aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d51f68-c5b7-4304-b777-97bf7df0492c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d51f68-c5b7-4304-b777-97bf7df0492c.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card, put it onto the battlefield, then shuffle.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -18935,7 +18935,7 @@
         },
         {
             "id": "3387fed6-250a-580e-b3e8-9f295158590c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c73420-c36c-4bec-8ea9-192552fc5e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c73420-c36c-4bec-8ea9-192552fc5e4c.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "Whenever a creature you control deals combat damage to a player, choose one \u2014\n\u2022 Goad target creature that player controls.\n\u2022 Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -18974,7 +18974,7 @@
         },
         {
             "id": "3ab3fb5e-1260-56f1-9d78-237e12dfcee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe4a513-3e64-4452-aff6-b990ece58f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe4a513-3e64-4452-aff6-b990ece58f38.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "{T}: Heartless Hidetsugu deals damage to each player equal to half that player's life total, rounded down.",
             "colours": [
@@ -19012,7 +19012,7 @@
         },
         {
             "id": "efe632c1-e2af-5c25-9fc4-fd870f7f51f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95300918-0273-4066-9a58-38ca77fc8b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95300918-0273-4066-9a58-38ca77fc8b5a.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -19047,7 +19047,7 @@
         },
         {
             "id": "618f05c2-ed78-522f-bdf8-ea87c4435b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31adaa1-6211-4bd3-9705-6dead01597d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31adaa1-6211-4bd3-9705-6dead01597d0.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -19082,7 +19082,7 @@
         },
         {
             "id": "0f5c8f32-0734-5829-a30b-e55325afa590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129ac8-4f35-4372-95e4-bde2ce62c189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129ac8-4f35-4372-95e4-bde2ce62c189.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -19116,7 +19116,7 @@
         },
         {
             "id": "8459b065-732b-5672-98dc-723d4108f75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae883514-2e5f-4ea3-bccc-3c475f70121a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae883514-2e5f-4ea3-bccc-3c475f70121a.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -19154,7 +19154,7 @@
         },
         {
             "id": "64721cc9-8da6-5248-9a42-29fa3bb97cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fef3784-5890-4e91-a881-a6be888f9b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fef3784-5890-4e91-a881-a6be888f9b90.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards their hand, then draws seven cards.",
             "colours": [
@@ -19191,7 +19191,7 @@
         },
         {
             "id": "0efe1fb6-97d3-530d-9b5a-d2ba79a4dbe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb971063-5415-49d5-87c2-9ff4e88c71e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb971063-5415-49d5-87c2-9ff4e88c71e1.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -19232,7 +19232,7 @@
         },
         {
             "id": "39f0f138-76f0-54e4-9285-63b3b4ed8f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44217db3-5fd8-4bb1-b004-60d8b179e5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44217db3-5fd8-4bb1-b004-60d8b179e5f4.jpg?1",
             "name": "Nesting Dragon",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, create a 0/2 red Dragon Egg creature token with defender and \"When this creature dies, create a 2/2 red Dragon creature token with flying and \u2018{R}: This creature gets +1/+0 until end of turn.'\"",
             "colours": [
@@ -19267,7 +19267,7 @@
         },
         {
             "id": "d608b768-7898-5bbf-98a8-66a46db4d8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf0b1b-bf8b-4dba-8ea9-5b6480897323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf0b1b-bf8b-4dba-8ea9-5b6480897323.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -19305,7 +19305,7 @@
         },
         {
             "id": "426a5e13-95f6-5f55-ac61-1fbcaca3090c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c85575a-8a56-4ce2-8ca9-7b404408dcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c85575a-8a56-4ce2-8ca9-7b404408dcc5.jpg?1",
             "name": "Savage Beating",
             "text": "Cast this spell only during your turn and only during combat.\nChoose one \u2014\n\u2022 Creatures you control gain double strike until end of turn.\n\u2022 Untap all creatures you control. After this phase, there is an additional combat phase.\nEntwine {1}{R}",
             "colours": [
@@ -19338,7 +19338,7 @@
         },
         {
             "id": "6597de4b-4d40-5d42-a438-e963037b91b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505efa34-72ff-4ecd-a662-7fbb5a86321f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505efa34-72ff-4ecd-a662-7fbb5a86321f.jpg?1",
             "name": "Scourge of the Throne",
             "text": "Flying\nDethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nWhenever Scourge of the Throne attacks for the first time each turn, if it's attacking the player with the most life or tied for most life, untap all attacking creatures. After this phase, there is an additional combat phase.",
             "colours": [
@@ -19373,7 +19373,7 @@
         },
         {
             "id": "835974fa-cadd-56f8-81c2-146d0b4589e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c516be1-ecdf-469f-9d7f-3eeeed962777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c516be1-ecdf-469f-9d7f-3eeeed962777.jpg?1",
             "name": "Star of Extinction",
             "text": "Destroy target land. Star of Extinction deals 20 damage to each creature and each planeswalker.",
             "colours": [
@@ -19406,7 +19406,7 @@
         },
         {
             "id": "eb6f59f0-a46a-5283-8ba2-6ecf3487ee36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc2ebdd-aec1-49f0-89c9-1008abfd999b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc2ebdd-aec1-49f0-89c9-1008abfd999b.jpg?1",
             "name": "Tempt with Vengeance",
             "text": "Tempting offer \u2014 Create X 1/1 red Elemental creature tokens with haste. Each opponent may create X 1/1 red Elemental creature tokens with haste. For each opponent who does, create X 1/1 red Elemental creature tokens with haste.",
             "colours": [
@@ -19439,7 +19439,7 @@
         },
         {
             "id": "bba256d0-e2aa-5f88-8941-bd23bae9ec1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77e0e6-b79e-4950-8011-10a37d6e84a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77e0e6-b79e-4950-8011-10a37d6e84a2.jpg?1",
             "name": "Treasure Nabber",
             "text": "Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.",
             "colours": [
@@ -19476,7 +19476,7 @@
         },
         {
             "id": "89c7b358-5b16-5d04-a7ba-eed2dc3b4aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df244eab-9631-4c84-b8d6-0f62ace60b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df244eab-9631-4c84-b8d6-0f62ace60b83.jpg?1",
             "name": "Arachnogenesis",
             "text": "Create X 1/2 green Spider creature tokens with reach, where X is the number of creatures attacking you. Prevent all combat damage that would be dealt this turn by non-Spider creatures.",
             "colours": [
@@ -19510,7 +19510,7 @@
         },
         {
             "id": "fefcec91-fd44-5326-a16c-3ed7c79be3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeb09a-8782-4390-840e-9b1b5c02f319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeb09a-8782-4390-840e-9b1b5c02f319.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -19549,7 +19549,7 @@
         },
         {
             "id": "b5aab904-2655-57f3-aa07-eb16198c48ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e07f2a-ca6f-4f56-b251-ef5ab1ee0146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e07f2a-ca6f-4f56-b251-ef5ab1ee0146.jpg?1",
             "name": "Bloodspore Thrinax",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nEach other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on Bloodspore Thrinax.",
             "colours": [
@@ -19584,7 +19584,7 @@
         },
         {
             "id": "63b75d51-338f-57e9-ab6e-c1363634a78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f9ba6-6bd1-4be8-b584-f67308e8c60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f9ba6-6bd1-4be8-b584-f67308e8c60d.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -19619,7 +19619,7 @@
         },
         {
             "id": "144bffdb-9667-579d-ab23-7b6531c4eed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f161997-ef21-4e90-b373-1d9e4402bf21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f161997-ef21-4e90-b373-1d9e4402bf21.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -19652,7 +19652,7 @@
         },
         {
             "id": "8255e540-f5c9-5210-8e98-d2d8ca394bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f07cc-eea4-4ad7-aabf-dab090327cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f07cc-eea4-4ad7-aabf-dab090327cbe.jpg?1",
             "name": "Ezuri's Predation",
             "text": "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures.",
             "colours": [
@@ -19685,7 +19685,7 @@
         },
         {
             "id": "01359a41-06e6-5262-9fd0-ccad985803a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ebbacf-4caf-47e5-8ce1-3b02b447ba7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ebbacf-4caf-47e5-8ce1-3b02b447ba7a.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -19719,7 +19719,7 @@
         },
         {
             "id": "acc714cc-b5f9-5589-96c4-30645c15a2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6160f7-00da-453b-a161-cb06a40b0b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6160f7-00da-453b-a161-cb06a40b0b62.jpg?1",
             "name": "Freyalise, Llanowar's Fury",
             "text": "+2: Create a 1/1 green Elf Druid creature token with \"{T}: Add {G}.\"\n\u22122: Destroy target artifact or enchantment.\n\u22126: Draw a card for each green creature you control.\nFreyalise, Llanowar's Fury can be your commander.",
             "colours": [
@@ -19756,7 +19756,7 @@
         },
         {
             "id": "f7750054-6efc-51bb-938e-52856de9587c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbd1d5-f0b1-4656-ad17-50b664230415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbd1d5-f0b1-4656-ad17-50b664230415.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -19794,7 +19794,7 @@
         },
         {
             "id": "ab206ddf-3138-5e53-a466-10e7dcffe971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1921b08-a3b3-422d-a82d-49af9149aee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1921b08-a3b3-422d-a82d-49af9149aee7.jpg?1",
             "name": "The Great Henge",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\n{T}: Add {G}{G}. You gain 2 life.\nWhenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.",
             "colours": [
@@ -19829,7 +19829,7 @@
         },
         {
             "id": "492c85f1-2e8c-51c5-9fe3-6dc6559081c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5c1e29-4b8e-4783-8bc7-163670face9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5c1e29-4b8e-4783-8bc7-163670face9d.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -19862,7 +19862,7 @@
         },
         {
             "id": "a1b1133b-3baf-50ec-b5ac-7c8ccd960638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cc65b2-4b31-40d7-8ea9-5435b6f5d4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cc65b2-4b31-40d7-8ea9-5435b6f5d4b5.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -19900,7 +19900,7 @@
         },
         {
             "id": "190681d2-4e50-5a4a-bdc9-72bd442e6ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b51f51-45ee-4b73-9550-c1104b0eb628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b51f51-45ee-4b73-9550-c1104b0eb628.jpg?1",
             "name": "Lifeblood Hydra",
             "text": "Trample\nLifeblood Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Lifeblood Hydra dies, you gain life and draw cards equal to its power.",
             "colours": [
@@ -19935,7 +19935,7 @@
         },
         {
             "id": "7ba54306-9e86-57e8-9acb-ab8b0cb97eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b12bb2e-3c75-4f23-a931-1735a28d954a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b12bb2e-3c75-4f23-a931-1735a28d954a.jpg?1",
             "name": "Obscuring Haze",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nPrevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -19969,7 +19969,7 @@
         },
         {
             "id": "2866c61f-2a51-50a4-a3c1-3a584f6f4ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08736a3-2a53-45c0-8ede-5207ffbea32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08736a3-2a53-45c0-8ede-5207ffbea32c.jpg?1",
             "name": "Ohran Frostfang",
             "text": "Attacking creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -20007,7 +20007,7 @@
         },
         {
             "id": "7b0ebed9-445e-553f-8211-9adb61f34779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f725636-8947-4232-a2fb-5c85d7fbcd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f725636-8947-4232-a2fb-5c85d7fbcd1b.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -20046,7 +20046,7 @@
         },
         {
             "id": "da356044-788a-5a0d-8598-f1f9b729df1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017c271-6c8d-4f4d-9507-f79ffc265376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017c271-6c8d-4f4d-9507-f79ffc265376.jpg?1",
             "name": "Regal Behemoth",
             "text": "Trample\nWhen Regal Behemoth enters the battlefield, you become the monarch.\nWhenever you tap a land for mana while you're the monarch, add an additional one mana of any color.",
             "colours": [
@@ -20082,7 +20082,7 @@
         },
         {
             "id": "11f7c426-6e1b-50e4-9fe8-6276d28d8633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c703c7de-4d20-4921-880b-da7d0f986164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c703c7de-4d20-4921-880b-da7d0f986164.jpg?1",
             "name": "Sakiko, Mother of Summer",
             "text": "Whenever a creature you control deals combat damage to a player, add that much {G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -20120,7 +20120,7 @@
         },
         {
             "id": "628e5170-d7ea-5857-bdd9-c0767fdf36a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc3323f-cdc7-4368-9ab9-ce8a41085bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc3323f-cdc7-4368-9ab9-ce8a41085bca.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -20160,7 +20160,7 @@
         },
         {
             "id": "eb418969-2a0c-5b32-a88a-ceb0b03f9db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce1130c-fc27-4508-a621-5d720a4df4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce1130c-fc27-4508-a621-5d720a4df4ea.jpg?1",
             "name": "Song of the Dryads",
             "text": "Enchant permanent\nEnchanted permanent is a colorless Forest land.",
             "colours": [
@@ -20195,7 +20195,7 @@
         },
         {
             "id": "63ab07c1-302e-5a10-9501-48f9da4d9f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7560722-3481-4866-a86d-5df837e30d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7560722-3481-4866-a86d-5df837e30d43.jpg?1",
             "name": "Stonehoof Chieftain",
             "text": "Trample, indestructible\nWhenever another creature you control attacks, it gains trample and indestructible until end of turn.",
             "colours": [
@@ -20231,7 +20231,7 @@
         },
         {
             "id": "fa211ca3-520f-588a-ba26-cd5e7d1a80f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39691b12-9a01-46a1-bbb7-458a79a4f115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39691b12-9a01-46a1-bbb7-458a79a4f115.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014\n\u2022 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n\u2022 Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -20265,7 +20265,7 @@
         },
         {
             "id": "f9feeb24-4206-573a-8e3f-fa908489400c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa64560b-773c-4a93-b28d-cf317c78da09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa64560b-773c-4a93-b28d-cf317c78da09.jpg?1",
             "name": "Verdant Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Return target permanent card from your graveyard to your hand.\n\u2022 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -20298,7 +20298,7 @@
         },
         {
             "id": "0574a7f9-d606-5092-8c81-e596afb6f2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abbe-871e-468c-8d37-fc0de030d735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abbe-871e-468c-8d37-fc0de030d735.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.",
             "colours": [
@@ -20333,7 +20333,7 @@
         },
         {
             "id": "410fe4ac-9da8-503a-b53d-c40041f8c2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a76f047-0143-4485-bb37-3a0159f4d5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a76f047-0143-4485-bb37-3a0159f4d5fa.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "{2}{G}, {T}, Put a verse counter on Yisan, the Wanderer Bard: Search your library for a creature card with mana value equal to the number of verse counters on Yisan, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -20372,7 +20372,7 @@
         },
         {
             "id": "9b74c8d4-0d15-5e15-92e0-ce90a014e6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3827786f-c47b-409b-998f-1f3fee8e5eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3827786f-c47b-409b-998f-1f3fee8e5eca.jpg?1",
             "name": "Experiment Kraj",
             "text": "Experiment Kraj has all activated abilities of each other creature with a +1/+1 counter on it.\n{T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -20412,7 +20412,7 @@
         },
         {
             "id": "57cd427d-221a-5397-b8c6-e3eb7dfd908d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eab50d6-8282-445b-8fd7-64ce52554a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eab50d6-8282-445b-8fd7-64ce52554a06.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -20452,7 +20452,7 @@
         },
         {
             "id": "f37d7f4d-e128-52af-ae40-4ae718b93ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbe7958-0647-4c89-bbb3-939124423c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbe7958-0647-4c89-bbb3-939124423c19.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -20492,7 +20492,7 @@
         },
         {
             "id": "a0b32d9c-4a35-51c0-b808-ad35e6bfd8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a008a-df2e-438d-9bdf-a7d007179372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a008a-df2e-438d-9bdf-a7d007179372.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -20534,7 +20534,7 @@
         },
         {
             "id": "1f2bf70d-a614-5d2f-bef7-3e55c3fdbaa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8cf137-49a9-4705-b0ae-5cb42e0778a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8cf137-49a9-4705-b0ae-5cb42e0778a4.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -20577,7 +20577,7 @@
         },
         {
             "id": "1ed20728-7561-5016-848b-990339114e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4178d93f-72fa-43a1-b6aa-35f1b4a597a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4178d93f-72fa-43a1-b6aa-35f1b4a597a7.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -20619,7 +20619,7 @@
         },
         {
             "id": "d0fd0961-6694-5d21-9ce4-1b239182d693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4bd2d3-ab54-432a-b617-247771b9c22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4bd2d3-ab54-432a-b617-247771b9c22b.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "Whenever another creature you control dies, you get an experience counter.\nAt the beginning of your end step, choose target creature card in your graveyard. If that card's mana value is less than or equal to the number of experience counters you have, return it to the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -20660,7 +20660,7 @@
         },
         {
             "id": "3f603149-cc27-55df-b24d-a4930f8b572a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8c051d-3ff7-478c-89af-3691610c0adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8c051d-3ff7-478c-89af-3691610c0adf.jpg?1",
             "name": "Mirri, Weatherlight Duelist",
             "text": "First strike\nWhenever Mirri, Weatherlight Duelist attacks, each opponent can't block with more than one creature this combat.\nAs long as Mirri, Weatherlight Duelist is tapped, no more than one creature can attack you each combat.",
             "colours": [
@@ -20700,7 +20700,7 @@
         },
         {
             "id": "356efd14-aa92-508e-a41d-20d7a54b9bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c74-6aec-4d66-b9ff-7270ce27920f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c74-6aec-4d66-b9ff-7270ce27920f.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -20740,7 +20740,7 @@
         },
         {
             "id": "0266043b-60d8-512c-8369-e6a4c0a088e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4df0f7-68c4-48e4-adc9-32d2af9dc206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4df0f7-68c4-48e4-adc9-32d2af9dc206.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nWhenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",
             "colours": [
@@ -20782,7 +20782,7 @@
         },
         {
             "id": "4ac2ac2a-40a6-5b13-a415-65a474757aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a626cee3-156f-4f5f-990d-4309f3a94d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a626cee3-156f-4f5f-990d-4309f3a94d7a.jpg?1",
             "name": "Queen Marchesa",
             "text": "Deathtouch, haste\nWhen Queen Marchesa enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with deathtouch and haste.",
             "colours": [
@@ -20824,7 +20824,7 @@
         },
         {
             "id": "a9735926-8bfb-5b14-ab5b-1b77d39bfd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361087ea-16f9-4d93-b720-1ebaa05bc281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361087ea-16f9-4d93-b720-1ebaa05bc281.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -20866,7 +20866,7 @@
         },
         {
             "id": "7992fee5-8c8c-53b2-b79f-7d134b4db281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff8244-ec3b-41bd-a007-bbd403a96e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff8244-ec3b-41bd-a007-bbd403a96e96.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -20905,7 +20905,7 @@
         },
         {
             "id": "58710689-7b14-5afc-a917-1afd645c9c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d86df-388d-421d-b904-d563e81727ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d86df-388d-421d-b904-d563e81727ad.jpg?1",
             "name": "Sek'Kuar, Deathkeeper",
             "text": "Whenever another nontoken creature you control dies, create a 3/1 black and red Graveborn creature token with haste.",
             "colours": [
@@ -20947,7 +20947,7 @@
         },
         {
             "id": "ab18b3d8-d0b3-530d-a9cc-20e0bc8a86e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc3be0-6159-4cda-8785-b0bec7f4b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc3be0-6159-4cda-8785-b0bec7f4b69f.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -20989,7 +20989,7 @@
         },
         {
             "id": "3354747a-e4f7-5b66-a5eb-8d4f31a59c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385001c7-b39d-4654-9f6e-8d31ade506a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385001c7-b39d-4654-9f6e-8d31ade506a1.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -21030,7 +21030,7 @@
         },
         {
             "id": "572fcaf0-38c9-5f09-a48b-f377d18b9925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0192cd-9c14-4f24-bc31-febfb135f707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0192cd-9c14-4f24-bc31-febfb135f707.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -21078,7 +21078,7 @@
         },
         {
             "id": "0ac8e62f-9308-5936-b519-02b4c6ff73a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b87861-6262-4be4-9995-9016bca4fb6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b87861-6262-4be4-9995-9016bca4fb6e.jpg?1",
             "name": "Xantcha, Sleeper Agent",
             "text": "Xantcha, Sleeper Agent enters the battlefield under the control of an opponent of your choice.\nXantcha attacks each combat if able and can't attack its owner or planeswalkers its owner controls.\n{3}: Xantcha's controller loses 2 life and you draw a card. Any player may activate this ability.",
             "colours": [
@@ -21118,7 +21118,7 @@
         },
         {
             "id": "a46cd09d-8424-5fbb-b872-1257332e03f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4484804-a98d-440c-bb67-07714de2bef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4484804-a98d-440c-bb67-07714de2bef3.jpg?1",
             "name": "Yennett, Cryptic Sovereign",
             "text": "Flying, vigilance, menace\nWhenever Yennett, Cryptic Sovereign attacks, reveal the top card of your library. You may cast it without paying its mana cost if its mana value is odd. If you don't cast it, draw a card.",
             "colours": [
@@ -21159,7 +21159,7 @@
         },
         {
             "id": "025a5abb-a07a-50da-8b88-11a700a22177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f058f8e8-aa01-4dc0-a6a5-0490521b83d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f058f8e8-aa01-4dc0-a6a5-0490521b83d4.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's mana value.",
             "colours": [
@@ -21200,7 +21200,7 @@
         },
         {
             "id": "c2d78a88-cf0f-52e8-a0c5-7f02f1eba1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98c92cc-44c7-4555-8832-98c5b526c43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98c92cc-44c7-4555-8832-98c5b526c43a.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -21243,7 +21243,7 @@
         },
         {
             "id": "86ec5053-1eb0-55c3-b32d-b9e029253f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd12285b-12f8-42f5-bff1-2b66c4f5c568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd12285b-12f8-42f5-bff1-2b66c4f5c568.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "Trample\nLethal damage dealt to creatures you control is determined by their power rather than their toughness.",
             "colours": [
@@ -21282,7 +21282,7 @@
         },
         {
             "id": "c7dfe00d-5136-5047-b1f0-be1205bea62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac12f5-5198-447e-ac67-fdc4e876571d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac12f5-5198-447e-ac67-fdc4e876571d.jpg?1",
             "name": "Boompile",
             "text": "{T}: Flip a coin. If you win the flip, destroy all nonland permanents.",
             "colours": [],
@@ -21311,7 +21311,7 @@
         },
         {
             "id": "3ad7fa28-edc2-5a24-993d-d092aaabce27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5758df-adf9-4d78-8fae-d300a20a49a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5758df-adf9-4d78-8fae-d300a20a49a6.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -21343,7 +21343,7 @@
         },
         {
             "id": "a4f69fa3-b78e-59ba-bc74-5c0d9a643f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc68acfb-758d-4466-b4f2-c12ce2d8b6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc68acfb-758d-4466-b4f2-c12ce2d8b6d8.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
             "colours": [],
@@ -21372,7 +21372,7 @@
         },
         {
             "id": "949bb0f2-aae3-519b-9b2c-8ffe99308ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d53713-c489-4f77-96d6-c499fd6161d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d53713-c489-4f77-96d6-c499fd6161d6.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21401,7 +21401,7 @@
         },
         {
             "id": "7f476efd-a1ba-5997-888a-102b2fce3146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ec784-8c10-49f5-831b-309c383be4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ec784-8c10-49f5-831b-309c383be4ca.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint \u2014 When Extraplanar Lens enters the battlefield, you may exile target land you control.\nWhenever a land with the same name as the exiled card is tapped for mana, its controller adds one mana of any type that land produced.",
             "colours": [],
@@ -21431,7 +21431,7 @@
         },
         {
             "id": "0402b90b-778a-5483-b21e-8089eafdce7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929ec761-fcc6-473d-b160-0feff6cdf7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929ec761-fcc6-473d-b160-0feff6cdf7d0.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -21460,7 +21460,7 @@
         },
         {
             "id": "2cc9856d-ca56-539b-8bbe-9067e2490167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe0ad2c-9553-4f55-8e8a-f593971bf601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe0ad2c-9553-4f55-8e8a-f593971bf601.jpg?1",
             "name": "Hammer of Nazahn",
             "text": "Whenever Hammer of Nazahn or another Equipment enters the battlefield under your control, you may attach that Equipment to target creature you control.\nEquipped creature gets +2/+0 and has indestructible.\nEquip {4}",
             "colours": [],
@@ -21493,7 +21493,7 @@
         },
         {
             "id": "6ba1443b-fe35-5a31-85e4-d089b3c55d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a4b5-cdec-47bb-824f-4390abe832d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a4b5-cdec-47bb-824f-4390abe832d0.jpg?1",
             "name": "Idol of Oblivion",
             "text": "{T}: Draw a card. Activate only if you created a token this turn.\n{8}, {T}, Sacrifice Idol of Oblivion: Create a 10/10 colorless Eldrazi creature token.",
             "colours": [],
@@ -21522,7 +21522,7 @@
         },
         {
             "id": "79e9a505-77bf-59a1-b27d-0c9e69b32000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ae427-a727-48cb-9398-886b1dbd477c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ae427-a727-48cb-9398-886b1dbd477c.jpg?1",
             "name": "The Immortal Sun",
             "text": "Players can't activate planeswalkers' loyalty abilities.\nAt the beginning of your draw step, draw an additional card.\nSpells you cast cost {1} less to cast.\nCreatures you control get +1/+1.",
             "colours": [],
@@ -21553,7 +21553,7 @@
         },
         {
             "id": "8a761b7f-dbe2-5e0b-8268-1dc1ac88c817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae2050-764d-49aa-83db-aca6a46e4e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae2050-764d-49aa-83db-aca6a46e4e6f.jpg?1",
             "name": "Inspiring Statuary",
             "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -21582,7 +21582,7 @@
         },
         {
             "id": "d09a2865-0e13-5142-a118-e909bf7fa552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3469311-29a0-42bc-8643-70a961d24c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3469311-29a0-42bc-8643-70a961d24c23.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21611,7 +21611,7 @@
         },
         {
             "id": "7dc7f659-6dd5-5569-a106-ba331367c3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af70720-ba91-41b0-ba4a-ff2035afdb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af70720-ba91-41b0-ba4a-ff2035afdb0e.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -21642,7 +21642,7 @@
         },
         {
             "id": "6e3db26f-83da-5a4e-a934-a9726324afc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eec8c7-0391-4d9d-a388-d4bbd11abf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eec8c7-0391-4d9d-a388-d4bbd11abf03.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21671,7 +21671,7 @@
         },
         {
             "id": "e501c976-252b-5f6d-86d9-c680aaca18a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f58a480-1b01-4974-b859-2d6b6bfce463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f58a480-1b01-4974-b859-2d6b6bfce463.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21700,7 +21700,7 @@
         },
         {
             "id": "bb3b489e-3086-58f6-b68b-2d2de2eba279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af60a5d2-d8e9-4fea-9edc-1fbe6dd190a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af60a5d2-d8e9-4fea-9edc-1fbe6dd190a9.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21729,7 +21729,7 @@
         },
         {
             "id": "7fb44c0c-9b8a-5906-9e24-6c9c53f1e5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1b6402-c054-4dd5-a9d5-3d218270e8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1b6402-c054-4dd5-a9d5-3d218270e8ba.jpg?1",
             "name": "Scytheclaw",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, that player loses half their life, rounded up.\nEquip {3}",
             "colours": [],
@@ -21760,7 +21760,7 @@
         },
         {
             "id": "93d9bbc0-1e6a-5ba4-af38-f081388d23e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01048220-cef3-47ee-8d68-d01d324ad8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01048220-cef3-47ee-8d68-d01d324ad8af.jpg?1",
             "name": "Sword of the Animist",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nEquip {2}",
             "colours": [],
@@ -21793,7 +21793,7 @@
         },
         {
             "id": "7aeec5f2-67cf-5730-97e7-db154186c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaabadb6-fa93-4128-af87-1803e4b33040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaabadb6-fa93-4128-af87-1803e4b33040.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -21826,7 +21826,7 @@
         },
         {
             "id": "2c5fac9c-debd-5e37-ac26-29c1e28b8038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad21db5-5189-4d57-b399-0d1c415c0922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad21db5-5189-4d57-b399-0d1c415c0922.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -21859,7 +21859,7 @@
         },
         {
             "id": "2f2c44fa-03f3-52b4-9656-a970b15f153e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda58e50-9fce-46a6-989d-ee855e7369c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda58e50-9fce-46a6-989d-ee855e7369c3.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -21892,7 +21892,7 @@
         },
         {
             "id": "9d0c12e7-a614-51c7-b341-9315bf434284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a8afb-39f8-4e5a-88ca-2d8ad9ed4019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a8afb-39f8-4e5a-88ca-2d8ad9ed4019.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -21925,7 +21925,7 @@
         },
         {
             "id": "df681d9a-eab1-5682-858b-a43d64b6d099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f6c0a-5dad-4b9a-89cf-757c7e26e7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f6c0a-5dad-4b9a-89cf-757c7e26e7c4.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -21958,7 +21958,7 @@
         },
         {
             "id": "45d418cc-7d3c-5286-9a96-76efd8066db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b2bf55-6b24-4f63-bbb0-98471c167405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b2bf55-6b24-4f63-bbb0-98471c167405.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -21994,7 +21994,7 @@
         },
         {
             "id": "c7cfb1ee-675f-513b-b214-3503e2fe0c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08605ffa-de04-4831-a078-5b3d65c2526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08605ffa-de04-4831-a078-5b3d65c2526f.jpg?1",
             "name": "Darksteel Mutation",
             "text": "Enchant creature\nEnchanted creature is an Insect artifact creature with base power and toughness 0/1 and has indestructible, and it loses all other abilities, card types, and creature types.",
             "colours": [
@@ -22030,7 +22030,7 @@
         },
         {
             "id": "29e26b93-2a0c-54d1-bc5d-21cbaeeb4ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd4438-a25d-4618-9e93-2c62f6bfc5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd4438-a25d-4618-9e93-2c62f6bfc5f5.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -22064,7 +22064,7 @@
         },
         {
             "id": "7f93a84f-b52b-5337-86c4-c867aaf5622a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d28118-eddb-4ee3-a425-eadb1a1649a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d28118-eddb-4ee3-a425-eadb1a1649a8.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -22102,7 +22102,7 @@
         },
         {
             "id": "9a5d1d3b-484b-56a9-a812-ed242807b148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c2a76-b9f5-42f2-8652-dafa5bd132cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c2a76-b9f5-42f2-8652-dafa5bd132cb.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22136,7 +22136,7 @@
         },
         {
             "id": "f68050d1-1cc2-531b-9a53-6ca87b93780a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a89d111-1a7c-4446-9a53-99d5d68099cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a89d111-1a7c-4446-9a53-99d5d68099cf.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -22174,7 +22174,7 @@
         },
         {
             "id": "7c08caa3-2b34-5525-8ed3-995ad78b1af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba852b68-eeb7-4023-898c-0722a82d4cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba852b68-eeb7-4023-898c-0722a82d4cff.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -22208,7 +22208,7 @@
         },
         {
             "id": "c78fa4f0-c26b-5fe4-abee-a0457c491c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80b956-24a4-4b22-b483-4e3fc66b7662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80b956-24a4-4b22-b483-4e3fc66b7662.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -22243,7 +22243,7 @@
         },
         {
             "id": "e555abc7-47d6-5fed-b063-27b319b44b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e47212d-399e-4121-92d4-9fb0d85767cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e47212d-399e-4121-92d4-9fb0d85767cb.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -22277,7 +22277,7 @@
         },
         {
             "id": "430eb908-4e71-5dfc-9c7f-5dc63e513346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf26a2f-376e-4437-b2b4-78f8c512fb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf26a2f-376e-4437-b2b4-78f8c512fb13.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -22311,7 +22311,7 @@
         },
         {
             "id": "6a493cf1-2547-5971-a8f4-38a54b4137f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2a4ce-a44b-480b-b1a2-94fb2514c082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2a4ce-a44b-480b-b1a2-94fb2514c082.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -22345,7 +22345,7 @@
         },
         {
             "id": "a8a1b467-1a71-5154-afa2-a6f1382959db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c1fd2-ddb9-4454-ae24-de8e69437ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c1fd2-ddb9-4454-ae24-de8e69437ad1.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -22380,7 +22380,7 @@
         },
         {
             "id": "1396a2eb-6f2f-53e0-8bd7-725844c2f077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9fe9db-21c0-405b-b10e-11cb08e6a8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9fe9db-21c0-405b-b10e-11cb08e6a8fb.jpg?1",
             "name": "Reality Shift",
             "text": "Exile target creature. Its controller manifests the top card of their library.",
             "colours": [
@@ -22414,7 +22414,7 @@
         },
         {
             "id": "763add5a-8e48-5f95-85f8-d30743986ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2519c60-d0af-4df7-aa41-2624ce8af668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2519c60-d0af-4df7-aa41-2624ce8af668.jpg?1",
             "name": "Spellseeker",
             "text": "When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with mana value 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -22452,7 +22452,7 @@
         },
         {
             "id": "4b38949e-98c1-50f0-a9d3-2eba278774b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab9c69f-cb12-4095-af83-89319f00a3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab9c69f-cb12-4095-af83-89319f00a3fa.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension.\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -22487,7 +22487,7 @@
         },
         {
             "id": "10b3d66c-5392-51db-a257-cbf2c206c76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721aff76-9f80-4ec2-ae29-2dc8494a1a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721aff76-9f80-4ec2-ae29-2dc8494a1a06.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures.",
             "colours": [
@@ -22521,7 +22521,7 @@
         },
         {
             "id": "5d3fd16a-a936-5233-9923-0882df91bbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9bb677-6b9a-4ccf-accc-b1a91be85b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9bb677-6b9a-4ccf-accc-b1a91be85b70.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -22555,7 +22555,7 @@
         },
         {
             "id": "95550d09-78ac-5c2f-989e-a4d8a6c6f97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9d2a9b-daf2-4ebe-bb8c-0b1d4dfa9e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9d2a9b-daf2-4ebe-bb8c-0b1d4dfa9e35.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -22590,7 +22590,7 @@
         },
         {
             "id": "b325dc42-768c-5e3f-b7c2-029332c11821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada27732-0491-4c99-980d-2f3c3230f220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada27732-0491-4c99-980d-2f3c3230f220.jpg?1",
             "name": "Kindred Dominance",
             "text": "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
             "colours": [
@@ -22625,7 +22625,7 @@
         },
         {
             "id": "e842dba1-26c1-59c4-a8ea-b14bed6799f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0a988-5aee-4f4c-8efe-4c2a392702b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0a988-5aee-4f4c-8efe-4c2a392702b1.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -22662,7 +22662,7 @@
         },
         {
             "id": "b2eb3cc1-f5c9-568d-85be-ec8c40169e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65879a80-b656-412f-8b90-aa6d4f36a43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65879a80-b656-412f-8b90-aa6d4f36a43c.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R}",
             "colours": [
@@ -22696,7 +22696,7 @@
         },
         {
             "id": "847531bb-d26d-584a-aa56-d16a90c3b5fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d84eb6f-2675-436c-885e-207468110d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d84eb6f-2675-436c-885e-207468110d76.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards their hand, then draws seven cards.",
             "colours": [
@@ -22734,7 +22734,7 @@
         },
         {
             "id": "65620183-c8af-5177-8f31-01f183542d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c896fe-c208-41ec-aad8-fe56c7858942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c896fe-c208-41ec-aad8-fe56c7858942.jpg?1",
             "name": "Storm-Kiln Artist",
             "text": "Storm-Kiln Artist gets +1/+0 for each artifact you control.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a Treasure token.",
             "colours": [
@@ -22771,7 +22771,7 @@
         },
         {
             "id": "5067423e-74e4-52e3-9eb0-f9c554bf093f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9e634-1d92-4c5e-b371-593f695e48bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9e634-1d92-4c5e-b371-593f695e48bf.jpg?1",
             "name": "Treasure Nabber",
             "text": "Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.",
             "colours": [
@@ -22809,7 +22809,7 @@
         },
         {
             "id": "d0e9f6e8-09f6-5b0a-a910-21479128797e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd4b96-72d4-4eab-9a8d-90c8b3510250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd4b96-72d4-4eab-9a8d-90c8b3510250.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R}",
             "colours": [
@@ -22843,7 +22843,7 @@
         },
         {
             "id": "8e5475aa-b645-5b10-917e-fbeeadda7d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d3b29-ab35-4c61-82b8-bb5d481c738a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d3b29-ab35-4c61-82b8-bb5d481c738a.jpg?1",
             "name": "Arachnogenesis",
             "text": "Create X 1/2 green Spider creature tokens with reach, where X is the number of creatures attacking you. Prevent all combat damage that would be dealt this turn by non-Spider creatures.",
             "colours": [
@@ -22878,7 +22878,7 @@
         },
         {
             "id": "cde35dd3-ec4a-53fb-ac02-4a8445df874e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ba531-ab3b-4d00-af2c-2d4914c68cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ba531-ab3b-4d00-af2c-2d4914c68cd8.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -22915,7 +22915,7 @@
         },
         {
             "id": "3004378f-90c5-5906-9b21-c0109f2241b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0506e30-ed0d-4838-97b1-55900ad633b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0506e30-ed0d-4838-97b1-55900ad633b5.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -22951,7 +22951,7 @@
         },
         {
             "id": "f95fe532-f61a-5034-b96a-12f5de99a2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b5e975-bd75-4f7c-829d-e87f8b24bc2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b5e975-bd75-4f7c-829d-e87f8b24bc2f.jpg?1",
             "name": "Ohran Frostfang",
             "text": "Attacking creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -22990,7 +22990,7 @@
         },
         {
             "id": "580b4587-939d-5e98-9172-39e0fdb0cfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ff72b-30cf-44e8-a592-540a501589e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ff72b-30cf-44e8-a592-540a501589e8.jpg?1",
             "name": "Regal Behemoth",
             "text": "Trample\nWhen Regal Behemoth enters the battlefield, you become the monarch.\nWhenever you tap a land for mana while you're the monarch, add an additional one mana of any color.",
             "colours": [
@@ -23027,7 +23027,7 @@
         },
         {
             "id": "eb287912-c6f4-52a3-83b0-704a3341ad1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78e78d6-ef31-4343-91cc-c148e86f8497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78e78d6-ef31-4343-91cc-c148e86f8497.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014\n\u2022 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n\u2022 Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -23062,7 +23062,7 @@
         },
         {
             "id": "306bac0e-10b2-5db3-9e4b-a36dea8336ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1836b8a6-c616-4793-933b-b38296d70e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1836b8a6-c616-4793-933b-b38296d70e72.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -23092,7 +23092,7 @@
         },
         {
             "id": "deef6d2c-d636-5a95-89e9-bade7a110ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147b0d7d-3657-4521-b370-3a4f3a419313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147b0d7d-3657-4521-b370-3a4f3a419313.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -23125,7 +23125,7 @@
         },
         {
             "id": "6481991f-193f-552b-82dc-6924d697fa9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516692b8-fbaf-4698-864b-5363aafc95b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516692b8-fbaf-4698-864b-5363aafc95b9.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -23155,7 +23155,7 @@
         },
         {
             "id": "28bd87e7-a2cb-5256-980e-084d49eca972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8390737-edfe-459e-9f1e-bdec2d95057a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8390737-edfe-459e-9f1e-bdec2d95057a.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint \u2014 When Extraplanar Lens enters the battlefield, you may exile target land you control.\nWhenever a land with the same name as the exiled card is tapped for mana, its controller adds one mana of any type that land produced.",
             "colours": [],
@@ -23186,7 +23186,7 @@
         },
         {
             "id": "19ec5569-c4bf-58ed-b2bc-480b6b8f87af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa15d3b3-c709-4d9b-a9ec-c8d68f805ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa15d3b3-c709-4d9b-a9ec-c8d68f805ebf.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -23216,7 +23216,7 @@
         },
         {
             "id": "dd0cb906-b442-5c95-b0bd-d32093b0d9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428fe419-358d-4a36-89d8-bde0622beb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428fe419-358d-4a36-89d8-bde0622beb74.jpg?1",
             "name": "Thran Dynamo",
             "text": "{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -23246,7 +23246,7 @@
         },
         {
             "id": "d10f4df1-8e7a-5aa3-8d90-f2bd793c00d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24179418-d92c-43eb-a8f6-b8ea83f8c80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24179418-d92c-43eb-a8f6-b8ea83f8c80f.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -23276,7 +23276,7 @@
         },
         {
             "id": "baf97dee-78dc-568d-b80c-7a1a6acc6474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb9b5a-f904-4934-9530-87d752eeae75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb9b5a-f904-4934-9530-87d752eeae75.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -23306,7 +23306,7 @@
         },
         {
             "id": "efb33c58-bbea-5a36-a21a-d28efb821336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d574a-72b5-43be-b4b5-87865bbc7b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d574a-72b5-43be-b4b5-87865bbc7b5c.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -23336,7 +23336,7 @@
         },
         {
             "id": "385fcea3-2628-543e-9f15-ce47d594d600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a392e-ea3b-4de2-beeb-72772a546070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a392e-ea3b-4de2-beeb-72772a546070.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -23370,7 +23370,7 @@
         },
         {
             "id": "09c11b11-1fa0-5e72-b237-ad6ec5477abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2370ea-9bb8-496f-aaf5-f0bb3bb55f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2370ea-9bb8-496f-aaf5-f0bb3bb55f9b.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -23400,7 +23400,7 @@
         },
         {
             "id": "9a01cc57-e9d2-5119-bb45-8a734b2fe26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126484c-c3eb-484d-95a1-83eebb115b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126484c-c3eb-484d-95a1-83eebb115b83.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -23434,7 +23434,7 @@
         },
         {
             "id": "2b872d12-1cca-5df8-bfb5-5c0ec7ec09b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e601d1-cf31-4077-b3ad-e13dfce4dac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e601d1-cf31-4077-b3ad-e13dfce4dac3.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -23468,7 +23468,7 @@
         },
         {
             "id": "fc6bfd40-5525-530f-995a-9b2318b21bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84964ae0-5284-483c-8372-18bb485a25b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84964ae0-5284-483c-8372-18bb485a25b5.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -23502,7 +23502,7 @@
         },
         {
             "id": "cb70279f-d8e5-59e2-90c9-cc09b8d7cc34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be7c23e-312d-4b20-9bb7-0344a73acac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be7c23e-312d-4b20-9bb7-0344a73acac9.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -23536,7 +23536,7 @@
         },
         {
             "id": "04ef11e8-3918-5332-9f7c-3dc29d972c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fe08-37d1-40bb-bb64-af41b025314b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fe08-37d1-40bb-bb64-af41b025314b.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -23572,7 +23572,7 @@
         },
         {
             "id": "41708cad-0cbf-5648-a5bf-fc8f0316300f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2cfd10-37d9-4429-842e-f5a4c9abe3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2cfd10-37d9-4429-842e-f5a4c9abe3a4.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -23614,7 +23614,7 @@
         },
         {
             "id": "3bcc2d2e-f332-5087-963e-f7147a10500f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1571f-d73f-48ed-b6e2-f1388c410506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1571f-d73f-48ed-b6e2-f1388c410506.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -23650,7 +23650,7 @@
         },
         {
             "id": "c2656ebb-1210-554e-bc6d-5215765581db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae202c-21bf-4142-a8f0-89a13c25f9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae202c-21bf-4142-a8f0-89a13c25f9f9.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, create a 2/2 white Cat creature token for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -23689,7 +23689,7 @@
         },
         {
             "id": "52ad7e59-6f34-5df4-8a3b-2bdd5ff98256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6c234e-ce4a-4556-bfaf-9b3f53c92568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6c234e-ce4a-4556-bfaf-9b3f53c92568.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -23729,7 +23729,7 @@
         },
         {
             "id": "76774687-ebed-55ab-ab24-1437697142a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbfc7f-51b6-4925-a0f7-b2873366653e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbfc7f-51b6-4925-a0f7-b2873366653e.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -23769,7 +23769,7 @@
         },
         {
             "id": "3807363e-370d-5f54-b818-2de66a27f433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c6f09-a0b2-46c9-a291-59408dfa52b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c6f09-a0b2-46c9-a291-59408dfa52b0.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -23810,7 +23810,7 @@
         },
         {
             "id": "1407f184-0d3c-5fbd-b3d4-34c214a33ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffde74fb-cc20-4d82-bf6a-b18081047b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffde74fb-cc20-4d82-bf6a-b18081047b0a.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -23851,7 +23851,7 @@
         },
         {
             "id": "23ff6fd3-4760-51f9-85bd-f07ddf769796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25def92-c566-4ca9-8bda-e8917fc6582c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25def92-c566-4ca9-8bda-e8917fc6582c.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from the battlefield, you may return that card to the battlefield at the beginning of the next end step if Shirei, Shizo's Caretaker is still on the battlefield.",
             "colours": [
@@ -23889,7 +23889,7 @@
         },
         {
             "id": "1c31a72c-d957-51fa-9157-c8e693bcc79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6ab04e-f41f-487a-9c7e-4fb836c8b96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6ab04e-f41f-487a-9c7e-4fb836c8b96e.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "Whenever a creature you control deals combat damage to a player, choose one \u2014\n\u2022 Goad target creature that player controls.\n\u2022 Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -23929,7 +23929,7 @@
         },
         {
             "id": "516ab140-0bf3-535b-b836-313366cfe214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bf045f-9872-4af2-a067-ee59898545da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bf045f-9872-4af2-a067-ee59898545da.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -23971,7 +23971,7 @@
         },
         {
             "id": "6501ca61-0294-50ff-beb4-fb265609b198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2184e61d-6f25-425a-b914-b7d6ecd002c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2184e61d-6f25-425a-b914-b7d6ecd002c2.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -24011,7 +24011,7 @@
         },
         {
             "id": "a431efa7-6a68-5ca5-b504-fe35c4fd9111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fe30b-954a-4abf-aa18-4107683ad868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fe30b-954a-4abf-aa18-4107683ad868.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -24051,7 +24051,7 @@
         },
         {
             "id": "39bcdfb8-6f46-5965-9eb7-5b7a4a380742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088aed3-4568-4978-ac4c-6c435b65c083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088aed3-4568-4978-ac4c-6c435b65c083.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -24092,7 +24092,7 @@
         },
         {
             "id": "eee2a568-149d-5e9c-b596-17123eb5d492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477f06ee-b986-4de2-97e9-97ba7ec7c45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477f06ee-b986-4de2-97e9-97ba7ec7c45d.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -24133,7 +24133,7 @@
         },
         {
             "id": "b6959f17-31a5-52a6-a566-ec127fb236a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01e857d-cc78-4364-9f31-6879d4ec74e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01e857d-cc78-4364-9f31-6879d4ec74e1.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -24177,7 +24177,7 @@
         },
         {
             "id": "99251cea-863f-57c1-9b91-fc5b89aac82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8bb9c1-4b20-4fd9-b0c4-b1f74f0fb6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8bb9c1-4b20-4fd9-b0c4-b1f74f0fb6fd.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -24220,7 +24220,7 @@
         },
         {
             "id": "86d800bc-428c-5399-88a5-7f78471b018c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7ef286-666f-4a35-9d3f-12a0e888e35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7ef286-666f-4a35-9d3f-12a0e888e35a.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "Whenever another creature you control dies, you get an experience counter.\nAt the beginning of your end step, choose target creature card in your graveyard. If that card's mana value is less than or equal to the number of experience counters you have, return it to the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -24262,7 +24262,7 @@
         },
         {
             "id": "999c43e1-7dd5-56cc-ae97-afbdd824042e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c649e923-dcd1-45d7-90bd-4e2fe55c8ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c649e923-dcd1-45d7-90bd-4e2fe55c8ce7.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -24302,7 +24302,7 @@
         },
         {
             "id": "f8cbb75c-aebc-5acb-b48e-c06302d8daae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f8d9d-422a-43c8-903e-9b3e87142bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f8d9d-422a-43c8-903e-9b3e87142bb3.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -24343,7 +24343,7 @@
         },
         {
             "id": "bd618df2-7374-5233-91fe-08d5459b4ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581a2da7-80d3-409a-8a6c-aa6e9ccc1568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581a2da7-80d3-409a-8a6c-aa6e9ccc1568.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -24385,7 +24385,7 @@
         },
         {
             "id": "b809d179-e4f4-5691-82cb-0dd32a28dd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270c798-a3ba-4826-b0a9-82f7e12890f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270c798-a3ba-4826-b0a9-82f7e12890f6.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -24434,7 +24434,7 @@
         },
         {
             "id": "3a7e86b6-c5af-56b6-8718-d752d074f063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe61f-513e-4308-8194-99f73c6fa972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe61f-513e-4308-8194-99f73c6fa972.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's mana value.",
             "colours": [
@@ -24476,7 +24476,7 @@
         },
         {
             "id": "2a175a9d-8cb7-5ae7-b10e-2d488694b1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d59045-12b9-47aa-b1d5-15a07b4b931a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d59045-12b9-47aa-b1d5-15a07b4b931a.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -24520,7 +24520,7 @@
         },
         {
             "id": "7d55da97-31f0-5388-a85d-bd9ea2e3d612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bf400-31c0-4ae4-8429-0f6fb92cbe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bf400-31c0-4ae4-8429-0f6fb92cbe9e.jpg?1",
             "name": "Flawless Maneuver",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCreatures you control gain indestructible until end of turn.",
             "colours": [
@@ -24555,7 +24555,7 @@
         },
         {
             "id": "73b1087c-0842-592d-9c59-38bdbb0fe853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65d83c-67bd-4d54-9c9a-50d57ca115bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65d83c-67bd-4d54-9c9a-50d57ca115bb.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -24590,7 +24590,7 @@
         },
         {
             "id": "99971445-b296-5e06-a1d6-b2408ae0b7fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103c4d8-5a3c-443b-9caf-f41f8b61e73f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103c4d8-5a3c-443b-9caf-f41f8b61e73f.jpg?1",
             "name": "Fierce Guardianship",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCounter target noncreature spell.",
             "colours": [
@@ -24625,7 +24625,7 @@
         },
         {
             "id": "8ffa339e-baad-568b-a825-17eca245fd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c266d-579e-4757-a4d6-6722fa343a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c266d-579e-4757-a4d6-6722fa343a6c.jpg?1",
             "name": "Deadly Rollick",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nExile target creature.",
             "colours": [
@@ -24660,7 +24660,7 @@
         },
         {
             "id": "8e32d80d-dcc3-5bfa-92ee-118b7761a0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb8533-9404-4af0-a14a-1e136eacdb3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb8533-9404-4af0-a14a-1e136eacdb3a.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -24695,7 +24695,7 @@
         },
         {
             "id": "11c42b94-4cb2-509b-9fe0-045f9344f682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782653e-9d8c-485b-b152-9353cd4f6ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782653e-9d8c-485b-b152-9353cd4f6ec8.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -24732,7 +24732,7 @@
         },
         {
             "id": "847a524f-2c1c-5573-ad73-8dba2754dff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e70109-0352-45fc-a2fd-892ca65cac2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e70109-0352-45fc-a2fd-892ca65cac2f.jpg?1",
             "name": "Deflecting Swat",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nYou may choose new targets for target spell or ability.",
             "colours": [
@@ -24767,7 +24767,7 @@
         },
         {
             "id": "5f95d778-14d8-5b7a-a725-a1786223f1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8997b72-65cd-4584-8089-d2be620cc3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8997b72-65cd-4584-8089-d2be620cc3cb.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -24802,7 +24802,7 @@
         },
         {
             "id": "74a42419-5500-50e1-86e1-8955eac4d072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67d30b-7a4f-49b4-bf8b-e9cf8c248e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67d30b-7a4f-49b4-bf8b-e9cf8c248e4d.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -24837,7 +24837,7 @@
         },
         {
             "id": "37ca511f-63f0-5eb8-a297-13eed5449d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0ca66a-4dbd-4682-8f0a-3a3d3941a123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0ca66a-4dbd-4682-8f0a-3a3d3941a123.jpg?1",
             "name": "Obscuring Haze",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nPrevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -24872,7 +24872,7 @@
         },
         {
             "id": "ca89c3a8-a05c-5f16-bc1c-37cfe1c9ace7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e934462-bf6c-48ff-92a4-1df476c420b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e934462-bf6c-48ff-92a4-1df476c420b7.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -24904,7 +24904,7 @@
         },
         {
             "id": "2d0782b9-dfe7-56d5-84aa-bd4441628bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7454e0cc-98c2-48a1-b2c9-49908d2aedcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7454e0cc-98c2-48a1-b2c9-49908d2aedcc.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -24934,7 +24934,7 @@
         },
         {
             "id": "36582a99-0cc8-53a5-be8d-f9f106bbbfec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015461d-4214-4feb-8b04-519c537759eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015461d-4214-4feb-8b04-519c537759eb.jpg?1",
             "name": "Zhulodok, Void Gorger",
             "text": "Colorless spells you cast from your hand with mana value 7 or greater have \"Cascade, cascade.\" (When you cast one, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [],
@@ -24968,7 +24968,7 @@
         },
         {
             "id": "59191cfc-be27-5744-8c87-1aa61b09430a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b796a56-1611-4835-ac5b-48b4e9263685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b796a56-1611-4835-ac5b-48b4e9263685.jpg?1",
             "name": "Anikthea, Hand of Erebos",
             "text": "Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters the battlefield or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.",
             "colours": [
@@ -25011,7 +25011,7 @@
         },
         {
             "id": "2ac0d6ab-013a-5d3f-9a12-20727771c7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92870fc6-a6bc-4198-bb31-397e07e0e835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92870fc6-a6bc-4198-bb31-397e07e0e835.jpg?1",
             "name": "Commodore Guff",
             "text": "At the beginning of your end step, put a loyalty counter on another target planeswalker you control.\n+1: Create a 1/1 red Wizard creature token with \"{T}: Add {R}. Spend this mana only to cast a planeswalker spell.\"\n\u22123: You draw X cards and Commodore Guff deals X damage to each opponent, where X is the number of planeswalkers you control.\nCommodore Guff can be your commander.",
             "colours": [
@@ -25052,7 +25052,7 @@
         },
         {
             "id": "3f469657-c54d-534c-b8f3-28da92a169a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5d253e-9eb2-423c-90ee-68f27ec6bf88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5d253e-9eb2-423c-90ee-68f27ec6bf88.jpg?1",
             "name": "Sliver Gravemother",
             "text": "The \"legend rule\" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5} ({5}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -25098,7 +25098,7 @@
         },
         {
             "id": "c3395fb9-ca6e-57bf-acf0-389bd0e2398a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e16ac-8e0f-4e2e-9b74-d6a77dddf274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e16ac-8e0f-4e2e-9b74-d6a77dddf274.jpg?1",
             "name": "Omarthis, Ghostfire Initiate",
             "text": "Omarthis, Ghostfire Initiate enters the battlefield with X +1/+1 counters on it.\nWhenever you put one or more +1/+1 counters on another colorless creature, you may put a +1/+1 counter on Omarthis.\nWhen Omarthis dies, manifest a number of cards from the top of your library equal to the number of counters on it.",
             "colours": [],
@@ -25132,7 +25132,7 @@
         },
         {
             "id": "6b24745d-dd06-5f50-8ff7-3db84d3fb78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342979de-041e-4026-94c5-fc457ecde95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342979de-041e-4026-94c5-fc457ecde95d.jpg?1",
             "name": "Leori, Sparktouched Hunter",
             "text": "Flying, vigilance\nWhenever Leori, Sparktouched Hunter deals combat damage to a player, choose a planeswalker type. Until end of turn, whenever you activate an ability of a planeswalker of that type, copy that ability. You may choose new targets for the copies.",
             "colours": [
@@ -25174,7 +25174,7 @@
         },
         {
             "id": "a5021eab-b186-527e-95b9-da5b2474023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a2fa9-82d6-4cf7-adb4-65b187cd9cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a2fa9-82d6-4cf7-adb4-65b187cd9cda.jpg?1",
             "name": "Narci, Fable Singer",
             "text": "Lifelink\nWhenever you sacrifice an enchantment, draw a card.\nWhenever the final chapter ability of a Saga you control resolves, each opponent loses X life and you gain X life, where X is that Saga's mana value.",
             "colours": [
@@ -25216,7 +25216,7 @@
         },
         {
             "id": "0c04a6ce-ddbe-58d5-ae1d-fe31b2174b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f7397-9d75-4667-8872-e58a39512583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f7397-9d75-4667-8872-e58a39512583.jpg?1",
             "name": "Rukarumel, Biologist",
             "text": "As Rukarumel, Biologist enters the battlefield, choose a creature type.\nSlivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 1/1 colorless Sliver creature token.",
             "colours": [
@@ -25262,7 +25262,7 @@
         },
         {
             "id": "59fb32ea-a86a-56bd-8745-b4937c5015bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc2871b-c685-4951-b8e2-7370b9668f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc2871b-c685-4951-b8e2-7370b9668f7e.jpg?1",
             "name": "Abstruse Archaic",
             "text": "Vigilance\n{1}, {T}: Copy target activated or triggered ability you control from a colorless source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
             "colours": [],
@@ -25293,7 +25293,7 @@
         },
         {
             "id": "8a3c6366-a69a-532a-b015-b895dba3c6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a3a89-a87e-4108-87c5-74f656a6249f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a3a89-a87e-4108-87c5-74f656a6249f.jpg?1",
             "name": "Calamity of the Titans",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile each creature and planeswalker with mana value less than the revealed card's mana value.",
             "colours": [],
@@ -25322,7 +25322,7 @@
         },
         {
             "id": "f9c1da8e-a607-5fd9-b313-7ea1b5d7b067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396db2cb-8fa0-436a-993d-de8bb13b848f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396db2cb-8fa0-436a-993d-de8bb13b848f.jpg?1",
             "name": "Desecrate Reality",
             "text": "For each opponent, exile up to one target permanent that player controls with an even mana value. (Zero is even.)\nAdamant \u2014 If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.",
             "colours": [],
@@ -25351,7 +25351,7 @@
         },
         {
             "id": "056f05ba-6356-55a2-8790-3d8039c07253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f3ee0c-1e73-42b6-841d-0a878a80002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f3ee0c-1e73-42b6-841d-0a878a80002a.jpg?1",
             "name": "Flayer of Loyalties",
             "text": "When you cast this spell, gain control of target creature until end of turn. Untap that creature. Until end of turn, it has base power and toughness 10/10 and gains trample, annihilator 2, and haste.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nTrample",
             "colours": [],
@@ -25382,7 +25382,7 @@
         },
         {
             "id": "68b4200b-8673-5ae7-90a2-f4effb6ac16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4d851b-1fa9-4f5d-a8f6-6967b1ee5b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4d851b-1fa9-4f5d-a8f6-6967b1ee5b50.jpg?1",
             "name": "Rise of the Eldrazi",
             "text": "This spell can't be countered.\nDestroy target permanent. Target player draws four cards. Take an extra turn after this one.\nExile Rise of the Eldrazi.",
             "colours": [],
@@ -25411,7 +25411,7 @@
         },
         {
             "id": "18cf538b-15c5-53e2-bcea-004c1a1caeb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a83be9-856d-4c30-95f5-da72a5ac8263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a83be9-856d-4c30-95f5-da72a5ac8263.jpg?1",
             "name": "Skittering Cicada",
             "text": "Flash\nYou may cast colorless spells as though they had flash.\nWhenever you cast a colorless spell, until end of turn, Skittering Cicada gains trample and gets +X/+X, where X is that spell's mana value.",
             "colours": [],
@@ -25442,7 +25442,7 @@
         },
         {
             "id": "dfb100fa-7984-5121-ba12-068c60fdc9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42991890-731c-4e6a-b0c5-57d6217029ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42991890-731c-4e6a-b0c5-57d6217029ab.jpg?1",
             "name": "Ugin's Mastery",
             "text": "Whenever you cast a colorless creature spell, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever you attack with creatures with total power 6 or greater, you may turn a face-down creature you control face up.",
             "colours": [],
@@ -25471,7 +25471,7 @@
         },
         {
             "id": "0ba1836c-3ba0-5fa1-94c7-b546b818d691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0eaeb-9b62-427d-9873-d84de1740ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0eaeb-9b62-427d-9873-d84de1740ddc.jpg?1",
             "name": "Battle at the Helvault",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 For each player, exile up to one target non-Saga, nonland permanent that player controls until Battle at the Helvault leaves the battlefield.\nIII \u2014 Create Avacyn, a legendary 8/8 white Angel creature token with flying, vigilance, and indestructible.",
             "colours": [
@@ -25504,7 +25504,7 @@
         },
         {
             "id": "0c90917f-ac85-5130-bba5-90aac3380d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a588fc39-ed88-4262-96cd-908fadc7f049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a588fc39-ed88-4262-96cd-908fadc7f049.jpg?1",
             "name": "Boon of the Spirit Realm",
             "text": "Constellation \u2014 Whenever Boon of the Spirit Realm or another enchantment enters the battlefield under your control, put a blessing counter on Boon of the Spirit Realm.\nCreatures you control get +1/+1 for each blessing counter on Boon of the Spirit Realm.",
             "colours": [
@@ -25537,7 +25537,7 @@
         },
         {
             "id": "27ff7071-17ed-5461-a603-158aaeeed4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b3a1bb-1191-4484-80b0-71cf9f8e510b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b3a1bb-1191-4484-80b0-71cf9f8e510b.jpg?1",
             "name": "Gatewatch Beacon",
             "text": "Gatewatch Beacon enters the battlefield with three loyalty counters on it.\n{T}: Add {W}.\nWhenever a planeswalker enters the battlefield under your control, if Gatewatch Beacon has loyalty counters on it, you may move a loyalty counter from Gatewatch Beacon onto that planeswalker.",
             "colours": [
@@ -25570,7 +25570,7 @@
         },
         {
             "id": "6f289a6b-e970-5c13-9966-982ead7fbd24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d0caac-50c0-434e-af77-9ebd2a466415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d0caac-50c0-434e-af77-9ebd2a466415.jpg?1",
             "name": "Onakke Oathkeeper",
             "text": "Creatures can't attack planeswalkers you control unless their controller pays {1} for each creature they control that's attacking a planeswalker you control.\n{4}{W}{W}, Exile Onakke Oathkeeper from your graveyard: Return target planeswalker card from your graveyard to the battlefield.",
             "colours": [
@@ -25606,7 +25606,7 @@
         },
         {
             "id": "d769ff3e-ccc8-58ab-a18c-2958bcb8493d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71991921-a860-44fe-9005-bf604c723167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71991921-a860-44fe-9005-bf604c723167.jpg?1",
             "name": "Ondu Spiritdancer",
             "text": "Whenever an enchantment enters the battlefield under your control, you may create a token that's a copy of it. Do this only once each turn.",
             "colours": [
@@ -25642,7 +25642,7 @@
         },
         {
             "id": "0fca5628-5a40-52a5-8b78-4ca1afbe51b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b081723-41a1-4139-88ee-01c0238e50c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b081723-41a1-4139-88ee-01c0238e50c3.jpg?1",
             "name": "Regal Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch.\"",
             "colours": [
@@ -25677,7 +25677,7 @@
         },
         {
             "id": "98ad33fa-bf87-527b-b40f-29dd47b00b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66fa93a-6888-4297-b22e-7d69fd25c0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66fa93a-6888-4297-b22e-7d69fd25c0d7.jpg?1",
             "name": "Teyo, Geometric Tactician",
             "text": "When Teyo, Geometric Tactician enters the battlefield, create a 0/4 white Wall creature token with defender and flying.\n+1: You and target opponent each draw a card.\n\u22122: Choose left or right. Until your next turn, each player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.",
             "colours": [
@@ -25712,7 +25712,7 @@
         },
         {
             "id": "fb1b84b2-fb5d-52b2-ba1e-7def7913ca22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e941849-033b-499b-b691-6ad9250d9ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e941849-033b-499b-b691-6ad9250d9ecd.jpg?1",
             "name": "Sparkshaper Visionary",
             "text": "At the beginning of combat on your turn, choose any number of target planeswalkers you control. Until end of turn, they become 3/3 blue Bird creatures with flying, hexproof, and \"Whenever this creature deals combat damage to a player, scry 1.\" (They're no longer planeswalkers. Loyalty abilities can still be activated.)",
             "colours": [
@@ -25748,7 +25748,7 @@
         },
         {
             "id": "589e22e7-da58-5f94-a680-8f2bb16c7059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8a900-b15a-42eb-a240-35764d57c155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8a900-b15a-42eb-a240-35764d57c155.jpg?1",
             "name": "Taunting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, goad target creature an opponent controls.\" (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -25783,7 +25783,7 @@
         },
         {
             "id": "da0ec155-2705-5c26-b62e-520a64b839f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62807f83-b219-4769-afdd-2870deeb93c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62807f83-b219-4769-afdd-2870deeb93c0.jpg?1",
             "name": "Titan of Littjara",
             "text": "As Titan of Littjara enters the battlefield, choose a creature type.\nTitan of Littjara is the chosen type in addition to its other types.\nWhenever Titan of Littjara enters the battlefield or attacks, you may draw a card for each other creature you control that shares a creature type with it. If you do, discard a card.",
             "colours": [
@@ -25818,7 +25818,7 @@
         },
         {
             "id": "ba69ca2b-a70d-5450-90ce-6699a0326e0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd2504b-ff9b-464c-9595-7dffab3bc5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd2504b-ff9b-464c-9595-7dffab3bc5b9.jpg?1",
             "name": "Vronos, Masked Inquisitor",
             "text": "+1: Up to two other target planeswalkers you control phase out at the beginning of the next end step. (Treat them and anything attached to them as though they don't exist until your next turn.)\n\u22122: For each opponent, return up to one target nonland permanent that player controls to its owner's hand.\n\u22127: Target artifact you control becomes a 9/9 Construct artifact creature and gains vigilance, indestructible, and \"This creature can't be blocked.\"",
             "colours": [
@@ -25853,7 +25853,7 @@
         },
         {
             "id": "1da1249b-64cf-52a5-951d-5b6330d1550f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908d9aa5-818c-4651-b135-cc6d1983ad99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908d9aa5-818c-4651-b135-cc6d1983ad99.jpg?1",
             "name": "Cacophony Unleashed",
             "text": "When Cacophony Unleashed enters the battlefield, if you cast it, destroy all nonenchantment creatures.\nWhenever Cacophony Unleashed or another enchantment enters the battlefield under your control, until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment.",
             "colours": [
@@ -25886,7 +25886,7 @@
         },
         {
             "id": "ca138f19-dda8-5037-a1a5-37fe6ce64740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aac73-bcbb-4332-940b-96e1e312bbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aac73-bcbb-4332-940b-96e1e312bbf8.jpg?1",
             "name": "Demon of Fate's Design",
             "text": "Flying, trample\nOnce during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.\n{2}{B}, Sacrifice another enchantment: Demon of Fate's Design gets +X/+0 until end of turn, where X is the sacrificed enchantment's mana value.",
             "colours": [
@@ -25922,7 +25922,7 @@
         },
         {
             "id": "fbd47920-61c2-5703-9955-51838c72a8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe9d991-0abb-47c1-810d-fa44c1820063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe9d991-0abb-47c1-810d-fa44c1820063.jpg?1",
             "name": "Ghoulish Impetus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1, has deathtouch, and is goaded.\nWhen enchanted creature dies, return Ghoulish Impetus to the battlefield at the beginning of the next end step.",
             "colours": [
@@ -25957,7 +25957,7 @@
         },
         {
             "id": "74b2a189-1d1a-5dcc-8dec-fd0eddaddb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f7b4d-2997-412b-8e25-315d93d1603a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f7b4d-2997-412b-8e25-315d93d1603a.jpg?1",
             "name": "Lazotep Sliver",
             "text": "Sliver creatures you control have afflict 2. (Whenever a creature with afflict 2 becomes blocked, defending player loses 2 life.)\nWhenever a nontoken Sliver you control dies, amass Slivers 2. (Put two +1/+1 counters on an Army you control. It's also a Sliver. If you don't control an Army, create a 0/0 black Sliver Army creature token first.)",
             "colours": [
@@ -25993,7 +25993,7 @@
         },
         {
             "id": "5238fa68-2571-5e7c-b95f-313f2d548441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48938cd4-9158-4eb8-acb7-21ce7a11cfa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48938cd4-9158-4eb8-acb7-21ce7a11cfa7.jpg?1",
             "name": "Capricious Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"",
             "colours": [
@@ -26028,7 +26028,7 @@
         },
         {
             "id": "88290daa-b38d-5ca1-9731-dda472be6b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b764e0d-ded0-4036-83b1-de49c6ee8f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b764e0d-ded0-4036-83b1-de49c6ee8f7e.jpg?1",
             "name": "Chandra, Legacy of Fire",
             "text": "At the beginning of your end step, Chandra, Legacy of Fire deals X damage to each opponent, where X is the number of planeswalkers you control.\n+1: Add {R} for each planeswalker you control.\n0: Remove a loyalty counter from each of any number of permanents you control. Exile that many cards from the top of your library. You may play them this turn.",
             "colours": [
@@ -26063,7 +26063,7 @@
         },
         {
             "id": "0b4754a2-91e4-5b77-8565-12121cfb94bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53117fac-5bb0-4bc3-b9ec-f0453c38d7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53117fac-5bb0-4bc3-b9ec-f0453c38d7f8.jpg?1",
             "name": "Descendants' Fury",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may sacrifice one of them. If you do, reveal cards from the top of your library until you reveal a creature card that shares a creature type with the sacrificed creature. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -26096,7 +26096,7 @@
         },
         {
             "id": "d6546644-755c-561f-8ca6-b86f0e8b5c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c6ab7-cab9-4ee3-9f17-d6817f61efcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c6ab7-cab9-4ee3-9f17-d6817f61efcc.jpg?1",
             "name": "Guff Rewrites History",
             "text": "For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost.",
             "colours": [
@@ -26129,7 +26129,7 @@
         },
         {
             "id": "f269565c-1b13-5518-b6e8-a9a8010f6655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca45c6b-8cce-44db-9f5b-fa66075db6f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca45c6b-8cce-44db-9f5b-fa66075db6f6.jpg?1",
             "name": "Jaya's Phoenix",
             "text": "Flying, haste\nWhenever Jaya's Phoenix deals combat damage to a player or planeswalker, copy the next loyalty ability you activate this turn when you activate it. You may choose new targets for the copy.\nWhenever you cast a planeswalker spell, you may return Jaya's Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -26164,7 +26164,7 @@
         },
         {
             "id": "dc0b77e4-4373-5590-bdf4-93eac5dbbace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e06f8-e542-47d4-b527-7d8fc3dec38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e06f8-e542-47d4-b527-7d8fc3dec38c.jpg?1",
             "name": "Composer of Spring",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may put a land card from your hand onto the battlefield tapped. If you control six or more enchantments, instead you may put a creature or land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -26200,7 +26200,7 @@
         },
         {
             "id": "db3493e8-df3c-5980-9faa-e2c7e5c0d073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1b0a5-b6ca-41f8-be1c-05a56383c9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1b0a5-b6ca-41f8-be1c-05a56383c9a9.jpg?1",
             "name": "For the Ancestors",
             "text": "Choose a creature type. Look at the top six cards of your library. You may reveal any number of cards of the chosen type from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -26233,7 +26233,7 @@
         },
         {
             "id": "f7f72ee1-03b4-5376-a7c7-360ac76fd11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2737c-d8ef-4b03-9316-be3f61288d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2737c-d8ef-4b03-9316-be3f61288d3c.jpg?1",
             "name": "Hatchery Sliver",
             "text": "Replicate {1}{G} (When you cast this spell, copy it for each time you paid its replicate cost.)\nEach Sliver spell you cast has replicate. The replicate cost is equal to its mana cost. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -26268,7 +26268,7 @@
         },
         {
             "id": "c466c3f3-f88f-5221-bed0-824e13e0d384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f1dbdc-e590-48a4-bc52-e9e4e907fb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f1dbdc-e590-48a4-bc52-e9e4e907fb82.jpg?1",
             "name": "Nyxborn Behemoth",
             "text": "This spell costs {X} less to cast, where X is the total mana value of noncreature enchantments you control.\nTrample\n{1}{G}, Sacrifice another enchantment: Nyxborn Behemoth gains indestructible until end of turn.",
             "colours": [
@@ -26304,7 +26304,7 @@
         },
         {
             "id": "53e7c41b-2d26-5b37-919c-fa570ad18887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b7d3df-4e9b-422b-a88c-43650a67a9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b7d3df-4e9b-422b-a88c-43650a67a9c6.jpg?1",
             "name": "Darksteel Monolith",
             "text": "Indestructible\nOnce each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.",
             "colours": [],
@@ -26333,7 +26333,7 @@
         },
         {
             "id": "5c965485-0278-5b3a-8988-30f0514f50a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687c808-84de-4f16-afb9-a0c6c7f10ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687c808-84de-4f16-afb9-a0c6c7f10ab9.jpg?1",
             "name": "Abstruse Archaic",
             "text": "Vigilance\n{1}, {T}: Copy target activated or triggered ability you control from a colorless source. You may choose new targets for the copy.",
             "colours": [],
@@ -26365,7 +26365,7 @@
         },
         {
             "id": "8f73664a-9683-59f3-aa22-b41dd611b193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1ac650-b7b6-4d1f-a594-66cb3b58e696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1ac650-b7b6-4d1f-a594-66cb3b58e696.jpg?1",
             "name": "Calamity of the Titans",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile each creature and planeswalker with mana value less than the revealed card's mana value.",
             "colours": [],
@@ -26395,7 +26395,7 @@
         },
         {
             "id": "b23ebeec-ac70-5da2-9d78-4345f9aa5a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6957c952-e501-4ac3-839b-8a16f802b5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6957c952-e501-4ac3-839b-8a16f802b5fe.jpg?1",
             "name": "Desecrate Reality",
             "text": "For each opponent, exile up to one target permanent that player controls with an even mana value. (Zero is even.)\nAdamant \u2014 If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.",
             "colours": [],
@@ -26425,7 +26425,7 @@
         },
         {
             "id": "5e760f05-311c-5287-89be-39c0531f8c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d322c86-ffdd-4c39-8444-4dfca13c16ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d322c86-ffdd-4c39-8444-4dfca13c16ce.jpg?1",
             "name": "Flayer of Loyalties",
             "text": "When you cast this spell, gain control of target creature until end of turn. Untap that creature. Until end of turn, it has base power and toughness 10/10 and gains trample, annihilator 2, and haste.\nTrample, annihilator 2",
             "colours": [],
@@ -26457,7 +26457,7 @@
         },
         {
             "id": "44e9f29e-1387-5ac3-83b6-f1ee906b0197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b7f6e-cd93-4b59-a574-7faa65eb8596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b7f6e-cd93-4b59-a574-7faa65eb8596.jpg?1",
             "name": "Omarthis, Ghostfire Initiate",
             "text": "Omarthis, Ghostfire Initiate enters the battlefield with X +1/+1 counters on it.\nWhenever you put one or more +1/+1 counters on another colorless creature, you may put a +1/+1 counter on Omarthis.\nWhen Omarthis dies, manifest a number of cards from the top of your library equal to the number of counters on it.",
             "colours": [],
@@ -26492,7 +26492,7 @@
         },
         {
             "id": "f33fdc4a-6417-5a03-be89-5a856aa854cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8914ba3-5e76-4392-bc8d-05d14585918a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8914ba3-5e76-4392-bc8d-05d14585918a.jpg?1",
             "name": "Rise of the Eldrazi",
             "text": "This spell can't be countered.\nDestroy target permanent. Target player draws four cards. Take an extra turn after this one.\nExile Rise of the Eldrazi.",
             "colours": [],
@@ -26522,7 +26522,7 @@
         },
         {
             "id": "6f7b8a00-acdd-59ca-b194-9de59f656704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a430137-70d9-45fc-acaa-87b29ea0d588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a430137-70d9-45fc-acaa-87b29ea0d588.jpg?1",
             "name": "Skittering Cicada",
             "text": "Flash\nYou may cast colorless spells as though they had flash.\nWhenever you cast a colorless spell, until end of turn, Skittering Cicada gains trample and gets +X/+X, where X is that spell's mana value.",
             "colours": [],
@@ -26554,7 +26554,7 @@
         },
         {
             "id": "d6aa8f3f-5a4c-5aff-9af2-8ed8ea8af088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def39c7f-cccb-49ce-9096-e051f3bcdebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def39c7f-cccb-49ce-9096-e051f3bcdebe.jpg?1",
             "name": "Ugin's Mastery",
             "text": "Whenever you cast a colorless creature spell, manifest the top card of your library.\nWhenever you attack with creatures with total power 6 or greater, you may turn a face-down creature you control face up.",
             "colours": [],
@@ -26584,7 +26584,7 @@
         },
         {
             "id": "c06ac9e9-24a5-51f2-b85a-4d1c84e09b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59ba1ee-8080-4f3e-a9a0-fa7b8b049e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59ba1ee-8080-4f3e-a9a0-fa7b8b049e34.jpg?1",
             "name": "Zhulodok, Void Gorger",
             "text": "Colorless spells you cast from your hand with mana value 7 or greater have \"Cascade, cascade.\"",
             "colours": [],
@@ -26619,7 +26619,7 @@
         },
         {
             "id": "3e64ec7f-347d-5cec-a103-034a57117238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52906cd4-3877-4554-8bf9-1d082cdfd331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52906cd4-3877-4554-8bf9-1d082cdfd331.jpg?1",
             "name": "Boon of the Spirit Realm",
             "text": "Constellation \u2014 Whenever Boon of the Spirit Realm or another enchantment enters the battlefield under your control, put a blessing counter on Boon of the Spirit Realm.\nCreatures you control get +1/+1 for each blessing counter on Boon of the Spirit Realm.",
             "colours": [
@@ -26653,7 +26653,7 @@
         },
         {
             "id": "b46a684d-84ca-5185-a221-a0ee653ed20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca467a-40d2-4f15-a314-76016fb027c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca467a-40d2-4f15-a314-76016fb027c3.jpg?1",
             "name": "Gatewatch Beacon",
             "text": "Gatewatch Beacon enters the battlefield with three loyalty counters on it.\n{T}: Add {W}.\nWhenever a planeswalker enters the battlefield under your control, if Gatewatch Beacon has loyalty counters on it, you may move a loyalty counter from Gatewatch Beacon onto that planeswalker.",
             "colours": [
@@ -26687,7 +26687,7 @@
         },
         {
             "id": "4244ae0a-b3ed-5417-b94a-0e919c33fba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340093f-a8b2-4bd7-b7bf-32ddede628b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340093f-a8b2-4bd7-b7bf-32ddede628b1.jpg?1",
             "name": "Onakke Oathkeeper",
             "text": "Creatures can't attack planeswalkers you control unless their controller pays {1} for each creature they control that's attacking a planeswalker you control.\n{4}{W}{W}, Exile Onakke Oathkeeper from your graveyard: Return target planeswalker card from your graveyard to the battlefield.",
             "colours": [
@@ -26724,7 +26724,7 @@
         },
         {
             "id": "984247d8-2998-5b46-8624-200e2a7d29f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30e4bf-ac1a-4670-ad73-84ba70e48a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30e4bf-ac1a-4670-ad73-84ba70e48a72.jpg?1",
             "name": "Ondu Spiritdancer",
             "text": "Whenever an enchantment enters the battlefield under your control, you may create a token that's a copy of it. Do this only once each turn.",
             "colours": [
@@ -26761,7 +26761,7 @@
         },
         {
             "id": "137d6f46-4603-542d-928c-1fe56dd47e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b23e2e0-b7d8-41fa-8441-118c552cd872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b23e2e0-b7d8-41fa-8441-118c552cd872.jpg?1",
             "name": "Regal Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch.\"",
             "colours": [
@@ -26797,7 +26797,7 @@
         },
         {
             "id": "179b1d2e-890c-589d-9200-aac1ba3b323e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb6fc77-28f2-4ead-8561-1d46d7aa5878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb6fc77-28f2-4ead-8561-1d46d7aa5878.jpg?1",
             "name": "Sparkshaper Visionary",
             "text": "At the beginning of combat on your turn, choose any number of target planeswalkers you control. Until end of turn, they become 3/3 blue Bird creatures with flying, hexproof, and \"Whenever this creature deals combat damage to a player, scry 1.\" (They're no longer planeswalkers. Loyalty abilities can still be activated.)",
             "colours": [
@@ -26834,7 +26834,7 @@
         },
         {
             "id": "ee51daf6-563a-5686-bdfb-a3cc0db32f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d40ff-40a5-42cd-b699-764b3abf0d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d40ff-40a5-42cd-b699-764b3abf0d4c.jpg?1",
             "name": "Taunting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, goad target creature an opponent controls.\"",
             "colours": [
@@ -26870,7 +26870,7 @@
         },
         {
             "id": "063a0981-78a8-579b-99a4-189afce5263b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3c52d-8e38-4642-a28b-baa533b12c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3c52d-8e38-4642-a28b-baa533b12c8f.jpg?1",
             "name": "Titan of Littjara",
             "text": "As Titan of Littjara enters the battlefield, choose a creature type.\nTitan of Littjara is the chosen type in addition to its other types.\nWhenever Titan of Littjara enters the battlefield or attacks, you may draw a card for each other creature you control that shares a creature type with it. If you do, discard a card.",
             "colours": [
@@ -26906,7 +26906,7 @@
         },
         {
             "id": "85015b11-9b65-5a93-9908-1c4f26ef0491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d89a0-fa7f-4c56-a262-f8eac8aa892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d89a0-fa7f-4c56-a262-f8eac8aa892c.jpg?1",
             "name": "Cacophony Unleashed",
             "text": "When Cacophony Unleashed enters the battlefield, if you cast it, destroy all nonenchantment creatures.\nWhenever Cacophony Unleashed or another enchantment enters the battlefield under your control, until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment.",
             "colours": [
@@ -26940,7 +26940,7 @@
         },
         {
             "id": "96f9550f-375b-5e98-9669-7f0896c9d7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c242-cf50-4c0e-9ea9-ce6614be045e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c242-cf50-4c0e-9ea9-ce6614be045e.jpg?1",
             "name": "Demon of Fate's Design",
             "text": "Flying, trample\nOnce during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.\n{2}{B}, Sacrifice another enchantment: Demon of Fate's Design gets +X/+0 until end of turn, where X is the sacrificed enchantment's mana value.",
             "colours": [
@@ -26977,7 +26977,7 @@
         },
         {
             "id": "7b970425-8df6-5d51-830f-bddfbc9934ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072c852b-b078-4064-98c8-3ab011676e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072c852b-b078-4064-98c8-3ab011676e79.jpg?1",
             "name": "Ghoulish Impetus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1, has deathtouch, and is goaded.\nWhen enchanted creature dies, return Ghoulish Impetus to the battlefield at the beginning of the next end step.",
             "colours": [
@@ -27013,7 +27013,7 @@
         },
         {
             "id": "7ac0f5d4-af3b-5857-b74d-065657193f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b72fb20-4d91-40b0-9dc5-24924e758925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b72fb20-4d91-40b0-9dc5-24924e758925.jpg?1",
             "name": "Lazotep Sliver",
             "text": "Sliver creatures you control have afflict 2.\nWhenever a nontoken Sliver you control dies, amass Slivers 2.",
             "colours": [
@@ -27050,7 +27050,7 @@
         },
         {
             "id": "4d52dbb4-1ef4-5e6d-8ab8-c1058f1db9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a04e11-23e3-49f4-ba64-c8f35c419ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a04e11-23e3-49f4-ba64-c8f35c419ccd.jpg?1",
             "name": "Capricious Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"",
             "colours": [
@@ -27086,7 +27086,7 @@
         },
         {
             "id": "f9dc96f5-a8ea-5958-b02b-846638988c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce28dd7-56d0-4801-855f-ddebf81adf6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce28dd7-56d0-4801-855f-ddebf81adf6e.jpg?1",
             "name": "Descendants' Fury",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may sacrifice one of them. If you do, reveal cards from the top of your library until you reveal a creature card that shares a creature type with the sacrificed creature. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -27120,7 +27120,7 @@
         },
         {
             "id": "fbe9bcd8-c394-5930-8a05-f3584d56e791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4511a6f6-1cdf-4bff-abea-d43b257e6d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4511a6f6-1cdf-4bff-abea-d43b257e6d50.jpg?1",
             "name": "Guff Rewrites History",
             "text": "For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost.",
             "colours": [
@@ -27154,7 +27154,7 @@
         },
         {
             "id": "66f00553-c490-5bed-a111-2a6d2a6e0efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22009c47-3b0e-41f9-843d-f670d8afda23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22009c47-3b0e-41f9-843d-f670d8afda23.jpg?1",
             "name": "Jaya's Phoenix",
             "text": "Flying, haste\nWhenever Jaya's Phoenix deals combat damage to a player or planeswalker, copy the next loyalty ability you activate this turn when you activate it. You may choose new targets for the copy.\nWhenever you cast a planeswalker spell, you may return Jaya's Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -27190,7 +27190,7 @@
         },
         {
             "id": "c36d5351-5e81-52b5-9cad-4416508b7e49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bb4ab9-386f-4099-a3aa-87dab8611164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bb4ab9-386f-4099-a3aa-87dab8611164.jpg?1",
             "name": "Composer of Spring",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may put a land card from your hand onto the battlefield tapped. If you control six or more enchantments, instead you may put a creature or land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -27227,7 +27227,7 @@
         },
         {
             "id": "046e3a77-4aca-5774-809c-73b075800fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd5c87c-1514-467d-bc3f-b9dd6a582f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd5c87c-1514-467d-bc3f-b9dd6a582f71.jpg?1",
             "name": "For the Ancestors",
             "text": "Choose a creature type. Look at the top six cards of your library. You may reveal any number of cards of the chosen type from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{G}",
             "colours": [
@@ -27261,7 +27261,7 @@
         },
         {
             "id": "0e7d7808-85ad-5f37-9cbd-9f873587ee48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f4b12a-aec7-4b6b-b5d5-53ca1c2b7054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f4b12a-aec7-4b6b-b5d5-53ca1c2b7054.jpg?1",
             "name": "Hatchery Sliver",
             "text": "Replicate {1}{G}\nEach Sliver spell you cast has replicate. The replicate cost is equal to its mana cost.",
             "colours": [
@@ -27297,7 +27297,7 @@
         },
         {
             "id": "b172c687-7e04-5f98-9d12-4773f832e122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3b3e50-0292-47c8-940e-9cb5d47896f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3b3e50-0292-47c8-940e-9cb5d47896f8.jpg?1",
             "name": "Nyxborn Behemoth",
             "text": "This spell costs {X} less to cast, where X is the total mana value of noncreature enchantments you control.\nTrample\n{1}{G}, Sacrifice another enchantment: Nyxborn Behemoth gains indestructible until end of turn.",
             "colours": [
@@ -27334,7 +27334,7 @@
         },
         {
             "id": "7742f4e0-3226-5847-be49-7beeced3c689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71221a0-c474-4da1-9970-bb5adaad4f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71221a0-c474-4da1-9970-bb5adaad4f4d.jpg?1",
             "name": "Anikthea, Hand of Erebos",
             "text": "Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters the battlefield or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.",
             "colours": [
@@ -27378,7 +27378,7 @@
         },
         {
             "id": "fec45a30-f6b5-575d-a54c-f5c0db6581c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d2988e-a855-4bfd-8367-f5cbc4eb8560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d2988e-a855-4bfd-8367-f5cbc4eb8560.jpg?1",
             "name": "Leori, Sparktouched Hunter",
             "text": "Flying, vigilance\nWhenever Leori, Sparktouched Hunter deals combat damage to a player, choose a planeswalker type. Until end of turn, whenever you activate an ability of a planeswalker of that type, copy that ability. You may choose new targets for the copies.",
             "colours": [
@@ -27421,7 +27421,7 @@
         },
         {
             "id": "51620f24-a216-5457-ad0d-6b98c0fae876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff756c-0d65-44a9-8a43-bd0011f92383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff756c-0d65-44a9-8a43-bd0011f92383.jpg?1",
             "name": "Narci, Fable Singer",
             "text": "Lifelink\nWhenever you sacrifice an enchantment, draw a card.\nWhenever the final chapter ability of a Saga you control resolves, each opponent loses X life and you gain X life, where X is that Saga's mana value.",
             "colours": [
@@ -27464,7 +27464,7 @@
         },
         {
             "id": "71eeed46-2229-5b4c-a507-decc541b7ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad9b2c-4616-4c94-a9f4-006ccb4c4cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad9b2c-4616-4c94-a9f4-006ccb4c4cf5.jpg?1",
             "name": "Rukarumel, Biologist",
             "text": "As Rukarumel, Biologist enters the battlefield, choose a creature type.\nSlivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 1/1 colorless Sliver creature token.",
             "colours": [
@@ -27511,7 +27511,7 @@
         },
         {
             "id": "9b807668-b443-54ef-92e7-a59465350e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca55a2b4-f53a-4c76-bd28-8ce49108a322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca55a2b4-f53a-4c76-bd28-8ce49108a322.jpg?1",
             "name": "Sliver Gravemother",
             "text": "The \"legend rule\" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5}",
             "colours": [
@@ -27558,7 +27558,7 @@
         },
         {
             "id": "5fa94a3a-3480-5ec0-91da-d39cb5d03051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07f838-a813-43aa-9bcf-9f62797d7313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07f838-a813-43aa-9bcf-9f62797d7313.jpg?1",
             "name": "Darksteel Monolith",
             "text": "Indestructible\nOnce each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.",
             "colours": [],
@@ -27588,7 +27588,7 @@
         },
         {
             "id": "fd050589-f035-5ff4-a2dc-db3c8c8248b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4424b9ec-70d8-4b32-931f-fac1516f8472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4424b9ec-70d8-4b32-931f-fac1516f8472.jpg?1",
             "name": "Zhulodok, Void Gorger",
             "text": "Colorless spells you cast from your hand with mana value 7 or greater have \"Cascade, cascade.\" (When you cast one, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [],
@@ -27622,7 +27622,7 @@
         },
         {
             "id": "ffe434d9-65a5-5182-847a-caf8c4323443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f1c77c-07e6-4886-9b71-b556642f31cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f1c77c-07e6-4886-9b71-b556642f31cf.jpg?1",
             "name": "Anikthea, Hand of Erebos",
             "text": "Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters the battlefield or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.",
             "colours": [
@@ -27665,7 +27665,7 @@
         },
         {
             "id": "65eca6b6-8a34-5067-909b-660d18009cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5bb122-19f3-4e46-a71c-b8a53e9aacc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5bb122-19f3-4e46-a71c-b8a53e9aacc7.jpg?1",
             "name": "Commodore Guff",
             "text": "At the beginning of your end step, put a loyalty counter on another target planeswalker you control.\n+1: Create a 1/1 red Wizard creature token with \"{T}: Add {R}. Spend this mana only to cast a planeswalker spell.\"\n\u22123: You draw X cards and Commodore Guff deals X damage to each opponent, where X is the number of planeswalkers you control.\nCommodore Guff can be your commander.",
             "colours": [
@@ -27706,7 +27706,7 @@
         },
         {
             "id": "0e26bc84-e053-5231-84cb-23cf2b849208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e899ba84-d940-468a-8f18-5282b51b797e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e899ba84-d940-468a-8f18-5282b51b797e.jpg?1",
             "name": "Sliver Gravemother",
             "text": "The \"legend rule\" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5} ({5}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -27752,7 +27752,7 @@
         },
         {
             "id": "4dabadf1-2c7b-5548-bb92-479064eec72f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab98b67-3450-4cb2-9d2d-b4e3448dcd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab98b67-3450-4cb2-9d2d-b4e3448dcd73.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27793,7 +27793,7 @@
         },
         {
             "id": "72573adb-e6f3-58a9-89aa-0cfb082654c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e0813-96e9-40c3-8e7c-bee8bef27585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e0813-96e9-40c3-8e7c-bee8bef27585.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27834,7 +27834,7 @@
         },
         {
             "id": "e9efaead-54c5-5a41-a845-ee604230a27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cfdbd6-00c3-4eac-acd3-b058b82ff947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cfdbd6-00c3-4eac-acd3-b058b82ff947.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27875,7 +27875,7 @@
         },
         {
             "id": "8a39ac39-fa33-56f4-8573-d65576ea7a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7744562-1df1-4aea-ba15-5aa1e50e26a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7744562-1df1-4aea-ba15-5aa1e50e26a0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27916,7 +27916,7 @@
         },
         {
             "id": "b06c543e-5fcd-586d-b20f-1075ff3fa496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b1c00c-c292-44c7-a6c9-0dcdb00581aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b1c00c-c292-44c7-a6c9-0dcdb00581aa.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27957,7 +27957,7 @@
         },
         {
             "id": "e6266e24-09cd-523b-8cbe-e08580d7c230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f21ed59-a8c8-46fc-ac20-2b351fffd36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f21ed59-a8c8-46fc-ac20-2b351fffd36c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -27996,7 +27996,7 @@
         },
         {
             "id": "3b9ea227-a2d3-53c9-b38e-f4b833dc4169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd42c61-1e41-4df9-aa70-a39cc20dff51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd42c61-1e41-4df9-aa70-a39cc20dff51.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -28035,7 +28035,7 @@
         },
         {
             "id": "ffee0e42-5651-5a4e-81b1-677f486a51ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03438868-e177-46af-9ae8-edc4a991f18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03438868-e177-46af-9ae8-edc4a991f18c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -28074,7 +28074,7 @@
         },
         {
             "id": "7a23f450-efcf-51af-8d50-97818186198b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f0063-9a59-4ce1-90b5-e45921d5cc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f0063-9a59-4ce1-90b5-e45921d5cc3c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -28113,7 +28113,7 @@
         },
         {
             "id": "69f1dbea-4b04-5b36-a094-db9457a49116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e7f83-4a77-4544-ac4f-53b8c993724d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e7f83-4a77-4544-ac4f-53b8c993724d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -28152,7 +28152,7 @@
         },
         {
             "id": "3ab4754a-a7d2-5150-91f6-c5660f02ed98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63803c6b-144c-4c11-b8c1-4a1861085ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63803c6b-144c-4c11-b8c1-4a1861085ab7.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -28191,7 +28191,7 @@
         },
         {
             "id": "6c6f4a72-f149-5444-b1b2-b79ffa8917d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f08835-74ca-4ac5-980e-e802aada2bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f08835-74ca-4ac5-980e-e802aada2bb7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -28230,7 +28230,7 @@
         },
         {
             "id": "a1de425b-8f95-5e23-bfdc-69656fc7b519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748b9a1d-0fa3-41bc-beb0-7e3cf2eb33ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748b9a1d-0fa3-41bc-beb0-7e3cf2eb33ed.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -28269,7 +28269,7 @@
         },
         {
             "id": "d21de1cf-6f2b-5e90-9633-40d5e0c0d912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f64898e-d561-402e-8e4f-dda1ce241869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f64898e-d561-402e-8e4f-dda1ce241869.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -28308,7 +28308,7 @@
         },
         {
             "id": "dc901003-0852-5230-b658-4daf741f7fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db81be-753b-4d0e-9d66-9292364d2a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db81be-753b-4d0e-9d66-9292364d2a60.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -28347,7 +28347,7 @@
         },
         {
             "id": "b78e819d-73ff-5cda-98a2-644e1fac7757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08f11e-0f3f-464e-abe9-20f18de237d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08f11e-0f3f-464e-abe9-20f18de237d8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -28386,7 +28386,7 @@
         },
         {
             "id": "9595e31a-9567-570d-8aa2-02beaac5e9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a028172-c148-46fa-9afa-c5fdc7f9ba9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a028172-c148-46fa-9afa-c5fdc7f9ba9e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -28425,7 +28425,7 @@
         },
         {
             "id": "2c10bec7-d836-55c3-b43e-7d5808960f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210c54e-89fd-4971-ab6a-ca8f4e7fe97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210c54e-89fd-4971-ab6a-ca8f4e7fe97a.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all permanents they control that are one or more colors.",
             "colours": [],
@@ -28455,7 +28455,7 @@
         },
         {
             "id": "ec82ea26-67cc-599b-9d29-ff7e26c2e84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312fada-fc31-46ac-b6a1-cfffd776856f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312fada-fc31-46ac-b6a1-cfffd776856f.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast this spell, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -28484,7 +28484,7 @@
         },
         {
             "id": "ec657475-626e-5573-b0cd-c5c93c582a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb0fff-da50-40b9-9839-68cdf25a0193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb0fff-da50-40b9-9839-68cdf25a0193.jpg?1",
             "name": "Bane of Bala Ged",
             "text": "Whenever Bane of Bala Ged attacks, defending player exiles two permanents they control.",
             "colours": [],
@@ -28513,7 +28513,7 @@
         },
         {
             "id": "e345f2ac-c119-51f6-b026-4ba7fa59367d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ecacf-f036-45ea-8aa7-f012120429d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ecacf-f036-45ea-8aa7-f012120429d3.jpg?1",
             "name": "Endbringer",
             "text": "Untap Endbringer during each other player's untap step.\n{T}: Endbringer deals 1 damage to any target.\n{C}, {T}: Target creature can't attack or block this turn.\n{C}{C}, {T}: Draw a card.",
             "colours": [],
@@ -28542,7 +28542,7 @@
         },
         {
             "id": "8c87f05b-6db5-5c8d-adb3-904212022b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b3c10a-799f-4922-bb0a-44981b13203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b3c10a-799f-4922-bb0a-44981b13203b.jpg?1",
             "name": "Endless One",
             "text": "Endless One enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -28571,7 +28571,7 @@
         },
         {
             "id": "8360c19e-e299-57ad-8339-da401d9156f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08b369-783d-4fe4-8fc8-9cd595638550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08b369-783d-4fe4-8fc8-9cd595638550.jpg?1",
             "name": "It That Betrays",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nWhenever an opponent sacrifices a nontoken permanent, put that card onto the battlefield under your control.",
             "colours": [],
@@ -28600,7 +28600,7 @@
         },
         {
             "id": "01ad6c61-d28f-5b18-afbc-105753c6b14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e6e9aa-2e5f-49f7-beef-b876c070d72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e6e9aa-2e5f-49f7-beef-b876c070d72d.jpg?1",
             "name": "Matter Reshaper",
             "text": "When Matter Reshaper dies, reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with mana value 3 or less. Otherwise, put that card into your hand.",
             "colours": [],
@@ -28629,7 +28629,7 @@
         },
         {
             "id": "ecfe293a-084f-56b4-b357-b2c31e1d4d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18ce39e-211d-460b-a200-a26c17aeeb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18ce39e-211d-460b-a200-a26c17aeeb12.jpg?1",
             "name": "Not of This World",
             "text": "Counter target spell or ability that targets a permanent you control.\nThis spell costs {7} less to cast if it targets a spell or ability that targets a creature you control with power 7 or greater.",
             "colours": [],
@@ -28659,7 +28659,7 @@
         },
         {
             "id": "aff894a6-8724-5d62-8128-e9771200dda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef15a89-8df8-48f6-9fbf-0117efde9fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef15a89-8df8-48f6-9fbf-0117efde9fe0.jpg?1",
             "name": "Oblivion Sower",
             "text": "When you cast this spell, target opponent exiles the top four cards of their library, then you may put any number of land cards that player owns from exile onto the battlefield under your control.",
             "colours": [],
@@ -28688,7 +28688,7 @@
         },
         {
             "id": "7693c429-17f8-5da0-8a7e-ee3a836a5271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd2f8b3-62f3-4e52-ae17-dd0a61bc0e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd2f8b3-62f3-4e52-ae17-dd0a61bc0e26.jpg?1",
             "name": "Spatial Contortion",
             "text": "Target creature gets +3/-3 until end of turn.",
             "colours": [],
@@ -28715,7 +28715,7 @@
         },
         {
             "id": "e0a4fb96-ce05-515a-9a66-781917d962c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8cf3f-1ca8-41e4-b0f7-ea9d61f731d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8cf3f-1ca8-41e4-b0f7-ea9d61f731d7.jpg?1",
             "name": "Titan's Presence",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
             "colours": [],
@@ -28742,7 +28742,7 @@
         },
         {
             "id": "9a85178e-805e-57b6-8768-365109646cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb7e322-aba0-42f5-80a1-267f3444ac4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb7e322-aba0-42f5-80a1-267f3444ac4d.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "Colorless spells you cast cost {2} less to cast.\n+1: Exile the top card of your library face down and look at it. Create a 2/2 colorless Spirit creature token. When that token leaves the battlefield, put the exiled card into your hand.\n\u22123: Destroy target permanent that's one or more colors.",
             "colours": [],
@@ -28773,7 +28773,7 @@
         },
         {
             "id": "39ee95e8-84c7-554c-a3aa-0d90b1382694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcc9c88-836b-48b6-9d81-5a6844a6b70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcc9c88-836b-48b6-9d81-5a6844a6b70f.jpg?1",
             "name": "Warping Wail",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power or toughness 1 or less.\n\u2022 Counter target sorcery spell.\n\u2022 Create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -28800,7 +28800,7 @@
         },
         {
             "id": "b62b819b-419b-53ef-b9fd-49487ab6b366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51825d35-cdb2-40fa-ab89-1625161b04af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51825d35-cdb2-40fa-ab89-1625161b04af.jpg?1",
             "name": "Ajani Steadfast",
             "text": "+1: Until end of turn, up to one target creature gets +1/+1 and gains first strike, vigilance, and lifelink.\n\u22122: Put a +1/+1 counter on each creature you control and a loyalty counter on each other planeswalker you control.\n\u22127: You get an emblem with \"If a source would deal damage to you or a planeswalker you control, prevent all but 1 of that damage.\"",
             "colours": [
@@ -28835,7 +28835,7 @@
         },
         {
             "id": "1ae4beb2-9ee4-5365-a1f8-3a45e8cf6380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d10ba2-0408-47a2-bb6f-9e12541fe100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d10ba2-0408-47a2-bb6f-9e12541fe100.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, create a 2/2 white Pegasus creature token with flying.",
             "colours": [
@@ -28868,7 +28868,7 @@
         },
         {
             "id": "6447e75f-7cd7-5c6f-9134-fd319f911bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae24f37-0788-4f53-af5a-c6c1f2b64894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae24f37-0788-4f53-af5a-c6c1f2b64894.jpg?1",
             "name": "Bonescythe Sliver",
             "text": "Sliver creatures you control have double strike.",
             "colours": [
@@ -28901,7 +28901,7 @@
         },
         {
             "id": "03967130-0007-57ff-bc99-54a001b9b1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ea506-262b-415f-86f2-d70ddfd15a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ea506-262b-415f-86f2-d70ddfd15a8d.jpg?1",
             "name": "Cast Out",
             "text": "Flash\nWhen Cast Out enters the battlefield, exile target nonland permanent an opponent controls until Cast Out leaves the battlefield.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -28932,7 +28932,7 @@
         },
         {
             "id": "cb902b43-357b-5b41-9afa-2818f010a5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167d2e51-eb69-488c-a6b6-042a7b0e1744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167d2e51-eb69-488c-a6b6-042a7b0e1744.jpg?1",
             "name": "Cleansing Nova",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all artifacts and enchantments.",
             "colours": [
@@ -28963,7 +28963,7 @@
         },
         {
             "id": "3542fc4a-313e-53d5-a542-0caa6681d396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7d8e62-9bc0-4064-81c5-919c076de086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7d8e62-9bc0-4064-81c5-919c076de086.jpg?1",
             "name": "Constricting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, you may exile target creature an opponent controls until this creature leaves the battlefield.\"",
             "colours": [
@@ -28996,7 +28996,7 @@
         },
         {
             "id": "e42db91d-146e-5104-83e6-10390e05e073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f4c453-97b4-4cd5-a766-85e5647f71d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f4c453-97b4-4cd5-a766-85e5647f71d5.jpg?1",
             "name": "Deploy the Gatewatch",
             "text": "Look at the top seven cards of your library. Put up to two planeswalker cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -29027,7 +29027,7 @@
         },
         {
             "id": "74e3af1d-6215-5161-9668-6781663c09d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08382257-68d5-493e-8754-2ff72e9321e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08382257-68d5-493e-8754-2ff72e9321e9.jpg?1",
             "name": "Elspeth, Sun's Champion",
             "text": "+1: Create three 1/1 white Soldier creature tokens.\n\u22123: Destroy all creatures with power 4 or greater.\n\u22127: You get an emblem with \"Creatures you control get +2/+2 and have flying.\"",
             "colours": [
@@ -29062,7 +29062,7 @@
         },
         {
             "id": "4517ff3c-0099-5a89-b853-e7838cfe1e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c11ef-e036-4c54-98b7-83b7b25e7c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c11ef-e036-4c54-98b7-83b7b25e7c1b.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -29093,7 +29093,7 @@
         },
         {
             "id": "2e87414b-04a9-563a-b9c1-132dd840b118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d608df31-bcc6-4fec-89f1-5cefe5c2ec99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d608df31-bcc6-4fec-89f1-5cefe5c2ec99.jpg?1",
             "name": "Gideon Jura",
             "text": "+2: During target opponent's next turn, creatures that player controls attack Gideon Jura if able.\n\u22122: Destroy target tapped creature.\n0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -29128,7 +29128,7 @@
         },
         {
             "id": "ed84f9f2-9a13-52f8-8164-340097ad2bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787574-7700-47ab-b57c-98ef968cce71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787574-7700-47ab-b57c-98ef968cce71.jpg?1",
             "name": "Grasp of Fate",
             "text": "When Grasp of Fate enters the battlefield, for each opponent, exile up to one target nonland permanent that player controls until Grasp of Fate leaves the battlefield. (Those permanents return under their owners' control.)",
             "colours": [
@@ -29159,7 +29159,7 @@
         },
         {
             "id": "213c9141-e1dc-50f8-b980-c6ed58d6fe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1cf888-dd41-4cc2-a16e-3414ef7a78ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1cf888-dd41-4cc2-a16e-3414ef7a78ed.jpg?1",
             "name": "Grateful Apparition",
             "text": "Flying\nWhenever Grateful Apparition deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -29192,7 +29192,7 @@
         },
         {
             "id": "6e6fc3ad-78fb-5c62-b4f7-bcaabd259c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1448ffd-42af-475c-8883-1933508a8a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1448ffd-42af-475c-8883-1933508a8a6a.jpg?1",
             "name": "Harsh Mercy",
             "text": "Each player chooses a creature type. Destroy all creatures that aren't of a type chosen this way. They can't be regenerated.",
             "colours": [
@@ -29223,7 +29223,7 @@
         },
         {
             "id": "fe2a0a09-4902-51f9-b1a7-344fc6488bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e9693-4996-498c-95f7-884d40341298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e9693-4996-498c-95f7-884d40341298.jpg?1",
             "name": "Heliod, God of the Sun",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nOther creatures you control have vigilance.\n{2}{W}{W}: Create a 2/1 white Cleric enchantment creature token.",
             "colours": [
@@ -29259,7 +29259,7 @@
         },
         {
             "id": "e58450be-810f-53a3-bf39-7d8512517d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1096cb83-a192-406a-9b95-d7cbb1a0df84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1096cb83-a192-406a-9b95-d7cbb1a0df84.jpg?1",
             "name": "Love Song of Night and Day",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You and target opponent each draw two cards.\nII \u2014 Create a 1/1 white Bird creature token with flying.\nIII \u2014 Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -29292,7 +29292,7 @@
         },
         {
             "id": "1300d9ee-4858-5ec8-8148-a6a968e28733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c0ee3e-054e-4b01-b333-4ef3bc904750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c0ee3e-054e-4b01-b333-4ef3bc904750.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -29326,7 +29326,7 @@
         },
         {
             "id": "c4fd3dc6-e589-5a6c-98a4-f371aa4bf87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25bbe18-709c-4ed3-a047-5578ecfaaba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25bbe18-709c-4ed3-a047-5578ecfaaba7.jpg?1",
             "name": "Norn's Annex",
             "text": "({PW} can be paid with either {W} or 2 life.)\nCreatures can't attack you or planeswalkers you control unless their controller pays {PW} for each of those creatures.",
             "colours": [
@@ -29357,7 +29357,7 @@
         },
         {
             "id": "22bf6135-40b8-51e3-8f64-916cff996c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3f02b-9408-46a5-8d25-f5cec553d600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3f02b-9408-46a5-8d25-f5cec553d600.jpg?1",
             "name": "Oath of Gideon",
             "text": "When Oath of Gideon enters the battlefield, create two 1/1 white Kor Ally creature tokens.\nEach planeswalker you control enters the battlefield with an additional loyalty counter on it.",
             "colours": [
@@ -29390,7 +29390,7 @@
         },
         {
             "id": "acdee86e-3678-5a40-8cf9-366d3b9d9e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e4f28-d1b1-41e4-a2f1-6613a952bca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e4f28-d1b1-41e4-a2f1-6613a952bca2.jpg?1",
             "name": "Omen of the Sun",
             "text": "Flash\nWhen Omen of the Sun enters the battlefield, create two 1/1 white Human Soldier creature tokens and you gain 2 life.\n{2}{W}, Sacrifice Omen of the Sun: Scry 2.",
             "colours": [
@@ -29421,7 +29421,7 @@
         },
         {
             "id": "94b37152-c741-56f1-b37d-4625b60884be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebabe38-a035-4c2d-89b5-760712f311b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebabe38-a035-4c2d-89b5-760712f311b8.jpg?1",
             "name": "Oreskos Explorer",
             "text": "When Oreskos Explorer enters the battlefield, search your library for up to X Plains cards, where X is the number of players who control more lands than you. Reveal those cards, put them into your hand, then shuffle.",
             "colours": [
@@ -29455,7 +29455,7 @@
         },
         {
             "id": "0dd0c508-7093-5adc-ad93-07eef2573d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ae3bb-c22f-495f-82e3-cf909e8a8e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ae3bb-c22f-495f-82e3-cf909e8a8e49.jpg?1",
             "name": "Promise of Loyalty",
             "text": "Each player puts a vow counter on a creature they control and sacrifices the rest. Each of those creatures can't attack you or planeswalkers you control for as long as it has a vow counter on it.",
             "colours": [
@@ -29486,7 +29486,7 @@
         },
         {
             "id": "f106958a-f070-56e2-84a7-ce3d47aec54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2bb091-ac6d-4c99-bdf6-70ffb6291ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2bb091-ac6d-4c99-bdf6-70ffb6291ef0.jpg?1",
             "name": "Semester's End",
             "text": "Exile any number of target creatures and/or planeswalkers you control. At the beginning of the next end step, return each of them to the battlefield under its owner's control. Each of them enters the battlefield with an additional +1/+1 counter on it if it's a creature and an additional loyalty counter on it if it's a planeswalker.",
             "colours": [
@@ -29517,7 +29517,7 @@
         },
         {
             "id": "15251510-2b32-5416-af89-87c5ebf1c6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb2cc85-f4a6-47ad-b94e-f16534d02ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb2cc85-f4a6-47ad-b94e-f16534d02ae2.jpg?1",
             "name": "Sentinel Sliver",
             "text": "Sliver creatures you control have vigilance.",
             "colours": [
@@ -29550,7 +29550,7 @@
         },
         {
             "id": "4d9e26e2-0528-5a11-9d8d-458165ccbc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394fad93-ecdf-4f05-be17-291ca246262f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394fad93-ecdf-4f05-be17-291ca246262f.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -29581,7 +29581,7 @@
         },
         {
             "id": "f9eac973-33bc-5c1b-a64d-15dff9ff82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc983e-bbe3-4bc1-97e9-e40ead987ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc983e-bbe3-4bc1-97e9-e40ead987ef0.jpg?1",
             "name": "Sinew Sliver",
             "text": "All Sliver creatures get +1/+1.",
             "colours": [
@@ -29614,7 +29614,7 @@
         },
         {
             "id": "e7043888-c45b-58ca-8d6a-518ded5ebeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e038684-c476-41db-a1b1-57c46e5b4c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e038684-c476-41db-a1b1-57c46e5b4c9a.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -29648,7 +29648,7 @@
         },
         {
             "id": "a12889a8-71bf-5fd7-b6d6-f8ff045e410c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15b82ed-0c5c-4cc8-84ee-ce8e3b630c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15b82ed-0c5c-4cc8-84ee-ce8e3b630c86.jpg?1",
             "name": "Starfield Mystic",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Starfield Mystic.",
             "colours": [
@@ -29682,7 +29682,7 @@
         },
         {
             "id": "a50dbd25-658a-5d98-b40c-013d09f73745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e1cb-ceee-46aa-96d1-f3f26516cd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e1cb-ceee-46aa-96d1-f3f26516cd77.jpg?1",
             "name": "Starfield of Nyx",
             "text": "At the beginning of your upkeep, you may return target enchantment card from your graveyard to the battlefield.\nAs long as you control five or more enchantments, each other non-Aura enchantment you control is a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -29713,7 +29713,7 @@
         },
         {
             "id": "12a1b1ab-1a98-5018-a14f-b25c160563a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ecba4b-9624-428f-a8af-dd88139ab13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ecba4b-9624-428f-a8af-dd88139ab13c.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -29744,7 +29744,7 @@
         },
         {
             "id": "0ad2ed3a-6204-5189-93b3-4f96f8082ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b10977-64eb-4a50-a481-d67cc2950f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b10977-64eb-4a50-a481-d67cc2950f56.jpg?1",
             "name": "Urza's Ruinous Blast",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nExile all nonland permanents that aren't legendary.",
             "colours": [
@@ -29777,7 +29777,7 @@
         },
         {
             "id": "9c883e95-5e46-5656-a5cb-f448c2fbe7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ec3686-cecd-4dee-8a68-c3e4baec25ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ec3686-cecd-4dee-8a68-c3e4baec25ca.jpg?1",
             "name": "The Wanderer",
             "text": "Prevent all noncombat damage that would be dealt to you and other permanents you control.\n\u22122: Exile target creature with power 4 or greater.",
             "colours": [
@@ -29810,7 +29810,7 @@
         },
         {
             "id": "169de5a9-38b0-5b44-9db8-415a3aaf5992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e8e7b9-042e-4d01-87dd-27dc95257113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e8e7b9-042e-4d01-87dd-27dc95257113.jpg?1",
             "name": "Deepglow Skate",
             "text": "When Deepglow Skate enters the battlefield, double the number of each kind of counter on any number of target permanents.",
             "colours": [
@@ -29843,7 +29843,7 @@
         },
         {
             "id": "db705e5b-06a7-5fef-b8cf-1d7b10654ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5994259-8d16-4f12-b528-1821005f79af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5994259-8d16-4f12-b528-1821005f79af.jpg?1",
             "name": "Diffusion Sliver",
             "text": "Whenever a Sliver creature you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.",
             "colours": [
@@ -29876,7 +29876,7 @@
         },
         {
             "id": "96687795-67ab-51dd-984f-0ada82152627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73c83b5-3a91-4495-b6fb-20cdc6edd07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73c83b5-3a91-4495-b6fb-20cdc6edd07b.jpg?1",
             "name": "Distant Melody",
             "text": "Choose a creature type. Draw a card for each permanent you control of that type.",
             "colours": [
@@ -29907,7 +29907,7 @@
         },
         {
             "id": "689de23c-4c45-5472-84cf-5c6e65b4b889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c520263-6bad-4521-ba9e-192ca8223b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c520263-6bad-4521-ba9e-192ca8223b07.jpg?1",
             "name": "Flux Channeler",
             "text": "Whenever you cast a noncreature spell, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -29941,7 +29941,7 @@
         },
         {
             "id": "e605c5d8-29cf-55b0-8f41-084d66fe044f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14fb062-ff43-43eb-aaaf-304a876d5962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14fb062-ff43-43eb-aaaf-304a876d5962.jpg?1",
             "name": "Fog Bank",
             "text": "Defender, flying\nPrevent all combat damage that would be dealt to and dealt by Fog Bank.",
             "colours": [
@@ -29974,7 +29974,7 @@
         },
         {
             "id": "e7144a08-5077-5613-8b3e-18d4682c7009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dc671-b666-4003-a3a6-ff5b081bca54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dc671-b666-4003-a3a6-ff5b081bca54.jpg?1",
             "name": "Galerider Sliver",
             "text": "Sliver creatures you control have flying.",
             "colours": [
@@ -30007,7 +30007,7 @@
         },
         {
             "id": "3b665e6a-2751-518d-b54f-c778f0df71ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d4e61-004f-4e52-b2e8-ba11b922cc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d4e61-004f-4e52-b2e8-ba11b922cc7d.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n\u22121: Target player draws a card.\n\u221210: Target player mills twenty cards.",
             "colours": [
@@ -30042,7 +30042,7 @@
         },
         {
             "id": "d2f1f550-b13a-558b-96af-d9f06aec0f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7051cdfa-509e-4d84-bbae-f77556c861e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7051cdfa-509e-4d84-bbae-f77556c861e4.jpg?1",
             "name": "Jace, Architect of Thought",
             "text": "+1: Until your next turn, whenever a creature an opponent controls attacks, it gets -1/-0 until end of turn.\n\u22122: Reveal the top three cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other on the bottom of your library in any order.\n\u22128: For each player, search that player's library for a nonland card and exile it, then that player shuffles. You may cast those cards without paying their mana costs.",
             "colours": [
@@ -30077,7 +30077,7 @@
         },
         {
             "id": "f764ad80-2af5-59e6-bbcb-e2ca4e677905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d34cbf-e424-461a-adf3-003d556a7859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d34cbf-e424-461a-adf3-003d556a7859.jpg?1",
             "name": "Jace, Mirror Mage",
             "text": "Kicker {2}\nWhen Jace, Mirror Mage enters the battlefield, if Jace was kicked, create a token that's a copy of Jace, Mirror Mage, except it's not legendary and its starting loyalty is 1.\n+1: Scry 2.\n0: Draw a card and reveal it. Remove a number of loyalty counters equal to that card's mana value from Jace, Mirror Mage.",
             "colours": [
@@ -30112,7 +30112,7 @@
         },
         {
             "id": "43ee97f6-2c73-5c3f-83d4-c684f056056a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6e5c63-b6e5-4756-bf23-6c6f8669442d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6e5c63-b6e5-4756-bf23-6c6f8669442d.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "Each opponent can't draw more than one card each turn.\n\u22122: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -30147,7 +30147,7 @@
         },
         {
             "id": "d237c1c2-256a-59a7-bd4c-a282cd26c641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62e9a8-d1aa-4fea-abb7-50c10d40fa6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62e9a8-d1aa-4fea-abb7-50c10d40fa6a.jpg?1",
             "name": "Oath of Jace",
             "text": "When Oath of Jace enters the battlefield, draw three cards, then discard two cards.\nAt the beginning of your upkeep, scry X, where X is the number of planeswalkers you control.",
             "colours": [
@@ -30180,7 +30180,7 @@
         },
         {
             "id": "f0df9618-90c7-5aef-897b-025389f56244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d3b30b-d4c4-4f60-a7b3-e8854bd203d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d3b30b-d4c4-4f60-a7b3-e8854bd203d5.jpg?1",
             "name": "Shifting Sliver",
             "text": "Slivers can't be blocked except by Slivers.",
             "colours": [
@@ -30213,7 +30213,7 @@
         },
         {
             "id": "c810fc9e-78f4-552c-9225-0c525cf6cc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbb32db-fb1d-4f47-a258-fa1a0a00bd76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbb32db-fb1d-4f47-a258-fa1a0a00bd76.jpg?1",
             "name": "Spark Double",
             "text": "You may have Spark Double enter the battlefield as a copy of a creature or planeswalker you control, except it enters with an additional +1/+1 counter on it if it's a creature, it enters with an additional loyalty counter on it if it's a planeswalker, and it isn't legendary.",
             "colours": [
@@ -30246,7 +30246,7 @@
         },
         {
             "id": "bc47336c-d4c4-5a1c-b605-e83fa59bc1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c458a0f-0e63-417f-b51e-8491822835b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c458a0f-0e63-417f-b51e-8491822835b0.jpg?1",
             "name": "Synapse Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may draw a card.",
             "colours": [
@@ -30279,7 +30279,7 @@
         },
         {
             "id": "ccf95c65-1663-5c6e-bb76-a6cda4a28209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff84d8-1b89-42cc-a8c0-4ac6fa26ce65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff84d8-1b89-42cc-a8c0-4ac6fa26ce65.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -30314,7 +30314,7 @@
         },
         {
             "id": "69e05402-e64f-5bd8-9856-90db6ecedd58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4448fa01-1f81-41dc-9046-cfae41601bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4448fa01-1f81-41dc-9046-cfae41601bc4.jpg?1",
             "name": "Windfall",
             "text": "Each player discards their hand, then draws cards equal to the greatest number of cards a player discarded this way.",
             "colours": [
@@ -30345,7 +30345,7 @@
         },
         {
             "id": "b5272cb6-5c8d-5cc9-9936-d350d7c0e38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1fcaf2-fee3-4088-83e1-bcb72e8c0e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1fcaf2-fee3-4088-83e1-bcb72e8c0e88.jpg?1",
             "name": "Winged Sliver",
             "text": "All Sliver creatures have flying.",
             "colours": [
@@ -30378,7 +30378,7 @@
         },
         {
             "id": "39775821-9db7-5ebc-bb21-edf6aeb946a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fb777-0cbb-4c04-8b30-f2806366a957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fb777-0cbb-4c04-8b30-f2806366a957.jpg?1",
             "name": "Clot Sliver",
             "text": "All Slivers have \"{2}: Regenerate this permanent.\" (The next time this permanent would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -30411,7 +30411,7 @@
         },
         {
             "id": "a66ef8d7-3d26-593a-9e09-c332013a0ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a28c0-0d12-4c62-bc91-59c2ddfc9ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a28c0-0d12-4c62-bc91-59c2ddfc9ef8.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -30442,7 +30442,7 @@
         },
         {
             "id": "4735b657-5a8d-5273-97f1-cea5ca94ccbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90c9a9-098b-463a-8588-b078fb0364dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90c9a9-098b-463a-8588-b078fb0364dd.jpg?1",
             "name": "Crypt Sliver",
             "text": "All Slivers have \"{T}: Regenerate target Sliver.\" (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -30475,7 +30475,7 @@
         },
         {
             "id": "8c2bd9c7-92ac-5b92-83a5-eb19c6a7d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873ad15-e633-4858-8f6b-4cc3e561725f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873ad15-e633-4858-8f6b-4cc3e561725f.jpg?1",
             "name": "Cunning Rhetoric",
             "text": "Whenever an opponent attacks you and/or one or more planeswalkers you control, exile the top card of that player's library. You may play that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -30506,7 +30506,7 @@
         },
         {
             "id": "251875a4-0df6-5eb3-abde-535979d4e3c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082ddc9-f20c-4d33-8db4-baba03ef22b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082ddc9-f20c-4d33-8db4-baba03ef22b9.jpg?1",
             "name": "Doomwake Giant",
             "text": "Constellation \u2014 Whenever Doomwake Giant or another enchantment enters the battlefield under your control, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -30540,7 +30540,7 @@
         },
         {
             "id": "f422725e-b808-5c84-bbb5-c53fdeedad09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a6a3b-8809-4d22-bf1e-c4620c609aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a6a3b-8809-4d22-bf1e-c4620c609aba.jpg?1",
             "name": "Dreadhorde Invasion",
             "text": "At the beginning of your upkeep, you lose 1 life and amass Zombies 1. (Put a +1/+1 counter on an Army you control. It's also a Zombie. If you don't control an Army, create a 0/0 black Zombie Army creature token first.)\nWhenever a Zombie token you control with power 6 or greater attacks, it gains lifelink until end of turn.",
             "colours": [
@@ -30571,7 +30571,7 @@
         },
         {
             "id": "530d16ca-c4b4-5f5e-b591-246a5f8482e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06831e80-845d-4bd7-8fdc-8140eb606fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06831e80-845d-4bd7-8fdc-8140eb606fe4.jpg?1",
             "name": "The Eldest Reborn",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each opponent sacrifices a creature or planeswalker.\nII \u2014 Each opponent discards a card.\nIII \u2014 Put target creature or planeswalker card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -30604,7 +30604,7 @@
         },
         {
             "id": "553a8d9b-be0d-576b-95e2-1e882b21630d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84701927-799f-4af4-85b8-389f903c5bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84701927-799f-4af4-85b8-389f903c5bc0.jpg?1",
             "name": "Erebos, Bleak-Hearted",
             "text": "Indestructible\nAs long as your devotion to black is less than five, Erebos isn't a creature.\nWhenever another creature you control dies, you may pay 2 life. If you do, draw a card.\n{1}{B}, Sacrifice another creature: Target creature gets -2/-1 until end of turn.",
             "colours": [
@@ -30640,7 +30640,7 @@
         },
         {
             "id": "f488a19b-fa2f-5927-8919-d407e24a4001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dabd3ef-eac8-48ed-b2c1-f4ce8adcedf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dabd3ef-eac8-48ed-b2c1-f4ce8adcedf5.jpg?1",
             "name": "Mindwrack Harpy",
             "text": "Flying\nAt the beginning of combat on your turn, each player mills three cards. (They each put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -30674,7 +30674,7 @@
         },
         {
             "id": "c27d8e85-5cbb-5b27-a987-976db81ef23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222985-759c-4fdc-82ba-d970ef789b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222985-759c-4fdc-82ba-d970ef789b35.jpg?1",
             "name": "Syphon Sliver",
             "text": "Sliver creatures you control have lifelink.",
             "colours": [
@@ -30707,7 +30707,7 @@
         },
         {
             "id": "a7f8ea77-80b3-5d40-ad08-ffcf0a90937f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1165c2-9ea9-459b-a56a-5c0d0e9ae66a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1165c2-9ea9-459b-a56a-5c0d0e9ae66a.jpg?1",
             "name": "Blade Sliver",
             "text": "All Sliver creatures get +1/+0.",
             "colours": [
@@ -30740,7 +30740,7 @@
         },
         {
             "id": "e6d43e4b-29ce-5394-8de6-a94e77ff4d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd15a627-f7a6-4d66-abb5-5aaa167b41a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd15a627-f7a6-4d66-abb5-5aaa167b41a9.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -30771,7 +30771,7 @@
         },
         {
             "id": "18ed9705-746a-5a9d-beed-519941cdff11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44db4fa-8b13-4eb2-a66e-a55b2e0c0fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44db4fa-8b13-4eb2-a66e-a55b2e0c0fb3.jpg?1",
             "name": "Blur Sliver",
             "text": "Sliver creatures you control have haste.",
             "colours": [
@@ -30804,7 +30804,7 @@
         },
         {
             "id": "35ad6128-5139-52c6-864b-c843876dec1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83327f18-f9f6-4f9b-b72a-68f85ad96b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83327f18-f9f6-4f9b-b72a-68f85ad96b00.jpg?1",
             "name": "Bonesplitter Sliver",
             "text": "All Sliver creatures get +2/+0.",
             "colours": [
@@ -30837,7 +30837,7 @@
         },
         {
             "id": "7dce48f7-be41-5afa-8c64-0cfdf320fb8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4fb926-fe8c-4640-ac8d-ef418b8945d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4fb926-fe8c-4640-ac8d-ef418b8945d5.jpg?1",
             "name": "Chandra, Awakened Inferno",
             "text": "This spell can't be countered.\n+2: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n\u22123: Chandra, Awakened Inferno deals 3 damage to each non-Elemental creature.\n\u2212X: Chandra, Awakened Inferno deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -30872,7 +30872,7 @@
         },
         {
             "id": "dccde01c-2c7d-5659-9fbb-5628d2997d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eac0eaa-55b2-444a-863d-c66769aab4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eac0eaa-55b2-444a-863d-c66769aab4ee.jpg?1",
             "name": "Chandra, Torch of Defiance",
             "text": "+1: Exile the top card of your library. You may cast that card. If you don't, Chandra, Torch of Defiance deals 2 damage to each opponent.\n+1: Add {R}{R}.\n\u22123: Chandra, Torch of Defiance deals 4 damage to target creature.\n\u22127: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to any target.\"",
             "colours": [
@@ -30907,7 +30907,7 @@
         },
         {
             "id": "7680cd89-5c34-51b1-9047-41f346bead26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023dd90c-eb55-4876-94c9-b8058c80e82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023dd90c-eb55-4876-94c9-b8058c80e82d.jpg?1",
             "name": "Cleaving Sliver",
             "text": "Sliver creatures you control get +2/+0.",
             "colours": [
@@ -30940,7 +30940,7 @@
         },
         {
             "id": "b6a58643-390e-5bbf-a3c1-edc47dfe6079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c444a566-bcb1-424b-b66b-55ce87e4d98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c444a566-bcb1-424b-b66b-55ce87e4d98f.jpg?1",
             "name": "Hollowhead Sliver",
             "text": "Sliver creatures you control have \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -30973,7 +30973,7 @@
         },
         {
             "id": "d306cb4b-f60d-5280-ae1a-be36a562f035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb03593-9369-4c26-bfcc-8819648dc018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb03593-9369-4c26-bfcc-8819648dc018.jpg?1",
             "name": "Repeated Reverberation",
             "text": "When you next cast an instant spell, cast a sorcery spell, or activate a loyalty ability this turn, copy that spell or ability twice. You may choose new targets for the copies.",
             "colours": [
@@ -31004,7 +31004,7 @@
         },
         {
             "id": "655e29c6-baaa-5d3e-b3f4-7843f6692f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aced16a-ebbd-47bb-a4c4-9454afa9971c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aced16a-ebbd-47bb-a4c4-9454afa9971c.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "Whenever a creature attacks you or a planeswalker you control, each Dragon you control deals 1 damage to that creature.\n+1: Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.\n\u22123: Create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -31039,7 +31039,7 @@
         },
         {
             "id": "bce3d33f-bba5-56f8-a32b-ef4a670bde68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fb60c9-d10d-4966-b9bd-788fabc182d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fb60c9-d10d-4966-b9bd-788fabc182d2.jpg?1",
             "name": "Spiteful Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker.\"",
             "colours": [
@@ -31072,7 +31072,7 @@
         },
         {
             "id": "352d1ce7-8d28-582f-8c29-5fb9317988c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4652793-6f02-4bb6-8f71-eef302a001c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4652793-6f02-4bb6-8f71-eef302a001c6.jpg?1",
             "name": "Striking Sliver",
             "text": "Sliver creatures you control have first strike.",
             "colours": [
@@ -31105,7 +31105,7 @@
         },
         {
             "id": "79939c6e-9e59-5712-aef8-97c8297010e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd73d00-feb0-4ec6-8031-6af5b334bba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd73d00-feb0-4ec6-8031-6af5b334bba3.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -31138,7 +31138,7 @@
         },
         {
             "id": "9aa887c3-3206-5055-8e87-9f8803c56532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc359b0-8886-415b-a497-e98a2241084e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc359b0-8886-415b-a497-e98a2241084e.jpg?1",
             "name": "Abundance",
             "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -31169,7 +31169,7 @@
         },
         {
             "id": "849629b1-b09f-5e6c-8d8c-91174463f3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882be812-fc76-4493-abe2-2101603399ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882be812-fc76-4493-abe2-2101603399ce.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -31205,7 +31205,7 @@
         },
         {
             "id": "fe412c9a-fd5b-506d-ba5d-548064926e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c03969-db08-4af3-8c83-b13750e8b20a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c03969-db08-4af3-8c83-b13750e8b20a.jpg?1",
             "name": "The Binding of the Titans",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player mills three cards.\nII \u2014 Exile up to two target cards from graveyards. For each creature card exiled this way, you gain 1 life.\nIII \u2014 Return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -31238,7 +31238,7 @@
         },
         {
             "id": "8a56bdee-f6b6-5989-949c-f2bcafa6787e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a387b-e18a-41c7-84bb-bb7e354f4f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a387b-e18a-41c7-84bb-bb7e354f4f2d.jpg?1",
             "name": "Brood Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may create a 1/1 colorless Sliver creature token.",
             "colours": [
@@ -31271,7 +31271,7 @@
         },
         {
             "id": "8e641b8e-ded0-5f27-8a63-94bf877d3f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc63d2ea-a980-466e-9ebb-f28008f84c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc63d2ea-a980-466e-9ebb-f28008f84c3d.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play lands from the top of your library.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -31305,7 +31305,7 @@
         },
         {
             "id": "24309bc2-3212-51ea-b247-e8db65fc3a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34b52-7a67-44b4-82e7-2860729ba410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34b52-7a67-44b4-82e7-2860729ba410.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -31336,7 +31336,7 @@
         },
         {
             "id": "5d53e26e-2029-5e49-ad86-84e6bed88142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc3804b-3304-4add-81b4-0482bfed8074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc3804b-3304-4add-81b4-0482bfed8074.jpg?1",
             "name": "Destiny Spinner",
             "text": "Creature and enchantment spells you control can't be countered.\n{3}{G}: Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.",
             "colours": [
@@ -31370,7 +31370,7 @@
         },
         {
             "id": "a7e8b8b3-dbfc-566a-a5ce-dd1e5b9408b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43be1363-7e73-4862-b45f-07f490ab46be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43be1363-7e73-4862-b45f-07f490ab46be.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "You may play an additional land on each of your turns.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -31405,7 +31405,7 @@
         },
         {
             "id": "7ac8331c-35d2-5d4c-9957-04855cb4a3c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f882aa63-d43c-4359-9de6-77231500a08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f882aa63-d43c-4359-9de6-77231500a08e.jpg?1",
             "name": "Eidolon of Blossoms",
             "text": "Constellation \u2014 Whenever Eidolon of Blossoms or another enchantment enters the battlefield under your control, draw a card.",
             "colours": [
@@ -31439,7 +31439,7 @@
         },
         {
             "id": "13776945-ac33-53d1-b439-c0f528b3c9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50538b-f866-4e75-8856-2ad8af635011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50538b-f866-4e75-8856-2ad8af635011.jpg?1",
             "name": "Enchantress's Presence",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -31470,7 +31470,7 @@
         },
         {
             "id": "322cb64e-7cba-5849-b84c-ae27a4e7348e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b7c0df-5af2-4a01-86b3-b2ed5d60e613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b7c0df-5af2-4a01-86b3-b2ed5d60e613.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31501,7 +31501,7 @@
         },
         {
             "id": "202cc22e-9155-5e22-806a-dd68756a4de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e85cd4-c116-42e2-a94b-2c04b06c4e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e85cd4-c116-42e2-a94b-2c04b06c4e2b.jpg?1",
             "name": "Font of Fertility",
             "text": "{1}{G}, Sacrifice Font of Fertility: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31532,7 +31532,7 @@
         },
         {
             "id": "cc2c7a24-d070-5c54-9bb9-664ba5acdad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224af68a-41a6-4e4e-94d0-130be341b788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224af68a-41a6-4e4e-94d0-130be341b788.jpg?1",
             "name": "Gemhide Sliver",
             "text": "All Slivers have \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -31565,7 +31565,7 @@
         },
         {
             "id": "37c8d7c3-c0f2-556d-88da-d5fc6184fe3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb4b3-9926-4e06-b107-a7a39584fa7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb4b3-9926-4e06-b107-a7a39584fa7a.jpg?1",
             "name": "Greater Tanuki",
             "text": "Trample\nChannel \u2014 {2}{G}, Discard Greater Tanuki: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31599,7 +31599,7 @@
         },
         {
             "id": "9f3452fb-7d03-5c74-8f69-8963e8448d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360af3e-626d-46c9-99cf-6c85921f5d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360af3e-626d-46c9-99cf-6c85921f5d26.jpg?1",
             "name": "Herald of the Pantheon",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life.",
             "colours": [
@@ -31633,7 +31633,7 @@
         },
         {
             "id": "14478ed3-a11f-569b-8db6-235d331ca15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159c309c-568d-4780-9db5-b50a997e7bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159c309c-568d-4780-9db5-b50a997e7bb2.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31664,7 +31664,7 @@
         },
         {
             "id": "9737d763-aaec-53d4-aca2-50e1a5d54179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51629ac-51d5-47cb-a7fc-315b34dd82ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51629ac-51d5-47cb-a7fc-315b34dd82ce.jpg?1",
             "name": "Manaweft Sliver",
             "text": "Sliver creatures you control have \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -31697,7 +31697,7 @@
         },
         {
             "id": "b676f0f0-7fe2-5c5f-96d7-77925dd0b9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1afd5-d1d3-42b7-8417-bb05c91ef822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1afd5-d1d3-42b7-8417-bb05c91ef822.jpg?1",
             "name": "Megantic Sliver",
             "text": "Sliver creatures you control get +3/+3.",
             "colours": [
@@ -31730,7 +31730,7 @@
         },
         {
             "id": "2289de55-94f3-5ab5-b49f-5e2a1f42bb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf47fb5-2072-473d-96f9-5cdb7840f887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf47fb5-2072-473d-96f9-5cdb7840f887.jpg?1",
             "name": "The Mending of Dominaria",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Mill two cards, then you may return a creature card from your graveyard to your hand.\nIII \u2014 Return all land cards from your graveyard to the battlefield, then shuffle your graveyard into your library.",
             "colours": [
@@ -31763,7 +31763,7 @@
         },
         {
             "id": "4365ee29-e745-5279-9446-d88f8bdd080c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c783dfd2-a935-41e0-bd8e-97ac81f771b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c783dfd2-a935-41e0-bd8e-97ac81f771b2.jpg?1",
             "name": "Might Sliver",
             "text": "All Sliver creatures get +2/+2.",
             "colours": [
@@ -31796,7 +31796,7 @@
         },
         {
             "id": "440945e0-989d-55f9-a600-6dd221ca13b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78584e8-bb82-4977-a27d-68b1befe9b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78584e8-bb82-4977-a27d-68b1befe9b3b.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -31827,7 +31827,7 @@
         },
         {
             "id": "dbf8d5a1-7704-568e-a6c8-e46762347a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4789a2-f201-4b05-954d-527d169de091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4789a2-f201-4b05-954d-527d169de091.jpg?1",
             "name": "Nessian Wanderer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, look at the top three cards of your library. You may reveal a land card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -31861,7 +31861,7 @@
         },
         {
             "id": "82e23831-946c-5355-9a26-2acdc27891f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d5877d-fa0f-4117-adc1-9153aeba4777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d5877d-fa0f-4117-adc1-9153aeba4777.jpg?1",
             "name": "Omen of the Hunt",
             "text": "Flash\nWhen Omen of the Hunt enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{2}{G}, Sacrifice Omen of the Hunt: Scry 2.",
             "colours": [
@@ -31892,7 +31892,7 @@
         },
         {
             "id": "83fbf8d1-0d2f-5e87-ab39-94abca3884df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7749b2d-05a6-40ec-8d6a-8c1223cd5a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7749b2d-05a6-40ec-8d6a-8c1223cd5a09.jpg?1",
             "name": "Quick Sliver",
             "text": "Flash\nAny player may cast Sliver spells as though they had flash.",
             "colours": [
@@ -31925,7 +31925,7 @@
         },
         {
             "id": "e1292f93-5b7a-5d8a-b38d-5ab460ae1404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f4640f-563d-48a7-86d1-42737570121d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f4640f-563d-48a7-86d1-42737570121d.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31956,7 +31956,7 @@
         },
         {
             "id": "c55ee0b9-576a-5b63-8732-36f1284199d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c65ef6-93b4-448b-bf1c-01fe263cc39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c65ef6-93b4-448b-bf1c-01fe263cc39d.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling (This card is every creature type.)\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -31989,7 +31989,7 @@
         },
         {
             "id": "c4da421d-0399-5272-8052-efa8bc7d3da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9ac089-6962-48fd-bf67-f041ece27fa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9ac089-6962-48fd-bf67-f041ece27fa9.jpg?1",
             "name": "Sanctum Weaver",
             "text": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
             "colours": [
@@ -32023,7 +32023,7 @@
         },
         {
             "id": "71fbb42c-2974-5a7c-b3b3-59ee9b1662ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e64ba-5501-4212-b0b6-2a47f64d226a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e64ba-5501-4212-b0b6-2a47f64d226a.jpg?1",
             "name": "Sandwurm Convergence",
             "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
             "colours": [
@@ -32054,7 +32054,7 @@
         },
         {
             "id": "c9d5abc5-9439-541b-ae89-b246a7c252cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7680a8e1-cd59-43c5-8f06-426b918692c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7680a8e1-cd59-43c5-8f06-426b918692c8.jpg?1",
             "name": "Setessan Champion",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, put a +1/+1 counter on Setessan Champion and draw a card.",
             "colours": [
@@ -32088,7 +32088,7 @@
         },
         {
             "id": "b4eb80ef-2a6a-5f6d-969c-fc041f2df17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b6126-c134-4d7d-aa06-ac0f409a9f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b6126-c134-4d7d-aa06-ac0f409a9f74.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -32119,7 +32119,7 @@
         },
         {
             "id": "a62a4b67-e9a4-5711-93b7-ffd04b3bb727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8f9e9-4505-485a-b6c6-a92a4da5155a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8f9e9-4505-485a-b6c6-a92a4da5155a.jpg?1",
             "name": "Venom Sliver",
             "text": "Sliver creatures you control have deathtouch.",
             "colours": [
@@ -32152,7 +32152,7 @@
         },
         {
             "id": "74b0debf-a529-5aa4-bc9d-e4384e4f51e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722a73a1-9497-4d8d-850c-ec6c6ab1b8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722a73a1-9497-4d8d-850c-ec6c6ab1b8d3.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -32186,7 +32186,7 @@
         },
         {
             "id": "56b48708-6318-52c6-8874-bf0ae02b1c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83e860a-6dd5-4522-8b2b-b730934f59f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83e860a-6dd5-4522-8b2b-b730934f59f7.jpg?1",
             "name": "Battle for Bretagard",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human Warrior creature token.\nII \u2014 Create a 1/1 green Elf Warrior creature token.\nIII \u2014 Choose any number of artifact tokens and/or creature tokens you control with different names. For each of them, create a token that's a copy of it.",
             "colours": [
@@ -32221,7 +32221,7 @@
         },
         {
             "id": "bbe70e07-aaf5-55de-98cd-d7d323c3f195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0297fc9-9070-41cc-83fd-0dea2a65c263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0297fc9-9070-41cc-83fd-0dea2a65c263.jpg?1",
             "name": "Binding the Old Gods",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target nonland permanent an opponent controls.\nII \u2014 Search your library for a Forest card, put it onto the battlefield tapped, then shuffle.\nIII \u2014 Creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -32256,7 +32256,7 @@
         },
         {
             "id": "a1bdaca7-d979-5f20-b48f-707063d09821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec142a-81c0-43e3-bf37-bdc18d7b780e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec142a-81c0-43e3-bf37-bdc18d7b780e.jpg?1",
             "name": "Calix, Destiny's Hand",
             "text": "+1: Look at the top four cards of your library. You may reveal an enchantment card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Exile target creature or enchantment you don't control until target enchantment you control leaves the battlefield.\n\u22127: Return all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -32293,7 +32293,7 @@
         },
         {
             "id": "9c836ebc-1b70-5d83-966d-95cc925726df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f523765-7704-4faf-a72b-8a2c414bb179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f523765-7704-4faf-a72b-8a2c414bb179.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "Sliver creatures you control have flying and haste.",
             "colours": [
@@ -32328,7 +32328,7 @@
         },
         {
             "id": "2f454f24-910f-5330-a1f6-ba40b6f7ed8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c7f341-c61e-491d-850a-221c6a57ac64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c7f341-c61e-491d-850a-221c6a57ac64.jpg?1",
             "name": "Crystalline Sliver",
             "text": "All Slivers have shroud. (They can't be the targets of spells or abilities.)",
             "colours": [
@@ -32363,7 +32363,7 @@
         },
         {
             "id": "2fc31b5c-187c-5b92-8d3c-e5e822c567ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422a569-d94e-41e7-b9e1-78b2e9fe505f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422a569-d94e-41e7-b9e1-78b2e9fe505f.jpg?1",
             "name": "Culling Ritual",
             "text": "Destroy each nonland permanent with mana value 2 or less. Add {B} or {G} for each permanent destroyed this way.",
             "colours": [
@@ -32396,7 +32396,7 @@
         },
         {
             "id": "8568bc28-050e-5aad-ab52-9ea235dcea42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc34be-e274-436a-81dd-ced0f90e657c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc34be-e274-436a-81dd-ced0f90e657c.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -32429,7 +32429,7 @@
         },
         {
             "id": "dec67b98-2d2c-582a-9a57-ba63a1524d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6201bcd-1009-4753-b7ac-5c25cc1a4d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6201bcd-1009-4753-b7ac-5c25cc1a4d79.jpg?1",
             "name": "Firewake Sliver",
             "text": "All Sliver creatures have haste.\nAll Slivers have \"{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn.\"",
             "colours": [
@@ -32464,7 +32464,7 @@
         },
         {
             "id": "118546c4-841b-5760-9048-105352e69e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1228d068-a5cb-4fd5-9e6a-5dc6ac9376a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1228d068-a5cb-4fd5-9e6a-5dc6ac9376a4.jpg?1",
             "name": "Harmonic Sliver",
             "text": "All Slivers have \"When this permanent enters the battlefield, destroy target artifact or enchantment.\"",
             "colours": [
@@ -32499,7 +32499,7 @@
         },
         {
             "id": "0933a754-a4b3-5c73-9346-d18ab4b92d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e224cfb-5bc1-490c-ab1e-f5405dc2fa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e224cfb-5bc1-490c-ab1e-f5405dc2fa0b.jpg?1",
             "name": "Hibernation Sliver",
             "text": "All Slivers have \"Pay 2 life: Return this permanent to its owner's hand.\"",
             "colours": [
@@ -32534,7 +32534,7 @@
         },
         {
             "id": "c5bd20c0-aa2d-5fd1-b867-8bbed120131b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ff517f-5c31-46e9-9efb-52bc9ec9298d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ff517f-5c31-46e9-9efb-52bc9ec9298d.jpg?1",
             "name": "Jukai Naturalist",
             "text": "Lifelink\nEnchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -32571,7 +32571,7 @@
         },
         {
             "id": "909d15e8-89d4-5179-9b15-2b30a107d3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0de3c85-0662-4374-bd21-65d3a34f2263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0de3c85-0662-4374-bd21-65d3a34f2263.jpg?1",
             "name": "Lavabelly Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, it deals 1 damage to target player or planeswalker and you gain 1 life.\"",
             "colours": [
@@ -32606,7 +32606,7 @@
         },
         {
             "id": "846627b3-c91f-5271-be98-ac17a3d8073f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4fa4e8-39e8-47a6-b975-ff5d46e59edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4fa4e8-39e8-47a6-b975-ff5d46e59edd.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -32639,7 +32639,7 @@
         },
         {
             "id": "4ab5518d-7f27-5242-810a-58952639120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b2cc03-5d07-43e1-a8d9-298d17a5af44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b2cc03-5d07-43e1-a8d9-298d17a5af44.jpg?1",
             "name": "Nahiri, the Harbinger",
             "text": "+2: You may discard a card. If you do, draw a card.\n\u22122: Exile target enchantment, tapped artifact, or tapped creature.\n\u22128: Search your library for an artifact or creature card, put it onto the battlefield, then shuffle. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -32676,7 +32676,7 @@
         },
         {
             "id": "51eebfd4-09fc-501e-9542-60b280d9f1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f766f-9609-4105-9ed5-4299c48f7fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f766f-9609-4105-9ed5-4299c48f7fa7.jpg?1",
             "name": "Narset of the Ancient Way",
             "text": "+1: You gain 2 life. Add {U}, {R}, or {W}. Spend this mana only to cast a noncreature spell.\n\u22122: Draw a card, then you may discard a card. When you discard a nonland card this way, Narset of the Ancient Way deals damage equal to that card's mana value to target creature or planeswalker.\n\u22126: You get an emblem with \"Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.\"",
             "colours": [
@@ -32715,7 +32715,7 @@
         },
         {
             "id": "8880a669-43a2-5cb3-905a-a06a8ba823e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b0d5f-1071-4030-be16-2b4dadbdf9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b0d5f-1071-4030-be16-2b4dadbdf9e9.jpg?1",
             "name": "Narset, Enlightened Master",
             "text": "First strike, hexproof\nWhenever Narset, Enlightened Master attacks, exile the top four cards of your library. Until end of turn, you may cast noncreature spells from among those cards without paying their mana costs.",
             "colours": [
@@ -32755,7 +32755,7 @@
         },
         {
             "id": "973b8391-0a20-554f-b1fa-ff113ae73e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f4e782-5503-4698-a1ba-0f30e443f14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f4e782-5503-4698-a1ba-0f30e443f14c.jpg?1",
             "name": "Necrotic Sliver",
             "text": "All Slivers have \"{3}, Sacrifice this permanent: Destroy target permanent.\"",
             "colours": [
@@ -32790,7 +32790,7 @@
         },
         {
             "id": "7164ac2b-30d1-56fd-b0ee-b3a937eaf82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec67424e-718d-49d6-86b0-cf979530a830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec67424e-718d-49d6-86b0-cf979530a830.jpg?1",
             "name": "Nyx Weaver",
             "text": "Reach\nAt the beginning of your upkeep, mill two cards. (Put the top two cards of your library into your graveyard.)\n{1}{B}{G}, Exile Nyx Weaver: Return target card from your graveyard to your hand.",
             "colours": [
@@ -32826,7 +32826,7 @@
         },
         {
             "id": "779cc61b-f1f7-5c57-affe-8d1bdd5770f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7474f9e-a994-4ed7-83df-22edd8219e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7474f9e-a994-4ed7-83df-22edd8219e24.jpg?1",
             "name": "Oath of Teferi",
             "text": "When Oath of Teferi enters the battlefield, exile another target permanent you control. Return it to the battlefield under its owner's control at the beginning of the next end step.\nYou may activate the loyalty abilities of planeswalkers you control twice each turn rather than only once.",
             "colours": [
@@ -32861,7 +32861,7 @@
         },
         {
             "id": "9caca301-6f09-523e-9347-baa7d762c008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35a39a-6dcd-4bbc-b43b-bd1a5425cb05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35a39a-6dcd-4bbc-b43b-bd1a5425cb05.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "Whenever you cast a noncreature spell, create a 1/1 colorless Servo artifact creature token.\n\u22122: Target artifact you control becomes a copy of another target artifact or creature you control until end of turn, except it's an artifact in addition to its other types.",
             "colours": [
@@ -32898,7 +32898,7 @@
         },
         {
             "id": "edbea62b-4fa1-55b2-a134-68228757c36b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df83d28d-bb0b-4f3d-a16f-8ee8bf452e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df83d28d-bb0b-4f3d-a16f-8ee8bf452e10.jpg?1",
             "name": "Satyr Enchanter",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -32934,7 +32934,7 @@
         },
         {
             "id": "b7bd9379-9347-5983-9957-b2d7536c057c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b902f64-7795-4f1f-81e6-26db7c78a10c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b902f64-7795-4f1f-81e6-26db7c78a10c.jpg?1",
             "name": "Sliver Hivelord",
             "text": "Sliver creatures you control have indestructible.",
             "colours": [
@@ -32977,7 +32977,7 @@
         },
         {
             "id": "4a9c963b-70ed-5d3a-9605-330264cc6826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89511ab5-8ea6-4f07-a80b-c1ec7e89924e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89511ab5-8ea6-4f07-a80b-c1ec7e89924e.jpg?1",
             "name": "Sythis, Harvest's Hand",
             "text": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
             "colours": [
@@ -33015,7 +33015,7 @@
         },
         {
             "id": "995f303b-f2d1-57b3-ad83-3779c1c14d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ce45b-ab07-4bce-bb4a-83f5720b6ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ce45b-ab07-4bce-bb4a-83f5720b6ee7.jpg?1",
             "name": "Wall of Denial",
             "text": "Defender, flying\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -33050,7 +33050,7 @@
         },
         {
             "id": "b4a2a6fd-ed3a-534f-ae5d-e95b7c3f82cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed089db-54b9-40d7-9a91-19f0bab44303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed089db-54b9-40d7-9a91-19f0bab44303.jpg?1",
             "name": "Ancient Stone Idol",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature.\nTrample\nWhen Ancient Stone Idol dies, create a 6/12 colorless Construct artifact creature token with trample.",
             "colours": [],
@@ -33080,7 +33080,7 @@
         },
         {
             "id": "4d51db2b-b719-52f4-afc5-ca7e0a21e254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f012f5c8-a974-40a4-9375-071e4d95182a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f012f5c8-a974-40a4-9375-071e4d95182a.jpg?1",
             "name": "Azorius Signet",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -33110,7 +33110,7 @@
         },
         {
             "id": "f12234aa-1ca7-5a22-b248-2089b64ab9a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6e02b3-be4c-45b8-9cb8-6b3142b30c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6e02b3-be4c-45b8-9cb8-6b3142b30c6b.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -33140,7 +33140,7 @@
         },
         {
             "id": "36616551-37c0-53a8-9c12-1b9eb3d9bda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca66955-d900-45b6-9a40-38467689a68d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca66955-d900-45b6-9a40-38467689a68d.jpg?1",
             "name": "The Chain Veil",
             "text": "At the beginning of your end step, if you didn't activate a loyalty ability of a planeswalker this turn, you lose 2 life.\n{4}, {T}: For each planeswalker you control, you may activate one of its loyalty abilities once this turn as though none of its loyalty abilities have been activated this turn.",
             "colours": [],
@@ -33169,7 +33169,7 @@
         },
         {
             "id": "08a934e6-5382-54de-b640-92b856716998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e81f3-b456-4fe6-941d-a7f2bf4aa844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e81f3-b456-4fe6-941d-a7f2bf4aa844.jpg?1",
             "name": "Crashing Drawbridge",
             "text": "Defender\n{T}: Creatures you control gain haste until end of turn.",
             "colours": [],
@@ -33199,7 +33199,7 @@
         },
         {
             "id": "25e373e3-32b9-57cb-8b00-177f5b6de67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a27816-7ee9-4fa1-aa01-78796ad62337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a27816-7ee9-4fa1-aa01-78796ad62337.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {C}{C}{C}.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -33226,7 +33226,7 @@
         },
         {
             "id": "943bcc13-e688-5116-9012-29a70f2ca922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecb184f-c282-42f3-9576-09781a116352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecb184f-c282-42f3-9576-09781a116352.jpg?1",
             "name": "Duplicant",
             "text": "Imprint \u2014 When Duplicant enters the battlefield, you may exile target nontoken creature.\nAs long as a card exiled with Duplicant is a creature card, Duplicant has the power, toughness, and creature types of the last creature card exiled with Duplicant. It's still a Shapeshifter.",
             "colours": [],
@@ -33256,7 +33256,7 @@
         },
         {
             "id": "3189caed-2af7-5ead-a6a2-b6955e21d81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c2025-03cf-4c3d-9dd5-0d25f7019d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c2025-03cf-4c3d-9dd5-0d25f7019d25.jpg?1",
             "name": "Endless Atlas",
             "text": "{2}, {T}: Draw a card. Activate only if you control three or more lands with the same name.",
             "colours": [],
@@ -33283,7 +33283,7 @@
         },
         {
             "id": "c4741075-b6e7-5c95-9aee-afcedf95ee9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c18d57-16a7-4cc0-b086-81c4b9a166c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c18d57-16a7-4cc0-b086-81c4b9a166c7.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -33310,7 +33310,7 @@
         },
         {
             "id": "a3fe598c-6090-5307-851c-94a0f9b72782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43291d-87c8-4773-99b0-6b7a9d302cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43291d-87c8-4773-99b0-6b7a9d302cd8.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -33339,7 +33339,7 @@
         },
         {
             "id": "774a50f7-1e04-563e-a4cb-6a97b86305d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dfdb91-aa69-45a1-adcc-9fcd85f84ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dfdb91-aa69-45a1-adcc-9fcd85f84ccf.jpg?1",
             "name": "Forsaken Monument",
             "text": "Colorless creatures you control get +2/+2.\nWhenever you tap a permanent for {C}, add an additional {C}.\nWhenever you cast a colorless spell, you gain 2 life.",
             "colours": [],
@@ -33368,7 +33368,7 @@
         },
         {
             "id": "bec6e72d-96ab-5c4e-a73e-0940b35dec48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c323f-eecd-4560-a128-ab513d231552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c323f-eecd-4560-a128-ab513d231552.jpg?1",
             "name": "Hangarback Walker",
             "text": "Hangarback Walker enters the battlefield with X +1/+1 counters on it.\nWhen Hangarback Walker dies, create a 1/1 colorless Thopter artifact creature token with flying for each +1/+1 counter on Hangarback Walker.\n{1}, {T}: Put a +1/+1 counter on Hangarback Walker.",
             "colours": [],
@@ -33398,7 +33398,7 @@
         },
         {
             "id": "52224ec4-0b6d-5026-823a-0b9ee8ffc0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad69703c-637f-44c6-bc84-c1f60d9d9062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad69703c-637f-44c6-bc84-c1f60d9d9062.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -33425,7 +33425,7 @@
         },
         {
             "id": "4c29cc7e-6c91-5493-ae7a-4c3285c3fc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cc583b-4ca1-4e34-bf66-693d69e4f77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cc583b-4ca1-4e34-bf66-693d69e4f77e.jpg?1",
             "name": "Herald's Horn",
             "text": "As Herald's Horn enters the battlefield, choose a creature type.\nCreature spells you cast of the chosen type cost {1} less to cast.\nAt the beginning of your upkeep, look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand.",
             "colours": [],
@@ -33452,7 +33452,7 @@
         },
         {
             "id": "68fbe194-5ecd-505b-a735-1b52eec2ba00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39f563-2ea9-4ddd-8d76-900fa14b480c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39f563-2ea9-4ddd-8d76-900fa14b480c.jpg?1",
             "name": "Honor-Worn Shaku",
             "text": "{T}: Add {C}.\nTap an untapped legendary permanent you control: Untap Honor-Worn Shaku.",
             "colours": [],
@@ -33479,7 +33479,7 @@
         },
         {
             "id": "42ed4d9c-b89f-5f92-8bb6-d2a03611ffd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac115db-9a35-41da-bb77-a61ef6c73b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac115db-9a35-41da-bb77-a61ef6c73b6f.jpg?1",
             "name": "Icon of Ancestry",
             "text": "As Icon of Ancestry enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{3}, {T}: Look at the top three cards of your library. You may reveal a creature card of the chosen type from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -33506,7 +33506,7 @@
         },
         {
             "id": "df465b54-4788-5939-98cd-79714cbf661e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2e3c71-16ee-4521-ba3f-7b8cbba2ace2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2e3c71-16ee-4521-ba3f-7b8cbba2ace2.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -33535,7 +33535,7 @@
         },
         {
             "id": "fced9671-bc68-5b96-bc3c-8257a443bbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e894c45f-30fa-493c-af9e-20261c37d1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e894c45f-30fa-493c-af9e-20261c37d1e1.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -33565,7 +33565,7 @@
         },
         {
             "id": "5e4ef810-9f13-5d7b-8599-d125c0c5edc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572fb0dc-d876-4e1b-91d1-9c595f6f6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572fb0dc-d876-4e1b-91d1-9c595f6f6f04.jpg?1",
             "name": "Kaldra Compleat",
             "text": "Living weapon\nIndestructible\nEquipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"\nEquip {7}",
             "colours": [],
@@ -33596,7 +33596,7 @@
         },
         {
             "id": "bcd84aca-0519-5a82-8d4e-ef401b85b8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1880f-7ac9-45a8-b4cd-a89956078a45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1880f-7ac9-45a8-b4cd-a89956078a45.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on Mazemind Tome: Scry 1.\n{2}, {T}, Put a page counter on Mazemind Tome: Draw a card.\nWhen there are four or more page counters on Mazemind Tome, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -33623,7 +33623,7 @@
         },
         {
             "id": "40c7e175-2330-5ed5-abeb-51e9a59d3e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f61e807-aa79-41b1-b785-24dddad28021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f61e807-aa79-41b1-b785-24dddad28021.jpg?1",
             "name": "Metalwork Colossus",
             "text": "This spell costs {X} less to cast, where X is the total mana value of noncreature artifacts you control.\nSacrifice two artifacts: Return Metalwork Colossus from your graveyard to your hand.",
             "colours": [],
@@ -33653,7 +33653,7 @@
         },
         {
             "id": "067ecda7-cf7d-5a1d-8733-e55dae84b63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaf1f56-de96-480a-a0c4-0a06d4daf149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaf1f56-de96-480a-a0c4-0a06d4daf149.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -33680,7 +33680,7 @@
         },
         {
             "id": "07b08f98-ead6-5c82-bd95-491140e87853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1252c2-b951-4125-93a2-9282b607b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1252c2-b951-4125-93a2-9282b607b6a4.jpg?1",
             "name": "Mirage Mirror",
             "text": "{2}: Mirage Mirror becomes a copy of target artifact, creature, enchantment, or land until end of turn.",
             "colours": [],
@@ -33707,7 +33707,7 @@
         },
         {
             "id": "eaddf55f-b794-58e6-85ee-ec75be180ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe102126-9aee-4b50-8bc6-1e979132eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe102126-9aee-4b50-8bc6-1e979132eb3e.jpg?1",
             "name": "Myriad Construct",
             "text": "Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.",
             "colours": [],
@@ -33737,7 +33737,7 @@
         },
         {
             "id": "9b938a27-470d-581f-8a3a-4ddf6c565313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0de77a-c503-4000-9eb5-aa28a5e91082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0de77a-c503-4000-9eb5-aa28a5e91082.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast artifact spells and colorless spells from the top of your library.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -33764,7 +33764,7 @@
         },
         {
             "id": "31451d2a-900e-5030-86af-9c5a60f437d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fb6ee3-bd54-4e5b-b055-c2c42515c162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fb6ee3-bd54-4e5b-b055-c2c42515c162.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -33791,7 +33791,7 @@
         },
         {
             "id": "ecce46c3-b2af-543d-94ca-6d7e95984b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bbdc6c-b6c9-4f89-8f0a-6266e53c1fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bbdc6c-b6c9-4f89-8f0a-6266e53c1fb9.jpg?1",
             "name": "Ornithopter of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [],
@@ -33821,7 +33821,7 @@
         },
         {
             "id": "1e59b3b2-61ac-5036-bebd-0952cee58196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c6aba3-38c3-45d1-83e1-40829eb07862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c6aba3-38c3-45d1-83e1-40829eb07862.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -33851,7 +33851,7 @@
         },
         {
             "id": "65ad98c0-6744-51bc-9dba-799133c346c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f747fa8-515c-4c79-8d2e-f1bbab2e4602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f747fa8-515c-4c79-8d2e-f1bbab2e4602.jpg?1",
             "name": "Perilous Vault",
             "text": "{5}, {T}, Exile Perilous Vault: Exile all nonland permanents.",
             "colours": [],
@@ -33878,7 +33878,7 @@
         },
         {
             "id": "c53f5e61-8793-51f2-b2a7-8c55690b7155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55fcddd-e7c8-4f57-8f49-dd86e2d5fe49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55fcddd-e7c8-4f57-8f49-dd86e2d5fe49.jpg?1",
             "name": "Phyrexian Triniform",
             "text": "When Phyrexian Triniform dies, create three 3/3 colorless Phyrexian Golem artifact creature tokens.\nEncore {1}2 ({1}2, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [],
@@ -33909,7 +33909,7 @@
         },
         {
             "id": "706bfab4-a89f-5d97-8049-b51baaacd08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92c8c43-e7b5-4339-8926-1268a89bb2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92c8c43-e7b5-4339-8926-1268a89bb2da.jpg?1",
             "name": "Pillar of Origins",
             "text": "As Pillar of Origins enters the battlefield, choose a creature type.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -33936,7 +33936,7 @@
         },
         {
             "id": "d1711f09-65ee-5b5d-9010-28756da2edb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45c22ca-28fa-47ed-90bc-57a86ed31929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45c22ca-28fa-47ed-90bc-57a86ed31929.jpg?1",
             "name": "Scaretiller",
             "text": "Whenever Scaretiller becomes tapped, choose one \u2014\n\u2022 You may put a land card from your hand onto the battlefield tapped.\n\u2022 Return target land card from your graveyard to the battlefield tapped.",
             "colours": [],
@@ -33966,7 +33966,7 @@
         },
         {
             "id": "1ee96641-ee37-5046-ba28-9c4af1049ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f42cc9-8b7f-4f8a-8d68-8480e668c239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f42cc9-8b7f-4f8a-8d68-8480e668c239.jpg?1",
             "name": "Silent Arbiter",
             "text": "No more than one creature can attack each combat.\nNo more than one creature can block each combat.",
             "colours": [],
@@ -33996,7 +33996,7 @@
         },
         {
             "id": "372fec3e-98da-5654-b190-8ad7f8bb24c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d290747-3b54-4e40-baac-b64cb7ef7787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d290747-3b54-4e40-baac-b64cb7ef7787.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -34026,7 +34026,7 @@
         },
         {
             "id": "d8057f28-43b7-5148-bc7f-e6f9da4fec76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b6480a-9b25-42a2-b62c-1f375216b211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b6480a-9b25-42a2-b62c-1f375216b211.jpg?1",
             "name": "Soul of New Phyrexia",
             "text": "Trample\n{5}: Permanents you control gain indestructible until end of turn.\n{5}, Exile Soul of New Phyrexia from your graveyard: Permanents you control gain indestructible until end of turn.",
             "colours": [],
@@ -34057,7 +34057,7 @@
         },
         {
             "id": "3ff0b6bd-8da1-56b9-8e9b-13dba8d27af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9582e2e-f170-4060-b364-0a2dd23b8e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9582e2e-f170-4060-b364-0a2dd23b8e62.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: Steel Hellkite gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with mana value X whose controller was dealt combat damage by Steel Hellkite this turn. Activate only once each turn.",
             "colours": [],
@@ -34087,7 +34087,7 @@
         },
         {
             "id": "77dbfdc6-63d2-5eec-91c4-f60f737a6e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354456dc-81da-4cd1-b7b1-7ea1ce1bcc9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354456dc-81da-4cd1-b7b1-7ea1ce1bcc9f.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "Reach, trample, protection from multicolored\nStonecoil Serpent enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -34117,7 +34117,7 @@
         },
         {
             "id": "33a65ab3-80a5-5df1-a679-cfb1d77ae8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3803dd5f-32cb-45c3-ab0b-55a706549ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3803dd5f-32cb-45c3-ab0b-55a706549ba5.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -34147,7 +34147,7 @@
         },
         {
             "id": "29f493a7-b47a-50af-9c24-4638fbcfa2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a58b9-2cf5-4898-8261-b7c51edc2051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a58b9-2cf5-4898-8261-b7c51edc2051.jpg?1",
             "name": "Talisman of Conviction",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Talisman of Conviction deals 1 damage to you.",
             "colours": [],
@@ -34177,7 +34177,7 @@
         },
         {
             "id": "cc947e32-1ebf-5504-940d-08b6deb51287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebb2086-3d9c-4322-bd3f-1366a4354578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebb2086-3d9c-4322-bd3f-1366a4354578.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -34207,7 +34207,7 @@
         },
         {
             "id": "54040674-44d1-53ae-90b7-ce40743285d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c406a0-607a-49eb-b506-bee60234fe6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c406a0-607a-49eb-b506-bee60234fe6d.jpg?1",
             "name": "Talisman of Progress",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Talisman of Progress deals 1 damage to you.",
             "colours": [],
@@ -34237,7 +34237,7 @@
         },
         {
             "id": "a46fb681-4b28-5716-8f6a-a7136104d01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bbb789-82e3-4c41-997f-2dc829e2a29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bbb789-82e3-4c41-997f-2dc829e2a29d.jpg?1",
             "name": "Transmogrifying Wand",
             "text": "Transmogrifying Wand enters the battlefield with three charge counters on it.\n{1}, {T}, Remove a charge counter from Transmogrifying Wand: Destroy target creature. Its controller creates a 2/4 white Ox creature token. Activate only as a sorcery.",
             "colours": [],
@@ -34264,7 +34264,7 @@
         },
         {
             "id": "a62ebd0e-9c63-5032-b7d9-6ec7712f256e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8162961c-bfe0-4e30-bad4-f473bf582f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8162961c-bfe0-4e30-bad4-f473bf582f21.jpg?1",
             "name": "Vanquisher's Banner",
             "text": "As Vanquisher's Banner enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\nWhenever you cast a creature spell of the chosen type, draw a card.",
             "colours": [],
@@ -34291,7 +34291,7 @@
         },
         {
             "id": "9184a7c6-c49d-50ef-a889-2877ca43753a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61a30eb-66b2-4a59-ada3-400580cc9c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61a30eb-66b2-4a59-ada3-400580cc9c36.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -34318,7 +34318,7 @@
         },
         {
             "id": "48ab8ff6-9ee9-5484-8553-95dffb177064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f3445a-3488-4367-a6f3-fd1904b11148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f3445a-3488-4367-a6f3-fd1904b11148.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone enters the battlefield tapped.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -34345,7 +34345,7 @@
         },
         {
             "id": "5dd2d64f-8aa6-5cf4-ad82-cfaedf66a5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c247fd6-09f3-40cd-b3fb-53b6526e1dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c247fd6-09f3-40cd-b3fb-53b6526e1dcf.jpg?1",
             "name": "Arcane Lighthouse",
             "text": "{T}: Add {C}.\n{1}, {T}: Until end of turn, creatures your opponents control lose hexproof and shroud and can't have hexproof or shroud.",
             "colours": [],
@@ -34372,7 +34372,7 @@
         },
         {
             "id": "0f4514fc-472e-5146-b662-777cd4095e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4046d8-9f53-4b33-b76c-54bc5e83f496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4046d8-9f53-4b33-b76c-54bc5e83f496.jpg?1",
             "name": "Arch of Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C}.\n{5}, {T}: Draw a card. Activate only if you have the city's blessing.",
             "colours": [],
@@ -34399,7 +34399,7 @@
         },
         {
             "id": "dcd95a68-a392-552e-92d7-1f08e3b747f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad14f1-d541-4e58-af9f-f8e587fca05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad14f1-d541-4e58-af9f-f8e587fca05f.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -34426,7 +34426,7 @@
         },
         {
             "id": "f18af6d8-cad0-5400-bf08-b0eec5782cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b6aca8-190e-49b0-9185-2c72bd3fda7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b6aca8-190e-49b0-9185-2c72bd3fda7d.jpg?1",
             "name": "Bonders' Enclave",
             "text": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater.",
             "colours": [],
@@ -34453,7 +34453,7 @@
         },
         {
             "id": "73a1989b-204a-5f91-a4fc-b7b7dd4134a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b99bb11-bec7-4c50-a0c8-49740655f725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b99bb11-bec7-4c50-a0c8-49740655f725.jpg?1",
             "name": "Canopy Vista",
             "text": "({T}: Add {G} or {W}.)\nCanopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -34486,7 +34486,7 @@
         },
         {
             "id": "bf7d602d-eeb4-50e9-ba5f-b66a05fdcae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15406173-530f-4f4f-82f3-f3e193979fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15406173-530f-4f4f-82f3-f3e193979fd7.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {C}.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R}.",
             "colours": [],
@@ -34516,7 +34516,7 @@
         },
         {
             "id": "70f33f5e-2bfb-5e94-b534-3ac9fa1a2aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c02660c-a9ff-4f6e-9a0b-975b20afaff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c02660c-a9ff-4f6e-9a0b-975b20afaff3.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G}.)\nCinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -34549,7 +34549,7 @@
         },
         {
             "id": "5b0c991c-5d28-50c6-b31f-7a663cb0f626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbab7e1f-305e-4733-aa70-b27285740925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbab7e1f-305e-4733-aa70-b27285740925.jpg?1",
             "name": "Eldrazi Temple",
             "text": "{T}: Add {C}.\n{T}: Add {C}{C}. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
             "colours": [],
@@ -34576,7 +34576,7 @@
         },
         {
             "id": "d2c5cbcd-e870-5bf8-86cd-f059ca24cc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63325755-47d5-4bb2-a21c-f324c27e1bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63325755-47d5-4bb2-a21c-f324c27e1bbd.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -34603,7 +34603,7 @@
         },
         {
             "id": "541877c5-4d7e-5875-b8b0-31a6de99febd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc0fba-c285-4fad-85a6-79fd7f3f9c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc0fba-c285-4fad-85a6-79fd7f3f9c35.jpg?1",
             "name": "Flood Plain",
             "text": "Flood Plain enters the battlefield tapped.\n{T}, Sacrifice Flood Plain: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -34630,7 +34630,7 @@
         },
         {
             "id": "f4f18637-7458-58f3-9a68-e22a4bce65f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f11f053-5150-4a76-b2ca-9df3a0629911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f11f053-5150-4a76-b2ca-9df3a0629911.jpg?1",
             "name": "Forge of Heroes",
             "text": "{T}: Add {C}.\n{T}: Choose target commander that entered the battlefield this turn. Put a +1/+1 counter on it if it's a creature and a loyalty counter on it if it's a planeswalker.",
             "colours": [],
@@ -34657,7 +34657,7 @@
         },
         {
             "id": "4b0f1b49-cc18-5fa0-99e6-002b3f1bc39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedc3df-3ee0-4622-b103-701c45f331d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedc3df-3ee0-4622-b103-701c45f331d5.jpg?1",
             "name": "Fortified Village",
             "text": "As Fortified Village enters the battlefield, you may reveal a Forest or Plains card from your hand. If you don't, Fortified Village enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -34687,7 +34687,7 @@
         },
         {
             "id": "fdc46066-77d8-5604-ab52-a27af7cc612e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c4f254-1109-4aaf-a33c-ae59795b1c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c4f254-1109-4aaf-a33c-ae59795b1c20.jpg?1",
             "name": "Frontier Bivouac",
             "text": "Frontier Bivouac enters the battlefield tapped.\n{T}: Add {G}, {U}, or {R}.",
             "colours": [],
@@ -34718,7 +34718,7 @@
         },
         {
             "id": "12d78622-a060-5d92-8dac-f234d7e47088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c295e4b-0b52-4422-85bc-e631a93d9e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c295e4b-0b52-4422-85bc-e631a93d9e5f.jpg?1",
             "name": "Frostboil Snarl",
             "text": "As Frostboil Snarl enters the battlefield, you may reveal an Island or Mountain card from your hand. If you don't, Frostboil Snarl enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -34748,7 +34748,7 @@
         },
         {
             "id": "d0a92bb8-4ec3-5a3a-9e1d-6aa7e8b7bc92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703f058c-6fc4-4e06-8570-a094ffe44574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703f058c-6fc4-4e06-8570-a094ffe44574.jpg?1",
             "name": "Furycalm Snarl",
             "text": "As Furycalm Snarl enters the battlefield, you may reveal a Mountain or Plains card from your hand. If you don't, Furycalm Snarl enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -34778,7 +34778,7 @@
         },
         {
             "id": "66bee094-7386-515a-b0a6-8c7bf7642f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4d0772-35a3-434f-afb5-2137aa4f3dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4d0772-35a3-434f-afb5-2137aa4f3dec.jpg?1",
             "name": "Geier Reach Sanitarium",
             "text": "{T}: Add {C}.\n{2}, {T}: Each player draws a card, then discards a card.",
             "colours": [],
@@ -34807,7 +34807,7 @@
         },
         {
             "id": "84c18a8a-9136-59c6-9568-d1ccd1083091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ac08c9-e55e-4e4b-9170-0a82344cfbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ac08c9-e55e-4e4b-9170-0a82344cfbc1.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G}.",
             "colours": [],
@@ -34837,7 +34837,7 @@
         },
         {
             "id": "5d9419f5-4d67-51aa-bddd-4838b98c1318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf52798-b2e0-4d0a-a41b-8927bfa60375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf52798-b2e0-4d0a-a41b-8927bfa60375.jpg?1",
             "name": "Grasslands",
             "text": "Grasslands enters the battlefield tapped.\n{T}, Sacrifice Grasslands: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -34864,7 +34864,7 @@
         },
         {
             "id": "fbf1d544-2ec1-5cce-9093-b1958c974ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f943d5d-e8a1-4fe1-aad5-80c7ccf15435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f943d5d-e8a1-4fe1-aad5-80c7ccf15435.jpg?1",
             "name": "Guildless Commons",
             "text": "Guildless Commons enters the battlefield tapped.\nWhen Guildless Commons enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -34891,7 +34891,7 @@
         },
         {
             "id": "46164d32-6c41-51d7-a120-46247bc7d0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1bed72-2440-4364-a69f-a9d7c4fe3fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1bed72-2440-4364-a69f-a9d7c4fe3fea.jpg?1",
             "name": "Interplanar Beacon",
             "text": "Whenever you cast a planeswalker spell, you gain 1 life.\n{T}: Add {C}.\n{1}, {T}: Add two mana of different colors. Spend this mana only to cast planeswalker spells.",
             "colours": [],
@@ -34918,7 +34918,7 @@
         },
         {
             "id": "deb85562-db83-5ddc-bd6c-f4178d51e8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e428c9d-f70f-4777-8aab-3db7a4140742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e428c9d-f70f-4777-8aab-3db7a4140742.jpg?1",
             "name": "Irrigated Farmland",
             "text": "({T}: Add {W} or {U}.)\nIrrigated Farmland enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -34951,7 +34951,7 @@
         },
         {
             "id": "39aa808c-6f80-53a1-9453-556aa78cf274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7f64d5-3e54-4640-a0e4-1fea6ffb67eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7f64d5-3e54-4640-a0e4-1fea6ffb67eb.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine enters the battlefield tapped.\n{T}: Add {R}, {G}, or {W}.",
             "colours": [],
@@ -34982,7 +34982,7 @@
         },
         {
             "id": "09ddf326-7d37-5114-bc4c-5796a3713439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875ca80a-3eb8-434c-8114-536caab23211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875ca80a-3eb8-434c-8114-536caab23211.jpg?1",
             "name": "Karn's Bastion",
             "text": "{T}: Add {C}.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -35009,7 +35009,7 @@
         },
         {
             "id": "fd785bee-c498-5a94-97af-de041004aec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5ca583-38f2-4692-a29c-326510be5bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5ca583-38f2-4692-a29c-326510be5bb8.jpg?1",
             "name": "Krosan Verge",
             "text": "Krosan Verge enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Krosan Verge: Search your library for a Forest card and a Plains card, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -35036,7 +35036,7 @@
         },
         {
             "id": "2a362038-8c2d-5789-b1c4-a69c3eee968b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f060ea2b-717a-47ae-a4d6-b0594e838459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f060ea2b-717a-47ae-a4d6-b0594e838459.jpg?1",
             "name": "Mage-Ring Network",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Mage-Ring Network.\n{T}, Remove any number of storage counters from Mage-Ring Network: Add {C} for each storage counter removed this way.",
             "colours": [],
@@ -35063,7 +35063,7 @@
         },
         {
             "id": "a5e62f45-06ef-5386-a9bc-4cc782e27870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0441cd2c-3646-4c69-ae97-ad3bcea7466f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0441cd2c-3646-4c69-ae97-ad3bcea7466f.jpg?1",
             "name": "Mirrorpool",
             "text": "Mirrorpool enters the battlefield tapped.\n{T}: Add {C}.\n{2}{C}, {T}, Sacrifice Mirrorpool: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}{C}, {T}, Sacrifice Mirrorpool: Create a token that's a copy of target creature you control.",
             "colours": [],
@@ -35090,7 +35090,7 @@
         },
         {
             "id": "42bb7211-b22e-5bd9-b446-d04313d0392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7921b97-083b-480a-a7df-f2ab82e6f8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7921b97-083b-480a-a7df-f2ab82e6f8fb.jpg?1",
             "name": "Mobilized District",
             "text": "{T}: Add {C}.\n{4}: Mobilized District becomes a 3/3 Citizen creature with vigilance until end of turn. It's still a land. This ability costs {1} less to activate for each legendary creature and planeswalker you control.",
             "colours": [],
@@ -35117,7 +35117,7 @@
         },
         {
             "id": "ba4447f1-62ad-5fe2-8d55-07b4c7d5c9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86f172-4f6f-4f9e-9ae0-ca5c489cd671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86f172-4f6f-4f9e-9ae0-ca5c489cd671.jpg?1",
             "name": "Mountain Valley",
             "text": "Mountain Valley enters the battlefield tapped.\n{T}, Sacrifice Mountain Valley: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -35144,7 +35144,7 @@
         },
         {
             "id": "ed1d2d46-1950-5815-a5da-006f1a7146db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f99714f-43bc-4048-b650-97dfef4c10fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f99714f-43bc-4048-b650-97dfef4c10fe.jpg?1",
             "name": "Mystic Gate",
             "text": "{T}: Add {C}.\n{WU}, {T}: Add {W}{W}, {W}{U}, or {U}{U}.",
             "colours": [],
@@ -35174,7 +35174,7 @@
         },
         {
             "id": "047c163b-849b-532a-a2e7-6653f420570c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d3961-cc3f-408a-821e-2d9ea025c51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d3961-cc3f-408a-821e-2d9ea025c51e.jpg?1",
             "name": "Mystic Monastery",
             "text": "Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W}.",
             "colours": [],
@@ -35205,7 +35205,7 @@
         },
         {
             "id": "d3c3ab3d-dffc-5c1b-9f58-a00cf482fd7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734f816-2065-4741-a5c4-be9a7ebfae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734f816-2065-4741-a5c4-be9a7ebfae8f.jpg?1",
             "name": "Necroblossom Snarl",
             "text": "As Necroblossom Snarl enters the battlefield, you may reveal a Swamp or Forest card from your hand. If you don't, Necroblossom Snarl enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -35235,7 +35235,7 @@
         },
         {
             "id": "ec5f3a0b-a24e-56ce-ba60-058d472c33ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acb9c2c-8fdb-49da-b792-3e21c4274364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acb9c2c-8fdb-49da-b792-3e21c4274364.jpg?1",
             "name": "Nomad Outpost",
             "text": "Nomad Outpost enters the battlefield tapped.\n{T}: Add {R}, {W}, or {B}.",
             "colours": [],
@@ -35266,7 +35266,7 @@
         },
         {
             "id": "acc92766-d568-5f0c-a29e-fddf13ed903e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacdb4a4-10f8-45d8-abc7-d8b72f1ab0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacdb4a4-10f8-45d8-abc7-d8b72f1ab0ed.jpg?1",
             "name": "Opulent Palace",
             "text": "Opulent Palace enters the battlefield tapped.\n{T}: Add {B}, {G}, or {U}.",
             "colours": [],
@@ -35297,7 +35297,7 @@
         },
         {
             "id": "876ca65d-49d5-5617-af0d-406ad6b091db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149f23-9347-4343-a49f-9524e404fc43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149f23-9347-4343-a49f-9524e404fc43.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -35327,7 +35327,7 @@
         },
         {
             "id": "b79c68e2-ce3e-5a69-b4af-f8fcb68f6941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c035d-1309-4286-a758-07517f323f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c035d-1309-4286-a758-07517f323f34.jpg?1",
             "name": "Port Town",
             "text": "As Port Town enters the battlefield, you may reveal a Plains or Island card from your hand. If you don't, Port Town enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -35357,7 +35357,7 @@
         },
         {
             "id": "875de984-904a-569b-b5f5-0476b873292e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac634a-d792-4cca-8735-41a9a663f775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac634a-d792-4cca-8735-41a9a663f775.jpg?1",
             "name": "Prairie Stream",
             "text": "({T}: Add {W} or {U}.)\nPrairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -35390,7 +35390,7 @@
         },
         {
             "id": "7c464d23-51ce-5382-9110-c6f4c9cfc698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa3e6c-c37b-4e6e-9246-18ff9b36508d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa3e6c-c37b-4e6e-9246-18ff9b36508d.jpg?1",
             "name": "Rocky Tar Pit",
             "text": "Rocky Tar Pit enters the battlefield tapped.\n{T}, Sacrifice Rocky Tar Pit: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -35417,7 +35417,7 @@
         },
         {
             "id": "5866bbbc-86bb-5fc9-939d-676b6e757abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec2908-0b96-4b91-a269-3d7bc75be168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec2908-0b96-4b91-a269-3d7bc75be168.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {C}.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W}.",
             "colours": [],
@@ -35447,7 +35447,7 @@
         },
         {
             "id": "03d72a6e-297e-5945-bf9d-d41121732c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1159ef6-f3ac-42a0-ae46-7d5eb9b3a6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1159ef6-f3ac-42a0-ae46-7d5eb9b3a6eb.jpg?1",
             "name": "Ruins of Oran-Rief",
             "text": "Ruins of Oran-Rief enters the battlefield tapped.\n{T}: Add {C}.\n{T}: Put a +1/+1 counter on target colorless creature that entered the battlefield this turn.",
             "colours": [],
@@ -35474,7 +35474,7 @@
         },
         {
             "id": "be409be3-a158-514f-b88d-d65663af4167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f7d30c-91ec-4d02-9ee0-ed4de495cbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f7d30c-91ec-4d02-9ee0-ed4de495cbf5.jpg?1",
             "name": "Sandsteppe Citadel",
             "text": "Sandsteppe Citadel enters the battlefield tapped.\n{T}: Add {W}, {B}, or {G}.",
             "colours": [],
@@ -35505,7 +35505,7 @@
         },
         {
             "id": "e2f4b860-af59-524c-9025-de4e6a30316b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8502d1e6-86f1-40d8-8d3b-20d47e57bccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8502d1e6-86f1-40d8-8d3b-20d47e57bccb.jpg?1",
             "name": "Savage Lands",
             "text": "Savage Lands enters the battlefield tapped.\n{T}: Add {B}, {R}, or {G}.",
             "colours": [],
@@ -35536,7 +35536,7 @@
         },
         {
             "id": "cdfb8e71-9527-5add-a85c-f2df15bf7bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebce2f7a-1879-49f1-b4f7-98e5931c5fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebce2f7a-1879-49f1-b4f7-98e5931c5fb9.jpg?1",
             "name": "Scattered Groves",
             "text": "({T}: Add {G} or {W}.)\nScattered Groves enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -35569,7 +35569,7 @@
         },
         {
             "id": "ab576b8f-c4e5-56c3-b333-8f8714821902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c42d13-3ef6-4baf-81d0-766a6df1e712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c42d13-3ef6-4baf-81d0-766a6df1e712.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all graveyards.",
             "colours": [],
@@ -35598,7 +35598,7 @@
         },
         {
             "id": "21eba8a4-dcb3-5f1d-a812-92cd5f43d59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c137634-7531-4573-9bfa-623d8edf839c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c137634-7531-4573-9bfa-623d8edf839c.jpg?1",
             "name": "Sea Gate Wreckage",
             "text": "{T}: Add {C}.\n{2}{C}, {T}: Draw a card. Activate only if you have no cards in hand.",
             "colours": [],
@@ -35625,7 +35625,7 @@
         },
         {
             "id": "244b8806-aa13-5ce9-917f-d451e9838c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b198fc2c-9610-4564-a228-bd8cc01eddfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b198fc2c-9610-4564-a228-bd8cc01eddfe.jpg?1",
             "name": "Seaside Citadel",
             "text": "Seaside Citadel enters the battlefield tapped.\n{T}: Add {G}, {W}, or {U}.",
             "colours": [],
@@ -35656,7 +35656,7 @@
         },
         {
             "id": "4ce16d5a-9eca-51de-9525-03c86b447975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0da3a5-12fb-4ff0-9894-fdabdfa4d860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0da3a5-12fb-4ff0-9894-fdabdfa4d860.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As Secluded Courtyard enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature or creature card of the chosen type.",
             "colours": [],
@@ -35683,7 +35683,7 @@
         },
         {
             "id": "abebacdb-7f4e-512b-a738-e6e61ba2e0c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5bb089-a231-4d8a-a02a-296152cf5b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5bb089-a231-4d8a-a02a-296152cf5b4d.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W}.",
             "colours": [],
@@ -35713,7 +35713,7 @@
         },
         {
             "id": "0e05dd5b-dbc0-50c3-b7f4-f09a9258fdec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705cc0f7-9817-4e00-a926-f3b6e8e8cace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705cc0f7-9817-4e00-a926-f3b6e8e8cace.jpg?1",
             "name": "Sheltered Thicket",
             "text": "({T}: Add {R} or {G}.)\nSheltered Thicket enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -35746,7 +35746,7 @@
         },
         {
             "id": "1cc9a571-1b6d-5205-b402-4dbdd72d4184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492354e6-fe48-43f6-b86c-ac6bc64985f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492354e6-fe48-43f6-b86c-ac6bc64985f0.jpg?1",
             "name": "Shineshadow Snarl",
             "text": "As Shineshadow Snarl enters the battlefield, you may reveal a Plains or Swamp card from your hand. If you don't, Shineshadow Snarl enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -35776,7 +35776,7 @@
         },
         {
             "id": "40334f82-1235-5a49-a8a2-fe3071e3d01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0467d06a-2218-4824-a89e-7fb4cc9e04eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0467d06a-2218-4824-a89e-7fb4cc9e04eb.jpg?1",
             "name": "Shrine of the Forsaken Gods",
             "text": "{T}: Add {C}.\n{T}: Add {C}{C}. Spend this mana only to cast colorless spells. Activate only if you control seven or more lands.",
             "colours": [],
@@ -35803,7 +35803,7 @@
         },
         {
             "id": "bef80faa-9d04-5172-963b-85ebbc94fcba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1c9810-c6bf-4bce-b131-37ea34f3f840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1c9810-c6bf-4bce-b131-37ea34f3f840.jpg?1",
             "name": "Skycloud Expanse",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -35833,7 +35833,7 @@
         },
         {
             "id": "0ca1abeb-b171-5f08-be92-3934ded76d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66431343-b325-4477-a158-25f0e25fdb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66431343-b325-4477-a158-25f0e25fdb8e.jpg?1",
             "name": "Smoldering Marsh",
             "text": "({T}: Add {B} or {R}.)\nSmoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -35866,7 +35866,7 @@
         },
         {
             "id": "b4cb7e51-b461-5b59-93ed-07cc5a47404e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f0dd35-3732-429f-97e1-2ecfe872d404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f0dd35-3732-429f-97e1-2ecfe872d404.jpg?1",
             "name": "Sungrass Prairie",
             "text": "{1}, {T}: Add {G}{W}.",
             "colours": [],
@@ -35896,7 +35896,7 @@
         },
         {
             "id": "8eaf8f70-6621-52e7-8a31-fa99c18b2496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a82e6dd-f591-4e71-a1ae-ec24e5b97751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a82e6dd-f591-4e71-a1ae-ec24e5b97751.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B}.)\nSunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -35929,7 +35929,7 @@
         },
         {
             "id": "9b3b544b-2b8d-573b-9a1d-592f49bb4102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a1e07c-314c-4a7f-bd8f-97cdde1f0791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a1e07c-314c-4a7f-bd8f-97cdde1f0791.jpg?1",
             "name": "Tainted Field",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -35959,7 +35959,7 @@
         },
         {
             "id": "01554e83-4727-54ed-aac5-5abf36b08567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40830022-4e9d-4195-bf52-d4ed2eb58b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40830022-4e9d-4195-bf52-d4ed2eb58b3f.jpg?1",
             "name": "Tainted Wood",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Activate only if you control a Swamp.",
             "colours": [],
@@ -35989,7 +35989,7 @@
         },
         {
             "id": "f1394949-5419-52f9-893b-42c7aa346477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef1c3e3-f038-4ec3-84a1-756c52b5dbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef1c3e3-f038-4ec3-84a1-756c52b5dbe1.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -36019,7 +36019,7 @@
         },
         {
             "id": "6ce18af7-9de1-51ed-ac06-d2b55e9d0f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77363b9-276b-421d-b422-8c9a3838d118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77363b9-276b-421d-b422-8c9a3838d118.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -36049,7 +36049,7 @@
         },
         {
             "id": "29d445b8-3e69-5199-963d-8fc4b07e90ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c9c7cb-4e2d-4dd1-a3ed-49caab45aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c9c7cb-4e2d-4dd1-a3ed-49caab45aacb.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -36079,7 +36079,7 @@
         },
         {
             "id": "0b97ef34-15b9-5f48-8320-fdfdbfa678aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5de86-33fb-476e-a1ec-25a215401c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5de86-33fb-476e-a1ec-25a215401c41.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -36109,7 +36109,7 @@
         },
         {
             "id": "5718bd73-4739-56df-a89a-51929936473a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defc55e7-661b-4803-b581-eaa363c70f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defc55e7-661b-4803-b581-eaa363c70f04.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -36139,7 +36139,7 @@
         },
         {
             "id": "0ec67a9f-caa6-5c0d-bd5d-4366b37d5255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfdec59-36e0-4280-946f-cded4b600883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfdec59-36e0-4280-946f-cded4b600883.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {C}{C}. Activate only if you control five or more lands.",
             "colours": [],
@@ -36166,7 +36166,7 @@
         },
         {
             "id": "531f4bb1-298f-5cf6-9424-d968a20ee5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ead529-accb-4b6f-ab60-d715d80b3c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ead529-accb-4b6f-ab60-d715d80b3c99.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -36196,7 +36196,7 @@
         },
         {
             "id": "a51b71b9-93bb-5299-a69a-7d6a0920f735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824bf3cc-fb35-4bc1-998c-6758b1eed2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824bf3cc-fb35-4bc1-998c-6758b1eed2ca.jpg?1",
             "name": "Tomb of the Spirit Dragon",
             "text": "{T}: Add {C}.\n{2}, {T}: You gain 1 life for each colorless creature you control.",
             "colours": [],
@@ -36223,7 +36223,7 @@
         },
         {
             "id": "e03a34b7-8761-55c0-9405-5550b7107254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27906645-7d43-4c18-a20b-8d683069351e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27906645-7d43-4c18-a20b-8d683069351e.jpg?1",
             "name": "Tyrite Sanctum",
             "text": "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice Tyrite Sanctum: Put an indestructible counter on target God.",
             "colours": [],
@@ -36250,7 +36250,7 @@
         },
         {
             "id": "e3e4052c-b7b6-5b19-b9f6-b6440b467032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29e1761-87e6-448d-a901-1a6c5329e195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29e1761-87e6-448d-a901-1a6c5329e195.jpg?1",
             "name": "Unclaimed Territory",
             "text": "As Unclaimed Territory enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -36277,7 +36277,7 @@
         },
         {
             "id": "ad145d0c-c966-5921-95a5-37730cbf91c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bbb7d-ae61-4d8d-b931-9ed2f712832e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bbb7d-ae61-4d8d-b931-9ed2f712832e.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -36307,7 +36307,7 @@
         },
         {
             "id": "56126a13-325b-56a4-af5b-51427a1669c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0449a19-37f7-4169-9e32-928db5ec76fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0449a19-37f7-4169-9e32-928db5ec76fe.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -36337,7 +36337,7 @@
         },
         {
             "id": "6ebf0a67-06b0-5357-9241-6e26e5e7e03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f09b3-dd2d-4ba9-a57e-4f3c1793f752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f09b3-dd2d-4ba9-a57e-4f3c1793f752.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -36367,7 +36367,7 @@
         },
         {
             "id": "f1009aa3-979d-5eb5-bd66-dacbbc870a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2f5f65-4ab7-43c8-8a14-422fcfac80df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2f5f65-4ab7-43c8-8a14-422fcfac80df.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -36394,7 +36394,7 @@
         },
         {
             "id": "5ebcc232-4b93-54af-bc8d-7784607b1fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d479a83-16f7-425c-9873-b900f39ed620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d479a83-16f7-425c-9873-b900f39ed620.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -36425,7 +36425,7 @@
         },
         {
             "id": "2a595cdf-4bba-5349-9a1d-ee1a99d25a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2585d250-1cce-431c-a9d1-a3adce9d70cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2585d250-1cce-431c-a9d1-a3adce9d70cd.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -36456,7 +36456,7 @@
         },
         {
             "id": "f85354c3-9c15-53a3-8110-61aec8b37af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1471f611-1352-4c4a-aacd-57b27a996d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1471f611-1352-4c4a-aacd-57b27a996d2c.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -36491,7 +36491,7 @@
         },
         {
             "id": "66b76e73-12fc-5d65-aadf-3a2eab13370b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21e1de9-7128-4797-8483-86ac826ab1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21e1de9-7128-4797-8483-86ac826ab1e4.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -36532,7 +36532,7 @@
         },
         {
             "id": "978ad978-84de-53f4-81d8-d78476628659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe88719-d081-49f7-9505-f69a2694c0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe88719-d081-49f7-9505-f69a2694c0e7.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -36567,7 +36567,7 @@
         },
         {
             "id": "2476658f-9433-5aca-b14e-0ed1f476e8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e286a7c-9643-492f-8ce9-255499dfd1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e286a7c-9643-492f-8ce9-255499dfd1a7.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -36607,7 +36607,7 @@
         },
         {
             "id": "4628edce-fa74-54e5-a2d3-946f645f4760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b831b17a-396f-4242-8e98-1a60abb75c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b831b17a-396f-4242-8e98-1a60abb75c41.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -36647,7 +36647,7 @@
         },
         {
             "id": "5ee28824-3a1f-502c-87e9-d66116e9061c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd74a-0d9d-4c56-a167-dcff58e5ab26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd74a-0d9d-4c56-a167-dcff58e5ab26.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -36688,7 +36688,7 @@
         },
         {
             "id": "84e5604e-2327-5c13-a876-8d2c629ffd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5be1b6-3a6a-4601-914b-7f4b99629a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5be1b6-3a6a-4601-914b-7f4b99629a7f.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -36727,7 +36727,7 @@
         },
         {
             "id": "ba01d9b9-dfa4-5d61-8c8a-36c85b8fc58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2253ed0b-380e-40b9-bbf9-ff14b80dc272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2253ed0b-380e-40b9-bbf9-ff14b80dc272.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -36767,7 +36767,7 @@
         },
         {
             "id": "ac5f08e2-2619-5ff8-9141-f6bd2056d198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2763752-57af-4d4a-a0e5-5a496985b8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2763752-57af-4d4a-a0e5-5a496985b8bf.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -36815,7 +36815,7 @@
         },
         {
             "id": "6a0a0403-0b51-54bd-ad46-d124402cc927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99192884-b279-483e-a48a-3724f2e594bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99192884-b279-483e-a48a-3724f2e594bd.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -36846,7 +36846,7 @@
         },
         {
             "id": "2b90f16a-ce37-56a1-b7b0-47aeeee18710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ac73d8-9bd4-4bd1-98f5-4b1dd325b86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ac73d8-9bd4-4bd1-98f5-4b1dd325b86f.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control.",
             "colours": [
@@ -36880,7 +36880,7 @@
         },
         {
             "id": "a3030333-67fe-5f9b-a27a-139bb63040b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f00da-1c4d-45d4-af34-9216a34bff2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f00da-1c4d-45d4-af34-9216a34bff2a.jpg?1",
             "name": "Eldrazi",
             "text": "",
             "colours": [],
@@ -36911,7 +36911,7 @@
         },
         {
             "id": "1bc18505-8bd3-53e1-9d39-e79ced90f8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7df0d-d7d6-463d-b452-32666973234a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7df0d-d7d6-463d-b452-32666973234a.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -36943,7 +36943,7 @@
         },
         {
             "id": "07a7888c-27d3-5ab8-b2d2-db057d4610d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e820258-933f-4ad2-b63b-c6cd7f5bddf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e820258-933f-4ad2-b63b-c6cd7f5bddf3.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -36975,7 +36975,7 @@
         },
         {
             "id": "1e454e40-0232-5241-bafc-e32bbad90511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7ca733-6947-4e09-953e-d8b37b799e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7ca733-6947-4e09-953e-d8b37b799e6a.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -37010,7 +37010,7 @@
         },
         {
             "id": "edc00932-5ffc-5f52-8da6-d5298d564464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b3ed0c-1044-4662-9785-04d8503f1fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b3ed0c-1044-4662-9785-04d8503f1fbf.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -37045,7 +37045,7 @@
         },
         {
             "id": "6694c9b2-2bb0-5d4e-abab-ced0cb58da77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29dd78-a059-4aad-8627-9c783f245a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29dd78-a059-4aad-8627-9c783f245a91.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -37081,7 +37081,7 @@
         },
         {
             "id": "40127fba-2bcb-55f9-ad23-9d2b375c5933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df61c33-38b3-4549-9e5d-ae1b5c1afd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df61c33-38b3-4549-9e5d-ae1b5c1afd62.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -37116,7 +37116,7 @@
         },
         {
             "id": "a0cf69b8-6092-5687-85fa-a4402bd43e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8907c15d-831b-47d5-b2b5-7759876b8f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8907c15d-831b-47d5-b2b5-7759876b8f33.jpg?1",
             "name": "Kor Soldier",
             "text": "",
             "colours": [
@@ -37152,7 +37152,7 @@
         },
         {
             "id": "380b1a95-dd79-57f7-9f37-20c2d72ef53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10322962-5b45-438f-9d28-225414721c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10322962-5b45-438f-9d28-225414721c34.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -37187,7 +37187,7 @@
         },
         {
             "id": "920fc4a1-1aac-564d-bd72-e727b4586621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8ba2be-4e95-4d10-b866-9fde3f8c8a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8ba2be-4e95-4d10-b866-9fde3f8c8a3f.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -37222,7 +37222,7 @@
         },
         {
             "id": "4a62e0c4-bf54-5c81-9dcb-24ac27b2b7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70faf3a-adf6-482c-9f7d-7f254d5f8bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70faf3a-adf6-482c-9f7d-7f254d5f8bec.jpg?1",
             "name": "Bird Illusion",
             "text": "",
             "colours": [
@@ -37258,7 +37258,7 @@
         },
         {
             "id": "28c7e87c-3eda-52f4-aa11-ebb0880e2bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3a91bf-daa1-4bba-a052-d868700c610c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3a91bf-daa1-4bba-a052-d868700c610c.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -37293,7 +37293,7 @@
         },
         {
             "id": "12ea9ae7-f2ee-5e08-ba1e-68890a67cd4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ee09ec-0d88-469d-b61c-976f3be47766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ee09ec-0d88-469d-b61c-976f3be47766.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -37328,7 +37328,7 @@
         },
         {
             "id": "0fa7ebcf-46e9-5f3c-b8a0-06203060b81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57891433-318b-48a6-a73b-151a81ad3796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57891433-318b-48a6-a73b-151a81ad3796.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -37363,7 +37363,7 @@
         },
         {
             "id": "b4b23663-c2a0-555c-9c1a-a6e67b7858bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad40060-02a3-4044-9006-2c36f3d78e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad40060-02a3-4044-9006-2c36f3d78e16.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -37398,7 +37398,7 @@
         },
         {
             "id": "65313366-37ce-5d33-a1f4-a4e4d0de2f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc375fe9-e8aa-4b7d-b439-a67c0b61beaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc375fe9-e8aa-4b7d-b439-a67c0b61beaf.jpg?1",
             "name": "Phyrexian Germ",
             "text": "",
             "colours": [
@@ -37434,7 +37434,7 @@
         },
         {
             "id": "189e8d27-7f5b-50ab-ade5-914ef5f89753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5328e78-65c5-46e8-8980-3075ece0fa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5328e78-65c5-46e8-8980-3075ece0fa99.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -37469,7 +37469,7 @@
         },
         {
             "id": "d6c4e71a-968f-5b56-8ca9-d1c03571e79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5604c5-4fff-4bb6-bf6d-69027e4eeb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5604c5-4fff-4bb6-bf6d-69027e4eeb21.jpg?1",
             "name": "Thrull",
             "text": "",
             "colours": [
@@ -37504,7 +37504,7 @@
         },
         {
             "id": "0f223254-88df-5e76-be23-7a03641dd1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9feeb-23c3-4c3b-bc04-f50380d20197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9feeb-23c3-4c3b-bc04-f50380d20197.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -37539,7 +37539,7 @@
         },
         {
             "id": "c74d48b9-cea6-56a2-a18d-f36f3918bac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b11035-f651-427f-aad7-deb870d47c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b11035-f651-427f-aad7-deb870d47c10.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -37574,7 +37574,7 @@
         },
         {
             "id": "97cfd4de-c52d-52aa-81bb-d1586c413a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faee2063-b47e-4342-af98-0037b3e8e80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faee2063-b47e-4342-af98-0037b3e8e80f.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -37609,7 +37609,7 @@
         },
         {
             "id": "31bc6cfc-4bac-58b4-bec3-b2d2c99a0eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df0b0ed-b82a-4204-8e2c-9d297b29bf9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df0b0ed-b82a-4204-8e2c-9d297b29bf9a.jpg?1",
             "name": "Dragon Egg",
             "text": "",
             "colours": [
@@ -37645,7 +37645,7 @@
         },
         {
             "id": "58592a45-5fc9-5e4a-8134-4c88f4bf270a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d82864-0286-4511-9e80-a154bec2757f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d82864-0286-4511-9e80-a154bec2757f.jpg?1",
             "name": "Dwarf Berserker",
             "text": "",
             "colours": [
@@ -37681,7 +37681,7 @@
         },
         {
             "id": "b128a11f-f3e0-5829-bef5-cc3d6a662bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a214f-1b12-4d2c-9cc0-f0c5f4a6e7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a214f-1b12-4d2c-9cc0-f0c5f4a6e7a6.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -37716,7 +37716,7 @@
         },
         {
             "id": "1231b97d-bcc3-5c3c-a4e2-35866ffeb999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9051b-f964-43f9-877b-ea4f17620ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9051b-f964-43f9-877b-ea4f17620ecb.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -37751,7 +37751,7 @@
         },
         {
             "id": "0acacbab-00bf-5a8c-9cfd-bed5da4ddeb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d461a38d-761b-47bb-b49d-1b2522cf2f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d461a38d-761b-47bb-b49d-1b2522cf2f6e.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -37786,7 +37786,7 @@
         },
         {
             "id": "c2a8eed6-9133-56db-acbb-e5d14d3b94e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419c1799-1525-44ec-9f6c-dfc290f04ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419c1799-1525-44ec-9f6c-dfc290f04ba7.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -37821,7 +37821,7 @@
         },
         {
             "id": "f3277c26-3d25-511e-aa27-3fcb844aad5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81218951-e61f-43e6-802d-3820725e6f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81218951-e61f-43e6-802d-3820725e6f23.jpg?1",
             "name": "Ogre",
             "text": "",
             "colours": [
@@ -37856,7 +37856,7 @@
         },
         {
             "id": "29d32a74-4bc4-58c4-8441-257804031d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bdae00-bcbd-4238-87d6-7e12ff7ffd83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bdae00-bcbd-4238-87d6-7e12ff7ffd83.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -37891,7 +37891,7 @@
         },
         {
             "id": "d5685814-ee19-5b04-b4ef-bb83165c7c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf66184-0df9-4a6b-bf4a-c5bd0d21b5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf66184-0df9-4a6b-bf4a-c5bd0d21b5b6.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -37926,7 +37926,7 @@
         },
         {
             "id": "615aac95-5f4f-5106-bddf-b7f4aa696a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9a8f49-5b72-4480-ac58-904b7707ac0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9a8f49-5b72-4480-ac58-904b7707ac0b.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -37961,7 +37961,7 @@
         },
         {
             "id": "534409fb-bbd8-5199-ba67-c6bc2d5fdc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348b9211-e189-4c62-abdd-9778cfb84e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348b9211-e189-4c62-abdd-9778cfb84e16.jpg?1",
             "name": "Elf Druid",
             "text": "",
             "colours": [
@@ -37997,7 +37997,7 @@
         },
         {
             "id": "7dbc9f3e-6fc6-5bd2-a71f-0c503e2c12ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f07b07-e1d7-4a9b-bfa7-5566bbe43fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f07b07-e1d7-4a9b-bfa7-5566bbe43fd9.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -38032,7 +38032,7 @@
         },
         {
             "id": "f75de806-33e5-5836-abd6-6cf57f66241e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e981bbc-7690-4020-aa28-f06295ee8ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e981bbc-7690-4020-aa28-f06295ee8ff8.jpg?1",
             "name": "Phyrexian Beast",
             "text": "",
             "colours": [
@@ -38068,7 +38068,7 @@
         },
         {
             "id": "0fd11f84-7a70-5926-8f19-0fabafc4c440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f710ed-fda6-44dd-9a42-d5b37656307d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f710ed-fda6-44dd-9a42-d5b37656307d.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -38103,7 +38103,7 @@
         },
         {
             "id": "78cd88b3-b790-5832-b73c-d2600bd03add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d675b-1124-4a90-b270-39c52fdffc1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d675b-1124-4a90-b270-39c52fdffc1f.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -38138,7 +38138,7 @@
         },
         {
             "id": "1ab286c4-c46f-57b2-9941-2613eb74cc93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c88b9d-6ac2-4d38-8551-23998d76e6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c88b9d-6ac2-4d38-8551-23998d76e6ee.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -38175,7 +38175,7 @@
         },
         {
             "id": "8dabeaa9-2612-59dd-8e5f-6d070f22117f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab0fbc-293e-4917-9792-fdc9b512713d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab0fbc-293e-4917-9792-fdc9b512713d.jpg?1",
             "name": "Graveborn",
             "text": "",
             "colours": [
@@ -38212,7 +38212,7 @@
         },
         {
             "id": "6e925641-f72a-56fc-a91a-af67effb8d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d196a-eaf5-42b0-aa76-f30a75a74e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d196a-eaf5-42b0-aa76-f30a75a74e3a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -38249,7 +38249,7 @@
         },
         {
             "id": "b59f8820-344a-593d-8800-afdc93753a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adbbaa4-b1e3-4c5f-a1c7-aa294f838c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adbbaa4-b1e3-4c5f-a1c7-aa294f838c54.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -38280,7 +38280,7 @@
         },
         {
             "id": "230b6574-5ce0-5c34-96c1-7efa9a6d3f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fdadab-af27-46d3-bcf6-35e7affb1e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fdadab-af27-46d3-bcf6-35e7affb1e43.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -38312,7 +38312,7 @@
         },
         {
             "id": "f4260a65-d274-5382-b397-cdb68ddf0a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3954f9-776d-4a8d-a032-724c4eae0e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3954f9-776d-4a8d-a032-724c4eae0e13.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -38344,7 +38344,7 @@
         },
         {
             "id": "9cb97a78-9585-5641-96fd-d3e83ef9174b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b911529-052a-457b-b1a0-b3f498c2cbe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b911529-052a-457b-b1a0-b3f498c2cbe0.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -38376,7 +38376,7 @@
         },
         {
             "id": "d77d05bf-98a5-571f-8289-2debf071baae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ef9889-e61d-4733-b27c-9e78aea8e84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ef9889-e61d-4733-b27c-9e78aea8e84b.jpg?1",
             "name": "Phyrexian Myr",
             "text": "",
             "colours": [],
@@ -38408,7 +38408,7 @@
         },
         {
             "id": "fe5ab9c4-4f95-552e-a051-6a032351a716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a5faa3-b86e-4e05-93db-5db9507ae7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a5faa3-b86e-4e05-93db-5db9507ae7d0.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -38440,7 +38440,7 @@
         },
         {
             "id": "45302479-5f48-53e1-aa27-c60ddfebc93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f2a88f-ff00-4ef7-a9ed-e8457df2c9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f2a88f-ff00-4ef7-a9ed-e8457df2c9d3.jpg?1",
             "name": "Stoneforged Blade",
             "text": "",
             "colours": [],
@@ -38471,7 +38471,7 @@
         },
         {
             "id": "003cfec6-d5a5-5426-8943-9991e8c8195f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a94450-ebe4-49c6-b2b0-bf335880f44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a94450-ebe4-49c6-b2b0-bf335880f44f.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -38503,7 +38503,7 @@
         },
         {
             "id": "bf235272-bd80-5c56-8fa6-d355103fdf8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b5024-3a0b-4f14-977e-ba6c4c2567c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b5024-3a0b-4f14-977e-ba6c4c2567c9.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -38534,7 +38534,7 @@
         },
         {
             "id": "25237fb4-0549-5153-9a10-3884bc321241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49de1576-1c82-4e8c-b492-5097ca7b8819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49de1576-1c82-4e8c-b492-5097ca7b8819.jpg?1",
             "name": "City's Blessing",
             "text": "",
             "colours": [],
@@ -38562,7 +38562,7 @@
         },
         {
             "id": "b527d347-4d00-5772-881c-142aec24dabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9c491-6ba0-4484-822c-73bcbe9b0c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9c491-6ba0-4484-822c-73bcbe9b0c49.jpg?1",
             "name": "The Monarch",
             "text": "",
             "colours": [],
@@ -38590,7 +38590,7 @@
         },
         {
             "id": "38026e58-9e13-51f6-a006-f46ded9dc0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ace1f4-51b5-4a6a-a730-859717efbd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ace1f4-51b5-4a6a-a730-859717efbd6d.jpg?1",
             "name": "Daretti, Scrap Savant Emblem",
             "text": "",
             "colours": [],
@@ -38620,7 +38620,7 @@
         },
         {
             "id": "f9dd2167-6848-51b7-81f6-fb8e06b6d099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4bd21-2ab7-48cf-bc46-b67093b99421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4bd21-2ab7-48cf-bc46-b67093b99421.jpg?1",
             "name": "Ob Nixilis of the Black Oath Emblem",
             "text": "",
             "colours": [],
@@ -38650,7 +38650,7 @@
         },
         {
             "id": "d9f8696c-8329-5086-b268-b11a48908d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db0562-982a-43df-b7b3-4a51c4710757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db0562-982a-43df-b7b3-4a51c4710757.jpg?1",
             "name": "Teferi, Temporal Archmage Emblem",
             "text": "",
             "colours": [],
@@ -38680,7 +38680,7 @@
         },
         {
             "id": "a9151359-5f58-58f8-85af-53f0d6bb35b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305c212-148d-48dc-9e9b-cfeadd378eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305c212-148d-48dc-9e9b-cfeadd378eb5.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -38708,7 +38708,7 @@
         },
         {
             "id": "5a9097cb-1a78-558b-90d2-217688ef45d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfca87-fc37-46cc-8236-73bc5c0e5755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfca87-fc37-46cc-8236-73bc5c0e5755.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -38736,7 +38736,7 @@
         },
         {
             "id": "16742551-85da-5bbd-9c74-a21b7d5e505e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ae2eb8-5090-412a-ad72-46ec4861d599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ae2eb8-5090-412a-ad72-46ec4861d599.jpg?1",
             "name": "Manifest",
             "text": "",
             "colours": [],
@@ -38764,7 +38764,7 @@
         },
         {
             "id": "2246f5aa-0fa7-5864-a50e-2a7e2467f90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f50b09-3253-46a5-8639-5bc90c84b8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f50b09-3253-46a5-8639-5bc90c84b8e1.jpg?1",
             "name": "Sliver",
             "text": "",
             "colours": [],
@@ -38795,7 +38795,7 @@
         },
         {
             "id": "07423f39-2fad-5db8-82bc-d412819f923c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570a8272-7ca1-47db-834b-82f603d1417a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570a8272-7ca1-47db-834b-82f603d1417a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -38826,7 +38826,7 @@
         },
         {
             "id": "9357fc39-9ece-5ac2-b009-dac376c2db85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e56eac-93d5-4ed3-af8f-2c77f0071e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e56eac-93d5-4ed3-af8f-2c77f0071e16.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -38861,7 +38861,7 @@
         },
         {
             "id": "3577bc65-6b94-513e-8f41-242ee84ee921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8730fb-59ca-4cf7-96a4-d6ba3f6f2fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8730fb-59ca-4cf7-96a4-d6ba3f6f2fbe.jpg?1",
             "name": "Avacyn",
             "text": "",
             "colours": [
@@ -38898,7 +38898,7 @@
         },
         {
             "id": "662edb88-123c-5e71-9abd-6e900d27a110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33d9cf0-8138-4ae6-bbfe-02d48a4634c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33d9cf0-8138-4ae6-bbfe-02d48a4634c1.jpg?1",
             "name": "Cat Beast",
             "text": "",
             "colours": [
@@ -38934,7 +38934,7 @@
         },
         {
             "id": "5d1f37cc-0fb5-5426-94f9-1f7bd659d513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a72ad3d-8660-4be4-9f9b-7d2f6b8ee82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a72ad3d-8660-4be4-9f9b-7d2f6b8ee82b.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -38970,7 +38970,7 @@
         },
         {
             "id": "ade785de-89fd-5dc8-a159-d00d8089a9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d88db82-009a-4371-a91e-9083b561e80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d88db82-009a-4371-a91e-9083b561e80f.jpg?1",
             "name": "Human Warrior",
             "text": "",
             "colours": [
@@ -39006,7 +39006,7 @@
         },
         {
             "id": "63dca1e1-3f56-5848-8e1b-736fd6390f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820517-9895-47ba-a9d7-11ed807dcc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820517-9895-47ba-a9d7-11ed807dcc6d.jpg?1",
             "name": "Kor Ally",
             "text": "",
             "colours": [
@@ -39042,7 +39042,7 @@
         },
         {
             "id": "567a38ed-7707-5da2-9cde-e77e3fc37778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e94825-98a8-40f1-8f61-83c79885fec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e94825-98a8-40f1-8f61-83c79885fec0.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -39077,7 +39077,7 @@
         },
         {
             "id": "7da7b9ea-5d41-5cff-9d28-7f32e8570f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2f9b68-07a4-4502-9cf8-de8583b5cdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2f9b68-07a4-4502-9cf8-de8583b5cdd0.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -39112,7 +39112,7 @@
         },
         {
             "id": "e9b6acba-776c-5ba9-8353-51ce96738219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e421a-49ef-448c-9e04-9c5a7e5c071c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e421a-49ef-448c-9e04-9c5a7e5c071c.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -39147,7 +39147,7 @@
         },
         {
             "id": "00d52cd6-c646-5765-94f3-27ce41227c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9821f26-04b4-460b-880e-5052122b21ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9821f26-04b4-460b-880e-5052122b21ae.jpg?1",
             "name": "Sliver Army",
             "text": "",
             "colours": [
@@ -39183,7 +39183,7 @@
         },
         {
             "id": "0679e3b4-11e2-56ec-b9cc-c4501fe7885e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ce07c-d61c-4334-9ca8-bdf6ed9bee4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ce07c-d61c-4334-9ca8-bdf6ed9bee4f.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -39219,7 +39219,7 @@
         },
         {
             "id": "579da764-c50d-5b64-ac48-1be6f9f3dd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3ed483-a6c9-4f12-bd76-e205ffb8afd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3ed483-a6c9-4f12-bd76-e205ffb8afd4.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -39254,7 +39254,7 @@
         },
         {
             "id": "3cf5972f-8201-53a4-a77e-05a0951a0d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5b65c-00c7-415a-92f3-cd1177372956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5b65c-00c7-415a-92f3-cd1177372956.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -39289,7 +39289,7 @@
         },
         {
             "id": "bd185148-6d5c-5189-b44e-3737f6905b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e050305-6f8b-4261-a4b4-c9fa1dc99b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e050305-6f8b-4261-a4b4-c9fa1dc99b0f.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -39325,7 +39325,7 @@
         },
         {
             "id": "1e97e854-0f35-5cef-aefd-c9d0423e193a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a5c52e-c225-414c-93d9-e014c5aec465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a5c52e-c225-414c-93d9-e014c5aec465.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -39360,7 +39360,7 @@
         },
         {
             "id": "f6c6b3c2-81d6-5689-9af9-f6401738cf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f695aef-e30a-4289-a9b8-24b5495c344e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f695aef-e30a-4289-a9b8-24b5495c344e.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -39392,7 +39392,7 @@
         },
         {
             "id": "b2970797-bc7f-5474-b5f7-0343b1a7791f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6c1ca-e945-4ab2-b177-04e900a8e231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6c1ca-e945-4ab2-b177-04e900a8e231.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -39424,7 +39424,7 @@
         },
         {
             "id": "055887a7-b876-5001-8b42-2829d6ec9ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a91956-e351-4533-9f0d-4a578617f88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a91956-e351-4533-9f0d-4a578617f88b.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -39457,7 +39457,7 @@
         },
         {
             "id": "24629700-a5ac-54a5-b42f-d25c8e144ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f9aebc-6eb8-4325-801f-ad2fbbf391b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f9aebc-6eb8-4325-801f-ad2fbbf391b2.jpg?1",
             "name": "Ajani Steadfast Emblem",
             "text": "",
             "colours": [],
@@ -39487,7 +39487,7 @@
         },
         {
             "id": "7b18c822-3a82-5c0f-8524-53aae9fd1230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02347c41-407f-4388-9d9b-263ddf8b4e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02347c41-407f-4388-9d9b-263ddf8b4e11.jpg?1",
             "name": "Chandra, Awakened Inferno Emblem",
             "text": "",
             "colours": [],
@@ -39515,7 +39515,7 @@
         },
         {
             "id": "4dd29c6f-a26a-5b9b-a2cc-69e2cd425a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143984b-9798-4062-9a91-8ee139c3448e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143984b-9798-4062-9a91-8ee139c3448e.jpg?1",
             "name": "Chandra, Torch of Defiance Emblem",
             "text": "",
             "colours": [],
@@ -39545,7 +39545,7 @@
         },
         {
             "id": "a9a78d67-30a6-5827-85ef-e68e7bfa6256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffbc23b-23d3-4cc5-9ea2-fa3aab785ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffbc23b-23d3-4cc5-9ea2-fa3aab785ffe.jpg?1",
             "name": "Elspeth, Sun's Champion Emblem",
             "text": "",
             "colours": [],
@@ -39575,7 +39575,7 @@
         },
         {
             "id": "c3aa13d9-77c6-5143-a6a1-3a3fc605c505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ea709d-2470-4552-92b3-25d617155e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ea709d-2470-4552-92b3-25d617155e51.jpg?1",
             "name": "Narset of the Ancient Way Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/CMR.json
+++ b/Assets/Resources/Sets/CMR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9944c9b8-0847-5dc1-a55d-1032bb464da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e6d8f-f742-4508-a83a-38ae84be228c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e6d8f-f742-4508-a83a-38ae84be228c.jpg?1",
             "name": "The Prismatic Piper",
             "text": "If The Prismatic Piper is your commander, choose a color before the game begins. The Prismatic Piper is the chosen color.\nPartner (You can have two commanders if both have partner.)",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "4695aee9-5eac-5750-ba4f-a21691057ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bdd07d-9fb9-4ee4-80db-494ee0cba58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bdd07d-9fb9-4ee4-80db-494ee0cba58d.jpg?1",
             "name": "Akroma, Vision of Ixidor",
             "text": "Flying, first strike, vigilance, trample\nAt the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.\nPartner",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "f5ba0667-8366-5b3b-b46c-a6a53d4a72f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c281997b-1566-4469-a14c-6645f81ab023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c281997b-1566-4469-a14c-6645f81ab023.jpg?1",
             "name": "Akroma's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Creatures you control gain flying, vigilance, and double strike until end of turn.\n\u2022 Creatures you control gain lifelink, indestructible, and protection from all colors until end of turn.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "9b2af9c3-2a03-5b75-ab02-856f2b697b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047bfa4-3f4d-47bd-9484-545686f15b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047bfa4-3f4d-47bd-9484-545686f15b75.jpg?1",
             "name": "Alharu, Solemn Ritualist",
             "text": "When Alharu, Solemn Ritualist enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.\nWhenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white Spirit creature token with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -149,7 +149,7 @@
         },
         {
             "id": "870f507d-1f99-599a-b29a-462dd73a1f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8461c3-6e80-403a-b3eb-01882c841d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8461c3-6e80-403a-b3eb-01882c841d7a.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -183,7 +183,7 @@
         },
         {
             "id": "df6c7d71-f9ba-5437-bfff-27d93bc8a48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00ffeb5-195c-45ad-a791-ec67f463d552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00ffeb5-195c-45ad-a791-ec67f463d552.jpg?1",
             "name": "Angel of the Dawn",
             "text": "Flying\nWhen Angel of the Dawn enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "2259b514-d7ba-53a3-b89c-5d378cce3175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0775f2-3fd9-42aa-80e3-edac67764fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0775f2-3fd9-42aa-80e3-edac67764fa2.jpg?1",
             "name": "Angelic Gift",
             "text": "Enchant creature\nWhen Angelic Gift enters the battlefield, draw a card.\nEnchanted creature has flying.",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "9a7a3f7d-297e-5930-a817-6e2170f52e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66fcbb8-0fa5-48a9-b40c-d5a12f09a858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66fcbb8-0fa5-48a9-b40c-d5a12f09a858.jpg?1",
             "name": "Anointer of Valor",
             "text": "Flying\nWhenever a creature attacks, you may pay {3}. When you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "35b652cb-b83b-5a57-a1a8-10f38fa7914e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e367c30-3b77-445e-a1fb-78f6c5971826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e367c30-3b77-445e-a1fb-78f6c5971826.jpg?1",
             "name": "Archon of Coronation",
             "text": "Flying\nWhen Archon of Coronation enters the battlefield, you become the monarch.\nAs long as you're the monarch, damage doesn't cause you to lose life. (When a creature deals combat damage to you, its controller still becomes the monarch.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "99b4f253-6462-529e-b504-ef73f8514414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b802c-969b-4865-b7a0-871c585d097a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b802c-969b-4865-b7a0-871c585d097a.jpg?1",
             "name": "Ardenn, Intrepid Archaeologist",
             "text": "At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -360,7 +360,7 @@
         },
         {
             "id": "f99ce916-ba6b-5a82-a2d4-c0e7385697ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf63241-9091-42f5-b997-9ce5aa3484f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf63241-9091-42f5-b997-9ce5aa3484f1.jpg?1",
             "name": "Armored Skyhunter",
             "text": "Flying\nWhenever Armored Skyhunter attacks, look at the top six cards of your library. You may put an Aura or Equipment card from among them onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control. Put the rest of those cards on the bottom of your library in a random order.",
             "colours": [
@@ -397,7 +397,7 @@
         },
         {
             "id": "80a3d83b-d069-50ba-877d-28a9fd468860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ec853-411d-40a3-84a7-a62b3cb57cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ec853-411d-40a3-84a7-a62b3cb57cb3.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -431,7 +431,7 @@
         },
         {
             "id": "69588f7f-dc6c-5642-b6c9-0e966052c318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5c2401-da2c-46f9-b850-f37edcbb85cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5c2401-da2c-46f9-b850-f37edcbb85cd.jpg?1",
             "name": "Benevolent Blessing",
             "text": "Flash\nEnchant creature\nAs Benevolent Blessing enters the battlefield, choose a color.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Auras and Equipment you control that are already attached to it.",
             "colours": [
@@ -465,7 +465,7 @@
         },
         {
             "id": "17499f85-2f95-5e1e-8230-038e0cb9140b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655aefd8-8b0b-4c65-9973-376bbf05375b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655aefd8-8b0b-4c65-9973-376bbf05375b.jpg?1",
             "name": "Cage of Hands",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.",
             "colours": [
@@ -499,7 +499,7 @@
         },
         {
             "id": "08b98790-3425-5e61-8c01-3214bccbfc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac907330-492d-4705-bb8a-1fdb080632e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac907330-492d-4705-bb8a-1fdb080632e1.jpg?1",
             "name": "Captain's Call",
             "text": "Create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -531,7 +531,7 @@
         },
         {
             "id": "09a62abf-030f-5190-b06c-b03e0498e354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0be1b-554e-4b61-b495-6e2a7369cdb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0be1b-554e-4b61-b495-6e2a7369cdb1.jpg?1",
             "name": "Court of Grace",
             "text": "When Court of Grace enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, create a 1/1 white Spirit creature token with flying. If you're the monarch, create a 4/4 white Angel creature token with flying instead.",
             "colours": [
@@ -565,7 +565,7 @@
         },
         {
             "id": "a669993e-0c79-5067-9a92-6a4166fcb558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45b1d32-5a3a-4ec3-af11-d0ba947de175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45b1d32-5a3a-4ec3-af11-d0ba947de175.jpg?1",
             "name": "Court Street Denizen",
             "text": "Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "6223c0b1-e9f7-5f65-8d68-8eb5140991b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b717e3-4dc6-4a7d-928a-2111c8199177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b717e3-4dc6-4a7d-928a-2111c8199177.jpg?1",
             "name": "Dispeller's Capsule",
             "text": "{2}{W}, {T}, Sacrifice Dispeller's Capsule: Destroy target artifact or enchantment.",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "028682c8-bfca-5ccb-9935-f8cd0573182d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4573af-feba-4c9d-b24b-3d15888a5ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4573af-feba-4c9d-b24b-3d15888a5ce2.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "ffd453ea-df8c-5d20-af5d-1ce0c3fde563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a7da8c-a444-4deb-89b9-2fc9e5475bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a7da8c-a444-4deb-89b9-2fc9e5475bff.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -701,7 +701,7 @@
         },
         {
             "id": "24ffae73-bbcb-57a6-9bd9-d812b74a0840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8754c-816f-4d07-8dcd-9611bf0beb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8754c-816f-4d07-8dcd-9611bf0beb87.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "f4d069fb-3889-5c67-9190-c70b6a0fa48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0270f9f2-9afe-4bbb-b14c-0e2da7f54dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0270f9f2-9afe-4bbb-b14c-0e2da7f54dfc.jpg?1",
             "name": "First Response",
             "text": "At the beginning of each upkeep, if you lost life last turn, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "fe31d5b5-7951-594c-be8a-e4df90a21344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1287d422-d6b0-43eb-8e89-3d6a0201100d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1287d422-d6b0-43eb-8e89-3d6a0201100d.jpg?1",
             "name": "Inspiring Roar",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "8b932259-cabf-5f16-a1af-de60e86b5fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535764b9-67b2-4123-a4be-2aa72fcd8a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535764b9-67b2-4123-a4be-2aa72fcd8a33.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "dac8b89e-6578-5b10-a42a-d4e632fb69f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e792e689-0cf8-4bd0-b2f1-4edff9972e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e792e689-0cf8-4bd0-b2f1-4edff9972e18.jpg?1",
             "name": "Iona's Judgment",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "8b758c5d-c7e2-58ab-92c8-a052e9535913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f431b3-6f4e-40a5-b9d1-f2c67b70544d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f431b3-6f4e-40a5-b9d1-f2c67b70544d.jpg?1",
             "name": "Kangee's Lieutenant",
             "text": "Flying\nWhenever Kangee's Lieutenant attacks, attacking creatures with flying get +1/+1 until end of turn.\nEncore {5}{W} ({5}{W}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -899,7 +899,7 @@
         },
         {
             "id": "c0fbc7cc-c6b9-50c6-b437-58eb30871bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eec618-2c3d-423b-bbb7-72ef7deb38fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eec618-2c3d-423b-bbb7-72ef7deb38fc.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "962a7bff-8967-5f15-b174-16f5963b83f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba512-b6c3-4931-be05-cb6bd03a4b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba512-b6c3-4931-be05-cb6bd03a4b7c.jpg?1",
             "name": "Keleth, Sunmane Familiar",
             "text": "Whenever a commander you control attacks, put a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -974,7 +974,7 @@
         },
         {
             "id": "d68012fd-e6c8-52e8-8003-3a28d7f039d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2b413-e00f-440d-9d27-92eb069b8c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2b413-e00f-440d-9d27-92eb069b8c71.jpg?1",
             "name": "Kinsbaile Courier",
             "text": "When Kinsbaile Courier enters the battlefield, put a +1/+1 counter on target creature.\nEncore {2}{W} ({2}{W}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "92986004-21e7-5f39-9194-0fdd7b9f4307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef638-1ea1-4301-bb86-78cb2b5f3aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef638-1ea1-4301-bb86-78cb2b5f3aab.jpg?1",
             "name": "Kor Cartographer",
             "text": "When Kor Cartographer enters the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -1046,7 +1046,7 @@
         },
         {
             "id": "cd9dc06b-6a37-550c-be22-4355f0841452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bce846-8049-4d5c-b0ad-8abd484e5a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bce846-8049-4d5c-b0ad-8abd484e5a27.jpg?1",
             "name": "Livio, Oathsworn Sentinel",
             "text": "{1}{W}: Choose another target creature. Its controller may exile it with an aegis counter on it.\n{2}{W}, {T}: Return all exiled cards with aegis counters on them to the battlefield under their owners' control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "f7d68027-2773-5c53-b295-376cd358f16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a948ef4-145f-4bea-b4af-5daa951b338c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a948ef4-145f-4bea-b4af-5daa951b338c.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "002cd341-e050-528c-8e73-18a96dd9eaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9555fe-fa1d-4af9-90a4-c3f91e0edd9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9555fe-fa1d-4af9-90a4-c3f91e0edd9b.jpg?1",
             "name": "Ninth Bridge Patrol",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Ninth Bridge Patrol.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "200a9f46-ed7e-552a-9acc-946966f0c6fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db45698-9da9-4cea-b9bf-0f84ab276b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db45698-9da9-4cea-b9bf-0f84ab276b51.jpg?1",
             "name": "Open the Armory",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "98dab3aa-6137-5545-8c5f-8e136cef7c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96017805-0a26-4beb-8de3-6779c4e5633d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96017805-0a26-4beb-8de3-6779c4e5633d.jpg?1",
             "name": "Orzhov Advokist",
             "text": "At the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. If a player does, creatures that player controls can't attack you or a planeswalker you control until your next turn.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "f9c67574-4492-5c06-bc9c-a59dc5f40d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd0e9a0-f974-412a-aba1-c4fb68351149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd0e9a0-f974-412a-aba1-c4fb68351149.jpg?1",
             "name": "Palace Sentinels",
             "text": "When Palace Sentinels enters the battlefield, you become the monarch.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "85cd19a8-41ce-5fe9-9ea1-2d665d3f4587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db1e841-04e9-49ab-acbf-defd6d82140a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db1e841-04e9-49ab-acbf-defd6d82140a.jpg?1",
             "name": "Patron of the Valiant",
             "text": "Flying\nWhen Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "e127fbfe-1e0f-57aa-a205-2f2a41de09e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e40e2a-e447-4754-a98b-5521e546781f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e40e2a-e447-4754-a98b-5521e546781f.jpg?1",
             "name": "Prava of the Steel Legion",
             "text": "As long as it's your turn, creature tokens you control get +1/+4.\n{3}{W}: Create a 1/1 white Soldier creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1327,7 +1327,7 @@
         },
         {
             "id": "d3b3c586-1c17-5c38-ab7f-e7fc6fa022f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccffa9d-8896-4364-bc5c-37592d2714f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccffa9d-8896-4364-bc5c-37592d2714f9.jpg?1",
             "name": "Promise of Tomorrow",
             "text": "Whenever a creature you control dies, exile it.\nAt the beginning of each end step, if you control no creatures, sacrifice Promise of Tomorrow and return all cards exiled with it to the battlefield under your control.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "9d0e9ec7-04d5-5634-b73c-5825eea62806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b00110-e3de-40ce-b2bd-9466fe9e53a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b00110-e3de-40ce-b2bd-9466fe9e53a3.jpg?1",
             "name": "Radiant, Serra Archangel",
             "text": "Flying\nTap another untapped creature you control with flying: Radiant, Serra Archangel gains protection from the color of your choice until end of turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "79c9d62d-f16c-5122-a837-8cffbb9bcca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c8527-55f6-494d-b4f7-c427a5735053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c8527-55f6-494d-b4f7-c427a5735053.jpg?1",
             "name": "Raise the Alarm",
             "text": "Create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "dc7fa984-26d6-5d56-b9ca-1020b0737c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46975250-950f-4f5d-a7c5-f61aec8e40ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46975250-950f-4f5d-a7c5-f61aec8e40ad.jpg?1",
             "name": "Rebbec, Architect of Ascension",
             "text": "Artifacts you control have protection from each converted mana cost among artifacts you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "0dfd6f8d-f7e6-5aba-ab2b-88fb15e8aeb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f5785-36d8-473c-b2de-0b4635388d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f5785-36d8-473c-b2de-0b4635388d7e.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "e7da3691-5c28-5b41-8169-9dfb214e3463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bf33ea-2d2d-476d-ab1d-fba204fd034b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bf33ea-2d2d-476d-ab1d-fba204fd034b.jpg?1",
             "name": "Seraph of Dawn",
             "text": "Flying, lifelink",
             "colours": [
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "3ba7ddc1-7e26-5868-bbfc-70af7e1aeca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9b6e59-8e95-413d-825e-f1dc8874eaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9b6e59-8e95-413d-825e-f1dc8874eaa9.jpg?1",
             "name": "Seraphic Greatsword",
             "text": "Equipped creature gets +2/+2.\nWhenever equipped creature attacks the player with the most life or tied for most life, create a 4/4 white Angel creature token with flying that's tapped and attacking that player.\nEquip {4}",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "0b34259a-79e5-5707-9113-7f547818c8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5013-523f-42b2-b947-abe304a6cb84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5013-523f-42b2-b947-abe304a6cb84.jpg?1",
             "name": "Skywhaler's Shot",
             "text": "Destroy target creature with power 3 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "a43375a5-ed73-5c16-8c02-b50fab0b0fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0913a5e8-7f77-44f2-a7cf-c8c0d6270a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0913a5e8-7f77-44f2-a7cf-c8c0d6270a86.jpg?1",
             "name": "Slash the Ranks",
             "text": "Destroy all creatures and planeswalkers except for commanders.",
             "colours": [
@@ -1641,7 +1641,7 @@
         },
         {
             "id": "e974b61a-6109-5c7f-9f70-bef30b0f1d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d986177-3814-4069-bce5-f9e54c528e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d986177-3814-4069-bce5-f9e54c528e85.jpg?1",
             "name": "Slaughter the Strong",
             "text": "Each player chooses any number of creatures they control with total power 4 or less, then sacrifices all other creatures they control.",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "38f8ee4c-9327-57f8-8a0a-12d9bfbdc1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90157f8-ba3c-479e-80d8-8f9e042c540c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90157f8-ba3c-479e-80d8-8f9e042c540c.jpg?1",
             "name": "Slith Ascendant",
             "text": "Flying\nWhenever Slith Ascendant deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1707,7 +1707,7 @@
         },
         {
             "id": "b3a69571-9f37-5396-a210-26c9ad32de11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08241f94-8b5e-4f9b-8120-8175e3256e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08241f94-8b5e-4f9b-8120-8175e3256e35.jpg?1",
             "name": "Soul of Eternity",
             "text": "Soul of Eternity's power and toughness are each equal to your life total.\nEncore {7}{W}{W} ({7}{W}{W}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "316db31e-93b0-526e-a394-a4d149e05d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c98bc7-f6a9-4aaf-a6dc-7067c3d8a41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c98bc7-f6a9-4aaf-a6dc-7067c3d8a41a.jpg?1",
             "name": "Squad Captain",
             "text": "Vigilance\nSquad Captain enters the battlefield with a +1/+1 counter on it for each other creature you control.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "cc2ef946-184f-5a6c-a7ad-da43e5855f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db8e30-e3a4-4141-9ea3-7db4a060ec8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db8e30-e3a4-4141-9ea3-7db4a060ec8e.jpg?1",
             "name": "Triumphant Reckoning",
             "text": "Return all artifact, enchantment, and planeswalker cards from your graveyard to the battlefield.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "6e40e512-6013-57f8-a027-3561f7452dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcfe1b5-e35b-4a23-8ca8-4dee2ef94f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcfe1b5-e35b-4a23-8ca8-4dee2ef94f32.jpg?1",
             "name": "Trusty Packbeast",
             "text": "When Trusty Packbeast enters the battlefield, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "0686b9fb-0a0a-5f09-afb9-67de3695e27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c1b3f-1aab-48a1-a651-8302bc8682f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c1b3f-1aab-48a1-a651-8302bc8682f9.jpg?1",
             "name": "Vow of Duty",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has vigilance, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "4305dd7a-29b4-5d49-bede-a662471f170b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be9d06-3651-47f4-9e44-00ecd4a15e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be9d06-3651-47f4-9e44-00ecd4a15e3c.jpg?1",
             "name": "Amphin Mutineer",
             "text": "When Amphin Mutineer enters the battlefield, exile up to one target non-Salamander creature. That creature's controller creates a 4/3 blue Salamander Warrior creature token.\nEncore {4}{U}{U} ({4}{U}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "a7dd808f-2422-5d90-92c4-5e259211d814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859f7cb-ac12-490e-b769-6f019791f2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859f7cb-ac12-490e-b769-6f019791f2a5.jpg?1",
             "name": "Aqueous Form",
             "text": "Enchant creature\nEnchanted creature can't be blocked.\nWhenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "6e70194b-58f3-58f2-a2a4-4cd21d0342cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4981d99-c33d-4451-8f6a-28fffb3dcd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4981d99-c33d-4451-8f6a-28fffb3dcd1c.jpg?1",
             "name": "Aven Surveyor",
             "text": "Flying\nWhen Aven Surveyor enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Aven Surveyor.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "aa75b6c7-4797-5706-884f-c97762a11e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0889e22-deab-48ba-bbd6-f0d49bee5d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0889e22-deab-48ba-bbd6-f0d49bee5d9c.jpg?1",
             "name": "Azure Fleet Admiral",
             "text": "When Azure Fleet Admiral enters the battlefield, you become the monarch.\nAzure Fleet Admiral can't be blocked by creatures the monarch controls.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "8a889469-5251-5128-b360-44a080a9411e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786ae686-0790-4ba1-927f-523984331549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786ae686-0790-4ba1-927f-523984331549.jpg?1",
             "name": "Body of Knowledge",
             "text": "Body of Knowledge's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhenever Body of Knowledge is dealt damage, draw that many cards.",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "3ff11d11-a57e-503f-a724-da2b7b012051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b063dfd-5a80-48c9-8f7b-48d21a129a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b063dfd-5a80-48c9-8f7b-48d21a129a76.jpg?1",
             "name": "Brinelin, the Moon Kraken",
             "text": "When Brinelin, the Moon Kraken enters the battlefield or whenever you cast a spell with converted mana cost 6 or greater, you may return target nonland permanent to its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "5245c577-49df-5731-90ca-82332b5d4ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14a5b69-ce04-40fc-9933-20b16537de24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14a5b69-ce04-40fc-9933-20b16537de24.jpg?1",
             "name": "Flood of Recollection",
             "text": "Return target instant or sorcery card from your graveyard to your hand. Exile Flood of Recollection.",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "51a8cfbf-81eb-5962-8baf-ed738980b8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e4a88d-670b-4332-bf36-41c2e2492424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e4a88d-670b-4332-bf36-41c2e2492424.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -2161,7 +2161,7 @@
         },
         {
             "id": "c5152fdf-1e0c-5de7-a117-87ce9941586b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f585f52-7b07-4453-b543-9654d314aa36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f585f52-7b07-4453-b543-9654d314aa36.jpg?1",
             "name": "Court of Cunning",
             "text": "When Court of Cunning enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, any number of target players each mill two cards. If you're the monarch, each of those players mills ten cards instead. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -2195,7 +2195,7 @@
         },
         {
             "id": "e00873c3-09b8-5e97-8c6f-2c2b0770e3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bcccf7-cec0-4507-b941-e47873861d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bcccf7-cec0-4507-b941-e47873861d20.jpg?1",
             "name": "Daring Saboteur",
             "text": "{2}{U}: Daring Saboteur can't be blocked this turn.\nWhenever Daring Saboteur deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "8fe1d06a-2e8d-5352-8459-58ed34475b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73373421-c43d-4152-818a-55abc85b477a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73373421-c43d-4152-818a-55abc85b477a.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -2265,7 +2265,7 @@
         },
         {
             "id": "b3aaf6e3-840b-597b-b91c-b34547929164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0adf34-1a2b-497b-aaab-4b2b998ed8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0adf34-1a2b-497b-aaab-4b2b998ed8b3.jpg?1",
             "name": "Eligeth, Crossroads Augur",
             "text": "Flying\nIf you would scry a number of cards, draw that many cards instead.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "a2968510-709d-54fe-b793-60f03b8301c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86958821-76eb-43a5-974b-7c945e826a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86958821-76eb-43a5-974b-7c945e826a66.jpg?1",
             "name": "Esior, Wardwing Familiar",
             "text": "Flying\nSpells your opponents cast that target one or more commanders you control cost {3} more to cast.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "98a40435-c77f-5972-b8cc-02cfd856bac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709a18f-b99d-4fa1-ae5c-7f22abd02c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709a18f-b99d-4fa1-ae5c-7f22abd02c0a.jpg?1",
             "name": "Fall from Favor",
             "text": "Enchant creature\nWhen Fall from Favor enters the battlefield, tap enchanted creature and you become the monarch.\nEnchanted creature doesn't untap during its controller's untap step unless that player is the monarch.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "be906dc5-c97d-5a53-b4ba-42acc0c72f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c75157-2670-4804-8853-a6867c83c40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c75157-2670-4804-8853-a6867c83c40a.jpg?1",
             "name": "Forceful Denial",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nCounter target spell.",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "e3592670-2fe3-55dc-a534-b30fd46e1f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cdb0e-2684-4ad1-b7dd-e355e3e9a221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cdb0e-2684-4ad1-b7dd-e355e3e9a221.jpg?1",
             "name": "Galestrike",
             "text": "Return target tapped creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "1bba7865-a3fe-5c7e-9364-b0c3ec5d14a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a41506-85c6-4362-b983-36df13db09d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a41506-85c6-4362-b983-36df13db09d9.jpg?1",
             "name": "Ghost of Ramirez DePietro",
             "text": "Ghost of Ramirez DePietro can't be blocked by creatures with toughness 3 or greater.\nWhenever Ghost of Ramirez DePietro deals combat damage to a player, choose up to one target card in a graveyard that was discarded or put there from a library this turn. Put that card into its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2478,7 +2478,7 @@
         },
         {
             "id": "67869983-0d49-5922-aa93-6f7c0cdeaff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a736df42-18e9-4259-b0b8-54d21143e72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a736df42-18e9-4259-b0b8-54d21143e72e.jpg?1",
             "name": "Glacian, Powerstone Engineer",
             "text": "{T}, Tap X untapped artifacts you control: Look at the top X cards of your library. Put one of those cards into your hand and the rest into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "63265e24-1179-5617-8ed6-711b28b50c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c21aa7-678e-4998-9061-a13d04d92842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c21aa7-678e-4998-9061-a13d04d92842.jpg?1",
             "name": "Horizon Scholar",
             "text": "Flying\nWhen Horizon Scholar enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2551,7 +2551,7 @@
         },
         {
             "id": "96d97be2-9f7f-59ff-9584-91caf1920f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df8aabc-7fcb-4b7b-980b-18f499e6c170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df8aabc-7fcb-4b7b-980b-18f499e6c170.jpg?1",
             "name": "Hullbreacher",
             "text": "Flash\nIf an opponent would draw a card except the first one they draw in each of their draw steps, instead you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "dab9df6e-9344-5419-bd9d-56aab70c6617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbf049-5c02-4038-86de-fa6b5110cf7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbf049-5c02-4038-86de-fa6b5110cf7e.jpg?1",
             "name": "Interpret the Signs",
             "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's converted mana cost. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2620,7 +2620,7 @@
         },
         {
             "id": "c6c52721-af48-5268-8c84-26d9e1bafbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4534ffdd-9965-4e55-9c25-04123720cbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4534ffdd-9965-4e55-9c25-04123720cbba.jpg?1",
             "name": "Kitesail Corsair",
             "text": "Kitesail Corsair has flying as long as it's attacking.",
             "colours": [
@@ -2655,7 +2655,7 @@
         },
         {
             "id": "e4376c66-ff5e-531b-bb4e-4ca807489a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd356b3-29a9-4526-93a0-33375f65744b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd356b3-29a9-4526-93a0-33375f65744b.jpg?1",
             "name": "Kitesail Skirmisher",
             "text": "Flying\nWhenever Kitesail Skirmisher attacks, another target creature attacking the same player or planeswalker gains flying until end of turn.\nEncore {4}{U} ({4}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "0ac45d99-6b93-595a-963f-51aa4f433344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1d1e2-caea-4e64-8a3a-740f62b36853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1d1e2-caea-4e64-8a3a-740f62b36853.jpg?1",
             "name": "Laboratory Drudge",
             "text": "At the beginning of each end step, draw a card if you've cast a spell from a graveyard or activated an ability of a card in a graveyard this turn.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "bc1239f8-8007-5db7-a11e-a5dd47b51a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3bbda-a4bc-4302-a3fc-b1c89f0f5461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3bbda-a4bc-4302-a3fc-b1c89f0f5461.jpg?1",
             "name": "Malcolm, Keen-Eyed Navigator",
             "text": "Flying\nWhenever one or more Pirates you control deal damage to your opponents, you create a Treasure token for each opponent dealt damage. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "ad5c9ed1-51b1-5f48-a4d4-47e4a92b5247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba874c0c-f66f-4edc-9859-40273487aef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba874c0c-f66f-4edc-9859-40273487aef0.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's converted mana cost.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "68acd0e9-a567-5131-961b-02ec0e6c62ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad152da-057d-4805-9e0c-3842ad43e336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad152da-057d-4805-9e0c-3842ad43e336.jpg?1",
             "name": "Merchant Raiders",
             "text": "Whenever Merchant Raiders or another Pirate enters the battlefield under your control, tap up to one target creature. That creature doesn't untap during its controller's untap step for as long as you control Merchant Raiders.",
             "colours": [
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "67acb7b1-7f34-54f7-980b-78842c9fa81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e725b-2250-4189-9682-73461b5cfed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e725b-2250-4189-9682-73461b5cfed2.jpg?1",
             "name": "Mnemonic Deluge",
             "text": "Exile target instant or sorcery card from a graveyard. Copy that card three times. You may cast the copies without paying their mana costs. Exile Mnemonic Deluge.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "b83d288d-7839-5a9b-a9df-ec8d20375e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b635abe-ad7e-44b8-b3fe-6e365db87c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b635abe-ad7e-44b8-b3fe-6e365db87c29.jpg?1",
             "name": "Omenspeaker",
             "text": "When Omenspeaker enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "06bcfd09-c59e-5aed-9f38-f2ae5cf71787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1453f92e-df2d-4789-aa1b-a5b5c51567d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1453f92e-df2d-4789-aa1b-a5b5c51567d4.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "2c7dd25f-5051-5616-bec1-f67cb5163fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778bde-f927-419e-8052-6230562bdedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778bde-f927-419e-8052-6230562bdedd.jpg?1",
             "name": "Prosperous Pirates",
             "text": "When Prosperous Pirates enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "11b08bde-4481-5742-985d-08c5008dcd1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb58d7ba-ba86-433e-8f1e-3f492c380796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb58d7ba-ba86-433e-8f1e-3f492c380796.jpg?1",
             "name": "Prying Eyes",
             "text": "Draw four cards, then discard two cards.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "eb77ed7b-9196-5d16-b6d5-f52aca213dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d747d5f2-d3b0-44f9-92f0-781839386850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d747d5f2-d3b0-44f9-92f0-781839386850.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "7508e6bf-a8a9-5ba7-9afe-53a0542edf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e9011-a9b7-4a60-bb47-ce5c3c147280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e9011-a9b7-4a60-bb47-ce5c3c147280.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "009e6685-ebc6-5091-8c91-9fb33307ed1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/714c3a1f-7b30-4ed8-8f38-6176758741fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/714c3a1f-7b30-4ed8-8f38-6176758741fb.jpg?1",
             "name": "Sakashima of a Thousand Faces",
             "text": "You may have Sakashima of a Thousand Faces enter the battlefield as a copy of another creature you control, except it has Sakashima of a Thousand Faces's other abilities.\nThe \"legend rule\" doesn't apply to permanents you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "f6734b0c-60f5-5e71-94a0-fcd9bfa218e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce06cd4-099b-445f-af95-76564ee24668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce06cd4-099b-445f-af95-76564ee24668.jpg?1",
             "name": "Sakashima's Protege",
             "text": "Flash\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nYou may have Sakashima's Protege enter the battlefield as a copy of any permanent that entered the battlefield this turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "e3445734-f4f1-5b99-ac17-ba14aad21a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9fd318-ffb2-40d0-b1e0-e951d7735f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9fd318-ffb2-40d0-b1e0-e951d7735f78.jpg?1",
             "name": "Sakashima's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Target opponent chooses a creature they control. You gain control of it.\n\u2022 Choose a creature you control. Each other creature you control becomes a copy of that creature until end of turn.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "1ba8cb45-5f4d-5991-9c2b-e3037c3c1b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc4498e-24e6-40e9-8cd5-f42220366664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc4498e-24e6-40e9-8cd5-f42220366664.jpg?1",
             "name": "Scholar of Stars",
             "text": "When Scholar of Stars enters the battlefield, if you control an artifact, draw a card.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "275fc406-edbd-5f3e-8e9f-8289b92041f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfa31b5-8a4f-4766-9606-648cb8ee2916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfa31b5-8a4f-4766-9606-648cb8ee2916.jpg?1",
             "name": "Scholar of the Ages",
             "text": "When Scholar of the Ages enters the battlefield, return up to two target instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "75f2c848-eceb-56c2-bbe1-815fa1e86b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3ba315-f4da-4022-9251-961a378b35ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3ba315-f4da-4022-9251-961a378b35ce.jpg?1",
             "name": "Scrapdiver Serpent",
             "text": "Scrapdiver Serpent can't be blocked as long as defending player controls an artifact.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "6c054fa9-eb18-5f36-80c0-a07f90d7341a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8812e448-241e-4640-9cb6-0cdbe1ad2fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8812e448-241e-4640-9cb6-0cdbe1ad2fcc.jpg?1",
             "name": "Siani, Eye of the Storm",
             "text": "Flying\nWhenever Siani, Eye of the Storm attacks, scry X, where X is the number of attacking creatures with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "fa42999a-5ff1-5dc9-9c4b-44c94f5b6b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e5f191-0b20-4bc4-b41e-36c53a182f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e5f191-0b20-4bc4-b41e-36c53a182f85.jpg?1",
             "name": "Siren Stormtamer",
             "text": "Flying\n{U}, Sacrifice Siren Stormtamer: Counter target spell or ability that targets you or a creature you control.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "aabcf728-8f78-5eb2-bb5c-6af884a7e47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151fe63-3b3a-4cd4-9a2d-d80e7434e63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151fe63-3b3a-4cd4-9a2d-d80e7434e63c.jpg?1",
             "name": "Skaab Goliath",
             "text": "As an additional cost to cast this spell, exile two creature cards from your graveyard.\nTrample",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "8ce7c6d8-c561-5323-96ad-e224bdcba243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc396c69-9773-4d57-a955-280742a10a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc396c69-9773-4d57-a955-280742a10a91.jpg?1",
             "name": "Skilled Animator",
             "text": "When Skilled Animator enters the battlefield, target artifact you control becomes an artifact creature with base power and toughness 5/5 for as long as Skilled Animator remains on the battlefield.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "1b1d8fdc-c550-5bf5-b4b2-5e90e0c98e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b70a6-a150-4d81-921c-9b178fe0037d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b70a6-a150-4d81-921c-9b178fe0037d.jpg?1",
             "name": "Sphinx of the Second Sun",
             "text": "Flying\nAt the beginning of your postcombat main phase, you get an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "212274ce-ba77-524d-bf75-b1399655913b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6919154c-154e-4430-b7fd-ab9fe70326dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6919154c-154e-4430-b7fd-ab9fe70326dc.jpg?1",
             "name": "Spontaneous Mutation",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "fb2dad00-febe-53f0-bc43-1ce2410b1f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e14952-1a6a-4c6a-8def-54846108b542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e14952-1a6a-4c6a-8def-54846108b542.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "f803f528-afbe-5cf6-8787-3c9f9ecc026a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf7fd8a-adc3-4099-8e30-08375f263446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf7fd8a-adc3-4099-8e30-08375f263446.jpg?1",
             "name": "Supreme Will",
             "text": "Choose one \u2014\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "f2811ce8-08b1-5742-81d2-b549d0dd8491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8173ac-bd9c-4748-9a6a-e5556d74d754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8173ac-bd9c-4748-9a6a-e5556d74d754.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "c0a824c8-b0e8-53e4-9ec8-1bfc537c91bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b74135-b8db-4485-a4b1-7aaa3ef28072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b74135-b8db-4485-a4b1-7aaa3ef28072.jpg?1",
             "name": "Trove Tracker",
             "text": "When Trove Tracker dies, draw a card.\nEncore {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "9f5414a0-6d3a-5fec-a968-03fe8acd17d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9887121-6206-44bb-a1b4-520f28a61a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9887121-6206-44bb-a1b4-520f28a61a17.jpg?1",
             "name": "Vow of Flight",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has flying, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "88bf76f1-71d7-56a1-b3b6-620488cba105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfc5cef-aa9b-45d4-a9c3-4b157e4ed193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfc5cef-aa9b-45d4-a9c3-4b157e4ed193.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "032f2134-369e-5222-81d1-f483921780ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69687d-191a-4bca-b1f7-eea27847c1af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69687d-191a-4bca-b1f7-eea27847c1af.jpg?1",
             "name": "Wrong Turn",
             "text": "Target opponent gains control of target creature. (If an attacking or blocking creature changes controllers, it's removed from combat.)",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "9876a63e-e2c2-5cd1-9f97-6fafea992f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f69e24-6b5c-4a9a-af5b-1ce88efdc0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f69e24-6b5c-4a9a-af5b-1ce88efdc0aa.jpg?1",
             "name": "Armix, Filigree Thrasher",
             "text": "Whenever Armix, Filigree Thrasher attacks, you may discard a card. When you do, target creature defending player controls gets -X/-X until end of turn, where X is the number of artifacts you control plus the number of artifact cards in your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "148a8921-98e5-5038-83f9-7c5d0a7eff66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25657da2-e7bc-4e9b-8ec2-5a5779738436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25657da2-e7bc-4e9b-8ec2-5a5779738436.jpg?1",
             "name": "Bitter Revelation",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "e110ea55-5ffc-5d63-84ce-5d29c3220b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb59ce-7d40-4784-b96d-2d5a25a8e531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb59ce-7d40-4784-b96d-2d5a25a8e531.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "e40b5228-d3db-5173-8bc1-9d72d582b822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fb5f1-baf5-4934-aac7-ffbaa85b2428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fb5f1-baf5-4934-aac7-ffbaa85b2428.jpg?1",
             "name": "Briarblade Adept",
             "text": "Whenever Briarblade Adept attacks, target creature an opponent controls gets -1/-1 until end of turn.\nEncore {3}{B} ({3}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "2c8ae79f-c5d0-55b7-b701-101f65a01cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8426e-476a-45e4-b3a9-841da54d966c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8426e-476a-45e4-b3a9-841da54d966c.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -3904,7 +3904,7 @@
         },
         {
             "id": "f9c24a73-aee1-5daf-a20c-894f4f5b49a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fedb37f-4f3c-477c-84c0-aa864e87c111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fedb37f-4f3c-477c-84c0-aa864e87c111.jpg?1",
             "name": "Corpse Churn",
             "text": "Mill three cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "071b8b42-3008-5819-983b-f1a7015f86c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5deb0185-62b3-474b-83a1-25473fdae4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5deb0185-62b3-474b-83a1-25473fdae4fa.jpg?1",
             "name": "Court of Ambition",
             "text": "When Court of Ambition enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, each opponent loses 3 life unless they discard a card. If you're the monarch, instead each opponent loses 6 life unless they discard two cards.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "fda2a654-5e63-55ad-9026-313a902898d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e0654c-8c84-47a7-ba0b-de5b1268c27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e0654c-8c84-47a7-ba0b-de5b1268c27b.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "004e5214-641b-582f-b006-65ceed7107a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a26e910-275a-4981-831b-bfed936a7e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a26e910-275a-4981-831b-bfed936a7e3f.jpg?1",
             "name": "Cuombajj Witches",
             "text": "{T}: Cuombajj Witches deals 1 damage to any target and 1 damage to any target of an opponent's choice.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "b4323a2b-ed3e-50d2-8a63-4649f165d7ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1c30e-e539-4382-b0fd-724a502a4b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1c30e-e539-4382-b0fd-724a502a4b7e.jpg?1",
             "name": "Defiant Salvager",
             "text": "Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "ae68a23a-3d9d-57bf-95b0-d220d9293c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47733f20-f7b2-4a01-b429-0ec49b230fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47733f20-f7b2-4a01-b429-0ec49b230fd9.jpg?1",
             "name": "Demonic Lore",
             "text": "When Demonic Lore enters the battlefield, draw three cards.\nAt the beginning of your end step, you lose 2 life for each card in your hand.",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "a9aababf-9e4d-5595-a001-098b7e3d87a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0efe5b1-c515-4642-aca2-3eba68fe63ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0efe5b1-c515-4642-aca2-3eba68fe63ff.jpg?1",
             "name": "Dhund Operative",
             "text": "As long as you control an artifact, Dhund Operative gets +1/+0 and has deathtouch.",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "ecc9679d-638e-56bd-b8cc-6348d638fea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1264d2-c7c8-477f-84f6-c17b422aa45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1264d2-c7c8-477f-84f6-c17b422aa45e.jpg?1",
             "name": "Elvish Doomsayer",
             "text": "When Elvish Doomsayer dies, each opponent discards a card.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "f72ab129-3420-5389-b43d-4a4a088d56aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f452927-4d04-4c1d-9d88-19901fd06937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f452927-4d04-4c1d-9d88-19901fd06937.jpg?1",
             "name": "Elvish Dreadlord",
             "text": "Deathtouch\nWhen Elvish Dreadlord dies, non-Elf creatures get -3/-3 until end of turn.\nEncore {5}{B}{B} ({5}{B}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "e4332a04-61d0-53a4-8aad-8be7b2e5768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b75d9-f7c7-4a13-9318-02d7bbd80c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b75d9-f7c7-4a13-9318-02d7bbd80c9c.jpg?1",
             "name": "Exquisite Huntmaster",
             "text": "When Exquisite Huntmaster dies, create a 1/1 green Elf Warrior creature token.\nEncore {4}{B} ({4}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -4251,7 +4251,7 @@
         },
         {
             "id": "023604c7-0ec4-5ac9-976f-5db53761336e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a480da7-1b5d-41a5-b603-e63af100724a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a480da7-1b5d-41a5-b603-e63af100724a.jpg?1",
             "name": "Eyeblight Assassin",
             "text": "When Eyeblight Assassin enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "82511c0b-fea7-5fc8-836a-5ed5347772b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da777e75-6f1f-4e07-a5ec-e25454a0636c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da777e75-6f1f-4e07-a5ec-e25454a0636c.jpg?1",
             "name": "Eyeblight Cullers",
             "text": "When Eyeblight Cullers dies, create three 1/1 green Elf Warrior creature tokens, then mill three cards. (Put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "419b4870-1cd1-5c0b-bf04-ab5d29d58f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00670b-64a8-428a-8db0-9119efddaa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00670b-64a8-428a-8db0-9119efddaa1b.jpg?1",
             "name": "Eyeblight Massacre",
             "text": "Non-Elf creatures get -2/-2 until end of turn.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "91496316-74be-5a0b-b418-e7d45e467274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84537fea-ad81-4a9a-99d4-722a938adc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84537fea-ad81-4a9a-99d4-722a938adc7d.jpg?1",
             "name": "Falthis, Shadowcat Familiar",
             "text": "Commanders you control have menace and deathtouch.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "00965ce4-ece7-5bf8-9658-ca84558e2924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83f97d-c8c9-480c-a32c-918035673ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83f97d-c8c9-480c-a32c-918035673ab4.jpg?1",
             "name": "Feast of Succession",
             "text": "All creatures get -4/-4 until end of turn. You become the monarch.",
             "colours": [
@@ -4424,7 +4424,7 @@
         },
         {
             "id": "caee2044-7328-5a13-a8c8-030300a49ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4002b3a4-e00e-44ed-8989-d553e5d7d6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4002b3a4-e00e-44ed-8989-d553e5d7d6c8.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "6cbe6d84-dcdf-56e6-aeb6-33c5eb8c22a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe11a-fcc9-41e1-91ef-755bb4e22389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe11a-fcc9-41e1-91ef-755bb4e22389.jpg?1",
             "name": "Ghastly Demise",
             "text": "Destroy target nonblack creature if its toughness is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -4493,7 +4493,7 @@
         },
         {
             "id": "557722d1-bcb1-5cc3-9d7d-9912170894e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fbfc-c17d-4a5b-863e-842d4040200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fbfc-c17d-4a5b-863e-842d4040200a.jpg?1",
             "name": "Gilt-Leaf Winnower",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Gilt-Leaf Winnower enters the battlefield, you may destroy target non-Elf creature whose power and toughness aren't equal.",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "bdd9052c-faea-54ee-b3a3-e580de04706f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5ffe8-b4ed-4db8-8f0f-97aaeb659689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5ffe8-b4ed-4db8-8f0f-97aaeb659689.jpg?1",
             "name": "Keskit, the Flesh Sculptor",
             "text": "{T}, Sacrifice three other artifacts and/or creatures: Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "6dfed578-ce21-5a94-9b45-8a10d804cec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa715fde-8339-447b-8ac8-3126830bece8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa715fde-8339-447b-8ac8-3126830bece8.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When Maalfeld Twins dies, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "7e68a0b5-e3bc-5e34-bdec-c6c7f5aaa6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a76adc-42e1-4f65-940c-d0a5555c0633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a76adc-42e1-4f65-940c-d0a5555c0633.jpg?1",
             "name": "Miara, Thorn of the Glade",
             "text": "Whenever Miara, Thorn of the Glade or another Elf you control dies, you may pay {1} and 1 life. If you do, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "a8b5f870-8abd-5029-9e90-0897ff8a80e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440bfb8c-f29a-4c11-9fcb-ee935dead03f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440bfb8c-f29a-4c11-9fcb-ee935dead03f.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "d19616df-f0da-5d66-b81a-7c75fd08c01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c5948b-b021-4d07-8003-9c11db690bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c5948b-b021-4d07-8003-9c11db690bc0.jpg?1",
             "name": "Nadier, Agent of the Duskenel",
             "text": "Whenever a token you control leaves the battlefield, put a +1/+1 counter on Nadier, Agent of the Duskenel.\nWhen Nadier leaves the battlefield, create a number of 1/1 green Elf Warrior creature tokens equal to its power.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "6444d869-8b04-5a94-8c29-5db64d1e4695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbba08-0d93-4750-9dd6-d6a2779c6cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbba08-0d93-4750-9dd6-d6a2779c6cf3.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "6e05f526-4115-51b1-b4d0-37d83c2e14b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009d2fb8-6144-46d9-9085-26232c174109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009d2fb8-6144-46d9-9085-26232c174109.jpg?1",
             "name": "Necrotic Hex",
             "text": "Each player sacrifices six creatures. You create six tapped 2/2 black Zombie creature tokens.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "d326b8e9-30b3-57ec-89df-16ae1b409d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297ab13-d6f3-487b-86ec-6eb299eb0614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297ab13-d6f3-487b-86ec-6eb299eb0614.jpg?1",
             "name": "Nightshade Harvester",
             "text": "Whenever a land enters the battlefield under an opponent's control, that player loses 1 life. Put a +1/+1 counter on Nightshade Harvester.",
             "colours": [
@@ -4818,7 +4818,7 @@
         },
         {
             "id": "ce836168-bf2b-50ce-b9b7-55b8d126eba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01afdb32-d9a8-42d4-9ad2-4608ffd661f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01afdb32-d9a8-42d4-9ad2-4608ffd661f0.jpg?1",
             "name": "Noxious Dragon",
             "text": "Flying\nWhen Noxious Dragon dies, you may destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -4852,7 +4852,7 @@
         },
         {
             "id": "ce441784-d2a7-5f89-a224-da2353c149ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde7ecbc-b277-437c-ac94-4c3e89f1bda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde7ecbc-b277-437c-ac94-4c3e89f1bda6.jpg?1",
             "name": "Null Caller",
             "text": "{3}{B}, Exile a creature card from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "a47a987b-dc8c-5744-8893-4fdf27b8476f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f97e9-8b62-44f3-b467-149c2ac5ca78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f97e9-8b62-44f3-b467-149c2ac5ca78.jpg?1",
             "name": "Opposition Agent",
             "text": "Flash\nYou control your opponents while they're searching their libraries.\nWhile an opponent is searching their library, they exile each card they find. You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "815cfbec-2a77-5d3a-a106-fd9a4e917ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0d354e-3a63-4dfe-ae6d-5e82cbf419ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0d354e-3a63-4dfe-ae6d-5e82cbf419ac.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "393fe654-0072-5285-8a0e-cd8dc36c6c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9bc8-29c8-49cb-b4f5-1aceeda8bf45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9bc8-29c8-49cb-b4f5-1aceeda8bf45.jpg?1",
             "name": "Plague Reaver",
             "text": "At the beginning of your end step, sacrifice each other creature you control.\nDiscard two cards, Sacrifice Plague Reaver: Choose target opponent. Return Plague Reaver to the battlefield under that player's control at the beginning of their next upkeep.",
             "colours": [
@@ -4995,7 +4995,7 @@
         },
         {
             "id": "5bf7c6e3-87da-51bd-87ed-bf5add6dc612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30272e6d-683d-4c9a-90d6-ea7908943267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30272e6d-683d-4c9a-90d6-ea7908943267.jpg?1",
             "name": "Pride of the Perfect",
             "text": "Elves you control get +2/+0.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "aad3b32f-9ec2-5cb4-95e5-33f44999cb18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04d8edb-7350-4ab5-b721-390784c66329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04d8edb-7350-4ab5-b721-390784c66329.jpg?1",
             "name": "Profane Transfusion",
             "text": "Two target players exchange life totals. You create an X/X colorless Horror artifact creature token, where X is the difference between those players' life totals.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "f538e1c1-2b85-5535-9764-43b0b5b78379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31fd23d-e6b2-412b-b2ff-c99812365001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31fd23d-e6b2-412b-b2ff-c99812365001.jpg?1",
             "name": "Rakshasa Debaser",
             "text": "Whenever Rakshasa Debaser attacks, put target creature card from defending player's graveyard onto the battlefield under your control.\nEncore {6}{B}{B} ({6}{B}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "1356b24f-070f-57d0-98fd-46ee49c7239e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307a8465-9e33-4441-b512-a112e8524328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307a8465-9e33-4441-b512-a112e8524328.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "6a04afce-2a17-55e5-82f6-1b27bbb52f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c33d20d-8d1c-4cf7-a7ad-3dab9758fafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c33d20d-8d1c-4cf7-a7ad-3dab9758fafe.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -5166,7 +5166,7 @@
         },
         {
             "id": "738e4e5c-64ca-5eed-9394-a48916e3de8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d51a22e-74fc-442e-945a-56d02ca12713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d51a22e-74fc-442e-945a-56d02ca12713.jpg?1",
             "name": "Sengir, the Dark Baron",
             "text": "Flying\nWhenever another creature dies, put two +1/+1 counters on Sengir, the Dark Baron.\nWhenever another player loses the game, you gain life equal to that player's life total as the turn began.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "73de3286-f5f8-5c6c-9ee3-82fed95d0408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d42177-dd1b-482c-a549-6f563b3f3249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d42177-dd1b-482c-a549-6f563b3f3249.jpg?1",
             "name": "Spark Harvest",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "ab29f403-8c13-5afa-bb0d-25dc2d9b22ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce15ab0b-c70d-4ac0-a6ee-dbd31736ce1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce15ab0b-c70d-4ac0-a6ee-dbd31736ce1f.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -5270,7 +5270,7 @@
         },
         {
             "id": "5175b4b5-a435-5fc0-8dcc-1dd30735ac54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9828be7b-1eae-4718-9e71-2f625121b00b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9828be7b-1eae-4718-9e71-2f625121b00b.jpg?1",
             "name": "Szat's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Each opponent sacrifices a creature they control with the greatest power.\n\u2022 Exile all cards from all opponents' graveyards, then create X 0/1 black Thrull creature tokens, where X is the greatest power among creature cards exiled this way.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "9ae329c0-7f18-5139-b229-89dadbe595ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f244716-78ab-46f5-b6e9-fc1e6db28052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f244716-78ab-46f5-b6e9-fc1e6db28052.jpg?1",
             "name": "Tevesh Szat, Doom of Fools",
             "text": "+2: Create two 0/1 black Thrull creature tokens.\n+1: You may sacrifice another creature or planeswalker. If you do, draw two cards, then draw another card if the sacrificed permanent was a commander.\n\u221210: Gain control of all commanders. Put all commanders from the command zone onto the battlefield under your control.\nTevesh Szat, Doom of Fools can be your commander.\nPartner",
             "colours": [
@@ -5342,7 +5342,7 @@
         },
         {
             "id": "eb463207-cef8-5b62-a757-d07df4193fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7538ad-cc41-4229-8a39-c1db21f2899a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7538ad-cc41-4229-8a39-c1db21f2899a.jpg?1",
             "name": "Thorn of the Black Rose",
             "text": "Deathtouch\nWhen Thorn of the Black Rose enters the battlefield, you become the monarch.",
             "colours": [
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "3b193a3f-155e-59dc-8832-c0b5a620bd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89903d5e-241f-477e-a336-2abe0232c04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89903d5e-241f-477e-a336-2abe0232c04a.jpg?1",
             "name": "Tormod, the Desecrator",
             "text": "Whenever one or more cards leave your graveyard, create a tapped 2/2 black Zombie creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "8869e593-8d6e-5da1-9520-f141754a4533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bd50f2-c3ba-4217-a2d5-bb771e199706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bd50f2-c3ba-4217-a2d5-bb771e199706.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "20fa0466-f5ef-5e4c-885e-ec8486613b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855e9253-2219-4c43-8131-47633c564ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855e9253-2219-4c43-8131-47633c564ee2.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -5484,7 +5484,7 @@
         },
         {
             "id": "c96c9904-5765-501f-a39b-84029fb08a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49203dd-89b6-4e91-b3ff-5f9f5ce981f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49203dd-89b6-4e91-b3ff-5f9f5ce981f8.jpg?1",
             "name": "Viscera Seer",
             "text": "Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "4fcc34d6-bdf3-5efc-bab6-9655092b696c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae74624e-3850-4153-b682-d044272269c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae74624e-3850-4153-b682-d044272269c1.jpg?1",
             "name": "Vow of Torment",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has menace, and can't attack you or a planeswalker you control. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "d6a21294-4584-5d5d-998a-cb0c4cd2117d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c51949-b1ef-4c6e-98b0-4fb33a81db24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c51949-b1ef-4c6e-98b0-4fb33a81db24.jpg?1",
             "name": "Alena, Kessig Trapper",
             "text": "First strike\n{T}: Add an amount of {R} equal to the greatest power among creatures you control that entered the battlefield this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "01582551-627f-59c3-aa7c-7f94dc86e232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3841b5f9-f9a3-433d-bcdc-f2aa5c783b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3841b5f9-f9a3-433d-bcdc-f2aa5c783b6d.jpg?1",
             "name": "Aurora Phoenix",
             "text": "Flying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nWhenever you cast a spell with cascade, return Aurora Phoenix from your graveyard to your hand.",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "19840dd3-0f91-507d-8753-9d2fd92944e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1ef14-cb26-486e-9b54-0b532f5b7435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1ef14-cb26-486e-9b54-0b532f5b7435.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "b288bdfc-b88a-5e56-ab2b-60fa3485d489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186adacf-434b-475b-9b85-749615ae002b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186adacf-434b-475b-9b85-749615ae002b.jpg?1",
             "name": "Boarding Party",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "3598e199-097c-52b0-82b6-47c845ab0445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45657345-b564-4e5f-a57a-01dc54df7e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45657345-b564-4e5f-a57a-01dc54df7e7c.jpg?1",
             "name": "Brazen Freebooter",
             "text": "When Brazen Freebooter enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5734,7 +5734,7 @@
         },
         {
             "id": "651b7da2-c120-5876-b644-ea0de93ff480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e8fe2e-ec6c-47fc-85c0-6eec185ecdce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e8fe2e-ec6c-47fc-85c0-6eec185ecdce.jpg?1",
             "name": "Breeches, Brazen Plunderer",
             "text": "Menace\nWhenever one or more Pirates you control deal damage to your opponents, exile the top card of each of those opponents' libraries. You may play those cards this turn, and you may spend mana as though it were mana of any color to cast those spells.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "ddbab1e1-284f-524f-b523-7975baaecf24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a8f92-4418-4993-9f56-0b2f5069597c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a8f92-4418-4993-9f56-0b2f5069597c.jpg?1",
             "name": "Burning Anger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to any target.\"",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "d3241a14-eb0c-52fb-83a9-cffa7c5f9a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a248363d-40a0-4dc5-a0bb-a826c3ba4499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a248363d-40a0-4dc5-a0bb-a826c3ba4499.jpg?1",
             "name": "Champion of the Flame",
             "text": "Trample\nChampion of the Flame gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "61075dde-1e37-5814-b5a4-131e97ba6587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47e6bc-422a-4627-b21e-5a042193bed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47e6bc-422a-4627-b21e-5a042193bed0.jpg?1",
             "name": "Coastline Marauders",
             "text": "Trample\nWhenever Coastline Marauders attacks, it gets +1/+0 until end of turn for each land defending player controls.\nEncore {4}{R}{R} ({4}{R}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -5877,7 +5877,7 @@
         },
         {
             "id": "fcfb2216-2214-59a6-b2c5-024e0c1b03ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a02f1b-4f41-4285-a331-7211f4e6e2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a02f1b-4f41-4285-a331-7211f4e6e2b4.jpg?1",
             "name": "Coercive Recruiter",
             "text": "Whenever Coercive Recruiter or another Pirate enters the battlefield under your control, gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and becomes a Pirate in addition to its other types.",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "15c52b31-ad0c-5206-8667-ca185458b6d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca0dcc-7a87-49da-8011-8c11a8835df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca0dcc-7a87-49da-8011-8c11a8835df2.jpg?1",
             "name": "Court of Ire",
             "text": "When Court of Ire enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, Court of Ire deals 2 damage to any target. If you're the monarch, it deals 7 damage instead.",
             "colours": [
@@ -5948,7 +5948,7 @@
         },
         {
             "id": "305ce1cf-6bb1-5e91-a9b6-b0eedf67b6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90fdccf-30a6-40ee-9b35-83a6ee5c0681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90fdccf-30a6-40ee-9b35-83a6ee5c0681.jpg?1",
             "name": "Crimson Fleet Commodore",
             "text": "Trample\nWhen Crimson Fleet Commodore enters the battlefield, you become the monarch.",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "f02ab4c4-b512-53e7-b961-1e3c3fc5e942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd87cf8-4d5d-4aba-8dfa-800b1fb3799b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd87cf8-4d5d-4aba-8dfa-800b1fb3799b.jpg?1",
             "name": "Dargo, the Shipwrecker",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of artifacts and/or creatures. This spell costs {2} less to cast for each permanent sacrificed this way and {2} less to cast for each other artifact or creature you've sacrificed this turn.\nTrample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6022,7 +6022,7 @@
         },
         {
             "id": "1d54b6cc-3d3b-5be2-966b-21c75e788bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300761b6-9943-4251-9b1a-96a940f3334b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300761b6-9943-4251-9b1a-96a940f3334b.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -6057,7 +6057,7 @@
         },
         {
             "id": "b9ca2d56-8ee5-5162-8375-d100c29585d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca32fd66-f7f1-4e50-817f-bb259f690f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca32fd66-f7f1-4e50-817f-bb259f690f00.jpg?1",
             "name": "Dragon Mantle",
             "text": "Enchant creature\nWhen Dragon Mantle enters the battlefield, draw a card.\nEnchanted creature has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -6091,7 +6091,7 @@
         },
         {
             "id": "f1932cb1-b121-51a2-ac49-564dc9aa1960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362850cd-d33c-4f61-9b3a-5de748adee7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362850cd-d33c-4f61-9b3a-5de748adee7c.jpg?1",
             "name": "Emberwilde Captain",
             "text": "When Emberwilde Captain enters the battlefield, you become the monarch.\nWhenever an opponent attacks you while you're the monarch, Emberwilde Captain deals damage to that player equal to the number of cards in their hand.",
             "colours": [
@@ -6128,7 +6128,7 @@
         },
         {
             "id": "8fee2692-e949-57ca-9cb4-0d3a85641d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2f3dd5-a943-447b-8c76-8f69f06cefa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2f3dd5-a943-447b-8c76-8f69f06cefa4.jpg?1",
             "name": "Explosion of Riches",
             "text": "Draw a card, then each other player may draw a card. Whenever a card is drawn this way, Explosion of Riches deals 5 damage to target opponent chosen at random from among your opponents.",
             "colours": [
@@ -6160,7 +6160,7 @@
         },
         {
             "id": "2c18cae7-98d9-57f5-91fd-f21563f5e593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c267b7-dbd6-43c5-9741-10f635bff4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c267b7-dbd6-43c5-9741-10f635bff4b1.jpg?1",
             "name": "Fathom Fleet Swordjack",
             "text": "Whenever Fathom Fleet Swordjack attacks, it deals damage to the player or planeswalker it's attacking equal to the number of artifacts you control.\nEncore {5}{R} ({5}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "105036aa-f949-5e6a-b7c3-f009e8034d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f1cdf-712b-4518-a0e8-0039303dccdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f1cdf-712b-4518-a0e8-0039303dccdc.jpg?1",
             "name": "Fiery Cannonade",
             "text": "Fiery Cannonade deals 2 damage to each non-Pirate creature.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "5d5f0211-9541-54c6-95de-a9812699fecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2616030-01f2-43b1-98ba-f7e5a5a75379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2616030-01f2-43b1-98ba-f7e5a5a75379.jpg?1",
             "name": "Flamekin Herald",
             "text": "Commander spells you cast have cascade. (Whenever you cast a commander, exile cards from the top of your library until you exile a nonland card with lesser converted mana cost. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "27ee3059-6271-5008-89fc-d2d6b46d12e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518fffb-542f-4752-be05-d0dbcf4dd6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518fffb-542f-4752-be05-d0dbcf4dd6c2.jpg?1",
             "name": "Frenzied Saddlebrute",
             "text": "Haste\nAll creatures can attack your opponents and planeswalkers your opponents control as though those creatures had haste.",
             "colours": [
@@ -6299,7 +6299,7 @@
         },
         {
             "id": "dd73975b-04f7-5e2a-8e81-95ead26b2294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7f79-fc49-4d1e-a84f-c630ba238e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7f79-fc49-4d1e-a84f-c630ba238e83.jpg?1",
             "name": "Furnace Celebration",
             "text": "Whenever you sacrifice another permanent, you may pay {2}. If you do, Furnace Celebration deals 2 damage to any target.",
             "colours": [
@@ -6331,7 +6331,7 @@
         },
         {
             "id": "1cf9407c-da88-531c-bbbb-f886e7ad74f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca382425-2454-4300-b903-fdefd31582d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca382425-2454-4300-b903-fdefd31582d3.jpg?1",
             "name": "Goblin Trailblazer",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "fd9cdcab-4aaa-50dd-9541-4aece93b3543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45122e-b5ef-487b-8ea9-59ea066d3c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45122e-b5ef-487b-8ea9-59ea066d3c88.jpg?1",
             "name": "Hellkite Courser",
             "text": "Flying\nWhen Hellkite Courser enters the battlefield, you may put a commander you own from the command zone onto the battlefield. It gains haste. Return it to the command zone at the beginning of the next end step.",
             "colours": [
@@ -6402,7 +6402,7 @@
         },
         {
             "id": "321e56b9-d436-5b9e-8555-1b051e091079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6539ca2d-e577-43f7-9f0c-bd25599dcb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6539ca2d-e577-43f7-9f0c-bd25599dcb8c.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "a67ec8aa-00a5-5f54-aca7-3b3ec4e8ad1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ba9bea-5549-45cf-896c-501a1c81fd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ba9bea-5549-45cf-896c-501a1c81fd5a.jpg?1",
             "name": "Impulsive Pilferer",
             "text": "When Impulsive Pilferer dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEncore {3}{R} ({3}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "dc7953a6-d2d2-5db6-bf30-9e5902c8c0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48caf4c4-745c-4072-bf3d-1a3fa7c3bc9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48caf4c4-745c-4072-bf3d-1a3fa7c3bc9c.jpg?1",
             "name": "Jeska, Thrice Reborn",
             "text": "Jeska, Thrice Reborn enters the battlefield with a loyalty counter on it for each time you've cast a commander from the command zone this game.\n0: Choose target creature. Until your next turn, if that creature would deal combat damage to one of your opponents, it deals triple that damage to that player instead.\n\u2212X: Jeska, Thrice Reborn deals X damage to each of up to three targets.\nJeska, Thrice Reborn can be your commander.\nPartner",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "29c8038d-3b3c-5092-b618-75ab4487ed9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e91d96d-cc69-439b-b876-a7d57039022c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e91d96d-cc69-439b-b876-a7d57039022c.jpg?1",
             "name": "Jeska's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Add {R} for each card in target opponent's hand.\n\u2022 Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "f3f5f0de-68c9-59e4-ab61-77b58b2afb1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f606ebf1-483d-4331-b16a-9fb6f591a39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f606ebf1-483d-4331-b16a-9fb6f591a39f.jpg?1",
             "name": "Kediss, Emberclaw Familiar",
             "text": "Whenever a commander you control deals combat damage to an opponent, it deals that much damage to each other opponent.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6585,7 +6585,7 @@
         },
         {
             "id": "2704f6ad-6741-5194-9bf7-459d6b4c5b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a981cd-1951-438e-95c9-68294795638e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a981cd-1951-438e-95c9-68294795638e.jpg?1",
             "name": "Krark, the Thumbless",
             "text": "Whenever you cast an instant or sorcery spell, flip a coin. If you lose the flip, return that spell to its owner's hand. If you win the flip, copy that spell, and you may choose new targets for the copy.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6624,7 +6624,7 @@
         },
         {
             "id": "da151ce0-f377-5d8f-ab43-620b2d7269e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa676ef-3f26-43bb-98f9-9b0b9681a7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa676ef-3f26-43bb-98f9-9b0b9681a7fe.jpg?1",
             "name": "Lightning-Rig Crew",
             "text": "{T}: Lightning-Rig Crew deals 1 damage to each opponent.\nWhenever you cast a Pirate spell, untap Lightning-Rig Crew.",
             "colours": [
@@ -6659,7 +6659,7 @@
         },
         {
             "id": "7b69f1c2-3187-5c22-9ac8-ec2f5b45103a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1ad9f-e217-49fb-8b27-025ca133b6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1ad9f-e217-49fb-8b27-025ca133b6c9.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.",
             "colours": [
@@ -6691,7 +6691,7 @@
         },
         {
             "id": "c9084657-d201-5564-87cf-ddca6dafabc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb7e94-01df-4e80-9b24-bc303a27ffd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb7e94-01df-4e80-9b24-bc303a27ffd6.jpg?1",
             "name": "Meteoric Mace",
             "text": "Equipped creature gets +4/+0 and has trample.\nEquip {4}\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "9cf3abe2-d6ce-5e6a-9bfe-a8c76ef73511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0527b-bb28-4986-9843-040d06bd9def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0527b-bb28-4986-9843-040d06bd9def.jpg?1",
             "name": "Port Razer",
             "text": "Whenever Port Razer deals combat damage to a player, untap each creature you control. After this combat phase, there is an additional combat phase.\nPort Razer can't attack a player it has already attacked this turn.",
             "colours": [
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "74479dc6-c690-544b-be80-66ff17a14370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288606e-182a-4260-bbe9-3f8f09c2f33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288606e-182a-4260-bbe9-3f8f09c2f33c.jpg?1",
             "name": "Portent of Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "adad3014-25bb-53c7-8cb9-7d0482461c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfa0e65-1ce0-4f8e-a78b-2ade2d25e748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfa0e65-1ce0-4f8e-a78b-2ade2d25e748.jpg?1",
             "name": "Renegade Tactics",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "48448b61-5f31-53a2-9bbe-66293104501b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00924a16-fb85-41a4-bd7a-88f51f728333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00924a16-fb85-41a4-bd7a-88f51f728333.jpg?1",
             "name": "Ripscale Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "379be6bc-f2ec-50ef-b815-f2c1d3ff867f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fab67f-00c2-4125-9262-d21a29411797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fab67f-00c2-4125-9262-d21a29411797.jpg?1",
             "name": "Rograkh, Son of Rohgahh",
             "text": "First strike, menace, trample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6899,7 +6899,7 @@
         },
         {
             "id": "2e4a7cef-8462-5557-8cf6-5fc2a3b93113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254391a3-c12a-4944-9da5-ae166094480f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254391a3-c12a-4944-9da5-ae166094480f.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "b97549e9-0b87-5b96-9ea1-1b3495dcb6f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eed5cc-e5e8-476d-bdd7-c51233359a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eed5cc-e5e8-476d-bdd7-c51233359a48.jpg?1",
             "name": "Skyraker Giant",
             "text": "Reach",
             "colours": [
@@ -6968,7 +6968,7 @@
         },
         {
             "id": "b160d3a5-222a-562b-a182-4cdb4f510d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239a9f2e-145b-4f31-8128-4d376af1079d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239a9f2e-145b-4f31-8128-4d376af1079d.jpg?1",
             "name": "Soul's Fire",
             "text": "Target creature you control deals damage equal to its power to any target.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "bd128f43-2826-5813-8e4d-3cd710182ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2def4384-7175-4a26-a5a0-8f2c5b5ad71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2def4384-7175-4a26-a5a0-8f2c5b5ad71c.jpg?1",
             "name": "Soulfire Eruption",
             "text": "Choose any number of target creatures, planeswalkers, and/or players. For each of them, exile the top card of your library, then Soulfire Eruption deals damage equal to that card's converted mana cost to that permanent or player. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "e9f86bef-9987-5108-95c1-9d189c4c5e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a3c60-c740-4e2e-a622-a749ed230c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a3c60-c740-4e2e-a622-a749ed230c5b.jpg?1",
             "name": "Sparktongue Dragon",
             "text": "Flying\nWhen Sparktongue Dragon enters the battlefield, you may pay {2}{R}. When you do, it deals 3 damage to any target.",
             "colours": [
@@ -7068,7 +7068,7 @@
         },
         {
             "id": "82398377-5edb-5600-bbab-c64d6480b4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c111bf0-dedb-48eb-982c-f877120f12c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c111bf0-dedb-48eb-982c-f877120f12c3.jpg?1",
             "name": "Stonefury",
             "text": "Stonefury deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "a2eaff0d-7ba6-544c-875c-02c26001a887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a05b3e2-259e-4fce-92ee-c00660e22ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a05b3e2-259e-4fce-92ee-c00660e22ae7.jpg?1",
             "name": "Toggo, Goblin Weaponsmith",
             "text": "Whenever a land enters the battlefield under your control, create a colorless Equipment artifact token named Rock with \"Equipped creature has \u2018{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any target'\" and equip {1}.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "737853fe-4f6d-5c9d-8509-f9dbb6a391da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db7aa92-d86a-4986-a661-f3025ca79d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db7aa92-d86a-4986-a661-f3025ca79d3d.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -7173,7 +7173,7 @@
         },
         {
             "id": "c05bcc98-c211-5784-ae4b-50aa6a3a2eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8000d86-60e7-4edd-b685-14ade08b76f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8000d86-60e7-4edd-b685-14ade08b76f2.jpg?1",
             "name": "Valakut Invoker",
             "text": "{8}: Valakut Invoker deals 3 damage to any target.",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "d4ef1d4e-233e-5a2c-a4d0-0ceac8ae48db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419d29-21a1-4753-a2f0-1d0d996ec54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419d29-21a1-4753-a2f0-1d0d996ec54e.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying, haste",
             "colours": [
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "9b23d590-3945-5c74-9b3b-e0693e643fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb586da6-670d-4c50-9d9b-f320f1c288d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb586da6-670d-4c50-9d9b-f320f1c288d7.jpg?1",
             "name": "Volcanic Torrent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nVolcanic Torrent deals X damage to each creature and planeswalker your opponents control, where X is the number of spells you've cast this turn.",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "00b8b8c0-6c64-52f6-b7cf-297260191f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71218cff-7e57-40dd-83c2-d06b284a63fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71218cff-7e57-40dd-83c2-d06b284a63fd.jpg?1",
             "name": "Vow of Lightning",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has first strike, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -7308,7 +7308,7 @@
         },
         {
             "id": "9dba227d-910e-5b97-ab60-b4f7cb4d91a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cc190-6825-4226-8ea5-71abe788454d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cc190-6825-4226-8ea5-71abe788454d.jpg?1",
             "name": "Welding Sparks",
             "text": "Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.",
             "colours": [
@@ -7340,7 +7340,7 @@
         },
         {
             "id": "40b8812e-003d-56c3-a181-d47a090c0d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74177b51-a300-49d9-8ea7-557b19cf80c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74177b51-a300-49d9-8ea7-557b19cf80c7.jpg?1",
             "name": "Wheel of Misfortune",
             "text": "Each player secretly chooses a number 0 or greater, then all players reveal those numbers simultaneously and determine the highest and lowest numbers revealed this way. Wheel of Misfortune deals damage equal to the highest number to each player who chose that number. Each player who didn't choose the lowest number discards their hand, then draws seven cards.",
             "colours": [
@@ -7374,7 +7374,7 @@
         },
         {
             "id": "66a81257-2961-582a-9fb3-46224bb052cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9e72f4-0087-4a79-b9af-296c8b930a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9e72f4-0087-4a79-b9af-296c8b930a25.jpg?1",
             "name": "Wild Celebrants",
             "text": "When Wild Celebrants enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -7408,7 +7408,7 @@
         },
         {
             "id": "8d167cba-ebfd-5f2d-86cb-bccbbba625fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e386888-57f5-4eb6-88e8-5679bb8eb290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e386888-57f5-4eb6-88e8-5679bb8eb290.jpg?1",
             "name": "Ambush Viper",
             "text": "Flash\nDeathtouch",
             "colours": [
@@ -7442,7 +7442,7 @@
         },
         {
             "id": "a6643f91-5c8f-549b-b955-12a83d1560d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67cfaa-990c-4dcb-97a9-9c5d7316cabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67cfaa-990c-4dcb-97a9-9c5d7316cabe.jpg?1",
             "name": "Anara, Wolvid Familiar",
             "text": "As long as it's your turn, commanders you control have indestructible. (Effects that say \"destroy\" don't destroy them. A creature with indestructible can't be destroyed by damage.)\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "b48b8938-8fcb-52ab-b4f3-54be2b611105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee76006-5272-400d-b6b2-e1548bca9dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee76006-5272-400d-b6b2-e1548bca9dbf.jpg?1",
             "name": "Ancient Animus",
             "text": "Put a +1/+1 counter on target creature you control if it's legendary. Then it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "09038313-4035-5441-8f9b-f47d706a5988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536d618-0c98-45bb-913b-b8117b4acf87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536d618-0c98-45bb-913b-b8117b4acf87.jpg?1",
             "name": "Annoyed Altisaur",
             "text": "Reach, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "0973d08b-c588-5be8-882b-abb9631eb700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa281e1-5c48-4bba-b8e9-88c6f5f53abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa281e1-5c48-4bba-b8e9-88c6f5f53abb.jpg?1",
             "name": "Apex Devastator",
             "text": "Cascade, cascade, cascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Multiple instances of cascade each trigger separately.)",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "0ec1a938-e29f-5347-8071-d0a2ff6de6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1483d4-bb91-4bf9-a57f-dd46fa31056b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1483d4-bb91-4bf9-a57f-dd46fa31056b.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "576fe942-7f63-59af-92d1-eee987c9e8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf476f-ccc8-42ac-8d01-64bb85552acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf476f-ccc8-42ac-8d01-64bb85552acd.jpg?1",
             "name": "Biowaste Blob",
             "text": "Oozes you control get +1/+1.\nAt the beginning of your upkeep, if you control a commander, create a token that's a copy of Biowaste Blob.",
             "colours": [
@@ -7655,7 +7655,7 @@
         },
         {
             "id": "d2a4d2a9-c38c-513e-910f-0ac406aba2a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcffbea4-0126-483d-87da-b20e3c0b88a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcffbea4-0126-483d-87da-b20e3c0b88a7.jpg?1",
             "name": "Court of Bounty",
             "text": "When Court of Bounty enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, you may put a land card from your hand onto the battlefield. If you're the monarch, instead you may put a creature or land card from your hand onto the battlefield.",
             "colours": [
@@ -7689,7 +7689,7 @@
         },
         {
             "id": "59e2d2d9-a442-5c76-8c05-7d2cf75a32bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7adf3cb-2834-49fc-bdd0-9b939a20915c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7adf3cb-2834-49fc-bdd0-9b939a20915c.jpg?1",
             "name": "Crushing Vines",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -7721,7 +7721,7 @@
         },
         {
             "id": "9d462bb8-e690-55bf-9a77-8439b168fef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26025f0-72c0-4875-b2d7-916666b835d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26025f0-72c0-4875-b2d7-916666b835d9.jpg?1",
             "name": "Dawnglade Regent",
             "text": "When Dawnglade Regent enters the battlefield, you become the monarch.\nAs long as you're the monarch, permanents you control have hexproof.",
             "colours": [
@@ -7757,7 +7757,7 @@
         },
         {
             "id": "1af9ac64-e096-5e46-b7b3-ec69b713317f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f174e6-9532-4fc3-815b-2dc3966c6523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f174e6-9532-4fc3-815b-2dc3966c6523.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -7792,7 +7792,7 @@
         },
         {
             "id": "b10e39b4-7f2b-5f85-a796-8103bdf90bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e65427-1191-4f5a-b4ca-c383eecd274e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e65427-1191-4f5a-b4ca-c383eecd274e.jpg?1",
             "name": "Entourage of Trest",
             "text": "When Entourage of Trest enters the battlefield, you become the monarch.\nEntourage of Trest can block an additional creature each combat as long as you're the monarch.",
             "colours": [
@@ -7827,7 +7827,7 @@
         },
         {
             "id": "826db393-02de-539a-a5b8-5386d6054628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db681025-f912-4cba-8b89-c57cda2e6d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db681025-f912-4cba-8b89-c57cda2e6d53.jpg?1",
             "name": "Farhaven Elf",
             "text": "When Farhaven Elf enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7862,7 +7862,7 @@
         },
         {
             "id": "a28cd052-a52e-5a1e-8e70-ebe32d90264c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d56da0-6f37-4bd5-8982-940e80bd4282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d56da0-6f37-4bd5-8982-940e80bd4282.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles their library.",
             "colours": [
@@ -7896,7 +7896,7 @@
         },
         {
             "id": "5441780c-3567-5306-91ec-f7d9b3966d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb7af70-e024-44bf-a52b-209074b005a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb7af70-e024-44bf-a52b-209074b005a3.jpg?1",
             "name": "Fin-Clade Fugitives",
             "text": "Fin-Clade Fugitives can't be blocked by creatures with power 2 or less.\nEncore {4}{G} ({4}{G}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "4aa94472-4ade-5c48-9958-e09629e9263b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450744cf-7eba-491b-97b0-ca80c6368bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450744cf-7eba-491b-97b0-ca80c6368bbb.jpg?1",
             "name": "Fyndhorn Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -7969,7 +7969,7 @@
         },
         {
             "id": "5e6213d4-bdea-5195-b6d5-360fa1a715b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b361e3-8aaa-4194-8ae8-45bdb70c97bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b361e3-8aaa-4194-8ae8-45bdb70c97bb.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "55b71f80-36b8-57ba-8b2f-2d4db81c9b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745d297d-4bb4-40cf-bb9c-99dac04e5069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745d297d-4bb4-40cf-bb9c-99dac04e5069.jpg?1",
             "name": "Gilanra, Caller of Wirewood",
             "text": "{T}: Add {G}. When you spend this mana to cast a spell with converted mana cost 6 or greater, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "a836295d-4af9-5590-a83c-49b39abde7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee6eb2-2708-4596-86ad-40eea88dbb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee6eb2-2708-4596-86ad-40eea88dbb6b.jpg?1",
             "name": "Halana, Kessig Ranger",
             "text": "Reach\nWhenever another creature enters the battlefield under your control, you may pay {2}. When you do, that creature deals damage equal to its power to target creature.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "8bd56d7f-05e8-5d3e-b534-f27bca5b9a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1448cf-3ddc-437b-a21e-4f4086492ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1448cf-3ddc-437b-a21e-4f4086492ec6.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -8114,7 +8114,7 @@
         },
         {
             "id": "9767c0a3-2584-5383-8eeb-6873f4f20ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409a15a-7cf6-43e5-958c-d23da4304f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409a15a-7cf6-43e5-958c-d23da4304f29.jpg?1",
             "name": "Ich-Tekik, Salvage Splicer",
             "text": "When Ich-Tekik, Salvage Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nWhenever an artifact is put into a graveyard from the battlefield, put a +1/+1 counter on Ich-Tekik and a +1/+1 counter on each Golem you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "3a2fc10e-7f58-5922-948c-71903dc62f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9208db8-1ba5-4f9c-90a4-03e377ae6f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9208db8-1ba5-4f9c-90a4-03e377ae6f86.jpg?1",
             "name": "Immaculate Magistrate",
             "text": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
             "colours": [
@@ -8191,7 +8191,7 @@
         },
         {
             "id": "3b6d43d9-d72e-5f43-bb47-84b62b981baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef8940a-d1d9-460e-9949-89bb30f9e6d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef8940a-d1d9-460e-9949-89bb30f9e6d6.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elves you control get +1/+1.\n{G}, {T}: Create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "c3d57d00-2cf2-5810-9dab-16ee46f17339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bea375-8af3-4425-a418-bb5503e2dfb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bea375-8af3-4425-a418-bb5503e2dfb7.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "81a66020-9905-509d-8285-acb9d3bda6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3560ae-b1f6-4269-a9eb-1a45247b6232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3560ae-b1f6-4269-a9eb-1a45247b6232.jpg?1",
             "name": "Kamahl, Heart of Krosa",
             "text": "At the beginning of combat on your turn, creatures you control get +3/+3 and gain trample until end of turn.\n{1}{G}: Until end of turn, target land you control becomes a 1/1 Elemental creature with vigilance, indestructible, and haste. It's still a land.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "1f2ddca9-f0b3-5afc-bdf6-2a527ba198c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fe007f-fddf-4b3a-b336-0a88df95cb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fe007f-fddf-4b3a-b336-0a88df95cb14.jpg?1",
             "name": "Kamahl's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Until end of turn, any number of target lands you control become 1/1 Elemental creatures with vigilance, indestructible, and haste. They're still lands.\n\u2022 Choose target creature you don't control. Each creature you control deals damage equal to its power to that creature.",
             "colours": [
@@ -8334,7 +8334,7 @@
         },
         {
             "id": "472d5072-f952-5115-81f5-5d0d3d1adf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5105ee-09e2-4344-ab39-00f0e9034c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5105ee-09e2-4344-ab39-00f0e9034c47.jpg?1",
             "name": "Kodama of the East Tree",
             "text": "Reach\nWhenever another permanent enters the battlefield under your control, if it wasn't put onto the battlefield with this ability, you may put a permanent card with equal or lesser converted mana cost from your hand onto the battlefield.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8372,7 +8372,7 @@
         },
         {
             "id": "3d7085d6-735c-5c39-b0a4-54b8c1e0e322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa000086-e4aa-4bb6-8e66-f4c96e875749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa000086-e4aa-4bb6-8e66-f4c96e875749.jpg?1",
             "name": "Lifecrafter's Gift",
             "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -8404,7 +8404,7 @@
         },
         {
             "id": "e0abfa60-b253-5595-8fef-d227960f0e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888e2f0-223b-4509-8071-fe1b87a65b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888e2f0-223b-4509-8071-fe1b87a65b72.jpg?1",
             "name": "Lys Alana Bowmaster",
             "text": "Reach\nWhenever you cast an Elf spell, you may have Lys Alana Bowmaster deal 2 damage to target creature with flying.",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "14d81244-e39b-5e18-966b-177b6c603a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e5fa9-cfe3-487b-af77-0dbf6c68ee04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e5fa9-cfe3-487b-af77-0dbf6c68ee04.jpg?1",
             "name": "Magus of the Order",
             "text": "{G}, {T}, Sacrifice Magus of the Order and another green creature: Search your library for a green creature card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "28682398-1b11-5f20-b87c-d2d57835060e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636f571-43ed-4b60-b5d9-129ff94dd0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636f571-43ed-4b60-b5d9-129ff94dd0fa.jpg?1",
             "name": "Molder Beast",
             "text": "Trample\nWhenever an artifact is put into a graveyard from the battlefield, Molder Beast gets +2/+0 until end of turn.",
             "colours": [
@@ -8510,7 +8510,7 @@
         },
         {
             "id": "8da9d3d9-00f5-5605-8e9a-ddb17e81112d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc27f7f-5dd4-4f1d-ba3f-a4b0400cdc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc27f7f-5dd4-4f1d-ba3f-a4b0400cdc72.jpg?1",
             "name": "Monstrous Onslaught",
             "text": "Monstrous Onslaught deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast this spell.",
             "colours": [
@@ -8542,7 +8542,7 @@
         },
         {
             "id": "9f8f9a52-51f2-595c-80b7-b5332b075c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98fb7c-6962-4b57-b7b7-c71899564002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98fb7c-6962-4b57-b7b7-c71899564002.jpg?1",
             "name": "Natural Reclamation",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "02dc8039-bc77-5c65-9654-8cdffc350880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9465d118-5ad5-42c5-a512-7aca5f7b905d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9465d118-5ad5-42c5-a512-7aca5f7b905d.jpg?1",
             "name": "Numa, Joraga Chieftain",
             "text": "At the beginning of combat on your turn, you may pay {X}{X}. When you do, distribute X +1/+1 counters among any number of target Elves.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "ea6c5d30-8bba-5d0c-9d90-a9bb40c3f93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea175de9-15c2-4d08-ae0e-0427a0b8069b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea175de9-15c2-4d08-ae0e-0427a0b8069b.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea.\nWhen you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "56c27653-711b-5cdc-a751-38b68396d3f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b800bb44-3594-4fb7-b007-10732632b51a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b800bb44-3594-4fb7-b007-10732632b51a.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "5d6514c4-af2b-5417-ae1c-bfbe1d6bb918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada14bc8-4549-4a73-8cbb-9a43698deb36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada14bc8-4549-4a73-8cbb-9a43698deb36.jpg?1",
             "name": "Reshape the Earth",
             "text": "Search your library for up to ten land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "4c489f93-db86-584a-aabe-23bcbf619ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987e0ffe-ea75-4985-b6a3-b874bef78719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987e0ffe-ea75-4985-b6a3-b874bef78719.jpg?1",
             "name": "Rootweaver Druid",
             "text": "When Rootweaver Druid enters the battlefield, each opponent may search their library for up to three basic land cards. They each put one of those cards onto the battlefield tapped under your control and the rest onto the battlefield tapped under their control. Then each player who searched their library this way shuffles it.",
             "colours": [
@@ -8755,7 +8755,7 @@
         },
         {
             "id": "fcb66348-e4ff-5735-b140-9eaa2936c1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017ef6eb-7a2b-4730-bf21-a2289d4c07ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017ef6eb-7a2b-4730-bf21-a2289d4c07ad.jpg?1",
             "name": "Scaled Behemoth",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -8789,7 +8789,7 @@
         },
         {
             "id": "b6933827-f667-539f-bed8-6bf3a0719a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c8aab5-ed0d-489d-87af-7eb3193b75db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c8aab5-ed0d-489d-87af-7eb3193b75db.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -8824,7 +8824,7 @@
         },
         {
             "id": "b00630a0-5802-552f-8e9c-629a386e8b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e7af76-e505-49ca-a91e-8167027560ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e7af76-e505-49ca-a91e-8167027560ff.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "b95bd260-f247-551d-a5fa-419aa3d8831f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ff217-1bf6-4942-8d2f-8ddd71da683f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ff217-1bf6-4942-8d2f-8ddd71da683f.jpg?1",
             "name": "Sifter Wurm",
             "text": "Trample\nWhen Sifter Wurm enters the battlefield, scry 3, then reveal the top card of your library. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "ffeda675-671f-5194-a5dd-daff38581235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8048bab7-8fd1-446c-80e9-cc2ffb154295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8048bab7-8fd1-446c-80e9-cc2ffb154295.jpg?1",
             "name": "Silverback Shaman",
             "text": "Trample\nWhen Silverback Shaman dies, draw a card.",
             "colours": [
@@ -8927,7 +8927,7 @@
         },
         {
             "id": "cee16c13-ece0-5b53-83bc-bcbeb211fe98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da14a82-0c33-4319-9af5-390013ccbe19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da14a82-0c33-4319-9af5-390013ccbe19.jpg?1",
             "name": "Slurrk, All-Ingesting",
             "text": "Slurrk, All-Ingesting enters the battlefield with five +1/+1 counters on it.\nWhenever Slurrk or another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on each creature you control that has a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "b1ab4c62-4459-55a4-8119-8dac01571a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd32c85-3cc5-4987-8156-4def6d0004d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd32c85-3cc5-4987-8156-4def6d0004d6.jpg?1",
             "name": "Soul's Might",
             "text": "Put X +1/+1 counters on target creature, where X is that creature's power.",
             "colours": [
@@ -8997,7 +8997,7 @@
         },
         {
             "id": "2d335255-a266-5e2f-8420-c6e0ae86558d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f45424-2c26-43fa-9afe-eeb22ce772e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f45424-2c26-43fa-9afe-eeb22ce772e1.jpg?1",
             "name": "Stingerfling Spider",
             "text": "Reach\nWhen Stingerfling Spider enters the battlefield, you may destroy target creature with flying.",
             "colours": [
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "5e6549b6-5b43-5da1-8597-d7109b9befe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1ba0c-1131-4b16-9a11-90947cdb6292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1ba0c-1131-4b16-9a11-90947cdb6292.jpg?1",
             "name": "Strength of the Pack",
             "text": "Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -9063,7 +9063,7 @@
         },
         {
             "id": "89247cf6-b39b-58dc-8c77-1d41ac1b26b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd331b3-43cd-421a-964d-d3b35bb8abcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd331b3-43cd-421a-964d-d3b35bb8abcb.jpg?1",
             "name": "Sweet-Gum Recluse",
             "text": "Flash\nCascade\nReach\nWhen Sweet-Gum Recluse enters the battlefield, put three +1/+1 counters on each of any number of target creatures that entered the battlefield this turn.",
             "colours": [
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "e7ec28f5-cc4c-5a37-a8eb-6cb630e9a26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9307ec-987b-4bbf-a679-cfaabe283a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9307ec-987b-4bbf-a679-cfaabe283a80.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "ca3439c9-e3e9-585a-9864-ab2d22bfffa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764fa7f1-b92b-42cc-983e-e0b5457369a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764fa7f1-b92b-42cc-983e-e0b5457369a7.jpg?1",
             "name": "Vow of Wildness",
             "text": "Enchant creature\nEnchanted creature gets +3/+3, has trample, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -9167,7 +9167,7 @@
         },
         {
             "id": "a6d94b84-6645-5581-a284-1aff926ee00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143231b3-23c4-4c6d-8b58-e401e1ac6e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143231b3-23c4-4c6d-8b58-e401e1ac6e29.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -9202,7 +9202,7 @@
         },
         {
             "id": "88e3b8fc-b697-541a-8741-d6afa74c21e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e640d-9a24-471e-8092-0177ec8d824e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e640d-9a24-471e-8092-0177ec8d824e.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "825c7b44-9ad0-57c6-ae6e-cc2213fb027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567dbc64-4d59-4bab-a551-08fc66c085fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567dbc64-4d59-4bab-a551-08fc66c085fa.jpg?1",
             "name": "Abomination of Llanowar",
             "text": "Vigilance; menace (This creature can't be blocked except by two or more creatures.)\nAbomination of Llanowar's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.",
             "colours": [
@@ -9275,7 +9275,7 @@
         },
         {
             "id": "9f3f136a-5fcd-5862-aa93-446131f59c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbea010-de77-468e-be39-1717070c9303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbea010-de77-468e-be39-1717070c9303.jpg?1",
             "name": "Amareth, the Lustrous",
             "text": "Flying\nWhenever another permanent enters the battlefield under your control, look at the top card of your library. If it shares a card type with that permanent, you may reveal that card and put it into your hand.",
             "colours": [
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "ca25fdd8-2459-59b5-ad06-c7576a46e6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b597dd-f6eb-45da-977d-453e8c1433cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b597dd-f6eb-45da-977d-453e8c1433cc.jpg?1",
             "name": "Araumi of the Dead Tide",
             "text": "{T}, Exile cards from your graveyard equal to the number of opponents you have: Target creature card in your graveyard gains encore until end of turn. The encore cost is equal to its mana cost. (Exile the creature card and pay its mana cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -9358,7 +9358,7 @@
         },
         {
             "id": "b772f271-3685-5b83-bf3c-d2f1e0f11b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafb8740-1bab-4f5e-96d1-79f1f04cc0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafb8740-1bab-4f5e-96d1-79f1f04cc0d8.jpg?1",
             "name": "Archelos, Lagoon Mystic",
             "text": "As long as Archelos, Lagoon Mystic is tapped, other permanents enter the battlefield tapped.\nAs long as Archelos is untapped, other permanents enter the battlefield untapped.",
             "colours": [
@@ -9401,7 +9401,7 @@
         },
         {
             "id": "92f9d565-c101-5788-8aff-77ab21e0e60d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46b3ef3-3ba9-4da7-a675-86468a8da4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46b3ef3-3ba9-4da7-a675-86468a8da4c7.jpg?1",
             "name": "Averna, the Chaos Bloom",
             "text": "As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)",
             "colours": [
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "ed1fe3f2-0fa2-5ab3-b691-272f4fcb2389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4427e73-8c60-490d-8ae3-53e872a5163e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4427e73-8c60-490d-8ae3-53e872a5163e.jpg?1",
             "name": "Belbe, Corrupted Observer",
             "text": "At the beginning of each player's postcombat main phase, that player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)",
             "colours": [
@@ -9486,7 +9486,7 @@
         },
         {
             "id": "8f8bc5cc-80a6-5591-a149-15dfdac5acee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602cf54-3c34-4f86-8440-13ac28ace68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602cf54-3c34-4f86-8440-13ac28ace68c.jpg?1",
             "name": "Bell Borca, Spectral Sergeant",
             "text": "Note the converted mana cost of each card as it's put into exile.\nBell Borca, Spectral Sergeant's power is equal to the greatest number noted for it this turn.\nAt the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -9527,7 +9527,7 @@
         },
         {
             "id": "316658fe-3692-5597-9f3b-e0f480048c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8cd7dc-028a-4da2-b2a1-435d40cf48ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8cd7dc-028a-4da2-b2a1-435d40cf48ca.jpg?1",
             "name": "Blim, Comedic Genius",
             "text": "Flying\nWhenever Blim, Comedic Genius deals combat damage to a player, that player gains control of target permanent you control. Then each player loses life and discards cards equal to the number of permanents they control but don't own.",
             "colours": [
@@ -9567,7 +9567,7 @@
         },
         {
             "id": "dfc36f44-84ca-5336-893c-f9ad2f4473dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beafec9-24db-4903-97c1-c5fe740ada83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beafec9-24db-4903-97c1-c5fe740ada83.jpg?1",
             "name": "Captain Vargus Wrath",
             "text": "Whenever Captain Vargus Wrath attacks, Pirates you control get +1/+1 until end of turn for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -9608,7 +9608,7 @@
         },
         {
             "id": "82e67a3d-7767-59df-b2d2-1dcdb22b94ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa3b31a-b52a-43c0-9084-e0535e1bd871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa3b31a-b52a-43c0-9084-e0535e1bd871.jpg?1",
             "name": "Colfenor, the Last Yew",
             "text": "Vigilance, reach\nWhenever Colfenor, the Last Yew or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.",
             "colours": [
@@ -9651,7 +9651,7 @@
         },
         {
             "id": "044a4d3a-f1bc-5be9-9425-729a251286b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b335496-05d2-40f5-a52c-10029f7fa008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b335496-05d2-40f5-a52c-10029f7fa008.jpg?1",
             "name": "Ghen, Arcanum Weaver",
             "text": "{R}{W}{B}, {T}, Sacrifice an enchantment: Return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -9694,7 +9694,7 @@
         },
         {
             "id": "899bbb9b-a96a-5e0e-83f6-4f1e10f9298e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c171f179-9ccf-4819-915c-7f2cd3a91ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c171f179-9ccf-4819-915c-7f2cd3a91ad8.jpg?1",
             "name": "Gnostro, Voice of the Crags",
             "text": "{T}: Choose one. X is the number of spells you've cast this turn.\n\u2022 Scry X.\n\u2022 Gnostro, Voice of the Crags deals X damage to target creature.\n\u2022 You gain X life.",
             "colours": [
@@ -9736,7 +9736,7 @@
         },
         {
             "id": "27963f4c-79ea-5ffc-b78f-9c2750b6fddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b006f9-a287-4e64-915f-ca71712b8d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b006f9-a287-4e64-915f-ca71712b8d27.jpg?1",
             "name": "Gor Muldrak, Amphinologist",
             "text": "You and permanents you control have protection from Salamanders.\nAt the beginning of your end step, each player who controls the fewest creatures creates a 4/3 blue Salamander Warrior creature token.",
             "colours": [
@@ -9777,7 +9777,7 @@
         },
         {
             "id": "0b00d61f-7dab-50ae-87f1-61f49a66c0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c793d594-c319-4e97-8620-de8eddaf247d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c793d594-c319-4e97-8620-de8eddaf247d.jpg?1",
             "name": "Hamza, Guardian of Arashin",
             "text": "This spell costs {1} less to cast for each creature you control with a +1/+1 counter on it.\nCreature spells you cast cost {1} less to cast for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -9818,7 +9818,7 @@
         },
         {
             "id": "5aa3b5e8-0c4d-50fd-b42b-359987aceabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0babe-8da4-4c95-9cdf-626a5c5e2e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0babe-8da4-4c95-9cdf-626a5c5e2e5c.jpg?1",
             "name": "Hans Eriksson",
             "text": "Whenever Hans Eriksson attacks, reveal the top card of your library. If it's a creature card, put it onto the battlefield tapped and attacking defending player or a planeswalker they control. Otherwise, put that card into your hand. When you put a creature card onto the battlefield this way, it fights Hans Eriksson.",
             "colours": [
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "dea1a751-fed6-5028-8080-fcf4f4fa941b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afceb13-877a-4256-9ba6-851b6924ffd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afceb13-877a-4256-9ba6-851b6924ffd9.jpg?1",
             "name": "Imoti, Celebrant of Bounty",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nSpells you cast with converted mana cost 6 or greater have cascade.",
             "colours": [
@@ -9900,7 +9900,7 @@
         },
         {
             "id": "90ce43e8-9fb5-5ae7-90d0-410589863c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bd293b-07b9-4d7c-826a-948d5b01ab5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bd293b-07b9-4d7c-826a-948d5b01ab5e.jpg?1",
             "name": "Jared Carthalion, True Heir",
             "text": "When Jared Carthalion, True Heir enters the battlefield, target opponent becomes the monarch. You can't become the monarch this turn.\nIf damage would be dealt to Jared Carthalion while you're the monarch, prevent that damage and put that many +1/+1 counters on it.",
             "colours": [
@@ -9943,7 +9943,7 @@
         },
         {
             "id": "cefab359-da22-5336-9825-4d29307f191c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec6b2b7-625a-451d-bc0b-4456f5bf2719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec6b2b7-625a-451d-bc0b-4456f5bf2719.jpg?1",
             "name": "Juri, Master of the Revue",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Juri, Master of the Revue.\nWhen Juri dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "30a83050-6532-5c15-a64f-10d4c87ef12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99988f41-99b4-4423-be5f-9dc4ec7d813b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99988f41-99b4-4423-be5f-9dc4ec7d813b.jpg?1",
             "name": "Kangee, Sky Warden",
             "text": "Flying, vigilance\nWhenever Kangee, Sky Warden attacks, attacking creatures with flying get +2/+0 until end of turn.\nWhenever Kangee blocks, blocking creatures with flying get +0/+2 until end of turn.",
             "colours": [
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "73a0eba2-d474-56e7-bcdd-6bbec7216379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f571fef1-1fd2-4355-b803-5edccb6f4b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f571fef1-1fd2-4355-b803-5edccb6f4b94.jpg?1",
             "name": "Kwain, Itinerant Meddler",
             "text": "{T}: Each player may draw a card, then each player who drew a card this way gains 1 life.",
             "colours": [
@@ -10066,7 +10066,7 @@
         },
         {
             "id": "8003cd1e-c697-556a-b093-e95035447b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d3484f-abd1-43fe-99f8-e0fa0a7b6692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d3484f-abd1-43fe-99f8-e0fa0a7b6692.jpg?1",
             "name": "Lathiel, the Bounteous Dawn",
             "text": "Lifelink\nAt the beginning of each end step, if you gained life this turn, distribute up to that many +1/+1 counters among any number of other target creatures.",
             "colours": [
@@ -10106,7 +10106,7 @@
         },
         {
             "id": "c3d19769-e390-5ce3-aa5b-18a978fd310b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32453a1-1fd9-4bda-aaa8-7c287e4c2587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32453a1-1fd9-4bda-aaa8-7c287e4c2587.jpg?1",
             "name": "Liesa, Shroud of Dusk",
             "text": "Rather than pay {2} for each previous time you've cast this spell from the command zone this game, pay 2 life that many times.\nFlying, lifelink\nWhenever a player casts a spell, they lose 2 life.",
             "colours": [
@@ -10146,7 +10146,7 @@
         },
         {
             "id": "c380b206-8845-5af8-9c9d-2bc89df9089b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255848-3112-4508-a66a-d3101a53057e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255848-3112-4508-a66a-d3101a53057e.jpg?1",
             "name": "Nevinyrral, Urborg Tyrant",
             "text": "Hexproof from artifacts, creatures, and enchantments\nWhen Nevinyrral, Urborg Tyrant enters the battlefield, create a tapped 2/2 black Zombie creature token for each creature that died this turn.\nWhen Nevinyrral dies, you may pay {1}. When you do, destroy all artifacts, creatures, and enchantments.",
             "colours": [
@@ -10189,7 +10189,7 @@
         },
         {
             "id": "08fcc5d2-bbcf-56a9-946f-9417f92d44e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cfc97a-3c8a-4d44-846b-7a523dc11878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cfc97a-3c8a-4d44-846b-7a523dc11878.jpg?1",
             "name": "Nymris, Oona's Trickster",
             "text": "Flash\nFlying\nWhenever you cast your first spell during each opponent's turn, look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
             "colours": [
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "518599e3-c707-5600-973d-da0ad158efeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdb335d-3e45-4dd5-9e3e-c50ca0a4dfb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdb335d-3e45-4dd5-9e3e-c50ca0a4dfb6.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "{T}: The player whose turn it is may end the turn. (Exile all spells and abilities from the stack. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -10273,7 +10273,7 @@
         },
         {
             "id": "5d5612f7-e556-550a-9de9-8ed745b35f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90307dd6-196d-4d51-9b3f-6ff339882d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90307dd6-196d-4d51-9b3f-6ff339882d31.jpg?1",
             "name": "Reyav, Master Smith",
             "text": "Whenever a creature you control that's enchanted or equipped attacks, that creature gains double strike until end of turn.",
             "colours": [
@@ -10314,7 +10314,7 @@
         },
         {
             "id": "fd1322ce-57b8-511e-9b39-64ff84ebda86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d6363-ebe1-4a1a-b4e6-7bd53d878527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d6363-ebe1-4a1a-b4e6-7bd53d878527.jpg?1",
             "name": "Thalisse, Reverent Medium",
             "text": "At the beginning of each end step, create X 1/1 white Spirit creature tokens with flying, where X is the number of tokens you created this turn.",
             "colours": [
@@ -10355,7 +10355,7 @@
         },
         {
             "id": "d2db6a5d-bf0a-5683-81a7-10a34da2bfe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf6b42f-8eb7-4b40-a4e6-8775ee208f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf6b42f-8eb7-4b40-a4e6-8775ee208f7e.jpg?1",
             "name": "Tuya Bearclaw",
             "text": "Whenever Tuya Bearclaw attacks, it gets +X/+X until end of turn, where X is the greatest power among other creatures you control.",
             "colours": [
@@ -10396,7 +10396,7 @@
         },
         {
             "id": "0fba90e8-f8a6-534b-8d0c-096f5ff4d116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8a1f5-6260-47fa-a649-43711ec5bbeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8a1f5-6260-47fa-a649-43711ec5bbeb.jpg?1",
             "name": "Yurlok of Scorch Thrash",
             "text": "Vigilance\nA player losing unspent mana causes that player to lose that much life.\n{1}, {T}: Each player adds {B}{R}{G}.",
             "colours": [
@@ -10439,7 +10439,7 @@
         },
         {
             "id": "602a6f5f-f8f6-5ae9-804b-7ef20433169e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b1455e-b9c2-4501-a24f-b50534466c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b1455e-b9c2-4501-a24f-b50534466c31.jpg?1",
             "name": "Zara, Renegade Recruiter",
             "text": "Flying\nWhenever Zara, Renegade Recruiter attacks, look at defending player's hand. You may put a creature card from it onto the battlefield under your control tapped and attacking that player or a planeswalker they control. Return that creature to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -10480,7 +10480,7 @@
         },
         {
             "id": "f9bb6a1c-9ef8-5e4d-be64-42292affdba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de53345-5809-4704-bd60-682b0c3c3999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de53345-5809-4704-bd60-682b0c3c3999.jpg?1",
             "name": "Amorphous Axe",
             "text": "Equipped creature gets +3/+0 and is every creature type.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10510,7 +10510,7 @@
         },
         {
             "id": "41fe3375-7a5f-5577-8d74-20b70bf358cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92824de1-23f2-44c6-b8ab-46db94b8f79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92824de1-23f2-44c6-b8ab-46db94b8f79e.jpg?1",
             "name": "Angelic Armaments",
             "text": "Equipped creature gets +2/+2, has flying, and is a white Angel in addition to its other colors and types.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10540,7 +10540,7 @@
         },
         {
             "id": "811f0a64-cff0-5a50-817d-b9f26b22b409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40458c-7f3a-4fa6-976f-be1f7a336fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40458c-7f3a-4fa6-976f-be1f7a336fdc.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -10570,7 +10570,7 @@
         },
         {
             "id": "506cecee-cca4-5a17-8f7e-53266ee7016a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ae93e-6094-483d-b2c0-ae117ad01293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ae93e-6094-483d-b2c0-ae117ad01293.jpg?1",
             "name": "Armillary Sphere",
             "text": "{2}, {T}, Sacrifice Armillary Sphere: Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library.",
             "colours": [],
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "2a10aa59-98a1-5f53-bb5e-37559cbf1f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703a03ac-5bb5-4e36-ab9b-a5c007ffc03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703a03ac-5bb5-4e36-ab9b-a5c007ffc03d.jpg?1",
             "name": "Armory of Iroas",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "b3f6eea3-30c4-574b-9a21-b2334e3400c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c9b4fb-cfb6-4e5a-b23a-9aad9f69710e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c9b4fb-cfb6-4e5a-b23a-9aad9f69710e.jpg?1",
             "name": "Bladegriff Prototype",
             "text": "Flying\nWhenever Bladegriff Prototype deals combat damage to a player, destroy target nonland permanent of that player's choice that one of your opponents controls.",
             "colours": [],
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "650064ff-f6c6-5209-aed8-b2253ae15fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0380a4-225f-4a80-8c8b-d0f7e54f1626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0380a4-225f-4a80-8c8b-d0f7e54f1626.jpg?1",
             "name": "Brass Herald",
             "text": "As Brass Herald enters the battlefield, choose a creature type.\nWhen Brass Herald enters the battlefield, reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order.\nCreatures of the chosen type get +1/+1.",
             "colours": [],
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "322ac615-27a4-5378-b38a-b4c958ca1f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccb765-8f97-4806-87ef-55415ab09d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccb765-8f97-4806-87ef-55415ab09d9b.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "228dd3fc-8049-5f9a-beb1-671c8b93be32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99f4cd-7f6d-4f1a-a1d9-f8c3b6645038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99f4cd-7f6d-4f1a-a1d9-f8c3b6645038.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -10755,7 +10755,7 @@
         },
         {
             "id": "07390793-a3da-5efc-9fcc-a74ea8ada2fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5a3293-f3e7-4f68-af6a-b478959226c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5a3293-f3e7-4f68-af6a-b478959226c1.jpg?1",
             "name": "Codex Shredder",
             "text": "{T}: Target player mills a card. (They put the top card of their library into their graveyard.)\n{5}, {T}, Sacrifice Codex Shredder: Return target card from your graveyard to your hand.",
             "colours": [],
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "d46eaf32-3cb7-5892-ab91-bf1d8c8e9337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19992dbd-7a6a-43d3-b1db-01716b2eed27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19992dbd-7a6a-43d3-b1db-01716b2eed27.jpg?1",
             "name": "Commander's Plate",
             "text": "Equipped creature gets +3/+3 and has protection from each color that's not in your commander's color identity.\nEquip commander {3}\nEquip {5}",
             "colours": [],
@@ -10815,7 +10815,7 @@
         },
         {
             "id": "8236412e-3921-5f02-b5e6-04af3d78c402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c16a5-bc50-406f-9ab1-e8346acffbca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c16a5-bc50-406f-9ab1-e8346acffbca.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -10845,7 +10845,7 @@
         },
         {
             "id": "05a374b3-06d3-53cb-bcd7-bcec2d670546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a0b45f-d044-4d59-81fd-c2683beca401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a0b45f-d044-4d59-81fd-c2683beca401.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {C}{C}{C}.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "b845b1d7-5205-5424-9642-549635b88b39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875df3ef-fab4-455f-bfdb-8f6361b27bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875df3ef-fab4-455f-bfdb-8f6361b27bf6.jpg?1",
             "name": "Filigree Familiar",
             "text": "When Filigree Familiar enters the battlefield, you gain 2 life.\nWhen Filigree Familiar dies, draw a card.",
             "colours": [],
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "a87daf0e-14b7-5446-889d-157b129cfbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65f1fa-4196-40ba-8ca3-e68560fef392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65f1fa-4196-40ba-8ca3-e68560fef392.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -10934,7 +10934,7 @@
         },
         {
             "id": "dfc82532-0638-5003-ac71-b8d65a7dcdb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca62547-7dd3-4bb7-be5f-92c4fa51904d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca62547-7dd3-4bb7-be5f-92c4fa51904d.jpg?1",
             "name": "Foundry Inspector",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [],
@@ -10965,7 +10965,7 @@
         },
         {
             "id": "02a4bb24-63d8-5396-aefe-41810824f63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a3345-2507-46ed-bdb3-c5c45d17da51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a3345-2507-46ed-bdb3-c5c45d17da51.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -10996,7 +10996,7 @@
         },
         {
             "id": "b177ef11-5e07-51b5-8b10-d364dbc9ee74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d023d44-482e-4f60-b9b1-eede9bfb732f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d023d44-482e-4f60-b9b1-eede9bfb732f.jpg?1",
             "name": "Grafted Wargear",
             "text": "Equipped creature gets +3/+2.\nWhenever Grafted Wargear becomes unattached from a permanent, sacrifice that permanent.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11026,7 +11026,7 @@
         },
         {
             "id": "f8092d75-5b2c-5e4f-888a-f3c133706334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9a637-352a-45bd-a43a-6406f9da56af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9a637-352a-45bd-a43a-6406f9da56af.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "eb02e267-3318-5cb8-bdf2-f518ff2dfcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e982c4-19ef-40d6-a807-fd16c31e63db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e982c4-19ef-40d6-a807-fd16c31e63db.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11090,7 +11090,7 @@
         },
         {
             "id": "986d7e12-0a99-5049-b12e-fa1208b85ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6affd9c6-f7ab-488e-85fa-2a3a48383414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6affd9c6-f7ab-488e-85fa-2a3a48383414.jpg?1",
             "name": "Horizon Stone",
             "text": "If you would lose unspent mana, that mana becomes colorless instead.",
             "colours": [],
@@ -11120,7 +11120,7 @@
         },
         {
             "id": "93ec73ac-b93a-5d07-8c1b-64458ea1bdd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b54aaa-93e2-4f8b-8d06-2a848498d1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b54aaa-93e2-4f8b-8d06-2a848498d1fd.jpg?1",
             "name": "Howling Golem",
             "text": "Whenever Howling Golem attacks or blocks, each player draws a card.",
             "colours": [],
@@ -11151,7 +11151,7 @@
         },
         {
             "id": "62f9a316-960e-5163-97ff-3ea4936feb07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255db4-9c46-4971-bf89-f9014602999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255db4-9c46-4971-bf89-f9014602999c.jpg?1",
             "name": "Ingenuity Engine",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\n{1}, {T}, Sacrifice an artifact: Return target artifact you control to its owner's hand.",
             "colours": [],
@@ -11179,7 +11179,7 @@
         },
         {
             "id": "bd5fdd3b-f2c5-530f-a6c0-dc527369e384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24814552-c407-447a-a782-22c69c5b912b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24814552-c407-447a-a782-22c69c5b912b.jpg?1",
             "name": "Jalum Tome",
             "text": "{2}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -11207,7 +11207,7 @@
         },
         {
             "id": "10008e9d-123f-5892-898d-31393dd8762f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7de64b-3dc8-47dd-8999-4353b5a3a06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7de64b-3dc8-47dd-8999-4353b5a3a06f.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -11237,7 +11237,7 @@
         },
         {
             "id": "d6d1c9d0-d3b1-5aed-bbdf-0acd89395d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e95365a8-514a-4212-9d65-b0cdf2cd06e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e95365a8-514a-4212-9d65-b0cdf2cd06e5.jpg?1",
             "name": "Loreseeker's Stone",
             "text": "{3}, {T}: Draw three cards. This ability costs {1} more to activate for each card in your hand.",
             "colours": [],
@@ -11265,7 +11265,7 @@
         },
         {
             "id": "ae26004a-a9be-5f2e-a23e-b4472401e82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c200239c-d28e-4c55-a7bc-64a1d138cc2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c200239c-d28e-4c55-a7bc-64a1d138cc2f.jpg?1",
             "name": "Lumengrid Gargoyle",
             "text": "Flying",
             "colours": [],
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "a681056b-3fcb-545b-bc65-10a4b7ec63b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322491d2-d082-4d38-8d81-8588c011e725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322491d2-d082-4d38-8d81-8588c011e725.jpg?1",
             "name": "Maelstrom Colossus",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [],
@@ -11327,7 +11327,7 @@
         },
         {
             "id": "1ffe42ea-3d56-5b5e-9173-db0ed39736f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72125260-f4b7-4317-99f1-cbb78646296d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72125260-f4b7-4317-99f1-cbb78646296d.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -11357,7 +11357,7 @@
         },
         {
             "id": "7c6c03b9-3ba9-5b06-abef-e917bef1ae62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba275c02-8581-46a0-9c7c-8baa0fdb4982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba275c02-8581-46a0-9c7c-8baa0fdb4982.jpg?1",
             "name": "Mask of Memory",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw two cards. If you do, discard a card.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "23643e6e-5a26-50c4-b09f-743c73e9f584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b5324-bd25-4651-bcbc-5439b74df361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b5324-bd25-4651-bcbc-5439b74df361.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -11420,7 +11420,7 @@
         },
         {
             "id": "f1d1aaef-7339-5bde-b728-135b7ea4c7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a167f09d-b2dd-4365-8217-e7138d96304a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a167f09d-b2dd-4365-8217-e7138d96304a.jpg?1",
             "name": "Mindless Automaton",
             "text": "Mindless Automaton enters the battlefield with two +1/+1 counters on it.\n{1}, Discard a card: Put a +1/+1 counter on Mindless Automaton.\nRemove two +1/+1 counters from Mindless Automaton: Draw a card.",
             "colours": [],
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "b5a7a6ec-7dd2-53b3-a55f-876e9c688b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8ea247-5529-4948-8c81-0f413aedc82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8ea247-5529-4948-8c81-0f413aedc82e.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -11481,7 +11481,7 @@
         },
         {
             "id": "bb446cac-0880-5607-b928-af497264b1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7c8a-ed88-4f4f-9e1c-d97bde20e40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7c8a-ed88-4f4f-9e1c-d97bde20e40c.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -11511,7 +11511,7 @@
         },
         {
             "id": "6f6a14f6-298c-55f0-b416-758f171a9651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc89a7c-cdb9-45cd-a9e7-d66dd2066d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc89a7c-cdb9-45cd-a9e7-d66dd2066d1d.jpg?1",
             "name": "Pennon Blade",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "47b367b0-ffea-514a-8ccc-7474cb2c23df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a15c8ef-04ad-4aab-a7f1-c7a90c10eb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a15c8ef-04ad-4aab-a7f1-c7a90c10eb50.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr dies, it deals 2 damage to any target.",
             "colours": [],
@@ -11573,7 +11573,7 @@
         },
         {
             "id": "8205c799-9253-5d4c-8d19-483aa6323015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a6582-2281-4f75-8103-80fcb2846805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a6582-2281-4f75-8103-80fcb2846805.jpg?1",
             "name": "Phyrexian Triniform",
             "text": "When Phyrexian Triniform dies, create three 3/3 colorless Golem artifact creature tokens.\nEncore {1}2 ({1}2, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [],
@@ -11607,7 +11607,7 @@
         },
         {
             "id": "efbcff07-a0d4-5b6e-8f86-7bd317096f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f48d5f-7e01-424d-8e86-1d4a32f0ef34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f48d5f-7e01-424d-8e86-1d4a32f0ef34.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -11638,7 +11638,7 @@
         },
         {
             "id": "89f20dea-a7d4-54d7-80bd-7a98b03d7eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dc0635-0cc4-419e-ab64-c07a69f34f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dc0635-0cc4-419e-ab64-c07a69f34f75.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When Pirate's Cutlass enters the battlefield, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11668,7 +11668,7 @@
         },
         {
             "id": "e64b8c38-e501-53e7-b827-f636e3e4bb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14602fed-8666-4884-8fca-13529578f9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14602fed-8666-4884-8fca-13529578f9e2.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -11696,7 +11696,7 @@
         },
         {
             "id": "adc51a59-4f28-597f-8b6f-cde3abc3be31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838ffc87-517a-4d94-8ce0-bc9ed01ecc52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838ffc87-517a-4d94-8ce0-bc9ed01ecc52.jpg?1",
             "name": "Rings of Brighthearth",
             "text": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [],
@@ -11726,7 +11726,7 @@
         },
         {
             "id": "cc14b4b1-3ee2-5a66-839a-97f69946a307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b7213-f0db-4ef9-aab7-37028f9479af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b7213-f0db-4ef9-aab7-37028f9479af.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "23945b88-8eac-5d21-9437-7a927abfbbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaaa58d-89bb-4cb3-96a6-b480e6f6954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaaa58d-89bb-4cb3-96a6-b480e6f6954e.jpg?1",
             "name": "Scroll Rack",
             "text": "{1}, {T}: Exile any number of cards from your hand face down. Put that many cards from the top of your library into your hand. Then look at the exiled cards and put them on top of your library in any order.",
             "colours": [],
@@ -11787,7 +11787,7 @@
         },
         {
             "id": "d2bab3b4-c3c6-597a-9bf6-9446f1aca0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09bcfd12-6b50-4fdf-9bda-6d52bba2f897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09bcfd12-6b50-4fdf-9bda-6d52bba2f897.jpg?1",
             "name": "Seer's Lantern",
             "text": "{T}: Add {C}.\n{2}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -11815,7 +11815,7 @@
         },
         {
             "id": "aaad3862-c813-5fbc-bd42-252b68289e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7647cc5e-67c4-44e6-8674-f980de482a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7647cc5e-67c4-44e6-8674-f980de482a37.jpg?1",
             "name": "Shimmer Myr",
             "text": "Flash\nYou may cast artifact spells as though they had flash.",
             "colours": [],
@@ -11846,7 +11846,7 @@
         },
         {
             "id": "bf899cdf-63a5-55d9-a2d4-9ea40473e9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c0e608-0208-408a-b473-1e54caa96cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c0e608-0208-408a-b473-1e54caa96cea.jpg?1",
             "name": "Sisay's Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -11874,7 +11874,7 @@
         },
         {
             "id": "3f623eaa-3345-54df-b6eb-dfa720e2e4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc62a1e-830b-4b07-91e4-303e66d93648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc62a1e-830b-4b07-91e4-303e66d93648.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -11904,7 +11904,7 @@
         },
         {
             "id": "8d3061b0-d32b-5f08-b5dd-5e050e03b370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dd6c9-628b-4dde-a385-604501dd0979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dd6c9-628b-4dde-a385-604501dd0979.jpg?1",
             "name": "Spectral Searchlight",
             "text": "{T}: Choose a player. That player adds one mana of any color they choose.",
             "colours": [],
@@ -11932,7 +11932,7 @@
         },
         {
             "id": "44832978-c6af-5ca4-9ef6-15a204d31089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde838c8-2f32-4e7d-a236-0bc42dd7abd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde838c8-2f32-4e7d-a236-0bc42dd7abd9.jpg?1",
             "name": "Staff of Domination",
             "text": "{1}: Untap Staff of Domination.\n{2}, {T}: You gain 1 life.\n{3}, {T}: Untap target creature.\n{4}, {T}: Tap target creature.\n{5}, {T}: Draw a card.",
             "colours": [],
@@ -11962,7 +11962,7 @@
         },
         {
             "id": "0cb7e675-9419-53fa-9208-4bc311dce5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41017b24-957b-403d-b417-d84ad2624794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41017b24-957b-403d-b417-d84ad2624794.jpg?1",
             "name": "Staunch Throneguard",
             "text": "Vigilance\nWhen Staunch Throneguard enters the battlefield, you become the monarch.",
             "colours": [],
@@ -11993,7 +11993,7 @@
         },
         {
             "id": "3bfe1300-4f02-5fd5-83c3-42257c2e54b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d346c67-744c-4605-be62-18d794e83049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d346c67-744c-4605-be62-18d794e83049.jpg?1",
             "name": "Sunset Pyramid",
             "text": "Sunset Pyramid enters the battlefield with three brick counters on it.\n{2}, {T}, Remove a brick counter from Sunset Pyramid: Draw a card.\n{2}, {T}: Scry 1.",
             "colours": [],
@@ -12021,7 +12021,7 @@
         },
         {
             "id": "47272c45-37bb-52ed-a8a6-2e570670a6b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58ab310-cbee-4f0c-9819-a2e2121932ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58ab310-cbee-4f0c-9819-a2e2121932ff.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -12051,7 +12051,7 @@
         },
         {
             "id": "4ddd4686-06b0-5eac-9138-e83885d0f075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe257c5-d2f8-4a4f-bf74-f6dc4b6861e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe257c5-d2f8-4a4f-bf74-f6dc4b6861e4.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -12079,7 +12079,7 @@
         },
         {
             "id": "aaba24c3-78f5-5e6a-aa61-737df54716de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9387e8f-0e72-4212-81c8-e64050700c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9387e8f-0e72-4212-81c8-e64050700c52.jpg?1",
             "name": "Workshop Assistant",
             "text": "When Workshop Assistant dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -12110,7 +12110,7 @@
         },
         {
             "id": "da0dcbf5-7187-550a-bce0-8608e701133b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bec6181-e214-4833-8c2f-8a10d59b2879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bec6181-e214-4833-8c2f-8a10d59b2879.jpg?1",
             "name": "Command Beacon",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Command Beacon: Put your commander into your hand from the command zone.",
             "colours": [],
@@ -12140,7 +12140,7 @@
         },
         {
             "id": "d6d8df83-6867-5a62-b9ce-ea4a147b89e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86424491-a372-40c4-bfb5-faa2b2d41d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86424491-a372-40c4-bfb5-faa2b2d41d4c.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -12171,7 +12171,7 @@
         },
         {
             "id": "26b6712d-7345-5472-b8e0-6c15088f79d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c8d290-b5d2-412c-8db9-5a6246f430e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c8d290-b5d2-412c-8db9-5a6246f430e8.jpg?1",
             "name": "Guildless Commons",
             "text": "Guildless Commons enters the battlefield tapped.\nWhen Guildless Commons enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "b81dff1b-08f9-5e26-8438-eb8f53a38034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d68a79-00b5-453f-9fdc-92d9dbfb90b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d68a79-00b5-453f-9fdc-92d9dbfb90b2.jpg?1",
             "name": "Opal Palace",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
             "colours": [],
@@ -12229,7 +12229,7 @@
         },
         {
             "id": "3170b46a-6136-5829-89bf-9ba80ef1d5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1852c1e1-fbea-4b14-9927-4b1849f9b8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1852c1e1-fbea-4b14-9927-4b1849f9b8a3.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -12259,7 +12259,7 @@
         },
         {
             "id": "7ab9b79e-6510-5d02-95ce-97167a40c539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e69910-0d90-48a0-af29-3cddaeec5151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e69910-0d90-48a0-af29-3cddaeec5151.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "9da2c892-df79-5164-8ec9-c782fa51a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef4b15-efab-4255-ac2d-7794f253aa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef4b15-efab-4255-ac2d-7794f253aa52.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -12322,7 +12322,7 @@
         },
         {
             "id": "5e2abcdd-aa15-54e0-b70e-c9e656f80835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6f1453-fe93-4a29-965c-5f867a81e8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6f1453-fe93-4a29-965c-5f867a81e8b3.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -12355,7 +12355,7 @@
         },
         {
             "id": "06e49e8e-e561-5fb3-8f55-b9bcb7762fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8b3d63-db84-4aa0-a529-f3c128fae964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8b3d63-db84-4aa0-a529-f3c128fae964.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -12386,7 +12386,7 @@
         },
         {
             "id": "d6824f27-3f75-5012-8d4d-295e3f1cf0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15c58c0-4d42-488e-bb9d-7a550d9ea5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15c58c0-4d42-488e-bb9d-7a550d9ea5e6.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -12419,7 +12419,7 @@
         },
         {
             "id": "f8aa961e-8cf6-5446-b900-a576455f4290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df64c9cf-17de-44f3-831d-ba09661f2308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df64c9cf-17de-44f3-831d-ba09661f2308.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -12452,7 +12452,7 @@
         },
         {
             "id": "8ee91575-6005-5571-940f-8bb02226ade8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e144ae1-500d-4485-b476-5783b14380d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e144ae1-500d-4485-b476-5783b14380d9.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -12485,7 +12485,7 @@
         },
         {
             "id": "655bd629-d140-5cfc-925c-a39f2487a197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d6ce7c-5dc8-449b-acbd-db259ae687ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d6ce7c-5dc8-449b-acbd-db259ae687ed.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -12515,7 +12515,7 @@
         },
         {
             "id": "e09f4e6f-a618-5a8d-814e-8391cdec5566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5ada8c-98f2-4f9c-bcb5-dfa4f804fbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5ada8c-98f2-4f9c-bcb5-dfa4f804fbe6.jpg?1",
             "name": "Wyleth, Soul of Steel",
             "text": "Trample\nWhenever Wyleth, Soul of Steel attacks, draw a card for each Aura and Equipment attached to it.",
             "colours": [
@@ -12553,7 +12553,7 @@
         },
         {
             "id": "9dd97b88-1a61-571b-ae64-9f244c95d51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de08a92-9b60-4672-9f3b-3ceb53ca82ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de08a92-9b60-4672-9f3b-3ceb53ca82ca.jpg?1",
             "name": "Timely Ward",
             "text": "You may cast this spell as though it had flash if it targets a commander.\nEnchant creature\nEnchanted creature has indestructible.",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "b7a0fdce-ec99-517f-8950-16a8f98a1d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d276fe-5f2b-41aa-80fa-64d3b60fd54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d276fe-5f2b-41aa-80fa-64d3b60fd54f.jpg?1",
             "name": "Blazing Sunsteel",
             "text": "Equipped creature gets +1/+0 for each opponent you have.\nWhenever equipped creature is dealt damage, it deals that much damage to any target.\nEquip {4}",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "e183c2a8-549b-59d5-9063-f14bb619ca65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d607b003-6b48-429c-a7fd-45b8dd1bb4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d607b003-6b48-429c-a7fd-45b8dd1bb4f9.jpg?1",
             "name": "Aesi, Tyrant of Gyre Strait",
             "text": "You may play an additional land on each of your turns.\nWhenever a land enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "cb556a9c-201f-530c-a2c7-b76e27961a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909dc123-8234-4e81-bb7b-77404d94a87c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909dc123-8234-4e81-bb7b-77404d94a87c.jpg?1",
             "name": "Trench Behemoth",
             "text": "Return a land you control to its owner's hand: Untap Trench Behemoth. It gains hexproof until end of turn.\nWhenever a land enters the battlefield under your control, target creature an opponent controls attacks during its controller's next combat phase if able.",
             "colours": [
@@ -12689,7 +12689,7 @@
         },
         {
             "id": "cbfc34e7-8a55-564e-86b4-1de50f6417db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe8096b-332a-4832-b957-7a35bb350e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe8096b-332a-4832-b957-7a35bb350e4e.jpg?1",
             "name": "Stumpsquall Hydra",
             "text": "When Stumpsquall Hydra enters the battlefield, distribute X +1/+1 counters among it and any number of commanders.",
             "colours": [
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "9cf27b96-3144-50a5-a2f3-0d689e8816fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cffed4c-4e2b-414a-9b20-90ce21b47d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cffed4c-4e2b-414a-9b20-90ce21b47d16.jpg?1",
             "name": "Elder Deep-Fiend",
             "text": "Flash\nEmerge {5}{U}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast this spell, tap up to four target permanents.",
             "colours": [],
@@ -12754,7 +12754,7 @@
         },
         {
             "id": "d3d0b30f-de8c-5864-badf-ae741ea32b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dab28f-d0d0-49ef-9326-34fb348a7853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dab28f-d0d0-49ef-9326-34fb348a7853.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -12785,7 +12785,7 @@
         },
         {
             "id": "4f9a31e4-172c-515f-b7ce-149029521873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5391bc-6b50-49b0-96a1-df944a55d62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5391bc-6b50-49b0-96a1-df944a55d62e.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "c051fd0a-145f-5cd4-85dc-b1da6904cd4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc47e26a-2ba6-4b7a-bb03-43f7ecb9012e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc47e26a-2ba6-4b7a-bb03-43f7ecb9012e.jpg?1",
             "name": "Dawn Charm",
             "text": "Choose one \u2014\n\u2022 Prevent all combat damage that would be dealt this turn.\n\u2022 Regenerate target creature. (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)\n\u2022 Counter target spell that targets you.",
             "colours": [
@@ -12852,7 +12852,7 @@
         },
         {
             "id": "da5f979f-17da-5711-ad9c-c16e281b5536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba38105-bada-449a-ab2f-3d6db2764a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba38105-bada-449a-ab2f-3d6db2764a06.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -12883,7 +12883,7 @@
         },
         {
             "id": "649121d0-95d8-5c2f-9e4a-f066d528d6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eaee28-b7c6-4d5f-b181-61e0c68988aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eaee28-b7c6-4d5f-b181-61e0c68988aa.jpg?1",
             "name": "Faith Unbroken",
             "text": "Enchant creature you control\nWhen Faith Unbroken enters the battlefield, exile target creature an opponent controls until Faith Unbroken leaves the battlefield.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -12916,7 +12916,7 @@
         },
         {
             "id": "be9daf30-1883-5434-88c7-8e139f0511cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6501e4e-8188-44ed-b661-55fe32bc7fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6501e4e-8188-44ed-b661-55fe32bc7fec.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -12949,7 +12949,7 @@
         },
         {
             "id": "039b4036-830a-5d41-ac0e-8291aa771712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26296a96-bdca-405f-ab06-e280b42c4ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26296a96-bdca-405f-ab06-e280b42c4ab9.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -12982,7 +12982,7 @@
         },
         {
             "id": "0061f6d5-7e4d-5314-83db-dd9c2914ef24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2841f538-9686-423f-ac30-0580665112e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2841f538-9686-423f-ac30-0580665112e5.jpg?1",
             "name": "Ironclad Slayer",
             "text": "When Ironclad Slayer enters the battlefield, you may return target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -13016,7 +13016,7 @@
         },
         {
             "id": "a8fc49e5-c3f4-5b67-b254-bc2935e09391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e2670-90ff-4b26-a5d6-b74f465b6c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e2670-90ff-4b26-a5d6-b74f465b6c9c.jpg?1",
             "name": "Kor Cartographer",
             "text": "When Kor Cartographer enters the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -13052,7 +13052,7 @@
         },
         {
             "id": "d91c98d0-0d94-58c0-b2a1-c1050d74fc39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f30b99-5177-48e9-be0a-ab04bbc4586b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f30b99-5177-48e9-be0a-ab04bbc4586b.jpg?1",
             "name": "Martial Coup",
             "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -13083,7 +13083,7 @@
         },
         {
             "id": "72d899dd-028f-50e6-bf1d-a690a4e03648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b429bd-d7da-45f5-988b-7eed0d3efeaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b429bd-d7da-45f5-988b-7eed0d3efeaa.jpg?1",
             "name": "Odric, Lunarch Marshal",
             "text": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
             "colours": [
@@ -13119,7 +13119,7 @@
         },
         {
             "id": "9821aa88-2d69-5585-8897-548a160a9d04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57c65-5010-4472-b877-42daf2f15af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57c65-5010-4472-b877-42daf2f15af2.jpg?1",
             "name": "On Serra's Wings",
             "text": "Enchant creature\nEnchanted creature is legendary, gets +1/+1, and has flying, vigilance, and lifelink.",
             "colours": [
@@ -13154,7 +13154,7 @@
         },
         {
             "id": "1652156f-edf3-5f21-b137-adf2758d1fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cf5b23-dad0-4d4f-bd73-0133dbc9f8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cf5b23-dad0-4d4f-bd73-0133dbc9f8e1.jpg?1",
             "name": "Oreskos Explorer",
             "text": "When Oreskos Explorer enters the battlefield, search your library for up to X Plains cards, where X is the number of players who control more lands than you. Reveal those cards, put them into your hand, then shuffle your library.",
             "colours": [
@@ -13188,7 +13188,7 @@
         },
         {
             "id": "a93967b3-2a61-594a-97b7-65002f01d271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae71b0a7-90c6-48cd-808c-c6c430dcba9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae71b0a7-90c6-48cd-808c-c6c430dcba9c.jpg?1",
             "name": "Relic Seeker",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhen Relic Seeker becomes renowned, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -13222,7 +13222,7 @@
         },
         {
             "id": "5d1ddb47-9191-5527-a695-458bf67ec2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c342d-ae5e-492e-87e2-1149457b80ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c342d-ae5e-492e-87e2-1149457b80ab.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -13256,7 +13256,7 @@
         },
         {
             "id": "2dacceab-8ccd-52cc-a7bb-ec0a90bc79a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531da950-dc96-4050-94a8-e01b73ddd965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531da950-dc96-4050-94a8-e01b73ddd965.jpg?1",
             "name": "Sigarda's Aid",
             "text": "You may cast Aura and Equipment spells as though they had flash.\nWhenever an Equipment enters the battlefield under your control, you may attach it to target creature you control.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "cd91f13c-1354-57c8-9018-07bbb5354e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5fdaa3-7879-4fa3-a157-60c7890a660a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5fdaa3-7879-4fa3-a157-60c7890a660a.jpg?1",
             "name": "Spirit Mantle",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has protection from creatures.",
             "colours": [
@@ -13320,7 +13320,7 @@
         },
         {
             "id": "f9b5b1df-a6cc-5bd0-a53c-925a6263325c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ab1ef1-f4e8-461e-801a-a498e4946fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ab1ef1-f4e8-461e-801a-a498e4946fa1.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
             "colours": [
@@ -13356,7 +13356,7 @@
         },
         {
             "id": "92c30360-e72a-5eb6-8148-44eba77bbe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b4177-e47c-4dde-9ead-31b7602065ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b4177-e47c-4dde-9ead-31b7602065ec.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -13389,7 +13389,7 @@
         },
         {
             "id": "46909e73-9dd9-5f7c-8ac0-083024bc7e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2b5f7d-7105-4af3-aa0b-6f3cfb986ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2b5f7d-7105-4af3-aa0b-6f3cfb986ae0.jpg?1",
             "name": "Unbreakable Formation",
             "text": "Creatures you control gain indestructible until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, put a +1/+1 counter on each of those creatures and they gain vigilance until end of turn.",
             "colours": [
@@ -13420,7 +13420,7 @@
         },
         {
             "id": "af88e2d0-5875-5485-b296-62b21d010f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829710f9-6554-4391-bdb1-2ccdefc2caf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829710f9-6554-4391-bdb1-2ccdefc2caf5.jpg?1",
             "name": "Unquestioned Authority",
             "text": "Enchant creature\nWhen Unquestioned Authority enters the battlefield, draw a card.\nEnchanted creature has protection from creatures.",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "78391deb-ee03-5958-a30d-a61b42fbf653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87066f6-a5c3-4855-bee5-05931f421d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87066f6-a5c3-4855-bee5-05931f421d34.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -13484,7 +13484,7 @@
         },
         {
             "id": "352a2539-555e-5079-b77c-842faa7c7be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029e0450-ceb1-484d-8a18-e769defac428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029e0450-ceb1-484d-8a18-e769defac428.jpg?1",
             "name": "White Sun's Zenith",
             "text": "Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its owner's library.",
             "colours": [
@@ -13515,7 +13515,7 @@
         },
         {
             "id": "69059008-b6c9-5e0c-9de7-38b3cc4ffcc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b91ab9-a03b-4036-9ad4-5c9f7743cd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b91ab9-a03b-4036-9ad4-5c9f7743cd52.jpg?1",
             "name": "Winds of Rath",
             "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
             "colours": [
@@ -13546,7 +13546,7 @@
         },
         {
             "id": "57b292e9-3fc6-54e3-90a4-902a7fb5365b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a531642c-58dd-4f72-ae2b-38e005ae3a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a531642c-58dd-4f72-ae2b-38e005ae3a6b.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -13579,7 +13579,7 @@
         },
         {
             "id": "78731243-149d-5a54-a75d-23c20a91fe89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fcefbc-211f-4ad2-8866-9514f09cd3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fcefbc-211f-4ad2-8866-9514f09cd3b3.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless they discard a land card.",
             "colours": [
@@ -13610,7 +13610,7 @@
         },
         {
             "id": "d4b95cdb-1704-5939-b4e7-c0dca75555a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce30f926-bc06-46ee-9f35-0cdf09a67043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce30f926-bc06-46ee-9f35-0cdf09a67043.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -13643,7 +13643,7 @@
         },
         {
             "id": "f9004630-d64f-56ec-b0f1-3e71af0c50a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b41cb3-ca3d-4389-8f66-e1f77f5fb683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b41cb3-ca3d-4389-8f66-e1f77f5fb683.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -13676,7 +13676,7 @@
         },
         {
             "id": "18aab64b-89f8-580b-8521-e4bcab8843af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3463be0-df9e-4cb9-a90f-5d9d2ee729e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3463be0-df9e-4cb9-a90f-5d9d2ee729e0.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -13707,7 +13707,7 @@
         },
         {
             "id": "7d06b57f-7b21-5748-970d-f44bc39c6514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd466b20-d11d-419e-8765-9befb9590299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd466b20-d11d-419e-8765-9befb9590299.jpg?1",
             "name": "Ior Ruin Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Ior Ruin Expedition.\nRemove three quest counters from Ior Ruin Expedition and sacrifice it: Draw two cards.",
             "colours": [
@@ -13738,7 +13738,7 @@
         },
         {
             "id": "a3104aba-3b79-579f-9c75-565168133044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b9db96-a6ab-454b-99a7-910ef77560d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b9db96-a6ab-454b-99a7-910ef77560d7.jpg?1",
             "name": "Meloku the Clouded Mirror",
             "text": "Flying\n{1}, Return a land you control to its owner's hand: Create a 1/1 blue Illusion creature token with flying.",
             "colours": [
@@ -13774,7 +13774,7 @@
         },
         {
             "id": "957529d5-2595-55b0-afb9-aef820de4df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e06fc13-6a58-40f8-a3e6-5558a7a0d18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e06fc13-6a58-40f8-a3e6-5558a7a0d18f.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -13809,7 +13809,7 @@
         },
         {
             "id": "0da28cae-c6ec-5f43-8015-cdac21058bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a959b40d-dd8c-49d8-8003-744d0c877b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a959b40d-dd8c-49d8-8003-744d0c877b04.jpg?1",
             "name": "Nezahal, Primal Tide",
             "text": "This spell can't be countered.\nYou have no maximum hand size.\nWhenever an opponent casts a noncreature spell, draw a card.\nDiscard three cards: Exile Nezahal, Primal Tide. Return it to the battlefield tapped under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "9116558e-1281-5b70-b658-7d72b40eb65c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aec3bd-b52f-4b23-a86a-429fa78a5a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aec3bd-b52f-4b23-a86a-429fa78a5a6a.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -13876,7 +13876,7 @@
         },
         {
             "id": "0c6c2137-e578-5084-85a6-c603db958389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79471f9-5cc0-48f5-9fa4-1f1374993825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79471f9-5cc0-48f5-9fa4-1f1374993825.jpg?1",
             "name": "Scourge of Fleets",
             "text": "When Scourge of Fleets enters the battlefield, return each creature your opponents control with toughness X or less to its owner's hand, where X is the number of Islands you control.",
             "colours": [
@@ -13909,7 +13909,7 @@
         },
         {
             "id": "bdea1a39-d976-581a-8182-dc59ce916824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e558f0a-f921-4ecf-b1c9-2c93aa2d3fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e558f0a-f921-4ecf-b1c9-2c93aa2d3fd9.jpg?1",
             "name": "Shipbreaker Kraken",
             "text": "{6}{U}{U}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)\nWhen Shipbreaker Kraken becomes monstrous, tap up to four target creatures. Those creatures don't untap during their controllers' untap steps for as long as you control Shipbreaker Kraken.",
             "colours": [
@@ -13942,7 +13942,7 @@
         },
         {
             "id": "00ad5bf1-ebd6-54cc-b5bd-9cbba4eb101d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebf2c16-bd9d-4a8f-a1b6-6e0c393178bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebf2c16-bd9d-4a8f-a1b6-6e0c393178bc.jpg?1",
             "name": "Slinn Voda, the Rising Deep",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nWhen Slinn Voda, the Rising Deep enters the battlefield, if it was kicked, return all creatures to their owners' hands except for Merfolk, Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -13977,7 +13977,7 @@
         },
         {
             "id": "ff27a893-1385-5378-9f83-84a859e6ff06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5cd33-20e2-4063-b422-2bde13021888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5cd33-20e2-4063-b422-2bde13021888.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "5fdcf716-668c-5bd4-8350-254262927731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996bb4c0-dc72-4233-9f44-2e25aef71ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996bb4c0-dc72-4233-9f44-2e25aef71ad7.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -14043,7 +14043,7 @@
         },
         {
             "id": "f82ef462-e5e0-540b-9ef2-5587ead1cce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160686f3-44fd-4f7a-81cf-d3b5b964bfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160686f3-44fd-4f7a-81cf-d3b5b964bfba.jpg?1",
             "name": "Tromokratis",
             "text": "Tromokratis has hexproof unless it's attacking or blocking.\nTromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "236c6bd0-4a38-59f4-b02c-46a2a25da3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb863a0-3ff8-42a3-a151-4ea9aa433336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb863a0-3ff8-42a3-a151-4ea9aa433336.jpg?1",
             "name": "Whelming Wave",
             "text": "Return all creatures to their owners' hands except for Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -14109,7 +14109,7 @@
         },
         {
             "id": "125ef715-deea-5523-a7c7-d21250396a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d5b87-6dfc-4b99-822b-f6f8489ad275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d5b87-6dfc-4b99-822b-f6f8489ad275.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -14142,7 +14142,7 @@
         },
         {
             "id": "56b73fde-d0e9-557e-b9b5-737107c3d03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5f586d-6bf0-4590-ad73-2d46b2a45b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5f586d-6bf0-4590-ad73-2d46b2a45b1a.jpg?1",
             "name": "Comet Storm",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose any target, then choose another target for each time this spell was kicked. Comet Storm deals X damage to each of them.",
             "colours": [
@@ -14173,7 +14173,7 @@
         },
         {
             "id": "cd19793c-bad8-53af-baf6-c595d5ca5797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1371d7cb-3839-46e9-a02d-2253e18d2029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1371d7cb-3839-46e9-a02d-2253e18d2029.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "205b9d40-384d-5aee-959c-c4be94c855ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86c0628-0b61-44f2-91cc-1c3c309631ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86c0628-0b61-44f2-91cc-1c3c309631ce.jpg?1",
             "name": "Expedite",
             "text": "Target creature gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "38cf19ad-798b-5cfd-8792-0c0f2b7de865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1897b60d-7e15-488c-84d5-505187739b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1897b60d-7e15-488c-84d5-505187739b00.jpg?1",
             "name": "Fists of Flame",
             "text": "Draw a card. Until end of turn, target creature gains trample and gets +1/+0 for each card you've drawn this turn.",
             "colours": [
@@ -14269,7 +14269,7 @@
         },
         {
             "id": "29abdda7-b4f3-5c01-a111-7c70f7d81cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365336b4-92ee-429d-8f18-4624cba5469d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365336b4-92ee-429d-8f18-4624cba5469d.jpg?1",
             "name": "Jaya's Immolating Inferno",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nJaya's Immolating Inferno deals X damage to each of up to three targets.",
             "colours": [
@@ -14302,7 +14302,7 @@
         },
         {
             "id": "b98497be-5df9-5882-a86f-eed03c62e206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97622209-9357-4347-8961-f77f8d2389d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97622209-9357-4347-8961-f77f8d2389d8.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -14333,7 +14333,7 @@
         },
         {
             "id": "1224f525-f8d2-5475-a827-e75ae82d5ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d344f38d-0ef2-434b-914c-934c639e7e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d344f38d-0ef2-434b-914c-934c639e7e18.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -14366,7 +14366,7 @@
         },
         {
             "id": "dde7bc68-d46b-5121-9ec8-00aadc79d331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109c345-ce73-44b6-9228-5c4882764fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109c345-ce73-44b6-9228-5c4882764fab.jpg?1",
             "name": "Volcanic Fallout",
             "text": "This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
             "colours": [
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "31516e9e-f401-5c5a-9b3e-92987531377d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3dddfa-9579-42d7-867b-7e37b83b3eeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3dddfa-9579-42d7-867b-7e37b83b3eeb.jpg?1",
             "name": "Wild Ricochet",
             "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -14428,7 +14428,7 @@
         },
         {
             "id": "d759aa17-2785-583f-ab60-48d19e46bd40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa93215-9848-42d4-a386-6a248c2a1742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa93215-9848-42d4-a386-6a248c2a1742.jpg?1",
             "name": "Word of Seizing",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
             "colours": [
@@ -14459,7 +14459,7 @@
         },
         {
             "id": "cc3d585e-6835-5442-a227-7cdc23b6a839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea04b4f0-b8c4-43aa-8a2b-b72c22fb4517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea04b4f0-b8c4-43aa-8a2b-b72c22fb4517.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -14494,7 +14494,7 @@
         },
         {
             "id": "005a1089-8864-5f4b-a170-95d41d665335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dea775-bbb3-4e9c-8514-0605b5ad2e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dea775-bbb3-4e9c-8514-0605b5ad2e8b.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -14527,7 +14527,7 @@
         },
         {
             "id": "2ee57633-9301-5baa-b882-de8199bd8ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e228bede-5972-4381-969b-9de26e570117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e228bede-5972-4381-969b-9de26e570117.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Beast creature token.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "5d4e124d-6f6e-50f9-a211-f432c266f988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a108064-8143-4b20-a5a2-eeb3b80af82f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a108064-8143-4b20-a5a2-eeb3b80af82f.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -14589,7 +14589,7 @@
         },
         {
             "id": "54322c2b-676e-565c-bb88-d5e70dec8c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e7ded-d063-4d90-a9ff-91c44a8098d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e7ded-d063-4d90-a9ff-91c44a8098d7.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -14623,7 +14623,7 @@
         },
         {
             "id": "341529fa-baf1-5bd9-9a35-7656ddea84b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405ac8-a8e3-4c65-807e-6bfcfa162852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405ac8-a8e3-4c65-807e-6bfcfa162852.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -14654,7 +14654,7 @@
         },
         {
             "id": "b6fc8081-6d56-5e01-9a13-c6392b5bbe94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159e0372-de5e-4830-b690-f5154ed1036c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159e0372-de5e-4830-b690-f5154ed1036c.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -14685,7 +14685,7 @@
         },
         {
             "id": "2753979d-9d45-5e14-be5f-4f615bb652fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbbcfb-1b1b-4991-988d-17a22a08d5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbbcfb-1b1b-4991-988d-17a22a08d5b0.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -14716,7 +14716,7 @@
         },
         {
             "id": "da546e04-15c3-5f95-a9d5-6240624a58a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cb953-0553-462c-bd7e-4193987d36c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cb953-0553-462c-bd7e-4193987d36c9.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -14751,7 +14751,7 @@
         },
         {
             "id": "86464b9f-56a3-56a9-8feb-023afc2dafc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321f68b5-42ad-4f71-8df4-78075bf68ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321f68b5-42ad-4f71-8df4-78075bf68ce5.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -14786,7 +14786,7 @@
         },
         {
             "id": "16a7f18b-29fc-592e-9fb6-95f4d344afd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766c7781-d94e-482d-98f0-9b135ec5b8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766c7781-d94e-482d-98f0-9b135ec5b8ae.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -14819,7 +14819,7 @@
         },
         {
             "id": "8039040e-b2ca-5961-bd9d-eade044551ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbceb9b-4212-40b4-913f-e4a19db00fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbceb9b-4212-40b4-913f-e4a19db00fae.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -14850,7 +14850,7 @@
         },
         {
             "id": "5dbb752e-17cf-5e62-9115-f2b3fa92a438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8870ef0b-cb1f-463b-8509-fece4743d3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8870ef0b-cb1f-463b-8509-fece4743d3d4.jpg?1",
             "name": "Ramunap Excavator",
             "text": "You may play lands from your graveyard.",
             "colours": [
@@ -14884,7 +14884,7 @@
         },
         {
             "id": "1699cbbc-0a15-56c1-94f0-f3c193a4d356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9574f30-5e9e-4d66-ab07-fc48299e42ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9574f30-5e9e-4d66-ab07-fc48299e42ee.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -14920,7 +14920,7 @@
         },
         {
             "id": "d3279d22-23f2-5c41-bfea-e7f6ae8cfc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ac818-f476-43fd-841c-c91d78c2506e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ac818-f476-43fd-841c-c91d78c2506e.jpg?1",
             "name": "Retreat to Kazandu",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 You gain 2 life.",
             "colours": [
@@ -14951,7 +14951,7 @@
         },
         {
             "id": "33a3f429-0ffd-5175-9504-9d4ab166ebf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b6d93-0f7a-4df4-8c01-96cbd5e03315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b6d93-0f7a-4df4-8c01-96cbd5e03315.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -14982,7 +14982,7 @@
         },
         {
             "id": "8cb912c4-6c34-5e33-93e1-98b3cead6af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092bfc5f-8002-43da-8e70-c19fccfe54ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092bfc5f-8002-43da-8e70-c19fccfe54ac.jpg?1",
             "name": "Sporemound",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -15015,7 +15015,7 @@
         },
         {
             "id": "1fb8daa4-ae40-52b2-b93e-0af23330c30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32141ae3-0c1c-480c-8f61-90a46d5ce54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32141ae3-0c1c-480c-8f61-90a46d5ce54c.jpg?1",
             "name": "Terastodon",
             "text": "When Terastodon enters the battlefield, you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -15048,7 +15048,7 @@
         },
         {
             "id": "e0b9105c-852c-526a-80fb-ffc3fba53772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2d03a9-815d-4662-a3ee-d6b24047128c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2d03a9-815d-4662-a3ee-d6b24047128c.jpg?1",
             "name": "Verdant Sun's Avatar",
             "text": "Whenever Verdant Sun's Avatar or another creature enters the battlefield under your control, you gain life equal to that creature's toughness.",
             "colours": [
@@ -15082,7 +15082,7 @@
         },
         {
             "id": "4d19970a-257c-50a4-b5f6-0a750cecc820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a969128b-e03d-4f35-bac3-6a852881d27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a969128b-e03d-4f35-bac3-6a852881d27a.jpg?1",
             "name": "Wickerbough Elder",
             "text": "Wickerbough Elder enters the battlefield with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from Wickerbough Elder: Destroy target artifact or enchantment.",
             "colours": [
@@ -15116,7 +15116,7 @@
         },
         {
             "id": "e96bd745-5119-55a5-bbc4-63a6d9735572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cfb9b-77bb-4e5a-be31-3a9984af1217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cfb9b-77bb-4e5a-be31-3a9984af1217.jpg?1",
             "name": "Yavimaya Elder",
             "text": "When Yavimaya Elder dies, you may search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library.\n{2}, Sacrifice Yavimaya Elder: Draw a card.",
             "colours": [
@@ -15150,7 +15150,7 @@
         },
         {
             "id": "1447d633-cb0b-54ae-9351-6fcb66c54149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c3288b-ab10-40df-a0ce-17ee4ecdb98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c3288b-ab10-40df-a0ce-17ee4ecdb98e.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014\n\u2022 Boros Charm deals 4 damage to target player or planeswalker.\n\u2022 Permanents you control gain indestructible until end of turn.\n\u2022 Target creature gains double strike until end of turn.",
             "colours": [
@@ -15185,7 +15185,7 @@
         },
         {
             "id": "1eb02d13-d71b-5c31-91ca-9abdce337368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42b8b16-dd09-466b-ba1e-979e963ea384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42b8b16-dd09-466b-ba1e-979e963ea384.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -15224,7 +15224,7 @@
         },
         {
             "id": "79bc5dcc-c731-5d52-bf7b-62762b5da28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5580886-a402-4048-b8b6-39e19479f491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5580886-a402-4048-b8b6-39e19479f491.jpg?1",
             "name": "Deflecting Palm",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. If damage is prevented this way, Deflecting Palm deals that much damage to that source's controller.",
             "colours": [
@@ -15257,7 +15257,7 @@
         },
         {
             "id": "f75905de-e27b-5f59-ab3f-796b81f809c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9c5be-4bca-4c59-bbfc-50378e0404df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9c5be-4bca-4c59-bbfc-50378e0404df.jpg?1",
             "name": "Fathom Mage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever a +1/+1 counter is put on Fathom Mage, you may draw a card.",
             "colours": [
@@ -15293,7 +15293,7 @@
         },
         {
             "id": "3131ddf1-c363-5cc0-818e-1d6596468c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0f0add-4ed5-4146-972f-ece8a19e567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0f0add-4ed5-4146-972f-ece8a19e567d.jpg?1",
             "name": "Growth Spiral",
             "text": "Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -15326,7 +15326,7 @@
         },
         {
             "id": "1649d1a1-ef5f-51ad-8d6d-2d8c76819f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95749cf-dd12-4bca-a74d-01301b9b76df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95749cf-dd12-4bca-a74d-01301b9b76df.jpg?1",
             "name": "Master Warcraft",
             "text": "Cast this spell only before attackers are declared.\nYou choose which creatures attack this turn.\nYou choose which creatures block this turn and how those creatures block.",
             "colours": [
@@ -15359,7 +15359,7 @@
         },
         {
             "id": "8b4dde1f-0e45-5f74-8fb7-c48f714e76d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd7296c-ace8-43ea-8164-c69f8843d022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd7296c-ace8-43ea-8164-c69f8843d022.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -15394,7 +15394,7 @@
         },
         {
             "id": "02e11f9c-824f-5cd2-b72a-996ba0f6fe86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg?1",
             "name": "Response // Resurgence",
             "text": "Response deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -15427,7 +15427,7 @@
         },
         {
             "id": "8196f825-1f84-5957-90ad-97df5e765219",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg?1",
             "name": "Response // Resurgence",
             "text": "Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -15460,7 +15460,7 @@
         },
         {
             "id": "d12c9d5a-1625-51ec-a570-a97003b87acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db490f74-977f-476d-b8ee-da7b0a98b4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db490f74-977f-476d-b8ee-da7b0a98b4c4.jpg?1",
             "name": "Sharktocrab",
             "text": "{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Sharktocrab, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "47a128ab-cb69-5b17-bac5-970ac007d1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3384ee4e-738f-4442-bccd-4f96022b7219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3384ee4e-738f-4442-bccd-4f96022b7219.jpg?1",
             "name": "Simic Charm",
             "text": "Choose one \u2014\n\u2022 Target creature gets +3/+3 until end of turn.\n\u2022 Permanents you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -15530,7 +15530,7 @@
         },
         {
             "id": "4ff81946-5443-566a-a975-540d9b20f740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791b7fa-3d12-409d-b017-cb9fd8b71af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791b7fa-3d12-409d-b017-cb9fd8b71af7.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -15565,7 +15565,7 @@
         },
         {
             "id": "bf8e7062-fe35-57d2-b986-00d8fd6c2b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51d5d93-e4f7-4c83-a89f-f600668d2c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51d5d93-e4f7-4c83-a89f-f600668d2c29.jpg?1",
             "name": "Spitting Image",
             "text": "Create a token that's a copy of target creature.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -15598,7 +15598,7 @@
         },
         {
             "id": "d8b615f2-706f-57e6-9574-524853668264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63852ffb-22ef-4b88-9cba-254291e978cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63852ffb-22ef-4b88-9cba-254291e978cd.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -15636,7 +15636,7 @@
         },
         {
             "id": "994e8e98-850d-58f8-a0c7-c634feb9eff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba443c5-ed9f-4bc0-8821-0053b536d648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba443c5-ed9f-4bc0-8821-0053b536d648.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -15669,7 +15669,7 @@
         },
         {
             "id": "221f4799-f84b-550c-82d0-4531e0b5d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target artifact.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -15701,7 +15701,7 @@
         },
         {
             "id": "5550c46f-63e3-5336-a819-101c93fcbd01",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target enchantment.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -15733,7 +15733,7 @@
         },
         {
             "id": "5fe5da36-2b34-5cd0-b217-ec06d2bab709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f192c3e-34ce-4857-82ef-a0423823220d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f192c3e-34ce-4857-82ef-a0423823220d.jpg?1",
             "name": "Blackblade Reforged",
             "text": "Equipped creature gets +1/+1 for each land you control.\nEquip legendary creature {3}\nEquip {7}",
             "colours": [],
@@ -15764,7 +15764,7 @@
         },
         {
             "id": "336d5a5e-3765-523f-94f5-faed8c99396f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690972a8-72df-4050-a353-16e45589167c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690972a8-72df-4050-a353-16e45589167c.jpg?1",
             "name": "Bonesplitter",
             "text": "Equipped creature gets +2/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "4a988092-c1e9-536a-807b-de684910fc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae6081-1876-42ea-a6f8-d18dbe55c4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae6081-1876-42ea-a6f8-d18dbe55c4c4.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -15823,7 +15823,7 @@
         },
         {
             "id": "d1eb2bd4-62ca-516e-83d5-0b308d399180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48010648-6f68-41aa-93ae-e02a7de6abb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48010648-6f68-41aa-93ae-e02a7de6abb8.jpg?1",
             "name": "Brass Squire",
             "text": "{T}: Attach target Equipment you control to target creature you control.",
             "colours": [],
@@ -15853,7 +15853,7 @@
         },
         {
             "id": "1dd4f291-85d9-55cc-a49d-1b0abaf94d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cf33f-ef8d-4d10-87fe-ab03b8525766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cf33f-ef8d-4d10-87fe-ab03b8525766.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "c114a7ad-118e-5a38-b06d-88ff8345309c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0d12-5bd6-4d2f-8913-fe690c441104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0d12-5bd6-4d2f-8913-fe690c441104.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15911,7 +15911,7 @@
         },
         {
             "id": "03278e1b-47a4-5f54-81b8-942a11ec66cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ece771-d628-45e7-882d-a35f625d2e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ece771-d628-45e7-882d-a35f625d2e55.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15942,7 +15942,7 @@
         },
         {
             "id": "30646eeb-c012-5f22-935f-ea5763d6b40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd53b6a-6daf-436e-8069-270bed7b4b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd53b6a-6daf-436e-8069-270bed7b4b39.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15973,7 +15973,7 @@
         },
         {
             "id": "251fe08f-705e-5b6d-98cb-ca56175205e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ccdaf1-c491-4f87-94f8-d66e7e399681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ccdaf1-c491-4f87-94f8-d66e7e399681.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0 and has trample and lifelink.\nEquip {3}",
             "colours": [],
@@ -16002,7 +16002,7 @@
         },
         {
             "id": "49740c1c-bc8b-5827-8af9-320ad5319264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa1b193-c80e-4026-bd82-f16314e14431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa1b193-c80e-4026-bd82-f16314e14431.jpg?1",
             "name": "Mask of Avacyn",
             "text": "Equipped creature gets +1/+2 and has hexproof. (It can't be the target of spells or abilities your opponents control.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16031,7 +16031,7 @@
         },
         {
             "id": "69750e7f-5943-5766-a2c0-2ec3cca0b5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4894b26b-f1ee-4e08-8bab-082a8327c96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4894b26b-f1ee-4e08-8bab-082a8327c96f.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -16063,7 +16063,7 @@
         },
         {
             "id": "6f565827-0809-5faa-b124-b9d4b2b0d650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda91fbd-bf5b-46c4-bd96-037b507f3daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda91fbd-bf5b-46c4-bd96-037b507f3daa.jpg?1",
             "name": "Ring of Thune",
             "text": "Equipped creature has vigilance.\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's white.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16092,7 +16092,7 @@
         },
         {
             "id": "1e6cc958-5ae9-50f8-b565-cc19c84f9917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3c0bc4-6f89-48e2-b525-5efcb091bc5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3c0bc4-6f89-48e2-b525-5efcb091bc5e.jpg?1",
             "name": "Ring of Valkas",
             "text": "Equipped creature has haste.\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's red.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16121,7 +16121,7 @@
         },
         {
             "id": "9ede4cba-f622-5b39-bb15-15cdab1aa276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b8613-d5cd-4749-9c1b-d27a388c616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b8613-d5cd-4749-9c1b-d27a388c616a.jpg?1",
             "name": "Seer's Sundial",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -16148,7 +16148,7 @@
         },
         {
             "id": "18de36b3-5bcf-5a5b-963f-32c1caf4266e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ce2ab-d3e6-486c-a577-2d4f2c750cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ce2ab-d3e6-486c-a577-2d4f2c750cde.jpg?1",
             "name": "Simic Signet",
             "text": "{1}, {T}: Add {G}{U}.",
             "colours": [],
@@ -16178,7 +16178,7 @@
         },
         {
             "id": "4b9e45eb-f62b-5728-820c-48a3e6623682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b26011-e103-45c4-a253-900f4e6b2eeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b26011-e103-45c4-a253-900f4e6b2eeb.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -16207,7 +16207,7 @@
         },
         {
             "id": "9bea7744-d60e-5e33-a139-ba54c42bce6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3e42ee-ab13-460b-90fd-86e677abce4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3e42ee-ab13-460b-90fd-86e677abce4f.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -16239,7 +16239,7 @@
         },
         {
             "id": "c1796ad3-42bc-5c85-945f-e5268f629e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c45f3d-cf12-4db7-b161-9539ed969ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c45f3d-cf12-4db7-b161-9539ed969ca7.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -16270,7 +16270,7 @@
         },
         {
             "id": "26f20bff-4655-5847-88b8-d5043af9efc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032af060-4d49-4a0a-8841-9eb2d45a4b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032af060-4d49-4a0a-8841-9eb2d45a4b77.jpg?1",
             "name": "Sword of Vengeance",
             "text": "Equipped creature gets +2/+0 and has first strike, vigilance, trample, and haste.\nEquip {3}",
             "colours": [],
@@ -16299,7 +16299,7 @@
         },
         {
             "id": "2dc2d6b3-0af9-5be9-bd8a-3fc04151e1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a949030-a46c-4bac-bedc-c07d5c8464af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a949030-a46c-4bac-bedc-c07d5c8464af.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {C}.\n{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16328,7 +16328,7 @@
         },
         {
             "id": "57e23be9-399f-5a9f-b1a9-f2d8b2d390e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba2ac2-15dc-4c43-bb57-9943444ce1d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba2ac2-15dc-4c43-bb57-9943444ce1d7.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W}.",
             "colours": [],
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "885e6a92-ab91-5671-8e1e-4194427094ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce912e1-73fe-41f3-a86c-4c19ff3f100f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce912e1-73fe-41f3-a86c-4c19ff3f100f.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -16390,7 +16390,7 @@
         },
         {
             "id": "c9e1aec9-1d9a-594e-a31a-1afd4ac3a457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e72ac3-2b4f-43d8-9708-afe1b67c5d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e72ac3-2b4f-43d8-9708-afe1b67c5d00.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -16420,7 +16420,7 @@
         },
         {
             "id": "f11d5ca9-9baa-54e8-aec6-c62b0740c6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e3ea71-ea9f-4bbf-93cb-0f6339f8a3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e3ea71-ea9f-4bbf-93cb-0f6339f8a3ab.jpg?1",
             "name": "Coral Atoll",
             "text": "Coral Atoll enters the battlefield tapped.\nWhen Coral Atoll enters the battlefield, sacrifice it unless you return an untapped Island you control to its owner's hand.\n{T}: Add {C}{U}.",
             "colours": [],
@@ -16449,7 +16449,7 @@
         },
         {
             "id": "2280a733-b06b-5d29-bab8-16c0758af93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a591bffd-2f03-48f4-a719-04f2142abd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a591bffd-2f03-48f4-a719-04f2142abd77.jpg?1",
             "name": "Encroaching Wastes",
             "text": "{T}: Add {C}.\n{4}, {T}, Sacrifice Encroaching Wastes: Destroy target nonbasic land.",
             "colours": [],
@@ -16476,7 +16476,7 @@
         },
         {
             "id": "28ec0c20-5d17-5568-b5c0-fbd90bc624b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a25c6-a1b7-4d6c-8a22-b407043a2280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a25c6-a1b7-4d6c-8a22-b407043a2280.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16503,7 +16503,7 @@
         },
         {
             "id": "dbeee0cd-a60c-599d-8b93-f77ad94aff2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084bf9fe-78d2-4fef-8514-ed64d6c771e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084bf9fe-78d2-4fef-8514-ed64d6c771e6.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave enters the battlefield tapped.\n{T}: Add {R}.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -16532,7 +16532,7 @@
         },
         {
             "id": "684be8a4-442d-589d-ba3f-507d3eb07626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4929e39-fccc-450b-bb18-f5ad56a397bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4929e39-fccc-450b-bb18-f5ad56a397bd.jpg?1",
             "name": "Jungle Basin",
             "text": "Jungle Basin enters the battlefield tapped.\nWhen Jungle Basin enters the battlefield, sacrifice it unless you return an untapped Forest you control to its owner's hand.\n{T}: Add {C}{G}.",
             "colours": [],
@@ -16561,7 +16561,7 @@
         },
         {
             "id": "9a1f0d81-e56d-55eb-8074-65ba5922d6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d1438-95d3-4c2c-8011-7970cbf6fe88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d1438-95d3-4c2c-8011-7970cbf6fe88.jpg?1",
             "name": "Memorial to Genius",
             "text": "Memorial to Genius enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards.",
             "colours": [],
@@ -16590,7 +16590,7 @@
         },
         {
             "id": "f8d2af64-34c3-5f47-afe5-97fdd20a395e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fe9351-82ad-47b0-b30c-208effbb9f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fe9351-82ad-47b0-b30c-208effbb9f3d.jpg?1",
             "name": "Memorial to War",
             "text": "Memorial to War enters the battlefield tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice Memorial to War: Destroy target land.",
             "colours": [],
@@ -16619,7 +16619,7 @@
         },
         {
             "id": "e98bb4ca-031b-50d6-8d94-d238243ee340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538f54e-81dc-4396-9d47-3087df16b630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538f54e-81dc-4396-9d47-3087df16b630.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16648,7 +16648,7 @@
         },
         {
             "id": "5c9bcdfa-dae6-5c2f-854a-28583afb8ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdf72b4-d188-4d16-a1a9-943cbe3157d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdf72b4-d188-4d16-a1a9-943cbe3157d6.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -16677,7 +16677,7 @@
         },
         {
             "id": "e8bfd25f-3983-51b1-88c5-9d14e407ee32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbfd91-40d7-4cb4-ac82-27c50d872cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbfd91-40d7-4cb4-ac82-27c50d872cf5.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -16704,7 +16704,7 @@
         },
         {
             "id": "f13541fc-ac4d-5100-a800-a191623c8098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8340aa81-7c7f-4b0b-8d98-d3414cac331c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8340aa81-7c7f-4b0b-8d98-d3414cac331c.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -16733,7 +16733,7 @@
         },
         {
             "id": "02172589-7380-5029-9adb-0f3fb3c1b267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c536cbd-3e81-4c6a-a4e1-02fbd2776706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c536cbd-3e81-4c6a-a4e1-02fbd2776706.jpg?1",
             "name": "Secluded Steppe",
             "text": "Secluded Steppe enters the battlefield tapped.\n{T}: Add {W}.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "5b66f87c-9618-5e71-a6eb-8b18c5a7ccf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b84ef6-ba13-4c65-987e-cc6aa750086c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b84ef6-ba13-4c65-987e-cc6aa750086c.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U}.",
             "colours": [],
@@ -16792,7 +16792,7 @@
         },
         {
             "id": "c95315f0-4626-5072-9056-9abf1dd29297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93f0124-eb83-4261-8ad2-5590155274a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93f0124-eb83-4261-8ad2-5590155274a4.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -16824,7 +16824,7 @@
         },
         {
             "id": "24aed73f-08ad-5f8d-8a36-a8f67293e7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402bc1b6-f2f7-4bb7-954a-8579e43f612f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402bc1b6-f2f7-4bb7-954a-8579e43f612f.jpg?1",
             "name": "Slayers' Stronghold",
             "text": "{T}: Add {C}.\n{R}{W}, {T}: Target creature gets +2/+0 and gains vigilance and haste until end of turn.",
             "colours": [],
@@ -16854,7 +16854,7 @@
         },
         {
             "id": "38cf86b5-1c4e-5239-920a-e8bf51ad8ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3575e1-7d2c-4777-b469-16f7483bb8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3575e1-7d2c-4777-b469-16f7483bb8e7.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -16884,7 +16884,7 @@
         },
         {
             "id": "92163e05-711a-5cbb-86ae-269df5a2b156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7071a2-2ff2-405b-9052-f902dee820a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7071a2-2ff2-405b-9052-f902dee820a7.jpg?1",
             "name": "Sunhome, Fortress of the Legion",
             "text": "{T}: Add {C}.\n{2}{R}{W}, {T}: Target creature gains double strike until end of turn.",
             "colours": [],
@@ -16914,7 +16914,7 @@
         },
         {
             "id": "9da815e1-3345-5dc5-bcc4-05068fb2e4d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7a200-3da0-4714-ae1c-2e4847725416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7a200-3da0-4714-ae1c-2e4847725416.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16944,7 +16944,7 @@
         },
         {
             "id": "0d9bb632-6c40-578f-9a7f-df632bf4f3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e918f01a-3c24-440c-9e5b-c8cf47d81a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e918f01a-3c24-440c-9e5b-c8cf47d81a82.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -16974,7 +16974,7 @@
         },
         {
             "id": "8b4f9d6e-9cf7-5f4e-bea9-c0830bafb2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0baaa39-7fce-4feb-9118-b1d6bc24f548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0baaa39-7fce-4feb-9118-b1d6bc24f548.jpg?1",
             "name": "Transguild Promenade",
             "text": "Transguild Promenade enters the battlefield tapped.\nWhen Transguild Promenade enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -17001,7 +17001,7 @@
         },
         {
             "id": "9375f341-c019-5790-b335-e286d939199d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fde8caf-975e-4d43-b994-27199e0557fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fde8caf-975e-4d43-b994-27199e0557fa.jpg?1",
             "name": "Vivid Creek",
             "text": "Vivid Creek enters the battlefield tapped with two charge counters on it.\n{T}: Add {U}.\n{T}, Remove a charge counter from Vivid Creek: Add one mana of any color.",
             "colours": [],
@@ -17030,7 +17030,7 @@
         },
         {
             "id": "e93c81b0-38d1-5727-be75-19f6584b4511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdfbba9-c5f7-426b-8219-8661304ea588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdfbba9-c5f7-426b-8219-8661304ea588.jpg?1",
             "name": "Vivid Grove",
             "text": "Vivid Grove enters the battlefield tapped with two charge counters on it.\n{T}: Add {G}.\n{T}, Remove a charge counter from Vivid Grove: Add one mana of any color.",
             "colours": [],
@@ -17059,7 +17059,7 @@
         },
         {
             "id": "a00e4ed7-dc83-5435-90e4-4ab47e52880f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf1fd55-9e9f-49c2-bf4f-439a18f7f36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf1fd55-9e9f-49c2-bf4f-439a18f7f36a.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -17089,7 +17089,7 @@
         },
         {
             "id": "aa034fea-624f-53b3-ba28-7b8af975f5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77619840-963f-4ff7-9a42-b36e3d53646d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77619840-963f-4ff7-9a42-b36e3d53646d.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -17119,7 +17119,7 @@
         },
         {
             "id": "a5df25d6-c181-5800-bc89-efc959d6f904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e4d2b-2ba7-492f-9f0f-b2b2a2e4c049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e4d2b-2ba7-492f-9f0f-b2b2a2e4c049.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -17154,7 +17154,7 @@
         },
         {
             "id": "cac70c4e-cabc-5a8b-84d0-d4f3a7073a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0491b4f7-9722-4f7e-932c-e19dc0fdf6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0491b4f7-9722-4f7e-932c-e19dc0fdf6d2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -17189,7 +17189,7 @@
         },
         {
             "id": "adc096fe-4ff7-5898-b344-c6da1b609622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb15b40c-9795-42ae-9f88-8b8023b6c010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb15b40c-9795-42ae-9f88-8b8023b6c010.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -17224,7 +17224,7 @@
         },
         {
             "id": "552f4182-0e63-5edf-9483-54da4e322d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e905b6c5-1874-4d3b-8181-bc4bfab73bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e905b6c5-1874-4d3b-8181-bc4bfab73bd7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -17259,7 +17259,7 @@
         },
         {
             "id": "510a6b3b-0045-570b-9270-5fba1692be08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1baebba-a975-45b1-bbcb-f4ce1ba682b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1baebba-a975-45b1-bbcb-f4ce1ba682b5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17294,7 +17294,7 @@
         },
         {
             "id": "c3626c1a-5f8f-5279-9e7e-6c7eeec37851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3346e6-f8ca-45fa-944c-055ac038e828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3346e6-f8ca-45fa-944c-055ac038e828.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17329,7 +17329,7 @@
         },
         {
             "id": "f3ec19b4-64cc-5e4d-abdf-e2fd4db94803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845057a1-4da1-4a32-9bb2-bbf8502acd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845057a1-4da1-4a32-9bb2-bbf8502acd37.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17364,7 +17364,7 @@
         },
         {
             "id": "7d46dd9f-c4d0-57f0-927e-89f9862739b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eea1d-4d57-4aee-9ebe-a8eb594d319b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eea1d-4d57-4aee-9ebe-a8eb594d319b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17399,7 +17399,7 @@
         },
         {
             "id": "00396ed6-b91d-5c78-8760-bb22d8f3e9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f68b4de-271b-415f-ad8f-104981bb12ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f68b4de-271b-415f-ad8f-104981bb12ab.jpg?1",
             "name": "Tevesh Szat, Doom of Fools",
             "text": "+2: Create two 0/1 black Thrull creature tokens.\n+1: You may sacrifice another creature or planeswalker. If you do, draw two cards, then draw another card if the sacrificed permanent was a commander.\n\u221210: Gain control of all commanders. Put all commanders from the command zone onto the battlefield under your control.\nTevesh Szat, Doom of Fools can be your commander.\nPartner",
             "colours": [
@@ -17437,7 +17437,7 @@
         },
         {
             "id": "0732d9c5-ded3-58ee-88dc-1331769cc554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de336a3-224f-49e0-b4ff-34bf3de398bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de336a3-224f-49e0-b4ff-34bf3de398bf.jpg?1",
             "name": "Jeska, Thrice Reborn",
             "text": "Jeska, Thrice Reborn enters the battlefield with a loyalty counter on it for each time you've cast a commander from the command zone this game.\n0: Choose target creature. Until your next turn, if that creature would deal combat damage to one of your opponents, it deals triple that damage to that player instead.\n\u2212X: Jeska, Thrice Reborn deals X damage to each of up to three targets.\nJeska, Thrice Reborn can be your commander.\nPartner",
             "colours": [
@@ -17475,7 +17475,7 @@
         },
         {
             "id": "52201a8d-2650-509e-802b-7947489d1a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be898edb-35dd-4896-96d9-323aca64a2ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be898edb-35dd-4896-96d9-323aca64a2ce.jpg?1",
             "name": "Najeela, the Blade-Blossom",
             "text": "Whenever a Warrior attacks, you may have its controller create a 1/1 white Warrior creature token that's tapped and attacking.\n{W}{U}{B}{R}{G}: Untap all attacking creatures. They gain trample, lifelink, and haste until end of turn. After this phase, there is an additional combat phase. Activate this ability only during combat.",
             "colours": [
@@ -17515,7 +17515,7 @@
         },
         {
             "id": "9ae62129-9742-5258-b7fb-526d95f646f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9923a-ad50-49e5-bf96-c669a39b84fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9923a-ad50-49e5-bf96-c669a39b84fd.jpg?1",
             "name": "Akiri, Line-Slinger",
             "text": "First strike, vigilance\nAkiri, Line-Slinger gets +1/+0 for each artifact you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17554,7 +17554,7 @@
         },
         {
             "id": "51036a18-d7f7-5e0a-afd0-a83ba234db0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8bb45f-5f65-4ee4-a64e-d5e8f758d9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8bb45f-5f65-4ee4-a64e-d5e8f758d9e9.jpg?1",
             "name": "Brago, King Eternal",
             "text": "Flying\nWhenever Brago, King Eternal deals combat damage to a player, exile any number of target nonland permanents you control, then return those cards to the battlefield under their owner's control.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "9d70f008-2465-5665-bb3f-8eb9c751508b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816c031-8816-4f52-b1db-590f0688d801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816c031-8816-4f52-b1db-590f0688d801.jpg?1",
             "name": "Bruse Tarl, Boorish Herder",
             "text": "Whenever Bruse Tarl, Boorish Herder enters the battlefield or attacks, target creature you control gains double strike and lifelink until end of turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17630,7 +17630,7 @@
         },
         {
             "id": "7346cff6-ee3b-5890-ad75-dc70ba9ad32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a1707-1cda-4121-a3d1-55a7604bbd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a1707-1cda-4121-a3d1-55a7604bbd77.jpg?1",
             "name": "Derevi, Empyrial Tactician",
             "text": "Flying\nWhenever Derevi, Empyrial Tactician enters the battlefield or a creature you control deals combat damage to a player, you may tap or untap target permanent.\n{1}{G}{W}{U}: Put Derevi onto the battlefield from the command zone.",
             "colours": [
@@ -17670,7 +17670,7 @@
         },
         {
             "id": "3d7a2d70-d30e-5bc4-8d9f-12efc47bdbce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb98089-11b8-4afd-9724-e488d864b4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb98089-11b8-4afd-9724-e488d864b4dc.jpg?1",
             "name": "Ikra Shidiqi, the Usurper",
             "text": "Menace\nWhenever a creature you control deals combat damage to a player, you gain life equal to that creature's toughness.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17708,7 +17708,7 @@
         },
         {
             "id": "38380e04-8d4f-5f33-b86a-ab667e98949f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35eb2a8-ecdc-4ce3-a628-e031141645e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35eb2a8-ecdc-4ce3-a628-e031141645e6.jpg?1",
             "name": "Ishai, Ojutai Dragonspeaker",
             "text": "Flying\nWhenever an opponent casts a spell, put a +1/+1 counter on Ishai, Ojutai Dragonspeaker.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17746,7 +17746,7 @@
         },
         {
             "id": "c81dde4a-5cee-54b7-9d80-9284962eacd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61a6018-7f07-4623-b981-9516b53b8534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61a6018-7f07-4623-b981-9516b53b8534.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nDuring each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -17786,7 +17786,7 @@
         },
         {
             "id": "656cda09-102e-50d3-868c-cb6fe10cf496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb07085-0dcd-43c9-8355-270a77c573e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb07085-0dcd-43c9-8355-270a77c573e1.jpg?1",
             "name": "Karametra, God of Harvests",
             "text": "Indestructible\nAs long as your devotion to green and white is less than seven, Karametra isn't a creature.\nWhenever you cast a creature spell, you may search your library for a Forest or Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -17824,7 +17824,7 @@
         },
         {
             "id": "c66457a3-0855-5de4-ae94-1ac5215e5432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e13fc2-c4dd-4875-be32-e04d954e658d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e13fc2-c4dd-4875-be32-e04d954e658d.jpg?1",
             "name": "Kraum, Ludevic's Opus",
             "text": "Flying, haste\nWhenever an opponent casts their second spell each turn, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17862,7 +17862,7 @@
         },
         {
             "id": "13f6bab7-2dc2-5058-be50-b39ceae200b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eee902-dc0b-48d0-a8db-7e6de89977ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eee902-dc0b-48d0-a8db-7e6de89977ef.jpg?1",
             "name": "Kydele, Chosen of Kruphix",
             "text": "{T}: Add {C} for each card you've drawn this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17900,7 +17900,7 @@
         },
         {
             "id": "2f1ee9dd-cb59-50e8-8e03-1d2795a1472d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6724f-f781-446b-be69-5c6949f9bbaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6724f-f781-446b-be69-5c6949f9bbaa.jpg?1",
             "name": "Ludevic, Necro-Alchemist",
             "text": "At the beginning of each player's end step, that player may draw a card if a player other than you lost life this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17938,7 +17938,7 @@
         },
         {
             "id": "60d95ef5-9ec3-54bc-b2b3-8f30e4ba0332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a75062-b5e3-4942-af64-12f43101c294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a75062-b5e3-4942-af64-12f43101c294.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -17977,7 +17977,7 @@
         },
         {
             "id": "cded5e1a-95d2-5816-a046-059d9acc66a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e1033e-3d7e-451a-8e0f-1ae7f3de925a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e1033e-3d7e-451a-8e0f-1ae7f3de925a.jpg?1",
             "name": "Marath, Will of the Wild",
             "text": "Marath, Will of the Wild enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.\n{X}, Remove X +1/+1 counters from Marath: Choose one. X can't be 0.\n\u2022 Put X +1/+1 counters on target creature.\n\u2022 Marath deals X damage to any target.\n\u2022 Create an X/X green Elemental creature token.",
             "colours": [
@@ -18017,7 +18017,7 @@
         },
         {
             "id": "fce4bdd6-a05f-5076-aabb-770818d61c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c19629-b129-4c8b-9456-c38309248189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c19629-b129-4c8b-9456-c38309248189.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -18057,7 +18057,7 @@
         },
         {
             "id": "ba3833c2-d289-5aae-a8c6-d4f9b222635e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1691bd-5194-4f1e-981f-6d5ef808ed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1691bd-5194-4f1e-981f-6d5ef808ed4e.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nWhenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",
             "colours": [
@@ -18097,7 +18097,7 @@
         },
         {
             "id": "c8867a01-8d85-5829-a231-b8ecc5e309d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d5e58-f06e-43bb-8e3c-bbf241cc2de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d5e58-f06e-43bb-8e3c-bbf241cc2de6.jpg?1",
             "name": "Prossh, Skyraider of Kher",
             "text": "When you cast this spell, create X 0/1 red Kobold creature tokens named Kobolds of Kher Keep, where X is the amount of mana spent to cast it.\nFlying\nSacrifice another creature: Prossh, Skyraider of Kher gets +1/+0 until end of turn.",
             "colours": [
@@ -18136,7 +18136,7 @@
         },
         {
             "id": "cfc5a50a-a945-5f2c-8e5d-a4d1fd5b8831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c04d8d-f552-4af3-b014-efb7a1c577f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c04d8d-f552-4af3-b014-efb7a1c577f8.jpg?1",
             "name": "Queen Marchesa",
             "text": "Deathtouch, haste\nWhen Queen Marchesa enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with deathtouch and haste.",
             "colours": [
@@ -18176,7 +18176,7 @@
         },
         {
             "id": "0211c102-fc7f-5033-b372-782d1be6e145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f275-6d3e-4040-a60e-8259a82befdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f275-6d3e-4040-a60e-8259a82befdb.jpg?1",
             "name": "Rakdos, Lord of Riots",
             "text": "You can't cast this spell unless an opponent lost life this turn.\nFlying, trample\nCreature spells you cast cost {1} less to cast for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -18213,7 +18213,7 @@
         },
         {
             "id": "40946f30-4037-5350-8df6-f349cb7fb12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde62b0c-ea15-4b25-9cb1-697cc2e459c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde62b0c-ea15-4b25-9cb1-697cc2e459c0.jpg?1",
             "name": "Ravos, Soultender",
             "text": "Flying\nOther creatures you control get +1/+1.\nAt the beginning of your upkeep, you may return target creature card from your graveyard to your hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18251,7 +18251,7 @@
         },
         {
             "id": "6ec1302e-c70e-558d-8af7-e03630e23bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a34158d-9925-4de8-b862-d1cc06bbae60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a34158d-9925-4de8-b862-d1cc06bbae60.jpg?1",
             "name": "Reyhan, Last of the Abzan",
             "text": "Reyhan, Last of the Abzan enters the battlefield with three +1/+1 counters on it.\nWhenever a creature you control dies or is put into the command zone, if it had one or more +1/+1 counters on it, you may put that many +1/+1 counters on target creature.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18289,7 +18289,7 @@
         },
         {
             "id": "c9da1a6f-469a-583d-a26a-307c143eb94b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6593325-d279-43ca-a3bc-576852aaa4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6593325-d279-43ca-a3bc-576852aaa4f6.jpg?1",
             "name": "Sidar Kondo of Jamuraa",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nCreatures your opponents control without flying or reach can't block creatures with power 2 or less.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18327,7 +18327,7 @@
         },
         {
             "id": "94bf42da-623c-502c-8abc-9b725be98d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5e4382-3f5c-46c7-915f-df9373d316bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5e4382-3f5c-46c7-915f-df9373d316bf.jpg?1",
             "name": "Silas Renn, Seeker Adept",
             "text": "Deathtouch\nWhenever Silas Renn, Seeker Adept deals combat damage to a player, choose target artifact card in your graveyard. You may cast that card this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18365,7 +18365,7 @@
         },
         {
             "id": "945bf5ca-378e-53f6-a96a-4124e4ae11a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505876d-217f-43cb-b0cb-bf19208b98d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505876d-217f-43cb-b0cb-bf19208b98d2.jpg?1",
             "name": "Tana, the Bloodsower",
             "text": "Trample\nWhenever Tana, the Bloodsower deals combat damage to a player, create that many 1/1 green Saproling creature tokens.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18403,7 +18403,7 @@
         },
         {
             "id": "0ef6dc05-1c1d-5348-bd67-5d98f185b323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845bf543-0367-4d2c-81ba-e424bfbfb7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845bf543-0367-4d2c-81ba-e424bfbfb7de.jpg?1",
             "name": "Thrasios, Triton Hero",
             "text": "{4}: Scry 1, then reveal the top card of your library. If it's a land card, put it onto the battlefield tapped. Otherwise, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18441,7 +18441,7 @@
         },
         {
             "id": "12c42900-7a94-5f42-b9aa-7ac6b5e0056a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec4983f-c2ec-4bf5-9f14-e75f0a2788a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec4983f-c2ec-4bf5-9f14-e75f0a2788a6.jpg?1",
             "name": "Tymna the Weaver",
             "text": "Lifelink\nAt the beginning of your postcombat main phase, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18479,7 +18479,7 @@
         },
         {
             "id": "03512c0d-851c-5d6a-90a5-b17fc02345cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4dc32ca-89c9-4d3a-8809-846c34ef3592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4dc32ca-89c9-4d3a-8809-846c34ef3592.jpg?1",
             "name": "Vial Smasher the Fierce",
             "text": "Whenever you cast your first spell each turn, choose an opponent at random. Vial Smasher the Fierce deals damage equal to that spell's converted mana cost to that player or a planeswalker that player controls.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18517,7 +18517,7 @@
         },
         {
             "id": "0ac2867f-454d-568c-a5a3-8a1d180710a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5943d27d-6db2-422d-97f5-ae98270a2556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5943d27d-6db2-422d-97f5-ae98270a2556.jpg?1",
             "name": "Xenagos, God of Revels",
             "text": "Indestructible\nAs long as your devotion to red and green is less than seven, Xenagos isn't a creature.\nAt the beginning of combat on your turn, another target creature you control gains haste and gets +X/+X until end of turn, where X is that creature's power.",
             "colours": [
@@ -18555,7 +18555,7 @@
         },
         {
             "id": "f971607e-dbad-5646-aa12-a1fe5fd1e9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af7847e-82e6-45ed-834d-6f3bcba44017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af7847e-82e6-45ed-834d-6f3bcba44017.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's converted mana cost.",
             "colours": [
@@ -18593,7 +18593,7 @@
         },
         {
             "id": "7ecb7a65-90b4-5bfb-ad56-d142459d269d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f49150-9977-4ccb-b6cb-f89f7da9bf85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f49150-9977-4ccb-b6cb-f89f7da9bf85.jpg?1",
             "name": "Zedruu the Greathearted",
             "text": "At the beginning of your upkeep, you gain X life and draw X cards, where X is the number of permanents you own that your opponents control.\n{U}{R}{W}: Target opponent gains control of target permanent you control.",
             "colours": [
@@ -18633,7 +18633,7 @@
         },
         {
             "id": "f8103731-7410-5f6e-aec4-82e58d00bd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a9385e-fe0f-41d0-8415-123431aa1fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a9385e-fe0f-41d0-8415-123431aa1fee.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with converted mana cost 3 or less and put it onto the battlefield. If you do, shuffle your library.",
             "colours": [
@@ -18673,7 +18673,7 @@
         },
         {
             "id": "e5cc5804-fd79-5619-9eaf-9cb1b0cba522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865c39e-847e-4dc6-8e6c-a4200124f21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865c39e-847e-4dc6-8e6c-a4200124f21f.jpg?1",
             "name": "Ramos, Dragon Engine",
             "text": "Flying\nWhenever you cast a spell, put a +1/+1 counter on Ramos, Dragon Engine for each of that spell's colors.\nRemove five +1/+1 counters from Ramos: Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Activate this ability only once each turn.",
             "colours": [],
@@ -18711,7 +18711,7 @@
         },
         {
             "id": "38cea5f8-c06a-5b0d-a736-a27027d723ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a221ac-2022-49b6-929e-91db38929a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a221ac-2022-49b6-929e-91db38929a9f.jpg?1",
             "name": "The Prismatic Piper",
             "text": "If The Prismatic Piper is your commander, choose a color before the game begins. The Prismatic Piper is the chosen color.\nPartner (You can have two commanders if both have partner.)",
             "colours": [],
@@ -18744,7 +18744,7 @@
         },
         {
             "id": "e3eb9426-cb43-5074-aae4-689c887b7a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a9ba3-1aaf-4422-9b24-7e388b9a6f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a9ba3-1aaf-4422-9b24-7e388b9a6f45.jpg?1",
             "name": "Akroma, Vision of Ixidor",
             "text": "Flying, first strike, vigilance, trample\nAt the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.\nPartner",
             "colours": [
@@ -18781,7 +18781,7 @@
         },
         {
             "id": "3ac00442-4f77-57fe-8a88-2cca65157ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee8919-65f7-475c-972a-36d9c8d063fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee8919-65f7-475c-972a-36d9c8d063fc.jpg?1",
             "name": "Alharu, Solemn Ritualist",
             "text": "When Alharu, Solemn Ritualist enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.\nWhenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white Spirit creature token with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18819,7 +18819,7 @@
         },
         {
             "id": "15436eaf-5ee6-582e-8389-9715e5aa93ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb712a0-b648-460b-8d3d-7d920ed11a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb712a0-b648-460b-8d3d-7d920ed11a8c.jpg?1",
             "name": "Ardenn, Intrepid Archaeologist",
             "text": "At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18857,7 +18857,7 @@
         },
         {
             "id": "3de3af53-1515-57fb-9418-5273dfc991fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7e280f-1f41-4d70-8f8c-bb77c66bcf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7e280f-1f41-4d70-8f8c-bb77c66bcf8b.jpg?1",
             "name": "Keleth, Sunmane Familiar",
             "text": "Whenever a commander you control attacks, put a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18894,7 +18894,7 @@
         },
         {
             "id": "db56c42d-edef-5c80-b574-9ff09b745c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba508669-c15d-4194-ac37-236d4fd3ece7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba508669-c15d-4194-ac37-236d4fd3ece7.jpg?1",
             "name": "Livio, Oathsworn Sentinel",
             "text": "{1}{W}: Choose another target creature. Its controller may exile it with an aegis counter on it.\n{2}{W}, {T}: Return all exiled cards with aegis counters on them to the battlefield under their owners' control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18932,7 +18932,7 @@
         },
         {
             "id": "aa93cc81-f25f-5f16-86b0-c88592e33a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c33648-fb0e-4460-aae6-f3793d86e689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c33648-fb0e-4460-aae6-f3793d86e689.jpg?1",
             "name": "Prava of the Steel Legion",
             "text": "As long as it's your turn, creature tokens you control get +1/+4.\n{3}{W}: Create a 1/1 white Soldier creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18970,7 +18970,7 @@
         },
         {
             "id": "0dc11627-6034-58ac-b7c8-75c79cb97224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc74d047-9fcc-476f-bd4a-a74e52785ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc74d047-9fcc-476f-bd4a-a74e52785ebb.jpg?1",
             "name": "Radiant, Serra Archangel",
             "text": "Flying\nTap another untapped creature you control with flying: Radiant, Serra Archangel gains protection from the color of your choice until end of turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19007,7 +19007,7 @@
         },
         {
             "id": "0b33a208-9536-5074-ac6a-42843712d0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cfe1a-3ddd-481a-80d3-02504d3004dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cfe1a-3ddd-481a-80d3-02504d3004dc.jpg?1",
             "name": "Rebbec, Architect of Ascension",
             "text": "Artifacts you control have protection from each converted mana cost among artifacts you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19045,7 +19045,7 @@
         },
         {
             "id": "dba1cfab-54ae-520e-b039-b9de25e8de72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af2dc41-202e-4aec-ba58-f5dec01eaf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af2dc41-202e-4aec-ba58-f5dec01eaf27.jpg?1",
             "name": "Brinelin, the Moon Kraken",
             "text": "When Brinelin, the Moon Kraken enters the battlefield or whenever you cast a spell with converted mana cost 6 or greater, you may return target nonland permanent to its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19082,7 +19082,7 @@
         },
         {
             "id": "90ff325e-8fa5-564e-9e8b-fddf69077751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c163d7-8e63-42d0-a943-7cea3771fd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c163d7-8e63-42d0-a943-7cea3771fd87.jpg?1",
             "name": "Eligeth, Crossroads Augur",
             "text": "Flying\nIf you would scry a number of cards, draw that many cards instead.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19119,7 +19119,7 @@
         },
         {
             "id": "5f878cba-e502-522a-a614-84a04d346abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae854d22-f511-4bed-b30f-b3b52aed50a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae854d22-f511-4bed-b30f-b3b52aed50a4.jpg?1",
             "name": "Esior, Wardwing Familiar",
             "text": "Flying\nSpells your opponents cast that target one or more commanders you control cost {3} more to cast.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19156,7 +19156,7 @@
         },
         {
             "id": "7c884200-85e3-5e39-8a91-7a909a12529e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4cf323-e645-4db2-82c3-6860ea8aa9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4cf323-e645-4db2-82c3-6860ea8aa9a3.jpg?1",
             "name": "Ghost of Ramirez DePietro",
             "text": "Ghost of Ramirez DePietro can't be blocked by creatures with toughness 3 or greater.\nWhenever Ghost of Ramirez DePietro deals combat damage to a player, choose up to one target card in a graveyard that was discarded or put there from a library this turn. Put that card into its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19194,7 +19194,7 @@
         },
         {
             "id": "8973bfb0-98f1-55b5-a6d8-77d2ffa65a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81668017-5ba4-4f62-9e21-41de7a13ad76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81668017-5ba4-4f62-9e21-41de7a13ad76.jpg?1",
             "name": "Glacian, Powerstone Engineer",
             "text": "{T}, Tap X untapped artifacts you control: Look at the top X cards of your library. Put one of those cards into your hand and the rest into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19232,7 +19232,7 @@
         },
         {
             "id": "617d25f3-d774-5390-a50c-50d0412bbc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd85fd88-7e5b-494a-9106-c78602604a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd85fd88-7e5b-494a-9106-c78602604a1d.jpg?1",
             "name": "Malcolm, Keen-Eyed Navigator",
             "text": "Flying\nWhenever one or more Pirates you control deal damage to your opponents, you create a Treasure token for each opponent dealt damage. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19270,7 +19270,7 @@
         },
         {
             "id": "7009c686-a8bb-50b1-9aa8-078b1b632695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69639b23-9975-4356-ab7d-0aa3387e02c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69639b23-9975-4356-ab7d-0aa3387e02c7.jpg?1",
             "name": "Sakashima of a Thousand Faces",
             "text": "You may have Sakashima of a Thousand Faces enter the battlefield as a copy of another creature you control, except it has Sakashima of a Thousand Faces's other abilities.\nThe \"legend rule\" doesn't apply to permanents you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19308,7 +19308,7 @@
         },
         {
             "id": "cc22f482-ed44-5297-810e-fae2fcf4675c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3d31f8-f726-4b81-840b-c8ba2944d711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3d31f8-f726-4b81-840b-c8ba2944d711.jpg?1",
             "name": "Siani, Eye of the Storm",
             "text": "Flying\nWhenever Siani, Eye of the Storm attacks, scry X, where X is the number of attacking creatures with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19346,7 +19346,7 @@
         },
         {
             "id": "141992f9-3a53-5581-a0b4-d88a541303be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a678a-d81a-4994-a864-0b1af80a39ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a678a-d81a-4994-a864-0b1af80a39ca.jpg?1",
             "name": "Armix, Filigree Thrasher",
             "text": "Whenever Armix, Filigree Thrasher attacks, you may discard a card. When you do, target creature defending player controls gets -X/-X until end of turn, where X is the number of artifacts you control plus the number of artifact cards in your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19384,7 +19384,7 @@
         },
         {
             "id": "3cf4e98f-3bb5-5dfa-a31c-6b7a8ddb81f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb45a20-bfcc-45e2-9863-da58f5e9a0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb45a20-bfcc-45e2-9863-da58f5e9a0e0.jpg?1",
             "name": "Falthis, Shadowcat Familiar",
             "text": "Commanders you control have menace and deathtouch.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19422,7 +19422,7 @@
         },
         {
             "id": "963a46b5-3128-5d69-a654-760b8d86235c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6448e6e-f625-4dce-a7b9-01fee55cce6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6448e6e-f625-4dce-a7b9-01fee55cce6f.jpg?1",
             "name": "Keskit, the Flesh Sculptor",
             "text": "{T}, Sacrifice three other artifacts and/or creatures: Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19461,7 +19461,7 @@
         },
         {
             "id": "ab5d353b-ae7c-5063-bd60-3bb136bada04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d1cf4-bdf2-4ed3-8583-38309807ce93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d1cf4-bdf2-4ed3-8583-38309807ce93.jpg?1",
             "name": "Miara, Thorn of the Glade",
             "text": "Whenever Miara, Thorn of the Glade or another Elf you control dies, you may pay {1} and 1 life. If you do, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19499,7 +19499,7 @@
         },
         {
             "id": "2cc432ba-3b54-57e8-95e3-f46dc8462624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706b078f-0355-45cd-94db-26b925777efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706b078f-0355-45cd-94db-26b925777efe.jpg?1",
             "name": "Nadier, Agent of the Duskenel",
             "text": "Whenever a token you control leaves the battlefield, put a +1/+1 counter on Nadier, Agent of the Duskenel.\nWhen Nadier leaves the battlefield, create a number of 1/1 green Elf Warrior creature tokens equal to its power.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19537,7 +19537,7 @@
         },
         {
             "id": "e511d4fa-81ee-5879-a9fd-fe2217aba7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e44b5ff-450b-4345-902e-5721af142cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e44b5ff-450b-4345-902e-5721af142cdb.jpg?1",
             "name": "Sengir, the Dark Baron",
             "text": "Flying\nWhenever another creature dies, put two +1/+1 counters on Sengir, the Dark Baron.\nWhenever another player loses the game, you gain life equal to that player's life total as the turn began.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19576,7 +19576,7 @@
         },
         {
             "id": "075d381a-35ff-583a-91ad-94570f6b8260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aab532-0f3e-4569-9bef-18ce90654e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aab532-0f3e-4569-9bef-18ce90654e5d.jpg?1",
             "name": "Tormod, the Desecrator",
             "text": "Whenever one or more cards leave your graveyard, create a tapped 2/2 black Zombie creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19614,7 +19614,7 @@
         },
         {
             "id": "2a82d516-e291-530b-8a0a-9ff0846e419c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011dc183-eb83-4c66-9604-63d9ecf33705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011dc183-eb83-4c66-9604-63d9ecf33705.jpg?1",
             "name": "Alena, Kessig Trapper",
             "text": "First strike\n{T}: Add an amount of {R} equal to the greatest power among creatures you control that entered the battlefield this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19652,7 +19652,7 @@
         },
         {
             "id": "ed8f3f3a-9ef7-5e67-a8aa-a2957bafcd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef509abb-55d8-4c5c-b8c0-eec424665b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef509abb-55d8-4c5c-b8c0-eec424665b1e.jpg?1",
             "name": "Breeches, Brazen Plunderer",
             "text": "Menace\nWhenever one or more Pirates you control deal damage to your opponents, exile the top card of each of those opponents' libraries. You may play those cards this turn, and you may spend mana as though it were mana of any color to cast those spells.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19690,7 +19690,7 @@
         },
         {
             "id": "fda46d24-dd16-59a7-a28f-af631fde890d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf0cc0f-84fd-420e-ac90-b3f0bd49e2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf0cc0f-84fd-420e-ac90-b3f0bd49e2bb.jpg?1",
             "name": "Dargo, the Shipwrecker",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of artifacts and/or creatures. This spell costs {2} less to cast for each permanent sacrificed this way and {2} less to cast for each other artifact or creature you've sacrificed this turn.\nTrample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19728,7 +19728,7 @@
         },
         {
             "id": "60e88338-8476-5b95-98e2-71956ba8be9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23766fa0-e673-46c7-a29f-3fb140844b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23766fa0-e673-46c7-a29f-3fb140844b1c.jpg?1",
             "name": "Kediss, Emberclaw Familiar",
             "text": "Whenever a commander you control deals combat damage to an opponent, it deals that much damage to each other opponent.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19766,7 +19766,7 @@
         },
         {
             "id": "6203bb3b-66f7-5c12-9a4c-626afe64d6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69482de1-4959-4fd5-a314-983bde659c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69482de1-4959-4fd5-a314-983bde659c5d.jpg?1",
             "name": "Krark, the Thumbless",
             "text": "Whenever you cast an instant or sorcery spell, flip a coin. If you lose the flip, return that spell to its owner's hand. If you win the flip, copy that spell, and you may choose new targets for the copy.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19804,7 +19804,7 @@
         },
         {
             "id": "aa96aa16-62a1-5296-a061-acc38bb24417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7c27a-47e4-47d1-90b3-88a936839cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7c27a-47e4-47d1-90b3-88a936839cbc.jpg?1",
             "name": "Rograkh, Son of Rohgahh",
             "text": "First strike, menace, trample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19842,7 +19842,7 @@
         },
         {
             "id": "59834830-9c2e-5f8a-af60-86c412db4a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a097ba-6242-4a28-a6f1-72a5b3ec3a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a097ba-6242-4a28-a6f1-72a5b3ec3a8f.jpg?1",
             "name": "Toggo, Goblin Weaponsmith",
             "text": "Whenever a land enters the battlefield under your control, create a colorless Equipment artifact token named Rock with \"Equipped creature has \u2018{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any target'\" and equip {1}.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19880,7 +19880,7 @@
         },
         {
             "id": "2b59cb18-f6f1-5f80-8a36-3ac26caae6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2aadfd-e35a-4a00-9d64-265b57526d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2aadfd-e35a-4a00-9d64-265b57526d05.jpg?1",
             "name": "Anara, Wolvid Familiar",
             "text": "As long as it's your turn, commanders you control have indestructible.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19918,7 +19918,7 @@
         },
         {
             "id": "a76c76cd-b1ed-50e3-aba4-069893af8654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a65e24-08f1-4006-9547-804751e8959c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a65e24-08f1-4006-9547-804751e8959c.jpg?1",
             "name": "Gilanra, Caller of Wirewood",
             "text": "{T}: Add {G}. When you spend this mana to cast a spell with converted mana cost 6 or greater, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19956,7 +19956,7 @@
         },
         {
             "id": "a924a670-a7ae-56bc-95c2-fa6a8e5a3617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ad87f5-26da-445e-bdaa-8768d885444e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ad87f5-26da-445e-bdaa-8768d885444e.jpg?1",
             "name": "Halana, Kessig Ranger",
             "text": "Reach\nWhenever another creature enters the battlefield under your control, you may pay {2}. When you do, that creature deals damage equal to its power to target creature.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19995,7 +19995,7 @@
         },
         {
             "id": "03d63500-e56a-518f-9c61-56f97767701f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77faeb0-f0f3-4934-bb39-808db8002efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77faeb0-f0f3-4934-bb39-808db8002efd.jpg?1",
             "name": "Ich-Tekik, Salvage Splicer",
             "text": "When Ich-Tekik, Salvage Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nWhenever an artifact is put into a graveyard from the battlefield, put a +1/+1 counter on Ich-Tekik and a +1/+1 counter on each Golem you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20034,7 +20034,7 @@
         },
         {
             "id": "e94e3646-a032-5666-89b2-0f2222ff3d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9848a1d6-ffb5-4961-80f9-38de374dc707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9848a1d6-ffb5-4961-80f9-38de374dc707.jpg?1",
             "name": "Kamahl, Heart of Krosa",
             "text": "At the beginning of combat on your turn, creatures you control get +3/+3 and gain trample until end of turn.\n{1}{G}: Until end of turn, target land you control becomes a 1/1 Elemental creature with vigilance, indestructible, and haste. It's still a land.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20072,7 +20072,7 @@
         },
         {
             "id": "fcb5400e-fd19-5847-b7bd-a29f6fd1decb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896f357e-38e6-4259-91bc-1c2e7119d1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896f357e-38e6-4259-91bc-1c2e7119d1d5.jpg?1",
             "name": "Kodama of the East Tree",
             "text": "Reach\nWhenever another permanent enters the battlefield under your control, if it wasn't put onto the battlefield with this ability, you may put a permanent card with equal or lesser converted mana cost from your hand onto the battlefield.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20109,7 +20109,7 @@
         },
         {
             "id": "a4d0dd35-2544-5731-b6f2-62e8f0f54b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1706a2-7dbe-405f-a435-d9f3a0c06760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1706a2-7dbe-405f-a435-d9f3a0c06760.jpg?1",
             "name": "Numa, Joraga Chieftain",
             "text": "At the beginning of combat on your turn, you may pay {X}{X}. When you do, distribute X +1/+1 counters among any number of target Elves.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20147,7 +20147,7 @@
         },
         {
             "id": "5c221d09-5aa7-54d5-b99e-968ab123f7c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1783d-751a-490f-abe3-4661a76fce9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1783d-751a-490f-abe3-4661a76fce9e.jpg?1",
             "name": "Slurrk, All-Ingesting",
             "text": "Slurrk, All-Ingesting enters the battlefield with five +1/+1 counters on it.\nWhenever Slurrk or another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on each creature you control that has a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20184,7 +20184,7 @@
         },
         {
             "id": "c8fcb117-3840-5111-ae06-24024c934ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53229b5c-20d9-4abb-b7be-fd58acdb4747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53229b5c-20d9-4abb-b7be-fd58acdb4747.jpg?1",
             "name": "Abomination of Llanowar",
             "text": "Vigilance, menace\nAbomination of Llanowar's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.",
             "colours": [
@@ -20224,7 +20224,7 @@
         },
         {
             "id": "9850d3e4-3788-5d89-85dc-10f5f5742435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31ad3a5-4e42-4f2c-badf-4cef2a39be41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31ad3a5-4e42-4f2c-badf-4cef2a39be41.jpg?1",
             "name": "Amareth, the Lustrous",
             "text": "Flying\nWhenever another permanent enters the battlefield under your control, look at the top card of your library. If it shares a card type with that permanent, you may reveal that card and put it into your hand.",
             "colours": [
@@ -20265,7 +20265,7 @@
         },
         {
             "id": "ff96aca5-7d64-5e7f-99e2-a6dda3f97daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750f26c2-d7ea-4d39-bef0-f1f84c631265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750f26c2-d7ea-4d39-bef0-f1f84c631265.jpg?1",
             "name": "Araumi of the Dead Tide",
             "text": "{T}, Exile cards from your graveyard equal to the number of opponents you have: Target creature card in your graveyard gains encore until end of turn. The encore cost is equal to its mana cost. (Exile the creature card and pay its mana cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -20305,7 +20305,7 @@
         },
         {
             "id": "3ed262af-85a7-53be-9290-98f74498db65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5643c-26d9-4ada-bc03-cafda0f64f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5643c-26d9-4ada-bc03-cafda0f64f40.jpg?1",
             "name": "Archelos, Lagoon Mystic",
             "text": "As long as Archelos, Lagoon Mystic is tapped, other permanents enter the battlefield tapped.\nAs long as Archelos is untapped, other permanents enter the battlefield untapped.",
             "colours": [
@@ -20347,7 +20347,7 @@
         },
         {
             "id": "fe930e86-1cbd-551b-9acf-6452f80536c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17aa3ad-8f84-400e-ad73-e73ebcd5a4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17aa3ad-8f84-400e-ad73-e73ebcd5a4b0.jpg?1",
             "name": "Averna, the Chaos Bloom",
             "text": "As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)",
             "colours": [
@@ -20389,7 +20389,7 @@
         },
         {
             "id": "7f2f9067-df5f-5353-a9af-d83493c371cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6c3f6e-3c46-47b2-abcc-8aeb2f12d2fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6c3f6e-3c46-47b2-abcc-8aeb2f12d2fa.jpg?1",
             "name": "Belbe, Corrupted Observer",
             "text": "At the beginning of each player's postcombat main phase, that player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)",
             "colours": [
@@ -20430,7 +20430,7 @@
         },
         {
             "id": "a0e80e89-63e3-5b8f-88ac-fbf7adf7f469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88418f5-8f75-4144-b8f6-e1e5009fa341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88418f5-8f75-4144-b8f6-e1e5009fa341.jpg?1",
             "name": "Bell Borca, Spectral Sergeant",
             "text": "Note the converted mana cost of each card as it's put into exile.\nBell Borca, Spectral Sergeant's power is equal to the greatest number noted for it this turn.\nAt the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -20470,7 +20470,7 @@
         },
         {
             "id": "4693e4e3-886e-57d2-92b6-04e9db178d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7954777c-34c1-43c2-83e2-db2dbb82329c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7954777c-34c1-43c2-83e2-db2dbb82329c.jpg?1",
             "name": "Blim, Comedic Genius",
             "text": "Flying\nWhenever Blim, Comedic Genius deals combat damage to a player, that player gains control of target permanent you control. Then each player loses life and discards cards equal to the number of permanents they control but don't own.",
             "colours": [
@@ -20509,7 +20509,7 @@
         },
         {
             "id": "1b5d31f2-fc2e-5217-bc8c-263b4b86c1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7502db-947b-49ca-968c-58ee83bd19b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7502db-947b-49ca-968c-58ee83bd19b3.jpg?1",
             "name": "Captain Vargus Wrath",
             "text": "Whenever Captain Vargus Wrath attacks, Pirates you control get +1/+1 until end of turn for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -20549,7 +20549,7 @@
         },
         {
             "id": "41fa0c57-cc60-5ebf-a68f-33e968a7c4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2c725-6133-4264-96ac-d80fe85b3632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2c725-6133-4264-96ac-d80fe85b3632.jpg?1",
             "name": "Colfenor, the Last Yew",
             "text": "Vigilance, reach\nWhenever Colfenor, the Last Yew or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.",
             "colours": [
@@ -20591,7 +20591,7 @@
         },
         {
             "id": "5b53ca44-d26f-5092-9598-0497f0c1f8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804a7bac-0425-4cab-817a-5cb3686ef5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804a7bac-0425-4cab-817a-5cb3686ef5bb.jpg?1",
             "name": "Ghen, Arcanum Weaver",
             "text": "{R}{W}{B}, {T}, Sacrifice an enchantment: Return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -20633,7 +20633,7 @@
         },
         {
             "id": "bfa34682-ed6d-59af-ad9e-1868624d8780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d14b74-437e-4421-b5da-efbad2e70adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d14b74-437e-4421-b5da-efbad2e70adb.jpg?1",
             "name": "Gnostro, Voice of the Crags",
             "text": "{T}: Choose one. X is the number of spells you've cast this turn.\n\u2022 Scry X.\n\u2022 Gnostro, Voice of the Crags deals X damage to target creature.\n\u2022 You gain X life.",
             "colours": [
@@ -20674,7 +20674,7 @@
         },
         {
             "id": "3588b4b8-9c57-5821-8420-908a3afc608d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ff4985-981c-4748-b6f4-5d0dab6c787b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ff4985-981c-4748-b6f4-5d0dab6c787b.jpg?1",
             "name": "Gor Muldrak, Amphinologist",
             "text": "You and permanents you control have protection from Salamanders.\nAt the beginning of your end step, each player who controls the fewest creatures creates a 4/3 blue Salamander Warrior creature token.",
             "colours": [
@@ -20714,7 +20714,7 @@
         },
         {
             "id": "74c6d5dc-3e25-5f73-9213-9d4b95827905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713cf745-c41a-4f37-94b3-1c5850b751f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713cf745-c41a-4f37-94b3-1c5850b751f4.jpg?1",
             "name": "Hamza, Guardian of Arashin",
             "text": "This spell costs {1} less to cast for each creature you control with a +1/+1 counter on it.\nCreature spells you cast cost {1} less to cast for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -20754,7 +20754,7 @@
         },
         {
             "id": "f0845468-53d5-5158-a234-ba7251777344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb5d3b3-d92f-4d2a-82cc-8cb166241dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb5d3b3-d92f-4d2a-82cc-8cb166241dc5.jpg?1",
             "name": "Hans Eriksson",
             "text": "Whenever Hans Eriksson attacks, reveal the top card of your library. If it's a creature card, put it onto the battlefield tapped and attacking defending player or a planeswalker they control. Otherwise, put that card into your hand. When you put a creature card onto the battlefield this way, it fights Hans Eriksson.",
             "colours": [
@@ -20794,7 +20794,7 @@
         },
         {
             "id": "05387126-ff2d-59b0-b7bc-2b05e6b8c50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d6f813-a1ff-49fe-9678-e0fcd12dea48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d6f813-a1ff-49fe-9678-e0fcd12dea48.jpg?1",
             "name": "Imoti, Celebrant of Bounty",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nSpells you cast with converted mana cost 6 or greater have cascade.",
             "colours": [
@@ -20834,7 +20834,7 @@
         },
         {
             "id": "7d2d6350-5ae5-5435-a773-05207066395f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b925277-89e7-4143-8985-46c2fe3aeb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b925277-89e7-4143-8985-46c2fe3aeb9c.jpg?1",
             "name": "Jared Carthalion, True Heir",
             "text": "When Jared Carthalion, True Heir enters the battlefield, target opponent becomes the monarch. You can't become the monarch this turn.\nIf damage would be dealt to Jared Carthalion while you're the monarch, prevent that damage and put that many +1/+1 counters on it.",
             "colours": [
@@ -20876,7 +20876,7 @@
         },
         {
             "id": "f92f2472-f08c-5007-8f53-b42f18bc4754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89552cac-5567-43f2-a566-be522f24c7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89552cac-5567-43f2-a566-be522f24c7b2.jpg?1",
             "name": "Juri, Master of the Revue",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Juri, Master of the Revue.\nWhen Juri dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -20916,7 +20916,7 @@
         },
         {
             "id": "e64848b0-cef8-5b52-9cea-6093cfe6d51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c614a61d-b988-40fb-9172-0f86a0e41997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c614a61d-b988-40fb-9172-0f86a0e41997.jpg?1",
             "name": "Kangee, Sky Warden",
             "text": "Flying, vigilance\nWhenever Kangee, Sky Warden attacks, attacking creatures with flying get +2/+0 until end of turn.\nWhenever Kangee blocks, blocking creatures with flying get +0/+2 until end of turn.",
             "colours": [
@@ -20956,7 +20956,7 @@
         },
         {
             "id": "272f6294-44b1-5836-95fd-a06335533556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d4b6e-44c3-4bf9-8edd-aebf97438f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d4b6e-44c3-4bf9-8edd-aebf97438f19.jpg?1",
             "name": "Kwain, Itinerant Meddler",
             "text": "{T}: Each player may draw a card, then each player who drew a card this way gains 1 life.",
             "colours": [
@@ -20996,7 +20996,7 @@
         },
         {
             "id": "8a5ea143-6c6a-57e9-959e-fdcefa9413e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913752eb-b446-41f8-9914-f78f981b042b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913752eb-b446-41f8-9914-f78f981b042b.jpg?1",
             "name": "Lathiel, the Bounteous Dawn",
             "text": "Lifelink\nAt the beginning of each end step, if you gained life this turn, distribute up to that many +1/+1 counters among any number of other target creatures.",
             "colours": [
@@ -21035,7 +21035,7 @@
         },
         {
             "id": "8a1e924e-229b-56b8-8019-a98bd434005e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed90b377-8f27-47fc-a004-0f84f4ad6490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed90b377-8f27-47fc-a004-0f84f4ad6490.jpg?1",
             "name": "Liesa, Shroud of Dusk",
             "text": "Rather than pay {2} for each previous time you've cast this spell from the command zone this game, pay 2 life that many times.\nFlying, lifelink\nWhenever a player casts a spell, they lose 2 life.",
             "colours": [
@@ -21074,7 +21074,7 @@
         },
         {
             "id": "3777b628-6807-51dc-855a-12224af0f4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7247d7-fa1d-4d40-8630-e1874e41996b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7247d7-fa1d-4d40-8630-e1874e41996b.jpg?1",
             "name": "Nevinyrral, Urborg Tyrant",
             "text": "Hexproof from artifacts, creatures, and enchantments\nWhen Nevinyrral, Urborg Tyrant enters the battlefield, create a tapped 2/2 black Zombie creature token for each creature that died this turn.\nWhen Nevinyrral dies, you may pay {1}. When you do, destroy all artifacts, creatures, and enchantments.",
             "colours": [
@@ -21116,7 +21116,7 @@
         },
         {
             "id": "0982ee5b-de24-5872-92dd-1daace8f4d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f46923-2ffe-4bf8-8f19-ed3b60665426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f46923-2ffe-4bf8-8f19-ed3b60665426.jpg?1",
             "name": "Nymris, Oona's Trickster",
             "text": "Flash\nFlying\nWhenever you cast your first spell during each opponent's turn, look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
             "colours": [
@@ -21156,7 +21156,7 @@
         },
         {
             "id": "116e48fa-0c35-5fe9-9fa2-1fad0aeef52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa7030c-e3b8-4ea1-b245-60432ca6e303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa7030c-e3b8-4ea1-b245-60432ca6e303.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "{T}: The player whose turn it is may end the turn. (Exile all spells and abilities from the stack. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -21198,7 +21198,7 @@
         },
         {
             "id": "be8d49a5-7c34-51c9-b291-5d72d599a3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465c1e86-e828-44a0-802e-1cbba356c524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465c1e86-e828-44a0-802e-1cbba356c524.jpg?1",
             "name": "Reyav, Master Smith",
             "text": "Whenever a creature you control that's enchanted or equipped attacks, that creature gains double strike until end of turn.",
             "colours": [
@@ -21238,7 +21238,7 @@
         },
         {
             "id": "f3c2611f-afdf-5fbb-b185-982f74ba9d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4899773-c501-45e5-bf1f-8d818788d61f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4899773-c501-45e5-bf1f-8d818788d61f.jpg?1",
             "name": "Thalisse, Reverent Medium",
             "text": "At the beginning of each end step, create X 1/1 white Spirit creature tokens with flying, where X is the number of tokens you created this turn.",
             "colours": [
@@ -21278,7 +21278,7 @@
         },
         {
             "id": "dc7cd5cb-fda1-5fa4-9843-a3886e0a8442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491e74d-07e6-4467-90db-c5cb2627877f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491e74d-07e6-4467-90db-c5cb2627877f.jpg?1",
             "name": "Tuya Bearclaw",
             "text": "Whenever Tuya Bearclaw attacks, it gets +X/+X until end of turn, where X is the greatest power among other creatures you control.",
             "colours": [
@@ -21318,7 +21318,7 @@
         },
         {
             "id": "acaf7712-434a-5a18-a1c9-1f92081a7ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403b8d9c-da2e-4902-b198-edfcf16aea7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403b8d9c-da2e-4902-b198-edfcf16aea7f.jpg?1",
             "name": "Yurlok of Scorch Thrash",
             "text": "Vigilance\nA player losing unspent mana causes that player to lose that much life.\n{1}, {T}: Each player adds {B}{R}{G}.",
             "colours": [
@@ -21360,7 +21360,7 @@
         },
         {
             "id": "b9140d40-6aa5-5315-a1e0-c4e055b10bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9323237-9457-4751-8176-c322c9f6f9be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9323237-9457-4751-8176-c322c9f6f9be.jpg?1",
             "name": "Zara, Renegade Recruiter",
             "text": "Flying\nWhenever Zara, Renegade Recruiter attacks, look at defending player's hand. You may put a creature card from it onto the battlefield under your control tapped and attacking that player or a planeswalker they control. Return that creature to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -21400,7 +21400,7 @@
         },
         {
             "id": "fbb705d4-6133-562a-83fc-daca5013496c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e65d75-7fe1-4804-8cfa-d7a42bacacae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e65d75-7fe1-4804-8cfa-d7a42bacacae.jpg?1",
             "name": "Akroma's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Creatures you control gain flying, vigilance, and double strike until end of turn.\n\u2022 Creatures you control gain lifelink, indestructible, and protection from all colors until end of turn.",
             "colours": [
@@ -21434,7 +21434,7 @@
         },
         {
             "id": "e17b353f-1bd1-52e1-a901-dcb8f09fcd54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd14d110-185d-4812-a992-902e7b0ab880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd14d110-185d-4812-a992-902e7b0ab880.jpg?1",
             "name": "Archon of Coronation",
             "text": "Flying\nWhen Archon of Coronation enters the battlefield, you become the monarch.\nAs long as you're the monarch, damage doesn't cause you to lose life.",
             "colours": [
@@ -21470,7 +21470,7 @@
         },
         {
             "id": "17f9cd9e-46fe-5d72-9ebf-e4ba6621d7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255917-c54d-4569-b6f9-88a0e16c9064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255917-c54d-4569-b6f9-88a0e16c9064.jpg?1",
             "name": "Armored Skyhunter",
             "text": "Flying\nWhenever Armored Skyhunter attacks, look at the top six cards of your library. You may put an Aura or Equipment card from among them onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control. Put the rest of those cards on the bottom of your library in a random order.",
             "colours": [
@@ -21507,7 +21507,7 @@
         },
         {
             "id": "9f63f232-d291-5f4f-840a-101cf9ab0323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5db772-5ced-485f-a559-81b4e41bbff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5db772-5ced-485f-a559-81b4e41bbff1.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -21541,7 +21541,7 @@
         },
         {
             "id": "5241d0f3-9356-56fe-a4eb-78cbeaf31c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059aef39-1d27-472e-8bb6-b6cd8dc8c45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059aef39-1d27-472e-8bb6-b6cd8dc8c45e.jpg?1",
             "name": "Court of Grace",
             "text": "When Court of Grace enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, create a 1/1 white Spirit creature token with flying. If you're the monarch, create a 4/4 white Angel creature token with flying instead.",
             "colours": [
@@ -21575,7 +21575,7 @@
         },
         {
             "id": "35227595-64ed-597d-a704-ca88b08dddc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8ca62e-a48c-4381-a100-7061a84d230e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8ca62e-a48c-4381-a100-7061a84d230e.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -21609,7 +21609,7 @@
         },
         {
             "id": "4841d914-ec0a-525a-9235-a01a8a8daf5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f50b6f-0049-4f2c-8a41-1345d1b88dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f50b6f-0049-4f2c-8a41-1345d1b88dae.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -21646,7 +21646,7 @@
         },
         {
             "id": "55402ce2-cf50-5acb-a895-6619552e43ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a307a1-d2b3-481b-92cd-14a2866a022d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a307a1-d2b3-481b-92cd-14a2866a022d.jpg?1",
             "name": "Promise of Tomorrow",
             "text": "Whenever a creature you control dies, exile it.\nAt the beginning of each end step, if you control no creatures, sacrifice Promise of Tomorrow and return all cards exiled with it to the battlefield under your control.",
             "colours": [
@@ -21680,7 +21680,7 @@
         },
         {
             "id": "57ec163e-2368-5a73-abef-f1851339ae58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02d7ad-51c1-4088-b55b-9cb2aa346dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02d7ad-51c1-4088-b55b-9cb2aa346dcb.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -21715,7 +21715,7 @@
         },
         {
             "id": "bd83e833-b993-5f36-ab96-3546fc401a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18fd49d-c91e-458e-9bf3-13724ec404f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18fd49d-c91e-458e-9bf3-13724ec404f4.jpg?1",
             "name": "Seraphic Greatsword",
             "text": "Equipped creature gets +2/+2.\nWhenever equipped creature attacks the player with the most life or tied for most life, create a 4/4 white Angel creature token with flying that's tapped and attacking that player.\nEquip {4}",
             "colours": [
@@ -21751,7 +21751,7 @@
         },
         {
             "id": "77b73017-2825-53d3-a000-b666f566fd26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528f9922-b0c3-410e-86ca-87495a4fbd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528f9922-b0c3-410e-86ca-87495a4fbd3d.jpg?1",
             "name": "Slash the Ranks",
             "text": "Destroy all creatures and planeswalkers except for commanders.",
             "colours": [
@@ -21785,7 +21785,7 @@
         },
         {
             "id": "d36682f6-cdfb-5389-a723-49a9be35f166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007f0aab-e4e1-48dd-b333-76dd5c7ebe67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007f0aab-e4e1-48dd-b333-76dd5c7ebe67.jpg?1",
             "name": "Soul of Eternity",
             "text": "Soul of Eternity's power and toughness are each equal to your life total.\nEncore {7}{W}{W}",
             "colours": [
@@ -21821,7 +21821,7 @@
         },
         {
             "id": "13f8f02e-4790-5862-83b9-440e6de052bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd33c0f5-5545-477a-9185-53c707983795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd33c0f5-5545-477a-9185-53c707983795.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -21855,7 +21855,7 @@
         },
         {
             "id": "3d4861f7-fa0a-5f35-bb0e-3c7da1660de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1dbbb8-c384-42fe-a9b3-ab94f18e360f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1dbbb8-c384-42fe-a9b3-ab94f18e360f.jpg?1",
             "name": "Triumphant Reckoning",
             "text": "Return all artifact, enchantment, and planeswalker cards from your graveyard to the battlefield.",
             "colours": [
@@ -21889,7 +21889,7 @@
         },
         {
             "id": "95692f70-b6be-5b17-9b74-1c0e4b77f333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b465a22b-6fea-4bf8-b290-fa3e1a4aa6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b465a22b-6fea-4bf8-b290-fa3e1a4aa6eb.jpg?1",
             "name": "Amphin Mutineer",
             "text": "When Amphin Mutineer enters the battlefield, exile up to one target non-Salamander creature. That creature's controller creates a 4/3 blue Salamander Warrior creature token.\nEncore {4}{U}{U}",
             "colours": [
@@ -21926,7 +21926,7 @@
         },
         {
             "id": "8adcb66a-79cd-54ff-b741-0014163140af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25532c00-d4c0-4f49-b306-6991e49d3c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25532c00-d4c0-4f49-b306-6991e49d3c4c.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -21960,7 +21960,7 @@
         },
         {
             "id": "9ad98a7e-b18a-5f9b-96c6-13985ed340d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0295f53a-0529-4809-9f57-0c3f747ca449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0295f53a-0529-4809-9f57-0c3f747ca449.jpg?1",
             "name": "Body of Knowledge",
             "text": "Body of Knowledge's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhenever Body of Knowledge is dealt damage, draw that many cards.",
             "colours": [
@@ -21996,7 +21996,7 @@
         },
         {
             "id": "4b20eacd-04cc-576e-a439-04b919f70cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c6f284-fc07-4849-8210-80f12f77f518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c6f284-fc07-4849-8210-80f12f77f518.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -22030,7 +22030,7 @@
         },
         {
             "id": "a80e8715-4688-52f7-8b7d-797ac61fe6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60d3606-6f90-43b4-b056-543f7245958f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60d3606-6f90-43b4-b056-543f7245958f.jpg?1",
             "name": "Court of Cunning",
             "text": "When Court of Cunning enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, any number of target players each mill two cards. If you're the monarch, each of those players mills ten cards instead.",
             "colours": [
@@ -22064,7 +22064,7 @@
         },
         {
             "id": "f28d126b-465c-5ecf-b778-055527dfd3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb642e0-a390-4079-b349-ff0ec29c610e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb642e0-a390-4079-b349-ff0ec29c610e.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -22098,7 +22098,7 @@
         },
         {
             "id": "e1aaa71d-c9fa-5aeb-9262-fcf933db3929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49d0990-2f3b-4fa9-a895-4148d65c3fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49d0990-2f3b-4fa9-a895-4148d65c3fff.jpg?1",
             "name": "Hullbreacher",
             "text": "Flash\nIf an opponent would draw a card except the first one they draw in each of their draw steps, instead you create a Treasure token.",
             "colours": [
@@ -22135,7 +22135,7 @@
         },
         {
             "id": "b66b75d8-3fa3-51ba-86c9-21670ac522be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850acddf-b3ec-4e6f-bd48-9d0a100d0df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850acddf-b3ec-4e6f-bd48-9d0a100d0df1.jpg?1",
             "name": "Laboratory Drudge",
             "text": "At the beginning of each end step, draw a card if you've cast a spell from a graveyard or activated an ability of a card in a graveyard this turn.",
             "colours": [
@@ -22172,7 +22172,7 @@
         },
         {
             "id": "06fa2550-a64d-5ae1-bcc2-abc2c7a2eaf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e351ec05-8c4d-4631-9dbf-7f85f664770b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e351ec05-8c4d-4631-9dbf-7f85f664770b.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's converted mana cost.",
             "colours": [
@@ -22206,7 +22206,7 @@
         },
         {
             "id": "9f22ea88-a94e-5654-98c7-8782f206be93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbba25f3-6258-43e7-a230-334de1c31dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbba25f3-6258-43e7-a230-334de1c31dc8.jpg?1",
             "name": "Mnemonic Deluge",
             "text": "Exile target instant or sorcery card from a graveyard. Copy that card three times. You may cast the copies without paying their mana costs. Exile Mnemonic Deluge.",
             "colours": [
@@ -22240,7 +22240,7 @@
         },
         {
             "id": "ef05f756-128e-59d5-b4fa-e48cb0bfc959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0e6ff7-eed1-4965-813f-00d92fb48a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0e6ff7-eed1-4965-813f-00d92fb48a1e.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U}",
             "colours": [
@@ -22276,7 +22276,7 @@
         },
         {
             "id": "9fcb6a1a-9d5f-516b-a8f8-59b5e28fbf47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab73a5-6c55-4c30-a965-8adf3dba2ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab73a5-6c55-4c30-a965-8adf3dba2ddd.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card.",
             "colours": [
@@ -22310,7 +22310,7 @@
         },
         {
             "id": "33d7199b-9b21-5459-8ec7-c0a804a3b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d313bc-2ae5-4f97-ae34-12da285d7fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d313bc-2ae5-4f97-ae34-12da285d7fa7.jpg?1",
             "name": "Sakashima's Protege",
             "text": "Flash\nCascade\nYou may have Sakashima's Protege enter the battlefield as a copy of any permanent that entered the battlefield this turn.",
             "colours": [
@@ -22346,7 +22346,7 @@
         },
         {
             "id": "d3d6b163-8f3e-5903-afc3-cf013460c433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d4d43-7a46-4f72-97a9-3958bf253a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d4d43-7a46-4f72-97a9-3958bf253a3a.jpg?1",
             "name": "Sakashima's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Target opponent chooses a creature they control. You gain control of it.\n\u2022 Choose a creature you control. Each other creature you control becomes a copy of that creature until end of turn.",
             "colours": [
@@ -22380,7 +22380,7 @@
         },
         {
             "id": "cb183b38-6074-5630-b5c6-8a67a010e49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d8061-e1f0-4bef-bf32-1e7358ae65b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d8061-e1f0-4bef-bf32-1e7358ae65b6.jpg?1",
             "name": "Sphinx of the Second Sun",
             "text": "Flying\nAt the beginning of your postcombat main phase, you get an additional beginning phase after this phase.",
             "colours": [
@@ -22416,7 +22416,7 @@
         },
         {
             "id": "d0980527-9733-5beb-a939-86b073fdfcbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068879c2-d923-414a-b2e8-0a80f2634865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068879c2-d923-414a-b2e8-0a80f2634865.jpg?1",
             "name": "Wrong Turn",
             "text": "Target opponent gains control of target creature.",
             "colours": [
@@ -22450,7 +22450,7 @@
         },
         {
             "id": "38904869-346f-5457-b269-0e7736472852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fcc6b0-778f-4dcd-874e-04549493a6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fcc6b0-778f-4dcd-874e-04549493a6ad.jpg?1",
             "name": "Court of Ambition",
             "text": "When Court of Ambition enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, each opponent loses 3 life unless they discard a card. If you're the monarch, instead each opponent loses 6 life unless they discard two cards.",
             "colours": [
@@ -22484,7 +22484,7 @@
         },
         {
             "id": "df7c81f1-5d60-50db-98ec-5c7054f68cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca318a56-f13e-46cb-819d-2cf8a2b16f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca318a56-f13e-46cb-819d-2cf8a2b16f0e.jpg?1",
             "name": "Cuombajj Witches",
             "text": "{T}: Cuombajj Witches deals 1 damage to any target and 1 damage to any target of an opponent's choice.",
             "colours": [
@@ -22521,7 +22521,7 @@
         },
         {
             "id": "521b70e2-1dba-5915-b2dc-268884f939c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5039df58-70f9-404e-8b18-d1169c77699c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5039df58-70f9-404e-8b18-d1169c77699c.jpg?1",
             "name": "Elvish Dreadlord",
             "text": "Deathtouch\nWhen Elvish Dreadlord dies, non-Elf creatures get -3/-3 until end of turn.\nEncore {5}{B}{B}",
             "colours": [
@@ -22558,7 +22558,7 @@
         },
         {
             "id": "3bbd4755-83d9-5ee1-a888-d2f783b90e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c8708-cd43-4f1e-b520-ef90cf2ba72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c8708-cd43-4f1e-b520-ef90cf2ba72d.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -22595,7 +22595,7 @@
         },
         {
             "id": "aca7ab3f-e930-5727-8428-1370348e6c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d627c457-a1c2-451c-9ed8-ea55547e5b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d627c457-a1c2-451c-9ed8-ea55547e5b0d.jpg?1",
             "name": "Necrotic Hex",
             "text": "Each player sacrifices six creatures. You create six tapped 2/2 black Zombie creature tokens.",
             "colours": [
@@ -22629,7 +22629,7 @@
         },
         {
             "id": "32577336-fc50-5c2d-b86d-0d8abc257e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30039-580d-4ad0-a913-54298ceec42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30039-580d-4ad0-a913-54298ceec42e.jpg?1",
             "name": "Nightshade Harvester",
             "text": "Whenever a land enters the battlefield under an opponent's control, that player loses 1 life. Put a +1/+1 counter on Nightshade Harvester.",
             "colours": [
@@ -22666,7 +22666,7 @@
         },
         {
             "id": "a1506388-0629-5c52-b6d0-a420986be656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b218531-9f5c-4ffb-9d2f-f2ead5b9f221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b218531-9f5c-4ffb-9d2f-f2ead5b9f221.jpg?1",
             "name": "Opposition Agent",
             "text": "Flash\nYou control your opponents while they're searching their libraries.\nWhile an opponent is searching their library, they exile each card they find. You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them.",
             "colours": [
@@ -22703,7 +22703,7 @@
         },
         {
             "id": "8f32d0e2-a43d-5165-a54d-5450647fd3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b092685-b0c8-4977-a86a-a167f79eb6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b092685-b0c8-4977-a86a-a167f79eb6b2.jpg?1",
             "name": "Plague Reaver",
             "text": "At the beginning of your end step, sacrifice each other creature you control.\nDiscard two cards, Sacrifice Plague Reaver: Choose target opponent. Return Plague Reaver to the battlefield under that player's control at the beginning of their next upkeep.",
             "colours": [
@@ -22739,7 +22739,7 @@
         },
         {
             "id": "bead20d3-1ecc-59b9-9fca-093296e6aeca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3387cfc-2dbe-409e-bfc7-b399f05a817d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3387cfc-2dbe-409e-bfc7-b399f05a817d.jpg?1",
             "name": "Profane Transfusion",
             "text": "Two target players exchange life totals. You create an X/X colorless Horror artifact creature token, where X is the difference between those players' life totals.",
             "colours": [
@@ -22773,7 +22773,7 @@
         },
         {
             "id": "f67b5428-8925-5bf3-b0d2-7cf995f2e4f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d28b259-a368-484d-898f-ef29219a0135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d28b259-a368-484d-898f-ef29219a0135.jpg?1",
             "name": "Rakshasa Debaser",
             "text": "Whenever Rakshasa Debaser attacks, put target creature card from defending player's graveyard onto the battlefield under your control.\nEncore {6}{B}{B}",
             "colours": [
@@ -22810,7 +22810,7 @@
         },
         {
             "id": "8d8e65cd-2db5-541f-b1a8-c0c714146ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4eaff0d-678b-47ab-915d-12e4fa43bb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4eaff0d-678b-47ab-915d-12e4fa43bb6b.jpg?1",
             "name": "Szat's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Each opponent sacrifices a creature they control with the greatest power.\n\u2022 Exile all cards from all opponents' graveyards, then create X 0/1 black Thrull creature tokens, where X is the greatest power among creature cards exiled this way.",
             "colours": [
@@ -22844,7 +22844,7 @@
         },
         {
             "id": "9003521c-3006-5d46-97a9-3fa8ebc5372b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1b4cec-68e0-4259-9be5-565d927017d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1b4cec-68e0-4259-9be5-565d927017d9.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -22878,7 +22878,7 @@
         },
         {
             "id": "801a9ddb-d28a-5e9a-9cf4-2b0f74c24aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6eaeb18-a7e3-4b7d-b2c2-04a66a5b89d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6eaeb18-a7e3-4b7d-b2c2-04a66a5b89d6.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -22912,7 +22912,7 @@
         },
         {
             "id": "06675080-e645-5f6d-a357-9c37ff6981c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e1c1c3-641a-4cd5-b46d-e03e5e529cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e1c1c3-641a-4cd5-b46d-e03e5e529cc7.jpg?1",
             "name": "Viscera Seer",
             "text": "Sacrifice a creature: Scry 1.",
             "colours": [
@@ -22949,7 +22949,7 @@
         },
         {
             "id": "4986aa22-de4e-5f16-88bd-f378f8071905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f984662-8fe0-42eb-8031-89c80315dede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f984662-8fe0-42eb-8031-89c80315dede.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -22983,7 +22983,7 @@
         },
         {
             "id": "8901c5ba-b621-5987-a368-8c111ec2e279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af03a68-0746-4d9c-8b91-1305e2751700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af03a68-0746-4d9c-8b91-1305e2751700.jpg?1",
             "name": "Aurora Phoenix",
             "text": "Flying\nCascade\nWhenever you cast a spell with cascade, return Aurora Phoenix from your graveyard to your hand.",
             "colours": [
@@ -23019,7 +23019,7 @@
         },
         {
             "id": "f21cf086-968e-547c-a619-e01fe14759a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ddab6f-0d13-4ec7-908d-54edb09b5727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ddab6f-0d13-4ec7-908d-54edb09b5727.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -23053,7 +23053,7 @@
         },
         {
             "id": "c714eda0-6f34-55ec-8edd-70e40a0663ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daee74d-aaf9-41bb-96f4-6d967cd4faf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daee74d-aaf9-41bb-96f4-6d967cd4faf7.jpg?1",
             "name": "Coercive Recruiter",
             "text": "Whenever Coercive Recruiter or another Pirate enters the battlefield under your control, gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and becomes a Pirate in addition to its other types.",
             "colours": [
@@ -23090,7 +23090,7 @@
         },
         {
             "id": "fd87f93a-8202-5dc6-a66a-99a371bf9f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b67b7-900e-4b8b-a977-a96a71e198e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b67b7-900e-4b8b-a977-a96a71e198e1.jpg?1",
             "name": "Court of Ire",
             "text": "When Court of Ire enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, Court of Ire deals 2 damage to any target. If you're the monarch, it deals 7 damage to that player or permanent instead.",
             "colours": [
@@ -23124,7 +23124,7 @@
         },
         {
             "id": "c342285a-96e7-5613-8e6e-af78a119a889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1282-01fd-48a0-929f-356f6d7e201e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1282-01fd-48a0-929f-356f6d7e201e.jpg?1",
             "name": "Emberwilde Captain",
             "text": "When Emberwilde Captain enters the battlefield, you become the monarch.\nWhenever an opponent attacks you while you're the monarch, Emberwilde Captain deals damage to that player equal to the number of cards in their hand.",
             "colours": [
@@ -23161,7 +23161,7 @@
         },
         {
             "id": "0bc87a32-a633-5b53-b4f1-48bd3ad55343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f03399-c9f8-40ca-bee5-07217788c186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f03399-c9f8-40ca-bee5-07217788c186.jpg?1",
             "name": "Flamekin Herald",
             "text": "Commander spells you cast have cascade.",
             "colours": [
@@ -23198,7 +23198,7 @@
         },
         {
             "id": "d67b1870-6e98-5b94-b921-a03c7b064f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7f618-5757-4611-8689-e34690404992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7f618-5757-4611-8689-e34690404992.jpg?1",
             "name": "Hellkite Courser",
             "text": "Flying\nWhen Hellkite Courser enters the battlefield, you may put a commander you own from the command zone onto the battlefield. It gains haste. Return it to the command zone at the beginning of the next end step.",
             "colours": [
@@ -23234,7 +23234,7 @@
         },
         {
             "id": "a4e8ee0f-69f7-564d-baed-72584bd0e10b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccce0e4-7f59-4ab8-86e7-1134226ed2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccce0e4-7f59-4ab8-86e7-1134226ed2de.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -23271,7 +23271,7 @@
         },
         {
             "id": "7002d446-9687-52b4-ab69-12540ea5986c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4d78f-af3e-4210-8886-231a40a6bd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4d78f-af3e-4210-8886-231a40a6bd98.jpg?1",
             "name": "Jeska's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Add {R} for each card in target opponent's hand.\n\u2022 Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -23305,7 +23305,7 @@
         },
         {
             "id": "c96fd644-4445-5bae-9ea8-5286fc93677a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77222431-9db0-4bc8-80be-7bfc7c48bc5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77222431-9db0-4bc8-80be-7bfc7c48bc5e.jpg?1",
             "name": "Port Razer",
             "text": "Whenever Port Razer deals combat damage to a player, untap each creature you control. After this combat phase, there is an additional combat phase.\nPort Razer can't attack a player it has already attacked this turn.",
             "colours": [
@@ -23342,7 +23342,7 @@
         },
         {
             "id": "5895f5b2-68b2-51db-9bf3-283abfd801ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6532b62a-3cc3-44ed-8eac-eaa091be3cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6532b62a-3cc3-44ed-8eac-eaa091be3cee.jpg?1",
             "name": "Soulfire Eruption",
             "text": "Choose any number of target creatures, planeswalkers, and/or players. For each of them, exile the top card of your library, then Soulfire Eruption deals damage equal to that card's converted mana cost to that permanent or player. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -23376,7 +23376,7 @@
         },
         {
             "id": "190177ea-f4dd-59fa-a912-0487e3fb96aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796d5e7-78b9-419a-a04a-fa3232bd2906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796d5e7-78b9-419a-a04a-fa3232bd2906.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -23410,7 +23410,7 @@
         },
         {
             "id": "611f7491-a6e6-5130-856e-ec939e265070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943aa774-e149-431b-804a-310cca6de006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943aa774-e149-431b-804a-310cca6de006.jpg?1",
             "name": "Wheel of Misfortune",
             "text": "Each player secretly chooses a number 0 or greater, then all players reveal those numbers simultaneously and determine the highest and lowest numbers revealed this way. Wheel of Misfortune deals damage equal to the highest number to each player who chose that number. Each player who didn't choose the lowest number discards their hand, then draws seven cards.",
             "colours": [
@@ -23444,7 +23444,7 @@
         },
         {
             "id": "1a8abb85-2cc4-55c0-8edd-79b21688d0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551afb4c-17e8-424f-ace3-b2c184b16b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551afb4c-17e8-424f-ace3-b2c184b16b2a.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -23480,7 +23480,7 @@
         },
         {
             "id": "08471660-8ffa-5eb8-9152-1e34a2123fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b345eb6f-ef2e-4d24-964c-252956031e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b345eb6f-ef2e-4d24-964c-252956031e4f.jpg?1",
             "name": "Apex Devastator",
             "text": "Cascade, cascade, cascade, cascade",
             "colours": [
@@ -23517,7 +23517,7 @@
         },
         {
             "id": "26b3a9dd-b257-5736-b9be-b84f19d48e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699ee8a9-a06c-4f95-9308-f8f7fb272568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699ee8a9-a06c-4f95-9308-f8f7fb272568.jpg?1",
             "name": "Biowaste Blob",
             "text": "Oozes you control get +1/+1.\nAt the beginning of your upkeep, if you control a commander, create a token that's a copy of Biowaste Blob.",
             "colours": [
@@ -23553,7 +23553,7 @@
         },
         {
             "id": "a716295b-3a09-586a-9e3c-59c3af7b924f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c4205a-959d-4da8-b228-791fa1eed07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c4205a-959d-4da8-b228-791fa1eed07a.jpg?1",
             "name": "Court of Bounty",
             "text": "When Court of Bounty enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, you may put a land card from your hand onto the battlefield. If you're the monarch, instead you may put a creature or land card from your hand onto the battlefield.",
             "colours": [
@@ -23587,7 +23587,7 @@
         },
         {
             "id": "82d5fc9c-ff48-598c-ad8a-97ae73bcd43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1c8567-9d47-433c-b8d6-101d43f62a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1c8567-9d47-433c-b8d6-101d43f62a9a.jpg?1",
             "name": "Dawnglade Regent",
             "text": "When Dawnglade Regent enters the battlefield, you become the monarch.\nAs long as you're the monarch, permanents you control have hexproof.",
             "colours": [
@@ -23623,7 +23623,7 @@
         },
         {
             "id": "83e0b92d-fc7e-5540-b644-d656e8bb80da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8bf526-1260-40a1-b007-10ff9340f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8bf526-1260-40a1-b007-10ff9340f10b.jpg?1",
             "name": "Fyndhorn Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -23660,7 +23660,7 @@
         },
         {
             "id": "a7829b39-4b1c-5d49-9b56-f78d51140ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3ae08c-aa65-441e-a1cd-8bcb8bda5e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3ae08c-aa65-441e-a1cd-8bcb8bda5e33.jpg?1",
             "name": "Immaculate Magistrate",
             "text": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
             "colours": [
@@ -23697,7 +23697,7 @@
         },
         {
             "id": "c2129743-d75b-51fc-92fc-b7850fe75715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98793-8bc0-419b-a1a9-7360f370bcdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98793-8bc0-419b-a1a9-7360f370bcdf.jpg?1",
             "name": "Kamahl's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Until end of turn, any number of target lands you control become 1/1 Elemental creatures with vigilance, indestructible, and haste. They're still lands.\n\u2022 Choose target creature you don't control. Each creature you control deals damage equal to its power to that creature.",
             "colours": [
@@ -23731,7 +23731,7 @@
         },
         {
             "id": "95cfab69-435d-57f5-bfc3-9c0f890a2cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3eec2c0-dfe4-489a-a3e3-1bdb94707305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3eec2c0-dfe4-489a-a3e3-1bdb94707305.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -23767,7 +23767,7 @@
         },
         {
             "id": "9e1a223e-5adc-5c12-a856-969e729d870d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c861f78-c04a-41a9-bfca-54f22656973f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c861f78-c04a-41a9-bfca-54f22656973f.jpg?1",
             "name": "Magus of the Order",
             "text": "{G}, {T}, Sacrifice Magus of the Order and another green creature: Search your library for a green creature card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -23804,7 +23804,7 @@
         },
         {
             "id": "b6d0578d-7895-54e3-bf09-f5848cc8e1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa9a70-1221-4dba-8c2c-9872913021cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa9a70-1221-4dba-8c2c-9872913021cd.jpg?1",
             "name": "Reshape the Earth",
             "text": "Search your library for up to ten land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -23838,7 +23838,7 @@
         },
         {
             "id": "43575fb6-03dc-5c19-a060-9c76e97e799d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bea124-3241-4c0a-8863-a2e603c66126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bea124-3241-4c0a-8863-a2e603c66126.jpg?1",
             "name": "Rootweaver Druid",
             "text": "When Rootweaver Druid enters the battlefield, each opponent may search their library for up to three basic land cards. They each put one of those cards onto the battlefield tapped under your control and the rest onto the battlefield tapped under their control. Then each player who searched their library this way shuffles it.",
             "colours": [
@@ -23875,7 +23875,7 @@
         },
         {
             "id": "4d0acc8c-96c6-568d-9e1f-7db90feec15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5ffa3d-ecff-457f-9216-f4e8d3202536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5ffa3d-ecff-457f-9216-f4e8d3202536.jpg?1",
             "name": "Sweet-Gum Recluse",
             "text": "Flash\nCascade\nReach\nWhen Sweet-Gum Recluse enters the battlefield, put three +1/+1 counters on each of any number of target creatures that entered the battlefield this turn.",
             "colours": [
@@ -23911,7 +23911,7 @@
         },
         {
             "id": "a2f30516-1d70-58cc-93c1-6166ef52334f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9037cf0e-6e5f-455f-941c-b909a03e770f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9037cf0e-6e5f-455f-941c-b909a03e770f.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -23945,7 +23945,7 @@
         },
         {
             "id": "e9dd7f93-cf24-50d9-aabf-c5094f6f77a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607d5bb1-001a-451a-8021-434f7c0eda93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607d5bb1-001a-451a-8021-434f7c0eda93.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014\n\u2022 Boros Charm deals 4 damage to target player or planeswalker.\n\u2022 Permanents you control gain indestructible until end of turn.\n\u2022 Target creature gains double strike until end of turn.",
             "colours": [
@@ -23981,7 +23981,7 @@
         },
         {
             "id": "089ecf05-d207-5b14-adb5-fdb44253bd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ddfce6-5b8c-4ce1-a329-6a4a4576ca9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ddfce6-5b8c-4ce1-a329-6a4a4576ca9c.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -24021,7 +24021,7 @@
         },
         {
             "id": "cc5a2db8-d84d-50b1-817a-e361018de80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40924da3-c974-4b37-ad35-e7d8e4cd3d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40924da3-c974-4b37-ad35-e7d8e4cd3d4a.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -24051,7 +24051,7 @@
         },
         {
             "id": "d67ea288-4eb1-50a4-8c7e-02a25191c4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d90634-df3f-470b-aa1e-833a3b7b42f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d90634-df3f-470b-aa1e-833a3b7b42f5.jpg?1",
             "name": "Bladegriff Prototype",
             "text": "Flying\nWhenever Bladegriff Prototype deals combat damage to a player, destroy target nonland permanent of that player's choice that one of your opponents controls.",
             "colours": [],
@@ -24084,7 +24084,7 @@
         },
         {
             "id": "c8f1705a-793d-569c-9f00-d8f598fa4b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dddd41-ae59-4e5e-bac5-3695ba09edfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dddd41-ae59-4e5e-bac5-3695ba09edfd.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -24117,7 +24117,7 @@
         },
         {
             "id": "49e5fa5f-8051-5b23-9327-e4c6e0ff9df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f520601f-c092-4f83-9c21-66e999a01c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f520601f-c092-4f83-9c21-66e999a01c16.jpg?1",
             "name": "Commander's Plate",
             "text": "Equipped creature gets +3/+3 and has protection from each color that's not in your commander's color identity.\nEquip commander {3}\nEquip {5}",
             "colours": [],
@@ -24149,7 +24149,7 @@
         },
         {
             "id": "01462197-c897-5e29-8401-ec5b71dd81f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e75bf0-7f26-4852-b9e8-9576773ce78a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e75bf0-7f26-4852-b9e8-9576773ce78a.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -24179,7 +24179,7 @@
         },
         {
             "id": "50350f43-4c4c-5153-9669-2b979c784539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba7f1a7-5e3a-4567-8f4e-176f6322f4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba7f1a7-5e3a-4567-8f4e-176f6322f4a8.jpg?1",
             "name": "Horizon Stone",
             "text": "If you would lose unspent mana, that mana becomes colorless instead.",
             "colours": [],
@@ -24209,7 +24209,7 @@
         },
         {
             "id": "7af2e34e-5ca7-525d-8a74-ec7a74dd7d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c44abab-85ff-4196-a739-8e363df84aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c44abab-85ff-4196-a739-8e363df84aef.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -24239,7 +24239,7 @@
         },
         {
             "id": "fc096036-c5a4-5aa7-92b3-3146fbbcb92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9fbe2-3961-4096-aec5-f5358fa4b9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9fbe2-3961-4096-aec5-f5358fa4b9fc.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -24269,7 +24269,7 @@
         },
         {
             "id": "95f30b32-1d90-5bfd-8ee9-4ac6cbe1670a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2730b56a-47b9-4042-bf5b-463392807f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2730b56a-47b9-4042-bf5b-463392807f36.jpg?1",
             "name": "Phyrexian Triniform",
             "text": "When Phyrexian Triniform dies, create three 3/3 colorless Golem artifact creature tokens.\nEncore {1}2",
             "colours": [],
@@ -24303,7 +24303,7 @@
         },
         {
             "id": "fbd5b0a7-956d-592d-b164-b441e7e50a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc00c6-5df2-4953-95c2-6c79dc86f409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc00c6-5df2-4953-95c2-6c79dc86f409.jpg?1",
             "name": "Rings of Brighthearth",
             "text": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [],
@@ -24333,7 +24333,7 @@
         },
         {
             "id": "94c4d72b-260c-599d-a53f-e1670c6ad6bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3826d13f-e10f-4201-b680-51f826ff4ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3826d13f-e10f-4201-b680-51f826ff4ca9.jpg?1",
             "name": "Scroll Rack",
             "text": "{1}, {T}: Exile any number of cards from your hand face down. Put that many cards from the top of your library into your hand. Then look at the exiled cards and put them on top of your library in any order.",
             "colours": [],
@@ -24363,7 +24363,7 @@
         },
         {
             "id": "30a1baad-4ff6-513b-beb4-60ca98eda8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21fc27-42d0-456a-9882-34d7f404270b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21fc27-42d0-456a-9882-34d7f404270b.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -24393,7 +24393,7 @@
         },
         {
             "id": "d706d944-2f74-507b-a3e2-c1e0679a3148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea92a1b-1340-4777-9452-840e0aa9332d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea92a1b-1340-4777-9452-840e0aa9332d.jpg?1",
             "name": "Staff of Domination",
             "text": "{1}: Untap Staff of Domination.\n{2}, {T}: You gain 1 life.\n{3}, {T}: Untap target creature.\n{4}, {T}: Tap target creature.\n{5}, {T}: Draw a card.",
             "colours": [],
@@ -24423,7 +24423,7 @@
         },
         {
             "id": "02d6d445-1ac3-5dad-a9c5-0782fd513acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b216-d383-4212-981e-5bc277c962a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b216-d383-4212-981e-5bc277c962a9.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -24455,7 +24455,7 @@
         },
         {
             "id": "f8475342-6484-5974-aa45-556f101d9d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699f796-4721-4c2a-8834-ea2b2b5b74c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699f796-4721-4c2a-8834-ea2b2b5b74c7.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -24485,7 +24485,7 @@
         },
         {
             "id": "9c10290a-098f-5b03-a868-23264d42b0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dc9b78-d1c0-4473-acfc-75825a7f9bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dc9b78-d1c0-4473-acfc-75825a7f9bb8.jpg?1",
             "name": "Command Beacon",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Command Beacon: Put your commander into your hand from the command zone.",
             "colours": [],
@@ -24515,7 +24515,7 @@
         },
         {
             "id": "bffcebef-8cf7-5851-85cc-628a0f8da4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148abd94-e752-4394-abce-21d594318b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148abd94-e752-4394-abce-21d594318b41.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -24546,7 +24546,7 @@
         },
         {
             "id": "6b394450-2f23-5327-908a-f0d8a662908f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06906eb-a417-411d-bc66-854c9cf8056d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06906eb-a417-411d-bc66-854c9cf8056d.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -24576,7 +24576,7 @@
         },
         {
             "id": "73fcc9d5-37d3-5c5a-9878-f40f21a671f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb789935-b0ba-427c-a0d5-93b006a28312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb789935-b0ba-427c-a0d5-93b006a28312.jpg?1",
             "name": "Opal Palace",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
             "colours": [],
@@ -24606,7 +24606,7 @@
         },
         {
             "id": "5c3247c9-fce4-5fd3-ac16-dea8d30373ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c198ffd-50c8-46ae-a4bd-75c9d39f40de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c198ffd-50c8-46ae-a4bd-75c9d39f40de.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -24636,7 +24636,7 @@
         },
         {
             "id": "10559477-0100-59df-95c9-5c209acd8299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5888b82e-79e0-4b8e-9c16-07dddc2bfeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5888b82e-79e0-4b8e-9c16-07dddc2bfeff.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -24669,7 +24669,7 @@
         },
         {
             "id": "dcfbc284-5de9-56c0-9ae6-67ddb82dfde0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3f701-4783-42ef-bfe5-20606ada49f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3f701-4783-42ef-bfe5-20606ada49f7.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -24699,7 +24699,7 @@
         },
         {
             "id": "154a9e7a-4a5f-52d6-aa96-1218e7366e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16e9306-79bc-451a-9046-6a0f8d4b9606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16e9306-79bc-451a-9046-6a0f8d4b9606.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -24732,7 +24732,7 @@
         },
         {
             "id": "1ff6b267-c056-5a3c-a583-e05f59613818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92b751-6162-4293-953b-ec7190309a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92b751-6162-4293-953b-ec7190309a6a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -24763,7 +24763,7 @@
         },
         {
             "id": "8f375f11-3623-5815-9a46-cac6a94adc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0efa5-6559-446b-a4d9-47585f6e94fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0efa5-6559-446b-a4d9-47585f6e94fb.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -24796,7 +24796,7 @@
         },
         {
             "id": "6c5c10a6-231c-56cd-b6a1-66a64104005a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bd7a70-0cd1-48f2-96b6-7869c003a8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bd7a70-0cd1-48f2-96b6-7869c003a8c7.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -24829,7 +24829,7 @@
         },
         {
             "id": "85838ea7-58ee-55b4-901c-813223f550c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695a48e-391a-4ac1-93d6-35373e13718f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695a48e-391a-4ac1-93d6-35373e13718f.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -24862,7 +24862,7 @@
         },
         {
             "id": "a8f63e24-9659-5bf3-a0f4-8d904315a5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79793d28-64e4-4372-a0f7-468264c554a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79793d28-64e4-4372-a0f7-468264c554a0.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -24892,7 +24892,7 @@
         },
         {
             "id": "0f8e79b8-c429-5e9d-bb51-849c114bf5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb8d03e-e1d2-451e-97a8-141082f92501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb8d03e-e1d2-451e-97a8-141082f92501.jpg?1",
             "name": "Mana Confluence",
             "text": "",
             "colours": [],
@@ -24919,7 +24919,7 @@
         },
         {
             "id": "3bf1d039-6a10-53db-a78f-74326fed49e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d6256a-42b5-40f8-92e6-878d7002768f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d6256a-42b5-40f8-92e6-878d7002768f.jpg?1",
             "name": "Sengir, the Dark Baron",
             "text": "",
             "colours": [
@@ -24958,7 +24958,7 @@
         },
         {
             "id": "73b213cd-451a-5b18-a272-8f776c0763d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c65b6a-9c63-4604-b7db-d75772799616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c65b6a-9c63-4604-b7db-d75772799616.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -24993,7 +24993,7 @@
         },
         {
             "id": "6d497450-2c88-5142-a03c-dbbe74227ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430ed737-b918-4485-a623-e781c0beb67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430ed737-b918-4485-a623-e781c0beb67b.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -25028,7 +25028,7 @@
         },
         {
             "id": "afdf1b42-a3f9-50a2-bdc1-3fdb2f1992ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e580cb-6092-48b7-ba3e-d64ec28860da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e580cb-6092-48b7-ba3e-d64ec28860da.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -25063,7 +25063,7 @@
         },
         {
             "id": "20871e74-cf51-5956-8184-09ff568097a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0a6832-677f-4226-bd8d-f93eeeffd02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0a6832-677f-4226-bd8d-f93eeeffd02d.jpg?1",
             "name": "Salamander Warrior",
             "text": "",
             "colours": [
@@ -25099,7 +25099,7 @@
         },
         {
             "id": "54bad504-6cbd-5cb9-b16b-a1d6a04c248b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3042b-784c-4006-9bf1-60a323e60c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3042b-784c-4006-9bf1-60a323e60c5c.jpg?1",
             "name": "Thrull",
             "text": "",
             "colours": [
@@ -25134,7 +25134,7 @@
         },
         {
             "id": "1822997f-1ab6-5ff4-81ce-5d9fce80086e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d62c8ad-af51-493c-aef1-fe7774156d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d62c8ad-af51-493c-aef1-fe7774156d4b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -25169,7 +25169,7 @@
         },
         {
             "id": "fc7beddd-3df3-5984-a6e3-c59fdcac7ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f350ecf-67fa-49c8-a47d-9e5573851d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f350ecf-67fa-49c8-a47d-9e5573851d62.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -25204,7 +25204,7 @@
         },
         {
             "id": "f4dab64a-6da3-510f-b9d3-824abba40954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2aea59-c5f1-4927-8534-2215ef79bec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2aea59-c5f1-4927-8534-2215ef79bec7.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -25240,7 +25240,7 @@
         },
         {
             "id": "cf9d2b91-1654-5beb-9411-47cb73ebbb3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -25272,7 +25272,7 @@
         },
         {
             "id": "1bd3ecd2-7048-548f-ae5a-6410354766b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [],
@@ -25304,7 +25304,7 @@
         },
         {
             "id": "1657233e-c9e1-54ff-aa5a-6e2e2846be42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661cbde4-9444-4259-b2cf-7c8f9814a071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661cbde4-9444-4259-b2cf-7c8f9814a071.jpg?1",
             "name": "Rock",
             "text": "",
             "colours": [],
@@ -25335,7 +25335,7 @@
         },
         {
             "id": "6b23ba7a-3a1a-57fe-8492-a65c078a4d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284ec798-2725-4741-8748-578c259d0623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284ec798-2725-4741-8748-578c259d0623.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -25366,7 +25366,7 @@
         },
         {
             "id": "6fb54d70-bb1b-58bd-9cfc-36b142373be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1420c92f-a3f5-461a-b342-3708fa2212d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1420c92f-a3f5-461a-b342-3708fa2212d7.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -25394,7 +25394,7 @@
         },
         {
             "id": "3b337520-35b7-5f89-ac00-459637962b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7f3fc9-35f1-4b8c-b02b-494c71f31107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7f3fc9-35f1-4b8c-b02b-494c71f31107.jpg?1",
             "name": "The Monarch",
             "text": "",
             "colours": [],
@@ -25422,7 +25422,7 @@
         },
         {
             "id": "e3ee3e66-6fe5-56ca-b82b-317d6bea3beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b2c60-c995-441a-a3d6-20220d6cb7f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b2c60-c995-441a-a3d6-20220d6cb7f1.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -25456,7 +25456,7 @@
         },
         {
             "id": "9a28c20d-86fe-57ac-a3c3-ab330ed62190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b4c4d7-5b53-417a-a61b-df56eec4a274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b4c4d7-5b53-417a-a61b-df56eec4a274.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -25490,7 +25490,7 @@
         },
         {
             "id": "a97eeb64-a72f-5e72-bc3f-9be5896404cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274e711-42fd-489e-809d-77d3bce24422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274e711-42fd-489e-809d-77d3bce24422.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -25524,7 +25524,7 @@
         },
         {
             "id": "8903fa50-695b-57a5-8f42-acdb65adce94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d59ee8-446e-427f-ac88-53f5fa378384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d59ee8-446e-427f-ac88-53f5fa378384.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -25558,7 +25558,7 @@
         },
         {
             "id": "cf393d4e-6e10-54a0-8923-a5e8f31bd3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d90039-6e75-4c76-893d-cd1686a36be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d90039-6e75-4c76-893d-cd1686a36be9.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -25592,7 +25592,7 @@
         },
         {
             "id": "17970de2-7d33-583c-9f8e-ad8e4842225b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d495a-b4b7-4119-ae2d-5b602a0b309f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d495a-b4b7-4119-ae2d-5b602a0b309f.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -25626,7 +25626,7 @@
         },
         {
             "id": "a26835e5-4e0d-56b4-aa70-d79f8ddb1ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a2d72-595e-4212-837b-07445a2175bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a2d72-595e-4212-837b-07445a2175bf.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -25660,7 +25660,7 @@
         },
         {
             "id": "dcc3c1d2-e043-52d1-9a69-8a053a2d3137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08074778-ce6d-4a49-a1fc-1391d55e89be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08074778-ce6d-4a49-a1fc-1391d55e89be.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -25694,7 +25694,7 @@
         },
         {
             "id": "cf04eb05-5d99-5015-921c-d7df230b0341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f834ec3-0901-455a-a32d-aa5d3fcdb247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f834ec3-0901-455a-a32d-aa5d3fcdb247.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/CONX.json
+++ b/Assets/Resources/Sets/CONX.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1193bca9-122b-5360-b8d8-bf2a1d4cc45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e86a42-cc53-4731-819a-e76f203a742a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e86a42-cc53-4731-819a-e76f203a742a.jpg?1",
             "name": "Aerie Mystics",
             "text": "Flying\n{1}{G}{U}: Creatures you control gain shroud until end of turn.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "45566024-0e50-54fc-8255-130ad8ec4f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b817f7-ae05-4d31-8a2c-29d8082b4132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b817f7-ae05-4d31-8a2c-29d8082b4132.jpg?1",
             "name": "Asha's Favor",
             "text": "Enchant creature\nEnchanted creature has flying, first strike, and vigilance.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "8b0abea3-3bc5-5182-87a0-9ceae30db938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60301dbd-40d1-4af8-8e2b-797febfa859f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60301dbd-40d1-4af8-8e2b-797febfa859f.jpg?1",
             "name": "Aven Squire",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "11b45ee3-86f5-592a-a427-21b2934d8d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb032cd3-96a4-4cef-bb89-0843f2ed8189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb032cd3-96a4-4cef-bb89-0843f2ed8189.jpg?1",
             "name": "Aven Trailblazer",
             "text": "Flying\nDomain Aven Trailblazer's toughness is equal to the number of basic land types among lands you control.",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "97ab0a82-618d-5ae6-a8c5-3c70e5cd7ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c404e8-1241-4675-b259-fbbf1dba15c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c404e8-1241-4675-b259-fbbf1dba15c4.jpg?1",
             "name": "Celestial Purge",
             "text": "Remove target black or red permanent from the game.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "18bf9754-6218-5b93-990b-12ed61d08aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd20150c-ae49-457d-9f64-b72160745ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd20150c-ae49-457d-9f64-b72160745ff9.jpg?1",
             "name": "Court Homunculus",
             "text": "Court Homunculus gets +1/+1 as long as you control another artifact.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "9e83dce9-c047-5596-b580-7927ee42dd12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7162e5-8c56-457e-91eb-b8ae4d1b6adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7162e5-8c56-457e-91eb-b8ae4d1b6adb.jpg?1",
             "name": "Darklit Gargoyle",
             "text": "Flying\n{B}: Darklit Gargoyle gets +2/-1 until end of turn.",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "c7dea9e0-1826-5768-acc8-c2ec7d3fcf46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a8e0b-bee8-4b0d-b671-a5d8084d82ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a8e0b-bee8-4b0d-b671-a5d8084d82ee.jpg?1",
             "name": "Gleam of Resistance",
             "text": "Creatures you control get +1/+2 until end of turn. Untap those creatures.\nBasic landcycling {1}{W} ({1}{W}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "98b03e4e-1134-5bed-9992-a1449a3f3b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec609036-dfbf-47de-9a3a-762aea4196d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec609036-dfbf-47de-9a3a-762aea4196d4.jpg?1",
             "name": "Lapse of Certainty",
             "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "79555f4f-9bf9-57ea-aedd-21da59ce1d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9801e68-9a03-491f-be23-f0b830c4a0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9801e68-9a03-491f-be23-f0b830c4a0c5.jpg?1",
             "name": "Mark of Asylum",
             "text": "Prevent all noncombat damage that would be dealt to creatures you control.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "ae962ce9-8f56-5b1e-8dde-7794fef61227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4201385f-6f74-4e3d-aafb-0eff82cb24c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4201385f-6f74-4e3d-aafb-0eff82cb24c1.jpg?1",
             "name": "Martial Coup",
             "text": "Put X 1/1 white Soldier creature tokens into play. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "fbc8fc63-d6a7-57fd-9c64-12f819b41e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b3eec-7420-45fa-8750-7f01028836d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b3eec-7420-45fa-8750-7f01028836d3.jpg?1",
             "name": "Mirror-Sigil Sergeant",
             "text": "Trample\nAt the beginning of your upkeep, if you control a blue permanent, you may put a token into play that's a copy of Mirror-Sigil Sergeant.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "24eaccac-1788-573e-9e11-5be75576ae0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49096592-5bd8-4db7-b38b-dcb5dea8c088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49096592-5bd8-4db7-b38b-dcb5dea8c088.jpg?1",
             "name": "Nacatl Hunt-Pride",
             "text": "Vigilance\n{R}, {T}: Target creature can't block this turn.\n{G}, {T}: Target creature blocks this turn if able.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "586745fd-fdfe-533c-bc0a-e26bf597fd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c4772-fa03-4b71-a95e-1ad8466d25da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c4772-fa03-4b71-a95e-1ad8466d25da.jpg?1",
             "name": "Paragon of the Amesha",
             "text": "First strike\n{W}{U}{B}{R}{G}: Until end of turn, Paragon of the Amesha becomes an Angel, gets +3/+3, and gains flying and lifelink.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "1d9219ed-87ea-5d7c-9e1e-61c430a13238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7a8b1-b98e-483a-87a4-73bd831c03d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7a8b1-b98e-483a-87a4-73bd831c03d4.jpg?1",
             "name": "Path to Exile",
             "text": "Remove target creature from the game. Its controller may search his or her library for a basic land card, put that card into play tapped, then shuffle his or her library.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "c7c090ed-f44a-54fa-9abd-8edff9061721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f4f8d-2191-4743-aac6-cdcb4a68379c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f4f8d-2191-4743-aac6-cdcb4a68379c.jpg?1",
             "name": "Rhox Meditant",
             "text": "When Rhox Meditant comes into play, if you control a green permanent, draw a card.",
             "colours": [
@@ -554,7 +554,7 @@
         },
         {
             "id": "e09e59be-cf86-563e-a33f-ef1b394b45b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg?1",
             "name": "Scepter of Dominance",
             "text": "{W}, {T}: Tap target permanent.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "eacbf3ae-50e2-5622-891b-64bb949d101e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c451f63-2827-49fe-9d1d-87c87f7f5f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c451f63-2827-49fe-9d1d-87c87f7f5f8d.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you play an enchantment spell, put a 4/4 white Angel creature token with flying into play.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "83275a85-b57b-5002-a8a8-0a13215f32ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ec1486-900b-4763-9b5b-390cb00aff02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ec1486-900b-4763-9b5b-390cb00aff02.jpg?1",
             "name": "Valiant Guard",
             "text": "",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "62857712-0612-5df1-802c-27218f013fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fc82-fc5a-4f60-bcd6-363c2deb769d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fc82-fc5a-4f60-bcd6-363c2deb769d.jpg?1",
             "name": "Wall of Reverence",
             "text": "Defender, flying\nAt the end of your turn, you may gain life equal to the power of target creature you control.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "09ba2ff2-86b2-573c-b795-5bc831359bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e324d70f-a6ca-4003-8420-83035fd4cd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e324d70f-a6ca-4003-8420-83035fd4cd00.jpg?1",
             "name": "Brackwater Elemental",
             "text": "When Brackwater Elemental attacks or blocks, sacrifice it at end of turn.\nUnearth {2}{U} ({2}{U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "64e5d197-29d2-5658-8f93-9f3636b717e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a110be3-93ec-40ef-94a6-e4c43f1ce211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a110be3-93ec-40ef-94a6-e4c43f1ce211.jpg?1",
             "name": "Constricting Tendrils",
             "text": "Target creature gets -3/-0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "b63b5ddc-b6cf-590e-b6c2-5e2a799506d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e58e8-cb01-49b0-89b7-26536eb44e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e58e8-cb01-49b0-89b7-26536eb44e97.jpg?1",
             "name": "Controlled Instincts",
             "text": "Enchant red or green creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "4aff25df-63c5-5d42-8233-1637a0c3db01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7963ff52-1897-4f62-a91d-b0eaf155fce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7963ff52-1897-4f62-a91d-b0eaf155fce9.jpg?1",
             "name": "Cumber Stone",
             "text": "Creatures your opponents control get -1/-0.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "a8949060-7828-5c80-903c-4eda1069b81d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def637cb-40b2-4715-9b43-872c8f9aaabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def637cb-40b2-4715-9b43-872c8f9aaabe.jpg?1",
             "name": "Esperzoa",
             "text": "Flying\nAt the beginning of your upkeep, return an artifact you control to its owner's hand.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "03eb8da5-beb8-5104-b45d-dc8cc67972cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a056c-1e38-416b-bf01-2a1762b08020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a056c-1e38-416b-bf01-2a1762b08020.jpg?1",
             "name": "Ethersworn Adjudicator",
             "text": "Flying\n{1}{W}{B}, {T}: Destroy target creature or enchantment.\n{2}{U}: Untap Ethersworn Adjudicator.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "9db55084-d9ba-55f2-b71c-7f22f9d710c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d350ebd7-afcf-4d67-8173-b07cad3fa9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d350ebd7-afcf-4d67-8173-b07cad3fa9bc.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist comes into play, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "33ca8028-3847-5d59-b522-01676fce3204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46acbabc-9d0a-4fba-9604-7d131c22cdeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46acbabc-9d0a-4fba-9604-7d131c22cdeb.jpg?1",
             "name": "Frontline Sage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "613ba1f2-f9a1-51b7-9268-1eb5cd0911f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48352b88-857d-4386-83c6-0e047d11c15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48352b88-857d-4386-83c6-0e047d11c15b.jpg?1",
             "name": "Grixis Illusionist",
             "text": "{T}: Target land you control becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -999,7 +999,7 @@
         },
         {
             "id": "4c97d231-a316-54c1-bcea-2d1c4f0b99d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb380a5a-a3f9-42fb-ac5c-f54afa3c1079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb380a5a-a3f9-42fb-ac5c-f54afa3c1079.jpg?1",
             "name": "Inkwell Leviathan",
             "text": "Islandwalk, trample, shroud",
             "colours": [
@@ -1034,7 +1034,7 @@
         },
         {
             "id": "0744e381-5572-5941-a3e3-8b996c531908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252482b2-aaa7-49f3-af8c-30923ca98994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252482b2-aaa7-49f3-af8c-30923ca98994.jpg?1",
             "name": "Master Transmuter",
             "text": "{U}, {T}, Return an artifact you control to its owner's hand: You may put an artifact card from your hand into play.",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "3fda44a8-4712-54e7-8e98-dd7209d414a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36cd0c3-1955-41b1-9a9c-b30b31a2f094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36cd0c3-1955-41b1-9a9c-b30b31a2f094.jpg?1",
             "name": "Parasitic Strix",
             "text": "Flying\nWhen Parasitic Strix comes into play, if you control a black permanent, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -1105,7 +1105,7 @@
         },
         {
             "id": "591a223f-a788-5c6a-bd61-d94fa68d3401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg?1",
             "name": "Scepter of Insight",
             "text": "{3}{U}, {T}: Draw a card.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "fc9ac68a-6c95-5c8b-8160-a5eaf3b1484b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cdb2ff-6e30-4766-9166-9036a0bdb809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cdb2ff-6e30-4766-9166-9036a0bdb809.jpg?1",
             "name": "Scornful Aether-Lich",
             "text": "{W}{B}: Scornful \u00c6ther-Lich gains fear and vigilance until end of turn.",
             "colours": [
@@ -1175,7 +1175,7 @@
         },
         {
             "id": "6d7e0e83-569b-557c-9679-ee73f0c22567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac0f1fb-0ada-4b3c-b9bd-654ffc0a167d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac0f1fb-0ada-4b3c-b9bd-654ffc0a167d.jpg?1",
             "name": "Telemin Performance",
             "text": "Target opponent reveals cards from the top of his or her library until he or she reveals a creature card. That player puts all noncreature cards revealed this way into his or her graveyard, then you put the creature card into play under your control.",
             "colours": [
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "2a6a1a8a-a980-5826-9896-15014792f7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e8b03d-9265-4699-b626-5efa73292d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e8b03d-9265-4699-b626-5efa73292d43.jpg?1",
             "name": "Traumatic Visions",
             "text": "Counter target spell.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "a6a22cf7-499b-596a-84ce-3c5884e5890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b16d7d-836c-4b15-921b-ebe53e31044e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b16d7d-836c-4b15-921b-ebe53e31044e.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "861d8c52-259a-523c-a145-b47f1aab8a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc73034-4886-4855-b6de-392fa053fe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc73034-4886-4855-b6de-392fa053fe9e.jpg?1",
             "name": "View from Above",
             "text": "Target creature gains flying until end of turn. If you control a white permanent, return View from Above to its owner's hand.",
             "colours": [
@@ -1303,7 +1303,7 @@
         },
         {
             "id": "ecb0c495-0a0b-5fbc-a611-ab84ab6c13fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b454cbdc-b2ff-4b6a-acaf-b7cf52359f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b454cbdc-b2ff-4b6a-acaf-b7cf52359f0b.jpg?1",
             "name": "Worldly Counsel",
             "text": "Domain Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "a3c9a2bf-d421-5916-bb47-8647090fdc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5528886e-3198-48b1-a3b0-6d41ba87bfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5528886e-3198-48b1-a3b0-6d41ba87bfd6.jpg?1",
             "name": "Absorb Vis",
             "text": "Target player loses 4 life and you gain 4 life.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "9f655f7b-a888-5f8a-a9ce-0707c545acdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a7fe66-db40-4eca-8953-0eb2cf98e4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a7fe66-db40-4eca-8953-0eb2cf98e4e8.jpg?1",
             "name": "Corrupted Roots",
             "text": "Enchant Forest or Plains\nWhenever enchanted land becomes tapped, its controller loses 2 life.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "4ea95e7e-917c-5a90-b2b3-1e9744640dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03eb2163-cce2-4d07-b7d7-9c70a41fa373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03eb2163-cce2-4d07-b7d7-9c70a41fa373.jpg?1",
             "name": "Drag Down",
             "text": "Domain Target creature gets -1/-1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "d149c57f-badf-5d95-b8f6-0e4d29554d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb997b6-d872-438f-bf8a-db976bc27a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb997b6-d872-438f-bf8a-db976bc27a2d.jpg?1",
             "name": "Dreadwing",
             "text": "{1}{U}{R}: Dreadwing gets +3/+0 and gains flying until end of turn.",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "ac484d2d-82c3-5cb3-b950-a7f45e6ddd21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a382a-04ef-49d1-8cd6-1f587faa43cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a382a-04ef-49d1-8cd6-1f587faa43cd.jpg?1",
             "name": "Extractor Demon",
             "text": "Flying\nWhenever another creature leaves play, you may have target player put the top two cards of his or her library into his or her graveyard.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "ee71282e-a6d4-50c3-b4d2-04a34a01ce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c57090-c1fe-4100-a03c-95607074280e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c57090-c1fe-4100-a03c-95607074280e.jpg?1",
             "name": "Fleshformer",
             "text": "{W}{U}{B}{R}{G}: Fleshformer gets +2/+2 and gains fear until end of turn. Target creature gets -2/-2 until end of turn. Play this ability only during your turn.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "a5842159-7ccd-59ff-b771-2d506361956e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4851f-35aa-47c3-94b2-cdc166f9036f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4851f-35aa-47c3-94b2-cdc166f9036f.jpg?1",
             "name": "Grixis Slavedriver",
             "text": "When Grixis Slavedriver leaves play, put a 2/2 black Zombie creature token into play.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "694da27d-cb29-5f3b-bbbf-68470da23c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb460855-f09d-4460-9d3f-1bfcc7f3e626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb460855-f09d-4460-9d3f-1bfcc7f3e626.jpg?1",
             "name": "Infectious Horror",
             "text": "Whenever Infectious Horror attacks, each opponent loses 2 life.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "4ddee491-40dc-5d89-9ec9-3662143fb2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878c7d8c-4df0-43ac-8197-d89c8be5e70d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878c7d8c-4df0-43ac-8197-d89c8be5e70d.jpg?1",
             "name": "Kederekt Parasite",
             "text": "Whenever an opponent draws a card, if you control a red permanent, you may have Kederekt Parasite deal 1 damage to that player.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "168ada62-5401-54ce-83c4-7dbbc0de05ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c706ef-5a31-419d-83a3-d60522c14451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c706ef-5a31-419d-83a3-d60522c14451.jpg?1",
             "name": "Nyxathid",
             "text": "As Nyxathid comes into play, choose an opponent.\nNyxathid gets -1/-1 for each card in the chosen player's hand.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "456e2565-1b2f-52a9-b0fa-5810f4b342a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba00df7-2c8d-435a-86d1-6bd7b7413585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba00df7-2c8d-435a-86d1-6bd7b7413585.jpg?1",
             "name": "Pestilent Kathari",
             "text": "Flying\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)\n{2}{R}: Pestilent Kathari gains first strike until end of turn.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "7e0f56bb-814d-5c41-80dc-57d742e355e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dea310-8738-4fd9-b790-0361afe1e150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dea310-8738-4fd9-b790-0361afe1e150.jpg?1",
             "name": "Rotting Rats",
             "text": "When Rotting Rats comes into play, each player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "5046daee-1683-5d23-a1b8-e4e6e1e6952c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b0fd1-7445-4dba-bb90-ddd5f5ee8573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b0fd1-7445-4dba-bb90-ddd5f5ee8573.jpg?1",
             "name": "Salvage Slasher",
             "text": "Salvage Slasher gets +1/+0 for each artifact card in your graveyard.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "95c25019-0d24-56aa-81ee-332548022fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg?1",
             "name": "Scepter of Fugue",
             "text": "{1}{B}, {T}: Target player discards a card. Play this ability only during your turn.",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "3ae9daa4-b3e6-5141-be8b-7375848943a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbc5d7-86d0-4e09-b37c-e40eb88f3f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbc5d7-86d0-4e09-b37c-e40eb88f3f33.jpg?1",
             "name": "Sedraxis Alchemist",
             "text": "When Sedraxis Alchemist comes into play, if you control a blue permanent, return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "a076d053-e117-592c-8b29-9a64062eae45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf285d7-c414-48ab-ad1f-1f49e586c278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf285d7-c414-48ab-ad1f-1f49e586c278.jpg?1",
             "name": "Voices from the Void",
             "text": "Domain Target player discards a card for each basic land type among lands you control.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "8fbfd931-cdb5-576b-901e-564ef8922709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaf55b-2de3-4c8a-90ae-9c88c9d00fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaf55b-2de3-4c8a-90ae-9c88c9d00fd7.jpg?1",
             "name": "Wretched Banquet",
             "text": "Destroy target creature if it has the least power or is tied for least power among creatures in play.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "a5586b10-2c00-5855-87db-f7c8ec417b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4625e1-4ba4-43cd-8147-059e4d50fd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4625e1-4ba4-43cd-8147-059e4d50fd37.jpg?1",
             "name": "Yoke of the Damned",
             "text": "Enchant creature\nWhen a creature is put into a graveyard from play, destroy enchanted creature.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "64f7436b-3261-5dae-8feb-110ee33361e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188c68a-e9df-4803-a722-1993dd88f833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188c68a-e9df-4803-a722-1993dd88f833.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "78900170-2958-568d-9f38-f0cc348aaca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b7208e-aa64-43fa-b7f8-8d40d7005358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b7208e-aa64-43fa-b7f8-8d40d7005358.jpg?1",
             "name": "Bloodhall Ooze",
             "text": "At the beginning of your upkeep, if you control a black permanent, you may put a +1/+1 counter on Bloodhall Ooze.\nAt the beginning of your upkeep, if you control a green permanent, you may put a +1/+1 counter on Bloodhall Ooze.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "9d52d655-f845-55da-9612-0f9fe6d2263a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b200790-43c7-42ae-9edf-89c8198a385b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b200790-43c7-42ae-9edf-89c8198a385b.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -2053,7 +2053,7 @@
         },
         {
             "id": "46ff9f22-1fd9-5bf8-87bf-318f18611e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3209997-8cdc-40e9-9e95-92a0f33e7f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3209997-8cdc-40e9-9e95-92a0f33e7f8e.jpg?1",
             "name": "Dark Temper",
             "text": "Dark Temper deals 2 damage to target creature. If you control a black permanent, destroy the creature instead.",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "0b0384a2-b48d-54d1-9dd1-be1c6af8562d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14674d80-2571-4794-863e-247c2e2cfc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14674d80-2571-4794-863e-247c2e2cfc3e.jpg?1",
             "name": "Dragonsoul Knight",
             "text": "First strike\n{W}{U}{B}{R}{G}: Until end of turn, Dragonsoul Knight becomes a Dragon, gets +5/+3, and gains flying and trample.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "7cd01590-ac19-5f61-863d-9cdebc416f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687bb467-b447-4901-8a65-cd91fd3aa15d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687bb467-b447-4901-8a65-cd91fd3aa15d.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "7de420db-829b-5ca8-a006-82a2fbdf5e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ec933c-ee56-4b23-baba-699286984dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ec933c-ee56-4b23-baba-699286984dee.jpg?1",
             "name": "Goblin Razerunners",
             "text": "{1}{R}, Sacrifice a land: Put a +1/+1 counter on Goblin Razerunners.\nAt the end of your turn, you may have Goblin Razerunners deal damage equal to the number of +1/+1 counters on it to target player.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "86727832-0334-561d-bcac-e03dc2871d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a861a-c488-4834-a419-5bd1eeba6873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a861a-c488-4834-a419-5bd1eeba6873.jpg?1",
             "name": "Hellspark Elemental",
             "text": "Trample, haste\nAt end of turn, sacrifice Hellspark Elemental.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -2225,7 +2225,7 @@
         },
         {
             "id": "10f950d2-1af0-5c7b-b398-13eaa223d4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38419d9-e321-4642-aad4-99c5489f8fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38419d9-e321-4642-aad4-99c5489f8fa8.jpg?1",
             "name": "Ignite Disorder",
             "text": "Ignite Disorder deals 3 damage divided as you choose among any number of target white and/or blue creatures.",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "5f4a6e66-2b2f-5c4a-bebd-1d3ccf189f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aece74-cc1f-4f32-ad1f-00733eb79007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aece74-cc1f-4f32-ad1f-00733eb79007.jpg?1",
             "name": "Kranioceros",
             "text": "{1}{W}: Kranioceros gets +0/+3 until end of turn.",
             "colours": [
@@ -2292,7 +2292,7 @@
         },
         {
             "id": "ac5f2a3d-a266-5895-90bb-60a33aef5600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd98218-8318-40e7-8f36-68acce5d23a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd98218-8318-40e7-8f36-68acce5d23a1.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -2326,7 +2326,7 @@
         },
         {
             "id": "a787475d-3808-5339-a4bf-3d5b25e78fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58356504-e28e-456c-b1d3-e6232f4d78a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58356504-e28e-456c-b1d3-e6232f4d78a6.jpg?1",
             "name": "Molten Frame",
             "text": "Destroy target artifact creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "72f11c48-6838-50fb-81d7-b07ddf4a6700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1c0ded-2a80-4ed4-b9fc-3a18bf5c3239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1c0ded-2a80-4ed4-b9fc-3a18bf5c3239.jpg?1",
             "name": "Quenchable Fire",
             "text": "Quenchable Fire deals 3 damage to target player. It deals an additional 3 damage to that player at the beginning of your next upkeep step unless he or she pays {U} before that step.",
             "colours": [
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "e9f258bf-24b5-5e2d-8614-4fae477e7ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg?1",
             "name": "Rakka Mar",
             "text": "Haste\n{R}, {T}: Put a 3/1 red Elemental creature token with haste into play.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "8307d5bf-42a0-556a-8157-333299c51145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fd2dce-b91f-441f-a3ea-af87cc925713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fd2dce-b91f-441f-a3ea-af87cc925713.jpg?1",
             "name": "Toxic Iguanar",
             "text": "Toxic Iguanar has deathtouch as long as you control a green permanent. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "e3e22821-fbc9-5b67-98eb-a0488025be17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c30ee-616b-4b7d-97f9-cab1d6218e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c30ee-616b-4b7d-97f9-cab1d6218e3a.jpg?1",
             "name": "Viashino Slaughtermaster",
             "text": "Double strike\n{B}{G}: Viashino Slaughtermaster gets +1/+1 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "68c578dc-e1f9-5fbe-9252-4d2def14c067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65536d12-e75c-42b5-b592-a3ad4f550a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65536d12-e75c-42b5-b592-a3ad4f550a71.jpg?1",
             "name": "Volcanic Fallout",
             "text": "Volcanic Fallout can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
             "colours": [
@@ -2531,7 +2531,7 @@
         },
         {
             "id": "f979b0af-1625-5bbc-96f8-e999cf6901fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2ab319-bad8-4695-b56c-3654ba3389c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2ab319-bad8-4695-b56c-3654ba3389c5.jpg?1",
             "name": "Voracious Dragon",
             "text": "Flying\nDevour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nWhen Voracious Dragon comes into play, it deals damage to target creature or player equal to twice the number of Goblins it devoured.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "52105f00-802e-5ae3-b412-e77e9462cc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217281d9-a8f4-4e7a-987f-7ece0ae15eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217281d9-a8f4-4e7a-987f-7ece0ae15eba.jpg?1",
             "name": "Wandering Goblins",
             "text": "Domain {3}: Wandering Goblins gets +1/+0 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "cb70bfff-3765-51dd-b458-f8827592330f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73922629-5e85-451f-8ad6-4c8a60aab935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73922629-5e85-451f-8ad6-4c8a60aab935.jpg?1",
             "name": "Worldheart Phoenix",
             "text": "Flying\nYou may play Worldheart Phoenix from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost. If you do, it comes into play with two +1/+1 counters on it.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "1740bb83-e7c1-587d-978a-fedaee2fa137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc42e33-7489-4a32-bb30-adc80ec13521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc42e33-7489-4a32-bb30-adc80ec13521.jpg?1",
             "name": "Beacon Behemoth",
             "text": "{1}: Target creature with power 5 or greater gains vigilance until end of turn.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "a9c48537-707e-59a7-a57e-7dbfc07b9966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg?1",
             "name": "Cliffrunner Behemoth",
             "text": "Cliffrunner Behemoth has haste as long as you control a red permanent.\nCliffrunner Behemoth has lifelink as long as you control a white permanent.",
             "colours": [
@@ -2707,7 +2707,7 @@
         },
         {
             "id": "dc31bdcc-120d-50a7-80c3-2d18aaf796dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90665426-118e-4f0b-8222-1b516678a2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90665426-118e-4f0b-8222-1b516678a2f5.jpg?1",
             "name": "Cylian Sunsinger",
             "text": "{R}{G}{W}: Cylian Sunsinger and each other creature with the same name as it get +3/+3 until end of turn.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "832417c3-e252-5f3b-98e5-8ebc0b281dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10effbe2-fd8e-44b6-a08c-3984a92254d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10effbe2-fd8e-44b6-a08c-3984a92254d9.jpg?1",
             "name": "Ember Weaver",
             "text": "Reach (This can block creatures with flying.)\nAs long as you control a red permanent, Ember Weaver gets +1/+0 and has first strike.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "740001fa-af8c-583a-b5cf-8286f5a69bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65075828-d685-4107-866e-75a53cbc6414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65075828-d685-4107-866e-75a53cbc6414.jpg?1",
             "name": "Filigree Fracture",
             "text": "Destroy target artifact or enchantment. If that permanent was blue or black, draw a card.",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "9efa8adb-3e5b-5dcf-a15d-d51f357ac352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c7201-02b0-4e16-9fa6-0a79631e7724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c7201-02b0-4e16-9fa6-0a79631e7724.jpg?1",
             "name": "Gluttonous Slime",
             "text": "Flash\nDevour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "c70c39be-5129-5983-a538-afc5a4ed9e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32dcf7d-ac19-45c5-8c3a-1155bf25b216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32dcf7d-ac19-45c5-8c3a-1155bf25b216.jpg?1",
             "name": "Matca Rioters",
             "text": "Domain Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "7dd511d5-bbc1-5c44-820c-358ffb585261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514c013-bc11-4cc5-af8c-f82fd4098bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514c013-bc11-4cc5-af8c-f82fd4098bcf.jpg?1",
             "name": "Might of Alara",
             "text": "Domain Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "c9f7a241-a476-5e67-ba58-887b048e7e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad602fba-6a73-4fd0-aff5-802c3be3100e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad602fba-6a73-4fd0-aff5-802c3be3100e.jpg?1",
             "name": "Nacatl Savage",
             "text": "Protection from artifacts",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "7d6580e5-185b-5dff-a1fb-452a310e58e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adfe928-1305-444d-b709-1e714544daaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adfe928-1305-444d-b709-1e714544daaf.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "27d69eb4-f861-51cd-90ee-ca60e54e5ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg?1",
             "name": "Paleoloth",
             "text": "Whenever another creature with power 5 or greater comes into play under your control, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "8a575573-5ad0-559a-aca4-636a0bf81bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160335df-8377-4f72-9d3f-4b1492bd23ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160335df-8377-4f72-9d3f-4b1492bd23ea.jpg?1",
             "name": "Sacellum Archers",
             "text": "{R}{W}, {T}: Sacellum Archers deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "1ee95db7-76c7-5b32-b66c-baa5d854e033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74d6cdb-a087-4b3d-bf25-509200ed6d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74d6cdb-a087-4b3d-bf25-509200ed6d93.jpg?1",
             "name": "Scattershot Archer",
             "text": "{T}: Scattershot Archer deals 1 damage to each creature with flying.",
             "colours": [
@@ -3089,7 +3089,7 @@
         },
         {
             "id": "3aef6f3f-13b3-5a65-a69e-9b668eca09c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285beca0-4876-426f-a4b4-ecefe79ad55d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285beca0-4876-426f-a4b4-ecefe79ad55d.jpg?1",
             "name": "Shard Convergence",
             "text": "Search your library for a Plains card, an Island card, a Swamp card, and a Mountain card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "c65028fa-553f-5144-91ec-547ee69158a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0d50f-7c2b-4d01-8ae0-8d945e726874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0d50f-7c2b-4d01-8ae0-8d945e726874.jpg?1",
             "name": "Soul's Majesty",
             "text": "Draw cards equal to the power of target creature you control.",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "92d30065-2098-5217-9e2d-37048eb69253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fab6e3-29a5-42e0-872e-5c2f4f72bfc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fab6e3-29a5-42e0-872e-5c2f4f72bfc5.jpg?1",
             "name": "Spore Burst",
             "text": "Domain Put a 1/1 green Saproling creature token into play for each basic land type among lands you control.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "fd8ead0f-5f40-5247-8fdb-4e68a6af5798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717c573-e448-400e-a228-d438491f1754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717c573-e448-400e-a228-d438491f1754.jpg?1",
             "name": "Sylvan Bounty",
             "text": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "19e5d417-d84b-590c-b531-4cfa3bfb29c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg?1",
             "name": "Thornling",
             "text": "{G}: Thornling gains haste until end of turn.\n{G}: Thornling gains trample until end of turn.\n{G}: Thornling is indestructible this turn.\n{1}: Thornling gets +1/-1 until end of turn.\n{1}: Thornling gets -1/+1 until end of turn.",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "895f66b7-2733-57ec-890a-690f2b79b938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84666a8-4ce5-46e7-9a39-f64a392515e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84666a8-4ce5-46e7-9a39-f64a392515e7.jpg?1",
             "name": "Tukatongue Thallid",
             "text": "When Tukatongue Thallid is put into a graveyard from play, put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "a7fec3c6-bd2b-5c51-b651-54f1421faff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bc387-ac1a-42b4-9427-fc944094b3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bc387-ac1a-42b4-9427-fc944094b3a1.jpg?1",
             "name": "Wild Leotau",
             "text": "At the beginning of your upkeep, sacrifice Wild Leotau unless you pay {G}.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "186a7b8f-34c4-5b0b-a05f-a3e5bf09fef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc4bf11-dece-4cb7-bef1-69391488f987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc4bf11-dece-4cb7-bef1-69391488f987.jpg?1",
             "name": "Apocalypse Hydra",
             "text": "Apocalypse Hydra comes into play with X +1/+1 counters on it. If X is 5 or more, it comes into play with an additional X +1/+1 counters on it.\n{1}{R}, Remove a +1/+1 counter from Apocalypse Hydra: Apocalypse Hydra deals 1 damage to target creature or player.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "0137ced5-e397-5823-86c8-6efe74e7ff46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a235f619-6b44-4e60-ac16-0038b7531b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a235f619-6b44-4e60-ac16-0038b7531b77.jpg?1",
             "name": "Blood Tyrant",
             "text": "Flying, trample\nAt the beginning of your upkeep, each player loses 1 life. Put a +1/+1 counter on Blood Tyrant for each 1 life lost this way.\nWhenever a player loses the game, put five +1/+1 counters on Blood Tyrant.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "5d51c5a7-726c-5cbe-b8c6-bf263d2769d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb7e1ec-572f-4e78-8f12-0a8034e9d0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb7e1ec-572f-4e78-8f12-0a8034e9d0f6.jpg?1",
             "name": "Charnelhoard Wurm",
             "text": "Trample\nWhenever Charnelhoard Wurm deals damage to an opponent, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "6914e671-7167-5ad7-a7e8-9dcaf2895c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f701f-fba2-48db-95ef-0926986cdac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f701f-fba2-48db-95ef-0926986cdac9.jpg?1",
             "name": "Child of Alara",
             "text": "Trample\nWhen Child of Alara is put into a graveyard from play, destroy all nonland permanents. They can't be regenerated.",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "e7ce144c-4476-54cd-8226-e5b04836e56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db21da75-8d6a-4c8c-a83b-aab8290b586f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db21da75-8d6a-4c8c-a83b-aab8290b586f.jpg?1",
             "name": "Conflux",
             "text": "Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -3516,7 +3516,7 @@
         },
         {
             "id": "43d8515b-01ff-59f3-a0cd-5a8c2ff9bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec16e216-95e1-41f7-87e0-78b6ac3fe1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec16e216-95e1-41f7-87e0-78b6ac3fe1df.jpg?1",
             "name": "Countersquall",
             "text": "Counter target noncreature spell. Its controller loses 2 life.",
             "colours": [
@@ -3550,7 +3550,7 @@
         },
         {
             "id": "229e6fe5-da39-5e47-93d3-1a202194c5ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dfa8c-9068-4373-a9ae-fd0c63eeda44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dfa8c-9068-4373-a9ae-fd0c63eeda44.jpg?1",
             "name": "Elder Mastery",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has flying.\nWhenever enchanted creature deals damage to a player, that player discards two cards.",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "7095cee8-9ffe-59d0-ab79-f2fcb696bcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5068ed-8477-4d8d-9e37-c72474208e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5068ed-8477-4d8d-9e37-c72474208e2d.jpg?1",
             "name": "Esper Cormorants",
             "text": "Flying",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "186ea9aa-9c4f-52f3-bcc1-5e36fed2bec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f247aaaf-4d65-4dfc-bab2-3c1331762647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f247aaaf-4d65-4dfc-bab2-3c1331762647.jpg?1",
             "name": "Exploding Borders",
             "text": "Domain Search your library for a basic land card, put that card into play tapped, then shuffle your library. Exploding Borders deals X damage to target player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -3659,7 +3659,7 @@
         },
         {
             "id": "b7382cbe-c775-565c-88da-2b52c451aa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6712dbd-ee54-4fb7-93ab-64f8f07350f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6712dbd-ee54-4fb7-93ab-64f8f07350f1.jpg?1",
             "name": "Fusion Elemental",
             "text": "",
             "colours": [
@@ -3701,7 +3701,7 @@
         },
         {
             "id": "d76821b2-6f79-5093-861c-95fbb5cf5ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a67fd-6736-4f2b-8ed3-57a0a6afb98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a67fd-6736-4f2b-8ed3-57a0a6afb98f.jpg?1",
             "name": "Giltspire Avenger",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Destroy target creature that dealt damage to you this turn.",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "133bfb69-5ca2-55cb-a2c7-eecc3f10c2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33683b-8bda-4bb9-beb4-fc0cd5ed79ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33683b-8bda-4bb9-beb4-fc0cd5ed79ae.jpg?1",
             "name": "Goblin Outlander",
             "text": "Protection from white",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "948e81b6-43f9-5e85-bc69-b3be8eb19578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4d72b0-34be-497b-8bef-4bd045830917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4d72b0-34be-497b-8bef-4bd045830917.jpg?1",
             "name": "Gwafa Hazid, Profiteer",
             "text": "{W}{U}, {T}: Put a bribery counter on target creature you don't control. Its controller draws a card.\nCreatures with bribery counters on them can't attack or block.",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "aceb745c-1c36-5cb0-af0f-43d26799e585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09a3b69-1214-420d-984f-0b2a043a9dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09a3b69-1214-420d-984f-0b2a043a9dc2.jpg?1",
             "name": "Hellkite Hatchling",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nHellkite Hatchling has flying and trample if it devoured a creature.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "4652658a-e661-527d-a581-4dcaa1c1f07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e638e38-15b9-4081-8340-985d4646e3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e638e38-15b9-4081-8340-985d4646e3d7.jpg?1",
             "name": "Jhessian Balmgiver",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\n{T}: Target creature is unblockable this turn.",
             "colours": [
@@ -3889,7 +3889,7 @@
         },
         {
             "id": "6fa091cb-29d0-5103-9f89-824133900285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b8518-c09e-4cb7-95b2-08e4e370d89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b8518-c09e-4cb7-95b2-08e4e370d89c.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it into play, then shuffle your library.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "37fc686f-b695-5f77-84b9-ce38b684e99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6372fa0-e9c8-45d0-a3b8-72eb191c6b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6372fa0-e9c8-45d0-a3b8-72eb191c6b26.jpg?1",
             "name": "Knotvine Mystic",
             "text": "{1}, {T}: Add {R}{G}{W} to your mana pool.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "cc131651-4999-5481-b66a-3f79b5daee62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92ecfaa-2d8e-4352-b8ec-287da7ba0b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92ecfaa-2d8e-4352-b8ec-287da7ba0b78.jpg?1",
             "name": "Maelstrom Archangel",
             "text": "Flying\nWhenever Maelstrom Archangel deals combat damage to a player, you may play a nonland card from your hand without paying its mana cost.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "6ff0ce2b-990f-59a6-a321-7dfd8b8d53e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2abff9-6927-42cc-8cf1-a0876d3a45d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2abff9-6927-42cc-8cf1-a0876d3a45d7.jpg?1",
             "name": "Magister Sphinx",
             "text": "Flying\nWhen Magister Sphinx comes into play, target player's life total becomes 10.",
             "colours": [
@@ -4046,7 +4046,7 @@
         },
         {
             "id": "6ffaa8eb-2538-5dfa-b979-163070b64c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84de2e-3676-4112-823b-549c4d132280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84de2e-3676-4112-823b-549c4d132280.jpg?1",
             "name": "Malfegor",
             "text": "Flying\nWhen Malfegor comes into play, discard your hand. Each opponent sacrifices a creature for each card discarded this way.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "93f4c01c-a711-5c87-a856-979646e1e9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e32b7-87d6-44a8-a544-5dabcd64c9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e32b7-87d6-44a8-a544-5dabcd64c9f3.jpg?1",
             "name": "Meglonoth",
             "text": "Vigilance, trample\nWhenever Meglonoth blocks a creature, Meglonoth deals damage to that creature's controller equal to Meglonoth's power.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "a39b5b42-3852-512c-aa93-0d281f9468bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5b694-46c8-4cb0-ab6b-4bc67c04cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5b694-46c8-4cb0-ab6b-4bc67c04cc7f.jpg?1",
             "name": "Nacatl Outlander",
             "text": "Protection from blue",
             "colours": [
@@ -4160,7 +4160,7 @@
         },
         {
             "id": "738a5682-4459-545e-be8c-9e2c23c77204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ee3939-bc12-4275-a446-9de36f0b4672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ee3939-bc12-4275-a446-9de36f0b4672.jpg?1",
             "name": "Nicol Bolas, Planeswalker",
             "text": "+3: Destroy target noncreature permanent.\n-2: Gain control of target creature.\n-9: Nicol Bolas, Planeswalker deals 7 damage to target player. That player discards seven cards, then sacrifices seven permanents.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "83704f1a-b85d-5671-9d82-d6066c01201c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc764b0-3046-4bde-b424-c0f4e1a6169b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc764b0-3046-4bde-b424-c0f4e1a6169b.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "0f555141-8777-5061-ab21-ed513071b641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f43c8-9df6-49df-b145-4a19bc55e8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f43c8-9df6-49df-b145-4a19bc55e8f4.jpg?1",
             "name": "Rhox Bodyguard",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhen Rhox Bodyguard comes into play, you gain 3 life.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "5deb3c52-01e8-5cf9-adc8-3b0a46b291f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a179b9-e962-49a4-ad92-8cd0291296c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a179b9-e962-49a4-ad92-8cd0291296c1.jpg?1",
             "name": "Scarland Thrinax",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Scarland Thrinax.",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "4daf8422-88cc-5d17-a47b-90c9858618b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183e0fd7-ed58-46e5-86ce-f17d8657417d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183e0fd7-ed58-46e5-86ce-f17d8657417d.jpg?1",
             "name": "Shambling Remains",
             "text": "Shambling Remains can't block.\nUnearth {B}{R} ({B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -4358,7 +4358,7 @@
         },
         {
             "id": "f702b291-0ec6-5191-b2ae-f57cfd91c90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8125473-a296-4032-bacd-1c1b96819cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8125473-a296-4032-bacd-1c1b96819cf9.jpg?1",
             "name": "Skyward Eye Prophets",
             "text": "Vigilance\n{T}: Reveal the top card of your library. If it's a land card, put it into play. Otherwise, put it into your hand.",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "080010f0-a7e5-5d17-8ab9-cefe459c0d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8339ca-2971-4c5a-83ed-2682e5b3838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8339ca-2971-4c5a-83ed-2682e5b3838d.jpg?1",
             "name": "Sludge Strider",
             "text": "Whenever another artifact comes into play under your control or another artifact you control leaves play, you may pay {1}. If you do, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -4436,7 +4436,7 @@
         },
         {
             "id": "d1b2b51e-8e19-57b5-a88f-5b4c41e7d43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006b5000-2a8f-4020-9dbf-7170da13b54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006b5000-2a8f-4020-9dbf-7170da13b54e.jpg?1",
             "name": "Sphinx Summoner",
             "text": "Flying\nWhen Sphinx Summoner comes into play, you may search your library for an artifact creature card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "f5a18f7e-ef35-54ec-9714-126bab4655d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9375d8c-b429-4349-bc4d-cb08799bdb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9375d8c-b429-4349-bc4d-cb08799bdb58.jpg?1",
             "name": "Suicidal Charge",
             "text": "Sacrifice Suicidal Charge: Creatures your opponents control get -1/-1 until end of turn. Those creatures attack this turn if able.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "fd0950ca-d50d-58ea-91cb-9f4099f7b875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546b0a74-ebef-4596-b730-2190e20b2e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546b0a74-ebef-4596-b730-2190e20b2e66.jpg?1",
             "name": "Vagrant Plowbeasts",
             "text": "{1}: Regenerate target creature with power 5 or greater.",
             "colours": [
@@ -4543,7 +4543,7 @@
         },
         {
             "id": "17788d8c-8dad-5892-ab3c-76861475443e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e73cd46-0dec-441b-bb91-ec6defb3355e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e73cd46-0dec-441b-bb91-ec6defb3355e.jpg?1",
             "name": "Valeron Outlander",
             "text": "Protection from black",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "3391107f-a534-5e4f-8d41-5e8701083d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ac1be-43e4-4535-8633-730f306c0d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ac1be-43e4-4535-8633-730f306c0d00.jpg?1",
             "name": "Vectis Agents",
             "text": "{U}{B}: Vectis Agents gets -2/-0 until end of turn and is unblockable this turn.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "d7f5e8b7-8bab-56bd-8f0b-4ad8f2cc25ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7314-39f2-4e32-a5b0-ac1761b6d238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7314-39f2-4e32-a5b0-ac1761b6d238.jpg?1",
             "name": "Vedalken Outlander",
             "text": "Protection from red",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "c63471c7-f79f-547f-a1c6-25f9e92acb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27c2690-5121-452b-b82a-72acb8be6878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27c2690-5121-452b-b82a-72acb8be6878.jpg?1",
             "name": "Zombie Outlander",
             "text": "Protection from green",
             "colours": [
@@ -4693,7 +4693,7 @@
         },
         {
             "id": "cda01087-3785-507a-8864-d66871b99027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06cdd3b-3f8d-4b5e-882b-130b1db750a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06cdd3b-3f8d-4b5e-882b-130b1db750a0.jpg?1",
             "name": "Armillary Sphere",
             "text": "{2}, {T}, Sacrifice Armillary Sphere: Search your library for up to two basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [],
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "eb975bfd-a4c9-5b2f-8e0f-2738ed090ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bf79d6-4b4a-4fdd-a831-36eff2523661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bf79d6-4b4a-4fdd-a831-36eff2523661.jpg?1",
             "name": "Bone Saw",
             "text": "Equipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "d9055197-f01c-5fb9-bb4c-e7c1329bf837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c198caf8-27ab-4300-841b-507e1b0ce9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c198caf8-27ab-4300-841b-507e1b0ce9b3.jpg?1",
             "name": "Font of Mythos",
             "text": "At the beginning of each player's draw step, that player draws two additional cards.",
             "colours": [],
@@ -4779,7 +4779,7 @@
         },
         {
             "id": "533b23ea-2be7-5d55-984c-f424808e94d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79826f7f-e46b-489d-8fcb-1712d36e8f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79826f7f-e46b-489d-8fcb-1712d36e8f60.jpg?1",
             "name": "Kaleidostone",
             "text": "When Kaleidostone comes into play, draw a card.\n{5}, {T}, Sacrifice Kaleidostone: Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [],
@@ -4813,7 +4813,7 @@
         },
         {
             "id": "c0e8a020-1698-5c8a-8ad1-18aef60712a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e25c75-5e20-4990-9b7e-9d04c94fee9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e25c75-5e20-4990-9b7e-9d04c94fee9f.jpg?1",
             "name": "Mana Cylix",
             "text": "{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "4ee5f243-74b5-5adf-bec4-cd23837e38f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60e11f-ea7c-4d87-bc82-9e7f4eaeef5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60e11f-ea7c-4d87-bc82-9e7f4eaeef5a.jpg?1",
             "name": "Manaforce Mace",
             "text": "Domain Equipped creature gets +1/+1 for each basic land type among lands you control.\nEquip {3}",
             "colours": [],
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "593355f4-f874-56d1-a926-7a48ee89c378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc12ebe-54d8-4b91-8c68-3cde5690e26a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc12ebe-54d8-4b91-8c68-3cde5690e26a.jpg?1",
             "name": "Obelisk of Alara",
             "text": "{1}{W}, {T}: You gain 5 life.\n{1}{U}, {T}: Draw a card, then discard a card.\n{1}{B}, {T}: Target creature gets -2/-2 until end of turn.\n{1}{R}, {T}: Obelisk of Alara deals 3 damage to target player.\n{1}{G}, {T}: Target creature gets +4/+4 until end of turn.",
             "colours": [],
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "1c3f3211-7b81-5d89-81cf-6892871517a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348247d-0a70-4961-8590-9de41386c69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348247d-0a70-4961-8590-9de41386c69b.jpg?1",
             "name": "Ancient Ziggurat",
             "text": "{T}: Add one mana of any color to your mana pool. Spend this mana only to play creature spells.",
             "colours": [],
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "df220e74-4b35-5fde-b8b5-dbb5c3f2057e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aae6480-4e71-4d94-a648-f80d3849d792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aae6480-4e71-4d94-a648-f80d3849d792.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "180813e7-ad29-5870-9b03-0c430edd6ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0c1a5-dce7-4c7d-8a5b-0bf93ba68ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0c1a5-dce7-4c7d-8a5b-0bf93ba68ace.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "4fb21440-637c-565f-b0a5-1592ec05da42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568df642-3ad7-401c-a133-edb56970c3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568df642-3ad7-401c-a133-edb56970c3a1.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire comes into play tapped.\nWhen Rupture Spire comes into play, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "8a97d60e-a4ec-516d-994a-14483c8faecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97e739f-8675-488e-be2b-4e455fbe390b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97e739f-8675-488e-be2b-4e455fbe390b.jpg?1",
             "name": "Unstable Frontier",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Target land you control becomes the basic land type of your choice until end of turn.",
             "colours": [],
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "dc610050-0e01-5692-847c-e6955a1a93e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902520e-b4ed-4805-9f64-096acf7c5f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902520e-b4ed-4805-9f64-096acf7c5f31.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "8f415ec3-6027-5569-828e-7555c462953c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf56553-2ecc-4fe8-8730-917d891f6882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf56553-2ecc-4fe8-8730-917d891f6882.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/CSP.json
+++ b/Assets/Resources/Sets/CSP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ca7351d1-ab64-595a-8376-10e3c2f54535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4336a9-c904-44a3-8cbd-a1fd5fdbcd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4336a9-c904-44a3-8cbd-a1fd5fdbcd74.jpg?1",
             "name": "Adarkar Valkyrie",
             "text": "Flying, vigilance\n{T}: When target creature other than Adarkar Valkyrie is put into a graveyard this turn, return that card to play under your control.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "f2567096-25a2-569d-bcdd-eace03ad649b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36638e20-0a1d-4ea3-936c-2ea74add868a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36638e20-0a1d-4ea3-936c-2ea74add868a.jpg?1",
             "name": "Boreal Griffin",
             "text": "Flying\n{S}: Boreal Griffin gains first strike until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "aa622011-fd2b-589e-8fee-80d7b93adac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d9bb89-d8f8-4dff-8b94-3f7b8aa8f299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d9bb89-d8f8-4dff-8b94-3f7b8aa8f299.jpg?1",
             "name": "Cover of Winter",
             "text": "Cumulative upkeep {S} ({S} can be paid with one mana from a snow permanent.)\nIf a creature would deal combat damage to you and/or one or more creatures you control, prevent X of that damage, where X is the number of age counters on Cover of Winter.\n{S}: Put an age counter on Cover of Winter.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "efbec2be-9858-56a0-b0ba-8cb266319b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea571ae-b9bd-4bd2-9357-52915f0d2f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea571ae-b9bd-4bd2-9357-52915f0d2f15.jpg?1",
             "name": "Darien, King of Kjeldor",
             "text": "Whenever you're dealt damage, you may put that many 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "cf1f188d-d539-5ac2-b18b-14526b80705c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421648a0-51c8-45c4-9771-0fd3ccdc69c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421648a0-51c8-45c4-9771-0fd3ccdc69c9.jpg?1",
             "name": "Field Marshal",
             "text": "Other Soldiers get +1/+1 and have first strike.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "ce6e511f-ab1f-586b-b9a1-1c0436113eee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d372bb70-2d2a-4c44-8f69-4abff8ba7c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d372bb70-2d2a-4c44-8f69-4abff8ba7c2a.jpg?1",
             "name": "Gelid Shackles",
             "text": "Enchant creature\nEnchanted creature can't block and its activated abilities can't be played.\n{S}: Enchanted creature gains defender until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -218,7 +218,7 @@
         },
         {
             "id": "ad2de8c9-855b-539c-aeda-402693fab29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55742f0f-a894-48c3-82b1-dfc3d8390dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55742f0f-a894-48c3-82b1-dfc3d8390dc3.jpg?1",
             "name": "Glacial Plating",
             "text": "Enchant creature\nCumulative upkeep {S} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it. {S} can be paid with one mana from a snow permanent.)\nEnchanted creature gets +3/+3 for each age counter on Glacial Plating.",
             "colours": [
@@ -254,7 +254,7 @@
         },
         {
             "id": "f37bb3ba-1796-5a40-893e-55222129cac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526c510-bd33-4fac-8941-f19bd0997557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526c510-bd33-4fac-8941-f19bd0997557.jpg?1",
             "name": "J\u00f6tun Grunt",
             "text": "Cumulative upkeep\u2014\nPut two cards in a single graveyard on the bottom of their owner's library. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "724ed0bc-5ee8-58f8-ad66-84d1888bee02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1566c8a2-aaca-4ce0-a36b-620ea6f135cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1566c8a2-aaca-4ce0-a36b-620ea6f135cb.jpg?1",
             "name": "J\u00f6tun Owl Keeper",
             "text": "Cumulative upkeep {W} or {U} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen J\u00f6tun Owl Keeper is put into a graveyard from play, put a 1/1 white Bird creature token with flying into play for each age counter on it.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "54689944-a00e-51ac-9cd1-287a9b625d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a4892-fba0-459d-9e72-e82f7e079d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a4892-fba0-459d-9e72-e82f7e079d78.jpg?1",
             "name": "Kjeldoran Gargoyle",
             "text": "Flying, first strike\nWhenever Kjeldoran Gargoyle deals damage, you gain that much life.",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "5d159049-750a-5968-bb04-29e0701cc130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b0776b-d1ed-4b0d-9684-99978e3e3b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b0776b-d1ed-4b0d-9684-99978e3e3b46.jpg?1",
             "name": "Kjeldoran Javelineer",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\n{T}: Kjeldoran Javelineer deals damage to target attacking or blocking creature equal to the number of age counters on Kjeldoran Javelineer.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "52c5a6d2-45ea-5543-a0b2-c5efcc92a7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd641b1d-dab8-415b-9655-09e033df761d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd641b1d-dab8-415b-9655-09e033df761d.jpg?1",
             "name": "Kjeldoran Outrider",
             "text": "{W}: Kjeldoran Outrider gets +0/+1 until end of turn.",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "92749b94-d614-5a28-b4ec-541a711345be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320b2b02-a3ff-4f68-93e6-8539d7caa005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320b2b02-a3ff-4f68-93e6-8539d7caa005.jpg?1",
             "name": "Kjeldoran War Cry",
             "text": "Creatures you control get +X/+X until end of turn, where X is 1 plus the number of cards named Kjeldoran War Cry in all graveyards.",
             "colours": [
@@ -460,7 +460,7 @@
         },
         {
             "id": "1357940d-4137-5cfc-bb3c-bd5c53d1be71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e8fe10-a4b7-4504-849f-a5c8379e587d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e8fe10-a4b7-4504-849f-a5c8379e587d.jpg?1",
             "name": "Luminesce",
             "text": "Prevent all damage that black and/or red sources would deal this turn.",
             "colours": [
@@ -492,7 +492,7 @@
         },
         {
             "id": "2d977a95-4ea8-544e-a02f-692f0253fdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c55105-bffc-43dc-b5f3-2e6bb9323230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c55105-bffc-43dc-b5f3-2e6bb9323230.jpg?1",
             "name": "Martyr of Sands",
             "text": "{1}, Reveal X white cards from your hand, Sacrifice Martyr of Sands: You gain three times X life.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "cf6a3696-d1df-534f-b3d8-4a4d8a80df06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4764e1-e47c-4934-86a5-9b432c29a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4764e1-e47c-4934-86a5-9b432c29a158.jpg?1",
             "name": "Ronom Unicorn",
             "text": "Sacrifice Ronom Unicorn: Destroy target enchantment.",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "cea59ff5-64e7-5bbe-a7d5-c65e1c349b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ecb728-4b54-47d0-bbef-d39e5f7d172f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ecb728-4b54-47d0-bbef-d39e5f7d172f.jpg?1",
             "name": "Squall Drifter",
             "text": "Flying\n{W}, {T}: Tap target creature.",
             "colours": [
@@ -597,7 +597,7 @@
         },
         {
             "id": "49b3841d-91fe-574e-b018-7c98565287f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde59b0e-c75e-455b-b375-e0dac430a6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde59b0e-c75e-455b-b375-e0dac430a6d1.jpg?1",
             "name": "Sun's Bounty",
             "text": "You gain 4 life.\nRecover {1}{W} (When a creature is put into your graveyard from play, you may pay {1}{W}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -629,7 +629,7 @@
         },
         {
             "id": "a7d384e6-f114-53a5-ae2e-6ea50b4f83d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c726db-a30a-4e76-9fbf-ec6d5cd7a1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c726db-a30a-4e76-9fbf-ec6d5cd7a1ba.jpg?1",
             "name": "Sunscour",
             "text": "You may remove two white cards in your hand from the game rather than pay Sunscour's mana cost.\nDestroy all creatures.",
             "colours": [
@@ -661,7 +661,7 @@
         },
         {
             "id": "0ccaf773-319c-5a99-b30d-d62b092ac90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264d120a-d7e2-4b9e-ac85-c66e976c577b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264d120a-d7e2-4b9e-ac85-c66e976c577b.jpg?1",
             "name": "Surging Sentinels",
             "text": "First strike\nRipple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "d263e698-e07d-5105-8126-b4dfa2a090de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f97ef40-9d07-47fa-ad4b-45f26f7351c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f97ef40-9d07-47fa-ad4b-45f26f7351c9.jpg?1",
             "name": "Swift Maneuver",
             "text": "Prevent the next 2 damage that would be dealt to target creature or player this turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "e96fe0ff-6bd5-5598-a533-09b8a976e74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7c141-2e20-4891-93a8-1cf309d3b979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7c141-2e20-4891-93a8-1cf309d3b979.jpg?1",
             "name": "Ursine Fylgja",
             "text": "Ursine Fylgja comes into play with four healing counters on it.\nRemove a healing counter from Ursine Fylgja: Prevent the next 1 damage that would be dealt to Ursine Fylgja this turn.\n{2}{W}: Put a healing counter on Ursine Fylgja.",
             "colours": [
@@ -763,7 +763,7 @@
         },
         {
             "id": "db3c404e-28ac-54d9-ab4d-4171025b53aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884ee8d8-4c0d-4e44-8321-bccd18195693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884ee8d8-4c0d-4e44-8321-bccd18195693.jpg?1",
             "name": "Wall of Shards",
             "text": "Defender, flying\nCumulative upkeep\u2014\nAn opponent gains 1 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "535f3001-3391-59ae-9f19-789c95025f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368322d7-d399-45e1-8d7f-8001d048071e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368322d7-d399-45e1-8d7f-8001d048071e.jpg?1",
             "name": "White Shield Crusader",
             "text": "Protection from black\n{W}: White Shield Crusader gains flying until end of turn.\n{W}{W}: White Shield Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -834,7 +834,7 @@
         },
         {
             "id": "e09b89fd-b378-5c16-8dbd-ab7d1eec97a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ed6354-161e-496e-9ac7-74432f9b0818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ed6354-161e-496e-9ac7-74432f9b0818.jpg?1",
             "name": "Woolly Razorback",
             "text": "Woolly Razorback comes into play with three ice counters on it.\nAs long as Woolly Razorback has an ice counter on it, it has defender and any combat damage it would deal is prevented.\nWhenever Woolly Razorback blocks, remove an ice counter from it.",
             "colours": [
@@ -869,7 +869,7 @@
         },
         {
             "id": "1f272154-ad59-5365-8aaa-a04ad6228176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18bce4a-9afb-4b91-bc9a-d62634b0f8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18bce4a-9afb-4b91-bc9a-d62634b0f8dd.jpg?1",
             "name": "Adarkar Windform",
             "text": "Flying\n{1}{S}: Target creature loses flying until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "192f3473-1028-5ad2-93fd-446029642a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9d3ce7-53db-4808-88bc-03c120211f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9d3ce7-53db-4808-88bc-03c120211f81.jpg?1",
             "name": "Arcum Dagsson",
             "text": "{T}: Target artifact creature's controller sacrifices it. That player may search his or her library for a noncreature artifact card, put it into play, then shuffle his or her library.",
             "colours": [
@@ -942,7 +942,7 @@
         },
         {
             "id": "9c14b67d-5f7b-538a-a490-7d009ebd891c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18096cdb-0ba9-41e0-b597-c5ed819e7497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18096cdb-0ba9-41e0-b597-c5ed819e7497.jpg?1",
             "name": "Balduvian Frostwaker",
             "text": "{U}, {T}: Target snow land becomes a 2/2 blue Elemental creature with flying. It's still a land.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "9b78a70c-1331-5a17-8817-a9164c0af1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e6204-c622-4efe-ac4f-8195528cec9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e6204-c622-4efe-ac4f-8195528cec9c.jpg?1",
             "name": "Commandeer",
             "text": "You may remove two blue cards in your hand from the game rather than pay Commandeer's mana cost.\nGain control of target noncreature spell. You may choose new targets for it. (If that spell is an artifact or enchantment, the permanent comes into play under your control.)",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "72a5f639-36c5-505a-b55c-674d6cb890e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e670f6b-d16e-47fc-a5b7-7ca0d8763644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e670f6b-d16e-47fc-a5b7-7ca0d8763644.jpg?1",
             "name": "Controvert",
             "text": "Counter target spell.\nRecover {2}{U}{U} (When a creature is put into your graveyard from play, you may pay {2}{U}{U}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -1041,7 +1041,7 @@
         },
         {
             "id": "b0c88ccc-bbe9-5fa0-9cb3-09237a6a41f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c329ff2b-0331-4934-a8df-870dd7bf402b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c329ff2b-0331-4934-a8df-870dd7bf402b.jpg?1",
             "name": "Counterbalance",
             "text": "Whenever an opponent plays a spell, you may reveal the top card of your library. If you do, counter that spell if it has the same converted mana cost as the revealed card.",
             "colours": [
@@ -1073,7 +1073,7 @@
         },
         {
             "id": "a93bda8d-03c3-5f59-b207-5be2c96ee84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954a1e9c-ed2f-4774-b2b7-166052a5c59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954a1e9c-ed2f-4774-b2b7-166052a5c59a.jpg?1",
             "name": "Drelnoch",
             "text": "Whenever Drelnoch becomes blocked, you may draw two cards.",
             "colours": [
@@ -1108,7 +1108,7 @@
         },
         {
             "id": "9400ef04-7331-5768-8e39-953f55fa60b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefd9955-a195-4855-a00e-3809b96ca92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefd9955-a195-4855-a00e-3809b96ca92b.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1140,7 +1140,7 @@
         },
         {
             "id": "b1d26c58-2893-591a-aace-467aa919e402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab2f81a-fcbe-44d1-8281-04dd78bb9ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab2f81a-fcbe-44d1-8281-04dd78bb9ea3.jpg?1",
             "name": "Frost Raptor",
             "text": "Flying\n{S}{S}: Frost Raptor can't be the target of spells or abilities this turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -1176,7 +1176,7 @@
         },
         {
             "id": "8138fa39-effb-5ba4-9297-fa2fe306e31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c00743-d208-4aed-939a-d70de2d759b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c00743-d208-4aed-939a-d70de2d759b9.jpg?1",
             "name": "Frozen Solid",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nWhen damage is dealt to enchanted creature, destroy it.",
             "colours": [
@@ -1210,7 +1210,7 @@
         },
         {
             "id": "8c9aefc3-15d3-5c95-87fa-75576e09d582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39916d65-60a6-4da6-8675-8a8ef9505772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39916d65-60a6-4da6-8675-8a8ef9505772.jpg?1",
             "name": "Heidar, Rimewind Master",
             "text": "{2}, {T}: Return target permanent to its owner's hand. Play this ability only if you control four or more snow permanents.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "62b76bca-4311-5708-93f1-b930faf3383e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bd1c2f-dab8-4f22-9400-a0e45618757a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bd1c2f-dab8-4f22-9400-a0e45618757a.jpg?1",
             "name": "Jokulmorder",
             "text": "Trample\nJokulmorder comes into play tapped.\nWhen Jokulmorder comes into play, sacrifice it unless you sacrifice five lands.\nJokulmorder doesn't untap during your untap step.\nWhenever you play an Island, you may untap Jokulmorder.",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "61304e4f-39dc-5a49-9fb7-459050d14e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e09469-205d-4a60-821c-ceb7ae2e01be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e09469-205d-4a60-821c-ceb7ae2e01be.jpg?1",
             "name": "Krovikan Mist",
             "text": "Flying\nKrovikan Mist's power and toughness are each equal to the number of Illusions in play.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "7ac542e9-a0ed-5846-a052-eee535275648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac2469-db92-44e4-8930-96f2c40c60f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac2469-db92-44e4-8930-96f2c40c60f1.jpg?1",
             "name": "Krovikan Whispers",
             "text": "Enchant creature\nCumulative upkeep {U} or {B}\nYou control enchanted creature.\nWhen Krovikan Whispers is put into a graveyard from play, you lose 2 life for each age counter on it.",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "25435350-2b3b-5aa9-bae7-2d8f43cd94a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249136c-94d4-4f65-95a4-d45b4f20429b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249136c-94d4-4f65-95a4-d45b4f20429b.jpg?1",
             "name": "Martyr of Frost",
             "text": "{2}, Reveal X blue cards from your hand, Sacrifice Martyr of Frost: Counter target spell unless its controller pays {X}.",
             "colours": [
@@ -1385,7 +1385,7 @@
         },
         {
             "id": "3ec32c53-c7b5-57a9-b35d-90b6b9f29fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669285c-5560-4f49-8d0a-44b8c33e23d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669285c-5560-4f49-8d0a-44b8c33e23d0.jpg?1",
             "name": "Perilous Research",
             "text": "Draw two cards, then sacrifice a permanent.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "2405ad64-89ac-5f66-bee6-543ff4c3707a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e3552-a251-4a80-b0bb-a96a9f8a4c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e3552-a251-4a80-b0bb-a96a9f8a4c56.jpg?1",
             "name": "Rimefeather Owl",
             "text": "Flying\nRimefeather Owl's power and toughness are each equal to the number of snow permanents in play.\n{1}{S}: Put an ice counter on target permanent.\nPermanents with ice counters on them are snow.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "d671b32a-31e6-5bb7-8afb-0991b1459ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433653d-5ba9-4cdb-8a0b-69026301bc6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433653d-5ba9-4cdb-8a0b-69026301bc6f.jpg?1",
             "name": "Rimewind Cryomancer",
             "text": "{1}, {T}: Counter target activated ability. Play this ability only if you control four or more snow permanents. (Mana abilities can't be targeted.)",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "8fc9f2ef-2c1d-5da6-ae09-5cc91ded2d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cdc06e-1458-4b19-a272-28a3d0453643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cdc06e-1458-4b19-a272-28a3d0453643.jpg?1",
             "name": "Rimewind Taskmage",
             "text": "{1}, {T}: Tap or untap target permanent. Play this ability only if you control four or more snow permanents.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "a5d21bea-2c59-5548-9dbd-9df272bf3c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf81a39-0a6e-4253-81eb-a24f48253343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf81a39-0a6e-4253-81eb-a24f48253343.jpg?1",
             "name": "Ronom Serpent",
             "text": "Ronom Serpent can't attack unless defending player controls a snow land.\nWhen you control no snow lands, sacrifice Ronom Serpent.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "cee8cfd4-2302-575a-8c60-7319d6aca21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b6cadf-1974-47c8-98d8-ba413486c3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b6cadf-1974-47c8-98d8-ba413486c3b5.jpg?1",
             "name": "Rune Snag",
             "text": "Counter target spell unless its controller pays {2} plus an additional {2} for each card named Rune Snag in each graveyard.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "d5210648-65ab-569a-a13d-6c342ee19a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfba9fc2-8746-4693-bb75-01b5d78f7fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfba9fc2-8746-4693-bb75-01b5d78f7fee.jpg?1",
             "name": "Surging Aether",
             "text": "Ripple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "14de0091-75e3-51ec-b90e-94ce506ba366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a28c9cb-ae41-4f9c-b3f6-151ef95c81b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a28c9cb-ae41-4f9c-b3f6-151ef95c81b3.jpg?1",
             "name": "Survivor of the Unseen",
             "text": "Cumulative upkeep {2} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\n{T}: Draw two cards, then put a card from your hand on top of your library.",
             "colours": [
@@ -1658,7 +1658,7 @@
         },
         {
             "id": "271b985c-d857-5621-936d-2b346bdd552d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab8a0-906a-43b3-a554-db0d3dcd62d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab8a0-906a-43b3-a554-db0d3dcd62d3.jpg?1",
             "name": "Thermal Flux",
             "text": "Choose one Target nonsnow permanent becomes snow until end of turn; or target snow permanent isn't snow until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "afb8a88f-dc61-56b3-82d1-d9b4f2c3e9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cc1248-85c8-428f-ba08-96d188167eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cc1248-85c8-428f-ba08-96d188167eaa.jpg?1",
             "name": "Vexing Sphinx",
             "text": "Flying\nCumulative upkeep\u2014\nDiscard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Vexing Sphinx is put into a graveyard from play, draw a card for each age counter on it.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "83bf64c1-b589-51d9-9366-90dc739c23f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a52b952-6e3b-403b-b355-2af47a282ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a52b952-6e3b-403b-b355-2af47a282ab6.jpg?1",
             "name": "Balduvian Fallen",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever Balduvian Fallen's cumulative upkeep is paid, it gets +1/+0 until end of turn for each {B} or {R} spent this way.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "53242d6c-d177-5837-9a1c-326e72a856be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312505d7-362e-43cf-bd23-28c248a8b7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312505d7-362e-43cf-bd23-28c248a8b7e1.jpg?1",
             "name": "Chill to the Bone",
             "text": "Destroy target nonsnow creature.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "9b131f33-79aa-522b-ad36-26ee4a36f522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d050c8b9-2b5a-4025-9886-73c418f4e22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d050c8b9-2b5a-4025-9886-73c418f4e22f.jpg?1",
             "name": "Chilling Shade",
             "text": "Flying\n{S}: Chilling Shade gets +1/+1 until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "340deaa2-47b8-5689-a563-da9a4852960b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e8728-d0a0-4ee5-87c3-092ca94225e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e8728-d0a0-4ee5-87c3-092ca94225e0.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "746f0cb8-752a-575a-a5d5-505c82beb10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99ec07-8af7-4e80-9f0e-fa304a94d4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99ec07-8af7-4e80-9f0e-fa304a94d4b4.jpg?1",
             "name": "Disciple of Tevesh Szat",
             "text": "{T}: Target creature gets -1/-1 until end of turn.\n{4}{B}{B}, {T}, Sacrifice Disciple of Tevesh Szat: Target creature gets -6/-6 until end of turn.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "1fb9c09e-e036-579e-a7a9-897a61c3f5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d344791-5d5c-40c5-99c7-931954ea39d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d344791-5d5c-40c5-99c7-931954ea39d1.jpg?1",
             "name": "Feast of Flesh",
             "text": "Feast of Flesh deals X damage to target creature and you gain X life, where X is 1 plus the number of cards named Feast of Flesh in all graveyards.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "a49f3a52-aa88-598a-818b-23b314cfc33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3407ccbd-788d-4fe3-a039-0497724a94b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3407ccbd-788d-4fe3-a039-0497724a94b5.jpg?1",
             "name": "Garza's Assassin",
             "text": "Sacrifice Garza's Assassin: Destroy target nonblack creature.\nRecover\u2014\nPay half your life, rounded up. (When another creature is put into your graveyard from play, you may pay half your life, rounded up. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "5eb15421-57b2-5c71-b4d7-7a3157be63fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb1972f-2ef7-4fe2-8c8e-ab07f48a3176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb1972f-2ef7-4fe2-8c8e-ab07f48a3176.jpg?1",
             "name": "Grim Harvest",
             "text": "Return target creature card from your graveyard to your hand.\nRecover {2}{B} (When a creature is put into your graveyard from play, you may pay {2}{B}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "5cf1748f-cdc6-510f-852c-451bf339050b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8b607d-56c5-4a18-88b5-d5d0f50ef403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8b607d-56c5-4a18-88b5-d5d0f50ef403.jpg?1",
             "name": "Gristle Grinner",
             "text": "Whenever a creature is put into a graveyard from play, Gristle Grinner gets +2/+2 until end of turn.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "9fa970f0-4fad-5186-91c9-403d8fd4134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bb97ce-d9cf-47db-93cb-02745ebeb05e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bb97ce-d9cf-47db-93cb-02745ebeb05e.jpg?1",
             "name": "Gutless Ghoul",
             "text": "{1}, Sacrifice a creature: You gain 2 life.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "b9f9e43d-a9fb-585b-bf9f-f6c2924b17c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a7101e-e6c7-40d6-82cb-daa84701d1f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a7101e-e6c7-40d6-82cb-daa84701d1f8.jpg?1",
             "name": "Haakon, Stromgald Scourge",
             "text": "You may play Haakon, Stromgald Scourge from your graveyard, but not from anywhere else.\nAs long as Haakon is in play, you may play Knight cards from your graveyard.\nWhen Haakon is put into a graveyard from play, you lose 2 life.",
             "colours": [
@@ -2100,7 +2100,7 @@
         },
         {
             "id": "39b6fbda-c995-5f3a-98e8-86346275cf5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6080b1-b032-4172-8594-4d894a60a80d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6080b1-b032-4172-8594-4d894a60a80d.jpg?1",
             "name": "Herald of Leshrac",
             "text": "Flying\nCumulative upkeep\u2014\nGain control of a land you don't control.\nHerald of Leshrac gets +1/+1 for each land you control but don't own.\nWhen Herald of Leshrac leaves play, each player gains control of each land he or she owns that you control.",
             "colours": [
@@ -2134,7 +2134,7 @@
         },
         {
             "id": "c6e30e4d-503d-5cdb-8a1f-6630848a2ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17597c66-0d9f-41af-9160-0d92be88f450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17597c66-0d9f-41af-9160-0d92be88f450.jpg?1",
             "name": "Krovikan Rot",
             "text": "Destroy target creature with power 2 or less.\nRecover {1}{B}{B} (When a creature is put into your graveyard from play, you may pay {1}{B}{B}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "b2ddc6e9-83b3-5cc8-bb3b-6fb2c776efc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f046c-b416-4d80-8998-047b98361352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f046c-b416-4d80-8998-047b98361352.jpg?1",
             "name": "Krovikan Scoundrel",
             "text": "",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "b01b5982-8ec6-52a1-8117-52f439f84fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba602e-5a81-4da2-99c0-6082f8a981e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba602e-5a81-4da2-99c0-6082f8a981e1.jpg?1",
             "name": "Martyr of Bones",
             "text": "{1}, Reveal X black cards from your hand, Sacrifice Martyr of Bones: Remove up to X target cards in a single graveyard from the game.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "50813679-9391-5964-89f8-14733fdb3b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14802be-f9d4-4984-86e0-537467f37fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14802be-f9d4-4984-86e0-537467f37fd7.jpg?1",
             "name": "Phobian Phantasm",
             "text": "Flying, fear\nCumulative upkeep {B} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "bad9c827-bc15-557b-a1a4-dde6b2bb8c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978dbf63-0842-4abd-9950-a33aa080971c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978dbf63-0842-4abd-9950-a33aa080971c.jpg?1",
             "name": "Phyrexian Etchings",
             "text": "Cumulative upkeep {B} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the end of your turn, draw a card for each age counter on Phyrexian Etchings.\nWhen Phyrexian Etchings is put into a graveyard from play, you lose 2 life for each age counter on it.",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "03fc2f0c-7d5d-523b-a07d-7d05d0b8b56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18318fe-b429-459f-9b70-d444b48b8dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18318fe-b429-459f-9b70-d444b48b8dc7.jpg?1",
             "name": "Rime Transfusion",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has \"{S}: This creature can't be blocked this turn except by snow creatures.\" ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "c812971d-1ca3-5c4e-b368-cce0a84346d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6877469b-f14e-4121-aa5d-6cea92ab7278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6877469b-f14e-4121-aa5d-6cea92ab7278.jpg?1",
             "name": "Rimebound Dead",
             "text": "{S}: Regenerate Rimebound Dead. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "fc5bf077-a943-5f3e-b653-0cd16cccfbfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b14b97d-122b-453a-9e5f-129404f96440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b14b97d-122b-453a-9e5f-129404f96440.jpg?1",
             "name": "Soul Spike",
             "text": "You may remove two black cards in your hand from the game rather than pay Soul Spike's mana cost.\nSoul Spike deals 4 damage to target creature or player and you gain 4 life.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "81c2fc36-cf69-5291-8a86-8770fcf93b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5baeff5-40e9-47b6-85a8-3a6548565b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5baeff5-40e9-47b6-85a8-3a6548565b5f.jpg?1",
             "name": "Stromgald Crusader",
             "text": "Protection from white\n{B}: Stromgald Crusader gains flying until end of turn.\n{B}{B}: Stromgald Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "6d423e44-ab9a-5bce-a693-a4e4ee2c1e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb7cb72-24f7-433b-9858-26009189daaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb7cb72-24f7-433b-9858-26009189daaa.jpg?1",
             "name": "Surging Dementia",
             "text": "Ripple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)\nTarget player discards a card.",
             "colours": [
@@ -2473,7 +2473,7 @@
         },
         {
             "id": "f206e6af-87fb-53e7-973c-afc1d74cd327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b852d9f9-069d-419a-b8d1-db30c72aaac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b852d9f9-069d-419a-b8d1-db30c72aaac6.jpg?1",
             "name": "Tresserhorn Skyknight",
             "text": "Flying\nPrevent all damage that would be dealt to Tresserhorn Skyknight by creatures with first strike.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "236f73c1-0203-50b5-8365-0e97ff435887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba464b81-2633-4422-a4b5-3593dfb7e7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba464b81-2633-4422-a4b5-3593dfb7e7aa.jpg?1",
             "name": "Void Maw",
             "text": "Trample\nIf another creature would be put into a graveyard from play, remove it from the game instead.\nPut a card removed from the game with Void Maw into its owner's graveyard: Void Maw gets +2/+2 until end of turn.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "cdc8a082-a692-5ea9-b26d-5308384c1eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cf9ade-1c3d-4104-98fa-3c6a8cccc088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cf9ade-1c3d-4104-98fa-3c6a8cccc088.jpg?1",
             "name": "Zombie Musher",
             "text": "Snow landwalk\n{S}: Regenerate Zombie Musher. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "1a62583b-efd8-537d-bbe1-fe2427641faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716c980-bd89-4297-a843-9c3e18178b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716c980-bd89-4297-a843-9c3e18178b47.jpg?1",
             "name": "Balduvian Rage",
             "text": "Target attacking creature gets +X/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "92d7336b-490b-515f-a206-7d5fff2fb27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3286dbd-c8b8-45cb-98e4-d572289f2c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3286dbd-c8b8-45cb-98e4-d572289f2c14.jpg?1",
             "name": "Balduvian Warlord",
             "text": "{T}: Remove target blocking creature from combat. Creatures it blocked that no other creature blocked this combat become unblocked, then it blocks an attacking creature of your choice. Play this ability only during the declare blockers step.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "a98acb15-a709-5505-ab06-f2a70e508bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bab8de-6e0f-4ccd-a303-01e9c8c82d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bab8de-6e0f-4ccd-a303-01e9c8c82d3f.jpg?1",
             "name": "Braid of Fire",
             "text": "Cumulative upkeep\u2014\nAdd {R} to your mana pool. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "365fc9ca-cb22-5867-860f-4757503d7e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a892711-a1a4-4402-957f-92077d00320d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a892711-a1a4-4402-957f-92077d00320d.jpg?1",
             "name": "Cryoclasm",
             "text": "Destroy target Plains or Island. Cryoclasm deals 3 damage to that land's controller.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "37ed7358-14d4-5f4a-8d2f-e500d31f760b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b347f1bf-6167-4c59-bfa6-3e921874ab9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b347f1bf-6167-4c59-bfa6-3e921874ab9a.jpg?1",
             "name": "Earthen Goo",
             "text": "Trample\nCumulative upkeep {R} or {G} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nEarthen Goo gets +1/+1 for each age counter on it.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "7c4c2699-4b6e-5724-9c9f-78ed27c89ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3223ef9-787a-40ac-8ab2-79ac75664aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3223ef9-787a-40ac-8ab2-79ac75664aa2.jpg?1",
             "name": "Fury of the Horde",
             "text": "You may remove two red cards in your hand from the game rather than pay Fury of the Horde's mana cost.\nUntap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "3aac646a-8bcc-5b47-b147-6df99991084d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8ec9c1-da73-44fb-9e30-5279a7ed4e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8ec9c1-da73-44fb-9e30-5279a7ed4e7e.jpg?1",
             "name": "Goblin Furrier",
             "text": "Prevent all damage that Goblin Furrier would deal to snow creatures.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "ad994c60-4a70-53b2-90d0-192feddf45cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254a437-5240-40ca-bf7b-d30b95942bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254a437-5240-40ca-bf7b-d30b95942bf5.jpg?1",
             "name": "Goblin Rimerunner",
             "text": "{T}: Target creature can't block this turn.\n{S}: Goblin Rimerunner gains haste until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "0a57993a-471c-59e7-94ea-3d3ece8e784a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77697b16-7faa-400d-a865-732c8b0d3d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77697b16-7faa-400d-a865-732c8b0d3d41.jpg?1",
             "name": "Greater Stone Spirit",
             "text": "Greater Stone Spirit can't be blocked by creatures with flying.\n{2}{R}: Until end of turn, target creature gets +0/+2 and gains \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "7d4885ac-83b2-5864-aa59-5844e7cd7d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf90fc3-b08b-4261-a194-d6b06fdd59d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf90fc3-b08b-4261-a194-d6b06fdd59d8.jpg?1",
             "name": "Icefall",
             "text": "Destroy target artifact or land.\nRecover {R}{R} (When a creature is put into your graveyard from play, you may pay {R}{R}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "4d472d62-c113-5877-9fa2-2cd9d1f0ea0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963f45d7-ce84-47af-ae1c-727172a31f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963f45d7-ce84-47af-ae1c-727172a31f0f.jpg?1",
             "name": "Karplusan Minotaur",
             "text": "Cumulative upkeep\u2014\nFlip a coin.\nWhenever you win a coin flip, Karplusan Minotaur deals 1 damage to target creature or player.\nWhenever you lose a coin flip, Karplusan Minotaur deals 1 damage to target creature or player of an opponent's choice.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "d3dd0086-e3f8-59ed-a617-7fbfb4edbdea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602610ce-8f42-4a1d-8f6e-92424d9d637c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602610ce-8f42-4a1d-8f6e-92424d9d637c.jpg?1",
             "name": "Karplusan Wolverine",
             "text": "Whenever Karplusan Wolverine becomes blocked, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "3f6f9209-cfc3-5efe-aeb4-8e0c8585cfb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b4f4b6-51cd-4ae0-9585-82ad964853ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b4f4b6-51cd-4ae0-9585-82ad964853ba.jpg?1",
             "name": "Lightning Serpent",
             "text": "Trample, haste\nLightning Serpent comes into play with X +1/+0 counters on it.\nAt end of turn, sacrifice Lightning Serpent.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "bcecfad9-04d1-588a-b745-7958c5599d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0388e-a04c-4757-a06d-8e8046f5a783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0388e-a04c-4757-a06d-8e8046f5a783.jpg?1",
             "name": "Lightning Storm",
             "text": "Lightning Storm deals X damage to target creature or player, where X is 3 plus the number of charge counters on it.\nDiscard a land card: Put two charge counters on Lightning Storm. You may choose a new target for it. Any player may play this ability but only if Lightning Storm is on the stack.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "aed8cb47-47e7-5572-88e1-f01f4cee41ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd7d-0b85-4b63-89c9-9e865c680bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd7d-0b85-4b63-89c9-9e865c680bd4.jpg?1",
             "name": "Lovisa Coldeyes",
             "text": "Barbarians, Warriors, and Berserkers get +2/+2 and have haste.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "1c97fdfe-0f15-5de4-9ec5-d8ec93542f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db70f9-1feb-4932-97be-02db824eda70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db70f9-1feb-4932-97be-02db824eda70.jpg?1",
             "name": "Magmatic Core",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the end of your turn, Magmatic Core deals X damage divided as you choose among any number of target creatures, where X is the number of age counters on it.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "187faff5-a906-58a1-8f17-5891a4bc1df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600a2cd2-166a-4fd8-838d-e513534b7cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600a2cd2-166a-4fd8-838d-e513534b7cb0.jpg?1",
             "name": "Martyr of Ashes",
             "text": "{2}, Reveal X red cards from your hand, Sacrifice Martyr of Ashes: Martyr of Ashes deals X damage to each creature without flying.",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "064a5b86-88aa-5e20-a169-900a82098dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6cfa21-75b1-4380-b0fc-a7450699660f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6cfa21-75b1-4380-b0fc-a7450699660f.jpg?1",
             "name": "Ohran Yeti",
             "text": "{2}{S}: Target snow creature gains first strike until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "fc825ac8-88ec-5b43-8b97-f89df59fdbc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746eaf30-3ded-4a9f-a4ec-1925edcc8e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746eaf30-3ded-4a9f-a4ec-1925edcc8e94.jpg?1",
             "name": "Orcish Bloodpainter",
             "text": "{T}, Sacrifice a creature: Orcish Bloodpainter deals 1 damage to target creature or player.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "fcc40386-5897-5f8e-9a6e-2a2ef453ee50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d0342-0ba2-46b0-bda5-6a9fe4dcad3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d0342-0ba2-46b0-bda5-6a9fe4dcad3e.jpg?1",
             "name": "Rimescale Dragon",
             "text": "Flying\n{2}{S}: Tap target creature and put an ice counter on it. ({S} can be paid with one mana from a snow permanent.)\nCreatures with ice counters on them don't untap during their controllers' untap steps.",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "af228d13-6d11-5ec4-a0e3-b6b69df2e0b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062caf7-f0eb-44db-9f74-e6711a13fada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062caf7-f0eb-44db-9f74-e6711a13fada.jpg?1",
             "name": "Rite of Flame",
             "text": "Add {R}{R} to your mana pool, then add {R} to your mana pool for each card named Rite of Flame in each graveyard.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "ec5f6665-a935-51f1-8ab4-687f3cab250d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6d42a-7607-4361-acc4-7f3cb956bfc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6d42a-7607-4361-acc4-7f3cb956bfc9.jpg?1",
             "name": "Skred",
             "text": "Skred deals damage to target creature equal to the number of snow permanents you control.",
             "colours": [
@@ -3328,7 +3328,7 @@
         },
         {
             "id": "aa6dd436-ffc4-594b-8975-16689213c1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af53d0b-ac60-4519-a6f4-c67899bcfdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af53d0b-ac60-4519-a6f4-c67899bcfdd6.jpg?1",
             "name": "Stalking Yeti",
             "text": "When Stalking Yeti comes into play, if it's in play, it deals damage equal to its power to target creature an opponent controls and that creature deals damage equal to its power to Stalking Yeti.\n{2}{S}: Return Stalking Yeti to its owner's hand. Play this ability only any time you could play a sorcery. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -3364,7 +3364,7 @@
         },
         {
             "id": "644c152c-f5cf-535a-a001-464fb2f9cade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9974a543-7429-458b-a24f-c84cbffbb54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9974a543-7429-458b-a24f-c84cbffbb54d.jpg?1",
             "name": "Surging Flame",
             "text": "Ripple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)\nSurging Flame deals 2 damage to target creature or player.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "e3bb2e50-a85f-57c4-9f83-4691a54daa7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09475e9-d6c1-4d4b-905e-40bc30405725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09475e9-d6c1-4d4b-905e-40bc30405725.jpg?1",
             "name": "Thermopod",
             "text": "{S}: Thermopod gains haste until end of turn. ({S} can be paid with one mana from a snow permanent.)\nSacrifice a creature: Add {R} to your mana pool.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "94c73448-8293-56fc-8efd-603c8628632b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3ba39-5b4d-4a7c-9215-7e349aecbeb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3ba39-5b4d-4a7c-9215-7e349aecbeb3.jpg?1",
             "name": "Allosaurus Rider",
             "text": "You may remove two green cards in your hand from the game rather than pay Allosaurus Rider's mana cost.\nAllosaurus Rider's power and toughness are each equal to 1 plus the number of lands you control.",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "ca489bd9-49f0-5fa9-8587-cf940dfd204f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da62ada-b7cd-4110-a213-281f00fca3e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da62ada-b7cd-4110-a213-281f00fca3e7.jpg?1",
             "name": "Arctic Nishoba",
             "text": "Trample\nCumulative upkeep {G} or {W} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Arctic Nishoba is put into a graveyard from play, you gain 2 life for each age counter on it.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "019f1759-374d-5beb-a81d-77e8dc2a2f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757b3ad-b808-4506-934e-727e065f66c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757b3ad-b808-4506-934e-727e065f66c1.jpg?1",
             "name": "Aurochs Herd",
             "text": "Trample\nWhen Aurochs Herd comes into play, you may search your library for an Aurochs card, reveal it, and put it into your hand. If you do, shuffle your library.\nWhenever Aurochs Herd attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.",
             "colours": [
@@ -3537,7 +3537,7 @@
         },
         {
             "id": "37de099c-0c8b-54f0-b95f-9affb82b68b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05231fa1-47b8-49aa-9393-ec4d8384c41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05231fa1-47b8-49aa-9393-ec4d8384c41b.jpg?1",
             "name": "Boreal Centaur",
             "text": "{S}: Boreal Centaur gets +1/+1 until end of turn. Play this ability only once each turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "e27cda31-285f-5c81-8cb7-058f1e68d5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d3633-6dc7-4026-a50e-3ea76b9e8c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d3633-6dc7-4026-a50e-3ea76b9e8c20.jpg?1",
             "name": "Boreal Druid",
             "text": "{T}: Add {1} to your mana pool.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "ebf5a64a-0851-5293-bdf0-313c3b3e214f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252ef807-f861-4dcf-8e52-9260301c729a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252ef807-f861-4dcf-8e52-9260301c729a.jpg?1",
             "name": "Brooding Saurian",
             "text": "At the end of each turn, each player gains control of all nontoken permanents he or she owns.",
             "colours": [
@@ -3645,7 +3645,7 @@
         },
         {
             "id": "c111a6ca-5fe9-5d58-876a-cc86922ac951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d59bd4a-006b-4dd8-ab33-d931196f3a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d59bd4a-006b-4dd8-ab33-d931196f3a8a.jpg?1",
             "name": "Bull Aurochs",
             "text": "Trample\nWhenever Bull Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "63d94faa-a602-57e1-a854-1337445b97d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafb0b4-9f01-4c67-add4-a0ffe0a3a691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafb0b4-9f01-4c67-add4-a0ffe0a3a691.jpg?1",
             "name": "Freyalise's Radiance",
             "text": "Cumulative upkeep {2} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nSnow permanents don't untap during their controllers' untap steps.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "ac984b9f-458f-57e5-8bbe-7d7505d9811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48574974-bdbb-40e8-916a-44c54b08b501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48574974-bdbb-40e8-916a-44c54b08b501.jpg?1",
             "name": "Frostweb Spider",
             "text": "Frostweb Spider can block as though it had flying.\nWhenever Frostweb Spider blocks a creature with flying, put a +1/+1 counter on Frostweb Spider at end of combat.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "315c6fa7-2abc-543b-9c72-95f4d33e04e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ab03a-99e3-4596-a19a-033845f77a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ab03a-99e3-4596-a19a-033845f77a93.jpg?1",
             "name": "Hibernation's End",
             "text": "Cumulative upkeep {1}\nWhenever you pay Hibernation's End's cumulative upkeep, you may search your library for a creature card with converted mana cost equal to the number of age counters on Hibernation's End and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -3779,7 +3779,7 @@
         },
         {
             "id": "98d73439-b7d2-5d35-a5c4-1d7d30bcf55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cea55d-8ef3-44a5-894e-967f1e97fc02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cea55d-8ef3-44a5-894e-967f1e97fc02.jpg?1",
             "name": "Into the North",
             "text": "Search your library for a snow land card and put it into play tapped. Then shuffle your library.",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "e42aa9b5-dafd-5930-982c-8371a5ba4cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d27fdf-690b-4e93-8412-4f6fb0ed43db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d27fdf-690b-4e93-8412-4f6fb0ed43db.jpg?1",
             "name": "Karplusan Strider",
             "text": "Karplusan Strider can't be the target of blue or black spells.",
             "colours": [
@@ -3845,7 +3845,7 @@
         },
         {
             "id": "c5197664-72ac-5dd8-a976-d23be4ed6025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fc47b-9a1b-4540-9c07-09e4e92ab974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fc47b-9a1b-4540-9c07-09e4e92ab974.jpg?1",
             "name": "Martyr of Spores",
             "text": "{1}, Reveal X green cards from your hand, Sacrifice Martyr of Spores: Target creature gets +X/+X until end of turn.",
             "colours": [
@@ -3880,7 +3880,7 @@
         },
         {
             "id": "c8429f16-03dc-5862-b844-c6c2a27aaf03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ff91d-acc1-4be7-a327-58fcb036b452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ff91d-acc1-4be7-a327-58fcb036b452.jpg?1",
             "name": "Mystic Melting",
             "text": "Destroy target artifact or enchantment.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "d5343316-66d2-59af-9022-3cdc2f858e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fd0ee-2350-4eb0-8417-700459879f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fd0ee-2350-4eb0-8417-700459879f74.jpg?1",
             "name": "Ohran Viper",
             "text": "Whenever Ohran Viper deals combat damage to a creature, destroy that creature at the end of combat.\nWhenever Ohran Viper deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "dac26bf3-c449-5995-84b1-16828e6ccdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063bb28b-5e32-4f31-a208-16b653edf413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063bb28b-5e32-4f31-a208-16b653edf413.jpg?1",
             "name": "Panglacial Wurm",
             "text": "Trample\nWhile you're searching your library, you may play Panglacial Wurm from your library.",
             "colours": [
@@ -3982,7 +3982,7 @@
         },
         {
             "id": "107b7135-3aee-51af-b439-25e2a7bbc895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dded16-e516-430e-a528-c49a483f03b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dded16-e516-430e-a528-c49a483f03b4.jpg?1",
             "name": "Resize",
             "text": "Target creature gets +3/+3 until end of turn.\nRecover {1}{G} (When a creature is put into your graveyard from play, you may pay {1}{G}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -4014,7 +4014,7 @@
         },
         {
             "id": "73630d6d-80d4-561a-ba7e-bfc79c04b2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3844b3f8-2d42-4265-b2dd-fa888492efff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3844b3f8-2d42-4265-b2dd-fa888492efff.jpg?1",
             "name": "Rimehorn Aurochs",
             "text": "Trample\nWhenever Rimehorn Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.\n{2}{S}: Target creature blocks target creature this turn if able. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "b0262578-d834-5c53-ac41-c25c1c21b6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b4b14c-e6fa-4cd2-9be7-fa2a2df05de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b4b14c-e6fa-4cd2-9be7-fa2a2df05de1.jpg?1",
             "name": "Ronom Hulk",
             "text": "Protection from snow\nCumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "bc68c16f-f1e3-592e-842a-a77a301a366d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5436d55d-d2d0-4f22-b399-93f1d48e080f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5436d55d-d2d0-4f22-b399-93f1d48e080f.jpg?1",
             "name": "Shape of the Wiitigo",
             "text": "Enchant creature\nWhen Shape of the Wiitigo comes into play, put six +1/+1 counters on enchanted creature.\nAt the beginning of your upkeep, put a +1/+1 counter on enchanted creature if it attacked or blocked since your last upkeep. Otherwise, remove a +1/+1 counter from it.",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "dffc0883-7177-5f0d-b9af-30a025c84545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16535ae-6e03-4992-9459-d31626a3222e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16535ae-6e03-4992-9459-d31626a3222e.jpg?1",
             "name": "Sheltering Ancient",
             "text": "Trample\nCumulative upkeep\u2014\nPut a +1/+1 counter on a creature an opponent controls. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "608afc24-b9af-58db-a80e-c46d7c254d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2ed9f3-50b1-493b-9c14-0f8ddb4d8c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2ed9f3-50b1-493b-9c14-0f8ddb4d8c57.jpg?1",
             "name": "Simian Brawler",
             "text": "Discard a land card: Simian Brawler gets +1/+1 until end of turn.",
             "colours": [
@@ -4187,7 +4187,7 @@
         },
         {
             "id": "0f0445c3-4b42-5e40-a0be-9151ecd3e421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae586221-c13c-4f4e-83ae-9b1ab0aeae61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae586221-c13c-4f4e-83ae-9b1ab0aeae61.jpg?1",
             "name": "Sound the Call",
             "text": "Put a 1/1 green Wolf creature token into play with \"This creature gets +1/+1 for each card named Sound the Call in each graveyard.\"",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "b25af5de-ff93-5b0b-ac27-6b3a2421f80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa585b7-cf7e-4f04-9490-1e6c53631647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa585b7-cf7e-4f04-9490-1e6c53631647.jpg?1",
             "name": "Steam Spitter",
             "text": "Steam Spitter can block as though it had flying.\n{R}: Steam Spitter gets +1/+0 until end of turn.",
             "colours": [
@@ -4254,7 +4254,7 @@
         },
         {
             "id": "b2d20dfb-c4c6-515d-944a-9f9217450a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa51adee-b343-4a03-8fa0-0d86244db5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa51adee-b343-4a03-8fa0-0d86244db5b7.jpg?1",
             "name": "Surging Might",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nRipple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "b6e636e0-9849-5048-ae5e-f1dac085de3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d925746c-4bba-4d50-aeee-3a3bfd165a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d925746c-4bba-4d50-aeee-3a3bfd165a2e.jpg?1",
             "name": "Blizzard Specter",
             "text": "Flying\nWhenever Blizzard Specter deals combat damage to a player, choose one That player returns a permanent he or she controls to its owner's hand; or that player discards a card.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "ecd3af67-2fb7-56cf-9793-b9d8ed5d634b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26cf431-b79b-4619-9d19-bc4557f2f9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26cf431-b79b-4619-9d19-bc4557f2f9bf.jpg?1",
             "name": "Deepfire Elemental",
             "text": "{X}{X}{1}: Destroy target artifact or creature with converted mana cost X.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "6eecbfa5-c416-5d4b-8d35-5d0a59b92e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072cf13-284b-4fb8-ab2c-b2e15388a30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072cf13-284b-4fb8-ab2c-b2e15388a30a.jpg?1",
             "name": "Diamond Faerie",
             "text": "Flying\n{1}{S}: Snow creatures you control get +1/+1 until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -4402,7 +4402,7 @@
         },
         {
             "id": "d143e995-4826-5bc8-8ac4-62cec6c92df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570143b-183b-4ae2-8806-3d0c4cd7406e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570143b-183b-4ae2-8806-3d0c4cd7406e.jpg?1",
             "name": "Garza Zol, Plague Queen",
             "text": "Flying, haste\nWhenever a creature dealt damage by Garza Zol, Plague Queen this turn is put into a graveyard, put a +1/+1 counter on Garza Zol.\nWhenever Garza Zol deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "09fe7c45-359d-5770-80f9-ac22e93b3ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce582ff6-6a21-418d-b72c-4402a43be7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce582ff6-6a21-418d-b72c-4402a43be7dc.jpg?1",
             "name": "Juniper Order Ranger",
             "text": "Whenever another creature comes into play under your control, put a +1/+1 counter on that creature and a +1/+1 counter on Juniper Order Ranger.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "7e4c6d00-b464-599e-be8b-12ab02f4134d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9257bb20-de32-460c-96cf-375acb6a0b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9257bb20-de32-460c-96cf-375acb6a0b1d.jpg?1",
             "name": "Sek'Kuar, Deathkeeper",
             "text": "Whenever another nontoken creature you control is put into a graveyard from play, put a 3/1 black and red Graveborn creature token with haste into play.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "75a84e74-668d-5091-ad49-273db8a77269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32955b-cbf6-429b-9513-17ca75d4ec2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32955b-cbf6-429b-9513-17ca75d4ec2c.jpg?1",
             "name": "Tamanoa",
             "text": "Whenever a noncreature source you control deals damage, you gain that much life.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "d455367c-98d1-5ba8-9f7b-56bc4d1487b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da89cfe-274f-452d-a5ca-b034534898c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da89cfe-274f-452d-a5ca-b034534898c7.jpg?1",
             "name": "Vanish into Memory",
             "text": "Remove target creature from the game. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to play under its owner's control. If you do, discard cards equal to its toughness.",
             "colours": [
@@ -4594,7 +4594,7 @@
         },
         {
             "id": "fe2d1b88-87fc-5e32-b68a-fc1becd19eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63632a0-1493-4a72-917c-aae1600c6230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63632a0-1493-4a72-917c-aae1600c6230.jpg?1",
             "name": "Wilderness Elemental",
             "text": "Trample\nWilderness Elemental's power is equal to the number of nonbasic lands your opponents control.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "a95c66af-5603-58a2-a8da-5c3e94326b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1255e9-c0b8-4757-a857-b27a99dd4930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1255e9-c0b8-4757-a857-b27a99dd4930.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with converted mana cost 3 or less and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "bb73ac80-704a-50a9-8c05-ef78f8f64640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd5015e-fe31-42e3-923d-44b9cdece273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd5015e-fe31-42e3-923d-44b9cdece273.jpg?1",
             "name": "Coldsteel Heart",
             "text": "Coldsteel Heart comes into play tapped.\nAs Coldsteel Heart comes into play, choose a color.\n{T}: Add one mana of the chosen color to your mana pool.",
             "colours": [],
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "2379c5e6-fd3e-5213-8e54-78409c1c402a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7118c2e0-04d6-4a71-8ffd-b9365b154050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7118c2e0-04d6-4a71-8ffd-b9365b154050.jpg?1",
             "name": "Jester's Scepter",
             "text": "When Jester's Scepter comes into play, remove the top five cards of target player's library from the game face down. You may look at those cards as long as they remain removed from the game.\n{2}, {T}, Put a card removed from the game with Jester's Scepter into its owner's graveyard: Counter target spell if it has the same name as that card.",
             "colours": [],
@@ -4729,7 +4729,7 @@
         },
         {
             "id": "f91a8a7d-89df-5c91-9137-07640a16ccbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a720448-017f-4f4a-9501-678245eaed17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a720448-017f-4f4a-9501-678245eaed17.jpg?1",
             "name": "Mishra's Bauble",
             "text": "{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -4757,7 +4757,7 @@
         },
         {
             "id": "e4883f27-3886-5e94-a450-acba4a809301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ff9859-92a4-4732-94bf-6c02b0a57338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ff9859-92a4-4732-94bf-6c02b0a57338.jpg?1",
             "name": "Phyrexian Ironfoot",
             "text": "Phyrexian Ironfoot doesn't untap during your untap step.\n{1}{S}: Untap Phyrexian Ironfoot. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "aef2e11d-3053-58d8-8c10-c67e8a04515c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3cf3d3-101e-4649-9495-8a95507d0283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3cf3d3-101e-4649-9495-8a95507d0283.jpg?1",
             "name": "Phyrexian Snowcrusher",
             "text": "Phyrexian Snowcrusher attacks each turn if able.\n{1}{S}: Phyrexian Snowcrusher gets +1/+0 until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -4825,7 +4825,7 @@
         },
         {
             "id": "f633078a-defc-56cf-bc99-83e2d62e8d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4325ea-2e84-4871-a8d6-a42b1d3d6765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4325ea-2e84-4871-a8d6-a42b1d3d6765.jpg?1",
             "name": "Phyrexian Soulgorger",
             "text": "Cumulative upkeep\u2014\nSacrifice a creature. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [],
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "503396d5-3a3c-5282-a1ac-2afc344fc7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31412335-110c-449a-9c2f-bff8763a6504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31412335-110c-449a-9c2f-bff8763a6504.jpg?1",
             "name": "Thrumming Stone",
             "text": "Spells you control have ripple 4. (Whenever you play a spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as the spell without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [],
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "6ed6c742-e486-52a0-a7e7-16cca830f6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b15f6-e65b-46d6-95e8-dc39f25d7efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b15f6-e65b-46d6-95e8-dc39f25d7efa.jpg?1",
             "name": "Arctic Flats",
             "text": "Arctic Flats comes into play tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "13437e6d-e9fa-5bb1-b1f9-8c18174393cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8396-72ab-4387-9276-987836427107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8396-72ab-4387-9276-987836427107.jpg?1",
             "name": "Boreal Shelf",
             "text": "Boreal Shelf comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "7a1aab33-99c6-5756-8f30-832f2e11bc67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92409c3a-fb1a-4205-9fe1-0f5affc7b21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92409c3a-fb1a-4205-9fe1-0f5affc7b21d.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths comes into play with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, put an indestructible legendary 20/20 black Avatar creature token with flying named Marit Lage into play.",
             "colours": [],
@@ -4986,7 +4986,7 @@
         },
         {
             "id": "ed90a13f-fe30-542a-b6e2-81f1fbdf507b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9320033-d8d7-4a01-80db-60de222040e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9320033-d8d7-4a01-80db-60de222040e6.jpg?1",
             "name": "Frost Marsh",
             "text": "Frost Marsh comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "1cfbe1be-e78b-5102-be73-402f0cb04bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bcd111-0830-4fc0-a113-37eb306fb1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bcd111-0830-4fc0-a113-37eb306fb1a0.jpg?1",
             "name": "Highland Weald",
             "text": "Highland Weald comes into play tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5052,7 +5052,7 @@
         },
         {
             "id": "4ea40f2d-5c1b-53e5-a81e-a3265b77f407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8f7396-23d3-48e2-8686-2b59ccbfc7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8f7396-23d3-48e2-8686-2b59ccbfc7e5.jpg?1",
             "name": "Mouth of Ronom",
             "text": "{T}: Add {1} to your mana pool.\n{4}{S}, {T}, Sacrifice Mouth of Ronom: Mouth of Ronom deals 4 damage to target creature. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -5082,7 +5082,7 @@
         },
         {
             "id": "0d734f03-5b93-594e-8f0d-efb6406d0115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e95422-c6fe-4750-916b-43bf22ae193a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e95422-c6fe-4750-916b-43bf22ae193a.jpg?1",
             "name": "Scrying Sheets",
             "text": "{T}: Add {1} to your mana pool.\n{1}{S}, {T}: Look at the top card of your library. If that card is snow, you may reveal it and put it into your hand. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "db8f4791-cd61-5534-b120-94df11ecb15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8fe2c-2297-4e19-8a87-01eb99b8c6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8fe2c-2297-4e19-8a87-01eb99b8c6dc.jpg?1",
             "name": "Tresserhorn Sinks",
             "text": "Tresserhorn Sinks comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "04d47c59-e710-5b59-982d-9473cb3ba4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3a010-dae3-41b6-8dd8-e31d14c3ac4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3a010-dae3-41b6-8dd8-e31d14c3ac4a.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "W",
             "colours": [],
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "159e7a7b-f1f0-558a-a0cd-066408fff13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abf0692-07d1-4b72-af06-93d0e338589d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abf0692-07d1-4b72-af06-93d0e338589d.jpg?1",
             "name": "Snow-Covered Island",
             "text": "U",
             "colours": [],
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "e06fd9e6-9d48-55a5-80c5-0e1d3756f686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dacaf1-09b8-42bb-8064-990190fdaf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dacaf1-09b8-42bb-8064-990190fdaf81.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "B",
             "colours": [],
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "a80f4058-ccc2-5d6e-b8e9-2b3706687ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc9a6d1-a1ca-4b8f-894d-71c2a9933f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc9a6d1-a1ca-4b8f-894d-71c2a9933f79.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "R",
             "colours": [],
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "dd51a4c5-3cea-5fea-a9d8-719f1ca52a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838c915d-8153-43c2-b513-dfbe4e9388a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838c915d-8153-43c2-b513-dfbe4e9388a5.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/DFT.json
+++ b/Assets/Resources/Sets/DFT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6aecfdb4-c13d-5264-8d42-eb73598c0319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c8e29-de24-4664-baf8-959608dd99ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c8e29-de24-4664-baf8-959608dd99ca.jpg?1",
             "name": "Air Response Unit",
             "text": "Flying, vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "1e8bcc6d-783f-52fb-a50d-6c119fd63e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39f7f98-ad5e-4e5e-9f7b-abe0984ffe17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39f7f98-ad5e-4e5e-9f7b-abe0984ffe17.jpg?1",
             "name": "Alacrian Armory",
             "text": "Creatures you control get +0/+1 and have vigilance.\nAt the beginning of combat on your turn, choose up to one target Mount or Vehicle you control. Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact creature if it's a Vehicle.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "a15aaad0-a878-5436-a7db-3a6182f112e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg?1",
             "name": "Basri, Tomorrow's Champion",
             "text": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink. (An exerted creature won't untap during your next untap step.)\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "b80d4a32-78a1-5a14-a94e-b8123bff492e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb819eb-ba5c-4449-87b5-3894380558bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb819eb-ba5c-4449-87b5-3894380558bc.jpg?1",
             "name": "Brightfield Glider",
             "text": "Vigilance\nWhenever this creature attacks while saddled, it gets +1/+2 and gains flying until end of turn.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "667254d6-20b4-564d-883c-cd9b1464ac0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7cacc-f15e-46c1-9c25-b567bb3e8680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7cacc-f15e-46c1-9c25-b567bb3e8680.jpg?1",
             "name": "Brightfield Mustang",
             "text": "Whenever this creature attacks while saddled, untap it and put a +1/+1 counter on it.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "95937bd0-9175-5c65-bee8-ee9e5da7b0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ce2385-e33d-47b3-96c8-5a4672d9df7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ce2385-e33d-47b3-96c8-5a4672d9df7c.jpg?1",
             "name": "Broadcast Rambler",
             "text": "When this Vehicle enters, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -218,7 +218,7 @@
         },
         {
             "id": "cad506a8-9c0f-583a-86d7-6e4e856827b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106944b2-f3ae-4350-be33-61b9f92fc92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106944b2-f3ae-4350-be33-61b9f92fc92f.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "33e98556-7504-517e-a7ca-db3cd9703d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0b15da-a45c-42f5-aafc-20ad9e38bf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0b15da-a45c-42f5-aafc-20ad9e38bf24.jpg?1",
             "name": "Canyon Vaulter",
             "text": "Whenever this creature saddles a Mount or crews a Vehicle during your main phase, that Mount or Vehicle gains flying until end of turn.",
             "colours": [
@@ -292,7 +292,7 @@
         },
         {
             "id": "a70988e3-d9b5-58da-87a4-9c206952796b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380d87a-c460-409c-8d47-9b2fc5ddd2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380d87a-c460-409c-8d47-9b2fc5ddd2ea.jpg?1",
             "name": "Cloudspire Captain",
             "text": "Mounts and Vehicles you control get +1/+1.\nThis creature saddles Mounts and crews Vehicles as though its power were 2 greater.",
             "colours": [
@@ -327,7 +327,7 @@
         },
         {
             "id": "34a67cda-6a32-5b7c-9b00-c5ddd669bec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b60da34-b622-42de-a249-79545bcbf30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b60da34-b622-42de-a249-79545bcbf30d.jpg?1",
             "name": "Collision Course",
             "text": "Choose one \u2014\n\u2022 Collision Course deals X damage to target creature, where X is the number of permanents you control that are creatures and/or Vehicles.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "ad3d8549-f3f4-5d52-86eb-251249206fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382552c-2740-409a-83a1-80b60627beb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382552c-2740-409a-83a1-80b60627beb8.jpg?1",
             "name": "Daring Mechanic",
             "text": "{3}{W}: Put a +1/+1 counter on target Mount or Vehicle.",
             "colours": [
@@ -394,7 +394,7 @@
         },
         {
             "id": "68f0abf6-6e72-5574-b0ec-9c3d00aeb482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5e64f-7af2-4cb4-abd1-23992e346bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5e64f-7af2-4cb4-abd1-23992e346bee.jpg?1",
             "name": "Detention Chariot",
             "text": "When this Vehicle enters, exile target artifact or creature an opponent controls until this Vehicle leaves the battlefield.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "0c3b8632-59c9-51c0-98b5-d4cf0d86e711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdb58b7-e1ef-496b-b8dd-d1fabf3d2e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdb58b7-e1ef-496b-b8dd-d1fabf3d2e7a.jpg?1",
             "name": "Gallant Strike",
             "text": "Destroy target creature with toughness 4 or greater.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "2d27a571-5383-598a-a964-0c8cc45152e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ac678-8b74-4865-a896-c42692c02341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ac678-8b74-4865-a896-c42692c02341.jpg?1",
             "name": "Gloryheath Lynx",
             "text": "Lifelink\nWhenever this creature attacks while saddled, search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "11a07566-145e-5311-a92a-9abff92f24d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -536,7 +536,7 @@
         },
         {
             "id": "ba1664f3-0775-50bc-aada-17d1cc198374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeea2c-d8aa-416f-95d6-6af888591fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeea2c-d8aa-416f-95d6-6af888591fdf.jpg?1",
             "name": "Guidelight Synergist",
             "text": "Flying\nThis creature gets +1/+0 for each artifact you control.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "5171c0fd-cb7c-5ef9-b6a9-5e773a4f697d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd487a-a9e6-44e3-80af-bc384316106f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd487a-a9e6-44e3-80af-bc384316106f.jpg?1",
             "name": "Interface Ace",
             "text": "This creature saddles Mounts and crews Vehicles using its toughness rather than its power.\nWhenever this creature becomes tapped during your turn, untap it. This ability triggers only once each turn.",
             "colours": [
@@ -608,7 +608,7 @@
         },
         {
             "id": "515c6f6e-9114-53bd-97f3-e50555ae5205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e4107-213f-491b-a032-8e3367009ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e4107-213f-491b-a032-8e3367009ba8.jpg?1",
             "name": "Leonin Surveyor",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nDuring your turn, this creature has first strike.\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "fb18361d-7b50-51b4-8ff5-f37f498b520e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf6a0e7-1fd4-425f-b634-c93236daea35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf6a0e7-1fd4-425f-b634-c93236daea35.jpg?1",
             "name": "Lightshield Parry",
             "text": "Target creature gets +2/+2 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "1b7bae84-d1ee-5bdf-9d37-99ea75155816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab169c1-4e25-4a5d-8961-4f06298c3781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab169c1-4e25-4a5d-8961-4f06298c3781.jpg?1",
             "name": "Lightwheel Enhancements",
             "text": "Enchant creature or Vehicle\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nEnchanted permanent gets +1/+1 and has vigilance.\nMax speed \u2014 You may cast this card from your graveyard.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "5b90fb65-d2ed-5c69-a09e-42b0a33b3776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80645651-3804-481f-8f8f-ade762a011e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80645651-3804-481f-8f8f-ade762a011e1.jpg?1",
             "name": "Lotusguard Disciple",
             "text": "Flying\nWhen this creature enters, target creature or Vehicle gains lifelink and indestructible until end of turn.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "2396eeab-94ff-5384-b9e5-c5e1acc413d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829c0ae-f72f-4195-ad43-775d7218565c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829c0ae-f72f-4195-ad43-775d7218565c.jpg?1",
             "name": "Nesting Bot",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature dies, create a 1/1 colorless Servo artifact creature token.\nMax speed \u2014 This creature gets +1/+0.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "62ac529d-8776-597a-b701-d64454e4ad73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg?1",
             "name": "Perilous Snare",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed \u2014 {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "39d13575-1740-5b5c-8fbc-dad3cf1f65be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4172222f-d871-4354-9a02-7af0001d8956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4172222f-d871-4354-9a02-7af0001d8956.jpg?1",
             "name": "Pride of the Road",
             "text": "Vigilance\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 At the beginning of combat on your turn, target creature or Vehicle you control gains double strike until end of turn.",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "0952d25c-716a-5a37-8285-2929d3f40ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f96b33b-c952-45ac-9626-40169b2bd4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f96b33b-c952-45ac-9626-40169b2bd4ef.jpg?1",
             "name": "Ride's End",
             "text": "This spell costs {3} less to cast if it targets a tapped permanent.\nExile target creature or Vehicle.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "b36305b4-3076-5eb6-af7e-bb7438b69bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2a9154-7b43-4b8d-9d81-d11cfda5d597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2a9154-7b43-4b8d-9d81-d11cfda5d597.jpg?1",
             "name": "Roadside Assistance",
             "text": "Enchant creature or Vehicle\nWhen this Aura enters, create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"\nEnchanted permanent gets +1/+1 and has lifelink.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "ebc8962e-9cde-5a95-bea2-cb40bd8ff85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ed1bf2-0f3c-4528-b570-e5bdcd7ffda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ed1bf2-0f3c-4528-b570-e5bdcd7ffda9.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "cacc7245-c05e-583b-b140-e53dca3d8261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "2af2fffd-a539-5c14-8bc0-fa54e044d224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24a6309-0e69-45f0-a9ff-44d4997e7e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24a6309-0e69-45f0-a9ff-44d4997e7e4d.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "ebe644fa-fc6d-5cb7-850f-7201b3e262dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0489108-75b7-441c-888d-12987c0c1080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0489108-75b7-441c-888d-12987c0c1080.jpg?1",
             "name": "Spotcycle Scouter",
             "text": "When this Vehicle enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -1067,7 +1067,7 @@
         },
         {
             "id": "7cfa0e5c-471b-580c-a5e2-9320f125dd63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5435c-52f3-42d7-bcee-5aa13afd6626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5435c-52f3-42d7-bcee-5aa13afd6626.jpg?1",
             "name": "Sundial, Dawn Tyrant",
             "text": "",
             "colours": [
@@ -1104,7 +1104,7 @@
         },
         {
             "id": "f392deed-944c-5af8-abe5-298e4f67f0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db9bb9-d930-40e5-b144-01ebfd377996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db9bb9-d930-40e5-b144-01ebfd377996.jpg?1",
             "name": "Swiftwing Assailant",
             "text": "Flying\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 This creature gets +0/+1 and has vigilance.",
             "colours": [
@@ -1139,7 +1139,7 @@
         },
         {
             "id": "7dada4b5-ee3a-57fa-a464-159e45db71a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bddc5f-8f25-4313-b5bb-e5eae2923878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bddc5f-8f25-4313-b5bb-e5eae2923878.jpg?1",
             "name": "Tune Up",
             "text": "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.",
             "colours": [
@@ -1173,7 +1173,7 @@
         },
         {
             "id": "90a8de74-d829-5373-9716-35bbf3e25c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12296a74-5d60-4ee3-aa53-2289f84da776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12296a74-5d60-4ee3-aa53-2289f84da776.jpg?1",
             "name": "Unswerving Sloth",
             "text": "Whenever this creature attacks while saddled, it gains indestructible until end of turn. Untap all creatures you control.\nSaddle 4 (Tap any number of other creatures you control with total power 4 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "1acc5cf4-6e6f-5116-8e56-448f4e15ace8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W} ({X}{2}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "6bd581d3-be0f-59fc-b839-9a5226f24568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "e35e26cb-14a0-5dae-a03e-a2abba9a29f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcdc8c-fba1-4ea1-bf93-65072d10f0da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcdc8c-fba1-4ea1-bf93-65072d10f0da.jpg?1",
             "name": "Voyager Quickwelder",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "327b55b6-813f-5001-83cd-952adf695544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7033739-4cd8-4727-b9b5-099fb597006b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7033739-4cd8-4727-b9b5-099fb597006b.jpg?1",
             "name": "Aether Syphon",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}, {T}: Draw a card.\nMax speed \u2014 Whenever you draw a card, each opponent mills two cards. (Each opponent puts the top two cards of their library into their graveyard.)",
             "colours": [
@@ -1354,7 +1354,7 @@
         },
         {
             "id": "eec8d82b-776d-5f5d-9a96-bfe4cce55516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c8dda-2405-4879-8dd1-e790a833c42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c8dda-2405-4879-8dd1-e790a833c42d.jpg?1",
             "name": "Bounce Off",
             "text": "Return target creature or Vehicle to its owner's hand.",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "d05c7dbd-6f18-5aa2-b4cc-5dbce1302bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8654e38-4230-4094-b815-778bfb5d06f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8654e38-4230-4094-b815-778bfb5d06f2.jpg?1",
             "name": "Caelorna, Coral Tyrant",
             "text": "",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "0a40ba66-92a2-5e5f-97e2-dc11767543bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d4fa6-1fa3-4bfd-a462-47c23ccf9124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d4fa6-1fa3-4bfd-a462-47c23ccf9124.jpg?1",
             "name": "Diversion Unit",
             "text": "Flying\n{U}, Sacrifice this creature: Counter target instant or sorcery spell unless its controller pays {3}.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "0bd790e1-5a03-5f55-b561-31f3fb7b8516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57402f7c-5d4c-4f1e-8bce-a2328a297111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57402f7c-5d4c-4f1e-8bce-a2328a297111.jpg?1",
             "name": "Flood the Engine",
             "text": "Enchant creature or Vehicle\nWhen this Aura enters, tap enchanted permanent.\nEnchanted permanent loses all abilities and doesn't untap during its controller's untap step.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "a8406742-cf37-55fd-98ad-a2d2144148e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dca0007-42d3-4ee2-8e88-361d80a7103c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dca0007-42d3-4ee2-8e88-361d80a7103c.jpg?1",
             "name": "Gearseeker Serpent",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{5}{U}: This creature can't be blocked this turn.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "fa80c148-0142-574e-acb2-a88cd0105200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bb89b9-50dd-4b36-aa10-aba585e50246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bb89b9-50dd-4b36-aa10-aba585e50246.jpg?1",
             "name": "Glitch Ghost Surveyor",
             "text": "Flying\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -1560,7 +1560,7 @@
         },
         {
             "id": "d32140c1-e977-54a6-96a9-9eedc59f5614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fc07dd-05b1-49ed-a3ee-46c31b8e0a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fc07dd-05b1-49ed-a3ee-46c31b8e0a3d.jpg?1",
             "name": "Guidelight Optimizer",
             "text": "{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "71bc9467-8e35-5d5c-8a47-f10cc1333884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbd7758-59c7-4ae1-9af8-c3580f4aa958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbd7758-59c7-4ae1-9af8-c3580f4aa958.jpg?1",
             "name": "Howler's Heavy",
             "text": "Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle this card, target creature or Vehicle an opponent controls gets -3/-0 until end of turn.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "dba0ea70-2d45-5881-a372-beb8d2185d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402666f8-c9cc-4e8f-abaa-6c38be90cdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402666f8-c9cc-4e8f-abaa-6c38be90cdd2.jpg?1",
             "name": "Hulldrifter",
             "text": "Flying\nWhen this Vehicle enters, draw two cards.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -1666,7 +1666,7 @@
         },
         {
             "id": "e5bccfb5-45ed-57cb-bdad-a09c5f4930e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed90a63-5aca-470a-8e1e-518d8aeb6d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed90a63-5aca-470a-8e1e-518d8aeb6d91.jpg?1",
             "name": "Keen Buccaneer",
             "text": "Vigilance\nExhaust \u2014 {1}{U}: Draw a card, then discard a card. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -1701,7 +1701,7 @@
         },
         {
             "id": "2ad38154-bbe1-5fd0-821b-8f31abed0788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199ce2-0ea0-47e5-a36c-36373be53fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199ce2-0ea0-47e5-a36c-36373be53fec.jpg?1",
             "name": "Memory Guardian",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "77fee2dc-125d-5f58-8922-6dc16643bed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237568e3-7331-4bbb-a091-a766723134fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237568e3-7331-4bbb-a091-a766723134fc.jpg?1",
             "name": "Midnight Mangler",
             "text": "During turns other than yours, this Vehicle is an artifact creature.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -1773,7 +1773,7 @@
         },
         {
             "id": "8d351e6c-0ec2-5a54-bef7-c74593426bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control. (Activate each exhaust ability only once.)",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "38d80993-9c70-5d49-a493-31f6b2bb67a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "961b7322-bf7a-5120-9417-c75ee7d06631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47717312-f6c6-4e86-ba6a-a30698962430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47717312-f6c6-4e86-ba6a-a30698962430.jpg?1",
             "name": "Nimble Thopterist",
             "text": "When this creature enters, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "e18ff3d1-e51b-53b2-99f9-92f1b3e52136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -1928,7 +1928,7 @@
         },
         {
             "id": "b690d6a7-9d70-5846-a085-f0bcbabe1673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d2d713-8acb-4e3d-bd1d-0416fe9b9ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d2d713-8acb-4e3d-bd1d-0416fe9b9ef6.jpg?1",
             "name": "Rangers' Refueler",
             "text": "Whenever you activate an exhaust ability, draw a card.\nExhaust \u2014 {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. (Activate each exhaust ability only once.)\nCrew 2",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "20eee566-d709-54d6-b909-ef72dc40869f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg?1",
             "name": "Repurposing Bay",
             "text": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "57be02a5-3be2-5333-add6-1cf35b952e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg?1",
             "name": "Riverchurn Monument",
             "text": "{1}, {T}: Any number of target players each mill two cards. (Each of them puts the top two cards of their library into their graveyard.)\nExhaust \u2014 {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard. (Activate each exhaust ability only once.)",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "96160413-b40d-5aca-8a01-9cd5b7a60322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6153a76-56f7-46ee-bba5-b62c0143388a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6153a76-56f7-46ee-bba5-b62c0143388a.jpg?1",
             "name": "Roadside Blowout",
             "text": "This spell costs {2} less to cast if it targets a permanent with mana value 1.\nReturn target creature or Vehicle an opponent controls to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "2a003ce3-122c-5517-955d-26ff82f318d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bb15e2-e1ad-4645-aab0-df4a1a68563d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bb15e2-e1ad-4645-aab0-df4a1a68563d.jpg?1",
             "name": "Sabotage Strategist",
             "text": "Flying, vigilance\nWhenever one or more creatures attack you, those creatures get -1/-0 until end of turn.\nExhaust \u2014 {5}{U}{U}: Put three +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "f4ff3b77-9882-5792-9c3e-4c15a83bcf25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60bece3-6f63-4d9e-bca0-cef2d38f1472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60bece3-6f63-4d9e-bca0-cef2d38f1472.jpg?1",
             "name": "Scrounging Skyray",
             "text": "Flying\nWhenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "838258e5-d677-58b0-b9c8-bad18c501c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9c501-098d-4560-9826-329b05689e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9c501-098d-4560-9826-329b05689e0f.jpg?1",
             "name": "Skystreak Engineer",
             "text": "Flying\nExhaust \u2014 {4}{U}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "7bc06d0f-3783-55d4-857d-f3adf98a4253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e86ef50-4939-4e7c-853d-438f0f3e0411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e86ef50-4939-4e7c-853d-438f0f3e0411.jpg?1",
             "name": "Slick Imitator",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {1}, Sacrifice this creature: Copy target spell you control. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "32e94b6f-9296-58d4-94c5-4f8a79ca1124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860cb8af-a5f6-47e7-a34b-7b9f11ddc8c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860cb8af-a5f6-47e7-a34b-7b9f11ddc8c6.jpg?1",
             "name": "Spectral Interference",
             "text": "Counter target artifact or creature spell unless its controller pays {4}.",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "f3c70910-6c9f-57ec-8c2e-9ecf10078dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4374f-0301-4b2e-bc99-2cd19568cb3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4374f-0301-4b2e-bc99-2cd19568cb3b.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "758bcfad-dd54-5ea8-bbe5-be2be8fbc76a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1ece22-ca32-45bb-b5f4-480f9b366cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1ece22-ca32-45bb-b5f4-480f9b366cb5.jpg?1",
             "name": "Spikeshell Harrier",
             "text": "When this creature enters, return target creature or Vehicle an opponent controls to its owner's hand. If that opponent's speed is greater than each other player's speed, reduce that opponent's speed by 1. This effect can't reduce their speed below 1.",
             "colours": [
@@ -2305,7 +2305,7 @@
         },
         {
             "id": "22f1e890-e596-51c2-a699-5834d0f55f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea0e0d3-833f-4353-b648-57b0b657cc1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea0e0d3-833f-4353-b648-57b0b657cc1c.jpg?1",
             "name": "Stall Out",
             "text": "Tap target creature or Vehicle, then put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "f9e54eed-c35e-57fd-b76b-5c662c3cae79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a786855-6eb4-42c0-a528-4842db46809d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a786855-6eb4-42c0-a528-4842db46809d.jpg?1",
             "name": "Stock Up",
             "text": "Look at the top five cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "26a7bb43-08a1-58f4-b5ff-5b3714f1c7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "5241f0d4-844f-55c2-bd32-2203642ba895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0b5c09-6c21-4080-81c4-a8376deb729f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0b5c09-6c21-4080-81c4-a8376deb729f.jpg?1",
             "name": "Trade the Helm",
             "text": "Exchange control of target artifact or creature you control and target artifact or creature an opponent controls.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "bc3fce6f-bd7a-5b14-bcd6-1c83985a80eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6727169f-c33a-4ca5-889d-a63bcfc5a3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6727169f-c33a-4ca5-889d-a63bcfc5a3f0.jpg?1",
             "name": "Transit Mage",
             "text": "When this creature enters, you may search your library for an artifact card with mana value 4 or 5, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "6ab9aaeb-4e71-5fd7-a596-2f9a9973c31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273061f3-7aa7-4cb0-afd6-616252b88948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273061f3-7aa7-4cb0-afd6-616252b88948.jpg?1",
             "name": "Trip Up",
             "text": "Target nonland permanent's owner puts it on their choice of the top or bottom of their library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "9a7b3939-66c3-52bd-87e1-aa6e8eb928dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg?1",
             "name": "Unstoppable Plan",
             "text": "At the beginning of your end step, untap all nonland permanents you control.",
             "colours": [
@@ -2541,7 +2541,7 @@
         },
         {
             "id": "161516ee-035c-539d-8fd3-bd47ebde1d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg?1",
             "name": "Vnwxt, Verbose Host",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nYou have no maximum hand size.\nMax speed \u2014 If you would draw a card, draw two cards instead.",
             "colours": [
@@ -2580,7 +2580,7 @@
         },
         {
             "id": "33ffd84d-be0f-582d-9136-37cd4b22a1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "dec25922-9108-5ded-b1f1-c3e799b4fb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230301f2-f288-4b13-9f62-e649ad8357bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230301f2-f288-4b13-9f62-e649ad8357bb.jpg?1",
             "name": "Ancient Vendetta",
             "text": "Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. Then that player shuffles.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "96385267-f5a5-56c4-8252-2e9ae7e21666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c0032-9c62-4028-a55f-6a3da2545654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c0032-9c62-4028-a55f-6a3da2545654.jpg?1",
             "name": "Back on Track",
             "text": "Return target creature or Vehicle card from your graveyard to the battlefield. Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "5ad3166a-1694-5462-9c92-61c26dd4cfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdceefe6-f083-4955-b53a-8e6f8aeb2083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdceefe6-f083-4955-b53a-8e6f8aeb2083.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "e940f5d9-ffe8-5b34-b665-bc74df157d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fdee-3d24-4360-a4d2-ffd3c08a462d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fdee-3d24-4360-a4d2-ffd3c08a462d.jpg?1",
             "name": "Carrion Cruiser",
             "text": "When this Vehicle enters, mill two cards. Then return a creature or Vehicle card from your graveyard to your hand. (To mill two cards, put the top two cards of your library into your graveyard.)\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "c341e07c-b470-5e9b-93cc-9fa8676cfd6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4141-04a3-44c4-9d3e-aa2a773d9883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4141-04a3-44c4-9d3e-aa2a773d9883.jpg?1",
             "name": "Chitin Gravestalker",
             "text": "This spell costs {1} less to cast for each artifact and/or creature card in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e74608ea-afde-5bf5-a668-b566951d7c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "a26d134b-0d6f-544d-954d-965c090293ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5803b32-4a81-46c2-9b10-3198a709611d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5803b32-4a81-46c2-9b10-3198a709611d.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost. (Exile that card and pay its embalm cost: Create a token that's a copy of it, except it's a white Zombie in addition to its other types and has no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "b668dc0b-ee57-59af-bf06-3359384b633c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e704fb95-17b7-432a-831c-18abe7d9cc73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e704fb95-17b7-432a-831c-18abe7d9cc73.jpg?1",
             "name": "Deathless Pilot",
             "text": "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\n{3}{B}: Return this card from your graveyard to your hand.",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "c6c5b2d7-3334-510c-943a-ead373f6548a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "1f02ee50-90a0-52d6-8809-7dfb091568fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949d6137-98d3-4f46-ab1e-08d7492af307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949d6137-98d3-4f46-ab1e-08d7492af307.jpg?1",
             "name": "Engine Rat",
             "text": "Deathtouch\n{5}{B}: Each opponent loses 2 life.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "5606158b-fb82-59c1-a05e-5c5f69b57f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -3014,7 +3014,7 @@
         },
         {
             "id": "bf28e57c-bd11-59cd-9bcd-217c480e2499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4877b5-4ce5-466a-810f-6501f2a0f217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4877b5-4ce5-466a-810f-6501f2a0f217.jpg?1",
             "name": "Gastal Raider",
             "text": "Start your engines\nWhen this creature enters, target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.\nMax speed \u2014 This creature gets +1/+1 and has menace.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "6f8a99f7-c4ac-53af-8474-35090312a16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ca40a-e5c0-4956-8df0-ecbd2a25656f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ca40a-e5c0-4956-8df0-ecbd2a25656f.jpg?1",
             "name": "Gonti, Night Minister",
             "text": "Whenever a player casts a spell they don't own, that player creates a Treasure token.\nWhenever a creature deals combat damage to one of your opponents, its controller looks at the top card of that opponent's library and exiles it face down. They may play that card for as long as it remains exiled. Mana of any type can be spent to cast a spell this way.",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "5a143700-31bd-579e-900a-775b99c28e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdf60a-6f67-4872-8961-d63776b192c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdf60a-6f67-4872-8961-d63776b192c3.jpg?1",
             "name": "Grim Bauble",
             "text": "When this artifact enters, target creature an opponent controls gets -2/-2 until end of turn.\n{2}{B}, {T}, Sacrifice this artifact: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "57f29bdd-4494-5172-8ec7-7f0b7121f16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87154116-e306-4e15-bd5a-dcdb5ddbcd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87154116-e306-4e15-bd5a-dcdb5ddbcd36.jpg?1",
             "name": "Grim Javelineer",
             "text": "Whenever you attack, target attacking creature gets +1/+0 until end of turn. When that creature dies this turn, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "30a99c3d-823c-5e69-8235-e7d587a1ea59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9db650-47f9-46d7-ac17-8d19fef6d6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9db650-47f9-46d7-ac17-8d19fef6d6b0.jpg?1",
             "name": "Hellish Sideswipe",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDestroy target creature or Vehicle. If the sacrificed permanent was a Vehicle, draw a card.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "648e912b-7ddf-5362-b0bb-90160d199458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9192abc8-05a3-4e72-a634-fc5acbe97b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9192abc8-05a3-4e72-a634-fc5acbe97b26.jpg?1",
             "name": "Hour of Victory",
             "text": "Start your engines\nWhen this enchantment enters, create a 2/2 black Zombie creature token.\nMax speed \u2014 {1}{B}, Sacrifice this enchantment: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "3f0934f7-1ec0-50c0-8883-1a5bb1b27bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e6022-44d2-4dfe-8f7a-51581e298f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e6022-44d2-4dfe-8f7a-51581e298f23.jpg?1",
             "name": "Intimidation Tactics",
             "text": "Target opponent reveals their hand. You choose an artifact or creature card from it. Exile that card.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "0a8740a9-040a-5a10-9710-54c1cf338b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1214fc6d-ae47-418d-88cc-58633ec2ac7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1214fc6d-ae47-418d-88cc-58633ec2ac7a.jpg?1",
             "name": "Kalakscion, Hunger Tyrant",
             "text": "",
             "colours": [
@@ -3290,7 +3290,7 @@
         },
         {
             "id": "26218079-9a28-5e9a-b322-80ff84a92a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbb7b4e-bd32-44a0-9396-16738c5e4381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbb7b4e-bd32-44a0-9396-16738c5e4381.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "261c7bf3-b567-5004-935f-638b98755eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b3a547-6f74-4cb4-ad98-7e1b75f1a120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b3a547-6f74-4cb4-ad98-7e1b75f1a120.jpg?1",
             "name": "Locust Spray",
             "text": "Target creature gets -1/-1 until end of turn.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3362,7 +3362,7 @@
         },
         {
             "id": "3c59331b-74e7-5431-97bd-6240d6ab7011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e5bb2-cfe9-48e5-86f9-e21f3d328327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e5bb2-cfe9-48e5-86f9-e21f3d328327.jpg?1",
             "name": "Maximum Overdrive",
             "text": "Put a +1/+1 counter on target creature. It gains deathtouch and indestructible until end of turn.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "7c73bb8e-a38c-5b22-8934-23831ff6e479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38513b53-384f-45e7-9905-80dd2c3c4918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38513b53-384f-45e7-9905-80dd2c3c4918.jpg?1",
             "name": "Momentum Breaker",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, each opponent sacrifices a creature or Vehicle of their choice. Each opponent who can't discards a card.\n{2}, Sacrifice this enchantment: You gain life equal to your speed.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "2228a495-e14e-51ea-aeab-4bac8aec60a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cec5105-3907-40d2-8e46-95acfaaaa0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cec5105-3907-40d2-8e46-95acfaaaa0cc.jpg?1",
             "name": "Mutant Surveyor",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}: This creature gets +1/+1 until end of turn.\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "7a916339-5e81-5c09-902b-5b2bc7d14e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70226354-47b7-4f9d-a5a8-559d17f07720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70226354-47b7-4f9d-a5a8-559d17f07720.jpg?1",
             "name": "Pactdoll Terror",
             "text": "Whenever this creature or another artifact you control enters, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3496,7 +3496,7 @@
         },
         {
             "id": "f9aca8ad-deb4-592d-87e3-68bfdfb4d21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8b6033-63e6-484e-8efb-a4eb9ca59fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8b6033-63e6-484e-8efb-a4eb9ca59fbf.jpg?1",
             "name": "Quag Feast",
             "text": "Choose target creature, planeswalker, or Vehicle. Mill two cards, then destroy the chosen permanent if its mana value is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "552071c2-998f-5d74-bc05-145e125a6ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4981a4a-6eca-4f84-8715-8e2672507b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4981a4a-6eca-4f84-8715-8e2672507b59.jpg?1",
             "name": "Ripclaw Wrangler",
             "text": "When this Vehicle enters, each opponent discards a card.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "1a4bb799-99f1-570d-8ddf-b726240ef663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a68482a-401d-48e7-854e-46e3db07ff35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a68482a-401d-48e7-854e-46e3db07ff35.jpg?1",
             "name": "Risen Necroregent",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 At the beginning of your end step, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "30fd615c-f6c0-56ce-bb7f-3484dbe15a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80aa587-4445-43d7-abc0-654d94ff4cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80aa587-4445-43d7-abc0-654d94ff4cda.jpg?1",
             "name": "Risky Shortcut",
             "text": "Draw two cards. Each player loses 2 life.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "e40b50fd-b83b-5cd3-b57a-d53bfb9bb16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079dc8d2-0de3-415e-8af8-b8dec669368a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079dc8d2-0de3-415e-8af8-b8dec669368a.jpg?1",
             "name": "Shefet Archfiend",
             "text": "Flying\nWhen this creature enters, all other creatures get -2/-2 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "7091907f-c236-50a7-bf59-413cbf40464e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -3709,7 +3709,7 @@
         },
         {
             "id": "0a98382c-17fe-56ad-8ab7-eafe2f5923c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be722ac5-e8c4-4180-aed0-7c28895afc0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be722ac5-e8c4-4180-aed0-7c28895afc0d.jpg?1",
             "name": "Spin Out",
             "text": "Destroy target creature or Vehicle.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "c9eb5fae-ed38-5cdc-8d81-928a7b982a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff120a2-e2bb-42a2-bcb7-a48eb7a6d9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff120a2-e2bb-42a2-bcb7-a48eb7a6d9b2.jpg?1",
             "name": "Streaking Oilgorger",
             "text": "Flying, haste\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 This creature has lifelink.",
             "colours": [
@@ -3775,7 +3775,7 @@
         },
         {
             "id": "eb4ffc0e-b40b-5fe0-b921-e89b216c9ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af17ae0-1035-4cb2-8974-98b377bfaa48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af17ae0-1035-4cb2-8974-98b377bfaa48.jpg?1",
             "name": "Syphon Fuel",
             "text": "Target creature gets -6/-6 until end of turn. You gain 2 life.",
             "colours": [
@@ -3807,7 +3807,7 @@
         },
         {
             "id": "6ff56e65-f50a-528a-bc0c-bc0c395d142a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba78e076-8962-4b3f-b86f-04400b062951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba78e076-8962-4b3f-b86f-04400b062951.jpg?1",
             "name": "Wickerfolk Indomitable",
             "text": "You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "8ca67537-927a-51d7-8639-d9f3759b4ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeff3db7-81ac-4c51-9954-bc1dbcb8c4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeff3db7-81ac-4c51-9954-bc1dbcb8c4e3.jpg?1",
             "name": "Wreckage Wickerfolk",
             "text": "Flying\nWhen this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "c6ac77c7-a26e-503b-8934-d85f564b7ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4983177d-fbf4-47fa-997f-9d08294870f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4983177d-fbf4-47fa-997f-9d08294870f2.jpg?1",
             "name": "Wretched Doll",
             "text": "{B}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "80558364-dbb1-5ddd-b933-52746710430c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8655373-320d-440d-b700-d03413f743fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8655373-320d-440d-b700-d03413f743fd.jpg?1",
             "name": "Adrenaline Jockey",
             "text": "Whenever a player casts a spell, if it's not their turn, this creature deals 4 damage to them.\nWhenever you activate an exhaust ability, put a +1/+1 counter on this creature.",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "f2b96ac0-a174-5bed-b463-3bfc74f6abd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle. (Activate each exhaust ability only once.)\nCrew 2",
             "colours": [
@@ -3985,7 +3985,7 @@
         },
         {
             "id": "6f5ee150-c62f-5938-8f92-ed81a8007d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecee6509-1103-4ae5-a2e7-0441f5d4a872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecee6509-1103-4ae5-a2e7-0441f5d4a872.jpg?1",
             "name": "Burner Rocket",
             "text": "Flash\nWhen this Vehicle enters, target creature you control gets +2/+0 and gains trample until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "804338dc-15f0-546a-b673-5e05b721a8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db66e7b-cb7a-4d86-a563-d570946aeb0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db66e7b-cb7a-4d86-a563-d570946aeb0d.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "12f091b0-4f2d-5717-830f-e878bbbb1c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n\u22127: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "bc9ef912-e7fc-5e25-b409-2a16b3c9cd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4701da52-b9c8-4ce9-9d57-53e10899f19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4701da52-b9c8-4ce9-9d57-53e10899f19d.jpg?1",
             "name": "Clamorous Ironclad",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "1e8e0d38-5a88-5103-aab9-6cadbe3b2826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f31beae-9b8f-4c32-af84-9f3ee767ba1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f31beae-9b8f-4c32-af84-9f3ee767ba1d.jpg?1",
             "name": "Count on Luck",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "e5d3ef64-0069-5fd3-a63d-0225791b4270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a41a1-b36f-4b81-b74c-220d279c0e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a41a1-b36f-4b81-b74c-220d279c0e26.jpg?1",
             "name": "Crash and Burn",
             "text": "Choose one \u2014\n\u2022 Destroy target Vehicle.\n\u2022 Crash and Burn deals 6 damage to target creature or planeswalker.",
             "colours": [
@@ -4203,7 +4203,7 @@
         },
         {
             "id": "a944eade-8ed0-5451-85c5-bd40ea2e54ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg?1",
             "name": "Daretti, Rocketeer Engineer",
             "text": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "651f6dee-6355-51f4-ba96-a9af3fc62326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44440be-e611-4e70-9919-b08e2354b7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44440be-e611-4e70-9919-b08e2354b7ad.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "4db9fea1-b7ff-5d76-a662-fbf55497b421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf800b8c-d08e-4644-8ed2-11b839153861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf800b8c-d08e-4644-8ed2-11b839153861.jpg?1",
             "name": "Dracosaur Auxiliary",
             "text": "Flying, haste\nWhenever this creature attacks while saddled, it deals 2 damage to any target.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4318,7 +4318,7 @@
         },
         {
             "id": "81521594-ae43-54fb-bc34-74dbf1f9aad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4f96f6-dd91-4357-ae19-1c35db2c2bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4f96f6-dd91-4357-ae19-1c35db2c2bcb.jpg?1",
             "name": "Dynamite Diver",
             "text": "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\nWhen this creature dies, it deals 1 damage to any target.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "c81d00ef-bf54-5d1c-9cbd-865114f618db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5a67b-d969-4ba4-9dcc-32d0c2e5c04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5a67b-d969-4ba4-9dcc-32d0c2e5c04a.jpg?1",
             "name": "Endrider Catalyzer",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {T}: Add {R}{R}.",
             "colours": [
@@ -4388,7 +4388,7 @@
         },
         {
             "id": "dcca8315-c40b-570b-8987-4a7209877326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e58cb18-f216-4248-8f0d-65b0263c5c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e58cb18-f216-4248-8f0d-65b0263c5c28.jpg?1",
             "name": "Endrider Spikespitter",
             "text": "Reach\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "5c0cf323-8c64-53b2-bb49-707cb6defde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624335fb-8a0b-4fa9-aefb-60ac641a7934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624335fb-8a0b-4fa9-aefb-60ac641a7934.jpg?1",
             "name": "Fuel the Flames",
             "text": "Fuel the Flames deals 2 damage to each creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "a32adc12-99e2-5d1c-bcbf-2ba53f020836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg?1",
             "name": "Full Throttle",
             "text": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
             "colours": [
@@ -4490,7 +4490,7 @@
         },
         {
             "id": "e9a246fc-9afd-547f-806f-11f83485cde2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca41ec6-8f8f-42ef-abac-cc645c6440b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca41ec6-8f8f-42ef-abac-cc645c6440b7.jpg?1",
             "name": "Gastal Blockbuster",
             "text": "When this creature enters, you may sacrifice a creature or Vehicle. When you do, destroy target artifact an opponent controls.",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "c4e88a27-1752-599c-9ca5-cda0770869c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "c08179a3-710c-5dd6-8c58-b4a2f2e822b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55685602-a18c-43a4-ac60-13b039672fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55685602-a18c-43a4-ac60-13b039672fa4.jpg?1",
             "name": "Gilded Ghoda",
             "text": "Whenever this creature attacks while saddled, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "752f10d6-6f5d-5552-9134-328cdf92c6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efffe9-00f8-4177-a9e6-4ad62887d32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efffe9-00f8-4177-a9e6-4ad62887d32f.jpg?1",
             "name": "Goblin Surveyor",
             "text": "Trample\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "94ba0acd-9598-5224-a512-141e0338d6db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f0b123-fdb0-4f3e-ba78-fa155c227e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f0b123-fdb0-4f3e-ba78-fa155c227e20.jpg?1",
             "name": "Greasewrench Goblin",
             "text": "Exhaust \u2014 {2}{R}: Discard up to two cards, then draw that many cards. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "28f1d519-6f5d-5023-8964-aed9b62bb816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "30e96ef9-6a7f-5f17-9ea7-85e39da2013c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "18fd6e55-3111-51de-ad08-52ee2e0ffe02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5590e1-0ac0-4bdd-815b-136bf24ced03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5590e1-0ac0-4bdd-815b-136bf24ced03.jpg?1",
             "name": "Kickoff Celebrations",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, you may discard a card. If you do, draw two cards.\nMax speed \u2014 Sacrifice this enchantment: Creatures and Vehicles you control gain haste until end of turn.",
             "colours": [
@@ -4779,7 +4779,7 @@
         },
         {
             "id": "9286c27c-19d7-5fdf-a97e-ff4e325a47df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30077b49-b825-4dbb-a0c7-f3992f647df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30077b49-b825-4dbb-a0c7-f3992f647df0.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "48e6b39b-92f6-565d-bafe-a2377cdcfffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac26341-a100-424d-be84-33fbbf1b4078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac26341-a100-424d-be84-33fbbf1b4078.jpg?1",
             "name": "Magmakin Artillerist",
             "text": "Whenever you discard one or more cards, this creature deals that much damage to each opponent.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle this card, it deals 1 damage to each opponent.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "3e8b2550-5520-5f87-a362-5ae234090def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efbfd67-e0f5-43e0-9fff-1eb4a2bed0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efbfd67-e0f5-43e0-9fff-1eb4a2bed0d8.jpg?1",
             "name": "Marauding Mako",
             "text": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "b0e272c3-4d61-596f-a5fe-a873bf76fafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e415f-636f-4394-9b21-600ab720ac98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e415f-636f-4394-9b21-600ab720ac98.jpg?1",
             "name": "Outpace Oblivion",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, it deals 5 damage to up to one target creature or planeswalker.\n{2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "2245f6dd-7fe3-5adf-afad-7d0c63e2a64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364b4dc-8cce-498d-a62e-eabc612b062a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364b4dc-8cce-498d-a62e-eabc612b062a.jpg?1",
             "name": "Pacesetter Paragon",
             "text": "Exhaust \u2014 {2}{R}: Put a +1/+1 counter on this creature. It gains double strike until end of turn. (Activate each exhaust ability only once.)",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "64e99559-f3db-5070-82e7-cdfb6088a3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d07295-78b7-4f90-82c7-e7a639db9993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d07295-78b7-4f90-82c7-e7a639db9993.jpg?1",
             "name": "Pedal to the Metal",
             "text": "Target creature gets +X/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "2961a452-e159-5e46-8d50-c0dbb7f1a5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affbc8db-4ff7-4a86-954a-910493e5a2ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affbc8db-4ff7-4a86-954a-910493e5a2ef.jpg?1",
             "name": "Prowcatcher Specialist",
             "text": "Haste\nExhaust \u2014 {3}{R}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "fdc33587-b433-5548-87ee-75ef14811191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de84a2-2654-4e1a-a569-bf385bb43685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de84a2-2654-4e1a-a569-bf385bb43685.jpg?1",
             "name": "Push the Limit",
             "text": "Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at the beginning of the next end step.\nVehicles you control become artifact creatures until end of turn. Creatures you control gain haste until end of turn.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "158740af-c84b-57ac-8d27-9b5ff922d4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edd18be-3861-4510-ba6d-38ccba60bb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edd18be-3861-4510-ba6d-38ccba60bb5b.jpg?1",
             "name": "Reckless Velocitaur",
             "text": "Whenever this creature saddles a Mount or crews a Vehicle during your main phase, that Mount or Vehicle gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -5084,7 +5084,7 @@
         },
         {
             "id": "2fb8b609-1110-57f9-acd5-d1688ad3b2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca022de-0c7b-48ea-b3b5-af28987a5070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca022de-0c7b-48ea-b3b5-af28987a5070.jpg?1",
             "name": "Road Rage",
             "text": "Road Rage deals X damage to target creature or planeswalker, where X is 2 plus the number of Mounts and Vehicles you control.",
             "colours": [
@@ -5116,7 +5116,7 @@
         },
         {
             "id": "041166f6-7c28-5a78-9144-161764b23abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e82be6-d2b4-4c95-8466-477e8c6832e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e82be6-d2b4-4c95-8466-477e8c6832e9.jpg?1",
             "name": "Skycrash",
             "text": "Destroy target artifact.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -5148,7 +5148,7 @@
         },
         {
             "id": "c234dcbe-4605-54cd-8c76-fb816b4c160b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f483debe-9c54-4323-aec5-226587ece2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f483debe-9c54-4323-aec5-226587ece2c9.jpg?1",
             "name": "Spire Mechcycle",
             "text": "Haste\nExhaust \u2014 Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle. (Activate each exhaust ability only once.)\nCrew 2",
             "colours": [
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "a467834b-92fd-5313-b5ae-dfd75669cb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef537868-b2cb-4bbd-a935-b7f73f19bd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef537868-b2cb-4bbd-a935-b7f73f19bd06.jpg?1",
             "name": "Thunderhead Gunner",
             "text": "Reach\nDiscard a card: Draw a card. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "73ee487f-2979-5a2e-b302-a6f6aea4b30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159dc5a8-5cba-4c20-8c07-28a3d86c8411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159dc5a8-5cba-4c20-8c07-28a3d86c8411.jpg?1",
             "name": "Tyrox, Saurid Tyrant",
             "text": "",
             "colours": [
@@ -5256,7 +5256,7 @@
         },
         {
             "id": "b65bdac2-8b3a-548c-9fce-a444c6b843b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg?1",
             "name": "Afterburner Expert",
             "text": "Exhaust \u2014 {2}{G}{G}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "19227e47-9e31-5d87-9daf-3791136a07ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -5332,7 +5332,7 @@
         },
         {
             "id": "4fd9b256-cc61-541b-b117-41a58ce5e09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd40bca-aa54-4e52-8d48-b3709a11e633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd40bca-aa54-4e52-8d48-b3709a11e633.jpg?1",
             "name": "Alacrian Jaguar",
             "text": "Vigilance\nWhenever this creature attacks while saddled, it gets +2/+2 until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "eb8225e9-5a84-571f-9b0a-57e3dbf5d6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d313ea7-2456-48f3-8b12-97d8e8c2a5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d313ea7-2456-48f3-8b12-97d8e8c2a5b3.jpg?1",
             "name": "Autarch Mammoth",
             "text": "When this creature enters and whenever it attacks while saddled, create a 3/3 green Elephant creature token.\nSaddle 5 (Tap any number of other creatures you control with total power 5 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "299ca8b5-2240-5085-be98-66a80b0b937a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b99a61-49f1-46a2-9eb7-b6c88c236215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b99a61-49f1-46a2-9eb7-b6c88c236215.jpg?1",
             "name": "Beastrider Vanguard",
             "text": "{4}{G}: Look at the top three cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "db54cfbc-3da6-53d9-8303-156dba802113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a5adee-3482-4c5b-9260-58efa8fec5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a5adee-3482-4c5b-9260-58efa8fec5ba.jpg?1",
             "name": "Bestow Greatness",
             "text": "Target creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "8d6d43eb-0742-59c5-8ff5-8a54872cd408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7d5b71-7c1b-4fc2-a5ec-7285e17ffe0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7d5b71-7c1b-4fc2-a5ec-7285e17ffe0f.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -5501,7 +5501,7 @@
         },
         {
             "id": "28e53dc5-30d6-54c4-82b2-32aa0d8b0322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ed23a2-6153-47b2-ab73-062195cafb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ed23a2-6153-47b2-ab73-062195cafb74.jpg?1",
             "name": "Defend the Rider",
             "text": "Choose one \u2014\n\u2022 Target permanent you control gains hexproof and indestructible until end of turn.\n\u2022 Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "5a301449-9468-59b8-bca9-0a31f3801524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3171b16f-cd67-416d-be5e-5d9cccb8d0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3171b16f-cd67-416d-be5e-5d9cccb8d0a0.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "ba87925c-6802-5a8b-a224-565046b22e11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148400a0-7819-4551-9815-9357eed1db4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148400a0-7819-4551-9815-9357eed1db4d.jpg?1",
             "name": "Dredger's Insight",
             "text": "Whenever one or more artifact and/or creature cards leave your graveyard, you gain 1 life.\nWhen this enchantment enters, mill four cards. You may put an artifact, creature, or land card from among the milled cards into your hand. (To mill four cards, put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "ea8ee3e2-48cc-5105-96b7-33869a03f898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee386cd0-934a-4b33-9db3-0a9033ab577e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee386cd0-934a-4b33-9db3-0a9033ab577e.jpg?1",
             "name": "Earthrumbler",
             "text": "Vigilance, trample\nExile an artifact or creature card from your graveyard: This Vehicle becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "93cd15f7-72f5-5e7a-8e55-f431a9e45150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25dfbcb6-9b67-4151-b10f-dde70c5fd16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25dfbcb6-9b67-4151-b10f-dde70c5fd16d.jpg?1",
             "name": "Elvish Refueler",
             "text": "During your turn, as long as you haven't activated an exhaust ability this turn, you may activate exhaust abilities as though they haven't been activated.\nExhaust \u2014 {1}{G}: Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "821561cc-cbec-5376-9b76-86d0595503fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db483a7-c9f0-449d-be97-77dbd6d3a27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db483a7-c9f0-449d-be97-77dbd6d3a27a.jpg?1",
             "name": "Fang Guardian",
             "text": "Flash\nWhen this creature enters, another target creature or Vehicle you control gets +2/+2 until end of turn.",
             "colours": [
@@ -5710,7 +5710,7 @@
         },
         {
             "id": "f6704480-5cda-548d-a810-acda844075c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496442f6-48c7-464e-bcf3-4c14f49fa065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496442f6-48c7-464e-bcf3-4c14f49fa065.jpg?1",
             "name": "Fang-Druid Summoner",
             "text": "Reach\nWhen this creature enters, you may search your library and/or graveyard for a creature card with no abilities, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "b34c09aa-21b4-5504-9cfe-be5bd0204665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0000-5fd3-483b-bac5-f9b888d8755b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0000-5fd3-483b-bac5-f9b888d8755b.jpg?1",
             "name": "Greenbelt Guardian",
             "text": "{G}: Target creature gains trample until end of turn.\nExhaust \u2014 {3}{G}: Put three +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "3ed184af-1051-5cd9-8dbb-5f6ec5f724ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fbee7a-7e73-43cf-bc39-ccb1c63bf837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fbee7a-7e73-43cf-bc39-ccb1c63bf837.jpg?1",
             "name": "Hazard of the Dunes",
             "text": "Trample, reach\nExhaust \u2014 {6}{G}: Put three +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "aaea7beb-b0a4-5993-91ed-9365a28fdb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a0569b-65c8-49ce-91ac-e639b8faf939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a0569b-65c8-49ce-91ac-e639b8faf939.jpg?1",
             "name": "Jibbirik Omnivore",
             "text": "",
             "colours": [
@@ -5848,7 +5848,7 @@
         },
         {
             "id": "da6baaca-a7c2-51f8-9636-2c0cd1a2ca48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1cecb1-6776-4495-be56-b7dde65453f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1cecb1-6776-4495-be56-b7dde65453f1.jpg?1",
             "name": "Loxodon Surveyor",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "389934f6-0c3b-511a-ac72-f86c6c4752e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -5922,7 +5922,7 @@
         },
         {
             "id": "646a0817-0a5e-57ab-832e-5a594bd78ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "75f917eb-1ccd-59d7-8261-4f1aa6095164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba2219-8184-4141-8708-845cb0957299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba2219-8184-4141-8708-845cb0957299.jpg?1",
             "name": "Migrating Ketradon",
             "text": "Reach\nWhen this creature enters, you gain 4 life.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5993,7 +5993,7 @@
         },
         {
             "id": "0dec66af-3578-5d74-8ff1-804cf56d750a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f800bf4e-4bfb-45b6-950b-c76952f52bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f800bf4e-4bfb-45b6-950b-c76952f52bb1.jpg?1",
             "name": "Molt Tender",
             "text": "{T}: Mill a card. (Put the top card of your library into your graveyard.)\n{T}, Exile a card from your graveyard: Add one mana of any color.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "2052eff1-f8ab-514b-9dbe-03885fefe87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101d22c6-830d-4908-9003-6b206f694eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101d22c6-830d-4908-9003-6b206f694eba.jpg?1",
             "name": "Ooze Patrol",
             "text": "When this creature enters, mill two cards, then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard. (To mill two cards, put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -6062,7 +6062,7 @@
         },
         {
             "id": "8e0841ca-9fae-559e-bcd4-937568c3d34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg?1",
             "name": "Oviya, Automech Artisan",
             "text": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "0a9b1498-d888-5a57-874a-b946986691c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a311d4b3-ab2a-43c2-8480-6c5daac41178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a311d4b3-ab2a-43c2-8480-6c5daac41178.jpg?1",
             "name": "Plow Through",
             "text": "Choose one \u2014\n\u2022 Target creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)\n\u2022 Destroy target Vehicle.",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "65ae3393-4b5e-5ec9-9105-4dd2d9835c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd4c73d-0e9a-4ffe-8062-f2f4d0e601fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd4c73d-0e9a-4ffe-8062-f2f4d0e601fe.jpg?1",
             "name": "Point the Way",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{3}{G}, Sacrifice this enchantment: Search your library for up to X basic land cards, where X is your speed. Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "b71819a2-cd8b-56f5-bbae-04e1a970655c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7b59f-fdae-4a11-9784-497a8165d75a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7b59f-fdae-4a11-9784-497a8165d75a.jpg?1",
             "name": "Pothole Mole",
             "text": "When this creature enters, mill three cards, then you may return a land card from your graveyard to your hand. (To mill three cards, put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -6200,7 +6200,7 @@
         },
         {
             "id": "1bed67ca-7a59-512d-894d-4c8d5e1eb420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f569cc-ed09-4c27-b753-18b22ad7f425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f569cc-ed09-4c27-b753-18b22ad7f425.jpg?1",
             "name": "Regal Imperiosaur",
             "text": "Other Dinosaurs you control get +1/+1.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "3652e425-23b8-52aa-b7d5-d9732da54c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6ac32-a7a4-4c15-81b0-8485d6a0e7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6ac32-a7a4-4c15-81b0-8485d6a0e7ca.jpg?1",
             "name": "Rise from the Wreck",
             "text": "Return up to one target creature card, up to one target Mount card, up to one target Vehicle card, and up to one target creature card with no abilities from your graveyard to your hand.",
             "colours": [
@@ -6269,7 +6269,7 @@
         },
         {
             "id": "333b5768-bbf7-5701-b86d-e5766fc696de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642f8fdd-6c58-49a3-904c-27f717cae980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642f8fdd-6c58-49a3-904c-27f717cae980.jpg?1",
             "name": "Run Over",
             "text": "This spell costs {1} less to cast if it targets a Mount or Vehicle you control.\nTarget creature you control deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "6ddd6868-7a83-51e7-adba-1c7b5ad98794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e1ded-9b00-4d7b-884c-70a429783b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e1ded-9b00-4d7b-884c-70a429783b1f.jpg?1",
             "name": "Silken Strength",
             "text": "Flash\nEnchant creature or Vehicle\nWhen this Aura enters, untap enchanted permanent.\nEnchanted permanent gets +1/+2 and has reach.",
             "colours": [
@@ -6335,7 +6335,7 @@
         },
         {
             "id": "1c10be07-bff5-5009-b9dd-e57cf3795ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc713d7-4a7e-4f1f-b461-e89bb1457d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc713d7-4a7e-4f1f-b461-e89bb1457d7d.jpg?1",
             "name": "Stampeding Scurryfoot",
             "text": "Exhaust \u2014 {3}{G}: Put a +1/+1 counter on this creature. Create a 3/3 green Elephant creature token. (Activate each exhaust ability only once.)",
             "colours": [
@@ -6369,7 +6369,7 @@
         },
         {
             "id": "1b64c115-096b-5532-9112-ef0e3d8c1c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44255cf-5264-4ead-9de0-20cc0f7cac6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44255cf-5264-4ead-9de0-20cc0f7cac6f.jpg?1",
             "name": "Terrian, World Tyrant",
             "text": "",
             "colours": [
@@ -6406,7 +6406,7 @@
         },
         {
             "id": "80337f0d-630d-568d-a133-fbdbb3aa3ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "fb942058-367c-5338-a83a-62498d23e931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edde1a-f05c-4ce8-bedd-88359647aa0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edde1a-f05c-4ce8-bedd-88359647aa0d.jpg?1",
             "name": "Veloheart Bike",
             "text": "When this Vehicle enters, you gain 2 life.\n{T}: Add one mana of any color.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6480,7 +6480,7 @@
         },
         {
             "id": "892e9f61-e987-5f8e-9074-73c9c9aafd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9142b1c9-09d7-42e4-8138-6c15d31f2470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9142b1c9-09d7-42e4-8138-6c15d31f2470.jpg?1",
             "name": "Venomsac Lagac",
             "text": "Deathtouch\nWhenever this creature attacks while saddled, it gets +0/+3 until end of turn.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "06bad981-0634-596c-bcc2-644586843f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G} ({X}{G}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "7b00c266-61f7-5222-9251-6a2e1a7bb5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdaa29b-85ff-4a06-b27e-fcdbdfd4a3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdaa29b-85ff-4a06-b27e-fcdbdfd4a3fe.jpg?1",
             "name": "Aatchik, Emerald Radian",
             "text": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
             "colours": [
@@ -6596,7 +6596,7 @@
         },
         {
             "id": "ec28eb66-52ad-5d55-bc62-0e9dd5f64fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971286f5-77ea-4824-91de-f0ac88c46238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971286f5-77ea-4824-91de-f0ac88c46238.jpg?1",
             "name": "Apocalypse Runner",
             "text": "{T}: Target creature you control with power 2 or less gains lifelink until end of turn and can't be blocked this turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6634,7 +6634,7 @@
         },
         {
             "id": "375b8517-d702-5fab-9305-8ce4cfbb3424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b84684-10c9-4635-a922-620f04809bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b84684-10c9-4635-a922-620f04809bb1.jpg?1",
             "name": "Boom Scholar",
             "text": "Exhaust abilities of other permanents you control cost {2} less to activate.\nExhaust \u2014 {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "14443392-0bee-5af6-a378-16b0d3363988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563cb48-9dcb-4b92-af3a-4793adf03125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563cb48-9dcb-4b92-af3a-4793adf03125.jpg?1",
             "name": "Boosted Sloop",
             "text": "Menace\nWhenever you attack, draw a card, then discard a card.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6709,7 +6709,7 @@
         },
         {
             "id": "7aabc830-06cc-5b41-8a4d-a73e1f9bb0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dea5b45-925c-4732-8e9d-fa8232792736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dea5b45-925c-4732-8e9d-fa8232792736.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -6750,7 +6750,7 @@
         },
         {
             "id": "f20ebf95-0356-508b-b731-57950cb1239d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d086e4e5-98fa-437e-85aa-d8849c94ce94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d086e4e5-98fa-437e-85aa-d8849c94ce94.jpg?1",
             "name": "Broadside Barrage",
             "text": "Broadside Barrage deals 5 damage to target creature or planeswalker. Draw a card, then discard a card.",
             "colours": [
@@ -6784,7 +6784,7 @@
         },
         {
             "id": "1d0d7d4b-e419-52c5-9153-06fdb15deea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed09139b-a66e-4cd1-b45a-23a4648d3401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed09139b-a66e-4cd1-b45a-23a4648d3401.jpg?1",
             "name": "Broodheart Engine",
             "text": "At the beginning of your upkeep, surveil 1.\n{2}{B}{G}, {T}, Sacrifice this artifact: Return target creature or Vehicle card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "4c5afef1-764b-5ded-8b40-5e68a588a890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957c90f-e10d-40f8-a4be-9e9ef623dd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957c90f-e10d-40f8-a4be-9e9ef623dd43.jpg?1",
             "name": "Captain Howler, Sea Scourge",
             "text": "Ward\u2014{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "74066a51-c520-54aa-bf45-099ad6e7f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1256d22d-a2a9-41fb-b669-0661ba230bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1256d22d-a2a9-41fb-b669-0661ba230bc7.jpg?1",
             "name": "Caradora, Heart of Alacria",
             "text": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "a4a69363-5e9a-5a38-b3a6-6220dc0546c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef16cda-9150-4e7d-8490-d9f287b81b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef16cda-9150-4e7d-8490-d9f287b81b62.jpg?1",
             "name": "Cloudspire Coordinator",
             "text": "When this creature enters, scry 2.\n{T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts and/or Vehicles that entered the battlefield under your control this turn. The tokens have \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -6939,7 +6939,7 @@
         },
         {
             "id": "c0f9723f-6ce7-5dc7-b45d-c97273ff6deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f01a4-a923-4d56-bacb-984a389296fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f01a4-a923-4d56-bacb-984a389296fa.jpg?1",
             "name": "Cloudspire Skycycle",
             "text": "Flying\nWhen this Vehicle enters, distribute two +1/+1 counters among one or two other target Vehicles and/or creatures you control.\nCrew 1",
             "colours": [
@@ -6977,7 +6977,7 @@
         },
         {
             "id": "aca454af-970c-554f-a92c-eb472d9ba047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73431628-b9b0-41e6-8e9b-8a090939b0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73431628-b9b0-41e6-8e9b-8a090939b0c1.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "c8142d70-6307-59ec-a2bf-85595f3d7a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405e7900-f6df-4033-b70b-b1d2a8b6d7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405e7900-f6df-4033-b70b-b1d2a8b6d7c8.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "c110d2ea-524d-50cf-897d-c62e96a1e218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36185de4-55c2-4e5d-9bcc-ea12b7052728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36185de4-55c2-4e5d-9bcc-ea12b7052728.jpg?1",
             "name": "Dune Drifter",
             "text": "When this Vehicle enters, return target artifact or creature card with mana value X or less from your graveyard to the battlefield.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "eaeb0d00-5334-5dbb-aa44-2e27e7bfdb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf181ae-daa7-42f9-b667-5e679d80cf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf181ae-daa7-42f9-b667-5e679d80cf34.jpg?1",
             "name": "Embalmed Ascendant",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature enters, create a 2/2 black Zombie creature token.\nMax speed \u2014 Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "fe452cd5-75f4-5f10-b1f2-b3bc9c0ec289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a876edac-b8c8-4994-94f5-548e0fe70fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a876edac-b8c8-4994-94f5-548e0fe70fe4.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -7171,7 +7171,7 @@
         },
         {
             "id": "e20b85e5-5ab1-57f5-93c3-fbc62eb814e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f523e96d-9df1-4854-accb-9876aef787e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f523e96d-9df1-4854-accb-9876aef787e5.jpg?1",
             "name": "Far Fortune, End Boss",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed \u2014 If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -7213,7 +7213,7 @@
         },
         {
             "id": "a1fcb189-3b9a-5c4a-970d-c4f41982d562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d86d66b-481f-44ec-86d8-6fc91b52ef38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d86d66b-481f-44ec-86d8-6fc91b52ef38.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "fda38227-6be9-53df-b1a1-f0b941f8ae1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e5205d-d734-4292-a3c8-70cf5f131289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e5205d-d734-4292-a3c8-70cf5f131289.jpg?1",
             "name": "Gastal Thrillseeker",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature enters, it deals 1 damage to target opponent and you gain 1 life.\nMax speed \u2014 This creature has deathtouch and haste.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "9c12bccd-99d5-504d-8800-e0084e3efb58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e00cd7-925e-4bab-b064-c96aa2935f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e00cd7-925e-4bab-b064-c96aa2935f8c.jpg?1",
             "name": "Guidelight Pathmaker",
             "text": "Vigilance\nWhen this Vehicle enters, you may search your library for an artifact card and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. Then shuffle.\nCrew 2",
             "colours": [
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "381a1b61-890e-58f5-8747-a3a04cf6f530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478d236c-9778-435a-ac21-bd0017a17d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478d236c-9778-435a-ac21-bd0017a17d5b.jpg?1",
             "name": "Haunt the Network",
             "text": "Choose target opponent. Create two 1/1 colorless Thopter artifact creature tokens with flying. Then the chosen player loses X life and you gain X life, where X is the number of artifacts you control.",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "2e032a05-a9e8-52b0-8627-16e94b96e30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ce0d37-d5d7-49dd-885e-9998bb8abede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ce0d37-d5d7-49dd-885e-9998bb8abede.jpg?1",
             "name": "Haunted Hellride",
             "text": "Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of turn. Untap it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "0bd1bb94-7b76-5ae8-a47e-17e754f4d37f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffae8d0-7b4e-42ed-8124-24a86b38f490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffae8d0-7b4e-42ed-8124-24a86b38f490.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "219d8ecc-12aa-5357-ba67-e33d5a604b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd476-a236-4434-b191-5c8b6fa7be7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd476-a236-4434-b191-5c8b6fa7be7b.jpg?1",
             "name": "Kolodin, Triumph Caster",
             "text": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
             "colours": [
@@ -7485,7 +7485,7 @@
         },
         {
             "id": "e2142849-652f-5edc-a720-21b126142328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b04e3f4-103b-4845-b3f0-5417971c7666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b04e3f4-103b-4845-b3f0-5417971c7666.jpg?1",
             "name": "Lagorin, Soul of Alacria",
             "text": "Flying\nWhenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two target Mounts and/or Vehicles.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "47ea0a8d-a316-5cbd-9a43-05aa3e9e4bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c59c04-4c0b-4a60-826e-3a7757d0b2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c59c04-4c0b-4a60-826e-3a7757d0b2a2.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color. (Activate each exhaust ability only once.)\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "49ff9665-07de-5a69-a4ca-32500d5ce204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f434b103-490f-424e-a0a1-efb1b931c8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f434b103-490f-424e-a0a1-efb1b931c8e6.jpg?1",
             "name": "Mendicant Core, Guidelight",
             "text": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 Whenever you cast an artifact spell, you may pay {1}. If you do, copy it. (The copy becomes a token.)",
             "colours": [
@@ -7612,7 +7612,7 @@
         },
         {
             "id": "296fae2e-7721-5b38-9691-ab816585f9e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e4c342-dc22-4e9c-81fc-a691ae9e21c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e4c342-dc22-4e9c-81fc-a691ae9e21c1.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -7657,7 +7657,7 @@
         },
         {
             "id": "9c5b6427-08ca-5e33-a06e-44de4f37e249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e2d09e-b9f5-4a0d-96d3-984b5c2c387d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e2d09e-b9f5-4a0d-96d3-984b5c2c387d.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "b80605d6-e25f-5f4d-b710-9ce063497ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8493ee-bd06-4583-9908-a0dbcc5be6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8493ee-bd06-4583-9908-a0dbcc5be6d7.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -7739,7 +7739,7 @@
         },
         {
             "id": "0ed3224c-2d8d-5df8-88ef-99cf5a508a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238d2c-d10f-496d-aa34-5a1536e056b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238d2c-d10f-496d-aa34-5a1536e056b5.jpg?1",
             "name": "Rangers' Aetherhive",
             "text": "Vigilance\nWhenever you activate an exhaust ability, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "2af22d4f-529b-5676-9727-1412746fe804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fba3820-32ba-47e9-9fa8-f985ff471b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fba3820-32ba-47e9-9fa8-f985ff471b3f.jpg?1",
             "name": "Redshift, Rocketeer Chief",
             "text": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust \u2014 {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield. (Activate each exhaust ability only once.)",
             "colours": [
@@ -7819,7 +7819,7 @@
         },
         {
             "id": "7f9f4948-b218-5116-a548-3fee1f128fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfb0f7-18ca-4f6e-ba64-92120010456e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfb0f7-18ca-4f6e-ba64-92120010456e.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -7860,7 +7860,7 @@
         },
         {
             "id": "c2f0480c-3b13-53ce-8437-164ec13a9818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80c91e-dd3d-4c7b-89e4-bfb253eeaee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80c91e-dd3d-4c7b-89e4-bfb253eeaee2.jpg?1",
             "name": "Rocketeer Boostbuggy",
             "text": "Whenever this Vehicle attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nExhaust \u2014 {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. (Activate each exhaust ability only once.)\nCrew 1",
             "colours": [
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "bd7a3e6f-eb6d-5077-b1c8-d520244747c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef555b1-666d-4386-8983-0e88f9b6cdec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef555b1-666d-4386-8983-0e88f9b6cdec.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "d79955bc-eb17-564c-b6a2-01cc261c1042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efd8222-5c37-46d8-a2ec-1d7aae25320b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efd8222-5c37-46d8-a2ec-1d7aae25320b.jpg?1",
             "name": "Samut, the Driving Force",
             "text": "First strike, vigilance, haste\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
             "colours": [
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "6d3c6f65-653d-5c1a-aca8-109ab576876a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb523c06-6f3e-4e19-b777-19aefc4a4e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb523c06-6f3e-4e19-b777-19aefc4a4e02.jpg?1",
             "name": "Sita Varma, Masked Racer",
             "text": "Exhaust \u2014 {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn. (Activate each exhaust ability only once.)",
             "colours": [
@@ -8027,7 +8027,7 @@
         },
         {
             "id": "f1215e45-e215-5a18-a7c8-7c0517d0d5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbd9fc0-c0df-4119-a0d3-2e1790998c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbd9fc0-c0df-4119-a0d3-2e1790998c21.jpg?1",
             "name": "Skyserpent Seeker",
             "text": "Flying, deathtouch\nExhaust \u2014 {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -8065,7 +8065,7 @@
         },
         {
             "id": "ee1a5e5f-1d0e-5094-9558-004eb11cdaf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1576d4-15a3-4e91-84ef-e71e258185e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1576d4-15a3-4e91-84ef-e71e258185e7.jpg?1",
             "name": "Thundering Broodwagon",
             "text": "Menace, reach\nWhen this Vehicle enters, destroy target nonland permanent an opponent controls with mana value 4 or less.\nCrew 3\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -8103,7 +8103,7 @@
         },
         {
             "id": "58449cdb-d739-55bc-b809-85c2ddb1e194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab38f35-b60c-464c-a0b5-9d5f2dc6de7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab38f35-b60c-464c-a0b5-9d5f2dc6de7f.jpg?1",
             "name": "Veteran Beastrider",
             "text": "At the beginning of your end step, untap each creature you control.\n{2}{G}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8140,7 +8140,7 @@
         },
         {
             "id": "c5f367d1-e758-5baf-91b3-fb480c05656c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba835da-0247-4716-9079-1b605297f6d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba835da-0247-4716-9079-1b605297f6d5.jpg?1",
             "name": "Voyage Home",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nYou draw three cards and gain 3 life.",
             "colours": [
@@ -8176,7 +8176,7 @@
         },
         {
             "id": "376d210f-2c8a-5741-8326-16c5395ea024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d46d0e-3161-45b5-a49e-5cd592c67ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d46d0e-3161-45b5-a49e-5cd592c67ddd.jpg?1",
             "name": "Winter, Cursed Rider",
             "text": "Ward\u2014\nPay 2 life.\nArtifacts you control have \"Ward\u2014\nPay 2 life.\"\nExhaust \u2014 {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn. (Activate each exhaust ability only once.)",
             "colours": [
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "f601065b-7a04-5d51-89fe-9b90737a960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31944ea5-045d-481d-9aff-3c7ed663813a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31944ea5-045d-481d-9aff-3c7ed663813a.jpg?1",
             "name": "Zahur, Glory's Past",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed \u2014 Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "779e4b2c-c4bb-5e2e-9b1c-d6233b91893d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a29c8a5-fd98-422c-9518-2db0993495e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a29c8a5-fd98-422c-9518-2db0993495e5.jpg?1",
             "name": "Aetherjacket",
             "text": "Flying, vigilance\n{2}, {T}, Sacrifice this creature: Destroy another target artifact. Activate only as a sorcery.",
             "colours": [],
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "ca43c835-d9a9-5003-b8de-76cd7d6bb170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05690d52-06c4-40b1-8360-380418a83250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05690d52-06c4-40b1-8360-380418a83250.jpg?1",
             "name": "The Aetherspark",
             "text": "As long as The Aetherspark is attached to a creature, The Aetherspark can't be attacked and has \"Whenever equipped creature deals combat damage during your turn, put that many loyalty counters on The Aetherspark.\"\n+1: Attach The Aetherspark to up to one target creature you control. Put a +1/+1 counter on that creature.\n\u22125: Draw two cards.\n\u221210: Add ten mana of any one color.",
             "colours": [],
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "fae595cf-1e6b-5001-a369-7aa67e5b5d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968651db-92fb-46cd-acda-9e097668b7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968651db-92fb-46cd-acda-9e097668b7c9.jpg?1",
             "name": "Camera Launcher",
             "text": "Exhaust \u2014 {3}: Put a +1/+1 counter on this creature. Create a 1/1 colorless Thopter artifact creature token with flying. (Activate each exhaust ability only once.)",
             "colours": [],
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "217e4a3e-1752-55c8-b2c2-2fe01226afcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccf7fb5-c043-4a1f-ad2f-edb280cb5037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccf7fb5-c043-4a1f-ad2f-edb280cb5037.jpg?1",
             "name": "Guidelight Matrix",
             "text": "When this artifact enters, draw a card.\n{2}, {T}: Target Mount you control becomes saddled until end of turn. Activate only as a sorcery.\n{2}, {T}: Target Vehicle you control becomes an artifact creature until end of turn.",
             "colours": [],
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "c5a50588-637b-5c31-b108-86e9c4713ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c92203-17df-4f10-92c6-ebcc79f01357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c92203-17df-4f10-92c6-ebcc79f01357.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -8422,7 +8422,7 @@
         },
         {
             "id": "335d860c-472f-5152-bf2b-92777b378b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2152030-6007-493f-a616-545723a00249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2152030-6007-493f-a616-545723a00249.jpg?1",
             "name": "Marketback Walker",
             "text": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
             "colours": [],
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "5a85f0cd-0271-5632-8011-784ebc09e663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f920f83-6380-4e4f-be68-6bf9df3110d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f920f83-6380-4e4f-be68-6bf9df3110d8.jpg?1",
             "name": "Marshals' Pathcruiser",
             "text": "When this Vehicle enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nExhaust \u2014 {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it. (Activate each exhaust ability only once.)\nCrew 5",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "a4798ef1-6df3-5748-b596-289a8ef075ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21433ba-0a14-42bc-ad0b-a4ef823a3295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21433ba-0a14-42bc-ad0b-a4ef823a3295.jpg?1",
             "name": "Monument to Endurance",
             "text": "Whenever you discard a card, choose one that hasn't been chosen this turn \u2014\n\u2022 Draw a card.\n\u2022 Create a Treasure token.\n\u2022 Each opponent loses 3 life.",
             "colours": [],
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "4ec21929-6bd6-5ce6-b5c9-a18ec55ace40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72527ef-ac05-44c8-8c76-10532ce3da6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72527ef-ac05-44c8-8c76-10532ce3da6e.jpg?1",
             "name": "Pit Automaton",
             "text": "Defender\n{T}: Add {C}{C}. Spend this mana only to activate abilities.\n{2}, {T}: When you next activate an exhaust ability this turn, copy it. You may choose new targets for the copy.",
             "colours": [],
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "8e115f15-2135-5b83-85af-a2c5d2a24326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg?1",
             "name": "Racers' Scoreboard",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this artifact enters, draw two cards, then discard a card.\nMax speed \u2014 Spells you cast cost {1} less to cast.",
             "colours": [],
@@ -8584,7 +8584,7 @@
         },
         {
             "id": "4f836cc8-241a-57cf-a2f9-dde7c21638de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6dac83-39c2-40dc-a322-76a3ea4e7aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6dac83-39c2-40dc-a322-76a3ea4e7aee.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -8617,7 +8617,7 @@
         },
         {
             "id": "61bc64b5-b6e5-5ef3-8160-6a2308bcf03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855a999-83f6-4c0d-9444-3ff292f77d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855a999-83f6-4c0d-9444-3ff292f77d58.jpg?1",
             "name": "Rover Blades",
             "text": "Double strike\nEquipped creature has double strike.\nEquip {4}\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn. Creatures can't be attached to other permanents.)",
             "colours": [],
@@ -8650,7 +8650,7 @@
         },
         {
             "id": "d8883922-7652-5916-99d0-5421c4075d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg?1",
             "name": "Scrap Compactor",
             "text": "{3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.\n{6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle.",
             "colours": [],
@@ -8678,7 +8678,7 @@
         },
         {
             "id": "df62c122-01f5-5b32-88ce-bcc136b4c18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d9ef34-ae95-4465-a30c-372e231bd733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d9ef34-ae95-4465-a30c-372e231bd733.jpg?1",
             "name": "Skybox Ferry",
             "text": "Flying\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "4019fc70-e890-536d-b586-6d8936219a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0530b343-98c2-440a-b32e-d1566d318c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0530b343-98c2-440a-b32e-d1566d318c3b.jpg?1",
             "name": "Starting Column",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add one mana of any color.\nMax speed \u2014 {T}, Sacrifice this artifact: Draw two cards, then discard a card.",
             "colours": [],
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "091973ec-386c-59c0-9a67-8747e221fe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa178ed7-8f3a-45f0-817d-5fbc7993b04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa178ed7-8f3a-45f0-817d-5fbc7993b04a.jpg?1",
             "name": "Ticket Tortoise",
             "text": "Defender\nWhen this creature enters, if an opponent controls more lands than you, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [],
@@ -8769,7 +8769,7 @@
         },
         {
             "id": "9138f474-673a-51ca-a4b1-93c9ce53b4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ccbd73-9414-48a3-bdcf-e838fcffc08f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ccbd73-9414-48a3-bdcf-e838fcffc08f.jpg?1",
             "name": "Walking Sarcophagus",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 This creature gets +1/+2.",
             "colours": [],
@@ -8801,7 +8801,7 @@
         },
         {
             "id": "2f2b7f96-69d7-56c1-9e00-5cb274888b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3151960-cc0c-47b5-b476-295d7a17ae14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3151960-cc0c-47b5-b476-295d7a17ae14.jpg?1",
             "name": "Wreck Remover",
             "text": "Whenever this creature enters or attacks, exile up to one target card from a graveyard. You gain 1 life.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8832,7 +8832,7 @@
         },
         {
             "id": "23dec1bc-a75c-512a-a1c4-63a43553799f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312807-ea2a-4385-8774-4e23b4a5d4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312807-ea2a-4385-8774-4e23b4a5d4a6.jpg?1",
             "name": "Amonkhet Raceway",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed \u2014 {T}: Target creature gains haste until end of turn.",
             "colours": [],
@@ -8862,7 +8862,7 @@
         },
         {
             "id": "6a54290d-117c-50e2-85c9-74b9c13b9aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a6b378-c7fa-4226-a310-4ee7e550b4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a6b378-c7fa-4226-a310-4ee7e550b4d6.jpg?1",
             "name": "Avishkar Raceway",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed \u2014 {3}, {T}, Discard a card: Draw a card.",
             "colours": [],
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "4b958d55-9000-56a1-84e0-fc9829abe54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dcdabd-a186-45fe-9fee-6c0f1afeaf16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dcdabd-a186-45fe-9fee-6c0f1afeaf16.jpg?1",
             "name": "Bleachbone Verge",
             "text": "{T}: Add {B}.\n{T}: Add {W}. Activate only if you control a Plains or a Swamp.",
             "colours": [],
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "ea07bd64-eea3-53c2-a049-bb356fd927bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49195d90-de0c-4290-aa1c-9f4d948b5521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49195d90-de0c-4290-aa1c-9f4d948b5521.jpg?1",
             "name": "Bloodfell Caves",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "fadad1b4-62b8-51fb-94e2-1c01380aa7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69949863-2510-4fe2-a815-0682beeb08a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69949863-2510-4fe2-a815-0682beeb08a3.jpg?1",
             "name": "Blossoming Sands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "ed17d20d-0fa8-5445-8405-99e8708a7f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897acd91-12ba-4fa8-a26e-c09f009167a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897acd91-12ba-4fa8-a26e-c09f009167a8.jpg?1",
             "name": "Country Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {W}.\n{1}{W}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "4ae059e6-577a-5e19-8a9a-152898481c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20aef3f-79f6-4357-8631-1d141f437def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20aef3f-79f6-4357-8631-1d141f437def.jpg?1",
             "name": "Dismal Backwater",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9049,7 +9049,7 @@
         },
         {
             "id": "7504c04e-7bb0-5b0f-a3a8-4d040dbcaf3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c026a-c89f-41f3-8812-424124dd3760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c026a-c89f-41f3-8812-424124dd3760.jpg?1",
             "name": "Foul Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {B}.\n{1}{B}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9079,7 +9079,7 @@
         },
         {
             "id": "cac5e033-06bc-5d66-a2da-fa404b11d0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd24a1a-08db-4fa7-8939-f5541677327e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd24a1a-08db-4fa7-8939-f5541677327e.jpg?1",
             "name": "Jungle Hollow",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9110,7 +9110,7 @@
         },
         {
             "id": "eb15491c-79af-584a-bc46-b5e9c9560354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041ae16-29ff-4ad5-8a37-4736e9409294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041ae16-29ff-4ad5-8a37-4736e9409294.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "5a719845-3b75-5f8f-8258-c581ec21ed87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c1dce3-6136-4294-9d2b-5ef8527d733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c1dce3-6136-4294-9d2b-5ef8527d733b.jpg?1",
             "name": "Night Market",
             "text": "This land enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9170,7 +9170,7 @@
         },
         {
             "id": "aedea0fe-2e14-5eb5-b9bd-8e9b405cf185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8171a-2629-4356-ae86-b4d03aa14bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8171a-2629-4356-ae86-b4d03aa14bd3.jpg?1",
             "name": "Reef Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {U}.\n{1}{U}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9200,7 +9200,7 @@
         },
         {
             "id": "d94fd995-b642-5984-883a-a710a389e351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a93a71-d77c-417f-85d0-cd420f573331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a93a71-d77c-417f-85d0-cd420f573331.jpg?1",
             "name": "Riverpyre Verge",
             "text": "{T}: Add {R}.\n{T}: Add {U}. Activate only if you control an Island or a Mountain.",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "7a520cf1-38ac-50e3-bc48-b78262b02161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0d4e8a-aab5-458e-bc0e-2b6b0054646a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0d4e8a-aab5-458e-bc0e-2b6b0054646a.jpg?1",
             "name": "Rocky Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {R}.\n{1}{R}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9264,7 +9264,7 @@
         },
         {
             "id": "953f010e-e999-5245-94b0-abcec5cb4061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b7484f-923c-46c5-95bf-c2c6706c0d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b7484f-923c-46c5-95bf-c2c6706c0d48.jpg?1",
             "name": "Rugged Highlands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9295,7 +9295,7 @@
         },
         {
             "id": "d46acf94-f63d-51f1-8306-3144d05c2354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac52be0c-49f4-4956-820e-bdd7d2744d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac52be0c-49f4-4956-820e-bdd7d2744d2f.jpg?1",
             "name": "Scoured Barrens",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "2ab16da7-2e3f-5658-810d-eee8e22fe15f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed132f-b818-4dbf-9b4a-e5acb067e0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed132f-b818-4dbf-9b4a-e5acb067e0a4.jpg?1",
             "name": "Sunbillow Verge",
             "text": "{T}: Add {W}.\n{T}: Add {R}. Activate only if you control a Mountain or a Plains.",
             "colours": [],
@@ -9360,7 +9360,7 @@
         },
         {
             "id": "44beb8b6-d27c-5e9d-805f-a3ce062212e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949bf6bb-1e97-48a3-8547-0a780664c275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949bf6bb-1e97-48a3-8547-0a780664c275.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9391,7 +9391,7 @@
         },
         {
             "id": "12eae30e-9493-500a-baed-50e1fe179892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4723a303-7f20-4399-8bc6-6a27a61a3532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4723a303-7f20-4399-8bc6-6a27a61a3532.jpg?1",
             "name": "Thornwood Falls",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9422,7 +9422,7 @@
         },
         {
             "id": "1d427b10-199f-51d7-85ab-f3368a5cf927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70688800-7675-4e75-bb3c-9e05b95a685c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70688800-7675-4e75-bb3c-9e05b95a685c.jpg?1",
             "name": "Tranquil Cove",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9453,7 +9453,7 @@
         },
         {
             "id": "7bac7d37-f51c-5586-8fb5-c4a739b6d029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ceacc7d-d407-4f82-af58-9bdf8426924e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ceacc7d-d407-4f82-af58-9bdf8426924e.jpg?1",
             "name": "Wastewood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {B}. Activate only if you control a Swamp or a Forest.",
             "colours": [],
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "41dac39d-fe35-5440-8de3-38b023a7b157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3d48d1-a98e-40af-b04c-c40b9d52e9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3d48d1-a98e-40af-b04c-c40b9d52e9ee.jpg?1",
             "name": "Wild Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {G}.\n{1}{G}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "e93ffe60-3db8-5bae-964b-815c6ae60c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758d93d5-3f66-4395-a928-000485396c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758d93d5-3f66-4395-a928-000485396c87.jpg?1",
             "name": "Willowrush Verge",
             "text": "{T}: Add {U}.\n{T}: Add {G}. Activate only if you control a Forest or an Island.",
             "colours": [],
@@ -9551,7 +9551,7 @@
         },
         {
             "id": "afd59654-913a-57e7-8711-2e5bdd7f60a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882969d8-7e3e-4f32-858a-00da20c67b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882969d8-7e3e-4f32-858a-00da20c67b83.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "765bd05c-7733-59ad-a04b-b6846e25b83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2da8b9-797f-46e8-a15d-a86c7c56dc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2da8b9-797f-46e8-a15d-a86c7c56dc84.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9622,7 +9622,7 @@
         },
         {
             "id": "8b8bfdb6-036f-58d5-9d5c-72d6d4a54339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53ed206-8ec4-46a6-8603-c819682e1433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53ed206-8ec4-46a6-8603-c819682e1433.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "6cf53345-398a-547d-a4c6-c988b0ab6631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e969e168-e74c-4608-9fa0-a5660bf7fa02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e969e168-e74c-4608-9fa0-a5660bf7fa02.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "f200e2b8-4b95-5fb6-86df-e574e917fefb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50748a4c-43a0-4274-9a84-046d76027166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50748a4c-43a0-4274-9a84-046d76027166.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9742,7 +9742,7 @@
         },
         {
             "id": "cb2a03c5-55e6-5b5f-87dc-62d2ad0f48fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777e868d-cb88-4b8e-99d1-12ff67f5eae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777e868d-cb88-4b8e-99d1-12ff67f5eae2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "b214a017-5a4c-5ed9-9a47-2ff50503c511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9822,7 +9822,7 @@
         },
         {
             "id": "07991926-f94c-51c5-9223-4e2aabfd043b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b97d2f5-498c-42db-95d9-f9002d4dfcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b97d2f5-498c-42db-95d9-f9002d4dfcc5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9862,7 +9862,7 @@
         },
         {
             "id": "15d8b1b8-6939-5b78-a32e-ea13b4dd62c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cf2f81-3041-4349-9b37-f215c4e38c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cf2f81-3041-4349-9b37-f215c4e38c5b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9902,7 +9902,7 @@
         },
         {
             "id": "5f282781-a01b-563b-a237-7d25c53843c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9942,7 +9942,7 @@
         },
         {
             "id": "b73151b0-e042-59df-9f0e-253c2536e672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9369d0a-87c0-4c29-b43c-cd45c007f8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9369d0a-87c0-4c29-b43c-cd45c007f8d6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "f88b246d-f43e-55e3-80d4-aa56573f1cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3c4a9d-48db-474f-aeb6-8b4fa08ce6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3c4a9d-48db-474f-aeb6-8b4fa08ce6fa.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "f2c06bb1-cdca-5cb9-9e3f-239ad7063640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10062,7 +10062,7 @@
         },
         {
             "id": "ac63e212-f348-5080-a9de-b28bfcd60a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e124b6-3af7-41c0-b829-ff85aa0c3782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e124b6-3af7-41c0-b829-ff85aa0c3782.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10102,7 +10102,7 @@
         },
         {
             "id": "525511d1-4847-5d87-9d88-d2d23809458f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85288987-6f3f-4b7b-9ecc-9393dd37f115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85288987-6f3f-4b7b-9ecc-9393dd37f115.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "d85a3d1e-caa7-5bcf-a88d-e236f5a15ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10182,7 +10182,7 @@
         },
         {
             "id": "ff59fc34-ccfe-555f-8690-be6cdbe7a86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e70c-626f-4d2c-b26b-d94f815fceea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e70c-626f-4d2c-b26b-d94f815fceea.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "1772f4e7-d5fa-5960-89d2-d6592aa212d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e2393-30a7-4e0c-bd20-f05ca0ba3cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e2393-30a7-4e0c-bd20-f05ca0ba3cb6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "4f504ddd-dc7c-56ac-ad68-0b00ca8236a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10302,7 +10302,7 @@
         },
         {
             "id": "5fdc9723-d72b-577b-8f56-4094b502e69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6472e2a6-287f-4e7c-ad85-1454e40d4a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6472e2a6-287f-4e7c-ad85-1454e40d4a46.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10342,7 +10342,7 @@
         },
         {
             "id": "86f19aff-c504-5870-917f-6b8b62ab6290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562b16ae-8ae7-4b2d-9098-bf3ff1429f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562b16ae-8ae7-4b2d-9098-bf3ff1429f7b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10382,7 +10382,7 @@
         },
         {
             "id": "24f5ad36-4ef6-5a99-a1e1-62faf433efa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e66d63-56be-46f5-b0df-e1350106ba45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e66d63-56be-46f5-b0df-e1350106ba45.jpg?1",
             "name": "Air Response Unit",
             "text": "Flying, vigilance\nCrew 1",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "1e5d50b2-4431-55f8-8799-b23ac10b75df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6118bb1-9530-487b-a211-7cc56cef3fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6118bb1-9530-487b-a211-7cc56cef3fbb.jpg?1",
             "name": "Broadcast Rambler",
             "text": "When this Vehicle enters, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "cecc7e26-fa56-51f0-b9e2-b66f548c9ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e45f00e-2156-4e8c-813c-0e36ab34982e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e45f00e-2156-4e8c-813c-0e36ab34982e.jpg?1",
             "name": "Detention Chariot",
             "text": "When this Vehicle enters, exile target artifact or creature an opponent controls until this Vehicle leaves the battlefield.\nCrew 3\nCycling {W}",
             "colours": [
@@ -10490,7 +10490,7 @@
         },
         {
             "id": "019af060-3b53-5954-8007-8ca616e9fbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2e68f-3f40-45b1-9afe-cc1c5fb41203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2e68f-3f40-45b1-9afe-cc1c5fb41203.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -10530,7 +10530,7 @@
         },
         {
             "id": "9cffcdeb-50f5-53fb-acc0-3aa1d64bd33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0eb86e-371c-46fd-a261-384b2a603b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0eb86e-371c-46fd-a261-384b2a603b36.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "e9b35241-8d86-54d0-95f6-baa3325b355c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0303505-d6f1-4626-a932-0e577d9572fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0303505-d6f1-4626-a932-0e577d9572fe.jpg?1",
             "name": "Spotcycle Scouter",
             "text": "When this Vehicle enters, scry 2.\nCrew 1",
             "colours": [
@@ -10604,7 +10604,7 @@
         },
         {
             "id": "81e90d5a-03e1-562a-a7db-639eb319c146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f142d6c1-90f6-49d6-861e-36e9a6fac958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f142d6c1-90f6-49d6-861e-36e9a6fac958.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W}\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -10644,7 +10644,7 @@
         },
         {
             "id": "86bc7a75-3afd-5b8a-80a9-7837653de8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7da86-902a-4d40-a230-4d22d4b2df59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7da86-902a-4d40-a230-4d22d4b2df59.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -10682,7 +10682,7 @@
         },
         {
             "id": "0d4c304d-4570-5209-a847-fd07986a604f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279171d-1623-438c-b796-d294c6675604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279171d-1623-438c-b796-d294c6675604.jpg?1",
             "name": "Hulldrifter",
             "text": "Flying\nWhen this Vehicle enters, draw two cards.\nCrew 3",
             "colours": [
@@ -10718,7 +10718,7 @@
         },
         {
             "id": "8ec28bc7-b5c8-5135-ab28-3c0a11c2b72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aeb6fa4-569e-4ede-94c5-a8f3c28f55e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aeb6fa4-569e-4ede-94c5-a8f3c28f55e4.jpg?1",
             "name": "Midnight Mangler",
             "text": "During turns other than yours, this Vehicle is an artifact creature.\nCrew 2",
             "colours": [
@@ -10754,7 +10754,7 @@
         },
         {
             "id": "64a82a5e-60c8-5c53-94f9-ff0b33c680d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821045bd-c8e4-40fb-babd-5d13b64a71ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821045bd-c8e4-40fb-babd-5d13b64a71ec.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -10792,7 +10792,7 @@
         },
         {
             "id": "9db68664-60d8-58ad-a656-4d9b6e525ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530159a6-0672-485a-867c-aa0bac961765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530159a6-0672-485a-867c-aa0bac961765.jpg?1",
             "name": "Rangers' Refueler",
             "text": "Whenever you activate an exhaust ability, draw a card.\nExhaust \u2014 {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.\nCrew 2",
             "colours": [
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "0ac18fb9-8ab1-560c-ac36-4eb81699374d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd26a5a-ca58-4cb6-b599-7c84d601dc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd26a5a-ca58-4cb6-b599-7c84d601dc07.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -10866,7 +10866,7 @@
         },
         {
             "id": "848d8a3a-cb93-5432-82ca-07cb691e2e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818931d1-258d-4dda-9d0a-2015ec330bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818931d1-258d-4dda-9d0a-2015ec330bab.jpg?1",
             "name": "Carrion Cruiser",
             "text": "When this Vehicle enters, mill two cards. Then return a creature or Vehicle card from your graveyard to your hand.\nCrew 1",
             "colours": [
@@ -10902,7 +10902,7 @@
         },
         {
             "id": "739a238b-a842-576a-a530-6cd47edf1aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f4e3c-2729-488b-883f-7657deea39c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f4e3c-2729-488b-883f-7657deea39c8.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -10940,7 +10940,7 @@
         },
         {
             "id": "bb5327c4-a2b9-5e93-8fd8-71b96341be32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c322936f-3b56-454c-a89e-fa53faab6a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c322936f-3b56-454c-a89e-fa53faab6a33.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -10978,7 +10978,7 @@
         },
         {
             "id": "41327ee8-2370-57e7-8469-03c6a1480dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d563b1-f03b-4ce3-9de0-05dab257b67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d563b1-f03b-4ce3-9de0-05dab257b67c.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -11018,7 +11018,7 @@
         },
         {
             "id": "e42f497a-6c95-504c-9bd6-b60cc44b0028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba1b096-7424-4ce9-8dfd-56a86fe612e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba1b096-7424-4ce9-8dfd-56a86fe612e4.jpg?1",
             "name": "Ripclaw Wrangler",
             "text": "When this Vehicle enters, each opponent discards a card.\nCrew 2",
             "colours": [
@@ -11054,7 +11054,7 @@
         },
         {
             "id": "0cfc7ae0-8fb9-5c7f-8093-893daf3943ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3501b938-7a25-43c7-b1c5-03cd9b690930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3501b938-7a25-43c7-b1c5-03cd9b690930.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.\nCrew 2",
             "colours": [
@@ -11092,7 +11092,7 @@
         },
         {
             "id": "98b199fd-3900-5022-808e-46139d02743f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c93bd-1313-4c7b-bd6f-91e329932dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c93bd-1313-4c7b-bd6f-91e329932dea.jpg?1",
             "name": "Burner Rocket",
             "text": "Flash\nWhen this Vehicle enters, target creature you control gets +2/+0 and gains trample until end of turn.\nCrew 1",
             "colours": [
@@ -11128,7 +11128,7 @@
         },
         {
             "id": "89ba83ae-e40f-5578-a21e-9da9fd8f2a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d3c041-976c-41e2-9ce6-4b292e499526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d3c041-976c-41e2-9ce6-4b292e499526.jpg?1",
             "name": "Clamorous Ironclad",
             "text": "Menace\nCrew 3\nCycling {R}",
             "colours": [
@@ -11164,7 +11164,7 @@
         },
         {
             "id": "6aa8abda-bc03-529c-9d7c-bee4070ae343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a07256-3305-4178-bd4f-d1583d23106d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a07256-3305-4178-bd4f-d1583d23106d.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -11202,7 +11202,7 @@
         },
         {
             "id": "8b875666-c29b-5c3a-b644-6459e0453a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c0a-41f3-4d88-be1d-19c0821f158e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c0a-41f3-4d88-be1d-19c0821f158e.jpg?1",
             "name": "Spire Mechcycle",
             "text": "Haste\nExhaust \u2014 Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle.\nCrew 2",
             "colours": [
@@ -11238,7 +11238,7 @@
         },
         {
             "id": "65193ca8-fcdd-5769-a385-ac28e55a61de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95a5f3-7f14-4d59-8329-559ed4ff0491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95a5f3-7f14-4d59-8329-559ed4ff0491.jpg?1",
             "name": "Earthrumbler",
             "text": "Vigilance, trample\nExile an artifact or creature card from your graveyard: This Vehicle becomes an artifact creature until end of turn.\nCrew 3",
             "colours": [
@@ -11274,7 +11274,7 @@
         },
         {
             "id": "fb7307e1-e769-5e6d-89d9-900493a7270d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c196dd-61a9-4e75-bd43-9531ba3dc961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c196dd-61a9-4e75-bd43-9531ba3dc961.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -11313,7 +11313,7 @@
         },
         {
             "id": "429cdee2-c664-5173-9f21-09535698d991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f6a1c-7b34-4c23-8172-5b869c96eb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f6a1c-7b34-4c23-8172-5b869c96eb65.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -11351,7 +11351,7 @@
         },
         {
             "id": "e30317da-f08a-5a7f-81e1-8a47fe580faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdffb27-5035-49c2-b214-abe46a17433d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdffb27-5035-49c2-b214-abe46a17433d.jpg?1",
             "name": "Veloheart Bike",
             "text": "When this Vehicle enters, you gain 2 life.\n{T}: Add one mana of any color.\nCrew 2",
             "colours": [
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "a6f27e3c-ad76-5ee7-9219-a39a10766537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55a6ec-634c-4590-9875-db4e5b81795d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55a6ec-634c-4590-9875-db4e5b81795d.jpg?1",
             "name": "Apocalypse Runner",
             "text": "{T}: Target creature you control with power 2 or less gains lifelink until end of turn and can't be blocked this turn.\nCrew 3",
             "colours": [
@@ -11425,7 +11425,7 @@
         },
         {
             "id": "d95f156a-6d05-58d0-8369-b03649acc624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bb2217-d3e1-4638-9a14-bb72bfedd18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bb2217-d3e1-4638-9a14-bb72bfedd18c.jpg?1",
             "name": "Boosted Sloop",
             "text": "Menace\nWhenever you attack, draw a card, then discard a card.\nCrew 1",
             "colours": [
@@ -11463,7 +11463,7 @@
         },
         {
             "id": "2a9300df-318a-5387-ac58-c85f3693e8f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73918759-b7b6-4a09-baa1-7f660ecef42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73918759-b7b6-4a09-baa1-7f660ecef42e.jpg?1",
             "name": "Cloudspire Skycycle",
             "text": "Flying\nWhen this Vehicle enters, distribute two +1/+1 counters among one or two other target Vehicles and/or creatures you control.\nCrew 1",
             "colours": [
@@ -11501,7 +11501,7 @@
         },
         {
             "id": "2fe26bed-535c-542a-b8ee-7df3dad39d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe7293-2d85-42dd-b6a1-21e98487cbfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe7293-2d85-42dd-b6a1-21e98487cbfa.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "d3bde68a-93f6-587e-810a-3c4f8011b51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71586675-e9f5-4bec-984d-8683b2494b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71586675-e9f5-4bec-984d-8683b2494b35.jpg?1",
             "name": "Dune Drifter",
             "text": "When this Vehicle enters, return target artifact or creature card with mana value X or less from your graveyard to the battlefield.\nCrew 2",
             "colours": [
@@ -11579,7 +11579,7 @@
         },
         {
             "id": "5b5b65a1-fac3-582f-af22-6bc74bfb4f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83566cd0-2253-477e-ae99-4c0c4902ad6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83566cd0-2253-477e-ae99-4c0c4902ad6e.jpg?1",
             "name": "Guidelight Pathmaker",
             "text": "Vigilance\nWhen this Vehicle enters, you may search your library for an artifact card and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. Then shuffle.\nCrew 2",
             "colours": [
@@ -11617,7 +11617,7 @@
         },
         {
             "id": "4cf75816-d11c-5ad3-90f7-8aeb56937e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68c20a-f377-4613-8771-cdda1745cdff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68c20a-f377-4613-8771-cdda1745cdff.jpg?1",
             "name": "Haunted Hellride",
             "text": "Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of turn. Untap it.\nCrew 1",
             "colours": [
@@ -11655,7 +11655,7 @@
         },
         {
             "id": "9c0e3417-d672-58fd-85a0-5c948b482c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0d5c5c-d3d6-48ae-9775-fcd2cd9a0c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0d5c5c-d3d6-48ae-9775-fcd2cd9a0c65.jpg?1",
             "name": "Rangers' Aetherhive",
             "text": "Vigilance\nWhenever you activate an exhaust ability, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1",
             "colours": [
@@ -11693,7 +11693,7 @@
         },
         {
             "id": "2b6349bc-2fb4-56c2-a09a-fbb63d033b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db27c67-0462-474c-844b-4f69d8fe6734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db27c67-0462-474c-844b-4f69d8fe6734.jpg?1",
             "name": "Rocketeer Boostbuggy",
             "text": "Whenever this Vehicle attacks, create a Treasure token.\nExhaust \u2014 {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -11731,7 +11731,7 @@
         },
         {
             "id": "4a54d6ad-eeff-5d14-aeb1-f012e0a17937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4adfba1-c73a-43b4-8400-e11617958f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4adfba1-c73a-43b4-8400-e11617958f7f.jpg?1",
             "name": "Thundering Broodwagon",
             "text": "Menace, reach\nWhen this Vehicle enters, destroy target nonland permanent an opponent controls with mana value 4 or less.\nCrew 3\nCycling {2}",
             "colours": [
@@ -11769,7 +11769,7 @@
         },
         {
             "id": "e0d94e41-ed04-5a12-99a1-ea52174b3673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0aa565-1ef0-41f5-a86d-0701e357cde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0aa565-1ef0-41f5-a86d-0701e357cde9.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -11804,7 +11804,7 @@
         },
         {
             "id": "e668b265-7413-5e46-af0e-075116a77180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e88ae-7f5c-4dea-add0-a53a6a9bd8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e88ae-7f5c-4dea-add0-a53a6a9bd8e4.jpg?1",
             "name": "Marshals' Pathcruiser",
             "text": "When this Vehicle enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nExhaust \u2014 {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it.\nCrew 5",
             "colours": [],
@@ -11842,7 +11842,7 @@
         },
         {
             "id": "18feb146-707b-5548-8c93-67c72c11b72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3b07b7-8d51-428e-a399-61da45529c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3b07b7-8d51-428e-a399-61da45529c8f.jpg?1",
             "name": "Rover Blades",
             "text": "Double strike\nEquipped creature has double strike.\nEquip {4}\nCrew 2",
             "colours": [],
@@ -11875,7 +11875,7 @@
         },
         {
             "id": "86afbbc0-5f93-533d-a353-4ffa861f3333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9e294e-cdb2-423d-a034-f68f673b5973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9e294e-cdb2-423d-a034-f68f673b5973.jpg?1",
             "name": "Skybox Ferry",
             "text": "Flying\nCrew 2\nCycling {2}",
             "colours": [],
@@ -11907,7 +11907,7 @@
         },
         {
             "id": "13b20ccb-9db9-54c8-b59f-f5a775d036c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27736f40-a87b-45e4-a0da-accf9433c1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27736f40-a87b-45e4-a0da-accf9433c1fc.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1",
             "colours": [
@@ -11946,7 +11946,7 @@
         },
         {
             "id": "f7ee6ef6-5fc4-502e-b131-94c574f876b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309072be-b813-42bd-adaf-7d45053029c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309072be-b813-42bd-adaf-7d45053029c0.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -11985,7 +11985,7 @@
         },
         {
             "id": "ba30c761-8185-5f2b-be4f-056b435603cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcda94fc-43f0-4fa6-b38b-bb8c4c26d9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcda94fc-43f0-4fa6-b38b-bb8c4c26d9a1.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.",
             "colours": [
@@ -12024,7 +12024,7 @@
         },
         {
             "id": "b99a8002-88a3-5739-ba02-2f239b0c5d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc820fb-eec2-4873-a272-68e8379470fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc820fb-eec2-4873-a272-68e8379470fc.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2}",
             "colours": [
@@ -12062,7 +12062,7 @@
         },
         {
             "id": "4f97530a-3940-5a32-b102-de1681b3b9ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560bd1f-eb63-45bc-a8c7-b5de200facc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560bd1f-eb63-45bc-a8c7-b5de200facc9.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -12101,7 +12101,7 @@
         },
         {
             "id": "4903cc32-86b7-51df-ae95-42c8d009a70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3150199e-9e4f-486d-bfb0-fc2a9feb8536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3150199e-9e4f-486d-bfb0-fc2a9feb8536.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -12140,7 +12140,7 @@
         },
         {
             "id": "0c8e02d6-dd2d-511a-bafe-449559b1a9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4045e7-6d2c-4ef9-922e-3681fa820c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4045e7-6d2c-4ef9-922e-3681fa820c4b.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -12180,7 +12180,7 @@
         },
         {
             "id": "abdf05e4-5249-57c7-88b1-9a2c7cef2f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ffa8e-2794-4f11-8351-42f1a0f26831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ffa8e-2794-4f11-8351-42f1a0f26831.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -12219,7 +12219,7 @@
         },
         {
             "id": "43b21249-0f15-588b-9f91-a6599032a48d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4712279a-ae45-488c-870a-0187201c860f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4712279a-ae45-488c-870a-0187201c860f.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature.\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -12258,7 +12258,7 @@
         },
         {
             "id": "532095d3-6343-5cfa-ba08-e2dcfa429e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a758d38-adfe-4894-bf27-d988a228e944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a758d38-adfe-4894-bf27-d988a228e944.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -12297,7 +12297,7 @@
         },
         {
             "id": "3109baae-41da-5a46-bef1-f2072259b7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d60a4-af43-4a2e-98b5-1098478eeb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d60a4-af43-4a2e-98b5-1098478eeb02.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G}\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "ba65cbb8-1ac2-582b-be80-5c06b87e3a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f978b9-d464-42f7-ba8b-0c0795d54cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f978b9-d464-42f7-ba8b-0c0795d54cb5.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "7a90bef0-0807-5a74-aa5d-6895b3029592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8e016-2b68-43d1-b25a-553bad97e431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8e016-2b68-43d1-b25a-553bad97e431.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G}\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -12413,7 +12413,7 @@
         },
         {
             "id": "6bebfc53-0e12-55e1-ab3b-e44393232187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8aff7b-bcf4-46a2-a8f5-dc00394a84da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8aff7b-bcf4-46a2-a8f5-dc00394a84da.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -12454,7 +12454,7 @@
         },
         {
             "id": "47465391-d891-5ee4-b16e-4ec4654be643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6cbde-ce5b-4c25-9a27-715fe7abe4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6cbde-ce5b-4c25-9a27-715fe7abe4e4.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -12494,7 +12494,7 @@
         },
         {
             "id": "b49e1057-3ca1-53d6-8312-51ae49f777e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82000701-d4a8-4f9f-a4b0-236858c84954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82000701-d4a8-4f9f-a4b0-236858c84954.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -12535,7 +12535,7 @@
         },
         {
             "id": "ffc6ed37-193e-5c7c-879f-9e5793f6228b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4574869-9598-4295-bd43-ce3633e0d8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4574869-9598-4295-bd43-ce3633e0d8e6.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -12576,7 +12576,7 @@
         },
         {
             "id": "c3b37d34-addd-5d3b-a78e-cc94ed54239e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a81bf-f63c-40ca-a4da-db68df3f3e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a81bf-f63c-40ca-a4da-db68df3f3e1a.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -12618,7 +12618,7 @@
         },
         {
             "id": "117fe230-6a8a-5fc1-aa6e-b09932932a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ead92-1d35-495c-8ee8-14d73e9f1437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ead92-1d35-495c-8ee8-14d73e9f1437.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -12659,7 +12659,7 @@
         },
         {
             "id": "db81021e-356c-5d8c-8b25-0efb2284bd89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa0bc1-3c31-4886-bfd2-f1ab6e048559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa0bc1-3c31-4886-bfd2-f1ab6e048559.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -12700,7 +12700,7 @@
         },
         {
             "id": "e8cd8100-61bb-5e57-b6e5-cdd67635354b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cdbb98-a5b8-4b9e-aaaa-457eb9d4041e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cdbb98-a5b8-4b9e-aaaa-457eb9d4041e.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike, prowess\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -12741,7 +12741,7 @@
         },
         {
             "id": "21ace97a-136d-506b-9ef9-a68c8afef57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43655ecc-af27-494f-bee7-a5542cae9b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43655ecc-af27-494f-bee7-a5542cae9b54.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -12783,7 +12783,7 @@
         },
         {
             "id": "f4288e40-47be-51d3-aa4c-8046625be5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440766a6-5820-4248-ad91-4d946235e136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440766a6-5820-4248-ad91-4d946235e136.jpg?1",
             "name": "Basri, Tomorrow's Champion",
             "text": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink.\nCycling {2}{W}\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -12823,7 +12823,7 @@
         },
         {
             "id": "11409dde-0316-581c-a7bd-74f32d628c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d0d849-d400-43fc-a42a-0eeb27131d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d0d849-d400-43fc-a42a-0eeb27131d1b.jpg?1",
             "name": "Vnwxt, Verbose Host",
             "text": "Start your engines\nYou have no maximum hand size.\nMax speed \u2014 If you would draw a card, draw two cards instead.",
             "colours": [
@@ -12862,7 +12862,7 @@
         },
         {
             "id": "dff1c1f2-17e9-562e-9f6e-5fb252eed582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a867af-cf5d-4e3d-bba1-361e3cfeca82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a867af-cf5d-4e3d-bba1-361e3cfeca82.jpg?1",
             "name": "Gonti, Night Minister",
             "text": "Whenever a player casts a spell they don't own, that player creates a Treasure token.\nWhenever a creature deals combat damage to one of your opponents, its controller looks at the top card of that opponent's library and exiles it face down. They may play that card for as long as it remains exiled. Mana of any type can be spent to cast a spell this way.",
             "colours": [
@@ -12902,7 +12902,7 @@
         },
         {
             "id": "4589f7f6-a0de-5051-b802-e4fc829707b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993ac84-304a-4e42-aa39-b72be30471ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993ac84-304a-4e42-aa39-b72be30471ea.jpg?1",
             "name": "Daretti, Rocketeer Engineer",
             "text": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
             "colours": [
@@ -12942,7 +12942,7 @@
         },
         {
             "id": "d30a4627-9918-59bb-8cd3-f85575583107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b47651-5607-40b0-9e73-ad356b10acc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b47651-5607-40b0-9e73-ad356b10acc9.jpg?1",
             "name": "Oviya, Automech Artisan",
             "text": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
             "colours": [
@@ -12982,7 +12982,7 @@
         },
         {
             "id": "365b3890-cb47-52f4-b57a-1e297772b34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789df76-d658-47a4-9efb-74da6bd8821c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789df76-d658-47a4-9efb-74da6bd8821c.jpg?1",
             "name": "Aatchik, Emerald Radian",
             "text": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
             "colours": [
@@ -13024,7 +13024,7 @@
         },
         {
             "id": "357b6e6d-4253-53bb-a7b8-f17339bf0a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0f937-5519-4d38-9fc3-46460669bb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0f937-5519-4d38-9fc3-46460669bb86.jpg?1",
             "name": "Captain Howler, Sea Scourge",
             "text": "Ward\u2014{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
             "colours": [
@@ -13066,7 +13066,7 @@
         },
         {
             "id": "7b99ba9c-d314-5084-b592-01bcb81af155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bca478-48c0-4c39-95ae-ba8afb207153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bca478-48c0-4c39-95ae-ba8afb207153.jpg?1",
             "name": "Caradora, Heart of Alacria",
             "text": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -13108,7 +13108,7 @@
         },
         {
             "id": "cb779f42-dafb-5a85-97f9-583717600d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0bd239-25ae-496e-9be2-c2d968dc9346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0bd239-25ae-496e-9be2-c2d968dc9346.jpg?1",
             "name": "Far Fortune, End Boss",
             "text": "Start your engines\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed \u2014 If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -13150,7 +13150,7 @@
         },
         {
             "id": "c1cefff2-5707-54c4-996e-27a0bec43515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33887384-a2bb-4daf-b932-a4259c93b808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33887384-a2bb-4daf-b932-a4259c93b808.jpg?1",
             "name": "Kolodin, Triumph Caster",
             "text": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "e99b7dda-d75c-5141-9cf7-c42967efc2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11d7a7-72e9-406e-a701-5c3a556a43e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11d7a7-72e9-406e-a701-5c3a556a43e0.jpg?1",
             "name": "Mendicant Core, Guidelight",
             "text": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines\nMax speed \u2014 Whenever you cast an artifact spell, you may pay {1}. If you do, copy it.",
             "colours": [
@@ -13234,7 +13234,7 @@
         },
         {
             "id": "6b056c38-9bca-585c-94ca-e27c6f3c223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56bc66f-12d1-4eae-8de7-2fae34976d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56bc66f-12d1-4eae-8de7-2fae34976d6b.jpg?1",
             "name": "Redshift, Rocketeer Chief",
             "text": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust \u2014 {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield.",
             "colours": [
@@ -13276,7 +13276,7 @@
         },
         {
             "id": "45ef62c7-8cae-50fb-b79e-1fbcc24511cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227036a1-7570-4657-9c0a-635dd6d889e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227036a1-7570-4657-9c0a-635dd6d889e9.jpg?1",
             "name": "Samut, the Driving Force",
             "text": "First strike, vigilance, haste\nStart your engines\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
             "colours": [
@@ -13321,7 +13321,7 @@
         },
         {
             "id": "77ebecd0-c6a4-5139-ad86-c4ef809b7100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119a39ce-80f6-48b3-b159-e5d919d3b617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119a39ce-80f6-48b3-b159-e5d919d3b617.jpg?1",
             "name": "Sita Varma, Masked Racer",
             "text": "Exhaust \u2014 {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.",
             "colours": [
@@ -13363,7 +13363,7 @@
         },
         {
             "id": "1f0e5d5e-71e8-5456-95ee-3bac4c5c9f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa759b-a940-4071-9373-13e6aef62fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa759b-a940-4071-9373-13e6aef62fe4.jpg?1",
             "name": "Winter, Cursed Rider",
             "text": "Ward\u2014\nPay 2 life.\nArtifacts you control have \"Ward\u2014\nPay 2 life.\"\nExhaust \u2014 {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "a6b1ddcb-b64a-533e-b1f2-7e659a32747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004f64-5052-4b1e-8fd8-eda463fbd9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004f64-5052-4b1e-8fd8-eda463fbd9b7.jpg?1",
             "name": "Zahur, Glory's Past",
             "text": "Start your engines\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed \u2014 Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -13448,7 +13448,7 @@
         },
         {
             "id": "1f5cc599-e2d7-5d1c-bd61-7f562c1ccac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba2edc7-dbc0-4948-9f37-a27a91bdf7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba2edc7-dbc0-4948-9f37-a27a91bdf7b9.jpg?1",
             "name": "Bleachbone Verge",
             "text": "{T}: Add {B}.\n{T}: Add {W}. Activate only if you control a Plains or a Swamp.",
             "colours": [],
@@ -13482,7 +13482,7 @@
         },
         {
             "id": "17d4f88d-be53-5fce-b5be-a59483725941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc6f3-2fdc-4629-84b9-f3707b799460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc6f3-2fdc-4629-84b9-f3707b799460.jpg?1",
             "name": "Riverpyre Verge",
             "text": "{T}: Add {R}.\n{T}: Add {U}. Activate only if you control an Island or a Mountain.",
             "colours": [],
@@ -13516,7 +13516,7 @@
         },
         {
             "id": "bab02f65-4117-5500-8226-60fc2a6d81ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92a7ca5-a25b-4888-a319-6e176ab4d0ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92a7ca5-a25b-4888-a319-6e176ab4d0ce.jpg?1",
             "name": "Sunbillow Verge",
             "text": "{T}: Add {W}.\n{T}: Add {R}. Activate only if you control a Mountain or a Plains.",
             "colours": [],
@@ -13550,7 +13550,7 @@
         },
         {
             "id": "41f1ce00-d0c3-578d-abba-3317eccc5b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ab2fc7-7945-4b49-8ad0-223815d0d2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ab2fc7-7945-4b49-8ad0-223815d0d2c2.jpg?1",
             "name": "Wastewood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {B}. Activate only if you control a Swamp or a Forest.",
             "colours": [],
@@ -13584,7 +13584,7 @@
         },
         {
             "id": "6dfee968-6cba-557b-8cbb-bbd013fba9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38218d0f-4b70-45eb-a753-cdb44f94271c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38218d0f-4b70-45eb-a753-cdb44f94271c.jpg?1",
             "name": "Willowrush Verge",
             "text": "{T}: Add {U}.\n{T}: Add {G}. Activate only if you control a Forest or an Island.",
             "colours": [],
@@ -13618,7 +13618,7 @@
         },
         {
             "id": "b77bd321-60d8-52c4-a45a-313624edc21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934cc1ca-2ce8-4062-b1b7-1976e76da8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934cc1ca-2ce8-4062-b1b7-1976e76da8b6.jpg?1",
             "name": "The Aetherspark",
             "text": "",
             "colours": [],
@@ -13653,7 +13653,7 @@
         },
         {
             "id": "0368dc3f-fc0b-5c37-abfd-7004e629cb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1edff87-8563-4cb5-ab9b-7696e920346a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1edff87-8563-4cb5-ab9b-7696e920346a.jpg?1",
             "name": "Perilous Snare",
             "text": "Start your engines\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed \u2014 {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "605c7dd2-4597-5954-a077-dfb07363a5b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b513dfeb-d7c8-4e4d-b419-f67b45608b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b513dfeb-d7c8-4e4d-b419-f67b45608b4b.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2}",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "70059c65-75a0-57ae-8c75-e53a692ac49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4797dcb-507f-4219-95ff-994e2c0d251b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4797dcb-507f-4219-95ff-994e2c0d251b.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -13768,7 +13768,7 @@
         },
         {
             "id": "a8e34bf7-0b0d-5a42-9631-7a7681302454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231c4f52-5a12-407f-9917-d2ca91ba4706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231c4f52-5a12-407f-9917-d2ca91ba4706.jpg?1",
             "name": "Repurposing Bay",
             "text": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -13803,7 +13803,7 @@
         },
         {
             "id": "59a8950d-31df-565f-8a00-a5652dc01ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131df43b-2a72-4ca3-8aae-c0dca2eca8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131df43b-2a72-4ca3-8aae-c0dca2eca8fc.jpg?1",
             "name": "Riverchurn Monument",
             "text": "{1}, {T}: Any number of target players each mill two cards.\nExhaust \u2014 {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard.",
             "colours": [
@@ -13838,7 +13838,7 @@
         },
         {
             "id": "70af41fe-900e-5972-9c4f-0cd4f8940467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce40ff0e-04ae-4786-ac0c-54a66ffb48a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce40ff0e-04ae-4786-ac0c-54a66ffb48a6.jpg?1",
             "name": "Unstoppable Plan",
             "text": "At the beginning of your end step, untap all nonland permanents you control.",
             "colours": [
@@ -13873,7 +13873,7 @@
         },
         {
             "id": "8928f818-9372-5d3e-bcb8-b578e9e6ee12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57479-6409-49e1-8896-2bd3e88d554d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57479-6409-49e1-8896-2bd3e88d554d.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
             "colours": [
@@ -13910,7 +13910,7 @@
         },
         {
             "id": "01036828-d5f6-550c-81b7-b26d3093fe99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6498f0-5ebd-441a-a851-461b0460e7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6498f0-5ebd-441a-a851-461b0460e7d5.jpg?1",
             "name": "Quag Feast",
             "text": "Choose target creature, planeswalker, or Vehicle. Mill two cards, then destroy the chosen permanent if its mana value is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "f50fe125-7ff3-53aa-a7f7-f3bdfa379546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2abab5-c4f0-41ec-ae6f-e42721ca2cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2abab5-c4f0-41ec-ae6f-e42721ca2cfd.jpg?1",
             "name": "Count on Luck",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "166736d6-cbf8-5f4f-92c1-57e816ba8caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7967282-ae00-4fdd-85c6-bcc8bc9b790b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7967282-ae00-4fdd-85c6-bcc8bc9b790b.jpg?1",
             "name": "Full Throttle",
             "text": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
             "colours": [
@@ -14015,7 +14015,7 @@
         },
         {
             "id": "817b6ed1-d9e5-5b7a-a42d-66e141d7b1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe531a-f1f9-46d4-aff4-2b0df789be66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe531a-f1f9-46d4-aff4-2b0df789be66.jpg?1",
             "name": "Afterburner Expert",
             "text": "Exhaust \u2014 {2}{G}{G}: Put two +1/+1 counters on this creature.\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -14053,7 +14053,7 @@
         },
         {
             "id": "6533486e-e2fd-577a-a51c-5356aea4d95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615e3ebb-c41a-497a-b71b-6549366e5b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615e3ebb-c41a-497a-b71b-6549366e5b07.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -14090,7 +14090,7 @@
         },
         {
             "id": "ab5a75bd-b6e2-5d9c-a5dd-4e44047e8545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a198715-4f82-409d-add0-e0200a88d708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a198715-4f82-409d-add0-e0200a88d708.jpg?1",
             "name": "Regal Imperiosaur",
             "text": "Other Dinosaurs you control get +1/+1.",
             "colours": [
@@ -14127,7 +14127,7 @@
         },
         {
             "id": "64de4cf4-60bb-5254-b3ca-6a6076bdc2f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258dcf4-b481-4ad5-96ef-2a42de8c9c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258dcf4-b481-4ad5-96ef-2a42de8c9c2a.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -14166,7 +14166,7 @@
         },
         {
             "id": "1bf08fd4-ddbc-5211-ac44-05ef10177d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2528d058-5ca3-4671-8bf1-c8161872cd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2528d058-5ca3-4671-8bf1-c8161872cd36.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color.\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -14212,7 +14212,7 @@
         },
         {
             "id": "1c372a2f-2d80-578c-ba48-968899d76fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115088f3-9fca-4120-8ca5-c124c3d32975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115088f3-9fca-4120-8ca5-c124c3d32975.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -14257,7 +14257,7 @@
         },
         {
             "id": "d5ecbb84-6325-558b-a583-d572293662bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93211140-5aa7-4700-804d-aa46a8b141d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93211140-5aa7-4700-804d-aa46a8b141d7.jpg?1",
             "name": "Marketback Walker",
             "text": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
             "colours": [],
@@ -14291,7 +14291,7 @@
         },
         {
             "id": "cb1e4f3d-0665-5fa1-aeb3-d67a636828eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cbdac-1d15-40f5-b76f-6f21b917abbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cbdac-1d15-40f5-b76f-6f21b917abbc.jpg?1",
             "name": "Monument to Endurance",
             "text": "Whenever you discard a card, choose one that hasn't been chosen this turn \u2014\n\u2022 Draw a card.\n\u2022 Create a Treasure token.\n\u2022 Each opponent loses 3 life.",
             "colours": [],
@@ -14322,7 +14322,7 @@
         },
         {
             "id": "fc0d11c8-6e5a-5a8e-a0f6-bd55c991dfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef84601-6ace-4847-abeb-16dcfdba5c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef84601-6ace-4847-abeb-16dcfdba5c89.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "3879cbbd-ef4c-53d8-a8c5-a72db0705999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b87e12-bd95-450e-a528-a44c76dbfae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b87e12-bd95-450e-a528-a44c76dbfae5.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -14387,7 +14387,7 @@
         },
         {
             "id": "b61a5c3a-ae15-5303-98a9-fb70813bd842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cb1b9-38b7-42ad-b176-dc265bc8abe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cb1b9-38b7-42ad-b176-dc265bc8abe0.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -14426,7 +14426,7 @@
         },
         {
             "id": "ef20d586-edbb-51da-a771-93ec5078a65a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec93ed6d-a840-477d-a16c-ffd15a52c941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec93ed6d-a840-477d-a16c-ffd15a52c941.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2}",
             "colours": [
@@ -14462,7 +14462,7 @@
         },
         {
             "id": "8cf3bb04-f511-5fa0-8391-ede619f502d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe19f52-ae23-4a23-800d-f3cf186279f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe19f52-ae23-4a23-800d-f3cf186279f2.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -14504,7 +14504,7 @@
         },
         {
             "id": "d7b97010-f41a-5bc5-ad3f-4193bc62eece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5280941-bcda-4ac7-97d1-db02c7a18ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5280941-bcda-4ac7-97d1-db02c7a18ef9.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
             "colours": [
@@ -14540,7 +14540,7 @@
         },
         {
             "id": "7424b09b-9029-5111-bc05-5a92a454c239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1864b99-6893-4e4d-94de-641837c05da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1864b99-6893-4e4d-94de-641837c05da3.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n\u22127: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
             "colours": [
@@ -14579,7 +14579,7 @@
         },
         {
             "id": "d33b8330-0780-5814-9ecb-c6ae7a45b03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455027f1-26a4-464b-a456-271a6ec88669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455027f1-26a4-464b-a456-271a6ec88669.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -14615,7 +14615,7 @@
         },
         {
             "id": "fbd8f46d-b5ec-5dfa-9497-51595884ab97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a81f86-e80f-47f7-81cd-0c4b9330e646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a81f86-e80f-47f7-81cd-0c4b9330e646.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -14653,7 +14653,7 @@
         },
         {
             "id": "dedd5e67-16aa-5bf4-97e3-05659672991f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b04ab-4c61-47f5-88e4-c5c2f93edc11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b04ab-4c61-47f5-88e4-c5c2f93edc11.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color.\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -14698,7 +14698,7 @@
         },
         {
             "id": "2abd36d5-1c61-5319-8720-1c1991931acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8caa7-714e-4987-8d44-04fbe5a77c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8caa7-714e-4987-8d44-04fbe5a77c6d.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -14742,7 +14742,7 @@
         },
         {
             "id": "a02dfc12-6ed0-5357-892e-21e028cb3bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb85966-66a2-4fb7-b89d-05db7f4e2cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb85966-66a2-4fb7-b89d-05db7f4e2cb8.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -14774,7 +14774,7 @@
         },
         {
             "id": "1192181e-cce4-5dfe-8c23-d3fb989e806f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e73d4ed-def7-4456-a750-74fb2bf10f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e73d4ed-def7-4456-a750-74fb2bf10f9f.jpg?1",
             "name": "Salvation Engine",
             "text": "",
             "colours": [
@@ -14813,7 +14813,7 @@
         },
         {
             "id": "1652d071-0aba-5b4f-b34c-492c6ee3d62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fd4f1b-afbd-41a5-a76a-f9788e0cec9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fd4f1b-afbd-41a5-a76a-f9788e0cec9d.jpg?1",
             "name": "Spectacular Pileup",
             "text": "",
             "colours": [
@@ -14849,7 +14849,7 @@
         },
         {
             "id": "2cb62647-8d17-5a1c-ae86-f6878be72004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8327b4b6-058e-448b-99ca-7d2de52d3b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8327b4b6-058e-448b-99ca-7d2de52d3b4c.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "",
             "colours": [
@@ -14891,7 +14891,7 @@
         },
         {
             "id": "9b47cfe0-e540-59cf-83ba-11b7d41da39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c15a04e-b0a7-4560-a838-94213dbb2336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c15a04e-b0a7-4560-a838-94213dbb2336.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "",
             "colours": [
@@ -14927,7 +14927,7 @@
         },
         {
             "id": "3441bfa2-d573-52be-8a10-57e817efd8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a40fa6-4378-413b-bed8-7eb0d61b70ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a40fa6-4378-413b-bed8-7eb0d61b70ad.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "",
             "colours": [
@@ -14966,7 +14966,7 @@
         },
         {
             "id": "03f0456c-5e60-5523-a8a2-1d6feda7b2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9fbbfc-8920-46cd-95cd-2372feb4617a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9fbbfc-8920-46cd-95cd-2372feb4617a.jpg?1",
             "name": "March of the World Ooze",
             "text": "",
             "colours": [
@@ -15002,7 +15002,7 @@
         },
         {
             "id": "fc1da485-5e29-52de-beee-b18e587a2296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd66b9-f292-4b10-b753-2df112f6f714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd66b9-f292-4b10-b753-2df112f6f714.jpg?1",
             "name": "Explosive Getaway",
             "text": "",
             "colours": [
@@ -15040,7 +15040,7 @@
         },
         {
             "id": "5766cde6-8c88-5510-95be-d962530575bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fba04a-20ab-40eb-9edf-89fdd03bfb7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fba04a-20ab-40eb-9edf-89fdd03bfb7e.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "",
             "colours": [
@@ -15085,7 +15085,7 @@
         },
         {
             "id": "ea185248-b981-57fc-a31c-d8af2ddf7aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b243165-79ad-4193-af89-2ad5e34fc415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b243165-79ad-4193-af89-2ad5e34fc415.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "",
             "colours": [
@@ -15129,7 +15129,7 @@
         },
         {
             "id": "0fc05fc9-27e0-5827-b6b0-168f543416b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656ba742-b00f-4fce-8418-987226c25a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656ba742-b00f-4fce-8418-987226c25a81.jpg?1",
             "name": "Radiant Lotus",
             "text": "",
             "colours": [],
@@ -15161,7 +15161,7 @@
         },
         {
             "id": "3f3f4e7b-2cd5-5417-ac88-71adb7c65508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b832719-ac31-470f-9d50-0b514ecc6845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b832719-ac31-470f-9d50-0b514ecc6845.jpg?1",
             "name": "Tune Up",
             "text": "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.",
             "colours": [
@@ -15195,7 +15195,7 @@
         },
         {
             "id": "37fa87a1-c41f-5ff0-b2da-299fe2a6d45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b12dd-2ce3-48a6-9ea7-7d5f155164c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b12dd-2ce3-48a6-9ea7-7d5f155164c9.jpg?1",
             "name": "Gastal Raider",
             "text": "Start your engines\nWhen this creature enters, target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.\nMax speed \u2014 This creature gets +1/+1 and has menace.",
             "colours": [
@@ -15232,7 +15232,7 @@
         },
         {
             "id": "5dbbaccc-07d5-5008-b481-fd653d9663ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ebb23-fecd-4aa5-96b7-447c9768794e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ebb23-fecd-4aa5-96b7-447c9768794e.jpg?1",
             "name": "Marauding Mako",
             "text": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2}",
             "colours": [
@@ -15269,7 +15269,7 @@
         },
         {
             "id": "5db03f2f-b157-5264-ad15-3ae90190db33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7de8c7e-7270-4a4f-af03-9f088b04c05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7de8c7e-7270-4a4f-af03-9f088b04c05b.jpg?1",
             "name": "Skyserpent Seeker",
             "text": "Flying, deathtouch\nExhaust \u2014 {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature.",
             "colours": [
@@ -15307,7 +15307,7 @@
         },
         {
             "id": "44b18675-2107-5b70-86a1-5bdd5e14911f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30789c9b-7b4b-43e7-a161-aa6595ea9dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30789c9b-7b4b-43e7-a161-aa6595ea9dee.jpg?1",
             "name": "Voyage Home",
             "text": "Affinity for artifacts\nYou draw three cards and gain 3 life.",
             "colours": [
@@ -15343,7 +15343,7 @@
         },
         {
             "id": "3393a82d-6427-5e80-ac12-c9838730bbc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a85032-0c45-40f7-901a-3fd77ff212a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a85032-0c45-40f7-901a-3fd77ff212a4.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -15381,7 +15381,7 @@
         },
         {
             "id": "01165481-6e23-53db-8a2b-281c7a4e3310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eda600-af1e-4444-a822-830037133c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eda600-af1e-4444-a822-830037133c0d.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -15415,7 +15415,7 @@
         },
         {
             "id": "50bdfb6b-bcda-5b60-b015-5289fc10d493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37d984-5a9c-45e3-8213-4af93872d512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37d984-5a9c-45e3-8213-4af93872d512.jpg?1",
             "name": "Amonkhet Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Target creature gains haste until end of turn.",
             "colours": [],
@@ -15444,7 +15444,7 @@
         },
         {
             "id": "a42e0ca9-0b7d-5fb9-b0b9-64d92a391a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e9b236-f0e5-4e9d-a9c9-7d625e8412f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e9b236-f0e5-4e9d-a9c9-7d625e8412f2.jpg?1",
             "name": "Avishkar Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {3}, {T}, Discard a card: Draw a card.",
             "colours": [],
@@ -15473,7 +15473,7 @@
         },
         {
             "id": "5b99b7b2-8062-5bc8-aad2-57df0122ffe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db48a2f-5110-431e-8d72-b70bd2e9d887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db48a2f-5110-431e-8d72-b70bd2e9d887.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -15504,7 +15504,7 @@
         },
         {
             "id": "9f7491e8-6740-5884-9804-9e075d0ee351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d4e0c-2653-4353-8e70-b7cf0f6808ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d4e0c-2653-4353-8e70-b7cf0f6808ed.jpg?1",
             "name": "Basri, Tomorrow's Champion",
             "text": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink.\nCycling {2}{W}\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -15543,7 +15543,7 @@
         },
         {
             "id": "eaf1cb6a-f25c-53b2-ad79-80cd006db322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146670b1-0b6d-4d9b-b931-137c508309a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146670b1-0b6d-4d9b-b931-137c508309a9.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1",
             "colours": [
@@ -15581,7 +15581,7 @@
         },
         {
             "id": "93dbab40-85e3-590f-8291-d1fc6f2dabf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6b0d3e-0d3e-44a7-99e3-4ccba6c832e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6b0d3e-0d3e-44a7-99e3-4ccba6c832e1.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -15619,7 +15619,7 @@
         },
         {
             "id": "7ee2b117-1049-5399-859e-16f0a1bb06af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87181867-f63d-4642-875f-001c1ed7912f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87181867-f63d-4642-875f-001c1ed7912f.jpg?1",
             "name": "Perilous Snare",
             "text": "Start your engines\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed \u2014 {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
             "colours": [
@@ -15653,7 +15653,7 @@
         },
         {
             "id": "3cd3ba2e-febf-5fc6-b00f-416088e948df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f338af2-f173-45a0-bbea-02517d41bef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f338af2-f173-45a0-bbea-02517d41bef2.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "4cd356ef-524b-5213-9ca6-a1ef278cd39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a062cbd-b769-49d3-a9fd-7aeb414f44d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a062cbd-b769-49d3-a9fd-7aeb414f44d6.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -15729,7 +15729,7 @@
         },
         {
             "id": "9b1c54f6-abcd-50bc-bb37-b4596730080b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21406e-0c00-4501-a93e-ccd8172314e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21406e-0c00-4501-a93e-ccd8172314e8.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2}",
             "colours": [
@@ -15765,7 +15765,7 @@
         },
         {
             "id": "499c4ca8-f64e-5e3c-9b68-707ad756020d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f73b484-1503-4899-8b6a-076e8b087810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f73b484-1503-4899-8b6a-076e8b087810.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W}\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -15804,7 +15804,7 @@
         },
         {
             "id": "b43f2389-8af6-5b4d-b5fb-2630fd45cde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559dd83b-f24a-43e7-9195-9fcbe6c0c64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559dd83b-f24a-43e7-9195-9fcbe6c0c64b.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -15841,7 +15841,7 @@
         },
         {
             "id": "a94fd4a7-033a-5890-8320-3bdbd8f955a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e15402-8cc6-4ad2-8088-4df92fa20d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e15402-8cc6-4ad2-8088-4df92fa20d8e.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.",
             "colours": [
@@ -15879,7 +15879,7 @@
         },
         {
             "id": "f258d2ee-201e-5281-9154-bd5d1d863751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d45912-7b8d-416e-893b-1d103492a5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d45912-7b8d-416e-893b-1d103492a5a1.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -15921,7 +15921,7 @@
         },
         {
             "id": "f26b3b72-5424-5e23-8984-dd562986bb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858dc258-965a-4d1a-aab5-447e0fecbf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858dc258-965a-4d1a-aab5-447e0fecbf81.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -15958,7 +15958,7 @@
         },
         {
             "id": "0fff5efd-bdc2-55ca-8064-72d1caf341a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277eeef-50af-4654-9216-caf0c37c27d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277eeef-50af-4654-9216-caf0c37c27d7.jpg?1",
             "name": "Repurposing Bay",
             "text": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -15992,7 +15992,7 @@
         },
         {
             "id": "6ec90c7a-ebbe-5937-9e56-455f3c9a5e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d22866-07ac-4aef-b43e-29a37f3db1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d22866-07ac-4aef-b43e-29a37f3db1c0.jpg?1",
             "name": "Riverchurn Monument",
             "text": "{1}, {T}: Any number of target players each mill two cards.\nExhaust \u2014 {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard.",
             "colours": [
@@ -16026,7 +16026,7 @@
         },
         {
             "id": "2c581cad-8fb0-5fd8-b46f-5695bd76fae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98ff182-4a84-4d69-83ce-57a7e5b18ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98ff182-4a84-4d69-83ce-57a7e5b18ebb.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -16063,7 +16063,7 @@
         },
         {
             "id": "f14b0e16-2ca0-5ee8-b819-29658268a1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a95aeb-b1b0-42cd-ad67-fd13717d3c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a95aeb-b1b0-42cd-ad67-fd13717d3c6c.jpg?1",
             "name": "Unstoppable Plan",
             "text": "At the beginning of your end step, untap all nonland permanents you control.",
             "colours": [
@@ -16097,7 +16097,7 @@
         },
         {
             "id": "54d12e04-49be-57fc-b826-3583916f9d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642f9db-3eee-471d-ada6-60e990ec3fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642f9db-3eee-471d-ada6-60e990ec3fab.jpg?1",
             "name": "Vnwxt, Verbose Host",
             "text": "Start your engines\nYou have no maximum hand size.\nMax speed \u2014 If you would draw a card, draw two cards instead.",
             "colours": [
@@ -16135,7 +16135,7 @@
         },
         {
             "id": "0c495b6a-4c77-522a-bcd8-310f0d8a1645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb17c37c-907d-4416-b8c1-d6a6f4e312f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb17c37c-907d-4416-b8c1-d6a6f4e312f3.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2}",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "aa1438ab-d452-567a-8236-a692731bfeb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77534750-fa92-42b4-8f32-be437eca64ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77534750-fa92-42b4-8f32-be437eca64ad.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -16210,7 +16210,7 @@
         },
         {
             "id": "7924ab03-b7d8-5400-ba1d-40b1d9f67026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de65f4cd-3ba4-4e1a-8810-e43cf26b38a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de65f4cd-3ba4-4e1a-8810-e43cf26b38a4.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -16247,7 +16247,7 @@
         },
         {
             "id": "8ffce128-74b8-59df-b182-124b95dc5b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b283c18-abe7-4b73-8532-dd76a85fabd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b283c18-abe7-4b73-8532-dd76a85fabd6.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
             "colours": [
@@ -16283,7 +16283,7 @@
         },
         {
             "id": "506e773c-c136-551e-8fd2-1a0a238f81e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0eb3de-796d-4da3-aab3-08c2b5b6943d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0eb3de-796d-4da3-aab3-08c2b5b6943d.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -16320,7 +16320,7 @@
         },
         {
             "id": "5be6a922-1230-5d5a-80d3-b767d1d310a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e8e6d0-d155-49da-ac5b-47fb408202e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e8e6d0-d155-49da-ac5b-47fb408202e6.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "88b66702-7b5f-56bb-943d-a872aca52579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed5dd3-e67b-4425-bb98-6b07db1e9d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed5dd3-e67b-4425-bb98-6b07db1e9d1f.jpg?1",
             "name": "Gonti, Night Minister",
             "text": "Whenever a player casts a spell they don't own, that player creates a Treasure token.\nWhenever a creature deals combat damage to one of your opponents, its controller looks at the top card of that opponent's library and exiles it face down. They may play that card for as long as it remains exiled. Mana of any type can be spent to cast a spell this way.",
             "colours": [
@@ -16397,7 +16397,7 @@
         },
         {
             "id": "8c87ab57-75f2-580f-b5a3-c0fe76195750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a901a616-b8bb-4e10-9886-ee9c6fdc6435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a901a616-b8bb-4e10-9886-ee9c6fdc6435.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -16436,7 +16436,7 @@
         },
         {
             "id": "596ff515-107e-59e1-9dca-e7b6b586bcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8684d080-070c-4419-9cc8-777500573f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8684d080-070c-4419-9cc8-777500573f55.jpg?1",
             "name": "Quag Feast",
             "text": "Choose target creature, planeswalker, or Vehicle. Mill two cards, then destroy the chosen permanent if its mana value is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -16470,7 +16470,7 @@
         },
         {
             "id": "b5a3d74f-2f9c-5173-a457-2903ae53c927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8a7c1f-9d05-4a4c-bdf2-cd9ee7ed18a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8a7c1f-9d05-4a4c-bdf2-cd9ee7ed18a5.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -16509,7 +16509,7 @@
         },
         {
             "id": "816f79b9-690f-513e-b57a-37e0e3cf29a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1bff20-0b7a-49f9-b967-773f3043be13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1bff20-0b7a-49f9-b967-773f3043be13.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.\nCrew 2",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "14c886ae-918a-5d62-a08c-b2716f2ccb95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c9b613-1494-4df0-9a38-cc0a69fd3945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c9b613-1494-4df0-9a38-cc0a69fd3945.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -16584,7 +16584,7 @@
         },
         {
             "id": "d7c1e945-c039-5422-9957-b7ef7fddb860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b175a-b63f-46d1-a7e1-95dfc7c03e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b175a-b63f-46d1-a7e1-95dfc7c03e3f.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n\u22127: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
             "colours": [
@@ -16623,7 +16623,7 @@
         },
         {
             "id": "a4bbe32a-5d47-5bc8-a9c8-a5961b14ae17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee38fa7-d5c8-4f76-92f8-4c5cb5bae5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee38fa7-d5c8-4f76-92f8-4c5cb5bae5e7.jpg?1",
             "name": "Count on Luck",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "dee704a2-d026-500e-b873-886e8d19a73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a17ef59-177c-4c39-8cbb-efa8ab7ac24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a17ef59-177c-4c39-8cbb-efa8ab7ac24a.jpg?1",
             "name": "Daretti, Rocketeer Engineer",
             "text": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
             "colours": [
@@ -16696,7 +16696,7 @@
         },
         {
             "id": "f3095a82-d848-591d-a7ca-d60be8bbcd25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7758b89f-9629-45f9-ad37-6435dba37997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7758b89f-9629-45f9-ad37-6435dba37997.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature.\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -16734,7 +16734,7 @@
         },
         {
             "id": "1491d161-8e33-5074-a1e4-2bd1e29f2ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf1b29-5a8a-4ac1-aa17-58fcbda969a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf1b29-5a8a-4ac1-aa17-58fcbda969a2.jpg?1",
             "name": "Full Throttle",
             "text": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
             "colours": [
@@ -16768,7 +16768,7 @@
         },
         {
             "id": "cce2a720-6e6b-5b60-af5c-d1aff59e8201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a80bb9d-da0d-4f98-8946-43513db4aef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a80bb9d-da0d-4f98-8946-43513db4aef6.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -16805,7 +16805,7 @@
         },
         {
             "id": "58b21b6d-05c0-5984-9b2b-1c0abb586551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bbbcb2-822f-4729-872b-20638e7ad155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bbbcb2-822f-4729-872b-20638e7ad155.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -16844,7 +16844,7 @@
         },
         {
             "id": "80e96d18-e02d-5933-86f4-3baeeb3ba42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28b514a-29a1-4d85-8eaa-279f3d7e09c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28b514a-29a1-4d85-8eaa-279f3d7e09c1.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -16882,7 +16882,7 @@
         },
         {
             "id": "e682bb5f-b1ee-5a5f-af9a-c1c3ab2c0a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985ee93-3aeb-4f0d-a6af-686efbcadda4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985ee93-3aeb-4f0d-a6af-686efbcadda4.jpg?1",
             "name": "Afterburner Expert",
             "text": "Exhaust \u2014 {2}{G}{G}: Put two +1/+1 counters on this creature.\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -16919,7 +16919,7 @@
         },
         {
             "id": "9968e5fa-c5f9-574c-9c36-986894cf3906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc56fc-8c82-4d74-8119-5d260c691b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc56fc-8c82-4d74-8119-5d260c691b36.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G}\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -16956,7 +16956,7 @@
         },
         {
             "id": "b863bdbf-bf3e-588d-8224-81f674befe40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7926c8-1a46-4edb-950b-2c8bac91b476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7926c8-1a46-4edb-950b-2c8bac91b476.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -16994,7 +16994,7 @@
         },
         {
             "id": "02cbe60c-c728-5ede-977a-e4cafaa2deea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb97f9f-e7be-4794-a3a0-a0d73445c8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb97f9f-e7be-4794-a3a0-a0d73445c8fe.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -17032,7 +17032,7 @@
         },
         {
             "id": "bacae49a-b8fa-5477-89cf-fe04b05576f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89e403b-9653-493f-a3ac-e01aa6f006e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89e403b-9653-493f-a3ac-e01aa6f006e2.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -17068,7 +17068,7 @@
         },
         {
             "id": "6a8f7602-4bb0-554b-a17d-5b4cc36a9f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6eae8b-73de-4d79-bbe5-2921db1987b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6eae8b-73de-4d79-bbe5-2921db1987b2.jpg?1",
             "name": "Oviya, Automech Artisan",
             "text": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
             "colours": [
@@ -17107,7 +17107,7 @@
         },
         {
             "id": "2b2caa84-f296-5c04-bf94-6de45f583b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72328b4-19d1-4855-aa0d-331321eb9945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72328b4-19d1-4855-aa0d-331321eb9945.jpg?1",
             "name": "Regal Imperiosaur",
             "text": "Other Dinosaurs you control get +1/+1.",
             "colours": [
@@ -17143,7 +17143,7 @@
         },
         {
             "id": "d28e44d9-155a-5935-b2f7-b45a620b5711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63dc8cd-34a7-43ea-a422-3ced3c11f5be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63dc8cd-34a7-43ea-a422-3ced3c11f5be.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -17180,7 +17180,7 @@
         },
         {
             "id": "0b3f221b-3446-5ff0-878f-fbf6294ed42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c14636-3ff0-4fbf-9df1-1b6d3d52e29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c14636-3ff0-4fbf-9df1-1b6d3d52e29e.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G}\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -17218,7 +17218,7 @@
         },
         {
             "id": "543b5be7-6f39-550d-a58a-f29d1fa24e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71074080-d83d-4b4a-b385-f918186530b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71074080-d83d-4b4a-b385-f918186530b4.jpg?1",
             "name": "Aatchik, Emerald Radian",
             "text": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
             "colours": [
@@ -17259,7 +17259,7 @@
         },
         {
             "id": "08c32327-8cd6-5e82-b598-10d47f822511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e29a88-34b6-4c3d-9956-b7eb8d5ef591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e29a88-34b6-4c3d-9956-b7eb8d5ef591.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -17299,7 +17299,7 @@
         },
         {
             "id": "f70d35dd-3629-587c-a211-19aad1a818fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48629b-dc1b-4609-aea2-e4833f66d894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48629b-dc1b-4609-aea2-e4833f66d894.jpg?1",
             "name": "Captain Howler, Sea Scourge",
             "text": "Ward\u2014{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
             "colours": [
@@ -17340,7 +17340,7 @@
         },
         {
             "id": "afc39f60-209b-5e1a-a746-ea377e038010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bc2ca6-427f-4f07-88b0-cf57a1fe74ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bc2ca6-427f-4f07-88b0-cf57a1fe74ab.jpg?1",
             "name": "Caradora, Heart of Alacria",
             "text": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -17381,7 +17381,7 @@
         },
         {
             "id": "53d2fe86-7a9b-5daf-8370-e22be58f318f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cf7eba-b917-4f14-8bf4-420bb919b7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cf7eba-b917-4f14-8bf4-420bb919b7e5.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -17421,7 +17421,7 @@
         },
         {
             "id": "2d8c7cdd-a810-5473-be9a-bd9de72c250e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92766c53-703d-41a2-ad13-8c366dcf25ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92766c53-703d-41a2-ad13-8c366dcf25ec.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -17460,7 +17460,7 @@
         },
         {
             "id": "141bd371-d840-5aa9-8203-bd85288c0164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a556367e-7db7-47ad-9f10-37d277d80e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a556367e-7db7-47ad-9f10-37d277d80e77.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -17498,7 +17498,7 @@
         },
         {
             "id": "62a64af1-e9d5-5b50-80aa-50e5af931f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655e0a5-af3e-4720-b4cf-c93ae9c10cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655e0a5-af3e-4720-b4cf-c93ae9c10cac.jpg?1",
             "name": "Far Fortune, End Boss",
             "text": "Start your engines\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed \u2014 If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -17539,7 +17539,7 @@
         },
         {
             "id": "d24e8947-0e19-58c8-86f6-4ebed1f3cd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb615c-e142-4a6e-8d7a-f0a7a3b30568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb615c-e142-4a6e-8d7a-f0a7a3b30568.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -17579,7 +17579,7 @@
         },
         {
             "id": "4aae21bd-7d0d-50e5-ba7b-e651bebac4d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a86678f-e4b4-4c40-9a99-83029fd97730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a86678f-e4b4-4c40-9a99-83029fd97730.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -17620,7 +17620,7 @@
         },
         {
             "id": "7862b83b-8117-5232-be6a-1fbf032305db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46164400-0557-4c99-83d5-194dc814b46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46164400-0557-4c99-83d5-194dc814b46a.jpg?1",
             "name": "Kolodin, Triumph Caster",
             "text": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
             "colours": [
@@ -17661,7 +17661,7 @@
         },
         {
             "id": "e37bbc9c-7c1f-5312-af15-c3bf0ee65e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542fe4ca-d3d8-469c-b5cb-4d0824ba514b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542fe4ca-d3d8-469c-b5cb-4d0824ba514b.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color.\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -17706,7 +17706,7 @@
         },
         {
             "id": "20e030f3-dfc8-5099-99a1-b25538b5217b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec057f26-8d14-463b-84ce-cce82b95b08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec057f26-8d14-463b-84ce-cce82b95b08e.jpg?1",
             "name": "Mendicant Core, Guidelight",
             "text": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines\nMax speed \u2014 Whenever you cast an artifact spell, you may pay {1}. If you do, copy it.",
             "colours": [
@@ -17747,7 +17747,7 @@
         },
         {
             "id": "a635fa69-4ac7-550d-9faa-40549dad22b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2976e7e4-c53f-47d5-9890-cd30acad4f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2976e7e4-c53f-47d5-9890-cd30acad4f68.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -17791,7 +17791,7 @@
         },
         {
             "id": "aa7edc95-ae01-578b-8cce-28734cf8700c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749306b-26ce-4c71-8586-a1ef9788c286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749306b-26ce-4c71-8586-a1ef9788c286.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -17831,7 +17831,7 @@
         },
         {
             "id": "fc9999a4-a2c4-53cf-937c-0eab0c643884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794b7a29-eb42-4c52-a4d9-3976611efdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794b7a29-eb42-4c52-a4d9-3976611efdd7.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -17871,7 +17871,7 @@
         },
         {
             "id": "b094e30e-ee9c-55ca-bc2f-e31b859f4548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea12cb-c927-44f4-b304-f24919b1104e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea12cb-c927-44f4-b304-f24919b1104e.jpg?1",
             "name": "Redshift, Rocketeer Chief",
             "text": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust \u2014 {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield.",
             "colours": [
@@ -17912,7 +17912,7 @@
         },
         {
             "id": "52d61f58-acba-523b-8414-8e58a3f1853d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d5d0a0-b0ae-4a5c-ace6-77d87fcc8563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d5d0a0-b0ae-4a5c-ace6-77d87fcc8563.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike, prowess\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -17952,7 +17952,7 @@
         },
         {
             "id": "0ab1f293-0d4e-5892-b41f-e65aa377de91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36581aa3-8970-40cc-bd1c-e78787ebe441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36581aa3-8970-40cc-bd1c-e78787ebe441.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -17993,7 +17993,7 @@
         },
         {
             "id": "398586e8-6682-5458-911c-dbce41d2017e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd0f7d-1686-42ae-9bea-66b96309f322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd0f7d-1686-42ae-9bea-66b96309f322.jpg?1",
             "name": "Samut, the Driving Force",
             "text": "First strike, vigilance, haste\nStart your engines\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
             "colours": [
@@ -18037,7 +18037,7 @@
         },
         {
             "id": "fb532920-801a-5bb7-8308-505513869333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d595f-7efe-4004-9bbc-390b5a6eb734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d595f-7efe-4004-9bbc-390b5a6eb734.jpg?1",
             "name": "Sita Varma, Masked Racer",
             "text": "Exhaust \u2014 {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.",
             "colours": [
@@ -18078,7 +18078,7 @@
         },
         {
             "id": "743213bd-a711-5c0b-9168-000601948c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f93e48d-4681-4354-aa85-493a48287233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f93e48d-4681-4354-aa85-493a48287233.jpg?1",
             "name": "Winter, Cursed Rider",
             "text": "Ward\u2014\nPay 2 life.\nArtifacts you control have \"Ward\u2014\nPay 2 life.\"\nExhaust \u2014 {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.",
             "colours": [
@@ -18119,7 +18119,7 @@
         },
         {
             "id": "42517269-8271-5a3d-8089-0d514ae2213c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10ee92a-85cc-48cb-b0b5-8e5185781fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10ee92a-85cc-48cb-b0b5-8e5185781fb2.jpg?1",
             "name": "Zahur, Glory's Past",
             "text": "Start your engines\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed \u2014 Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -18161,7 +18161,7 @@
         },
         {
             "id": "5f719f2c-fb50-574c-9157-69c700c0b2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea3cfc-64f1-4289-ac6c-82d55bab65de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea3cfc-64f1-4289-ac6c-82d55bab65de.jpg?1",
             "name": "The Aetherspark",
             "text": "As long as The Aetherspark is attached to a creature, The Aetherspark can't be attacked and has \"Whenever equipped creature deals combat damage during your turn, put that many loyalty counters on The Aetherspark.\"\n+1: Attach The Aetherspark to up to one target creature you control. Put a +1/+1 counter on that creature.\n\u22125: Draw two cards.\n\u221210: Add ten mana of any one color.",
             "colours": [],
@@ -18196,7 +18196,7 @@
         },
         {
             "id": "3a7a00b7-6660-5c3b-ae57-a11a357cd5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c14d4cc-79c3-4934-b7a8-25e1973ffea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c14d4cc-79c3-4934-b7a8-25e1973ffea3.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -18230,7 +18230,7 @@
         },
         {
             "id": "084da9f5-aa42-5867-a0c5-8f024c15a080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20419718-d922-4f3c-aeb2-30ffb2ff7cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20419718-d922-4f3c-aeb2-30ffb2ff7cbb.jpg?1",
             "name": "Marketback Walker",
             "text": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
             "colours": [],
@@ -18263,7 +18263,7 @@
         },
         {
             "id": "74c4f5fb-876d-5dad-87da-8c983d4f5b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75f3b27-7c08-4e92-ae9a-6208aa9aec0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75f3b27-7c08-4e92-ae9a-6208aa9aec0c.jpg?1",
             "name": "Monument to Endurance",
             "text": "Whenever you discard a card, choose one that hasn't been chosen this turn \u2014\n\u2022 Draw a card.\n\u2022 Create a Treasure token.\n\u2022 Each opponent loses 3 life.",
             "colours": [],
@@ -18293,7 +18293,7 @@
         },
         {
             "id": "25621873-eb0c-5926-92c6-95dc20cc8250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333039ef-b328-4082-85ae-162caed5612e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333039ef-b328-4082-85ae-162caed5612e.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -18325,7 +18325,7 @@
         },
         {
             "id": "6d99124d-9d48-5791-a1f4-f544956b3baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712aab40-5452-4d62-8ad3-fec96d03db98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712aab40-5452-4d62-8ad3-fec96d03db98.jpg?1",
             "name": "Bleachbone Verge",
             "text": "{T}: Add {B}.\n{T}: Add {W}. Activate only if you control a Plains or a Swamp.",
             "colours": [],
@@ -18358,7 +18358,7 @@
         },
         {
             "id": "79921819-a4c5-59eb-bc21-f45ba3bbf647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6457d47-8e68-42db-85c9-e0f981c53aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6457d47-8e68-42db-85c9-e0f981c53aa4.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -18389,7 +18389,7 @@
         },
         {
             "id": "b8f0e01c-0c26-5f61-be74-ca377a4129fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21462ee-76d7-4910-9a0c-b470f96b8b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21462ee-76d7-4910-9a0c-b470f96b8b51.jpg?1",
             "name": "Riverpyre Verge",
             "text": "{T}: Add {R}.\n{T}: Add {U}. Activate only if you control an Island or a Mountain.",
             "colours": [],
@@ -18422,7 +18422,7 @@
         },
         {
             "id": "913467d6-ab70-54e5-8d33-a528331f093d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff03662-3879-4ca8-b73c-34918194203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff03662-3879-4ca8-b73c-34918194203b.jpg?1",
             "name": "Sunbillow Verge",
             "text": "{T}: Add {W}.\n{T}: Add {R}. Activate only if you control a Mountain or a Plains.",
             "colours": [],
@@ -18455,7 +18455,7 @@
         },
         {
             "id": "7c2d01fa-5309-5135-8f2c-5c406da359da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0c9044-13ae-465e-a9d1-7dc63827540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0c9044-13ae-465e-a9d1-7dc63827540d.jpg?1",
             "name": "Wastewood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {B}. Activate only if you control a Swamp or a Forest.",
             "colours": [],
@@ -18488,7 +18488,7 @@
         },
         {
             "id": "08f64040-3cbb-5df4-a517-60f135f932e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e928cc4-be33-4c99-b0d0-c808c225e3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e928cc4-be33-4c99-b0d0-c808c225e3ab.jpg?1",
             "name": "Willowrush Verge",
             "text": "{T}: Add {U}.\n{T}: Add {G}. Activate only if you control a Forest or an Island.",
             "colours": [],
@@ -18521,7 +18521,7 @@
         },
         {
             "id": "8431bf90-9e80-5738-a1b1-0ba34f0c159b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e196d67-1923-459d-98cf-646337914d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e196d67-1923-459d-98cf-646337914d3b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18560,7 +18560,7 @@
         },
         {
             "id": "e3c6470b-4963-5991-9cea-e15091150e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33841e-7006-41d4-98b0-313ab151c9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33841e-7006-41d4-98b0-313ab151c9ec.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18599,7 +18599,7 @@
         },
         {
             "id": "c5c24078-b9d6-5cd3-88e4-0dd91ac1cea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba042d60-b1e8-44ad-9103-f40588a0b29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba042d60-b1e8-44ad-9103-f40588a0b29c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -18638,7 +18638,7 @@
         },
         {
             "id": "6cb2250b-64d0-5aa4-8421-15a5b7705ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7533cbb-ab73-4a0c-9ea0-baa97c4665b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7533cbb-ab73-4a0c-9ea0-baa97c4665b8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -18677,7 +18677,7 @@
         },
         {
             "id": "e10a8e67-02f4-5357-88d6-fc64531070bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1b6c5c-4585-47c1-82eb-a324189f3ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1b6c5c-4585-47c1-82eb-a324189f3ebd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -18716,7 +18716,7 @@
         },
         {
             "id": "033b03c4-d2a2-50b4-b4cc-db17f0d7b46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd76e71-df9b-4fd2-b534-d3f724a56a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd76e71-df9b-4fd2-b534-d3f724a56a91.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18755,7 +18755,7 @@
         },
         {
             "id": "ffb2e2ed-b892-5482-adfa-19f1ddefaae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13bb767-1123-48d2-960f-b90b6db3f6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13bb767-1123-48d2-960f-b90b6db3f6ed.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18794,7 +18794,7 @@
         },
         {
             "id": "dddedbb1-81e5-5bd8-b2ed-921b202b32a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d198b3-2ff5-484a-905f-c272de7c139d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d198b3-2ff5-484a-905f-c272de7c139d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -18833,7 +18833,7 @@
         },
         {
             "id": "a7c67b15-03d7-5579-ad52-f7ae7a9f5f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4952a8-4e1f-4a74-8a06-c9d633b25dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4952a8-4e1f-4a74-8a06-c9d633b25dcd.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -18872,7 +18872,7 @@
         },
         {
             "id": "c9612053-7eb0-507c-82ac-033d1ce7bbd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7aba60-d300-4c33-9e1e-846d6167dc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7aba60-d300-4c33-9e1e-846d6167dc50.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -18911,7 +18911,7 @@
         },
         {
             "id": "d729bc4f-936b-5d6f-b924-b3c8f04254b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c7805b-c952-4847-b321-e0567923c80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c7805b-c952-4847-b321-e0567923c80e.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -18950,7 +18950,7 @@
         },
         {
             "id": "b4d4893a-89ef-5d57-914c-cc266791c98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d5057-39f7-42aa-9dd5-ecc52f861366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d5057-39f7-42aa-9dd5-ecc52f861366.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -18987,7 +18987,7 @@
         },
         {
             "id": "166db6a6-ba9d-5883-b6df-658efdfddf74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4d35a-1f7e-4c5e-a999-09ad42f8b4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4d35a-1f7e-4c5e-a999-09ad42f8b4e2.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W}\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -19026,7 +19026,7 @@
         },
         {
             "id": "819bb46f-42fd-5ec3-92f0-a36f0ffe3e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3666b4e-d6a4-41be-a529-4a577e75c86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3666b4e-d6a4-41be-a529-4a577e75c86d.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -19063,7 +19063,7 @@
         },
         {
             "id": "f922593f-3e51-503a-994e-402102504a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0c1eb-603e-4e3e-b40b-65662c22d72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0c1eb-603e-4e3e-b40b-65662c22d72d.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -19100,7 +19100,7 @@
         },
         {
             "id": "45b79684-e3f5-582b-a3a1-64d551da982c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f1f362-fa4a-49e6-baa5-6797a9408cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f1f362-fa4a-49e6-baa5-6797a9408cad.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -19137,7 +19137,7 @@
         },
         {
             "id": "70f1fcee-51b9-5d37-b845-3ab25eec30b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56ae43-4a6b-4af6-9707-679068bd0934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56ae43-4a6b-4af6-9707-679068bd0934.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -19174,7 +19174,7 @@
         },
         {
             "id": "98845a3e-3a88-5169-a7bc-5c2c077e3ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9747c8c-024f-417f-86ad-ee7c6f756aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9747c8c-024f-417f-86ad-ee7c6f756aa2.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -19211,7 +19211,7 @@
         },
         {
             "id": "23591dcd-606a-5bf7-b436-faf3f745f576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85dac5a-c6fa-4a86-9fe3-7a17db06f07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85dac5a-c6fa-4a86-9fe3-7a17db06f07c.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -19250,7 +19250,7 @@
         },
         {
             "id": "c9a6dc10-0448-5b80-b2b2-aa065e5ce9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62d070e-52b7-4d7f-bd98-13622d859a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62d070e-52b7-4d7f-bd98-13622d859a7b.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.\nCrew 2",
             "colours": [
@@ -19287,7 +19287,7 @@
         },
         {
             "id": "062f8687-754b-562d-a697-9d9f07cca6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b39bc-8eda-4c5a-8705-5416cdb24f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b39bc-8eda-4c5a-8705-5416cdb24f0d.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -19324,7 +19324,7 @@
         },
         {
             "id": "f2dac19f-37ad-5f6f-80f7-417a881aa8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83725fcd-d5ec-4b99-b3f6-e7f5325c766e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83725fcd-d5ec-4b99-b3f6-e7f5325c766e.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -19362,7 +19362,7 @@
         },
         {
             "id": "7948eca2-288e-59b4-bf08-6a4cb5838ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ff9fc-5c34-4a07-a1f3-35c21a3323b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ff9fc-5c34-4a07-a1f3-35c21a3323b0.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -19399,7 +19399,7 @@
         },
         {
             "id": "923606bb-b007-5b33-91a8-30b0d8b22e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efa1ade-00f9-4736-8397-11d4faf65b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efa1ade-00f9-4736-8397-11d4faf65b7b.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -19438,7 +19438,7 @@
         },
         {
             "id": "c579387c-b8c9-5bc2-ab13-2390a40b4e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91496c82-44bc-4bb7-9e2a-5f4a3a199f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91496c82-44bc-4bb7-9e2a-5f4a3a199f4c.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -19472,7 +19472,7 @@
         },
         {
             "id": "a253440d-26cc-5776-8bdf-6fc899458b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e8762-0aed-4009-86f0-7935a1d12b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e8762-0aed-4009-86f0-7935a1d12b52.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1",
             "colours": [
@@ -19510,7 +19510,7 @@
         },
         {
             "id": "4a64fcc4-b3bb-5ee4-94ed-78de0eee9bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb0c5b-ef3f-42db-9f40-0463cacd548d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb0c5b-ef3f-42db-9f40-0463cacd548d.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -19548,7 +19548,7 @@
         },
         {
             "id": "481fed5f-fbb4-5f19-b6a2-35819351280b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1191c3a-a6eb-4765-bb79-2f0d920899f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1191c3a-a6eb-4765-bb79-2f0d920899f9.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.",
             "colours": [
@@ -19586,7 +19586,7 @@
         },
         {
             "id": "b90d8f9b-c22e-5497-af42-532af9bf271e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7ee49c-1e5d-4b3a-8e0a-59a0d258e804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7ee49c-1e5d-4b3a-8e0a-59a0d258e804.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2}",
             "colours": [
@@ -19623,7 +19623,7 @@
         },
         {
             "id": "3840ef31-c6a8-5475-89ea-4a65ac787b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489de46-e90c-483e-ac2b-547497f64e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489de46-e90c-483e-ac2b-547497f64e82.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -19661,7 +19661,7 @@
         },
         {
             "id": "6e2995f3-cbcc-54d4-982a-54f060b0faec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b75e83-2ed5-48c9-881a-da3d77bdef99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b75e83-2ed5-48c9-881a-da3d77bdef99.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -19699,7 +19699,7 @@
         },
         {
             "id": "086c581d-43e8-5a4e-8ee2-2f6dfcf1ba7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bd51bd-e451-4f1d-af19-bb777ec1a85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bd51bd-e451-4f1d-af19-bb777ec1a85c.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -19738,7 +19738,7 @@
         },
         {
             "id": "608bfc8c-7372-531a-a5e2-63734257847e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2151639-5621-4ffa-9374-3a1c48a635d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2151639-5621-4ffa-9374-3a1c48a635d9.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -19776,7 +19776,7 @@
         },
         {
             "id": "949b3dba-5ca3-56f1-8184-c27732f880f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9419e00b-062b-4bb2-9203-f2f86b502371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9419e00b-062b-4bb2-9203-f2f86b502371.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature.\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -19814,7 +19814,7 @@
         },
         {
             "id": "adb029b3-686d-5e26-805d-e48c3cbcfd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf709cb6-8953-40ce-9fcc-396b6c0ab37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf709cb6-8953-40ce-9fcc-396b6c0ab37a.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -19852,7 +19852,7 @@
         },
         {
             "id": "46f0d9cb-8143-5384-9b5e-6e15be0717c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d815a94-cdf0-4a19-ad06-4292efbb7105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d815a94-cdf0-4a19-ad06-4292efbb7105.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G}\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -19889,7 +19889,7 @@
         },
         {
             "id": "334433e5-e370-5817-9e44-9b7881c23950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ad303-505d-4e2a-9380-80ab9f91a0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ad303-505d-4e2a-9380-80ab9f91a0a3.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -19927,7 +19927,7 @@
         },
         {
             "id": "3868483a-bb65-54c3-aa2a-505a681fc279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf3bcd2-fdc6-4490-858d-3334437a3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf3bcd2-fdc6-4490-858d-3334437a3148.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G}\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -19965,7 +19965,7 @@
         },
         {
             "id": "f853193f-5a3e-5fc4-b128-e5746b0572bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c8f0f0-f2d0-44fa-8163-41a8e35952fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c8f0f0-f2d0-44fa-8163-41a8e35952fd.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -20005,7 +20005,7 @@
         },
         {
             "id": "b958e8e0-2289-5517-a027-912bcab0768e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e0ead2-933a-41ad-b1c3-0aa79cc41e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e0ead2-933a-41ad-b1c3-0aa79cc41e93.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -20044,7 +20044,7 @@
         },
         {
             "id": "2f703045-e00b-5e9a-8dc7-978f75733eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b787e28-a6bf-489c-affb-4043845c9769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b787e28-a6bf-489c-affb-4043845c9769.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -20084,7 +20084,7 @@
         },
         {
             "id": "9bdfc60b-1a4a-5793-a56a-d704ed8068b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4363ec0d-a473-4afc-9ae5-4feed762a630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4363ec0d-a473-4afc-9ae5-4feed762a630.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -20124,7 +20124,7 @@
         },
         {
             "id": "9c118ec8-e771-5626-b053-9fe695fe478e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1688041b-a654-493e-bfac-247fdca68b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1688041b-a654-493e-bfac-247fdca68b22.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -20165,7 +20165,7 @@
         },
         {
             "id": "0c4047dd-5440-5fee-8667-a1398ecb29bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd7467-4e77-4fad-b8e9-b258fa6254f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd7467-4e77-4fad-b8e9-b258fa6254f3.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -20205,7 +20205,7 @@
         },
         {
             "id": "ac6b81f7-7ed2-595f-9ac8-a3b811da16d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50050d-1da8-4f37-a975-f81d5684a619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50050d-1da8-4f37-a975-f81d5684a619.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -20245,7 +20245,7 @@
         },
         {
             "id": "7dca3711-8bd3-58cb-a93b-d1c8c821c8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6127cd9e-5785-4ba5-89d0-5eeb0d8aaa0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6127cd9e-5785-4ba5-89d0-5eeb0d8aaa0e.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike, prowess\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -20285,7 +20285,7 @@
         },
         {
             "id": "25ace84a-3371-52b1-839f-d4eff375cc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f9907-e187-4c01-964c-24b3d27948b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f9907-e187-4c01-964c-24b3d27948b5.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -20326,7 +20326,7 @@
         },
         {
             "id": "648bee61-604f-58a2-8beb-11faa77a89af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1",
             "name": "Pilot",
             "text": "",
             "colours": [],
@@ -20357,7 +20357,7 @@
         },
         {
             "id": "e79827a9-d8b8-5a7c-a9ae-ff706794fd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -20392,7 +20392,7 @@
         },
         {
             "id": "80e85df7-9984-55a2-a99c-245a54b062df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -20427,7 +20427,7 @@
         },
         {
             "id": "eca095c0-5330-5c63-a18e-b4c46ac5d6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932aac56-2afa-4431-96fa-bd55d8bba983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932aac56-2afa-4431-96fa-bd55d8bba983.jpg?1",
             "name": "Dinosaur Dragon",
             "text": "",
             "colours": [
@@ -20463,7 +20463,7 @@
         },
         {
             "id": "ab1efd04-449e-5744-9042-1f201280fc70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -20498,7 +20498,7 @@
         },
         {
             "id": "b804cdc2-1aaf-5dee-9760-fc9e88a37542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecb6655-2aa0-4622-ae9a-21dfffa7625e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecb6655-2aa0-4622-ae9a-21dfffa7625e.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -20533,7 +20533,7 @@
         },
         {
             "id": "25b7d586-b387-5362-bac0-94259e7553b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d855d-93a1-4ec4-af19-e544f271ae10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d855d-93a1-4ec4-af19-e544f271ae10.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -20568,7 +20568,7 @@
         },
         {
             "id": "cc281264-7f00-5567-bb0e-c14f40c41490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10de413b-3307-4bc7-bb21-f177543d7e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10de413b-3307-4bc7-bb21-f177543d7e21.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -20600,7 +20600,7 @@
         },
         {
             "id": "c2d963e3-a4f2-52be-b254-d7ebbfdc4244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -20632,7 +20632,7 @@
         },
         {
             "id": "d0ddfd70-ed9e-56db-8424-5a30af6d2425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e52380-13a1-44fe-b762-e71261cac3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e52380-13a1-44fe-b762-e71261cac3d0.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -20664,7 +20664,7 @@
         },
         {
             "id": "79b7a1b8-532b-580f-ad16-5a2dcd304e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7638ef-114b-4055-9855-390f82b7d5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7638ef-114b-4055-9855-390f82b7d5c5.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -20695,7 +20695,7 @@
         },
         {
             "id": "64d3c795-19c6-599b-be5b-4a7073b41588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3803365-ed78-409f-8ca5-7aa3634faf76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3803365-ed78-409f-8ca5-7aa3634faf76.jpg?1",
             "name": "Vehicle",
             "text": "",
             "colours": [],
@@ -20726,7 +20726,7 @@
         },
         {
             "id": "352f5ba4-3a9e-5f6a-8eb3-33b29f216a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343d2622-a5a6-4195-ab41-c6bd17e334a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343d2622-a5a6-4195-ab41-c6bd17e334a2.jpg?1",
             "name": "Chandra, Spark Hunter Emblem",
             "text": "",
             "colours": [],
@@ -20754,7 +20754,7 @@
         },
         {
             "id": "04c42b99-db90-5f19-a978-41d095cc6de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg?1",
             "name": "Start Your Engines! // Max Speed",
             "text": "",
             "colours": [],
@@ -20782,7 +20782,7 @@
         },
         {
             "id": "08f43e68-5c13-5827-8de5-471f10fd6a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg?1",
             "name": "Start Your Engines! // Max Speed",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/DGM.json
+++ b/Assets/Resources/Sets/DGM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5db3baa0-26d0-5b08-90b9-35ee765aaa9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a3bfb6-3843-4bda-bbcb-905e4b351dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a3bfb6-3843-4bda-bbcb-905e4b351dea.jpg?1",
             "name": "Boros Mastiff",
             "text": "Battalion \u2014 Whenever Boros Mastiff and at least two other creatures attack, Boros Mastiff gains lifelink until end of turn. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "f7ce9f7a-902b-5469-9558-03d4aee2a28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3c012-f356-424d-a960-60e95f395134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3c012-f356-424d-a960-60e95f395134.jpg?1",
             "name": "Haazda Snare Squad",
             "text": "Whenever Haazda Snare Squad attacks, you may pay {W}. If you do, tap target creature an opponent controls.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "04a07512-1195-5a45-9307-2469af674823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773cf2aa-4337-4d14-8a8e-ff8b1fdec1b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773cf2aa-4337-4d14-8a8e-ff8b1fdec1b5.jpg?1",
             "name": "Lyev Decree",
             "text": "Detain up to two target creatures your opponents control. (Until your next turn, those creatures can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "a704dbbd-b2ea-5e97-b782-f9d11fa02977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a977e2d-a2bc-42d1-be7d-36a822c6a66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a977e2d-a2bc-42d1-be7d-36a822c6a66e.jpg?1",
             "name": "Maze Sentinel",
             "text": "Vigilance\nMulticolored creatures you control have vigilance.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "8a3b9683-a45d-5df6-8aa5-f296db8c6fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9acc14-24e0-4c03-a09a-2afee351f2cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9acc14-24e0-4c03-a09a-2afee351f2cc.jpg?1",
             "name": "Renounce the Guilds",
             "text": "Each player sacrifices a multicolored permanent.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "93c3532d-c8b9-5a0f-a013-0c7f256797e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7886607-86db-4221-8752-296104aaaef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7886607-86db-4221-8752-296104aaaef2.jpg?1",
             "name": "Riot Control",
             "text": "You gain 1 life for each creature your opponents control. Prevent all damage that would be dealt to you this turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "ecf64b9a-8ee3-58c8-abdb-748e70c50096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd20865-0a9a-4a72-92f9-77c8d6384b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd20865-0a9a-4a72-92f9-77c8d6384b46.jpg?1",
             "name": "Scion of Vitu-Ghazi",
             "text": "When Scion of Vitu-Ghazi enters the battlefield, if you cast it from your hand, put a 1/1 white Bird creature token with flying onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "39fb83e6-3830-5dea-9bee-8661da390142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecafab-97f4-40ed-bc43-d186eb2f3af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecafab-97f4-40ed-bc43-d186eb2f3af6.jpg?1",
             "name": "Steeple Roc",
             "text": "Flying, first strike",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "2f4a4c5a-beb4-5e10-baa2-e8119a8e1196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3bc6b9-475b-4257-a3bc-1a0b70d45f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3bc6b9-475b-4257-a3bc-1a0b70d45f79.jpg?1",
             "name": "Sunspire Gatekeepers",
             "text": "When Sunspire Gatekeepers enters the battlefield, if you control two or more Gates, put a 2/2 white Knight creature token with vigilance onto the battlefield.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "4f9f1b00-561c-59af-9234-de3febf6dd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db0074c-95cf-4d15-8fe1-7282803ec757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db0074c-95cf-4d15-8fe1-7282803ec757.jpg?1",
             "name": "Wake the Reflections",
             "text": "Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "fe48f6cf-572c-5cd9-a1f9-42ef54b70166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c93313b-cf43-47e9-a911-717b4d14b0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c93313b-cf43-47e9-a911-717b4d14b0b5.jpg?1",
             "name": "Aetherling",
             "text": "{U}: Exile \u00c6therling. Return it to the battlefield under its owner's control at the beginning of the next end step.\n{U}: \u00c6therling is unblockable this turn.\n{1}: \u00c6therling gets +1/-1 until end of turn.\n{1}: \u00c6therling gets -1/+1 until end of turn.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "87a85cb6-be61-5981-8cbd-b018c07713ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216e8047-6f54-49ce-bf86-27dc8fc8c8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216e8047-6f54-49ce-bf86-27dc8fc8c8f7.jpg?1",
             "name": "Hidden Strings",
             "text": "You may tap or untap target permanent, then you may tap or untap another target permanent.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "dd6d23eb-ae26-5cb6-b0c8-194898012f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d20281-49c0-4fd0-91f2-390506ac33f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d20281-49c0-4fd0-91f2-390506ac33f6.jpg?1",
             "name": "Maze Glider",
             "text": "Flying\nMulticolored creatures you control have flying.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "bc2619f0-9a21-516e-969c-d5af5b6b23ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d3fad5-a12a-4b41-9c7b-c1af5e0b5ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d3fad5-a12a-4b41-9c7b-c1af5e0b5ca8.jpg?1",
             "name": "Mindstatic",
             "text": "Counter target spell unless its controller pays {6}.",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "1aa7fbb7-65de-5a5e-90fe-de7cd89682d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9752644c-7c43-429e-a79c-1239b9a0bc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9752644c-7c43-429e-a79c-1239b9a0bc8a.jpg?1",
             "name": "Murmuring Phantasm",
             "text": "Defender",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "e0ac8b1d-2c92-52d5-ac32-0929096b8fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43ac38f-5cd0-46cf-8623-d82cb8fb719b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43ac38f-5cd0-46cf-8623-d82cb8fb719b.jpg?1",
             "name": "Opal Lake Gatekeepers",
             "text": "When Opal Lake Gatekeepers enters the battlefield, if you control two or more Gates, you may draw a card.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "f978fb16-4e27-53ef-9a54-1d9c8d367049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696b5a6-edfd-445e-ac80-64c1be94fbfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696b5a6-edfd-445e-ac80-64c1be94fbfc.jpg?1",
             "name": "Runner's Bane",
             "text": "Enchant creature with power 3 or less\nWhen Runner's Bane enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "452f75b4-69d3-567a-9cf4-2048e0c8876c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a7981-5940-4b75-907f-7600a742f946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a7981-5940-4b75-907f-7600a742f946.jpg?1",
             "name": "Trait Doctoring",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another until end of turn.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -605,7 +605,7 @@
         },
         {
             "id": "5871e9fa-7750-5c7d-8ee0-0ec529bf2da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd24556-994f-4480-835e-11d4443f0700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd24556-994f-4480-835e-11d4443f0700.jpg?1",
             "name": "Uncovered Clues",
             "text": "Look at the top four cards of your library. You may reveal up to two instant and/or sorcery cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -637,7 +637,7 @@
         },
         {
             "id": "fc3ed198-3360-5e0e-b9a1-d7a5ce7ccc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ea454f-b640-4a89-937f-bae05556292a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ea454f-b640-4a89-937f-bae05556292a.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -671,7 +671,7 @@
         },
         {
             "id": "9f8d230e-8219-5863-b6ec-a2b56f32d8f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fcad03-4567-4f96-976e-01a07d8ab050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fcad03-4567-4f96-976e-01a07d8ab050.jpg?1",
             "name": "Bane Alley Blackguard",
             "text": "",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "dc3258be-efad-5e70-b059-bf5117d84fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea8179a-d3c9-4cdc-a5b5-68cc73279050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea8179a-d3c9-4cdc-a5b5-68cc73279050.jpg?1",
             "name": "Blood Scrivener",
             "text": "If you would draw a card while you have no cards in hand, instead draw two cards and lose 1 life.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "f22e3ffa-3d2b-5385-8d79-2beb2ffa3595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b71cc5-0a81-4cab-bae3-49335c04aaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b71cc5-0a81-4cab-bae3-49335c04aaaa.jpg?1",
             "name": "Crypt Incursion",
             "text": "Exile all creature cards from target player's graveyard. You gain 3 life for each card exiled this way.",
             "colours": [
@@ -773,7 +773,7 @@
         },
         {
             "id": "776fd41a-922f-5061-801d-b63199445fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967aa636-a11d-4c5c-ba85-648734b295c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967aa636-a11d-4c5c-ba85-648734b295c2.jpg?1",
             "name": "Fatal Fumes",
             "text": "Target creature gets -4/-2 until end of turn.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "f83682a3-2d7f-5f47-9e92-9e25bc8bacca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e9f79e-6606-4c9b-838c-eda5d8cc612c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e9f79e-6606-4c9b-838c-eda5d8cc612c.jpg?1",
             "name": "Hired Torturer",
             "text": "Defender\n{3}{B}, {T}: Target opponent loses 2 life, then reveals a card at random from his or her hand.",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "1e88221c-6ff6-56f6-bc65-694a514d2918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84659f-4209-42a2-800a-61706470ce54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84659f-4209-42a2-800a-61706470ce54.jpg?1",
             "name": "Maze Abomination",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nMulticolored creatures you control have deathtouch.",
             "colours": [
@@ -874,7 +874,7 @@
         },
         {
             "id": "ca9e4874-ac7d-525c-8ef8-7762c80913f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e5291f-9281-4cb7-9158-54b7cb336b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e5291f-9281-4cb7-9158-54b7cb336b93.jpg?1",
             "name": "Pontiff of Blight",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nOther creatures you control have extort. (If a creature has multiple instances of extort, each triggers separately.)",
             "colours": [
@@ -909,7 +909,7 @@
         },
         {
             "id": "e43007c4-a3d6-5ef5-855f-36319cd216d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c1bfd7-b8b2-4db7-9ea7-a2d643a83589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c1bfd7-b8b2-4db7-9ea7-a2d643a83589.jpg?1",
             "name": "Rakdos Drake",
             "text": "Flying\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "88ca6fe4-901e-5198-8e06-412f9a064be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f54c15b-fec0-49a6-8a49-d1af4eeee40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f54c15b-fec0-49a6-8a49-d1af4eeee40e.jpg?1",
             "name": "Sinister Possession",
             "text": "Enchant creature\nWhenever enchanted creature attacks or blocks, its controller loses 2 life.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "c020d22f-dcd1-57ae-8742-adf12efba087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2e327-adfd-459b-8d18-faa39d88b5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2e327-adfd-459b-8d18-faa39d88b5de.jpg?1",
             "name": "Ubul Sar Gatekeepers",
             "text": "When Ubul Sar Gatekeepers enters the battlefield, if you control two or more Gates, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -1012,7 +1012,7 @@
         },
         {
             "id": "e566bf73-f360-5a9f-825d-e84eb9dabf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec644ac3-07a2-43de-8173-9cc18e2ea2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec644ac3-07a2-43de-8173-9cc18e2ea2d9.jpg?1",
             "name": "Awe for the Guilds",
             "text": "Monocolored creatures can't block this turn.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "59732c01-393c-5b07-8040-309e875973e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8f904b-a9a3-4bae-9284-4e9cbe7592ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8f904b-a9a3-4bae-9284-4e9cbe7592ee.jpg?1",
             "name": "Clear a Path",
             "text": "Destroy target creature with defender.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "fc807797-1578-53fc-843a-02fef7a8f2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d2eb8-e27f-4f84-9725-d2ae6446e217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d2eb8-e27f-4f84-9725-d2ae6446e217.jpg?1",
             "name": "Maze Rusher",
             "text": "Haste\nMulticolored creatures you control have haste.",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "cfcb67f8-0b44-5ee4-a0ad-b136f5bb2622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858aa831-b491-4f1e-bb56-33eeca14771d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858aa831-b491-4f1e-bb56-33eeca14771d.jpg?1",
             "name": "Possibility Storm",
             "text": "Whenever a player casts a spell from his or her hand, that player exiles it, then exiles cards from the top of his or her library until he or she exiles a card that shares a card type with it. That player may cast that card without paying its mana cost. Then he or she puts all cards exiled with Possibility Storm on the bottom of his or her library in a random order.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "1567336d-421d-596b-a754-1102920d37bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4179a72b-8482-46ec-9815-f5d6d94b5aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4179a72b-8482-46ec-9815-f5d6d94b5aa5.jpg?1",
             "name": "Punish the Enemy",
             "text": "Punish the Enemy deals 3 damage to target player and 3 damage to target creature.",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "e40e3ae9-d2e2-5dfc-a554-ea18d188aa90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f6e45-f613-420d-83d2-d93c643265ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f6e45-f613-420d-83d2-d93c643265ee.jpg?1",
             "name": "Pyrewild Shaman",
             "text": "Bloodrush \u2014 {1}{R}, Discard Pyrewild Shaman: Target attacking creature gets +3/+1 until end of turn.\nWhenever one or more creatures you control deal combat damage to a player, if Pyrewild Shaman is in your graveyard, you may pay {3}. If you do, return Pyrewild Shaman to your hand.",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "35798183-bb15-566d-83b1-bbd6d2b2bc51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daaccd2-733c-4b3b-aa3f-cc825bcc3e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daaccd2-733c-4b3b-aa3f-cc825bcc3e53.jpg?1",
             "name": "Riot Piker",
             "text": "First strike\nRiot Piker attacks each turn if able.",
             "colours": [
@@ -1244,7 +1244,7 @@
         },
         {
             "id": "c1865fa7-eea0-5c82-9666-589abdd39806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc802d62-6559-45b9-ad11-de5887aece2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc802d62-6559-45b9-ad11-de5887aece2b.jpg?1",
             "name": "Rubblebelt Maaka",
             "text": "Bloodrush \u2014 {R}, Discard Rubblebelt Maaka: Target attacking creature gets +3/+3 until end of turn.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "89061cb4-4ba7-5903-a79a-f7cd8ea8f682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8237b11f-36d2-4624-a0ef-520663385891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8237b11f-36d2-4624-a0ef-520663385891.jpg?1",
             "name": "Smelt-Ward Gatekeepers",
             "text": "When Smelt-Ward Gatekeepers enters the battlefield, if you control two or more Gates, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "3c884a7f-d6dc-5ede-9840-38bd9cbf547a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28df164-8bff-4428-b7dd-2974c288f1d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28df164-8bff-4428-b7dd-2974c288f1d3.jpg?1",
             "name": "Weapon Surge",
             "text": "Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1345,7 +1345,7 @@
         },
         {
             "id": "5e0756d4-cf3a-5f92-ac88-8757eb8243f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9aa740-9adf-412a-b6ec-0b9bb1b4618b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9aa740-9adf-412a-b6ec-0b9bb1b4618b.jpg?1",
             "name": "Battering Krasis",
             "text": "Trample\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "e44750f0-79c2-57ad-8816-3d72090c1684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71da8cc-8773-4dcb-aca8-50a000142218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71da8cc-8773-4dcb-aca8-50a000142218.jpg?1",
             "name": "Kraul Warrior",
             "text": "{5}{G}: Kraul Warrior gets +3/+3 until end of turn.",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "1ade9f34-23c5-5506-acd6-82fd3bab8137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9678-dea7-4219-bac0-9e1cef531f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9678-dea7-4219-bac0-9e1cef531f54.jpg?1",
             "name": "Maze Behemoth",
             "text": "Trample\nMulticolored creatures you control have trample.",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "f0e314ed-720b-5707-a260-5d640c82bd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c042c7ee-0e74-4ca5-bbb9-2898b0576f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c042c7ee-0e74-4ca5-bbb9-2898b0576f0a.jpg?1",
             "name": "Mending Touch",
             "text": "Regenerate target creature.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "8802c1d5-f188-57e7-bc2d-f5d6d3f05f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e32d47-2796-4eac-b373-a93506d8d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e32d47-2796-4eac-b373-a93506d8d6b7.jpg?1",
             "name": "Mutant's Prey",
             "text": "Target creature you control with a +1/+1 counter on it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "3ba65ebb-18ee-586b-8d29-eb73e83df87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7507afc4-f504-4eb2-a86d-f99bc2860838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7507afc4-f504-4eb2-a86d-f99bc2860838.jpg?1",
             "name": "Phytoburst",
             "text": "Target creature gets +5/+5 until end of turn.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "c8af3b68-2d5a-5c24-8870-ee43cd4b45b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b68921-0c34-4d92-83c3-21542f62c7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b68921-0c34-4d92-83c3-21542f62c7f6.jpg?1",
             "name": "Renegade Krasis",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever Renegade Krasis evolves, put a +1/+1 counter on each other creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "706aabda-3b12-5405-b102-1d843b5ebf12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471a5b1d-e2e5-4d90-b72a-ffae81ad6602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471a5b1d-e2e5-4d90-b72a-ffae81ad6602.jpg?1",
             "name": "Saruli Gatekeepers",
             "text": "When Saruli Gatekeepers enters the battlefield, if you control two or more Gates, you gain 7 life.",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "dfced25d-a029-5fa6-ae16-7f651e13882e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c2069-deb1-4e56-8069-170c4f495944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c2069-deb1-4e56-8069-170c4f495944.jpg?1",
             "name": "Skylasher",
             "text": "Flash\nSkylasher can't be countered.\nReach, protection from blue",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "2ef21462-163f-5d23-8784-3c12045084f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0d63a-d947-4ce4-8e34-5c1521955b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0d63a-d947-4ce4-8e34-5c1521955b18.jpg?1",
             "name": "Thrashing Mossdog",
             "text": "Reach (This creature can block creatures with flying.)\nScavenge {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "0107c4be-08d3-5182-a283-505dbbe0866d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40284e6-01a1-4372-a92c-940e5732607e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40284e6-01a1-4372-a92c-940e5732607e.jpg?1",
             "name": "Advent of the Wurm",
             "text": "Put a 5/5 green Wurm creature token with trample onto the battlefield.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "c3d9dc7c-14c2-5d65-8035-5508c7d8bc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43d959f-6055-4578-a69a-0ec93e993e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43d959f-6055-4578-a69a-0ec93e993e21.jpg?1",
             "name": "Armored Wolf-Rider",
             "text": "",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "203185c1-d233-50c1-ac0b-e59e615fa927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f00799-80ce-431e-97bb-8bb4e0e8ba49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f00799-80ce-431e-97bb-8bb4e0e8ba49.jpg?1",
             "name": "Ascended Lawmage",
             "text": "Flying, hexproof",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "013e365b-754c-52f4-8377-0f566ffcb0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2f7d7f-4097-419b-8de0-b7bf28fc3a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2f7d7f-4097-419b-8de0-b7bf28fc3a4b.jpg?1",
             "name": "Beetleform Mage",
             "text": "{G}{U}: Beetleform Mage gets +2/+2 and gains flying until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "c2a6a168-d35d-5836-b4f6-99bb20b986e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ff592c-bd35-4947-ba17-8b6170d5388e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ff592c-bd35-4947-ba17-8b6170d5388e.jpg?1",
             "name": "Blast of Genius",
             "text": "Choose target creature or player. Draw three cards, then discard a card. Blast of Genius deals damage equal to the discarded card's converted mana cost to that creature or player.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "da92caf3-68ab-58ac-bc04-04213e7f6299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e179f0d-2965-44e4-8483-67b330a8608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e179f0d-2965-44e4-8483-67b330a8608c.jpg?1",
             "name": "Blaze Commando",
             "text": "Whenever an instant or sorcery spell you control deals damage, put two 1/1 red and white Soldier creature tokens with haste onto the battlefield.",
             "colours": [
@@ -1901,7 +1901,7 @@
         },
         {
             "id": "d90db469-0bc7-5143-a4f5-56968b9d20d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4edad09-bf7b-40e9-ac2a-100da8a43274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4edad09-bf7b-40e9-ac2a-100da8a43274.jpg?1",
             "name": "Blood Baron of Vizkopa",
             "text": "Lifelink, protection from white and from black\nAs long as you have 30 or more life and an opponent has 10 or less life, Blood Baron of Vizkopa gets +6/+6 and has flying.",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "8642dd92-1a2e-589e-8793-e7fd202d7634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c43e449-acf2-4e94-b7cf-8c84d70191da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c43e449-acf2-4e94-b7cf-8c84d70191da.jpg?1",
             "name": "Boros Battleshaper",
             "text": "At the beginning of each combat, up to one target creature attacks or blocks this combat if able and up to one target creature can't attack or block this combat.",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "4c64b7ee-dd11-57ba-b5f6-ee42b7cd13e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258a536-2275-45e8-8833-e921ca15c5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258a536-2275-45e8-8833-e921ca15c5a7.jpg?1",
             "name": "Bred for the Hunt",
             "text": "Whenever a creature you control with a +1/+1 counter on it deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "c59828b2-074c-526f-8cdf-33bda527b688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291c0ebc-d489-42c7-8d8a-9216c333412f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291c0ebc-d489-42c7-8d8a-9216c333412f.jpg?1",
             "name": "Bronzebeak Moa",
             "text": "Whenever another creature enters the battlefield under your control, Bronzebeak Moa gets +3/+3 until end of turn.",
             "colours": [
@@ -2044,7 +2044,7 @@
         },
         {
             "id": "b170011c-cd9b-5926-b58b-a71bd2fba0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bde6c1-917c-4860-a8d0-a9d7c461f8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bde6c1-917c-4860-a8d0-a9d7c461f8d2.jpg?1",
             "name": "Carnage Gladiator",
             "text": "Whenever a creature blocks, that creature's controller loses 1 life.\n{1}{B}{R}: Regenerate Carnage Gladiator.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "047df831-8637-52d9-81b7-6e2a75e13b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a6a5-0042-40ae-bd33-a6d5a65a9944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a6a5-0042-40ae-bd33-a6d5a65a9944.jpg?1",
             "name": "Council of the Absolute",
             "text": "As Council of the Absolute enters the battlefield, name a card other than a creature or land card.\nYour opponents can't cast cards with the chosen name.\nSpells with the chosen name you cast cost {2} less to cast.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "a833c7c5-024e-517e-b61b-33dab4201af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26417a58-b0c9-49fa-956c-794ee1c09a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26417a58-b0c9-49fa-956c-794ee1c09a4f.jpg?1",
             "name": "Deadbridge Chant",
             "text": "When Deadbridge Chant enters the battlefield, put the top ten cards of your library into your graveyard.\nAt the beginning of your upkeep, choose a card at random in your graveyard. If it's a creature card, put it onto the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "c046f9fb-51f4-5213-a228-ac32ff307890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610e5a91-857b-4121-8b75-dbbea27aa0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610e5a91-857b-4121-8b75-dbbea27aa0aa.jpg?1",
             "name": "Debt to the Deathless",
             "text": "Each opponent loses two times X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "eb570b20-5c8e-5131-b715-9733eba5da62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b555888-21b1-4c45-966d-d98f32460d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b555888-21b1-4c45-966d-d98f32460d4e.jpg?1",
             "name": "Deputy of Acquittals",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Deputy of Acquittals enters the battlefield, you may return another target creature you control to its owner's hand.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "0285cea3-8c5f-582e-aea8-f844fc750d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c046e4e-810c-4123-bb1a-4f97e0cd43d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c046e4e-810c-4123-bb1a-4f97e0cd43d1.jpg?1",
             "name": "Dragonshift",
             "text": "Until end of turn, target creature you control becomes a 4/4 blue and red Dragon, loses all abilities, and gains flying.\nOverload {3}{U}{U}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "d8aed26a-409f-5432-9136-59096cfde1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22feacda-01e0-4f0d-a3c7-a22e3d40bf4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22feacda-01e0-4f0d-a3c7-a22e3d40bf4e.jpg?1",
             "name": "Drown in Filth",
             "text": "Choose target creature. Put the top four cards of your library into your graveyard, then that creature gets -1/-1 until end of turn for each land card in your graveyard.",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "10da6c92-240a-5edd-833e-9a9b4c00b574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c91a0a-2f14-4131-8ca7-1d0046a8edd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c91a0a-2f14-4131-8ca7-1d0046a8edd2.jpg?1",
             "name": "Emmara Tandris",
             "text": "Prevent all damage that would be dealt to creature tokens you control.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "751a3d4e-38cd-5644-ac5a-605b377f38fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb72a64-89e7-4b0e-a3d3-1309829071d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb72a64-89e7-4b0e-a3d3-1309829071d2.jpg?1",
             "name": "Exava, Rakdos Blood Witch",
             "text": "First strike, haste\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\nEach other creature you control with a +1/+1 counter on it has haste.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "c9217e7a-4d00-56fb-9a00-92ecf9dde9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108a9ef2-c74a-450b-8148-4fdf9f09843f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108a9ef2-c74a-450b-8148-4fdf9f09843f.jpg?1",
             "name": "Feral Animist",
             "text": "{3}: Feral Animist gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "dc77a9cf-61f3-54f0-9713-4bd72909c2ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c58f6ed-2544-4b58-8dc0-a0a37b9547e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c58f6ed-2544-4b58-8dc0-a0a37b9547e6.jpg?1",
             "name": "Fluxcharger",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, you may switch Fluxcharger's power and toughness until end of turn.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "44c30cd3-2e8a-5169-a16e-a6c8855f460e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9ac10-d114-4aa5-87ac-f1069cde8e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9ac10-d114-4aa5-87ac-f1069cde8e40.jpg?1",
             "name": "Gaze of Granite",
             "text": "Destroy each nonland permanent with converted mana cost X or less.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "febcfa69-6d75-5461-b4b5-fb06c367d70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f0feef-1a71-4c8c-9fd1-f5cbe718a988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f0feef-1a71-4c8c-9fd1-f5cbe718a988.jpg?1",
             "name": "Gleam of Battle",
             "text": "Whenever a creature you control attacks, put a +1/+1 counter on it.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "331142d0-c74c-5ce8-a03e-e12106cdb09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8dbb9aa-1bf8-447d-a96c-33e2248bfb01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8dbb9aa-1bf8-447d-a96c-33e2248bfb01.jpg?1",
             "name": "Goblin Test Pilot",
             "text": "Flying\n{T}: Goblin Test Pilot deals 2 damage to target creature or player chosen at random.",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "3cbae5d1-f120-5e80-9495-12625953a982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df383a6a-5eb1-48e8-a5f3-f4731ddb871b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df383a6a-5eb1-48e8-a5f3-f4731ddb871b.jpg?1",
             "name": "Gruul War Chant",
             "text": "Each attacking creature you control gets +1/+0 and can't be blocked except by two or more creatures.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "b5765712-0b42-5384-ac52-9114257b978d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438683f5-adfa-42ae-a6fb-c4649a8a30ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438683f5-adfa-42ae-a6fb-c4649a8a30ab.jpg?1",
             "name": "Haunter of Nightveil",
             "text": "Creatures your opponents control get -1/-0.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "6b751b88-1f4b-5271-8280-59313c5b758f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c89eb-d7c6-4945-9689-2f2c0e428b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c89eb-d7c6-4945-9689-2f2c0e428b84.jpg?1",
             "name": "Jelenn Sphinx",
             "text": "Flying, vigilance\nWhenever Jelenn Sphinx attacks, other attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "01e4b497-4859-5a75-84c2-53cb31f249a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7006e5b9-d6a3-43ce-904b-b2ac0fea67e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7006e5b9-d6a3-43ce-904b-b2ac0fea67e5.jpg?1",
             "name": "Korozda Gorgon",
             "text": "Deathtouch\n{2}, Remove a +1/+1 counter from a creature you control: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "d1cb3557-e9fc-5155-8ab9-080a1683ec77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da986da-e8ee-4b53-8bbd-9285d0f7f3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da986da-e8ee-4b53-8bbd-9285d0f7f3cb.jpg?1",
             "name": "Krasis Incubation",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\n{1}{G}{U}, Return Krasis Incubation to its owner's hand: Put two +1/+1 counters on enchanted creature.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "d93b6059-40e4-5833-96ee-148e056c1547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813f1967-c048-4e6e-9720-216773fde47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813f1967-c048-4e6e-9720-216773fde47e.jpg?1",
             "name": "Lavinia of the Tenth",
             "text": "Protection from red\nWhen Lavinia of the Tenth enters the battlefield, detain each nonland permanent your opponents control with converted mana cost 4 or less. (Until your next turn, those permanents can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "58b194d8-3f85-59cf-b0f5-1ad36ad96b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672051a6-d232-4546-842a-369d412c38d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672051a6-d232-4546-842a-369d412c38d2.jpg?1",
             "name": "Legion's Initiative",
             "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "125bc380-18f3-5a64-be46-a333bb0bdc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4d8ab5-252c-4727-817d-6f18cbaedd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4d8ab5-252c-4727-817d-6f18cbaedd91.jpg?1",
             "name": "Master of Cruelties",
             "text": "First strike, deathtouch\nMaster of Cruelties can only attack alone.\nWhenever Master of Cruelties attacks a player and isn't blocked, that player's life total becomes 1. Master of Cruelties assigns no combat damage this combat.",
             "colours": [
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "82a68eac-1213-5c42-a7ab-48028ddb143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1131c6-04da-4c4d-ab61-874ac5be7087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1131c6-04da-4c4d-ab61-874ac5be7087.jpg?1",
             "name": "Maw of the Obzedat",
             "text": "Sacrifice a creature: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "10ec3ff3-a4b3-5f66-b7ba-c5b8625ac81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e892d86-f443-4846-8049-40ec6b8c22b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e892d86-f443-4846-8049-40ec6b8c22b4.jpg?1",
             "name": "Melek, Izzet Paragon",
             "text": "Play with the top card of your library revealed.\nYou may cast the top card of your library if it's an instant or sorcery card.\nWhenever you cast an instant or sorcery spell from your library, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -2910,7 +2910,7 @@
         },
         {
             "id": "659ff13f-3a4b-5e7b-96a2-1091ba0d293c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37cdd3e-4303-4391-aff4-4a543e65a836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37cdd3e-4303-4391-aff4-4a543e65a836.jpg?1",
             "name": "Mirko Vosk, Mind Drinker",
             "text": "Flying\nWhenever Mirko Vosk, Mind Drinker deals combat damage to a player, that player reveals cards from the top of his or her library until he or she reveals four land cards, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2948,7 +2948,7 @@
         },
         {
             "id": "768aea19-db3b-58b4-a6a8-a0eb3669dbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c2909-87ab-4027-9b56-58a2abae3fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c2909-87ab-4027-9b56-58a2abae3fa3.jpg?1",
             "name": "Morgue Burst",
             "text": "Return target creature card from your graveyard to your hand. Morgue Burst deals damage to target creature or player equal to the power of the card returned this way.",
             "colours": [
@@ -2982,7 +2982,7 @@
         },
         {
             "id": "1ec7016b-8b75-55cc-8c05-4964cbd1c331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7a0e26-8cd4-4f53-8922-93ca28b1879b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7a0e26-8cd4-4f53-8922-93ca28b1879b.jpg?1",
             "name": "Nivix Cyclops",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, Nivix Cyclops gets +3/+0 until end of turn and can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "aed7f997-c431-5032-9f42-4fcb63b04d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e660b-ad8b-49d2-a7e5-6588e496519b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e660b-ad8b-49d2-a7e5-6588e496519b.jpg?1",
             "name": "Notion Thief",
             "text": "Flash\nIf an opponent would draw a card except the first one he or she draws in each of his or her draw steps, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "5c62efa6-2d16-58d9-b3b6-6ed790c3c1cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b846ba99-81ba-424a-98eb-f9f69c40f984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b846ba99-81ba-424a-98eb-f9f69c40f984.jpg?1",
             "name": "Obzedat's Aid",
             "text": "Return target permanent card from your graveyard to the battlefield.",
             "colours": [
@@ -3089,7 +3089,7 @@
         },
         {
             "id": "5ef35577-cd4b-523a-91b9-4889010ad3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3475fcc6-ee53-48da-89d2-80685a584e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3475fcc6-ee53-48da-89d2-80685a584e6a.jpg?1",
             "name": "Pilfered Plans",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard. Draw two cards.",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "978d1a92-eaa2-5044-af7e-4ff184d24af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe8485-d5fb-47cc-af53-6e0fd062b7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe8485-d5fb-47cc-af53-6e0fd062b7a2.jpg?1",
             "name": "Plasm Capture",
             "text": "Counter target spell. At the beginning of your next precombat main phase, add X mana in any combination of colors to your mana pool, where X is that spell's converted mana cost.",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "d8d14e18-5d7a-582d-a238-b7e2a8f91362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad76314-b5d5-4353-86aa-e899e0d757a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad76314-b5d5-4353-86aa-e899e0d757a5.jpg?1",
             "name": "Progenitor Mimic",
             "text": "You may have Progenitor Mimic enter the battlefield as a copy of any creature on the battlefield except it gains \"At the beginning of your upkeep, if this creature isn't a token, put a token onto the battlefield that's a copy of this creature.\"",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "68d2c7fe-4f24-50cc-8b6b-288cab25b00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d43a0b6-2a5c-4959-96ee-6e570949dfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d43a0b6-2a5c-4959-96ee-6e570949dfed.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "9a8136f4-5220-5b76-bdfb-d5f35ad8275a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdbb062-0b0b-4b4c-b4db-dd149f744baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdbb062-0b0b-4b4c-b4db-dd149f744baa.jpg?1",
             "name": "Ral Zarek",
             "text": "+1: Tap target permanent, then untap another target permanent.\n-2: Ral Zarek deals 3 damage to target creature or player.\n-7: Flip five coins. Take an extra turn after this one for each coin that comes up heads.",
             "colours": [
@@ -3265,7 +3265,7 @@
         },
         {
             "id": "8568c0a5-3aec-54fe-a2ad-19c178402a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6297df2-c67a-4054-9617-5c6202c76de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6297df2-c67a-4054-9617-5c6202c76de8.jpg?1",
             "name": "Reap Intellect",
             "text": "Target opponent reveals his or her hand. You choose up to X nonland cards from it and exile them. For each card exiled this way, search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "cd83f152-6819-5734-946d-0f46bcc570a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f3d6e4-0abe-4042-a7f6-0395683e8582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f3d6e4-0abe-4042-a7f6-0395683e8582.jpg?1",
             "name": "Render Silent",
             "text": "Counter target spell. Its controller can't cast spells this turn.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "be66c38d-ca82-56f0-8d8c-9e68757aca7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105902f6-99d0-4bee-9dfd-87a92ac04d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105902f6-99d0-4bee-9dfd-87a92ac04d91.jpg?1",
             "name": "Restore the Peace",
             "text": "Return each creature that dealt damage this turn to its owner's hand.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "ac779edf-e69a-5fa7-9f42-5442f6085d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5af2dd-75c7-402c-be9a-3d0d4290520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5af2dd-75c7-402c-be9a-3d0d4290520c.jpg?1",
             "name": "Rot Farm Skeleton",
             "text": "Rot Farm Skeleton can't block.\n{2}{B}{G}, Put the top four cards of your library into your graveyard: Return Rot Farm Skeleton from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "4e92b500-0869-5cbc-b699-fc193feb9c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dd3586-7c3b-4f9c-a1eb-7745b75339b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dd3586-7c3b-4f9c-a1eb-7745b75339b0.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each turn if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -3443,7 +3443,7 @@
         },
         {
             "id": "ed6fc784-532d-583c-b817-69b017666cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b73cd-6179-4885-9d92-1782d0b492c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b73cd-6179-4885-9d92-1782d0b492c1.jpg?1",
             "name": "Savageborn Hydra",
             "text": "Double strike\nSavageborn Hydra enters the battlefield with X +1/+1 counters on it.\n{1}{RG}: Put a +1/+1 counter on Savageborn Hydra. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "91eedeef-8ebd-5b6b-bf1d-241a8e289c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e360ae-4c78-47a9-81d4-1849cfa518b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e360ae-4c78-47a9-81d4-1849cfa518b7.jpg?1",
             "name": "Scab-Clan Giant",
             "text": "When Scab-Clan Giant enters the battlefield, it fights target creature an opponent controls chosen at random.",
             "colours": [
@@ -3516,7 +3516,7 @@
         },
         {
             "id": "b56c828e-2114-57dc-bad3-6fbfb6c16b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd1f68b-3f16-484e-95c9-5cfa8da218c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd1f68b-3f16-484e-95c9-5cfa8da218c9.jpg?1",
             "name": "Showstopper",
             "text": "Until end of turn, creatures you control gain \"When this creature dies, it deals 2 damage to target creature an opponent controls.\"",
             "colours": [
@@ -3550,7 +3550,7 @@
         },
         {
             "id": "d3d51757-20b7-598f-9db9-6cd894669c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305a3feb-df49-486c-a3b4-ff2721d60019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305a3feb-df49-486c-a3b4-ff2721d60019.jpg?1",
             "name": "Sin Collector",
             "text": "When Sin Collector enters the battlefield, target opponent reveals his or her hand. You choose an instant or sorcery card from it and exile that card.",
             "colours": [
@@ -3587,7 +3587,7 @@
         },
         {
             "id": "af1f641f-2934-5bb9-85ef-c48c4f31389a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3665cfb7-51b6-4083-8eae-fbd3fa6c3554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3665cfb7-51b6-4083-8eae-fbd3fa6c3554.jpg?1",
             "name": "Sire of Insanity",
             "text": "At the beginning of each end step, each player discards his or her hand.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "49766be6-bc26-5303-9df2-d5add9134124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0087a98-55cf-4c8b-a180-fb0d9c336eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0087a98-55cf-4c8b-a180-fb0d9c336eb2.jpg?1",
             "name": "Species Gorger",
             "text": "At the beginning of your upkeep, return a creature you control to its owner's hand.",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "7bde76de-2130-566f-b4df-3e55fa4ba832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec50499-70d4-4dc1-9cae-abbecfc8e87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec50499-70d4-4dc1-9cae-abbecfc8e87d.jpg?1",
             "name": "Spike Jester",
             "text": "Haste",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "effd998a-2628-5543-83fb-3427e5468ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5717c1-338e-446c-aa7e-93e79e4abb72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5717c1-338e-446c-aa7e-93e79e4abb72.jpg?1",
             "name": "Tajic, Blade of the Legion",
             "text": "Tajic, Blade of the Legion is indestructible.\nBattalion \u2014 Whenever Tajic and at least two other creatures attack, Tajic gets +5/+5 until end of turn.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "1e238e23-c947-5974-af2a-5c2cdd6412e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd8183c-6967-4332-b822-02b82c14ef2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd8183c-6967-4332-b822-02b82c14ef2d.jpg?1",
             "name": "Teysa, Envoy of Ghosts",
             "text": "Vigilance, protection from creatures\nWhenever a creature deals combat damage to you, destroy that creature. Put a 1/1 white and black Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -3775,7 +3775,7 @@
         },
         {
             "id": "bb490f68-a110-5e9a-b4c4-67a3605202cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069aa06-35b0-4af8-89cb-af653708ed32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069aa06-35b0-4af8-89cb-af653708ed32.jpg?1",
             "name": "Tithe Drinker",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "f03666b0-aa28-5627-929d-707d0345cce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921fa4e-2256-4ef1-b2fe-874f9fbbcdf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921fa4e-2256-4ef1-b2fe-874f9fbbcdf3.jpg?1",
             "name": "Trostani's Summoner",
             "text": "When Trostani's Summoner enters the battlefield, put a 2/2 white Knight creature token with vigilance, a 3/3 green Centaur creature token, and a 4/4 green Rhino creature token with trample onto the battlefield.",
             "colours": [
@@ -3848,7 +3848,7 @@
         },
         {
             "id": "05ef566c-a1e1-53f2-9563-9c897db39ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35952c24-d728-4ec6-b0d1-b8183a18554a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35952c24-d728-4ec6-b0d1-b8183a18554a.jpg?1",
             "name": "Unflinching Courage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample and lifelink.",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "f1472ab6-d72b-566b-b6a2-e95b82331c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3ae3db-c14a-4ffc-805c-a3a51da9370d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3ae3db-c14a-4ffc-805c-a3a51da9370d.jpg?1",
             "name": "Varolz, the Scar-Striped",
             "text": "Each creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.)\nSacrifice another creature: Regenerate Varolz, the Scar-Striped.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "b3d46c7c-7eea-5fe9-977d-3168a50aab6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0c21c-bdf1-478a-9ad8-6c6bda6ffb0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0c21c-bdf1-478a-9ad8-6c6bda6ffb0f.jpg?1",
             "name": "Viashino Firstblade",
             "text": "Haste\nWhen Viashino Firstblade enters the battlefield, it gets +2/+2 until end of turn.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "0ca44f26-1a27-5369-a0a0-e260f4d800ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07246783-d475-4f61-99ac-e2b574072349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07246783-d475-4f61-99ac-e2b574072349.jpg?1",
             "name": "Voice of Resurgence",
             "text": "Whenever an opponent casts a spell during your turn or when Voice of Resurgence dies, put a green and white Elemental creature token onto the battlefield with \"This creature's power and toughness are each equal to the number of creatures you control.\"",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "4dec73e5-557e-5069-8683-e69b1407bfed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0665d4-d974-4d5e-ba29-7bf40cbbe29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0665d4-d974-4d5e-ba29-7bf40cbbe29c.jpg?1",
             "name": "Vorel of the Hull Clade",
             "text": "{G}{U}, {T}: For each counter on target artifact, creature, or land, put another of those counters on that permanent.",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "32a64f45-26a5-57c0-8cc8-5e314f4c0f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e474ac-54f7-43f9-8af9-2f1adf258b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e474ac-54f7-43f9-8af9-2f1adf258b15.jpg?1",
             "name": "Warleader's Helix",
             "text": "Warleader's Helix deals 4 damage to target creature or player and you gain 4 life.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "f82deb2f-647e-5405-81bd-cb5048d0c392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134802b2-7c5c-4eda-a879-b29bc06faaed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134802b2-7c5c-4eda-a879-b29bc06faaed.jpg?1",
             "name": "Warped Physique",
             "text": "Target creature gets +X/-X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "54b3c131-3460-580b-9c71-45a215fd8d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1e6fe-e959-4030-9925-9ccc27040275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1e6fe-e959-4030-9925-9ccc27040275.jpg?1",
             "name": "Woodlot Crawler",
             "text": "Forestwalk, protection from green",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "5ff9ce34-59d2-5bb0-a907-19db98c77887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2076308f-0f4e-4b31-9e75-c2965942e7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2076308f-0f4e-4b31-9e75-c2965942e7d1.jpg?1",
             "name": "Zhur-Taa Ancient",
             "text": "Whenever a player taps a land for mana, that player adds one mana to his or her mana pool of any type that land produced.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "63b65db7-b1c0-5c6e-a941-974f0168467e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd565782-8b2f-4b9f-a62d-4af60af20a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd565782-8b2f-4b9f-a62d-4af60af20a82.jpg?1",
             "name": "Zhur-Taa Druid",
             "text": "{T}: Add {G} to your mana pool.\nWhenever you tap Zhur-Taa Druid for mana, it deals 1 damage to each opponent.",
             "colours": [
@@ -4212,7 +4212,7 @@
         },
         {
             "id": "7f5f719b-947a-50b0-834b-693f59fc0bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg?1",
             "name": "Alive // Well",
             "text": "Put a 3/3 green Centaur creature token onto the battlefield.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "9e4f170e-6610-5655-827f-25550996d0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg?1",
             "name": "Alive // Well",
             "text": "You gain 2 life for each creature you control.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4278,7 +4278,7 @@
         },
         {
             "id": "d0a285c2-890f-55e9-b208-7a58b621c423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg?1",
             "name": "Armed // Dangerous",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "56488133-3089-5ca0-ad07-f6a926e3feb9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg?1",
             "name": "Armed // Dangerous",
             "text": "All creatures able to block target creature this turn do so.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "85c87a3f-ab18-5135-8e8a-b7f0bb2f30b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg?1",
             "name": "Beck // Call",
             "text": "Whenever a creature enters the battlefield this turn, you may draw a card.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "7ee5faec-ccc1-5e35-84fa-d0dbbbdb778f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg?1",
             "name": "Beck // Call",
             "text": "Put four 1/1 white Bird creature tokens with flying onto the battlefield.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "330afd68-39e8-544e-8ce2-d4d4a6c4fac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg?1",
             "name": "Breaking // Entering",
             "text": "Target player puts the top eight cards of his or her library into his or her graveyard.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "97bada65-7590-55d1-900a-ee8488d8cadb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg?1",
             "name": "Breaking // Entering",
             "text": "Put a creature card from a graveyard onto the battlefield under your control. It gains haste until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "ed55a9ee-f1bb-5178-9259-3160b7c65c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg?1",
             "name": "Catch // Release",
             "text": "Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "44a70943-7e2e-5c3b-9453-5a085dced28f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg?1",
             "name": "Catch // Release",
             "text": "Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "25a0a5e8-794c-50a2-a2c3-b18c9a349c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg?1",
             "name": "Down // Dirty",
             "text": "Target player discards two cards.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "c1a29064-f090-503c-9578-015a9d2bbff2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg?1",
             "name": "Down // Dirty",
             "text": "Return target card from your graveyard to your hand.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "cbf4d6cd-1341-5841-89ed-f996b99fad8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg?1",
             "name": "Far // Away",
             "text": "Return target creature to its owner's hand.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4653,7 +4653,7 @@
         },
         {
             "id": "2a4f4e5a-6a38-5880-8bf8-b0c1b0045ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg?1",
             "name": "Far // Away",
             "text": "Target player sacrifices a creature.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4686,7 +4686,7 @@
         },
         {
             "id": "cc068d00-3075-5217-8896-c32caefc69e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg?1",
             "name": "Flesh // Blood",
             "text": "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "2c3149d4-1e00-5851-bcdc-8118f91b5e36",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg?1",
             "name": "Flesh // Blood",
             "text": "Target creature you control deals damage equal to its power to target creature or player.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "3c0a1207-b39f-5caa-85e9-72f07a83cf56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg?1",
             "name": "Give // Take",
             "text": "Put three +1/+1 counters on target creature.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4789,7 +4789,7 @@
         },
         {
             "id": "073efd6b-4cfa-52ba-b209-8a20a8337688",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg?1",
             "name": "Give // Take",
             "text": "Remove all +1/+1 counters from target creature you control. Draw that many cards.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "a15ef45d-90c8-5380-b703-bca06d570109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg?1",
             "name": "Profit // Loss",
             "text": "Creatures you control get +1/+1 until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "39f7e585-dabf-5fd0-9026-dbc7ac816af5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg?1",
             "name": "Profit // Loss",
             "text": "Creatures your opponents control get -1/-1 until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "10d7aced-4982-50bc-b66a-784382e63687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg?1",
             "name": "Protect // Serve",
             "text": "Target creature gets +2/+4 until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "9e8cf6c1-e78c-51f5-afc9-8f953cbc7b45",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg?1",
             "name": "Protect // Serve",
             "text": "Target creature gets -6/-0 until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "b9834378-cf65-5b1f-af7c-0498821613ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg?1",
             "name": "Ready // Willing",
             "text": "Creatures you control are indestructible this turn. Untap each creature you control.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "6ce4f670-203d-5abc-af0c-45ec21b061d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg?1",
             "name": "Ready // Willing",
             "text": "Creatures you control gain deathtouch and lifelink until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "ab2c4624-e208-53a6-beba-e85aa46b9222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg?1",
             "name": "Toil // Trouble",
             "text": "Target player draws two cards and loses 2 life.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "3188266a-9cf6-5037-b7bc-bf137ccb9a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg?1",
             "name": "Toil // Trouble",
             "text": "Trouble deals damage to target player equal to the number of cards in that player's hand.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "0d576072-ff48-50bc-b7b4-e434daf9f636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg?1",
             "name": "Turn // Burn",
             "text": "Target creature loses all abilities and becomes a 0/1 red Weird until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5123,7 +5123,7 @@
         },
         {
             "id": "7fd108ce-4422-5d0a-a5cf-cebb9eefcc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg?1",
             "name": "Turn // Burn",
             "text": "Burn deals 2 damage to target creature or player.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "00e889ab-c5ba-5941-a50c-2f654e9390c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target artifact.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "838d6449-7190-56d8-bc7c-1e23c1cc20c0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target enchantment.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "2da9b6a4-e63d-5ca2-bffb-a88944e0eaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb301-bc28-4515-ad69-0b1b5164a5bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb301-bc28-4515-ad69-0b1b5164a5bc.jpg?1",
             "name": "Azorius Cluestone",
             "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}, {T}, Sacrifice Azorius Cluestone: Draw a card.",
             "colours": [],
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "0b24ed80-30c0-5e7b-873a-aeaa91700528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87252577-3e7b-4ea2-b0ac-3ba3f0eaac40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87252577-3e7b-4ea2-b0ac-3ba3f0eaac40.jpg?1",
             "name": "Boros Cluestone",
             "text": "{T}: Add {R} or {W} to your mana pool.\n{R}{W}, {T}, Sacrifice Boros Cluestone: Draw a card.",
             "colours": [],
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "ccb97dc5-383b-5e74-93d3-c24923b4c3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8ac24f-3309-453a-b2d6-6363df9a1ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8ac24f-3309-453a-b2d6-6363df9a1ddd.jpg?1",
             "name": "Dimir Cluestone",
             "text": "{T}: Add {U} or {B} to your mana pool.\n{U}{B}, {T}, Sacrifice Dimir Cluestone: Draw a card.",
             "colours": [],
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "94e2d452-b13d-5b5e-b92f-826799db405e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff77e1ee-7fa3-4370-a0c9-ec008b63302f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff77e1ee-7fa3-4370-a0c9-ec008b63302f.jpg?1",
             "name": "Golgari Cluestone",
             "text": "{T}: Add {B} or {G} to your mana pool.\n{B}{G}, {T}, Sacrifice Golgari Cluestone: Draw a card.",
             "colours": [],
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "78f0320a-d4d4-5200-b199-237600d61499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc47d1fe-8ab2-42f6-bcab-4bc2084ceba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc47d1fe-8ab2-42f6-bcab-4bc2084ceba7.jpg?1",
             "name": "Gruul Cluestone",
             "text": "{T}: Add {R} or {G} to your mana pool.\n{R}{G}, {T}, Sacrifice Gruul Cluestone: Draw a card.",
             "colours": [],
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "8a5722ac-5410-5b35-a3e7-2829fbdc0c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf63def-e2cc-48c7-8409-c08a36eddf93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf63def-e2cc-48c7-8409-c08a36eddf93.jpg?1",
             "name": "Izzet Cluestone",
             "text": "{T}: Add {U} or {R} to your mana pool.\n{U}{R}, {T}, Sacrifice Izzet Cluestone: Draw a card.",
             "colours": [],
@@ -5408,7 +5408,7 @@
         },
         {
             "id": "45fac33e-c179-5728-b5ba-922b5346925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4823f904-1c41-42cf-aef7-db0dcf82b10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4823f904-1c41-42cf-aef7-db0dcf82b10b.jpg?1",
             "name": "Orzhov Cluestone",
             "text": "{T}: Add {W} or {B} to your mana pool.\n{W}{B}, {T}, Sacrifice Orzhov Cluestone: Draw a card.",
             "colours": [],
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "e1dc971c-0450-5707-a7df-55ab648c15f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef43817-1813-4608-8e3d-3c14321ab736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef43817-1813-4608-8e3d-3c14321ab736.jpg?1",
             "name": "Rakdos Cluestone",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{B}{R}, {T}, Sacrifice Rakdos Cluestone: Draw a card.",
             "colours": [],
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "3b045440-a0c0-5b25-b8ab-8e887f28a5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad5631-439a-43e2-b00a-04f78d66b8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad5631-439a-43e2-b00a-04f78d66b8e6.jpg?1",
             "name": "Selesnya Cluestone",
             "text": "{T}: Add {G} or {W} to your mana pool.\n{G}{W}, {T}, Sacrifice Selesnya Cluestone: Draw a card.",
             "colours": [],
@@ -5501,7 +5501,7 @@
         },
         {
             "id": "0f32ffc0-b18f-5e68-b533-4e83af3f57e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c47552-afed-463d-bd24-13eb1cd724fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c47552-afed-463d-bd24-13eb1cd724fc.jpg?1",
             "name": "Simic Cluestone",
             "text": "{T}: Add {G} or {U} to your mana pool.\n{G}{U}, {T}, Sacrifice Simic Cluestone: Draw a card.",
             "colours": [],
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "5ba0dcdf-f7a3-5636-bc9c-0422729a6821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bbe27d-c92a-4c65-a997-b21536d7667e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bbe27d-c92a-4c65-a997-b21536d7667e.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "b423fa16-eb47-5ae4-8e11-23c210877650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94cc167-a6da-4404-88aa-61eee8b4b9e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94cc167-a6da-4404-88aa-61eee8b4b9e8.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "e59027bb-8737-5b1b-bb51-fb0a7effc50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627f9eb-c3fc-4517-9d65-132fdcc217d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627f9eb-c3fc-4517-9d65-132fdcc217d7.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "68207548-c302-5a28-b6a2-76ec2e55000d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0248cc88-e95c-4667-82a2-40e881acabc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0248cc88-e95c-4667-82a2-40e881acabc2.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "3ed109b1-8af3-556a-aad0-c4f02caddc35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24221b9a-5ff1-43f8-b409-c56967f8308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24221b9a-5ff1-43f8-b409-c56967f8308d.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "0e5950e3-57a8-591c-abdc-647e089cac03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165ee8d7-d509-41d4-abd2-298b3db3ca46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165ee8d7-d509-41d4-abd2-298b3db3ca46.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "9b52754e-74f8-5a3d-b296-67fd7cde9877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f7042-24fd-42a0-ae7c-e6b7de1aa446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f7042-24fd-42a0-ae7c-e6b7de1aa446.jpg?1",
             "name": "Maze's End",
             "text": "Maze's End enters the battlefield tapped.\n{T}: Add {1} to your mana pool.\n{3}, {T}, Return Maze's End to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle your library. If you control ten or more Gates with different names, you win the game.",
             "colours": [],
@@ -5758,7 +5758,7 @@
         },
         {
             "id": "5479b6cf-816f-5c44-a972-304eb87cfc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e2006-5bff-4e91-862b-aa76521a99c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e2006-5bff-4e91-862b-aa76521a99c3.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "df5f7ebf-422e-52a3-bc12-19bf116484dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1368e7c6-2220-4dad-8129-68336f261af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1368e7c6-2220-4dad-8129-68336f261af0.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "9c6871ce-a971-5a9a-b63c-8afa747c90ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90198725-0cd3-4650-9575-c22674aa4185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90198725-0cd3-4650-9575-c22674aa4185.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "c7a4cb9a-a976-53e5-94cc-f54f48eb668a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee34fcb-0158-4741-9292-513fed9684cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee34fcb-0158-4741-9292-513fed9684cb.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -5890,7 +5890,7 @@
         },
         {
             "id": "c24dadf0-35cd-5122-91a2-c6744ff64ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfb1440-d4c1-42cf-a777-ee1644dbbac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfb1440-d4c1-42cf-a777-ee1644dbbac7.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/DIS.json
+++ b/Assets/Resources/Sets/DIS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9cbfe285-ce53-5b65-8c65-d56215c9d65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb3d0b-8630-4373-b863-bc831cf08098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb3d0b-8630-4373-b863-bc831cf08098.jpg?1",
             "name": "Aurora Eidolon",
             "text": "{W}, Sacrifice Aurora Eidolon: Prevent the next 3 damage that would be dealt to target creature or player this turn.\nWhenever you play a multicolored spell, you may return Aurora Eidolon from your graveyard to your hand.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "5df9324a-27bf-53ba-a867-0d8aa26f4434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1923ffb2-1fab-475a-914a-120312e26628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1923ffb2-1fab-475a-914a-120312e26628.jpg?1",
             "name": "Azorius Herald",
             "text": "Azorius Herald is unblockable.\nWhen Azorius Herald comes into play, you gain 4 life.\nWhen Azorius Herald comes into play, sacrifice it unless {U} was spent to play it.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "97b24743-a520-571e-9198-cc015ca5971c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ea4a-087e-4a6d-9973-0778a1ed2b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ea4a-087e-4a6d-9973-0778a1ed2b7e.jpg?1",
             "name": "Beacon Hawk",
             "text": "Flying\nWhenever Beacon Hawk deals combat damage to a player, you may untap target creature.\n{W}: Beacon Hawk gets +0/+1 until end of turn.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "e8bc3aea-ebee-5fc5-a309-bd181b2b7905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689b4ba1-5bb5-458d-8900-19a330e0093c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689b4ba1-5bb5-458d-8900-19a330e0093c.jpg?1",
             "name": "Blessing of the Nephilim",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each of its colors.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "ae6ab120-5a88-5aea-baee-eda4929761a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1f1c57-693f-452b-951f-8c8c23f2ee99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1f1c57-693f-452b-951f-8c8c23f2ee99.jpg?1",
             "name": "Brace for Impact",
             "text": "Prevent all damage that would be dealt to target multicolored creature this turn. For each 1 damage prevented this way, put a +1/+1 counter on that creature.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "381ef883-10d9-5ab6-a98a-abef28b7b856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184e0964-1e04-49f9-bb76-0a6e682c52f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184e0964-1e04-49f9-bb76-0a6e682c52f5.jpg?1",
             "name": "Carom",
             "text": "The next 1 damage that would be dealt to target creature this turn is dealt to another target creature instead.\nDraw a card.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "9ab40ad1-e2f2-5dfe-90cb-006f74921008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012fb3a6-99ff-4b5e-96e3-0a2eeca36bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012fb3a6-99ff-4b5e-96e3-0a2eeca36bdb.jpg?1",
             "name": "Celestial Ancient",
             "text": "Flying\nWhenever you play an enchantment spell, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "1b80696b-dde2-50fe-90e5-4c0943abb088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4f5a0-b2d0-4a60-b1e1-bb2140abfd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4f5a0-b2d0-4a60-b1e1-bb2140abfd6d.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "6b730b4f-63f9-5691-aa75-edb4c618ad5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b82b76d-697b-4312-aab5-bf741c207438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b82b76d-697b-4312-aab5-bf741c207438.jpg?1",
             "name": "Freewind Equenaut",
             "text": "Flying\nAs long as Freewind Equenaut is enchanted, it has \"{T}: Freewind Equenaut deals 2 damage to target attacking or blocking creature.\"",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "b87fb0d8-5b16-5b57-a0c7-d8b867b0990d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8dd004b-01e4-4fe1-a164-9f2ea8d7d88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8dd004b-01e4-4fe1-a164-9f2ea8d7d88e.jpg?1",
             "name": "Guardian of the Guildpact",
             "text": "Protection from monocolored",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "7847de2e-431d-5223-ab05-755b319a6191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca97f2-cf38-4d68-80a9-f4e890271e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca97f2-cf38-4d68-80a9-f4e890271e5c.jpg?1",
             "name": "Haazda Exonerator",
             "text": "{T}, Sacrifice Haazda Exonerator: Destroy target Aura.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "c61c66fb-3344-537e-9e01-ba20567b0996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940e8c6-1423-4dbf-89c8-9055bf15d4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940e8c6-1423-4dbf-89c8-9055bf15d4ec.jpg?1",
             "name": "Haazda Shield Mate",
             "text": "At the beginning of your upkeep, sacrifice Haazda Shield Mate unless you pay {W}{W}.\n{W}: The next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "ba2f7af2-d446-5ae6-b585-c16ff7d54106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19db5386-3ef1-4654-8494-6e7949ed7234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19db5386-3ef1-4654-8494-6e7949ed7234.jpg?1",
             "name": "Mistral Charger",
             "text": "Flying",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "05732b9b-d508-5481-a9a6-ca3090f0ca33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c1dc-e676-4c24-93b0-db2aae663ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c1dc-e676-4c24-93b0-db2aae663ea2.jpg?1",
             "name": "Paladin of Prahv",
             "text": "Whenever Paladin of Prahv deals damage, you gain that much life.\nForecast {1}{W}, Reveal Paladin of Prahv from your hand: Whenever target creature deals damage this turn, you gain that much life. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "ecc2a3ff-56ba-59f6-8e0d-80e0bc180786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc799c97-3df1-4194-b220-6cf862ce3810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc799c97-3df1-4194-b220-6cf862ce3810.jpg?1",
             "name": "Proclamation of Rebirth",
             "text": "Return up to three target creature cards with converted mana cost 1 or less from your graveyard to play.\nForecast {5}{W}, Reveal Proclamation of Rebirth from your hand: Return target creature card with converted mana cost 1 or less from your graveyard to play. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "c5921d8f-9459-5f35-85fc-6f0543fd713b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a4756-d82b-4c6d-b652-5c3722d3edec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a4756-d82b-4c6d-b652-5c3722d3edec.jpg?1",
             "name": "Proper Burial",
             "text": "Whenever a creature you control is put into a graveyard from play, you gain life equal to that creature's toughness.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "129b97e1-93a2-5506-9dac-e61d92f9f405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668c4e40-0035-44e0-8401-dd17fa11ecd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668c4e40-0035-44e0-8401-dd17fa11ecd4.jpg?1",
             "name": "Soulsworn Jury",
             "text": "Defender (This creature can't attack.)\n{1}{U}, Sacrifice Soulsworn Jury: Counter target creature spell.",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "495d4524-adf3-527a-aa17-d242cbe88749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f89bd01-310e-4ec2-8d42-052c66ff8d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f89bd01-310e-4ec2-8d42-052c66ff8d0f.jpg?1",
             "name": "Steeling Stance",
             "text": "Creatures you control get +1/+1 until end of turn.\nForecast {W}, Reveal Steeling Stance from your hand: Target creature gets +1/+1 until end of turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "1f125c37-e38b-5c6f-92fe-cc8614c2c51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bff58-e7cd-4787-a2c1-1afd6ed1b4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bff58-e7cd-4787-a2c1-1afd6ed1b4ff.jpg?1",
             "name": "Stoic Ephemera",
             "text": "Defender (This creature can't attack.)\nFlying\nWhen Stoic Ephemera blocks, sacrifice it at end of combat.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "ee5c6d40-c62b-5f23-ae2c-edc576c0d51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3554f9e9-3f09-490a-9284-28c7aefc70d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3554f9e9-3f09-490a-9284-28c7aefc70d0.jpg?1",
             "name": "Valor Made Real",
             "text": "Target creature can block any number of creatures this turn.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "edd870f6-5e23-5c91-80ef-fbd9f9974ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52bdb-81a6-45c6-942c-373f1dabc8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52bdb-81a6-45c6-942c-373f1dabc8d8.jpg?1",
             "name": "Wakestone Gargoyle",
             "text": "Defender (This creature can't attack.)\nFlying\n{1}{W}: Creatures you control with defender can attack this turn as though they didn't have defender.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "0d66306a-3908-56ed-aa0c-0e90290d91b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970f492-d4fc-4833-a083-05e422a3c456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970f492-d4fc-4833-a083-05e422a3c456.jpg?1",
             "name": "Court Hussar",
             "text": "Vigilance\nWhen Court Hussar comes into play, look at the top three cards of your library, then put one of them into your hand and the rest on the bottom of your library in any order.\nWhen Court Hussar comes into play, sacrifice it unless {W} was spent to play it.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "d275f26a-702c-50d8-954e-b79c00fc662e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb6b06d-b132-44e9-a743-61187afb6152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb6b06d-b132-44e9-a743-61187afb6152.jpg?1",
             "name": "Cytoplast Manipulator",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{U}, {T}: Gain control of target creature with a +1/+1 counter on it as long as Cytoplast Manipulator remains in play.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "b141e78f-fe0e-58df-ad03-ad9963213ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814a1082-6e2c-46d3-9b45-12dab7006c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814a1082-6e2c-46d3-9b45-12dab7006c0f.jpg?1",
             "name": "Enigma Eidolon",
             "text": "{U}, Sacrifice Enigma Eidolon: Target player puts the top three cards of his or her library into his or her graveyard.\nWhenever you play a multicolored spell, you may return Enigma Eidolon from your graveyard to your hand.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "d5fca825-58c9-50ba-91bf-511b74b8aa4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23106341-9200-4eee-93d0-d6173b0b39c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23106341-9200-4eee-93d0-d6173b0b39c4.jpg?1",
             "name": "Govern the Guildless",
             "text": "Gain control of target monocolored creature.\nForecast {1}{U}, Reveal Govern the Guildless from your hand: Target creature becomes the color or colors of your choice until end of turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "dcc5fe9b-d008-5f8c-b7fb-babaffba1484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764e3d28-1876-46da-b927-b98089d62776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764e3d28-1876-46da-b927-b98089d62776.jpg?1",
             "name": "Helium Squirter",
             "text": "Graft 3 (This creature comes into play with three +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}: Target creature with a +1/+1 counter on it gains flying until end of turn.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "ba669c21-cac1-51c1-90ef-e305f2ddea48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ec467e-5d4a-4941-ac30-801ed681da54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ec467e-5d4a-4941-ac30-801ed681da54.jpg?1",
             "name": "Novijen Sages",
             "text": "Graft 4 (This creature comes into play with four +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}, Remove two +1/+1 counters from among creatures you control: Draw a card.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "612a12b3-717a-5c3e-bfa6-c5464c4fe195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c883e75-5c37-44bb-a6c8-f97aa704c739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c883e75-5c37-44bb-a6c8-f97aa704c739.jpg?1",
             "name": "Ocular Halo",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Draw a card.\"\n{W}: Enchanted creature gains vigilance until end of turn.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "84388715-61f0-5602-abfe-9c3e6aae43a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae3598d-4d76-45ac-ab96-00d27a8de6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae3598d-4d76-45ac-ab96-00d27a8de6c8.jpg?1",
             "name": "Plaxmanta",
             "text": "You may play Plaxmanta any time you could play an instant.\nWhen Plaxmanta comes into play, creatures you control can't be the targets of spells or abilities this turn.\nWhen Plaxmanta comes into play, sacrifice it unless {G} was spent to play it.",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "40011488-1981-5725-ac9c-8bf412d10a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8364ce0-4c11-4af0-9f4b-e4c20d640dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8364ce0-4c11-4af0-9f4b-e4c20d640dfc.jpg?1",
             "name": "Psychic Possession",
             "text": "Enchant opponent\nSkip your draw step.\nWhenever enchanted opponent draws a card, you may draw a card.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "99126da8-1c43-5134-8e6f-8c1d1489b7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f165aa-2986-47d1-912d-d50490a15c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f165aa-2986-47d1-912d-d50490a15c0b.jpg?1",
             "name": "Silkwing Scout",
             "text": "Flying\n{G}, Sacrifice Silkwing Scout: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "c49d452a-f380-5b81-8fdf-fc505d9cd19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa63967-5422-4db5-9dba-8ab6f9b18d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa63967-5422-4db5-9dba-8ab6f9b18d60.jpg?1",
             "name": "Skyscribing",
             "text": "Each player draws X cards.\nForecast {2}{U}, Reveal Skyscribing from your hand: Each player draws a card. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "e83f40dd-591b-5a97-8bbb-d6ad0e851490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35554fdf-c70a-4baa-a35a-414caa9978be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35554fdf-c70a-4baa-a35a-414caa9978be.jpg?1",
             "name": "Spell Snare",
             "text": "Counter target spell with converted mana cost 2.",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "ef9601d2-de87-5bad-b1ce-a19c2f958ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44865244-2b9f-4734-a4da-49613b23ee4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44865244-2b9f-4734-a4da-49613b23ee4d.jpg?1",
             "name": "Tidespout Tyrant",
             "text": "Flying\nWhenever you play a spell, return target permanent to its owner's hand.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "5bc056c3-421e-5683-b35b-577b0e1a6816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c75901c-fe69-49b8-b491-879e9adf7902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c75901c-fe69-49b8-b491-879e9adf7902.jpg?1",
             "name": "Vigean Graftmage",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}{U}: Untap target creature with a +1/+1 counter on it.",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "c5f468fc-b83c-543b-a6db-61e0c932fbda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e632566-1f58-4439-983a-a25c06b7196c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e632566-1f58-4439-983a-a25c06b7196c.jpg?1",
             "name": "Vision Skeins",
             "text": "Each player draws two cards.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "15dbe322-452a-5565-b871-b5daf7200ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd58eee-1108-49be-9ae7-da179fb081c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd58eee-1108-49be-9ae7-da179fb081c2.jpg?1",
             "name": "Writ of Passage",
             "text": "Enchant creature\nWhenever enchanted creature attacks, if its power is 2 or less, it's unblockable this turn.\nForecast {1}{U}, Reveal Writ of Passage from your hand: Target creature with power 2 or less is unblockable this turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "c6fa7a15-ab2c-57fc-b23e-b4b52c733c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832acb3f-4dd4-4bf1-b990-7cc7a68a1d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832acb3f-4dd4-4bf1-b990-7cc7a68a1d57.jpg?1",
             "name": "Bond of Agony",
             "text": "As an additional cost to play Bond of Agony, pay X life.\nEach other player loses X life.",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "bcfd453b-2323-50c1-9f8f-55003824978d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65692f-fabc-4b56-a0f6-d623ed069cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65692f-fabc-4b56-a0f6-d623ed069cb8.jpg?1",
             "name": "Brain Pry",
             "text": "Name a nonland card. Target player reveals his or her hand. That player discards a card with that name. If he or she can't, you draw a card.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "72cee6ae-f7ee-5573-a062-fec8940fd055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed424a46-8bac-4a3c-a6e6-87d02a20b292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed424a46-8bac-4a3c-a6e6-87d02a20b292.jpg?1",
             "name": "Crypt Champion",
             "text": "Double strike\nWhen Crypt Champion comes into play, each player puts a creature card with converted mana cost 3 or less from his or her graveyard into play.\nWhen Crypt Champion comes into play, sacrifice it unless {R} was spent to play it.",
             "colours": [
@@ -1358,7 +1358,7 @@
         },
         {
             "id": "223e15f2-39f8-545b-8beb-46e453266314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a480f1d-1959-4318-bf66-680266fcefd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a480f1d-1959-4318-bf66-680266fcefd0.jpg?1",
             "name": "Delirium Skeins",
             "text": "Each player discards three cards.",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "1825f4b7-e7e9-5f70-a927-f438a84fca76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a3f694-0cf3-4d25-8ab0-36a3f637ff9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a3f694-0cf3-4d25-8ab0-36a3f637ff9a.jpg?1",
             "name": "Demon's Jester",
             "text": "Flying\nHellbent Demon's Jester gets +2/+1 as long as you have no cards in hand.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "936dfc83-47c4-5fc5-86f0-3c476993c681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459d8cb7-cbb8-4e73-9571-44277f1d1be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459d8cb7-cbb8-4e73-9571-44277f1d1be2.jpg?1",
             "name": "Drekavac",
             "text": "When Drekavac comes into play, sacrifice it unless you discard a noncreature card.",
             "colours": [
@@ -1458,7 +1458,7 @@
         },
         {
             "id": "160aee45-c334-5432-8330-758632416a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc7d53-2510-4322-969c-1e138287562c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc7d53-2510-4322-969c-1e138287562c.jpg?1",
             "name": "Enemy of the Guildpact",
             "text": "Protection from multicolored",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "0bd9765e-8c22-55be-9166-c17ff6466f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5998cab0-77cd-4a22-8049-37d39928df6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5998cab0-77cd-4a22-8049-37d39928df6d.jpg?1",
             "name": "Entropic Eidolon",
             "text": "{B}, Sacrifice Entropic Eidolon: Target player loses 1 life and you gain 1 life.\nWhenever you play a multicolored spell, you may return Entropic Eidolon from your graveyard to your hand.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "60f21863-44e2-51b2-9d2b-0f529937f96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4e4be5-e057-4b50-9f86-76bc0b9987de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4e4be5-e057-4b50-9f86-76bc0b9987de.jpg?1",
             "name": "Infernal Tutor",
             "text": "Reveal a card from your hand. Search your library for a card with the same name as that card, reveal it, put it into your hand, then shuffle your library.\nHellbent If you have no cards in hand, instead search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "d0817602-6dcd-53a7-9cdc-d3e2736413f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cd7bc3-73ba-4364-84b2-9954648cd8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cd7bc3-73ba-4364-84b2-9954648cd8a9.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "53acd9c7-608a-5e88-8636-207ead902483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bf458c-9e2c-4d36-90c5-d9b772f99d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bf458c-9e2c-4d36-90c5-d9b772f99d3c.jpg?1",
             "name": "Nettling Curse",
             "text": "Enchant creature\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.\n{1}{R}: Enchanted creature attacks this turn if able.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "879dc1f4-4d43-56a6-b9f2-96b6cb03818b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f7f7f7-c7eb-466c-bfe6-0ef586284ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f7f7f7-c7eb-466c-bfe6-0ef586284ee9.jpg?1",
             "name": "Nightcreep",
             "text": "Until end of turn, all creatures become black and all lands become Swamps.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "aed9cd87-e3b5-57b1-a0ca-4345b35c08b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603486d-c8d7-4a02-bdb3-c25d2bc62ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603486d-c8d7-4a02-bdb3-c25d2bc62ba6.jpg?1",
             "name": "Nihilistic Glee",
             "text": "{2}{B}, Discard a card: Target opponent loses 1 life and you gain 1 life.\nHellbent {1}, Pay 2 life: Draw a card. Play this ability only if you have no cards in hand.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "33863321-797d-57e2-ad9c-b3f0ef819b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db5cccc-e9e4-4db8-affb-93d629d67b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db5cccc-e9e4-4db8-affb-93d629d67b91.jpg?1",
             "name": "Ragamuffyn",
             "text": "Hellbent {T}, Sacrifice a creature or land: Draw a card. Play this ability only if you have no cards in hand.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "2a6ac14f-5d27-5460-8957-8fa21bea68c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0cd9c-48ec-4914-9502-afacc58ce5fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0cd9c-48ec-4914-9502-afacc58ce5fd.jpg?1",
             "name": "Ratcatcher",
             "text": "Fear\nAt the beginning of your upkeep, you may search your library for a Rat card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "2bf76404-ff16-5360-a716-89f5a8e8d89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f85644-d8c6-4680-a417-08aa863ad4bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f85644-d8c6-4680-a417-08aa863ad4bb.jpg?1",
             "name": "Seal of Doom",
             "text": "Sacrifice Seal of Doom: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "d47bce68-1787-5f9b-9e98-b5963e9e2a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e71c1-5d95-44f3-99f1-b3b6eda8b26c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e71c1-5d95-44f3-99f1-b3b6eda8b26c.jpg?1",
             "name": "Slaughterhouse Bouncer",
             "text": "Hellbent When Slaughterhouse Bouncer is put into a graveyard from play, if you have no cards in hand, target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "30d09a0b-100d-54d8-a511-b9ff1eacfe87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c216194-0c6b-4c03-9262-bd2613e17d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c216194-0c6b-4c03-9262-bd2613e17d9a.jpg?1",
             "name": "Slithering Shade",
             "text": "Defender (This creature can't attack.)\n{B}: Slithering Shade gets +1/+1 until end of turn.\nHellbent Slithering Shade can attack as though it didn't have defender as long as you have no cards in hand.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "6ef3ff32-b6c8-59af-a295-46a5f4f162c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694bbf39-fd66-4ff4-9cc3-ec75b1fb3a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694bbf39-fd66-4ff4-9cc3-ec75b1fb3a51.jpg?1",
             "name": "Unliving Psychopath",
             "text": "{B}: Unliving Psychopath gets +1/-1 until end of turn.\n{B}, {T}: Destroy target creature with power less than Unliving Psychopath's power.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "577c0d73-ee06-5466-9d86-081893fd1508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669efa40-be9a-4475-9bcb-3325518403b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669efa40-be9a-4475-9bcb-3325518403b5.jpg?1",
             "name": "Vesper Ghoul",
             "text": "{T}, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "2edbdbb5-7dcb-5c1e-9e9e-dd4608ef92b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f8e20c-6d8e-45a1-aabd-176d8df843db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f8e20c-6d8e-45a1-aabd-176d8df843db.jpg?1",
             "name": "Wit's End",
             "text": "Target player discards his or her hand.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "0237c517-b61d-5c1a-ab61-5798f1e2a6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a371e-fb82-41f1-892c-975f932b668e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a371e-fb82-41f1-892c-975f932b668e.jpg?1",
             "name": "Cackling Flames",
             "text": "Cackling Flames deals 3 damage to target creature or player.\nHellbent Cackling Flames deals 5 damage to that creature or player instead if you have no cards in hand.",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "0e752030-5a7b-5b17-b68a-e54706dd4baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2ad333-722e-4d7e-972a-903c24068931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2ad333-722e-4d7e-972a-903c24068931.jpg?1",
             "name": "Demonfire",
             "text": "Demonfire deals X damage to target creature or player. If a creature dealt damage this way would be put into a graveyard this turn, remove it from the game instead.\nHellbent If you have no cards in hand, Demonfire can't be countered by spells or abilities and the damage can't be prevented.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "42748102-0ee5-5276-a0ae-897e0a3d55cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8092518-99ba-43b8-b5e9-8b46f1679696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8092518-99ba-43b8-b5e9-8b46f1679696.jpg?1",
             "name": "Flame-Kin War Scout",
             "text": "When another creature comes into play, sacrifice Flame-Kin War Scout. If you do, Flame-Kin War Scout deals 4 damage to that creature.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "a172c415-e2ee-56bb-ad04-664dd7910343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98a6c69-4100-42fc-b71e-381696f73852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98a6c69-4100-42fc-b71e-381696f73852.jpg?1",
             "name": "Flaring Flame-Kin",
             "text": "As long as Flaring Flame-Kin is enchanted, it gets +2/+2, has trample, and has \"{R}: Flaring Flame-Kin gets +1/+0 until end of turn.\"",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "1a63f041-c541-59fb-8372-39de9c8576cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccf9c8b-8a03-4ef8-8267-af57ac35fe02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccf9c8b-8a03-4ef8-8267-af57ac35fe02.jpg?1",
             "name": "Gnat Alley Creeper",
             "text": "Gnat Alley Creeper can't be blocked by creatures with flying.",
             "colours": [
@@ -2131,7 +2131,7 @@
         },
         {
             "id": "bea68cd8-38c9-5ddf-a3eb-2a9225ec59f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2db886-d394-4a8b-8fe0-dc2613500adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2db886-d394-4a8b-8fe0-dc2613500adc.jpg?1",
             "name": "Ignorant Bliss",
             "text": "Remove all cards in your hand from the game face down. At end of turn, return those cards to your hand, then draw a card.",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "bbec0e9e-c602-5745-a669-66161459e24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c96bb-6844-4c73-8b32-099bde7bd9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c96bb-6844-4c73-8b32-099bde7bd9f1.jpg?1",
             "name": "Kill-Suit Cultist",
             "text": "Kill-Suit Cultist attacks each turn if able.\n{B}, Sacrifice Kill-Suit Cultist: The next time damage would be dealt to target creature this turn, destroy that creature instead.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "93b8a058-b34d-54a4-8a51-83d45fc503d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5dfa91-8f93-41b7-95e9-3374550f1617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5dfa91-8f93-41b7-95e9-3374550f1617.jpg?1",
             "name": "Kindle the Carnage",
             "text": "Discard a card at random. If you do, Kindle the Carnage deals damage equal to that card's converted mana cost to each creature. You may repeat this process any number of times.",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "69f467a2-40d7-5522-83f0-253221cf00bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffddd4e2-e98c-4535-bac2-0af73f1535c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffddd4e2-e98c-4535-bac2-0af73f1535c5.jpg?1",
             "name": "Ogre Gatecrasher",
             "text": "When Ogre Gatecrasher comes into play, destroy target creature with defender.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "95406662-96bb-596e-8f80-68b5516fc735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f626c70-1ede-4b00-bd95-d6ee26371131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f626c70-1ede-4b00-bd95-d6ee26371131.jpg?1",
             "name": "Psychotic Fury",
             "text": "Target multicolored creature gains double strike until end of turn.\nDraw a card.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "2ce2af55-0082-5c8c-9203-0df92ae3231f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bdc80-26e9-4119-9dda-476aac8447ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bdc80-26e9-4119-9dda-476aac8447ba.jpg?1",
             "name": "Rakdos Pit Dragon",
             "text": "{R}{R}: Rakdos Pit Dragon gains flying until end of turn.\n{R}: Rakdos Pit Dragon gets +1/+0 until end of turn.\nHellbent Rakdos Pit Dragon has double strike as long as you have no cards in hand.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "d8ac59bb-783f-563e-9811-bc7a3f48c90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e61ce3-e2cc-401c-b998-8baf8836e83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e61ce3-e2cc-401c-b998-8baf8836e83a.jpg?1",
             "name": "Sandstorm Eidolon",
             "text": "{R}, Sacrifice Sandstorm Eidolon: Target creature can't block this turn.\nWhenever you play a multicolored spell, you may return Sandstorm Eidolon from your graveyard to your hand.",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "d5923e41-af43-565c-a25e-94bcd6d47b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff3740-93e2-454a-8e6b-e29d0c9d0fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff3740-93e2-454a-8e6b-e29d0c9d0fc2.jpg?1",
             "name": "Seal of Fire",
             "text": "Sacrifice Seal of Fire: Seal of Fire deals 2 damage to target creature or player.",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "27c4a221-9b1c-55c6-ae66-6066cfd6746a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b445a0e-798d-4f82-88cc-04f600d38e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b445a0e-798d-4f82-88cc-04f600d38e49.jpg?1",
             "name": "Squealing Devil",
             "text": "Fear\nWhen Squealing Devil comes into play, you may pay {X}. If you do, target creature gets +X/+0 until end of turn.\nWhen Squealing Devil comes into play, sacrifice it unless {B} was spent to play it.",
             "colours": [
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "717c72e3-4265-5452-9d4e-53da2bad7b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3585709-db2b-4f0a-98a4-4a07c6467ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3585709-db2b-4f0a-98a4-4a07c6467ca3.jpg?1",
             "name": "Stalking Vengeance",
             "text": "Haste\nWhenever another creature you control is put into a graveyard from play, it deals damage equal to its power to target player.",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "d2f7848b-457c-579c-a450-6065661a74a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dbd0ef-9888-4489-ba4a-65128308fb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dbd0ef-9888-4489-ba4a-65128308fb11.jpg?1",
             "name": "Stormscale Anarch",
             "text": "{2}{R}, Discard a card at random: Stormscale Anarch deals 2 damage to target creature or player. If the discarded card was multicolored, Stormscale Anarch deals 4 damage to that creature or player instead.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "02a83f27-30bb-5ff6-ba02-757c6790c210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fbb2eb-5738-46e5-a0a6-8ee98c7c8cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fbb2eb-5738-46e5-a0a6-8ee98c7c8cfb.jpg?1",
             "name": "Taste for Mayhem",
             "text": "Enchant creature\nEnchanted creature gets +2/+0.\nHellbent Enchanted creature gets an additional +2/+0 as long as you have no cards in hand.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "cf26d591-9ea1-5efd-98dc-84db9de8a114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0a5aa2-f33a-4976-88b1-f424243016da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0a5aa2-f33a-4976-88b1-f424243016da.jpg?1",
             "name": "Utvara Scalper",
             "text": "Flying\nUtvara Scalper attacks each turn if able.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "93bd4948-5cca-5910-981a-31ce51481ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5f6c39-55eb-4d8d-83cf-94652b07bc46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5f6c39-55eb-4d8d-83cf-94652b07bc46.jpg?1",
             "name": "War's Toll",
             "text": "Whenever an opponent taps a land for mana, tap all lands that player controls.\nIf a creature an opponent controls attacks, all creatures that opponent controls attack if able.",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "8f47eedc-cfcb-5b65-b166-b75dc525292e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f26a87-4562-450c-800b-7d4acc1ae17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f26a87-4562-450c-800b-7d4acc1ae17b.jpg?1",
             "name": "Weight of Spires",
             "text": "Weight of Spires deals damage to target creature equal to the number of nonbasic lands that creature's controller controls.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "99570474-c065-521b-920e-e4c13bf06c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd8e674-49be-47b7-910d-736c9acfa916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd8e674-49be-47b7-910d-736c9acfa916.jpg?1",
             "name": "Whiptail Moloch",
             "text": "When Whiptail Moloch comes into play, it deals 3 damage to target creature you control.",
             "colours": [
@@ -2669,7 +2669,7 @@
         },
         {
             "id": "59b15f26-5e8e-56b9-965e-df35364c3c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bec131-e34e-473b-8792-1a8d53a03fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bec131-e34e-473b-8792-1a8d53a03fa6.jpg?1",
             "name": "Aquastrand Spider",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it can block as though it had flying this turn.",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "4f3bd17e-9972-504d-a0f1-57ce8fa796f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83483c-95d0-4db8-b4d4-c6db400ebc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83483c-95d0-4db8-b4d4-c6db400ebc97.jpg?1",
             "name": "Cytoplast Root-Kin",
             "text": "Graft 4 (This creature comes into play with four +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\nWhen Cytoplast Root-Kin comes into play, put a +1/+1 counter on each other creature you control that has a +1/+1 counter on it.\n{2}: Move a +1/+1 counter from target creature you control onto Cytoplast Root-Kin.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "c68ae8f1-235b-5d96-80c0-8b229439e69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c87c15-742b-47fb-9d4c-0a985cc1e15a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c87c15-742b-47fb-9d4c-0a985cc1e15a.jpg?1",
             "name": "Cytospawn Shambler",
             "text": "Graft 6 (This creature comes into play with six +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it gains trample until end of turn.",
             "colours": [
@@ -2774,7 +2774,7 @@
         },
         {
             "id": "47308a89-09aa-5dd1-9cfe-a1db3a7deeaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757631a-c505-4a16-94c1-8bb609ce7bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757631a-c505-4a16-94c1-8bb609ce7bc5.jpg?1",
             "name": "Elemental Resonance",
             "text": "Enchant permanent\nAt the beginning of your precombat main phase, add mana equal to enchanted permanent's mana cost to your mana pool. (Mana cost includes color. If a mana symbol has multiple colors, choose one.)",
             "colours": [
@@ -2808,7 +2808,7 @@
         },
         {
             "id": "12ed5514-b5db-5248-b7b4-c70bb733e165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c879af-a092-4cc4-a53d-760553d94864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c879af-a092-4cc4-a53d-760553d94864.jpg?1",
             "name": "Fertile Imagination",
             "text": "Choose a card type. Target opponent reveals his or her hand. Put two 1/1 green Saproling creature tokens into play for each card of the chosen type revealed this way. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "5e8de53e-216b-5b13-aa1a-51959d58b135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c63da-dfe3-475f-88d9-20008c01163a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c63da-dfe3-475f-88d9-20008c01163a.jpg?1",
             "name": "Flash Foliage",
             "text": "Put a 1/1 green Saproling creature token into play blocking target creature attacking you.\nDraw a card.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "7ca3703d-370c-5e49-9840-004b9fcdf76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe57b3a2-0fd9-4f99-bb2b-828979dbcfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe57b3a2-0fd9-4f99-bb2b-828979dbcfc3.jpg?1",
             "name": "Indrik Stomphowler",
             "text": "When Indrik Stomphowler comes into play, destroy target artifact or enchantment.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "d882959c-5eed-51aa-a130-3e8de6a38e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34b3f97-1c00-4ad2-a28d-6f064f499761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34b3f97-1c00-4ad2-a28d-6f064f499761.jpg?1",
             "name": "Loaming Shaman",
             "text": "When Loaming Shaman comes into play, target player shuffles any number of target cards from his or her graveyard into his or her library.",
             "colours": [
@@ -2941,7 +2941,7 @@
         },
         {
             "id": "543a292b-fc6f-52b1-b364-1fcdf8e1f43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5c4a29-0650-4b9e-af6b-39bee19167ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5c4a29-0650-4b9e-af6b-39bee19167ad.jpg?1",
             "name": "Might of the Nephilim",
             "text": "Target creature gets +2/+2 until end of turn for each of its colors.",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "72d3328a-fe45-5bc7-a65f-1daa7962feab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78031831-f773-489f-b1c2-c8f5537f2286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78031831-f773-489f-b1c2-c8f5537f2286.jpg?1",
             "name": "Patagia Viper",
             "text": "Flying\nWhen Patagia Viper comes into play, put two 1/1 green and blue Snake creature tokens into play.\nWhen Patagia Viper comes into play, sacrifice it unless {U} was spent to play it.",
             "colours": [
@@ -3008,7 +3008,7 @@
         },
         {
             "id": "80665f2a-2b0d-588b-9a98-01879cffbc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d978332-95bf-4f86-9e67-06f10983c267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d978332-95bf-4f86-9e67-06f10983c267.jpg?1",
             "name": "Protean Hulk",
             "text": "When Protean Hulk is put into a graveyard from play, search your library for any number of creature cards with total converted mana cost 6 or less and put them into play. Then shuffle your library.",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "74d781f1-bc45-5709-ab68-4f742b57ddc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e7af53-62d8-45b8-829f-c575dda53e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e7af53-62d8-45b8-829f-c575dda53e25.jpg?1",
             "name": "Simic Basilisk",
             "text": "Graft 3 (This creature comes into play with three +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}{G}: Until end of turn, target creature with a +1/+1 counter on it gains \"Whenever this creature deals combat damage to a creature, destroy that creature at end of combat.\"",
             "colours": [
@@ -3077,7 +3077,7 @@
         },
         {
             "id": "cdd52f1c-88e0-517e-81cb-117039aa85c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6602c592-3cde-4e73-919c-1d3f3df22092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6602c592-3cde-4e73-919c-1d3f3df22092.jpg?1",
             "name": "Simic Initiate",
             "text": "Graft 1 (This creature comes into play with a +1/+1 counter on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "a8bdafa1-13d7-5625-bb2e-7e4049302661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1f4b84-dd5d-4f5f-808e-26ef9414b38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1f4b84-dd5d-4f5f-808e-26ef9414b38a.jpg?1",
             "name": "Simic Ragworm",
             "text": "{U}: Untap Simic Ragworm.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "77b70826-c346-547d-ad0c-4a154c1aa078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bdca24-3beb-4d0d-b3bc-b98c23316fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bdca24-3beb-4d0d-b3bc-b98c23316fe7.jpg?1",
             "name": "Sporeback Troll",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}{G}: Regenerate target creature with a +1/+1 counter on it.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "73255f78-5697-5f7a-b9b3-c25667c4a778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a478eaa-2658-49db-965f-db25fc1d720e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a478eaa-2658-49db-965f-db25fc1d720e.jpg?1",
             "name": "Sprouting Phytohydra",
             "text": "Defender (This creature can't attack.)\nWhenever Sprouting Phytohydra is dealt damage, you may put a token into play that's a copy of Sprouting Phytohydra.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "9fafcd27-14f0-5186-823a-177bd39858be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be523140-7c68-4231-a692-7b3af417d858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be523140-7c68-4231-a692-7b3af417d858.jpg?1",
             "name": "Stomp and Howl",
             "text": "Destroy target artifact and target enchantment.",
             "colours": [
@@ -3249,7 +3249,7 @@
         },
         {
             "id": "ba755f23-218e-538c-a6fb-778f4cf73271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5b4fc-e1de-4520-9524-f9c4aa89b252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5b4fc-e1de-4520-9524-f9c4aa89b252.jpg?1",
             "name": "Street Savvy",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and can block creatures with landwalk abilities as though they didn't have those abilities.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "1912983b-4be5-54e6-a56a-139d1bd73fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce041c2-5a63-4007-a0fa-f0a6f4b39c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce041c2-5a63-4007-a0fa-f0a6f4b39c16.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "29e6576c-936e-5631-96c3-33d8f830629d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5047e271-fbf1-402c-9eb9-0806e5988f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5047e271-fbf1-402c-9eb9-0806e5988f76.jpg?1",
             "name": "Utopia Sprawl",
             "text": "Enchant Forest\nAs Utopia Sprawl comes into play, choose a color.\nWhenever enchanted Forest is tapped for mana, its controller adds one mana of the chosen color to his or her mana pool.",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "12589186-2b33-5a94-9178-379535d4f806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8120d141-2759-49d4-bed9-e20617a0b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8120d141-2759-49d4-bed9-e20617a0b009.jpg?1",
             "name": "Verdant Eidolon",
             "text": "{G}, Sacrifice Verdant Eidolon: Add three mana of any one color to your mana pool.\nWhenever you play a multicolored spell, you may return Verdant Eidolon from your graveyard to your hand.",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "5c85f117-628a-55a6-bee0-c4ccaf1170c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5debdea2-538f-405b-87b0-3789dba95e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5debdea2-538f-405b-87b0-3789dba95e8e.jpg?1",
             "name": "Aethermage's Touch",
             "text": "Reveal the top four cards of your library. You may put a creature card from among them into play with \"At the end of your turn, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "94c46b30-3147-557b-acf4-b7b8d7cde50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea00d757-0ea9-4123-89f6-0a437d7fd33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea00d757-0ea9-4123-89f6-0a437d7fd33d.jpg?1",
             "name": "Anthem of Rakdos",
             "text": "Whenever a creature you control attacks, it gets +2/+0 until end of turn and Anthem of Rakdos deals 1 damage to you.\nHellbent As long as you have no cards in hand, if a source you control would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "f15dee97-e4a0-5c08-89b8-c837c72079d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6443-c941-418a-a766-05bba088a117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6443-c941-418a-a766-05bba088a117.jpg?1",
             "name": "Assault Zeppelid",
             "text": "Flying, trample",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "cbc05314-bd4b-5d9e-b787-7c9793f20d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b640ff8-8baa-4069-b5a9-8a4fb22a056e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b640ff8-8baa-4069-b5a9-8a4fb22a056e.jpg?1",
             "name": "Azorius Aethermage",
             "text": "Whenever a permanent is returned to your hand, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "b463a2aa-5616-5f86-b6ee-c787e02c9c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675c1e6-add5-4959-a5be-f2571ccebcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675c1e6-add5-4959-a5be-f2571ccebcb4.jpg?1",
             "name": "Azorius First-Wing",
             "text": "Flying, protection from enchantments",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "51175d7b-537c-5047-9a57-be6febd005c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763f2c68-77a9-43e9-8f9b-2f318afcd686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763f2c68-77a9-43e9-8f9b-2f318afcd686.jpg?1",
             "name": "Azorius Ploy",
             "text": "Prevent all combat damage target creature would deal this turn.\nPrevent all combat damage that would be dealt to target creature this turn.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "cb17d663-dc0a-55dc-b72a-065dcb1a88b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a6ba2a-b372-4b15-9a1e-09b41316eab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a6ba2a-b372-4b15-9a1e-09b41316eab7.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle comes into play, reveal the top card of your library. If it's a land card, put it into play. Otherwise, put that card into your hand.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "180bad9b-1a4b-5cc4-acc3-bc18609b3c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758023cb-548a-4a98-a355-f5c6e9eab5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758023cb-548a-4a98-a355-f5c6e9eab5ff.jpg?1",
             "name": "Cytoshape",
             "text": "Choose a nonlegendary creature in play. Target creature becomes a copy of that creature until end of turn.",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "7bbedeff-fd83-5568-a8fd-817f739975b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cdad60-3a73-49ac-bbbd-679254b6ba9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cdad60-3a73-49ac-bbbd-679254b6ba9e.jpg?1",
             "name": "Dread Slag",
             "text": "Trample\nDread Slag gets -4/-4 for each card in your hand.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "4e093663-4be6-5948-9812-f3ad079e4d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f42a1-0996-4799-ad3a-9525c8e31343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f42a1-0996-4799-ad3a-9525c8e31343.jpg?1",
             "name": "Experiment Kraj",
             "text": "Experiment Kraj has all activated abilities of each other creature with a +1/+1 counter on it.\n{T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "90ade948-99e0-57c0-a084-3c19a7843b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae123ca6-2b96-4bbe-82b2-0be294edff80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae123ca6-2b96-4bbe-82b2-0be294edff80.jpg?1",
             "name": "Gobhobbler Rats",
             "text": "Hellbent Gobhobbler Rats gets +1/+0 and has \"{B}: Regenerate Gobhobbler Rats\" as long as you have no cards in hand.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "ba510206-0770-5515-8a74-f2efc3e6d435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ac328b-923f-48dd-a4f5-de389ade9125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ac328b-923f-48dd-a4f5-de389ade9125.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you play cost {1} less to play.\nBlue spells you play cost {1} less to play.\nSpells your opponents play cost {1} more to play.",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "bdac6ff0-ff85-54b1-94d4-e9df619b1817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eb937-21d4-44b1-85e7-b95995865f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eb937-21d4-44b1-85e7-b95995865f44.jpg?1",
             "name": "Hellhole Rats",
             "text": "Haste\nWhen Hellhole Rats comes into play, target player discards a card. Hellhole Rats deals damage to that player equal to that card's converted mana cost.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "88892ec6-6a6c-5c5d-9e96-e376ec329016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b365b0-6949-41d2-be60-eb2162b1f882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b365b0-6949-41d2-be60-eb2162b1f882.jpg?1",
             "name": "Isperia the Inscrutable",
             "text": "Flying\nWhenever Isperia the Inscrutable deals combat damage to a player, name a card. That player reveals his or her hand. If he or she reveals the named card, search your library for a creature card with flying, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "6081e956-5b9e-580c-99ce-2097947fa056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796a838-3599-4769-b90b-9bbbaad76fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796a838-3599-4769-b90b-9bbbaad76fcb.jpg?1",
             "name": "Jagged Poppet",
             "text": "Whenever Jagged Poppet is dealt damage, discard that many cards.\nHellbent Whenever Jagged Poppet deals combat damage to a player, if you have no cards in hand, that player discards cards equal to the damage.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "d9bc4ae8-5dd2-52b7-b92f-b41b697a05fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9cb544-fa42-4671-917d-e08c582f7657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9cb544-fa42-4671-917d-e08c582f7657.jpg?1",
             "name": "Leafdrake Roost",
             "text": "Enchant land\nEnchanted land has \"{G}{U}, {T}: Put a 2/2 green and blue Drake creature token with flying into play.\"",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "8ec2bbc8-15e2-5571-b0dc-396cf26abea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18df285f-4cb9-4998-bd26-eefbe28f80c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18df285f-4cb9-4998-bd26-eefbe28f80c7.jpg?1",
             "name": "Lyzolda, the Blood Witch",
             "text": "{2}, Sacrifice a creature: Lyzolda, the Blood Witch deals 2 damage to target creature or player if the sacrificed creature was red. Draw a card if the sacrificed creature was black.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "eb690538-0945-5fd9-a83d-7a9eb97bd752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a8c801-df0c-402b-a41c-4703a2abfb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a8c801-df0c-402b-a41c-4703a2abfb66.jpg?1",
             "name": "Momir Vig, Simic Visionary",
             "text": "Whenever you play a green creature spell, you may search your library for a creature card and reveal it. If you do, shuffle your library and put that card on top of it.\nWhenever you play a blue creature spell, reveal the top card of your library. If it's a creature card, put that card into your hand.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "f7b2e2db-5571-5555-8623-c4d9c021db5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a5a212-395c-427e-81b8-893745274068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a5a212-395c-427e-81b8-893745274068.jpg?1",
             "name": "Omnibian",
             "text": "{T}: Target creature becomes a 3/3 Frog until end of turn.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "b7fc625a-8593-55c6-ab7a-1675a2b33d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b83a31-f974-4a49-b9ee-92f7767f11e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b83a31-f974-4a49-b9ee-92f7767f11e0.jpg?1",
             "name": "Overrule",
             "text": "Counter target spell unless its controller pays {X}. You gain X life.",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "4599df76-1112-5122-8244-4c7ce7c82c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844801e4-cf37-4f20-9149-b58a57b9276e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844801e4-cf37-4f20-9149-b58a57b9276e.jpg?1",
             "name": "Pain Magnification",
             "text": "Whenever an opponent is dealt 3 or more damage by a single source, that player discards a card.",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "7e4c2c57-9ea0-5e3e-8b8c-18b49d73cf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda10c3b-ee16-4de5-9e54-d0187cd5cc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda10c3b-ee16-4de5-9e54-d0187cd5cc80.jpg?1",
             "name": "Palliation Accord",
             "text": "Whenever a creature an opponent controls becomes tapped, put a shield counter on Palliation Accord.\nRemove a shield counter from Palliation Accord: Prevent the next 1 damage that would be dealt to you this turn.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "609b9ef8-5b71-59fe-a9a5-902674dc7b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bb1946-8057-4a31-9de7-4bd1a9845165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bb1946-8057-4a31-9de7-4bd1a9845165.jpg?1",
             "name": "Plaxcaster Frogling",
             "text": "Graft 3 (This creature comes into play with three +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{2}: Target creature with a +1/+1 counter on it can't be the target of spells or abilities this turn.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "40be2025-3dd6-5bb8-882e-aa2bdcbf295a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02dcf40-03ad-463c-a14a-5dfc886dea4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02dcf40-03ad-463c-a14a-5dfc886dea4c.jpg?1",
             "name": "Plumes of Peace",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nForecast {W}{U}, Reveal Plumes of Peace from your hand: Tap target creature. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "5543fbfa-20c0-5633-8767-411c34a43b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a029-6e64-4b6d-9d82-afc319dbc57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a029-6e64-4b6d-9d82-afc319dbc57a.jpg?1",
             "name": "Pride of the Clouds",
             "text": "Flying\nPride of the Clouds gets +1/+1 for each other creature in play with flying.\nForecast {2}{W}{U}, Reveal Pride of the Clouds from your hand: Put a 1/1 white and blue Bird creature token with flying into play. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "b6f39f92-1987-54de-bfe2-351ed3ebac39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd62003-e345-48b6-9f93-fc111924c318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd62003-e345-48b6-9f93-fc111924c318.jpg?1",
             "name": "Rain of Gore",
             "text": "If a spell or ability would cause its controller to gain life, that player loses that much life instead.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "acd8bebf-9f3d-56b4-94dc-7efd64717bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5507ec6-430e-41bf-8ac8-42a79f11012d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5507ec6-430e-41bf-8ac8-42a79f11012d.jpg?1",
             "name": "Rakdos Augermage",
             "text": "First strike\n{T}: Reveal your hand and discard a card of target opponent's choice. Then that player reveals his or her hand and discards a card of your choice. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "05ffd5d6-0422-5e9b-ab45-b8b9aadc6cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c007b10b-2701-4bac-8b95-8fc7dcfb9e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c007b10b-2701-4bac-8b95-8fc7dcfb9e21.jpg?1",
             "name": "Rakdos Ickspitter",
             "text": "{T}: Rakdos Ickspitter deals 1 damage to target creature and that creature's controller loses 1 life.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "ef13020e-203b-5ae3-9423-fd70c1a693d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c4be4-06ae-4737-a3b0-818edadaf2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c4be4-06ae-4737-a3b0-818edadaf2e0.jpg?1",
             "name": "Rakdos the Defiler",
             "text": "Flying, trample\nWhenever Rakdos the Defiler attacks, sacrifice half the non-Demon permanents you control, rounded up.\nWhenever Rakdos deals combat damage to a player, that player sacrifices half the non-Demon permanents he or she controls, rounded up.",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "da6b2342-b9e1-50f5-8c84-17bcad9cf833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f625b270-f560-402b-b253-51951822ce42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f625b270-f560-402b-b253-51951822ce42.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nSimic Sky Swallower can't be the target of spells or abilities.",
             "colours": [
@@ -4470,7 +4470,7 @@
         },
         {
             "id": "8227868c-ce2c-5cb7-8259-fb74b9fc1b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a795ea0-5a8f-4dc2-863b-d3c00844d873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a795ea0-5a8f-4dc2-863b-d3c00844d873.jpg?1",
             "name": "Sky Hussar",
             "text": "Flying\nWhen Sky Hussar comes into play, untap all creatures you control.\nForecast Tap two untapped white and/or blue creatures you control, Reveal Sky Hussar from your hand: Draw a card. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "e31e7181-db17-5323-b92b-c1a6d284c2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c5f733-e126-4c22-b528-18bdb90b509b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c5f733-e126-4c22-b528-18bdb90b509b.jpg?1",
             "name": "Swift Silence",
             "text": "Counter all other spells. Draw a card for each spell countered this way.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "e09d70dc-409f-5d98-ab87-1d212d23936e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f54bf-7bf0-48f0-853d-1468713784eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f54bf-7bf0-48f0-853d-1468713784eb.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -4577,7 +4577,7 @@
         },
         {
             "id": "c338e47f-6631-56da-9486-9afa2fa5a43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfc8ebe-58f4-450f-abdc-8d558f6f5551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfc8ebe-58f4-450f-abdc-8d558f6f5551.jpg?1",
             "name": "Twinstrike",
             "text": "Twinstrike deals 2 damage to each of two target creatures.\nHellbent Destroy those creatures instead if you have no cards in hand.",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "c728b57f-005e-5bf5-872a-e01310ba3eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6373aedc-4385-4608-bfbc-1937d6528d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6373aedc-4385-4608-bfbc-1937d6528d28.jpg?1",
             "name": "Vigean Hydropon",
             "text": "Graft 5 (This creature comes into play with five +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\nVigean Hydropon can't attack or block.",
             "colours": [
@@ -4648,7 +4648,7 @@
         },
         {
             "id": "5bd6fbb0-046c-5f1c-8548-7b3cc6b8e182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be493737-0457-447b-802b-043d7a77f389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be493737-0457-447b-802b-043d7a77f389.jpg?1",
             "name": "Vigean Intuition",
             "text": "Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "dbf7493e-b804-5d92-b7fd-ef7a7d56efcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97121d5a-18ab-47cd-808f-562cd865955a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97121d5a-18ab-47cd-808f-562cd865955a.jpg?1",
             "name": "Voidslime",
             "text": "Counter target spell, activated ability, or triggered ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "0c329198-bbe5-5c1d-9556-4eee579603f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af5727-5348-4e2e-8a00-10f6983edce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af5727-5348-4e2e-8a00-10f6983edce8.jpg?1",
             "name": "Windreaver",
             "text": "Flying\n{W}: Windreaver gains vigilance until end of turn.\n{W}: Windreaver gets +0/+1 until end of turn.\n{U}: Switch Windreaver's power and toughness until end of turn.\n{U}: Return Windreaver to its owner's hand.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "2c1348bc-e003-5f0b-8400-f5db11cee56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1182e0cf-475e-4cb9-a00a-c9a4032f51e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1182e0cf-475e-4cb9-a00a-c9a4032f51e4.jpg?1",
             "name": "Wrecking Ball",
             "text": "Destroy target creature or land.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "8036c0cd-686f-58b3-9721-e1ba29db0a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06824d21-600b-44cd-8b51-0d8379cb0b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06824d21-600b-44cd-8b51-0d8379cb0b47.jpg?1",
             "name": "Avatar of Discord",
             "text": "({BR} can be paid with either {B} or {R}.)\nFlying\nWhen Avatar of Discord comes into play, sacrifice it unless you discard two cards.",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "34293e7c-7974-56ef-ad2d-29583740bc8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0f0ce-7c23-444c-9d9f-bfa9c8705fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0f0ce-7c23-444c-9d9f-bfa9c8705fd5.jpg?1",
             "name": "Azorius Guildmage",
             "text": "({WU} can be paid with either {W} or {U}.)\n{2}{W}: Tap target creature.\n{2}{U}: Counter target activated ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "964eb375-3ad8-5c76-9fc2-5a09d40efc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feb398e-069a-4c30-884c-67292a56ca45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feb398e-069a-4c30-884c-67292a56ca45.jpg?1",
             "name": "Biomantic Mastery",
             "text": "({GW} can be paid with either {G} or {U}.)\nDraw a card for each creature target player controls, then draw a card for each creature another target player controls.",
             "colours": [
@@ -4893,7 +4893,7 @@
         },
         {
             "id": "be2dc7b0-d699-5be4-ae98-043270fa9cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e3d6e6-ac17-4d73-acac-089442de4af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e3d6e6-ac17-4d73-acac-089442de4af6.jpg?1",
             "name": "Dovescape",
             "text": "({WU} can be paid with either {W} or {U}.)\nWhenever a player plays a noncreature spell, counter that spell. That player puts X 1/1 white and blue Bird creature tokens with flying into play, where X is the spell's converted mana cost.",
             "colours": [
@@ -4927,7 +4927,7 @@
         },
         {
             "id": "c9954033-44cc-537f-b1de-5ce608caf523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aada87-a880-4d33-8694-9fbc74211755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aada87-a880-4d33-8694-9fbc74211755.jpg?1",
             "name": "Minister of Impediments",
             "text": "({WU} can be paid with either {W} or {U}.)\n{T}: Tap target creature.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "1970dc14-7156-5e41-b66f-ed277ed56dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e01fef8-5563-4dec-ab8e-e486e19e202c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e01fef8-5563-4dec-ab8e-e486e19e202c.jpg?1",
             "name": "Rakdos Guildmage",
             "text": "({BR} can be paid with either {B} or {R}.)\n{3}{B}, Discard a card: Target creature gets -2/-2 until end of turn.\n{3}{R}: Put a 2/1 red Goblin creature token with haste into play. Remove it from the game at end of turn.",
             "colours": [
@@ -5001,7 +5001,7 @@
         },
         {
             "id": "46705f3c-34a1-58fa-92b5-f2220023820c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f909-9906-4ff7-9b10-9d817f20d8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f909-9906-4ff7-9b10-9d817f20d8a9.jpg?1",
             "name": "Riot Spikes",
             "text": "({BR} can be paid with either {B} or {R}.)\nEnchant creature\nEnchanted creature gets +2/-1.",
             "colours": [
@@ -5037,7 +5037,7 @@
         },
         {
             "id": "7c5905c3-2bbe-5478-9e11-ec12210988ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2f90be-e76c-4e74-898e-d2848e345599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2f90be-e76c-4e74-898e-d2848e345599.jpg?1",
             "name": "Shielding Plax",
             "text": "({GW} can be paid with either {G} or {U}.)\nEnchant creature\nWhen Shielding Plax comes into play, draw a card.\nEnchanted creature can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "ff614e7f-f896-577d-976c-4553a444517c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77d4ffb-a829-49ca-9c37-c60ba467852c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77d4ffb-a829-49ca-9c37-c60ba467852c.jpg?1",
             "name": "Simic Guildmage",
             "text": "({GW} can be paid with either {G} or {U}.)\n{1}{G}: Move a +1/+1 counter from target creature onto another target creature with the same controller.\n{1}{U}: Attach target Aura enchanting a permanent to another permanent with the same controller.",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "3c6f89e6-cc4a-5340-9fed-f5d23e798d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg?1",
             "name": "Bound // Determined",
             "text": "Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was. Then remove this card from the game.",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "eca14704-9044-5e15-bb68-01a433f65bad",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg?1",
             "name": "Bound // Determined",
             "text": "Other spells you control can't be countered by spells or abilities this turn.\nDraw a card.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "54a0d6ee-191a-52b0-aab9-bdf0945eafe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg?1",
             "name": "Crime // Punishment",
             "text": "Put target creature or enchantment card in an opponent's graveyard into play under your control.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "64d4699a-aaa8-5503-8f5c-dfb312ed4f37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg?1",
             "name": "Crime // Punishment",
             "text": "Destroy each artifact, creature, and enchantment with converted mana cost X.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "4c3f9a88-f6df-5d9a-83cc-20c7366356f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg?1",
             "name": "Hide // Seek",
             "text": "Put target artifact or enchantment on the bottom of its owner's library.",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "64a5acc6-f96a-5178-bfe9-97c791a7e6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg?1",
             "name": "Hide // Seek",
             "text": "Search target opponent's library for a card and remove that card from the game. You gain life equal to its converted mana cost. Then that player shuffles his or her library.",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "c8179183-e9d1-5532-b920-1a6ffd822736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg?1",
             "name": "Hit // Run",
             "text": "Target player sacrifices an artifact or creature. Hit deals damage to that player equal to that permanent's converted mana cost.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "ae71a824-bd09-5c14-b60e-9279b2578d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg?1",
             "name": "Hit // Run",
             "text": "Attacking creatures you control get +1/+0 until end of turn for each other attacking creature.",
             "colours": [
@@ -5390,7 +5390,7 @@
         },
         {
             "id": "8627334a-4c13-5373-a44f-68ab068c4807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg?1",
             "name": "Odds // Ends",
             "text": "Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy.",
             "colours": [
@@ -5425,7 +5425,7 @@
         },
         {
             "id": "a3edef48-0c50-56cb-a287-01b4bf7e3897",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg?1",
             "name": "Odds // Ends",
             "text": "Target player sacrifices two attacking creatures.",
             "colours": [
@@ -5460,7 +5460,7 @@
         },
         {
             "id": "e4c0da91-2ee6-51fb-90d9-d4dba59d03dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg?1",
             "name": "Pure // Simple",
             "text": "Destroy target multicolored permanent.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "66069159-702f-52e9-8d94-d71f193d52a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg?1",
             "name": "Pure // Simple",
             "text": "Destroy all Auras and Equipment.",
             "colours": [
@@ -5530,7 +5530,7 @@
         },
         {
             "id": "c46d48b7-b4d1-5347-9ef4-561c0e3a0645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg?1",
             "name": "Research // Development",
             "text": "Choose up to four cards you own from outside the game and shuffle them into your library.",
             "colours": [
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "b5160299-e1b9-52e4-b52e-ed53bf996067",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg?1",
             "name": "Research // Development",
             "text": "Put a 3/1 red Elemental creature token into play unless an opponent lets you draw a card. Repeat this process two more times.",
             "colours": [
@@ -5600,7 +5600,7 @@
         },
         {
             "id": "a5d77fcb-9642-5c00-b13e-6f447f1a2400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg?1",
             "name": "Rise // Fall",
             "text": "Return target creature card in a graveyard and target creature in play to their owners' hands.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "681fbbc6-2aa8-54a6-a902-5ef1ef5e780a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg?1",
             "name": "Rise // Fall",
             "text": "Target player reveals two cards at random from his or her hand, then discards each nonland card revealed this way.",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "20fcadf6-c98d-5580-af3f-94b1f9e4f01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg?1",
             "name": "Supply // Demand",
             "text": "Put X 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -5705,7 +5705,7 @@
         },
         {
             "id": "59ac62e1-c8cc-5d49-a691-2d4d65ad8832",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg?1",
             "name": "Supply // Demand",
             "text": "Search your library for a multicolored card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "149ef71c-0de7-5f02-98d9-e129a24ac2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg?1",
             "name": "Trial // Error",
             "text": "Return all creatures blocking or blocked by target creature to their owner's hand.",
             "colours": [
@@ -5775,7 +5775,7 @@
         },
         {
             "id": "b8ba11ab-65d5-5514-a707-6a3ea51ca980",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg?1",
             "name": "Trial // Error",
             "text": "Counter target multicolored spell.",
             "colours": [
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "6d772ea4-e180-52a8-8a90-59a574980745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91a527d-51f1-4fb1-9016-fc923fd43a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91a527d-51f1-4fb1-9016-fc923fd43a6a.jpg?1",
             "name": "Azorius Signet",
             "text": "{1}, {T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -5841,7 +5841,7 @@
         },
         {
             "id": "12223ed8-b850-5189-8bf7-70e97a9c0f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ec20d-b862-4f13-989c-aa88efa51cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ec20d-b862-4f13-989c-aa88efa51cdf.jpg?1",
             "name": "Bronze Bombshell",
             "text": "When a player other than Bronze Bombshell's owner controls it, that player sacrifices it. If the player does, Bronze Bombshell deals 7 damage to him or her.",
             "colours": [],
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "5904a26e-8216-538c-8d9f-2825c5e767ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed874e4-87ca-41f0-af0a-a803194d78c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed874e4-87ca-41f0-af0a-a803194d78c9.jpg?1",
             "name": "Evolution Vat",
             "text": "{3}, {T}: Tap target creature and put a +1/+1 counter on it. Until end of turn, that creature gains \"{2}{G}{U}: Double the number of +1/+1 counters on this creature.\"",
             "colours": [],
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "ba358c83-f9e9-5fe1-8b25-92e9cfc81f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e8442-91ce-4106-bfc6-a1f6e0e34c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e8442-91ce-4106-bfc6-a1f6e0e34c2d.jpg?1",
             "name": "Magewright's Stone",
             "text": "{1}, {T}: Untap target creature that has an activated ability with {T} in its cost.",
             "colours": [],
@@ -5931,7 +5931,7 @@
         },
         {
             "id": "8b26b036-9d33-5a2f-9fc8-548580548e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10482209-19b1-4941-9133-f2764eeba092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10482209-19b1-4941-9133-f2764eeba092.jpg?1",
             "name": "Muse Vessel",
             "text": "{3}, {T}: Target player removes a card in his or her hand from the game. Play this ability only any time you could play a sorcery.\n{1}: Choose a card removed from the game with Muse Vessel. You may play that card this turn.",
             "colours": [],
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "72d2a9b0-df9f-59ba-b410-b4791819f09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6e10a-3df1-4c6f-bf4c-d4a2a0467c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6e10a-3df1-4c6f-bf4c-d4a2a0467c60.jpg?1",
             "name": "Rakdos Riteknife",
             "text": "Equipped creature gets +1/+0 for each blood counter on Rakdos Riteknife and has \"{T}, Sacrifice a creature: Put a blood counter on Rakdos Riteknife.\"\n{B}{R}, Sacrifice Rakdos Riteknife: Target player sacrifices a permanent for each blood counter on Rakdos Riteknife.\nEquip {2}",
             "colours": [],
@@ -5992,7 +5992,7 @@
         },
         {
             "id": "666410cb-14db-5758-b265-0cf0e1f6cdb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a3f95c-5a05-46ea-8dc6-b77b59324035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a3f95c-5a05-46ea-8dc6-b77b59324035.jpg?1",
             "name": "Rakdos Signet",
             "text": "{1}, {T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "1a35310d-953d-511b-8801-135290477a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90107d10-e2aa-4cb7-a000-039f0c581b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90107d10-e2aa-4cb7-a000-039f0c581b47.jpg?1",
             "name": "Simic Signet",
             "text": "{1}, {T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "cefc3f86-234e-5463-abee-b5941de33164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8567c5-d068-42bb-a593-3849e65e29c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8567c5-d068-42bb-a593-3849e65e29c0.jpg?1",
             "name": "Skullmead Cauldron",
             "text": "{T}: You gain 1 life.\n{T}, Discard a card: You gain 3 life.",
             "colours": [],
@@ -6082,7 +6082,7 @@
         },
         {
             "id": "6ed8ddf5-f3ff-5249-9752-bcc116c8266e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449a9db4-f219-4a6a-b9a3-3dd3edec2a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449a9db4-f219-4a6a-b9a3-3dd3edec2a16.jpg?1",
             "name": "Transguild Courier",
             "text": "Transguild Courier is all colors (even if this card isn't in play).",
             "colours": [
@@ -6125,7 +6125,7 @@
         },
         {
             "id": "03573100-489d-5b02-8daf-2f5c25079159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c390e074-bd30-4564-a39a-176af7df79f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c390e074-bd30-4564-a39a-176af7df79f4.jpg?1",
             "name": "Walking Archive",
             "text": "Defender (This creature can't attack.)\nWalking Archive comes into play with a +1/+1 counter on it.\nAt the beginning of each player's upkeep, that player draws a card for each +1/+1 counter on Walking Archive.\n{2}{W}{U}: Put a +1/+1 counter on Walking Archive.",
             "colours": [],
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "5e69a6ae-f9ca-5bf7-94a8-e582f7d2dda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58365d2-e4db-444b-b1a9-795668ad3038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58365d2-e4db-444b-b1a9-795668ad3038.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery comes into play tapped.\nWhen Azorius Chancery comes into play, return a land you control to its owner's hand.\n{T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "c5867684-80f1-54b5-936e-e6a964176b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f281e16f-0fe1-4095-bd63-0a4479f75c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f281e16f-0fe1-4095-bd63-0a4479f75c11.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R} to your mana pool.)\nAs Blood Crypt comes into play, you may pay 2 life. If you don't, Blood Crypt comes into play tapped instead.",
             "colours": [],
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "27f5c620-9b05-5973-ba56-41a350eaad9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98b2a35-ec2b-47fe-903d-dd292e469a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98b2a35-ec2b-47fe-903d-dd292e469a3c.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U} to your mana pool.)\nAs Breeding Pool comes into play, you may pay 2 life. If you don't, Breeding Pool comes into play tapped instead.",
             "colours": [],
@@ -6258,7 +6258,7 @@
         },
         {
             "id": "170eacc5-6cdd-5635-a1ce-d1c3050c6ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893eb7e4-5d8d-477b-aaa7-fb85ef2a54fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893eb7e4-5d8d-477b-aaa7-fb85ef2a54fc.jpg?1",
             "name": "Ghost Quarter",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it into play, then shuffle his or her library.",
             "colours": [],
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "ca2170eb-1906-5bf6-8641-3202f6b9cddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28aea19-2a39-4934-afda-909e234fa3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28aea19-2a39-4934-afda-909e234fa3ba.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U} to your mana pool.)\nAs Hallowed Fountain comes into play, you may pay 2 life. If you don't, Hallowed Fountain comes into play tapped instead.",
             "colours": [],
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "74313a58-fb5b-5b9c-a252-c7fda27dc4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed595b59-b5c7-4335-a3c4-1c24c5a9cba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed595b59-b5c7-4335-a3c4-1c24c5a9cba2.jpg?1",
             "name": "Novijen, Heart of Progress",
             "text": "{T}: Add {1} to your mana pool.\n{G}{U}, {T}: Put a +1/+1 counter on each creature that came into play this turn.",
             "colours": [],
@@ -6351,7 +6351,7 @@
         },
         {
             "id": "228cac8b-0f8c-54ab-b50d-b1dba428cb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dcb39-b81e-4ae2-b153-01be0577ed93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dcb39-b81e-4ae2-b153-01be0577ed93.jpg?1",
             "name": "Pillar of the Paruns",
             "text": "{T}: Add one mana of any color to your mana pool. Spend this mana only to play a multicolored spell.",
             "colours": [],
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "bbf1cfec-7a62-5a7e-9bc4-16663da660f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a315f63-96ad-4a5f-8eb4-d81361797348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a315f63-96ad-4a5f-8eb4-d81361797348.jpg?1",
             "name": "Prahv, Spires of Order",
             "text": "{T}: Add {1} to your mana pool.\n{4}{W}{U}, {T}: Prevent all damage a source of your choice would deal this turn.",
             "colours": [],
@@ -6410,7 +6410,7 @@
         },
         {
             "id": "ae9fc745-fc05-5880-8287-d44b78a60577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f146f3-6541-4d2a-96e3-a3cd680c0a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f146f3-6541-4d2a-96e3-a3cd680c0a1e.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium comes into play tapped.\nWhen Rakdos Carnarium comes into play, return a land you control to its owner's hand.\n{T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "42e26432-0cfe-5d38-a98a-d1dcf7eadbb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f56ce7-1974-417e-a4cb-c9d9a9509039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f56ce7-1974-417e-a4cb-c9d9a9509039.jpg?1",
             "name": "Rix Maadi, Dungeon Palace",
             "text": "{T}: Add {1} to your mana pool.\n{1}{B}{R}, {T}: Each player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [],
@@ -6472,7 +6472,7 @@
         },
         {
             "id": "cdae08df-bd11-5385-bf56-1b961c8ec5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d0a0c-a6be-4bd5-8355-1715698c6bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d0a0c-a6be-4bd5-8355-1715698c6bde.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber comes into play tapped.\nWhen Simic Growth Chamber comes into play, return a land you control to its owner's hand.\n{T}: Add {G}{U} to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/DKA.json
+++ b/Assets/Resources/Sets/DKA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f432ef1a-3db0-57a9-9e18-5573df9ae065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99837b3-b487-43bb-846b-7a0e8afb6eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99837b3-b487-43bb-846b-7a0e8afb6eef.jpg?1",
             "name": "Archangel's Light",
             "text": "You gain 2 life for each card in your graveyard, then shuffle your graveyard into your library.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "3d648f9e-b244-590e-859c-8d4a76dd685c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b593f544-2d82-4237-b9a9-88503b5036cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b593f544-2d82-4237-b9a9-88503b5036cc.jpg?1",
             "name": "Bar the Door",
             "text": "Creatures you control get +0/+4 until end of turn.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "f6fa417d-da84-5125-8e74-9aa72394e5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e39da2a-814a-46bb-a1ca-fc5532ece842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e39da2a-814a-46bb-a1ca-fc5532ece842.jpg?1",
             "name": "Break of Day",
             "text": "Creatures you control get +1/+1 until end of turn.\nFateful hour \u2014 If you have 5 or less life, those creatures also are indestructible this turn. (Lethal damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -100,7 +100,7 @@
         },
         {
             "id": "8007507d-322d-5ddb-9ce4-2da1890c4658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7440288-6c55-4502-bf20-3c5b50a2de5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7440288-6c55-4502-bf20-3c5b50a2de5a.jpg?1",
             "name": "Burden of Guilt",
             "text": "Enchant creature\n{1}: Tap enchanted creature.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "2755ff07-9120-5fe1-94fb-afadce7a30d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b737a959-e974-4b2a-8dca-a257da6084b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b737a959-e974-4b2a-8dca-a257da6084b0.jpg?1",
             "name": "Curse of Exhaustion",
             "text": "Enchant player\nEnchanted player can't cast more than one spell each turn.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "e73ede92-2df9-53d7-9d6e-1b654013cf1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342e1da-7ab9-4e29-96e6-77d820a45ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342e1da-7ab9-4e29-96e6-77d820a45ede.jpg?1",
             "name": "Elgaud Inquisitor",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen Elgaud Inquisitor dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -204,7 +204,7 @@
         },
         {
             "id": "df43d3b7-d053-5b97-b77b-6f2abbab29bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb5920-3b03-4300-bc77-0fba5e6abe69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb5920-3b03-4300-bc77-0fba5e6abe69.jpg?1",
             "name": "Faith's Shield",
             "text": "Target permanent you control gains protection from the color of your choice until end of turn.\nFateful hour \u2014 If you have 5 or less life, instead you and each permanent you control gain protection from the color of your choice until end of turn.",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "8cbabfcb-8c9b-500d-888a-e4ab3d4b4cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfa554b-ee6d-4d4e-aabc-fe7bc6b25236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfa554b-ee6d-4d4e-aabc-fe7bc6b25236.jpg?1",
             "name": "Gather the Townsfolk",
             "text": "Put two 1/1 white Human creature tokens onto the battlefield.\nFateful hour \u2014 If you have 5 or less life, put five of those tokens onto the battlefield instead.",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "e30ed83c-fe32-5d1a-b6dd-16ec99e9849c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d8de75-b169-4426-94a4-b19cdfdffd89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d8de75-b169-4426-94a4-b19cdfdffd89.jpg?1",
             "name": "Gavony Ironwright",
             "text": "Fateful hour \u2014 As long as you have 5 or less life, other creatures you control get +1/+4.",
             "colours": [
@@ -303,7 +303,7 @@
         },
         {
             "id": "01145c58-70d0-500c-b78a-b8a1ab2b8e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1be91a-cdec-4933-b834-0a7838abb9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1be91a-cdec-4933-b834-0a7838abb9b8.jpg?1",
             "name": "Hollowhenge Spirit",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhen Hollowhenge Spirit enters the battlefield, remove target attacking or blocking creature from combat.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "4b491bf9-4f79-52cb-b26d-ced5942e1a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b5de81-65a6-4a74-8a71-767b92e89e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b5de81-65a6-4a74-8a71-767b92e89e91.jpg?1",
             "name": "Increasing Devotion",
             "text": "Put five 1/1 white Human creature tokens onto the battlefield. If Increasing Devotion was cast from a graveyard, put ten of those tokens onto the battlefield instead.\nFlashback {7}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "59a255f2-b0fc-5385-8e8e-9aeddbcc3f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891a92d7-9ccf-4de1-8286-aa5254f27ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891a92d7-9ccf-4de1-8286-aa5254f27ba9.jpg?1",
             "name": "Lingering Souls",
             "text": "Put two 1/1 white Spirit creature tokens with flying onto the battlefield.\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "9e581220-877d-50ac-878d-7806094e933c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg?1",
             "name": "Loyal Cathar // Unhallowed Cathar",
             "text": "Vigilance\nWhen Loyal Cathar dies, return it to the battlefield transformed under your control at the beginning of the next end step.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "3cf1fc99-a10e-5190-a253-18c416e921cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg?1",
             "name": "Loyal Cathar // Unhallowed Cathar",
             "text": "Unhallowed Cathar can't block.",
             "colours": [
@@ -474,7 +474,7 @@
         },
         {
             "id": "81c9c2c2-195d-5420-8fe3-2892c33ec654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2264b760-c527-470d-bad0-d8baaf543631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2264b760-c527-470d-bad0-d8baaf543631.jpg?1",
             "name": "Midnight Guard",
             "text": "Whenever another creature enters the battlefield, untap Midnight Guard.",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "e2c7adde-a7a3-56f2-a2b5-1be205967782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08aea6e3-c8a8-4964-b95d-4c639da55de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08aea6e3-c8a8-4964-b95d-4c639da55de1.jpg?1",
             "name": "Niblis of the Mist",
             "text": "Flying\nWhen Niblis of the Mist enters the battlefield, you may tap target creature.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "c04917fc-6e56-5a2e-a5c5-ce8c44dcc28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2ff7-0f8d-47ea-adfd-af299e793a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2ff7-0f8d-47ea-adfd-af299e793a37.jpg?1",
             "name": "Niblis of the Urn",
             "text": "Flying\nWhenever Niblis of the Urn attacks, you may tap target creature.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "a8138242-15a4-50de-804c-281ff672ea56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e2c5a4-cf92-46bd-9033-8036436488cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e2c5a4-cf92-46bd-9033-8036436488cb.jpg?1",
             "name": "Ray of Revelation",
             "text": "Destroy target enchantment.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "e36410e4-f8e0-5ca2-a992-35d8f4ee3cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5385925d-05ad-4f2e-bd2c-8de6c088ed05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5385925d-05ad-4f2e-bd2c-8de6c088ed05.jpg?1",
             "name": "Requiem Angel",
             "text": "Flying\nWhenever another non-Spirit creature you control dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "d1226750-ce73-5951-ab86-aa3c50565710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96865440-01ad-40f2-90d7-9ecd0b4efecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96865440-01ad-40f2-90d7-9ecd0b4efecc.jpg?1",
             "name": "Sanctuary Cat",
             "text": "",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "18ef4109-9cae-5ea5-807a-15001000470b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ae92c-af6d-4a00-b102-c6d3bcc394b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ae92c-af6d-4a00-b102-c6d3bcc394b4.jpg?1",
             "name": "S\u00e9ance",
             "text": "At the beginning of each upkeep, you may exile target creature card from your graveyard. If you do, put a token onto the battlefield that's a copy of that card except it's a Spirit in addition to its other types. Exile it at the beginning of the next end step.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "7ba961b7-a7cf-572c-a62c-a5e407ca65af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54528722-a6aa-4567-9cd1-e4a97adec7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54528722-a6aa-4567-9cd1-e4a97adec7d0.jpg?1",
             "name": "Silverclaw Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "73f6d10c-37d2-5c81-a222-7e9d4ccf1195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a28abc1-3e75-4db4-baa1-b47abdb7453b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a28abc1-3e75-4db4-baa1-b47abdb7453b.jpg?1",
             "name": "Skillful Lunge",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "5b095452-8c3c-508a-98ce-928199377ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51b792c-b987-49b6-9cc6-80d613c7d065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51b792c-b987-49b6-9cc6-80d613c7d065.jpg?1",
             "name": "Sudden Disappearance",
             "text": "Exile all nonland permanents target player controls. Return the exiled cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "d55fe93f-58f3-5fb1-862b-1a9615f3c040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824423ff-6441-4be6-b754-810adf9ca6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824423ff-6441-4be6-b754-810adf9ca6a2.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "f400481b-5894-5c65-b1b9-6d343a9f973e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a9312-a5b2-4fc5-b46d-e0c9020583a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a9312-a5b2-4fc5-b46d-e0c9020583a5.jpg?1",
             "name": "Thraben Doomsayer",
             "text": "{T}: Put a 1/1 white Human creature token onto the battlefield.\nFateful hour \u2014 As long as you have 5 or less life, other creatures you control get +2/+2.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "81558520-5d3a-5ed7-9467-95fca3cea09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cc36df-040b-4f29-bcc1-f5600803f71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cc36df-040b-4f29-bcc1-f5600803f71d.jpg?1",
             "name": "Thraben Heretic",
             "text": "{T}: Exile target creature card from a graveyard.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "d00d36f9-9f33-5d3f-a2e8-26f187ac2106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ce6aa-e19f-4299-9807-e68920e63c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ce6aa-e19f-4299-9807-e68920e63c73.jpg?1",
             "name": "Artful Dodge",
             "text": "Target creature is unblockable this turn.\nFlashback {U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "49a39b51-2346-583f-8e52-1f36edce75cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ae024-d565-48a1-8004-5aa320a5d24d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ae024-d565-48a1-8004-5aa320a5d24d.jpg?1",
             "name": "Beguiler of Wills",
             "text": "{T}: Gain control of target creature with power less than or equal to the number of creatures you control.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "e22341a9-d0e5-5499-b1e2-ae0b2f3b8f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a75cef-9551-45e2-b1ff-80662c76ec20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a75cef-9551-45e2-b1ff-80662c76ec20.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "8739a6dd-2182-53b2-8dae-f159085e044f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee35f96c-6060-4456-897e-27b74c8c2137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee35f96c-6060-4456-897e-27b74c8c2137.jpg?1",
             "name": "Call to the Kindred",
             "text": "Enchant creature\nAt the beginning of your upkeep, you may look at the top five cards of your library. If you do, you may put a creature card that shares a creature type with enchanted creature from among them onto the battlefield, then you put the rest of those cards on the bottom of your library in any order.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "b642eefe-a338-5432-b5e5-affa74182681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e604b2e-f257-465d-9342-6eb55b2334c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e604b2e-f257-465d-9342-6eb55b2334c5.jpg?1",
             "name": "Chant of the Skifsang",
             "text": "Enchant creature\nEnchanted creature gets -13/-0.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "0b4be7e4-9b92-5831-8231-f3ef22f49356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abd6534-92bb-44e3-88c2-6709f1a4f29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abd6534-92bb-44e3-88c2-6709f1a4f29c.jpg?1",
             "name": "Chill of Foreboding",
             "text": "Each player puts the top five cards of his or her library into his or her graveyard.\nFlashback {7}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "abf8da06-1649-5a6b-bd78-815340e29924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec2c57-8e67-472d-8f2e-0492d311f130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec2c57-8e67-472d-8f2e-0492d311f130.jpg?1",
             "name": "Counterlash",
             "text": "Counter target spell. You may cast a nonland card in your hand that shares a card type with that spell without paying its mana cost.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "72b2ba8d-a9c6-5da3-b059-ce66a6a8fdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147dbe42-665a-4e21-b405-d17554d5efcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147dbe42-665a-4e21-b405-d17554d5efcf.jpg?1",
             "name": "Curse of Echoes",
             "text": "Enchant player\nWhenever enchanted player casts an instant or sorcery spell, each other player may copy that spell and may choose new targets for the copy he or she controls.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "2815ee52-5fc1-5e69-8a22-a781ae42efb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1340f1-85a4-4551-9871-bb00db6d97a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1340f1-85a4-4551-9871-bb00db6d97a8.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1213,7 +1213,7 @@
         },
         {
             "id": "84b03fd3-829c-5b35-a55c-5350669762c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715da2e-c816-4c14-8522-811c97c66fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715da2e-c816-4c14-8522-811c97c66fed.jpg?1",
             "name": "Dungeon Geists",
             "text": "Flying\nWhen Dungeon Geists enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Dungeon Geists.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "c4655460-de98-5512-b222-cbcf0cf0a3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac8b5f-4d95-43fc-bf23-10247986a746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac8b5f-4d95-43fc-bf23-10247986a746.jpg?1",
             "name": "Geralf's Mindcrusher",
             "text": "When Geralf's Mindcrusher enters the battlefield, target player puts the top five cards of his or her library into his or her graveyard.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1282,7 +1282,7 @@
         },
         {
             "id": "b5d26202-03ed-58dc-a1bc-169036804ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f92b74-86bb-4bb3-8f78-640984698f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f92b74-86bb-4bb3-8f78-640984698f28.jpg?1",
             "name": "Griptide",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -1314,7 +1314,7 @@
         },
         {
             "id": "e56c0679-17f5-5e5b-8d86-d342123925bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de766c12-eb2c-466a-8630-8242a153eb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de766c12-eb2c-466a-8630-8242a153eb1f.jpg?1",
             "name": "Havengul Runebinder",
             "text": "{2}{U}, {T}, Exile a creature card from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield, then put a +1/+1 counter on each Zombie creature you control.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "bd35948e-0f2a-5b0f-bc4a-23a215be8174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca63f9a2-381e-4c84-b0bb-3acd9445b4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca63f9a2-381e-4c84-b0bb-3acd9445b4db.jpg?1",
             "name": "Headless Skaab",
             "text": "As an additional cost to cast Headless Skaab, exile a creature card from your graveyard.\nHeadless Skaab enters the battlefield tapped.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "da62503e-cc29-5ec2-9613-1615beda0e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f5bcdc-70bb-4d67-99e1-282f166ee4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f5bcdc-70bb-4d67-99e1-282f166ee4bf.jpg?1",
             "name": "Increasing Confusion",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard. If Increasing Confusion was cast from a graveyard, that player puts twice that many cards into his or her graveyard instead.\nFlashback {X}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1416,7 +1416,7 @@
         },
         {
             "id": "52e7d095-e8c2-58c5-b2df-ab8e25086c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a685a-bd02-43bf-8700-2207c65bbbb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a685a-bd02-43bf-8700-2207c65bbbb1.jpg?1",
             "name": "Mystic Retrieval",
             "text": "Return target instant or sorcery card from your graveyard to your hand.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "814941ea-a079-5cf0-b4e7-dfd8001abccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174a1d08-cd79-43d6-897f-3ee9a682d15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174a1d08-cd79-43d6-897f-3ee9a682d15e.jpg?1",
             "name": "Nephalia Seakite",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "bab62d12-98aa-52bc-8ef3-735908674fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686843d-6d1e-4488-8c17-7c986a154195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686843d-6d1e-4488-8c17-7c986a154195.jpg?1",
             "name": "Niblis of the Breath",
             "text": "Flying\n{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "ee98734f-f54d-51ea-8fe5-97515b829fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg?1",
             "name": "Relentless Skaabs",
             "text": "As an additional cost to cast Relentless Skaabs, exile a creature card from your graveyard.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "eaff75b5-af38-5501-859d-c6ea9a1c5417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914837df-c255-4cea-9255-b05f218fd9f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914837df-c255-4cea-9255-b05f218fd9f8.jpg?1",
             "name": "Saving Grasp",
             "text": "Return target creature you own to your hand.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1584,7 +1584,7 @@
         },
         {
             "id": "5922c93f-1461-5229-80c8-a4086af2840f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c40a2c7-df7a-41a6-a49e-5f7db808b810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c40a2c7-df7a-41a6-a49e-5f7db808b810.jpg?1",
             "name": "Screeching Skaab",
             "text": "When Screeching Skaab enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "d40d69b0-ddc2-5808-88af-370fda127ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c982d679-581d-43e1-acd0-db77eb0987c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c982d679-581d-43e1-acd0-db77eb0987c2.jpg?1",
             "name": "Secrets of the Dead",
             "text": "Whenever you cast a spell from your graveyard, draw a card.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "8483679b-f851-5e55-ba55-747b94aef353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435c5218-46b3-456a-aedf-d9586a4bd0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435c5218-46b3-456a-aedf-d9586a4bd0a3.jpg?1",
             "name": "Shriekgeist",
             "text": "Flying\nWhenever Shriekgeist deals combat damage to a player, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "e8b267a0-3755-51af-95a9-bed1ac7aa88d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg?1",
             "name": "Soul Seizer // Ghastly Haunting",
             "text": "Flying\nWhen Soul Seizer deals combat damage to a player, you may transform it. If you do, attach it to target creature that player controls.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "6950f8fc-b5a6-53e5-9cfa-3555e1edfaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg?1",
             "name": "Soul Seizer // Ghastly Haunting",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -1752,7 +1752,7 @@
         },
         {
             "id": "40a9c798-43c7-5a2b-b2de-a67c99e441c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040eddb0-fca2-41eb-ab07-c48d49385973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040eddb0-fca2-41eb-ab07-c48d49385973.jpg?1",
             "name": "Stormbound Geist",
             "text": "Flying\nStormbound Geist can block only creatures with flying.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "0be9fd72-98ad-507d-ab8c-c2a000357289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1ebb-9d85-4b9b-a614-c7f965c0893d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1ebb-9d85-4b9b-a614-c7f965c0893d.jpg?1",
             "name": "Thought Scour",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard.\nDraw a card.",
             "colours": [
@@ -1818,7 +1818,7 @@
         },
         {
             "id": "081a5f59-f5dd-566c-840d-eef95de89aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e9f552-34b6-43a5-8ef8-9d5208f4cae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e9f552-34b6-43a5-8ef8-9d5208f4cae0.jpg?1",
             "name": "Tower Geist",
             "text": "Flying\nWhen Tower Geist enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "5582242e-08e0-567f-a6fb-f8057d1f3593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1c6379-69d5-48aa-8d06-257c0592794e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1c6379-69d5-48aa-8d06-257c0592794e.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "7cead567-4bf7-5d80-80cd-f3336aa5d5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg?1",
             "name": "Chosen of Markov // Markov's Servant",
             "text": "{T}, Tap an untapped Vampire you control: Transform Chosen of Markov.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "28d7d7f0-b651-55bf-b4b9-7b9a4a48d863",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg?1",
             "name": "Chosen of Markov // Markov's Servant",
             "text": "",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "c0a1b7b7-742b-5663-b517-072647b5de05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c531d218-ff1c-4333-a19d-446d709b1e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c531d218-ff1c-4333-a19d-446d709b1e28.jpg?1",
             "name": "Curse of Misfortunes",
             "text": "Enchant player\nAt the beginning of your upkeep, you may search your library for a Curse card that doesn't have the same name as a Curse attached to enchanted player, put it onto the battlefield attached to that player, then shuffle your library.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "15dc8a56-5075-5be0-8d41-fea655b39ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ed5d1-44dc-4733-9e01-65fbc5dc02f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ed5d1-44dc-4733-9e01-65fbc5dc02f2.jpg?1",
             "name": "Curse of Thirst",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, Curse of Thirst deals damage to that player equal to the number of Curses attached to him or her.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "0bf450c7-643e-5fea-a14f-f8e90dd506b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271bc29e-d33f-4c21-a3ee-b2c6b5c9015e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271bc29e-d33f-4c21-a3ee-b2c6b5c9015e.jpg?1",
             "name": "Deadly Allure",
             "text": "Target creature gains deathtouch until end of turn and must be blocked this turn if able.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2058,7 +2058,7 @@
         },
         {
             "id": "e6e1d6ac-5159-54b9-8f50-0372f44740ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0643fb9a-8284-4dfc-836a-c2c69ef09f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0643fb9a-8284-4dfc-836a-c2c69ef09f32.jpg?1",
             "name": "Death's Caress",
             "text": "Destroy target creature. If that creature was a Human, you gain life equal to its toughness.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "bacf974f-190b-5144-8c89-7a7f06978b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e81d6ed-2141-4177-9ded-680fff65b39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e81d6ed-2141-4177-9ded-680fff65b39e.jpg?1",
             "name": "Falkenrath Torturer",
             "text": "Sacrifice a creature: Falkenrath Torturer gains flying until end of turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Torturer.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "c499a97e-b7fc-5585-8b83-43f9267ec3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d45316-b44a-4cf6-8cbe-b02fe6545141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d45316-b44a-4cf6-8cbe-b02fe6545141.jpg?1",
             "name": "Farbog Boneflinger",
             "text": "When Farbog Boneflinger enters the battlefield, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2158,7 +2158,7 @@
         },
         {
             "id": "4ab11688-fa02-5e83-9343-5eb2d59659e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38167118-f5b3-4e07-8060-b170b49cff9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38167118-f5b3-4e07-8060-b170b49cff9e.jpg?1",
             "name": "Fiend of the Shadows",
             "text": "Flying\nWhenever Fiend of the Shadows deals combat damage to a player, that player exiles a card from his or her hand. You may play that card for as long as it remains exiled.\nSacrifice a Human: Regenerate Fiend of the Shadows.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "7a8a91f7-abf8-5d5b-9c32-495cde7f628b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffaad78-97ff-431f-bfb0-e96c7558f974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffaad78-97ff-431f-bfb0-e96c7558f974.jpg?1",
             "name": "Geralf's Messenger",
             "text": "Geralf's Messenger enters the battlefield tapped.\nWhen Geralf's Messenger enters the battlefield, target opponent loses 2 life.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "bfc4b3f8-b6e0-59c6-8600-007f146bc554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d73cb5-22ac-43df-9c4b-0c860bb80b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d73cb5-22ac-43df-9c4b-0c860bb80b3e.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -2261,7 +2261,7 @@
         },
         {
             "id": "1988e713-9ce6-5117-938f-6bdc97fa0fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0c266b-9ef5-4de2-a358-65739de41491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0c266b-9ef5-4de2-a358-65739de41491.jpg?1",
             "name": "Gravepurge",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "8ee9a022-4f38-5a25-85d5-4875a1a1b81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9d733-24b6-49ed-a15a-c00285eea4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9d733-24b6-49ed-a15a-c00285eea4b2.jpg?1",
             "name": "Gruesome Discovery",
             "text": "Target player discards two cards.\nMorbid \u2014 If a creature died this turn, instead that player reveals his or her hand, you choose two cards from it, then that player discards those cards.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "14902953-83d9-53cb-b856-2e7e1a96ae9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf96a6c-8481-4954-b149-7153b80480be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf96a6c-8481-4954-b149-7153b80480be.jpg?1",
             "name": "Harrowing Journey",
             "text": "Target player draws three cards and loses 3 life.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "41e6e1c5-e8c4-5181-acb9-43c5c120547c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe999ed-b419-440c-9189-1046f43d7b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe999ed-b419-440c-9189-1046f43d7b87.jpg?1",
             "name": "Highborn Ghoul",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "4100b2d5-e735-57a9-9b1a-741e4c146928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f508dc-7c7d-47e8-a4ef-0e8fd99cbd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f508dc-7c7d-47e8-a4ef-0e8fd99cbd74.jpg?1",
             "name": "Increasing Ambition",
             "text": "Search your library for a card and put that card into your hand. If Increasing Ambition was cast from a graveyard, instead search your library for two cards and put those cards into your hand. Then shuffle your library.\nFlashback {7}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "7c57482e-4f47-5adc-b614-aa1be6ee50df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b124d-3546-4882-a6e1-c9c353628a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b124d-3546-4882-a6e1-c9c353628a18.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "43aa4d36-9514-554e-bd91-157707b87b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg?1",
             "name": "Ravenous Demon // Archdemon of Greed",
             "text": "Sacrifice a Human: Transform Ravenous Demon. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "d0aa4bb6-bff1-51ba-b9ae-fb5c35239b3b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg?1",
             "name": "Ravenous Demon // Archdemon of Greed",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a Human. If you can't, tap Archdemon of Greed and it deals 9 damage to you.",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "f8620697-3a95-5fa7-899e-7b7626d10df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4defdead-19fa-4535-9f71-8808388b0332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4defdead-19fa-4535-9f71-8808388b0332.jpg?1",
             "name": "Reap the Seagraf",
             "text": "Put a 2/2 black Zombie creature token onto the battlefield.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "7a5885cf-bb5c-5bac-b036-caa10193e7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018bd4ae-cdea-410d-9ce6-6a70f12de966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018bd4ae-cdea-410d-9ce6-6a70f12de966.jpg?1",
             "name": "Sightless Ghoul",
             "text": "Sightless Ghoul can't block.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "6a341ff4-00e8-5216-aa0a-2f57c86dab6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274976b0-2bb5-46e6-b62e-b50d80a77e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274976b0-2bb5-46e6-b62e-b50d80a77e28.jpg?1",
             "name": "Skirsdag Flayer",
             "text": "{3}{B}, {T}, Sacrifice a Human: Destroy target creature.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "a0ed4512-ab21-5dbf-b450-bb632e0f68f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0a94fe-11d6-48a7-9195-2cb5eff4b962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0a94fe-11d6-48a7-9195-2cb5eff4b962.jpg?1",
             "name": "Spiteful Shadows",
             "text": "Enchant creature\nWhenever enchanted creature is dealt damage, it deals that much damage to its controller.",
             "colours": [
@@ -2665,7 +2665,7 @@
         },
         {
             "id": "05f97900-7f22-5aa7-8dc9-9efe96c6166b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09666671-601e-4fca-bdfb-fb288bf2672c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09666671-601e-4fca-bdfb-fb288bf2672c.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "25a231f7-2b67-5df4-92cd-37288ae4217e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f2243-54fd-484b-a742-166cea7ec179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f2243-54fd-484b-a742-166cea7ec179.jpg?1",
             "name": "Undying Evil",
             "text": "Target creature gains undying until end of turn. (When it dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "0a057fd9-bf97-5e0f-93aa-e6c2295fad35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03c64a7-37d2-4d8f-bd7a-9435bc2f4101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03c64a7-37d2-4d8f-bd7a-9435bc2f4101.jpg?1",
             "name": "Vengeful Vampire",
             "text": "Flying\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "d176b196-4f6f-5ee4-be0e-c5cceebe70ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f533fbfa-42ae-4e27-92a4-9936bcd2a5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f533fbfa-42ae-4e27-92a4-9936bcd2a5f4.jpg?1",
             "name": "Wakedancer",
             "text": "Morbid \u2014 When Wakedancer enters the battlefield, if a creature died this turn, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -2798,7 +2798,7 @@
         },
         {
             "id": "6d6004a3-8a92-53fc-8f17-9d4d36c6835a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe662a08-a8b1-4f25-b7c0-dca1c7ad7271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe662a08-a8b1-4f25-b7c0-dca1c7ad7271.jpg?1",
             "name": "Zombie Apocalypse",
             "text": "Return all Zombie creature cards from your graveyard to the battlefield tapped, then destroy all Humans.",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "925aef52-b1b5-5493-a88a-74f42fbd0ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg?1",
             "name": "Afflicted Deserter // Werewolf Ransacker",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Afflicted Deserter.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "f40dda4a-0d51-5a68-b310-21b8b0ec5b37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg?1",
             "name": "Afflicted Deserter // Werewolf Ransacker",
             "text": "Whenever this creature transforms into Werewolf Ransacker, you may destroy target artifact. If that artifact is put into a graveyard this way, Werewolf Ransacker deals 3 damage to that artifact's controller.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Werewolf Ransacker.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "7e84abf0-a001-517d-ad16-b5b153bd8483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ec168a-3e4f-4527-901a-bc28cc28d125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ec168a-3e4f-4527-901a-bc28cc28d125.jpg?1",
             "name": "Alpha Brawl",
             "text": "Target creature an opponent controls deals damage equal to its power to each other creature that player controls, then each of those creatures deals damage equal to its power to that creature.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "e2d33f4d-458f-5ad8-8c71-f67415e9660b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634d59b8-6046-4796-95c5-eec75a239986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634d59b8-6046-4796-95c5-eec75a239986.jpg?1",
             "name": "Blood Feud",
             "text": "Target creature fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "3fd37123-94ae-572d-9d97-86627ca854da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47773da8-afe4-43e1-8355-6ab51451ee00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47773da8-afe4-43e1-8355-6ab51451ee00.jpg?1",
             "name": "Burning Oil",
             "text": "Burning Oil deals 3 damage to target attacking or blocking creature.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "d822db94-b23d-56b4-8fdc-5befa6a01bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4ac6f-0005-47f8-bee9-10429cc542e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4ac6f-0005-47f8-bee9-10429cc542e4.jpg?1",
             "name": "Curse of Bloodletting",
             "text": "Enchant player\nIf a source would deal damage to enchanted player, it deals double that damage to that player instead.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "fd5af8a8-9fd4-5a2f-9c3d-a4a173938ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ea5e9-6d05-4bc6-8f14-00eb2532c8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ea5e9-6d05-4bc6-8f14-00eb2532c8b5.jpg?1",
             "name": "Erdwal Ripper",
             "text": "Haste\nWhenever Erdwal Ripper deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "8e1e236b-0e80-55b9-ac30-a52a7181807b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b0da17-d595-441d-811c-a2d28d2bb232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b0da17-d595-441d-811c-a2d28d2bb232.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "721e5822-27a1-504b-92bc-548f227184ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d94aaa4-c2fd-4714-9198-8415158b9c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d94aaa4-c2fd-4714-9198-8415158b9c4d.jpg?1",
             "name": "Fires of Undeath",
             "text": "Fires of Undeath deals 2 damage to target creature or player.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "990c5cec-8bde-5bf1-b8a3-42f410f06184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb17c3f-0154-49ee-bb5f-cd1df8546871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb17c3f-0154-49ee-bb5f-cd1df8546871.jpg?1",
             "name": "Flayer of the Hatebound",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)\nWhenever Flayer of the Hatebound or another creature enters the battlefield from your graveyard, that creature deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "de51396c-5b83-56f0-ae68-79f7f4e4c2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1ab466-44bb-45d5-a94f-21b8924f0d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1ab466-44bb-45d5-a94f-21b8924f0d89.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "efd01986-0971-51ec-a174-47b6870014f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b565a5-d706-47b4-bfa2-deebcc0e2e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b565a5-d706-47b4-bfa2-deebcc0e2e60.jpg?1",
             "name": "Forge Devil",
             "text": "When Forge Devil enters the battlefield, it deals 1 damage to target creature and 1 damage to you.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "a6bd1f34-29f9-5f3b-a89d-d3d4eecf93fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fd8895-9282-44d3-969f-b0529eb3bc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fd8895-9282-44d3-969f-b0529eb3bc07.jpg?1",
             "name": "Heckling Fiends",
             "text": "{2}{R}: Target creature attacks this turn if able.",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "0a0c3751-69b7-5942-a17c-7b49085891e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec8d800-7f06-44e0-b22d-cdff0a9b153d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec8d800-7f06-44e0-b22d-cdff0a9b153d.jpg?1",
             "name": "Hellrider",
             "text": "Haste\nWhenever a creature you control attacks, Hellrider deals 1 damage to defending player.",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "f2401a1b-10da-5ec6-843a-015d972dcabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg?1",
             "name": "Hinterland Hermit // Hinterland Scourge",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Hinterland Hermit.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "7dddff97-6436-5e71-8e1e-abbe2af9154f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg?1",
             "name": "Hinterland Hermit // Hinterland Scourge",
             "text": "Hinterland Scourge must be blocked if able.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Hinterland Scourge.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "745aef19-1b77-5266-ad5f-b32f0781ec90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13afe4a-4a3d-42ae-ac0a-b789364c7e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13afe4a-4a3d-42ae-ac0a-b789364c7e7e.jpg?1",
             "name": "Increasing Vengeance",
             "text": "Copy target instant or sorcery spell you control. If Increasing Vengeance was cast from a graveyard, copy that spell twice instead. You may choose new targets for the copies.\nFlashback {3}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3399,7 +3399,7 @@
         },
         {
             "id": "1c5c95c0-31a0-5865-9527-7aad5967e501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122163dd-e070-48af-8036-e9850541d138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122163dd-e070-48af-8036-e9850541d138.jpg?1",
             "name": "Markov Blademaster",
             "text": "Double strike\nWhenever Markov Blademaster deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "963448b6-7f6f-5503-86c3-abe5a01a5824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5035276f-31b9-4dd3-9ec8-42a664bdbd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5035276f-31b9-4dd3-9ec8-42a664bdbd5c.jpg?1",
             "name": "Markov Warlord",
             "text": "Haste\nWhen Markov Warlord enters the battlefield, up to two target creatures can't block this turn.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "fc85f238-6fc8-5300-af37-4153fc2f806d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg?1",
             "name": "Mondronen Shaman // Tovolar's Magehunter",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Mondronen Shaman.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "0a0444ca-b731-5818-bd39-8c7094c7ef87",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg?1",
             "name": "Mondronen Shaman // Tovolar's Magehunter",
             "text": "Whenever an opponent casts a spell, Tovolar's Magehunter deals 2 damage to that player.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Tovolar's Magehunter.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "6563d0ea-11d4-548e-a3ba-03a4fe408a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92503118-b37b-4c52-b40a-487f6ad695ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92503118-b37b-4c52-b40a-487f6ad695ef.jpg?1",
             "name": "Moonveil Dragon",
             "text": "Flying\n{R}: Each creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "b2e2a074-458b-5310-820e-05474ed63388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4cdf4a-2d55-4769-8c51-bc86c13000ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4cdf4a-2d55-4769-8c51-bc86c13000ef.jpg?1",
             "name": "Nearheath Stalker",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3608,7 +3608,7 @@
         },
         {
             "id": "a58e8f31-ec50-516c-ae68-4546712c0032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9722f20c-e0d9-4165-8cd5-4abadc5378eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9722f20c-e0d9-4165-8cd5-4abadc5378eb.jpg?1",
             "name": "Pyreheart Wolf",
             "text": "Whenever Pyreheart Wolf attacks, each creature you control can't be blocked this turn except by two or more creatures.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "b0610b09-71c7-53f9-b411-603a8113b485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c7c972-5a11-4709-b3ef-e2acb3b51dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c7c972-5a11-4709-b3ef-e2acb3b51dd9.jpg?1",
             "name": "Russet Wolves",
             "text": "",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "eaeb1611-70f6-5482-b2b1-c30224b5494a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4338d-e5c0-46b4-ab16-1f9aa97b4026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4338d-e5c0-46b4-ab16-1f9aa97b4026.jpg?1",
             "name": "Scorch the Fields",
             "text": "Destroy target land. Scorch the Fields deals 1 damage to each Human creature.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "53696378-2cd9-5b83-a0e5-22829905fbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5223b4-e0d1-4fc6-a363-ebcdfeee56d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5223b4-e0d1-4fc6-a363-ebcdfeee56d1.jpg?1",
             "name": "Shattered Perception",
             "text": "Discard all the cards in your hand, then draw that many cards.\nFlashback {5}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "4f8a49c1-cdb2-5ae0-a020-93a555cf3176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e38239-a9ec-4149-9c90-74dcd46ed95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e38239-a9ec-4149-9c90-74dcd46ed95d.jpg?1",
             "name": "Talons of Falkenrath",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature has \"{1}{R}: This creature gets +2/+0 until end of turn.\"",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "7f5e490f-f76d-5ba7-a3d9-2ce3cff03a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d596feee-6ccc-4648-884b-ed2eeb1cffc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d596feee-6ccc-4648-884b-ed2eeb1cffc0.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "d8a4b79a-a065-5d9c-a5f2-49eac1adddb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f27ee20-b5c5-4867-b832-9cdade0eda03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f27ee20-b5c5-4867-b832-9cdade0eda03.jpg?1",
             "name": "Wrack with Madness",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "764b967b-7011-5260-a8f1-190538804b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a052e945-7535-4b0a-b580-cf76377633f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a052e945-7535-4b0a-b580-cf76377633f3.jpg?1",
             "name": "Briarpack Alpha",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Briarpack Alpha enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "eef62138-eda3-5968-acc0-7dd9c5201312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0152975-790a-40e4-993e-a970676a2d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0152975-790a-40e4-993e-a970676a2d32.jpg?1",
             "name": "Clinging Mists",
             "text": "Prevent all combat damage that would be dealt this turn.\nFateful hour \u2014 If you have 5 or less life, tap all attacking creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "48c15384-a2f8-5ea2-aa43-4bb1cc1fde53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59b3653-5a50-48f2-bcf1-ab305ef30902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59b3653-5a50-48f2-bcf1-ab305ef30902.jpg?1",
             "name": "Crushing Vines",
             "text": "Choose one \u2014 Destroy target creature with flying; or destroy target artifact.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "4574fdb2-dfec-5641-9b30-fe8ca634b0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127c969b-1c9a-4265-af0e-5b9dbe136064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127c969b-1c9a-4265-af0e-5b9dbe136064.jpg?1",
             "name": "Dawntreader Elk",
             "text": "{G}, Sacrifice Dawntreader Elk: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "51f98648-7a55-51f9-8fdc-0d89dac5ea5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b35fee-8e24-4d89-ad77-d55d06bb1d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b35fee-8e24-4d89-ad77-d55d06bb1d7f.jpg?1",
             "name": "Deranged Outcast",
             "text": "{1}{G}, Sacrifice a Human: Put two +1/+1 counters on target creature.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "4deda099-27da-5c25-8632-205e85c738d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0e760a-241b-40c5-b201-bfc03effed2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0e760a-241b-40c5-b201-bfc03effed2e.jpg?1",
             "name": "Favor of the Woods",
             "text": "Enchant creature\nWhenever enchanted creature blocks, you gain 3 life.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "b279c94a-e357-5105-8f53-24b6cbd6688c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831e3cc-659b-4408-b5d8-a27ae2738680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831e3cc-659b-4408-b5d8-a27ae2738680.jpg?1",
             "name": "Feed the Pack",
             "text": "At the beginning of your end step, you may sacrifice a nontoken creature. If you do, put X 2/2 green Wolf creature tokens onto the battlefield, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "358c2525-6036-5505-8b09-a1edad1afbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a413c65e-5965-429b-8c25-11f8b73cba03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a413c65e-5965-429b-8c25-11f8b73cba03.jpg?1",
             "name": "Ghoultree",
             "text": "Ghoultree costs {1} less to cast for each creature card in your graveyard.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "1517c2ee-55ea-50fa-bcf3-3947bc926931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9fe36-2eac-49e3-8f89-810009ba8a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9fe36-2eac-49e3-8f89-810009ba8a4b.jpg?1",
             "name": "Gravetiller Wurm",
             "text": "Trample\nMorbid \u2014 Gravetiller Wurm enters the battlefield with four +1/+1 counters on it if a creature died this turn.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "aa78de56-3934-5cb2-82c9-7e8a66cadd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3e2ad-7a04-4735-ba73-576e32249ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3e2ad-7a04-4735-ba73-576e32249ba3.jpg?1",
             "name": "Grim Flowering",
             "text": "Draw a card for each creature card in your graveyard.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "7f609a29-9438-5203-8ea4-e67cddd29c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab91f-ac01-43f4-9276-9af35dbfbf71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab91f-ac01-43f4-9276-9af35dbfbf71.jpg?1",
             "name": "Hollowhenge Beast",
             "text": "",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "0e06c6a6-6913-51ef-87e2-5b8cd4cd5eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38a0dbc-3ebd-4f87-a5fb-bc2ee8a48a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38a0dbc-3ebd-4f87-a5fb-bc2ee8a48a8d.jpg?1",
             "name": "Hunger of the Howlpack",
             "text": "Put a +1/+1 counter on target creature.\nMorbid \u2014 Put three +1/+1 counters on that creature instead if a creature died this turn.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "83bfb8d9-0126-5e05-a7d1-4eeb42470c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ab8737-151f-4702-a95d-7f7b60a5ee8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ab8737-151f-4702-a95d-7f7b60a5ee8a.jpg?1",
             "name": "Increasing Savagery",
             "text": "Put five +1/+1 counters on target creature. If Increasing Savagery was cast from a graveyard, put ten +1/+1 counters on that creature instead.\nFlashback {5}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "0e05dd3f-75da-5ade-b4fb-42ad45820ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695b8abe-796e-4d9b-aad3-4e03e925d2a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695b8abe-796e-4d9b-aad3-4e03e925d2a7.jpg?1",
             "name": "Kessig Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "c5a8dd6c-a086-586d-9756-cd5b44a39d80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg?1",
             "name": "Lambholt Elder // Silverpelt Werewolf",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Lambholt Elder.",
             "colours": [
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "da5ed573-adba-58da-ae0f-08b38fafae9c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg?1",
             "name": "Lambholt Elder // Silverpelt Werewolf",
             "text": "Whenever Silverpelt Werewolf deals combat damage to a player, draw a card.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Silverpelt Werewolf.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "cb87f8b8-24b7-57b8-b6cd-168c96ece3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865603c-0a5e-45c3-84e3-2dc3b4cf0cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865603c-0a5e-45c3-84e3-2dc3b4cf0cf7.jpg?1",
             "name": "Lost in the Woods",
             "text": "Whenever a creature attacks you or a planeswalker you control, reveal the top card of your library. If it's a Forest card, remove that creature from combat. Then put the revealed card on the bottom of your library.",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "e3bf560d-4aac-5668-979e-ee1acaddce2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c71457-f7c9-4ab4-b89d-e235e3f15e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c71457-f7c9-4ab4-b89d-e235e3f15e16.jpg?1",
             "name": "Predator Ooze",
             "text": "Predator Ooze is indestructible.\nWhenever Predator Ooze attacks, put a +1/+1 counter on it.\nWhenever a creature dealt damage by Predator Ooze this turn dies, put a +1/+1 counter on Predator Ooze.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "423395c8-4bd3-512e-9172-1c71c47925b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1",
             "name": "Scorned Villager // Moonscarred Werewolf",
             "text": "{T}: Add {G} to your mana pool.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Scorned Villager.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "dc98dce3-262d-5788-a15f-5839588393dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1",
             "name": "Scorned Villager // Moonscarred Werewolf",
             "text": "Vigilance\n{T}: Add {G}{G} to your mana pool.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Moonscarred Werewolf.",
             "colours": [
@@ -4510,7 +4510,7 @@
         },
         {
             "id": "4c00c2b9-4ff5-5194-828c-274886dbdea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307edca0-769d-4071-9654-3537341e96bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307edca0-769d-4071-9654-3537341e96bd.jpg?1",
             "name": "Somberwald Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -4544,7 +4544,7 @@
         },
         {
             "id": "9f17556a-21be-5322-87f7-6e1b11b3dad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1fb137-205c-480f-b6dc-dfa137793ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1fb137-205c-480f-b6dc-dfa137793ae3.jpg?1",
             "name": "Strangleroot Geist",
             "text": "Haste\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4578,7 +4578,7 @@
         },
         {
             "id": "cf20c231-6171-5ae0-948d-d3ee99b3fe89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59960387-3adf-4b9a-b0e6-c441579f7388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59960387-3adf-4b9a-b0e6-c441579f7388.jpg?1",
             "name": "Tracker's Instincts",
             "text": "Reveal the top four cards of your library. Put a creature card from among them into your hand and the rest into your graveyard.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "ac6b9db9-9a63-51e3-9dc3-813891980745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3837a7-854a-440d-93d7-d36f50149346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3837a7-854a-440d-93d7-d36f50149346.jpg?1",
             "name": "Ulvenwald Bear",
             "text": "Morbid \u2014 When Ulvenwald Bear enters the battlefield, if a creature died this turn, put two +1/+1 counters on target creature.",
             "colours": [
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "35a3c35b-a8fa-57a3-8f8f-671e27ac8339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c0e852-9966-4145-b7c3-ac957f729376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c0e852-9966-4145-b7c3-ac957f729376.jpg?1",
             "name": "Village Survivors",
             "text": "Vigilance\nFateful hour \u2014 As long as you have 5 or less life, other creatures you control have vigilance.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "aad45fe9-c4ba-51b2-8405-7c6858eb64d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1348aa65-85e7-4ac7-bcdb-a83f2c3aa1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1348aa65-85e7-4ac7-bcdb-a83f2c3aa1a6.jpg?1",
             "name": "Vorapede",
             "text": "Vigilance, trample\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "e20b8a72-59e1-5a98-b1a8-9e3a281deb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a564e8d4-4111-4d8e-897d-523bc4cfef94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a564e8d4-4111-4d8e-897d-523bc4cfef94.jpg?1",
             "name": "Wild Hunger",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "8a054acd-2001-5ece-9d72-6d49168192d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg?1",
             "name": "Wolfbitten Captive // Krallenhorde Killer",
             "text": "{1}{G}: Wolfbitten Captive gets +2/+2 until end of turn. Activate this ability only once each turn.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Wolfbitten Captive.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "e9a348e6-d996-5ddf-bbef-598adb934794",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg?1",
             "name": "Wolfbitten Captive // Krallenhorde Killer",
             "text": "{3}{G}: Krallenhorde Killer gets +4/+4 until end of turn. Activate this ability only once each turn.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Krallenhorde Killer.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "85f6f5ec-f3cc-5523-a53a-76523a9e5b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39aa40-ef5f-40f1-a6dd-fbce91172c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39aa40-ef5f-40f1-a6dd-fbce91172c50.jpg?1",
             "name": "Young Wolf",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "c814c42a-8193-50a0-85d1-b018dd556261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e5f41eb-609b-4882-af9e-904daa717484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e5f41eb-609b-4882-af9e-904daa717484.jpg?1",
             "name": "Diregraf Captain",
             "text": "Deathtouch\nOther Zombie creatures you control get +1/+1.\nWhenever another Zombie you control dies, target opponent loses 1 life.",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "d5950c10-b773-5cb0-b886-0e26152464be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8238e36-625f-460d-9e39-fd501e65490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8238e36-625f-460d-9e39-fd501e65490c.jpg?1",
             "name": "Drogskol Captain",
             "text": "Flying\nOther Spirit creatures you control get +1/+1 and have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -4923,7 +4923,7 @@
         },
         {
             "id": "f4e7b75d-57c7-5f53-8c64-12f978c6ac96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d9e0b-6433-40a2-9847-9fa4e3c008c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d9e0b-6433-40a2-9847-9fa4e3c008c4.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying, double strike, lifelink\nWhenever you gain life, draw a card.",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "2667f661-15ee-5024-bca5-4d486858a371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397388e-ebe2-4034-83b7-a7c0df1af78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397388e-ebe2-4034-83b7-a7c0df1af78f.jpg?1",
             "name": "Falkenrath Aristocrat",
             "text": "Flying, haste\nSacrifice a creature: Falkenrath Aristocrat is indestructible this turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "56103b7d-428f-5aba-8df3-7a4dc2ca2bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321077a4-e468-4e74-94f7-80c83790e0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321077a4-e468-4e74-94f7-80c83790e0d9.jpg?1",
             "name": "Havengul Lich",
             "text": "{1}: You may cast target creature card in a graveyard this turn. When you cast that card this turn, Havengul Lich gains all activated abilities of that card until end of turn.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "d7eb7756-fc8f-5e70-b86d-db6446361748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "Whenever this creature enters the battlefield or transforms into Huntmaster of the Fells, put a 2/2 green Wolf creature token onto the battlefield and you gain 2 life.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Huntmaster of the Fells.",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "9e35bea5-695f-54ad-affc-c75ac7cde0d2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "Trample\nWhenever this creature transforms into Ravager of the Fells, it deals 2 damage to target opponent and 2 damage to up to one target creature that player controls.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ravager of the Fells.",
             "colours": [
@@ -5106,7 +5106,7 @@
         },
         {
             "id": "1c8671ee-d281-5b36-b8c8-9d98c502c650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9326061f-ea76-4be7-a06f-aefb63454777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9326061f-ea76-4be7-a06f-aefb63454777.jpg?1",
             "name": "Immerwolf",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nOther Wolf and Werewolf creatures you control get +1/+1.\nNon-Human Werewolves you control can't transform.",
             "colours": [
@@ -5142,7 +5142,7 @@
         },
         {
             "id": "37351af6-9659-599b-a519-be9ddec8e09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bb371f-d49f-41bd-bbe0-d5e1e2067e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bb371f-d49f-41bd-bbe0-d5e1e2067e36.jpg?1",
             "name": "Sorin, Lord of Innistrad",
             "text": "+1: Put a 1/1 black Vampire creature token with lifelink onto the battlefield.\n-2: You get an emblem with \"Creatures you control get +1/+0.\"\n-6: Destroy up to three target creatures and/or other planeswalkers. Return each card put into a graveyard this way to the battlefield under your control.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "9d9cc499-3672-5600-aefd-45db63e3d51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfcca87-04f8-480a-bae6-ae87f7afb7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfcca87-04f8-480a-bae6-ae87f7afb7e1.jpg?1",
             "name": "Stromkirk Captain",
             "text": "First strike\nOther Vampire creatures you control get +1/+1 and have first strike.",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "b295314f-1ae4-533e-96c7-63f93dcdc866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e5322-1b41-488d-94b1-7742fbd983d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e5322-1b41-488d-94b1-7742fbd983d4.jpg?1",
             "name": "Altar of the Lost",
             "text": "Altar of the Lost enters the battlefield tapped.\n{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast spells with flashback from a graveyard.",
             "colours": [],
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "a3cbc6b4-34fb-5906-93b0-804c58eca3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9a78-204b-4012-b394-b40fd0edac4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9a78-204b-4012-b394-b40fd0edac4c.jpg?1",
             "name": "Avacyn's Collar",
             "text": "Equipped creature gets +1/+0 and has vigilance.\nWhenever equipped creature dies, if it was a Human, put a 1/1 white Spirit creature token with flying onto the battlefield.\nEquip {2}",
             "colours": [],
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "34b16f70-2dd9-5843-b680-0a40a4b68e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1",
             "name": "Chalice of Life // Chalice of Death",
             "text": "{T}: You gain 1 life. Then if you have at least 10 life more than your starting life total, transform Chalice of Life.",
             "colours": [],
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "429cf546-1ea8-5acf-9f3c-9d17394a1875",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1",
             "name": "Chalice of Life // Chalice of Death",
             "text": "{T}: Target player loses 5 life.",
             "colours": [],
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "56463017-ab81-5be0-bbdb-54c74cafaf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg?1",
             "name": "Elbrus, the Binding Blade // Withengar Unbound",
             "text": "Equipped creature gets +1/+0.\nWhen equipped creature deals combat damage to a player, unattach Elbrus, the Binding Blade, then transform it.\nEquip {1}",
             "colours": [],
@@ -5365,7 +5365,7 @@
         },
         {
             "id": "5b2da00b-8ae3-5a52-b377-163555853a69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg?1",
             "name": "Elbrus, the Binding Blade // Withengar Unbound",
             "text": "Flying, intimidate, trample\nWhenever a player loses the game, put thirteen +1/+1 counters on Withengar Unbound.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "5e2680da-81b0-590c-991b-d5f7ebf21192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7447d115-9b29-4086-8435-40c7c957f242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7447d115-9b29-4086-8435-40c7c957f242.jpg?1",
             "name": "Executioner's Hood",
             "text": "Equipped creature has intimidate. (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5431,7 +5431,7 @@
         },
         {
             "id": "76fbb5ac-829d-5f43-9f79-a5392d7c944c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6240e7-d3aa-40e9-a627-58e7bf62525c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6240e7-d3aa-40e9-a627-58e7bf62525c.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "Creature cards can't enter the battlefield from graveyards or libraries.\nPlayers can't cast cards in graveyards or libraries.",
             "colours": [],
@@ -5459,7 +5459,7 @@
         },
         {
             "id": "8ea7c557-99df-537d-97d3-1cea1ea2236e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b09df01-0b3e-463e-bf00-0a9f1822261a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b09df01-0b3e-463e-bf00-0a9f1822261a.jpg?1",
             "name": "Heavy Mattock",
             "text": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human, it gets an additional +1/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5489,7 +5489,7 @@
         },
         {
             "id": "9d55721e-5345-5a3a-8acc-711df27a0166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2448c-1b2e-466a-a0ab-e20ba1de6bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2448c-1b2e-466a-a0ab-e20ba1de6bc9.jpg?1",
             "name": "Helvault",
             "text": "{1}, {T}: Exile target creature you control.\n{7}, {T}: Exile target creature you don't control.\nWhen Helvault is put into a graveyard from the battlefield, return all cards exiled with it to the battlefield under their owners' control.",
             "colours": [],
@@ -5519,7 +5519,7 @@
         },
         {
             "id": "644ff745-3b5f-5f7c-8880-ed5434937d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72825270-d5c1-4ab1-903a-e2868ade17f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72825270-d5c1-4ab1-903a-e2868ade17f2.jpg?1",
             "name": "Jar of Eyeballs",
             "text": "Whenever a creature you control dies, put two eyeball counters on Jar of Eyeballs.\n{3}, {T}, Remove all eyeball counters from Jar of Eyeballs: Look at the top X cards of your library, where X is the number of eyeball counters removed this way. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [],
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "170f00bc-d1a6-5f78-b909-a01ece5545bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1a1f48-d46b-4b8e-a642-fc70fd9ef7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1a1f48-d46b-4b8e-a642-fc70fd9ef7df.jpg?1",
             "name": "Warden of the Wall",
             "text": "Warden of the Wall enters the battlefield tapped.\n{T}: Add {1} to your mana pool.\nAs long as it's not your turn, Warden of the Wall is a 2/3 Gargoyle artifact creature with flying.",
             "colours": [],
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "1bfe8246-2fa6-54b8-aee1-62474a1401b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84c9b19-9b4d-4a60-984f-636b749c8bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84c9b19-9b4d-4a60-984f-636b749c8bcc.jpg?1",
             "name": "Wolfhunter's Quiver",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target creature or player\" and \"{T}: This creature deals 3 damage to target Werewolf creature.\"\nEquip {5}",
             "colours": [],
@@ -5605,7 +5605,7 @@
         },
         {
             "id": "0dd27d0a-2a8b-5325-b46f-545c3e7f32fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30066306-f943-44c1-8814-b8b60388c26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30066306-f943-44c1-8814-b8b60388c26d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "67517604-4b50-57ae-b3a0-c7f54bfea63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045abeeb-f5e5-4f3f-9836-5b1553e03f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045abeeb-f5e5-4f3f-9836-5b1553e03f11.jpg?1",
             "name": "Grim Backwoods",
             "text": "{T}: Add {1} to your mana pool.\n{2}{B}{G}, {T}, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "c80a61c9-7d6f-5e4b-b8ab-cbae6fac2985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bca9e1-c0b7-4dce-9ee4-370db2c322b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bca9e1-c0b7-4dce-9ee4-370db2c322b6.jpg?1",
             "name": "Haunted Fengraf",
             "text": "{T}: Add {1} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
             "colours": [],
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "86bcb705-43f2-5348-8b39-97c7ba5a0e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a65437-430a-42ef-854f-6e66f8e1a04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a65437-430a-42ef-854f-6e66f8e1a04a.jpg?1",
             "name": "Vault of the Archangel",
             "text": "{T}: Add {1} to your mana pool.\n{2}{W}{B}, {T}: Creatures you control gain deathtouch and lifelink until end of turn.",
             "colours": [],
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "5b9a227b-eac7-53f0-bd82-e1837d0bbe79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5cd362-34f9-445f-85e1-9f6694f0f90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5cd362-34f9-445f-85e1-9f6694f0f90a.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -5757,7 +5757,7 @@
         },
         {
             "id": "d22c8edf-740f-5145-9b41-f1f786a968c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6abdaa-7be5-48a1-acc9-b3cba4c10619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6abdaa-7be5-48a1-acc9-b3cba4c10619.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "1d0792f5-6ed6-5385-9a96-87b472909d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddaaf-b6a7-4c80-9b38-5ab68181b3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddaaf-b6a7-4c80-9b38-5ab68181b3d6.jpg?1",
             "name": "Sorin, Lord of Innistrad Emblem",
             "text": "",
             "colours": [],
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "098155d6-fa7c-5b32-8921-9d3c17840552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c61e7-bf33-45ea-af78-97ab3bc96753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c61e7-bf33-45ea-af78-97ab3bc96753.jpg?1",
             "name": "Dark Ascension Checklist",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/DMR.json
+++ b/Assets/Resources/Sets/DMR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7c746310-21dd-5fe5-89df-cc81b8016a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe359e9-2ac8-48ae-9a43-e2f12fd4a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe359e9-2ac8-48ae-9a43-e2f12fd4a785.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "9f6b8cdd-0e8d-5767-b12b-0f52c1fbd4a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a21cf44-4d8e-4b24-a1fe-4222c857f0ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a21cf44-4d8e-4b24-a1fe-4222c857f0ef.jpg?1",
             "name": "Battle Screech",
             "text": "Create two 1/1 white Bird creature tokens with flying.\nFlashback\u2014\nTap three untapped white creatures you control. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "eb79745a-b32d-5032-bfff-a4691960a9cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b24ae-590f-4a79-8aeb-b006de6545ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b24ae-590f-4a79-8aeb-b006de6545ca.jpg?1",
             "name": "Cleric of the Forward Order",
             "text": "When Cleric of the Forward Order enters the battlefield, you gain 2 life for each creature you control named Cleric of the Forward Order.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "f932ba62-b536-536a-bc5d-1401b4e2884e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89396f5e-5bc3-4c8a-976b-2cb2946eb35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89396f5e-5bc3-4c8a-976b-2cb2946eb35d.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "bbf92633-3ae0-5f1c-94db-b8105d80f7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d4044-f2bd-470a-8468-a319e0a21d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d4044-f2bd-470a-8468-a319e0a21d8d.jpg?1",
             "name": "Divine Sacrament",
             "text": "White creatures get +1/+1.\nThreshold \u2014 White creatures get an additional +1/+1 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "3faa652f-b9e1-51c3-ae4a-4dc6aedb4042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9675fb-1a89-420f-aea8-50e0642f549c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9675fb-1a89-420f-aea8-50e0642f549c.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "60988864-36c2-59d5-9d0b-08a97a1fe5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b01ebcf-8451-486e-84f6-8e6e1bb9d6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b01ebcf-8451-486e-84f6-8e6e1bb9d6e3.jpg?1",
             "name": "Glory",
             "text": "Flying\n{2}{W}: Choose a color. Creatures you control gain protection from the chosen color until end of turn. Activate only if Glory is in your graveyard.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "dcfc78db-777b-50a2-a389-5ef828bb9934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf5e-10f6-49aa-82eb-2f56cc29d393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf5e-10f6-49aa-82eb-2f56cc29d393.jpg?1",
             "name": "Griffin Guide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\nWhen enchanted creature dies, create a 2/2 white Griffin creature token with flying.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "c0a52805-c0e7-52d5-be95-51d95e3f9168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccce13a-77e6-4c74-9acc-d5e7c271872a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccce13a-77e6-4c74-9acc-d5e7c271872a.jpg?1",
             "name": "Icatian Javelineers",
             "text": "Icatian Javelineers enters the battlefield with a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: It deals 1 damage to any target.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "7a62762f-5c46-5fff-8c01-eade42eaa0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c205ba-cafb-4afc-83fe-09fff38130d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c205ba-cafb-4afc-83fe-09fff38130d7.jpg?1",
             "name": "Improvised Armor",
             "text": "Enchant creature\nEnchanted creature gets +2/+5.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "ac3db2ae-f541-5f56-a088-6b63729283cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c090af7-3f75-4c14-9ab5-1f409dfd6de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c090af7-3f75-4c14-9ab5-1f409dfd6de1.jpg?1",
             "name": "Kjeldoran Gargoyle",
             "text": "Flying, first strike\nWhenever Kjeldoran Gargoyle deals damage, you gain that much life.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "0bff34c9-6f97-51ae-a150-4a156772985a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba0c3-237e-4349-85e9-c31b016f609b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba0c3-237e-4349-85e9-c31b016f609b.jpg?1",
             "name": "Lieutenant Kirtar",
             "text": "Flying\n{1}{W}, Sacrifice Lieutenant Kirtar: Exile target attacking creature.",
             "colours": [
@@ -419,7 +419,7 @@
         },
         {
             "id": "82d7d15f-bc46-5804-9dce-ed8c902628cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e0c8c5-ea0e-4347-b5cb-b7b1801a523b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e0c8c5-ea0e-4347-b5cb-b7b1801a523b.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "ccb69180-b368-50a9-8d88-8756f8c4fb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d9309f-497e-4807-a9cc-f41887a73ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d9309f-497e-4807-a9cc-f41887a73ca0.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "58f11500-47fc-5129-8823-99295ec70482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619c620d-1920-40d1-98d4-df5607f84d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619c620d-1920-40d1-98d4-df5607f84d26.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "cd234c85-b18b-5574-91dc-63f82fe39920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc955bd-b998-44b9-918f-84b96cf5e915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc955bd-b998-44b9-918f-84b96cf5e915.jpg?1",
             "name": "Mystic Zealot",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Mystic Zealot gets +1/+1 and has flying.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "5f802dcb-ddc3-525a-9d9d-7efa48aeeec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da039589-f3ee-4aff-b8b0-e5fda13ebe97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da039589-f3ee-4aff-b8b0-e5fda13ebe97.jpg?1",
             "name": "Nomad Decoy",
             "text": "{W}, {T}: Tap target creature.\nThreshold \u2014 {W}{W}, {T}: Tap two target creatures. Activate only if seven or more cards are in your graveyard.",
             "colours": [
@@ -601,7 +601,7 @@
         },
         {
             "id": "104a3f1d-84d3-5492-b6f2-95c07def9ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f86bba5-e203-4a86-a415-ce748f6d1f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f86bba5-e203-4a86-a415-ce748f6d1f6f.jpg?1",
             "name": "Orim's Thunder",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nDestroy target artifact or enchantment. If this spell was kicked, it deals damage equal to that permanent's mana value to target creature.",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "9aea009d-4b67-5bc2-a320-8caf339c5115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5242a576-4d35-4f29-8d40-9a7179e51d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5242a576-4d35-4f29-8d40-9a7179e51d0c.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "95080914-3e05-53de-bc7d-e3773101a547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314602ae-fb42-4afe-9fab-fa6976db39ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314602ae-fb42-4afe-9fab-fa6976db39ad.jpg?1",
             "name": "Phantom Flock",
             "text": "Flying\nPhantom Flock enters the battlefield with three +1/+1 counters on it.\nIf damage would be dealt to Phantom Flock, prevent that damage. Remove a +1/+1 counter from Phantom Flock.",
             "colours": [
@@ -704,7 +704,7 @@
         },
         {
             "id": "06d5fb55-f048-5beb-8efb-adeacc33563a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5abbdd37-dc24-4bf7-808e-6354af7d7ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5abbdd37-dc24-4bf7-808e-6354af7d7ec6.jpg?1",
             "name": "Radiant's Judgment",
             "text": "Destroy target creature with power 4 or greater.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "7d9f5490-5ec8-5b75-bc77-5dfd6dd25f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9700fe0e-bf71-463b-ad7b-34831c7f9e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9700fe0e-bf71-463b-ad7b-34831c7f9e99.jpg?1",
             "name": "Remedy",
             "text": "Prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "7f573fd2-8251-5ad7-8ea2-f6cd8957b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d66dd3-330f-4b12-81f6-52d7a31013a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d66dd3-330f-4b12-81f6-52d7a31013a9.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "c80dbd6a-f50b-59b2-a957-14e88fc29aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e770d089-9957-412c-a51f-3f11b6b9692a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e770d089-9957-412c-a51f-3f11b6b9692a.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -838,7 +838,7 @@
         },
         {
             "id": "a9cf4a26-4025-5e11-8760-3ec4c96caa6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f949cbb1-c8a8-4f26-b12d-c58a0605cb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f949cbb1-c8a8-4f26-b12d-c58a0605cb14.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -874,7 +874,7 @@
         },
         {
             "id": "5cf3532b-eb44-5a92-b50f-3638adbf3b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041dcfd-c1af-448c-91f7-75fd1d34e93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041dcfd-c1af-448c-91f7-75fd1d34e93e.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar's power and toughness are each equal to your life total.\nWhen Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "9452982f-c6c0-58d3-ae37-f5efaa551f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b272b9a-9348-4eaa-8978-2fe549182c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b272b9a-9348-4eaa-8978-2fe549182c84.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "bffd7db1-59ed-5484-96b2-5652730ec6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa545eb-aa45-4085-8472-676f5d5e1c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa545eb-aa45-4085-8472-676f5d5e1c48.jpg?1",
             "name": "Spectral Lynx",
             "text": "Protection from green\n{B}: Regenerate Spectral Lynx. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "0636f33e-e5c4-5840-9d56-17290e39615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc046a97-4699-438d-8da4-022560a18564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc046a97-4699-438d-8da4-022560a18564.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "c75a09e5-5995-5150-85f5-8f943a205b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e33908-cf4f-45b4-8d97-a117308187f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e33908-cf4f-45b4-8d97-a117308187f7.jpg?1",
             "name": "Sun Clasp",
             "text": "Enchant creature\nEnchanted creature gets +1/+3.\n{W}: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "2bc3fd8b-8f58-517f-858e-83bd754fa21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d839f21-68c7-47db-8407-ff3e2c3e13b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d839f21-68c7-47db-8407-ff3e2c3e13b4.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "a0dd5b1d-9107-581d-abfb-59541260cc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76841945-8ff1-4c2d-895e-d1e2cf468cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76841945-8ff1-4c2d-895e-d1e2cf468cff.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "f08556f6-181b-54a3-a70e-eea1b1b1806b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75772e5-257e-4b08-90a4-492a43f229b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75772e5-257e-4b08-90a4-492a43f229b3.jpg?1",
             "name": "Vigilant Sentry",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Vigilant Sentry gets +1/+1 and has \"{T}: Target attacking or blocking creature gets +3/+3 until end of turn.\"",
             "colours": [
@@ -1154,7 +1154,7 @@
         },
         {
             "id": "94ccc284-8595-5253-a266-07e25329f9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1c31-fb33-4f5c-b766-6ca8ad6e0976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1c31-fb33-4f5c-b766-6ca8ad6e0976.jpg?1",
             "name": "Voice of All",
             "text": "Flying\nAs Voice of All enters the battlefield, choose a color.\nVoice of All has protection from the chosen color.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "81cf3d9e-bfb0-5992-b7ca-11d3700e6c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a358def9-65a0-4741-896c-b2a8c8947768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a358def9-65a0-4741-896c-b2a8c8947768.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "7e803ebf-4035-502f-b7b1-35e97b250c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b72ba3c-12f5-47d0-adaa-f470ad3a416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b72ba3c-12f5-47d0-adaa-f470ad3a416c.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "88940600-d5cb-5450-8556-abd1ca1a2899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3700519-b74c-4445-b42e-03690b8d4463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3700519-b74c-4445-b42e-03690b8d4463.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "0f87776b-fdb2-59fe-8c7a-6d031caa1f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62721a55-37c6-4c05-aedf-0aa203045afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62721a55-37c6-4c05-aedf-0aa203045afa.jpg?1",
             "name": "Aquamoeba",
             "text": "Discard a card: Switch Aquamoeba's power and toughness until end of turn.",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "b1d2c640-f7c9-5aaf-bb70-a75205fe2567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2074ed36-fbae-4886-b3ad-360fdfbb69cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2074ed36-fbae-4886-b3ad-360fdfbb69cd.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "5faa0dae-6c8d-5a44-9c9e-0433351448b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9ed6d-2c26-4cb8-8ecf-8c02a534b9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9ed6d-2c26-4cb8-8ecf-8c02a534b9eb.jpg?1",
             "name": "Aven Fateshaper",
             "text": "Flying\nWhen Aven Fateshaper enters the battlefield, look at the top four cards of your library, then put them back in any order.\n{4}{U}: Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "469f066a-c49b-57e0-9f0f-0c728433e5ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8cd57-df68-4f6d-9612-21e66b9f0190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8cd57-df68-4f6d-9612-21e66b9f0190.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying\nWhen Aven Fisher dies, you may draw a card.",
             "colours": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "f3c04e55-eb98-50ee-a7b2-140fce6b44c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b19fdac-da3e-4ebd-ae7b-6f31a97b2a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b19fdac-da3e-4ebd-ae7b-6f31a97b2a0f.jpg?1",
             "name": "Circular Logic",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "b1c671b3-47b2-52d1-8312-fe3e7aff91ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed95f539-1d8b-408b-9af2-8c6f93fb98c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed95f539-1d8b-408b-9af2-8c6f93fb98c8.jpg?1",
             "name": "Cloud of Faeries",
             "text": "Flying\nWhen Cloud of Faeries enters the battlefield, untap up to two lands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "a264aa90-bb40-5a33-9675-1ebaab7800b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dca85-a880-4ea2-a483-072bb50b7aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dca85-a880-4ea2-a483-072bb50b7aee.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "ca9ea15a-862b-5343-baa8-ef27230a4614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02da8709-4228-4fed-9d2d-781e686661df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02da8709-4228-4fed-9d2d-781e686661df.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "2375b191-8ffc-5997-90a2-3d0cea4bab70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d675e0-0e79-4f90-b3d7-d4bfaedd4719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d675e0-0e79-4f90-b3d7-d4bfaedd4719.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1606,7 +1606,7 @@
         },
         {
             "id": "923eb364-1ba7-534c-8ab1-c920c6668cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7959e9-8ae7-49f7-acf9-a0fc2afa219e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7959e9-8ae7-49f7-acf9-a0fc2afa219e.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep enters the battlefield, return each other creature you control to its owner's hand.",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "e0a45f40-dcf6-5823-9a29-ba5972a913ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758a8b6-f586-4d27-9379-8f7c4a78d90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758a8b6-f586-4d27-9379-8f7c4a78d90c.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "b4a29ef8-f460-5d4e-901e-f950faaa034f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600b315b-58f8-4b1b-b210-f09e3e5e3b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600b315b-58f8-4b1b-b210-f09e3e5e3b27.jpg?1",
             "name": "Floodgate",
             "text": "Defender\nWhen Floodgate has flying, sacrifice it.\nWhen Floodgate leaves the battlefield, it deals damage to each nonblue creature without flying equal to half the number of Islands you control, rounded down.",
             "colours": [
@@ -1711,7 +1711,7 @@
         },
         {
             "id": "798f944f-a711-584d-a15b-d8ee886f68c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f612d6-7c59-4a7b-a87d-45f789e88ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f612d6-7c59-4a7b-a87d-45f789e88ba5.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "37c2a404-e90f-5e7c-b241-dff600105c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cceaa53-5cac-415c-ad52-6299d6934ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cceaa53-5cac-415c-ad52-6299d6934ba0.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "617a1e98-5b17-5e79-96c3-1275b79d3690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b26379-0007-450e-9b94-2932eef6ac2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b26379-0007-450e-9b94-2932eef6ac2c.jpg?1",
             "name": "Glintwing Invoker",
             "text": "{7}{U}: Glintwing Invoker gets +3/+3 and gains flying until end of turn.",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "174429bf-31c1-58b9-95d6-bc6708012f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50762ad-494a-46fa-811f-4e472de8cebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50762ad-494a-46fa-811f-4e472de8cebd.jpg?1",
             "name": "Hermetic Study",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to any target.\"",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "82b89a01-d566-5e62-a707-9a1b63459823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babd2248-5517-4b7b-a159-9a1f7b5583c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babd2248-5517-4b7b-a159-9a1f7b5583c8.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "fa2cbcd5-37d8-57f8-a1c5-10f3b462dbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8ba7cc-2586-497a-8b62-4342a3f19506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8ba7cc-2586-497a-8b62-4342a3f19506.jpg?1",
             "name": "Horseshoe Crab",
             "text": "{U}: Untap Horseshoe Crab.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "1bca0f5b-5d8e-5a7e-ab39-a460c2a98021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec50625-5e14-4fd0-9a96-86f195342695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec50625-5e14-4fd0-9a96-86f195342695.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "9dd06365-457a-5758-ba64-c8f76076578b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49427c35-7d24-4047-94f6-070d0084ee31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49427c35-7d24-4047-94f6-070d0084ee31.jpg?1",
             "name": "Leaden Fists",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +3/+3 and doesn't untap during its controller's untap step.",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "f972fb8e-faa6-5147-baa3-92d71f0cd83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ef40d5-c287-4229-8059-3505d9f251ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ef40d5-c287-4229-8059-3505d9f251ca.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "acc99cd5-e276-5be3-87d9-632e5fe7fcda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40140991-cffa-4b52-9a25-37e9a8aa9ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40140991-cffa-4b52-9a25-37e9a8aa9ddd.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "7c1d9e74-e795-524c-8eb9-50d5d077b46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fa9a0b-b0c9-43ea-ba11-99d7982f974e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fa9a0b-b0c9-43ea-ba11-99d7982f974e.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -2091,7 +2091,7 @@
         },
         {
             "id": "32cdcefa-74d6-56c9-a61a-b10c481a553d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d97436e-329a-49a4-a7c9-671ec9ba90cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d97436e-329a-49a4-a7c9-671ec9ba90cc.jpg?1",
             "name": "Obsessive Search",
             "text": "Draw a card.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "b3941729-06de-5963-a074-cece40ba1b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae14acde-8a5c-4f0e-8e68-b799a363b9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae14acde-8a5c-4f0e-8e68-b799a363b9f7.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "0ad7a2bf-68c4-5c5d-816e-e36272f9a92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92204e3-2c98-4834-a838-ddc9f85fdeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92204e3-2c98-4834-a838-ddc9f85fdeea.jpg?1",
             "name": "Ovinize",
             "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "5b48d071-e765-512c-b989-3fd3aa2e5a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af3166-6338-4fac-bfa6-cea19daefc62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af3166-6338-4fac-bfa6-cea19daefc62.jpg?1",
             "name": "Ovinomancer",
             "text": "When Ovinomancer enters the battlefield, sacrifice it unless you return three basic lands you control to their owner's hand.\n{T}, Return Ovinomancer to its owner's hand: Destroy target creature. It can't be regenerated. That creature's controller creates a 0/1 green Sheep creature token.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "626c4a72-1086-5986-b135-be3cc2200041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611c8fa2-b53f-483b-9efa-759ac59dc30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611c8fa2-b53f-483b-9efa-759ac59dc30f.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake enters the battlefield, untap up to five lands.",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "45c8e4c7-9e6d-5396-b45d-23b8519a0fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13406c6-f208-402a-94d3-a94a24f03563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13406c6-f208-402a-94d3-a94a24f03563.jpg?1",
             "name": "Snap",
             "text": "Return target creature to its owner's hand. Untap up to two lands.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "8e384ef9-0ba5-5ccc-97d6-181089481b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5b8542-f8b9-4b98-89ee-ce577b862bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5b8542-f8b9-4b98-89ee-ce577b862bce.jpg?1",
             "name": "Stroke of Genius",
             "text": "Target player draws X cards.",
             "colours": [
@@ -2328,7 +2328,7 @@
         },
         {
             "id": "0c50a4ef-a68f-56aa-a637-3038d3b3dd79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9a1760-d681-471d-b3a2-ca5051b8bed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9a1760-d681-471d-b3a2-ca5051b8bed3.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying\nWhenever Thieving Magpie deals damage to an opponent, draw a card.",
             "colours": [
@@ -2362,7 +2362,7 @@
         },
         {
             "id": "e6af1e0c-7eff-54ac-91d2-dcb959675894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc791fd-d49c-4c66-b8fb-6b54ce842e90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc791fd-d49c-4c66-b8fb-6b54ce842e90.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "5a383838-7b7b-5b70-99fa-911f2055be5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cfc84b-88ae-4fb8-b568-e0635e2a194a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cfc84b-88ae-4fb8-b568-e0635e2a194a.jpg?1",
             "name": "Turnabout",
             "text": "Choose artifact, creature, or land. Tap all untapped permanents of the chosen type target player controls, or untap all tapped permanents of that type that player controls.",
             "colours": [
@@ -2431,7 +2431,7 @@
         },
         {
             "id": "13f19804-433b-554e-9033-1928602c20fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b26e53-1fc2-4d07-a56f-9000ed25580d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b26e53-1fc2-4d07-a56f-9000ed25580d.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "48182289-e848-585e-ba95-5dff6228e9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1964316-82c7-4ee1-a7cc-d969c6254ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1964316-82c7-4ee1-a7cc-d969c6254ace.jpg?1",
             "name": "Veiled Serpent",
             "text": "When an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature with \"This creature can't attack unless defending player controls an Island.\" (It's no longer an enchantment.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "381fa687-b00f-598a-a85f-9dcf8b259531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c75f806-b900-403c-8de1-cc3173afc8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c75f806-b900-403c-8de1-cc3173afc8f0.jpg?1",
             "name": "Vexing Sphinx",
             "text": "Flying\nCumulative upkeep\u2014\nDiscard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Vexing Sphinx dies, draw a card for each age counter on it.",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "998245da-d41b-572b-96f4-8e7ca3561bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501128c7-c541-4de8-a041-9367c032dbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501128c7-c541-4de8-a041-9367c032dbb3.jpg?1",
             "name": "Wormfang Drake",
             "text": "Flying\nWhen Wormfang Drake enters the battlefield, sacrifice it unless you exile a creature you control other than Wormfang Drake.\nWhen Wormfang Drake leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "caa8a50c-492b-546c-bce8-83ad8face919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7d83a8-3bad-40cf-991c-fc7f8e399c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7d83a8-3bad-40cf-991c-fc7f8e399c42.jpg?1",
             "name": "Body Snatcher",
             "text": "When Body Snatcher enters the battlefield, exile it unless you discard a creature card.\nWhen Body Snatcher dies, exile it and return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -2611,7 +2611,7 @@
         },
         {
             "id": "93e3b7d2-0a5f-560c-859b-4c3f7bdea49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4fa7f-a5d7-46cd-bc46-d3d231235460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4fa7f-a5d7-46cd-bc46-d3d231235460.jpg?1",
             "name": "Cackling Fiend",
             "text": "When Cackling Fiend enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "54d6f61c-843f-542e-a6d3-e1cc31ba0c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c294695b-a096-441a-9034-91ca74763903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c294695b-a096-441a-9034-91ca74763903.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "95aabd08-cbe8-5145-a813-1e97dd46114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c204471-d908-4a08-83e4-cf38999fa80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c204471-d908-4a08-83e4-cf38999fa80f.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2720,7 +2720,7 @@
         },
         {
             "id": "6104f20c-f86c-5ce7-8296-5f708e0367ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6996d612-28a5-4515-baba-9aad65bf4b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6996d612-28a5-4515-baba-9aad65bf4b28.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "329ff93d-ef34-5d0c-b28b-7c6108ce0925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb7707b-e779-4429-b741-5d3b842a50cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb7707b-e779-4429-b741-5d3b842a50cb.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "0d2228c1-cbb1-5355-bab5-eb36a2fc1044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cd43ba-646b-44b3-a1a5-0e6b6ceca866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cd43ba-646b-44b3-a1a5-0e6b6ceca866.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "30c197be-13af-50dd-96f3-c362d9e92b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caa9c55-5e3b-436b-84a9-b7ccebf63799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caa9c55-5e3b-436b-84a9-b7ccebf63799.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "bab9570c-76bc-54a1-ba9c-d46fbea1d2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3dbd4-7c3d-49df-98b0-068db5399083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3dbd4-7c3d-49df-98b0-068db5399083.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "Non-Eye creatures you control can't attack.\nEvil Eye of Orms-by-Gore can't be blocked except by Walls.",
             "colours": [
@@ -2891,7 +2891,7 @@
         },
         {
             "id": "f1a63607-77d4-5afc-b20e-7870200795ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5511e2-a218-411e-aea3-96461e9c5fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5511e2-a218-411e-aea3-96461e9c5fdd.jpg?1",
             "name": "Faceless Butcher",
             "text": "When Faceless Butcher enters the battlefield, exile another target creature.\nWhen Faceless Butcher leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "380fe0cd-c965-5783-a88b-d43da8a82ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b039f65e-1287-4c6e-a1c2-773a008fc0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b039f65e-1287-4c6e-a1c2-773a008fc0a3.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin dies, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2961,7 +2961,7 @@
         },
         {
             "id": "aa17bc11-67e4-55c0-a2af-33f96ddcc6a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d56f46a-7327-4d98-b194-272333c8171e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d56f46a-7327-4d98-b194-272333c8171e.jpg?1",
             "name": "Flesh Reaver",
             "text": "Whenever Flesh Reaver deals damage to a creature or opponent, Flesh Reaver deals that much damage to you.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "74bdee4f-e916-5dc5-8a46-77c8f1578d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9e49ee-9103-4340-bf92-f888c722af47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9e49ee-9103-4340-bf92-f888c722af47.jpg?1",
             "name": "Goblin Turncoat",
             "text": "Sacrifice a Goblin: Regenerate Goblin Turncoat. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "95804fc4-b89c-5a22-9471-d6278bf56be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ef6b1c-2a86-415f-a5e3-c4b4f73a4de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ef6b1c-2a86-415f-a5e3-c4b4f73a4de0.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "8054f3d1-ae77-55ed-a0cd-7937b0deeaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875b7d0b-8354-41a0-9a53-8bc19ffdc016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875b7d0b-8354-41a0-9a53-8bc19ffdc016.jpg?1",
             "name": "Hyalopterous Lemure",
             "text": "{0}: Hyalopterous Lemure gets -1/-0 and gains flying until end of turn.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "2eea4284-cba4-577f-91be-1fc07c4b18b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db67828-5697-45fd-87db-ff27ef9cec5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db67828-5697-45fd-87db-ff27ef9cec5a.jpg?1",
             "name": "Ichor Slick",
             "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "b3add679-aa1e-5893-9e2b-873664a2d281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc86134-8af6-4355-b1ad-96917c99ff3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc86134-8af6-4355-b1ad-96917c99ff3c.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer dies, each player discards their hand.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "97e9281b-98c3-5ac6-8188-f073b558292f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4c5dd4-79dc-4bd2-8c18-897924a4a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4c5dd4-79dc-4bd2-8c18-897924a4a959.jpg?1",
             "name": "Nantuko Shade",
             "text": "{B}: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "31694a90-2e78-55dc-ac15-01f8bdbd35fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ce2548-38d3-4763-960a-d5d802094a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ce2548-38d3-4763-960a-d5d802094a0c.jpg?1",
             "name": "Necrosavant",
             "text": "{3}{B}{B}, Sacrifice a creature: Return Necrosavant from your graveyard to the battlefield. Activate only during your upkeep.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "a1e41437-34d6-5ce9-b074-4bfae788f3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1918f-ad58-4f62-bd8c-649919de0e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1918f-ad58-4f62-bd8c-649919de0e75.jpg?1",
             "name": "Nightscape Familiar",
             "text": "Blue spells and red spells you cast cost {1} less to cast.\n{1}{B}: Regenerate Nightscape Familiar. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "c56f9b73-3761-5ff8-9bd6-5788d4761c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c5e1dd-2fe6-4734-8406-7bcdf17aa60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c5e1dd-2fe6-4734-8406-7bcdf17aa60c.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature deals damage to you, destroy it.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "a2a18633-4ca5-5ab0-a265-f0a1fb9b16ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b7312a-c775-4fa8-ba62-c84ff38459e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b7312a-c775-4fa8-ba62-c84ff38459e8.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "bfab7167-512b-57e0-98bf-5f96bd0dee13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e2c6ac-455e-4d99-983b-1b154fd8bb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e2c6ac-455e-4d99-983b-1b154fd8bb24.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\n{T}, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "dea8d864-3287-5543-bcde-b397d15e5221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08586285-9a42-48ef-9188-0dd5d7294ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08586285-9a42-48ef-9188-0dd5d7294ad2.jpg?1",
             "name": "Phyrexian Ghoul",
             "text": "Sacrifice a creature: Phyrexian Ghoul gets +2/+2 until end of turn.",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "0aa04796-0164-5750-b8c1-c9facdac26c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db97152-afd5-4190-8bf1-1276b0fcf005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db97152-afd5-4190-8bf1-1276b0fcf005.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "e43604dd-03bb-5e41-8273-60dea33c35c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5b3b5c-121a-406e-a31a-537991309399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5b3b5c-121a-406e-a31a-537991309399.jpg?1",
             "name": "Phyrexian Scuta",
             "text": "Kicker\u2014\nPay 3 life. (You may pay 3 life in addition to any other costs as you cast this spell.)\nIf Phyrexian Scuta was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "66bf9da7-3bb9-5163-8225-f5674945476d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef9842-7142-4c63-8aea-fa73f02722a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef9842-7142-4c63-8aea-fa73f02722a5.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "561ffd1d-f062-5a80-9381-b924781c9ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d09cc57-2275-4b6b-aaf6-a6d781cd9365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d09cc57-2275-4b6b-aaf6-a6d781cd9365.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3557,7 +3557,7 @@
         },
         {
             "id": "74a571c0-938c-5c45-8148-a6ca2661a4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3870eba-4e8f-414d-817c-14ec97f6a93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3870eba-4e8f-414d-817c-14ec97f6a93c.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "8eb3812f-c912-53da-8823-1c618a726e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c26af-2b73-48fd-b7e3-ba217c9853d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c26af-2b73-48fd-b7e3-ba217c9853d3.jpg?1",
             "name": "Twisted Experiment",
             "text": "Enchant creature\nEnchanted creature gets +3/-1.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "e5692ad0-71a5-5d1d-a5ae-305d2c3ca772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a3d34-4e4e-4545-8e2e-6977eb754270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a3d34-4e4e-4545-8e2e-6977eb754270.jpg?1",
             "name": "Undead Gladiator",
             "text": "{1}{B}, Discard a card: Return Undead Gladiator from your graveyard to your hand. Activate only during your upkeep.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "08e871e9-3f50-5fd8-9f6a-fd783452b646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857d76-f2ca-4323-9611-cb20b9615202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857d76-f2ca-4323-9611-cb20b9615202.jpg?1",
             "name": "Urborg Syphon-Mage",
             "text": "{2}{B}, {T}, Discard a card: Each other player loses 2 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "6e84a56b-85f7-5e7a-9d36-c9633f36faed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497dedba-909a-4f1d-8b05-39c512007fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497dedba-909a-4f1d-8b05-39c512007fbd.jpg?1",
             "name": "Urborg Uprising",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "9b7ad9b0-40b5-5758-a525-c707015c5e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0203f-9cce-43a4-9cb7-8ce6647895cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0203f-9cce-43a4-9cb7-8ce6647895cd.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "7dc01727-9e47-5ce9-85fe-eb61ee65decf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8635a8-9e12-4e15-b757-892d0154caea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8635a8-9e12-4e15-b757-892d0154caea.jpg?1",
             "name": "Wretched Anurid",
             "text": "Whenever another creature enters the battlefield, you lose 1 life.",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "7fb06063-3cbb-56de-811d-eab8e92698ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a79f5d-d0df-4799-ac3a-84305e3af0c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a79f5d-d0df-4799-ac3a-84305e3af0c9.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "a6c0f5ee-8810-5b15-9bc3-032ab554dd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2c8aca-3ade-46b0-8366-ab3b244eca01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2c8aca-3ade-46b0-8366-ab3b244eca01.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards: Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "3f279845-042a-5343-995d-8b4f59d4f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895ddf9-7d94-411c-ad2e-90d47e51810d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895ddf9-7d94-411c-ad2e-90d47e51810d.jpg?1",
             "name": "Avarax",
             "text": "Haste\nWhen Avarax enters the battlefield, you may search your library for a card named Avarax, reveal it, put it into your hand, then shuffle.\n{1}{R}: Avarax gets +1/+0 until end of turn.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "295c2d3b-405a-51da-97fd-62fae4e8862c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2105a0d9-ea2e-4ffc-be08-424b5617205d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2105a0d9-ea2e-4ffc-be08-424b5617205d.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "0bcab18c-3b64-5699-982d-b77aad60e7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c8578e-052f-4182-9bb1-fb35450d22c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c8578e-052f-4182-9bb1-fb35450d22c0.jpg?1",
             "name": "Coal Stoker",
             "text": "When Coal Stoker enters the battlefield, if you cast it from your hand, add {R}{R}{R}.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "267bcf00-11de-5d81-997e-155e23b3d6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f9cb4d-5ee2-4934-a0ca-43148491ae35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f9cb4d-5ee2-4934-a0ca-43148491ae35.jpg?1",
             "name": "Deadapult",
             "text": "{R}, Sacrifice a Zombie: Deadapult deals 2 damage to any target.",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "d09b96de-fdc8-5cd0-a1aa-7e87d383da95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7520ad-3b13-41a6-82b2-fef562545f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7520ad-3b13-41a6-82b2-fef562545f1c.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice Dragon Whelp at the beginning of the next end step.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "ebbc1129-2af1-5291-923f-e095eaa94d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75faca7-cfcf-4c3b-a507-c89659cce93a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75faca7-cfcf-4c3b-a507-c89659cce93a.jpg?1",
             "name": "Ember Beast",
             "text": "Ember Beast can't attack or block alone.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "778c4a7a-2cec-54e8-8ce3-bf256c05d1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939d765a-aefb-4393-8808-98b1bbd7e803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939d765a-aefb-4393-8808-98b1bbd7e803.jpg?1",
             "name": "Empty the Warrens",
             "text": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -4110,7 +4110,7 @@
         },
         {
             "id": "33933583-a8ad-5c17-9e50-764c214f90ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ab67cc-b553-4451-9cda-0e5fe3303940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ab67cc-b553-4451-9cda-0e5fe3303940.jpg?1",
             "name": "Fireblast",
             "text": "You may sacrifice two Mountains rather than pay this spell's mana cost.\nFireblast deals 4 damage to any target.",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "6669faa9-4639-5051-936f-336f25e74f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3a5139-3341-409e-be33-184897c7398e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3a5139-3341-409e-be33-184897c7398e.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -4181,7 +4181,7 @@
         },
         {
             "id": "999d6866-ec64-528d-8832-e883608ff5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e37fae5-ddd0-4e16-8581-71579f89d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e37fae5-ddd0-4e16-8581-71579f89d9c5.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "8f2a267a-2fa7-5f76-8975-2b17dba8bf00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c231e3-10ec-458b-bba1-891812e000f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c231e3-10ec-458b-bba1-891812e000f6.jpg?1",
             "name": "Gempalm Incinerator",
             "text": "Cycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins on the battlefield.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "33ea8c4c-f227-5e2b-9808-02303997a586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521a254-c484-4d59-bb7e-8745e96d4bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521a254-c484-4d59-bb7e-8745e96d4bbf.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "45ba6755-1d4f-5d1b-aa17-2f0a6a86f2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980d45cb-e9e6-4f09-9275-c3f2c538b57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980d45cb-e9e6-4f09-9275-c3f2c538b57c.jpg?1",
             "name": "Goblin Medics",
             "text": "Whenever Goblin Medics becomes tapped, it deals 1 damage to any target.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "74d61fc1-bd4f-5c3d-816e-cf3d673b05d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923e1291-3999-4f81-ade4-073fb982143f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923e1291-3999-4f81-ade4-073fb982143f.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to any target.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "0a0610e7-3059-5fa0-9e34-7847292711fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6ffe8-e1ad-4db9-98f7-d6038f271866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6ffe8-e1ad-4db9-98f7-d6038f271866.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "6a3a4199-778d-5f17-ba0b-d67caac3617b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efb595-d407-4389-a99d-d97c4d6bdcd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efb595-d407-4389-a99d-d97c4d6bdcd0.jpg?1",
             "name": "Last Chance",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -4428,7 +4428,7 @@
         },
         {
             "id": "0891d4f8-d695-5ae0-9ad1-46016c4fc947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9653f159-3f56-4446-bb6d-b4b4ee0cd61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9653f159-3f56-4446-bb6d-b4b4ee0cd61d.jpg?1",
             "name": "Lightning Reflexes",
             "text": "You may cast Lightning Reflexes as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nEnchant creature\nEnchanted creature gets +1/+0 and has first strike.",
             "colours": [
@@ -4462,7 +4462,7 @@
         },
         {
             "id": "47e001fa-2dea-5c34-bf75-7ece31e00219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b731b2-70cb-4e94-8c9a-d694f617a521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b731b2-70cb-4e94-8c9a-d694f617a521.jpg?1",
             "name": "Lightning Rift",
             "text": "Whenever a player cycles a card, you may pay {1}. If you do, Lightning Rift deals 2 damage to any target.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "d4c8b239-71b4-5f9e-9da0-ee8529f943cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c750f7d7-25b8-433f-b3a8-0d842b99276f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c750f7d7-25b8-433f-b3a8-0d842b99276f.jpg?1",
             "name": "Macetail Hystrodon",
             "text": "First strike, haste\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "8468b70c-c76d-56e1-b962-36f9eacd8868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7f39c-94a0-4ccb-b658-23095ada4005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7f39c-94a0-4ccb-b658-23095ada4005.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "7f27b517-9f82-536a-8223-260bc2bb027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e812a8-66cf-4005-a647-780d49aa74a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e812a8-66cf-4005-a647-780d49aa74a4.jpg?1",
             "name": "Overmaster",
             "text": "The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "603996b8-8bf3-5b93-a2e5-0ff2e46825e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20a650-65b0-4714-b7ce-0481af3db377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20a650-65b0-4714-b7ce-0481af3db377.jpg?1",
             "name": "Pashalik Mons",
             "text": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "e37c2617-c8e1-5492-8501-09f294711efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720a0e44-0675-488e-bfa5-ae557337e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720a0e44-0675-488e-bfa5-ae557337e9c4.jpg?1",
             "name": "Ridgetop Raptor",
             "text": "Double strike",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "2e4ecd80-86dc-56e8-9a03-8db48b42bae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b78eb49-bd68-47e6-90a3-83ec2eeb4312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b78eb49-bd68-47e6-90a3-83ec2eeb4312.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "49da47da-3fa9-5a61-a6ed-fb850fb45ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd6a913-88df-4fbc-964e-a8fec3ad989f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd6a913-88df-4fbc-964e-a8fec3ad989f.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "509b40e2-975a-5e1e-9bdf-73d5ce802b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc508b3-8b38-4cf0-89a7-a2cb247ed083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc508b3-8b38-4cf0-89a7-a2cb247ed083.jpg?1",
             "name": "Skirk Prospector",
             "text": "Sacrifice a Goblin: Add {R}.",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "3b775278-1076-56e8-9ecf-bb5fe3c39efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521e68e-b3dd-4cb4-a7fb-0f74c40f917b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521e68e-b3dd-4cb4-a7fb-0f74c40f917b.jpg?1",
             "name": "Slice and Dice",
             "text": "Slice and Dice deals 4 damage to each creature.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
             "colours": [
@@ -4812,7 +4812,7 @@
         },
         {
             "id": "4c973c8e-8497-5dc7-bd51-bbc799df61be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b4ca9-4355-4690-84c3-a7d44c367dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b4ca9-4355-4690-84c3-a7d44c367dbf.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "d884b2f9-116d-562b-b6f7-0f2d042383d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87202a72-72aa-46d3-ba16-10a180276905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87202a72-72aa-46d3-ba16-10a180276905.jpg?1",
             "name": "Solar Blast",
             "text": "Solar Blast deals 3 damage to any target.\nCycling {1}{R}{R} ({1}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to any target.",
             "colours": [
@@ -4878,7 +4878,7 @@
         },
         {
             "id": "5d9dad62-d168-5571-9896-b5f646c4a30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22844a75-7064-4108-921f-6a590aa2e71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22844a75-7064-4108-921f-6a590aa2e71c.jpg?1",
             "name": "Spark Spray",
             "text": "Spark Spray deals 1 damage to any target.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4910,7 +4910,7 @@
         },
         {
             "id": "e2020f48-c8b0-5dbe-a763-598a3a96799a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701f0a77-28df-4f58-8577-1923bb9a2f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701f0a77-28df-4f58-8577-1923bb9a2f58.jpg?1",
             "name": "Storm Entity",
             "text": "Haste\nStorm Entity enters the battlefield with a +1/+1 counter on it for each other spell cast this turn.",
             "colours": [
@@ -4944,7 +4944,7 @@
         },
         {
             "id": "7cbf88eb-c98e-574d-b9cb-e63afd5c434c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6c26c-84f8-46dd-bb32-b3fc57e172c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6c26c-84f8-46dd-bb32-b3fc57e172c0.jpg?1",
             "name": "Subterranean Scout",
             "text": "When Subterranean Scout enters the battlefield, target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4979,7 +4979,7 @@
         },
         {
             "id": "da699b6a-ad1a-572a-bfbe-5bf047146118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3253a624-50cc-4a8a-9b0c-9902aa53775f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3253a624-50cc-4a8a-9b0c-9902aa53775f.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "287325e6-4c1f-5e08-84c4-e7b3f7478527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd519a-c6f4-47a8-b773-a058e50e4440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd519a-c6f4-47a8-b773-a058e50e4440.jpg?1",
             "name": "Suq'Ata Lancer",
             "text": "Haste\nFlanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "3c0237fa-4d3c-586d-9c4e-9b31f59303b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2072badc-d4ec-469b-b3cd-6977cbe42fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2072badc-d4ec-469b-b3cd-6977cbe42fbd.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -5082,7 +5082,7 @@
         },
         {
             "id": "f6fe0692-4795-5ef9-914f-b774ea386b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba207cd-b22e-4c82-b2b0-0ef57afa1117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba207cd-b22e-4c82-b2b0-0ef57afa1117.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "01d6a74b-023b-5720-bfe8-a66d8a3e262c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dde6e0-d0a7-4432-a3f4-b48234f4e055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dde6e0-d0a7-4432-a3f4-b48234f4e055.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "07a22afb-0b5c-5c50-8dae-220a3cfad2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18f4de2-adfe-4784-bd57-9e2ad9088825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18f4de2-adfe-4784-bd57-9e2ad9088825.jpg?1",
             "name": "Arboria",
             "text": "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "47ae7586-7987-585c-a5b6-5291bdd019d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f234-c1c1-4b4b-8385-6e0ced9977f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f234-c1c1-4b4b-8385-6e0ced9977f1.jpg?1",
             "name": "Battlefield Scrounger",
             "text": "Threshold \u2014 Put three cards from your graveyard on the bottom of your library: Battlefield Scrounger gets +3/+3 until end of turn. Activate only once each turn and only if seven or more cards are in your graveyard.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "05a5be6d-0ded-5fd7-9fe6-8013ac6633e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496849a5-4b24-4eae-8bfb-d46f645d85ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496849a5-4b24-4eae-8bfb-d46f645d85ea.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [
@@ -5267,7 +5267,7 @@
         },
         {
             "id": "861aee3c-d9f9-57b1-89a1-7f3534b406ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f334d2-d450-4a36-9b2e-ce81297b22e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f334d2-d450-4a36-9b2e-ce81297b22e3.jpg?1",
             "name": "Break Asunder",
             "text": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "a0d90e3c-2abe-5019-b864-cdf6e5349192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680bc22c-a80c-44db-aacd-aa80982202b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680bc22c-a80c-44db-aacd-aa80982202b9.jpg?1",
             "name": "Call of the Herd",
             "text": "Create a 3/3 green Elephant creature token.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "1c5ab726-a6d9-503e-bdb5-3890969fa7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523414cb-f8db-407a-808a-01454e03d8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523414cb-f8db-407a-808a-01454e03d8b9.jpg?1",
             "name": "Crop Rotation",
             "text": "As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a land card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "4f2f1d06-3402-5c17-bf1f-d3dbe58b072e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba393aa0-06d3-4811-85f5-a812c6ac5acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba393aa0-06d3-4811-85f5-a812c6ac5acf.jpg?1",
             "name": "Deadwood Treefolk",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk enters or leaves the battlefield, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -5399,7 +5399,7 @@
         },
         {
             "id": "8d0e6196-4ba3-59f3-ace2-da8f1e731fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd91d0d-bc6c-41a1-aecf-d31465717182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd91d0d-bc6c-41a1-aecf-d31465717182.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G}.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "15f79180-1b65-5bcd-b726-6f2376199969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aded92-f934-441f-8e48-d68d471e70d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aded92-f934-441f-8e48-d68d471e70d8.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "Exile Elvish Spirit Guide from your hand: Add {G}.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "5b46f1b7-e660-544a-9084-8ff570acdd17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5862e38-b48b-45e1-b0f6-d1d0d1124e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5862e38-b48b-45e1-b0f6-d1d0d1124e50.jpg?1",
             "name": "Emerald Charm",
             "text": "Choose one \u2014\n\u2022 Untap target permanent.\n\u2022 Destroy target non-Aura enchantment.\n\u2022 Target creature loses flying until end of turn.",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "1ed73d89-ac92-56a0-9a1d-3974989b3f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b372045-a4a0-44c8-96ec-1e201d61ed26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b372045-a4a0-44c8-96ec-1e201d61ed26.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "497e1eb2-c8bf-5659-bc16-bfc451de06c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d717a50-6409-462e-9643-4427d754c773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d717a50-6409-462e-9643-4427d754c773.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "ed9f9930-4578-53f5-b150-0212d26551bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d79e492-993e-4305-bff2-b45f6b2536c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d79e492-993e-4305-bff2-b45f6b2536c8.jpg?1",
             "name": "Forgotten Ancient",
             "text": "Whenever a player casts a spell, you may put a +1/+1 counter on Forgotten Ancient.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Forgotten Ancient onto other creatures.",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "47dfd36e-b806-52f4-9259-475ea6768bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba14c0-18c0-4ded-ae56-5a689106f1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba14c0-18c0-4ded-ae56-5a689106f1a1.jpg?1",
             "name": "Gamekeeper",
             "text": "When Gamekeeper dies, you may exile it. If you do, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and put all other cards revealed this way into your graveyard.",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "96d6e82d-a9c0-5d2b-b2b5-1ddd83432e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213c9202-b6f4-43ab-b57f-b97a1da5e263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213c9202-b6f4-43ab-b57f-b97a1da5e263.jpg?1",
             "name": "Giant Spider",
             "text": "Reach",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "5d4a5b00-f513-53c2-811f-183f5cbc4faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb5124d-bcd6-4aa4-8fd2-f49c8dc6765a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb5124d-bcd6-4aa4-8fd2-f49c8dc6765a.jpg?1",
             "name": "Invigorating Boon",
             "text": "Whenever a player cycles a card, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "a3b53ad5-9810-57f8-b627-c57e6777e06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65852aa0-98f4-4b38-89f1-96062677e590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65852aa0-98f4-4b38-89f1-96062677e590.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "75e3700d-abe7-5e0d-8936-a80c92959359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c960672d-06ad-4d41-8904-9c007f824756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c960672d-06ad-4d41-8904-9c007f824756.jpg?1",
             "name": "Kamahl, Fist of Krosa",
             "text": "{G}: Target land becomes a 1/1 creature until end of turn. It's still a land.\n{2}{G}{G}{G}: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "abd9b172-e755-5663-b95e-745673de9f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53cbda8-805f-42a4-aba4-9939b08e37ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53cbda8-805f-42a4-aba4-9939b08e37ca.jpg?1",
             "name": "Kavu Primarch",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf Kavu Primarch was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "3648e6b5-d6c0-580c-bd9d-5fd8d1205acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12508498-ecb7-4df9-b83f-87ef3bc2f4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12508498-ecb7-4df9-b83f-87ef3bc2f4e2.jpg?1",
             "name": "Krosan Restorer",
             "text": "{T}: Untap target land.\nThreshold \u2014 {T}: Untap up to three target lands. Activate only if seven or more cards are in your graveyard.",
             "colours": [
@@ -5859,7 +5859,7 @@
         },
         {
             "id": "fd8b8f02-b73b-5113-9498-e0336ca0353e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24540d-28e6-4e49-acd4-216b1ef27e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24540d-28e6-4e49-acd4-216b1ef27e7f.jpg?1",
             "name": "Lull",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "7b224258-add9-5592-a4b9-804e513ebeea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761adafd-0bf5-4bab-95d4-8362954c1019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761adafd-0bf5-4bab-95d4-8362954c1019.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "eefdfb9e-ac87-5a91-b5d5-5830b9640d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32980fc5-32ef-4f6d-8972-7a9e122c02e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32980fc5-32ef-4f6d-8972-7a9e122c02e2.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may create a 1/1 green Squirrel creature token.\nThreshold \u2014 All Squirrels get +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -5965,7 +5965,7 @@
         },
         {
             "id": "434ab927-1bda-565a-bb69-bbdb27ca9d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359fbd40-0f61-4ec7-872c-228a476c7ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359fbd40-0f61-4ec7-872c-228a476c7ad5.jpg?1",
             "name": "Penumbra Bobcat",
             "text": "When Penumbra Bobcat dies, create a 2/1 black Cat creature token.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "51486cbb-1afe-5f84-8346-b88f7a23b1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f93eb0-cb0c-4ee0-8006-3d3c7515d254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f93eb0-cb0c-4ee0-8006-3d3c7515d254.jpg?1",
             "name": "Primal Boost",
             "text": "Target creature gets +4/+4 until end of turn.\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Primal Boost, you may have target creature get +1/+1 until end of turn.",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "9abb2c14-8ffa-5a5c-ac9b-f439d4e01269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fb3d07-a128-455a-a632-c1aba4a4ceb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fb3d07-a128-455a-a632-c1aba4a4ceb8.jpg?1",
             "name": "Sandstorm",
             "text": "Sandstorm deals 1 damage to each attacking creature.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "17366eec-ba38-51f5-bade-0485dcbad7a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae774a-c1de-4c9e-a2ec-86d71cb2d1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae774a-c1de-4c9e-a2ec-86d71cb2d1db.jpg?1",
             "name": "Saproling Symbiosis",
             "text": "You may cast Saproling Symbiosis as though it had flash if you pay {2} more to cast it.\nCreate a 1/1 green Saproling creature token for each creature you control.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "ab8a8f37-11e9-51ee-b14e-4dc6ed17e485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c7f922-c334-4a75-9f5a-e68595049318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c7f922-c334-4a75-9f5a-e68595049318.jpg?1",
             "name": "Seton's Desire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nThreshold \u2014 As long as seven or more cards are in your graveyard, all creatures able to block enchanted creature do so.",
             "colours": [
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "f0c9b5f0-10ee-5f05-a39e-e3b02cf2a227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2aa025-e041-4ed5-a046-9debc474fda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2aa025-e041-4ed5-a046-9debc474fda0.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "44f527ec-4f8b-565a-b846-cb56f31fe52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ea6aac-d42b-4522-b7a9-4c99ed9c14bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ea6aac-d42b-4522-b7a9-4c99ed9c14bd.jpg?1",
             "name": "Stonewood Invoker",
             "text": "{7}{G}: Stonewood Invoker gets +5/+5 until end of turn.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "76fcdadd-5861-54d8-9d3a-38855a19f59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ada256f-2e55-4c1f-b4d3-d7b10b498956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ada256f-2e55-4c1f-b4d3-d7b10b498956.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "155d5211-8561-5d6d-94e0-47abbd28307c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf013aa4-76d6-4378-8916-d10f591f225a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf013aa4-76d6-4378-8916-d10f591f225a.jpg?1",
             "name": "Symbiotic Beast",
             "text": "When Symbiotic Beast dies, create four 1/1 green Insect creature tokens.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "8829ed6d-8bb6-5e07-b371-ba9b14bcf2dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70fbe1c-d3f4-4e28-a830-2072dee1b7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70fbe1c-d3f4-4e28-a830-2072dee1b7b5.jpg?1",
             "name": "Terravore",
             "text": "Trample\nTerravore's power and toughness are each equal to the number of land cards in all graveyards.",
             "colours": [
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "6d4e95b5-439a-5367-90b4-c6718c307faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973310bb-ab32-46dc-8f59-8a5d3e1c58cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973310bb-ab32-46dc-8f59-8a5d3e1c58cc.jpg?1",
             "name": "Werebear",
             "text": "{T}: Add {G}.\nThreshold \u2014 Werebear gets +3/+3 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -6342,7 +6342,7 @@
         },
         {
             "id": "155ff3af-2187-5001-adaf-cef1ee83d8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa526aa-f569-486a-8712-47c972481cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa526aa-f569-486a-8712-47c972481cd4.jpg?1",
             "name": "Wild Dogs",
             "text": "At the beginning of your upkeep, if a player has more life than each other player, the player with the most life gains control of Wild Dogs.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "b28592d2-259f-52b2-b834-b5c0495d042b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61429340-15fa-4a70-aac3-3e358b23b02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61429340-15fa-4a70-aac3-3e358b23b02c.jpg?1",
             "name": "Wild Growth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.",
             "colours": [
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "f71e6284-26da-59f8-ac75-2738412d3926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39aa2e9-e294-4ce6-bf5e-e1f579101a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39aa2e9-e294-4ce6-bf5e-e1f579101a7a.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card, reveal it, then shuffle and put the card on top.",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "af9aa5df-af41-5daa-9ad7-d6ad2916dcf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21892cbc-1af2-4ea1-8907-cec514b53004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21892cbc-1af2-4ea1-8907-cec514b53004.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "8142dc35-fb2e-55bc-99a5-5d7d94b39675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175695bb-2630-4269-a407-9138c7008e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175695bb-2630-4269-a407-9138c7008e81.jpg?1",
             "name": "Arcades Sabboth",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Arcades Sabboth unless you pay {G}{W}{U}.\nEach untapped creature you control gets +0/+2 as long as it's not attacking.\n{W}: Arcades Sabboth gets +0/+1 until end of turn.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "33c150bf-bff8-545f-af0f-de941c061f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8931725a-8034-4ecc-ac44-3f09ded677d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8931725a-8034-4ecc-ac44-3f09ded677d7.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -6566,7 +6566,7 @@
         },
         {
             "id": "2fe271d5-72d5-5ad8-8dd9-80327a82afe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844976c7-c8f7-435a-9bd4-1fea3c635030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844976c7-c8f7-435a-9bd4-1fea3c635030.jpg?1",
             "name": "Dralnu's Crusade",
             "text": "All Goblins get +1/+1.\nAll Goblins are black and are Zombies in addition to their other creature types.",
             "colours": [
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "b20ab15c-74e1-5bf5-939a-6c1dcc786100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d9d3be-0a66-4871-9d60-d253d3a37a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d9d3be-0a66-4871-9d60-d253d3a37a13.jpg?1",
             "name": "Gerrard's Verdict",
             "text": "Target player discards two cards. You gain 3 life for each land card discarded this way.",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "ed394b92-600c-5aec-b77d-ff332cc7976f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e544772-5ab8-47dd-8a6e-686d385a6ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e544772-5ab8-47dd-8a6e-686d385a6ee7.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Hunting Grounds has \"Whenever an opponent casts a spell, you may put a creature card from your hand onto the battlefield.\"",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "c69e44ed-8c93-5425-88ed-f4313d9d33e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187ebb67-1bdd-4a9c-aeeb-554e7580ce24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187ebb67-1bdd-4a9c-aeeb-554e7580ce24.jpg?1",
             "name": "Mystic Enforcer",
             "text": "Protection from black\nThreshold \u2014 As long as seven or more cards are in your graveyard, Mystic Enforcer gets +3/+3 and has flying.",
             "colours": [
@@ -6715,7 +6715,7 @@
         },
         {
             "id": "a146afa6-a294-5128-b9dd-b0eda774dbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2281a21b-fc68-46ad-b340-eb13ca0165ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2281a21b-fc68-46ad-b340-eb13ca0165ec.jpg?1",
             "name": "Phantom Nishoba",
             "text": "Trample\nPhantom Nishoba enters the battlefield with seven +1/+1 counters on it.\nWhenever Phantom Nishoba deals damage, you gain that much life.\nIf damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.",
             "colours": [
@@ -6755,7 +6755,7 @@
         },
         {
             "id": "c869964b-b697-547d-b0dc-3faa1655d565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2db45-0ef7-45c8-ac65-eb785c173bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2db45-0ef7-45c8-ac65-eb785c173bd7.jpg?1",
             "name": "Pyre Zombie",
             "text": "At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay {1}{B}{B}. If you do, return Pyre Zombie to your hand.\n{1}{R}{R}, Sacrifice Pyre Zombie: It deals 2 damage to any target.",
             "colours": [
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "c09d8eb9-53e7-5f92-8a28-ed9733c979ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138d2d9d-d5ab-400f-a714-cd38212a0dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138d2d9d-d5ab-400f-a714-cd38212a0dae.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target player or planeswalker. You draw a card.\"",
             "colours": [
@@ -6831,7 +6831,7 @@
         },
         {
             "id": "727e91d0-105f-5f4c-a03e-83e75c1ec020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb7c19a-b4af-405d-b016-a546ed12a99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb7c19a-b4af-405d-b016-a546ed12a99d.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "6270b83a-62a8-5583-a2da-dc527591d1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9035dda8-5ad3-4169-b281-83d6ca55b71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9035dda8-5ad3-4169-b281-83d6ca55b71e.jpg?1",
             "name": "Recoil",
             "text": "Return target permanent to its owner's hand. Then that player discards a card.",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "f32b9f74-eba6-5b33-9ce1-8c6ca4386256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a75961-39a3-4221-9367-a763cf871d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a75961-39a3-4221-9367-a763cf871d42.jpg?1",
             "name": "Rith, the Awakener",
             "text": "Flying\nWhenever Rith, the Awakener deals combat damage to a player, you may pay {2}{G}. If you do, choose a color, then create a 1/1 green Saproling creature token for each permanent of that color.",
             "colours": [
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "7766f4da-afa3-5d7d-8c34-80fc605e7c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5882a5-ea4c-4b2b-bcf9-7d15087d8bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5882a5-ea4c-4b2b-bcf9-7d15087d8bd4.jpg?1",
             "name": "Sawtooth Loon",
             "text": "Flying\nWhen Sawtooth Loon enters the battlefield, return a white or blue creature you control to its owner's hand.\nWhen Sawtooth Loon enters the battlefield, draw two cards, then put two cards from your hand on the bottom of your library.",
             "colours": [
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "421795b1-1c5c-51ce-a80a-de18583ce15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b4cb6a-ac4f-48ac-8c94-ba2b8e6b32a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b4cb6a-ac4f-48ac-8c94-ba2b8e6b32a8.jpg?1",
             "name": "Sol'kanar the Swamp King",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nWhenever a player casts a black spell, you gain 1 life.",
             "colours": [
@@ -7031,7 +7031,7 @@
         },
         {
             "id": "549b0bc9-5fdd-556b-a489-314c7fd90ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12b2d6-3940-4d47-8c76-ae73b8a14b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12b2d6-3940-4d47-8c76-ae73b8a14b15.jpg?1",
             "name": "Spinal Embrace",
             "text": "Cast this spell only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "2359de9d-ff5a-58b7-b7d9-629e750939aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da7739e-8413-45b6-8539-fde2021b06a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da7739e-8413-45b6-8539-fde2021b06a7.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\n{B}: Regenerate Spiritmonger.\n{G}: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "e4fceb06-8a99-509e-83f1-71eeb354ca71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8953672-b1ae-4f0a-8107-e28322fc16b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8953672-b1ae-4f0a-8107-e28322fc16b7.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "83b8ff45-87d3-5bc2-9e45-7f3935d741db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8030dc33-bead-4b1a-9270-fe19809044b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8030dc33-bead-4b1a-9270-fe19809044b9.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -7187,7 +7187,7 @@
         },
         {
             "id": "16bec147-39c1-506f-adf3-27d1d883aaa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce050d13-7897-4889-a514-a7617a1ed686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce050d13-7897-4889-a514-a7617a1ed686.jpg?1",
             "name": "Xira Arien",
             "text": "Flying\n{B}{R}{G}, {T}: Target player draws a card.",
             "colours": [
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "fc89da4a-5786-5e5f-b029-dbc0ebb1603f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cfc04-65ea-49a4-8638-b4631a7cf828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cfc04-65ea-49a4-8638-b4631a7cf828.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "11f13ccc-a479-5b2f-a51b-9c0998431b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg?1",
             "name": "Stand // Deliver",
             "text": "",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "3e799e34-3b98-5ff6-ac4a-00cb2ec8f565",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg?1",
             "name": "Stand // Deliver",
             "text": "",
             "colours": [
@@ -7339,7 +7339,7 @@
         },
         {
             "id": "1ffb2e80-93e2-519e-b9cf-157badc50aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg?1",
             "name": "Spite // Malice",
             "text": "",
             "colours": [
@@ -7372,7 +7372,7 @@
         },
         {
             "id": "7a283c06-3cc9-50c5-8504-fa00dc18f4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg?1",
             "name": "Spite // Malice",
             "text": "",
             "colours": [
@@ -7405,7 +7405,7 @@
         },
         {
             "id": "13c07799-78e1-5393-87c3-eb35bf5d8a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg?1",
             "name": "Pain // Suffering",
             "text": "",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "a06453d3-f4c5-53d7-9b7d-2c2fe86e6582",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg?1",
             "name": "Pain // Suffering",
             "text": "",
             "colours": [
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "ddb3ba26-b6ac-5159-9e0b-a4bae6cccbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg?1",
             "name": "Assault // Battery",
             "text": "",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "161687e8-00bd-579f-861a-8729fb050124",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg?1",
             "name": "Assault // Battery",
             "text": "",
             "colours": [
@@ -7537,7 +7537,7 @@
         },
         {
             "id": "5c1e0dc3-d9e9-5aad-b09a-d42c2d70bfcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg?1",
             "name": "Wax // Wane",
             "text": "",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "85a09902-fc04-58f6-b39d-8214d7ea806b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg?1",
             "name": "Wax // Wane",
             "text": "",
             "colours": [
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "489580b9-5c37-5451-9d08-37232b283341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg?1",
             "name": "Order // Chaos",
             "text": "",
             "colours": [
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "d282ea7e-41f3-5ef5-8d4e-f15b0471dc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg?1",
             "name": "Order // Chaos",
             "text": "",
             "colours": [
@@ -7669,7 +7669,7 @@
         },
         {
             "id": "2f096046-75d5-53c2-9f56-fb54c78984b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg?1",
             "name": "Illusion // Reality",
             "text": "",
             "colours": [
@@ -7702,7 +7702,7 @@
         },
         {
             "id": "b4e6965a-af9a-551f-a321-315eae2e9630",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg?1",
             "name": "Illusion // Reality",
             "text": "",
             "colours": [
@@ -7735,7 +7735,7 @@
         },
         {
             "id": "b048e268-99f2-50d9-bccb-68ecf7ec3e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg?1",
             "name": "Night // Day",
             "text": "",
             "colours": [
@@ -7768,7 +7768,7 @@
         },
         {
             "id": "a5555d4e-9740-5549-b286-f09667dd6f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg?1",
             "name": "Night // Day",
             "text": "",
             "colours": [
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "1f570290-38b9-5b62-ba96-f1199645ec10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18303862-4726-4136-814f-157aa7006579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18303862-4726-4136-814f-157aa7006579.jpg?1",
             "name": "Fire // Ice",
             "text": "",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "7b02cf06-6df4-573a-86ec-18c88fc8891b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18303862-4726-4136-814f-157aa7006579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18303862-4726-4136-814f-157aa7006579.jpg?1",
             "name": "Fire // Ice",
             "text": "",
             "colours": [
@@ -7867,7 +7867,7 @@
         },
         {
             "id": "8730efc0-f216-5208-b94f-928293e2a55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg?1",
             "name": "Life // Death",
             "text": "",
             "colours": [
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "870eee8f-449f-5a8c-977d-a906f82f740c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg?1",
             "name": "Life // Death",
             "text": "",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "78e1c040-fa8c-5f3f-bd16-fa9365a1a313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8e092a-610d-4cea-bb92-65e01954b5c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8e092a-610d-4cea-bb92-65e01954b5c4.jpg?1",
             "name": "Crawlspace",
             "text": "No more than two creatures can attack you each combat.",
             "colours": [],
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "83edfcd7-1045-5da2-9364-3e50e0101287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e2b4-3ca9-4649-b863-17c0c4065f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e2b4-3ca9-4649-b863-17c0c4065f63.jpg?1",
             "name": "Cryptic Gateway",
             "text": "Tap two untapped creatures you control: You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield.",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "d867cd4a-a0a9-5993-9c27-e00b6d1c121d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550860b4-887d-423a-8add-816c2a8da615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550860b4-887d-423a-8add-816c2a8da615.jpg?1",
             "name": "Damping Sphere",
             "text": "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
             "colours": [],
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "e7928086-336d-54c8-8bbd-67cd0d8ae756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156afb5a-df38-4555-b59b-f3fa64ce5bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156afb5a-df38-4555-b59b-f3fa64ce5bff.jpg?1",
             "name": "Dodecapod",
             "text": "If a spell or ability an opponent controls causes you to discard Dodecapod, put it onto the battlefield with two +1/+1 counters on it instead of putting it into your graveyard.",
             "colours": [],
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "eaaa7065-8c62-5e39-b343-e1add7bfdfad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4398ae9c-4177-4fee-95ba-e98b7f514f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4398ae9c-4177-4fee-95ba-e98b7f514f57.jpg?1",
             "name": "Dragon Blood",
             "text": "{3}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "70e4dd98-8133-5041-a3eb-063e6bea21b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045f373e-510f-4552-9859-884f6ce4cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045f373e-510f-4552-9859-884f6ce4cc59.jpg?1",
             "name": "Dragon Engine",
             "text": "{2}: Dragon Engine gets +1/+0 until end of turn.",
             "colours": [],
@@ -8113,7 +8113,7 @@
         },
         {
             "id": "cb952962-53a2-5f59-9a56-8f2e483f7e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d153663f-f08a-483e-92c9-82b5a9723807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d153663f-f08a-483e-92c9-82b5a9723807.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "99295c92-8212-5b5c-a10f-d04f7304027d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e4ff9c-6244-43e1-b569-32a270c4e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e4ff9c-6244-43e1-b569-32a270c4e014.jpg?1",
             "name": "Helm of Awakening",
             "text": "Spells cost {1} less to cast.",
             "colours": [],
@@ -8175,7 +8175,7 @@
         },
         {
             "id": "10633941-a0f8-5743-b605-6dffef343353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5a54ca-f175-4005-895f-d76effd6178e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5a54ca-f175-4005-895f-d76effd6178e.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -8205,7 +8205,7 @@
         },
         {
             "id": "d0086754-7f95-5ed1-93b9-80629ac53c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2db45f-4cdb-4b7f-a270-44b2b1482f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2db45f-4cdb-4b7f-a270-44b2b1482f69.jpg?1",
             "name": "Jalum Tome",
             "text": "{2}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -8233,7 +8233,7 @@
         },
         {
             "id": "da030af0-9737-5260-b4b7-403735753b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b364e7e7-83e5-474b-9768-8b70a77e5ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b364e7e7-83e5-474b-9768-8b70a77e5ffa.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and exile them. Then that player shuffles.",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "d19b4714-e5b6-596c-b911-30371d78a9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211ba3e4-8979-4dd1-b1a0-1d8a19969349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211ba3e4-8979-4dd1-b1a0-1d8a19969349.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "c5ec9f91-ef5d-56a7-82fd-78052e0b4d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd35d5c-7f28-4842-85e8-692d6c391c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd35d5c-7f28-4842-85e8-692d6c391c3a.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Exile target permanent.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "290c0682-9913-5d34-9601-c124b31fa90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b92fd6-e3a7-4d50-b94f-1508a830b799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b92fd6-e3a7-4d50-b94f-1508a830b799.jpg?1",
             "name": "Lotus Blossom",
             "text": "At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.\n{T}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.",
             "colours": [],
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "5e36b80e-ed15-51bc-8121-fdeca5ab92e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad71523-a88a-4239-ba3d-3b79f526964e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad71523-a88a-4239-ba3d-3b79f526964e.jpg?1",
             "name": "Millikin",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "0fd8f9cf-a2c9-5d02-8456-a6a4201c34e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cef8f31-a95e-49d0-ba75-7a639fcaa649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cef8f31-a95e-49d0-ba75-7a639fcaa649.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -8428,7 +8428,7 @@
         },
         {
             "id": "d36cdc58-1524-5baa-a16d-4f0353fc3732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305078a5-ac18-4721-bba2-3434eba5b1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305078a5-ac18-4721-bba2-3434eba5b1cf.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "2fa84bf9-74e5-5302-899d-db6c2150c70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ea19b9-d25e-4d46-a7ea-059a3a2fceb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ea19b9-d25e-4d46-a7ea-059a3a2fceb1.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "078f59d3-ff88-5371-b53f-5d5cea2827f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf493-5839-47e8-95f2-6d8201907428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf493-5839-47e8-95f2-6d8201907428.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile target player's graveyard.",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "92e0cd6f-a2cd-5aa0-88ff-3075ad685454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151a1d7-bf4a-4615-8bf1-37d1e406a708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151a1d7-bf4a-4615-8bf1-37d1e406a708.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "b5e9c1c3-0a1b-55ae-9d1c-64f17772301d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556ed8e-2ad9-4135-902a-24f8e327584b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556ed8e-2ad9-4135-902a-24f8e327584b.jpg?1",
             "name": "Umbilicus",
             "text": "At the beginning of each player's upkeep, that player may pay 2 life. If they don't, they return a permanent they control to its owner's hand.",
             "colours": [],
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "550e79ac-3b00-5c12-87d7-420ea16f465e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2b6a7-b93a-42d3-b66a-a70b573fc58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2b6a7-b93a-42d3-b66a-a70b573fc58a.jpg?1",
             "name": "Urza's Blueprints",
             "text": "Echo {6} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{T}: Draw a card.",
             "colours": [],
@@ -8618,7 +8618,7 @@
         },
         {
             "id": "60e0cffb-231d-5b19-9b70-3faa7b757b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8122161-1608-4af4-9aca-7f22c2f746aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8122161-1608-4af4-9aca-7f22c2f746aa.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -8649,7 +8649,7 @@
         },
         {
             "id": "4a7cb0b6-b689-57eb-982b-b8817c805707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f19832-0c66-4f06-8110-ce4b2a3d8346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f19832-0c66-4f06-8110-ce4b2a3d8346.jpg?1",
             "name": "Wall of Junk",
             "text": "Defender\nWhen Wall of Junk blocks, return it to its owner's hand at end of combat. (Return it only if it's on the battlefield.)",
             "colours": [],
@@ -8680,7 +8680,7 @@
         },
         {
             "id": "9b236327-a957-547c-a7b7-083defd13f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f775a-2eb3-4151-b21d-9fe62ae17f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f775a-2eb3-4151-b21d-9fe62ae17f54.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8713,7 +8713,7 @@
         },
         {
             "id": "5a750431-719d-5190-b4da-ea7a586fbefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce462b-e4de-4972-9e96-2e3d3a20d1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce462b-e4de-4972-9e96-2e3d3a20d1fc.jpg?1",
             "name": "Crosis's Catacombs",
             "text": "When Crosis's Catacombs enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {U}, {B}, or {R}.",
             "colours": [],
@@ -8747,7 +8747,7 @@
         },
         {
             "id": "50d07ba4-8407-5d74-bb55-8b2b79e536a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b1ad2d-f02e-4e6b-a49a-f65d174bb0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b1ad2d-f02e-4e6b-a49a-f65d174bb0fc.jpg?1",
             "name": "Darigaaz's Caldera",
             "text": "When Darigaaz's Caldera enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {B}, {R}, or {G}.",
             "colours": [],
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "0cfa9389-9cd7-517b-9f13-b2b0de54546f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b11ad-d077-40b6-988c-0462e118fe3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b11ad-d077-40b6-988c-0462e118fe3d.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "2eeb6b84-7458-5fdd-b014-23c74a4aeacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb024fa-2df1-4414-b0d7-6f700d152c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb024fa-2df1-4414-b0d7-6f700d152c51.jpg?1",
             "name": "Drifting Meadow",
             "text": "Drifting Meadow enters the battlefield tapped.\n{T}: Add {W}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8845,7 +8845,7 @@
         },
         {
             "id": "513963ac-dcbb-5459-b3e9-630a0313a4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10380662-88bd-4bc5-b8c3-14af425fc5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10380662-88bd-4bc5-b8c3-14af425fc5a5.jpg?1",
             "name": "Dromar's Cavern",
             "text": "When Dromar's Cavern enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {W}, {U}, or {B}.",
             "colours": [],
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "f116d248-3c5d-546f-87e1-129f2ff6d74b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee152618-761f-43b4-942a-f63b16c182cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee152618-761f-43b4-942a-f63b16c182cc.jpg?1",
             "name": "Gemstone Mine",
             "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color. If there are no mining counters on Gemstone Mine, sacrifice it.",
             "colours": [],
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "d5b0b125-a0c8-5692-a849-2b7a90d1758d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da629db7-c200-43ed-8de2-a5859b639a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da629db7-c200-43ed-8de2-a5859b639a6d.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "cc3e4a54-b2ed-529a-a863-6a622a9a00ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d359281b-b509-41be-a820-c7ac9f36f27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d359281b-b509-41be-a820-c7ac9f36f27f.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "8b8364c2-0c2e-5c31-aebe-ded112eecc15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5889fde1-730d-43d0-aaa4-499784a80530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5889fde1-730d-43d0-aaa4-499784a80530.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "bf7bc8e2-92a3-56c4-a96d-ff085d9dc9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9fec20-a52c-42c0-9928-c572d9e1b21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9fec20-a52c-42c0-9928-c572d9e1b21f.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -9037,7 +9037,7 @@
         },
         {
             "id": "1bacbaa5-1ee7-59c9-aa09-a4d17edbe4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4188a561-46e3-4ddd-8797-f33c37e9adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4188a561-46e3-4ddd-8797-f33c37e9adb2.jpg?1",
             "name": "Nantuko Monastery",
             "text": "{T}: Add {C}.\nThreshold \u2014 {G}{W}: Nantuko Monastery becomes a 4/4 green and white Insect Monk creature with first strike until end of turn. It's still a land. Activate only if seven or more cards are in your graveyard.",
             "colours": [],
@@ -9068,7 +9068,7 @@
         },
         {
             "id": "921da358-df89-58b2-a8aa-27a2b46cfa3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb724bec-3509-4f5f-84c0-b1b54063d06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb724bec-3509-4f5f-84c0-b1b54063d06f.jpg?1",
             "name": "Polluted Mire",
             "text": "Polluted Mire enters the battlefield tapped.\n{T}: Add {B}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9098,7 +9098,7 @@
         },
         {
             "id": "d72472d9-9ae1-53b0-83d6-51a9f97e6931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a340af37-c0a7-4f26-974b-95397b5c32f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a340af37-c0a7-4f26-974b-95397b5c32f7.jpg?1",
             "name": "Remote Isle",
             "text": "Remote Isle enters the battlefield tapped.\n{T}: Add {U}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9128,7 +9128,7 @@
         },
         {
             "id": "85685c04-f498-5161-a8fc-cb2b0528cd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a605ce4-ede6-44dd-a2ea-e953902be6bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a605ce4-ede6-44dd-a2ea-e953902be6bd.jpg?1",
             "name": "Rith's Grove",
             "text": "When Rith's Grove enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {R}, {G}, or {W}.",
             "colours": [],
@@ -9162,7 +9162,7 @@
         },
         {
             "id": "40985ee8-d2ed-5a06-853b-aeed4918a51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41073e8-01cc-4d19-acb5-caaf2861bc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41073e8-01cc-4d19-acb5-caaf2861bc6a.jpg?1",
             "name": "Slippery Karst",
             "text": "Slippery Karst enters the battlefield tapped.\n{T}: Add {G}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9192,7 +9192,7 @@
         },
         {
             "id": "b660ac75-7c2b-54c7-a4a4-36820e143e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcfaaed-c139-4787-946f-59800bde71e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcfaaed-c139-4787-946f-59800bde71e4.jpg?1",
             "name": "Smoldering Crater",
             "text": "Smoldering Crater enters the battlefield tapped.\n{T}: Add {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9222,7 +9222,7 @@
         },
         {
             "id": "67b9648d-7459-5b68-945e-d0632d92fca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e12e4-6122-41d8-8ffb-a883d02d3278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e12e4-6122-41d8-8ffb-a883d02d3278.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9255,7 +9255,7 @@
         },
         {
             "id": "154419b9-f97a-5dd7-84f1-d421507b998f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9029f22b-f153-4f9a-a60f-ba2d0b6e0a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9029f22b-f153-4f9a-a60f-ba2d0b6e0a1d.jpg?1",
             "name": "Terminal Moraine",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Terminal Moraine: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9283,7 +9283,7 @@
         },
         {
             "id": "e826a187-31e5-5c72-a5f3-917688f925d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f39366c-00df-4528-a324-6a89d0c53f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f39366c-00df-4528-a324-6a89d0c53f0a.jpg?1",
             "name": "Treva's Ruins",
             "text": "When Treva's Ruins enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {G}, {W}, or {U}.",
             "colours": [],
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "0cb82c34-6f54-59bf-8f2e-e7520a3b9049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100b00b-a7de-4e36-a83b-1ce1fa427cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100b00b-a7de-4e36-a83b-1ce1fa427cc2.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9350,7 +9350,7 @@
         },
         {
             "id": "1e7f9c15-861a-5059-820d-f2948296de62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27840eab-9262-49d8-8007-033d42afcad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27840eab-9262-49d8-8007-033d42afcad7.jpg?1",
             "name": "Divine Sacrament",
             "text": "White creatures get +1/+1.\nThreshold \u2014 White creatures get an additional +1/+1 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -9384,7 +9384,7 @@
         },
         {
             "id": "7c671f47-bc1a-5610-a483-42c169ecbab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecea08d-7d65-4d61-a34d-2f8976af5f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecea08d-7d65-4d61-a34d-2f8976af5f5e.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "9babea33-5571-5d39-80e4-1de794d0547e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ada52e-073c-4775-a190-310d51569682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ada52e-073c-4775-a190-310d51569682.jpg?1",
             "name": "Glory",
             "text": "Flying\n{2}{W}: Choose a color. Creatures you control gain protection from the chosen color until end of turn. Activate only if Glory is in your graveyard.",
             "colours": [
@@ -9455,7 +9455,7 @@
         },
         {
             "id": "c31360d1-2a59-5c6f-afcb-656488fbaee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f40d25a-6966-4a5c-83d8-01d37a8379c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f40d25a-6966-4a5c-83d8-01d37a8379c6.jpg?1",
             "name": "Lieutenant Kirtar",
             "text": "Flying\n{1}{W}, Sacrifice Lieutenant Kirtar: Exile target attacking creature.",
             "colours": [
@@ -9494,7 +9494,7 @@
         },
         {
             "id": "c48ca885-54f0-583c-bd95-4d6c5d5953c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da75521-e2f0-4064-8abe-0565353df7c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da75521-e2f0-4064-8abe-0565353df7c5.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -9533,7 +9533,7 @@
         },
         {
             "id": "eb9aad01-dbf9-5444-ac2e-1ca14daa72b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811043f5-b2eb-4983-a8d6-85c3912e6d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811043f5-b2eb-4983-a8d6-85c3912e6d99.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "f3d14e0d-634f-51ac-ac18-288913503c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd5aa4-b920-4aff-ba0d-2d4777ebbf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd5aa4-b920-4aff-ba0d-2d4777ebbf66.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "f28f5517-1b62-5029-9504-e349c91b0098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df3e4d-d8a5-417b-a765-351564f0c38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df3e4d-d8a5-417b-a765-351564f0c38f.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "a440c6f0-681b-560f-a649-52683e1f8e11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d52e0-dfa6-4ac0-909e-81d1a16b84b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d52e0-dfa6-4ac0-909e-81d1a16b84b4.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -9675,7 +9675,7 @@
         },
         {
             "id": "2098b071-4c7a-5676-942d-25c271cbcc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e430b8c9-9439-4256-9066-e9b57f257fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e430b8c9-9439-4256-9066-e9b57f257fe7.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -9711,7 +9711,7 @@
         },
         {
             "id": "a6cc7d87-b04f-526b-8d7f-2d8d3bf73ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f0108-e936-4286-95a9-f11b679ebaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f0108-e936-4286-95a9-f11b679ebaa0.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar's power and toughness are each equal to your life total.\nWhen Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "7c32fff9-5c9c-5d98-826b-8c1fb3e7e522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec5dc4-a40d-41d4-ba50-47c494632037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec5dc4-a40d-41d4-ba50-47c494632037.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9781,7 +9781,7 @@
         },
         {
             "id": "a0eed162-97bb-5175-b7bf-ce12bb32eaf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6aa4e90-1bb0-445f-a321-caaa69372d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6aa4e90-1bb0-445f-a321-caaa69372d53.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -9817,7 +9817,7 @@
         },
         {
             "id": "0f44164d-a241-59cc-9e07-0846b24fbac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3067d-768b-40e7-80d6-08cc42f162b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3067d-768b-40e7-80d6-08cc42f162b6.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "d02b584d-d4e4-534d-a26d-e2743c74f8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b65824-f3d8-4f01-ad8a-ebd19ce5062e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b65824-f3d8-4f01-ad8a-ebd19ce5062e.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "83e52c69-f8df-56de-ba42-a199d116c85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe919e-13c8-44de-a778-8e6ce0b16a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe919e-13c8-44de-a778-8e6ce0b16a58.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "af18e638-c0d3-58d1-904a-a107527063b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1649d-85c9-4f69-8850-2e4df6f8fc9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1649d-85c9-4f69-8850-2e4df6f8fc9c.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -9959,7 +9959,7 @@
         },
         {
             "id": "a7b94a6a-d732-5c3b-a4fe-4672f04ff9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8603c3b-9a10-4a04-b417-284a8e3925a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8603c3b-9a10-4a04-b417-284a8e3925a9.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "47ebb575-1c4f-5a19-bc0b-0adeb5b0b4e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2c1c92-3da1-4f7e-a02c-831311115a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2c1c92-3da1-4f7e-a02c-831311115a5d.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -10032,7 +10032,7 @@
         },
         {
             "id": "62bb67cb-120f-5262-815c-39d8228bc1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14d5ff3-40c0-4f22-91ad-d6c8447cb9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14d5ff3-40c0-4f22-91ad-d6c8447cb9e0.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -10067,7 +10067,7 @@
         },
         {
             "id": "fd1a87b6-8a32-50ea-af0e-3fa35648021b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89882438-6357-4ef9-9a52-f1ff49952c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89882438-6357-4ef9-9a52-f1ff49952c10.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep enters the battlefield, return each other creature you control to its owner's hand.",
             "colours": [
@@ -10104,7 +10104,7 @@
         },
         {
             "id": "e0b77f4f-c80a-57e8-a461-7031ab60a361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3e09f-f9a1-4618-9ec6-ee91e1398522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3e09f-f9a1-4618-9ec6-ee91e1398522.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "de866bb1-814b-5b05-9235-cca64f1ef97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83240eaa-edb4-4bd3-b193-29470cf46828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83240eaa-edb4-4bd3-b193-29470cf46828.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -10173,7 +10173,7 @@
         },
         {
             "id": "05d9b0c7-f50a-5ccd-8f38-8fb0c0b0e5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad4d49f-2505-43b7-b5fb-58bf1b8fcc71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad4d49f-2505-43b7-b5fb-58bf1b8fcc71.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -10207,7 +10207,7 @@
         },
         {
             "id": "7a6a49eb-d8ba-56f9-9374-0769a2a7ea1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f3e6df-33c0-4d0d-b382-58d00be2051a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f3e6df-33c0-4d0d-b382-58d00be2051a.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.",
             "colours": [
@@ -10242,7 +10242,7 @@
         },
         {
             "id": "95d359ee-c93f-5516-9a7b-fa1349d53757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4880c0ca-7127-4d8d-ade7-2459e4acd706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4880c0ca-7127-4d8d-ade7-2459e4acd706.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -10276,7 +10276,7 @@
         },
         {
             "id": "75e3585b-f700-5b5c-8a0f-f8b374a3b252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87c041-c516-4911-ad28-1fb961c0d3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87c041-c516-4911-ad28-1fb961c0d3dc.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
             "colours": [
@@ -10311,7 +10311,7 @@
         },
         {
             "id": "ebc62c21-9daf-557f-b78c-14696c13b4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7331aade-3b7f-4b4d-b198-2e0b6b80895c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7331aade-3b7f-4b4d-b198-2e0b6b80895c.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -10346,7 +10346,7 @@
         },
         {
             "id": "7d3365fd-6955-5cab-9a68-a5cbbed3bb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de069a00-be1f-4762-b511-bb9211bf2cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de069a00-be1f-4762-b511-bb9211bf2cc8.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -10380,7 +10380,7 @@
         },
         {
             "id": "ff34c368-03e2-513e-ab07-c0a59658f371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d72f51a-3615-4b98-acaa-7d55aabb6c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d72f51a-3615-4b98-acaa-7d55aabb6c10.jpg?1",
             "name": "Ovinize",
             "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
             "colours": [
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "9d347321-ebae-5e66-be8a-ff3c4a2040b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb4952-593b-4cdf-97b8-d3cdbe424ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb4952-593b-4cdf-97b8-d3cdbe424ba6.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake enters the battlefield, untap up to five lands.",
             "colours": [
@@ -10450,7 +10450,7 @@
         },
         {
             "id": "357908f7-1261-5372-a22c-c818ed14e8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906569a3-1750-41af-8d83-a5354500c850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906569a3-1750-41af-8d83-a5354500c850.jpg?1",
             "name": "Stroke of Genius",
             "text": "Target player draws X cards.",
             "colours": [
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "e8f2e1df-dc93-508e-b1be-cd02d2f3596b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa810491-ce45-4a87-b3ec-85ec340e33a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa810491-ce45-4a87-b3ec-85ec340e33a4.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -10519,7 +10519,7 @@
         },
         {
             "id": "80d26865-28b8-5c12-b340-8d9d76f8d954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22702a76-f8ed-4a73-ba9d-f928add32d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22702a76-f8ed-4a73-ba9d-f928add32d85.jpg?1",
             "name": "Turnabout",
             "text": "Choose artifact, creature, or land. Tap all untapped permanents of the chosen type target player controls, or untap all tapped permanents of that type that player controls.",
             "colours": [
@@ -10553,7 +10553,7 @@
         },
         {
             "id": "55bd5802-5f1a-578c-9a7d-13b6fa1cf73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81329329-0154-4f89-a476-a54112dfa0b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81329329-0154-4f89-a476-a54112dfa0b7.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -10593,7 +10593,7 @@
         },
         {
             "id": "6a1a16a6-d42e-5dbc-b995-d1faf1172c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a53a7e-f54c-410c-8cd2-7d3e0347bc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a53a7e-f54c-410c-8cd2-7d3e0347bc6b.jpg?1",
             "name": "Vexing Sphinx",
             "text": "Flying\nCumulative upkeep\u2014\nDiscard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Vexing Sphinx dies, draw a card for each age counter on it.",
             "colours": [
@@ -10629,7 +10629,7 @@
         },
         {
             "id": "43862451-5ce4-534d-bad0-262156811ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd51f0b-3c8a-4b2e-a0b6-7fa98c3ba678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd51f0b-3c8a-4b2e-a0b6-7fa98c3ba678.jpg?1",
             "name": "Body Snatcher",
             "text": "When Body Snatcher enters the battlefield, exile it unless you discard a creature card.\nWhen Body Snatcher dies, exile it and return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -10666,7 +10666,7 @@
         },
         {
             "id": "49c61ff8-f35e-57c4-bd7e-5f7866b43182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f85a4be-fa18-47ce-b24d-8cac718227ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f85a4be-fa18-47ce-b24d-8cac718227ef.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -10706,7 +10706,7 @@
         },
         {
             "id": "924aaf13-0817-5ee5-8a9a-a63dc67c1afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63416b41-7791-48ff-bcdc-54101afbea31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63416b41-7791-48ff-bcdc-54101afbea31.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10741,7 +10741,7 @@
         },
         {
             "id": "5aef892e-018d-569d-bb7d-0e33df2b245a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc427d9-2697-4e60-b1eb-948a6556f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc427d9-2697-4e60-b1eb-948a6556f1ad.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "b48f67b9-1999-5b02-972c-4d5808e23255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dc1ce-a224-4271-86f1-31b3fe53405c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dc1ce-a224-4271-86f1-31b3fe53405c.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10809,7 +10809,7 @@
         },
         {
             "id": "efe79a95-6053-5821-bc90-713ea3cd9515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e533c49-35a5-4c78-a27c-d3e6f9355d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e533c49-35a5-4c78-a27c-d3e6f9355d37.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -10843,7 +10843,7 @@
         },
         {
             "id": "165805e1-87a8-5cd6-9448-f8defca4a8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750820a5-b03f-46ee-970a-b66845176853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750820a5-b03f-46ee-970a-b66845176853.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "63958091-2565-55e2-b359-90466d70d0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93e4486-aaf3-4f56-ab34-1ff1aeebb021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93e4486-aaf3-4f56-ab34-1ff1aeebb021.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer dies, each player discards their hand.",
             "colours": [
@@ -10914,7 +10914,7 @@
         },
         {
             "id": "f64e97a8-a397-5093-908b-48020317ceba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48375e7-46b6-45a7-9d19-f7b7de85fe55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48375e7-46b6-45a7-9d19-f7b7de85fe55.jpg?1",
             "name": "Nantuko Shade",
             "text": "{B}: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10951,7 +10951,7 @@
         },
         {
             "id": "4d555380-3191-592d-b25b-1f45f094c641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f7677-5f35-4cb9-a938-dba13fb7863a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f7677-5f35-4cb9-a938-dba13fb7863a.jpg?1",
             "name": "Necrosavant",
             "text": "{3}{B}{B}, Sacrifice a creature: Return Necrosavant from your graveyard to the battlefield. Activate only during your upkeep.",
             "colours": [
@@ -10988,7 +10988,7 @@
         },
         {
             "id": "346539f1-db61-5bb0-9458-dd851c13842c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2598da4-0764-440a-9e9d-0161e68667fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2598da4-0764-440a-9e9d-0161e68667fb.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature deals damage to you, destroy it.",
             "colours": [
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "a029795a-1a00-5538-b55c-df567b1a141a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f95c0-1470-4282-ba26-4908ed36a557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f95c0-1470-4282-ba26-4908ed36a557.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "fee0cabc-081d-56b8-b882-4b31b6a62753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11095,7 +11095,7 @@
         },
         {
             "id": "9e2ddfcc-336d-5fad-9232-fb0a1b153159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a06831-0cbd-48f9-a817-4c5a36fa782a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a06831-0cbd-48f9-a817-4c5a36fa782a.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "175b0aa7-ca62-5e1a-8404-16fc158bcf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9040f60a-03a5-4410-b6f8-92620ff91af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9040f60a-03a5-4410-b6f8-92620ff91af4.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "c80de890-7b29-5d4a-a8dd-5cdb81fff684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ca0c3-3308-4ebd-a0ce-f90eb605b0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ca0c3-3308-4ebd-a0ce-f90eb605b0f5.jpg?1",
             "name": "Undead Gladiator",
             "text": "{1}{B}, Discard a card: Return Undead Gladiator from your graveyard to your hand. Activate only during your upkeep.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -11203,7 +11203,7 @@
         },
         {
             "id": "7bee703b-1f5d-53b9-99b4-d4c956ad68a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ad722a-d6f3-483e-bd13-e0923cc8a265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ad722a-d6f3-483e-bd13-e0923cc8a265.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -11238,7 +11238,7 @@
         },
         {
             "id": "4b1b6ddb-8eeb-573b-8a4e-c56940fc8e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef603c2-b09c-40e9-b3ab-fceb4964aafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef603c2-b09c-40e9-b3ab-fceb4964aafd.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "307645c3-aec3-524f-a562-0ce951d88e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfc299-0cf5-40ab-9f50-11408ff82282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfc299-0cf5-40ab-9f50-11408ff82282.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -11312,7 +11312,7 @@
         },
         {
             "id": "526aa76c-02d4-5611-a514-9cba67d33f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190f2d1-e7e5-4cf7-8227-c2690568d159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190f2d1-e7e5-4cf7-8227-c2690568d159.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice Dragon Whelp at the beginning of the next end step.",
             "colours": [
@@ -11348,7 +11348,7 @@
         },
         {
             "id": "1a0fab57-22ea-5298-9a19-b1193fbe1f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd81c2e-9c0d-47b2-ba02-6f1dca1d96dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd81c2e-9c0d-47b2-ba02-6f1dca1d96dc.jpg?1",
             "name": "Empty the Warrens",
             "text": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -11382,7 +11382,7 @@
         },
         {
             "id": "f7a92945-b98c-56fd-9f47-098a63bf12d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d80d765-70bf-4eb5-ae55-fe459e96caf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d80d765-70bf-4eb5-ae55-fe459e96caf8.jpg?1",
             "name": "Fireblast",
             "text": "You may sacrifice two Mountains rather than pay this spell's mana cost.\nFireblast deals 4 damage to any target.",
             "colours": [
@@ -11416,7 +11416,7 @@
         },
         {
             "id": "d85e1d81-e9e4-5878-ab97-fd192d28dfb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f601db5-e522-48d2-a0df-ff3192f8d38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f601db5-e522-48d2-a0df-ff3192f8d38d.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -11453,7 +11453,7 @@
         },
         {
             "id": "3ef798f9-39a9-5dc6-a325-3774f61cf17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa5f934-5407-4844-9cd5-9ba5fa7c4748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa5f934-5407-4844-9cd5-9ba5fa7c4748.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle.",
             "colours": [
@@ -11488,7 +11488,7 @@
         },
         {
             "id": "f31a086d-2e87-52e2-acd3-63b4d28a0cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce01c9-f6f3-49e3-ac2c-10613eba0ed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce01c9-f6f3-49e3-ac2c-10613eba0ed6.jpg?1",
             "name": "Gempalm Incinerator",
             "text": "Cycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins on the battlefield.",
             "colours": [
@@ -11524,7 +11524,7 @@
         },
         {
             "id": "5287e7f6-1291-5464-b4bb-0d45ca42c1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ec4b08-6df1-4e92-8b7c-1450a4d033bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ec4b08-6df1-4e92-8b7c-1450a4d033bf.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -11560,7 +11560,7 @@
         },
         {
             "id": "e3347fab-cbf6-56c1-9b8d-54120529a967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59035b53-e374-49f6-8b02-8b54f6df45d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59035b53-e374-49f6-8b02-8b54f6df45d2.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "19d294d9-24a5-5897-bfe3-16b303285710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585be7c2-b303-4612-bafa-ca7a555212aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585be7c2-b303-4612-bafa-ca7a555212aa.jpg?1",
             "name": "Last Chance",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "640ab42b-198b-55c1-9666-242ebca05f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027246-1dd3-4be0-bea6-3a7476a833ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027246-1dd3-4be0-bea6-3a7476a833ce.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11670,7 +11670,7 @@
         },
         {
             "id": "65553096-a5c5-5845-bc81-d2c02bc7966d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3725a437-d853-4231-b669-c97f6a6666e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3725a437-d853-4231-b669-c97f6a6666e1.jpg?1",
             "name": "Overmaster",
             "text": "The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.",
             "colours": [
@@ -11704,7 +11704,7 @@
         },
         {
             "id": "bf0604d2-bc6c-58d1-a0cf-3f81304abf3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62b7671-efde-40b2-9cb1-76339d614d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62b7671-efde-40b2-9cb1-76339d614d29.jpg?1",
             "name": "Pashalik Mons",
             "text": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -11743,7 +11743,7 @@
         },
         {
             "id": "92b16033-406b-5bcc-9715-98361220bdd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f8025-95ff-431a-a33c-4e2e7366633f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f8025-95ff-431a-a33c-4e2e7366633f.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -11779,7 +11779,7 @@
         },
         {
             "id": "e92c013c-aef8-54f1-b177-e17c298f85c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bea810-1566-4132-bfb3-611f9b6b3333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bea810-1566-4132-bfb3-611f9b6b3333.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -11816,7 +11816,7 @@
         },
         {
             "id": "f8a93e23-7769-5e63-b76b-cff3100973aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2418b3d-574a-40e7-9b6b-1bc4a8199105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2418b3d-574a-40e7-9b6b-1bc4a8199105.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -11850,7 +11850,7 @@
         },
         {
             "id": "18cd090f-530a-57b8-a687-6f5f0a1ac966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d446b8b-1b09-4fef-8454-95ad272503c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d446b8b-1b09-4fef-8454-95ad272503c0.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -11884,7 +11884,7 @@
         },
         {
             "id": "a807d6a9-2145-5dec-82f4-528fd27dffaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9abfd4d-8f7d-4739-8416-2c03bc1c7a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9abfd4d-8f7d-4739-8416-2c03bc1c7a04.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "fe3fb83c-d2d1-5c09-8ea6-56d391dfcd2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed63bcc-4cdd-4b4e-af7f-f5ff71a4ef14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed63bcc-4cdd-4b4e-af7f-f5ff71a4ef14.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -11961,7 +11961,7 @@
         },
         {
             "id": "af9f30c5-08fc-5782-ab49-255c218752b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b991e-b5c1-4d23-ba3a-4554c272a41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b991e-b5c1-4d23-ba3a-4554c272a41f.jpg?1",
             "name": "Arboria",
             "text": "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn.",
             "colours": [
@@ -11998,7 +11998,7 @@
         },
         {
             "id": "72d94a98-5149-519e-97a6-cd3fbca71fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef6d6c-db50-4d24-8ebd-311613ddef06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef6d6c-db50-4d24-8ebd-311613ddef06.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [
@@ -12035,7 +12035,7 @@
         },
         {
             "id": "ba3bd9f2-0852-553a-9cc2-905687c51a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a39ab84-1f0f-4b4f-a13d-301960bbc971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a39ab84-1f0f-4b4f-a13d-301960bbc971.jpg?1",
             "name": "Deadwood Treefolk",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk enters or leaves the battlefield, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "5d1860a2-3d46-5955-82ae-356b69905cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02805527-943c-4d88-9d80-50ed71a14af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02805527-943c-4d88-9d80-50ed71a14af2.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "Exile Elvish Spirit Guide from your hand: Add {G}.",
             "colours": [
@@ -12108,7 +12108,7 @@
         },
         {
             "id": "0f6184cf-27b5-5b7d-8bb3-d8975d99bc31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbcd04-aabf-420e-9bc8-4270f78e25d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbcd04-aabf-420e-9bc8-4270f78e25d7.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -12142,7 +12142,7 @@
         },
         {
             "id": "8dbbde62-9c02-5b0a-84a4-398517ec336c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095eda4-7a9c-4161-a775-4dbfac32dbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095eda4-7a9c-4161-a775-4dbfac32dbab.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "76d13fb6-e011-57f6-b280-b39d1aef055c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afea4ea-02f2-47ca-b690-864a5663eecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afea4ea-02f2-47ca-b690-864a5663eecc.jpg?1",
             "name": "Forgotten Ancient",
             "text": "Whenever a player casts a spell, you may put a +1/+1 counter on Forgotten Ancient.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Forgotten Ancient onto other creatures.",
             "colours": [
@@ -12215,7 +12215,7 @@
         },
         {
             "id": "d5958393-2ca3-5cbc-8299-770fb24d17c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13286ebf-e4dd-48be-82e7-9057755027ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13286ebf-e4dd-48be-82e7-9057755027ec.jpg?1",
             "name": "Invigorating Boon",
             "text": "Whenever a player cycles a card, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -12249,7 +12249,7 @@
         },
         {
             "id": "824e146e-b100-5813-a776-6c62eff7c66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888c4cd-8cdf-442f-838c-dc1e4d696998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888c4cd-8cdf-442f-838c-dc1e4d696998.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -12288,7 +12288,7 @@
         },
         {
             "id": "715f59f7-1d87-5abd-b12c-b74e932b40c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ef4c48-978c-41f5-b347-230433326f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ef4c48-978c-41f5-b347-230433326f7c.jpg?1",
             "name": "Kamahl, Fist of Krosa",
             "text": "{G}: Target land becomes a 1/1 creature until end of turn. It's still a land.\n{2}{G}{G}{G}: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -12327,7 +12327,7 @@
         },
         {
             "id": "d7025c46-a717-53c2-b0b6-7a83f01f58e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9cbb7f-8745-4ec4-8d8a-efd1f7e93b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9cbb7f-8745-4ec4-8d8a-efd1f7e93b1e.jpg?1",
             "name": "Lull",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -12361,7 +12361,7 @@
         },
         {
             "id": "febcd3dc-9c0e-569c-91a5-0e4dd6634bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3e1d00-effa-46ac-a899-030c0eb149ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3e1d00-effa-46ac-a899-030c0eb149ac.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -12395,7 +12395,7 @@
         },
         {
             "id": "4d43130f-2fee-54b6-bc94-588711280c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa53cbd-efe8-4ca8-8c1c-664de27d1b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa53cbd-efe8-4ca8-8c1c-664de27d1b69.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may create a 1/1 green Squirrel creature token.\nThreshold \u2014 All Squirrels get +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -12433,7 +12433,7 @@
         },
         {
             "id": "292a9422-2257-5f37-a3c7-5c38951b7988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8253dab6-d6a7-4a1c-b5f6-5a2ee051a128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8253dab6-d6a7-4a1c-b5f6-5a2ee051a128.jpg?1",
             "name": "Saproling Symbiosis",
             "text": "You may cast Saproling Symbiosis as though it had flash if you pay {2} more to cast it.\nCreate a 1/1 green Saproling creature token for each creature you control.",
             "colours": [
@@ -12467,7 +12467,7 @@
         },
         {
             "id": "524e3bcf-c543-52bd-b90d-3038ca25cecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4112147-5609-484f-b303-c34df2f315ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4112147-5609-484f-b303-c34df2f315ce.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -12503,7 +12503,7 @@
         },
         {
             "id": "0403cf30-a565-557b-8bab-7a2683a246f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17788434-47c5-4290-8555-adc8171d55cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17788434-47c5-4290-8555-adc8171d55cd.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -12538,7 +12538,7 @@
         },
         {
             "id": "8506584d-e422-588e-8992-d5af6b47c8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ea0b6a-c0f1-49f8-bbd1-fed61ef0c0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ea0b6a-c0f1-49f8-bbd1-fed61ef0c0f3.jpg?1",
             "name": "Wild Dogs",
             "text": "At the beginning of your upkeep, if a player has more life than each other player, the player with the most life gains control of Wild Dogs.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -12574,7 +12574,7 @@
         },
         {
             "id": "cbc1c62b-17b3-5c73-91fa-e11397007a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7246bde-9298-4386-ac4f-1d79f7f0cca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7246bde-9298-4386-ac4f-1d79f7f0cca5.jpg?1",
             "name": "Wild Growth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.",
             "colours": [
@@ -12610,7 +12610,7 @@
         },
         {
             "id": "d5e87e86-5788-5eed-93b6-7faa9341c9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6706ed-f05b-411f-afa5-f6154f718c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6706ed-f05b-411f-afa5-f6154f718c80.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card, reveal it, then shuffle and put the card on top.",
             "colours": [
@@ -12645,7 +12645,7 @@
         },
         {
             "id": "a7ea10dc-d112-5f12-b886-b34527e3ae46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5f70fa-7f96-4b7e-a1cf-56a053f0bff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5f70fa-7f96-4b7e-a1cf-56a053f0bff6.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -12682,7 +12682,7 @@
         },
         {
             "id": "e68121ef-8d75-5a60-932c-2b9202ddd3ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f75fe15-5499-4dfe-917d-adfeccd6838a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f75fe15-5499-4dfe-917d-adfeccd6838a.jpg?1",
             "name": "Arcades Sabboth",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Arcades Sabboth unless you pay {G}{W}{U}.\nEach untapped creature you control gets +0/+2 as long as it's not attacking.\n{W}: Arcades Sabboth gets +0/+1 until end of turn.",
             "colours": [
@@ -12725,7 +12725,7 @@
         },
         {
             "id": "fc079c17-d2b5-52d0-9c2e-4c5b23899a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18445778-6176-40f6-a396-05e85579e85e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18445778-6176-40f6-a396-05e85579e85e.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -12762,7 +12762,7 @@
         },
         {
             "id": "92a98cf0-cbf0-5e45-b580-b4cf6f91558b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46db87-f1b2-4c04-a9f2-642571a8d81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46db87-f1b2-4c04-a9f2-642571a8d81b.jpg?1",
             "name": "Dralnu's Crusade",
             "text": "All Goblins get +1/+1.\nAll Goblins are black and are Zombies in addition to their other creature types.",
             "colours": [
@@ -12798,7 +12798,7 @@
         },
         {
             "id": "1dde490d-7fa0-557b-92d5-447c7fbbd1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4057a41-c8d1-40dd-ac38-abfe6564c8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4057a41-c8d1-40dd-ac38-abfe6564c8bc.jpg?1",
             "name": "Gerrard's Verdict",
             "text": "Target player discards two cards. You gain 3 life for each land card discarded this way.",
             "colours": [
@@ -12834,7 +12834,7 @@
         },
         {
             "id": "268cd2e2-1647-5b7a-a3da-8146f3d22c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0d5a1-1a2e-449f-a9b5-14bf2061529c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0d5a1-1a2e-449f-a9b5-14bf2061529c.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Hunting Grounds has \"Whenever an opponent casts a spell, you may put a creature card from your hand onto the battlefield.\"",
             "colours": [
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "144cd87e-177e-5b54-91ba-6b6ccf431e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31318a5f-6758-45a6-930f-ba6b1e812af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31318a5f-6758-45a6-930f-ba6b1e812af1.jpg?1",
             "name": "Mystic Enforcer",
             "text": "Protection from black\nThreshold \u2014 As long as seven or more cards are in your graveyard, Mystic Enforcer gets +3/+3 and has flying.",
             "colours": [
@@ -12911,7 +12911,7 @@
         },
         {
             "id": "bcfbadc8-abce-53b2-94df-8b5fb0eccd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000f904-be97-4ad6-825a-0b05c31c3362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000f904-be97-4ad6-825a-0b05c31c3362.jpg?1",
             "name": "Phantom Nishoba",
             "text": "Trample\nPhantom Nishoba enters the battlefield with seven +1/+1 counters on it.\nWhenever Phantom Nishoba deals damage, you gain that much life.\nIf damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.",
             "colours": [
@@ -12951,7 +12951,7 @@
         },
         {
             "id": "aee189d7-579c-501f-a5d7-272007d7c9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8279d133-ae1a-4389-8c20-1d7ca2f121b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8279d133-ae1a-4389-8c20-1d7ca2f121b1.jpg?1",
             "name": "Pyre Zombie",
             "text": "At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay {1}{B}{B}. If you do, return Pyre Zombie to your hand.\n{1}{R}{R}, Sacrifice Pyre Zombie: It deals 2 damage to any target.",
             "colours": [
@@ -12989,7 +12989,7 @@
         },
         {
             "id": "f19ab45c-b168-5e7d-b4d5-649a81ebb697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07be7455-7ead-4ba5-b694-e021b28687d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07be7455-7ead-4ba5-b694-e021b28687d9.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target player or planeswalker. You draw a card.\"",
             "colours": [
@@ -13027,7 +13027,7 @@
         },
         {
             "id": "dee76714-6d4a-5068-bfbd-66680a801119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27600b4d-ade5-428a-8eb7-d7c387573a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27600b4d-ade5-428a-8eb7-d7c387573a91.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "b206ffce-6629-56ce-a5cd-dfbddc318dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669ad7e-8366-4fec-8151-ded41a9c4548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669ad7e-8366-4fec-8151-ded41a9c4548.jpg?1",
             "name": "Recoil",
             "text": "Return target permanent to its owner's hand. Then that player discards a card.",
             "colours": [
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "e71d4c7f-7dbb-5f22-9c43-be8c5faea2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0a3c92-826e-491a-8e80-7861e5b199c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0a3c92-826e-491a-8e80-7861e5b199c2.jpg?1",
             "name": "Rith, the Awakener",
             "text": "Flying\nWhenever Rith, the Awakener deals combat damage to a player, you may pay {2}{G}. If you do, choose a color, then create a 1/1 green Saproling creature token for each permanent of that color.",
             "colours": [
@@ -13147,7 +13147,7 @@
         },
         {
             "id": "4038fd6b-d213-56dc-8e8a-918cac806116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f856897c-fb63-4ba2-a1ce-9a8a0bf67072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f856897c-fb63-4ba2-a1ce-9a8a0bf67072.jpg?1",
             "name": "Sawtooth Loon",
             "text": "Flying\nWhen Sawtooth Loon enters the battlefield, return a white or blue creature you control to its owner's hand.\nWhen Sawtooth Loon enters the battlefield, draw two cards, then put two cards from your hand on the bottom of your library.",
             "colours": [
@@ -13185,7 +13185,7 @@
         },
         {
             "id": "6c2670a5-8e56-51cb-94ef-495716ffb3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b989b3f-2eec-4593-ac39-daa8e9ca0daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b989b3f-2eec-4593-ac39-daa8e9ca0daa.jpg?1",
             "name": "Sol'kanar the Swamp King",
             "text": "Swampwalk\nWhenever a player casts a black spell, you gain 1 life.",
             "colours": [
@@ -13227,7 +13227,7 @@
         },
         {
             "id": "2cd7a713-fed0-5762-8824-0550c6705704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa304be0-3944-42c3-94cd-6568db8a661e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa304be0-3944-42c3-94cd-6568db8a661e.jpg?1",
             "name": "Spinal Embrace",
             "text": "Cast this spell only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness.",
             "colours": [
@@ -13263,7 +13263,7 @@
         },
         {
             "id": "228a8d3e-a2d9-5ea9-8066-3024e94ca441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e366f-6c64-423d-92fc-1a1e2806e4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e366f-6c64-423d-92fc-1a1e2806e4c3.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\n{B}: Regenerate Spiritmonger.\n{G}: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -13301,7 +13301,7 @@
         },
         {
             "id": "c9c87ea9-29f0-5bcf-a377-6690dfd0f5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32efed1-73ed-49bc-a1e1-53520ddd5d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32efed1-73ed-49bc-a1e1-53520ddd5d43.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -13342,7 +13342,7 @@
         },
         {
             "id": "8f6c2e82-8de8-5886-98d2-72846dd3df54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58dcad2-2e38-46d1-bab7-beddd3600a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58dcad2-2e38-46d1-bab7-beddd3600a1c.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -13383,7 +13383,7 @@
         },
         {
             "id": "8ebdbe8f-41ad-5b6c-8d35-3d0e14ab5941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5de65-5b64-4a32-8c7c-8a7c84f406a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5de65-5b64-4a32-8c7c-8a7c84f406a8.jpg?1",
             "name": "Xira Arien",
             "text": "Flying\n{B}{R}{G}, {T}: Target player draws a card.",
             "colours": [
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "0a769a21-1484-5015-9671-a3a01bcd7944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17188ab9-0fd1-43af-be3b-6e37c55cda9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17188ab9-0fd1-43af-be3b-6e37c55cda9c.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -13469,7 +13469,7 @@
         },
         {
             "id": "f17eff03-0745-5649-9215-8c7b62cc239d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c628d-ae86-4a87-94bb-d06574cda9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c628d-ae86-4a87-94bb-d06574cda9ce.jpg?1",
             "name": "Crawlspace",
             "text": "No more than two creatures can attack you each combat.",
             "colours": [],
@@ -13499,7 +13499,7 @@
         },
         {
             "id": "07293060-21c9-5e70-a037-0c127cb46d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7280d-3727-4c96-bd7a-ae699d007469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7280d-3727-4c96-bd7a-ae699d007469.jpg?1",
             "name": "Cryptic Gateway",
             "text": "Tap two untapped creatures you control: You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield.",
             "colours": [],
@@ -13529,7 +13529,7 @@
         },
         {
             "id": "5d44f9fa-e211-5e13-a324-256d64f6b6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c178d4c-bce9-4165-af1c-6075a94c84e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c178d4c-bce9-4165-af1c-6075a94c84e4.jpg?1",
             "name": "Damping Sphere",
             "text": "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
             "colours": [],
@@ -13559,7 +13559,7 @@
         },
         {
             "id": "df673a80-8855-5473-8fd3-355594325fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9649b3-0159-426c-838d-d649c6dbe147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9649b3-0159-426c-838d-d649c6dbe147.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -13590,7 +13590,7 @@
         },
         {
             "id": "adc8578d-cd9d-58f7-84d7-ba56d283f68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571bf6-44e1-4975-999d-c44e6709dd5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571bf6-44e1-4975-999d-c44e6709dd5d.jpg?1",
             "name": "Helm of Awakening",
             "text": "Spells cost {1} less to cast.",
             "colours": [],
@@ -13621,7 +13621,7 @@
         },
         {
             "id": "4c51539f-4dde-56b2-9bde-11a4e3730447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e416c68f-433c-44f9-8fcc-043b3919a312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e416c68f-433c-44f9-8fcc-043b3919a312.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -13651,7 +13651,7 @@
         },
         {
             "id": "d26d54d4-8d09-5af7-81ca-8fe161dcdea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f036d2-81ce-490c-b8a0-ab5dc29148ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f036d2-81ce-490c-b8a0-ab5dc29148ec.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and exile them. Then that player shuffles.",
             "colours": [],
@@ -13682,7 +13682,7 @@
         },
         {
             "id": "1ab34cb3-b470-5a2a-bded-e492e37d375d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3468f8d1-4373-4df4-9bbe-3c61a840b23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3468f8d1-4373-4df4-9bbe-3c61a840b23b.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -13715,7 +13715,7 @@
         },
         {
             "id": "c1f2eac6-4f0f-5f95-97ac-eae6735a3607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17f9e1-341f-4649-9e8a-728ef67f875c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17f9e1-341f-4649-9e8a-728ef67f875c.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Exile target permanent.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -13754,7 +13754,7 @@
         },
         {
             "id": "58d138be-855c-55e7-8aa4-66db80663fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67680b01-648a-4056-b117-3ba22ee00051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67680b01-648a-4056-b117-3ba22ee00051.jpg?1",
             "name": "Lotus Blossom",
             "text": "At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.\n{T}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.",
             "colours": [],
@@ -13785,7 +13785,7 @@
         },
         {
             "id": "36213d55-410f-529e-96db-bcd1a35abc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d470d-e0f0-44c2-97f7-f31c02cdfbd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d470d-e0f0-44c2-97f7-f31c02cdfbd3.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -13815,7 +13815,7 @@
         },
         {
             "id": "6873d365-c51e-5f22-87f3-4b1cabc8757c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051386e0-4c1c-48ed-8883-664c719cf0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051386e0-4c1c-48ed-8883-664c719cf0fe.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -13848,7 +13848,7 @@
         },
         {
             "id": "a6593936-d28f-5075-82a7-aff08a28bd3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ee8a2a-7ee8-4017-97b6-799fdb3ce4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ee8a2a-7ee8-4017-97b6-799fdb3ce4f7.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -13881,7 +13881,7 @@
         },
         {
             "id": "002dcca6-d9d7-52a9-8153-05db5d099a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23814c0-f9da-49c4-bfff-69786a5d651b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23814c0-f9da-49c4-bfff-69786a5d651b.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile target player's graveyard.",
             "colours": [],
@@ -13911,7 +13911,7 @@
         },
         {
             "id": "758f67c2-633a-52f6-83cb-ebb018ceb29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5adfe0f-496a-4d56-8c8b-6b58cc827339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5adfe0f-496a-4d56-8c8b-6b58cc827339.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "d3e5e36b-9b94-57b2-b2d3-aef88552e694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c5666-5373-4c81-802a-782a150d70ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c5666-5373-4c81-802a-782a150d70ad.jpg?1",
             "name": "Umbilicus",
             "text": "At the beginning of each player's upkeep, that player may pay 2 life. If they don't, they return a permanent they control to its owner's hand.",
             "colours": [],
@@ -13975,7 +13975,7 @@
         },
         {
             "id": "b9bba509-75a1-5801-b2fe-61874c7b0d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2c48-c1ad-4148-bf68-803d2c33ee0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2c48-c1ad-4148-bf68-803d2c33ee0e.jpg?1",
             "name": "Urza's Blueprints",
             "text": "Echo {6} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{T}: Draw a card.",
             "colours": [],
@@ -14005,7 +14005,7 @@
         },
         {
             "id": "97233505-7197-52a5-90e5-d4df9215a9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd254044-2b66-4fd8-9f72-3c30226c2a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd254044-2b66-4fd8-9f72-3c30226c2a9c.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -14036,7 +14036,7 @@
         },
         {
             "id": "4ca544a9-bd6f-54c2-b9c4-c4e5104fd8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c177316-31b5-4b73-8cab-eef9d8cbb2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c177316-31b5-4b73-8cab-eef9d8cbb2d1.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -14069,7 +14069,7 @@
         },
         {
             "id": "937057f8-97d2-5d56-b98f-37066a712e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78398af-06b7-41f8-8aaa-81800f490121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78398af-06b7-41f8-8aaa-81800f490121.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -14103,7 +14103,7 @@
         },
         {
             "id": "91c5d98b-ebd9-5b94-aed1-699af9c76de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0961cc70-6069-41b1-8fd4-befc4efa5143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0961cc70-6069-41b1-8fd4-befc4efa5143.jpg?1",
             "name": "Gemstone Mine",
             "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color. If there are no mining counters on Gemstone Mine, sacrifice it.",
             "colours": [],
@@ -14134,7 +14134,7 @@
         },
         {
             "id": "7f487c88-6c7c-5d02-8c79-200e3d8004ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0678705f-708e-44ab-9e85-76df13bea694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0678705f-708e-44ab-9e85-76df13bea694.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -14167,7 +14167,7 @@
         },
         {
             "id": "6e5bce18-5599-5bd3-a6b2-27446adb960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc6c906-9013-4840-9cda-d85ad72c04b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc6c906-9013-4840-9cda-d85ad72c04b0.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -14200,7 +14200,7 @@
         },
         {
             "id": "ee9ad085-db2f-502e-ad27-e6dbb612d9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202554-88a7-4b7f-b20f-d034997dbd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202554-88a7-4b7f-b20f-d034997dbd02.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -14231,7 +14231,7 @@
         },
         {
             "id": "bbddf23f-a602-57d9-9d31-64117c470b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88a1690-111e-4e8f-a896-890e793e8a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88a1690-111e-4e8f-a896-890e793e8a9f.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -14261,7 +14261,7 @@
         },
         {
             "id": "7d062993-dd76-5daf-8256-ae68fe4cbbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4ee66c-1c3f-4ece-8c0a-4f0c259c5142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4ee66c-1c3f-4ece-8c0a-4f0c259c5142.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "e8a49df9-745a-5968-ae52-2bab05e652b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16761d3b-3507-47ee-acff-54b426164d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16761d3b-3507-47ee-acff-54b426164d89.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -14327,7 +14327,7 @@
         },
         {
             "id": "51fbfb6f-cd05-516d-8999-ffa04f1bcb70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac23c5e-a489-4fba-b14f-a968b202ac22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac23c5e-a489-4fba-b14f-a968b202ac22.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14363,7 +14363,7 @@
         },
         {
             "id": "ddd119ae-4ef2-5200-bdde-7a68009bc010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8b581b-5177-4cea-8021-42f4d21583ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8b581b-5177-4cea-8021-42f4d21583ad.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14399,7 +14399,7 @@
         },
         {
             "id": "42be320c-9b10-5d4b-82ad-7525ea8fe8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c4ab8b-9f84-4b92-a114-93b082c15080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c4ab8b-9f84-4b92-a114-93b082c15080.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14435,7 +14435,7 @@
         },
         {
             "id": "f2073f3f-90e7-592a-b658-2b069274872d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0473605a-6c6a-433e-b828-933544472a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0473605a-6c6a-433e-b828-933544472a3d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14471,7 +14471,7 @@
         },
         {
             "id": "9d1f23ee-5502-5edc-a0ea-2eb726ff0589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cf978-7492-4bf9-9b20-a91c21008841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cf978-7492-4bf9-9b20-a91c21008841.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14507,7 +14507,7 @@
         },
         {
             "id": "7b21647a-c516-5e08-9a5e-58a1d9492331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c46b9a-07ea-40ab-9a2b-5bee8e7d3496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c46b9a-07ea-40ab-9a2b-5bee8e7d3496.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14543,7 +14543,7 @@
         },
         {
             "id": "e9c147d3-7034-52db-ba75-b4f57058f8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad7ef0-101c-436e-a41a-cdc8e91d2f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad7ef0-101c-436e-a41a-cdc8e91d2f2a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14579,7 +14579,7 @@
         },
         {
             "id": "cdf2570d-8f01-52fb-a24c-82b3be4183ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5fb3d-2c9e-4cdb-a202-ad5955eae42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5fb3d-2c9e-4cdb-a202-ad5955eae42c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14615,7 +14615,7 @@
         },
         {
             "id": "eca9c920-3e02-5e39-baf6-29cbf64104d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941546b8-8540-40dd-bacc-9b11f3d63033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941546b8-8540-40dd-bacc-9b11f3d63033.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14651,7 +14651,7 @@
         },
         {
             "id": "b2c70ad6-1914-54b6-928d-f39cc1188413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae0bd2b-6875-4823-b596-f5c7c0a0809e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae0bd2b-6875-4823-b596-f5c7c0a0809e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14687,7 +14687,7 @@
         },
         {
             "id": "bd8dcfc3-f5e4-5c44-9ac1-360ef38003fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f690bd2a-e565-4316-8312-3d0386c8ba36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f690bd2a-e565-4316-8312-3d0386c8ba36.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -14722,7 +14722,7 @@
         },
         {
             "id": "df0999ba-c2d2-5d94-aac7-13caa635a1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44899568-7aac-47ae-9f7d-b5414f65625b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44899568-7aac-47ae-9f7d-b5414f65625b.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -14761,7 +14761,7 @@
         },
         {
             "id": "17f52524-e247-5cc4-9561-b5541d60480a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5bfae8-f789-445e-bc60-a4eead19caec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5bfae8-f789-445e-bc60-a4eead19caec.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "b098029d-5f68-5a72-9ef2-2c83ffe09e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6939e631-91b7-4d58-b15d-ae588e73259c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6939e631-91b7-4d58-b15d-ae588e73259c.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "7bb5fdc0-961e-5ee8-9bb0-2d81eee99541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b24aeb-afba-4215-bf3e-61e581eb412c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b24aeb-afba-4215-bf3e-61e581eb412c.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -14868,7 +14868,7 @@
         },
         {
             "id": "4315d483-782d-5c7c-85b5-5c08c55c7bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd2427a-9b63-4345-af20-46e2f530bab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd2427a-9b63-4345-af20-46e2f530bab0.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep enters the battlefield, return each other creature you control to its owner's hand.",
             "colours": [
@@ -14905,7 +14905,7 @@
         },
         {
             "id": "31d0c9be-88e5-5d51-ac06-5b8844c0a357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7b0e29-09d9-4b3e-ab94-f1f4a61d9159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7b0e29-09d9-4b3e-ab94-f1f4a61d9159.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -14940,7 +14940,7 @@
         },
         {
             "id": "62418702-e99e-56fe-b679-d5f138388ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2400cc-987b-49de-8ac7-3d4b12c4200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2400cc-987b-49de-8ac7-3d4b12c4200a.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.",
             "colours": [
@@ -14975,7 +14975,7 @@
         },
         {
             "id": "c1faaac4-1f2c-5cd3-ac49-0249f4a06edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff393aab-0b02-496c-97df-0ffa0f8b1ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff393aab-0b02-496c-97df-0ffa0f8b1ec9.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
             "colours": [
@@ -15010,7 +15010,7 @@
         },
         {
             "id": "380609c6-a4c2-5972-a00a-256d2f95520a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -15045,7 +15045,7 @@
         },
         {
             "id": "5ac81cb7-cc4e-59b1-9de3-fb7600ff4fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8318aa5-6a08-4e92-afae-ff07a3f0ae5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8318aa5-6a08-4e92-afae-ff07a3f0ae5e.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -15080,7 +15080,7 @@
         },
         {
             "id": "f9fad058-2af3-5ba7-9cf4-6a8b875b4150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e626cc-b01a-4e20-9414-8ba6347041f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e626cc-b01a-4e20-9414-8ba6347041f0.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -15120,7 +15120,7 @@
         },
         {
             "id": "f72a5d05-102d-563e-ae1a-3aa746663106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46958867-db3b-416f-afc5-fbf241c29b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46958867-db3b-416f-afc5-fbf241c29b7d.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -15160,7 +15160,7 @@
         },
         {
             "id": "bd6273a0-c7a6-5c74-aa6e-3cb1e98ee7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1962-f4ad-4d76-a00a-f363e102018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1962-f4ad-4d76-a00a-f363e102018e.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B}",
             "colours": [
@@ -15195,7 +15195,7 @@
         },
         {
             "id": "3af33503-8788-5882-9b6d-dc824196acf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baede1c0-5bd0-4a3b-af3c-32fbb14033e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baede1c0-5bd0-4a3b-af3c-32fbb14033e8.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -15230,7 +15230,7 @@
         },
         {
             "id": "6cbae0a3-f0d6-504f-bb3f-fb3e1e36e33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7295eb82-8785-4a5f-ba64-0a0b5cb77d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7295eb82-8785-4a5f-ba64-0a0b5cb77d3f.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature deals damage to you, destroy it.",
             "colours": [
@@ -15265,7 +15265,7 @@
         },
         {
             "id": "a92cb3c1-4c26-5e17-a300-249000777826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29220f44-aa0f-4819-8873-c7a313a8d159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29220f44-aa0f-4819-8873-c7a313a8d159.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15300,7 +15300,7 @@
         },
         {
             "id": "80854bfe-9e54-5bcd-ae96-79a42fc7615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d645f8b-8aad-4633-b021-dc8ed870d8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d645f8b-8aad-4633-b021-dc8ed870d8e8.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life.",
             "colours": [
@@ -15337,7 +15337,7 @@
         },
         {
             "id": "1b0c00d2-fe86-5062-a86b-559e91282f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c04bbbe-cae0-4ac5-8bd3-ecc95a2b6bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c04bbbe-cae0-4ac5-8bd3-ecc95a2b6bd8.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -15372,7 +15372,7 @@
         },
         {
             "id": "ba55edb1-c9c2-5f74-b7a1-27853b0e84ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed98e1-898b-494b-a27d-7c1ab28cd9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed98e1-898b-494b-a27d-7c1ab28cd9f1.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate.",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "edbfee1a-7405-5e46-9f07-837bfb3e3231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150047e1-32f8-4aff-b311-0f6d58ce36fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150047e1-32f8-4aff-b311-0f6d58ce36fe.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -15449,7 +15449,7 @@
         },
         {
             "id": "173af9fe-dc10-5cd4-8d22-51957758dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bc7576-233f-4267-9943-d831a5b2c233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bc7576-233f-4267-9943-d831a5b2c233.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle.",
             "colours": [
@@ -15484,7 +15484,7 @@
         },
         {
             "id": "e63064fa-1153-5b5d-bd85-2beb0dc8a068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ae5aec-1341-439b-aae7-83cb69e8c1d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ae5aec-1341-439b-aae7-83cb69e8c1d4.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -15522,7 +15522,7 @@
         },
         {
             "id": "a2bc1345-85a5-5d01-93e1-0db3bc0ff96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c76b986-30e5-440c-a30c-ef3d77cace1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c76b986-30e5-440c-a30c-ef3d77cace1e.jpg?1",
             "name": "Last Chance",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -15557,7 +15557,7 @@
         },
         {
             "id": "e0137a81-cf7c-5c54-8b79-0ca060b4a607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf33009-b795-4097-a77c-08be7dce90cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf33009-b795-4097-a77c-08be7dce90cc.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -15594,7 +15594,7 @@
         },
         {
             "id": "25194d6a-653b-5b03-878e-8076ea5268cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3b30d4-5f8b-40fe-b446-b929a1b1e368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3b30d4-5f8b-40fe-b446-b929a1b1e368.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -15632,7 +15632,7 @@
         },
         {
             "id": "3a4be5ec-853e-5e93-be2d-5ad91080f2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a834bdb8-6c4f-4ca4-a097-27411d66e797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a834bdb8-6c4f-4ca4-a097-27411d66e797.jpg?1",
             "name": "Arboria",
             "text": "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn.",
             "colours": [
@@ -15669,7 +15669,7 @@
         },
         {
             "id": "16fbfae8-7318-53a6-8832-d8e4a3f218f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0e2b-1ff1-494a-8bc9-9741d6bb5590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0e2b-1ff1-494a-8bc9-9741d6bb5590.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [
@@ -15706,7 +15706,7 @@
         },
         {
             "id": "7acca04c-a4ea-59f3-a224-6a8c967993a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61af26f-bab1-412d-8849-0d7c3c304950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61af26f-bab1-412d-8849-0d7c3c304950.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may create a 1/1 green Squirrel creature token.\nThreshold \u2014 All Squirrels get +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -15744,7 +15744,7 @@
         },
         {
             "id": "a1f0f828-e954-593f-9e36-e7c2fdcd9ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49129453-1fe8-47de-b6aa-5b92d3d74c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49129453-1fe8-47de-b6aa-5b92d3d74c99.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -15779,7 +15779,7 @@
         },
         {
             "id": "125c584f-69c7-5901-a523-de932ccf0556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4d0a8-3270-4e53-9f1d-90f995c3b712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4d0a8-3270-4e53-9f1d-90f995c3b712.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card, reveal it, then shuffle and put the card on top.",
             "colours": [
@@ -15814,7 +15814,7 @@
         },
         {
             "id": "19fecd5b-3615-5eb1-a3a5-36468a6ee114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a7ff06-32b7-48cd-99bb-a91f7f43538d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a7ff06-32b7-48cd-99bb-a91f7f43538d.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "03fee19a-dbbc-5ba6-93b9-ac5a49178811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3fc84d-dbae-40a2-bb95-abedbc83c0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3fc84d-dbae-40a2-bb95-abedbc83c0cd.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -15888,7 +15888,7 @@
         },
         {
             "id": "64f1b70c-28ba-5b93-a172-05f321a075e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea268a6-cf0a-4912-b1eb-47a99ff8c10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea268a6-cf0a-4912-b1eb-47a99ff8c10e.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Hunting Grounds has \"Whenever an opponent casts a spell, you may put a creature card from your hand onto the battlefield.\"",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "f14f0cc9-7ac2-58e5-ad33-e88da076d77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6accaee3-8941-4409-bc1e-46a5b653d411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6accaee3-8941-4409-bc1e-46a5b653d411.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -15967,7 +15967,7 @@
         },
         {
             "id": "2d98ac8a-7141-53fa-b7e2-77d52131cacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b98e9c2-8843-4b59-828c-af54e1628e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b98e9c2-8843-4b59-828c-af54e1628e98.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -15998,7 +15998,7 @@
         },
         {
             "id": "ab1410e8-3e98-546e-aa57-22c392df7c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b94aed3-a5c0-4573-a6d5-29a04ac522b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b94aed3-a5c0-4573-a6d5-29a04ac522b2.jpg?1",
             "name": "Helm of Awakening",
             "text": "Spells cost {1} less to cast.",
             "colours": [],
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "100ab5d8-7290-528e-aa73-c1d3ab5b6976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffa2589-006a-4f60-a7e9-3a1e00d8fa91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffa2589-006a-4f60-a7e9-3a1e00d8fa91.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and exile them. Then that player shuffles.",
             "colours": [],
@@ -16060,7 +16060,7 @@
         },
         {
             "id": "09727967-aaa9-5e58-b34d-810f8d7fa054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbecc305-a35a-47b2-a825-f48ce1171b79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbecc305-a35a-47b2-a825-f48ce1171b79.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Exile target permanent.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -16099,7 +16099,7 @@
         },
         {
             "id": "cbb5ea00-3943-50f5-94fa-3ca9d6636ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45d36d0-7706-4e36-a5ed-d32c22c67eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45d36d0-7706-4e36-a5ed-d32c22c67eae.jpg?1",
             "name": "Lotus Blossom",
             "text": "At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.\n{T}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.",
             "colours": [],
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "1cbf352c-293c-5bef-be06-347651ede58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3e03a3-0082-4d4e-8891-8c8dcc8f1cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3e03a3-0082-4d4e-8891-8c8dcc8f1cbf.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -16164,7 +16164,7 @@
         },
         {
             "id": "79196b53-0f9f-516b-856c-b8f25d34f724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87830ee-c6b9-4c68-bc04-74987b03858d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87830ee-c6b9-4c68-bc04-74987b03858d.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -16195,7 +16195,7 @@
         },
         {
             "id": "80cd91fb-bb57-5d78-8378-01d0b7a3d926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ebe92-1ea2-4bfa-8464-851b808fef0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ebe92-1ea2-4bfa-8464-851b808fef0b.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -16229,7 +16229,7 @@
         },
         {
             "id": "2570050e-59de-532e-85c2-ad9f5e84081f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65b459e-2756-4f66-b80d-4bdc1c1c9bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65b459e-2756-4f66-b80d-4bdc1c1c9bae.jpg?1",
             "name": "Gemstone Mine",
             "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color. If there are no mining counters on Gemstone Mine, sacrifice it.",
             "colours": [],
@@ -16260,7 +16260,7 @@
         },
         {
             "id": "57153149-5207-5b42-8f71-8527d606e0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286bd95-0d8e-4b1a-b319-052fe2ae1951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286bd95-0d8e-4b1a-b319-052fe2ae1951.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -16291,7 +16291,7 @@
         },
         {
             "id": "b9deb2bb-c641-54a1-b5f5-5eedfe2a2f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b73577a-8ca1-41d7-9b2b-7300286fde43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b73577a-8ca1-41d7-9b2b-7300286fde43.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -16325,7 +16325,7 @@
         },
         {
             "id": "3375837a-9a31-52fe-9903-1fcf6bf2236a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fdde92-dc2c-4ed0-b092-926ef9c091ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fdde92-dc2c-4ed0-b092-926ef9c091ad.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16360,7 +16360,7 @@
         },
         {
             "id": "4413b219-26dc-51cc-8f16-20bac10a1052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeea28b-c11b-4fa0-a64c-637bc58171cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeea28b-c11b-4fa0-a64c-637bc58171cc.jpg?1",
             "name": "Griffin",
             "text": "",
             "colours": [
@@ -16395,7 +16395,7 @@
         },
         {
             "id": "0f3003cf-a33a-5216-8b38-469f62b51d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a61555-ddb9-4d55-b637-a219d772033d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a61555-ddb9-4d55-b637-a219d772033d.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16430,7 +16430,7 @@
         },
         {
             "id": "e2eaae22-fda0-5aa8-99a9-70df43af1258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34db5e62-4792-4207-b008-7d62bae683a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34db5e62-4792-4207-b008-7d62bae683a7.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -16467,7 +16467,7 @@
         },
         {
             "id": "58d92f0f-82b7-5d95-9f0c-2205689ffae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700cb99-1cee-455f-9a36-d7d9a79fed06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700cb99-1cee-455f-9a36-d7d9a79fed06.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -16502,7 +16502,7 @@
         },
         {
             "id": "097997f7-05b7-5199-9b99-54cca98c6d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae1be7-f2f6-4aef-8764-4af5ca963c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae1be7-f2f6-4aef-8764-4af5ca963c9e.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16537,7 +16537,7 @@
         },
         {
             "id": "a82aa998-5fbf-5125-ac16-b9d57f944875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8316a-ec6d-43de-a1c5-6ef3c5c53146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8316a-ec6d-43de-a1c5-6ef3c5c53146.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16572,7 +16572,7 @@
         },
         {
             "id": "196e0c7e-1e9d-5995-8b94-28ce63b5cdcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b58d5f-8a9f-4fd6-83d6-efe3a92e89b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b58d5f-8a9f-4fd6-83d6-efe3a92e89b2.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16607,7 +16607,7 @@
         },
         {
             "id": "ed4b719a-b918-59b4-ba00-ecf427f0643f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05000b-0ac3-4856-b25d-c87c19bda451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05000b-0ac3-4856-b25d-c87c19bda451.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -16642,7 +16642,7 @@
         },
         {
             "id": "74c9115b-2802-5edb-939e-fd3d82713790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662eefb-c454-44b9-8270-f2229e20024e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662eefb-c454-44b9-8270-f2229e20024e.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16677,7 +16677,7 @@
         },
         {
             "id": "77dd8f14-31ba-5a86-9c5e-c93a4b7ca682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb00e4-7eb0-4f7d-b2c3-8995959a6e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb00e4-7eb0-4f7d-b2c3-8995959a6e6a.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -16712,7 +16712,7 @@
         },
         {
             "id": "0c552176-fe45-5ad4-91e6-c810444fa78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acb4442-e7e5-482b-9ce8-f1af8069114e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acb4442-e7e5-482b-9ce8-f1af8069114e.jpg?1",
             "name": "Sheep",
             "text": "",
             "colours": [
@@ -16747,7 +16747,7 @@
         },
         {
             "id": "65bd5d1c-a5cf-5b9f-b5c6-671338f887e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ccb9-32b2-4562-a60f-843e82795984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ccb9-32b2-4562-a60f-843e82795984.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -16782,7 +16782,7 @@
         },
         {
             "id": "3df82ae6-2a99-52b1-a4da-a34ae0c882a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1fd1a-9c1e-4b01-974e-84f18d325cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1fd1a-9c1e-4b01-974e-84f18d325cfc.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/DMU.json
+++ b/Assets/Resources/Sets/DMU.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c55d896f-66d1-5e26-ac69-049d5d996a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83b1b87-01d5-4624-8a2b-4b771e13e59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83b1b87-01d5-4624-8a2b-4b771e13e59c.jpg?1",
             "name": "Karn, Living Legacy",
             "text": "+1: Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n\u22121: Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Tap an untapped artifact you control: This emblem deals 1 damage to any target.\"",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "77c57a1e-026b-5304-9f6d-c3ca7bfb368d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8127b5-3a65-411a-84bc-54e5c1be1477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8127b5-3a65-411a-84bc-54e5c1be1477.jpg?1",
             "name": "Anointed Peacekeeper",
             "text": "Vigilance\nAs Anointed Peacekeeper enters the battlefield, look at an opponent's hand, then choose any card name.\nSpells your opponents cast with the chosen name cost {2} more to cast.\nActivated abilities of sources with the chosen name cost {2} more to activate unless they're mana abilities.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "4615643e-64a9-5a0d-8da1-c0edfb4ae291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d00bab2-e95d-4296-a805-2a05e7640efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d00bab2-e95d-4296-a805-2a05e7640efb.jpg?1",
             "name": "Archangel of Wrath",
             "text": "Kicker {B} and/or {R} (You may pay an additional {B} and/or {R} as you cast this spell.)\nFlying, lifelink\nWhen Archangel of Wrath enters the battlefield, if it was kicked, it deals 2 damage to any target.\nWhen Archangel of Wrath enters the battlefield, if it was kicked twice, it deals 2 damage to any target.",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "70e7b490-3f26-58c3-878d-ae20f345121a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57746e72-ba9f-4717-a4a2-6c6a039080c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57746e72-ba9f-4717-a4a2-6c6a039080c3.jpg?1",
             "name": "Argivian Cavalier",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhen Argivian Cavalier enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "cd9efe31-9150-5501-b355-450324c03ea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbadc37-1b4f-4237-a3c0-772bafb18aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbadc37-1b4f-4237-a3c0-772bafb18aa0.jpg?1",
             "name": "Argivian Phalanx",
             "text": "This spell costs {1} less to cast for each creature you control.\nVigilance",
             "colours": [
@@ -184,7 +184,7 @@
         },
         {
             "id": "db0b6377-ae7d-5bf7-b50b-33c74ebd8b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d7293-657f-48ac-931b-fb6a44128e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d7293-657f-48ac-931b-fb6a44128e6d.jpg?1",
             "name": "Artillery Blast",
             "text": "Domain \u2014 Artillery Blast deals X damage to target tapped creature, where X is 1 plus the number of basic land types among lands you control.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "247341b0-f5b1-5a3a-bb90-ce3c4850edba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d77df-a899-406f-9d79-e3fa3abeaebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d77df-a899-406f-9d79-e3fa3abeaebc.jpg?1",
             "name": "Benalish Faithbonder",
             "text": "Vigilance\nEnlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "167c4307-d634-5b5a-ae22-097897f3a6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96089ea-20cf-496d-84a6-9b660c2ef672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96089ea-20cf-496d-84a6-9b660c2ef672.jpg?1",
             "name": "Benalish Sleeper",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen Benalish Sleeper enters the battlefield, if it was kicked, each player sacrifices a creature.",
             "colours": [
@@ -288,7 +288,7 @@
         },
         {
             "id": "7c90ec50-e572-514a-9efe-bfc4b58c4c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ed7e0-0e80-44d3-a7af-b4c321239df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ed7e0-0e80-44d3-a7af-b4c321239df8.jpg?1",
             "name": "Captain's Call",
             "text": "Create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "7377a85f-bd4d-56d3-b271-521f3f2cfcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51764fe-0d75-4cfa-a699-0d9e7ffb7843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51764fe-0d75-4cfa-a699-0d9e7ffb7843.jpg?1",
             "name": "Charismatic Vanguard",
             "text": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "d11fa83c-a01a-5005-84e6-40714e85d5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9806370b-51e3-4144-a847-6b367fb937ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9806370b-51e3-4144-a847-6b367fb937ef.jpg?1",
             "name": "Citizen's Arrest",
             "text": "When Citizen's Arrest enters the battlefield, exile target creature or planeswalker an opponent controls until Citizen's Arrest leaves the battlefield.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "7527d6d7-4adc-5818-a4b1-bc4f674bea93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6544a289-3b27-4980-8ed7-22f50ae92c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6544a289-3b27-4980-8ed7-22f50ae92c1a.jpg?1",
             "name": "Cleaving Skyrider",
             "text": "Flash\nKicker {2}{R} (You may pay an additional {2}{R} as you cast this spell.)\nFlying\nWhen Cleaving Skyrider enters the battlefield, if it was kicked, it deals X damage to any target, where X is the number of attacking creatures.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "a52e5e51-98ae-5d07-b5ff-629c8d249ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cb79c-163d-4b36-bd93-954eca8fe26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cb79c-163d-4b36-bd93-954eca8fe26e.jpg?1",
             "name": "Clockwork Drawbridge",
             "text": "Defender\n{2}{W}, {T}: Tap target creature.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "58ec0539-39fe-5002-814b-c38aa6e1d3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12da45-aff4-406d-83a3-39ecaff6ff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12da45-aff4-406d-83a3-39ecaff6ff56.jpg?1",
             "name": "Coalition Skyknight",
             "text": "Flying\nEnlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "6f933a66-8049-564c-adda-9d04d22b68b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845e5663-2959-44ae-b4c6-d6ea41f01d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845e5663-2959-44ae-b4c6-d6ea41f01d6e.jpg?1",
             "name": "Danitha, Benalia's Hope",
             "text": "First strike, vigilance, lifelink\nWhen Danitha, Benalia's Hope enters the battlefield, you may put an Aura or Equipment card from your hand or graveyard onto the battlefield attached to Danitha.",
             "colours": [
@@ -533,7 +533,7 @@
         },
         {
             "id": "77403f19-61f2-55db-87fd-a93eb5671d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfe404d-1a27-4627-9284-56188d92d5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfe404d-1a27-4627-9284-56188d92d5d5.jpg?1",
             "name": "Defiler of Faith",
             "text": "Vigilance\nAs an additional cost to cast white permanent spells, you may pay 2 life. Those spells cost {W} less to cast if you paid life this way. This effect reduces only the amount of white mana you pay.\nWhenever you cast a white permanent spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -570,7 +570,7 @@
         },
         {
             "id": "c2d03344-53f6-511f-8299-64e8c8c5f823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7862ef-2c8d-4d28-9e50-7cc41861f245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7862ef-2c8d-4d28-9e50-7cc41861f245.jpg?1",
             "name": "Destroy Evil",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with toughness 4 or greater.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "74d0d38f-8276-58de-95ea-a471a7b35a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d1d701-841c-4bf3-9122-b01842a22ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d1d701-841c-4bf3-9122-b01842a22ac6.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -636,7 +636,7 @@
         },
         {
             "id": "b0e7e1c5-d5ae-566e-a489-0750d039b677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da76ee-fec3-4b2e-915d-10cf8d518d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da76ee-fec3-4b2e-915d-10cf8d518d2c.jpg?1",
             "name": "Guardian of New Benalia",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhenever Guardian of New Benalia enlists a creature, scry 2.\nDiscard a card: Guardian of New Benalia gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "0d120cd9-e2b2-5f6f-a4ff-6672ded79d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aab611c-64e0-4b38-97b9-b29a1c6a79b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aab611c-64e0-4b38-97b9-b29a1c6a79b7.jpg?1",
             "name": "Heroic Charge",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nCreatures you control get +2/+1 until end of turn. If this spell was kicked, those creatures also gain trample until end of turn.",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "f04462f9-cb41-5aba-bbc4-d6a443e7f95b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dce5e7-c864-4239-bab7-af6a3adcb731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dce5e7-c864-4239-bab7-af6a3adcb731.jpg?1",
             "name": "Join Forces",
             "text": "Untap up to two target creatures. They each get +2/+2 until end of turn.",
             "colours": [
@@ -738,7 +738,7 @@
         },
         {
             "id": "96377cf8-c0d7-5d23-8233-7e6c5471cf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56cf82f-8bbb-49ae-ad93-291cbec9126e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56cf82f-8bbb-49ae-ad93-291cbec9126e.jpg?1",
             "name": "Juniper Order Rootweaver",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nWhen Juniper Order Rootweaver enters the battlefield, if it was kicked, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "e5e80711-3836-5081-8000-5199f08b2309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c7a54e-4df6-4745-8bae-aeefda934d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c7a54e-4df6-4745-8bae-aeefda934d82.jpg?1",
             "name": "Knight of Dawn's Light",
             "text": "First strike\nIf you would gain life, you gain that much life plus 1 instead.\n{1}{W}: Knight of Dawn's Light gets +1/+1 until end of turn.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "ed16b24f-2e06-55e1-85a8-06abae69424b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3ac3dd-35db-447f-8674-37b4680a1ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3ac3dd-35db-447f-8674-37b4680a1ef7.jpg?1",
             "name": "Leyline Binding",
             "text": "Flash\nDomain \u2014 This spell costs {1} less to cast for each basic land type among lands you control.\nWhen Leyline Binding enters the battlefield, exile target nonland permanent an opponent controls until Leyline Binding leaves the battlefield.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "73e33c97-d77d-5023-8265-4fa7f48df847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e08d288-2f09-4856-a9ed-cc8aa8d953d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e08d288-2f09-4856-a9ed-cc8aa8d953d7.jpg?1",
             "name": "Love Song of Night and Day",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You and target opponent each draw two cards.\nII \u2014 Create a 1/1 white Bird creature token with flying.\nIII \u2014 Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "e492e6bb-f0a7-5ff4-b9bf-d317108c003a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeec740-7ffc-4f57-b52c-92209da91d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeec740-7ffc-4f57-b52c-92209da91d69.jpg?1",
             "name": "Mesa Cavalier",
             "text": "Flying\nWhen Mesa Cavalier enters the battlefield, you gain 2 life.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "7524bc19-2a3b-5bd8-8e4a-4fe367787c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f22fcfa-a5f0-4fae-b578-cdfd7d46a4c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f22fcfa-a5f0-4fae-b578-cdfd7d46a4c8.jpg?1",
             "name": "Phyrexian Missionary",
             "text": "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nLifelink\nWhen Phyrexian Missionary enters the battlefield, if it was kicked, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "f8c05897-9041-5574-a02d-5cfb15da3625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322f90b6-6b49-458d-9d5b-b601bfdd0af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322f90b6-6b49-458d-9d5b-b601bfdd0af8.jpg?1",
             "name": "Prayer of Binding",
             "text": "Flash\nWhen Prayer of Binding enters the battlefield, exile up to one target nonland permanent an opponent controls until Prayer of Binding leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "c886886a-810c-5a5a-a8bd-7a6d4b152c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e11ad33-b9d7-43ef-840a-61955683b599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e11ad33-b9d7-43ef-840a-61955683b599.jpg?1",
             "name": "Resolute Reinforcements",
             "text": "Flash\nWhen Resolute Reinforcements enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "a44434e3-fab9-5ce5-a979-74b887aa3d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54413be-7d73-478d-a25a-8fe06f6491a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54413be-7d73-478d-a25a-8fe06f6491a5.jpg?1",
             "name": "Runic Shot",
             "text": "Kicker {U} (You may pay an additional {U} as you cast this spell.)\nDestroy target tapped creature. If this spell was kicked, scry 2.",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "d5ff4cfb-3d38-5261-abd1-42ac1530e157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409189da-53c9-4daf-b6b2-d155fc14f91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409189da-53c9-4daf-b6b2-d155fc14f91a.jpg?1",
             "name": "Samite Herbalist",
             "text": "Whenever Samite Herbalist becomes tapped, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "902d10c4-03fa-59b9-ad5d-46ce3898e3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce295f1e-fb31-4275-a5d3-8c6f29afff40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce295f1e-fb31-4275-a5d3-8c6f29afff40.jpg?1",
             "name": "Serra Paragon",
             "text": "Flying\nOnce during each of your turns, you may play a land from your graveyard or cast a permanent spell with mana value 3 or less from your graveyard. If you do, it gains \"When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life.\"",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "56700267-e56f-54f5-9558-31ffd2c75ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39996722-e7f2-41e4-aa1e-2b6778d7b535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39996722-e7f2-41e4-aa1e-2b6778d7b535.jpg?1",
             "name": "Shalai's Acolyte",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nFlying\nIf Shalai's Acolyte was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "a674349e-fe46-57f8-be5e-a60c66864337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346defa-ee4a-404e-8154-0e33ebe9102c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346defa-ee4a-404e-8154-0e33ebe9102c.jpg?1",
             "name": "Stall for Time",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nTap up to two target creatures. If this spell was kicked, put a stun counter on each of those creatures. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nDraw a card.",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "c68e07dc-166f-5e70-9823-f040a0626e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851e842e-a497-4c36-90ee-8d64f806c378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851e842e-a497-4c36-90ee-8d64f806c378.jpg?1",
             "name": "Take Up the Shield",
             "text": "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "1252c2e5-5728-5057-b5e7-2299260b8492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b3088f-7b49-45e9-b447-129a597ceb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b3088f-7b49-45e9-b447-129a597ceb75.jpg?1",
             "name": "Temporary Lockdown",
             "text": "When Temporary Lockdown enters the battlefield, exile each nonland permanent with mana value 2 or less until Temporary Lockdown leaves the battlefield.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "d8031971-fd92-50bc-809c-c21ac9397daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a544d7-ead7-42fd-a35a-c1b672771d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a544d7-ead7-42fd-a35a-c1b672771d5b.jpg?1",
             "name": "Urza Assembles the Titans",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Scry 4, then you may reveal the top card of your library. If a planeswalker card is revealed this way, put it into your hand.\nII \u2014 You may put a planeswalker card with mana value 6 or less from your hand onto the battlefield.\nIII \u2014 You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "a2d1a644-479c-5974-8b63-9bf88c489d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b1a4ee-437f-4a08-b176-8342d526143f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b1a4ee-437f-4a08-b176-8342d526143f.jpg?1",
             "name": "Valiant Veteran",
             "text": "Other Soldiers you control get +1/+1.\n{3}{W}{W}, Exile Valiant Veteran from your graveyard: Put a +1/+1 counter on each Soldier you control.",
             "colours": [
@@ -1327,7 +1327,7 @@
         },
         {
             "id": "4aeb1490-7fe3-5b2c-ab0c-6ffd8816d42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5800f3d-b2e0-4c74-94bf-f29b27f82130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5800f3d-b2e0-4c74-94bf-f29b27f82130.jpg?1",
             "name": "Wingmantle Chaplain",
             "text": "Defender\nWhen Wingmantle Chaplain enters the battlefield, create a 1/1 white Bird creature token with flying for each creature with defender you control.\nWhenever another creature with defender enters the battlefield under your control, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "d4a2c823-c95b-5bf1-b30c-958b73244f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fca4c4f-a77b-483e-9da4-574ba2e3d179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fca4c4f-a77b-483e-9da4-574ba2e3d179.jpg?1",
             "name": "Academy Loremaster",
             "text": "At the beginning of each player's draw step, that player may draw an additional card. If they do, spells they cast this turn cost {2} more to cast.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "8ff06a3c-b956-5f31-8df6-6ec20c57d72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2028115-f0de-4e8b-99bc-7369352e1e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2028115-f0de-4e8b-99bc-7369352e1e07.jpg?1",
             "name": "Academy Wall",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "5029812a-03c4-5e9d-a171-b89ba78207e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60afeb75-2c1e-4634-8c83-88b1dddb77c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60afeb75-2c1e-4634-8c83-88b1dddb77c2.jpg?1",
             "name": "Aether Channeler",
             "text": "When Aether Channeler enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 white Bird creature token with flying.\n\u2022 Return another target nonland permanent to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "cd16d4c5-ee04-5e30-8818-cf9e82cf34a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1",
             "name": "Battlewing Mystic",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nFlying\nWhen Battlewing Mystic enters the battlefield, if it was kicked, discard your hand, then draw two cards.",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "ea0bf2ff-e4f0-56ab-8658-a9ca13671148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44738c-706f-40b2-a09d-b21cd0889049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44738c-706f-40b2-a09d-b21cd0889049.jpg?1",
             "name": "Combat Research",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, draw a card.\"\nAs long as enchanted creature is legendary, it gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "e4edb9eb-0487-5400-bc22-06210caf0b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e3882-1f97-48eb-b9e3-2f9683ff5897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e3882-1f97-48eb-b9e3-2f9683ff5897.jpg?1",
             "name": "Coral Colony",
             "text": "Defender\n{1}{U}, {T}: Target player mills X cards, where X is the number of creatures you control with defender. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "47ab9225-7054-5d17-8b37-3477d7350991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881cc4a3-252b-4155-a34f-63d4b4f44442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881cc4a3-252b-4155-a34f-63d4b4f44442.jpg?1",
             "name": "Defiler of Dreams",
             "text": "Flying\nAs an additional cost to cast blue permanent spells, you may pay 2 life. Those spells cost {U} less to cast if you paid life this way. This effect reduces only the amount of blue mana you pay.\nWhenever you cast a blue permanent spell, draw a card.",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "cde032cf-96a9-5ea9-94f4-8dc30ae3926a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55606da-de3e-4375-925b-cc16b03b6365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55606da-de3e-4375-925b-cc16b03b6365.jpg?1",
             "name": "Djinn of the Fountain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, choose one \u2014\n\u2022 Djinn of the Fountain gets +1/+1 until end of turn.\n\u2022 Exile Djinn of the Fountain. Return it to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Scry 1.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "4b2fa8c4-fd42-50a1-80f3-f848a8105dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6129b0d3-b50a-4a4b-9111-39f8fc6718dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6129b0d3-b50a-4a4b-9111-39f8fc6718dd.jpg?1",
             "name": "Ertai's Scorn",
             "text": "This spell costs {U} less to cast if an opponent cast two or more spells this turn.\nCounter target spell.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "1d7228c1-9f20-50b5-8c93-5589d56e4fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad4441-e300-4267-bedb-4ae6a64f59cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad4441-e300-4267-bedb-4ae6a64f59cd.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "8059c4c4-825f-560f-88ec-2caab2ab3079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d841faa-9e0b-45ff-9dfd-f8a169d9af76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d841faa-9e0b-45ff-9dfd-f8a169d9af76.jpg?1",
             "name": "Founding the Third Path",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You may cast an instant or sorcery spell with mana value 1 or 2 from your hand without paying its mana cost.\nII \u2014 Target player mills four cards.\nIII \u2014 Exile target instant or sorcery card from your graveyard. Copy it. You may cast the copy.",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "a2d504b1-e8cb-5bb8-a6d8-fdb868fa599a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40141353-c0d6-4529-b26a-34dfccbcf231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40141353-c0d6-4529-b26a-34dfccbcf231.jpg?1",
             "name": "Frostfist Strider",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Frostfist Strider enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "1f8955a0-3406-5d6c-a7ee-bbaf446efc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35095a68-b7c0-4805-b0b6-6ca15a338692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35095a68-b7c0-4805-b0b6-6ca15a338692.jpg?1",
             "name": "Haughty Djinn",
             "text": "Flying\nHaughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "8aae24ec-32e1-542d-97be-d027c0e26b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14b07ea-18e4-41fb-8136-759d5349e88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14b07ea-18e4-41fb-8136-759d5349e88a.jpg?1",
             "name": "Haunting Figment",
             "text": "Vigilance\nHaunting Figment can't be blocked as long as you've cast an instant or sorcery spell this turn.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "f4abebf3-6ef3-5e03-9f67-2af3287ed4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259c04f7-86f2-4584-97fb-8278dca9a213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259c04f7-86f2-4584-97fb-8278dca9a213.jpg?1",
             "name": "Impede Momentum",
             "text": "Tap target creature and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "64c40e9f-024c-5f55-ae43-4da7f2c42321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aec2b2c-0764-4869-814d-aad921122af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aec2b2c-0764-4869-814d-aad921122af9.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1912,7 +1912,7 @@
         },
         {
             "id": "7f2ff2ea-4328-5ff7-9d30-f79e82e024a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25ab334-1060-457e-b212-3d7a697c545e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25ab334-1060-457e-b212-3d7a697c545e.jpg?1",
             "name": "Joint Exploration",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nScry 2, then draw a card. If this spell was kicked, you may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -1945,7 +1945,7 @@
         },
         {
             "id": "df06e121-94e3-5107-8ee2-c3badb79e2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21203c8-a935-4ce0-a742-148587e32145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21203c8-a935-4ce0-a742-148587e32145.jpg?1",
             "name": "Micromancer",
             "text": "When Micromancer enters the battlefield, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "66766b66-2524-51ae-b397-91ed7c2b4a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016c6f7-7cb4-46c2-af73-3bd6d682ea5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016c6f7-7cb4-46c2-af73-3bd6d682ea5e.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "b0a93b6d-c2c3-5f67-baf7-ccf7c2667f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770eb6a-4f01-4677-a401-14c1b30692c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770eb6a-4f01-4677-a401-14c1b30692c9.jpg?1",
             "name": "The Phasing of Zhalfir",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI, II \u2014 Another target nonland permanent phases out. It can't phase in for as long as you control The Phasing of Zhalfir.\nIII \u2014 Destroy all creatures. For each creature destroyed this way, its controller creates a 2/2 black Phyrexian creature token.",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "98293818-1285-5ac7-a5a9-5488cca6bc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b983366-385f-41a3-aa46-20151e68d140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b983366-385f-41a3-aa46-20151e68d140.jpg?1",
             "name": "Phyrexian Espionage",
             "text": "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nDraw two cards. If this spell was kicked, each opponent discards a card.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "f656a571-0fab-58cb-a618-39a6ce62e8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171bfcb2-dd43-4d63-b2e2-6ca594c2ec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171bfcb2-dd43-4d63-b2e2-6ca594c2ec40.jpg?1",
             "name": "Pixie Illusionist",
             "text": "Kicker {3}{G} (You may pay an additional {3}{G} as you cast this spell.)\nFlying\nIf Pixie Illusionist was kicked, it enters the battlefield with two +1/+1 counters on it.\n{T}: Target land you control becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -2117,7 +2117,7 @@
         },
         {
             "id": "f401f2f5-d13e-5f38-a6b7-894877791632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6db604-8bbe-4719-88bd-f3cad8c4725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6db604-8bbe-4719-88bd-f3cad8c4725d.jpg?1",
             "name": "Protect the Negotiators",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nIf this spell was kicked, create a 1/1 white Soldier creature token.\nCounter target spell unless its controller pays {1} for each creature you control.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "fea0f6b4-f86a-5cef-9aff-92bdd8f4d3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96533-f28a-4465-893b-0c9394d5b8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96533-f28a-4465-893b-0c9394d5b8d7.jpg?1",
             "name": "Rona's Vortex",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nReturn target creature or planeswalker you don't control to its owner's hand. If this spell was kicked, put that permanent on the bottom of its owner's library instead.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "3a2e73fb-71b1-56ad-9d1d-169981db6c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d933bf1-14f0-4150-a0d2-6b845b9624cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d933bf1-14f0-4150-a0d2-6b845b9624cf.jpg?1",
             "name": "Shore Up",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "38f09b3d-55b5-51d7-81d2-4243810aeac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b650ab6-9c22-424f-99e5-8ef5235a18a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b650ab6-9c22-424f-99e5-8ef5235a18a3.jpg?1",
             "name": "Silver Scrutiny",
             "text": "You may cast Silver Scrutiny as though it had flash if X is 3 or less.\nDraw X cards.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "2758d906-f551-5c62-8069-fc7f9ced5914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0979f9-aae3-4fc7-beae-c8c6637ae596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0979f9-aae3-4fc7-beae-c8c6637ae596.jpg?1",
             "name": "Soaring Drake",
             "text": "Flying",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "2a8db1da-eeee-57a3-a7f7-ffa21d13499c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974c9e0c-07b2-4535-a3d0-bb827b651075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974c9e0c-07b2-4535-a3d0-bb827b651075.jpg?1",
             "name": "Sphinx of Clear Skies",
             "text": "Flying, ward {2}\nDomain \u2014 Whenever Sphinx of Clear Skies deals combat damage to a player, reveal the top X cards of your library, where X is the number of basic land types among lands you control. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard. (Piles can be empty.)",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "43b20c58-7366-595a-b846-24930b1f2406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4b9afe-aeb7-4c56-8a22-96e19a7a938c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4b9afe-aeb7-4c56-8a22-96e19a7a938c.jpg?1",
             "name": "Talas Lookout",
             "text": "Flying\nWhen Talas Lookout dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "3e77d8e8-db3b-5ae3-bd5f-0250b672e117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397fb84-8573-4b2c-be2c-f8fd820342f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397fb84-8573-4b2c-be2c-f8fd820342f0.jpg?1",
             "name": "Tidepool Turtle",
             "text": "{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "1e88c6c8-1e7f-5d5e-9d91-37f398d0fe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017a3c6b-9a1e-403a-9c20-2360090d39ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017a3c6b-9a1e-403a-9c20-2360090d39ee.jpg?1",
             "name": "Timely Interference",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nTarget creature gets -1/-0 until end of turn. If this spell was kicked, that creature blocks this turn if able.\nDraw a card.",
             "colours": [
@@ -2421,7 +2421,7 @@
         },
         {
             "id": "d25a1cfc-c7eb-5028-9951-89e945338164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd5f389-fea2-4aed-a218-eca162902775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd5f389-fea2-4aed-a218-eca162902775.jpg?1",
             "name": "Tolarian Geyser",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nReturn target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "10c88fdc-6c79-5a57-83a2-509a51c74fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01cba-43d4-46ad-b7a5-d7631b0e1347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01cba-43d4-46ad-b7a5-d7631b0e1347.jpg?1",
             "name": "Tolarian Terror",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -2488,7 +2488,7 @@
         },
         {
             "id": "84cc007a-da37-50e5-9c1d-eacb5febf7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2119bc-a377-4156-89d4-56e7b5b494a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2119bc-a377-4156-89d4-56e7b5b494a8.jpg?1",
             "name": "Vesuvan Duplimancy",
             "text": "Whenever you cast a spell that targets only a single artifact or creature you control, create a token that's a copy of that artifact or creature, except it's not legendary.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "49a63af4-8185-5b15-8707-35a68a874585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3cc789-cbb8-4dae-a749-af169832dd7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3cc789-cbb8-4dae-a749-af169832dd7b.jpg?1",
             "name": "Voda Sea Scavenger",
             "text": "Domain \u2014 When Voda Sea Scavenger enters the battlefield, look at the top X cards of your library, where X is the number of basic land types among lands you control. You may put one of those cards on top of your library. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "d6837816-e595-597e-bbf0-d0736de595fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec464dc-b1dd-4e45-b093-c3ad65a74050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec464dc-b1dd-4e45-b093-c3ad65a74050.jpg?1",
             "name": "Vodalian Hexcatcher",
             "text": "Flash\nOther Merfolk you control get +1/+1.\nSacrifice a Merfolk: Counter target noncreature spell unless its controller pays {1}.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "f8032bde-7daa-58d1-857d-8551543cebb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211a9db2-8b5f-419d-8032-ac2a571dbb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211a9db2-8b5f-419d-8032-ac2a571dbb53.jpg?1",
             "name": "Vodalian Mindsinger",
             "text": "Kicker {1}{R} and/or {1}{G}\nVodalian Mindsinger enters the battlefield with two +1/+1 counters on it for each time it was kicked.\nWhen Vodalian Mindsinger enters the battlefield, gain control of target creature with power less than Vodalian Mindsinger's power for as long as you control Vodalian Mindsinger.",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "df28712b-f18e-5147-a161-96ad530b0328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61871b-9295-4ea0-86ef-e7a11e23bda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61871b-9295-4ea0-86ef-e7a11e23bda8.jpg?1",
             "name": "Volshe Tideturner",
             "text": "{T}: Add {U}. Spend this mana only to cast an instant or sorcery spell or a kicked spell.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "6b112088-7ce6-5d94-ba48-864c4652686c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac809fca-664a-4e7d-a39f-2bc1dea0fbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac809fca-664a-4e7d-a39f-2bc1dea0fbd8.jpg?1",
             "name": "Aggressive Sabotage",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTarget player discards two cards. If this spell was kicked, it deals 3 damage to that player.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "4f8ec569-ad9c-544b-87e1-f0d209f80a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365333c4-59a0-4365-b242-a67b6224c1b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365333c4-59a0-4365-b242-a67b6224c1b8.jpg?1",
             "name": "Balduvian Atrocity",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nMenace\nWhen Balduvian Atrocity enters the battlefield, if it was kicked, return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2737,7 +2737,7 @@
         },
         {
             "id": "67160731-f865-519a-92c9-8bf8acb51972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc631b-49d1-4f1c-adac-5b07a2ccd06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc631b-49d1-4f1c-adac-5b07a2ccd06f.jpg?1",
             "name": "Battle-Rage Blessing",
             "text": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "6dee9d1a-7504-57fd-9654-fc2ecedb9b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6b4a2d-0bc0-4a54-9c78-712b48ad6be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6b4a2d-0bc0-4a54-9c78-712b48ad6be1.jpg?1",
             "name": "Battlefly Swarm",
             "text": "Flying\n{B}: Battlefly Swarm gains deathtouch until end of turn.",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "4dd6ad79-f460-50b7-bb3c-70830dd1c483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc2699-03e6-47d1-b976-1453fe9d27b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc2699-03e6-47d1-b976-1453fe9d27b7.jpg?1",
             "name": "Blight Pile",
             "text": "Defender\n{2}{B}, {T}: Each opponent loses X life, where X is the number of creatures with defender you control.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "6183cba4-c188-5829-85e6-1f36e1455fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106b5c96-d1bd-433d-955e-ace0b60d3bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106b5c96-d1bd-433d-955e-ace0b60d3bc3.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "0bf470a2-5d71-5df4-bd0a-d9331d1f791b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff97c69-6a6b-401c-b0a1-55fa81045d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff97c69-6a6b-401c-b0a1-55fa81045d19.jpg?1",
             "name": "Braids, Arisen Nightmare",
             "text": "At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.",
             "colours": [
@@ -2909,7 +2909,7 @@
         },
         {
             "id": "823adee3-3e64-55b7-a02f-5cf65e554765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aa8d4c-04e9-4f38-9786-2c9ad735dd72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aa8d4c-04e9-4f38-9786-2c9ad735dd72.jpg?1",
             "name": "Braids's Frightful Return",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You may sacrifice a creature. If you do, each opponent discards a card.\nII \u2014 Return target creature card from your graveyard to your hand.\nIII \u2014 Target opponent may sacrifice a nonland, nontoken permanent. If they don't, they lose 2 life and you draw a card.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "6ea3bd25-3601-58b8-99ac-ebe81e3db487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba537452-3dab-4ecd-b65f-9e311a130d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba537452-3dab-4ecd-b65f-9e311a130d31.jpg?1",
             "name": "Choking Miasma",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nIf this spell was kicked, put a +1/+1 counter on a creature you control.\nAll creatures get -2/-2 until end of turn.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "39faf307-25d2-5c54-a852-16f7cc0a0ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6e5eb3-25ab-4e9e-96e8-655e0ce74675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6e5eb3-25ab-4e9e-96e8-655e0ce74675.jpg?1",
             "name": "The Cruelty of Gix",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Target opponent reveals their hand. You choose a creature or planeswalker card from it. That player discards that card.\nII \u2014 Search your library for a card, put that card into your hand, then shuffle. You lose 3 life.\nIII \u2014 Put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "b3f598df-fe18-5b24-a3b9-b1e37469463b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed77513-94ab-44e2-b9a1-30ba927cd6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed77513-94ab-44e2-b9a1-30ba927cd6ee.jpg?1",
             "name": "Cult Conscript",
             "text": "Cult Conscript enters the battlefield tapped.\n{1}{B}: Return Cult Conscript from your graveyard to the battlefield. Activate only if a non-Skeleton creature died under your control this turn.",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "472fa0d9-aedb-5fd6-a3b9-89b784208904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753db072-5d6a-4f37-8f7d-255572ecd3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753db072-5d6a-4f37-8f7d-255572ecd3bd.jpg?1",
             "name": "Cut Down",
             "text": "Destroy target creature with total power and toughness 5 or less.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "3c8407c4-9fa9-5f14-b031-af68a85d45e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a4dd11-6166-4a54-95c0-728c623d0fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a4dd11-6166-4a54-95c0-728c623d0fbc.jpg?1",
             "name": "Defiler of Flesh",
             "text": "Menace\nAs an additional cost to cast black permanent spells, you may pay 2 life. Those spells cost {B} less to cast if you paid life this way. This effect reduces only the amount of black mana you pay.\nWhenever you cast a black permanent spell, target creature you control gets +1/+1 and gains menace until end of turn.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "a91edcde-c241-59a1-b726-d8e151e5eec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d243099-94b1-4571-96af-4c5a34241911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d243099-94b1-4571-96af-4c5a34241911.jpg?1",
             "name": "Drag to the Bottom",
             "text": "Domain \u2014 Each creature gets -X/-X until end of turn, where X is 1 plus the number of basic land types among lands you control.",
             "colours": [
@@ -3150,7 +3150,7 @@
         },
         {
             "id": "2c0461d7-b84e-5f69-876c-803c41683731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335f3146-743c-4a25-86b5-c45e9c66eb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335f3146-743c-4a25-86b5-c45e9c66eb15.jpg?1",
             "name": "Eerie Soultender",
             "text": "When Eerie Soultender enters the battlefield, mill three cards. (To mill a card, put the top card of your library into your graveyard.)\n{4}{B}, Exile Eerie Soultender from your graveyard: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "66665ece-84f7-51c5-834e-5c09bcb2eea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebeafbc2-0399-4335-8f63-76a3e085e8c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebeafbc2-0399-4335-8f63-76a3e085e8c6.jpg?1",
             "name": "Evolved Sleeper",
             "text": "{B}: Evolved Sleeper becomes a Human Cleric with base power and toughness 2/2.\n{1}{B}: If Evolved Sleeper is a Cleric, put a deathtouch counter on it and it becomes a Phyrexian Human Cleric with base power and toughness 3/3.\n{1}{B}{B}: If Evolved Sleeper is a Phyrexian, put a +1/+1 counter on it, then you draw a card and you lose 1 life.",
             "colours": [
@@ -3221,7 +3221,7 @@
         },
         {
             "id": "9a8d75dc-0f19-5771-8cf2-ea43d8727028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a51d08-f90e-4b72-8dce-fb2a6c72f181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a51d08-f90e-4b72-8dce-fb2a6c72f181.jpg?1",
             "name": "Extinguish the Light",
             "text": "Destroy target creature or planeswalker. If its mana value was 3 or less, you gain 3 life.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "7acf0f67-d1ac-573d-a0b4-b79db34e9ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0674b340-420d-4864-92fe-7b268fe0874c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0674b340-420d-4864-92fe-7b268fe0874c.jpg?1",
             "name": "Gibbering Barricade",
             "text": "Defender\n{2}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "715a05c4-7274-5eb1-879f-57786d1f1bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dfd2fe-e0e0-465c-b730-a30e6f5c271c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dfd2fe-e0e0-465c-b730-a30e6f5c271c.jpg?1",
             "name": "Knight of Dusk's Shadow",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nYour opponents can't gain life.\n{1}{B}: Knight of Dusk's Shadow gets +1/+1 until end of turn.",
             "colours": [
@@ -3323,7 +3323,7 @@
         },
         {
             "id": "039c2d6f-6647-5d1a-941a-5b838412c7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12c8c97-6491-452c-811d-943441a7ef9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12c8c97-6491-452c-811d-943441a7ef9f.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "2a623232-93c4-5a7d-bdf6-162bcfc37efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660d7983-b335-48b4-898d-f182effcf2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660d7983-b335-48b4-898d-f182effcf2de.jpg?1",
             "name": "Monstrous War-Leech",
             "text": "Kicker {U} (You may pay an additional {U} as you cast this spell.)\nAs Monstrous War-Leech enters the battlefield, if it was kicked, mill four cards. (To mill a card, put the top card of your library into your graveyard.)\nMonstrous War-Leech's power and toughness are each equal to the highest mana value among cards in your graveyard.",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "45244e11-d857-5241-9b94-ea585fdf28f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd574e7-705f-4a65-aad0-68ff6d63bf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd574e7-705f-4a65-aad0-68ff6d63bf0f.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "13d410bd-a829-547a-8205-147ba4c00607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65617a8f-4bd8-4edb-b5ec-e20b4482390b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65617a8f-4bd8-4edb-b5ec-e20b4482390b.jpg?1",
             "name": "Phyrexian Vivisector",
             "text": "Whenever a creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "1c44a1b3-c409-5088-a744-9a3c4525ef66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42167ef-7858-4c66-b1bc-41c3288a8ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42167ef-7858-4c66-b1bc-41c3288a8ee8.jpg?1",
             "name": "Phyrexian Warhorse",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nWhen Phyrexian Warhorse enters the battlefield, if it was kicked, create a 1/1 white Soldier creature token.\n{1}, Sacrifice another creature: Phyrexian Warhorse gets +2/+1 until end of turn.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "23dc7046-5c89-55d3-afc6-03091df8be22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d872c10-4126-4130-a74a-1331ed418ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d872c10-4126-4130-a74a-1331ed418ca8.jpg?1",
             "name": "Pilfer",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "e3cc8442-68cb-56e0-aaa7-59cae59d51a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e761fb2-ae4f-4d72-a142-f7e9bd681303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e761fb2-ae4f-4d72-a142-f7e9bd681303.jpg?1",
             "name": "The Raven Man",
             "text": "At the beginning of each end step, if a player discarded a card this turn, create a 1/1 black Bird creature token with flying and \"This creature can't block.\"\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "af541e77-516e-599e-9a00-75af7681da0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9231f0-7733-46d9-b9c6-c6c5b7fe65dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9231f0-7733-46d9-b9c6-c6c5b7fe65dd.jpg?1",
             "name": "Sengir Connoisseur",
             "text": "Flying\nWhenever one or more other creatures die, put a +1/+1 counter on Sengir Connoisseur. This ability triggers only once each turn.",
             "colours": [
@@ -3609,7 +3609,7 @@
         },
         {
             "id": "ab2e80cf-e6e6-5397-92e4-ae90aa039528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb078448-9e9f-4994-8aff-7e7c4fb62efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb078448-9e9f-4994-8aff-7e7c4fb62efc.jpg?1",
             "name": "Shadow Prophecy",
             "text": "Domain \u2014 Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to two of them into your hand and the rest into your graveyard. You lose 2 life.",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "9cd26ae5-037f-5c85-acf9-317f83f8ba2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg?1",
             "name": "Shadow-Rite Priest",
             "text": "Other Clerics you control get +1/+1.\n{3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "9408edd9-f629-5231-b827-1ea1211d1d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67be074-cdd4-41d9-ac89-0a0456c4e4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67be074-cdd4-41d9-ac89-0a0456c4e4b2.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "5e5775f0-c4bc-541b-8180-9a88cb0e7586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed719f25-1aab-4a1e-8c9f-dd574db5de0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed719f25-1aab-4a1e-8c9f-dd574db5de0c.jpg?1",
             "name": "Sheoldred's Restoration",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nReturn target creature card from your graveyard to the battlefield. If this spell was kicked, you gain life equal to that card's mana value. Otherwise, you lose that much life.\nExile Sheoldred's Restoration.",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "f4c630f4-088d-5802-b6dd-d54d64fd14ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5045027d-0ff4-484c-b4cb-e0b61885d428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5045027d-0ff4-484c-b4cb-e0b61885d428.jpg?1",
             "name": "Splatter Goblin",
             "text": "When Splatter Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "f3a6c49f-8da2-57c8-882b-06873fb5fed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb64b0a7-3e9a-490f-bf02-c62fc8cf750d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb64b0a7-3e9a-490f-bf02-c62fc8cf750d.jpg?1",
             "name": "Stronghold Arena",
             "text": "Kicker {G} and/or {W} (You may pay an additional {G} and/or {W} as you cast this spell.)\nWhen Stronghold Arena enters the battlefield, you gain 3 life for each time it was kicked.\nWhenever one or more creatures you control deal combat damage to a player, you may reveal the top card of your library and put it into your hand. If you do, you lose life equal to its mana value.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "4ab5978e-80f5-5089-9cd3-ecfe22d36fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0368e91c-31ee-4b81-a361-30a4555b1a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0368e91c-31ee-4b81-a361-30a4555b1a42.jpg?1",
             "name": "Tattered Apparition",
             "text": "Flying\n{1}{B}: Tattered Apparition gets +1/+1 until end of turn.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "a4c71098-3f44-5e6e-8778-1d1797d42136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f435329e-6de7-4b05-ba70-cb63d121116e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f435329e-6de7-4b05-ba70-cb63d121116e.jpg?1",
             "name": "Toxic Abomination",
             "text": "When Toxic Abomination enters the battlefield, you lose 2 life.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "0492e300-fd38-5428-8b93-494982c64fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31274707-3e16-4f46-8450-6927d936064b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31274707-3e16-4f46-8450-6927d936064b.jpg?1",
             "name": "Tribute to Urborg",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets an additional -1/-1 until end of turn for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "f6df6e5f-82e4-54de-8bd5-fa94fb4c24c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb8dab0-ecce-4321-b382-c58b296c2fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb8dab0-ecce-4321-b382-c58b296c2fd3.jpg?1",
             "name": "Urborg Repossession",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nReturn target creature card from your graveyard to your hand. You gain 2 life. If this spell was kicked, return another target permanent card from your graveyard to your hand.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "4e414276-e1bf-5489-8eb4-b87ba30ddc33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a166abef-f068-47e9-8a65-43ebf4b015bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a166abef-f068-47e9-8a65-43ebf4b015bd.jpg?1",
             "name": "Writhing Necromass",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nDeathtouch",
             "colours": [
@@ -3995,7 +3995,7 @@
         },
         {
             "id": "b3818efd-0067-5935-8f21-ce28e2c85551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35bab2f-8464-4968-8c50-8807638d687b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35bab2f-8464-4968-8c50-8807638d687b.jpg?1",
             "name": "Balduvian Berserker",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhen Balduvian Berserker dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "95569009-36c5-5baa-a2fb-7640b3105328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfb44f1-e366-437a-bde3-59bfdb362864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfb44f1-e366-437a-bde3-59bfdb362864.jpg?1",
             "name": "Chaotic Transformation",
             "text": "Exile up to one target artifact, up to one target creature, up to one target enchantment, up to one target planeswalker, and/or up to one target land. For each permanent exiled this way, its controller reveals cards from the top of their library until they reveal a card that shares a card type with it, puts that card onto the battlefield, then shuffles.",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "b83919af-1c51-5881-8831-8a4c185377fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c422f-2a1b-47c0-9358-42b85cdbb84e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c422f-2a1b-47c0-9358-42b85cdbb84e.jpg?1",
             "name": "Coalition Warbrute",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nTrample",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "25fe0c1d-03e2-51d1-babe-5b7b3aa86b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e76e0cc-caff-4b15-b550-39e2324c8c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e76e0cc-caff-4b15-b550-39e2324c8c95.jpg?1",
             "name": "Defiler of Instinct",
             "text": "First strike\nAs an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.\nWhenever you cast a red permanent spell, Defiler of Instinct deals 1 damage to any target.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "743bec4c-81a5-57f4-a5c2-bcf2b46400e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13d40b9-319b-4630-a5cd-228ff2f24367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13d40b9-319b-4630-a5cd-228ff2f24367.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice Dragon Whelp at the beginning of the next end step.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "5ce2110b-fa4a-5826-9a84-bec4cc9c77fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c52c7d4-a350-4518-8c9a-72cf7b14603d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c52c7d4-a350-4518-8c9a-72cf7b14603d.jpg?1",
             "name": "The Elder Dragon War",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 The Elder Dragon War deals 2 damage to each creature and each opponent.\nII \u2014 Discard any number of cards, then draw that many cards.\nIII \u2014 Create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "dec6252f-610c-58de-8ab1-6b14a1445ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2d72f-f1cf-45a7-adf7-969f531721ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2d72f-f1cf-45a7-adf7-969f531721ce.jpg?1",
             "name": "Electrostatic Infantry",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on Electrostatic Infantry.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "382ac095-1215-5938-b50d-ea2ceae6d3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58096e5-3cd4-4edd-b71a-3bdb47ab2536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58096e5-3cd4-4edd-b71a-3bdb47ab2536.jpg?1",
             "name": "Fires of Victory",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nIf this spell was kicked, draw a card. Fires of Victory deals damage to target creature or planeswalker equal to the number of cards in your hand.",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "3f73b267-126f-55de-9c1a-64d4349d5937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57c3674-9a31-4418-b306-e6b0a2514d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57c3674-9a31-4418-b306-e6b0a2514d8f.jpg?1",
             "name": "Flowstone Infusion",
             "text": "Target creature gets +2/-2 until end of turn.",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "0e69a5c7-a746-57e5-a19f-7ce684d793fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e40916-3502-448a-a509-f6a6ff3cd73d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e40916-3502-448a-a509-f6a6ff3cd73d.jpg?1",
             "name": "Flowstone Kavu",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{R}: Flowstone Kavu gets +1/-1 until end of turn.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "705711cf-c814-54ea-973e-447a16f04f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d05659-bfff-4b73-80f7-a9f31a7ef957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d05659-bfff-4b73-80f7-a9f31a7ef957.jpg?1",
             "name": "Furious Bellow",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "a79d53f2-d94c-5807-b23b-2a3dc8a1b917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1845806-7585-40d5-9d3a-f13667e6a9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1845806-7585-40d5-9d3a-f13667e6a9d2.jpg?1",
             "name": "Ghitu Amplifier",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nWhen Ghitu Amplifier enters the battlefield, if it was kicked, return target creature an opponent controls to its owner's hand.\nWhenever you cast an instant or sorcery spell, Ghitu Amplifier gets +2/+0 until end of turn.",
             "colours": [
@@ -4406,7 +4406,7 @@
         },
         {
             "id": "e489e427-87e8-5cde-94a8-47b0404a04a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f1f06-dde5-41f2-923c-67d1d4d13fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f1f06-dde5-41f2-923c-67d1d4d13fab.jpg?1",
             "name": "Goblin Picker",
             "text": "{R}, {T}, Discard a card: Draw a card.",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "82aa51bb-72f3-50da-a15e-4a7d542dbe17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d858e9e-452b-4281-9379-641ef6ebef39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d858e9e-452b-4281-9379-641ef6ebef39.jpg?1",
             "name": "Hammerhand",
             "text": "Enchant creature\nWhen Hammerhand enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "2bac4684-abd4-5847-9f83-b3b20798e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f2cf2-5908-4f49-9c5c-6c9e22a65a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f2cf2-5908-4f49-9c5c-6c9e22a65a4d.jpg?1",
             "name": "Hurler Cyclops",
             "text": "{1}, Sacrifice another creature: Hurler Cyclops deals 1 damage to any target.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "c92e2986-927f-5009-a210-a2a4c64747b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff252e80-c155-467b-8df3-9bddc5cc45c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff252e80-c155-467b-8df3-9bddc5cc45c3.jpg?1",
             "name": "Hurloon Battle Hymn",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nHurloon Battle Hymn deals 4 damage to target creature or planeswalker. If this spell was kicked, you gain 4 life.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "013b4307-b052-5a9b-8b5e-68021c24284a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33284f-bdb1-4982-8636-8f2e12896053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33284f-bdb1-4982-8636-8f2e12896053.jpg?1",
             "name": "In Thrall to the Pit",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If this spell was kicked, sacrifice that creature at the beginning of the next end step.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "b797ce1d-974d-59cc-b407-91081e35a039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9f54f0-4368-4d28-aa21-3f1e7be1b23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9f54f0-4368-4d28-aa21-3f1e7be1b23a.jpg?1",
             "name": "Jaya, Fiery Negotiator",
             "text": "+1: Create a 1/1 red Monk creature token with prowess.\n\u22121: Exile the top two cards of your library. Choose one of them. You may play that card this turn.\n\u22122: Choose target creature an opponent controls. Whenever you attack this turn, Jaya, Fiery Negotiator deals damage equal to the number of attacking creatures to that creature.\n\u22128: You get an emblem with \"Whenever you cast a red instant or sorcery spell, copy it twice. You may choose new targets for the copies.\"",
             "colours": [
@@ -4612,7 +4612,7 @@
         },
         {
             "id": "b8572a21-2e62-5bb5-bd24-bd100badb246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b78eaab-819c-4f06-b3b1-a25c17ab2235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b78eaab-819c-4f06-b3b1-a25c17ab2235.jpg?1",
             "name": "Jaya's Firenado",
             "text": "Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4644,7 +4644,7 @@
         },
         {
             "id": "5eb122b6-018f-5cad-bc79-91a5e935a805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2a3c-63a7-4e33-9ae3-21fb6b3d8326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2a3c-63a7-4e33-9ae3-21fb6b3d8326.jpg?1",
             "name": "Keldon Flamesage",
             "text": "Enlist\nWhenever Keldon Flamesage attacks, look at the top X cards of your library, where X is Keldon Flamesage's power. You may exile an instant or sorcery card with mana value X or less from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -4681,7 +4681,7 @@
         },
         {
             "id": "a7f0d552-ced6-5a66-b541-4bf9e5f76e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af4031e-b14e-4568-b047-b3d470d9b18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af4031e-b14e-4568-b047-b3d470d9b18e.jpg?1",
             "name": "Keldon Strike Team",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nWhen Keldon Strike Team enters the battlefield, if it was kicked, create two 1/1 white Soldier creature tokens.\nAs long as Keldon Strike Team entered the battlefield this turn, creatures you control have haste.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "b83e1618-3bf5-570b-96d4-8403eeb6ee6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d541125-bfb8-4f88-8bf3-ad7b6af7ad1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d541125-bfb8-4f88-8bf3-ad7b6af7ad1d.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "6b64141a-a78f-5144-840b-a2c8f1cf1b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48aa964f-99b5-4b6b-b158-42f39514c910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48aa964f-99b5-4b6b-b158-42f39514c910.jpg?1",
             "name": "Meria's Outrider",
             "text": "Reach\nDomain \u2014 When Meria's Outrider enters the battlefield, it deals damage to each opponent equal to the number of basic land types among lands you control.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "5b324bd9-d0e5-5a04-8a1d-afbbec99e5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240957e5-ab0a-443f-92de-ae999b08c44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240957e5-ab0a-443f-92de-ae999b08c44f.jpg?1",
             "name": "Molten Monstrosity",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nTrample",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "ea192a33-d92d-5225-9ac7-2d8755ebdd2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bdc912-61da-428d-b0d7-3a38676a402a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bdc912-61da-428d-b0d7-3a38676a402a.jpg?1",
             "name": "Phoenix Chick",
             "text": "Flying, haste\nPhoenix Chick can't block.\nWhenever you attack with three or more creatures, you may pay {R}{R}. If you do, return Phoenix Chick from your graveyard to the battlefield tapped and attacking with a +1/+1 counter on it.",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "6c902234-0629-5a47-8038-8269fb722ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a90c4-4a79-49e7-9fab-076b35d28adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a90c4-4a79-49e7-9fab-076b35d28adb.jpg?1",
             "name": "Radha's Firebrand",
             "text": "Whenever Radha's Firebrand attacks, target creature defending player controls with power less than Radha's Firebrand's power can't block this turn.\nDomain \u2014 {5}{R}: Radha's Firebrand gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.",
             "colours": [
@@ -4891,7 +4891,7 @@
         },
         {
             "id": "a68fb89c-70d0-544f-84ae-08ec55676baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffee9dbe-af90-4e19-844d-4df1180f24c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffee9dbe-af90-4e19-844d-4df1180f24c4.jpg?1",
             "name": "Rundvelt Hordemaster",
             "text": "Other Goblins you control get +1/+1.\nWhenever Rundvelt Hordemaster or another Goblin you control dies, exile the top card of your library. If it's a Goblin creature card, you may cast that card until the end of your next turn.",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "9530479f-e32e-5d11-af58-16d3e794f654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5d274c-3a03-4f0d-97e8-7eef6508105d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5d274c-3a03-4f0d-97e8-7eef6508105d.jpg?1",
             "name": "Shivan Devastator",
             "text": "Flying, haste\nShivan Devastator enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "1b21275d-fc01-554e-ae39-37d5c3e58368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747881c7-3788-4dd6-b78d-b2a5ded20e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747881c7-3788-4dd6-b78d-b2a5ded20e14.jpg?1",
             "name": "Smash to Dust",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature with defender.\n\u2022 Smash to Dust deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "da97b9ef-95ee-52b3-a164-852cd6042c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602f5370-d096-4765-b612-16bcec3aafa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602f5370-d096-4765-b612-16bcec3aafa7.jpg?1",
             "name": "Sprouting Goblin",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nWhen Sprouting Goblin enters the battlefield, if it was kicked, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.\n{R}, {T}, Sacrifice a land: Draw a card.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "9ca7f193-71d3-5e5e-a802-5026846344e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd907ed-9c68-4bd6-af92-6244909fdf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd907ed-9c68-4bd6-af92-6244909fdf8b.jpg?1",
             "name": "Squee, Dubious Monarch",
             "text": "Haste\nWhenever Squee, Dubious Monarch attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\nYou may cast Squee, Dubious Monarch from your graveyard by paying {3}{R} and exiling four other cards from your graveyard rather than paying its mana cost.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "f5e410c0-ce36-52d1-a578-26c63f194176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d690340-75f1-4733-bde5-2d60fd02f060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d690340-75f1-4733-bde5-2d60fd02f060.jpg?1",
             "name": "Temporal Firestorm",
             "text": "Kicker {1}{W} and/or {1}{U} (You may pay an additional {1}{W} and/or {1}{U} as you cast this spell.)\nChoose up to X creatures and/or planeswalkers you control, where X is the number of times this spell was kicked. Those permanents phase out.\nTemporal Firestorm deals 5 damage to each creature and each planeswalker.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "b03f4111-007b-5c13-af38-05feef7d0289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5dc88-9573-4eaa-bd37-eb0dee4add03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5dc88-9573-4eaa-bd37-eb0dee4add03.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "3aae8e92-b516-56ad-b3db-bd263f845f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc531409-26cb-4c58-ba69-f39dd8aee3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc531409-26cb-4c58-ba69-f39dd8aee3d1.jpg?1",
             "name": "Twinferno",
             "text": "Choose one \u2014\n\u2022 When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\n\u2022 Target creature you control gains double strike until end of turn.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "e63b0310-92ea-53df-8394-92c0b398be6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f08749e-05e0-4fb4-a4ae-35e7187584ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f08749e-05e0-4fb4-a4ae-35e7187584ab.jpg?1",
             "name": "Viashino Branchrider",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nHaste\nIf Viashino Branchrider was kicked, it enters the battlefield with two +1/+1 counters on it.\n{2}{R}: Viashino Branchrider gets +2/+0 until end of turn.",
             "colours": [
@@ -5209,7 +5209,7 @@
         },
         {
             "id": "ceaee314-aa0a-5659-aeff-69b8a5484a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83d571b-ad91-43f5-8498-115cede4867d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83d571b-ad91-43f5-8498-115cede4867d.jpg?1",
             "name": "Warhost's Frenzy",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nCreatures you control get +2/+0 until end of turn. If this spell was kicked, whenever a creature you control dies this turn, draw a card.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "2caafa8e-412b-5f72-8550-db8da65cf6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25175622-7b68-4916-adf2-3bf2d82e8356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25175622-7b68-4916-adf2-3bf2d82e8356.jpg?1",
             "name": "Yavimaya Steelcrusher",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\n{1}, Sacrifice Yavimaya Steelcrusher: Destroy target artifact.",
             "colours": [
@@ -5277,7 +5277,7 @@
         },
         {
             "id": "15f41f31-e87d-50e1-b7a2-657e77d84f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd9e99a-ae8c-4323-aa86-b19288c877d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd9e99a-ae8c-4323-aa86-b19288c877d4.jpg?1",
             "name": "Yotia Declares War",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Create a 0/2 colorless Thopter artifact creature token with flying named Ornithopter.\nII \u2014 Tap any number of untapped artifacts you control. When you do, Yotia Declares War deals that much damage to target creature or planeswalker.\nIII \u2014 Up to one target artifact you control becomes a creature with base power and toughness 4/4 until end of turn.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "5947e8b0-7528-5bb3-8338-8ab93b657d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c62c55-7b04-4987-9047-1322c842bb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c62c55-7b04-4987-9047-1322c842bb59.jpg?1",
             "name": "Barkweave Crusher",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "4ea28ed4-6096-5661-8b4c-edfb744906df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eacd3de-b803-4322-8d88-d533761aa748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eacd3de-b803-4322-8d88-d533761aa748.jpg?1",
             "name": "Bite Down",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "fbafdd06-9f0f-5071-9a33-f2f6a9a72c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d31d878-9114-4205-b7a9-bb13ce6aedd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d31d878-9114-4205-b7a9-bb13ce6aedd2.jpg?1",
             "name": "Bog Badger",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen Bog Badger enters the battlefield, if it was kicked, creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "4d1f2203-341d-50ec-b03f-ce512af86f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ced8d87-ac22-41b0-a632-298159cbb316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ced8d87-ac22-41b0-a632-298159cbb316.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -5445,7 +5445,7 @@
         },
         {
             "id": "1513c706-2ba5-5cae-a434-e9b67221011f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9142f35-75f4-44c7-b03c-79c4a2d43c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9142f35-75f4-44c7-b03c-79c4a2d43c88.jpg?1",
             "name": "Colossal Growth",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTarget creature gets +3/+3 until end of turn. If this spell was kicked, instead that creature gets +4/+4 and gains trample and haste until end of turn.",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "5bbae107-15f5-5edd-a910-c670cfaf44c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dee3d1-0496-40ea-b208-7362a932f531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dee3d1-0496-40ea-b208-7362a932f531.jpg?1",
             "name": "Deathbloom Gardener",
             "text": "Deathtouch\n{T}: Add one mana of any color.",
             "colours": [
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "9b1c5b2c-e5f4-543b-9ee1-1b1bae6e7ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0896860c-d028-4193-89a5-97e05c12a1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0896860c-d028-4193-89a5-97e05c12a1e7.jpg?1",
             "name": "Defiler of Vigor",
             "text": "Trample\nAs an additional cost to cast green permanent spells, you may pay 2 life. Those spells cost {G} less to cast if you paid life this way. This effect reduces only the amount of green mana you pay.\nWhenever you cast a green permanent spell, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -5550,7 +5550,7 @@
         },
         {
             "id": "0862f24d-c020-5bfd-b33f-4617733b4d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2dc99b-083d-473e-b352-e8264353e85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2dc99b-083d-473e-b352-e8264353e85b.jpg?1",
             "name": "Elfhame Wurm",
             "text": "Vigilance, trample",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "ec731574-0217-5fab-993f-4552dcf9e86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dc4122-4f7a-4d9f-8427-de36e3e8a913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dc4122-4f7a-4d9f-8427-de36e3e8a913.jpg?1",
             "name": "Elvish Hydromancer",
             "text": "Kicker {3}{U} (You may pay an additional {3}{U} as you cast this spell.)\nWhen Elvish Hydromancer enters the battlefield, if it was kicked, create a token that's a copy of target creature you control.",
             "colours": [
@@ -5620,7 +5620,7 @@
         },
         {
             "id": "098eee21-80ef-5fa3-a33b-5f1e4c9d660f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8382b7c7-762e-43f6-b285-e0cebe749fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8382b7c7-762e-43f6-b285-e0cebe749fab.jpg?1",
             "name": "Floriferous Vinewall",
             "text": "Defender\nWhen Floriferous Vinewall enters the battlefield, look at the top six cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "f6da7e2f-0a32-544d-9f39-b533a5375a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c46e9c-ae7c-466c-bb11-4f4d01ea7a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c46e9c-ae7c-466c-bb11-4f4d01ea7a63.jpg?1",
             "name": "Gaea's Might",
             "text": "Domain \u2014 Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -5687,7 +5687,7 @@
         },
         {
             "id": "5a1ab7c0-49b5-5047-9af6-4177832d89af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0244a1f-e696-4223-9c14-22c2ca3cb738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0244a1f-e696-4223-9c14-22c2ca3cb738.jpg?1",
             "name": "Herd Migration",
             "text": "Domain \u2014 Create a 3/3 green Beast creature token for each basic land type among lands you control.\n{1}{G}, Discard Herd Migration: Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "cc69ffcb-2a5c-5cec-a768-9eacda3a9f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd5a635-bcf5-4a05-b00b-bf40322823fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd5a635-bcf5-4a05-b00b-bf40322823fe.jpg?1",
             "name": "Hexbane Tortoise",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nEnlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "a920b7d5-ab85-5844-a743-464942470011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg?1",
             "name": "Leaf-Crowned Visionary",
             "text": "Other Elves you control get +1/+1.\nWhenever you cast an Elf spell, you may pay {G}. If you do, draw a card.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "8611289d-4af4-5fb2-b32d-095209b71b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15cc59c7-6478-4f84-898a-7e0fed10f004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15cc59c7-6478-4f84-898a-7e0fed10f004.jpg?1",
             "name": "Linebreaker Baloth",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nLinebreaker Baloth can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "c3d87915-2115-5e38-a283-02c26b951e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f90e4d-f60f-4175-830f-c2ce04c5a945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f90e4d-f60f-4175-830f-c2ce04c5a945.jpg?1",
             "name": "Llanowar Greenwidow",
             "text": "Reach, trample\nDomain \u2014 {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\" This ability costs {1} less to activate for each basic land type among lands you control.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "21fa8ab2-4ac5-5771-b06b-d66854f21911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5611db-82dd-464d-8b03-70d7619dcefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5611db-82dd-464d-8b03-70d7619dcefe.jpg?1",
             "name": "Llanowar Loamspeaker",
             "text": "{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "c57a8e87-707a-54ff-a01d-5e127cac7ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d714d8-0e9b-4761-a0ef-3429b4e2f5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d714d8-0e9b-4761-a0ef-3429b4e2f5b7.jpg?1",
             "name": "Llanowar Stalker",
             "text": "Whenever another creature enters the battlefield under your control, Llanowar Stalker gets +1/+0 until end of turn.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "42955759-64d0-5ab0-8ac5-e6b3783226f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d939d4bc-b7e8-4ee8-b904-68f0bff0fde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d939d4bc-b7e8-4ee8-b904-68f0bff0fde1.jpg?1",
             "name": "Magnigoth Sentry",
             "text": "Reach",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "578dce8e-6929-5d72-91e6-242ed50d6bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e528d36-cea6-4013-83d5-ba837d570713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e528d36-cea6-4013-83d5-ba837d570713.jpg?1",
             "name": "Mossbeard Ancient",
             "text": "Trample\nWhen Mossbeard Ancient enters the battlefield, you gain 5 life.",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "27a4cb61-bead-52c0-988d-ffe9c2b1e44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef6cb5f-0ab3-4652-9b39-c2cbf6d693d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef6cb5f-0ab3-4652-9b39-c2cbf6d693d5.jpg?1",
             "name": "Nishoba Brawler",
             "text": "Trample\nDomain \u2014 Nishoba Brawler's power is equal to the number of basic land types among lands you control.",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "6bb27875-aace-54cf-b5e0-293c6a68e0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a501319-59a7-45d4-a6ca-666276095f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a501319-59a7-45d4-a6ca-666276095f87.jpg?1",
             "name": "Quirion Beastcaller",
             "text": "Whenever you cast a creature spell, put a +1/+1 counter on Quirion Beastcaller.\nWhen Quirion Beastcaller dies, distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on Quirion Beastcaller.",
             "colours": [
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "91e2fc9b-4818-5360-ade7-4026c9962bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccd67d4-1a22-4378-804d-6e2c93dc4938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccd67d4-1a22-4378-804d-6e2c93dc4938.jpg?1",
             "name": "Scout the Wilderness",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nSearch your library for a basic land card, put it onto the battlefield tapped, then shuffle. If this spell was kicked, create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -6111,7 +6111,7 @@
         },
         {
             "id": "eb457a4c-d1ef-5549-89a3-1fe4bc313db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b987664f-0b74-4c0a-b306-14767a55559a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b987664f-0b74-4c0a-b306-14767a55559a.jpg?1",
             "name": "Silverback Elder",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "aa0f861f-f4c0-58b8-be63-76d9c266b987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622f96fc-179a-4ff6-95a5-de721492f7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622f96fc-179a-4ff6-95a5-de721492f7eb.jpg?1",
             "name": "Slimefoot's Survey",
             "text": "Domain \u2014 Search your library for up to two land cards that each have a basic land type, put them onto the battlefield tapped, then shuffle. Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "25de3bca-4d98-5b42-8935-0f6e9107d187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51c3b5-db70-4976-986d-ed3fc8584d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51c3b5-db70-4976-986d-ed3fc8584d1a.jpg?1",
             "name": "Snarespinner",
             "text": "Reach\nWhenever Snarespinner blocks a creature with flying, Snarespinner gets +2/+0 until end of turn.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "307dcaf1-8106-543d-b6ca-ba15f1462267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8418c504-24fe-470f-8102-dcad68ba1520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8418c504-24fe-470f-8102-dcad68ba1520.jpg?1",
             "name": "Strength of the Coalition",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nTarget creature you control gets +2/+2 until end of turn. If this spell was kicked, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "148b963d-f2c0-51bf-8341-f5ecf4cbb0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6f015-2ad6-4b8e-8590-c2c2d01b6d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6f015-2ad6-4b8e-8590-c2c2d01b6d98.jpg?1",
             "name": "Sunbathing Rootwalla",
             "text": "Domain \u2014 {3}{G}: Until end of turn, Sunbathing Rootwalla gets +1/+1 for each basic land type among lands you control. Activate only once each turn.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "3f49d710-c10d-5d79-a011-89f1248ab474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a39b26-8c83-40ea-b492-036251366d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a39b26-8c83-40ea-b492-036251366d73.jpg?1",
             "name": "Tail Swipe",
             "text": "Choose target creature you control and target creature you don't control. If you cast this spell during your main phase, the creature you control gets +1/+1 until end of turn. Then those creatures fight each other. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6313,7 +6313,7 @@
         },
         {
             "id": "178e241f-3f0f-5645-b821-31aab8cfd945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629aa907-9533-4681-9bf2-9e56450a4cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629aa907-9533-4681-9bf2-9e56450a4cc2.jpg?1",
             "name": "Tear Asunder",
             "text": "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nExile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "e382d955-cfe0-5c9c-9b14-61cef061cdd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853ddf31-826b-411e-9b6d-75d53cdd1b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853ddf31-826b-411e-9b6d-75d53cdd1b84.jpg?1",
             "name": "Territorial Maro",
             "text": "Domain \u2014 Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control.",
             "colours": [
@@ -6380,7 +6380,7 @@
         },
         {
             "id": "4eeec8fc-85ea-5c45-8d42-4ee84c662831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99545c3e-0710-48d3-8558-046bd66f225c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99545c3e-0710-48d3-8558-046bd66f225c.jpg?1",
             "name": "Threats Undetected",
             "text": "Search your library for up to four creature cards with different powers and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest into your hand.",
             "colours": [
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "cf6e1271-b100-5d0c-9746-a81bb13ac9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f97236-1497-4811-8189-0545707451da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f97236-1497-4811-8189-0545707451da.jpg?1",
             "name": "Urborg Lhurgoyf",
             "text": "Kicker {U} and/or {B} (You may pay an additional {U} and/or {B} as you cast this spell.)\nAs Urborg Lhurgoyf enters the battlefield, mill three cards for each time it was kicked.\nUrborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -6452,7 +6452,7 @@
         },
         {
             "id": "4608b676-8f04-5e68-934b-69d37ac97c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545cddde-8018-4fdd-874d-b5193b73b414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545cddde-8018-4fdd-874d-b5193b73b414.jpg?1",
             "name": "Vineshaper Prodigy",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nWhen Vineshaper Prodigy enters the battlefield, if it was kicked, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "ba98fa51-4dcd-5817-9366-c9ccf449076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a54461-1f75-4304-b6d7-635171419456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a54461-1f75-4304-b6d7-635171419456.jpg?1",
             "name": "The Weatherseed Treaty",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nII \u2014 Create a 1/1 green Saproling creature token.\nIII \u2014 Domain \u2014 Target creature you control gets +X/+X and gains trample until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -6522,7 +6522,7 @@
         },
         {
             "id": "a1a94d8a-499f-5cef-95ea-52eacc228adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a9112a-6a1d-4d89-9866-189b55cd326d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a9112a-6a1d-4d89-9866-189b55cd326d.jpg?1",
             "name": "The World Spell",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI, II \u2014 Look at the top seven cards of your library. You may reveal a non-Saga permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nIII \u2014 Put up to two non-Saga permanent cards from your hand onto the battlefield.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "74c004e7-ec16-5918-80f9-1837b21e1bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1af9be-7f5e-48e9-a6e7-9261e199812e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1af9be-7f5e-48e9-a6e7-9261e199812e.jpg?1",
             "name": "Yavimaya Iconoclast",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTrample\nWhen Yavimaya Iconoclast enters the battlefield, if it was kicked, it gets +1/+1 and gains haste until end of turn.",
             "colours": [
@@ -6591,7 +6591,7 @@
         },
         {
             "id": "357e3ea6-541c-55af-b177-5d36d2b92422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fdb424-4d2c-437e-b2a2-8bc56c028338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fdb424-4d2c-437e-b2a2-8bc56c028338.jpg?1",
             "name": "Yavimaya Sojourner",
             "text": "Domain \u2014 This spell costs {1} less to cast for each basic land type among lands you control.",
             "colours": [
@@ -6625,7 +6625,7 @@
         },
         {
             "id": "d001f781-541d-5a02-a4d6-374e6c2b5bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7641f4d9-4614-41c8-87f5-4845bd78e9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7641f4d9-4614-41c8-87f5-4845bd78e9b3.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "c3381b00-0f11-505a-b30a-6377a5e58ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f8bf98-8911-4c86-978a-427377700544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f8bf98-8911-4c86-978a-427377700544.jpg?1",
             "name": "Aron, Benalia's Ruin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{W}{B}, {T}, Sacrifice another creature: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "b17be53d-16fb-5f03-9dd9-e5288b10aa82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f3a0ba-b917-488b-adbf-60a0d3c58a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f3a0ba-b917-488b-adbf-60a0d3c58a56.jpg?1",
             "name": "Astor, Bearer of Blades",
             "text": "When Astor, Bearer of Blades enters the battlefield, look at the top seven cards of your library. You may reveal an Equipment or Vehicle card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquipment you control have equip {1}.\nVehicles you control have crew 1.",
             "colours": [
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "96bf94ee-ffd3-5289-8649-e6fb52edb8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f643d78-d8d8-4645-9357-a68ebd0d3517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f643d78-d8d8-4645-9357-a68ebd0d3517.jpg?1",
             "name": "Baird, Argivian Recruiter",
             "text": "At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "db814f87-ed1c-5a7b-8090-c0cd6e88b87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ba62e-bb3a-49ad-8b1b-e787e413e5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ba62e-bb3a-49ad-8b1b-e787e413e5d4.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "b6c1fa7d-57e3-5074-917b-2f8f80632232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25855f-abfc-482d-a36b-088b023a7df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25855f-abfc-482d-a36b-088b023a7df6.jpg?1",
             "name": "Bortuk Bonerattle",
             "text": "Domain \u2014 When Bortuk Bonerattle enters the battlefield, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.",
             "colours": [
@@ -6878,7 +6878,7 @@
         },
         {
             "id": "a89e8ae0-fd52-5b42-b900-25bcec075ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f0ffe-cf51-4c30-8cd5-9e3c7e92c019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f0ffe-cf51-4c30-8cd5-9e3c7e92c019.jpg?1",
             "name": "Elas il-Kor, Sadistic Pilgrim",
             "text": "Deathtouch\nWhenever another creature enters the battlefield under your control, you gain 1 life.\nWhenever another creature you control dies, each opponent loses 1 life.",
             "colours": [
@@ -6921,7 +6921,7 @@
         },
         {
             "id": "a9a13511-d259-5839-9aaf-ed4a85bb4ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e780e-fbc5-4dc0-b5c7-efcb8645c7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e780e-fbc5-4dc0-b5c7-efcb8645c7c6.jpg?1",
             "name": "Ertai Resurrected",
             "text": "Flash\nWhen Ertai Resurrected enters the battlefield, choose up to one \u2014\n\u2022 Counter target spell, activated ability, or triggered ability. Its controller draws a card.\n\u2022 Destroy another target creature or planeswalker. Its controller draws a card.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "11f9d48a-01ef-5e66-aa2c-d45df44a8efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c5f08-08e7-458f-8838-ff321dc5d9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c5f08-08e7-458f-8838-ff321dc5d9f2.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.",
             "colours": [
@@ -7006,7 +7006,7 @@
         },
         {
             "id": "cc556787-ae3e-5cf6-8481-2d01f8b52d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94c15b7-6c8f-45a6-8734-975e3e3b790c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94c15b7-6c8f-45a6-8734-975e3e3b790c.jpg?1",
             "name": "Ivy, Gleeful Spellthief",
             "text": "Flying\nWhenever a player casts a spell that targets only a single creature other than Ivy, Gleeful Spellthief, you may copy that spell. The copy targets Ivy. (A copy of an Aura spell becomes a token.)",
             "colours": [
@@ -7048,7 +7048,7 @@
         },
         {
             "id": "e5a7a432-d7e7-54ef-84fb-847fd65ac0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd911900-1f5f-4420-96b8-1e4fe67e59f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd911900-1f5f-4420-96b8-1e4fe67e59f6.jpg?1",
             "name": "Jhoira, Ageless Innovator",
             "text": "{T}: Put two ingenuity counters on Jhoira, Ageless Innovator, then you may put an artifact card with mana value X or less from your hand onto the battlefield, where X is the number of ingenuity counters on Jhoira.",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "04fae974-50e6-55e2-b05b-a0302b35fc8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b1aa1e-b4e3-4346-8937-76b312501c70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b1aa1e-b4e3-4346-8937-76b312501c70.jpg?1",
             "name": "Jodah, the Unifier",
             "text": "Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.\nWhenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7138,7 +7138,7 @@
         },
         {
             "id": "43754f09-8bbf-5cd9-abe8-648ef6e85408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10eca3b1-f35a-4984-bfc0-818e619b1ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10eca3b1-f35a-4984-bfc0-818e619b1ece.jpg?1",
             "name": "King Darien XLVIII",
             "text": "Other creatures you control get +1/+1.\n{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token.\nSacrifice King Darien: Creature tokens you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -7180,7 +7180,7 @@
         },
         {
             "id": "bc675ae4-5c65-5527-8082-3fd61e096383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6bb0c2-1e3c-48cd-8f10-49f047e0514c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6bb0c2-1e3c-48cd-8f10-49f047e0514c.jpg?1",
             "name": "Lagomos, Hand of Hatred",
             "text": "At the beginning of combat on your turn, create a 2/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n{T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "45d837ea-3930-5c62-a339-53eb44ead006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eedd979-783d-4721-92de-965b77c20576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eedd979-783d-4721-92de-965b77c20576.jpg?1",
             "name": "Meria, Scholar of Antiquity",
             "text": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -7264,7 +7264,7 @@
         },
         {
             "id": "3f53c07f-19d2-5f4a-b62c-9b74d0463b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da59e8f-cbe5-4c14-a5a9-28d56048dc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da59e8f-cbe5-4c14-a5a9-28d56048dc23.jpg?1",
             "name": "Nael, Avizoa Aeronaut",
             "text": "Flying\nDomain \u2014 Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "9317ce97-3cba-565b-890d-34b60d218ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017ee70-761b-434e-bc44-705cf14336fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017ee70-761b-434e-bc44-705cf14336fa.jpg?1",
             "name": "Najal, the Storm Runner",
             "text": "You may cast sorcery spells as though they had flash.\nWhenever Najal, the Storm Runner attacks, you may pay {2}. If you do, when you cast your next instant or sorcery spell this turn, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -7348,7 +7348,7 @@
         },
         {
             "id": "3db7306a-656c-5c24-b56b-871adceddafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcd556d-351f-4faf-9456-0e47def69a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcd556d-351f-4faf-9456-0e47def69a69.jpg?1",
             "name": "Nemata, Primeval Warden",
             "text": "Reach\nIf a creature an opponent controls would die, exile it instead. When you do, create a 1/1 green Saproling creature token.\n{G}, Sacrifice a Saproling: Nemata, Primeval Warden gets +2/+2 until end of turn.\n{1}{B}, Sacrifice two Saprolings: Draw a card.",
             "colours": [
@@ -7389,7 +7389,7 @@
         },
         {
             "id": "14bf36aa-d92a-5f3e-9d60-016d4c839aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44b4e8b-7675-4c6a-a16a-92f8b6a0259f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44b4e8b-7675-4c6a-a16a-92f8b6a0259f.jpg?1",
             "name": "Queen Allenal of Ruadach",
             "text": "Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.\nIf one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "b4d62ee8-d114-5aed-9a66-e22c4926a76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec235e-7ce0-4947-b221-a555b2c865bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec235e-7ce0-4947-b221-a555b2c865bd.jpg?1",
             "name": "Radha, Coalition Warlord",
             "text": "Domain \u2014 Whenever Radha, Coalition Warlord becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "30d829e2-f260-51f7-a9b2-e33ae6b58b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0cba4c-d9f0-421f-acf4-ab1adcd59c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0cba4c-d9f0-421f-acf4-ab1adcd59c80.jpg?1",
             "name": "Raff, Weatherlight Stalwart",
             "text": "Whenever you cast an instant or sorcery spell, you may tap two untapped creatures you control. If you do, draw a card.\n{3}{W}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -7515,7 +7515,7 @@
         },
         {
             "id": "1b926df3-31db-5f00-9d0d-ebee0900e237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9315812d-03e8-4eb4-a693-e7adf281f7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9315812d-03e8-4eb4-a693-e7adf281f7fb.jpg?1",
             "name": "Ratadrabik of Urborg",
             "text": "Vigilance, ward {2}\nOther Zombies you control have vigilance.\nWhenever another legendary creature you control dies, create a token that's a copy of that creature, except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "e354a03e-f1e1-593a-a306-f1cff6b21e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac148784-b7b6-4aae-bffb-a4cf09f56971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac148784-b7b6-4aae-bffb-a4cf09f56971.jpg?1",
             "name": "Rith, Liberated Primeval",
             "text": "Flying, ward {2}\nOther Dragons you control have ward {2}.\nAt the beginning of your end step, if a creature or planeswalker an opponent controlled was dealt excess damage this turn, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "401078ca-59dd-5b6c-8440-51aa8c4ced2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47573a-601e-4738-acef-16118289f939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47573a-601e-4738-acef-16118289f939.jpg?1",
             "name": "Rivaz of the Claw",
             "text": "Menace\n{T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon creature spells.\nOnce during each of your turns, you may cast a Dragon creature spell from your graveyard.\nWhenever you cast a Dragon creature spell from your graveyard, it gains \"When this creature dies, exile it.\"",
             "colours": [
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "7229b499-1e54-56d3-b2e5-258055a9ed04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8331ab-adc9-45c6-9728-66afc72d901c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8331ab-adc9-45c6-9728-66afc72d901c.jpg?1",
             "name": "Rona, Sheoldred's Faithful",
             "text": "Whenever you cast an instant or sorcery spell, each opponent loses 1 life.\nYou may cast Rona, Sheoldred's Faithful from your graveyard by discarding two cards in addition to paying its other costs.",
             "colours": [
@@ -7684,7 +7684,7 @@
         },
         {
             "id": "54f495b1-417b-55bd-bb9e-ec820a6e1e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa49711-473d-4774-99b8-2bfbabc6b735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa49711-473d-4774-99b8-2bfbabc6b735.jpg?1",
             "name": "Rulik Mons, Warren Chief",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Rulik Mons, Warren Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -7725,7 +7725,7 @@
         },
         {
             "id": "0190263b-2d6d-5c93-890e-838e0d750288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261c443-8d27-4d85-8027-2a0271b85e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261c443-8d27-4d85-8027-2a0271b85e07.jpg?1",
             "name": "Shanna, Purifying Blade",
             "text": "Lifelink\nAt the beginning of your end step, you may pay {X}. If you do, draw X cards. X can't be greater than the amount of life you gained this turn.",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "2b2a0002-21e2-5094-b373-b31ecd715423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027347d-5fd3-47cd-83d4-8c834e00794c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027347d-5fd3-47cd-83d4-8c834e00794c.jpg?1",
             "name": "Sol'Kanar the Tainted",
             "text": "At the beginning of your end step, choose one that hasn't been chosen \u2014\n\u2022 Draw a card.\n\u2022 Each opponent loses 2 life and you gain 2 life.\n\u2022 Sol'kanar the Tainted deals 3 damage to up to one other target creature or planeswalker.\n\u2022 Exile Sol'kanar, then return it to the battlefield under an opponent's control.",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "67b05656-d6c5-595c-b4a1-534d10b9e431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e775a2e6-e701-4cb8-8c0b-718d3508f6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e775a2e6-e701-4cb8-8c0b-718d3508f6b6.jpg?1",
             "name": "Soul of Windgrace",
             "text": "Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "0534b8f1-fad8-5127-ba60-ba42825efaed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07177a8e-5ded-4084-a22f-2d8fe933de7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07177a8e-5ded-4084-a22f-2d8fe933de7a.jpg?1",
             "name": "Stenn, Paranoid Partisan",
             "text": "As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -7899,7 +7899,7 @@
         },
         {
             "id": "9b4a39bf-f899-5d44-9e01-8b6f9da1a0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d446cb9-519a-4889-b057-029db9400021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d446cb9-519a-4889-b057-029db9400021.jpg?1",
             "name": "Tatyova, Steward of Tides",
             "text": "Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "7cda1524-869e-50e3-86cf-2050e0daa532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c873c5b-61f6-49b9-8993-2d5e9823de62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c873c5b-61f6-49b9-8993-2d5e9823de62.jpg?1",
             "name": "Tori D'Avenant, Fury Rider",
             "text": "Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn. Untap each other white attacking creature you control.",
             "colours": [
@@ -7983,7 +7983,7 @@
         },
         {
             "id": "67d7c177-7515-5e93-b7ed-aa3e479b6203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c839d302-bf85-4a30-a49a-dbbd48695b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c839d302-bf85-4a30-a49a-dbbd48695b5c.jpg?1",
             "name": "Tura Kenner\u00fcd, Skyknight",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -8025,7 +8025,7 @@
         },
         {
             "id": "44dfa3f7-ec31-5304-af3c-c89201fc642d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3fc36c-682b-4352-a66f-eddd2baf0bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3fc36c-682b-4352-a66f-eddd2baf0bf6.jpg?1",
             "name": "Uurg, Spawn of Turg",
             "text": "Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\n{B}{G}, Sacrifice a land: You gain 2 life.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "5205b325-008a-5748-b721-3b966c4892ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807c7812-c108-45a7-a5b2-08cc693bc500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807c7812-c108-45a7-a5b2-08cc693bc500.jpg?1",
             "name": "Vohar, Vodalian Desecrator",
             "text": "{T}: Draw a card, then discard a card. If you discarded an instant or sorcery card this way, each opponent loses 1 life and you gain 1 life.\n{2}, Sacrifice Vohar, Vodalian Desecrator: You may cast target instant or sorcery card from your graveyard this turn. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "5fe183a4-2615-5d15-8958-54bd9243e232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c903e3-d622-415e-9144-a5b2f3f7b9ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c903e3-d622-415e-9144-a5b2f3f7b9ed.jpg?1",
             "name": "Zar Ojanen, Scion of Efrava",
             "text": "Domain \u2014 Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.",
             "colours": [
@@ -8152,7 +8152,7 @@
         },
         {
             "id": "b14f85a1-7f9e-5161-ad2f-5b62875bb23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d987435-2403-4e0f-b19d-693da923ba50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d987435-2403-4e0f-b19d-693da923ba50.jpg?1",
             "name": "Zur, Eternal Schemer",
             "text": "Flying\nEnchantment creatures you control have deathtouch, lifelink, and hexproof.\n{1}{W}: Target non-Aura enchantment you control becomes a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "402dc85b-aa54-51c6-bc9b-f477467bbfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3d7ece-0f57-4213-a0ab-a9d7c1536ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3d7ece-0f57-4213-a0ab-a9d7c1536ebb.jpg?1",
             "name": "Automatic Librarian",
             "text": "When Automatic Librarian enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [],
@@ -8227,7 +8227,7 @@
         },
         {
             "id": "0c67c061-a6f4-5384-9f60-cbe14eb16ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8611a53-e54e-4625-8e28-03511f1550e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8611a53-e54e-4625-8e28-03511f1550e8.jpg?1",
             "name": "Golden Argosy",
             "text": "Whenever Golden Argosy attacks, exile each creature that crewed it this turn. Return them to the battlefield tapped under their owner's control at the beginning of the next end step.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8259,7 +8259,7 @@
         },
         {
             "id": "e20ea3c4-0cc8-563f-91c4-e574ab870e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7c0d2d-7107-4599-8d49-c7c57d21e467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7c0d2d-7107-4599-8d49-c7c57d21e467.jpg?1",
             "name": "Hero's Heirloom",
             "text": "Equipped creature gets +2/+1.\nAs long as equipped creature is legendary, it has trample and haste.\nEquip {2}",
             "colours": [],
@@ -8289,7 +8289,7 @@
         },
         {
             "id": "bee500cc-58c9-54b1-b66f-38186df5e52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699d8655-d250-4ab6-92c5-376979bbabc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699d8655-d250-4ab6-92c5-376979bbabc7.jpg?1",
             "name": "Inscribed Tablet",
             "text": "{1}, {T}, Sacrifice Inscribed Tablet: Reveal the top five cards of your library. Put a land card from among them into your hand and the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, draw a card.",
             "colours": [],
@@ -8317,7 +8317,7 @@
         },
         {
             "id": "7ed4711e-7dc4-5abe-8923-d7f47ed8e2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da1e-4cc6-40a1-bd83-cc0dd761b1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da1e-4cc6-40a1-bd83-cc0dd761b1cc.jpg?1",
             "name": "Jodah's Codex",
             "text": "Domain \u2014 {5}, {T}: Draw a card. This ability costs {1} less to activate for each basic land type among lands you control.",
             "colours": [],
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "09d4a04d-4fe3-5aa9-9406-8e9374a00c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a8676-0a93-4ca3-a786-63f138027e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a8676-0a93-4ca3-a786-63f138027e8a.jpg?1",
             "name": "Karn's Sylex",
             "text": "Karn's Sylex enters the battlefield tapped.\nPlayers can't pay life to cast spells or to activate abilities that aren't mana abilities.\n{X}, {T}, Exile Karn's Sylex: Destroy each nonland permanent with mana value X or less. Activate only as a sorcery.",
             "colours": [],
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "6ea672cd-d56c-5d8d-bbdc-81f95cf69a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eb2032-50af-4fd6-bdc7-7cae2211956c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eb2032-50af-4fd6-bdc7-7cae2211956c.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to any target.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "055a1144-d6c0-5ad6-9b32-f08e59a5919e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2809e-c441-416c-90ff-6fb1e246dff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2809e-c441-416c-90ff-6fb1e246dff3.jpg?1",
             "name": "Relic of Legends",
             "text": "{T}: Add one mana of any color.\nTap an untapped legendary creature you control: Add one mana of any color.",
             "colours": [],
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "85683f98-7406-5fc7-a2b4-114c8f0689d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc22ecb-5d87-464e-8c7d-5d40a52e1e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc22ecb-5d87-464e-8c7d-5d40a52e1e4f.jpg?1",
             "name": "Salvaged Manaworker",
             "text": "{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -8462,7 +8462,7 @@
         },
         {
             "id": "79706b1f-4d87-52eb-975e-d98f4707676e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e57e1d7-da1d-4a2b-867f-85b8331b7bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e57e1d7-da1d-4a2b-867f-85b8331b7bbc.jpg?1",
             "name": "Shield-Wall Sentinel",
             "text": "Defender\nWhen Shield-Wall Sentinel enters the battlefield, you may search your library for a creature card with defender, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -8493,7 +8493,7 @@
         },
         {
             "id": "c861ffa3-56f7-53be-8786-7db69d2e2258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f566387-3342-4325-ba4c-eee7626072ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f566387-3342-4325-ba4c-eee7626072ac.jpg?1",
             "name": "Timeless Lotus",
             "text": "Timeless Lotus enters the battlefield tapped.\n{T}: Add {W}{U}{B}{R}{G}.",
             "colours": [],
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "5304745c-94d7-5d10-b3da-18140312fc49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef37244-deb9-464e-ab8c-4308369ae09b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef37244-deb9-464e-ab8c-4308369ae09b.jpg?1",
             "name": "Vanquisher's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8559,7 +8559,7 @@
         },
         {
             "id": "9d579c63-119d-5feb-9de4-980a8e461191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602d163c-d341-4b3b-9d3c-5d3419e9b10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602d163c-d341-4b3b-9d3c-5d3419e9b10b.jpg?1",
             "name": "Walking Bulwark",
             "text": "Defender\n{2}: Until end of turn, target creature with defender gains haste, can attack as though it didn't have defender, and assigns combat damage equal to its toughness rather than its power. Activate only as a sorcery.",
             "colours": [],
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "00605bc0-86d5-58bb-8007-1ef050832405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976fd9d9-a9b5-40b6-ad38-4b3b263e1ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976fd9d9-a9b5-40b6-ad38-4b3b263e1ebc.jpg?1",
             "name": "Weatherlight Compleated",
             "text": "Flying\nAs long as Weatherlight Compleated has four or more phyresis counters on it, it's a Phyrexian creature in addition to its other types.\nWhenever a creature you control dies, put a phyresis counter on Weatherlight Compleated. Then draw a card if it has seven or more phyresis counters on it. If it doesn't, scry 1.",
             "colours": [],
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "5b7b5bce-4f88-5071-bfe6-3e6030a659b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae1037-6f70-41a9-b75e-98fa9a2152c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae1037-6f70-41a9-b75e-98fa9a2152c8.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -8655,7 +8655,7 @@
         },
         {
             "id": "3d1a049a-6c28-5b81-acf7-871e39ca23d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99264beb-2149-4cd4-9880-f0dc5c570c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99264beb-2149-4cd4-9880-f0dc5c570c1b.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -8688,7 +8688,7 @@
         },
         {
             "id": "478dc640-76cd-5300-a016-f680285a1712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb570f4-de68-4d8c-a9f3-8a3294163aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb570f4-de68-4d8c-a9f3-8a3294163aa8.jpg?1",
             "name": "Contaminated Aquifer",
             "text": "({T}: Add {U} or {B}.)\nContaminated Aquifer enters the battlefield tapped.",
             "colours": [],
@@ -8722,7 +8722,7 @@
         },
         {
             "id": "775a3bd2-2e24-57d6-984c-90c9bcc98172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg?1",
             "name": "Crystal Grotto",
             "text": "When Crystal Grotto enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "d4c937e9-1219-5ee0-9135-3bb439649553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e62fe57-4fa4-4bfd-8e31-9f6db774d7e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e62fe57-4fa4-4bfd-8e31-9f6db774d7e2.jpg?1",
             "name": "Geothermal Bog",
             "text": "({T}: Add {B} or {R}.)\nGeothermal Bog enters the battlefield tapped.",
             "colours": [],
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "f23783ec-de54-5622-b167-7dcac60b76f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f5e958-56e6-4666-a534-24deba6f652d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f5e958-56e6-4666-a534-24deba6f652d.jpg?1",
             "name": "Haunted Mire",
             "text": "({T}: Add {B} or {G}.)\nHaunted Mire enters the battlefield tapped.",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "db466008-fd93-59e6-8099-8abede9d8911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50ec22c-decb-419f-ae52-78ea1706eb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50ec22c-decb-419f-ae52-78ea1706eb11.jpg?1",
             "name": "Idyllic Beachfront",
             "text": "({T}: Add {W} or {U}.)\nIdyllic Beachfront enters the battlefield tapped.",
             "colours": [],
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "2e22f220-e190-59ed-976c-fbe7e762032e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89b2c79-e3d3-4ef9-bfc8-f9c090975011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89b2c79-e3d3-4ef9-bfc8-f9c090975011.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {G}. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -8885,7 +8885,7 @@
         },
         {
             "id": "4f545707-f91d-529c-b6e1-a5304aac0297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aff4af-5128-432f-a8c8-65b6909d31ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aff4af-5128-432f-a8c8-65b6909d31ac.jpg?1",
             "name": "Molten Tributary",
             "text": "({T}: Add {U} or {R}.)\nMolten Tributary enters the battlefield tapped.",
             "colours": [],
@@ -8919,7 +8919,7 @@
         },
         {
             "id": "89d2b50a-5e60-5fee-976c-b61c00d859d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cfcf67-f83c-43af-9e2d-5513fcdde835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cfcf67-f83c-43af-9e2d-5513fcdde835.jpg?1",
             "name": "Plaza of Heroes",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a legendary spell.\n{T}: Add one mana of any color among legendary permanents you control.\n{3}, {T}, Exile Plaza of Heroes: Target legendary creature gains hexproof and indestructible until end of turn.",
             "colours": [],
@@ -8949,7 +8949,7 @@
         },
         {
             "id": "0a46cf8f-c403-5a1e-8901-12769faddec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f9dca6-e5ae-4714-8a59-2ef1d8f1e82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f9dca6-e5ae-4714-8a59-2ef1d8f1e82d.jpg?1",
             "name": "Radiant Grove",
             "text": "({T}: Add {G} or {W}.)\nRadiant Grove enters the battlefield tapped.",
             "colours": [],
@@ -8983,7 +8983,7 @@
         },
         {
             "id": "c55cbc0d-ea04-5101-8f0c-d038a3472595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24957d64-ad17-4d4f-8a00-3cdd83e1ce88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24957d64-ad17-4d4f-8a00-3cdd83e1ce88.jpg?1",
             "name": "Sacred Peaks",
             "text": "({T}: Add {R} or {W}.)\nSacred Peaks enters the battlefield tapped.",
             "colours": [],
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "6875db8f-16ae-58ad-8e6b-be7cd8e0965d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338107b-0960-4496-a9a5-f7b672e7c043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338107b-0960-4496-a9a5-f7b672e7c043.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -9050,7 +9050,7 @@
         },
         {
             "id": "1c625990-9930-5f6c-ab1a-81b50f421300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd5450a-6490-417f-9aea-b6fca6f380d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd5450a-6490-417f-9aea-b6fca6f380d7.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "a906989d-db7c-5539-896d-7aa176790ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0588fbf-3c05-452a-b3f7-67604c1f921d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0588fbf-3c05-452a-b3f7-67604c1f921d.jpg?1",
             "name": "Sunlit Marsh",
             "text": "({T}: Add {W} or {B}.)\nSunlit Marsh enters the battlefield tapped.",
             "colours": [],
@@ -9117,7 +9117,7 @@
         },
         {
             "id": "b9a185a2-c687-5b00-b5f7-a1fb815c68ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a325fb4-fe71-47f1-9a2f-05b8cfe88fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a325fb4-fe71-47f1-9a2f-05b8cfe88fe6.jpg?1",
             "name": "Tangled Islet",
             "text": "({T}: Add {G} or {U}.)\nTangled Islet enters the battlefield tapped.",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "bae7661f-7093-576d-a0b6-e4cc4e6fda36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef074a2e-a387-4af8-a180-74b145d93992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef074a2e-a387-4af8-a180-74b145d93992.jpg?1",
             "name": "Thran Portal",
             "text": "Thran Portal enters the battlefield tapped unless you control two or fewer other lands.\nAs Thran Portal enters the battlefield, choose a basic land type.\nThran Portal is the chosen type in addition to its other types.\nMana abilities of Thran Portal cost an additional 1 life to activate.",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "a55c6894-120c-5454-bc7d-8756438a281c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e31184-dca4-48b1-be9d-581247c41d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e31184-dca4-48b1-be9d-581247c41d99.jpg?1",
             "name": "Wooded Ridgeline",
             "text": "({T}: Add {R} or {G}.)\nWooded Ridgeline enters the battlefield tapped.",
             "colours": [],
@@ -9217,7 +9217,7 @@
         },
         {
             "id": "045fcf34-ec03-55d7-963e-08bdcb296c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed6c8b0-f154-4678-89d0-9869864ead8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed6c8b0-f154-4678-89d0-9869864ead8d.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -9250,7 +9250,7 @@
         },
         {
             "id": "a949620d-6fec-5115-b260-199c34f7f769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5822b027-369d-46da-b6dd-c31207e2f449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5822b027-369d-46da-b6dd-c31207e2f449.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9288,7 +9288,7 @@
         },
         {
             "id": "2067808d-9cfe-5de9-9c9a-8a7454932f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b364f40-c3c0-4e3a-8556-73f6fcc19eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b364f40-c3c0-4e3a-8556-73f6fcc19eec.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "c8e28bfc-c1db-57d1-bf77-02e6cbaebc2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be849ad5-9f96-4605-a0dc-8b9588ac7dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be849ad5-9f96-4605-a0dc-8b9588ac7dd6.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "db2b0bb2-19ec-565f-992b-4380a22e25d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafc217-3d83-4551-b2e3-3494ec14b2f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafc217-3d83-4551-b2e3-3494ec14b2f9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "4b32503f-a32b-54b3-a690-4cfd7877931f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec0f4f-e6f7-4a49-81a3-a1fbad102a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec0f4f-e6f7-4a49-81a3-a1fbad102a9d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9440,7 +9440,7 @@
         },
         {
             "id": "f98d1399-b2f9-5142-ba80-a554f970768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e7580a-92bd-4b50-84fc-ee42e47c9014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e7580a-92bd-4b50-84fc-ee42e47c9014.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9478,7 +9478,7 @@
         },
         {
             "id": "9d8d4d04-3442-5608-822a-1b483a838d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a846f00-ccb9-4ee2-8358-7c7722258601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a846f00-ccb9-4ee2-8358-7c7722258601.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9516,7 +9516,7 @@
         },
         {
             "id": "fd2c888e-948a-5e66-b00b-5038192658b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00daa026-aba3-421e-9eaa-aa5649b36eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00daa026-aba3-421e-9eaa-aa5649b36eb2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "fcb3527f-bca1-5b83-aece-8381af4cca2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0306607d-2a42-4008-ac84-8d3ed91fe3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0306607d-2a42-4008-ac84-8d3ed91fe3aa.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9592,7 +9592,7 @@
         },
         {
             "id": "1ab4f93c-757e-5fbf-b107-f402b81d83d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82f782e-abc8-4b92-a193-17b2c383f765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82f782e-abc8-4b92-a193-17b2c383f765.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9630,7 +9630,7 @@
         },
         {
             "id": "2ae58685-1379-53be-b5c5-dd0642537872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72776f25-48f5-4d7f-84a9-310928b9d7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72776f25-48f5-4d7f-84a9-310928b9d7ad.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9668,7 +9668,7 @@
         },
         {
             "id": "8cfeb308-9ff8-51b1-bf69-953727aad77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d07155-d45d-4fec-a15e-525df5010af3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d07155-d45d-4fec-a15e-525df5010af3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "ed4fa28d-0be9-5a85-a4d9-355d7081bc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52097f6a-58d3-4176-b3bf-dc94f44adf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52097f6a-58d3-4176-b3bf-dc94f44adf30.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9744,7 +9744,7 @@
         },
         {
             "id": "6e13fde1-5cef-56fb-ae26-3e7100d0c1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b6004-6dda-4495-85f7-eb8fa29873e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b6004-6dda-4495-85f7-eb8fa29873e9.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "6b5259df-3677-58cd-8890-0a122aefc38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279ebd05-229a-4a4a-a1c0-c5f24d16dee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279ebd05-229a-4a4a-a1c0-c5f24d16dee3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "413e9e4d-9d1b-5486-8551-b06236e7f4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eab93-7b1d-434b-ba92-844248e472d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eab93-7b1d-434b-ba92-844248e472d0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9858,7 +9858,7 @@
         },
         {
             "id": "2b02c3a5-2bc7-56da-8566-1688432e78ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67477a4-6878-4356-8037-807f41590ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67477a4-6878-4356-8037-807f41590ad1.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9896,7 +9896,7 @@
         },
         {
             "id": "1fcbadcb-600a-5553-9c52-86d2ee061a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8c9a6-62eb-436e-9277-e2b8075d482d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8c9a6-62eb-436e-9277-e2b8075d482d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "64d3d573-4513-5acf-9715-2f85641497c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf15b9-1bf5-424a-a994-67beaae29d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf15b9-1bf5-424a-a994-67beaae29d36.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9972,7 +9972,7 @@
         },
         {
             "id": "bb51b61e-943a-5c7c-a801-a4b276251f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e9959a-b422-4906-8d35-8b05c5dd6de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e9959a-b422-4906-8d35-8b05c5dd6de1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10010,7 +10010,7 @@
         },
         {
             "id": "c7eff468-154e-5848-b8a1-9b88080568f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b9cb5c-29f2-46ed-803e-c2170955217c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b9cb5c-29f2-46ed-803e-c2170955217c.jpg?1",
             "name": "Serra Redeemer",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, put two +1/+1 counters on that creature.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "b2e212ad-d8c0-52ce-b2ff-f02facd4bd31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79718dbe-d5d6-4f24-b514-5c392963f021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79718dbe-d5d6-4f24-b514-5c392963f021.jpg?1",
             "name": "Cosmic Epiphany",
             "text": "Draw cards equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "9e7bdc2d-d4c6-5bc6-b084-dd671681a852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027ef1fc-4a7a-465c-9c25-dc19c771b5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027ef1fc-4a7a-465c-9c25-dc19c771b5f5.jpg?1",
             "name": "Tyrannical Pitlord",
             "text": "Flying, trample\nAs Tyrannical Pitlord enters the battlefield, choose another creature you control.\nThe chosen creature gets +3/+3 and has flying.\nWhen Tyrannical Pitlord leaves the battlefield, sacrifice the chosen creature.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "5b2eac0a-56d8-5fca-9f99-0c8556176aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ccd68d-0162-4a4c-892e-1726b8b28612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ccd68d-0162-4a4c-892e-1726b8b28612.jpg?1",
             "name": "Ragefire Hellkite",
             "text": "Flying\nWhenever Ragefire Hellkite attacks, you may sacrifice another creature. If you do, Ragefire Hellkite gains double strike until end of turn.",
             "colours": [
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "5a8edb6d-3f60-5b77-847d-4cc87cecc89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390fd5d1-3ce9-456e-b130-30ad0557f4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390fd5d1-3ce9-456e-b130-30ad0557f4cf.jpg?1",
             "name": "Briar Hydra",
             "text": "Trample\nDomain \u2014 Whenever Briar Hydra deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -10190,7 +10190,7 @@
         },
         {
             "id": "e604e4d3-ff1d-5eb5-beba-23cf8337b065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9609d8-4dcf-4b70-b947-a4d62275f34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9609d8-4dcf-4b70-b947-a4d62275f34a.jpg?1",
             "name": "Danitha, Benalia's Hope",
             "text": "First strike, vigilance, lifelink\nWhen Danitha, Benalia's Hope enters the battlefield, you may put an Aura or Equipment card from your hand or graveyard onto the battlefield attached to Danitha.",
             "colours": [
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "5a044b9c-5baf-52eb-8628-23d843fdca82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2559ff7-a97c-40c6-942f-36998eafb050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2559ff7-a97c-40c6-942f-36998eafb050.jpg?1",
             "name": "Braids, Arisen Nightmare",
             "text": "At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.",
             "colours": [
@@ -10269,7 +10269,7 @@
         },
         {
             "id": "aec8ab8f-9561-5c51-ba1b-93493750e1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f4cca-90fa-4f53-8243-09d99823add3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f4cca-90fa-4f53-8243-09d99823add3.jpg?1",
             "name": "The Raven Man",
             "text": "At the beginning of each end step, if a player discarded a card this turn, create a 1/1 black Bird creature token with flying and \"This creature can't block.\"\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "2dfde2ee-e093-558e-b1a1-2d018e80c6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc5be7df-16e0-494c-b960-19fd64d57b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc5be7df-16e0-494c-b960-19fd64d57b35.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -10352,7 +10352,7 @@
         },
         {
             "id": "992fa7bc-9e0b-5918-a920-b64864b2a1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f39ecc9-0a4c-47e7-b8e6-7e00d4cb61e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f39ecc9-0a4c-47e7-b8e6-7e00d4cb61e3.jpg?1",
             "name": "Squee, Dubious Monarch",
             "text": "Haste\nWhenever Squee, Dubious Monarch attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\nYou may cast Squee, Dubious Monarch from your graveyard by paying {3}{R} and exiling four other cards from your graveyard rather than paying its mana cost.",
             "colours": [
@@ -10392,7 +10392,7 @@
         },
         {
             "id": "a525521e-4c4c-5b12-91c7-c8dfa2cf3155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f36b9-9f43-4ace-8e60-4ba671b2655a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f36b9-9f43-4ace-8e60-4ba671b2655a.jpg?1",
             "name": "Aron, Benalia's Ruin",
             "text": "Menace\n{W}{B}, {T}, Sacrifice another creature: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10434,7 +10434,7 @@
         },
         {
             "id": "8e0bdf45-a7a5-50d8-b324-5399f48af377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ab2cad-ac4c-4b04-8724-c824b45db4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ab2cad-ac4c-4b04-8724-c824b45db4d0.jpg?1",
             "name": "Astor, Bearer of Blades",
             "text": "When Astor, Bearer of Blades enters the battlefield, look at the top seven cards of your library. You may reveal an Equipment or Vehicle card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquipment you control have equip {1}.\nVehicles you control have crew 1.",
             "colours": [
@@ -10476,7 +10476,7 @@
         },
         {
             "id": "f3ebeb9f-e5f5-561a-aba2-a8abcecd8afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7acac3-cb41-46bb-ae5e-98dc60620e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7acac3-cb41-46bb-ae5e-98dc60620e53.jpg?1",
             "name": "Baird, Argivian Recruiter",
             "text": "At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -10518,7 +10518,7 @@
         },
         {
             "id": "9aa13d14-1ae8-58d4-ad25-dd343d118cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e3ba0f-0879-4eea-9911-14b874f039b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e3ba0f-0879-4eea-9911-14b874f039b3.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -10560,7 +10560,7 @@
         },
         {
             "id": "4503050f-ed4d-533f-8755-4b32f6fd029b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f342de7-f179-4894-96e4-56339d32f801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f342de7-f179-4894-96e4-56339d32f801.jpg?1",
             "name": "Bortuk Bonerattle",
             "text": "Domain \u2014 When Bortuk Bonerattle enters the battlefield, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.",
             "colours": [
@@ -10602,7 +10602,7 @@
         },
         {
             "id": "4ec27c63-aed1-588f-85c4-30369448505b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552fbde6-515d-457e-81c9-d67157eaaf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552fbde6-515d-457e-81c9-d67157eaaf37.jpg?1",
             "name": "Elas il-Kor, Sadistic Pilgrim",
             "text": "Deathtouch\nWhenever another creature enters the battlefield under your control, you gain 1 life.\nWhenever another creature you control dies, each opponent loses 1 life.",
             "colours": [
@@ -10645,7 +10645,7 @@
         },
         {
             "id": "c49e2f04-4282-52e2-997e-871273d7608f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2185d26-05b7-4e8b-ab0a-4f9d1541d4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2185d26-05b7-4e8b-ab0a-4f9d1541d4c5.jpg?1",
             "name": "Ertai Resurrected",
             "text": "Flash\nWhen Ertai Resurrected enters the battlefield, choose up to one \u2014\n\u2022 Counter target spell, activated ability, or triggered ability. Its controller draws a card.\n\u2022 Destroy another target creature or planeswalker. Its controller draws a card.",
             "colours": [
@@ -10688,7 +10688,7 @@
         },
         {
             "id": "645598bf-3669-5e10-9418-4db7321f86bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8721c-371b-454c-8ccd-5e57779fc4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8721c-371b-454c-8ccd-5e57779fc4d0.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.",
             "colours": [
@@ -10730,7 +10730,7 @@
         },
         {
             "id": "e787b03c-b705-5f5d-a952-b9ab05b129a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba0d0-ca77-47c0-8f77-7beedb6c557b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba0d0-ca77-47c0-8f77-7beedb6c557b.jpg?1",
             "name": "Ivy, Gleeful Spellthief",
             "text": "Flying\nWhenever a player casts a spell that targets only a single creature other than Ivy, Gleeful Spellthief, you may copy that spell. The copy targets Ivy.",
             "colours": [
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "33ada028-58ea-5b50-8f1b-b22e5fa49049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538eb568-23e7-49c6-855a-543a65fdae46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538eb568-23e7-49c6-855a-543a65fdae46.jpg?1",
             "name": "Jhoira, Ageless Innovator",
             "text": "{T}: Put two ingenuity counters on Jhoira, Ageless Innovator, then you may put an artifact card with mana value X or less from your hand onto the battlefield, where X is the number of ingenuity counters on Jhoira.",
             "colours": [
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "a3aaaaac-e972-5b7c-b9e5-2a5f998e8b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416429e0-4b7e-43d1-8126-16ab679b6e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416429e0-4b7e-43d1-8126-16ab679b6e39.jpg?1",
             "name": "Jodah, the Unifier",
             "text": "Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.\nWhenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10862,7 +10862,7 @@
         },
         {
             "id": "f44e9755-d844-5c62-ab31-da3083fc1116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47698a3-f7eb-42e4-8246-b657f487a5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47698a3-f7eb-42e4-8246-b657f487a5df.jpg?1",
             "name": "King Darien XLVIII",
             "text": "Other creatures you control get +1/+1.\n{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token.\nSacrifice King Darien: Creature tokens you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "136f7ecc-0d60-5d29-b422-5af886430d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dd512f-9f77-4f54-9081-f14ae0aa8c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dd512f-9f77-4f54-9081-f14ae0aa8c7a.jpg?1",
             "name": "Lagomos, Hand of Hatred",
             "text": "At the beginning of combat on your turn, create a 2/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n{T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.",
             "colours": [
@@ -10946,7 +10946,7 @@
         },
         {
             "id": "ee74d42f-bf36-5d69-87ee-198ff16b70c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378b99b7-9b7b-4596-b41e-641ff4630d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378b99b7-9b7b-4596-b41e-641ff4630d99.jpg?1",
             "name": "Meria, Scholar of Antiquity",
             "text": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -10988,7 +10988,7 @@
         },
         {
             "id": "b3877db5-b860-5950-bed0-ce075f8e3ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f81814-2870-4aab-9c50-bad78aad4e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f81814-2870-4aab-9c50-bad78aad4e36.jpg?1",
             "name": "Nael, Avizoa Aeronaut",
             "text": "Flying\nDomain \u2014 Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.",
             "colours": [
@@ -11030,7 +11030,7 @@
         },
         {
             "id": "abd1b607-1428-5927-ba2e-9f52cabbb2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf2ec7b-7cac-49aa-8fab-f9280548573b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf2ec7b-7cac-49aa-8fab-f9280548573b.jpg?1",
             "name": "Najal, the Storm Runner",
             "text": "You may cast sorcery spells as though they had flash.\nWhenever Najal, the Storm Runner attacks, you may pay {2}. If you do, when you cast your next instant or sorcery spell this turn, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "54dac28c-78d7-5523-a89c-afbfffa90348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706bc2aa-bc63-42b0-8735-486f80aaee17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706bc2aa-bc63-42b0-8735-486f80aaee17.jpg?1",
             "name": "Nemata, Primeval Warden",
             "text": "Reach\nIf a creature an opponent controls would die, exile it instead. When you do, create a 1/1 green Saproling creature token.\n{G}, Sacrifice a Saproling: Nemata, Primeval Warden gets +2/+2 until end of turn.\n{1}{B}, Sacrifice two Saprolings: Draw a card.",
             "colours": [
@@ -11113,7 +11113,7 @@
         },
         {
             "id": "78cae655-6d68-5183-bacc-44ce105043c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4101cf9-4e05-414a-843e-b2fda0db917c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4101cf9-4e05-414a-843e-b2fda0db917c.jpg?1",
             "name": "Queen Allenal of Ruadach",
             "text": "Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.\nIf one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.",
             "colours": [
@@ -11155,7 +11155,7 @@
         },
         {
             "id": "47af2b33-aa5c-5c10-924c-02a87a99a734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a42355-ead5-48b9-813a-1e9be9a45747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a42355-ead5-48b9-813a-1e9be9a45747.jpg?1",
             "name": "Radha, Coalition Warlord",
             "text": "Domain \u2014 Whenever Radha, Coalition Warlord becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "244ddfec-55d6-5abd-ad42-76f04a80267e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ed3b1-9c7d-44ff-8f0a-2a7a08313863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ed3b1-9c7d-44ff-8f0a-2a7a08313863.jpg?1",
             "name": "Raff, Weatherlight Stalwart",
             "text": "Whenever you cast an instant or sorcery spell, you may tap two untapped creatures you control. If you do, draw a card.\n{3}{W}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -11239,7 +11239,7 @@
         },
         {
             "id": "92700201-0c62-5c93-be02-0c90c187b5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ebcd93-672f-404a-8e4d-28713e9e611b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ebcd93-672f-404a-8e4d-28713e9e611b.jpg?1",
             "name": "Ratadrabik of Urborg",
             "text": "Vigilance, ward {2}\nOther Zombies you control have vigilance.\nWhenever another legendary creature you control dies, create a token that's a copy of that creature, except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -11281,7 +11281,7 @@
         },
         {
             "id": "f51eec83-c686-50a5-a889-de9f89de38d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d804a-09ea-4339-aa89-0ff2a5f5d4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d804a-09ea-4339-aa89-0ff2a5f5d4eb.jpg?1",
             "name": "Rith, Liberated Primeval",
             "text": "Flying, ward {2}\nOther Dragons you control have ward {2}.\nAt the beginning of your end step, if a creature or planeswalker an opponent controlled was dealt excess damage this turn, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "3ab9cb12-82bf-53df-a554-9041baf54e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6e2336-5bb6-4ea8-9c0a-961777176464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6e2336-5bb6-4ea8-9c0a-961777176464.jpg?1",
             "name": "Rivaz of the Claw",
             "text": "Menace\n{T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon creature spells.\nOnce during each of your turns, you may cast a Dragon creature spell from your graveyard.\nWhenever you cast a Dragon creature spell from your graveyard, it gains \"When this creature dies, exile it.\"",
             "colours": [
@@ -11366,7 +11366,7 @@
         },
         {
             "id": "93992073-d078-528e-8d25-da7f8eabad02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af90bf02-5732-4666-8dfd-50370e478711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af90bf02-5732-4666-8dfd-50370e478711.jpg?1",
             "name": "Rona, Sheoldred's Faithful",
             "text": "Whenever you cast an instant or sorcery spell, each opponent loses 1 life.\nYou may cast Rona, Sheoldred's Faithful from your graveyard by discarding two cards in addition to paying its other costs.",
             "colours": [
@@ -11408,7 +11408,7 @@
         },
         {
             "id": "00948fb7-4532-5e04-be18-8339a826a49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be69f87e-3fbb-4b37-953f-623443573fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be69f87e-3fbb-4b37-953f-623443573fca.jpg?1",
             "name": "Rulik Mons, Warren Chief",
             "text": "Menace\nWhenever Rulik Mons, Warren Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11449,7 +11449,7 @@
         },
         {
             "id": "0ff6cfa5-b9f6-5f9b-8659-03ebbe8df81d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d5e4c-bc67-47a1-85d9-cf862a38edf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d5e4c-bc67-47a1-85d9-cf862a38edf5.jpg?1",
             "name": "Shanna, Purifying Blade",
             "text": "Lifelink\nAt the beginning of your end step, you may pay {X}. If you do, draw X cards. X can't be greater than the amount of life you gained this turn.",
             "colours": [
@@ -11493,7 +11493,7 @@
         },
         {
             "id": "ead2c629-7f7e-5cb4-8050-bbc4beaa0b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2ea06b-dd6f-472b-85db-e8474deee8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2ea06b-dd6f-472b-85db-e8474deee8c5.jpg?1",
             "name": "Sol'Kanar the Tainted",
             "text": "At the beginning of your end step, choose one that hasn't been chosen \u2014\n\u2022 Draw a card.\n\u2022 Each opponent loses 2 life and you gain 2 life.\n\u2022 Sol'kanar the Tainted deals 3 damage to up to one other target creature or planeswalker.\n\u2022 Exile Sol'kanar, then return it to the battlefield under an opponent's control.",
             "colours": [
@@ -11537,7 +11537,7 @@
         },
         {
             "id": "6a49541f-79f3-5035-a44f-da9c4abefcd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92b23d2-d18a-41f9-9f1e-6809e7e02342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92b23d2-d18a-41f9-9f1e-6809e7e02342.jpg?1",
             "name": "Soul of Windgrace",
             "text": "Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -11581,7 +11581,7 @@
         },
         {
             "id": "c2081236-fc80-5df4-a32e-c9db9b6d7610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f73077b-ab99-4008-b49f-0cac4754f2ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f73077b-ab99-4008-b49f-0cac4754f2ee.jpg?1",
             "name": "Stenn, Paranoid Partisan",
             "text": "As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -11623,7 +11623,7 @@
         },
         {
             "id": "9986f2ab-343d-5dd7-8d25-de7f83c2e313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3f2dd-8745-4e2e-b01c-6b692c6ff8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3f2dd-8745-4e2e-b01c-6b692c6ff8af.jpg?1",
             "name": "Tatyova, Steward of Tides",
             "text": "Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -11665,7 +11665,7 @@
         },
         {
             "id": "3e2d9951-7661-5d4d-a980-ff15a9b9cba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676bc62e-f685-45cb-bcdd-d8adbe9c4ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676bc62e-f685-45cb-bcdd-d8adbe9c4ccb.jpg?1",
             "name": "Tori D'Avenant, Fury Rider",
             "text": "Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn. Untap each other white attacking creature you control.",
             "colours": [
@@ -11707,7 +11707,7 @@
         },
         {
             "id": "e94559fe-45f6-5bea-8f75-c1de0821ada6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d710ba7b-b0c9-4372-8f6e-1938bd114ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d710ba7b-b0c9-4372-8f6e-1938bd114ac4.jpg?1",
             "name": "Tura Kenner\u00fcd, Skyknight",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -11749,7 +11749,7 @@
         },
         {
             "id": "690003a6-c512-59ed-89af-dca3ce414206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216b4613-9b2a-472b-bc9a-49ad6c9b9f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216b4613-9b2a-472b-bc9a-49ad6c9b9f03.jpg?1",
             "name": "Uurg, Spawn of Turg",
             "text": "Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\n{B}{G}, Sacrifice a land: You gain 2 life.",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "fdb72bd7-a70b-59db-a517-9a6938f45929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a573c574-754a-4994-881c-ca5177727775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a573c574-754a-4994-881c-ca5177727775.jpg?1",
             "name": "Vohar, Vodalian Desecrator",
             "text": "{T}: Draw a card, then discard a card. If you discarded an instant or sorcery card this way, each opponent loses 1 life and you gain 1 life.\n{2}, Sacrifice Vohar, Vodalian Desecrator: You may cast target instant or sorcery card from your graveyard this turn. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -11834,7 +11834,7 @@
         },
         {
             "id": "fda9912d-ed0c-5392-bd18-b120f6163eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15e0c8b-3609-4a59-8e9b-bf2ce93d775f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15e0c8b-3609-4a59-8e9b-bf2ce93d775f.jpg?1",
             "name": "Zar Ojanen, Scion of Efrava",
             "text": "Domain \u2014 Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.",
             "colours": [
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "9046c10d-ad51-5b58-a142-8da558db0999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf4693-668e-4498-a652-a9d5eb77f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf4693-668e-4498-a652-a9d5eb77f9b7.jpg?1",
             "name": "Zur, Eternal Schemer",
             "text": "Flying\nEnchantment creatures you control have deathtouch, lifelink, and hexproof.\n{1}{W}: Target non-Aura enchantment you control becomes a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -11920,7 +11920,7 @@
         },
         {
             "id": "d10199d5-6b0a-530f-be61-ff7aaf9097a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26070716-4860-4137-8316-083baef1faad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26070716-4860-4137-8316-083baef1faad.jpg?1",
             "name": "Danitha, Benalia's Hope",
             "text": "First strike, vigilance, lifelink\nWhen Danitha, Benalia's Hope enters the battlefield, you may put an Aura or Equipment card from your hand or graveyard onto the battlefield attached to Danitha.",
             "colours": [
@@ -11959,7 +11959,7 @@
         },
         {
             "id": "cb854b94-706d-5250-b9b0-27a9da4199b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e20d56c-20df-4fe9-a329-df5768a180af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e20d56c-20df-4fe9-a329-df5768a180af.jpg?1",
             "name": "Braids, Arisen Nightmare",
             "text": "At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.",
             "colours": [
@@ -11997,7 +11997,7 @@
         },
         {
             "id": "21165149-8426-548e-b9a0-4949983acb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee62bdd-3e29-442b-9ce4-1c66d12a5877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee62bdd-3e29-442b-9ce4-1c66d12a5877.jpg?1",
             "name": "The Raven Man",
             "text": "At the beginning of each end step, if a player discarded a card this turn, create a 1/1 black Bird creature token with flying and \"This creature can't block.\"\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -12036,7 +12036,7 @@
         },
         {
             "id": "228e2ce5-f36d-5ac8-9ba3-cc2ad2c37745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9494e5f-bfd2-45b0-b324-fd1407d9b644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9494e5f-bfd2-45b0-b324-fd1407d9b644.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -12078,7 +12078,7 @@
         },
         {
             "id": "72b9fc47-3e96-569a-b8f4-8ed43fcd9f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a6d17-d48d-409c-abf7-40b0526eae7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a6d17-d48d-409c-abf7-40b0526eae7a.jpg?1",
             "name": "Squee, Dubious Monarch",
             "text": "Haste\nWhenever Squee, Dubious Monarch attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\nYou may cast Squee, Dubious Monarch from your graveyard by paying {3}{R} and exiling four other cards from your graveyard rather than paying its mana cost.",
             "colours": [
@@ -12117,7 +12117,7 @@
         },
         {
             "id": "e7a69198-8b9b-58c2-907e-14889ee8e5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f83110c-d6d3-4824-8acd-96b068b7f0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f83110c-d6d3-4824-8acd-96b068b7f0a5.jpg?1",
             "name": "Aron, Benalia's Ruin",
             "text": "Menace\n{W}{B}, {T}, Sacrifice another creature: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -12158,7 +12158,7 @@
         },
         {
             "id": "f2ba3a8e-944c-5332-a018-69d77f33b2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e390bd-a1ad-4abe-b6a2-ab9ce8059193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e390bd-a1ad-4abe-b6a2-ab9ce8059193.jpg?1",
             "name": "Astor, Bearer of Blades",
             "text": "When Astor, Bearer of Blades enters the battlefield, look at the top seven cards of your library. You may reveal an Equipment or Vehicle card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquipment you control have equip {1}.\nVehicles you control have crew 1.",
             "colours": [
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "823cac09-cb3c-549d-a127-454f38e922d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba3078-c06e-41d1-a574-1a2ff09c63d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba3078-c06e-41d1-a574-1a2ff09c63d9.jpg?1",
             "name": "Baird, Argivian Recruiter",
             "text": "At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -12240,7 +12240,7 @@
         },
         {
             "id": "295106b1-ee37-548a-97de-040fc9df6ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07452998-e70a-4c15-9b09-6f33aa0d933d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07452998-e70a-4c15-9b09-6f33aa0d933d.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -12281,7 +12281,7 @@
         },
         {
             "id": "226e11b0-d139-59d2-ad7c-96e4c3aa52c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01f1f1f-e0b9-4640-ab5e-c2af4bf9df51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01f1f1f-e0b9-4640-ab5e-c2af4bf9df51.jpg?1",
             "name": "Bortuk Bonerattle",
             "text": "Domain \u2014 When Bortuk Bonerattle enters the battlefield, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.",
             "colours": [
@@ -12322,7 +12322,7 @@
         },
         {
             "id": "31f81403-5240-5d53-8291-06d044f204cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e03e38f-cfbf-4e59-8639-d9f015714058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e03e38f-cfbf-4e59-8639-d9f015714058.jpg?1",
             "name": "Elas il-Kor, Sadistic Pilgrim",
             "text": "Deathtouch\nWhenever another creature enters the battlefield under your control, you gain 1 life.\nWhenever another creature you control dies, each opponent loses 1 life.",
             "colours": [
@@ -12364,7 +12364,7 @@
         },
         {
             "id": "443e5570-a0e5-5ce3-b169-2d30849f47b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46a2ca-27fd-44d4-80d0-7c83ed0a564e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46a2ca-27fd-44d4-80d0-7c83ed0a564e.jpg?1",
             "name": "Ertai Resurrected",
             "text": "Flash\nWhen Ertai Resurrected enters the battlefield, choose up to one \u2014\n\u2022 Counter target spell, activated ability, or triggered ability. Its controller draws a card.\n\u2022 Destroy another target creature or planeswalker. Its controller draws a card.",
             "colours": [
@@ -12406,7 +12406,7 @@
         },
         {
             "id": "0b87f85e-85fd-53de-82de-68f568ff73db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ab0eb2-1c6d-4117-b620-81ba324dd4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ab0eb2-1c6d-4117-b620-81ba324dd4c7.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.",
             "colours": [
@@ -12447,7 +12447,7 @@
         },
         {
             "id": "f0f79ddd-ed23-5531-affa-70ebd0a297b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9187f4ea-27f2-4f94-b783-6992087d64a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9187f4ea-27f2-4f94-b783-6992087d64a4.jpg?1",
             "name": "Ivy, Gleeful Spellthief",
             "text": "Flying\nWhenever a player casts a spell that targets only a single creature other than Ivy, Gleeful Spellthief, you may copy that spell. The copy targets Ivy.",
             "colours": [
@@ -12488,7 +12488,7 @@
         },
         {
             "id": "2420a537-a9a0-50e7-b5f1-33a0e9a25768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c24b7f-256b-4759-8627-a07c5cde52ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c24b7f-256b-4759-8627-a07c5cde52ad.jpg?1",
             "name": "Jhoira, Ageless Innovator",
             "text": "{T}: Put two ingenuity counters on Jhoira, Ageless Innovator, then you may put an artifact card with mana value X or less from your hand onto the battlefield, where X is the number of ingenuity counters on Jhoira.",
             "colours": [
@@ -12529,7 +12529,7 @@
         },
         {
             "id": "216e5340-238a-5c80-84db-9968ca5cb727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb2313a-e002-4b37-9ecb-20bfe1799157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb2313a-e002-4b37-9ecb-20bfe1799157.jpg?1",
             "name": "Jodah, the Unifier",
             "text": "Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.\nWhenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12576,7 +12576,7 @@
         },
         {
             "id": "9d1b4dad-d1e8-57ae-907d-d90a07ddc972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b1257-2766-45d3-abc9-97f0d85d7010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b1257-2766-45d3-abc9-97f0d85d7010.jpg?1",
             "name": "King Darien XLVIII",
             "text": "Other creatures you control get +1/+1.\n{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token.\nSacrifice King Darien: Creature tokens you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -12617,7 +12617,7 @@
         },
         {
             "id": "0fcbf11a-036e-5021-ac6a-b863f958610c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175746b-e98e-448c-b3ca-bcbcdf2817cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175746b-e98e-448c-b3ca-bcbcdf2817cf.jpg?1",
             "name": "Lagomos, Hand of Hatred",
             "text": "At the beginning of combat on your turn, create a 2/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n{T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.",
             "colours": [
@@ -12658,7 +12658,7 @@
         },
         {
             "id": "389b6102-2959-5e83-b705-edc572763bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d4f9f-3a32-4bab-baa4-baf8102a8787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d4f9f-3a32-4bab-baa4-baf8102a8787.jpg?1",
             "name": "Meria, Scholar of Antiquity",
             "text": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -12699,7 +12699,7 @@
         },
         {
             "id": "07fb3d40-3973-5626-87ee-b23d56bf9767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd2081c-d53b-4a5e-976b-0b28465c0be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd2081c-d53b-4a5e-976b-0b28465c0be8.jpg?1",
             "name": "Nael, Avizoa Aeronaut",
             "text": "Flying\nDomain \u2014 Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.",
             "colours": [
@@ -12740,7 +12740,7 @@
         },
         {
             "id": "6eca4c02-1e25-590e-ade0-d0d00191244e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686ec9c3-9549-42e6-8cb5-d00f8cae0f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686ec9c3-9549-42e6-8cb5-d00f8cae0f16.jpg?1",
             "name": "Najal, the Storm Runner",
             "text": "You may cast sorcery spells as though they had flash.\nWhenever Najal, the Storm Runner attacks, you may pay {2}. If you do, when you cast your next instant or sorcery spell this turn, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -12781,7 +12781,7 @@
         },
         {
             "id": "e01f5cd1-8202-5a2c-87f7-0be1533018aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739f7a27-93a6-4ebf-bc3c-e3caf49fce5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739f7a27-93a6-4ebf-bc3c-e3caf49fce5d.jpg?1",
             "name": "Nemata, Primeval Warden",
             "text": "Reach\nIf a creature an opponent controls would die, exile it instead. When you do, create a 1/1 green Saproling creature token.\n{G}, Sacrifice a Saproling: Nemata, Primeval Warden gets +2/+2 until end of turn.\n{1}{B}, Sacrifice two Saprolings: Draw a card.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "a05f975b-104c-5b95-8dd2-22afce65b643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d66aab-d99c-46de-ba72-b6b5fa0847c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d66aab-d99c-46de-ba72-b6b5fa0847c2.jpg?1",
             "name": "Queen Allenal of Ruadach",
             "text": "Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.\nIf one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.",
             "colours": [
@@ -12862,7 +12862,7 @@
         },
         {
             "id": "524eb6a0-2040-527b-a5dc-61ef692c09c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0336da59-a51a-4b23-965c-06532d1f3a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0336da59-a51a-4b23-965c-06532d1f3a23.jpg?1",
             "name": "Radha, Coalition Warlord",
             "text": "Domain \u2014 Whenever Radha, Coalition Warlord becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -12903,7 +12903,7 @@
         },
         {
             "id": "0fbb959d-e4a2-5044-a11b-715d9047cf26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf938c0-b32f-4780-b628-457874eae638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf938c0-b32f-4780-b628-457874eae638.jpg?1",
             "name": "Raff, Weatherlight Stalwart",
             "text": "Whenever you cast an instant or sorcery spell, you may tap two untapped creatures you control. If you do, draw a card.\n{3}{W}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -12944,7 +12944,7 @@
         },
         {
             "id": "f1a207ba-33d3-51e8-91e2-c84edd007811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce0c81-1c30-4971-ae6f-a9c6a4dd017d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce0c81-1c30-4971-ae6f-a9c6a4dd017d.jpg?1",
             "name": "Ratadrabik of Urborg",
             "text": "Vigilance, ward {2}\nOther Zombies you control have vigilance.\nWhenever another legendary creature you control dies, create a token that's a copy of that creature, except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -12985,7 +12985,7 @@
         },
         {
             "id": "0c1b7f76-93ac-5ad4-a35c-096afae678d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5370c07-5158-4cd8-87d2-433f4b1f6e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5370c07-5158-4cd8-87d2-433f4b1f6e02.jpg?1",
             "name": "Rith, Liberated Primeval",
             "text": "Flying, ward {2}\nOther Dragons you control have ward {2}.\nAt the beginning of your end step, if a creature or planeswalker an opponent controlled was dealt excess damage this turn, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -13027,7 +13027,7 @@
         },
         {
             "id": "8c6afd10-a027-5587-8761-5b124118a114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8218a4-1861-4ac6-9e36-4d6ff4199f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8218a4-1861-4ac6-9e36-4d6ff4199f55.jpg?1",
             "name": "Rivaz of the Claw",
             "text": "Menace\n{T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon creature spells.\nOnce during each of your turns, you may cast a Dragon creature spell from your graveyard.\nWhenever you cast a Dragon creature spell from your graveyard, it gains \"When this creature dies, exile it.\"",
             "colours": [
@@ -13068,7 +13068,7 @@
         },
         {
             "id": "6287aaef-d2ba-588d-ae9f-e8edfc973963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ed0d3c-def9-4ba5-98d4-5bf35d711ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ed0d3c-def9-4ba5-98d4-5bf35d711ec9.jpg?1",
             "name": "Rona, Sheoldred's Faithful",
             "text": "Whenever you cast an instant or sorcery spell, each opponent loses 1 life.\nYou may cast Rona, Sheoldred's Faithful from your graveyard by discarding two cards in addition to paying its other costs.",
             "colours": [
@@ -13109,7 +13109,7 @@
         },
         {
             "id": "e003c785-e861-5da0-afc7-bba89d71e69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c79f75-0389-4514-b86f-5ee353965c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c79f75-0389-4514-b86f-5ee353965c02.jpg?1",
             "name": "Rulik Mons, Warren Chief",
             "text": "Menace\nWhenever Rulik Mons, Warren Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -13149,7 +13149,7 @@
         },
         {
             "id": "7c093216-3992-525f-a30e-ae5865c74e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b31f4-600c-4be6-a6db-b991447527ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b31f4-600c-4be6-a6db-b991447527ec.jpg?1",
             "name": "Shanna, Purifying Blade",
             "text": "Lifelink\nAt the beginning of your end step, you may pay {X}. If you do, draw X cards. X can't be greater than the amount of life you gained this turn.",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "9bdcf60e-d894-5cc8-9d6b-9bfbd93d1e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bccbe5e-4076-429d-96e4-a6dd14adcfa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bccbe5e-4076-429d-96e4-a6dd14adcfa1.jpg?1",
             "name": "Sol'Kanar the Tainted",
             "text": "At the beginning of your end step, choose one that hasn't been chosen \u2014\n\u2022 Draw a card.\n\u2022 Each opponent loses 2 life and you gain 2 life.\n\u2022 Sol'kanar the Tainted deals 3 damage to up to one other target creature or planeswalker.\n\u2022 Exile Sol'kanar, then return it to the battlefield under an opponent's control.",
             "colours": [
@@ -13235,7 +13235,7 @@
         },
         {
             "id": "5e774cfe-d40e-5b1b-883c-0d156d99a0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9ce534-4bd4-4ba1-b875-7f74dd5f712c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9ce534-4bd4-4ba1-b875-7f74dd5f712c.jpg?1",
             "name": "Soul of Windgrace",
             "text": "Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -13278,7 +13278,7 @@
         },
         {
             "id": "979d5a36-747d-5e56-b242-70605b9ff8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb5bd07-b456-4f0e-9e39-2c4a89b32327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb5bd07-b456-4f0e-9e39-2c4a89b32327.jpg?1",
             "name": "Stenn, Paranoid Partisan",
             "text": "As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -13319,7 +13319,7 @@
         },
         {
             "id": "402c4f97-9f5f-5dff-85ec-667e2986e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3296c85f-01f6-42b4-96d6-0c576617dbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3296c85f-01f6-42b4-96d6-0c576617dbd8.jpg?1",
             "name": "Tatyova, Steward of Tides",
             "text": "Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -13360,7 +13360,7 @@
         },
         {
             "id": "1b7a5236-9697-57dc-b53f-f0714f615507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd8ea0-05be-4db1-8f7b-bccbb484d552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd8ea0-05be-4db1-8f7b-bccbb484d552.jpg?1",
             "name": "Tori D'Avenant, Fury Rider",
             "text": "Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn. Untap each other white attacking creature you control.",
             "colours": [
@@ -13401,7 +13401,7 @@
         },
         {
             "id": "85789f92-f23d-5e60-b619-512a44d87c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaef59b-639c-4f97-addd-a32a523dd961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaef59b-639c-4f97-addd-a32a523dd961.jpg?1",
             "name": "Tura Kenner\u00fcd, Skyknight",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -13442,7 +13442,7 @@
         },
         {
             "id": "c6b4cab7-2ee4-5d6d-9a9d-d0f21f7a79c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98cc9a0-8c7e-435d-b041-63717e57ce1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98cc9a0-8c7e-435d-b041-63717e57ce1f.jpg?1",
             "name": "Uurg, Spawn of Turg",
             "text": "Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\n{B}{G}, Sacrifice a land: You gain 2 life.",
             "colours": [
@@ -13483,7 +13483,7 @@
         },
         {
             "id": "3f6ff04a-5649-53ab-a358-08b348609c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2124e308-091c-4a0d-8631-e3106636b59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2124e308-091c-4a0d-8631-e3106636b59b.jpg?1",
             "name": "Vohar, Vodalian Desecrator",
             "text": "{T}: Draw a card, then discard a card. If you discarded an instant or sorcery card this way, each opponent loses 1 life and you gain 1 life.\n{2}, Sacrifice Vohar, Vodalian Desecrator: You may cast target instant or sorcery card from your graveyard this turn. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -13525,7 +13525,7 @@
         },
         {
             "id": "2ae3e82d-7091-52ed-95ab-14b8749aebc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9afd7c2-fe9b-4ccd-bd55-a0f91c52fd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9afd7c2-fe9b-4ccd-bd55-a0f91c52fd29.jpg?1",
             "name": "Zar Ojanen, Scion of Efrava",
             "text": "Domain \u2014 Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.",
             "colours": [
@@ -13566,7 +13566,7 @@
         },
         {
             "id": "54d573d6-f0ea-58a7-a274-1b38fc463422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95979e43-7f1d-4c06-8f28-5ea378633c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95979e43-7f1d-4c06-8f28-5ea378633c14.jpg?1",
             "name": "Zur, Eternal Schemer",
             "text": "Flying\nEnchantment creatures you control have deathtouch, lifelink, and hexproof.\n{1}{W}: Target non-Aura enchantment you control becomes a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -13609,7 +13609,7 @@
         },
         {
             "id": "c0a8a0d5-4a99-52cb-bb9b-8faad45cb4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ebbb6d-04f8-42ec-a1b7-6ca67994b8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ebbb6d-04f8-42ec-a1b7-6ca67994b8d3.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -13652,7 +13652,7 @@
         },
         {
             "id": "b0ab486a-1e98-5e52-94b5-c76239dcdb74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2af6c1-fdf1-4d04-bd74-f07da939110a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2af6c1-fdf1-4d04-bd74-f07da939110a.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13695,7 +13695,7 @@
         },
         {
             "id": "2cca9e31-a1ec-5a14-b7c2-4c41ce876b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea352f02-de67-4da6-8049-d3031c0877ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea352f02-de67-4da6-8049-d3031c0877ae.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13738,7 +13738,7 @@
         },
         {
             "id": "cb6cd168-e0cf-560d-80a2-533afbb613aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493341c3-1f59-4d7e-b852-1449a2333be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493341c3-1f59-4d7e-b852-1449a2333be9.jpg?1",
             "name": "Karn, Living Legacy",
             "text": "+1: Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n\u22121: Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Tap an untapped artifact you control: This emblem deals 1 damage to any target.\"",
             "colours": [],
@@ -13772,7 +13772,7 @@
         },
         {
             "id": "987670e7-5626-53b3-a110-c0ed6588f6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18b8768-4126-4636-990e-21b4308740dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18b8768-4126-4636-990e-21b4308740dc.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
             "colours": [
@@ -13810,7 +13810,7 @@
         },
         {
             "id": "e02c20d5-0dd0-5ffe-967e-f2e6b6cee355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a532c-94c3-4302-9fba-af8396329890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a532c-94c3-4302-9fba-af8396329890.jpg?1",
             "name": "Jaya, Fiery Negotiator",
             "text": "+1: Create a 1/1 red Monk creature token with prowess.\n\u22121: Exile the top two cards of your library. Choose one of them. You may play that card this turn.\n\u22122: Choose target creature an opponent controls. Whenever you attack this turn, Jaya, Fiery Negotiator deals damage equal to the number of attacking creatures to that creature.\n\u22128: You get an emblem with \"Whenever you cast a red instant or sorcery spell, copy it twice. You may choose new targets for the copies.\"",
             "colours": [
@@ -13848,7 +13848,7 @@
         },
         {
             "id": "b670515f-de66-567e-921d-ebfc7911664c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d14829d-3119-4c65-8e9a-5281771bbaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d14829d-3119-4c65-8e9a-5281771bbaf3.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13891,7 +13891,7 @@
         },
         {
             "id": "85c16d6e-21ce-57f0-9671-cb545d603836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894a44e-ac13-453f-b45a-ab6bec574197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894a44e-ac13-453f-b45a-ab6bec574197.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13934,7 +13934,7 @@
         },
         {
             "id": "941db312-aef6-586a-940d-94e19b221a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5764bd-712b-4e6b-b71e-5767d5613b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5764bd-712b-4e6b-b71e-5767d5613b1c.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "90205dbc-63ce-59ee-87b8-627811a2c4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7328a565-966d-4053-b32b-25bdce031d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7328a565-966d-4053-b32b-25bdce031d9f.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -14000,7 +14000,7 @@
         },
         {
             "id": "3b8734ef-2061-5938-b10f-5a3ef6f4b4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83eca4-b6ad-4ec4-91f2-b2a62b32b056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83eca4-b6ad-4ec4-91f2-b2a62b32b056.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {G}. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -14033,7 +14033,7 @@
         },
         {
             "id": "90ff98d7-1b4e-50e7-89c2-0064cd7112d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c11164-e98c-4f09-9840-825bd1f91247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c11164-e98c-4f09-9840-825bd1f91247.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -14066,7 +14066,7 @@
         },
         {
             "id": "01a11b62-380d-5ceb-8c9c-77c28f48498d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba5d3e7-afd9-40c5-8ee9-238ba47f0841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba5d3e7-afd9-40c5-8ee9-238ba47f0841.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -14099,7 +14099,7 @@
         },
         {
             "id": "82260831-cf64-5335-8ef8-8aa88eb9d0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa9c09-5eeb-466f-a8f5-9898de6e7c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa9c09-5eeb-466f-a8f5-9898de6e7c88.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -14132,7 +14132,7 @@
         },
         {
             "id": "e51899f5-2480-5e01-91a3-1bc6f0465173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aba15c0-fbc6-473f-8da9-522aa582b2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aba15c0-fbc6-473f-8da9-522aa582b2bf.jpg?1",
             "name": "Anointed Peacekeeper",
             "text": "Vigilance\nAs Anointed Peacekeeper enters the battlefield, look at an opponent's hand, then choose any card name.\nSpells your opponents cast with the chosen name cost {2} more to cast.\nActivated abilities of sources with the chosen name cost {2} more to activate unless they're mana abilities.",
             "colours": [
@@ -14169,7 +14169,7 @@
         },
         {
             "id": "31006dd0-e4b8-5c13-9ad4-efbee3de5874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9e837-a1eb-48d9-a8bd-94dd54ad97d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9e837-a1eb-48d9-a8bd-94dd54ad97d1.jpg?1",
             "name": "Archangel of Wrath",
             "text": "Kicker {B} and/or {R}\nFlying, lifelink\nWhen Archangel of Wrath enters the battlefield, if it was kicked, it deals 2 damage to any target.\nWhen Archangel of Wrath enters the battlefield, if it was kicked twice, it deals 2 damage to any target.",
             "colours": [
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "c1972fad-ff9b-524b-9bee-22acf5191643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fa16ec-b4ab-4da8-a1fa-cf6c303edc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fa16ec-b4ab-4da8-a1fa-cf6c303edc7a.jpg?1",
             "name": "Defiler of Faith",
             "text": "Vigilance\nAs an additional cost to cast white permanent spells, you may pay 2 life. Those spells cost {W} less to cast if you paid life this way. This effect reduces only the amount of white mana you pay.\nWhenever you cast a white permanent spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "83f9c535-689f-52f1-bcc4-8e5ac9a59202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75168c8-6798-46cd-8dd7-22115203cb2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75168c8-6798-46cd-8dd7-22115203cb2b.jpg?1",
             "name": "Guardian of New Benalia",
             "text": "Enlist\nWhenever Guardian of New Benalia enlists a creature, scry 2.\nDiscard a card: Guardian of New Benalia gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -14281,7 +14281,7 @@
         },
         {
             "id": "0b7a6350-25f2-5dbe-aad4-f13e38ca3fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32da8479-7d0e-4eb1-b18c-66eb170e31a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32da8479-7d0e-4eb1-b18c-66eb170e31a5.jpg?1",
             "name": "Leyline Binding",
             "text": "Flash\nDomain \u2014 This spell costs {1} less to cast for each basic land type among lands you control.\nWhen Leyline Binding enters the battlefield, exile target nonland permanent an opponent controls until Leyline Binding leaves the battlefield.",
             "colours": [
@@ -14315,7 +14315,7 @@
         },
         {
             "id": "1f21ff2f-5fbe-588f-b909-511ca731ef9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69284b53-f712-418c-94a0-4e5638117256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69284b53-f712-418c-94a0-4e5638117256.jpg?1",
             "name": "Serra Paragon",
             "text": "Flying\nOnce during each of your turns, you may play a land from your graveyard or cast a permanent spell with mana value 3 or less from your graveyard. If you do, it gains \"When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life.\"",
             "colours": [
@@ -14351,7 +14351,7 @@
         },
         {
             "id": "eee091de-f5e8-540e-8937-9c5409250d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9672bc7-ccc9-4f89-ad92-60e130369336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9672bc7-ccc9-4f89-ad92-60e130369336.jpg?1",
             "name": "Temporary Lockdown",
             "text": "When Temporary Lockdown enters the battlefield, exile each nonland permanent with mana value 2 or less until Temporary Lockdown leaves the battlefield.",
             "colours": [
@@ -14385,7 +14385,7 @@
         },
         {
             "id": "9ef38776-95ae-52c1-a36f-3bd5a27badb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90492217-d6c1-4fc0-87b8-f66dc49c3265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90492217-d6c1-4fc0-87b8-f66dc49c3265.jpg?1",
             "name": "Valiant Veteran",
             "text": "Other Soldiers you control get +1/+1.\n{3}{W}{W}, Exile Valiant Veteran from your graveyard: Put a +1/+1 counter on each Soldier you control.",
             "colours": [
@@ -14422,7 +14422,7 @@
         },
         {
             "id": "2a259473-33e2-51e9-b56f-162a7e37e660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2aaf56-5597-47f3-bc7c-49943799d4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2aaf56-5597-47f3-bc7c-49943799d4de.jpg?1",
             "name": "Academy Loremaster",
             "text": "At the beginning of each player's draw step, that player may draw an additional card. If they do, spells they cast this turn cost {2} more to cast.",
             "colours": [
@@ -14459,7 +14459,7 @@
         },
         {
             "id": "e9483ecb-d2e6-58d7-8f1d-2de905ab3d31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2026190a-1463-4b55-923c-bc00c85ef3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2026190a-1463-4b55-923c-bc00c85ef3e0.jpg?1",
             "name": "Aether Channeler",
             "text": "When Aether Channeler enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 white Bird creature token with flying.\n\u2022 Return another target nonland permanent to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -14496,7 +14496,7 @@
         },
         {
             "id": "6f77c4c5-c1b8-5ec4-a40c-00fb5b2b78b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8640da59-6ff1-4171-9723-5ef56dc59fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8640da59-6ff1-4171-9723-5ef56dc59fbc.jpg?1",
             "name": "Defiler of Dreams",
             "text": "Flying\nAs an additional cost to cast blue permanent spells, you may pay 2 life. Those spells cost {U} less to cast if you paid life this way. This effect reduces only the amount of blue mana you pay.\nWhenever you cast a blue permanent spell, draw a card.",
             "colours": [
@@ -14533,7 +14533,7 @@
         },
         {
             "id": "4d39415c-4f85-5d18-a11d-24fe2a544d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e127cb-1d35-4851-93e2-66b42d58da8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e127cb-1d35-4851-93e2-66b42d58da8d.jpg?1",
             "name": "Haughty Djinn",
             "text": "Flying\nHaughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -14569,7 +14569,7 @@
         },
         {
             "id": "e6e32187-cc4b-5a5c-9999-c27feebd481a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cedd68-c170-4b97-9035-e0a6398482f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cedd68-c170-4b97-9035-e0a6398482f0.jpg?1",
             "name": "Silver Scrutiny",
             "text": "You may cast Silver Scrutiny as though it had flash if X is 3 or less.\nDraw X cards.",
             "colours": [
@@ -14603,7 +14603,7 @@
         },
         {
             "id": "eb0a61e0-e074-5614-8df0-529939e8c4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf41d9-d44c-46f8-86e5-f4491541cea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf41d9-d44c-46f8-86e5-f4491541cea4.jpg?1",
             "name": "Sphinx of Clear Skies",
             "text": "Flying, ward {2}\nDomain \u2014 Whenever Sphinx of Clear Skies deals combat damage to a player, reveal the top X cards of your library, where X is the number of basic land types among lands you control. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -14639,7 +14639,7 @@
         },
         {
             "id": "e47cd188-c0cd-5392-a66c-35dcb7574fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ab9af3-718e-49fa-96d3-da67bc55c7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ab9af3-718e-49fa-96d3-da67bc55c7d4.jpg?1",
             "name": "Vesuvan Duplimancy",
             "text": "Whenever you cast a spell that targets only a single artifact or creature you control, create a token that's a copy of that artifact or creature, except it's not legendary.",
             "colours": [
@@ -14673,7 +14673,7 @@
         },
         {
             "id": "0518ecc2-4457-5538-803e-1217d13b89a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1198e0f9-7240-4eae-85d1-4b8ee5d61458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1198e0f9-7240-4eae-85d1-4b8ee5d61458.jpg?1",
             "name": "Vodalian Hexcatcher",
             "text": "Flash\nOther Merfolk you control get +1/+1.\nSacrifice a Merfolk: Counter target noncreature spell unless its controller pays {1}.",
             "colours": [
@@ -14710,7 +14710,7 @@
         },
         {
             "id": "31c7c708-b29e-58ef-9e39-944f8a4b905d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb97507-e332-410c-8f8c-3aa77c235742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb97507-e332-410c-8f8c-3aa77c235742.jpg?1",
             "name": "Vodalian Mindsinger",
             "text": "Kicker {1}{R} and/or {1}{G}\nVodalian Mindsinger enters the battlefield with two +1/+1 counters on it for each time it was kicked.\nWhen Vodalian Mindsinger enters the battlefield, gain control of target creature with power less than Vodalian Mindsinger's power for as long as you control Vodalian Mindsinger.",
             "colours": [
@@ -14749,7 +14749,7 @@
         },
         {
             "id": "299f6fc7-715e-5c54-9d99-202c84f196db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c27d94e-7dc8-45b4-aac6-b30a677b8ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c27d94e-7dc8-45b4-aac6-b30a677b8ad5.jpg?1",
             "name": "Defiler of Flesh",
             "text": "Menace\nAs an additional cost to cast black permanent spells, you may pay 2 life. Those spells cost {B} less to cast if you paid life this way. This effect reduces only the amount of black mana you pay.\nWhenever you cast a black permanent spell, target creature you control gets +1/+1 and gains menace until end of turn.",
             "colours": [
@@ -14786,7 +14786,7 @@
         },
         {
             "id": "0fab5150-9cd5-554e-8e51-e272c9d12b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f72da0d-f48d-438d-8bc8-23e509a47149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f72da0d-f48d-438d-8bc8-23e509a47149.jpg?1",
             "name": "Drag to the Bottom",
             "text": "Domain \u2014 Each creature gets -X/-X until end of turn, where X is 1 plus the number of basic land types among lands you control.",
             "colours": [
@@ -14820,7 +14820,7 @@
         },
         {
             "id": "679cb1cb-9ec8-53cd-9d34-eb2108520998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c7253c-eb58-4b89-b1ae-a025e8ad1c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c7253c-eb58-4b89-b1ae-a025e8ad1c20.jpg?1",
             "name": "Evolved Sleeper",
             "text": "{B}: Evolved Sleeper becomes a Human Cleric with base power and toughness 2/2.\n{1}{B}: If Evolved Sleeper is a Cleric, put a deathtouch counter on it and it becomes a Phyrexian Human Cleric with base power and toughness 3/3.\n{1}{B}{B}: If Evolved Sleeper is a Phyrexian, put a +1/+1 counter on it, then you draw a card and you lose 1 life.",
             "colours": [
@@ -14856,7 +14856,7 @@
         },
         {
             "id": "7126842e-207e-54d9-920e-3041de35e4ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac9e1a7-544b-4c13-8c41-8fecc0232446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac9e1a7-544b-4c13-8c41-8fecc0232446.jpg?1",
             "name": "Shadow-Rite Priest",
             "text": "Other Clerics you control get +1/+1.\n{3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "2fa00b00-908d-5f3d-8ab8-c458a2e6873c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c48497-7ef8-4b45-b160-8af28d8e61ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c48497-7ef8-4b45-b160-8af28d8e61ba.jpg?1",
             "name": "Stronghold Arena",
             "text": "Kicker {G} and/or {W}\nWhen Stronghold Arena enters the battlefield, you gain 3 life for each time it was kicked.\nWhenever one or more creatures you control deal combat damage to a player, you may reveal the top card of your library and put it into your hand. If you do, you lose life equal to its mana value.",
             "colours": [
@@ -14929,7 +14929,7 @@
         },
         {
             "id": "75af9d4b-f095-5081-b8db-14f66ea7fdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8995e45-3ff3-48d5-97ac-7c982f80f640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8995e45-3ff3-48d5-97ac-7c982f80f640.jpg?1",
             "name": "Chaotic Transformation",
             "text": "Exile up to one target artifact, up to one target creature, up to one target enchantment, up to one target planeswalker, and/or up to one target land. For each permanent exiled this way, its controller reveals cards from the top of their library until they reveal a card that shares a card type with it, puts that card onto the battlefield, then shuffles.",
             "colours": [
@@ -14963,7 +14963,7 @@
         },
         {
             "id": "69d2a70f-dca6-5520-95d9-5aeec202d289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cadcc4-ed5e-4396-9034-ffcce3a3ed82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cadcc4-ed5e-4396-9034-ffcce3a3ed82.jpg?1",
             "name": "Defiler of Instinct",
             "text": "First strike\nAs an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.\nWhenever you cast a red permanent spell, Defiler of Instinct deals 1 damage to any target.",
             "colours": [
@@ -15000,7 +15000,7 @@
         },
         {
             "id": "031b2f99-a5ed-5a6e-8bb5-98a5710f85dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dacef18-5c0d-4c99-8273-1f9c896552bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dacef18-5c0d-4c99-8273-1f9c896552bf.jpg?1",
             "name": "Keldon Flamesage",
             "text": "Enlist\nWhenever Keldon Flamesage attacks, look at the top X cards of your library, where X is Keldon Flamesage's power. You may exile an instant or sorcery card with mana value X or less from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -15037,7 +15037,7 @@
         },
         {
             "id": "1cb8bc21-0bdd-5064-bb2a-e20a45da3838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20e461-2850-4404-838a-ad2c810100b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20e461-2850-4404-838a-ad2c810100b5.jpg?1",
             "name": "Radha's Firebrand",
             "text": "Whenever Radha's Firebrand attacks, target creature defending player controls with power less than Radha's Firebrand's power can't block this turn.\nDomain \u2014 {5}{R}: Radha's Firebrand gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.",
             "colours": [
@@ -15074,7 +15074,7 @@
         },
         {
             "id": "b58d9a6e-cae1-560d-a318-0961c65c88fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060d14a4-e903-4c89-9c3a-baa91f125c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060d14a4-e903-4c89-9c3a-baa91f125c4e.jpg?1",
             "name": "Rundvelt Hordemaster",
             "text": "Other Goblins you control get +1/+1.\nWhenever Rundvelt Hordemaster or another Goblin you control dies, exile the top card of your library. If it's a Goblin creature card, you may cast that card until the end of your next turn.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "bc44b8ad-ebc9-5f87-a3bb-1fb30ada89e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaca6ca-58e0-4846-b9b7-5ac9547bcde5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaca6ca-58e0-4846-b9b7-5ac9547bcde5.jpg?1",
             "name": "Shivan Devastator",
             "text": "Flying, haste\nShivan Devastator enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "7ac31d7d-fb21-503e-9651-7d6378005b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3affc335-ebb4-46e4-8f84-ba204804100e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3affc335-ebb4-46e4-8f84-ba204804100e.jpg?1",
             "name": "Temporal Firestorm",
             "text": "Kicker {1}{W} and/or {1}{U}\nChoose up to X creatures and/or planeswalkers you control, where X is the number of times this spell was kicked. Those permanents phase out.\nTemporal Firestorm deals 5 damage to each creature and each planeswalker.",
             "colours": [
@@ -15184,7 +15184,7 @@
         },
         {
             "id": "5eed1a87-045c-533b-9986-9a335f6b4105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644ec3b-fa6e-4642-8367-35a3ba1f88de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644ec3b-fa6e-4642-8367-35a3ba1f88de.jpg?1",
             "name": "Defiler of Vigor",
             "text": "Trample\nAs an additional cost to cast green permanent spells, you may pay 2 life. Those spells cost {G} less to cast if you paid life this way. This effect reduces only the amount of green mana you pay.\nWhenever you cast a green permanent spell, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -15221,7 +15221,7 @@
         },
         {
             "id": "261f1b2c-5655-56b2-b3e6-a7c54bb73573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2ff77-09ac-4833-9d3a-47bac7428086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2ff77-09ac-4833-9d3a-47bac7428086.jpg?1",
             "name": "Herd Migration",
             "text": "Domain \u2014 Create a 3/3 green Beast creature token for each basic land type among lands you control.\n{1}{G}, Discard Herd Migration: Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -15256,7 +15256,7 @@
         },
         {
             "id": "18b9b1b0-2770-5869-8005-2879d1022996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7bc1f4-a0f5-42ee-b9ee-499fed12f884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7bc1f4-a0f5-42ee-b9ee-499fed12f884.jpg?1",
             "name": "Leaf-Crowned Visionary",
             "text": "Other Elves you control get +1/+1.\nWhenever you cast an Elf spell, you may pay {G}. If you do, draw a card.",
             "colours": [
@@ -15293,7 +15293,7 @@
         },
         {
             "id": "be726bbe-560b-5a93-a130-656ae85cc22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8236d62a-bce3-4c5d-8224-f717188e34c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8236d62a-bce3-4c5d-8224-f717188e34c9.jpg?1",
             "name": "Llanowar Greenwidow",
             "text": "Reach, trample\nDomain \u2014 {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. tapped. It gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\" This ability costs {1} less to activate for each basic land type among lands you control.",
             "colours": [
@@ -15329,7 +15329,7 @@
         },
         {
             "id": "7c97dfc9-e16d-522c-99e3-875a9efb0b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdb1dfd-6394-414f-959e-9f129a3ab1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdb1dfd-6394-414f-959e-9f129a3ab1a1.jpg?1",
             "name": "Llanowar Loamspeaker",
             "text": "{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.",
             "colours": [
@@ -15367,7 +15367,7 @@
         },
         {
             "id": "3862bd72-18ae-5550-9955-d50e6bf50436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba11bcd6-7ce1-410e-95df-7ab63116503a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba11bcd6-7ce1-410e-95df-7ab63116503a.jpg?1",
             "name": "Quirion Beastcaller",
             "text": "Whenever you cast a creature spell, put a +1/+1 counter on Quirion Beastcaller.\nWhen Quirion Beastcaller dies, distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on Quirion Beastcaller.",
             "colours": [
@@ -15404,7 +15404,7 @@
         },
         {
             "id": "4a4c94c5-bf23-550c-94ce-df7532213965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8efd65-65d0-47b9-beb3-dc895993af9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8efd65-65d0-47b9-beb3-dc895993af9a.jpg?1",
             "name": "Silverback Elder",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\n\u2022 You gain 4 life.",
             "colours": [
@@ -15441,7 +15441,7 @@
         },
         {
             "id": "d04fbd21-d864-522e-ace9-af2187f56a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2bdf21-fad4-4c86-ba74-d5d262e46228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2bdf21-fad4-4c86-ba74-d5d262e46228.jpg?1",
             "name": "Threats Undetected",
             "text": "Search your library for up to four creature cards with different powers and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest into your hand.",
             "colours": [
@@ -15475,7 +15475,7 @@
         },
         {
             "id": "678e2596-7734-5713-ba4d-755b0e987ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c569975-5b7c-448a-889e-877f28989642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c569975-5b7c-448a-889e-877f28989642.jpg?1",
             "name": "Urborg Lhurgoyf",
             "text": "Kicker {U} and/or {B}\nAs Urborg Lhurgoyf enters the battlefield, mill three cards for each time it was kicked.\nUrborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "7dcf51ec-945c-59c9-aa07-f208d12fb9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9fc6ee-2205-4f77-8e14-313bfbe68c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9fc6ee-2205-4f77-8e14-313bfbe68c1e.jpg?1",
             "name": "Plaza of Heroes",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a legendary spell.\n{T}: Add one mana of any color among legendary permanents you control.\n{3}, {T}, Exile Plaza of Heroes: Target legendary creature gains hexproof and indestructible until end of turn.",
             "colours": [],
@@ -15543,7 +15543,7 @@
         },
         {
             "id": "8db190e7-e731-5997-a999-dcfa2ee9e7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba2995e-f255-46da-abcf-9a6f3996edb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba2995e-f255-46da-abcf-9a6f3996edb1.jpg?1",
             "name": "Thran Portal",
             "text": "Thran Portal enters the battlefield tapped unless you control two or fewer other lands.\nAs Thran Portal enters the battlefield, choose a basic land type.\nThran Portal is the chosen type in addition to its other types.\nMana abilities of Thran Portal cost an additional 1 life to activate.",
             "colours": [],
@@ -15575,7 +15575,7 @@
         },
         {
             "id": "9d08f8c5-6c99-522a-8d01-318e6f5839d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6395960-c48a-4098-91da-4ccfeddbaace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6395960-c48a-4098-91da-4ccfeddbaace.jpg?1",
             "name": "Serra Redeemer",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, put two +1/+1 counters on that creature.",
             "colours": [
@@ -15612,7 +15612,7 @@
         },
         {
             "id": "9312aaa2-e439-50da-b77b-bdfbe6d64150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefb7a2-95f9-4aa7-b2ef-8b91c018c504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefb7a2-95f9-4aa7-b2ef-8b91c018c504.jpg?1",
             "name": "Cosmic Epiphany",
             "text": "Draw cards equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -15646,7 +15646,7 @@
         },
         {
             "id": "bea063ea-57d3-5987-a357-8f9152fcac4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038c02-d792-407d-8aa6-8d279009a1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038c02-d792-407d-8aa6-8d279009a1cb.jpg?1",
             "name": "Tyrannical Pitlord",
             "text": "Flying, trample\nAs Tyrannical Pitlord enters the battlefield, choose another creature you control.\nThe chosen creature gets +3/+3 and has flying.\nWhen Tyrannical Pitlord leaves the battlefield, sacrifice the chosen creature.",
             "colours": [
@@ -15682,7 +15682,7 @@
         },
         {
             "id": "2e5fe655-b8a4-5bc4-b55c-84eae66681f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2a8ebf-f882-43fa-9749-8b78fa7b5e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2a8ebf-f882-43fa-9749-8b78fa7b5e41.jpg?1",
             "name": "Ragefire Hellkite",
             "text": "Flying\nWhenever Ragefire Hellkite attacks, you may sacrifice another creature. If you do, Ragefire Hellkite gains double strike until end of turn.",
             "colours": [
@@ -15718,7 +15718,7 @@
         },
         {
             "id": "411ca805-9f0a-54f4-8873-5545ef62160f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df437db0-5f18-43ff-b0ff-e9cac4a6ee81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df437db0-5f18-43ff-b0ff-e9cac4a6ee81.jpg?1",
             "name": "Briar Hydra",
             "text": "Trample\nDomain \u2014 Whenever Briar Hydra deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -15755,7 +15755,7 @@
         },
         {
             "id": "28033089-b3df-5b42-b8c7-d8e494826e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a1c0d-23cf-472e-a6b3-fd0c3905b4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a1c0d-23cf-472e-a6b3-fd0c3905b4e4.jpg?1",
             "name": "Llanowar Loamspeaker",
             "text": "{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.",
             "colours": [
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "283b9728-31bf-58c9-924f-2159b6432943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b91c26-26f3-45d6-bf7d-35a2963dde37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b91c26-26f3-45d6-bf7d-35a2963dde37.jpg?1",
             "name": "Herd Migration",
             "text": "Domain \u2014 Create a 3/3 green Beast creature token for each basic land type among lands you control.\n{1}{G}, Discard Herd Migration: Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -15827,7 +15827,7 @@
         },
         {
             "id": "a1969fd4-9b68-5ecd-b88f-7160a13b89b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25a8991-99ac-4fc5-97e2-4631ff234f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25a8991-99ac-4fc5-97e2-4631ff234f65.jpg?1",
             "name": "Resolute Reinforcements",
             "text": "Flash\nWhen Resolute Reinforcements enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -15864,7 +15864,7 @@
         },
         {
             "id": "f4c62340-15ae-57b9-ba90-68dfdc787ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287e20f-a161-4522-8a72-3f2b914019b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287e20f-a161-4522-8a72-3f2b914019b5.jpg?1",
             "name": "Micromancer",
             "text": "When Micromancer enters the battlefield, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -15901,7 +15901,7 @@
         },
         {
             "id": "15ab83ab-fa9e-582c-acae-901793489f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fdde82-6c4d-4e34-a15c-9756c834e9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fdde82-6c4d-4e34-a15c-9756c834e9a0.jpg?1",
             "name": "Cut Down",
             "text": "Destroy target creature with total power and toughness 5 or less.",
             "colours": [
@@ -15935,7 +15935,7 @@
         },
         {
             "id": "6a54c835-305b-5c3d-91d6-41dbe9d953a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93d0972-4043-4d86-8707-9f9ec5b6e770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93d0972-4043-4d86-8707-9f9ec5b6e770.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -15969,7 +15969,7 @@
         },
         {
             "id": "5fc06110-46a0-58b9-8bd6-48effea0e022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ed86e0-91d9-4ba3-8fd4-0f27d3095412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ed86e0-91d9-4ba3-8fd4-0f27d3095412.jpg?1",
             "name": "Nishoba Brawler",
             "text": "Trample\nDomain \u2014 Nishoba Brawler's power is equal to the number of basic land types among lands you control.",
             "colours": [
@@ -16006,7 +16006,7 @@
         },
         {
             "id": "1a21a7f0-f5f6-5107-906b-5a33b9f5532e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df6603a-38c1-4d18-8b84-6211e9a7cc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df6603a-38c1-4d18-8b84-6211e9a7cc09.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "",
             "colours": [
@@ -16049,7 +16049,7 @@
         },
         {
             "id": "8685cc2b-7f3e-5f8c-abec-836cd70f21de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee7c1b3-36c3-4f81-a45d-f34331db5b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee7c1b3-36c3-4f81-a45d-f34331db5b18.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "",
             "colours": [
@@ -16091,7 +16091,7 @@
         },
         {
             "id": "01a47bde-4e4b-5439-abd8-fc553f88fe66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -16126,7 +16126,7 @@
         },
         {
             "id": "e1fe63ec-ea55-5052-a9ea-5517fa3c8ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3034f6-145f-4e60-9e55-c4054fd8e70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3034f6-145f-4e60-9e55-c4054fd8e70f.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16161,7 +16161,7 @@
         },
         {
             "id": "896fde15-0956-5a5c-94a9-575552322c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16196,7 +16196,7 @@
         },
         {
             "id": "d3eecb4c-1ec3-5770-893f-3e89c455ebe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b0257-2ca5-4015-9d63-d7cf6e87ab9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b0257-2ca5-4015-9d63-d7cf6e87ab9d.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16231,7 +16231,7 @@
         },
         {
             "id": "62ef67bc-de90-56b8-b9fe-8995539dd8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -16266,7 +16266,7 @@
         },
         {
             "id": "abbfb88b-cb12-5377-b069-0aee675281de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce95d5-2ae7-4bd9-92f4-1cb3bed5f733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce95d5-2ae7-4bd9-92f4-1cb3bed5f733.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16301,7 +16301,7 @@
         },
         {
             "id": "60caed98-acff-565f-903e-bd854e08b427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41933b2-a91f-4c43-8734-08fc3a392ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41933b2-a91f-4c43-8734-08fc3a392ac2.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16336,7 +16336,7 @@
         },
         {
             "id": "596bc1a1-147e-514e-ba92-0786ac7f334e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a7b17-a65a-4c37-bc2b-8be5ff8ce692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a7b17-a65a-4c37-bc2b-8be5ff8ce692.jpg?1",
             "name": "Phyrexian",
             "text": "",
             "colours": [
@@ -16371,7 +16371,7 @@
         },
         {
             "id": "d79f7166-316f-52a4-94ed-dad69841437f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -16406,7 +16406,7 @@
         },
         {
             "id": "b880b621-4914-5e0c-a12a-c98553bc464b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cae334-1e24-48a3-83a2-0a27bc9d3b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cae334-1e24-48a3-83a2-0a27bc9d3b29.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -16441,7 +16441,7 @@
         },
         {
             "id": "57889f36-37eb-5bda-af92-8ac1cfd6a169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b2ff6f-d55a-4fa2-86be-e2e012267de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b2ff6f-d55a-4fa2-86be-e2e012267de4.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16476,7 +16476,7 @@
         },
         {
             "id": "2b1fa4b9-8203-524c-86b9-68b3cff120fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128511d0-bc4c-48d9-9e8e-9c7c945cfaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128511d0-bc4c-48d9-9e8e-9c7c945cfaeb.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16511,7 +16511,7 @@
         },
         {
             "id": "fc63ce2c-cc73-51d0-85b5-ce18e94ef10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "d8325e25-9412-589b-a884-ca3b1cb62825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388180bd-cc96-4b18-9ddd-18a3f7e06282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388180bd-cc96-4b18-9ddd-18a3f7e06282.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -16581,7 +16581,7 @@
         },
         {
             "id": "91e766ed-eeec-5fa4-a8db-2ae498ab82c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg?1",
             "name": "Badger",
             "text": "",
             "colours": [
@@ -16616,7 +16616,7 @@
         },
         {
             "id": "7b6f1fd3-ee74-5480-a579-c09bef46e563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/591cb5b2-6394-4c1a-b227-5c32e633b493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/591cb5b2-6394-4c1a-b227-5c32e633b493.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -16651,7 +16651,7 @@
         },
         {
             "id": "4603b26d-cc27-5fee-94af-ae77d0b684b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg?1",
             "name": "Cat Warrior",
             "text": "",
             "colours": [
@@ -16687,7 +16687,7 @@
         },
         {
             "id": "61621bc7-618c-5ec0-94f6-2f6fb504a640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a07153-9eb6-4366-aa09-ebe9b4868e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a07153-9eb6-4366-aa09-ebe9b4868e7f.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -16722,7 +16722,7 @@
         },
         {
             "id": "70231ceb-8114-5502-8272-aa843ca2f40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -16757,7 +16757,7 @@
         },
         {
             "id": "a0e3ae99-0632-5c22-870d-2944507a50bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg?1",
             "name": "Sand Warrior",
             "text": "",
             "colours": [
@@ -16797,7 +16797,7 @@
         },
         {
             "id": "1195abea-6b63-5e95-83df-0cfd89762e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg?1",
             "name": "Stangg Twin",
             "text": "",
             "colours": [
@@ -16837,7 +16837,7 @@
         },
         {
             "id": "ffd5d2be-da01-5e70-b2d5-4b607cd354ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63d3174-75af-4dfa-b2f9-c4330c755af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63d3174-75af-4dfa-b2f9-c4330c755af1.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -16869,7 +16869,7 @@
         },
         {
             "id": "f1369647-2863-5cc6-91b4-00d9c735e19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447af615-1e59-471f-886b-bf46007a938d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447af615-1e59-471f-886b-bf46007a938d.jpg?1",
             "name": "Powerstone",
             "text": "",
             "colours": [],
@@ -16900,7 +16900,7 @@
         },
         {
             "id": "6b012b36-d1d6-5d9d-a3f3-1f0ca2df04c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -16931,7 +16931,7 @@
         },
         {
             "id": "d98a1805-56ab-5ef2-b496-391468d5ff21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee46d-b2f4-4710-bf7d-1d7a5ec0aefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee46d-b2f4-4710-bf7d-1d7a5ec0aefe.jpg?1",
             "name": "Ajani, Sleeper Agent Emblem",
             "text": "",
             "colours": [],
@@ -16959,7 +16959,7 @@
         },
         {
             "id": "05d59711-8773-5466-b66a-902cf865cbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a5830-d7a0-46c9-98c0-4d1dfc3ebc8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a5830-d7a0-46c9-98c0-4d1dfc3ebc8c.jpg?1",
             "name": "Jaya, Fiery Negotiator Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/DOM.json
+++ b/Assets/Resources/Sets/DOM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2888d633-3d08-59d5-981f-5ec5f010d1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a3d9e8-8597-498b-869c-cff79e0df516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a3d9e8-8597-498b-869c-cff79e0df516.jpg?1",
             "name": "Karn, Scion of Urza",
             "text": "+1: Reveal the top two cards of your library. An opponent chooses one of them. Put that card into your hand and exile the other with a silver counter on it.\n\u22121: Put a card you own with a silver counter on it from exile into your hand.\n\u22122: Create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "99057a3d-ca34-5b1d-b3f6-bdb870072010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8817-ca3c-44ba-92f2-e9d6294cd25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8817-ca3c-44ba-92f2-e9d6294cd25d.jpg?1",
             "name": "Adamant Will",
             "text": "Target creature gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "2c49879f-3a5c-5b8b-a6c1-e5c47a511912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf49e5bf-07fb-44b0-8e74-092088d9019f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf49e5bf-07fb-44b0-8e74-092088d9019f.jpg?1",
             "name": "Aven Sentry",
             "text": "Flying",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "f4eef77c-8c21-5aca-8fcc-05652e91df41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a9594e-edc9-42b2-ba8a-8298da9441fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a9594e-edc9-42b2-ba8a-8298da9441fb.jpg?1",
             "name": "Baird, Steward of Argive",
             "text": "Vigilance\nCreatures can't attack you or a planeswalker you control unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "9e80a9a7-607b-5d98-8819-f73b3c6f88c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a5ecf1-2063-4cb3-a4ab-a0601b28256a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a5ecf1-2063-4cb3-a4ab-a0601b28256a.jpg?1",
             "name": "Benalish Honor Guard",
             "text": "Benalish Honor Guard gets +1/+0 for each legendary creature you control.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "08aa3178-c059-5475-8b09-06733db40d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd1a7fc-5dbd-4ed2-9b02-9fd5c55bb629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd1a7fc-5dbd-4ed2-9b02-9fd5c55bb629.jpg?1",
             "name": "Benalish Marshal",
             "text": "Other creatures you control get +1/+1.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "95248d10-08a3-5713-b2ec-122b7fde43ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3eb65-0f52-49c1-8243-14ce05de9f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3eb65-0f52-49c1-8243-14ce05de9f3b.jpg?1",
             "name": "Blessed Light",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "9af8e98b-e576-57ba-8d9f-3f1859d3fe2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d10fa-d42d-4867-9e2f-fc8de582d5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d10fa-d42d-4867-9e2f-fc8de582d5e7.jpg?1",
             "name": "Board the Weatherlight",
             "text": "Look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "13156d51-08a9-560c-840f-438187e9897f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978a719-b159-4155-88d9-9c0b15183037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978a719-b159-4155-88d9-9c0b15183037.jpg?1",
             "name": "Call the Cavalry",
             "text": "Create two 2/2 white Knight creature tokens with vigilance.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "55e5a91d-633f-500e-a9dc-b0e684884b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1",
             "name": "Charge",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "36e15cb4-e115-55fd-80f9-bc5a2935f421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5881ab3-566b-4999-997e-cd5ecb84282b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5881ab3-566b-4999-997e-cd5ecb84282b.jpg?1",
             "name": "D'Avenant Trapper",
             "text": "Whenever you cast a historic spell, tap target creature an opponent controls. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "865d468e-2035-5146-b547-639683002706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a2b53c-0bf2-4d3d-91c2-57a484ae4f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a2b53c-0bf2-4d3d-91c2-57a484ae4f6b.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "acd90712-69b1-5c9c-85e4-47a1333a3f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306ebfe1-428d-4f38-950e-b72a44262c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306ebfe1-428d-4f38-950e-b72a44262c25.jpg?1",
             "name": "Daring Archaeologist",
             "text": "When Daring Archaeologist enters the battlefield, you may return target artifact card from your graveyard to your hand.\nWhenever you cast a historic spell, put a +1/+1 counter on Daring Archaeologist. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "01f8b96f-38df-5503-8260-83f7eb92071a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f82012-5c33-47bc-a3c8-56ae2eea1fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f82012-5c33-47bc-a3c8-56ae2eea1fb9.jpg?1",
             "name": "Dauntless Bodyguard",
             "text": "As Dauntless Bodyguard enters the battlefield, choose another creature you control.\nSacrifice Dauntless Bodyguard: The chosen creature gains indestructible until end of turn.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "bb4bf965-1b69-5d15-b158-ffe9dc5e74b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca49646-970a-4b91-9cae-5dbdef9f7727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca49646-970a-4b91-9cae-5dbdef9f7727.jpg?1",
             "name": "Dub",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has first strike, and is a Knight in addition to its other types.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "f605ad25-b192-53d6-ba21-4841687a658e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f57a57-8ce8-4d01-9b91-99ec0623d1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f57a57-8ce8-4d01-9b91-99ec0623d1e9.jpg?1",
             "name": "Evra, Halcyon Witness",
             "text": "Lifelink\n{4}: Exchange your life total with Evra, Halcyon Witness's power.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "dca7a1de-09e8-5a71-8afa-55b9af000021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760ce08a-49d3-4cdf-bbe2-33dd8a6a7966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760ce08a-49d3-4cdf-bbe2-33dd8a6a7966.jpg?1",
             "name": "Excavation Elephant",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nWhen Excavation Elephant enters the battlefield, if it was kicked, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "63411faf-1a52-5f41-98fb-edc021c261f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a613a01-6145-4e34-987c-c9bdcb068370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a613a01-6145-4e34-987c-c9bdcb068370.jpg?1",
             "name": "Fall of the Thran",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy all lands.\nII, III \u2014 Each player returns two land cards from their graveyard to the battlefield.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "c31df3f9-5362-50c8-bc58-47b10b8eae6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg?1",
             "name": "Gideon's Reproach",
             "text": "Gideon's Reproach deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "ed58dc38-a96d-58cf-a4c9-d2198564d3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7512d31-dc35-4046-a1ba-49b74239c329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7512d31-dc35-4046-a1ba-49b74239c329.jpg?1",
             "name": "Healing Grace",
             "text": "Prevent the next 3 damage that would be dealt to any target this turn by a source of your choice. You gain 3 life.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "6baa61c2-ecc6-564b-a6cf-d1c44646fa0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d134385d-b01c-41c7-bb2d-30722b44dc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d134385d-b01c-41c7-bb2d-30722b44dc5a.jpg?1",
             "name": "History of Benalia",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a 2/2 white Knight creature token with vigilance.\nIII \u2014 Knights you control get +2/+1 until end of turn.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "d54faa21-61a3-5a42-8152-dc55123364e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe72ae-ea5c-4065-9f5b-3d931f72952d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe72ae-ea5c-4065-9f5b-3d931f72952d.jpg?1",
             "name": "Invoke the Divine",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "aaec2e0e-9257-5efb-8291-fad9f93bf4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbbddc0-f8b3-4255-bd82-d50f829ca009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbbddc0-f8b3-4255-bd82-d50f829ca009.jpg?1",
             "name": "Knight of Grace",
             "text": "First strike\nHexproof from black (This creature can't be the target of black spells or abilities your opponents control.)\nKnight of Grace gets +1/+0 as long as any player controls a black permanent.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "04d354cb-1190-5ac4-ac56-91f09c1d27cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c50c4b-a2c8-4cdc-a171-aa3ff9ef107f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c50c4b-a2c8-4cdc-a171-aa3ff9ef107f.jpg?1",
             "name": "Knight of New Benalia",
             "text": "",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "5086456d-1c92-518f-ac43-c4ef080a00bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3b6a8-3e4a-4e2b-900a-9a21fa0ced4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3b6a8-3e4a-4e2b-900a-9a21fa0ced4c.jpg?1",
             "name": "Kwende, Pride of Femeref",
             "text": "Double strike\nCreatures you control with first strike have double strike.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "1479ac5b-a67f-5816-8057-f6d79bb7e172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be6799-7b9d-44d4-84dc-2961692b5a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be6799-7b9d-44d4-84dc-2961692b5a85.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "f22cd70d-2155-5591-b52f-f3a9bef9e9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ed7b5-08ee-4d2c-9bf8-03a1b85b635a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ed7b5-08ee-4d2c-9bf8-03a1b85b635a.jpg?1",
             "name": "Mesa Unicorn",
             "text": "Lifelink",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "b2b30365-05ad-5ec5-8df7-d17667c474e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063b8d2c-862b-458e-8f7c-c3e29a98c234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063b8d2c-862b-458e-8f7c-c3e29a98c234.jpg?1",
             "name": "On Serra's Wings",
             "text": "Enchant creature\nEnchanted creature is legendary, gets +1/+1, and has flying, vigilance, and lifelink.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "884271cd-5fd1-5ed8-9645-1f5345793c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35263639-f09d-429f-bd99-09cfdee668e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35263639-f09d-429f-bd99-09cfdee668e8.jpg?1",
             "name": "Pegasus Courser",
             "text": "Flying\nWhenever Pegasus Courser attacks, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "1d44410b-5606-549a-8811-55e7edeb1189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4795dd-75d4-4ce5-87e7-fe892616e42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4795dd-75d4-4ce5-87e7-fe892616e42e.jpg?1",
             "name": "Sanctum Spirit",
             "text": "Lifelink\nDiscard a historic card: Sanctum Spirit gains indestructible until end of turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "ef953c62-d00a-5836-9d67-e54ec4c87540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8d6588-671d-4eb3-874f-f7139da2e05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8d6588-671d-4eb3-874f-f7139da2e05a.jpg?1",
             "name": "Seal Away",
             "text": "Flash\nWhen Seal Away enters the battlefield, exile target tapped creature an opponent controls until Seal Away leaves the battlefield.",
             "colours": [
@@ -1061,7 +1061,7 @@
         },
         {
             "id": "af0e106c-4a7f-5d6a-8ebd-1bf3f82860f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f70b1ee-47b6-4904-850d-8ea8064bd27d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f70b1ee-47b6-4904-850d-8ea8064bd27d.jpg?1",
             "name": "Sergeant-at-Arms",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nWhen Sergeant-at-Arms enters the battlefield, if it was kicked, create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "47e840f4-c8b5-5ab0-afa7-35b5d0269131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56b9131-4f7e-4912-ba47-63ed82f21d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56b9131-4f7e-4912-ba47-63ed82f21d1b.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "f09365cb-8e43-5218-a517-fde47750df22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8359c3a8-d826-4326-a899-9f60ca774308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8359c3a8-d826-4326-a899-9f60ca774308.jpg?1",
             "name": "Serra Disciple",
             "text": "Flying, first strike\nWhenever you cast a historic spell, Serra Disciple gets +1/+1 until end of turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "95b8b513-12eb-54ca-9ed8-9a62ab5a2f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db827ee7-6f2e-4e10-aac0-120fc2b69fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db827ee7-6f2e-4e10-aac0-120fc2b69fbd.jpg?1",
             "name": "Shalai, Voice of Plenty",
             "text": "Flying\nYou, planeswalkers you control, and other creatures you control have hexproof.\n{4}{G}{G}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "fc7a869c-82b4-58b9-9b02-0d6b01b40e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d115b4-51d5-4898-b56c-2729aa428018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d115b4-51d5-4898-b56c-2729aa428018.jpg?1",
             "name": "Teshar, Ancestor's Apostle",
             "text": "Flying\nWhenever you cast a historic spell, return target creature card with converted mana cost 3 or less from your graveyard to the battlefield. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "45502d58-d89c-5bf4-9b4b-c01ff3b6605b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f957b353-7765-4c16-9645-d41000154130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f957b353-7765-4c16-9645-d41000154130.jpg?1",
             "name": "Tragic Poet",
             "text": "{T}, Sacrifice Tragic Poet: Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "dcec35ca-747c-5b62-b2eb-00b8eb5b5b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416fae7-46a0-4048-b969-9cf95bac09db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416fae7-46a0-4048-b969-9cf95bac09db.jpg?1",
             "name": "Triumph of Gerrard",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put a +1/+1 counter on target creature you control with the greatest power.\nIII \u2014 Target creature you control with the greatest power gains flying, first strike, and lifelink until end of turn.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "ae09affb-34a1-5759-b960-2deda05b540e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b50a96-6221-44f0-b54a-76076621047e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b50a96-6221-44f0-b54a-76076621047e.jpg?1",
             "name": "Urza's Ruinous Blast",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nExile all nonland permanents that aren't legendary.",
             "colours": [
@@ -1341,7 +1341,7 @@
         },
         {
             "id": "40ea994b-f38a-51e9-8099-d6dace098ef8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bacb12-da46-4b00-804f-9ff6bff452bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bacb12-da46-4b00-804f-9ff6bff452bc.jpg?1",
             "name": "Academy Drake",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nFlying\nIf Academy Drake was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -1375,7 +1375,7 @@
         },
         {
             "id": "724a8e50-193c-5308-9c54-a12eabf81d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46a65e0-66a3-4896-8acc-0ad5e9927c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46a65e0-66a3-4896-8acc-0ad5e9927c40.jpg?1",
             "name": "Academy Journeymage",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nWhen Academy Journeymage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "6378d4a2-16bc-54c5-b81f-2c242a4e0720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda670a-00a7-419c-b4b5-bfdb323f006d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda670a-00a7-419c-b4b5-bfdb323f006d.jpg?1",
             "name": "The Antiquities War",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Look at the top five cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nIII \u2014 Artifacts you control become artifact creatures with base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "00e8e34a-6d00-5beb-b851-3b584710edaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fbb1c0-ba57-4a5a-8ad6-77fbc6aeeec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fbb1c0-ba57-4a5a-8ad6-77fbc6aeeec9.jpg?1",
             "name": "Arcane Flight",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "5f877fe0-cc63-5736-a5f1-f5eb4153572f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadf867-b999-49b2-88d8-91da975a3cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadf867-b999-49b2-88d8-91da975a3cc5.jpg?1",
             "name": "Artificer's Assistant",
             "text": "Flying\nWhenever you cast a historic spell, scry 1. (Artifacts, legendaries, and Sagas are historic. To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -1512,7 +1512,7 @@
         },
         {
             "id": "7c3df55e-9dc6-5ad3-8799-0bb92d8aac90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88858285-23ac-4d7e-b8dd-a20982d95a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88858285-23ac-4d7e-b8dd-a20982d95a2d.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "16241138-6d2a-52a1-8e04-2e76738c6bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab830392-4d7e-4b45-93cf-35ed1e935228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab830392-4d7e-4b45-93cf-35ed1e935228.jpg?1",
             "name": "Blink of an Eye",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "fba3b30f-97e7-557d-ab06-ce6041e77d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85a696-fa1a-4e05-b0aa-79b3381e849a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85a696-fa1a-4e05-b0aa-79b3381e849a.jpg?1",
             "name": "Cloudreader Sphinx",
             "text": "Flying\nWhen Cloudreader Sphinx enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "ac5a47b6-c8fa-593c-b126-2ed5f602ceff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339549-4325-40c6-adde-0cd31bb738e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339549-4325-40c6-adde-0cd31bb738e0.jpg?1",
             "name": "Cold-Water Snapper",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "a310d5f8-2654-5f35-8716-c8ca9f718d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cc417f-0ea7-47a8-b7d0-aa8d20168faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cc417f-0ea7-47a8-b7d0-aa8d20168faf.jpg?1",
             "name": "Curator's Ward",
             "text": "Enchant permanent\nEnchanted permanent has hexproof.\nWhen enchanted permanent leaves the battlefield, if it was historic, draw two cards. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "7c21710d-8fd8-51c4-a667-c1f35ae14311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51765d87-e842-4d84-aaf0-998737fe754c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51765d87-e842-4d84-aaf0-998737fe754c.jpg?1",
             "name": "Deep Freeze",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/4, has defender, loses all other abilities, and is a blue Wall in addition to its other colors and types.",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "6f793e92-2619-58f7-aac6-2913f079c461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65212970-770e-4110-aa86-c89128688867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65212970-770e-4110-aa86-c89128688867.jpg?1",
             "name": "Diligent Excavator",
             "text": "Whenever you cast a historic spell, target player puts the top two cards of their library into their graveyard. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "8806aa3a-befc-59b3-a354-696bdf9952bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f9daf0-dbfd-45b2-be35-9c2de9d1a56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f9daf0-dbfd-45b2-be35-9c2de9d1a56e.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "ff1ebedb-8150-5e44-8ad0-ebd507596a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7aa6-1897-4657-b3a6-991b05f7ea5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7aa6-1897-4657-b3a6-991b05f7ea5e.jpg?1",
             "name": "Homarid Explorer",
             "text": "When Homarid Explorer enters the battlefield, target player puts the top four cards of their library into their graveyard.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "aaf1bab8-c53a-5892-adfd-11be4c854ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72bf6b4-ac70-4be0-86de-cb3c47244dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72bf6b4-ac70-4be0-86de-cb3c47244dbc.jpg?1",
             "name": "In Bolas's Clutches",
             "text": "Enchant permanent\nYou control enchanted permanent.\nEnchanted permanent is legendary.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "ea29573e-bca1-5a4d-a017-000533b20f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a64c1a4-02ce-49d2-97f2-970b8c33672d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a64c1a4-02ce-49d2-97f2-970b8c33672d.jpg?1",
             "name": "Karn's Temporal Sundering",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nTarget player takes an extra turn after this one. Return up to one target nonland permanent to its owner's hand. Exile Karn's Temporal Sundering.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "d8978b89-416c-5463-b566-6e37ec0f406e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2f2b-7b58-47b6-b00c-8616f981e3a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2f2b-7b58-47b6-b00c-8616f981e3a3.jpg?1",
             "name": "Merfolk Trickster",
             "text": "Flash\nWhen Merfolk Trickster enters the battlefield, tap target creature an opponent controls. It loses all abilities until end of turn.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "88082e57-df1a-51bd-ab3e-0324c54c5d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c68954c-4bab-4973-9819-ecd084438303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c68954c-4bab-4973-9819-ecd084438303.jpg?1",
             "name": "The Mirari Conjecture",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Return target instant card from your graveyard to your hand.\nII \u2014 Return target sorcery card from your graveyard to your hand.\nIII \u2014 Until end of turn, whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "28ad8a7b-d96f-56de-8967-0a9bed57591e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f41175-880f-491e-96c3-bf52f3c0db5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f41175-880f-491e-96c3-bf52f3c0db5d.jpg?1",
             "name": "Naban, Dean of Iteration",
             "text": "If a Wizard entering the battlefield under your control causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "8de751f2-d146-5ec1-bcce-408ab15f430a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57168712-73dc-411c-9d13-f0c43202cb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57168712-73dc-411c-9d13-f0c43202cb9a.jpg?1",
             "name": "Naru Meha, Master Wizard",
             "text": "Flash\nWhen Naru Meha, Master Wizard enters the battlefield, copy target instant or sorcery spell you control. You may choose new targets for the copy.\nOther Wizards you control get +1/+1.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "9b69bb58-b2f0-5bf8-8f93-4ddf009861bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f2e4d0-effd-4e83-b7aa-1a0d8f120951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f2e4d0-effd-4e83-b7aa-1a0d8f120951.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "3e649656-3212-59f3-9e40-fa91cd09758a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a92ee-2b20-4299-84b2-b4963f4a42a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a92ee-2b20-4299-84b2-b4963f4a42a1.jpg?1",
             "name": "Precognition Field",
             "text": "You may look at the top card of your library. (You may do this at any time.)\nYou may cast the top card of your library if it's an instant or sorcery card.\n{3}: Exile the top card of your library.",
             "colours": [
@@ -2091,7 +2091,7 @@
         },
         {
             "id": "a78d8548-93c8-5d32-9689-a42537b0a371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5993e-f619-4de5-aa94-7569b0efe415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5993e-f619-4de5-aa94-7569b0efe415.jpg?1",
             "name": "Relic Runner",
             "text": "Relic Runner can't be blocked if you've cast a historic spell this turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "31a9a3f7-982a-52ce-bcc0-d4ce47042215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08050607-b558-4f99-b716-bbbab54e9b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08050607-b558-4f99-b716-bbbab54e9b68.jpg?1",
             "name": "Rescue",
             "text": "Return target permanent you control to its owner's hand.",
             "colours": [
@@ -2158,7 +2158,7 @@
         },
         {
             "id": "167f3d60-9168-510e-9585-e3627e67008a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7395b77-f7f7-404b-8639-9db6dc28d558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7395b77-f7f7-404b-8639-9db6dc28d558.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "{T}, Sacrifice an artifact: Draw a card.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "feb7d3fd-a421-5807-802b-800e7bb133a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da73230-2562-4e7d-9f03-b0508b9a31e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da73230-2562-4e7d-9f03-b0508b9a31e0.jpg?1",
             "name": "Sentinel of the Pearl Trident",
             "text": "Flash\nWhen Sentinel of the Pearl Trident enters the battlefield, you may exile target historic permanent you control. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "ec9b2d7a-bbc8-5238-b488-9da3c259d9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b4581-fe4a-498d-af58-c1e453235df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b4581-fe4a-498d-af58-c1e453235df8.jpg?1",
             "name": "Slinn Voda, the Rising Deep",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nWhen Slinn Voda, the Rising Deep enters the battlefield, if it was kicked, return all creatures to their owners' hands except for Merfolk, Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "e3f4d769-3769-5d30-aee8-37578ea0433b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81739a5-35a7-4812-a7af-e1951bf5579c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81739a5-35a7-4812-a7af-e1951bf5579c.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays {X}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "311f4fec-cf9e-5c1d-a3f9-b6f6579869bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc883b-3aea-4d0b-ae0f-00d4a08c47c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc883b-3aea-4d0b-ae0f-00d4a08c47c1.jpg?1",
             "name": "Tempest Djinn",
             "text": "Flying\nTempest Djinn gets +1/+0 for each basic Island you control.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "e3e15af8-c559-548a-b89d-1c40e6aa6a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16185c50-f7b8-4cea-a129-dfad8e9df781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16185c50-f7b8-4cea-a129-dfad8e9df781.jpg?1",
             "name": "Tetsuko Umezawa, Fugitive",
             "text": "Creatures you control with power or toughness 1 or less can't be blocked.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "788749aa-c94b-5420-ad28-8fb062d873d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcd0674-68b9-41ca-ab46-a73dfcbe4149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcd0674-68b9-41ca-ab46-a73dfcbe4149.jpg?1",
             "name": "Time of Ice",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Tap target creature an opponent controls. It doesn't untap during its controller's untap step for as long as you control Time of Ice.\nIII \u2014 Return all tapped creatures to their owners' hands.",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "0d2d9537-01ac-5965-93ee-51058589ac2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d89839-60d7-4de2-a78a-1afdcc21c053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d89839-60d7-4de2-a78a-1afdcc21c053.jpg?1",
             "name": "Tolarian Scholar",
             "text": "",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "9dee28a0-cd63-5bd5-915c-b410e6ab9e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97da6607-9131-4f8b-8af3-63439a59b78b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97da6607-9131-4f8b-8af3-63439a59b78b.jpg?1",
             "name": "Unwind",
             "text": "Counter target noncreature spell. Untap up to three lands.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "64c6aa6c-d14c-5945-93a9-4baf45e88dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7795fb-2995-4dff-bc1b-7809bfbb1657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7795fb-2995-4dff-bc1b-7809bfbb1657.jpg?1",
             "name": "Vodalian Arcanist",
             "text": "{T}: Add {C}. Spend this mana only to cast an instant or sorcery spell.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "1b5f754a-e0a1-5fad-8db0-1a02f3e73bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2359aa-9230-4519-b12e-ec395a8dd2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2359aa-9230-4519-b12e-ec395a8dd2a0.jpg?1",
             "name": "Weight of Memory",
             "text": "Draw three cards. Target player puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "234ff821-6775-5639-9ef4-959d95ddeddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae30b7d-9306-46ef-adea-c4057f59c9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae30b7d-9306-46ef-adea-c4057f59c9c1.jpg?1",
             "name": "Wizard's Retort",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nCounter target spell.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "5bb2dcfc-5277-570c-99e9-6f0d69ad0f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ea0c1-cd97-4160-87df-646ad763f5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ea0c1-cd97-4160-87df-646ad763f5fc.jpg?1",
             "name": "Zahid, Djinn of the Lamp",
             "text": "You may pay {3}{U} and tap an untapped artifact you control rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "a85906bb-9288-50fb-93d3-cc719240e0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224940c-d87c-4317-9ca3-b704ef894a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224940c-d87c-4317-9ca3-b704ef894a7b.jpg?1",
             "name": "Blessing of Belzenlok",
             "text": "Target creature gets +2/+1 until end of turn. If it's legendary, it also gains lifelink until end of turn.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "810f1fff-568d-5583-adeb-4a0c38e0271f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d218d2a2-bb5d-4ea8-a131-341c574410b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d218d2a2-bb5d-4ea8-a131-341c574410b2.jpg?1",
             "name": "Cabal Evangel",
             "text": "",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "c9377e57-3a3f-5aae-8520-d1ca6fb809bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cff2cb9-f4e6-4fee-94ef-ad11e24525c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cff2cb9-f4e6-4fee-94ef-ad11e24525c1.jpg?1",
             "name": "Cabal Paladin",
             "text": "Whenever you cast a historic spell, Cabal Paladin deals 2 damage to each opponent. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "50f38924-adbf-5f22-b73c-7aaed4d93201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e23ee25-2005-4e81-a807-f52c0dbfb192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e23ee25-2005-4e81-a807-f52c0dbfb192.jpg?1",
             "name": "Caligo Skin-Witch",
             "text": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nWhen Caligo Skin-Witch enters the battlefield, if it was kicked, each opponent discards two cards.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "22926bdb-d96e-5947-aa15-47b423d260b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116ce944-6871-4f51-a889-d9c4a5d7cff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116ce944-6871-4f51-a889-d9c4a5d7cff2.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -2772,7 +2772,7 @@
         },
         {
             "id": "3a0aeb64-f0fb-5cc8-a165-604abd522208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42beafb-2fba-482c-a86a-7d668fa7cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42beafb-2fba-482c-a86a-7d668fa7cb4b.jpg?1",
             "name": "Chainer's Torment",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Chainer's Torment deals 2 damage to each opponent and you gain 2 life.\nIII \u2014 Create an X/X black Nightmare Horror creature token, where X is half your life total, rounded up. It deals X damage to you.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "dfbf3e9e-23b9-51fb-bfec-253b91173a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cbedc6-482e-42de-b310-22d3a955ad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cbedc6-482e-42de-b310-22d3a955ad7e.jpg?1",
             "name": "Dark Bargain",
             "text": "Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard. Dark Bargain deals 2 damage to you.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "97687f1e-d093-5245-8b18-510dea5e0e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236ead00-d43e-4079-b74d-09be9875fd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236ead00-d43e-4079-b74d-09be9875fd2d.jpg?1",
             "name": "Deathbloom Thallid",
             "text": "When Deathbloom Thallid dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "5e1aad8d-a43d-53c8-ac33-bef7990a95dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09950456-09d6-4675-9995-0dc540ddb6e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09950456-09d6-4675-9995-0dc540ddb6e4.jpg?1",
             "name": "Demonic Vigor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nWhen enchanted creature dies, return that card to its owner's hand.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "196633b8-161d-5e23-82df-441d9c5e63ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4dbe8-15fa-467f-9366-66382b192113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4dbe8-15fa-467f-9366-66382b192113.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "Flying, trample\nWhen Demonlord Belzenlok enters the battlefield, exile cards from the top of your library until you exile a nonland card, then put that card into your hand. If the card's converted mana cost is 4 or greater, repeat this process. Demonlord Belzenlok deals 1 damage to you for each card put into your hand this way.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "18a355bc-e825-5aa7-9709-5da60dd2d554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6619810-7933-4844-8556-2a575ed7f18a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6619810-7933-4844-8556-2a575ed7f18a.jpg?1",
             "name": "Divest",
             "text": "Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "d35e061a-bb4e-5d82-9f27-f35eec23a3f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b8b1d7-9d2b-4943-bb3b-238a6333ce93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b8b1d7-9d2b-4943-bb3b-238a6333ce93.jpg?1",
             "name": "Dread Shade",
             "text": "{B}: Dread Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "c6c86e6e-3d9c-5478-a9a3-d0c3583054d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9764a718-1748-4c2a-925c-370e22003b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9764a718-1748-4c2a-925c-370e22003b62.jpg?1",
             "name": "Drudge Sentinel",
             "text": "{3}: Tap Drudge Sentinel. It gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "049e434b-36f8-580f-8116-96bac5f14729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8318f40-ecd5-429e-8fe2-febf31f64841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8318f40-ecd5-429e-8fe2-febf31f64841.jpg?1",
             "name": "The Eldest Reborn",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each opponent sacrifices a creature or planeswalker.\nII \u2014 Each opponent discards a card.\nIII \u2014 Put target creature or planeswalker card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "715fa7f1-0987-55c2-8158-0ea9befbd13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ba90b8-3a30-4058-b8d3-72900b1f4fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ba90b8-3a30-4058-b8d3-72900b1f4fe0.jpg?1",
             "name": "Eviscerate",
             "text": "Destroy target creature.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "3c138e9b-68a0-531d-baeb-0fb93b56625e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3292e262-4409-4f31-9de2-a232817a0734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3292e262-4409-4f31-9de2-a232817a0734.jpg?1",
             "name": "Feral Abomination",
             "text": "Deathtouch",
             "colours": [
@@ -3144,7 +3144,7 @@
         },
         {
             "id": "a130d30d-3309-5c78-9347-ede28221ee1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8803f6-9efa-4323-b8c5-29bdd5a48f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8803f6-9efa-4323-b8c5-29bdd5a48f9a.jpg?1",
             "name": "Final Parting",
             "text": "Search your library for two cards. Put one into your hand and the other into your graveyard. Then shuffle your library.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "45e81e5c-e850-5d6d-9c15-4f92206a4f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6baa5-666d-40b0-82e8-b0df10ff3cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6baa5-666d-40b0-82e8-b0df10ff3cdd.jpg?1",
             "name": "Fungal Infection",
             "text": "Target creature gets -1/-1 until end of turn. Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -3208,7 +3208,7 @@
         },
         {
             "id": "e6987065-ae64-5b6c-a4ed-4f94bd196c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed6d088-db82-4648-a109-0e3fa1421847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed6d088-db82-4648-a109-0e3fa1421847.jpg?1",
             "name": "Josu Vess, Lich Knight",
             "text": "Kicker {5}{B} (You may pay an additional {5}{B} as you cast this spell.)\nMenace\nWhen Josu Vess, Lich Knight enters the battlefield, if it was kicked, create eight 2/2 black Zombie Knight creature tokens with menace.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "0ede6c77-0b09-5fc7-924a-d1ffb34ee0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff7077-496b-46ca-b9d7-a8c1772f9a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff7077-496b-46ca-b9d7-a8c1772f9a91.jpg?1",
             "name": "Kazarov, Sengir Pureblood",
             "text": "Flying\nWhenever a creature an opponent controls is dealt damage, put a +1/+1 counter on Kazarov, Sengir Pureblood.\n{3}{R}: Kazarov deals 2 damage to target creature.",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "c4466355-75ac-5fb7-a52e-8342c475e554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45266f0-eb4f-4a06-bc64-8c2d774b4cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45266f0-eb4f-4a06-bc64-8c2d774b4cc5.jpg?1",
             "name": "Knight of Malice",
             "text": "First strike\nHexproof from white (This creature can't be the target of white spells or abilities your opponents control.)\nKnight of Malice gets +1/+0 as long as any player controls a white permanent.",
             "colours": [
@@ -3317,7 +3317,7 @@
         },
         {
             "id": "7f69ca3d-0276-53ab-a951-1e1648f6faaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f4c9cb-f364-4556-8673-4b19d52a2cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f4c9cb-f364-4556-8673-4b19d52a2cff.jpg?1",
             "name": "Lich's Mastery",
             "text": "Hexproof\nYou can't lose the game.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, for each 1 life you lost, exile a permanent you control or a card from your hand or graveyard.\nWhen Lich's Mastery leaves the battlefield, you lose the game.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "de2bc0fb-2248-56a6-9112-c8cfc817db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316239e-8fe6-467f-87e6-a3f4d19b860e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316239e-8fe6-467f-87e6-a3f4d19b860e.jpg?1",
             "name": "Lingering Phantom",
             "text": "Whenever you cast a historic spell, you may pay {B}. If you do, return Lingering Phantom from your graveyard to your hand. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "0bf538ed-8f69-5b3c-9fbd-dff7311ee4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3423d7-cb81-47bf-b9a6-a279ba6cedf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3423d7-cb81-47bf-b9a6-a279ba6cedf4.jpg?1",
             "name": "Phyrexian Scriptures",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Put a +1/+1 counter on up to one target creature. That creature becomes an artifact in addition to its other types.\nII \u2014 Destroy all nonartifact creatures.\nIII \u2014 Exile all cards from all opponents' graveyards.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "a48fd664-d71c-59d0-8a83-373d62905d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f618e07-f06f-45d2-8512-e6cef88c0434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f618e07-f06f-45d2-8512-e6cef88c0434.jpg?1",
             "name": "Rat Colony",
             "text": "Rat Colony gets +1/+0 for each other Rat you control.\nA deck can have any number of cards named Rat Colony.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "9d99018f-d158-5672-a110-d2c33ef34787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed7cca3-79be-44ca-bf10-2ae1c0835ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed7cca3-79be-44ca-bf10-2ae1c0835ed1.jpg?1",
             "name": "Rite of Belzenlok",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create two 0/1 black Cleric creature tokens.\nIII \u2014 Create a 6/6 black Demon creature token with flying, trample, and \"At the beginning of your upkeep, sacrifice another creature. If you can't, this creature deals 6 damage to you.\"",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "7ce557c0-4b17-54b3-819d-38f398330b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b18558f-6b40-4d1d-859a-3ba68950f064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b18558f-6b40-4d1d-859a-3ba68950f064.jpg?1",
             "name": "Settle the Score",
             "text": "Exile target creature. Put two loyalty counters on a planeswalker you control.",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "e6f697cc-1e44-5433-bca3-91769e4aa3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347060c0-fef7-45da-b42e-8e11051b2c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347060c0-fef7-45da-b42e-8e11051b2c69.jpg?1",
             "name": "Soul Salvage",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3551,7 +3551,7 @@
         },
         {
             "id": "be66609b-c32b-5af0-8c09-20837b12573e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3fcc43-839b-48c1-91e3-7cc80d8c7f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3fcc43-839b-48c1-91e3-7cc80d8c7f9a.jpg?1",
             "name": "Stronghold Confessor",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nMenace (This creature can't be blocked except by two or more creatures.)\nIf Stronghold Confessor was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "0990d6ff-1bf3-5685-979e-4bf064983505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b35391-f1dc-434b-b581-ca6cb6f3439f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b35391-f1dc-434b-b581-ca6cb6f3439f.jpg?1",
             "name": "Thallid Omnivore",
             "text": "{1}, Sacrifice another creature: Thallid Omnivore gets +2/+2 until end of turn. If a Saproling was sacrificed this way, you gain 2 life.",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "583da2fb-798c-59e5-8160-6b8beced5b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204173b6-ae51-49ca-bd67-0703e882bf9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204173b6-ae51-49ca-bd67-0703e882bf9e.jpg?1",
             "name": "Thallid Soothsayer",
             "text": "{2}, Sacrifice a creature: Draw a card.",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "02445867-2995-556f-badd-9155dba5a671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab46d5c-95dd-47a0-9f96-dde07d2f8b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab46d5c-95dd-47a0-9f96-dde07d2f8b81.jpg?1",
             "name": "Torgaar, Famine Incarnate",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of creatures. This spell costs {2} less to cast for each creature sacrificed this way.\nWhen Torgaar, Famine Incarnate enters the battlefield, up to one target player's life total becomes half their starting life total, rounded down.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "64874af5-6870-5f5a-8431-d16c91556ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8652fb7-1bce-44ee-b75e-4c773ff8fdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8652fb7-1bce-44ee-b75e-4c773ff8fdb3.jpg?1",
             "name": "Urgoros, the Empty One",
             "text": "Flying\nWhenever Urgoros, the Empty One deals combat damage to a player, that player discards a card at random. If the player can't, you draw a card.",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "99201966-a64e-5358-9f28-895d073cb893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaed7828-57c1-4ad3-a91b-209c66f0876b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaed7828-57c1-4ad3-a91b-209c66f0876b.jpg?1",
             "name": "Vicious Offering",
             "text": "Kicker\u2014\nSacrifice a creature. (You may sacrifice a creature in addition to any other costs as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -5/-5 until end of turn instead.",
             "colours": [
@@ -3758,7 +3758,7 @@
         },
         {
             "id": "4ddaf474-149a-513e-b296-9773acc6e26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0647feeb-ad7a-40c7-830f-f307ba8339ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0647feeb-ad7a-40c7-830f-f307ba8339ad.jpg?1",
             "name": "Whisper, Blood Liturgist",
             "text": "{T}, Sacrifice two creatures: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "9ae92f82-607e-566e-a798-ceb5d60b4891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835285e-96d9-4574-a497-3b612cae8e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835285e-96d9-4574-a497-3b612cae8e22.jpg?1",
             "name": "Windgrace Acolyte",
             "text": "Flying\nWhen Windgrace Acolyte enters the battlefield, put the top three cards of your library into your graveyard and you gain 3 life.",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "dbb7838c-60bf-5231-b6ba-73e2873656c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645cfc1b-76f2-4823-9fb0-03cb009f8b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645cfc1b-76f2-4823-9fb0-03cb009f8b32.jpg?1",
             "name": "Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "72ba3b47-48f7-595b-be4d-404780fa4fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9794a7-caf5-40b9-8046-67823ff64a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9794a7-caf5-40b9-8046-67823ff64a2c.jpg?1",
             "name": "Yawgmoth's Vile Offering",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nPut up to one target creature or planeswalker card from a graveyard onto the battlefield under your control. Destroy up to one target creature or planeswalker. Exile Yawgmoth's Vile Offering.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "7802bf42-8bc0-5b33-b968-56d8c7afc6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31adbfd4-56aa-4137-aeba-8720233260be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31adbfd4-56aa-4137-aeba-8720233260be.jpg?1",
             "name": "Bloodstone Goblin",
             "text": "Whenever you cast a spell, if that spell was kicked, Bloodstone Goblin gets +1/+1 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "a21754c1-0f9b-5e2e-8bd7-270e3348f346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460fa161-362f-406d-9149-d412bc51836c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460fa161-362f-406d-9149-d412bc51836c.jpg?1",
             "name": "Champion of the Flame",
             "text": "Trample\nChampion of the Flame gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "2fece7de-202b-560f-9e92-c769a386d36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f76e51-a726-4a5f-ae2b-2e826e89f5f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f76e51-a726-4a5f-ae2b-2e826e89f5f7.jpg?1",
             "name": "Fervent Strike",
             "text": "Target creature gets +1/+0 and gains first strike and haste until end of turn.",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "6de3607a-b301-50e9-aa22-c437ebcd5e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f36a25-3692-4f2e-a25e-84b90656e6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f36a25-3692-4f2e-a25e-84b90656e6a4.jpg?1",
             "name": "Fiery Intervention",
             "text": "Choose one \u2014\n\u2022 Fiery Intervention deals 5 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "8dce6e64-614b-5ac4-aaaa-14fcb391778b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c94d7a-cad7-438f-bc96-e6a7158ab0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c94d7a-cad7-438f-bc96-e6a7158ab0e6.jpg?1",
             "name": "Fight with Fire",
             "text": "Kicker {5}{R} (You may pay an additional {5}{R} as you cast this spell.)\nFight with Fire deals 5 damage to target creature. If this spell was kicked, it deals 10 damage divided as you choose among any number of targets instead. (Those targets can include players and planeswalkers.)",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "8f01a280-1357-5838-9c70-b673cea2bb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62405700-d42c-4c96-9678-dd72d7b7c807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62405700-d42c-4c96-9678-dd72d7b7c807.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "3234646e-b009-5eb9-9a18-5a6e64e389d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0569365d-9e50-436f-a8f3-90820ef06381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0569365d-9e50-436f-a8f3-90820ef06381.jpg?1",
             "name": "Firefist Adept",
             "text": "When Firefist Adept enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of Wizards you control.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "ec1a3c04-8561-5466-8169-3706a270c252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc241f-64b5-4e28-b14a-b3f19ca6e7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc241f-64b5-4e28-b14a-b3f19ca6e7b5.jpg?1",
             "name": "The First Eruption",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 The First Eruption deals 1 damage to each creature without flying.\nII \u2014 Add {R}{R}.\nIII \u2014 Sacrifice a Mountain. If you do, The First Eruption deals 3 damage to each creature.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "02c5c276-a312-5849-91a2-03ad459b57fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324399ed-3d6e-4b4c-8f3d-b7802e2ecadf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324399ed-3d6e-4b4c-8f3d-b7802e2ecadf.jpg?1",
             "name": "The Flame of Keld",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Discard your hand.\nII \u2014 Draw two cards.\nIII \u2014 If a red source you control would deal damage to a permanent or player this turn, it deals that much damage plus 2 to that permanent or player instead.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "3ee8a213-b5b6-5a12-81c2-b5e07e953ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca9c16-5720-4531-88ea-48b48d189479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca9c16-5720-4531-88ea-48b48d189479.jpg?1",
             "name": "Frenzied Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "7ae244ea-9ac6-5e02-a7a8-cf09ec0faeb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca6dd9-040a-4122-9308-8dcd0d506ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca6dd9-040a-4122-9308-8dcd0d506ada.jpg?1",
             "name": "Ghitu Chronicler",
             "text": "Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nWhen Ghitu Chronicler enters the battlefield, if it was kicked, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "b96649b4-c6c7-5b33-b766-322acb83cec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4360bc9-76f0-4e82-8968-4c6c62a35ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4360bc9-76f0-4e82-8968-4c6c62a35ed1.jpg?1",
             "name": "Ghitu Journeymage",
             "text": "When Ghitu Journeymage enters the battlefield, if you control another Wizard, Ghitu Journeymage deals 2 damage to each opponent.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "b2bfe7e7-75eb-5675-8936-ae77653b06a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c448ba82-a502-459f-9ebc-fc9e85674e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c448ba82-a502-459f-9ebc-fc9e85674e6c.jpg?1",
             "name": "Ghitu Lavarunner",
             "text": "As long as there are two or more instant and/or sorcery cards in your graveyard, Ghitu Lavarunner gets +1/+0 and has haste.",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "f41b11bb-1bba-5e23-a7c3-23bfc71b6696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849db5d-cd41-49f6-acd5-697cdc8263f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849db5d-cd41-49f6-acd5-697cdc8263f6.jpg?1",
             "name": "Goblin Barrage",
             "text": "Kicker\u2014\nSacrifice an artifact or Goblin. (You may sacrifice an artifact or Goblin in addition to any other costs as you cast this spell.)\nGoblin Barrage deals 4 damage to target creature. If this spell was kicked, it also deals 4 damage to target player or planeswalker.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "4aa981fb-6c16-52fa-b046-9ea88b27974e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb2883-3cfd-4fb0-9f99-6a57277f7fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb2883-3cfd-4fb0-9f99-6a57277f7fe4.jpg?1",
             "name": "Goblin Chainwhirler",
             "text": "First strike\nWhen Goblin Chainwhirler enters the battlefield, it deals 1 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -4410,7 +4410,7 @@
         },
         {
             "id": "13c0d75f-a993-576a-9b16-b472c94b9777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac033c-dc4e-40a0-b103-4892e4b50249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac033c-dc4e-40a0-b103-4892e4b50249.jpg?1",
             "name": "Goblin Warchief",
             "text": "Goblin spells you cast cost {1} less to cast.\nGoblins you control have haste.",
             "colours": [
@@ -4445,7 +4445,7 @@
         },
         {
             "id": "6bbf251b-3237-553d-8958-a8c2a33a7fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e558a5bd-e8f9-477f-a514-1bf0708f4e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e558a5bd-e8f9-477f-a514-1bf0708f4e9e.jpg?1",
             "name": "Haphazard Bombardment",
             "text": "When Haphazard Bombardment enters the battlefield, choose four nonenchantment permanents you don't control and put an aim counter on each of them.\nAt the beginning of your end step, if two or more permanents you don't control have an aim counter on them, destroy one of those permanents at random.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "d7e471b0-04d4-5ee2-837a-b09411a5e596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa25fedc-6038-48c8-b42a-817ac186492e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa25fedc-6038-48c8-b42a-817ac186492e.jpg?1",
             "name": "Jaya Ballard",
             "text": "+1: Add {R}{R}{R}. Spend this mana only to cast instant or sorcery spells.\n+1: Discard up to three cards, then draw that many cards.\n\u22128: You get an emblem with \"You may cast instant and sorcery cards from your graveyard. If a card cast this way would be put into your graveyard, exile it instead.\"",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "00caa8b8-f5c3-57ed-b0bd-0267e3fcd77d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48268bb8-1326-451b-9fae-de6605eb6cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48268bb8-1326-451b-9fae-de6605eb6cfd.jpg?1",
             "name": "Jaya's Immolating Inferno",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nJaya's Immolating Inferno deals X damage to each of up to three targets.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "a373cfb7-72ad-5b62-89f6-7aa92d463af6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66b814-9c47-4d17-8c02-1d9be565c76c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66b814-9c47-4d17-8c02-1d9be565c76c.jpg?1",
             "name": "Keldon Overseer",
             "text": "Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nHaste\nWhen Keldon Overseer enters the battlefield, if it was kicked, gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4582,7 +4582,7 @@
         },
         {
             "id": "459035bf-ab59-52d8-842e-ad211aa42bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1245212-d081-4e95-a508-e1d3a7496473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1245212-d081-4e95-a508-e1d3a7496473.jpg?1",
             "name": "Keldon Raider",
             "text": "When Keldon Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "6bf88367-9864-57b5-abe7-96d425ef8266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2e230-2d60-402d-98e4-0f33d2f27c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2e230-2d60-402d-98e4-0f33d2f27c56.jpg?1",
             "name": "Keldon Warcaller",
             "text": "Whenever Keldon Warcaller attacks, put a lore counter on target Saga you control.",
             "colours": [
@@ -4652,7 +4652,7 @@
         },
         {
             "id": "9d18ac00-5330-5215-becb-e4afb5b05faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6192b4ea-f781-4c56-89bc-530f5388b6b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6192b4ea-f781-4c56-89bc-530f5388b6b5.jpg?1",
             "name": "Orcish Vandal",
             "text": "{T}, Sacrifice an artifact: Orcish Vandal deals 2 damage to any target.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "5b10ada4-a5e2-54ca-9f25-cdfbb3c60a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94454128-92f1-475d-abc4-c235f501eeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94454128-92f1-475d-abc4-c235f501eeb6.jpg?1",
             "name": "Radiating Lightning",
             "text": "Radiating Lightning deals 3 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "79d98aad-5998-5062-81c6-6f09558e3c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdac0c6-bf72-4a9b-9fad-ae7bc2632a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdac0c6-bf72-4a9b-9fad-ae7bc2632a4a.jpg?1",
             "name": "Rampaging Cyclops",
             "text": "Rampaging Cyclops gets -2/-0 as long as two or more creatures are blocking it.",
             "colours": [
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "3f2dc9e1-9abf-5f92-8f1b-bbcd3f6db850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f2aa2c-deec-4927-a2d6-f5dce5967e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f2aa2c-deec-4927-a2d6-f5dce5967e26.jpg?1",
             "name": "Run Amok",
             "text": "Target attacking creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "d68c8a1e-5dd3-5b64-a3f8-fcd6f410a6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad40a04-a026-4285-8c78-088a356652d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad40a04-a026-4285-8c78-088a356652d1.jpg?1",
             "name": "Seismic Shift",
             "text": "Destroy target land. Up to two target creatures can't block this turn.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "cdbe0606-3ea5-53c9-8bcc-089306c673ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b9d339-99ed-4923-8f56-be37f29a0bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b9d339-99ed-4923-8f56-be37f29a0bfa.jpg?1",
             "name": "Shivan Fire",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nShivan Fire deals 2 damage to target creature. If this spell was kicked, it deals 4 damage to that creature instead.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "da05ebc7-9418-5eb7-8582-388c858f8f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ff087-97e7-4946-871f-1833abb2558a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ff087-97e7-4946-871f-1833abb2558a.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "490588dd-7ea2-577d-804a-d5227d2ff717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg?1",
             "name": "Skirk Prospector",
             "text": "Sacrifice a Goblin: Add {R}.",
             "colours": [
@@ -4917,7 +4917,7 @@
         },
         {
             "id": "ee2f7181-0431-5f63-9eb1-6dfc9f260890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9d28-1639-47bd-b925-7f3d2eefd352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9d28-1639-47bd-b925-7f3d2eefd352.jpg?1",
             "name": "Skizzik",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTrample, haste\nAt the beginning of the end step, if Skizzik wasn't kicked, sacrifice it.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "5e356aff-7c5d-5411-ad67-ecf143b03e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3974c62-a524-454e-9ce7-2c23b704e5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3974c62-a524-454e-9ce7-2c23b704e5cb.jpg?1",
             "name": "Squee, the Immortal",
             "text": "You may cast Squee, the Immortal from your graveyard or from exile.",
             "colours": [
@@ -4987,7 +4987,7 @@
         },
         {
             "id": "d6a8ddac-5644-5a6d-89f4-8b706fdd030e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f86c365-3ce5-45e5-b610-6f2587f99b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f86c365-3ce5-45e5-b610-6f2587f99b42.jpg?1",
             "name": "Two-Headed Giant",
             "text": "Whenever Two-Headed Giant attacks, flip two coins. If both coins come up heads, Two-Headed Giant gains double strike until end of turn. If both coins come up tails, Two-Headed Giant gains menace until end of turn.",
             "colours": [
@@ -5022,7 +5022,7 @@
         },
         {
             "id": "46a183c4-1b7c-5ebf-a738-73a5f8c98fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253f9e43-5bc6-4f26-a8e9-773cd0ca3d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253f9e43-5bc6-4f26-a8e9-773cd0ca3d02.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "7b8c02f7-dfc3-50a0-9c7f-f8c59480ea26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db785c-cf82-4caa-aef6-8c61d9bec7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db785c-cf82-4caa-aef6-8c61d9bec7c6.jpg?1",
             "name": "Verix Bladewing",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nFlying\nWhen Verix Bladewing enters the battlefield, if it was kicked, create Karox Bladewing, a legendary 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "edc6f6a4-9f03-50d5-a4d0-50667081a881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff561f01-8dbc-4988-be00-592d1e417396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff561f01-8dbc-4988-be00-592d1e417396.jpg?1",
             "name": "Warcry Phoenix",
             "text": "Flying, haste\nWhenever you attack with three or more creatures, you may pay {2}{R}. If you do, return Warcry Phoenix from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "c0b323f2-77ce-536f-a9bb-4d2eb015f533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd63cf-7e8c-4c8d-844d-98535d5f3039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd63cf-7e8c-4c8d-844d-98535d5f3039.jpg?1",
             "name": "Warlord's Fury",
             "text": "Creatures you control gain first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "2ae0aae0-9fc5-5ff5-8313-414534a23c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bf371a-164c-4db8-9207-197c2e7c3c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bf371a-164c-4db8-9207-197c2e7c3c10.jpg?1",
             "name": "Wizard's Lightning",
             "text": "This spell costs {2} less to cast if you control a Wizard.\nWizard's Lightning deals 3 damage to any target.",
             "colours": [
@@ -5193,7 +5193,7 @@
         },
         {
             "id": "4b8811e7-c3ad-5baa-90a2-659612f27486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426c92c-6e71-49f0-9a91-0d529bf8c17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426c92c-6e71-49f0-9a91-0d529bf8c17d.jpg?1",
             "name": "Adventurous Impulse",
             "text": "Look at the top three cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "ea78ae83-5070-5b41-920a-3e3997aaed67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a3b223-b232-4da3-9431-ccb4688d5941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a3b223-b232-4da3-9431-ccb4688d5941.jpg?1",
             "name": "Ancient Animus",
             "text": "Put a +1/+1 counter on target creature you control if it's legendary. Then it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "f516535a-cef2-5b06-a78d-ddc4972be7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceb365c-5de6-47ae-b42d-7fbce7781f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceb365c-5de6-47ae-b42d-7fbce7781f8e.jpg?1",
             "name": "Arbor Armament",
             "text": "Put a +1/+1 counter on target creature. That creature gains reach until end of turn.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "b8aab163-9206-5b4c-a3d7-5fc7aa4f0484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504090bb-d183-4833-aea5-d4193b5c57a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504090bb-d183-4833-aea5-d4193b5c57a1.jpg?1",
             "name": "Baloth Gorger",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nIf Baloth Gorger was kicked, it enters the battlefield with three +1/+1 counters on it.",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "b2472ccf-1b75-5056-bd33-edb9802c6217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dcb59f-2a47-4461-9831-204ad15696b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dcb59f-2a47-4461-9831-204ad15696b5.jpg?1",
             "name": "Broken Bond",
             "text": "Destroy target artifact or enchantment. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "d923a5bc-2cda-59d9-9151-dcfd8622f5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13deb9c-5985-4355-8716-ee1c7b54b8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13deb9c-5985-4355-8716-ee1c7b54b8e2.jpg?1",
             "name": "Corrosive Ooze",
             "text": "Whenever Corrosive Ooze blocks or becomes blocked by an equipped creature, destroy all Equipment attached to that creature at end of combat.",
             "colours": [
@@ -5389,7 +5389,7 @@
         },
         {
             "id": "69676074-6212-5bd8-8a2c-dcba66a26b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e62226e-3585-42d2-9b7a-2462fcd967f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e62226e-3585-42d2-9b7a-2462fcd967f5.jpg?1",
             "name": "Elfhame Druid",
             "text": "{T}: Add {G}.\n{T}: Add {G}{G}. Spend this mana only to cast kicked spells.",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "9c4905b4-f3a4-5955-8128-b9b56acb09ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419f2a-63cf-4ab7-bad0-b0f773fc0570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419f2a-63cf-4ab7-bad0-b0f773fc0570.jpg?1",
             "name": "Fungal Plots",
             "text": "{1}{G}, Exile a creature card from your graveyard: Create a 1/1 green Saproling creature token.\nSacrifice two Saprolings: You gain 2 life and draw a card.",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "deae7ecf-43ca-50fb-a68f-613bd92fb3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23cf81ed-b86c-42b8-b796-2032b0a3654a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23cf81ed-b86c-42b8-b796-2032b0a3654a.jpg?1",
             "name": "Gaea's Blessing",
             "text": "Target player shuffles up to three target cards from their graveyard into their library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "95845410-5d79-564c-b01d-7ea5e48ca0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc5ce71-282c-43f9-b12a-edd8f4ab6006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc5ce71-282c-43f9-b12a-edd8f4ab6006.jpg?1",
             "name": "Gaea's Protector",
             "text": "Gaea's Protector must be blocked if able.",
             "colours": [
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "fa42977f-03b7-5678-951b-cfd51722ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8878-5928-47ec-bb31-f4ee24ad982b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8878-5928-47ec-bb31-f4ee24ad982b.jpg?1",
             "name": "Gift of Growth",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nUntap target creature. It gets +2/+2 until end of turn. If this spell was kicked, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "da5ba291-35e8-5738-a353-638b041c7d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4d1c2-671c-498c-a232-7d076e3dc3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4d1c2-671c-498c-a232-7d076e3dc3bb.jpg?1",
             "name": "Grow from the Ashes",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nSearch your library for a basic land card, put it onto the battlefield, then shuffle your library. If this spell was kicked, instead search your library for two basic land cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "93e541a0-8989-57de-a048-fdd72e06469f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a9aa5c-1501-4958-872a-39c512514033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a9aa5c-1501-4958-872a-39c512514033.jpg?1",
             "name": "Grunn, the Lonely King",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nIf Grunn, the Lonely King was kicked, it enters the battlefield with five +1/+1 counters on it.\nWhenever Grunn attacks alone, double its power and toughness until end of turn.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "e81c020e-00b0-5942-8bb5-a95c38f1195f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf95ef60-e67b-466d-a6cb-d487ffa88b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf95ef60-e67b-466d-a6cb-d487ffa88b72.jpg?1",
             "name": "Kamahl's Druidic Vow",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nLook at the top X cards of your library. You may put any number of land and/or legendary permanent cards with converted mana cost X or less from among them onto the battlefield. Put the rest into your graveyard.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "67a9a12d-bb34-575a-888c-8120d598685c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c332dc82-7664-44d0-b92a-a3d867399884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c332dc82-7664-44d0-b92a-a3d867399884.jpg?1",
             "name": "Krosan Druid",
             "text": "Kicker {4}{G} (You may pay an additional {4}{G} as you cast this spell.)\nWhen Krosan Druid enters the battlefield, if it was kicked, you gain 10 life.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "8e40b6d6-c40b-5ce9-91e1-9b8eb48e81f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581b7327-3215-4a4f-b4ae-d9d4002ba882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581b7327-3215-4a4f-b4ae-d9d4002ba882.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "5625a9dd-75f9-5f7a-ba0f-3be0f6650ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a667bba-ecf0-4212-8ca3-75d4db6abce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a667bba-ecf0-4212-8ca3-75d4db6abce2.jpg?1",
             "name": "Llanowar Envoy",
             "text": "{1}{G}: Add one mana of any color.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "1e425ff7-46ee-5fae-a5b2-12a9ab69709a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8026d80-2e91-46f9-ae97-1f137848236c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8026d80-2e91-46f9-ae97-1f137848236c.jpg?1",
             "name": "Llanowar Scout",
             "text": "{T}: You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -5798,7 +5798,7 @@
         },
         {
             "id": "cbe43d6e-45a2-5e6c-9d79-adb8ff859c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db18bbcd-527d-4134-a6ae-6f4381419867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db18bbcd-527d-4134-a6ae-6f4381419867.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach",
             "colours": [
@@ -5832,7 +5832,7 @@
         },
         {
             "id": "d0f214fe-fe7e-5314-8bc6-f2313cf03058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251613c0-2e72-4bd1-b3b5-69602b07b6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251613c0-2e72-4bd1-b3b5-69602b07b6f9.jpg?1",
             "name": "Marwyn, the Nurturer",
             "text": "Whenever another Elf enters the battlefield under your control, put a +1/+1 counter on Marwyn, the Nurturer.\n{T}: Add an amount of {G} equal to Marwyn's power.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "bcb48081-4b63-5a3e-949d-6ff77d39f790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5e4d9a-34e1-46eb-814b-8e3bd4475b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5e4d9a-34e1-46eb-814b-8e3bd4475b8a.jpg?1",
             "name": "The Mending of Dominaria",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put the top two cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.\nIII \u2014 Return all land cards from your graveyard to the battlefield, then shuffle your graveyard into your library.",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "e2c35a48-c336-5b62-82ec-d339fe7b1e0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233ad7b-2903-4736-b13a-5cd4a275eb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233ad7b-2903-4736-b13a-5cd4a275eb61.jpg?1",
             "name": "Multani, Yavimaya's Avatar",
             "text": "Reach, trample\nMultani, Yavimaya's Avatar gets +1/+1 for each land you control and each land card in your graveyard.\n{1}{G}, Return two lands you control to their owner's hand: Return Multani from your graveyard to your hand.",
             "colours": [
@@ -5940,7 +5940,7 @@
         },
         {
             "id": "8c0ae940-0926-5cc4-ba37-f5646d1f72cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6666b95e-80de-4bf7-bae6-8a7e991b38ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6666b95e-80de-4bf7-bae6-8a7e991b38ad.jpg?1",
             "name": "Nature's Spiral",
             "text": "Return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -5972,7 +5972,7 @@
         },
         {
             "id": "d8df9471-7b5d-517f-b4ba-d6c3cd81c039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df491512-ba8a-4ba5-ad42-338190201170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df491512-ba8a-4ba5-ad42-338190201170.jpg?1",
             "name": "Pierce the Sky",
             "text": "Pierce the Sky deals 7 damage to target creature with flying.",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "b991d060-061e-51ec-b0e0-a405d482493a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fb52be-0e17-437d-8583-af69cdfff87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fb52be-0e17-437d-8583-af69cdfff87b.jpg?1",
             "name": "Primordial Wurm",
             "text": "",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "7847c602-1d8c-5c3b-b5f7-732b2588397c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2578d25e-5f8d-42ff-90ce-4e7d100cbbb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2578d25e-5f8d-42ff-90ce-4e7d100cbbb6.jpg?1",
             "name": "Saproling Migration",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nCreate two 1/1 green Saproling creature tokens. If this spell was kicked, create four of those tokens instead.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "3d23afc2-8cb8-568c-aa91-220b444d3850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b534b-8442-4074-a8d2-f38e83f24868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b534b-8442-4074-a8d2-f38e83f24868.jpg?1",
             "name": "Song of Freyalise",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Until your next turn, creatures you control gain \"{T}: Add one mana of any color.\"\nIII \u2014 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance, trample, and indestructible until end of turn.",
             "colours": [
@@ -6104,7 +6104,7 @@
         },
         {
             "id": "4fbb65be-ed32-558e-ba2c-1970fbd1e36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2314215-23af-4c8e-860f-b029e151af36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2314215-23af-4c8e-860f-b029e151af36.jpg?1",
             "name": "Spore Swarm",
             "text": "Create three 1/1 green Saproling creature tokens.",
             "colours": [
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "01b11482-8dc2-52e8-80a5-d5f4bdff4e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b93b5-e16a-4a1a-bd26-74a9f25caffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b93b5-e16a-4a1a-bd26-74a9f25caffe.jpg?1",
             "name": "Sporecrown Thallid",
             "text": "Each other creature you control that's a Fungus or Saproling gets +1/+1.",
             "colours": [
@@ -6170,7 +6170,7 @@
         },
         {
             "id": "0b7bb966-77d9-505b-afd1-f0cfa91e8f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8a688-79d4-49b9-ab0c-c7f5c9b551f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8a688-79d4-49b9-ab0c-c7f5c9b551f4.jpg?1",
             "name": "Steel Leaf Champion",
             "text": "Steel Leaf Champion can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "fb8b609f-76d7-5244-92e3-300888d5516e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ac4d3d-064e-459d-b3a4-6c0872a2da8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ac4d3d-064e-459d-b3a4-6c0872a2da8c.jpg?1",
             "name": "Sylvan Awakening",
             "text": "Until your next turn, all lands you control become 2/2 Elemental creatures with reach, indestructible, and haste. They're still lands.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "d4891502-9304-5ed6-818b-08a2ca4e9e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ac2b0-47ea-4aa3-bf24-c78227a0c913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ac2b0-47ea-4aa3-bf24-c78227a0c913.jpg?1",
             "name": "Territorial Allosaurus",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nWhen Territorial Allosaurus enters the battlefield, if it was kicked, it fights another target creature.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "dc4ebc69-b63c-54ae-9105-0bb6ac20e2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da901037-20e6-4445-8e7e-1ccd2e8b13ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da901037-20e6-4445-8e7e-1ccd2e8b13ae.jpg?1",
             "name": "Thorn Elemental",
             "text": "You may have Thorn Elemental assign its combat damage as though it weren't blocked.",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "a3b3fb8c-e9cd-571a-89ba-54757978f450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4cf84a-2024-45bb-9e24-8a9a6d9ad247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4cf84a-2024-45bb-9e24-8a9a6d9ad247.jpg?1",
             "name": "Untamed Kavu",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nVigilance, trample\nIf Untamed Kavu was kicked, it enters the battlefield with three +1/+1 counters on it.",
             "colours": [
@@ -6339,7 +6339,7 @@
         },
         {
             "id": "8460f1c3-bc7e-57fd-9517-26e853b1d3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d972f97-1945-440b-8bd3-63038db22257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d972f97-1945-440b-8bd3-63038db22257.jpg?1",
             "name": "Verdant Force",
             "text": "At the beginning of each upkeep, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "65753422-5f54-510e-b6a1-c413eefa6744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb75cf21-08be-4b92-bdf6-014a36090738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb75cf21-08be-4b92-bdf6-014a36090738.jpg?1",
             "name": "Wild Onslaught",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nPut a +1/+1 counter on each creature you control. If this spell was kicked, put two +1/+1 counters on each creature you control instead.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "5fe08682-4f92-5905-af75-94487deb6044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef6b657-7273-4abe-92f4-e1e4cda78f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef6b657-7273-4abe-92f4-e1e4cda78f96.jpg?1",
             "name": "Yavimaya Sapherd",
             "text": "When Yavimaya Sapherd enters the battlefield, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "f8397d62-ca19-5877-9d62-fad9a78d0a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c950e2-a43b-47f8-9ad6-1909ccc7acbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c950e2-a43b-47f8-9ad6-1909ccc7acbf.jpg?1",
             "name": "Adeliz, the Cinder Wind",
             "text": "Flying, haste\nWhenever you cast an instant or sorcery spell, Wizards you control get +1/+1 until end of turn.",
             "colours": [
@@ -6478,7 +6478,7 @@
         },
         {
             "id": "e69167b7-de6e-5b2b-bb73-dc45979e2602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811f37a-f381-42e7-9b4a-15b2241eb10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811f37a-f381-42e7-9b4a-15b2241eb10d.jpg?1",
             "name": "Arvad the Cursed",
             "text": "Deathtouch, lifelink\nOther legendary creatures you control get +2/+2.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "48a70f50-f083-58d6-8b35-d3f97b3c132d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e2981b-bf25-4d9d-8811-5a1ff0b4d5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e2981b-bf25-4d9d-8811-5a1ff0b4d5d2.jpg?1",
             "name": "Aryel, Knight of Windgrace",
             "text": "Vigilance\n{2}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.\n{B}, {T}, Tap X untapped Knights you control: Destroy target creature with power X or less.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "54f30576-f4d3-5e68-a7a7-50fa2402e693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9459ffca-5a1f-4641-88d4-8a499b261faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9459ffca-5a1f-4641-88d4-8a499b261faa.jpg?1",
             "name": "Darigaaz Reincarnated",
             "text": "Flying, trample, haste\nIf Darigaaz Reincarnated would die, instead exile it with three egg counters on it.\nAt the beginning of your upkeep, if Darigaaz is exiled with an egg counter on it, remove an egg counter from it. Then if Darigaaz has no egg counters on it, return it to the battlefield.",
             "colours": [
@@ -6596,7 +6596,7 @@
         },
         {
             "id": "4164cd02-e4d0-5541-9f6c-1e38ed308af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9c1471-ae6f-4b66-9842-46f1a74e93b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9c1471-ae6f-4b66-9842-46f1a74e93b5.jpg?1",
             "name": "Garna, the Bloodflame",
             "text": "Flash\nWhen Garna, the Bloodflame enters the battlefield, return to your hand all creature cards in your graveyard that were put there from anywhere this turn.\nOther creatures you control have haste.",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "9e575e54-ded0-5a9b-bdad-adeb802b7c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986981fa-a744-45d8-81c7-68ef335c79e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986981fa-a744-45d8-81c7-68ef335c79e2.jpg?1",
             "name": "Grand Warlord Radha",
             "text": "Haste\nWhenever one or more creatures you control attack, add that much mana in any combination of {R} and/or {G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "33b59732-1aed-5237-9497-8cbce94c42a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c896643e-eeef-49a6-a1ca-2577b55af2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c896643e-eeef-49a6-a1ca-2577b55af2b0.jpg?1",
             "name": "Hallar, the Firefletcher",
             "text": "Trample\nWhenever you cast a spell, if that spell was kicked, put a +1/+1 counter on Hallar, the Firefletcher, then Hallar deals damage equal to the number of +1/+1 counters on it to each opponent.",
             "colours": [
@@ -6713,7 +6713,7 @@
         },
         {
             "id": "11f91e9f-ce4d-595c-8433-a4a49b650379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cf8c6b-1322-4bc5-a604-6e372607fae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cf8c6b-1322-4bc5-a604-6e372607fae4.jpg?1",
             "name": "Jhoira, Weatherlight Captain",
             "text": "Whenever you cast a historic spell, draw a card. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "9681ed19-7c25-530b-8485-fe1fec52136c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee86efa-248e-4251-b734-f8ad3e8a0344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee86efa-248e-4251-b734-f8ad3e8a0344.jpg?1",
             "name": "Jodah, Archmage Eternal",
             "text": "Flying\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -6795,7 +6795,7 @@
         },
         {
             "id": "f9aff7c9-eb03-5464-b07c-df3b04d353e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c654737d-34ac-42ff-ae27-3a3bbb930fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c654737d-34ac-42ff-ae27-3a3bbb930fc1.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play up to one permanent card of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "6e43cd0d-5c68-5278-b0e4-2598caa31deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7fadca-0a94-4624-ab95-2c2410829824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7fadca-0a94-4624-ab95-2c2410829824.jpg?1",
             "name": "Oath of Teferi",
             "text": "When Oath of Teferi enters the battlefield, exile another target permanent you control. Return it to the battlefield under its owner's control at the beginning of the next end step.\nYou may activate the loyalty abilities of planeswalkers you control twice each turn rather than only once.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "be7242ef-2621-5967-90aa-faffd5e58ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dd2950-502c-4859-85fe-9fbef09aef43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dd2950-502c-4859-85fe-9fbef09aef43.jpg?1",
             "name": "Primevals' Glorious Rebirth",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nReturn all legendary permanent cards from your graveyard to the battlefield.",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "58732750-7552-5a15-b87e-fca46e7aaa1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674070e3-6efe-45e4-aff6-e4a49ec2106e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674070e3-6efe-45e4-aff6-e4a49ec2106e.jpg?1",
             "name": "Raff Capashen, Ship's Mage",
             "text": "Flash\nFlying\nYou may cast historic spells as though they had flash. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "66cacc14-33a7-57f4-81c5-d569de20d5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45420f5e-f7f8-4db7-9b54-e2fa1be22094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45420f5e-f7f8-4db7-9b54-e2fa1be22094.jpg?1",
             "name": "Rona, Disciple of Gix",
             "text": "When Rona, Disciple of Gix enters the battlefield, you may exile target historic card from your graveyard. (Artifacts, legendaries, and Sagas are historic.)\nYou may cast nonland cards exiled with Rona.\n{4}, {T}: Exile the top card of your library.",
             "colours": [
@@ -6986,7 +6986,7 @@
         },
         {
             "id": "887bc22b-2ced-5d22-bfc3-a527ed9cbc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90df81c-d738-46b3-8e96-9db0b3507ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90df81c-d738-46b3-8e96-9db0b3507ee0.jpg?1",
             "name": "Shanna, Sisay's Legacy",
             "text": "Shanna, Sisay's Legacy can't be the target of abilities your opponents control.\nShanna gets +1/+1 for each creature you control.",
             "colours": [
@@ -7025,7 +7025,7 @@
         },
         {
             "id": "f599550d-28ba-53ae-b725-20489667ad9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8815cd9-7032-445a-aebc-cfc19bd51ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8815cd9-7032-445a-aebc-cfc19bd51ee4.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "578a5f76-cfa5-58d6-9dc0-bb7d6c77bd7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93657aaa-7a0f-49ad-b026-6f79b3bd6768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93657aaa-7a0f-49ad-b026-6f79b3bd6768.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -7102,7 +7102,7 @@
         },
         {
             "id": "19a650ba-eba3-563b-b2a9-de5d4c21df28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d10b752-d9cb-419d-a5c4-d4ee1acb655e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d10b752-d9cb-419d-a5c4-d4ee1acb655e.jpg?1",
             "name": "Teferi, Hero of Dominaria",
             "text": "+1: Draw a card. At the beginning of the next end step, untap two lands.\n\u22123: Put target nonland permanent into its owner's library third from the top.\n\u22128: You get an emblem with \"Whenever you draw a card, exile target permanent an opponent controls.\"",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "6af3a8df-f7e1-5104-b35b-8b6cd2e559ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8aea2f-1e1d-4e0d-8370-207b6cae76e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8aea2f-1e1d-4e0d-8370-207b6cae76e3.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "ffa2e344-15c4-5c01-86da-fc0289be2ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25afd4a7-4253-4a4e-a105-e92f64460faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25afd4a7-4253-4a4e-a105-e92f64460faa.jpg?1",
             "name": "Aesthir Glider",
             "text": "Flying\nAesthir Glider can't block.",
             "colours": [],
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "068203a3-3d31-5968-8e3b-ab37831d8168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b49065-0a46-4813-a721-71d718e73d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b49065-0a46-4813-a721-71d718e73d18.jpg?1",
             "name": "Amaranthine Wall",
             "text": "Defender\n{2}: Amaranthine Wall gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [],
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "6cf56b29-9e5c-55ad-939d-03272ed13393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862d38d1-e3d0-47e1-a535-ff445b1c55c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862d38d1-e3d0-47e1-a535-ff445b1c55c6.jpg?1",
             "name": "Blackblade Reforged",
             "text": "Equipped creature gets +1/+1 for each land you control.\nEquip legendary creature {3}\nEquip {7}",
             "colours": [],
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "e1d07e0a-0ff6-5d9b-ab3b-1cc76247931e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8125b6-911e-4663-962a-d741984c927d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8125b6-911e-4663-962a-d741984c927d.jpg?1",
             "name": "Bloodtallow Candle",
             "text": "{6}, {T}, Sacrifice Bloodtallow Candle: Target creature gets -5/-5 until end of turn.",
             "colours": [],
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "4396c81b-9cea-5a94-bc34-e5ac6b9a894b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7d16b-8f4e-42b9-be24-3cb091932d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7d16b-8f4e-42b9-be24-3cb091932d7c.jpg?1",
             "name": "Damping Sphere",
             "text": "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
             "colours": [],
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "2a2fd78a-8917-521c-b73e-f8508b068f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52212fd5-551e-4bc1-9dac-6361e27c27ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52212fd5-551e-4bc1-9dac-6361e27c27ad.jpg?1",
             "name": "Forebear's Blade",
             "text": "Equipped creature gets +3/+0 and has vigilance and trample.\nWhenever equipped creature dies, attach Forebear's Blade to target creature you control.\nEquip {3}",
             "colours": [],
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "e3f30308-0d86-5d8e-a2ae-efeedb1726a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a487e208-8493-4bca-8c44-284d89c66b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a487e208-8493-4bca-8c44-284d89c66b15.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "8e1184b1-5a30-56f5-9ec9-a2ebf3400e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbc615a-708a-444b-acab-871cce22694d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbc615a-708a-444b-acab-871cce22694d.jpg?1",
             "name": "Guardians of Koilos",
             "text": "When Guardians of Koilos enters the battlefield, you may return another target historic permanent you control to its owner's hand. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "e71b8be6-2930-5b8d-95fd-7d665eef7e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d65d20c-09e5-4139-838b-7e0e48eb2b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d65d20c-09e5-4139-838b-7e0e48eb2b2b.jpg?1",
             "name": "Helm of the Host",
             "text": "At the beginning of combat on your turn, create a token that's a copy of equipped creature, except the token isn't legendary if equipped creature is legendary. That token gains haste.\nEquip {5}",
             "colours": [],
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "206c6974-dcee-503a-8bed-a825e42c1aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775ab60a-2dc1-44fc-8022-f7becd8ee195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775ab60a-2dc1-44fc-8022-f7becd8ee195.jpg?1",
             "name": "Howling Golem",
             "text": "Whenever Howling Golem attacks or blocks, each player draws a card.",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "fed701bb-70de-5810-9b33-108be935bc10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd9b205-817e-4ca4-8a29-3c2b6cbf7207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd9b205-817e-4ca4-8a29-3c2b6cbf7207.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "0511776a-2024-559f-9423-b46bb0d08408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3718761f-feb1-46c4-aaa3-7e07a3fa72fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3718761f-feb1-46c4-aaa3-7e07a3fa72fa.jpg?1",
             "name": "Jhoira's Familiar",
             "text": "Flying\nHistoric spells you cast cost {1} less to cast. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7541,7 +7541,7 @@
         },
         {
             "id": "ff2d77ff-fd4f-55f8-876c-dd1ad18212c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446579ab-5e36-44e2-84d7-cfa537619146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446579ab-5e36-44e2-84d7-cfa537619146.jpg?1",
             "name": "Jousting Lance",
             "text": "Equipped creature gets +2/+0.\nAs long as it's your turn, equipped creature has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7571,7 +7571,7 @@
         },
         {
             "id": "b871187c-e720-555c-8e4d-a8c0bc155f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfebeab7-44cf-4895-bdd5-04cbb2c700d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfebeab7-44cf-4895-bdd5-04cbb2c700d7.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "2c634452-6b48-5b27-977c-de75078e3fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f342b2-1ba6-4b72-9f03-bc076c795b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f342b2-1ba6-4b72-9f03-bc076c795b3d.jpg?1",
             "name": "Mishra's Self-Replicator",
             "text": "Whenever you cast a historic spell, you may pay {1}. If you do, create a token that's a copy of Mishra's Self-Replicator. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "e82dce50-0b88-5f60-be8c-fcf3ce71a910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66024e69-ad60-4c9a-a0ca-da138d33ad80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66024e69-ad60-4c9a-a0ca-da138d33ad80.jpg?1",
             "name": "Mox Amber",
             "text": "{T}: Add one mana of any color among legendary creatures and planeswalkers you control.",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "3cdf4d49-a47f-547c-8bc5-3b2e4a312232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a283135-7a51-4cf7-82a6-7e50894e64a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a283135-7a51-4cf7-82a6-7e50894e64a5.jpg?1",
             "name": "Navigator's Compass",
             "text": "When Navigator's Compass enters the battlefield, you gain 3 life.\n{T}: Until end of turn, target land you control becomes the basic land type of your choice in addition to its other types.",
             "colours": [],
@@ -7691,7 +7691,7 @@
         },
         {
             "id": "6bbdc05c-eebd-5302-a29b-b51da39ff33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fffe967-3a99-4f00-af46-f4e5567598df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fffe967-3a99-4f00-af46-f4e5567598df.jpg?1",
             "name": "Pardic Wanderer",
             "text": "Trample",
             "colours": [],
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "4f027779-6b52-56bc-9e83-20252d4cf95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62fd366-c287-48c3-9ded-5dc63a34518c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62fd366-c287-48c3-9ded-5dc63a34518c.jpg?1",
             "name": "Powerstone Shard",
             "text": "{T}: Add {C} for each artifact you control named Powerstone Shard.",
             "colours": [],
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "82831d1e-830b-535e-93b1-5cced9f27e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7207edf8-8534-4982-969f-df97febcb9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7207edf8-8534-4982-969f-df97febcb9fc.jpg?1",
             "name": "Shield of the Realm",
             "text": "If a source would deal damage to equipped creature, prevent 2 of that damage.\nEquip {1}",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "87857475-7975-50a0-99c4-f288945e66f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb79a623-21c3-4310-bc76-310935511d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb79a623-21c3-4310-bc76-310935511d45.jpg?1",
             "name": "Short Sword",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7810,7 +7810,7 @@
         },
         {
             "id": "598445f9-bace-5058-988d-01a6da322de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7bea0-79c9-4856-8279-cef7cee82fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7bea0-79c9-4856-8279-cef7cee82fc1.jpg?1",
             "name": "Skittering Surveyor",
             "text": "When Skittering Surveyor enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "3745a8cf-9cd7-55f1-8510-8f8549412cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ee3692-54e3-42de-85c6-0a3b5c6a2402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ee3692-54e3-42de-85c6-0a3b5c6a2402.jpg?1",
             "name": "Sorcerer's Wand",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target player or planeswalker. If this creature is a Wizard, it deals 2 damage to that player or planeswalker instead.\"\nEquip {3}",
             "colours": [],
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "d1020a60-9528-572a-abef-4e9e4e4a5dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc7db8-386e-4fb6-aefa-591e99747eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc7db8-386e-4fb6-aefa-591e99747eb2.jpg?1",
             "name": "Sparring Construct",
             "text": "When Sparring Construct dies, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "21312047-dc36-5597-8f26-5c6cfb5469c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72806f4f-74e8-4621-92b0-5c63bb898884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72806f4f-74e8-4621-92b0-5c63bb898884.jpg?1",
             "name": "Thran Temporal Gateway",
             "text": "{4}, {T}: You may put a historic permanent card from your hand onto the battlefield. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "82f40e86-79cb-5b78-9375-b336f1dd334e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab80216-3df7-4e4f-8732-16dd6cac6bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab80216-3df7-4e4f-8732-16dd6cac6bcf.jpg?1",
             "name": "Traxos, Scourge of Kroog",
             "text": "Trample\nTraxos, Scourge of Kroog enters the battlefield tapped and doesn't untap during your untap step.\nWhenever you cast a historic spell, untap Traxos. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7965,7 +7965,7 @@
         },
         {
             "id": "a2087b7c-7fc4-5390-a1c1-7d37a6c6566b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bead8b-a67f-4451-9d44-038f8688093f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bead8b-a67f-4451-9d44-038f8688093f.jpg?1",
             "name": "Urza's Tome",
             "text": "{3}, {T}: Draw a card. Then discard a card unless you exile a historic card from your graveyard. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "7e083d79-79e4-5156-ae10-3b4b3a89dda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28564ac6-8b9b-4b99-9630-8fb3158d354c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28564ac6-8b9b-4b99-9630-8fb3158d354c.jpg?1",
             "name": "Voltaic Servant",
             "text": "At the beginning of your end step, untap target artifact.",
             "colours": [],
@@ -8024,7 +8024,7 @@
         },
         {
             "id": "7018d3b4-a50b-5dad-bedd-3c1c7e77784a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4581fc0-551c-4ee5-bde0-65c2b8cdf1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4581fc0-551c-4ee5-bde0-65c2b8cdf1b7.jpg?1",
             "name": "Weatherlight",
             "text": "Flying\nWhenever Weatherlight deals combat damage to a player, look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. (Artifacts, legendaries, and Sagas are historic.)\nCrew 3",
             "colours": [],
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "fb0481bd-0ad1-588e-9cd6-8661298171e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda51ef-ee3e-48d4-92e2-c9083bbe0f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda51ef-ee3e-48d4-92e2-c9083bbe0f80.jpg?1",
             "name": "Cabal Stronghold",
             "text": "{T}: Add {C}.\n{3}, {T}: Add {B} for each basic Swamp you control.",
             "colours": [],
@@ -8086,7 +8086,7 @@
         },
         {
             "id": "f369da12-cc76-513f-959f-93bedd009d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b52b9c-7278-46b4-9f3c-3a7fc0c7e526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b52b9c-7278-46b4-9f3c-3a7fc0c7e526.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "49b1b3a5-fcc4-5b83-b30d-f522b4dd2edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631d040-51e9-4540-91e7-aeb5ade84090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631d040-51e9-4540-91e7-aeb5ade84090.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "c0dfade1-3de9-5dc0-a5df-44417437c9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d95d37-5dbe-4a25-bc80-a4db08f3c63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d95d37-5dbe-4a25-bc80-a4db08f3c63a.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "8a86682c-2ebd-501b-b031-1bee916ae76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbe56f2-aec5-4e8b-8003-1bf1ca7f5659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbe56f2-aec5-4e8b-8003-1bf1ca7f5659.jpg?1",
             "name": "Memorial to Folly",
             "text": "Memorial to Folly enters the battlefield tapped.\n{T}: Add {B}.\n{2}{B}, {T}, Sacrifice Memorial to Folly: Return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -8209,7 +8209,7 @@
         },
         {
             "id": "5274537a-fc6c-5ff1-8879-a2b32a2d3ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97bb62e-45cf-4862-b181-5af463a442b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97bb62e-45cf-4862-b181-5af463a442b5.jpg?1",
             "name": "Memorial to Genius",
             "text": "Memorial to Genius enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards.",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "9df4981d-4a3a-5388-8211-c81647b8be39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564d6ff1-2be1-42f1-a919-fe8c2e148c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564d6ff1-2be1-42f1-a919-fe8c2e148c3f.jpg?1",
             "name": "Memorial to Glory",
             "text": "Memorial to Glory enters the battlefield tapped.\n{T}: Add {W}.\n{3}{W}, {T}, Sacrifice Memorial to Glory: Create two 1/1 white Soldier creature tokens.",
             "colours": [],
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "7956e732-51b6-59b6-9f8c-ccf153b5932f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994d903b-0d54-4af4-898f-213e716e9ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994d903b-0d54-4af4-898f-213e716e9ed4.jpg?1",
             "name": "Memorial to Unity",
             "text": "Memorial to Unity enters the battlefield tapped.\n{T}: Add {G}.\n{2}{G}, {T}, Sacrifice Memorial to Unity: Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Then put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "8ea9a20c-6708-52cf-a313-45253de5c5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53920ed7-fc9a-4b50-85c8-d62de05b2390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53920ed7-fc9a-4b50-85c8-d62de05b2390.jpg?1",
             "name": "Memorial to War",
             "text": "Memorial to War enters the battlefield tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice Memorial to War: Destroy target land.",
             "colours": [],
@@ -8329,7 +8329,7 @@
         },
         {
             "id": "6cf241f2-fba0-56ba-8756-1300b258b3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc412fc-e9d4-4283-bd4a-811384e79b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc412fc-e9d4-4283-bd4a-811384e79b5c.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8360,7 +8360,7 @@
         },
         {
             "id": "c639e2fa-87c3-5357-a1f8-01e1044d3e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05cf47-9823-41f9-b893-321ea89e473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05cf47-9823-41f9-b893-321ea89e473e.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "ccf89329-4e12-5be1-8d6b-d51a56d358ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f41f3-7304-4b45-bc16-fa1ddcc5eff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f41f3-7304-4b45-bc16-fa1ddcc5eff0.jpg?1",
             "name": "Zhalfirin Void",
             "text": "When Zhalfirin Void enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {C}.",
             "colours": [],
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "5b771097-73cc-55e4-ae61-3c82f878ccd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023d333b-14f2-40ad-bb76-8b9e38040f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023d333b-14f2-40ad-bb76-8b9e38040f89.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8457,7 +8457,7 @@
         },
         {
             "id": "30844257-fa7d-5454-abd2-39527a602158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f1d17a-c17c-4a27-97db-a37ee8c0e706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f1d17a-c17c-4a27-97db-a37ee8c0e706.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "bc124941-2502-5add-acba-b5611c757dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443d32d-0576-4666-8da8-241de446b7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443d32d-0576-4666-8da8-241de446b7db.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "2aa273a5-4859-5224-bde4-ab1be38b47cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17acb3-0765-4703-a03d-6867a2f59db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17acb3-0765-4703-a03d-6867a2f59db2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "a607c46a-777b-52df-a377-9ca1e7d225d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce67a27-aa80-46ac-955a-8fea336995d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce67a27-aa80-46ac-955a-8fea336995d9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8609,7 +8609,7 @@
         },
         {
             "id": "de94d1ad-c734-585b-90c8-fc459fda52bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54693eb8-bd68-4781-a60f-113adf947d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54693eb8-bd68-4781-a60f-113adf947d5d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "2e1410b5-1fe1-59d4-a19d-41b4b4045807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ee4f9-ca54-4cc1-ac2e-2a2ef5eea9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ee4f9-ca54-4cc1-ac2e-2a2ef5eea9ce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8685,7 +8685,7 @@
         },
         {
             "id": "ce47df56-badc-5f62-8e12-c0a95dfc824a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90520e73-5c7e-4735-a16d-f737e1a230cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90520e73-5c7e-4735-a16d-f737e1a230cf.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8723,7 +8723,7 @@
         },
         {
             "id": "166a204a-e494-50d7-adb6-d2e63d88d17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb6aa-45ac-4a0e-bab2-1a004aac841f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb6aa-45ac-4a0e-bab2-1a004aac841f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "1e201b24-b700-5de8-92ea-5ebb3d48cb27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44baaa0a-9951-4ee7-a9db-64f841bd1bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44baaa0a-9951-4ee7-a9db-64f841bd1bd0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "3833ab30-e75a-5854-927f-c7dc8303b56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc1392-7701-4f3e-b5af-d8756bef6d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc1392-7701-4f3e-b5af-d8756bef6d07.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8837,7 +8837,7 @@
         },
         {
             "id": "cb5b693c-afbb-5e7d-82ee-dda0da3dcae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ebefe-ad31-430b-b298-c9df929e03cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ebefe-ad31-430b-b298-c9df929e03cc.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "11378eb6-370a-5245-998a-a71db992db07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621aa8e1-aebf-4eea-beb5-7fb47700a87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621aa8e1-aebf-4eea-beb5-7fb47700a87a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8913,7 +8913,7 @@
         },
         {
             "id": "88ba47e5-5b95-5a66-8d1a-52b8a2a79793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7255ed-4fec-488e-b334-59d3c0f1acd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7255ed-4fec-488e-b334-59d3c0f1acd6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8951,7 +8951,7 @@
         },
         {
             "id": "01980ea4-a5ae-5636-9ad8-fdbbfb108471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6bb74-b58b-4019-bfa4-7325d70a2fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6bb74-b58b-4019-bfa4-7325d70a2fc2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "6cd09e64-a1bf-5977-b6b5-89041a871172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7b582-dc68-4d12-bebd-baf79fd226f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7b582-dc68-4d12-bebd-baf79fd226f0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9027,7 +9027,7 @@
         },
         {
             "id": "e9284d61-d2f9-585b-a85a-109a0e9c4d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae21165c-cc6d-45cc-b5c1-97b73e85dddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae21165c-cc6d-45cc-b5c1-97b73e85dddd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9065,7 +9065,7 @@
         },
         {
             "id": "91e8ca13-bb2d-5972-9be9-336ede64f1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f48b35-5fe1-4090-ae9d-11955ee8099b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f48b35-5fe1-4090-ae9d-11955ee8099b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "674340b1-db35-559c-998f-fb9691af0bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45adf695-69f3-4d71-a0dd-70d302e2a119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45adf695-69f3-4d71-a0dd-70d302e2a119.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9141,7 +9141,7 @@
         },
         {
             "id": "18f89524-412e-56e5-8d1a-5a59d0252b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060fa791-ccae-42df-b01c-2d4446d78422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060fa791-ccae-42df-b01c-2d4446d78422.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "4e565392-2a01-5542-874d-4534d0fbcfa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2b7388-ac6b-45c0-a5cc-da6450724b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2b7388-ac6b-45c0-a5cc-da6450724b59.jpg?1",
             "name": "Teferi, Timebender",
             "text": "+2: Untap up to one target artifact or creature.\n\u22123: You gain 2 life and draw two cards.\n\u22129: Take an extra turn after this one.",
             "colours": [
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "98a2dfb8-14cf-5ed2-b1f9-553a6278a983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba8df17-ab81-4e28-b274-ad38aa2899b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba8df17-ab81-4e28-b274-ad38aa2899b3.jpg?1",
             "name": "Temporal Machinations",
             "text": "Return target creature to its owner's hand. If you control an artifact, draw a card.",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "4a0f1c43-f8a8-5c2f-b46b-310d3c4d5971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c638677c-2b92-4d0c-b61c-598b5a843844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c638677c-2b92-4d0c-b61c-598b5a843844.jpg?1",
             "name": "Niambi, Faithful Healer",
             "text": "When Niambi, Faithful Healer enters the battlefield, you may search your library and/or graveyard for a card named Teferi, Timebender, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9285,7 +9285,7 @@
         },
         {
             "id": "42c7424d-7b38-5722-86a1-2a7bf1ae1fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058304f4-f08a-4b3a-ae74-c06f4968c99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058304f4-f08a-4b3a-ae74-c06f4968c99a.jpg?1",
             "name": "Teferi's Sentinel",
             "text": "As long as you control a Teferi planeswalker, Teferi's Sentinel gets +4/+0.",
             "colours": [],
@@ -9315,7 +9315,7 @@
         },
         {
             "id": "260d4f75-30da-5dcc-9886-4642aa1e18ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4585bcf-288b-4251-b57f-9d7e50dffc7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4585bcf-288b-4251-b57f-9d7e50dffc7e.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9345,7 +9345,7 @@
         },
         {
             "id": "1ad0b2cc-22f5-5609-ad70-fd6899f7a93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d2384-5c3f-4eb1-86b4-26ee13f1c767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d2384-5c3f-4eb1-86b4-26ee13f1c767.jpg?1",
             "name": "Chandra, Bold Pyromancer",
             "text": "+1: Add {R}{R}. Chandra, Bold Pyromancer deals 2 damage to target player.\n\u22123: Chandra, Bold Pyromancer deals 3 damage to target creature or planeswalker.\n\u22127: Chandra, Bold Pyromancer deals 10 damage to target player and each creature and planeswalker they control.",
             "colours": [
@@ -9380,7 +9380,7 @@
         },
         {
             "id": "1823d18c-a697-5eef-9c0b-a661a77f49c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e849c3-f357-4e81-a580-be5056bed51b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e849c3-f357-4e81-a580-be5056bed51b.jpg?1",
             "name": "Chandra's Outburst",
             "text": "Chandra's Outburst deals 4 damage to target player or planeswalker.\nSearch your library and/or graveyard for a card named Chandra, Bold Pyromancer, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9411,7 +9411,7 @@
         },
         {
             "id": "993603d9-bd7c-5e1b-b897-020c6314dee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95179b31-8cb5-4dd9-ad93-782b8774534d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95179b31-8cb5-4dd9-ad93-782b8774534d.jpg?1",
             "name": "Karplusan Hound",
             "text": "Whenever Karplusan Hound attacks, if you control a Chandra planeswalker, this creature deals 2 damage to any target.",
             "colours": [
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "7928b4e9-8283-585d-95ad-bb222e3e8362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670d02b-9bfc-4671-97ed-59bfbe633d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670d02b-9bfc-4671-97ed-59bfbe633d82.jpg?1",
             "name": "Pyromantic Pilgrim",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -9478,7 +9478,7 @@
         },
         {
             "id": "1980d0d3-70f1-5adb-a77e-ab169f04bfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10f979-63e0-4999-9047-fdbd914cedf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10f979-63e0-4999-9047-fdbd914cedf4.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9508,7 +9508,7 @@
         },
         {
             "id": "66e338d4-7ed4-5737-a8ba-8c6ae36843ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3923708a-60b8-4fb0-beb2-9ab18f5fd381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3923708a-60b8-4fb0-beb2-9ab18f5fd381.jpg?1",
             "name": "Firesong and Sunspeaker",
             "text": "Red instant and sorcery spells you control have lifelink.\nWhenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.",
             "colours": [
@@ -9546,7 +9546,7 @@
         },
         {
             "id": "a2fb70d3-cec6-5ed9-8a5d-a66b8d8be9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bce908-fc95-40c6-a04a-752d56aca836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bce908-fc95-40c6-a04a-752d56aca836.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9580,7 +9580,7 @@
         },
         {
             "id": "86bb0387-4773-59b3-972f-53ba8518f3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7d137c-f6c0-44e5-af9f-a8bbd52d3b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7d137c-f6c0-44e5-af9f-a8bbd52d3b2a.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9614,7 +9614,7 @@
         },
         {
             "id": "d9f8aea6-4fd0-5f6c-9ebb-7f7aa2b03eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b56129-17a2-4512-a4d6-34779224473f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b56129-17a2-4512-a4d6-34779224473f.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9648,7 +9648,7 @@
         },
         {
             "id": "4c856b1d-64ea-5405-a1bf-cbb7182969cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74791ac4-7297-4731-aff8-20130da8b4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74791ac4-7297-4731-aff8-20130da8b4b7.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -9682,7 +9682,7 @@
         },
         {
             "id": "a0be967f-e97f-5b57-bd21-d711a9b0d50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b527bcd-0d37-495a-8457-8123388056b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b527bcd-0d37-495a-8457-8123388056b9.jpg?1",
             "name": "Zombie Knight",
             "text": "",
             "colours": [
@@ -9717,7 +9717,7 @@
         },
         {
             "id": "ac66aba2-a487-5025-8197-d9a268c36935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d33b752-c806-4932-ae0a-46f00ed937de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d33b752-c806-4932-ae0a-46f00ed937de.jpg?1",
             "name": "Nightmare Horror",
             "text": "",
             "colours": [
@@ -9752,7 +9752,7 @@
         },
         {
             "id": "70dc7182-d50b-5a6a-97e8-6dccdd600cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b858b5-803b-4bcf-99d6-8c20c8b37f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b858b5-803b-4bcf-99d6-8c20c8b37f07.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "07ab51c3-554b-5ab8-9505-0c54a3574489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9cc37a-b9c3-40c2-a3e4-abfec86e199b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9cc37a-b9c3-40c2-a3e4-abfec86e199b.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "244a91db-8c0d-56eb-8608-5cad324293d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79264f-0734-48b7-8333-4035e518d46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79264f-0734-48b7-8333-4035e518d46c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9854,7 +9854,7 @@
         },
         {
             "id": "e4dcfe4f-8441-5eec-9f74-a7b3672e90e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0cdb0d-f720-4ed2-af08-ced9b54f6702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0cdb0d-f720-4ed2-af08-ced9b54f6702.jpg?1",
             "name": "Karox Bladewing",
             "text": "",
             "colours": [
@@ -9890,7 +9890,7 @@
         },
         {
             "id": "245d1760-240f-562f-b461-255540830625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5371de1b-db33-4db4-a518-e35c71aa72b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5371de1b-db33-4db4-a518-e35c71aa72b7.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9924,7 +9924,7 @@
         },
         {
             "id": "892ec565-9a4c-5bfd-8c19-9aecdda1f2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b425bdc-b3d5-4825-9f97-a00e2d932438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b425bdc-b3d5-4825-9f97-a00e2d932438.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9958,7 +9958,7 @@
         },
         {
             "id": "99471feb-8fda-52ea-bfa7-db760334bc81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49da8fe-559f-4c34-b904-c285188fb98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49da8fe-559f-4c34-b904-c285188fb98d.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9992,7 +9992,7 @@
         },
         {
             "id": "58a0e346-16cd-5935-b222-66e48175d908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5eafa38-5333-4ef2-9661-08074c580a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5eafa38-5333-4ef2-9661-08074c580a32.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -10023,7 +10023,7 @@
         },
         {
             "id": "79823e1c-a618-5692-8b82-00ec1786c0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcdb224-d4b3-4d99-abea-467def65ef42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcdb224-d4b3-4d99-abea-467def65ef42.jpg?1",
             "name": "Jaya Ballard Emblem",
             "text": "",
             "colours": [],
@@ -10052,7 +10052,7 @@
         },
         {
             "id": "1e082e53-8e0e-5424-a063-c1b5a08a3aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82ac152-5df1-46c9-98e9-ad5585f7e799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82ac152-5df1-46c9-98e9-ad5585f7e799.jpg?1",
             "name": "Teferi, Hero of Dominaria Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/DRK.json
+++ b/Assets/Resources/Sets/DRK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "60d11d96-a614-5182-becf-b0b4f63b8ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e14db1c-0a05-47d2-9f27-df881f7f37ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e14db1c-0a05-47d2-9f27-df881f7f37ab.jpg?1",
             "name": "Angry Mob",
             "text": "Trample\nDuring your turn, the *s below are both equal to the total number of swamps all opponents control. During any other player's turn, * equals 0.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "985f4256-9b2e-5561-b8cc-67b11fb8f313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d4761d-acf2-4cb3-86a8-a3f30420a92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d4761d-acf2-4cb3-86a8-a3f30420a92e.jpg?1",
             "name": "Blood of the Martyr",
             "text": "For the remainder of the turn, you may redirect damage done to any number of creatures to yourself instead.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "af6e3d0a-8b31-50b7-bc23-30f5234eec9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da4fb5a-0d24-4bee-b3f5-535ba9fe6850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da4fb5a-0d24-4bee-b3f5-535ba9fe6850.jpg?1",
             "name": "Brainwash",
             "text": "Target creature may not attack unless its controller pays o3 in addition to any other costs required for the creature to attack.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "9aea78f5-d39f-5652-8d85-c801c1ffdfd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1973a3-1410-4c6d-9b09-bd9d18646a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1973a3-1410-4c6d-9b09-bd9d18646a1e.jpg?1",
             "name": "Cleansing",
             "text": "All land is destroyed. Players may prevent Cleansing from destroying specific lands by paying 1 life for each land they wish to protect. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -132,7 +132,7 @@
         },
         {
             "id": "11c9b608-2df1-5ce1-85e7-959fc671cc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade075fd-73ee-4d12-a2da-48e5938043af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade075fd-73ee-4d12-a2da-48e5938043af.jpg?1",
             "name": "Dust to Dust",
             "text": "Removes two target artifacts from the game.",
             "colours": [
@@ -163,7 +163,7 @@
         },
         {
             "id": "660a73d3-4164-5a88-a6fa-c507034f0101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg?1",
             "name": "Exorcist",
             "text": "o1o\nW, oc\nT: Target black creature is destroyed.",
             "colours": [
@@ -197,7 +197,7 @@
         },
         {
             "id": "6175ab78-9557-5c61-880f-add377daa651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da35f9f-e72c-4154-a212-7de98f84ad7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da35f9f-e72c-4154-a212-7de98f84ad7d.jpg?1",
             "name": "Fasting",
             "text": "You may choose to skip your draw phase; if you do so, you gain 2 life. If you draw a card for any reason, Fasting is destroyed. During your upkeep, put a hunger counter on Fasting. When Fasting has five hunger counters on it, it is destroyed.",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "c5cb0e84-933a-5689-a5d4-0cec01e95d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9357990-701a-4336-b545-ac5a24d89cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9357990-701a-4336-b545-ac5a24d89cad.jpg?1",
             "name": "Festival",
             "text": "Opponent may not declare an attack this turn. Play during opponent's upkeep phase.",
             "colours": [
@@ -259,7 +259,7 @@
         },
         {
             "id": "88fb1446-6e49-5b9b-856c-c59e5b2538b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5208dbb-63d2-4789-8ef9-f82499a43b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5208dbb-63d2-4789-8ef9-f82499a43b3a.jpg?1",
             "name": "Fire and Brimstone",
             "text": "Fire and Brimstone does 4 damage to target player and 4 damage to you. Can only be used during a turn in which target player has declared an attack.",
             "colours": [
@@ -290,7 +290,7 @@
         },
         {
             "id": "680f5452-1014-51a5-ae26-661e995bddb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c8a850-bc99-4679-a316-45ecdea696b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c8a850-bc99-4679-a316-45ecdea696b2.jpg?1",
             "name": "Holy Light",
             "text": "All non-white creatures get -1/-1 until end of turn.",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "27d476b9-5ad6-572c-ac34-438268db1d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg?1",
             "name": "Knights of Thorn",
             "text": "Protection from red, banding",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "f0911261-37c1-5895-aa4a-2c0bb7c04da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c9f463-d1cc-4f11-aad2-d4a4520aa978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c9f463-d1cc-4f11-aad2-d4a4520aa978.jpg?1",
             "name": "Martyr's Cry",
             "text": "All white creatures are removed from the game. Players must draw one card for each white creature they control that is lost in this manner.",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "a065eb66-5fe4-5b0c-93f7-5af0627b11c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d29bda-096c-44d4-b45e-c2c507f8efbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d29bda-096c-44d4-b45e-c2c507f8efbe.jpg?1",
             "name": "Miracle Worker",
             "text": "oc\nT: Destroy target enchantment card on a creature you control.",
             "colours": [
@@ -420,7 +420,7 @@
         },
         {
             "id": "b1a13008-0046-5d43-a927-616a7c1b584d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4104546-abd9-4bfb-a65e-5928cdd4522f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4104546-abd9-4bfb-a65e-5928cdd4522f.jpg?1",
             "name": "Morale",
             "text": "All attacking creatures gain +1/+1 until end of turn.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "245b93ee-c442-5212-a68b-8dc3e5245fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2f6936-b50c-4907-9b55-ebf8a3fba8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2f6936-b50c-4907-9b55-ebf8a3fba8f5.jpg?1",
             "name": "Pikemen",
             "text": "Banding, first strike",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "f54d3eb7-350c-5349-9496-e3deabab358d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e03d335-d259-4ab4-814f-9333cfd3afc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e03d335-d259-4ab4-814f-9333cfd3afc9.jpg?1",
             "name": "Preacher",
             "text": "oc\nT: Gain control of one of opponent's creatures. Opponent chooses which target creature you control. If Preacher becomes untapped, you lose control of this creature; you may choose not to untap Preacher as normal during your untap phase. You also lose control of the creature if Preacher leaves play or at end of game.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "6efd8cb3-756c-55f1-821a-233846fc722b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374df061-ebd2-4f1f-9a6e-7940a49197a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374df061-ebd2-4f1f-9a6e-7940a49197a9.jpg?1",
             "name": "Squire",
             "text": "",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "9621c7e9-f3ea-5007-932e-168a5b26eecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6da540-6803-47e5-9af0-7ae8e2f84b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6da540-6803-47e5-9af0-7ae8e2f84b6c.jpg?1",
             "name": "Tivadar's Crusade",
             "text": "All Goblins are destroyed.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "6ee3f11a-fcfd-51d2-b4f3-4ebcba840853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg?1",
             "name": "Witch Hunter",
             "text": "oc\nT: Witch Hunter does 1 damage to target player.\no1o\nWo\nW, oc\nT: Return target creature opponent controls from play to owner's hand. Enchantments on target creature are destroyed.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "f4633f0c-5f50-5772-96ab-e473fe076c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07df65c-ebcc-4873-b928-d99040d1f2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07df65c-ebcc-4873-b928-d99040d1f2f6.jpg?1",
             "name": "Amnesia",
             "text": "Look at target player's hand. Target player discards all non-land cards in his or her hand.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "742c1760-32be-5774-960d-c8fe36aff7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg?1",
             "name": "Apprentice Wizard",
             "text": "o\nU, oc\nT: Add o3 to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "ca304132-bcd6-5cf1-a1b4-07962a37dea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13453abe-3f05-4956-8493-382d7d2af699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13453abe-3f05-4956-8493-382d7d2af699.jpg?1",
             "name": "Dance of Many",
             "text": "When Dance of Many is brought into play, choose a target summon card in play. Then put a token creature in play and treat it as if you have just brought an exact copy of target summon card into play. If Dance of Many leaves play, remove token creature from game. If token creature leaves play, destroy Dance of Many. If you do not pay o\nUo\nU during your upkeep, Dance of Many is destroyed.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "22fc22cd-5b76-5f93-bbb2-e15af8c0768b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6a230-6bc0-499c-b7fd-4aaa2569f98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6a230-6bc0-499c-b7fd-4aaa2569f98f.jpg?1",
             "name": "Deep Water",
             "text": "oo\nU All mana-producing lands you control provide o\nU instead of their normal mana until end of turn.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "d265e0a8-77de-5b0e-885c-755cb8f70fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg?1",
             "name": "Drowned",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "7da6bef5-4c15-5546-9030-9455571c5b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8834c18-0e4e-4785-9d15-b33345e3789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8834c18-0e4e-4785-9d15-b33345e3789b.jpg?1",
             "name": "Electric Eel",
             "text": "o\nRoo\nR +2/+0; Electric Eel does 1 damage to you. Electric Eel does 1 damage to you when it is brought into play.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "9a801da4-e614-5f06-8c8d-dde6e00f95a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b6507-89ee-482e-aafd-8e05ada8f1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b6507-89ee-482e-aafd-8e05ada8f1ce.jpg?1",
             "name": "Erosion",
             "text": "Target land is destroyed unless its controller pays o1 or pays 1 life during his or her upkeep. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "ae85935e-b55b-51c1-a9be-a5db09acb083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabc3267-b59b-4f36-8873-5b4b072711ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabc3267-b59b-4f36-8873-5b4b072711ca.jpg?1",
             "name": "Flood",
             "text": "o\nUoo\nU Target non-flying creature becomes tapped.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "6869e7dd-f681-585b-a058-c8387f86df7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db591b28-37e5-4e7c-ae4d-d761262b12d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db591b28-37e5-4e7c-ae4d-d761262b12d0.jpg?1",
             "name": "Ghost Ship",
             "text": "Flying, o\nUo\nUoo\nU Regenerates",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "d1f7d9e5-b393-5e43-a376-810fb55509bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4a19-0f2f-4713-a869-58832484648d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4a19-0f2f-4713-a869-58832484648d.jpg?1",
             "name": "Giant Shark",
             "text": "If Giant Shark blocks or is blocked by a creature that has taken damage this turn, Giant Shark gains +2/+0 and trample until end of turn. Giant Shark cannot attack unless opponent controls at least one island. Giant Shark is buried immediately if at any time controller controls no islands.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "e0151b5b-e8a7-5286-be0f-4f62b68f0e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b638d9be-c533-45c3-92f9-fabf56edc2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b638d9be-c533-45c3-92f9-fabf56edc2df.jpg?1",
             "name": "Leviathan",
             "text": "Trample\nLeviathan comes into play tapped, and does not untap as normal during your untap phase.\nSacrifice two islands during your upkeep phase to untap Leviathan.\nLeviathan may not attack unless you sacrifice two islands during your attack.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "b51efe73-7d7a-5ac4-805a-adc84f63b8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857a00a-82e0-4227-86ee-1f9c7ca232ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857a00a-82e0-4227-86ee-1f9c7ca232ae.jpg?1",
             "name": "Mana Vortex",
             "text": "Each player who controls land sacrifices one land during his or her upkeep. If at any time there are no lands in play, Mana Vortex is destroyed. If you do not sacrifice a land when Mana Vortex is cast, Mana Vortex is countered.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "2161112f-4077-50d0-808d-15243c08cd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36313dc7-6bf2-4d73-b696-969d984a7466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36313dc7-6bf2-4d73-b696-969d984a7466.jpg?1",
             "name": "Merfolk Assassin",
             "text": "oc\nT: Destroy target creature that has islandwalk.",
             "colours": [
@@ -1041,7 +1041,7 @@
         },
         {
             "id": "4b15e01a-1fe7-5668-84ae-e70c6bdb2a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee810a5-f0f9-4b73-8194-3d1344784050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee810a5-f0f9-4b73-8194-3d1344784050.jpg?1",
             "name": "Mind Bomb",
             "text": "Mind Bomb does 3 damage to each player. All players may discard up to three cards of their choice from their hands. Each card a player discards in this manner prevents 1 damage to that player from Mind Bomb.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "3af1aad7-27c3-513b-a4c4-33637938ad6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec3275e-4491-43a8-9f23-d7b48177c103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec3275e-4491-43a8-9f23-d7b48177c103.jpg?1",
             "name": "Psychic Allergy",
             "text": "Choose a color when casting Psychic Allergy. During opponent's upkeep, Psychic Allergy does 1 damage to opponent for each card of this color that he or she controls. Sacrifice two islands during your upkeep or Psychic Allergy is destroyed.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "fef800df-bb64-5e3e-ad3a-484cedc6760d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f11ae4-e30e-441d-bb64-439930d9997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f11ae4-e30e-441d-bb64-439930d9997c.jpg?1",
             "name": "Riptide",
             "text": "All blue creatures become tapped.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "89c3c711-a5e9-5d9e-a576-0a6b11eb171b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e0f9ec-2b06-4bda-8b80-a716d82d1f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e0f9ec-2b06-4bda-8b80-a716d82d1f13.jpg?1",
             "name": "Sunken City",
             "text": "All blue creatures gain +1/+1.\nIf you do not pay o\nUo\nU during your upkeep, Sunken City is destroyed.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "56a24040-5782-50f4-b10b-daab26fc1eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497bc42d-ab81-4d84-bdf7-e3a05a7c984d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497bc42d-ab81-4d84-bdf7-e3a05a7c984d.jpg?1",
             "name": "Tangle Kelp",
             "text": "Target creature does not untap during its controller's untap phase if it attacked during its controller's last turn. Target creature becomes tapped when Tangle Kelp is cast.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "f6a602ee-3c1c-5ef6-bf44-40276c9fa9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3da4a88-5225-467f-9240-f30bc1eee520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3da4a88-5225-467f-9240-f30bc1eee520.jpg?1",
             "name": "Water Wurm",
             "text": "Water Wurm gains +0/+1 if opponent controls at least one island.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "e2178fba-af5c-5936-8f6e-8e8b98b96180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825496e5-19c7-4f50-8070-0265a58608dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825496e5-19c7-4f50-8070-0265a58608dc.jpg?1",
             "name": "Ashes to Ashes",
             "text": "Ashes to Ashes removes two target non-artifact creatures from the game and does 5 damage to you.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "c24facd0-4b74-56d2-825c-0c9a8ba4206e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66eaa7d6-48b2-4b35-a834-790edd679e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66eaa7d6-48b2-4b35-a834-790edd679e0e.jpg?1",
             "name": "Banshee",
             "text": "o\nX, oc\nT: Banshee does X damage\u2014half (rounded up) to you and half (rounded down) to any one target.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "28a28373-86e2-538e-a4b7-a2fdaecb41ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb7271-634a-4612-9073-7a5438e8c2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb7271-634a-4612-9073-7a5438e8c2b8.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "5d521295-e76f-50c6-9881-498e80555ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64c9153-bc6d-4a64-885f-c039a5487a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64c9153-bc6d-4a64-885f-c039a5487a31.jpg?1",
             "name": "Bog Rats",
             "text": "Cannot be blocked by walls.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "fa19bc8d-6b01-5a39-9317-bdb857ad2d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0d070-8a42-4d5e-8f2b-ceb59147de6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0d070-8a42-4d5e-8f2b-ceb59147de6f.jpg?1",
             "name": "Curse Artifact",
             "text": "During his or her upkeep, controller of target artifact may choose to bury target artifact. If controller chooses not to bury target artifact, Curse Artifact does 2 damage to him or her.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "5f25f4ce-bed0-5bf4-917f-ef1f51638171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89fe2be-bb7e-4bae-9b1f-9f0d58f20ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89fe2be-bb7e-4bae-9b1f-9f0d58f20ceb.jpg?1",
             "name": "Eater of the Dead",
             "text": "o0: Take one creature from any graveyard and remove it from the game. Untap Eater of the Dead.",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "7d58d12d-a310-557b-ac5c-a3aee3a51b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99894d-5ece-44f1-acce-474494ae2084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99894d-5ece-44f1-acce-474494ae2084.jpg?1",
             "name": "Frankenstein's Monster",
             "text": "When Frankenstein's Monster is brought into play, if you do not take X creatures from your graveyard and remove them from the game, Frankenstein's Monster is countered. For each creature removed from your graveyard in this way, you may choose to give Frankenstein's Monster a permanent +2/+0, +1/+1, or +0/+2.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "23664438-d521-5f8c-8f4b-96d913cd27a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg?1",
             "name": "Grave Robbers",
             "text": "o\nB, oc\nT: Take one artifact from any graveyard and remove it from the game. Gain 2 life.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "bc68ffa9-0a53-5baa-91a2-583ab678f3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f133f06-6398-4db1-8577-66c16fd3e00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f133f06-6398-4db1-8577-66c16fd3e00d.jpg?1",
             "name": "Inquisition",
             "text": "Look at target player's hand. Inquisition does 1 damage to target player for each white card in his or her hand.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "69373057-60e2-562c-98f4-1b7278df491c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80ecb15-258b-4fc9-86e4-c2bf01891606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80ecb15-258b-4fc9-86e4-c2bf01891606.jpg?1",
             "name": "Marsh Gas",
             "text": "All creatures get -2/-0 until end of turn.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "a0741e02-1816-5ca6-b4a9-c9dc277def26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a213450f-02f4-4c08-8da8-891ebfa8e237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a213450f-02f4-4c08-8da8-891ebfa8e237.jpg?1",
             "name": "Murk Dwellers",
             "text": "When attacking, Murk Dwellers gain +2/+0 if not blocked.",
             "colours": [
@@ -1589,7 +1589,7 @@
         },
         {
             "id": "21c31892-344a-5ae4-b7ca-09187a9b6037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348a467a-4661-4fdb-af1d-9171a1a930d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348a467a-4661-4fdb-af1d-9171a1a930d9.jpg?1",
             "name": "Nameless Race",
             "text": "Trample\nPay * life when bringing Nameless Race into play. Effects that prevent or redirect damage may not be used to counter this loss of life. When Nameless Race is brought into play, * may not be greater than the total number of white cards all opponents have in play and in their graveyards.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "e0a7e0c3-d82c-56b8-94b0-1563386d7803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c133b8-8383-433f-be96-c47a937287b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c133b8-8383-433f-be96-c47a937287b7.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at opponent's hand.\nIf opponent has any creature cards in hand, he or she discards one of them at random. This ability can only be used during controller's turn.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "b0d49ef7-653f-52bd-a187-62ff922e0ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06900a71-34ca-48c6-94ac-fca744356829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06900a71-34ca-48c6-94ac-fca744356829.jpg?1",
             "name": "Season of the Witch",
             "text": "At the end of each player's turn, all of his or her untapped creatures that could have attacked but did not are destroyed. If you do not pay 2 life during your upkeep, Season of the Witch is destroyed. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "51debb8f-7f50-5c99-8775-47108bc09fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a176e1-b22b-4f36-ba7b-c506cb4e1bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a176e1-b22b-4f36-ba7b-c506cb4e1bed.jpg?1",
             "name": "The Fallen",
             "text": "During its controller's upkeep, The Fallen does 1 damage to each opponent it has previously damaged.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "eb9cf89f-8371-5be9-b9de-e6dcf19d66f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848ad6d5-3a7e-4d6b-9929-36465796871f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848ad6d5-3a7e-4d6b-9929-36465796871f.jpg?1",
             "name": "Uncle Istvan",
             "text": "All damage done to Uncle Istvan by creatures is reduced to 0.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "13b239a8-9a73-5193-8b1c-04ae2a8d2d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30efdb-f1f1-497f-80a6-ec961db67c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30efdb-f1f1-497f-80a6-ec961db67c1d.jpg?1",
             "name": "Word of Binding",
             "text": "X target creatures become tapped.",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "57fdddd7-ff03-569f-bf53-d813ab60b51e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a97821-ca5b-46fb-af08-86de81d0daac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a97821-ca5b-46fb-af08-86de81d0daac.jpg?1",
             "name": "Worms of the Earth",
             "text": "No new land may be brought into play. During any player's upkeep, any player may destroy Worms of the Earth by sacrificing two lands or taking 5 damage from Worms of the Earth.",
             "colours": [
@@ -1813,7 +1813,7 @@
         },
         {
             "id": "7c92ec59-0b8e-5010-b961-aed18bc39dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ba83ab-83f5-421d-bba1-0f925870b5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ba83ab-83f5-421d-bba1-0f925870b5c8.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample\nBall Lightning may attack on the turn during which it is summoned. Ball Lightning is buried at the end of the turn during which it is summoned.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "70b8059d-311f-5010-9d2b-cf8e4e0d3864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78373616-e2d6-4ccf-998f-09f02bea45b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78373616-e2d6-4ccf-998f-09f02bea45b4.jpg?1",
             "name": "Blood Moon",
             "text": "All non-basic lands are now basic mountains.",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "0b6cb935-8eaa-54d3-a663-7eb3cb115460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2cc4a6-fdcc-4082-801a-d2c50e560e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2cc4a6-fdcc-4082-801a-d2c50e560e8d.jpg?1",
             "name": "Brothers of Fire",
             "text": "o1o\nRoo\nR Brothers of Fire do 1 damage to any target and 1 damage to you.",
             "colours": [
@@ -1911,7 +1911,7 @@
         },
         {
             "id": "92c28d18-5b59-50e6-a330-66aa0f02a028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72746a5d-faa1-44b7-97b5-0ef9302a3c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72746a5d-faa1-44b7-97b5-0ef9302a3c13.jpg?1",
             "name": "Cave People",
             "text": "If declared as an attacker, Cave People get +1/-2 until end of turn.\no1o\nRo\nR, oc\nT: Target creature gains mountainwalk until end of turn.",
             "colours": [
@@ -1944,7 +1944,7 @@
         },
         {
             "id": "b0bd3dfb-4935-5698-bae0-48bd6928a12e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d646feea-3c20-4737-8d20-ffad42258ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d646feea-3c20-4737-8d20-ffad42258ced.jpg?1",
             "name": "Eternal Flame",
             "text": "Eternal Flame does an amount of damage to your opponent equal to the number of mountains you control, but it also does half that amount of damage to you, rounding up.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "42b0d781-a69e-5481-b498-92a93d763714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3419db6-1c38-4aa4-b953-1dde7d22b927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3419db6-1c38-4aa4-b953-1dde7d22b927.jpg?1",
             "name": "Fire Drake",
             "text": "Flying\noo\nR +1/+0 until end of turn. No more than o\nR may be spent in this way each turn.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "91b08c89-99f0-58fb-94bd-f11d75b3178c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2d778d-d74b-45ec-a86b-5d52ffad6ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2d778d-d74b-45ec-a86b-5d52ffad6ba5.jpg?1",
             "name": "Fissure",
             "text": "Target land or creature is buried.",
             "colours": [
@@ -2039,7 +2039,7 @@
         },
         {
             "id": "1e82f5d7-28b8-5d17-9475-f0aa33e63b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a415b0-00a2-4a65-8994-4a395c50ae2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a415b0-00a2-4a65-8994-4a395c50ae2d.jpg?1",
             "name": "Goblin Caves",
             "text": "If target land is a basic mountain, all Goblins gain +0/+2.",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "220cec60-5038-50d3-b59b-cabe5885f78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a538b9d-351e-40bb-be11-9ba08c16352b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a538b9d-351e-40bb-be11-9ba08c16352b.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT: Sacrifice Goblin Digging Team to destroy target wall.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "ae64cf01-1062-5f0d-a8bb-fc7c72fdfc88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7135a569-e5d3-4a1f-924b-bdb86926b4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7135a569-e5d3-4a1f-924b-bdb86926b4e1.jpg?1",
             "name": "Goblin Hero",
             "text": "",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "7e2d3d69-6d2b-58de-9069-3c2e2910a16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0b59d-8f9b-4a76-9845-bcb0dc32523d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0b59d-8f9b-4a76-9845-bcb0dc32523d.jpg?1",
             "name": "Goblin Rock Sled",
             "text": "Trample\nRock Sled may not attack unless opponent controls at least one mountain. Rock Sled does not untap as normal during your untap phase if it attacked during your last turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "d3e530d4-363a-5b43-af8b-46254425646f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd69a6dc-27f3-42aa-9e63-4417796e4ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd69a6dc-27f3-42aa-9e63-4417796e4ef5.jpg?1",
             "name": "Goblin Shrine",
             "text": "If target land is a basic mountain, all Goblins gain +1/0. Goblin Shrine does 1 damage to all Goblins if it leaves play.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "23edced7-2dbc-51c5-9f85-fe20ba555af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b73dfb4-d930-4a89-b621-129dd9f6328c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b73dfb4-d930-4a89-b621-129dd9f6328c.jpg?1",
             "name": "Goblin Wizard",
             "text": "oc\nT: Take a Goblin from your hand and put it directly into play. Treat this goblin as if it were just summoned.\noo\nR Target Goblin gains protection from white until end of turn.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "ee6e7bb8-f9d0-53f2-b626-a75284e50f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd333b18-b896-4ab8-9c46-eed4efdd94f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd333b18-b896-4ab8-9c46-eed4efdd94f2.jpg?1",
             "name": "Goblins of the Flarg",
             "text": "Mountainwalk\nGoblins of the Flarg are buried if controller controls any Dwarves.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "76079bfe-ba8c-5657-ba4a-22597935f4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b61512-5b24-424c-966f-36b595781e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b61512-5b24-424c-966f-36b595781e14.jpg?1",
             "name": "Inferno",
             "text": "Inferno does 6 damage to all players and all creatures.",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "f505a90c-4d6c-5848-a4e8-9f5a83f0d717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72955141-d990-459f-adbe-7d3d0f5f6c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72955141-d990-459f-adbe-7d3d0f5f6c95.jpg?1",
             "name": "Mana Clash",
             "text": "You and target player each flip a coin. Mana Clash does 1 damage to any player whose coin comes up tails. Repeat this process until both players' coins come up heads at the same time.",
             "colours": [
@@ -2334,7 +2334,7 @@
         },
         {
             "id": "062d6ed0-82ff-5172-a1e3-461b852c91e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a10fd5-506e-46bf-87e6-fde134c0dc04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a10fd5-506e-46bf-87e6-fde134c0dc04.jpg?1",
             "name": "Orc General",
             "text": "oc\nT: Sacrifice one Orc or Goblin to give all Orcs +1/+1 until end of turn.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "d9372348-fefd-5998-ad1a-e664ff9053d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e0ccd-decb-48d2-981f-cefa8045340f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e0ccd-decb-48d2-981f-cefa8045340f.jpg?1",
             "name": "Sisters of the Flame",
             "text": "oc\nT: Add o\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "b551e9aa-e3cf-5ec0-acd0-69240060b632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a615650-4da3-4efc-aa5e-c1f2c4f79478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a615650-4da3-4efc-aa5e-c1f2c4f79478.jpg?1",
             "name": "Carnivorous Plant",
             "text": "",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "37b5042e-09a1-56d4-80b3-d90b4437c4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f395278e-6d74-4f35-af9d-21bad7b19763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f395278e-6d74-4f35-af9d-21bad7b19763.jpg?1",
             "name": "Elves of Deep Shadow",
             "text": "oc\nT: Add o\nB to your mana pool, and Elves of Deep Shadow do 1 damage to you. This ability is played as an interrupt.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "766b09da-d1e1-568c-a543-88fc63f61896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1ae3d6-6d96-4db6-bbc4-cee91bae6cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1ae3d6-6d96-4db6-bbc4-cee91bae6cf7.jpg?1",
             "name": "Gaea's Touch",
             "text": "You may put one additional land in play during each of your turns, but that land must be a basic forest. You may sacrifice Gaea's Touch to add o\nGo\nG to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "e4a6ea15-93da-55fb-9afa-7252fd71ce99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7705328-4b5d-4383-9abe-75fca9c32c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7705328-4b5d-4383-9abe-75fca9c32c09.jpg?1",
             "name": "Gaea's Touch",
             "text": "",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "89663c71-b978-59a9-b142-ae95eeba7eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg?1",
             "name": "Hidden Path",
             "text": "All green creatures gain forestwalk.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "935267fb-334e-565e-b29c-527f49cf3eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff99543d-86a1-44f8-88ec-aaec071d6c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff99543d-86a1-44f8-88ec-aaec071d6c05.jpg?1",
             "name": "Land Leeches",
             "text": "First strike",
             "colours": [
@@ -2601,7 +2601,7 @@
         },
         {
             "id": "2decfffe-8a1e-530f-ae37-e57ee113bd12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39eb671-e17e-4c5a-8913-1e3be7faedfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39eb671-e17e-4c5a-8913-1e3be7faedfb.jpg?1",
             "name": "Lurker",
             "text": "Lurker may not be the target of any spell unless Lurker was declared as an attacker or blocker this turn.",
             "colours": [
@@ -2634,7 +2634,7 @@
         },
         {
             "id": "a96fe16b-d076-5b67-963e-6ce9c49a9346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109cce7a-96f7-4e67-878a-bd5c93ea8643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109cce7a-96f7-4e67-878a-bd5c93ea8643.jpg?1",
             "name": "Marsh Viper",
             "text": "If Marsh Viper damages opponent, opponent gets two poison counters. If opponent ever has ten or more poison counters, opponent loses game.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "5693598b-0831-54a6-8551-6403729a72b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg?1",
             "name": "Niall Silvain",
             "text": "o\nGo\nGo\nGo\nG, oc\nT: Target creature is regenerated.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "2dc1b1d7-5516-586f-a5c6-4c1b1b83f956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5926f-9988-4bc0-b2b7-e286db208310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5926f-9988-4bc0-b2b7-e286db208310.jpg?1",
             "name": "People of the Woods",
             "text": "The * below represents the number of forests controlled by People of the Woods' controller.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "2c71635e-3235-51ca-a067-a15c5fcf3802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fb3014-f631-4a75-92cd-7e626b13a4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fb3014-f631-4a75-92cd-7e626b13a4c3.jpg?1",
             "name": "Savaen Elves",
             "text": "o\nGo\nG, oc\nT: Target enchant land is destroyed.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "b83586ae-a0b3-56a0-bfeb-a3aaecce77af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b762a7-a774-4cb4-8ecf-dd6486a066c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b762a7-a774-4cb4-8ecf-dd6486a066c3.jpg?1",
             "name": "Scarwood Bandits",
             "text": "Forestwalk\no2o\nG, oc\nT: Take control of target artifact. Opponent may counter this action by paying o2. You lose control of target artifact if Scarwood Bandits leave play or at end of game.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "b3c89730-d48d-5a30-8d85-934abe75d03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2655e4-3a4d-4f73-820a-02fab675d42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2655e4-3a4d-4f73-820a-02fab675d42e.jpg?1",
             "name": "Scarwood Hag",
             "text": "o\nGo\nGo\nGo\nG, oc\nT: Target creature gains forestwalk until end of turn.\noc\nT: Target creature loses forestwalk until end of turn.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "55e133c1-2c1a-54ea-8b90-80adb54c004d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e99870c-b2b9-431b-b8a8-3f4a80aa8fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e99870c-b2b9-431b-b8a8-3f4a80aa8fa5.jpg?1",
             "name": "Scavenger Folk",
             "text": "o\nG, oc\nT: Sacrifice Scavenger Folk to destroy target artifact.",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "7c7c6846-ec8e-5ba1-acbe-41b453be0ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7011356e-7516-4ca0-ac54-d30af7ce03a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7011356e-7516-4ca0-ac54-d30af7ce03a2.jpg?1",
             "name": "Spitting Slug",
             "text": "o1oo\nG Spitting Slug gains first strike until end of turn. If this ability is not activated, all creatures blocking or blocked by Spitting Slug gain first strike until end of turn.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "e9e305ae-06d1-52b0-ad91-b5450de69e11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffc69e-26f2-434f-8c89-2df108dd984a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffc69e-26f2-434f-8c89-2df108dd984a.jpg?1",
             "name": "Tracker",
             "text": "o\nGo\nG, oc\nT: Tracker does an amount of damage equal to its power to target creature. Target creature does an amount of damage equal to its power to Tracker.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "ac2bbd74-e4ec-52fa-aba6-080344997a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0480f5-6aae-4297-afa6-3f7a5801bf95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0480f5-6aae-4297-afa6-3f7a5801bf95.jpg?1",
             "name": "Venom",
             "text": "All non-wall creatures target creature blocks or is blocked by are destroyed at the end of combat.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "32cc7226-4a37-5dcc-a5d3-d67ad0c36e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56146bf-5db0-4bef-83bb-efa5ebec6684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56146bf-5db0-4bef-83bb-efa5ebec6684.jpg?1",
             "name": "Whippoorwill",
             "text": "o\nGo\nG, oc\nT: Until end of turn, target creature may not regenerate and damage done to target creature may not be prevented or redirected. If target creature goes to the graveyard, remove it from game.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "5ff3458b-d974-57e8-9a61-df376654776c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa20173-e88a-4b14-9c54-14567ca5571c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa20173-e88a-4b14-9c54-14567ca5571c.jpg?1",
             "name": "Wormwood Treefolk",
             "text": "o\nGoo\nG Wormwood Treefolk gains forestwalk until end of turn and does 2 damage to you.\no\nBoo\nB Wormwood Treefolk gains swampwalk until end of turn and does 2 damage to you.",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "bb85954c-b092-5ba8-b857-f4e5a7fb9ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aabd80f-a18a-4bc1-9f05-4c3a63de77ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aabd80f-a18a-4bc1-9f05-4c3a63de77ce.jpg?1",
             "name": "Marsh Goblins",
             "text": "Swampwalk\nCounts as both a black card and a red card.",
             "colours": [
@@ -3067,7 +3067,7 @@
         },
         {
             "id": "de4ddf02-868d-508b-90d9-42c3e14a3219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5542d236-af43-43b8-b30f-8980d74bbdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5542d236-af43-43b8-b30f-8980d74bbdd0.jpg?1",
             "name": "Scarwood Goblins",
             "text": "Counts as both a green card and a red card.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "521f6071-be1e-5440-8b3f-907bc504c289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d3df64-1e90-4aef-86ae-0062aa23ff30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d3df64-1e90-4aef-86ae-0062aa23ff30.jpg?1",
             "name": "Dark Heart of the Wood",
             "text": "You may sacrifice a forest to gain 3 life.\nCounts as both a black card and a green card.",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "3b344894-4e0c-55d0-a687-5bbddc1f44e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768a307-da2e-435e-8efd-72d82b4d4a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768a307-da2e-435e-8efd-72d82b4d4a2b.jpg?1",
             "name": "Barl's Cage",
             "text": "o3: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [],
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "297b4bf4-a5ab-5c3d-9576-3f2ee73185ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a31de0-d764-4ff6-a85f-027e1e58d86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a31de0-d764-4ff6-a85f-027e1e58d86c.jpg?1",
             "name": "Bone Flute",
             "text": "o2, oc\nT: All creatures get -1/-0 until end of turn.",
             "colours": [],
@@ -3189,7 +3189,7 @@
         },
         {
             "id": "9b5792de-8ba7-505e-9674-db65570cf772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a391ada-e9e3-45db-ae84-17421ac6b44d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a391ada-e9e3-45db-ae84-17421ac6b44d.jpg?1",
             "name": "Book of Rass",
             "text": "o2: Pay 2 life to draw one card. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [],
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "fb3a6f27-2d9b-5111-a1b2-6cf07609d1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg?1",
             "name": "Coal Golem",
             "text": "o3: Sacrifice Coal Golem to add o\nRo\nRo\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "1c6240ac-ffa7-56a4-a29b-046a71305dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cfe9b9-677d-4ecb-83ab-67fb6481371d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cfe9b9-677d-4ecb-83ab-67fb6481371d.jpg?1",
             "name": "Dark Sphere",
             "text": "oc\nT: Sacrifice Dark Sphere to prevent half of the damage done to you by a single source, rounded down.",
             "colours": [],
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "5586410b-e298-5068-a6fb-7290f7599a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b0f228-6b06-4426-a557-1225d547b908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b0f228-6b06-4426-a557-1225d547b908.jpg?1",
             "name": "Diabolic Machine",
             "text": "o3: Regenerates",
             "colours": [],
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "6722c0e0-13c7-5a24-bd60-f89836d48ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc47e322-f8b8-4685-b035-fda0cc433e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc47e322-f8b8-4685-b035-fda0cc433e6b.jpg?1",
             "name": "Fellwar Stone",
             "text": "oc\nT: Add 1 mana to your mana pool. This mana may be of any color that any of opponent's lands can produce. This ability is played as an interrupt.",
             "colours": [],
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "567535e1-09d0-5933-9493-5eb4ce41fae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60eb23-cb9a-4203-86fb-60e47dbd870b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60eb23-cb9a-4203-86fb-60e47dbd870b.jpg?1",
             "name": "Fountain of Youth",
             "text": "o2, oc\nT: Gain 1 life.",
             "colours": [],
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "90e0d9fd-84da-5314-a5b1-a7e79c5445fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cca55-1ea7-4a11-8c5d-3d84c9af862f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cca55-1ea7-4a11-8c5d-3d84c9af862f.jpg?1",
             "name": "Fountain of Youth",
             "text": "",
             "colours": [],
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "6f38331e-73ed-5d11-8946-05c70504ffcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31a957-ad1e-40cc-b3c4-2f4caa492b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31a957-ad1e-40cc-b3c4-2f4caa492b77.jpg?1",
             "name": "Living Armor",
             "text": "oc\nT: Sacrifice Living Armor to put a +0/+X counter on target creature, where X is target creature's casting cost.",
             "colours": [],
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "3c438f2e-fd90-5f5a-9787-58afbd4536c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893e8e9c-983e-4db1-8d93-10637025a559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893e8e9c-983e-4db1-8d93-10637025a559.jpg?1",
             "name": "Necropolis",
             "text": "Counts as a wall.\no0: Take a creature in your graveyard and remove it from the game. Put X +0/+1 counters on Necropolis, where X is the removed creature's casting cost.",
             "colours": [],
@@ -3447,7 +3447,7 @@
         },
         {
             "id": "b330c63d-c481-5c8d-98d2-cb8558fb5b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d551ff93-d8da-4c21-bc3c-6451c0dde07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d551ff93-d8da-4c21-bc3c-6451c0dde07e.jpg?1",
             "name": "Reflecting Mirror",
             "text": "o\nX, oc\nT: Target spell, which targets you, targets the player of your choice instead. X is twice the casting cost of target spell. This ability is played as an interrupt.",
             "colours": [],
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "2cebd997-e506-5c13-9be8-e505b7676a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741dbcf2-3372-45a8-b66f-d2ae12b4aac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741dbcf2-3372-45a8-b66f-d2ae12b4aac6.jpg?1",
             "name": "Runesword",
             "text": "o3, oc\nT: Target attacking creature gains +2/+0 until end of turn. Any creature damaged by target creature may not be regenerated this turn; if such a creature is placed in the graveyard this turn, remove it from the game. If target creature leaves play before end of turn, Runesword is buried.",
             "colours": [],
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "410e1ae0-5c06-540c-b450-063e1894bddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf27955f-015b-4d86-99b9-4c4f6fe2fa73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf27955f-015b-4d86-99b9-4c4f6fe2fa73.jpg?1",
             "name": "Runesword",
             "text": "",
             "colours": [],
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "3a04c9f5-5733-516b-8542-9870e6aaa8d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93850e74-744c-4261-a84e-01eaced6e49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93850e74-744c-4261-a84e-01eaced6e49a.jpg?1",
             "name": "Scarecrow",
             "text": "o6, oc\nT: Until end of turn, all damage done to you by flying creatures is reduced to 0.",
             "colours": [],
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "71604cf4-ad10-578e-918f-1003ff70d71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1d9bb5-972a-4705-bf22-0fa1e974dd26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1d9bb5-972a-4705-bf22-0fa1e974dd26.jpg?1",
             "name": "Skull of Orm",
             "text": "o5, oc\nT: Bring one enchantment card from your graveyard to your hand.",
             "colours": [],
@@ -3589,7 +3589,7 @@
         },
         {
             "id": "820172ea-0d6b-5360-adeb-c83c8dea3381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4c853e-2231-4af2-bcb0-1781c18ec3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4c853e-2231-4af2-bcb0-1781c18ec3be.jpg?1",
             "name": "Standing Stones",
             "text": "o1, oc\nT: Pay 1 life and add 1 mana of any color to your mana pool. This ability is played as an interrupt. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [],
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "e72ed6e0-8b58-59e8-ab2b-2cd33613d2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ba1a5-33b1-40f2-9780-26139ed829d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ba1a5-33b1-40f2-9780-26139ed829d7.jpg?1",
             "name": "Stone Calendar",
             "text": "Your spells cost up to 1 less to cast; casting cost of spells cannot go below 0.",
             "colours": [],
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "a2cf13ae-ac3d-5fcd-8b6e-253dd626e363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9668ba-d26d-4484-b4b8-6fb91fbfb617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9668ba-d26d-4484-b4b8-6fb91fbfb617.jpg?1",
             "name": "Tormod's Crypt",
             "text": "oc\nT: Sacrifice Tormod's Crypt to remove all cards in target player's graveyard from the game.",
             "colours": [],
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "f50d77ec-ddf1-52e1-8e80-62e22ab83022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c19977-ac7d-4ce7-925c-33a7503420f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c19977-ac7d-4ce7-925c-33a7503420f5.jpg?1",
             "name": "Tower of Coireall",
             "text": "oc\nT: Target creature cannot be blocked by walls until end of turn.",
             "colours": [],
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "34162dde-c972-5462-bcd2-a1c1a96349e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c9070a-8c70-480e-a476-e00f8e2c71b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c9070a-8c70-480e-a476-e00f8e2c71b9.jpg?1",
             "name": "Wand of Ith",
             "text": "o3, oc\nT: Look at one card at random from target player's hand. If the card is not a land, target player must choose either to discard it or pay an amount of life equal to its casting cost. If the card is a land, target player must choose either to discard it or pay 1 life. Effects that prevent or redirect damage may not be used to counter this loss of life. Can only be used during controller's turn.",
             "colours": [],
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "5e171ded-64bf-508e-a438-f2d419350307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9023c078-4169-498b-8626-a4862e0631f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9023c078-4169-498b-8626-a4862e0631f8.jpg?1",
             "name": "War Barge",
             "text": "o3: Target creature gains islandwalk until end of turn. If War Barge leaves play this turn, target creature is buried.",
             "colours": [],
@@ -3751,7 +3751,7 @@
         },
         {
             "id": "0ce7661e-5398-5b62-b5f6-6f44f68269a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5ee8a-34e5-4a2e-a04e-9fcdc7e53dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5ee8a-34e5-4a2e-a04e-9fcdc7e53dda.jpg?1",
             "name": "City of Shadows",
             "text": "oc\nT: Sacrifice one of your creatures, but remove it from the game instead of placing it in your graveyard. Put a counter on City of Shadows.\noc\nT: Add X colorless mana to your mana pool, where X is the number of counters on City of Shadows.",
             "colours": [],
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "0de59a71-9aef-5996-9670-84bf4605b28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dcceee-2a47-4eaa-a6a3-2931b3d50244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dcceee-2a47-4eaa-a6a3-2931b3d50244.jpg?1",
             "name": "Maze of Ith",
             "text": "oc\nT: Target attacking creature becomes untapped. This creature neither deals nor receives damage as a result of combat.",
             "colours": [],
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "28903892-7c61-5961-bba6-6c13b3d9a15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d48fb47-1bed-4791-a014-504515f3d36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d48fb47-1bed-4791-a014-504515f3d36f.jpg?1",
             "name": "Safe Haven",
             "text": "o2, oc\nT: Remove target creature you control from game. This ability is played as an interrupt.\nDuring your upkeep, sacrifice Safe Haven to return all creatures it has removed from game directly into play. Treat this as if they were just summoned.",
             "colours": [],
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "6c64fef3-580f-5281-b5d9-6d53db4555dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75946b-1690-43cc-993c-d4e451a1a41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75946b-1690-43cc-993c-d4e451a1a41c.jpg?1",
             "name": "Sorrow's Path",
             "text": "oc\nT: Exchange two of opponent's blocking creatures. This exchange may not cause an illegal block. Sorrow's Path does 2 damage to you and 2 damage to each creature you control whenever it is tapped.",
             "colours": [],

--- a/Assets/Resources/Sets/DSK.json
+++ b/Assets/Resources/Sets/DSK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a3523602-b7ee-58b6-99e5-c430fc4fd856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a7590-3eee-4803-b192-d4fb771e6a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a7590-3eee-4803-b192-d4fb771e6a86.jpg?1",
             "name": "Acrobatic Cheerleader",
             "text": "Survival \u2014 At the beginning of your second main phase, if Acrobatic Cheerleader is tapped, put a flying counter on it. This ability triggers only once.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "2607492c-0635-59f3-bc25-beba4c0bb1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b8fbe-8a5e-4b62-b53f-9ead8147bbbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b8fbe-8a5e-4b62-b53f-9ead8147bbbb.jpg?1",
             "name": "Cult Healer",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Cult Healer gains lifelink until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "6532323b-473a-5085-99ba-a29656a44344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "e6d2a89a-8797-5e30-87cf-099649a13761",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "",
             "colours": [
@@ -146,7 +146,7 @@
         },
         {
             "id": "e9ec6f85-fe3f-513c-9752-2a20b326ee1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "b03eb6db-5698-5935-b57e-144955934925",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "",
             "colours": [
@@ -218,7 +218,7 @@
         },
         {
             "id": "b2bebd44-e503-5760-af8f-5918a58dccd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba16fbf-2d44-4337-87cb-6ff6b84a258a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba16fbf-2d44-4337-87cb-6ff6b84a258a.jpg?1",
             "name": "Emerge from the Cocoon",
             "text": "Return target creature card from your graveyard to the battlefield. You gain 3 life.",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "5b69d554-246f-5f61-9a2d-8578e513c310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f79439-b8f8-418f-9772-26d81844749e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f79439-b8f8-418f-9772-26d81844749e.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -290,7 +290,7 @@
         },
         {
             "id": "b840a843-39b2-5528-b6bc-04c76ad231c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0e8a82-0201-483e-a976-5f29764b35a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0e8a82-0201-483e-a976-5f29764b35a4.jpg?1",
             "name": "Ethereal Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each enchantment you control and has first strike.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "c437115c-ca3c-5f1b-8a87-af8d4a592c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49006f2-a097-417d-8eb0-b8016ff2e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49006f2-a097-417d-8eb0-b8016ff2e0d5.jpg?1",
             "name": "Exorcise",
             "text": "Exile target artifact, enchantment, or creature with power 4 or greater.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "25291691-fdb6-599c-8349-8f06cacb3009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9374be-5e4b-4c23-8b6e-94c03d4f5ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9374be-5e4b-4c23-8b6e-94c03d4f5ef1.jpg?1",
             "name": "Fear of Abduction",
             "text": "As an additional cost to cast this spell, exile a creature you control.\nFlying\nWhen Fear of Abduction enters, exile target creature an opponent controls.\nWhen Fear of Abduction leaves the battlefield, put each card exiled with it into its owner's hand.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "2161aafe-876c-50aa-ba85-40e795350cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9220c8fa-6ef7-4bc1-acb9-fc54cc43e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9220c8fa-6ef7-4bc1-acb9-fc54cc43e498.jpg?1",
             "name": "Fear of Immobility",
             "text": "When Fear of Immobility enters, tap up to one target creature. If an opponent controls that creature, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -426,7 +426,7 @@
         },
         {
             "id": "41ca3da8-a526-599f-9076-b66a99004e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e98559d-d9fd-4bdf-8df9-389eee756a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e98559d-d9fd-4bdf-8df9-389eee756a3a.jpg?1",
             "name": "Fear of Surveillance",
             "text": "Vigilance\nWhenever Fear of Surveillance attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -461,7 +461,7 @@
         },
         {
             "id": "282d8066-e827-5b85-8100-4cf1f566ce7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e0dba2-d15c-4d55-9b68-00648175e760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e0dba2-d15c-4d55-9b68-00648175e760.jpg?1",
             "name": "Friendly Ghost",
             "text": "Flying\nWhen Friendly Ghost enters, target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "67188047-40fb-5dc1-aaaf-41380c549e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg?1",
             "name": "Ghostly Dancers",
             "text": "Flying\nWhen Ghostly Dancers enters, return an enchantment card from your graveyard to your hand or unlock a locked door of a Room you control.\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying.",
             "colours": [
@@ -531,7 +531,7 @@
         },
         {
             "id": "f0077f6c-6db5-523b-86be-75ea68b82223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f06bbb1-0c7d-4803-9b35-8a2206803eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f06bbb1-0c7d-4803-9b35-8a2206803eed.jpg?1",
             "name": "Glimmer Seeker",
             "text": "Survival \u2014 At the beginning of your second main phase, if Glimmer Seeker is tapped, draw a card if you control a Glimmer creature. If you don't control a Glimmer creature, create a 1/1 white Glimmer enchantment creature token.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "3eeeb333-471b-5101-917c-f054b818bc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "156244a2-6cd1-5de4-94ac-fe73b2541d59",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "",
             "colours": [
@@ -638,7 +638,7 @@
         },
         {
             "id": "dae79fcf-2649-512c-9db0-89b6547cd778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12054e10-46d6-4581-a7e5-ff277cb0e229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12054e10-46d6-4581-a7e5-ff277cb0e229.jpg?1",
             "name": "Hardened Escort",
             "text": "Whenever Hardened Escort attacks, another target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "ba660cb0-16b3-59ad-b105-81ce4a08244a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dd8903-31ca-470d-b2ff-280f6d40c794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dd8903-31ca-470d-b2ff-280f6d40c794.jpg?1",
             "name": "Jump Scare",
             "text": "Until end of turn, target creature gets +2/+2, gains flying, and becomes a Horror enchantment creature in addition to its other types.",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "6e522c94-1bb8-5104-a6de-3285a512bb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg?1",
             "name": "Leyline of Hope",
             "text": "If Leyline of Hope is in your opening hand, you may begin the game with it on the battlefield.\nIf you would gain life, you gain that much life plus 1 instead.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "c38dc3a9-5e5d-5f83-af4f-0fc6a3c4b018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e1c6f-331c-45f1-bf5d-9b9742aa8903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e1c6f-331c-45f1-bf5d-9b9742aa8903.jpg?1",
             "name": "Lionheart Glimmer",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhenever you attack, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "33aa95b9-93ee-5e98-8b15-1ad8da338cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8266f93b-f91c-4427-a222-075ceb0be3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8266f93b-f91c-4427-a222-075ceb0be3af.jpg?1",
             "name": "Living Phone",
             "text": "When Living Phone dies, look at the top five cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "7383c8f1-4cf0-5b23-a0cb-f102ab397c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c72fc6f-6a96-420d-812d-b5cf0f57cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c72fc6f-6a96-420d-812d-b5cf0f57cc7f.jpg?1",
             "name": "Optimistic Scavenger",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, put a +1/+1 counter on target creature.",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "fdea5842-b488-594a-b1bd-42ef7dbbcb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef4aab1-8bc0-4652-91d7-3e8b20b411ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef4aab1-8bc0-4652-91d7-3e8b20b411ad.jpg?1",
             "name": "Orphans of the Wheat",
             "text": "Whenever Orphans of the Wheat attacks, tap any number of untapped creatures you control. Orphans of the Wheat gets +1/+1 until end of turn for each creature tapped this way.",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "c80fdf27-bc65-51ea-b115-770821d565c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcafc2e-cef6-412d-8c5d-1658c3337292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcafc2e-cef6-412d-8c5d-1658c3337292.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -921,7 +921,7 @@
         },
         {
             "id": "c2ba8e64-5d98-513f-a415-1a65a0199636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513da431-4f3a-4f4a-8be4-7e162dd93307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513da431-4f3a-4f4a-8be4-7e162dd93307.jpg?1",
             "name": "Patched Plaything",
             "text": "Double strike\nPatched Plaything enters with two -1/-1 counters on it if you cast it from your hand.",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "a05f2933-2d68-54b5-9761-e73a07a90d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg?1",
             "name": "Possessed Goat",
             "text": "{3}, Discard a card: Put three +1/+1 counters on Possessed Goat and it becomes a black Demon in addition to its other colors and types. Activate only once.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "3c33d793-2a1f-5ddc-adba-4e33503b5664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg?1",
             "name": "Reluctant Role Model",
             "text": "Survival \u2014 At the beginning of your second main phase, if Reluctant Role Model is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever Reluctant Role Model or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "7d554eea-cb75-5dee-b9f2-b50f0bf398c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ed31ea-c278-4e8c-afa7-6d09af399345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ed31ea-c278-4e8c-afa7-6d09af399345.jpg?1",
             "name": "Savior of the Small",
             "text": "Survival \u2014 At the beginning of your second main phase, if Savior of the Small is tapped, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "6b874068-7cd3-5fe3-b80f-a2ef25a3452f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24456083-0c76-46c5-9b18-8d468702df69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24456083-0c76-46c5-9b18-8d468702df69.jpg?1",
             "name": "Seized from Slumber",
             "text": "This spell costs {3} less to cast if it targets a tapped creature.\nDestroy target creature.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "92074085-27bb-50cb-949c-6424cbe3f747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed0cafa-d701-4e1f-9773-abcf817c244c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed0cafa-d701-4e1f-9773-abcf817c244c.jpg?1",
             "name": "Shardmage's Rescue",
             "text": "Flash\nEnchant creature you control\nAs long as Shardmage's Rescue entered this turn, enchanted creature has hexproof.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "f953e6d8-a71d-5b94-bbea-95208df67a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f3f7b-be40-4a2d-b5cc-28471a577981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f3f7b-be40-4a2d-b5cc-28471a577981.jpg?1",
             "name": "Sheltered by Ghosts",
             "text": "Enchant creature you control\nWhen Sheltered by Ghosts enters, exile target nonland permanent an opponent controls until Sheltered by Ghosts leaves the battlefield.\nEnchanted creature gets +1/+0 and has lifelink and ward {2}.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "4b7e0601-7b4f-546c-8fe5-28077d2e0ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c02ab1-0fb2-4cb0-a871-bfad406726fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c02ab1-0fb2-4cb0-a871-bfad406726fc.jpg?1",
             "name": "Shepherding Spirits",
             "text": "Flying\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "de985ac6-9da0-59c6-a58e-097c69688b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb9a5b1-48d2-453e-8991-c788bc63e482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb9a5b1-48d2-453e-8991-c788bc63e482.jpg?1",
             "name": "Split Up",
             "text": "Choose one \u2014\n\u2022 Destroy all tapped creatures.\n\u2022 Destroy all untapped creatures.",
             "colours": [
@@ -1233,7 +1233,7 @@
         },
         {
             "id": "85a24de0-fe90-51eb-b65d-f07090efb7a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453be94-e59b-48f1-a488-7a9fd96a627e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453be94-e59b-48f1-a488-7a9fd96a627e.jpg?1",
             "name": "Splitskin Doll",
             "text": "When Splitskin Doll enters, draw a card. Then discard a card unless you control another creature with power 2 or less.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "57ff9e80-9b4c-56ee-83af-4dac96b4aee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg?1",
             "name": "Surgical Suite // Hospital Room",
             "text": "When you unlock this door, return target creature card with mana value 3 or less from your graveyard to the battlefield.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "58653d19-4a11-5c4e-8c59-f2e6cc88ba28",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg?1",
             "name": "Surgical Suite // Hospital Room",
             "text": "Hospital Room\no3o\nW\nWhenever you attack, put a +1/+1 counter on target attacking creature.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "aa65592c-6bbe-5b75-b5d3-f7c1d683d71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg?1",
             "name": "Toby, Beastie Befriender",
             "text": "When Toby, Beastie Befriender enters, create a 4/4 white Beast creature token with \"This creature can't attack or block alone.\"\nAs long as you control four or more creature tokens, creature tokens you control have flying.",
             "colours": [
@@ -1375,7 +1375,7 @@
         },
         {
             "id": "cba1c2ae-cb22-5edf-99b0-982683ff9000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe95bfb-8ca7-434f-a2e7-a6b2e699584e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe95bfb-8ca7-434f-a2e7-a6b2e699584e.jpg?1",
             "name": "Trapped in the Screen",
             "text": "Ward {2} (Whenever this enchantment becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Trapped in the Screen enters, exile target artifact, creature, or enchantment an opponent controls until Trapped in the Screen leaves the battlefield.",
             "colours": [
@@ -1407,7 +1407,7 @@
         },
         {
             "id": "0531cf92-0c5c-55b3-92d6-435a60624d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg?1",
             "name": "Unidentified Hovership",
             "text": "Flying\nWhen Unidentified Hovership enters, exile up to one target creature with toughness 5 or less.\nWhen Unidentified Hovership leaves the battlefield, the exiled card's owner manifests dread.\nCrew 1",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "1c41ec1f-c4fd-5142-b744-ccf7f262c0d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da2e65-4e22-48b6-98ad-6969684d69e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da2e65-4e22-48b6-98ad-6969684d69e1.jpg?1",
             "name": "Unsettling Twins",
             "text": "When Unsettling Twins enters, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "17ed1f3a-0d13-5c6c-b058-f5c4c1cac3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b54447f-1daf-4352-b5c3-3c0ec8b8f4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b54447f-1daf-4352-b5c3-3c0ec8b8f4d0.jpg?1",
             "name": "Unwanted Remake",
             "text": "Destroy target creature. Its controller manifests dread. (That player looks at the top two cards of their library, then puts one onto the battlefield face down as a 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "b4fcd019-8f4d-5326-8570-6aad6a77c2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39368ea2-f665-40b1-b042-c0182f7c6df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39368ea2-f665-40b1-b042-c0182f7c6df0.jpg?1",
             "name": "Veteran Survivor",
             "text": "Survival \u2014 At the beginning of your second main phase, if Veteran Survivor is tapped, exile up to one target card from a graveyard.\nAs long as there are three or more cards exiled with Veteran Survivor, it gets +3/+3 and has hexproof. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "02c06897-69c5-5a92-bcb9-5121dbbb04b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ccca86-df8b-4fd9-8fdf-0a5a7b14cdee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ccca86-df8b-4fd9-8fdf-0a5a7b14cdee.jpg?1",
             "name": "The Wandering Rescuer",
             "text": "Flash\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDouble strike\nOther tapped creatures you control have hexproof.",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "43ec1283-25da-5505-aa46-0c12c514471b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg?1",
             "name": "Abhorrent Oculus",
             "text": "As an additional cost to cast this spell, exile six cards from your graveyard.\nFlying\nAt the beginning of each opponent's upkeep, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "3191ecdc-97a3-5eac-a808-b6c46be97082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg?1",
             "name": "Bottomless Pool // Locker Room",
             "text": "When you unlock this door, return up to one target creature to its owner's hand.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "5e157784-c31c-5fd3-8ac5-72fd101c943e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg?1",
             "name": "Bottomless Pool // Locker Room",
             "text": "Locker Room\no4o\nU\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "4f31f6f5-5e1e-57e4-8e27-c48c38c4a4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "f58a84bc-b347-599e-99c2-ddda8ddff696",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "af41bf7c-46ad-568d-8617-78f8c771203b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237f0b93-f12e-4c5f-a3d7-83e8f20f8493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237f0b93-f12e-4c5f-a3d7-83e8f20f8493.jpg?1",
             "name": "Clammy Prowler",
             "text": "Whenever Clammy Prowler attacks, another target attacking creature can't be blocked this turn.",
             "colours": [
@@ -1798,7 +1798,7 @@
         },
         {
             "id": "3fc15b6a-8d9b-57f9-b90a-1eba1ab0f680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg?1",
             "name": "Creeping Peeper",
             "text": "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "0facd25b-1943-5c07-98d7-6ed7941fb584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f651e216-f9da-4696-8a1d-6d674e9044c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f651e216-f9da-4696-8a1d-6d674e9044c0.jpg?1",
             "name": "Cursed Windbreaker",
             "text": "When Cursed Windbreaker enters, manifest dread, then attach Cursed Windbreaker to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature has flying.\nEquip {3}",
             "colours": [
@@ -1866,7 +1866,7 @@
         },
         {
             "id": "cb2d0175-e8d2-5e2c-9203-0ae57b33a133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a38b9-29aa-4804-ab27-4c40321f0bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a38b9-29aa-4804-ab27-4c40321f0bc3.jpg?1",
             "name": "Daggermaw Megalodon",
             "text": "Vigilance\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "388e81e6-6218-50e2-8a36-d5ea090fcd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f42e59-7315-41cb-9c41-346e44f0c5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f42e59-7315-41cb-9c41-346e44f0c5fb.jpg?1",
             "name": "Don't Make a Sound",
             "text": "Counter target spell unless its controller pays {2}. If they do, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "4543cdc1-d3ea-5f81-b2fa-ad987574e77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96dbc9-c2fd-42c1-9d55-5c14fa1c1c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96dbc9-c2fd-42c1-9d55-5c14fa1c1c6f.jpg?1",
             "name": "Duskmourn's Domination",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets -3/-0 and loses all abilities.",
             "colours": [
@@ -1966,7 +1966,7 @@
         },
         {
             "id": "0d2feb0c-2504-5890-98f6-1d1f417b9303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "05472b46-cd6a-593d-948d-efe44b04a2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5479c7-9e46-4a57-abe7-8cc670de89e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5479c7-9e46-4a57-abe7-8cc670de89e4.jpg?1",
             "name": "Enter the Enigma",
             "text": "Target creature can't be blocked this turn.\nDraw a card.",
             "colours": [
@@ -2038,7 +2038,7 @@
         },
         {
             "id": "b3165028-93b4-52bc-9c5e-302703d3ef88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae54d697-6d06-4af1-a617-8a47a6ab9c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae54d697-6d06-4af1-a617-8a47a6ab9c01.jpg?1",
             "name": "Entity Tracker",
             "text": "Flash\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "bfc31b69-73a8-5fb5-b175-688b149e4c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74fd612-2890-4333-a379-5bf7650fbb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74fd612-2890-4333-a379-5bf7650fbb87.jpg?1",
             "name": "Erratic Apparition",
             "text": "Flying, vigilance\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Erratic Apparition gets +1/+1 until end of turn.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "b9e9a01f-c7d5-57b7-908e-4ae668c95d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c39df-7636-454b-8485-a1cc9362fd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c39df-7636-454b-8485-a1cc9362fd84.jpg?1",
             "name": "Fear of Failed Tests",
             "text": "Whenever Fear of Failed Tests deals combat damage to a player, draw that many cards.",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "abc34ea5-d1e7-5931-947a-da18b4b550d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e814e48-cd9d-428f-90e2-74d97cb9c8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e814e48-cd9d-428f-90e2-74d97cb9c8f1.jpg?1",
             "name": "Fear of Falling",
             "text": "Flying\nWhenever Fear of Falling attacks, target creature defending player controls gets -2/-0 and loses flying until your next turn.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "707935d5-9157-59c4-a022-062915e17b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdee441e-14ab-42d1-b447-5a6488fd713a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdee441e-14ab-42d1-b447-5a6488fd713a.jpg?1",
             "name": "Fear of Impostors",
             "text": "Flash\nWhen Fear of Impostors enters, counter target spell. Its controller manifests dread. (That player looks at the top two cards of their library, then puts one onto the battlefield face down as a 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "df3297db-dba2-59ad-adc0-f650a0b66b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69aa6054-8c59-4bbc-a283-adb453639786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69aa6054-8c59-4bbc-a283-adb453639786.jpg?1",
             "name": "Fear of Isolation",
             "text": "As an additional cost to cast this spell, return a permanent you control to its owner's hand.\nFlying",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "9442b457-5a17-538e-9ec1-114cb4604b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62aa3-8edb-4000-8ebd-15ec4b00eed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62aa3-8edb-4000-8ebd-15ec4b00eed7.jpg?1",
             "name": "Floodpits Drowner",
             "text": "Flash\nVigilance\nWhen Floodpits Drowner enters, tap target creature an opponent controls and put a stun counter on it.\n{1}{U}, {T}: Shuffle Floodpits Drowner and target creature with a stun counter on it into their owners' libraries.",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "83376425-0784-5ed8-a985-fbe941042cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9471c8-2db9-4ce3-a1e5-42b85134cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9471c8-2db9-4ce3-a1e5-42b85134cb8e.jpg?1",
             "name": "Get Out",
             "text": "Choose one \u2014\n\u2022 Counter target creature or enchantment spell.\n\u2022 Return one or two target creatures and/or enchantments you own to your hand.",
             "colours": [
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "5f0a392f-0a9c-5d50-8e86-b6edef4590b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d04a98-6997-4653-9719-e6b215567599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d04a98-6997-4653-9719-e6b215567599.jpg?1",
             "name": "Ghostly Keybearer",
             "text": "Flying\nWhenever Ghostly Keybearer deals combat damage to a player, unlock a locked door of up to one target Room you control.",
             "colours": [
@@ -2350,7 +2350,7 @@
         },
         {
             "id": "361795fb-b13a-5201-94c0-86b12a70f117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1ab8db-3994-4b6d-9eaf-75243a78b715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1ab8db-3994-4b6d-9eaf-75243a78b715.jpg?1",
             "name": "Glimmerburst",
             "text": "Draw two cards. Create a 1/1 white Glimmer enchantment creature token.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "74b1ac20-3da1-5e7d-98a8-d96e83d1294e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg?1",
             "name": "Leyline of Transformation",
             "text": "If Leyline of Transformation is in your opening hand, you may begin the game with it on the battlefield.\nAs Leyline of Transformation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "4761fe98-6f8d-5597-987d-0d8c73f27bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg?1",
             "name": "Marina Vendrell's Grimoire",
             "text": "When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.\nYou have no maximum hand size and don't lose the game for having 0 or less life.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "65435acc-204a-5d28-a50a-dccd4f2dd515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg?1",
             "name": "Meat Locker // Drowned Diner",
             "text": "When you unlock this door, tap up to one target creature and put two stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "6e02de34-e9dc-5784-938c-28df9f2cea71",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg?1",
             "name": "Meat Locker // Drowned Diner",
             "text": "Drowned Diner\no3o\nUo\nU\nWhen you unlock this door, draw three cards, then discard a card.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "ce687985-b6cf-501c-91d9-402a6f290f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg?1",
             "name": "The Mindskinner",
             "text": "The Mindskinner can't be blocked.\nIf a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "50603666-04c5-593e-bd2b-b020a5894311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "28480e8a-5f63-595a-b955-8ee21177f9a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "1ec3e707-ba67-5c0f-85e3-3c5e830f19b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5de8-9cda-4370-9f72-4462f8cfd696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5de8-9cda-4370-9f72-4462f8cfd696.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "0e30656c-1353-5250-b0fa-2279908195e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cf954a-5503-460c-8720-8960842eea47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cf954a-5503-460c-8720-8960842eea47.jpg?1",
             "name": "Paranormal Analyst",
             "text": "Whenever you manifest dread, put a card you put into your graveyard this way into your hand.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "aa18cb09-d403-58ca-a19b-59f6e6369f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd891675-12d4-40df-996a-97d694155227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd891675-12d4-40df-996a-97d694155227.jpg?1",
             "name": "Piranha Fly",
             "text": "Flying\nPiranha Fly enters tapped.",
             "colours": [
@@ -2741,7 +2741,7 @@
         },
         {
             "id": "ad48d027-a544-5def-b460-458617c489c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1017b8e-e7fa-41de-8eb2-2e4a59db5117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1017b8e-e7fa-41de-8eb2-2e4a59db5117.jpg?1",
             "name": "Scrabbling Skullcrab",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "a95265c6-c9b6-5fb1-ab8c-57f1dc87cb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg?1",
             "name": "Silent Hallcreeper",
             "text": "Silent Hallcreeper can't be blocked.\nWhenever Silent Hallcreeper deals combat damage to a player, choose one that hasn't been chosen \u2014\n\u2022 Put two +1/+1 counters on Silent Hallcreeper.\n\u2022 Draw a card.\n\u2022 Silent Hallcreeper becomes a copy of another target creature you control.",
             "colours": [
@@ -2813,7 +2813,7 @@
         },
         {
             "id": "da720467-e4d8-5d4b-aeea-8ef641d360ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26ccad-adfa-43cc-be4c-dc8dd584bca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26ccad-adfa-43cc-be4c-dc8dd584bca3.jpg?1",
             "name": "Stalked Researcher",
             "text": "Defender\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Stalked Researcher can attack this turn as though it didn't have defender.",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "87371f12-904e-55d0-802d-8b68e0e2a4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661ffe7-4f58-43fe-a1f1-dd7a6d4d28a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661ffe7-4f58-43fe-a1f1-dd7a6d4d28a7.jpg?1",
             "name": "Stay Hidden, Stay Silent",
             "text": "Enchant creature\nWhen Stay Hidden, Stay Silent enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate only as a sorcery.",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "5204bcd4-945b-5415-a9b1-0e267d8ce576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeba193-05d3-4c2d-a304-bbe7114c2eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeba193-05d3-4c2d-a304-bbe7114c2eef.jpg?1",
             "name": "The Tale of Tamiyo",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Mill two cards. If two cards that share a card type were milled this way, draw a card and repeat this process.\nIV \u2014 Exile any number of target instant, sorcery, and/or Tamiyo planeswalker cards from your graveyard. Copy them. You may cast any number of the copies.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "dcd569ea-9292-5bf1-9339-4c72d5ef74a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ee2690-f464-4a38-81e1-6dd2053a3327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ee2690-f464-4a38-81e1-6dd2053a3327.jpg?1",
             "name": "Tunnel Surveyor",
             "text": "When Tunnel Surveyor enters, create a 1/1 white Glimmer enchantment creature token.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "bd9c560a-952c-55a6-b6e4-4763aba09c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644714dd-7a0b-4d4b-9a61-8f6e505b1d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644714dd-7a0b-4d4b-9a61-8f6e505b1d22.jpg?1",
             "name": "Twist Reality",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "6d89cc57-a52c-557c-bcc5-59e19ba406d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg?1",
             "name": "Unable to Scream",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a Toy artifact creature with base power and toughness 0/2 in addition to its other types.\nAs long as enchanted creature is face down, it can't be turned face up.",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "9693221c-41cf-517e-b1b5-0a6fe8cf1fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg?1",
             "name": "Underwater Tunnel // Slimy Aquarium",
             "text": "When you unlock this door, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "ad03ae0c-3e8a-529f-9e2c-dde9d0f294e7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg?1",
             "name": "Underwater Tunnel // Slimy Aquarium",
             "text": "Slimy Aquarium\no3o\nU\nWhen you unlock this door, manifest dread, then put a +1/+1 counter on that creature.",
             "colours": [
@@ -3089,7 +3089,7 @@
         },
         {
             "id": "c05e8344-1146-5b0c-9987-8e2f3bb33acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602756d-76d2-4502-965f-36fc44596123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602756d-76d2-4502-965f-36fc44596123.jpg?1",
             "name": "Unnerving Grasp",
             "text": "Return up to one target nonland permanent to its owner's hand. Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "daaa4fce-3ab4-51b7-a8b4-03c5b9957649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1758ed-fe33-4ead-8c83-e54fabcb4cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1758ed-fe33-4ead-8c83-e54fabcb4cfe.jpg?1",
             "name": "Unwilling Vessel",
             "text": "Vigilance\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, put a possession counter on Unwilling Vessel.\nWhen Unwilling Vessel dies, create an X/X blue Spirit creature token with flying, where X is the number of counters on Unwilling Vessel.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "ad63f21e-7f8f-5a76-b4a6-81354bfa681b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254988b-3113-42f7-b751-517ffb3b40f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254988b-3113-42f7-b751-517ffb3b40f0.jpg?1",
             "name": "Vanish from Sight",
             "text": "Target nonland permanent's owner puts it on the top or bottom of their library. Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3188,7 +3188,7 @@
         },
         {
             "id": "66a88902-be45-5772-812b-3f530bb6a8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16b3cf3-7b85-4153-b25a-e6b5fce725cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16b3cf3-7b85-4153-b25a-e6b5fce725cf.jpg?1",
             "name": "Appendage Amalgam",
             "text": "Flash\nWhenever Appendage Amalgam attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3223,7 +3223,7 @@
         },
         {
             "id": "0eddb098-53ff-5781-82c0-862e1a60a601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0621b32-95c5-4f70-96cf-d46d20efc85d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0621b32-95c5-4f70-96cf-d46d20efc85d.jpg?1",
             "name": "Balemurk Leech",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, each opponent loses 1 life.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "99cc53d5-babc-5834-8c48-a36f06e64b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269ccf-febf-42b0-8c20-21ccb731a3ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269ccf-febf-42b0-8c20-21ccb731a3ec.jpg?1",
             "name": "Cackling Slasher",
             "text": "Deathtouch\nCackling Slasher enters with a +1/+1 counter on it if a creature died this turn.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "d48b03c1-62b5-57f0-88fc-a0ec4da5bb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg?1",
             "name": "Come Back Wrong",
             "text": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "ce1fb39e-5391-5bd9-851b-89dd5a53c6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg?1",
             "name": "Commune with Evil",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. You gain 3 life.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "4081850c-8b02-5ad2-ad02-e1322fb5b3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7616ad5e-ed30-4876-8743-6f0f9f143ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7616ad5e-ed30-4876-8743-6f0f9f143ea1.jpg?1",
             "name": "Cracked Skull",
             "text": "Enchant creature\nWhen Cracked Skull enters, look at target player's hand. You may choose a nonland card from it. That player discards that card.\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "41714f54-9776-57fb-b78f-a4fd24c017a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc93bcb8-778d-491e-877b-e6ad432764cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc93bcb8-778d-491e-877b-e6ad432764cb.jpg?1",
             "name": "Cynical Loner",
             "text": "Cynical Loner can't be blocked by Glimmers.\nSurvival \u2014 At the beginning of your second main phase, if Cynical Loner is tapped, you may search your library for a card, put it into your graveyard, then shuffle.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "0597a0db-4bb7-5278-8928-a99d6a31d63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790a90cc-d36f-43b5-8423-89e30bdf7b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790a90cc-d36f-43b5-8423-89e30bdf7b9f.jpg?1",
             "name": "Dashing Bloodsucker",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Dashing Bloodsucker gets +2/+0 and gains lifelink until end of turn.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "3f9de0d7-102c-5022-bdd1-c33b5aaaf855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg?1",
             "name": "Defiled Crypt // Cadaver Lab",
             "text": "Whenever one or more cards leave your graveyard, create a 2/2 black Horror enchantment creature token. This ability triggers only once each turn.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "a45c2b4b-3301-532f-8963-810cbcc5e0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg?1",
             "name": "Defiled Crypt // Cadaver Lab",
             "text": "Cadaver Lab\no\nB\nWhen you unlock this door, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "c4516787-050f-5119-997b-1184ea631c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg?1",
             "name": "Demonic Counsel",
             "text": "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead search your library for any card, put it into your hand, then shuffle.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "d2118542-371c-58b1-8b50-c2609de58378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg?1",
             "name": "Derelict Attic // Widow's Walk",
             "text": "When you unlock this door, you draw two cards and you lose 2 life.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "911bec78-3d2e-5fd2-bc2e-66aa99fd5161",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg?1",
             "name": "Derelict Attic // Widow's Walk",
             "text": "Widow's Walk\no3o\nB\nWhenever a creature you control attacks alone, it gets +1/+0 and gains deathtouch until end of turn.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "9cb0e626-49d3-5712-addd-8c4217a816b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg?1",
             "name": "Doomsday Excruciator",
             "text": "Flying\nWhen Doomsday Excruciator enters, if it was cast, each player exiles all but the bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card.",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "23e13c55-b25d-552d-8c8f-2ff0ca6f2abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -3709,7 +3709,7 @@
         },
         {
             "id": "c6c68ca2-88af-5469-a647-76cff76ef9fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0acb05-91e0-4f7c-b48b-99e1068fad16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0acb05-91e0-4f7c-b48b-99e1068fad16.jpg?1",
             "name": "Fanatic of the Harrowing",
             "text": "When Fanatic of the Harrowing enters, each player discards a card. If you discarded a card this way, draw a card.",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "91d3f7ba-3cb7-55c5-84df-e82d0b0912c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259045fe-f349-4be1-bf29-465d084ed35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259045fe-f349-4be1-bf29-465d084ed35e.jpg?1",
             "name": "Fear of Lost Teeth",
             "text": "When Fear of Lost Teeth dies, it deals 1 damage to any target and you gain 1 life.",
             "colours": [
@@ -3779,7 +3779,7 @@
         },
         {
             "id": "ef5a843e-a238-5f16-952a-550c1ea13bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700eb8d-1cc0-45ff-b769-c875ee6500ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700eb8d-1cc0-45ff-b769-c875ee6500ea.jpg?1",
             "name": "Fear of the Dark",
             "text": "Whenever Fear of the Dark attacks, if defending player controls no Glimmer creatures, it gains menace and deathtouch until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3814,7 +3814,7 @@
         },
         {
             "id": "82dd2183-bd88-5c83-b887-9a5bec231a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648da934-71f6-4945-a08f-09698414417b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648da934-71f6-4945-a08f-09698414417b.jpg?1",
             "name": "Final Vengeance",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nExile target creature.",
             "colours": [
@@ -3846,7 +3846,7 @@
         },
         {
             "id": "878a8613-c5b1-5457-b3b7-d5b380afa44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "",
             "colours": [
@@ -3882,7 +3882,7 @@
         },
         {
             "id": "d9eb10f0-aa4c-556d-a5ce-9b4e42a0490a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "35bc3647-dee9-52eb-9fa6-669fd5c16aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ac1759-d4cc-41d5-a9b7-a89b80d2190c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ac1759-d4cc-41d5-a9b7-a89b80d2190c.jpg?1",
             "name": "Give In to Violence",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "9393364c-8562-50de-a7c4-b16d1fac0314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg?1",
             "name": "Grievous Wound",
             "text": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "f902c01c-118f-5815-8ec7-d36a25bfc7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94edbbc5-5673-4753-bfad-4432c4b7dca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94edbbc5-5673-4753-bfad-4432c4b7dca4.jpg?1",
             "name": "Innocuous Rat",
             "text": "When Innocuous Rat dies, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "6fcd8623-f829-5580-9fb8-439cb7852e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fc02ae-77b8-4e5e-94b4-22ecf7ae40ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fc02ae-77b8-4e5e-94b4-22ecf7ae40ae.jpg?1",
             "name": "Killer's Mask",
             "text": "When Killer's Mask enters, manifest dread, then attach Killer's Mask to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature has menace.\nEquip {2}",
             "colours": [
@@ -4055,7 +4055,7 @@
         },
         {
             "id": "6c915da5-868a-5eb1-b876-38180ca069a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645911b4-7728-4380-9097-e4139b986423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645911b4-7728-4380-9097-e4139b986423.jpg?1",
             "name": "Let's Play a Game",
             "text": "Delirium \u2014 Choose one. If there are four or more card types among cards in your graveyard, choose one or more instead.\n\u2022 Creatures your opponents control get -1/-1 until end of turn.\n\u2022 Each opponent discards two cards.\n\u2022 Each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "bc8493e4-b1fc-5dd9-adbe-78cd6b12a6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa3aff-608d-4723-bb7c-8daedebe9f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa3aff-608d-4723-bb7c-8daedebe9f36.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "a300e157-cbfc-58bf-b5ef-cc3eb0b08bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81e438-e38f-42a1-b677-202dbcb3837c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81e438-e38f-42a1-b677-202dbcb3837c.jpg?1",
             "name": "Live or Die",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to the battlefield.\n\u2022 Destroy target creature.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "0389e70c-50f3-52c5-b489-b52c2f8fe53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg?1",
             "name": "Meathook Massacre II",
             "text": "When Meathook Massacre II enters, each player sacrifices X creatures.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "ab320381-d909-5542-a7f9-7609091cfec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d167c00-75ff-4301-855a-8319b89e3689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d167c00-75ff-4301-855a-8319b89e3689.jpg?1",
             "name": "Miasma Demon",
             "text": "Flying\nWhen Miasma Demon enters, you may discard any number of cards. When you do, up to that many target creatures each get -2/-2 until end of turn.",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "510331ff-2cc0-50e7-87ab-4c8e713a0fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c249609-9cf7-46f1-b94c-9329add966bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c249609-9cf7-46f1-b94c-9329add966bb.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "4c26fbbc-0362-5071-b0e7-df3e1bed2442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee60e9d-9ee7-444a-88f3-c1929e1888fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee60e9d-9ee7-444a-88f3-c1929e1888fb.jpg?1",
             "name": "Nowhere to Run",
             "text": "Flash\nWhen Nowhere to Run enters, target creature an opponent controls gets -3/-3 until end of turn.\nCreatures your opponents control can be the targets of spells and abilities as though they didn't have hexproof. Ward abilities of those creatures don't trigger.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "f9b435a9-7c70-55ed-86ce-40386095a15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43473e-1302-4543-b331-1a86cfbc3ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43473e-1302-4543-b331-1a86cfbc3ced.jpg?1",
             "name": "Osseous Sticktwister",
             "text": "Lifelink\nDelirium \u2014 At the beginning of your end step, if there are four or more card types among cards in your graveyard, each opponent may sacrifice a nonland permanent or discard a card. Then Osseous Sticktwister deals damage equal to its power to each opponent who didn't sacrifice a permanent or discard a card this way.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "805bbd73-9501-527d-86be-bfb55e4abdd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911653-7b96-4cf3-a907-13c5c53a14f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911653-7b96-4cf3-a907-13c5c53a14f7.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B} (If you cast this spell for its impending cost, it enters with five time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "aa32279c-2646-5583-a80f-e1eaf6e834a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e64605-8edb-4def-9522-765e90d1f0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e64605-8edb-4def-9522-765e90d1f0f3.jpg?1",
             "name": "Popular Egotist",
             "text": "{1}{B}, Sacrifice another creature or enchantment: Popular Egotist gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)\nWhenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "5ecd3170-57a0-5ac7-8f51-54159f3daa94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41bd259-e81f-432a-bebf-4c6534f23db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41bd259-e81f-432a-bebf-4c6534f23db7.jpg?1",
             "name": "Resurrected Cultist",
             "text": "Delirium \u2014 {2}{B}{B}: Return Resurrected Cultist from your graveyard to the battlefield with a finality counter on it. Activate only if there are four or more card types among cards in your graveyard and only as a sorcery. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "2b90209a-7ad0-5228-909f-3a2961d64e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f90f57-94a0-4ee1-9383-093e8fca52ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f90f57-94a0-4ee1-9383-093e8fca52ea.jpg?1",
             "name": "Spectral Snatcher",
             "text": "Ward\u2014\nDiscard a card. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player discards a card.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "b6aac1cf-bc8f-57d0-b24d-30742f95cf6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae086e-0781-4f4d-bc9c-a98228bc380c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae086e-0781-4f4d-bc9c-a98228bc380c.jpg?1",
             "name": "Sporogenic Infection",
             "text": "Enchant creature\nWhen Sporogenic Infection enters, target player sacrifices a creature other than enchanted creature.\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "dc6e09c1-3382-5828-b620-72c87ca28bee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "3292acbe-1245-5f0d-b4fe-baba590d548c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "",
             "colours": [
@@ -4573,7 +4573,7 @@
         },
         {
             "id": "cb2f106e-42d8-5270-8270-9bbacf704193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78da035-6b5b-4136-9ab6-f622b64fdc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78da035-6b5b-4136-9ab6-f622b64fdc54.jpg?1",
             "name": "Unstoppable Slasher",
             "text": "Deathtouch\nWhenever Unstoppable Slasher deals combat damage to a player, they lose half their life, rounded up.\nWhen Unstoppable Slasher dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "5f7c6a59-2960-5adf-9089-8d38fd4dc5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg?1",
             "name": "Valgavoth, Terror Eater",
             "text": "Flying, lifelink\nWard\u2014\nSacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "e8d310a2-d17d-5328-8262-5f3fc1140c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995194a0-ceb7-48c2-be5d-a208b3971e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995194a0-ceb7-48c2-be5d-a208b3971e77.jpg?1",
             "name": "Valgavoth's Faithful",
             "text": "{3}{B}, Sacrifice Valgavoth's Faithful: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4688,7 +4688,7 @@
         },
         {
             "id": "10c6b3eb-94e4-535f-9c7a-17d06e92344c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383fe040-98bb-40f3-b809-48c429b83f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383fe040-98bb-40f3-b809-48c429b83f47.jpg?1",
             "name": "Vile Mutilator",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nFlying, trample\nWhen Vile Mutilator enters, each opponent sacrifices a nontoken enchantment, then sacrifices a nontoken creature.",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "3bc5bbb7-e0d4-571f-be41-15e6eb9d4182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d38fa-bbcf-4bcc-93a8-adbfd9c93faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d38fa-bbcf-4bcc-93a8-adbfd9c93faa.jpg?1",
             "name": "Winter's Intervention",
             "text": "Winter's Intervention deals 2 damage to target creature. You gain 2 life.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "15dcb36c-b915-5b55-8b6c-fb0f4ab272ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38048d14-3463-4157-951f-1d68ec78a64e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38048d14-3463-4157-951f-1d68ec78a64e.jpg?1",
             "name": "Withering Torment",
             "text": "Destroy target creature or enchantment. You lose 2 life.",
             "colours": [
@@ -4788,7 +4788,7 @@
         },
         {
             "id": "56ba778a-1869-5181-a63a-533baf88079d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c72b5b-dd81-4eb4-80d9-a0124e27e1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c72b5b-dd81-4eb4-80d9-a0124e27e1dc.jpg?1",
             "name": "Bedhead Beastie",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "7634134d-44a9-594d-bb87-1636291bf1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956ae00-8f0c-48f0-8110-19ff53863876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956ae00-8f0c-48f0-8110-19ff53863876.jpg?1",
             "name": "Betrayer's Bargain",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment or pay {2}.\nBetrayer's Bargain deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "d5bec7c4-aeae-537a-a480-e402aebf58f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68009c-83cd-455f-81e9-bdd720d23a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68009c-83cd-455f-81e9-bdd720d23a43.jpg?1",
             "name": "Boilerbilges Ripper",
             "text": "When Boilerbilges Ripper enters, you may sacrifice another creature or enchantment. When you do, Boilerbilges Ripper deals 2 damage to any target.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "7e31cd17-674d-5fff-87ef-5c40b6317495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg?1",
             "name": "Chainsaw",
             "text": "When Chainsaw enters, it deals 3 damage to up to one target creature.\nWhenever one or more creatures die, put a rev counter on Chainsaw.\nEquipped creature gets +X/+0, where X is the number of rev counters on Chainsaw.\nEquip {3}",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "75ef0f5c-d3c2-50da-a516-90a1c221a90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "f38ff991-89ff-56d5-8786-a74815cd2877",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "abe77c3f-948b-5dfd-ba01-47247a2434be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10986e5a-9fc6-41e2-8352-289328245171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10986e5a-9fc6-41e2-8352-289328245171.jpg?1",
             "name": "Clockwork Percussionist",
             "text": "Haste\nWhen Clockwork Percussionist dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -5035,7 +5035,7 @@
         },
         {
             "id": "87346839-ed95-513f-bce2-f34394ae2fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg?1",
             "name": "Cursed Recording",
             "text": "Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "6e009fe2-7523-5a25-b426-0a2ec63325a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9b17c-4210-49f4-a920-b1dc9dfa950f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9b17c-4210-49f4-a920-b1dc9dfa950f.jpg?1",
             "name": "Diversion Specialist",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{1}, Sacrifice another creature or enchantment: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "e6137a85-bbac-5828-ae0b-c2450f3d5315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46ac55f-d68e-4d5d-af0a-3879f97f705e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46ac55f-d68e-4d5d-af0a-3879f97f705e.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "a4006054-49cd-53ee-aee5-ecebcfa208d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a5e716-68c1-4fa0-aa08-5b08114e08d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a5e716-68c1-4fa0-aa08-5b08114e08d8.jpg?1",
             "name": "Fear of Being Hunted",
             "text": "Haste\nFear of Being Hunted must be blocked if able.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "93b09e32-c7b1-506f-b09a-5d571d9ca5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b282f8e3-8b79-47e9-8c18-62284211442b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b282f8e3-8b79-47e9-8c18-62284211442b.jpg?1",
             "name": "Fear of Burning Alive",
             "text": "When Fear of Burning Alive enters, it deals 4 damage to each opponent.\nDelirium \u2014 Whenever a source you control deals noncombat damage to an opponent, if there are four or more card types among cards in your graveyard, Fear of Burning Alive deals that amount of damage to target creature that player controls.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "e59f8b8e-3d1d-593d-8e4f-d8175d428e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg?1",
             "name": "Fear of Missing Out",
             "text": "When Fear of Missing Out enters, discard a card, then draw a card.\nDelirium \u2014 Whenever Fear of Missing Out attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.",
             "colours": [
@@ -5252,7 +5252,7 @@
         },
         {
             "id": "5d70128c-84ec-5d34-a8d9-aabeeb98bd75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg?1",
             "name": "Glassworks // Shattered Yard",
             "text": "When you unlock this door, this Room deals 4 damage to target creature an opponent controls.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "347b899b-e313-5ee1-afbf-7fe0142167d0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg?1",
             "name": "Glassworks // Shattered Yard",
             "text": "Shattered Yard\no4o\nR\nAt the beginning of your end step, this Room deals 1 damage to each opponent.",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "52094f45-38ba-5459-b580-bedde716c502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50895202-f1a1-4840-a11a-55b78b8b5929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50895202-f1a1-4840-a11a-55b78b8b5929.jpg?1",
             "name": "Grab the Prize",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards. If the discarded card wasn't a land card, Grab the Prize deals 2 damage to each opponent.",
             "colours": [
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "d0d74072-7041-5290-a556-c1ca8cf15f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c2860-5a68-4a18-a23a-ca5cfdfbcac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c2860-5a68-4a18-a23a-ca5cfdfbcac8.jpg?1",
             "name": "Hand That Feeds",
             "text": "Delirium \u2014 Whenever Hand That Feeds attacks while there are four or more card types among cards in your graveyard, it gets +2/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5386,7 +5386,7 @@
         },
         {
             "id": "60f5f62e-2600-52e2-8a4b-bcc404ef770d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35248f9-9a4e-4758-a4c1-0e0c83e3fd75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35248f9-9a4e-4758-a4c1-0e0c83e3fd75.jpg?1",
             "name": "Impossible Inferno",
             "text": "Impossible Inferno deals 6 damage to target creature.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "ed961de3-0a25-5644-b6fe-31e6ce8f1650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5999f-a185-4fc7-86fa-c4e5b091e768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5999f-a185-4fc7-86fa-c4e5b091e768.jpg?1",
             "name": "Infernal Phantom",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Infernal Phantom gets +2/+0 until end of turn.\nWhen Infernal Phantom dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "78160156-ba38-5db3-b861-b8ab2eb8bfdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da254f5-53f2-41d2-a4f0-a90b3dd6209c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da254f5-53f2-41d2-a4f0-a90b3dd6209c.jpg?1",
             "name": "Irreverent Gremlin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever another creature you control with power 2 or less enters, you may discard a card. If you do, draw a card. Do this only once each turn.",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "90b12b3e-319b-5a42-a270-d1632eecb391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg?1",
             "name": "Leyline of Resonance",
             "text": "If Leyline of Resonance is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you cast an instant or sorcery spell that targets only a single creature you control, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "bea36a70-39c0-560c-942f-f5903ef33a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7b635-4c72-4129-bf95-1eef05cce3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7b635-4c72-4129-bf95-1eef05cce3d3.jpg?1",
             "name": "Most Valuable Slayer",
             "text": "Whenever you attack, target attacking creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "16444ace-4142-55f2-861d-89a12b83aea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0fdf4-3881-4327-924f-2c1b67ccda93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0fdf4-3881-4327-924f-2c1b67ccda93.jpg?1",
             "name": "Norin, Swift Survivalist",
             "text": "Norin, Swift Survivalist can't block.\nWhenever a creature you control becomes blocked, you may exile it. You may play that card from exile this turn.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "82395047-8396-5b73-9ba1-2d043963d9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58d3545-043a-457a-8324-facc3c2363ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58d3545-043a-457a-8324-facc3c2363ec.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "3e4d74d9-07ce-57f5-9f58-04a9200eb857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg?1",
             "name": "Painter's Studio // Defaced Gallery",
             "text": "When you unlock this door, exile the top two cards of your library. You may play them until the end of your next turn.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "aee7351e-476e-5b9c-ab18-2aa156f59557",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg?1",
             "name": "Painter's Studio // Defaced Gallery",
             "text": "Defaced Gallery\no1o\nR\nWhenever you attack, attacking creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5702,7 +5702,7 @@
         },
         {
             "id": "8423892d-34f6-5c0d-bab0-73949a2ff7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d35442-5ca0-4fd7-8ff1-b7347b3e6690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d35442-5ca0-4fd7-8ff1-b7347b3e6690.jpg?1",
             "name": "Piggy Bank",
             "text": "When Piggy Bank dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "aa3cdc04-b8f4-52a6-867c-81478d8accd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391b0af-2f26-4a45-9e2a-5bd8e9838107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391b0af-2f26-4a45-9e2a-5bd8e9838107.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -5772,7 +5772,7 @@
         },
         {
             "id": "8fae41b1-a3f9-500f-98b1-22aa3fd9b4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000499a4-3f39-4d25-a2a2-b2f014e30754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000499a4-3f39-4d25-a2a2-b2f014e30754.jpg?1",
             "name": "Ragged Playmate",
             "text": "{1}, {T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "15a7680e-f64e-51f3-a4c3-07dca92c3a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c914b-95af-428f-a142-6f20e418bc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c914b-95af-428f-a142-6f20e418bc59.jpg?1",
             "name": "Rampaging Soulrager",
             "text": "Rampaging Soulrager gets +3/+0 as long as there are two or more unlocked doors among Rooms you control.",
             "colours": [
@@ -5841,7 +5841,7 @@
         },
         {
             "id": "65ae68a4-69bf-526b-a764-6ac74cd091f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fb0f11-d1d0-4941-a1a7-a2db88f30394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fb0f11-d1d0-4941-a1a7-a2db88f30394.jpg?1",
             "name": "Razorkin Hordecaller",
             "text": "Haste\nWhenever you attack, create a 1/1 red Gremlin creature token.",
             "colours": [
@@ -5877,7 +5877,7 @@
         },
         {
             "id": "08c414a4-3f2b-5e2d-8263-7e520cc66641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73b963-23c0-46d2-853a-34a8b463994e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73b963-23c0-46d2-853a-34a8b463994e.jpg?1",
             "name": "Razorkin Needlehead",
             "text": "Razorkin Needlehead has first strike during your turn.\nWhenever an opponent draws a card, Razorkin Needlehead deals 1 damage to them.",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "9ece59f6-d640-5925-9e98-fa5c9065055b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effad662-3309-434c-addc-4394db1f359c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effad662-3309-434c-addc-4394db1f359c.jpg?1",
             "name": "Ripchain Razorkin",
             "text": "Reach\n{2}{R}, Sacrifice a land: Draw a card.",
             "colours": [
@@ -5949,7 +5949,7 @@
         },
         {
             "id": "71d94431-9ee2-5e52-bc83-15a361dc005f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg?1",
             "name": "The Rollercrusher Ride",
             "text": "Delirium \u2014 If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "1d80ddc5-5f00-556f-8ab9-c67660e9ab6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f4f37-796a-4b18-a5ee-1d4f711f19b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f4f37-796a-4b18-a5ee-1d4f711f19b8.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "72056277-7cda-57af-ae3c-f313b0452b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg?1",
             "name": "Screaming Nemesis",
             "text": "Haste\nWhenever Screaming Nemesis is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "a159bb7d-dce3-53d3-9802-ce17dd9dd631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg?1",
             "name": "Ticket Booth // Tunnel of Hate",
             "text": "When you unlock this door, manifest dread.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -6088,7 +6088,7 @@
         },
         {
             "id": "2456a921-9f47-5733-ad99-dca9653e97c7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg?1",
             "name": "Ticket Booth // Tunnel of Hate",
             "text": "Tunnel of Hate\no4o\nRo\nR\nWhenever you attack, target attacking creature gains double strike until end of turn.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "028a9b4e-f39b-59b5-a077-fb13ab76ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa62f67a-d20f-4d99-b0a2-327634299c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa62f67a-d20f-4d99-b0a2-327634299c9f.jpg?1",
             "name": "Trial of Agony",
             "text": "Choose two target creatures controlled by the same opponent. That player chooses one of those creatures. Trial of Agony deals 5 damage to that creature, and the other can't block this turn.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "0e1256d1-a918-58fe-86f1-f62636a3cf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2a92c-06d3-4cb5-883d-cba428a7e98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2a92c-06d3-4cb5-883d-cba428a7e98e.jpg?1",
             "name": "Turn Inside Out",
             "text": "Target creature gets +3/+0 until end of turn. When it dies this turn, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "bb96d613-88b8-5566-a53f-d1bd90e00680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857bfb0e-17dc-4dda-bc37-3df927a9eae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857bfb0e-17dc-4dda-bc37-3df927a9eae6.jpg?1",
             "name": "Untimely Malfunction",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Change the target of target spell or ability with a single target.\n\u2022 One or two target creatures can't block this turn.",
             "colours": [
@@ -6218,7 +6218,7 @@
         },
         {
             "id": "d13a7980-9b48-52d6-bfeb-667bde9575d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6918d50-a4c3-40d8-9480-343f14773a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6918d50-a4c3-40d8-9480-343f14773a69.jpg?1",
             "name": "Vengeful Possession",
             "text": "Gain control of target creature until end of turn. Untap it. It gains haste until end of turn. You may discard a card. If you do, draw a card.",
             "colours": [
@@ -6250,7 +6250,7 @@
         },
         {
             "id": "a3e9b738-9852-52a5-ba37-21c8efaaafb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12649f73-9d29-4eed-bc89-cc0d1a8969e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12649f73-9d29-4eed-bc89-cc0d1a8969e3.jpg?1",
             "name": "Vicious Clown",
             "text": "Whenever another creature you control with power 2 or less enters, Vicious Clown gets +2/+0 until end of turn.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "469929f6-02ab-5618-97cb-96e8dedfa48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg?1",
             "name": "Violent Urge",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, that creature gains double strike until end of turn.",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "de6528b8-c898-56b3-95a5-91002d8036a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg?1",
             "name": "Waltz of Rage",
             "text": "Target creature you control deals damage equal to its power to each other creature. Until end of turn, whenever a creature you control dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -6351,7 +6351,7 @@
         },
         {
             "id": "840c6f16-70db-5e71-bfad-0a346f5f382f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807b0674-8eba-4204-b6b6-fa2b785a79e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807b0674-8eba-4204-b6b6-fa2b785a79e9.jpg?1",
             "name": "Altanak, the Thrice-Called",
             "text": "Trample\nWhenever Altanak, the Thrice-Called becomes the target of a spell or ability an opponent controls, draw a card.\n{1}{G}, Discard Altanak, the Thrice-Called: Return target land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6388,7 +6388,7 @@
         },
         {
             "id": "bbf7bafc-3981-57cc-b615-ed4c0134bf97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51216ab0-9806-4faa-afbd-143e95dc255b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51216ab0-9806-4faa-afbd-143e95dc255b.jpg?1",
             "name": "Anthropede",
             "text": "Reach\nWhen Anthropede enters, you may discard a card or pay {2}. When you do, destroy target Room.",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "a781e411-a28c-5a7f-9905-98ae782d7dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76610e6e-b60f-494f-bb11-68371eb494f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76610e6e-b60f-494f-bb11-68371eb494f2.jpg?1",
             "name": "Balustrade Wurm",
             "text": "This spell can't be countered.\nTrample, haste\nDelirium \u2014 {2}{G}{G}: Return Balustrade Wurm from your graveyard to the battlefield with a finality counter on it. Activate only if there are four or more card types among cards in your graveyard and only as a sorcery.",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "1e6e8a87-092e-53bc-a44f-0c643d234a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20fa7ee-a4c2-4eb0-9467-195f3b894fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20fa7ee-a4c2-4eb0-9467-195f3b894fa0.jpg?1",
             "name": "Bashful Beastie",
             "text": "When Bashful Beastie dies, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "fedd4a13-823c-55c9-a7ef-63516151d28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209e9bbc-a15d-47fc-b149-6b0c57dd09ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209e9bbc-a15d-47fc-b149-6b0c57dd09ea.jpg?1",
             "name": "Break Down the Door",
             "text": "Choose one \u2014\n\u2022 Exile target artifact.\n\u2022 Exile target enchantment.\n\u2022 Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6524,7 +6524,7 @@
         },
         {
             "id": "cc8a4772-78bf-5ba4-afdd-e80a053d64a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc250a-854d-4555-ba78-db9283fa7c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc250a-854d-4555-ba78-db9283fa7c22.jpg?1",
             "name": "Cathartic Parting",
             "text": "The owner of target artifact or enchantment an opponent controls shuffles it into their library. You may shuffle up to four target cards from your graveyard into your library.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "cfa3aa18-9e1a-52cc-8316-11ca2c62169c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b4c1a-e058-4e06-bc46-e250fd9c9b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b4c1a-e058-4e06-bc46-e250fd9c9b54.jpg?1",
             "name": "Cautious Survivor",
             "text": "Survival \u2014 At the beginning of your second main phase, if Cautious Survivor is tapped, you gain 2 life.",
             "colours": [
@@ -6591,7 +6591,7 @@
         },
         {
             "id": "e79e46ee-3f69-55be-b14f-a38ea6d52345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498cd5d-5807-4297-bc8a-c0941f2f5ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498cd5d-5807-4297-bc8a-c0941f2f5ce2.jpg?1",
             "name": "Coordinated Clobbering",
             "text": "Tap one or two target untapped creatures you control. They each deal damage equal to their power to target creature an opponent controls.",
             "colours": [
@@ -6623,7 +6623,7 @@
         },
         {
             "id": "31cd2be1-b74b-5d80-bd52-810273ef2a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820c2932-2e23-4f67-92d0-a630aec6f1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820c2932-2e23-4f67-92d0-a630aec6f1b4.jpg?1",
             "name": "Cryptid Inspector",
             "text": "Vigilance\nWhenever a face-down permanent you control enters and whenever Cryptid Inspector or another permanent you control is turned face up, put a +1/+1 counter on Cryptid Inspector.",
             "colours": [
@@ -6658,7 +6658,7 @@
         },
         {
             "id": "58ec8774-1f1a-574a-a7c0-5ac51c88acb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327772f3-5a87-47af-9308-c1119ad2711d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327772f3-5a87-47af-9308-c1119ad2711d.jpg?1",
             "name": "Defiant Survivor",
             "text": "Survival \u2014 At the beginning of your second main phase, if Defiant Survivor is tapped, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "b6ad6ec9-87db-5c99-9655-41043086ffef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "bf1b0b5b-46a5-5360-b424-ddabe7a6d0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93bb4abc-5af1-4cf5-919b-244b6a36f8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93bb4abc-5af1-4cf5-919b-244b6a36f8ec.jpg?1",
             "name": "Fear of Exposure",
             "text": "As an additional cost to cast this spell, tap two untapped creatures and/or lands you control.\nTrample",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "5f1ec504-0261-5342-aa10-e0f14abe7a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60499c90-a512-4abb-98eb-0735a7138421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60499c90-a512-4abb-98eb-0735a7138421.jpg?1",
             "name": "Flesh Burrower",
             "text": "Deathtouch\nWhenever Flesh Burrower attacks, another target creature you control gains deathtouch until end of turn.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "d2589919-0f1a-5b73-bfc0-5750eacc86d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9d35d-7fd0-4193-9f7e-b8a59fae4ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9d35d-7fd0-4193-9f7e-b8a59fae4ac5.jpg?1",
             "name": "Frantic Strength",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+2 and has trample.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "b4881ca4-298f-5f00-8735-97c86f1435f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fddcd48-3efe-4b56-9d69-9659b3dc6021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fddcd48-3efe-4b56-9d69-9659b3dc6021.jpg?1",
             "name": "Grasping Longneck",
             "text": "Reach\nWhen Grasping Longneck dies, you gain 2 life.",
             "colours": [
@@ -6871,7 +6871,7 @@
         },
         {
             "id": "bfa902a2-a366-572c-a819-c128686eb084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg?1",
             "name": "Greenhouse // Rickety Gazebo",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "6ac1fc4d-10df-5f00-9e0b-12efc8db59de",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg?1",
             "name": "Greenhouse // Rickety Gazebo",
             "text": "Rickety Gazebo\no3o\nG\nWhen you unlock this door, mill four cards, then return up to two permanent cards from among them to your hand.",
             "colours": [
@@ -6939,7 +6939,7 @@
         },
         {
             "id": "b7b204b5-ac99-5ff8-9e58-f93c74ec9b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744ef0bc-9973-450e-a0c4-056d8244f357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744ef0bc-9973-450e-a0c4-056d8244f357.jpg?1",
             "name": "Hauntwoods Shrieker",
             "text": "Whenever Hauntwoods Shrieker attacks, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\n{1}{G}: Reveal target face-down permanent. If it's a creature card, you may turn it face up.",
             "colours": [
@@ -6976,7 +6976,7 @@
         },
         {
             "id": "a181e173-1403-5e66-b394-13bb2d261d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg?1",
             "name": "Hedge Shredder",
             "text": "Whenever Hedge Shredder attacks, you may mill two cards.\nWhenever one or more land cards are put into your graveyard from your library, put them onto the battlefield tapped.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "6dddf05e-ab72-5dac-9676-1f6758272558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c175c998-7b80-4187-bdbc-5b6e0d7eac91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c175c998-7b80-4187-bdbc-5b6e0d7eac91.jpg?1",
             "name": "Horrid Vigor",
             "text": "Target creature gains deathtouch and indestructible until end of turn.",
             "colours": [
@@ -7044,7 +7044,7 @@
         },
         {
             "id": "bab33d4b-5abb-507c-b5ed-4623246dca6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a534918-a009-4f7d-87c9-5ef600b6e7c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a534918-a009-4f7d-87c9-5ef600b6e7c2.jpg?1",
             "name": "House Cartographer",
             "text": "Survival \u2014 At the beginning of your second main phase, if House Cartographer is tapped, reveal cards from the top of your library until you reveal a land card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "e401eeb6-3f2b-52cd-9996-61630efe271f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60d2e62-06da-410a-81ed-6cebb2632fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60d2e62-06da-410a-81ed-6cebb2632fb6.jpg?1",
             "name": "Insidious Fungus",
             "text": "{2}, Sacrifice Insidious Fungus: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Draw a card. Then you may put a land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -7116,7 +7116,7 @@
         },
         {
             "id": "472c6623-aa7a-548f-8198-941b89904340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg?1",
             "name": "Kona, Rescue Beastie",
             "text": "Survival \u2014 At the beginning of your second main phase, if Kona, Rescue Beastie is tapped, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "f59cdb60-220a-52f8-b08e-b9031c056fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg?1",
             "name": "Leyline of Mutation",
             "text": "If Leyline of Mutation is in your opening hand, you may begin the game with it on the battlefield.\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "1573e95e-2673-52e7-bbe5-141f7dbbf5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a649265b-6c32-49e7-b6cb-6086c40d26e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a649265b-6c32-49e7-b6cb-6086c40d26e8.jpg?1",
             "name": "Manifest Dread",
             "text": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "fd52305c-8edf-536f-9384-bde983bf3e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg?1",
             "name": "Moldering Gym // Weight Room",
             "text": "When you unlock this door, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -7260,7 +7260,7 @@
         },
         {
             "id": "90eabdd2-7a2d-5fee-886c-a96ffa3b72eb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg?1",
             "name": "Moldering Gym // Weight Room",
             "text": "Weight Room\no5o\nG\nWhen you unlock this door, manifest dread, then put three +1/+1 counters on that creature.",
             "colours": [
@@ -7294,7 +7294,7 @@
         },
         {
             "id": "ed481b0e-f1b5-5213-bf7f-a53218b806da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999eb47-b842-47f1-be91-c79fc46e1896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999eb47-b842-47f1-be91-c79fc46e1896.jpg?1",
             "name": "Monstrous Emergence",
             "text": "As an additional cost to cast this spell, choose a creature you control or reveal a creature card from your hand.\nMonstrous Emergence deals damage equal to the power of the creature you chose or the card you revealed to target creature.",
             "colours": [
@@ -7326,7 +7326,7 @@
         },
         {
             "id": "f52ecd4d-d13f-59a1-a9ca-608e0fc8792a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg?1",
             "name": "Omnivorous Flytrap",
             "text": "Delirium \u2014 Whenever Omnivorous Flytrap enters or attacks, if there are four or more card types among cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if there are six or more card types among cards in your graveyard, double the number of +1/+1 counters on those creatures.",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "665cca29-eb6c-5577-a582-7256d39d7a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg?1",
             "name": "Overgrown Zealot",
             "text": "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this mana only to turn permanents face up.",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "efe21992-9359-5b88-a6ca-8a482a136ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d08ff1-edcc-4c76-96e0-683b3da36ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d08ff1-edcc-4c76-96e0-683b3da36ebb.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -7437,7 +7437,7 @@
         },
         {
             "id": "eada20e1-7d44-5074-b6e1-15ebbc34cc22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895de583-36d2-43fd-927f-8876d4302c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895de583-36d2-43fd-927f-8876d4302c73.jpg?1",
             "name": "Patchwork Beastie",
             "text": "Delirium \u2014 Patchwork Beastie can't attack or block unless there are four or more card types among cards in your graveyard.\nAt the beginning of your upkeep, you may mill a card. (You may put the top card of your library into your graveyard.)",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "ddf4ca5a-5ff7-54c1-9a98-24d01c6bc02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d843c242-088f-4131-9e52-7ee2d0db5e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d843c242-088f-4131-9e52-7ee2d0db5e20.jpg?1",
             "name": "Rootwise Survivor",
             "text": "Haste\nSurvival \u2014 At the beginning of your second main phase, if Rootwise Survivor is tapped, put three +1/+1 counters on up to one target land you control. That land becomes a 0/0 Elemental creature in addition to its other types. It gains haste until your next turn.",
             "colours": [
@@ -7507,7 +7507,7 @@
         },
         {
             "id": "c2bfef0b-8c4e-5890-adee-da065f496927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c58683-b5f2-4863-9562-6f6be1ec21fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c58683-b5f2-4863-9562-6f6be1ec21fe.jpg?1",
             "name": "Say Its Name",
             "text": "Mill three cards. Then you may return a creature or land card from your graveyard to your hand.\nExile this card and two other cards named Say Its Name from your graveyard: Search your graveyard, hand, and/or library for a card named Altanak, the Thrice-Called and put it onto the battlefield. If you search your library this way, shuffle. Activate only as a sorcery.",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "075d6191-4a31-5a55-a4df-512611ef1af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ca4d-5895-4074-8315-656363d14862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ca4d-5895-4074-8315-656363d14862.jpg?1",
             "name": "Slavering Branchsnapper",
             "text": "Trample\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "0faa02e9-1c66-5238-9c85-b6dbd5a3b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d697c-8358-429b-8f79-7ad9d01a5edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d697c-8358-429b-8f79-7ad9d01a5edd.jpg?1",
             "name": "Spineseeker Centipede",
             "text": "When Spineseeker Centipede enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nDelirium \u2014 Spineseeker Centipede gets +1/+2 and has vigilance as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -7607,7 +7607,7 @@
         },
         {
             "id": "c94cdc97-f02e-5527-b0cc-b70986697e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7201ee12-9104-48d8-aeec-08a318c8ee10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7201ee12-9104-48d8-aeec-08a318c8ee10.jpg?1",
             "name": "Threats Around Every Corner",
             "text": "When Threats Around Every Corner enters, manifest dread.\nWhenever a face-down permanent you control enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "29f10329-ed52-5a84-b7fe-be3c522851ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg?1",
             "name": "Twitching Doll",
             "text": "{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.",
             "colours": [
@@ -7678,7 +7678,7 @@
         },
         {
             "id": "54a3710d-c0bb-539e-8ef0-95ed32a89b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7687b1-630a-4e95-89c7-eaf456d8cb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7687b1-630a-4e95-89c7-eaf456d8cb68.jpg?1",
             "name": "Tyvar, the Pummeler",
             "text": "Tap another untapped creature you control: Tyvar, the Pummeler gains indestructible until end of turn. Tap it.\n{3}{G}{G}: Creatures you control get +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "df6c1eb4-368e-5326-a8b0-0fc83959a386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1ad3-00ad-48ec-a71f-812649d55e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1ad3-00ad-48ec-a71f-812649d55e14.jpg?1",
             "name": "Under the Skin",
             "text": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nYou may return a permanent card from your graveyard to your hand.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "62d4034c-f7e5-5c0e-ac51-07338cfa2b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg?1",
             "name": "Valgavoth's Onslaught",
             "text": "Manifest dread X times, then put X +1/+1 counters on each of those creatures. (To manifest dread, look at the top two cards of your library, then put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "cc5f93b5-f109-5bc0-9b68-9189a7f6183f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "281345a9-41d8-5656-8758-4ebd616f9a70",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "",
             "colours": [
@@ -7858,7 +7858,7 @@
         },
         {
             "id": "a8da9466-b670-5618-9c25-90ff6f172452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ed97f2-b47e-49b7-9b1a-694c4bbeca3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ed97f2-b47e-49b7-9b1a-694c4bbeca3b.jpg?1",
             "name": "Wary Watchdog",
             "text": "When Wary Watchdog enters or dies, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7892,7 +7892,7 @@
         },
         {
             "id": "a6b9f2e9-1bba-5a12-8024-15f86f0ed65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a74892-20cd-47f7-b514-a4c7f14cca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a74892-20cd-47f7-b514-a4c7f14cca8b.jpg?1",
             "name": "Wickerfolk Thresher",
             "text": "Delirium \u2014 Whenever Wickerfolk Thresher attacks, if there are four or more card types among cards in your graveyard, look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "0a26e4d3-3762-5242-8478-4ffbcca37259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f683d5a1-b8bf-446f-9fe3-88a4398bf3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f683d5a1-b8bf-446f-9fe3-88a4398bf3cf.jpg?1",
             "name": "Arabella, Abandoned Doll",
             "text": "Whenever Arabella, Abandoned Doll attacks, it deals X damage to each opponent and you gain X life, where X is the number of creatures you control with power 2 or less.",
             "colours": [
@@ -7966,7 +7966,7 @@
         },
         {
             "id": "f590f8c0-5f2b-5fe3-9753-64112e31f7ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438accb1-6d2c-4710-adeb-df4301a7b8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438accb1-6d2c-4710-adeb-df4301a7b8f1.jpg?1",
             "name": "Baseball Bat",
             "text": "When Baseball Bat enters, attach it to target creature you control.\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, tap up to one target creature.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "861b3892-b706-5960-af73-7ff05396efd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f889c95-46af-4fd9-aff2-573d5384fd58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f889c95-46af-4fd9-aff2-573d5384fd58.jpg?1",
             "name": "Beastie Beatdown",
             "text": "Choose target creature you control and target creature an opponent controls.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, put two +1/+1 counters on the creature you control.\nThe creature you control deals damage equal to its power to the creature an opponent controls.",
             "colours": [
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "fc1d0b9a-c65f-562a-95fb-b37316e8bf45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdd2622-ab7a-4990-b026-3667cac42894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdd2622-ab7a-4990-b026-3667cac42894.jpg?1",
             "name": "Broodspinner",
             "text": "Reach\nWhen Broodspinner enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n{4}{B}{G}, {T}, Sacrifice Broodspinner: Create a number of 1/1 black and green Insect creature tokens with flying equal to the number of card types among cards in your graveyard.",
             "colours": [
@@ -8072,7 +8072,7 @@
         },
         {
             "id": "7a24ce69-bfc1-53e7-bed8-9c776c8e1019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b0c5d-6823-439c-a011-8b9bf424bdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b0c5d-6823-439c-a011-8b9bf424bdad.jpg?1",
             "name": "Disturbing Mirth",
             "text": "When Disturbing Mirth enters, you may sacrifice another enchantment or creature. If you do, draw two cards.\nWhen you sacrifice Disturbing Mirth, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "0f17aa5d-ff22-526b-8d52-b6aea79fc22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f46095-6479-46b0-9e59-194d83f86a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f46095-6479-46b0-9e59-194d83f86a46.jpg?1",
             "name": "Drag to the Roots",
             "text": "Delirium \u2014 This spell costs {2} less to cast as long as there are four or more card types among cards in your graveyard.\nDestroy target nonland permanent.",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "143eb035-4cc1-5d29-a878-a40c491b6fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81756844-c642-406f-842d-35c1e404fec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81756844-c642-406f-842d-35c1e404fec0.jpg?1",
             "name": "Fear of Infinity",
             "text": "Flying, lifelink\nFear of Infinity can't block.\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, you may return Fear of Infinity from your graveyard to your hand.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "93669828-8074-5886-8e8e-3872f18a3b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3593a222-21c5-4f91-bde1-763ea08071da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3593a222-21c5-4f91-bde1-763ea08071da.jpg?1",
             "name": "Gremlin Tamer",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 1/1 red Gremlin creature token.",
             "colours": [
@@ -8216,7 +8216,7 @@
         },
         {
             "id": "5c464cbc-7490-5df8-9501-a49fe8c9ed0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5479ac50-8335-4c6a-be99-750a44e24f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5479ac50-8335-4c6a-be99-750a44e24f25.jpg?1",
             "name": "Growing Dread",
             "text": "Flash\nWhen Growing Dread enters, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever you turn a permanent face up, put a +1/+1 counter on it.",
             "colours": [
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "480f7221-c81e-5d2f-8e9f-e964fc2e63c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f66e3e-9f1f-4601-aa30-30b66805a5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f66e3e-9f1f-4601-aa30-30b66805a5a8.jpg?1",
             "name": "Inquisitive Glimmer",
             "text": "Enchantment spells you cast cost {1} less to cast.\nUnlock costs you pay cost {1} less.",
             "colours": [
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "4d3e7bce-9b81-5f85-825c-541a61c37dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffc298-0219-4807-ab05-d94460e767bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffc298-0219-4807-ab05-d94460e767bc.jpg?1",
             "name": "Intruding Soulrager",
             "text": "Vigilance\n{T}, Sacrifice a Room: Intruding Soulrager deals 2 damage to each opponent. Draw a card.",
             "colours": [
@@ -8326,7 +8326,7 @@
         },
         {
             "id": "903dd6a6-e6e6-54f1-a41f-1cb716febba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e2e0-1c0e-475d-a0f4-1be4216c2bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e2e0-1c0e-475d-a0f4-1be4216c2bad.jpg?1",
             "name": "The Jolly Balloon Man",
             "text": "Haste\n{1}, {T}: Create a token that's a copy of another target creature you control, except it's a 1/1 red Balloon creature in addition to its other colors and types and it has flying and haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "e28d871a-716f-5e8a-af8c-0034d114837d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a14f30-4ff9-4472-90a6-c3139f1c18e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a14f30-4ff9-4472-90a6-c3139f1c18e5.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B} ({1}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "1f9cf760-85b7-50ae-b151-11c3e2f9570d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6428cddc-2fb6-41af-a643-e83c81dc04f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6428cddc-2fb6-41af-a643-e83c81dc04f5.jpg?1",
             "name": "Marina Vendrell",
             "text": "When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment cards from among them into your hand and the rest on the bottom of your library in a random order.\n{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
             "colours": [
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "f188e82b-2f29-5e73-8ead-206ea95f58d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc0b94f-08b3-4fb6-9b09-2f3a215203ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc0b94f-08b3-4fb6-9b09-2f3a215203ca.jpg?1",
             "name": "Midnight Mayhem",
             "text": "Create three 1/1 red Gremlin creature tokens. Gremlins you control gain menace, lifelink, and haste until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "a8e11bfc-1c4a-512b-87d8-94fad866a7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9e1e-43f2-499e-844d-22fc10dbad06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9e1e-43f2-499e-844d-22fc10dbad06.jpg?1",
             "name": "Nashi, Searcher in the Dark",
             "text": "Menace\nWhenever Nashi, Searcher in the Dark deals combat damage to a player, you mill that many cards. You may put any number of legendary and/or enchantment cards from among them into your hand. If you put no cards into your hand this way, put a +1/+1 counter on Nashi.",
             "colours": [
@@ -8532,7 +8532,7 @@
         },
         {
             "id": "da80eccb-b9fe-5ab4-aaf7-2575502453f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ad013f-de8d-4980-b4b6-c7f91ff495b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ad013f-de8d-4980-b4b6-c7f91ff495b1.jpg?1",
             "name": "Niko, Light of Hope",
             "text": "When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "2f227788-09fe-5dc3-ba0f-f62ad5d43188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b4c50b-fe76-430d-8f96-208f15ca4cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b4c50b-fe76-430d-8f96-208f15ca4cd7.jpg?1",
             "name": "Oblivious Bookworm",
             "text": "At the beginning of your end step, you may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn.",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "1efe9af6-58e0-588c-9bcf-d9695950a521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874eadb6-602e-47dc-8094-82e37ac89c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874eadb6-602e-47dc-8094-82e37ac89c94.jpg?1",
             "name": "Peer Past the Veil",
             "text": "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard.",
             "colours": [
@@ -8649,7 +8649,7 @@
         },
         {
             "id": "3306130d-0e63-5255-a217-bd1a7485ba3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "907454bd-5d40-5624-8711-07f0ce38590f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "",
             "colours": [
@@ -8723,7 +8723,7 @@
         },
         {
             "id": "78b68c36-8883-5af9-9119-89c188385704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12e3b3-a260-4913-b13a-7fbb753dd702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12e3b3-a260-4913-b13a-7fbb753dd702.jpg?1",
             "name": "Rip, Spawn Hunter",
             "text": "Survival \u2014 At the beginning of your second main phase, if Rip, Spawn Hunter is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8764,7 +8764,7 @@
         },
         {
             "id": "bf2acdc0-461a-5c0f-8b5e-554d4e8bdc0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e79123f-accd-4193-8c72-b750e0d6f3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e79123f-accd-4193-8c72-b750e0d6f3fa.jpg?1",
             "name": "Rite of the Moth",
             "text": "Return target creature card from your graveyard to the battlefield with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)\nFlashback {3}{W}{W}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8798,7 +8798,7 @@
         },
         {
             "id": "dbe5c0fc-9eaa-5030-8702-dde9ef1d9de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "",
             "colours": [
@@ -8835,7 +8835,7 @@
         },
         {
             "id": "f75d6d5f-8dff-5c31-9081-5ede6c598d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "",
             "colours": [
@@ -8872,7 +8872,7 @@
         },
         {
             "id": "80decd66-646b-50d7-92eb-b3423b24d04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe51964-50d2-49b0-9c3c-81751dcbeade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe51964-50d2-49b0-9c3c-81751dcbeade.jpg?1",
             "name": "Sawblade Skinripper",
             "text": "Menace\n{2}, Sacrifice another creature or enchantment: Put a +1/+1 counter on Sawblade Skinripper.\nAt the beginning of your end step, if you sacrificed one or more permanents this turn, Sawblade Skinripper deals that much damage to any target.",
             "colours": [
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "2b1f5c62-d3da-5720-95d4-e39b7de656fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9636877-8fcc-4ad5-8eb2-a5d5ba49583d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9636877-8fcc-4ad5-8eb2-a5d5ba49583d.jpg?1",
             "name": "Shrewd Storyteller",
             "text": "Survival \u2014 At the beginning of your second main phase, if Shrewd Storyteller is tapped, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8946,7 +8946,7 @@
         },
         {
             "id": "cecffedd-9077-56dd-8b10-c481d97ae679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f746bf-0642-48db-835e-27a7fe369fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f746bf-0642-48db-835e-27a7fe369fef.jpg?1",
             "name": "Shroudstomper",
             "text": "Deathtouch\nWhenever Shroudstomper enters or attacks, each opponent loses 2 life. You gain 2 life and draw a card.",
             "colours": [
@@ -8982,7 +8982,7 @@
         },
         {
             "id": "22b67cb3-4c25-5514-94af-d77951ac3a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fdcdfd0-8c66-4767-a894-58cf0c6d7e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fdcdfd0-8c66-4767-a894-58cf0c6d7e07.jpg?1",
             "name": "Skullsnap Nuisance",
             "text": "Flying\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -9019,7 +9019,7 @@
         },
         {
             "id": "9568be43-ac9a-5c79-9940-453826cc59fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg?1",
             "name": "Smoky Lounge // Misty Salon",
             "text": "At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells and unlock doors.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -9054,7 +9054,7 @@
         },
         {
             "id": "1d1d6353-1898-5849-a4c5-a6de87a10454",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg?1",
             "name": "Smoky Lounge // Misty Salon",
             "text": "Misty Salon\no3o\nU\nWhen you unlock this door, create an X/X blue Spirit creature token with flying, where X is the number of unlocked doors among Rooms you control.",
             "colours": [
@@ -9089,7 +9089,7 @@
         },
         {
             "id": "8f124bbb-5bd0-5cf4-be5d-ac0b50889d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3b17b-f2f6-4702-864d-8c96100b0563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3b17b-f2f6-4702-864d-8c96100b0563.jpg?1",
             "name": "The Swarmweaver",
             "text": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "e5e0e6d1-64e5-5ca5-8c6a-77b87c0dc0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b96951-4884-4df7-bdf0-94be2bc044f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b96951-4884-4df7-bdf0-94be2bc044f0.jpg?1",
             "name": "Undead Sprinter",
             "text": "Trample, haste\nYou may cast Undead Sprinter from your graveyard if a non-Zombie creature died this turn. If you do, Undead Sprinter enters with a +1/+1 counter on it.",
             "colours": [
@@ -9169,7 +9169,7 @@
         },
         {
             "id": "67f6cc5e-0158-5a98-890c-9305823f174a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51392ece-c9f5-46b0-9dce-0a1a0343a536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51392ece-c9f5-46b0-9dce-0a1a0343a536.jpg?1",
             "name": "Victor, Valgavoth's Seneschal",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "e423c38b-8221-5340-a66d-3335bd657288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7fbc6e-09c6-4f0e-92e2-766aae950b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7fbc6e-09c6-4f0e-92e2-766aae950b3d.jpg?1",
             "name": "Wildfire Wickerfolk",
             "text": "Haste\nDelirium \u2014 Wildfire Wickerfolk gets +1/+1 and has trample as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "fc1488ec-1f65-5813-a641-fc63e1feff4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b81421-44cb-440f-a6ac-3ddf620f1989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b81421-44cb-440f-a6ac-3ddf620f1989.jpg?1",
             "name": "Winter, Misanthropic Guide",
             "text": "Ward {2}\nAt the beginning of your upkeep, each player draws two cards.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, each opponent's maximum hand size is equal to seven minus the number of those card types.",
             "colours": [
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "3ed05381-6603-56e0-8355-7d555987d88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722f4f7-fe38-4107-a715-7b27b6a4e341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722f4f7-fe38-4107-a715-7b27b6a4e341.jpg?1",
             "name": "Zimone, All-Questioning",
             "text": "At the beginning of your end step, if a land entered the battlefield under your control this turn and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters on it. (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, and 31 are prime numbers.)",
             "colours": [
@@ -9331,7 +9331,7 @@
         },
         {
             "id": "41eccfe3-4aaa-5c41-bb3a-4a5c967a7276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477dc3e-0fa1-4ce4-b3de-8cae0d1a0763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477dc3e-0fa1-4ce4-b3de-8cae0d1a0763.jpg?1",
             "name": "Attack-in-the-Box",
             "text": "Whenever Attack-in-the-Box attacks, you may have it get +4/+0 until end of turn. If you do, sacrifice it at the beginning of the next end step.",
             "colours": [],
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "fd2b2391-4a79-5724-9984-43f8380fb21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c27d6-dc3a-4420-bb35-d97dc216e002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c27d6-dc3a-4420-bb35-d97dc216e002.jpg?1",
             "name": "Bear Trap",
             "text": "Flash\n{3}, {T}, Sacrifice Bear Trap: It deals 3 damage to target creature.",
             "colours": [],
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "eb26f5d6-e8de-5b3f-824f-2541480da797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf37c1a-096b-4306-97cf-bc4d4c47d4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf37c1a-096b-4306-97cf-bc4d4c47d4a1.jpg?1",
             "name": "Conductive Machete",
             "text": "When Conductive Machete enters, manifest dread, then attach Conductive Machete to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature gets +2/+1.\nEquip {4}",
             "colours": [],
@@ -9420,7 +9420,7 @@
         },
         {
             "id": "7bbc1f20-3388-5e00-9014-527b2d59d644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048bb2c6-91bd-4d6a-a070-c73d8277c264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048bb2c6-91bd-4d6a-a070-c73d8277c264.jpg?1",
             "name": "Dissection Tools",
             "text": "When Dissection Tools enters, manifest dread, then attach Dissection Tools to that creature.\nEquipped creature gets +2/+2 and has deathtouch and lifelink.\nEquip\u2014\nSacrifice a creature.",
             "colours": [],
@@ -9452,7 +9452,7 @@
         },
         {
             "id": "41c7c095-3248-5fd1-80f3-0abc0e9ca761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12eb087-762e-4e7d-a6e0-f48df603b7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12eb087-762e-4e7d-a6e0-f48df603b7c7.jpg?1",
             "name": "Found Footage",
             "text": "You may look at face-down creatures your opponents control any time.\n{2}, Sacrifice Found Footage: Surveil 2, then draw a card. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [],
@@ -9482,7 +9482,7 @@
         },
         {
             "id": "ee056c6d-15f1-5b5a-a94e-346c70756622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg?1",
             "name": "Friendly Teddy",
             "text": "When Friendly Teddy dies, each player draws a card.",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "c2ec2e17-401d-5f22-b37f-115bf70c41fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg?1",
             "name": "Ghost Vacuum",
             "text": "{T}: Exile target card from a graveyard.\n{6}, {T}, Sacrifice Ghost Vacuum: Put each creature card exiled with Ghost Vacuum onto the battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to its other types. Activate only as a sorcery.",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "deb12f49-09db-5dfd-a105-174b51c0db34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071691c-5c65-42d4-ac96-d302185ca678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071691c-5c65-42d4-ac96-d302185ca678.jpg?1",
             "name": "Glimmerlight",
             "text": "When Glimmerlight enters, create a 1/1 white Glimmer enchantment creature token.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "487d3471-44bb-59a9-91d5-0188bced4eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7d552f-a7ac-4a49-a582-9d378137005f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7d552f-a7ac-4a49-a582-9d378137005f.jpg?1",
             "name": "Haunted Screen",
             "text": "{T}: Add {W} or {B}.\n{T}, Pay 1 life: Add {G}, {U}, or {R}.\n{7}: Put seven +1/+1 counters on Haunted Screen. It becomes a 0/0 Spirit creature in addition to its other types. Activate only once.",
             "colours": [],
@@ -9608,7 +9608,7 @@
         },
         {
             "id": "2d19b129-8691-5527-9bed-4b8bb3f00bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c11a413-7f33-4b63-bdd9-e143e529f56d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c11a413-7f33-4b63-bdd9-e143e529f56d.jpg?1",
             "name": "Keys to the House",
             "text": "{1}, {T}, Sacrifice Keys to the House: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{3}, {T}, Sacrifice Keys to the House: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
             "colours": [],
@@ -9636,7 +9636,7 @@
         },
         {
             "id": "0193a02b-3977-5e0c-a77e-c33b71db25d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09d296-4493-47f7-ad76-ad76c747df78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09d296-4493-47f7-ad76-ad76c747df78.jpg?1",
             "name": "Malevolent Chandelier",
             "text": "Flying\n{2}: Put target card from a graveyard on the bottom of its owner's library. Activate only as a sorcery.",
             "colours": [],
@@ -9667,7 +9667,7 @@
         },
         {
             "id": "7842ec2a-7edc-5680-b6ab-c8707828afc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66898970-b99b-48f2-9240-68c301c95500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66898970-b99b-48f2-9240-68c301c95500.jpg?1",
             "name": "Marvin, Murderous Mimic",
             "text": "Marvin, Murderous Mimic has all activated abilities of creatures you control that don't have the same name as this creature.",
             "colours": [],
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "9f087ad0-b002-5d7f-a6b5-3fe7e1f71899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603c3ef4-4ef1-4db8-9ed2-e2b0926269d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603c3ef4-4ef1-4db8-9ed2-e2b0926269d5.jpg?1",
             "name": "Saw",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, you may sacrifice a permanent other than that creature or Saw. If you do, draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "b280bcf1-1373-5bfa-a6d5-c3e90bf7925f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0565f5-ebdb-43f9-bbb4-0485b1968937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0565f5-ebdb-43f9-bbb4-0485b1968937.jpg?1",
             "name": "Abandoned Campground",
             "text": "Abandoned Campground enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "3106d59e-a4f4-5cd4-8720-9c2fbe8ee7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151c8e2-d715-470d-868a-f45191db9fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151c8e2-d715-470d-868a-f45191db9fa0.jpg?1",
             "name": "Blazemire Verge",
             "text": "{T}: Add {B}.\n{T}: Add {R}. Activate only if you control a Swamp or a Mountain.",
             "colours": [],
@@ -9796,7 +9796,7 @@
         },
         {
             "id": "b2cc16e6-79bd-56c0-b660-86ab1d10923c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb224874-aff5-461f-82ee-89b06663231a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb224874-aff5-461f-82ee-89b06663231a.jpg?1",
             "name": "Bleeding Woods",
             "text": "Bleeding Woods enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9827,7 +9827,7 @@
         },
         {
             "id": "96b237a3-84e0-5f3f-97cb-2130f66ff68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900b89-0e10-4602-bba2-da8d60ea5885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900b89-0e10-4602-bba2-da8d60ea5885.jpg?1",
             "name": "Etched Cornfield",
             "text": "Etched Cornfield enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9858,7 +9858,7 @@
         },
         {
             "id": "110c0fdc-c1b3-5027-a062-9022465fb47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ed0db-1199-44b3-8eda-8189dfcf53d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ed0db-1199-44b3-8eda-8189dfcf53d1.jpg?1",
             "name": "Floodfarm Verge",
             "text": "{T}: Add {W}.\n{T}: Add {U}. Activate only if you control a Plains or an Island.",
             "colours": [],
@@ -9891,7 +9891,7 @@
         },
         {
             "id": "2197641e-f184-5d7a-ac13-c467fc2e4b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f510b7-4cbd-4883-9c26-c8824bc668ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f510b7-4cbd-4883-9c26-c8824bc668ac.jpg?1",
             "name": "Gloomlake Verge",
             "text": "{T}: Add {U}.\n{T}: Add {B}. Activate only if you control an Island or a Swamp.",
             "colours": [],
@@ -9924,7 +9924,7 @@
         },
         {
             "id": "a6f3be16-22a5-5655-aace-bee1527ab595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec288d76-c1f5-471b-8a53-504f88469c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec288d76-c1f5-471b-8a53-504f88469c1b.jpg?1",
             "name": "Hushwood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {W}. Activate only if you control a Forest or a Plains.",
             "colours": [],
@@ -9957,7 +9957,7 @@
         },
         {
             "id": "ac39050a-f1b0-5dd8-9bb2-4075101a91ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9367acd-393a-4966-ba60-af2ecd4e7596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9367acd-393a-4966-ba60-af2ecd4e7596.jpg?1",
             "name": "Lakeside Shack",
             "text": "Lakeside Shack enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "42ec847f-fae8-53e4-8973-396c79dd08d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6098d8be-4e3f-455d-8799-91435bf45a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6098d8be-4e3f-455d-8799-91435bf45a1c.jpg?1",
             "name": "Murky Sewer",
             "text": "Murky Sewer enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "39350f1a-9160-51a1-9582-e74c7370c621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cf1531-8a3c-4e28-a114-d3a342b33bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cf1531-8a3c-4e28-a114-d3a342b33bb6.jpg?1",
             "name": "Neglected Manor",
             "text": "Neglected Manor enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10050,7 +10050,7 @@
         },
         {
             "id": "2d1e9d74-d182-5334-9a0e-2a06cbad4bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e40c0-e70e-4353-a920-9851cfac71dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e40c0-e70e-4353-a920-9851cfac71dd.jpg?1",
             "name": "Peculiar Lighthouse",
             "text": "Peculiar Lighthouse enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "22c9420e-993f-5784-ad36-5cae6c8dbccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3604a211-9bf7-474e-bd78-32a862f4259c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3604a211-9bf7-474e-bd78-32a862f4259c.jpg?1",
             "name": "Raucous Carnival",
             "text": "Raucous Carnival enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10112,7 +10112,7 @@
         },
         {
             "id": "3bdfeabf-e9c4-512a-a8ef-05cf89208535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d0d067-b52d-47ec-ba7b-8cfcd716c0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d0d067-b52d-47ec-ba7b-8cfcd716c0e5.jpg?1",
             "name": "Razortrap Gorge",
             "text": "Razortrap Gorge enters tapped unless a player has 13 or less life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "572333ff-8f00-5895-872a-2d50716c7b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ce9250-bdbe-4c77-9243-6db9ffffe69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ce9250-bdbe-4c77-9243-6db9ffffe69b.jpg?1",
             "name": "Strangled Cemetery",
             "text": "Strangled Cemetery enters tapped unless a player has 13 or less life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10174,7 +10174,7 @@
         },
         {
             "id": "80a92854-a04e-5203-87d3-5caab886a78c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b379c8f1-817c-4f18-8f58-45c40504433e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b379c8f1-817c-4f18-8f58-45c40504433e.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10202,7 +10202,7 @@
         },
         {
             "id": "9e39728c-ba50-5d30-814a-c25547182c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1cdc03-6faa-4138-9a52-caafbe34fb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1cdc03-6faa-4138-9a52-caafbe34fb59.jpg?1",
             "name": "Thornspire Verge",
             "text": "{T}: Add {R}.\n{T}: Add {G}. Activate only if you control a Mountain or a Forest.",
             "colours": [],
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "cbc36a0d-5ec5-51be-a24d-b89c7b5602f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff914e-3f3e-4b7a-b69d-73575b68fb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff914e-3f3e-4b7a-b69d-73575b68fb8e.jpg?1",
             "name": "Valgavoth's Lair",
             "text": "Hexproof\nValgavoth's Lair enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -10266,7 +10266,7 @@
         },
         {
             "id": "88dea124-b6f2-5890-8ec1-be2e74b8c588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67ce864-bf29-42f1-81ca-a98022892eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67ce864-bf29-42f1-81ca-a98022892eec.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10303,7 +10303,7 @@
         },
         {
             "id": "417e6ecf-e74f-5509-85d7-167d68762767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e3bf00-84cc-498c-b214-1052b4904d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e3bf00-84cc-498c-b214-1052b4904d92.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "7faf698f-7b41-5642-94a2-b55ba9ff5858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7442c1c7-1c10-4387-92e6-4bdea263064f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7442c1c7-1c10-4387-92e6-4bdea263064f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "b34bedff-8b29-5e46-bdad-a12a63da7b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8841b2-9b4e-4f65-8e30-1e9423cb8fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8841b2-9b4e-4f65-8e30-1e9423cb8fbc.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "d69ba27f-05d4-5f35-944e-147eba64ec36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a4cbb-f325-4178-80db-7090f5672414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a4cbb-f325-4178-80db-7090f5672414.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10451,7 +10451,7 @@
         },
         {
             "id": "68b3cf6c-9a7e-56be-9518-942f93ef4aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b499b37-efaf-4484-95e8-a70a9778c804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b499b37-efaf-4484-95e8-a70a9778c804.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10488,7 +10488,7 @@
         },
         {
             "id": "50b89850-074b-5cfa-8cd1-addf6aaf944c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756abff9-9810-4e2d-b1d7-ec4e2d6d5187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756abff9-9810-4e2d-b1d7-ec4e2d6d5187.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10525,7 +10525,7 @@
         },
         {
             "id": "964a202d-195e-5753-8589-5a8a81990982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947702ca-d065-4368-9f26-f859d4642cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947702ca-d065-4368-9f26-f859d4642cb6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "fabcecd5-7c1e-5881-bf54-000581164c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d10d9c-8771-4870-aebf-e767d0fada32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d10d9c-8771-4870-aebf-e767d0fada32.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10599,7 +10599,7 @@
         },
         {
             "id": "d72a7d3f-15cc-55ae-9f80-cf1d72fa7983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c51de66-a3ed-4ca9-befb-9813e96c4ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c51de66-a3ed-4ca9-befb-9813e96c4ade.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10636,7 +10636,7 @@
         },
         {
             "id": "c6bc0f7a-916f-531c-8c81-d03843007720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd95de0-702a-4b88-a1cc-981cf1d9673e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd95de0-702a-4b88-a1cc-981cf1d9673e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "6b058c43-663c-5af1-9f0e-f429294ea437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accb56f0-3903-4894-86f0-3965162064d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accb56f0-3903-4894-86f0-3965162064d4.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "23e36a02-131b-5776-b42c-d19f35f0be9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44d8a4-21de-497d-9eed-702d7b592728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44d8a4-21de-497d-9eed-702d7b592728.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "f26c0259-765b-51bd-8081-6288f734bbce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c0880-728d-4ac2-b685-4f18f66c24db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c0880-728d-4ac2-b685-4f18f66c24db.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "ef3438e3-1028-5e37-9c74-98412ae9f536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da5fbc2-24ad-4520-a60a-436d3a485fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da5fbc2-24ad-4520-a60a-436d3a485fec.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10821,7 +10821,7 @@
         },
         {
             "id": "19442c19-47e0-5bef-905c-21500977133a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "When you unlock this door, create a 1/1 white Glimmer enchantment creature token.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -10857,7 +10857,7 @@
         },
         {
             "id": "cffe562a-3550-5992-9a83-36bd82ea6fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "Elegant Rotunda\no2o\nW\nWhen you unlock this door, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -10893,7 +10893,7 @@
         },
         {
             "id": "22f31cf4-22c8-55a2-b778-90e2f06a6293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d6bd4-b03a-4d04-bc38-85b3ee39aa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d6bd4-b03a-4d04-bc38-85b3ee39aa8a.jpg?1",
             "name": "Optimistic Scavenger",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, put a +1/+1 counter on target creature.",
             "colours": [
@@ -10930,7 +10930,7 @@
         },
         {
             "id": "ac8f190a-296a-5fdd-9aa5-9d4982e77414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a6f3e-d517-4978-8958-db189fe3f1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a6f3e-d517-4978-8958-db189fe3f1f9.jpg?1",
             "name": "Reluctant Role Model",
             "text": "Survival \u2014 At the beginning of your second main phase, if Reluctant Role Model is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever Reluctant Role Model or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
             "colours": [
@@ -10968,7 +10968,7 @@
         },
         {
             "id": "f9bfbb12-2c64-5e66-ab77-a7d7200bb510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0a079e-26f4-44ed-859a-f7df4b40a3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0a079e-26f4-44ed-859a-f7df4b40a3cd.jpg?1",
             "name": "Entity Tracker",
             "text": "Flash\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.",
             "colours": [
@@ -11006,7 +11006,7 @@
         },
         {
             "id": "cb7778ac-866c-580a-96c0-5e453300e8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd7bdd-2ba8-4658-9825-741aecad5f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd7bdd-2ba8-4658-9825-741aecad5f42.jpg?1",
             "name": "Stay Hidden, Stay Silent",
             "text": "Enchant creature\nWhen Stay Hidden, Stay Silent enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate only as a sorcery.",
             "colours": [
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "ad291d57-4d64-5ebf-a7d0-f6d6f518e6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abe8236-a9e3-435a-a459-833ec3af93c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abe8236-a9e3-435a-a459-833ec3af93c7.jpg?1",
             "name": "Come Back Wrong",
             "text": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -11077,7 +11077,7 @@
         },
         {
             "id": "90509dcf-d8d2-54c3-9d06-03df2beb443b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacb88b3-96a9-45e4-8053-2f8fcbe4028e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacb88b3-96a9-45e4-8053-2f8fcbe4028e.jpg?1",
             "name": "Meathook Massacre II",
             "text": "When Meathook Massacre II enters, each player sacrifices X creatures.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
             "colours": [
@@ -11114,7 +11114,7 @@
         },
         {
             "id": "edbe8957-ab3d-568a-8023-f7aeb5079b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d865cf-8c5f-4c27-a731-33564b01bc64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d865cf-8c5f-4c27-a731-33564b01bc64.jpg?1",
             "name": "Unstoppable Slasher",
             "text": "Deathtouch\nWhenever Unstoppable Slasher deals combat damage to a player, they lose half their life, rounded up.\nWhen Unstoppable Slasher dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
             "colours": [
@@ -11152,7 +11152,7 @@
         },
         {
             "id": "4b3dad97-5df6-5a2f-99ee-015bcd1eef66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44340c7-d3bb-4cf9-a105-ebbf6ce3ace1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44340c7-d3bb-4cf9-a105-ebbf6ce3ace1.jpg?1",
             "name": "Clockwork Percussionist",
             "text": "Haste\nWhen Clockwork Percussionist dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -11190,7 +11190,7 @@
         },
         {
             "id": "42473e28-ccc1-5006-a1e2-1ad851ee4592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d2c67b-b523-4da3-826e-5f56f19914ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d2c67b-b523-4da3-826e-5f56f19914ba.jpg?1",
             "name": "Cursed Recording",
             "text": "Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -11225,7 +11225,7 @@
         },
         {
             "id": "7e677483-6204-58e1-9b20-02fb9d93c187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f4026-b75a-4d74-871e-715ece0225d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f4026-b75a-4d74-871e-715ece0225d3.jpg?1",
             "name": "Norin, Swift Survivalist",
             "text": "Norin, Swift Survivalist can't block.\nWhenever a creature you control becomes blocked, you may exile it. You may play that card from exile this turn.",
             "colours": [
@@ -11264,7 +11264,7 @@
         },
         {
             "id": "993da63b-116d-50d4-a47f-fae97f31e453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb57a981-e70b-4298-b620-577914d67cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb57a981-e70b-4298-b620-577914d67cb7.jpg?1",
             "name": "The Rollercrusher Ride",
             "text": "Delirium \u2014 If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
             "colours": [
@@ -11301,7 +11301,7 @@
         },
         {
             "id": "e144b78e-aa1a-5a91-bad6-68501849e9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bfb93-c7f2-4a96-8c57-c356d8ce21c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bfb93-c7f2-4a96-8c57-c356d8ce21c0.jpg?1",
             "name": "Kona, Rescue Beastie",
             "text": "Survival \u2014 At the beginning of your second main phase, if Kona, Rescue Beastie is tapped, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -11341,7 +11341,7 @@
         },
         {
             "id": "cb1140d2-067d-5c8d-9921-eacf76900018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f328937-6585-4325-a1f2-95facab2c58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f328937-6585-4325-a1f2-95facab2c58a.jpg?1",
             "name": "Oblivious Bookworm",
             "text": "At the beginning of your end step, you may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn.",
             "colours": [
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "b1cf80aa-ea29-58fd-a575-c25ef278215a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8fbdac-e3bb-4b6b-b210-febb23846c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8fbdac-e3bb-4b6b-b210-febb23846c23.jpg?1",
             "name": "The Swarmweaver",
             "text": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -11422,7 +11422,7 @@
         },
         {
             "id": "973ea2f6-d566-54ee-9f6f-52fa30003843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851b9caa-bb70-4d84-8139-b70867193922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851b9caa-bb70-4d84-8139-b70867193922.jpg?1",
             "name": "Ghostly Dancers",
             "text": "Flying\nWhen Ghostly Dancers enters, return an enchantment card from your graveyard to your hand or unlock a locked door of a Room you control.\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying.",
             "colours": [
@@ -11458,7 +11458,7 @@
         },
         {
             "id": "d18b7ca3-59f9-517e-81ae-66d2fb6845c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcea7eb-3174-4549-a1de-8dda577cd0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcea7eb-3174-4549-a1de-8dda577cd0b9.jpg?1",
             "name": "Reluctant Role Model",
             "text": "Survival \u2014 At the beginning of your second main phase, if Reluctant Role Model is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever Reluctant Role Model or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
             "colours": [
@@ -11496,7 +11496,7 @@
         },
         {
             "id": "7c6d2560-42d2-58a6-ab25-3493df542ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7428a157-67e8-48fb-9882-54bf3ae001e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7428a157-67e8-48fb-9882-54bf3ae001e3.jpg?1",
             "name": "Split Up",
             "text": "Choose one \u2014\n\u2022 Destroy all tapped creatures.\n\u2022 Destroy all untapped creatures.",
             "colours": [
@@ -11530,7 +11530,7 @@
         },
         {
             "id": "c06068c4-8840-5c92-906a-3e76012fd5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b1aa9-e94f-4654-88c7-9cea52f1bc0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b1aa9-e94f-4654-88c7-9cea52f1bc0a.jpg?1",
             "name": "Unidentified Hovership",
             "text": "Flying\nWhen Unidentified Hovership enters, exile up to one target creature with toughness 5 or less.\nWhen Unidentified Hovership leaves the battlefield, the exiled card's owner manifests dread.\nCrew 1",
             "colours": [
@@ -11566,7 +11566,7 @@
         },
         {
             "id": "0e276c5f-6e3a-5d4e-9e55-ac18d2eb25be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be897dda-8603-4264-a022-87870f635b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be897dda-8603-4264-a022-87870f635b40.jpg?1",
             "name": "Unwanted Remake",
             "text": "Destroy target creature. Its controller manifests dread.",
             "colours": [
@@ -11600,7 +11600,7 @@
         },
         {
             "id": "ec5f5aef-28be-5b37-8785-b1a6c051d84f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885098d1-f9b4-429b-97b5-c5c448111e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885098d1-f9b4-429b-97b5-c5c448111e22.jpg?1",
             "name": "Entity Tracker",
             "text": "Flash\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.",
             "colours": [
@@ -11638,7 +11638,7 @@
         },
         {
             "id": "330df40e-c786-5f11-af85-036ea78948f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b976d642-3cf0-42c5-b3ba-12818e596f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b976d642-3cf0-42c5-b3ba-12818e596f9c.jpg?1",
             "name": "Marina Vendrell's Grimoire",
             "text": "When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.\nYou have no maximum hand size and don't lose the game for having 0 or less life.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.",
             "colours": [
@@ -11674,7 +11674,7 @@
         },
         {
             "id": "2ec8b11f-e0e7-5b58-aad1-ef1efbe1f5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8761b8-3583-422d-a23c-b3f0915ce15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8761b8-3583-422d-a23c-b3f0915ce15b.jpg?1",
             "name": "Come Back Wrong",
             "text": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "4e2332bd-9af5-5b2e-ac67-2785d216c483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9defeb-d28e-451e-9333-914394231fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9defeb-d28e-451e-9333-914394231fbb.jpg?1",
             "name": "Demonic Counsel",
             "text": "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead search your library for any card, put it into your hand, then shuffle.",
             "colours": [
@@ -11743,7 +11743,7 @@
         },
         {
             "id": "a6d354ec-b3de-5dd9-9896-8846fdceecbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3686075-cef4-48b7-ac50-3e27282a3f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3686075-cef4-48b7-ac50-3e27282a3f70.jpg?1",
             "name": "Meathook Massacre II",
             "text": "When Meathook Massacre II enters, each player sacrifices X creatures.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
             "colours": [
@@ -11780,7 +11780,7 @@
         },
         {
             "id": "64f888f1-6d59-5f43-80b5-67ab8d8cab21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30a301-8e87-46e7-89aa-cd55b1a14420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30a301-8e87-46e7-89aa-cd55b1a14420.jpg?1",
             "name": "Unstoppable Slasher",
             "text": "Deathtouch\nWhenever Unstoppable Slasher deals combat damage to a player, they lose half their life, rounded up.\nWhen Unstoppable Slasher dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
             "colours": [
@@ -11818,7 +11818,7 @@
         },
         {
             "id": "cfacb253-c384-5fa8-afdd-9f16801dd20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e03d07-c491-4ea1-a2f7-49c022005059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e03d07-c491-4ea1-a2f7-49c022005059.jpg?1",
             "name": "Withering Torment",
             "text": "Destroy target creature or enchantment. You lose 2 life.",
             "colours": [
@@ -11852,7 +11852,7 @@
         },
         {
             "id": "347536dd-1930-5c48-9e2b-41772273e220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8d0f4e-6b1e-4444-8851-adf857273964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8d0f4e-6b1e-4444-8851-adf857273964.jpg?1",
             "name": "Chainsaw",
             "text": "When Chainsaw enters, it deals 3 damage to up to one target creature.\nWhenever one or more creatures die, put a rev counter on Chainsaw.\nEquipped creature gets +X/+0, where X is the number of rev counters on Chainsaw.\nEquip {3}",
             "colours": [
@@ -11888,7 +11888,7 @@
         },
         {
             "id": "3f5fe83a-3593-59b9-9b69-5b4fe2fbdfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aacedd1-de6b-4485-891e-0283ef33f3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aacedd1-de6b-4485-891e-0283ef33f3d4.jpg?1",
             "name": "Cursed Recording",
             "text": "Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "be25b5f3-bc32-5e18-a18c-9c7296ed31de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b924a5-6533-4ca6-bd2e-32debdfb6c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b924a5-6533-4ca6-bd2e-32debdfb6c08.jpg?1",
             "name": "Fear of Missing Out",
             "text": "When Fear of Missing Out enters, discard a card, then draw a card.\nDelirium \u2014 Whenever Fear of Missing Out attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.",
             "colours": [
@@ -11960,7 +11960,7 @@
         },
         {
             "id": "46556200-fa70-50d9-abc7-9ed8787873fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d14e9ee-f82f-4062-b972-9486377dacdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d14e9ee-f82f-4062-b972-9486377dacdb.jpg?1",
             "name": "The Rollercrusher Ride",
             "text": "Delirium \u2014 If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
             "colours": [
@@ -11997,7 +11997,7 @@
         },
         {
             "id": "655b2363-c282-5ab4-aed3-ede090725418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcecce11-59e3-4c95-bff9-b02d004c917b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcecce11-59e3-4c95-bff9-b02d004c917b.jpg?1",
             "name": "Waltz of Rage",
             "text": "Target creature you control deals damage equal to its power to each other creature. Until end of turn, whenever a creature you control dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -12031,7 +12031,7 @@
         },
         {
             "id": "56d4d205-3c35-5bc2-82d1-c710f0227ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7944c86-c578-48fa-b222-7fce3f5d301d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7944c86-c578-48fa-b222-7fce3f5d301d.jpg?1",
             "name": "Balustrade Wurm",
             "text": "This spell can't be countered.\nTrample, haste\nDelirium \u2014 {2}{G}{G}: Return Balustrade Wurm from your graveyard to the battlefield with a finality counter on it. Activate only if there are four or more card types among cards in your graveyard and only as a sorcery.",
             "colours": [
@@ -12067,7 +12067,7 @@
         },
         {
             "id": "558c09bd-54bd-5b50-921f-9623f36d6a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01595caa-7abd-4b47-8015-3754d8eb39cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01595caa-7abd-4b47-8015-3754d8eb39cf.jpg?1",
             "name": "Hedge Shredder",
             "text": "Whenever Hedge Shredder attacks, you may mill two cards.\nWhenever one or more land cards are put into your graveyard from your library, put them onto the battlefield tapped.\nCrew 1",
             "colours": [
@@ -12103,7 +12103,7 @@
         },
         {
             "id": "b5967616-0c58-5a8d-bf5b-679825298c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fadf08-c799-47da-8330-5d0df7b41ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fadf08-c799-47da-8330-5d0df7b41ca1.jpg?1",
             "name": "Insidious Fungus",
             "text": "{2}, Sacrifice Insidious Fungus: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Draw a card. Then you may put a land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -12139,7 +12139,7 @@
         },
         {
             "id": "c12af897-b531-598f-8e81-1967f859b032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f779cc02-2470-4fc0-ae08-503adeb8e0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f779cc02-2470-4fc0-ae08-503adeb8e0a9.jpg?1",
             "name": "Omnivorous Flytrap",
             "text": "Delirium \u2014 Whenever Omnivorous Flytrap enters or attacks, if there are four or more card types among cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if there are six or more card types among cards in your graveyard, double the number of +1/+1 counters on those creatures.",
             "colours": [
@@ -12175,7 +12175,7 @@
         },
         {
             "id": "c11d5507-883f-5ac9-acbe-ea35a6922a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb34e17-bc12-4a4e-a418-0dbd3e6665a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb34e17-bc12-4a4e-a418-0dbd3e6665a8.jpg?1",
             "name": "Under the Skin",
             "text": "Manifest dread.\nYou may return a permanent card from your graveyard to your hand.",
             "colours": [
@@ -12209,7 +12209,7 @@
         },
         {
             "id": "95cd918d-44c2-58c6-925d-30c39a1e8f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3518fbe6-5640-4aca-a2fd-e83c82d2e2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3518fbe6-5640-4aca-a2fd-e83c82d2e2fd.jpg?1",
             "name": "Valgavoth's Onslaught",
             "text": "Manifest dread X times, then put X +1/+1 counters on each of those creatures.",
             "colours": [
@@ -12243,7 +12243,7 @@
         },
         {
             "id": "7335ab48-f0bb-507a-915e-75c0d2f5e680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e7b3a-3fe2-4f3c-8292-b44e4a0fc5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e7b3a-3fe2-4f3c-8292-b44e4a0fc5a4.jpg?1",
             "name": "Peer Past the Veil",
             "text": "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard.",
             "colours": [
@@ -12279,7 +12279,7 @@
         },
         {
             "id": "4767e37a-9413-5e69-a9ec-81edb7ea9a2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf254c0-7c3c-4b68-8b3e-4ae444baa886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf254c0-7c3c-4b68-8b3e-4ae444baa886.jpg?1",
             "name": "Ghost Vacuum",
             "text": "{T}: Exile target card from a graveyard.\n{6}, {T}, Sacrifice Ghost Vacuum: Put each creature card exiled with Ghost Vacuum onto the battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to its other types. Activate only as a sorcery.",
             "colours": [],
@@ -12309,7 +12309,7 @@
         },
         {
             "id": "e9b5b5ac-3d87-5efa-821a-50b686749bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5041f1-7cb8-4b60-94f6-436430bbece4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5041f1-7cb8-4b60-94f6-436430bbece4.jpg?1",
             "name": "Valgavoth's Lair",
             "text": "Hexproof\nValgavoth's Lair enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "a49df111-8e54-5a95-9b48-6e923eaa7854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d24cf8-107e-4b5b-a4f5-a7498647abef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d24cf8-107e-4b5b-a4f5-a7498647abef.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B}\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -12382,7 +12382,7 @@
         },
         {
             "id": "1c9d8c32-b605-5367-a741-66a916cfd120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a926c5-ba2b-4ac5-9717-6c9181f9a827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a926c5-ba2b-4ac5-9717-6c9181f9a827.jpg?1",
             "name": "Blazemire Verge",
             "text": "{T}: Add {B}.\n{T}: Add {R}. Activate only if you control a Swamp or a Mountain.",
             "colours": [],
@@ -12415,7 +12415,7 @@
         },
         {
             "id": "bd95beaf-970f-5cbd-9a8a-ee31a454e629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025152a1-4fdf-4e4e-a792-c540dd43fccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025152a1-4fdf-4e4e-a792-c540dd43fccd.jpg?1",
             "name": "Floodfarm Verge",
             "text": "{T}: Add {W}.\n{T}: Add {U}. Activate only if you control a Plains or an Island.",
             "colours": [],
@@ -12448,7 +12448,7 @@
         },
         {
             "id": "70bf27f5-14a8-5acd-9355-51581511b8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414e4bd-a443-4ab3-bee4-1ad1d039aa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414e4bd-a443-4ab3-bee4-1ad1d039aa1a.jpg?1",
             "name": "Gloomlake Verge",
             "text": "{T}: Add {U}.\n{T}: Add {B}. Activate only if you control an Island or a Swamp.",
             "colours": [],
@@ -12481,7 +12481,7 @@
         },
         {
             "id": "d50a02ae-7085-51a3-8eac-d75605d29a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b38f-11bf-4eb0-b333-4d605290e75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b38f-11bf-4eb0-b333-4d605290e75b.jpg?1",
             "name": "Hushwood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {W}. Activate only if you control a Forest or a Plains.",
             "colours": [],
@@ -12514,7 +12514,7 @@
         },
         {
             "id": "2fff7faa-c02e-5713-aa10-715c5cb3ca75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a817f77d-19ea-4342-b90f-d92f62543303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a817f77d-19ea-4342-b90f-d92f62543303.jpg?1",
             "name": "Thornspire Verge",
             "text": "{T}: Add {R}.\n{T}: Add {G}. Activate only if you control a Mountain or a Forest.",
             "colours": [],
@@ -12547,7 +12547,7 @@
         },
         {
             "id": "b0331bd0-c891-5c5c-afb8-f833a4ad8001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "Creature spells you cast have convoke.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12583,7 +12583,7 @@
         },
         {
             "id": "479d07ed-b99a-5589-a657-c265b303388e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "Prop Room\no2o\nW\nUntap each creature you control during each other player's untap step.",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "43c9f704-7152-535e-ad83-994118eb0f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "Whenever one or more non-Toy creatures you control attack a player, create a 1/1 white Toy artifact creature token.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12655,7 +12655,7 @@
         },
         {
             "id": "84427b9c-7911-5254-bb94-a07a7bd36ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "Porcelain Gallery\no4o\nWo\nW\nCreatures you control have base power and toughness each equal to the number of creatures you control.",
             "colours": [
@@ -12691,7 +12691,7 @@
         },
         {
             "id": "b6f94f62-1aa1-59a9-9a84-e0c987f49533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "When you unlock this door, search your library for a Room card that doesn't have the same name as a Room you control, reveal it, put it into your hand, then shuffle.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12727,7 +12727,7 @@
         },
         {
             "id": "8969cfa6-ff5e-5ba4-b45e-8d670f38d1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "Promising Stairs\no2o\nU\nAt the beginning of your upkeep, surveil 1. You win the game if there are eight or more different names among unlocked doors of Rooms you control.",
             "colours": [
@@ -12763,7 +12763,7 @@
         },
         {
             "id": "61a43fa5-621a-5715-a73b-45f28dc12fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "When you unlock this door, create a token that's a copy of target creature you control, except it's a Reflection in addition to its other creature types.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12799,7 +12799,7 @@
         },
         {
             "id": "5717f16d-fdd4-5b3d-8b87-238ffb0d9e89",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "Fractured Realm\no5o\nUo\nU\nIf a triggered ability of a permanent you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -12835,7 +12835,7 @@
         },
         {
             "id": "cbe4a5d4-be78-5772-88ab-16e17f031d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "c67f6f71-9a02-5428-9467-446d9c68d0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "Awakening Hall\no6o\nBo\nB\nWhen you unlock this door, return all creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -12907,7 +12907,7 @@
         },
         {
             "id": "e9fa1b75-f005-513a-8052-e9508196d5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "At the beginning of your end step, draw a card. If you control a Demon, each opponent loses 2 life and you gain 2 life. Otherwise, you lose 2 life.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12943,7 +12943,7 @@
         },
         {
             "id": "240fed4e-493f-5d49-98ff-283f36f5298e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "Ritual Chamber\no3o\nBo\nB\nWhen you unlock this door, create a 6/6 black Demon creature token with flying.",
             "colours": [
@@ -12979,7 +12979,7 @@
         },
         {
             "id": "106efb13-af94-53db-aa8a-41b46d00d6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play it this turn.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13015,7 +13015,7 @@
         },
         {
             "id": "0208cfb4-ab12-50c5-b221-02e4b37b8ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "Warped Space\no4o\nRo\nR\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.",
             "colours": [
@@ -13051,7 +13051,7 @@
         },
         {
             "id": "b21d6567-1307-52d4-9c6e-657491278d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "You may play lands from your graveyard.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13087,7 +13087,7 @@
         },
         {
             "id": "e4ebbef7-05dc-555c-9148-c23dead049c1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "Forgotten Cellar\no3o\nGo\nG\nWhen you unlock this door, you may cast spells from your graveyard this turn, and if a card would be put into your graveyard from anywhere this turn, exile it instead.",
             "colours": [
@@ -13123,7 +13123,7 @@
         },
         {
             "id": "b90a5fdd-c423-5805-ac80-66ed20db2e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "When you unlock this door, destroy all creatures with power 3 or greater.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13160,7 +13160,7 @@
         },
         {
             "id": "9a7d5dcd-1978-5215-a870-095b8e95afd3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "Lecture Hall\no5o\nUo\nU\nOther permanents you control have hexproof.",
             "colours": [
@@ -13197,7 +13197,7 @@
         },
         {
             "id": "4e16a9c5-2aad-5cb9-babf-847d50ba41dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "When you unlock this door, this Room deals damage equal to the number of cards in your hand to target creature an opponent controls.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13234,7 +13234,7 @@
         },
         {
             "id": "dc3ba564-5288-5dc6-8419-47a3e4f56fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "At the beginning of your end step, draw a card.\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13271,7 +13271,7 @@
         },
         {
             "id": "d2074c78-c6f4-575b-8cd1-11fc33ca066b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f89402a-ef5c-47c1-8cef-f40920f98fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f89402a-ef5c-47c1-8cef-f40920f98fac.jpg?1",
             "name": "Abhorrent Oculus",
             "text": "As an additional cost to cast this spell, exile six cards from your graveyard.\nFlying\nAt the beginning of each opponent's upkeep, manifest dread.",
             "colours": [
@@ -13307,7 +13307,7 @@
         },
         {
             "id": "3a9d24d5-b2e9-5002-ae8a-325d52b4d782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ee370f-99d1-44bc-9952-29bcafbf7887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ee370f-99d1-44bc-9952-29bcafbf7887.jpg?1",
             "name": "Silent Hallcreeper",
             "text": "Silent Hallcreeper can't be blocked.\nWhenever Silent Hallcreeper deals combat damage to a player, choose one that hasn't been chosen \u2014\n\u2022 Put two +1/+1 counters on Silent Hallcreeper.\n\u2022 Draw a card.\n\u2022 Silent Hallcreeper becomes a copy of another target creature you control.",
             "colours": [
@@ -13344,7 +13344,7 @@
         },
         {
             "id": "a1c4e8a7-dda6-5b67-a794-9c4afa2a1732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f9cecb-0ff7-4837-a8c5-4af394834e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f9cecb-0ff7-4837-a8c5-4af394834e2c.jpg?1",
             "name": "Doomsday Excruciator",
             "text": "Flying\nWhen Doomsday Excruciator enters, if it was cast, each player exiles all but the bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card.",
             "colours": [
@@ -13380,7 +13380,7 @@
         },
         {
             "id": "f99449ac-909d-5223-83e0-6864e5783443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c34cb6-c8cb-4814-a647-9c63b10f02c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c34cb6-c8cb-4814-a647-9c63b10f02c4.jpg?1",
             "name": "Razorkin Needlehead",
             "text": "Razorkin Needlehead has first strike during your turn.\nWhenever an opponent draws a card, Razorkin Needlehead deals 1 damage to them.",
             "colours": [
@@ -13417,7 +13417,7 @@
         },
         {
             "id": "1868eb33-898c-592e-8938-2762df5392df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3f4c72-ff6e-4d7f-8eb8-45a0a9605fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3f4c72-ff6e-4d7f-8eb8-45a0a9605fc0.jpg?1",
             "name": "Screaming Nemesis",
             "text": "Haste\nWhenever Screaming Nemesis is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "f908049c-dfb2-5805-a872-165982c821a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6148f7-01cb-4789-87a6-53d741f44ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6148f7-01cb-4789-87a6-53d741f44ec2.jpg?1",
             "name": "Hauntwoods Shrieker",
             "text": "Whenever Hauntwoods Shrieker attacks, manifest dread.\n{1}{G}: Reveal target face-down permanent. If it's a creature card, you may turn it face up.",
             "colours": [
@@ -13490,7 +13490,7 @@
         },
         {
             "id": "b9048d8c-b2ee-5a73-8c77-f839e4906266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef349a98-d4df-4eab-81e3-96a74aff5902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef349a98-d4df-4eab-81e3-96a74aff5902.jpg?1",
             "name": "Undead Sprinter",
             "text": "Trample, haste\nYou may cast Undead Sprinter from your graveyard if a non-Zombie creature died this turn. If you do, Undead Sprinter enters with a +1/+1 counter on it.",
             "colours": [
@@ -13528,7 +13528,7 @@
         },
         {
             "id": "5e9a11f3-2f98-57a4-8ca9-92364c87663d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e3837d-0481-42cd-a7da-56b7e5cb1b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e3837d-0481-42cd-a7da-56b7e5cb1b7e.jpg?1",
             "name": "The Wandering Rescuer",
             "text": "Flash, convoke\nDouble strike\nOther tapped creatures you control have hexproof.",
             "colours": [
@@ -13569,7 +13569,7 @@
         },
         {
             "id": "672bd9fa-0986-5f36-aeed-378ee1a42483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee79357-2488-41a1-8f8c-dfcb77206f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee79357-2488-41a1-8f8c-dfcb77206f8a.jpg?1",
             "name": "Valgavoth, Terror Eater",
             "text": "Flying, lifelink\nWard\u2014\nSacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
             "colours": [
@@ -13609,7 +13609,7 @@
         },
         {
             "id": "3a4f831f-241a-5d58-8fb0-a5dc146a1453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6f8dd7-6ec8-44b5-8827-192f255c4211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6f8dd7-6ec8-44b5-8827-192f255c4211.jpg?1",
             "name": "Tyvar, the Pummeler",
             "text": "Tap another untapped creature you control: Tyvar, the Pummeler gains indestructible until end of turn. Tap it.\n{3}{G}{G}: Creatures you control get +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -13649,7 +13649,7 @@
         },
         {
             "id": "5f44be78-a515-53c1-b985-ef1d1c1d05cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7927a69-62a9-4f69-923d-f651bb03a7b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7927a69-62a9-4f69-923d-f651bb03a7b4.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B}\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -13691,7 +13691,7 @@
         },
         {
             "id": "751a2866-6910-5e9b-8dcd-f688da724cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6f4e4e-8c3c-4860-bc9e-cbce44bcdc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6f4e4e-8c3c-4860-bc9e-cbce44bcdc23.jpg?1",
             "name": "Niko, Light of Hope",
             "text": "When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -13733,7 +13733,7 @@
         },
         {
             "id": "af2e51b4-3ad1-5091-8d98-847ab94d833e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafe5755-88b0-4fee-8596-4232844f60fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafe5755-88b0-4fee-8596-4232844f60fc.jpg?1",
             "name": "Toby, Beastie Befriender",
             "text": "When Toby, Beastie Befriender enters, create a 4/4 white Beast creature token with \"This creature can't attack or block alone.\"\nAs long as you control four or more creature tokens, creature tokens you control have flying.",
             "colours": [
@@ -13772,7 +13772,7 @@
         },
         {
             "id": "aa800869-c538-5340-998e-f4d582008bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3130a342-3c98-4c69-975b-a958ccddfe37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3130a342-3c98-4c69-975b-a958ccddfe37.jpg?1",
             "name": "The Mindskinner",
             "text": "The Mindskinner can't be blocked.\nIf a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.",
             "colours": [
@@ -13811,7 +13811,7 @@
         },
         {
             "id": "33e7c53b-73a6-5051-a913-b71d6ebf4f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf256f95-d184-4ea9-9039-fc64f461d9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf256f95-d184-4ea9-9039-fc64f461d9b3.jpg?1",
             "name": "Kona, Rescue Beastie",
             "text": "Survival \u2014 At the beginning of your second main phase, if Kona, Rescue Beastie is tapped, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -13851,7 +13851,7 @@
         },
         {
             "id": "f37e0aa7-0009-5d16-9b7b-82501b21d405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594df270-02d0-438b-a758-c32d71e8d4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594df270-02d0-438b-a758-c32d71e8d4ff.jpg?1",
             "name": "The Jolly Balloon Man",
             "text": "Haste\n{1}, {T}: Create a token that's a copy of another target creature you control, except it's a 1/1 red Balloon creature in addition to its other colors and types and it has flying and haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -13892,7 +13892,7 @@
         },
         {
             "id": "7e15c1f3-b4db-5e06-a890-2d66d9cbf33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6424845-7e9b-4514-93aa-1cf6c45f634c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6424845-7e9b-4514-93aa-1cf6c45f634c.jpg?1",
             "name": "Marina Vendrell",
             "text": "When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment cards from among them into your hand and the rest on the bottom of your library in a random order.\n{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
             "colours": [
@@ -13939,7 +13939,7 @@
         },
         {
             "id": "75d4fdf4-54d5-54e0-a99a-8daaab67db53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aa4f0c-7b2b-44cc-a59f-95f276b25898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aa4f0c-7b2b-44cc-a59f-95f276b25898.jpg?1",
             "name": "Nashi, Searcher in the Dark",
             "text": "Menace\nWhenever Nashi, Searcher in the Dark deals combat damage to a player, you mill that many cards. You may put any number of legendary and/or enchantment cards from among them into your hand. If you put no cards into your hand this way, put a +1/+1 counter on Nashi.",
             "colours": [
@@ -13981,7 +13981,7 @@
         },
         {
             "id": "32132e69-43a3-5f12-affe-b18b2e67a5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8da0e-7822-4e8b-b073-5d4edcb38c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8da0e-7822-4e8b-b073-5d4edcb38c59.jpg?1",
             "name": "Rip, Spawn Hunter",
             "text": "Survival \u2014 At the beginning of your second main phase, if Rip, Spawn Hunter is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14022,7 +14022,7 @@
         },
         {
             "id": "32467dbb-b1a5-552f-a24a-cf1d44ef310f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4542e4f-2fb7-4036-aefc-291f5c010ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4542e4f-2fb7-4036-aefc-291f5c010ca8.jpg?1",
             "name": "The Swarmweaver",
             "text": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -14064,7 +14064,7 @@
         },
         {
             "id": "694263f8-4b3d-5367-9f67-85b586e80693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db4440e-0107-434d-9d8e-77a11bc0245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db4440e-0107-434d-9d8e-77a11bc0245a.jpg?1",
             "name": "Victor, Valgavoth's Seneschal",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -14105,7 +14105,7 @@
         },
         {
             "id": "a416758a-699e-5415-b799-a00716921f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf9f742-a662-46b3-84e1-1609177d0c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf9f742-a662-46b3-84e1-1609177d0c8a.jpg?1",
             "name": "Winter, Misanthropic Guide",
             "text": "Ward {2}\nAt the beginning of your upkeep, each player draws two cards.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, each opponent's maximum hand size is equal to seven minus the number of those card types.",
             "colours": [
@@ -14148,7 +14148,7 @@
         },
         {
             "id": "b71ae479-1a85-59da-8e6a-4b34d3754ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8af5a2b-b87e-4ee2-88bd-f80670559875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8af5a2b-b87e-4ee2-88bd-f80670559875.jpg?1",
             "name": "Zimone, All-Questioning",
             "text": "At the beginning of your end step, if a land entered the battlefield under your control this turn and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters on it. (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, and 31 are prime numbers.)",
             "colours": [
@@ -14189,7 +14189,7 @@
         },
         {
             "id": "ef5b3dce-b005-5205-9d6f-443813832d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f107a-ce90-464c-8be0-eb6c1db0f80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f107a-ce90-464c-8be0-eb6c1db0f80f.jpg?1",
             "name": "Marvin, Murderous Mimic",
             "text": "Marvin, Murderous Mimic has all activated abilities of creatures you control that don't have the same name as this creature.",
             "colours": [],
@@ -14224,7 +14224,7 @@
         },
         {
             "id": "f0906ea0-800f-54ad-b1c4-651bad927053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d908299-aac0-46a6-8fa5-780d5b3e0386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d908299-aac0-46a6-8fa5-780d5b3e0386.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14264,7 +14264,7 @@
         },
         {
             "id": "b9ab0570-0f37-5a45-8c8a-fafe7560de7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6209ca8-3a2a-4c0a-9f86-54283af9df75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6209ca8-3a2a-4c0a-9f86-54283af9df75.jpg?1",
             "name": "Leyline of Hope",
             "text": "If Leyline of Hope is in your opening hand, you may begin the game with it on the battlefield.\nIf you would gain life, you gain that much life plus 1 instead.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -14298,7 +14298,7 @@
         },
         {
             "id": "6e0eeee9-968f-5f52-a80f-ac9669ede1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509735a5-2b41-4e52-9ab1-0e4a6fa41d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509735a5-2b41-4e52-9ab1-0e4a6fa41d1b.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W}\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -14338,7 +14338,7 @@
         },
         {
             "id": "9cc887e8-2eda-5564-998f-12262dd12e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce740fb7-d2d1-451b-bfa0-27364b804161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce740fb7-d2d1-451b-bfa0-27364b804161.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14378,7 +14378,7 @@
         },
         {
             "id": "2893b439-f2be-5919-bacd-39ff6074a6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd545d86-9a3e-4e4f-b0fe-9363a85b9290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd545d86-9a3e-4e4f-b0fe-9363a85b9290.jpg?1",
             "name": "Leyline of Transformation",
             "text": "If Leyline of Transformation is in your opening hand, you may begin the game with it on the battlefield.\nAs Leyline of Transformation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -14412,7 +14412,7 @@
         },
         {
             "id": "247c977e-1c4e-585a-9b16-292964cbf9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d446b-75ac-49d8-911a-73d17419ff05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d446b-75ac-49d8-911a-73d17419ff05.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U}\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -14452,7 +14452,7 @@
         },
         {
             "id": "fdf30502-4f67-55b3-bbe6-a4df64c17fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2d0033-1a73-4927-93a9-76d00ae7c6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2d0033-1a73-4927-93a9-76d00ae7c6a8.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14492,7 +14492,7 @@
         },
         {
             "id": "2213e850-5456-5b3c-b1d2-e26760474bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3222c21-8d81-487d-a0c4-2413b30a26ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3222c21-8d81-487d-a0c4-2413b30a26ab.jpg?1",
             "name": "Grievous Wound",
             "text": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
             "colours": [
@@ -14529,7 +14529,7 @@
         },
         {
             "id": "8845dda6-859c-5c7c-88eb-5bf7d9bc6ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a559e-79f9-479e-8ef1-65fb91b9507d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a559e-79f9-479e-8ef1-65fb91b9507d.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14563,7 +14563,7 @@
         },
         {
             "id": "07b5ac1e-5471-568a-a5dd-a719f07c53de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da8e15d-033e-41ab-9f95-656a5737bdac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da8e15d-033e-41ab-9f95-656a5737bdac.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B}\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -14603,7 +14603,7 @@
         },
         {
             "id": "9f0a3f02-5861-5543-a7a3-00dcb460da5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c10aa8-111a-4b02-a0a4-fee4c17f9c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c10aa8-111a-4b02-a0a4-fee4c17f9c24.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14643,7 +14643,7 @@
         },
         {
             "id": "d114ce3b-ca03-5e67-afc1-3248ffc58fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c006baf9-451e-461c-9355-7bf5a4f0d601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c006baf9-451e-461c-9355-7bf5a4f0d601.jpg?1",
             "name": "Leyline of Resonance",
             "text": "If Leyline of Resonance is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you cast an instant or sorcery spell that targets only a single creature you control, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -14677,7 +14677,7 @@
         },
         {
             "id": "979866cb-6f0b-5aa6-9641-3a7931c6f85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27266b27-3f16-4690-aaa0-07ea10b37bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27266b27-3f16-4690-aaa0-07ea10b37bb6.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R}\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -14717,7 +14717,7 @@
         },
         {
             "id": "16127a67-7da4-5783-bacc-14a05a035123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400eaca3-d7ee-4334-bade-1b05f3591417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400eaca3-d7ee-4334-bade-1b05f3591417.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14757,7 +14757,7 @@
         },
         {
             "id": "229dffa7-5f3d-5718-bd94-ab77cca01c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5ad232-9863-454f-9455-9725e69fa33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5ad232-9863-454f-9455-9725e69fa33f.jpg?1",
             "name": "Leyline of Mutation",
             "text": "If Leyline of Mutation is in your opening hand, you may begin the game with it on the battlefield.\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -14795,7 +14795,7 @@
         },
         {
             "id": "57a5414c-5d04-577f-b742-0ba8036d4357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3832d950-eb12-470f-9593-0f10d2a3a0f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3832d950-eb12-470f-9593-0f10d2a3a0f2.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G}\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -14835,7 +14835,7 @@
         },
         {
             "id": "87f1d396-965d-5f6c-99b6-70e7ca242c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47d003-bbdb-4c58-a648-3f0d7474f326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47d003-bbdb-4c58-a648-3f0d7474f326.jpg?1",
             "name": "Twitching Doll",
             "text": "{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.",
             "colours": [
@@ -14874,7 +14874,7 @@
         },
         {
             "id": "30ad74fb-3bee-51c7-93f0-9dd2027e65c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a376a56-7385-4d64-bbaa-952218531a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a376a56-7385-4d64-bbaa-952218531a76.jpg?1",
             "name": "Dissection Tools",
             "text": "When Dissection Tools enters, manifest dread, then attach Dissection Tools to that creature.\nEquipped creature gets +2/+2 and has deathtouch and lifelink.\nEquip\u2014\nSacrifice a creature.",
             "colours": [],
@@ -14906,7 +14906,7 @@
         },
         {
             "id": "51496970-cd7a-5092-8259-064abf12ff21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aca1ee8-c1ae-4052-b9d0-1a2903f61c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aca1ee8-c1ae-4052-b9d0-1a2903f61c88.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14945,7 +14945,7 @@
         },
         {
             "id": "6ab6838d-e055-5d26-abef-b3b351095fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1951ed76-16a1-4639-b824-08dfc3d6d098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1951ed76-16a1-4639-b824-08dfc3d6d098.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W}\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -14984,7 +14984,7 @@
         },
         {
             "id": "e4b55305-dee6-5d99-b509-cd061887bae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3b6b0-ad74-43d1-bf2d-fc830214bdb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3b6b0-ad74-43d1-bf2d-fc830214bdb4.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15023,7 +15023,7 @@
         },
         {
             "id": "f56b3e8f-6675-5472-b554-908826b6eaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194a6f4-f994-494c-aa29-1de8af48a3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194a6f4-f994-494c-aa29-1de8af48a3f1.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U}\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -15062,7 +15062,7 @@
         },
         {
             "id": "c54b8502-5b07-5dc5-91f0-6ae7809bc3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74a0fbc-7150-4c44-983f-ac31e74644fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74a0fbc-7150-4c44-983f-ac31e74644fd.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "6310903c-32e2-5af5-a1d9-c0d2f305e678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49993a18-f733-4d1f-b629-12fc45cbb327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49993a18-f733-4d1f-b629-12fc45cbb327.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B}\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "faf000af-fcb3-528d-95a2-eb5a05b4e542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c7fa72-3c5f-49db-95f0-9a1c5d404651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c7fa72-3c5f-49db-95f0-9a1c5d404651.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15179,7 +15179,7 @@
         },
         {
             "id": "d2ab71a2-f0f4-5f38-82aa-caae7a6c94c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8607011b-0222-47c2-a537-b817dff93541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8607011b-0222-47c2-a537-b817dff93541.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R}\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -15218,7 +15218,7 @@
         },
         {
             "id": "8a318aa5-c25a-5374-9d4f-771b8f233511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999c030-66c1-41f3-b59a-8ba1ef5a756c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999c030-66c1-41f3-b59a-8ba1ef5a756c.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15257,7 +15257,7 @@
         },
         {
             "id": "60743256-48fa-5f6e-9d91-ba2759e56f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033440c-7d52-4f2c-bc62-ccd6d587d528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033440c-7d52-4f2c-bc62-ccd6d587d528.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G}\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -15296,7 +15296,7 @@
         },
         {
             "id": "ed600f8f-76d9-5f3a-bb05-bc67e6b503ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc36adbc-544c-46a1-9e99-92cc7b2b2af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc36adbc-544c-46a1-9e99-92cc7b2b2af1.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15335,7 +15335,7 @@
         },
         {
             "id": "3925b792-cedf-5a10-84df-54801070f72f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2c4873-dfa7-4dd8-aded-a5d1b6048ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2c4873-dfa7-4dd8-aded-a5d1b6048ad7.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W}\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -15374,7 +15374,7 @@
         },
         {
             "id": "adae6f77-9e5e-5d03-a9d5-50c164f30e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c10e8d-b393-41fd-ba31-5e39b2dc7cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c10e8d-b393-41fd-ba31-5e39b2dc7cce.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15413,7 +15413,7 @@
         },
         {
             "id": "81e52a5c-918d-5696-b991-04b4b6f61081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42de20-43af-4c37-a5af-aa7c48699596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42de20-43af-4c37-a5af-aa7c48699596.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U}\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -15452,7 +15452,7 @@
         },
         {
             "id": "346910ee-bd22-5c18-8a36-03650bc45b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b698d6-4107-45d3-bc27-fb0746b7f91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b698d6-4107-45d3-bc27-fb0746b7f91a.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15491,7 +15491,7 @@
         },
         {
             "id": "2f6190a3-9bb9-5589-9e66-4cb7c5f53432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49df3de4-ed62-4828-8256-a05220d9eada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49df3de4-ed62-4828-8256-a05220d9eada.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B}\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -15530,7 +15530,7 @@
         },
         {
             "id": "2b8d4174-966b-57b8-be31-3b96f8d3c294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07d4d21-2a88-4cfc-b0ce-9def76c20b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07d4d21-2a88-4cfc-b0ce-9def76c20b7d.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15569,7 +15569,7 @@
         },
         {
             "id": "0da7a5cf-87e5-573e-a052-7c7803fba119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8c085e-db0e-45a8-96d0-80b480361771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8c085e-db0e-45a8-96d0-80b480361771.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R}\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -15608,7 +15608,7 @@
         },
         {
             "id": "944c3bb6-4108-5ea7-8038-2e3decb99886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8c711f-f29f-4f6a-88c4-3dbf9ce471c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8c711f-f29f-4f6a-88c4-3dbf9ce471c3.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15647,7 +15647,7 @@
         },
         {
             "id": "2114a245-a82b-5b57-9990-5d7d9de30da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f3ecff-2d67-4676-8706-9191d67215fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f3ecff-2d67-4676-8706-9191d67215fc.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G}\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -15686,7 +15686,7 @@
         },
         {
             "id": "ad242519-e249-5cb9-9b5c-49e5f7def9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a4f2ba-2d16-4dda-85e8-dafce0d5ee1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a4f2ba-2d16-4dda-85e8-dafce0d5ee1b.jpg?1",
             "name": "The Wandering Rescuer",
             "text": "Flash, convoke\nDouble strike\nOther tapped creatures you control have hexproof.",
             "colours": [
@@ -15726,7 +15726,7 @@
         },
         {
             "id": "3128d29a-1d2b-54f3-b372-ef82ee7beffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497ec48f-5e6a-4f57-86ca-3640b7235002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497ec48f-5e6a-4f57-86ca-3640b7235002.jpg?1",
             "name": "Valgavoth, Terror Eater",
             "text": "Flying, lifelink\nWard\u2014\nSacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
             "colours": [
@@ -15765,7 +15765,7 @@
         },
         {
             "id": "f8603604-9038-55aa-b7cd-595cd52d01c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd10920a-25b2-4191-b7f2-c43dbd1c5cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd10920a-25b2-4191-b7f2-c43dbd1c5cc5.jpg?1",
             "name": "Tyvar, the Pummeler",
             "text": "Tap another untapped creature you control: Tyvar, the Pummeler gains indestructible until end of turn. Tap it.\n{3}{G}{G}: Creatures you control get +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -15804,7 +15804,7 @@
         },
         {
             "id": "be1407df-ab32-5ed4-9834-5502738e6b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14901700-881a-4c79-b162-aeeb1579757e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14901700-881a-4c79-b162-aeeb1579757e.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B}\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -15845,7 +15845,7 @@
         },
         {
             "id": "d54622bc-0243-5640-a65b-62151ebd34a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54c9d18-76d7-4c24-ab19-7ad57d9a33a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54c9d18-76d7-4c24-ab19-7ad57d9a33a4.jpg?1",
             "name": "Niko, Light of Hope",
             "text": "When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -15886,7 +15886,7 @@
         },
         {
             "id": "f1b62f27-655d-554b-bf06-e80e2b943c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05652e01-1144-4214-b962-c34f677e0a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05652e01-1144-4214-b962-c34f677e0a07.jpg?1",
             "name": "Shardmage's Rescue",
             "text": "Flash\nEnchant creature you control\nAs long as Shardmage's Rescue entered this turn, enchanted creature has hexproof.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -15922,7 +15922,7 @@
         },
         {
             "id": "744a4ac3-612d-5c14-9228-da3a309dea82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ef0c5b-4bcf-435f-b9bb-c8175c7b4257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ef0c5b-4bcf-435f-b9bb-c8175c7b4257.jpg?1",
             "name": "Valgavoth's Faithful",
             "text": "{3}{B}, Sacrifice Valgavoth's Faithful: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -15959,7 +15959,7 @@
         },
         {
             "id": "7212101e-a2ac-58c7-9350-2dc5839b67e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4005974-fac5-465f-b742-bcb41eb8ba74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4005974-fac5-465f-b742-bcb41eb8ba74.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -15993,7 +15993,7 @@
         },
         {
             "id": "9c70b55c-aec1-58e9-95be-635c230b6e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f764d201-b62e-4968-a1fc-a69247859854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f764d201-b62e-4968-a1fc-a69247859854.jpg?1",
             "name": "Drag to the Roots",
             "text": "Delirium \u2014 This spell costs {2} less to cast as long as there are four or more card types among cards in your graveyard.\nDestroy target nonland permanent.",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "f1d1a127-5678-5abf-97c6-862dc129bbe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cc1465-ee00-40f4-aaa9-02f0465beb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cc1465-ee00-40f4-aaa9-02f0465beb88.jpg?1",
             "name": "Inquisitive Glimmer",
             "text": "Enchantment spells you cast cost {1} less to cast.\nUnlock costs you pay cost {1} less.",
             "colours": [
@@ -16069,7 +16069,7 @@
         },
         {
             "id": "42d28e51-7afd-59e9-9366-fd2f21fa3d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea4b0aa-7ed8-4e1c-867b-50754447f41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea4b0aa-7ed8-4e1c-867b-50754447f41b.jpg?1",
             "name": "Grievous Wound",
             "text": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
             "colours": [
@@ -16105,7 +16105,7 @@
         },
         {
             "id": "911f4ff9-dd3b-58d9-bffe-7d516e669103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23684053-024e-4e15-8aec-de3d4bc7f126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23684053-024e-4e15-8aec-de3d4bc7f126.jpg?1",
             "name": "Twitching Doll",
             "text": "{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "3bbbe9b2-6a32-575f-90af-6b419debf932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19112b9-1583-445d-bc48-5ca3325fab48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19112b9-1583-445d-bc48-5ca3325fab48.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -16170,7 +16170,7 @@
         },
         {
             "id": "2310bee9-2b1f-58ea-b586-707024457259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a198942-049c-4537-b5b1-d35df32d45d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a198942-049c-4537-b5b1-d35df32d45d5.jpg?1",
             "name": "Shard",
             "text": "",
             "colours": [],
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "55726f99-c11b-58f8-91d9-1c84759541ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43e18d8-529d-4d63-b627-b9d9fa4f3f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43e18d8-529d-4d63-b627-b9d9fa4f3f38.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -16236,7 +16236,7 @@
         },
         {
             "id": "7918eafc-a710-5e80-9b59-bdfe07067a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg?1",
             "name": "Glimmer",
             "text": "",
             "colours": [
@@ -16271,7 +16271,7 @@
         },
         {
             "id": "d350c562-4e9f-5462-bbf5-afc8a0e7910d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802aea8-0ca3-4d2c-a8ef-a80e16729c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802aea8-0ca3-4d2c-a8ef-a80e16729c9b.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16306,7 +16306,7 @@
         },
         {
             "id": "2e65d6d5-6d8b-5dbd-a0a0-97c2bffc38fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16341,7 +16341,7 @@
         },
         {
             "id": "509d3688-c99e-5b90-b975-8716e3b97fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6d479d-c30d-4048-b250-5233358a174c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6d479d-c30d-4048-b250-5233358a174c.jpg?1",
             "name": "Toy",
             "text": "",
             "colours": [
@@ -16377,7 +16377,7 @@
         },
         {
             "id": "cf39570a-a491-5d21-a385-0119796ac0a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16412,7 +16412,7 @@
         },
         {
             "id": "1fb16f1b-36a5-5421-968c-19c83c42fdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba307eb-814c-4c87-acdf-b54c87d04f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba307eb-814c-4c87-acdf-b54c87d04f82.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -16447,7 +16447,7 @@
         },
         {
             "id": "a5e74906-fe74-5db5-bb64-26b4472f3a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb6907-e7d7-4f99-966a-ab09ca130fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb6907-e7d7-4f99-966a-ab09ca130fb8.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [
@@ -16482,7 +16482,7 @@
         },
         {
             "id": "fc3e7e0f-3224-53c0-b66c-e404679fda18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -16517,7 +16517,7 @@
         },
         {
             "id": "29562e6b-2aa3-563e-8e61-1ff513354a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8852eb-1318-40c2-aa2a-8c0e830cca71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8852eb-1318-40c2-aa2a-8c0e830cca71.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -16552,7 +16552,7 @@
         },
         {
             "id": "26fab7df-78f1-5a13-af43-ab906331ae31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377f1a20-b270-4b07-9892-7170cd0bee38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377f1a20-b270-4b07-9892-7170cd0bee38.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16589,7 +16589,7 @@
         },
         {
             "id": "4060afb6-0ca7-5111-9344-54ed2dd3f8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9de169-fb85-43cc-8527-9829d7cb5bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9de169-fb85-43cc-8527-9829d7cb5bc5.jpg?1",
             "name": "Primo, the Indivisible",
             "text": "",
             "colours": [
@@ -16628,7 +16628,7 @@
         },
         {
             "id": "bcc85e6e-80b5-537b-98fe-8b96243cd68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0b31c3-5775-41a6-9981-44fc4a6d4aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0b31c3-5775-41a6-9981-44fc4a6d4aa8.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -16659,7 +16659,7 @@
         },
         {
             "id": "705428c3-5dfd-5c2f-81cc-47db81a41e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b76b7a4-f398-4bb4-833e-97ec0d4e581a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b76b7a4-f398-4bb4-833e-97ec0d4e581a.jpg?1",
             "name": "Everywhere",
             "text": "",
             "colours": [],
@@ -16694,7 +16694,7 @@
         },
         {
             "id": "6b0efa14-b9fd-542d-ae6c-9d03e6a4fade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435e707c-2b1d-48a7-ba75-c3c67824b50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435e707c-2b1d-48a7-ba75-c3c67824b50d.jpg?1",
             "name": "Kaito, Bane of Nightmares Emblem",
             "text": "",
             "colours": [],
@@ -16722,7 +16722,7 @@
         },
         {
             "id": "34b761d0-6e4d-5706-9a21-5dbb4073d7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01104ab1-84e1-4c78-853d-637c6554bdf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01104ab1-84e1-4c78-853d-637c6554bdf9.jpg?1",
             "name": "Manifest",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/DST.json
+++ b/Assets/Resources/Sets/DST.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ef1bb6bf-19f5-5987-9158-38571ab1c5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cce4d4-bff2-4dbb-bc12-1a726ad82dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cce4d4-bff2-4dbb-bc12-1a726ad82dd4.jpg?1",
             "name": "Auriok Glaivemaster",
             "text": "As long as Auriok Glaivemaster is equipped, it gets +1/+1 and has first strike.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "d5f1697b-551e-518c-be5e-43859c9d6075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060e278c-dc34-4a94-9b15-6e9ffb2a1aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060e278c-dc34-4a94-9b15-6e9ffb2a1aee.jpg?1",
             "name": "Echoing Calm",
             "text": "Destroy target enchantment and all other enchantments with the same name as that enchantment.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "739a12f3-d088-54b0-a5c8-43d11de907cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c47553-4209-4634-a49c-25714cd3967b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c47553-4209-4634-a49c-25714cd3967b.jpg?1",
             "name": "Emissary of Hope",
             "text": "Flying\nWhenever Emissary of Hope deals combat damage to a player, you gain 1 life for each artifact that player controls.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "648e15b8-d4b3-5e4a-92b7-0121e357588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fe80a0-cb3d-48bc-b67e-2e2253cfee14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fe80a0-cb3d-48bc-b67e-2e2253cfee14.jpg?1",
             "name": "Hallow",
             "text": "Prevent all damage target spell would deal this turn. You gain life equal to the damage prevented this way.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "c9f55419-1a24-5452-ac0f-ac72d2fdd552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c14e05-8c50-44de-8cd4-5b3a11ecdb30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c14e05-8c50-44de-8cd4-5b3a11ecdb30.jpg?1",
             "name": "Leonin Battlemage",
             "text": "{T}: Target creature gets +1/+1 until end of turn.\nWhenever you play a spell, you may untap Leonin Battlemage.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "99725375-64f6-552a-a258-725f8663dc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2a0f5-e340-4a85-aa5c-340e7f8231b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2a0f5-e340-4a85-aa5c-340e7f8231b0.jpg?1",
             "name": "Leonin Shikari",
             "text": "You may play equip abilities any time you could play an instant.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "4e1701f7-78f0-5f69-9ead-e407e5f28ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976c352-ac49-4e0d-a4c0-ec9b6b78db9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976c352-ac49-4e0d-a4c0-ec9b6b78db9c.jpg?1",
             "name": "Loxodon Mystic",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "2fd1eafe-e422-5390-93fd-318844f5121d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa32494-24bc-44c7-81d4-7285bd1fe3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa32494-24bc-44c7-81d4-7285bd1fe3c8.jpg?1",
             "name": "Metal Fatigue",
             "text": "Tap all artifacts.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "c176698d-0f5b-5240-9375-0cde177735c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cabc4c-0c2b-4004-9676-aba151a9242f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cabc4c-0c2b-4004-9676-aba151a9242f.jpg?1",
             "name": "Pristine Angel",
             "text": "Flying\nAs long as Pristine Angel is untapped, it has protection from artifacts and from all colors.\nWhenever you play a spell, you may untap Pristine Angel.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "38fb6f62-24b4-5b7d-82f3-1fc601b2177e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aff26fc-e6d3-4135-96b9-0da7cb8b6dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aff26fc-e6d3-4135-96b9-0da7cb8b6dae.jpg?1",
             "name": "Pteron Ghost",
             "text": "Flying\nSacrifice Pteron Ghost: Regenerate target artifact.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "d32cdc71-4e93-59c9-9cbc-41ee3c1e7f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedff5d-4c5d-4120-9d9a-4bb5b0b2d2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedff5d-4c5d-4120-9d9a-4bb5b0b2d2f2.jpg?1",
             "name": "Pulse of the Fields",
             "text": "You gain 4 life. Then if an opponent has more life than you, return Pulse of the Fields to its owner's hand.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "77e017da-b7e2-5c41-9724-0436d2e70c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcbe727-81f0-469e-92f1-0dd9acdb54ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcbe727-81f0-469e-92f1-0dd9acdb54ea.jpg?1",
             "name": "Purge",
             "text": "Destroy target artifact creature or black creature. It can't be regenerated.",
             "colours": [
@@ -407,7 +407,7 @@
         },
         {
             "id": "8389e817-2078-582d-a5d0-68e3f435d806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73142844-de7c-4427-8183-c2281bde6449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73142844-de7c-4427-8183-c2281bde6449.jpg?1",
             "name": "Ritual of Restoration",
             "text": "Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "73091e10-9a09-5b95-b7bf-7247eb3b4c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b431711-ac9d-4f05-af66-44f1ca5fabf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b431711-ac9d-4f05-af66-44f1ca5fabf1.jpg?1",
             "name": "Soulscour",
             "text": "Destroy all nonartifact permanents.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "924d1f70-ce06-5f31-ae50-6c11d2be1507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4793de1-4d5d-4538-b48f-db5d31757bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4793de1-4d5d-4538-b48f-db5d31757bcc.jpg?1",
             "name": "Steelshaper Apprentice",
             "text": "{W}, {T}, Return Steelshaper Apprentice to its owner's hand: Search your library for an Equipment card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "8dd511f1-ec01-5a86-b418-89557d769ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7632585e-28e1-4f45-b5ba-172d44573708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7632585e-28e1-4f45-b5ba-172d44573708.jpg?1",
             "name": "Stir the Pride",
             "text": "Choose one Creatures you control get +2/+2 until end of turn; or until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "91622f41-152c-5c0c-862b-6a5f76f79473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e519c3ab-1963-4aa1-843f-3cc1b6aec7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e519c3ab-1963-4aa1-843f-3cc1b6aec7b2.jpg?1",
             "name": "Test of Faith",
             "text": "Prevent the next 3 damage that would be dealt to target creature this turn, and put a +1/+1 counter on that creature for each 1 damage prevented this way.",
             "colours": [
@@ -570,7 +570,7 @@
         },
         {
             "id": "a255a5d4-de5f-5222-b664-7adbc9388c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b38c5-4be1-4f33-92e8-6fe0476b5299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b38c5-4be1-4f33-92e8-6fe0476b5299.jpg?1",
             "name": "Turn the Tables",
             "text": "All combat damage that would be dealt to you this turn is dealt to target attacking creature instead.",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "7d0477bb-e85e-5d23-b35d-536b45eb317f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17e86f-410e-42d0-8ef8-739ea26da0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17e86f-410e-42d0-8ef8-739ea26da0a7.jpg?1",
             "name": "Carry Away",
             "text": "When Carry Away comes into play, unattach enchanted Equipment.\nYou control enchanted Equipment.",
             "colours": [
@@ -636,7 +636,7 @@
         },
         {
             "id": "c261f03b-e8a9-54bb-947f-c2c6dd1da2ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22aa7ef-da34-49c1-9aac-67d129ffa6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22aa7ef-da34-49c1-9aac-67d129ffa6fe.jpg?1",
             "name": "Chromescale Drake",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying\nWhen Chromescale Drake comes into play, reveal the top three cards of your library. Put all artifact cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -670,7 +670,7 @@
         },
         {
             "id": "7dfd7f95-1e2a-57b4-8cf3-71e5549807ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefedd7-1bf5-4148-9084-d7d8f1138140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefedd7-1bf5-4148-9084-d7d8f1138140.jpg?1",
             "name": "Echoing Truth",
             "text": "Return target nonland permanent and all other permanents with the same name as that permanent to their owners' hands.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "014495d8-5069-5970-9914-00c9188e3d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ab80bf-d115-4155-82e1-9a3a70b1b67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ab80bf-d115-4155-82e1-9a3a70b1b67d.jpg?1",
             "name": "Hoverguard Observer",
             "text": "Flying\nHoverguard Observer can block only creatures with flying.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "65c73cf8-3513-597c-a1b3-ba0418be16d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d2ece-f656-4cac-8d77-b0f083f76c70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d2ece-f656-4cac-8d77-b0f083f76c70.jpg?1",
             "name": "Last Word",
             "text": "Last Word can't be countered by spells or abilities.\nCounter target spell.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "a5735d2b-e4da-53ab-8bbb-9a64777d4042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e815b3-373c-4b2e-beb5-c894a52ffdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e815b3-373c-4b2e-beb5-c894a52ffdea.jpg?1",
             "name": "Machinate",
             "text": "Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "7575b370-8b13-5146-8db5-ffb153c8c541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab7022-fa0f-42da-b0ca-998cbd0c791c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab7022-fa0f-42da-b0ca-998cbd0c791c.jpg?1",
             "name": "Magnetic Flux",
             "text": "Artifact creatures you control gain flying until end of turn.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "d4e493a9-0686-53ff-84eb-ae75d85ff6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb179448-5e1f-4ef3-858c-ba7a9ea05a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb179448-5e1f-4ef3-858c-ba7a9ea05a78.jpg?1",
             "name": "Neurok Prodigy",
             "text": "Flying\nDiscard an artifact card from your hand: Return Neurok Prodigy to its owner's hand.",
             "colours": [
@@ -867,7 +867,7 @@
         },
         {
             "id": "48fdb57d-9f4f-5e12-a9a6-faa30a9dd7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604172f-e9b8-41bc-aee4-691f9fa4ce42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604172f-e9b8-41bc-aee4-691f9fa4ce42.jpg?1",
             "name": "Neurok Transmuter",
             "text": "{U}: Target creature becomes an artifact in addition to its other types until end of turn.\n{U}: Until end of turn, target artifact creature becomes blue and isn't an artifact.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "10fc6d3b-e272-5e4b-aca5-9d4d45fdb972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32d0779-ef2a-42be-ad67-cee9b06122de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32d0779-ef2a-42be-ad67-cee9b06122de.jpg?1",
             "name": "Psychic Overload",
             "text": "When Psychic Overload comes into play, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step.\nEnchanted permanent has \"Discard two artifact cards from your hand: Untap this permanent.\"",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "52c28fb2-33c8-5f35-a16b-f67fc3c50f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6805341-fa4f-4d89-8003-b27280fadfbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6805341-fa4f-4d89-8003-b27280fadfbd.jpg?1",
             "name": "Pulse of the Grid",
             "text": "Draw two cards, then discard a card from your hand. Then if an opponent has more cards in hand than you, return Pulse of the Grid to its owner's hand.",
             "colours": [
@@ -968,7 +968,7 @@
         },
         {
             "id": "9f44d218-9ee9-5e5d-9306-96f87645328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645bfe2d-845b-4cf3-88b6-b2b62b8531e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645bfe2d-845b-4cf3-88b6-b2b62b8531e4.jpg?1",
             "name": "Quicksilver Behemoth",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nWhen Quicksilver Behemoth attacks or blocks, return it to its owner's hand at end of combat. (Return it only if it's in play.)",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "9d689387-6572-5d01-b187-bc3952e4f80d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a8d65d-0c6f-433d-a818-002c242a17e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a8d65d-0c6f-433d-a818-002c242a17e8.jpg?1",
             "name": "Reshape",
             "text": "As an additional cost to play Reshape, sacrifice an artifact.\nSearch your library for an artifact card with converted mana cost X or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -1034,7 +1034,7 @@
         },
         {
             "id": "3d8471a3-3b59-57ae-bf48-e1a56c2e38bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e09a443-0a00-458a-b351-8cb188e9218c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e09a443-0a00-458a-b351-8cb188e9218c.jpg?1",
             "name": "Retract",
             "text": "Return all artifacts you control to their owner's hand.",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "799a0b2f-3fc9-505a-847c-e330d1101cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a07cdc-8335-45da-9ae2-3052193663ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a07cdc-8335-45da-9ae2-3052193663ef.jpg?1",
             "name": "Second Sight",
             "text": "Choose one Look at the top five cards of target opponent's library, then put them back in any order; or look at the top five cards of your library, then put them back in any order.\nEntwine {U} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "df8a1332-7b97-56fc-8289-14724fd1541d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc895eea-505d-4a12-936b-dcf9895d01a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc895eea-505d-4a12-936b-dcf9895d01a1.jpg?1",
             "name": "Synod Artificer",
             "text": "{X}, {T}: Tap X target noncreature artifacts.\n{X}, {T}: Untap X target noncreature artifacts.",
             "colours": [
@@ -1133,7 +1133,7 @@
         },
         {
             "id": "2c841a8f-586f-5657-929b-c6c55ebfa747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2d9a-9401-4711-97b6-825652090c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2d9a-9401-4711-97b6-825652090c4d.jpg?1",
             "name": "Vedalken Engineer",
             "text": "{T}: Add two mana of any one color to your mana pool. Spend this mana only to play artifact spells or activated abilities of artifacts.",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "70a12909-df2d-57e9-a767-308f136bec0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28a9f15-5469-4dc2-8a73-646f854fec7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28a9f15-5469-4dc2-8a73-646f854fec7e.jpg?1",
             "name": "Vex",
             "text": "Counter target spell. That spell's controller may draw a card.",
             "colours": [
@@ -1200,7 +1200,7 @@
         },
         {
             "id": "c5a6db43-2ca4-5869-943b-5ca0c50010dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9422b79-2bc5-4d0a-8f91-157d9fc09641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9422b79-2bc5-4d0a-8f91-157d9fc09641.jpg?1",
             "name": "Aether Snap",
             "text": "Remove all counters from all permanents and remove all tokens from the game.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "8bac6e76-2094-5e6f-9ca2-94f983917686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37abcf5-f009-4258-bf32-b93b47cb71dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37abcf5-f009-4258-bf32-b93b47cb71dc.jpg?1",
             "name": "Burden of Greed",
             "text": "Target player loses 1 life for each tapped artifact he or she controls.",
             "colours": [
@@ -1264,7 +1264,7 @@
         },
         {
             "id": "6e755613-becc-598f-9b2c-149b6e0c74f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980135d5-dfaa-4beb-b4b3-1e256bb46e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980135d5-dfaa-4beb-b4b3-1e256bb46e61.jpg?1",
             "name": "Chittering Rats",
             "text": "When Chittering Rats comes into play, target opponent puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "96e855cd-aa9a-55c5-8588-61a981807d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0bfb9-859b-4fed-a1c4-1f0924715801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0bfb9-859b-4fed-a1c4-1f0924715801.jpg?1",
             "name": "Death Cloud",
             "text": "Each player loses X life, then discards X cards from his or her hand, then sacrifices X creatures, then sacrifices X lands.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "da9c5948-f6c0-5760-9851-713012071a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e688e7-8350-4b78-bd49-a6ffdedad556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e688e7-8350-4b78-bd49-a6ffdedad556.jpg?1",
             "name": "Echoing Decay",
             "text": "Target creature and all other creatures with the same name as that creature get -2/-2 until end of turn.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "c02b797b-b500-5530-93ea-b3f3526cf068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa8ae06-882b-428e-b446-1e750ffcddd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa8ae06-882b-428e-b446-1e750ffcddd1.jpg?1",
             "name": "Emissary of Despair",
             "text": "Flying\nWhenever Emissary of Despair deals combat damage to a player, that player loses 1 life for each artifact he or she controls.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "1415fd15-bba0-5ac8-ade8-5505f6f6c205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9950052e-f674-4f09-802e-3f5f52f5e717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9950052e-f674-4f09-802e-3f5f52f5e717.jpg?1",
             "name": "Essence Drain",
             "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "4eb7b656-fae2-50e9-ad1d-35363d1cc01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b9c148-5f31-405e-9215-a12bafcac99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b9c148-5f31-405e-9215-a12bafcac99a.jpg?1",
             "name": "Greater Harvester",
             "text": "At the beginning of your upkeep, sacrifice a permanent.\nWhenever Greater Harvester deals combat damage to a player, that player sacrifices two permanents.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "f2d9c174-d936-5268-b5f4-cc50ca93f1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d6ed5-0bbc-465e-bc30-3174c910b435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d6ed5-0bbc-465e-bc30-3174c910b435.jpg?1",
             "name": "Grimclaw Bats",
             "text": "Flying\n{B}, Pay 1 life: Grimclaw Bats gets +1/+1 until end of turn.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "1f2a7e16-66f4-5989-979c-5f8b7e1b9883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba50e47-2417-447f-b334-50ef0faecfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba50e47-2417-447f-b334-50ef0faecfae.jpg?1",
             "name": "Hunger of the Nim",
             "text": "Target creature gets +1/+0 until end of turn for each artifact you control.",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "ff17cc87-ca9c-5a6e-94dc-cd5fa14f9f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5465de95-1249-4f14-a2e3-2b2861dfe058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5465de95-1249-4f14-a2e3-2b2861dfe058.jpg?1",
             "name": "Mephitic Ooze",
             "text": "Mephitic Ooze gets +1/+0 for each artifact you control.\nWhenever Mephitic Ooze deals combat damage to a creature, destroy that creature. The creature can't be regenerated.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "bb2c191a-e033-5d92-9378-95cbafed7007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ece344-c516-449e-ab7c-2e78d4778f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ece344-c516-449e-ab7c-2e78d4778f02.jpg?1",
             "name": "Murderous Spoils",
             "text": "Destroy target nonblack creature. It can't be regenerated. You gain control of all Equipment that was attached to it. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "d4c6168d-d48c-5eda-a8de-d7a36e24cf79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1072fef6-3a58-41bb-8d34-0aaedf827aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1072fef6-3a58-41bb-8d34-0aaedf827aa5.jpg?1",
             "name": "Nim Abomination",
             "text": "At the end of your turn, if Nim Abomination is untapped, you lose 3 life.",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "0cd58e48-fa0e-57dd-8136-63bbeac1f152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8b1d0a-2c78-4173-b7ed-d7f3a0502fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8b1d0a-2c78-4173-b7ed-d7f3a0502fe7.jpg?1",
             "name": "Pulse of the Dross",
             "text": "Target player reveals three cards from his or her hand and you choose one of them. That player discards that card. Then if that player has more cards in hand than you, return Pulse of the Dross to its owner's hand.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "067c996f-202e-5953-903a-c31a05669490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023603c1-3f1e-42d1-81e1-535547ef6ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023603c1-3f1e-42d1-81e1-535547ef6ee0.jpg?1",
             "name": "Scavenging Scarab",
             "text": "Scavenging Scarab can't block.",
             "colours": [
@@ -1694,7 +1694,7 @@
         },
         {
             "id": "7362d3fe-8a0b-57b5-937f-e270a1ec9540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c03b3c-5140-4577-a1aa-952986223a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c03b3c-5140-4577-a1aa-952986223a82.jpg?1",
             "name": "Screams from Within",
             "text": "Enchanted creature gets -1/-1.\nWhen enchanted creature is put into a graveyard, return Screams from Within from your graveyard to play.",
             "colours": [
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "7b721158-2c1a-5516-b185-f7fd9a46fadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30f99a-b295-45a2-bff7-479cbe7541a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30f99a-b295-45a2-bff7-479cbe7541a5.jpg?1",
             "name": "Scrounge",
             "text": "Target opponent chooses an artifact card in his or her graveyard. Put that card into play under your control.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "7fca8ba8-bc6d-55a1-ab84-60a326a97c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c255d5-9246-4a93-8750-0da8871fb12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c255d5-9246-4a93-8750-0da8871fb12d.jpg?1",
             "name": "Shriveling Rot",
             "text": "Choose one Until end of turn, whenever a creature is dealt damage, destroy it; or until end of turn, whenever a creature is put into a graveyard from play, that creature's controller loses life equal to its toughness.\nEntwine {2}{B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "0eecae94-846b-59c3-8678-b7788ef28d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509482a-68d8-4e94-9d1e-5b069ebdc2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509482a-68d8-4e94-9d1e-5b069ebdc2e4.jpg?1",
             "name": "Barbed Lightning",
             "text": "Choose one Barbed Lightning deals 3 damage to target creature; or Barbed Lightning deals 3 damage to target player.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "d28d7463-e215-5522-8460-cf69ef21acce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fdb57b-7547-4588-9780-15e3bea0bc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fdb57b-7547-4588-9780-15e3bea0bc4c.jpg?1",
             "name": "Crazed Goblin",
             "text": "Crazed Goblin attacks each turn if able.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "b8d7b3f4-945b-55de-9a64-89ecfae26d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9915ff-a9b9-429c-bdc1-6a52d9f0e6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9915ff-a9b9-429c-bdc1-6a52d9f0e6d4.jpg?1",
             "name": "Dismantle",
             "text": "Destroy target artifact. If that artifact had counters on it, put that many +1/+1 counters or charge counters on an artifact you control.",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "39f05caf-9329-54d0-824e-dfc1815f58f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2036745a-09ea-476f-ace6-1d06b8502f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2036745a-09ea-476f-ace6-1d06b8502f83.jpg?1",
             "name": "Drooling Ogre",
             "text": "Whenever a player plays an artifact spell, that player gains control of Drooling Ogre. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "a123a4da-da4c-54a2-989e-235e50717fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f842c8-cd6c-4f4d-9aa8-417a92b37867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f842c8-cd6c-4f4d-9aa8-417a92b37867.jpg?1",
             "name": "Echoing Ruin",
             "text": "Destroy target artifact and all other artifacts with the same name as that artifact.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "dc1b80b3-a3fd-5d0f-9f74-07a49ce727be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967465c4-619a-4407-bffc-ffadb89726cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967465c4-619a-4407-bffc-ffadb89726cd.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nAs an additional cost to play Fireball, pay {1} for each target beyond the first.",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "ae6f9535-2563-57ea-9f09-34fecfa29f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e1f06f-7c87-4da8-b339-e571e391cab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e1f06f-7c87-4da8-b339-e571e391cab1.jpg?1",
             "name": "Flamebreak",
             "text": "Flamebreak deals 3 damage to each creature without flying and each player. Creatures dealt damage this way can't be regenerated this turn.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "cc2b2881-8ef3-5055-91f7-42a9bc86118e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f5c675-b629-45ec-907c-36594f5fe54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f5c675-b629-45ec-907c-36594f5fe54a.jpg?1",
             "name": "Furnace Dragon",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying\nWhen Furnace Dragon comes into play, if you played it from your hand, remove all artifacts from the game.",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "e6b89a49-b0f9-5651-999e-9af4e284a19c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326a7d0-8e24-4ae4-9014-ca6eb6983644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326a7d0-8e24-4ae4-9014-ca6eb6983644.jpg?1",
             "name": "Goblin Archaeologist",
             "text": "{R}, {T}: Flip a coin. If you win the flip, destroy target artifact and untap Goblin Archaeologist. If you lose the flip, sacrifice Goblin Archaeologist.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "f526fc99-d02f-5500-9e1a-582635c56cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efad9a-2fcf-4045-8105-bf9f5e79d12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efad9a-2fcf-4045-8105-bf9f5e79d12c.jpg?1",
             "name": "Inflame",
             "text": "Inflame deals 2 damage to each creature dealt damage this turn.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "57729606-67c1-517a-9d27-49855cb52cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90da818-ffa1-435d-8734-fc7a1330d323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90da818-ffa1-435d-8734-fc7a1330d323.jpg?1",
             "name": "Krark-Clan Stoker",
             "text": "{T}, Sacrifice an artifact: Add {R}{R} to your mana pool.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "78f9f4b8-c4b9-54ab-a6c2-b420249cf0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ed9c8-b552-4a9a-b77a-8b148638b4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ed9c8-b552-4a9a-b77a-8b148638b4f0.jpg?1",
             "name": "Pulse of the Forge",
             "text": "Pulse of the Forge deals 4 damage to target player. Then if that player has more life than you, return Pulse of the Forge to its owner's hand.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "c936f090-39bc-5880-b3df-b8246498f39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3739d37-7865-46bf-abbc-7a5678709508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3739d37-7865-46bf-abbc-7a5678709508.jpg?1",
             "name": "Savage Beating",
             "text": "Play Savage Beating only during your turn and only during combat.\nChoose one Creatures you control gain double strike until end of turn; or untap all creatures you control and after this phase, there is an additional combat phase.\nEntwine {1}{R}",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "12ceb544-270c-5091-9ffd-1bd0d95e683f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee290e-c22b-4fad-bf99-0630a2b89d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee290e-c22b-4fad-bf99-0630a2b89d68.jpg?1",
             "name": "Shunt",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "701de95f-5d9d-5429-a21e-85f88e0435bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14aa0e-6d34-48ca-aee0-3563bbfb3b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14aa0e-6d34-48ca-aee0-3563bbfb3b15.jpg?1",
             "name": "Slobad, Goblin Tinkerer",
             "text": "Sacrifice an artifact: Target artifact becomes indestructible until end of turn. (\"Destroy\" effects and lethal damage don't destroy that artifact.)",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "40d2a942-c3e9-56fe-ae85-0d0216342847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070fa2d9-6238-49f6-9d63-75ae88ced8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070fa2d9-6238-49f6-9d63-75ae88ced8e5.jpg?1",
             "name": "Tears of Rage",
             "text": "Play Tears of Rage only during the declare attackers step.\nAttacking creatures you control get +X/+0 until end of turn, where X is the number of attacking creatures. Sacrifice those creatures at end of turn.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "adf0de87-23dd-50dc-80d3-6113eb736199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d369a3da-3424-4984-a50a-59fd9c3d689e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d369a3da-3424-4984-a50a-59fd9c3d689e.jpg?1",
             "name": "Unforge",
             "text": "Destroy target Equipment. If that Equipment was attached to a creature, Unforge deals 2 damage to that creature.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "95c67a5f-e08b-53da-9b3c-4b5ec5a94dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b232a-834c-4c9a-bf36-821d125dc318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b232a-834c-4c9a-bf36-821d125dc318.jpg?1",
             "name": "Vulshok War Boar",
             "text": "When Vulshok War Boar comes into play, sacrifice it unless you sacrifice an artifact.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "ba895b22-d67e-526c-8e2a-748c4d9d5868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d9b77b-d775-4546-91c8-df438a1d8dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d9b77b-d775-4546-91c8-df438a1d8dbe.jpg?1",
             "name": "Ageless Entity",
             "text": "Whenever you gain life, put that many +1/+1 counters on Ageless Entity.",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "ac92648a-5ef0-53fb-9964-5475d36b741d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37bf33-f340-44eb-a092-1cb9385c8981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37bf33-f340-44eb-a092-1cb9385c8981.jpg?1",
             "name": "Echoing Courage",
             "text": "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
             "colours": [
@@ -2455,7 +2455,7 @@
         },
         {
             "id": "d59ab0ac-3c4c-5bf3-9567-f9e1762971ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d5fc3c-7f6b-42a5-a482-d789a2a421c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d5fc3c-7f6b-42a5-a482-d789a2a421c7.jpg?1",
             "name": "Fangren Firstborn",
             "text": "Whenever Fangren Firstborn attacks, put a +1/+1 counter on each attacking creature.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "886e5649-aa8c-5b60-88ea-55076e614536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc7bf3-fa3f-450a-875e-05a022794181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc7bf3-fa3f-450a-875e-05a022794181.jpg?1",
             "name": "Infested Roothold",
             "text": "(Walls can't attack.)\nProtection from artifacts\nWhenever an opponent plays an artifact spell, you may put a 1/1 green Insect creature token into play.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "d2d4bed7-eb8a-5187-90f2-79e38bb3ef6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028c52f2-c45b-42da-89bd-cdd5cd7850f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028c52f2-c45b-42da-89bd-cdd5cd7850f3.jpg?1",
             "name": "Karstoderm",
             "text": "Karstoderm comes into play with five +1/+1 counters on it.\nWhenever an artifact comes into play, remove a +1/+1 counter from Karstoderm.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "20dd2477-c5bc-5fce-a33b-cca41778fb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0597dd97-fe6f-4e74-88e5-35528ada0140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0597dd97-fe6f-4e74-88e5-35528ada0140.jpg?1",
             "name": "Nourish",
             "text": "You gain 6 life.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "71241ec9-ac1f-5d12-9648-f57fae0feac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349969e-1cbe-4541-b3ed-154f5a39f1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349969e-1cbe-4541-b3ed-154f5a39f1f0.jpg?1",
             "name": "Oxidize",
             "text": "Destroy target artifact. It can't be regenerated.",
             "colours": [
@@ -2621,7 +2621,7 @@
         },
         {
             "id": "ca2e3783-6492-5761-b354-df32cd3c8581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cf1c67-9edc-42dd-ba7f-96baab25813a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cf1c67-9edc-42dd-ba7f-96baab25813a.jpg?1",
             "name": "Pulse of the Tangle",
             "text": "Put a 3/3 green Beast creature token into play. Then if an opponent controls more creatures than you, return Pulse of the Tangle to its owner's hand.",
             "colours": [
@@ -2653,7 +2653,7 @@
         },
         {
             "id": "7df6c8b0-8366-5d1d-a5f3-29b509da710b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6c4ae7-8509-47a2-bc28-d131b1e6676c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6c4ae7-8509-47a2-bc28-d131b1e6676c.jpg?1",
             "name": "Reap and Sow",
             "text": "Choose one Destroy target land; or search your library for a land card, put that card into play, then shuffle your library.\nEntwine {1}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "8197ca91-9cfa-55c4-b84f-bc76182b23d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5940ed12-5224-4aed-9edc-dd4190691ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5940ed12-5224-4aed-9edc-dd4190691ee9.jpg?1",
             "name": "Rebuking Ceremony",
             "text": "Put two target artifacts on top of their owners' libraries.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "94ea6e3c-8a75-5643-a4d0-847a5b99cef8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0338c6fe-54f6-4be0-a70d-b15e5403d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0338c6fe-54f6-4be0-a70d-b15e5403d842.jpg?1",
             "name": "Roaring Slagwurm",
             "text": "Whenever Roaring Slagwurm attacks, tap all artifacts.",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "c53f7b9d-647c-5970-b089-bea5917cdc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c590-fb9d-433a-8e5f-2b1aff4efd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c590-fb9d-433a-8e5f-2b1aff4efd29.jpg?1",
             "name": "Stand Together",
             "text": "Put two +1/+1 counters on target creature and two +1/+1 counters on another target creature.",
             "colours": [
@@ -2783,7 +2783,7 @@
         },
         {
             "id": "12975333-f8c9-57aa-9bb8-738490ccb8cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca75ce1-8f4e-4980-adb7-5816446d56a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca75ce1-8f4e-4980-adb7-5816446d56a9.jpg?1",
             "name": "Tangle Spider",
             "text": "You may play Tangle Spider any time you could play an instant.\nTangle Spider may block as though it had flying.",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "f4ede5e4-a6bd-5be7-9d00-cdc15725cb51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23266fca-7bda-47ca-a72e-140ed51e94c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23266fca-7bda-47ca-a72e-140ed51e94c0.jpg?1",
             "name": "Tanglewalker",
             "text": "Creatures you control are unblockable as long as defending player controls an artifact land.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "72cdf1c0-bf72-5a44-bf0b-97133301c802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d811d8f-437b-4c9f-8ea2-c85590a07935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d811d8f-437b-4c9f-8ea2-c85590a07935.jpg?1",
             "name": "Tel-Jilad Outrider",
             "text": "Protection from artifacts",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "5b6bacae-d444-5187-a09a-b8242426b82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac40a1c6-88df-4f01-aa59-4ef3c6b57e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac40a1c6-88df-4f01-aa59-4ef3c6b57e75.jpg?1",
             "name": "Tel-Jilad Wolf",
             "text": "Whenever Tel-Jilad Wolf becomes blocked by an artifact creature, Tel-Jilad Wolf gets +3/+3 until end of turn.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "36bd1018-ae5e-55e4-acf3-8ca81001a7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64448241-978c-43e0-b0ea-b4bb3e25b715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64448241-978c-43e0-b0ea-b4bb3e25b715.jpg?1",
             "name": "Viridian Acolyte",
             "text": "{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "b29b7094-6376-58fb-8b88-e6ecc1dffd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1ecdd4-9dbc-4635-a0ef-0aae6f8ffcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1ecdd4-9dbc-4635-a0ef-0aae6f8ffcdb.jpg?1",
             "name": "Viridian Zealot",
             "text": "{1}{G}, Sacrifice Viridian Zealot: Destroy target artifact or enchantment.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "d3261c53-4524-5e3a-8fba-ccce7588f206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741c479b-5e92-4837-9673-9bc72aa11d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741c479b-5e92-4837-9673-9bc72aa11d26.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on \u00c6ther Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on \u00c6ther Vial from your hand into play.",
             "colours": [],
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "a776a2e5-21bf-5116-bd36-d27869dc2bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a11d101-2e82-42d5-b4a1-8f0c520441ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a11d101-2e82-42d5-b4a1-8f0c520441ab.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player plays a white spell, you may gain 1 life.",
             "colours": [],
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "fb43aa91-02f3-5999-a26b-8074d851d220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d85c9-859a-4ff5-9a41-bf20622a3ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d85c9-859a-4ff5-9a41-bf20622a3ff5.jpg?1",
             "name": "Arcane Spyglass",
             "text": "{2}, {T}, Sacrifice a land: Draw a card and put a charge counter on Arcane Spyglass.\nRemove three charge counters from Arcane Spyglass: Draw a card.",
             "colours": [],
@@ -3074,7 +3074,7 @@
         },
         {
             "id": "10158614-de16-5b79-a009-b28d47e24adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4672ba6-cd82-4208-bc08-764986899999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4672ba6-cd82-4208-bc08-764986899999.jpg?1",
             "name": "Arcbound Bruiser",
             "text": "Modular 3 (This comes into play with three +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "48fe2843-c88d-5400-9f50-833f6a445d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748448bb-a1b2-4e84-b09a-5ecc4322f3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748448bb-a1b2-4e84-b09a-5ecc4322f3c6.jpg?1",
             "name": "Arcbound Crusher",
             "text": "Trample\nWhenever another artifact comes into play, put a +1/+1 counter on Arcbound Crusher.\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "698a0cb8-8d45-5da5-ab7c-da820a760584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408f42ae-fb83-4c8a-8638-38c719dec197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408f42ae-fb83-4c8a-8638-38c719dec197.jpg?1",
             "name": "Arcbound Fiend",
             "text": "Fear\nAt the beginning of your upkeep, you may move a +1/+1 counter from target creature onto Arcbound Fiend.\nModular 3 (This comes into play with three +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3167,7 +3167,7 @@
         },
         {
             "id": "cc13a05a-cd6c-5357-b10d-bee9a116c5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f33f9d-dffd-4742-92c6-be7fe6463dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f33f9d-dffd-4742-92c6-be7fe6463dca.jpg?1",
             "name": "Arcbound Hybrid",
             "text": "Haste\nModular 2 (This comes into play with two +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "e80a0d75-df79-52df-9f90-ce1a2fc03597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff3241b-49ba-4243-b8fc-fef600836c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff3241b-49ba-4243-b8fc-fef600836c8c.jpg?1",
             "name": "Arcbound Lancer",
             "text": "First strike\nModular 4 (This comes into play with four +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3229,7 +3229,7 @@
         },
         {
             "id": "c79f738e-c921-501c-bdd5-802b45eb646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b64717e-0e7b-4b4c-ba82-48498ee87aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b64717e-0e7b-4b4c-ba82-48498ee87aad.jpg?1",
             "name": "Arcbound Overseer",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature with modular you control.\nModular 6 (This comes into play with six +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "62ae25c1-2958-556e-8992-d82c96d35a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c1a731-7854-42b1-8719-ac3c2a269c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c1a731-7854-42b1-8719-ac3c2a269c1f.jpg?1",
             "name": "Arcbound Ravager",
             "text": "Sacrifice an artifact: Put a +1/+1 counter on Arcbound Ravager.\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "1cbcba85-610d-5f6e-9f9f-d6ad0fd4ca53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4c5228-1dff-4df0-9d14-f8103364c701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4c5228-1dff-4df0-9d14-f8103364c701.jpg?1",
             "name": "Arcbound Reclaimer",
             "text": "Remove a +1/+1 counter from Arcbound Reclaimer: Put target artifact card from your graveyard on top of your library.\nModular 2 (This comes into play with two +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "b420fcd6-80f2-57fa-a17b-232beae2df4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2f544a-4a42-43ee-9796-5bf6b396b245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2f544a-4a42-43ee-9796-5bf6b396b245.jpg?1",
             "name": "Arcbound Slith",
             "text": "Whenever Arcbound Slith deals combat damage to a player, put a +1/+1 counter on it.\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "8d976321-04c3-5b2e-a5de-c2d9dc73e71f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397ea22-93cd-498a-a493-9af841d09bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397ea22-93cd-498a-a493-9af841d09bf5.jpg?1",
             "name": "Arcbound Stinger",
             "text": "Flying\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "6cb5b235-575d-57c0-b1bc-7e6b5cef8bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75561093-8892-4b51-813a-c933a06d8cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75561093-8892-4b51-813a-c933a06d8cbd.jpg?1",
             "name": "Arcbound Worker",
             "text": "Modular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "7a16982e-130d-55be-b975-f38ec0840105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3808b1-41df-467a-9779-70bbdfbefa6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3808b1-41df-467a-9779-70bbdfbefa6f.jpg?1",
             "name": "Auriok Siege Sled",
             "text": "{1}: Target artifact creature blocks Auriok Siege Sled this turn if able.\n{1}: Target artifact creature can't block Auriok Siege Sled this turn.",
             "colours": [],
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "3cb65b7a-c95a-55a2-a803-e06ae6d09d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516f267-e72b-453c-bceb-4766582568d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516f267-e72b-453c-bceb-4766582568d2.jpg?1",
             "name": "Chimeric Egg",
             "text": "Whenever an opponent plays a nonartifact spell, put a charge counter on Chimeric Egg.\nRemove three charge counters from Chimeric Egg: Chimeric Egg becomes a 6/6 artifact creature with trample until end of turn.",
             "colours": [],
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "3af8e80c-7b49-52c9-9a91-fa50b7406445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeaca72-aadd-4ef8-939a-36f320100e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeaca72-aadd-4ef8-939a-36f320100e6e.jpg?1",
             "name": "Coretapper",
             "text": "{T}: Put a charge counter on target artifact.\nSacrifice Coretapper: Put two charge counters on target artifact.",
             "colours": [],
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "3e827cfe-b245-55c0-ae2b-a1fffed6ede5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06125c05-a345-481d-bc7f-bf234b946b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06125c05-a345-481d-bc7f-bf234b946b5b.jpg?1",
             "name": "Darksteel Brute",
             "text": "Darksteel Brute is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{3}: Darksteel Brute becomes a 2/2 artifact creature until end of turn.",
             "colours": [],
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "89c0e775-0c96-51b8-b202-035f24e452a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc27b24-f085-48b0-8757-cd11fbf25b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc27b24-f085-48b0-8757-cd11fbf25b91.jpg?1",
             "name": "Darksteel Colossus",
             "text": "Trample\nDarksteel Colossus is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "4f3844bb-da9c-5a4d-bb3f-385f4aa4194c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99078ecc-f50a-43e0-93c1-63240cd97bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99078ecc-f50a-43e0-93c1-63240cd97bf7.jpg?1",
             "name": "Darksteel Forge",
             "text": "Artifacts you control are indestructible. (\"Destroy\" effects and lethal damage don't destroy them.)",
             "colours": [],
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "b0d2c01a-ea42-59ae-a805-9c9400e1d101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4fc3bf-a2c1-4a5f-a05e-b0a814c358bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4fc3bf-a2c1-4a5f-a05e-b0a814c358bd.jpg?1",
             "name": "Darksteel Gargoyle",
             "text": "Flying\nDarksteel Gargoyle is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)",
             "colours": [],
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "4d86aa69-68f7-55c6-9344-dfc757ffba7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02b9634-77e9-48ae-a6bf-859598d12c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02b9634-77e9-48ae-a6bf-859598d12c52.jpg?1",
             "name": "Darksteel Ingot",
             "text": "Darksteel Ingot is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "f2e749f7-45fa-54ee-af7a-a1da715cd873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1bac5f-c41a-49f0-94b0-79653b6fa67a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1bac5f-c41a-49f0-94b0-79653b6fa67a.jpg?1",
             "name": "Darksteel Pendant",
             "text": "Darksteel Pendant is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{1}, {T}: Look at the top card of your library. You may put that card on the bottom of your library.",
             "colours": [],
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "6acc678b-645d-5abd-afdd-5de89e3f9847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f1e30-7b30-4853-aeac-3b0933d4ac5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f1e30-7b30-4853-aeac-3b0933d4ac5e.jpg?1",
             "name": "Darksteel Reactor",
             "text": "Darksteel Reactor is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nAt the beginning of your upkeep, you may put a charge counter on Darksteel Reactor.\nWhen Darksteel Reactor has twenty or more charge counters on it, you win the game.",
             "colours": [],
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "b30dbba9-02ed-54e0-8f8e-262901d7d2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e8d67d-3b49-4158-b2bf-8dd0607de51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e8d67d-3b49-4158-b2bf-8dd0607de51f.jpg?1",
             "name": "Death-Mask Duplicant",
             "text": "Imprint {1}: Remove target creature card in your graveyard from the game. (The removed card is imprinted on this artifact.)\nAs long as an imprinted creature card has flying, Death-Mask Duplicant has flying. The same is true for fear, first strike, double strike, haste, landwalk, protection, and trample.",
             "colours": [],
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "6ea19d24-5091-55b5-a159-a13e3ed7e137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d40eb4-643a-4e22-a15f-eda45a48cfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d40eb4-643a-4e22-a15f-eda45a48cfd6.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player plays a black spell, you may gain 1 life.",
             "colours": [],
@@ -3766,7 +3766,7 @@
         },
         {
             "id": "c1a7adfe-0b42-5ffb-94f8-ac54c46d357d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a46bbcc-b287-47bb-b252-5dd3217f61a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a46bbcc-b287-47bb-b252-5dd3217f61a9.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player plays a red spell, you may gain 1 life.",
             "colours": [],
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "0415d3db-9a71-5635-9d38-88bf405aec3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b60dc6a-3b38-4dde-9dd4-aa49a53f29ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b60dc6a-3b38-4dde-9dd4-aa49a53f29ae.jpg?1",
             "name": "Drill-Skimmer",
             "text": "Flying\nDrill-Skimmer can't be the target of spells or abilities as long as you control another artifact creature.",
             "colours": [],
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "ec48b345-d86f-5c47-87b1-9ac23f54271e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df2f4fd-b96a-4537-93a4-38141b0fa577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df2f4fd-b96a-4537-93a4-38141b0fa577.jpg?1",
             "name": "Dross Golem",
             "text": "Affinity for Swamps (This spell costs {1} less to play for each Swamp you control.)\nFear",
             "colours": [],
@@ -3856,7 +3856,7 @@
         },
         {
             "id": "89bafda3-fbf7-502e-b82a-2dcfbf55cff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6870db-8aca-4aee-8e4d-c56a7d8dc242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6870db-8aca-4aee-8e4d-c56a7d8dc242.jpg?1",
             "name": "Eater of Days",
             "text": "Flying, trample\nWhen Eater of Days comes into play, you skip your next two turns.",
             "colours": [],
@@ -3887,7 +3887,7 @@
         },
         {
             "id": "e8d8cd0a-704e-57f6-83f9-1043dc1f76c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e03e05b-011b-4695-950b-98dd7643b8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e03e05b-011b-4695-950b-98dd7643b8a0.jpg?1",
             "name": "Gemini Engine",
             "text": "Whenever Gemini Engine attacks, put an attacking Twin artifact creature token into play. Its power is equal to Gemini Engine's power and its toughness is equal to Gemini Engine's toughness. Sacrifice the token at end of combat.",
             "colours": [],
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "e0a213ad-2eb0-5772-8b96-54677f44e348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a66ded-c697-4bab-8abf-464185f32a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a66ded-c697-4bab-8abf-464185f32a70.jpg?1",
             "name": "Genesis Chamber",
             "text": "Whenever a nontoken creature comes into play, if Genesis Chamber is untapped, that creature's controller puts a 1/1 Myr artifact creature token into play.",
             "colours": [],
@@ -3946,7 +3946,7 @@
         },
         {
             "id": "d7fb608e-8a0c-5021-9fe8-35954947bb27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a21d76d-d86c-4348-be45-f65167d2b5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a21d76d-d86c-4348-be45-f65167d2b5a9.jpg?1",
             "name": "Geth's Grimoire",
             "text": "Whenever an opponent discards a card from his or her hand, you may draw a card.",
             "colours": [],
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "6cf452fe-05d3-5f30-a240-bb7cfa5db655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f33c08-f3c3-4015-970d-ac0530f97c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f33c08-f3c3-4015-970d-ac0530f97c9c.jpg?1",
             "name": "Heartseeker",
             "text": "Equipped creature gets +2/+1 and has \"{T}, Unattach Heartseeker: Destroy target creature.\"\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "162e46dc-f438-58e7-9be4-2eedf60a35cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d159d90-2f3b-4034-bb45-41448b67fe2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d159d90-2f3b-4034-bb45-41448b67fe2e.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "5d880c7d-6deb-5d76-b740-6ffee474d6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc767637-627a-4ea2-873b-d8a80ccc925b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc767637-627a-4ea2-873b-d8a80ccc925b.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player plays a blue spell, you may gain 1 life.",
             "colours": [],
@@ -4063,7 +4063,7 @@
         },
         {
             "id": "fe2d957a-1d7f-5130-9890-d8337a0b7b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eab112-20a6-414f-84c9-678580485420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eab112-20a6-414f-84c9-678580485420.jpg?1",
             "name": "Leonin Bola",
             "text": "Equipped creature has \"{T}, Unattach Leonin Bola: Tap target creature.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "f13214a9-d8c3-5792-9a0f-b580796369d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca24a105-e32a-4b2c-99bf-cfd85bae6229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca24a105-e32a-4b2c-99bf-cfd85bae6229.jpg?1",
             "name": "Lich's Tomb",
             "text": "You don't lose the game for having 0 or less life.\nWhenever you lose life, sacrifice a permanent for each 1 life you lost. (Damage causes loss of life.)",
             "colours": [],
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "5a424865-95d6-53cc-9516-da9b7f94f040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae2417-b859-4254-a3a5-6bff159447ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae2417-b859-4254-a3a5-6bff159447ca.jpg?1",
             "name": "Memnarch",
             "text": "{1}{U}{U}: Target permanent becomes an artifact in addition to its other types. (This effect doesn't end at end of turn.)\n{3}{U}: Gain control of target artifact. (This effect doesn't end at end of turn.)",
             "colours": [],
@@ -4156,7 +4156,7 @@
         },
         {
             "id": "e4b71e49-ea0d-5063-a7c7-d121bc1ff8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7f15a-074a-4137-88ca-e5d376d146fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7f15a-074a-4137-88ca-e5d376d146fd.jpg?1",
             "name": "Mycosynth Lattice",
             "text": "All permanents are artifacts in addition to their other types.\nAll cards that aren't in play, spells, and permanents are colorless.\nPlayers may spend mana as though it were mana of any color.",
             "colours": [],
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "59b2345b-f410-521a-98fa-c7a52bcc0ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb654ac-9bb0-465e-8878-5456c154274f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb654ac-9bb0-465e-8878-5456c154274f.jpg?1",
             "name": "Myr Landshaper",
             "text": "{T}: Target land becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "13fcfb03-68ed-5ccd-ba51-0b4f42096f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1af62e-d566-4f39-a467-244602c9240b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1af62e-d566-4f39-a467-244602c9240b.jpg?1",
             "name": "Myr Matrix",
             "text": "Myr Matrix is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nAll Myr get +1/+1.\n{5}: Put a 1/1 Myr artifact creature token into play.",
             "colours": [],
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "0669e383-12f6-5560-96cb-3d0d2a1104c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0515cc-bf2d-4674-b339-4f4eefbc943d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0515cc-bf2d-4674-b339-4f4eefbc943d.jpg?1",
             "name": "Myr Moonvessel",
             "text": "When Myr Moonvessel is put into a graveyard from play, add {1} to your mana pool.",
             "colours": [],
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "37cd9de9-2551-5a0c-8cce-2c99bfab78ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fc3b76-bc51-49ce-8f3f-2314207be4a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fc3b76-bc51-49ce-8f3f-2314207be4a7.jpg?1",
             "name": "Nemesis Mask",
             "text": "All creatures able to block equipped creature do so.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "67908022-fa5b-5dbf-a1e5-bfd1098f2274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4624fff2-e78f-4c13-a444-7e50586cb0b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4624fff2-e78f-4c13-a444-7e50586cb0b3.jpg?1",
             "name": "Oxidda Golem",
             "text": "Affinity for Mountains (This spell costs {1} less to play for each Mountain you control.)\nHaste",
             "colours": [],
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "f1f15f6b-494d-5f74-83ba-939d0da8397f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e945b0-e919-41bb-9bc5-f71ad531e8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e945b0-e919-41bb-9bc5-f71ad531e8f1.jpg?1",
             "name": "Panoptic Mirror",
             "text": "Imprint {X}, {T}: You may remove an instant or sorcery card with converted mana cost X in your hand from the game. (That card is imprinted on this artifact.)\nAt the beginning of your upkeep, you may copy an imprinted instant or sorcery card and play the copy without paying its mana cost.",
             "colours": [],
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "658ab85f-81dc-553e-ac88-24febc08f390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a86ec3-378f-4fca-b5f7-6dc02d47f7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a86ec3-378f-4fca-b5f7-6dc02d47f7b9.jpg?1",
             "name": "Razor Golem",
             "text": "Affinity for Plains (This spell costs {1} less to play for each Plains you control.)\nAttacking doesn't cause Razor Golem to tap.",
             "colours": [],
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "c1bbf2db-926f-5247-895a-cc39f54d13c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8330afd6-f43a-4955-a704-8f2b963cd0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8330afd6-f43a-4955-a704-8f2b963cd0c6.jpg?1",
             "name": "Serum Powder",
             "text": "{T}: Add {1} to your mana pool.\nAny time you could mulligan and Serum Powder is in your hand, you may remove your hand from the game, then draw that many cards. (You can do this in addition to taking mulligans.)",
             "colours": [],
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "e60b3160-22da-5b21-a54b-5777783590d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e09c8a-6c55-491b-96e9-6cf05f673ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e09c8a-6c55-491b-96e9-6cf05f673ac3.jpg?1",
             "name": "Shield of Kaldra",
             "text": "Equipment named Sword of Kaldra, Shield of Kaldra, and Helm of Kaldra are indestructible.\nEquipped creature is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nEquip {4}",
             "colours": [],
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "4df374aa-8bec-5152-b634-c18956d02ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55318397-de3c-47ea-a088-72a24df5c8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55318397-de3c-47ea-a088-72a24df5c8fa.jpg?1",
             "name": "Skullclamp",
             "text": "Equipped creature gets +1/-1.\nWhen equipped creature is put into a graveyard, draw two cards.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "4d81dc12-a7f5-5ffd-bbca-7649d0ff8e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a3345d-1190-45f4-8191-897b4dcec376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a3345d-1190-45f4-8191-897b4dcec376.jpg?1",
             "name": "Spawning Pit",
             "text": "Sacrifice a creature: Put a charge counter on Spawning Pit.\n{1}, Remove two charge counters from Spawning Pit: Put a 2/2 Spawn artifact creature token into play.",
             "colours": [],
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "d334c18e-f33f-5512-a2c7-49589e8f82a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6d2e20-3887-4996-adbe-304dff27dea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6d2e20-3887-4996-adbe-304dff27dea6.jpg?1",
             "name": "Specter's Shroud",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature deals combat damage to a player, that player discards a card from his or her hand.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4542,7 +4542,7 @@
         },
         {
             "id": "8b1d3657-e1a0-5adb-a832-ca16f315a970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d193d4f-1beb-4938-b3fb-b2e96d0c9ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d193d4f-1beb-4938-b3fb-b2e96d0c9ec4.jpg?1",
             "name": "Spellbinder",
             "text": "Imprint When Spellbinder comes into play, you may remove an instant card in your hand from the game.\nWhenever equipped creature deals combat damage to a player, you may copy the imprinted instant card and play the copy without paying its mana cost.\nEquip {4}",
             "colours": [],
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "39368544-2b46-5181-a4e9-52294e1e99ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269a34-cec6-4978-a109-592723cd80dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269a34-cec6-4978-a109-592723cd80dc.jpg?1",
             "name": "Spincrusher",
             "text": "Whenever Spincrusher blocks, put a +1/+1 counter on it.\nRemove a +1/+1 counter from Spincrusher: Spincrusher is unblockable this turn.",
             "colours": [],
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "73db8f8d-d60a-5ca2-a73b-87dea4ec2474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19239c7b-add3-4537-bdfd-a0f7d38d4d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19239c7b-add3-4537-bdfd-a0f7d38d4d8e.jpg?1",
             "name": "Spire Golem",
             "text": "Affinity for Islands (This spell costs {1} less to play for each Island you control.)\nFlying",
             "colours": [],
@@ -4634,7 +4634,7 @@
         },
         {
             "id": "b489f67d-8939-53e4-97ae-dcce3fc2a4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4bd552-e629-41a4-868f-d656187317b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4bd552-e629-41a4-868f-d656187317b7.jpg?1",
             "name": "Sundering Titan",
             "text": "When Sundering Titan comes into play, choose a land of each basic land type, then destroy those lands.\nWhen Sundering Titan leaves play, choose a land of each basic land type, then destroy those lands.",
             "colours": [],
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "e2c5fb9b-4e3a-528c-9cab-fde857106321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcb621d-5831-4b7c-b3e1-c321a6e10392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcb621d-5831-4b7c-b3e1-c321a6e10392.jpg?1",
             "name": "Surestrike Trident",
             "text": "Equipped creature has first strike and \"{T}, Unattach Surestrike Trident: This creature deals damage equal to its power to target player.\"\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4695,7 +4695,7 @@
         },
         {
             "id": "ecb656f9-1886-54a9-9daf-cae0cbb424e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb613ee-8b8b-4a34-886c-6592b27672b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb613ee-8b8b-4a34-886c-6592b27672b3.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to target creature or player and you draw a card.\nEquip {2}",
             "colours": [],
@@ -4725,7 +4725,7 @@
         },
         {
             "id": "9be1c5f7-f516-5d11-b959-44bc8a994579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d08a91-665e-458c-9b8f-4ebd5f54a0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d08a91-665e-458c-9b8f-4ebd5f54a0d6.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "5eea39d9-fac9-5e7f-92f5-7d237e947c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4ab5e0-5f6b-422d-8ba7-9e0ce1450af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4ab5e0-5f6b-422d-8ba7-9e0ce1450af8.jpg?1",
             "name": "Talon of Pain",
             "text": "Whenever a source you control other than Talon of Pain deals damage to an opponent, put a charge counter on Talon of Pain.\n{X}, {T}, Remove X charge counters from Talon of Pain: Talon of Pain deals X damage to target creature or player.",
             "colours": [],
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "d7f3fecf-226e-582f-b8c1-9e2654e91366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9915977-bd6b-477a-a495-f7ddbbeb82eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9915977-bd6b-477a-a495-f7ddbbeb82eb.jpg?1",
             "name": "Tangle Golem",
             "text": "Affinity for Forests (This spell costs {1} less to play for each Forest you control.)",
             "colours": [],
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "f5e3162d-0e99-511f-b210-94a72c022f43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0e921-b81a-4803-8e1b-f7ae556c1e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0e921-b81a-4803-8e1b-f7ae556c1e6f.jpg?1",
             "name": "Thought Dissector",
             "text": "{X}, {T}: Target opponent reveals cards from the top of his or her library until an artifact card or X cards are revealed, whichever comes first. If an artifact card is revealed this way, put it into play under your control and sacrifice Thought Dissector. Put the rest of the revealed cards into that player's graveyard.",
             "colours": [],
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "5a4a6eb0-3561-5fdc-ab9a-68c7f8a67b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d23ce7-3880-40e7-985b-a8dce97ff77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d23ce7-3880-40e7-985b-a8dce97ff77c.jpg?1",
             "name": "Thunderstaff",
             "text": "If Thunderstaff is untapped and a creature would deal combat damage to you, prevent 1 of that damage.\n{2}, {T}: Attacking creatures get +1/+0 until end of turn.",
             "colours": [],
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "d2cba4f3-f556-59d5-b6b4-eff7d8371105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d465597a-362e-4bd0-b547-f11d8807e597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d465597a-362e-4bd0-b547-f11d8807e597.jpg?1",
             "name": "Trinisphere",
             "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to play costs three mana to play. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to play costs {2}{B} to play instead.)",
             "colours": [],
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "987cf3be-ebc3-5258-a59f-f4a17a5b015f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cd61eb-a526-46db-8675-334663e0d63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cd61eb-a526-46db-8675-334663e0d63a.jpg?1",
             "name": "Ur-Golem's Eye",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "5dbf217a-dff8-5bde-9f50-2992c4c42aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ca55ec-d262-40d8-b654-40e177bcfd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ca55ec-d262-40d8-b654-40e177bcfd6e.jpg?1",
             "name": "Voltaic Construct",
             "text": "{2}: Untap target artifact creature.",
             "colours": [],
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "3330b203-ac82-55ba-bcd0-5eeeb00096d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf00de0-af24-4ef9-8ac2-135e6b53a8fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf00de0-af24-4ef9-8ac2-135e6b53a8fd.jpg?1",
             "name": "Vulshok Morningstar",
             "text": "Equipped creature gets +2/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "e8470a8b-0063-56ca-bec4-c02247dcd845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1131c187-8fc3-4cee-9422-355ef6622de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1131c187-8fc3-4cee-9422-355ef6622de7.jpg?1",
             "name": "Wand of the Elements",
             "text": "{T}, Sacrifice an Island: Put a 2/2 blue Elemental creature token with flying into play.\n{T}, Sacrifice a Mountain: Put a 3/3 red Elemental creature token into play.",
             "colours": [],
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "38b1c8b5-6edc-5f45-aac0-407cec74ec9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf1b915-7790-43f4-b308-a80a1be6ec29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf1b915-7790-43f4-b308-a80a1be6ec29.jpg?1",
             "name": "Well of Lost Dreams",
             "text": "Whenever you gain life, you may pay {X}, where X is less than or equal to the amount of life you gained. If you do, draw X cards.",
             "colours": [],
@@ -5044,7 +5044,7 @@
         },
         {
             "id": "6beb596f-0b7e-5610-b162-e8e15a6665ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4fdefd-8774-400d-bea6-4064d87383f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4fdefd-8774-400d-bea6-4064d87383f1.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable and can't be the target of spells or abilities.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "4f452889-6501-50d0-94fc-c78f4f8949e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb7e06-748c-4fc0-adc5-f8f2ec62029a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb7e06-748c-4fc0-adc5-f8f2ec62029a.jpg?1",
             "name": "Wirefly Hive",
             "text": "{3}, {T}: Flip a coin. If you win the flip, put a 2/2 Wirefly artifact creature token with flying into play. If you lose the flip, destroy all Wireflies.",
             "colours": [],
@@ -5102,7 +5102,7 @@
         },
         {
             "id": "2d275458-31f7-5134-b17b-90c51251fbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482cdbe0-b865-4e09-bd30-61ab93739b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482cdbe0-b865-4e09-bd30-61ab93739b53.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player plays a green spell, you may gain 1 life.",
             "colours": [],
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "5eff4cda-a902-5231-8ac9-a7f47ae1eb02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf51c665-7823-4d6a-b1da-8c2d93dae10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf51c665-7823-4d6a-b1da-8c2d93dae10b.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth gets +1/+1 until end of turn.",
             "colours": [],
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "cd90f41e-8403-5b0a-88ef-95487157def7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d0e808-d67b-4ea3-9c04-d20269fe692c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d0e808-d67b-4ea3-9c04-d20269fe692c.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Darksteel Citadel is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "d9f86b21-9463-567a-9103-94ae551c2518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0e60c9-1548-4981-ada1-6656804a772e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0e60c9-1548-4981-ada1-6656804a772e.jpg?1",
             "name": "Mirrodin's Core",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Put a charge counter on Mirrodin's Core.\n{T}, Remove a charge counter from Mirrodin's Core: Add one mana of any color to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/DTK.json
+++ b/Assets/Resources/Sets/DTK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "aee44480-bc11-53d9-a862-518058b354e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d62d6-8abf-4693-974c-bef6841b394f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d62d6-8abf-4693-974c-bef6841b394f.jpg?1",
             "name": "Scion of Ugin",
             "text": "Flying",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "86cb7e5f-7042-5134-9ed9-57cd3af38f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55611f05-10cf-42d0-b93e-7f0c0c852a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55611f05-10cf-42d0-b93e-7f0c0c852a06.jpg?1",
             "name": "Anafenza, Kin-Tree Spirit",
             "text": "Whenever another nontoken creature enters the battlefield under your control, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "3038dd92-6290-5003-b610-956d7f00b7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88ecc5-df1d-47e6-8cf3-1d708e2389e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88ecc5-df1d-47e6-8cf3-1d708e2389e4.jpg?1",
             "name": "Arashin Foremost",
             "text": "Double strike\nWhenever Arashin Foremost enters the battlefield or attacks, another target Warrior creature you control gains double strike until end of turn.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "383a836b-e636-57c8-81dd-2c0149dfacd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaf67e-ba97-4af9-8c47-dbca703cba35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaf67e-ba97-4af9-8c47-dbca703cba35.jpg?1",
             "name": "Artful Maneuver",
             "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "1aefb80b-df80-52ba-afbf-60e79f5de00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a54b36b-5a8d-41a1-9371-1a59d81c2733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a54b36b-5a8d-41a1-9371-1a59d81c2733.jpg?1",
             "name": "Aven Sunstriker",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)\nMegamorph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "47a8f2a6-5b16-56c4-a347-c2922e950222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dfc3ec-ca06-40a6-b77c-c2432af9802f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dfc3ec-ca06-40a6-b77c-c2432af9802f.jpg?1",
             "name": "Aven Tactician",
             "text": "Flying\nWhen Aven Tactician enters the battlefield, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "0fa6ad36-6bc1-54d6-90e7-bba37deb03d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e3cab-3d01-4e8b-bb28-20d45acccdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e3cab-3d01-4e8b-bb28-20d45acccdbf.jpg?1",
             "name": "Battle Mastery",
             "text": "Enchant creature\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "2f7c5504-3689-5463-9c1e-e33c926b58db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfca3763-9823-4fa4-968d-c701434b3d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfca3763-9823-4fa4-968d-c701434b3d28.jpg?1",
             "name": "Center Soul",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "89eaeca5-cc68-5d61-8145-fc5e6a8921d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5635c8f2-164c-4a13-965a-9432d07092ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5635c8f2-164c-4a13-965a-9432d07092ed.jpg?1",
             "name": "Champion of Arashin",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "ff6585b9-075f-5968-bb3a-e076d5ef44b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a0362-b973-445a-a355-5a2f3dc67f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a0362-b973-445a-a355-5a2f3dc67f16.jpg?1",
             "name": "Dragon Hunter",
             "text": "Protection from Dragons\nDragon Hunter can block Dragons as though it had reach.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "ef4dce37-ca34-5e68-bfdf-07ecf9f164f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750880cd-59bf-4b67-a2d5-9b66e4d05665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750880cd-59bf-4b67-a2d5-9b66e4d05665.jpg?1",
             "name": "Dragon's Eye Sentry",
             "text": "Defender, first strike",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "abd53c68-ee6a-594a-9e2a-0c5db6722c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d11837c-613f-4e36-b5dd-99baf8b38532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d11837c-613f-4e36-b5dd-99baf8b38532.jpg?1",
             "name": "Dromoka Captain",
             "text": "First strike\nWhenever Dromoka Captain attacks, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "41f8b102-5e10-5435-a4f8-b59f65db9042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e542-4bcc-43e1-9616-64ce40348a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e542-4bcc-43e1-9616-64ce40348a34.jpg?1",
             "name": "Dromoka Dunecaster",
             "text": "{1}{W}, {T}: Tap target creature without flying.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "59d77f1b-7e81-5156-a5a4-56d1343ebc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ae001b-556f-4576-8cf4-0b8902997bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ae001b-556f-4576-8cf4-0b8902997bb1.jpg?1",
             "name": "Dromoka Warrior",
             "text": "",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "096c8728-f265-5761-b551-0fbb2fa35b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531414e6-ea72-4934-b05e-e1782249fd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531414e6-ea72-4934-b05e-e1782249fd1f.jpg?1",
             "name": "Echoes of the Kin Tree",
             "text": "{2}{W}: Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "b7fefa73-d5bf-5fb1-88b3-e08e570f1381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fef763-7ee2-4341-9c67-546e4b6710b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fef763-7ee2-4341-9c67-546e4b6710b7.jpg?1",
             "name": "Enduring Victory",
             "text": "Destroy target attacking or blocking creature. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -549,7 +549,7 @@
         },
         {
             "id": "2390604b-8e50-582c-885c-875ac817b0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2161d9-ad52-45a6-9be9-e7ff09ec8f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2161d9-ad52-45a6-9be9-e7ff09ec8f5a.jpg?1",
             "name": "Fate Forgotten",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "1c102879-aeee-56d5-8215-fe04f2e5af02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f66474-05bb-4235-b8b4-c2e6452118fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f66474-05bb-4235-b8b4-c2e6452118fc.jpg?1",
             "name": "Glaring Aegis",
             "text": "Enchant creature\nWhen Glaring Aegis enters the battlefield, tap target creature an opponent controls.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "9c9bf39e-56ec-5a9a-981a-c1aa3c29dd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96847438-eb09-4e3f-8ebf-f064b88f70c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96847438-eb09-4e3f-8ebf-f064b88f70c9.jpg?1",
             "name": "Gleam of Authority",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each +1/+1 counter on other creatures you control.\nEnchanted creature has vigilance and \"{W}, {T}: Bolster 1.\" (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "fa23de08-5186-59e0-9f3f-28f734af4e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedcf6c-5796-4843-b6b8-df78e11e72c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedcf6c-5796-4843-b6b8-df78e11e72c2.jpg?1",
             "name": "Graceblade Artisan",
             "text": "Graceblade Artisan gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "d04590e3-5768-51d6-ba98-74f749d1d415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce2761c-20ee-497a-8c05-947a1ac93e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce2761c-20ee-497a-8c05-947a1ac93e57.jpg?1",
             "name": "Great Teacher's Decree",
             "text": "Creatures you control get +2/+1 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "4937fb67-a3a5-5e62-9589-069c365450ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987b2af-66d6-4271-a139-37e544cdec62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987b2af-66d6-4271-a139-37e544cdec62.jpg?1",
             "name": "Herald of Dromoka",
             "text": "Vigilance\nOther Warrior creatures you control have vigilance.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "1abb9935-00ee-51a9-93d6-a1b3b3e591bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c760a8-e051-4584-ae1b-178164b84427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c760a8-e051-4584-ae1b-178164b84427.jpg?1",
             "name": "Hidden Dragonslayer",
             "text": "Lifelink\nMegamorph {2}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Hidden Dragonslayer is turned face up, destroy target creature with power 4 or greater an opponent controls.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "8f448b6f-77c4-5aba-b973-916af754ff9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bf1837-41b0-4ff1-9cb1-ee2d75d410c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bf1837-41b0-4ff1-9cb1-ee2d75d410c7.jpg?1",
             "name": "Lightwalker",
             "text": "Lightwalker has flying as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -821,7 +821,7 @@
         },
         {
             "id": "e319b50f-bf02-5c56-b892-f2fe8e3917b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef8595-96e8-4df3-aa5a-9fc8c5fa9a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef8595-96e8-4df3-aa5a-9fc8c5fa9a3d.jpg?1",
             "name": "Misthoof Kirin",
             "text": "Flying, vigilance\nMegamorph {1}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "627c71d7-afbb-5bef-be33-3071f3d607a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd9f67-32a7-4022-bb53-5bfc671520c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd9f67-32a7-4022-bb53-5bfc671520c7.jpg?1",
             "name": "Myth Realized",
             "text": "Whenever you cast a noncreature spell, put a lore counter on Myth Realized.\n{2}{W}: Put a lore counter on Myth Realized.\n{W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\"",
             "colours": [
@@ -887,7 +887,7 @@
         },
         {
             "id": "a35d827f-3889-5807-8148-57fb2ed1d8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1205482-2f9d-463e-893f-18998aaf09c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1205482-2f9d-463e-893f-18998aaf09c6.jpg?1",
             "name": "Ojutai Exemplars",
             "text": "Whenever you cast a noncreature spell, choose one \u2014\n\u2022 Tap target creature.\n\u2022 Ojutai Exemplars gains first strike and lifelink until of turn.\n\u2022 Exile Ojutai Exemplars, then return it to the battlefield tapped under its owner's control.",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "ef1b829a-e5de-55f8-a2dd-bb23a1561a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc68c7d8-60fa-4e55-92c1-43fcf5e9abf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc68c7d8-60fa-4e55-92c1-43fcf5e9abf1.jpg?1",
             "name": "Orator of Ojutai",
             "text": "As an additional cost to cast Orator of Ojutai, you may reveal a Dragon card from your hand.\nDefender, flying\nWhen Orator of Ojutai enters the battlefield, if you revealed a Dragon card or controlled a Dragon as you cast Orator of Ojutai, draw a card.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "d43ff56a-1ceb-5669-9a33-2092473a1da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7939502-d6aa-4bde-b42f-67ed433f95f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7939502-d6aa-4bde-b42f-67ed433f95f1.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "f39080d9-0ab0-56f7-9763-7c4c614db9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg?1",
             "name": "Profound Journey",
             "text": "Return target permanent card from your graveyard to the battlefield.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "afe3ac5b-2cb3-5475-9913-72e0cf437f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d94f4-c504-4cf1-9bc7-d318fbee54d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d94f4-c504-4cf1-9bc7-d318fbee54d7.jpg?1",
             "name": "Radiant Purge",
             "text": "Exile target multicolored creature or multicolored enchantment.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "1ad6f74a-0e42-5016-9fb5-95f9cf02c7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf47c52-4065-4b81-acdc-878e74767bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf47c52-4065-4b81-acdc-878e74767bba.jpg?1",
             "name": "Resupply",
             "text": "You gain 6 life.\nDraw a card.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "457764d1-2e1e-5357-9079-05d99104630f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8998b4a5-d94b-45b3-b619-bd850e240ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8998b4a5-d94b-45b3-b619-bd850e240ce0.jpg?1",
             "name": "Sandcrafter Mage",
             "text": "When Sandcrafter Mage enters the battlefield, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "780e841d-94f6-57e6-8904-f0e8b5aa80a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757be26-4480-43b7-a38a-8e4bde4e2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757be26-4480-43b7-a38a-8e4bde4e2d50.jpg?1",
             "name": "Sandstorm Charger",
             "text": "Megamorph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "01a72980-f328-577f-a23f-205fc6e10e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76515a0-31eb-4bba-bf07-1f9fde423e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76515a0-31eb-4bba-bf07-1f9fde423e24.jpg?1",
             "name": "Scale Blessing",
             "text": "Bolster 1, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "ceb42101-7d73-5145-a307-c4dbabb6f129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d2f5f-b228-4190-ade9-52e2a8056847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d2f5f-b228-4190-ade9-52e2a8056847.jpg?1",
             "name": "Secure the Wastes",
             "text": "Put X 1/1 white Warrior creature tokens onto the battlefield.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "277edfc8-5e73-57e0-9d56-23b227491760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd0af4-44e1-424b-8e55-87f84a42d40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd0af4-44e1-424b-8e55-87f84a42d40a.jpg?1",
             "name": "Shieldhide Dragon",
             "text": "Flying, lifelink\nMegamorph {5}{W}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Shieldhide Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "359049d9-b7d1-5c58-b98a-ee64e1f33751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ee9009-59a7-40e6-bf1a-1d26d4b399e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ee9009-59a7-40e6-bf1a-1d26d4b399e8.jpg?1",
             "name": "Silkwrap",
             "text": "When Silkwrap enters the battlefield, exile target creature with converted mana cost 3 or less an opponent controls until Silkwrap leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "ce9d8eb1-bce8-5bf1-8126-81f196713465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5f5ead-b9e0-44c0-893f-0e3ae01933d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5f5ead-b9e0-44c0-893f-0e3ae01933d3.jpg?1",
             "name": "Strongarm Monk",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "57f69c47-8d80-56f2-b29b-7e9a02325e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d06616c-a0df-4d2d-8bfc-9f59060d323b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d06616c-a0df-4d2d-8bfc-9f59060d323b.jpg?1",
             "name": "Student of Ojutai",
             "text": "Whenever you cast a noncreature spell, you gain 2 life.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "56fc81b8-9bca-588f-a19a-3d2bd6644964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e638-f478-40b8-8c89-120746b7cefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e638-f478-40b8-8c89-120746b7cefd.jpg?1",
             "name": "Sunscorch Regent",
             "text": "Flying\nWhenever an opponent casts a spell, put a +1/+1 counter on Sunscorch Regent and you gain 1 life.",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "972dd5dc-f2b9-5358-96a4-da8a8e34ac2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114366f3-237f-4f96-b644-5bd82d97b18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114366f3-237f-4f96-b644-5bd82d97b18b.jpg?1",
             "name": "Surge of Righteousness",
             "text": "Destroy target black or red creature that's attacking or blocking. You gain 2 life.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "5e6b8c2b-afc4-598e-94d9-2113a15ed046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c83aa5e-b607-4c4f-a5f6-db61c93a1152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c83aa5e-b607-4c4f-a5f6-db61c93a1152.jpg?1",
             "name": "Territorial Roc",
             "text": "Flying",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "b2fc0f64-a59a-51ce-acb6-602f490b0f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fef6e95-e7f1-4646-be5e-130c8b5a3ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fef6e95-e7f1-4646-be5e-130c8b5a3ca6.jpg?1",
             "name": "Ancient Carp",
             "text": "",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "75580c84-60ef-5db4-b891-d68ee7f254e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028d9e8-002f-43a1-bdce-0db0b6a642b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028d9e8-002f-43a1-bdce-0db0b6a642b0.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "2c8f26b4-0105-56e9-8697-f0ea747d93a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8fba0-fcb4-440c-9442-92278e21c5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8fba0-fcb4-440c-9442-92278e21c5e9.jpg?1",
             "name": "Belltoll Dragon",
             "text": "Flying, hexproof\nMegamorph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Belltoll Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "ae1783f0-e2cb-5a00-991b-48831496f740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401cd79d-638e-43b4-8d0c-d7af05c55a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401cd79d-638e-43b4-8d0c-d7af05c55a1a.jpg?1",
             "name": "Blessed Reincarnation",
             "text": "Exile target creature an opponent controls. That player reveals cards from the top of his or her library until a creature card is revealed. The player puts that card onto the battlefield, then shuffles the rest into his or her library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "fb65c743-cda4-554e-9480-37dd0ecf1e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c6a201-1d4d-4ae5-a84e-098e094eaf61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c6a201-1d4d-4ae5-a84e-098e094eaf61.jpg?1",
             "name": "Clone Legion",
             "text": "For each creature target player controls, put a token onto the battlefield that's a copy of that creature.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "0fa0ca0f-2171-520b-9332-1644e3a353f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b3d4ff-09d1-4d9f-8c83-cdfbd7bb1079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b3d4ff-09d1-4d9f-8c83-cdfbd7bb1079.jpg?1",
             "name": "Contradict",
             "text": "Counter target spell.\nDraw a card.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "44bc67fb-6dee-5565-a0b7-8b2af52c5cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c548d140-3d81-4b33-9985-87703d316a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c548d140-3d81-4b33-9985-87703d316a83.jpg?1",
             "name": "Dance of the Skywise",
             "text": "Until end of turn, target creature you control becomes a blue Dragon Illusion with base power and toughness 4/4, loses all abilities, and gains flying.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "03e07e06-3674-54f5-80c8-fb7108f5b3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c388de-c2c9-4975-9eac-86a8030a9884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c388de-c2c9-4975-9eac-86a8030a9884.jpg?1",
             "name": "Dirgur Nemesis",
             "text": "Defender\nMegamorph {6}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "b1f0d601-bb0f-52a6-bbd7-d626495cbee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f2d2b3-6e48-413e-ad8f-9ce40c7ff167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f2d2b3-6e48-413e-ad8f-9ce40c7ff167.jpg?1",
             "name": "Dragonlord's Prerogative",
             "text": "As an additional cost to cast Dragonlord's Prerogative, you may reveal a Dragon card from your hand.\nIf you revealed a Dragon card or controlled a Dragon as you cast Dragonlord's Prerogative, Dragonlord's Prerogative can't be countered.\nDraw four cards.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "8187f38d-fc71-5548-af1b-0da9140b9be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13b8c2-9d7d-44d8-8934-16458e7267dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13b8c2-9d7d-44d8-8934-16458e7267dc.jpg?1",
             "name": "Elusive Spellfist",
             "text": "Whenever you cast a noncreature spell, Elusive Spellfist gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "583c45dd-1d2c-537e-9b37-d0cbb534c1ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcad5bd9-3236-48d4-920f-c3ed12d5f329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcad5bd9-3236-48d4-920f-c3ed12d5f329.jpg?1",
             "name": "Encase in Ice",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant red or green creature\nWhen Encase in Ice enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "b4707d93-02bd-5f25-a9c0-c10b5903f75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fa105f-c76b-4fd0-9b83-34b46648e0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fa105f-c76b-4fd0-9b83-34b46648e0d6.jpg?1",
             "name": "Glint",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "acf20c1c-6421-5165-825d-957f9069e26e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84d5344-2d15-43da-b536-27e0d308606b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84d5344-2d15-43da-b536-27e0d308606b.jpg?1",
             "name": "Gudul Lurker",
             "text": "Gudul Lurker can't be blocked.\nMegamorph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "bf57a89f-a07c-5520-915d-709c20417f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5087a664-6ed7-43a1-8851-71bbee204eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5087a664-6ed7-43a1-8851-71bbee204eb1.jpg?1",
             "name": "Gurmag Drowner",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Gurmag Drowner exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "e553dbd0-5a4a-5f61-8492-8113083618ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbbd377-4617-4285-b367-98418a588dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbbd377-4617-4285-b367-98418a588dab.jpg?1",
             "name": "Icefall Regent",
             "text": "Flying\nWhen Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent.\nSpells your opponents cast that target Icefall Regent cost {2} more to cast.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "c56fd790-cb53-5c52-90e0-23a2a8e4b9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747dfb21-a00c-46ba-9da3-739f570e1246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747dfb21-a00c-46ba-9da3-739f570e1246.jpg?1",
             "name": "Illusory Gains",
             "text": "Enchant creature\nYou control enchanted creature.\nWhenever a creature enters the battlefield under an opponent's control, attach Illusory Gains to that creature.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "f4b40b83-6490-5fe9-b311-1242c6769fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c6e76-dba4-4448-a4f4-d9591d4539c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c6e76-dba4-4448-a4f4-d9591d4539c7.jpg?1",
             "name": "Learn from the Past",
             "text": "Target player shuffles his or her graveyard into his or her library.\nDraw a card.",
             "colours": [
@@ -2020,7 +2020,7 @@
         },
         {
             "id": "396b6a60-0838-542b-b53c-41ea392b170b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f658281-1c6c-4450-8d75-81714dbd0472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f658281-1c6c-4450-8d75-81714dbd0472.jpg?1",
             "name": "Living Lore",
             "text": "As Living Lore enters the battlefield, exile an instant or sorcery card from your graveyard.\nLiving Lore's power and toughness are each equal to the exiled card's converted mana cost.\nWhenever Living Lore deals combat damage, you may sacrifice it. If you do, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "2f7b8b4c-bf93-5cdd-af42-36ccd4f9ef8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837b050-70a6-46f0-963d-4badb37a42a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837b050-70a6-46f0-963d-4badb37a42a1.jpg?1",
             "name": "Mirror Mockery",
             "text": "Enchant creature\nWhenever enchanted creature attacks, you may put a token onto the battlefield that's a copy of that creature. Exile that token at end of combat.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "c671e400-5783-5c77-8c50-b2610009b8ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b9d8de-5746-4af0-9353-a19fa977df41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b9d8de-5746-4af0-9353-a19fa977df41.jpg?1",
             "name": "Monastery Loremaster",
             "text": "Megamorph {5}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Monastery Loremaster is turned face up, return target noncreature, nonland card from your graveyard to your hand.",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "b4a53e0a-812c-557c-b567-b62b45b8493d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169f469-10d5-4ae8-88fe-12a8e20ab01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169f469-10d5-4ae8-88fe-12a8e20ab01b.jpg?1",
             "name": "Mystic Meditation",
             "text": "Draw three cards. Then discard two cards unless you discard a creature card.",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "b9baf6b3-f404-5c19-abe9-0031dbf7613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60380ed0-fed1-4d68-9763-56a9ff8ac5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60380ed0-fed1-4d68-9763-56a9ff8ac5e6.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "89725140-e439-56aa-bea1-ecaa0f041ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a84666-ad2b-494c-b52b-ecee14788ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a84666-ad2b-494c-b52b-ecee14788ef2.jpg?1",
             "name": "Ojutai Interceptor",
             "text": "Flying\nMegamorph {3}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "4e207e89-95cb-5778-bd33-23855a76a6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af51e5a1-7d46-4dad-a25c-6767cbd03dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af51e5a1-7d46-4dad-a25c-6767cbd03dff.jpg?1",
             "name": "Ojutai's Breath",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "a29c3ae7-525b-5da5-9e56-63e1f53f3817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769341a-1331-456d-a2bb-cd7fffe7b51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769341a-1331-456d-a2bb-cd7fffe7b51d.jpg?1",
             "name": "Ojutai's Summons",
             "text": "Put a 2/2 blue Djinn Monk creature token with flying onto the battlefield.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "085e9948-570d-5b12-977d-1bdbb6ca6a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0c17c9-54af-4dd4-8d4a-fd5a7b8c3c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0c17c9-54af-4dd4-8d4a-fd5a7b8c3c77.jpg?1",
             "name": "Palace Familiar",
             "text": "Flying\nWhen Palace Familiar dies, draw a card.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "551df7ec-f2ad-54e7-82f0-a1454e80c9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87630910-47cc-4347-b126-fd779e7dadc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87630910-47cc-4347-b126-fd779e7dadc0.jpg?1",
             "name": "Profaner of the Dead",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Profaner of the Dead exploits a creature, return to their owners' hands all creatures your opponents control with toughness less than the exploited creature's toughness.",
             "colours": [
@@ -2355,7 +2355,7 @@
         },
         {
             "id": "7a6f9cc5-336a-5abf-baff-918fffd7a6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d64264-895f-4d4d-8e5c-ab1d0d6e340b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d64264-895f-4d4d-8e5c-ab1d0d6e340b.jpg?1",
             "name": "Qarsi Deceiver",
             "text": "{T}: Add {1} to your mana pool. Spend this mana only to cast a face-down creature spell, pay a mana cost to turn a manifested creature face up, or pay a morph cost. (A megamorph cost is a morph cost.)",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "eb8bb124-6e5a-5319-9b98-8c0bfb9ac383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad1d13-c4f6-4440-9988-e1db40039f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad1d13-c4f6-4440-9988-e1db40039f02.jpg?1",
             "name": "Reduce in Stature",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/2.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "f292e1b2-420b-5dba-abb7-fbcb82578ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8890fc6-45e9-443d-ae86-f1acb1ebd0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8890fc6-45e9-443d-ae86-f1acb1ebd0aa.jpg?1",
             "name": "Shorecrasher Elemental",
             "text": "{U}: Exile Shorecrasher Elemental, then return it to the battlefield face down under its owner's control.\n{1}: Shorecrasher Elemental gets +1/-1 or -1/+1 until end of turn.\nMegamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "e0b0e245-513f-5b98-b005-34db5cfbacad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d02daad9-701f-40d4-ad0b-44a3cbd32c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d02daad9-701f-40d4-ad0b-44a3cbd32c3f.jpg?1",
             "name": "Sidisi's Faithful",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "d263f475-4097-5e81-9a84-1f4d981c04da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0df83-fe20-497f-b372-1d2e4d7c8df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0df83-fe20-497f-b372-1d2e4d7c8df9.jpg?1",
             "name": "Sight Beyond Sight",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "cce6b1ba-959b-590e-8ccf-834f73276a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a914304-e774-49fd-9ac7-09e36989b1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a914304-e774-49fd-9ac7-09e36989b1d5.jpg?1",
             "name": "Silumgar Sorcerer",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Silumgar Sorcerer exploits a creature, counter target creature spell.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "1ec07d11-5b1e-5c7e-aef8-b6baf4d18b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a99655-34b2-4756-bf12-b344eb71ad37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a99655-34b2-4756-bf12-b344eb71ad37.jpg?1",
             "name": "Silumgar Spell-Eater",
             "text": "Megamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Silumgar Spell-Eater is turned face up, counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "147a03d4-f5cb-5aa2-962f-d73b63cc4565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bee72-62f6-4d90-8557-ff9cac42ec9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bee72-62f6-4d90-8557-ff9cac42ec9a.jpg?1",
             "name": "Silumgar's Scorn",
             "text": "As an additional cost to cast Silumgar's Scorn, you may reveal a Dragon card from your hand.\nCounter target spell unless its controller pays {1}. If you revealed a Dragon card or controlled a Dragon as you cast Silumgar's Scorn, counter that spell instead.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "59ba3abe-5f2a-54ec-82d7-cbdff833f98a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87875281-12d1-45b9-b1a9-fe0ae7448ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87875281-12d1-45b9-b1a9-fe0ae7448ab8.jpg?1",
             "name": "Skywise Teachings",
             "text": "Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, put a 2/2 blue Djinn Monk creature token with flying onto the battlefield.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "e446f088-52e9-5f89-9602-817b147e03e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bf4f37-2a2e-4c49-88dc-a26dd7367afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bf4f37-2a2e-4c49-88dc-a26dd7367afb.jpg?1",
             "name": "Stratus Dancer",
             "text": "Flying\nMegamorph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Stratus Dancer is turned face up, counter target instant or sorcery spell.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "f68feeb8-69fd-5c0c-ba19-2b0465ebd9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef5e279-14c4-4f91-b24d-c7098140efcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef5e279-14c4-4f91-b24d-c7098140efcd.jpg?1",
             "name": "Taigam's Strike",
             "text": "Target creature gets +2/+0 until end of turn and can't be blocked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "957c93f1-b13f-5319-a5c6-0fda7db0ad50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621c700-569d-4d07-847e-68b97113415f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621c700-569d-4d07-847e-68b97113415f.jpg?1",
             "name": "Updraft Elemental",
             "text": "Flying",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "6c82ab9e-4d63-5fe3-98e8-6a6dd6bedcd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a7aee-6403-44ce-a119-66147aa311fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a7aee-6403-44ce-a119-66147aa311fd.jpg?1",
             "name": "Void Squall",
             "text": "Return target nonland permanent to its owner's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "8c5c7160-5307-590b-85f2-8d79110dcc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ae8147-bf25-44f9-b75f-837b81ebe0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ae8147-bf25-44f9-b75f-837b81ebe0de.jpg?1",
             "name": "Youthful Scholar",
             "text": "When Youthful Scholar dies, draw two cards.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "3df60f70-7923-5e0a-a605-8c141afef475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ae0d2-0ca1-4095-8710-be5800e389cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ae0d2-0ca1-4095-8710-be5800e389cd.jpg?1",
             "name": "Zephyr Scribe",
             "text": "{U}, {T}: Draw a card, then discard a card.\nWhenever you cast a noncreature spell, untap Zephyr Scribe.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "72d82ff2-b291-5d85-959a-775b45a73d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f58f1-4843-4926-b3c4-98898201c216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f58f1-4843-4926-b3c4-98898201c216.jpg?1",
             "name": "Acid-Spewer Dragon",
             "text": "Flying, deathtouch\nMegamorph {5}{B}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Acid-Spewer Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "e5b5fe8c-3ea4-5cec-b912-f27d1c82783b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a91f8-5f9f-46a2-bd80-1ca014591de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a91f8-5f9f-46a2-bd80-1ca014591de9.jpg?1",
             "name": "Ambuscade Shaman",
             "text": "Whenever Ambuscade Shaman or another creature enters the battlefield under your control, that creature gets +2/+2 until end of turn.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "d4f2bf65-292d-5d2e-bc23-17ce18cbc9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb00d55-de56-4bbb-9545-e8cfb25a4f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb00d55-de56-4bbb-9545-e8cfb25a4f23.jpg?1",
             "name": "Blood-Chin Fanatic",
             "text": "{1}{B}, Sacrifice another Warrior creature: Target player loses X life and you gain X life, where X is the sacrificed creature's power.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "784398fe-7e6e-5a8c-84b4-7a66ca720e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e93684-a587-4510-b48b-ecf27ff695f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e93684-a587-4510-b48b-ecf27ff695f4.jpg?1",
             "name": "Blood-Chin Rager",
             "text": "Whenever Blood-Chin Rager attacks, each Warrior creature you control can't be blocked this turn except by two or more creatures.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "ebdd3b42-869f-597d-8d52-b51bf9f72525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e7919e-6190-4f3c-99f7-faa666d34f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e7919e-6190-4f3c-99f7-faa666d34f79.jpg?1",
             "name": "Butcher's Glee",
             "text": "Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -3033,7 +3033,7 @@
         },
         {
             "id": "887a0f7b-6780-5c06-a378-b202c58904b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e012-7043-405c-b6cd-b3b38f8a8d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e012-7043-405c-b6cd-b3b38f8a8d54.jpg?1",
             "name": "Coat with Venom",
             "text": "Target creature gets +1/+2 and gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "f4ab3542-486f-5e01-885d-8054ce7379a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cf24e7-2e6e-46e0-aedd-89e17953811c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cf24e7-2e6e-46e0-aedd-89e17953811c.jpg?1",
             "name": "Corpseweft",
             "text": "{1}{B}, Exile one or more creature cards from your graveyard: Put an X/X black Zombie Horror creature token onto the battlefield tapped, where X is twice the number of cards exiled this way.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "8666ec97-ce16-5380-932c-2a991d012086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65bcf62-48c3-4e4d-b129-8e03b3635326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65bcf62-48c3-4e4d-b129-8e03b3635326.jpg?1",
             "name": "Damnable Pact",
             "text": "Target player draws X cards and loses X life.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "45300689-e5e8-5c2f-9042-347115a61997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bb5d9f-9b12-482a-91b4-6786e8310805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bb5d9f-9b12-482a-91b4-6786e8310805.jpg?1",
             "name": "Deadly Wanderings",
             "text": "As long as you control exactly one creature, that creature gets +2/+0 and has deathtouch and lifelink.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "b25b3ceb-1e37-58f4-9cb4-7a8d6d1135b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ed0a14-1a98-4190-b195-f84fa42d4364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ed0a14-1a98-4190-b195-f84fa42d4364.jpg?1",
             "name": "Death Wind",
             "text": "Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "7694a2d1-e9e4-596f-a101-836c5028b279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cad378-129f-41da-8db2-065fc45c76eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cad378-129f-41da-8db2-065fc45c76eb.jpg?1",
             "name": "Deathbringer Regent",
             "text": "Flying\nWhen Deathbringer Regent enters the battlefield, if you cast it from your hand and there are five or more other creatures on the battlefield, destroy all other creatures.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "45c339f6-9fff-522c-b3c4-79e9c2e9ceda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60473300-0bdc-4e89-87d9-28c8d7b4d83d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60473300-0bdc-4e89-87d9-28c8d7b4d83d.jpg?1",
             "name": "Defeat",
             "text": "Destroy target creature with power 2 or less.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "35fe28b9-d9d2-5457-a2c7-a553f6b08a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e79c2c-1b4d-4f20-a769-94890c91b539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e79c2c-1b4d-4f20-a769-94890c91b539.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "cf00ae72-a075-53cb-b38d-037099660889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee71b19-eb1d-4f5a-a1b7-1799f2f50da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee71b19-eb1d-4f5a-a1b7-1799f2f50da0.jpg?1",
             "name": "Dutiful Attendant",
             "text": "When Dutiful Attendant dies, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "9fcf6cdf-8ec4-5d33-aa4b-f17820431c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2acae67-5238-40bb-a173-6fc858264a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2acae67-5238-40bb-a173-6fc858264a6c.jpg?1",
             "name": "Flatten",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "be35f0a0-8398-52bf-998b-1670c7c71dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e319b7ca-d0a4-43ff-8e87-2af6ead089f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e319b7ca-d0a4-43ff-8e87-2af6ead089f5.jpg?1",
             "name": "Foul Renewal",
             "text": "Return target creature card from your graveyard to your hand. Target creature gets -X/-X until end of turn, where X is the toughness of the card returned this way.",
             "colours": [
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "25b5ba4d-7c10-5536-88f3-b669ef810294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d021a-7bb8-4173-9a2f-e4a1d21fda8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d021a-7bb8-4173-9a2f-e4a1d21fda8e.jpg?1",
             "name": "Foul-Tongue Invocation",
             "text": "As an additional cost to cast Foul-Tongue Invocation, you may reveal a Dragon card from your hand.\nTarget player sacrifices a creature. If you revealed a Dragon card or controlled a Dragon as you cast Foul-Tongue Invocation, you gain 4 life.",
             "colours": [
@@ -3422,7 +3422,7 @@
         },
         {
             "id": "e145effd-0976-5718-8b86-b7fe237742ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d98ee0-6b32-4735-89f1-b37da766761f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d98ee0-6b32-4735-89f1-b37da766761f.jpg?1",
             "name": "Foul-Tongue Shriek",
             "text": "Target opponent loses 1 life for each attacking creature you control. You gain that much life.",
             "colours": [
@@ -3454,7 +3454,7 @@
         },
         {
             "id": "a5eeae57-f2a7-50d0-b7ab-f2c2b43f8940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf549c-799f-456f-85d5-8a7302bc729d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf549c-799f-456f-85d5-8a7302bc729d.jpg?1",
             "name": "Gravepurge",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "2dad1239-64a9-57e3-ac89-f746a6657bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884cbc26-f164-47bd-878c-dd46652465d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884cbc26-f164-47bd-878c-dd46652465d0.jpg?1",
             "name": "Hand of Silumgar",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "a55fcbf7-633f-5897-b738-fb9615d20080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b73bbf-39a8-4358-9af6-8f4f0b57c028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b73bbf-39a8-4358-9af6-8f4f0b57c028.jpg?1",
             "name": "Hedonist's Trove",
             "text": "When Hedonist's Trove enters the battlefield, exile all cards from target opponent's graveyard.\nYou may play land cards exiled with Hedonist's Trove.\nYou may cast nonland cards exiled with Hedonist's Trove. You can't cast more than one spell this way each turn.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "291600cd-0030-530c-822d-ee16775267f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced0adca-d11c-41b6-aec4-4799946425d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced0adca-d11c-41b6-aec4-4799946425d3.jpg?1",
             "name": "Kolaghan Skirmisher",
             "text": "Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "da7c0ac9-0cad-5e26-b414-86af8f74f24d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9497f7e6-2121-44a9-9bd6-258685636b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9497f7e6-2121-44a9-9bd6-258685636b1c.jpg?1",
             "name": "Marang River Skeleton",
             "text": "{B}: Regenerate Marang River Skeleton.\nMegamorph {3}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "65992b70-b107-5d88-ba90-422eb29bd496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff347b25-7ce9-42c4-811d-86f3e9c55d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff347b25-7ce9-42c4-811d-86f3e9c55d75.jpg?1",
             "name": "Marsh Hulk",
             "text": "Megamorph {6}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "25042f74-ce0f-53de-8a9e-c79d54b5071c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272180bd-6afc-4be6-993c-b761acdedec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272180bd-6afc-4be6-993c-b761acdedec3.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "d2f96402-a6e9-5cc0-86ae-ddf9c9d49805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf4c637-82c3-41fa-b484-31e7dcf475a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf4c637-82c3-41fa-b484-31e7dcf475a9.jpg?1",
             "name": "Minister of Pain",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Minister of Pain exploits a creature, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "a32a062b-ceca-56d1-8e45-8a9bbb170a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg?1",
             "name": "Pitiless Horde",
             "text": "At the beginning of your upkeep, you lose 2 life.\nDash {2}{B}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "9313d685-4234-5af4-852f-e96af9ac9ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068c44b9-0ba8-4275-b73d-18ad366f4b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068c44b9-0ba8-4275-b73d-18ad366f4b45.jpg?1",
             "name": "Qarsi Sadist",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Qarsi Sadist exploits a creature, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "35e233d8-aa10-553f-8e8e-cfe73d1de30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf584fd-b13b-4f86-9c9a-fa6514255aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf584fd-b13b-4f86-9c9a-fa6514255aba.jpg?1",
             "name": "Rakshasa Gravecaller",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Rakshasa Gravecaller exploits a creature, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "9bf23f81-112e-5fbf-a040-eec0287e6183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a44e0a-5fff-4fc0-a76d-1b097f1d4d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a44e0a-5fff-4fc0-a76d-1b097f1d4d5d.jpg?1",
             "name": "Reckless Imp",
             "text": "Flying\nReckless Imp can't block.\nDash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "04c12079-03c8-537b-804c-fd21131bcd6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ff5e62-b73e-4b85-b65f-5226e75c7f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ff5e62-b73e-4b85-b65f-5226e75c7f97.jpg?1",
             "name": "Risen Executioner",
             "text": "Risen Executioner can't block.\nOther Zombie creatures you control get +1/+1.\nYou may cast Risen Executioner from your graveyard if you pay {1} more to cast it for each other creature card in your graveyard.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "ff92bcfa-c897-5059-a06c-8f0f74585826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b1a5d-fb17-43f0-bf29-4ade853e0e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b1a5d-fb17-43f0-bf29-4ade853e0e6e.jpg?1",
             "name": "Self-Inflicted Wound",
             "text": "Target opponent sacrifices a green or white creature. If that player does, he or she loses 2 life.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "ee146b59-eca3-5624-8e5f-e59206ca5aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9404c7d5-3450-4425-94e5-aa7d4e571d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9404c7d5-3450-4425-94e5-aa7d4e571d4e.jpg?1",
             "name": "Shambling Goblin",
             "text": "When Shambling Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "08c49f94-ded9-5ee1-a590-8cfab1d41698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3835752e-11a6-406c-8bff-b7d4f2f31d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3835752e-11a6-406c-8bff-b7d4f2f31d85.jpg?1",
             "name": "Sibsig Icebreakers",
             "text": "When Sibsig Icebreakers enters the battlefield, each player discards a card.",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "e93dd219-9064-5f86-8028-a965fc759074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5dbba-6114-4d97-9363-817ab9e896d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5dbba-6114-4d97-9363-817ab9e896d3.jpg?1",
             "name": "Sidisi, Undead Vizier",
             "text": "Deathtouch\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Sidisi, Undead Vizier exploits a creature, you may search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4036,7 +4036,7 @@
         },
         {
             "id": "e7deaa10-8081-5fb7-a1ae-22b0fa11bb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc4693f-59fe-4671-b8c6-66fe53a76bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc4693f-59fe-4671-b8c6-66fe53a76bbe.jpg?1",
             "name": "Silumgar Assassin",
             "text": "Creatures with power greater than Silumgar Assassin's power can't block it.\nMegamorph {2}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Silumgar Assassin is turned face up, destroy target creature with power 3 or less an opponent controls.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "68dbd7d5-2b87-5d3a-8856-68136af7d9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cb67f7-b4e1-423b-8f55-d44ed383e778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cb67f7-b4e1-423b-8f55-d44ed383e778.jpg?1",
             "name": "Silumgar Butcher",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Silumgar Butcher exploits a creature, target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "2fb3c544-8099-5ada-b51f-7f885604fb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d2f6ee-af76-48f0-898d-3a19698d2790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d2f6ee-af76-48f0-898d-3a19698d2790.jpg?1",
             "name": "Ukud Cobra",
             "text": "Deathtouch",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "465fe5b5-cd45-57ed-94cc-0340ba11b607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41f7cf3-bd76-4184-b694-f565aa5cf3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41f7cf3-bd76-4184-b694-f565aa5cf3a4.jpg?1",
             "name": "Ultimate Price",
             "text": "Destroy target monocolored creature.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "44c604e1-aa40-5bbc-90ed-cf1306fe7906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f82b6-53d9-43ce-8a17-c680c443e586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f82b6-53d9-43ce-8a17-c680c443e586.jpg?1",
             "name": "Virulent Plague",
             "text": "Creature tokens get -2/-2.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "d057cdee-e74f-5d30-90ed-98a1e1243f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fb0cc9-aebd-4bbf-8735-add3b753c118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fb0cc9-aebd-4bbf-8735-add3b753c118.jpg?1",
             "name": "Vulturous Aven",
             "text": "Flying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Vulturous Aven exploits a creature, you draw two cards and you lose 2 life.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "60fc623f-b7a0-5d0b-aefc-7eae1f917153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66e1d97-d676-471a-a140-deb39600a7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66e1d97-d676-471a-a140-deb39600a7a9.jpg?1",
             "name": "Wandering Tombshell",
             "text": "",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "675300d6-d129-54ca-87fa-896252ef6a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b192067c-7cdb-4d3c-95b7-819733e44678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b192067c-7cdb-4d3c-95b7-819733e44678.jpg?1",
             "name": "Atarka Efreet",
             "text": "Megamorph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Atarka Efreet is turned face up, it deals 1 damage to target creature or player.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "22073797-733a-55af-9687-719d6b66d807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f2528-f37f-46b9-b95f-4d142f656723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f2528-f37f-46b9-b95f-4d142f656723.jpg?1",
             "name": "Atarka Pummeler",
             "text": "Formidable \u2014 {3}{R}{R}: Each creature you control can't be blocked this turn except by two or more creatures. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "c06e8d97-01f2-51dd-b754-e5e9402c33cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee571a78-16b2-40ba-92b2-87c1bf4b39bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee571a78-16b2-40ba-92b2-87c1bf4b39bc.jpg?1",
             "name": "Berserkers' Onslaught",
             "text": "Attacking creatures you control have double strike.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "9617a02c-4214-5bbd-ba6f-485843cc5ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051141cb-562a-42a5-984b-a83ee8baca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051141cb-562a-42a5-984b-a83ee8baca51.jpg?1",
             "name": "Commune with Lava",
             "text": "Exile the top X cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "8c414afd-1f6c-54b4-9c23-16559ba0ce1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee8d1f-00e8-44e3-b125-ef98e1461263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee8d1f-00e8-44e3-b125-ef98e1461263.jpg?1",
             "name": "Crater Elemental",
             "text": "{R}, {T}, Sacrifice Crater Elemental: Crater Elemental deals 4 damage to target creature.\nFormidable \u2014 {2}{R}: Crater Elemental has base power 8 until end of turn. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "d398f15b-66df-5e2f-a8a0-c592c08ae4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab919f3-5797-406b-ae1f-7a7c27739b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab919f3-5797-406b-ae1f-7a7c27739b2d.jpg?1",
             "name": "Descent of the Dragons",
             "text": "Destroy any number of target creatures. For each creature destroyed this way, its controller puts a 4/4 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "7ffa4b7d-0b6e-52e2-a302-e3d38e36ccd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf5591c-46e3-4904-8b4e-4f1f84d3118f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf5591c-46e3-4904-8b4e-4f1f84d3118f.jpg?1",
             "name": "Draconic Roar",
             "text": "As an additional cost to cast Draconic Roar, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast Draconic Roar, Draconic Roar deals 3 damage to that creature's controller.",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "8bb7d15b-66c3-5fbb-ba48-da372bcbf55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220e572-7386-4f2f-905f-ba4a2d222f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220e572-7386-4f2f-905f-ba4a2d222f83.jpg?1",
             "name": "Dragon Fodder",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "b9ee8ab5-d45e-5751-9f0b-85b60924a872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefac283-8491-4d11-9a40-0e90cbeac19f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefac283-8491-4d11-9a40-0e90cbeac19f.jpg?1",
             "name": "Dragon Tempest",
             "text": "Whenever a creature with flying enters the battlefield under your control, it gains haste until end of turn.\nWhenever a Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "c2c10853-c5e0-5e6f-93cc-2096cc89056b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c75b106-349f-44e1-a737-079955cc91b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c75b106-349f-44e1-a737-079955cc91b2.jpg?1",
             "name": "Dragon Whisperer",
             "text": "{R}: Dragon Whisperer gains flying until end of turn.\n{1}{R}: Dragon Whisperer gets +1/+0 until end of turn.\nFormidable \u2014 {4}{R}{R}: Put a 4/4 red Dragon creature token with flying onto the battlefield. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "3d45cd13-126d-5496-a343-2bff1525b298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffcdd54-b6be-4d42-82c0-ae927037e859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffcdd54-b6be-4d42-82c0-ae927037e859.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "8969fa11-9502-5ed2-9da0-0e5ec676ca6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10fb883-12b8-4050-967e-4281ea620906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10fb883-12b8-4050-967e-4281ea620906.jpg?1",
             "name": "Hardened Berserker",
             "text": "Whenever Hardened Berserker attacks, the next spell you cast this turn costs {1} less to cast.",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "a48f295e-926f-52ac-9c4b-79210825eb5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb4035-197b-4d28-9bf7-bb62c304067e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb4035-197b-4d28-9bf7-bb62c304067e.jpg?1",
             "name": "Impact Tremors",
             "text": "Whenever a creature enters the battlefield under your control, Impact Tremors deals 1 damage to each opponent.",
             "colours": [
@@ -4707,7 +4707,7 @@
         },
         {
             "id": "50cbb70e-c47f-55ab-8d46-3d198e3d8ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f8ac7a-a68a-4adf-995f-1cd96ee3d295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f8ac7a-a68a-4adf-995f-1cd96ee3d295.jpg?1",
             "name": "Ire Shaman",
             "text": "Ire Shaman can't be blocked except by two or more creatures.\nMegamorph {R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ire Shaman is turned face up, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4742,7 +4742,7 @@
         },
         {
             "id": "c403767d-12d1-5121-bc31-059ab237ac16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82220a35-a6e0-4482-b514-f964664ec5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82220a35-a6e0-4482-b514-f964664ec5ec.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "801290e4-9d0e-5170-b374-1672f1317ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa17972e-c16b-4dec-a108-1c3fb0138a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa17972e-c16b-4dec-a108-1c3fb0138a4e.jpg?1",
             "name": "Kolaghan Aspirant",
             "text": "Whenever Kolaghan Aspirant becomes blocked by a creature, Kolaghan Aspirant deals 1 damage to that creature.",
             "colours": [
@@ -4809,7 +4809,7 @@
         },
         {
             "id": "4e51d7cc-06c3-5344-9d66-38d3550d999a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c56a8de-8ae8-4672-8119-9e6a1f4cf5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c56a8de-8ae8-4672-8119-9e6a1f4cf5cd.jpg?1",
             "name": "Kolaghan Forerunners",
             "text": "Trample\nKolaghan Forerunners's power is equal to the number of creatures you control.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "04a64196-ad9b-5b24-aa57-8ed7351e692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6723f5-a7a9-425d-b4b0-f380da578ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6723f5-a7a9-425d-b4b0-f380da578ef8.jpg?1",
             "name": "Kolaghan Stormsinger",
             "text": "Haste\nMegamorph {R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Kolaghan Stormsinger is turned face up, target creature gains haste until end of turn.",
             "colours": [
@@ -4879,7 +4879,7 @@
         },
         {
             "id": "202e7336-8271-5124-8691-e0811800de19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3285cb6f-a9c0-4195-b6b2-3f33a16eaa01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3285cb6f-a9c0-4195-b6b2-3f33a16eaa01.jpg?1",
             "name": "Lightning Berserker",
             "text": "{R}: Lightning Berserker gets +1/+0 until end of turn.\nDash {R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "b92ab86e-407c-5f5c-98af-861ede027586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732a4912-97d1-4640-976e-ae1ffeb70236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732a4912-97d1-4640-976e-ae1ffeb70236.jpg?1",
             "name": "Lose Calm",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn and can't be blocked this turn except by two or more creatures.",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "16faf6b2-986f-5c8b-b9ce-bb68690c4f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62a56c4-a3d9-43ab-83a8-6333578bcbc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62a56c4-a3d9-43ab-83a8-6333578bcbc8.jpg?1",
             "name": "Magmatic Chasm",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -4978,7 +4978,7 @@
         },
         {
             "id": "c276a7bc-e17f-5f85-829f-566d18dd8db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea70e96a-bebd-4ca4-aa24-e5fd0df38b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea70e96a-bebd-4ca4-aa24-e5fd0df38b8a.jpg?1",
             "name": "Qal Sisma Behemoth",
             "text": "Qal Sisma Behemoth can't attack or block unless you pay {2}.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "7a28a0d6-2615-571a-85bc-670d48b118a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8234090e-9df1-4915-90ef-8a4bc6212655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8234090e-9df1-4915-90ef-8a4bc6212655.jpg?1",
             "name": "Rending Volley",
             "text": "Rending Volley can't be countered by spells or abilities.\nRending Volley deals 4 damage to target white or blue creature.",
             "colours": [
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "4d2cb13b-45d0-5b3f-b23c-73e1daab5dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2e9a8-fcbb-4328-b475-36730182b765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2e9a8-fcbb-4328-b475-36730182b765.jpg?1",
             "name": "Roast",
             "text": "Roast deals 5 damage to target creature without flying.",
             "colours": [
@@ -5077,7 +5077,7 @@
         },
         {
             "id": "4a694867-c243-5b48-9fff-92cd82077f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ddda91-3ccb-4c87-82e6-d4e60f4afc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ddda91-3ccb-4c87-82e6-d4e60f4afc24.jpg?1",
             "name": "Sabertooth Outrider",
             "text": "Trample\nFormidable \u2014 Whenever Sabertooth Outrider attacks, if creatures you control have total power 8 or greater, Sabertooth Outrider gains first strike until end of turn.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "22d1228a-d991-57db-84a3-09b95b498e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4787924f-3186-4e18-b53c-dd67c5f42220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4787924f-3186-4e18-b53c-dd67c5f42220.jpg?1",
             "name": "Sarkhan's Rage",
             "text": "Sarkhan's Rage deals 5 damage to target creature or player. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "1b00a79d-bbf3-5cbb-af72-93ffdd952f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a0ff4d-060e-41dc-8b79-1fa42838adf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a0ff4d-060e-41dc-8b79-1fa42838adf2.jpg?1",
             "name": "Sarkhan's Triumph",
             "text": "Search your library for a Dragon creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "289c7605-f989-5228-8b05-dae35deb028b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfab1c5-e267-43a9-ae16-f6b8ae531eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfab1c5-e267-43a9-ae16-f6b8ae531eef.jpg?1",
             "name": "Screamreach Brawler",
             "text": "Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "de8c701e-0edc-5888-abc9-1cbe74dd4c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b952e4e-c1ed-4455-90d5-46b56478e6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b952e4e-c1ed-4455-90d5-46b56478e6b0.jpg?1",
             "name": "Seismic Rupture",
             "text": "Seismic Rupture deals 2 damage to each creature without flying.",
             "colours": [
@@ -5243,7 +5243,7 @@
         },
         {
             "id": "23a929a5-24c7-547b-ac73-7a8a431df97c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a215bde8-1680-4aea-9d0f-2d6d80a592e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a215bde8-1680-4aea-9d0f-2d6d80a592e3.jpg?1",
             "name": "Sprinting Warbrute",
             "text": "Sprinting Warbrute attacks each turn if able.\nDash {3}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "72a1cdcb-6e6b-5c9f-b9c6-2a6d728b9512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906f718-635b-4d51-8896-530c52b260f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906f718-635b-4d51-8896-530c52b260f7.jpg?1",
             "name": "Stormcrag Elemental",
             "text": "Trample\nMegamorph {4}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "90c7b7d1-ddd8-56c1-9507-1a80a3cf3712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da2b004-97e5-41ab-98b0-3637cb32a35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da2b004-97e5-41ab-98b0-3637cb32a35a.jpg?1",
             "name": "Stormwing Dragon",
             "text": "Flying, first strike\nMegamorph {5}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Stormwing Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "4ec4444f-7974-5899-97f1-62b89e57af7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec9005d-eca8-45a6-b221-9d5a2cfb1e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec9005d-eca8-45a6-b221-9d5a2cfb1e91.jpg?1",
             "name": "Summit Prowler",
             "text": "",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "0d1901c8-be1d-5c19-89a6-ab5ca468899b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a59f12-8d1b-4378-abb8-e266d9b6cdba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a59f12-8d1b-4378-abb8-e266d9b6cdba.jpg?1",
             "name": "Tail Slash",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "776d2f42-9a5c-58a5-9acf-9d4ddcfccfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b9cf2b-efe3-4815-be18-c3b69ee762f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b9cf2b-efe3-4815-be18-c3b69ee762f2.jpg?1",
             "name": "Thunderbreak Regent",
             "text": "Flying\nWhenever a Dragon you control becomes the target of a spell or ability an opponent controls, Thunderbreak Regent deals 3 damage to that player.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "141d2766-952d-58d8-b7de-b4af4ad9fb8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfc312c-13c6-45e7-a780-229186be69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfc312c-13c6-45e7-a780-229186be69f4.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "df15dd46-9de6-5291-9951-efbde49a5d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd58ec4-34a9-4fc2-b057-438492e2e06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd58ec4-34a9-4fc2-b057-438492e2e06e.jpg?1",
             "name": "Twin Bolt",
             "text": "Twin Bolt deals 2 damage divided as you choose among one or two target creatures and/or players.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "2d8e2765-663c-5d5e-9230-8adba6ef56a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b04f7a-4fd6-47d2-b378-99c7fb0c1809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b04f7a-4fd6-47d2-b378-99c7fb0c1809.jpg?1",
             "name": "Vandalize",
             "text": "Choose one or both \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target land.",
             "colours": [
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "05090b72-d93d-5ed7-9ed1-6c4b32c56b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b808883-f630-4070-ab7e-d347e26a9564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b808883-f630-4070-ab7e-d347e26a9564.jpg?1",
             "name": "Volcanic Rush",
             "text": "Attacking creatures get +2/+0 and gain trample until end of turn.",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "dba0a8c1-5fb2-51d2-9088-3ca9b8e40a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979da13b-9be6-49cc-a62c-67eeea289612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979da13b-9be6-49cc-a62c-67eeea289612.jpg?1",
             "name": "Volcanic Vision",
             "text": "Return target instant or sorcery card from your graveyard to your hand. Volcanic Vision deals damage equal to that card's converted mana cost to each creature your opponents control. Exile Volcanic Vision.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "81958944-47d3-5bae-8dfe-2932480617e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4951ef-2519-4511-b952-c835cd81def7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4951ef-2519-4511-b952-c835cd81def7.jpg?1",
             "name": "Warbringer",
             "text": "Dash costs you pay cost {2} less (as long as this creature is on the battlefield).\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "d9dafe58-eb88-51b1-a8c2-9dbbbb8996d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbac6d75-59ab-4d7d-87ae-46875abf8cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbac6d75-59ab-4d7d-87ae-46875abf8cc7.jpg?1",
             "name": "Zurgo Bellstriker",
             "text": "Zurgo Bellstriker can't block creatures with power 2 or greater.\nDash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "311c8827-9716-5cd3-bcea-b22b19bf12e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6db26b5-d28c-4524-9347-eec412d584bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6db26b5-d28c-4524-9347-eec412d584bc.jpg?1",
             "name": "Aerie Bowmasters",
             "text": "Reach (This creature can block creatures with flying.)\nMegamorph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "69680809-ead1-58b0-a5d1-184fc3ff3ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4c8964-06e4-4a24-9a7e-9cac0fb8518e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4c8964-06e4-4a24-9a7e-9cac0fb8518e.jpg?1",
             "name": "Ainok Artillerist",
             "text": "Ainok Artillerist has reach as long as it has a +1/+1 counter on it. (It can block creatures with flying.)",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "b529f002-78e0-590f-b93e-3f617e0b2e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a7410-493c-4c99-99e2-b8e1116622e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a7410-493c-4c99-99e2-b8e1116622e8.jpg?1",
             "name": "Ainok Survivalist",
             "text": "Megamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ainok Survivalist is turned face up, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "3dfafd08-a501-5b05-bce5-4a68ad9b7661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f672dd0-cd63-464c-9581-0ec6f0e391f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f672dd0-cd63-464c-9581-0ec6f0e391f7.jpg?1",
             "name": "Assault Formation",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -5815,7 +5815,7 @@
         },
         {
             "id": "d56c5296-487e-5f8f-b9e2-5fdb7e8e02c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ef9a03-3044-4e90-9409-c330972fcafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ef9a03-3044-4e90-9409-c330972fcafb.jpg?1",
             "name": "Atarka Beastbreaker",
             "text": "Formidable \u2014 {4}{G}: Atarka Beastbreaker gets +4/+4 until end of turn. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "7acb34f6-e5ab-5038-b2f4-c2b5fdf53a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf18a2f-f93e-4a18-92d5-c9d2cca276d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf18a2f-f93e-4a18-92d5-c9d2cca276d7.jpg?1",
             "name": "Avatar of the Resolute",
             "text": "Reach, trample\nAvatar of the Resolute enters the battlefield with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "7566cd94-7685-5731-9a83-1e01160c940f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99df522-cc97-41e3-8073-72e092afe8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99df522-cc97-41e3-8073-72e092afe8bb.jpg?1",
             "name": "Circle of Elders",
             "text": "Vigilance\nFormidable \u2014 {T}: Add {3} to your mana pool. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "11574c52-6597-5fe8-8133-bad84437c999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg?1",
             "name": "Collected Company",
             "text": "Look at the top six cards of your library. Put up to two creature cards with converted mana cost 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "c29c27af-8562-5ea9-8add-dd68bb712ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c60e63-0b86-4100-a932-bb9e9b197610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c60e63-0b86-4100-a932-bb9e9b197610.jpg?1",
             "name": "Colossodon Yearling",
             "text": "",
             "colours": [
@@ -5985,7 +5985,7 @@
         },
         {
             "id": "fdf5f7bc-5c8b-5afb-873b-f45e3a2d18a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f07879-7893-46d9-9239-8d2625355881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f07879-7893-46d9-9239-8d2625355881.jpg?1",
             "name": "Conifer Strider",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "e1c6ce51-a871-5e6b-aa8b-60bca8c05ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c40df1-3f63-49e7-a869-1ce14f94a753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c40df1-3f63-49e7-a869-1ce14f94a753.jpg?1",
             "name": "Deathmist Raptor",
             "text": "Deathtouch\nWhenever a permanent you control is turned face up, you may return Deathmist Raptor from your graveyard to the battlefield face up or face down.\nMegamorph {4}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "e0c322a9-4486-5282-9d62-4a1bf6d49453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd90d5ea-c586-4afd-be75-1c821e48df0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd90d5ea-c586-4afd-be75-1c821e48df0c.jpg?1",
             "name": "Den Protector",
             "text": "Creatures with power less than Den Protector's power can't block it.\nMegamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Den Protector is turned face up, return target card from your graveyard to your hand.",
             "colours": [
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "55a1cf60-3603-5905-bf05-219c768eba2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65572ff2-281f-431d-b776-e8231f24d2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65572ff2-281f-431d-b776-e8231f24d2c6.jpg?1",
             "name": "Display of Dominance",
             "text": "Choose one \u2014\n\u2022 Destroy target blue or black noncreature permanent.\n\u2022 Permanents you control can't be the targets of blue or black spells your opponents control this turn.",
             "colours": [
@@ -6121,7 +6121,7 @@
         },
         {
             "id": "f7acdd49-5c69-51bb-ab95-7c079e342a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689a6390-894a-4d31-87c2-f9cec3b187a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689a6390-894a-4d31-87c2-f9cec3b187a7.jpg?1",
             "name": "Dragon-Scarred Bear",
             "text": "Formidable \u2014 {1}{G}: Regenerate Dragon-Scarred Bear. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6155,7 +6155,7 @@
         },
         {
             "id": "ddd4ba0b-9563-52de-a51a-fc88b8eec35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a356afb6-19d7-459a-84ca-090924d45387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a356afb6-19d7-459a-84ca-090924d45387.jpg?1",
             "name": "Dromoka's Gift",
             "text": "Bolster 4. (Choose a creature with the least toughness among creatures you control and put four +1/+1 counters on it.)",
             "colours": [
@@ -6187,7 +6187,7 @@
         },
         {
             "id": "e2fcb8bc-e3ba-5b8d-8642-b24d4229b79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f587436e-51ff-4c9c-a6ce-e2768844a71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f587436e-51ff-4c9c-a6ce-e2768844a71a.jpg?1",
             "name": "Epic Confrontation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6219,7 +6219,7 @@
         },
         {
             "id": "c9b33f11-4ec0-55fa-94fe-0ebd67931595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9d3ec9-49d2-4322-aeb1-522aac380fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9d3ec9-49d2-4322-aeb1-522aac380fd3.jpg?1",
             "name": "Explosive Vegetation",
             "text": "Search your library for up to two basic land cards and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "123c5197-b92e-575c-9311-04502da331bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a266c3-de47-4e94-bdc4-210e34981de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a266c3-de47-4e94-bdc4-210e34981de3.jpg?1",
             "name": "Foe-Razer Regent",
             "text": "Flying\nWhen Foe-Razer Regent enters the battlefield, you may have it fight target creature you don't control.\nWhenever a creature you control fights, put two +1/+1 counters on it at the beginning of the next end step.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "bc3d268c-b8ec-54b5-80a5-b8cec49ad823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9c6d9-e715-4b70-a10e-8bc5a4e9e938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9c6d9-e715-4b70-a10e-8bc5a4e9e938.jpg?1",
             "name": "Glade Watcher",
             "text": "Defender\nFormidable \u2014 {G}: Glade Watcher can attack this turn as though it didn't have defender. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "8d5bc2d4-8af8-59b9-894a-fde80937ca56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbd7958-29a0-4f59-9648-eabe0fbfb4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbd7958-29a0-4f59-9648-eabe0fbfb4f9.jpg?1",
             "name": "Guardian Shield-Bearer",
             "text": "Megamorph {3}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Guardian Shield-Bearer is turned face up, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "20927d62-9876-59cd-b5de-775c7441cedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb84323-b6f7-43ea-baf1-3e29b33b680d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb84323-b6f7-43ea-baf1-3e29b33b680d.jpg?1",
             "name": "Herdchaser Dragon",
             "text": "Flying, trample\nMegamorph {5}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Herdchaser Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -6388,7 +6388,7 @@
         },
         {
             "id": "2b515b4c-16c3-5adf-9f82-8e2b4e4150e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565b991-7021-4b81-b9c0-f7231daae360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565b991-7021-4b81-b9c0-f7231daae360.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "a5f115c7-d4fa-584f-b5c3-2867393a7b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f59bc0b-88de-4580-bfc8-5af911d9ee99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f59bc0b-88de-4580-bfc8-5af911d9ee99.jpg?1",
             "name": "Lurking Arynx",
             "text": "Formidable \u2014 {2}{G}: Target creature blocks Lurking Arynx this turn if able. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "a73c8cf5-b47b-5da7-b676-a1fe61a8dac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a766442-bbfd-4869-9cf5-918d9117c359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a766442-bbfd-4869-9cf5-918d9117c359.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6487,7 +6487,7 @@
         },
         {
             "id": "c502e065-1e3a-5c94-9bcf-fc2dbeaae3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bff71e3-b309-4659-9d43-7a0d8ada1efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bff71e3-b309-4659-9d43-7a0d8ada1efc.jpg?1",
             "name": "Obscuring Aether",
             "text": "Face-down creature spells you cast cost {1} less to cast.\n{1}{G}: Turn Obscuring \u00c6ther face down. (It becomes a 2/2 creature.)",
             "colours": [
@@ -6519,7 +6519,7 @@
         },
         {
             "id": "4a323985-63c1-5b1c-bfe4-31289eb3de39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d6df03-c3c3-42c3-85a4-6fccb0741592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d6df03-c3c3-42c3-85a4-6fccb0741592.jpg?1",
             "name": "Pinion Feast",
             "text": "Destroy target creature with flying. Bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -6551,7 +6551,7 @@
         },
         {
             "id": "98f0b41f-c2b6-5f9f-bcc3-a4f8a992aa0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09253b39-8b3e-4cb8-b054-0e1a49762387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09253b39-8b3e-4cb8-b054-0e1a49762387.jpg?1",
             "name": "Press the Advantage",
             "text": "Up to two target creatures each get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "11648354-262f-5300-8efd-c9613cfa0188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bdd624-e412-4ec8-9929-e1f6b4720e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bdd624-e412-4ec8-9929-e1f6b4720e82.jpg?1",
             "name": "Revealing Wind",
             "text": "Prevent all combat damage that would be dealt this turn. You may look at each face-down creature that's attacking or blocking.",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "bd09d604-47f9-50c5-8779-c9360b7ac7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1111a-9680-4d34-8cf7-af16ae508a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1111a-9680-4d34-8cf7-af16ae508a72.jpg?1",
             "name": "Salt Road Ambushers",
             "text": "Whenever another permanent you control is turned face up, if it's a creature, put two +1/+1 counters on it.\nMegamorph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "914a442e-1ff9-573b-88ae-e981fc21e29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4076bf6b-c8b1-49ef-8f23-afaf7a234e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4076bf6b-c8b1-49ef-8f23-afaf7a234e2d.jpg?1",
             "name": "Salt Road Quartermasters",
             "text": "Salt Road Quartermasters enters the battlefield with two +1/+1 counters on it.\n{2}{G}, Remove a +1/+1 counter from Salt Road Quartermasters: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -6685,7 +6685,7 @@
         },
         {
             "id": "8f15960f-74fa-5442-ad6a-a7638cce4a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f215b-4f3b-4aca-9664-3ef9a0ddea1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f215b-4f3b-4aca-9664-3ef9a0ddea1a.jpg?1",
             "name": "Sandsteppe Scavenger",
             "text": "When Sandsteppe Scavenger enters the battlefield, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "44af609b-be23-506b-afce-756ce9f2467f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701da01c-0f27-4cb2-8bfa-407239778982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701da01c-0f27-4cb2-8bfa-407239778982.jpg?1",
             "name": "Scaleguard Sentinels",
             "text": "As an additional cost to cast Scaleguard Sentinels, you may reveal a Dragon card from your hand.\nScaleguard Sentinels enters the battlefield with a +1/+1 counter on it if you revealed a Dragon card or controlled a Dragon as you cast Scaleguard Sentinels.",
             "colours": [
@@ -6755,7 +6755,7 @@
         },
         {
             "id": "47729619-522d-5cc2-96e9-9d16c28d4e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbe824-f9c7-4f4d-af92-438b16057d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbe824-f9c7-4f4d-af92-438b16057d99.jpg?1",
             "name": "Segmented Krotiq",
             "text": "Megamorph {6}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "49d4efff-351d-57ed-b8a2-38487f002f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca887c41-a8ee-4751-a902-87149c29a9df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca887c41-a8ee-4751-a902-87149c29a9df.jpg?1",
             "name": "Servant of the Scale",
             "text": "Servant of the Scale enters the battlefield with a +1/+1 counter on it.\nWhen Servant of the Scale dies, put X +1/+1 counters on target creature you control, where X is the number of +1/+1 counters on Servant of the Scale.",
             "colours": [
@@ -6824,7 +6824,7 @@
         },
         {
             "id": "368a0177-98c1-5a8c-947b-6203b3bd9aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e9c8f7-2232-4a2a-8a00-0a2908bc7543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e9c8f7-2232-4a2a-8a00-0a2908bc7543.jpg?1",
             "name": "Shaman of Forgotten Ways",
             "text": "{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast creature spells.\nFormidable \u2014 {9}{G}{G}, {T}: Each player's life total becomes the number of creatures he or she controls. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6859,7 +6859,7 @@
         },
         {
             "id": "5ce0074c-f60f-5383-8a34-9d4ae9b4324a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0243dde4-29c9-4e47-9129-8e01296851cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0243dde4-29c9-4e47-9129-8e01296851cc.jpg?1",
             "name": "Shape the Sands",
             "text": "Target creature gets +0/+5 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -6891,7 +6891,7 @@
         },
         {
             "id": "275520f7-d43a-5d71-96c4-850e085d93e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afecf5a8-3c9e-48e0-8818-e2e3183e958c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afecf5a8-3c9e-48e0-8818-e2e3183e958c.jpg?1",
             "name": "Sheltered Aerie",
             "text": "Enchant land\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "b80ba665-148c-5362-a3bd-1001151c9625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5921758-4e21-4d34-8cf7-b0205d4b0912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5921758-4e21-4d34-8cf7-b0205d4b0912.jpg?1",
             "name": "Sight of the Scalelords",
             "text": "At the beginning of combat on your turn, creatures you control with toughness 4 or greater get +2/+2 and gain vigilance until end of turn.",
             "colours": [
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "8afec94e-8803-5fc9-9aec-6c8e21cb3946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55e213-6eab-4086-96cd-024de6150fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55e213-6eab-4086-96cd-024de6150fbe.jpg?1",
             "name": "Stampeding Elk Herd",
             "text": "Formidable \u2014 Whenever Stampeding Elk Herd attacks, if creatures you control have total power 8 or greater, creatures you control gain trample until end of turn.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "024c688c-0c0b-56b2-b0f0-6f6880de8970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4d33ea-0193-4ea5-92ea-5f50a533bf6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4d33ea-0193-4ea5-92ea-5f50a533bf6b.jpg?1",
             "name": "Sunbringer's Touch",
             "text": "Bolster X, where X is the number of cards in your hand. Each creature you control with a +1/+1 counter on it gains trample until end of turn. (To bolster X, choose a creature with the least toughness among creatures you control and put X +1/+1 counters on it.)",
             "colours": [
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "bf1aa40c-243a-50f3-8f2c-da18f94059f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b374446d-44bc-4ac5-9829-8c49f0cca173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b374446d-44bc-4ac5-9829-8c49f0cca173.jpg?1",
             "name": "Surrak, the Hunt Caller",
             "text": "Formidable \u2014 At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "3f357928-9abc-5025-a481-c6c51feb89a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f04d27-f38a-4be2-8eb6-7dd0d3a1ac6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f04d27-f38a-4be2-8eb6-7dd0d3a1ac6d.jpg?1",
             "name": "Tread Upon",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "4d7b91cc-43b0-5c95-8c42-6fb50bd5e5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7fbf78-8cb6-4fbf-b925-5543bcb64b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7fbf78-8cb6-4fbf-b925-5543bcb64b45.jpg?1",
             "name": "Arashin Sovereign",
             "text": "Flying\nWhen Arashin Sovereign dies, you may put it on the top or bottom of its owner's library.",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "e18396ae-0aa0-5b09-8368-dbbf4d36b40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d78c9-c5b3-45c3-a6d0-7e92b4196ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d78c9-c5b3-45c3-a6d0-7e92b4196ae3.jpg?1",
             "name": "Atarka's Command",
             "text": "Choose two \u2014\n\u2022 Your opponents can't gain life this turn.\n\u2022 Atarka's Command deals 3 damage to each opponent.\n\u2022 You may put a land card from your hand onto the battlefield.\n\u2022 Creatures you control get +1/+1 and gain reach until end of turn.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "bfb6c1dd-5f97-5aae-a50f-8e81c58a00fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab8841f-5c6f-47fc-91c9-acf3c84b7313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab8841f-5c6f-47fc-91c9-acf3c84b7313.jpg?1",
             "name": "Boltwing Marauder",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -7198,7 +7198,7 @@
         },
         {
             "id": "993fb839-ac31-5765-8f84-4cbd385f48f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbfe3b0-3b1d-4b0c-9d98-07f1cecce4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbfe3b0-3b1d-4b0c-9d98-07f1cecce4b7.jpg?1",
             "name": "Cunning Breezedancer",
             "text": "Flying\nWhenever you cast a noncreature spell, Cunning Breezedancer gets +2/+2 until end of turn.",
             "colours": [
@@ -7234,7 +7234,7 @@
         },
         {
             "id": "bb56cadb-a79f-54d7-92a0-d4f05ee68582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0c3b45-cf1d-4d85-9fe3-fb26b4b15dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0c3b45-cf1d-4d85-9fe3-fb26b4b15dfd.jpg?1",
             "name": "Dragonlord Atarka",
             "text": "Flying, trample\nWhen Dragonlord Atarka enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "c9da5048-60d4-5507-a462-5555c3b59466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908042f3-0d03-4edf-816a-ec846a1e315f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908042f3-0d03-4edf-816a-ec846a1e315f.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "Dragonlord Dromoka can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -7312,7 +7312,7 @@
         },
         {
             "id": "7c4369ad-9aa4-50c1-83b1-008ebc730658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbf8933-32a1-4892-9bdc-89464ed9ce1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbf8933-32a1-4892-9bdc-89464ed9ce1b.jpg?1",
             "name": "Dragonlord Kolaghan",
             "text": "Flying, haste\nOther creatures you control have haste.\nWhenever an opponent casts a creature or planeswalker spell with the same name as a card in his or her graveyard, that player loses 10 life.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "db22b048-ecbd-5498-b187-b0ea184f9cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42b2c9c-1650-468e-94d6-e09b3518447f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42b2c9c-1650-468e-94d6-e09b3518447f.jpg?1",
             "name": "Dragonlord Ojutai",
             "text": "Flying\nDragonlord Ojutai has hexproof as long as it's untapped.\nWhenever Dragonlord Ojutai deals combat damage to a player, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -7390,7 +7390,7 @@
         },
         {
             "id": "58a5ad07-c61e-59fd-b521-69f49bbbae31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eae504d-d4a9-440f-8ceb-df967cc50494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eae504d-d4a9-440f-8ceb-df967cc50494.jpg?1",
             "name": "Dragonlord Silumgar",
             "text": "Flying, deathtouch\nWhen Dragonlord Silumgar enters the battlefield, gain control of target creature or planeswalker for as long as you control Dragonlord Silumgar.",
             "colours": [
@@ -7429,7 +7429,7 @@
         },
         {
             "id": "1eba186b-ae39-569b-8725-9f65bc2226ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1e43a8-0adc-4e26-bc56-6b914bd35838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1e43a8-0adc-4e26-bc56-6b914bd35838.jpg?1",
             "name": "Dromoka's Command",
             "text": "Choose two \u2014\n\u2022 Prevent all damage target instant or sorcery spell would deal this turn.\n\u2022 Target player sacrifices an enchantment.\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "0816d3fd-b480-5464-a7f5-83a56c22000e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfdfff3-0ef8-4e9a-b6bd-a0e11cbdf22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfdfff3-0ef8-4e9a-b6bd-a0e11cbdf22e.jpg?1",
             "name": "Enduring Scalelord",
             "text": "Flying\nWhenever one or more +1/+1 counters are placed on another creature you control, you may put a +1/+1 counter on Enduring Scalelord.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "f6d17a8a-3daa-53fa-803a-7a22378c4cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb21b8-8817-48c2-8ae8-25221600ce32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb21b8-8817-48c2-8ae8-25221600ce32.jpg?1",
             "name": "Harbinger of the Hunt",
             "text": "Flying\n{2}{R}: Harbinger of the Hunt deals 1 damage to each creature without flying.\n{2}{G}: Harbinger of the Hunt deals 1 damage to each other creature with flying.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "f20dc5a8-f699-529b-a2bf-b76dc2d6c150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c884e1e-fecb-4330-b3de-5fc2a60f7173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c884e1e-fecb-4330-b3de-5fc2a60f7173.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to target creature or player.",
             "colours": [
@@ -7569,7 +7569,7 @@
         },
         {
             "id": "c32d309f-650c-5fae-8bd5-0b22b9aa5951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4816d092-e34b-4397-8599-43d8e85a8f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4816d092-e34b-4397-8599-43d8e85a8f39.jpg?1",
             "name": "Narset Transcendent",
             "text": "+1: Look at the top card of your library. If it's a noncreature, nonland card, you may reveal it and put it into your hand.\n\u22122: When you cast your next instant or sorcery spell from your hand this turn, it gains rebound.\n\u22129: You get an emblem with \"Your opponents can't cast noncreature spells.\"",
             "colours": [
@@ -7607,7 +7607,7 @@
         },
         {
             "id": "ee821486-d569-56f0-ae85-6c376fcc7d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2574aaf5-8397-4a88-b047-1b4dbb176930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2574aaf5-8397-4a88-b047-1b4dbb176930.jpg?1",
             "name": "Necromaster Dragon",
             "text": "Flying\nWhenever Necromaster Dragon deals combat damage to a player, you may pay {2}. If you do, put a 2/2 black Zombie creature token onto the battlefield and each opponent puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -7643,7 +7643,7 @@
         },
         {
             "id": "25a056dc-64cc-540a-b534-a238f042bf2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7f500-594d-4c7b-80e8-54ae1ada2444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7f500-594d-4c7b-80e8-54ae1ada2444.jpg?1",
             "name": "Ojutai's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u2022 You gain 4 life.\n\u2022 Counter target creature spell.\n\u2022 Draw a card.",
             "colours": [
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "23342fbb-7037-524a-9141-89a26b3bc93c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083eabac-f7c9-45d9-b3c7-10d719da1e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083eabac-f7c9-45d9-b3c7-10d719da1e0b.jpg?1",
             "name": "Pristine Skywise",
             "text": "Flying\nWhenever you cast a noncreature spell, untap Pristine Skywise. It gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "e81209bf-37fd-5d9c-a7fd-ad34d60cac97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d99f0d-f5d4-4480-ac5e-fe9ff808416e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d99f0d-f5d4-4480-ac5e-fe9ff808416e.jpg?1",
             "name": "Ruthless Deathfang",
             "text": "Flying\nWhenever you sacrifice a creature, target opponent sacrifices a creature.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "6da2f85a-8119-5e63-b89e-c330cb7e8ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192452f8-93c2-4a20-a52b-0093741a9e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192452f8-93c2-4a20-a52b-0093741a9e45.jpg?1",
             "name": "Sarkhan Unbroken",
             "text": "+1: Draw a card, then add one mana of any color to your mana pool.\n\u22122: Put a 4/4 red Dragon creature token with flying onto the battlefield.\n\u22128: Search your library for any number of Dragon creature cards and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "bc9c4385-2ae1-57d3-8e47-22bc8059184f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690008d1-d1fe-49ad-810c-84be57cecc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690008d1-d1fe-49ad-810c-84be57cecc6c.jpg?1",
             "name": "Savage Ventmaw",
             "text": "Flying\nWhenever Savage Ventmaw attacks, add {R}{R}{R}{G}{G}{G} to your mana pool. Until end of turn, this mana doesn't empty from your mana pool as steps and phases end.",
             "colours": [
@@ -7825,7 +7825,7 @@
         },
         {
             "id": "b482573a-1e19-5988-b764-e92dff6ad33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba26dbbc-d4a2-44a1-8e6b-affe61f43a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba26dbbc-d4a2-44a1-8e6b-affe61f43a34.jpg?1",
             "name": "Silumgar's Command",
             "text": "Choose two \u2014\n\u2022 Counter target noncreature spell.\n\u2022 Return target permanent to its owner's hand.\n\u2022 Target creature gets -3/-3 until end of turn.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "54cc72be-7e37-56b4-8146-b3ad637b29f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62db9d7-3cc7-49cb-bffc-d2f9c286aa36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62db9d7-3cc7-49cb-bffc-d2f9c286aa36.jpg?1",
             "name": "Swift Warkite",
             "text": "Flying\nWhen Swift Warkite enters the battlefield, you may put a creature card with converted mana cost 3 or less from your hand or graveyard onto the battlefield. That creature gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "3eafb831-32f7-5dc2-8f8e-4e794c29b511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7124a6f-b690-4326-93b5-036a8c520c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7124a6f-b690-4326-93b5-036a8c520c1f.jpg?1",
             "name": "Ancestral Statue",
             "text": "When Ancestral Statue enters the battlefield, return a nonland permanent you control to its owner's hand.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "0a1959a6-0db0-509e-b5dd-195e9aae4290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d52217-a340-4567-9b07-28092a7dc561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d52217-a340-4567-9b07-28092a7dc561.jpg?1",
             "name": "Atarka Monument",
             "text": "{T}: Add {R} or {G} to your mana pool.\n{4}{R}{G}: Atarka Monument becomes a 4/4 red and green Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "2fae3294-3f9d-5dec-b7ee-5105b36c897e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f061-9506-40fb-b10d-4bada38ca0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f061-9506-40fb-b10d-4bada38ca0f7.jpg?1",
             "name": "Custodian of the Trove",
             "text": "Defender\nCustodian of the Trove enters the battlefield tapped.",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "c174d8a1-191e-5bdb-8144-d903e645b397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7463c18-5bef-42a0-a37e-6112809ebc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7463c18-5bef-42a0-a37e-6112809ebc78.jpg?1",
             "name": "Dragonloft Idol",
             "text": "As long as you control a Dragon, Dragonloft Idol gets +1/+1 and has flying and trample.",
             "colours": [],
@@ -8019,7 +8019,7 @@
         },
         {
             "id": "9b4274c3-173e-51bd-9abe-ea8223d357f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df975f-b6ef-4e8e-8be8-529c0ffd8a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df975f-b6ef-4e8e-8be8-529c0ffd8a37.jpg?1",
             "name": "Dromoka Monument",
             "text": "{T}: Add {G} or {W} to your mana pool.\n{4}{G}{W}: Dromoka Monument becomes a 4/4 green and white Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "3d81011f-defe-519e-8bde-03dd1ad9f6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1",
             "name": "Gate Smasher",
             "text": "Gate Smasher can be attached only to a creature with toughness 4 or greater.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "1d377c83-74b6-58d0-8abd-a13f38adc9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6c502-ae3e-4e67-8f1d-3323b4468f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6c502-ae3e-4e67-8f1d-3323b4468f72.jpg?1",
             "name": "Keeper of the Lens",
             "text": "You may look at face-down creatures you don't control. (You may do this at any time.)",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "9df978d1-61fc-59e5-b8ca-3b5b9926b41a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620cddb7-abf7-4367-8440-815b886db8e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620cddb7-abf7-4367-8440-815b886db8e0.jpg?1",
             "name": "Kolaghan Monument",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{4}{B}{R}: Kolaghan Monument becomes a 4/4 black and red Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "55792f05-92bf-5592-a9bc-9547870916b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29942-a7e3-4e47-9f95-527a5d7e4f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29942-a7e3-4e47-9f95-527a5d7e4f1d.jpg?1",
             "name": "Ojutai Monument",
             "text": "{T}: Add {W} or {U} to your mana pool.\n{4}{W}{U}: Ojutai Monument becomes a 4/4 white and blue Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "f69445e6-4110-5362-8517-e91d42031858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3243e300-1420-4e96-a3d3-610c3723a11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3243e300-1420-4e96-a3d3-610c3723a11f.jpg?1",
             "name": "Silumgar Monument",
             "text": "{T}: Add {U} or {B} to your mana pool.\n{4}{U}{B}: Silumgar Monument becomes a 4/4 blue and black Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8204,7 +8204,7 @@
         },
         {
             "id": "3692b236-308a-5f4a-87be-ae96bb3c7a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561b47c-b863-463a-8a10-56fede2cb42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561b47c-b863-463a-8a10-56fede2cb42c.jpg?1",
             "name": "Spidersilk Net",
             "text": "Equipped creature gets +0/+2 and has reach. (It can block creatures with flying.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "066b9133-196d-5c15-b8c9-9bb61fc637b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b08344-780d-4bd7-882a-dcadeb40f159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b08344-780d-4bd7-882a-dcadeb40f159.jpg?1",
             "name": "Stormrider Rig",
             "text": "Equipped creature gets +1/+1.\nWhenever a creature enters the battlefield under your control, you may attach Stormrider Rig to it.\nEquip {2}",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "5a334c91-4a89-58d8-b04a-449d40d9373a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e5e24-d704-4f1c-9577-0f25aaabb7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e5e24-d704-4f1c-9577-0f25aaabb7ed.jpg?1",
             "name": "Tapestry of the Ages",
             "text": "{2}, {T}: Draw a card. Activate this ability only if you've cast a noncreature spell this turn.",
             "colours": [],
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "0d146a66-1402-531e-9bad-ad0fcdef32f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e88fe-307a-4944-9233-14df4e0bb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e88fe-307a-4944-9233-14df4e0bb775.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: Vial of Dragonfire deals 2 damage to target creature.",
             "colours": [],
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "c901a24a-4332-57a6-a95e-596e0e8a62db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb66398d-afb4-41d9-a8b8-ec115d2ad5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb66398d-afb4-41d9-a8b8-ec115d2ad5f2.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8348,7 +8348,7 @@
         },
         {
             "id": "55fabcc4-7129-5613-8a0e-693ba4eaf878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9910042e-091f-47da-ad29-8f76c9d3b8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9910042e-091f-47da-ad29-8f76c9d3b8c1.jpg?1",
             "name": "Haven of the Spirit Dragon",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a Dragon creature spell.\n{2}, {T}, Sacrifice Haven of the Spirit Dragon: Return target Dragon creature card or Ugin planeswalker card from your graveyard to your hand.",
             "colours": [],
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "2248938b-8183-5149-990e-55d2cac0d2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf91075-8d8d-43c3-8125-2469e2dcd132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf91075-8d8d-43c3-8125-2469e2dcd132.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8413,7 +8413,7 @@
         },
         {
             "id": "60144f0e-9761-5476-9d4f-1fc31ff89e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2484c9db-44bc-411c-af43-bfe0e30f0ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2484c9db-44bc-411c-af43-bfe0e30f0ffa.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "b8aafd34-77e3-5f65-bd1b-cc46c4640315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f2bcd-8d37-417c-a969-86e04f1daf23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f2bcd-8d37-417c-a969-86e04f1daf23.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "a1b40fb9-fec1-5bec-b994-a96b8e0c0ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2f901-7d7b-47ec-a3d4-96ddcbd9218c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2f901-7d7b-47ec-a3d4-96ddcbd9218c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "dbef8fa7-0a1f-590d-9507-45653279185c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78732e7f-421d-43e8-8f43-341bb01e993e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78732e7f-421d-43e8-8f43-341bb01e993e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "5723abb8-6486-5585-830e-695bd1c8c0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ac118-6d94-4f3b-9873-7a2440ab92d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ac118-6d94-4f3b-9873-7a2440ab92d9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "e183fcd2-a6f5-592a-a407-78b04295c945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4498e-e753-418e-8db6-e11d2caac3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4498e-e753-418e-8db6-e11d2caac3b1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "4fe3ed72-97c6-501b-ab16-208e3ee53185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4873cb-43ce-47b4-9d91-a8495a244c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4873cb-43ce-47b4-9d91-a8495a244c85.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "c5481830-959f-55e3-979b-41574a18ffbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846729-deec-436f-af5c-08faf53ec36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846729-deec-436f-af5c-08faf53ec36f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8709,7 +8709,7 @@
         },
         {
             "id": "4dd86277-5f6c-581c-a032-3a8c45b4e049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54968fa2-36f1-4d21-89e7-a307d68cfccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54968fa2-36f1-4d21-89e7-a307d68cfccc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "155931ea-cdf3-5cdc-9923-cfd6f16b55db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f613b2-de5b-4592-8d14-5ad373537a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f613b2-de5b-4592-8d14-5ad373537a21.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "7ed8596b-ef0d-536c-8ff2-bd05207e40af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c356eb7-ebf4-400d-95a7-7452382bc32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c356eb7-ebf4-400d-95a7-7452382bc32f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "31be3f47-9c33-5ee1-844a-e6c36d07ac80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f341b39-ac40-436b-967c-568265354886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f341b39-ac40-436b-967c-568265354886.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "4c95ff48-606b-58f0-b736-f3cf6a8e2835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c9425a-2093-40c1-b3a9-a882d80cf198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c9425a-2093-40c1-b3a9-a882d80cf198.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8894,7 +8894,7 @@
         },
         {
             "id": "589002de-2c7b-5e6f-a64e-9c61268d61aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67becef5-cd70-4fe9-b8a3-1bff2ea04ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67becef5-cd70-4fe9-b8a3-1bff2ea04ab4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8931,7 +8931,7 @@
         },
         {
             "id": "333f27ec-e546-5d55-b739-ae314b12aefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677a1d9d-86fd-49db-9573-8cd2cbc1a096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677a1d9d-86fd-49db-9573-8cd2cbc1a096.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "309ecb76-1644-5382-887e-9d2a6a14381e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e8077e-4400-4923-afe6-6ff5a51b5e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e8077e-4400-4923-afe6-6ff5a51b5e91.jpg?1",
             "name": "Djinn Monk",
             "text": "",
             "colours": [
@@ -9000,7 +9000,7 @@
         },
         {
             "id": "f4bb30b0-4043-5507-adc3-cd7b229b2ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4de662d-374d-4dd7-908f-bcde7bdc5ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4de662d-374d-4dd7-908f-bcde7bdc5ae9.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9034,7 +9034,7 @@
         },
         {
             "id": "c648341a-d6a1-51c3-95c2-acaf0fdfe6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c41ab-d9ee-4817-a982-41d4da6fa9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c41ab-d9ee-4817-a982-41d4da6fa9ad.jpg?1",
             "name": "Zombie Horror",
             "text": "",
             "colours": [
@@ -9069,7 +9069,7 @@
         },
         {
             "id": "c3375df1-7408-53da-bfd3-2d02d1394323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0725f-8562-49c2-83fa-11a702e5c78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0725f-8562-49c2-83fa-11a702e5c78d.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "4e38df2b-44f9-5199-bff8-87c0aa26a91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55d42ad-63b1-4468-8da0-c245db4d0ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55d42ad-63b1-4468-8da0-c245db4d0ae3.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9137,7 +9137,7 @@
         },
         {
             "id": "335a7198-afd5-582a-a988-51b077a203f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f29231c-dd21-4a45-a1f0-464d338128ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f29231c-dd21-4a45-a1f0-464d338128ed.jpg?1",
             "name": "Morph",
             "text": "",
             "colours": [],
@@ -9164,7 +9164,7 @@
         },
         {
             "id": "bf5f7333-ba0e-5c38-969e-c29de3b1d417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a70dfe0-874c-473a-a26e-1f88a842df41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a70dfe0-874c-473a-a26e-1f88a842df41.jpg?1",
             "name": "Narset Transcendent Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ELD.json
+++ b/Assets/Resources/Sets/ELD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7ebde572-911a-5ce4-a607-fe21718e01e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b12e7-bb93-4eb6-bad1-b256a6ccff4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b12e7-bb93-4eb6-bad1-b256a6ccff4e.jpg?1",
             "name": "Acclaimed Contender",
             "text": "When Acclaimed Contender enters the battlefield, if you control another Knight, look at the top five cards of your library. You may reveal a Knight, Aura, Equipment, or legendary artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "f045cc48-0343-50fe-8298-8b862cea93bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9713032-2956-4564-b5f5-2dd16245a4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9713032-2956-4564-b5f5-2dd16245a4e6.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "53ff6480-29a3-564c-8006-baea54baf120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ca60c-7ed4-49e1-b54a-91d129539375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ca60c-7ed4-49e1-b54a-91d129539375.jpg?1",
             "name": "Archon of Absolution",
             "text": "Flying\nProtection from white (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything white.)\nCreatures can't attack you or a planeswalker you control unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "aaea1863-e4d3-5686-acfe-95f4dfac4bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32fa360-6c41-4146-931b-c19e9a766803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32fa360-6c41-4146-931b-c19e9a766803.jpg?1",
             "name": "Ardenvale Paladin",
             "text": "Adamant \u2014 If at least three white mana was spent to cast this spell, Ardenvale Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "387eb117-53ec-5272-b887-9ac2b3221bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "Flying",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "345c03f4-4667-55e3-bf82-c53a360a1675",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "Tap up to two target creatures. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "2e70ab93-91d9-5b1b-9da5-0b0fbc33a36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de43c67-7dfe-4282-b433-4e394366d2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de43c67-7dfe-4282-b433-4e394366d2e9.jpg?1",
             "name": "Bartered Cow",
             "text": "When Bartered Cow dies or when you discard it, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "deadf543-11a5-5b9f-8960-c4a3cbd5bac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6ee4eb-70b2-4f99-9d54-5caf2d3713be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6ee4eb-70b2-4f99-9d54-5caf2d3713be.jpg?1",
             "name": "Beloved Princess",
             "text": "Lifelink\nBeloved Princess can't be blocked by creatures with power 3 or greater.",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "51a8ed36-1e45-5c6b-9417-a237507b3b4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb94950-3f3e-4876-84f8-d5e4d9cfecee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb94950-3f3e-4876-84f8-d5e4d9cfecee.jpg?1",
             "name": "Charming Prince",
             "text": "When Charming Prince enters the battlefield, choose one \u2014\n\u2022 Scry 2.\n\u2022 You gain 3 life.\n\u2022 Exile another target creature you own. Return it to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "eacb708a-214c-5991-9e1e-07c00625acfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79093d00-362d-4d07-8a0a-cf5e1ccf9c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79093d00-362d-4d07-8a0a-cf5e1ccf9c0f.jpg?1",
             "name": "The Circle of Loyalty",
             "text": "This spell costs {1} less to cast for each Knight you control.\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "966e7d05-c334-546e-b610-749ea04e84f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6072d9b0-d3c7-46f4-bd24-095bb13c4dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6072d9b0-d3c7-46f4-bd24-095bb13c4dea.jpg?1",
             "name": "Deafening Silence",
             "text": "Each player can't cast more than one noncreature spell each turn.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "9e5550cb-10e1-59ca-b5c7-435c3dc263fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "Flying",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "87571e42-2272-5c7a-9d6b-1e1156b0f840",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "Target creature gets +2/+1 and gains flying until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "db73594f-d131-5b59-8f82-c5a1f4c94b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769cddf0-2078-456b-a622-057571464fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769cddf0-2078-456b-a622-057571464fe7.jpg?1",
             "name": "Flutterfox",
             "text": "As long as you control an artifact or enchantment, Flutterfox has flying.",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "54d3da09-0dfe-5e35-a33b-2aea643d8651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ce113c-53da-4fab-b7c9-fc3df248b65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ce113c-53da-4fab-b7c9-fc3df248b65e.jpg?1",
             "name": "Fortifying Provisions",
             "text": "Creatures you control get +0/+1.\nWhen Fortifying Provisions enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "91680403-7ed7-5c5a-8f38-b2005200e27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "{1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "6322919e-dd2c-5ca6-9408-fecd46c33671",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "Destroy target creature with power 4 or greater. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "1b262ddb-de89-5a53-983f-8d6e3d983dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1c51-d245-4771-bf61-415297e4f9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1c51-d245-4771-bf61-415297e4f9d5.jpg?1",
             "name": "Glass Casket",
             "text": "When Glass Casket enters the battlefield, exile target creature an opponent controls with converted mana cost 3 or less until Glass Casket leaves the battlefield.",
             "colours": [
@@ -636,7 +636,7 @@
         },
         {
             "id": "ddca76fa-b633-56fb-9503-e4117d19e58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d85d5-a6f0-4cc5-9fd6-6b329aae2e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d85d5-a6f0-4cc5-9fd6-6b329aae2e5b.jpg?1",
             "name": "Happily Ever After",
             "text": "When Happily Ever After enters the battlefield, each player gains 5 life and draws a card.\nAt the beginning of your upkeep, if there are five colors among permanents you control, there are six or more card types among permanents you control and/or cards in your graveyard, and your life total is greater than or equal to your starting life total, you win the game.",
             "colours": [
@@ -670,7 +670,7 @@
         },
         {
             "id": "1922fc6f-2bec-5803-aa7a-3f8132d01a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7093834-9627-4da2-9322-c03bfd5b3a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7093834-9627-4da2-9322-c03bfd5b3a71.jpg?1",
             "name": "Harmonious Archon",
             "text": "Flying\nNon-Archon creatures have base power and toughness 3/3.\nWhen Harmonious Archon enters the battlefield, create two 1/1 white Human creature tokens.",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "3d05d919-983b-5efa-a65a-a429f6f2529f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663b3e6f-1099-4de8-a0a7-6f1919c38010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663b3e6f-1099-4de8-a0a7-6f1919c38010.jpg?1",
             "name": "Hushbringer",
             "text": "Flying, lifelink\nCreatures entering the battlefield or dying don't cause abilities to trigger.",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "83b512cf-106c-5461-a31a-f8c842583409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49653d-cd4e-40a7-99de-fc531b5d8594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49653d-cd4e-40a7-99de-fc531b5d8594.jpg?1",
             "name": "Knight of the Keep",
             "text": "",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "83bba8bd-dc90-5739-ba31-df347823775e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ab467-be97-4b84-a73d-b03484d06b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ab467-be97-4b84-a73d-b03484d06b97.jpg?1",
             "name": "Linden, the Steadfast Queen",
             "text": "Vigilance\nWhenever a white creature you control attacks, you gain 1 life.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "5c7667ca-4006-532b-a8b5-eb9dcdd841f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "Vigilance",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "56effca8-14d7-5489-8bf6-e308c1314c64",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "451f195e-d557-50cc-ae0b-39dc7c099239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1028aa10-aded-4aeb-b70f-d7a9003ae846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1028aa10-aded-4aeb-b70f-d7a9003ae846.jpg?1",
             "name": "Mysterious Pathlighter",
             "text": "Flying\nEach creature you control that has an Adventure enters the battlefield with an additional +1/+1 counter on it. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "b2cd346d-f5c5-5246-99e2-270b865502c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663e0208-81c3-4a76-bcc2-bc59cf8ca649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663e0208-81c3-4a76-bcc2-bc59cf8ca649.jpg?1",
             "name": "Outflank",
             "text": "Outflank deals damage to target attacking or blocking creature equal to the number of creatures you control.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "4c953c2a-76b6-53ed-851c-aefe087e111c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877bd423-83ff-4a28-b0d2-447a7821bb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877bd423-83ff-4a28-b0d2-447a7821bb8c.jpg?1",
             "name": "Prized Griffin",
             "text": "Flying",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "805f103f-c18b-5dd0-a69e-afa38e2ea3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d7ff0-70b6-4221-b50b-3ee8547e1b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d7ff0-70b6-4221-b50b-3ee8547e1b0a.jpg?1",
             "name": "Rally for the Throne",
             "text": "Create two 1/1 white Human creature tokens.\nAdamant \u2014 If at least three white mana was spent to cast this spell, you gain 1 life for each creature you control.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "3699ea8c-6b2d-5ef2-8aad-85f3b7a5ef8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "Vigilance",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "d7d28769-c1e9-53a0-8f31-cfc44919d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "Destroy all non-Giant creatures. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "13a45c3e-acf7-546e-a67a-c293e9e8184e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910df2-e288-4fa0-9859-c5ca35da2d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910df2-e288-4fa0-9859-c5ca35da2d55.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "1dddec28-ae0e-512e-a8a8-e93e1606fb8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "8580848d-5d70-5f53-966f-2c0979f71e02",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "Return target permanent you control to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "161c939a-5d1b-5331-959a-b2a3417f7547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7791f46e-f772-4d3f-824e-52b4fc721b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7791f46e-f772-4d3f-824e-52b4fc721b58.jpg?1",
             "name": "Shining Armor",
             "text": "Flash\nWhen Shining Armor enters the battlefield, attach it to target Knight you control.\nEquipped creature gets +0/+2 and has vigilance.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "073b5d29-9abc-56d4-b503-844d87776846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad7efd1-5f53-4466-9a02-c474c265298a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad7efd1-5f53-4466-9a02-c474c265298a.jpg?1",
             "name": "Silverflame Ritual",
             "text": "Put a +1/+1 counter on each creature you control.\nAdamant \u2014 If at least three white mana was spent to cast this spell, creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "bc7f6a84-51f1-5f5b-af14-ec1719cebb05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "f5bbbeae-e0b7-50e2-8666-197c3831aa8d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "Target creature gets +2/+2 until end of turn. Untap it. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "714b9b3c-2d29-559d-8060-e872a04282cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cddb2d2-d813-4b83-a592-380ba4edf54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cddb2d2-d813-4b83-a592-380ba4edf54f.jpg?1",
             "name": "Syr Alin, the Lion's Claw",
             "text": "First strike\nWhenever Syr Alin, the Lion's Claw attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1373,7 +1373,7 @@
         },
         {
             "id": "ed77de73-efcb-564f-931b-8fea1f03b36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974e84ce-5b51-4bd7-9a4d-b64d8f8f62d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974e84ce-5b51-4bd7-9a4d-b64d8f8f62d4.jpg?1",
             "name": "Trapped in the Tower",
             "text": "Enchant creature without flying\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1407,7 +1407,7 @@
         },
         {
             "id": "62c672b0-87f3-5e93-a9b8-d9de6013926a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4bac2-f6cb-4712-8510-a63657c43a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4bac2-f6cb-4712-8510-a63657c43a5c.jpg?1",
             "name": "True Love's Kiss",
             "text": "Exile target artifact or enchantment.\nDraw a card.",
             "colours": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "a25e879a-579b-59fd-b069-4deff1f0aca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1",
             "name": "Venerable Knight",
             "text": "When Venerable Knight dies, put a +1/+1 counter on target Knight you control.",
             "colours": [
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "4b50fe89-fa8b-5e05-9fa9-586c5b67f9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2bde2d-e5df-407e-993c-85880dbb6045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2bde2d-e5df-407e-993c-85880dbb6045.jpg?1",
             "name": "Worthy Knight",
             "text": "Whenever you cast a Knight spell, create a 1/1 white Human creature token.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "dbc1152c-966d-5361-bfe8-112dfcf79595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1a3fec-39de-4223-9da2-22749a58cd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1a3fec-39de-4223-9da2-22749a58cd62.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "b4fa27bb-bf91-5c50-b22d-9d5656230820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "Flying",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "dfd33ae1-2d4e-570e-b5ed-85704ba766db",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on it.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "51c8a322-0601-51ed-b5f9-bebb5d97b5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "Flash\nFlying\nBrazen Borrower can block only creatures with flying.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "6d05f540-87ee-53cb-b9ae-dcb9d1ff8844",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "Return target nonland permanent an opponent controls to its owner's hand.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "f543c0a9-c3bf-5daa-9ab6-7d4fb5f47f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f97d9e-650b-4b69-8733-d80c8e0f723f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f97d9e-650b-4b69-8733-d80c8e0f723f.jpg?1",
             "name": "Charmed Sleep",
             "text": "Enchant creature\nWhen Charmed Sleep enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "da03442a-bfc6-538b-87e1-c98b8d5cfb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9347802a-0971-443c-867a-cb9400f18d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9347802a-0971-443c-867a-cb9400f18d5c.jpg?1",
             "name": "Corridor Monitor",
             "text": "When Corridor Monitor enters the battlefield, untap target artifact or creature you control.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "fbf9e0ad-f134-57b6-b4a4-929f78887993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77500b53-0852-4d6a-bfe3-b1e8ef5a12cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77500b53-0852-4d6a-bfe3-b1e8ef5a12cd.jpg?1",
             "name": "Didn't Say Please",
             "text": "Counter target spell. Its controller puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "be49dcfd-70d3-52a6-a597-912540e42e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4b9a8a-b42a-46fb-b0d0-9cf800f63c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4b9a8a-b42a-46fb-b0d0-9cf800f63c8a.jpg?1",
             "name": "Emry, Lurker of the Loch",
             "text": "This spell costs {1} less to cast for each artifact you control.\nWhen Emry, Lurker of the Loch enters the battlefield, put the top four cards of your library into your graveyard.\n{T}: Choose target artifact card in your graveyard. You may cast that card this turn. (You still pay its costs. Timing rules still apply.)",
             "colours": [
@@ -1831,7 +1831,7 @@
         },
         {
             "id": "c02816a4-59bf-5549-b5c7-59b86c760f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "Flying\n{1}{U}, Discard two cards: Return Fae of Wishes to its owner's hand.",
             "colours": [
@@ -1868,7 +1868,7 @@
         },
         {
             "id": "bb837ff4-f864-52e5-a244-eb416d598986",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "You may choose a noncreature card you own from outside the game, reveal it, and put it into your hand.",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "1f36d944-7a4b-5fdf-8c17-63e550a58c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789c5c2b-3e51-4f6c-ac76-d276facf716f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789c5c2b-3e51-4f6c-ac76-d276facf716f.jpg?1",
             "name": "Faerie Vandal",
             "text": "Flash\nFlying\nWhenever you draw your second card each turn, put a +1/+1 counter on Faerie Vandal.",
             "colours": [
@@ -1939,7 +1939,7 @@
         },
         {
             "id": "c5bdfd03-bf15-5ce3-9729-fd38098f5362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc67d1-1018-4a15-ab5f-377fd11dcd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc67d1-1018-4a15-ab5f-377fd11dcd3d.jpg?1",
             "name": "Folio of Fancies",
             "text": "Players have no maximum hand size.\n{X}{X}, {T}: Each player draws X cards.\n{2}{U}, {T}: Each opponent puts a number of cards equal to the number of cards in their hand from the top of their library into their graveyard.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "5d15164e-fdd8-55f0-a4f9-1a88207b9c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cbb20-3c4e-480b-a330-9c6d6b39d12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cbb20-3c4e-480b-a330-9c6d6b39d12f.jpg?1",
             "name": "Frogify",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1. (It loses all other card types and creature types.)",
             "colours": [
@@ -2007,7 +2007,7 @@
         },
         {
             "id": "0f6208a8-2b72-5e81-b597-d7838749f951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ddce0d-f22a-4fcd-9a4a-d71938750ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ddce0d-f22a-4fcd-9a4a-d71938750ba1.jpg?1",
             "name": "Gadwick, the Wizened",
             "text": "When Gadwick, the Wizened enters the battlefield, draw X cards.\nWhenever you cast a blue spell, tap target nonland permanent an opponent controls.",
             "colours": [
@@ -2046,7 +2046,7 @@
         },
         {
             "id": "57214924-fcae-54b4-a6e6-0b9ffe18897d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "Flying",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "c5652c2c-a4ff-58e4-a8e1-eb4f7cfffe2e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "Counter target spell with converted mana cost 3 or less. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "d58d86a0-c935-5432-b26c-e8dca90e771e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c838f08e-7fb6-46e7-83bb-dce8877d6c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c838f08e-7fb6-46e7-83bb-dce8877d6c87.jpg?1",
             "name": "Into the Story",
             "text": "This spell costs {3} less to cast if an opponent has seven or more cards in their graveyard.\nDraw four cards.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "30c1cb26-cafa-565d-a597-5f226e8cf708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b89af1-7b22-4153-b42d-a2ea4e0f320c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b89af1-7b22-4153-b42d-a2ea4e0f320c.jpg?1",
             "name": "The Magic Mirror",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nYou have no maximum hand size.\nAt the beginning of your upkeep, put a knowledge counter on The Magic Mirror, then draw a card for each knowledge counter on The Magic Mirror.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "9cef53d2-7445-5fc0-8b4d-85f1a30bdbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058d01e-f705-4407-bd9e-a2d127afdf04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058d01e-f705-4407-bd9e-a2d127afdf04.jpg?1",
             "name": "Mantle of Tides",
             "text": "Equipped creature gets +1/+2.\nWhenever you draw your second card each turn, attach Mantle of Tides to target creature you control.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "2af500fe-ae8a-58c9-8cbe-9f4491fce2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "31468d7c-d6d2-55d4-80b3-661261e1eb69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "Target player puts the top four cards of their library into their graveyard. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "9eeb10fb-676b-52cd-9f26-4edf3f15f069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7f1148-7b1b-4969-a2f8-428de1e2e8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7f1148-7b1b-4969-a2f8-428de1e2e8ff.jpg?1",
             "name": "Midnight Clock",
             "text": "{T}: Add {U}.\n{2}{U}: Put an hour counter on Midnight Clock.\nAt the beginning of each upkeep, put an hour counter on Midnight Clock.\nWhen the twelfth hour counter is put on Midnight Clock, shuffle your hand and graveyard into your library, then draw seven cards. Exile Midnight Clock.",
             "colours": [
@@ -2327,7 +2327,7 @@
         },
         {
             "id": "54b1fa21-a848-51a5-aec8-63b087cced26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10c1407-d397-4caa-b7b7-e7d91ffd4ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10c1407-d397-4caa-b7b7-e7d91ffd4ee9.jpg?1",
             "name": "Mirrormade",
             "text": "You may have Mirrormade enter the battlefield as a copy of any artifact or enchantment on the battlefield.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "7ae19a7e-8232-5558-a377-6f57242ce9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c78c386-c64b-4fab-a718-f18b46360e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c78c386-c64b-4fab-a718-f18b46360e20.jpg?1",
             "name": "Mistford River Turtle",
             "text": "Whenever Mistford River Turtle attacks, another target attacking non-Human creature can't be blocked this turn.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "4425f1f0-f882-5eaf-a778-179a19cf963e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a658bbd-8d64-460b-87ae-ec8054204794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a658bbd-8d64-460b-87ae-ec8054204794.jpg?1",
             "name": "Moonlit Scavengers",
             "text": "When Moonlit Scavengers enters the battlefield, if you control an artifact or enchantment, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "5651bd95-cb41-5266-8654-93707f0c4f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe04cb8-a8b9-4241-baae-b398a2509a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe04cb8-a8b9-4241-baae-b398a2509a3a.jpg?1",
             "name": "Mystical Dispute",
             "text": "This spell costs {2} less to cast if it targets a blue spell.\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "3bb348f6-c64a-5540-a052-40b799c0301b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3669391-8f64-4904-b432-0f0582f30449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3669391-8f64-4904-b432-0f0582f30449.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "55aefaee-be7d-52f8-a75a-8518a348ffc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659092e-4fe8-42be-ab03-efc99ed37436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659092e-4fe8-42be-ab03-efc99ed37436.jpg?1",
             "name": "Overwhelmed Apprentice",
             "text": "When Overwhelmed Apprentice enters the battlefield, each opponent puts the top two cards of their library into their graveyard. Then you scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "a86a55eb-9812-530b-9618-92eb860c2e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "Whenever Queen of Ice deals combat damage to a creature, tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "97f40d3e-37a6-5923-8387-52e5fe12e8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "06db99b2-a318-5d62-ae7e-4440f7ab27b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeffc3c0-567c-442f-ba06-b7d9617c5789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeffc3c0-567c-442f-ba06-b7d9617c5789.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "aa7f274a-6812-5560-b5de-9263df65e0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3aa4-4b46-4daa-a7a8-400a20c59435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3aa4-4b46-4daa-a7a8-400a20c59435.jpg?1",
             "name": "Sage of the Falls",
             "text": "Whenever Sage of the Falls or another non-Human creature enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "dc1ec750-ccef-5538-a559-0dce7969741a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421650f2-1b34-4a36-9675-9424997c9d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421650f2-1b34-4a36-9675-9424997c9d0b.jpg?1",
             "name": "So Tiny",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-0. It gets -6/-0 instead as long as its controller has seven or more cards in their graveyard.",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "ab73b88e-b751-57d7-958c-6edb6d97f80a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d361328-8b0a-40a0-b5c0-215398fdfb47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d361328-8b0a-40a0-b5c0-215398fdfb47.jpg?1",
             "name": "Steelgaze Griffin",
             "text": "Flying\nWhenever you draw your second card each turn, Steelgaze Griffin gets +2/+0 until end of turn.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "ed815b0b-76c6-5a95-bae8-f4d29130c55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a7698-57fb-41f6-86d4-251c7d444c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a7698-57fb-41f6-86d4-251c7d444c6a.jpg?1",
             "name": "Stolen by the Fae",
             "text": "Return target creature with converted mana cost X to its owner's hand. You create X 1/1 blue Faerie creature tokens with flying.",
             "colours": [
@@ -2772,7 +2772,7 @@
         },
         {
             "id": "e0fb0b08-1121-5a60-9115-4edde0db4ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a0817-2e9c-4d98-974c-2d3e5c37e1a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a0817-2e9c-4d98-974c-2d3e5c37e1a2.jpg?1",
             "name": "Syr Elenora, the Discerning",
             "text": "Syr Elenora, the Discerning's power is equal to the number of cards in your hand.\nWhen Syr Elenora enters the battlefield, draw a card.\nSpells your opponents cast that target Syr Elenora cost {2} more to cast.",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "e739f8b6-e4e2-5208-bf52-8b8088c5ae3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ad850-5801-4654-a388-f86be20a43bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ad850-5801-4654-a388-f86be20a43bf.jpg?1",
             "name": "Tome Raider",
             "text": "Flying\nWhen Tome Raider enters the battlefield, draw a card.",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "ac08f109-cef3-5819-ba32-583086587870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a37dcb-4a18-4f03-b28c-27188a1a5ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a37dcb-4a18-4f03-b28c-27188a1a5ec1.jpg?1",
             "name": "Turn into a Pumpkin",
             "text": "Return target nonland permanent to its owner's hand. Draw a card.\nAdamant \u2014 If at least three blue mana was spent to cast this spell, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -2875,7 +2875,7 @@
         },
         {
             "id": "d0e4c4f4-1432-527e-ac41-34b2fcb4fe96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1de1d84-e548-409d-b9ec-d2665477b43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1de1d84-e548-409d-b9ec-d2665477b43d.jpg?1",
             "name": "Unexplained Vision",
             "text": "Draw three cards.\nAdamant \u2014 If at least three blue mana was spent to cast this spell, scry 3.",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "30e7a954-da07-5e47-92f3-53abf5b21296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff1c8d-0f25-4bec-bd50-208ae2ac0aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff1c8d-0f25-4bec-bd50-208ae2ac0aac.jpg?1",
             "name": "Vantress Gargoyle",
             "text": "Flying\nVantress Gargoyle can't attack unless defending player has seven or more cards in their graveyard.\nVantress Gargoyle can't block unless you have four or more cards in hand.\n{T}: Each player puts the top card of their library into their graveyard.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "7d2b6618-87c5-52bd-a787-1024d040eea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dd633f-9a07-47df-adb1-36013fc2f43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dd633f-9a07-47df-adb1-36013fc2f43a.jpg?1",
             "name": "Vantress Paladin",
             "text": "Flying\nAdamant \u2014 If at least three blue mana was spent to cast this spell, Vantress Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "626d95b7-56c7-5b24-99e3-baba831fc708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9358d5d-726e-43e0-a58e-4cfe7c755913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9358d5d-726e-43e0-a58e-4cfe7c755913.jpg?1",
             "name": "Wishful Merfolk",
             "text": "Defender\n{1}{U}: Wishful Merfolk loses defender and becomes a Human until end of turn.",
             "colours": [
@@ -3013,7 +3013,7 @@
         },
         {
             "id": "b55ab864-594e-5942-ae07-253cd2973b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3132f-f897-4a7a-9de4-c6388e83f5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3132f-f897-4a7a-9de4-c6388e83f5ad.jpg?1",
             "name": "Witching Well",
             "text": "When Witching Well enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{3}{U}, Sacrifice Witching Well: Draw two cards.",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "c699a4f4-1295-5cce-89d4-e7c0fda5a1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ace28-9a33-4f0d-b8c8-f5517f20ccf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ace28-9a33-4f0d-b8c8-f5517f20ccf1.jpg?1",
             "name": "Ayara, First of Locthwain",
             "text": "Whenever Ayara, First of Locthwain or another black creature enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.\n{T}, Sacrifice another black creature: Draw a card.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "ca7c4ece-bea2-52fb-b56e-e3ceecf18a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a4d090-1bb7-4334-ab22-e2527391e79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a4d090-1bb7-4334-ab22-e2527391e79b.jpg?1",
             "name": "Bake into a Pie",
             "text": "Destroy target creature. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "179d04be-61ce-5152-bb33-c4ada8c11771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45707c22-fce8-4dbd-9d19-73f08c68f449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45707c22-fce8-4dbd-9d19-73f08c68f449.jpg?1",
             "name": "Barrow Witches",
             "text": "When Barrow Witches enters the battlefield, return target Knight card from your graveyard to your hand.",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "804f8427-d707-5bfc-8fa4-b9b8459763ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3c992a-70b5-4d3c-9a96-93c3365691ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3c992a-70b5-4d3c-9a96-93c3365691ac.jpg?1",
             "name": "Belle of the Brawl",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Belle of the Brawl attacks, other Knights you control get +1/+0 until end of turn.",
             "colours": [
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "1854518a-e0c9-54c8-ae5d-4c3448793a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0a63bb-dd94-429f-aa9b-21f3d1c53ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0a63bb-dd94-429f-aa9b-21f3d1c53ae5.jpg?1",
             "name": "Blacklance Paragon",
             "text": "Flash\nWhen Blacklance Paragon enters the battlefield, target Knight gains deathtouch and lifelink until end of turn.",
             "colours": [
@@ -3223,7 +3223,7 @@
         },
         {
             "id": "bd247c88-9207-5d60-9033-330ab0a2594e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf282fe-83fd-4208-b46f-dae76e3a7f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf282fe-83fd-4208-b46f-dae76e3a7f62.jpg?1",
             "name": "Bog Naughty",
             "text": "Flying\n{2}{B}, Sacrifice a Food: Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "a18b87d1-223f-5c9f-983f-df9a2df5d40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a539a23-8383-4525-82dd-acfe1d219fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a539a23-8383-4525-82dd-acfe1d219fe9.jpg?1",
             "name": "Cauldron Familiar",
             "text": "When Cauldron Familiar enters the battlefield, each opponent loses 1 life and you gain 1 life.\nSacrifice a Food: Return Cauldron Familiar from your graveyard to the battlefield.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "d2fbe660-727d-54c3-8236-017da88bbded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55cdc15-e289-49a0-94d9-d0a118ad0a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55cdc15-e289-49a0-94d9-d0a118ad0a2a.jpg?1",
             "name": "A-Cauldron Familiar",
             "text": "",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "ab5b6ad3-3d04-552e-8310-c1b83d41ecb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb69473f-de99-43a7-b094-429465ae735c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb69473f-de99-43a7-b094-429465ae735c.jpg?1",
             "name": "The Cauldron of Eternity",
             "text": "This spell costs {2} less to cast for each creature card in your graveyard.\nWhenever a creature you control dies, put it on the bottom of its owner's library.\n{2}{B}, {T}, Pay 2 life: Return target creature card from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "92e12af9-81f7-53c4-ab48-bcaa708da3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db19a94-1170-45a0-9f06-893bf58b7233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db19a94-1170-45a0-9f06-893bf58b7233.jpg?1",
             "name": "Cauldron's Gift",
             "text": "Adamant \u2014 If at least three black mana was spent to cast this spell, put the top four cards of your library into your graveyard.\nYou may choose a creature card in your graveyard. If you do, return it to the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "ca832926-1143-5474-93f5-93aa7b75ea8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85929131-4df6-415c-b592-aefb2943c477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85929131-4df6-415c-b592-aefb2943c477.jpg?1",
             "name": "Clackbridge Troll",
             "text": "Trample, haste\nWhen Clackbridge Troll enters the battlefield, target opponent creates three 0/1 white Goat creature tokens.\nAt the beginning of combat on your turn, any opponent may sacrifice a creature. If a player does, tap Clackbridge Troll, you gain 3 life, and you draw a card.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "10939fcd-ecb1-51b0-9d0d-4a342a446cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63da83fe-fa59-40cb-a42e-e1b14b650bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63da83fe-fa59-40cb-a42e-e1b14b650bc8.jpg?1",
             "name": "Epic Downfall",
             "text": "Exile target creature with converted mana cost 3 or greater.",
             "colours": [
@@ -3460,7 +3460,7 @@
         },
         {
             "id": "406ca902-1edc-57f7-b93c-66871e97f144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9bb2f3-a7c7-4e8f-ba39-44e6acd9240b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9bb2f3-a7c7-4e8f-ba39-44e6acd9240b.jpg?1",
             "name": "Eye Collector",
             "text": "Flying\nWhenever Eye Collector deals combat damage to a player, each player puts the top card of their library into their graveyard.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "cb8a0180-b10a-5a37-8b7a-4290fd69af3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a90af0-eb40-40da-bf4b-f0af687c6430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a90af0-eb40-40da-bf4b-f0af687c6430.jpg?1",
             "name": "Festive Funeral",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "06e89b89-704a-5bed-a7d1-c2ac9ab2d14e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f79ec4-3722-4fda-824b-e80dc7608d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f79ec4-3722-4fda-824b-e80dc7608d01.jpg?1",
             "name": "Foreboding Fruit",
             "text": "Target player draws two cards and loses 2 life.\nAdamant \u2014 If at least three black mana was spent to cast this spell, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "5fcecdd6-f114-5515-9a86-62fc4074c0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7873c1f9-572c-4740-82f8-cf3cbc7318d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7873c1f9-572c-4740-82f8-cf3cbc7318d0.jpg?1",
             "name": "Forever Young",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "981642e0-5519-5928-95d6-c1a838185583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "Deathtouch",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "79fca063-ad37-5261-9a73-feab8e20f045",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "65a9a6aa-8209-524c-9c9f-986e67c17db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050c03f9-ccbd-4dcc-9789-8013875ef470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050c03f9-ccbd-4dcc-9789-8013875ef470.jpg?1",
             "name": "Giant's Skewer",
             "text": "Equipped creature gets +2/+1.\nWhenever equipped creature deals combat damage to a creature, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "a99e9a94-d585-50c1-82c2-01b3af5ee46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea45e972-6e4a-4854-9be3-6ffb24e7d7a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea45e972-6e4a-4854-9be3-6ffb24e7d7a5.jpg?1",
             "name": "Lash of Thorns",
             "text": "Target creature gets +2/+1 and gains deathtouch until end of turn.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "0aff230e-db52-528b-b87f-4187ed9fb494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6f21a8-3dd0-42af-8a93-84f98968c781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6f21a8-3dd0-42af-8a93-84f98968c781.jpg?1",
             "name": "Locthwain Paladin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nAdamant \u2014 If at least three black mana was spent to cast this spell, Locthwain Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "a5837977-dd65-5900-beed-b2159f4a5b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6139d3-5397-4403-9c1e-312c11a7542b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6139d3-5397-4403-9c1e-312c11a7542b.jpg?1",
             "name": "Lost Legion",
             "text": "When Lost Legion enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "59ede61d-f18d-562c-b013-a12e2889af5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc7e996-151f-4d88-8e1e-91bb88f5db02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc7e996-151f-4d88-8e1e-91bb88f5db02.jpg?1",
             "name": "Malevolent Noble",
             "text": "{2}, Sacrifice an artifact or another creature: Put a +1/+1 counter on Malevolent Noble.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "d0636f61-06a4-517c-8778-678c421c6076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397fd49b-a520-4b0e-9ab9-71675ab5969d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397fd49b-a520-4b0e-9ab9-71675ab5969d.jpg?1",
             "name": "Memory Theft",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. You may put a card that has an Adventure that player owns from exile into that player's graveyard.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "1583e21a-84a4-5299-b3aa-ab4dec02d2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "Lifelink\nWhen Murderous Rider dies, put it on the bottom of its owner's library.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "7d27e18f-6ffa-5328-a13b-dfb41a2f0109",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "Destroy target creature or planeswalker. You lose 2 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "78db89fe-e6e4-502e-9571-11e131189fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9173ffda-1d3b-4dab-8dcb-de44717de464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9173ffda-1d3b-4dab-8dcb-de44717de464.jpg?1",
             "name": "Oathsworn Knight",
             "text": "Oathsworn Knight enters the battlefield with four +1/+1 counters on it.\nOathsworn Knight attacks each combat if able.\nIf damage would be dealt to Oathsworn Knight while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from it.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "a9879e18-ba17-5577-b5da-7e6b433804b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "Flying\nOrder of Midnight can't block.",
             "colours": [
@@ -4013,7 +4013,7 @@
         },
         {
             "id": "c45098e6-b676-5758-ac75-f83d41fe7afa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4049,7 +4049,7 @@
         },
         {
             "id": "372145ed-c7a8-5494-b1e6-6f5aec74d7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7962fe-b715-4981-86c3-223bad9b1899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7962fe-b715-4981-86c3-223bad9b1899.jpg?1",
             "name": "Piper of the Swarm",
             "text": "Rats you control have menace.\n{1}{B}, {T}: Create a 1/1 black Rat creature token.\n{2}{B}{B}, {T}, Sacrifice three Rats: Gain control of target creature.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "27e99eca-011b-5569-b836-ee0b50b33e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2c11d-dfc3-4ba9-8c0f-a98114090396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2c11d-dfc3-4ba9-8c0f-a98114090396.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "Flying, haste\nWhenever Rankle, Master of Pranks deals combat damage to a player, choose any number \u2014\n\u2022 Each player discards a card.\n\u2022 Each player loses 1 life and draws a card.\n\u2022 Each player sacrifices a creature.",
             "colours": [
@@ -4126,7 +4126,7 @@
         },
         {
             "id": "223aa9a5-a95c-53fd-bdd2-aee24b7fa7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "Whenever Reaper of Night attacks, if defending player has two or fewer cards in hand, it gains flying until end of turn.",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "57d7d404-cb16-591a-97e6-43a71d32701c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "Target opponent discards two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "0d475c4c-74c6-57d7-ad62-d5dde25e7612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ff657-aa44-4336-895a-87518159cef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ff657-aa44-4336-895a-87518159cef6.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "f6e03176-0962-590d-885e-627b93867f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3474289a-193e-452d-b248-e53ee99e22c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3474289a-193e-452d-b248-e53ee99e22c0.jpg?1",
             "name": "Revenge of Ravens",
             "text": "Whenever a creature attacks you or a planeswalker you control, that creature's controller loses 1 life and you gain 1 life.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "8c533a75-2816-5c2e-8f1d-79610a7bc06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "Lifelink",
             "colours": [
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "c46d7d74-aa23-5f63-870d-bcda1f77c08a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "You gain X life and each opponent loses X life, where X is the number of Knights you control.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "adfe4990-cc5c-5bee-a0db-be6dc29b3a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edae2c29-1418-477c-9efe-e53fa6c7fe93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edae2c29-1418-477c-9efe-e53fa6c7fe93.jpg?1",
             "name": "Specter's Shriek",
             "text": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, that player exiles that card. If a nonblack card is exiled this way, exile a card from your hand.",
             "colours": [
@@ -4367,7 +4367,7 @@
         },
         {
             "id": "0cf485ea-1155-591d-967c-e74264331362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a808868f-aea8-4651-9357-85a4d7b4f290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a808868f-aea8-4651-9357-85a4d7b4f290.jpg?1",
             "name": "Syr Konrad, the Grim",
             "text": "Whenever another creature dies, or a creature card is put into a graveyard from anywhere other than the battlefield, or a creature card leaves your graveyard, Syr Konrad, the Grim deals 1 damage to each opponent.\n{1}{B}: Each player puts the top card of their library into their graveyard.",
             "colours": [
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "91232911-b35d-54ef-8c98-a215163c31fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b217e5a-3c18-48b4-8124-b8c4fd7b2df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b217e5a-3c18-48b4-8124-b8c4fd7b2df1.jpg?1",
             "name": "Tempting Witch",
             "text": "When Tempting Witch enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}, {T}, Sacrifice a Food: Target player loses 3 life.",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "5b65ac34-7762-58bd-baaf-972980afbefa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cd91b2-0f9b-4582-ad90-32fa3ee1fde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cd91b2-0f9b-4582-ad90-32fa3ee1fde7.jpg?1",
             "name": "Wicked Guardian",
             "text": "When Wicked Guardian enters the battlefield, you may have it deal 2 damage to another creature you control. If you do, draw a card.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "628f1173-87ee-5b2f-a20d-9df587f09e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c17b01-ee5d-491a-8403-b3f819b778c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c17b01-ee5d-491a-8403-b3f819b778c4.jpg?1",
             "name": "Wishclaw Talisman",
             "text": "Wishclaw Talisman enters the battlefield with three wish counters on it.\n{1}, {T}, Remove a wish counter from Wishclaw Talisman: Search your library for a card, put it into your hand, then shuffle your library. An opponent gains control of Wishclaw Talisman. Activate this ability only during your turn.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "570ffb14-1814-5dfc-8eca-3ca858552ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf16457-3444-4130-b220-834b69d9faa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf16457-3444-4130-b220-834b69d9faa3.jpg?1",
             "name": "Witch's Vengeance",
             "text": "Creatures of the creature type of your choice get -3/-3 until end of turn.",
             "colours": [
@@ -4542,7 +4542,7 @@
         },
         {
             "id": "e6724d82-da78-52a6-80cd-7a8b1f49c0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe337c-4b8c-42ce-8c43-4c95051d09ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe337c-4b8c-42ce-8c43-4c95051d09ac.jpg?1",
             "name": "Barge In",
             "text": "Target attacking creature gets +2/+2 until end of turn. Each attacking non-Human creature gains trample until end of turn.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "3655e999-b971-5f4c-8547-b9bfb1b58d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6c0bc1-cb07-4009-83b1-1122381cf9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6c0bc1-cb07-4009-83b1-1122381cf9c4.jpg?1",
             "name": "Bloodhaze Wolverine",
             "text": "Whenever you draw your second card each turn, Bloodhaze Wolverine gets +1/+1 and gains first strike until end of turn.",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "ec072252-348d-5972-8bed-9f93586d2a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04b85e7-a401-42d5-9629-8d4b8c8a46b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04b85e7-a401-42d5-9629-8d4b8c8a46b0.jpg?1",
             "name": "Blow Your House Down",
             "text": "Up to three target creatures can't block this turn. Destroy any of them that are Walls.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "d26fdb0c-80d4-5ea2-af6e-adbd290fc163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Whenever Bonecrusher Giant becomes the target of a spell, Bonecrusher Giant deals 2 damage to that spell's controller.",
             "colours": [
@@ -4676,7 +4676,7 @@
         },
         {
             "id": "9ec1a801-76eb-57ae-a3a2-b8d2d1b06e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Damage can't be prevented this turn. Stomp deals 2 damage to any target.",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "74b27345-3ebb-53c3-9587-c86f2c74b154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c49e0e-4375-4e45-a57b-8df667e45ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c49e0e-4375-4e45-a57b-8df667e45ce6.jpg?1",
             "name": "Brimstone Trebuchet",
             "text": "Defender, reach\n{T}: Brimstone Trebuchet deals 1 damage to each opponent.\nWhenever a Knight enters the battlefield under your control, untap Brimstone Trebuchet.",
             "colours": [
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "fbd12dc3-997d-5df7-838e-cdc79e4b7fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17755d1b-3a56-4362-a534-85b35ceb1802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17755d1b-3a56-4362-a534-85b35ceb1802.jpg?1",
             "name": "Burning-Yard Trainer",
             "text": "Trample, haste\nWhen Burning-Yard Trainer enters the battlefield, another target Knight you control gets +2/+2 and gains trample and haste until end of turn.",
             "colours": [
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "4f39c093-f2d1-542d-93d8-d2f0ccbc490d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feaf1e6c-c7d9-4ac7-9aeb-c4b5d61548ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feaf1e6c-c7d9-4ac7-9aeb-c4b5d61548ec.jpg?1",
             "name": "Claim the Firstborn",
             "text": "Gain control of target creature with converted mana cost 3 or less until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "dc6df12a-75cb-52a0-8b19-f9d8644ec505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f738ca6-5254-4dbc-9f59-854e81c8dac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f738ca6-5254-4dbc-9f59-854e81c8dac2.jpg?1",
             "name": "Crystal Slipper",
             "text": "Equipped creature gets +1/+0 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "2786262b-6aac-5ed3-8ed1-ff3db07ab3a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaae15dd-11b6-4421-99e9-365c7fe4a5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaae15dd-11b6-4421-99e9-365c7fe4a5d6.jpg?1",
             "name": "Embercleave",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature you control.\nWhen Embercleave enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3}",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "01c6d9ad-8e56-55dc-87a4-53a637559403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcfe06b-3bb5-434e-acf4-4bfa8a94141d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcfe06b-3bb5-434e-acf4-4bfa8a94141d.jpg?1",
             "name": "Embereth Paladin",
             "text": "Haste\nAdamant \u2014 If at least three red mana was spent to cast this spell, Embereth Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "c77178a9-4d38-5736-835c-318a46fa7edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "f668c83c-f302-5d4e-87ad-c0e12cf6e110",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "Destroy target artifact. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "60fa1367-5c47-57b2-925d-cb0c5202db63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7005fd-5917-4f7d-9a7d-7ccc044d0f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7005fd-5917-4f7d-9a7d-7ccc044d0f87.jpg?1",
             "name": "Ferocity of the Wilds",
             "text": "Attacking non-Human creatures you control get +1/+0 and have trample.",
             "colours": [
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "55ba7cbf-7208-5e1f-9e14-25413e6d7fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d66db-5570-48a1-99cf-e0417517747b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d66db-5570-48a1-99cf-e0417517747b.jpg?1",
             "name": "Fervent Champion",
             "text": "First strike, haste\nWhenever Fervent Champion attacks, another target attacking Knight you control gets +1/+0 until end of turn.\nEquip abilities you activate that target Fervent Champion cost {3} less to activate.",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "3fb2a885-ed81-5522-bcbd-84e5c299fc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b16b0-f75f-42d8-9b24-947c1908e0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b16b0-f75f-42d8-9b24-947c1908e0f7.jpg?1",
             "name": "Fires of Invention",
             "text": "You can cast spells only during your turn and you can cast no more than two spells each turn.\nYou may cast spells with converted mana cost less than or equal to the number of lands you control without paying their mana costs.",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "1ee74ce9-713f-5e5c-977a-7d1dac645c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24729f25-e900-4a71-a304-7346eb17990a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24729f25-e900-4a71-a304-7346eb17990a.jpg?1",
             "name": "A-Fires of Invention",
             "text": "",
             "colours": [
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "e81cb093-7862-52d2-a148-7211d26acfce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28fe03-8269-41de-b766-42c3421aeaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28fe03-8269-41de-b766-42c3421aeaef.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to any target.",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "7ad805e7-bd7e-5568-89b3-8d6ff8af1722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bcf822-e129-45f6-9403-310ce9410f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bcf822-e129-45f6-9403-310ce9410f3b.jpg?1",
             "name": "Irencrag Feat",
             "text": "Add seven {R}. You can cast only one more spell this turn.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "af8e70cc-7a7f-5b03-9525-11af6e9cdc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7b0ead-5629-429d-bede-8154f3fae96d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7b0ead-5629-429d-bede-8154f3fae96d.jpg?1",
             "name": "Irencrag Pyromancer",
             "text": "Whenever you draw your second card each turn, Irencrag Pyromancer deals 3 damage to any target.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "c7767976-03e2-5440-8f2b-13c2b282d090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e725f04-5530-47f1-9f04-4cc13ed9348b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e725f04-5530-47f1-9f04-4cc13ed9348b.jpg?1",
             "name": "Joust",
             "text": "Choose target creature you control and target creature you don't control. The creature you control gets +2/+1 until end of turn if it's a Knight. Then those creatures fight each other. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5263,7 +5263,7 @@
         },
         {
             "id": "ef632a62-365a-5844-a27f-e7935f5a22ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4cabcc-fb29-4bf2-b5ba-32b8c96aefd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4cabcc-fb29-4bf2-b5ba-32b8c96aefd6.jpg?1",
             "name": "Mad Ratter",
             "text": "Whenever you draw your second card each turn, create two 1/1 black Rat creature tokens.",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "0908d356-67cc-5922-93be-e8884af020d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "{2}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "a2f5a90b-00bd-5821-9c58-8ace45bf7191",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "You may discard a card. If you do, draw a card. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "0c941678-45c6-5aab-a863-136c1e0b7a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e96f3dc-dc58-4034-8d3d-3ae74fa64562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e96f3dc-dc58-4034-8d3d-3ae74fa64562.jpg?1",
             "name": "Ogre Errant",
             "text": "Whenever Ogre Errant attacks, another target attacking Knight gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "f8fb069c-0608-5e3b-ab49-63ecb732cf84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa16922-3583-4f5b-8805-509b95a8da49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa16922-3583-4f5b-8805-509b95a8da49.jpg?1",
             "name": "Opportunistic Dragon",
             "text": "Flying\nWhen Opportunistic Dragon enters the battlefield, choose target Human or artifact an opponent controls. For as long as Opportunistic Dragon remains on the battlefield, gain control of that permanent, it loses all abilities, and it can't attack or block.",
             "colours": [
@@ -5441,7 +5441,7 @@
         },
         {
             "id": "3ce33ca7-473c-54ff-b205-cae6f3bc6c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9325398-41c3-4177-a64d-ea38cb7a8737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9325398-41c3-4177-a64d-ea38cb7a8737.jpg?1",
             "name": "Raging Redcap",
             "text": "Double strike",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "ed974790-983c-50e3-aee9-7d20cfe97c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd1dd34-d480-4dfd-9f82-73c4e24a11fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd1dd34-d480-4dfd-9f82-73c4e24a11fc.jpg?1",
             "name": "Redcap Melee",
             "text": "Redcap Melee deals 4 damage to target creature or planeswalker. If a nonred permanent is dealt damage this way, you sacrifice a land.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "c90440b6-1901-5f01-9173-0f734dc68ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cf5c4-6ba3-4fa0-9732-0a350c637c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cf5c4-6ba3-4fa0-9732-0a350c637c7a.jpg?1",
             "name": "Redcap Raiders",
             "text": "Whenever Redcap Raiders attacks, you may tap an untapped non-Human creature you control. If you do, Redcap Raiders gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "21d183eb-268f-5f52-93d6-57b81e615767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "Rimrock Knight can't block.",
             "colours": [
@@ -5580,7 +5580,7 @@
         },
         {
             "id": "cc319b2b-9191-5b58-8749-6d008be25878",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "Target creature gets +2/+0 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "1a9b9120-c7ad-5024-b948-4ae2d0adb3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecbe097-ba51-42e5-957c-382eb66c08f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecbe097-ba51-42e5-957c-382eb66c08f0.jpg?1",
             "name": "Robber of the Rich",
             "text": "Reach, haste\nWhenever Robber of the Rich attacks, if defending player has more cards in hand than you, exile the top card of their library. During any turn you attacked with a Rogue, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "2427f954-eead-5ea7-8188-5749103baa53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b74a806-ed74-458e-8903-d3d084e9f507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b74a806-ed74-458e-8903-d3d084e9f507.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "3261737f-2698-5f05-b714-6d1dffcf20cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f11135-e9ce-4e4c-bea7-72a46d326e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f11135-e9ce-4e4c-bea7-72a46d326e40.jpg?1",
             "name": "Searing Barrage",
             "text": "Searing Barrage deals 5 damage to target creature.\nAdamant \u2014 If at least three red mana was spent to cast this spell, Searing Barrage deals 3 damage to that creature's controller.",
             "colours": [
@@ -5718,7 +5718,7 @@
         },
         {
             "id": "0a00eb60-c3a1-5e43-9d87-0ce618a7f599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464adbae-70ea-48e1-b8ae-b404766f7a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464adbae-70ea-48e1-b8ae-b404766f7a5a.jpg?1",
             "name": "Seven Dwarves",
             "text": "Seven Dwarves gets +1/+1 for each other creature named Seven Dwarves you control.\nA deck can have up to seven cards named Seven Dwarves.",
             "colours": [
@@ -5752,7 +5752,7 @@
         },
         {
             "id": "4b2e454d-1fb5-596b-986d-ab0a1060f20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa89e28-c0a9-4b76-b0d5-8dcaa75bfd59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa89e28-c0a9-4b76-b0d5-8dcaa75bfd59.jpg?1",
             "name": "Skullknocker Ogre",
             "text": "Whenever Skullknocker Ogre deals damage to an opponent, that player discards a card at random. If the player does, they draw a card.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "beb3990e-ee5c-51e0-9651-e1e5a5f336c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b5b110-c430-4ffe-9fc1-8e6987f52d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b5b110-c430-4ffe-9fc1-8e6987f52d1e.jpg?1",
             "name": "Slaying Fire",
             "text": "Slaying Fire deals 3 damage to any target.\nAdamant \u2014 If at least three red mana was spent to cast this spell, it deals 4 damage instead.",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "78347b06-1230-5109-b5cc-99374e1ff619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b7a774-ca49-4291-8a19-cb5e475b10d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b7a774-ca49-4291-8a19-cb5e475b10d5.jpg?1",
             "name": "Sundering Stroke",
             "text": "Sundering Stroke deals 7 damage divided as you choose among one, two, or three targets. If at least seven red mana was spent to cast this spell, instead Sundering Stroke deals 7 damage to each of those permanents and/or players.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "a629cfa4-41d5-5591-81ad-6e1ce4173a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a249a-df47-4769-bb63-0d8ab3f2467c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a249a-df47-4769-bb63-0d8ab3f2467c.jpg?1",
             "name": "Syr Carah, the Bold",
             "text": "Whenever Syr Carah, the Bold or an instant or sorcery spell you control deals damage to a player, exile the top card of your library. You may play that card this turn.\n{T}: Syr Carah deals 1 damage to any target.",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "df65bf2d-7ffc-5a0e-b5be-bee84a9b7f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5923,7 +5923,7 @@
         },
         {
             "id": "33cf4573-fd62-5f4d-a278-9d258b5285e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f591cd-d277-4ba5-b1bf-1c09cac9cb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f591cd-d277-4ba5-b1bf-1c09cac9cb8a.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "If a red source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "ce6e4f48-9eaa-5bb0-839e-594135a0646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a78207-fd76-4112-a257-54a25da6f818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a78207-fd76-4112-a257-54a25da6f818.jpg?1",
             "name": "Weaselback Redcap",
             "text": "{1}{R}: Weaselback Redcap gets +2/+0 until end of turn.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "59a637f5-ef4e-58c3-b1c0-dfddb587c815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Beanstalk Giant's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "b8de4b50-8889-5573-9ca7-eb3d7a7d62a8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "5093bb6a-f20e-5079-b4d7-e7422d7601cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "",
             "colours": [
@@ -6106,7 +6106,7 @@
         },
         {
             "id": "27045496-fb07-5260-8201-c98491e6ee31",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "eb0467cf-9e18-590c-837e-bf039dcf9dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5d0560-f9e6-4c70-8cce-cae61e4e74bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5d0560-f9e6-4c70-8cce-cae61e4e74bc.jpg?1",
             "name": "Edgewall Innkeeper",
             "text": "Whenever you cast a creature spell that has an Adventure, draw a card. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "9fd6f332-5201-52da-8a53-1418d7f64b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6bb435-1205-416a-a5a0-ca6d37b4dcb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6bb435-1205-416a-a5a0-ca6d37b4dcb2.jpg?1",
             "name": "Feasting Troll King",
             "text": "Vigilance, trample\nWhen Feasting Troll King enters the battlefield, if you cast it from your hand, create three Food tokens.\nSacrifice three Foods: Return Feasting Troll King from your graveyard to the battlefield. Activate this ability only during your turn.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "b86be36e-0ce6-5382-ab23-8e1fa7d2ffd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d3cc84-7cb6-4de2-9018-4695a3b1e099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d3cc84-7cb6-4de2-9018-4695a3b1e099.jpg?1",
             "name": "Fell the Pheasant",
             "text": "Fell the Pheasant deals 5 damage to target creature with flying. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6246,7 +6246,7 @@
         },
         {
             "id": "4ec240b3-9595-5f13-abc0-953dd99e7955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63a6be2-ae9a-4758-9d5c-0297ef9af57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63a6be2-ae9a-4758-9d5c-0297ef9af57c.jpg?1",
             "name": "Fierce Witchstalker",
             "text": "Trample\nWhen Fierce Witchstalker enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "136a943f-a2c0-5f1f-b6d3-5a55b3ad76c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "Whenever Flaxen Intruder deals combat damage to a player, you may sacrifice it. When you do, destroy target artifact or enchantment.",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "8288d260-50a7-5c4d-a3fa-3855c5ec54fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "Create three 2/2 green Bear creature tokens. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "35a814b7-8c18-54d9-afac-86cc84fbaf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "",
             "colours": [
@@ -6390,7 +6390,7 @@
         },
         {
             "id": "15a36683-b9ef-5cce-b7b6-e8f560789e61",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "Target creature gets +2/+2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6426,7 +6426,7 @@
         },
         {
             "id": "20f48c17-eb13-5d5c-a63c-56dd5288ed19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8445020a-6fab-47dd-9e57-886c28f68b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8445020a-6fab-47dd-9e57-886c28f68b3f.jpg?1",
             "name": "Garenbrig Paladin",
             "text": "Adamant \u2014 If at least three green mana was spent to cast this spell, Garenbrig Paladin enters the battlefield with a +1/+1 counter on it.\nGarenbrig Paladin can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6461,7 +6461,7 @@
         },
         {
             "id": "e39052a9-b084-583f-bcf9-db97dee8f00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74237cce-2ca2-4bfd-a846-c7309621a85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74237cce-2ca2-4bfd-a846-c7309621a85f.jpg?1",
             "name": "Garenbrig Squire",
             "text": "Whenever you cast a creature spell that has an Adventure, Garenbrig Squire gets +1/+1 until end of turn. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -6496,7 +6496,7 @@
         },
         {
             "id": "6726f091-63a5-5d78-a721-83800d1e0d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40383646-3fc4-4267-b9ad-bf90a85972fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40383646-3fc4-4267-b9ad-bf90a85972fc.jpg?1",
             "name": "Giant Opportunity",
             "text": "You may sacrifice two Foods. If you do, create a 7/7 green Giant creature token. Otherwise, create three Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "8e7dd1ef-db8a-5dd7-ac9e-c9fdb1682e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30377bf0-d9b1-4c14-8dde-f74b1e02d604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30377bf0-d9b1-4c14-8dde-f74b1e02d604.jpg?1",
             "name": "Gilded Goose",
             "text": "Flying\nWhen Gilded Goose enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{1}{G}, {T}: Create a Food token.\n{T}, Sacrifice a Food: Add one mana of any color.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "0a573387-0cbb-55f0-8b82-f300660b58eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af915ed2-1f34-43f6-85f5-2430325b720f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af915ed2-1f34-43f6-85f5-2430325b720f.jpg?1",
             "name": "The Great Henge",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\n{T}: Add {G}{G}. You gain 2 life.\nWhenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "ac5e2242-923a-50c1-91b8-55d821ac09fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2357f2db-00c2-41f6-bd04-93f905dea461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2357f2db-00c2-41f6-bd04-93f905dea461.jpg?1",
             "name": "Insatiable Appetite",
             "text": "You may sacrifice a Food. If you do, target creature gets +5/+5 until end of turn. Otherwise, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6632,7 +6632,7 @@
         },
         {
             "id": "9c024494-8a88-5dd8-989e-a4fee515f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6754d6cf-3506-48b5-a0ef-8a90b8dd2701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6754d6cf-3506-48b5-a0ef-8a90b8dd2701.jpg?1",
             "name": "Keeper of Fables",
             "text": "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "856041c2-3b3c-58e0-81cf-98947d913942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da7cd39-1f8a-4f68-adb7-df2beac02263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da7cd39-1f8a-4f68-adb7-df2beac02263.jpg?1",
             "name": "Kenrith's Transformation",
             "text": "Enchant creature\nWhen Kenrith's Transformation enters the battlefield, draw a card.\nEnchanted creature loses all abilities and is a green Elk creature with base power and toughness 3/3. (It loses all other card types and creature types.)",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "89fd5608-1ece-5c6f-8428-828d599b9cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Lovestruck Beast can't attack unless you control a 1/1 creature.",
             "colours": [
@@ -6739,7 +6739,7 @@
         },
         {
             "id": "3a4b9941-f695-5a5d-9b46-990a967f2eba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Create a 1/1 white Human creature token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "cf9b9161-5519-55a2-8644-af583ec455bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b198d-493c-4d6c-bfb6-e842728522f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b198d-493c-4d6c-bfb6-e842728522f6.jpg?1",
             "name": "Maraleaf Rider",
             "text": "Sacrifice a Food: Target creature blocks Maraleaf Rider this turn if able.",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "9966ccd7-ad8e-5942-a717-8446b353fff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb4e77f-e189-4ad3-9fca-8da04289e396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb4e77f-e189-4ad3-9fca-8da04289e396.jpg?1",
             "name": "Oakhame Adversary",
             "text": "This spell costs {2} less to cast if an opponent controls a green permanent.\nDeathtouch\nWhenever Oakhame Adversary deals combat damage to a player, draw a card.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "73b4bff5-0a6e-5beb-9877-422c7ca2b8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5dd4e8-4d5f-45a0-9cae-4f842751894d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5dd4e8-4d5f-45a0-9cae-4f842751894d.jpg?1",
             "name": "Once and Future",
             "text": "Return target card from your graveyard to your hand. Put up to one other target card from your graveyard on top of your library. Exile Once and Future.\nAdamant \u2014 If at least three green mana was spent to cast this spell, instead return those cards to your hand and exile Once and Future.",
             "colours": [
@@ -6877,7 +6877,7 @@
         },
         {
             "id": "0add0930-720f-5bf5-bcf5-ee208eeb9040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4034e5ba-9974-43e3-bde7-8d9b4586c3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4034e5ba-9974-43e3-bde7-8d9b4586c3a4.jpg?1",
             "name": "Once Upon a Time",
             "text": "If this spell is the first spell you've cast this game, you may cast it without paying its mana cost.\nLook at the top five cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "14903635-d346-52c7-a401-230dfee1859f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d0ddcc-e6df-4fe1-9ac9-f895885ccc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d0ddcc-e6df-4fe1-9ac9-f895885ccc84.jpg?1",
             "name": "Outmuscle",
             "text": "Put a +1/+1 counter on target creature you control, then it fights target creature you don't control. (Each deals damage equal to its power to the other.)\nAdamant \u2014 If at least three green mana was spent to cast this spell, the creature you control gains indestructible until end of turn.",
             "colours": [
@@ -6943,7 +6943,7 @@
         },
         {
             "id": "11de1543-2792-58ea-9e93-2fc5e624d7a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cf82d-3213-47ce-a015-6e51a8b07e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cf82d-3213-47ce-a015-6e51a8b07e4f.jpg?1",
             "name": "Questing Beast",
             "text": "Vigilance, deathtouch, haste\nQuesting Beast can't be blocked by creatures with power 2 or less.\nCombat damage that would be dealt by creatures you control can't be prevented.\nWhenever Questing Beast deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "28a991a6-87fe-54c8-ace9-cd8759d3de3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a4943-bd1b-4d10-9cd3-b2ab91b25c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a4943-bd1b-4d10-9cd3-b2ab91b25c10.jpg?1",
             "name": "Return of the Wildspeaker",
             "text": "Choose one \u2014\n\u2022 Draw cards equal to the greatest power among non-Human creatures you control.\n\u2022 Non-Human creatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -7015,7 +7015,7 @@
         },
         {
             "id": "d0a4f8f6-7ee2-5825-bdf3-42e2e0234ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d5088e-21d0-4255-a14c-ad950133a90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d5088e-21d0-4255-a14c-ad950133a90e.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -7047,7 +7047,7 @@
         },
         {
             "id": "d514cf1d-cbbb-5c26-8d17-83439facfe19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "{T}: Add one mana of any color.",
             "colours": [
@@ -7084,7 +7084,7 @@
         },
         {
             "id": "1cb1e10a-f718-5a47-8396-19024a39f56f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "Add one mana of any color. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "852cc4ef-9b90-5b52-b897-4752217705f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a66e33-af5c-42b5-bef6-0ff0197ecc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a66e33-af5c-42b5-bef6-0ff0197ecc14.jpg?1",
             "name": "Rosethorn Halberd",
             "text": "When Rosethorn Halberd enters the battlefield, attach it to target non-Human creature you control.\nEquipped creature gets +2/+1.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "6f06ee37-7e68-5b43-a4a3-aa1789c21d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc33252-145f-45c0-bb70-23183c698f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc33252-145f-45c0-bb70-23183c698f66.jpg?1",
             "name": "Sporecap Spider",
             "text": "Reach",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "ca49d9d4-7941-5a6a-8e7f-0cc63db5e1bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b1fea-3c5d-43d2-b4d2-e8938f3f7b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b1fea-3c5d-43d2-b4d2-e8938f3f7b9c.jpg?1",
             "name": "Syr Faren, the Hengehammer",
             "text": "Whenever Syr Faren, the Hengehammer attacks, another target attacking creature gets +X/+X until end of turn, where X is Syr Faren's power.",
             "colours": [
@@ -7225,7 +7225,7 @@
         },
         {
             "id": "02004117-58fe-5d15-97fa-dab4bd86104b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098bfd71-a47f-4dfc-b516-b88a388fb7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098bfd71-a47f-4dfc-b516-b88a388fb7b5.jpg?1",
             "name": "Tall as a Beanstalk",
             "text": "Enchant creature\nEnchanted creature gets +3/+3, has reach, and is a Giant in addition to its other types.",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "2e5c5bd2-ed4a-556f-a920-10ee0ddcb6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ac16-4ed6-4e79-815a-be173deb4603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ac16-4ed6-4e79-815a-be173deb4603.jpg?1",
             "name": "Trail of Crumbs",
             "text": "When Trail of Crumbs enters the battlefield, create a Food token.\nWhenever you sacrifice a Food, you may pay {1}. If you do, look at the top two cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "b881496f-e240-51b7-8218-5b4e179651e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "bcacffef-ba52-567e-9898-06472a44de1e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "Put two +1/+1 counters on target creature. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "53e0b2ab-a532-5181-a2a5-e8c48860bf31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09476eac-55d2-4955-8951-ae4ce117c98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09476eac-55d2-4955-8951-ae4ce117c98b.jpg?1",
             "name": "Wicked Wolf",
             "text": "When Wicked Wolf enters the battlefield, it fights up to one target creature you don't control.\nSacrifice a Food: Put a +1/+1 counter on Wicked Wolf. It gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "1ec2a1a5-9fb6-5718-837f-5efe58cb1f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f76830-369e-4224-9ded-7d1ce04c87e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f76830-369e-4224-9ded-7d1ce04c87e4.jpg?1",
             "name": "Wildborn Preserver",
             "text": "Flash\nReach\nWhenever another non-Human creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on Wildborn Preserver.",
             "colours": [
@@ -7437,7 +7437,7 @@
         },
         {
             "id": "5acfd1c1-7c07-5fca-883a-0887427889d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3538eba1-475a-4388-8a72-55ab7cd1027e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3538eba1-475a-4388-8a72-55ab7cd1027e.jpg?1",
             "name": "Wildwood Tracker",
             "text": "Whenever Wildwood Tracker attacks or blocks, if you control another non-Human creature, Wildwood Tracker gets +1/+1 until end of turn.",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "5ff9f483-6baf-5d10-928c-095a6752a896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21c15f-378e-4abf-992f-9743aa6ab6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21c15f-378e-4abf-992f-9743aa6ab6b8.jpg?1",
             "name": "Wolf's Quarry",
             "text": "Create three 1/1 green Boar creature tokens with \"When this creature dies, create a Food token.\" (A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "208ba1b3-5c90-5615-89a3-c333c31a6389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2998a1-1713-467e-a08e-0efd8720aa5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2998a1-1713-467e-a08e-0efd8720aa5b.jpg?1",
             "name": "Yorvo, Lord of Garenbrig",
             "text": "Yorvo, Lord of Garenbrig enters the battlefield with four +1/+1 counters on it.\nWhenever another green creature enters the battlefield under your control, put a +1/+1 counter on Yorvo. Then if that creature's power is greater than Yorvo's power, put another +1/+1 counter on Yorvo.",
             "colours": [
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "f8fa0571-f1cf-5b6d-92ce-bf66bbf689e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dca90ef-1c17-4dcc-9fef-dab9ee92f590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dca90ef-1c17-4dcc-9fef-dab9ee92f590.jpg?1",
             "name": "Dance of the Manse",
             "text": "Return up to X target artifact and/or non-Aura enchantment cards each with converted mana cost X or less from your graveyard to the battlefield. If X is 6 or more, those permanents are 4/4 creatures in addition to their other types.",
             "colours": [
@@ -7579,7 +7579,7 @@
         },
         {
             "id": "be69dba8-21fa-536d-b86a-a99d4f177d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c0c83-3e87-474d-bc72-1677eed32cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c0c83-3e87-474d-bc72-1677eed32cfa.jpg?1",
             "name": "Doom Foretold",
             "text": "At the beginning of each player's upkeep, that player sacrifices a nonland, nontoken permanent. If that player can't, they discard a card, they lose 2 life, you draw a card, you gain 2 life, you create a 2/2 white Knight creature token with vigilance, then you sacrifice Doom Foretold.",
             "colours": [
@@ -7615,7 +7615,7 @@
         },
         {
             "id": "18c59430-8741-5e14-88aa-efe0e73853e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf5df5b-164d-4ec2-a5e6-bbaea152e271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf5df5b-164d-4ec2-a5e6-bbaea152e271.jpg?1",
             "name": "Drown in the Loch",
             "text": "Choose one \u2014\n\u2022 Counter target spell with converted mana cost less than or equal to the number of cards in its controller's graveyard.\n\u2022 Destroy target creature with converted mana cost less than or equal to the number of cards in its controller's graveyard.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "477f0265-6a4f-54c5-b85a-f80981fa5930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e26c10b-179f-4a6e-bc8d-3ec1d6783fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e26c10b-179f-4a6e-bc8d-3ec1d6783fb9.jpg?1",
             "name": "Escape to the Wilds",
             "text": "Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn.\nYou may play an additional land this turn.",
             "colours": [
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "8859f1e4-f915-5ad5-a9ca-9e665516e5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca29912-88b1-413f-ad9d-63d7d1b1ca16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca29912-88b1-413f-ad9d-63d7d1b1ca16.jpg?1",
             "name": "Faeburrow Elder",
             "text": "Vigilance\nFaeburrow Elder gets +1/+1 for each color among permanents you control.\n{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "562674f3-9cb1-5fca-a574-6319fe190dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abef512f-8f1d-4257-b16f-c0eed58670ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abef512f-8f1d-4257-b16f-c0eed58670ec.jpg?1",
             "name": "Garruk, Cursed Huntsman",
             "text": "0: Create two 2/2 black and green Wolf creature tokens with \"When this creature dies, put a loyalty counter on each Garruk you control.\"\n\u22123: Destroy target creature. Draw a card.\n\u22126: You get an emblem with \"Creatures you control get +3/+3 and have trample.\"",
             "colours": [
@@ -7764,7 +7764,7 @@
         },
         {
             "id": "8d7df51b-d09e-5985-bd36-735e358258eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d50d26-3c44-4c8f-81bb-9093dacfb804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d50d26-3c44-4c8f-81bb-9093dacfb804.jpg?1",
             "name": "Grumgully, the Generous",
             "text": "Each other non-Human creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -7803,7 +7803,7 @@
         },
         {
             "id": "9ae4d2c9-8764-59bc-88ee-d6c4927118f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0461867b-ec35-4d37-a398-5247e06c4afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0461867b-ec35-4d37-a398-5247e06c4afe.jpg?1",
             "name": "Improbable Alliance",
             "text": "Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying.\n{4}{U}{R}: Draw a card, then discard a card.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "3a6f5d81-0f85-5718-ba57-077df1d3f93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3f372d-259d-4a31-9491-2d369b3f3f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3f372d-259d-4a31-9491-2d369b3f3f8b.jpg?1",
             "name": "Inspiring Veteran",
             "text": "Other Knights you control get +1/+1.",
             "colours": [
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "a6cfb134-1b19-53cf-8f54-2ef8dd87c3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287beea-747c-4cb6-aea5-051e85c5de8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287beea-747c-4cb6-aea5-051e85c5de8d.jpg?1",
             "name": "Lochmere Serpent",
             "text": "Flash\n{U}, Sacrifice an Island: Lochmere Serpent can't be blocked this turn.\n{B}, Sacrifice a Swamp: You gain 1 life and draw a card.\n{U}{B}: Exile five target cards from an opponent's graveyard. Return Lochmere Serpent from your graveyard to your hand. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "ecad5a65-7b5c-52a3-b4a2-46d4f1743937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d7f9c9-dd83-4684-a949-1c22f316138a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d7f9c9-dd83-4684-a949-1c22f316138a.jpg?1",
             "name": "Maraleaf Pixie",
             "text": "Flying\n{T}: Add {G} or {U}.",
             "colours": [
@@ -7952,7 +7952,7 @@
         },
         {
             "id": "46153afe-5e05-5082-852a-648c03924bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462a3d0-5552-49fa-9eb7-100960c55891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462a3d0-5552-49fa-9eb7-100960c55891.jpg?1",
             "name": "Oko, Thief of Crowns",
             "text": "+2: Create a Food token.\n+1: Target artifact or creature loses all abilities and becomes a green Elk creature with base power and toughness 3/3.\n\u22125: Exchange control of target artifact or creature you control and target creature an opponent controls with power 3 or less.",
             "colours": [
@@ -7992,7 +7992,7 @@
         },
         {
             "id": "5931de28-1cb3-5517-9f71-211f6cea385b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7585ab-a364-471c-8ef1-318e459b4020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7585ab-a364-471c-8ef1-318e459b4020.jpg?1",
             "name": "Outlaws' Merriment",
             "text": "At the beginning of your upkeep, choose one at random. Create a red and white creature token with those characteristics.\n\u2022 3/1 Human Warrior with trample and haste.\n\u2022 2/1 Human Cleric with lifelink and haste.\n\u2022 1/2 Human Rogue with haste and \"When this creature enters the battlefield, it deals 1 damage to any target.\"",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "0b84effe-4c47-53d1-b497-3a408b009c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7111f3-01a6-4311-bc08-036a1fba60f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7111f3-01a6-4311-bc08-036a1fba60f5.jpg?1",
             "name": "The Royal Scions",
             "text": "+1: Draw a card, then discard a card.\n+1: Target creature gets +2/+0 and gains first strike and trample until end of turn.\n\u22128: Draw four cards. When you do, The Royal Scions deals damage to any target equal to the number of cards in your hand.",
             "colours": [
@@ -8069,7 +8069,7 @@
         },
         {
             "id": "9a86407d-ccde-5c76-ac98-26dbd2b2927d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c98441-2b31-4e48-a399-f36dffcfa41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c98441-2b31-4e48-a399-f36dffcfa41d.jpg?1",
             "name": "Savvy Hunter",
             "text": "Whenever Savvy Hunter attacks or blocks, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nSacrifice two Foods: Draw a card.",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "db7930a7-37bb-5542-af54-b0bb58ae613c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5314b-4994-4cd0-a680-12e56be7c1e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5314b-4994-4cd0-a680-12e56be7c1e2.jpg?1",
             "name": "Shinechaser",
             "text": "Flying, vigilance\nShinechaser gets +1/+1 as long as you control an artifact.\nShinechaser gets +1/+1 as long as you control an enchantment.",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "ca9035f4-c17f-5b5a-b561-3e73955e527e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafcf909-d726-4bc2-adf6-c12ca242f0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafcf909-d726-4bc2-adf6-c12ca242f0c1.jpg?1",
             "name": "Steelclaw Lance",
             "text": "Equipped creature gets +2/+2.\nEquip Knight {1}\nEquip {3}",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "ffe88f06-c830-5be4-b9fe-916d6c2b8d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27425f2e-e0b2-489d-877d-8257d2026bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27425f2e-e0b2-489d-877d-8257d2026bfd.jpg?1",
             "name": "Stormfist Crusader",
             "text": "Menace\nAt the beginning of your upkeep, each player draws a card and loses 1 life.",
             "colours": [
@@ -8217,7 +8217,7 @@
         },
         {
             "id": "fd7edeb0-80ad-5b6e-b47d-a6896b00cdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fb5b-5c55-4ce9-b9d0-98f924d6f338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fb5b-5c55-4ce9-b9d0-98f924d6f338.jpg?1",
             "name": "Wandermare",
             "text": "Whenever you cast a creature spell that has an Adventure, put a +1/+1 counter on Wandermare. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -8253,7 +8253,7 @@
         },
         {
             "id": "031ee583-8863-5e0d-bb3f-140e346b6557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e8d715-025f-4578-b427-e401318a9c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e8d715-025f-4578-b427-e401318a9c58.jpg?1",
             "name": "Wintermoor Commander",
             "text": "Deathtouch\nWintermoor Commander's toughness is equal to the number of Knights you control.\nWhenever Wintermoor Commander attacks, another target Knight you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "d83a4786-30e6-522c-bb99-53bc4d5bfda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42e1359-c79d-4848-a0f1-3f274e0bf0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42e1359-c79d-4848-a0f1-3f274e0bf0d9.jpg?1",
             "name": "Arcanist's Owl",
             "text": "Flying\nWhen Arcanist's Owl enters the battlefield, look at the top four cards of your library. You may reveal an artifact or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "bcec5dee-375f-5367-97cc-7d8e169d4514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4871d-4d74-411b-88e0-9a9d386cafe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4871d-4d74-411b-88e0-9a9d386cafe1.jpg?1",
             "name": "Covetous Urge",
             "text": "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -8361,7 +8361,7 @@
         },
         {
             "id": "1a1ca1b3-740f-547b-8917-596deae8feb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c6e952-97b5-435c-a7fd-6271ddc23200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c6e952-97b5-435c-a7fd-6271ddc23200.jpg?1",
             "name": "Deathless Knight",
             "text": "Haste\nWhen you gain life for the first time each turn, return Deathless Knight from your graveyard to your hand.",
             "colours": [
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "f890541a-a4a3-54c2-a36d-111cf82e662f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9d0279-4fe0-4228-a82f-bc3cd91500df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9d0279-4fe0-4228-a82f-bc3cd91500df.jpg?1",
             "name": "Elite Headhunter",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{BR}{BR}{BR}, Sacrifice another creature or an artifact: Elite Headhunter deals 2 damage to target creature or planeswalker.",
             "colours": [
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "36898bc6-f71c-58cc-98bc-513115c0aca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716f46c-806d-4b3e-8a1c-fd6dcedacf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716f46c-806d-4b3e-8a1c-fd6dcedacf8e.jpg?1",
             "name": "Fireborn Knight",
             "text": "Double strike\n{GU}{GU}{GU}{GU}: Fireborn Knight gets +1/+1 until end of turn.",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "6f58230d-88a5-583f-a66c-dc0c071ddc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a99088e-7162-4e65-867f-bca1c7400ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a99088e-7162-4e65-867f-bca1c7400ce3.jpg?1",
             "name": "Loch Dragon",
             "text": "Flying\nWhenever Loch Dragon enters the battlefield or attacks, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "1945c138-c3fb-50cd-91f1-f9f92571365a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "{T}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "1503d4db-926c-5fec-8a74-e6780d863683",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "Create two 1/1 white Human creature tokens. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8586,7 +8586,7 @@
         },
         {
             "id": "4e58283e-05a2-5f9d-b4d2-b613a0863efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb9a632-a56b-48fb-bc24-14572b6a8a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb9a632-a56b-48fb-bc24-14572b6a8a55.jpg?1",
             "name": "Rampart Smasher",
             "text": "Rampart Smasher can't be blocked by Knights or Walls.",
             "colours": [
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "afafb7b4-d994-552f-a510-91db87c36511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853dbf04-7165-4728-b96c-c9e4ff4d3491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853dbf04-7165-4728-b96c-c9e4ff4d3491.jpg?1",
             "name": "Resolute Rider",
             "text": "{WB}{WB}: Resolute Rider gains lifelink until end of turn.\n{WB}{WB}{WB}: Resolute Rider gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8659,7 +8659,7 @@
         },
         {
             "id": "74e8a0c7-6ae0-533f-8aa1-cb80ffd160ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576d4f1-47bb-45e0-803c-93fa2cdacbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576d4f1-47bb-45e0-803c-93fa2cdacbe5.jpg?1",
             "name": "Thunderous Snapper",
             "text": "Whenever you cast a spell with converted mana cost 5 or greater, draw a card.",
             "colours": [
@@ -8696,7 +8696,7 @@
         },
         {
             "id": "87ee6756-9cf6-587a-b2a6-4d53634cc66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3af5942-d171-401a-9444-3b59c579e4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3af5942-d171-401a-9444-3b59c579e4db.jpg?1",
             "name": "Clockwork Servant",
             "text": "Adamant \u2014 When Clockwork Servant enters the battlefield, if at least three mana of the same color was spent to cast it, draw a card.",
             "colours": [],
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "eb81c17e-a742-57b4-abdb-8180db177b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7108f-635c-423b-988a-bc8fc4c6edef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7108f-635c-423b-988a-bc8fc4c6edef.jpg?1",
             "name": "Crashing Drawbridge",
             "text": "Defender\n{T}: Creatures you control gain haste until end of turn.",
             "colours": [],
@@ -8758,7 +8758,7 @@
         },
         {
             "id": "af5f40f4-1dbd-537e-ac6d-1dad11a5b02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057c2ae-ea4f-404a-ab95-f3979efd1b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057c2ae-ea4f-404a-ab95-f3979efd1b3b.jpg?1",
             "name": "Enchanted Carriage",
             "text": "When Enchanted Carriage enters the battlefield, create two 1/1 white Mouse creature tokens.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "d15e8893-98ca-5a86-b8bb-cc7f24033b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55fe038-c903-4d92-b689-72dd6d041a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55fe038-c903-4d92-b689-72dd6d041a91.jpg?1",
             "name": "Gingerbrute",
             "text": "Haste\n{1}: Gingerbrute can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice Gingerbrute: You gain 3 life.",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "a93e03ba-e337-564c-9504-9310526133b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525142c3-f17c-4e02-a02d-fa385215aa12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525142c3-f17c-4e02-a02d-fa385215aa12.jpg?1",
             "name": "Golden Egg",
             "text": "When Golden Egg enters the battlefield, draw a card.\n{1}, {T}, Sacrifice Golden Egg: Add one mana of any color.\n{2}, {T}, Sacrifice Golden Egg: You gain 3 life.",
             "colours": [],
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "15683485-77f7-5c6f-b94d-93dab47a662b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9925f0bc-8685-4e38-8864-0ad3a9549ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9925f0bc-8685-4e38-8864-0ad3a9549ab5.jpg?1",
             "name": "Henge Walker",
             "text": "Adamant \u2014 If at least three mana of the same color was spent to cast this spell, Henge Walker enters the battlefield with a +1/+1 counter on it.",
             "colours": [],
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "c3fb2c28-dadb-5ca7-90d7-d05677605c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e349af5-3f25-46d3-908e-83b2f6028b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e349af5-3f25-46d3-908e-83b2f6028b95.jpg?1",
             "name": "Heraldic Banner",
             "text": "As Heraldic Banner enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+0.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "9312733a-9dd4-5601-8d7a-5439d6861c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807a570a-b5eb-420d-9fa5-6e5364025510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807a570a-b5eb-420d-9fa5-6e5364025510.jpg?1",
             "name": "Inquisitive Puppet",
             "text": "When Inquisitive Puppet enters the battlefield, scry 1.\nExile Inquisitive Puppet: Create a 1/1 white Human creature token.",
             "colours": [],
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "342a9886-3eec-51ee-bf23-fdc7069d98a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601056-af08-4239-97d5-5e11597fce18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601056-af08-4239-97d5-5e11597fce18.jpg?1",
             "name": "Jousting Dummy",
             "text": "{3}: Jousting Dummy gets +1/+0 until end of turn.",
             "colours": [],
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "7c1d7e97-f6d0-5b93-837a-e7cf417a809f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551bee-335c-4bf7-b38e-67dd71d1d567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551bee-335c-4bf7-b38e-67dd71d1d567.jpg?1",
             "name": "Locthwain Gargoyle",
             "text": "{4}: Locthwain Gargoyle gets +2/+0 and gains flying until end of turn.",
             "colours": [],
@@ -9003,7 +9003,7 @@
         },
         {
             "id": "cb4e9fb1-4b47-5cc4-9dc1-b2882c676e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5d23a6-3a23-4169-aea1-f10bf5153180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5d23a6-3a23-4169-aea1-f10bf5153180.jpg?1",
             "name": "Lucky Clover",
             "text": "Whenever you cast an Adventure instant or sorcery spell, copy it. You may choose new targets for the copy.",
             "colours": [],
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "03c54f64-639a-599b-b04e-b3d2b8a304ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58131bf2-2a9f-4b81-9eeb-810372f3896c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58131bf2-2a9f-4b81-9eeb-810372f3896c.jpg?1",
             "name": "Prophet of the Peak",
             "text": "When Prophet of the Peak enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [],
@@ -9062,7 +9062,7 @@
         },
         {
             "id": "4f7caf33-25ba-5280-b86e-a730d86010f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a0136e-a637-4a12-a38f-35f772b290a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a0136e-a637-4a12-a38f-35f772b290a9.jpg?1",
             "name": "Roving Keep",
             "text": "Defender\n{7}: Roving Keep gets +2/+0 and gains trample until end of turn. It can attack this turn as though it didn't have defender.",
             "colours": [],
@@ -9093,7 +9093,7 @@
         },
         {
             "id": "e9fb9412-47a1-53e9-b70d-c3cc3f429c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2782-2b23-441f-9890-6fa9c923b701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2782-2b23-441f-9890-6fa9c923b701.jpg?1",
             "name": "Scalding Cauldron",
             "text": "{3}, {T}, Sacrifice Scalding Cauldron: It deals 3 damage to target creature.",
             "colours": [],
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "2ac9dead-1e25-5902-bbba-e39936cf1c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1100b898-31a8-4fdf-a54f-a1470ec032f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1100b898-31a8-4fdf-a54f-a1470ec032f3.jpg?1",
             "name": "Shambling Suit",
             "text": "Shambling Suit's power is equal to the number of artifacts and/or enchantments you control.",
             "colours": [],
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "ffdd0a0b-d797-539c-8e91-cc89106a7702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5f336-c100-4bec-89d5-548f60064d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5f336-c100-4bec-89d5-548f60064d7f.jpg?1",
             "name": "Signpost Scarecrow",
             "text": "Vigilance\n{2}: Add one mana of any color.",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "992aee64-505a-521f-a14c-eaa6e6bec4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071e8f20-18b3-4bf5-a23a-adb42bf5819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071e8f20-18b3-4bf5-a23a-adb42bf5819b.jpg?1",
             "name": "Sorcerer's Broom",
             "text": "Whenever you sacrifice another permanent, you may pay {3}. If you do, create a token that's a copy of Sorcerer's Broom.",
             "colours": [],
@@ -9214,7 +9214,7 @@
         },
         {
             "id": "141e393e-b431-5d42-90c8-b25e6f870437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47e85d1-8c4a-43a9-92b3-7cb2a5b89219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47e85d1-8c4a-43a9-92b3-7cb2a5b89219.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "ef6ef75d-0496-5ede-99f6-453aeb0e337a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070ff479-9d87-4ab6-aaaa-e96b9df0bac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070ff479-9d87-4ab6-aaaa-e96b9df0bac4.jpg?1",
             "name": "Spinning Wheel",
             "text": "{T}: Add one mana of any color.\n{5}, {T}: Tap target creature.",
             "colours": [],
@@ -9272,7 +9272,7 @@
         },
         {
             "id": "9df2da58-6741-5150-a7c0-a78eb5c17391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bf7fd-9fe3-43e2-8cfe-7ce7cff08afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bf7fd-9fe3-43e2-8cfe-7ce7cff08afe.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "Reach, trample, protection from multicolored\nStonecoil Serpent enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "40bc1031-6cc8-5e10-9ff3-12f8a7b70c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ca22d2-3ba5-4173-9c8c-6587a901ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ca22d2-3ba5-4173-9c8c-6587a901ff4a.jpg?1",
             "name": "Weapon Rack",
             "text": "Weapon Rack enters the battlefield with three +1/+1 counters on it.\n{T}: Move a +1/+1 counter from Weapon Rack onto target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -9333,7 +9333,7 @@
         },
         {
             "id": "afc36fe4-7907-5968-add1-320302f9fc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ef8493-d986-45f8-a718-617b028f7ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ef8493-d986-45f8-a718-617b028f7ad4.jpg?1",
             "name": "Witch's Oven",
             "text": "{T}, Sacrifice a creature: Create a Food token. If the sacrificed creature's toughness was 4 or greater, create two Food tokens instead. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "278e5356-5ac2-5727-94e5-99e3c984b120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f910495-8bd7-4134-a281-c16fd666d5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f910495-8bd7-4134-a281-c16fd666d5cc.jpg?1",
             "name": "Castle Ardenvale",
             "text": "Castle Ardenvale enters the battlefield tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Create a 1/1 white Human creature token.",
             "colours": [],
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "93cfe50e-222e-5585-bd24-48482d449c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg?1",
             "name": "Castle Embereth",
             "text": "Castle Embereth enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "d609d89b-e2cd-5923-ab07-585316ebb90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c66c-f7f0-41d5-a805-a129aeaf1b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c66c-f7f0-41d5-a805-a129aeaf1b75.jpg?1",
             "name": "Castle Garenbrig",
             "text": "Castle Garenbrig enters the battlefield tapped unless you control a Forest.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Add six {G}. Spend this mana only to cast creature spells or activate abilities of creatures.",
             "colours": [],
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "5eca79a0-df79-59bb-bef4-9fa77b37fcbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195383c1-4723-40b0-ba53-298dfd8e30d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195383c1-4723-40b0-ba53-298dfd8e30d0.jpg?1",
             "name": "Castle Locthwain",
             "text": "Castle Locthwain enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{1}{B}{B}, {T}: Draw a card, then you lose life equal to the number of cards in your hand.",
             "colours": [],
@@ -9489,7 +9489,7 @@
         },
         {
             "id": "24d73291-c3b5-57ab-a63e-4744868343dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg?1",
             "name": "Castle Vantress",
             "text": "Castle Vantress enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{2}{U}{U}, {T}: Scry 2.",
             "colours": [],
@@ -9521,7 +9521,7 @@
         },
         {
             "id": "bd47e60c-8798-504d-8dc1-cea50931cec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c83074d-0c9b-4b58-94ca-d75240485579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c83074d-0c9b-4b58-94ca-d75240485579.jpg?1",
             "name": "Dwarven Mine",
             "text": "({T}: Add {R}.)\nDwarven Mine enters the battlefield tapped unless you control three or more other Mountains.\nWhen Dwarven Mine enters the battlefield untapped, create a 1/1 red Dwarf creature token.",
             "colours": [],
@@ -9553,7 +9553,7 @@
         },
         {
             "id": "aa351463-01d2-5c91-8e07-3f50865fa6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b841bfa8-7c17-4df2-8466-780ab9a4a53a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b841bfa8-7c17-4df2-8466-780ab9a4a53a.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -9583,7 +9583,7 @@
         },
         {
             "id": "716181f5-9562-59d6-9c39-c64756399a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f5296-5f7d-41ca-a67d-e976273d7386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f5296-5f7d-41ca-a67d-e976273d7386.jpg?1",
             "name": "Gingerbread Cabin",
             "text": "({T}: Add {G}.)\nGingerbread Cabin enters the battlefield tapped unless you control three or more other Forests.\nWhen Gingerbread Cabin enters the battlefield untapped, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -9615,7 +9615,7 @@
         },
         {
             "id": "732cab48-d4be-56ad-8d14-aa73f03ff677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2c611c-3a6f-44b0-9daa-837a465845e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2c611c-3a6f-44b0-9daa-837a465845e0.jpg?1",
             "name": "Idyllic Grange",
             "text": "({T}: Add {W}.)\nIdyllic Grange enters the battlefield tapped unless you control three or more other Plains.\nWhen Idyllic Grange enters the battlefield untapped, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -9647,7 +9647,7 @@
         },
         {
             "id": "649ffc40-4d61-599d-a2fa-17e99032d00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e792c-80d5-4775-ad95-37614574ab84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e792c-80d5-4775-ad95-37614574ab84.jpg?1",
             "name": "Mystic Sanctuary",
             "text": "({T}: Add {U}.)\nMystic Sanctuary enters the battlefield tapped unless you control three or more other Islands.\nWhen Mystic Sanctuary enters the battlefield untapped, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [],
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "7df77858-8f54-5934-8d38-db40ec93af97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd438d51-a778-4b38-8b4b-a6a9cd9b4b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd438d51-a778-4b38-8b4b-a6a9cd9b4b22.jpg?1",
             "name": "Tournament Grounds",
             "text": "{T}: Add {C}.\n{T}: Add {R}, {W}, or {B}. Spend this mana only to cast a Knight or Equipment spell.",
             "colours": [],
@@ -9711,7 +9711,7 @@
         },
         {
             "id": "45634668-e09f-5276-baf0-384dbdb34e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87891cd-b457-4dff-8d18-a7eaf6748fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87891cd-b457-4dff-8d18-a7eaf6748fc6.jpg?1",
             "name": "Witch's Cottage",
             "text": "({T}: Add {B}.)\nWitch's Cottage enters the battlefield tapped unless you control three or more other Swamps.\nWhen Witch's Cottage enters the battlefield untapped, you may put target creature card from your graveyard on top of your library.",
             "colours": [],
@@ -9743,7 +9743,7 @@
         },
         {
             "id": "5f4ea979-2cbd-540a-8903-a1c0a1153b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ded4b2a-ba56-43da-8ea7-392b77fc2926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ded4b2a-ba56-43da-8ea7-392b77fc2926.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9781,7 +9781,7 @@
         },
         {
             "id": "afb23454-e6ab-5dc0-b4b8-5f28bf5b4592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b7076-03b9-4a8b-a55c-6cba0b8162e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b7076-03b9-4a8b-a55c-6cba0b8162e8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9819,7 +9819,7 @@
         },
         {
             "id": "bd2cb389-829c-514a-8150-da875b32cfd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5fbeae-9bd5-4741-80a2-9b646b374328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5fbeae-9bd5-4741-80a2-9b646b374328.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9857,7 +9857,7 @@
         },
         {
             "id": "3527fcd2-7319-547b-baac-f9178f070ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5f9eef-925c-479e-a9a5-ce61fc06f3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5f9eef-925c-479e-a9a5-ce61fc06f3be.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9895,7 +9895,7 @@
         },
         {
             "id": "566ca88c-f03f-540a-9198-527a899041ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4134cd82-6e48-4fc0-bcb4-1e3af369ef82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4134cd82-6e48-4fc0-bcb4-1e3af369ef82.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9933,7 +9933,7 @@
         },
         {
             "id": "208be91d-ac8c-54df-b0a5-f67df4192623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9971,7 +9971,7 @@
         },
         {
             "id": "68d1c3e9-218c-5c1e-8a9d-e2e8822d5485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772b4f6b-dc2b-4247-8f55-f37608d75725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772b4f6b-dc2b-4247-8f55-f37608d75725.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10009,7 +10009,7 @@
         },
         {
             "id": "4b5c1cbd-b1bb-52ce-ad5c-4eac954c4bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb2a1e-9995-49c3-bfc7-7f392c95e16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb2a1e-9995-49c3-bfc7-7f392c95e16a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "12e211cb-ffb7-5324-bca9-d998f11f38bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f184c5-4f3c-4aea-afa1-f0903d3cc71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f184c5-4f3c-4aea-afa1-f0903d3cc71a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "799c8613-90a6-597a-bc3a-73d683aaf4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbeae38f-67e3-48fe-81ea-6af5db74cb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbeae38f-67e3-48fe-81ea-6af5db74cb28.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10123,7 +10123,7 @@
         },
         {
             "id": "e275cffc-6b6b-5f1b-8759-cac87732312d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41aa58c2-eaf2-4b17-b014-afbba7199d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41aa58c2-eaf2-4b17-b014-afbba7199d4a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10161,7 +10161,7 @@
         },
         {
             "id": "c6dfe188-fe59-5896-9a6e-1a1792545e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8705f4-c569-4d5f-bfd5-f076fbc78440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8705f4-c569-4d5f-bfd5-f076fbc78440.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10199,7 +10199,7 @@
         },
         {
             "id": "7cedd093-cbd9-5134-aa20-46bfd6de9712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32982ed2-96e4-4cc5-8562-744b06bca239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32982ed2-96e4-4cc5-8562-744b06bca239.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10237,7 +10237,7 @@
         },
         {
             "id": "43a2492e-2400-51e6-9e14-5cb96d95dc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c82442-e201-407d-9db7-613f24c1eb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c82442-e201-407d-9db7-613f24c1eb03.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10275,7 +10275,7 @@
         },
         {
             "id": "24f2c0d9-c443-5c5d-bbf6-860730e849fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84db98e-c51a-4380-8704-57fdd5eb360f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84db98e-c51a-4380-8704-57fdd5eb360f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10313,7 +10313,7 @@
         },
         {
             "id": "ba38264f-25ac-5370-ade8-b60d08684c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f43c81-10fc-4e08-9070-5453bc5826b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f43c81-10fc-4e08-9070-5453bc5826b4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "ae82cc1f-fef7-58ac-8bc7-e01197b5cbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f03bb2-313e-4688-945f-052eed678174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f03bb2-313e-4688-945f-052eed678174.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10389,7 +10389,7 @@
         },
         {
             "id": "403b406c-92b2-5f78-9a75-44a0abc290f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff5153-cdb8-4ed2-b17e-7ee2aa689da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff5153-cdb8-4ed2-b17e-7ee2aa689da0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "8d948f19-aea2-5d84-a86d-20aa539ff29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52fa771-eaff-48e0-8c23-d118dc4b3438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52fa771-eaff-48e0-8c23-d118dc4b3438.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10465,7 +10465,7 @@
         },
         {
             "id": "50929a4f-e5c8-5836-8133-8286f8beede2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd257a5-439d-4ef8-9cc9-9741e99a04e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd257a5-439d-4ef8-9cc9-9741e99a04e3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10503,7 +10503,7 @@
         },
         {
             "id": "6f6a1a8c-be54-5003-bcf2-5d7412678d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f8dd7-b774-40c5-9e67-3eb87bb72541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f8dd7-b774-40c5-9e67-3eb87bb72541.jpg?1",
             "name": "Garruk, Cursed Huntsman",
             "text": "",
             "colours": [
@@ -10543,7 +10543,7 @@
         },
         {
             "id": "f203bad8-9c07-507c-9699-fc8fec69e2d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da027e-34c1-4098-827d-1647693ad8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da027e-34c1-4098-827d-1647693ad8f4.jpg?1",
             "name": "Oko, Thief of Crowns",
             "text": "",
             "colours": [
@@ -10583,7 +10583,7 @@
         },
         {
             "id": "8e6befac-3f64-5666-ac47-99d5e82db820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e8af9-e3db-4cea-967f-11798dbcfa54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e8af9-e3db-4cea-967f-11798dbcfa54.jpg?1",
             "name": "The Royal Scions",
             "text": "",
             "colours": [
@@ -10624,7 +10624,7 @@
         },
         {
             "id": "24ddc5b0-3978-5cb0-9a05-b224b0642800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "985a785a-af16-59c3-bc70-237269bd19fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "",
             "colours": [
@@ -10697,7 +10697,7 @@
         },
         {
             "id": "8e924666-0aa4-526d-affc-c777fbb9abef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "",
             "colours": [
@@ -10733,7 +10733,7 @@
         },
         {
             "id": "96dc3f02-5ece-5337-8609-7f6f5f490254",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "",
             "colours": [
@@ -10769,7 +10769,7 @@
         },
         {
             "id": "5ba3be28-c945-502d-8ef4-8297b5fa0fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "",
             "colours": [
@@ -10806,7 +10806,7 @@
         },
         {
             "id": "fb77bdb3-9f6d-5e6e-95ec-e10bc9465ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "",
             "colours": [
@@ -10842,7 +10842,7 @@
         },
         {
             "id": "fef06068-703b-5c3d-8d91-b7e73c7b2f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "643ce08b-0dd1-59cb-a498-8a59da0bd5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "",
             "colours": [
@@ -10914,7 +10914,7 @@
         },
         {
             "id": "2fe9fcfe-046b-5ccc-b477-269ab12262c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "",
             "colours": [
@@ -10950,7 +10950,7 @@
         },
         {
             "id": "3f9af606-6254-5896-9432-377a72309486",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "",
             "colours": [
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "34322e9d-0a9f-5a99-a0bc-80d579b395cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "",
             "colours": [
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "edf8f64f-384d-5ad1-a720-f3649ed57e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "",
             "colours": [
@@ -11059,7 +11059,7 @@
         },
         {
             "id": "2efb07cf-00e9-55da-8f4c-f40afb4724ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "",
             "colours": [
@@ -11096,7 +11096,7 @@
         },
         {
             "id": "ec577788-9d1c-5b69-b0a3-b52beaaaba69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "e56fab2f-3093-555f-9c5d-c5fcca0dfbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "",
             "colours": [
@@ -11168,7 +11168,7 @@
         },
         {
             "id": "dce62e19-cecd-5484-89b0-ec878b20853c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "",
             "colours": [
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "66819bb9-e044-512b-921e-7a5a82be79f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -11241,7 +11241,7 @@
         },
         {
             "id": "f21cc3ef-1bd5-55b6-a5dd-11bdf3713a54",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -11277,7 +11277,7 @@
         },
         {
             "id": "8d2f7788-a8d8-5097-9cc2-ad61bbba9c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "",
             "colours": [
@@ -11314,7 +11314,7 @@
         },
         {
             "id": "d290ae99-5111-5cba-b04f-38a75c8ff266",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "",
             "colours": [
@@ -11350,7 +11350,7 @@
         },
         {
             "id": "4a41ac62-bf72-5175-a84d-25fdf2c925a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "",
             "colours": [
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "71a3d258-6da4-5761-b48b-3baaf1251db7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "",
             "colours": [
@@ -11422,7 +11422,7 @@
         },
         {
             "id": "1780ff22-2953-5b72-b4be-43b9f7454167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "",
             "colours": [
@@ -11459,7 +11459,7 @@
         },
         {
             "id": "1026a53f-0f85-5a52-b711-9d539967a52d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "",
             "colours": [
@@ -11495,7 +11495,7 @@
         },
         {
             "id": "9bab7e52-edd0-595b-b3d7-81a850848843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "",
             "colours": [
@@ -11533,7 +11533,7 @@
         },
         {
             "id": "0f94b82d-fdf5-5d5f-b569-5b11ef34ec8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "",
             "colours": [
@@ -11569,7 +11569,7 @@
         },
         {
             "id": "41747a81-62b5-51c2-984b-45cdd3f9adcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "",
             "colours": [
@@ -11606,7 +11606,7 @@
         },
         {
             "id": "c7c388bc-8daf-5b5f-b91d-302865b49d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "",
             "colours": [
@@ -11642,7 +11642,7 @@
         },
         {
             "id": "4f200c09-f83f-586d-a364-1f94e5fa2652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "",
             "colours": [
@@ -11679,7 +11679,7 @@
         },
         {
             "id": "cde8ada5-6815-5946-ae7a-8607a9da00a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "",
             "colours": [
@@ -11715,7 +11715,7 @@
         },
         {
             "id": "fa18a3c2-fa27-5460-bd62-0222d1242cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "",
             "colours": [
@@ -11752,7 +11752,7 @@
         },
         {
             "id": "bacc03fa-774b-5b28-a24e-33d04be38333",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "",
             "colours": [
@@ -11788,7 +11788,7 @@
         },
         {
             "id": "3fe29c0e-4ca5-5f3b-93cd-8b2664bc61c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "",
             "colours": [
@@ -11824,7 +11824,7 @@
         },
         {
             "id": "084595aa-9673-52d0-89ec-d7f846bce8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "",
             "colours": [
@@ -11860,7 +11860,7 @@
         },
         {
             "id": "56da8c67-31a8-567c-9ac0-18b42db36158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "",
             "colours": [
@@ -11897,7 +11897,7 @@
         },
         {
             "id": "4040c173-4cd4-5908-88e5-4d91b3913ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "",
             "colours": [
@@ -11933,7 +11933,7 @@
         },
         {
             "id": "7684f22a-6acb-53ed-a568-2029875ddfde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "",
             "colours": [
@@ -11969,7 +11969,7 @@
         },
         {
             "id": "7060ed02-2559-509e-af4b-0078286641b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "",
             "colours": [
@@ -12005,7 +12005,7 @@
         },
         {
             "id": "07f10747-d129-5025-9af0-b7919df3c82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -12042,7 +12042,7 @@
         },
         {
             "id": "5a4d4c37-4c8b-5232-bc2f-5eeb2fc28883",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -12078,7 +12078,7 @@
         },
         {
             "id": "67884248-a6ce-5821-bd73-72ed8a292732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "",
             "colours": [
@@ -12115,7 +12115,7 @@
         },
         {
             "id": "4ff9473d-0b6b-59a0-9fef-5cf29cfd2457",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "",
             "colours": [
@@ -12151,7 +12151,7 @@
         },
         {
             "id": "07d5f71c-4fca-53b8-abd7-626265880f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "",
             "colours": [
@@ -12188,7 +12188,7 @@
         },
         {
             "id": "a48274ad-20c8-5a9b-9480-da41d4ce348d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "",
             "colours": [
@@ -12224,7 +12224,7 @@
         },
         {
             "id": "935ddb73-3b3b-5466-8b25-706b1c5eeb5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "",
             "colours": [
@@ -12260,7 +12260,7 @@
         },
         {
             "id": "e78d0b7a-7b47-59b2-a148-c5a130224adb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "",
             "colours": [
@@ -12296,7 +12296,7 @@
         },
         {
             "id": "56933d43-1a1f-58ce-8c7b-557def831b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "",
             "colours": [
@@ -12333,7 +12333,7 @@
         },
         {
             "id": "5e6369c8-d8c5-5877-8a26-6f7f5b021c09",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "",
             "colours": [
@@ -12369,7 +12369,7 @@
         },
         {
             "id": "73562a88-c8d7-5bd3-abc2-2c7961a5c634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "",
             "colours": [
@@ -12406,7 +12406,7 @@
         },
         {
             "id": "7938d306-5ffd-59fe-afdf-4360f7ca1316",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "",
             "colours": [
@@ -12442,7 +12442,7 @@
         },
         {
             "id": "eeec2aa9-1458-55c4-99f0-60ea6a0299ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "",
             "colours": [
@@ -12479,7 +12479,7 @@
         },
         {
             "id": "0f01a6ce-778a-538d-9926-e9f35d2efc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "",
             "colours": [
@@ -12515,7 +12515,7 @@
         },
         {
             "id": "808aab9f-f353-598e-ae86-0099ad7b0da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "",
             "colours": [
@@ -12552,7 +12552,7 @@
         },
         {
             "id": "55214f09-66df-5578-901e-56ca36ee5102",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "",
             "colours": [
@@ -12588,7 +12588,7 @@
         },
         {
             "id": "7d6334a7-3a55-5aa3-b67a-853af5d9ebec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "",
             "colours": [
@@ -12625,7 +12625,7 @@
         },
         {
             "id": "6753cc93-b956-54f1-8975-f62cfa591875",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "",
             "colours": [
@@ -12661,7 +12661,7 @@
         },
         {
             "id": "9fc20058-38cb-5dd7-b7e4-1c40a33e921d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "",
             "colours": [
@@ -12698,7 +12698,7 @@
         },
         {
             "id": "02b707a3-0563-549e-9dba-36708ea3f25e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "",
             "colours": [
@@ -12734,7 +12734,7 @@
         },
         {
             "id": "08f5c431-3da6-5cd9-b633-27c84fe7150d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "",
             "colours": [
@@ -12774,7 +12774,7 @@
         },
         {
             "id": "2531e40e-3271-500e-ab5e-ed12df3588e0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "",
             "colours": [
@@ -12812,7 +12812,7 @@
         },
         {
             "id": "b716ea42-01fa-5f8d-af42-efaecf77a748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1227e-bea7-47cb-bbec-389a3d585af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1227e-bea7-47cb-bbec-389a3d585af5.jpg?1",
             "name": "Kenrith, the Returned King",
             "text": "{R}: All creatures gain trample and haste until end of turn.\n{1}{G}: Put a +1/+1 counter on target creature.\n{2}{W}: Target player gains 5 life.\n{3}{U}: Target player draws a card.\n{4}{B}: Put target creature card from a graveyard onto the battlefield under its owner's control.",
             "colours": [
@@ -12853,7 +12853,7 @@
         },
         {
             "id": "ade2779a-a5e9-5549-9a84-0875ae05ff1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030f4058-54e5-4333-bd6c-2789c334bf12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030f4058-54e5-4333-bd6c-2789c334bf12.jpg?1",
             "name": "Rowan, Fearless Sparkmage",
             "text": "+1: Up to one target creature gets +3/+0 and gains first strike until end of turn.\n\u22122: Rowan, Fearless Sparkmage deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.\n\u22129: Gain control of all creatures until end of turn. Untap them. They gain haste until end of turn.",
             "colours": [
@@ -12889,7 +12889,7 @@
         },
         {
             "id": "660dcfab-3332-55f8-8635-b39dcbb37423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a04717-5cd7-4982-bf36-00cea30b9ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a04717-5cd7-4982-bf36-00cea30b9ef1.jpg?1",
             "name": "Garrison Griffin",
             "text": "Flying\nWhenever Garrison Griffin attacks, target Knight you control gains flying until end of turn.",
             "colours": [
@@ -12922,7 +12922,7 @@
         },
         {
             "id": "3762582d-3812-57e2-8571-88e3c9b3564d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a3119-ce9b-4fe5-aea3-871a7eee216e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a3119-ce9b-4fe5-aea3-871a7eee216e.jpg?1",
             "name": "Rowan's Battleguard",
             "text": "First strike\nAs long as you control a Rowan planeswalker, Rowan's Battleguard gets +3/+0.",
             "colours": [
@@ -12956,7 +12956,7 @@
         },
         {
             "id": "48e671ef-26fc-5b42-bc3f-363b3114c499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b537c4e3-88d1-430d-b4c8-16e0716d1927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b537c4e3-88d1-430d-b4c8-16e0716d1927.jpg?1",
             "name": "Rowan's Stalwarts",
             "text": "When Rowan's Stalwarts enters the battlefield, you may search your library and/or graveyard for a card named Rowan, Fearless Sparkmage, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "1b210c99-2bdd-5d82-99de-28d81a01472a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5875e-487f-4586-95f3-3627050a6744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5875e-487f-4586-95f3-3627050a6744.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -13020,7 +13020,7 @@
         },
         {
             "id": "4d2e6c97-b5f7-5b40-84a7-83c78cc427dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e61813-c4c8-4e80-8808-ac5107966ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e61813-c4c8-4e80-8808-ac5107966ee3.jpg?1",
             "name": "Oko, the Trickster",
             "text": "+1: Put two +1/+1 counters on up to one target creature you control.\n0: Until end of turn, Oko, the Trickster becomes a copy of target creature you control. Prevent all damage that would be dealt to him this turn.\n\u22127: Until end of turn, each creature you control has base power and toughness 10/10 and gains trample.",
             "colours": [
@@ -13058,7 +13058,7 @@
         },
         {
             "id": "f2bab806-a163-5ff2-ab64-ce1bb4f23bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c52b50-35aa-4858-8c8e-c81dcb29a7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c52b50-35aa-4858-8c8e-c81dcb29a7fc.jpg?1",
             "name": "Oko's Accomplices",
             "text": "Flying",
             "colours": [
@@ -13091,7 +13091,7 @@
         },
         {
             "id": "29e2cb93-93c1-51e6-9c6f-e39c637a0c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc83a142-9d0f-4a39-baeb-4e2f62009204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc83a142-9d0f-4a39-baeb-4e2f62009204.jpg?1",
             "name": "Bramblefort Fink",
             "text": "{8}: Bramblefort Fink has base power and toughness 10/10 until end of turn. Activate this ability only if you control an Oko planeswalker.",
             "colours": [
@@ -13124,7 +13124,7 @@
         },
         {
             "id": "b3dd0d4c-6f78-51e4-8354-d07300132f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fb103d-f07c-4113-9da7-843cc7dab340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fb103d-f07c-4113-9da7-843cc7dab340.jpg?1",
             "name": "Oko's Hospitality",
             "text": "Creatures you control have base power and toughness 3/3 until end of turn. You may search your library and/or graveyard for a card named Oko, the Trickster, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -13157,7 +13157,7 @@
         },
         {
             "id": "dda81482-5cfa-5c74-b46f-5e6e6b7821cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5159db6-a87f-40eb-8c5c-821dfb67ff6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5159db6-a87f-40eb-8c5c-821dfb67ff6d.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -13187,7 +13187,7 @@
         },
         {
             "id": "9d57d649-3a67-577e-81a1-df5a5cdaec35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c141ed6-02ee-49c4-98af-938ebcefb2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c141ed6-02ee-49c4-98af-938ebcefb2f5.jpg?1",
             "name": "Mace of the Valiant",
             "text": "Equipped creature gets +1/+1 for each charge counter on Mace of the Valiant and has vigilance.\nWhenever a creature enters the battlefield under your control, put a charge counter on Mace of the Valiant.\nEquip {3}",
             "colours": [
@@ -13220,7 +13220,7 @@
         },
         {
             "id": "a8ef0e50-2a6e-5d8c-8b07-98634840ffb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4348513e-4a03-4e06-98e0-ac6c0dfb013d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4348513e-4a03-4e06-98e0-ac6c0dfb013d.jpg?1",
             "name": "Silverwing Squadron",
             "text": "Flying, vigilance\nSilverwing Squadron's power and toughness are each equal to the number of creatures you control.\nWhenever Silverwing Squadron attacks, create a number of 2/2 white Knight creature tokens with vigilance equal to the number of opponents you have.",
             "colours": [
@@ -13254,7 +13254,7 @@
         },
         {
             "id": "aaa045ba-3b1f-5a10-b464-88eb8ff41403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg?1",
             "name": "Faerie Formation",
             "text": "Flying\n{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "afeae767-3cc1-5a17-be07-c0f4f575b422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5beffa4c-4188-48c1-8374-3ac3e8ea1900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5beffa4c-4188-48c1-8374-3ac3e8ea1900.jpg?1",
             "name": "Shimmer Dragon",
             "text": "Flying\nAs long as you control four or more artifacts, Shimmer Dragon has hexproof.\nTap two untapped artifacts you control: Draw a card.",
             "colours": [
@@ -13320,7 +13320,7 @@
         },
         {
             "id": "470588ce-cb15-5980-b9a5-59340bd695ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53913e26-d98b-4ca6-aeea-23633d762d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53913e26-d98b-4ca6-aeea-23633d762d46.jpg?1",
             "name": "Workshop Elders",
             "text": "Artifact creatures you control have flying.\nAt the beginning of combat on your turn, you may have target noncreature artifact you control become a 0/0 artifact creature. If you do, put four +1/+1 counters on it.",
             "colours": [
@@ -13354,7 +13354,7 @@
         },
         {
             "id": "e4872789-196f-5380-9c44-b3b988b95829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298940-4277-4145-9f2f-a284fd2e1a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298940-4277-4145-9f2f-a284fd2e1a9d.jpg?1",
             "name": "Chittering Witch",
             "text": "When Chittering Witch enters the battlefield, create a number of 1/1 black Rat creature tokens equal to the number of opponents you have.\n{1}{B}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -13388,7 +13388,7 @@
         },
         {
             "id": "8377d66c-5953-5752-a2f7-08d6cf351fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851066e5-d5f2-4e53-8b88-487441a77548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851066e5-d5f2-4e53-8b88-487441a77548.jpg?1",
             "name": "Taste of Death",
             "text": "Each player sacrifices three creatures. You create three Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -13419,7 +13419,7 @@
         },
         {
             "id": "f7dc5362-c7ed-5d4a-ad03-ddaf9a35e58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166ee7fc-a0f7-49af-85bf-d5b36bb2bff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166ee7fc-a0f7-49af-85bf-d5b36bb2bff4.jpg?1",
             "name": "Embereth Skyblazer",
             "text": "As long as it's your turn, Embereth Skyblazer has flying.\nWhenever Embereth Skyblazer attacks, you may pay {2}{R}. If you do, creatures you control get +X/+0 until end of turn, where X is the number of opponents you have.",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "8d91375c-73b1-52bf-b475-d54ffce0f44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d0e54d-6e18-44a5-adc2-d875d5b6784f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d0e54d-6e18-44a5-adc2-d875d5b6784f.jpg?1",
             "name": "Steelbane Hydra",
             "text": "Steelbane Hydra enters the battlefield with X +1/+1 counters on it.\n{2}{G}, Remove a +1/+1 counter from Steelbane Hydra: Destroy target artifact or enchantment.",
             "colours": [
@@ -13487,7 +13487,7 @@
         },
         {
             "id": "fc932e4f-4e9b-529d-86b0-4c0429e9534c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80138656-b2e2-43bf-9fe6-7a852f53f9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80138656-b2e2-43bf-9fe6-7a852f53f9e9.jpg?1",
             "name": "Thorn Mammoth",
             "text": "Trample\nWhenever Thorn Mammoth or another creature enters the battlefield under your control, Thorn Mammoth fights up to one target creature you don't control.",
             "colours": [
@@ -13520,7 +13520,7 @@
         },
         {
             "id": "0aa7dd0c-321b-5164-ae52-cd0c047c2cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e7dc5-2089-4758-93e1-79212aedf75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e7dc5-2089-4758-93e1-79212aedf75f.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "Flying, deathtouch, lifelink\nOther creatures you control with flying get +1/+0.\nWhenever you cast an artifact or enchantment spell, create a 1/1 blue Faerie creature token with flying.",
             "colours": [
@@ -13561,7 +13561,7 @@
         },
         {
             "id": "5a301df2-47ee-5e02-906c-5a105f95da8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5e4c5d-7d1d-4426-8351-35c12e29d9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5e4c5d-7d1d-4426-8351-35c12e29d9c3.jpg?1",
             "name": "Banish into Fable",
             "text": "When you cast this spell from your hand, copy it if you control an artifact, then copy it if you control an enchantment. You may choose new targets for the copies.\nReturn target nonland permanent to its owner's hand. You create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -13594,7 +13594,7 @@
         },
         {
             "id": "56c28062-e7c3-542f-923c-4e11e3901983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f43730-1c1f-4150-8771-d901c54bedc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f43730-1c1f-4150-8771-d901c54bedc4.jpg?1",
             "name": "Chulane, Teller of Tales",
             "text": "Vigilance\nWhenever you cast a creature spell, draw a card, then you may put a land card from your hand onto the battlefield.\n{3}, {T}: Return target creature you control to its owner's hand.",
             "colours": [
@@ -13635,7 +13635,7 @@
         },
         {
             "id": "0ad01b9a-f691-5c55-9542-d58b070e604c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e245b-6153-479c-9e09-682afb017ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e245b-6153-479c-9e09-682afb017ff3.jpg?1",
             "name": "Gluttonous Troll",
             "text": "Trample\nWhen Gluttonous Troll enters the battlefield, create a number of Food tokens equal to the number of opponents you have. (Food tokens are artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{1}{G}, Sacrifice another nonland permanent: Gluttonous Troll gets +2/+2 until end of turn.",
             "colours": [
@@ -13670,7 +13670,7 @@
         },
         {
             "id": "cc92eca8-1a76-5b02-acab-26a45ef7f549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b86f7db-ae1d-49fe-a9c5-488bbf3afac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b86f7db-ae1d-49fe-a9c5-488bbf3afac7.jpg?1",
             "name": "Knights' Charge",
             "text": "Whenever a Knight you control attacks, each opponent loses 1 life and you gain 1 life.\n{6}{W}{B}, Sacrifice Knights' Charge: Return all Knight creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -13703,7 +13703,7 @@
         },
         {
             "id": "9aba2136-443c-515a-9154-318a1b046491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1575-eb64-43b5-b604-c6e23054f228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1575-eb64-43b5-b604-c6e23054f228.jpg?1",
             "name": "Korvold, Fae-Cursed King",
             "text": "Flying\nWhenever Korvold, Fae-Cursed King enters the battlefield or attacks, sacrifice another permanent.\nWhenever you sacrifice a permanent, put a +1/+1 counter on Korvold and draw a card.",
             "colours": [
@@ -13744,7 +13744,7 @@
         },
         {
             "id": "95648381-c7ec-5ce4-a86e-b1417feacf82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33add37-379d-4a90-9c04-529dff676986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33add37-379d-4a90-9c04-529dff676986.jpg?1",
             "name": "Syr Gwyn, Hero of Ashvale",
             "text": "Vigilance, menace\nWhenever an equipped creature you control attacks, you draw a card and you lose 1 life.\nEquipment you control have equip Knight {0}.",
             "colours": [
@@ -13785,7 +13785,7 @@
         },
         {
             "id": "92b1996a-d32e-5d11-b4be-dd5b73f92027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84128e98-87d6-4c2f-909b-9435a7833e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84128e98-87d6-4c2f-909b-9435a7833e63.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13812,7 +13812,7 @@
         },
         {
             "id": "d0113384-cc3f-5408-82e2-4e3ac27535b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040301e8-20c1-4f4c-8766-d05f11415efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040301e8-20c1-4f4c-8766-d05f11415efd.jpg?1",
             "name": "Tome of Legends",
             "text": "Tome of Legends enters the battlefield with a page counter on it.\nWhenever your commander enters the battlefield or attacks, put a page counter on Tome of Legends.\n{1}, {T}, Remove a page counter from Tome of Legends: Draw a card.",
             "colours": [],
@@ -13839,7 +13839,7 @@
         },
         {
             "id": "445b6d2a-be40-5ef0-8dfa-35f330c1f575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1f1041-f667-4b73-b1f2-e5bcae84095e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1f1041-f667-4b73-b1f2-e5bcae84095e.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13866,7 +13866,7 @@
         },
         {
             "id": "1653864b-0cb0-5917-a4f6-44df2fed3211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbf3260-b956-40da-abc7-764781c9f26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbf3260-b956-40da-abc7-764781c9f26f.jpg?1",
             "name": "Acclaimed Contender",
             "text": "",
             "colours": [
@@ -13903,7 +13903,7 @@
         },
         {
             "id": "11734b7b-4467-5f49-ae1e-c00a33ee0f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd45820e-39be-448e-b446-44f3ebab555e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd45820e-39be-448e-b446-44f3ebab555e.jpg?1",
             "name": "Charming Prince",
             "text": "",
             "colours": [
@@ -13940,7 +13940,7 @@
         },
         {
             "id": "818f500c-b45c-5edf-bf9e-6dddb4079a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35538cb0-813a-46a1-9c2b-0a1eda866ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35538cb0-813a-46a1-9c2b-0a1eda866ed0.jpg?1",
             "name": "The Circle of Loyalty",
             "text": "",
             "colours": [
@@ -13976,7 +13976,7 @@
         },
         {
             "id": "bf14e983-c011-535e-9032-14074f3520fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38c9120-ac20-4f81-b8d8-9d490cc2a913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38c9120-ac20-4f81-b8d8-9d490cc2a913.jpg?1",
             "name": "Happily Ever After",
             "text": "",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "5d7fea72-9a1e-5af2-a84d-f8107e5fcf41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee91fd2-794f-4c6a-8ce6-3bd2b12f95bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee91fd2-794f-4c6a-8ce6-3bd2b12f95bb.jpg?1",
             "name": "Harmonious Archon",
             "text": "",
             "colours": [
@@ -14046,7 +14046,7 @@
         },
         {
             "id": "bc763d1d-1509-533b-bba2-9159e44c6b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda18da1-1ba4-421c-8980-a94984a5e12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda18da1-1ba4-421c-8980-a94984a5e12a.jpg?1",
             "name": "Hushbringer",
             "text": "",
             "colours": [
@@ -14082,7 +14082,7 @@
         },
         {
             "id": "2620aa49-4bf1-534f-af69-a159de6491a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab231-6575-4682-9208-13ac6b9d7910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab231-6575-4682-9208-13ac6b9d7910.jpg?1",
             "name": "Linden, the Steadfast Queen",
             "text": "",
             "colours": [
@@ -14121,7 +14121,7 @@
         },
         {
             "id": "6f2774a6-607d-5632-a68e-f8d60bb64725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323ed08b-36a2-46ba-953b-59085e5db4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323ed08b-36a2-46ba-953b-59085e5db4e3.jpg?1",
             "name": "Worthy Knight",
             "text": "",
             "colours": [
@@ -14158,7 +14158,7 @@
         },
         {
             "id": "f0b0e75e-853c-5f43-ad42-be007d2d69c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157f343d-8583-4827-a77d-d916e6a5caa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157f343d-8583-4827-a77d-d916e6a5caa1.jpg?1",
             "name": "Emry, Lurker of the Loch",
             "text": "",
             "colours": [
@@ -14197,7 +14197,7 @@
         },
         {
             "id": "94b0c999-f0fa-5af0-936c-39d01f4f6994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb4518-406b-4673-afd9-61a9440e3335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb4518-406b-4673-afd9-61a9440e3335.jpg?1",
             "name": "Folio of Fancies",
             "text": "",
             "colours": [
@@ -14231,7 +14231,7 @@
         },
         {
             "id": "c914c5a5-b573-5a69-b58b-cc121d0a75cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b89ce-fdb2-4730-b87c-e23aa131be24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b89ce-fdb2-4730-b87c-e23aa131be24.jpg?1",
             "name": "Gadwick, the Wizened",
             "text": "",
             "colours": [
@@ -14270,7 +14270,7 @@
         },
         {
             "id": "54a23418-acbe-5fc5-83b3-cf7842aa54a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccea8f-b3f1-41a2-a145-8fc41b21d936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccea8f-b3f1-41a2-a145-8fc41b21d936.jpg?1",
             "name": "The Magic Mirror",
             "text": "",
             "colours": [
@@ -14306,7 +14306,7 @@
         },
         {
             "id": "0881200f-fa9e-59d3-96d1-0dbba3d71c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef0851-c2bb-4b11-b9c2-c659abadd0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef0851-c2bb-4b11-b9c2-c659abadd0d9.jpg?1",
             "name": "Midnight Clock",
             "text": "",
             "colours": [
@@ -14340,7 +14340,7 @@
         },
         {
             "id": "f1a4f70c-5762-5776-8ea4-4263d6750d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b40cd-c359-41cc-b530-d7d6fbbe33bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b40cd-c359-41cc-b530-d7d6fbbe33bf.jpg?1",
             "name": "Mirrormade",
             "text": "",
             "colours": [
@@ -14374,7 +14374,7 @@
         },
         {
             "id": "704bca3e-445f-5329-b628-ce18aa485a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314ca59b-873b-4665-b46d-d73398f85a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314ca59b-873b-4665-b46d-d73398f85a67.jpg?1",
             "name": "Stolen by the Fae",
             "text": "",
             "colours": [
@@ -14408,7 +14408,7 @@
         },
         {
             "id": "23d92b62-cb7e-59e1-ba8a-f4a5adb2be8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42af2e9-a2cb-495e-a039-ee7b46035310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42af2e9-a2cb-495e-a039-ee7b46035310.jpg?1",
             "name": "Vantress Gargoyle",
             "text": "",
             "colours": [
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "6d97d91d-ed16-5684-8cdd-0c161f0c8e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c6e2cf-3799-4d5b-99c2-feeec15580ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c6e2cf-3799-4d5b-99c2-feeec15580ec.jpg?1",
             "name": "Ayara, First of Locthwain",
             "text": "",
             "colours": [
@@ -14484,7 +14484,7 @@
         },
         {
             "id": "1ee17f08-0e86-5fd8-b41d-e85bca6dce7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b03278-9ce8-4698-a8ca-135668384718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b03278-9ce8-4698-a8ca-135668384718.jpg?1",
             "name": "Blacklance Paragon",
             "text": "",
             "colours": [
@@ -14521,7 +14521,7 @@
         },
         {
             "id": "104ce562-e2f5-561b-bb0f-888b2ce23187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cc8dd-b32c-4306-a542-cc97dc2aafdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cc8dd-b32c-4306-a542-cc97dc2aafdf.jpg?1",
             "name": "The Cauldron of Eternity",
             "text": "",
             "colours": [
@@ -14557,7 +14557,7 @@
         },
         {
             "id": "a518300d-0ced-5a34-bd30-7bb378d1464c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfe592d-7733-4f26-a395-3042817cc831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfe592d-7733-4f26-a395-3042817cc831.jpg?1",
             "name": "Clackbridge Troll",
             "text": "",
             "colours": [
@@ -14593,7 +14593,7 @@
         },
         {
             "id": "5d4140fa-b08b-5591-86f7-d757191ae43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc82c1f-3584-49d0-b39f-87d97d9153fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc82c1f-3584-49d0-b39f-87d97d9153fc.jpg?1",
             "name": "Oathsworn Knight",
             "text": "",
             "colours": [
@@ -14630,7 +14630,7 @@
         },
         {
             "id": "cb8c4745-f3d2-51d6-87ab-71612430ae5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee235810-078e-4208-91e2-b559c277eb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee235810-078e-4208-91e2-b559c277eb86.jpg?1",
             "name": "Piper of the Swarm",
             "text": "",
             "colours": [
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "45647264-5fae-5944-899d-519e37416bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d196e-7ce4-4dc1-9d58-102a89aca2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d196e-7ce4-4dc1-9d58-102a89aca2a4.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "",
             "colours": [
@@ -14707,7 +14707,7 @@
         },
         {
             "id": "50b9af8d-eba0-5f8c-909e-49e16a726fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebcb070-953c-4b47-ad8a-ef207c65053f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebcb070-953c-4b47-ad8a-ef207c65053f.jpg?1",
             "name": "Wishclaw Talisman",
             "text": "",
             "colours": [
@@ -14741,7 +14741,7 @@
         },
         {
             "id": "12fef22c-6d30-5da3-a1f3-3e5d954aa951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28cfb-dedc-4dac-8b26-27f963f4d310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28cfb-dedc-4dac-8b26-27f963f4d310.jpg?1",
             "name": "Witch's Vengeance",
             "text": "",
             "colours": [
@@ -14775,7 +14775,7 @@
         },
         {
             "id": "ed70b04c-0be8-51e3-aca2-30e1baf1804a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b8bcc-b9ac-4d8c-9db4-2bf91a853f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b8bcc-b9ac-4d8c-9db4-2bf91a853f03.jpg?1",
             "name": "Embercleave",
             "text": "",
             "colours": [
@@ -14813,7 +14813,7 @@
         },
         {
             "id": "fd3f56b9-f103-5d57-bc4e-b18d26b92522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66e70e-354e-4c3c-9d5d-90f0bf1b857d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66e70e-354e-4c3c-9d5d-90f0bf1b857d.jpg?1",
             "name": "Fervent Champion",
             "text": "",
             "colours": [
@@ -14850,7 +14850,7 @@
         },
         {
             "id": "59fffc28-3a2b-59eb-a547-d862530d3d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515aded7-16fc-498e-9736-f4853e6d5a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515aded7-16fc-498e-9736-f4853e6d5a72.jpg?1",
             "name": "Fires of Invention",
             "text": "",
             "colours": [
@@ -14884,7 +14884,7 @@
         },
         {
             "id": "866ac912-1e8e-50fd-a488-956e172dd278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257a84d3-bc4e-4bb3-a435-6d243929bd8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257a84d3-bc4e-4bb3-a435-6d243929bd8c.jpg?1",
             "name": "Irencrag Feat",
             "text": "",
             "colours": [
@@ -14918,7 +14918,7 @@
         },
         {
             "id": "2393eb7c-fb89-54c5-bc9c-3a9b7c950af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ef45e3-b12a-403e-823c-44f4c95543e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ef45e3-b12a-403e-823c-44f4c95543e8.jpg?1",
             "name": "Irencrag Pyromancer",
             "text": "",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "ed4f0f55-3741-57f0-9ea3-95b39d9eb10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104f257-b3aa-4e7e-987c-7358b6ca7b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104f257-b3aa-4e7e-987c-7358b6ca7b12.jpg?1",
             "name": "Opportunistic Dragon",
             "text": "",
             "colours": [
@@ -14991,7 +14991,7 @@
         },
         {
             "id": "ef8ced05-9770-5dfd-8612-193be7286975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b44930-f109-4865-8cd0-735ae5b4299c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b44930-f109-4865-8cd0-735ae5b4299c.jpg?1",
             "name": "Robber of the Rich",
             "text": "",
             "colours": [
@@ -15029,7 +15029,7 @@
         },
         {
             "id": "847b6ee2-8741-5455-8f79-e36831d556fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40ddc1e-aab6-497f-b0d0-ab1dc4d32b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40ddc1e-aab6-497f-b0d0-ab1dc4d32b44.jpg?1",
             "name": "Sundering Stroke",
             "text": "",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "1d075fe6-99a7-576a-97ae-a5a00caf9cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b63513-5e53-4357-8b28-cb91790e9a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b63513-5e53-4357-8b28-cb91790e9a72.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "",
             "colours": [
@@ -15102,7 +15102,7 @@
         },
         {
             "id": "f557770e-bb46-561b-b3c0-94ba106e25ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f907f50-c02e-4348-a2d0-6697705e4047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f907f50-c02e-4348-a2d0-6697705e4047.jpg?1",
             "name": "Feasting Troll King",
             "text": "",
             "colours": [
@@ -15139,7 +15139,7 @@
         },
         {
             "id": "0330234e-b38e-5973-9cf4-dce5f36254c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d274723a-27f3-49ec-ade0-d0b5e0e87d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d274723a-27f3-49ec-ade0-d0b5e0e87d84.jpg?1",
             "name": "Gilded Goose",
             "text": "",
             "colours": [
@@ -15175,7 +15175,7 @@
         },
         {
             "id": "3ef6edae-e899-521c-a731-3aeeff8b154e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7e30c8-b3fc-430f-ac63-d376d9e47a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7e30c8-b3fc-430f-ac63-d376d9e47a8d.jpg?1",
             "name": "The Great Henge",
             "text": "",
             "colours": [
@@ -15211,7 +15211,7 @@
         },
         {
             "id": "6c62c84e-ef63-5447-81d6-c6d1d0a9a117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ca07ab-32e9-477c-a263-721a03f778ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ca07ab-32e9-477c-a263-721a03f778ff.jpg?1",
             "name": "Once Upon a Time",
             "text": "",
             "colours": [
@@ -15245,7 +15245,7 @@
         },
         {
             "id": "fbfd3536-f255-5021-9922-833d1bbe2dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357e802-2d25-48d3-a188-101c142787b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357e802-2d25-48d3-a188-101c142787b7.jpg?1",
             "name": "Questing Beast",
             "text": "",
             "colours": [
@@ -15283,7 +15283,7 @@
         },
         {
             "id": "4b0c9cbd-32b6-5986-849d-ef54fdd2331d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8183abc4-c4b3-409a-908f-cc549a545e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8183abc4-c4b3-409a-908f-cc549a545e69.jpg?1",
             "name": "Return of the Wildspeaker",
             "text": "",
             "colours": [
@@ -15317,7 +15317,7 @@
         },
         {
             "id": "a12d890a-1619-5545-b2f0-3897d6c61c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1377f-c907-4dd4-be1f-e447dd68a06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1377f-c907-4dd4-be1f-e447dd68a06e.jpg?1",
             "name": "Wicked Wolf",
             "text": "",
             "colours": [
@@ -15353,7 +15353,7 @@
         },
         {
             "id": "3bf835a3-c2b2-5ccb-96d1-b5b63435673f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a907bc-2000-43b4-b95f-00acfa594fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a907bc-2000-43b4-b95f-00acfa594fe0.jpg?1",
             "name": "Wildborn Preserver",
             "text": "",
             "colours": [
@@ -15390,7 +15390,7 @@
         },
         {
             "id": "421f7635-1261-5d83-abbe-bf73a04bc234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85311717-07f7-4be5-902c-0df1307bf5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85311717-07f7-4be5-902c-0df1307bf5b5.jpg?1",
             "name": "Yorvo, Lord of Garenbrig",
             "text": "",
             "colours": [
@@ -15429,7 +15429,7 @@
         },
         {
             "id": "9836b5b8-0d2a-5c0b-94ac-906533ec81a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2804de2-5b13-493c-87ac-e59b3bb569a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2804de2-5b13-493c-87ac-e59b3bb569a4.jpg?1",
             "name": "Dance of the Manse",
             "text": "",
             "colours": [
@@ -15465,7 +15465,7 @@
         },
         {
             "id": "1af63d5d-68d4-547b-9500-c0dca2831471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6d15f8-7ebc-43b7-b8fd-00555e74bcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6d15f8-7ebc-43b7-b8fd-00555e74bcb0.jpg?1",
             "name": "Doom Foretold",
             "text": "",
             "colours": [
@@ -15501,7 +15501,7 @@
         },
         {
             "id": "14dcb06d-47c0-5882-9b9e-cc8b8e1bf7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bff641e-aad3-414f-ad5b-8d32c734efa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bff641e-aad3-414f-ad5b-8d32c734efa9.jpg?1",
             "name": "Escape to the Wilds",
             "text": "",
             "colours": [
@@ -15537,7 +15537,7 @@
         },
         {
             "id": "bff36b07-c09e-5992-b069-44e14b2f4d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d54dca-d09b-49a6-a446-8144a7db6711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d54dca-d09b-49a6-a446-8144a7db6711.jpg?1",
             "name": "Faeburrow Elder",
             "text": "",
             "colours": [
@@ -15576,7 +15576,7 @@
         },
         {
             "id": "ffe2f826-0559-576d-b0c7-065d3e2621b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072648c6-a3ee-4db7-877e-67a5fab46272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072648c6-a3ee-4db7-877e-67a5fab46272.jpg?1",
             "name": "Lochmere Serpent",
             "text": "",
             "colours": [
@@ -15614,7 +15614,7 @@
         },
         {
             "id": "b349e917-4cf2-520c-bd54-9fec516e53c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505532ef-3791-4253-8a2a-b6f02ef45ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505532ef-3791-4253-8a2a-b6f02ef45ab4.jpg?1",
             "name": "Outlaws' Merriment",
             "text": "",
             "colours": [
@@ -15650,7 +15650,7 @@
         },
         {
             "id": "fe594161-6f4c-517b-aca1-854e4888b166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516df79f-f2c1-43f1-af1a-c9a32820929b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516df79f-f2c1-43f1-af1a-c9a32820929b.jpg?1",
             "name": "Stormfist Crusader",
             "text": "",
             "colours": [
@@ -15689,7 +15689,7 @@
         },
         {
             "id": "7005b9ee-239e-5530-a095-81920d47eaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c177f0e0-a1d3-4790-9e2c-bd5d2250603d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c177f0e0-a1d3-4790-9e2c-bd5d2250603d.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "",
             "colours": [],
@@ -15719,7 +15719,7 @@
         },
         {
             "id": "e4aad3dd-c8d5-53df-92a6-2388b60b09d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47357be-9e4b-4581-94f5-0574754e2977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47357be-9e4b-4581-94f5-0574754e2977.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "",
             "colours": [],
@@ -15752,7 +15752,7 @@
         },
         {
             "id": "2c332633-6986-5048-af41-90153bcb3a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1383eb-aa7d-4d3b-bee4-8cffba9ae846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1383eb-aa7d-4d3b-bee4-8cffba9ae846.jpg?1",
             "name": "Castle Ardenvale",
             "text": "",
             "colours": [],
@@ -15784,7 +15784,7 @@
         },
         {
             "id": "67617d6c-87e2-5487-a21b-24ed36284a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954b9bb-21e7-40af-aaa7-b2001b8d1d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954b9bb-21e7-40af-aaa7-b2001b8d1d45.jpg?1",
             "name": "Castle Embereth",
             "text": "",
             "colours": [],
@@ -15816,7 +15816,7 @@
         },
         {
             "id": "3b5b208f-f02c-5a05-a331-d4b20dedde4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca10c34-010a-4a9f-a747-2592c4d58c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca10c34-010a-4a9f-a747-2592c4d58c5d.jpg?1",
             "name": "Castle Garenbrig",
             "text": "",
             "colours": [],
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "fd9d6361-8ae1-503f-810a-e32895eb3c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b8c2e6-5256-4e7e-8d7d-4b386419780a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b8c2e6-5256-4e7e-8d7d-4b386419780a.jpg?1",
             "name": "Castle Locthwain",
             "text": "",
             "colours": [],
@@ -15880,7 +15880,7 @@
         },
         {
             "id": "57d8f9bd-7d36-52ae-a41f-f3ee2dea7f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4113eeed-9399-4b59-a6d9-7d40190853c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4113eeed-9399-4b59-a6d9-7d40190853c5.jpg?1",
             "name": "Castle Vantress",
             "text": "",
             "colours": [],
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "4545d8b2-5ba4-58ab-8ccc-1ec9962f494c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57645743-27fa-4a75-9511-acfc32dd349a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57645743-27fa-4a75-9511-acfc32dd349a.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -15942,7 +15942,7 @@
         },
         {
             "id": "37fdc0d7-976d-5e5e-af6c-ee6b50795454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3dee73-b220-4da9-82ef-e3f551dccb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3dee73-b220-4da9-82ef-e3f551dccb17.jpg?1",
             "name": "Piper of the Swarm",
             "text": "Rats you control have menace.\n{1}{B}, {T}: Create a 1/1 black Rat creature token.\n{2}{B}{B}, {T}, Sacrifice three Rats: Gain control of target creature.",
             "colours": [
@@ -15980,7 +15980,7 @@
         },
         {
             "id": "a0690948-e034-5e03-8d91-d3f5f2175d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2728180c-c24d-4deb-a901-ae90232ad45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2728180c-c24d-4deb-a901-ae90232ad45d.jpg?1",
             "name": "Glass Casket",
             "text": "",
             "colours": [
@@ -16014,7 +16014,7 @@
         },
         {
             "id": "7508bb9a-011e-5046-b882-b8e3f4e93dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfe8919-6244-41ca-a637-07ee971042ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfe8919-6244-41ca-a637-07ee971042ed.jpg?1",
             "name": "Slaying Fire",
             "text": "",
             "colours": [
@@ -16048,7 +16048,7 @@
         },
         {
             "id": "16f3580d-a7ea-53ad-bc81-9e0031cf2a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e5f61-6074-458d-9e8c-aff99fda75d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e5f61-6074-458d-9e8c-aff99fda75d7.jpg?1",
             "name": "Kenrith's Transformation",
             "text": "",
             "colours": [
@@ -16084,7 +16084,7 @@
         },
         {
             "id": "7c8a80eb-0a12-56d0-bdd4-9caaea98d373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eceaa1d6-0d31-4f2d-8ffb-5a4e31712ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eceaa1d6-0d31-4f2d-8ffb-5a4e31712ffa.jpg?1",
             "name": "Improbable Alliance",
             "text": "",
             "colours": [
@@ -16120,7 +16120,7 @@
         },
         {
             "id": "5ee49684-4bbd-5888-803e-fa1f36612cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb96078d-8632-4e7e-93ae-c4c86c530d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb96078d-8632-4e7e-93ae-c4c86c530d19.jpg?1",
             "name": "Inspiring Veteran",
             "text": "",
             "colours": [
@@ -16159,7 +16159,7 @@
         },
         {
             "id": "c60ebff2-0afe-5a7e-b011-cb3156ff8207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213be25c-88db-440b-83c3-973586a4f320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213be25c-88db-440b-83c3-973586a4f320.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -16194,7 +16194,7 @@
         },
         {
             "id": "e9a6488c-20ca-5519-bf6e-7555fcf45db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94057dc6-e589-4a29-9bda-90f5bece96c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94057dc6-e589-4a29-9bda-90f5bece96c4.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -16229,7 +16229,7 @@
         },
         {
             "id": "d45c64b0-431e-58a6-8767-2e396adefc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703e7ecf-3d73-40c1-8cfe-0758778817cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703e7ecf-3d73-40c1-8cfe-0758778817cf.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16264,7 +16264,7 @@
         },
         {
             "id": "2b448a9b-08c0-5fd8-8eb4-faba27eb6cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10da68-dd05-4e8e-ab94-37262e835fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10da68-dd05-4e8e-ab94-37262e835fb3.jpg?1",
             "name": "Mouse",
             "text": "",
             "colours": [
@@ -16299,7 +16299,7 @@
         },
         {
             "id": "c08d6e6b-8a6b-5e8e-9e23-f48e8345ccdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd82cb0-ff4b-4f4d-b3d0-3ac53883b099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd82cb0-ff4b-4f4d-b3d0-3ac53883b099.jpg?1",
             "name": "Faerie",
             "text": "",
             "colours": [
@@ -16334,7 +16334,7 @@
         },
         {
             "id": "feb7929b-e7d1-5dae-aa9c-e3a6277f4892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a205e-43ea-4b3e-92ab-c2ee2172a50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a205e-43ea-4b3e-92ab-c2ee2172a50a.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -16369,7 +16369,7 @@
         },
         {
             "id": "2d55a6d7-c092-5fcf-abc0-8a0109e407d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5d0dd-8095-4410-8feb-8c13edfcb2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5d0dd-8095-4410-8feb-8c13edfcb2e5.jpg?1",
             "name": "Dwarf",
             "text": "",
             "colours": [
@@ -16404,7 +16404,7 @@
         },
         {
             "id": "a8e53688-0c28-52ac-855a-897c851fc151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f09f9e-e0f9-4ed8-bfc0-5f1a3046106e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f09f9e-e0f9-4ed8-bfc0-5f1a3046106e.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -16439,7 +16439,7 @@
         },
         {
             "id": "322b56a4-c774-50f2-9561-cd5ae4114b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365b2234-c29d-42db-a8e0-80685a4b6434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365b2234-c29d-42db-a8e0-80685a4b6434.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -16474,7 +16474,7 @@
         },
         {
             "id": "02dd9f56-d7d1-53e3-9819-b3029e8adbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1debc4-0b12-4848-b551-90680ab8c0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1debc4-0b12-4848-b551-90680ab8c0ab.jpg?1",
             "name": "Giant",
             "text": "",
             "colours": [
@@ -16509,7 +16509,7 @@
         },
         {
             "id": "2d5f69c8-8c6a-5ff3-95b2-93f039fa4a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db951f76-b785-453e-91b9-b3b8a5c1cfd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db951f76-b785-453e-91b9-b3b8a5c1cfd4.jpg?1",
             "name": "Human Cleric",
             "text": "",
             "colours": [
@@ -16547,7 +16547,7 @@
         },
         {
             "id": "a80b2904-822c-540c-b5f8-f1c910d05ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ca6d5-4b2c-46d4-95f3-f0f2fa47f447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ca6d5-4b2c-46d4-95f3-f0f2fa47f447.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -16585,7 +16585,7 @@
         },
         {
             "id": "54dc8e6d-10b4-56f7-a712-30c9f030c149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c994ea90-71f4-403f-9418-2b72cc2de14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c994ea90-71f4-403f-9418-2b72cc2de14d.jpg?1",
             "name": "Human Warrior",
             "text": "",
             "colours": [
@@ -16623,7 +16623,7 @@
         },
         {
             "id": "b3a7b457-9102-5fd2-8264-99624a253fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88452ed7-1065-41c3-94a6-dc41108c45c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88452ed7-1065-41c3-94a6-dc41108c45c1.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -16660,7 +16660,7 @@
         },
         {
             "id": "8671529f-3caf-52a0-ad0c-212d999deab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf36408d-ed85-497f-8e68-d3a922c388a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf36408d-ed85-497f-8e68-d3a922c388a0.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16690,7 +16690,7 @@
         },
         {
             "id": "dcf079a4-9833-5527-b318-9318ef6491d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e8f518-1c0d-4c01-a397-71481839d02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e8f518-1c0d-4c01-a397-71481839d02b.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16721,7 +16721,7 @@
         },
         {
             "id": "5f8204d1-ab7a-5182-b905-725704116a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46582e55-c6f4-46e4-a78e-2c586ca4cf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46582e55-c6f4-46e4-a78e-2c586ca4cf4d.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16751,7 +16751,7 @@
         },
         {
             "id": "90b377a5-5f77-5f59-a5e0-3da610eef6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261aed78-2d57-4ed4-b3d2-53b139b6bd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261aed78-2d57-4ed4-b3d2-53b139b6bd44.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16781,7 +16781,7 @@
         },
         {
             "id": "3f8126fa-4cc3-57c1-abbf-9aeddc9aa36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c65749-1774-4b36-891e-abf762c95cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c65749-1774-4b36-891e-abf762c95cec.jpg?1",
             "name": "Garruk, Cursed Huntsman Emblem",
             "text": "",
             "colours": [],
@@ -16809,7 +16809,7 @@
         },
         {
             "id": "f1ced965-e127-5b18-a7ce-f929eabeccd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d50cf9-03e6-467a-aadf-84a24106ffa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d50cf9-03e6-467a-aadf-84a24106ffa9.jpg?1",
             "name": "On an Adventure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/EMA.json
+++ b/Assets/Resources/Sets/EMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "46224561-ab6a-50c7-92e8-6f360efd75b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647208dd-77f3-4509-b9d6-7801a52418d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647208dd-77f3-4509-b9d6-7801a52418d9.jpg?1",
             "name": "Aven Riftwatcher",
             "text": "Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher enters the battlefield or leaves the battlefield, you gain 2 life.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "080c378c-79d0-5cee-a4e9-38b112d39d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce648aa3-098b-4af0-a433-fd290bc85904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce648aa3-098b-4af0-a433-fd290bc85904.jpg?1",
             "name": "Balance",
             "text": "Each player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "06fa564a-5fb3-5909-b215-f7b34f863626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d191b8f7-40e0-47f3-8395-659f26a12851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d191b8f7-40e0-47f3-8395-659f26a12851.jpg?1",
             "name": "Ballynock Cohort",
             "text": "First strike\nBallynock Cohort gets +1/+1 as long as you control another white creature.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "7a7b1d4f-4d01-517b-8e19-da1f882e9b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e5c4e-0f0b-4a3f-91e0-87387a11e81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e5c4e-0f0b-4a3f-91e0-87387a11e81e.jpg?1",
             "name": "Benevolent Bodyguard",
             "text": "Sacrifice Benevolent Bodyguard: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "b89495e9-9d61-50e2-bd63-d5dd6b90edd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1585bb24-41de-48a7-820e-d99ee76aec01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1585bb24-41de-48a7-820e-d99ee76aec01.jpg?1",
             "name": "Calciderm",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nVanishing 4 (This creature enters the battlefield with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "48163b4a-3b16-5da2-be7e-59cf5cf63ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7c2b5c-634a-4d83-81bc-c6128e3ac339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7c2b5c-634a-4d83-81bc-c6128e3ac339.jpg?1",
             "name": "Coalition Honor Guard",
             "text": "While choosing targets as part of casting a spell or activating an ability, your opponents must choose at least one Flagbearer on the battlefield if able.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "4a5a9dff-b78d-5ffa-871c-68d46dbb02eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10a72dc-10ca-4925-b1ea-5377f7867b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10a72dc-10ca-4925-b1ea-5377f7867b57.jpg?1",
             "name": "Eight-and-a-Half-Tails",
             "text": "{1}{W}: Target permanent you control gains protection from white until end of turn.\n{1}: Target spell or permanent becomes white until end of turn.",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "092e2182-55ad-59b1-8f5e-1c7383c3b420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a5c350-2ed1-4a25-9626-0f8da5d1aef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a5c350-2ed1-4a25-9626-0f8da5d1aef7.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -283,7 +283,7 @@
         },
         {
             "id": "0d6c4763-8c1e-596c-aecd-810241702e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ebec9-3474-4062-9607-2e2a72f78299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ebec9-3474-4062-9607-2e2a72f78299.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "27daaaa6-a74a-58bc-a05c-a9e86085a07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ef45fc-d431-4a24-9566-e52b5c4a06ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ef45fc-d431-4a24-9566-e52b5c4a06ca.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "ceab9d5a-5f03-530a-b496-999c8dbdec79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018e48ee-cbd8-4ff8-92f6-c649e8e8df57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018e48ee-cbd8-4ff8-92f6-c649e8e8df57.jpg?1",
             "name": "Field of Souls",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "935ac801-07ff-5925-85ef-6a3759ace102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63205c2a-e9d4-4354-b519-9e84be8f9eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63205c2a-e9d4-4354-b519-9e84be8f9eb7.jpg?1",
             "name": "Glimmerpoint Stag",
             "text": "Vigilance\nWhen Glimmerpoint Stag enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "6e23c0e0-8007-5ca7-a004-248847b7ccf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c3a75d-7cae-4199-8e87-915ebb439b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c3a75d-7cae-4199-8e87-915ebb439b62.jpg?1",
             "name": "Honden of Cleansing Fire",
             "text": "At the beginning of your upkeep, you gain 2 life for each Shrine you control.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "45472646-e6e6-53fd-8819-caa21b17982d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b876e92-ec9f-4b96-9ec2-2d44f4231b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b876e92-ec9f-4b96-9ec2-2d44f4231b14.jpg?1",
             "name": "Humble",
             "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "a7c82361-a014-5a20-80f8-14f9a950bfeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010bd0f4-994c-4793-99b3-f64f6f87fe67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010bd0f4-994c-4793-99b3-f64f6f87fe67.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "964e781b-295c-55a6-9f09-178972f25d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4351b9a4-0173-4373-9a0e-efdbf2d3bcc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4351b9a4-0173-4373-9a0e-efdbf2d3bcc8.jpg?1",
             "name": "Jareth, Leonine Titan",
             "text": "Whenever Jareth, Leonine Titan blocks, it gets +7/+7 until end of turn.\n{W}: Jareth gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "03dabf5d-4a8c-5fd5-a160-ff3438a8da8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab6c67-1fbb-44b7-a255-15ceaf8352cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab6c67-1fbb-44b7-a255-15ceaf8352cf.jpg?1",
             "name": "Karmic Guide",
             "text": "Flying, protection from black\nEcho {3}{W}{W} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Karmic Guide enters the battlefield, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "ece47c74-9534-5146-8f36-54ff8dfb9c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447a17-7570-4174-b78b-f20c4cc9de14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447a17-7570-4174-b78b-f20c4cc9de14.jpg?1",
             "name": "Kor Hookmaster",
             "text": "When Kor Hookmaster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "a4b805a5-b9f2-5b50-874d-75092228b312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7550ac-c8cd-4e10-8099-c5a42ab093fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7550ac-c8cd-4e10-8099-c5a42ab093fc.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -657,7 +657,7 @@
         },
         {
             "id": "c91234d9-6666-585f-b37c-9506273c9b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5453dd-1000-4841-bace-36e67c35ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5453dd-1000-4841-bace-36e67c35ced4.jpg?1",
             "name": "Mistral Charger",
             "text": "Flying",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "f4c61e0a-9c5d-54b0-9857-ab674f9f743d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c729e2-4e55-4a14-a288-9c3473e58b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c729e2-4e55-4a14-a288-9c3473e58b88.jpg?1",
             "name": "Monk Idealist",
             "text": "When Monk Idealist enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -727,7 +727,7 @@
         },
         {
             "id": "cf6caedd-a850-574f-9d8c-045bf66dcfd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf2354e-1232-452e-b89b-78ac8be206f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf2354e-1232-452e-b89b-78ac8be206f7.jpg?1",
             "name": "Mother of Runes",
             "text": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "e06004a3-be92-5472-b428-0f8c084bc8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e0cc-68bd-49c6-97d2-be9b353d1579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e0cc-68bd-49c6-97d2-be9b353d1579.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "71d9f163-0c4c-55f0-b653-95b4c7964dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b883b92-1bd5-42c3-b893-073db5a60de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b883b92-1bd5-42c3-b893-073db5a60de2.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -828,7 +828,7 @@
         },
         {
             "id": "3e7e4348-20fe-57a9-90ee-31fd037f4ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3eab5-89fb-440a-b56a-b35e2dca44f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3eab5-89fb-440a-b56a-b35e2dca44f0.jpg?1",
             "name": "Rally the Peasants",
             "text": "Creatures you control get +2/+0 until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "35a45688-5d26-5c41-8869-a3f4fa6a3653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e69e8-a527-44b8-a8d8-79e09b92c7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e69e8-a527-44b8-a8d8-79e09b92c7b2.jpg?1",
             "name": "Seal of Cleansing",
             "text": "Sacrifice Seal of Cleansing: Destroy target artifact or enchantment.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "8ce0db8d-604f-5ebc-9b12-ee641564d00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8b53ca-272f-44ba-a3aa-13ec0844ada9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8b53ca-272f-44ba-a3aa-13ec0844ada9.jpg?1",
             "name": "Second Thoughts",
             "text": "Exile target attacking creature.\nDraw a card.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "03737714-097e-5999-a89c-1679e74b0611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d2060-8c4b-4115-ab31-e572ee61a0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d2060-8c4b-4115-ab31-e572ee61a0cc.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "6dc1b78a-970d-53d7-af28-cf81c724eaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431360c2-3c7c-4c96-b09b-9caafe211d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431360c2-3c7c-4c96-b09b-9caafe211d83.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "48cfb318-8e9d-55b2-b773-d50952f9f80a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3333fa0e-32d5-4c3f-a89a-637ab982d61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3333fa0e-32d5-4c3f-a89a-637ab982d61a.jpg?1",
             "name": "Soulcatcher",
             "text": "Flying\nWhenever a creature with flying dies, put a +1/+1 counter on Soulcatcher.",
             "colours": [
@@ -1026,7 +1026,7 @@
         },
         {
             "id": "301b0d04-b733-5379-ba28-fad3ca6ab555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affaf05a-020c-44c1-84fa-7976c3d2a5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affaf05a-020c-44c1-84fa-7976c3d2a5cc.jpg?1",
             "name": "Squadron Hawk",
             "text": "Flying\nWhen Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "7af4b517-5b1b-5d0b-a63b-cd2673ea4f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bafa7b-62a4-477c-b2f5-6b9d26c6cbf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bafa7b-62a4-477c-b2f5-6b9d26c6cbf4.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "8a63aab8-08de-5dfa-bb08-8fe77ea4ba18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6071cf-76bb-48f0-acbe-27b92558495a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6071cf-76bb-48f0-acbe-27b92558495a.jpg?1",
             "name": "Unexpectedly Absent",
             "text": "Put target nonland permanent into its owner's library just beneath the top X cards of that library.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "e0b84e03-9ced-5f2b-b5cc-f563226b7c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c2aad9-1dc4-4e33-a630-9b828de1ed20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c2aad9-1dc4-4e33-a630-9b828de1ed20.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "5d19d5c9-1631-5804-9769-221a60d3bb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b222a639-dd46-40f9-835d-3c68b74c295e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b222a639-dd46-40f9-835d-3c68b74c295e.jpg?1",
             "name": "War Priest of Thune",
             "text": "When War Priest of Thune enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "1a1c1fb1-82d8-5830-a115-164fe5d82b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5c82bd-9946-4121-94f6-70442dab9f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5c82bd-9946-4121-94f6-70442dab9f54.jpg?1",
             "name": "Welkin Guide",
             "text": "Flying\nWhen Welkin Guide enters the battlefield, target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "97f64add-f38e-5ecc-ae52-9033980ae9e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcef00b9-8f18-44fa-a690-569e33d6ce81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcef00b9-8f18-44fa-a690-569e33d6ce81.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "6438cd2b-e7b8-52fa-a083-39108592044d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b12cc-f616-4b52-91eb-a430e70f9251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b12cc-f616-4b52-91eb-a430e70f9251.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1294,7 +1294,7 @@
         },
         {
             "id": "23ca7245-0b51-521e-a0fe-f758bd1f9ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bf47e-ad40-4b3d-9e64-37b311df52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bf47e-ad40-4b3d-9e64-37b311df52e9.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "8c45184f-2b35-5e4b-abcc-4423bff915f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e6787-af32-44f2-ac56-6f348254aa6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e6787-af32-44f2-ac56-6f348254aa6d.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "cb555a42-8aea-5fb4-bca3-923b63e016b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4186eb4-5c79-4616-9a20-c48a6c3f5a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4186eb4-5c79-4616-9a20-c48a6c3f5a82.jpg?1",
             "name": "Cephalid Sage",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Cephalid Sage has \"When Cephalid Sage enters the battlefield, draw three cards, then discard two cards.\"",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "bdc8726d-8868-5c78-ada7-864f511757cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e90849-ca7a-4f66-871e-1cb4b59aefcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e90849-ca7a-4f66-871e-1cb4b59aefcf.jpg?1",
             "name": "Control Magic",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "43164596-7a42-5909-b9dc-e6de2ea5cec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9a7cb0-5bff-48ff-b620-2838816ac9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9a7cb0-5bff-48ff-b620-2838816ac9b5.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "43db7c72-9317-5dbe-b74c-ed678fc76558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05e9a3e-8a35-4687-85cb-e31b3927a5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05e9a3e-8a35-4687-85cb-e31b3927a5e2.jpg?1",
             "name": "Daze",
             "text": "You may return an Island you control to its owner's hand rather than pay Daze's mana cost.\nCounter target spell unless its controller pays {1}.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "c103c9c4-112d-5c5a-b6ec-b79c7556d407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cc8b6-eb2e-4441-8d88-c54cb44ab024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cc8b6-eb2e-4441-8d88-c54cb44ab024.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "825659f8-9a37-507a-82cf-2355cbcb9aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ed455f-95cd-48ca-8b0d-4db259347bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ed455f-95cd-48ca-8b0d-4db259347bb6.jpg?1",
             "name": "Diminishing Returns",
             "text": "Each player shuffles his or her hand and graveyard into his or her library. You exile the top ten cards of your library. Then each player draws up to seven cards.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "5ee13223-ebdb-5e3d-842c-ba773ba43f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fa20df-b8d5-4de7-a2fa-6ced4bfcf979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fa20df-b8d5-4de7-a2fa-6ced4bfcf979.jpg?1",
             "name": "Dream Twist",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "b6797bb4-dbcb-5dec-a5db-2906e891407b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e7c13-d73d-421a-b2cc-4ff7fde05af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e7c13-d73d-421a-b2cc-4ff7fde05af7.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "043c7d0d-fae3-5188-9a1d-51dfa3c5bd96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc01ab4-d89a-4d25-bf54-6aed33772f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc01ab4-d89a-4d25-bf54-6aed33772f4b.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay Force of Will's mana cost.\nCounter target spell.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "d8e4629f-2697-5cb9-ae3f-8d194a0e5d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf3b52f-edcd-429d-9a65-703bbd97cb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf3b52f-edcd-429d-9a65-703bbd97cb5e.jpg?1",
             "name": "Future Sight",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "a72eeae9-5d70-5e26-bed5-01685152e19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5464250-a6a9-4399-a67f-2488073794e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5464250-a6a9-4399-a67f-2488073794e9.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchant creature\nPrevent all combat damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "1b3db940-2450-549a-8e65-4b4703ba843c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5124c4bd-d9a4-4f17-80fc-c64d4a77a614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5124c4bd-d9a4-4f17-80fc-c64d4a77a614.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gets +0/+3 as long as it's untapped.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "1c47ee57-d277-5ba2-8a6a-0e6712da1e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059330e-1aef-4d22-b3c2-cd84cab5fe38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059330e-1aef-4d22-b3c2-cd84cab5fe38.jpg?1",
             "name": "Glacial Wall",
             "text": "Defender",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "1b1db4f3-2567-5db7-9782-effcd9fbc883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ffdaad-7b35-4256-9da1-0befc6bd86f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ffdaad-7b35-4256-9da1-0befc6bd86f4.jpg?1",
             "name": "Honden of Seeing Winds",
             "text": "At the beginning of your upkeep, draw a card for each Shrine you control.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "9a1dcc1c-a728-5cf4-a41c-bd13182646cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c9b16-5567-4473-95e6-622292f77336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c9b16-5567-4473-95e6-622292f77336.jpg?1",
             "name": "Hydroblast",
             "text": "Choose one \u2014\n\u2022 Counter target spell if it's red.\n\u2022 Destroy target permanent if it's red.",
             "colours": [
@@ -1856,7 +1856,7 @@
         },
         {
             "id": "e0158dcb-991b-55a2-930b-ff5ba1949a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1869098e-536f-4381-85d4-7691679a7cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1869098e-536f-4381-85d4-7691679a7cc9.jpg?1",
             "name": "Inkwell Leviathan",
             "text": "Islandwalk, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "49d8b49f-5c5f-5f1e-94a2-524c50569fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1a1910-9587-481c-9e5c-5eb0c3b098c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1a1910-9587-481c-9e5c-5eb0c3b098c6.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles his or her hand into his or her library.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "f6b60f02-2b4a-53ac-bfb6-876364046f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f01503-03d3-4d74-b9d0-b973f7d66094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f01503-03d3-4d74-b9d0-b973f7d66094.jpg?1",
             "name": "Jetting Glasskite",
             "text": "Flying\nWhenever Jetting Glasskite becomes the target of a spell or ability for the first time each turn, counter that spell or ability.",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "c076ca36-d2fb-5649-83c5-7eec7d2d9860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b484714-e1bc-4acb-a925-ac5e80dc8f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b484714-e1bc-4acb-a925-ac5e80dc8f04.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "c73a899c-4f3b-5699-b133-d93d5a90255e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30202613-d05f-4f47-af97-d0b75ccac293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30202613-d05f-4f47-af97-d0b75ccac293.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "fd392f01-53e5-59d9-a051-c3248fcdd2e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5db14e-6b48-4729-bdf7-2965cf3dbb9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5db14e-6b48-4729-bdf7-2965cf3dbb9d.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "99401923-bd82-517e-8b04-9f78b050493c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9264ecb7-bfc0-495d-aaaa-829045ea858f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9264ecb7-bfc0-495d-aaaa-829045ea858f.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "98849bc9-1ba9-545a-a0cb-e53dfe764bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441aa75a-e0f1-43d1-836a-9788e9fd1be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441aa75a-e0f1-43d1-836a-9788e9fd1be5.jpg?1",
             "name": "Oona's Grace",
             "text": "Target player draws a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "86dc310e-f959-5472-a1cf-84e5119c3c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e3b84-31ea-4ff2-8028-1e983fad22d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e3b84-31ea-4ff2-8028-1e983fad22d4.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake enters the battlefield, untap up to five lands.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "408c2adc-e708-5cf1-b680-e7e886504f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e65e19-bc2b-4450-98ea-02a13effeb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e65e19-bc2b-4450-98ea-02a13effeb57.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "53b7c6c9-7d76-5ec6-b287-85671c6d1216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbf99b0-8287-4e30-bd47-989bd0a4d483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbf99b0-8287-4e30-bd47-989bd0a4d483.jpg?1",
             "name": "Phyrexian Ingester",
             "text": "Imprint \u2014 When Phyrexian Ingester enters the battlefield, you may exile target nontoken creature.\nPhyrexian Ingester gets +X/+Y, where X is the exiled creature card's power and Y is its toughness.",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "cb24fe92-d821-516b-91bc-5a363c0763d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef269-55f9-4d84-8bc5-29e794297f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef269-55f9-4d84-8bc5-29e794297f11.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "{T}: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "d0a621b3-5eb9-5680-9243-6b46734d8583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12fd06-26c5-42d8-936c-fe10b778a561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12fd06-26c5-42d8-936c-fe10b778a561.jpg?1",
             "name": "Quiet Speculation",
             "text": "Search target player's library for up to three cards with flashback and put them into that player's graveyard. Then the player shuffles his or her library.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "fa4da507-0eca-5606-bbd4-3777d4386c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc87bc-2ae9-423d-8f95-6dbd18b57745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc87bc-2ae9-423d-8f95-6dbd18b57745.jpg?1",
             "name": "Screeching Skaab",
             "text": "When Screeching Skaab enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "3a3b3860-c638-57f1-a08a-b3932800dfeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb9b623-db1c-47c4-a886-56266c27fab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb9b623-db1c-47c4-a886-56266c27fab5.jpg?1",
             "name": "Serendib Efreet",
             "text": "Flying\nAt the beginning of your upkeep, Serendib Efreet deals 1 damage to you.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "33a38068-b339-5f5f-9a28-8f0431654a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f5d61-cd96-4c02-8cc4-405d2efb37fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f5d61-cd96-4c02-8cc4-405d2efb37fd.jpg?1",
             "name": "Shoreline Ranger",
             "text": "Flying\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "97029835-54ec-5f35-a6de-4d651479268b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9882d7be-1d58-432b-ad36-4cd13609ad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9882d7be-1d58-432b-ad36-4cd13609ad90.jpg?1",
             "name": "Silent Departure",
             "text": "Return target creature to its owner's hand.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "8ab43445-f02b-523d-9d8d-b3f832053364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f1b2c9-7b37-451a-a8cc-252a47b2cded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f1b2c9-7b37-451a-a8cc-252a47b2cded.jpg?1",
             "name": "Sprite Noble",
             "text": "Flying\nOther creatures you control with flying get +0/+1.\n{T}: Other creatures you control with flying get +1/+0 until end of turn.",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "7a0598e3-f436-5d74-8b3c-0d6f77b7f6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6355ae63-3072-4c6f-bf46-ee6e9c4fedba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6355ae63-3072-4c6f-bf46-ee6e9c4fedba.jpg?1",
             "name": "Stupefying Touch",
             "text": "Enchant creature\nWhen Stupefying Touch enters the battlefield, draw a card.\nEnchanted creature's activated abilities can't be activated.",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "6cf24a2a-8c0f-537c-aac9-6fb1e86ca843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9dbed75-6153-4413-9fa4-d96a3c10c050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9dbed75-6153-4413-9fa4-d96a3c10c050.jpg?1",
             "name": "Tidal Wave",
             "text": "Put a 5/5 blue Wall creature token with defender onto the battlefield. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2533,7 +2533,7 @@
         },
         {
             "id": "b16b7f72-c8c8-5b66-88bc-a3a9d643751d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a65d542-7be3-4e11-8626-13392baadd57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a65d542-7be3-4e11-8626-13392baadd57.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "4c5d1c1c-74b3-5fb7-abe3-9dda1ede93fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597d16e3-aba1-4c23-a0a6-c8cb6f823888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597d16e3-aba1-4c23-a0a6-c8cb6f823888.jpg?1",
             "name": "Wonder",
             "text": "Flying\nAs long as Wonder is in your graveyard and you control an Island, creatures you control have flying.",
             "colours": [
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "1f146fb5-bc4e-58e4-9002-8a2cb1ebf2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83536a-efa4-41f3-9424-75b0efc0aea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83536a-efa4-41f3-9424-75b0efc0aea5.jpg?1",
             "name": "Animate Dead",
             "text": "Enchant creature card in a graveyard\nWhen Animate Dead enters the battlefield, if it's on the battlefield, it loses \"enchant creature card in a graveyard\" and gains \"enchant creature put onto the battlefield with Animate Dead.\" Return enchanted creature card to the battlefield under your control and attach Animate Dead to it. When Animate Dead leaves the battlefield, that creature's controller sacrifices it.\nEnchanted creature gets -1/-0.",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "9432b784-59c8-5670-82ed-916ac2876383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b99f7-d388-4e1b-9fbc-8a945701b6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b99f7-d388-4e1b-9fbc-8a945701b6b1.jpg?1",
             "name": "Annihilate",
             "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "8e30c9b9-d3dc-5128-8965-f3ea8c36a431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fd17d4-96e1-4b53-8375-57f800dc661a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fd17d4-96e1-4b53-8375-57f800dc661a.jpg?1",
             "name": "Blightsoil Druid",
             "text": "{T}, Pay 1 life: Add {G} to your mana pool.",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "4e1f54cb-f68e-5919-869b-3fb768c54d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6d92a-45d3-4d67-8ae9-f25dd4a86739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6d92a-45d3-4d67-8ae9-f25dd4a86739.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "2e7bbd6e-6a1e-5f7e-9d54-f6574dc23a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532bca1-a115-4fe7-847e-296677bdd3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532bca1-a115-4fe7-847e-296677bdd3ee.jpg?1",
             "name": "Braids, Cabal Minion",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact, creature, or land.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "e643d6aa-d79a-5337-9add-4c1d6d743e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b12f0-986f-43d0-a81b-64111e7f17e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b12f0-986f-43d0-a81b-64111e7f17e6.jpg?1",
             "name": "Cabal Therapy",
             "text": "Name a nonland card. Target player reveals his or her hand and discards all cards with that name.\nFlashback\u2014\nSacrifice a creature. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "5e009d4e-8bf3-58f1-a021-2773d144c1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e33835-a293-4a1f-85d5-8ac22360ef35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e33835-a293-4a1f-85d5-8ac22360ef35.jpg?1",
             "name": "Carrion Feeder",
             "text": "Carrion Feeder can't block.\nSacrifice a creature: Put a +1/+1 counter on Carrion Feeder.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "65b046e8-9c6f-5d3d-a68e-cc8b64e16bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110fa8e-3fbf-4a81-a743-e709f58e4414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110fa8e-3fbf-4a81-a743-e709f58e4414.jpg?1",
             "name": "Deadbridge Shaman",
             "text": "When Deadbridge Shaman dies, target opponent discards a card.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "d57129f4-a6ae-57a7-a9b0-78287691a71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3727cf-e4f8-4900-aeee-23ff36109c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3727cf-e4f8-4900-aeee-23ff36109c67.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "b3ae6888-0582-57fc-af2f-29258c10df7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba0068-c63f-4699-b630-a56b26ad8239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba0068-c63f-4699-b630-a56b26ad8239.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card and put that card into your graveyard. Then shuffle your library.",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "b0a773c1-bbd7-508c-97e3-1fe765c2f3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423fc5f-5a3b-46e3-8193-2542a0b35386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423fc5f-5a3b-46e3-8193-2542a0b35386.jpg?1",
             "name": "Eyeblight's Ending",
             "text": "Destroy target non-Elf creature.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "077695b2-43c4-5d7d-9b7e-df2563e9e338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8413748e-33f4-4bba-8fb6-864bd048bcb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8413748e-33f4-4bba-8fb6-864bd048bcb2.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "c31f7540-5aab-5f1b-b721-a19fcc0397bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad8ecef-bc09-4d30-bff1-4d21c239b2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad8ecef-bc09-4d30-bff1-4d21c239b2fb.jpg?1",
             "name": "Havoc Demon",
             "text": "Flying\nWhen Havoc Demon dies, all creatures get -5/-5 until end of turn.",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "aead6e23-b4c3-5b0a-80af-75f3ea2d6f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135b6adb-5c9c-4852-8c2a-c6f6d9bf96b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135b6adb-5c9c-4852-8c2a-c6f6d9bf96b1.jpg?1",
             "name": "Honden of Night's Reach",
             "text": "At the beginning of your upkeep, target opponent discards a card for each Shrine you control.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "06a73dbe-d929-579f-93c7-061de79c24fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faa8c5e-9e1b-4cee-b322-a033bf33dcbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faa8c5e-9e1b-4cee-b322-a033bf33dcbc.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "69f4bc7f-edcb-59e0-a66d-f4f45bcdcb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5bc1e4-eefb-4613-aa18-2bf2b9bdf415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5bc1e4-eefb-4613-aa18-2bf2b9bdf415.jpg?1",
             "name": "Ichorid",
             "text": "Haste\nAt the beginning of the end step, sacrifice Ichorid.\nAt the beginning of your upkeep, if Ichorid is in your graveyard, you may exile a black creature card other than Ichorid from your graveyard. If you do, return Ichorid to the battlefield.",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "4ef85ab0-4201-5ce6-916e-592b93bb08d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1621e396-b7ea-4507-95a3-7206a8fe7903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1621e396-b7ea-4507-95a3-7206a8fe7903.jpg?1",
             "name": "Innocent Blood",
             "text": "Each player sacrifices a creature.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "c99f6905-1c65-5ce8-a38a-7a1f95edbe93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d625a7-5753-4b11-ae68-0894af337d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d625a7-5753-4b11-ae68-0894af337d4b.jpg?1",
             "name": "Lys Alana Scarblade",
             "text": "{T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control.",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "0b58f372-eb9b-55a2-975a-6102f87286e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127f3f4d-93f4-4e52-b3c1-325c3981e0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127f3f4d-93f4-4e52-b3c1-325c3981e0e1.jpg?1",
             "name": "Malicious Affliction",
             "text": "Morbid \u2014 When you cast Malicious Affliction, if a creature died this turn, you may copy Malicious Affliction and may choose a new target for the copy.\nDestroy target nonblack creature.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "b26403df-ad96-59aa-91a8-e19cac505e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569173f-df5e-4518-9fb3-f972210595df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569173f-df5e-4518-9fb3-f972210595df.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "c763014c-45a6-5960-b004-0759043fbf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ffb8ad-d8b4-4764-bbb0-ca4106080a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ffb8ad-d8b4-4764-bbb0-ca4106080a90.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "22b82a1e-af05-5e9d-b5fa-95603074871e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a4f2a-57ea-4fa0-a76f-3e215a36d1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a4f2a-57ea-4fa0-a76f-3e215a36d1f4.jpg?1",
             "name": "Nekrataal",
             "text": "First strike\nWhen Nekrataal enters the battlefield, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "496af8d0-32b9-5690-8f4f-a8a6042c1603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4638720-a55d-4c3b-b57d-2d028db5894d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4638720-a55d-4c3b-b57d-2d028db5894d.jpg?1",
             "name": "Night's Whisper",
             "text": "You draw two cards and you lose 2 life.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "b0ceb949-1e89-527d-ab8e-2d26b7256a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f222e50-6fd3-4873-88f4-1c30d08dddfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f222e50-6fd3-4873-88f4-1c30d08dddfc.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "0bd4a1b3-e689-5236-a84f-4d5f947ef002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1cd5e02-9450-4097-b0a5-a62a8e2e552d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1cd5e02-9450-4097-b0a5-a62a8e2e552d.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "ebef09b3-311a-5af1-b9f5-3106e471114c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1e3438-dbee-473a-8556-d4e28b939266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1e3438-dbee-473a-8556-d4e28b939266.jpg?1",
             "name": "Plague Witch",
             "text": "{B}, {T}, Discard a card: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "825bb6ca-ed4b-57ab-9508-7dcaa0f387b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bf8191-3154-48d7-a49b-4d07b5e35a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bf8191-3154-48d7-a49b-4d07b5e35a15.jpg?1",
             "name": "Prowling Pangolin",
             "text": "When Prowling Pangolin enters the battlefield, any player may sacrifice two creatures. If a player does, sacrifice Prowling Pangolin.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "434dd6df-d11f-538a-ac34-93dc8bf50685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa8a17-ff86-465e-9092-0968081f4e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa8a17-ff86-465e-9092-0968081f4e28.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat enters the battlefield, put three 0/1 black Serf creature tokens onto the battlefield.\nWhen Sengir Autocrat leaves the battlefield, exile all Serf tokens.",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "6693dca0-30ab-5a9f-bd51-1e4fb980c007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a084d0fb-8db2-4873-a2f9-e6e5fecdd38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a084d0fb-8db2-4873-a2f9-e6e5fecdd38c.jpg?1",
             "name": "Sinkhole",
             "text": "Destroy target land.",
             "colours": [
@@ -3581,7 +3581,7 @@
         },
         {
             "id": "fc8722ab-0081-5e0c-ae39-c1832613a957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285f37a0-88ad-4cd6-8a8f-60c2d9805437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285f37a0-88ad-4cd6-8a8f-60c2d9805437.jpg?1",
             "name": "Skulking Ghost",
             "text": "Flying\nWhen Skulking Ghost becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "09feb324-5275-577b-8d63-31f3f670e319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796c01-0821-4a20-a256-d98b774faedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796c01-0821-4a20-a256-d98b774faedc.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast Toxic Deluge, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -3647,7 +3647,7 @@
         },
         {
             "id": "5196b3d3-1d46-5c67-bf24-c5dce3352ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3140bf5-9846-47ae-8142-b013aac14609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3140bf5-9846-47ae-8142-b013aac14609.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "ccd2d891-9be8-543d-b4c4-24ec356f5281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1335db4-dda0-4947-9ab6-1f140a1a8aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1335db4-dda0-4947-9ab6-1f140a1a8aa8.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "23fe1f1d-ff54-501d-9fdc-ce1e3499fbe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4f0fdb-fb1a-41e0-b7af-a2dc25cf116e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4f0fdb-fb1a-41e0-b7af-a2dc25cf116e.jpg?1",
             "name": "Urborg Uprising",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -3746,7 +3746,7 @@
         },
         {
             "id": "145eaa60-d7aa-5a48-8dc3-833502dc1f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e778ce-3f1e-4626-8f55-bba03970d91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e778ce-3f1e-4626-8f55-bba03970d91a.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "6d30b3b3-8b83-5aa7-aec8-ecc6079519a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6660d6-b9e4-4020-a936-96d5eac26a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6660d6-b9e4-4020-a936-96d5eac26a58.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "f394205e-3005-568b-b6b9-34e183173369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f66946-ff52-4ce4-af25-b81196fa451b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f66946-ff52-4ce4-af25-b81196fa451b.jpg?1",
             "name": "Visara the Dreadful",
             "text": "Flying\n{T}: Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -3846,7 +3846,7 @@
         },
         {
             "id": "abbffe54-1c40-5b27-8537-e1c5dc8e5b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23716e-453e-4686-a8dd-ca1d67ad577d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23716e-453e-4686-a8dd-ca1d67ad577d.jpg?1",
             "name": "Wake of Vultures",
             "text": "Flying\n{1}{B}, Sacrifice a creature: Regenerate Wake of Vultures.",
             "colours": [
@@ -3880,7 +3880,7 @@
         },
         {
             "id": "74520ce1-ebfd-5eca-97f9-7269081b3b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a5833-042b-4b13-8151-f9e4bcf8e810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a5833-042b-4b13-8151-f9e4bcf8e810.jpg?1",
             "name": "Wakedancer",
             "text": "Morbid \u2014 When Wakedancer enters the battlefield, if a creature died this turn, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3915,7 +3915,7 @@
         },
         {
             "id": "b316bd3f-656f-5537-a152-51477730a7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421ee1c4-a105-41bf-83e9-edf3c49d057c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421ee1c4-a105-41bf-83e9-edf3c49d057c.jpg?1",
             "name": "Avarax",
             "text": "Haste\nWhen Avarax enters the battlefield, you may search your library for a card named Avarax, reveal it, and put it into your hand. If you do, shuffle your library.\n{1}{R}: Avarax gets +1/+0 until end of turn.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "cc16a205-ddbb-5d69-b2ed-deb7dd485a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d9dab-b8ab-420a-b1cf-edb6592e18c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d9dab-b8ab-420a-b1cf-edb6592e18c1.jpg?1",
             "name": "Battle Squadron",
             "text": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "5a0b9fd9-d8e2-57fb-9917-f3b4222c1bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779d4745-ff14-4c79-b2c8-8e273faf7375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779d4745-ff14-4c79-b2c8-8e273faf7375.jpg?1",
             "name": "Beetleback Chief",
             "text": "When Beetleback Chief enters the battlefield, put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4018,7 +4018,7 @@
         },
         {
             "id": "68c7a6d8-c9f1-505d-a38a-4d9c71f5511e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff958ec-ceae-424b-8f9c-3d8f581f1119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff958ec-ceae-424b-8f9c-3d8f581f1119.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "93127e39-c89c-58fe-8d6a-4daee7a1fb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b82ed97-b55d-45ed-a963-85c0741992be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b82ed97-b55d-45ed-a963-85c0741992be.jpg?1",
             "name": "Burning Vengeance",
             "text": "Whenever you cast a spell from your graveyard, Burning Vengeance deals 2 damage to target creature or player.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "ac34eabb-038a-5351-a675-2b4fead775ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b4767b-edd1-4e36-b363-52114a9afe5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b4767b-edd1-4e36-b363-52114a9afe5e.jpg?1",
             "name": "Carbonize",
             "text": "Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would die this turn, exile it instead.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "ca79025a-516f-5ffd-9c4b-2211e3e96915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89af0f45-c11c-4f13-9950-b1489440ee5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89af0f45-c11c-4f13-9950-b1489440ee5b.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -4149,7 +4149,7 @@
         },
         {
             "id": "ee687403-16a8-557a-9fab-ab81276732be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c02ae-e390-4da6-9904-ec138abbe047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c02ae-e390-4da6-9904-ec138abbe047.jpg?1",
             "name": "Crater Hellion",
             "text": "Echo {4}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Crater Hellion enters the battlefield, it deals 4 damage to each other creature.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "ddab1caa-3d35-504f-b972-ef22c862a031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88a833-273b-4fe6-b9aa-f014170f06fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88a833-273b-4fe6-b9aa-f014170f06fd.jpg?1",
             "name": "Desperate Ravings",
             "text": "Draw two cards, then discard a card at random.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "1bcbd490-e374-5769-ab31-d675339c9244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdad3f3-7009-4b8b-9105-263b454217c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdad3f3-7009-4b8b-9105-263b454217c8.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, put a 2/2 red Dragon creature token with flying onto the battlefield. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "5c0bf156-3521-5391-b07c-28d5cfb731c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50607c1-c283-44b7-b69b-79d1ad332b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50607c1-c283-44b7-b69b-79d1ad332b5a.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "983d0caa-dd1c-5f8d-a375-077187da315c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734278b4-74ae-4df5-97d7-745e56189e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734278b4-74ae-4df5-97d7-745e56189e1b.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "e82de421-69f6-58af-945c-128e7dfafc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c00c27c-7826-4d6e-9d56-2844c59c8066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c00c27c-7826-4d6e-9d56-2844c59c8066.jpg?1",
             "name": "Fervent Cathar",
             "text": "Haste\nWhen Fervent Cathar enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4354,7 +4354,7 @@
         },
         {
             "id": "65af0baa-f0ac-5bf7-9f1c-8fa65cc3133e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90aae741-88af-4d21-a230-9a2592acdc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90aae741-88af-4d21-a230-9a2592acdc87.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to target creature or player.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4386,7 +4386,7 @@
         },
         {
             "id": "3ad556bc-c008-53bf-8f0b-4bdcbadef73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e227f18f-7260-4066-bae2-01db4fd1abdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e227f18f-7260-4066-bae2-01db4fd1abdd.jpg?1",
             "name": "Flame Jab",
             "text": "Flame Jab deals 1 damage to target creature or player.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "3cb3eeae-f2f6-53af-97e4-b99779490b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7602b70b-686f-432b-ac59-1141dd3d0dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7602b70b-686f-432b-ac59-1141dd3d0dea.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle your library.",
             "colours": [
@@ -4450,7 +4450,7 @@
         },
         {
             "id": "6740318b-46bb-5170-b314-d40da9152d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923de31f-0941-4df1-8939-3eed75b7eb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923de31f-0941-4df1-8939-3eed75b7eb39.jpg?1",
             "name": "Ghitu Slinger",
             "text": "Echo {2}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Ghitu Slinger enters the battlefield, it deals 2 damage to target creature or player.",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "19ec5d47-a2bf-564d-a86e-da0d65232a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174bcea4-4e9c-4de5-b001-6a9df2242e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174bcea4-4e9c-4de5-b001-6a9df2242e37.jpg?1",
             "name": "Honden of Infinite Rage",
             "text": "At the beginning of your upkeep, Honden of Infinite Rage deals damage to target creature or player equal to the number of Shrines you control.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "c67f1675-c67b-5f86-a3bd-f2880758643b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca0987e-7dff-410a-8328-45ba1c53e974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca0987e-7dff-410a-8328-45ba1c53e974.jpg?1",
             "name": "Keldon Champion",
             "text": "Haste\nEcho {2}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Keldon Champion enters the battlefield, it deals 3 damage to target player.",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "6eeddd60-d823-5134-b8ea-851f5b653daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42524c-97e5-40b2-8a6d-d2a1f0a9eb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42524c-97e5-40b2-8a6d-d2a1f0a9eb65.jpg?1",
             "name": "Keldon Marauders",
             "text": "Vanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Keldon Marauders enters the battlefield or leaves the battlefield, it deals 1 damage to target player.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "ccec4ef4-3afb-57c6-aea6-7a39bbabb47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14a5c79-29a3-4415-9b70-b287a474a0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14a5c79-29a3-4415-9b70-b287a474a0e0.jpg?1",
             "name": "Kird Ape",
             "text": "Kird Ape gets +1/+2 as long as you control a Forest.",
             "colours": [
@@ -4625,7 +4625,7 @@
         },
         {
             "id": "b82feb72-8386-54ea-8212-2ad2daceb660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d479ca28-bdc2-4b87-abf7-5aeb229a3f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d479ca28-bdc2-4b87-abf7-5aeb229a3f1e.jpg?1",
             "name": "Mogg Fanatic",
             "text": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "964462f1-473b-5b3a-969f-2f8c39d312b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deed0a5a-6662-460c-bd78-e3d95e8bc83e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deed0a5a-6662-460c-bd78-e3d95e8bc83e.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, put a 1/1 red Goblin creature token onto the battlefield.",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "aa3509ab-f25e-5181-95f4-df2c94eea3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b568475-97db-47be-842c-03305b459fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b568475-97db-47be-842c-03305b459fb7.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "ea80cee9-e139-5170-b262-178b356f95ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1342144-7a15-438b-a848-3196238a79e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1342144-7a15-438b-a848-3196238a79e8.jpg?1",
             "name": "Price of Progress",
             "text": "Price of Progress deals damage to each player equal to twice the number of nonbasic lands that player controls.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "de4ba425-848d-537b-88a9-6b9f3a73a4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b029eb9a-dd7a-40c2-96c4-0063d9cc002c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b029eb9a-dd7a-40c2-96c4-0063d9cc002c.jpg?1",
             "name": "Pyroblast",
             "text": "Choose one \u2014\n\u2022 Counter target spell if it's blue.\n\u2022 Destroy target permanent if it's blue.",
             "colours": [
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "69783c37-2f0f-52d3-b317-2efe90dae7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f98f02-9ada-4561-93fd-9cfcb0f48b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f98f02-9ada-4561-93fd-9cfcb0f48b5d.jpg?1",
             "name": "Pyrokinesis",
             "text": "You may exile a red card from your hand rather than pay Pyrokinesis's mana cost.\nPyrokinesis deals 4 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "e60400c0-30e3-52f6-a424-69cd73085348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b357221-cae0-48ef-aedc-2dbdb694e373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b357221-cae0-48ef-aedc-2dbdb694e373.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "6c110743-92e1-5569-9597-e9ae8df0dac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2e7e50-e0b7-474b-a07d-35071011a70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2e7e50-e0b7-474b-a07d-35071011a70c.jpg?1",
             "name": "Rorix Bladewing",
             "text": "Flying, haste",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "c7eab655-e549-5627-9cbb-22015ce2c856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7bb50b1-e65c-4d56-8705-f20f6fa1ca12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7bb50b1-e65c-4d56-8705-f20f6fa1ca12.jpg?1",
             "name": "Seismic Stomp",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "51c2d24d-1a88-58ad-aee1-2a133764ec7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326dae6-7539-4422-8c81-a1cffbbe8f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326dae6-7539-4422-8c81-a1cffbbe8f74.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, put three 1/1 red Goblin creature tokens onto the battlefield.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "eee9b88e-e9e7-5abf-8748-56d71805c3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207d5f12-fbc6-4c75-9d84-fd2f0023fbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207d5f12-fbc6-4c75-9d84-fd2f0023fbd0.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "b990a717-d830-5d1b-b6fa-30fd459b5970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617477d7-eb82-4324-b99b-d7c9ecbdcfda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617477d7-eb82-4324-b99b-d7c9ecbdcfda.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "93969bf6-4a4c-5ef7-8b1d-61c6808dae25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0463e989-ba32-4a46-a82f-e0d6daf3cd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0463e989-ba32-4a46-a82f-e0d6daf3cd51.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "3bc30864-6ba8-5592-9383-ce84227b23e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c77d9f-22bd-4676-b594-8499369c449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c77d9f-22bd-4676-b594-8499369c449c.jpg?1",
             "name": "Tooth and Claw",
             "text": "Sacrifice two creatures: Put a 3/1 red Beast creature token named Carnivore onto the battlefield.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "b8ff0476-9a11-5004-9bb8-7dc5c2c8847f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0876a17b-19d4-483d-bd01-dafd28c3635f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0876a17b-19d4-483d-bd01-dafd28c3635f.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "01a1c69d-1647-5184-848f-cca58dd6ff27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f255055-0499-400f-ae0a-c32624f0ce78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f255055-0499-400f-ae0a-c32624f0ce78.jpg?1",
             "name": "Wildfire Emissary",
             "text": "Protection from white\n{1}{R}: Wildfire Emissary gets +1/+0 until end of turn.",
             "colours": [
@@ -5155,7 +5155,7 @@
         },
         {
             "id": "1f96ccb0-c5ee-53c5-bcdb-8069165d109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae8fa6-c86e-492b-b28b-96d4ee83f6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae8fa6-c86e-492b-b28b-96d4ee83f6c6.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "544cdac0-75f8-5b9f-bc13-7ae2cdc6dfa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd3e04-2cc6-4538-b0e4-11a3653f8331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd3e04-2cc6-4538-b0e4-11a3653f8331.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, put a 1/1 red Elemental creature token onto the battlefield.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "5b4e6175-8bf7-5bc3-a6cf-696ad7ab5190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc00bf8-236b-4c68-be85-1609be122259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc00bf8-236b-4c68-be85-1609be122259.jpg?1",
             "name": "Abundant Growth",
             "text": "Enchant land\nWhen Abundant Growth enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "bc42649d-282d-5fab-b247-6496ecf629ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a19fc5-20f3-48d2-8c12-e012d3b302e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a19fc5-20f3-48d2-8c12-e012d3b302e7.jpg?1",
             "name": "Ancestral Mask",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 for each other enchantment on the battlefield.",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "72754ff7-3237-58cb-a0c3-68beb508cf70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99ff81f-08d9-4b4a-a879-de5e5e402802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99ff81f-08d9-4b4a-a879-de5e5e402802.jpg?1",
             "name": "Argothian Enchantress",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nWhenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "cafe44be-7145-5160-a90a-6b7d99e85684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23745d1-e03f-429b-889f-9fb92400ee3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23745d1-e03f-429b-889f-9fb92400ee3b.jpg?1",
             "name": "Brawn",
             "text": "Trample\nAs long as Brawn is in your graveyard and you control a Forest, creatures you control have trample.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "80324925-96bf-5822-8987-dec555cad05f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb106dd9-32f4-4716-9578-8e7164cc704a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb106dd9-32f4-4716-9578-8e7164cc704a.jpg?1",
             "name": "Centaur Chieftain",
             "text": "Haste\nThreshold \u2014 As long as seven or more cards are in your graveyard, Centaur Chieftain has \"When Centaur Chieftain enters the battlefield, creatures you control get +1/+1 and gain trample until end of turn.\"",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "f5266746-23a5-56f6-8f8b-a317956203ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee03108-036b-4996-a256-7c772a801492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee03108-036b-4996-a256-7c772a801492.jpg?1",
             "name": "Civic Wayfinder",
             "text": "When Civic Wayfinder enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "97287c11-04d5-5576-a532-0e535c754bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d95f6f-3ff0-483d-b98f-ccb4fb5715f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d95f6f-3ff0-483d-b98f-ccb4fb5715f4.jpg?1",
             "name": "Commune with the Gods",
             "text": "Reveal the top five cards of your library. You may put a creature or enchantment card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "569691fd-ea78-59db-9e11-9f05b8418583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c997fe6c-cb57-4e0e-9267-42bd12cc3b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c997fe6c-cb57-4e0e-9267-42bd12cc3b03.jpg?1",
             "name": "Elephant Guide",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nWhen enchanted creature dies, put a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -5498,7 +5498,7 @@
         },
         {
             "id": "f79b8ebd-8e1e-5e99-a63b-658791e70d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dd5e5-8dc1-4de4-8bfb-3024e3ff8bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dd5e5-8dc1-4de4-8bfb-3024e3ff8bf2.jpg?1",
             "name": "Elvish Vanguard",
             "text": "Whenever another Elf enters the battlefield, put a +1/+1 counter on Elvish Vanguard.",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "dc5cff82-7138-55ee-b1ee-071cce86a0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c30e2-e751-4481-9a46-413c52bbff90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c30e2-e751-4481-9a46-413c52bbff90.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -5567,7 +5567,7 @@
         },
         {
             "id": "1f6c0ff1-edf9-50ad-a464-02772d77fa51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873be98f-e263-4e84-afa0-1e329aa47550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873be98f-e263-4e84-afa0-1e329aa47550.jpg?1",
             "name": "Flinthoof Boar",
             "text": "Flinthoof Boar gets +1/+1 as long as you control a Mountain.\n{R}: Flinthoof Boar gains haste until end of turn.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "7b8a9840-e991-522e-9dc9-2450359dc654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3152e-7b3b-4ac6-8b33-abfebde216aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3152e-7b3b-4ac6-8b33-abfebde216aa.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "f6c15603-6a4a-5d56-8f3f-8f060632217a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a872293-d164-426d-aa3e-eeeaa02fd38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a872293-d164-426d-aa3e-eeeaa02fd38b.jpg?1",
             "name": "Gaea's Blessing",
             "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "4a9893ea-e327-5c46-810d-99903fd7a952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01794178-cf41-454c-ac37-1d8b18e42db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01794178-cf41-454c-ac37-1d8b18e42db2.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -5698,7 +5698,7 @@
         },
         {
             "id": "121c90e3-19c1-59a6-919a-09d1c334b064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e7f83-a54a-43bc-a518-b1aa2baf4758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e7f83-a54a-43bc-a518-b1aa2baf4758.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "29e52eb1-f699-58c8-a782-003450e32bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57948c65-4324-42bc-97ae-7cc700eb3817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57948c65-4324-42bc-97ae-7cc700eb3817.jpg?1",
             "name": "Heritage Druid",
             "text": "Tap three untapped Elves you control: Add {G}{G}{G} to your mana pool.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "0b4cdbc8-14d1-5f70-a8c6-5b02c59e2a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766562f1-63b2-41d3-b76d-a31bac70fa89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766562f1-63b2-41d3-b76d-a31bac70fa89.jpg?1",
             "name": "Honden of Life's Web",
             "text": "At the beginning of your upkeep, put a 1/1 colorless Spirit creature token onto the battlefield for each Shrine you control.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "df112777-c228-5220-b6d5-a95b643910a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f527ba3-ac8f-4bcc-880a-94ec9623d624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f527ba3-ac8f-4bcc-880a-94ec9623d624.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elf creatures you control get +1/+1.\n{G}, {T}: Put a 1/1 green Elf Warrior creature token onto the battlefield.",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "657fba5a-fcc0-5cae-8345-00c8061d6814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcec43b3-80dd-40a3-a277-6bca00b69f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcec43b3-80dd-40a3-a277-6bca00b69f35.jpg?1",
             "name": "Invigorate",
             "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5868,7 +5868,7 @@
         },
         {
             "id": "d5f35f56-55f6-52f0-8757-3f9ee33799dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8a1386-77ca-46ae-8987-aaed435556ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8a1386-77ca-46ae-8987-aaed435556ea.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "4cb1178f-61c1-5669-a24d-40ad9b02bbed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724d28a0-730c-489d-a729-55eb8149402d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724d28a0-730c-489d-a729-55eb8149402d.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "Whenever you cast an Elf spell, you may put a 1/1 green Elf Warrior creature token onto the battlefield.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "ab22c3ee-4b3b-5bcd-89b2-f969ed61bfe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe3329c-7faa-4925-b9d2-075a1ab27e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe3329c-7faa-4925-b9d2-075a1ab27e80.jpg?1",
             "name": "Natural Order",
             "text": "As an additional cost to cast Natural Order, sacrifice a green creature.\nSearch your library for a green creature card and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "fde6b1d1-d079-58b9-8fe0-5555f3d2dc17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666a8ac9-d21d-4f3e-84a4-117fbeabbe8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666a8ac9-d21d-4f3e-84a4-117fbeabbe8b.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "580124b3-0490-5576-9832-4169391e7686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bfc161-7bf5-4796-b539-1cdeaa95e3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bfc161-7bf5-4796-b539-1cdeaa95e3de.jpg?1",
             "name": "Nimble Mongoose",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nThreshold \u2014 Nimble Mongoose gets +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "4cd32922-4fc5-5832-96e3-bbc11e8510e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd96a99-c3a0-4923-80a1-51d26fc8bb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd96a99-c3a0-4923-80a1-51d26fc8bb91.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "54062b97-1db2-5a44-a27d-bca92736cd48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6eb422-6e99-42bc-890b-99d4f6cd20f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6eb422-6e99-42bc-890b-99d4f6cd20f2.jpg?1",
             "name": "Regal Force",
             "text": "When Regal Force enters the battlefield, draw a card for each green creature you control.",
             "colours": [
@@ -6104,7 +6104,7 @@
         },
         {
             "id": "fe37b4f5-b6e2-5fb1-8248-608b29dc0c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b55e5ab-f437-477d-8c21-eb96f03f089e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b55e5ab-f437-477d-8c21-eb96f03f089e.jpg?1",
             "name": "Roar of the Wurm",
             "text": "Put a 6/6 green Wurm creature token onto the battlefield.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "4d5b9975-589d-526e-b2b4-960f676f3cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e40f1-2212-402b-a1b6-31c75a2aa816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e40f1-2212-402b-a1b6-31c75a2aa816.jpg?1",
             "name": "Roots",
             "text": "Enchant creature without flying\nWhen Roots enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -6170,7 +6170,7 @@
         },
         {
             "id": "ab556ec3-63d2-5666-9c32-d177ff4754d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559c3909-51e3-4a3e-8570-107ffe69e30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559c3909-51e3-4a3e-8570-107ffe69e30d.jpg?1",
             "name": "Seal of Strength",
             "text": "Sacrifice Seal of Strength: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "9e56efc1-8cc7-501b-ac7b-b8443dee8626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddd780-29e5-4dbd-a371-5e46f63157d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddd780-29e5-4dbd-a371-5e46f63157d4.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -6236,7 +6236,7 @@
         },
         {
             "id": "872cbe9c-0384-50c8-a2df-bbcf45198de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1175357-01fe-438c-93bc-09e29ed8c9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1175357-01fe-438c-93bc-09e29ed8c9cb.jpg?1",
             "name": "Silvos, Rogue Elemental",
             "text": "Trample\n{G}: Regenerate Silvos, Rogue Elemental.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "8935e459-ba0b-54d6-b123-1614b4e13058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d2a7-8185-4df0-a35a-f89c12857f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d2a7-8185-4df0-a35a-f89c12857f87.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -6304,7 +6304,7 @@
         },
         {
             "id": "578d2e9b-792e-50ab-9087-791e1e69eaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f905cc8-dd34-4e56-a92e-1ea1814d1983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f905cc8-dd34-4e56-a92e-1ea1814d1983.jpg?1",
             "name": "Sylvan Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nFlashback {2}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6336,7 +6336,7 @@
         },
         {
             "id": "6bf38027-13df-5be3-b89a-67ca6cb1c635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608b0f34-83be-44a3-ba92-69df9b8af8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608b0f34-83be-44a3-ba92-69df9b8af8d1.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach, deathtouch",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "f4566c5e-316b-5771-84a3-713d129f37bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d902a83-5e39-4df3-a897-e9ac65a8209c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d902a83-5e39-4df3-a897-e9ac65a8209c.jpg?1",
             "name": "Timberwatch Elf",
             "text": "{T}: Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "7324cfb4-ce55-54d6-9053-f41ce8cb5715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224ea635-b95b-4803-8716-edd4cb655923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224ea635-b95b-4803-8716-edd4cb655923.jpg?1",
             "name": "Werebear",
             "text": "{T}: Add {G} to your mana pool.\nThreshold \u2014 Werebear gets +3/+3 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "7da184d2-aad9-5b27-bf1b-aedc8d0d232f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f1d22-1416-4012-979c-35152ff520bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f1d22-1416-4012-979c-35152ff520bd.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "Return an Elf you control to its owner's hand: Untap target creature. Activate this ability only once each turn.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "2cb51f34-c81a-53f0-b2a8-4862d2b89845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ab408-3292-40b6-b35e-ac1b7f06dffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ab408-3292-40b6-b35e-ac1b7f06dffa.jpg?1",
             "name": "Xantid Swarm",
             "text": "Flying\nWhenever Xantid Swarm attacks, defending player can't cast spells this turn.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "cda93da7-53ed-5b39-bd4b-34140cc29fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cc6976-7247-4cd9-a0f0-fcb2e860a70e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cc6976-7247-4cd9-a0f0-fcb2e860a70e.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment on the battlefield.",
             "colours": [
@@ -6544,7 +6544,7 @@
         },
         {
             "id": "8575f6ba-57c4-54eb-9919-de904435c575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa232c65-dbb4-4414-bd95-b3bbd321c653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa232c65-dbb4-4414-bd95-b3bbd321c653.jpg?1",
             "name": "Armadillo Cloak",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample.\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "f05af4a8-c77b-57b2-893b-9de4baff0a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7536fa-a501-4e31-941f-b391a61e358a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7536fa-a501-4e31-941f-b391a61e358a.jpg?1",
             "name": "Baleful Strix",
             "text": "Flying, deathtouch\nWhen Baleful Strix enters the battlefield, draw a card.",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "78e075e1-4cc8-5f83-babe-aef751376a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b15ab8-c117-42b9-8177-df96153d6a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b15ab8-c117-42b9-8177-df96153d6a38.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -6654,7 +6654,7 @@
         },
         {
             "id": "fa07cb1f-8f33-5510-a786-3dc1e0b28d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba873c1-f1ff-49f2-9e0d-bc9d52f94d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba873c1-f1ff-49f2-9e0d-bc9d52f94d76.jpg?1",
             "name": "Brago, King Eternal",
             "text": "Flying\nWhenever Brago, King Eternal deals combat damage to a player, exile any number of target nonland permanents you control, then return those cards to the battlefield under their owner's control.",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "f517a677-d53c-541a-80c7-4137ccf7aca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10158a5e-5a03-41ab-85d2-0907ccf32c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10158a5e-5a03-41ab-85d2-0907ccf32c9b.jpg?1",
             "name": "Dack Fayden",
             "text": "+1: Target player draws two cards, then discards two cards.\n\u22122: Gain control of target artifact.\n\u22126: You get an emblem with \"Whenever you cast a spell that targets one or more permanents, gain control of those permanents.\"",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "a18545fa-c13e-5feb-ab3b-30de53b98442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17592ec3-cffb-4cf9-86bc-4ad3ac696d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17592ec3-cffb-4cf9-86bc-4ad3ac696d91.jpg?1",
             "name": "Extract from Darkness",
             "text": "Each player puts the top two cards of his or her library into his or her graveyard. Then put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -6765,7 +6765,7 @@
         },
         {
             "id": "39bd59e0-ed85-53a3-8d1b-172a32888c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7db99b-903f-43d8-bc60-cab2d914a0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7db99b-903f-43d8-bc60-cab2d914a0cb.jpg?1",
             "name": "Flame-Kin Zealot",
             "text": "When Flame-Kin Zealot enters the battlefield, creatures you control get +1/+1 and gain haste until end of turn.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "d52d8e38-17f1-514a-9af5-5986fe1344fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b6e40f-02d6-498f-bb3b-6a9e19ed46f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b6e40f-02d6-498f-bb3b-6a9e19ed46f6.jpg?1",
             "name": "Glare of Subdual",
             "text": "Tap an untapped creature you control: Tap target artifact or creature.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "941a5380-8613-5fe5-87e9-e94ef279bec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06625dee-d2e6-4efa-a385-5113d0fe78ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06625dee-d2e6-4efa-a385-5113d0fe78ac.jpg?1",
             "name": "Goblin Trenches",
             "text": "{2}, Sacrifice a land: Put two 1/1 red and white Goblin Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "8b388a3d-dc70-5931-b4b7-07da5f8ab6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a494b35-44d4-45e3-abfa-eb1874c6aa21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a494b35-44d4-45e3-abfa-eb1874c6aa21.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order. Then do it again.)",
             "colours": [
@@ -6910,7 +6910,7 @@
         },
         {
             "id": "15324acd-6d61-5bee-ab7b-b96993317df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedf655-771d-4a08-a24a-3dc5d1725314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedf655-771d-4a08-a24a-3dc5d1725314.jpg?1",
             "name": "Shaman of the Pack",
             "text": "When Shaman of the Pack enters the battlefield, target opponent loses life equal to the number of Elves you control.",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "f5104ae2-a0a9-54bf-af9c-0d3b606d43de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddb094-533a-4f9e-ab9a-e95a6432ce85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddb094-533a-4f9e-ab9a-e95a6432ce85.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "1f191de2-6af5-5d6f-b941-4686b267c89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9b802-3381-4318-a352-d85451aba586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9b802-3381-4318-a352-d85451aba586.jpg?1",
             "name": "Sphinx of the Steel Wind",
             "text": "Flying, first strike, vigilance, lifelink, protection from red and from green",
             "colours": [
@@ -7024,7 +7024,7 @@
         },
         {
             "id": "3bf15900-671a-54b6-abc9-8876269f7084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64551550-6279-4f6e-a5b9-e1332e927421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64551550-6279-4f6e-a5b9-e1332e927421.jpg?1",
             "name": "Thunderclap Wyvern",
             "text": "Flash\nFlying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "2a51a660-bc7c-57ad-bd6a-80b41f40472e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9f1b7c-96b4-4036-9c1b-0ea9891da89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9f1b7c-96b4-4036-9c1b-0ea9891da89e.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "525ef4ed-b7f8-5bf1-924e-233ee7d7d4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f7927-77a0-4f66-8b92-e42c5bf6251d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f7927-77a0-4f66-8b92-e42c5bf6251d.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -7130,7 +7130,7 @@
         },
         {
             "id": "a25022ce-8590-5eb7-ad2e-1c2493d17ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b3e320-a85c-4d92-944e-0a5e78a066a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b3e320-a85c-4d92-944e-0a5e78a066a5.jpg?1",
             "name": "Void",
             "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards all nonland cards with converted mana cost equal to the number.",
             "colours": [
@@ -7164,7 +7164,7 @@
         },
         {
             "id": "4f5fe89e-c721-55a8-9850-604f6179ce0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68a75f-abcb-49b0-a07b-a011b934969a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68a75f-abcb-49b0-a07b-a011b934969a.jpg?1",
             "name": "Wee Dragonauts",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Wee Dragonauts gets +2/+0 until end of turn.",
             "colours": [
@@ -7201,7 +7201,7 @@
         },
         {
             "id": "e88d42f9-a4d2-53d2-a326-40db60ad5979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e69fc-9a3e-4830-a0ea-36183274325a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e69fc-9a3e-4830-a0ea-36183274325a.jpg?1",
             "name": "Zealous Persecution",
             "text": "Until end of turn, creatures you control get +1/+1 and creatures your opponents control get -1/-1.",
             "colours": [
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "067c3a75-34a7-502d-bc28-92373931db25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9511172e-f5dc-4356-9a9d-9fd4527069e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9511172e-f5dc-4356-9a9d-9fd4527069e3.jpg?1",
             "name": "Call the Skybreaker",
             "text": "Put a 5/5 blue and red Elemental creature token with flying onto the battlefield.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -7269,7 +7269,7 @@
         },
         {
             "id": "e4762986-08df-5826-ba7d-463a77ba10a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14f9fc8-e48c-473f-ba6b-9cffce94bb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14f9fc8-e48c-473f-ba6b-9cffce94bb53.jpg?1",
             "name": "Deathrite Shaman",
             "text": "{T}: Exile target land card from a graveyard. Add one mana of any color to your mana pool.\n{B}, {T}: Exile target instant or sorcery card from a graveyard. Each opponent loses 2 life.\n{G}, {T}: Exile target creature card from a graveyard. You gain 2 life.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "9aeea31f-bd6f-5f7c-a1a9-b214b5be73e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6038-e2e9-4de2-a94e-0798c80a94c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6038-e2e9-4de2-a94e-0798c80a94c6.jpg?1",
             "name": "Giant Solifuge",
             "text": "Trample, haste\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -7342,7 +7342,7 @@
         },
         {
             "id": "dc7c896f-8d6b-5e0a-b771-2fbaa588dfc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0252d0d9-af34-4eaf-8cf2-ef1a3af494f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0252d0d9-af34-4eaf-8cf2-ef1a3af494f8.jpg?1",
             "name": "Torrent of Souls",
             "text": "Return up to one target creature card from your graveyard to the battlefield if {B} was spent to cast Torrent of Souls. Creatures target player controls get +2/+0 and gain haste until end of turn if {R} was spent to cast Torrent of Souls. (Do both if {B}{R} was spent.)",
             "colours": [
@@ -7376,7 +7376,7 @@
         },
         {
             "id": "72dce557-ea67-5b17-b5cd-adf407af04fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87da5ad8-b35f-4f9c-b17a-bb2563cbc186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87da5ad8-b35f-4f9c-b17a-bb2563cbc186.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "6ae990d1-0777-50a7-af3f-2753261602dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f7138-60e0-444e-aaa3-8769072da916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f7138-60e0-444e-aaa3-8769072da916.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint \u2014 When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors to your mana pool.",
             "colours": [],
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "df5c550a-9a13-5723-8342-a7a5d6974fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e357856-99d6-407a-bfa2-3cddbf4affd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e357856-99d6-407a-bfa2-3cddbf4affd3.jpg?1",
             "name": "Duplicant",
             "text": "Imprint \u2014 When Duplicant enters the battlefield, you may exile target nontoken creature.\nAs long as a card exiled with Duplicant is a creature card, Duplicant has the power, toughness, and creature types of the last creature card exiled with Duplicant. It's still a Shapeshifter.",
             "colours": [],
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "5da345a2-3521-5abb-858f-3d1cda1fd99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb78dd-03d7-43a0-8ff5-1b97c6f515c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb78dd-03d7-43a0-8ff5-1b97c6f515c9.jpg?1",
             "name": "Emmessi Tome",
             "text": "{5}, {T}: Draw two cards, then discard a card.",
             "colours": [],
@@ -7491,7 +7491,7 @@
         },
         {
             "id": "c88c0114-34f3-5cc8-9119-41d4dd106a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451f9489-6997-42c2-96c2-021cd8bdd5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451f9489-6997-42c2-96c2-021cd8bdd5d3.jpg?1",
             "name": "Goblin Charbelcher",
             "text": "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. Goblin Charbelcher deals damage equal to the number of nonland cards revealed this way to target creature or player. If the revealed land card was a Mountain, Goblin Charbelcher deals double that damage instead. Put the revealed cards on the bottom of your library in any order.",
             "colours": [],
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "5a3962da-e5aa-5ef4-8faf-d172b3aecd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c0e902-f7ee-4dab-9a07-025a305c9958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c0e902-f7ee-4dab-9a07-025a305c9958.jpg?1",
             "name": "Isochron Scepter",
             "text": "Imprint \u2014 When Isochron Scepter enters the battlefield, you may exile an instant card with converted mana cost 2 or less from your hand.\n{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its mana cost.",
             "colours": [],
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "4cdfab61-9b1b-511f-b451-053a5541f71d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b0c1a-d4f5-4ef8-a7f1-020453314f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b0c1a-d4f5-4ef8-a7f1-020453314f97.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "a35420a0-a9ff-5fcb-ab06-14b35597c0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb33b46-4d1b-4f97-bfdc-d815aee111da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb33b46-4d1b-4f97-bfdc-d815aee111da.jpg?1",
             "name": "Mana Crypt",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you.\n{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7606,7 +7606,7 @@
         },
         {
             "id": "669b9206-4e2b-5618-8af8-d2f1d0444dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37757eae-e473-4d54-ab12-8ab453855e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37757eae-e473-4d54-ab12-8ab453855e91.jpg?1",
             "name": "Millikin",
             "text": "{T}, Put the top card of your library into your graveyard: Add {C} to your mana pool.",
             "colours": [],
@@ -7637,7 +7637,7 @@
         },
         {
             "id": "c235a8b6-0bb3-5b00-99f5-d1be80a84ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e81c3a-663d-414f-9a4f-95c0e55b1aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e81c3a-663d-414f-9a4f-95c0e55b1aa1.jpg?1",
             "name": "Mindless Automaton",
             "text": "Mindless Automaton enters the battlefield with two +1/+1 counters on it.\n{1}, Discard a card: Put a +1/+1 counter on Mindless Automaton.\nRemove two +1/+1 counters from Mindless Automaton: Draw a card.",
             "colours": [],
@@ -7668,7 +7668,7 @@
         },
         {
             "id": "12a83361-2303-5dab-883e-cdbd7bce12b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72584d-f65e-4c8f-be05-f44389c2381d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72584d-f65e-4c8f-be05-f44389c2381d.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "566b2882-d68a-5a19-9b0c-e623d7733ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da685792-5846-4201-ae64-19a822a4e575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da685792-5846-4201-ae64-19a822a4e575.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "b9f51098-909d-57d6-8543-3e8d6a16d010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19786221-ff63-48be-98cb-82360ca12634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19786221-ff63-48be-98cb-82360ca12634.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "b66754d3-60c2-53cf-9e47-ffc3defeba09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436cd66c-0622-43cd-8748-af4d21a2db3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436cd66c-0622-43cd-8748-af4d21a2db3f.jpg?1",
             "name": "Relic of Progenitus",
             "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "3b24df41-5116-503a-82ad-ee292c94237f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c01c91-ea01-46c7-b94c-97777b968459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c01c91-ea01-46c7-b94c-97777b968459.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "415c586d-8a69-5cf0-b8c0-286da95c33a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6358cf-fcb9-42af-9755-dd1f39bfc8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6358cf-fcb9-42af-9755-dd1f39bfc8ff.jpg?1",
             "name": "Ticking Gnomes",
             "text": "Echo {3} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nSacrifice Ticking Gnomes: Ticking Gnomes deals 1 damage to target creature or player.",
             "colours": [],
@@ -7842,7 +7842,7 @@
         },
         {
             "id": "d60c334b-6101-5464-9080-cdf86351d486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3cec7e-513e-400d-a1a8-2c71cdde02c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3cec7e-513e-400d-a1a8-2c71cdde02c6.jpg?1",
             "name": "Winter Orb",
             "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
             "colours": [],
@@ -7870,7 +7870,7 @@
         },
         {
             "id": "eff7b726-f80a-53a9-9b33-c43881099e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb7c6c-14ac-41f3-a461-451d9ee8e1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb7c6c-14ac-41f3-a461-451d9ee8e1df.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone enters the battlefield tapped.\n{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "e0d8333d-5df6-53e0-adf3-28ce70adc060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d38a0-7714-40c7-ae8e-2afd121ed59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d38a0-7714-40c7-ae8e-2afd121ed59a.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "083c3942-34bc-553e-85ea-30c5c417f854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f3e01-c469-44f8-b34e-e594cd037e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f3e01-c469-44f8-b34e-e594cd037e49.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7960,7 +7960,7 @@
         },
         {
             "id": "5f68b12d-3686-5458-bbe8-7bb45983b21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671633dd-017b-4da5-93e4-45a9b889cc68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671633dd-017b-4da5-93e4-45a9b889cc68.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7991,7 +7991,7 @@
         },
         {
             "id": "f0f39db8-2442-5de1-be6b-5fa433e2e798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d833fd8f-8d1f-4a4d-a42a-58af63c17186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d833fd8f-8d1f-4a4d-a42a-58af63c17186.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8022,7 +8022,7 @@
         },
         {
             "id": "12d5d8b0-0711-58f0-ba4a-ec1eb790875c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c2218-9d12-4ac3-a721-fca590b89847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c2218-9d12-4ac3-a721-fca590b89847.jpg?1",
             "name": "Karakas",
             "text": "{T}: Add {W} to your mana pool.\n{T}: Return target legendary creature to its owner's hand.",
             "colours": [],
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "c41f9f8e-fb71-5cf6-9669-18b3681e48a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8eee4f-99e3-499d-9d6d-0bff023f6512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8eee4f-99e3-499d-9d6d-0bff023f6512.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "5915c825-a6be-50f7-ab4f-b10d1bd55ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f305f103-746b-4406-b569-1a7dc32beee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f305f103-746b-4406-b569-1a7dc32beee7.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "d7e66a47-9415-5679-9874-363b67e50a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642dd947-253b-4082-a774-d474b214a704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642dd947-253b-4082-a774-d474b214a704.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8141,7 +8141,7 @@
         },
         {
             "id": "acd31bcd-678d-54c6-bc93-41a45abf6c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54294215-3d63-4c44-8886-7e2f71c78379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54294215-3d63-4c44-8886-7e2f71c78379.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "ed7b96c9-9f2b-5537-875f-32a3ba2fdac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc7fdf-ff3e-4c09-9d5c-f08cf986689b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc7fdf-ff3e-4c09-9d5c-f08cf986689b.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "380226ae-232a-5846-9ff0-96e5948a6def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "23014a87-6cc5-55c1-a71e-5b4eeb0ef997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f4e8-e4e8-4a77-992a-3af8ef2f8df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f4e8-e4e8-4a77-992a-3af8ef2f8df6.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "26c976b7-e593-5f9a-a1a6-4f5114af6f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaafb9bc-7cea-4624-a227-595544fa42b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaafb9bc-7cea-4624-a227-595544fa42b0.jpg?1",
             "name": "Wasteland",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Wasteland: Destroy target nonbasic land.",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "a7b00e53-2b83-5bb6-91f8-93a60f57393b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a34e90d-6b79-448a-8f90-05733139207e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a34e90d-6b79-448a-8f90-05733139207e.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8324,7 +8324,7 @@
         },
         {
             "id": "86ccef6e-a581-536a-8c5c-81040de8bb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082c3bad-3fea-4c3f-8263-4b16139bb32a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082c3bad-3fea-4c3f-8263-4b16139bb32a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -8354,7 +8354,7 @@
         },
         {
             "id": "243dd9d1-4750-5abb-9c7b-5878f3a4b702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c807dc-9c4f-4e87-9263-4dc9864e78ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c807dc-9c4f-4e87-9263-4dc9864e78ed.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "85cb438e-6852-54f6-98de-60384aac0fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b36a9a-7456-4c72-a7b2-478461d886a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b36a9a-7456-4c72-a7b2-478461d886a4.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8422,7 +8422,7 @@
         },
         {
             "id": "ac41772f-9365-5129-bbf3-99333ec63586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f31debf-0b93-44c7-99b6-be441ba4e167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f31debf-0b93-44c7-99b6-be441ba4e167.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "c1d00c5e-3e97-5815-b0f6-d3547afd1080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98dbedd-b1f1-4a9c-af37-8ce2ae07a247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98dbedd-b1f1-4a9c-af37-8ce2ae07a247.jpg?1",
             "name": "Serf",
             "text": "",
             "colours": [
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "f865d69f-5f58-50a7-9368-d4f2383f474b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207e9b8c-3e5e-4262-8d78-248780600462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207e9b8c-3e5e-4262-8d78-248780600462.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "2916cad8-e495-5469-a1d2-b80c26fb74e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8437b125-6057-4d17-9f2c-28ea56553f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8437b125-6057-4d17-9f2c-28ea56553f84.jpg?1",
             "name": "Carnivore",
             "text": "",
             "colours": [
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "494cf5e8-9c77-5cb5-9f4c-e1c318e8a6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d37f45-e5ad-48e2-b6d4-9f39b1643f3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d37f45-e5ad-48e2-b6d4-9f39b1643f3a.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8592,7 +8592,7 @@
         },
         {
             "id": "b729388a-eea6-5c99-a333-26a1cfed0ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f81e2-916f-4af4-9e63-f4469e953122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f81e2-916f-4af4-9e63-f4469e953122.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "261364f9-97f9-5ecd-a221-2d7b039ed47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ad6525-af56-4512-9a6e-3441e686c367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ad6525-af56-4512-9a6e-3441e686c367.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "c0dea9db-fb14-52e0-8304-5025d32f26f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de85f692-4c8b-45b5-af8b-05a4c2a6cebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de85f692-4c8b-45b5-af8b-05a4c2a6cebf.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8694,7 +8694,7 @@
         },
         {
             "id": "9c643f20-444d-5d60-a0fd-a946556a74fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355eaeb4-582f-4b74-b573-3dd68f376317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355eaeb4-582f-4b74-b573-3dd68f376317.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -8729,7 +8729,7 @@
         },
         {
             "id": "7141cacc-91af-515d-9912-ecd112ba0f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32175ed-d4f8-43b0-8f31-df529167610b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32175ed-d4f8-43b0-8f31-df529167610b.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8763,7 +8763,7 @@
         },
         {
             "id": "22763a77-bc0b-584d-8c2d-6bfe415a0db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae82b600-c406-4c3b-a09b-a18e18fc57b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae82b600-c406-4c3b-a09b-a18e18fc57b1.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "40ea0deb-83d1-565f-9f72-592652ed3606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3022b41d-05c1-452e-a1cd-5ec5a7f4d79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3022b41d-05c1-452e-a1cd-5ec5a7f4d79d.jpg?1",
             "name": "Goblin Soldier",
             "text": "",
             "colours": [
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "6d990ec4-e98d-5b60-bf55-271f19741864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92a00d8-ddac-45df-8130-87ac32815984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92a00d8-ddac-45df-8130-87ac32815984.jpg?1",
             "name": "Dack Fayden Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/EMN.json
+++ b/Assets/Resources/Sets/EMN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e706ac5a-bcae-5b45-9a7a-592635b49c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e7ef7-7958-4d7c-b319-4d3db7955002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e7ef7-7958-4d7c-b319-4d3db7955002.jpg?1",
             "name": "Abundant Maw",
             "text": "Emerge {6}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Abundant Maw, target opponent loses 3 life and you gain 3 life.",
             "colours": [],
@@ -37,7 +37,7 @@
         },
         {
             "id": "75bb3101-c74c-5560-b905-6ed948f8bfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587cb384-db24-4e3d-a338-230e50305d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587cb384-db24-4e3d-a338-230e50305d31.jpg?1",
             "name": "Decimator of the Provinces",
             "text": "Emerge {6}{G}{G}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Decimator of the Provinces, creatures you control get +2/+2 and gain trample until end of turn.\nTrample, haste",
             "colours": [],
@@ -70,7 +70,7 @@
         },
         {
             "id": "f7fdce4d-1dc6-5da2-9326-2f8c4e9e06ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5d1e41-fb0b-4866-912a-2a7d49542428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5d1e41-fb0b-4866-912a-2a7d49542428.jpg?1",
             "name": "Distended Mindbender",
             "text": "Emerge {5}{B}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Distended Mindbender, target opponent reveals his or her hand. You choose from it a nonland card with converted mana cost 3 or less and a card with converted mana cost 4 or greater. That player discards those cards.",
             "colours": [],
@@ -103,7 +103,7 @@
         },
         {
             "id": "57f9c6c6-32b9-552e-93e1-cb929b9572aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082690e8-07b9-4a91-b779-e0123a69ee12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082690e8-07b9-4a91-b779-e0123a69ee12.jpg?1",
             "name": "Drownyard Behemoth",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEmerge {7}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nDrownyard Behemoth has hexproof as long as it entered the battlefield this turn.",
             "colours": [],
@@ -136,7 +136,7 @@
         },
         {
             "id": "658bf7ec-027a-5a3b-9677-1ba4c9135f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2789fb-a263-4207-8a56-4eeb015a024c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2789fb-a263-4207-8a56-4eeb015a024c.jpg?1",
             "name": "Elder Deep-Fiend",
             "text": "Flash\nEmerge {5}{U}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Elder Deep-Fiend, tap up to four target permanents.",
             "colours": [],
@@ -169,7 +169,7 @@
         },
         {
             "id": "14e28c5d-8113-510c-b755-0b66b9281022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74a469-c71d-4773-99d3-5456b31df424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74a469-c71d-4773-99d3-5456b31df424.jpg?1",
             "name": "Emrakul, the Promised End",
             "text": "Emrakul, the Promised End costs {1} less to cast for each card type among cards in your graveyard.\nWhen you cast Emrakul, you gain control of target opponent during that player's next turn. After that turn, that player takes an extra turn.\nFlying, trample, protection from instants",
             "colours": [],
@@ -201,7 +201,7 @@
         },
         {
             "id": "ac3c3b6c-c7e1-58d1-8643-2d0c7f31ad22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce52f5-6d49-4d44-a3d7-925340de8406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce52f5-6d49-4d44-a3d7-925340de8406.jpg?1",
             "name": "Eternal Scourge",
             "text": "You may cast Eternal Scourge from exile.\nWhen Eternal Scourge becomes the target of a spell or ability an opponent controls, exile Eternal Scourge.",
             "colours": [],
@@ -232,7 +232,7 @@
         },
         {
             "id": "21ec97c2-bcf6-5e3e-99e8-22e555fd17d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9160cb-d3de-49ca-a97d-2cd259cd5447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9160cb-d3de-49ca-a97d-2cd259cd5447.jpg?1",
             "name": "It of the Horrid Swarm",
             "text": "Emerge {6}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast It of the Horrid Swarm, put two 1/1 green Insect creature tokens onto the battlefield.",
             "colours": [],
@@ -265,7 +265,7 @@
         },
         {
             "id": "99f63685-c8b6-5b1a-b447-9d95a114c483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13f9a76-3370-4809-88ff-c300bca31c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13f9a76-3370-4809-88ff-c300bca31c9e.jpg?1",
             "name": "Lashweed Lurker",
             "text": "Emerge {5}{G}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Lashweed Lurker, you may put target nonland permanent on top of its owner's library.",
             "colours": [],
@@ -299,7 +299,7 @@
         },
         {
             "id": "a8fd720a-678a-549c-932e-a8d6398bf5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3118737f-2fd9-4fe5-bd0f-43c9ef2166e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3118737f-2fd9-4fe5-bd0f-43c9ef2166e2.jpg?1",
             "name": "Mockery of Nature",
             "text": "Emerge {7}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Mockery of Nature, you may destroy target artifact or enchantment.",
             "colours": [],
@@ -332,7 +332,7 @@
         },
         {
             "id": "42573b73-ef26-5b35-b07e-35b291f95a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3dd0aa-f6e9-435c-af64-20e9de67efe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3dd0aa-f6e9-435c-af64-20e9de67efe9.jpg?1",
             "name": "Vexing Scuttler",
             "text": "Emerge {6}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Vexing Scuttler, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [],
@@ -365,7 +365,7 @@
         },
         {
             "id": "9fde7c4e-1ca6-5fff-a266-3e4c8871ca09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d65efec-018f-485c-906c-460379b4af87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d65efec-018f-485c-906c-460379b4af87.jpg?1",
             "name": "Wretched Gryff",
             "text": "Emerge {5}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Wretched Gryff, draw a card.\nFlying",
             "colours": [],
@@ -398,7 +398,7 @@
         },
         {
             "id": "32962ab0-bb3f-5678-aaaf-e45cb3440d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5805eab-9a32-4c0c-9015-7bdb74ad7634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5805eab-9a32-4c0c-9015-7bdb74ad7634.jpg?1",
             "name": "Blessed Alliance",
             "text": "Escalate {2} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Target player gains 4 life.\n\u2022 Untap up to two target creatures.\n\u2022 Target opponent sacrifices an attacking creature.",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "b87bd158-cb94-5f95-b4f8-aef71e7e8eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0067567-3434-4c12-9d4d-04ffc98d012c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0067567-3434-4c12-9d4d-04ffc98d012c.jpg?1",
             "name": "Borrowed Grace",
             "text": "Escalate {1}{W} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "6081d8fd-26e1-5e6a-9c98-417d03214856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27907985-b5f6-4098-ab43-15a0c2bf94d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27907985-b5f6-4098-ab43-15a0c2bf94d5.jpg?1",
             "name": "Bruna, the Fading Light // Brisela, Voice of Nightmares",
             "text": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
             "colours": [
@@ -499,7 +499,7 @@
         },
         {
             "id": "1b18ca2b-4e5e-54c1-bf43-1f32afa75f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg?1",
             "name": "Brisela, Voice of Nightmares",
             "text": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
             "colours": [],
@@ -534,7 +534,7 @@
         },
         {
             "id": "74e72ea7-64c5-59f1-a63e-e5e8df4c1dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4549735d-df63-47db-ad53-0497499fe387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4549735d-df63-47db-ad53-0497499fe387.jpg?1",
             "name": "Choking Restraints",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{3}{W}{W}, Sacrifice Choking Restraints: Exile enchanted creature.",
             "colours": [
@@ -568,7 +568,7 @@
         },
         {
             "id": "d3208fe3-73ca-5def-88fb-d6dd796d4c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a6369-c07f-47d5-8448-72d8ec7e7898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a6369-c07f-47d5-8448-72d8ec7e7898.jpg?1",
             "name": "Collective Effort",
             "text": "Escalate\u2014\nTap an untapped creature you control. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Destroy target creature with power 4 or greater.\n\u2022 Destroy target enchantment.\n\u2022 Put a +1/+1 counter on each creature target player controls.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "19846933-bf72-506b-8f0c-2dc96bfaeb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4123da54-9947-462e-9862-3eecc459a75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4123da54-9947-462e-9862-3eecc459a75b.jpg?1",
             "name": "Courageous Outrider",
             "text": "When Courageous Outrider enters the battlefield, look at the top four cards of your library. You may reveal a Human card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -635,7 +635,7 @@
         },
         {
             "id": "556da1ee-5ecc-5598-8559-4ed6b11e21e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d30894-82b9-4af8-b0bb-48a78acbc4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d30894-82b9-4af8-b0bb-48a78acbc4bd.jpg?1",
             "name": "Dawn Gryff",
             "text": "Flying",
             "colours": [
@@ -669,7 +669,7 @@
         },
         {
             "id": "dd5f4eaf-b9d2-52e5-9cba-3313b17485cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aa54d9-9f01-46e4-b4bd-f8bc57b44ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aa54d9-9f01-46e4-b4bd-f8bc57b44ac1.jpg?1",
             "name": "Deploy the Gatewatch",
             "text": "Look at the top seven cards of your library. Put up to two planeswalker cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -701,7 +701,7 @@
         },
         {
             "id": "35957337-3c18-50cb-82c0-4997b7fa9ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4135c619-fcff-4339-b778-31dd83e68fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4135c619-fcff-4339-b778-31dd83e68fcb.jpg?1",
             "name": "Desperate Sentry",
             "text": "When Desperate Sentry dies, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.\nDelirium \u2014 Desperate Sentry gets +3/+0 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "755d1e2d-6d14-5dfd-a196-42d19f012daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156b4bca-4145-472b-bf80-13edb0bef561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156b4bca-4145-472b-bf80-13edb0bef561.jpg?1",
             "name": "Drogskol Shieldmate",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Drogskol Shieldmate enters the battlefield, other creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -771,7 +771,7 @@
         },
         {
             "id": "5bd2cbe8-89c4-5742-9abf-23a40cb84d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg?1",
             "name": "Extricator of Sin // Extricator of Flesh",
             "text": "When Extricator of Sin enters the battlefield, you may sacrifice another permanent. If you do, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.\nDelirium \u2014 At the beginning of your upkeep, if there are four or more card types among cards in your graveyard, transform Extricator of Sin.",
             "colours": [
@@ -806,7 +806,7 @@
         },
         {
             "id": "e141f315-d86b-54dc-a5a3-ce4ba65395d3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg?1",
             "name": "Extricator of Sin // Extricator of Flesh",
             "text": "Eldrazi you control have vigilance.\n{2}, {T}, Sacrifice a non-Eldrazi creature: Put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [],
@@ -839,7 +839,7 @@
         },
         {
             "id": "36b0132a-693a-5ef8-9feb-d079ae53002c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6e58-c278-4bfe-8443-33afc7618b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6e58-c278-4bfe-8443-33afc7618b38.jpg?1",
             "name": "Faith Unbroken",
             "text": "Enchant creature you control\nWhen Faith Unbroken enters the battlefield, exile target creature an opponent controls until Faith Unbroken leaves the battlefield.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -873,7 +873,7 @@
         },
         {
             "id": "8e2cae1a-fa5c-58a6-9ee8-2c42c1c9a5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af15a774-b97f-4bc0-913d-4d2a047fed8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af15a774-b97f-4bc0-913d-4d2a047fed8a.jpg?1",
             "name": "Faithbearer Paladin",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "51640cdb-ee01-520f-b8c8-0593a3c4b21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0870d21-603f-4d36-8054-943adba06301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0870d21-603f-4d36-8054-943adba06301.jpg?1",
             "name": "Fiend Binder",
             "text": "Whenever Fiend Binder attacks, tap target creature defending player controls.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "22710322-66ee-5ef6-b9dc-d25e1ab8a266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13118343-e026-4970-bf03-ba2d8fc58bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13118343-e026-4970-bf03-ba2d8fc58bac.jpg?1",
             "name": "Geist of the Lonely Vigil",
             "text": "Defender, flying\nDelirium \u2014 Geist of the Lonely Vigil can attack as though it didn't have defender as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "5bb79a0f-ad7d-5383-8c9d-04bc757bcb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c035a-7da9-4b36-982d-fca8220b1797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c035a-7da9-4b36-982d-fca8220b1797.jpg?1",
             "name": "Gisela, the Broken Blade // Brisela, Voice of Nightmares",
             "text": "Flying, first strike, lifelink\nAt the beginning of your end step, if you both own and control Gisela, the Broken Blade and a creature named Bruna, the Fading Light, exile them, then meld them into Brisela, Voice of Nightmares.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "0a26fb93-b908-5fa4-982d-586f4b574e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3347a-9b32-46a4-a621-4ae5244ba2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3347a-9b32-46a4-a621-4ae5244ba2f5.jpg?1",
             "name": "Give No Ground",
             "text": "Target creature gets +2/+6 until end of turn and can block any number of creatures this turn.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "5bdc20b8-ddbf-5090-92dc-d619f6e701d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41b6ca9-1d6f-46ce-aba0-952871a10a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41b6ca9-1d6f-46ce-aba0-952871a10a4b.jpg?1",
             "name": "Guardian of Pilgrims",
             "text": "When Guardian of Pilgrims enters the battlefield, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "5da895ab-0681-542d-a3d4-c99cc0e95beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d413f69f-fe2d-4049-8640-178af7e927d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d413f69f-fe2d-4049-8640-178af7e927d9.jpg?1",
             "name": "Ironclad Slayer",
             "text": "When Ironclad Slayer enters the battlefield, you may return target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "e3b0edad-55db-5de9-ae4f-f154357d711a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916d8aa5-158f-46f4-babe-981a391fd88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916d8aa5-158f-46f4-babe-981a391fd88b.jpg?1",
             "name": "Ironwright's Cleansing",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "0a437bde-70d9-5efc-9a6a-c194179f58a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg?1",
             "name": "Lone Rider // It That Rides as One",
             "text": "First strike, lifelink\nAt the beginning of the end step, if you gained 3 or more life this turn, transform Lone Rider.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "d5b0032c-a988-5339-b2af-d23dc19b8426",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg?1",
             "name": "Lone Rider // It That Rides as One",
             "text": "First strike, trample, lifelink",
             "colours": [],
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "e4f7e0b8-2f50-597e-b332-e7037bff95ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568323c-b631-48b6-b6da-4dc29d330a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568323c-b631-48b6-b6da-4dc29d330a12.jpg?1",
             "name": "Long Road Home",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "aa53d0e7-f7a0-5f07-b864-dd56f162b93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360f4759-c178-4ac2-b561-c81e13f67740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360f4759-c178-4ac2-b561-c81e13f67740.jpg?1",
             "name": "Lunarch Mantle",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}, Sacrifice a permanent: This creature gains flying until end of turn.\"",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "05482b05-a4e9-504b-ac5d-cb809194f468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e37aa2-d898-47f5-9679-5717bfa25688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e37aa2-d898-47f5-9679-5717bfa25688.jpg?1",
             "name": "Peace of Mind",
             "text": "{W}, Discard a card: You gain 3 life.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "3fd26259-6256-5b9d-8fd3-af7e36967f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5edd8d-8e10-4414-a326-95a672dfcff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5edd8d-8e10-4414-a326-95a672dfcff7.jpg?1",
             "name": "Providence",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, your life total becomes 26.\nYour life total becomes 26.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "00a51f75-8484-5d49-bc0c-ae5dff205332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf153f4d-0d37-41a9-80d8-7f2adaad79c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf153f4d-0d37-41a9-80d8-7f2adaad79c7.jpg?1",
             "name": "Repel the Abominable",
             "text": "Prevent all damage that would be dealt this turn by non-Human sources.",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "9c437fbc-ae92-5adc-8672-9bb339a9a3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d839c5a-dc35-4eaa-9cf0-b6e002815726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d839c5a-dc35-4eaa-9cf0-b6e002815726.jpg?1",
             "name": "Sanctifier of Souls",
             "text": "Whenever another creature enters the battlefield under your control, Sanctifier of Souls gets +1/+1 until end of turn.\n{2}{W}, Exile a creature card from your graveyard: Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -1414,7 +1414,7 @@
         },
         {
             "id": "274b02fc-18c3-5ce7-b3a7-a2c61636ebea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4624976-3773-4a1e-b725-5f6efce147a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4624976-3773-4a1e-b725-5f6efce147a5.jpg?1",
             "name": "Selfless Spirit",
             "text": "Flying\nSacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "0506e6a0-df3a-56f5-8e03-7656006cd5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc32f1d-dee7-4f71-a652-26a006e6020a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc32f1d-dee7-4f71-a652-26a006e6020a.jpg?1",
             "name": "Sigarda's Aid",
             "text": "You may cast Aura and Equipment spells as though they had flash.\nWhenever an Equipment enters the battlefield under your control, you may attach it to target creature you control.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "910708b9-cef0-538a-9fce-0cd329d47f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e798c7-0cbc-444e-8033-629baec7dca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e798c7-0cbc-444e-8033-629baec7dca8.jpg?1",
             "name": "Sigardian Priest",
             "text": "{1}, {T}: Tap target non-Human creature.",
             "colours": [
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "8279139e-363d-5bd0-bbd9-ca3c658164a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618aa2d-d5b3-41e6-978f-2c8292f7f896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618aa2d-d5b3-41e6-978f-2c8292f7f896.jpg?1",
             "name": "Spectral Reserves",
             "text": "Put two 1/1 white Spirit creature tokens with flying onto the battlefield. You gain 2 life.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "91252f81-6e45-54b5-9044-85542d0887dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b65a7-d385-428b-986c-a0d9283a5f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b65a7-d385-428b-986c-a0d9283a5f75.jpg?1",
             "name": "Steadfast Cathar",
             "text": "Whenever Steadfast Cathar attacks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -1583,7 +1583,7 @@
         },
         {
             "id": "35967a39-3539-5069-b272-20de8c72c3ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af01371c-cd09-4882-9caf-04426dd4c965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af01371c-cd09-4882-9caf-04426dd4c965.jpg?1",
             "name": "Subjugator Angel",
             "text": "Flying\nWhen Subjugator Angel enters the battlefield, tap all creatures your opponents control.",
             "colours": [
@@ -1617,7 +1617,7 @@
         },
         {
             "id": "15021980-357c-597c-9412-b378caf2c406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cee38-5e24-49d0-870c-22843ed4e101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cee38-5e24-49d0-870c-22843ed4e101.jpg?1",
             "name": "Thalia, Heretic Cathar",
             "text": "First strike\nCreatures and nonbasic lands your opponents control enter the battlefield tapped.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "50c80ce4-7b6c-559c-adbd-ac89e921b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9930d08d-5965-4c16-a84d-43c8ccf2ad0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9930d08d-5965-4c16-a84d-43c8ccf2ad0b.jpg?1",
             "name": "Thalia's Lancers",
             "text": "First strike\nWhen Thalia's Lancers enters the battlefield, you may search your library for a legendary card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "59375340-7188-5bd8-8fa6-b86ca5a690cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b7cd60-e3b9-4dd8-ad3c-a687f642147f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b7cd60-e3b9-4dd8-ad3c-a687f642147f.jpg?1",
             "name": "Thraben Standard Bearer",
             "text": "{1}{W}, {T}, Discard a card: Put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "aee8c7a4-24fb-5f64-ad8f-0c0bcb8ef379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdb7f1c-6139-4e68-8706-01f373548a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdb7f1c-6139-4e68-8706-01f373548a4f.jpg?1",
             "name": "Advanced Stitchwing",
             "text": "Flying\n{2}{U}, Discard two cards: Return Advanced Stitchwing from your graveyard to the battlefield tapped.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "f0b412e0-7bdb-52a9-bacd-a40f4ec0cdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d85d58-eae3-4f9d-8f54-440fa6ded95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d85d58-eae3-4f9d-8f54-440fa6ded95b.jpg?1",
             "name": "Chilling Grasp",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.\nMadness {3}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "be51fb62-e5e3-5d1a-9c88-9a6add06e376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740ad768-2be0-4e5a-9d60-6c7ec4bdc107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740ad768-2be0-4e5a-9d60-6c7ec4bdc107.jpg?1",
             "name": "Coax from the Blind Eternities",
             "text": "You may choose an Eldrazi card you own from outside the game or in exile, reveal that card, and put it into your hand.",
             "colours": [
@@ -1823,7 +1823,7 @@
         },
         {
             "id": "b68d10da-b9e2-50d0-b559-defe6825a478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edb76bd-db4b-4279-8eaa-dfdf5952eafc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edb76bd-db4b-4279-8eaa-dfdf5952eafc.jpg?1",
             "name": "Contingency Plan",
             "text": "Look at the top five cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "2241aab6-5f91-50da-bc56-af0f08f45425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17cf756-ec41-4934-8906-4276277c1470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17cf756-ec41-4934-8906-4276277c1470.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "16aef24b-0215-5551-8b15-24b14444c568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg?1",
             "name": "Curious Homunculus // Voracious Reader",
             "text": "{T}: Add {C} to your mana pool. Spend this mana only to cast an instant or sorcery spell.\nAt the beginning of your upkeep, if there are three or more instant and/or sorcery cards in your graveyard, transform Curious Homunculus.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "fdf2f2d9-484e-5fd3-b060-d67be380c513",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg?1",
             "name": "Curious Homunculus // Voracious Reader",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [],
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "1b59d5e1-a6e9-596b-a5c1-a9b4e66e57fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab850c5-6f5e-41b7-ab52-094579caca12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab850c5-6f5e-41b7-ab52-094579caca12.jpg?1",
             "name": "Displace",
             "text": "Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "321ceb85-30d5-5e14-8a42-15136755080e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1",
             "name": "Docent of Perfection // Final Iteration",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, put a 1/1 blue Human Wizard creature token onto the battlefield. Then if you control three or more Wizards, transform Docent of Perfection.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "f5fd28b8-2ca9-5b9c-809e-b683b36f6295",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1",
             "name": "Docent of Perfection // Final Iteration",
             "text": "Flying\nWizards you control get +2/+1 and have flying.\nWhenever you cast an instant or sorcery spell, put a 1/1 blue Human Wizard creature token onto the battlefield.",
             "colours": [],
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "a89b9107-02b2-506f-a380-3bbd688ec9e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dffa444-92ff-41d8-8b55-8896808bbfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dffa444-92ff-41d8-8b55-8896808bbfab.jpg?1",
             "name": "Drag Under",
             "text": "Return target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "d32ca20b-9397-533c-9238-dd0c96d19621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e692b8-f71d-485b-b37b-71259dc6c48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e692b8-f71d-485b-b37b-71259dc6c48e.jpg?1",
             "name": "Enlightened Maniac",
             "text": "When Enlightened Maniac enters the battlefield, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "6eb8577b-b1fd-549c-8d04-2c26fcef87bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c22e0a-81c5-485f-81f0-3e85397108e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c22e0a-81c5-485f-81f0-3e85397108e0.jpg?1",
             "name": "Exultant Cultist",
             "text": "When Exultant Cultist dies, draw a card.",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "118ea154-677d-52db-aa68-56d499345b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0894d76b-801a-4e3b-8378-bfa81fe24d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0894d76b-801a-4e3b-8378-bfa81fe24d59.jpg?1",
             "name": "Fogwalker",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Fogwalker enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "58de8d65-2a87-569c-8edb-fe80a1f86645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a67dd08-0064-4750-adf5-07bacb0296eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a67dd08-0064-4750-adf5-07bacb0296eb.jpg?1",
             "name": "Fortune's Favor",
             "text": "Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "1783e462-21fb-5dd7-9449-000f1d9b2c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4fcbc-15b2-4370-a267-bc2c63ba2aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4fcbc-15b2-4370-a267-bc2c63ba2aa5.jpg?1",
             "name": "Geist of the Archives",
             "text": "Defender\nAt the beginning of your upkeep, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "78df89c8-6aa3-57e8-bf41-c4943af674f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1",
             "name": "Grizzled Angler // Grisly Anglerfish",
             "text": "{T}: Put the top two cards of your library into your graveyard. Then if there is a colorless creature card in your graveyard, transform Grizzled Angler.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "1e3062d1-c2a5-545d-97d6-2137eade0190",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1",
             "name": "Grizzled Angler // Grisly Anglerfish",
             "text": "{6}: Creatures your opponents control attack this turn if able.",
             "colours": [],
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "1498e66b-3ddf-54e1-a4c4-a76a664a4bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9865100f-dddc-407e-a379-2c285475ec89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9865100f-dddc-407e-a379-2c285475ec89.jpg?1",
             "name": "Identity Thief",
             "text": "Whenever Identity Thief attacks, you may exile another target nontoken creature. If you do, Identity Thief becomes a copy of that creature until end of turn. Return the exiled card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "23612c12-a2cd-5945-97b4-db8d5ced1b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7990ebba-e9f2-4ba4-a352-e26ec81d4bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7990ebba-e9f2-4ba4-a352-e26ec81d4bed.jpg?1",
             "name": "Imprisoned in the Moon",
             "text": "Enchant creature, land, or planeswalker\nEnchanted permanent is a colorless land with \"{T}: Add {C} to your mana pool\" and loses all other card types and abilities.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "cba50d4b-c1ec-5baa-a7a3-7ac7f0b82f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6ed0b-40ba-407d-94de-05a705e79b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6ed0b-40ba-407d-94de-05a705e79b95.jpg?1",
             "name": "Ingenious Skaab",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{U}: Ingenious Skaab gets +1/-1 until end of turn.",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "bc071fad-cdcd-5a6a-80e8-2f63ec93c61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f228e-46ff-43e2-bc1d-c2d2df443c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f228e-46ff-43e2-bc1d-c2d2df443c51.jpg?1",
             "name": "Laboratory Brute",
             "text": "When Laboratory Brute enters the battlefield, put the top four cards of your library into your graveyard.",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "3e18b449-9e68-5381-9394-4ded42d56b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614db3-480f-41f6-91ad-66301fc8e394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614db3-480f-41f6-91ad-66301fc8e394.jpg?1",
             "name": "Lunar Force",
             "text": "When an opponent casts a spell, sacrifice Lunar Force and counter that spell.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "5dff60f1-8ccc-59e9-859b-6708f99353ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42391fa7-6172-487c-b8aa-d41ab7c64973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42391fa7-6172-487c-b8aa-d41ab7c64973.jpg?1",
             "name": "Mausoleum Wanderer",
             "text": "Flying\nWhenever another Spirit enters the battlefield under your control, Mausoleum Wanderer gets +1/+1 until end of turn.\nSacrifice Mausoleum Wanderer: Counter target instant or sorcery spell unless its controller pays {X}, where X is Mausoleum Wanderer's power.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "6e2deb37-f4a5-54be-acdb-12bfd1615407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6522a-b9a0-4185-b5ba-c20fa1b772eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6522a-b9a0-4185-b5ba-c20fa1b772eb.jpg?1",
             "name": "Mind's Dilation",
             "text": "Whenever an opponent casts his or her first spell each turn, that player exiles the top card of his or her library. If it's a nonland card, you may cast it without paying its mana cost.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "f90110bf-659e-5ce4-8907-082636057a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40965d3b-9b8f-4706-9364-64f758a768e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40965d3b-9b8f-4706-9364-64f758a768e6.jpg?1",
             "name": "Nebelgast Herald",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever Nebelgast Herald or another Spirit enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "4e60474b-93e0-538b-b283-cdfc1500bd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2301c8-0ca8-4b26-a232-1df90effcb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2301c8-0ca8-4b26-a232-1df90effcb42.jpg?1",
             "name": "Niblis of Frost",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast an instant or sorcery spell, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "7cd27519-352c-5a76-81d2-75f704a84588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3247a4-f99a-4fff-a3a1-c3d51ed1a754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3247a4-f99a-4fff-a3a1-c3d51ed1a754.jpg?1",
             "name": "Scour the Laboratory",
             "text": "Delirium \u2014 Scour the Laboratory costs {2} less to cast if there are four or more card types among cards in your graveyard.\nDraw three cards.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "91be5b53-346d-5f93-88df-871ac4fdcc5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a022c983-0fb8-4e8c-9ba3-9356ad340f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a022c983-0fb8-4e8c-9ba3-9356ad340f66.jpg?1",
             "name": "Spontaneous Mutation",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "67afe4ef-7f85-551c-a778-8865ff426744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b75794d-3334-4b4d-9446-0a251dd3bd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b75794d-3334-4b4d-9446-0a251dd3bd15.jpg?1",
             "name": "Summary Dismissal",
             "text": "Exile all other spells and counter all abilities.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "3dba0b84-269e-5e0e-ba78-febcee1478b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3584150-4f09-4c15-b13e-707bd91b3004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3584150-4f09-4c15-b13e-707bd91b3004.jpg?1",
             "name": "Take Inventory",
             "text": "Draw a card, then draw cards equal to the number of cards named Take Inventory in your graveyard.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "72f20f7c-2170-557c-bd2d-de360e5eed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ac8da-7497-4b07-af86-29bac1361c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ac8da-7497-4b07-af86-29bac1361c8e.jpg?1",
             "name": "Tattered Haunter",
             "text": "Flying\nTattered Haunter can block only creatures with flying.",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "6c52c93d-8478-5c29-8810-f18478015e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7573c2-484c-4b4e-9c26-0f005bd1daee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7573c2-484c-4b4e-9c26-0f005bd1daee.jpg?1",
             "name": "Turn Aside",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "7e5fc133-fe8a-57d7-8d05-084b988bb194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5dac3d-4b49-44c4-a7b2-0a99485252c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5dac3d-4b49-44c4-a7b2-0a99485252c9.jpg?1",
             "name": "Unsubstantiate",
             "text": "Return target spell or creature to its owner's hand.",
             "colours": [
@@ -2854,7 +2854,7 @@
         },
         {
             "id": "d1403cc9-bc6d-5ab3-90c5-c824fbe09fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264baa9a-67fc-4903-9ed8-a4ce6912a184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264baa9a-67fc-4903-9ed8-a4ce6912a184.jpg?1",
             "name": "Wharf Infiltrator",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhenever Wharf Infiltrator deals combat damage to a player, you may draw a card. If you do, discard a card.\nWhenever you discard a creature card, you may pay {2}. If you do, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "cebbc3b7-7bda-5b14-8dd8-2c284798dba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bb97c6-d2ff-459f-986e-73e30534d865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bb97c6-d2ff-459f-986e-73e30534d865.jpg?1",
             "name": "Boon of Emrakul",
             "text": "Enchant creature\nEnchanted creature gets +3/-3.",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "d033495d-66ca-5d90-848c-4baf4615f423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f123e-aad9-4f3e-9f43-1d1be359affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f123e-aad9-4f3e-9f43-1d1be359affb.jpg?1",
             "name": "Borrowed Malevolence",
             "text": "Escalate {2} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both \u2014\n\u2022 Target creature gets +1/+1 until end of turn.\n\u2022 Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "43e0a613-0250-5746-b043-450a137c8c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a23adea-9f4a-409c-a37d-323eee781273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a23adea-9f4a-409c-a37d-323eee781273.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "3a4e88d7-2228-5cef-aa24-ce68b17a981b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67784b3-eb55-452e-b965-f63220b88896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67784b3-eb55-452e-b965-f63220b88896.jpg?1",
             "name": "Certain Death",
             "text": "Destroy target creature. Its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "de291617-a2c1-5392-bcce-c846d62e3ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb94a02f-4660-45b6-8a39-941b710cf8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb94a02f-4660-45b6-8a39-941b710cf8f3.jpg?1",
             "name": "Collective Brutality",
             "text": "Escalate\u2014\nDiscard a card. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Target opponent reveals his or her hand. You choose an instant or sorcery card from it. That player discards that card.\n\u2022 Target creature gets -2/-2 until end of turn.\n\u2022 Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "2af70103-20e1-596c-8301-fcb991642b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629e37d1-c0f3-44f2-926e-41eb3687c1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629e37d1-c0f3-44f2-926e-41eb3687c1d9.jpg?1",
             "name": "Cryptbreaker",
             "text": "{1}{B}, {T}, Discard a card: Put a 2/2 black Zombie creature token onto the battlefield.\nTap three untapped Zombies you control: You draw a card and you lose 1 life.",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "b33e2f83-6bb6-55c1-8651-ae591b4c8439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5978bd-a696-430e-8c35-729d96eec53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5978bd-a696-430e-8c35-729d96eec53e.jpg?1",
             "name": "Dark Salvation",
             "text": "Target player puts X 2/2 black Zombie creature tokens onto the battlefield, then up to one target creature gets -1/-1 until end of turn for each Zombie that player controls.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "9f80d052-a3f3-55c4-9a12-c117cad408a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34a6fdc-5be9-4cb4-97cc-de63e8a0dde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34a6fdc-5be9-4cb4-97cc-de63e8a0dde1.jpg?1",
             "name": "Dusk Feaster",
             "text": "Delirium \u2014 Dusk Feaster costs {2} less to cast if there are four or more card types among cards in your graveyard.\nFlying",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "3e828497-a35d-545d-a8b3-6eec637edf96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f4c713-089b-497c-8c0f-826cab10aa87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f4c713-089b-497c-8c0f-826cab10aa87.jpg?1",
             "name": "Gavony Unhallowed",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Gavony Unhallowed.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "39733f58-1a2d-52a5-8a4a-876e5a585095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc17697-9db9-41d4-aacf-b2f2e6ff80cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc17697-9db9-41d4-aacf-b2f2e6ff80cf.jpg?1",
             "name": "Graf Harvest",
             "text": "Zombies you control have menace. (They can't be blocked except by two or more creatures.)\n{3}{B}, Exile a creature card from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "d8483bbd-7271-5fd3-9892-38473dc69f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dedaff6-bd69-4fe3-a301-f7ea7c2f2861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dedaff6-bd69-4fe3-a301-f7ea7c2f2861.jpg?1",
             "name": "Graf Rats // Chittering Host",
             "text": "At the beginning of combat on your turn, if you both own and control Graf Rats and a creature named Midnight Scavengers, exile them, then meld them into Chittering Host.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "656184c7-05fc-5194-bc28-6931a8ba451b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7c8b7-ca77-47a0-8965-949723ec902d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7c8b7-ca77-47a0-8965-949723ec902d.jpg?1",
             "name": "Haunted Dead",
             "text": "When Haunted Dead enters the battlefield, put a 1/1 white Spirit creature token with flying onto the battlefield.\n{1}{B}, Discard two cards: Return Haunted Dead from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "b695494a-8e71-5c42-a3ae-150d1c9ceccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6ac7d2-0127-49a8-b7d2-a38308d3c27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6ac7d2-0127-49a8-b7d2-a38308d3c27b.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Put the top two cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, put X 2/2 black Zombie creature tokens onto the battlefield, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "e9a60a6f-eb8d-512c-b994-38f5b2cc8d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad542aa9-5c0e-4962-b167-9071e66f9c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad542aa9-5c0e-4962-b167-9071e66f9c03.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -3355,7 +3355,7 @@
         },
         {
             "id": "b48181d5-abd9-5080-9086-6fdeda1d057b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d8354b-df56-4294-9f8a-b7c92e31b88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d8354b-df56-4294-9f8a-b7c92e31b88e.jpg?1",
             "name": "Markov Crusader",
             "text": "Lifelink\nMarkov Crusader has haste as long as you control another Vampire.",
             "colours": [
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "639f197b-8f7f-5981-9d9d-c652c1a970b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a57187c-f0ec-40de-b725-786f787b00a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a57187c-f0ec-40de-b725-786f787b00a2.jpg?1",
             "name": "Midnight Scavengers // Chittering Host",
             "text": "When Midnight Scavengers enters the battlefield, you may return target creature card with converted mana cost 3 or less from your graveyard to your hand.\n(Melds with Graf Rats.)",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "3f8cdafb-10d5-510a-b908-49dd4c80fff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b94f21-4f01-46f8-ad50-e2bb0b68ea33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b94f21-4f01-46f8-ad50-e2bb0b68ea33.jpg?1",
             "name": "Chittering Host",
             "text": "When Midnight Scavengers enters the battlefield, you may return target creature card with converted mana cost 3 or less from your graveyard to your hand.\n(Melds with Graf Rats.)",
             "colours": [],
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "61a5fdce-439a-5c59-ad9f-48e55e9aa99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2eb849-b3ab-4d26-86c5-235c8161cf2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2eb849-b3ab-4d26-86c5-235c8161cf2a.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3490,7 +3490,7 @@
         },
         {
             "id": "d4b52df0-7bc0-5041-b3ac-510944cfe1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de44166d-3db6-4ece-985d-b8977c25e29f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de44166d-3db6-4ece-985d-b8977c25e29f.jpg?1",
             "name": "Noosegraf Mob",
             "text": "Noosegraf Mob enters the battlefield with five +1/+1 counters on it.\nWhenever a player casts a spell, remove a +1/+1 counter from Noosegraf Mob. If you do, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "0e41de37-a8b4-5741-be47-7f232262e635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2028f577-e0fb-48dd-89c6-f4a000b0a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2028f577-e0fb-48dd-89c6-f4a000b0a881.jpg?1",
             "name": "Oath of Liliana",
             "text": "When Oath of Liliana enters the battlefield, each opponent sacrifices a creature.\nAt the beginning of each end step, if a planeswalker entered the battlefield under your control this turn, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "5427de4e-98fa-50ac-b899-30b39859451c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868067ce-3415-4239-b7c3-d3ad4c03fb8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868067ce-3415-4239-b7c3-d3ad4c03fb8d.jpg?1",
             "name": "Olivia's Dragoon",
             "text": "Discard a card: Olivia's Dragoon gains flying until end of turn.",
             "colours": [
@@ -3593,7 +3593,7 @@
         },
         {
             "id": "f26941ad-592b-5475-95af-bbc643d3f37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9fcf7c-8785-4285-b583-7060edabc3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9fcf7c-8785-4285-b583-7060edabc3c6.jpg?1",
             "name": "Prying Questions",
             "text": "Target opponent loses 3 life and puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "5ac13717-8c8c-5070-910a-2d2507659bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e5b5d5-691c-44f0-8fab-fdecdd4c721d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e5b5d5-691c-44f0-8fab-fdecdd4c721d.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "e145b644-f955-58f9-9922-397d6c2c3ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe81c78f-e3e2-4513-9711-896e6a1e6aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe81c78f-e3e2-4513-9711-896e6a1e6aba.jpg?1",
             "name": "Ruthless Disposal",
             "text": "As an additional cost to cast Ruthless Disposal, discard a card and sacrifice a creature.\nTwo target creatures each get -13/-13 until end of turn.",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "76c99e60-9c6a-59ca-a909-96a0ae3d258e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f63897-15a1-4b34-9916-d9df62f66785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f63897-15a1-4b34-9916-d9df62f66785.jpg?1",
             "name": "Skirsdag Supplicant",
             "text": "{B}, {T}, Discard a card: Each player loses 2 life.",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "d060ca5b-ded0-5119-a31e-6cc1260863c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b9847-7ef7-4fcc-ba16-8f2859d53fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b9847-7ef7-4fcc-ba16-8f2859d53fe6.jpg?1",
             "name": "Strange Augmentation",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nDelirium \u2014 Enchanted creature gets an additional +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -3758,7 +3758,7 @@
         },
         {
             "id": "439e5e45-6ec8-52a8-92c6-1d444fb2c7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a8403e-bf4c-4aae-9102-188f49c61ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a8403e-bf4c-4aae-9102-188f49c61ddf.jpg?1",
             "name": "Stromkirk Condemned",
             "text": "Discard a card: Vampires you control get +1/+1 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -3793,7 +3793,7 @@
         },
         {
             "id": "cd115834-83c7-59b9-b21e-57c88371d5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2974e18b-be17-4059-9f29-7afe1d1a51eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2974e18b-be17-4059-9f29-7afe1d1a51eb.jpg?1",
             "name": "Succumb to Temptation",
             "text": "You draw two cards and you lose 2 life.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "a52f763d-cdf5-5a72-8baf-35827270e36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0f72e0-1254-4bfb-b405-d64012dc171a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0f72e0-1254-4bfb-b405-d64012dc171a.jpg?1",
             "name": "Thraben Foulbloods",
             "text": "Delirium \u2014 Thraben Foulbloods gets +1/+1 and has menace as long as there are four or more card types among cards in your graveyard. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3860,7 +3860,7 @@
         },
         {
             "id": "e23c9d1a-66ba-5764-8dd8-dd0a4bea766c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305bd19a-ae5e-46ca-8ff7-27810c968315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305bd19a-ae5e-46ca-8ff7-27810c968315.jpg?1",
             "name": "Tree of Perdition",
             "text": "Defender\n{T}: Exchange target opponent's life total with Tree of Perdition's toughness.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "0249922a-bd27-55e7-9bdf-73549c655870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954d53f3-ebbe-48e0-9e1a-7019d2b0740c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954d53f3-ebbe-48e0-9e1a-7019d2b0740c.jpg?1",
             "name": "Vampire Cutthroat",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3929,7 +3929,7 @@
         },
         {
             "id": "f4682753-4359-5150-9b2a-0df7094c18c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg?1",
             "name": "Voldaren Pariah // Abolisher of Bloodlines",
             "text": "Flying\nSacrifice three other creatures: Transform Voldaren Pariah.\nMadness {B}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3964,7 +3964,7 @@
         },
         {
             "id": "a9495c75-2e68-58ad-9a26-311d5f9cc35e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg?1",
             "name": "Voldaren Pariah // Abolisher of Bloodlines",
             "text": "Flying\nWhen this creature transforms into Abolisher of Bloodlines, target opponent sacrifices three creatures.",
             "colours": [],
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "66295061-60b9-54db-ade5-155d6bbf1bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1bf0dd-825c-4c8a-a48d-84f35fbe5901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1bf0dd-825c-4c8a-a48d-84f35fbe5901.jpg?1",
             "name": "Wailing Ghoul",
             "text": "When Wailing Ghoul enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "c7504f2c-7c93-510e-8dda-60636d9ae7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5234ac-e308-417d-96b0-d860f3186e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5234ac-e308-417d-96b0-d860f3186e6b.jpg?1",
             "name": "Weirded Vampire",
             "text": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "152011ca-24fd-50db-bd56-4c3bf6c8e252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7ba428-5a35-4062-8e16-39eb927cb316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7ba428-5a35-4062-8e16-39eb927cb316.jpg?1",
             "name": "Whispers of Emrakul",
             "text": "Target opponent discards a card at random.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, that player discards two cards at random instead.",
             "colours": [
@@ -4098,7 +4098,7 @@
         },
         {
             "id": "f2c10c1a-e847-5ff9-bf09-5ea4e293514d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c0b3b3-bb62-42c5-9869-386af0540a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c0b3b3-bb62-42c5-9869-386af0540a9b.jpg?1",
             "name": "Abandon Reason",
             "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "256b47ac-76d4-5a46-871e-e42b0f8a97f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f33aaa1-cbaa-40a9-889e-3eca26b3a549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f33aaa1-cbaa-40a9-889e-3eca26b3a549.jpg?1",
             "name": "Alchemist's Greeting",
             "text": "Alchemist's Greeting deals 4 damage to target creature.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "c6947287-28c0-5416-b4e1-12fe952a54d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8603c493-afb0-47a1-b4e3-9848b3824840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8603c493-afb0-47a1-b4e3-9848b3824840.jpg?1",
             "name": "Assembled Alphas",
             "text": "Whenever Assembled Alphas blocks or becomes blocked by a creature, Assembled Alphas deals 3 damage to that creature and 3 damage to that creature's controller.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "b6bf6db4-c2e9-5811-bc25-20564cc52f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0232f188-44f2-4aee-963c-6f6edc4a21ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0232f188-44f2-4aee-963c-6f6edc4a21ac.jpg?1",
             "name": "Bedlam Reveler",
             "text": "Bedlam Reveler costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "d9425806-f510-56a8-bd2a-f4a0fa12b7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6982bde-1fa3-48fa-803d-a45d6acbc2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6982bde-1fa3-48fa-803d-a45d6acbc2fe.jpg?1",
             "name": "Blood Mist",
             "text": "At the beginning of combat on your turn, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "c3fa8e57-ccca-5795-a4e9-10b2d83229ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bb2e6d-2ead-4ce3-8e5e-fc6900435583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bb2e6d-2ead-4ce3-8e5e-fc6900435583.jpg?1",
             "name": "Bold Impaler",
             "text": "{2}{R}: Bold Impaler gets +2/+0 until end of turn.",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "aebde1ad-3f20-59a0-bbc6-7a7794701a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd91a194-6043-4c2d-afc8-427c38996ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd91a194-6043-4c2d-afc8-427c38996ef4.jpg?1",
             "name": "Borrowed Hostility",
             "text": "Escalate {3} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both \u2014\n\u2022 Target creature gets +3/+0 until end of turn.\n\u2022 Target creature gains first strike until end of turn.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "50ed97df-c060-5f6b-84f3-2dd1b4fc263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8e2ece-3c66-4f34-9042-fc02639c6a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8e2ece-3c66-4f34-9042-fc02639c6a79.jpg?1",
             "name": "Brazen Wolves",
             "text": "Whenever Brazen Wolves attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "c68f1b69-2b72-5d26-99b7-ece48f4fa716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960883f-3813-412b-9a5b-f8cf8d566fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960883f-3813-412b-9a5b-f8cf8d566fac.jpg?1",
             "name": "Collective Defiance",
             "text": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Target player discards all the cards in his or her hand, then draws that many cards.\n\u2022 Collective Defiance deals 4 damage to target creature.\n\u2022 Collective Defiance deals 3 damage to target opponent.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "99cbc65e-59b7-5bcc-9dc2-e4ee565a5ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg?1",
             "name": "Conduit of Storms // Conduit of Emrakul",
             "text": "Whenever Conduit of Storms attacks, add {R} to your mana pool at the beginning of your next main phase this turn.\n{3}{R}{R}: Transform Conduit of Storms.",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "091d8bee-913c-5277-a9d6-13a03c772bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg?1",
             "name": "Conduit of Storms // Conduit of Emrakul",
             "text": "Whenever Conduit of Emrakul attacks, add {C}{C} to your mana pool at the beginning of your next main phase this turn.",
             "colours": [],
@@ -4464,7 +4464,7 @@
         },
         {
             "id": "0b5ebbfe-84bf-50ae-a2b2-972e8b706461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06f9eb-112e-458b-83c8-3761df6d60ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06f9eb-112e-458b-83c8-3761df6d60ff.jpg?1",
             "name": "Deranged Whelp",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "9c766fd0-8a67-568d-8466-051f77e59a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad2acb-073b-4a98-be8c-2ea39ca85496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad2acb-073b-4a98-be8c-2ea39ca85496.jpg?1",
             "name": "Distemper of the Blood",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "57e77108-0148-5d43-8c42-3225507a7ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2023b3-5999-44b1-a67f-3f2a76cb2d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2023b3-5999-44b1-a67f-3f2a76cb2d14.jpg?1",
             "name": "Falkenrath Reaver",
             "text": "",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "e3367176-bd52-5b9d-964f-6ec287135fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a957d6-fc14-453a-a250-63fc130e330d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a957d6-fc14-453a-a250-63fc130e330d.jpg?1",
             "name": "Furyblade Vampire",
             "text": "Trample\nAt the beginning of combat on your turn, you may discard a card. If you do, Furyblade Vampire gets +3/+0 until end of turn.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "c1398e83-8956-59c0-acdf-c4f5a7ce1440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6a4367-bbee-43b8-b5dd-28498f8e2ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6a4367-bbee-43b8-b5dd-28498f8e2ede.jpg?1",
             "name": "Galvanic Bombardment",
             "text": "Galvanic Bombardment deals X damage to target creature, where X is 2 plus the number of cards named Galvanic Bombardment in your graveyard.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "68858e2c-9998-566e-a653-52cf1120957a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900e494-962d-48c6-8e78-66a489be4bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900e494-962d-48c6-8e78-66a489be4bb2.jpg?1",
             "name": "Hanweir Garrison // Hanweir, the Writhing Township",
             "text": "Whenever Hanweir Garrison attacks, put two 1/1 red Human creature tokens onto the battlefield tapped and attacking.\n(Melds with Hanweir Battlements.)",
             "colours": [
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "90a1aef4-314c-580d-8f64-fcddcafb474f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg?1",
             "name": "Hanweir, the Writhing Township",
             "text": "Whenever Hanweir Garrison attacks, put two 1/1 red Human creature tokens onto the battlefield tapped and attacking.\n(Melds with Hanweir Battlements.)",
             "colours": [],
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "432c740b-50c5-549d-a352-6eb854c53613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f3cc4f-7943-4025-b332-b40653b13014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f3cc4f-7943-4025-b332-b40653b13014.jpg?1",
             "name": "Harmless Offering",
             "text": "Target opponent gains control of target permanent you control.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "bc1e398f-fe7c-5dd9-aa2e-415dc5ef94e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba7acc0-6ef0-4c34-be23-118e1872271f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba7acc0-6ef0-4c34-be23-118e1872271f.jpg?1",
             "name": "Impetuous Devils",
             "text": "Trample, haste\nWhen Impetuous Devils attacks, up to one target creature defending player controls blocks it this combat if able.\nAt the beginning of the end step, sacrifice Impetuous Devils.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "5c5cba30-903c-5142-a654-c3e1f145c1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf464f61-8a7f-493b-a80f-2f2b0ebd8bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf464f61-8a7f-493b-a80f-2f2b0ebd8bf6.jpg?1",
             "name": "Incendiary Flow",
             "text": "Incendiary Flow deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "7f40fa2d-1065-5a16-b6f5-6cb8ab690ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb56491b-bad7-44da-8aa5-91ffd875e76a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb56491b-bad7-44da-8aa5-91ffd875e76a.jpg?1",
             "name": "Insatiable Gorgers",
             "text": "Insatiable Gorgers attacks each combat if able.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "ba490776-6b96-555e-9528-90c705a3d945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2049072-5901-4edd-8305-ce55f256bca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2049072-5901-4edd-8305-ce55f256bca5.jpg?1",
             "name": "Make Mischief",
             "text": "Make Mischief deals 1 damage to target creature or player. Put a 1/1 red Devil creature token onto the battlefield. It has \"When this creature dies, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "889044b3-cc97-5e91-85b2-48e9b1cabb2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7e33a8-765b-4909-a5c6-5fe8f8774a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7e33a8-765b-4909-a5c6-5fe8f8774a51.jpg?1",
             "name": "Mirrorwing Dragon",
             "text": "Flying\nWhenever a player casts an instant or sorcery spell that targets only Mirrorwing Dragon, that player copies that spell for each other creature he or she controls that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "5d9149e0-82b0-5c57-aa06-d00b2df95a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6cb8b0-e3a5-4a94-845d-3b286aa392ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6cb8b0-e3a5-4a94-845d-3b286aa392ac.jpg?1",
             "name": "Nahiri's Wrath",
             "text": "As an additional cost to cast Nahiri's Wrath, discard X cards.\nNahiri's Wrath deals damage equal to the total converted mana cost of the discarded cards to each of up to X target creatures and/or planeswalkers.",
             "colours": [
@@ -4932,7 +4932,7 @@
         },
         {
             "id": "57554642-bb44-5526-a351-d58f0b7f55f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34409e34-04e9-4279-8d21-6ef362b20b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34409e34-04e9-4279-8d21-6ef362b20b72.jpg?1",
             "name": "Otherworldly Outburst",
             "text": "Target creature gets +1/+0 until end of turn. When that creature dies this turn, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "f1556e6b-53e5-5850-947e-64a58cd3ca70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e58861-a548-4344-a37b-1c5764b144d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e58861-a548-4344-a37b-1c5764b144d9.jpg?1",
             "name": "Prophetic Ravings",
             "text": "Enchant creature\nEnchanted creature has haste and \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "42dea550-0519-54e9-a5fd-1782499b3f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5255da8-8511-48a7-98e5-ba43ca6e8681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5255da8-8511-48a7-98e5-ba43ca6e8681.jpg?1",
             "name": "Savage Alliance",
             "text": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Creatures target player controls gain trample until end of turn.\n\u2022 Savage Alliance deals 2 damage to target creature.\n\u2022 Savage Alliance deals 1 damage to each creature target opponent controls.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "72234756-e930-5912-8d31-01ef6578c056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782e5600-ac63-4f90-acbe-49c04d2840ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782e5600-ac63-4f90-acbe-49c04d2840ee.jpg?1",
             "name": "Shreds of Sanity",
             "text": "Return up to one target instant card and up to one target sorcery card from your graveyard to your hand, then discard a card. Exile Shreds of Sanity.",
             "colours": [
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "743fb3c8-3997-51c9-a514-4699be2e8d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1",
             "name": "Smoldering Werewolf // Erupting Dreadwolf",
             "text": "When Smoldering Werewolf enters the battlefield, it deals 1 damage to each of up to two target creatures.\n{4}{R}{R}: Transform Smoldering Werewolf.",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "81d2421f-34b6-5936-bde0-5aaa24784f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1",
             "name": "Smoldering Werewolf // Erupting Dreadwolf",
             "text": "Whenever Erupting Dreadwolf attacks, it deals 2 damage to target creature or player.",
             "colours": [],
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "5ce326fc-d4b8-56fd-8c55-d5c2bf55be72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c655b1dc-8df1-44c8-a963-bd0a671ec7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c655b1dc-8df1-44c8-a963-bd0a671ec7e5.jpg?1",
             "name": "Spreading Flames",
             "text": "Spreading Flames deals 6 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -5162,7 +5162,7 @@
         },
         {
             "id": "c3c0c30d-9431-519d-b57f-3378b2e29090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828db19a-ca0d-4b82-a4b6-451125865093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828db19a-ca0d-4b82-a4b6-451125865093.jpg?1",
             "name": "Stensia Banquet",
             "text": "Stensia Banquet deals damage to target opponent equal to the number of Vampires you control.\nDraw a card.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "4ce8abdf-9690-559a-8d7f-127b8cb54277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40c471-70c8-4171-a214-ce932c4c7e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40c471-70c8-4171-a214-ce932c4c7e2e.jpg?1",
             "name": "Stensia Innkeeper",
             "text": "When Stensia Innkeeper enters the battlefield, tap target land an opponent controls. That land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "0b1489a2-f7f8-5d95-82d9-915d288ff101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa6a443-b23b-48ae-97bb-8fd4deec52c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa6a443-b23b-48ae-97bb-8fd4deec52c4.jpg?1",
             "name": "Stromkirk Occultist",
             "text": "Trample\nWhenever Stromkirk Occultist deals combat damage to a player, exile the top card of your library. Until end of turn, you may play that card.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5263,7 +5263,7 @@
         },
         {
             "id": "89079973-0e0c-51e0-998e-38af4980fc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c194ea-32a5-4683-a6da-4a93d9b4722e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c194ea-32a5-4683-a6da-4a93d9b4722e.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -5298,7 +5298,7 @@
         },
         {
             "id": "c55fd7a5-d0dc-5d80-b9b8-c83d69ab8331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg?1",
             "name": "Vildin-Pack Outcast // Dronepack Kindred",
             "text": "Trample\n{R}: Vildin-Pack Outcast gets +1/-1 until end of turn.\n{5}{R}{R}: Transform Vildin-Pack Outcast.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "8c6ab54f-9aeb-561d-9004-83a6ec0dd36b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg?1",
             "name": "Vildin-Pack Outcast // Dronepack Kindred",
             "text": "Trample\n{1}: Dronepack Kindred gets +1/+0 until end of turn.",
             "colours": [],
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "e0a4774f-130f-5b86-9ddd-4577714a57cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1e6885-dca0-4a4b-abb8-0f32680f618d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1e6885-dca0-4a4b-abb8-0f32680f618d.jpg?1",
             "name": "Weaver of Lightning",
             "text": "Reach\nWhenever you cast an instant or sorcery spell, Weaver of Lightning deals 1 damage to target creature an opponent controls.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "baf10ed1-ae11-557c-8dc2-b48beca958b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a65be-0ca1-437f-aafe-d96e8fe428ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a65be-0ca1-437f-aafe-d96e8fe428ad.jpg?1",
             "name": "Backwoods Survivalists",
             "text": "Delirium \u2014 Backwoods Survivalists gets +1/+1 and has trample as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "4bbf1a82-1084-5119-af0d-7b96e6d40011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1d82e-876f-48a6-8153-f02a44cf90a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1d82e-876f-48a6-8153-f02a44cf90a8.jpg?1",
             "name": "Bloodbriar",
             "text": "Whenever you sacrifice another permanent, put a +1/+1 counter on Bloodbriar.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "59a38566-ec90-5173-8eab-0c3aa0f442d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa1d34-7e32-45b7-9f6f-68f152f75d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa1d34-7e32-45b7-9f6f-68f152f75d1a.jpg?1",
             "name": "Clear Shot",
             "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "025557fe-23a8-5749-a942-c00d352f6522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861e8c51-0cda-497a-b289-a9f678f0e328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861e8c51-0cda-497a-b289-a9f678f0e328.jpg?1",
             "name": "Crop Sigil",
             "text": "At the beginning of your upkeep, you may put the top card of your library into your graveyard.\nDelirium \u2014 {2}{G}, Sacrifice Crop Sigil: Return up to one target creature card and up to one target land card from your graveyard to your hand. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "16b61930-bb41-59a8-97ce-316d20acf94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a83854-dc45-4c26-aca0-67f372236383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a83854-dc45-4c26-aca0-67f372236383.jpg?1",
             "name": "Crossroads Consecrator",
             "text": "{G}, {T}: Target attacking Human gets +1/+1 until end of turn.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "a7688ec6-6872-553c-9242-3bb0927fa7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcb00e5-2caa-45c8-ad19-05d45c683d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcb00e5-2caa-45c8-ad19-05d45c683d16.jpg?1",
             "name": "Eldritch Evolution",
             "text": "As an additional cost to cast Eldritch Evolution, sacrifice a creature.\nSearch your library for a creature card with converted mana cost X or less, where X is 2 plus the sacrificed creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Exile Eldritch Evolution.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "e6c4c854-3a69-5a90-83e4-d6ec7084c839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c21822-972f-4c20-ac3b-80ba9af101c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c21822-972f-4c20-ac3b-80ba9af101c5.jpg?1",
             "name": "Emrakul's Evangel",
             "text": "{T}, Sacrifice Emrakul's Evangel and any number of other non-Eldrazi creatures: Put a 3/2 colorless Eldrazi Horror creature token onto the battlefield for each creature sacrificed this way.",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "1e949ace-e724-5659-88f9-e7414eb3bb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112476e7-72ab-4ebc-9e6e-e96fbf5109c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112476e7-72ab-4ebc-9e6e-e96fbf5109c0.jpg?1",
             "name": "Emrakul's Influence",
             "text": "Whenever you cast an Eldrazi creature spell with converted mana cost 7 or greater, draw two cards.",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "20dae635-b84f-521e-8826-df28a4d3958c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41446e3b-ecd1-442f-9209-713f0abfc538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41446e3b-ecd1-442f-9209-713f0abfc538.jpg?1",
             "name": "Foul Emissary",
             "text": "When Foul Emissary enters the battlefield, look at the top four cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nWhen you sacrifice Foul Emissary while casting a spell with emerge, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "3e7644ef-a11b-50bd-890d-5afb32f4ff3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa506387-e538-4b2c-94df-29866eb74a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa506387-e538-4b2c-94df-29866eb74a71.jpg?1",
             "name": "Gnarlwood Dryad",
             "text": "Deathtouch\nDelirium \u2014 Gnarlwood Dryad gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5739,7 +5739,7 @@
         },
         {
             "id": "95d1889c-f7aa-5a2d-9ec1-3c8bebc0af53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44a77a6-e8a1-4706-886f-8ab3af56b342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44a77a6-e8a1-4706-886f-8ab3af56b342.jpg?1",
             "name": "Grapple with the Past",
             "text": "Put the top three cards of your library into your graveyard, then you may return a creature or land card from your graveyard to your hand.",
             "colours": [
@@ -5771,7 +5771,7 @@
         },
         {
             "id": "610d888d-dea6-5621-b108-475aaf587b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43435939-20cf-49c9-8e37-63681740399b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43435939-20cf-49c9-8e37-63681740399b.jpg?1",
             "name": "Hamlet Captain",
             "text": "Whenever Hamlet Captain attacks or blocks, other Humans you control get +1/+1 until end of turn.",
             "colours": [
@@ -5806,7 +5806,7 @@
         },
         {
             "id": "9305bd16-2e28-5e4f-bddd-c3feb6e73eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6c5a98-2fe5-4671-a6a8-98a47c09c5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6c5a98-2fe5-4671-a6a8-98a47c09c5a7.jpg?1",
             "name": "Ishkanah, Grafwidow",
             "text": "Reach\nDelirium \u2014 When Ishkanah, Grafwidow enters the battlefield, if there are four or more card types among cards in your graveyard, put three 1/2 green Spider creature tokens with reach onto the battlefield.\n{6}{B}: Target opponent loses 1 life for each Spider you control.",
             "colours": [
@@ -5843,7 +5843,7 @@
         },
         {
             "id": "dd845d91-fc48-591e-b172-faeafe968345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg?1",
             "name": "Kessig Prowler // Sinuous Predator",
             "text": "{4}{G}: Transform Kessig Prowler.",
             "colours": [
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "7e6b0af1-c53d-5c00-b076-b288487d9e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg?1",
             "name": "Kessig Prowler // Sinuous Predator",
             "text": "Sinuous Predator can't be blocked by more than one creature.",
             "colours": [],
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "ee3157cd-3d0d-5f08-8f8b-796eb6b6ba83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307329cd-a69b-4acf-bcba-83d8306fe7ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307329cd-a69b-4acf-bcba-83d8306fe7ee.jpg?1",
             "name": "Noose Constrictor",
             "text": "Reach\nDiscard a card: Noose Constrictor gets +1/+1 until end of turn.",
             "colours": [
@@ -5945,7 +5945,7 @@
         },
         {
             "id": "2f323289-0329-5543-be5d-0609aa764b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71290eb-b529-4fc3-ab94-fee0ab9e2169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71290eb-b529-4fc3-ab94-fee0ab9e2169.jpg?1",
             "name": "Permeating Mass",
             "text": "Whenever Permeating Mass deals combat damage to a creature, that creature becomes a copy of Permeating Mass.",
             "colours": [
@@ -5979,7 +5979,7 @@
         },
         {
             "id": "1905d84c-611a-53a5-bc24-e681a877376f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f480aab-725d-410a-be06-242361d0be82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f480aab-725d-410a-be06-242361d0be82.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control.",
             "colours": [
@@ -6011,7 +6011,7 @@
         },
         {
             "id": "42901c99-6052-592d-9918-86377d64b83b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e928f694-c53b-46c5-8390-fa24b53f559c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e928f694-c53b-46c5-8390-fa24b53f559c.jpg?1",
             "name": "Primal Druid",
             "text": "When Primal Druid dies, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "1789cc6e-381d-5c70-9639-0a52b3123942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1",
             "name": "Shrill Howler // Howling Chorus",
             "text": "Creatures with power less than Shrill Howler's power can't block it.\n{5}{G}: Transform Shrill Howler.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "77010854-7200-586c-b4d5-e6e0e069520f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1",
             "name": "Shrill Howler // Howling Chorus",
             "text": "Creatures with power less than Howling Chorus's power can't block it.\nWhenever Howling Chorus deals combat damage to a player, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [],
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "aa4891ef-5327-5956-8d7e-835ebbabc4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651428a8-27af-4137-84f0-f71274a8b4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651428a8-27af-4137-84f0-f71274a8b4a6.jpg?1",
             "name": "Somberwald Stag",
             "text": "When Somberwald Stag enters the battlefield, you may have it fight target creature you don't control.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "5c155d0b-ef27-5a3c-9d6e-22557d86345d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f7b11-49ac-4078-aab7-efe3aff746b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f7b11-49ac-4078-aab7-efe3aff746b2.jpg?1",
             "name": "Spirit of the Hunt",
             "text": "Flash\nWhen Spirit of the Hunt enters the battlefield, each other creature you control that's a Wolf or a Werewolf gets +0/+3 until end of turn.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "a09ad07d-3bf7-578c-bc97-475d95ed4d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17e172-3a46-4957-b711-edc53f70a284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17e172-3a46-4957-b711-edc53f70a284.jpg?1",
             "name": "Splendid Reclamation",
             "text": "Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "d5c39558-1e7b-5388-9b68-76ec630d6e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0b23a4-5868-4dd8-ae68-846934e1bd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0b23a4-5868-4dd8-ae68-846934e1bd52.jpg?1",
             "name": "Springsage Ritual",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "b65595aa-d11b-52fd-b159-4de71bd75514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264f78d8-d554-45f3-867e-19dba38e4644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264f78d8-d554-45f3-867e-19dba38e4644.jpg?1",
             "name": "Swift Spinner",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "ba4023ff-4e33-53ed-bde2-e5b84ccdb21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg?1",
             "name": "Tangleclaw Werewolf // Fibrous Entangler",
             "text": "Tangleclaw Werewolf can block an additional creature each combat.\n{6}{G}: Transform Tangleclaw Werewolf.",
             "colours": [
@@ -6316,7 +6316,7 @@
         },
         {
             "id": "9da52824-fd73-5375-97a5-6da4cec4ea82",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg?1",
             "name": "Tangleclaw Werewolf // Fibrous Entangler",
             "text": "Vigilance\nFibrous Entangler must be blocked if able.\nFibrous Entangler can block an additional creature each combat.",
             "colours": [],
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "db8f0b43-e5f4-5b0f-abee-2f10df4244ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg?1",
             "name": "Ulvenwald Captive // Ulvenwald Abomination",
             "text": "Defender\n{T}: Add {G} to your mana pool.\n{5}{G}{G}: Transform Ulvenwald Captive.",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "9db8a0f2-7122-52ac-a257-ddd344f1e0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg?1",
             "name": "Ulvenwald Captive // Ulvenwald Abomination",
             "text": "{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -6417,7 +6417,7 @@
         },
         {
             "id": "03165ee2-339b-5b9a-8799-ef5ddf062a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d23d5-2f94-48e6-824f-f1de8f742989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d23d5-2f94-48e6-824f-f1de8f742989.jpg?1",
             "name": "Ulvenwald Observer",
             "text": "Whenever a creature you control with toughness 4 or greater dies, draw a card.",
             "colours": [
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "56769a84-2658-5aa8-8d5e-f4f5f370a18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617f9f3a-61a1-4c73-8efe-3d74fe362901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617f9f3a-61a1-4c73-8efe-3d74fe362901.jpg?1",
             "name": "Waxing Moon",
             "text": "Transform up to one target Werewolf you control. Creatures you control gain trample until end of turn.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "86c6b348-08ed-56e1-a685-29f99696125c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748f263e-efef-4033-8950-c58fd024a87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748f263e-efef-4033-8950-c58fd024a87f.jpg?1",
             "name": "Wolfkin Bond",
             "text": "Enchant creature\nWhen Wolfkin Bond enters the battlefield, put a 2/2 green Wolf creature token onto the battlefield.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "9c843bf7-bb9f-5a6a-ae68-374bcf79c67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc329134-4b71-4c33-8cfb-c3867a733115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc329134-4b71-4c33-8cfb-c3867a733115.jpg?1",
             "name": "Woodcutter's Grit",
             "text": "Target creature you control gets +3/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "78fbf7dc-ebe5-5999-838a-64304e9573db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a134bd1-3c5a-467e-bad1-65548b33faa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a134bd1-3c5a-467e-bad1-65548b33faa5.jpg?1",
             "name": "Woodland Patrol",
             "text": "Vigilance",
             "colours": [
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "bc78b1b8-6424-5a9b-8c75-7e8f34dd7ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4824cca-0039-4486-be8f-650dac2c8e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4824cca-0039-4486-be8f-650dac2c8e9f.jpg?1",
             "name": "Bloodhall Priest",
             "text": "Whenever Bloodhall Priest enters the battlefield or attacks, if you have no cards in hand, Bloodhall Priest deals 2 damage to target creature or player.\nMadness {1}{B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6621,7 +6621,7 @@
         },
         {
             "id": "a9950534-e1f7-5a77-8929-85224529bd36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c284997a-cfc3-4ffc-bc25-00c130fb1eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c284997a-cfc3-4ffc-bc25-00c130fb1eb0.jpg?1",
             "name": "Campaign of Vengeance",
             "text": "Whenever a creature you control attacks, defending player loses 1 life and you gain 1 life.",
             "colours": [
@@ -6655,7 +6655,7 @@
         },
         {
             "id": "8bd69452-02c6-5e1c-9594-4d9dea373fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2c85d8-0bef-40d0-abaf-4555462c29c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2c85d8-0bef-40d0-abaf-4555462c29c5.jpg?1",
             "name": "Gisa and Geralf",
             "text": "When Gisa and Geralf enters the battlefield, put the top four cards of your library into your graveyard.\nDuring each of your turns, you may cast a Zombie creature card from your graveyard.",
             "colours": [
@@ -6694,7 +6694,7 @@
         },
         {
             "id": "0067f1bc-85aa-528e-ad50-4dcec5294077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025af99f-a029-4f99-9c76-676b68821520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025af99f-a029-4f99-9c76-676b68821520.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "c1b867eb-aff8-5d00-ab4e-1199e658a102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6448b2e2-01b2-4693-b41e-263909dc6a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6448b2e2-01b2-4693-b41e-263909dc6a95.jpg?1",
             "name": "Heron's Grace Champion",
             "text": "Flash\nLifelink\nWhen Heron's Grace Champion enters the battlefield, other Humans you control get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "ae121ee9-bab9-5797-a3ad-5e18c18f2480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab14779-7e79-449c-9a47-6ba219d0dbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab14779-7e79-449c-9a47-6ba219d0dbc5.jpg?1",
             "name": "Mercurial Geists",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Mercurial Geists gets +3/+0 until end of turn.",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "881d7adb-07ab-5fcd-a7ae-9b52238b16ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa37d8-6765-443f-9b70-200fecf8fa1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa37d8-6765-443f-9b70-200fecf8fa1e.jpg?1",
             "name": "Mournwillow",
             "text": "Haste\nDelirium \u2014 When Mournwillow enters the battlefield, if there are four or more card types among cards in your graveyard, creatures with power 2 or less can't block this turn.",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "c42ee763-b449-5746-822c-106fa03c5946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c021868f-9ab8-4a52-b12e-3cc35c9d67f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c021868f-9ab8-4a52-b12e-3cc35c9d67f0.jpg?1",
             "name": "Ride Down",
             "text": "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "b01b97e4-4e70-5bd0-8105-e1b03a4499b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b76bcd4-580a-4435-afe9-290940b1837f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b76bcd4-580a-4435-afe9-290940b1837f.jpg?1",
             "name": "Spell Queller",
             "text": "Flash\nFlying\nWhen Spell Queller enters the battlefield, exile target spell with converted mana cost 4 or less.\nWhen Spell Queller leaves the battlefield, the exiled card's owner may cast that card without paying its mana cost.",
             "colours": [
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "b8ff7df7-321c-5961-9b2c-5862f988a44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9aced7-9ae9-432f-b8c0-caac9cad098b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9aced7-9ae9-432f-b8c0-caac9cad098b.jpg?1",
             "name": "Tamiyo, Field Researcher",
             "text": "+1: Choose up to two target creatures. Until your next turn, whenever either of those creatures deals combat damage, you draw a card.\n\u22122: Tap up to two target nonland permanents. They don't untap during their controller's next untap step.\n\u22127: Draw three cards. You get an emblem with \"You may cast nonland cards from your hand without paying their mana costs.\"",
             "colours": [
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "a2dd98ba-a682-593d-91a3-fbdd707fc6f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg?1",
             "name": "Ulrich of the Krallenhorde // Ulrich, Uncontested Alpha",
             "text": "Whenever this creature enters the battlefield or transforms into Ulrich of the Krallenhorde, target creature gets +4/+4 until end of turn.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Ulrich of the Krallenhorde.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "64f8d938-d2d7-5c79-ab0e-926bb8aeaa04",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg?1",
             "name": "Ulrich of the Krallenhorde // Ulrich, Uncontested Alpha",
             "text": "Whenever this creature transforms into Ulrich, Uncontested Alpha, you may have it fight target non-Werewolf creature you don't control.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ulrich, Uncontested Alpha.",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "55a8a643-a924-5c96-ad1f-8fc2f2ac1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c18ffa-ffff-4dc4-9db0-d5f183c35e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c18ffa-ffff-4dc4-9db0-d5f183c35e17.jpg?1",
             "name": "Cathar's Shield",
             "text": "Equipped creature gets +0/+3 and has vigilance.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "49aaf11e-fd85-50c4-9bac-2ced9b0cf779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1",
             "name": "Cryptolith Fragment // Aurora of Emrakul",
             "text": "Cryptolith Fragment enters the battlefield tapped.\n{T}: Add one mana of any color to your mana pool. Each player loses 1 life.\nAt the beginning of your upkeep, if each player has 10 or less life, transform Cryptolith Fragment.",
             "colours": [],
@@ -7086,7 +7086,7 @@
         },
         {
             "id": "913591af-1ed0-5c1e-8819-a99d145ab208",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1",
             "name": "Cryptolith Fragment // Aurora of Emrakul",
             "text": "Flying, deathtouch\nWhenever Aurora of Emrakul attacks, each opponent loses 3 life.",
             "colours": [],
@@ -7117,7 +7117,7 @@
         },
         {
             "id": "316faf30-fb10-57a3-87da-1c014c0101e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da8c523-44e8-43e7-8431-28dbed1015ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da8c523-44e8-43e7-8431-28dbed1015ac.jpg?1",
             "name": "Cultist's Staff",
             "text": "Equipped creature gets +2/+2.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7147,7 +7147,7 @@
         },
         {
             "id": "4222ffa7-2322-5cf0-9d6b-77c26005446e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92b162-f51d-4138-8d9b-e5eb929ad87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92b162-f51d-4138-8d9b-e5eb929ad87e.jpg?1",
             "name": "Field Creeper",
             "text": "",
             "colours": [],
@@ -7178,7 +7178,7 @@
         },
         {
             "id": "ada046ce-8d9c-5a3c-9f0e-dadc66151421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c9cafb-4543-409f-a98a-df0e7a0f2749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c9cafb-4543-409f-a98a-df0e7a0f2749.jpg?1",
             "name": "Geist-Fueled Scarecrow",
             "text": "Creature spells you cast cost {1} more to cast.",
             "colours": [],
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "6eea8158-b0fc-52f1-80d1-a9c532a4fa1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8272ca-8e3d-4980-99f2-352a1db76d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8272ca-8e3d-4980-99f2-352a1db76d74.jpg?1",
             "name": "Lupine Prototype",
             "text": "Lupine Prototype can't attack or block unless a player has no cards in hand.",
             "colours": [],
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "0adf9d9a-7130-5503-9109-167e84008df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de4a83a-3a0c-4174-ba65-a6e100383b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de4a83a-3a0c-4174-ba65-a6e100383b32.jpg?1",
             "name": "Slayer's Cleaver",
             "text": "Equipped creature gets +3/+1 and must be blocked by an Eldrazi if able.\nEquip {4}",
             "colours": [],
@@ -7271,7 +7271,7 @@
         },
         {
             "id": "0bf024e3-b0c9-5baf-a126-ddf18b903623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b1158-dfc4-4fe9-b970-338be8a99662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b1158-dfc4-4fe9-b970-338be8a99662.jpg?1",
             "name": "Soul Separator",
             "text": "{5}, {T}, Sacrifice Soul Separator: Exile target creature card from your graveyard. Put a token onto the battlefield that's a copy of that card except it's 1/1, it's a Spirit in addition to its other types, and it has flying. Put a black Zombie creature token onto the battlefield with power equal to that card's power and toughness equal to that card's toughness.",
             "colours": [],
@@ -7299,7 +7299,7 @@
         },
         {
             "id": "8c5f01b9-9160-529b-b401-c969161353b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6d700e-0514-41d7-9255-cedd859316fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6d700e-0514-41d7-9255-cedd859316fc.jpg?1",
             "name": "Stitcher's Graft",
             "text": "Equipped creature gets +3/+3.\nWhenever equipped creature attacks, it doesn't untap during its controller's next untap step.\nWhenever Stitcher's Graft becomes unattached from a permanent, sacrifice that permanent.\nEquip {2}",
             "colours": [],
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "5cc1c6c4-9078-557e-a202-3126b5148f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fae696-0db9-4a87-8a88-b4298da01a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fae696-0db9-4a87-8a88-b4298da01a19.jpg?1",
             "name": "Terrarion",
             "text": "Terrarion enters the battlefield tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana in any combination of colors to your mana pool.\nWhen Terrarion is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "8b036fa8-f0cf-5282-a4cb-42ad3deb7da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e5303-c07a-4be0-a314-bf5739a856e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e5303-c07a-4be0-a314-bf5739a856e5.jpg?1",
             "name": "Thirsting Axe",
             "text": "Equipped creature gets +4/+0.\nAt the beginning of your end step, if equipped creature didn't deal combat damage to a creature this turn, sacrifice it.\nEquip {2}",
             "colours": [],
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "9b1c5042-f89a-5e35-956d-78d488bf25f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96093739-fedc-4d8f-a29d-0e57f571e5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96093739-fedc-4d8f-a29d-0e57f571e5a9.jpg?1",
             "name": "Geier Reach Sanitarium",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Each player draws a card, then discards a card.",
             "colours": [],
@@ -7417,7 +7417,7 @@
         },
         {
             "id": "ded0b33b-e9ad-58ee-ba5a-2529756c398a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d743ad6-6ca2-409a-9773-581cc195dbf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d743ad6-6ca2-409a-9773-581cc195dbf2.jpg?1",
             "name": "Hanweir Battlements // Hanweir, the Writhing Township",
             "text": "{T}: Add {C} to your mana pool.\n{R}, {T}: Target creature gains haste until end of turn.\n{3}{R}{R}, {T}: If you both own and control Hanweir Battlements and a creature named Hanweir Garrison, exile them, then meld them into Hanweir, the Writhing Township.",
             "colours": [],
@@ -7447,7 +7447,7 @@
         },
         {
             "id": "5ff1e68f-51a1-5a04-8795-2048167fcc59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243eb5b-905e-446f-9ee0-7557e3b31db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243eb5b-905e-446f-9ee0-7557e3b31db3.jpg?1",
             "name": "Nephalia Academy",
             "text": "If a spell or ability an opponent controls causes you to discard a card, you may reveal that card and put it on top of your library instead of putting it anywhere else.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "97d1206f-a2e2-5a25-b24b-ff685b87d47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d25bde-a303-4b06-a3e1-4ad642deae58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d25bde-a303-4b06-a3e1-4ad642deae58.jpg?1",
             "name": "Eldrazi Horror",
             "text": "",
             "colours": [],
@@ -7506,7 +7506,7 @@
         },
         {
             "id": "5a885f7d-d9d3-58fc-adb5-4be0bc6cd1f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8586f9-97e2-438d-b74f-1e53c811f314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8586f9-97e2-438d-b74f-1e53c811f314.jpg?1",
             "name": "Eldritch Moon Checklist",
             "text": "",
             "colours": [],
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "7513b439-3b1b-51a6-a771-76d22da1c16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4439a8b-ef98-428d-a274-53c660b23afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4439a8b-ef98-428d-a274-53c660b23afe.jpg?1",
             "name": "Human Wizard",
             "text": "",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "c454ff79-6729-5d5d-bcfe-81ba641dc8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f1f43a-cbdb-4d1b-a254-dadcb2469784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f1f43a-cbdb-4d1b-a254-dadcb2469784.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "45532777-f91c-50a2-9b77-5bab52dc4d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e7f8df-826e-4ba7-9c6c-8c8eb7a61de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e7f8df-826e-4ba7-9c6c-8c8eb7a61de8.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "d73c5077-732d-5a56-b229-b23d3b4124aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8710a30-8314-49ef-b995-bd05454095be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8710a30-8314-49ef-b995-bd05454095be.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "94d9bf29-b5c7-57fe-b6da-bc068103aa50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44aa879-b63b-497c-9c1b-2333950161fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44aa879-b63b-497c-9c1b-2333950161fa.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7704,7 +7704,7 @@
         },
         {
             "id": "e1b159eb-6dd2-5aac-bf20-2ba7ac9de6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd994fc-f3f0-4c81-86bd-14ca63ec229b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd994fc-f3f0-4c81-86bd-14ca63ec229b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "c5d1d542-2d37-59c3-b620-05f69d6d9e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce90c48f-74fb-4e87-9e46-7f8c3d79cbb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce90c48f-74fb-4e87-9e46-7f8c3d79cbb0.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -7772,7 +7772,7 @@
         },
         {
             "id": "e7276485-7a85-577e-bd84-5f09f2333c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1512fe7b-5e01-424e-9747-8d4840a5d22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1512fe7b-5e01-424e-9747-8d4840a5d22a.jpg?1",
             "name": "Liliana, the Last Hope Emblem",
             "text": "",
             "colours": [],
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "b36eab7b-2acf-5694-b7c5-15e565e05cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c6e29e-261a-4953-bdbe-cce8790eb5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c6e29e-261a-4953-bdbe-cce8790eb5a8.jpg?1",
             "name": "Tamiyo, Field Researcher Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/EVE.json
+++ b/Assets/Resources/Sets/EVE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "03a654ae-5f63-53dc-be7d-1e634101f44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab707e7f-8ab5-43f1-9428-6a17c1b672fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab707e7f-8ab5-43f1-9428-6a17c1b672fa.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice is put into a graveyard from play, remove target permanent from the game.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "e9326289-4e94-5a29-8422-4fb8e09535b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b10d37b-2cbc-4061-b25a-ad8ff3944ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b10d37b-2cbc-4061-b25a-ad8ff3944ad3.jpg?1",
             "name": "Ballynock Trapper",
             "text": "{T}: Tap target creature.\nWhenever you play a white spell, you may untap Ballynock Trapper.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "0f422807-8ad6-5dc0-9bf7-d08ae13fbe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c1375-9908-4fe8-960a-595b9b58cd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c1375-9908-4fe8-960a-595b9b58cd10.jpg?1",
             "name": "Cenn's Enlistment",
             "text": "Put two 1/1 white Kithkin Soldier creature tokens into play.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "a3a49712-f5da-5b9a-a8b3-1566ea539b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32385604-dcff-41e4-97a5-fcf230033a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32385604-dcff-41e4-97a5-fcf230033a87.jpg?1",
             "name": "Endless Horizons",
             "text": "When Endless Horizons comes into play, search your library for any number of Plains cards and remove them from the game. Then shuffle your library.\nAt the beginning of your upkeep, you may put a card you own removed from the game with Endless Horizons into your hand.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "f1897f1d-b02c-5871-b706-0634536ff191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7904ba-0764-4dd3-9c78-35f799e99049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7904ba-0764-4dd3-9c78-35f799e99049.jpg?1",
             "name": "Endure",
             "text": "Prevent all damage that would be dealt to you and permanents you control this turn.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "8a8b0f3b-3a37-5468-aa5a-208727d8c515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb3cb5c-8d66-4f5e-a9a9-917e6045f024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb3cb5c-8d66-4f5e-a9a9-917e6045f024.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp comes into play, remove another target permanent from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "41efc890-387c-54e1-99fc-a481adf701e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42fad4b-caeb-4aa2-9586-cb26bdec56cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42fad4b-caeb-4aa2-9586-cb26bdec56cd.jpg?1",
             "name": "Hallowed Burial",
             "text": "Put all creatures on the bottom of their owners' libraries.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "fdfaa8c0-ce80-564c-9ed3-9b8c03c16f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71547cb8-b275-4ff2-a7fa-327cb493ce04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71547cb8-b275-4ff2-a7fa-327cb493ce04.jpg?1",
             "name": "Kithkin Spellduster",
             "text": "Flying\n{1}{W}, Sacrifice Kithkin Spellduster: Destroy target enchantment.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -270,7 +270,7 @@
         },
         {
             "id": "b71ad28f-5ba9-5ab9-9a37-edf23e2736de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f9a29c-9219-424f-a703-dccffbf23cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f9a29c-9219-424f-a703-dccffbf23cdc.jpg?1",
             "name": "Kithkin Zealot",
             "text": "When Kithkin Zealot comes into play, you gain 1 life for each black and/or red permanent target opponent controls.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "a2d49a09-d695-5dc5-85e9-1d1bfd2c1f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afda091-ed14-4bc5-8896-bdb7c95a499e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afda091-ed14-4bc5-8896-bdb7c95a499e.jpg?1",
             "name": "Light from Within",
             "text": "Chroma Each creature you control gets +1/+1 for each white mana symbol in its mana cost.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "e89ecf65-0146-5814-9e31-7c29f83cf52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f9f53-0a54-4097-9bb5-8a39732c7016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f9f53-0a54-4097-9bb5-8a39732c7016.jpg?1",
             "name": "Loyal Gyrfalcon",
             "text": "Defender, flying\nWhenever you play a white spell, Loyal Gyrfalcon loses defender until end of turn.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "f622649f-9bdc-505a-9c29-6f7abf1dec8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3fd4ccb-e632-4fa0-8e36-6103806f020c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3fd4ccb-e632-4fa0-8e36-6103806f020c.jpg?1",
             "name": "Patrol Signaler",
             "text": "{1}{W}, {Q}: Put a 1/1 white Kithkin Soldier creature token into play. ({Q} is the untap symbol.)",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "0d8b2f76-b5be-57e6-bb33-7bc2ef537176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c28634-337d-458a-bcf0-b7fbf65a41da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c28634-337d-458a-bcf0-b7fbf65a41da.jpg?1",
             "name": "Recumbent Bliss",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nAt the beginning of your upkeep, you may gain 1 life.",
             "colours": [
@@ -440,7 +440,7 @@
         },
         {
             "id": "8ac4c121-c50a-56a8-83d4-13472ef51947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667cf0b6-1dd9-420a-abf8-f6a698aafea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667cf0b6-1dd9-420a-abf8-f6a698aafea7.jpg?1",
             "name": "Spirit of the Hearth",
             "text": "Flying\nYou can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "caa31c0f-7512-50f1-a3a9-70019fb98aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25991e3-4b83-4521-ab2b-c11b1fa9d0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25991e3-4b83-4521-ab2b-c11b1fa9d0bd.jpg?1",
             "name": "Springjack Shepherd",
             "text": "Chroma When Springjack Shepherd comes into play, put a 0/1 white Goat creature token into play for each white mana symbol in the mana costs of permanents you control.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "913e6bba-0434-59ae-a02d-2c247872d0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08520f97-e7f5-45fc-9423-fa6a3a507671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08520f97-e7f5-45fc-9423-fa6a3a507671.jpg?1",
             "name": "Suture Spirit",
             "text": "Flying\n{WB}{WB}{WB}: Regenerate target creature.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "860ffaf2-de0c-5903-8251-70d02578de1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371a769a-ddae-47f6-b2c2-957de5c18417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371a769a-ddae-47f6-b2c2-957de5c18417.jpg?1",
             "name": "Banishing Knack",
             "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "cfbfdd73-6d8e-5f28-882a-db43472bf87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe945308-f103-4d36-b279-98102e3de123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe945308-f103-4d36-b279-98102e3de123.jpg?1",
             "name": "Cache Raiders",
             "text": "At the beginning of your upkeep, return a permanent you control to its owner's hand.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "70eebf45-5b98-5e46-8278-ef1490f6f6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfd71ff-d899-4f5b-b7df-ec47e2840be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfd71ff-d899-4f5b-b7df-ec47e2840be9.jpg?1",
             "name": "Dream Fracture",
             "text": "Counter target spell. Its controller draws a card.\nDraw a card.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "ce6724c6-5725-565a-bfa6-4e4fade13607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811026ed-1bae-4464-bdfe-dcec76259152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811026ed-1bae-4464-bdfe-dcec76259152.jpg?1",
             "name": "Dream Thief",
             "text": "Flying\nWhen Dream Thief comes into play, draw a card if you played another blue spell this turn.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "ff7329b7-733a-533e-9c8e-78a0117ff8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829a0a1c-761f-4a7f-b59a-c889d995f446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829a0a1c-761f-4a7f-b59a-c889d995f446.jpg?1",
             "name": "Glamerdye",
             "text": "Change the text of target spell or permanent by replacing all instances of one color word with another.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "08954c3e-3497-528c-9efa-d70eb772d017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09516d3d-e6c2-4359-af2a-a4aa244ca033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09516d3d-e6c2-4359-af2a-a4aa244ca033.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "Flying\n{U}, Sacrifice Glen Elendra Archmage: Counter target noncreature spell.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "1584e48f-e820-5cc3-b976-75fdb4570f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797f80be-019d-4e44-a48d-43c6e52d2ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797f80be-019d-4e44-a48d-43c6e52d2ab5.jpg?1",
             "name": "Idle Thoughts",
             "text": "{2}: Draw a card if you have no cards in hand.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "6511fc06-1018-5539-b256-e414cc799373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e6e481-a050-4515-a557-d59ba6136ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e6e481-a050-4515-a557-d59ba6136ff6.jpg?1",
             "name": "Indigo Faerie",
             "text": "Flying\n{U}: Target permanent becomes blue in addition to its other colors until end of turn.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "6e0a832a-6741-5af2-9787-4b2a0395d03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5047c92-2885-4a7b-b51f-f3e093dca5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5047c92-2885-4a7b-b51f-f3e093dca5ad.jpg?1",
             "name": "Inundate",
             "text": "Return all nonblue creatures to their owners' hands.",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "503b9d37-6527-5a86-8145-59a577803812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b2f122-0406-44f4-82b0-9f46b52e7d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b2f122-0406-44f4-82b0-9f46b52e7d99.jpg?1",
             "name": "Merrow Levitator",
             "text": "{T}: Target creature gains flying until end of turn.\nWhenever you play a blue spell, you may untap Merrow Levitator.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "fb7edbb4-ad0a-5f27-86a9-3338e3f0b922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5404ae3f-ff19-4627-ae69-9bd2c36ab7d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5404ae3f-ff19-4627-ae69-9bd2c36ab7d3.jpg?1",
             "name": "Oona's Grace",
             "text": "Target player draws a card.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "7a46ff72-4644-5978-be44-9f5f039e87be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed978036-c473-46d8-8302-3707d222aff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed978036-c473-46d8-8302-3707d222aff5.jpg?1",
             "name": "Razorfin Abolisher",
             "text": "{1}{U}, {T}: Return target creature with a counter on it to its owner's hand.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "4286d5bd-1186-5878-a14c-5339ead8ad09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e377f-6bb7-4fa1-b58b-7e2af06ca4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e377f-6bb7-4fa1-b58b-7e2af06ca4b7.jpg?1",
             "name": "Sanity Grinding",
             "text": "Chroma Reveal the top ten cards of your library. For each blue mana symbol in the mana costs of the revealed cards, target opponent puts the top card of his or her library into his or her graveyard. Then put the cards you revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -979,7 +979,7 @@
         },
         {
             "id": "7e94e28f-be51-5a02-adf4-978d5af38f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f6256e-5d24-4fa0-a83b-5ff971f7e1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f6256e-5d24-4fa0-a83b-5ff971f7e1cc.jpg?1",
             "name": "Talonrend",
             "text": "Flying\n{UR}: Talonrend gets +1/-1 until end of turn.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "3ae72dce-629a-5059-b605-0ababaef231b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116209-636a-4b86-a8ed-d4a03e1d7212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116209-636a-4b86-a8ed-d4a03e1d7212.jpg?1",
             "name": "Wake Thrasher",
             "text": "Whenever a permanent you control becomes untapped, Wake Thrasher gets +1/+1 until end of turn.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "6849b431-06ad-56fc-8b7d-5ad9ced67322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947000d-bc0f-4f8b-a9a6-09bf29f846ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947000d-bc0f-4f8b-a9a6-09bf29f846ea.jpg?1",
             "name": "Wilderness Hypnotist",
             "text": "{T}: Target red or green creature gets -2/-0 until end of turn.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "a1281f43-e233-5a1e-a18f-bd710297ab38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/350580d8-45db-4428-a292-cc4802bf1e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/350580d8-45db-4428-a292-cc4802bf1e4d.jpg?1",
             "name": "Ashling, the Extinguisher",
             "text": "Whenever Ashling, the Extinguisher deals combat damage to a player, choose target creature that player controls. He or she sacrifices that creature.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "a569db27-40b9-5b10-8422-9db84723042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4e94d3-0df5-4d2b-a5d9-178fe1350ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4e94d3-0df5-4d2b-a5d9-178fe1350ceb.jpg?1",
             "name": "Creakwood Ghoul",
             "text": "{BG}{BG}: Remove target card in a graveyard from the game. You gain 1 life.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "cb53154a-c1b7-51de-922b-7f2634b3b9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73ac3c-bd5a-4993-be65-76396b7d38ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73ac3c-bd5a-4993-be65-76396b7d38ad.jpg?1",
             "name": "Crumbling Ashes",
             "text": "At the beginning of your upkeep, destroy target creature with a -1/-1 counter on it.",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "85aef10c-c958-5b1e-85f8-82178c900020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5165880-9727-4f52-9633-fd5cecce7f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5165880-9727-4f52-9633-fd5cecce7f01.jpg?1",
             "name": "Lingering Tormentor",
             "text": "Fear\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "7abbdd3d-3a0c-55bf-ae81-2befd15dd489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e49aa4-ac23-49b1-b9b7-49d45b56b21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e49aa4-ac23-49b1-b9b7-49d45b56b21d.jpg?1",
             "name": "Merrow Bonegnawer",
             "text": "{T}: Target player removes a card in his or her graveyard from the game.\nWhenever you play a black spell, you may untap Merrow Bonegnawer.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "a5af59c0-f169-5372-a97f-2154d7db56c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02907b62-5456-4605-a8cd-321487928761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02907b62-5456-4605-a8cd-321487928761.jpg?1",
             "name": "Necroskitter",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls with a -1/-1 counter on it is put into a graveyard, you may return that card to play under your control.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "7f694101-4bb1-5e6a-94f5-ae2492810674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21af9e72-fbaf-460a-a2eb-a09b925ebd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21af9e72-fbaf-460a-a2eb-a09b925ebd9a.jpg?1",
             "name": "Needle Specter",
             "text": "Flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever Needle Specter deals combat damage to a player, that player discards that many cards.",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "5fb2898f-3f9f-53e8-968f-e3b6fa1a29b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cccd244-9fd4-4f58-85da-af6d235ef7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cccd244-9fd4-4f58-85da-af6d235ef7bb.jpg?1",
             "name": "Nightmare Incursion",
             "text": "Search target player's library for up to X cards, where X is the number of Swamps you control, and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1358,7 +1358,7 @@
         },
         {
             "id": "e8b8e0f2-ddf2-52ff-8499-851b79ad8498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ced5797-5de0-43ca-9dc9-e48912333a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ced5797-5de0-43ca-9dc9-e48912333a70.jpg?1",
             "name": "Raven's Crime",
             "text": "Target player discards a card.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "9e7071bb-d625-57fc-89bb-b77c41d9ac25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f764936-fceb-4a3d-ac32-15397d7ce664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f764936-fceb-4a3d-ac32-15397d7ce664.jpg?1",
             "name": "Smoldering Butcher",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "8802f614-decd-542e-a829-c6ef1c7ae6fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f50d1d-5694-4701-9755-a9d1e6dfae29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f50d1d-5694-4701-9755-a9d1e6dfae29.jpg?1",
             "name": "Soot Imp",
             "text": "Flying\nWhenever a player plays a nonblack spell, that player loses 1 life.",
             "colours": [
@@ -1459,7 +1459,7 @@
         },
         {
             "id": "3f0cce21-a806-5b4a-b95f-af6a835ea396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a129e2-bed5-4ee7-b223-851452f72682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a129e2-bed5-4ee7-b223-851452f72682.jpg?1",
             "name": "Soul Reap",
             "text": "Destroy target nongreen creature. Its controller loses 3 life if you played another black spell this turn.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "eed04d7f-11a8-5910-8aa7-53f27ef76ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06194432-d208-4e3e-8384-eceba58cfd63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06194432-d208-4e3e-8384-eceba58cfd63.jpg?1",
             "name": "Soul Snuffers",
             "text": "When Soul Snuffers comes into play, put a -1/-1 counter on each creature.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "93ffa620-3396-589f-9d6f-28ed4df597fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd8bf-fd0e-4cab-903b-10c6d0dd4741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd8bf-fd0e-4cab-903b-10c6d0dd4741.jpg?1",
             "name": "Syphon Life",
             "text": "Target player loses 2 life and you gain 2 life.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "78448a28-5437-5f35-9a97-6f3afe1abef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd68e4c4-0216-4f58-a3ce-3432ab5830c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd68e4c4-0216-4f58-a3ce-3432ab5830c6.jpg?1",
             "name": "Talara's Bane",
             "text": "Target opponent reveals his or her hand. Choose a green or white creature card from it. You gain life equal that creature card's toughness, then that player discards that card.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "9b59ccc9-23df-512b-8730-3048c0fe1b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efdd70a-5a84-48a5-82bf-ba29fda097c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efdd70a-5a84-48a5-82bf-ba29fda097c0.jpg?1",
             "name": "Umbra Stalker",
             "text": "Chroma Umbra Stalker's power and toughness are each equal to the number of black mana symbols in the mana costs of cards in your graveyard.",
             "colours": [
@@ -1624,7 +1624,7 @@
         },
         {
             "id": "1b9a1019-c07e-5cbe-bf0d-fa24c43fa04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f96c71-e585-4c99-b054-e53ab12b392c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f96c71-e585-4c99-b054-e53ab12b392c.jpg?1",
             "name": "Chaotic Backlash",
             "text": "Chaotic Backlash deals damage to target player equal to twice the number of white and/or blue permanents he or she controls.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "5773770f-63ab-578d-9fd7-ed2b0261886e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6125689-0098-4e52-bed8-24840d22cdc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6125689-0098-4e52-bed8-24840d22cdc1.jpg?1",
             "name": "Cinder Pyromancer",
             "text": "{T}: Cinder Pyromancer deals 1 damage to target player.\nWhenever you play a red spell, you may untap Cinder Pyromancer.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "dc37cb19-3a21-54c9-be10-996bcd3c5c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48fda3d-5e6f-4f32-8fca-030521f6df98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48fda3d-5e6f-4f32-8fca-030521f6df98.jpg?1",
             "name": "Duergar Cave-Guard",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{GU}: Duergar Cave-Guard gets +1/+0 until end of turn.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "d550bdcc-5ba7-5e24-a414-6630688dfb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c348d137-4774-41d7-8b4d-d383c816ae2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c348d137-4774-41d7-8b4d-d383c816ae2a.jpg?1",
             "name": "Fiery Bombardment",
             "text": "Chroma {2}, Sacrifice a creature: Fiery Bombardment deals damage to target creature or player equal to the number of red mana symbols in the sacrificed creature's mana cost.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "3fdb2c28-d478-54c2-9dda-1e8d1255ab2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c2b6b2-485e-41e6-b106-4f6f402e0ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c2b6b2-485e-41e6-b106-4f6f402e0ec3.jpg?1",
             "name": "Flame Jab",
             "text": "Flame Jab deals 1 damage to target creature or player.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "ebbe23c7-9f7e-54f3-b5cb-d39090c53073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d99d1c2-3c24-47b6-97eb-ae1d8726948e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d99d1c2-3c24-47b6-97eb-ae1d8726948e.jpg?1",
             "name": "Hatchet Bully",
             "text": "{2}{R}, {T}, Put a -1/-1 counter on a creature you control: Hatchet Bully deals 2 damage to target creature or player.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "570bf66f-237a-5487-bd0e-cc8c3c12f034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c26ba3-e325-433b-b653-4e80e737b54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c26ba3-e325-433b-b653-4e80e737b54d.jpg?1",
             "name": "Hateflayer",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{2}{R}, {Q}: Hateflayer deals damage equal to its power to target creature or player. ({Q} is the untap symbol.)",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "c8db8cff-7d91-5923-a9e6-eed05274b3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c38e02-5df3-4655-a18f-a7be2c352b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c38e02-5df3-4655-a18f-a7be2c352b7b.jpg?1",
             "name": "Heartlash Cinder",
             "text": "Haste\nChroma When Heartlash Cinder comes into play, it gets +X/+0 until end of turn, where X is the number of red mana symbols in the mana costs of permanents you control.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "8ffff4ce-2405-539d-93ad-56fcae334877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74481546-debc-44df-b5a9-7fde0ada0eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74481546-debc-44df-b5a9-7fde0ada0eca.jpg?1",
             "name": "Hotheaded Giant",
             "text": "Haste\nHotheaded Giant comes into play with two -1/-1 counters on it unless you played another red spell this turn.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "d0e77185-47bd-563f-bb36-1af9951288fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b768940-409a-4876-809f-ef311002b944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b768940-409a-4876-809f-ef311002b944.jpg?1",
             "name": "Impelled Giant",
             "text": "Trample\nTap an untapped red creature you control other than Impelled Giant: Impelled Giant gets +X/+0 until end of turn, where X is the power of the creature tapped this way.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "eca6a98e-fb78-5c2a-929a-eabab03bc4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf2b2fb-d521-42ea-a6de-f80054b8a4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf2b2fb-d521-42ea-a6de-f80054b8a4a6.jpg?1",
             "name": "Outrage Shaman",
             "text": "Chroma When Outrage Shaman comes into play, it deals damage to target creature equal to the number of red mana symbols in the mana costs of permanents you control.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "797378c6-2b54-558a-8be7-3964d2802f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf90b4d-98cf-4953-b6ae-c41d21ab559b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf90b4d-98cf-4953-b6ae-c41d21ab559b.jpg?1",
             "name": "Puncture Blast",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nPuncture Blast deals 3 damage to target creature or player.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "de550665-a4f2-57bb-96ea-9a3f596225e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131c6377-4ed4-4a76-a9cb-be7ad17d76fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131c6377-4ed4-4a76-a9cb-be7ad17d76fd.jpg?1",
             "name": "Rekindled Flame",
             "text": "Rekindled Flame deals 4 damage to target creature or player.\nAt the beginning of your upkeep, if an opponent has no cards in hand, you may return Rekindled Flame from your graveyard to your hand.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "07ffc7ed-3029-5a45-b76d-ed3b890b684a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5d1fd4-0543-46ce-bcea-1695fc04e85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5d1fd4-0543-46ce-bcea-1695fc04e85b.jpg?1",
             "name": "Stigma Lasher",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever Stigma Lasher deals damage to a player, that player can't gain life for the rest of the game.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "73ffcf75-7d76-5fde-bb36-378fed606c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5872624-7994-468c-9e16-4a771a0dbcfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5872624-7994-468c-9e16-4a771a0dbcfa.jpg?1",
             "name": "Thunderblust",
             "text": "Haste\nThunderblust has trample as long as it has a -1/-1 counter on it.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "a26b2da0-1b6c-5795-9414-841a30866834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cdd83c-50e2-4c04-a4fe-1fe2f545c7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cdd83c-50e2-4c04-a4fe-1fe2f545c7a2.jpg?1",
             "name": "Unwilling Recruit",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gets +X/+0 and gains haste until end of turn.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "7f9ffc76-4dc2-5468-a193-1d1d79f1c1d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4cb09-c99f-4a17-a6fd-55c9a169a808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4cb09-c99f-4a17-a6fd-55c9a169a808.jpg?1",
             "name": "Aerie Ouphes",
             "text": "Sacrifice Aerie Ouphes: Aerie Ouphes deals damage equal to its power to target creature with flying.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "3d13cead-3261-57f9-b3f8-bed61147e5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cc2828-dfe7-410b-9735-10bb7211f0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cc2828-dfe7-410b-9735-10bb7211f0f5.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color to your mana pool.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "089ea162-a3b9-53a7-98e9-212ae916cec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d10736d-047b-423f-9017-f59732d446bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d10736d-047b-423f-9017-f59732d446bf.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "a93b25e4-9353-535c-9211-f4404c2fa8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1121df-b03e-4ad9-8c45-c3b4066e4a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1121df-b03e-4ad9-8c45-c3b4066e4a39.jpg?1",
             "name": "Helix Pinnacle",
             "text": "Shroud\n{X}: Put X tower counters on Helix Pinnacle.\nAt the beginning of your upkeep, if there are 100 or more tower counters on Helix Pinnacle, you win the game.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "26c4f971-9a40-5e93-a96a-dd5c3adcc6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1fbb7-aa02-4f56-8be7-88a3ba55f7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1fbb7-aa02-4f56-8be7-88a3ba55f7d2.jpg?1",
             "name": "Marshdrinker Giant",
             "text": "When Marshdrinker Giant comes into play, destroy target Island or Swamp an opponent controls.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "a5aa4436-34d1-5149-9075-9e8bff7d6f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585b52bc-aff5-4406-b55b-1b7decfd80f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585b52bc-aff5-4406-b55b-1b7decfd80f9.jpg?1",
             "name": "Monstrify",
             "text": "Target creature gets +4/+4 until end of turn.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "af7a10d6-69ed-5916-bcf8-4ee9181d7d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f21681-fd36-4106-8395-3153599a08a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f21681-fd36-4106-8395-3153599a08a6.jpg?1",
             "name": "Nettle Sentinel",
             "text": "Nettle Sentinel doesn't untap during its controller's untap step.\nWhenever you play a green spell, you may untap Nettle Sentinel.",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "b5c3a165-5e87-50ba-bbd5-e2c2db38f0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8316eb28-9e58-4194-a0c6-cad32bddc391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8316eb28-9e58-4194-a0c6-cad32bddc391.jpg?1",
             "name": "Phosphorescent Feast",
             "text": "Chroma Reveal any number of cards in your hand. You gain 2 life for each green mana symbol in those cards' mana costs.",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "7b43cb71-97f3-5c06-9f58-050285bb104b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f805f7b-bb7e-436b-abd3-20a35e7ef71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f805f7b-bb7e-436b-abd3-20a35e7ef71e.jpg?1",
             "name": "Primalcrux",
             "text": "Trample\nChroma Primalcrux's power and toughness are each equal to the number of green mana symbols in the mana costs of permanents you control.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "fcc54344-e5c5-53aa-a971-71119eeadcdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674a694a-22b8-4fb8-b901-91d64564c0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674a694a-22b8-4fb8-b901-91d64564c0db.jpg?1",
             "name": "Regal Force",
             "text": "When Regal Force comes into play, draw a card for each green creature you control.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "ff26a131-cae7-5742-ad86-cdfbf13140d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88ab58b-918b-478a-8c6b-a213e2bc87ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88ab58b-918b-478a-8c6b-a213e2bc87ab.jpg?1",
             "name": "Savage Conception",
             "text": "Put a 3/3 green Beast creature token into play.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "8a8ca92e-533a-56d7-a1e4-9960f23ccf45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d057c-c51c-46bb-b8fe-aabe7f3b07b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d057c-c51c-46bb-b8fe-aabe7f3b07b6.jpg?1",
             "name": "Swirling Spriggan",
             "text": "{GW}{GW}: Target creature you control becomes the color or colors of your choice until end of turn.",
             "colours": [
@@ -2570,7 +2570,7 @@
         },
         {
             "id": "03a2eef2-959c-5e10-9672-76317538e20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d00ea9-1111-47c3-9722-4c68ce3e4d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d00ea9-1111-47c3-9722-4c68ce3e4d56.jpg?1",
             "name": "Talara's Battalion",
             "text": "Trample\nPlay Talara's Battalion only if you played another green spell this turn.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "d37d518f-acdf-5e8a-af1f-8b43124d192b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a10d0-214d-4e7b-9683-c84034f8f6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a10d0-214d-4e7b-9683-c84034f8f6b7.jpg?1",
             "name": "Tilling Treefolk",
             "text": "When Tilling Treefolk comes into play, you may return up to two target land cards from your graveyard to your hand.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "a4da26e1-a546-5d54-84fb-d2407ace0542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0092d7a0-bd00-45e5-a052-c0a9d970bc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0092d7a0-bd00-45e5-a052-c0a9d970bc2e.jpg?1",
             "name": "Twinblade Slasher",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{1}{G}: Twinblade Slasher gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "9a7ee7b0-f244-5341-91a1-efe45e2cb2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc283b4-9106-4a32-88b4-000f2a3bed84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc283b4-9106-4a32-88b4-000f2a3bed84.jpg?1",
             "name": "Wickerbough Elder",
             "text": "Wickerbough Elder comes into play with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from Wickerbough Elder: Destroy target artifact or enchantment.",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "73ac6df6-0138-5f7c-ab0c-a177b5d24947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165960f2-b26a-4204-8234-9c00a98a8b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165960f2-b26a-4204-8234-9c00a98a8b34.jpg?1",
             "name": "Batwing Brume",
             "text": "Prevent all combat damage that would be dealt this turn if {W} was spent to play Batwing Brume. Each player loses 1 life for each attacking creature he or she controls if {B} was spent to play Batwing Brume. (Do both if {W}{B} was spent.)",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "7db601e3-b2c1-5f71-be25-31d671a67d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bae1a3b-881b-4b10-ac5f-822c809edc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bae1a3b-881b-4b10-ac5f-822c809edc36.jpg?1",
             "name": "Beckon Apparition",
             "text": "Remove target card in a graveyard from the game. Put a 1/1 white and black Spirit creature token with flying into play.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "3978f775-ccb9-50ee-838d-555303e7622d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68b6fc7-e565-4f7d-8efb-c4d29e41c689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68b6fc7-e565-4f7d-8efb-c4d29e41c689.jpg?1",
             "name": "Bloodied Ghost",
             "text": "Flying\nBloodied Ghost comes into play with a -1/-1 counter on it.",
             "colours": [
@@ -2814,7 +2814,7 @@
         },
         {
             "id": "53b0d15c-92cb-5678-8c94-0c5e12b98206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d0def7-42dd-46f4-8499-d79876783a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d0def7-42dd-46f4-8499-d79876783a39.jpg?1",
             "name": "Cauldron Haze",
             "text": "Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it's put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "e34ec215-3a1c-5efd-aee6-72c27eafbce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8157e1-72ae-47ea-84ce-fb0b154215aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8157e1-72ae-47ea-84ce-fb0b154215aa.jpg?1",
             "name": "Deathbringer Liege",
             "text": "Other white creatures you control get +1/+1.\nOther black creatures you control get +1/+1.\nWhenever you play a white spell, you may tap target creature.\nWhenever you play a black spell, you may destroy target creature if it's tapped.",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "02ea1702-5b8d-5914-9f58-ac73d7848f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb71651-7ede-4348-89a4-b441da72491b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb71651-7ede-4348-89a4-b441da72491b.jpg?1",
             "name": "Divinity of Pride",
             "text": "Flying, lifelink\nDivinity of Pride gets +4/+4 as long as you have 25 or more life.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "d927fab3-aa40-5b00-96be-fc6838d52ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd079d8-b191-4f54-bb04-427b3736f745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd079d8-b191-4f54-bb04-427b3736f745.jpg?1",
             "name": "Edge of the Divinity",
             "text": "Enchant creature\nAs long as enchanted creature is white, it gets +1/+2.\nAs long as enchanted creature is black, it gets +2/+1.",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "83f84198-c564-5329-9b7a-a4c6eb2a5980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499d1789-f7b0-47a1-962e-4c75b23befd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499d1789-f7b0-47a1-962e-4c75b23befd5.jpg?1",
             "name": "Evershrike",
             "text": "Flying\nEvershrike gets +2/+2 for each Aura attached to it.\n{X}{WB}{WB}: Return Evershrike from your graveyard to play. You may put an Aura card with converted mana cost X or less from your hand into play attached to it. If you don't, remove Evershrike from the game.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "236ba113-7381-5edd-a3f3-4013b3c01f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914e6fda-808f-43fb-8024-8b8a8781a7ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914e6fda-808f-43fb-8024-8b8a8781a7ac.jpg?1",
             "name": "Gwyllion Hedge-Mage",
             "text": "When Gwyllion Hedge-Mage comes into play, if you control two or more Plains, you may put a 1/1 white Kithkin Soldier creature token into play.\nWhen Gwyllion Hedge-Mage comes into play, if you control two or more Swamps, you may put a -1/-1 counter on target creature.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "049c80a9-db73-514f-9d76-79fcc535bf99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0491d1-343d-453e-aa52-a3d3daa1478e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0491d1-343d-453e-aa52-a3d3daa1478e.jpg?1",
             "name": "Harvest Gwyllion",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -3067,7 +3067,7 @@
         },
         {
             "id": "ea3ad998-6f53-5ccb-a0fb-772386d7b05c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dbda67-3bc4-4c8a-8357-250d84d0d1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dbda67-3bc4-4c8a-8357-250d84d0d1d8.jpg?1",
             "name": "Nightsky Mimic",
             "text": "Whenever you play a spell that's both white and black, Nightsky Mimic becomes 4/4 and gains flying until end of turn.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "e289d529-beda-5853-96bb-56ddcf570c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ad92d-8803-4569-98c8-4a7416799cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ad92d-8803-4569-98c8-4a7416799cfc.jpg?1",
             "name": "Nip Gwyllion",
             "text": "Lifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "33076fc0-c2f6-5ec1-a7cd-053a84ec94c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae92d23-2028-450c-9598-6932a71f8c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae92d23-2028-450c-9598-6932a71f8c32.jpg?1",
             "name": "Pyrrhic Revival",
             "text": "Each player returns each creature card in his or her graveyard to play with a -1/-1 counter on it.",
             "colours": [
@@ -3173,7 +3173,7 @@
         },
         {
             "id": "ae642db9-03ff-511c-a338-f301afb08994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6480d0-17c5-4ac2-afb2-4d44f089de22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6480d0-17c5-4ac2-afb2-4d44f089de22.jpg?1",
             "name": "Restless Apparition",
             "text": "{WB}{WB}{WB}: Restless Apparition gets +3/+3 until end of turn.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "919555eb-c02a-5424-a524-1d26795193fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400dc91e-96c0-49bf-b307-677d6f80f3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400dc91e-96c0-49bf-b307-677d6f80f3ed.jpg?1",
             "name": "Stillmoon Cavalier",
             "text": "Protection from white and from black\n{WB}: Stillmoon Cavalier gains flying until end of turn.\n{WB}: Stillmoon Cavalier gains first strike until end of turn.\n{WB}{WB}: Stillmoon Cavalier gets +1/+0 until end of turn.",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "53a72db0-0b43-5b0d-9418-a2fe48c4a1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338f7852-9f69-4406-b6ad-93a2574296f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338f7852-9f69-4406-b6ad-93a2574296f7.jpg?1",
             "name": "Unmake",
             "text": "Remove target creature from the game.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "455c6f9c-9b3d-590c-abb6-051ab7954f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66b1a84-ab15-48d8-909c-08116dc71c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66b1a84-ab15-48d8-909c-08116dc71c76.jpg?1",
             "name": "Voracious Hatchling",
             "text": "Lifelink\nVoracious Hatchling comes into play with four -1/-1 counters on it.\nWhenever you play a white spell, remove a -1/-1 counter from Voracious Hatchling.\nWhenever you play a black spell, remove a -1/-1 counter from Voracious Hatchling.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "8fe1a16a-ab5c-5737-a434-6632390e8d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751db106-e9bc-4f16-97c6-f624eb1aa809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751db106-e9bc-4f16-97c6-f624eb1aa809.jpg?1",
             "name": "Call the Skybreaker",
             "text": "Put a 5/5 blue and red Elemental creature token with flying into play.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "1a88fa8c-b551-535c-ab50-ba9204bd84dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ce6d6-014f-46c2-baf3-f250e9dc3085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ce6d6-014f-46c2-baf3-f250e9dc3085.jpg?1",
             "name": "Clout of the Dominus",
             "text": "Enchant creature\nAs long as enchanted creature is blue, it gets +1/+1 and has shroud. (It can't be the target of spells or abilities.)\nAs long as enchanted creature is red, it gets +1/+1 and has haste.",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "dc162a3b-8625-5d0e-9cbf-a3df76e8677d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be19f23-5db4-4d50-a9d7-622e247ff0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be19f23-5db4-4d50-a9d7-622e247ff0ab.jpg?1",
             "name": "Crackleburr",
             "text": "{UR}{UR}, {T}, Tap two untapped red creatures you control: Crackleburr deals 3 damage to target creature or player.\n{UR}{UR}, {Q}, Untap two tapped blue creatures you control: Return target creature to its owner's hand. ({Q} is the untap symbol.)",
             "colours": [
@@ -3422,7 +3422,7 @@
         },
         {
             "id": "50ed9364-38ab-58ec-817d-1e16099cf911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c11707-1ded-4891-82b4-9827a7dfc489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c11707-1ded-4891-82b4-9827a7dfc489.jpg?1",
             "name": "Crag Puca",
             "text": "{UR}: Switch Crag Puca's power and toughness until end of turn.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "bf1256e3-9a98-54a1-a3a6-580576157387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff447e1-bbcc-4ada-87c0-04b6b144c2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff447e1-bbcc-4ada-87c0-04b6b144c2cd.jpg?1",
             "name": "Dominus of Fealty",
             "text": "Flying\nAt the beginning of your upkeep, you may gain control of target permanent until end of turn. If you do, untap it and it gains haste until end of turn.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "fa8333fc-ac7f-5bb0-9551-ad95434ddd81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51180ee-8677-4d5a-9685-3861c67a1d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51180ee-8677-4d5a-9685-3861c67a1d1f.jpg?1",
             "name": "Inside Out",
             "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "2d7965a6-b809-555b-b2c9-405356413584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b412a60-b49e-42ea-9547-03e4ef44ffea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b412a60-b49e-42ea-9547-03e4ef44ffea.jpg?1",
             "name": "Mindwrack Liege",
             "text": "Other blue creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\n{UR}{UR}{UR}{UR}: You may put a blue or red creature card from your hand into play.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "dbf1fc75-c757-5e18-81bb-64452c56415b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26b31ce-416f-4309-b591-798cf12175af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26b31ce-416f-4309-b591-798cf12175af.jpg?1",
             "name": "Mirror Sheen",
             "text": "{1}{UR}{UR}: Copy target instant or sorcery spell that targets you. You may choose new targets for the copy.",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "23ff7e34-5d90-5c61-8055-55271de0d6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552c9c66-8023-41ef-8d4f-3b0dc30743f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552c9c66-8023-41ef-8d4f-3b0dc30743f3.jpg?1",
             "name": "Noggle Bandit",
             "text": "Noggle Bandit can't be blocked except by creatures with defender.",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "0e3b9e3b-fd13-56e4-a72c-a49d7a732753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545a52ed-b4d4-4972-940d-9daf07a488b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545a52ed-b4d4-4972-940d-9daf07a488b1.jpg?1",
             "name": "Noggle Bridgebreaker",
             "text": "When Noggle Bridgebreaker comes into play, return a land you control to its owner's hand.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "a90c24e6-ed83-52a1-81db-2afeda06d24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497e1713-dd2d-4f25-8c8c-0c515eec7040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497e1713-dd2d-4f25-8c8c-0c515eec7040.jpg?1",
             "name": "Noggle Hedge-Mage",
             "text": "When Noggle Hedge-Mage comes into play, if you control two or more Islands, you may tap two target permanents.\nWhen Noggle Hedge-Mage comes into play, if you control two or more Mountains, you may have Noggle Hedge-Mage deal 2 damage to target player.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "7ed5b61f-02ed-5d6b-9f72-b3a12020ed9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dbe4e2-77f3-4764-b9fb-b555a1228bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dbe4e2-77f3-4764-b9fb-b555a1228bf3.jpg?1",
             "name": "Noggle Ransacker",
             "text": "When Noggle Ransacker comes into play, each player draws two cards, then discards a card at random.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "03cbb600-af0d-5b44-8f99-1582fcd2ae32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f54b0a-b0e1-44f1-bb91-523cc9e1c298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f54b0a-b0e1-44f1-bb91-523cc9e1c298.jpg?1",
             "name": "Nucklavee",
             "text": "When Nucklavee comes into play, you may return target red sorcery card from your graveyard to your hand.\nWhen Nucklavee comes into play, you may return target blue instant card from your graveyard to your hand.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "7427aa05-545a-549a-8970-c91685109622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ed3ce-d7f7-4275-baef-edc5127475d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ed3ce-d7f7-4275-baef-edc5127475d7.jpg?1",
             "name": "Riverfall Mimic",
             "text": "Whenever you play a spell that's both blue and red, Riverfall Mimic becomes 3/3 and is unblockable until end of turn.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "731b23bd-14c4-5644-bcb5-46edd5243f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0148ef2-d825-4425-b767-c74b406880fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0148ef2-d825-4425-b767-c74b406880fd.jpg?1",
             "name": "Shrewd Hatchling",
             "text": "Shrewd Hatchling comes into play with four -1/-1 counters on it.\n{UR}: Target creature can't block Shrewd Hatchling this turn.\nWhenever you play a blue spell, remove a -1/-1 counter from Shrewd Hatchling.\nWhenever you play a red spell, remove a -1/-1 counter from Shrewd Hatchling.",
             "colours": [
@@ -3855,7 +3855,7 @@
         },
         {
             "id": "10dcf077-b25b-57b8-8322-6ae92d7e17ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55371d0e-29da-4517-ab16-075782a1326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55371d0e-29da-4517-ab16-075782a1326f.jpg?1",
             "name": "Stream Hopper",
             "text": "{UR}: Stream Hopper gains flying until end of turn.",
             "colours": [
@@ -3891,7 +3891,7 @@
         },
         {
             "id": "86e2b69f-5826-5eca-a541-daced00def07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eccfd-19d0-48cc-8b27-9027e4911fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eccfd-19d0-48cc-8b27-9027e4911fee.jpg?1",
             "name": "Unnerving Assault",
             "text": "Creatures your opponents control get -1/-0 until end of turn if {U} was spent to play Unnerving Assault, and creatures you control get +1/+0 until end of turn if {R} was spent to play it. (Do both if {U}{R} was spent.)",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "970d954f-3139-5711-89e1-257640183095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fac2e0-b65e-4b84-9d7e-2a9b2ddfe970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fac2e0-b65e-4b84-9d7e-2a9b2ddfe970.jpg?1",
             "name": "Canker Abomination",
             "text": "As Canker Abomination comes into play, choose an opponent. Canker Abomination comes into play with a -1/-1 counter on it for each creature that player controls.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "d5a07ee2-8ffb-5487-85eb-23beb882515a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45840408-33e7-43fa-96ab-d3bd53e3fd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45840408-33e7-43fa-96ab-d3bd53e3fd6b.jpg?1",
             "name": "Cankerous Thirst",
             "text": "If {B} was spent to play Cankerous Thirst, you may have target creature get -3/-3 until end of turn. If {G} was spent to play Cankerous Thirst, you may have target creature get +3/+3 until end of turn. (Do both if {B}{G} was spent.)",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "d8f12878-6c9d-5d42-ad0a-38edb4c4b219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906ddeb6-4021-4e16-b0b9-dfe087673944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906ddeb6-4021-4e16-b0b9-dfe087673944.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may put a 1/1 black and green Worm creature token into play.",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "eae1e3b2-d14d-505c-9559-bf096f0cb9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efc2cc8-2445-4d64-b1c5-26483efbcc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efc2cc8-2445-4d64-b1c5-26483efbcc30.jpg?1",
             "name": "Deity of Scars",
             "text": "Trample\nDeity of Scars comes into play with two -1/-1 counters on it.\n{BG}, Remove a -1/-1 counter from Deity of Scars: Regenerate Deity of Scars.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "0c9dbe65-ff51-5726-847e-30f691af7f91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d2e092-c805-447c-b784-1896b69524e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d2e092-c805-447c-b784-1896b69524e0.jpg?1",
             "name": "Desecrator Hag",
             "text": "When Desecrator Hag comes into play, return to your hand the creature card in your graveyard with the highest power. If two or more cards are tied for highest power, you choose one of them.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "25a921ed-3db6-538e-894f-9d4fe41c6a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173fd1c6-ffd9-424f-ad65-90b193edbe00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173fd1c6-ffd9-424f-ad65-90b193edbe00.jpg?1",
             "name": "Doomgape",
             "text": "Trample\nAt the beginning of your upkeep, sacrifice a creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -4141,7 +4141,7 @@
         },
         {
             "id": "6cdaa356-055b-5cf8-ad52-fab72255015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebd1f5-55ee-48c9-a8df-85c8c4bf3473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebd1f5-55ee-48c9-a8df-85c8c4bf3473.jpg?1",
             "name": "Drain the Well",
             "text": "Destroy target land. You gain 2 life.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "1c2e3483-b7aa-58b3-897a-c99567dc74c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2dba5c-2f00-4a44-9093-3b845a8bf552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2dba5c-2f00-4a44-9093-3b845a8bf552.jpg?1",
             "name": "Gift of the Deity",
             "text": "Enchant creature\nAs long as enchanted creature is black, it gets +1/+1 and has deathtouch. (Whenever it deals damage to a creature, destroy that creature.)\nAs long as enchanted creature is green, it gets +1/+1 and all creatures able to block it do so.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "06cc030b-9ce9-5c21-a449-6b2b317b6c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d461d67-8554-4b55-8f01-909a54d23117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d461d67-8554-4b55-8f01-909a54d23117.jpg?1",
             "name": "Hag Hedge-Mage",
             "text": "When Hag Hedge-Mage comes into play, if you control two or more Swamps, you may have target player discard a card.\nWhen Hag Hedge-Mage comes into play, if you control two or more Forests, you may put target card in your graveyard on top of your library.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "3f1cf1dc-2f0a-5e7a-bede-f5e51c78decf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898fd93f-05f2-4523-a3f5-18b48a7365a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898fd93f-05f2-4523-a3f5-18b48a7365a2.jpg?1",
             "name": "Noxious Hatchling",
             "text": "Noxious Hatchling comes into play with four -1/-1 counters on it.\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever you play a black spell, remove a -1/-1 counter from Noxious Hatchling.\nWhenever you play a green spell, remove a -1/-1 counter from Noxious Hatchling.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "09525df4-cc1f-5a7d-95aa-c890f34f44e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2e0c36-645a-46c8-bd9e-4b8b591dfb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2e0c36-645a-46c8-bd9e-4b8b591dfb58.jpg?1",
             "name": "Odious Trow",
             "text": "{1}{BG}: Regenerate Odious Trow.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "873a1a6b-c824-5f5c-9f8e-a503eeded360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb4054-d5d6-4015-ae86-6f99280afe0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb4054-d5d6-4015-ae86-6f99280afe0a.jpg?1",
             "name": "Quillspike",
             "text": "{BG}, Remove a -1/-1 counter from a creature you control: Quillspike gets +3/+3 until end of turn.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "7f440a9b-1810-5401-85d3-3e304ae17c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc293a4b-abd6-47b6-99d1-578bc22580de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc293a4b-abd6-47b6-99d1-578bc22580de.jpg?1",
             "name": "Rendclaw Trow",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "81386b8c-77da-516b-b18a-093e0adb50fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c373d-9733-425b-8ff5-2862a96f5188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c373d-9733-425b-8ff5-2862a96f5188.jpg?1",
             "name": "Sapling of Colfenor",
             "text": "Sapling of Colfenor is indestructible.\nWhenever Sapling of Colfenor attacks, reveal the top card of your library. If it's a creature card, you gain life equal to that card's toughness, lose life equal to its power, then put it into your hand.",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "20c0419d-6f7f-518b-93dd-ba6c4dccbdaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0eed33-553a-4865-9b22-30c33fbd1c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0eed33-553a-4865-9b22-30c33fbd1c51.jpg?1",
             "name": "Stalker Hag",
             "text": "Swampwalk, forestwalk",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "f969330a-62cf-5610-83fc-59f9012cf0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86dd5a9-4793-4ca2-b94d-4333781b1468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86dd5a9-4793-4ca2-b94d-4333781b1468.jpg?1",
             "name": "Woodlurker Mimic",
             "text": "Whenever you play a spell that's both black and green, Woodlurker Mimic becomes 4/5 and gains wither until end of turn. (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "44e371cf-3eb3-525a-a2d2-b68f31116aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f48156-a7db-4d96-981e-a288cfaa67e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f48156-a7db-4d96-981e-a288cfaa67e7.jpg?1",
             "name": "Worm Harvest",
             "text": "Put a 1/1 black and green Worm creature token into play for each land card in your graveyard.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "c713ccd6-8f61-515d-950e-c23db21ac5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d302fbd-d43c-47ff-920d-559c5a9028ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d302fbd-d43c-47ff-920d-559c5a9028ee.jpg?1",
             "name": "Balefire Liege",
             "text": "Other red creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nWhenever you play a red spell, Balefire Liege deals 3 damage to target player.\nWhenever you play a white spell, you gain 3 life.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "b4bdde27-7fd8-5305-b71a-553b48a2ed15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a0bc8-d736-45e6-ac20-63c5ca69a8d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a0bc8-d736-45e6-ac20-63c5ca69a8d5.jpg?1",
             "name": "Battlegate Mimic",
             "text": "Whenever you play a spell that's both red and white, Battlegate Mimic becomes 4/2 and gains first strike until end of turn.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "290609e9-0057-5c2b-bb64-c113496f60a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cdf36c-d8a2-4629-8f2a-d4ac86ac9320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cdf36c-d8a2-4629-8f2a-d4ac86ac9320.jpg?1",
             "name": "Belligerent Hatchling",
             "text": "First strike\nBelligerent Hatchling comes into play with four -1/-1 counters on it.\nWhenever you play a red spell, remove a -1/-1 counter from Belligerent Hatchling.\nWhenever you play a white spell, remove a -1/-1 counter from Belligerent Hatchling.",
             "colours": [
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "300bb6f4-8100-51a8-8430-6d7a3d2a345e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ac70a-6484-4b1f-8948-4646a380ed20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ac70a-6484-4b1f-8948-4646a380ed20.jpg?1",
             "name": "Double Cleave",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "3cdf3142-ab49-5234-8873-e08b337d7b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6555cbb-97fc-4258-9b11-096c3eaec833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6555cbb-97fc-4258-9b11-096c3eaec833.jpg?1",
             "name": "Duergar Assailant",
             "text": "Sacrifice Duergar Assailant: Duergar Assailant deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "fc97e711-4dc9-51a7-9830-ed5dad2b0887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d45e026-58fc-4a0c-9099-6849e5a8fa67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d45e026-58fc-4a0c-9099-6849e5a8fa67.jpg?1",
             "name": "Duergar Hedge-Mage",
             "text": "When Duergar Hedge-Mage comes into play, if you control two or more Mountains, you may destroy target artifact.\nWhen Duergar Hedge-Mage comes into play, if you control two or more Plains, you may destroy target enchantment.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "d55259b7-19b1-5cde-ad49-9098a8d78779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97983b9-6c93-41ce-8deb-ac08811a0834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97983b9-6c93-41ce-8deb-ac08811a0834.jpg?1",
             "name": "Duergar Mine-Captain",
             "text": "{1}{GU}, {Q}: Attacking creatures get +1/+0 until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "6283ee8c-c13e-504d-9a55-ef5bce05fa83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da69523-cece-425a-b08a-fb27fac29374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da69523-cece-425a-b08a-fb27fac29374.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a 2/2 Kithkin Spirit.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a 4/4 Kithkin Spirit Warrior.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike.",
             "colours": [
@@ -4827,7 +4827,7 @@
         },
         {
             "id": "d05af934-4cd9-5383-9dd4-f817a5a288b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53617fbc-a6e9-4f06-8c4b-4699325cdcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53617fbc-a6e9-4f06-8c4b-4699325cdcac.jpg?1",
             "name": "Fire at Will",
             "text": "Fire at Will deals 3 damage divided as you choose among any number of target attacking or blocking creatures.",
             "colours": [
@@ -4861,7 +4861,7 @@
         },
         {
             "id": "5c0f3bbc-a417-51da-9674-82e753335a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc104-7189-480c-bfe1-c5da07df48f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc104-7189-480c-bfe1-c5da07df48f4.jpg?1",
             "name": "Hearthfire Hobgoblin",
             "text": "Double strike",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "efbc1025-9316-53ce-9e21-6e4b84174748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090223a1-2644-4b81-a9f5-d15ca6df5229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090223a1-2644-4b81-a9f5-d15ca6df5229.jpg?1",
             "name": "Hobgoblin Dragoon",
             "text": "Flying, first strike",
             "colours": [
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "e80731e8-f02c-5a09-8558-353f8423c9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72245a8-6f5e-4564-804f-30407c1c4e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72245a8-6f5e-4564-804f-30407c1c4e57.jpg?1",
             "name": "Moonhold",
             "text": "Target player can't play land cards this turn if {R} was spent to play Moonhold and can't play creature cards this turn if {W} was spent to play it. (Do both if {R}{W} was spent.)",
             "colours": [
@@ -4969,7 +4969,7 @@
         },
         {
             "id": "6c24e909-3658-5791-85b0-bde025dd74ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d54ab6e-dd56-40fe-abab-a1e67b024744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d54ab6e-dd56-40fe-abab-a1e67b024744.jpg?1",
             "name": "Nobilis of War",
             "text": "Flying\nAttacking creatures you control get +2/+0.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "a7c05056-ff39-5cc8-ab92-2fe57cd1f2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d47d-0c5c-4932-aaf1-df21b8b8daeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d47d-0c5c-4932-aaf1-df21b8b8daeb.jpg?1",
             "name": "Rise of the Hobgoblins",
             "text": "When Rise of the Hobgoblins comes into play, you may pay {X}. If you do, put X 1/1 red and white Goblin Soldier creature tokens into play.\n{GU}: Red creatures and white creatures you control gain first strike until end of turn.",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "50858b80-3105-5ed0-b5f6-284d6e06114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adccc97-3774-4c57-aa78-dcb9fbbe9324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adccc97-3774-4c57-aa78-dcb9fbbe9324.jpg?1",
             "name": "Scourge of the Nobilis",
             "text": "Enchant creature\nAs long as enchanted creature is red, it gets +1/+1 and has \"{GU}: This creature gets +1/+0 until end of turn.\"\nAs long as enchanted creature is white, it gets +1/+1 and has lifelink. (Whenever it deals damage, its controller gains that much life.)",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "6ab82d81-c24a-59a8-9b3f-e2b77d1fa260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefeb0e2-ddd4-4881-bca4-6c7699c82d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefeb0e2-ddd4-4881-bca4-6c7699c82d79.jpg?1",
             "name": "Spitemare",
             "text": "Whenever Spitemare is dealt damage, it deals that much damage to target creature or player.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "fb6b216a-e05a-5558-953e-760fe475fbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d52ba7-ffb3-4c24-85d8-8635ef1880d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d52ba7-ffb3-4c24-85d8-8635ef1880d9.jpg?1",
             "name": "Waves of Aggression",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "c3d82ac5-9fd1-5f72-b064-486459ba8365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b266c6-20f9-46ae-990d-0017144971e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b266c6-20f9-46ae-990d-0017144971e7.jpg?1",
             "name": "Cold-Eyed Selkie",
             "text": "Islandwalk\nWhenever Cold-Eyed Selkie deals combat damage to a player, you may draw that many cards.",
             "colours": [
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "2bbc95a4-c748-541c-9db4-e0d223dbd427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be364b69-aa59-420c-a613-b1d0b303a4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be364b69-aa59-420c-a613-b1d0b303a4e5.jpg?1",
             "name": "Fable of Wolf and Owl",
             "text": "Whenever you play a green spell, you may put a 2/2 green Wolf creature token into play.\nWhenever you play a blue spell, you may put a 1/1 blue Bird creature token with flying into play.",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "ba39315e-3b9a-5362-a276-81b245893580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf061f8-3aec-429a-bde7-7c110f872416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf061f8-3aec-429a-bde7-7c110f872416.jpg?1",
             "name": "Favor of the Overbeing",
             "text": "Enchant creature\nAs long as enchanted creature is green, it gets +1/+1 and has vigilance.\nAs long as enchanted creature is blue, it gets +1/+1 and has flying.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "f4f0ebac-2a9e-50cf-a3b9-fa4553081d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca006ff-3a95-4821-bdb2-2d80e64b4abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca006ff-3a95-4821-bdb2-2d80e64b4abf.jpg?1",
             "name": "Gilder Bairn",
             "text": "{2}{GW}, {Q}: For each counter on target permanent, put another of those counters on that permanent. ({Q} is the untap symbol.)",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "fa3fd9b5-89f1-56f8-b903-d2781f23f818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ccef2d-9a1f-4011-89e1-911bcc109b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ccef2d-9a1f-4011-89e1-911bcc109b9d.jpg?1",
             "name": "Grazing Kelpie",
             "text": "{GW}, Sacrifice Grazing Kelpie: Put target card in a graveyard on the bottom of its owner's library.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5325,7 +5325,7 @@
         },
         {
             "id": "83bd0e35-ac0c-5e94-9d30-dfed8356de85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e7056e-42b9-436a-8302-fcbfa0abd84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e7056e-42b9-436a-8302-fcbfa0abd84f.jpg?1",
             "name": "Groundling Pouncer",
             "text": "{GW}: Groundling Pouncer gets +1/+3 and gains flying until end of turn. Play this ability only once each turn and only if an opponent controls a creature with flying.",
             "colours": [
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "211d982b-cec0-557b-93c6-89606d51ab24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d0a6f9-478f-43c7-8591-3b601c12ed01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d0a6f9-478f-43c7-8591-3b601c12ed01.jpg?1",
             "name": "Invert the Skies",
             "text": "Creatures your opponents control lose flying until end of turn if {G} was spent to play Invert the Skies, and creatures you control gain flying until end of turn if {U} was spent to play it. (Do both if {G}{U} was spent.)",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "a666b49c-a661-504f-9ef0-04925e9a6df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8250af-696f-4e28-86ba-29e316d01e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8250af-696f-4e28-86ba-29e316d01e56.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -5431,7 +5431,7 @@
         },
         {
             "id": "145ec295-c0f9-5387-8687-6a2f9a371300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bbc404-a456-4a4b-af88-23921d80d671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bbc404-a456-4a4b-af88-23921d80d671.jpg?1",
             "name": "Overbeing of Myth",
             "text": "Overbeing of Myth's power and toughness are each equal to the number of cards in your hand.\nAt the beginning of your draw step, draw a card.",
             "colours": [
@@ -5468,7 +5468,7 @@
         },
         {
             "id": "ee4f4eac-55ea-5088-83ca-8fb8a0b2fb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f66b0b4-44fc-444d-9181-0b717c9642fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f66b0b4-44fc-444d-9181-0b717c9642fa.jpg?1",
             "name": "Selkie Hedge-Mage",
             "text": "When Selkie Hedge-Mage comes into play, if you control two or more Forests, you may gain 3 life.\nWhen Selkie Hedge-Mage comes into play, if you control two or more Islands, you may return target tapped creature to its owner's hand.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "e6432886-ffd5-5559-99c6-0669532319e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24babb9e-edc8-484b-9db4-18abbafdf096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24babb9e-edc8-484b-9db4-18abbafdf096.jpg?1",
             "name": "Shorecrasher Mimic",
             "text": "Whenever you play a spell that's both green and blue, Shorecrasher Mimic becomes 5/3 and gains trample until end of turn.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "dc3d0e52-dece-5711-baec-0482366e14a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19714d6c-2bfa-4ee0-aa2f-5ccc196bc5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19714d6c-2bfa-4ee0-aa2f-5ccc196bc5d8.jpg?1",
             "name": "Slippery Bogle",
             "text": "Slippery Bogle can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "6c48b000-825a-5b77-b4ba-8dff8fc0cef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d96d4f2-7f19-4687-927a-5b840254a4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d96d4f2-7f19-4687-927a-5b840254a4f9.jpg?1",
             "name": "Snakeform",
             "text": "Target creature loses all abilities and becomes a 1/1 green Snake until end of turn.\nDraw a card.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "67411f74-afd0-5cb7-a679-7eaf4f1283de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d60c0c-1bc8-4962-9205-4645db7fb26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d60c0c-1bc8-4962-9205-4645db7fb26e.jpg?1",
             "name": "Spitting Image",
             "text": "Put a token into play that's a copy of target creature.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -5645,7 +5645,7 @@
         },
         {
             "id": "2213f4fb-a302-52fe-9081-158451e60ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41330e2-c6e8-47af-831d-b2d2bd1d06a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41330e2-c6e8-47af-831d-b2d2bd1d06a3.jpg?1",
             "name": "Sturdy Hatchling",
             "text": "Sturdy Hatchling comes into play with four -1/-1 counters on it.\n{GW}: Sturdy Hatchling gains shroud until end of turn.\nWhenever you play a green spell, remove a -1/-1 counter from Sturdy Hatchling.\nWhenever you play a blue spell, remove a -1/-1 counter from Sturdy Hatchling.",
             "colours": [
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "fd46f8e0-3127-5f0c-a5ea-10809dfe8fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62615f86-0431-4709-b41c-af43f7793fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62615f86-0431-4709-b41c-af43f7793fdb.jpg?1",
             "name": "Trapjaw Kelpie",
             "text": "Flash\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "6ca1aa20-d0a4-57d6-94e3-c323b57f5139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3e6feb-3d78-4463-9315-5ba27ab33733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3e6feb-3d78-4463-9315-5ba27ab33733.jpg?1",
             "name": "Wistful Selkie",
             "text": "When Wistful Selkie comes into play, draw a card.",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "5f335e1a-6031-5203-8155-a92693ad8901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed81c72-743d-4d2a-97a6-22f5651e15d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed81c72-743d-4d2a-97a6-22f5651e15d5.jpg?1",
             "name": "Altar Golem",
             "text": "Trample\nAltar Golem's power and toughness are each equal to the number of creatures in play.\nAltar Golem doesn't untap during its controller's untap step.\nTap five untapped creatures you control: Untap Altar Golem.",
             "colours": [],
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "0acaee76-73b5-5439-b793-190cfac530ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca66c361-3cea-4f9c-836d-3513f05d6b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca66c361-3cea-4f9c-836d-3513f05d6b22.jpg?1",
             "name": "Antler Skulkin",
             "text": "{2}: Target white creature gains persist until end of turn. (When it's put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "866b0c2b-7344-584a-b3a1-74bc6a50a903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5ed574-4ff2-4f67-8989-d3e47ba1d750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5ed574-4ff2-4f67-8989-d3e47ba1d750.jpg?1",
             "name": "Fang Skulkin",
             "text": "{2}: Target black creature gains wither until end of turn. (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [],
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "839e9b19-8728-5a74-bf89-3547ef349318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea91be37-aca0-484a-ab94-0186073269d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea91be37-aca0-484a-ab94-0186073269d2.jpg?1",
             "name": "Hoof Skulkin",
             "text": "{3}: Target green creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "d0f77126-ff3c-59ba-9207-8415c40a2744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a88f807-96ce-432f-aaf5-d0097d234a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a88f807-96ce-432f-aaf5-d0097d234a4b.jpg?1",
             "name": "Jawbone Skulkin",
             "text": "{2}: Target red creature gains haste until end of turn.",
             "colours": [],
@@ -5909,7 +5909,7 @@
         },
         {
             "id": "00730563-84b6-562e-bf0a-51b2fdaf583c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bcabd-7bbe-463c-a35a-992c12c4e4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bcabd-7bbe-463c-a35a-992c12c4e4bf.jpg?1",
             "name": "Leering Emblem",
             "text": "Whenever you play a spell, equipped creature gets +2/+2 until end of turn.\nEquip {2}",
             "colours": [],
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "4696cb7b-484d-5035-afba-9829d160cba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1978400d-a8f1-4df7-8caf-b9ca81334bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1978400d-a8f1-4df7-8caf-b9ca81334bce.jpg?1",
             "name": "Scarecrone",
             "text": "{1}, Sacrifice a Scarecrow: Draw a card.\n{4}, {T}: Return target artifact creature card from your graveyard to play.",
             "colours": [],
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "401963b9-f54f-544c-bbe8-d32d2cca8758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0953373-66e1-4af1-a4ec-cc990e20a1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0953373-66e1-4af1-a4ec-cc990e20a1de.jpg?1",
             "name": "Shell Skulkin",
             "text": "{3}: Target blue creature gains shroud until end of turn.",
             "colours": [],
@@ -6001,7 +6001,7 @@
         },
         {
             "id": "975ccf00-3a2f-5ca6-b381-2e64b3e2759e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a271351e-5d5e-443b-99a4-ebdc8a3c4923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a271351e-5d5e-443b-99a4-ebdc8a3c4923.jpg?1",
             "name": "Ward of Bones",
             "text": "Each opponent who controls more creatures than you can't play creature cards. The same is true for artifacts, enchantments, and lands.",
             "colours": [],
@@ -6029,7 +6029,7 @@
         },
         {
             "id": "f4b7766a-8590-57bf-b625-159c8f9c4103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eede44-270a-481d-850b-b4862b9685ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eede44-270a-481d-850b-b4862b9685ea.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {1} to your mana pool.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "feecb7fd-b8c3-5136-9114-2b7257a2a766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb9790-3744-4dcb-881a-452573298822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb9790-3744-4dcb-881a-452573298822.jpg?1",
             "name": "Fetid Heath",
             "text": "{T}: Add {1} to your mana pool.\n{WB}, {T}: Add {W}{W}, {W}{B}, or {B}{B} to your mana pool.",
             "colours": [],
@@ -6091,7 +6091,7 @@
         },
         {
             "id": "b584f07b-e23b-5af1-bad0-944054694522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e45d16b-8320-4a9b-ad15-9687dfb52bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e45d16b-8320-4a9b-ad15-9687dfb52bed.jpg?1",
             "name": "Flooded Grove",
             "text": "{T}: Add {1} to your mana pool.\n{GW}, {T}: Add {G}{G}, {G}{U}, or {U}{U} to your mana pool.",
             "colours": [],
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "27e87e79-77ff-5179-b9f6-597433b8a038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31f8b2a-acf4-423c-bc99-8cf44f3c018a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31f8b2a-acf4-423c-bc99-8cf44f3c018a.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {1} to your mana pool.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W} to your mana pool.",
             "colours": [],
@@ -6153,7 +6153,7 @@
         },
         {
             "id": "8db72e25-a8e8-529e-b017-e9136665691b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02df7f4-c664-48bd-9508-f0b4298b1ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02df7f4-c664-48bd-9508-f0b4298b1ef8.jpg?1",
             "name": "Springjack Pasture",
             "text": "{T}: Add {1} to your mana pool.\n{4}, {T}: Put a 0/1 white Goat creature token into play.\n{T}, Sacrifice X Goats: Add X mana of any one color to your mana pool. You gain X life.",
             "colours": [],
@@ -6181,7 +6181,7 @@
         },
         {
             "id": "7a39815b-7cac-550f-ad76-84167d8a9df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff619a09-4fe5-4341-9077-88a0a9f4fbf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff619a09-4fe5-4341-9077-88a0a9f4fbf9.jpg?1",
             "name": "Twilight Mire",
             "text": "{T}: Add {1} to your mana pool.\n{BG}, {T}: Add {B}{B}, {B}{G}, or {G}{G} to your mana pool.",
             "colours": [],
@@ -6212,7 +6212,7 @@
         },
         {
             "id": "da3796c8-1666-58fd-b962-3e960cd28bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f67615-8a09-4ab9-9927-899a15e72c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f67615-8a09-4ab9-9927-899a15e72c03.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -6246,7 +6246,7 @@
         },
         {
             "id": "4a3f32ed-8d70-5358-adde-7c206a525b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453ee89-6122-4d51-989c-e78b046a9de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453ee89-6122-4d51-989c-e78b046a9de3.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "0f7766ea-bb7c-5936-967b-49eac1f8fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc3a29a-280d-4f2c-9a01-8cfead75f583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc3a29a-280d-4f2c-9a01-8cfead75f583.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "c39b810f-d8ab-5fd6-a971-5e5017d7b511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d8e99-a530-4eec-a938-254c98073975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d8e99-a530-4eec-a938-254c98073975.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "e59691aa-e1f1-5b09-836c-3104c1f45bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c702fc63-4a79-4c54-b22e-7e479b8354d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c702fc63-4a79-4c54-b22e-7e479b8354d2.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "daae7519-b9df-5c2d-9bde-25d115b7ece3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0788f7a4-793a-42f4-a7c9-05e4b4587897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0788f7a4-793a-42f4-a7c9-05e4b4587897.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "69863b68-0cee-589c-a3d4-b02bbce9db2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e836db04-161c-4f4f-88d2-4271cec62008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e836db04-161c-4f4f-88d2-4271cec62008.jpg?1",
             "name": "Goblin Soldier",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/EXO.json
+++ b/Assets/Resources/Sets/EXO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6eeb61a0-ea46-56f3-8118-89a32ffda0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20a1c6d-ec6a-4bd6-b3b2-b997f71d41fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20a1c6d-ec6a-4bd6-b3b2-b997f71d41fc.jpg?1",
             "name": "Allay",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target enchantment.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "0c1cf88e-67ca-516a-b59e-8a45585741f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3c8bae-953f-4bb4-a78d-02e4e354e53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3c8bae-953f-4bb4-a78d-02e4e354e53c.jpg?1",
             "name": "Angelic Blessing",
             "text": "Target creature gets +3/+3 and gains flying until end of turn.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "033d8210-7238-53cb-aacc-ac11cde3fc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024ae668-a1ae-4020-89c8-acbd8bd0a691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024ae668-a1ae-4020-89c8-acbd8bd0a691.jpg?1",
             "name": "Cataclysm",
             "text": "Each player chooses from the permanents he or she controls an artifact, a creature, an enchantment, and a land and sacrifices the rest.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "3a42c724-19e3-5ab5-989c-0d4d9cd8c17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f3f72-2923-4432-898a-02679a8b320f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f3f72-2923-4432-898a-02679a8b320f.jpg?1",
             "name": "Charging Paladin",
             "text": "If Charging Paladin attacks, it gets +0/+3 until end of turn.",
             "colours": [
@@ -131,7 +131,7 @@
         },
         {
             "id": "7cb04fb1-81b8-5d7f-b91b-47c3d64770bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd49a61-42ba-400a-8ca9-9f6058bf85ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd49a61-42ba-400a-8ca9-9f6058bf85ca.jpg?1",
             "name": "Convalescence",
             "text": "During your upkeep, if you have 10 or less life, gain 1 life.",
             "colours": [
@@ -162,7 +162,7 @@
         },
         {
             "id": "6f21746e-87ab-569a-bd4e-1ba4829c81b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7537bab3-4bac-4b83-9ad3-dfcb4ff19d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7537bab3-4bac-4b83-9ad3-dfcb4ff19d6d.jpg?1",
             "name": "Exalted Dragon",
             "text": "Flying\nEach turn, Exalted Dragon cannot attack unless you sacrifice a land.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "18bbb8c7-336b-5eb2-b92f-6a3e34fd0943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5239dc-f51b-48c0-91a2-ed6551aaff32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5239dc-f51b-48c0-91a2-ed6551aaff32.jpg?1",
             "name": "High Ground",
             "text": "Each creature you control may block one additional creature. (All defense must be legal.)",
             "colours": [
@@ -226,7 +226,7 @@
         },
         {
             "id": "1f029ee4-cb61-5510-99d6-99188b16885f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eda847-c599-4163-b48b-aa76b153ed86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eda847-c599-4163-b48b-aa76b153ed86.jpg?1",
             "name": "Keeper of the Light",
             "text": "o\nW, oc\nT: Gain 3 life. Play this ability only if you have less life than target opponent.",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "5dff28fd-f1d1-503a-811a-f051f9f98a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc61cc3-0312-44f4-9c23-4fc37c3fbbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc61cc3-0312-44f4-9c23-4fc37c3fbbd5.jpg?1",
             "name": "Kor Chant",
             "text": "Redirect to target creature all damage dealt to any one creature you control from any one source.",
             "colours": [
@@ -291,7 +291,7 @@
         },
         {
             "id": "43d9cb2c-c26c-53db-886e-ffabb72cf3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ae3609-a3cc-486c-94f6-b8f647adfb47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ae3609-a3cc-486c-94f6-b8f647adfb47.jpg?1",
             "name": "Limited Resources",
             "text": "When Limited Resources comes into play, each player chooses five lands he or she controls and sacrifices the rest.\nAs long as there are ten or more lands in play, players cannot play lands.",
             "colours": [
@@ -322,7 +322,7 @@
         },
         {
             "id": "1ae3cbd6-2c63-5936-b3f4-db3dc63c7a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470a2092-eeda-4557-8cee-ac401b61a225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470a2092-eeda-4557-8cee-ac401b61a225.jpg?1",
             "name": "Oath of Lieges",
             "text": "During each player's upkeep, if that player controls fewer lands than target opponent, the player may search his or her library for a basic land card and put that land into play. The player shuffles his or her library afterwards.",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "de082077-37e1-5ce8-a345-d22026487e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1ea89d-4b9d-455f-a7f4-a26026e0c272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1ea89d-4b9d-455f-a7f4-a26026e0c272.jpg?1",
             "name": "Paladin en-Vec",
             "text": "First strike, protection from black, protection from red",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "f1253730-e2ff-5886-adff-efb29db76322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c383f12f-da06-4ef0-bf8e-6a8a9cfcc74c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c383f12f-da06-4ef0-bf8e-6a8a9cfcc74c.jpg?1",
             "name": "Peace of Mind",
             "text": "o\nW, Choose and discard a card: Gain 3 life.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "e4c27329-ba8b-5fc7-ba9c-d75bfadf805e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b941576-8254-4d69-85ae-c748c7921ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b941576-8254-4d69-85ae-c748c7921ce5.jpg?1",
             "name": "Pegasus Stampede",
             "text": "Buyback\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Pegasus Stampede into your hand instead of your graveyard as part of the spell's effect.)\nPut a Pegasus token into play. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "9246de07-091e-50a5-9273-62e3225887b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3db848-8394-43bd-a236-264641033a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3db848-8394-43bd-a236-264641033a6d.jpg?1",
             "name": "Penance",
             "text": "Choose a card from your hand and put that card on top of your library: Prevent all damage from a black or red source. (Treat further damage from that source normally.)",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "a0d36f71-25b1-5881-8f9d-323fb9f322d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379b0495-8795-4b21-9d0a-dc4e10098de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379b0495-8795-4b21-9d0a-dc4e10098de2.jpg?1",
             "name": "Reaping the Rewards",
             "text": "Buyback\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Reaping the Rewards into your hand instead of your graveyard as part of the spell's effect.)\nGain 2 life.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "a52218c4-fc79-5fb4-b45b-a823db604f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16012d8-703c-4385-8769-13e3caba3fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16012d8-703c-4385-8769-13e3caba3fc6.jpg?1",
             "name": "Reconnaissance",
             "text": "o0: Remove target attacking creature you control from combat and untap it. (That creature neither deals nor receives combat damage this turn.)",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "35967038-f8fc-5986-a9a1-cfdc37b93a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5315668-b8ef-49ab-a8f5-144adc7bcd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5315668-b8ef-49ab-a8f5-144adc7bcd84.jpg?1",
             "name": "Shackles",
             "text": "Enchanted creature does not untap during its controller's untap phase.\noo\nW Return Shackles to owner's hand.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "a2029eeb-3dcb-5099-9ecb-72cbcb505308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49261bb-66b5-4226-9001-02d045fbcbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49261bb-66b5-4226-9001-02d045fbcbce.jpg?1",
             "name": "Shield Mate",
             "text": "Sacrifice Shield Mate: Target creature gets +0/+4 until end of turn.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "a8ec8b5b-b7d3-56d9-b770-55e960e9d9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3ae384-7b60-4264-9dc1-1613917168ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3ae384-7b60-4264-9dc1-1613917168ca.jpg?1",
             "name": "Soltari Visionary",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Visionary damages any player, destroy target enchantment that player controls.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "81a73b58-804f-5ae7-81c8-cbd680f3af6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ee24ee-4d28-4634-bd43-90eff15c16dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ee24ee-4d28-4634-bd43-90eff15c16dd.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever any other creature comes into play, gain 1 life.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "de06f13a-708b-5155-adc8-40f2e3435cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135e258a-71d8-45dd-9307-91111aa34bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135e258a-71d8-45dd-9307-91111aa34bde.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking does not cause Standing Troops to tap.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "7f0d3965-257b-59b2-8703-60218456ba9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06452630-621b-498e-8f25-ecfe544d4213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06452630-621b-498e-8f25-ecfe544d4213.jpg?1",
             "name": "Treasure Hunter",
             "text": "When Treasure Hunter comes into play, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "0b1a698a-3c82-5cbf-91ba-0b7c7deb5a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1da8e79-365d-4a36-87c5-648085828f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1da8e79-365d-4a36-87c5-648085828f9f.jpg?1",
             "name": "Wall of Nets",
             "text": "(Walls cannot attack.)\nAt end of combat, remove from the game all creatures blocked by Wall of Nets.\nIf Wall of Nets leaves play, return to play under their owners' control all creatures removed from the game with Wall of Nets.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "7c320fb6-1943-503f-9982-96600f413d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8166253c-c6ac-4b5e-9746-09ce3774c66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8166253c-c6ac-4b5e-9746-09ce3774c66b.jpg?1",
             "name": "Welkin Hawk",
             "text": "Flying\nIf Welkin Hawk is put into any graveyard from play, you may search your library for a Welkin Hawk card, reveal that card to all players, and put it into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "b0ce8e40-719b-524e-ab32-4bdb2ae7ce49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9fb486-1d6a-478e-af6e-fd8539dc646d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9fb486-1d6a-478e-af6e-fd8539dc646d.jpg?1",
             "name": "Zealots en-Dal",
             "text": "During your upkeep, if all nonland permanents you control are white, gain 1 life.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "c52455af-fd3a-585a-a407-dd07d1625521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aab7526-5825-4f31-92ff-be25ab5af2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aab7526-5825-4f31-92ff-be25ab5af2f5.jpg?1",
             "name": "Aether Tide",
             "text": "Choose and discard X creature cards: Return X target creatures to their owner's hand.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "1cebea0d-f8cb-5ee4-8915-e99f8bfb22f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f36bb8-5a97-4596-8ca3-707665770c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f36bb8-5a97-4596-8ca3-707665770c76.jpg?1",
             "name": "Cunning",
             "text": "Enchanted creature gets +3/+3.\nIf enchanted creature attacks or blocks, sacrifice Cunning at end of turn.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "0b550b62-2a83-5006-af52-79742c04633e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee17ef5-7e1a-42ae-b680-df81204df7dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee17ef5-7e1a-42ae-b680-df81204df7dd.jpg?1",
             "name": "Curiosity",
             "text": "If enchanted creature damages an opponent, you may draw a card.",
             "colours": [
@@ -941,7 +941,7 @@
         },
         {
             "id": "72a5c776-0d93-5434-b0db-6315ce28265a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e03323-43e8-4ddc-a874-211a97fd7648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e03323-43e8-4ddc-a874-211a97fd7648.jpg?1",
             "name": "Dominating Licid",
             "text": "o1o\nUo\nU, oc\nT: Dominating Licid loses this ability and becomes a creature enchantment that reads \"Gain control of enchanted creature\" instead of any other type of permanent. Move Dominating Licid onto target creature. You may pay o\nU to end this effect.",
             "colours": [
@@ -974,7 +974,7 @@
         },
         {
             "id": "e9206e1d-7c2b-518e-ae7e-3227770b6e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cdcd3b-6df5-481a-a244-1fc2545d1356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cdcd3b-6df5-481a-a244-1fc2545d1356.jpg?1",
             "name": "Ephemeron",
             "text": "Flying\nChoose and discard a card: Return Ephemeron to owner's hand.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "cf9f7ba1-13cd-592b-b50f-3e89ced55f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460b2ec6-0180-4214-acca-c9eed778ef50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460b2ec6-0180-4214-acca-c9eed778ef50.jpg?1",
             "name": "Equilibrium",
             "text": "Whenever you successfully cast a creature spell, you may pay o1 to return target creature to owner's hand.",
             "colours": [
@@ -1038,7 +1038,7 @@
         },
         {
             "id": "8806c719-4992-54dd-9263-320a344a0da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91971e19-61ce-45ac-b700-9ffca5091a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91971e19-61ce-45ac-b700-9ffca5091a27.jpg?1",
             "name": "Ertai, Wizard Adept",
             "text": "Ertai, Wizard Adept counts as a Wizard.\no2o\nUo\nU, oc\nT: Counter target spell. Play this ability as an interrupt.",
             "colours": [
@@ -1074,7 +1074,7 @@
         },
         {
             "id": "85b99b7d-7c0d-55dc-b660-26ac4768b42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f9103e-dcc2-4f7a-a8ca-eaa831f5f83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f9103e-dcc2-4f7a-a8ca-eaa831f5f83b.jpg?1",
             "name": "Fade Away",
             "text": "For each creature, that creature's controller pays o1 or sacrifices a permanent.",
             "colours": [
@@ -1105,7 +1105,7 @@
         },
         {
             "id": "e5bc597e-b51e-56eb-8560-11056578d552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29df5ef7-d679-4543-bdb7-3984155c87e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29df5ef7-d679-4543-bdb7-3984155c87e0.jpg?1",
             "name": "Forbid",
             "text": "Buyback\u2014\nChoose and discard two cards. (You may choose and discard two cards in addition to any other costs when you play this spell. If you do, put Forbid into your hand instead of your graveyard as part of the spell's effect.)\nCounter target spell.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "2059afee-3f3a-5587-babb-88dbccaee73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc232d4-ab4f-4d88-a9ec-72403d05ec04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc232d4-ab4f-4d88-a9ec-72403d05ec04.jpg?1",
             "name": "Keeper of the Mind",
             "text": "o\nU, oc\nT: Draw a card. Play this ability only if target opponent has at least two more cards in hand than you.",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "ce3ff3e3-6e11-5971-a8ef-ba3e9efb8329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d932f6d3-4918-4a41-836c-4eaa6cfac049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d932f6d3-4918-4a41-836c-4eaa6cfac049.jpg?1",
             "name": "Killer Whale",
             "text": "oo\nU Killer Whale gains flying until end of turn.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "f4a69d59-475a-54d6-a6ee-661550289927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a97f019-5ad9-4520-ba79-2c9b259748d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a97f019-5ad9-4520-ba79-2c9b259748d9.jpg?1",
             "name": "Mana Breach",
             "text": "Whenever any player plays a spell, that player returns a land he or she controls to owner's hand.",
             "colours": [
@@ -1234,7 +1234,7 @@
         },
         {
             "id": "ef4340b6-d60e-5107-8868-bc12c502c1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb1c41-388f-4ff2-af37-ad64a0f4618e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb1c41-388f-4ff2-af37-ad64a0f4618e.jpg?1",
             "name": "Merfolk Looter",
             "text": "oc\nT: Draw a card, then choose and discard a card.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "47c1848a-9b00-568d-9a4d-5a3e24f0c914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e091dd6-149f-46ea-bae0-224e79e3aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e091dd6-149f-46ea-bae0-224e79e3aacb.jpg?1",
             "name": "Mind Over Matter",
             "text": "Choose and discard a card: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "b10738f3-d416-5adc-8140-5c798aab779b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16417e94-e33f-4ed4-bb3e-52f29f7d441b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16417e94-e33f-4ed4-bb3e-52f29f7d441b.jpg?1",
             "name": "Mirozel",
             "text": "Flying\nIf Mirozel is the target of any spell or ability, return Mirozel to owner's hand.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "027750b1-809f-5833-b5bc-3b04b2084cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61376ad-21c8-4d34-b37d-ed60877f5d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61376ad-21c8-4d34-b37d-ed60877f5d4a.jpg?1",
             "name": "Oath of Scholars",
             "text": "During each player's upkeep, if that player has fewer cards in hand than target opponent, the player may discard his or her hand and draw three cards.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "82d8a704-9fc8-5b07-98af-b36e3e1ec051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371720a2-ec3f-43a5-9551-c018e164e79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371720a2-ec3f-43a5-9551-c018e164e79f.jpg?1",
             "name": "Robe of Mirrors",
             "text": "Enchanted creature cannot be the target of spells or abilities.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "26b4edef-e58f-5d8e-9c55-9e480473f4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94af81f2-383c-4129-b8dc-60633c3f4ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94af81f2-383c-4129-b8dc-60633c3f4ea1.jpg?1",
             "name": "Rootwater Mystic",
             "text": "o1oo\nU Look at the top card of target player's library.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "4807bd11-8a63-5129-bd56-85eb8d9933ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71217af5-3538-4e42-9343-3949b5306671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71217af5-3538-4e42-9343-3949b5306671.jpg?1",
             "name": "School of Piranha",
             "text": "During your upkeep, pay o1o\nU or sacrifice School of Piranha.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "b663c159-504d-5b95-9ae5-36a9034a3915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b236bba-160a-4637-a83e-8456834ce59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b236bba-160a-4637-a83e-8456834ce59f.jpg?1",
             "name": "Scrivener",
             "text": "When Scrivener comes into play, you may return target instant or interrupt card from your graveyard to your hand.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "30cf7f9c-81d9-52a8-85fd-8c6e4575cddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e13d2-6bd7-403c-8e2e-e00917b39597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e13d2-6bd7-403c-8e2e-e00917b39597.jpg?1",
             "name": "Thalakos Drifters",
             "text": "Choose and discard a card: Thalakos Drifters gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1530,7 +1530,7 @@
         },
         {
             "id": "58a812dc-9d44-5dba-b3a1-f7bf93ce619b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1703fe9d-ca70-4e8a-9d6a-6173a17d0f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1703fe9d-ca70-4e8a-9d6a-6173a17d0f04.jpg?1",
             "name": "Thalakos Scout",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nChoose and discard a card: Return Thalakos Scout to owner's hand.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "b913f6ed-3c82-5173-92b8-81b31b0f502b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099da8aa-16b1-4395-8467-1636feb14a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099da8aa-16b1-4395-8467-1636feb14a8a.jpg?1",
             "name": "Theft of Dreams",
             "text": "For each tapped creature target opponent controls, draw a card.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "ada1ef96-1161-5cd3-a732-e58b76608321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ce909-e744-47ca-943d-62d97e97b1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ce909-e744-47ca-943d-62d97e97b1ea.jpg?1",
             "name": "Treasure Trove",
             "text": "o2o\nUoo\nU Draw a card.",
             "colours": [
@@ -1627,7 +1627,7 @@
         },
         {
             "id": "120575e6-ed6a-5568-8e67-27e33ed308e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f96d5d-1d16-40bb-aaa7-8a7dd465d37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f96d5d-1d16-40bb-aaa7-8a7dd465d37b.jpg?1",
             "name": "Wayward Soul",
             "text": "Flying\noo\nU Put Wayward Soul on top of owner's library.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "b41ab697-6f63-5d7b-be26-e9f28150d72a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc17186-e786-46a3-9812-4a6e367e78b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc17186-e786-46a3-9812-4a6e367e78b9.jpg?1",
             "name": "Whiptongue Frog",
             "text": "oo\nU Whiptongue Frog gains flying until end of turn.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "37430fe8-172d-596f-b71e-066941598242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c057f-cb1b-4895-831a-fb35c75d3845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c057f-cb1b-4895-831a-fb35c75d3845.jpg?1",
             "name": "Carnophage",
             "text": "During your upkeep, pay 1 life or tap Carnophage.",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "286685ac-0c97-5df5-a51f-d6782b951e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947109f9-7035-4a2a-bbc2-a2958f8c5d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947109f9-7035-4a2a-bbc2-a2958f8c5d01.jpg?1",
             "name": "Cat Burglar",
             "text": "o2o\nB, oc\nT: Target player chooses and discards a card. Play this ability as a sorcery.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "28af757d-5e16-5725-9a81-d3b8b1bd97d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c33f18-0a5c-4e46-ab0d-6e450915594f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c33f18-0a5c-4e46-ab0d-6e450915594f.jpg?1",
             "name": "Culling the Weak",
             "text": "Sacrifice a creature: Add o\nBo\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "7fe15dd1-1b85-5c6e-9819-40627fe20211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7433b9bf-ee6e-41fe-b826-0d20584198b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7433b9bf-ee6e-41fe-b826-0d20584198b1.jpg?1",
             "name": "Cursed Flesh",
             "text": "Enchanted creature gets -1/-1 and cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "6ff71206-c05c-5ade-a42b-13cbb4f9ae4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127b8994-fff8-4500-8ab4-244eeb3ed110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127b8994-fff8-4500-8ab4-244eeb3ed110.jpg?1",
             "name": "Dauthi Cutthroat",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no1o\nB, oc\nT: Destroy target creature with shadow.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "66abba6d-cbcd-50bb-8abb-72252187ab64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419871bc-f036-4244-8b6c-3857ebe993f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419871bc-f036-4244-8b6c-3857ebe993f3.jpg?1",
             "name": "Dauthi Jackal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no\nBo\nB, Sacrifice Dauthi Jackal: Destroy target blocking creature.",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "0e984450-ed46-5b17-ab0f-f589cdab2312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ca689-482a-457d-9744-0bd79981f361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ca689-482a-457d-9744-0bd79981f361.jpg?1",
             "name": "Dauthi Warlord",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Warlord has power equal to the number of creatures with shadow in play.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "3bbed77b-5352-5dcd-88a1-00eec600e728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4756b6fd-2bb2-4be1-9b02-851a26ff4303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4756b6fd-2bb2-4be1-9b02-851a26ff4303.jpg?1",
             "name": "Death's Duet",
             "text": "Return two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -1958,7 +1958,7 @@
         },
         {
             "id": "b11f15be-6184-56f2-9611-829df104777d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb04d81-b0ab-4bc7-935d-c31005887240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb04d81-b0ab-4bc7-935d-c31005887240.jpg?1",
             "name": "Entropic Specter",
             "text": "Flying\nEntropic Specter has power and toughness each equal to the number of cards in target opponent's hand.\nIf Entropic Specter damages any player, that player chooses and discards a card.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "053f3c6c-5bfb-5f53-90bb-56f5b1ff94f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1629cd63-95aa-40b6-aa57-7fb88f569e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1629cd63-95aa-40b6-aa57-7fb88f569e59.jpg?1",
             "name": "Fugue",
             "text": "Target player chooses and discards three cards.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "393266ac-2012-55e4-a3dc-d3634465013f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f6301a-d581-4aaf-9993-3013323074aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f6301a-d581-4aaf-9993-3013323074aa.jpg?1",
             "name": "Grollub",
             "text": "For each 1 damage dealt to Grollub, each opponent gains 1 life.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "67ac1d38-e935-5955-a8a1-3860587eadd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2383a8d9-96fd-4f9a-bcf9-eb81fdb15ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2383a8d9-96fd-4f9a-bcf9-eb81fdb15ead.jpg?1",
             "name": "Hatred",
             "text": "Pay X life: Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "3990fc5f-b823-51f1-a8de-c5b75c39665b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b641171-35bc-4945-ada9-3ea28ea9fabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b641171-35bc-4945-ada9-3ea28ea9fabf.jpg?1",
             "name": "Keeper of the Dead",
             "text": "o\nB, oc\nT: Destroy target nonblack creature. Play this ability only if that creature's controller has at least two fewer creature cards in his or her graveyard than you have in yours.",
             "colours": [
@@ -2121,7 +2121,7 @@
         },
         {
             "id": "f18ec648-87bc-5597-91e5-797034de01ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c92a7f-a250-4497-aa7a-0394e94ef13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c92a7f-a250-4497-aa7a-0394e94ef13d.jpg?1",
             "name": "Mind Maggots",
             "text": "When Mind Maggots comes into play, choose and discard any number of creature cards. For each card discarded this way, put two +1/+1 counters on Mind Maggots.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "23aa6a30-f7de-5168-9e71-d87aa6cfa6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10531d8-fc99-4a2b-94b0-97a25521d725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10531d8-fc99-4a2b-94b0-97a25521d725.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "676d1dff-2257-5a3b-9fe6-f7af3d15ceae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ee9d9-20be-46f0-8752-1df50942f59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ee9d9-20be-46f0-8752-1df50942f59c.jpg?1",
             "name": "Necrologia",
             "text": "Play Necrologia only during your discard phase.\nPay X life: Draw X cards.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "a35339cf-7b5c-569d-bcee-2d00d5929523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1102f35a-ae62-479d-b61c-31a82978aedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1102f35a-ae62-479d-b61c-31a82978aedd.jpg?1",
             "name": "Oath of Ghouls",
             "text": "During each player's upkeep, if there are more creature cards in that player's graveyard than in target opponent's graveyard, the player may return a creature card from his or her graveyard to his or her hand.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "c29b0822-ffec-5ab8-af54-61e9bea876bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669ad60b-4053-4f07-9072-52e6ff65b4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669ad60b-4053-4f07-9072-52e6ff65b4e3.jpg?1",
             "name": "Pit Spawn",
             "text": "First strike\nDuring your upkeep, pay o\nBo\nB or sacrifice Pit Spawn.\nIf Pit Spawn damages any creature, remove that creature from the game.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "5b7fdf35-7a82-5481-a97d-ff2c87e43afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8493df6-9954-4e33-867c-ca4bcf3953b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8493df6-9954-4e33-867c-ca4bcf3953b2.jpg?1",
             "name": "Plaguebearer",
             "text": "o\nXo\nXoo\nB Destroy target nonblack creature with total casting cost equal to X.",
             "colours": [
@@ -2313,7 +2313,7 @@
         },
         {
             "id": "063929a5-a4d9-5b57-8237-8db43be48342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173030-1c33-417c-b8e9-79231b6a85a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173030-1c33-417c-b8e9-79231b6a85a7.jpg?1",
             "name": "Recurring Nightmare",
             "text": "Sacrifice a creature, Return Recurring Nightmare to owner's hand: Put target creature card from your graveyard into play. Play this ability as a sorcery.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "864b9ab2-aafc-5ba9-9de7-03b73473feea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9d4e11-ce2e-445a-9536-756a6687d6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9d4e11-ce2e-445a-9536-756a6687d6d7.jpg?1",
             "name": "Scare Tactics",
             "text": "All creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "1d2cc863-b67d-5f89-b4a5-d89ef7b81333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff06c7d-5e78-4bcf-864b-34487f6555b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff06c7d-5e78-4bcf-864b-34487f6555b2.jpg?1",
             "name": "Slaughter",
             "text": "Buyback\u2014\nPay 4 life. (You may pay 4 life in addition to any other costs when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target nonblack creature. That creature cannot be regenerated this turn.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "e534e4b0-75a4-5526-8dc4-4246d03f5bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64003772-c62f-4728-a00c-48c78991c6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64003772-c62f-4728-a00c-48c78991c6ae.jpg?1",
             "name": "Spike Cannibal",
             "text": "Spike Cannibal comes into play with one +1/+1 counter on it.\nWhen Spike Cannibal comes into play, move all +1/+1 counters from all creatures onto Spike Cannibal.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "2ee88115-88f6-56c6-a85b-8b00a602effd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e89bf1-42c9-4829-a565-78cac632810b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e89bf1-42c9-4829-a565-78cac632810b.jpg?1",
             "name": "Thrull Surgeon",
             "text": "o1o\nB, Sacrifice Thrull Surgeon: Look at target player's hand and choose one of those cards. That player discards that card. Play this ability as a sorcery.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "f6fdc3c5-4bdb-5213-b763-c374c3c16bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746bc301-9f08-4d9b-819e-690f6fce6bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746bc301-9f08-4d9b-819e-690f6fce6bc8.jpg?1",
             "name": "Vampire Hounds",
             "text": "Choose and discard a creature card: Vampire Hounds gets +2/+2 until end of turn.",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "4248f87e-7c73-502a-bc5a-ff6e60c3e07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab28e1-74e1-4c4e-920f-a658c6a44d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab28e1-74e1-4c4e-920f-a658c6a44d75.jpg?1",
             "name": "Volrath's Dungeon",
             "text": "Any player may pay 5 life during his or her turn to destroy Volrath's Dungeon.\nChoose and discard a card: Target player chooses a card in his or her hand and puts that card on top of his or her library. Play this ability as a sorcery.",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "2efaaaf9-beed-5d3f-95c0-bd48fb172d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a298df66-2075-40a7-bced-457656b6b788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a298df66-2075-40a7-bced-457656b6b788.jpg?1",
             "name": "Anarchist",
             "text": "When Anarchist comes into play, you may return target sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "3988282c-85d8-513b-9b7b-506b201dac0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9406050-d76b-4569-a463-e21acaf84166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9406050-d76b-4569-a463-e21acaf84166.jpg?1",
             "name": "Cinder Crawler",
             "text": "oo\nR Cinder Crawler gets +1/+0 until end of turn. Use this ability only if Cinder Crawler is blocked.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "614b94f8-4622-5d0f-9241-8e2840c653c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a482cf-a1cd-47b5-a76a-08e03965c679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a482cf-a1cd-47b5-a76a-08e03965c679.jpg?1",
             "name": "Dizzying Gaze",
             "text": "Play Dizzying Gaze only on a creature you control.\noo\nR Enchanted creature deals 1 damage to target creature with flying.",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "df323991-5e1a-5551-a28c-ad6a1e0a11fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75f6e9-5eee-4904-88c0-71ec730a0f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75f6e9-5eee-4904-88c0-71ec730a0f23.jpg?1",
             "name": "Fighting Chance",
             "text": "For each blocking creature, flip a coin. If you win the flip, that creature deals no combat damage this turn.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "7cd6dfc0-26da-5719-a25d-8aa8fcbb205f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcda003-6fac-4879-87e6-ec0c115630ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcda003-6fac-4879-87e6-ec0c115630ba.jpg?1",
             "name": "Flowstone Flood",
             "text": "Buyback\u2014\nPay 3 life, Discard a card at random. (You may pay 3 life and discard a card at random in addition to any other costs when you play this spell. If you do, put Flowstone Flood into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target land.",
             "colours": [
@@ -2699,7 +2699,7 @@
         },
         {
             "id": "7db4bad4-f785-5404-b48e-4b72c36b80e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79c6d9-96f1-434a-89b8-d773aa77ac5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79c6d9-96f1-434a-89b8-d773aa77ac5e.jpg?1",
             "name": "Furnace Brood",
             "text": "oo\nR Target creature cannot be regenerated this turn.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "bc580b31-a4ef-5b30-99d0-b3638cf17769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf246ca-9dfc-400f-8883-acc80ac016e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf246ca-9dfc-400f-8883-acc80ac016e1.jpg?1",
             "name": "Keeper of the Flame",
             "text": "o\nR, oc\nT: Keeper of the Flame deals 2 damage to target opponent. Use this ability only if that opponent has more life than you.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "e30ae589-4537-5533-8afc-5230dec41d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e3e38b-2191-4b92-ae5d-bb9397d24a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e3e38b-2191-4b92-ae5d-bb9397d24a27.jpg?1",
             "name": "Mage il-Vec",
             "text": "oc\nT, Discard a card at random: Mage il-Vec deals 1 damage to target creature or player.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "840f30ab-03e7-55ef-9731-3ac604a9135b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3aa840f-6a70-4674-acb7-ded0ea4397d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3aa840f-6a70-4674-acb7-ded0ea4397d8.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchanted creature gets +2/+2 and cannot block.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "0d4dc355-7dd4-512a-9046-809207bc6782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1124725d-e643-43a1-873e-255636c7f334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1124725d-e643-43a1-873e-255636c7f334.jpg?1",
             "name": "Mogg Assassin",
             "text": "oc\nT: Flip a coin. If you win the flip, destroy target creature an opponent controls. Otherwise, destroy target creature of that opponent's choice.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "c851f73d-d85a-5439-a4ef-bab1cedfcafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5066b1b-3910-4434-83d6-030851f20bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5066b1b-3910-4434-83d6-030851f20bcf.jpg?1",
             "name": "Monstrous Hound",
             "text": "Monstrous Hound cannot attack unless you control more lands than defending player.\nMonstrous Hound cannot block unless you control more lands than attacking player.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "cc2b64a2-d949-5a2f-9446-9892c3516e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8708d2-2c73-4da5-b6ff-41c083b59caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8708d2-2c73-4da5-b6ff-41c083b59caa.jpg?1",
             "name": "Oath of Mages",
             "text": "During each player's upkeep, if that player has less life than target opponent, he or she may have Oath of Mages deal 1 damage to that opponent.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "8b997794-4c6f-57ea-a2cf-f5f49fc28d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3224ac-9b60-48cf-9734-86768fd370ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3224ac-9b60-48cf-9734-86768fd370ac.jpg?1",
             "name": "Ogre Shaman",
             "text": "o2, Discard a card at random: Ogre Shaman deals 2 damage to target creature or player.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "3e917bef-a284-5c8b-b3cd-70922804d760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afaf142-dbca-45bf-aea2-01c53bda635a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afaf142-dbca-45bf-aea2-01c53bda635a.jpg?1",
             "name": "Onslaught",
             "text": "Whenever you successfully cast a creature spell, tap target creature.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "9e40c654-bb8c-5b20-8142-944bd1832d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f618231-28bb-4cdd-b887-a8aa186814d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f618231-28bb-4cdd-b887-a8aa186814d5.jpg?1",
             "name": "Pandemonium",
             "text": "Whenever any creature comes into play, that creature's controller may choose to have it deal damage equal to its power to target creature or player.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "3bb91b71-f9f5-510c-ab9a-bb7b839d558d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53320321-4f02-40ee-8171-2375b1d4ed66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53320321-4f02-40ee-8171-2375b1d4ed66.jpg?1",
             "name": "Paroxysm",
             "text": "During the upkeep of enchanted creature's controller, reveal the top card of that player's library to all players. If that card is a land card, destroy enchanted creature. Otherwise, enchanted creature gets +3/+3 until end of turn. (Return the card to the top of the player's library, face down.)",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "1dba2ff6-17b8-5af4-b036-126046cebc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5283db-3e22-4862-9d95-56d03d09c2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5283db-3e22-4862-9d95-56d03d09c2ae.jpg?1",
             "name": "Price of Progress",
             "text": "Price of Progress deals 2 damage to each player for each nonbasic land he or she controls.",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "fd41c261-d282-543b-ae32-cc38f5505060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0a166c-f7c0-45b4-aa90-053ce545cfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0a166c-f7c0-45b4-aa90-053ce545cfb2.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness.",
             "colours": [
@@ -3125,7 +3125,7 @@
         },
         {
             "id": "5ededc32-1479-50cb-86ef-646eee6802df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d00b68b-8b6a-48c9-8911-2a3270897091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d00b68b-8b6a-48c9-8911-2a3270897091.jpg?1",
             "name": "Ravenous Baboons",
             "text": "When Ravenous Baboons comes into play, destroy target nonbasic land.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "f7576f1b-1f69-52b3-bd5b-e8f79984f4e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d27b79-a22d-48d9-86b2-7ad02cab8697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d27b79-a22d-48d9-86b2-7ad02cab8697.jpg?1",
             "name": "Reckless Ogre",
             "text": "If Reckless Ogre attacks and no other creatures do, it gets +3/+0 until end of turn.",
             "colours": [
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "ee540c7f-0774-5693-85d9-69b1f5ea3771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c1d384-d341-4bab-bf71-5dbcf76d51e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c1d384-d341-4bab-bf71-5dbcf76d51e8.jpg?1",
             "name": "Sabertooth Wyvern",
             "text": "Flying, first strike",
             "colours": [
@@ -3224,7 +3224,7 @@
         },
         {
             "id": "3dcac15b-c8f3-5498-9cea-aea952007395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0e9433-88d7-4bfc-99a0-ff47807fd594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0e9433-88d7-4bfc-99a0-ff47807fd594.jpg?1",
             "name": "Scalding Salamander",
             "text": "o0: Scalding Salamander deals 1 damage to each creature without flying defending player controls. Play this ability only if Scalding Salamander is attacking and only once each turn.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "8ad24bd0-598b-5c4a-9451-e65c364a7e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc494af5-4da4-43f5-a193-426ef84d80a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc494af5-4da4-43f5-a193-426ef84d80a7.jpg?1",
             "name": "Seismic Assault",
             "text": "Choose and discard a land card: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "00e99d4c-8aff-56b8-851e-ed83450095e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d3b846-6071-4d65-86ba-da08c4bd0aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d3b846-6071-4d65-86ba-da08c4bd0aa1.jpg?1",
             "name": "Shattering Pulse",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target artifact.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "97313f2c-0ed4-5475-b6ed-2c59133aae22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05530d5a-dcb6-403e-9e35-224c7b5cf615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05530d5a-dcb6-403e-9e35-224c7b5cf615.jpg?1",
             "name": "Sonic Burst",
             "text": "Discard a card at random: Sonic Burst deals 4 damage to target creature or player.",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "2be15898-9758-59b1-a378-d1b2445ee9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db2a78-e1c5-4732-a4ee-04b4c540edbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db2a78-e1c5-4732-a4ee-04b4c540edbe.jpg?1",
             "name": "Spellshock",
             "text": "Whenever any player successfully casts a spell, Spellshock deals 2 damage to him or her.",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "79bf01d1-a7b1-54f3-9849-2729ca5bcb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca9fd31-639a-4fbc-84bd-c3078df29c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca9fd31-639a-4fbc-84bd-c3078df29c0a.jpg?1",
             "name": "Avenging Druid",
             "text": "If Avenging Druid damages any opponent, you may reveal cards from your library until you reveal a land card. Put that land into play and put all other revealed cards into your graveyard.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "d775ffc0-0658-531c-8523-906edc5cdc80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aae577-9683-4d9b-bfd5-52702b38d3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aae577-9683-4d9b-bfd5-52702b38d3a7.jpg?1",
             "name": "Bequeathal",
             "text": "If enchanted creature is put into any graveyard, draw two cards.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "dcf01db0-5b17-5fbc-923a-eeec51af7b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c2cc9-37ce-435e-9df2-083d5e3c8c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c2cc9-37ce-435e-9df2-083d5e3c8c5c.jpg?1",
             "name": "Cartographer",
             "text": "When Cartographer comes into play, you may return target land card from your graveyard to your hand.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "4af2c742-954c-5766-93e9-fc503073dfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2965bd5-4f16-443a-9133-adb92cf0e12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2965bd5-4f16-443a-9133-adb92cf0e12b.jpg?1",
             "name": "Crashing Boars",
             "text": "If Crashing Boars attacks, defending player chooses an untapped creature he or she controls. That creature blocks Crashing Boars this turn if able.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "e58165d6-78c2-52fd-bc61-f1fc183d7ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b990ffe5-fd2a-4646-bac3-8e52cdc328aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b990ffe5-fd2a-4646-bac3-8e52cdc328aa.jpg?1",
             "name": "Elven Palisade",
             "text": "Sacrifice a forest: Target attacking creature gets -3/-0 until end of turn.",
             "colours": [
@@ -3545,7 +3545,7 @@
         },
         {
             "id": "77512035-74f5-5c6b-a98c-f061d02fe765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa69a8e-1b75-4d93-918d-d772cec69e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa69a8e-1b75-4d93-918d-d772cec69e99.jpg?1",
             "name": "Elvish Berserker",
             "text": "For each creature that blocks it, Elvish Berserker gets +1/+1 until end of turn.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "de622ed9-36c5-5a06-b888-e230ff4686a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80105c-d2c0-4f8c-9302-5e6152a60f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80105c-d2c0-4f8c-9302-5e6152a60f54.jpg?1",
             "name": "Jackalope Herd",
             "text": "If you play any spell, return Jackalope Herd to owner's hand.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "b641bc13-2279-52cd-aebd-6b693096385e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccccf78-8b00-406b-a2b7-0e6ba76703d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccccf78-8b00-406b-a2b7-0e6ba76703d0.jpg?1",
             "name": "Keeper of the Beasts",
             "text": "o\nG, oc\nT: Put a Beast token into play. Treat this token as a 2/2 green creature. Play this ability only if target opponent controls more creatures than you.",
             "colours": [
@@ -3647,7 +3647,7 @@
         },
         {
             "id": "fab0a25c-a5fe-5c3f-90e4-3d64ae00046f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212ca7e7-5ba3-4da7-a2f0-16c721004bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212ca7e7-5ba3-4da7-a2f0-16c721004bac.jpg?1",
             "name": "Manabond",
             "text": "During your discard phase, you may choose to put all land cards from your hand into play. If you do, discard the rest of your hand.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "8166de85-98db-50be-88a8-81f2a9370f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1682dd-5a99-4bee-a2c2-c8735047e1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1682dd-5a99-4bee-a2c2-c8735047e1a9.jpg?1",
             "name": "Mirri, Cat Warrior",
             "text": "Mirri, Cat Warrior counts as a Cat Warrior.\nFirst strike; forestwalk (If defending player controls any forests, this creature is unblockable.)\nAttacking does not cause Mirri to tap.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "fc297e6e-f094-51b1-8e68-b6d93a677fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf14de50-d123-400c-862e-2c95fd2aa23f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf14de50-d123-400c-862e-2c95fd2aa23f.jpg?1",
             "name": "Oath of Druids",
             "text": "During each player's upkeep, if that player controls fewer creatures than target opponent, the player may reveal cards from his or her library until he or she reveals a creature card. The player puts that creature into play and all other revealed cards into his or her graveyard.",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "5431ece4-5a0b-5d6b-82a2-1b95dc158c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf4da70-c656-4e40-bb0f-68e9dda024c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf4da70-c656-4e40-bb0f-68e9dda024c9.jpg?1",
             "name": "Plated Rootwalla",
             "text": "o2oo\nG Plated Rootwalla gets +3/+3 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "68c5b687-b584-5f8a-915e-f9b106b009d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9d28-3a05-4dfa-a322-36b4cc2697d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9d28-3a05-4dfa-a322-36b4cc2697d4.jpg?1",
             "name": "Predatory Hunger",
             "text": "Whenever any opponent successfully casts a creature spell, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "0d3f06f3-743b-531a-95b3-357395bdbf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be9714d-125f-4700-879d-b920fe9f1b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be9714d-125f-4700-879d-b920fe9f1b68.jpg?1",
             "name": "Pygmy Troll",
             "text": "For each creature that blocks it, Pygmy Troll gets +1/+1 until end of turn.\noo\nG Regenerate Pygmy Troll.",
             "colours": [
@@ -3844,7 +3844,7 @@
         },
         {
             "id": "2a150efb-0b42-586c-9d47-8b41ca9bb0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99121a2b-c735-47be-b01e-cdf59809e7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99121a2b-c735-47be-b01e-cdf59809e7f3.jpg?1",
             "name": "Rabid Wolverines",
             "text": "For each creature that blocks it, Rabid Wolverines gets +1/+1 until end of turn.",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "1335c32c-cc3e-5d2e-a68c-7705259e4f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b47c082-57f6-4f69-87e8-a07cad9ef042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b47c082-57f6-4f69-87e8-a07cad9ef042.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -3908,7 +3908,7 @@
         },
         {
             "id": "ba8463f1-3703-5844-91ab-a0e9894f3017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5707560-fcc6-4aca-adce-d41de45f37e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5707560-fcc6-4aca-adce-d41de45f37e8.jpg?1",
             "name": "Resuscitate",
             "text": "Until end of turn, each creature you control gains \"o1: Regenerate this creature.\"",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "8ba6623d-8358-50ac-b38c-99fd5d50f726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a840bba-4725-45fd-885f-1b3d615dfa97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a840bba-4725-45fd-885f-1b3d615dfa97.jpg?1",
             "name": "Rootwater Alligator",
             "text": "Sacrifice a forest: Regenerate Rootwater Alligator.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "8c440f85-ef41-50c2-8916-376a45bd2632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a496a4-1b4c-4c5d-99e5-ec40601c759d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a496a4-1b4c-4c5d-99e5-ec40601c759d.jpg?1",
             "name": "Skyshroud Elite",
             "text": "Skyshroud Elite gets +1/+2 as long as any opponent controls any nonbasic lands.",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "10d6e38e-29be-59ba-933e-a709946b6100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d809c1-e674-40b8-816d-c45d77c66722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d809c1-e674-40b8-816d-c45d77c66722.jpg?1",
             "name": "Skyshroud War Beast",
             "text": "Trample\nSkyshroud War Beast has power and toughness each equal to the number of nonbasic lands target opponent controls.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "48abdb45-5704-56bb-bab0-ff97359770a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba85b2f-37da-4595-9880-8e9f1ddbac09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba85b2f-37da-4595-9880-8e9f1ddbac09.jpg?1",
             "name": "Song of Serenity",
             "text": "Creatures with any enchantments on them cannot attack or block.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "39ef301e-7b62-50ce-9d44-51e7f8cea9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f79fb79-37a0-483f-ba19-853cbfffc73d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f79fb79-37a0-483f-ba19-853cbfffc73d.jpg?1",
             "name": "Spike Hatcher",
             "text": "Spike Hatcher comes into play with six +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Hatcher: Put a +1/+1 counter on target creature.\no1, Remove a +1/+1 counter from Spike Hatcher: Regenerate Spike Hatcher.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "2644bf84-1b2b-5c9c-b3fd-066cd9d2f2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d9b671-344b-460d-8f65-d65129db91c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d9b671-344b-460d-8f65-d65129db91c3.jpg?1",
             "name": "Spike Rogue",
             "text": "Spike Rogue comes into play with two +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Rogue: Put a +1/+1 counter on target creature.\no2, Remove a +1/+1 counter from any creature you control: Put a +1/+1 counter on Spike Rogue.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "0f3895a1-c684-5546-b52f-940675291511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c561a2a-91c6-4d4b-9f96-bffd43a00478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c561a2a-91c6-4d4b-9f96-bffd43a00478.jpg?1",
             "name": "Spike Weaver",
             "text": "Spike Weaver comes into play with three +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Weaver: Put a +1/+1 counter on target creature.\no1, Remove a +1/+1 counter from Spike Weaver: Creatures deal no combat damage this turn.",
             "colours": [
@@ -4168,7 +4168,7 @@
         },
         {
             "id": "78e2c28e-4331-5f97-9ce8-96032de08bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060c178-3c0e-493f-b6f0-ead5b1d6f191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060c178-3c0e-493f-b6f0-ead5b1d6f191.jpg?1",
             "name": "Survival of the Fittest",
             "text": "o\nG, Choose and discard a creature card: Search your library for a creature card, reveal that card to all players, and put it into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -4199,7 +4199,7 @@
         },
         {
             "id": "2707929d-98e6-54e4-b0ae-c5d915e340d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716bb55-0821-4809-9bc0-04e299b09549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716bb55-0821-4809-9bc0-04e299b09549.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a forest card and put that forest into play. Shuffle your library afterwards.",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "6543faa0-fbdf-5247-bbb7-befd6e6d4cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e32c939-1d64-4082-bafe-59dfa9c054f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e32c939-1d64-4082-bafe-59dfa9c054f6.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play of the same creature type. (For example, if there are three Goblins in play, each of them gets +2/+2.)",
             "colours": [],
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "ae4cfad0-ea30-5046-8ffc-0cf995df16e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e652007-02f0-424f-b52c-c1540d1939bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e652007-02f0-424f-b52c-c1540d1939bd.jpg?1",
             "name": "Erratic Portal",
             "text": "o1, oc\nT: Return target creature to owner's hand unless its controller pays o1.",
             "colours": [],
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "c22daa90-fe5b-545a-be02-fc6d509597ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399c06d5-af2a-47a1-9239-ff14224a026b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399c06d5-af2a-47a1-9239-ff14224a026b.jpg?1",
             "name": "Medicine Bag",
             "text": "o1, oc\nT, Choose and discard a card: Regenerate target creature.",
             "colours": [],
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "dff23ea0-f7d1-519b-ba24-112cb6e6c5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c786ea5b-52ad-4d1b-855e-ce6d0b9af67e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c786ea5b-52ad-4d1b-855e-ce6d0b9af67e.jpg?1",
             "name": "Memory Crystal",
             "text": "All buyback costs are reduced by o2.",
             "colours": [],
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "6168b788-27e6-5cd7-b1c4-333195de93f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddfc5ab-b11b-4ad7-ab46-8ee60d938a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddfc5ab-b11b-4ad7-ab46-8ee60d938a5b.jpg?1",
             "name": "Mindless Automaton",
             "text": "Mindless Automaton comes into play with two +1/+1 counters on it.\no1, Choose and discard a card: Put a +1/+1 counter on Mindless Automaton.\nRemove two +1/+1 counters from Mindless Automaton: Draw a card.",
             "colours": [],
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "5842868e-0cfc-5309-8365-85bb2fd22a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d5a0c6-916c-428a-ae66-8adc8844e56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d5a0c6-916c-428a-ae66-8adc8844e56e.jpg?1",
             "name": "Null Brooch",
             "text": "o2, oc\nT, Discard your hand: Counter target noncreature spell. Play this ability as an interrupt.",
             "colours": [],
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "6a7b875c-0d24-52f0-b2a2-729596a47349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234ed934-6ea7-41f6-bd13-3df8662a3a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234ed934-6ea7-41f6-bd13-3df8662a3a1d.jpg?1",
             "name": "Skyshaper",
             "text": "Sacrifice Skyshaper: All creatures you control gain flying until end of turn.",
             "colours": [],
@@ -4425,7 +4425,7 @@
         },
         {
             "id": "b1f903e0-5d42-5e46-8cf5-e5c1ee28e7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb104c-f8ca-4da2-8f1f-8fe6f291407e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb104c-f8ca-4da2-8f1f-8fe6f291407e.jpg?1",
             "name": "Spellbook",
             "text": "Skip your discard phase.",
             "colours": [],
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "11c0de6b-9910-53b1-9669-4a941d53520b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f4d2a5-bb85-4662-b2dd-a363ec7eab9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f4d2a5-bb85-4662-b2dd-a363ec7eab9b.jpg?1",
             "name": "Sphere of Resistance",
             "text": "All spells cost an additional o1 to play.",
             "colours": [],
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "c5e356a6-8d4a-5b94-90d8-8866326090c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ac2d30-7c9a-40b3-812e-e77e49229f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ac2d30-7c9a-40b3-812e-e77e49229f48.jpg?1",
             "name": "Thopter Squadron",
             "text": "Flying\nThopter Squadron comes into play with three +1/+1 counters on it.\no1, Remove a +1/+1 counter from Thopter Squadron: Put a Thopter token into play. Treat this token as a 1/1 artifact creature with flying. Play this ability as a sorcery.\no1, Sacrifice a Thopter: Put a +1/+1 counter on Thopter Squadron. Play this ability as a sorcery.",
             "colours": [],
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "ce441c2b-34a2-58e4-871c-f43350600653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a115563-81da-42f6-95c4-22ae7bb51a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a115563-81da-42f6-95c4-22ae7bb51a0f.jpg?1",
             "name": "Transmogrifying Licid",
             "text": "Transmogrifying Licid counts as a Licid.\no1, oc\nT: Transmogrifying Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature gets +1/+1 and counts as an artifact\" instead of any other type of permanent. Move Transmogrifying Licid onto target creature. You may pay o1 to end this effect.",
             "colours": [],
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "80dec60e-3005-5d3a-a39c-db71c78d8864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2571ff7-0287-4ba2-8365-5ff08de641a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2571ff7-0287-4ba2-8365-5ff08de641a2.jpg?1",
             "name": "Workhorse",
             "text": "Workhorse comes into play with four +1/+1 counters on it.\nRemove a +1/+1 counter from Workhorse: Add one colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "d81e7409-5299-560b-a79c-e3dda4807c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a8b6b8-b95f-4014-b17a-a6d44d965995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a8b6b8-b95f-4014-b17a-a6d44d965995.jpg?1",
             "name": "City of Traitors",
             "text": "If you play a land, sacrifice City of Traitors.\noc\nT: Add two colorless mana to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/FDN.json
+++ b/Assets/Resources/Sets/FDN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "46149862-416f-563b-b854-1893b7c76d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8432a7-1c8a-4cfb-947c-ecf9791063eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8432a7-1c8a-4cfb-947c-ecf9791063eb.jpg?1",
             "name": "Sire of Seven Deaths",
             "text": "First strike, vigilance\nMenace, trample\nReach, lifelink\nWard\u2014\nPay 7 life.",
             "colours": [],
@@ -37,7 +37,7 @@
         },
         {
             "id": "355a81e1-e59a-5683-bc2c-17cf713b4372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524a5d93-26ed-436d-a437-dc9460acce98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524a5d93-26ed-436d-a437-dc9460acce98.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "a294c623-56e1-5a42-8b73-9966a7b7c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80fc380-0499-4499-8a60-c43844c02c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80fc380-0499-4499-8a60-c43844c02c9b.jpg?1",
             "name": "Armasaur Guide",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever you attack with three or more creatures, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "57cc0820-dfee-53e9-9d0b-8bd6667e44ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526fe356-bff1-4211-9e88-bf913ac76b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526fe356-bff1-4211-9e88-bf913ac76b1d.jpg?1",
             "name": "Cat Collector",
             "text": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nWhenever you gain life for the first time during each of your turns, create a 1/1 white Cat creature token.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "87fed9fb-fa34-5ea1-ba1d-3f1d50496c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809ee8ad-1573-49e5-9e84-b7cdd29efcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809ee8ad-1573-49e5-9e84-b7cdd29efcae.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W} ({3}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "e77d49ab-7da9-5761-a29c-f0924c337e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396049c-b976-4b7f-8ecd-564e24ebd631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396049c-b976-4b7f-8ecd-564e24ebd631.jpg?1",
             "name": "Claws Out",
             "text": "This spell costs {1} less to cast for each Cat you control.\nCreatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "38156075-dfa1-58df-9c7a-c2a745d462f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender (This creature can't attack.)\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -256,7 +256,7 @@
         },
         {
             "id": "e99ecca8-89ab-5a08-8cf3-7a79b46bb2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a136f26-ac66-407f-b389-357222d2c4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a136f26-ac66-407f-b389-357222d2c4a2.jpg?1",
             "name": "Dauntless Veteran",
             "text": "Whenever this creature attacks, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -291,7 +291,7 @@
         },
         {
             "id": "dc07b427-46a4-548e-9d86-93f0cbd772a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027dc444-e544-4693-8653-3dcdda530162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027dc444-e544-4693-8653-3dcdda530162.jpg?1",
             "name": "Dazzling Angel",
             "text": "Flying\nWhenever another creature you control enters, you gain 1 life.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "f6e5c20b-c629-5200-af95-20ed514e742d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a08245-a535-4d24-b8c0-78759bb9c4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a08245-a535-4d24-b8c0-78759bb9c4b0.jpg?1",
             "name": "Divine Resilience",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nTarget creature you control gains indestructible until end of turn. If this spell was kicked, instead any number of target creatures you control gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "4f570d33-17a1-551a-a965-a1e73b0117cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8fc5-fdd2-446a-a676-5c363f96928f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8fc5-fdd2-446a-a676-5c363f96928f.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -395,7 +395,7 @@
         },
         {
             "id": "b42f13e4-50b0-50bd-b267-5101d8444e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd092b14-d72f-4de0-8f19-1338661b9e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd092b14-d72f-4de0-8f19-1338661b9e3b.jpg?1",
             "name": "Felidar Savior",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "19b84094-8b71-5eb5-a48c-f7eabba27fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55139100-9342-41fd-b10a-8e9932e605d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55139100-9342-41fd-b10a-8e9932e605d4.jpg?1",
             "name": "Fleeting Flight",
             "text": "Put a +1/+1 counter on target creature. It gains flying until end of turn. Prevent all combat damage that would be dealt to it this turn.",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "f78300d6-df6c-5a18-a979-83ef6810f6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525ba5c7-3ce5-4e52-b8b5-96c9040a6738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525ba5c7-3ce5-4e52-b8b5-96c9040a6738.jpg?1",
             "name": "Guarded Heir",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, create two 3/3 white Knight creature tokens.",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "085bb8e1-07cf-55c2-853b-c9adf261237f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg?1",
             "name": "Hare Apparent",
             "text": "When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.\nA deck can have any number of cards named Hare Apparent.",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "81ded782-e8a5-59f1-94be-dbf78f1728fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9a0e91-80b5-428f-8f08-931d0631be14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9a0e91-80b5-428f-8f08-931d0631be14.jpg?1",
             "name": "Helpful Hunter",
             "text": "When this creature enters, draw a card.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "2cf29847-ef40-588c-8c3e-ba9792edd04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdfebf-98e0-4718-bac3-6eee1cd0623d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdfebf-98e0-4718-bac3-6eee1cd0623d.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -606,7 +606,7 @@
         },
         {
             "id": "16d94186-533e-5f5a-acb1-77b494189626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0763be06-25b2-4d6b-ab33-a1af85aeb443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0763be06-25b2-4d6b-ab33-a1af85aeb443.jpg?1",
             "name": "Inspiring Paladin",
             "text": "During your turn, this creature has first strike. (It deals combat damage before creatures without first strike.)\nDuring your turn, creatures you control with +1/+1 counters on them have first strike.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "d8cc6e4b-1c35-5c9d-928b-b7de2d166a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846adb38-f9bb-4fed-b8ed-36ec7885f989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846adb38-f9bb-4fed-b8ed-36ec7885f989.jpg?1",
             "name": "Joust Through",
             "text": "Joust Through deals 3 damage to target attacking or blocking creature. You gain 1 life.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "207ea838-ef73-544a-9dc3-9a9cc004703e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621839e1-2756-4cdc-a25c-5f76ea98dd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621839e1-2756-4cdc-a25c-5f76ea98dd87.jpg?1",
             "name": "Luminous Rebuke",
             "text": "This spell costs {3} less to cast if it targets a tapped creature.\nDestroy target creature.",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "62d19be0-aed0-5dbd-afd6-52ca5a1e176d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742117a-8a72-43b9-b05d-274829d138a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742117a-8a72-43b9-b05d-274829d138a2.jpg?1",
             "name": "Prideful Parent",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "551fdc06-6070-52d1-bf01-fb069193f00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "9b7b196f-6c34-53a6-a258-8e4fbd6171fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfe4e62-c153-47b8-8e09-cedaf91f53d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfe4e62-c153-47b8-8e09-cedaf91f53d8.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "7477de59-d999-5f61-8d5f-ac841303d6e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e1ee86-6f08-4aa0-bf63-ae12028ef080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e1ee86-6f08-4aa0-bf63-ae12028ef080.jpg?1",
             "name": "Squad Rallier",
             "text": "{2}{W}: Look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "3e955570-70ed-5b87-a757-8949c2867a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323d029e-9a88-4188-b3a4-38ef32cffc9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323d029e-9a88-4188-b3a4-38ef32cffc9f.jpg?1",
             "name": "Sun-Blessed Healer",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, if it was kicked, return target nonland permanent card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "2b28a741-13f6-5ff8-8eae-adb815e329cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf01cbe-9fcb-4f35-bc6b-2280620b06ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf01cbe-9fcb-4f35-bc6b-2280620b06ff.jpg?1",
             "name": "Twinblade Blessing",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "412339eb-948c-5275-9a3c-fefad0ab86a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "c450689f-78df-5afb-a7f3-673a10da5b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329c861-fc16-4a96-9c03-25af6ac2adc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329c861-fc16-4a96-9c03-25af6ac2adc8.jpg?1",
             "name": "Vanguard Seraph",
             "text": "Flying\nWhenever you gain life for the first time each turn, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "b1d8b422-906f-50a8-a8a7-3ee1263d9b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06431793-5dfe-4cbf-990b-4bcc960d1f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06431793-5dfe-4cbf-990b-4bcc960d1f31.jpg?1",
             "name": "Arcane Epiphany",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nDraw three cards.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "a474f5de-fb4d-58f6-ad7a-1e7d2f7c4867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334b5018-2da9-49f1-9d09-83d312ecfb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334b5018-2da9-49f1-9d09-83d312ecfb02.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "e882ca08-bc72-53c3-963e-7e1b7b881532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1d5b76-b07e-45c6-800d-4cfce085164f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1d5b76-b07e-45c6-800d-4cfce085164f.jpg?1",
             "name": "Bigfin Bouncer",
             "text": "When this creature enters, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "a3ea191a-8510-5421-97be-1c9a8beb0b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e47680-18c7-4ffb-aac4-c5db6e7095ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e47680-18c7-4ffb-aac4-c5db6e7095ba.jpg?1",
             "name": "Cephalid Inkmage",
             "text": "When this creature enters, surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nThreshold \u2014 This creature can't be blocked as long as there are seven or more cards in your graveyard.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "bbe7a835-f541-5de0-ba7c-9aa2a9bd1c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36012810-0e83-4640-8ba7-7262229f1b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36012810-0e83-4640-8ba7-7262229f1b84.jpg?1",
             "name": "Clinquant Skymage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on this creature.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "1c08f5b8-02f2-56e2-abde-92da53c97519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "61d1ad67-45b8-562e-bfab-a01fea035a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaf4196-6bf3-47fa-b5c7-0e77f45cf820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaf4196-6bf3-47fa-b5c7-0e77f45cf820.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -1242,7 +1242,7 @@
         },
         {
             "id": "a864ad97-5274-59da-852e-5a49b13d685f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9768cc6-8f53-4922-ae32-376a2f32d719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9768cc6-8f53-4922-ae32-376a2f32d719.jpg?1",
             "name": "Elementalist Adept",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1277,7 +1277,7 @@
         },
         {
             "id": "679b8c5e-bbe5-57c5-9f36-fe7df05c84cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273c417-0fcd-4273-b24e-afff76336d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273c417-0fcd-4273-b24e-afff76336d0c.jpg?1",
             "name": "Erudite Wizard",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "58a42eb3-2135-5dd1-a4b7-297e8aca2c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3bee8f-f5be-4404-a696-c902637799c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3bee8f-f5be-4404-a696-c902637799c3.jpg?1",
             "name": "Faebloom Trick",
             "text": "Create two 1/1 blue Faerie creature tokens with flying. When you do, tap target creature an opponent controls.",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "d0fcbb0c-5811-5f31-b185-50286e37acce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f5cab3-3fc0-448d-8252-cd55abf5b596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f5cab3-3fc0-448d-8252-cd55abf5b596.jpg?1",
             "name": "Grappling Kraken",
             "text": "Landfall \u2014 Whenever a land you control enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1378,7 +1378,7 @@
         },
         {
             "id": "08078e34-6700-578c-aa7f-98a882cd82c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "26a41dbc-b05c-5168-9f59-2b29b513a25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "467a475b-0bbd-5236-9619-5f72e924e0ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0eba76-3829-408b-828f-0b223c884728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0eba76-3829-408b-828f-0b223c884728.jpg?1",
             "name": "Icewind Elemental",
             "text": "Flying\nWhen this creature enters, draw a card, then discard a card.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "7c68ec52-be40-54c1-b20e-946decd2173e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636fe95-664f-4fb1-aab9-28856edeccd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636fe95-664f-4fb1-aab9-28856edeccd6.jpg?1",
             "name": "Inspiration from Beyond",
             "text": "Mill three cards, then return an instant or sorcery card from your graveyard to your hand.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "f014a6c5-c126-5011-a3e1-e7bfb621c71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "0ea5c8e8-97c6-5b1d-99d4-abe6d6a9211a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f20a32-9f5d-4a68-8995-549e57554da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f20a32-9f5d-4a68-8995-549e57554da2.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -1603,7 +1603,7 @@
         },
         {
             "id": "d78c556c-578b-5740-9e7d-0ee0f68ad3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a159f6-fecf-4bdd-b2f8-a9665a5cc32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a159f6-fecf-4bdd-b2f8-a9665a5cc32d.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "fd02035b-edc5-5748-a862-1cefa1b70410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d89cec-528b-4b2a-87db-e11ce0000622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d89cec-528b-4b2a-87db-e11ce0000622.jpg?1",
             "name": "Mischievous Mystic",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "d4ab1334-95e9-5b19-9a72-9e666a7170bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38806934-dd9c-4ad4-a59c-a16dce03a14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38806934-dd9c-4ad4-a59c-a16dce03a14a.jpg?1",
             "name": "Refute",
             "text": "Counter target spell. Draw a card, then discard a card.",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "6811ddcb-ad7a-5307-96a4-7495610fe970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0f147b-95ed-4f32-9b46-6a633ae31976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0f147b-95ed-4f32-9b46-6a633ae31976.jpg?1",
             "name": "Rune-Sealed Wall",
             "text": "Defender\n{T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "50f43a0c-2823-5faa-993a-3556d00df0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62958fc3-55dc-4b97-a070-490d6ed27820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62958fc3-55dc-4b97-a070-490d6ed27820.jpg?1",
             "name": "Skyship Buccaneer",
             "text": "Flying\nRaid \u2014 When this creature enters, if you attacked this turn, draw a card.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "9a238a7d-00d7-5198-9244-c57333b304d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "9e719055-5095-5c42-b1dc-4ee89358e501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd2422e-8e84-4c39-af29-3b4d38baee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd2422e-8e84-4c39-af29-3b4d38baee63.jpg?1",
             "name": "Strix Lookout",
             "text": "Flying, vigilance (Attacking doesn't cause this creature to tap.)\n{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "6344e200-94b5-5509-ab0a-c694e7f69d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0846820-e595-4743-8a28-29c57d728677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0846820-e595-4743-8a28-29c57d728677.jpg?1",
             "name": "Uncharted Voyage",
             "text": "Target creature's owner puts it on their choice of the top or bottom of their library.\nSurveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "53653716-0e7a-58f8-a65c-c9ab33494d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "7441c269-801c-5757-885e-47f929573f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2496c4a-df03-4583-bd76-f98ed5cb61ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2496c4a-df03-4583-bd76-f98ed5cb61ee.jpg?1",
             "name": "Arbiter of Woe",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying\nWhen this creature enters, each opponent discards a card and loses 2 life. You draw a card and gain 2 life.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "ecc7e249-e28a-56b0-a81d-f272cc52bf79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3587a9-0667-4d53-807b-c437bcb1d7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3587a9-0667-4d53-807b-c437bcb1d7b3.jpg?1",
             "name": "Billowing Shriekmass",
             "text": "Flying\nWhen this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nThreshold \u2014 This creature gets +2/+1 as long as there are seven or more cards in your graveyard.",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "162bf48c-f23e-5cbd-b899-168d386c94fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "07415aed-3458-58dd-a438-0a5e73e06de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life. (Damage causes loss of life.)",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "3e642319-331e-5fdf-813f-0cf352e216a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b072811-998a-4a71-b59c-6afecc0dc4b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b072811-998a-4a71-b59c-6afecc0dc4b6.jpg?1",
             "name": "Crypt Feaster",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nThreshold \u2014 Whenever this creature attacks, if there are seven or more cards in your graveyard, this creature gets +2/+0 until end of turn.",
             "colours": [
@@ -2100,7 +2100,7 @@
         },
         {
             "id": "43bef5ba-9abc-50ec-9aff-1a9b43b4d560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909d7778-c7f8-4fa4-89f2-8b32e86e96e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909d7778-c7f8-4fa4-89f2-8b32e86e96e4.jpg?1",
             "name": "Gutless Plunderer",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRaid \u2014 When this creature enters, if you attacked this turn, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "06eb1b5f-067c-534c-b273-48c086180093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da4a4b-ea12-4169-a7cf-eb4427f13e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da4a4b-ea12-4169-a7cf-eb4427f13e84.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "0635f382-dc3e-56f8-9c28-c7b7b2fc6e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790f9433-7565-4f7f-88e8-8af762ea0296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790f9433-7565-4f7f-88e8-8af762ea0296.jpg?1",
             "name": "Hungry Ghoul",
             "text": "{1}, Sacrifice another creature: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "4de9f36d-8b8a-59ef-a7a5-1ac01189eca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b6330-2d0b-4f2f-a848-f10b06fb4ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b6330-2d0b-4f2f-a848-f10b06fb4ef5.jpg?1",
             "name": "Infernal Vessel",
             "text": "When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's control with two +1/+1 counters on it. It's a Demon in addition to its other types.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "767849b3-c33e-5933-bebd-82ba519851bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c73de-7a5f-46f2-a70b-449bc8ecfe24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c73de-7a5f-46f2-a70b-449bc8ecfe24.jpg?1",
             "name": "Infestation Sage",
             "text": "When this creature dies, create a 1/1 black and green Insect creature token with flying.",
             "colours": [
@@ -2278,7 +2278,7 @@
         },
         {
             "id": "9566e2e2-fc51-5e4c-b3e6-aa57b967ec0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7543f-2a45-4db6-b560-d15507a58c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7543f-2a45-4db6-b560-d15507a58c91.jpg?1",
             "name": "Midnight Snack",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{2}{B}, Sacrifice this enchantment: Target opponent loses X life, where X is the amount of life you gained this turn.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "9f578a4d-5d48-5cca-883a-2592f88d5bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -2348,7 +2348,7 @@
         },
         {
             "id": "6634ed50-f3ca-5500-a90a-88ea2d618c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f463c55-39a0-4f2f-aae3-0c5540bde5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f463c55-39a0-4f2f-aae3-0c5540bde5b7.jpg?1",
             "name": "Revenge of the Rats",
             "text": "Create a tapped 1/1 black Rat creature token for each creature card in your graveyard.\nFlashback {2}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2380,7 +2380,7 @@
         },
         {
             "id": "55fa65e4-32ef-515c-9ebf-37e7775585d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1daf5bb-c8e9-4e79-a532-ca92a9a885cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1daf5bb-c8e9-4e79-a532-ca92a9a885cd.jpg?1",
             "name": "Sanguine Syphoner",
             "text": "Whenever this creature attacks, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "69aef091-4420-5cd4-99c4-09b39fe65647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc359da6-8b7f-45ec-b530-ce159fc35953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc359da6-8b7f-45ec-b530-ce159fc35953.jpg?1",
             "name": "Seeker's Folly",
             "text": "Choose one \u2014\n\u2022 Target opponent discards two cards.\n\u2022 Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2447,7 +2447,7 @@
         },
         {
             "id": "09458ed6-d8b1-54f3-a256-61a6d706fd9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deea5690-6eb2-4353-b917-cbbf840e4e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deea5690-6eb2-4353-b917-cbbf840e4e71.jpg?1",
             "name": "Soul-Shackled Zombie",
             "text": "When this creature enters, exile up to two target cards from a single graveyard. If at least one creature card was exiled this way, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "272f41d3-3347-556b-b7ed-2481acae2b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6859a5ba-1c1c-4631-bba8-f9900b827178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6859a5ba-1c1c-4631-bba8-f9900b827178.jpg?1",
             "name": "Stab",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "4e2349e1-4f16-5bd7-94f2-78c995f660b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3d85bc-ef2d-4251-baf4-a14bd0cee61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3d85bc-ef2d-4251-baf4-a14bd0cee61e.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "2424970f-6872-55aa-86db-103debeec0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30df3e33-2f17-4067-99f1-5db6b0f41fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30df3e33-2f17-4067-99f1-5db6b0f41fd4.jpg?1",
             "name": "Tragic Banshee",
             "text": "Morbid \u2014 When this creature enters, target creature an opponent controls gets -1/-1 until end of turn. If a creature died this turn, that creature gets -13/-13 instead.",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "b1873070-cae4-5929-a2eb-3fb6b2f29660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917514c0-9cd5-4b97-85b9-c4f753560ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917514c0-9cd5-4b97-85b9-c4f753560ad4.jpg?1",
             "name": "Vampire Gourmand",
             "text": "Whenever this creature attacks, you may sacrifice another creature. If you do, draw a card and this creature can't be blocked this turn.",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "ad5f67d6-bef1-543b-aae5-82f682bed453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d076293-3b45-4878-8f67-978927cc1f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d076293-3b45-4878-8f67-978927cc1f68.jpg?1",
             "name": "Vampire Soulcaller",
             "text": "Flying\nThis creature can't block.\nWhen this creature enters, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "be29d89d-a25b-54ea-be5f-4bf34fa73be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0c12dd-f138-45c0-9614-d83a1d8e8399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0c12dd-f138-45c0-9614-d83a1d8e8399.jpg?1",
             "name": "Vengeful Bloodwitch",
             "text": "Whenever this creature or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "b8d8648e-e113-5111-ba55-522a8b2a771b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "9432017f-4236-5e67-83ee-b3162a46854e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8b199-5d62-485f-b1c3-b30aa550595b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8b199-5d62-485f-b1c3-b30aa550595b.jpg?1",
             "name": "Battlesong Berserker",
             "text": "Whenever you attack, target creature you control gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "73cc9164-0f64-5054-8d97-6da4e5a15e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1ec351-5e70-4eb2-b590-6bff94ef8178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1ec351-5e70-4eb2-b590-6bff94ef8178.jpg?1",
             "name": "Boltwave",
             "text": "Boltwave deals 3 damage to each opponent.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "1ea308d1-ff14-5a56-974d-47880bb27cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dcc50-da10-4281-b522-9240c1204f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dcc50-da10-4281-b522-9240c1204f5d.jpg?1",
             "name": "Bulk Up",
             "text": "Double target creature's power until end of turn.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "7314f2bf-b150-5acd-ba1a-7f7dd4ee6ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg?1",
             "name": "Chandra, Flameshaper",
             "text": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n\u22124: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
             "colours": [
@@ -2873,7 +2873,7 @@
         },
         {
             "id": "846795bb-0155-5608-8772-87facc7ee2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db6819c-666a-409d-85a5-b9ac34d8dd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db6819c-666a-409d-85a5-b9ac34d8dd2f.jpg?1",
             "name": "Courageous Goblin",
             "text": "Whenever this creature attacks while you control a creature with power 4 or greater, this creature gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "095deb11-a6c2-5dbd-9765-1bbadeb2896a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5b899a-52f7-471b-ad50-4fa6566758fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5b899a-52f7-471b-ad50-4fa6566758fd.jpg?1",
             "name": "Crackling Cyclops",
             "text": "Whenever you cast a noncreature spell, this creature gets +3/+0 until end of turn.",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "23feb4ed-4363-5480-8613-13d4cda5068b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd75a1-cb54-4e38-9ce1-e8f32a73c6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd75a1-cb54-4e38-9ce1-e8f32a73c6eb.jpg?1",
             "name": "Dragon Trainer",
             "text": "When this creature enters, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "18c0ffe6-fcef-55aa-835b-8fe455214384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3012,7 +3012,7 @@
         },
         {
             "id": "5c485a8e-11b9-5399-94f4-d758bbff453a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe00aa-d284-48f9-b5a2-1bd4c5fa8e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe00aa-d284-48f9-b5a2-1bd4c5fa8e58.jpg?1",
             "name": "Fiery Annihilation",
             "text": "Fiery Annihilation deals 5 damage to target creature. Exile up to one target Equipment attached to that creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "3982633c-d2f5-5ec4-ab2c-cbcf69ca9f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4409a063-bf2a-4a49-803e-3ce6bd474353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4409a063-bf2a-4a49-803e-3ce6bd474353.jpg?1",
             "name": "Goblin Boarders",
             "text": "Raid \u2014 This creature enters with a +1/+1 counter on it if you attacked this turn.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "a5ed1289-b561-58c8-a6c2-085bf8541988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2016585-e26c-4d13-b09f-af6383c192f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2016585-e26c-4d13-b09f-af6383c192f7.jpg?1",
             "name": "Goblin Negotiation",
             "text": "Goblin Negotiation deals X damage to target creature. Create a number of 1/1 red Goblin creature tokens equal to the amount of excess damage dealt to that creature this way.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "c532626d-d61a-535c-8a52-9148bc5cfc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ce6c40-3452-4aa0-a45b-dbfd70f8d220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ce6c40-3452-4aa0-a45b-dbfd70f8d220.jpg?1",
             "name": "Gorehorn Raider",
             "text": "Raid \u2014 When this creature enters, if you attacked this turn, this creature deals 2 damage to any target.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "aa4a12f3-a5b6-5a29-909d-8d6f88c38a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e20ab-c5ca-4295-884d-78efdaa83243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e20ab-c5ca-4295-884d-78efdaa83243.jpg?1",
             "name": "Incinerating Blast",
             "text": "Incinerating Blast deals 6 damage to target creature.\nYou may discard a card. If you do, draw a card.",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "f440d436-a6ab-5cae-aebf-fa7af5cecdfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "0dac603b-4c49-5e27-91f0-761f62108920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673e4561-8dfd-46db-b492-878009666ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673e4561-8dfd-46db-b492-878009666ac7.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -3256,7 +3256,7 @@
         },
         {
             "id": "b9df8b84-b747-517e-aeef-80beb45ecba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ad0b97-a318-4e76-ac79-b3e83417c333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ad0b97-a318-4e76-ac79-b3e83417c333.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "ed17e1dc-89a3-505a-9346-099ea35c6ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06faa8-201d-45db-b398-ad56f7b01848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06faa8-201d-45db-b398-ad56f7b01848.jpg?1",
             "name": "Slumbering Cerberus",
             "text": "This creature doesn't untap during your untap step.\nMorbid \u2014 At the beginning of each end step, if a creature died this turn, untap this creature.",
             "colours": [
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "66f2c0bd-a18f-5e00-bccd-fa495e7a183f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff50606-491c-4946-8d03-719b01cfad77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff50606-491c-4946-8d03-719b01cfad77.jpg?1",
             "name": "Sower of Chaos",
             "text": "{2}{R}: Target creature can't block this turn.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "802042e5-e5da-5bc9-81ea-587a509ea93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2223eb8-59f9-489b-a3f3-b6496218cb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2223eb8-59f9-489b-a3f3-b6496218cb79.jpg?1",
             "name": "Strongbox Raider",
             "text": "Raid \u2014 When this creature enters, if you attacked this turn, exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -3398,7 +3398,7 @@
         },
         {
             "id": "3f120402-2fc1-5ef8-aec0-a556016bffbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "66885d74-6001-5a11-b8d4-01cbf10fef19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903832c-318e-42ab-bf58-c682ec2f7afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903832c-318e-42ab-bf58-c682ec2f7afd.jpg?1",
             "name": "Ambush Wolf",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, exile up to one target card from a graveyard.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "26481264-a3e0-541d-8620-47118d6e2c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7b0c-0e1b-46ce-9917-9fc6e05aa148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7b0c-0e1b-46ce-9917-9fc6e05aa148.jpg?1",
             "name": "Apothecary Stomper",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, choose one \u2014\n\u2022 Put two +1/+1 counters on target creature you control.\n\u2022 You gain 4 life.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "ae62b6eb-b7f9-5679-9450-1b226d77574c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0102e0be-5783-4825-9489-713b1b1df0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0102e0be-5783-4825-9489-713b1b1df0b2.jpg?1",
             "name": "Beast-Kin Ranger",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever another creature you control enters, this creature gets +1/+0 until end of turn.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "6b77124e-6ded-55ba-ae16-89751e538d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e971-c075-4203-8d83-c28f22d4f9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e971-c075-4203-8d83-c28f22d4f9b9.jpg?1",
             "name": "Cackling Prowler",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nMorbid \u2014 At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "06a79841-e87b-5e32-a469-bc3ed314df2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8433d-eb2a-43d1-b59b-7d70ff97c8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8433d-eb2a-43d1-b59b-7d70ff97c8e7.jpg?1",
             "name": "Eager Trufflesnout",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever this creature deals combat damage to a player, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "6fb94a99-c9a1-5cee-a86f-d90f16a2fd97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128a5be-ffa6-4998-8488-872d80b24cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128a5be-ffa6-4998-8488-872d80b24cb2.jpg?1",
             "name": "Elfsworn Giant",
             "text": "Reach (This creature can block creatures with flying.)\nLandfall \u2014 Whenever a land you control enters, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "880b41aa-ea48-5c53-a1ac-6778d40660b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2694e3cd-26ed-4a10-ae55-fb84d7800253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2694e3cd-26ed-4a10-ae55-fb84d7800253.jpg?1",
             "name": "Elvish Regrower",
             "text": "When this creature enters, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "22635d39-ec8b-534f-bd3c-6f71153e1991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96948ae3-b15d-4d6d-aa73-9f52084cd903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96948ae3-b15d-4d6d-aa73-9f52084cd903.jpg?1",
             "name": "Felling Blow",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "765fc4b1-421f-5a44-a298-fa101d2ca473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "fefd8be3-8253-598f-938d-4c44a090ebf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -3791,7 +3791,7 @@
         },
         {
             "id": "7eff95e7-d15b-575c-b65a-86d9b6df4db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c1679-e02b-44f2-b34e-12fd6b5142e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c1679-e02b-44f2-b34e-12fd6b5142e9.jpg?1",
             "name": "Needletooth Pack",
             "text": "Morbid \u2014 At the beginning of your end step, if a creature died this turn, put two +1/+1 counters on target creature you control.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "c2804779-4f95-51c5-b25f-f2e55f470c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb65189-60e4-42e0-9fb1-da6b716b91d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb65189-60e4-42e0-9fb1-da6b716b91d7.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "9cc580df-eede-5e20-9148-3d7d37c5a826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067f72c2-ead6-4879-bc9d-696c9f87c0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067f72c2-ead6-4879-bc9d-696c9f87c0b2.jpg?1",
             "name": "Quakestrider Ceratops",
             "text": "",
             "colours": [
@@ -3895,7 +3895,7 @@
         },
         {
             "id": "8d754d4e-e020-52e7-91d7-8d7457eae7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it. (It must survive to get the counters.)\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "e96c8eaf-27a4-5980-8765-67fa5155fa72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "9b3634b7-1517-501d-8a20-0ac82858eef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35b683c-d3b2-46a1-876a-81b34e8ba2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35b683c-d3b2-46a1-876a-81b34e8ba2fc.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "c157230e-551b-54ae-b1a5-a3f7c61a4907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e68fa3-159d-49a6-8ac6-afc9bd6f1718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e68fa3-159d-49a6-8ac6-afc9bd6f1718.jpg?1",
             "name": "Treetop Snarespinner",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{2}{G}: Put a +1/+1 counter on target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "9df9ba87-8740-52d9-b894-75437fecdaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e3406-4e29-4bc0-ae52-cbd2ac1f99a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e3406-4e29-4bc0-ae52-cbd2ac1f99a4.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "4d91a969-98eb-5e3f-8f8b-2d1ff7bb7a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe3a40-9cbe-4235-86f9-32576aaebba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe3a40-9cbe-4235-86f9-32576aaebba8.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "def8ce02-ce59-588e-b793-70c739fc1a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece147f-d71a-4c95-9fe5-f5c862ef14ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece147f-d71a-4c95-9fe5-f5c862ef14ac.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "1d75bb72-d5cf-5fe4-94e1-6cf6569b595d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d838b-ab48-410a-9a50-dbfea5da089b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d838b-ab48-410a-9a50-dbfea5da089b.jpg?1",
             "name": "Dreadwing Scavenger",
             "text": "Flying\nWhenever this creature enters or attacks, draw a card, then discard a card.\nThreshold \u2014 This creature gets +1/+1 and has deathtouch as long as there are seven or more cards in your graveyard.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "c54f7119-5c1c-5f5e-ba86-14da6ac96063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24955f5f-093c-4d33-b0c1-911cd36032ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24955f5f-093c-4d33-b0c1-911cd36032ce.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -4244,7 +4244,7 @@
         },
         {
             "id": "1bbbf5c2-4e97-519d-ada9-d58b4f5e6d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e434d74-cad0-45f5-bc8d-f34aa5e1d879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e434d74-cad0-45f5-bc8d-f34aa5e1d879.jpg?1",
             "name": "Fiendish Panda",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.\nWhen this creature dies, return another target non-Bear creature card with mana value less than or equal to this creature's power from your graveyard to the battlefield.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "089890db-60b4-5c24-a402-ce9633a1c699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b92caa-3401-4b11-9515-152f3e057c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b92caa-3401-4b11-9515-152f3e057c05.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "8318540e-9a05-5ae1-89a1-8ecd77ee2cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c980998-7124-4ec6-a0b6-e8d9a2364925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c980998-7124-4ec6-a0b6-e8d9a2364925.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -4366,7 +4366,7 @@
         },
         {
             "id": "82c132ce-0d38-57f8-9565-f63ad8dcbb2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69a618-d588-4745-8ede-0ff0a9f356f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69a618-d588-4745-8ede-0ff0a9f356f1.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "4d065588-13a8-5c05-9649-9a9cc9b6bd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72980409-53f0-43c1-965e-06f22e7bb608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72980409-53f0-43c1-965e-06f22e7bb608.jpg?1",
             "name": "Perforating Artist",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRaid \u2014 At the beginning of your end step, if you attacked this turn, each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card.",
             "colours": [
@@ -4445,7 +4445,7 @@
         },
         {
             "id": "4871ae10-f282-5a15-aea8-3ec1859f1af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea9b2c-5723-4eff-88ac-6669975939e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea9b2c-5723-4eff-88ac-6669975939e3.jpg?1",
             "name": "Wardens of the Cycle",
             "text": "Morbid \u2014 At the beginning of your end step, if a creature died this turn, choose one \u2014\n\u2022 You gain 2 life.\n\u2022 You draw a card and you lose 1 life.",
             "colours": [
@@ -4482,7 +4482,7 @@
         },
         {
             "id": "27f1a808-3914-54a1-bc3f-062001f2267e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ccbfdd-ddae-440c-9bc0-38b15a56fdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ccbfdd-ddae-440c-9bc0-38b15a56fdd1.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "5b9d3a69-ca99-52b1-a72f-ae9720bf76bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c16c0-4053-46b0-8fa6-be8b4a7a1c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c16c0-4053-46b0-8fa6-be8b4a7a1c8a.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "781255ab-74d2-5801-bf63-e16d63746171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95ab836-3277-4223-9aaa-ef2c77256b65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95ab836-3277-4223-9aaa-ef2c77256b65.jpg?1",
             "name": "Fishing Pole",
             "text": "Equipped creature has \"{1}, {T}, Tap Fishing Pole: Put a bait counter on Fishing Pole.\"\nWhenever equipped creature becomes untapped, remove a bait counter from this Equipment. If you do, create a 1/1 blue Fish creature token.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "88dd0c2c-5045-5b7d-85a6-65637cc84d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c03336-a321-4c06-94d1-809f328fabd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c03336-a321-4c06-94d1-809f328fabd8.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "05d9a955-cf8f-5473-9277-f5e8fc8681e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beec98-c89c-4673-953c-8b3ef3d81560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beec98-c89c-4673-953c-8b3ef3d81560.jpg?1",
             "name": "Quick-Draw Katana",
             "text": "During your turn, equipped creature gets +2/+0 and has first strike. (It deals combat damage before creatures without first strike.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "14197f0a-3a76-5583-879b-a0a27793c1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cadee5-6f26-4440-ad31-a8e573a90436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cadee5-6f26-4440-ad31-a8e573a90436.jpg?1",
             "name": "Ravenous Amulet",
             "text": "{1}, {T}, Sacrifice a creature: Draw a card and put a soul counter on this artifact. Activate only as a sorcery.\n{4}, {T}, Sacrifice this artifact: Each opponent loses life equal to the number of soul counters on this artifact.",
             "colours": [],
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "dcce3613-a77f-5521-ad36-1c3fea6bcae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1176dcf-40ee-4342-aa74-791b8352e99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1176dcf-40ee-4342-aa74-791b8352e99a.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -4715,7 +4715,7 @@
         },
         {
             "id": "573f754d-a5ff-5baa-86e8-bbc83345c837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642553a7-6d0f-483d-a873-3a703786db42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642553a7-6d0f-483d-a873-3a703786db42.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "8867b16d-e7a8-5b75-ba08-90ea76f2edd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59793f1c-8c7e-433e-9c09-40aa3ce931a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59793f1c-8c7e-433e-9c09-40aa3ce931a1.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n\u22123: Target creature gains flying and double strike until end of turn.\n\u22128: Create X 2/2 white Cat creature tokens, where X is your life total.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "07e7e965-ecc8-5533-b3b6-a2d5159263db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222c1a68-e34c-4103-b1be-17d4ceaef6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222c1a68-e34c-4103-b1be-17d4ceaef6ce.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.",
             "colours": [
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "3e2d47d0-e607-51e8-8cb3-bb36accc17f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaabd52-3aa9-4e2f-9369-d4db8b405ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaabd52-3aa9-4e2f-9369-d4db8b405ba8.jpg?1",
             "name": "Angel of Finality",
             "text": "Flying\nWhen this creature enters, exile target player's graveyard.",
             "colours": [
@@ -4857,7 +4857,7 @@
         },
         {
             "id": "2ca14c1f-2347-5ac8-82ac-e610e9bba806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ce2d7f-5924-47c0-b5ed-dacf9f9617a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ce2d7f-5924-47c0-b5ed-dacf9f9617a0.jpg?1",
             "name": "Authority of the Consuls",
             "text": "Creatures your opponents control enter tapped.\nWhenever a creature an opponent controls enters, you gain 1 life.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "4d998039-e580-50e3-b99a-b78d3f76bd9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38dc3b3-1629-491b-8afd-0e7a9a857713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38dc3b3-1629-491b-8afd-0e7a9a857713.jpg?1",
             "name": "Banishing Light",
             "text": "When this enchantment enters, exile target nonland permanent an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "3898d51d-0277-5621-86b7-d84ec537ecc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf024d-edb6-4a79-8676-73f8db0cdf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf024d-edb6-4a79-8676-73f8db0cdf1f.jpg?1",
             "name": "Cathar Commando",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\n{1}, Sacrifice this creature: Destroy target artifact or enchantment.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "4f00c3ce-f6b8-5a16-93b5-1477a8ec8e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e84bdc-8a9a-4c58-ba8b-9f052fd60069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e84bdc-8a9a-4c58-ba8b-9f052fd60069.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "c8ce1094-4857-5ea0-ac6e-e2767f097937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae6fc26-cfad-4da8-98d9-49c27c24d293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae6fc26-cfad-4da8-98d9-49c27c24d293.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "bb5fb4bc-c0b1-509a-9aee-925aed552554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8e4563-04bb-46b5-835e-64ba11c0e972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8e4563-04bb-46b5-835e-64ba11c0e972.jpg?1",
             "name": "Healer's Hawk",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -5064,7 +5064,7 @@
         },
         {
             "id": "9ed6bd6b-2f81-5036-8c62-fe6f5122e521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368f861-3288-4645-90a7-ca35d6da3721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368f861-3288-4645-90a7-ca35d6da3721.jpg?1",
             "name": "Make Your Move",
             "text": "Destroy target artifact, enchantment, or creature with power 4 or greater.",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "5ebf287a-abca-5158-a3a8-bb107c455437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7214d984-6400-44d7-bde6-57d96b606e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7214d984-6400-44d7-bde6-57d96b606e78.jpg?1",
             "name": "Mischievous Pup",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, return up to one other target permanent you control to its owner's hand.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "30c0b57a-bab2-5c50-b4ae-675dd10da7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f3989-77cc-49a9-92e0-095a75d80f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f3989-77cc-49a9-92e0-095a75d80f0f.jpg?1",
             "name": "Resolute Reinforcements",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -5165,7 +5165,7 @@
         },
         {
             "id": "2e03b095-937a-5d41-9ce0-9e8236c6b1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9ac1bc-cdf3-4fa6-8319-a7ea164e9e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9ac1bc-cdf3-4fa6-8319-a7ea164e9e47.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -5199,7 +5199,7 @@
         },
         {
             "id": "ff7b8ff2-3450-5cef-aeaf-6405123a92ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cee9303-9d65-45a2-93d4-ef4aba59141b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cee9303-9d65-45a2-93d4-ef4aba59141b.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -5233,7 +5233,7 @@
         },
         {
             "id": "0e1ca27b-f3a6-5186-8d37-e111bd449d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab135925-d924-456d-851a-6ccdaaf27271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab135925-d924-456d-851a-6ccdaaf27271.jpg?1",
             "name": "Stroke of Midnight",
             "text": "Destroy target nonland permanent. Its controller creates a 1/1 white Human creature token.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "4e558a82-adc2-562f-8781-92a8ac0ae9d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d795f79-c3a5-4ea1-a5cf-1ce73d6837b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d795f79-c3a5-4ea1-a5cf-1ce73d6837b6.jpg?1",
             "name": "Youthful Valkyrie",
             "text": "Flying\nWhenever another Angel you control enters, put a +1/+1 counter on this creature.",
             "colours": [
@@ -5301,7 +5301,7 @@
         },
         {
             "id": "dcad9bd7-8edb-578c-96b3-f5061528191f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f2014a-fbc9-447c-a440-e06d01066bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f2014a-fbc9-447c-a440-e06d01066bb9.jpg?1",
             "name": "Aegis Turtle",
             "text": "",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "2125df2b-3434-5e48-ab5a-765df3708bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5530fc-0291-4a17-b048-c5d24e6f51d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5530fc-0291-4a17-b048-c5d24e6f51d8.jpg?1",
             "name": "Aetherize",
             "text": "Return all attacking creatures to their owner's hand.",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "fe59d085-e709-569e-87a7-8632a4194c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7aafb-931f-49e5-8691-eab8cb34b05e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7aafb-931f-49e5-8691-eab8cb34b05e.jpg?1",
             "name": "Brineborn Cutthroat",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "9c13b10c-3943-5977-b953-93653d891981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd05c850-f91e-4ffb-b4cc-8418d49dad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd05c850-f91e-4ffb-b4cc-8418d49dad90.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "d01b97ff-de7e-572b-8de4-e78612444282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a41dfae-bc7e-4105-8f7e-fd0109197ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a41dfae-bc7e-4105-8f7e-fd0109197ad8.jpg?1",
             "name": "Extravagant Replication",
             "text": "At the beginning of your upkeep, create a token that's a copy of another target nonland permanent you control.",
             "colours": [
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "db7131df-7834-5b20-9fde-fff474bc4a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b86a7b-4912-43a7-ab89-c3432385baa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b86a7b-4912-43a7-ab89-c3432385baa1.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -5498,7 +5498,7 @@
         },
         {
             "id": "999838e6-8761-5567-af66-5d9182fe09aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28e147-6622-4399-a314-c14a5c912dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28e147-6622-4399-a314-c14a5c912dd0.jpg?1",
             "name": "Imprisoned in the Moon",
             "text": "Enchant creature, land, or planeswalker\nEnchanted permanent is a colorless land with \"{T}: Add {C}\" and loses all other card types and abilities.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "92b19767-1f40-5bb3-b6c3-8a8dff0ba1de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb75315c-ea8f-4eb0-899e-c73ef75fc396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb75315c-ea8f-4eb0-899e-c73ef75fc396.jpg?1",
             "name": "Lightshell Duo",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -5567,7 +5567,7 @@
         },
         {
             "id": "cfccf86f-cc31-5231-82e6-88208119d8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6af54ea-b57a-4e50-8e46-1747cca14430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6af54ea-b57a-4e50-8e46-1747cca14430.jpg?1",
             "name": "Micromancer",
             "text": "When this creature enters, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "64fe199e-239e-517e-8b9b-bcbae7400cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6792f63-b651-497d-8aa5-cddf4cedeca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6792f63-b651-497d-8aa5-cddf4cedeca8.jpg?1",
             "name": "Mocking Sprite",
             "text": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "861ec992-f416-5138-a584-b6d11a87db94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a829747f-cf9b-4d81-ba66-9f0630ed4565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a829747f-cf9b-4d81-ba66-9f0630ed4565.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -5671,7 +5671,7 @@
         },
         {
             "id": "80e05035-5fab-5b73-acf2-df7f472e5d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d91d0-1506-45e4-9def-975bf901815e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d91d0-1506-45e4-9def-975bf901815e.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -5706,7 +5706,7 @@
         },
         {
             "id": "d8147e74-424f-5ef0-a155-2405c88481e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e598eb7b-10dc-49e6-ac60-2fefa987173e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e598eb7b-10dc-49e6-ac60-2fefa987173e.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "5440efd0-cb6f-5716-b54c-7cbfcda34616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e6abc9-25b2-4d51-b519-2525079eab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e6abc9-25b2-4d51-b519-2525079eab51.jpg?1",
             "name": "Self-Reflection",
             "text": "Create a token that's a copy of target creature you control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "782b2591-5045-5147-9d66-cd545666c8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a49535-c5f3-4a6f-b333-7ac7bffdc9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a49535-c5f3-4a6f-b333-7ac7bffdc9ae.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -5805,7 +5805,7 @@
         },
         {
             "id": "b9258cf8-55c5-50fd-a1e7-2d96da26978e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88faaa1-eb41-40f7-991c-5c06e1138f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88faaa1-eb41-40f7-991c-5c06e1138f3d.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5841,7 +5841,7 @@
         },
         {
             "id": "769baa76-524e-531a-9bbd-0c95270af172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d938603b-0f1e-44c4-b86e-38e15f4a0d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d938603b-0f1e-44c4-b86e-38e15f4a0d27.jpg?1",
             "name": "Time Stop",
             "text": "End the turn. (Exile all spells and abilities, including this spell. The player whose turn it is discards down to their maximum hand size. Damage heals and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "99197ef0-3841-5744-956d-e0c552720bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569d4f3-55ed-4f99-9592-34c7df0aab72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569d4f3-55ed-4f99-9592-34c7df0aab72.jpg?1",
             "name": "Tolarian Terror",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "cf9e44c8-ea46-5f0d-9119-52d15200f06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231e981-0069-43ce-ac1c-c85ced613e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231e981-0069-43ce-ac1c-c85ced613e93.jpg?1",
             "name": "Witness Protection",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a green and white Citizen creature with base power and toughness 1/1 named Legitimate Businessperson. (It loses all other colors, card types, creature types, and names.)",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "b1f70c23-9846-53be-a574-f40a15e698e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab0e660-86a3-4b92-82fa-77dcb5db947d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab0e660-86a3-4b92-82fa-77dcb5db947d.jpg?1",
             "name": "Bake into a Pie",
             "text": "Destroy target creature. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
             "colours": [
@@ -5973,7 +5973,7 @@
         },
         {
             "id": "0026b9a2-e2f8-5c3d-bef2-d698955a74e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c8758-ce3d-49cf-8173-c0eb46f5e7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c8758-ce3d-49cf-8173-c0eb46f5e7bc.jpg?1",
             "name": "Burglar Rat",
             "text": "When this creature enters, each opponent discards a card.",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "b3609a7f-41c5-5e01-ad27-95d9d6babed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4682012c-d7e0-4257-b538-3de497507464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4682012c-d7e0-4257-b538-3de497507464.jpg?1",
             "name": "Diregraf Ghoul",
             "text": "This creature enters tapped.",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "86c0d20a-b5be-535f-a893-016281c6e502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f7b20-b2a8-498c-8c36-dc296863b0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f7b20-b2a8-498c-8c36-dc296863b0b9.jpg?1",
             "name": "Eaten Alive",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nExile target creature or planeswalker.",
             "colours": [
@@ -6073,7 +6073,7 @@
         },
         {
             "id": "ed7699a2-cd3d-55fa-9f96-ed5d37795652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11d7311-4066-4a5d-ba28-9857fa707a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11d7311-4066-4a5d-ba28-9857fa707a0b.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "0058c59f-1948-568d-80d6-a35ac7381c62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693635a6-df50-44c5-9598-0c79b45d4df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693635a6-df50-44c5-9598-0c79b45d4df4.jpg?1",
             "name": "Fake Your Own Death",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control and you create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "4ee883ed-faca-51ec-b4d8-4aa7a4ad4b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c01d9-8f54-46c0-9dc9-d4d4764ce1c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c01d9-8f54-46c0-9dc9-d4d4764ce1c9.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "f9e2074c-269f-5e4c-ad19-9fcf23efbab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28d217-795e-4320-a032-cd713f7ecc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28d217-795e-4320-a032-cd713f7ecc8a.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures of their choice.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "44fb19b7-d696-50fc-8975-bfeccdc71a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1f3c84-89ba-4426-a80b-d524f172c912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1f3c84-89ba-4426-a80b-d524f172c912.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -6242,7 +6242,7 @@
         },
         {
             "id": "9a5acce6-55df-526e-aee8-2331b03cc338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f70dafc-c638-4ec0-ab5b-62998f752720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f70dafc-c638-4ec0-ab5b-62998f752720.jpg?1",
             "name": "Marauding Blight-Priest",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -6277,7 +6277,7 @@
         },
         {
             "id": "fad5d3e9-cb89-5ec2-8b0a-003398fdae02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05757669-e8a6-4a2f-8479-d4e2ade822ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05757669-e8a6-4a2f-8479-d4e2ade822ca.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless they discard a card.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "66ced0b1-e261-5a8d-a681-3b071921a940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0784b6f0-9ebf-43d2-ba0f-a6bc93ba0c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0784b6f0-9ebf-43d2-ba0f-a6bc93ba0c48.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "18761f76-86df-58e4-ad50-564fc9857c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7c88b5-6d09-453b-b9c1-7dcbba8f1080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7c88b5-6d09-453b-b9c1-7dcbba8f1080.jpg?1",
             "name": "Pilfer",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "00dec49b-3df4-5c26-a18d-3b48e577b5f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e84b1b-1c05-4e1b-93b8-9cc2ca73509d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e84b1b-1c05-4e1b-93b8-9cc2ca73509d.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return this card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6412,7 +6412,7 @@
         },
         {
             "id": "47d3d28c-b318-5d2a-8998-6b0286adf115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8645bf0c-631f-4003-bd24-3e069ae23513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8645bf0c-631f-4003-bd24-3e069ae23513.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "e47115ab-bbd3-59bd-98c5-03967f5b75fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae3165-554d-4759-8f18-794e2a7d8464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae3165-554d-4759-8f18-794e2a7d8464.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen this creature enters, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -6481,7 +6481,7 @@
         },
         {
             "id": "fe39828e-8601-5395-b7d7-6bb1d0d51ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485d6a5a-2054-47d5-91b8-71ce308ed4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485d6a5a-2054-47d5-91b8-71ce308ed4dc.jpg?1",
             "name": "Stromkirk Bloodthief",
             "text": "At the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on target Vampire you control.",
             "colours": [
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "672d1d6f-78f8-5e24-84bb-8d985aea5645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1934ab-3171-4fc6-8033-ad998899ba73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1934ab-3171-4fc6-8033-ad998899ba73.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -6551,7 +6551,7 @@
         },
         {
             "id": "dce4dfc8-5ffa-5d76-9642-86a30e25fc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc798e6f-13c4-457c-b052-b7b65bc83cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc798e6f-13c4-457c-b052-b7b65bc83cfe.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "9f288880-e42f-54ae-922b-d78df931e36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548947dc-a5ca-43b5-9531-bcef20fa4ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548947dc-a5ca-43b5-9531-bcef20fa4ae5.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "280fd6ca-591a-566a-8d93-e0e46b83c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3cc41a-adae-4c9b-b4d3-03f3ca862fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3cc41a-adae-4c9b-b4d3-03f3ca862fed.jpg?1",
             "name": "Axgard Cavalry",
             "text": "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "beed527f-6368-5295-8fd5-b604b2536861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fe7127-b0ec-400f-97f1-6e17ab8e319d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fe7127-b0ec-400f-97f1-6e17ab8e319d.jpg?1",
             "name": "Brass's Bounty",
             "text": "For each land you control, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "fbee614d-e4f3-5dc8-9d6b-bc97f26b60b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84b86c-3276-4fc1-a09d-47de388cb729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84b86c-3276-4fc1-a09d-47de388cb729.jpg?1",
             "name": "Brazen Scourge",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -6718,7 +6718,7 @@
         },
         {
             "id": "5714ba1e-1b5a-5d7e-9fb5-58150425ea44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec5d380-d354-4750-931a-6c91853e2edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec5d380-d354-4750-931a-6c91853e2edc.jpg?1",
             "name": "Burst Lightning",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to any target. If this spell was kicked, it deals 4 damage instead.",
             "colours": [
@@ -6750,7 +6750,7 @@
         },
         {
             "id": "d99c0e22-484a-56bf-ae58-f2434ea46989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b1edb-e1de-4f1c-81df-8d17f4920318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b1edb-e1de-4f1c-81df-8d17f4920318.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -6786,7 +6786,7 @@
         },
         {
             "id": "6c7ec352-c9cd-5dc7-a74e-86175f9028a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6af9894-95b5-4c8e-902f-a9ba70f02e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6af9894-95b5-4c8e-902f-a9ba70f02e4a.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "a323bcc9-4858-55dd-b49e-4dc08816c7d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1296316-7781-4e98-95e6-7020648be6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1296316-7781-4e98-95e6-7020648be6a5.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}, Sacrifice this creature: It deals 1 damage to any target.",
             "colours": [
@@ -6861,7 +6861,7 @@
         },
         {
             "id": "3a0b1966-0bd7-574b-b6b5-bc99946707f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0312f1-4c98-4b7f-8a34-0059ea80edef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0312f1-4c98-4b7f-8a34-0059ea80edef.jpg?1",
             "name": "Firebrand Archer",
             "text": "Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "7935aa79-8e14-500c-b7f4-a48713598e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a4c7d-3126-4bde-9dca-cb6a1e2f37c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a4c7d-3126-4bde-9dca-cb6a1e2f37c9.jpg?1",
             "name": "Firespitter Whelp",
             "text": "Flying\nWhenever you cast a noncreature or Dragon spell, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "379311e6-d2af-5723-b42d-c67e3892a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f008e-48a0-406b-83fa-99cd396831f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f008e-48a0-406b-83fa-99cd396831f8.jpg?1",
             "name": "Flamewake Phoenix",
             "text": "Flying, haste\nThis creature attacks each combat if able.\nAt the beginning of combat on your turn, if you control a creature with power 4 or greater, you may pay {R}. If you do, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "836b6067-c6f1-54bf-bc7d-9513bab8f267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592573-2889-40b1-b1d5-c2802482549a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592573-2889-40b1-b1d5-c2802482549a.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever this creature attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -6999,7 +6999,7 @@
         },
         {
             "id": "bb08b36d-fe2b-5ee2-98a4-640bd099d688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e.jpg?1",
             "name": "Goblin Surprise",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -7031,7 +7031,7 @@
         },
         {
             "id": "72524102-acf4-5c0c-8e78-7ab16f47aa1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca38f4d-01f5-4a02-9000-01261a440dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca38f4d-01f5-4a02-9000-01261a440dbf.jpg?1",
             "name": "Heartfire Immolator",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{R}, Sacrifice this creature: It deals damage equal to its power to target creature or planeswalker.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "c70d0bf4-de34-51aa-b5f1-1b7cbaab6cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609421da-8d89-4365-b18b-778832d91482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609421da-8d89-4365-b18b-778832d91482.jpg?1",
             "name": "Hidetsugu's Second Rite",
             "text": "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "72d323b6-606b-5535-8b94-43bc0a576bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad3d62-2f24-4562-b3fa-809213dbc4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad3d62-2f24-4562-b3fa-809213dbc4a4.jpg?1",
             "name": "Involuntary Employment",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -7130,7 +7130,7 @@
         },
         {
             "id": "3e788340-1f6f-5329-84e7-f8fe9c59c8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824b2d73-2151-4e5e-9f05-8f63e2bdcaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824b2d73-2151-4e5e-9f05-8f63e2bdcaa9.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -7167,7 +7167,7 @@
         },
         {
             "id": "f8b60b98-baab-5164-9471-5c80bba19257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519a51a-26a0-4884-9ba8-9db135c9ee49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519a51a-26a0-4884-9ba8-9db135c9ee49.jpg?1",
             "name": "Seismic Rupture",
             "text": "Seismic Rupture deals 2 damage to each creature without flying.",
             "colours": [
@@ -7199,7 +7199,7 @@
         },
         {
             "id": "fcb73a3f-8d66-5136-bf6b-e7bce48a85ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcff1e0-2745-448d-a27b-e31719e222e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcff1e0-2745-448d-a27b-e31719e222e9.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: This creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "f3e1b6ea-9876-5f82-af30-68faa0a90f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0.jpg?1",
             "name": "Slagstorm",
             "text": "Choose one \u2014\n\u2022 Slagstorm deals 3 damage to each creature.\n\u2022 Slagstorm deals 3 damage to each player.",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "d71e8b3a-bd6e-5b17-a087-728717e2e9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f600cd-b696-4f49-9cbc-5a33aa43d04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f600cd-b696-4f49-9cbc-5a33aa43d04c.jpg?1",
             "name": "Spitfire Lagac",
             "text": "Landfall \u2014 Whenever a land you control enters, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -7299,7 +7299,7 @@
         },
         {
             "id": "1c22a3a8-a478-53c0-8ae6-82ad92727e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de6a1e4-5c66-43e6-9f2a-2635bdab03f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de6a1e4-5c66-43e6-9f2a-2635bdab03f6.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "9779bd6a-8e06-5038-8419-b2bdb810714a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b348c-076b-41d8-b505-063480636669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b348c-076b-41d8-b505-063480636669.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "1f83bbd4-9ce6-5028-ba0d-bb2bee72c0b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8347d-06a4-46e0-a55e-cc2da4660263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8347d-06a4-46e0-a55e-cc2da4660263.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When this creature enters, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "f29559f8-bbe0-5428-9c8d-0e4213838629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d70b3b-f6f9-4b3c-ad70-0ce369e812b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d70b3b-f6f9-4b3c-ad70-0ce369e812b5.jpg?1",
             "name": "Bite Down",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7429,7 +7429,7 @@
         },
         {
             "id": "b0979c34-a084-5e0d-b840-daf459a844b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd7ec1a-dafa-42ca-bc25-f6848fb03f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd7ec1a-dafa-42ca-bc25-f6848fb03f60.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "b0b93d80-8fae-5be3-b302-5598bf2103b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f9cbeb-cc9c-4562-be65-8a77053faefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f9cbeb-cc9c-4562-be65-8a77053faefe.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -7495,7 +7495,7 @@
         },
         {
             "id": "7d0f68ef-cc8b-56f7-85d7-ce4d62bbbc13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ebdb36-55e0-49dd-a514-785fbeb4ae19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ebdb36-55e0-49dd-a514-785fbeb4ae19.jpg?1",
             "name": "Bushwhack",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n\u2022 Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7527,7 +7527,7 @@
         },
         {
             "id": "0c609e6f-a2e6-586c-8220-52c172de9da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c4f80e-84a0-463b-82c3-5c6503809351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c4f80e-84a0-463b-82c3-5c6503809351.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "e1438cba-8708-5da0-b38a-9ddbbcf6d0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c00d7b-7fac-4f8c-a1ea-de2cf4d06627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c00d7b-7fac-4f8c-a1ea-de2cf4d06627.jpg?1",
             "name": "Dwynen, Gilt-Leaf Daen",
             "text": "Reach (This creature can block creatures with flying.)\nOther Elf creatures you control get +1/+1.\nWhenever Dwynen attacks, you gain 1 life for each attacking Elf you control.",
             "colours": [
@@ -7599,7 +7599,7 @@
         },
         {
             "id": "856703c6-99f7-53e9-827f-eee7254d4bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d94c28-ea2e-4a3d-935f-6b2d9f2efc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d94c28-ea2e-4a3d-935f-6b2d9f2efc7a.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When this creature enters, if you control another Elf, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "cc3c3154-566c-581b-85c1-21f091c9c382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341da856-7414-403b-b2e3-4bebd58a5aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341da856-7414-403b-b2e3-4bebd58a5aa4.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} for each Elf you control.",
             "colours": [
@@ -7669,7 +7669,7 @@
         },
         {
             "id": "92898aba-637b-5bf9-9d27-40633eb11dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805c303-e73b-443b-a09f-49d2c2c88bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805c303-e73b-443b-a09f-49d2c2c88bb5.jpg?1",
             "name": "Garruk's Uprising",
             "text": "When this enchantment enters, if you control a creature with power 4 or greater, draw a card.\nCreatures you control have trample. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever a creature you control with power 4 or greater enters, draw a card.",
             "colours": [
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "49bfd3a9-f10f-5181-96bb-31e1b61f2124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f7ddb-f986-4f1f-b096-ae1a02d0bdc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f7ddb-f986-4f1f-b096-ae1a02d0bdc8.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -7736,7 +7736,7 @@
         },
         {
             "id": "1606bfd8-3f01-5c04-ab2b-806058523f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9c39e4-a8cf-42dd-8d0e-45634b335546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9c39e4-a8cf-42dd-8d0e-45634b335546.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "ec350655-b736-53b4-a7ed-85560b791cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf74e-14c1-4428-88d8-2181a080b5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf74e-14c1-4428-88d8-2181a080b5d0.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "24b330da-643f-5c73-af39-83bfd478153a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47565d10-96bf-4fb0-820f-f20a44a76b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47565d10-96bf-4fb0-820f-f20a44a76b6f.jpg?1",
             "name": "Gnarlid Colony",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nIf this creature was kicked, it enters with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7842,7 +7842,7 @@
         },
         {
             "id": "5b9584f4-7202-52fa-868e-c8aeb0f7579d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42525f8a-aee7-4811-8f05-471b559c2c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42525f8a-aee7-4811-8f05-471b559c2c4a.jpg?1",
             "name": "Grow from the Ashes",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nSearch your library for a basic land card, put it onto the battlefield, then shuffle. If this spell was kicked, instead search your library for two basic land cards, put them onto the battlefield, then shuffle.",
             "colours": [
@@ -7874,7 +7874,7 @@
         },
         {
             "id": "fd4049f5-a1f6-555b-b965-9c9bdebb0b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e241642-5172-4437-b694-f6aa159d5cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e241642-5172-4437-b694-f6aa159d5cd9.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -7906,7 +7906,7 @@
         },
         {
             "id": "1650c6e0-3ab7-5e71-a4bd-2483134076bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0b230b-d391-4998-a3f7-7b158a0ec2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0b230b-d391-4998-a3f7-7b158a0ec2cd.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "bbafe5df-71c8-5059-a7bd-408222eba716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5389663a-fe25-41b9-8c92-1f4d7721ffc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5389663a-fe25-41b9-8c92-1f4d7721ffc2.jpg?1",
             "name": "Mild-Mannered Librarian",
             "text": "{3}{G}: This creature becomes a Werewolf. Put two +1/+1 counters on it and you draw a card. Activate only once.",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "0d85ba9a-8f56-5ddd-a99c-0203fd81d694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d93de-85c6-4653-8ddd-d8bf21516d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d93de-85c6-4653-8ddd-d8bf21516d44.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on this creature.",
             "colours": [
@@ -8012,7 +8012,7 @@
         },
         {
             "id": "35bcb87c-69d7-5e8a-97d8-e810f866177d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8e9cbb-8bf4-4a48-a58e-79deb3abdf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8e9cbb-8bf4-4a48-a58e-79deb3abdf7f.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -8044,7 +8044,7 @@
         },
         {
             "id": "e952bab9-74d9-5184-8fb3-41af633076d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1918ea65-ab7f-4d40-97fd-a656c892a2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1918ea65-ab7f-4d40-97fd-a656c892a2a1.jpg?1",
             "name": "Reclamation Sage",
             "text": "When this creature enters, you may destroy target artifact or enchantment.",
             "colours": [
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "1e6f1167-9dbf-58b8-a7aa-86b1e1f655e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504c23-1e9a-411b-9cfe-4180d0c744f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504c23-1e9a-411b-9cfe-4180d0c744f6.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on this creature and you gain 1 life.",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "6ffda4af-33ff-5b4f-aaa8-b300f84df0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4c21d-9bdc-4490-9203-17f51db0ddd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4c21d-9bdc-4490-9203-17f51db0ddd1.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -8147,7 +8147,7 @@
         },
         {
             "id": "8c6baf50-15fa-55b9-9cc0-8e2fd6b4098e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38769247-42a1-4571-9071-6d59fe28650a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38769247-42a1-4571-9071-6d59fe28650a.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -8186,7 +8186,7 @@
         },
         {
             "id": "6291cf06-55c7-5d6b-baac-c9ee7ea38b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d62d04-0974-4cb5-9a35-5e996c6456e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d62d04-0974-4cb5-9a35-5e996c6456e2.jpg?1",
             "name": "Wary Thespian",
             "text": "When this creature enters or dies, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -8221,7 +8221,7 @@
         },
         {
             "id": "67a8461d-c1ef-50ac-947d-56e789c3d1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36359fb6-fb8c-4382-8555-e348422f116c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36359fb6-fb8c-4382-8555-e348422f116c.jpg?1",
             "name": "Wildwood Scourge",
             "text": "This creature enters with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on this creature.",
             "colours": [
@@ -8255,7 +8255,7 @@
         },
         {
             "id": "5043fbee-81bd-551d-9f2a-2e69d398c7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b45ab13-9bb6-48af-8b37-d97b25801ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b45ab13-9bb6-48af-8b37-d97b25801ac8.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "6bb47321-7f25-5e7a-9b13-0ade37f3cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2b28fd-66b0-457c-80ea-7caed2cc7926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2b28fd-66b0-457c-80ea-7caed2cc7926.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -8330,7 +8330,7 @@
         },
         {
             "id": "092f0078-d6d0-522a-aa9c-7ec4d1dc7058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577e99a7-4a55-4314-8f08-2ae0c33b85c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577e99a7-4a55-4314-8f08-2ae0c33b85c7.jpg?1",
             "name": "Empyrean Eagle",
             "text": "Flying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "769b68d9-5ef0-523c-9464-7de7db1e8d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabbe163-2b15-42e3-89ce-7363e6250d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabbe163-2b15-42e3-89ce-7363e6250d3a.jpg?1",
             "name": "Good-Fortune Unicorn",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on that creature.",
             "colours": [
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "549bd4d6-ec04-52b8-8254-79fac8572a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a05e8d5-c2ad-489a-888d-22622886b620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a05e8d5-c2ad-489a-888d-22622886b620.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste. (They can attack and {T} this turn.)",
             "colours": [
@@ -8437,7 +8437,7 @@
         },
         {
             "id": "def5bb0f-5706-5b75-b605-4ca34966cedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e5480-a287-4a25-b855-a26dae555b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e5480-a287-4a25-b855-a26dae555b1c.jpg?1",
             "name": "Lathril, Blade of the Elves",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Lathril deals combat damage to a player, create that many 1/1 green Elf Warrior creature tokens.\n{T}, Tap ten untapped Elves you control: Each opponent loses 10 life and you gain 10 life.",
             "colours": [
@@ -8479,7 +8479,7 @@
         },
         {
             "id": "1bb2562f-d7ef-56e6-baac-73bb4a798bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51710b19-68e3-4853-901f-e618bde61161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51710b19-68e3-4853-901f-e618bde61161.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "27d64304-575a-5941-a7b7-827ebe19d22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77fbc87-d78e-4602-baa0-da9b0d464dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77fbc87-d78e-4602-baa0-da9b0d464dfb.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "01a67c48-2ba1-55ba-aee9-8f0ad4ccf5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e7dd2-b66d-4218-9fde-f84bec26b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e7dd2-b66d-4218-9fde-f84bec26b7bf.jpg?1",
             "name": "Ruby, Daring Tracker",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever Ruby attacks while you control a creature with power 4 or greater, Ruby gets +2/+2 until end of turn.\n{T}: Add {R} or {G}.",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "0369b369-a4ac-54c5-8317-5ba92b671ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94618ec-000c-4371-b925-05ff82bfe221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94618ec-000c-4371-b925-05ff82bfe221.jpg?1",
             "name": "Swiftblade Vindicator",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nVigilance (Attacking doesn't cause this creature to tap.)\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "6270c594-3828-5c25-a691-bd4b1be4b5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc978a-0666-472d-bdc6-d4b29d29eca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc978a-0666-472d-bdc6-d4b29d29eca4.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land you control enters, you gain 1 life and draw a card.",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "13075021-4a8d-5d12-9107-d8b024f5617c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c48a67-1410-40f1-9b93-0172d85e4688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c48a67-1410-40f1-9b93-0172d85e4688.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "cf260592-0390-520c-8aaf-97653a061c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361f9b99-5b5d-40da-b4b9-5ad90f6280ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361f9b99-5b5d-40da-b4b9-5ad90f6280ee.jpg?1",
             "name": "Adventuring Gear",
             "text": "Landfall \u2014 Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "90823c89-4af3-5108-89e9-26b631c07dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ebbff0-fbe6-4310-a33f-e00bb2534979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ebbff0-fbe6-4310-a33f-e00bb2534979.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice this creature: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "e027f4fc-37c6-54af-9f57-db18afbdd3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c59814-3167-4b05-bb85-6c736f3956a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c59814-3167-4b05-bb85-6c736f3956a4.jpg?1",
             "name": "Campus Guide",
             "text": "When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -8812,7 +8812,7 @@
         },
         {
             "id": "931c37e5-efd4-511d-8506-10a1852a7150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49b009-e6f2-494a-9235-f5c25c2d70a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49b009-e6f2-494a-9235-f5c25c2d70a9.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [],
@@ -8843,7 +8843,7 @@
         },
         {
             "id": "18314580-94e5-51e1-870c-8c697fb66003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a241317d-2277-467e-a8f9-aa71c944e244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a241317d-2277-467e-a8f9-aa71c944e244.jpg?1",
             "name": "Goldvein Pick",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "c81b9315-3cae-5081-a05a-dbe52ca07fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743ea709-dbb3-4db8-a2ce-544f47eb6339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743ea709-dbb3-4db8-a2ce-544f47eb6339.jpg?1",
             "name": "Heraldic Banner",
             "text": "As this artifact enters, choose a color.\nCreatures you control of the chosen color get +1/+0.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -8901,7 +8901,7 @@
         },
         {
             "id": "a9c74785-4978-507e-86a0-762af0598777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4468fff-cd6f-428c-b7a0-ff89f5bbea2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4468fff-cd6f-428c-b7a0-ff89f5bbea2e.jpg?1",
             "name": "Juggernaut",
             "text": "This creature attacks each combat if able.\nThis creature can't be blocked by Walls.",
             "colours": [],
@@ -8932,7 +8932,7 @@
         },
         {
             "id": "925cec9b-e266-560f-801c-e73adb72b19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291ea1e-36bc-46b3-b3ae-084fa0ba69eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291ea1e-36bc-46b3-b3ae-084fa0ba69eb.jpg?1",
             "name": "Meteor Golem",
             "text": "When this creature enters, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -8963,7 +8963,7 @@
         },
         {
             "id": "6fb69167-3ae7-55df-82b6-3d4dadf3a38d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383f45e-3da2-40fb-beee-801448bbb60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383f45e-3da2-40fb-beee-801448bbb60f.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When this creature enters, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen this creature dies, you may draw a card.",
             "colours": [],
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "28df17d7-72c6-5a97-961d-ae14cbaf0650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41040541-b129-4cf4-9411-09b1d9d32c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41040541-b129-4cf4-9411-09b1d9d32c19.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control. It can attack and {T} no matter when it came under your control.)\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9028,7 +9028,7 @@
         },
         {
             "id": "fb37ca76-d139-58bb-8801-2e8283640c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b90dc92-cb66-41d9-89f9-2b6e3cfc8082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b90dc92-cb66-41d9-89f9-2b6e3cfc8082.jpg?1",
             "name": "Bloodfell Caves",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9059,7 +9059,7 @@
         },
         {
             "id": "d2885538-8a01-5740-99c4-391cc559cc6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37676ed8-588c-4bca-8065-874b74d84807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37676ed8-588c-4bca-8065-874b74d84807.jpg?1",
             "name": "Blossoming Sands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9090,7 +9090,7 @@
         },
         {
             "id": "ae6c46f8-c255-5237-8c60-e358cf80722e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb0df36-8467-4a41-8e1c-6c3584d4fd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb0df36-8467-4a41-8e1c-6c3584d4fd10.jpg?1",
             "name": "Dismal Backwater",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "861df981-8c3c-5f2c-a7d2-64c113d69f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9356-5b91-4542-8802-f0f7275238e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9356-5b91-4542-8802-f0f7275238e1.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9149,7 +9149,7 @@
         },
         {
             "id": "5eceeacc-92cc-5c58-85d9-437553042dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc758e14-d370-45e4-bbc5-938fb4d21127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc758e14-d370-45e4-bbc5-938fb4d21127.jpg?1",
             "name": "Jungle Hollow",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9180,7 +9180,7 @@
         },
         {
             "id": "b84ab312-34ca-5fd6-a7a3-81983f60268d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a424ea-ef32-4ac5-8f8c-3ea1839f01d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a424ea-ef32-4ac5-8f8c-3ea1839f01d4.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -9208,7 +9208,7 @@
         },
         {
             "id": "aed8fc71-6827-599c-a135-a121bf6b9de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6eaf8e-8881-4d7b-bafc-75e4ca5cbef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6eaf8e-8881-4d7b-bafc-75e4ca5cbef6.jpg?1",
             "name": "Rugged Highlands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "8d79cb33-5622-5627-b165-18437fafeacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2632a4b2-9ca6-4b67-9a99-14f52ad3dc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2632a4b2-9ca6-4b67-9a99-14f52ad3dc41.jpg?1",
             "name": "Scoured Barrens",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9270,7 +9270,7 @@
         },
         {
             "id": "66c5e01e-8337-5558-b7c1-aeb9c96e49ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13373d2-139b-48c7-a8c9-828cefc4f150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13373d2-139b-48c7-a8c9-828cefc4f150.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As this land enters, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature source of the chosen type.",
             "colours": [],
@@ -9298,7 +9298,7 @@
         },
         {
             "id": "bdcc2da8-673a-509b-8985-dec3db90bddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88667d-7088-4889-960f-317486ebe856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88667d-7088-4889-960f-317486ebe856.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "49835ac8-1aa7-5025-ae57-88d259ce82f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42799f51-0f8c-444b-974e-dae281a5c697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42799f51-0f8c-444b-974e-dae281a5c697.jpg?1",
             "name": "Thornwood Falls",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9360,7 +9360,7 @@
         },
         {
             "id": "f1ce5c3b-ee79-509e-a3cb-1915458c303c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9cabca-5bcc-4b97-b2ac-a345ad3ee43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9cabca-5bcc-4b97-b2ac-a345ad3ee43c.jpg?1",
             "name": "Tranquil Cove",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9391,7 +9391,7 @@
         },
         {
             "id": "7e8f128c-0f48-58ef-8861-11956f964876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759e99df-11a8-4aee-b6bc-344e84e10d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759e99df-11a8-4aee-b6bc-344e84e10d94.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9422,7 +9422,7 @@
         },
         {
             "id": "522c1064-48c5-5533-a5f5-94bfbd8b4270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef17ed4-a9b5-4b8e-b4cb-2ecb7e5898c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef17ed4-a9b5-4b8e-b4cb-2ecb7e5898c3.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9460,7 +9460,7 @@
         },
         {
             "id": "fd38849f-006a-503e-be35-f7f26c7c5792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37edc4b5-75f5-4b43-a57e-a8192565a2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37edc4b5-75f5-4b43-a57e-a8192565a2a0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9498,7 +9498,7 @@
         },
         {
             "id": "11b33d79-95c0-511e-aa05-d367ee5cbff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e2b637-72b1-4457-aaba-66d51107be4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e2b637-72b1-4457-aaba-66d51107be4c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "90fded18-4d90-55c5-90b5-6a70f341f12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23635e40-d040-40b7-8b98-90ed362aa028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23635e40-d040-40b7-8b98-90ed362aa028.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "e315449b-6d8a-51c4-9dfe-f36ffe4b1e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319bc1f0-ee42-44e5-b08b-735613ded2ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319bc1f0-ee42-44e5-b08b-735613ded2ba.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9612,7 +9612,7 @@
         },
         {
             "id": "42ee61fd-b275-5813-877b-24715c590d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505c15-14e0-4200-82bd-fb9bce949e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505c15-14e0-4200-82bd-fb9bce949e68.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "083a5b53-5e60-5885-9f51-08d3ee19eab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279df7e2-2a3b-464a-a7df-e91da28e3a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279df7e2-2a3b-464a-a7df-e91da28e3a8c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "d95e58a5-2f67-59b0-be71-8da454a2a869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc5050-69bd-416d-b04c-7f82de2a1901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc5050-69bd-416d-b04c-7f82de2a1901.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9726,7 +9726,7 @@
         },
         {
             "id": "85b7201c-9329-575e-b3d2-a610493dd6fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d232fcc2-12f6-401a-b1aa-ddff11cb9378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d232fcc2-12f6-401a-b1aa-ddff11cb9378.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9764,7 +9764,7 @@
         },
         {
             "id": "1faa9e62-8ce1-5c5a-ac34-9639aca3f7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8affbb-d2a2-436b-bbc2-9e8b6cf0d2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8affbb-d2a2-436b-bbc2-9e8b6cf0d2c4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9802,7 +9802,7 @@
         },
         {
             "id": "b8bb403e-8178-5254-a13a-1ffb876307bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6f19b3-4c76-4078-8ed2-b2832a33d066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6f19b3-4c76-4078-8ed2-b2832a33d066.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "aaaa5c45-e9f4-5e5c-a22a-51e720a9e25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0f9892-89cd-46ff-bc87-114e175cb575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0f9892-89cd-46ff-bc87-114e175cb575.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9878,7 +9878,7 @@
         },
         {
             "id": "ccd7d78d-c8b2-5b93-833e-e148274c7446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886eae6e-ced2-4d94-96fa-9bb5385b06f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886eae6e-ced2-4d94-96fa-9bb5385b06f4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "d0cc9ee9-067a-5f02-abd0-7bd690650692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f534ddc-f610-45cd-84dc-bb6df6c5a84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f534ddc-f610-45cd-84dc-bb6df6c5a84f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "8e6343b2-c503-537c-89b2-09cbf90df0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f23a73a-522b-40cf-a14b-ffdf47a24c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f23a73a-522b-40cf-a14b-ffdf47a24c01.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9992,7 +9992,7 @@
         },
         {
             "id": "dc9161df-5d88-5705-b11a-de2ab77aa5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda1dbfa-a57b-4aa8-9993-c8f97aec28bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda1dbfa-a57b-4aa8-9993-c8f97aec28bb.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10030,7 +10030,7 @@
         },
         {
             "id": "da6bb75b-16ed-507f-9d66-6eb0e20be081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3afd00-da06-4a9f-8cd1-7133728e0fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3afd00-da06-4a9f-8cd1-7133728e0fdd.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "8277604e-aad1-53a3-8c17-b042de999dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b04b4-f7f4-4c1a-86ad-b50d788aa99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b04b4-f7f4-4c1a-86ad-b50d788aa99e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10106,7 +10106,7 @@
         },
         {
             "id": "d85b7806-1da6-5117-b86c-0b3e8b13d5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbeb57d-5fa0-4ff7-b5e8-caafc139669b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbeb57d-5fa0-4ff7-b5e8-caafc139669b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10144,7 +10144,7 @@
         },
         {
             "id": "4f4875b5-832b-580c-9781-04deca045354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ab60a-b888-4585-b0c6-769d387069f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ab60a-b888-4585-b0c6-769d387069f7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10182,7 +10182,7 @@
         },
         {
             "id": "81ccfd9c-846f-56c8-9cc7-0068d1312a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b486b75-4680-4a94-af8c-c1c335c9782b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b486b75-4680-4a94-af8c-c1c335c9782b.jpg?1",
             "name": "Sire of Seven Deaths",
             "text": "First strike\nVigilance\nMenace\nTrample\nReach\nLifelink\nWard\u2014\nPay 7 life.",
             "colours": [],
@@ -10215,7 +10215,7 @@
         },
         {
             "id": "dded4ee2-67ba-5993-b241-b44e8abbd3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cfb9bc-4273-4e5f-a7ac-2006a8345a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cfb9bc-4273-4e5f-a7ac-2006a8345a4e.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.",
             "colours": [
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "1a6bf895-b9e1-57a8-9805-13c3470d41cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a39af-bafe-4a38-a270-39a0ce0f4aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a39af-bafe-4a38-a270-39a0ce0f4aa5.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -10293,7 +10293,7 @@
         },
         {
             "id": "ddff03c6-3ddf-591a-be5e-2cc2d9fb042a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0302a684-563c-49b2-9029-7f079ac58fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0302a684-563c-49b2-9029-7f079ac58fd2.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W}",
             "colours": [
@@ -10331,7 +10331,7 @@
         },
         {
             "id": "3b1e19c7-5465-522d-8b4c-0105a0088474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c62996-3dc9-4f1a-8979-790b9b6b134e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c62996-3dc9-4f1a-8979-790b9b6b134e.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender\nYou have hexproof.\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "ff222ac6-7563-5101-b79a-e6060c358a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b28fe-f10f-4e3e-8c19-ed012349faf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b28fe-f10f-4e3e-8c19-ed012349faf4.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "07159a60-1e11-5703-878d-6170ae538b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b235e9f-a8a6-45d7-b301-bc6db752dda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b235e9f-a8a6-45d7-b301-bc6db752dda8.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -10447,7 +10447,7 @@
         },
         {
             "id": "9c4780b8-f9ab-50e6-a9bb-bc976795c221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5e421e-c187-4bf5-be9d-20a1e32b570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5e421e-c187-4bf5-be9d-20a1e32b570b.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "9cfe6b55-aaea-52ae-b8ed-0474a15634df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff36db9-560b-4cda-8122-d9ff748acf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff36db9-560b-4cda-8122-d9ff748acf4d.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -10523,7 +10523,7 @@
         },
         {
             "id": "2e4a814a-2384-51b9-8e6f-8102f4d3c0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d0d34-4d66-4e0d-9d64-bb7786930b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d0d34-4d66-4e0d-9d64-bb7786930b7a.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "ccdab08b-6935-5ac3-bb9b-539c313067f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0f6b48-63e6-4eff-92db-9f2a4652c5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0f6b48-63e6-4eff-92db-9f2a4652c5c1.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "6e66dbf6-a7f9-528f-93ec-783d082d1948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d2690b-8d73-468c-be25-576bc615069a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d2690b-8d73-468c-be25-576bc615069a.jpg?1",
             "name": "Youthful Valkyrie",
             "text": "Flying\nWhenever another Angel you control enters, put a +1/+1 counter on this creature.",
             "colours": [
@@ -10634,7 +10634,7 @@
         },
         {
             "id": "9c7c07eb-9c46-5698-a4b4-1ba8ae65d04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f15cc5-c3dc-4830-aa55-13080c738739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f15cc5-c3dc-4830-aa55-13080c738739.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "5ef70719-424b-53c7-bbe7-8c7051c864b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abab9f07-ea0f-4f6f-81f4-a9177909c9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abab9f07-ea0f-4f6f-81f4-a9177909c9e7.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -10711,7 +10711,7 @@
         },
         {
             "id": "818f653b-e726-5a7a-a1fa-b643bc4ce13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60cf418-b927-49b6-9613-41eae6296902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60cf418-b927-49b6-9613-41eae6296902.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "9320a87a-7100-520a-b215-e8280a37293d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21180a4-208f-4c13-a704-58403ddaf12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21180a4-208f-4c13-a704-58403ddaf12f.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -10789,7 +10789,7 @@
         },
         {
             "id": "ffa7450b-8ea9-5289-9e34-59d55532448c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dbb6ff-1262-44cc-8d36-153b2d3eace0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dbb6ff-1262-44cc-8d36-153b2d3eace0.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -10827,7 +10827,7 @@
         },
         {
             "id": "1585e9ed-2652-5361-b869-5a328c5d821f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a123794-096f-4d01-bfd4-1d23f22608f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a123794-096f-4d01-bfd4-1d23f22608f7.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "1bc3fc63-9b43-5ce0-8ad7-31af13c5c785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80f2eb-e34a-4f39-a831-d6fb42f6b4cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80f2eb-e34a-4f39-a831-d6fb42f6b4cc.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "f6ff9880-d1d5-5fa0-8448-c9e1df91ebf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6aaee9-8c44-4e23-8167-ead64e599711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6aaee9-8c44-4e23-8167-ead64e599711.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens.",
             "colours": [
@@ -10938,7 +10938,7 @@
         },
         {
             "id": "2eb4d51c-afe8-52a6-b151-37b5910c917e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c72dced-adae-4c66-af2a-0a1216953ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c72dced-adae-4c66-af2a-0a1216953ab6.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "215d5d25-70ea-5b30-abb8-2012f802642f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a65d5b-d07e-4ff0-900a-30d509ce0f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a65d5b-d07e-4ff0-900a-30d509ce0f35.jpg?1",
             "name": "Refute",
             "text": "Counter target spell. Draw a card, then discard a card.",
             "colours": [
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "3e908528-1e0f-52b4-a28a-927339c8e780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9571a123-37b4-42fa-96ba-42580afb6d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9571a123-37b4-42fa-96ba-42580afb6d9d.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -11045,7 +11045,7 @@
         },
         {
             "id": "b0178454-a1a6-536a-a2fb-5f753eb58e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a7e9bb-0772-4539-bbf9-7a95d5e47947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a7e9bb-0772-4539-bbf9-7a95d5e47947.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U}",
             "colours": [
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "21157ba1-f2c7-557e-92a4-11c892f95f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e44b856-1803-4e63-ad81-43a1c4ef5020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e44b856-1803-4e63-ad81-43a1c4ef5020.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -11120,7 +11120,7 @@
         },
         {
             "id": "a48f1a37-4568-57e3-ba42-96fe4147ff73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a669cb-24fc-4055-9e53-70b794805f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a669cb-24fc-4055-9e53-70b794805f3b.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -11156,7 +11156,7 @@
         },
         {
             "id": "d5c751e0-7dd8-5132-9e7b-cc4fd96ce83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c340ba8-9287-4072-937a-438251b5ff1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c340ba8-9287-4072-937a-438251b5ff1d.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "b12b2f8e-629d-5cea-80a1-9511349cbe27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cedc6d-075a-4f9b-a858-e2c29809ee33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cedc6d-075a-4f9b-a858-e2c29809ee33.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -11231,7 +11231,7 @@
         },
         {
             "id": "35cea5ff-c5bf-5727-979c-70c34107f6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30c5bb1-58c6-40a4-9e87-3f71b026c523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30c5bb1-58c6-40a4-9e87-3f71b026c523.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "c4be7dee-5ad1-52dc-87e6-b31edb72b535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc1623f-370d-42b5-88a2-039f31e9be0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc1623f-370d-42b5-88a2-039f31e9be0b.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "084d4581-8bae-51cf-a27f-2fe018bd4411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ea5129-7e83-4fb5-8096-2f5ebdc3efe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ea5129-7e83-4fb5-8096-2f5ebdc3efe1.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "f706000d-7a84-5754-ab30-9871e4eeac38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d466d44-3203-4e9d-befc-877414a7308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d466d44-3203-4e9d-befc-877414a7308d.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -11379,7 +11379,7 @@
         },
         {
             "id": "d575e330-48d1-5e10-8037-d6d851c73f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8d5d4-b52d-42c7-aa56-c104a539133c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8d5d4-b52d-42c7-aa56-c104a539133c.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -11420,7 +11420,7 @@
         },
         {
             "id": "55b95720-be50-5cf0-84e4-8478b9d28bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c944c5dc-9cb6-4dfd-aa90-5e180ffaa0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c944c5dc-9cb6-4dfd-aa90-5e180ffaa0fe.jpg?1",
             "name": "Vengeful Bloodwitch",
             "text": "Whenever this creature or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11457,7 +11457,7 @@
         },
         {
             "id": "ea167adf-3bec-52fe-9a69-4625807908ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1aad48-88f0-464d-9776-ecd023d87b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1aad48-88f0-464d-9776-ecd023d87b8f.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life.\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -11498,7 +11498,7 @@
         },
         {
             "id": "1cd5f92c-e2eb-5407-8cf7-833687237c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74ab7c-b9de-47ab-83ea-2b98738838c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74ab7c-b9de-47ab-83ea-2b98738838c7.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "a5d176f0-39ff-5a43-b3a6-1f28d79371ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ab83-3b8e-4747-98ae-7b981bcc77b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ab83-3b8e-4747-98ae-7b981bcc77b1.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R}",
             "colours": [
@@ -11568,7 +11568,7 @@
         },
         {
             "id": "c858a5e7-e6fd-5ce6-ad46-8d06e0970fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f30943b-f739-49eb-bafb-fec6614a0c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f30943b-f739-49eb-bafb-fec6614a0c5e.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -11608,7 +11608,7 @@
         },
         {
             "id": "ccc1bbba-c414-5cee-93c7-0549cec4577f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e413f37-b59a-4302-86d3-2abce81edc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e413f37-b59a-4302-86d3-2abce81edc78.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -11650,7 +11650,7 @@
         },
         {
             "id": "688632df-a37f-5615-aa63-3d0a4bdf15aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa981d3-4a41-4bf1-ba64-2cd7224a6059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa981d3-4a41-4bf1-ba64-2cd7224a6059.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "218c9dba-60d2-5ec6-994f-c9e060b732e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58deba9d-5c95-4633-a86c-2637a8bb7ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58deba9d-5c95-4633-a86c-2637a8bb7ce2.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11725,7 +11725,7 @@
         },
         {
             "id": "d9337710-b760-56dc-8658-faea5ad0daeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab62a48-93b5-4eb3-aa6b-92dd4cc617f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab62a48-93b5-4eb3-aa6b-92dd4cc617f6.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -11765,7 +11765,7 @@
         },
         {
             "id": "48e22ecf-b631-5623-9d8d-50b0052eada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51445b-1590-4072-9712-5ca344b25e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51445b-1590-4072-9712-5ca344b25e3e.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "c3009e9f-d785-5b1d-be15-3e0874f66131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4561678b-db52-4b89-9f34-50fe600a55d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4561678b-db52-4b89-9f34-50fe600a55d7.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -11840,7 +11840,7 @@
         },
         {
             "id": "1c35254e-1088-52de-aae9-30245b11bdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ce9555-a687-4a37-864c-eb59b1e80a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ce9555-a687-4a37-864c-eb59b1e80a8f.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -11881,7 +11881,7 @@
         },
         {
             "id": "8ce8012e-645c-5ac7-8a77-41f8f2dc3f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be84175-062c-439f-abad-c57cd9eb490f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be84175-062c-439f-abad-c57cd9eb490f.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -11920,7 +11920,7 @@
         },
         {
             "id": "69c1ce3b-023e-5c29-b9eb-67e8d85cc614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d611f8cd-fe7d-41d3-9572-9dda77d83d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d611f8cd-fe7d-41d3-9572-9dda77d83d25.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -11956,7 +11956,7 @@
         },
         {
             "id": "9aeb7be5-737e-5d0d-b466-c26999d69c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00e8e36-bd52-4eca-ae48-f3e03a655704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00e8e36-bd52-4eca-ae48-f3e03a655704.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it.\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -11994,7 +11994,7 @@
         },
         {
             "id": "3745f593-8030-574f-b058-e2301c819aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3f0764-9d80-4e15-a402-1f93e652bcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3f0764-9d80-4e15-a402-1f93e652bcbb.jpg?1",
             "name": "Reclamation Sage",
             "text": "When this creature enters, you may destroy target artifact or enchantment.",
             "colours": [
@@ -12031,7 +12031,7 @@
         },
         {
             "id": "19041e0b-6bbe-5420-8f65-10af96982cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984be4a8-8d34-4911-8210-0741f173bfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984be4a8-8d34-4911-8210-0741f173bfab.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12070,7 +12070,7 @@
         },
         {
             "id": "22c1bf9a-fa27-5574-b120-3c2c8f57f555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd7c1c1-e5e2-4481-b860-a4f7f7a1034b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd7c1c1-e5e2-4481-b860-a4f7f7a1034b.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -12106,7 +12106,7 @@
         },
         {
             "id": "ba7fcf49-852f-502b-8447-82fac3fe88a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48858f3-40a4-4117-b4c5-e1b973be4869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48858f3-40a4-4117-b4c5-e1b973be4869.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -12149,7 +12149,7 @@
         },
         {
             "id": "62ca4dff-e28f-5aa1-81e4-31a73b16a4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf3fcd4-bac8-4cf1-b042-743cfc62e517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf3fcd4-bac8-4cf1-b042-743cfc62e517.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -12187,7 +12187,7 @@
         },
         {
             "id": "09dc2cf5-133f-5fcc-a9cb-82dfd15d0ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b39d89-9902-4a45-a774-bea1c17ca5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b39d89-9902-4a45-a774-bea1c17ca5e4.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -12228,7 +12228,7 @@
         },
         {
             "id": "edd162ba-4b95-5020-ad16-8271243f3457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14994b68-5930-49a4-af1c-e8123c8c8025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14994b68-5930-49a4-af1c-e8123c8c8025.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -12271,7 +12271,7 @@
         },
         {
             "id": "3c231436-5f87-52c6-aa3f-df2a828ea473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8889e1ca-eec1-408b-b11e-98cc0a357a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8889e1ca-eec1-408b-b11e-98cc0a357a97.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -12313,7 +12313,7 @@
         },
         {
             "id": "6996c42c-3d1a-5281-96e9-d847af6fc25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1763648-802f-4178-a46a-a0c19142fd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1763648-802f-4178-a46a-a0c19142fd67.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -12356,7 +12356,7 @@
         },
         {
             "id": "9346ab3a-a62e-5de0-99b0-c642cf3f6b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f766b8-a92e-4353-b457-ac62fc470713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f766b8-a92e-4353-b457-ac62fc470713.jpg?1",
             "name": "Lathril, Blade of the Elves",
             "text": "Menace\nWhenever Lathril deals combat damage to a player, create that many 1/1 green Elf Warrior creature tokens.\n{T}, Tap ten untapped Elves you control: Each opponent loses 10 life and you gain 10 life.",
             "colours": [
@@ -12398,7 +12398,7 @@
         },
         {
             "id": "2982b6d7-8a09-5270-b548-44b462d187a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666749f4-3481-424b-9f18-37763ebf769a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666749f4-3481-424b-9f18-37763ebf769a.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "3f5f08f8-a281-50ff-b941-df29ccf21794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0490270-f94d-4f17-8a6c-527c9eab5d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0490270-f94d-4f17-8a6c-527c9eab5d73.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -12484,7 +12484,7 @@
         },
         {
             "id": "0cffee48-7438-5550-8120-47eefee780cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a9b8b0-c1ba-48c3-8f90-6af6948274ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a9b8b0-c1ba-48c3-8f90-6af6948274ee.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -12516,7 +12516,7 @@
         },
         {
             "id": "cfac1530-1611-5da5-a4d9-8c2d787a86ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9df1f5-1b60-47b8-ac87-5c58719d7de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9df1f5-1b60-47b8-ac87-5c58719d7de4.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3}",
             "colours": [],
@@ -12550,7 +12550,7 @@
         },
         {
             "id": "ccd0af47-8e4c-54d3-9792-366f7aeb8104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d8c9b5-6863-45d1-89f0-6a4f8189758b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d8c9b5-6863-45d1-89f0-6a4f8189758b.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "84c43af0-b6ca-5e75-bfcf-bbe954797b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9b53da-4744-429d-97c6-f7ee4d568731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9b53da-4744-429d-97c6-f7ee4d568731.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -12618,7 +12618,7 @@
         },
         {
             "id": "db7f4806-7e59-54fb-beca-fcf9df1fd96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4cc78-c25f-494c-b57e-c185d37605e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4cc78-c25f-494c-b57e-c185d37605e8.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -12650,7 +12650,7 @@
         },
         {
             "id": "f10cc0c3-3d22-5e43-8f53-1c27d78ce214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f329a0b-13cc-48c5-9fb7-38d8a537aa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f329a0b-13cc-48c5-9fb7-38d8a537aa30.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n\u22123: Target creature gains flying and double strike until end of turn.\n\u22128: Create X 2/2 white Cat creature tokens, where X is your life total.",
             "colours": [
@@ -12689,7 +12689,7 @@
         },
         {
             "id": "b488c201-d718-592f-9d06-a4b3ed743d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be447408-0846-49be-b47e-c6f256032deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be447408-0846-49be-b47e-c6f256032deb.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -12730,7 +12730,7 @@
         },
         {
             "id": "e4848506-0172-5d87-92bd-8c66a835a1a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba461127-2220-4274-81cb-423a1700c9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba461127-2220-4274-81cb-423a1700c9eb.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures of their choice.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -12769,7 +12769,7 @@
         },
         {
             "id": "d181c236-8ee8-5ad0-81ae-2397e54ad76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02db5a2d-28d3-4f57-9045-f0ef16d8aad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02db5a2d-28d3-4f57-9045-f0ef16d8aad1.jpg?1",
             "name": "Chandra, Flameshaper",
             "text": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n\u22124: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
             "colours": [
@@ -12808,7 +12808,7 @@
         },
         {
             "id": "939129c7-d44f-5d63-a8d2-a902a57f2c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cc3e80-2ffa-4d48-bd67-a6315375b236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cc3e80-2ffa-4d48-bd67-a6315375b236.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -12847,7 +12847,7 @@
         },
         {
             "id": "39752ddb-d0e0-5712-8aad-2996b5acda2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5493f0f-6eec-4776-a5aa-661eef1389fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5493f0f-6eec-4776-a5aa-661eef1389fa.jpg?1",
             "name": "Sire of Seven Deaths",
             "text": "First strike\nVigilance\nMenace\nTrample\nReach\nLifelink\nWard\u2014\nPay 7 life.",
             "colours": [],
@@ -12879,7 +12879,7 @@
         },
         {
             "id": "500d2b98-d266-5ef8-acdf-433aa264bf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2507fddd-2dc0-45f0-ac47-1ddd8690be46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2507fddd-2dc0-45f0-ac47-1ddd8690be46.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -12919,7 +12919,7 @@
         },
         {
             "id": "22782a7a-1df2-5de1-a28b-c555e86be31f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0787c7-338d-4db5-bfe8-70d578a422b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0787c7-338d-4db5-bfe8-70d578a422b9.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W}",
             "colours": [
@@ -12956,7 +12956,7 @@
         },
         {
             "id": "545faba0-14a9-5360-82d5-f71268490f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f6acd2-3b91-4bd7-996f-42c75b88ee87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f6acd2-3b91-4bd7-996f-42c75b88ee87.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender\nYou have hexproof.\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -12994,7 +12994,7 @@
         },
         {
             "id": "9a47fe44-6cdb-5d73-883b-b4da92b84a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67b3e48-98e8-404b-93b0-c3cbbd764d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67b3e48-98e8-404b-93b0-c3cbbd764d1c.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -13031,7 +13031,7 @@
         },
         {
             "id": "cd2c5cd5-eec2-531c-a11c-49cfa09973fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ed447-aade-4fd8-8787-2330436c750f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ed447-aade-4fd8-8787-2330436c750f.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "a6bbd05e-a652-5ba3-9d33-25304809b6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cc6624-d288-4f99-9606-3ce914890530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cc6624-d288-4f99-9606-3ce914890530.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -13108,7 +13108,7 @@
         },
         {
             "id": "5dd61365-c12f-5d0b-a0b7-28b9cb987639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4542ac9d-74fe-4a38-ac54-e141f4923540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4542ac9d-74fe-4a38-ac54-e141f4923540.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -13143,7 +13143,7 @@
         },
         {
             "id": "15c55952-7b41-55e0-8c90-3a0fb39c8ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccc2ced-861f-40c3-90e9-49250e1874d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccc2ced-861f-40c3-90e9-49250e1874d9.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "a5f5edbe-778f-5c45-a700-4a30994a30b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb6810-6f51-4e28-a4e7-40edcffc2059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb6810-6f51-4e28-a4e7-40edcffc2059.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -13216,7 +13216,7 @@
         },
         {
             "id": "47081b9b-6444-5c6b-9c68-bd49bd444fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6117837-83d4-4f84-967a-f5551515f0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6117837-83d4-4f84-967a-f5551515f0b9.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -13254,7 +13254,7 @@
         },
         {
             "id": "aa7ac9ba-2808-5f1b-a570-3355588e2576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7b1e9-1a11-41bf-8257-a8d3218b34fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7b1e9-1a11-41bf-8257-a8d3218b34fc.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -13291,7 +13291,7 @@
         },
         {
             "id": "606a428d-96a9-5fb2-8c6a-62f9729dd484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ef01c5-c79e-4fc1-af17-0956dc156a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ef01c5-c79e-4fc1-af17-0956dc156a28.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -13329,7 +13329,7 @@
         },
         {
             "id": "f50514f7-548c-5317-b55d-95c046dc0641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257630d3-8f82-4cfc-b0fd-21399a2cde6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257630d3-8f82-4cfc-b0fd-21399a2cde6c.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -13367,7 +13367,7 @@
         },
         {
             "id": "95f69a88-afa2-53aa-82f5-e7406e1f0528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae8f2d9-5759-49bf-b5d6-f2b9515ef919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae8f2d9-5759-49bf-b5d6-f2b9515ef919.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -13404,7 +13404,7 @@
         },
         {
             "id": "0e3cdf60-6e3b-5469-a57b-e61731ad0405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c7e2a5-9b56-48de-9cfd-be1ac6c692d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c7e2a5-9b56-48de-9cfd-be1ac6c692d9.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -13444,7 +13444,7 @@
         },
         {
             "id": "8cce51c0-708a-5d4b-9507-3db71b27ca99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c9474-f9d1-4123-aafa-dd41950ea112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c9474-f9d1-4123-aafa-dd41950ea112.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -13479,7 +13479,7 @@
         },
         {
             "id": "3e2d528f-bb65-5451-b527-c428bf38f270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f173425-8bae-47b1-8a2c-e27a071acd24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f173425-8bae-47b1-8a2c-e27a071acd24.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -13513,7 +13513,7 @@
         },
         {
             "id": "e79ab8b6-d5ec-5d8e-a5b9-26b9ffc81825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0552a2c4-36d4-405f-a56f-dc55610ae191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0552a2c4-36d4-405f-a56f-dc55610ae191.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -13550,7 +13550,7 @@
         },
         {
             "id": "8ef6eb3d-d431-5a35-a446-0e04b14f1ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8aeaa6f-984a-4e8d-a934-547c95f0b482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8aeaa6f-984a-4e8d-a934-547c95f0b482.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -13588,7 +13588,7 @@
         },
         {
             "id": "a1374dd7-f452-51e4-9792-80504e60ebb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e35e15-9456-46eb-b6be-5faab05185b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e35e15-9456-46eb-b6be-5faab05185b2.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -13623,7 +13623,7 @@
         },
         {
             "id": "4878051e-a16e-5249-acc9-664c988c1639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b10ba4e-4e6a-4127-a8a3-d9728e8d5f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b10ba4e-4e6a-4127-a8a3-d9728e8d5f8b.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -13663,7 +13663,7 @@
         },
         {
             "id": "2fd3baac-059f-5293-a7fe-2ebea5535ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafa089f-e33b-4933-a43d-e110dba29069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafa089f-e33b-4933-a43d-e110dba29069.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -13701,7 +13701,7 @@
         },
         {
             "id": "f03437b3-53e2-550a-a960-810bc3415294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54357fb3-f76b-411e-a466-c97643a8c0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54357fb3-f76b-411e-a466-c97643a8c0c7.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -13738,7 +13738,7 @@
         },
         {
             "id": "d5aeeb7a-5a85-52cd-b622-91a8bf99900b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f9f00-b33a-434d-8293-3a4c9e614358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f9f00-b33a-434d-8293-3a4c9e614358.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -13773,7 +13773,7 @@
         },
         {
             "id": "068e73d6-22c0-5f7e-95c1-1279aae0ca60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afefa7d5-e83a-4bbe-a9eb-e20c1bc25cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afefa7d5-e83a-4bbe-a9eb-e20c1bc25cdd.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -13807,7 +13807,7 @@
         },
         {
             "id": "c18bf88a-29bf-5c5e-a927-8e8cafb92dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bdc11d-bef3-4823-b8bd-209cdac4ea31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bdc11d-bef3-4823-b8bd-209cdac4ea31.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -13847,7 +13847,7 @@
         },
         {
             "id": "f3448169-09bf-53a2-bd6a-d3b5942feefb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d94cc2-938d-4e98-a190-3a481b0a2966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d94cc2-938d-4e98-a190-3a481b0a2966.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life.\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -13887,7 +13887,7 @@
         },
         {
             "id": "a476dc9b-2c92-54fe-bfbe-47696b0b7687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47172bc-71c3-472a-b1bd-eff9b7c140e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47172bc-71c3-472a-b1bd-eff9b7c140e0.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R}",
             "colours": [
@@ -13922,7 +13922,7 @@
         },
         {
             "id": "31774cda-7f63-5280-970b-3cf73f73770a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d02e4b-4da8-4304-bce3-b4c273462106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d02e4b-4da8-4304-bce3-b4c273462106.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -13961,7 +13961,7 @@
         },
         {
             "id": "f3a4ccdd-ce1f-5924-98c4-db5ec5efffdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7913c8f-a374-4d12-8ec9-8aee7604e135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7913c8f-a374-4d12-8ec9-8aee7604e135.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -14002,7 +14002,7 @@
         },
         {
             "id": "b929679c-1d71-50ae-92fa-173bb52501b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73750c-ddd4-448e-94f3-f64bada20508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73750c-ddd4-448e-94f3-f64bada20508.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -14037,7 +14037,7 @@
         },
         {
             "id": "51bacf8e-3d41-5c0a-a8dc-86bab643fed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523f8d8-4324-4e1d-9a88-4fd871e93bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523f8d8-4324-4e1d-9a88-4fd871e93bb8.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -14075,7 +14075,7 @@
         },
         {
             "id": "da40d1a2-d8c5-5647-9a4e-0f6ae62b1a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd09badf-b28d-48b9-8cb4-2336e5b1e4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd09badf-b28d-48b9-8cb4-2336e5b1e4b9.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -14114,7 +14114,7 @@
         },
         {
             "id": "cdfe6b5e-a6f4-5c93-bc20-726fcfa40461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4742df-edef-4b72-b523-429b1c284102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4742df-edef-4b72-b523-429b1c284102.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -14148,7 +14148,7 @@
         },
         {
             "id": "ac550dfa-8f6a-56aa-999d-8eb75f069802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f89bc6f-fc43-49ad-881f-8897750e4b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f89bc6f-fc43-49ad-881f-8897750e4b5f.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -14187,7 +14187,7 @@
         },
         {
             "id": "981a0cdf-5ec8-5a9f-81b2-a1a86c03f893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25b231-f2cf-4915-b6e1-557142b4c7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25b231-f2cf-4915-b6e1-557142b4c7bb.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -14227,7 +14227,7 @@
         },
         {
             "id": "3268120d-4be6-50c4-aefb-f6556a5036fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fca15a-16bb-439a-9dfe-b5168918a4ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fca15a-16bb-439a-9dfe-b5168918a4ed.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -14265,7 +14265,7 @@
         },
         {
             "id": "0c3492d9-db4f-5e12-b1a8-351fbd6df3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb6f1e-2545-4393-9985-383d11379977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb6f1e-2545-4393-9985-383d11379977.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -14300,7 +14300,7 @@
         },
         {
             "id": "36fedfb5-c15e-59bd-8984-b5d5829af063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6224fdea-d899-4bb2-af29-ef6faef5a0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6224fdea-d899-4bb2-af29-ef6faef5a0ed.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it.\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -14337,7 +14337,7 @@
         },
         {
             "id": "41936dab-82d5-5378-9f62-0e8d12781987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce5bc0f-ddb2-4135-a2a8-e8b21648a711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce5bc0f-ddb2-4135-a2a8-e8b21648a711.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14375,7 +14375,7 @@
         },
         {
             "id": "4cababf1-8726-5021-8360-0b427a2b7450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60b8a2-3302-43ea-a5c9-89c86b9104ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60b8a2-3302-43ea-a5c9-89c86b9104ac.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -14410,7 +14410,7 @@
         },
         {
             "id": "0b2c58c6-bb95-5f60-94be-3973c14bb0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea65396-4873-4bb0-9781-ea74f2ba923b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea65396-4873-4bb0-9781-ea74f2ba923b.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -14452,7 +14452,7 @@
         },
         {
             "id": "51a7fb98-33ab-55d5-b80c-d5ad2db52cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065802f-6194-49e9-94f5-880392519562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065802f-6194-49e9-94f5-880392519562.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -14489,7 +14489,7 @@
         },
         {
             "id": "a50627df-6429-5e03-9bec-3ab37176c806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e3dcae-c1d5-46ba-8d0d-021968992d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e3dcae-c1d5-46ba-8d0d-021968992d76.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -14529,7 +14529,7 @@
         },
         {
             "id": "90a844dc-e7cd-5189-b68d-d17f29f52951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc24bc-1287-449e-8b8a-02b44f569610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc24bc-1287-449e-8b8a-02b44f569610.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -14571,7 +14571,7 @@
         },
         {
             "id": "205e1c27-d93c-5fbc-8130-c143adcf508c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338cc7f-1134-42b4-b384-a93a4f92edc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338cc7f-1134-42b4-b384-a93a4f92edc9.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -14612,7 +14612,7 @@
         },
         {
             "id": "66950b8d-f2d1-52ac-a4e7-48eef99fc2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8ec6f1-4889-46e2-b681-59bf7b581195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8ec6f1-4889-46e2-b681-59bf7b581195.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -14654,7 +14654,7 @@
         },
         {
             "id": "54071920-0f1e-5f26-a0d7-9a1b0e879877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8463968-c2e9-48d7-ab9d-6a9b71470c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8463968-c2e9-48d7-ab9d-6a9b71470c3e.jpg?1",
             "name": "Lathril, Blade of the Elves",
             "text": "Menace\nWhenever Lathril deals combat damage to a player, create that many 1/1 green Elf Warrior creature tokens.\n{T}, Tap ten untapped Elves you control: Each opponent loses 10 life and you gain 10 life.",
             "colours": [
@@ -14695,7 +14695,7 @@
         },
         {
             "id": "9d606f8d-6d95-5a1e-bf2a-4a1e620dca1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c07579-1567-4e3f-a28a-ca7f106fd1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c07579-1567-4e3f-a28a-ca7f106fd1dc.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -14737,7 +14737,7 @@
         },
         {
             "id": "4a9e0a2e-4bce-5c67-ac93-c79775ad9d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ac2011-4021-46bc-b6cf-08de8db134aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ac2011-4021-46bc-b6cf-08de8db134aa.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -14779,7 +14779,7 @@
         },
         {
             "id": "91c61101-ace7-5779-970b-9b6b3aff7eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa434d9-c0c2-47f2-85ba-d2258ad91f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa434d9-c0c2-47f2-85ba-d2258ad91f58.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -14810,7 +14810,7 @@
         },
         {
             "id": "f01c4ef3-5cd7-5a62-9976-11f333645c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d3f263-cabd-4a81-a68a-cb93cb1c2107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d3f263-cabd-4a81-a68a-cb93cb1c2107.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3}",
             "colours": [],
@@ -14843,7 +14843,7 @@
         },
         {
             "id": "ed9ad2e3-3f37-5bfc-87b5-68b67b871c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c935438-2f3d-469d-a645-bfb3c95c3e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c935438-2f3d-469d-a645-bfb3c95c3e0a.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -14878,7 +14878,7 @@
         },
         {
             "id": "a710328e-23b8-513a-99eb-1318ed564b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab27d7a8-de69-4939-a35b-760b1b42e070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab27d7a8-de69-4939-a35b-760b1b42e070.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -14909,7 +14909,7 @@
         },
         {
             "id": "b4488e9b-8a6c-55d1-8417-13e3d397d592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345f7610-5b95-4d24-9ab0-e18d27ccabed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345f7610-5b95-4d24-9ab0-e18d27ccabed.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n\u22123: Target creature gains flying and double strike until end of turn.\n\u22128: Create X 2/2 white Cat creature tokens, where X is your life total.",
             "colours": [
@@ -14947,7 +14947,7 @@
         },
         {
             "id": "d421208c-2f93-54aa-b8e8-ad42fe26c505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6feaf235-ab3a-41f2-ae81-4f2d0b109ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6feaf235-ab3a-41f2-ae81-4f2d0b109ebc.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -14987,7 +14987,7 @@
         },
         {
             "id": "9f1b8a96-5982-5ead-aba6-6a3166160618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a097413-b77c-45e8-a4ac-5b2dc1d34e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a097413-b77c-45e8-a4ac-5b2dc1d34e16.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures of their choice.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -15025,7 +15025,7 @@
         },
         {
             "id": "56469e96-b56c-5531-90fb-73f437985743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd73be04-3ec2-4ea3-8d93-47fa39aaeed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd73be04-3ec2-4ea3-8d93-47fa39aaeed8.jpg?1",
             "name": "Chandra, Flameshaper",
             "text": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n\u22124: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "8d3d5b97-f1db-5dc5-884e-ae6940b44937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3a3b-257e-46c7-bb29-65627b00363d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3a3b-257e-46c7-bb29-65627b00363d.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "af868f46-ed09-53e1-a353-1e6ca413ddfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66be885f-a319-4c17-b909-0467fe66cf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66be885f-a319-4c17-b909-0467fe66cf3b.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -15135,7 +15135,7 @@
         },
         {
             "id": "44f9dd78-33f4-5f89-b9a0-8a42ec594e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b336e-7471-48d8-ac21-66b2a01578d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b336e-7471-48d8-ac21-66b2a01578d5.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -15174,7 +15174,7 @@
         },
         {
             "id": "bd7e5238-9d3d-5000-9292-9288db88e24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a1cbdf-36aa-4619-932a-609c1699cc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a1cbdf-36aa-4619-932a-609c1699cc6a.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -15214,7 +15214,7 @@
         },
         {
             "id": "38f0ebf5-32cf-5d39-9b89-af41823f589f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6615cc95-0d7a-474d-bf35-3ea4dfc4cced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6615cc95-0d7a-474d-bf35-3ea4dfc4cced.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U}",
             "colours": [
@@ -15249,7 +15249,7 @@
         },
         {
             "id": "868cb584-8fb2-586e-a60f-79a94db32c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb45b34-a1e7-4861-b0fe-b701aa5e894a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb45b34-a1e7-4861-b0fe-b701aa5e894a.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -15289,7 +15289,7 @@
         },
         {
             "id": "a7b60325-9afc-5fd1-8d77-422fe8c03972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765e6a52-773d-420c-829c-fefe4993bfd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765e6a52-773d-420c-829c-fefe4993bfd9.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -15328,7 +15328,7 @@
         },
         {
             "id": "f91b4613-1633-5428-90ca-420174ceb533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8fabe-3af7-4f19-9508-5b5a6a608a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8fabe-3af7-4f19-9508-5b5a6a608a3c.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -15362,7 +15362,7 @@
         },
         {
             "id": "b3e2bea0-1c3b-5f00-afc1-29348081f591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd43a84a-cde2-48f8-b6ab-1ec023c9e0c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd43a84a-cde2-48f8-b6ab-1ec023c9e0c3.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -15399,7 +15399,7 @@
         },
         {
             "id": "19c9ce19-033c-5ed0-9b78-115be874df9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff672733-486b-4042-8209-fca70df86b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff672733-486b-4042-8209-fca70df86b7d.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard.",
             "colours": [
@@ -15442,7 +15442,7 @@
         },
         {
             "id": "45b17118-140d-59ed-8049-50632f9d9138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee7f2b-de71-4ab2-8104-5fb467b4100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee7f2b-de71-4ab2-8104-5fb467b4100b.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -15489,7 +15489,7 @@
         },
         {
             "id": "a77faf94-1867-5b72-8139-2fc482dffde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b2d913-0b0e-4840-bf88-29dd6f9da631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b2d913-0b0e-4840-bf88-29dd6f9da631.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -15523,7 +15523,7 @@
         },
         {
             "id": "14e39fed-eef9-5d4e-9a5a-5913aa8319d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb46675-5286-4eaf-9c25-eef773a4daeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb46675-5286-4eaf-9c25-eef773a4daeb.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -15562,7 +15562,7 @@
         },
         {
             "id": "787698c2-808b-5cd2-aeca-f85d1ee28ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84779aa7-6147-4c83-aab2-ae4346524977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84779aa7-6147-4c83-aab2-ae4346524977.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -15602,7 +15602,7 @@
         },
         {
             "id": "4619eef9-1c44-5d53-a608-5dd904d7fdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228018d-3e25-41f0-ae16-beb96dd5e1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228018d-3e25-41f0-ae16-beb96dd5e1cc.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U}",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "c7bcd838-cc76-5f87-b8c3-0a9740932afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926074a7-a01d-43bb-a257-0d95394773a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926074a7-a01d-43bb-a257-0d95394773a0.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -15677,7 +15677,7 @@
         },
         {
             "id": "8ca590aa-71c4-5bc1-9cf3-2af072b3363c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d02e4b-3854-4e10-acb7-0b6128401b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d02e4b-3854-4e10-acb7-0b6128401b2e.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -15716,7 +15716,7 @@
         },
         {
             "id": "a3b12060-c344-5a28-aee0-fd813cfddd53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bf249-3773-404f-9e46-d7745d3826e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bf249-3773-404f-9e46-d7745d3826e8.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -15750,7 +15750,7 @@
         },
         {
             "id": "33698a32-1d56-5acf-9bcb-108c133a8c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bd6cef-f887-4b07-a957-4c53cb3c9c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bd6cef-f887-4b07-a957-4c53cb3c9c87.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -15787,7 +15787,7 @@
         },
         {
             "id": "6a4d429f-3145-5ffd-9bd6-511dd859eea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc15cd2-e6d1-406e-af58-2f5fbaa74a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc15cd2-e6d1-406e-af58-2f5fbaa74a30.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard.",
             "colours": [
@@ -15830,7 +15830,7 @@
         },
         {
             "id": "002fe066-2f24-587e-bf2a-d9f7bb37bb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d284ddb-c1de-49a3-8a2a-8146f7c3fbeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d284ddb-c1de-49a3-8a2a-8146f7c3fbeb.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -15877,7 +15877,7 @@
         },
         {
             "id": "daad7cf1-f923-526b-9f4e-4121a260739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52605015-ba08-4427-8c06-b47ecd603b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52605015-ba08-4427-8c06-b47ecd603b27.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -15918,7 +15918,7 @@
         },
         {
             "id": "7fc143cf-936a-5a82-b3d3-af237d371ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e9e1d6-5cb3-42c1-9211-9769b2c04db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e9e1d6-5cb3-42c1-9211-9769b2c04db6.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W} ({3}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -15956,7 +15956,7 @@
         },
         {
             "id": "84d5323b-26a5-55bf-8545-f4e9f4763277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb02c30-8898-4692-a22b-7ea7855e8f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb02c30-8898-4692-a22b-7ea7855e8f81.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender (This creature can't attack.)\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "9eaf450a-db55-56e0-b01b-66701f110e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d61887-a6f7-4ce0-a44d-9661e8bb2107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d61887-a6f7-4ce0-a44d-9661e8bb2107.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -16033,7 +16033,7 @@
         },
         {
             "id": "b444b47c-beea-5cbe-9f59-3ae664a4b8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38dc08b-9a80-47ad-8c0e-ed19487f043f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38dc08b-9a80-47ad-8c0e-ed19487f043f.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -16073,7 +16073,7 @@
         },
         {
             "id": "e41c8b86-e8c1-5132-970b-b86330643f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f9421-da89-4221-8a59-a8d112a5598d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f9421-da89-4221-8a59-a8d112a5598d.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -16109,7 +16109,7 @@
         },
         {
             "id": "d81a14ee-6559-5fc1-aa30-135b124a3238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28007f11-6610-42e8-9fb6-1a6091ec9435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28007f11-6610-42e8-9fb6-1a6091ec9435.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -16148,7 +16148,7 @@
         },
         {
             "id": "15e7f4f5-6631-5545-8cd6-e7b7d14c4e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650498aa-3fc1-47ac-b8d1-d13433640d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650498aa-3fc1-47ac-b8d1-d13433640d57.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -16184,7 +16184,7 @@
         },
         {
             "id": "97282d3d-b685-5f53-afef-ded75a5ec23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28658ae0-9b5b-497d-a3c9-0a0626b7b344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28658ae0-9b5b-497d-a3c9-0a0626b7b344.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -16223,7 +16223,7 @@
         },
         {
             "id": "ff08a2ee-fb81-556b-b9cb-9d695770ad91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d11928-1d4b-413d-b43c-280525238d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d11928-1d4b-413d-b43c-280525238d58.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -16261,7 +16261,7 @@
         },
         {
             "id": "41bacfa2-1054-5ac0-92d0-b174376304f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c31f0d-b77f-4cf9-8350-2dde15d427a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c31f0d-b77f-4cf9-8350-2dde15d427a7.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -16300,7 +16300,7 @@
         },
         {
             "id": "d15c8b80-3c92-501c-867e-660853781044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347e6783-3809-4b8f-ac68-e786c944e7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347e6783-3809-4b8f-ac68-e786c944e7f5.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -16339,7 +16339,7 @@
         },
         {
             "id": "8cd363d3-958c-5a1a-a8dd-9dc7b4138875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ec1d32-9467-4c79-a9d6-bf3aad2d7fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ec1d32-9467-4c79-a9d6-bf3aad2d7fed.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -16377,7 +16377,7 @@
         },
         {
             "id": "a3804baf-845b-5bb3-abc8-f126d2364f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b137e8d-3537-454d-8d6b-24d2a6d81993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b137e8d-3537-454d-8d6b-24d2a6d81993.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -16418,7 +16418,7 @@
         },
         {
             "id": "4ee15643-5477-5aac-a4b3-2e00be0aa813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdec49a8-508d-4c4b-a60f-4cbeea56f4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdec49a8-508d-4c4b-a60f-4cbeea56f4cd.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -16454,7 +16454,7 @@
         },
         {
             "id": "926aea35-5674-5268-8f29-5b6bcc89f604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce455a01-87c1-42d1-a51e-1f9a7bd553d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce455a01-87c1-42d1-a51e-1f9a7bd553d6.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -16492,7 +16492,7 @@
         },
         {
             "id": "5f4a5a2e-c379-5f08-9a69-cc8121226d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f257e3-1d03-4395-8a2d-c71f702db9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f257e3-1d03-4395-8a2d-c71f702db9ad.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -16531,7 +16531,7 @@
         },
         {
             "id": "ca7c3bdb-a853-5b5c-aeea-32ed3b904109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a6c01-70c4-4e84-b5ca-9a9d4e7c0d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a6c01-70c4-4e84-b5ca-9a9d4e7c0d86.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -16567,7 +16567,7 @@
         },
         {
             "id": "c2eace62-5255-5625-a6ac-aeb88627f3d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd05eaa-7c0d-45f0-b085-87dc1d610c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd05eaa-7c0d-45f0-b085-87dc1d610c34.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life. (Damage causes loss of life.)",
             "colours": [
@@ -16608,7 +16608,7 @@
         },
         {
             "id": "b29e23c5-d5e3-52e8-9bcc-6866707d70f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf85410-7abe-4bd8-97be-c6432142c947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf85410-7abe-4bd8-97be-c6432142c947.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -16647,7 +16647,7 @@
         },
         {
             "id": "786f45f8-ecb8-5a9c-8c80-c9da7aa2eca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c1b96-7ec0-4063-833f-fb32b720650e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c1b96-7ec0-4063-833f-fb32b720650e.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -16685,7 +16685,7 @@
         },
         {
             "id": "4ff1ac17-9544-554b-8305-4780a5481e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01d5f4b-a780-4a89-82b1-84d4f3b62a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01d5f4b-a780-4a89-82b1-84d4f3b62a7b.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -16726,7 +16726,7 @@
         },
         {
             "id": "43870e3e-cf42-5965-bda0-c6aab7a85492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb2c4-210c-4361-9232-dc1327f0a972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb2c4-210c-4361-9232-dc1327f0a972.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -16767,7 +16767,7 @@
         },
         {
             "id": "0960b2a6-e118-5b86-a188-7cb316ef996f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6ab9e-99f7-4296-b8b2-6cdfa91c5fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6ab9e-99f7-4296-b8b2-6cdfa91c5fba.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -16803,7 +16803,7 @@
         },
         {
             "id": "8823a572-c50a-5b7c-be97-8e9f108d3f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e35fbe-55b7-40c8-b24b-2d9d933bcdaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e35fbe-55b7-40c8-b24b-2d9d933bcdaa.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -16845,7 +16845,7 @@
         },
         {
             "id": "9816500e-2752-5f15-b7be-8cb1684a2c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a99d9bc-da4e-488b-bc4a-90594c072b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a99d9bc-da4e-488b-bc4a-90594c072b66.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -16881,7 +16881,7 @@
         },
         {
             "id": "c085a252-8efb-559d-8577-23807d364a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3059e4-b198-4eba-98e8-f0f9f83d1928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3059e4-b198-4eba-98e8-f0f9f83d1928.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -16920,7 +16920,7 @@
         },
         {
             "id": "aef84205-b056-51ac-bc57-aacd1240d3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a474e3-e7de-4b4d-ad89-a72571968687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a474e3-e7de-4b4d-ad89-a72571968687.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -16960,7 +16960,7 @@
         },
         {
             "id": "28b74ac0-3a83-54eb-8c6c-5bc8bac5c26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6671b19-28d3-4d67-a8fa-83e4f6596c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6671b19-28d3-4d67-a8fa-83e4f6596c68.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -17001,7 +17001,7 @@
         },
         {
             "id": "0449c1a1-d75c-54f6-985a-fd512539f128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60e591e-5673-4504-9b1e-8448fae664ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60e591e-5673-4504-9b1e-8448fae664ea.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -17040,7 +17040,7 @@
         },
         {
             "id": "bb4a5d76-2bd7-521a-9551-434937ad01de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838e2693-2dd4-4aec-bde9-369a069a3fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838e2693-2dd4-4aec-bde9-369a069a3fef.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -17076,7 +17076,7 @@
         },
         {
             "id": "72300d6c-7fc3-5f32-8289-543ad243bd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354df84b-28a1-4b8f-a8ab-94060a35e05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354df84b-28a1-4b8f-a8ab-94060a35e05f.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it. (It must survive to get the counters.)\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -17114,7 +17114,7 @@
         },
         {
             "id": "b00ed64a-4fd7-5e29-ad0e-01ac871c1309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3f233a-d4df-4836-84cc-9d3e86165926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3f233a-d4df-4836-84cc-9d3e86165926.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -17153,7 +17153,7 @@
         },
         {
             "id": "fef26c25-e7af-5cf5-bed9-ca779d8869a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4b8c6-ded3-4f97-b5a4-346792a25991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4b8c6-ded3-4f97-b5a4-346792a25991.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -17189,7 +17189,7 @@
         },
         {
             "id": "57c28198-5d31-5bf3-979d-4b3649c87470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003d05be-4cf2-43c6-a823-c2b9c6482d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003d05be-4cf2-43c6-a823-c2b9c6482d38.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -17232,7 +17232,7 @@
         },
         {
             "id": "a93d5cb6-8d51-554f-bc99-86f4eafaa031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6749d0b4-4c37-4b43-9ad3-3b36d831f9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6749d0b4-4c37-4b43-9ad3-3b36d831f9e7.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -17270,7 +17270,7 @@
         },
         {
             "id": "d1b83b0a-0d9a-543e-ad1e-db56514292cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c436e43-e575-4a01-ba03-9d72810a2883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c436e43-e575-4a01-ba03-9d72810a2883.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -17311,7 +17311,7 @@
         },
         {
             "id": "34b3e296-fc8a-5644-be15-28347c15bdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c76cc76-317c-4680-b411-43842000aa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c76cc76-317c-4680-b411-43842000aa9f.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -17354,7 +17354,7 @@
         },
         {
             "id": "d703403e-ab48-5335-b18c-d9e7ec628187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ac4ece-8551-4662-baca-4e7d5beecb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ac4ece-8551-4662-baca-4e7d5beecb5e.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -17396,7 +17396,7 @@
         },
         {
             "id": "1c5db2d9-0e20-5cd0-a7cf-6c3a261fe728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa23ced5-0baa-4a8d-9263-ec2d94233a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa23ced5-0baa-4a8d-9263-ec2d94233a84.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -17439,7 +17439,7 @@
         },
         {
             "id": "b8b39a7f-22b5-5f10-80c3-d82b2cafaae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76503c75-ff97-4c27-a55b-74c3e68578c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76503c75-ff97-4c27-a55b-74c3e68578c9.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -17482,7 +17482,7 @@
         },
         {
             "id": "80c38cd6-5f7b-5fb0-84da-ca490bf81244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b82d3f-eaba-499a-9783-e90f5a2b623b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b82d3f-eaba-499a-9783-e90f5a2b623b.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -17525,7 +17525,7 @@
         },
         {
             "id": "b3326774-41b0-5754-a9ed-a887f06f76fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4709aed-a74b-4319-87c1-40f14cca6dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4709aed-a74b-4319-87c1-40f14cca6dad.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -17557,7 +17557,7 @@
         },
         {
             "id": "516d3376-e811-5667-9fc8-7b52da3bb316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd7a17-24f5-43d5-bd5a-8b51b48e8a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd7a17-24f5-43d5-bd5a-8b51b48e8a39.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -17591,7 +17591,7 @@
         },
         {
             "id": "efad7897-c20e-56ed-8d5f-3791adc701e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1835cd8-16c1-467b-a613-a4df6f752894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1835cd8-16c1-467b-a613-a4df6f752894.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -17627,7 +17627,7 @@
         },
         {
             "id": "8b93658b-6d54-5d41-84b8-71925d86bc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620f95e-fc95-4643-ba11-7f9116176253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620f95e-fc95-4643-ba11-7f9116176253.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -17659,7 +17659,7 @@
         },
         {
             "id": "fc0d8273-00d0-5895-870c-39438e52488e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2c9ab-b3dd-4f68-b91f-0f075a045757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2c9ab-b3dd-4f68-b91f-0f075a045757.jpg?1",
             "name": "Adamant Will",
             "text": "Target creature gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -17690,7 +17690,7 @@
         },
         {
             "id": "35b51a47-b92a-52e2-b84d-67bf74f3d117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df43d9d4-3fef-4a56-8b38-d52824117201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df43d9d4-3fef-4a56-8b38-d52824117201.jpg?1",
             "name": "Ancestor Dragon",
             "text": "Flying\nWhenever one or more creatures you control attack, you gain 1 life for each attacking creature.",
             "colours": [
@@ -17723,7 +17723,7 @@
         },
         {
             "id": "4480c07d-7a50-593d-9033-a5c676fe3f1c",
-            "imageUrl": "https://cards.scryfall.io/large/front/c/0/c0bf349e-2974-4aea-a5c0-fdaea77325cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bf349e-2974-4aea-a5c0-fdaea77325cc.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -17754,7 +17754,7 @@
         },
         {
             "id": "af9bd0a0-9d53-5be4-82bc-e17569e53992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfd7b3-6d01-4e98-aec3-b27e8e2444e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfd7b3-6d01-4e98-aec3-b27e8e2444e8.jpg?1",
             "name": "Bishop's Soldier",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -17788,7 +17788,7 @@
         },
         {
             "id": "9ca19d45-8552-517e-811f-98ca2aa2f1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5804a-075b-41d8-9639-785cad5c0974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5804a-075b-41d8-9639-785cad5c0974.jpg?1",
             "name": "Deadly Riposte",
             "text": "Deadly Riposte deals 3 damage to target tapped creature and you gain 2 life.",
             "colours": [
@@ -17819,7 +17819,7 @@
         },
         {
             "id": "d9aa5f74-cd0e-5168-a29e-ebe5205e4436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b405a442-cf6f-4c0b-9950-f208b30c052e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b405a442-cf6f-4c0b-9950-f208b30c052e.jpg?1",
             "name": "Elspeth's Smite",
             "text": "Elspeth's Smite deals 3 damage to target attacking or blocking creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -17850,7 +17850,7 @@
         },
         {
             "id": "b0178f62-907e-5ed6-a226-ccccbdff72b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5579f35b-b3d2-4342-a52b-ae36b579d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5579f35b-b3d2-4342-a52b-ae36b579d044.jpg?1",
             "name": "Herald of Faith",
             "text": "Flying\nWhenever this creature attacks, you gain 2 life.",
             "colours": [
@@ -17883,7 +17883,7 @@
         },
         {
             "id": "62541872-f74a-5bf8-993e-8fef7175ad25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea566679-4202-4076-9314-142241485f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea566679-4202-4076-9314-142241485f6e.jpg?1",
             "name": "Ingenious Leonin",
             "text": "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature is a Cat, it gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -17917,7 +17917,7 @@
         },
         {
             "id": "8cc449ac-1241-5459-beff-c0a17de186b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e9aa54-e5d5-4cbb-9d2a-263b9eba398f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e9aa54-e5d5-4cbb-9d2a-263b9eba398f.jpg?1",
             "name": "Inspiring Overseer",
             "text": "Flying\nWhen this creature enters, you gain 1 life and draw a card.",
             "colours": [
@@ -17951,7 +17951,7 @@
         },
         {
             "id": "a1cbccb7-fe7f-54bc-9277-27f635834306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa8f635-c638-4207-8631-f6b5185f8696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa8f635-c638-4207-8631-f6b5185f8696.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -17987,7 +17987,7 @@
         },
         {
             "id": "0174c271-7d03-5201-8baa-000545050418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218e0009-5f11-4348-97b8-4bc7b41f80b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218e0009-5f11-4348-97b8-4bc7b41f80b8.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying",
             "colours": [
@@ -18021,7 +18021,7 @@
         },
         {
             "id": "ab5f0d7d-89eb-5692-b8ba-47a840973ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b25850-f1bd-4410-beec-603b2a77f264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b25850-f1bd-4410-beec-603b2a77f264.jpg?1",
             "name": "Leonin Vanguard",
             "text": "At the beginning of combat on your turn, if you control three or more creatures, this creature gets +1/+1 until end of turn and you gain 1 life.",
             "colours": [
@@ -18055,7 +18055,7 @@
         },
         {
             "id": "d54db298-7243-53d9-9ea1-b04c249e2fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911deea0-38d2-41d9-a2ae-fb8eb45b2c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911deea0-38d2-41d9-a2ae-fb8eb45b2c23.jpg?1",
             "name": "Moment of Triumph",
             "text": "Target creature gets +2/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -18086,7 +18086,7 @@
         },
         {
             "id": "28aacea2-107e-588f-b654-e0df405ab749",
-            "imageUrl": "https://cards.scryfall.io/large/front/8/3/839160d2-44a3-4566-be9d-558d043beac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839160d2-44a3-4566-be9d-558d043beac8.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -18119,7 +18119,7 @@
         },
         {
             "id": "615eb743-0cb2-55ff-89a7-db6b21efcb69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b42c4-90d8-462d-aca5-891906992ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b42c4-90d8-462d-aca5-891906992ab8.jpg?1",
             "name": "Prayer of Binding",
             "text": "Flash\nWhen this enchantment enters, exile up to one target nonland permanent an opponent controls until this enchantment leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -18150,7 +18150,7 @@
         },
         {
             "id": "691a1848-eed9-54d3-b430-199307d1e5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9e73d-de8d-486f-bbbd-a2f5d3f8f686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9e73d-de8d-486f-bbbd-a2f5d3f8f686.jpg?1",
             "name": "Twinblade Paladin",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.\nAs long as you have 25 or more life, this creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -18184,7 +18184,7 @@
         },
         {
             "id": "c2003792-8f98-5b69-bf9b-ae68678ce38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f11ea2-cd4c-417a-804c-3df80d9ddd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f11ea2-cd4c-417a-804c-3df80d9ddd5f.jpg?1",
             "name": "Burrog Befuddler",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature an opponent controls gets -1/-0 until end of turn.",
             "colours": [
@@ -18218,7 +18218,7 @@
         },
         {
             "id": "2d129c28-540c-53e0-8cf9-626dc67aaf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bff39-220a-4490-9c2e-d311e306a6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bff39-220a-4490-9c2e-d311e306a6db.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -18249,7 +18249,7 @@
         },
         {
             "id": "7b70ac65-c478-52ec-9640-89b06003106c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5017dbc-07fd-45ea-9629-7c584144e8be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5017dbc-07fd-45ea-9629-7c584144e8be.jpg?1",
             "name": "Corsair Captain",
             "text": "When this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nOther Pirates you control get +1/+1.",
             "colours": [
@@ -18283,7 +18283,7 @@
         },
         {
             "id": "47f6506d-4a22-52d1-b6db-a3016699bbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475e28bb-1333-45e1-b6fd-83121c2f1ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475e28bb-1333-45e1-b6fd-83121c2f1ab9.jpg?1",
             "name": "Eaten by Piranhas",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature loses all abilities and is a black Skeleton creature with base power and toughness 1/1. (It loses all other colors, card types, and creature types.)",
             "colours": [
@@ -18316,7 +18316,7 @@
         },
         {
             "id": "ad2beb36-a0f9-506b-857c-20c5bcbf2742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c8024e-490a-484a-bcee-da7728a64a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c8024e-490a-484a-bcee-da7728a64a1f.jpg?1",
             "name": "Exclusion Mage",
             "text": "When this creature enters, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -18350,7 +18350,7 @@
         },
         {
             "id": "a7514c4a-57af-5ada-897f-804525987c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25edefa9-9fff-4b71-83ae-696c196a795c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25edefa9-9fff-4b71-83ae-696c196a795c.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -18381,7 +18381,7 @@
         },
         {
             "id": "184f03c7-af9e-500b-8394-94b78ad6581f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82d7c6d-523c-46c9-a189-44c0bd8386d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82d7c6d-523c-46c9-a189-44c0bd8386d1.jpg?1",
             "name": "Kitesail Corsair",
             "text": "This creature has flying as long as it's attacking.",
             "colours": [
@@ -18415,7 +18415,7 @@
         },
         {
             "id": "1fc7bb2f-9b22-5a26-8663-d6661827a1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ff32-6759-48a2-8674-4f729c91dcd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ff32-6759-48a2-8674-4f729c91dcd0.jpg?1",
             "name": "Mystic Archaeologist",
             "text": "{3}{U}{U}: Draw two cards.",
             "colours": [
@@ -18449,7 +18449,7 @@
         },
         {
             "id": "3cdf748e-3c0d-5896-932e-8b5f9ae60a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d26b54-0093-4e90-a2b1-b57c64340f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d26b54-0093-4e90-a2b1-b57c64340f9c.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\nDraw a card.",
             "colours": [
@@ -18480,7 +18480,7 @@
         },
         {
             "id": "6625c7e1-58ef-5d09-ba65-92dcec1ecd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c86fd-5a38-41fd-be44-ab963448f2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c86fd-5a38-41fd-be44-ab963448f2a2.jpg?1",
             "name": "Quick Study",
             "text": "Draw two cards.",
             "colours": [
@@ -18511,7 +18511,7 @@
         },
         {
             "id": "8d67c9ca-fd13-5080-974d-d64239ae0ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fb19b2-4f6c-4cbd-8756-a7eb5c7c9ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fb19b2-4f6c-4cbd-8756-a7eb5c7c9ef6.jpg?1",
             "name": "Starlight Snare",
             "text": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -18544,7 +18544,7 @@
         },
         {
             "id": "180f033f-28ef-5d6b-a77a-ae56954d6bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c5206e-63db-44c0-86ab-f645cd358b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c5206e-63db-44c0-86ab-f645cd358b3b.jpg?1",
             "name": "Storm Fleet Spy",
             "text": "Raid \u2014 When this creature enters, if you attacked this turn, draw a card.",
             "colours": [
@@ -18578,7 +18578,7 @@
         },
         {
             "id": "cf792215-f3f0-53c5-b71a-eb89027215bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d951-dd85-4d22-9505-ce6e2eaf47cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d951-dd85-4d22-9505-ce6e2eaf47cf.jpg?1",
             "name": "Bloodtithe Collector",
             "text": "Flying\nWhen this creature enters, if an opponent lost life this turn, each opponent discards a card.",
             "colours": [
@@ -18612,7 +18612,7 @@
         },
         {
             "id": "c3ca3bd5-257c-59ea-a6e2-5234a022cb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a80873-86d7-44a9-894b-65e8f77dd2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a80873-86d7-44a9-894b-65e8f77dd2ea.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -18643,7 +18643,7 @@
         },
         {
             "id": "ac11efc3-7262-53bd-be2a-c3b3130ab6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5e19c-4cb8-4bd7-923c-4db747dc6ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5e19c-4cb8-4bd7-923c-4db747dc6ca3.jpg?1",
             "name": "Crossway Troublemakers",
             "text": "Attacking Vampires you control have deathtouch and lifelink. (Any amount of damage they deal to a creature is enough to destroy it. Damage dealt by those creatures also causes their controller to gain that much life.)\nWhenever a Vampire you control dies, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -18676,7 +18676,7 @@
         },
         {
             "id": "7a02c74b-3180-548e-9afe-053248a50e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd74e93-064a-42d7-8e6e-c413912a08cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd74e93-064a-42d7-8e6e-c413912a08cd.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen this creature enters or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -18710,7 +18710,7 @@
         },
         {
             "id": "10ed2023-c7c5-56f1-bc38-c13a86dc64f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32fddc3-a38f-4eea-ae01-4158e3cbca6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32fddc3-a38f-4eea-ae01-4158e3cbca6c.jpg?1",
             "name": "Deadly Plot",
             "text": "Choose one \u2014\n\u2022 Destroy target creature or planeswalker.\n\u2022 Return target Zombie creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -18741,7 +18741,7 @@
         },
         {
             "id": "c449934a-b1dd-5884-967e-03296a6fd3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a27142-cf45-4164-9e10-373e5c8bf7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a27142-cf45-4164-9e10-373e5c8bf7c6.jpg?1",
             "name": "Death Baron",
             "text": "Skeletons you control and other Zombies you control get +1/+1 and have deathtouch. (Any amount of damage they deal to a creature is enough to destroy it.)",
             "colours": [
@@ -18775,7 +18775,7 @@
         },
         {
             "id": "3e28ed1b-f64e-51a4-9a92-76aef12aaf46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c56a23-eb4f-4be1-ada9-1ad5b80195d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c56a23-eb4f-4be1-ada9-1ad5b80195d3.jpg?1",
             "name": "Highborn Vampire",
             "text": "",
             "colours": [
@@ -18809,7 +18809,7 @@
         },
         {
             "id": "937a713f-9599-5948-88fe-80bc7161cd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c166df8f-9508-427a-8ec7-bc8541b6ed88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c166df8f-9508-427a-8ec7-bc8541b6ed88.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When this creature dies, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -18842,7 +18842,7 @@
         },
         {
             "id": "791fd5a2-c405-5eaa-a71d-9563269f1fde",
-            "imageUrl": "https://cards.scryfall.io/large/front/3/6/3627f9fb-b828-49cd-887d-e2ab3ef43dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3627f9fb-b828-49cd-887d-e2ab3ef43dfb.jpg?1",
             "name": "Moment of Craving",
             "text": "Target creature gets -2/-2 until end of turn. You gain 2 life.",
             "colours": [
@@ -18873,7 +18873,7 @@
         },
         {
             "id": "1b6c5420-eca9-5979-94ba-c41bf99991fa",
-            "imageUrl": "https://cards.scryfall.io/large/front/6/d/6d5802ed-507d-4a52-90e3-d989cd61961b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5802ed-507d-4a52-90e3-d989cd61961b.jpg?1",
             "name": "Offer Immortality",
             "text": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -18904,7 +18904,7 @@
         },
         {
             "id": "9cc65db3-6560-59f0-9a94-cda6a146ecb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a959048-0d8a-41bb-8a33-52264e525085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a959048-0d8a-41bb-8a33-52264e525085.jpg?1",
             "name": "Skeleton Archer",
             "text": "When this creature enters, it deals 1 damage to any target.",
             "colours": [
@@ -18938,7 +18938,7 @@
         },
         {
             "id": "2c64f109-f55a-5d4a-92bd-7e3c01eec610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2c5345-eb55-4bca-9183-b4e1404405f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2c5345-eb55-4bca-9183-b4e1404405f8.jpg?1",
             "name": "Suspicious Shambler",
             "text": "{4}{B}{B}, Exile this card from your graveyard: Create two 2/2 black Zombie creature tokens. Activate only as a sorcery.",
             "colours": [
@@ -18971,7 +18971,7 @@
         },
         {
             "id": "ca8afbe3-0bba-54b6-93dd-ce83cffad897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b3cf11-e352-4ee1-8c03-13898f576ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b3cf11-e352-4ee1-8c03-13898f576ef9.jpg?1",
             "name": "Undying Malice",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
             "colours": [
@@ -19002,7 +19002,7 @@
         },
         {
             "id": "42216626-ef9d-5421-982e-e7eab521ab31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05937911-897b-4638-9536-2e463884f453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05937911-897b-4638-9536-2e463884f453.jpg?1",
             "name": "Untamed Hunger",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -19035,7 +19035,7 @@
         },
         {
             "id": "139d2b58-7895-5aeb-9d37-1464c87ac588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65455d94-487c-4104-a1a0-149515a90eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65455d94-487c-4104-a1a0-149515a90eaa.jpg?1",
             "name": "Vampire Interloper",
             "text": "Flying\nThis creature can't block.",
             "colours": [
@@ -19069,7 +19069,7 @@
         },
         {
             "id": "43d8854b-85c8-51f4-bc5e-9c90ffdd4e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d64a1d-cda4-4c76-8d58-ccab5a6859a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d64a1d-cda4-4c76-8d58-ccab5a6859a0.jpg?1",
             "name": "Vampire Neonate",
             "text": "{2}, {T}: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -19102,7 +19102,7 @@
         },
         {
             "id": "920641f4-7934-56dd-9cfe-77845fc87c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc8d2e-ad63-498d-83b6-5f72b5ae0e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc8d2e-ad63-498d-83b6-5f72b5ae0e67.jpg?1",
             "name": "Vampire Spawn",
             "text": "When this creature enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -19135,7 +19135,7 @@
         },
         {
             "id": "cd400900-bc58-55ec-8c99-0976de2c04de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee05f7e-d4da-4a72-8140-d505eecbdd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee05f7e-d4da-4a72-8140-d505eecbdd32.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -19169,7 +19169,7 @@
         },
         {
             "id": "d953419f-4495-5e16-8fec-b49237983777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c07546-c5a1-4dfc-b5e1-d697578a8c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c07546-c5a1-4dfc-b5e1-d697578a8c11.jpg?1",
             "name": "Carnelian Orb of Dragonkind",
             "text": "{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.",
             "colours": [
@@ -19200,7 +19200,7 @@
         },
         {
             "id": "34b9cb7c-347a-5b0f-828f-7a04bcdcfbf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9abe517-f601-4784-8d62-2350bd755146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9abe517-f601-4784-8d62-2350bd755146.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -19231,7 +19231,7 @@
         },
         {
             "id": "19692683-4d62-5e09-8715-7288ebd36ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e35f88-a580-4b55-9c11-0b58e2f752d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e35f88-a580-4b55-9c11-0b58e2f752d1.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -19265,7 +19265,7 @@
         },
         {
             "id": "e4ceec86-7695-5108-a183-f6788d944fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg?1",
             "name": "Dropkick Bomber",
             "text": "Other Goblins you control get +1/+1.\n{R}: Until end of turn, another target Goblin you control gains flying and \"When this creature deals combat damage, sacrifice it.\"",
             "colours": [
@@ -19299,7 +19299,7 @@
         },
         {
             "id": "5d313e56-679b-5e13-a499-54014c996580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc506f58-048d-49cc-ad8c-2eb851b08bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc506f58-048d-49cc-ad8c-2eb851b08bb6.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -19332,7 +19332,7 @@
         },
         {
             "id": "a3b0198a-8108-5f78-987d-03af55525f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0259e4d8-849b-468e-a902-aa1d7f2d5b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0259e4d8-849b-468e-a902-aa1d7f2d5b6a.jpg?1",
             "name": "Goblin Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -19363,7 +19363,7 @@
         },
         {
             "id": "efbb133f-f316-50d0-8fb4-380b0aaad2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5837ccf1-9bac-4afb-bcc9-82c5f3c0e8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5837ccf1-9bac-4afb-bcc9-82c5f3c0e8e2.jpg?1",
             "name": "Goblin Smuggler",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Another target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -19397,7 +19397,7 @@
         },
         {
             "id": "cb95813c-93cb-54ad-b324-b070975069b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aef07-4291-4dfd-b9b2-bfc26745341c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aef07-4291-4dfd-b9b2-bfc26745341c.jpg?1",
             "name": "Kargan Dragonrider",
             "text": "As long as you control a Dragon, this creature has flying.",
             "colours": [
@@ -19431,7 +19431,7 @@
         },
         {
             "id": "1cc793c0-19bf-552b-8eb8-f428f6f77c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af158462-91e3-4ad7-b435-95d4eb32fe0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af158462-91e3-4ad7-b435-95d4eb32fe0a.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -19462,7 +19462,7 @@
         },
         {
             "id": "f87a9093-0d38-5504-a9c0-7c0766612c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627b0a7-bda9-44df-81c9-aa70cc976331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627b0a7-bda9-44df-81c9-aa70cc976331.jpg?1",
             "name": "Raging Redcap",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -19496,7 +19496,7 @@
         },
         {
             "id": "3c6a2d11-6618-5d87-86fe-21388d0a6f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaddac1-d8ca-4949-8140-c9193e3df921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaddac1-d8ca-4949-8140-c9193e3df921.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen this creature enters, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -19529,7 +19529,7 @@
         },
         {
             "id": "bff7912b-93b9-567c-b67a-7261176d3f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ea09c1-d420-4e99-a968-ade614579287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ea09c1-d420-4e99-a968-ade614579287.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -19560,7 +19560,7 @@
         },
         {
             "id": "db9ede56-68d3-5d47-b3bd-e81e62cf0a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf7e75-5de2-45cc-9275-caccd73214fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf7e75-5de2-45cc-9275-caccd73214fa.jpg?1",
             "name": "Seize the Spoils",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -19591,7 +19591,7 @@
         },
         {
             "id": "6996adb5-72d0-58a9-a68b-8fa9a4dbd797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3fbafb-e915-43eb-8a68-245840ba73ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3fbafb-e915-43eb-8a68-245840ba73ff.jpg?1",
             "name": "Skyraker Giant",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -19624,7 +19624,7 @@
         },
         {
             "id": "976aa7aa-31ce-546e-a10c-585c3e918712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db11970-74c2-463d-88bb-9f88aa079eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db11970-74c2-463d-88bb-9f88aa079eaa.jpg?1",
             "name": "Swab Goblin",
             "text": "",
             "colours": [
@@ -19658,7 +19658,7 @@
         },
         {
             "id": "33420db6-b39b-5a86-964f-ebea8712beba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959a6c7-d615-4524-b94d-65f4164a2656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959a6c7-d615-4524-b94d-65f4164a2656.jpg?1",
             "name": "Terror of Mount Velus",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)\nWhen this creature enters, creatures you control gain double strike until end of turn.",
             "colours": [
@@ -19691,7 +19691,7 @@
         },
         {
             "id": "0dec2d4d-0035-5c6b-ab6f-d15d66390d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc914fe-e699-4a21-aa09-f3573d020b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc914fe-e699-4a21-aa09-f3573d020b87.jpg?1",
             "name": "Volley Veteran",
             "text": "When this creature enters, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -19725,7 +19725,7 @@
         },
         {
             "id": "9129a289-fd63-5173-b89c-d4311ac61755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7724b978-999b-4654-96f3-58e28aa7cb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7724b978-999b-4654-96f3-58e28aa7cb34.jpg?1",
             "name": "Aggressive Mammoth",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther creatures you control have trample.",
             "colours": [
@@ -19758,7 +19758,7 @@
         },
         {
             "id": "7c351923-0a42-5b25-817d-02686a9c532b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8662ebb-068b-41d2-b504-4b5854e4d4aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8662ebb-068b-41d2-b504-4b5854e4d4aa.jpg?1",
             "name": "Bear Cub",
             "text": "",
             "colours": [
@@ -19791,7 +19791,7 @@
         },
         {
             "id": "4a99527f-ab5a-5afa-8c0e-76270ff938ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef20af5e-1ffe-426a-805a-ca4a6a122260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef20af5e-1ffe-426a-805a-ca4a6a122260.jpg?1",
             "name": "Biogenic Upgrade",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.",
             "colours": [
@@ -19822,7 +19822,7 @@
         },
         {
             "id": "66a38f24-16fc-5b6c-afa2-3deb6a022be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2d0ee9-865c-4fc9-8cb6-540c597e1bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2d0ee9-865c-4fc9-8cb6-540c597e1bf4.jpg?1",
             "name": "Druid of the Cowl",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -19856,7 +19856,7 @@
         },
         {
             "id": "5f277d3a-93b2-5c35-89df-c35af9fa8ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ceca57-65f4-4f99-bd14-9fe5f86c1f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ceca57-65f4-4f99-bd14-9fe5f86c1f62.jpg?1",
             "name": "Joraga Invocation",
             "text": "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -19887,7 +19887,7 @@
         },
         {
             "id": "0d93300f-5728-5a3d-897d-15b5af6fcb10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5624e610-c4c0-4103-a32b-0f1264030a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5624e610-c4c0-4103-a32b-0f1264030a7a.jpg?1",
             "name": "Magnigoth Sentry",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -19920,7 +19920,7 @@
         },
         {
             "id": "28c98466-e4fb-5da0-8e0c-f57efad292e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3923c-c35c-4eb2-9dd3-b15c13778ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3923c-c35c-4eb2-9dd3-b15c13778ecf.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen this Aura enters, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -19953,7 +19953,7 @@
         },
         {
             "id": "069853c5-6346-5fbf-a581-3ab24fb636c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da20a0d3-2022-4dea-84c8-85adc5a974f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da20a0d3-2022-4dea-84c8-85adc5a974f8.jpg?1",
             "name": "Tajuru Pathwarden",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -19988,7 +19988,7 @@
         },
         {
             "id": "bcf2e9fe-a348-579f-a37a-ea2bd73e931e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f6199-f2fe-49a5-89ca-3c4cb39fbf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f6199-f2fe-49a5-89ca-3c4cb39fbf2b.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -20022,7 +20022,7 @@
         },
         {
             "id": "20a0096d-b0d5-5bc2-b287-6f1703f118c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592364bf-68b5-4ea0-97d6-c7cadce940fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592364bf-68b5-4ea0-97d6-c7cadce940fd.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice this creature: Destroy target artifact or enchantment.",
             "colours": [
@@ -20055,7 +20055,7 @@
         },
         {
             "id": "5b871ec9-e20f-5545-86c9-3783f78115dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f42969-bb5c-4183-8bd3-ba87f008391d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f42969-bb5c-4183-8bd3-ba87f008391d.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -20089,7 +20089,7 @@
         },
         {
             "id": "3fe523c5-3d5f-5c3e-bf3e-4996d9b87818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ab3f99-9541-4100-818c-5d9e916791e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ab3f99-9541-4100-818c-5d9e916791e4.jpg?1",
             "name": "Goblin Firebomb",
             "text": "Flash\n{7}, {T}, Sacrifice this artifact: Destroy target permanent.",
             "colours": [],
@@ -20116,7 +20116,7 @@
         },
         {
             "id": "adc8ae51-5efe-5339-99dd-6624b9b4d067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d20aef-d35b-4353-a241-e6cfa9730975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d20aef-d35b-4353-a241-e6cfa9730975.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When this Equipment enters, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -20145,7 +20145,7 @@
         },
         {
             "id": "0bf415d7-9a4a-50ff-b220-0e08916a856b",
-            "imageUrl": "https://cards.scryfall.io/large/front/1/7/172cd5b7-98fc-4add-b858-a0b3dfb75c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172cd5b7-98fc-4add-b858-a0b3dfb75c19.jpg?1",
             "name": "Uncharted Haven",
             "text": "This land enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -20172,7 +20172,7 @@
         },
         {
             "id": "cfc7fd80-d1c7-585d-9845-53fb298aad71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066d73fa-369b-44a3-b1a9-d22176ac3566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066d73fa-369b-44a3-b1a9-d22176ac3566.jpg?1",
             "name": "Angelic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition to its other types.\nWhen enchanted creature dies, return Angelic Destiny to its owner's hand.",
             "colours": [
@@ -20205,7 +20205,7 @@
         },
         {
             "id": "44e268ff-2f50-54bb-83f0-b2fe08ed695e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ff489-bdd7-4aeb-8130-3c234d0dd3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ff489-bdd7-4aeb-8130-3c234d0dd3dd.jpg?1",
             "name": "Archway Angel",
             "text": "Flying\nWhen this creature enters, you gain 2 life for each Gate you control.",
             "colours": [
@@ -20238,7 +20238,7 @@
         },
         {
             "id": "0800b712-53f4-58e1-8d53-424fc1ad0c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a7daa-a112-4728-9123-594366694915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a7daa-a112-4728-9123-594366694915.jpg?1",
             "name": "Ballyrush Banneret",
             "text": "Kithkin spells and Soldier spells you cast cost {1} less to cast.",
             "colours": [
@@ -20272,7 +20272,7 @@
         },
         {
             "id": "12f71161-1bc7-5df6-bcd9-3162ead8df3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7b47e1-7e32-4f2f-aecf-bac7ca197081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7b47e1-7e32-4f2f-aecf-bac7ca197081.jpg?1",
             "name": "Charming Prince",
             "text": "When this creature enters, choose one \u2014\n\u2022 Scry 2.\n\u2022 You gain 3 life.\n\u2022 Exile another target creature you own. Return it to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -20306,7 +20306,7 @@
         },
         {
             "id": "4f353e97-e3a8-5d2a-a438-90c7c3233cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009029c2-26b9-498f-8765-e91c2e1f3aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009029c2-26b9-498f-8765-e91c2e1f3aee.jpg?1",
             "name": "Crusader of Odric",
             "text": "Crusader of Odric's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -20340,7 +20340,7 @@
         },
         {
             "id": "2d083f37-e9a0-5832-ad51-973c2ca32e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807db84f-addb-4ef0-b9ba-32b3e1bced3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807db84f-addb-4ef0-b9ba-32b3e1bced3d.jpg?1",
             "name": "Dawnwing Marshal",
             "text": "Flying\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -20374,7 +20374,7 @@
         },
         {
             "id": "4c21a8d5-a75b-5646-be01-b9ad91be11fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d174cb01-b1cf-444c-a893-cc61ddf88b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d174cb01-b1cf-444c-a893-cc61ddf88b8c.jpg?1",
             "name": "Devout Decree",
             "text": "Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -20405,7 +20405,7 @@
         },
         {
             "id": "ce340585-e603-5c45-a81c-10418d5b8448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac43e16-8b14-46f2-877a-600ea918766b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac43e16-8b14-46f2-877a-600ea918766b.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -20436,7 +20436,7 @@
         },
         {
             "id": "a61901c5-1bac-5643-bcad-4e89b9d080ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d61d50b-7ab6-45a9-b207-31d87aa2e555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d61d50b-7ab6-45a9-b207-31d87aa2e555.jpg?1",
             "name": "Felidar Cub",
             "text": "Sacrifice this creature: Destroy target enchantment.",
             "colours": [
@@ -20470,7 +20470,7 @@
         },
         {
             "id": "c7ce0ac9-8c1a-58b3-87fa-da8a21bb1dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e3cc09-5057-4c05-88fc-d6cda809fc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e3cc09-5057-4c05-88fc-d6cda809fc74.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land you control enters, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -20501,7 +20501,7 @@
         },
         {
             "id": "ff01fa7c-3794-5df9-842b-6077b53e74ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c1e655-1883-428f-abe8-69c011cfbd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c1e655-1883-428f-abe8-69c011cfbd4b.jpg?1",
             "name": "Fumigate",
             "text": "Destroy all creatures. You gain 1 life for each creature destroyed this way.",
             "colours": [
@@ -20532,7 +20532,7 @@
         },
         {
             "id": "cb432ba4-ffde-5f3a-af3c-eb63910b6947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efb8633-0a70-4ddc-80af-42508ec75cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efb8633-0a70-4ddc-80af-42508ec75cff.jpg?1",
             "name": "Knight of Grace",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nHexproof from black (This creature can't be the target of black spells or abilities your opponents control.)\nThis creature gets +1/+0 as long as any player controls a black permanent.",
             "colours": [
@@ -20566,7 +20566,7 @@
         },
         {
             "id": "28cd16d7-693b-5800-8915-2a3331a04095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcd0898-db3d-44ec-9d56-a1b558da90f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcd0898-db3d-44ec-9d56-a1b558da90f4.jpg?1",
             "name": "Linden, the Steadfast Queen",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever a white creature you control attacks, you gain 1 life.",
             "colours": [
@@ -20602,7 +20602,7 @@
         },
         {
             "id": "17bcec5b-61b5-5022-83db-da87b9dd8263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790977-efd4-470a-823a-6929f84016e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790977-efd4-470a-823a-6929f84016e7.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature you control with power 2 or less enters, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -20636,7 +20636,7 @@
         },
         {
             "id": "16d3a4d4-33bc-5de9-9452-4635ceb813bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6310a82-73db-40cb-ae64-6f07f869024c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6310a82-73db-40cb-ae64-6f07f869024c.jpg?1",
             "name": "Regal Caracal",
             "text": "Other Cats you control get +1/+1 and have lifelink. (Damage dealt by those creatures also causes you to gain that much life.)\nWhen this creature enters, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -20669,7 +20669,7 @@
         },
         {
             "id": "764717e1-2ffb-5a29-a6d6-75b4b3701b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f10906-4fd5-44e8-99c7-3f9dcc988c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f10906-4fd5-44e8-99c7-3f9dcc988c48.jpg?1",
             "name": "Release the Dogs",
             "text": "Create four 1/1 white Dog creature tokens.",
             "colours": [
@@ -20700,7 +20700,7 @@
         },
         {
             "id": "bee3b8ac-e34c-5207-9d1b-afd5423336e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce41e348-44c2-47f8-8e7d-da2e4d16d648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce41e348-44c2-47f8-8e7d-da2e4d16d648.jpg?1",
             "name": "Stasis Snare",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this enchantment enters, exile target creature an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -20731,7 +20731,7 @@
         },
         {
             "id": "998cdccb-6678-53ab-bf06-e636565db608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d42be5f-a6a7-4699-abf7-9632de6daede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d42be5f-a6a7-4699-abf7-9632de6daede.jpg?1",
             "name": "Syr Alin, the Lion's Claw",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Syr Alin attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -20767,7 +20767,7 @@
         },
         {
             "id": "002c8b92-c54f-5474-a5df-6ce7a0ea6143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4c47e3-04b6-4760-9a80-b6acef1e4524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4c47e3-04b6-4760-9a80-b6acef1e4524.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -20798,7 +20798,7 @@
         },
         {
             "id": "f2093e7e-1dd8-5cc0-9a05-8d82acd7d37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694df80e-77d1-4455-b6f1-58d212267d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694df80e-77d1-4455-b6f1-58d212267d76.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -20834,7 +20834,7 @@
         },
         {
             "id": "dc50d493-dfeb-5569-8c46-51373d6b2621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fee90a-7cb3-4fad-91a7-1b1edbde0133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fee90a-7cb3-4fad-91a7-1b1edbde0133.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis to its owner's hand.",
             "colours": [
@@ -20869,7 +20869,7 @@
         },
         {
             "id": "e3b81ced-d237-5704-9628-766ab6fe3529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599d459-fe71-48f4-8c65-0f519bb63a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599d459-fe71-48f4-8c65-0f519bb63a68.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked this turn.",
             "colours": [
@@ -20900,7 +20900,7 @@
         },
         {
             "id": "29397c75-2235-5bbf-9601-75a3a084773a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e4087b-e692-4eb2-bb59-ff2a001d6dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e4087b-e692-4eb2-bb59-ff2a001d6dd4.jpg?1",
             "name": "Dictate of Kruphix",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nAt the beginning of each player's draw step, that player draws an additional card.",
             "colours": [
@@ -20931,7 +20931,7 @@
         },
         {
             "id": "06369e19-248b-56eb-a3a0-29da9fdd9560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d5cff9-a3ec-432d-9ce5-68949e524279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d5cff9-a3ec-432d-9ce5-68949e524279.jpg?1",
             "name": "Dive Down",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -20962,7 +20962,7 @@
         },
         {
             "id": "19babb20-4d5e-5a23-b71c-93012e8e22cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a77e063-e8f6-4cb2-954e-74cf41ce73da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a77e063-e8f6-4cb2-954e-74cf41ce73da.jpg?1",
             "name": "Finale of Revelation",
             "text": "Draw X cards. If X is 10 or more, instead shuffle your graveyard into your library, draw X cards, untap up to five lands, and you have no maximum hand size for the rest of the game.\nExile Finale of Revelation.",
             "colours": [
@@ -20993,7 +20993,7 @@
         },
         {
             "id": "4350c5e6-acc1-56e7-a721-d9ea4eaefcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e37a7e-6093-4ef5-b6e4-4aa800ddfc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e37a7e-6093-4ef5-b6e4-4aa800ddfc1b.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -21024,7 +21024,7 @@
         },
         {
             "id": "38b7af9a-47ec-585b-bb61-ca4ceed8b08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18748b1d-4161-482c-a726-8762b4c1819c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18748b1d-4161-482c-a726-8762b4c1819c.jpg?1",
             "name": "Fog Bank",
             "text": "Defender (This creature can't attack.)\nFlying\nPrevent all combat damage that would be dealt to and dealt by this creature.",
             "colours": [
@@ -21057,7 +21057,7 @@
         },
         {
             "id": "41b3ca0f-6843-5055-a493-e3b1dd4a1017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3834176f-29c5-4511-87d6-75d0c348a770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3834176f-29c5-4511-87d6-75d0c348a770.jpg?1",
             "name": "Gateway Sneak",
             "text": "Whenever a Gate you control enters, this creature can't be blocked this turn.\nWhenever this creature deals combat damage to a player, draw a card.",
             "colours": [
@@ -21091,7 +21091,7 @@
         },
         {
             "id": "d0956e0e-6517-5b75-bc8c-f6daddc3bdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca4f70d-ec17-49a4-8968-598ecdbe8243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca4f70d-ec17-49a4-8968-598ecdbe8243.jpg?1",
             "name": "Harbinger of the Tides",
             "text": "You may cast this card as though it had flash if you pay {2} more to cast it. (You may cast it any time you could cast an instant.)\nWhen this creature enters, you may return target tapped creature an opponent controls to its owner's hand.",
             "colours": [
@@ -21125,7 +21125,7 @@
         },
         {
             "id": "6a27cbc3-3d65-5c19-add5-c4fae06ac2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f88eacf-5c7b-4a35-86f0-af3b0516d4c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f88eacf-5c7b-4a35-86f0-af3b0516d4c2.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, put it into your hand, then shuffle.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -21157,7 +21157,7 @@
         },
         {
             "id": "4b0ecaab-ce8d-50a3-9dec-cdd5bb1313b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg?1",
             "name": "River's Rebuke",
             "text": "Return all nonland permanents target player controls to their owner's hand.",
             "colours": [
@@ -21188,7 +21188,7 @@
         },
         {
             "id": "16020744-d652-5318-b6fa-7e7e2f975bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f20fe3d-792a-4030-a25c-e81b48b2bcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f20fe3d-792a-4030-a25c-e81b48b2bcb4.jpg?1",
             "name": "Shipwreck Dowser",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -21222,7 +21222,7 @@
         },
         {
             "id": "09e73939-6d95-5637-a63b-c7be5401ddc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cf2366-40d0-4f94-84a5-8aa42308e223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cf2366-40d0-4f94-84a5-8aa42308e223.jpg?1",
             "name": "Sphinx of the Final Word",
             "text": "This spell can't be countered.\nFlying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)\nInstant and sorcery spells you control can't be countered.",
             "colours": [
@@ -21255,7 +21255,7 @@
         },
         {
             "id": "9a810491-6100-5855-98c8-91e765ee6aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7766506c-bc18-4ac3-9034-e8f7e54c4039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7766506c-bc18-4ac3-9034-e8f7e54c4039.jpg?1",
             "name": "Tempest Djinn",
             "text": "Flying\nThis creature gets +1/+0 for each basic Island you control.",
             "colours": [
@@ -21288,7 +21288,7 @@
         },
         {
             "id": "1bab8a13-916b-5e7d-a59c-43cd6f6f84ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378d319-ab98-422a-8f72-121a9d26f5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378d319-ab98-422a-8f72-121a9d26f5c6.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -21319,7 +21319,7 @@
         },
         {
             "id": "497fd560-8792-53dd-939c-95a9d669867a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27b40dd-9b2a-4a99-a984-ee9cfdb091a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27b40dd-9b2a-4a99-a984-ee9cfdb091a1.jpg?1",
             "name": "Voracious Greatshark",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, counter target artifact or creature spell.",
             "colours": [
@@ -21352,7 +21352,7 @@
         },
         {
             "id": "3bf3a815-5570-5dcb-b4ba-582e0f78d136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42592d75-593e-4719-b13b-bca374017e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42592d75-593e-4719-b13b-bca374017e79.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -21383,7 +21383,7 @@
         },
         {
             "id": "8c220808-74ba-523a-8bf8-4c8aa86ebc94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0b7242-df91-48cf-bf4e-b68306c9965f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0b7242-df91-48cf-bf4e-b68306c9965f.jpg?1",
             "name": "Demonic Pact",
             "text": "At the beginning of your upkeep, choose one that hasn't been chosen \u2014\n\u2022 This enchantment deals 4 damage to any target and you gain 4 life.\n\u2022 Target opponent discards two cards.\n\u2022 Draw two cards.\n\u2022 You lose the game.",
             "colours": [
@@ -21414,7 +21414,7 @@
         },
         {
             "id": "522ac52c-490d-5dd5-bb60-f0098381ee63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bf6460-0df6-4dd3-8af8-df728683bcaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bf6460-0df6-4dd3-8af8-df728683bcaa.jpg?1",
             "name": "Desecration Demon",
             "text": "Flying\nAt the beginning of each combat, any opponent may sacrifice a creature of their choice. If a player does, tap this creature and put a +1/+1 counter on it.",
             "colours": [
@@ -21447,7 +21447,7 @@
         },
         {
             "id": "13f0fd2f-5249-5098-8b62-c18e71d7e40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb5dd33-6e5b-4d78-92fa-678c9f01c606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb5dd33-6e5b-4d78-92fa-678c9f01c606.jpg?1",
             "name": "Dread Summons",
             "text": "Each player mills X cards. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -21478,7 +21478,7 @@
         },
         {
             "id": "5d984ec7-7295-5ca7-b608-82b1f959431e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443696a-0b9a-4081-91aa-800b5c4065d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443696a-0b9a-4081-91aa-800b5c4065d2.jpg?1",
             "name": "Driver of the Dead",
             "text": "When this creature dies, return target creature card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -21511,7 +21511,7 @@
         },
         {
             "id": "a251feb0-e73f-587c-a823-c0da42bffee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3a894-ee75-4db9-a69f-711bb3cc150a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3a894-ee75-4db9-a69f-711bb3cc150a.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -21542,7 +21542,7 @@
         },
         {
             "id": "bd3aaf58-5524-5450-beae-7c238e82bacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a52f6ef-7759-4be3-8b80-a57e9d6ae386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a52f6ef-7759-4be3-8b80-a57e9d6ae386.jpg?1",
             "name": "Kalastria Highborn",
             "text": "Whenever this creature or another Vampire you control dies, you may pay {B}. If you do, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -21576,7 +21576,7 @@
         },
         {
             "id": "89563a90-fcf4-50b2-8a82-a4f438f432d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb678e10-e5a4-4143-8e49-7b523118674e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb678e10-e5a4-4143-8e49-7b523118674e.jpg?1",
             "name": "Knight of Malice",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nHexproof from white (This creature can't be the target of white spells or abilities your opponents control.)\nThis creature gets +1/+0 as long as any player controls a white permanent.",
             "colours": [
@@ -21610,7 +21610,7 @@
         },
         {
             "id": "9095c95c-b8b5-5df2-9fd7-b5d3045b56d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f229b0e6-1ffd-410e-b04b-a0afc179c58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f229b0e6-1ffd-410e-b04b-a0afc179c58c.jpg?1",
             "name": "Midnight Reaper",
             "text": "Whenever a nontoken creature you control dies, this creature deals 1 damage to you and you draw a card.",
             "colours": [
@@ -21644,7 +21644,7 @@
         },
         {
             "id": "99fdc6fe-8f4a-5837-a200-a5406683c5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc5505-7fa0-4ebf-a691-b4ca5f52b019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc5505-7fa0-4ebf-a691-b4ca5f52b019.jpg?1",
             "name": "Myojin of Night's Reach",
             "text": "Myojin of Night's Reach enters with a divinity counter on it if you cast it from your hand.\nMyojin of Night's Reach has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Night's Reach: Each opponent discards their hand.",
             "colours": [
@@ -21679,7 +21679,7 @@
         },
         {
             "id": "9603dc1c-5273-5b26-9b55-06bda9e0f98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7613c-38fc-49c3-93ee-1df93136455a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7613c-38fc-49c3-93ee-1df93136455a.jpg?1",
             "name": "Nullpriest of Oblivion",
             "text": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nLifelink\nMenace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, if it was kicked, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -21713,7 +21713,7 @@
         },
         {
             "id": "16520114-4140-5450-9347-b21f82e9cf2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbbe4d-5c93-4b14-8123-cd835452870f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbbe4d-5c93-4b14-8123-cd835452870f.jpg?1",
             "name": "Pulse Tracker",
             "text": "Whenever this creature attacks, each opponent loses 1 life.",
             "colours": [
@@ -21747,7 +21747,7 @@
         },
         {
             "id": "462a9cc6-3d4e-5ffd-ad82-4309164430ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a26ca7-b26f-4b86-a060-712f15f4bf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a26ca7-b26f-4b86-a060-712f15f4bf7f.jpg?1",
             "name": "Sanguine Indulgence",
             "text": "This spell costs {3} less to cast if you've gained 3 or more life this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -21778,7 +21778,7 @@
         },
         {
             "id": "2d1866ed-7412-5a9e-81aa-0604795a552a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1b897-bb7d-4217-97a7-c89f2453c8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1b897-bb7d-4217-97a7-c89f2453c8fa.jpg?1",
             "name": "Tribute to Hunger",
             "text": "Target opponent sacrifices a creature of their choice. You gain life equal to that creature's toughness.",
             "colours": [
@@ -21809,7 +21809,7 @@
         },
         {
             "id": "3b853bf9-8485-536b-b2e2-1b306f8766de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0b1e0-a481-4a98-b67b-0cf8bac53fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0b1e0-a481-4a98-b67b-0cf8bac53fdd.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -21840,7 +21840,7 @@
         },
         {
             "id": "3052f2c9-b1db-56cd-987b-ccbd941aed80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833b5a32-5d77-4e46-a524-25bada29ef59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833b5a32-5d77-4e46-a524-25bada29ef59.jpg?1",
             "name": "Vile Entomber",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen this creature enters, search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -21874,7 +21874,7 @@
         },
         {
             "id": "126156cd-d51f-5f9d-a154-607538a16b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5.jpg?1",
             "name": "Wishclaw Talisman",
             "text": "This artifact enters with three wish counters on it.\n{1}, {T}, Remove a wish counter from this artifact: Search your library for a card, put it into your hand, then shuffle. An opponent gains control of this artifact. Activate only during your turn.",
             "colours": [
@@ -21905,7 +21905,7 @@
         },
         {
             "id": "eebb2f94-beb6-538f-8ed7-f64a69bd885d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f27dbf0-6818-40ea-832d-10686b4c2900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f27dbf0-6818-40ea-832d-10686b4c2900.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nAt the beginning of the end step, sacrifice this creature.",
             "colours": [
@@ -21938,7 +21938,7 @@
         },
         {
             "id": "3cac278c-014b-55c3-9bf0-d09f5a087e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01af2c-68e5-4bb5-81de-f3a1b860fb2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01af2c-68e5-4bb5-81de-f3a1b860fb2e.jpg?1",
             "name": "Bolt Bend",
             "text": "This spell costs {3} less to cast if you control a creature with power 4 or greater.\nChange the target of target spell or ability with a single target.",
             "colours": [
@@ -21969,7 +21969,7 @@
         },
         {
             "id": "9d6ad563-b624-557e-b697-90e45aba8a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb16918-6363-4849-8d74-e26822a0ddf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb16918-6363-4849-8d74-e26822a0ddf7.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn. (Each of those creature can deal excess combat damage to the player or planeswalker it's attacking.)\nDraw a card.",
             "colours": [
@@ -22000,7 +22000,7 @@
         },
         {
             "id": "8a5427ab-e3c1-594d-9d0a-735ecd317c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5525cfde-a92b-4fb5-8f15-a05efebecd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5525cfde-a92b-4fb5-8f15-a05efebecd3d.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever this creature deals combat damage to a player, each player discards their hand, then draws seven cards.",
             "colours": [
@@ -22034,7 +22034,7 @@
         },
         {
             "id": "e12a6665-c806-531c-8d4a-eb1a99f3116d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b720f3a8-f38f-4460-86a3-dad541e7add7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b720f3a8-f38f-4460-86a3-dad541e7add7.jpg?1",
             "name": "Dragonmaster Outcast",
             "text": "At the beginning of your upkeep, if you control six or more lands, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -22068,7 +22068,7 @@
         },
         {
             "id": "cc5c3acd-6233-5e25-a05d-5ba2f7fe399b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940d76d-c09f-4d72-a037-439c70ee8d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940d76d-c09f-4d72-a037-439c70ee8d9d.jpg?1",
             "name": "Ghitu Lavarunner",
             "text": "As long as there are two or more instant and/or sorcery cards in your graveyard, this creature gets +1/+0 and has haste. (It can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -22102,7 +22102,7 @@
         },
         {
             "id": "e17b6c63-d871-5e6e-bd6c-275759e23159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f5298-0e57-49cf-aaf5-2bb16f3e636c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f5298-0e57-49cf-aaf5-2bb16f3e636c.jpg?1",
             "name": "Giant Cindermaw",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nPlayers can't gain life.",
             "colours": [
@@ -22136,7 +22136,7 @@
         },
         {
             "id": "87143714-e631-55f1-ace4-22eb5575e274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg?1",
             "name": "Harmless Offering",
             "text": "Target opponent gains control of target permanent you control.",
             "colours": [
@@ -22167,7 +22167,7 @@
         },
         {
             "id": "154beef4-7ea7-5fb7-bf03-09c1676a61e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a35b3b-0c92-4b40-8210-86a5b5f275eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a35b3b-0c92-4b40-8210-86a5b5f275eb.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen this creature enters, you may search your library for an artifact card, exile it, then shuffle.\nWhen this creature dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -22200,7 +22200,7 @@
         },
         {
             "id": "08b966cc-4bcf-5535-8248-6806a84e2b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409acb8f-cf03-4a56-a8c0-e4c97a01ee10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409acb8f-cf03-4a56-a8c0-e4c97a01ee10.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon you control enters, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -22235,7 +22235,7 @@
         },
         {
             "id": "1bc5eb5b-f42b-54c3-aefe-2b3c61b80dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8b3e58-be07-451e-a5c7-61c70cc3a5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8b3e58-be07-451e-a5c7-61c70cc3a5a2.jpg?1",
             "name": "Mindsparker",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever an opponent casts a white or blue instant or sorcery spell, this creature deals 2 damage to that player.",
             "colours": [
@@ -22268,7 +22268,7 @@
         },
         {
             "id": "187d91dd-cdcf-5956-9762-0ebbc0f29a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e836b-1c7b-43ac-889b-5f94e1638c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e836b-1c7b-43ac-889b-5f94e1638c42.jpg?1",
             "name": "Obliterating Bolt",
             "text": "Obliterating Bolt deals 4 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -22299,7 +22299,7 @@
         },
         {
             "id": "94e7f574-c99e-5267-bc24-a2eef376eae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b70c4-9086-4db4-8e65-f9bb5f67cf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b70c4-9086-4db4-8e65-f9bb5f67cf1b.jpg?1",
             "name": "Ravenous Giant",
             "text": "At the beginning of your upkeep, this creature deals 1 damage to you.",
             "colours": [
@@ -22332,7 +22332,7 @@
         },
         {
             "id": "a9a3fbc0-da68-57a9-9877-7a6f6c55744e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c7f55a-bcc7-4ca3-853d-fc6e260d9429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c7f55a-bcc7-4ca3-853d-fc6e260d9429.jpg?1",
             "name": "Redcap Gutter-Dweller",
             "text": "Menace\nWhen this creature enters, create two 1/1 black Rat creature tokens with \"This token can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature and exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -22366,7 +22366,7 @@
         },
         {
             "id": "ccd3c206-4b94-5df8-87ba-3726848dafe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f306c7e-cacc-4c26-a3f1-fad4f3ff7cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f306c7e-cacc-4c26-a3f1-fad4f3ff7cf3.jpg?1",
             "name": "Stromkirk Noble",
             "text": "This creature can't be blocked by Humans.\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -22400,7 +22400,7 @@
         },
         {
             "id": "cb54466e-31f8-5b9b-ae86-48ae126c97c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca7caa5-d920-4f06-90bd-214aa4e85cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca7caa5-d920-4f06-90bd-214aa4e85cb3.jpg?1",
             "name": "Taurean Mauler",
             "text": "Changeling (This card is every creature type.)\nWhenever an opponent casts a spell, you may put a +1/+1 counter on this creature.",
             "colours": [
@@ -22433,7 +22433,7 @@
         },
         {
             "id": "985f184a-f5a4-551f-9134-a37a94942bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f52ada2-cabc-46a3-99df-271833a86909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f52ada2-cabc-46a3-99df-271833a86909.jpg?1",
             "name": "Viashino Pyromancer",
             "text": "When this creature enters, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -22467,7 +22467,7 @@
         },
         {
             "id": "af74d5af-5dbe-55a8-88ed-35f47dca3623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a806dec2-d4f9-4f8d-a1dd-170777941131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a806dec2-d4f9-4f8d-a1dd-170777941131.jpg?1",
             "name": "Circuitous Route",
             "text": "Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22498,7 +22498,7 @@
         },
         {
             "id": "8ea9035b-1e52-5ebd-a5d3-606a4efc10bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1dd7f-2e42-4062-a941-b489b98a49fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1dd7f-2e42-4062-a941-b489b98a49fc.jpg?1",
             "name": "Fierce Empath",
             "text": "When this creature enters, you may search your library for a creature card with mana value 6 or greater, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -22531,7 +22531,7 @@
         },
         {
             "id": "1d8f0d5e-1f91-5d67-a205-8e8108fbc679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699efb9e-2649-432b-8b2d-10775114c314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699efb9e-2649-432b-8b2d-10775114c314.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -22567,7 +22567,7 @@
         },
         {
             "id": "8aeb31df-6916-5f49-9bd0-c7a22cb3b618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b638f3d-7eb6-4675-9538-4a87a7f75c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b638f3d-7eb6-4675-9538-4a87a7f75c43.jpg?1",
             "name": "Gnarlback Rhino",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever you cast a spell that targets this creature, draw a card.",
             "colours": [
@@ -22600,7 +22600,7 @@
         },
         {
             "id": "49c7504a-649d-5898-bf8b-6c7d9c66ed86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f83195c-5150-4763-a2e1-5b109d185d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f83195c-5150-4763-a2e1-5b109d185d55.jpg?1",
             "name": "Heroes' Bane",
             "text": "This creature enters with four +1/+1 counters on it.\n{2}{G}{G}: Put X +1/+1 counters on this creature, where X is its power.",
             "colours": [
@@ -22633,7 +22633,7 @@
         },
         {
             "id": "7e532c83-1a3c-56e1-8f25-b929fc47d42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d665cd-a2c6-4b81-8032-379e476b5ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d665cd-a2c6-4b81-8032-379e476b5ea5.jpg?1",
             "name": "Mold Adder",
             "text": "Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on this creature.",
             "colours": [
@@ -22667,7 +22667,7 @@
         },
         {
             "id": "238dcbbf-dc26-5900-a97e-b950f0dde4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a70424d-86a7-44a3-acda-4463d7ac503b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a70424d-86a7-44a3-acda-4463d7ac503b.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice this Aura.\nWhen you sacrifice this Aura, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22700,7 +22700,7 @@
         },
         {
             "id": "8fae94e6-68bf-5b24-9e84-dd9590d229ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a.jpg?1",
             "name": "Predator Ooze",
             "text": "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature.)\nWhenever this creature attacks, put a +1/+1 counter on it.\nWhenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature.",
             "colours": [
@@ -22733,7 +22733,7 @@
         },
         {
             "id": "87e2456d-2b52-5aba-8cb1-4f3b9c4a3446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae57d6b-15e8-4f2a-97c2-76d801a1a42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae57d6b-15e8-4f2a-97c2-76d801a1a42a.jpg?1",
             "name": "Primal Might",
             "text": "Target creature you control gets +X/+X until end of turn. Then it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -22764,7 +22764,7 @@
         },
         {
             "id": "e307dc72-3423-512d-8e1b-8e6940283979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332c9742-dc3b-48e5-8736-7724fae1b4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332c9742-dc3b-48e5-8736-7724fae1b4c4.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nLandfall \u2014 Whenever a land you control enters, you gain 3 life.",
             "colours": [
@@ -22795,7 +22795,7 @@
         },
         {
             "id": "295e6c98-ea41-5578-8777-94b81a35f3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25ee47b-d099-4788-9c2b-73d151bf56fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25ee47b-d099-4788-9c2b-73d151bf56fb.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land you control enters, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -22828,7 +22828,7 @@
         },
         {
             "id": "ad04875d-d329-5217-aca6-8d725e5db702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa87cb5f-4dc9-49a4-9ae6-ebc7fedac018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa87cb5f-4dc9-49a4-9ae6-ebc7fedac018.jpg?1",
             "name": "Springbloom Druid",
             "text": "When this creature enters, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22862,7 +22862,7 @@
         },
         {
             "id": "e67ae3d8-f610-5f84-85d9-139de3804a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8759d-0dc8-4218-93ac-b1a35088f776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8759d-0dc8-4218-93ac-b1a35088f776.jpg?1",
             "name": "Surrak, the Hunt Caller",
             "text": "At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn. (It can attack and {T} no matter when it came under your control.)",
             "colours": [
@@ -22898,7 +22898,7 @@
         },
         {
             "id": "5c914fe7-5636-5ed9-8e78-30dd90d7c246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f8d876-3697-4359-9f2b-6053682b556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f8d876-3697-4359-9f2b-6053682b556c.jpg?1",
             "name": "Venom Connoisseur",
             "text": "Whenever another creature you control enters, this creature gains deathtouch until end of turn. If this is the second time this ability has resolved this turn, all creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -22932,7 +22932,7 @@
         },
         {
             "id": "bbd8960a-ffdb-5060-b4c1-7648bec3535f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3010ec33-c3f6-42ce-ad5a-e149e5c9a805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3010ec33-c3f6-42ce-ad5a-e149e5c9a805.jpg?1",
             "name": "Vizier of the Menagerie",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\nYou can spend mana of any type to cast creature spells.",
             "colours": [
@@ -22966,7 +22966,7 @@
         },
         {
             "id": "fddef846-406d-5529-a805-66d1fa459f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a249d1c-a5fe-48e5-bd9b-e50d8eea391b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a249d1c-a5fe-48e5-bd9b-e50d8eea391b.jpg?1",
             "name": "Wildborn Preserver",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nReach (This creature can block creatures with flying.)\nWhenever another non-Human creature you control enters, you may pay {X}. When you do, put X +1/+1 counters on this creature.",
             "colours": [
@@ -23000,7 +23000,7 @@
         },
         {
             "id": "2d4e0d3f-2c1d-5a17-b5f2-86baba0ddaf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ffc1c-575b-4116-83c9-d13b29886c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ffc1c-575b-4116-83c9-d13b29886c35.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -23037,7 +23037,7 @@
         },
         {
             "id": "0fd4d2f0-bfba-5be1-af85-14d605378f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06969031-2c13-4b5a-bb4e-86eed025e614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06969031-2c13-4b5a-bb4e-86eed025e614.jpg?1",
             "name": "Ayli, Eternal Pilgrim",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.\n{1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate only if you have at least 10 life more than your starting life total.",
             "colours": [
@@ -23075,7 +23075,7 @@
         },
         {
             "id": "3f93d5ae-c27b-51a5-a181-884610b3a320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c966ab-0d92-4fa7-8a91-1f77089d8fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c966ab-0d92-4fa7-8a91-1f77089d8fc7.jpg?1",
             "name": "Cloudblazer",
             "text": "Flying\nWhen this creature enters, you gain 2 life and draw two cards.",
             "colours": [
@@ -23111,7 +23111,7 @@
         },
         {
             "id": "3e4e2e91-c8da-5f0f-af4e-c8b45eaf229a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd4d5a4-4342-49fb-b1e4-7d08e6cf5376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd4d5a4-4342-49fb-b1e4-7d08e6cf5376.jpg?1",
             "name": "Deadly Brew",
             "text": "Each player sacrifices a creature or planeswalker of their choice. If you sacrificed a permanent this way, you may return another permanent card from your graveyard to your hand.",
             "colours": [
@@ -23144,7 +23144,7 @@
         },
         {
             "id": "04248f06-df86-5b21-a65c-58a0ec2f2705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a4450c-8dfd-4d05-adb9-e84ec6066c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a4450c-8dfd-4d05-adb9-e84ec6066c7d.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhenever you gain life, draw a card.",
             "colours": [
@@ -23179,7 +23179,7 @@
         },
         {
             "id": "72972ff9-e3e5-5683-9f6a-88ad7008c8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb36712-26e9-4ec7-8946-626bb7094c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb36712-26e9-4ec7-8946-626bb7094c15.jpg?1",
             "name": "Dryad Militant",
             "text": "({RW} can be paid with either {G} or {W}.)\nIf an instant or sorcery card would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -23215,7 +23215,7 @@
         },
         {
             "id": "5aecd614-a32b-5d65-8b57-dd60f3714f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce1338-5a46-4d96-a991-d5fa8d4330ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce1338-5a46-4d96-a991-d5fa8d4330ae.jpg?1",
             "name": "Enigma Drake",
             "text": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -23250,7 +23250,7 @@
         },
         {
             "id": "8de1e29f-9c6c-503e-86e4-a6aa91a4074d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7fcd03-fffe-467a-88a5-e583e32afd7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7fcd03-fffe-467a-88a5-e583e32afd7a.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna deals 1 damage to each opponent.",
             "colours": [
@@ -23288,7 +23288,7 @@
         },
         {
             "id": "be7e1056-ad91-50f2-b46a-70bdeee2a962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b649f459-c9dc-495d-8703-b685996bb80c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b649f459-c9dc-495d-8703-b685996bb80c.jpg?1",
             "name": "Halana and Alena, Partners",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nReach (This creature can block creatures with flying.)\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is Halana and Alena's power. That creature gains haste until end of turn.",
             "colours": [
@@ -23326,7 +23326,7 @@
         },
         {
             "id": "79b53a94-8921-51c2-8df6-49747709f459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dfc234-e87a-4594-8dcf-0a2f95eedc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dfc234-e87a-4594-8dcf-0a2f95eedc97.jpg?1",
             "name": "Immersturm Predator",
             "text": "Flying\nWhenever this creature becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on this creature.\nSacrifice another creature: This creature gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -23362,7 +23362,7 @@
         },
         {
             "id": "e2c1ac61-f4b1-513e-b279-d46cca1034bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e8d47-a086-4e9f-8130-8c3b2dc50179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e8d47-a086-4e9f-8130-8c3b2dc50179.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -23395,7 +23395,7 @@
         },
         {
             "id": "0a7de96a-8e98-5ed3-90fc-2af6cf78e0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e85619-3a7d-48c2-b9b0-20718c913696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e85619-3a7d-48c2-b9b0-20718c913696.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -23428,7 +23428,7 @@
         },
         {
             "id": "3b15b465-0c5d-54f1-bd6b-86838e6817f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54819d7a-eec6-49e6-a0bb-d9d07d42b4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54819d7a-eec6-49e6-a0bb-d9d07d42b4a6.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "Flying\nWard\u2014{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
             "colours": [
@@ -23466,7 +23466,7 @@
         },
         {
             "id": "2a0644d0-23e7-5481-9783-4c56e1a0f99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f007b0-b578-44f8-be65-cd9e2ac56e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f007b0-b578-44f8-be65-cd9e2ac56e09.jpg?1",
             "name": "Prime Speaker Zegana",
             "text": "Prime Speaker Zegana enters with X +1/+1 counters on it, where X is the greatest power among other creatures you control.\nWhen Prime Speaker Zegana enters, draw cards equal to its power.",
             "colours": [
@@ -23504,7 +23504,7 @@
         },
         {
             "id": "0d0475b5-46b5-5802-ab56-918c1233c7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50027d69-8bb0-444c-8e9b-4c9afd91cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50027d69-8bb0-444c-8e9b-4c9afd91cbda.jpg?1",
             "name": "Savage Ventmaw",
             "text": "Flying\nWhenever this creature attacks, add {R}{R}{R}{G}{G}{G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -23539,7 +23539,7 @@
         },
         {
             "id": "a5f49c01-81b4-53a9-bd15-297554148263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516baae5-f7bf-4a90-a80d-192ff19dbae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516baae5-f7bf-4a90-a80d-192ff19dbae5.jpg?1",
             "name": "Teach by Example",
             "text": "({UR} can be paid with either {U} or {R}.)\nWhen you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -23572,7 +23572,7 @@
         },
         {
             "id": "957116b3-c28b-5c99-a239-cab4154698d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb88a22-8086-4bf7-89e8-cce929440dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb88a22-8086-4bf7-89e8-cce929440dd8.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever this creature deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -23607,7 +23607,7 @@
         },
         {
             "id": "10c100dc-dd35-5516-8f7f-5cfb03e7fc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d383bbf-6bb1-4c2c-899b-65d8df9d0889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d383bbf-6bb1-4c2c-899b-65d8df9d0889.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "({RW} can be paid with either {G} or {W}.)\nOther green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard this card, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -23643,7 +23643,7 @@
         },
         {
             "id": "1ecd6350-bc4d-52fc-a1bf-bf8ba079c76f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b36fba7-71f7-4b7f-bde5-b3a9752ad21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b36fba7-71f7-4b7f-bde5-b3a9752ad21c.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink. (Any amount of damage it deals to a creature is enough to destroy it. Damage dealt by this creature also causes you to gain that much life.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -23672,7 +23672,7 @@
         },
         {
             "id": "013893d0-9c04-547e-bff0-32d14eff6056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249aa94c-85ab-4606-aa2c-c902bd83ac21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249aa94c-85ab-4606-aa2c-c902bd83ac21.jpg?1",
             "name": "Cultivator's Caravan",
             "text": "{T}: Add one mana of any color.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -23701,7 +23701,7 @@
         },
         {
             "id": "fc7b35ff-806d-55a8-8b9f-86462f79abda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70197723-c61b-4600-b61d-41380c8f3067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70197723-c61b-4600-b61d-41380c8f3067.jpg?1",
             "name": "Darksteel Colossus",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nIndestructible (Damage and effects that say \"destroy\" don't destroy this creature.)\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -23731,7 +23731,7 @@
         },
         {
             "id": "3738b140-ba04-5b58-b739-e20732895617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721463ad-9531-487f-bd82-5e638c4fc35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721463ad-9531-487f-bd82-5e638c4fc35f.jpg?1",
             "name": "Diamond Mare",
             "text": "",
             "colours": [],
@@ -23761,7 +23761,7 @@
         },
         {
             "id": "4cb4a4b6-2a8d-5fd8-a71b-ef16aa91cb01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f55c3-8e65-4520-b26d-6208344f73b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f55c3-8e65-4520-b26d-6208344f73b2.jpg?1",
             "name": "Feldon's Cane",
             "text": "{T}, Exile this artifact: Shuffle your graveyard into your library.",
             "colours": [],
@@ -23788,7 +23788,7 @@
         },
         {
             "id": "280223fb-1780-5418-895a-f6af6fe285ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484fbce6-71bd-40eb-a71b-86958a094708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484fbce6-71bd-40eb-a71b-86958a094708.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -23817,7 +23817,7 @@
         },
         {
             "id": "8e20473c-9534-5760-bc2b-986d3c5ad789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc49d9cb-8c7a-4a8f-96ea-bbe6ade8ae00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc49d9cb-8c7a-4a8f-96ea-bbe6ade8ae00.jpg?1",
             "name": "Gate Colossus",
             "text": "This spell costs {1} less to cast for each Gate you control.\nThis creature can't be blocked by creatures with power 2 or less.\nWhenever a Gate you control enters, you may put this card from your graveyard on top of your library.",
             "colours": [],
@@ -23847,7 +23847,7 @@
         },
         {
             "id": "fbb8a1b2-cdba-56fb-9575-e09a54fd83ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45072cd-e3f2-4090-b984-50ec8d360bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45072cd-e3f2-4090-b984-50ec8d360bf2.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on this artifact: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{2}, {T}, Put a page counter on this artifact: Draw a card.\nWhen there are four or more page counters on this artifact, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -23874,7 +23874,7 @@
         },
         {
             "id": "82dfd914-6d49-5ca8-b4e3-3a6456180bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340d8a4-196a-4433-807c-b7124e96e44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340d8a4-196a-4433-807c-b7124e96e44f.jpg?1",
             "name": "Pyromancer's Goggles",
             "text": "",
             "colours": [],
@@ -23905,7 +23905,7 @@
         },
         {
             "id": "9156339c-70f5-5972-ad6b-89a44a72a5ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f95f753-bbaa-4282-9cd9-f1737136fc9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f95f753-bbaa-4282-9cd9-f1737136fc9e.jpg?1",
             "name": "Ramos, Dragon Engine",
             "text": "Flying\nWhenever you cast a spell, put a +1/+1 counter on Ramos for each of that spell's colors.\nRemove five +1/+1 counters from Ramos: Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Activate only once each turn.",
             "colours": [],
@@ -23943,7 +23943,7 @@
         },
         {
             "id": "5513361c-0f1b-54f7-b72b-b9e5fecd0f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99356b-eed0-4d92-818b-80754bcb75f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99356b-eed0-4d92-818b-80754bcb75f3.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As this artifact enters, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -23970,7 +23970,7 @@
         },
         {
             "id": "e017d45b-d0c8-51da-9c96-c8390fe4eefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3ff537-86f0-405e-b96b-1250720af031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3ff537-86f0-405e-b96b-1250720af031.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "When this artifact enters, exile target card from a graveyard.\n{T}, Sacrifice this artifact: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice this artifact: Draw a card.",
             "colours": [],
@@ -23997,7 +23997,7 @@
         },
         {
             "id": "95dcd8a5-2712-58ab-88be-035aa61bb181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931ad21b-a6bb-4a89-8d6f-80adfcf126c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931ad21b-a6bb-4a89-8d6f-80adfcf126c7.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: This creature gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with mana value X whose controller was dealt combat damage by this creature this turn. Activate only once each turn.",
             "colours": [],
@@ -24027,7 +24027,7 @@
         },
         {
             "id": "a42d2a93-d4be-511f-bcc5-d34e2d3df0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b8bf3a-1cb5-4ce2-ac25-9410f17130de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b8bf3a-1cb5-4ce2-ac25-9410f17130de.jpg?1",
             "name": "Three Tree Mascot",
             "text": "Changeling (This card is every creature type.)\n{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -24057,7 +24057,7 @@
         },
         {
             "id": "dda52b4e-b7c6-582f-8c0a-3c7510e3e929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a7264-0a83-42c8-a94d-05ad4c234242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a7264-0a83-42c8-a94d-05ad4c234242.jpg?1",
             "name": "Azorius Guildgate",
             "text": "This land enters tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -24089,7 +24089,7 @@
         },
         {
             "id": "d016d703-0605-524d-91f7-b197242a72c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3c74ea-40e9-4ad9-a491-c208403b68ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3c74ea-40e9-4ad9-a491-c208403b68ad.jpg?1",
             "name": "Boros Guildgate",
             "text": "This land enters tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -24121,7 +24121,7 @@
         },
         {
             "id": "b2f651b5-d206-5a4d-8764-7e4ceb317358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2aff0e-1319-4d3b-903c-fa1ce3db7602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2aff0e-1319-4d3b-903c-fa1ce3db7602.jpg?1",
             "name": "Crawling Barrens",
             "text": "{T}: Add {C}.\n{4}: Put two +1/+1 counters on this land. Then you may have it become a 0/0 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -24148,7 +24148,7 @@
         },
         {
             "id": "e54241c8-6f31-50fa-8ed4-1fcbfa8c3400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7976098-b560-458a-ad3c-18f7873add21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7976098-b560-458a-ad3c-18f7873add21.jpg?1",
             "name": "Cryptic Caves",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands.",
             "colours": [],
@@ -24175,7 +24175,7 @@
         },
         {
             "id": "b0bc4aaf-ef5d-55d5-878b-b4f2f77d2a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7e51b6-4898-4632-b39c-3ce438caa882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7e51b6-4898-4632-b39c-3ce438caa882.jpg?1",
             "name": "Demolition Field",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. That land's controller may search their library for a basic land card, put it onto the battlefield, then shuffle. You may search your library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -24202,7 +24202,7 @@
         },
         {
             "id": "5aef3ea6-54e2-5cfb-9c55-c2afc2bb6169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8a159-5e58-4432-8ecd-62f39afa96da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8a159-5e58-4432-8ecd-62f39afa96da.jpg?1",
             "name": "Dimir Guildgate",
             "text": "This land enters tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -24234,7 +24234,7 @@
         },
         {
             "id": "aabb9bce-ac0d-5093-ae0a-62a8447d69ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d4646c-a375-4835-aa58-8bb77d1a5abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d4646c-a375-4835-aa58-8bb77d1a5abf.jpg?1",
             "name": "Golgari Guildgate",
             "text": "This land enters tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -24266,7 +24266,7 @@
         },
         {
             "id": "07a862b1-ccc2-5898-8cb7-59c0bebf0b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab6c240-c97d-4a5c-bc39-860c2d9901c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab6c240-c97d-4a5c-bc39-860c2d9901c2.jpg?1",
             "name": "Gruul Guildgate",
             "text": "This land enters tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -24298,7 +24298,7 @@
         },
         {
             "id": "c28c2f78-bb82-5e72-8672-ab56ecf949a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9e6fc9-813d-4a71-8a68-8e0f83fa945d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9e6fc9-813d-4a71-8a68-8e0f83fa945d.jpg?1",
             "name": "Izzet Guildgate",
             "text": "",
             "colours": [],
@@ -24330,7 +24330,7 @@
         },
         {
             "id": "0fef10c3-7543-5d46-8732-38772aa1022f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a917be03-0c17-4454-b044-c4375e5c8085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a917be03-0c17-4454-b044-c4375e5c8085.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "This land enters tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -24362,7 +24362,7 @@
         },
         {
             "id": "6bdd5b9d-bf46-5444-bca8-57da44ba193e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f01964-c610-4d0f-a2b4-f52e46dc50d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f01964-c610-4d0f-a2b4-f52e46dc50d2.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "This land enters tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -24394,7 +24394,7 @@
         },
         {
             "id": "190d0cb3-f517-5e22-8c0a-60223f160946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6718d4e7-768e-473f-8064-a68422e977f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6718d4e7-768e-473f-8064-a68422e977f6.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "This land enters tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -24426,7 +24426,7 @@
         },
         {
             "id": "5fab4ae5-a4b8-576c-8920-041e348c62e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96590855-1ee5-4d69-9070-776e23f71976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96590855-1ee5-4d69-9070-776e23f71976.jpg?1",
             "name": "Simic Guildgate",
             "text": "This land enters tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -24458,7 +24458,7 @@
         },
         {
             "id": "2ed37817-9a74-5a98-a0a7-2176a6b592dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a990a92-8d0f-489f-ae97-68c90fc5ccf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a990a92-8d0f-489f-ae97-68c90fc5ccf1.jpg?1",
             "name": "Temple of Abandon",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -24488,7 +24488,7 @@
         },
         {
             "id": "15b9bfac-2443-5372-8cca-4c976a74fc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18748ce-e52e-4cd1-89d4-cd2578a0d574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18748ce-e52e-4cd1-89d4-cd2578a0d574.jpg?1",
             "name": "Temple of Deceit",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -24518,7 +24518,7 @@
         },
         {
             "id": "da49d26f-84c2-5f96-b7ac-cfaa40bf5234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f23c1a-a0fe-4520-88ed-045aa4044567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f23c1a-a0fe-4520-88ed-045aa4044567.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -24548,7 +24548,7 @@
         },
         {
             "id": "c6a3b8ce-bd36-5102-9cec-84d0a73c52fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224e8255-7bc6-44a2-86af-14f8446f4f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224e8255-7bc6-44a2-86af-14f8446f4f77.jpg?1",
             "name": "Temple of Epiphany",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -24578,7 +24578,7 @@
         },
         {
             "id": "0e1004b0-d1eb-5418-9e25-397ea0080b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e7d0d5-2329-42a6-b6ff-a5197ba5f1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e7d0d5-2329-42a6-b6ff-a5197ba5f1d0.jpg?1",
             "name": "Temple of Malady",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -24608,7 +24608,7 @@
         },
         {
             "id": "aacae80d-5043-5351-88a3-6d8d2d1014b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78eccc4-1500-43f1-94f5-b39c160b6381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78eccc4-1500-43f1-94f5-b39c160b6381.jpg?1",
             "name": "Temple of Malice",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -24638,7 +24638,7 @@
         },
         {
             "id": "fada3b60-6e13-5c68-ae38-5e4c76616c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd581f1d-d8ba-47f9-b10b-b7b6d46239ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd581f1d-d8ba-47f9-b10b-b7b6d46239ce.jpg?1",
             "name": "Temple of Mystery",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -24668,7 +24668,7 @@
         },
         {
             "id": "92bdc206-9682-5980-9cd9-fcd6e1c8f11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69762774-c8e1-42de-90b3-5a4d50f5d84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69762774-c8e1-42de-90b3-5a4d50f5d84d.jpg?1",
             "name": "Temple of Plenty",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -24698,7 +24698,7 @@
         },
         {
             "id": "35affd4b-e640-500e-9930-c143acdca0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408ad759-052a-4949-9adf-7541cb2ef77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408ad759-052a-4949-9adf-7541cb2ef77e.jpg?1",
             "name": "Temple of Silence",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -24728,7 +24728,7 @@
         },
         {
             "id": "97bf0d3f-8cbe-5b83-9bb3-d2a97549cfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f58450-838d-4404-a68f-159e82b0e58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f58450-838d-4404-a68f-159e82b0e58d.jpg?1",
             "name": "Temple of Triumph",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -24758,7 +24758,7 @@
         },
         {
             "id": "029fd302-0a81-5b08-9280-ef4a25f4c4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c279947e-168f-4af5-902b-aba724f52b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c279947e-168f-4af5-902b-aba724f52b8a.jpg?1",
             "name": "Angel of Vitality",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nThis creature gets +2/+2 as long as you have 25 or more life.",
             "colours": [
@@ -24791,7 +24791,7 @@
         },
         {
             "id": "f0bc94df-5988-59cb-9db6-bcc600b76847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2abce4d-ef21-4028-8a86-b7d1387bc937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2abce4d-ef21-4028-8a86-b7d1387bc937.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -24826,7 +24826,7 @@
         },
         {
             "id": "fa4984dd-caa9-5feb-af2a-32e7b927b5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c26415d-9e98-480b-9e30-b3aed00d5f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c26415d-9e98-480b-9e30-b3aed00d5f3d.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -24857,7 +24857,7 @@
         },
         {
             "id": "4cc75136-a516-5410-b86c-c3a6e524ad00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a1553-e5f3-4c9c-833d-579e82e1708f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a1553-e5f3-4c9c-833d-579e82e1708f.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -24890,7 +24890,7 @@
         },
         {
             "id": "bfc41f58-7eec-58d9-b843-37c417e37692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3b0dba-0207-4249-bdab-e807c76ce39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3b0dba-0207-4249-bdab-e807c76ce39e.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -24921,7 +24921,7 @@
         },
         {
             "id": "50cc768a-ebee-5491-b98b-ad14c1b506ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe98958d-30ee-4a47-aacc-064e02d109b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe98958d-30ee-4a47-aacc-064e02d109b3.jpg?1",
             "name": "Rite of Replication",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a token that's a copy of target creature. If this spell was kicked, create five of those tokens instead.",
             "colours": [
@@ -24952,7 +24952,7 @@
         },
         {
             "id": "46f98852-e2d0-582d-9481-ad3f1d59a562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d4541-160c-4137-98e7-0eaa692c7d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d4541-160c-4137-98e7-0eaa692c7d7a.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
             "colours": [
@@ -24983,7 +24983,7 @@
         },
         {
             "id": "83b8d3ab-37ca-521e-ab9c-7905b5b612d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd61c12-f5e2-4698-9080-097679754f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd61c12-f5e2-4698-9080-097679754f16.jpg?1",
             "name": "Gatekeeper of Malakir",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen this creature enters, if it was kicked, target player sacrifices a creature of their choice.",
             "colours": [
@@ -25017,7 +25017,7 @@
         },
         {
             "id": "f2b47362-28da-5f69-b5da-c45446920385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39be2675-986c-4812-9448-99737e797671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39be2675-986c-4812-9448-99737e797671.jpg?1",
             "name": "Massacre Wurm",
             "text": "When this creature enters, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -25051,7 +25051,7 @@
         },
         {
             "id": "0b3c496d-9650-5c2c-a6d2-6727d9cdae25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89024c5-eef5-468c-92b4-e53dd212909c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89024c5-eef5-468c-92b4-e53dd212909c.jpg?1",
             "name": "Gratuitous Violence",
             "text": "If a creature you control would deal damage to a permanent or player, it deals double that damage instead.",
             "colours": [
@@ -25082,7 +25082,7 @@
         },
         {
             "id": "22638c1e-1a01-567b-83af-6be4c84fb32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde674d6-f4e7-410b-acf0-34021290576d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde674d6-f4e7-410b-acf0-34021290576d.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, this creature deals 2 damage to each opponent.",
             "colours": [
@@ -25116,7 +25116,7 @@
         },
         {
             "id": "4ee957fd-079e-51cc-b737-39bf63af9b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b7cecf-b51b-4d30-b7e9-cd7976271e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b7cecf-b51b-4d30-b7e9-cd7976271e07.jpg?1",
             "name": "Impact Tremors",
             "text": "Whenever a creature you control enters, this enchantment deals 1 damage to each opponent.",
             "colours": [
@@ -25147,7 +25147,7 @@
         },
         {
             "id": "8dbbb3cf-5e03-5138-a2d9-857e81bd9923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1c518a-dcb4-407c-85be-ed5935a24198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1c518a-dcb4-407c-85be-ed5935a24198.jpg?1",
             "name": "Gigantosaurus",
             "text": "",
             "colours": [
@@ -25180,7 +25180,7 @@
         },
         {
             "id": "76d02e6d-e8db-5571-9a37-5acc3dd01b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b4a09f-ea53-42b4-a41a-4299192a6fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b4a09f-ea53-42b4-a41a-4299192a6fd3.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elves you control get +1/+1.\n{G}, {T}: Create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -25214,7 +25214,7 @@
         },
         {
             "id": "c1cec8e3-7dc0-5593-a5d3-34d0add3e8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa150070-80b6-453d-b00f-4462175cac79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa150070-80b6-453d-b00f-4462175cac79.jpg?1",
             "name": "Pelakka Wurm",
             "text": "",
             "colours": [
@@ -25247,7 +25247,7 @@
         },
         {
             "id": "6963f7ba-c820-5d37-8868-06e9b60e196a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d8c9f6-cbbd-4694-b100-01cfb81036cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d8c9f6-cbbd-4694-b100-01cfb81036cc.jpg?1",
             "name": "Boros Charm",
             "text": "",
             "colours": [
@@ -25280,7 +25280,7 @@
         },
         {
             "id": "eab953e3-68e2-5aed-9d6a-64bb027aad53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1201875-b3d8-4f95-801e-bf18ee77919b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1201875-b3d8-4f95-801e-bf18ee77919b.jpg?1",
             "name": "Unflinching Courage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample and lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -25315,7 +25315,7 @@
         },
         {
             "id": "4feb5911-355b-5ef7-9f30-3441e4430052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35e614c-51a9-4d5c-b7fa-1a0a87108785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35e614c-51a9-4d5c-b7fa-1a0a87108785.jpg?1",
             "name": "Adaptive Automaton",
             "text": "As this creature enters, choose a creature type.\nThis creature is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -25345,7 +25345,7 @@
         },
         {
             "id": "81a772ac-1ea7-5f9e-85f3-1c4e06b167ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e66835-c228-48fa-bcaa-eb96edbd4f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e66835-c228-48fa-bcaa-eb96edbd4f5a.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice this artifact: Search your library for a land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -25372,7 +25372,7 @@
         },
         {
             "id": "89aab41d-837c-5135-a91f-2fde25bf7765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5e88f1-0ddf-45d7-bbd0-baa88d121867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5e88f1-0ddf-45d7-bbd0-baa88d121867.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -25399,7 +25399,7 @@
         },
         {
             "id": "0bc775e8-418c-506c-b00b-705ede9bc584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b9ac6-dba2-4162-86ed-df3e9fad0306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b9ac6-dba2-4162-86ed-df3e9fad0306.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice this artifact: Draw two cards.",
             "colours": [],
@@ -25426,7 +25426,7 @@
         },
         {
             "id": "485ad0e8-dcc5-54d0-86a6-62df8b5461c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a4d1a-79dd-4b15-8e3b-f111f16d6bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a4d1a-79dd-4b15-8e3b-f111f16d6bfc.jpg?1",
             "name": "Maze's End",
             "text": "This land enters tapped.\n{T}: Add {C}.\n{3}, {T}, Return this land to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle. If you control ten or more Gates with different names, you win the game.",
             "colours": [],
@@ -25453,7 +25453,7 @@
         },
         {
             "id": "bb58388f-7e51-5d0e-b090-53261227457d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d28b7-1e56-428d-84a7-0eb6a2b5efda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d28b7-1e56-428d-84a7-0eb6a2b5efda.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -25488,7 +25488,7 @@
         },
         {
             "id": "ee0352c4-2c04-50df-b60d-d98ce400457d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aae48-a783-468d-aa14-552307ec2021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aae48-a783-468d-aa14-552307ec2021.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When this creature enters, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen this creature dies, you may draw a card.",
             "colours": [],
@@ -25520,7 +25520,7 @@
         },
         {
             "id": "c7125740-84ed-5723-9349-8c44592b0a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632df69e-6377-43d0-bba5-65518a320aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632df69e-6377-43d0-bba5-65518a320aa5.jpg?1",
             "name": "Hinterland Sanctifier",
             "text": "Whenever another creature you control enters, you gain 1 life.",
             "colours": [
@@ -25555,7 +25555,7 @@
         },
         {
             "id": "a8f27148-ffb9-5e5d-aad4-9c8df30fff28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -25590,7 +25590,7 @@
         },
         {
             "id": "4983cf20-03e7-5f8d-a817-2d69acc1db5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16213b5-c0da-4a24-9f2e-b9432652859e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16213b5-c0da-4a24-9f2e-b9432652859e.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -25625,7 +25625,7 @@
         },
         {
             "id": "402d3eb7-f758-5f33-851b-3658e5e454e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06af3d5a-7b38-42f6-822f-da4e04a7f265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06af3d5a-7b38-42f6-822f-da4e04a7f265.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -25660,7 +25660,7 @@
         },
         {
             "id": "1093d137-4954-50d5-84c4-de2d86400ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d287806-07bb-4709-9260-b9ef34fe2a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d287806-07bb-4709-9260-b9ef34fe2a13.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -25695,7 +25695,7 @@
         },
         {
             "id": "9e6b66e9-f17f-5985-a9a9-30d0f919fe5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ae4f9c-ad6e-4d6a-89f1-653916bf5373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ae4f9c-ad6e-4d6a-89f1-653916bf5373.jpg?1",
             "name": "Rabbit",
             "text": "",
             "colours": [
@@ -25730,7 +25730,7 @@
         },
         {
             "id": "933197f0-b11c-50eb-9d03-d393b683e392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d093322e-a717-4e2d-8199-fa560792bcf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d093322e-a717-4e2d-8199-fa560792bcf6.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -25765,7 +25765,7 @@
         },
         {
             "id": "1e59b4ed-5f6e-57f1-9e1c-06282af80df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278adad2-49a6-4baa-8dbe-93474545eef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278adad2-49a6-4baa-8dbe-93474545eef7.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -25800,7 +25800,7 @@
         },
         {
             "id": "e86fefb7-38d9-58a6-94bc-102738bfd02b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a73034-e20f-4e7e-ac15-3460b1e9c69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a73034-e20f-4e7e-ac15-3460b1e9c69b.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -25835,7 +25835,7 @@
         },
         {
             "id": "b04a1625-27ea-55b7-9c1e-8988f4f71ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1",
             "name": "Faerie",
             "text": "",
             "colours": [
@@ -25870,7 +25870,7 @@
         },
         {
             "id": "de757afa-42be-5403-b98c-4ef9f3ef6ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44057462-40b7-4709-afac-2ce03d53d525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44057462-40b7-4709-afac-2ce03d53d525.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -25905,7 +25905,7 @@
         },
         {
             "id": "dc6cc014-7de9-55dd-8880-9bed7737775d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef25434-cd23-4dcf-b77e-36e648a8de23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef25434-cd23-4dcf-b77e-36e648a8de23.jpg?1",
             "name": "Koma's Coil",
             "text": "",
             "colours": [
@@ -25940,7 +25940,7 @@
         },
         {
             "id": "aceee0e0-4feb-53a8-a993-3385c20a2e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg?1",
             "name": "Ninja",
             "text": "",
             "colours": [
@@ -25975,7 +25975,7 @@
         },
         {
             "id": "d2eacb19-81f4-5484-864f-d20c70285496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c478f7-b426-4055-8d06-e5782226c826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c478f7-b426-4055-8d06-e5782226c826.jpg?1",
             "name": "Scion of the Deep",
             "text": "",
             "colours": [],
@@ -26008,7 +26008,7 @@
         },
         {
             "id": "8fc2ba1b-74e5-57f1-9ce7-1bee912bb474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad84b0-2bbf-479c-ae46-f725892d04d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad84b0-2bbf-479c-ae46-f725892d04d1.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -26043,7 +26043,7 @@
         },
         {
             "id": "e8918ec2-32fe-5ef5-a5aa-5c578794d5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29a360b-11fd-42ba-82ba-de8f7e136c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29a360b-11fd-42ba-82ba-de8f7e136c20.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -26078,7 +26078,7 @@
         },
         {
             "id": "637ba3b8-013c-5bd4-81a4-5ac52f4b05be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c6be20-b65a-4b1e-8133-4c2d88c1f6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c6be20-b65a-4b1e-8133-4c2d88c1f6f9.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -26113,7 +26113,7 @@
         },
         {
             "id": "1600e7fe-a629-50ea-9c4a-95c468f82f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d4dd3b-0a5f-4d2c-aa6b-3c47e71e8c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d4dd3b-0a5f-4d2c-aa6b-3c47e71e8c39.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -26148,7 +26148,7 @@
         },
         {
             "id": "c1c03878-08f8-5419-a688-6af5f5dce8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -26183,7 +26183,7 @@
         },
         {
             "id": "73b705e5-0868-50dc-aff2-73f0d36de975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c45f4-7bc9-45d5-bbf5-2533cf80af60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c45f4-7bc9-45d5-bbf5-2533cf80af60.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -26219,7 +26219,7 @@
         },
         {
             "id": "d971e0cc-d6c0-5778-8c33-1385ace5d6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d8730-d6bd-4525-96e9-0513ed02de37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d8730-d6bd-4525-96e9-0513ed02de37.jpg?1",
             "name": "Raccoon",
             "text": "",
             "colours": [
@@ -26254,7 +26254,7 @@
         },
         {
             "id": "8db2b86f-81e5-51c7-812a-532fef7b2acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c2cbd7-79bb-4d93-b2b6-5d3abe88a012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c2cbd7-79bb-4d93-b2b6-5d3abe88a012.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -26291,7 +26291,7 @@
         },
         {
             "id": "e097be71-8e76-516b-9764-7e93746e0d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1077f8-9e2a-4155-a7f0-4604bc0f94e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1077f8-9e2a-4155-a7f0-4604bc0f94e8.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -26322,7 +26322,7 @@
         },
         {
             "id": "9b7b8d88-0042-548c-a8dd-18089528b064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21210145-8edd-41f5-9a64-9f0b5be79864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21210145-8edd-41f5-9a64-9f0b5be79864.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -26353,7 +26353,7 @@
         },
         {
             "id": "a4f50f82-9b71-53fc-b719-3c50bb1ab393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4b1d5-f252-48fe-b4a1-7fbbc2523cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4b1d5-f252-48fe-b4a1-7fbbc2523cf1.jpg?1",
             "name": "Kaito, Cunning Infiltrator Emblem",
             "text": "",
             "colours": [],
@@ -26381,7 +26381,7 @@
         },
         {
             "id": "6ce46d45-a445-5567-9852-53a3040d5769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804d502-1092-4ff3-93d9-d1b0ac0f07d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804d502-1092-4ff3-93d9-d1b0ac0f07d5.jpg?1",
             "name": "Vivien Reid Emblem",
             "text": "",
             "colours": [],
@@ -26411,7 +26411,7 @@
         },
         {
             "id": "7f30de76-415e-5a5c-987d-a51686e4e4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc586e46-b7d0-4c84-8678-3542cd390de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc586e46-b7d0-4c84-8678-3542cd390de1.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -26439,7 +26439,7 @@
         },
         {
             "id": "1e6cce59-0cd2-56ea-94a3-452a0b4c7714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86701490-17ac-4253-810d-6cfd7a46594c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86701490-17ac-4253-810d-6cfd7a46594c.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -26474,7 +26474,7 @@
         },
         {
             "id": "2856c4fb-893c-5600-800f-2f1327f1ccc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322ef76e-e0f0-48d7-a6ad-5d4c1c9ccb2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322ef76e-e0f0-48d7-a6ad-5d4c1c9ccb2e.jpg?1",
             "name": "Cat Beast",
             "text": "",
             "colours": [
@@ -26510,7 +26510,7 @@
         },
         {
             "id": "fc2a3b16-ac9a-5eed-acb8-155f61615a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8da5b2-7e02-494b-8686-c5845286d0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8da5b2-7e02-494b-8686-c5845286d0b9.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -26545,7 +26545,7 @@
         },
         {
             "id": "1bff76b1-3db7-5b9c-af6a-0c9759ac4f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384238b-cffb-4946-96de-dc6b7a37b979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384238b-cffb-4946-96de-dc6b7a37b979.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -26580,7 +26580,7 @@
         },
         {
             "id": "6e30de50-4851-5313-b1e3-eda8a0ef4027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e437a1-6d74-4006-8598-06284444c837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e437a1-6d74-4006-8598-06284444c837.jpg?1",
             "name": "Phyrexian Goblin",
             "text": "",
             "colours": [
@@ -26616,7 +26616,7 @@
         },
         {
             "id": "a044bb73-0342-5a84-985b-6526bf1e019f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca697323-bdc8-4fa0-a0ba-c2dd4deff68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca697323-bdc8-4fa0-a0ba-c2dd4deff68c.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -26651,7 +26651,7 @@
         },
         {
             "id": "97c5c865-86c4-5aac-8837-1caf9695383f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bd6fb3-f60c-49cc-8854-6a20a1e1d9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bd6fb3-f60c-49cc-8854-6a20a1e1d9c7.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/FEM.json
+++ b/Assets/Resources/Sets/FEM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "262937ec-a425-589c-b17f-2d3e3eaf5c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfd96cb-03d6-4845-8595-50bf17b35726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfd96cb-03d6-4845-8595-50bf17b35726.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -43,7 +43,7 @@
         },
         {
             "id": "eb70eac4-88b1-5b5a-9fc1-fca34169202f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a324a98-31c2-470a-b792-96b6b098a58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a324a98-31c2-470a-b792-96b6b098a58c.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -82,7 +82,7 @@
         },
         {
             "id": "a7b0225d-8757-5605-82fd-14dfe6e1c7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9d1eac-3ac2-4881-a984-e40d87f60784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9d1eac-3ac2-4881-a984-e40d87f60784.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -121,7 +121,7 @@
         },
         {
             "id": "3a0aff41-d9ba-5ea9-9019-2935b3ab876b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26c079-61ea-436d-89ae-2f1c6f863e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26c079-61ea-436d-89ae-2f1c6f863e91.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -160,7 +160,7 @@
         },
         {
             "id": "886243d9-b1c6-5f02-856a-e3902afcdbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af092da3-8713-4a59-86d3-827b942d6456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af092da3-8713-4a59-86d3-827b942d6456.jpg?1",
             "name": "Farrel's Mantle",
             "text": "If target creature attacks and is not blocked, it may deal X+2 damage to any other target creature, where X is the power of the creature Farrel's Mantle enchants. If it does so, it deals no damage to opponent this turn.",
             "colours": [
@@ -193,7 +193,7 @@
         },
         {
             "id": "640616ed-08b8-55d3-99b1-37187266e1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0401bd23-9f81-40b7-a6c2-e3f9847d175c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0401bd23-9f81-40b7-a6c2-e3f9847d175c.jpg?1",
             "name": "Farrel's Zealot",
             "text": "If Farrel's Zealot attacks and is not blocked, you may choose to have it deal 3 damage to a target creature. If you do so, it deals no damage to opponent this turn.",
             "colours": [
@@ -229,7 +229,7 @@
         },
         {
             "id": "1e587134-cb92-5383-b893-43e5f1da1ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3aeee7-975c-419a-bfb3-45bb48ba6918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3aeee7-975c-419a-bfb3-45bb48ba6918.jpg?1",
             "name": "Farrel's Zealot",
             "text": "If Farrel's Zealot attacks and is not blocked, you may choose to have it deal 3 damage to a target creature. If you do so, it deals no damage to opponent this turn.",
             "colours": [
@@ -265,7 +265,7 @@
         },
         {
             "id": "33a36fb1-9886-52ea-9c1a-d9ac0b2bc19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54252fd2-21a6-40d1-8515-697f18c78a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54252fd2-21a6-40d1-8515-697f18c78a06.jpg?1",
             "name": "Farrel's Zealot",
             "text": "If Farrel's Zealot attacks and is not blocked, you may choose to have it deal 3 damage to a target creature. If you do so, it deals no damage to opponent this turn.",
             "colours": [
@@ -301,7 +301,7 @@
         },
         {
             "id": "8e7f724c-ced6-55f7-a8f2-37df6fd9a2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11bf79b-a951-4d0c-acdf-d8ba5290a648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11bf79b-a951-4d0c-acdf-d8ba5290a648.jpg?1",
             "name": "Farrelite Priest",
             "text": "o1: Add o\nW to your mana pool. Play this ability as an interrupt. If more than 3 is spent in this way during one turn, bury Farrelite Priest at end of turn.",
             "colours": [
@@ -335,7 +335,7 @@
         },
         {
             "id": "e9a60f48-801c-56e6-bb9e-b0b495016915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a899b2d-825c-4929-a769-f4df70bf6a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a899b2d-825c-4929-a769-f4df70bf6a17.jpg?1",
             "name": "Hand of Justice",
             "text": "oc\nT: Tap three target white creatures you control to destroy any target creature.",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "4d2600b4-74dc-52f4-867f-fefed1bb051a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ee87a0-a7eb-4472-9045-85d11e8a1501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ee87a0-a7eb-4472-9045-85d11e8a1501.jpg?1",
             "name": "Heroism",
             "text": "o0: Sacrifice a white creature to have attacking red creatures deal no damage during combat this turn. The attacking player may pay o2o\nR for an attacking creature to have it deal damage as normal.",
             "colours": [
@@ -400,7 +400,7 @@
         },
         {
             "id": "7bb91f66-a7a7-5503-925c-ebb5b7080925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95d42d8-ba75-43bf-81b8-b02374f03e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95d42d8-ba75-43bf-81b8-b02374f03e83.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "75b1d080-7330-55c3-9b09-e8cc635249a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e4a9d2-ea43-46ac-8b8b-00496a478103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e4a9d2-ea43-46ac-8b8b-00496a478103.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "77ed49b3-5dba-586a-b952-27c4498c77ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efac583d-a492-45ee-8c52-60a6422b2168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efac583d-a492-45ee-8c52-60a6422b2168.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "f20c7ec2-30ae-572f-a892-47e607121e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a8d4-7c06-454c-9923-553294aada4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a8d4-7c06-454c-9923-553294aada4f.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "d4324874-0c9d-5d2e-936c-d24b8f5de060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04b8356-2384-4743-80dd-f15ca7ec65f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04b8356-2384-4743-80dd-f15ca7ec65f7.jpg?1",
             "name": "Icatian Javelineers",
             "text": "When Icatian Javelineers is brought into play, put a javelin counter on it.\noc\nT: Remove the javelin counter to have Icatian Javelineers deal 1 damage to any target.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "aa2fefe5-c3ec-5bcc-be43-20ecf54c3ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70f8f50-866a-4889-b986-48636225638a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70f8f50-866a-4889-b986-48636225638a.jpg?1",
             "name": "Icatian Javelineers",
             "text": "When Icatian Javelineers is brought into play, put a javelin counter on it.\noc\nT: Remove the javelin counter to have Icatian Javelineers deal 1 damage to any target.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "653fa5a7-0494-5ed3-9ac1-d10ac7e15c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be5ab7a-e7db-4c09-8df2-6fe55fa4a116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be5ab7a-e7db-4c09-8df2-6fe55fa4a116.jpg?1",
             "name": "Icatian Javelineers",
             "text": "When Icatian Javelineers is brought into play, put a javelin counter on it.\noc\nT: Remove the javelin counter to have Icatian Javelineers deal 1 damage to any target.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "2ae12fc4-706a-57b8-9d73-03c301e5db76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fec59a-4ade-4c6f-ae7d-911fbe6da26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fec59a-4ade-4c6f-ae7d-911fbe6da26d.jpg?1",
             "name": "Icatian Lieutenant",
             "text": "o1oo\nW Target Soldier gets +1/+0 until end of turn.",
             "colours": [
@@ -697,7 +697,7 @@
         },
         {
             "id": "45868b1b-41c0-58c3-8763-efbafa84ad40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d502d4-4a96-47b3-ae26-8b2c9f36623d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d502d4-4a96-47b3-ae26-8b2c9f36623d.jpg?1",
             "name": "Icatian Moneychanger",
             "text": "Moneychanger deals 3 damage to you when summoned; put three credit counters on Moneychanger at that time. During your upkeep, put one credit counter on Moneychanger.\no0: Sacrifice Moneychanger to gain 1 life for each credit counter on it. Use this ability only during your upkeep.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "7a927a19-7746-5842-8b8a-f1d922782090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf9194c-8e50-4f50-9a87-3b339a5bc279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf9194c-8e50-4f50-9a87-3b339a5bc279.jpg?1",
             "name": "Icatian Moneychanger",
             "text": "Moneychanger deals 3 damage to you when summoned; put three credit counters on Moneychanger at that time. During your upkeep, put one credit counter on Moneychanger.\no0: Sacrifice Moneychanger to gain 1 life for each credit counter on it. Use this ability only during your upkeep.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "219206df-2dd6-5471-9ce9-302a63080dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9521ae-6fac-4d86-9c60-adecaae5687d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9521ae-6fac-4d86-9c60-adecaae5687d.jpg?1",
             "name": "Icatian Moneychanger",
             "text": "Moneychanger deals 3 damage to you when summoned; put three credit counters on Moneychanger at that time. During your upkeep, put one credit counter on Moneychanger.\no0: Sacrifice Moneychanger to gain 1 life for each credit counter on it. Use this ability only during your upkeep.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "67e973a5-333e-58ed-be99-7002192cf446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc02d30-3eef-4a48-8b11-b4f37219ab3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc02d30-3eef-4a48-8b11-b4f37219ab3a.jpg?1",
             "name": "Icatian Phalanx",
             "text": "Bands",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "7e07e17e-5711-5630-941f-723cd8c5e869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7690cdd-6610-4310-9e93-60dc4db2ae8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7690cdd-6610-4310-9e93-60dc4db2ae8d.jpg?1",
             "name": "Icatian Priest",
             "text": "o1o\nWo\nW: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -873,7 +873,7 @@
         },
         {
             "id": "d3050ced-2bac-5493-99a9-c59b6a518d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf4aaa-a9b1-4798-a96b-c3e35afb77f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf4aaa-a9b1-4798-a96b-c3e35afb77f7.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "d38623e4-7729-5459-9c23-17d9a87992c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9db3442-01cb-4db2-ac33-8eca6880c315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9db3442-01cb-4db2-ac33-8eca6880c315.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "a893e1d3-98e1-515d-a094-28ae0e4effd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c461655-a05d-4eed-85b2-04d554f5ec50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c461655-a05d-4eed-85b2-04d554f5ec50.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "819145ba-68fe-5650-b3c0-9d9797154a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db63ad7f-6dc4-4249-b360-46ec5569a5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db63ad7f-6dc4-4249-b360-46ec5569a5a9.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "c70c8733-75e9-51c2-bfe9-312e63f29180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f6d115-c02d-45a3-aa6d-402964df47dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f6d115-c02d-45a3-aa6d-402964df47dd.jpg?1",
             "name": "Icatian Skirmishers",
             "text": "Bands, first strike\nAll creatures that band with Skirmishers to attack gain first strike until end of turn.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "2ac349a9-ccfc-55f8-a7ae-a6dfa6eb299c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb7c28d-0366-4d01-84a2-f1bc9f38aa4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb7c28d-0366-4d01-84a2-f1bc9f38aa4a.jpg?1",
             "name": "Icatian Town",
             "text": "Put 4 Citizen tokens into play. Treat these tokens as 1/1 white creatures.",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "7718dd24-5332-555c-b691-43005671c656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd6e51e-f042-4673-a898-291607105829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd6e51e-f042-4673-a898-291607105829.jpg?1",
             "name": "Order of Leitbur",
             "text": "Protection from black\no\nWoo\nW +1/+0 until end of turn\noo\nW First strike until end of turn",
             "colours": [
@@ -1132,7 +1132,7 @@
         },
         {
             "id": "d03c0473-d059-53ea-be2f-c882d9cb7dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb537b5a-d725-420d-bc15-0d54ba23331c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb537b5a-d725-420d-bc15-0d54ba23331c.jpg?1",
             "name": "Order of Leitbur",
             "text": "Protection from black\no\nWoo\nW +1/+0 until end of turn\noo\nW First strike until end of turn",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "45612bba-095c-50aa-9582-2dd3099b7197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1373dea4-3565-4612-8505-ab8fba3ddb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1373dea4-3565-4612-8505-ab8fba3ddb67.jpg?1",
             "name": "Order of Leitbur",
             "text": "Protection from black\no\nWoo\nW +1/+0 until end of turn\noo\nW First strike until end of turn",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "56c8bc07-768b-554c-8928-b1f865086058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c9e4a5-735f-471c-ab1a-6e6d50ba5724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c9e4a5-735f-471c-ab1a-6e6d50ba5724.jpg?1",
             "name": "Deep Spawn",
             "text": "Trample\nDuring your upkeep, take two cards from the top of your library and put them in your graveyard, or destroy Deep Spawn.\noo\nU Deep Spawn may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Deep Spawn is untapped, tap it.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "0eb674a3-b4ec-5ba6-be30-ac533d728947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686bbb9-517f-4cce-aa7a-5db41e22c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686bbb9-517f-4cce-aa7a-5db41e22c02b.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, all islands produce an additional o\nU when tapped for mana.",
             "colours": [
@@ -1275,7 +1275,7 @@
         },
         {
             "id": "edcab1da-308a-52dc-87b5-ae9d00684121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2813677-91cc-4c8b-a8ea-403fa776c9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2813677-91cc-4c8b-a8ea-403fa776c9f0.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, all islands produce an additional o\nU when tapped for mana.",
             "colours": [
@@ -1309,7 +1309,7 @@
         },
         {
             "id": "09213226-093f-5643-a451-5316c8fe61ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af611e3-45d6-4aee-bf48-56598b14a242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af611e3-45d6-4aee-bf48-56598b14a242.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, all islands produce an additional o\nU when tapped for mana.",
             "colours": [
@@ -1343,7 +1343,7 @@
         },
         {
             "id": "33af6fd5-8db0-5680-8e52-80441a020d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ffeab4-83b1-4414-ae72-e59a2354ea15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ffeab4-83b1-4414-ae72-e59a2354ea15.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "4f0a2c3c-9d62-5f07-bca5-9a7a596e73ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6c13f-6019-4ad5-9de6-07844c361b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6c13f-6019-4ad5-9de6-07844c361b41.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "1eb9af4b-b2be-53ee-ad1e-b39e26c15910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33536b0a-1cff-481f-b695-eadaf6897bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33536b0a-1cff-481f-b695-eadaf6897bf0.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "3f288583-e627-5f24-ad59-7a635f97e76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f1cc24-a5fc-43cc-b558-ac7901c48b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f1cc24-a5fc-43cc-b558-ac7901c48b81.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "84efb523-8ff5-5f09-a3b3-218a8a1a61ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17c6416-86d6-46ea-aea1-41b98a66b250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17c6416-86d6-46ea-aea1-41b98a66b250.jpg?1",
             "name": "Homarid Shaman",
             "text": "oo\nU Tap a target green creature.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "971bd5e2-098f-519b-84e2-a6678f1e0128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbb62fc-3cd9-41a6-804a-4ff9a766897f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbb62fc-3cd9-41a6-804a-4ff9a766897f.jpg?1",
             "name": "Homarid Spawning Bed",
             "text": "o1o\nUoo\nU Sacrifice a blue creature to put X Camarid tokens into play, where X is the casting cost of the sacrificed creature. Treat these tokens as 1/1 blue creatures.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "d63b2d32-9e00-558a-98eb-56ea6106db94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627ca588-917f-4768-a69d-3d93c1210390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627ca588-917f-4768-a69d-3d93c1210390.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Homarid Warrior is untapped, tap it.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "46015c37-2fbb-5d1c-b4f5-8378e777fb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a9bdcf-543b-4140-b836-9e222a4a9233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a9bdcf-543b-4140-b836-9e222a4a9233.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Homarid Warrior is untapped, tap it.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "8773d164-4681-545b-8858-4a03c78605ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1cccdc-9c4d-4ef3-807b-278e6fd23230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1cccdc-9c4d-4ef3-807b-278e6fd23230.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Homarid Warrior is untapped, tap it.",
             "colours": [
@@ -1667,7 +1667,7 @@
         },
         {
             "id": "cea65470-2c66-5175-8b33-f3f221fa4cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e96895-ef1d-44fa-b263-bce833fc3109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e96895-ef1d-44fa-b263-bce833fc3109.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "2f00edda-8d4a-53a3-9519-9b9242a22c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7fb804-65ba-477e-93e8-eea101c1521e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7fb804-65ba-477e-93e8-eea101c1521e.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "86cf768c-57f4-58ad-9a64-e7cb99ee6095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd197f8-ced0-461a-9672-2720a7b70803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd197f8-ced0-461a-9672-2720a7b70803.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "6978e422-5d61-5cf4-ac89-1f9cf7ad9c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a9e9a-d1f8-44c5-9f79-a1201acfb5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a9e9a-d1f8-44c5-9f79-a1201acfb5fc.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "c090890d-b1da-5469-8a06-27ed37d26e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7fa54-4b89-4a9a-b088-4b89c525c1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7fa54-4b89-4a9a-b088-4b89c525c1ea.jpg?1",
             "name": "River Merfolk",
             "text": "oo\nU Mountainwalk until end of turn",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "46654342-8a75-5487-8f05-e0bb714517ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5266aa1-e2ea-46b9-91ab-b94a7bb7e9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5266aa1-e2ea-46b9-91ab-b94a7bb7e9f9.jpg?1",
             "name": "Seasinger",
             "text": "Bury Seasinger if you control no islands.\noc\nT: Gain control of a target creature if its controller controls at least one island. You lose control of target creature if Seasinger leaves play, if you lose control of Seasinger, or if Seasinger becomes untapped. You may choose not to untap Seasinger as normal during your untap phase.",
             "colours": [
@@ -1881,7 +1881,7 @@
         },
         {
             "id": "fcecb5a7-0da1-5b2d-8dad-0cf926187d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316d25ae-7ac6-4f5b-93ab-0e0e28ec104b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316d25ae-7ac6-4f5b-93ab-0e0e28ec104b.jpg?1",
             "name": "Svyelunite Priest",
             "text": "o\nUo\nU, oc\nT: Target creature may not be the target of spells or effects until end of turn. Use this ability only during your upkeep.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "02857b62-d88d-5b94-8f64-b51a457f2ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820f3f-434e-4d09-91b9-0ebd6966b393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820f3f-434e-4d09-91b9-0ebd6966b393.jpg?1",
             "name": "Tidal Flats",
             "text": "o\nUoo\nU All your creatures that are blocking any non-flying creatures gain first strike until end of turn. The attacking player may pay o1 for each attacking creature to prevent Tidal Flats from giving that creature's blockers first strike.",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "92f448c4-34ae-5105-bba9-ea5f01f9a5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7d376-3e22-44aa-9c96-a3b8eb1568fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7d376-3e22-44aa-9c96-a3b8eb1568fe.jpg?1",
             "name": "Tidal Flats",
             "text": "o\nUoo\nU All your creatures that are blocking any non-flying creatures gain first strike until end of turn. The attacking player may pay o1 for each attacking creature to prevent Tidal Flats from giving that creature's blockers first strike.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "56443850-917e-510f-b402-3d5c5c1f261d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445c4767-6261-449c-bb57-713e2a2bb0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445c4767-6261-449c-bb57-713e2a2bb0bf.jpg?1",
             "name": "Tidal Flats",
             "text": "o\nUoo\nU All your creatures that are blocking any non-flying creatures gain first strike until end of turn. The attacking player may pay o1 for each attacking creature to prevent Tidal Flats from giving that creature's blockers first strike.",
             "colours": [
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "41112049-753d-5fab-8cb8-991f0ae6b14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2192c7b-ef6f-4ff6-9017-b1a125340517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2192c7b-ef6f-4ff6-9017-b1a125340517.jpg?1",
             "name": "Tidal Influence",
             "text": "Put a tide counter on Tidal Influence when it is brought into play and during your upkeep. If there is one tide counter on Tidal Influence, all blue creatures get -2/-0. If there are three tide counters on Tidal Influence, all blue creatures get +2/+0. When there are four tide counters on Tidal Influence, remove them all.\nYou may not cast Tidal Influence if there is another Tidal Influence in play.",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "412b0e7a-d20b-5d2a-8ea8-f95c97767845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d97e1b-2526-4740-b354-f158734d1f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d97e1b-2526-4740-b354-f158734d1f72.jpg?1",
             "name": "Vodalian Knights",
             "text": "First strike\noo\nU Flying until end of turn\nVodalian Knights may not attack unless opponent controls at least one island. Bury Vodalian Knights if you control no islands.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "7d192fa9-cde1-51e0-a884-252dc2633244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c107e82b-134a-4f2b-98c2-6537fae6a50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c107e82b-134a-4f2b-98c2-6537fae6a50d.jpg?1",
             "name": "Vodalian Mage",
             "text": "o\nU, oc\nT: Counters a target spell if caster of target spell does not pay an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "5297d639-0248-56ff-9156-33933dab10a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47beac4-161d-4f8e-9778-78293ff9b383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47beac4-161d-4f8e-9778-78293ff9b383.jpg?1",
             "name": "Vodalian Mage",
             "text": "o\nU, oc\nT: Counters a target spell if caster of target spell does not pay an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "dacc6807-bf80-5000-9574-ab82a566f3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3cc91d-6f87-4f2e-b3c7-8181d19a1f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3cc91d-6f87-4f2e-b3c7-8181d19a1f0b.jpg?1",
             "name": "Vodalian Mage",
             "text": "o\nU, oc\nT: Counters a target spell if caster of target spell does not pay an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "2ba124cd-929c-5206-bab1-8d2fbbaabeed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb50256-9113-4b03-bcef-9aea24be8493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb50256-9113-4b03-bcef-9aea24be8493.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "40bdeefe-3e55-5490-b4be-56b65e0d68ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a68c-14d6-4447-a894-0e48d1662bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a68c-14d6-4447-a894-0e48d1662bc3.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "32ede19d-59b6-50e1-9602-1141ab6a257f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1ceac-bb75-4c46-9ab4-1ef623ed3027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1ceac-bb75-4c46-9ab4-1ef623ed3027.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "593c7492-ced7-5a41-83d3-06f6c65f46e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d22f83-1171-4b5c-8a72-956db26d7c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d22f83-1171-4b5c-8a72-956db26d7c60.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "d7122aef-703d-5626-a32f-3cc2752028fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd962ff0-4aa6-453e-931e-bd36fc034273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd962ff0-4aa6-453e-931e-bd36fc034273.jpg?1",
             "name": "Vodalian War Machine",
             "text": "o0: Tap target Merfolk you control to allow Vodalian War Machine to attack this turn or to give Vodalian War Machine +2/+1 until end of turn. If Vodalian War Machine is put in the graveyard, all Merfolk tapped in this manner this turn are destroyed.",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "ca4da0be-14f0-5f79-adb8-f2116b99c768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98384d1-8e7d-4c41-9f23-47bc2ae2ad6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98384d1-8e7d-4c41-9f23-47bc2ae2ad6a.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "7d1d6ed5-e192-586d-b518-dcf5386ff852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6120e6-ceb8-4eab-86b0-18d38ed97d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6120e6-ceb8-4eab-86b0-18d38ed97d8f.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "a860ebd5-1f8a-54b8-bf83-473fd7594a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a91ed4-131e-455b-a3bd-0bd42aa754e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a91ed4-131e-455b-a3bd-0bd42aa754e5.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "c55e8de2-b991-55a4-9f88-052e55671ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d653ca4-c21f-4594-b900-2526a912001b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d653ca4-c21f-4594-b900-2526a912001b.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "40e70197-ddf5-59f4-86dd-c0d556ecd072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1d5d13-0160-48cb-8fac-dd86102569b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1d5d13-0160-48cb-8fac-dd86102569b4.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "1e5e8355-c4c0-552c-a000-ad80e603844e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf60db5-4f69-4db4-9dc2-1a6fbdec0429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf60db5-4f69-4db4-9dc2-1a6fbdec0429.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "2a5d5cf7-1bfe-58fd-9e7e-a0339b7feea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86d9647-3a87-4620-aa07-26f996fc6fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86d9647-3a87-4620-aa07-26f996fc6fa3.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "60fd2fa7-af05-54c7-b5f5-f631dc6d4f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6908e4c-f94d-4b0d-b9a5-64c04751f108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6908e4c-f94d-4b0d-b9a5-64c04751f108.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "97747bac-81c8-54b8-b745-6b7b5371f92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7e85f-eba5-4fc5-9fc0-109109d368aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7e85f-eba5-4fc5-9fc0-109109d368aa.jpg?1",
             "name": "Breeding Pit",
             "text": "During your upkeep, pay o\nBo\nB or bury Breeding Pit. At the end of your turn, put a Thrull token into play. Treat this token as a 0/1 black creature.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "f2a5af88-e0ad-591f-aebb-b368220518a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2b79f-f09a-49dc-8e0f-7d711ba78981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2b79f-f09a-49dc-8e0f-7d711ba78981.jpg?1",
             "name": "Derelor",
             "text": "Your black spells cost an additional o\nB to cast.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "ab9458e9-aa10-5ef5-9e50-d40ab22cfdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40451f7a-692a-422d-99d3-d93a4d9315e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40451f7a-692a-422d-99d3-d93a4d9315e0.jpg?1",
             "name": "Ebon Praetor",
             "text": "Trample, first strike\nDuring your upkeep, put a -2/-2 counter on Ebon Praetor.\nYou may sacrifice a creature during your upkeep to remove a -2/-2 counter from Ebon Praetor. If the creature sacrificed was a Thrull, also put a +1/+0 counter on Ebon Praetor. Only one creature may be sacrificed in this manner each turn.",
             "colours": [
@@ -2772,7 +2772,7 @@
         },
         {
             "id": "d08f6e17-c983-5c32-815e-c66c8c90606e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9273ea-9a41-42e3-8c9c-0d50b127a818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9273ea-9a41-42e3-8c9c-0d50b127a818.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "51e85858-a0cd-5435-92fe-cb8230e5af63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8601f082-7e43-44ef-97d0-dead272b7eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8601f082-7e43-44ef-97d0-dead272b7eb4.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2842,7 +2842,7 @@
         },
         {
             "id": "edcdc086-3283-5a89-81dd-1cc27d196ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e125c6-81dc-4907-aad2-2ccd1cb166f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e125c6-81dc-4907-aad2-2ccd1cb166f0.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "70b81f27-2508-5ae5-a86c-eaa599e76113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc50e08-dd6f-4ea7-87f8-cce72bafb928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc50e08-dd6f-4ea7-87f8-cce72bafb928.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "111b576c-2b37-5786-91d5-7e8855e31f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be87527-3b8f-4529-afdb-a61ad4e787e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be87527-3b8f-4529-afdb-a61ad4e787e1.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. Play this ability as an interrupt. If more than o3 is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn.",
             "colours": [
@@ -2948,7 +2948,7 @@
         },
         {
             "id": "cd99cdda-0923-51f5-be4d-7ff7a6a7bb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7dc01-46d0-42be-a1a9-48f69c846d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7dc01-46d0-42be-a1a9-48f69c846d12.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. Play this ability as an interrupt. If more than o3 is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn.",
             "colours": [
@@ -2984,7 +2984,7 @@
         },
         {
             "id": "78140b2b-9da8-506d-af30-442d40cc4755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982970-e8b8-4659-bcf0-21aab662d89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982970-e8b8-4659-bcf0-21aab662d89d.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. Play this ability as an interrupt. If more than o3 is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn.",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "0d11234e-c969-5dab-a1e5-cb8e38b8dcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a791f-ac4f-4a96-b59b-37043686a79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a791f-ac4f-4a96-b59b-37043686a79a.jpg?1",
             "name": "Mindstab Thrull",
             "text": "If Mindstab Thrull attacks and is not blocked, you may sacrifice it to force the player it attacked to discard three cards. If you do so, it deals no damage during combat this turn. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "e220dc65-d0db-5d2c-96ad-004d57e6be19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781e4b62-3910-4ba1-9e72-e99de8523a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781e4b62-3910-4ba1-9e72-e99de8523a94.jpg?1",
             "name": "Mindstab Thrull",
             "text": "If Mindstab Thrull attacks and is not blocked, you may sacrifice it to force the player it attacked to discard three cards. If you do so, it deals no damage during combat this turn. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "ae6b247d-6e50-5c5f-9201-9988ce3d4d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923189c6-d407-4cc4-a062-2f09a4c7c1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923189c6-d407-4cc4-a062-2f09a4c7c1e3.jpg?1",
             "name": "Mindstab Thrull",
             "text": "If Mindstab Thrull attacks and is not blocked, you may sacrifice it to force the player it attacked to discard three cards. If you do so, it deals no damage during combat this turn. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "ded6af34-c031-5a7c-979d-e4771e25c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d752a-ce8a-44cb-8aeb-1ed66705eb09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d752a-ce8a-44cb-8aeb-1ed66705eb09.jpg?1",
             "name": "Necrite",
             "text": "If Necrite attacks and is not blocked, you may sacrifice it to bury a target creature controlled by the player Necrite attacked this turn. If you do so, Necrite deals no damage during combat this turn.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "ec8ae7da-997f-5ee4-aeda-eb116f1473ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a4d41-e7b0-48b3-8e2e-9ac00f119ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a4d41-e7b0-48b3-8e2e-9ac00f119ce2.jpg?1",
             "name": "Necrite",
             "text": "If Necrite attacks and is not blocked, you may sacrifice it to bury a target creature controlled by the player Necrite attacked this turn. If you do so, Necrite deals no damage during combat this turn.",
             "colours": [
@@ -3200,7 +3200,7 @@
         },
         {
             "id": "a91d49fb-62bf-5b24-a5ad-754ec52852c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ae99f-4e61-45fd-9436-855a38289c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ae99f-4e61-45fd-9436-855a38289c8b.jpg?1",
             "name": "Necrite",
             "text": "If Necrite attacks and is not blocked, you may sacrifice it to bury a target creature controlled by the player Necrite attacked this turn. If you do so, Necrite deals no damage during combat this turn.",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "eb7b37a3-e980-57d6-8650-09189af34662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51f5d8-a7cc-4720-8af5-e002bcfd78a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51f5d8-a7cc-4720-8af5-e002bcfd78a0.jpg?1",
             "name": "Order of the Ebon Hand",
             "text": "Protection from white\no\nBoo\nB +1/+0 until end of turn\noo\nB First strike until end of turn",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "99f840de-f34c-5d12-b380-fa73207194dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ffbb40-13c1-4d01-9421-95b2410d0d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ffbb40-13c1-4d01-9421-95b2410d0d3b.jpg?1",
             "name": "Order of the Ebon Hand",
             "text": "Protection from white\no\nBoo\nB +1/+0 until end of turn\noo\nB First strike until end of turn",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "624f4270-ec57-5594-af14-faf585eadcbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c32774-5507-4a60-9ed2-2a570f6ff8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c32774-5507-4a60-9ed2-2a570f6ff8e3.jpg?1",
             "name": "Order of the Ebon Hand",
             "text": "Protection from white\no\nBoo\nB +1/+0 until end of turn\noo\nB First strike until end of turn",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "240b5139-0cfb-5902-a79d-341b7cd1ab78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f73597d-f453-4d37-b2ef-c54ef683a884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f73597d-f453-4d37-b2ef-c54ef683a884.jpg?1",
             "name": "Soul Exchange",
             "text": "Sacrifice a creature, but remove it from the game instead of putting it in your graveyard. Take a creature from your graveyard and put it directly into play as though it were just summoned. Put a +2/+2 counter on this creature if the creature sacrificed was a Thrull.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "65a703f4-bcca-51be-a26d-5f2fb6a77576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3cafdd-a03b-4b08-b9c1-c776f8450d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3cafdd-a03b-4b08-b9c1-c776f8450d3a.jpg?1",
             "name": "Thrull Champion",
             "text": "All Thrulls get +1/+1.\noc\nT: Take control of a target Thrull. You lose control of target Thrull if Thrull Champion leaves play or you lose control of Thrull Champion.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "79cbbdfe-eac3-55d3-993c-30fc6a917264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d800512b-1492-41d2-931d-57c625044454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d800512b-1492-41d2-931d-57c625044454.jpg?1",
             "name": "Thrull Retainer",
             "text": "Target creature gets +1/+1.\nSacrifice Thrull Retainer to regenerate the creature it enchants.",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "498b2236-4696-5154-959c-0d524e0786f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e732fb-cbef-4fd8-b704-e4d513a6cf2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e732fb-cbef-4fd8-b704-e4d513a6cf2d.jpg?1",
             "name": "Thrull Wizard",
             "text": "o1oo\nB Counters a target black spell if caster of target spell does not pay an additional o\nB or o3. Play this ability as an interrupt.",
             "colours": [
@@ -3478,7 +3478,7 @@
         },
         {
             "id": "cd5af987-2ff6-53eb-9796-91146643b921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06883fd2-eccd-47c6-8c34-10d95e923685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06883fd2-eccd-47c6-8c34-10d95e923685.jpg?1",
             "name": "Tourach's Chant",
             "text": "During your upkeep, pay o\nB or bury Tourach's Chant.\nWhenever a player puts a forest into play, Tourach's Chant deals 3 damage to him or her unless that player puts a -1/-1 counter on a target creature he or she controls.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "4eb3e0f3-6faa-5fb3-a312-0b90632631d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f6401-a9fb-449c-b511-6fb837055bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f6401-a9fb-449c-b511-6fb837055bb4.jpg?1",
             "name": "Tourach's Gate",
             "text": "Can only be played on a target land you control. Sacrifice a Thrull to put three time counters on Tourach's Gate. During your upkeep, remove a time counter from Tourach's Gate. If there are no time counters on Tourach's Gate, bury it.\no0: Tap land Tourach's Gate enchants. All attacking creatures you control get +2/-1 until end of turn.",
             "colours": [
@@ -3542,7 +3542,7 @@
         },
         {
             "id": "6d34d87d-95f5-568c-9e0e-a26b2961f02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0cb8f6-6ba7-402c-9829-251f7443e871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0cb8f6-6ba7-402c-9829-251f7443e871.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "45f14fda-e7ae-595e-a840-98c4008742c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9d0354-9ddd-4fe1-8174-9d3686ca564c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9d0354-9ddd-4fe1-8174-9d3686ca564c.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "a8babe8b-5cd5-53bf-ab72-695d887bbcf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1e461-f74e-436c-a9df-aff197cf48e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1e461-f74e-436c-a9df-aff197cf48e1.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3653,7 +3653,7 @@
         },
         {
             "id": "92a0ce5f-4d4e-530d-a1c6-9044bd8f303f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f0f4fe-2dd0-42c1-8f68-5d24a8a9d07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f0f4fe-2dd0-42c1-8f68-5d24a8a9d07d.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "97bdaecd-ba23-581b-8307-2b8be0879785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d50bf06-97ab-4874-a484-9289f41dc98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d50bf06-97ab-4874-a484-9289f41dc98e.jpg?1",
             "name": "Dwarven Armorer",
             "text": "o\nR, oc\nT: Discard a card from your hand to put either a +0/+1 or a +1/+0 counter on a target creature.",
             "colours": [
@@ -3723,7 +3723,7 @@
         },
         {
             "id": "9161ade4-b646-51cc-b0bb-3eb76125495b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c6932-638a-4df7-bf9b-8d921f7484d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c6932-638a-4df7-bf9b-8d921f7484d9.jpg?1",
             "name": "Dwarven Catapult",
             "text": "Dwarven Catapult does X damage, divided evenly among all of opponent's creatures (round down).",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "953c83e0-42ff-515c-9d60-c59d188dacb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a38b1-4676-425a-b40d-4fb478966024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a38b1-4676-425a-b40d-4fb478966024.jpg?1",
             "name": "Dwarven Lieutenant",
             "text": "o1oo\nR Target Dwarf gets +1/+0 until end of turn.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "6c777825-7190-5178-a647-1a28157d173b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe77608-0b33-43f5-83fb-ae993ca1bf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe77608-0b33-43f5-83fb-ae993ca1bf7c.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "c593936b-fb18-572f-8179-ca5a2fbca40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c52-dfe1-4b15-a0d6-4f26c294426d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c52-dfe1-4b15-a0d6-4f26c294426d.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "731f2008-a273-5bd5-b553-180d055866f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872c5601-f356-4873-adf9-9a39536e7d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872c5601-f356-4873-adf9-9a39536e7d4a.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "8857aa11-9f31-5623-a398-736d63b5ab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b710c21-e9f5-4660-80f6-2104ec65f63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b710c21-e9f5-4660-80f6-2104ec65f63f.jpg?1",
             "name": "Goblin Chirurgeon",
             "text": "o0: Sacrifice a Goblin to regenerate a target creature.",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "03949ce0-be07-5bd8-972b-f17cc1222c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982115b2-e1e7-4b2f-8eb6-a1633477d4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982115b2-e1e7-4b2f-8eb6-a1633477d4a8.jpg?1",
             "name": "Goblin Chirurgeon",
             "text": "o0: Sacrifice a Goblin to regenerate a target creature.",
             "colours": [
@@ -3973,7 +3973,7 @@
         },
         {
             "id": "9f0ec541-47f9-5a3b-bbf9-90c842d7742d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9740842-7955-4cf9-8f76-a426858360b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9740842-7955-4cf9-8f76-a426858360b1.jpg?1",
             "name": "Goblin Chirurgeon",
             "text": "o0: Sacrifice a Goblin to regenerate a target creature.",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "a61790a8-0f29-5377-8514-eed8512b1c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87024efe-4a74-49fe-a43a-480bed0a650a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87024efe-4a74-49fe-a43a-480bed0a650a.jpg?1",
             "name": "Goblin Flotilla",
             "text": "Islandwalk\nAt the beginning of the attack, pay o\nR or any creatures blocking or blocked by Goblin Flotilla gain first strike until end of turn.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "3f8b0029-2c7f-5c25-9b43-3d866a8d2641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8837eaba-9602-4f63-9897-85583fcdcf51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8837eaba-9602-4f63-9897-85583fcdcf51.jpg?1",
             "name": "Goblin Grenade",
             "text": "Sacrifice a Goblin to have Goblin Grenade deal 5 damage to one target.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "466b471a-d541-54b7-8604-0dbdcb1fcd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee262da-3002-4c08-8043-4e40e1b46822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee262da-3002-4c08-8043-4e40e1b46822.jpg?1",
             "name": "Goblin Grenade",
             "text": "Sacrifice a Goblin to have Goblin Grenade deal 5 damage to one target.",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "ad4cf79d-16cf-5558-ae33-16012950dac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1befdfc7-a1e3-4a2a-ad68-7d0fee170f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1befdfc7-a1e3-4a2a-ad68-7d0fee170f3f.jpg?1",
             "name": "Goblin Grenade",
             "text": "Sacrifice a Goblin to have Goblin Grenade deal 5 damage to one target.",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "d525d883-72e0-5ef0-bc59-565c9c9068b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a27ac3-2273-469a-92ba-3f4a3d55de6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a27ac3-2273-469a-92ba-3f4a3d55de6f.jpg?1",
             "name": "Goblin Kites",
             "text": "oo\nR A target creature you control, which cannot have a toughness greater than 2, gains flying until end of turn. Other effects may later be used to increase the creature's toughness. At end of turn, flip a coin; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, bury that creature.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "a03bd000-11d1-5252-ac55-ba73027fd2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c4e4b-e9a7-4180-927b-589514c21876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c4e4b-e9a7-4180-927b-589514c21876.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "6c0411bc-7a09-5be2-bfff-f67942f1a9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5988a3d2-748f-4642-9e33-293ddc568111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5988a3d2-748f-4642-9e33-293ddc568111.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "6cb580a1-0a98-5427-a435-b031ce19a8f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2232386e-986d-41b5-8b70-e086264f3277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2232386e-986d-41b5-8b70-e086264f3277.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "035a78f0-ce02-57c3-bbcf-3b541b4fc1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0185f3-fbc0-44d7-b933-30627cda1bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0185f3-fbc0-44d7-b933-30627cda1bf9.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "ed525145-3a80-598a-872b-d82a91d8fb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec4aa5-3319-43dc-8347-5633edbd7018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec4aa5-3319-43dc-8347-5633edbd7018.jpg?1",
             "name": "Goblin Warrens",
             "text": "o2oo\nR Sacrifice two Goblins to put three Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -4347,7 +4347,7 @@
         },
         {
             "id": "9885640b-c264-58b6-8fa9-1cc5a8bef3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43cf61d-b4d6-4461-a228-47fd8b026d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43cf61d-b4d6-4461-a228-47fd8b026d33.jpg?1",
             "name": "Orcish Captain",
             "text": "o1: Choose a target Orc. Flip a coin; opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, that Orc gets +2/+0 until end of turn. Otherwise, that Orc gets -0/-2 until end of turn.",
             "colours": [
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "81c2db17-646a-54ca-a15c-6c054d061e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3890d1-563d-4519-ab8c-913031d71918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3890d1-563d-4519-ab8c-913031d71918.jpg?1",
             "name": "Orcish Spy",
             "text": "oc\nT: Look at the top three cards of target player's library and return them in the same order.",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "539f6f9f-1a21-5795-a592-a6d8e0db85ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b931cfd-b952-416c-ab2c-271ecaee8e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b931cfd-b952-416c-ab2c-271ecaee8e0c.jpg?1",
             "name": "Orcish Spy",
             "text": "oc\nT: Look at the top three cards of target player's library and return them in the same order.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "366db4ae-9b5f-5b22-a584-e73d57a40309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e08767-7e92-4ff4-b0d8-196565fbc23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e08767-7e92-4ff4-b0d8-196565fbc23c.jpg?1",
             "name": "Orcish Spy",
             "text": "oc\nT: Look at the top three cards of target player's library and return them in the same order.",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "f54b5068-3f09-50c5-a6dc-32ce16528115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbca765-8756-4e28-9faf-25714c9b8838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbca765-8756-4e28-9faf-25714c9b8838.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "4c099534-b6c2-5296-902f-5fedce0dcd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc37db83-9efc-4d58-90c9-78eef9073ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc37db83-9efc-4d58-90c9-78eef9073ec2.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "18c1f076-4741-5b81-8de5-e61775b86b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334004e6-bf8c-4a4e-a30c-1537a99819c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334004e6-bf8c-4a4e-a30c-1537a99819c9.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "27d543fc-6456-57e7-9d00-901228e5093a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4990dd4b-2b18-4e4c-81d4-1cd8d746a7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4990dd4b-2b18-4e4c-81d4-1cd8d746a7dc.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "e98e6dd3-c0e4-512d-9991-542f8d980b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af19ab0-4bd0-4d5f-8d2e-507e4fe87c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af19ab0-4bd0-4d5f-8d2e-507e4fe87c18.jpg?1",
             "name": "Orgg",
             "text": "Trample\nOrgg may not attack if opponent controls an untapped creature of power greater than 2. Orgg cannot be assigned to block any creature of power greater than 2.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "def75dab-f9a9-5ec6-8d84-467e46a76e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a3396-706b-4ca2-9973-bca758986032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a3396-706b-4ca2-9973-bca758986032.jpg?1",
             "name": "Raiding Party",
             "text": "Raiding Party may not be the target of white spells or effects.\no0: Sacrifice an Orc to destroy all plains. A player may tap a white creature to prevent up to two plains from being destroyed. Any number of creatures may be tapped in this manner.",
             "colours": [
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "28398fda-0f34-5070-a939-db8c1c68e100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387105d-46d0-4db0-8980-dd0fded15eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387105d-46d0-4db0-8980-dd0fded15eef.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "4187dc66-3ec5-5ffb-a9a0-e57e813dfd21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091b5ed4-91f5-47c1-b1a1-5443f7346078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091b5ed4-91f5-47c1-b1a1-5443f7346078.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "c0e12bcf-f43c-5bd8-9e41-3ed950989a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960b542f-cb24-4f74-92da-d31559d87c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960b542f-cb24-4f74-92da-d31559d87c2d.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4809,7 +4809,7 @@
         },
         {
             "id": "3d0663a1-e25f-594e-8c57-cc62132349c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52743f0-5c5b-46b9-bbbd-67950d4c89e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52743f0-5c5b-46b9-bbbd-67950d4c89e5.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "a8f5020a-b193-5b39-951b-ae8e20eeb7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9710e-b2f8-4746-8640-d450f58a6e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9710e-b2f8-4746-8640-d450f58a6e49.jpg?1",
             "name": "Elvish Farmer",
             "text": "During your upkeep, put a spore counter on Elvish Farmer.\no0: Remove three spore counters from Elvish Farmer to put a Saproling token into play. Treat this token as a 1/1 green creature.\no0: Sacrifice a Saproling to gain 2 life.",
             "colours": [
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "304cfa9f-b8f5-53fa-84b4-5501bc996007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00455ac-c7ce-4916-98ed-cca9354e3f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00455ac-c7ce-4916-98ed-cca9354e3f22.jpg?1",
             "name": "Elvish Hunter",
             "text": "o1o\nG, oc\nT: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "ff3c7e2c-45e1-52a9-a3a2-b07a92ab9984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff096c-487f-42f9-a394-a298503391da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff096c-487f-42f9-a394-a298503391da.jpg?1",
             "name": "Elvish Hunter",
             "text": "o1o\nG, oc\nT: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "c7b73d37-3fc4-56b1-8c7a-efb088bc6c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204c8aff-b103-4606-b86b-d794bc5dcde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204c8aff-b103-4606-b86b-d794bc5dcde1.jpg?1",
             "name": "Elvish Hunter",
             "text": "o1o\nG, oc\nT: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "84927d71-9a0c-520b-b67c-f6edb3e2c6d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cd2ed-be81-4769-a8ec-287946301396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cd2ed-be81-4769-a8ec-287946301396.jpg?1",
             "name": "Elvish Scout",
             "text": "o\nG, oc\nT: Untap a target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "1b3c1275-1bcb-588f-a9d5-8880d8854148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faff88d-594e-473c-a2d1-cd60f51b2ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faff88d-594e-473c-a2d1-cd60f51b2ee7.jpg?1",
             "name": "Elvish Scout",
             "text": "o\nG, oc\nT: Untap a target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "934bba54-7fbc-5f13-8c17-bc08eb6181fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d414bf5a-2604-426c-8c68-5c1696557b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d414bf5a-2604-426c-8c68-5c1696557b57.jpg?1",
             "name": "Elvish Scout",
             "text": "o\nG, oc\nT: Untap a target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "59df4db1-b36f-5442-a681-a571290399b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585241e-c647-456d-b3b1-3d48dd78c372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585241e-c647-456d-b3b1-3d48dd78c372.jpg?1",
             "name": "Feral Thallid",
             "text": "During your upkeep, put a spore counter on Feral Thallid.\no0: Remove three spore counters from Feral Thallid to regenerate it.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "c134ff45-b508-5394-b1d2-5383cd942aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1a2cb2-9a6b-41f7-96f7-ec457c69c16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1a2cb2-9a6b-41f7-96f7-ec457c69c16c.jpg?1",
             "name": "Fungal Bloom",
             "text": "o\nGoo\nG Put a spore counter on a target Fungus.",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "681d74ea-b1a4-571c-8571-32cc6b1b823d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda6d18-d4b1-4b8a-a72e-f90115adf4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda6d18-d4b1-4b8a-a72e-f90115adf4c3.jpg?1",
             "name": "Night Soil",
             "text": "o1: Remove two creatures in any graveyard from the game to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5197,7 +5197,7 @@
         },
         {
             "id": "0add4d13-9084-5b9c-8d85-ad94d7b8842c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f25a497-46dc-47aa-8586-d514578a6d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f25a497-46dc-47aa-8586-d514578a6d25.jpg?1",
             "name": "Night Soil",
             "text": "o1: Remove two creatures in any graveyard from the game to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "1c098126-42f1-5a45-aadf-5396609d4572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3eb61b-698c-42b1-8a33-0ce7c3829e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3eb61b-698c-42b1-8a33-0ce7c3829e07.jpg?1",
             "name": "Night Soil",
             "text": "o1: Remove two creatures in any graveyard from the game to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "e29fee44-6cc5-5be6-bae6-9e69f661ae8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1691a9f4-4ea7-440f-9bdc-4214ab3c90f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1691a9f4-4ea7-440f-9bdc-4214ab3c90f0.jpg?1",
             "name": "Spore Cloud",
             "text": "Tap all blocking creatures. No creatures deal damage in combat this turn. Neither attacking nor blocking creatures untap as normal during their controllers' next untap phase.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "43a93afc-c9d2-511c-9712-7f7204d6c735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3070f8-6dae-4f22-b186-e2a3a9647cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3070f8-6dae-4f22-b186-e2a3a9647cc5.jpg?1",
             "name": "Spore Cloud",
             "text": "Tap all blocking creatures. No creatures deal damage in combat this turn. Neither attacking nor blocking creatures untap as normal during their controllers' next untap phase.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "25fd3aa0-9a68-532f-9bb6-bf07bb6e967f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fe098c-c9b5-4bba-92b5-5720d6919073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fe098c-c9b5-4bba-92b5-5720d6919073.jpg?1",
             "name": "Spore Cloud",
             "text": "Tap all blocking creatures. No creatures deal damage in combat this turn. Neither attacking nor blocking creatures untap as normal during their controllers' next untap phase.",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "16a3be22-4630-5551-9132-340acebe5e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9681dc0-d0fc-4d5b-a23c-63ec1cc8343d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9681dc0-d0fc-4d5b-a23c-63ec1cc8343d.jpg?1",
             "name": "Spore Flower",
             "text": "During your upkeep, put a spore counter on Spore Flower.\no0: Remove three spore counters from Spore Flower. No creatures deal damage in combat this turn.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "98545ba8-e0df-5e18-ab4e-b69b7309800c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caaf31b-86a9-485b-8da7-d5b526ed1233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caaf31b-86a9-485b-8da7-d5b526ed1233.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "5d50a6ce-2c78-58a4-9589-b1492648e768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f8f778-ae31-45cd-b27f-f93a07853ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f8f778-ae31-45cd-b27f-f93a07853ede.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "65169180-9a19-578e-9c21-62e7f79839c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2f3da-9101-439d-8caa-910ff40bfbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2f3da-9101-439d-8caa-910ff40bfbb3.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "892cbc98-2909-52d9-82b4-a59bd98c5370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01827286-b104-41c5-bac9-7c38414bc40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01827286-b104-41c5-bac9-7c38414bc40e.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5548,7 +5548,7 @@
         },
         {
             "id": "8d6b22fe-8583-5908-b964-05e3174e3154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa533845-4c4b-4072-aa39-8e56ce7ec325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa533845-4c4b-4072-aa39-8e56ce7ec325.jpg?1",
             "name": "Thallid Devourer",
             "text": "During your upkeep, put a spore counter on Thallid Devourer.\no0: Remove three spore counters from Thallid Devourer to put a Saproling token into play. Treat this token as a 1/1 green creature.\no0: Sacrifice a Saproling to give Thallid Devourer +1/+2 until end of turn.",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "c2663eaa-e4aa-5ac6-97dc-8d98acb408f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d970195-0a09-4cb4-a2c0-c16fcab5c859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d970195-0a09-4cb4-a2c0-c16fcab5c859.jpg?1",
             "name": "Thelon's Chant",
             "text": "During your upkeep, pay o\nG or bury Thelon's Chant.\nWhenever a player puts a swamp into play, Thelon's Chant deals 3 damage to him or her unless that player puts a -1/-1 counter on a target creature he or she controls.",
             "colours": [
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "a0121bf2-80e8-5d26-a241-96a56a978970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b868846-cc3c-4756-a5dd-2335bb380567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b868846-cc3c-4756-a5dd-2335bb380567.jpg?1",
             "name": "Thelon's Curse",
             "text": "Blue creatures do not untap as normal during their controller's untap phase. During his or her upkeep, a blue creature's controller may pay an additional o\nU to untap it. Each creature may be untapped in this way only once per turn.",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "57183cf9-3f59-598c-9cb3-3aa52b9d5fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8772dd-513d-4dd0-a5db-5214dc8da4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8772dd-513d-4dd0-a5db-5214dc8da4e0.jpg?1",
             "name": "Thelonite Druid",
             "text": "o1o\nG, oc\nT: Sacrifice a creature to turn all your forests into 2/3 creatures until end of turn. The forests still count as lands but may not be tapped for mana if they were brought into play this turn.",
             "colours": [
@@ -5679,7 +5679,7 @@
         },
         {
             "id": "a34aaf79-2413-5cd7-88a0-b7c770548a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5400ff25-c70e-4095-a228-190601b86043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5400ff25-c70e-4095-a228-190601b86043.jpg?1",
             "name": "Thelonite Monk",
             "text": "oc\nT: Sacrifice a green creature to turn a target land into a basic forest. Mark changed land with a counter.",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "e1b79765-febc-532d-a615-9c38500433db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e61c00-3e94-4f6f-8515-65b430829e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e61c00-3e94-4f6f-8515-65b430829e91.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "f986ea00-5aef-575b-b776-92089eb75ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84283348-789b-4236-b406-7fc6338a867d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84283348-789b-4236-b406-7fc6338a867d.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5788,7 +5788,7 @@
         },
         {
             "id": "e4ee68ff-08d3-5796-85ab-0d8d869717f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1537a338-3b68-4a41-bac6-554e8e530e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1537a338-3b68-4a41-bac6-554e8e530e46.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "74032f60-c83c-5332-867d-7f5bb116bfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8f50be-1629-40eb-8916-019903d2e6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8f50be-1629-40eb-8916-019903d2e6a4.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "a510d791-ecf5-5d9f-b575-56702ddc649b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09030ee-415c-45af-bf08-7623197a314f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09030ee-415c-45af-bf08-7623197a314f.jpg?1",
             "name": "Aeolipile",
             "text": "o1, oc\nT: Sacrifice Aeolipile to have it deal 2 damage to any target.",
             "colours": [],
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "3a1167dc-13e9-5ebc-99f9-d0c20824a364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95de4a-7fae-42bc-9660-39ea7685ca02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95de4a-7fae-42bc-9660-39ea7685ca02.jpg?1",
             "name": "Balm of Restoration",
             "text": "o1, oc\nT: Sacrifice Balm of Restoration to gain 2 life or prevent up to 2 damage to any player or creature.",
             "colours": [],
@@ -5916,7 +5916,7 @@
         },
         {
             "id": "8d60451e-b3de-5df2-81f2-d644313495af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860a9ba3-e4c4-4af9-bdfe-1ada39289fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860a9ba3-e4c4-4af9-bdfe-1ada39289fd5.jpg?1",
             "name": "Conch Horn",
             "text": "o1, oc\nT: Sacrifice Conch Horn. Draw two cards, then put any one card from your hand back on top of your library.",
             "colours": [],
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "e307c624-1d5d-529e-a750-f1474c99acce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262b8788-c5a0-4c8e-9d58-b769b1b0a2ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262b8788-c5a0-4c8e-9d58-b769b1b0a2ff.jpg?1",
             "name": "Delif's Cone",
             "text": "oc\nT: Sacrifice Delif's Cone. If target creature you control attacks and is not blocked, you may choose to gain its power in life. If you do so, it deals no damage to opponent this turn.",
             "colours": [],
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "9e8801cd-674d-59e6-ae06-6fce4a17d6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14749600-9eca-4122-b04f-30ddda091b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14749600-9eca-4122-b04f-30ddda091b74.jpg?1",
             "name": "Delif's Cube",
             "text": "o2, oc\nT: If target creature you control attacks and is not blocked, it deals no damage to opponent. Instead, put a cube counter on Delif's Cube.\no2: Remove a cube counter to regenerate a target creature.",
             "colours": [],
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "984e3138-f1b8-503b-adf9-c3defa134e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a419c9e3-5615-44f9-9256-94a3022bb69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a419c9e3-5615-44f9-9256-94a3022bb69f.jpg?1",
             "name": "Draconian Cylix",
             "text": "o2, oc\nT: Discard a card at random from your hand to regenerate a target creature.",
             "colours": [],
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "7f33817f-f1a2-5eca-84f8-6a0d35687f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a8cd72-04c0-46f7-a249-f1cecddfdc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a8cd72-04c0-46f7-a249-f1cecddfdc26.jpg?1",
             "name": "Elven Lyre",
             "text": "o1, oc\nT: Sacrifice Elven Lyre to give a target creature +2/+2 until end of turn.",
             "colours": [],
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "67e49cf2-34d8-5443-a60d-e2b98a6e276f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5deb95-79a6-4398-b82a-c1df169550d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5deb95-79a6-4398-b82a-c1df169550d9.jpg?1",
             "name": "Implements of Sacrifice",
             "text": "o1, oc\nT: Sacrifice Implements of Sacrifice to add 2 mana of any one color to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "619b0328-378c-5219-bd20-ff1aeb1a45ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a532d38a-809b-4132-8690-be15fe23afab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a532d38a-809b-4132-8690-be15fe23afab.jpg?1",
             "name": "Ring of Renewal",
             "text": "o5, oc\nT: Discard a card at random from your hand and draw two cards.",
             "colours": [],
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "7472d926-2a14-55c5-a645-0a0f6104d874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213d6e0d-5ec9-441e-a38d-50ce44583e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213d6e0d-5ec9-441e-a38d-50ce44583e4b.jpg?1",
             "name": "Spirit Shield",
             "text": "o2, oc\nT: Target creature gets +0/+2 as long as Spirit Shield remains tapped.\nYou may choose not to untap Spirit Shield as normal during your untap phase.",
             "colours": [],
@@ -6132,7 +6132,7 @@
         },
         {
             "id": "ae97c205-c455-5d81-8e1c-991f9c11bf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4137160b-5248-4fbd-8ae8-25e9afd8fb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4137160b-5248-4fbd-8ae8-25e9afd8fb5c.jpg?1",
             "name": "Zelyon Sword",
             "text": "o3, oc\nT: Target creature gets +2/+0 as long as Zelyon Sword remains tapped.\nYou may choose not to untap Zelyon Sword as normal during your untap phase.",
             "colours": [],
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "c30d5bf0-83bd-5160-9b8c-7739e728743b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639ae988-d1d1-4ead-b0f8-47fc39eb64a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639ae988-d1d1-4ead-b0f8-47fc39eb64a0.jpg?1",
             "name": "Bottomless Vault",
             "text": "Comes into play tapped. You may choose not to untap Bottomless Vault during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Bottomless Vault. For each storage counter removed, add o\nB to your mana pool.",
             "colours": [],
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "3a86ec0b-9c11-5eca-b370-cb9ade90ab2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3142ded-ff62-4817-aa54-75a7ea4498a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3142ded-ff62-4817-aa54-75a7ea4498a6.jpg?1",
             "name": "Dwarven Hold",
             "text": "Comes into play tapped. You may choose not to untap Dwarven Hold during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Dwarven Hold. For each storage counter removed, add o\nR to your mana pool.",
             "colours": [],
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "6bb18df7-b40f-5bba-accd-a791a434b122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfe1352-27be-4c99-a58f-b961f911f270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfe1352-27be-4c99-a58f-b961f911f270.jpg?1",
             "name": "Dwarven Ruins",
             "text": "Comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT: Sacrifice Dwarven Ruins to add o\nRo\nR to your mana pool.",
             "colours": [],
@@ -6246,7 +6246,7 @@
         },
         {
             "id": "7e74f2cc-c6d5-597a-bed1-e11700c79896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb2a11f-a8e4-4acf-871a-11171e3304ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb2a11f-a8e4-4acf-871a-11171e3304ef.jpg?1",
             "name": "Ebon Stronghold",
             "text": "Comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT: Sacrifice Ebon Stronghold to add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "368aca41-69c8-552c-9cc5-e30772a0bd3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9028f200-80dd-4c53-877f-ea380ff417cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9028f200-80dd-4c53-877f-ea380ff417cb.jpg?1",
             "name": "Havenwood Battleground",
             "text": "Comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT: Sacrifice Havenwood Battleground to add o\nGo\nG to your mana pool.",
             "colours": [],
@@ -6304,7 +6304,7 @@
         },
         {
             "id": "16fc106f-15a9-59b5-b16a-5f3ee3d4b6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90845410-e09a-4753-ad4c-bf2b2f3c95ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90845410-e09a-4753-ad4c-bf2b2f3c95ac.jpg?1",
             "name": "Hollow Trees",
             "text": "Comes into play tapped. You may choose not to untap Hollow Trees during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Hollow Trees. For each storage counter removed, add o\nG to your mana pool.",
             "colours": [],
@@ -6333,7 +6333,7 @@
         },
         {
             "id": "442d4d25-fcb3-5d63-b563-941cf7a11827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd8d8c-52c7-402f-92e1-5e5866f2555a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd8d8c-52c7-402f-92e1-5e5866f2555a.jpg?1",
             "name": "Icatian Store",
             "text": "Comes into play tapped. You may choose not to untap Icatian Store during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Icatian Store. For each storage counter removed, add o\nW to your mana pool.",
             "colours": [],
@@ -6362,7 +6362,7 @@
         },
         {
             "id": "1f244e6d-b287-5937-ad07-3529650e84ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b138e1-f8fc-435c-9aed-98004768479c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b138e1-f8fc-435c-9aed-98004768479c.jpg?1",
             "name": "Rainbow Vale",
             "text": "oc\nT: Add 1 mana of any color to your mana pool. Control of Rainbow Vale passes to opponent at end of turn.",
             "colours": [],
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "8305b0d0-7d4f-5351-806a-340186f705ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce2e734-8cff-4bfe-85f8-17b3e1903f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce2e734-8cff-4bfe-85f8-17b3e1903f18.jpg?1",
             "name": "Ruins of Trokair",
             "text": "Comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT: Sacrifice Ruins of Trokair to add o\nWo\nW to your mana pool.",
             "colours": [],
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "7d08d742-6b14-5f8e-a12a-5fa42f5d1fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f1fcb-d903-4a31-abab-40488569eef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f1fcb-d903-4a31-abab-40488569eef6.jpg?1",
             "name": "Sand Silos",
             "text": "Comes into play tapped. You may choose not to untap Sand Silos during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Sand Silos. For each storage counter removed, add o\nU to your mana pool.",
             "colours": [],
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "5bc5930c-6e0d-529f-8a4a-a376af5fb796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3fde62-ab21-459b-9c5d-01aa6fe1d08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3fde62-ab21-459b-9c5d-01aa6fe1d08e.jpg?1",
             "name": "Svyelunite Temple",
             "text": "Comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT: Sacrifice Svyelunite Temple to add o\nUo\nU to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/FRF.json
+++ b/Assets/Resources/Sets/FRF.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6c42141e-0304-57b5-a1fc-d5b10ca09ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1e824-c8a9-4312-8e4c-a29a26d189a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1e824-c8a9-4312-8e4c-a29a26d189a4.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to target creature or player.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "80b708f8-4715-5270-83d6-904e09d5e0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffd46f5-afd1-4130-b019-d8822e61fdfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffd46f5-afd1-4130-b019-d8822e61fdfa.jpg?1",
             "name": "Abzan Advantage",
             "text": "Target player sacrifices an enchantment. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "be7dd08e-7787-5d28-a938-1eacc2bc31ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe356261-3126-41f1-ae71-b69ca5641f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe356261-3126-41f1-ae71-b69ca5641f84.jpg?1",
             "name": "Abzan Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has vigilance as long as you control a black or green permanent.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "1d90a1b9-872f-53da-be04-2111ac65fc12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4195373-e902-4fc3-aead-1f6e728dbbae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4195373-e902-4fc3-aead-1f6e728dbbae.jpg?1",
             "name": "Abzan Skycaptain",
             "text": "Flying\nWhen Abzan Skycaptain dies, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "ec827f0e-fd97-5372-903c-7ec28d74a1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10aeac19-6892-448e-9e5f-302051a089fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10aeac19-6892-448e-9e5f-302051a089fc.jpg?1",
             "name": "Arashin Cleric",
             "text": "When Arashin Cleric enters the battlefield, you gain 3 life.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "4c99bec8-64aa-5547-b791-4131ecf357e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f7a3b1-4d92-4d32-a823-2e774c6e7e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f7a3b1-4d92-4d32-a823-2e774c6e7e73.jpg?1",
             "name": "Aven Skirmisher",
             "text": "Flying",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "9ea10aa8-c3a5-5016-8626-05022669c614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8801465e-295f-4b6b-a321-120f1b1edd0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8801465e-295f-4b6b-a321-120f1b1edd0b.jpg?1",
             "name": "Channel Harm",
             "text": "Prevent all damage that would be dealt to you and permanents you control this turn by sources you don't control. If damage is prevented this way, you may have Channel Harm deal that much damage to target creature.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "0b9e6b05-8212-5334-b495-6b48c397be1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239c373a-465c-4cda-9895-624871d8606e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239c373a-465c-4cda-9895-624871d8606e.jpg?1",
             "name": "Citadel Siege",
             "text": "As Citadel Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of combat on your turn, put two +1/+1 counters on target creature you control.\n\u2022 Dragons \u2014 At the beginning of combat on each opponent's turn, tap target creature that player controls.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "55c52dba-3c5d-5f0e-98ad-e40552598df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce58a8bd-e979-41e0-a533-7408830e0154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce58a8bd-e979-41e0-a533-7408830e0154.jpg?1",
             "name": "Citadel Siege",
             "text": "",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "f57671bf-389f-583d-a336-6329243424c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7eed1e-7b28-4900-a6ac-67f167476c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7eed1e-7b28-4900-a6ac-67f167476c11.jpg?1",
             "name": "Daghatar the Adamant",
             "text": "Vigilance\nDaghatar the Adamant enters the battlefield with four +1/+1 counters on it.\n{1}{BG}{BG}: Move a +1/+1 counter from target creature onto a second target creature.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "9f22526e-b836-5b5d-865b-da55bd1fdc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed0c9c7-e50d-4bcf-a90e-89cb441de0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed0c9c7-e50d-4bcf-a90e-89cb441de0af.jpg?1",
             "name": "Dragon Bell Monk",
             "text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "686d25b2-c3f6-591c-a761-2d0feebfac4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df904cc6-3ee0-4326-a854-818695aa2890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df904cc6-3ee0-4326-a854-818695aa2890.jpg?1",
             "name": "Dragonscale General",
             "text": "At the beginning of your end step, bolster X, where X is the number of tapped creatures you control. (Choose a creature with the least toughness among creatures you control and put X +1/+1 counters on it.)",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "be30374c-04f9-5dda-9a3a-ad51e4ca3c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ac3224-54af-4688-a015-6a447971544e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ac3224-54af-4688-a015-6a447971544e.jpg?1",
             "name": "Elite Scaleguard",
             "text": "When Elite Scaleguard enters the battlefield, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)\nWhenever a creature you control with a +1/+1 counter on it attacks, tap target creature defending player controls.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "e056912b-45ea-54a4-ab64-6158f2fdefaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e08cb-407b-4b3d-8af0-077ff96bf160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e08cb-407b-4b3d-8af0-077ff96bf160.jpg?1",
             "name": "Great-Horn Krushok",
             "text": "",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "2829d786-bfca-5f34-96c6-b5d4ea189f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084c8b16-7aae-4d1f-87c2-6a150f11bb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084c8b16-7aae-4d1f-87c2-6a150f11bb15.jpg?1",
             "name": "Honor's Reward",
             "text": "You gain 4 life. Bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "e076fd37-4421-538f-82e5-2a6cdefd7334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa2d511-6eec-42dd-9ebe-1260c8527856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa2d511-6eec-42dd-9ebe-1260c8527856.jpg?1",
             "name": "Jeskai Barricade",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nDefender\nWhen Jeskai Barricade enters the battlefield, you may return another target creature you control to its owner's hand.",
             "colours": [
@@ -549,7 +549,7 @@
         },
         {
             "id": "9e258de6-9c67-5989-a4ca-b63dc381be8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa25045-ae03-4ac0-a4ed-472f7ca4ab3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa25045-ae03-4ac0-a4ed-472f7ca4ab3b.jpg?1",
             "name": "Lightform",
             "text": "When Lightform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Lightform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has flying and lifelink.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "5fc080a0-b8d8-55d5-9e17-fa0da88eed18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf97a0-2b90-4006-8a54-7795dbc0dba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf97a0-2b90-4006-8a54-7795dbc0dba1.jpg?1",
             "name": "Lotus-Eye Mystics",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Lotus-Eye Mystics enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "91e08ed7-943c-5a34-934e-98c056df551f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf14a32-b97b-48c7-8395-d9c3626735c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf14a32-b97b-48c7-8395-d9c3626735c1.jpg?1",
             "name": "Mardu Woe-Reaper",
             "text": "Whenever Mardu Woe-Reaper or another Warrior enters the battlefield under your control, you may exile target creature card from a graveyard. If you do, you gain 1 life.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "7ca6e73f-0c6f-512c-aaa3-bba1d6dbc700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b844764-89d4-43a2-8041-3a9a8b4f2912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b844764-89d4-43a2-8041-3a9a8b4f2912.jpg?1",
             "name": "Mastery of the Unseen",
             "text": "Whenever a permanent you control is turned face up, you gain 1 life for each creature you control.\n{3}{W}: Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "0d7b47c3-5d61-5c37-922d-ff3b05d91780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd0e32-2e6b-419b-9e8a-af38f2b48a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd0e32-2e6b-419b-9e8a-af38f2b48a66.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, put a 1/1 white Monk creature token with prowess onto the battlefield.",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "a1d90aa6-c544-57cc-95a5-95d004f660f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0027360-736c-4b3e-b2cd-0d821cca587a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0027360-736c-4b3e-b2cd-0d821cca587a.jpg?1",
             "name": "Pressure Point",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "5260630e-4da4-507d-a765-a443a5a4ad37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9efacb-9d7c-41f4-9b11-59df1be50e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9efacb-9d7c-41f4-9b11-59df1be50e11.jpg?1",
             "name": "Rally the Ancestors",
             "text": "Return each creature card with converted mana cost X or less from your graveyard to the battlefield. Exile those creatures at the beginning of your next upkeep. Exile Rally the Ancestors.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "b07d8aec-03a7-5e64-9f57-017c1502d9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f22dd6f-807a-48a7-bc69-29aaec7012de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f22dd6f-807a-48a7-bc69-29aaec7012de.jpg?1",
             "name": "Sage's Reverie",
             "text": "Enchant creature\nWhen Sage's Reverie enters the battlefield, draw a card for each Aura you control that's attached to a creature.\nEnchanted creature gets +1/+1 for each Aura you control that's attached to a creature.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "a74fd5cc-3ae3-5588-a4d5-57bff74c4842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7305cd4-a9f1-4801-bdfe-b07869ed5b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7305cd4-a9f1-4801-bdfe-b07869ed5b56.jpg?1",
             "name": "Sandblast",
             "text": "Sandblast deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "a24b339d-a28c-5de8-b0c4-5db3ed16466e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29943bb-aa89-443b-96b7-8f6f24672a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29943bb-aa89-443b-96b7-8f6f24672a9d.jpg?1",
             "name": "Sandsteppe Outcast",
             "text": "When Sandsteppe Outcast enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Sandsteppe Outcast.\n\u2022 Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "b89a8481-b9cb-5c43-aedc-7b262788209d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb884ac2-c990-4ab0-8610-e07d93da2f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb884ac2-c990-4ab0-8610-e07d93da2f13.jpg?1",
             "name": "Soul Summons",
             "text": "Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "3d659aa1-cf0a-5e0a-be42-0d0a045672ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3a4e7d-6667-4c2f-b6b4-484f401b0455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3a4e7d-6667-4c2f-b6b4-484f401b0455.jpg?1",
             "name": "Soulfire Grand Master",
             "text": "Lifelink\nInstant and sorcery spells you control have lifelink.\n{2}{UR}{UR}: The next time you cast an instant or sorcery spell from your hand this turn, put that card into your hand instead of into your graveyard as it resolves.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "514c8116-7abc-5ded-9b6d-1eb7e5785d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65998e94-15a0-41f1-8288-730b957f81df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65998e94-15a0-41f1-8288-730b957f81df.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "69fc424a-78b9-5348-9969-9a28f09e8ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59086792-c048-455f-ac0d-1a4a994bd621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59086792-c048-455f-ac0d-1a4a994bd621.jpg?1",
             "name": "Wandering Champion",
             "text": "Whenever Wandering Champion deals combat damage to a player, if you control a blue or red permanent, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "5500fdcb-3be5-5b08-ad05-181f381169dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4290215-3aec-40b8-aac5-e5c39c035cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4290215-3aec-40b8-aac5-e5c39c035cfe.jpg?1",
             "name": "Wardscale Dragon",
             "text": "Flying\nAs long as Wardscale Dragon is attacking, defending player can't cast spells.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "067a49a2-c497-59a8-a6a7-222c6effbd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2185d-46c6-44c1-a67c-9b6af872e8eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2185d-46c6-44c1-a67c-9b6af872e8eb.jpg?1",
             "name": "Aven Surveyor",
             "text": "Flying\nWhen Aven Surveyor enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Aven Surveyor.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "6d56715b-0bb4-580f-a367-dcaaa8146132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bb0f87-a0b3-4389-9580-63db449a2241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bb0f87-a0b3-4389-9580-63db449a2241.jpg?1",
             "name": "Cloudform",
             "text": "When Cloudform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Cloudform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has flying and hexproof.",
             "colours": [
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "8696e165-d286-5e6a-8b18-0597b17b1ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21df7db7-c23b-4dca-b9c8-c785d7007285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21df7db7-c23b-4dca-b9c8-c785d7007285.jpg?1",
             "name": "Enhanced Awareness",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "4a9308a6-7af6-5da8-8b55-6d981bae3b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c96615-0dcb-4108-978a-b41b43e12f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c96615-0dcb-4108-978a-b41b43e12f38.jpg?1",
             "name": "Fascination",
             "text": "Choose one \u2014\n\u2022 Each player draws X cards.\n\u2022 Each player puts the top X cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "7f6b29d8-05dd-51ac-abba-51de3aeef1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb2c83d-48db-4d0b-8c3a-f4b0353eeb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb2c83d-48db-4d0b-8c3a-f4b0353eeb86.jpg?1",
             "name": "Frost Walker",
             "text": "When Frost Walker becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "85e6e583-9e48-5c0c-a593-2d023eafa82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea15d083-551b-4c13-92ad-3fc2d5414ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea15d083-551b-4c13-92ad-3fc2d5414ab3.jpg?1",
             "name": "Jeskai Infiltrator",
             "text": "Jeskai Infiltrator can't be blocked as long as you control no other creatures.\nWhen Jeskai Infiltrator deals combat damage to a player, exile it and the top card of your library in a face-down pile, shuffle that pile, then manifest those cards. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "5566f778-703e-5663-a31c-43e304e269ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ada6302-326b-4ab1-a9a3-ae4fa6a9001c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ada6302-326b-4ab1-a9a3-ae4fa6a9001c.jpg?1",
             "name": "Jeskai Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has flying as long as you control a red or white permanent.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "e6d75d27-bd5a-5af3-b542-69d5fdf90cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff4734-7b2a-4089-a78a-46199818f39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff4734-7b2a-4089-a78a-46199818f39d.jpg?1",
             "name": "Jeskai Sage",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Jeskai Sage dies, draw a card.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "16e101e1-1043-585a-a5d6-5d4e14fb7cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ec248-70d9-47f4-a53b-99b23f021116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ec248-70d9-47f4-a53b-99b23f021116.jpg?1",
             "name": "Lotus Path Djinn",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "de002232-fb3a-5b89-bfdf-304ae5c3f542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8174c-da93-414e-b89c-c588a2c4ed0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8174c-da93-414e-b89c-c588a2c4ed0c.jpg?1",
             "name": "Marang River Prowler",
             "text": "Marang River Prowler can't block and can't be blocked.\nYou may cast Marang River Prowler from your graveyard as long as you control a black or green permanent.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "dc240c64-da4f-5b36-bd6c-9350e653d063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5708290-60ae-400c-b149-2a63153c2890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5708290-60ae-400c-b149-2a63153c2890.jpg?1",
             "name": "Mindscour Dragon",
             "text": "Flying\nWhenever Mindscour Dragon deals combat damage to an opponent, target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "33929abf-b781-5d4d-b872-fd8f4d7a33de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb2388-9ec4-496a-a63e-6b3f33a608a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb2388-9ec4-496a-a63e-6b3f33a608a7.jpg?1",
             "name": "Mistfire Adept",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, target creature gains flying until end of turn.",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "73d67c3d-1468-5da8-9073-0448a2ab3d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef398b5-38f7-4a11-8fcf-d4e0d27267cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef398b5-38f7-4a11-8fcf-d4e0d27267cf.jpg?1",
             "name": "Monastery Siege",
             "text": "As Monastery Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your draw step, draw an additional card, then discard a card.\n\u2022 Dragons \u2014 Spells your opponents cast that target you or a permanent you control cost {2} more to cast.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "44e6f00e-dcc3-58df-8c62-a2433ac13120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30154ecf-f7ae-435b-a339-0219650bebed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30154ecf-f7ae-435b-a339-0219650bebed.jpg?1",
             "name": "Monastery Siege",
             "text": "",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "2a29760a-6fb2-5286-8cf0-3131ca14dd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549a8fc-6001-43db-88b1-ce8ed42a3443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549a8fc-6001-43db-88b1-ce8ed42a3443.jpg?1",
             "name": "Neutralizing Blast",
             "text": "Counter target multicolored spell.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "0243ded6-df0f-5181-a923-4e12722ef835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9e8a25-2e71-431b-897f-8b62520a3ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9e8a25-2e71-431b-897f-8b62520a3ce9.jpg?1",
             "name": "Rakshasa's Disdain",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "ac5f7b6a-d6ce-59a1-9d05-7800f32b4388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01367cb-79f4-4ed9-b12c-66f3c30264a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01367cb-79f4-4ed9-b12c-66f3c30264a0.jpg?1",
             "name": "Reality Shift",
             "text": "Exile target creature. Its controller manifests the top card of his or her library. (That player puts the top card of his or her library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "4a354133-b78c-51f7-8e0e-b93dcd766c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c78973-f2ae-4c76-802f-793d1022fcbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c78973-f2ae-4c76-802f-793d1022fcbd.jpg?1",
             "name": "Refocus",
             "text": "Untap target creature.\nDraw a card.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "c612971c-a181-5e1f-949e-5de0c7f97142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500f72e0-2de2-4c02-bda0-8a61aa9b37fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500f72e0-2de2-4c02-bda0-8a61aa9b37fc.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {2} to your mana pool. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "c4ebfc30-ed41-5cf6-877a-21d7323defcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20afe614-a367-461a-a67b-02d5ed634cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20afe614-a367-461a-a67b-02d5ed634cc5.jpg?1",
             "name": "Rite of Undoing",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nReturn target nonland permanent you control and target nonland permanent you don't control to their owners' hands.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "70c2a1d4-c96b-56d0-af30-38b77931a969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8050bb72-4fd4-4acd-ab21-e83f8503dcc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8050bb72-4fd4-4acd-ab21-e83f8503dcc1.jpg?1",
             "name": "Sage-Eye Avengers",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Sage-Eye Avengers attacks, you may return target creature to its owner's hand if its power is less than Sage-Eye Avengers's power.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "9040f0fe-1f30-5609-8ce5-ef2a8aef46a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9ff175-2e4c-4658-813e-1bfb4b9a6ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9ff175-2e4c-4658-813e-1bfb4b9a6ca0.jpg?1",
             "name": "Shifting Loyalties",
             "text": "Exchange control of two target permanents that share a card type. (Artifact, creature, enchantment, land, and planeswalker are card types.)",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "9351cdc9-d49a-5779-8a4d-4faf4bbfdd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79e83a-a34b-472c-9317-12af4ed2ca28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79e83a-a34b-472c-9317-12af4ed2ca28.jpg?1",
             "name": "Shu Yun, the Silent Tempest",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, you may pay {GU}{GU}. If you do, target creature gains double strike until end of turn.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "171895f0-682c-55f0-bf70-fd893f742c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a93355-553c-456b-999b-e9f826a1f572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a93355-553c-456b-999b-e9f826a1f572.jpg?1",
             "name": "Sultai Skullkeeper",
             "text": "When Sultai Skullkeeper enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "ace37ff3-6ef4-558d-bb27-c7ad5c0d664c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df927c0-9aa9-450b-ab2a-ae12c5489d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df927c0-9aa9-450b-ab2a-ae12c5489d57.jpg?1",
             "name": "Supplant Form",
             "text": "Return target creature to its owner's hand. You put a token onto the battlefield that's a copy of that creature.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "aec2010f-08c8-5d60-b6e0-e3b413889fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b7a1e-b404-41ea-875f-b3468501cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b7a1e-b404-41ea-875f-b3468501cb4b.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "1b8721c2-64ac-5b42-a9a0-fdd8cde03f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4850e4-acb9-458d-952f-b3952cab2a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4850e4-acb9-458d-952f-b3952cab2a5b.jpg?1",
             "name": "Torrent Elemental",
             "text": "Flying\nWhenever Torrent Elemental attacks, tap all creatures defending player controls.\n{3}{BG}{BG}: Put Torrent Elemental from exile onto the battlefield tapped. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "78304174-b3d0-5e91-ae4f-5f02a65cb3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5d96a9-11dd-44cc-baf1-bab298ae03f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5d96a9-11dd-44cc-baf1-bab298ae03f0.jpg?1",
             "name": "Whisk Away",
             "text": "Put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "071dfb78-6e25-5240-bf52-d1dd5cd16825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed1c4d-f11e-476a-bbb2-06ffc6e261f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed1c4d-f11e-476a-bbb2-06ffc6e261f3.jpg?1",
             "name": "Will of the Naga",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "1e9944c0-f47a-54ce-b2af-90c4d6d4b383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e6fbe-cda0-4fbf-853c-c03c567a7de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e6fbe-cda0-4fbf-853c-c03c567a7de9.jpg?1",
             "name": "Write into Being",
             "text": "Look at the top two cards of your library. Manifest one of those cards, then put the other on the top or bottom of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "09cbd9ec-5b45-5498-a0fd-80436ee21ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb135f-1c58-42ed-bbf2-4a2e842f99d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb135f-1c58-42ed-bbf2-4a2e842f99d7.jpg?1",
             "name": "Alesha's Vanguard",
             "text": "Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "0da8c72e-abbe-5937-8f87-d0849c981b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0094e-07ff-4b47-8c6e-500adabf12e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0094e-07ff-4b47-8c6e-500adabf12e4.jpg?1",
             "name": "Ancestral Vengeance",
             "text": "Enchant creature\nWhen Ancestral Vengeance enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted creature gets -1/-1.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "fdf5cd5b-85ed-58c1-82d3-f2b273938bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e343b5-37d6-44f6-be24-66313f18c246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e343b5-37d6-44f6-be24-66313f18c246.jpg?1",
             "name": "Archfiend of Depravity",
             "text": "Flying\nAt the beginning of each opponent's end step, that player chooses up to two creatures he or she controls, then sacrifices the rest.",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "e76ff1dc-d103-5afd-b952-7e6e454d911b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9b5baf-6163-48a9-b58d-195edfeb437d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9b5baf-6163-48a9-b58d-195edfeb437d.jpg?1",
             "name": "Battle Brawler",
             "text": "As long as you control a red or white permanent, Battle Brawler gets +1/+0 and has first strike.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "683ce3b9-42f4-5578-a808-b722a463596f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8ec769-99cd-4542-9b4d-61ee41b622bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8ec769-99cd-4542-9b4d-61ee41b622bc.jpg?1",
             "name": "Brutal Hordechief",
             "text": "Whenever a creature you control attacks, defending player loses 1 life and you gain 1 life.\n{3}{GU}{GU}: Creatures your opponents control block this turn if able, and you choose how those creatures block.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "1b019d3c-63a9-5aa7-93d1-05db927e97db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d45374-a41b-4b3f-a7c8-3eb5ca767cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d45374-a41b-4b3f-a7c8-3eb5ca767cf6.jpg?1",
             "name": "Crux of Fate",
             "text": "Choose one \u2014\n\u2022 Destroy all Dragon creatures.\n\u2022 Destroy all non-Dragon creatures.",
             "colours": [
@@ -2267,7 +2267,7 @@
         },
         {
             "id": "fa59488e-a199-58cb-92bd-ff0e29c92278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c13a4-c077-4f9b-ba0f-9fc81b53e58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c13a4-c077-4f9b-ba0f-9fc81b53e58a.jpg?1",
             "name": "Crux of Fate",
             "text": "",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "04cffe1f-a7f4-5031-886b-a4f45bef34ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69dfaafe-2fbd-4f2f-913d-ea64e4ce44cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69dfaafe-2fbd-4f2f-913d-ea64e4ce44cd.jpg?1",
             "name": "Dark Deal",
             "text": "Each player discards all the cards in his or her hand, then draws that many cards minus one.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "132d2e97-9c4d-5f1a-b6ea-d24ac3e5e3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69faf63b-f39b-4005-a35d-1204faaa6d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69faf63b-f39b-4005-a35d-1204faaa6d57.jpg?1",
             "name": "Diplomacy of the Wastes",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from it. That player discards that card. If you control a Warrior, that player loses 2 life.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "9e4f2ed4-1882-5d50-833f-21dd78ae7849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b710fcd-0721-4720-a8fa-6d9ceb7b8104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b710fcd-0721-4720-a8fa-6d9ceb7b8104.jpg?1",
             "name": "Douse in Gloom",
             "text": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "2de3a528-ff43-5617-96f6-726e92299569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a672979-024a-4f69-91ae-a2cf4055e0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a672979-024a-4f69-91ae-a2cf4055e0a8.jpg?1",
             "name": "Fearsome Awakening",
             "text": "Return target creature card from your graveyard to the battlefield. If it's a Dragon, put two +1/+1 counters on it.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "0fbb9101-a4b5-588f-851b-0b842be73175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f7d4a-27b3-43e8-a301-c81d4d403a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f7d4a-27b3-43e8-a301-c81d4d403a8f.jpg?1",
             "name": "Ghastly Conscription",
             "text": "Exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "07221efb-b001-5e54-a595-85c418cb69df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bc4463-69f6-4039-987d-e5db2ef256d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bc4463-69f6-4039-987d-e5db2ef256d5.jpg?1",
             "name": "Grave Strength",
             "text": "Choose target creature. Put the top three cards of your library into your graveyard, then put a +1/+1 counter on that creature for each creature card in your graveyard.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "75acd622-5868-5a63-ab54-5385d21efe43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a8cf1-a8c7-4f45-bbd3-188fab2652f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a8cf1-a8c7-4f45-bbd3-188fab2652f9.jpg?1",
             "name": "Gurmag Angler",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "b105d337-eca5-5ed5-b63e-ebb9637b1253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d4da1d-5b8c-43be-aa30-22df69c0cc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d4da1d-5b8c-43be-aa30-22df69c0cc23.jpg?1",
             "name": "Hooded Assassin",
             "text": "When Hooded Assassin enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Hooded Assassin.\n\u2022 Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "a354dbea-8cbe-5d36-9fd4-128b1928189b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f55b50-b3b1-4336-914c-1cc2669b8fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f55b50-b3b1-4336-914c-1cc2669b8fac.jpg?1",
             "name": "Mardu Shadowspear",
             "text": "Whenever Mardu Shadowspear attacks, each opponent loses 1 life.\nDash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "f6a9ebd9-bedb-55ed-85f2-b5d06cef55d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93fd5f0-fb62-42cc-8c7d-c0368e191c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93fd5f0-fb62-42cc-8c7d-c0368e191c4b.jpg?1",
             "name": "Mardu Strike Leader",
             "text": "Whenever Mardu Strike Leader attacks, put a 2/1 black Warrior creature token onto the battlefield.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "579ee755-5e39-5a90-948d-9f085d0c1965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c588d7a-e352-40a0-9fc7-55c7b4bfd013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c588d7a-e352-40a0-9fc7-55c7b4bfd013.jpg?1",
             "name": "Merciless Executioner",
             "text": "When Merciless Executioner enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "c653169e-aef2-58ce-a01e-6bd2c3cbb79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cece7235-604c-49b6-b80f-3229a20b154f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cece7235-604c-49b6-b80f-3229a20b154f.jpg?1",
             "name": "Noxious Dragon",
             "text": "Flying\nWhen Noxious Dragon dies, you may destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "c18ed337-6523-5726-b70e-8b31e5868149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/292326cd-4b90-40c6-88b1-f8560fde236c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/292326cd-4b90-40c6-88b1-f8560fde236c.jpg?1",
             "name": "Orc Sureshot",
             "text": "Whenever another creature enters the battlefield under your control, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "f1070ff9-1c8f-57f8-bf61-c9d69b44b3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee5a83-7096-4cbd-ad16-eb839d293d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee5a83-7096-4cbd-ad16-eb839d293d88.jpg?1",
             "name": "Palace Siege",
             "text": "As Palace Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your upkeep, return target creature card from your graveyard to your hand.\n\u2022 Dragons \u2014 At the beginning of your upkeep, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "eab5e691-9ab3-5d77-bcbf-0cd4e43ef63d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367945dd-871a-46c9-b047-c701e664d2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367945dd-871a-46c9-b047-c701e664d2bb.jpg?1",
             "name": "Palace Siege",
             "text": "",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "cc0ed524-5f8c-5ffb-b44b-bd4624825d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1bdbc-2bf4-4036-bf83-669c27458c6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1bdbc-2bf4-4036-bf83-669c27458c6e.jpg?1",
             "name": "Qarsi High Priest",
             "text": "{1}{B}, {T}, Sacrifice another creature: Manifest the top card of your library. (Put that card onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "cbd38ede-f8b2-5c5c-906b-f87c7b485b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9a803-473a-4c38-b352-d47c4fd93d5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9a803-473a-4c38-b352-d47c4fd93d5e.jpg?1",
             "name": "Reach of Shadows",
             "text": "Destroy target creature that's one or more colors.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "3579c2f6-d4f7-5020-ab94-8310333efd60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2791f1a5-bf29-48ac-8a41-88b7f97ede41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2791f1a5-bf29-48ac-8a41-88b7f97ede41.jpg?1",
             "name": "Sibsig Host",
             "text": "When Sibsig Host enters the battlefield, each player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "9ee21aa6-8ee7-5f3d-a9bf-333552c5dd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88297c1-c612-47bf-80b7-374099b00e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88297c1-c612-47bf-80b7-374099b00e07.jpg?1",
             "name": "Sibsig Muckdraggers",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nWhen Sibsig Muckdraggers enters the battlefield, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "68a9f77e-60f7-5cb6-85d0-66929bc46f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5084c8ff-1296-4d8e-bd06-93b1a3401661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5084c8ff-1296-4d8e-bd06-93b1a3401661.jpg?1",
             "name": "Soulflayer",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nIf a creature card with flying was exiled with Soulflayer's delve ability, Soulflayer has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, reach, trample, and vigilance.",
             "colours": [
@@ -2971,7 +2971,7 @@
         },
         {
             "id": "dc86a473-46cd-54e4-b16a-2f3588442418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12421e1c-5144-4391-abf2-a2fb864920e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12421e1c-5144-4391-abf2-a2fb864920e9.jpg?1",
             "name": "Sultai Emissary",
             "text": "When Sultai Emissary dies, manifest the top card of your library. (Put that card onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "92ad5992-9ed9-5486-9992-b615beb1752a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d73ae0-de01-4a70-a51c-b990687561a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d73ae0-de01-4a70-a51c-b990687561a1.jpg?1",
             "name": "Sultai Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has deathtouch as long as you control a green or blue permanent. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3040,7 +3040,7 @@
         },
         {
             "id": "bbd2b1f9-891d-5178-830a-3de690491f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f93ac5-d149-4ccf-8b99-13ecf3190c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f93ac5-d149-4ccf-8b99-13ecf3190c29.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n{2}{GW}{GW}: Put the top two cards of your library into your graveyard, then return a nonland card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "429be107-fcba-5331-be63-69b5fa21301f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169748df-10ac-4db4-ba94-192345c6fad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169748df-10ac-4db4-ba94-192345c6fad3.jpg?1",
             "name": "Tasigur's Cruelty",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nEach opponent discards two cards.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "90a3ef51-f84e-5eed-8e25-e35a9554de03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb90b-50c3-46ef-83f8-812dfb7ff881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb90b-50c3-46ef-83f8-812dfb7ff881.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "2cb4304e-dc77-5247-8862-93f3ffed528a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac9669-d0ee-4df8-af77-12dfccac774f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac9669-d0ee-4df8-af77-12dfccac774f.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "fc19b800-7fc9-50c4-ad11-a888d8235344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc397d1-50a8-46cd-98b2-7104f2241420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc397d1-50a8-46cd-98b2-7104f2241420.jpg?1",
             "name": "Arcbond",
             "text": "Choose target creature. Whenever that creature is dealt damage this turn, it deals that much damage to each other creature and each player.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "a96d5e4d-8ab5-587b-b00e-ee7d9392a471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cc6931-2005-4d0a-a42a-ce8bc279372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cc6931-2005-4d0a-a42a-ce8bc279372e.jpg?1",
             "name": "Bathe in Dragonfire",
             "text": "Bathe in Dragonfire deals 4 damage to target creature.",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "61b883cb-182f-544a-a71c-dbf14cd6c67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f0a37-32d6-4c1f-858d-7eec096dd42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f0a37-32d6-4c1f-858d-7eec096dd42a.jpg?1",
             "name": "Bloodfire Enforcers",
             "text": "Bloodfire Enforcers has first strike and trample as long as an instant card and a sorcery card are in your graveyard.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "f1ec9108-caa5-5150-8643-ce5b38e94197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1cdbe-5ddb-4cc6-975b-42f3f1ee4749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1cdbe-5ddb-4cc6-975b-42f3f1ee4749.jpg?1",
             "name": "Break Through the Line",
             "text": "{R}: Target creature with power 2 or less gains haste until end of turn and can't be blocked this turn.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "b0260fea-e364-592c-a7d1-99aad533e513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb738362-b0b4-4811-9fbf-5f45c852c822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb738362-b0b4-4811-9fbf-5f45c852c822.jpg?1",
             "name": "Collateral Damage",
             "text": "As an additional cost to cast Collateral Damage, sacrifice a creature.\nCollateral Damage deals 3 damage to target creature or player.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "cca7bade-fdbf-535a-a2b8-11e3266b962b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfd3d5-1b44-4dc7-b35d-703f3a75da88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfd3d5-1b44-4dc7-b35d-703f3a75da88.jpg?1",
             "name": "Defiant Ogre",
             "text": "When Defiant Ogre enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Defiant Ogre.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "1f92d38a-5dc2-5ff0-8318-56ca814157ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b7bf2a-9d68-4aa8-a0b1-5df22a5a3c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b7bf2a-9d68-4aa8-a0b1-5df22a5a3c1b.jpg?1",
             "name": "Dragonrage",
             "text": "Add {R} to your mana pool for each attacking creature you control. Until end of turn, attacking creatures you control gain \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -3414,7 +3414,7 @@
         },
         {
             "id": "1492641f-7659-5796-9d2f-4c9049532cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0137de04-9fd7-41b0-b497-163e6e93432b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0137de04-9fd7-41b0-b497-163e6e93432b.jpg?1",
             "name": "Fierce Invocation",
             "text": "Manifest the top card of your library, then put two +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "e62a42f9-3358-5738-8d82-334d00bc50e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304107d6-d096-43a1-956f-5a3b6ed6dc60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304107d6-d096-43a1-956f-5a3b6ed6dc60.jpg?1",
             "name": "Flamerush Rider",
             "text": "Whenever Flamerush Rider attacks, put a token onto the battlefield tapped and attacking that's a copy of another target attacking creature. Exile the token at end of combat.\nDash {2}{R}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "76445c57-6be2-5669-ba2f-4fdb382152da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd5848-9fe1-4129-a5d7-e51606bf76ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd5848-9fe1-4129-a5d7-e51606bf76ef.jpg?1",
             "name": "Flamewake Phoenix",
             "text": "Flying, haste\nFlamewake Phoenix attacks each turn if able.\nFerocious \u2014 At the beginning of combat on your turn, if you control a creature with power 4 or greater, you may pay {R}. If you do, return Flamewake Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "719cc9e6-c25c-5be5-8628-46a68ed15ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4272ca-bb15-415c-a589-a472953a0dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4272ca-bb15-415c-a589-a472953a0dd9.jpg?1",
             "name": "Friendly Fire",
             "text": "Target creature's controller reveals a card at random from his or her hand. Friendly Fire deals damage to that creature and that player equal to the revealed card's converted mana cost.",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "ef428f6d-e079-5d19-9495-4dd5f5ab2cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3bfeb6-95d6-4f00-8981-c6d3c9c93f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3bfeb6-95d6-4f00-8981-c6d3c9c93f67.jpg?1",
             "name": "Goblin Heelcutter",
             "text": "Whenever Goblin Heelcutter attacks, target creature can't block this turn.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "95c72e36-170a-5628-9ff8-595d4e0ef13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c36d53-1173-4a55-8fb8-63a624fde7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c36d53-1173-4a55-8fb8-63a624fde7de.jpg?1",
             "name": "Gore Swine",
             "text": "",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "7ab1d9e9-05b0-5f09-a5a5-8e328ce5cf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb0c13f-6cea-48b4-a5c8-2c0cfcfea7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb0c13f-6cea-48b4-a5c8-2c0cfcfea7fd.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "ca81d5d6-6d80-5841-b1e6-724ffbd6bf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7c596-5633-41e8-adcd-d4dc6eae5c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7c596-5633-41e8-adcd-d4dc6eae5c88.jpg?1",
             "name": "Hungering Yeti",
             "text": "As long as you control a green or blue permanent, you may cast Hungering Yeti as though it had flash. (You may cast it any time you could cast an instant.)",
             "colours": [
@@ -3685,7 +3685,7 @@
         },
         {
             "id": "7aa2932b-afe6-53f8-b8d4-d12aaf3aba37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0071bf6e-a78b-4286-b3e7-acf44631a001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0071bf6e-a78b-4286-b3e7-acf44631a001.jpg?1",
             "name": "Lightning Shrieker",
             "text": "Flying, trample, haste\nAt the beginning of the end step, Lightning Shrieker's owner shuffles it into his or her library.",
             "colours": [
@@ -3719,7 +3719,7 @@
         },
         {
             "id": "bd70c5a6-ae97-54b0-a274-813c8aba47a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333df10b-7db4-4f8a-a754-e8a630b26cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333df10b-7db4-4f8a-a754-e8a630b26cac.jpg?1",
             "name": "Mardu Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has first strike as long as you control a white or black permanent.",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "106dd845-f8f9-5029-a737-c7cc84a91696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7891b8-ba69-4c5b-a29f-ee7bcf2374f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7891b8-ba69-4c5b-a29f-ee7bcf2374f0.jpg?1",
             "name": "Mardu Scout",
             "text": "Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "8fd346d9-55e1-5b96-8739-83a4868964e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d76845f-c827-4cb4-b2d0-3f2cf5ee0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d76845f-c827-4cb4-b2d0-3f2cf5ee0e81.jpg?1",
             "name": "Mob Rule",
             "text": "Choose one \u2014\n\u2022 Gain control of all creatures with power 4 or greater until end of turn. Untap those creatures. They gain haste until end of turn.\n\u2022 Gain control of all creatures with power 3 or less until end of turn. Untap those creatures. They gain haste until end of turn.",
             "colours": [
@@ -3820,7 +3820,7 @@
         },
         {
             "id": "30ee6a96-0e6f-5eff-8e37-79d9b2a117d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880f6602-f335-4ad8-9e2f-f32b6d715f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880f6602-f335-4ad8-9e2f-f32b6d715f72.jpg?1",
             "name": "Outpost Siege",
             "text": "As Outpost Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your upkeep, exile the top card of your library. Until end of turn, you may play that card.\n\u2022 Dragons \u2014 Whenever a creature you control leaves the battlefield, Outpost Siege deals 1 damage to target creature or player.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "cf0666f8-634d-5300-9ea9-893998b816c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a2034-25bf-4b42-9f47-a2418d48286c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a2034-25bf-4b42-9f47-a2418d48286c.jpg?1",
             "name": "Outpost Siege",
             "text": "",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "aedc7dc0-4fa3-5ca6-bbd6-1cd98247b69d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51893dd5-e70f-44bb-85d4-e31480ba84d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51893dd5-e70f-44bb-85d4-e31480ba84d6.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "904e6eee-fd1e-52c3-897e-a81240a07287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038ed726-bde8-46b0-bdf5-f88e2f074434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038ed726-bde8-46b0-bdf5-f88e2f074434.jpg?1",
             "name": "Rageform",
             "text": "When Rageform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Rageform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "2a26719e-458d-5868-bcce-3b6c90958bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbd8cd1-465c-4501-94ba-5a3402f30ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbd8cd1-465c-4501-94ba-5a3402f30ded.jpg?1",
             "name": "Shaman of the Great Hunt",
             "text": "Haste\nWhenever a creature you control deals combat damage to a player, put a +1/+1 counter on it.\nFerocious \u2014 {2}{GW}{GW}: Draw a card for each creature you control with power 4 or greater.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "e8e4021b-fa65-57b4-9bcd-56c201e81218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4810919-b379-40db-a68b-a769dd3ee32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4810919-b379-40db-a68b-a769dd3ee32d.jpg?1",
             "name": "Shockmaw Dragon",
             "text": "Flying\nWhenever Shockmaw Dragon deals combat damage to a player, it deals 1 damage to each creature that player controls.",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "6b703c19-84ed-5907-9b10-a257e368e4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af33b204-6b50-4404-b986-9f6b970a7f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af33b204-6b50-4404-b986-9f6b970a7f06.jpg?1",
             "name": "Smoldering Efreet",
             "text": "When Smoldering Efreet dies, it deals 2 damage to you.",
             "colours": [
@@ -4056,7 +4056,7 @@
         },
         {
             "id": "ca57337e-e9d3-5b69-ba5b-3a65e94f63ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1dd786-f4e3-4951-b87b-82442edec016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1dd786-f4e3-4951-b87b-82442edec016.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -4088,7 +4088,7 @@
         },
         {
             "id": "9a32aa43-2408-5d32-a1a9-8aadc89bc1dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12891fcf-7118-428a-bdfe-9495a77f8b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12891fcf-7118-428a-bdfe-9495a77f8b3d.jpg?1",
             "name": "Vaultbreaker",
             "text": "Whenever Vaultbreaker attacks, you may discard a card. If you do, draw a card.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "90c23009-e53c-53f9-8f1b-c587e7cca750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6975490f-7679-48b3-ba34-04dec97a29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6975490f-7679-48b3-ba34-04dec97a29c2.jpg?1",
             "name": "Wild Slash",
             "text": "Ferocious \u2014 If you control a creature with power 4 or greater, damage can't be prevented this turn.\nWild Slash deals 2 damage to target creature or player.",
             "colours": [
@@ -4155,7 +4155,7 @@
         },
         {
             "id": "a9b0162b-d9a2-5001-8036-f7e29d0688c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c4ab2-1f7c-469b-a72a-d435213f130c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c4ab2-1f7c-469b-a72a-d435213f130c.jpg?1",
             "name": "Abzan Beastmaster",
             "text": "At the beginning of your upkeep, draw a card if you control the creature with the greatest toughness or tied for the greatest toughness.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "c705cd87-8234-54d9-9031-f61ca5abff72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec0ef55-57fd-404f-b9f6-b5d41e77b58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec0ef55-57fd-404f-b9f6-b5d41e77b58c.jpg?1",
             "name": "Abzan Kin-Guard",
             "text": "Abzan Kin-Guard has lifelink as long as you control a white or black permanent.",
             "colours": [
@@ -4225,7 +4225,7 @@
         },
         {
             "id": "52d0092c-8c98-565a-a2ce-f9d4ca4e404f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c361ea9c-a989-4ded-8b2c-f565aa9d8a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c361ea9c-a989-4ded-8b2c-f565aa9d8a1d.jpg?1",
             "name": "Ainok Guide",
             "text": "When Ainok Guide enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Ainok Guide.\n\u2022 Search your library for a basic land card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "5c9ed491-b1e8-5c37-80e5-e987cafd3e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3068c6-d403-46d5-b3d7-1c3b00b9a9b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3068c6-d403-46d5-b3d7-1c3b00b9a9b1.jpg?1",
             "name": "Ambush Krotiq",
             "text": "Trample\nWhen Ambush Krotiq enters the battlefield, return another creature you control to its owner's hand.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "d45b58f6-9382-593f-9d59-0d0aa419ff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aed11a-0831-4619-931f-7dfded999c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aed11a-0831-4619-931f-7dfded999c66.jpg?1",
             "name": "Arashin War Beast",
             "text": "Whenever Arashin War Beast deals combat damage to one or more blocking creatures, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4328,7 +4328,7 @@
         },
         {
             "id": "288005ec-7474-5fe7-95d9-e902865f8176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcf0074-162a-4cc0-9726-8672a0261307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcf0074-162a-4cc0-9726-8672a0261307.jpg?1",
             "name": "Archers of Qarsi",
             "text": "Defender\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "5fd77950-33b7-54cf-a44c-25d12e90862b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b425cd-c5a5-48e9-b697-3860dfa6d5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b425cd-c5a5-48e9-b697-3860dfa6d5d3.jpg?1",
             "name": "Battlefront Krushok",
             "text": "Battlefront Krushok can't be blocked by more than one creature.\nEach creature you control with a +1/+1 counter on it can't be blocked by more than one creature.",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "59a38e97-4db8-59d3-a010-b4ecb7f2b66e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad36cf-5f29-41c4-b2a3-6b8e8c0c493f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad36cf-5f29-41c4-b2a3-6b8e8c0c493f.jpg?1",
             "name": "Cached Defenses",
             "text": "Bolster 3. (Choose a creature with the least toughness among creatures you control and put three +1/+1 counters on it.)",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "10206d79-148d-5d99-b2f5-ffd2d4abbfde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cb2f2-00ed-46a3-a69d-5360e1558b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cb2f2-00ed-46a3-a69d-5360e1558b03.jpg?1",
             "name": "Destructor Dragon",
             "text": "Flying\nWhen Destructor Dragon dies, destroy target noncreature permanent.",
             "colours": [
@@ -4463,7 +4463,7 @@
         },
         {
             "id": "15ad54d1-0567-51dd-9809-b90f7acadf31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041996b-c265-4c4f-a52c-dfe29b2e282d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041996b-c265-4c4f-a52c-dfe29b2e282d.jpg?1",
             "name": "Feral Krushok",
             "text": "",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "c5141733-10b6-5486-ad53-39ad25e18045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70646e4-936a-4c2a-8d4a-a2c659733093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70646e4-936a-4c2a-8d4a-a2c659733093.jpg?1",
             "name": "Formless Nurturing",
             "text": "Manifest the top card of your library, then put a +1/+1 counter on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "663d16c3-70fc-5d58-9d4e-216dc049f484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c09fe7-d55f-49b4-95c9-a3bb36baa3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c09fe7-d55f-49b4-95c9-a3bb36baa3aa.jpg?1",
             "name": "Frontier Mastodon",
             "text": "Ferocious \u2014 Frontier Mastodon enters the battlefield with a +1/+1 counter on it if you control a creature with power 4 or greater.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "fbb94c50-7b98-502f-bfaf-a852edf628c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a474981a-581a-49c0-a036-87afaaeea7ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a474981a-581a-49c0-a036-87afaaeea7ef.jpg?1",
             "name": "Frontier Siege",
             "text": "As Frontier Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of each of your main phases, add {G}{G} to your mana pool.\n\u2022 Dragons \u2014 Whenever a creature with flying enters the battlefield under your control, you may have it fight target creature you don't control.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "63120617-fd87-5cef-8f91-dd4ba57f801b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d6b939-8331-49d2-a59a-3054c7b0f353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d6b939-8331-49d2-a59a-3054c7b0f353.jpg?1",
             "name": "Frontier Siege",
             "text": "",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "12d8fad9-94e8-5d8e-bbd3-d73bf82b100b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3e6a6a-4a19-41e1-b29e-a8f19838efe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3e6a6a-4a19-41e1-b29e-a8f19838efe3.jpg?1",
             "name": "Fruit of the First Tree",
             "text": "Enchant creature\nWhen enchanted creature dies, you gain X life and draw X cards, where X is its toughness.",
             "colours": [
@@ -4663,7 +4663,7 @@
         },
         {
             "id": "52a2b10e-3d40-587a-ad9e-af2183914bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdaf8bc-e7ce-4cfc-963a-c3fb924a8fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdaf8bc-e7ce-4cfc-963a-c3fb924a8fa7.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4695,7 +4695,7 @@
         },
         {
             "id": "cafe82f9-67a6-5d2b-be5a-847b532ab59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b61b1-79d5-44b6-8c0f-b8e8e508e5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b61b1-79d5-44b6-8c0f-b8e8e508e5a9.jpg?1",
             "name": "Map the Wastes",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "4b5c66a4-7110-58a2-8cf7-6b39fa348d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a53144-2ef3-47d9-a176-73d620202df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a53144-2ef3-47d9-a176-73d620202df6.jpg?1",
             "name": "Return to the Earth",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -4759,7 +4759,7 @@
         },
         {
             "id": "4a20137b-474a-5d8f-86a3-8713a9eb6ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c8bfde-c4c5-40de-83de-ff236999d79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c8bfde-c4c5-40de-83de-ff236999d79b.jpg?1",
             "name": "Ruthless Instincts",
             "text": "Choose one \u2014\n\u2022 Target nonattacking creature gains reach and deathtouch until end of turn. Untap it.\n\u2022 Target attacking creature gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "a55f9d9c-1e70-5eaa-aa45-8540c0e2e177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae01fb-12fa-444d-9d49-bfe195c2a5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae01fb-12fa-444d-9d49-bfe195c2a5a6.jpg?1",
             "name": "Sandsteppe Mastodon",
             "text": "Reach\nWhen Sandsteppe Mastodon enters the battlefield, bolster 5. (Choose a creature with the least toughness among creatures you control and put five +1/+1 counters on it.)",
             "colours": [
@@ -4825,7 +4825,7 @@
         },
         {
             "id": "2b25315e-0ce8-567b-9d79-61a36c4b2957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f2c73-26d8-42a6-acde-2c5a2f4e21a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f2c73-26d8-42a6-acde-2c5a2f4e21a1.jpg?1",
             "name": "Shamanic Revelation",
             "text": "Draw a card for each creature you control.\nFerocious \u2014 You gain 4 life for each creature you control with power 4 or greater.",
             "colours": [
@@ -4857,7 +4857,7 @@
         },
         {
             "id": "3b17826d-2ac8-5876-a55a-b191119bd18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac7645d-ea10-4ca6-92a5-ac3418c6a510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac7645d-ea10-4ca6-92a5-ac3418c6a510.jpg?1",
             "name": "Sudden Reclamation",
             "text": "Put the top four cards of your library into your graveyard, then return a creature card and a land card from your graveyard to your hand.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "10aa246f-d9d0-55ad-9c68-0cbb5363da11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd76874-842e-4f4c-b18e-0e441dae59d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd76874-842e-4f4c-b18e-0e441dae59d7.jpg?1",
             "name": "Temur Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has trample as long as you control a blue or red permanent.",
             "colours": [
@@ -4923,7 +4923,7 @@
         },
         {
             "id": "6b20767a-e3dd-5a36-8467-5e072529c71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d54da7c-8828-4d34-bfd0-a654692d3f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d54da7c-8828-4d34-bfd0-a654692d3f5a.jpg?1",
             "name": "Temur Sabertooth",
             "text": "{1}{G}: You may return another creature you control to its owner's hand. If you do, Temur Sabertooth gains indestructible until end of turn.",
             "colours": [
@@ -4957,7 +4957,7 @@
         },
         {
             "id": "7362464a-80ab-5a41-a59d-031e89df1f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873164f-d8eb-460e-a8cc-8b2a663dcf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873164f-d8eb-460e-a8cc-8b2a663dcf3a.jpg?1",
             "name": "Temur War Shaman",
             "text": "When Temur War Shaman enters the battlefield, manifest the top card of your library. (Put that card onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever a permanent you control is turned face up, if it's a creature, you may have it fight target creature you don't control.",
             "colours": [
@@ -4992,7 +4992,7 @@
         },
         {
             "id": "328e770d-4a3e-58e3-b557-871681bf33c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0c6628-04f1-4800-baa8-bcaefe64f59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0c6628-04f1-4800-baa8-bcaefe64f59f.jpg?1",
             "name": "Warden of the First Tree",
             "text": "{1}{WB}: Warden of the First Tree becomes a Human Warrior with base power and toughness 3/3.\n{2}{WB}{WB}: If Warden of the First Tree is a Warrior, it becomes a Human Spirit Warrior with trample and lifelink.\n{3}{WB}{WB}{WB}: If Warden of the First Tree is a Spirit, put five +1/+1 counters on it.",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "f5bcd19a-740b-5b1c-bd7d-23636504d21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c66d388-b140-4d52-897a-6ac6cd68f980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c66d388-b140-4d52-897a-6ac6cd68f980.jpg?1",
             "name": "Whisperer of the Wilds",
             "text": "{T}: Add {G} to your mana pool.\nFerocious \u2014 {T}: Add {G}{G} to your mana pool. Activate this ability only if you control a creature with power 4 or greater.",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "8fdfeb71-2875-5625-a8ed-cf32f771499d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c61828-98b9-4264-b3dd-e83f881f4a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c61828-98b9-4264-b3dd-e83f881f4a67.jpg?1",
             "name": "Whisperwood Elemental",
             "text": "At the beginning of your end step, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nSacrifice Whisperwood Elemental: Until end of turn, face-up nontoken creatures you control gain \"When this creature dies, manifest the top card of your library.\"",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "7b8e2b08-a1a8-58a6-9caf-44be97d7639c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065fc4d8-c097-4d0e-81cf-22a0b694be9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065fc4d8-c097-4d0e-81cf-22a0b694be9a.jpg?1",
             "name": "Wildcall",
             "text": "Manifest the top card of your library, then put X +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "625e838b-9c01-52fe-ae51-4e936ef5a4fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45d98d-b8bd-409d-bce9-d7d73be735a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45d98d-b8bd-409d-bce9-d7d73be735a9.jpg?1",
             "name": "Winds of Qal Sisma",
             "text": "Prevent all combat damage that would be dealt this turn.\nFerocious \u2014 If you control a creature with power 4 or greater, instead prevent all combat damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "a4e361b3-da80-52ea-9ab5-f7712eebafcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490994c6-9fef-482b-835d-a64350bfaa8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490994c6-9fef-482b-835d-a64350bfaa8d.jpg?1",
             "name": "Yasova Dragonclaw",
             "text": "Trample\nAt the beginning of combat on your turn, you may pay {1}{UR}{UR}. If you do, gain control of target creature an opponent controls with power less than Yasova Dragonclaw's power until end of turn, untap that creature, and it gains haste until end of turn.",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "56c1631d-7bdf-5c80-a368-dca6d2012282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c341df3-177c-49b4-91fe-38f73c64ef88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c341df3-177c-49b4-91fe-38f73c64ef88.jpg?1",
             "name": "Atarka, World Render",
             "text": "Flying, trample\nWhenever a Dragon you control attacks, it gains double strike until end of turn.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "937c4e71-3745-58d1-98fd-dbb1ec71bd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4991f81-3190-4d33-bf09-9d5387cbec11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4991f81-3190-4d33-bf09-9d5387cbec11.jpg?1",
             "name": "Cunning Strike",
             "text": "Cunning Strike deals 2 damage to target creature and 2 damage to target player.\nDraw a card.",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "8ff57104-30fd-5e02-a6c1-cdd62ae5cf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a10e86-d2cd-4193-85f5-5e4908c30e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a10e86-d2cd-4193-85f5-5e4908c30e7f.jpg?1",
             "name": "Dromoka, the Eternal",
             "text": "Flying\nWhenever a Dragon you control attacks, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -5310,7 +5310,7 @@
         },
         {
             "id": "03a77f01-162d-5f39-b7d6-b0235bd3d434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d3f4d-eba3-4c45-8846-03b246e93f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d3f4d-eba3-4c45-8846-03b246e93f6c.jpg?1",
             "name": "Ethereal Ambush",
             "text": "Manifest the top two cards of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -5344,7 +5344,7 @@
         },
         {
             "id": "e1f959fb-f897-5792-a953-790280d6eb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c44722-c65a-41ae-92a9-9c9d7d759a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c44722-c65a-41ae-92a9-9c9d7d759a8e.jpg?1",
             "name": "Grim Contest",
             "text": "Choose target creature you control and target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "36428486-2783-5d09-bc00-a513a53d108d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770d60a0-23fc-4224-873c-2e5549b3a816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770d60a0-23fc-4224-873c-2e5549b3a816.jpg?1",
             "name": "Harsh Sustenance",
             "text": "Harsh Sustenance deals X damage to target creature or player and you gain X life, where X is the number of creatures you control.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "e2eb5339-60e0-5a67-a91b-12bd110f6210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96376314-2085-4c57-861e-44d25e2d3bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96376314-2085-4c57-861e-44d25e2d3bc8.jpg?1",
             "name": "Kolaghan, the Storm's Fury",
             "text": "Flying\nWhenever a Dragon you control attacks, creatures you control get +1/+0 until end of turn.\nDash {3}{B}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "01a87dd9-e027-5750-beef-45f82da1c461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d470cd-9ff9-49d8-b66a-331cb6cf8257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d470cd-9ff9-49d8-b66a-331cb6cf8257.jpg?1",
             "name": "Ojutai, Soul of Winter",
             "text": "Flying, vigilance\nWhenever a Dragon you control attacks, tap target nonland permanent an opponent controls. That permanent doesn't untap during its controller's next untap step.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "ecc0f888-7056-5a64-8d0c-e4c73f965266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9108e7-6c39-4587-aa3a-0ec27f9761b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9108e7-6c39-4587-aa3a-0ec27f9761b2.jpg?1",
             "name": "Silumgar, the Drifting Death",
             "text": "Flying, hexproof\nWhenever a Dragon you control attacks, creatures defending player controls get -1/-1 until end of turn.",
             "colours": [
@@ -5526,7 +5526,7 @@
         },
         {
             "id": "8fbbe355-b0ed-52ac-b6a0-656b2df62d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243f33d8-ec20-4376-99c2-a12098773dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243f33d8-ec20-4376-99c2-a12098773dee.jpg?1",
             "name": "War Flare",
             "text": "Creatures you control get +2/+1 until end of turn. Untap those creatures.",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "654f272e-b755-5c88-ad58-125b9c57a79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14343e23-83fb-4d2e-a272-20d7787ef2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14343e23-83fb-4d2e-a272-20d7787ef2ca.jpg?1",
             "name": "Goblin Boom Keg",
             "text": "At the beginning of your upkeep, sacrifice Goblin Boom Keg.\nWhen Goblin Boom Keg is put into a graveyard from the battlefield, it deals 3 damage to target creature or player.",
             "colours": [],
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "cfa7f82b-e7de-5e9e-b60e-2213ff842847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69b72c1-232c-420e-b900-6dfe73cfff13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69b72c1-232c-420e-b900-6dfe73cfff13.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4}",
             "colours": [],
@@ -5618,7 +5618,7 @@
         },
         {
             "id": "3a05e49c-047c-5617-8350-9cede2ad1282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250bc19c-b882-42ae-b516-fe876d0d047d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250bc19c-b882-42ae-b516-fe876d0d047d.jpg?1",
             "name": "Hewed Stone Retainers",
             "text": "Cast Hewed Stone Retainers only if you've cast another spell this turn.",
             "colours": [],
@@ -5649,7 +5649,7 @@
         },
         {
             "id": "ea9b9595-9214-5508-a42f-b93c0957dab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a60623-d523-4b43-89b0-8e89568546c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a60623-d523-4b43-89b0-8e89568546c7.jpg?1",
             "name": "Pilgrim of the Fires",
             "text": "First strike, trample",
             "colours": [],
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "362c243a-56cb-5d1b-b340-092f790e4b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c7f24e-5ead-4b32-a804-4c89929508f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c7f24e-5ead-4b32-a804-4c89929508f6.jpg?1",
             "name": "Scroll of the Masters",
             "text": "Whenever you cast a noncreature spell, put a lore counter on Scroll of the Masters.\n{3}, {T}: Target creature you control gets +1/+1 until end of turn for each lore counter on Scroll of the Masters.",
             "colours": [],
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "52f97e1c-7515-54f3-8743-514eca0db0e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee009a4-72d0-4828-b826-3ed7c7d87b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee009a4-72d0-4828-b826-3ed7c7d87b53.jpg?1",
             "name": "Ugin's Construct",
             "text": "When Ugin's Construct enters the battlefield, sacrifice a permanent that's one or more colors.",
             "colours": [],
@@ -5739,7 +5739,7 @@
         },
         {
             "id": "fda1bc92-2a92-5435-ae87-a5ee2000b436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb65512-fb39-473e-b646-15ed81b55d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb65512-fb39-473e-b646-15ed81b55d17.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "8214e1e4-ba33-595f-ba88-52d1a7dff70c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247579f6-cf8c-4c61-aae6-e01c1d9237dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247579f6-cf8c-4c61-aae6-e01c1d9237dc.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "0b9ce27e-e344-5d0a-a6fb-5688920d093b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf563e0-1f42-4768-a667-3e120bdb6534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf563e0-1f42-4768-a667-3e120bdb6534.jpg?1",
             "name": "Crucible of the Spirit Dragon",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Crucible of the Spirit Dragon.\n{T}, Remove X storage counters from Crucible of the Spirit Dragon: Add X mana in any combination of colors to your mana pool. Spend this mana only to cast Dragon spells or activate abilities of Dragons.",
             "colours": [],
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "3931e802-c658-50d4-a11b-1c394c0bffdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69005861-f228-444d-ae64-d36ec74b23da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69005861-f228-444d-ae64-d36ec74b23da.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "317b5414-f93f-56b7-9a07-85b48c640a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b4535-468b-44b9-9ae3-d09a2228f1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b4535-468b-44b9-9ae3-d09a2228f1cc.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "ddcaf552-acc1-53da-bd8e-a708c915c3a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cfcbfc-f060-4610-a1ce-9437d6b32473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cfcbfc-f060-4610-a1ce-9437d6b32473.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5922,7 +5922,7 @@
         },
         {
             "id": "56efd197-9449-53ff-90e7-d7ab6b0d99e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f0d2ed-063a-4086-8563-de3bc71330cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f0d2ed-063a-4086-8563-de3bc71330cf.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "b7e6dec8-7541-5f0a-941a-348f0e678180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e3d45-5449-4479-893e-8c0f8d4b0154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e3d45-5449-4479-893e-8c0f8d4b0154.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "fafa0a99-69e4-5366-add1-73f0518d379a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de1ade0-f4c7-4508-9fba-bbe00c634305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de1ade0-f4c7-4508-9fba-bbe00c634305.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -6015,7 +6015,7 @@
         },
         {
             "id": "085de752-ee66-5638-9269-f4e94f1b823c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ef7b5-ffad-4342-9a3a-f01a6d67d5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ef7b5-ffad-4342-9a3a-f01a6d67d5e2.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "ce175875-1450-5c86-92d2-49f144042678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43431a-d1cf-4f89-9c07-2efd6ac8f218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43431a-d1cf-4f89-9c07-2efd6ac8f218.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -6077,7 +6077,7 @@
         },
         {
             "id": "341eb86c-5d5f-53af-9f23-2d69aeafde0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7eb6a-aed1-4fc9-9b10-06169fa50690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7eb6a-aed1-4fc9-9b10-06169fa50690.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6113,7 +6113,7 @@
         },
         {
             "id": "c2133aed-fc82-5b93-93d5-11665a74b50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133c49a9-6c43-4b52-8ee5-b1fb34cba060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133c49a9-6c43-4b52-8ee5-b1fb34cba060.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6149,7 +6149,7 @@
         },
         {
             "id": "c77a0a7a-0e98-58b7-b296-4913b1c82618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99702ff6-e496-422a-aa62-ec933110acf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99702ff6-e496-422a-aa62-ec933110acf7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6185,7 +6185,7 @@
         },
         {
             "id": "26c675c3-a585-59c2-88cb-222460c816fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899f42b3-2f7a-4d85-8883-ceae911473a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899f42b3-2f7a-4d85-8883-ceae911473a9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "b9673e78-16bc-50cd-be15-a624fd1e05f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21900fe6-ae43-42af-a601-d70c25457239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21900fe6-ae43-42af-a601-d70c25457239.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6257,7 +6257,7 @@
         },
         {
             "id": "1f6425b1-65c2-508e-bcea-ff269d75aa90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ace7e2d-17af-467d-a0fc-9af922189452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ace7e2d-17af-467d-a0fc-9af922189452.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "09b4b1bf-58c4-52af-ad84-51607f3c9320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55483163-c53a-424d-9cc4-74da9aa6dff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55483163-c53a-424d-9cc4-74da9aa6dff9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "a1048d2c-fe3f-5e03-90b3-6170fb16d57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d5cb40-7365-492b-a3bc-4a624f78cec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d5cb40-7365-492b-a3bc-4a624f78cec4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "2aafd7bf-285b-5444-a21c-c3bc21efcf42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b712739-df44-4c23-b076-0fb778aa6dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b712739-df44-4c23-b076-0fb778aa6dc4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "b88d9000-083f-5c76-994a-cc051fbf16a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d36c04-c238-412a-97de-63fc92840c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d36c04-c238-412a-97de-63fc92840c1e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6437,7 +6437,7 @@
         },
         {
             "id": "f675da35-e696-5a98-b8f9-3ae29c46c8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -6471,7 +6471,7 @@
         },
         {
             "id": "fc935967-06fc-55d4-b706-7d27c0a7a3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e32ad7-d59e-4cd8-ab88-3c7c0c083357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e32ad7-d59e-4cd8-ab88-3c7c0c083357.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -6505,7 +6505,7 @@
         },
         {
             "id": "6bd32f00-70a5-5a56-a22f-1b995028ad02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5eaba1-a7e1-4bbb-949c-e7f6a9592f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5eaba1-a7e1-4bbb-949c-e7f6a9592f50.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -6539,7 +6539,7 @@
         },
         {
             "id": "470d1083-a538-57bc-874f-bafc8157ade6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f896d4-34b4-407d-be7e-bf7a69aaf811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f896d4-34b4-407d-be7e-bf7a69aaf811.jpg?1",
             "name": "Manifest",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/FUT.json
+++ b/Assets/Resources/Sets/FUT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b43d7a81-fdab-5540-8c21-8d00120c5a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf69645-d1f1-4836-bdc3-76874abcfd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf69645-d1f1-4836-bdc3-76874abcfd5f.jpg?1",
             "name": "Angel of Salvation",
             "text": "Flash; convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nFlying\nWhen Angel of Salvation comes into play, prevent the next 5 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "4797db27-910a-55d4-afa5-7ca4ff3233b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1fdf86-22aa-4c18-a971-8ff1fd8b3de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1fdf86-22aa-4c18-a971-8ff1fd8b3de1.jpg?1",
             "name": "Augur il-Vec",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSacrifice Augur il-Vec: You gain 4 life. Play this ability only during your upkeep.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "eeb28fe2-c190-5b59-8de6-5023d9c2d983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12220d53-3356-4541-aa43-a0de6ed3f7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12220d53-3356-4541-aa43-a0de6ed3f7d0.jpg?1",
             "name": "Barren Glory",
             "text": "At the beginning of your upkeep, if you control no permanents other than Barren Glory and have no cards in hand, you win the game.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "94cd3e76-00ad-5543-8715-e76a4aadc420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6989fd-05cf-4169-96c0-37c556454b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6989fd-05cf-4169-96c0-37c556454b92.jpg?1",
             "name": "Chronomantic Escape",
             "text": "Until your next turn, creatures can't attack you. Remove Chronomantic Escape from the game with three time counters on it.\nSuspend 3\u2014{2}{W} (Rather than play this card from your hand, you may pay {2}{W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "2831025f-a151-5cdc-866e-f5564992b3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c8f6f-8dcd-4b47-bc79-9657824cf1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c8f6f-8dcd-4b47-bc79-9657824cf1b7.jpg?1",
             "name": "Dust of Moments",
             "text": "Choose one Remove two time counters from each permanent and each suspended card; or put two time counters on each permanent with a time counter on it and each suspended card.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "1457ccee-92c4-53a1-a61c-6fc4ec24adb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704cd76-dca8-4526-b03f-7e3753d8fbb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704cd76-dca8-4526-b03f-7e3753d8fbb5.jpg?1",
             "name": "Even the Odds",
             "text": "Play Even the Odds only if you control fewer creatures than each opponent.\nPut three 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -201,7 +201,7 @@
         },
         {
             "id": "969794bb-95b2-57c3-95a0-a0dddad288f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b5231b-aed9-4b88-aba5-43e57a705dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b5231b-aed9-4b88-aba5-43e57a705dc5.jpg?1",
             "name": "Gift of Granite",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "ef358078-2c77-5345-81ea-9c8968f6d2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca127ef-349e-4380-875d-49c14fa03b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca127ef-349e-4380-875d-49c14fa03b18.jpg?1",
             "name": "Intervention Pact",
             "text": "Intervention Pact is white.\nThe next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.\nAt the beginning of your next upkeep, pay {1}{W}{W}. If you don't, you lose the game.",
             "colours": [
@@ -267,7 +267,7 @@
         },
         {
             "id": "376a7925-5683-53f6-831b-45784fa74c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0f9cb-f848-460e-94cc-d85b23133d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0f9cb-f848-460e-94cc-d85b23133d6e.jpg?1",
             "name": "Judge Unworthy",
             "text": "Choose target attacking or blocking creature. Scry 3, then reveal the top card of your library. Judge Unworthy deals damage equal to that card's converted mana cost to that creature. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -299,7 +299,7 @@
         },
         {
             "id": "1df10bb1-f0e3-5d02-bb6d-a5f4953d4999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b23129-25b2-4870-9462-ab12718ae7be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b23129-25b2-4870-9462-ab12718ae7be.jpg?1",
             "name": "Knight of Sursi",
             "text": "Flying, flanking\nSuspend 3\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "f3c162fa-25ad-5e4b-b9ba-c30ee8651cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834bfc49-9411-4a0f-b79b-d0d35f898952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834bfc49-9411-4a0f-b79b-d0d35f898952.jpg?1",
             "name": "Lost Auramancers",
             "text": "Vanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Lost Auramancers is put into a graveyard from play, if it had no time counters on it, you may search your library for an enchantment card and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "67450a81-338c-549d-9832-32caf17a3ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dcdda9-66a2-401f-9e1b-5603f771f56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dcdda9-66a2-401f-9e1b-5603f771f56f.jpg?1",
             "name": "Magus of the Moat",
             "text": "Creatures without flying can't attack.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "3df91cfb-d3e4-5294-82aa-88e2ff234a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d7f7e-8df3-4465-be07-83cb340cffc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d7f7e-8df3-4465-be07-83cb340cffc1.jpg?1",
             "name": "Marshaling Cry",
             "text": "Creatures you control get +1/+1 and gain vigilance until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nFlashback {3}{W} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "57318d84-0440-5bf5-b5fb-78028c91d437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823bdf79-998f-4d7c-834d-7a474cfa895e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823bdf79-998f-4d7c-834d-7a474cfa895e.jpg?1",
             "name": "Saltskitter",
             "text": "Whenever another creature comes into play, remove Saltskitter from the game. Return Saltskitter to play under its owner's control at end of turn.",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "7b5c008e-67fe-5610-9ca2-db0157dab723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6aeea-0144-4148-b7a6-47b703f64af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6aeea-0144-4148-b7a6-47b703f64af9.jpg?1",
             "name": "Samite Censer-Bearer",
             "text": "{W}, Sacrifice Samite Censer-Bearer: Prevent the next 1 damage that would be dealt to each creature you control this turn.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "8bec845f-3d60-52f9-9337-5f85d47a70c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6639e3d-b0c4-4c08-83d5-f3fc58fac9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6639e3d-b0c4-4c08-83d5-f3fc58fac9b2.jpg?1",
             "name": "Scout's Warning",
             "text": "The next creature card you play this turn can be played as though it had flash.\nDraw a card.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "bf882285-f770-563f-8440-bb9d564a18dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0d6477-9c50-4196-a04f-da73b5a07e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0d6477-9c50-4196-a04f-da73b5a07e01.jpg?1",
             "name": "Spirit en-Dal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nForecast {1}{W}, Reveal Spirit en-Dal from your hand: Target creature gains shadow until end of turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "8d55ff4c-cfa1-5142-ab88-09636f9880c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ede8a-5317-4662-b964-a9bd202a4aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ede8a-5317-4662-b964-a9bd202a4aab.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "3c83aab8-25d2-5f31-9af3-2654add558b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ccfe28-ec08-4751-b65c-c40b2bafa955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ccfe28-ec08-4751-b65c-c40b2bafa955.jpg?1",
             "name": "Blade of the Sixth Pride",
             "text": "",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "8ba3daee-8e18-55ae-8566-23aa7bb5283c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a6e04-ce3b-4025-92ba-8980022b8038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a6e04-ce3b-4025-92ba-8980022b8038.jpg?1",
             "name": "Bound in Silence",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "fac94213-9dd6-5084-b4f9-ec4765793139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f208f3d-ad21-477a-9e9b-de19afd536b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f208f3d-ad21-477a-9e9b-de19afd536b0.jpg?1",
             "name": "Daybreak Coronet",
             "text": "Enchant creature with another Aura attached to it\nEnchanted creature gets +3/+3 and has first strike, vigilance, and lifelink. (Whenever it deals damage, its controller gains that much life.)",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "028edd2d-eec3-59e6-a716-b120a4d89f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0eb4c-c8f1-40cf-ae0a-a413432b4c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0eb4c-c8f1-40cf-ae0a-a413432b4c5f.jpg?1",
             "name": "Goldmeadow Lookout",
             "text": "{W}, {T}, Discard a card: Put a 1/1 white Kithkin Soldier creature token named Goldmeadow Harrier into play with \"{W}, {T}: Tap target creature.\"",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "4f2d0431-aa3d-5fd9-b8da-e05a17943e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb02f692-80a9-4740-afde-cb4792d24774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb02f692-80a9-4740-afde-cb4792d24774.jpg?1",
             "name": "Imperial Mask",
             "text": "When Imperial Mask comes into play, if it's not a token, each of your teammates puts a token into play that's a copy of Imperial Mask.\nYou can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "4db420a9-bc0b-59a8-99fa-8037ad97a3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd700719-2f65-4fd5-b3aa-3e9402560c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd700719-2f65-4fd5-b3aa-3e9402560c79.jpg?1",
             "name": "Lucent Liminid",
             "text": "Flying",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "e76efd55-2ae9-52f2-9571-0806058598be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772bf1a3-ab2d-4fe6-830b-1c5ef8f5dc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772bf1a3-ab2d-4fe6-830b-1c5ef8f5dc07.jpg?1",
             "name": "Lumithread Field",
             "text": "Creatures you control get +0/+1.\nMorph {1}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "cbc1392f-11fc-52e9-be5d-722d9bba8dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cdb51f-c785-47d1-b23c-de74eeb22a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cdb51f-c785-47d1-b23c-de74eeb22a31.jpg?1",
             "name": "Lymph Sliver",
             "text": "All Sliver creatures have absorb 1. (If a source would deal damage to a Sliver, prevent 1 of that damage.)",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "2fc10375-ed28-55d9-838a-2bd0ca51a0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b45f8f-8f41-426d-b773-1e8cdfbff6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b45f8f-8f41-426d-b773-1e8cdfbff6f8.jpg?1",
             "name": "Mistmeadow Skulk",
             "text": "Protection from converted mana cost 3 or greater\nLifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "7a76b5a0-61c0-58a6-ae3d-c758c885fa1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9a3aeb-a316-4b1e-927b-36c3f999f2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9a3aeb-a316-4b1e-927b-36c3f999f2c3.jpg?1",
             "name": "Oriss, Samite Guardian",
             "text": "{T}: Prevent all damage that would be dealt to target creature this turn.\nGrandeur Discard another card named Oriss, Samite Guardian: Target player can't play spells this turn, and creatures that player controls can't attack this turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "2400c885-3546-55c1-93f8-53fd7a072751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfd70c-2923-4813-bf14-04194518163c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfd70c-2923-4813-bf14-04194518163c.jpg?1",
             "name": "Patrician's Scorn",
             "text": "If you played another white spell this turn, you may play Patrician's Scorn without paying its mana cost.\nDestroy all enchantments.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "37be15c4-bc82-5d95-affe-87a167b42fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250ee8d2-6f03-44a5-8f4c-ced4eaa4cdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250ee8d2-6f03-44a5-8f4c-ced4eaa4cdea.jpg?1",
             "name": "Ramosian Revivalist",
             "text": "{6}, {T}: Return target Rebel permanent card with converted mana cost 5 or less from your graveyard to play.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "5f5debdc-a2e4-5591-8fc7-c4e96b9fb284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092edca-cdc9-47e2-9c0c-e73c5a657777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092edca-cdc9-47e2-9c0c-e73c5a657777.jpg?1",
             "name": "Seht's Tiger",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Seht's Tiger comes into play, you gain protection from the color of your choice until end of turn. (You can't be targeted, dealt damage, or enchanted by anything of the chosen color.)",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "f98a04e8-f2f4-5b1d-a5a4-ef3e2294ea70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7599618-cbd9-4013-b0a5-4ba77fd52ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7599618-cbd9-4013-b0a5-4ba77fd52ab4.jpg?1",
             "name": "Aven Augur",
             "text": "Flying\nSacrifice Aven Augur: Return up to two target creatures to their owners' hands. Play this ability only during your upkeep.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "b2ceeb03-15c8-5694-8326-c0634f764892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727f9f4b-a8b6-47bd-9830-e69d118fe671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727f9f4b-a8b6-47bd-9830-e69d118fe671.jpg?1",
             "name": "Cloudseeder",
             "text": "Flying\n{U}, {T}, Discard a card: Put a 1/1 blue Faerie creature token named Cloud Sprite into play with flying and \"Cloud Sprite can block only creatures with flying.\"",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "9e90da30-0545-5224-8573-5c18f523804f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51026a-ae3c-4fa1-ac1e-96d44ae55b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51026a-ae3c-4fa1-ac1e-96d44ae55b82.jpg?1",
             "name": "Cryptic Annelid",
             "text": "When Cryptic Annelid comes into play, scry 1, then scry 2, then scry 3. (To scry X, look at the top X cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "0e9113b4-b6a1-5564-919e-feb6a4b8198f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e821d337-4bc5-4401-ac9b-34adf4012b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e821d337-4bc5-4401-ac9b-34adf4012b73.jpg?1",
             "name": "Delay",
             "text": "Counter target spell. If the spell is countered this way, remove it from the game with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, remove a counter from that card. When the last is removed, the player plays it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "2049d8f3-991a-5e9f-a16a-ef940a6a0010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bd95b5-1e90-41c5-8a9f-f3009f3f504a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bd95b5-1e90-41c5-8a9f-f3009f3f504a.jpg?1",
             "name": "Foresee",
             "text": "Scry 4, then draw two cards. (To scry 4, look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "ad602a51-dd9d-5c13-9ade-68b90d2f12da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa2e4b5-aec8-43e0-9ef3-d9cbe1072f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa2e4b5-aec8-43e0-9ef3-d9cbe1072f18.jpg?1",
             "name": "Infiltrator il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSuspend 2\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "2928023e-5da0-5bbe-b5e0-9270eb442305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be497544-bbf0-472d-adf6-ff1fd1951370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be497544-bbf0-472d-adf6-ff1fd1951370.jpg?1",
             "name": "Leaden Fists",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets +3/+3 and doesn't untap during its controller's untap step.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "897f73d3-f77b-5b55-a49e-efd7252be6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c102f29-6f3f-4f97-8177-4307586bd1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c102f29-6f3f-4f97-8177-4307586bd1b2.jpg?1",
             "name": "Maelstrom Djinn",
             "text": "Flying\nMorph {2}{U}\nWhen Maelstrom Djinn is turned face up, put two time counters on it and it gains vanishing. (At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "9ec39787-7b67-58b8-bded-63feca7df62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7025e614-7d08-4915-a985-3b876f1bdd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7025e614-7d08-4915-a985-3b876f1bdd1c.jpg?1",
             "name": "Magus of the Future",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "800e94bf-6f50-510f-9637-22c8703c8292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adfcb4-6a0a-46f9-a171-bfa9fade2156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adfcb4-6a0a-46f9-a171-bfa9fade2156.jpg?1",
             "name": "Mystic Speculation",
             "text": "Buyback {2} (You may pay an additional {2} as you play this spell. If you do, put this card into your hand as it resolves.)\nScry 3 (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "a1b61724-cfd4-5301-9f8b-326cd572b4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca467a2-a2b3-4bdf-9d60-62979f675347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca467a2-a2b3-4bdf-9d60-62979f675347.jpg?1",
             "name": "Pact of Negation",
             "text": "Pact of Negation is blue.\nCounter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "d7fe7fd4-6814-53ca-ba73-90accaf1f280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d881a-f7b1-471f-bc0b-64a79bb491c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d881a-f7b1-471f-bc0b-64a79bb491c9.jpg?1",
             "name": "Reality Strobe",
             "text": "Return target permanent to its owner's hand. Remove Reality Strobe from the game with three time counters on it.\nSuspend 3\u2014{2}{U} (Rather than play this card from your hand, you may pay {2}{U} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "7b610dde-f3ce-55c7-9e26-3601bddf668d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78366049-4613-4cd1-aab0-308996926563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78366049-4613-4cd1-aab0-308996926563.jpg?1",
             "name": "Take Possession",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nEnchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "12059ea3-7324-51e4-99a7-e62ece70df88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06111178-685d-4bda-8325-1db142d5801c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06111178-685d-4bda-8325-1db142d5801c.jpg?1",
             "name": "Unblinking Bleb",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever Unblinking Bleb or another permanent is turned face up, you may scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "9a1bfd8a-59d7-5409-8635-1d6c1ed91f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84fc99-4045-4518-b588-512a675f2933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84fc99-4045-4518-b588-512a675f2933.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Venser, Shaper Savant comes into play, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "bc077c85-0a9e-5169-ba21-2a73f9091ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbedfc40-7c2f-4a6e-8157-219cafca3548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbedfc40-7c2f-4a6e-8157-219cafca3548.jpg?1",
             "name": "Venser's Diffusion",
             "text": "Return target nonland permanent or suspended card to its owner's hand.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "4a0c5a08-a077-5071-a83d-bf017ddb8d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e6e715-abd8-4ff9-a8aa-8f4b929b0283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e6e715-abd8-4ff9-a8aa-8f4b929b0283.jpg?1",
             "name": "Arcanum Wings",
             "text": "Enchant creature\nEnchanted creature has flying.\nAura swap {2}{U} ({2}{U}: Exchange this Aura with an Aura card in your hand.)",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "a5db391e-cf8b-54ac-bf6d-8e48b6617d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26ee7b-de1a-4a39-9580-89941c3d0f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26ee7b-de1a-4a39-9580-89941c3d0f21.jpg?1",
             "name": "Blind Phantasm",
             "text": "",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "5af71cde-6547-5a8c-8b84-bcfbdc55a7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ced470-97c3-4683-b97f-9ebb8c3fbd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ced470-97c3-4683-b97f-9ebb8c3fbd11.jpg?1",
             "name": "Bonded Fetch",
             "text": "Defender, haste\n{T}: Draw a card, then discard a card.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "1bd417ba-230a-52de-bd29-f4962ff2f316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799538af-e497-457b-b096-ee6f342f51b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799538af-e497-457b-b096-ee6f342f51b5.jpg?1",
             "name": "Linessa, Zephyr Mage",
             "text": "{X}{U}{U}, {T}: Return target creature with converted mana cost X to its owner's hand.\nGrandeur Discard another card named Linessa, Zephyr Mage: Target player returns a creature he or she controls to its owner's hand, then repeats this process for an artifact, an enchantment, and a land.",
             "colours": [
@@ -1733,7 +1733,7 @@
         },
         {
             "id": "60c1d9f9-9903-5033-bf9d-f8b4b869dcf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e946be1-4ed6-4e2c-9782-3f630f8a8e1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e946be1-4ed6-4e2c-9782-3f630f8a8e1f.jpg?1",
             "name": "Logic Knot",
             "text": "Delve (You may remove any number of cards in your graveyard from the game as you play this spell. It costs {1} less to play for each card removed this way.)\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -1765,7 +1765,7 @@
         },
         {
             "id": "6f626eb9-cba0-55e7-8d0d-e3e4224b21ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bf083e-d0ec-4df9-a17a-8a28ad13d594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bf083e-d0ec-4df9-a17a-8a28ad13d594.jpg?1",
             "name": "Mesmeric Sliver",
             "text": "All Slivers have \"When this permanent comes into play, you may fateseal 1.\" (Its controller looks at the top card of an opponent's library, then he or she may put that card on the bottom of that library.)",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "89b91a60-c564-5561-b0b5-37ab602db1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76b3746-2e2c-4560-a2d2-e7b5b92833b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76b3746-2e2c-4560-a2d2-e7b5b92833b2.jpg?1",
             "name": "Narcomoeba",
             "text": "Flying\nWhen Narcomoeba is put into your graveyard from your library, you may put it into play.",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "d5464d6f-93a2-5f60-943a-3931289663d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dab4f64-2a91-409a-b83b-45b22afd22ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dab4f64-2a91-409a-b83b-45b22afd22ff.jpg?1",
             "name": "Nix",
             "text": "Counter target spell if no mana was spent to play it.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "10d17429-a28a-5eb2-9840-b6adbfd4a502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a425d3-a0b7-4d8d-8013-a27c59758b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a425d3-a0b7-4d8d-8013-a27c59758b28.jpg?1",
             "name": "Sarcomite Myr",
             "text": "{2}: Sarcomite Myr gains flying until end of turn.\n{2}, Sacrifice Sarcomite Myr: Draw a card.",
             "colours": [
@@ -1901,7 +1901,7 @@
         },
         {
             "id": "bcef3c65-860c-555c-be31-fea72a0dbb1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d2f8f-1166-4579-9609-d8ba5db79172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d2f8f-1166-4579-9609-d8ba5db79172.jpg?1",
             "name": "Second Wind",
             "text": "Enchant creature\n{T}: Tap enchanted creature.\n{T}: Untap enchanted creature.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "0070b2d5-60b8-556d-b36b-ad52c1421e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb3fa8-555f-4df6-994e-cf01896f7470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb3fa8-555f-4df6-994e-cf01896f7470.jpg?1",
             "name": "Shapeshifter's Marrow",
             "text": "At the beginning of each opponent's upkeep, that player reveals the top card of his or her library. If it's a creature card, the player puts the card into his or her graveyard and Shapeshifter's Marrow becomes a copy of that card. (If it does, it loses this ability.)",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "f718865e-bc7f-5bde-b3a5-b773d2075fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cc73ea-3f07-4d11-9961-dc31ac598b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cc73ea-3f07-4d11-9961-dc31ac598b73.jpg?1",
             "name": "Spellweaver Volute",
             "text": "Enchant instant card in a graveyard\nWhenever you play a sorcery spell, copy the enchanted instant card. You may play the copy without paying its mana cost. If you do, remove the enchanted card from the game and attach Spellweaver Volute to another instant card in a graveyard.",
             "colours": [
@@ -2001,7 +2001,7 @@
         },
         {
             "id": "03009531-9577-5d8a-9c97-e1a6fad472aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0808b800-9f5f-42ef-8cd0-c04e64945adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0808b800-9f5f-42ef-8cd0-c04e64945adf.jpg?1",
             "name": "Spin into Myth",
             "text": "Put target creature on top of its owner's library, then fateseal 2. (Look at the top two cards of an opponent's library, then put any number of them on the bottom of that player's library and the rest on top in any order.)",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "924bc581-766c-5c20-984a-699f33732de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496eb37d-5c8f-4dd7-a0a7-3ed1bd2210d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496eb37d-5c8f-4dd7-a0a7-3ed1bd2210d6.jpg?1",
             "name": "Vedalken Aethermage",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Vedalken \u00c6thermage comes into play, return target Sliver to its owner's hand.\nWizardcycling {3} ({3}, Discard this card: Search your library for a Wizard card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "34386302-0688-50b4-b516-6b5900882538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ddb99-08a4-4349-a246-d19de32527e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ddb99-08a4-4349-a246-d19de32527e2.jpg?1",
             "name": "Whip-Spine Drake",
             "text": "Flying\nMorph {2}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2103,7 +2103,7 @@
         },
         {
             "id": "097a7983-2be9-50c8-bae9-a1cacfe6aa50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945404d5-9e44-45e7-84fd-5f8c893e7d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945404d5-9e44-45e7-84fd-5f8c893e7d27.jpg?1",
             "name": "Augur of Skulls",
             "text": "{1}{B}: Regenerate Augur of Skulls.\nSacrifice Augur of Skulls: Target player discards two cards. Play this ability only during your upkeep.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "7a890435-0d34-5721-a155-8f4acfd03af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bc089-696d-41b4-a02f-d7dc166feedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bc089-696d-41b4-a02f-d7dc166feedd.jpg?1",
             "name": "Cutthroat il-Dal",
             "text": "Hellbent Cutthroat il-Dal has shadow as long as you have no cards in hand. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -2173,7 +2173,7 @@
         },
         {
             "id": "f209afcf-4062-5838-b314-3d6cad3a1db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c34e6aa-0414-45ba-b6eb-1ac4255d7de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c34e6aa-0414-45ba-b6eb-1ac4255d7de8.jpg?1",
             "name": "Festering March",
             "text": "Creatures your opponents control get -1/-1 until end of turn. Remove Festering March from the game with three time counters on it.\nSuspend 3\u2014{2}{B} (Rather than play this card from your hand, you may pay {2}{B} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "4c9ba1ce-f136-54e9-9e24-1281105ac8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4839a0b-47db-4464-9e9a-0e976d468106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4839a0b-47db-4464-9e9a-0e976d468106.jpg?1",
             "name": "Gibbering Descent",
             "text": "At the beginning of each player's upkeep, that player loses 1 life and discards a card.\nHellbent Skip your upkeep step if you have no cards in hand.\nMadness {2}{B}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "4c051da2-faeb-50f7-87ad-279be3b23cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d301f6-1ae2-4e26-a736-e59c7a8f2198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d301f6-1ae2-4e26-a736-e59c7a8f2198.jpg?1",
             "name": "Grave Peril",
             "text": "When a nonblack creature comes into play, sacrifice Grave Peril. If you do, destroy that creature.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "d4d87742-5958-5683-b298-45d7e1eab9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34603c3e-1078-48ca-9350-7d90c290b721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34603c3e-1078-48ca-9350-7d90c290b721.jpg?1",
             "name": "Ichor Slick",
             "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "20e4f99b-4227-557a-9765-09dbc4ed26a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfff4a8-43ae-41d4-acca-998234f9df35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfff4a8-43ae-41d4-acca-998234f9df35.jpg?1",
             "name": "Lost Hours",
             "text": "Target player reveals his or her hand. Choose a nonland card from it. That player puts that card into his or her library third from the top.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "7df71ba4-6d18-5a71-b038-dcdbbeeda323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a22c-491b-4969-befb-406c42fcec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a22c-491b-4969-befb-406c42fcec68.jpg?1",
             "name": "Magus of the Abyss",
             "text": "At the beginning of each player's upkeep, destroy target nonartifact creature that player controls of his or her choice. It can't be regenerated.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "039c3a5f-76e1-5779-afd0-c2157c13042c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6438a3b-6acb-4b49-8a46-9db80811d17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6438a3b-6acb-4b49-8a46-9db80811d17c.jpg?1",
             "name": "Minions' Murmurs",
             "text": "You draw X cards and you lose X life, where X is the number of creatures you control.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "c309fc53-571c-5e03-b81b-b0a9805ab77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a431fa-e98c-434a-9138-b4bcc86edde8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a431fa-e98c-434a-9138-b4bcc86edde8.jpg?1",
             "name": "Nihilith",
             "text": "Fear\nSuspend 7\u2014{1}{B}\nWhenever a card is put into an opponent's graveyard from anywhere, if Nihilith is suspended, you may remove a time counter from Nihilith.",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "ef874740-55c7-5a42-a028-833912859712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd5486b-c6f4-4cfc-9590-8ffc78b48b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd5486b-c6f4-4cfc-9590-8ffc78b48b0a.jpg?1",
             "name": "Oblivion Crown",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature has \"Discard a card: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "594bb6fd-7fdc-50f0-9557-924cf54299d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0911fb8b-d27a-4afc-9114-212f3e090393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0911fb8b-d27a-4afc-9114-212f3e090393.jpg?1",
             "name": "Pooling Venom",
             "text": "Enchant land\nWhenever enchanted land becomes tapped, its controller loses 2 life.\n{3}{B}: Destroy enchanted land.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "bde677d8-9681-58b4-bad8-44cad8afa480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e82edf-8acc-4024-bb88-f727f632b061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e82edf-8acc-4024-bb88-f727f632b061.jpg?1",
             "name": "Putrid Cyclops",
             "text": "When Putrid Cyclops comes into play, scry 1, then reveal the top card of your library. Putrid Cyclops gets -X/-X until end of turn, where X is that card's converted mana cost. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "22f33ee6-ba31-5852-ba5f-4cc2a5d70fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6faa406-aa7a-49ce-a42e-00e98f3fb74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6faa406-aa7a-49ce-a42e-00e98f3fb74e.jpg?1",
             "name": "Shimian Specter",
             "text": "Flying\nWhenever Shimian Specter deals combat damage to a player, that player reveals his or her hand. Choose a nonland card from it. Search that player's graveyard, hand, and library for all cards with the same name as that card and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "5a996160-85e5-5561-bb9c-cfa00f42d487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e783332-ea4e-4330-ba91-d23e5a58a7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e783332-ea4e-4330-ba91-d23e5a58a7eb.jpg?1",
             "name": "Skirk Ridge Exhumer",
             "text": "{B}, {T}, Discard a card: Put a 1/1 black Zombie Goblin creature token named Festering Goblin into play with \"When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.\"",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "2cf4902b-79ce-56d0-8413-f6b27406a5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42696fdb-de1f-44ae-bef3-b6af068958d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42696fdb-de1f-44ae-bef3-b6af068958d0.jpg?1",
             "name": "Slaughter Pact",
             "text": "Slaughter Pact is black.\nDestroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "521385bb-ec00-5592-a5e5-70e653ab73d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6006922b-20f8-4f38-9522-9851541a6de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6006922b-20f8-4f38-9522-9851541a6de5.jpg?1",
             "name": "Stronghold Rats",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Stronghold Rats deals combat damage to a player, each player discards a card.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "b9e4fd20-f99a-5964-b31f-e2624324d5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879e7a1-0256-4116-be22-7c9972e4ce0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879e7a1-0256-4116-be22-7c9972e4ce0b.jpg?1",
             "name": "Bitter Ordeal",
             "text": "Search target player's library for a card and remove that card from the game. Then that player shuffles his or her library.\nGravestorm (When you play this spell, copy it for each permanent put into a graveyard this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "554e6701-31b5-517d-ad50-6491b7da2296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c44610-6d4b-4c14-839f-2c085badec90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c44610-6d4b-4c14-839f-2c085badec90.jpg?1",
             "name": "Bridge from Below",
             "text": "Whenever a nontoken creature is put into your graveyard from play, if Bridge from Below is in your graveyard, put a 2/2 black Zombie creature token into play.\nWhen a creature is put into an opponent's graveyard from play, if Bridge from Below is in your graveyard, remove Bridge from Below from the game.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "19ade576-ec17-571f-8b25-59957c013fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cddafc8-57d6-456e-af58-4b7f45e195d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cddafc8-57d6-456e-af58-4b7f45e195d5.jpg?1",
             "name": "Death Rattle",
             "text": "Delve (You may remove any number of cards in your graveyard from the game as you play this spell. It costs {1} less to play for each card removed this way.)\nDestroy target nongreen creature. It can't be regenerated.",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "8bfd8000-5c23-50e3-89de-9a92bce0ad7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66cc281-3fa9-4d7b-a32b-41c0a93059ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66cc281-3fa9-4d7b-a32b-41c0a93059ba.jpg?1",
             "name": "Deepcavern Imp",
             "text": "Flying, haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -2803,7 +2803,7 @@
         },
         {
             "id": "a3219b80-63ae-59ce-bede-2ea3b526d43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e1a646-6925-4a53-a99c-8951af016a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e1a646-6925-4a53-a99c-8951af016a7a.jpg?1",
             "name": "Fleshwrither",
             "text": "Transfigure {1}{B}{B} ({1}{B}{B}, Sacrifice this creature: Search your library for a creature card with the same converted mana cost as this creature and put that card into play. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "237fb0d8-93f8-5d3b-a0ed-2c96ab4fb9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d796119a-f1eb-4de9-a9ca-d322017e9c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d796119a-f1eb-4de9-a9ca-d322017e9c5e.jpg?1",
             "name": "Frenzy Sliver",
             "text": "All Sliver creatures have frenzy 1. (Whenever a Sliver attacks and isn't blocked, it gets +1/+0 until end of turn.)",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "abefe00c-c3fb-5dd2-9532-2dadfd9af55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0a08a8-bbb9-4816-b03c-af4d729fce45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0a08a8-bbb9-4816-b03c-af4d729fce45.jpg?1",
             "name": "Grave Scrabbler",
             "text": "Madness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)\nWhen Grave Scrabbler comes into play, if its madness cost was paid, you may return target creature card in a graveyard to its owner's hand.",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "a3a28617-28c6-5344-92ad-39cf7b9b0b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f1f022-da7f-49a4-881d-b3a2c54c38eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f1f022-da7f-49a4-881d-b3a2c54c38eb.jpg?1",
             "name": "Korlash, Heir to Blackblade",
             "text": "Korlash, Heir to Blackblade's power and toughness are each equal to the number of Swamps you control.\n{1}{B}: Regenerate Korlash.\nGrandeur Discard another card named Korlash, Heir to Blackblade: Search your library for up to two Swamp cards, put them into play tapped, then shuffle your library.",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "341ff434-b7b1-5649-85d3-f7a84b668dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c3f515-de7d-41eb-8ba0-532f4c13ac39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c3f515-de7d-41eb-8ba0-532f4c13ac39.jpg?1",
             "name": "Mass of Ghouls",
             "text": "",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "6142b42e-bf4b-57bc-9448-cd9875e0fc40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b47606-82d1-402c-b1c6-591457b10d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b47606-82d1-402c-b1c6-591457b10d86.jpg?1",
             "name": "Snake Cult Initiation",
             "text": "Enchant creature\nEnchanted creature has poisonous 3. (Whenever it deals combat damage to a player, that player gets three poison counters. A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "4fb8d892-2d39-5f60-acaa-f954e9f02943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2815-bbcc-4338-a8ba-9aa97142ea69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2815-bbcc-4338-a8ba-9aa97142ea69.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "59a14f02-aabf-5e00-bc24-649806f97879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd55a11-8658-4b92-9151-d6173a11991a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd55a11-8658-4b92-9151-d6173a11991a.jpg?1",
             "name": "Tombstalker",
             "text": "Flying\nDelve (You may remove any number of cards in your graveyard from the game as you play this spell. It costs {1} less to play for each card removed this way.)",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "693142d6-5a33-59d0-a57b-3e0229615e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651c7735-088d-495b-a58f-69abf4cac197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651c7735-088d-495b-a58f-69abf4cac197.jpg?1",
             "name": "Witch's Mist",
             "text": "{2}{B}, {T}: Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "6f70a7b9-4baf-5c4c-9693-c00cf960dbc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6ba6a5-942d-44ff-87a9-3febf0b7e39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6ba6a5-942d-44ff-87a9-3febf0b7e39b.jpg?1",
             "name": "Yixlid Jailer",
             "text": "Cards in graveyards lose all abilities.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "39816564-ecef-5840-8be7-c72639804c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1c04fb-213f-4be1-9bba-94c737826bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1c04fb-213f-4be1-9bba-94c737826bf8.jpg?1",
             "name": "Arc Blade",
             "text": "Arc Blade deals 2 damage to target creature or player. Remove Arc Blade from the game with three time counters on it.\nSuspend 3\u2014{2}{R} (Rather than play this card from your hand, you may pay {2}{R} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "b81edfd5-8f34-5007-b26a-ff269f367cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814464-e5b6-46c6-ac2e-d7234add43f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814464-e5b6-46c6-ac2e-d7234add43f4.jpg?1",
             "name": "Bogardan Lancer",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nFlanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "7a2b0651-614e-55fc-bbf7-ed86a5a06d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae256118-3a7c-4b6e-b716-ba1ddfb4fb85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae256118-3a7c-4b6e-b716-ba1ddfb4fb85.jpg?1",
             "name": "Char-Rumbler",
             "text": "Double strike\n{R}: Char-Rumbler gets +1/+0 until end of turn.",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "efd085f8-ea88-50fe-a57b-a46faced763d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78dbef-315c-4f9b-8a1a-76a62a941182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78dbef-315c-4f9b-8a1a-76a62a941182.jpg?1",
             "name": "Emberwilde Augur",
             "text": "Sacrifice Emberwilde Augur: Emberwilde Augur deals 3 damage to target player. Play this ability only during your upkeep.",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "86ae5062-0116-544a-806e-8f83f9a3c2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930ff9ec-6b97-445e-b274-7c8c5fe0c0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930ff9ec-6b97-445e-b274-7c8c5fe0c0fc.jpg?1",
             "name": "Fatal Attraction",
             "text": "Enchant creature\nWhen Fatal Attraction comes into play, it deals 2 damage to enchanted creature.\nAt the beginning of your upkeep, Fatal Attraction deals 4 damage to enchanted creature.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "2afcb3ef-f12b-5470-8e92-3c53155a7ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af5c695-d0f4-4ea7-bc12-f3a24d5b6a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af5c695-d0f4-4ea7-bc12-f3a24d5b6a11.jpg?1",
             "name": "Gathan Raiders",
             "text": "Hellbent Gathan Raiders gets +2/+2 if you have no cards in hand.\nMorph\u2014\nDiscard a card. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "b4c1f5a9-a905-5db8-bfd5-1458dcc8d802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846134c0-5a8d-4ccb-8451-db29b70be3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846134c0-5a8d-4ccb-8451-db29b70be3f5.jpg?1",
             "name": "Haze of Rage",
             "text": "Buyback {2} (You may pay an additional {2} as you play this spell. If you do, put this card into your hand as it resolves.)\nCreatures you control get +1/+0 until end of turn.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "0fc464fe-c198-5508-9bbc-3904df839d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06a4443-6851-4873-8fb8-2ef76c9d6d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06a4443-6851-4873-8fb8-2ef76c9d6d2c.jpg?1",
             "name": "Magus of the Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "4cb9bf40-ca7d-5c9f-83a4-4b58081ee8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e0713c-dbf4-4403-ae69-58fd483e2481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e0713c-dbf4-4403-ae69-58fd483e2481.jpg?1",
             "name": "Molten Disaster",
             "text": "Kicker {R} (You may pay an additional {R} as you play this spell.)\nIf the kicker cost was paid, Molten Disaster has split second. (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
             "colours": [
@@ -3450,7 +3450,7 @@
         },
         {
             "id": "66ca489c-f2ac-5aef-9959-b9e96f8805be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f332ef3-335a-494d-a90f-61a9e9834ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f332ef3-335a-494d-a90f-61a9e9834ccd.jpg?1",
             "name": "Pact of the Titan",
             "text": "Pact of the Titan is red.\nPut a 4/4 red Giant creature token into play.\nAt the beginning of your next upkeep, pay {4}{R}. If you don't, you lose the game.",
             "colours": [
@@ -3482,7 +3482,7 @@
         },
         {
             "id": "819844f1-0136-5077-b270-81ef3408c18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456c4d8b-1dec-42ca-af89-4c40545261bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456c4d8b-1dec-42ca-af89-4c40545261bb.jpg?1",
             "name": "Pyromancer's Swath",
             "text": "If an instant or sorcery source you control would deal damage to a creature or player, it deals that much damage plus 2 to that creature or player instead.\nAt end of turn, discard your hand.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "19fbf047-61d4-5a29-bc2b-77a467ae72dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338be9e2-c0b8-4b69-b7b6-6ba9927a3a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338be9e2-c0b8-4b69-b7b6-6ba9927a3a4d.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose target creature or player. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that creature or player. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "be5b911b-4c88-5e66-9e71-376f67696599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c1a05-0dd2-4535-aa7f-ed33bbe92681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c1a05-0dd2-4535-aa7f-ed33bbe92681.jpg?1",
             "name": "Rift Elemental",
             "text": "{1}{R}, Remove a time counter from a permanent you control or suspended card you own: Rift Elemental gets +2/+0 until end of turn.",
             "colours": [
@@ -3580,7 +3580,7 @@
         },
         {
             "id": "43374446-c7bc-5741-9601-29ecceec655b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede410a-8b5c-48c0-8f5d-d8bd17e0b86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede410a-8b5c-48c0-8f5d-d8bd17e0b86b.jpg?1",
             "name": "Scourge of Kher Ridges",
             "text": "Flying\n{1}{R}: Scourge of Kher Ridges deals 2 damage to each creature without flying.\n{5}{R}: Scourge of Kher Ridges deals 6 damage to each other creature with flying.",
             "colours": [
@@ -3614,7 +3614,7 @@
         },
         {
             "id": "6dd7fbb7-2991-58bd-b720-1509f417a225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d3e0ff-7738-4f5e-b35a-b9494095ab9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d3e0ff-7738-4f5e-b35a-b9494095ab9f.jpg?1",
             "name": "Shivan Sand-Mage",
             "text": "When Shivan Sand-Mage comes into play, choose one Remove two time counters from target permanent or suspended card; or put two time counters on target permanent with a time counter on it or suspended card.\nSuspend 4\u2014{R}",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "0dba4d1e-232a-5201-9e95-b80bb8e878f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91431126-05b3-4c2e-aff7-41c2866265f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91431126-05b3-4c2e-aff7-41c2866265f6.jpg?1",
             "name": "Sparkspitter",
             "text": "{R}, {T}, Discard a card: Put a 3/1 red Elemental creature token named Spark Elemental into play with trample, haste, and \"At end of turn, sacrifice Spark Elemental.\"",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "f7a3bc00-73f5-560e-81a3-56337d19df03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930b146-d132-454f-b35d-4a247c14c054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930b146-d132-454f-b35d-4a247c14c054.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Play this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -3719,7 +3719,7 @@
         },
         {
             "id": "b96f5d56-8de8-5f83-ab95-753c248c934f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bec14-2e22-43eb-8854-b70a97dd023b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bec14-2e22-43eb-8854-b70a97dd023b.jpg?1",
             "name": "Boldwyr Intimidator",
             "text": "Cowards can't block Warriors.\n{R}: Target creature's type becomes Coward until end of turn.\n{2}{R}: Target creature's type becomes Warrior until end of turn.",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "e7137fdc-a325-5182-8201-8bc36686b16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab2a41-315b-439c-b02c-f12335fc903a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab2a41-315b-439c-b02c-f12335fc903a.jpg?1",
             "name": "Emblem of the Warmind",
             "text": "Enchant creature you control\nCreatures you control have haste.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "df7c3110-d5f1-591f-b8d0-f68ea57acd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3969cc7-92b9-45cd-9a4f-d94c2178a04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3969cc7-92b9-45cd-9a4f-d94c2178a04d.jpg?1",
             "name": "Flowstone Embrace",
             "text": "Enchant creature\n{T}: Enchanted creature gets +2/-2 until end of turn.",
             "colours": [
@@ -3822,7 +3822,7 @@
         },
         {
             "id": "f887a5ae-2166-5878-95b8-21f0143b633d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8216b3f3-b9b6-4d90-a624-c1b9b7bdf953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8216b3f3-b9b6-4d90-a624-c1b9b7bdf953.jpg?1",
             "name": "Fomori Nomad",
             "text": "",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "0125c541-acc6-5e3f-a3fc-f86a3aa9e24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60475e5-0d37-4af0-b717-da4c8dea45ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60475e5-0d37-4af0-b717-da4c8dea45ac.jpg?1",
             "name": "Ghostfire",
             "text": "Ghostfire is colorless.\nGhostfire deals 3 damage to target creature or player.",
             "colours": [],
@@ -3887,7 +3887,7 @@
         },
         {
             "id": "0fbc66ab-9292-596d-88fa-44a74ddb9956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31716a43-2522-46ff-a9a4-b6952cd41f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31716a43-2522-46ff-a9a4-b6952cd41f11.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {2}{R} to your mana pool. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "7dd039c7-047d-56f8-a351-009743452831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b41cef7-bb16-4d89-9900-dc6d1f5200f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b41cef7-bb16-4d89-9900-dc6d1f5200f0.jpg?1",
             "name": "Henchfiend of Ukor",
             "text": "Haste\nEcho {1}{B} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice this permanent unless you pay its echo cost.)\n{BR}: Henchfiend of Ukor gets +1/+0 until end of turn.",
             "colours": [
@@ -3956,7 +3956,7 @@
         },
         {
             "id": "f0ca8cf1-5617-525e-badf-c5508cd7106d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c876479-5040-4d36-b43a-54d7fc9160c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c876479-5040-4d36-b43a-54d7fc9160c1.jpg?1",
             "name": "Homing Sliver",
             "text": "Each Sliver card in each player's hand has slivercycling {3}.\nSlivercycling {3} ({3}, Discard this card: Search your library for a Sliver card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "6a7238a3-a107-5b00-a74c-8c3e706a1858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee5e9e3-e3ae-4e1b-a8fb-48c523631105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee5e9e3-e3ae-4e1b-a8fb-48c523631105.jpg?1",
             "name": "Shah of Naar Isle",
             "text": "Trample\nEcho {0} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Shah of Naar Isle's echo cost is paid, each opponent may draw up to three cards.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "e6d5751f-e385-559f-af0b-364e06ef0322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b232c36-bff1-4f5e-98a6-ce6a98591aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b232c36-bff1-4f5e-98a6-ce6a98591aa6.jpg?1",
             "name": "Skizzik Surger",
             "text": "Haste\nEcho\u2014\nSacrifice two lands. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "0881b75c-dc58-5076-a0f6-98d1d9740b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007ce039-def1-4039-a0a0-ba72e8872dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007ce039-def1-4039-a0a0-ba72e8872dc5.jpg?1",
             "name": "Steamflogger Boss",
             "text": "Other Rigger creatures you control get +1/+0 and have haste.\nIf a Rigger you control would assemble a Contraption, it assembles two Contraptions instead.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "28bd0d3b-3baf-50e8-ace6-6e74dd25e3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2db053-3da0-4c3a-9b36-0eff6477540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2db053-3da0-4c3a-9b36-0eff6477540d.jpg?1",
             "name": "Storm Entity",
             "text": "Haste\nStorm Entity comes into play with a +1/+1 counter on it for each other spell played this turn.",
             "colours": [
@@ -4127,7 +4127,7 @@
         },
         {
             "id": "9dfab376-fe2a-57ed-a043-617e01a86aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b06bd73-c45a-4560-bd8d-413608c5f89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b06bd73-c45a-4560-bd8d-413608c5f89e.jpg?1",
             "name": "Tarox Bladewing",
             "text": "Flying, haste\nGrandeur Discard another card named Tarox Bladewing: Tarox Bladewing gets +X/+X until end of turn, where X is its power.",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "3c793f92-cfab-59b2-a18b-9928b369a8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a85be1-9de5-4f96-9fd1-15f3f17c4bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a85be1-9de5-4f96-9fd1-15f3f17c4bea.jpg?1",
             "name": "Thunderblade Charge",
             "text": "Thunderblade Charge deals 3 damage to target creature or player.\nWhenever one or more creatures you control deal combat damage to a player, if Thunderblade Charge is in your graveyard, you may pay {2}{R}{R}{R}. If you do, play it without paying its mana cost.",
             "colours": [
@@ -4195,7 +4195,7 @@
         },
         {
             "id": "9f70d049-11ef-5358-93ae-5de038cc0975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2fa14-b08b-4cb9-bd77-c9da1dfa91d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2fa14-b08b-4cb9-bd77-c9da1dfa91d4.jpg?1",
             "name": "Cyclical Evolution",
             "text": "Target creature gets +3/+3 until end of turn. Remove Cyclical Evolution from the game with three time counters on it.\nSuspend 3\u2014{2}{G} (Rather than play this card from your hand, you may pay {2}{G} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "b72c7566-cedf-5410-8566-62a57f5748ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b344511d-631e-4f1d-9d7d-d7c89a473d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b344511d-631e-4f1d-9d7d-d7c89a473d1b.jpg?1",
             "name": "Force of Savagery",
             "text": "Trample",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "599cb0e2-d2a3-5463-b04e-ae6f6c54273c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2216497-ce38-41fe-bde9-e8066df36d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2216497-ce38-41fe-bde9-e8066df36d60.jpg?1",
             "name": "Heartwood Storyteller",
             "text": "Whenever a player plays a noncreature spell, each of that player's opponents may draw a card.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "586b8e51-e4c0-500a-aad9-82d05400bf5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19216a1-4fe2-496e-9ef4-6ac652e5b7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19216a1-4fe2-496e-9ef4-6ac652e5b7ca.jpg?1",
             "name": "Kavu Primarch",
             "text": "Convoke (Each creature you tap while playing this spell reduces its total cost by {1} or by one mana of that creature's color.)\nKicker {4} (You may pay an additional {4} as you play this spell.)\nIf the kicker cost was paid, Kavu Primarch comes into play with four +1/+1 counters on it.",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "e4f48bcc-5ac1-5039-a338-0fbfaa8841ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8c9473-97f4-4875-8f06-d3a70d4cbe6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8c9473-97f4-4875-8f06-d3a70d4cbe6d.jpg?1",
             "name": "Llanowar Augur",
             "text": "Sacrifice Llanowar Augur: Target creature gets +3/+3 and gains trample until end of turn. Play this ability only during your upkeep.",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "3f429b26-bdd0-576c-b7c8-401280f03764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf831ed3-d3ae-43ac-82ca-4984c05dde86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf831ed3-d3ae-43ac-82ca-4984c05dde86.jpg?1",
             "name": "Llanowar Empath",
             "text": "When Llanowar Empath comes into play, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "360867c1-f07d-59f2-b935-b05360ed2935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23f0074-40ad-4057-a672-42ed4f9564c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23f0074-40ad-4057-a672-42ed4f9564c0.jpg?1",
             "name": "Llanowar Mentor",
             "text": "{G}, {T}, Discard a card: Put a 1/1 green Elf Druid creature token named Llanowar Elves into play with \"{T}: Add {G} to your mana pool.\"",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "440f3189-41cc-595c-bbd7-83ecbfcaddcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a9453c-09b2-4dbb-969a-369f5e78a90f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a9453c-09b2-4dbb-969a-369f5e78a90f.jpg?1",
             "name": "Magus of the Vineyard",
             "text": "At the beginning of each player's precombat main phase, add {G}{G} to that player's mana pool.",
             "colours": [
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "53dd061a-5c25-57d6-bad6-ae6121adef14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1195c459-5e06-4f4e-aa6e-58fefa712684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1195c459-5e06-4f4e-aa6e-58fefa712684.jpg?1",
             "name": "Petrified Plating",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nSuspend 2\u2014{G} (Rather than play this card from your hand, you may pay {G} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "387e6a8e-31f5-5cc4-b5b5-c0fdb83ab563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ce95e-5102-44fb-b74d-7469331ca9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ce95e-5102-44fb-b74d-7469331ca9cc.jpg?1",
             "name": "Quiet Disrepair",
             "text": "Enchant artifact or enchantment\nAt the beginning of your upkeep, choose one Destroy enchanted permanent; or you gain 2 life.",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "80d783b0-aafc-5766-83a8-f4ca4ad6d530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e09949e-c8cd-4bb4-9ed4-699abbc7ad3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e09949e-c8cd-4bb4-9ed4-699abbc7ad3c.jpg?1",
             "name": "Ravaging Riftwurm",
             "text": "Kicker {4} (You may pay an additional {4} as you play this spell.)\nVanishing 2 (This permanent comes into play with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nIf the kicker cost was paid, Ravaging Riftwurm comes into play with three additional time counters on it.",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "528a2572-25dc-504e-85e7-a2d7f0ee4e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847dbbbc-e069-4a90-bc47-c28418bb8540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847dbbbc-e069-4a90-bc47-c28418bb8540.jpg?1",
             "name": "Riftsweeper",
             "text": "When Riftsweeper comes into play, choose target face-up card that's removed from the game. Its owner shuffles it into his or her library.",
             "colours": [
@@ -4606,7 +4606,7 @@
         },
         {
             "id": "d6b0363a-4129-5cc5-a2af-433bf03bc973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811458c7-dcdc-43ef-8c3e-a90e21ce315e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811458c7-dcdc-43ef-8c3e-a90e21ce315e.jpg?1",
             "name": "Rites of Flourishing",
             "text": "At the beginning of each player's draw step, that player draws a card.\nEach player may play an additional land on each of his or her turns.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "68e727c2-ba07-59e8-9d98-4e9714edda47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b915355-4e98-44df-81bd-961a3d3c86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b915355-4e98-44df-81bd-961a3d3c86b8.jpg?1",
             "name": "Sprout Swarm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its total cost by {1} or by one mana of that creature's color.)\nBuyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nPut a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "bc78ff9e-3147-506b-b777-c6e3c5b33903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b026c-cfce-462b-afb6-7a383bd121de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b026c-cfce-462b-afb6-7a383bd121de.jpg?1",
             "name": "Summoner's Pact",
             "text": "Summoner's Pact is green.\nSearch your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -4702,7 +4702,7 @@
         },
         {
             "id": "fe326117-9808-5168-b9a6-7abed7310478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d3d285-8327-4dba-911b-ff03b186f6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d3d285-8327-4dba-911b-ff03b186f6b8.jpg?1",
             "name": "Utopia Mycon",
             "text": "At the beginning of your upkeep, put a spore counter on Utopia Mycon.\nRemove three spore counters from Utopia Mycon: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Add one mana of any color to your mana pool.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "b57fe913-f089-5951-a141-cebfe11c5c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d438a-ce68-480b-bdfc-1fc3e151e5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d438a-ce68-480b-bdfc-1fc3e151e5f8.jpg?1",
             "name": "Wrap in Vigor",
             "text": "Regenerate each creature you control.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "f8ed8eb7-7a54-5ff7-abd2-d1e780ad4b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a74fcde-7685-402c-9b2a-245aa75d75c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a74fcde-7685-402c-9b2a-245aa75d75c1.jpg?1",
             "name": "Baru, Fist of Krosa",
             "text": "Whenever a Forest comes into play, green creatures you control get +1/+1 and gain trample until end of turn.\nGrandeur Discard another card named Baru, Fist of Krosa: Put an X/X green Wurm creature token into play, where X is the number of lands you control.",
             "colours": [
@@ -4805,7 +4805,7 @@
         },
         {
             "id": "f0cade63-ec0f-5182-b089-24d93faef530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5807814f-7b18-431a-8031-898ff70ad69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5807814f-7b18-431a-8031-898ff70ad69f.jpg?1",
             "name": "Centaur Omenreader",
             "text": "As long as Centaur Omenreader is tapped, creature spells you play cost {2} less to play.",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "2fc908fc-8e52-5ee9-8e6c-f989d9e2b5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03998e86-ef67-4329-b106-61252f3f532a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03998e86-ef67-4329-b106-61252f3f532a.jpg?1",
             "name": "Edge of Autumn",
             "text": "If you control four or fewer lands, search your library for a basic land card, put it into play tapped, then shuffle your library.\nCycling\u2014\nSacrifice a land. (Sacrifice a land, Discard this card: Draw a card.)",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "6effbd5b-2357-5e44-8a1b-a43f3953b577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5136f8-1616-4463-8aa7-122cde6dcddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5136f8-1616-4463-8aa7-122cde6dcddb.jpg?1",
             "name": "Imperiosaur",
             "text": "Spend only mana produced by basic lands to play Imperiosaur.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "7d86e0d1-0184-513c-9b80-406f1d625966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4091524c-569c-4668-b18a-7f869b1169f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4091524c-569c-4668-b18a-7f869b1169f3.jpg?1",
             "name": "Muraganda Petroglyphs",
             "text": "Creatures with no abilities get +2/+2.",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "77590295-4c6c-5f4f-bde4-9eb6a49bcb3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef863d2-1e11-41cc-90d5-008bf6234565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef863d2-1e11-41cc-90d5-008bf6234565.jpg?1",
             "name": "Nacatl War-Pride",
             "text": "Nacatl War-Pride must be blocked by exactly one creature if able.\nWhenever Nacatl War-Pride attacks, put X tokens into play tapped and attacking that are copies of Nacatl War-Pride, where X is the number of creatures defending player controls. Remove the tokens from the game at end of turn.",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "ea92cd99-0f10-58bd-ae3a-08b518ffce2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b18b70-f656-4426-a3e5-69cf61fdaad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b18b70-f656-4426-a3e5-69cf61fdaad1.jpg?1",
             "name": "Nessian Courser",
             "text": "",
             "colours": [
@@ -5010,7 +5010,7 @@
         },
         {
             "id": "648ca487-a525-51e0-84fe-2b8f7185a38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca13d7a-0f60-4de6-9455-aea454cb2e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca13d7a-0f60-4de6-9455-aea454cb2e46.jpg?1",
             "name": "Phosphorescent Feast",
             "text": "Reveal any number of cards in your hand. You gain 2 life for each green mana symbol in those cards' mana costs.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "89b82a07-3fc4-525b-b438-2b3d077a653b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335c3aa3-af89-44ce-955a-69e12d83175f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335c3aa3-af89-44ce-955a-69e12d83175f.jpg?1",
             "name": "Quagnoth",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nShroud (This permanent can't be the target of spells or abilities.)\nWhen a spell or ability an opponent controls causes you to discard Quagnoth, return it to your hand.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "012e1d6f-c232-5026-bdc3-2eb092180f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231eb017-2945-4915-8032-c09894e88d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231eb017-2945-4915-8032-c09894e88d49.jpg?1",
             "name": "Spellwild Ouphe",
             "text": "Spells that target Spellwild Ouphe cost {2} less to play.",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "6c13474e-af90-5eb7-b3e6-391a499ab115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8f3f3-4ff4-4943-8ae0-c1af78a5ae16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8f3f3-4ff4-4943-8ae0-c1af78a5ae16.jpg?1",
             "name": "Sporoloth Ancient",
             "text": "At the beginning of your upkeep, put a spore counter on Sporoloth Ancient.\nCreatures you control have \"Remove two spore counters from this creature: Put a 1/1 green Saproling creature token into play.\"",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "e4bc70c6-e2c9-5014-a570-af461df67335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6876d9e-0908-43ac-8542-09c7aa02b5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6876d9e-0908-43ac-8542-09c7aa02b5ba.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1. (The card types are artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal.)",
             "colours": [
@@ -5178,7 +5178,7 @@
         },
         {
             "id": "d3b9df86-ae62-5de0-818b-c0f9efcc7869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783a50a0-9394-4d97-856f-21eb126a0018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783a50a0-9394-4d97-856f-21eb126a0018.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "539bf5c8-d8d4-5126-9e2a-2fab53558ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de9c95-e590-4b0d-a2d7-886d7a488a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de9c95-e590-4b0d-a2d7-886d7a488a10.jpg?1",
             "name": "Virulent Sliver",
             "text": "All Sliver creatures have poisonous 1. (Whenever a Sliver deals combat damage to a player, that player gets a poison counter. A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "29b71dc4-30ec-5890-9f84-46da931d24d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec73e1ba-b543-4c64-aa89-164eef1d15d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec73e1ba-b543-4c64-aa89-164eef1d15d6.jpg?1",
             "name": "Glittering Wish",
             "text": "Choose a multicolored card you own from outside the game, reveal that card, and put it into your hand. Remove Glittering Wish from the game.",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "9efb77a5-faca-5da4-a6bf-8314e6f47b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f437128-3a87-4958-97d0-3940d8761cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f437128-3a87-4958-97d0-3940d8761cba.jpg?1",
             "name": "Jhoira of the Ghitu",
             "text": "{2}, Remove a nonland card in your hand from the game: Put four time counters on the removed card. If it doesn't have suspend, it gains suspend. (At the beginning of your upkeep, remove a time counter from that card. When the last is removed, play it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "1e9dac73-6c4e-5bec-a32c-6d3a76f584e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd37a04-87b1-42ad-b3e2-f17cd8998f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd37a04-87b1-42ad-b3e2-f17cd8998f9d.jpg?1",
             "name": "Sliver Legion",
             "text": "All Sliver creatures get +1/+1 for each other Sliver in play.",
             "colours": [
@@ -5364,7 +5364,7 @@
         },
         {
             "id": "20b00f09-f3d3-5a2c-bb57-48b6b985e016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cb3bdf-dff5-4285-ad67-ae7ca84c9fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cb3bdf-dff5-4285-ad67-ae7ca84c9fbc.jpg?1",
             "name": "Akroma's Memorial",
             "text": "Creatures you control have flying, first strike, vigilance, trample, haste, protection from black, and protection from red.",
             "colours": [],
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "aac8ddea-afd9-5f47-b065-7180efffcde0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b893ab56-44a6-4b3c-bb3e-6deec298cbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b893ab56-44a6-4b3c-bb3e-6deec298cbce.jpg?1",
             "name": "Cloud Key",
             "text": "As Cloud Key comes into play, choose artifact, creature, enchantment, instant, or sorcery.\nSpells you play of the chosen type cost {1} less to play.",
             "colours": [],
@@ -5422,7 +5422,7 @@
         },
         {
             "id": "c4f61a73-6471-574b-bd73-68915c550b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c98b0-d64d-4d0a-b284-1187a8e7095e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c98b0-d64d-4d0a-b284-1187a8e7095e.jpg?1",
             "name": "Coalition Relic",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color to your mana pool for each counter removed this way.",
             "colours": [],
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "f2a91235-cb6e-585f-9d56-2e46fc05ee14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7971f6a6-c26c-4f8f-8de7-afc40563967d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7971f6a6-c26c-4f8f-8de7-afc40563967d.jpg?1",
             "name": "Epochrasite",
             "text": "Epochrasite comes into play with three +1/+1 counters on it if you didn't play it from your hand.\nWhen Epochrasite is put into a graveyard from play, remove it from the game with three time counters on it and it gains suspend.",
             "colours": [],
@@ -5481,7 +5481,7 @@
         },
         {
             "id": "84590293-505b-5cd9-89a3-e598be5e4960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242b7dd-a632-4024-a69a-179a63fb93a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242b7dd-a632-4024-a69a-179a63fb93a8.jpg?1",
             "name": "Sliversmith",
             "text": "{1}, {T}, Discard a card: Put a 1/1 Sliver artifact creature token named Metallic Sliver into play.",
             "colours": [],
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "d9674423-3213-5467-b0d9-00b92438f806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efa61f0-c7bd-49e2-9d66-bf15ad0e9d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efa61f0-c7bd-49e2-9d66-bf15ad0e9d03.jpg?1",
             "name": "Soultether Golem",
             "text": "Vanishing 1 (This permanent comes into play with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever another creature comes into play under your control, put a time counter on Soultether Golem.",
             "colours": [],
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "cae0dd73-07bd-582d-9242-0f20f6be73e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f13705-6ede-4c29-a2b4-a082bf69e9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f13705-6ede-4c29-a2b4-a082bf69e9c5.jpg?1",
             "name": "Sword of the Meek",
             "text": "Equipped creature gets +1/+2.\nEquip {2}\nWhenever a 1/1 creature comes into play under your control, you may return Sword of the Meek from your graveyard to play, then attach it to that creature.",
             "colours": [],
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "5607990a-3534-5359-9877-a3bfdf49dd61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705d3e4-317e-460d-b16e-e57238a19070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705d3e4-317e-460d-b16e-e57238a19070.jpg?1",
             "name": "Veilstone Amulet",
             "text": "Whenever you play a spell, creatures you control can't be the targets of spells or abilities your opponents control this turn.",
             "colours": [],
@@ -5601,7 +5601,7 @@
         },
         {
             "id": "189be2a8-e419-5c70-8771-e322d71c235b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77eaaa0-40f9-40e4-b0ba-5a8addd764d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77eaaa0-40f9-40e4-b0ba-5a8addd764d3.jpg?1",
             "name": "Darksteel Garrison",
             "text": "Fortified land is indestructible.\nWhenever fortified land becomes tapped, target creature gets +1/+1 until end of turn.\nFortify {3} ({3}: Attach to target land you control. Fortify only as a sorcery. This card comes into play unattached and stays in play if the land leaves play.)",
             "colours": [],
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "a4b88ce5-f7f2-5d1f-ac81-3227305def78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6040b6-cf02-4f7e-a275-177c3a6415aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6040b6-cf02-4f7e-a275-177c3a6415aa.jpg?1",
             "name": "Whetwheel",
             "text": "{X}{X}, {T}: Target player puts the top X cards of his or her library into his or her graveyard.\nMorph {3} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "e73d4dbc-0b5e-5639-896c-091510bfecf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f06e8-d8ee-435c-965c-8e1302a8ec10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f06e8-d8ee-435c-965c-8e1302a8ec10.jpg?1",
             "name": "Dakmor Salvage",
             "text": "Dakmor Salvage comes into play tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [],
@@ -5689,7 +5689,7 @@
         },
         {
             "id": "9cc1d138-5ab1-5dd8-b765-4a1f303c61b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6d546d-df98-4cb4-a68b-2a0c8bac5a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6d546d-df98-4cb4-a68b-2a0c8bac5a72.jpg?1",
             "name": "Keldon Megaliths",
             "text": "Keldon Megaliths comes into play tapped.\n{T}: Add {R} to your mana pool.\nHellbent {1}{R}, {T}: Keldon Megaliths deals 1 damage to target creature or player. Play this ability only if you have no cards in hand.",
             "colours": [],
@@ -5719,7 +5719,7 @@
         },
         {
             "id": "f45f1ef3-9740-56a0-9cc0-1e9168969c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d07c6b-1afa-4321-b4f9-f22e81a0b818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d07c6b-1afa-4321-b4f9-f22e81a0b818.jpg?1",
             "name": "Llanowar Reborn",
             "text": "Llanowar Reborn comes into play tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land comes into play with a +1/+1 counter on it. Whenever a creature comes into play, you may move a +1/+1 counter from this land onto it.)",
             "colours": [],
@@ -5749,7 +5749,7 @@
         },
         {
             "id": "bd08706c-c4d7-50e8-b8c8-9b97ae7c4ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bde721-8fa0-4f69-9909-b4864929e676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bde721-8fa0-4f69-9909-b4864929e676.jpg?1",
             "name": "New Benalia",
             "text": "New Benalia comes into play tapped.\nWhen New Benalia comes into play, scry 1. (Look at the top card of your library, then you may put that card on the bottom of your library.)\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -5779,7 +5779,7 @@
         },
         {
             "id": "282d83ac-814f-5d1d-8fa7-66917eb57f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e80f06-ea05-4151-920f-7ddc88952169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e80f06-ea05-4151-920f-7ddc88952169.jpg?1",
             "name": "Tolaria West",
             "text": "Tolaria West comes into play tapped.\n{T}: Add {U} to your mana pool.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with converted mana cost 0, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [],
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "152ebf50-8a88-5bff-9da4-7f2364db8e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cee476d-42e1-4997-87af-73e18f542167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cee476d-42e1-4997-87af-73e18f542167.jpg?1",
             "name": "Dryad Arbor",
             "text": "(Dryad Arbor isn't a spell, it's affected by summoning sickness, and it has \"{T}: Add {G} to your mana pool.\")\nDryad Arbor is green.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "70535b46-aa0c-5d69-8654-ddb8735dcefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7d329-ef6a-45f3-82b6-37a3606c00bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7d329-ef6a-45f3-82b6-37a3606c00bc.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {1} to your mana pool.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "245cdf7a-8ff2-5e38-8b86-141627a122bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b4d4b1-6e25-4c4b-a21a-1b7b1c1d6452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b4d4b1-6e25-4c4b-a21a-1b7b1c1d6452.jpg?1",
             "name": "Grove of the Burnwillows",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Each opponent gains 1 life.",
             "colours": [],
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "98a6fbfc-2e16-5596-a309-0c9393acfa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfc25d-a17b-4ead-9484-e8a18b8fa176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfc25d-a17b-4ead-9484-e8a18b8fa176.jpg?1",
             "name": "Horizon Canopy",
             "text": "{T}, Pay 1 life: Add {G} or {W} to your mana pool.\n{1}, {T}, Sacrifice Horizon Canopy: Draw a card.",
             "colours": [],
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "159ccb76-6816-54b0-9000-fea0e6acdc39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d1f953-9403-4e0a-b8e1-3f7d928a2834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d1f953-9403-4e0a-b8e1-3f7d928a2834.jpg?1",
             "name": "Nimbus Maze",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} to your mana pool. Play this ability only if you control an Island.\n{T}: Add {U} to your mana pool. Play this ability only if you control a Plains.",
             "colours": [],
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "52be12f7-0d62-5d61-9e40-89e9741165d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5b2058-99fc-4d9b-9e3d-056fa3fd1244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5b2058-99fc-4d9b-9e3d-056fa3fd1244.jpg?1",
             "name": "River of Tears",
             "text": "{T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.",
             "colours": [],
@@ -6000,7 +6000,7 @@
         },
         {
             "id": "015ea4fb-f436-535f-9549-62fcdfa67de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db30e1-31df-44b9-930a-02428bd5ce47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db30e1-31df-44b9-930a-02428bd5ce47.jpg?1",
             "name": "Zoetic Cavern",
             "text": "{T}: Add {1} to your mana pool.\nMorph {2} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],

--- a/Assets/Resources/Sets/GPT.json
+++ b/Assets/Resources/Sets/GPT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9c1f142e-75e9-52e8-b0c5-37e5737f6e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711979c3-e70b-4973-a4f1-020db534fc73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711979c3-e70b-4973-a4f1-020db534fc73.jpg?1",
             "name": "Absolver Thrull",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Absolver Thrull comes into play or the creature it haunts is put into a graveyard, destroy target enchantment.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "07285b14-649d-57bd-9d45-c73b9db93759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556e4e71-b149-49c8-8a22-83660bef57bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556e4e71-b149-49c8-8a22-83660bef57bb.jpg?1",
             "name": "Belfry Spirit",
             "text": "Flying\nHaunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Belfry Spirit comes into play or the creature it haunts is put into a graveyard, put two 1/1 black Bat creature tokens with flying into play.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "1e304047-5c93-5c74-ae0d-c92ce79d2320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ea99d1-9e88-4b14-b0b3-39bcd8191eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ea99d1-9e88-4b14-b0b3-39bcd8191eab.jpg?1",
             "name": "Benediction of Moons",
             "text": "You gain 1 life for each player.\nHaunt (When this spell card is put into a graveyard after resolving, remove it from the game haunting target creature.)\nWhen the creature Benediction of Moons haunts is put into a graveyard, you gain 1 life for each player.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "fb02449c-c552-5537-bcab-147aca77db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756eb23a-c6de-439a-b83d-e694cfae7ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756eb23a-c6de-439a-b83d-e694cfae7ccb.jpg?1",
             "name": "Droning Bureaucrats",
             "text": "{X}, {T}: Each creature with converted mana cost X can't attack or block this turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "12effa8c-7175-5270-b762-3744624676af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4304abfe-3c81-4053-a398-574cfac613a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4304abfe-3c81-4053-a398-574cfac613a7.jpg?1",
             "name": "Ghost Warden",
             "text": "{T}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "1d4deb4b-b443-587d-98af-3a765b00ec09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b83d750-16d9-41e4-b823-3295c5f6b319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b83d750-16d9-41e4-b823-3295c5f6b319.jpg?1",
             "name": "Ghostway",
             "text": "Remove each creature you control from the game. Return those creatures to play under their owners' control at end of turn.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "2490835b-aa17-5720-8e94-3c0b609ecc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dc44f8-ff1d-4c5a-971d-c3ce9a65f35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dc44f8-ff1d-4c5a-971d-c3ce9a65f35d.jpg?1",
             "name": "Graven Dominator",
             "text": "Flying\nHaunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Graven Dominator comes into play or the creature it haunts is put into a graveyard, each other creature becomes 1/1 until end of turn.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "c2372fba-62d9-5334-8c83-466125fbe2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a688e9-28ec-4604-8705-46549402a6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a688e9-28ec-4604-8705-46549402a6f8.jpg?1",
             "name": "Guardian's Magemark",
             "text": "You may play Guardian's Magemark any time you could play an instant.\nEnchant creature\nCreatures you control that are enchanted get +1/+1.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "dce6a0b1-b7f2-54b3-be26-c9038f97b1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2781696e-e70c-4c96-b3aa-75be51cdc68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2781696e-e70c-4c96-b3aa-75be51cdc68e.jpg?1",
             "name": "Harrier Griffin",
             "text": "Flying\nAt the beginning of your upkeep, tap target creature.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "2e72d8d6-497e-56da-81f0-24530a0ec6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc58757-abcc-41c9-b4d2-e70e9f387cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc58757-abcc-41c9-b4d2-e70e9f387cbb.jpg?1",
             "name": "Leyline of the Meek",
             "text": "If Leyline of the Meek is in your opening hand, you may begin the game with it in play.\nCreature tokens get +1/+1.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "5679474f-1fc6-5c00-bdc6-d184caaf7e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704ba6ce-5d28-417b-8574-d3c097e6e39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704ba6ce-5d28-417b-8574-d3c097e6e39f.jpg?1",
             "name": "Lionheart Maverick",
             "text": "Vigilance\n{4}{W}: Lionheart Maverick gets +1/+2 until end of turn.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "c1098fff-5cd3-5cb7-99c6-cd6e6486b03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d7ad75-1fa9-4683-b0d0-737368de3796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d7ad75-1fa9-4683-b0d0-737368de3796.jpg?1",
             "name": "Martyred Rusalka",
             "text": "{W}, Sacrifice a creature: Target creature can't attack this turn.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "6f215484-0773-57c4-b88c-37432c7f6dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41981edd-df29-4ded-85d6-0d1a2a3a7a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41981edd-df29-4ded-85d6-0d1a2a3a7a59.jpg?1",
             "name": "Order of the Stars",
             "text": "Defender (This creature can't attack.)\nAs Order of the Stars comes into play, choose a color.\nOrder of the Stars has protection from the chosen color.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "1cb71f20-8235-5ed9-b6a0-901d33ac70a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b5590f-d964-49cb-8e2e-94b067112c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b5590f-d964-49cb-8e2e-94b067112c8e.jpg?1",
             "name": "Shadow Lance",
             "text": "Enchant creature\nEnchanted creature has first strike.\n{1}{B}: Enchanted creature gets +2/+2 until end of turn.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "cbf32399-0a9b-5756-bf9b-532c30d6058b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924863b6-6d7b-441b-90cc-4e98e1c41aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924863b6-6d7b-441b-90cc-4e98e1c41aa9.jpg?1",
             "name": "Shadow Lance",
             "text": "",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "bcf6d79c-3b9b-56ba-b733-f2ddea7fc579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c221f01-b094-41c7-bb5f-eef97cbf584e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c221f01-b094-41c7-bb5f-eef97cbf584e.jpg?1",
             "name": "Shrieking Grotesque",
             "text": "Flying\nWhen Shrieking Grotesque comes into play, if {B} was spent to play Shrieking Grotesque, target player discards a card.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "34b3cba3-3068-5996-a603-b1605532a0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6889030-f4cd-41a3-8596-b552a9539873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6889030-f4cd-41a3-8596-b552a9539873.jpg?1",
             "name": "Sinstriker's Will",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to target attacking or blocking creature.\"",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "134f1b68-58ff-54b0-9f85-0acd45105c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d760a01-d6c4-462b-b66c-cfd0f594e13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d760a01-d6c4-462b-b66c-cfd0f594e13a.jpg?1",
             "name": "Skyrider Trainee",
             "text": "As long as Skyrider Trainee is enchanted, it has flying.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "2d105a88-a8c3-5ca9-91fc-f11cec30948f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd5682a-ca93-4b5f-af21-e1ff4439361b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd5682a-ca93-4b5f-af21-e1ff4439361b.jpg?1",
             "name": "Spelltithe Enforcer",
             "text": "Whenever an opponent plays a spell, that player sacrifices a permanent unless he or she pays {1}.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "65372408-f85a-5178-8a94-c3175f756de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c86398-2cbc-4ad7-a231-6802e3b4d1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c86398-2cbc-4ad7-a231-6802e3b4d1c0.jpg?1",
             "name": "Storm Herd",
             "text": "Put X 1/1 white Pegasus creature tokens with flying into play, where X is your life total.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "5a64edee-23a7-5c0d-8170-0cca6b8270ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f72d4b7-3b65-411b-a072-8218a0202974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f72d4b7-3b65-411b-a072-8218a0202974.jpg?1",
             "name": "To Arms!",
             "text": "Untap all creatures you control.\nDraw a card.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "75d0c810-d84b-5a28-9fb4-f82f4a8085b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb458f79-13dd-4446-be75-463f19548867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb458f79-13dd-4446-be75-463f19548867.jpg?1",
             "name": "Withstand",
             "text": "Prevent the next 3 damage that would be dealt to target creature or player this turn.\nDraw a card.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "0fc98b17-8787-5188-a733-40f385b8e56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bee334-c56e-4221-97ed-bea73a61b812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bee334-c56e-4221-97ed-bea73a61b812.jpg?1",
             "name": "Aetherplasm",
             "text": "Whenever \u00c6therplasm blocks a creature, you may return \u00c6therplasm to its owner's hand. If you do, you may put a creature card from your hand into play blocking that creature.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "b32cfc0f-eff4-5b30-9c6c-16056b314216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549ed5bd-da29-4cd4-893e-9e53e33a8557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549ed5bd-da29-4cd4-893e-9e53e33a8557.jpg?1",
             "name": "Crystal Seer",
             "text": "When Crystal Seer comes into play, look at the top four cards of your library, then put them back in any order.\n{4}{U}: Return Crystal Seer to its owner's hand.",
             "colours": [
@@ -821,7 +821,7 @@
         },
         {
             "id": "c46ca2ea-82ad-5365-afe8-936aba7759ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68864836-799e-467d-97cc-38c89f71afcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68864836-799e-467d-97cc-38c89f71afcf.jpg?1",
             "name": "Drowned Rusalka",
             "text": "{U}, Sacrifice a creature: Discard a card, then draw a card.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "1d33718e-17d5-54f2-8b1e-54e3622d547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg?1",
             "name": "Frazzle",
             "text": "Counter target nonblue spell.",
             "colours": [
@@ -887,7 +887,7 @@
         },
         {
             "id": "0b1e0b30-b4a0-5782-a5bb-d2d3cc941686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9f85b3-eb8c-43de-aaac-8a887e9c58da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9f85b3-eb8c-43de-aaac-8a887e9c58da.jpg?1",
             "name": "Gigadrowse",
             "text": "Replicate {U} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTap target permanent.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "0694ed7b-921c-5461-b1c1-61c1a4abe9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef327629-9831-4a0c-bd61-7542b0713ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef327629-9831-4a0c-bd61-7542b0713ea8.jpg?1",
             "name": "Hatching Plans",
             "text": "When Hatching Plans is put into a graveyard from play, draw three cards.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "daedfc74-ddee-5044-b0b9-c7ff24fa6a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63a62b7-7c66-422d-8588-d48ec49de127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63a62b7-7c66-422d-8588-d48ec49de127.jpg?1",
             "name": "Infiltrator's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1 and can't be blocked except by creatures with defender.",
             "colours": [
@@ -985,7 +985,7 @@
         },
         {
             "id": "ca3438f0-4813-5158-939e-c8273ade1295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40d7e5c-3b6d-4e42-b495-b3cd7ae0d808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40d7e5c-3b6d-4e42-b495-b3cd7ae0d808.jpg?1",
             "name": "Leyline of Singularity",
             "text": "If Leyline of Singularity is in your opening hand, you may begin the game with it in play.\nAll nonland permanents are legendary.",
             "colours": [
@@ -1017,7 +1017,7 @@
         },
         {
             "id": "4dedf69b-dd50-56b8-abf9-7ee1d03c4ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ada33a-5b7c-426a-8416-4ce01bccaa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ada33a-5b7c-426a-8416-4ce01bccaa5c.jpg?1",
             "name": "Mimeofacture",
             "text": "Replicate {3}{U} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nChoose target permanent an opponent controls. Search that player's library for a card with the same name and put it into play under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "a6eafdd0-e651-5ce9-ba74-8ce6677dba61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a276b12-4647-4223-b89e-f55d72feb2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a276b12-4647-4223-b89e-f55d72feb2d0.jpg?1",
             "name": "Quicken",
             "text": "The next sorcery spell you play this turn can be played any time you could play an instant.\nDraw a card.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "502d49cf-e97b-5ee8-9354-5857583f68a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "b49192ce-ad47-52d1-a30b-e39d8a091ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2fb23-f8b5-4f83-9b29-b18507acaa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2fb23-f8b5-4f83-9b29-b18507acaa1a.jpg?1",
             "name": "Runeboggle",
             "text": "Counter target spell unless its controller pays {1}.\nDraw a card.",
             "colours": [
@@ -1145,7 +1145,7 @@
         },
         {
             "id": "cd9e2261-be3e-5a88-ab00-c98f9ef9ea7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05189964-5ad0-48b7-a3af-67c7f46fe89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05189964-5ad0-48b7-a3af-67c7f46fe89e.jpg?1",
             "name": "Sky Swallower",
             "text": "Flying\nWhen Sky Swallower comes into play, target opponent gains control of all other permanents you control.",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "dad8e5f0-d2a2-5220-a52d-644f61dca6bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3992f-f874-448f-8aa4-ade71d6b3168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3992f-f874-448f-8aa4-ade71d6b3168.jpg?1",
             "name": "Steamcore Weird",
             "text": "When Steamcore Weird comes into play, if {R} was spent to play Steamcore Weird, it deals 2 damage to target creature or player.",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "5ea50acf-b1b6-5e4e-b336-b3faae93456d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc49d-2a07-4088-a288-ba7be4da7bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc49d-2a07-4088-a288-ba7be4da7bc2.jpg?1",
             "name": "Stratozeppelid",
             "text": "Flying\nStratozeppelid can block only creatures with flying.",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "07d0a735-dec4-5b23-a5d5-6b9f0d7a9625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56de9727-021e-4b37-b80b-08dcd898aec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56de9727-021e-4b37-b80b-08dcd898aec0.jpg?1",
             "name": "Thunderheads",
             "text": "Replicate {2}{U} (When you play this spell, copy it for each time you paid its replicate cost.)\nPut a 3/3 blue Weird creature token with defender and flying into play. Remove it from the game at end of turn.",
             "colours": [
@@ -1280,7 +1280,7 @@
         },
         {
             "id": "596dfede-3094-5591-a391-3646cdce006f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beff896-df7a-42b3-aaca-0b9ca1b8cf0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beff896-df7a-42b3-aaca-0b9ca1b8cf0c.jpg?1",
             "name": "Torch Drake",
             "text": "Flying\n{1}{R}: Torch Drake gets +1/+0 until end of turn.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "ae50ac73-4997-5754-8ad0-fa3d0f84c11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98f5890-a494-4609-acae-f9e9bacd991d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98f5890-a494-4609-acae-f9e9bacd991d.jpg?1",
             "name": "Train of Thought",
             "text": "Replicate {1}{U} (When you play this spell, copy it for each time you paid its replicate cost.)\nDraw a card.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "3c2cce49-3aae-5ca9-b492-d7399588319a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870cdf0b-f707-47b9-b977-f06dad8c345a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870cdf0b-f707-47b9-b977-f06dad8c345a.jpg?1",
             "name": "Vacuumelt",
             "text": "Replicate {2}{U} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nReturn target creature to its owner's hand.",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "a1bab7ba-6731-54f5-8a3c-b2029f97d5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a886154e-1b49-471c-9432-cf44a3b3c9f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a886154e-1b49-471c-9432-cf44a3b3c9f4.jpg?1",
             "name": "Vedalken Plotter",
             "text": "When Vedalken Plotter comes into play, exchange control of target land you control and target land an opponent controls.",
             "colours": [
@@ -1414,7 +1414,7 @@
         },
         {
             "id": "0415a68c-b771-55cf-a190-1ae3fcab38e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bdfb7d-029d-4a70-8ae3-ef9a27e729c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bdfb7d-029d-4a70-8ae3-ef9a27e729c3.jpg?1",
             "name": "Vertigo Spawn",
             "text": "Defender (This creature can't attack.)\nWhenever Vertigo Spawn blocks a creature, tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1448,7 +1448,7 @@
         },
         {
             "id": "bb5f1e38-2202-560c-bdb1-58355ec16e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe094903-45a6-4b11-b80e-aabe915c4b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe094903-45a6-4b11-b80e-aabe915c4b7c.jpg?1",
             "name": "Abyssal Nocturnus",
             "text": "Whenever an opponent discards a card, Abyssal Nocturnus gets +2/+2 and gains fear until end of turn.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "2b60038e-f193-5eca-a7ed-adb9e747e7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fde21d-ce4e-41b7-97d5-c982f90b84a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fde21d-ce4e-41b7-97d5-c982f90b84a0.jpg?1",
             "name": "Caustic Rain",
             "text": "Remove target land from the game.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "e2e07256-c340-5441-9fc1-17f228252d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a9ce8f-df8a-44bc-8d34-9f42135a3a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a9ce8f-df8a-44bc-8d34-9f42135a3a23.jpg?1",
             "name": "Cremate",
             "text": "Remove target card in a graveyard from the game.\nDraw a card.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "ca1de59b-92a0-5bd3-bd26-f42070dadeb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62016f24-3f40-406b-8e29-30a6545d0fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62016f24-3f40-406b-8e29-30a6545d0fc1.jpg?1",
             "name": "Cry of Contrition",
             "text": "Target player discards a card.\nHaunt (When this spell card is put into a graveyard after resolving, remove it from the game haunting target creature.)\nWhen the creature Cry of Contrition haunts is put into a graveyard, target player discards a card.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "1b7ffe80-d3d7-51c0-9bce-6732aefdec26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13337c99-7d9e-4464-905b-87e8deb072ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13337c99-7d9e-4464-905b-87e8deb072ac.jpg?1",
             "name": "Cryptwailing",
             "text": "{1}, Remove two creature cards in your graveyard from the game: Target player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "e50832b9-ecbc-5029-87c7-8f58347e04ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d285981-f342-4679-a199-cf5d003407e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d285981-f342-4679-a199-cf5d003407e8.jpg?1",
             "name": "Daggerclaw Imp",
             "text": "Flying\nDaggerclaw Imp can't block.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "aa23243e-9291-5e49-b563-08dd6cf06a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a4fe4d-460d-4143-9a8e-14e16b211722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a4fe4d-460d-4143-9a8e-14e16b211722.jpg?1",
             "name": "Douse in Gloom",
             "text": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "1fe12d9b-ae43-5e03-b19b-c12becd817db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c53fda-3768-4cc5-8ca3-a60805c340ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c53fda-3768-4cc5-8ca3-a60805c340ba.jpg?1",
             "name": "Exhumer Thrull",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Exhumer Thrull comes into play or the creature it haunts is put into a graveyard, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "685cec7e-ebe7-5d34-8f25-57472e68e835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f394fd39-842f-4c98-b857-bdad3fd09758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f394fd39-842f-4c98-b857-bdad3fd09758.jpg?1",
             "name": "Hissing Miasma",
             "text": "Whenever a creature attacks you, its controller loses 1 life.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "e12f3df4-ed41-5dd6-be00-f1bc55373f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dfe8b8-b39e-4e70-9e5b-be42c93b4f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dfe8b8-b39e-4e70-9e5b-be42c93b4f70.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it in play.\nIf a card would be put into an opponent's graveyard, remove it from the game instead.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "e2f15d1c-6f14-567f-8899-93198274aad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b045121-7742-41ee-be27-591692f42331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b045121-7742-41ee-be27-591692f42331.jpg?1",
             "name": "Necromancer's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1.\nIf a creature you control that's enchanted would be put into a graveyard, return it to its owner's hand instead.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "5ed86732-f511-5046-abf9-cd0080759bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104adc35-69fb-4b63-9b03-a71097e15652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104adc35-69fb-4b63-9b03-a71097e15652.jpg?1",
             "name": "Orzhov Euthanist",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Orzhov Euthanist comes into play or the creature it haunts is put into a graveyard, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -1843,7 +1843,7 @@
         },
         {
             "id": "068275d5-00e8-5201-9a91-5d83f6d1b95b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26407330-d7a1-4915-b7c6-e08e166cf638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26407330-d7a1-4915-b7c6-e08e166cf638.jpg?1",
             "name": "Ostiary Thrull",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "a6f15e04-b517-5b04-b132-611e0ad9e11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd84bbb3-8b99-4e6d-b514-b094ec93eaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd84bbb3-8b99-4e6d-b514-b094ec93eaa0.jpg?1",
             "name": "Plagued Rusalka",
             "text": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -1912,7 +1912,7 @@
         },
         {
             "id": "9eaf5922-d5d7-5abe-a854-f60feac1c1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a168b953-eac4-472e-ac74-598febb05f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a168b953-eac4-472e-ac74-598febb05f83.jpg?1",
             "name": "Poisonbelly Ogre",
             "text": "Whenever another creature comes into play, its controller loses 1 life.",
             "colours": [
@@ -1947,7 +1947,7 @@
         },
         {
             "id": "b90c96d3-ea53-599f-8fae-8064eefa92d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d11a4f2-376e-42ae-9693-9dc754bd2282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d11a4f2-376e-42ae-9693-9dc754bd2282.jpg?1",
             "name": "Restless Bones",
             "text": "{3}{B}, {T}: Target creature gains swampwalk until end of turn.\n{1}{B}: Regenerate Restless Bones.",
             "colours": [
@@ -1981,7 +1981,7 @@
         },
         {
             "id": "c97a4b55-d3e2-54a4-9c45-7aaefab7b568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71b7b73-567a-4291-bf60-f17c1fe55de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71b7b73-567a-4291-bf60-f17c1fe55de6.jpg?1",
             "name": "Revenant Patriarch",
             "text": "When Revenant Patriarch comes into play, if {W} was spent to play Revenant Patriarch, target player skips his or her next combat phase.\nRevenant Patriarch can't block.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "f9bd30f2-53ce-5d30-9448-6595e506aff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8291b1a9-2d04-4dd7-b8c5-3b1018aa0d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8291b1a9-2d04-4dd7-b8c5-3b1018aa0d2f.jpg?1",
             "name": "Sanguine Praetor",
             "text": "{B}, Sacrifice a creature: Destroy each creature with the same converted mana cost as the sacrificed creature.",
             "colours": [
@@ -2051,7 +2051,7 @@
         },
         {
             "id": "e4a48c95-dde7-57e1-8d5b-2b002048b412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bf245f-e8e0-4d32-8cd7-06d832609910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bf245f-e8e0-4d32-8cd7-06d832609910.jpg?1",
             "name": "Seize the Soul",
             "text": "Destroy target nonwhite nonblack creature. Put a 1/1 white Spirit creature token with flying into play.\nHaunt\nWhen the creature Seize the Soul haunts is put into a graveyard, destroy target nonwhite nonblack creature. Put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -2083,7 +2083,7 @@
         },
         {
             "id": "84e03c6b-5559-5260-92e4-7481b4e6e039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69251d44-3038-4b64-ab78-fc87f0406ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69251d44-3038-4b64-ab78-fc87f0406ba2.jpg?1",
             "name": "Skeletal Vampire",
             "text": "Flying\nWhen Skeletal Vampire comes into play, put two 1/1 black Bat creature tokens with flying into play.\n{3}{B}{B}, Sacrifice a Bat: Put two 1/1 black Bat creature tokens with flying into play.\nSacrifice a Bat: Regenerate Skeletal Vampire.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "ce86cac0-64f2-596f-bd2d-ff24983cfe20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2b2bf-92bc-4362-b232-8a403b9a7ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2b2bf-92bc-4362-b232-8a403b9a7ade.jpg?1",
             "name": "Smogsteed Rider",
             "text": "Whenever Smogsteed Rider attacks, each other attacking creature gains fear until end of turn.",
             "colours": [
@@ -2153,7 +2153,7 @@
         },
         {
             "id": "60552cfd-3d39-5837-82e2-0a09262225c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8197cc43-c787-4372-81dc-759a9fe24708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8197cc43-c787-4372-81dc-759a9fe24708.jpg?1",
             "name": "Bloodscale Prowler",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "81e40627-4ea8-508b-a2d2-c0c651226cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a33fb-8b36-4dad-9eef-e0e601723f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a33fb-8b36-4dad-9eef-e0e601723f78.jpg?1",
             "name": "Fencer's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1 and have first strike.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "443472f7-9618-59a1-bfb5-6bfbc42a441f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cab68b-ee26-46eb-a18b-9b42bf2d10e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cab68b-ee26-46eb-a18b-9b42bf2d10e5.jpg?1",
             "name": "Ghor-Clan Bloodscale",
             "text": "First strike\n{3}{G}: Ghor-Clan Bloodscale gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "2e42ef0e-a406-5f8b-a6ea-34ddf2f17ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaa3c6e-1f8a-4580-8e03-e670f50ab958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaa3c6e-1f8a-4580-8e03-e670f50ab958.jpg?1",
             "name": "Hypervolt Grasp",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target creature or player.\"\n{1}{U}: Return Hypervolt Grasp to its owner's hand.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "c17c547a-7e96-59ad-b6ea-d17cbe2a62a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d09839-b41e-4aab-8913-40d63052dbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d09839-b41e-4aab-8913-40d63052dbf3.jpg?1",
             "name": "Leyline of Lightning",
             "text": "If Leyline of Lightning is in your opening hand, you may begin the game with it in play.\nWhenever you play a spell, you may pay {1}. If you do, Leyline of Lightning deals 1 damage to target player.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "8f974e95-3ad8-5035-ada0-63c84fa9d90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b8143-2742-4262-b18f-2825bf8cea6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b8143-2742-4262-b18f-2825bf8cea6f.jpg?1",
             "name": "Living Inferno",
             "text": "{T}: Living Inferno deals damage equal to its power divided as you choose among any number of target creatures. Each of those creatures deals damage equal to its power to Living Inferno.",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "974941bb-c9fe-5e34-8441-16641c720f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7448ed3-8720-4098-a3dd-9151ba10bb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7448ed3-8720-4098-a3dd-9151ba10bb49.jpg?1",
             "name": "Ogre Savant",
             "text": "When Ogre Savant comes into play, if {U} was spent to play Ogre Savant, return target creature to its owner's hand.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "32bc1e9b-ff2d-5c4e-b466-1548f4cbbaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891f1d29-377a-4f71-917f-ff10e785caee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891f1d29-377a-4f71-917f-ff10e785caee.jpg?1",
             "name": "Parallectric Feedback",
             "text": "Parallectric Feedback deals damage to target spell's controller equal to that spell's converted mana cost.",
             "colours": [
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "76a8e95d-0c84-504a-93ff-4e32885c9689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c9dab-e8d5-48b3-8fd2-9f4138ee0c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c9dab-e8d5-48b3-8fd2-9f4138ee0c7c.jpg?1",
             "name": "Pyromatics",
             "text": "Replicate {1}{R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nPyromatics deals 1 damage to target creature or player.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "0fdfff6f-e68c-552c-bccb-eaa4e92e7748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6877862-f7c5-493d-baaf-41a91d4c7982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6877862-f7c5-493d-baaf-41a91d4c7982.jpg?1",
             "name": "Rabble-Rouser",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\n{R}, {T}: Attacking creatures get +X/+0 until end of turn, where X is Rabble-Rouser's power.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "c9ff9d01-0219-57e3-ac7b-198992f40cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f955164-ddb8-484c-a063-967621abce87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f955164-ddb8-484c-a063-967621abce87.jpg?1",
             "name": "Scorched Rusalka",
             "text": "{R}, Sacrifice a creature: Scorched Rusalka deals 1 damage to target player.",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "cdaeafb3-30c8-5610-8c2d-292d727cd1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dcff21-5900-43c4-a38b-cdc19c704ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dcff21-5900-43c4-a38b-cdc19c704ce4.jpg?1",
             "name": "Shattering Spree",
             "text": "Replicate {R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nDestroy target artifact.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "f285d140-c30a-5c72-9ac7-db059dabc996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db24da9-8901-4e2d-9565-39ce1b7639c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db24da9-8901-4e2d-9565-39ce1b7639c9.jpg?1",
             "name": "Siege of Towers",
             "text": "Replicate {1}{R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTarget Mountain becomes a 3/1 creature. It's still a land.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "7759e457-8103-5096-b3bf-5b67400dab6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c51e46-3236-41ee-913e-f253f218067c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c51e46-3236-41ee-913e-f253f218067c.jpg?1",
             "name": "Skarrgan Firebird",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature comes into play with three +1/+1 counters on it.)\nFlying\n{R}{R}{R}: Return Skarrgan Firebird from your graveyard to your hand. Play this ability only if an opponent was dealt damage this turn.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "40838d00-89c9-5c49-a1f8-d136d1be49f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad525bb3-15fd-4887-a3e7-0a036258dcc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad525bb3-15fd-4887-a3e7-0a036258dcc7.jpg?1",
             "name": "Tin Street Hooligan",
             "text": "When Tin Street Hooligan comes into play, if {G} was spent to play Tin Street Hooligan, destroy target artifact.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "cb6eecca-1b15-5b24-a397-2c56c2d47ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0fb683-2e9b-465c-9fb5-2eb334c2739a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0fb683-2e9b-465c-9fb5-2eb334c2739a.jpg?1",
             "name": "Battering Wurm",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nCreatures with power less than Battering Wurm's power can't block it.",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "159bfb6b-9da4-5820-ada5-337e7653e1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5eea61-373a-4bca-a793-d6be7f6214e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5eea61-373a-4bca-a793-d6be7f6214e2.jpg?1",
             "name": "Beastmaster's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1.\nWhenever a creature you control that's enchanted becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -2730,7 +2730,7 @@
         },
         {
             "id": "8cf4932f-f361-53f8-ae40-5e4745a99740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7170a1db-3502-4caf-a54b-bd0df0d93f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7170a1db-3502-4caf-a54b-bd0df0d93f2d.jpg?1",
             "name": "Bioplasm",
             "text": "Whenever Bioplasm attacks, remove the top card of your library from the game. If it's a creature card, Bioplasm gets +X/+Y until end of turn, where X is the removed creature card's power and Y is its toughness. (A * on a card not in play is 0.)",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "5d17aaf5-e7b5-59e6-8dfe-17010302eee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8683546-85b7-4658-91be-91ef65fb3fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8683546-85b7-4658-91be-91ef65fb3fc3.jpg?1",
             "name": "Crash Landing",
             "text": "Target creature with flying loses flying until end of turn. Crash Landing deals damage to that creature equal to the number of Forests you control.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "416056ec-a5d4-5f3a-b476-92d6146c6df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bf5ce-f7f8-47cb-abb8-f14ce5f1af67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bf5ce-f7f8-47cb-abb8-f14ce5f1af67.jpg?1",
             "name": "Dryad Sophisticate",
             "text": "Nonbasic landwalk",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "72336841-4d42-5e0a-9b3b-78516ce38687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325503ee-ea62-459b-a58a-53fb3c1ef027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325503ee-ea62-459b-a58a-53fb3c1ef027.jpg?1",
             "name": "Earth Surge",
             "text": "Each land gets +2/+2 as long as it's a creature.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "5bbf705e-d900-5c3a-a724-db0934ff9e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d75367-88e7-44e6-9234-590dc143fd1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d75367-88e7-44e6-9234-590dc143fd1d.jpg?1",
             "name": "Gatherer of Graces",
             "text": "Gatherer of Graces gets +1/+1 for each Aura attached to it.\nSacrifice an Aura: Regenerate Gatherer of Graces.",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "fd821b70-252b-5616-a04b-5d3d8d4d3797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77ad353-7543-4d65-bf02-33f66abaf14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77ad353-7543-4d65-bf02-33f66abaf14b.jpg?1",
             "name": "Ghor-Clan Savage",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature comes into play with three +1/+1 counters on it.)",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "7cab5209-00d4-510b-806c-e11c81de715d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82f763a-c960-4b59-8c77-f3bea7bd8c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82f763a-c960-4b59-8c77-f3bea7bd8c8b.jpg?1",
             "name": "Gristleback",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nSacrifice Gristleback: You gain life equal to Gristleback's power.",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "54c31f5e-b954-5f10-a836-3f25b95d7189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9855ce83-ae26-4b1d-ab7f-637cde09d679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9855ce83-ae26-4b1d-ab7f-637cde09d679.jpg?1",
             "name": "Gruul Nodorog",
             "text": "{R}: Gruul Nodorog can't be blocked this turn except by two or more creatures.",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "7738a7d0-7640-54ef-9957-1f1a5dc21210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3fdc0-3fd1-47da-b3ed-e4a462179e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3fdc0-3fd1-47da-b3ed-e4a462179e75.jpg?1",
             "name": "Gruul Scrapper",
             "text": "When Gruul Scrapper comes into play, if {R} was spent to play Gruul Scrapper, it gains haste until end of turn.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "f29a7a09-9114-5047-8560-5f1ddf215893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7caffa7-29bd-455c-9770-94a0ad7ef5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7caffa7-29bd-455c-9770-94a0ad7ef5e3.jpg?1",
             "name": "Leyline of Lifeforce",
             "text": "If Leyline of Lifeforce is in your opening hand, you may begin the game with it in play.\nCreature spells can't be countered.",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "47b754c9-8b07-5e22-9116-109c70f6135e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56fbf32-f08f-4882-b8d4-41ccb60cba63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56fbf32-f08f-4882-b8d4-41ccb60cba63.jpg?1",
             "name": "Petrified Wood-Kin",
             "text": "Petrified Wood-Kin can't be countered.\nBloodthirst X (This creature comes into play with X +1/+1 counters on it, where X is the damage dealt to your opponents this turn.)\nProtection from instants",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "02060fb0-0d17-5a54-92b2-17f457e3c3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fc1314-4bf2-44f2-a016-58765eb04607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fc1314-4bf2-44f2-a016-58765eb04607.jpg?1",
             "name": "Predatory Focus",
             "text": "You may have creatures you control deal their combat damage to defending player this turn as though they weren't blocked.",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "9b8e2b86-e932-5fbf-8157-391f28d0f1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293ce819-c228-4ff1-827c-3d0cbed703ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293ce819-c228-4ff1-827c-3d0cbed703ea.jpg?1",
             "name": "Primeval Light",
             "text": "Destroy all enchantments target player controls.",
             "colours": [
@@ -3169,7 +3169,7 @@
         },
         {
             "id": "4e78fc54-dd05-5750-b431-dba0a4837a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c921343a-4496-4e21-a0ff-e04a1fb407bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c921343a-4496-4e21-a0ff-e04a1fb407bf.jpg?1",
             "name": "Silhana Ledgewalker",
             "text": "Silhana Ledgewalker can't be blocked except by creatures with flying.\nSilhana Ledgewalker can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "58db6478-6a0e-5201-84ea-04bff70a16af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9c7e09-8384-4866-af92-ba56bd307d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9c7e09-8384-4866-af92-ba56bd307d9c.jpg?1",
             "name": "Silhana Starfletcher",
             "text": "As Silhana Starfletcher comes into play, choose a color.\n{T}: Add one mana of the chosen color to your mana pool.\nSilhana Starfletcher can block as though it had flying.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "7c1c2db3-5914-5581-a475-d355d18e537c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc65d7ea-e8f4-4be9-94e4-2fa2e4d83177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc65d7ea-e8f4-4be9-94e4-2fa2e4d83177.jpg?1",
             "name": "Skarrgan Pit-Skulk",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nCreatures with power less than Skarrgan Pit-Skulk's power can't block it.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "f23adea7-9b35-53c7-b10f-36250b6e7343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b4aec5-0a7d-4b1c-8819-ea675d415eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b4aec5-0a7d-4b1c-8819-ea675d415eac.jpg?1",
             "name": "Starved Rusalka",
             "text": "{G}, Sacrifice a creature: You gain 1 life.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "ff8d0ab7-d985-5439-9bb3-e66895719a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef061ed-736c-41ba-b692-d1fbfaca242e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef061ed-736c-41ba-b692-d1fbfaca242e.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "49017e63-cd08-5658-ba92-51d66428a87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661580bc-b5e5-48ce-b855-c177f1c61742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661580bc-b5e5-48ce-b855-c177f1c61742.jpg?1",
             "name": "Wurmweaver Coil",
             "text": "Enchant green creature\nEnchanted creature gets +6/+6.\n{G}{G}{G}, Sacrifice Wurmweaver Coil: Put a 6/6 green Wurm creature token into play.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "09fc1989-e64c-57de-ac03-4cb9af7f3039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9b0ab4-5c6b-494d-926d-daa38a3ac640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9b0ab4-5c6b-494d-926d-daa38a3ac640.jpg?1",
             "name": "Agent of Masks",
             "text": "At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3412,7 +3412,7 @@
         },
         {
             "id": "115a644d-3b60-504d-8efe-35342b58fe9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae71424-df9c-481c-9305-a0c30adcfda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae71424-df9c-481c-9305-a0c30adcfda2.jpg?1",
             "name": "Angel of Despair",
             "text": "Flying\nWhen Angel of Despair comes into play, destroy target permanent.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "73a116cc-b5ca-5151-9f72-26afde63c0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c8995-be36-43f6-9bd7-7b8712894331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c8995-be36-43f6-9bd7-7b8712894331.jpg?1",
             "name": "Blind Hunter",
             "text": "Flying\nHaunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Blind Hunter comes into play or the creature it haunts is put into a graveyard, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "60aa0732-a2a4-55e2-98be-ea515159aa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4a08e9-06c7-43e9-a855-4f507a35ae8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4a08e9-06c7-43e9-a855-4f507a35ae8b.jpg?1",
             "name": "Borborygmos",
             "text": "Trample\nWhenever Borborygmos deals combat damage to a player, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "d48230ff-79b5-5036-ac75-5f537381d496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6492648-8115-41ff-a184-08efebae28b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6492648-8115-41ff-a184-08efebae28b1.jpg?1",
             "name": "Burning-Tree Bloodscale",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\n{2}{R}: Target creature can't block Burning-Tree Bloodscale this turn.\n{2}{G}: Target creature blocks Burning-Tree Bloodscale this turn if able.",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "32af7bc3-fd5e-538e-a398-a5ca566cb126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133863fc-e820-4be6-a354-a02e7fe25eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133863fc-e820-4be6-a354-a02e7fe25eae.jpg?1",
             "name": "Burning-Tree Shaman",
             "text": "Whenever a player plays an activated ability that isn't a mana ability, Burning-Tree Shaman deals 1 damage to that player.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "dab0fb50-bd56-5daf-aed5-80d52d060c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112c47e4-5ff8-4ea0-ac14-956e4b94119a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112c47e4-5ff8-4ea0-ac14-956e4b94119a.jpg?1",
             "name": "Castigate",
             "text": "Target opponent reveals his or her hand. Choose a nonland card from it. Remove that card from the game.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "f2098da5-ea37-5729-bcf0-fef5427ab070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779cdad3-9d90-4de1-8071-f772fb85142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779cdad3-9d90-4de1-8071-f772fb85142b.jpg?1",
             "name": "Cerebral Vortex",
             "text": "Target player draws two cards, then Cerebral Vortex deals damage to that player equal to the number of cards he or she has drawn this turn.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "9fc10ab3-9607-5166-b0b9-11d4117d6b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39849576-b58f-45f0-ad33-a9bf2135d9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39849576-b58f-45f0-ad33-a9bf2135d9b7.jpg?1",
             "name": "Conjurer's Ban",
             "text": "Name a card. Until your next turn, the named card can't be played.\nDraw a card.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "c3f254ed-45ba-58b5-8079-ee425eae4e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec5a956-c846-46b6-91bd-37e4db542280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec5a956-c846-46b6-91bd-37e4db542280.jpg?1",
             "name": "Culling Sun",
             "text": "Destroy each creature with converted mana cost 3 or less.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "b999b6e3-d057-58b0-a619-52ca67546198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b4ee44-28c4-4a39-9c06-aca43787954f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b4ee44-28c4-4a39-9c06-aca43787954f.jpg?1",
             "name": "Dune-Brood Nephilim",
             "text": "Whenever Dune-Brood Nephilim deals combat damage to a player, put a 1/1 colorless Sand creature token into play for each land you control.",
             "colours": [
@@ -3772,7 +3772,7 @@
         },
         {
             "id": "2004a702-ab54-5f27-ab12-f6a110038618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among any number of target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "59035d42-c920-5a08-8b43-e3457d1decfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad65c721-b601-46f9-ba0b-ac4d96567cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad65c721-b601-46f9-ba0b-ac4d96567cee.jpg?1",
             "name": "Feral Animist",
             "text": "{3}: Feral Animist gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "b2b15520-5c47-5b1a-93ef-9c799d2e3d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa9c4a-7027-4ddd-93e0-3c5dcaa8e48b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa9c4a-7027-4ddd-93e0-3c5dcaa8e48b.jpg?1",
             "name": "Gelectrode",
             "text": "{T}: Gelectrode deals 1 damage to target creature or player.\nWhenever you play an instant or sorcery spell, you may untap Gelectrode.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "6d6f471c-3a46-5ca1-aaa1-6b16258a6e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83a5785-a9a9-4a07-82c7-97dc5b9a2475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83a5785-a9a9-4a07-82c7-97dc5b9a2475.jpg?1",
             "name": "Ghost Council of Orzhova",
             "text": "When Ghost Council of Orzhova comes into play, target opponent loses 1 life and you gain 1 life.\n{1}, Sacrifice a creature: Remove Ghost Council of Orzhova from the game. Return it to play under its owner's control at end of turn.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "f76d698e-ea6e-5480-89e4-7610aa71bc17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc68fa-d6cf-4f6d-8f44-4d62c9cdd5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc68fa-d6cf-4f6d-8f44-4d62c9cdd5c3.jpg?1",
             "name": "Glint-Eye Nephilim",
             "text": "Whenever Glint-Eye Nephilim deals combat damage to a player, draw that many cards.\n{1}, Discard a card: Glint-Eye Nephilim gets +1/+1 until end of turn.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "677cc272-f243-5213-94c9-569875d827e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8170c05b-826c-4879-b202-29eec6f955ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8170c05b-826c-4879-b202-29eec6f955ea.jpg?1",
             "name": "Goblin Flectomancer",
             "text": "Sacrifice Goblin Flectomancer: You may change the targets of target instant or sorcery spell.",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "631432fa-43bb-5de3-a871-5a0a8807e736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29bb432-1ca6-4305-b6d3-d7afe06c6c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29bb432-1ca6-4305-b6d3-d7afe06c6c69.jpg?1",
             "name": "Ink-Treader Nephilim",
             "text": "Whenever a player plays an instant or sorcery spell, if Ink-Treader Nephilim is the only target of that spell, copy the spell for each other creature that spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "dfd6c1ed-e149-5975-80cf-7fd8be1fdd45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8e41a-5990-4ceb-9d41-76632faa7883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8e41a-5990-4ceb-9d41-76632faa7883.jpg?1",
             "name": "Invoke the Firemind",
             "text": "Choose one Draw X cards; or Invoke the Firemind deals X damage to target creature or player.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "edc9a91c-7bef-5722-8793-1b78cf0769ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg?1",
             "name": "Izzet Chronarch",
             "text": "When Izzet Chronarch comes into play, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "17c83766-c757-5655-b60e-780df43ea428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c808a8ec-895c-4777-9e11-e83ce34eddef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c808a8ec-895c-4777-9e11-e83ce34eddef.jpg?1",
             "name": "Killer Instinct",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card, put it into play. That creature gains haste until end of turn. Sacrifice it at end of turn.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "0943d268-b6ad-59d8-8c9f-0b8a725de477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c011b432-ec39-44c8-bf2a-1c3fec32a576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c011b432-ec39-44c8-bf2a-1c3fec32a576.jpg?1",
             "name": "Leap of Flame",
             "text": "Replicate {U}{R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTarget creature gets +1/+0 and gains flying and first strike until end of turn.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "60856fe2-e02d-58a8-a8e7-67aa146f5dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2c5187-71c7-4801-8a76-339c67322d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2c5187-71c7-4801-8a76-339c67322d35.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "cebab560-850d-5078-91db-1ea78906d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994d98a-090b-4203-b44f-b6517b6a83ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994d98a-090b-4203-b44f-b6517b6a83ea.jpg?1",
             "name": "Niv-Mizzet, the Firemind",
             "text": "Flying\nWhenever you draw a card, Niv-Mizzet, the Firemind deals 1 damage to target creature or player.\n{T}: Draw a card.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "05bda4b6-4705-5283-bc40-59221482c032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b5813b-955b-469a-b287-65325c589b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b5813b-955b-469a-b287-65325c589b59.jpg?1",
             "name": "Orzhov Pontiff",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Orzhov Pontiff comes into play or the creature it haunts is put into a graveyard, choose one creatures you control get +1/+1 until end of turn; or creatures you don't control get -1/-1 until end of turn.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "589d1006-c5bb-546b-a3da-52eb25fc7772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36964bbd-f068-4a69-8d6b-7e4e97938b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36964bbd-f068-4a69-8d6b-7e4e97938b98.jpg?1",
             "name": "Pillory of the Sleepless",
             "text": "",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "193ebeb2-5bc7-51b6-843b-8535ad32ea03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d891c5c2-55d4-43a9-a56b-a92166fd41b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d891c5c2-55d4-43a9-a56b-a92166fd41b8.jpg?1",
             "name": "Rumbling Slum",
             "text": "At the beginning of your upkeep, Rumbling Slum deals 1 damage to each player.",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "aeee755e-54a0-5f62-9bd8-b3fc6601983f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ee5a9-2995-4868-b7ea-8735b2aee77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ee5a9-2995-4868-b7ea-8735b2aee77e.jpg?1",
             "name": "Savage Twister",
             "text": "Savage Twister deals X damage to each creature.",
             "colours": [
@@ -4389,7 +4389,7 @@
         },
         {
             "id": "31bc27e8-ccc3-573f-84e7-6c9efa4aa33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e040a6-9e10-4528-8ee1-ef3a00e93cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e040a6-9e10-4528-8ee1-ef3a00e93cbc.jpg?1",
             "name": "Scab-Clan Mauler",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature comes into play with two +1/+1 counters on it.)\nTrample",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "cd726636-dba3-514b-8bc7-fe49b491de9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98510af3-a884-417a-8cd9-991890d42919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98510af3-a884-417a-8cd9-991890d42919.jpg?1",
             "name": "Schismotivate",
             "text": "Target creature gets +4/+0 until end of turn. Another target creature gets -4/-0 until end of turn.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "7b750d23-1fdb-5b95-bd0b-6ad7da290219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d24d84e-09ec-4300-914b-1a540e300692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d24d84e-09ec-4300-914b-1a540e300692.jpg?1",
             "name": "Skarrgan Skybreaker",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature comes into play with three +1/+1 counters on it.)\n{1}, Sacrifice Skarrgan Skybreaker: Skarrgan Skybreaker deals damage equal to its power to target creature or player.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "9d7325a6-7c6e-5d96-af7c-ad373770e411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f02a09-e959-438c-ab48-abd34b10d07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f02a09-e959-438c-ab48-abd34b10d07c.jpg?1",
             "name": "Souls of the Faultless",
             "text": "Defender (This creature can't attack.)\nWhenever Souls of the Faultless is dealt combat damage, you gain that much life and attacking player loses that much life.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "94523aba-1f04-5653-88fc-7b47f0139bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ee9c0d-c0ac-4c75-b254-77329dc42366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ee9c0d-c0ac-4c75-b254-77329dc42366.jpg?1",
             "name": "Stitch in Time",
             "text": "Flip a coin. If you win the flip, take an extra turn after this one.",
             "colours": [
@@ -4567,7 +4567,7 @@
         },
         {
             "id": "01837939-d874-57cd-bf7c-30f71ab6f933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5313054-91a5-401c-84d1-03a2cd265060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5313054-91a5-401c-84d1-03a2cd265060.jpg?1",
             "name": "Streetbreaker Wurm",
             "text": "",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "95b2c44e-8659-54c9-b255-82034154977f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb856e6-8f63-4048-9818-cc3e65748855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb856e6-8f63-4048-9818-cc3e65748855.jpg?1",
             "name": "Teysa, Orzhov Scion",
             "text": "Sacrifice three white creatures: Remove target creature from the game.\nWhenever another black creature you control is put into a graveyard from play, put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "a845ec00-f711-596c-b5d7-b44dd4837b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149ce3cc-5df6-4158-b732-5bd2c1b3007f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149ce3cc-5df6-4158-b732-5bd2c1b3007f.jpg?1",
             "name": "Tibor and Lumia",
             "text": "Whenever you play a blue spell, target creature gains flying until end of turn.\nWhenever you play a red spell, Tibor and Lumia deals 1 damage to each creature without flying.",
             "colours": [
@@ -4681,7 +4681,7 @@
         },
         {
             "id": "841f5b2d-3e8e-5e26-9138-6d1d6d62b997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ba043a-d508-49dd-9bf3-a7ae8d26ac9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ba043a-d508-49dd-9bf3-a7ae8d26ac9b.jpg?1",
             "name": "Ulasht, the Hate Seed",
             "text": "Ulasht, the Hate Seed comes into play with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one Ulasht deals 1 damage to target creature; or put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "179815e0-d6c3-57a7-a603-12cee212d7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fd3734-8c28-4bd0-b202-eee1ab98c328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fd3734-8c28-4bd0-b202-eee1ab98c328.jpg?1",
             "name": "Wee Dragonauts",
             "text": "Flying\nWhenever you play an instant or sorcery spell, Wee Dragonauts gets +2/+0 until end of turn.",
             "colours": [
@@ -4757,7 +4757,7 @@
         },
         {
             "id": "25ef4d25-d1aa-5afd-8125-587d44dfb434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185d56ab-b7f2-4eb2-9540-db8f2dc9b436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185d56ab-b7f2-4eb2-9540-db8f2dc9b436.jpg?1",
             "name": "Witch-Maw Nephilim",
             "text": "Whenever you play a spell, you may put two +1/+1 counters on Witch-Maw Nephilim.\nWhenever Witch-Maw Nephilim attacks, it gains trample until end of turn if its power is 10 or greater.",
             "colours": [
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "324a1ced-9b04-5582-99e8-183cda1ea09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b44e5-0ad8-4487-a6e2-d43b123086ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b44e5-0ad8-4487-a6e2-d43b123086ab.jpg?1",
             "name": "Wreak Havoc",
             "text": "Wreak Havoc can't be countered by spells or abilities.\nDestroy target artifact or land.",
             "colours": [
@@ -4831,7 +4831,7 @@
         },
         {
             "id": "fb5e22ed-7232-5b85-8108-4c10b8269567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0247d76c-dee4-4d1b-9c25-faa56171541e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0247d76c-dee4-4d1b-9c25-faa56171541e.jpg?1",
             "name": "Yore-Tiller Nephilim",
             "text": "Whenever Yore-Tiller Nephilim attacks, return target creature card from your graveyard to play tapped and attacking.",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "68451ed9-c2df-505b-975f-f0696ea81e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a76c61-fd84-458d-9bc0-583768f4275a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a76c61-fd84-458d-9bc0-583768f4275a.jpg?1",
             "name": "Debtors' Knell",
             "text": "({WB} can be paid with either {W} or {B}.)\nAt the beginning of your upkeep, put target creature card in a graveyard into play under your control.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "7754b372-277d-5a0d-8d28-10b081e40812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc3bb4-657c-46fa-9ad5-c924fdaefc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc3bb4-657c-46fa-9ad5-c924fdaefc83.jpg?1",
             "name": "Djinn Illuminatus",
             "text": "({UR} can be paid with either {U} or {R}.)\nFlying\nEach instant and sorcery spell you play has replicate. The replicate cost is equal to its mana cost. (When you play it, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "c229ffc4-0155-57cd-acd4-9d4e4f6c1ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a83dbc9-802f-4ebf-93de-b2bf4844cc9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a83dbc9-802f-4ebf-93de-b2bf4844cc9e.jpg?1",
             "name": "Giant Solifuge",
             "text": "({RG} can be paid with either {R} or {G}.)\nTrample, haste\nGiant Solifuge can't be the target of spells or abilities.",
             "colours": [
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "92684e99-3d62-5e0e-8de8-ba1da3000514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a61f8-aab1-48d7-aebb-cf500ac5cb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a61f8-aab1-48d7-aebb-cf500ac5cb0e.jpg?1",
             "name": "Gruul Guildmage",
             "text": "({RG} can be paid with either {R} or {G}.)\n{3}{R}, Sacrifice a land: Gruul Guildmage deals 2 damage to target player.\n{3}{G}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "a34d5c92-b50e-5aa3-bb54-78d6e9dcf39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce6ade-8741-4567-8ed3-3e03becc6f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce6ade-8741-4567-8ed3-3e03becc6f1b.jpg?1",
             "name": "Izzet Guildmage",
             "text": "({UR} can be paid with either {U} or {R}.)\n{2}{U}: Copy target instant spell you control with converted mana cost 2 or less. You may choose new targets for the copy.\n{2}{R}: Copy target sorcery spell you control with converted mana cost 2 or less. You may choose new targets for the copy.",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "aefab0a2-652d-5b52-b5ab-7def35c9bab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a217a-e47b-4874-9861-bb57c7b1f06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a217a-e47b-4874-9861-bb57c7b1f06a.jpg?1",
             "name": "Mourning Thrull",
             "text": "({WB} can be paid with either {W} or {B}.)\nFlying\nWhenever Mourning Thrull deals damage, you gain that much life.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "84c61fa0-61de-5b76-9baf-945f4e741893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ae5b4-2caf-4992-b2c2-64f00e9e567a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ae5b4-2caf-4992-b2c2-64f00e9e567a.jpg?1",
             "name": "Orzhov Guildmage",
             "text": "({WB} can be paid with either {W} or {B}.)\n{2}{W}: Target player gains 1 life.\n{2}{B}: Each player loses 1 life.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "f6b3d2de-af5b-5d0e-b223-4bee0db7c1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b876fa0-4018-43a2-8911-e1525f95f09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b876fa0-4018-43a2-8911-e1525f95f09f.jpg?1",
             "name": "Petrahydrox",
             "text": "({UR} can be paid with either {U} or {R}.)\nWhen Petrahydrox becomes the target of a spell or ability, return Petrahydrox to its owner's hand.",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "38d7a715-9bad-50e6-87fc-7dabadb7182f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242dc29e-d8f5-4207-abbf-cf5425f08551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242dc29e-d8f5-4207-abbf-cf5425f08551.jpg?1",
             "name": "Wild Cantor",
             "text": "({RG} can be paid with either {R} or {G}.)\nSacrifice Wild Cantor: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5197,7 +5197,7 @@
         },
         {
             "id": "0296fa82-0eeb-5dba-9c92-242f146e35d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb30340-96a4-49d8-838b-8788900401a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb30340-96a4-49d8-838b-8788900401a0.jpg?1",
             "name": "Gruul Signet",
             "text": "{1}, {T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "2e9f4115-343e-5098-bcc6-e8aab9f725ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92efc66e-4112-413b-ae7c-85f270abc4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92efc66e-4112-413b-ae7c-85f270abc4ff.jpg?1",
             "name": "Gruul War Plow",
             "text": "Creatures you control have trample.\n{1}{R}{G}: Gruul War Plow becomes a 4/4 Juggernaut artifact creature until end of turn.",
             "colours": [],
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "a7bb91bf-0cb2-5f41-979a-b61a36452cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -5290,7 +5290,7 @@
         },
         {
             "id": "1d03635b-50b1-597c-9ff9-7d8f4f8c0250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29c3bf9-d37c-4e0a-ac44-15d47770ed44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29c3bf9-d37c-4e0a-ac44-15d47770ed44.jpg?1",
             "name": "Mizzium Transreliquat",
             "text": "{3}: Mizzium Transreliquat becomes a copy of target artifact until end of turn.\n{1}{U}{R}: Mizzium Transreliquat becomes a copy of target artifact and gains this ability.",
             "colours": [],
@@ -5321,7 +5321,7 @@
         },
         {
             "id": "12cad604-0e2b-5f21-bd0c-5de640f1bba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5529edfc-22bd-43dc-878b-6ec9fba74795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5529edfc-22bd-43dc-878b-6ec9fba74795.jpg?1",
             "name": "Moratorium Stone",
             "text": "{2}, {T}: Remove target card in a graveyard from the game.\n{2}{W}{B}, {T}, Sacrifice Moratorium Stone: Remove from the game target nonland card in a graveyard, all other cards in graveyards with the same name as that card, and all permanents with that name.",
             "colours": [],
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "6d5ca155-b8d7-50a2-962b-52cbc4e9dd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9298a1d-5b41-46d8-929c-b6980d1e6eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9298a1d-5b41-46d8-929c-b6980d1e6eb7.jpg?1",
             "name": "Orzhov Signet",
             "text": "{1}, {T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "268c5e8d-3a09-538a-a648-db74d0b93a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2225d05-d85c-4304-8226-b056e7dedad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2225d05-d85c-4304-8226-b056e7dedad7.jpg?1",
             "name": "Sword of the Paruns",
             "text": "As long as equipped creature is tapped, tapped creatures you control get +2/+0.\nAs long as equipped creature is untapped, untapped creatures you control get +0/+2.\n{3}: Tap or untap equipped creature.\nEquip {3}",
             "colours": [],
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "ac4599aa-bdc3-5dca-9c8f-f8a9f81c9886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be010c2f-06db-47e3-80bd-df3f2a21ca34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be010c2f-06db-47e3-80bd-df3f2a21ca34.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B} to your mana pool.)\nAs Godless Shrine comes into play, you may pay 2 life. If you don't, Godless Shrine comes into play tapped instead.",
             "colours": [],
@@ -5447,7 +5447,7 @@
         },
         {
             "id": "1a198921-2aea-5b44-a92f-c406acca41ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550b70e0-ebd5-49de-b62c-5224b8bf8e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550b70e0-ebd5-49de-b62c-5224b8bf8e98.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf comes into play tapped.\nWhen Gruul Turf comes into play, return a land you control to its owner's hand.\n{T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "479f98b4-f3b2-5b85-80e5-9651947343e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666f455e-3a3d-475d-b67a-a1fdd74820eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666f455e-3a3d-475d-b67a-a1fdd74820eb.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks comes into play tapped.\nWhen Izzet Boilerworks comes into play, return a land you control to its owner's hand.\n{T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "2e8ea301-66de-58b0-aeec-7c4cf754c19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ddda-400b-4543-8c31-941e65aa5ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ddda-400b-4543-8c31-941e65aa5ad1.jpg?1",
             "name": "Nivix, Aerie of the Firemind",
             "text": "{T}: Add {1} to your mana pool.\n{2}{U}{R}, {T}: Remove the top card of your library from the game. Until your next turn, you may play that card if it's an instant or sorcery.",
             "colours": [],
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "63559645-0df5-5838-a1a8-194237dc2131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9154d2a-3fc5-4fd6-9885-a810cb6b542a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9154d2a-3fc5-4fd6-9885-a810cb6b542a.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica comes into play tapped.\nWhen Orzhov Basilica comes into play, return a land you control to its owner's hand.\n{T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "2e21b013-68c5-5755-b1b8-281166e5b7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9015cc09-56c9-4d8f-b241-a0cfaec7e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9015cc09-56c9-4d8f-b241-a0cfaec7e1f1.jpg?1",
             "name": "Orzhova, the Church of Deals",
             "text": "{T}: Add {1} to your mana pool.\n{3}{W}{B}, {T}: Target player loses 1 life and you gain 1 life.",
             "colours": [],
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "79e4302b-7c5f-59b1-8036-068a9f539a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342dcdde-e4cc-4a49-a818-9283002aba1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342dcdde-e4cc-4a49-a818-9283002aba1a.jpg?1",
             "name": "Skarrg, the Rage Pits",
             "text": "{T}: Add {1} to your mana pool.\n{R}{G}, {T}: Target creature gets +1/+1 and gains trample until end of turn.",
             "colours": [],
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "bc239abe-8839-5700-bf91-911165678248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f2276-2dd5-43da-bb26-c57c560861fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f2276-2dd5-43da-bb26-c57c560861fe.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R} to your mana pool.)\nAs Steam Vents comes into play, you may pay 2 life. If you don't, Steam Vents comes into play tapped instead.",
             "colours": [],
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "0b0728fd-8d36-539c-9ca2-b24e05d29e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2773d8f-f906-475d-aaff-b7ca3b01f188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2773d8f-f906-475d-aaff-b7ca3b01f188.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G} to your mana pool.)\nAs Stomping Ground comes into play, you may pay 2 life. If you don't, Stomping Ground comes into play tapped instead.",
             "colours": [],

--- a/Assets/Resources/Sets/GRN.json
+++ b/Assets/Resources/Sets/GRN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b443439d-d199-57eb-a6c9-61dc806153c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1c7f07-8d39-425b-8ae9-b3ab317cc0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1c7f07-8d39-425b-8ae9-b3ab317cc0fe.jpg?1",
             "name": "Blade Instructor",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "4a4c6630-b38e-5fb2-ab2c-cef0d0990b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e938121-5917-4b67-9014-74fca106a471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e938121-5917-4b67-9014-74fca106a471.jpg?1",
             "name": "Bounty Agent",
             "text": "Vigilance\n{T}, Sacrifice Bounty Agent: Destroy target legendary permanent that's an artifact, creature, or enchantment.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "27bfda10-73b4-5774-923b-12340e95fdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg?1",
             "name": "Candlelight Vigil",
             "text": "Enchant creature\nEnchanted creature gets +3/+2 and has vigilance.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "9837a5c1-2b49-5257-9771-d47c6b83187e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995200f-1e9d-4ff3-9e04-4a4309e0e09c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995200f-1e9d-4ff3-9e04-4a4309e0e09c.jpg?1",
             "name": "Citywide Bust",
             "text": "Destroy all creatures with toughness 4 or greater.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "fc6a3773-00d7-5a3c-8745-f8b7f1b06f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf305b7-d1f7-4770-9201-8f3fb6735cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf305b7-d1f7-4770-9201-8f3fb6735cd9.jpg?1",
             "name": "Collar the Culprit",
             "text": "Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "234c46d1-3372-5d8e-9958-fdc50a9c4710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9fda5d-df8f-45d6-b8f0-33f903c4bf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9fda5d-df8f-45d6-b8f0-33f903c4bf83.jpg?1",
             "name": "Conclave Tribunal",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Conclave Tribunal enters the battlefield, exile target nonland permanent an opponent controls until Conclave Tribunal leaves the battlefield.",
             "colours": [
@@ -204,7 +204,7 @@
         },
         {
             "id": "07370f86-e870-5092-98cf-6574736618c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg?1",
             "name": "Crush Contraband",
             "text": "Choose one or both \u2014\n\u2022 Exile target artifact.\n\u2022 Exile target enchantment.",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "122a2ad6-3931-54da-85b4-680b1603e8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg?1",
             "name": "Dawn of Hope",
             "text": "Whenever you gain life, you may pay {2}. If you do, draw a card.\n{3}{W}: Create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "b7cc4fc8-9e52-535d-8954-6e23714e1221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69202217-ef36-4d6c-bbd0-ebbb2ade51f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69202217-ef36-4d6c-bbd0-ebbb2ade51f7.jpg?1",
             "name": "Demotion",
             "text": "Enchant creature\nEnchanted creature can't block, and its activated abilities can't be activated.",
             "colours": [
@@ -302,7 +302,7 @@
         },
         {
             "id": "117ae35b-37c3-5b67-ac93-94439d7bafc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3789d4-3621-44a1-bb72-8e3bbac8bf72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3789d4-3621-44a1-bb72-8e3bbac8bf72.jpg?1",
             "name": "Divine Visitation",
             "text": "If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "2694d5ac-ba34-5c4b-9aae-1d8d8f9ca7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg?1",
             "name": "Flight of Equenauts",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "6cdb440c-190c-5333-9838-071a0e96065f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f731df-eb40-44c8-a72d-f377c824584d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f731df-eb40-44c8-a72d-f377c824584d.jpg?1",
             "name": "Gird for Battle",
             "text": "Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -401,7 +401,7 @@
         },
         {
             "id": "cd8d5415-5da4-59ca-9762-4135eee23ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c561d89-b02d-4f1a-b49a-cdf2def3404d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c561d89-b02d-4f1a-b49a-cdf2def3404d.jpg?1",
             "name": "Haazda Marshal",
             "text": "Whenever Haazda Marshal and at least two other creatures attack, create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "4b5e1a85-74f4-5505-a5c4-c5947ca6e3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3313bd5c-b657-47a3-822a-dd0d9165492a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3313bd5c-b657-47a3-822a-dd0d9165492a.jpg?1",
             "name": "Healer's Hawk",
             "text": "Flying, lifelink",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "90cbb8ff-d3a0-5457-a8f5-bcdd821855b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg?1",
             "name": "Hunted Witness",
             "text": "When Hunted Witness dies, create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "66f7bf77-082f-584d-bf7b-c0ddba4d94b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg?1",
             "name": "Inspiring Unicorn",
             "text": "Whenever Inspiring Unicorn attacks, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "daebfbad-5901-55b2-bcd9-ef400e2039b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49266f3c-4b43-4175-8bac-16789ba6f4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49266f3c-4b43-4175-8bac-16789ba6f4b9.jpg?1",
             "name": "Intrusive Packbeast",
             "text": "Vigilance\nWhen Intrusive Packbeast enters the battlefield, tap up to two target creatures your opponents control.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "c229fc96-6500-556a-9304-7076c95c980a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg?1",
             "name": "Ledev Guardian",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "f4d538e8-2c69-5672-a19f-e25e28132ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f1b831-ca55-4575-9dfa-c3163e3d789d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f1b831-ca55-4575-9dfa-c3163e3d789d.jpg?1",
             "name": "Light of the Legion",
             "text": "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhen Light of the Legion dies, put a +1/+1 counter on each white creature you control.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "a878bcd4-1af4-52f9-a948-cbc38fd26f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg?1",
             "name": "Loxodon Restorer",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Loxodon Restorer enters the battlefield, you gain 4 life.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "d09c6056-f6b9-5e0f-9fdd-329c11b92641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d471de4-a7b2-4e13-9492-3fa94f5867ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d471de4-a7b2-4e13-9492-3fa94f5867ac.jpg?1",
             "name": "Luminous Bonds",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "2056295e-f58e-5b53-92f7-dc3b183487a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef126f2-7e72-4338-8021-3ad95e4ab982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef126f2-7e72-4338-8021-3ad95e4ab982.jpg?1",
             "name": "Parhelion Patrol",
             "text": "Flying, vigilance\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "39016dcf-6b46-5937-aa28-b47a165c0714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4501520-acf4-438f-9e96-4a649875ffdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4501520-acf4-438f-9e96-4a649875ffdd.jpg?1",
             "name": "Righteous Blow",
             "text": "Righteous Blow deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "304d0914-a19a-5942-a651-17a96be4625c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg?1",
             "name": "Roc Charger",
             "text": "Flying\nWhenever Roc Charger attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "72d5f528-ac86-561f-b95d-ad0fb51f21b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg?1",
             "name": "Skyline Scout",
             "text": "Whenever Skyline Scout attacks, you may pay {1}{W}. If you do, it gains flying until end of turn.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "07a5db22-4846-5822-8081-de3ff4459953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a431f183-17eb-4a6c-a137-d106bdc8c997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a431f183-17eb-4a6c-a137-d106bdc8c997.jpg?1",
             "name": "Sunhome Stalwart",
             "text": "First strike\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "a632b22d-25f8-5f51-aeb0-b692d90eae09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg?1",
             "name": "Sworn Companions",
             "text": "Create two 1/1 white Soldier creature tokens with lifelink.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "15785dfb-9df8-5931-8560-2ce8243db9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg?1",
             "name": "Take Heart",
             "text": "Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "130923a8-445d-5b08-b245-3e389f6ea8eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg?1",
             "name": "Tenth District Guard",
             "text": "When Tenth District Guard enters the battlefield, target creature gets +0/+1 until end of turn.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "410c0320-3a53-562c-9fe4-21d4f34fcc6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93599fba-7c53-4621-85b5-6434be077bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93599fba-7c53-4621-85b5-6434be077bf6.jpg?1",
             "name": "Venerated Loxodon",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Venerated Loxodon enters the battlefield, put a +1/+1 counter on each creature that convoked it.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "84737cc7-c6c1-5a62-911b-b8a8a66bfcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a799ac8-5798-4a26-81c1-763d6dcfcbe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a799ac8-5798-4a26-81c1-763d6dcfcbe8.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "1e56cb97-4cf4-55cc-9394-2f723523cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13a295-0d51-4b56-8c58-0896eb41c567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13a295-0d51-4b56-8c58-0896eb41c567.jpg?1",
             "name": "Chemister's Insight",
             "text": "Draw two cards.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "78d7172e-ca26-5c8a-8f28-cbd83a992595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg?1",
             "name": "Citywatch Sphinx",
             "text": "Flying\nWhen Citywatch Sphinx dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1115,7 +1115,7 @@
         },
         {
             "id": "e97b27b0-a74a-5a80-bd51-67f9b4be0cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d4639a-b634-469e-a848-35e3a3dfd47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d4639a-b634-469e-a848-35e3a3dfd47e.jpg?1",
             "name": "Dazzling Lights",
             "text": "Target creature gets -3/-0 until end of turn.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "a1b25a13-6776-5e45-a64c-0830cbda27d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ac6b0a-b1a5-439d-b65e-5f04e1826c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ac6b0a-b1a5-439d-b65e-5f04e1826c80.jpg?1",
             "name": "Devious Cover-Up",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may shuffle up to four target cards from your graveyard into your library.",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "49506765-08ee-5c91-a7db-1d79a70934d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg?1",
             "name": "Dimir Informant",
             "text": "When Dimir Informant enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "10a83c44-a436-55a1-87d7-a6379596559d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0193dfa3-8409-44be-b4be-6c3cad42d4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0193dfa3-8409-44be-b4be-6c3cad42d4a4.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -1246,7 +1246,7 @@
         },
         {
             "id": "4337133b-b58c-5736-8c9d-59f9068786b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3a4677-7683-4f63-af31-b76491ec9f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3a4677-7683-4f63-af31-b76491ec9f9c.jpg?1",
             "name": "Dream Eater",
             "text": "Flash\nFlying\nWhen Dream Eater enters the battlefield, surveil 4. When you do, you may return target nonland permanent an opponent controls to its owner's hand. (To surveil 4, look at the top four cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "9241fc49-6ac3-533e-ad54-f700baf51975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc98428-7a0f-445f-9d48-eeb76c3e10d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc98428-7a0f-445f-9d48-eeb76c3e10d6.jpg?1",
             "name": "Drowned Secrets",
             "text": "Whenever you cast a blue spell, target player puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "e35ef37f-dfc1-5527-b8ce-c6aeb7e8336e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d254e-da25-494b-a16d-3d7d6bb75c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d254e-da25-494b-a16d-3d7d6bb75c73.jpg?1",
             "name": "Enhanced Surveillance",
             "text": "You may look at an additional two cards each time you surveil.\nExile Enhanced Surveillance: Shuffle your graveyard into your library.",
             "colours": [
@@ -1345,7 +1345,7 @@
         },
         {
             "id": "e8425587-a086-5fa0-94ae-c69e0596d9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d952259f-9e0a-49af-9dfb-3cad1a1bb3a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d952259f-9e0a-49af-9dfb-3cad1a1bb3a8.jpg?1",
             "name": "Guild Summit",
             "text": "When Guild Summit enters the battlefield, you may tap any number of untapped Gates you control. Draw a card for each Gate tapped this way.\nWhenever a Gate enters the battlefield under your control, draw a card.",
             "colours": [
@@ -1377,7 +1377,7 @@
         },
         {
             "id": "1d1aac09-7bf8-589e-90a7-60662a0ae19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e415a03-f7f8-4fca-954a-ef21b4a2c60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e415a03-f7f8-4fca-954a-ef21b4a2c60f.jpg?1",
             "name": "Leapfrog",
             "text": "Leapfrog has flying as long as you've cast an instant or sorcery spell this turn.",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "2de2e7a9-a3fc-5f70-99dc-a9d5d683972a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5a08a0-b002-4bfe-9cac-d2bf96175f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5a08a0-b002-4bfe-9cac-d2bf96175f8e.jpg?1",
             "name": "Maximize Altitude",
             "text": "Target creature gets +1/+1 and gains flying until end of turn.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "24d08303-ac44-573b-a995-2bedf0c53c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bed34d-67d9-4ae9-b351-dc9a89daeabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bed34d-67d9-4ae9-b351-dc9a89daeabf.jpg?1",
             "name": "Mission Briefing",
             "text": "Surveil 2, then choose an instant or sorcery card in your graveyard. You may cast that card this turn. If that card would be put into your graveyard this turn, exile it instead. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "12584dbf-8696-59d0-b292-3f3ec1910c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc6adff-dcb3-456d-a8c2-0e77b784ff89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc6adff-dcb3-456d-a8c2-0e77b784ff89.jpg?1",
             "name": "Murmuring Mystic",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 blue Bird Illusion creature token with flying.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "2441b91d-a6b7-5d67-a7de-59b5e9b4e83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg?1",
             "name": "Muse Drake",
             "text": "Flying\nWhen Muse Drake enters the battlefield, draw a card.",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "47d73d75-84e8-5f66-9f07-5212e9df3135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e23275-2261-4d6d-88d8-124342334391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e23275-2261-4d6d-88d8-124342334391.jpg?1",
             "name": "Narcomoeba",
             "text": "Flying\nWhen Narcomoeba is put into your graveyard from your library, you may put it onto the battlefield.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "86e83dd9-d2f6-5cff-ad67-eb91c96956cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg?1",
             "name": "Nightveil Sprite",
             "text": "Flying\nWhenever Nightveil Sprite attacks, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "1bc9cf69-5f7a-5bd7-b3b2-7e2a75ae716b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17664df-e8ba-464d-b338-3e671d2d7f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17664df-e8ba-464d-b338-3e671d2d7f0e.jpg?1",
             "name": "Omnispell Adept",
             "text": "{2}{U}, {T}: You may cast an instant or sorcery card from your hand without paying its mana cost.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "375f5605-57bc-5af8-aa4d-df4761da2cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg?1",
             "name": "Passwall Adept",
             "text": "{2}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "946370fe-5ec2-54db-8fcd-9fc2f8d3d489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069646c-fae2-40bd-92bc-35459a84d847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069646c-fae2-40bd-92bc-35459a84d847.jpg?1",
             "name": "Quasiduplicate",
             "text": "Create a token that's a copy of target creature you control.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "d5261330-e2af-50ba-a943-db5b2f77065c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9570734-5e9b-46ff-b606-9759b5195756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9570734-5e9b-46ff-b606-9759b5195756.jpg?1",
             "name": "Radical Idea",
             "text": "Draw a card.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "311277a1-e1c8-5822-83d9-ee96931f3514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adfc0ac-08a9-487a-b01c-5de52fae0312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adfc0ac-08a9-487a-b01c-5de52fae0312.jpg?1",
             "name": "Selective Snare",
             "text": "Return X target creatures of the creature type of your choice to their owner's hand.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "4bef0dbd-8c27-5300-b23b-92c3d83dd397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbef36d-7170-424f-8fb1-8e7e112b7f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbef36d-7170-424f-8fb1-8e7e112b7f0b.jpg?1",
             "name": "Sinister Sabotage",
             "text": "Counter target spell.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -1811,7 +1811,7 @@
         },
         {
             "id": "0cee522e-c125-5d70-a7c4-d64b81e8d1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36478e73-162a-412c-bf5b-9ca0d92f51e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36478e73-162a-412c-bf5b-9ca0d92f51e2.jpg?1",
             "name": "Thoughtbound Phantasm",
             "text": "Defender\nWhenever you surveil, put a +1/+1 counter on Thoughtbound Phantasm.\nAs long as Thoughtbound Phantasm has three or more +1/+1 counters on it, it can attack as though it didn't have defender.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "8ae387f1-1b6a-57f6-a3e1-0179e09f6241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c99b239-50d2-4393-80ec-94dbfaa6ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c99b239-50d2-4393-80ec-94dbfaa6ae70.jpg?1",
             "name": "Unexplained Disappearance",
             "text": "Return target creature to its owner's hand.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "5bbf628d-16b3-50c5-a36d-fd6f835488ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg?1",
             "name": "Vedalken Mesmerist",
             "text": "Whenever Vedalken Mesmerist attacks, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1912,7 +1912,7 @@
         },
         {
             "id": "37b5213a-3dea-545f-b0c8-6daf1174666e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a37646-8f7c-40fc-851d-e3fdd205b012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a37646-8f7c-40fc-851d-e3fdd205b012.jpg?1",
             "name": "Wall of Mist",
             "text": "Defender",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "6a3cc459-a9a2-5daa-a067-9d063b00274a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg?1",
             "name": "Watcher in the Mist",
             "text": "Flying\nWhen Watcher in the Mist enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1980,7 +1980,7 @@
         },
         {
             "id": "6c1db7d1-69ce-5753-8128-625ae18e9818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg?1",
             "name": "Wishcoin Crab",
             "text": "",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "22b0b9f5-f617-5ace-a216-c79659560067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg?1",
             "name": "Barrier of Bones",
             "text": "Defender\nWhen Barrier of Bones enters the battlefield, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "54374096-819e-51f7-a323-784509a6b9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg?1",
             "name": "Bartizan Bats",
             "text": "Flying",
             "colours": [
@@ -2083,7 +2083,7 @@
         },
         {
             "id": "cac07159-ee01-5ef5-bbf1-fffdfab224b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1",
             "name": "Blood Operative",
             "text": "Lifelink\nWhen Blood Operative enters the battlefield, you may exile target card from a graveyard.\nWhenever you surveil, if Blood Operative is in your graveyard, you may pay 3 life. If you do, return Blood Operative to your hand.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "8c734b4a-22b2-55ba-926f-0b5937d21359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7f218-fd2a-4233-8753-065ddc314f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7f218-fd2a-4233-8753-065ddc314f2d.jpg?1",
             "name": "Burglar Rat",
             "text": "When Burglar Rat enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "70b5f6dc-543b-564a-bfd4-021c3a8fa9dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afebf1a5-eb9a-48c6-a26a-55b75408992b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afebf1a5-eb9a-48c6-a26a-55b75408992b.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "3040ba5c-13fd-5da5-9fcf-a4c363f9ae8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5456173-7a08-4b5c-8450-7123375f4a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5456173-7a08-4b5c-8450-7123375f4a86.jpg?1",
             "name": "Creeping Chill",
             "text": "Creeping Chill deals 3 damage to each opponent and you gain 3 life.\nWhen Creeping Chill is put into your graveyard from your library, you may exile it. If you do, Creeping Chill deals 3 damage to each opponent and you gain 3 life.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "43b41a9c-56c7-5aa9-80bf-dc90211351ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a81554-50d4-4fe0-bf0d-5304f215d19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a81554-50d4-4fe0-bf0d-5304f215d19e.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "b86144cd-5e45-5038-90d0-c4e97dcdab20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462fe190-5264-42d8-bd27-23c5aa0c641f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462fe190-5264-42d8-bd27-23c5aa0c641f.jpg?1",
             "name": "Deadly Visit",
             "text": "Destroy target creature.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "68d37fc0-33e3-56ce-a96d-eacef2cc9139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg?1",
             "name": "Doom Whisperer",
             "text": "Flying, trample\nPay 2 life: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "f25e3d41-1524-5630-81a2-471af099c10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg?1",
             "name": "Douser of Lights",
             "text": "",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "58fe4998-d335-5261-931e-5071e3fa8531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0e4d9-bf0d-4e28-a647-9010701a915e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0e4d9-bf0d-4e28-a647-9010701a915e.jpg?1",
             "name": "Gruesome Menagerie",
             "text": "Choose a creature card with converted mana cost 1 in your graveyard, then do the same for creature cards with converted mana costs 2 and 3. Return those cards to the battlefield.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "a6547ae0-9355-57e6-8b31-f591bf0a3f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg?1",
             "name": "Hired Poisoner",
             "text": "Deathtouch",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "26c2e7f4-b1d4-5f41-ac63-143b51508d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg?1",
             "name": "Kraul Swarm",
             "text": "Flying\n{2}{B}, Discard a creature card: Return Kraul Swarm from your graveyard to your hand.",
             "colours": [
@@ -2455,7 +2455,7 @@
         },
         {
             "id": "6f74cac8-fae8-53f5-b751-70a8c6c0e51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dc38b7-52f7-4394-b095-5442429ab291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dc38b7-52f7-4394-b095-5442429ab291.jpg?1",
             "name": "Lotleth Giant",
             "text": "Undergrowth \u2014 When Lotleth Giant enters the battlefield, it deals 1 damage to target opponent for each creature card in your graveyard.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "e10acf77-9e94-5b81-b413-0161d23438d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7cf38-78cc-4139-9f2a-4dd0be7d9da8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7cf38-78cc-4139-9f2a-4dd0be7d9da8.jpg?1",
             "name": "Mausoleum Secrets",
             "text": "Undergrowth \u2014 Search your library for a black card with converted mana cost less than or equal to the number of creature cards in your graveyard, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "b5f4dd37-3c87-51b4-af9e-09294aba0093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675640ba-37e7-4231-8524-87e8b87ea46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675640ba-37e7-4231-8524-87e8b87ea46f.jpg?1",
             "name": "Mephitic Vapors",
             "text": "All creatures get -1/-1 until end of turn.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "4b860dee-1cf9-5ed8-8a66-202b1574ead3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e122fe0-51c5-404d-a7b9-3d161a426c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e122fe0-51c5-404d-a7b9-3d161a426c35.jpg?1",
             "name": "Midnight Reaper",
             "text": "Whenever a nontoken creature you control dies, Midnight Reaper deals 1 damage to you and you draw a card.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "32e00b22-6a82-54c0-b1c5-30f69fc77c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82903e5f-c10f-4767-a2c0-6f8cc7280fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82903e5f-c10f-4767-a2c0-6f8cc7280fa0.jpg?1",
             "name": "Moodmark Painter",
             "text": "Undergrowth \u2014 When Moodmark Painter enters the battlefield, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "706d72ba-d6d7-5d8f-a01f-ebd6d130f1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab636af-5b30-4138-8e68-81f567f10417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab636af-5b30-4138-8e68-81f567f10417.jpg?1",
             "name": "Necrotic Wound",
             "text": "Undergrowth \u2014 Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "8fc41761-87dd-5a38-9f54-27b087797691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d3746-9e54-4983-9daa-f1a7afbdedad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d3746-9e54-4983-9daa-f1a7afbdedad.jpg?1",
             "name": "Never Happened",
             "text": "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "5cfd67f3-2e14-53b9-b759-18aa881b4a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646dedff-150c-4ed2-8f2e-3b2e6ba5521a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646dedff-150c-4ed2-8f2e-3b2e6ba5521a.jpg?1",
             "name": "Pilfering Imp",
             "text": "Flying\n{1}{B}, {T}, Sacrifice Pilfering Imp: Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "3ee49282-9abf-55fa-a978-a7d1e1dfece3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8682fb87-df14-4277-aaa0-0d53d766c406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8682fb87-df14-4277-aaa0-0d53d766c406.jpg?1",
             "name": "Plaguecrafter",
             "text": "When Plaguecrafter enters the battlefield, each player sacrifices a creature or planeswalker. Each player who can't discards a card.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "eb9a092f-6db5-5da9-ab00-0a6ff077dd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b52152-0f7c-4466-9e49-033477028f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b52152-0f7c-4466-9e49-033477028f67.jpg?1",
             "name": "Price of Fame",
             "text": "This spell costs {2} less to cast if it targets a legendary creature.\nDestroy target creature.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "5a717aec-3977-5bc7-b766-6c42dc386efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg?1",
             "name": "Ritual of Soot",
             "text": "Destroy all creatures with converted mana cost 3 or less.",
             "colours": [
@@ -2821,7 +2821,7 @@
         },
         {
             "id": "4d4e338d-493a-5b5a-86c6-3d0f077ad6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce654d6-fcf1-40a8-8bdb-5c37e561f7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce654d6-fcf1-40a8-8bdb-5c37e561f7dc.jpg?1",
             "name": "Severed Strands",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nYou gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "3c41bd01-7bd6-53d2-bd48-41ef47dc1cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg?1",
             "name": "Spinal Centipede",
             "text": "When Spinal Centipede dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "2249f36a-f49d-52da-940d-2448cfdb4bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2571d168-38d4-46d7-afae-ffbd12bd2313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2571d168-38d4-46d7-afae-ffbd12bd2313.jpg?1",
             "name": "Undercity Necrolisk",
             "text": "{1}, Sacrifice another creature: Put a +1/+1 counter on Undercity Necrolisk. It gains menace until end of turn. Activate this ability only any time you could cast a sorcery. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2922,7 +2922,7 @@
         },
         {
             "id": "4d66eafc-abed-53fa-8eb1-5d5967fbadc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg?1",
             "name": "Veiled Shade",
             "text": "{1}{B}: Veiled Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "9854701d-6337-54ab-a666-db111af92e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1939952-608e-4786-beeb-a6ff0fa36624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1939952-608e-4786-beeb-a6ff0fa36624.jpg?1",
             "name": "Vicious Rumors",
             "text": "Vicious Rumors deals 1 damage to each opponent. Each opponent discards a card, then puts the top card of their library into their graveyard. You gain 1 life.",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "d7651c82-2c00-5a74-ae5c-f28272e92032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ca97e-b402-4a73-9c70-79ec4565a39c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ca97e-b402-4a73-9c70-79ec4565a39c.jpg?1",
             "name": "Whispering Snitch",
             "text": "Whenever you surveil for the first time each turn, Whispering Snitch deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -3023,7 +3023,7 @@
         },
         {
             "id": "864c94a7-a6d7-5055-bb8f-8709f90cfabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787de9ce-02c5-4a17-a88b-d38e83dbeb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787de9ce-02c5-4a17-a88b-d38e83dbeb0b.jpg?1",
             "name": "Arclight Phoenix",
             "text": "Flying, haste\nAt the beginning of combat on your turn, if you've cast three or more instant and sorcery spells this turn, return Arclight Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "d471e741-3508-5537-acd5-69905c03f8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a54ebc-008a-4180-a023-2e1d5318780c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a54ebc-008a-4180-a023-2e1d5318780c.jpg?1",
             "name": "Barging Sergeant",
             "text": "Haste\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "e742635f-49c7-5192-bfe7-12984ff1bad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dfe640-5bd2-4d0b-8977-887b2ed4c2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dfe640-5bd2-4d0b-8977-887b2ed4c2dd.jpg?1",
             "name": "Book Devourer",
             "text": "Trample\nWhenever Book Devourer deals combat damage to a player, you may discard all the cards in your hand. If you do, draw that many cards.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "f9a6540d-1614-56ae-83f7-6518e3364b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg?1",
             "name": "Command the Storm",
             "text": "Command the Storm deals 5 damage to target creature.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "9f1bdcc2-02bf-55ee-9e7a-734d111dab93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c5bafa-8cd8-4158-98e0-46dc74c027c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c5bafa-8cd8-4158-98e0-46dc74c027c0.jpg?1",
             "name": "Cosmotronic Wave",
             "text": "Cosmotronic Wave deals 1 damage to each creature your opponents control. Creatures your opponents control can't block this turn.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "ec48568e-d830-5226-b2e5-115b94253659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166b0d75-824c-4c04-833b-7f7c69569a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166b0d75-824c-4c04-833b-7f7c69569a18.jpg?1",
             "name": "Direct Current",
             "text": "Direct Current deals 2 damage to any target.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "2735998c-9a71-5fd2-b8ea-b34b7cd70e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg?1",
             "name": "Electrostatic Field",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, Electrostatic Field deals 1 damage to each opponent.",
             "colours": [
@@ -3256,7 +3256,7 @@
         },
         {
             "id": "5a9ca116-5b28-503d-ab61-5656d8f50990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c310df89-d894-40ab-ae34-7d0bfd19a1af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c310df89-d894-40ab-ae34-7d0bfd19a1af.jpg?1",
             "name": "Erratic Cyclops",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, Erratic Cyclops gets +X/+0 until end of turn, where X is that spell's converted mana cost.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "98ae591f-44f7-58cc-a1cc-dd63da1ca671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8f32e2-5dc8-4f1b-8a69-d3ae06378ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8f32e2-5dc8-4f1b-8a69-d3ae06378ed8.jpg?1",
             "name": "Experimental Frenzy",
             "text": "You may look at the top card of your library any time.\nYou may play the top card of your library.\nYou can't play cards from your hand.\n{3}{R}: Destroy Experimental Frenzy.",
             "colours": [
@@ -3323,7 +3323,7 @@
         },
         {
             "id": "6cec0914-a17e-5835-8e3a-e7b57f6a2550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg?1",
             "name": "Fearless Halberdier",
             "text": "",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "d76567b1-5de1-56a5-9bf4-26e75adb14aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg?1",
             "name": "Fire Urchin",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, Fire Urchin gets +1/+0 until end of turn.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "4e8608b1-a0c4-5655-9283-f114eda815d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b3b56c-5236-4319-b17e-5f71143a7906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b3b56c-5236-4319-b17e-5f71143a7906.jpg?1",
             "name": "Goblin Banneret",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\n{1}{R}: Goblin Banneret gets +2/+0 until end of turn.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "9e31b423-8a4d-59b8-8196-aea1263da4a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaedc-08f1-4de7-aae8-056df57940e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaedc-08f1-4de7-aae8-056df57940e0.jpg?1",
             "name": "Goblin Cratermaker",
             "text": "{1}, Sacrifice Goblin Cratermaker: Choose one \u2014\n\u2022 Goblin Cratermaker deals 2 damage to target creature.\n\u2022 Destroy target colorless nonland permanent.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "4db4ecec-4ae1-5323-b9b0-b6234987a02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2bed0a-990a-499a-af0a-52b77557d7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2bed0a-990a-499a-af0a-52b77557d7cb.jpg?1",
             "name": "Goblin Locksmith",
             "text": "Whenever Goblin Locksmith attacks, creatures with defender can't block this turn.",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "90819996-d612-5d27-b8e3-43ffee7a3e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05fe0428-6e7d-49d4-9a29-80a3589f565a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05fe0428-6e7d-49d4-9a29-80a3589f565a.jpg?1",
             "name": "Gravitic Punch",
             "text": "Target creature you control deals damage equal to its power to target player.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "573d9cfa-c531-56de-a0f1-bafcac074eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e902e8-bbd5-40fe-a655-45d3d3bc9fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e902e8-bbd5-40fe-a655-45d3d3bc9fde.jpg?1",
             "name": "Hellkite Whelp",
             "text": "Flying\nWhenever Hellkite Whelp attacks, it deals 1 damage to target creature defending player controls.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "cacf7fb2-e347-53cb-a646-0a8dfab3815e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg?1",
             "name": "Inescapable Blaze",
             "text": "This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "5a1e6511-67ab-5f6d-b133-0e14b470d092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6135cf4-50c2-4e44-b9b0-96e1187a2200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6135cf4-50c2-4e44-b9b0-96e1187a2200.jpg?1",
             "name": "Lava Coil",
             "text": "Lava Coil deals 4 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "f79181bb-060c-5b46-a651-c4950e641bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e84cb9c-9876-47a4-aea4-78574321bc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e84cb9c-9876-47a4-aea4-78574321bc36.jpg?1",
             "name": "Legion Warboss",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token gains haste until end of turn and attacks this combat if able.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "0ef31c23-2190-551a-86c9-9f52e5c85c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882f8dcf-b361-4dc9-8329-e7d1f807acd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882f8dcf-b361-4dc9-8329-e7d1f807acd6.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "95917fd5-187c-5ea1-9f89-aed0c4490b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7a2aa-f002-4f05-b9ec-8adee4c65e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7a2aa-f002-4f05-b9ec-8adee4c65e46.jpg?1",
             "name": "Maximize Velocity",
             "text": "Target creature gets +1/+1 and gains haste until end of turn.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "ae683c2e-1a66-5b24-a631-07df1cd937b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c1353-b315-4a0e-80b5-0d9a2962e35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c1353-b315-4a0e-80b5-0d9a2962e35f.jpg?1",
             "name": "Ornery Goblin",
             "text": "Whenever Ornery Goblin blocks or becomes blocked by a creature, Ornery Goblin deals 1 damage to that creature.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "e1bcac1d-a3cb-5876-a7b1-680c1ab789df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eda89d9-9bd1-4a55-ac02-f9a0625d8e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eda89d9-9bd1-4a55-ac02-f9a0625d8e5b.jpg?1",
             "name": "Risk Factor",
             "text": "Target opponent may have Risk Factor deal 4 damage to them. If that player doesn't, you draw three cards.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "017dcfc0-f2d7-546d-9527-8e91e8116e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg?1",
             "name": "Rubblebelt Boar",
             "text": "When Rubblebelt Boar enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "7793b045-4181-5fd4-a2de-be262150524f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c9c111-fbc7-44e1-94bd-1ca164370623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c9c111-fbc7-44e1-94bd-1ca164370623.jpg?1",
             "name": "Runaway Steam-Kin",
             "text": "Whenever you cast a red spell, if Runaway Steam-Kin has fewer than three +1/+1 counters on it, put a +1/+1 counter on Runaway Steam-Kin.\nRemove three +1/+1 counters from Runaway Steam-Kin: Add {R}{R}{R}.",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "f1ad73c0-6b88-57ce-acd8-d88f2357a6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg?1",
             "name": "Smelt-Ward Minotaur",
             "text": "Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "6b8719e6-62b6-5a68-949d-8ddb86df31f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b352d5-4a57-41bc-b4c4-8b81255a9db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b352d5-4a57-41bc-b4c4-8b81255a9db8.jpg?1",
             "name": "Street Riot",
             "text": "As long as it's your turn, creatures you control get +1/+0 and have trample.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "8e7b3bde-1aea-5135-aa81-c177c8694ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d01f1ce-9931-4712-a907-72c2c6d5ee76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d01f1ce-9931-4712-a907-72c2c6d5ee76.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "c89e6d0c-52b6-5838-817b-e58052c8e341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c9fc8c-e68f-4636-84b8-877f6ec04b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c9fc8c-e68f-4636-84b8-877f6ec04b09.jpg?1",
             "name": "Torch Courier",
             "text": "Haste\nSacrifice Torch Courier: Another target creature gains haste until end of turn.",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "449c654d-fa7c-5f6b-b701-b8f2d7addb76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebff5313-e325-47c3-814b-38fdb4c6c8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebff5313-e325-47c3-814b-38fdb4c6c8d2.jpg?1",
             "name": "Wojek Bodyguard",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWojek Bodyguard can't attack or block alone.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "e9e6f91a-126d-5ed3-83e2-1322950bf7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8ddc1-d95c-499f-b1d1-f608f8f07b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8ddc1-d95c-499f-b1d1-f608f8f07b02.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4065,7 +4065,7 @@
         },
         {
             "id": "f87bf8a4-74cb-5fd8-9aab-c3a05a870ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg?1",
             "name": "Arboretum Elemental",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "fe3f82f5-33b4-527a-9f68-cbe829e0e6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg?1",
             "name": "Beast Whisperer",
             "text": "Whenever you cast a creature spell, draw a card.",
             "colours": [
@@ -4134,7 +4134,7 @@
         },
         {
             "id": "e60b5355-1652-50ee-934e-2da578d92d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a950d8-e6e2-42d6-83d7-a60c15d2035d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a950d8-e6e2-42d6-83d7-a60c15d2035d.jpg?1",
             "name": "Bounty of Might",
             "text": "Target creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "b1affcc5-4e71-5143-aea6-d65e4f9881bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a970429-6369-4422-a343-00b30267f09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a970429-6369-4422-a343-00b30267f09d.jpg?1",
             "name": "Circuitous Route",
             "text": "Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "7ee20e10-de9e-5360-87a4-52ebf5520047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c4f213-0ea4-44c0-8429-172a317b77f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c4f213-0ea4-44c0-8429-172a317b77f5.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "91466c81-42e4-5362-88da-4e61e217b55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg?1",
             "name": "Devkarin Dissident",
             "text": "{4}{G}: Devkarin Dissident gets +2/+2 until end of turn.",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "49da04ef-411e-551d-aa49-859946b398f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150deec-3287-40ef-9b9c-c22bf5d70b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150deec-3287-40ef-9b9c-c22bf5d70b02.jpg?1",
             "name": "District Guide",
             "text": "When District Guide enters the battlefield, you may search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "00afc5b6-4169-5049-8486-bb7e65d5154c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg?1",
             "name": "Generous Stray",
             "text": "When Generous Stray enters the battlefield, draw a card.",
             "colours": [
@@ -4334,7 +4334,7 @@
         },
         {
             "id": "39f82ac4-e3c2-5713-8b6c-061259d7f650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37284ba8-441c-4cf6-95c6-6a0f52e6d36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37284ba8-441c-4cf6-95c6-6a0f52e6d36d.jpg?1",
             "name": "Golgari Raiders",
             "text": "Haste\nUndergrowth \u2014 Golgari Raiders enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "d9abff7a-6dab-5649-9182-ea4baf79e78c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg?1",
             "name": "Grappling Sundew",
             "text": "Defender, reach\n{4}{G}: Grappling Sundew gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy this creature.)",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "97f4712f-3d04-580c-9899-eeb6aacf89fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b841904-202c-4b42-869a-e345112ab1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b841904-202c-4b42-869a-e345112ab1c8.jpg?1",
             "name": "Hatchery Spider",
             "text": "Reach\nUndergrowth \u2014 When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with converted mana cost X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "a063bbc9-da81-53b9-a9a6-c337fa3f9bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe349432-8726-49cf-ad07-6f8add8f78c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe349432-8726-49cf-ad07-6f8add8f78c8.jpg?1",
             "name": "Hitchclaw Recluse",
             "text": "Reach",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "7f54e17b-41af-5f71-bc56-4322abeae495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f8b6b0-f858-41d5-9839-fd1247b9477f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f8b6b0-f858-41d5-9839-fd1247b9477f.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "5af631e1-7c82-524d-acce-41ea641b69f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ed4b08-8583-4ad4-b0ba-0463d367efc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ed4b08-8583-4ad4-b0ba-0463d367efc8.jpg?1",
             "name": "Kraul Foragers",
             "text": "Undergrowth \u2014 When Kraul Foragers enters the battlefield, you gain 1 life for each creature card in your graveyard.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "b14e38b7-5cd9-521c-8f3e-8c1b0a685b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d3c086-9ce4-41c3-8402-2818f1b27192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d3c086-9ce4-41c3-8402-2818f1b27192.jpg?1",
             "name": "Kraul Harpooner",
             "text": "Reach\nUndergrowth \u2014 When Kraul Harpooner enters the battlefield, choose up to one target creature with flying you don't control. Kraul Harpooner gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have Kraul Harpooner fight that creature.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "efaabd70-37be-5705-87b4-fd2f40ae9661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d9ef7-0b16-4095-9c70-f6776e4cd3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d9ef7-0b16-4095-9c70-f6776e4cd3cb.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "ac0d34ed-7e9e-53b4-a995-69dd1e0ebd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c30bb0-06ba-432b-a20c-6fa79b0dc68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c30bb0-06ba-432b-a20c-6fa79b0dc68a.jpg?1",
             "name": "Nullhide Ferox",
             "text": "Hexproof\nYou can't cast noncreature spells.\n{2}: Nullhide Ferox loses all abilities until end of turn. Any player may activate this ability.\nIf a spell or ability an opponent controls causes you to discard Nullhide Ferox, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "518dd289-0af5-5ff5-b8d7-1dd00217f275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg?1",
             "name": "Pack's Favor",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "2feaaa54-4d66-5439-8ae7-7e87dfd244bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg?1",
             "name": "Pause for Reflection",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPrevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "ae9aea70-f636-58b5-8dac-5cc88dc2f55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee125cb-12b9-4f78-8e1d-6018d9c52275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee125cb-12b9-4f78-8e1d-6018d9c52275.jpg?1",
             "name": "Pelt Collector",
             "text": "Whenever another creature you control enters the battlefield or dies, if that creature's power is greater than Pelt Collector's, put a +1/+1 counter on Pelt Collector.\nAs long as Pelt Collector has three or more +1/+1 counters on it, it has trample.",
             "colours": [
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "acb4a681-f10b-5ea4-b6d0-c6c39e5a4379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg?1",
             "name": "Portcullis Vine",
             "text": "Defender\n{2}, {T}, Sacrifice a creature with defender: Draw a card.",
             "colours": [
@@ -4775,7 +4775,7 @@
         },
         {
             "id": "73741041-b0df-5e2f-abc0-e2e3b9c93325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16979827-4011-454a-9886-18326cfa3e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16979827-4011-454a-9886-18326cfa3e77.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "1d7e3d5c-8ed5-525a-8344-498ea373a6ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1dfd96-8e17-4ba8-b786-a5cc0ae2ff2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1dfd96-8e17-4ba8-b786-a5cc0ae2ff2d.jpg?1",
             "name": "Siege Wurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "d5b6d782-5eb5-590f-b583-997da474ae53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668232ab-5e58-49f3-804a-c938252ff177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668232ab-5e58-49f3-804a-c938252ff177.jpg?1",
             "name": "Sprouting Renewal",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one \u2014\n\u2022 Create a 2/2 green and white Elf Knight creature token with vigilance.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "cb2ae5f2-52ba-5da6-b311-3ad5cee26b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d7ab0e-db37-4051-86dd-3ab09c047a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d7ab0e-db37-4051-86dd-3ab09c047a2b.jpg?1",
             "name": "Urban Utopia",
             "text": "Enchant land\nWhen Urban Utopia enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "315acfe0-7346-53ed-8421-99a1140d1597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62625de-3a2f-43d6-8cf7-ea38f038f3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62625de-3a2f-43d6-8cf7-ea38f038f3b6.jpg?1",
             "name": "Vigorspore Wurm",
             "text": "Undergrowth \u2014 When Vigorspore Wurm enters the battlefield, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.\nVigorspore Wurm can't be blocked by more than one creature.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "f136c090-cd0c-5527-99cb-d378e598203b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e67fcfd-0e9e-4b88-8c65-2125fac10a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e67fcfd-0e9e-4b88-8c65-2125fac10a3d.jpg?1",
             "name": "Vivid Revival",
             "text": "Return up to three target multicolored cards from your graveyard to your hand. Exile Vivid Revival.",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "fdd073ee-44d1-5ba6-943f-8e87a437a0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg?1",
             "name": "Wary Okapi",
             "text": "Vigilance",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "ebbe9eb9-26f0-52b9-a02d-2ea455d5c402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg?1",
             "name": "Wild Ceratok",
             "text": "",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "11b108a1-e4d3-56b3-beb1-fb9a1b3a964e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg?1",
             "name": "Artful Takedown",
             "text": "Choose one or both \u2014\n\u2022 Tap target creature.\n\u2022 Target creature gets -2/-4 until end of turn.",
             "colours": [
@@ -5075,7 +5075,7 @@
         },
         {
             "id": "159d16f2-4a84-57e3-9e87-12f036e84e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle their library.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "62cbbd6e-0b9f-5d86-bd36-541e9a60bc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9f4d2-bba5-4061-8ae7-a68b912f2c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9f4d2-bba5-4061-8ae7-a68b912f2c11.jpg?1",
             "name": "Aurelia, Exemplar of Justice",
             "text": "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nAt the beginning of combat on your turn, choose up to one target creature you control. Until end of turn, that creature gets +2/+0, gains trample if it's red, and gains vigilance if it's white.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "83db81aa-2e76-5609-bad2-a0adf5427274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c9e4b5-364b-4c0b-bb47-266563a6abf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c9e4b5-364b-4c0b-bb47-266563a6abf2.jpg?1",
             "name": "Beacon Bolt",
             "text": "Beacon Bolt deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "c84ce67b-ddc7-59e1-83e8-a9124060b584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1801f2-ea6e-4196-858e-2afc456cf6a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1801f2-ea6e-4196-858e-2afc456cf6a0.jpg?1",
             "name": "Beamsplitter Mage",
             "text": "Whenever you cast an instant or sorcery spell that targets only Beamsplitter Mage, if you control one or more other creatures that spell could target, choose one of those creatures. Copy that spell. The copy targets the chosen creature.",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "89b88e85-91dc-56d9-8694-68f27c9c331e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545f3a30-7984-4046-8a14-51bc9cbc3fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545f3a30-7984-4046-8a14-51bc9cbc3fe0.jpg?1",
             "name": "Boros Challenger",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\n{2}{R}{W}: Boros Challenger gets +1/+1 until end of turn.",
             "colours": [
@@ -5255,7 +5255,7 @@
         },
         {
             "id": "101c3036-0587-5078-95c8-5c6a9ea1a758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890a2fa9-1141-4a4c-85af-05723aba5e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890a2fa9-1141-4a4c-85af-05723aba5e39.jpg?1",
             "name": "Camaraderie",
             "text": "You gain X life and draw X cards, where X is the number of creatures you control. Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "86d5b24e-49fc-5a4d-9dd6-9e0c1465e900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e630e9b-7817-4255-9de1-795b2a788d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e630e9b-7817-4255-9de1-795b2a788d80.jpg?1",
             "name": "Centaur Peacemaker",
             "text": "When Centaur Peacemaker enters the battlefield, each player gains 4 life.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "3c700851-c1b3-5fbc-ba9a-171dd8b1a34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edf6f9-b863-41e2-bb51-857ea2798090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edf6f9-b863-41e2-bb51-857ea2798090.jpg?1",
             "name": "Chance for Glory",
             "text": "Creatures you control gain indestructible. Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -5360,7 +5360,7 @@
         },
         {
             "id": "afdc0573-5bc9-59aa-a036-6243fb8627bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fec229-e22c-4655-8640-02d0ec472be0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fec229-e22c-4655-8640-02d0ec472be0.jpg?1",
             "name": "Charnel Troll",
             "text": "Trample\nAt the beginning of your upkeep, exile a creature card from your graveyard. If you do, put a +1/+1 counter on Charnel Troll. Otherwise, sacrifice it.\n{B}{G}, Discard a creature card: Put a +1/+1 counter on Charnel Troll.",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "4a5aae8c-8528-5fbb-b337-053654804214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b658a309-d14c-4e20-8c76-e7b3c5156bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b658a309-d14c-4e20-8c76-e7b3c5156bf2.jpg?1",
             "name": "Conclave Cavalier",
             "text": "Vigilance\nWhen Conclave Cavalier dies, create two 2/2 green and white Elf Knight creature tokens with vigilance.",
             "colours": [
@@ -5433,7 +5433,7 @@
         },
         {
             "id": "deea540c-a88d-5b4d-8f18-d97e7b7fb019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279e551d-3ac3-48d5-9822-1d05159c8905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279e551d-3ac3-48d5-9822-1d05159c8905.jpg?1",
             "name": "Conclave Guildmage",
             "text": "{G}, {T}: Creatures you control gain trample until end of turn.\n{5}{W}, {T}: Create a 2/2 green and white Elf Knight creature token with vigilance.",
             "colours": [
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "085c5343-6060-5d4e-a967-3b40e64246f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00fa3a7-e3e2-4b23-a126-a076e75b5dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00fa3a7-e3e2-4b23-a126-a076e75b5dbd.jpg?1",
             "name": "Crackling Drake",
             "text": "Flying\nCrackling Drake's power is equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\nWhen Crackling Drake enters the battlefield, draw a card.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "55c72075-a0af-5396-a11f-fd314c11e360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b610c5-61e5-43df-a87b-3eaaa915402b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b610c5-61e5-43df-a87b-3eaaa915402b.jpg?1",
             "name": "Darkblade Agent",
             "text": "As long as you've surveilled this turn, Darkblade Agent has deathtouch and \"Whenever this creature deals combat damage to a player, you draw a card.\"",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "1f51d832-5077-5d7c-b65b-5a598e789df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg?1",
             "name": "Deafening Clarion",
             "text": "Choose one or both \u2014\n\u2022 Deafening Clarion deals 3 damage to each creature.\n\u2022 Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "07323ff9-0d38-5e8f-9a48-57370dcd091b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c18c450-0bfb-4ba6-9212-b5833fce63a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c18c450-0bfb-4ba6-9212-b5833fce63a2.jpg?1",
             "name": "Dimir Spybug",
             "text": "Flying\nMenace (This creature can't be blocked except by two or more creatures.)\nWhenever you surveil, put a +1/+1 counter on Dimir Spybug.",
             "colours": [
@@ -5613,7 +5613,7 @@
         },
         {
             "id": "a3951b3f-cc88-5b3d-bdb1-36d75d9cd1b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a79ff3-58ed-4cc2-9ebc-0edbb86cd6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a79ff3-58ed-4cc2-9ebc-0edbb86cd6fb.jpg?1",
             "name": "Disinformation Campaign",
             "text": "When Disinformation Campaign enters the battlefield, you draw a card and each opponent discards a card.\nWhenever you surveil, return Disinformation Campaign to its owner's hand.",
             "colours": [
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "41e731d9-eaf6-5c30-84df-2c30ebb15312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b930ee-e16b-4612-87de-c03ecc6ff6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b930ee-e16b-4612-87de-c03ecc6ff6db.jpg?1",
             "name": "Emmara, Soul of the Accord",
             "text": "Whenever Emmara, Soul of the Accord becomes tapped, create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "cc9c728b-331c-5d0d-b283-e4ec7e267766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg?1",
             "name": "Erstwhile Trooper",
             "text": "Discard a creature card: Erstwhile Trooper gets +2/+2 and gains trample until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "d42b3e98-9383-53be-b968-57cd0b4a0e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa36b142-e67e-49da-9080-c5994e275266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa36b142-e67e-49da-9080-c5994e275266.jpg?1",
             "name": "Etrata, the Silencer",
             "text": "Etrata, the Silencer can't be blocked.\nWhenever Etrata deals combat damage to a player, exile target creature that player controls and put a hit counter on that card. That player loses the game if they own three or more exiled cards with hit counters on them. Etrata's owner shuffles Etrata into their library.",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "36f9e604-5239-5094-8e5f-df2f0e688313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc926b2-1e54-4c62-8b6c-fce4ef013abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc926b2-1e54-4c62-8b6c-fce4ef013abc.jpg?1",
             "name": "Firemind's Research",
             "text": "Whenever you cast an instant or sorcery spell, put a charge counter on Firemind's Research.\n{1}{U}, Remove two charge counters from Firemind's Research: Draw a card.\n{1}{R}, Remove five charge counters from Firemind's Research: It deals 5 damage to any target.",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "134ffdc6-a6e8-5553-b710-4fe3b7281fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd957a1-a354-48e9-80ad-66e49aa845fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd957a1-a354-48e9-80ad-66e49aa845fc.jpg?1",
             "name": "Garrison Sergeant",
             "text": "Garrison Sergeant has double strike as long as you control a Gate.",
             "colours": [
@@ -5833,7 +5833,7 @@
         },
         {
             "id": "9a818048-a017-5b0d-bd47-76b3a61d51ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fe260a-d204-4e75-b3e5-0cd9b4ca7084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fe260a-d204-4e75-b3e5-0cd9b4ca7084.jpg?1",
             "name": "Glowspore Shaman",
             "text": "When Glowspore Shaman enters the battlefield, put the top three cards of your library into your graveyard. You may put a land card from your graveyard on top of your library.",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "7130e8b8-b5d5-5a91-9c36-afd3c68bf048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae987da-e4b5-4b82-843c-6aaa87262fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae987da-e4b5-4b82-843c-6aaa87262fc8.jpg?1",
             "name": "Goblin Electromancer",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "ce380ce9-e8da-5310-a8aa-5203d55d43b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg?1",
             "name": "Golgari Findbroker",
             "text": "When Golgari Findbroker enters the battlefield, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "6509858f-5a80-5498-9143-06c33630914a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efac789-587b-45c1-b16e-616e9486b59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efac789-587b-45c1-b16e-616e9486b59b.jpg?1",
             "name": "Hammer Dropper",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -5981,7 +5981,7 @@
         },
         {
             "id": "1b8b0b2c-6f59-5658-97e7-ade12c57cff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ee7bc8-d5cf-47b1-93c2-7e1d5f536c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ee7bc8-d5cf-47b1-93c2-7e1d5f536c85.jpg?1",
             "name": "House Guildmage",
             "text": "{1}{U}, {T}: Target creature doesn't untap during its controller's next untap step.\n{2}{B}, {T}: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "4d35f9d3-a4a5-579b-8524-6cccefbfd520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5690329-feb8-49c0-8f59-ee13782e8d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5690329-feb8-49c0-8f59-ee13782e8d3b.jpg?1",
             "name": "Hypothesizzle",
             "text": "Draw two cards. Then you may discard a nonland card. When you do, Hypothesizzle deals 4 damage to target creature.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "760d8369-2e5d-5c20-a1a0-3a18d42612a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f161f7d2-eaa1-4931-93f9-befa8b5df821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f161f7d2-eaa1-4931-93f9-befa8b5df821.jpg?1",
             "name": "Ionize",
             "text": "Counter target spell. Ionize deals 2 damage to that spell's controller.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "cbc55a76-9235-5e23-98c7-7b916a649903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75955b0e-12d6-40ba-aab5-b7b7e2bde121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75955b0e-12d6-40ba-aab5-b7b7e2bde121.jpg?1",
             "name": "Izoni, Thousand-Eyed",
             "text": "Undergrowth \u2014 When Izoni, Thousand-Eyed enters the battlefield, create a 1/1 black and green Insect creature token for each creature card in your graveyard.\n{B}{G}, Sacrifice another creature: You gain 1 life and draw a card.",
             "colours": [
@@ -6125,7 +6125,7 @@
         },
         {
             "id": "de8109be-ef99-5a40-817c-6225575f5b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91898d8a-589d-43db-8dc4-0ec6a3bd6d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91898d8a-589d-43db-8dc4-0ec6a3bd6d49.jpg?1",
             "name": "Join Shields",
             "text": "Untap all creatures you control. They gain hexproof and indestructible until end of turn. (They can't be the targets of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "fa0d0bb3-e9b7-5752-911e-0719ff9a1a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27619ce9-59df-4f0e-a5db-2d32a530e547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27619ce9-59df-4f0e-a5db-2d32a530e547.jpg?1",
             "name": "Justice Strike",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -6193,7 +6193,7 @@
         },
         {
             "id": "4d44e0cd-5c67-50fa-b05e-57a6437ebe08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg?1",
             "name": "Knight of Autumn",
             "text": "When Knight of Autumn enters the battlefield, choose one \u2014\n\u2022 Put two +1/+1 counters on Knight of Autumn.\n\u2022 Destroy target artifact or enchantment.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6230,7 +6230,7 @@
         },
         {
             "id": "99d3110e-bdd3-576e-b261-16c47efcdc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1e710-f61c-4dd6-b620-6d2e1ecab689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1e710-f61c-4dd6-b620-6d2e1ecab689.jpg?1",
             "name": "Lazav, the Multifarious",
             "text": "When Lazav, the Multifarious enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{X}: Lazav, the Multifarious becomes a copy of target creature card in your graveyard with converted mana cost X, except its name is Lazav, the Multifarious, it's legendary in addition to its other types, and it has this ability.",
             "colours": [
@@ -6268,7 +6268,7 @@
         },
         {
             "id": "56cb0f63-0be1-5d5b-84fb-72827b85ab6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439118d-4869-486e-8930-6e00db2634b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439118d-4869-486e-8930-6e00db2634b2.jpg?1",
             "name": "League Guildmage",
             "text": "{3}{U}, {T}: Draw a card.\n{X}{R}, {T}: Copy target instant or sorcery spell you control with converted mana cost X. You may choose new targets for the copy.",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "3c24662a-8032-53bf-b2c4-1c45a86b35b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f508b-a48d-4462-9d89-ee2ead3a0847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f508b-a48d-4462-9d89-ee2ead3a0847.jpg?1",
             "name": "Ledev Champion",
             "text": "Whenever Ledev Champion attacks, you may tap any number of untapped creatures you control. Ledev Champion gets +1/+1 until end of turn for each creature tapped this way.\n{3}{G}{W}: Create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -6342,7 +6342,7 @@
         },
         {
             "id": "c5a56599-33d0-550c-b7fa-ed55275611d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03423b2-faca-4b2e-8328-8b9b7fdb7ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03423b2-faca-4b2e-8328-8b9b7fdb7ce3.jpg?1",
             "name": "Legion Guildmage",
             "text": "{5}{R}, {T}: Legion Guildmage deals 3 damage to each opponent.\n{2}{W}, {T}: Tap another target creature.",
             "colours": [
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "fb06f4e1-d214-53fc-9a14-9f8ca309e3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg?1",
             "name": "March of the Multitudes",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate X 1/1 white Soldier creature tokens with lifelink.",
             "colours": [
@@ -6413,7 +6413,7 @@
         },
         {
             "id": "1799b591-fd2a-5241-8fc0-7dc2d0364a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cf45aa-ed34-4add-a2ec-fc11f8c15ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cf45aa-ed34-4add-a2ec-fc11f8c15ffa.jpg?1",
             "name": "Mnemonic Betrayal",
             "text": "Exile all cards from all opponents' graveyards. You may cast those cards this turn, and you may spend mana as though it were mana of any type to cast those spells. At the beginning of the next end step, if any of those cards remain exiled, return them to their owners' graveyards.\nExile Mnemonic Betrayal.",
             "colours": [
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "ababf69f-3fc4-51a6-869a-d52ae3f4e8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg?1",
             "name": "Molderhulk",
             "text": "Undergrowth \u2014 This spell costs {1} less to cast for each creature card in your graveyard.\nWhen Molderhulk enters the battlefield, return target land card from your graveyard to the battlefield.",
             "colours": [
@@ -6484,7 +6484,7 @@
         },
         {
             "id": "27f9cec2-429f-5463-bd40-f237853969fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg?1",
             "name": "Nightveil Predator",
             "text": "Flying, deathtouch\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6520,7 +6520,7 @@
         },
         {
             "id": "f72d5581-dd94-5ecb-8ad1-a86b1bdf6df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d2dc5-7b9d-4af6-9f3b-4de90fbf63c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d2dc5-7b9d-4af6-9f3b-4de90fbf63c9.jpg?1",
             "name": "Niv-Mizzet, Parun",
             "text": "This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.",
             "colours": [
@@ -6559,7 +6559,7 @@
         },
         {
             "id": "c23f19a5-9257-59bf-acf1-bf034d826cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db287e-34c1-459b-882d-3db58f13eade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db287e-34c1-459b-882d-3db58f13eade.jpg?1",
             "name": "Notion Rain",
             "text": "Surveil 2, then draw two cards. Notion Rain deals 2 damage to you. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "01584bee-dcc6-514e-91cd-a67eede89b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ef933-64f8-4075-9bd3-97149ac84b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ef933-64f8-4075-9bd3-97149ac84b2b.jpg?1",
             "name": "Ochran Assassin",
             "text": "Deathtouch\nAll creatures able to block Ochran Assassin do so.",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "fd7eebd4-8033-5ba3-9405-cf24d017e4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52066b3-84dc-4198-8090-3336e7df8b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52066b3-84dc-4198-8090-3336e7df8b5d.jpg?1",
             "name": "Ral, Izzet Viceroy",
             "text": "+1: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\n\u22123: Ral, Izzet Viceroy deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\n\u22128: You get an emblem with \"Whenever you cast an instant or sorcery spell, this emblem deals 4 damage to any target and you draw two cards.\"",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "f8d4e5b2-66da-5ad2-aa06-bedadddf5bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg?1",
             "name": "Rhizome Lurcher",
             "text": "Undergrowth \u2014 Rhizome Lurcher enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "9dcd6265-67b3-59d7-a38a-07fc88e728d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg?1",
             "name": "Rosemane Centaur",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nVigilance",
             "colours": [
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "a4a26c58-0694-5d52-9305-38188651411b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c27f2ce-702a-4ec2-a470-982171a9ec73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c27f2ce-702a-4ec2-a470-982171a9ec73.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -6779,7 +6779,7 @@
         },
         {
             "id": "ec8ea354-791f-536d-bbcb-313bc598dd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61a398-cf16-415b-b3cf-897217dc7cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61a398-cf16-415b-b3cf-897217dc7cc9.jpg?1",
             "name": "Sonic Assault",
             "text": "Tap target creature. Sonic Assault deals 2 damage to that creature's controller.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "fb4d9ac2-a253-56a2-bc5f-391a6f7863a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg?1",
             "name": "Sumala Woodshaper",
             "text": "When Sumala Woodshaper enters the battlefield, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "89829313-05f6-5c86-ad9a-e7b8c3e01110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg?1",
             "name": "Swarm Guildmage",
             "text": "{4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn. (They can't be blocked except by two or more creatures.)\n{1}{G}, {T}: You gain 2 life.",
             "colours": [
@@ -6887,7 +6887,7 @@
         },
         {
             "id": "5a2696f3-ecfe-5cb0-b650-384d5a050882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700b38c5-3fd2-4566-8d27-9a09d5ab02b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700b38c5-3fd2-4566-8d27-9a09d5ab02b2.jpg?1",
             "name": "Swathcutter Giant",
             "text": "Vigilance\nWhenever Swathcutter Giant attacks, it deals 1 damage to each creature defending player controls.",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "68dae348-4104-5a94-8492-12a98d446d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285c4d9e-0f22-49a8-b68c-150fd0d4b617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285c4d9e-0f22-49a8-b68c-150fd0d4b617.jpg?1",
             "name": "Swiftblade Vindicator",
             "text": "Double strike, vigilance, trample",
             "colours": [
@@ -6961,7 +6961,7 @@
         },
         {
             "id": "05529d8e-db22-5193-8ead-04e5c6dd835b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e669a01-84d3-4fcc-8396-9e987bd89b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e669a01-84d3-4fcc-8396-9e987bd89b4f.jpg?1",
             "name": "Tajic, Legion's Edge",
             "text": "Haste\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nPrevent all noncombat damage that would be dealt to other creatures you control.\n{R}{W}: Tajic, Legion's Edge gains first strike until end of turn.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "7b882e45-4540-5f06-a157-a24e015c58e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307543ca-8e17-433f-9758-4c77da6c0870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307543ca-8e17-433f-9758-4c77da6c0870.jpg?1",
             "name": "Thief of Sanity",
             "text": "Flying\nWhenever Thief of Sanity deals combat damage to a player, look at the top three cards of that player's library, exile one of them face down, then put the rest into their graveyard. For as long as that card remains exiled, you may look at it, you may cast it, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "f2b51d93-e3c4-570e-b075-4cc1f5c9bd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce226ad-cb1d-47f5-90fc-27704e181884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce226ad-cb1d-47f5-90fc-27704e181884.jpg?1",
             "name": "Thought Erasure",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nSurveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7070,7 +7070,7 @@
         },
         {
             "id": "32a42452-a10b-5c6f-92a0-d13a7c1d95f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a0863-7d07-43f0-925d-a8ce0383a1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a0863-7d07-43f0-925d-a8ce0383a1cb.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "48b1becc-f701-5ae5-b9f4-f94666339df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1190a4-3d7e-4500-991f-e36ec3d1d9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1190a4-3d7e-4500-991f-e36ec3d1d9dc.jpg?1",
             "name": "Trostani Discordant",
             "text": "Other creatures you control get +1/+1.\nWhen Trostani Discordant enters the battlefield, create two 1/1 white Soldier creature tokens with lifelink.\nAt the beginning of your end step, each player gains control of all creatures they own.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "7c6e54ef-0763-56be-9411-c4acd8948b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6099a230-9298-4649-b257-243af40d0625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6099a230-9298-4649-b257-243af40d0625.jpg?1",
             "name": "Truefire Captain",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhenever Truefire Captain is dealt damage, it deals that much damage to target player.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "e2e6cbb2-a9cb-51d4-ad56-d31290ddeedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e08bf-a5d6-48bb-9f7f-4711f9ec88d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e08bf-a5d6-48bb-9f7f-4711f9ec88d7.jpg?1",
             "name": "Undercity Uprising",
             "text": "Creatures you control gain deathtouch until end of turn. Then target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7213,7 +7213,7 @@
         },
         {
             "id": "b0712617-ce64-57c4-ba79-9f35a9105b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782e090-209c-428f-966a-17f3ceab2903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782e090-209c-428f-966a-17f3ceab2903.jpg?1",
             "name": "Underrealm Lich",
             "text": "If you would draw a card, instead look at the top three cards of your library, then put one into your hand and the rest into your graveyard.\nPay 4 life: Underrealm Lich gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -7251,7 +7251,7 @@
         },
         {
             "id": "0bb3a53b-2004-5426-95ea-31ce7f71c17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95aecc12-3363-41f7-9b58-277c81859670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95aecc12-3363-41f7-9b58-277c81859670.jpg?1",
             "name": "Unmoored Ego",
             "text": "Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles their library, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "c92d3b22-ae93-5660-a487-44fd09845dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36d3ea7-0f18-4865-b47b-755673db065e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36d3ea7-0f18-4865-b47b-755673db065e.jpg?1",
             "name": "Vraska, Golgari Queen",
             "text": "+2: You may sacrifice another permanent. If you do, you gain 1 life and draw a card.\n\u22123: Destroy target nonland permanent with converted mana cost 3 or less.\n\u22129: You get an emblem with \"Whenever a creature you control deals combat damage to a player, that player loses the game.\"",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "b62a63e8-5208-5d18-b8dc-8190d37b885a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee17a1-76ce-4ae8-9109-ba32457cbeec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee17a1-76ce-4ae8-9109-ba32457cbeec.jpg?1",
             "name": "Wee Dragonauts",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Wee Dragonauts gets +2/+0 until end of turn.",
             "colours": [
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "8708d385-a3ee-50f4-8377-83be641cad4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg?1",
             "name": "Worldsoul Colossus",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWorldsoul Colossus enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -7396,7 +7396,7 @@
         },
         {
             "id": "aa07b355-dcd5-585f-bdd9-1fa028eaf24d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b19518-7752-4673-a7d8-ae2e0070129c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b19518-7752-4673-a7d8-ae2e0070129c.jpg?1",
             "name": "Fresh-Faced Recruit",
             "text": "As long as it's your turn, Fresh-Faced Recruit has first strike.",
             "colours": [
@@ -7433,7 +7433,7 @@
         },
         {
             "id": "4b319d61-dfce-52bc-b81d-72ddc165ccf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec7523a-a9c4-4b76-8f9e-b591a88e2e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec7523a-a9c4-4b76-8f9e-b591a88e2e37.jpg?1",
             "name": "Piston-Fist Cyclops",
             "text": "Defender\nAs long as you've cast an instant or sorcery spell this turn, Piston-Fist Cyclops can attack as though it didn't have defender.",
             "colours": [
@@ -7469,7 +7469,7 @@
         },
         {
             "id": "1d09942f-b07d-564d-8396-719ee994d7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg?1",
             "name": "Pitiless Gorgon",
             "text": "Deathtouch",
             "colours": [
@@ -7505,7 +7505,7 @@
         },
         {
             "id": "093bfdec-03ae-5159-b5a5-7518b84fb50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg?1",
             "name": "Vernadi Shieldmate",
             "text": "Vigilance",
             "colours": [
@@ -7542,7 +7542,7 @@
         },
         {
             "id": "c107f11f-13e1-5b9c-896f-52c753c5fa81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg?1",
             "name": "Whisper Agent",
             "text": "Flash\nWhen Whisper Agent enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7579,7 +7579,7 @@
         },
         {
             "id": "30151a21-89a0-5e95-9c50-18569875cdab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg?1",
             "name": "Assure // Assemble",
             "text": "Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.",
             "colours": [
@@ -7613,7 +7613,7 @@
         },
         {
             "id": "67adb8d5-8077-5222-a0b5-e1e37ec7507a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg?1",
             "name": "Assure // Assemble",
             "text": "Create three 2/2 green and white Elf Knight creature tokens with vigilance.",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "e3406eb1-506e-553d-81b1-f3ef839ff58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg?1",
             "name": "Connive // Concoct",
             "text": "Gain control of target creature with power 2 or less.",
             "colours": [
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "9044bc5b-81bb-5d32-8ee8-48cc8671efae",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg?1",
             "name": "Connive // Concoct",
             "text": "Surveil 3, then return a creature card from your graveyard to the battlefield.",
             "colours": [
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "84af590f-f59c-5961-b312-70dcc1d2dfea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg?1",
             "name": "Discovery // Dispersal",
             "text": "Surveil 2, then draw a card. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "08aec574-a6c5-58cd-aaa8-5de809f3cefb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg?1",
             "name": "Discovery // Dispersal",
             "text": "Each opponent returns a nonland permanent they control with the highest converted mana cost among permanents they control to its owner's hand, then discards a card.",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "f2f6904a-e7f7-524c-9077-feab5f2e4577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg?1",
             "name": "Expansion // Explosion",
             "text": "Copy target instant or sorcery spell with converted mana cost 4 or less. You may choose new targets for the copy.",
             "colours": [
@@ -7817,7 +7817,7 @@
         },
         {
             "id": "a0aaef0f-9c24-5708-90f9-50fd524cd312",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg?1",
             "name": "Expansion // Explosion",
             "text": "Explosion deals X damage to any target. Target player draws X cards.",
             "colours": [
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "dc6a3121-9752-5078-b88f-abd64a96118e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg?1",
             "name": "Find // Finality",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -7885,7 +7885,7 @@
         },
         {
             "id": "7b7fedbb-7703-55e2-b678-c8698bdf8ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg?1",
             "name": "Find // Finality",
             "text": "You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.",
             "colours": [
@@ -7919,7 +7919,7 @@
         },
         {
             "id": "fbc07191-5f41-5ce8-b5a0-2330840715a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg?1",
             "name": "Flower // Flourish",
             "text": "Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -7953,7 +7953,7 @@
         },
         {
             "id": "565c56f9-b9b7-50b2-9852-f7ea0a137978",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg?1",
             "name": "Flower // Flourish",
             "text": "Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -7987,7 +7987,7 @@
         },
         {
             "id": "6374adea-5750-5bf6-8f82-e70bdfd71bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg?1",
             "name": "Integrity // Intervention",
             "text": "Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "0766b4b2-e233-5827-ad3c-b048f2ac3d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg?1",
             "name": "Integrity // Intervention",
             "text": "Intervention deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "4387960d-3972-5b9c-a186-8dcf70034359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg?1",
             "name": "Invert // Invent",
             "text": "Switch the power and toughness of each of up to two target creatures.",
             "colours": [
@@ -8089,7 +8089,7 @@
         },
         {
             "id": "c5d3fc32-fe45-5c84-86f3-174edf24b334",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg?1",
             "name": "Invert // Invent",
             "text": "Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -8123,7 +8123,7 @@
         },
         {
             "id": "5d6e8114-f958-5521-966c-1a3a044423fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg?1",
             "name": "Response // Resurgence",
             "text": "Response deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "e1746db1-c96d-5887-bb16-c2d14f4714e2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg?1",
             "name": "Response // Resurgence",
             "text": "Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -8191,7 +8191,7 @@
         },
         {
             "id": "11d1affe-50ea-54d7-86e7-649416f30204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg?1",
             "name": "Status // Statue",
             "text": "Target creature gets +1/+1 and gains deathtouch until end of turn.",
             "colours": [
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "3a952e1f-b101-5652-a90b-eb0fa00b1e48",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg?1",
             "name": "Status // Statue",
             "text": "Destroy target artifact, creature, or enchantment.",
             "colours": [
@@ -8259,7 +8259,7 @@
         },
         {
             "id": "f5e3b7fa-83e1-5e77-b656-ffc34b2c5437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg?1",
             "name": "Boros Locket",
             "text": "{T}: Add {R} or {W}.\n{GU}{GU}{GU}{GU}, {T}, Sacrifice Boros Locket: Draw two cards.",
             "colours": [],
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "b36fb73e-f357-5f54-bd3f-43b82108180b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dfd5f2-5298-4cf4-80fe-43db9be24f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dfd5f2-5298-4cf4-80fe-43db9be24f57.jpg?1",
             "name": "Chamber Sentry",
             "text": "Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.\n{X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.\n{W}{U}{B}{R}{G}: Return Chamber Sentry from your graveyard to your hand.",
             "colours": [],
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "0aeb1e56-d320-53f2-9f29-4c699dcf2b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea123356-3055-4e42-b816-ac3c4e9087d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea123356-3055-4e42-b816-ac3c4e9087d1.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "431afa9a-168b-579a-b004-10b0f8cffd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg?1",
             "name": "Dimir Locket",
             "text": "{T}: Add {U} or {B}.\n{UB}{UB}{UB}{UB}, {T}, Sacrifice Dimir Locket: Draw two cards.",
             "colours": [],
@@ -8386,7 +8386,7 @@
         },
         {
             "id": "601991f2-36ef-5583-8f79-7fd5e3c1e346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bbdd54e-5d7e-4e4b-8d59-4e3f46877d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bbdd54e-5d7e-4e4b-8d59-4e3f46877d39.jpg?1",
             "name": "Gatekeeper Gargoyle",
             "text": "Flying\nGatekeeper Gargoyle enters the battlefield with a +1/+1 counter on it for each Gate you control.",
             "colours": [],
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "83c992e4-1493-5858-886c-213fd0fcb040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19723ad-7bd2-49ee-a57a-ece99018f4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19723ad-7bd2-49ee-a57a-ece99018f4e8.jpg?1",
             "name": "Glaive of the Guildpact",
             "text": "Equipped creature gets +1/+0 for each Gate you control and has vigilance and menace. (A creature with menace can't be blocked except by two or more creatures.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "5418a8ad-be11-567c-99f6-8a2c6db605e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg?1",
             "name": "Golgari Locket",
             "text": "{T}: Add {B} or {G}.\n{BG}{BG}{BG}{BG}, {T}, Sacrifice Golgari Locket: Draw two cards.",
             "colours": [],
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "ee1277fe-8246-5d33-85d4-905fc897b702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg?1",
             "name": "Izzet Locket",
             "text": "{T}: Add {U} or {R}.\n{UR}{UR}{UR}{UR}, {T}, Sacrifice Izzet Locket: Draw two cards.",
             "colours": [],
@@ -8509,7 +8509,7 @@
         },
         {
             "id": "dc7b364d-2755-513a-b414-6c88b73343db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg?1",
             "name": "Rampaging Monument",
             "text": "Trample\nRampaging Monument enters the battlefield with three +1/+1 counters on it.\nWhenever you cast a multicolored spell, put a +1/+1 counter on Rampaging Monument.",
             "colours": [],
@@ -8540,7 +8540,7 @@
         },
         {
             "id": "3b5437ec-9f28-55f8-9fd3-6814fe7d1578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg?1",
             "name": "Selesnya Locket",
             "text": "{T}: Add {G} or {W}.\n{RW}{RW}{RW}{RW}, {T}, Sacrifice Selesnya Locket: Draw two cards.",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "5ecb845a-1e71-5fd1-ba08-14dafe510a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg?1",
             "name": "Silent Dart",
             "text": "{4}, {T}, Sacrifice Silent Dart: It deals 3 damage to target creature.",
             "colours": [],
@@ -8599,7 +8599,7 @@
         },
         {
             "id": "d3888501-29a1-5636-86d6-84c706a7ee0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f208bc-e4dc-4d3a-8906-dccde3cc251b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f208bc-e4dc-4d3a-8906-dccde3cc251b.jpg?1",
             "name": "Wand of Vertebrae",
             "text": "{T}: Put the top card of your library into your graveyard.\n{2}, {T}, Exile Wand of Vertebrae: Shuffle up to five target cards from your graveyard into your library.",
             "colours": [],
@@ -8627,7 +8627,7 @@
         },
         {
             "id": "bfd93037-c939-5174-9c4a-b735bbd2822f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52ceefc-90d0-49d1-ae54-9a4eab819849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52ceefc-90d0-49d1-ae54-9a4eab819849.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "d3cf9123-77d4-5f74-ad3c-b1d6f86f142b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f52d32-c04b-4711-9edc-8fd1d3547a44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f52d32-c04b-4711-9edc-8fd1d3547a44.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "86e860bb-6974-5b6b-9158-0bd2adcdb911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7129bdf-de02-4ed2-b5de-f774b8a7d302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7129bdf-de02-4ed2-b5de-f774b8a7d302.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8732,7 +8732,7 @@
         },
         {
             "id": "44f8087c-cc55-5ae7-a618-8751e7bcb13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3694ac90-e71e-4736-8945-7dbf5b5fd6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3694ac90-e71e-4736-8945-7dbf5b5fd6a9.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "b65b4e3d-d08a-5559-a8c2-714de82e3889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg?1",
             "name": "Gateway Plaza",
             "text": "Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8797,7 +8797,7 @@
         },
         {
             "id": "218b1942-147e-5714-bc42-313a5f63b2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86706d8e-de08-4778-94ba-ae75ed522472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86706d8e-de08-4778-94ba-ae75ed522472.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8832,7 +8832,7 @@
         },
         {
             "id": "adc48ddd-9973-57f9-8fd4-541d24c9a02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a021e9-b11a-4028-86c9-01b62eae1877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a021e9-b11a-4028-86c9-01b62eae1877.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "e02d2a6d-cea1-55dc-817e-8e7389fcb118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba12bda-d460-4206-8469-4357c967b9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba12bda-d460-4206-8469-4357c967b9b8.jpg?1",
             "name": "Guildmages' Forum",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color. If that mana is spent on a multicolored creature spell, that creature enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [],
@@ -8895,7 +8895,7 @@
         },
         {
             "id": "e5c3454f-6ad9-5b79-848a-0577f126a365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2055a83a-99c8-4808-90b9-1c2fdcda79b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2055a83a-99c8-4808-90b9-1c2fdcda79b4.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "3c010556-ee1a-50fd-b488-ec4ae0832d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc36bb2a-115d-4e24-a1e9-02b21773e945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc36bb2a-115d-4e24-a1e9-02b21773e945.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "6746108f-8643-5585-9e7a-a3444ec29122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff1f52c-5c43-4260-aaa0-6920846a191c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff1f52c-5c43-4260-aaa0-6920846a191c.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G}.)\nAs Overgrown Tomb enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "0f18776f-71b4-59aa-af5a-df8ff1bc0ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b598d0-535d-477d-a33d-d6a10ff5439a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b598d0-535d-477d-a33d-d6a10ff5439a.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W}.)\nAs Sacred Foundry enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9033,7 +9033,7 @@
         },
         {
             "id": "17416856-3b20-5357-a0cd-977a73d75b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee7a5-937a-4c2b-af8c-6e5734677c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee7a5-937a-4c2b-af8c-6e5734677c53.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9068,7 +9068,7 @@
         },
         {
             "id": "60b24e18-89ed-5657-8bff-bfc191b872b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1db693-5dd9-48de-8520-014d9ad5b596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1db693-5dd9-48de-8520-014d9ad5b596.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "6d0c10f2-c95b-5b71-b5df-ad2f14e642c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ebe3cf-7143-453a-b0ef-2f5bdaac3185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ebe3cf-7143-453a-b0ef-2f5bdaac3185.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R}.)\nAs Steam Vents enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9137,7 +9137,7 @@
         },
         {
             "id": "f5d5918f-da74-5790-9130-37f0ad7f839e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9b0195-beda-403e-bc27-7ae3be9f318c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9b0195-beda-403e-bc27-7ae3be9f318c.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W}.)\nAs Temple Garden enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9171,7 +9171,7 @@
         },
         {
             "id": "1e98e3ac-019c-5a88-9473-993be2484c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4595f2-9297-40dc-b2dd-7144bbb401f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4595f2-9297-40dc-b2dd-7144bbb401f7.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B}.)\nAs Watery Grave enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9205,7 +9205,7 @@
         },
         {
             "id": "61e6c590-9134-5dfc-8d5e-1f5edad07549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983acda-68b6-468b-b0c1-aad8b53db49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983acda-68b6-468b-b0c1-aad8b53db49c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "a865513e-d082-5b04-8009-1f8bb7e636c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bfbf3e-3a6c-40d4-8e1b-255f429de6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bfbf3e-3a6c-40d4-8e1b-255f429de6cc.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9273,7 +9273,7 @@
         },
         {
             "id": "1f848d3c-98b8-5941-86b6-352995f489b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd5a7f0-5ad3-44e8-a103-07739fd53630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd5a7f0-5ad3-44e8-a103-07739fd53630.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "f7e3deba-7d3e-5705-be88-957a77523c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f918a49-a046-4115-80b8-13490ed5cd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f918a49-a046-4115-80b8-13490ed5cd0a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "adb305c1-9371-57b5-8212-6a890b82330c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85892ae-dacd-4a55-a557-9db3c16017c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85892ae-dacd-4a55-a557-9db3c16017c7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "72c69fec-2809-5a5f-ad5e-02e9963bca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44f0c60-5732-4c25-9ba9-4829f1891762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44f0c60-5732-4c25-9ba9-4829f1891762.jpg?1",
             "name": "Ral, Caller of Storms",
             "text": "+1: Draw a card.\n\u22122: Ral, Caller of Storms deals 3 damage divided as you choose among one, two, or three targets.\n\u22127: Draw seven cards. Ral, Caller of Storms deals 7 damage to each creature your opponents control.",
             "colours": [
@@ -9412,7 +9412,7 @@
         },
         {
             "id": "ff593171-c63d-5ed9-88b4-4353525a073a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2660fae-6459-446d-85dc-3c9126c81cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2660fae-6459-446d-85dc-3c9126c81cb3.jpg?1",
             "name": "Ral's Dispersal",
             "text": "Return target creature to its owner's hand. You may search your library and/or graveyard for a card named Ral, Caller of Storms, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9443,7 +9443,7 @@
         },
         {
             "id": "4132334d-c29c-5ee7-a307-7d3c0b2f32e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg?1",
             "name": "Precision Bolt",
             "text": "Precision Bolt deals 3 damage to any target.",
             "colours": [
@@ -9474,7 +9474,7 @@
         },
         {
             "id": "06451a69-e67d-5ea8-bfcf-8b28ad10d0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa16dc-03b3-4533-884c-a23b992b8d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa16dc-03b3-4533-884c-a23b992b8d86.jpg?1",
             "name": "Ral's Staticaster",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever Ral's Staticaster attacks, if you control a Ral planeswalker, Ral's Staticaster gets +1/+0 for each card in your hand until end of turn.",
             "colours": [
@@ -9510,7 +9510,7 @@
         },
         {
             "id": "b11075fb-b582-5438-aa8a-5fbd46e33a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4299dbe6-c94d-4ecc-8bfd-741d2649cba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4299dbe6-c94d-4ecc-8bfd-741d2649cba1.jpg?1",
             "name": "Vraska, Regal Gorgon",
             "text": "+2: Put a +1/+1 counter on up to one target creature. That creature gains menace until end of turn.\n\u22123: Destroy target creature.\n\u221210: For each creature card in your graveyard, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -9547,7 +9547,7 @@
         },
         {
             "id": "76a96141-7f23-537f-bc92-f288b8d08b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg?1",
             "name": "Kraul Raider",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -9581,7 +9581,7 @@
         },
         {
             "id": "475c1dd9-816b-5fec-a1a8-a48a9b3dfec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4840f1-3db3-4ba6-b75b-bbd87251a3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4840f1-3db3-4ba6-b75b-bbd87251a3af.jpg?1",
             "name": "Attendant of Vraska",
             "text": "When Attendant of Vraska dies, if you control a Vraska planeswalker, you gain life equal to Attendant of Vraska's power.",
             "colours": [
@@ -9617,7 +9617,7 @@
         },
         {
             "id": "116d77fe-d09d-516b-87e7-736686ee122e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fc4db6-a5f5-4254-ae64-c8eaf2c98030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fc4db6-a5f5-4254-ae64-c8eaf2c98030.jpg?1",
             "name": "Vraska's Stoneglare",
             "text": "Destroy target creature. You gain life equal to its toughness. You may search your library and/or graveyard for a card named Vraska, Regal Gorgon, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "ad5c0740-144d-58fd-8fde-e2f3aee52fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg?1",
             "name": "Impervious Greatwurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
             "colours": [
@@ -9683,7 +9683,7 @@
         },
         {
             "id": "4c454188-bb99-56c9-8ef8-54c6b0a13053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb271a8-68bb-45e6-9f99-568479e92ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb271a8-68bb-45e6-9f99-568479e92ea0.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9717,7 +9717,7 @@
         },
         {
             "id": "4f83983f-76b0-57e8-8231-0e19f4bd4362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45907b16-af17-4237-ab38-9d7537fd30e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45907b16-af17-4237-ab38-9d7537fd30e8.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9751,7 +9751,7 @@
         },
         {
             "id": "c5499171-7f2a-51e7-8679-f4732f2b4d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c3dc23-d6f2-4209-82e1-a0b936c94231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c3dc23-d6f2-4209-82e1-a0b936c94231.jpg?1",
             "name": "Bird Illusion",
             "text": "",
             "colours": [
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "02c36c5b-83d2-5f52-8936-ef55ae895933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27dc0bd-ba46-4a5c-9559-7c11eb4ec37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27dc0bd-ba46-4a5c-9559-7c11eb4ec37b.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "99859c93-5f3d-5dc3-ace1-f8c1802706f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0436e71b-c1f9-4ca8-a29c-775da858a0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0436e71b-c1f9-4ca8-a29c-775da858a0cd.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -9856,7 +9856,7 @@
         },
         {
             "id": "e34f0600-7c7d-53c2-9a84-79b7cba4b62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74506297-41ad-40e5-bb05-175650ff4907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74506297-41ad-40e5-bb05-175650ff4907.jpg?1",
             "name": "Elf Knight",
             "text": "",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "5ef31151-c5e4-5a26-8239-e17a1cbe245b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03580d3a-4c02-4f2e-b667-f82028ccde0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03580d3a-4c02-4f2e-b667-f82028ccde0b.jpg?1",
             "name": "Ral, Izzet Viceroy Emblem",
             "text": "",
             "colours": [],
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "6d9a50c3-1fbb-5ac3-9b2a-3f809e5ca705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81478ee-1ddf-44f5-98a0-df6d4eecad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81478ee-1ddf-44f5-98a0-df6d4eecad7e.jpg?1",
             "name": "Vraska, Golgari Queen Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/GTC.json
+++ b/Assets/Resources/Sets/GTC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "bee409c6-6fb9-5ac1-8c12-891ad27b72b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63e9c49-3fa4-41ad-9eed-19801df103c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63e9c49-3fa4-41ad-9eed-19801df103c6.jpg?1",
             "name": "Aerial Maneuver",
             "text": "Target creature gets +1/+1 and gains flying and first strike until end of turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "7be5a9a3-d8ba-5b98-aeab-34609f042bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b62d3-c200-4330-a255-92d77f01ba44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b62d3-c200-4330-a255-92d77f01ba44.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "8a74424e-bb7c-5c8c-b2d1-3e6e2c230ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb04702-5cb2-4590-b675-9409ba52a395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb04702-5cb2-4590-b675-9409ba52a395.jpg?1",
             "name": "Angelic Skirmisher",
             "text": "Flying\nAt the beginning of each combat, choose first strike, vigilance, or lifelink. Creatures you control gain that ability until end of turn.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "a54dc634-b6f5-5ffe-afb2-21bdf1331e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704286a5-e3a8-4517-85e5-6447c5c2530f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704286a5-e3a8-4517-85e5-6447c5c2530f.jpg?1",
             "name": "Assault Griffin",
             "text": "Flying",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "4b210ccc-11d0-5bbe-9511-4aff34d2994a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39fed-4b39-4027-9c80-f2186f7dd941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39fed-4b39-4027-9c80-f2186f7dd941.jpg?1",
             "name": "Basilica Guards",
             "text": "Defender\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "7419d1dc-a480-52ac-9b8c-f96825f58a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c3e78d-d917-4552-842f-feff99c059e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c3e78d-d917-4552-842f-feff99c059e0.jpg?1",
             "name": "Blind Obedience",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nArtifacts and creatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "52214847-9686-541a-b344-b3d825860763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03974e6-aced-4664-8c5c-3190bb1eb233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03974e6-aced-4664-8c5c-3190bb1eb233.jpg?1",
             "name": "Boros Elite",
             "text": "Battalion \u2014 Whenever Boros Elite and at least two other creatures attack, Boros Elite gets +2/+2 until end of turn.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "a68d4ba3-a72c-5778-9e07-f17df73dd287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6a5cb3-b6e5-4879-83b5-4ad590a5467a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6a5cb3-b6e5-4879-83b5-4ad590a5467a.jpg?1",
             "name": "Court Street Denizen",
             "text": "Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "1ee7384f-513a-514c-b41d-940a1ae9ad87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c28412d-9add-4911-8487-c84559006fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c28412d-9add-4911-8487-c84559006fb0.jpg?1",
             "name": "Daring Skyjek",
             "text": "Battalion \u2014 Whenever Daring Skyjek and at least two other creatures attack, Daring Skyjek gains flying until end of turn.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "531edb3b-9590-592c-a035-3c15a886b0a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafb0372-6860-4b0b-b92e-873735489006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafb0372-6860-4b0b-b92e-873735489006.jpg?1",
             "name": "Debtor's Pulpit",
             "text": "Enchant land\nEnchanted land has \"{T}: Tap target creature.\"",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "d19ad127-ffcb-51a2-852a-6ce53ddb5a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d586143-fac0-463f-96ec-c6b9fd582194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d586143-fac0-463f-96ec-c6b9fd582194.jpg?1",
             "name": "Dutiful Thrull",
             "text": "{B}: Regenerate Dutiful Thrull.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "a7759ce2-cbd0-5410-b1fb-1e2a7cb051b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711a5eca-531d-4b07-b7df-9b06bad491be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711a5eca-531d-4b07-b7df-9b06bad491be.jpg?1",
             "name": "Frontline Medic",
             "text": "Battalion \u2014 Whenever Frontline Medic and at least two other creatures attack, creatures you control are indestructible this turn.\nSacrifice Frontline Medic: Counter target spell with {X} in its mana cost unless its controller pays {3}.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "1744765e-0d19-5111-99aa-206fd97af367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d0509a-a863-4d9c-b39f-625a8cc1a547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d0509a-a863-4d9c-b39f-625a8cc1a547.jpg?1",
             "name": "Gideon, Champion of Justice",
             "text": "+1: Put a loyalty counter on Gideon, Champion of Justice for each creature target opponent controls.\n0: Until end of turn, Gideon, Champion of Justice becomes an indestructible Human Soldier creature with power and toughness each equal to the number of loyalty counters on him. He's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n-15: Exile all other permanents.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "4cfc18c6-76b8-54e2-aecb-9683515c0daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86940635-7001-4ecf-b4ee-25aa1e2d81fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86940635-7001-4ecf-b4ee-25aa1e2d81fc.jpg?1",
             "name": "Guardian of the Gateless",
             "text": "Flying\nGuardian of the Gateless can block any number of creatures.\nWhenever Guardian of the Gateless blocks, it gets +1/+1 until end of turn for each creature it's blocking.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "c63b0b5d-9a3e-5bcf-9f7b-89e9e5f2dabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c5c496-0a3e-40e1-84ac-8ad3a9d8352b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c5c496-0a3e-40e1-84ac-8ad3a9d8352b.jpg?1",
             "name": "Guildscorn Ward",
             "text": "Enchant creature\nEnchanted creature has protection from multicolored.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "9b8c573d-ad6a-5f4f-a56c-43c4a82bb9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fd52d0-0e41-48d5-b96f-4c6409788c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fd52d0-0e41-48d5-b96f-4c6409788c18.jpg?1",
             "name": "Hold the Gates",
             "text": "Creatures you control get +0/+1 for each Gate you control and have vigilance.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "3aa60db0-9a99-5201-bd07-977e1e7c760f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95567596-c5b1-426f-bc2c-43306f7221b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95567596-c5b1-426f-bc2c-43306f7221b0.jpg?1",
             "name": "Holy Mantle",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has protection from creatures.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "4b19bd55-06b7-53b1-91b1-2f571ff747aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2a1100-a2e6-4ef5-a8e3-2aca552d6b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2a1100-a2e6-4ef5-a8e3-2aca552d6b66.jpg?1",
             "name": "Knight of Obligation",
             "text": "Vigilance\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "9853c637-334c-5d0f-be60-bb4cdd2a3668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd492072-9a8c-4d55-ac71-3c8efaa3fc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd492072-9a8c-4d55-ac71-3c8efaa3fc87.jpg?1",
             "name": "Knight Watch",
             "text": "Put two 2/2 white Knight creature tokens with vigilance onto the battlefield.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "dbd830c7-eddf-5040-a486-fe2c50a73272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0747b12-c75a-4fdf-a881-f2383a23ccdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0747b12-c75a-4fdf-a881-f2383a23ccdd.jpg?1",
             "name": "Luminate Primordial",
             "text": "Vigilance\nWhen Luminate Primordial enters the battlefield, for each opponent, exile up to one target creature that player controls and that player gains life equal to its power.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "c4c15faa-3bd0-533c-88f4-527569aeeea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3bb284-d10e-4265-92a4-8dcaf118f3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3bb284-d10e-4265-92a4-8dcaf118f3c8.jpg?1",
             "name": "Murder Investigation",
             "text": "Enchant creature you control\nWhen enchanted creature dies, put X 1/1 white Soldier creature tokens onto the battlefield, where X is its power.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "6b2fe06e-eb5a-58ee-8703-fe525bcb8a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d7f8-375f-40f5-98cd-08be08580bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d7f8-375f-40f5-98cd-08be08580bef.jpg?1",
             "name": "Nav Squad Commandos",
             "text": "Battalion \u2014 Whenever Nav Squad Commandos and at least two other creatures attack, Nav Squad Commandos gets +1/+1 until end of turn. Untap it.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "5ccfb36c-c190-558d-ad6b-54734e83b0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52cb325-4f16-4cf3-9999-feafe0fde8c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52cb325-4f16-4cf3-9999-feafe0fde8c2.jpg?1",
             "name": "Righteous Charge",
             "text": "Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "236594f4-c099-54c0-8107-08388ccb8d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6546b6c4-73b2-41b3-9ff9-316e9ce916e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6546b6c4-73b2-41b3-9ff9-316e9ce916e5.jpg?1",
             "name": "Shielded Passage",
             "text": "Prevent all damage that would be dealt to target creature this turn.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "8b186c0d-3a80-576f-aa18-7983522cc8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff799e40-fd40-4f6a-8fa8-c22d77476168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff799e40-fd40-4f6a-8fa8-c22d77476168.jpg?1",
             "name": "Smite",
             "text": "Destroy target blocked creature.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "8d610cba-8282-5f0d-b665-6c3d152510fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bafaa3b-eeaa-427f-9a73-6a1c98d257ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bafaa3b-eeaa-427f-9a73-6a1c98d257ca.jpg?1",
             "name": "Syndic of Tithes",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "f176ac72-ab9a-5262-b08a-fef5c1e084c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf932ac-5ea5-491b-b555-5e9ea971d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf932ac-5ea5-491b-b555-5e9ea971d93d.jpg?1",
             "name": "Urbis Protector",
             "text": "When Urbis Protector enters the battlefield, put a 4/4 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "f8091b87-998c-53bd-a6bc-fa091cc79f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf5efe4-d9a0-4704-b5ba-3213c946df37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf5efe4-d9a0-4704-b5ba-3213c946df37.jpg?1",
             "name": "Zarichi Tiger",
             "text": "{1}{W}, {T}: You gain 2 life.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "3377e7d7-fcea-5636-82d8-ca0ffabc16e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33303859-c6e0-4ebd-bb5f-44be7f5d7459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33303859-c6e0-4ebd-bb5f-44be7f5d7459.jpg?1",
             "name": "Aetherize",
             "text": "Return all attacking creatures to their owner's hand.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "8e6e0c9d-b5f1-5de8-986b-36042c11326d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a3efab-ee0a-4770-a323-e4bac38e4287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a3efab-ee0a-4770-a323-e4bac38e4287.jpg?1",
             "name": "Agoraphobia",
             "text": "Enchant creature\nEnchanted creature gets -5/-0.\n{2}{U}: Return Agoraphobia to its owner's hand.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "f708accb-edc6-5684-8711-5b69bfc80895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e183069-096d-4977-8154-e7b60f17a787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e183069-096d-4977-8154-e7b60f17a787.jpg?1",
             "name": "Clinging Anemones",
             "text": "Defender\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "2d25f0a0-c0d8-56e7-b006-a982ee6abddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2931f27-43f9-4e52-aab3-967c26739e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2931f27-43f9-4e52-aab3-967c26739e43.jpg?1",
             "name": "Cloudfin Raptor",
             "text": "Flying\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "f711d896-7ec5-5dbd-ad8a-1c0dc310b8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c34af-91de-44c6-a3e2-f48dbb0ce9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c34af-91de-44c6-a3e2-f48dbb0ce9fd.jpg?1",
             "name": "Diluvian Primordial",
             "text": "Flying\nWhen Diluvian Primordial enters the battlefield, for each opponent, you may cast up to one target instant or sorcery card from that player's graveyard without paying its mana cost. If a card cast this way would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "501b70c9-4d86-519b-9a08-af31deb555cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612beb8f-2ab1-4a8b-84c5-c47d19d400ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612beb8f-2ab1-4a8b-84c5-c47d19d400ab.jpg?1",
             "name": "Enter the Infinite",
             "text": "Draw cards equal to the number of cards in your library, then put a card from your hand on top of your library. You have no maximum hand size until your next turn.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "f99185c5-c847-5092-9679-607207a45f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f3a08f-403e-4d6c-87c7-add8170bde8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f3a08f-403e-4d6c-87c7-add8170bde8b.jpg?1",
             "name": "Frilled Oculus",
             "text": "{1}{G}: Frilled Oculus gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "bfc0f48f-c36d-5e24-8e3f-352d57fb1c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f5c126-3df9-4771-9e74-4ca33161ac08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f5c126-3df9-4771-9e74-4ca33161ac08.jpg?1",
             "name": "Gridlock",
             "text": "Tap X target nonland permanents.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "27041222-6210-5044-a7eb-68edfc5dda1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeef50a-f5c9-47ab-ad04-645f49bbae6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeef50a-f5c9-47ab-ad04-645f49bbae6b.jpg?1",
             "name": "Hands of Binding",
             "text": "Tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "f036c5b4-d4d8-53ec-b90a-b39b8aeea1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290e56e0-e699-413a-9d6a-e740bf460b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290e56e0-e699-413a-9d6a-e740bf460b35.jpg?1",
             "name": "Incursion Specialist",
             "text": "Whenever you cast your second spell each turn, Incursion Specialist gets +2/+0 until end of turn and is unblockable this turn.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "328d557b-438d-52da-b8fc-20c6fcf99c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ee9a3-a862-46a7-9aa5-7b6fc4ffa1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ee9a3-a862-46a7-9aa5-7b6fc4ffa1ab.jpg?1",
             "name": "Keymaster Rogue",
             "text": "Keymaster Rogue is unblockable.\nWhen Keymaster Rogue enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "ac15542b-15b6-5600-8633-4bb8d51cac9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6033d07-124c-4001-81e1-c6eb99e07fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6033d07-124c-4001-81e1-c6eb99e07fdd.jpg?1",
             "name": "Last Thoughts",
             "text": "Draw a card.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1354,7 +1354,7 @@
         },
         {
             "id": "a7d2544b-6834-5bc0-95f2-fa871f777951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0867865-d9eb-45d2-a359-064f0f61197b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0867865-d9eb-45d2-a359-064f0f61197b.jpg?1",
             "name": "Leyline Phantom",
             "text": "When Leyline Phantom deals combat damage, return it to its owner's hand. (Return it only if it survived combat.)",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "e60a0605-0e50-5e0e-a9ad-3071fa19c6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f349013-0846-4bec-bdf9-47a3706d9989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f349013-0846-4bec-bdf9-47a3706d9989.jpg?1",
             "name": "Metropolis Sprite",
             "text": "Flying\n{U}: Metropolis Sprite gets +1/-1 until end of turn.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "dd6fea2b-3220-5553-8f24-c13c5c5d7b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947f44b0-91be-4115-b499-57893f0f69a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947f44b0-91be-4115-b499-57893f0f69a9.jpg?1",
             "name": "Mindeye Drake",
             "text": "Flying\nWhen Mindeye Drake dies, target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "14bcd970-5e90-50d2-acf7-a91d7a4fff3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83557f55-f1ab-4995-9cc1-37be895a59db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83557f55-f1ab-4995-9cc1-37be895a59db.jpg?1",
             "name": "Rapid Hybridization",
             "text": "Destroy target creature. It can't be regenerated. That creature's controller puts a 3/3 green Frog Lizard creature token onto the battlefield.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "ddac5c27-49dc-571d-a142-9950ab16e17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989c76b2-d130-443d-8534-6525fef404c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989c76b2-d130-443d-8534-6525fef404c2.jpg?1",
             "name": "Realmwright",
             "text": "As Realmwright enters the battlefield, choose a basic land type.\nLands you control are the chosen type in addition to their other types.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "b9e56838-e585-5f46-a58f-c2dbf4208627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063e6df9-2287-485a-ab46-fa4a38783884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063e6df9-2287-485a-ab46-fa4a38783884.jpg?1",
             "name": "Sage's Row Denizen",
             "text": "Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "44a82c1d-9fd1-594c-b4a1-b1fb2a8eb2c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fe14cf-5d34-47d1-9071-4a532819719b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fe14cf-5d34-47d1-9071-4a532819719b.jpg?1",
             "name": "Sapphire Drake",
             "text": "Flying\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "c3fca587-b376-5e1a-a847-da240bf892f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ed969f-2c8e-4421-9448-dc5a2afdc81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ed969f-2c8e-4421-9448-dc5a2afdc81d.jpg?1",
             "name": "Scatter Arc",
             "text": "Counter target noncreature spell.\nDraw a card.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "06024474-14b6-53d7-b744-fb7ae8cdf09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633b59-6051-4f47-9e27-538fda03b5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633b59-6051-4f47-9e27-538fda03b5dd.jpg?1",
             "name": "Simic Fluxmage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\n{1}{U}, {T}: Move a +1/+1 counter from Simic Fluxmage onto target creature.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "6f890f45-e5cc-5d03-89ff-7457e3387c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dff9e6-5e0c-4e5b-8184-f0ae9cf347b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dff9e6-5e0c-4e5b-8184-f0ae9cf347b3.jpg?1",
             "name": "Simic Manipulator",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\n{T}, Remove one or more +1/+1 counters from Simic Manipulator: Gain control of target creature with power less than or equal to the number of +1/+1 counters removed this way.",
             "colours": [
@@ -1695,7 +1695,7 @@
         },
         {
             "id": "840a11c5-862e-5b58-a5a6-3101ebac30fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5bf75-762f-46ef-8304-aacdb248bc5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5bf75-762f-46ef-8304-aacdb248bc5b.jpg?1",
             "name": "Skygames",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature gains flying until end of turn. Activate this ability only any time you could cast a sorcery.\"",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "babc3fdc-8296-5b65-96ff-8c7e16661230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7267fcec-0879-4743-a45f-35057ccb2596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7267fcec-0879-4743-a45f-35057ccb2596.jpg?1",
             "name": "Spell Rupture",
             "text": "Counter target spell unless its controller pays {X}, where X is the greatest power among creatures you control.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "7caa711f-6581-5858-815a-f5b55c9d3129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e058447-7cee-4670-b86b-c95bd6b68144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e058447-7cee-4670-b86b-c95bd6b68144.jpg?1",
             "name": "Stolen Identity",
             "text": "Put a token onto the battlefield that's a copy of target artifact or creature.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "746dec76-537b-5614-8e7f-c3146c4686ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8e4142-7c46-4d2f-aaa6-6410f323d9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8e4142-7c46-4d2f-aaa6-6410f323d9f0.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "d696c22d-5fdd-579a-ba6a-c11f0e126be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611d0e10-e767-4e66-b1f1-02f1624fab2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611d0e10-e767-4e66-b1f1-02f1624fab2b.jpg?1",
             "name": "Voidwalk",
             "text": "Exile target creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "b3596e45-6339-5780-90c9-5019cb33b3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249ca81-bd8d-4d3d-81d6-15e8d669c416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249ca81-bd8d-4d3d-81d6-15e8d669c416.jpg?1",
             "name": "Way of the Thief",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature is unblockable as long as you control a Gate.",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "a295ce0b-0c89-5196-b9ba-3584335d42f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a3f05-864d-401d-a2f1-5f58358fe089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a3f05-864d-401d-a2f1-5f58358fe089.jpg?1",
             "name": "Balustrade Spy",
             "text": "Flying\nWhen Balustrade Spy enters the battlefield, target player reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "83d849a7-2e83-57d3-bf6d-d4a1ed199f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d233c6bc-c4dd-482d-b0f4-87359acab7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d233c6bc-c4dd-482d-b0f4-87359acab7cb.jpg?1",
             "name": "Basilica Screecher",
             "text": "Flying\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "f92a3c70-8fee-5bf3-b35b-d7226c7d6fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2384356-0a62-499a-8b28-085974331368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2384356-0a62-499a-8b28-085974331368.jpg?1",
             "name": "Contaminated Ground",
             "text": "Enchant land\nEnchanted land is a Swamp.\nWhenever enchanted land becomes tapped, its controller loses 2 life.",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "811d3657-606e-5b5e-83bd-336de23b00f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84234e51-e5d6-43d9-89d0-f0398fc6b7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84234e51-e5d6-43d9-89d0-f0398fc6b7fd.jpg?1",
             "name": "Corpse Blockade",
             "text": "Defender\nSacrifice another creature: Corpse Blockade gains deathtouch until end of turn.",
             "colours": [
@@ -2028,7 +2028,7 @@
         },
         {
             "id": "a029ea82-d13c-5e89-8df4-b9a68c7c95c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3795a4e7-646f-4bb7-b154-2610eb740e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3795a4e7-646f-4bb7-b154-2610eb740e8d.jpg?1",
             "name": "Crypt Ghast",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever you tap a Swamp for mana, add {B} to your mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "7d636893-17aa-553b-9b1f-6db7b20d2008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f69c6f-522d-42c8-be7c-ea6d7ffb6a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f69c6f-522d-42c8-be7c-ea6d7ffb6a90.jpg?1",
             "name": "Death's Approach",
             "text": "Enchant creature\nEnchanted creature gets -X/-X, where X is the number of creature cards in its controller's graveyard.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "ae3c76af-8641-5f57-b41f-6002c67e6b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c42ebd-114a-430d-b3a4-ff2fb3093bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c42ebd-114a-430d-b3a4-ff2fb3093bf5.jpg?1",
             "name": "Devour Flesh",
             "text": "Target player sacrifices a creature, then gains life equal to that creature's toughness.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "7bbdb017-92b2-5bb7-8895-568e749ce16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46e83d3-c66d-42fb-8435-b6c448db01ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46e83d3-c66d-42fb-8435-b6c448db01ae.jpg?1",
             "name": "Dying Wish",
             "text": "Enchant creature you control\nWhen enchanted creature dies, target player loses X life and you gain X life, where X is its power.",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "c246c024-f040-5d9f-b4e9-12580748d21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33fc15-3a4f-48bc-be7c-fdec1cb49c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33fc15-3a4f-48bc-be7c-fdec1cb49c10.jpg?1",
             "name": "Gateway Shade",
             "text": "{B}: Gateway Shade gets +1/+1 until end of turn.\nTap an untapped Gate you control: Gateway Shade gets +2/+2 until end of turn.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "8070ed06-c052-5b7f-a8c9-1c0f030a1d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d0f6e-e7bd-4206-a0da-1c9c203a73f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d0f6e-e7bd-4206-a0da-1c9c203a73f2.jpg?1",
             "name": "Grisly Spectacle",
             "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "faf78a13-4585-53bc-8c96-3756ffd7a281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830c7c77-20c4-429f-88c7-b85ab7a0e38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830c7c77-20c4-429f-88c7-b85ab7a0e38b.jpg?1",
             "name": "Gutter Skulk",
             "text": "",
             "colours": [
@@ -2263,7 +2263,7 @@
         },
         {
             "id": "82a0b21a-2bf3-59d6-a3e0-e4d0114de55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d36c9d-967e-42dc-890c-0485b12f704f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d36c9d-967e-42dc-890c-0485b12f704f.jpg?1",
             "name": "Horror of the Dim",
             "text": "{U}: Horror of the Dim gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "e114c72c-06fe-5c6b-bf2b-fcf7c7e69f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989a68c1-3b76-4c2d-9db3-23c45be3f9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989a68c1-3b76-4c2d-9db3-23c45be3f9ff.jpg?1",
             "name": "Illness in the Ranks",
             "text": "Creature tokens get -1/-1.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "37b9b0ce-7abb-56a3-ac78-8d94e32c5aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a4d87d-b844-4f20-8b14-4fd32c53dea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a4d87d-b844-4f20-8b14-4fd32c53dea5.jpg?1",
             "name": "Killing Glare",
             "text": "Destroy target creature with power X or less.",
             "colours": [
@@ -2362,7 +2362,7 @@
         },
         {
             "id": "200865c3-37bb-5e7b-a419-60239bda0ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b83fe5-fd00-4532-bc67-07836abfc99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b83fe5-fd00-4532-bc67-07836abfc99c.jpg?1",
             "name": "Lord of the Void",
             "text": "Flying\nWhenever Lord of the Void deals combat damage to a player, exile the top seven cards of that player's library, then put a creature card from among them onto the battlefield under your control.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "d3241085-4130-5aa2-b9d4-f164fec00a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076e7c58-a6fe-4882-8f8d-698be9a7f22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076e7c58-a6fe-4882-8f8d-698be9a7f22d.jpg?1",
             "name": "Mental Vapors",
             "text": "Target player discards a card.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "caa808f4-5de9-5f2d-8e50-576787f582ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df40471-1118-4429-83bf-8225ea50b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df40471-1118-4429-83bf-8225ea50b69f.jpg?1",
             "name": "Midnight Recovery",
             "text": "Return target creature card from your graveyard to your hand.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "52ba9b7e-9761-5e35-8048-2136880d97c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727bd1-9415-408a-99de-dd992e26e767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727bd1-9415-408a-99de-dd992e26e767.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may put a 1/1 black Rat creature token onto the battlefield.\nRats you control have deathtouch.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "10671ab6-0121-52ee-813f-2e36322aa87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0865cd-d9b4-43ea-87d2-ad5c65fc0459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0865cd-d9b4-43ea-87d2-ad5c65fc0459.jpg?1",
             "name": "Sepulchral Primordial",
             "text": "Intimidate\nWhen Sepulchral Primordial enters the battlefield, for each opponent, you may put up to one target creature card from that player's graveyard onto the battlefield under your control.",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "011ccfdb-3149-52a6-b57e-9720ab1b3d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985997ae-59bc-49d7-87ca-e63ed9706fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985997ae-59bc-49d7-87ca-e63ed9706fdf.jpg?1",
             "name": "Shadow Alley Denizen",
             "text": "Whenever another black creature enters the battlefield under your control, target creature gains intimidate until end of turn. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2564,7 +2564,7 @@
         },
         {
             "id": "04f6262b-a81e-5a45-b970-983208ae7f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497fbf4-cf09-4028-af16-349ed12ca360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497fbf4-cf09-4028-af16-349ed12ca360.jpg?1",
             "name": "Shadow Slice",
             "text": "Target opponent loses 3 life.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "852268ea-ce0b-562c-97e4-def7e2e512a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51528a3e-beba-47f8-a524-ad99b1fec308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51528a3e-beba-47f8-a524-ad99b1fec308.jpg?1",
             "name": "Slate Street Ruffian",
             "text": "Whenever Slate Street Ruffian becomes blocked, defending player discards a card.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "b98227f8-711e-5666-a1d9-19e0ebe56123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667871d3-0d1b-496b-afbd-7504989798e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667871d3-0d1b-496b-afbd-7504989798e4.jpg?1",
             "name": "Smog Elemental",
             "text": "Flying\nCreatures with flying your opponents control get -1/-1.",
             "colours": [
@@ -2665,7 +2665,7 @@
         },
         {
             "id": "77aebac0-58c8-5379-a89f-602d0856e044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde6ee2e-a114-4935-8345-d3e264f9fc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde6ee2e-a114-4935-8345-d3e264f9fc26.jpg?1",
             "name": "Syndicate Enforcer",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "50e02e85-171c-5676-a1cb-627b887e1725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38dfb08-ab41-4759-9967-b5a25f18518a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38dfb08-ab41-4759-9967-b5a25f18518a.jpg?1",
             "name": "Thrull Parasite",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\n{T}, Pay 2 life: Remove a counter from target nonland permanent.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "09b06bba-0c62-5b5f-acce-5ab08ae72b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0f73-cfb0-41d9-b4eb-09c605112a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0f73-cfb0-41d9-b4eb-09c605112a13.jpg?1",
             "name": "Undercity Informer",
             "text": "{1}, Sacrifice a creature: Target player reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "982abb54-d16b-5386-8a07-76687a18a9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b25d3bc-33e9-4d1a-855d-38580e67b6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b25d3bc-33e9-4d1a-855d-38580e67b6cc.jpg?1",
             "name": "Undercity Plague",
             "text": "Target player loses 1 life, discards a card, then sacrifices a permanent.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "736996b4-3053-5055-aace-11bdbe3953a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04644ba-5962-4e64-bc53-92941c5b6715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04644ba-5962-4e64-bc53-92941c5b6715.jpg?1",
             "name": "Wight of Precinct Six",
             "text": "Wight of Precinct Six gets +1/+1 for each creature card in your opponents' graveyards.",
             "colours": [
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "6e2b6aad-f9a0-5c6b-a667-a73f4917fdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04c8c6f-14e9-427c-918e-208ccd39ec4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04c8c6f-14e9-427c-918e-208ccd39ec4a.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "a8fe51ff-e2ee-5f70-afc5-f153e7b8a440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1675f2-e950-4f3c-9dd3-29ead615ff23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1675f2-e950-4f3c-9dd3-29ead615ff23.jpg?1",
             "name": "Bomber Corps",
             "text": "Battalion \u2014 Whenever Bomber Corps and at least two other creatures attack, Bomber Corps deals 1 damage to target creature or player.",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "b210a41a-6df9-51b9-a3a9-b38331019c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf10ce-69e0-4984-91a3-f65df919830d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf10ce-69e0-4984-91a3-f65df919830d.jpg?1",
             "name": "Cinder Elemental",
             "text": "{X}{R}, {T}, Sacrifice Cinder Elemental: Cinder Elemental deals X damage to target creature or player.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "039b8af0-7436-590f-a9e5-a2dfee7ffd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323c86c-73bd-4e23-9f80-54bf5c1dd0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323c86c-73bd-4e23-9f80-54bf5c1dd0bc.jpg?1",
             "name": "Crackling Perimeter",
             "text": "Tap an untapped Gate you control: Crackling Perimeter deals 1 damage to each opponent.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "8409a946-77a4-55c0-9719-644dba661d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d9cab-b07b-456b-9562-7ea7f6bec7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d9cab-b07b-456b-9562-7ea7f6bec7f3.jpg?1",
             "name": "Ember Beast",
             "text": "Ember Beast can't attack or block alone.",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "89e0b5c5-b4fb-5860-bf9b-c50a16c883ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc2f22-4500-4c74-a1a2-51d8238c1d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc2f22-4500-4c74-a1a2-51d8238c1d16.jpg?1",
             "name": "Firefist Striker",
             "text": "Battalion \u2014 Whenever Firefist Striker and at least two other creatures attack, target creature can't block this turn.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "eaf56bb3-2a64-5632-a62e-7d1bc1bf33ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb550d0c-2261-4f41-a2b1-d185f0bce86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb550d0c-2261-4f41-a2b1-d185f0bce86a.jpg?1",
             "name": "Five-Alarm Fire",
             "text": "Whenever a creature you control deals combat damage, put a blaze counter on Five-Alarm Fire.\nRemove five blaze counters from Five-Alarm Fire: Five-Alarm Fire deals 5 damage to target creature or player.",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "b6fa94fd-d44d-54b7-aec2-5898c37a7196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0befed63-07ba-4728-9078-57bbccbeeeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0befed63-07ba-4728-9078-57bbccbeeeb1.jpg?1",
             "name": "Foundry Street Denizen",
             "text": "Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "2ec932a2-0eb1-50d1-bde3-73ddadc836af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeea013-1cf8-4c77-a097-aa69e141e3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeea013-1cf8-4c77-a097-aa69e141e3f4.jpg?1",
             "name": "Furious Resistance",
             "text": "Target blocking creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "7d88b6d9-c6f0-5326-ad91-dc643c4485d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3401f-935b-45ce-b1e6-300a5d9dfd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3401f-935b-45ce-b1e6-300a5d9dfd4f.jpg?1",
             "name": "Hellkite Tyrant",
             "text": "Flying, trample\nWhenever Hellkite Tyrant deals combat damage to a player, gain control of all artifacts that player controls.\nAt the beginning of your upkeep, if you control twenty or more artifacts, you win the game.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "7e995515-e099-5f4a-8256-a8321e9aaf5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156941e7-9169-47aa-b04d-37ca78c54f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156941e7-9169-47aa-b04d-37ca78c54f7c.jpg?1",
             "name": "Hellraiser Goblin",
             "text": "Creatures you control have haste and attack each combat if able.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "39c8355f-26e9-533d-9561-c6bc440688b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6535816-8fa4-4c8b-8677-ac80f769f528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6535816-8fa4-4c8b-8677-ac80f769f528.jpg?1",
             "name": "Homing Lightning",
             "text": "Homing Lightning deals 4 damage to target creature and each other creature with the same name as that creature.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "2e6de5bd-c4ed-540d-bcc8-95d01d23feff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47f639e-4635-4c26-bb2a-4925f0582c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47f639e-4635-4c26-bb2a-4925f0582c21.jpg?1",
             "name": "Legion Loyalist",
             "text": "Haste\nBattalion \u2014 Whenever Legion Loyalist and at least two other creatures attack, creatures you control gain first strike and trample until end of turn and can't be blocked by creature tokens this turn.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "ea117600-17da-5065-8656-b23c380d5c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2667-40f6-4c1c-af81-3e45d2437d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2667-40f6-4c1c-af81-3e45d2437d5f.jpg?1",
             "name": "Madcap Skills",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and can't be blocked except by two or more creatures.",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "8d1d2b60-3179-578f-b171-017638c169a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45498dbd-a512-4299-800b-06c15a4fd94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45498dbd-a512-4299-800b-06c15a4fd94e.jpg?1",
             "name": "Mark for Death",
             "text": "Target creature an opponent controls blocks this turn if able. Untap that creature. Other creatures that player controls can't block this turn.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "2fe94e9e-4c1f-5e52-aa53-dcf95a02ca2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b16fbd8-fb62-4f75-92b3-a6295d95b327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b16fbd8-fb62-4f75-92b3-a6295d95b327.jpg?1",
             "name": "Massive Raid",
             "text": "Massive Raid deals damage to target creature or player equal to the number of creatures you control.",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "53271b3f-498f-5fe9-aceb-f60f2f27a4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5c7e2-f4da-4cee-a7d0-80b29bb73acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5c7e2-f4da-4cee-a7d0-80b29bb73acd.jpg?1",
             "name": "Molten Primordial",
             "text": "Haste\nWhen Molten Primordial enters the battlefield, for each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "3148644d-45e6-585b-a98d-26882e6e2dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ca502f-73a3-42f3-b7ad-f69aa239900a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ca502f-73a3-42f3-b7ad-f69aa239900a.jpg?1",
             "name": "Mugging",
             "text": "Mugging deals 2 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -3436,7 +3436,7 @@
         },
         {
             "id": "49cb7a50-09e8-5eb0-97ca-36b0df3aa3aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d5daf-404d-46e9-b622-e89a1f55e908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d5daf-404d-46e9-b622-e89a1f55e908.jpg?1",
             "name": "Ripscale Predator",
             "text": "Ripscale Predator can't be blocked except by two or more creatures.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "4a0d6748-4df1-5c12-a136-e392bb3e5108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ac6bde-1fef-45f4-b505-80a66b03140a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ac6bde-1fef-45f4-b505-80a66b03140a.jpg?1",
             "name": "Scorchwalker",
             "text": "Bloodrush \u2014 {1}{R}{R}, Discard Scorchwalker: Target attacking creature gets +5/+1 until end of turn.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "476425dd-8896-557d-806e-7ca653fb0f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4f9b6c-3ba9-4f4f-8135-f5236195e507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4f9b6c-3ba9-4f4f-8135-f5236195e507.jpg?1",
             "name": "Skinbrand Goblin",
             "text": "Bloodrush \u2014 {R}, Discard Skinbrand Goblin: Target attacking creature gets +2/+1 until end of turn.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "61b3ae38-ad0a-54b6-8a26-aad0567cf6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068a146-f6fe-46f3-a42e-822fbc3502e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068a146-f6fe-46f3-a42e-822fbc3502e6.jpg?1",
             "name": "Skullcrack",
             "text": "Players can't gain life this turn. Damage can't be prevented this turn. Skullcrack deals 3 damage to target player.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "928ad2e9-9272-5f1e-8ea9-a630a2ccd6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10da484-db67-4afc-90ef-6caf7d2e3a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10da484-db67-4afc-90ef-6caf7d2e3a75.jpg?1",
             "name": "Structural Collapse",
             "text": "Target player sacrifices an artifact and a land. Structural Collapse deals 2 damage to that player.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "d2ac5556-c442-5da1-a774-e3dbf6b372ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1f543b-2222-4ef5-b4f7-2c3d2ea27fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1f543b-2222-4ef5-b4f7-2c3d2ea27fdc.jpg?1",
             "name": "Tin Street Market",
             "text": "Enchant land\nEnchanted land has \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "80313df5-ca0f-5d07-9217-a20d18227236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68e9280-cb1a-48e1-a91e-217e101f19c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68e9280-cb1a-48e1-a91e-217e101f19c5.jpg?1",
             "name": "Towering Thunderfist",
             "text": "{W}: Towering Thunderfist gains vigilance until end of turn.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "a03e9272-4b67-5bdc-8f84-cb79b58d31c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dd72d5-548a-4b0e-95bb-e6b8d2de0fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dd72d5-548a-4b0e-95bb-e6b8d2de0fbe.jpg?1",
             "name": "Viashino Shanktail",
             "text": "First strike\nBloodrush \u2014 {2}{R}, Discard Viashino Shanktail: Target attacking creature gets +3/+1 and gains first strike until end of turn.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "044345d6-7cb8-5c5a-9a00-2049f0c6b521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a5f801-9e55-4e14-85b0-5719521cd9d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a5f801-9e55-4e14-85b0-5719521cd9d6.jpg?1",
             "name": "Warmind Infantry",
             "text": "Battalion \u2014 Whenever Warmind Infantry and at least two other creatures attack, Warmind Infantry gets +2/+0 until end of turn.",
             "colours": [
@@ -3743,7 +3743,7 @@
         },
         {
             "id": "2a0b7325-b5cb-5ee0-871d-8d547704fc99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f1a27c-c576-4c34-873f-6faf020c2773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f1a27c-c576-4c34-873f-6faf020c2773.jpg?1",
             "name": "Wrecking Ogre",
             "text": "Double strike\nBloodrush \u2014 {3}{R}{R}, Discard Wrecking Ogre: Target attacking creature gets +3/+3 and gains double strike until end of turn.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "189efa7c-ff59-5c95-99f5-c1e88531a919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3c0c43-2d6d-49b8-a112-07611a23ae69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3c0c43-2d6d-49b8-a112-07611a23ae69.jpg?1",
             "name": "Adaptive Snapjaw",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3813,7 +3813,7 @@
         },
         {
             "id": "22a36c33-8c3e-50f4-afdf-c31de32342f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc42ca6-db90-41d0-8a4b-3217fb2c114c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc42ca6-db90-41d0-8a4b-3217fb2c114c.jpg?1",
             "name": "Alpha Authority",
             "text": "Enchant creature\nEnchanted creature has hexproof and can't be blocked by more than one creature.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "b1397a7c-1175-5fef-b1d8-701336901330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbd617-9f2e-4882-b8f0-dfc2fced2281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbd617-9f2e-4882-b8f0-dfc2fced2281.jpg?1",
             "name": "Burst of Strength",
             "text": "Put a +1/+1 counter on target creature and untap it.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "f5fbabd1-6e66-5a5e-8187-8e7f3b8b99ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b459a988-97b0-4370-b89a-2565f8721b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b459a988-97b0-4370-b89a-2565f8721b60.jpg?1",
             "name": "Crocanura",
             "text": "Reach (This creature can block creatures with flying.)\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3914,7 +3914,7 @@
         },
         {
             "id": "f85e2c35-bb4a-590e-aa1b-484db366664b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eacc64-f418-4df0-bd8a-6b0036d0d2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eacc64-f418-4df0-bd8a-6b0036d0d2a1.jpg?1",
             "name": "Crowned Ceratok",
             "text": "Trample\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "73b7d35d-b2a6-5d45-a07e-d9bbc2624d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c62b3ee-db2b-45c3-87d5-5d917ea4baeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c62b3ee-db2b-45c3-87d5-5d917ea4baeb.jpg?1",
             "name": "Disciple of the Old Ways",
             "text": "{R}: Disciple of the Old Ways gains first strike until end of turn.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "981e4517-b3e6-5aeb-b50b-42937a3408a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc1d8d0-bb43-4962-ad29-bb6478aa986b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc1d8d0-bb43-4962-ad29-bb6478aa986b.jpg?1",
             "name": "Experiment One",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nRemove two +1/+1 counters from Experiment One: Regenerate Experiment One.",
             "colours": [
@@ -4019,7 +4019,7 @@
         },
         {
             "id": "f5fab74a-f8f0-5ad1-be76-5a41874034a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6527d61-e9d3-44d0-833e-19c072309270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6527d61-e9d3-44d0-833e-19c072309270.jpg?1",
             "name": "Forced Adaptation",
             "text": "Enchant creature\nAt the beginning of your upkeep, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "366fde79-33fe-5ae5-9748-31b959d633b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae725f-e582-4377-a855-51af035cdac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae725f-e582-4377-a855-51af035cdac3.jpg?1",
             "name": "Giant Adephage",
             "text": "Trample\nWhenever Giant Adephage deals combat damage to a player, put a token onto the battlefield that's a copy of Giant Adephage.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "a9f6b2e5-56ad-518a-b869-408718c05a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e825cb2d-98d7-423d-9ba1-b4d04027027e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e825cb2d-98d7-423d-9ba1-b4d04027027e.jpg?1",
             "name": "Greenside Watcher",
             "text": "{T}: Untap target Gate.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "6ca3f7fa-713b-5769-9090-eb8491406d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6345376a-3d2d-4fff-9430-5e90a96e2f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6345376a-3d2d-4fff-9430-5e90a96e2f0f.jpg?1",
             "name": "Gyre Sage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\n{T}: Add {G} to your mana pool for each +1/+1 counter on Gyre Sage.",
             "colours": [
@@ -4157,7 +4157,7 @@
         },
         {
             "id": "bc853ac1-054b-548c-b67d-a13a42c03ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b85a09-6d43-4798-8164-131d35b65836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b85a09-6d43-4798-8164-131d35b65836.jpg?1",
             "name": "Hindervines",
             "text": "Prevent all combat damage that would be dealt this turn by creatures with no +1/+1 counters on them.",
             "colours": [
@@ -4189,7 +4189,7 @@
         },
         {
             "id": "83cf41cb-58ea-5daa-a9f4-77bec644a75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95be874-93c0-4e05-9e5a-fe8f38bcb445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95be874-93c0-4e05-9e5a-fe8f38bcb445.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "cc8ef28b-fa86-5fcd-9617-62c48e598714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d0584-89d2-499b-b6c2-2425c4ffcd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d0584-89d2-499b-b6c2-2425c4ffcd13.jpg?1",
             "name": "Miming Slime",
             "text": "Put an X/X green Ooze creature token onto the battlefield, where X is the greatest power among creatures you control.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "3ee506e1-8a6f-5c5c-8d02-8126146ea746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf36ca-56ca-4987-ac93-248d43c9c401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf36ca-56ca-4987-ac93-248d43c9c401.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "de8eea8f-b20f-51c4-a51e-3505f7ae4cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9554369-7961-4cea-9da0-a1235805a26a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9554369-7961-4cea-9da0-a1235805a26a.jpg?1",
             "name": "Ooze Flux",
             "text": "{1}{G}, Remove one or more +1/+1 counters from among creatures you control: Put an X/X green Ooze creature token onto the battlefield, where X is the number of +1/+1 counters removed this way.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "17787951-6808-50dc-b4ab-79696afa114f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47324ab7-df78-4859-be0b-2eef5d4f8082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47324ab7-df78-4859-be0b-2eef5d4f8082.jpg?1",
             "name": "Predator's Rapport",
             "text": "Choose target creature you control. You gain life equal to that creature's power plus its toughness.",
             "colours": [
@@ -4352,7 +4352,7 @@
         },
         {
             "id": "64a86440-5b54-51a5-9bb6-986ea92fb40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57335b5-30e2-431f-ab50-d5f1981783c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57335b5-30e2-431f-ab50-d5f1981783c3.jpg?1",
             "name": "Rust Scarab",
             "text": "Whenever Rust Scarab becomes blocked, you may destroy target artifact or enchantment defending player controls.",
             "colours": [
@@ -4386,7 +4386,7 @@
         },
         {
             "id": "6234ea25-15ac-57b8-8d8f-736500c8ca63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964c88d3-3141-44ab-8856-44a3f08331ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964c88d3-3141-44ab-8856-44a3f08331ea.jpg?1",
             "name": "Scab-Clan Charger",
             "text": "Bloodrush \u2014 {1}{G}, Discard Scab-Clan Charger: Target attacking creature gets +2/+4 until end of turn.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "a7e9682e-c5ce-50d4-acba-902af50acd8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3da4b8-9dd6-455d-b24a-3d0207ae5ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3da4b8-9dd6-455d-b24a-3d0207ae5ee8.jpg?1",
             "name": "Serene Remembrance",
             "text": "Shuffle Serene Remembrance and up to three target cards from a single graveyard into their owners' libraries.",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "ac290a91-0e75-5fb3-81f6-a674841e93e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2dcafd-eb72-4f3a-9c1c-ba17fe30bf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2dcafd-eb72-4f3a-9c1c-ba17fe30bf0f.jpg?1",
             "name": "Skarrg Goliath",
             "text": "Trample\nBloodrush \u2014 {5}{G}{G}, Discard Skarrg Goliath: Target attacking creature gets +9/+9 and gains trample until end of turn.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "b5501360-ef2f-563e-8277-bfc1def32e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3fcc7a-ff5b-4695-aa86-9166f6cba565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3fcc7a-ff5b-4695-aa86-9166f6cba565.jpg?1",
             "name": "Slaughterhorn",
             "text": "Bloodrush \u2014 {G}, Discard Slaughterhorn: Target attacking creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "31f51b71-ff55-5c4a-8934-cf3802694b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428b0d43-94c9-4f7f-b042-ea63f88ac697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428b0d43-94c9-4f7f-b042-ea63f88ac697.jpg?1",
             "name": "Spire Tracer",
             "text": "Spire Tracer can't be blocked except by creatures with flying or reach.",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "60bbf3f1-2ceb-56b1-a1e7-8a02ceef1a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0483c869-38dc-4b0b-82f3-dd08a1ab985f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0483c869-38dc-4b0b-82f3-dd08a1ab985f.jpg?1",
             "name": "Sylvan Primordial",
             "text": "Reach\nWhen Sylvan Primordial enters the battlefield, for each opponent, destroy target noncreature permanent that player controls. For each permanent destroyed this way, search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "9ed78783-af34-5a81-ad69-45d6d093888c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857e1eb2-f3f2-4c7f-9965-da9d7e385223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857e1eb2-f3f2-4c7f-9965-da9d7e385223.jpg?1",
             "name": "Tower Defense",
             "text": "Creatures you control get +0/+5 and gain reach until end of turn.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "86b45483-51ae-5bdf-ab90-1d4cbafc6c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59109a0-fdab-49cb-bbf6-d405de4d1645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59109a0-fdab-49cb-bbf6-d405de4d1645.jpg?1",
             "name": "Verdant Haven",
             "text": "Enchant land\nWhen Verdant Haven enters the battlefield, you gain 2 life.\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "ceed2fb9-ec96-59ae-8ce0-dc7e0ba856e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a5b2b8-3890-485f-8731-8f178a2da3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a5b2b8-3890-485f-8731-8f178a2da3d7.jpg?1",
             "name": "Wasteland Viper",
             "text": "Deathtouch\nBloodrush \u2014 {G}, Discard Wasteland Viper: Target attacking creature gets +1/+2 and gains deathtouch until end of turn.",
             "colours": [
@@ -4690,7 +4690,7 @@
         },
         {
             "id": "b07568f8-5b1f-5aca-89b5-79a2434d87b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a93a1-4442-4d5b-ad7a-136b87b5f7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a93a1-4442-4d5b-ad7a-136b87b5f7ab.jpg?1",
             "name": "Wildwood Rebirth",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "fda5b1c5-8c98-55b7-a77d-6cf167ce6dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce441759-cd4c-4bcc-925e-08e8b60853c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce441759-cd4c-4bcc-925e-08e8b60853c0.jpg?1",
             "name": "Alms Beast",
             "text": "Creatures blocking or blocked by Alms Beast have lifelink.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "37a44282-ab4f-5509-af5a-0aebe83c868f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43675ed7-ece1-4414-965e-9ebadcbf3dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43675ed7-ece1-4414-965e-9ebadcbf3dfb.jpg?1",
             "name": "Assemble the Legion",
             "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then put a 1/1 red and white Soldier creature token with haste onto the battlefield for each muster counter on Assemble the Legion.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "33cae8f7-d7ee-5bfe-a5f4-fb522799dbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18e35-05e4-4bfc-b32b-c3e71c95a71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18e35-05e4-4bfc-b32b-c3e71c95a71d.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia, the Warleader attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -4830,7 +4830,7 @@
         },
         {
             "id": "a195ee3b-6b98-5c42-8a9d-ff093ec7935c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3465b6-ee7f-4553-bbf1-85fae9734b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3465b6-ee7f-4553-bbf1-85fae9734b67.jpg?1",
             "name": "Aurelia's Fury",
             "text": "Aurelia's Fury deals X damage divided as you choose among any number of target creatures and/or players. Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.",
             "colours": [
@@ -4864,7 +4864,7 @@
         },
         {
             "id": "621aff12-468b-593c-828a-dca8b58fd1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996df7f-70f5-412c-9573-9512e4e131ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996df7f-70f5-412c-9573-9512e4e131ac.jpg?1",
             "name": "Bane Alley Broker",
             "text": "{T}: Draw a card, then exile a card from your hand face down.\nYou may look at cards exiled with Bane Alley Broker.\n{U}{B}, {T}: Return a card exiled with Bane Alley Broker to its owner's hand.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "cb451162-23bf-5969-8473-92da77538c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000b4e8-7887-454e-9d52-211516613dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000b4e8-7887-454e-9d52-211516613dd0.jpg?1",
             "name": "Biovisionary",
             "text": "At the beginning of the end step, if you control four or more creatures named Biovisionary, you win the game.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "f5a22037-cf5a-54e8-bf1b-1e3e5907244c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644c60f-7d06-4026-bcf3-df054701ca0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644c60f-7d06-4026-bcf3-df054701ca0a.jpg?1",
             "name": "Borborygmos Enraged",
             "text": "Trample\nWhenever Borborygmos Enraged deals combat damage to a player, reveal the top three cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.\nDiscard a land card: Borborygmos Enraged deals 3 damage to target creature or player.",
             "colours": [
@@ -4976,7 +4976,7 @@
         },
         {
             "id": "7db0102a-5a85-55d8-9f87-d5c0adf08ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ddf9cc-40a7-4b4f-bb51-b08171453c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ddf9cc-40a7-4b4f-bb51-b08171453c9a.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014 Boros Charm deals 4 damage to target player; or permanents you control are indestructible this turn; or target creature gains double strike until end of turn.",
             "colours": [
@@ -5010,7 +5010,7 @@
         },
         {
             "id": "961594a7-ba1a-55cb-af05-31d8bf916c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef30a570-b988-42e8-8910-41fe39ffa260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef30a570-b988-42e8-8910-41fe39ffa260.jpg?1",
             "name": "Call of the Nightwing",
             "text": "Put a 1/1 blue and black Horror creature token with flying onto the battlefield.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -5044,7 +5044,7 @@
         },
         {
             "id": "c95d3247-d1a1-5733-9057-c663169f52ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcfbc0-1401-4e5e-8145-c8936c4ff725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcfbc0-1401-4e5e-8145-c8936c4ff725.jpg?1",
             "name": "Cartel Aristocrat",
             "text": "Sacrifice another creature: Cartel Aristocrat gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "49ffa3c8-6d2e-5daf-8f1b-9ac2b5b37fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa05298-9c94-4179-b75a-49ee2ca92920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa05298-9c94-4179-b75a-49ee2ca92920.jpg?1",
             "name": "Clan Defiance",
             "text": "Choose one or more \u2014 Clan Defiance deals X damage to target creature with flying; Clan Defiance deals X damage to target creature without flying; and/or Clan Defiance deals X damage to target player.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "fb67069b-7732-5c85-8b0c-5c3fb2e61a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6354de66-f7f8-4e33-98d0-52624d3d7828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6354de66-f7f8-4e33-98d0-52624d3d7828.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "2c2b8b80-6b37-5b47-9d7b-840279708c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cfc3c5-6d69-443e-a506-76b94178979b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cfc3c5-6d69-443e-a506-76b94178979b.jpg?1",
             "name": "Deathpact Angel",
             "text": "Flying\nWhen Deathpact Angel dies, put a 1/1 white and black Cleric creature token onto the battlefield. It has \"{3}{W}{B}{B}, {T}, Sacrifice this creature: Return a card named Deathpact Angel from your graveyard to the battlefield.\"",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "f5fb364c-0acc-52fd-9c43-2a3a3f133260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f4cfa7-8ee4-4a85-9e6a-65a7541f62c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f4cfa7-8ee4-4a85-9e6a-65a7541f62c1.jpg?1",
             "name": "Dimir Charm",
             "text": "Choose one \u2014 Counter target sorcery spell; or destroy target creature with power 2 or less; or look at the top three cards of target player's library, then put one back and the rest into that player's graveyard.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "8f43a230-5467-5534-a678-0167a4001867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398df5e6-6bda-467a-81e2-91be7e21d715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398df5e6-6bda-467a-81e2-91be7e21d715.jpg?1",
             "name": "Dinrova Horror",
             "text": "When Dinrova Horror enters the battlefield, return target permanent to its owner's hand, then that player discards a card.",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "8cef3768-7062-5b98-87ea-243eaf4facba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b48170-99dd-440f-9954-fc229d6094d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b48170-99dd-440f-9954-fc229d6094d3.jpg?1",
             "name": "Domri Rade",
             "text": "+1: Look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand.\n-2: Target creature you control fights another target creature.\n-7: You get an emblem with \"Creatures you control have double strike, trample, hexproof, and haste.\"",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "abfa904b-ca58-57bb-b143-acdfd373927f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016d1d17-ba5c-4168-9a3d-232bdcc98c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016d1d17-ba5c-4168-9a3d-232bdcc98c80.jpg?1",
             "name": "Drakewing Krasis",
             "text": "Flying, trample",
             "colours": [
@@ -5332,7 +5332,7 @@
         },
         {
             "id": "ead8b7f3-6de1-5b68-94dc-95286e61a5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1509ff-387e-4ccd-bda0-86e8738a98fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1509ff-387e-4ccd-bda0-86e8738a98fb.jpg?1",
             "name": "Duskmantle Guildmage",
             "text": "{1}{U}{B}: Whenever a card is put into an opponent's graveyard from anywhere this turn, that player loses 1 life.\n{2}{U}{B}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "eea2ffee-b527-5cc7-b045-b58aa4f234a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63711861-87e0-4a63-8b7b-f834aa5f3f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63711861-87e0-4a63-8b7b-f834aa5f3f18.jpg?1",
             "name": "Duskmantle Seer",
             "text": "Flying\nAt the beginning of your upkeep, each player reveals the top card of his or her library, loses life equal to that card's converted mana cost, then puts it into his or her hand.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "57e09939-73cc-5e9c-a681-7a5049580dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd62e422-e5e2-4736-9ed3-d2dc693f6f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd62e422-e5e2-4736-9ed3-d2dc693f6f8f.jpg?1",
             "name": "Elusive Krasis",
             "text": "Elusive Krasis is unblockable.\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -5443,7 +5443,7 @@
         },
         {
             "id": "aa565831-8bc8-5bba-ae9d-ea5d9ad9b08d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2122586d-9b23-47c2-8b00-e673aa0310f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2122586d-9b23-47c2-8b00-e673aa0310f0.jpg?1",
             "name": "Executioner's Swing",
             "text": "Target creature that dealt damage this turn gets -5/-5 until end of turn.",
             "colours": [
@@ -5477,7 +5477,7 @@
         },
         {
             "id": "0c0b31c3-4d54-576d-826f-7662b703d4d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa311f1-f11e-492d-9f18-e7489f950be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa311f1-f11e-492d-9f18-e7489f950be7.jpg?1",
             "name": "Fathom Mage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever a +1/+1 counter is placed on Fathom Mage, you may draw a card.",
             "colours": [
@@ -5514,7 +5514,7 @@
         },
         {
             "id": "6315c69c-f0ad-52ca-a24f-2570568f3242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c198-efdc-492a-9c52-76aac006de9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c198-efdc-492a-9c52-76aac006de9d.jpg?1",
             "name": "Firemane Avenger",
             "text": "Flying\nBattalion \u2014 Whenever Firemane Avenger and at least two other creatures attack, Firemane Avenger deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -5550,7 +5550,7 @@
         },
         {
             "id": "8c305c77-51d9-56a2-8d20-6d602f9f78a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f835f0-abba-402c-bdae-be03ad3fb658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f835f0-abba-402c-bdae-be03ad3fb658.jpg?1",
             "name": "Fortress Cyclops",
             "text": "Whenever Fortress Cyclops attacks, it gets +3/+0 until end of turn.\nWhenever Fortress Cyclops blocks, it gets +0/+3 until end of turn.",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "1096ed0b-ef32-58e8-b26f-4f4b64a47154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e39703-db78-4d3d-aacd-5396848253ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e39703-db78-4d3d-aacd-5396848253ed.jpg?1",
             "name": "Foundry Champion",
             "text": "When Foundry Champion enters the battlefield, it deals damage to target creature or player equal to the number of creatures you control.\n{R}: Foundry Champion gets +1/+0 until end of turn.\n{W}: Foundry Champion gets +0/+1 until end of turn.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "18abd15b-df71-50d6-87fa-c871f1fe6ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bce9a7-6215-43ff-b4d0-55f96f683aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bce9a7-6215-43ff-b4d0-55f96f683aba.jpg?1",
             "name": "Frenzied Tilling",
             "text": "Destroy target land. Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "5fda76c9-9320-5f4f-b961-ee372cd07967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382048ec-0bf5-49a5-90d5-f80fbda08962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382048ec-0bf5-49a5-90d5-f80fbda08962.jpg?1",
             "name": "Ghor-Clan Rampager",
             "text": "Trample\nBloodrush \u2014 {R}{G}, Discard Ghor-Clan Rampager: Target attacking creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5694,7 +5694,7 @@
         },
         {
             "id": "83cab24e-b201-5fc9-adcc-f0a1c6c4a10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4220348-f030-4639-b1a9-6f61ac6bb6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4220348-f030-4639-b1a9-6f61ac6bb6a8.jpg?1",
             "name": "Ground Assault",
             "text": "Ground Assault deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "7ede2cb4-37d2-5d4b-81a1-931c67740da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235afe5-0a6b-43c2-921c-18524cf032f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235afe5-0a6b-43c2-921c-18524cf032f1.jpg?1",
             "name": "Gruul Charm",
             "text": "Choose one \u2014 Creatures without flying can't block this turn; or gain control of all permanents you own; or Gruul Charm deals 3 damage to each creature with flying.",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "80706d20-fe62-5b12-9fbc-3ce209d1e48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ef367-7904-4e5c-a8b4-1fb62f951f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ef367-7904-4e5c-a8b4-1fb62f951f3e.jpg?1",
             "name": "Gruul Ragebeast",
             "text": "Whenever Gruul Ragebeast or another creature enters the battlefield under your control, that creature fights target creature an opponent controls.",
             "colours": [
@@ -5798,7 +5798,7 @@
         },
         {
             "id": "7f01d00c-9f5f-589a-94f9-995ca7aa19e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ff8d-6d7e-49f0-8d30-7f8c23db568b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ff8d-6d7e-49f0-8d30-7f8c23db568b.jpg?1",
             "name": "High Priest of Penance",
             "text": "Whenever High Priest of Penance is dealt damage, you may destroy target nonland permanent.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "fe2fa9ee-b8d3-5e2f-8f4b-fb6e248d0dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4e1f41-4aed-451b-bbaa-6cc6780cd6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4e1f41-4aed-451b-bbaa-6cc6780cd6c9.jpg?1",
             "name": "Hydroform",
             "text": "Target land becomes a 3/3 Elemental creature with flying until end of turn. It's still a land.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "950efa9c-5bf2-513f-8b20-c34f0a165b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3465cf63-4f10-4b53-9703-69746364dbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3465cf63-4f10-4b53-9703-69746364dbc7.jpg?1",
             "name": "Kingpin's Pet",
             "text": "Flying\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -5905,7 +5905,7 @@
         },
         {
             "id": "48a839e0-d8d9-5a16-b7b5-46a0ad994d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8fcdb-4798-4961-995a-e128a3ff431a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8fcdb-4798-4961-995a-e128a3ff431a.jpg?1",
             "name": "Lazav, Dimir Mastermind",
             "text": "Hexproof\nWhenever a creature card is put into an opponent's graveyard from anywhere, you may have Lazav, Dimir Mastermind become a copy of that card except its name is still Lazav, Dimir Mastermind, it's legendary in addition to its other types, and it gains hexproof and this ability.",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "345795cc-a87c-5259-baf2-95354eb3b264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690c96c-70a3-45e5-84d7-5c82809a8f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690c96c-70a3-45e5-84d7-5c82809a8f45.jpg?1",
             "name": "Martial Glory",
             "text": "Target creature gets +3/+0 until end of turn.\nTarget creature gets +0/+3 until end of turn.",
             "colours": [
@@ -5977,7 +5977,7 @@
         },
         {
             "id": "676871af-8fe8-5d8d-a3c3-cf49126c19b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a47da7c-80f3-4b98-aaac-778c34a35cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a47da7c-80f3-4b98-aaac-778c34a35cb6.jpg?1",
             "name": "Master Biomancer",
             "text": "Each other creature you control enters the battlefield with a number of additional +1/+1 counters on it equal to Master Biomancer's power and as a Mutant in addition to its other types.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "1d67b296-1b75-5fe1-8b9e-4e58987054bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9876a4c-714b-47e5-9589-148a623af96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9876a4c-714b-47e5-9589-148a623af96a.jpg?1",
             "name": "Merciless Eviction",
             "text": "Choose one \u2014 Exile all artifacts; or exile all creatures; or exile all enchantments; or exile all planeswalkers.",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "00640f49-f878-5a62-842e-ae7bcd658b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671eb9e8-1a69-4570-8972-2e7de371cef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671eb9e8-1a69-4570-8972-2e7de371cef4.jpg?1",
             "name": "Mind Grind",
             "text": "Each opponent reveals cards from the top of his or her library until he or she reveals X land cards, then puts all cards revealed this way into his or her graveyard. X can't be 0.",
             "colours": [
@@ -6082,7 +6082,7 @@
         },
         {
             "id": "d4cff110-dd79-5bfd-a7a7-2b1ebb3d0089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644eb6e-cc49-4834-bc2c-53f6a4ceb451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644eb6e-cc49-4834-bc2c-53f6a4ceb451.jpg?1",
             "name": "Mortus Strider",
             "text": "When Mortus Strider dies, return it to its owner's hand.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "98cdfa4c-e4ff-5d86-9091-afdf08c049b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1dd1ac-1a1e-485d-a11f-d1323a69f95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1dd1ac-1a1e-485d-a11f-d1323a69f95e.jpg?1",
             "name": "Mystic Genesis",
             "text": "Counter target spell. Put an X/X green Ooze creature token onto the battlefield, where X is that spell's converted mana cost.",
             "colours": [
@@ -6152,7 +6152,7 @@
         },
         {
             "id": "04333f76-ed5f-5085-9be3-9215e1b63b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d691cd3b-afe5-4f28-95a9-125475515126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d691cd3b-afe5-4f28-95a9-125475515126.jpg?1",
             "name": "Nimbus Swimmer",
             "text": "Flying\nNimbus Swimmer enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "d2438561-33fb-5a8b-8f59-cca51bb75f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc198d8-1f27-482d-8f5d-21e02c59797a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc198d8-1f27-482d-8f5d-21e02c59797a.jpg?1",
             "name": "Obzedat, Ghost Council",
             "text": "When Obzedat, Ghost Council enters the battlefield, target opponent loses 2 life and you gain 2 life.\nAt the beginning of your end step, you may exile Obzedat. If you do, return it to the battlefield under its owner's control at the beginning of your next upkeep. It gains haste.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "2738798b-ae64-5365-9ad4-741282884aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef2d548-477b-4be1-b946-6df6aac2ee6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef2d548-477b-4be1-b946-6df6aac2ee6e.jpg?1",
             "name": "One Thousand Lashes",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "2ba16d21-8fcf-51bc-81a5-e47dd9edccd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fea3f6-e64a-4964-86bc-c0b8fef0ab25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fea3f6-e64a-4964-86bc-c0b8fef0ab25.jpg?1",
             "name": "Ordruun Veteran",
             "text": "Battalion \u2014 Whenever Ordruun Veteran and at least two other creatures attack, Ordruun Veteran gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -6300,7 +6300,7 @@
         },
         {
             "id": "6ef4f182-2b33-5564-a10f-fb47f5378853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca44265-5e1b-4fbf-9002-52b2ce9b7448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca44265-5e1b-4fbf-9002-52b2ce9b7448.jpg?1",
             "name": "Orzhov Charm",
             "text": "Choose one \u2014 Return target creature you control and all Auras you control attached to it to their owner's hand; or destroy target creature and you lose life equal to its toughness; or return target creature card with converted mana cost 1 or less from your graveyard to the battlefield.",
             "colours": [
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "337b0cb1-5b79-5c2b-b9c3-6d61200eed64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af406038-91ce-41fe-8b6d-55408a96d0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af406038-91ce-41fe-8b6d-55408a96d0a2.jpg?1",
             "name": "Paranoid Delusions",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -6368,7 +6368,7 @@
         },
         {
             "id": "686b8cd7-f23c-5db0-8af9-3005c6d3a069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd518e8-047a-4df0-a0b8-ba116d048fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd518e8-047a-4df0-a0b8-ba116d048fa8.jpg?1",
             "name": "Primal Visitation",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has haste.",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "98a4219f-09d2-5aa6-b686-cc89c734c101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30dfb8e-f540-45ab-a4e8-63425099646a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30dfb8e-f540-45ab-a4e8-63425099646a.jpg?1",
             "name": "Prime Speaker Zegana",
             "text": "Prime Speaker Zegana enters the battlefield with X +1/+1 counters on it, where X is the greatest power among other creatures you control.\nWhen Prime Speaker Zegana enters the battlefield, draw cards equal to its power.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "f0beff58-f38b-53a5-ad5f-4ce988694955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d87927c-80a6-4146-92a5-58c510ce7958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d87927c-80a6-4146-92a5-58c510ce7958.jpg?1",
             "name": "Psychic Strike",
             "text": "Counter target spell. Its controller puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -6477,7 +6477,7 @@
         },
         {
             "id": "b7b109ee-6f08-544b-8daa-c0c0e1ff30f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937ee156-0105-4291-8c67-d03a59c24679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937ee156-0105-4291-8c67-d03a59c24679.jpg?1",
             "name": "Purge the Profane",
             "text": "Target opponent discards two cards and you gain 2 life.",
             "colours": [
@@ -6511,7 +6511,7 @@
         },
         {
             "id": "af722f5f-55e5-5949-a467-b9677793c134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c502590-f780-4512-8067-7c66f16f8c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c502590-f780-4512-8067-7c66f16f8c9d.jpg?1",
             "name": "Rubblehulk",
             "text": "Rubblehulk's power and toughness are each equal to the number of lands you control.\nBloodrush \u2014 {1}{R}{G}, Discard Rubblehulk: Target attacking creature gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "83f6680f-8d1d-5e15-b651-468ff42fa358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce04d1ee-2605-472d-b3ee-24800342e9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce04d1ee-2605-472d-b3ee-24800342e9af.jpg?1",
             "name": "Ruination Wurm",
             "text": "",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "19966dd9-e91a-5df1-b027-74555322c8f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07855a17-4e68-4257-af7f-275c9fb0a9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07855a17-4e68-4257-af7f-275c9fb0a9b8.jpg?1",
             "name": "Shambleshark",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "6a4559cc-a1c0-51a3-80ae-5513e472d72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34261992-db62-49e3-95bc-1b2960868de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34261992-db62-49e3-95bc-1b2960868de4.jpg?1",
             "name": "Signal the Clans",
             "text": "Search your library for three creature cards and reveal them. If you reveal three cards with different names, choose one of them at random and put that card into your hand. Shuffle the rest into your library.",
             "colours": [
@@ -6654,7 +6654,7 @@
         },
         {
             "id": "2d4403f5-8912-511b-b256-bd3b6f26a906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c27bdd-77f5-4e93-8f54-93a204fc980a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c27bdd-77f5-4e93-8f54-93a204fc980a.jpg?1",
             "name": "Simic Charm",
             "text": "Choose one \u2014 Target creature gets +3/+3 until end of turn; or permanents you control gain hexproof until end of turn; or return target creature to its owner's hand.",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "0da5a13d-0a8b-53e1-ae68-4dbedebb412c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f206c0-a8a7-4ca0-b88f-4736c3dac588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f206c0-a8a7-4ca0-b88f-4736c3dac588.jpg?1",
             "name": "Skarrg Guildmage",
             "text": "{R}{G}: Creatures you control gain trample until end of turn.\n{1}{R}{G}: Target land you control becomes a 4/4 Elemental creature until end of turn. It's still a land.",
             "colours": [
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "b649315e-9bfb-5f12-9bda-6805dfb41871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8c9948-b52e-4d07-a72a-99ab6be05cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8c9948-b52e-4d07-a72a-99ab6be05cc6.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "be7ed97d-bfda-5e4d-b842-4ccb15f57b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd705732-cce9-4d11-85ca-be49381dbaa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd705732-cce9-4d11-85ca-be49381dbaa8.jpg?1",
             "name": "Soul Ransom",
             "text": "Enchant creature\nYou control enchanted creature.\nDiscard two cards: Soul Ransom's controller sacrifices it, then draws two cards. Only any opponent may activate this ability.",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "151a289b-1c0b-50cd-8d04-edd3f43fdee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eb69b5-b8e2-48c6-8c27-cb0108df8dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eb69b5-b8e2-48c6-8c27-cb0108df8dad.jpg?1",
             "name": "Spark Trooper",
             "text": "Trample, lifelink, haste\nAt the beginning of the end step, sacrifice Spark Trooper.",
             "colours": [
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "e9cf8ab3-a6b9-566a-bdbb-d799a944316e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d1122a-099b-49bf-9b53-52429658816a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d1122a-099b-49bf-9b53-52429658816a.jpg?1",
             "name": "Sunhome Guildmage",
             "text": "{1}{R}{W}: Creatures you control get +1/+0 until end of turn.\n{2}{R}{W}: Put a 1/1 red and white Soldier creature token with haste onto the battlefield.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "6b2c1983-e5a6-5b16-8f25-12f26e58c654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f013e6f0-85d0-4c8e-a10b-7beea572c32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f013e6f0-85d0-4c8e-a10b-7beea572c32d.jpg?1",
             "name": "Treasury Thrull",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever Treasury Thrull attacks, you may return target artifact, creature, or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "cffb01e3-a868-56b8-bdb0-c2689e077b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39610192-6d3c-4d03-9c3e-cda966c924b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39610192-6d3c-4d03-9c3e-cda966c924b1.jpg?1",
             "name": "Truefire Paladin",
             "text": "Vigilance\n{R}{W}: Truefire Paladin gets +2/+0 until end of turn.\n{R}{W}: Truefire Paladin gains first strike until end of turn.",
             "colours": [
@@ -6945,7 +6945,7 @@
         },
         {
             "id": "88ba71cf-5061-598e-b121-6ef176554ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10a22-6070-48d7-99ab-45f770f16fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10a22-6070-48d7-99ab-45f770f16fd1.jpg?1",
             "name": "Unexpected Results",
             "text": "Shuffle your library, then reveal the top card. If it's a nonland card, you may cast it without paying its mana cost. If it's a land card, you may put it onto the battlefield and return Unexpected Results to its owner's hand.",
             "colours": [
@@ -6979,7 +6979,7 @@
         },
         {
             "id": "c138b935-e096-5da7-8c76-5c4ee25795d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcd6fac-2cde-4a89-b484-b910be2dcecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcd6fac-2cde-4a89-b484-b910be2dcecf.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -7013,7 +7013,7 @@
         },
         {
             "id": "e8401ce4-67a0-59f2-9514-d70d8912c70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac639b9-6c20-45ac-a61f-082bdcebdb83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac639b9-6c20-45ac-a61f-082bdcebdb83.jpg?1",
             "name": "Vizkopa Confessor",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nWhen Vizkopa Confessor enters the battlefield, pay any amount of life. Target opponent reveals that many cards from his or her hand. You choose one of them and exile it.",
             "colours": [
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "2121deba-edd4-5782-8e00-207d10e2da6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f505a3-2c54-43a9-b4a9-43a1451b36f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f505a3-2c54-43a9-b4a9-43a1451b36f6.jpg?1",
             "name": "Vizkopa Guildmage",
             "text": "{1}{W}{B}: Target creature gains lifelink until end of turn.\n{1}{W}{B}: Whenever you gain life this turn, each opponent loses that much life.",
             "colours": [
@@ -7087,7 +7087,7 @@
         },
         {
             "id": "ae621fea-aa1d-57cb-ba21-74c6ef03f881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4b0cc-e611-4a4b-8392-b37bfc3a77e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4b0cc-e611-4a4b-8392-b37bfc3a77e1.jpg?1",
             "name": "Whispering Madness",
             "text": "Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "d29b521b-164c-5ef8-a576-030b9a70c87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f0870-dc1c-4cd8-b92c-6d5f92abbaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f0870-dc1c-4cd8-b92c-6d5f92abbaec.jpg?1",
             "name": "Wojek Halberdiers",
             "text": "Battalion \u2014 Whenever Wojek Halberdiers and at least two other creatures attack, Wojek Halberdiers gains first strike until end of turn.",
             "colours": [
@@ -7158,7 +7158,7 @@
         },
         {
             "id": "1abfe4a2-0132-5569-9160-cee05164547a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeaf99b-7720-42e3-8cb1-23218b646458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeaf99b-7720-42e3-8cb1-23218b646458.jpg?1",
             "name": "Zameck Guildmage",
             "text": "{G}{U}: This turn, each creature you control enters the battlefield with an additional +1/+1 counter on it.\n{G}{U}, Remove a +1/+1 counter from a creature you control: Draw a card.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "8d03d417-e907-5aef-b829-8acb32809a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef93050-2f24-4c85-a00b-796e53868ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef93050-2f24-4c85-a00b-796e53868ac1.jpg?1",
             "name": "Zhur-Taa Swine",
             "text": "Bloodrush \u2014 {1}{R}{G}, Discard Zhur-Taa Swine: Target attacking creature gets +5/+4 until end of turn.",
             "colours": [
@@ -7231,7 +7231,7 @@
         },
         {
             "id": "82883729-c917-531a-8dd2-e692fdecc4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64a15f4-6e2f-4479-95da-8805ce2091fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64a15f4-6e2f-4479-95da-8805ce2091fa.jpg?1",
             "name": "Arrows of Justice",
             "text": "Arrows of Justice deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "f95ca074-e12a-50b9-9604-c865fa5a2260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2ef9c5-ca6f-4243-bd38-2b325257831c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2ef9c5-ca6f-4243-bd38-2b325257831c.jpg?1",
             "name": "Beckon Apparition",
             "text": "Exile target card from a graveyard. Put a 1/1 white and black Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -7299,7 +7299,7 @@
         },
         {
             "id": "c5db77c4-8dcc-581f-9e60-ac7a6457183b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0a11d-0390-437e-8ece-3229863c76db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0a11d-0390-437e-8ece-3229863c76db.jpg?1",
             "name": "Biomass Mutation",
             "text": "Creatures you control become X/X until end of turn.",
             "colours": [
@@ -7333,7 +7333,7 @@
         },
         {
             "id": "2f8e9281-44c8-5180-b0a4-157b05f2a5e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18f7a9-2af6-467a-8f62-5f7da83a3c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18f7a9-2af6-467a-8f62-5f7da83a3c92.jpg?1",
             "name": "Bioshift",
             "text": "Move any number of +1/+1 counters from target creature onto another target creature with the same controller.",
             "colours": [
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "43c8c8bc-e235-5b30-b2b3-1be6d9407f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a18b07-38b8-4854-9735-3cfe83b11bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a18b07-38b8-4854-9735-3cfe83b11bf1.jpg?1",
             "name": "Boros Reckoner",
             "text": "Whenever Boros Reckoner is dealt damage, it deals that much damage to target creature or player.\n{GU}: Boros Reckoner gains first strike until end of turn.",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "5995e269-6e40-5850-b88d-c766de2ae29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d5f35-3613-4c69-9176-13baf442fb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d5f35-3613-4c69-9176-13baf442fb50.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G} to your mana pool.",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "cb16d4a7-6eaf-5d05-9dea-4e46270eb2b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76102f1-b05f-472b-81cf-eae424c55638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76102f1-b05f-472b-81cf-eae424c55638.jpg?1",
             "name": "Coerced Confession",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard. You draw a card for each creature card put into that graveyard this way.",
             "colours": [
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "2f3954ba-b17d-5837-be29-4604286898b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c186d2-e631-4811-83ea-fdb54e730a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c186d2-e631-4811-83ea-fdb54e730a5d.jpg?1",
             "name": "Deathcult Rogue",
             "text": "Deathcult Rogue can't be blocked except by Rogues.",
             "colours": [
@@ -7512,7 +7512,7 @@
         },
         {
             "id": "cf8e58d8-0a2c-5dc4-a62a-b1a0db7adfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d759ef8-cb04-4769-9944-85793af3f6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d759ef8-cb04-4769-9944-85793af3f6e8.jpg?1",
             "name": "Gift of Orzhova",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying and lifelink.",
             "colours": [
@@ -7548,7 +7548,7 @@
         },
         {
             "id": "1e63e3e6-ba67-519f-8f03-ecff3d4aa4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88366762-4be0-422a-a0ff-ed046d30afe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88366762-4be0-422a-a0ff-ed046d30afe1.jpg?1",
             "name": "Immortal Servitude",
             "text": "Return each creature card with converted mana cost X from your graveyard to the battlefield.",
             "colours": [
@@ -7582,7 +7582,7 @@
         },
         {
             "id": "4b2d7089-47db-5b16-80cc-efb2456bff9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddb2e15-a53e-4647-a627-6c7032429fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddb2e15-a53e-4647-a627-6c7032429fca.jpg?1",
             "name": "Merfolk of the Depths",
             "text": "Flash (You may cast this spell any time you could cast an instant.)",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "68658172-c4ae-5b96-95bf-47186b87f945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3754b8c-16d2-41e3-b41b-4b2e70833e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3754b8c-16d2-41e3-b41b-4b2e70833e82.jpg?1",
             "name": "Nightveil Specter",
             "text": "Flying\nWhenever Nightveil Specter deals combat damage to a player, that player exiles the top card of his or her library.\nYou may play cards exiled with Nightveil Specter.",
             "colours": [
@@ -7655,7 +7655,7 @@
         },
         {
             "id": "e906aad3-043f-563e-a4e0-5233a61bbbfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3624332e-60fc-4819-a0f1-d7ec41c6518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3624332e-60fc-4819-a0f1-d7ec41c6518b.jpg?1",
             "name": "Pit Fight",
             "text": "Target creature you control fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7689,7 +7689,7 @@
         },
         {
             "id": "d0cc1f38-200f-5c6b-bf0f-dafb87b21bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec7d6a-2362-4c62-bd81-35bba6086f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec7d6a-2362-4c62-bd81-35bba6086f7d.jpg?1",
             "name": "Rubblebelt Raiders",
             "text": "Whenever Rubblebelt Raiders attacks, put a +1/+1 counter on it for each attacking creature you control.",
             "colours": [
@@ -7726,7 +7726,7 @@
         },
         {
             "id": "57e2deb3-6050-581c-bc5d-00d0c98d1ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77058d9-d2b5-424a-bfe2-070b754051cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77058d9-d2b5-424a-bfe2-070b754051cb.jpg?1",
             "name": "Shattering Blow",
             "text": "Exile target artifact.",
             "colours": [
@@ -7760,7 +7760,7 @@
         },
         {
             "id": "4b1a24aa-2216-527e-8a41-72558c3034dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cf8f6c-217e-4d51-aa63-859c2d38d438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cf8f6c-217e-4d51-aa63-859c2d38d438.jpg?1",
             "name": "Armored Transport",
             "text": "Prevent all combat damage that would be dealt to Armored Transport by creatures blocking it.",
             "colours": [],
@@ -7791,7 +7791,7 @@
         },
         {
             "id": "c539a52f-f7bc-521a-8129-bf80757604b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b65847-fee2-4e00-b598-7363059ec3ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b65847-fee2-4e00-b598-7363059ec3ff.jpg?1",
             "name": "Boros Keyrune",
             "text": "{T}: Add {R} or {W} to your mana pool.\n{R}{W}: Boros Keyrune becomes a 1/1 red and white Soldier artifact creature with double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [],
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "24dbbacb-5dc0-53f7-b540-4fe2dfedf412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d91bb34-5d8d-48c9-ad19-d28884e083bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d91bb34-5d8d-48c9-ad19-d28884e083bc.jpg?1",
             "name": "Dimir Keyrune",
             "text": "{T}: Add {U} or {B} to your mana pool.\n{U}{B}: Dimir Keyrune becomes a 2/2 blue and black Horror artifact creature until end of turn and is unblockable this turn.",
             "colours": [],
@@ -7853,7 +7853,7 @@
         },
         {
             "id": "647ca3ba-3c6c-5aaa-9d87-456907ffaed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6070239-54a7-49d4-bd3c-d5c4cda971db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6070239-54a7-49d4-bd3c-d5c4cda971db.jpg?1",
             "name": "Glaring Spotlight",
             "text": "Creatures your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.\n{3}, Sacrifice Glaring Spotlight: Creatures you control gain hexproof until end of turn and are unblockable this turn.",
             "colours": [],
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "f9aa2ccb-4420-5bf0-a985-7ae5111263f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf96f1c-066e-4fde-acb8-4674842fb6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf96f1c-066e-4fde-acb8-4674842fb6c2.jpg?1",
             "name": "Gruul Keyrune",
             "text": "{T}: Add {R} or {G} to your mana pool.\n{R}{G}: Gruul Keyrune becomes a 3/2 red and green Beast artifact creature with trample until end of turn.",
             "colours": [],
@@ -7912,7 +7912,7 @@
         },
         {
             "id": "dcf312dd-3399-5965-a1d4-f2ee60961870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc06cf32-5d66-4772-845d-ff7649396092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc06cf32-5d66-4772-845d-ff7649396092.jpg?1",
             "name": "Illusionist's Bracers",
             "text": "Whenever an ability of equipped creature is activated, if it isn't a mana ability, copy that ability. You may choose new targets for the copy.\nEquip {3}",
             "colours": [],
@@ -7942,7 +7942,7 @@
         },
         {
             "id": "f9fd5b5f-840d-5633-a8d1-9eb35168510e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d1bc6e-84aa-4973-924a-6688b742bafa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d1bc6e-84aa-4973-924a-6688b742bafa.jpg?1",
             "name": "Millennial Gargoyle",
             "text": "Flying",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "312f3444-aeb9-5167-b200-1e165cac648b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5c0f38-916a-4f6c-b678-7447cb0709e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5c0f38-916a-4f6c-b678-7447cb0709e0.jpg?1",
             "name": "Orzhov Keyrune",
             "text": "{T}: Add {W} or {B} to your mana pool.\n{W}{B}: Orzhov Keyrune becomes a 1/4 white and black Thrull artifact creature with lifelink until end of turn.",
             "colours": [],
@@ -8004,7 +8004,7 @@
         },
         {
             "id": "44c41b6b-0150-5397-8967-1ad2781c3514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b29a2-9e6f-45b7-8af5-f09779aae58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b29a2-9e6f-45b7-8af5-f09779aae58e.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8032,7 +8032,7 @@
         },
         {
             "id": "dd6b2ba9-f4f8-5124-9c24-3f2318d0a16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24619d3f-1051-4d8e-9c8d-70a12621b282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24619d3f-1051-4d8e-9c8d-70a12621b282.jpg?1",
             "name": "Razortip Whip",
             "text": "{1}, {T}: Razortip Whip deals 1 damage to target opponent.",
             "colours": [],
@@ -8060,7 +8060,7 @@
         },
         {
             "id": "d0594ad5-ec6c-5fd0-86f6-e5a30632550a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be1289-76f9-40b3-9387-b76a8b8d8797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be1289-76f9-40b3-9387-b76a8b8d8797.jpg?1",
             "name": "Riot Gear",
             "text": "Equipped creature gets +1/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8090,7 +8090,7 @@
         },
         {
             "id": "39b37e23-dde7-562d-bd0a-b8cfd5e1ed66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039aae6-38f5-42b5-a530-e0dd03abc7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039aae6-38f5-42b5-a530-e0dd03abc7d5.jpg?1",
             "name": "Simic Keyrune",
             "text": "{T}: Add {G} or {U} to your mana pool.\n{G}{U}: Simic Keyrune becomes a 2/3 green and blue Crab artifact creature with hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [],
@@ -8121,7 +8121,7 @@
         },
         {
             "id": "8ef0f29f-dcfc-573f-b7b0-4eb09cdd2abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1602ee8-019d-4dde-8d31-042207017615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1602ee8-019d-4dde-8d31-042207017615.jpg?1",
             "name": "Skyblinder Staff",
             "text": "Equipped creature gets +1/+0 and can't be blocked by creatures with flying.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8151,7 +8151,7 @@
         },
         {
             "id": "eb247595-7283-5c3b-aa01-3421bc2fce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b447a8-524b-4bda-b975-7e194fd741fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b447a8-524b-4bda-b975-7e194fd741fb.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8184,7 +8184,7 @@
         },
         {
             "id": "78441f3e-0047-548a-8f0d-e157fede836b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece3bcdd-cb33-4923-b919-ba57a327d3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece3bcdd-cb33-4923-b919-ba57a327d3cd.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U} to your mana pool.)\nAs Breeding Pool enters the battlefield, you may pay 2 life. If you don't, Breeding Pool enters the battlefield tapped.",
             "colours": [],
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "f800f864-c42c-58a2-8f3b-3771a66bc8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951bf75-1a88-4c85-b4e9-063d84f1dabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951bf75-1a88-4c85-b4e9-063d84f1dabf.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "4230de84-de12-50c8-91b9-de0412f2de83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd672bb-18cf-44e3-8dda-5310b1e0fffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd672bb-18cf-44e3-8dda-5310b1e0fffe.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B} to your mana pool.)\nAs Godless Shrine enters the battlefield, you may pay 2 life. If you don't, Godless Shrine enters the battlefield tapped.",
             "colours": [],
@@ -8285,7 +8285,7 @@
         },
         {
             "id": "21c7493a-2c25-5737-aee0-41aeae09223d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c54269-8798-4023-836f-640103e08ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c54269-8798-4023-836f-640103e08ce0.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8318,7 +8318,7 @@
         },
         {
             "id": "9e18976f-5c7f-561d-9c8d-8dfc06140d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8351,7 +8351,7 @@
         },
         {
             "id": "b67b96c4-42c5-5c5c-a1e2-4a7fa17d6cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a26d900-c652-4f9c-8681-a35c5f8b1937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a26d900-c652-4f9c-8681-a35c5f8b1937.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W} to your mana pool.)\nAs Sacred Foundry enters the battlefield, you may pay 2 life. If you don't, Sacred Foundry enters the battlefield tapped.",
             "colours": [],
@@ -8385,7 +8385,7 @@
         },
         {
             "id": "9a83ba1c-2fb4-5cc0-b34e-ddcc6ecb507a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce3f6f2-c52c-4fb8-afa0-b1ea723bb4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce3f6f2-c52c-4fb8-afa0-b1ea723bb4c6.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "ef4ff4ab-6732-5fc4-b2f4-6dd9aac2f65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29f3415-971c-4a5d-aae9-3893f4bdab1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29f3415-971c-4a5d-aae9-3893f4bdab1e.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G} to your mana pool.)\nAs Stomping Ground enters the battlefield, you may pay 2 life. If you don't, Stomping Ground enters the battlefield tapped.",
             "colours": [],
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "358351a4-e9f0-5340-a45d-35f670f24b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f27909-e5cd-44c0-91c4-21624f692fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f27909-e5cd-44c0-91c4-21624f692fd9.jpg?1",
             "name": "Thespian's Stage",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Thespian's Stage becomes a copy of target land and gains this ability.",
             "colours": [],
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "84425e4b-a93e-5a64-8ec9-eca0e5caffd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fde349-010e-4a2e-838e-e924dbeec355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fde349-010e-4a2e-838e-e924dbeec355.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B} to your mana pool.)\nAs Watery Grave enters the battlefield, you may pay 2 life. If you don't, Watery Grave enters the battlefield tapped.",
             "colours": [],
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "072cf722-dcbf-5a4e-aff0-b20b9d6a2483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71766a5a-ce00-4e48-b4f6-0d1a7f5b2691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71766a5a-ce00-4e48-b4f6-0d1a7f5b2691.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "454575b1-cacd-57fc-b25c-4a2025f5285e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fb8ca6-7351-457a-b2a4-48f57ec3c64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fb8ca6-7351-457a-b2a4-48f57ec3c64a.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "90c3872a-9afa-5003-bc53-cbec13e1bb0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b938d2e0-7e90-4f57-b363-5c68a6207d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b938d2e0-7e90-4f57-b363-5c68a6207d6c.jpg?1",
             "name": "Frog Lizard",
             "text": "",
             "colours": [
@@ -8617,7 +8617,7 @@
         },
         {
             "id": "a0f235bb-c637-520c-9262-d810aefc8192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af74e26-69d7-4683-9a71-9b420c03d75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af74e26-69d7-4683-9a71-9b420c03d75f.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -8653,7 +8653,7 @@
         },
         {
             "id": "222e0f63-f7c4-52e0-8f47-6d600b2586a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a71b52-58f9-4945-9557-0fbcbbf5a241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a71b52-58f9-4945-9557-0fbcbbf5a241.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [
@@ -8689,7 +8689,7 @@
         },
         {
             "id": "413b8191-e883-5446-8618-8929e16a2a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5a5a5-a8ae-41ed-9af5-b99d80ce0b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5a5a5-a8ae-41ed-9af5-b99d80ce0b35.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8725,7 +8725,7 @@
         },
         {
             "id": "6465289c-c523-5089-a6c0-66f85c308232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f3a4b0-0992-4245-b245-033ad1083a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f3a4b0-0992-4245-b245-033ad1083a93.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "7705471e-c210-59ec-9248-ee989cee67ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1612f546-1bdb-4861-966c-4eeb7d1e65e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1612f546-1bdb-4861-966c-4eeb7d1e65e8.jpg?1",
             "name": "Domri Rade Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/HML.json
+++ b/Assets/Resources/Sets/HML.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "505092c2-5501-54c4-bf8a-4e296cb08c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5d8de-25f1-4070-a7a6-dc3f2339ce30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5d8de-25f1-4070-a7a6-dc3f2339ce30.jpg?1",
             "name": "Abbey Gargoyles",
             "text": "Flying, protection from red",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "64a0d121-4a0b-5015-bcf2-985a996f196f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158caa84-da2e-4c4c-b24d-0c035c900e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158caa84-da2e-4c4c-b24d-0c035c900e20.jpg?1",
             "name": "Abbey Matron",
             "text": "o\nW, oc\nT: +0/+3 until end of turn",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "a4c57432-3ccd-5b85-897e-bfa922e002e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd950ddc-28f4-47a5-8fc1-d6f70002fceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd950ddc-28f4-47a5-8fc1-d6f70002fceb.jpg?1",
             "name": "Abbey Matron",
             "text": "o\nW, oc\nT: +0/+3 until end of turn",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "b356ac91-c608-5730-b532-a2a59604895f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91170faf-3143-4fa8-88d6-eef72e1f5459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91170faf-3143-4fa8-88d6-eef72e1f5459.jpg?1",
             "name": "Aysen Bureaucrats",
             "text": "oc\nT: Tap target creature with power no greater than 2.",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "4c4b0b7c-61b0-58b9-ba25-6038be2e1316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca3fa70-50b3-4157-afda-fe58bf72ee16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca3fa70-50b3-4157-afda-fe58bf72ee16.jpg?1",
             "name": "Aysen Bureaucrats",
             "text": "oc\nT: Tap target creature with power no greater than 2.",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "665af871-8404-520a-8103-b12420b413ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7908cfdc-5ed6-48a8-a5b9-351864f8b4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7908cfdc-5ed6-48a8-a5b9-351864f8b4fd.jpg?1",
             "name": "Aysen Crusader",
             "text": "Aysen Crusader has power and toughness each equal to 2 plus the number of Heroes you control.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "1cb80f4b-f3a6-5786-8341-91669498223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa87eb-9a11-459c-bff8-87bb09b61b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa87eb-9a11-459c-bff8-87bb09b61b87.jpg?1",
             "name": "Aysen Highway",
             "text": "All white creatures gain plainswalk.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "af5b3c88-a9b2-5b7b-8503-2e05adba8d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b42f6c-5c7e-4ba8-b0fb-ac8564aaf825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b42f6c-5c7e-4ba8-b0fb-ac8564aaf825.jpg?1",
             "name": "Beast Walkers",
             "text": "oo\nG Banding until end of turn",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "bbd07804-fc81-5a51-bc58-83e741fc7953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17c19a4-0186-45a0-89b9-d7b0fb0ddd8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17c19a4-0186-45a0-89b9-d7b0fb0ddd8a.jpg?1",
             "name": "Death Speakers",
             "text": "Protection from black",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "0d35f19d-0f3d-5f09-91aa-f21e262fa364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfd416a-dddf-40e4-acf0-84057edb7a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfd416a-dddf-40e4-acf0-84057edb7a58.jpg?1",
             "name": "Hazduhr the Abbot",
             "text": "o\nX, oc\nT: Redirect to Hazduhr the Abbot X damage dealt to any white creature you control.",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "1653e699-3073-5c83-88ae-c8106dea3cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db206e-b254-476c-b2f3-1cd56bb5297d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db206e-b254-476c-b2f3-1cd56bb5297d.jpg?1",
             "name": "Leeches",
             "text": "Target player loses all poison counters. Leeches deals 1 damage to that player for each poison counter removed in this way.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "b6b84f7e-6898-5b57-bb8e-96df2718494d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2c7004-691b-4385-ad9b-60b93d474ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2c7004-691b-4385-ad9b-60b93d474ebd.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "9351e0dc-afed-56c0-acb3-ee72aec6f246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2f5e2-fb95-48b0-b7bf-689d45fa8970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2f5e2-fb95-48b0-b7bf-689d45fa8970.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "c7f6cb42-96c6-5660-844e-7228d3dae0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f514eb63-3a4e-4410-ba3d-487cf81f7063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f514eb63-3a4e-4410-ba3d-487cf81f7063.jpg?1",
             "name": "Prophecy",
             "text": "Reveal the top card of target opponent's library to all players. If it is a land, gain 1 life. That opponent then shuffles his or her library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "9d730c77-4340-5654-94f0-11c1a5b090bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf30363-9db2-44c5-8c13-dbf1aaa8c86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf30363-9db2-44c5-8c13-dbf1aaa8c86b.jpg?1",
             "name": "Rashka the Slayer",
             "text": "Can block creatures with flying.\nIf assigned to block any black creatures, Rashka the Slayer gets +1/+2 until end of turn.",
             "colours": [
@@ -520,7 +520,7 @@
         },
         {
             "id": "14166bc5-0ab1-51ca-a1bb-3c0d7be36660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68224871-d4c2-4b43-9ab8-c0685588b035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68224871-d4c2-4b43-9ab8-c0685588b035.jpg?1",
             "name": "Samite Alchemist",
             "text": "o\nWo\nW, oc\nT: Prevent up to 4 damage to a creature you control. Tap that creature. The creature does not untap during your next untap phase.",
             "colours": [
@@ -556,7 +556,7 @@
         },
         {
             "id": "335833e6-92d4-5795-aecb-df3475a5f566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0545fc43-9c67-4ad4-b1d9-6b57b53321af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0545fc43-9c67-4ad4-b1d9-6b57b53321af.jpg?1",
             "name": "Samite Alchemist",
             "text": "o\nWo\nW, oc\nT: Prevent up to 4 damage to a creature you control. Tap that creature. The creature does not untap during your next untap phase.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "9aef9f49-079f-59ee-92c4-a65760e6bd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688a8de2-0167-4b35-a38d-3574034a892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688a8de2-0167-4b35-a38d-3574034a892c.jpg?1",
             "name": "Serra Aviary",
             "text": "All creatures with flying get +1/+1.",
             "colours": [
@@ -625,7 +625,7 @@
         },
         {
             "id": "35fca37b-26bb-5918-a5f3-930cf86850de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1c8b8-9b3e-444a-a12c-bd09ec899641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1c8b8-9b3e-444a-a12c-bd09ec899641.jpg?1",
             "name": "Serra Bestiary",
             "text": "During your upkeep, pay o\nWo\nW or bury Serra Bestiary.\nTarget creature cannot attack, block, or use any ability that includes oc\nT in the activation cost.",
             "colours": [
@@ -658,7 +658,7 @@
         },
         {
             "id": "119546dc-6b64-5b3d-8dd6-c49d969b2b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fbe3c8-92fb-41b9-b778-726d22c63054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fbe3c8-92fb-41b9-b778-726d22c63054.jpg?1",
             "name": "Serra Inquisitors",
             "text": "If assigned to block any black creatures or any black creatures are assigned to block it, Serra Inquisitors gets +2/+0 until end of turn.",
             "colours": [
@@ -692,7 +692,7 @@
         },
         {
             "id": "a29dc632-0c32-5108-a65f-025ad03b77ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd25adf-4d97-4229-abdb-1c060036cfbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd25adf-4d97-4229-abdb-1c060036cfbd.jpg?1",
             "name": "Serra Paladin",
             "text": "oc\nT: Prevent 1 damage to any creature or player.\no1o\nWo\nW, oc\nT: Attacking does not cause target creature to tap this turn.",
             "colours": [
@@ -726,7 +726,7 @@
         },
         {
             "id": "092ea29a-bae4-56e3-af4e-33dcb2b1a48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb3ce2-a660-4829-9af4-330cfd612f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb3ce2-a660-4829-9af4-330cfd612f06.jpg?1",
             "name": "Soraya the Falconer",
             "text": "All Falcons get +1/+1.\no1oo\nW Target Falcon gains banding until end of turn.",
             "colours": [
@@ -761,7 +761,7 @@
         },
         {
             "id": "6967f9b4-b2da-5c72-8d78-7ce6391c3c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcc821b-8125-4585-ba44-4bf8c1873fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcc821b-8125-4585-ba44-4bf8c1873fbf.jpg?1",
             "name": "Trade Caravan",
             "text": "During your upkeep, put a currency counter on Trade Caravan.\no0: Remove two currency counters from Trade Caravan to untap target basic land. Use this ability only during any opponent's upkeep.",
             "colours": [
@@ -797,7 +797,7 @@
         },
         {
             "id": "d50bc621-bf66-5be9-98d9-84485729a274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ddb1e-e607-4080-849c-3e1a79052729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ddb1e-e607-4080-849c-3e1a79052729.jpg?1",
             "name": "Trade Caravan",
             "text": "During your upkeep, put a currency counter on Trade Caravan.\no0: Remove two currency counters from Trade Caravan to untap target basic land. Use this ability only during any opponent's upkeep.",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "b54484c9-e44b-5b52-8ac2-20467dde7aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c5fd74-bd46-4833-ae25-1a11a8c15ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c5fd74-bd46-4833-ae25-1a11a8c15ed2.jpg?1",
             "name": "Truce",
             "text": "Each player may draw up to two cards. For each card less than two any player draws, that player gains 2 life.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "3fde0a9a-8705-5d15-894d-1695b166b38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce479e91-7b21-4312-a3c0-950d9f6dc029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce479e91-7b21-4312-a3c0-950d9f6dc029.jpg?1",
             "name": "Aether Storm",
             "text": "No summon spells may be cast. Any player may pay 4 life to bury \u00c6ther Storm. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "098159fb-552b-5854-bd8b-f4ca6a119e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3261b4c-7963-4ca0-875d-77b7c8571b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3261b4c-7963-4ca0-875d-77b7c8571b3f.jpg?1",
             "name": "Baki's Curse",
             "text": "Baki's Curse deals 2 damage to each creature for each creature enchantment on that creature.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "2808a088-455c-5249-bd0b-38d6e73e6c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f0c52-67c2-4302-82bd-fbb4e3c6d4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f0c52-67c2-4302-82bd-fbb4e3c6d4f4.jpg?1",
             "name": "Chain Stasis",
             "text": "Tap or untap target creature. Whenever any player uses Chain Stasis to tap or untap a creature, that creature's controller may pay o2o\nU to use Chain Stasis to tap or untap any target creature.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "ce158f87-7b75-5bff-bd9f-5a75b9f2ed22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe2280-a996-4072-b5bf-f4fd56607a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe2280-a996-4072-b5bf-f4fd56607a51.jpg?1",
             "name": "Coral Reef",
             "text": "When Coral Reef comes into play, put four polyp counters on it.\no0: Sacrifice an island to put two polyp counters on Coral Reef.\noo\nU Tap target blue creature you control and remove a polyp counter from Coral Reef to put a +0/+1 counter on any target creature.",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "93d6a697-0f9a-5a02-8231-d931f7371222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a8ed9-db1e-4ce8-bfb3-92604a577df7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a8ed9-db1e-4ce8-bfb3-92604a577df7.jpg?1",
             "name": "Dark Maze",
             "text": "o0: Dark Maze can attack this turn. At end of turn, remove Dark Maze from the game. Dark Maze cannot attack the turn it comes under your control.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "3b17c358-4930-53eb-812c-f87e76c5588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d68a76-c843-4c67-90a7-2f79295798d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d68a76-c843-4c67-90a7-2f79295798d0.jpg?1",
             "name": "Dark Maze",
             "text": "o0: Dark Maze can attack this turn. At end of turn, remove Dark Maze from the game. Dark Maze cannot attack the turn it comes under your control.",
             "colours": [
@@ -1058,7 +1058,7 @@
         },
         {
             "id": "5abe3c8e-e5dd-535b-a51d-44f813aebd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3115a9-ad65-4213-9320-6f39c11676f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3115a9-ad65-4213-9320-6f39c11676f3.jpg?1",
             "name": "Forget",
             "text": "Target player chooses and discards 2 cards from his or her hand. If that player does not have enough cards in hand, his or her entire hand is discarded. The player then draws as many cards as he or she discarded in this way.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "cea58a4e-9166-58f3-aefb-b76b92837b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce05870-74d3-43f1-92d0-dc1744c0138d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce05870-74d3-43f1-92d0-dc1744c0138d.jpg?1",
             "name": "Giant Albatross",
             "text": "Flying\no1oo\nU Bury all creatures that damaged Giant Albatross this turn. The controller of any of those creatures may pay 2 life to prevent that creature from being buried. Effects that prevent or redirect damage cannot be used to counter this loss of life. Use this ability only when Giant Albatross is put into the graveyard from play.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "e161364b-e4ad-5ce8-81c7-0548e3e4ce47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26334fc-d8ee-4b8c-ac50-5a304fae6c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26334fc-d8ee-4b8c-ac50-5a304fae6c60.jpg?1",
             "name": "Giant Albatross",
             "text": "Flying\no1oo\nU Bury all creatures that damaged Giant Albatross this turn. The controller of any of those creatures may pay 2 life to prevent that creature from being buried. Effects that prevent or redirect damage cannot be used to counter this loss of life. Use this ability only when Giant Albatross is put into the graveyard from play.",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "2517de1c-4037-597c-9c1d-99d4bc7b6421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8045d23-e6e6-474c-a3e7-ddfc6121657a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8045d23-e6e6-474c-a3e7-ddfc6121657a.jpg?1",
             "name": "Giant Oyster",
             "text": "You may choose not to untap Giant Oyster during your untap phase.\noc\nT: Target tapped creature does not untap during its controller's untap phase as long as Giant Oyster remains tapped. During your upkeep, put a -1/-1 counter on that creature. If Giant Oyster becomes untapped or leaves play, remove all these counters from the creature.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "04778b81-5bf3-5b8c-8c47-e739eb253959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81fca41-2315-4d12-b05c-d921a4c3c19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81fca41-2315-4d12-b05c-d921a4c3c19e.jpg?1",
             "name": "Jinx",
             "text": "Target land becomes a basic land type of your choice until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "26c206f5-339a-569f-a0fe-7d23d3ce7f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8c1786-a2c1-43f9-9cef-8c4542833093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8c1786-a2c1-43f9-9cef-8c4542833093.jpg?1",
             "name": "Labyrinth Minotaur",
             "text": "Creatures Labyrinth Minotaur is assigned to block do not untap during their controller's next untap phase.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "687d5f47-0b3d-59f7-a572-2327df234616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0663c756-9db9-4298-8a6e-a1af935286a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0663c756-9db9-4298-8a6e-a1af935286a0.jpg?1",
             "name": "Labyrinth Minotaur",
             "text": "Creatures Labyrinth Minotaur is assigned to block do not untap during their controller's next untap phase.",
             "colours": [
@@ -1293,7 +1293,7 @@
         },
         {
             "id": "f0052d9e-34f5-5aca-a8fd-ba5f6cc2fb8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6aa3299-3b7a-4ea5-bc1f-beead26d8116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6aa3299-3b7a-4ea5-bc1f-beead26d8116.jpg?1",
             "name": "Marjhan",
             "text": "Does not untap during your untap phase.\nMarjhan cannot attack if defending player controls no islands. If at any time you control no islands, bury Marjhan.\no\nUoo\nU Sacrifice a creature to untap Marjhan. Use this ability only during your upkeep.\no\nUoo\nU -1/-0 until end of turn. Marjhan deals 1 damage to target attacking creature without flying.",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "927391aa-2a02-5318-bb37-c176732eb2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2cc591-3a81-468a-91a4-3c3aac83a21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2cc591-3a81-468a-91a4-3c3aac83a21a.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of its owner's library.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "2f01f5b8-6fe8-510e-8c35-3b209dbd41ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8b5df3-6153-470e-be9c-f38d3cf66081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8b5df3-6153-470e-be9c-f38d3cf66081.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of its owner's library.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "81963e5d-d248-5465-bd26-f4274a77b0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4133ceb-6176-411a-9eb8-51721c1bb435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4133ceb-6176-411a-9eb8-51721c1bb435.jpg?1",
             "name": "Merchant Scroll",
             "text": "Search your library for a blue instant or interrupt. Reveal that card to all players and put it into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "c7f55f12-d1fe-57ed-8255-681ac76234f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b069e6a-2c0e-4fc9-8e19-08bf1245a6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b069e6a-2c0e-4fc9-8e19-08bf1245a6c0.jpg?1",
             "name": "Mystic Decree",
             "text": "All creatures lose flying and islandwalk.",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "75305680-c561-5f44-be80-f7bfc8f14be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202d3ed5-f493-43b6-bf36-81ad289e6fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202d3ed5-f493-43b6-bf36-81ad289e6fb0.jpg?1",
             "name": "Narwhal",
             "text": "First strike, protection from red",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "8831bbc0-fffa-57fc-ad21-f65e392c5f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b742d75-860d-4b90-89cb-4292f18aed39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b742d75-860d-4b90-89cb-4292f18aed39.jpg?1",
             "name": "Reef Pirates",
             "text": "Whenever Reef Pirates damages any opponent, take the top card of his or her library and put it into his or her graveyard.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "275f800c-1280-53f6-ba37-18a5d018e212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5e641-0276-4321-b486-ef8602a5f185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5e641-0276-4321-b486-ef8602a5f185.jpg?1",
             "name": "Reef Pirates",
             "text": "Whenever Reef Pirates damages any opponent, take the top card of his or her library and put it into his or her graveyard.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "7c752380-dc52-57b4-8f92-3137528a8c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a952236e-3085-4e6e-8639-355976b7c8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a952236e-3085-4e6e-8639-355976b7c8f5.jpg?1",
             "name": "Reveka, Wizard Savant",
             "text": "oc\nT: Reveka deals 2 damage to target creature or player and does not untap during your next untap phase.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "f46ddd4a-3151-5ef7-a7f0-61318532d8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb001b-3afb-44f5-ab78-af2bf9a4e63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb001b-3afb-44f5-ab78-af2bf9a4e63a.jpg?1",
             "name": "Sea Sprite",
             "text": "Flying, protection from red",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "97903ffc-6caa-5e1a-b06c-8b95f6b0f8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da23d4-f9fb-40a5-8395-51b47a064600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da23d4-f9fb-40a5-8395-51b47a064600.jpg?1",
             "name": "Sea Troll",
             "text": "o\nU: Regenerate. Use this ability only during a turn in which Sea Troll blocked a blue creature or a blue creature blocked Sea Troll.",
             "colours": [
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "8905aa96-5654-5e13-ae0e-c7ec8ac3d36a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff5051-e24b-4453-aaae-ed4f2bf213ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff5051-e24b-4453-aaae-ed4f2bf213ab.jpg?1",
             "name": "Wall of Kelp",
             "text": "o\nUo\nU, oc\nT: Put a Kelp token into play. Treat this token as a 0/1 blue wall.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "c86a9100-58a5-53ef-b3c1-ad2e9531a0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bdddac-02fc-493a-a0ea-689273252d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bdddac-02fc-493a-a0ea-689273252d7e.jpg?1",
             "name": "Baron Sengir",
             "text": "Flying\nWhenever a creature is put into the graveyard the same turn Baron Sengir damaged it, put a +2/+2 counter on Baron Sengir.\noc\nT: Regenerate target Vampire.",
             "colours": [
@@ -1733,7 +1733,7 @@
         },
         {
             "id": "80fdf65b-0b12-5aea-8ad6-a0401fe2361b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87068116-6000-44ee-b47f-f5cb8c233bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87068116-6000-44ee-b47f-f5cb8c233bb2.jpg?1",
             "name": "Black Carriage",
             "text": "Trample\nDoes not untap during your untap phase.\no0: Sacrifice a creature to untap Black Carriage. Use this ability only during your upkeep.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "b0780f79-4368-526b-b6ec-042a58fe2172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be199e7-feaa-4f23-b93c-3eab54a02e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be199e7-feaa-4f23-b93c-3eab54a02e74.jpg?1",
             "name": "Broken Visage",
             "text": "Bury target non-artifact attacking creature and put a Shadow token into play.\nTreat this token as a black creature with power and toughness equal to the power and toughness of that attacking creature. Bury Shadow token at end of turn.",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "bb8a0acc-7d46-579c-b2ac-edb4fe0ecbc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f0614-06dc-4bd2-b8b9-d951ae27db21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f0614-06dc-4bd2-b8b9-d951ae27db21.jpg?1",
             "name": "Cemetery Gate",
             "text": "Protection from black",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "f018f607-a9e3-5e6f-a22d-50f3a92b34c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b2cc1-cb0b-4cb8-963f-453a1d5b0e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b2cc1-cb0b-4cb8-963f-453a1d5b0e3c.jpg?1",
             "name": "Cemetery Gate",
             "text": "Protection from black",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "66f4f554-786f-5c18-b066-5e8e34d30860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b352de-e989-4ad5-963c-818092fc9f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b352de-e989-4ad5-963c-818092fc9f1a.jpg?1",
             "name": "Drudge Spell",
             "text": "oo\nB Remove from the game two target creatures in your graveyard to put a Skeleton token into play. Treat this token as a 1/1 black creature with \"oo\nB Regenerate\". If Drudge Spell leaves play, bury all Skeleton tokens.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "88c67ae7-99f0-574f-ba7a-27d69b8f9b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c10ea-8ace-4496-8b99-61863c0cec1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c10ea-8ace-4496-8b99-61863c0cec1b.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and player.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "12277540-a5d1-58df-9538-78c997935db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997ea663-40a1-49b7-80f1-2e1febc1b6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997ea663-40a1-49b7-80f1-2e1febc1b6fa.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and player.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "08b7d7d0-a64a-59b1-a0be-139a2b1c4952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e41d6-79c3-463f-ae63-872c3d8729a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e41d6-79c3-463f-ae63-872c3d8729a7.jpg?1",
             "name": "Feast of the Unicorn",
             "text": "Target creature gets +4/+0.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "7b6ef475-b6c3-5152-bd91-b5ac9dea2128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05a2735-0f0d-46b5-9c2e-6c0ed8d8944d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05a2735-0f0d-46b5-9c2e-6c0ed8d8944d.jpg?1",
             "name": "Feast of the Unicorn",
             "text": "Target creature gets +4/+0.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "0615af89-af8c-5690-8138-388f62fb9fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054c5678-63d1-45d9-bd51-43100fd10afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054c5678-63d1-45d9-bd51-43100fd10afd.jpg?1",
             "name": "Funeral March",
             "text": "When target creature leaves play, that creature's controller sacrifices a creature he or she controls. Ignore this effect if that player controls no creatures.",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "a078e132-b9e2-5dbf-87f5-cf05605e1535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1298b43-0b10-4b7c-9d33-786d4d7bd80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1298b43-0b10-4b7c-9d33-786d4d7bd80e.jpg?1",
             "name": "Ghost Hounds",
             "text": "Attacking does not cause Ghost Hounds to tap.\nIf assigned to block any white creatures or any white creatures are assigned to block it, Ghost Hounds gains first strike until end of turn.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "664e2a2b-f7af-5b91-9ceb-0f7d5b4bfe10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0ac91-5e8e-47b1-aa34-902eef60349f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0ac91-5e8e-47b1-aa34-902eef60349f.jpg?1",
             "name": "Grandmother Sengir",
             "text": "o1o\nB, oc\nT: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "bbb8a453-58ef-598e-83d8-4a0b89a267f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c29c45f-db1a-43e3-ae42-1a72dabe7880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c29c45f-db1a-43e3-ae42-1a72dabe7880.jpg?1",
             "name": "Greater Werewolf",
             "text": "At end of combat, put a -0/-2 counter on all creatures blocking or blocked by Greater Werewolf.",
             "colours": [
@@ -2170,7 +2170,7 @@
         },
         {
             "id": "153a14cc-7df7-592f-8001-c5d1fea3d076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdae7fa-1076-4ff3-b771-fc3f5d9ba89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdae7fa-1076-4ff3-b771-fc3f5d9ba89f.jpg?1",
             "name": "Headstone",
             "text": "Remove from the game target card in any graveyard.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "f3dc3c30-e5bb-5a73-bfd0-7e5c096913d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82351724-2814-4d9e-b065-bb72c761b2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82351724-2814-4d9e-b065-bb72c761b2e7.jpg?1",
             "name": "Ihsan's Shade",
             "text": "Protection from white",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "1837863b-a6a4-5cf8-b666-da341dc00f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518e3b77-d482-4b90-94c0-0b8cdd949b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518e3b77-d482-4b90-94c0-0b8cdd949b9f.jpg?1",
             "name": "Irini Sengir",
             "text": "White enchantments and green enchantments each cost an additional o2 to cast.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "aa943b1b-cf1a-541c-a075-b9b196c34a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04292a4e-8910-4911-a76d-4f2c3e15da33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04292a4e-8910-4911-a76d-4f2c3e15da33.jpg?1",
             "name": "Koskun Falls",
             "text": "During your upkeep, tap target untapped creature you control or bury Koskun Falls.\nNo creature can attack you unless its controller pays an additional o2 whenever that creature attacks.",
             "colours": [
@@ -2306,7 +2306,7 @@
         },
         {
             "id": "ce7ac428-ec21-5ff7-a322-b2b37c94a031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e024-7865-43d0-8cd8-8933ef741d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e024-7865-43d0-8cd8-8933ef741d05.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat comes into play, put three Serf tokens into play. Treat these tokens as 0/1 black creatures. If Sengir Autocrat leaves play, bury all Serf tokens.",
             "colours": [
@@ -2339,7 +2339,7 @@
         },
         {
             "id": "44d7ed30-b9ad-57c9-83c4-7f363d8aa6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c745c2c-4311-412d-a137-02bf6d106e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c745c2c-4311-412d-a137-02bf6d106e46.jpg?1",
             "name": "Sengir Bats",
             "text": "Flying\nWhenever a creature is put into the graveyard the same turn Sengir Bats damaged it, put a +1/+1 counter on Sengir Bats.",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "0ea0d106-4b6f-50bd-931b-e0faa73ed707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb981a-d9e3-4efe-a383-5c98ee3b0b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb981a-d9e3-4efe-a383-5c98ee3b0b84.jpg?1",
             "name": "Sengir Bats",
             "text": "Flying\nWhenever a creature is put into the graveyard the same turn Sengir Bats damaged it, put a +1/+1 counter on Sengir Bats.",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "981507e9-74e5-5a9c-a597-4ed49e6f22ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90643766-c92f-4a25-bd02-227f3c91f391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90643766-c92f-4a25-bd02-227f3c91f391.jpg?1",
             "name": "Timmerian Fiends",
             "text": "Remove Timmerian Fiends from your deck before playing if not playing for ante.\no\nBo\nBoo\nB Sacrifice Timmerian Fiends to bury target artifact that any opponent owns in your graveyard. Put Timmerian Fiends into that opponent's graveyard. This change in ownership is permanent. The opponent may ante an additional card to counter this effect.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "3e135447-ac30-57e9-8110-4b93c6ca8ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8cc6c-7e24-4629-a9ce-5f717f236c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8cc6c-7e24-4629-a9ce-5f717f236c37.jpg?1",
             "name": "Torture",
             "text": "Choose target creature.\no1oo\nB Put a -1/-1 counter on creature Torture enchants.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "283d1079-24fc-5c86-ac28-a37203e12826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7e94a3-192f-483b-9a62-b94904ba3464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7e94a3-192f-483b-9a62-b94904ba3464.jpg?1",
             "name": "Torture",
             "text": "Choose target creature.\no1oo\nB Put a -1/-1 counter on creature Torture enchants.",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "2e9978c5-609d-5d81-914d-f97a697b6ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ce7d7-d370-4ef8-b1fa-aa70b2fd5ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ce7d7-d370-4ef8-b1fa-aa70b2fd5ab1.jpg?1",
             "name": "Veldrane of Sengir",
             "text": "o1o\nBoo\nB Forestwalk and -3/-0 until end of turn",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "0dccf89d-c38c-5394-8a8c-57f8d5ccb4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f711ea8-a73a-42da-8bf7-101ba588f203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f711ea8-a73a-42da-8bf7-101ba588f203.jpg?1",
             "name": "Aliban's Tower",
             "text": "Target blocking creature gets +3/+1 until end of turn.",
             "colours": [
@@ -2581,7 +2581,7 @@
         },
         {
             "id": "29188648-93d3-5f7e-b1e2-de930242ee07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e94b9-23f6-45a8-97bd-602e3aaa6711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e94b9-23f6-45a8-97bd-602e3aaa6711.jpg?1",
             "name": "Aliban's Tower",
             "text": "Target blocking creature gets +3/+1 until end of turn.",
             "colours": [
@@ -2614,7 +2614,7 @@
         },
         {
             "id": "612e57e8-442c-5056-8a6c-75e01b05c050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7dd8623-b64a-4b47-a69d-ed62d44596fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7dd8623-b64a-4b47-a69d-ed62d44596fb.jpg?1",
             "name": "Ambush",
             "text": "All blocking creatures gain first strike until end of turn.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "5c5d1977-c9b5-573f-bce4-f64076800545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e24788-cc7c-4f5d-84d8-dcb35e10626f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e24788-cc7c-4f5d-84d8-dcb35e10626f.jpg?1",
             "name": "Ambush Party",
             "text": "First strike\nAmbush Party can attack the turn it comes into play on your side.",
             "colours": [
@@ -2681,7 +2681,7 @@
         },
         {
             "id": "f6e61f41-35db-5c39-a24c-0b64ae6b0c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea200e93-e5bd-4777-b47e-e53849a89fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea200e93-e5bd-4777-b47e-e53849a89fe7.jpg?1",
             "name": "Ambush Party",
             "text": "First strike\nAmbush Party can attack the turn it comes into play on your side.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "27b9d2e1-b6f5-547c-b52f-2bef3eab5591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f905d57-2f52-4179-8041-2667b1fb1baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f905d57-2f52-4179-8041-2667b1fb1baa.jpg?1",
             "name": "An-Zerrin Ruins",
             "text": "Choose a creature type. Creatures of that type do not untap during their controller's untap phase.",
             "colours": [
@@ -2748,7 +2748,7 @@
         },
         {
             "id": "93a9141f-f4df-5442-9d85-c4708001f545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d33cc0-525d-4e25-927b-b6b18087c27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d33cc0-525d-4e25-927b-b6b18087c27b.jpg?1",
             "name": "Anaba Ancestor",
             "text": "oc\nT: Target Minotaur gets +1/+1 until end of turn.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "3a1ce028-11d5-5e59-999e-7bb86c858eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e3c69-dca7-4c0a-8f8c-984250e6a867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e3c69-dca7-4c0a-8f8c-984250e6a867.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "43f2cf62-df65-57ea-8973-cfe72843c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a54048-4640-499b-a1c3-192917c25169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a54048-4640-499b-a1c3-192917c25169.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike",
             "colours": [
@@ -2852,7 +2852,7 @@
         },
         {
             "id": "4588b1bd-2b86-5859-9f89-94934f50eb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55d086a-d848-43bc-8c1e-de96d10877e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55d086a-d848-43bc-8c1e-de96d10877e1.jpg?1",
             "name": "Anaba Shaman",
             "text": "o\nR, oc\nT: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -2888,7 +2888,7 @@
         },
         {
             "id": "63de4b50-24ab-5de3-b5f2-0945d98bc042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b456355-9f73-45c2-9554-6e6b20d949a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b456355-9f73-45c2-9554-6e6b20d949a1.jpg?1",
             "name": "Anaba Shaman",
             "text": "o\nR, oc\nT: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "b59ca690-f655-5625-be35-6977f91fd420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aaabc2-1dab-4f9c-8ed3-60bc1aa995ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aaabc2-1dab-4f9c-8ed3-60bc1aa995ba.jpg?1",
             "name": "Anaba Spirit Crafter",
             "text": "All Minotaurs get +1/+0.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "5617f78b-162d-5154-977d-befa7c8400f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd3a8e3-9a90-44f4-996c-57242d3c47a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd3a8e3-9a90-44f4-996c-57242d3c47a5.jpg?1",
             "name": "Chandler",
             "text": "o\nRo\nRo\nR, oc\nT: Destroy target artifact creature.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "2bebfdc9-c070-5a51-bb30-4a0e7566f473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a3019f-0b27-4ba3-be4c-73ed50eb9514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a3019f-0b27-4ba3-be4c-73ed50eb9514.jpg?1",
             "name": "Dwarven Pony",
             "text": "o1o\nR, oc\nT: Target Dwarf gains mountainwalk until end of turn.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "48098f7f-fa5a-5a67-a75b-99a3795ecd1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb722d9-1998-4912-a6f2-4ffa8d21311a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb722d9-1998-4912-a6f2-4ffa8d21311a.jpg?1",
             "name": "Dwarven Sea Clan",
             "text": "oc\nT: At end of combat, Dwarven Sea Clan deals 2 damage to target attacking or blocking creature. Use this ability only if that creature's controller controls any islands.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "0e9963aa-3754-53ab-b28a-2cab6a3fcceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db9aa47-f42b-41e9-948c-8b012c3809fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db9aa47-f42b-41e9-948c-8b012c3809fb.jpg?1",
             "name": "Dwarven Trader",
             "text": "",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "b7717b9b-4ea0-5327-906f-e0cf4408ab16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d9318-30d6-473f-b576-cc249454440f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d9318-30d6-473f-b576-cc249454440f.jpg?1",
             "name": "Dwarven Trader",
             "text": "",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "63e1cf96-2985-5012-a8a1-c6c2aa2ade0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6329bd9-1e03-43e6-b50b-8abe1356ffcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6329bd9-1e03-43e6-b50b-8abe1356ffcc.jpg?1",
             "name": "Eron the Relentless",
             "text": "Eron the Relentless can attack the turn it comes into play on your side.\no\nRo\nRoo\nR Regenerate",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "5109a80b-3326-5f34-880b-3d7b5396ac33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c99939-4854-4e28-a142-4cb7f89fe898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c99939-4854-4e28-a142-4cb7f89fe898.jpg?1",
             "name": "Evaporate",
             "text": "Evaporate deals 1 damage to each blue creature and white creature.",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "63ba138c-da9c-5827-b50f-3278ae542f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0427dcd-26da-462b-b936-a382d3d8afce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0427dcd-26da-462b-b936-a382d3d8afce.jpg?1",
             "name": "Heart Wolf",
             "text": "First strike\noc\nT: Target Dwarf gains first strike and gets +2/+0 until end of turn. If that Dwarf leaves play this turn, bury Heart Wolf. Use this ability only when attack or defense is announced.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "452a2552-9c83-5c5c-afcb-579741d24fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796f0ff-4e7b-4849-b463-0aac860c72ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796f0ff-4e7b-4849-b463-0aac860c72ea.jpg?1",
             "name": "Ironclaw Curse",
             "text": "Target creature gets -0/-1. That creature cannot be assigned to block any creature with power greater than or equal to the toughness of the creature Ironclaw Curse enchants.",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "39154614-22f8-595c-9893-77da50ac2339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dabe3af-cd5b-461e-95a4-aad046646419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dabe3af-cd5b-461e-95a4-aad046646419.jpg?1",
             "name": "Joven",
             "text": "o\nRo\nRo\nR, oc\nT: Destroy target non-creature artifact.",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "5421a66c-f4ba-5445-88a7-b04890f5a041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a630875-b43d-4591-992c-117e1212fa34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a630875-b43d-4591-992c-117e1212fa34.jpg?1",
             "name": "Orcish Mine",
             "text": "When Orcish Mine comes into play, put three ore counters on it. During your upkeep and whenever target land becomes tapped, remove an ore counter from Orcish Mine. When the last ore counter is removed from Orcish Mine, destroy the land Orcish Mine enchants; Orcish Mine deals 2 damage to that land's controller.",
             "colours": [
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "da4b9c03-3bae-54e2-9927-1d1c6017ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3adf9a6-7137-4995-9a83-2d410cb3cd20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3adf9a6-7137-4995-9a83-2d410cb3cd20.jpg?1",
             "name": "Retribution",
             "text": "Choose two target creatures controlled by an opponent. Bury one of those creatures, and put a -1/-1 counter on the other. That opponent chooses which creature is buried.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "3e6f01c5-e95b-5a92-94e8-00628d0d424c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1035f3-3027-4a41-834c-55222b13c2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1035f3-3027-4a41-834c-55222b13c2bc.jpg?1",
             "name": "Winter Sky",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, Winter Sky deals 1 damage to each creature and player. Otherwise, each player draws a card.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "04e7fce9-9088-5dc0-9974-03a4f163049c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c5a793-a777-44f9-a977-d16d26d3f852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c5a793-a777-44f9-a977-d16d26d3f852.jpg?1",
             "name": "An-Havva Constable",
             "text": "An-Havva Constable has toughness equal to 1 plus the total number of green creatures in play.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "b4b11381-9512-53fe-88fb-47b4804534ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff4531f-d19d-44af-861a-33087197d21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff4531f-d19d-44af-861a-33087197d21c.jpg?1",
             "name": "An-Havva Inn",
             "text": "Gain 1+* life, where * is equal to the total number of green creatures in play.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "06170056-7792-52d8-8553-790c1058c1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea60340-bbdb-48e2-94a6-5ac1197e978a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea60340-bbdb-48e2-94a6-5ac1197e978a.jpg?1",
             "name": "Autumn Willow",
             "text": "Cannot be the target of spells or effects.\noo\nG Target player may target Autumn Willow with spells or effects until end of turn.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "6f3048dd-9939-5a40-96fc-67bd7c03e6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07159586-270e-4a3e-9b21-0d74cf3e49d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07159586-270e-4a3e-9b21-0d74cf3e49d7.jpg?1",
             "name": "Carapace",
             "text": "Target creature gets +0/+2.\no0: Sacrifice Carapace to regenerate creature Carapace enchants.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "17355e9c-9fa6-5cd0-b56a-1618454c9a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d51d61e-c010-4b4e-a337-20ba5eb845e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d51d61e-c010-4b4e-a337-20ba5eb845e3.jpg?1",
             "name": "Carapace",
             "text": "Target creature gets +0/+2.\no0: Sacrifice Carapace to regenerate creature Carapace enchants.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "36c365c0-f233-5906-ae55-7f92b42f3e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9c59-f340-414c-b55b-39d46dd97e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9c59-f340-414c-b55b-39d46dd97e8e.jpg?1",
             "name": "Daughter of Autumn",
             "text": "oo\nW Redirect to Daughter of Autumn 1 damage dealt to a white creature.",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "68a6589e-b358-5bff-a003-0f92ca7b3374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8931e-6402-483c-a9e8-63ee344c36a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8931e-6402-483c-a9e8-63ee344c36a7.jpg?1",
             "name": "Faerie Noble",
             "text": "Flying\nAll Faeries you control get +0/+1.\noc\nT: All Faeries you control get +1/+0 until end of turn.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "5a8aacf9-dfb4-5d3a-a36e-87b2ef6cca43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4a595e-51f6-4e84-aa3a-5d9c18dc8b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4a595e-51f6-4e84-aa3a-5d9c18dc8b3f.jpg?1",
             "name": "Folk of An-Havva",
             "text": "If assigned as a blocker, Folk of An-Havva gets +2/+0 until end of turn.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "c4e32e64-d5df-5721-b7c3-0cf2c5d9f212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4118c563-08a7-4654-973e-ab9c454f00f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4118c563-08a7-4654-973e-ab9c454f00f9.jpg?1",
             "name": "Folk of An-Havva",
             "text": "If assigned as a blocker, Folk of An-Havva gets +2/+0 until end of turn.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "91556c5f-b11e-573d-a3bb-627dfa6c2926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085973eb-56cd-4bb5-aefd-bdf36f2d2a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085973eb-56cd-4bb5-aefd-bdf36f2d2a3e.jpg?1",
             "name": "Hungry Mist",
             "text": "During your upkeep, pay o\nGo\nG or bury Hungry Mist.",
             "colours": [
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "74484d41-3d02-5bd7-a5fc-a0dfc481bb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a486eab3-3a09-4bd5-ad97-8ec620434f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a486eab3-3a09-4bd5-ad97-8ec620434f7e.jpg?1",
             "name": "Hungry Mist",
             "text": "During your upkeep, pay o\nGo\nG or bury Hungry Mist.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "c0fc3770-4e7b-5ea5-98f1-db232e794588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f95eda2-f791-46e9-bb82-31422b8c5ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f95eda2-f791-46e9-bb82-31422b8c5ce4.jpg?1",
             "name": "Joven's Ferrets",
             "text": "If declared as an attacker, Joven's Ferrets gets +0/+2 until end of turn. At end of combat, tap any creatures that blocked Joven's Ferrets. Those creatures do not untap during their controller's next untap phase.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "558610bc-f4ea-5715-9e8d-b82c1a3babe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e4744-4d73-4e6e-950b-bb4c83229499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e4744-4d73-4e6e-950b-bb4c83229499.jpg?1",
             "name": "Leaping Lizard",
             "text": "o1oo\nG Flying and -0/-1 until end of turn",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "b00c496b-e598-5d1b-8369-ab696a71598a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be67121-068c-4770-bc42-c081577a442c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be67121-068c-4770-bc42-c081577a442c.jpg?1",
             "name": "Mammoth Harness",
             "text": "Target creature loses flying. If any creature is assigned to block the creature Mammoth Harness enchants or has the creature Mammoth Harness enchants assigned to block it, that creature gains first strike until end of turn.",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "16507ca6-d14d-5f55-bef9-a600f731582f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3b8f7-c794-40ef-9ebd-dec5357260d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3b8f7-c794-40ef-9ebd-dec5357260d4.jpg?1",
             "name": "Primal Order",
             "text": "During each player's upkeep, Primal Order deals 1 damage to that player for each non-basic land he or she controls.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "764be8fe-81c3-54ba-a86b-4864fb96eb65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab998cd1-2f49-42e7-b889-c6717b0ce884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab998cd1-2f49-42e7-b889-c6717b0ce884.jpg?1",
             "name": "Renewal",
             "text": "Sacrifice a land to search your library for a basic land and put it directly into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "c22f8d59-7870-565f-84be-751b889eb836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d67b0-d496-401b-8844-8e3ea2fd2046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d67b0-d496-401b-8844-8e3ea2fd2046.jpg?1",
             "name": "Root Spider",
             "text": "If assigned as a blocker, Root Spider gains first strike and gets +1/+0 until end of turn.",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "2d439fcb-eb25-5dd0-9e69-202af1ec308c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb4c256-e790-41ec-a9ab-e6358e810798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb4c256-e790-41ec-a9ab-e6358e810798.jpg?1",
             "name": "Roots",
             "text": "Tap target creature without flying. That creature does not untap during its controller's untap phase.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "990ab0f0-b4a8-5ec2-92b6-a2243da8c171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab87a387-678b-4913-a0c7-85f0238cee26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab87a387-678b-4913-a0c7-85f0238cee26.jpg?1",
             "name": "Rysorian Badger",
             "text": "If Rysorian Badger attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, remove from the game up to two target creatures from that player's graveyard. Gain 1 life for each creature removed in this way.",
             "colours": [
@@ -4033,7 +4033,7 @@
         },
         {
             "id": "52f5f1de-ae4e-5f84-8c32-fd2ef3f4a324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30785867-32f7-46c9-94c2-775078e792ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30785867-32f7-46c9-94c2-775078e792ae.jpg?1",
             "name": "Shrink",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "e8cd1fd2-96d1-5499-9932-48c28f7195e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f4eaa1-3c2b-4f5d-8d4e-98d153899873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f4eaa1-3c2b-4f5d-8d4e-98d153899873.jpg?1",
             "name": "Shrink",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "647035d6-42e5-58d6-9214-c1f03787b22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e13875f-f745-4afd-a830-33df9576dce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e13875f-f745-4afd-a830-33df9576dce8.jpg?1",
             "name": "Spectral Bears",
             "text": "If Spectral Bears is declared as an attacker and defending player controls no black cards, it does not untap during your next untap phase.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "1d95ef75-7a9b-5ad0-abee-826ecf707f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce80dc-86d9-4613-af98-c385ca5d1cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce80dc-86d9-4613-af98-c385ca5d1cf4.jpg?1",
             "name": "Willow Faerie",
             "text": "Flying",
             "colours": [
@@ -4168,7 +4168,7 @@
         },
         {
             "id": "4240c9a9-72a2-535e-8684-e8dedd0c5ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e777dfe-44ed-4e73-bf77-ef4c667092d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e777dfe-44ed-4e73-bf77-ef4c667092d4.jpg?1",
             "name": "Willow Faerie",
             "text": "Flying",
             "colours": [
@@ -4203,7 +4203,7 @@
         },
         {
             "id": "1eacde4d-93b3-52c9-a7c3-7b7c6ea77dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c636a608-26d7-4154-8052-a093b11362b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c636a608-26d7-4154-8052-a093b11362b1.jpg?1",
             "name": "Willow Priestess",
             "text": "oc\nT: Take a Faerie from your hand and put it directly into play as though it were just summoned.\no2oo\nG Target green creature gains protection from black until end of turn.",
             "colours": [
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "5a0d5476-80c3-5a47-aa82-28981d06f261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef20d8f-6e80-4fca-b6a7-541981f6a112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef20d8f-6e80-4fca-b6a7-541981f6a112.jpg?1",
             "name": "Apocalypse Chime",
             "text": "o2, oc\nT: Sacrifice Apocalypse Chime to bury all cards from the Homelands expansion.",
             "colours": [],
@@ -4264,7 +4264,7 @@
         },
         {
             "id": "bfd3ddf3-ee0d-5023-95d3-154eb6c23a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0ca2ea-e059-4742-8ce4-22876762048c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0ca2ea-e059-4742-8ce4-22876762048c.jpg?1",
             "name": "Clockwork Gnomes",
             "text": "o3, oc\nT: Regenerate target artifact creature.",
             "colours": [],
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "03ad43a4-1f04-543a-b131-e8bcdf28feec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b080587-d062-42ff-abc5-8e04a20faece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b080587-d062-42ff-abc5-8e04a20faece.jpg?1",
             "name": "Clockwork Steed",
             "text": "Cannot be blocked by artifact creatures.\nWhen Clockwork Steed comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Steed attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Steed. You may have no more than four of these counters on Clockwork Steed. Use this ability only during your upkeep.",
             "colours": [],
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "a02bc541-512c-5d22-bc3d-46b5b03dbefb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd89e5c-79dc-4a57-b5ea-16491443fea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd89e5c-79dc-4a57-b5ea-16491443fea1.jpg?1",
             "name": "Clockwork Swarm",
             "text": "Cannot be blocked by walls.\nWhen Clockwork Swarm comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Swarm attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Swarm. You may have no more than four of these counters on Clockwork Swarm. Use this ability only during your upkeep.",
             "colours": [],
@@ -4354,7 +4354,7 @@
         },
         {
             "id": "f3dc2766-6503-5984-a30b-470d8a1da1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828f8f68-abe2-4e39-b3e4-991dceacd5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828f8f68-abe2-4e39-b3e4-991dceacd5d9.jpg?1",
             "name": "Didgeridoo",
             "text": "o3: Take a Minotaur from your hand and put it directly into play as though it were just summoned.",
             "colours": [],
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "647bddea-8ab7-5762-ac56-0101ce77005c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db749e-a1df-4615-9449-94731fa23a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db749e-a1df-4615-9449-94731fa23a9f.jpg?1",
             "name": "Ebony Rhino",
             "text": "Trample",
             "colours": [],
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "e67ff526-b337-5c58-b4f9-ca189dd20c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff4430-c8f7-408a-aad2-a098d747ea62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff4430-c8f7-408a-aad2-a098d747ea62.jpg?1",
             "name": "Feroz's Ban",
             "text": "Summon spells each cost an additional o2 to cast.",
             "colours": [],
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "1984f95d-48a8-51b9-9570-736f3a1252bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2520b38-76c1-45a2-9cda-a305f70762bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2520b38-76c1-45a2-9cda-a305f70762bd.jpg?1",
             "name": "Joven's Tools",
             "text": "o4, oc\nT: Target creature cannot be blocked except by walls until end of turn.",
             "colours": [],
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "85848a71-d5df-589c-9320-fc18328f27bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22148a1a-2172-4718-8ee4-08770eafed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22148a1a-2172-4718-8ee4-08770eafed9f.jpg?1",
             "name": "Roterothopter",
             "text": "Flying\no2: +1/+0 until end of turn. You cannot spend more than o4 in this way each turn.",
             "colours": [],
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "67fad983-0ed6-5705-9f19-50dd36542853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a7d2b-3fdb-4e7f-b0b6-f6559dcb32e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a7d2b-3fdb-4e7f-b0b6-f6559dcb32e2.jpg?1",
             "name": "Serrated Arrows",
             "text": "When Serrated Arrows comes into play, put three arrowhead counters on it.\nDuring your upkeep, bury Serrated Arrows if there are no arrowhead counters on it.\noc\nT: Remove an arrowhead counter from Serrated Arrows to put a -1/-1 counter on target creature.",
             "colours": [],
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "567d9c4b-c847-51bd-89a9-9b8855363456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afac347-4316-43e2-848b-e474ed563af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afac347-4316-43e2-848b-e474ed563af6.jpg?1",
             "name": "An-Havva Township",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nG to your mana pool.\no2, oc\nT: Add o\nW to your mana pool.\no2, oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "82b2543f-8aaa-5fdc-85e3-686bcd03b903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2e669b-61b2-4729-b636-094796fb1d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2e669b-61b2-4729-b636-094796fb1d93.jpg?1",
             "name": "Aysen Abbey",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nW to your mana pool.\no2, oc\nT: Add o\nU to your mana pool.\no2, oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "efa14e7d-f7bc-5e13-84ed-6945b6e98916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bfba30-4075-4bd6-9e4b-3a37641d43ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bfba30-4075-4bd6-9e4b-3a37641d43ce.jpg?1",
             "name": "Castle Sengir",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nB to your mana pool.\no2, oc\nT: Add o\nU to your mana pool.\no2, oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "32b84f4e-c4b7-5b41-b230-9af50f247efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395fe900-ed19-438e-a658-ed7cf85818e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395fe900-ed19-438e-a658-ed7cf85818e5.jpg?1",
             "name": "Koskun Keep",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nR to your mana pool.\no2, oc\nT: Add o\nB to your mana pool.\no2, oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "c848f0c5-5857-5189-9c59-4485134ffbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd736532-8e98-4f4a-b48f-a66c57efcbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd736532-8e98-4f4a-b48f-a66c57efcbfd.jpg?1",
             "name": "Wizards' School",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nU to your mana pool.\no2, oc\nT: Add o\nW to your mana pool.\no2, oc\nT: Add o\nB to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/HOU.json
+++ b/Assets/Resources/Sets/HOU.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d4508551-ed8f-524e-abc5-c1e28ad49677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebc06f6-305d-4a5a-9be7-fbc6d8cd9c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebc06f6-305d-4a5a-9be7-fbc6d8cd9c72.jpg?1",
             "name": "Act of Heroism",
             "text": "Untap target creature. It gets +2/+2 until end of turn and can block an additional creature this turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "5c4b27d3-1d37-572f-bba7-aba489855a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e267d-450c-4eeb-b61d-bd0ec5d8534a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e267d-450c-4eeb-b61d-bd0ec5d8534a.jpg?1",
             "name": "Adorned Pouncer",
             "text": "Double strike\nEternalize {3}{W}{W} ({3}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Cat with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "910022e0-4598-52f3-85a7-032c2f92bb9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dad070-e41d-419b-ae27-ace82b9ab2c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dad070-e41d-419b-ae27-ace82b9ab2c5.jpg?1",
             "name": "Angel of Condemnation",
             "text": "Flying, vigilance\n{2}{W}, {T}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n{2}{W}, {T}, Exert Angel of Condemnation: Exile another target creature until Angel of Condemnation leaves the battlefield. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "a1c442b7-e8be-5246-9fdc-203ab55c993b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad202785-a91f-4dc8-bcc0-eb1bd49f162e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad202785-a91f-4dc8-bcc0-eb1bd49f162e.jpg?1",
             "name": "Angel of the God-Pharaoh",
             "text": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "42a98d49-5115-5ee8-9b7b-65c301d47249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c1310c-1b54-42dd-bf24-889770fa2ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c1310c-1b54-42dd-bf24-889770fa2ded.jpg?1",
             "name": "Aven of Enduring Hope",
             "text": "Flying\nWhen Aven of Enduring Hope enters the battlefield, you gain 3 life.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "609cd717-5e92-5b4d-b04c-2e26b9965d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732fa4c9-11da-4bdb-96af-aa37c74be25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732fa4c9-11da-4bdb-96af-aa37c74be25f.jpg?1",
             "name": "Crested Sunmare",
             "text": "Other Horses you control have indestructible.\nAt the beginning of each end step, if you gained life this turn, create a 5/5 white Horse creature token.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "8836bac7-34af-58a2-b56f-6c697b9e9577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e6320c-6f8b-4582-ad11-9b868bff08a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e6320c-6f8b-4582-ad11-9b868bff08a1.jpg?1",
             "name": "Dauntless Aven",
             "text": "Flying\nWhenever Dauntless Aven attacks, untap target creature you control.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "5ddaa9ea-5561-5392-9ec7-2cc3c97caa82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082298e-05c4-48b3-9367-713f59aafdc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082298e-05c4-48b3-9367-713f59aafdc6.jpg?1",
             "name": "Desert's Hold",
             "text": "Enchant creature\nWhen Desert's Hold enters the battlefield, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "93a50a7d-30e1-53ea-be26-e94158fe00c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad806d67-4c98-438b-859f-b1358281e09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad806d67-4c98-438b-859f-b1358281e09d.jpg?1",
             "name": "Disposal Mummy",
             "text": "When Disposal Mummy enters the battlefield, exile target card from an opponent's graveyard.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "66db8210-bfd5-5949-a78e-68466f6bad0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2234df89-0835-4a17-b5d8-2334ee8f692d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2234df89-0835-4a17-b5d8-2334ee8f692d.jpg?1",
             "name": "Djeru, With Eyes Open",
             "text": "Vigilance\nWhen Djeru, With Eyes Open enters the battlefield, you may search your library for a planeswalker card, reveal it, put it into your hand, then shuffle your library.\nIf a source would deal damage to a planeswalker you control, prevent 1 of that damage.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "ba32c3b9-d59a-5391-8f1e-75dc71e0111a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f005de-7971-4f22-ad1f-5d0667f68113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f005de-7971-4f22-ad1f-5d0667f68113.jpg?1",
             "name": "Djeru's Renunciation",
             "text": "Tap up to two target creatures.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "24d128d3-b617-5c94-8012-71eb8ddd5ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7684db4c-6eff-4da1-a410-48d707fb5bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7684db4c-6eff-4da1-a410-48d707fb5bf1.jpg?1",
             "name": "Dutiful Servants",
             "text": "",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "6aa04650-ca1e-5cff-8044-c152b19aecc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4722eb81-1aa1-4863-8dfb-d9d6035bd6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4722eb81-1aa1-4863-8dfb-d9d6035bd6c6.jpg?1",
             "name": "Gideon's Defeat",
             "text": "Exile target white creature that's attacking or blocking. If it was a Gideon planeswalker, you gain 5 life.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "596eea2e-de8f-549f-8be1-6a4bf1e734cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8a25b-2ad0-4ffe-b41a-6b3f8b48c1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8a25b-2ad0-4ffe-b41a-6b3f8b48c1e9.jpg?1",
             "name": "God-Pharaoh's Faithful",
             "text": "Whenever you cast a blue, black, or red spell, you gain 1 life.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "6d7c254e-eea2-5f7d-9861-d7f26fa02fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a89652-95ef-45b4-80c3-02241483f3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a89652-95ef-45b4-80c3-02241483f3c0.jpg?1",
             "name": "Hour of Revelation",
             "text": "Hour of Revelation costs {3} less to cast if there are ten or more nonland permanents on the battlefield.\nDestroy all nonland permanents.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "a962307a-9855-5b2f-85d4-938124f782cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b1a3e5-cf77-439d-8e0d-cf6571f6891c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b1a3e5-cf77-439d-8e0d-cf6571f6891c.jpg?1",
             "name": "Mummy Paramount",
             "text": "Whenever another Zombie enters the battlefield under your control, Mummy Paramount gets +1/+1 until end of turn.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "f8bed615-54f8-5d80-a0d4-9bc22b6de1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a644b4-a2f7-4219-935b-237936b07948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a644b4-a2f7-4219-935b-237936b07948.jpg?1",
             "name": "Oketra's Avenger",
             "text": "You may exert Oketra's Avenger as it attacks. When you do, prevent all combat damage that would be dealt to it this turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "41a9cf25-26c4-5337-80ec-a79d505b304a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d3bf26-6003-4699-a26e-b3b5bcd3e8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d3bf26-6003-4699-a26e-b3b5bcd3e8dc.jpg?1",
             "name": "Oketra's Last Mercy",
             "text": "Your life total becomes equal to your starting life total. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "b9a5189b-1f0d-5233-a36d-cc87d8104fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867b32d2-e396-411d-ac02-1af4106dd3d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867b32d2-e396-411d-ac02-1af4106dd3d2.jpg?1",
             "name": "Overwhelming Splendor",
             "text": "Enchant player\nCreatures enchanted player controls lose all abilities and have base power and toughness 1/1.\nEnchanted player can't activate abilities that aren't mana abilities or loyalty abilities.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "0c59a8ff-e1d2-5fce-afae-3ffc7ada3d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c501c-4e23-4e56-ad99-1803c8a877ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c501c-4e23-4e56-ad99-1803c8a877ca.jpg?1",
             "name": "Sandblast",
             "text": "Sandblast deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "87ab393d-1f15-500d-a0fe-875dc82a51bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac7b2d8-7702-4b8c-84ed-1d785dea5cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac7b2d8-7702-4b8c-84ed-1d785dea5cc5.jpg?1",
             "name": "Saving Grace",
             "text": "Flash\nEnchant creature you control\nWhen Saving Grace enters the battlefield, all damage that would be dealt this turn to you and permanents you control is dealt to enchanted creature instead.\nEnchanted creature gets +0/+3.",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "e3d2d863-12e9-5165-83d6-2fcae0f0b15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a71fb62-acbd-49f5-842f-0fc9fa48afea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a71fb62-acbd-49f5-842f-0fc9fa48afea.jpg?1",
             "name": "Solemnity",
             "text": "Players can't get counters.\nCounters can't be put on artifacts, creatures, enchantments, or lands.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "a7952b62-ecfb-53fa-82b1-92e05b15b98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adb8dbf-c83c-4169-b822-8e32aa36cffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adb8dbf-c83c-4169-b822-8e32aa36cffa.jpg?1",
             "name": "Solitary Camel",
             "text": "Solitary Camel has lifelink as long as you control a Desert or there is a Desert card in your graveyard. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "4750017d-0360-5f0c-bb3c-63dcd43a6752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707a30d2-0fca-4b39-91fb-9b03152705ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707a30d2-0fca-4b39-91fb-9b03152705ba.jpg?1",
             "name": "Steadfast Sentinel",
             "text": "Vigilance\nEternalize {4}{W}{W} ({4}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Cleric with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "268aab3f-b2b5-5f21-b5a6-e98c82bf49e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda3cd3b-d4c5-4537-8c81-5ccf269f810e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda3cd3b-d4c5-4537-8c81-5ccf269f810e.jpg?1",
             "name": "Steward of Solidarity",
             "text": "{T}, Exert Steward of Solidarity: Create a 1/1 white Warrior creature token with vigilance. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "df30f715-29b6-537b-bd1b-b2fe08621100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb41cc-6edb-4a31-92cb-b17850b49432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb41cc-6edb-4a31-92cb-b17850b49432.jpg?1",
             "name": "Sunscourge Champion",
             "text": "When Sunscourge Champion enters the battlefield, you gain life equal to its power.\nEternalize\u2014{2}{W}{W}, Discard a card. ({2}{W}{W}, Discard a card, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "0d4dc816-9e9f-5ee3-9d51-39ed4626cde2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db5673-ecd3-4e58-8dc9-b42c76f80186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db5673-ecd3-4e58-8dc9-b42c76f80186.jpg?1",
             "name": "Unconventional Tactics",
             "text": "Target creature gets +3/+3 and gains flying until end of turn.\nWhenever a Zombie enters the battlefield under your control, you may pay {W}. If you do, return Unconventional Tactics from your graveyard to your hand.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "8eed6a70-eea5-5a36-9319-4fcdd47e93d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1800882-e886-48d5-ac85-0a8e5841dc9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1800882-e886-48d5-ac85-0a8e5841dc9a.jpg?1",
             "name": "Vizier of the True",
             "text": "You may exert Vizier of the True as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, tap target creature an opponent controls.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "f77b1642-4235-53f7-a1e6-482fcc88c9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b744c138-9b9e-47f6-9d56-feb6a78ce377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b744c138-9b9e-47f6-9d56-feb6a78ce377.jpg?1",
             "name": "Aerial Guide",
             "text": "Flying\nWhenever Aerial Guide attacks, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "722fd135-242e-5ed2-80cf-8e4e64d266bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c2d70a-d646-44eb-9f65-ddf6e329ab43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c2d70a-d646-44eb-9f65-ddf6e329ab43.jpg?1",
             "name": "Aven Reedstalker",
             "text": "Flash\nFlying",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "eed9b3ea-33ae-564f-a419-f971d6ef907b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765221d-9718-47eb-aa49-9c0719337139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765221d-9718-47eb-aa49-9c0719337139.jpg?1",
             "name": "Champion of Wits",
             "text": "When Champion of Wits enters the battlefield, you may draw cards equal to its power. If you do, discard two cards.\nEternalize {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Naga Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1057,7 +1057,7 @@
         },
         {
             "id": "1da388b9-a308-5703-aa66-a52b8e75d6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0ef3-b32c-403a-93cb-29cf05795711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0ef3-b32c-403a-93cb-29cf05795711.jpg?1",
             "name": "Countervailing Winds",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "07c39d9f-c042-52a7-b360-c5ea1530e7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9093e7-c129-4efa-9f25-a2366f92e15a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9093e7-c129-4efa-9f25-a2366f92e15a.jpg?1",
             "name": "Cunning Survivor",
             "text": "Whenever you cycle or discard a card, Cunning Survivor gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "071c2878-b456-5c27-b9a8-f775c7e741cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0389daf7-0818-488f-8e6a-94818a6c94a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0389daf7-0818-488f-8e6a-94818a6c94a6.jpg?1",
             "name": "Eternal of Harsh Truths",
             "text": "Afflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)\nWhenever Eternal of Harsh Truths attacks and isn't blocked, draw a card.",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "b6bd3097-c28c-563a-883a-421acbe4d903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e5c1ab-eebd-41ca-a1ca-29b00370f6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e5c1ab-eebd-41ca-a1ca-29b00370f6e8.jpg?1",
             "name": "Fraying Sanity",
             "text": "Enchant player\nAt the beginning of each end step, enchanted player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards put into that graveyard from anywhere this turn.",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "1b309e3c-55a4-555b-b3c9-337978a300f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01040ed3-4f64-4e47-8f80-3d3a339004f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01040ed3-4f64-4e47-8f80-3d3a339004f7.jpg?1",
             "name": "Hour of Eternity",
             "text": "Exile X target creature cards from your graveyard. For each card exiled this way, create a token that's a copy of that card, except it's a 4/4 black Zombie.",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "707eee32-9200-5d99-a6b8-9318d6662b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c3a6a5-9a50-4a38-9f5f-b8caa320909d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c3a6a5-9a50-4a38-9f5f-b8caa320909d.jpg?1",
             "name": "Imaginary Threats",
             "text": "Creatures target opponent controls attack this turn if able. During that player's next untap step, creatures he or she controls don't untap.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "4269a447-33f1-5645-83bb-66976183a10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b103c1-9b25-4bfe-9081-570977e9fdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b103c1-9b25-4bfe-9081-570977e9fdad.jpg?1",
             "name": "Jace's Defeat",
             "text": "Counter target blue spell. If it was a Jace planeswalker spell, scry 2.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "83054a5e-497a-526c-85c0-620563b60b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7e5103-ee7d-40d7-bcd4-c5d1a48e9821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7e5103-ee7d-40d7-bcd4-c5d1a48e9821.jpg?1",
             "name": "Kefnet's Last Word",
             "text": "Gain control of target artifact, creature, or enchantment. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "e093e616-3d30-57c6-b9c3-d8d562e593a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26012b65-7e0a-427e-945e-de24738517fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26012b65-7e0a-427e-945e-de24738517fb.jpg?1",
             "name": "Nimble Obstructionist",
             "text": "Flash\nFlying\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\nWhen you cycle Nimble Obstructionist, counter target activated or triggered ability you don't control.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "357cb20e-2d75-5fd8-b0e4-d3b51af1852d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2361bd3b-9ae0-4198-9296-6d278feff042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2361bd3b-9ae0-4198-9296-6d278feff042.jpg?1",
             "name": "Ominous Sphinx",
             "text": "Flying\nWhenever you cycle or discard a card, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "fda6c3ac-f459-58c0-b0b0-50130454e4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83fd08a-c87b-4e29-bd1d-31dea3732156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83fd08a-c87b-4e29-bd1d-31dea3732156.jpg?1",
             "name": "Proven Combatant",
             "text": "Eternalize {4}{U}{U} ({4}{U}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Warrior with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "4ba1fcc7-94b0-5a8a-847f-09b34aa02d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e54dc4a-3fd6-4895-8497-3a19e4e9a3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e54dc4a-3fd6-4895-8497-3a19e4e9a3d8.jpg?1",
             "name": "Riddleform",
             "text": "Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1.",
             "colours": [
@@ -1458,7 +1458,7 @@
         },
         {
             "id": "cc5cbb72-6e95-52c7-aa0d-6c3655f5f4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e897f14-8775-4bc3-a3b2-b149f79ec702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e897f14-8775-4bc3-a3b2-b149f79ec702.jpg?1",
             "name": "Seer of the Last Tomorrow",
             "text": "{U}, {T}, Discard a card: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "30641e76-d07d-5cfd-8a3d-b9bb93b158f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2b97d1-3e69-4305-b1df-947ff64c5043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2b97d1-3e69-4305-b1df-947ff64c5043.jpg?1",
             "name": "Sinuous Striker",
             "text": "{U}: Sinuous Striker gets +1/-1 until end of turn.\nEternalize\u2014{3}{U}{U}, Discard a card. ({3}{U}{U}, Discard a card, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Naga Warrior with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "f3d79f36-87af-5976-a67b-1d405129bf3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb7d1a-d606-46a8-a592-648c5d2e7382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb7d1a-d606-46a8-a592-648c5d2e7382.jpg?1",
             "name": "Spellweaver Eternal",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nAfflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)",
             "colours": [
@@ -1564,7 +1564,7 @@
         },
         {
             "id": "eebf317d-ba0a-5e39-a0c6-fe4048813ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95756b98-59c2-494d-9894-7406185ad144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95756b98-59c2-494d-9894-7406185ad144.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "b7dbc8d3-132a-5902-979c-ccb49fb45c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeef9ef-487c-400b-bcee-1c0e8ec94b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeef9ef-487c-400b-bcee-1c0e8ec94b6a.jpg?1",
             "name": "Striped Riverwinder",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "1f29a0e0-e50d-54c1-a34b-7ba572934465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b677e7cb-7b5d-4993-8f13-881493c498ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b677e7cb-7b5d-4993-8f13-881493c498ce.jpg?1",
             "name": "Supreme Will",
             "text": "Choose one \u2014\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "b8956b67-4835-5768-b174-b05fbd3668ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bec26d-20ba-4f31-a153-2c93a4f474e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bec26d-20ba-4f31-a153-2c93a4f474e5.jpg?1",
             "name": "Swarm Intelligence",
             "text": "Whenever you cast an instant or sorcery spell, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -1694,7 +1694,7 @@
         },
         {
             "id": "5e28ab4c-30c5-5a87-b35d-7cae075aab4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0353c-f1e0-49db-9edc-eea9090de872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0353c-f1e0-49db-9edc-eea9090de872.jpg?1",
             "name": "Tragic Lesson",
             "text": "Draw two cards. Then discard a card unless you return a land you control to its owner's hand.",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "91f1328d-e988-594e-a984-bb4d66fabd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd1a8b2-f4ba-45af-9586-98a98834b8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd1a8b2-f4ba-45af-9586-98a98834b8bc.jpg?1",
             "name": "Unesh, Criosphinx Sovereign",
             "text": "Flying\nSphinx spells you cast cost {2} less to cast.\nWhenever Unesh, Criosphinx Sovereign or another Sphinx enters the battlefield under your control, reveal the top four cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "4f1dda38-ba12-5cbe-b725-d8dee358fb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a418b2aa-dbc2-409b-9f19-e16a0ad8cbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a418b2aa-dbc2-409b-9f19-e16a0ad8cbac.jpg?1",
             "name": "Unquenchable Thirst",
             "text": "Enchant creature\nWhen Unquenchable Thirst enters the battlefield, if you control a Desert or there is a Desert card in your graveyard, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "39cf7018-6173-5c6a-91c9-a410555a14bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a5bd6-d7e0-4e35-bb7d-b9a41fcf67bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a5bd6-d7e0-4e35-bb7d-b9a41fcf67bc.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "bc5ac72b-ff19-5a0d-9c83-a74794fbd155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef426c-b396-4767-b360-435f67207022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef426c-b396-4767-b360-435f67207022.jpg?1",
             "name": "Vizier of the Anointed",
             "text": "When Vizier of the Anointed enters the battlefield, you may search your library for a creature card with eternalize or embalm, put that card into your graveyard, then shuffle your library.\nWhenever you activate an eternalize or embalm ability, draw a card.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "e57173a9-dd2b-5787-8eb9-2d1a1fe423ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691b79ef-87da-4b52-8311-2f6f46c6368d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691b79ef-87da-4b52-8311-2f6f46c6368d.jpg?1",
             "name": "Accursed Horde",
             "text": "{1}{B}: Target attacking Zombie gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "93755b0e-972c-5ed4-8625-cd64f795b53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b04934f-87d1-4768-b7b5-5f7249a09771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b04934f-87d1-4768-b7b5-5f7249a09771.jpg?1",
             "name": "Ammit Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nWhenever an opponent casts a spell, put a -1/-1 counter on Ammit Eternal.\nWhenever Ammit Eternal deals combat damage to a player, remove all -1/-1 counters from it.",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "5c5c835c-6f5d-5c27-8ff5-615e2722252a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dfbf99-55e8-468b-bcd9-9179cad7cab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dfbf99-55e8-468b-bcd9-9179cad7cab6.jpg?1",
             "name": "Apocalypse Demon",
             "text": "Flying\nApocalypse Demon's power and toughness are each equal to the number of cards in your graveyard.\nAt the beginning of your upkeep, tap Apocalypse Demon unless you sacrifice another creature.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "255b77ca-75e6-5ec3-876e-dd0ca432e2ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005a19e2-c334-4b87-bc8b-55f62fc9abd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005a19e2-c334-4b87-bc8b-55f62fc9abd9.jpg?1",
             "name": "Banewhip Punisher",
             "text": "When Banewhip Punisher enters the battlefield, you may put a -1/-1 counter on target creature.\n{B}, Sacrifice Banewhip Punisher: Destroy target creature that has a -1/-1 counter on it.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "c63fd178-043a-5b08-a567-e34bffa89f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0102-c0d6-4d50-941a-dd1c3575a3a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0102-c0d6-4d50-941a-dd1c3575a3a8.jpg?1",
             "name": "Bontu's Last Reckoning",
             "text": "Destroy all creatures. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "0a1b7773-30ff-5273-811f-895ad5637263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b9e3a3-8d01-4273-9658-9ffcbc2d2297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b9e3a3-8d01-4273-9658-9ffcbc2d2297.jpg?1",
             "name": "Carrion Screecher",
             "text": "Flying",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "160442d0-264d-58c7-8d42-8ae9034552ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db6ef5-1aa9-4b8c-b0b7-d6668a2347a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db6ef5-1aa9-4b8c-b0b7-d6668a2347a1.jpg?1",
             "name": "Doomfall",
             "text": "Choose one \u2014\n\u2022 Target opponent exiles a creature he or she controls.\n\u2022 Target opponent reveals his or her hand. You choose a nonland card from it. Exile that card.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "ec7ae413-8afc-54cf-a233-9cd86c753975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4fcde3-03c9-43e6-a34b-29f6ce44e7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4fcde3-03c9-43e6-a34b-29f6ce44e7c4.jpg?1",
             "name": "Dreamstealer",
             "text": "Menace\nWhenever Dreamstealer deals combat damage to a player, that player discards that many cards.\nEternalize {4}{B}{B} ({4}{B}{B}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "b7b873de-0154-59a3-ad0e-03ade8ef523d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035ee44d-63ef-45b7-b36b-38ac341a2ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035ee44d-63ef-45b7-b36b-38ac341a2ca7.jpg?1",
             "name": "Grisly Survivor",
             "text": "Whenever you cycle or discard a card, Grisly Survivor gets +2/+0 until end of turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "0ee5a5f1-5527-5932-a9bc-6f69fa0656d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35e66cb-af50-411a-b6f2-16fb7072eff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35e66cb-af50-411a-b6f2-16fb7072eff5.jpg?1",
             "name": "Hour of Glory",
             "text": "Exile target creature. If that creature was a God, its controller reveals his or her hand and exiles all cards from it with the same name as that creature.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "7122934b-8d56-5c3f-ba41-ec1df596341b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbdc277-4a76-44a9-aeda-edabab1f579e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbdc277-4a76-44a9-aeda-edabab1f579e.jpg?1",
             "name": "Khenra Eternal",
             "text": "Afflict 1 (Whenever this creature becomes blocked, defending player loses 1 life.)",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "09b2acaa-7c4e-55db-ad5b-da9cda721ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaded6bf-2db7-4b1d-93cc-4b7b571cd2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaded6bf-2db7-4b1d-93cc-4b7b571cd2de.jpg?1",
             "name": "Lethal Sting",
             "text": "As an additional cost to cast Lethal Sting, put a -1/-1 counter on a creature you control.\nDestroy target creature.",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "697f2b9b-4ca8-52bb-bd13-d1578684a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f72b028-b9df-40c7-822f-4acc6bdcc719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f72b028-b9df-40c7-822f-4acc6bdcc719.jpg?1",
             "name": "Liliana's Defeat",
             "text": "Destroy target black creature or black planeswalker. If that permanent was a Liliana planeswalker, her controller loses 3 life.",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "61e661fc-669f-5a84-9194-8f02fab8e6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06be97-71c8-46c8-a1c2-5da3af25e6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06be97-71c8-46c8-a1c2-5da3af25e6de.jpg?1",
             "name": "Lurching Rotbeast",
             "text": "Cycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "0856bd9a-c9b1-5e49-9a0a-106f47b13760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfb7f50-14b1-4c7d-b4c8-f50bc14f4fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfb7f50-14b1-4c7d-b4c8-f50bc14f4fb7.jpg?1",
             "name": "Marauding Boneslasher",
             "text": "Marauding Boneslasher can't block unless you control another Zombie.",
             "colours": [
@@ -2373,7 +2373,7 @@
         },
         {
             "id": "3f3e95b9-be2c-5571-a259-ed61795655d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a6becd-15be-4f2d-8fda-35b1b289b28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a6becd-15be-4f2d-8fda-35b1b289b28f.jpg?1",
             "name": "Merciless Eternal",
             "text": "Afflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)\n{2}{B}, Discard a card: Merciless Eternal gets +2/+2 until end of turn.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "ebfff495-2257-5e09-980d-51d5fb128611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef494f81-638a-4e5d-b987-0dde7f2a135c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef494f81-638a-4e5d-b987-0dde7f2a135c.jpg?1",
             "name": "Moaning Wall",
             "text": "Defender\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "5eff6de5-153b-51ea-a75f-fa7f48d1efe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14adff9-33cc-467e-b782-068854c5e7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14adff9-33cc-467e-b782-068854c5e7b7.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "Flying, trample\nPay 2 life, Sacrifice another creature: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -2479,7 +2479,7 @@
         },
         {
             "id": "ccd1ae3b-a99e-5fea-bc22-dd58a3a953c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd36987a-48c3-477b-b859-0268e84b7e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd36987a-48c3-477b-b859-0268e84b7e7b.jpg?1",
             "name": "Razaketh's Rite",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "a19fdf32-17e7-524d-961e-7744371b142e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91652fe0-2064-4996-b484-a1f88e0023f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91652fe0-2064-4996-b484-a1f88e0023f7.jpg?1",
             "name": "Ruin Rat",
             "text": "Deathtouch\nWhen Ruin Rat dies, exile target card from an opponent's graveyard.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "f7ffb3be-b705-5e52-ba54-ce97d1eb4c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66f3c4-5a11-4e28-a4ae-673b3b36d3ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66f3c4-5a11-4e28-a4ae-673b3b36d3ec.jpg?1",
             "name": "Scrounger of Souls",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "292c20c5-2a81-5a1c-b664-ded1d46c4256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69d77d1-5980-436c-bf48-790939b069aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69d77d1-5980-436c-bf48-790939b069aa.jpg?1",
             "name": "Torment of Hailfire",
             "text": "Repeat the following process X times. Each opponent loses 3 life unless that player sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -2611,7 +2611,7 @@
         },
         {
             "id": "39c66ea4-b8e9-5676-a62a-67ab726c8405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01651f67-cc25-4240-9698-58b7d906a160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01651f67-cc25-4240-9698-58b7d906a160.jpg?1",
             "name": "Torment of Scarabs",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player loses 3 life unless he or she sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "8de2277a-8770-56b3-b010-a8c124d1395b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66410b-67a3-4f6a-b3ae-dcad9858a5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66410b-67a3-4f6a-b3ae-dcad9858a5da.jpg?1",
             "name": "Torment of Venom",
             "text": "Put three -1/-1 counters on target creature. Its controller loses 3 life unless he or she sacrifices another nonland permanent or discards a card.",
             "colours": [
@@ -2678,7 +2678,7 @@
         },
         {
             "id": "c06d3db7-dc8b-5427-8623-d5cca8824cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160bc31-bdfa-4654-9d69-95ee2a5fe870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160bc31-bdfa-4654-9d69-95ee2a5fe870.jpg?1",
             "name": "Vile Manifestation",
             "text": "Vile Manifestation gets +1/+0 for each card with cycling in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "3f28f2a6-9eb9-5bb3-a456-c7923a51226f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6695fa8-881c-407c-91d9-3ac770372d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6695fa8-881c-407c-91d9-3ac770372d35.jpg?1",
             "name": "Without Weakness",
             "text": "Target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "d2f0cf1f-a8d6-5efe-a47f-fc786d0db97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd729df-8a02-4d5e-8432-bc0d006b0d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd729df-8a02-4d5e-8432-bc0d006b0d3d.jpg?1",
             "name": "Wretched Camel",
             "text": "When Wretched Camel dies, if you control a Desert or there is a Desert card in your graveyard, target player discards a card.",
             "colours": [
@@ -2779,7 +2779,7 @@
         },
         {
             "id": "8bfef07c-ae3d-51ce-8020-46aef3724660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84319dfb-eaf7-4b98-8c4f-30f5e779591b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84319dfb-eaf7-4b98-8c4f-30f5e779591b.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "49cb8945-d967-5bdf-b2d0-3621b91749a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5b9b-d24b-4e9a-bc90-7ed198cd1132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5b9b-d24b-4e9a-bc90-7ed198cd1132.jpg?1",
             "name": "Blur of Blades",
             "text": "Put a -1/-1 counter on target creature. Blur of Blades deals 2 damage to that creature's controller.",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "c1703dfe-c749-5ff7-9660-ccbc0e3d4b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f191fb-eaf6-432f-a668-37ad48ffabaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f191fb-eaf6-432f-a668-37ad48ffabaf.jpg?1",
             "name": "Burning-Fist Minotaur",
             "text": "First strike\n{1}{R}, Discard a card: Burning-Fist Minotaur gets +2/+0 until end of turn.",
             "colours": [
@@ -2878,7 +2878,7 @@
         },
         {
             "id": "916e3734-27ce-5b8b-998a-5cccc3a820df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38c6613-b1f7-4b38-b956-7860d041e593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38c6613-b1f7-4b38-b956-7860d041e593.jpg?1",
             "name": "Chandra's Defeat",
             "text": "Chandra's Defeat deals 5 damage to target red creature or red planeswalker. If that permanent is a Chandra planeswalker, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -2910,7 +2910,7 @@
         },
         {
             "id": "f7b4dae5-fe4e-5907-b768-5343fdbbd79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8094908b-1d3a-42df-bc27-8456fbb98e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8094908b-1d3a-42df-bc27-8456fbb98e65.jpg?1",
             "name": "Chaos Maw",
             "text": "When Chaos Maw enters the battlefield, it deals 3 damage to each other creature.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "63224dc2-7aee-5dba-aa48-ac5e584c4d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdaba76-b98d-4699-9a5f-e59285b09552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdaba76-b98d-4699-9a5f-e59285b09552.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn.\nDraw a card.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "06bbb3b2-a0cc-55f5-bcda-043147b3b7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e3983d-b1ed-46a9-9ab0-96c4d0d77050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e3983d-b1ed-46a9-9ab0-96c4d0d77050.jpg?1",
             "name": "Defiant Khenra",
             "text": "",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "7e971bfe-9d90-59e6-b355-3cd28b8c437d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60eabe-b281-4eba-9c26-287364ed2067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60eabe-b281-4eba-9c26-287364ed2067.jpg?1",
             "name": "Earthshaker Khenra",
             "text": "Haste\nWhen Earthshaker Khenra enters the battlefield, target creature with power less than or equal to Earthshaker Khenra's power can't block this turn.\nEternalize {4}{R}{R} ({4}{R}{R}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Jackal Warrior with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "38d14f01-a54a-54a6-8b46-1023e1187b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c78708-254c-446f-b6eb-8839faf08790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c78708-254c-446f-b6eb-8839faf08790.jpg?1",
             "name": "Fervent Paincaster",
             "text": "{T}: Fervent Paincaster deals 1 damage to target player.\n{T}, Exert Fervent Paincaster: It deals 1 damage to target creature. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "f275366f-bc06-5607-afa2-a7292195dd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc6b73-298b-4afa-990a-63706e77dd9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc6b73-298b-4afa-990a-63706e77dd9f.jpg?1",
             "name": "Firebrand Archer",
             "text": "Whenever you cast a noncreature spell, Firebrand Archer deals 1 damage to each opponent.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "75196f4b-0a58-5923-b4f2-9169f4a45c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c869cc4-eed9-4b24-b60f-2d7f85b885dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c869cc4-eed9-4b24-b60f-2d7f85b885dc.jpg?1",
             "name": "Frontline Devastator",
             "text": "Afflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)\n{1}{R}: Frontline Devastator gets +1/+0 until end of turn.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "32c2dc52-d1ff-50ce-b162-8167b1ed9122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8fbd-9223-447d-a85c-fa6222c75277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8fbd-9223-447d-a85c-fa6222c75277.jpg?1",
             "name": "Gilded Cerodon",
             "text": "Whenever Gilded Cerodon attacks, if you control a Desert or there is a Desert card in your graveyard, target creature can't block this turn.",
             "colours": [
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "60d9a908-f1dd-570b-b48b-772e79b54f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607bdb54-a956-4a9c-89cf-af6f1163b856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607bdb54-a956-4a9c-89cf-af6f1163b856.jpg?1",
             "name": "Granitic Titan",
             "text": "Menace\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "eb7ede84-6408-504d-bda9-abbc35021553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f578576-19ca-4e67-94da-2c0767d9a2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f578576-19ca-4e67-94da-2c0767d9a2bb.jpg?1",
             "name": "Hazoret's Undying Fury",
             "text": "Shuffle your library, then exile the top four cards. You may cast any number of nonland cards with converted mana cost 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "bd31cb83-233a-5aa2-a960-c1e8bb856b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420cc12-cfd7-4007-a0c2-b16c8f63a754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420cc12-cfd7-4007-a0c2-b16c8f63a754.jpg?1",
             "name": "Hour of Devastation",
             "text": "All creatures lose indestructible until end of turn. Hour of Devastation deals 5 damage to each creature and each non-Bolas planeswalker.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "d8ee858b-3e39-5a03-a92a-f8e3ff938352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f8207-485e-4a4e-aa62-8e0e69645a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f8207-485e-4a4e-aa62-8e0e69645a0e.jpg?1",
             "name": "Imminent Doom",
             "text": "Imminent Doom enters the battlefield with a doom counter on it.\nWhenever you cast a spell with converted mana cost equal to the number of doom counters on Imminent Doom, Imminent Doom deals that much damage to target creature or player. Then put a doom counter on Imminent Doom.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "113b0483-3c74-5393-9256-be66b39779ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6a43fe-369d-4943-a825-570eb3cceba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6a43fe-369d-4943-a825-570eb3cceba4.jpg?1",
             "name": "Inferno Jet",
             "text": "Inferno Jet deals 6 damage to target opponent.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3348,7 +3348,7 @@
         },
         {
             "id": "f8c486d6-6c92-5758-a182-932c35dfc703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4caac-95e8-47bb-90c4-3bf877afdc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4caac-95e8-47bb-90c4-3bf877afdc57.jpg?1",
             "name": "Khenra Scrapper",
             "text": "Menace\nYou may exert Khenra Scrapper as it attacks. When you do, it gets +2/+0 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "072c38b4-65ed-5644-b081-d61d733a6e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffb2c38-76b0-4d5f-a4d1-e2494f4be192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffb2c38-76b0-4d5f-a4d1-e2494f4be192.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "9722e68d-3d12-5e88-b6fb-6e38f54785ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f87128-2d12-467b-895d-943f318b7c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f87128-2d12-467b-895d-943f318b7c38.jpg?1",
             "name": "Magmaroth",
             "text": "At the beginning of your upkeep, put a -1/-1 counter on Magmaroth.\nWhenever you cast a noncreature spell, remove a -1/-1 counter from Magmaroth.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "35690152-40d1-548a-b765-b229e46a6a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03a9686-d30b-4048-8b0a-23fd2f0aed4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03a9686-d30b-4048-8b0a-23fd2f0aed4b.jpg?1",
             "name": "Manticore Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nManticore Eternal attacks each combat if able.",
             "colours": [
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "232b5560-25c5-5e78-9db1-4f0ad6fc8a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54231832-d492-4812-b658-4ab9a30fefe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54231832-d492-4812-b658-4ab9a30fefe2.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} to your mana pool for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "c37b43f6-0b65-56d0-b1e2-fd3ececc351b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f9fb5-ffb5-4325-9f81-ce8782e5f9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f9fb5-ffb5-4325-9f81-ce8782e5f9e9.jpg?1",
             "name": "Open Fire",
             "text": "Open Fire deals 3 damage to target creature or player.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "2f1027b1-ae1e-5962-a52e-146bca00a76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d88da5-d9a3-49b3-a091-458b058c9114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d88da5-d9a3-49b3-a091-458b058c9114.jpg?1",
             "name": "Puncturing Blow",
             "text": "Puncturing Blow deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "d77a320d-863c-50af-8787-b86315a548b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7153be-ad6c-47ff-8f45-bc8df17973cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7153be-ad6c-47ff-8f45-bc8df17973cb.jpg?1",
             "name": "Sand Strangler",
             "text": "When Sand Strangler enters the battlefield, if you control a Desert or there is a Desert card in your graveyard, you may have Sand Strangler deal 3 damage to target creature.",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "8f703ff2-775e-5120-8eb6-18a3c25003ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ab2615-5a02-4b59-b8bd-577b91a1a0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ab2615-5a02-4b59-b8bd-577b91a1a0e3.jpg?1",
             "name": "Thorned Moloch",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nThorned Moloch has first strike as long as it's attacking.",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "3df51c5a-8374-56b8-a913-8c0d9e37273c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd845479-619a-4262-b445-d93975c183b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd845479-619a-4262-b445-d93975c183b4.jpg?1",
             "name": "Wildfire Eternal",
             "text": "Afflict 4 (Whenever this creature becomes blocked, defending player loses 4 life.)\nWhenever Wildfire Eternal attacks and isn't blocked, you may cast an instant or sorcery card from your hand without paying its mana cost.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "9885f042-add6-51af-aa3c-2b2d92571c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc06303-cb35-4feb-b23d-7ac0a2fa7ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc06303-cb35-4feb-b23d-7ac0a2fa7ce3.jpg?1",
             "name": "Ambuscade",
             "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -3722,7 +3722,7 @@
         },
         {
             "id": "3c483fd1-ac6e-527b-bab9-e804c9ec8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c0cf0-df4a-4e50-8396-53713f925b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c0cf0-df4a-4e50-8396-53713f925b53.jpg?1",
             "name": "Beneath the Sands",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "004d92ae-0ce9-5f63-9e63-1451c4270c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfcf99-be2b-4e5f-adef-1977ee5c6a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfcf99-be2b-4e5f-adef-1977ee5c6a0f.jpg?1",
             "name": "Bitterbow Sharpshooters",
             "text": "Vigilance, reach",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "fbba740f-2ce1-5166-8de7-e1e9dcdca3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977698ab-3b64-41f2-a214-ac95e04c9956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977698ab-3b64-41f2-a214-ac95e04c9956.jpg?1",
             "name": "Devotee of Strength",
             "text": "{4}{G}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3824,7 +3824,7 @@
         },
         {
             "id": "69872bb7-4607-53b2-bc65-d92a60614d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01818188-e18e-4dc0-b7ef-34cedef64f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01818188-e18e-4dc0-b7ef-34cedef64f7e.jpg?1",
             "name": "Dune Diviner",
             "text": "{1}, Tap an untapped Desert you control: You gain 1 life.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "b88c6b2f-7452-5282-a539-08f8022a07f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0431ad-185a-4917-b994-e58dd9850f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0431ad-185a-4917-b994-e58dd9850f5e.jpg?1",
             "name": "Feral Prowler",
             "text": "When Feral Prowler dies, draw a card.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "481f98a6-54d2-5303-9a5d-1ab301c8f388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b1be52-5e54-4840-bb53-0b2512785e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b1be52-5e54-4840-bb53-0b2512785e0b.jpg?1",
             "name": "Frilled Sandwalla",
             "text": "{1}{G}: Frilled Sandwalla gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "b1cf1064-7166-513c-9125-32450b5ac937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b779620-6bac-445e-a6fe-6d770c0a9c70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b779620-6bac-445e-a6fe-6d770c0a9c70.jpg?1",
             "name": "Gift of Strength",
             "text": "Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -3959,7 +3959,7 @@
         },
         {
             "id": "0a8978e2-2516-5588-89ca-3e8abd3c0e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg?1",
             "name": "Harrier Naga",
             "text": "",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "2823ef1f-f1e1-528f-8233-c94da63a07ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffb676d-54b7-4d30-9c84-ff9b48030705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffb676d-54b7-4d30-9c84-ff9b48030705.jpg?1",
             "name": "Hope Tender",
             "text": "{1}, {T}: Untap target land.\n{1}, {T}, Exert Hope Tender: Untap two target lands. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "2299967c-747e-577d-aacc-b819687cdc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee374f-31dc-4b2c-beba-431d5b1126d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee374f-31dc-4b2c-beba-431d5b1126d0.jpg?1",
             "name": "Hour of Promise",
             "text": "Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library. Then if you control three or more Deserts, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "03a4592e-6a1f-52f5-92b9-8b5769740dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f39c264-a9a5-46f3-bd67-01d93d69e457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f39c264-a9a5-46f3-bd67-01d93d69e457.jpg?1",
             "name": "Life Goes On",
             "text": "You gain 4 life. If a creature died this turn, you gain 8 life instead.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "c2757919-baf3-51df-89d3-28b6f229a700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d47cc7-2849-432e-9bcd-6b97023f1969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d47cc7-2849-432e-9bcd-6b97023f1969.jpg?1",
             "name": "Majestic Myriarch",
             "text": "Majestic Myriarch's power and toughness are each equal to twice the number of creatures you control.\nAt the beginning of each combat, if you control a creature with flying, Majestic Myriarch gains flying until end of turn. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -4127,7 +4127,7 @@
         },
         {
             "id": "ffa74dcd-dd8d-53c2-af9a-25b9b9bfceeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86326456-d188-4083-9141-a639b821b291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86326456-d188-4083-9141-a639b821b291.jpg?1",
             "name": "Nissa's Defeat",
             "text": "Destroy target Forest, green enchantment, or green planeswalker. If that permanent was a Nissa planeswalker, draw a card.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "0c202d3b-b4f5-5953-9325-c843c65e2f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb49b-956e-44bc-8a32-46d4c9c13245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb49b-956e-44bc-8a32-46d4c9c13245.jpg?1",
             "name": "Oasis Ritualist",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}, Exert Oasis Ritualist: Add two mana of any one color to your mana pool. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4194,7 +4194,7 @@
         },
         {
             "id": "c2deeb98-bd8b-5a15-91c6-a528224fe1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dc2427-685a-4739-8b92-e60f134d4adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dc2427-685a-4739-8b92-e60f134d4adb.jpg?1",
             "name": "Overcome",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "b76be63d-7324-5cfb-af3b-d758248c6aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3d32b7-672f-4ceb-a1c9-17daefd2cb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3d32b7-672f-4ceb-a1c9-17daefd2cb0c.jpg?1",
             "name": "Pride Sovereign",
             "text": "Pride Sovereign gets +1/+1 for each other Cat you control.\n{W}, {T}, Exert Pride Sovereign: Create two 1/1 white Cat creature tokens with lifelink. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "4de575c7-69cf-5968-bde2-c27d61be7519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e11478-bfc7-4bcc-b65c-dc2d4449e99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e11478-bfc7-4bcc-b65c-dc2d4449e99f.jpg?1",
             "name": "Quarry Beetle",
             "text": "When Quarry Beetle enters the battlefield, you may return target land card from your graveyard to the battlefield.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "517044f9-5a08-5d86-9391-75d3b2262bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c97229f-2fc8-439a-a18b-efa09b366b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c97229f-2fc8-439a-a18b-efa09b366b70.jpg?1",
             "name": "Rampaging Hippo",
             "text": "Trample\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "25bd760e-7f64-56bb-9021-f8289bfd3229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a54d18-8403-441d-a115-ee462fabdabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a54d18-8403-441d-a115-ee462fabdabb.jpg?1",
             "name": "Ramunap Excavator",
             "text": "You may play land cards from your graveyard.",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "a9f39ac3-0322-5b25-99bd-9bef640a381e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f3722-2126-4eb3-a3d8-cff4b0703a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f3722-2126-4eb3-a3d8-cff4b0703a9c.jpg?1",
             "name": "Ramunap Hydra",
             "text": "Vigilance, reach, trample\nRamunap Hydra gets +1/+1 as long as you control a Desert.\nRamunap Hydra gets +1/+1 as long as there is a Desert card in your graveyard.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "18fcc4b1-e865-50b8-948e-4e3f948e713b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033a69fb-2af9-426c-b1d6-3e5b18c78c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033a69fb-2af9-426c-b1d6-3e5b18c78c9a.jpg?1",
             "name": "Resilient Khenra",
             "text": "When Resilient Khenra enters the battlefield, you may have target creature get +X/+X until end of turn, where X is Resilient Khenra's power.\nEternalize {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Jackal Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "771f848b-35a2-585f-bc4d-77f1ddd1ad66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e991d1eb-70ab-4e2c-862d-fb8bfcefc542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e991d1eb-70ab-4e2c-862d-fb8bfcefc542.jpg?1",
             "name": "Rhonas's Last Stand",
             "text": "Create a 5/4 green Snake creature token. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "68ce379d-058d-5caf-9b0a-1bdcb7f9a85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d4f791-9084-4644-a1f5-85adbf6dc790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d4f791-9084-4644-a1f5-85adbf6dc790.jpg?1",
             "name": "Rhonas's Stalwart",
             "text": "You may exert Rhonas's Stalwart as it attacks. When you do, it gets +1/+1 until end of turn and can't be blocked by creatures with power 2 or less this turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "55fd9ecf-324c-5ff8-ab9d-a912dc3d4e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3786d75-1a8a-4917-aa98-6836df1b9145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3786d75-1a8a-4917-aa98-6836df1b9145.jpg?1",
             "name": "Sidewinder Naga",
             "text": "As long as you control a Desert or there is a Desert card in your graveyard, Sidewinder Naga gets +1/+0 and has trample.",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "18091443-fd1f-519a-9b63-69a62f2dfd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbaf7e3-e2fc-4399-aa83-c13df43008a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbaf7e3-e2fc-4399-aa83-c13df43008a0.jpg?1",
             "name": "Sifter Wurm",
             "text": "Trample\nWhen Sifter Wurm enters the battlefield, scry 3, then reveal the top card of your library. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "2ce39e23-9823-52b0-945e-6ba4e7431bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eec0010-52ab-4bf2-b589-e7fd97c290fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eec0010-52ab-4bf2-b589-e7fd97c290fe.jpg?1",
             "name": "Tenacious Hunter",
             "text": "As long as a creature has a -1/-1 counter on it, Tenacious Hunter has vigilance and deathtouch.",
             "colours": [
@@ -4604,7 +4604,7 @@
         },
         {
             "id": "d369b012-0f80-50a7-b68b-912581df194c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4aa918-53b9-4177-a859-f5a8eff09fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4aa918-53b9-4177-a859-f5a8eff09fe5.jpg?1",
             "name": "Uncage the Menagerie",
             "text": "Search your library for up to X creature cards with different names that each have converted mana cost X, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "3e65a929-0c1e-59c3-8a80-327307babada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d0a04-b640-4d1d-b538-2d946c1ff913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d0a04-b640-4d1d-b538-2d946c1ff913.jpg?1",
             "name": "Bloodwater Entity",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bloodwater Entity enters the battlefield, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "b9e4d55e-7ce2-544d-8e5a-b77639b5714f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0c1d0a-2651-4961-8b70-ff78093732ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0c1d0a-2651-4961-8b70-ff78093732ce.jpg?1",
             "name": "The Locust God",
             "text": "Flying\nWhenever you draw a card, create a 1/1 blue and red Insect creature token with flying and haste.\n{2}{U}{R}: Draw a card, then discard a card.\nWhen The Locust God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "97cf4661-6eed-5251-afa7-29f495a9b941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e92f4-3904-41df-91f7-42eedbe3ccd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e92f4-3904-41df-91f7-42eedbe3ccd2.jpg?1",
             "name": "Nicol Bolas, God-Pharaoh",
             "text": "+2: Target opponent exiles cards from the top of his or her library until he or she exiles a nonland card. Until end of turn, you may cast that card without paying its mana cost.\n+1: Each opponent exiles two cards from his or her hand.\n\u22124: Nicol Bolas, God-Pharaoh deals 7 damage to target opponent or creature an opponent controls.\n\u221212: Exile each nonland permanent your opponents control.",
             "colours": [
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "873f9f77-c4f3-5afe-9dcc-296841f35523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae054604-0d77-45d0-b17b-55a83fb18e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae054604-0d77-45d0-b17b-55a83fb18e39.jpg?1",
             "name": "Obelisk Spider",
             "text": "Reach\nWhenever Obelisk Spider deals combat damage to a creature, put a -1/-1 counter on that creature.\nWhenever you put one or more -1/-1 counters on a creature, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "f9cffddd-c246-5ae6-b567-d08295ec36c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713f469e-58c3-4db4-aa7a-77126bda13f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713f469e-58c3-4db4-aa7a-77126bda13f2.jpg?1",
             "name": "Resolute Survivors",
             "text": "You may exert Resolute Survivors as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, Resolute Survivors deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "c5251a7e-62a9-5db4-9bb9-05eadfc1bb50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ec4c2-aae2-403e-af32-3324122c472a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ec4c2-aae2-403e-af32-3324122c472a.jpg?1",
             "name": "River Hoopoe",
             "text": "Flying\n{3}{G}{U}: You gain 2 life and draw a card.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "a53c626a-d931-5489-ab2f-9348f77591e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f06f55-7918-46c4-80ff-0bf39e091a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f06f55-7918-46c4-80ff-0bf39e091a4a.jpg?1",
             "name": "Samut, the Tested",
             "text": "+1: Up to one target creature gains double strike until end of turn.\n\u22122: Samut, the Tested deals 2 damage divided as you choose among one or two target creatures and/or players.\n\u22127: Search your library for up to two creature and/or planeswalker cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "c750f8b5-1259-528c-b113-8829a14e80d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621cfd79-be4e-41e3-95ce-62b0eeff5baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621cfd79-be4e-41e3-95ce-62b0eeff5baf.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "ab2f6dcd-8ed0-561c-8aea-4a9260a2e57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0d0ac-6422-486e-b42b-e1813dd0a23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0d0ac-6422-486e-b42b-e1813dd0a23e.jpg?1",
             "name": "The Scorpion God",
             "text": "Whenever a creature with a -1/-1 counter on it dies, draw a card.\n{1}{B}{R}: Put a -1/-1 counter on another target creature.\nWhen The Scorpion God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "8a9ad5d7-a7ae-57c6-94fc-d10a1990d725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3802f3-feb3-4dcd-a5ba-f493baf3d447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3802f3-feb3-4dcd-a5ba-f493baf3d447.jpg?1",
             "name": "Unraveling Mummy",
             "text": "{1}{W}: Target attacking Zombie gains lifelink until end of turn.\n{1}{B}: Target attacking Zombie gains deathtouch until end of turn.",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "c96e7305-f5c0-51cd-94c9-bbc47377a847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg?1",
             "name": "Farm // Market",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "c0e0ca48-6241-5e4a-8b35-a5c322546317",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg?1",
             "name": "Farm // Market",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards, then discard two cards.",
             "colours": [
@@ -5075,7 +5075,7 @@
         },
         {
             "id": "7dccf77f-fb2c-527d-9611-51d042c35c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg?1",
             "name": "Consign // Oblivion",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "d5645482-98df-52f2-99e3-63c5f9acec18",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg?1",
             "name": "Consign // Oblivion",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget opponent discards two cards.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "f7d57482-4b76-5c59-9e0d-19fc4616b605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg?1",
             "name": "Claim // Fame",
             "text": "Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -5174,7 +5174,7 @@
         },
         {
             "id": "7250b98f-aba3-52e7-a7eb-5db86eaf427f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg?1",
             "name": "Claim // Fame",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "49fb02c7-49c0-5eed-b547-431c64546b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg?1",
             "name": "Struggle // Survive",
             "text": "Struggle deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "13d3b70a-003e-568e-9cab-d8bfa6a24b22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg?1",
             "name": "Struggle // Survive",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "c74b3d87-9240-5181-811d-84c22c2ec873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg?1",
             "name": "Appeal // Authority",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.",
             "colours": [
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "0a894f7b-0dc8-566d-95d4-b780d19d2aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg?1",
             "name": "Appeal // Authority",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTap up to two target creatures your opponents control. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "5226f792-da6b-59db-8ca8-a80e488284b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg?1",
             "name": "Leave // Chance",
             "text": "Return any number of target permanents you own to your hand.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "0d89fce1-8041-54bd-ac7f-963b88e51a05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg?1",
             "name": "Leave // Chance",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDiscard any number of cards, then draw that many cards.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "e9724b0e-dc11-5eed-a095-0de10f996bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg?1",
             "name": "Reason // Believe",
             "text": "Scry 3.",
             "colours": [
@@ -5438,7 +5438,7 @@
         },
         {
             "id": "ee68cb5a-ce11-5cb3-9601-bf854e6ed323",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg?1",
             "name": "Reason // Believe",
             "text": "Aftermath\nLook at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "fa414a0a-ce09-5c11-b6b8-c263d45aa4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg?1",
             "name": "Grind // Dust",
             "text": "Put a -1/-1 counter on each of up to two target creatures.",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "852ce01a-0c3e-51f1-b2cb-7e2a189d76fd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg?1",
             "name": "Grind // Dust",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile any number of target creatures that have -1/-1 counters on them.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "7e1f20b1-f2bd-52ad-ac39-1e490018d067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg?1",
             "name": "Refuse // Cooperate",
             "text": "Refuse deals damage to target spell's controller equal to that spell's converted mana cost.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "5081088f-8d64-5649-857a-7496bbb26294",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg?1",
             "name": "Refuse // Cooperate",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "b1e82c03-4ed1-5339-a46d-4920792ed449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg?1",
             "name": "Driven // Despair",
             "text": "Until end of turn, creatures you control gain trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "f2177eb9-4646-5ee7-8e36-84d353e1bec0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg?1",
             "name": "Driven // Despair",
             "text": "Aftermath\nUntil end of turn, creatures you control gain menace and \"Whenever this creature deals combat damage to a player, that player discards a card.\"",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "ff3e3eb6-1132-596f-9148-953a2e3da20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191fb87-f111-4ac2-a52a-3af103a9314e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191fb87-f111-4ac2-a52a-3af103a9314e.jpg?1",
             "name": "Abandoned Sarcophagus",
             "text": "You may cast nonland cards with cycling from your graveyard.\nIf a card with cycling would be put into your graveyard from anywhere and it wasn't cycled, exile it instead.",
             "colours": [],
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "ac6f1d10-ec92-5045-b531-3c1d85044fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f6d7c2-ee4f-4cd0-a9a2-d8469ff89291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f6d7c2-ee4f-4cd0-a9a2-d8469ff89291.jpg?1",
             "name": "Crook of Condemnation",
             "text": "{1}, {T}: Exile target card from a graveyard.\n{1}, Exile Crook of Condemnation: Exile all cards from all graveyards.",
             "colours": [],
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "ee2ef81f-666b-587a-a363-552a8efced54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9d9d7-bc4e-4367-b27c-e8d6e430467e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9d9d7-bc4e-4367-b27c-e8d6e430467e.jpg?1",
             "name": "Dagger of the Worthy",
             "text": "Equipped creature gets +2/+0 and has afflict 1. (Whenever it becomes blocked, defending player loses 1 life.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5755,7 +5755,7 @@
         },
         {
             "id": "1a7c10f4-ad51-56c6-bc35-b70933f984b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e85a9e-4c37-4721-b7ea-de3413ec39df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e85a9e-4c37-4721-b7ea-de3413ec39df.jpg?1",
             "name": "God-Pharaoh's Gift",
             "text": "At the beginning of combat on your turn, you may exile a creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a 4/4 black Zombie. It gains haste until end of turn.",
             "colours": [],
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "8198d1f0-d143-5a13-9a57-e01d939ad44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89880f30-aa38-4231-8d16-25c644bde6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89880f30-aa38-4231-8d16-25c644bde6bf.jpg?1",
             "name": "Graven Abomination",
             "text": "Whenever Graven Abomination attacks, exile target card from defending player's graveyard.",
             "colours": [],
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "c4ed4661-40de-518d-b8af-12079e65d84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fe9c6d-4fa2-4f9a-9025-1bf12fe7ed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fe9c6d-4fa2-4f9a-9025-1bf12fe7ed9f.jpg?1",
             "name": "Hollow One",
             "text": "Hollow One costs {2} less to cast for each card you've cycled or discarded this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "0fcfd5c4-723e-5aab-93bb-f7323817449d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b420ed-75b8-4779-aaa2-e245e84202d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b420ed-75b8-4779-aaa2-e245e84202d1.jpg?1",
             "name": "Manalith",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "b6f204be-a9a2-5c3b-9c39-21d808f3c078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29148d7e-b398-4e19-a29e-d9a660ad5016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29148d7e-b398-4e19-a29e-d9a660ad5016.jpg?1",
             "name": "Mirage Mirror",
             "text": "{2}: Mirage Mirror becomes a copy of target artifact, creature, enchantment, or land until end of turn.",
             "colours": [],
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "09a51b4b-a63a-52d8-a141-8dc26feeb4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377a4e80-0f28-42a2-9972-47ab66baee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377a4e80-0f28-42a2-9972-47ab66baee63.jpg?1",
             "name": "Sunset Pyramid",
             "text": "Sunset Pyramid enters the battlefield with three brick counters on it.\n{2}, {T}, Remove a brick counter from Sunset Pyramid: Draw a card.\n{2}, {T}: Scry 1.",
             "colours": [],
@@ -5929,7 +5929,7 @@
         },
         {
             "id": "0395ca43-dbfd-5455-80ed-c1804fc4c038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195464f1-f01c-4211-950d-963c5bad786f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195464f1-f01c-4211-950d-963c5bad786f.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -5957,7 +5957,7 @@
         },
         {
             "id": "5f7fee49-a922-57da-86cd-8f6b5708693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f8f211-79f9-4d34-8e23-c0835703cd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f8f211-79f9-4d34-8e23-c0835703cd91.jpg?1",
             "name": "Wall of Forgotten Pharaohs",
             "text": "Defender\n{T}: Wall of Forgotten Pharaohs deals 1 damage to target player. Activate this ability only if you control a Desert or there is a Desert card in your graveyard.",
             "colours": [],
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "2dc9cde3-6af8-5521-b969-d7998a6dad49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5b199-e79d-4ca9-970c-cfd9df8fd1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5b199-e79d-4ca9-970c-cfd9df8fd1e4.jpg?1",
             "name": "Crypt of the Eternals",
             "text": "When Crypt of the Eternals enters the battlefield, you gain 1 life.\n{T}: Add {C} to your mana pool.\n{1}, {T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -6020,7 +6020,7 @@
         },
         {
             "id": "c81eee3f-b130-5752-ba94-61aea6700ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f547d664-25ce-4a24-b3ae-7bf3cbdf4703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f547d664-25ce-4a24-b3ae-7bf3cbdf4703.jpg?1",
             "name": "Desert of the Fervent",
             "text": "Desert of the Fervent enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "1ab2c8c5-98a5-5092-97ab-f1195483ea27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a19aea-209d-4354-8c59-d08244185eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a19aea-209d-4354-8c59-d08244185eb8.jpg?1",
             "name": "Desert of the Glorified",
             "text": "Desert of the Glorified enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "86c9cfc9-8cc7-5642-bdc9-d1fb884c1d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42aa0c-0408-4b0d-bec5-9861dbcf9ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42aa0c-0408-4b0d-bec5-9861dbcf9ee1.jpg?1",
             "name": "Desert of the Indomitable",
             "text": "Desert of the Indomitable enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6116,7 +6116,7 @@
         },
         {
             "id": "ad2f92b0-6f31-5fda-b885-dc32e0bb2b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b92d87-776c-490f-9ff1-234e47145df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b92d87-776c-490f-9ff1-234e47145df8.jpg?1",
             "name": "Desert of the Mindful",
             "text": "Desert of the Mindful enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "c5cf207b-4a6d-557c-80a1-6c2da3e139b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d9308c-8af4-4587-b740-aea874d5ccae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d9308c-8af4-4587-b740-aea874d5ccae.jpg?1",
             "name": "Desert of the True",
             "text": "Desert of the True enters the battlefield tapped.\n{T}: Add {W} to your mana pool.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "92c45684-4357-5f7d-a9e1-3883336ce00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326c7483-2c45-4804-85c4-d40ecdba4fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326c7483-2c45-4804-85c4-d40ecdba4fc7.jpg?1",
             "name": "Dunes of the Dead",
             "text": "{T}: Add {C} to your mana pool.\nWhen Dunes of the Dead is put into a graveyard from the battlefield, create a 2/2 black Zombie creature token.",
             "colours": [],
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "4f0a27e8-cc5b-53ed-acf5-632f1a5d1778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebd3e0a-30cc-4bc1-b9fa-6d65db9a6f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebd3e0a-30cc-4bc1-b9fa-6d65db9a6f5b.jpg?1",
             "name": "Endless Sands",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Exile target creature you control.\n{4}, {T}, Sacrifice Endless Sands: Return each creature card exiled with Endless Sands to the battlefield under its owner's control.",
             "colours": [],
@@ -6240,7 +6240,7 @@
         },
         {
             "id": "3623249e-2a12-59b4-b036-dc71cf940fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bba75d2-3f1b-4828-be11-2da695f7bde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bba75d2-3f1b-4828-be11-2da695f7bde7.jpg?1",
             "name": "Hashep Oasis",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {G} to your mana pool.\n{1}{G}{G}, {T}, Sacrifice a Desert: Target creature gets +3/+3 until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "c30f214b-513e-59bd-9f81-7d7003e79a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c35cb-77e7-4600-a915-ccf327fe3385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c35cb-77e7-4600-a915-ccf327fe3385.jpg?1",
             "name": "Hostile Desert",
             "text": "{T}: Add {C} to your mana pool.\n{2}, Exile a land card from your graveyard: Hostile Desert becomes a 3/4 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -6302,7 +6302,7 @@
         },
         {
             "id": "162303a8-38ed-55ca-b9e1-15ec20b8dae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b88728b-9b18-40c6-b634-f87f8da83665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b88728b-9b18-40c6-b634-f87f8da83665.jpg?1",
             "name": "Ifnir Deadlands",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {B} to your mana pool.\n{2}{B}{B}, {T}, Sacrifice a Desert: Put two -1/-1 counters on target creature an opponent controls. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "bd4079df-b93d-5137-a79b-06a3ed1797f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203011ef-3737-4fd1-bd23-0e531b5a7c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203011ef-3737-4fd1-bd23-0e531b5a7c32.jpg?1",
             "name": "Ipnu Rivulet",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {U} to your mana pool.\n{1}{U}, {T}, Sacrifice a Desert: Target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "6a7d2671-4374-5e08-8415-faf4b6c82a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11d41a-0d29-45e9-9d27-a41282b9e292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11d41a-0d29-45e9-9d27-a41282b9e292.jpg?1",
             "name": "Ramunap Ruins",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {R} to your mana pool.\n{2}{R}{R}, {T}, Sacrifice a Desert: Ramunap Ruins deals 2 damage to each opponent.",
             "colours": [],
@@ -6398,7 +6398,7 @@
         },
         {
             "id": "d807f64f-b71e-5467-abe9-f2f1464bc662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd91eeb-7abf-4538-91dc-47c736dfc237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd91eeb-7abf-4538-91dc-47c736dfc237.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice a Desert: Exile all cards from all graveyards.",
             "colours": [],
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "7ba86193-e572-5023-843f-d7ca0c543502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6077f4e9-5717-4048-b798-4f8d535a4170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6077f4e9-5717-4048-b798-4f8d535a4170.jpg?1",
             "name": "Shefet Dunes",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {W} to your mana pool.\n{2}{W}{W}, {T}, Sacrifice a Desert: Creatures you control get +1/+1 until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "57f13be1-910e-52a3-9c44-4dfba17e772f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b0404e-0f42-456b-91ce-f960195c4951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b0404e-0f42-456b-91ce-f960195c4951.jpg?1",
             "name": "Survivors' Encampment",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6490,7 +6490,7 @@
         },
         {
             "id": "7a263ce3-bf16-5a5a-ad77-a0ca5b397126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20ec10e-78fc-49dc-a112-7863a34056b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20ec10e-78fc-49dc-a112-7863a34056b1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6527,7 +6527,7 @@
         },
         {
             "id": "a10ed875-dbe2-5f6f-a534-9980abbbeb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a735e9b5-1231-4aa9-9eb3-c83037b849f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a735e9b5-1231-4aa9-9eb3-c83037b849f2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "13612292-1094-5c52-855b-1b9d76a81743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5cb444-7b48-40c8-a4d9-3fee37429513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5cb444-7b48-40c8-a4d9-3fee37429513.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "a449e8f7-9b24-53c8-93af-4afbf5171535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad4e9cd-76e2-4ee0-8185-8b3aec3578ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad4e9cd-76e2-4ee0-8185-8b3aec3578ce.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "43647e8e-7297-5656-b2a6-26048516d6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c318bae5-5d3f-4e91-adfe-13c182511ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c318bae5-5d3f-4e91-adfe-13c182511ef7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "70adcf98-90cb-5239-b597-2e1fe3363d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce617aad-2c72-4b47-a9ae-51792459cffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce617aad-2c72-4b47-a9ae-51792459cffd.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "7ab20360-c04d-5c0b-9786-4ef470d5493f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fd89a6-56ef-4488-842b-27bf31d8c04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fd89a6-56ef-4488-842b-27bf31d8c04f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6749,7 +6749,7 @@
         },
         {
             "id": "bbfc7dbd-4cbb-5e91-94eb-13ddb3724188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4717cd-f9a7-4386-9091-d25218e23d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4717cd-f9a7-4386-9091-d25218e23d79.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6786,7 +6786,7 @@
         },
         {
             "id": "ecb091a7-e6d7-5577-bbbc-1083820cb49a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0830bbcf-ee78-4f8a-bc6c-547be3a9fc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0830bbcf-ee78-4f8a-bc6c-547be3a9fc4c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6823,7 +6823,7 @@
         },
         {
             "id": "b4662504-783e-539f-a91c-4b8e3cc36126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447f8dbc-2f09-4995-81e2-2dc1654031fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447f8dbc-2f09-4995-81e2-2dc1654031fd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "a066d360-e617-530e-a4b9-47212927372d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e864369-2837-4487-8eee-0d643889d642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e864369-2837-4487-8eee-0d643889d642.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "bb3de13b-7169-5ff6-af2e-8b8cc971989f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e439e2-2c7c-42fd-a47b-f615641f7392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e439e2-2c7c-42fd-a47b-f615641f7392.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "da94e20d-5e51-5ac5-b0b3-8a7b5d3843dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e7306-df23-4339-b3af-faf9effe0140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e7306-df23-4339-b3af-faf9effe0140.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6971,7 +6971,7 @@
         },
         {
             "id": "a5272f48-77a9-5398-9b04-1db1bc7b0953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cbd941-53ab-4b02-b96c-a9af7767e606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cbd941-53ab-4b02-b96c-a9af7767e606.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "5ae80a0f-08c7-5792-aa56-1c477128ce65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99aacd5-c692-4de8-b565-d5092598295d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99aacd5-c692-4de8-b565-d5092598295d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "66afc412-0014-5c0b-8104-970ac6bba526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2923c85a-4022-4cda-bcbb-bb000137f64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2923c85a-4022-4cda-bcbb-bb000137f64f.jpg?1",
             "name": "Nissa, Genesis Mage",
             "text": "+2: Untap up to two target creatures and up to two target lands.\n\u22123: Target creature gets +5/+5 until end of turn.\n\u221210: Look at the top ten cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "f5da01e9-925b-535d-822e-c3695c231aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468e488-94ce-4ae3-abe4-7782673a7e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468e488-94ce-4ae3-abe4-7782673a7e62.jpg?1",
             "name": "Avid Reclaimer",
             "text": "{T}: Add {G} or {U} to your mana pool. If you control a Nissa planeswalker, you gain 2 life.",
             "colours": [
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "a1e0de95-16b6-560c-a6ba-3813d7a90db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c759e94-e437-4dda-af0f-6578c0a50619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c759e94-e437-4dda-af0f-6578c0a50619.jpg?1",
             "name": "Brambleweft Behemoth",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -7148,7 +7148,7 @@
         },
         {
             "id": "a4165e7c-a155-592a-83f9-455c159aaab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a489d5c7-ef57-4973-86ac-06234c308c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a489d5c7-ef57-4973-86ac-06234c308c3c.jpg?1",
             "name": "Nissa's Encouragement",
             "text": "Search your library and graveyard for a card named Forest, a card named Brambleweft Behemoth, and a card named Nissa, Genesis Mage. Reveal those cards, put them into your hand, then shuffle your library.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "bb1a2bd9-91fc-5e87-aa2f-e88555ec29f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d757641-a6e8-4584-b35e-be043c228134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d757641-a6e8-4584-b35e-be043c228134.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "0212b149-6b3d-59e5-8709-9f2cba006dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74239d78-1608-4b27-b2fd-8c7453f6b86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74239d78-1608-4b27-b2fd-8c7453f6b86b.jpg?1",
             "name": "Nicol Bolas, the Deceiver",
             "text": "+3: Each opponent loses 3 life unless that player sacrifices a nonland permanent or discards a card.\n\u22123: Destroy target creature. Draw a card.\n\u221211: Nicol Bolas, the Deceiver deals 7 damage to each opponent. You draw seven cards.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "19e1688e-e826-5f51-86da-0d9b11ec41ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d348eb-7db0-4209-8960-c6adc473417d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d348eb-7db0-4209-8960-c6adc473417d.jpg?1",
             "name": "Wasp of the Bitter End",
             "text": "Flying\nWhenever you cast a Bolas planeswalker spell, you may sacrifice Wasp of the Bitter End. If you do, destroy target creature.",
             "colours": [
@@ -7282,7 +7282,7 @@
         },
         {
             "id": "ff93f08c-02e6-586b-a448-1ed32babb862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d1cd4-7d0d-4279-bc2a-59bb21b06904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d1cd4-7d0d-4279-bc2a-59bb21b06904.jpg?1",
             "name": "Zealot of the God-Pharaoh",
             "text": "{4}{R}: Zealot of the God-Pharaoh deals 2 damage to target opponent.",
             "colours": [
@@ -7316,7 +7316,7 @@
         },
         {
             "id": "69ba0772-4500-5a74-8fe4-abe4a0d9f627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29bbfe2-d59f-4361-8ea4-6a8d1b909769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29bbfe2-d59f-4361-8ea4-6a8d1b909769.jpg?1",
             "name": "Visage of Bolas",
             "text": "When Visage of Bolas enters the battlefield, you may search your library and/or graveyard for a card named Nicol Bolas, the Deceiver, reveal it, and put it into your hand. If you search your library this way, shuffle it.\n{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7347,7 +7347,7 @@
         },
         {
             "id": "d12d46ae-6be6-54f2-be5c-9328f9a83118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caedf353-35f8-4b58-8ed9-183d29302be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caedf353-35f8-4b58-8ed9-183d29302be9.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7377,7 +7377,7 @@
         },
         {
             "id": "d4974282-1fae-53a6-84c1-db1374537f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc8556-a658-40e1-8a93-6a62af208a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc8556-a658-40e1-8a93-6a62af208a28.jpg?1",
             "name": "Adorned Pouncer",
             "text": "",
             "colours": [
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "46bbc6b1-67bd-5471-959a-8aeca495d287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eebe6c-5bc9-463c-b74c-eae79fc3c1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eebe6c-5bc9-463c-b74c-eae79fc3c1b6.jpg?1",
             "name": "Champion of Wits",
             "text": "",
             "colours": [
@@ -7448,7 +7448,7 @@
         },
         {
             "id": "1cfb9daa-8bf2-52e4-a048-b442f30a3a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c362d05-f2f7-4415-8937-f9f368986e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c362d05-f2f7-4415-8937-f9f368986e61.jpg?1",
             "name": "Dreamstealer",
             "text": "",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "54246804-4196-54aa-b8c2-5db7cc754529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb3bd7-5aef-495e-81ba-f5d287981dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb3bd7-5aef-495e-81ba-f5d287981dbd.jpg?1",
             "name": "Earthshaker Khenra",
             "text": "",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "33dc50f9-6044-5afb-b9d9-b23b91f7330d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d8aac-c032-4e0d-a8ef-99a7c53c7a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d8aac-c032-4e0d-a8ef-99a7c53c7a19.jpg?1",
             "name": "Proven Combatant",
             "text": "",
             "colours": [
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "77f2af28-01a6-5fb6-bf0b-b263c23cea8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1326c5d-b5a5-4942-b15d-37830ac62c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1326c5d-b5a5-4942-b15d-37830ac62c7d.jpg?1",
             "name": "Resilient Khenra",
             "text": "",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "4c97ece3-648a-5cdb-80c9-8ef423834674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513f2ce9-0127-4479-b37a-a835fbada8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513f2ce9-0127-4479-b37a-a835fbada8f8.jpg?1",
             "name": "Sinuous Striker",
             "text": "",
             "colours": [
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "5d63c444-2bf4-58e0-9987-c98dcfb45bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872694ba-0666-43c1-8884-47a2e92a127c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872694ba-0666-43c1-8884-47a2e92a127c.jpg?1",
             "name": "Steadfast Sentinel",
             "text": "",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "5186a529-39ed-5561-8577-2a86a9d17ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a9593-151e-47d0-b0de-5eb9f061515a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a9593-151e-47d0-b0de-5eb9f061515a.jpg?1",
             "name": "Sunscourge Champion",
             "text": "",
             "colours": [
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "6637c9fd-5c78-5fd5-9854-e4a4d7b011ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b.jpg?1",
             "name": "Horse",
             "text": "",
             "colours": [
@@ -7735,7 +7735,7 @@
         },
         {
             "id": "a01fef88-79a9-5885-b1a9-354a1be3b6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57708b3d-ddfb-4924-b5c9-123aa9e967ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57708b3d-ddfb-4924-b5c9-123aa9e967ad.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "2a09eeab-3490-5d02-a556-ba650d80126e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae56d9e8-de05-456b-af32-b5992992ee15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae56d9e8-de05-456b-af32-b5992992ee15.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "01176210-5c0b-5a3b-87f8-5e521d2e116f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37022fc1-6a13-4873-9eaf-b827da73328e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37022fc1-6a13-4873-9eaf-b827da73328e.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],
@@ -7832,7 +7832,7 @@
         },
         {
             "id": "81416e88-9cbb-5add-ac03-ce34d7838db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d3368-6295-4db1-ac89-06c77175c6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d3368-6295-4db1-ac89-06c77175c6de.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ICE.json
+++ b/Assets/Resources/Sets/ICE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e56f418c-a350-5803-847d-ea0c82d49438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7526f-dba8-4483-b925-946164fc0ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7526f-dba8-4483-b925-946164fc0ae9.jpg?1",
             "name": "Adarkar Unicorn",
             "text": "oc\nT: Add either o\nU or o\nU and one colorless mana to your mana pool. This mana is usable only for cumulative upkeep. Play this ability as an interrupt.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "08caa01c-b2d4-5742-bdf8-64903c9b9dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f99c3e-dddc-492f-aab6-1d899346a385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f99c3e-dddc-492f-aab6-1d899346a385.jpg?1",
             "name": "Arctic Foxes",
             "text": "If defending player controls any snow-covered lands, no creature with power greater than 1 may be assigned to block Arctic Foxes.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "a1335d78-5a6e-5436-b1f3-7d96b76091e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94f3e87-1b39-49a8-ad0d-f18c854e298a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94f3e87-1b39-49a8-ad0d-f18c854e298a.jpg?1",
             "name": "Arenson's Aura",
             "text": "oo\nW Sacrifice an enchantment to destroy target enchantment.\no3o\nUoo\nU Counter target enchantment.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "c9c47303-74e3-5fe2-812f-d94a150df474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccbbc47-99c6-4ba9-95c2-992d5d2a67b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccbbc47-99c6-4ba9-95c2-992d5d2a67b2.jpg?1",
             "name": "Armor of Faith",
             "text": "Target creature gets +1/+1.\noo\nW Creature Armor of Faith enchants gets +0/+1 until end of turn.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "e0a5849a-ab9b-55cd-a263-36d4da9c06fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c558a8c4-035c-464e-9ff8-c188c1bb619e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c558a8c4-035c-464e-9ff8-c188c1bb619e.jpg?1",
             "name": "Battle Cry",
             "text": "Untap all white creatures you control. Any creature that blocks this turn gets +0/+1 until end of turn.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "4fcfa122-587d-5251-91f1-d03694a76852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfd4ee1-05f9-45ae-a31d-1225b271dbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfd4ee1-05f9-45ae-a31d-1225b271dbe6.jpg?1",
             "name": "Black Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any black cards. That creature cannot be blocked by black creatures.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "b50e467d-88e3-5e49-95e9-b98832d2fa36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a92f9-9bbc-4887-9fbc-0f7212fd5e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a92f9-9bbc-4887-9fbc-0f7212fd5e66.jpg?1",
             "name": "Blessed Wine",
             "text": "Gain 1 life. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "ea10d39b-1006-5f56-8a28-7e5e471ff54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0683-9cfa-4439-a533-8773e7747ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0683-9cfa-4439-a533-8773e7747ec4.jpg?1",
             "name": "Blinking Spirit",
             "text": "o0: Return Blinking Spirit to owner's hand.",
             "colours": [
@@ -264,7 +264,7 @@
         },
         {
             "id": "aafcd972-9197-5422-82c1-77407680ddcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b423bb5a-eaac-4c1d-981a-1c635001fc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b423bb5a-eaac-4c1d-981a-1c635001fc5a.jpg?1",
             "name": "Blue Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any blue cards. That creature cannot be blocked by blue creatures.",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "290851be-48c6-5a06-a257-a0228ade6170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92f0d4a-23d8-47d4-b910-d142e0eefd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92f0d4a-23d8-47d4-b910-d142e0eefd3d.jpg?1",
             "name": "Call to Arms",
             "text": "Choose a color. As long as target opponent controls more cards of that color than any other color, all white creatures get +1/+1. If at any time that opponent does not control more cards of that color than any other color, bury Call to Arms.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "1c1a02cc-ea2c-5327-8340-f0eef2b1b085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5f8041-67fc-4e00-b119-d216e5cc5a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5f8041-67fc-4e00-b119-d216e5cc5a3a.jpg?1",
             "name": "Caribou Range",
             "text": "When Caribou Range comes into play, choose target land you control.\no\nWo\nW: Tap land Caribou Range enchants to put a Caribou token into play. Treat this token as a 0/1 white creature.\no0: Sacrifice a Caribou token to gain 1 life.",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "4594c8e8-617c-5a99-944d-0a775edd203e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528045d-3b80-48fd-b606-c132da052685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528045d-3b80-48fd-b606-c132da052685.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage against you from one black source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "fc6a079e-3cac-5cc7-952c-e40789ed131b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d377ec-c43c-43b9-934a-91b4d11650ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d377ec-c43c-43b9-934a-91b4d11650ab.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage against you from one blue source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "3c554814-4215-5d3a-b4ab-077543e6f103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487dfb1f-b3ab-4daa-bbd9-c43dc91a5fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487dfb1f-b3ab-4daa-bbd9-c43dc91a5fba.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage against you from one green source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -454,7 +454,7 @@
         },
         {
             "id": "0095dc15-9033-59d3-9931-00cf4bdc03e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790ce22-a94f-402e-bcc7-b98f71af9fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790ce22-a94f-402e-bcc7-b98f71af9fe5.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage against you from one red source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "e1399f87-13e9-5ff4-ad6f-c3b6e59c0890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bc4bb0-350c-424e-976e-b800915f7fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bc4bb0-350c-424e-976e-b800915f7fb4.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage against you from one white source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "d2294aa6-f06a-5015-92eb-fa8cfa213a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b87a58-b20c-4f38-afa3-59d398195740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b87a58-b20c-4f38-afa3-59d398195740.jpg?1",
             "name": "Cold Snap",
             "text": "Cumulative Upkeep: o2\nDuring each player's upkeep, Cold Snap deals 1 damage to that player for each snow-covered land he or she controls.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "b79507c5-e039-54cf-81ec-999889b0337b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a815ed-c8b4-4414-8b27-ea612e2977e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a815ed-c8b4-4414-8b27-ea612e2977e2.jpg?1",
             "name": "Cooperation",
             "text": "Target creature gains banding.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "cfc80d68-92e9-5bc1-be60-5a684f161eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b21d29-050d-4704-a4c8-93e3b55086ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b21d29-050d-4704-a4c8-93e3b55086ac.jpg?1",
             "name": "Death Ward",
             "text": "Regenerate target creature.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "2efd1be9-e0ad-5ba6-834f-c3127dee074e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6085d0c-ab2b-445d-bf9d-0fa0a19183a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6085d0c-ab2b-445d-bf9d-0fa0a19183a2.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "fe6c6282-200d-5239-92e5-bb19716adb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97736696-3de3-416d-94cf-4fac792f23f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97736696-3de3-416d-94cf-4fac792f23f0.jpg?1",
             "name": "Drought",
             "text": "During your upkeep, pay o\nWo\nW or destroy Drought. Before a spell that requires o\nB as part of its casting cost may be cast or an ability that requires o\nB as part of its activation cost may be played, the controller of that spell or ability sacrifices a swamp for each o\nB in the spell's casting cost or the ability's activation cost.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "92ceaebc-dc95-5a68-996e-6d721b584612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bd8485-d63a-4077-a3d1-4d0f2f4d8035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bd8485-d63a-4077-a3d1-4d0f2f4d8035.jpg?1",
             "name": "Elvish Healer",
             "text": "oc\nT: Prevent 1 damage to any non-green creature or any player or up to 2 damage to any green creature.",
             "colours": [
@@ -707,7 +707,7 @@
         },
         {
             "id": "3914ef61-feb9-5a05-a59c-70f917689c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be77edac-9a8b-4b7f-a859-27df76b10aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be77edac-9a8b-4b7f-a859-27df76b10aa6.jpg?1",
             "name": "Enduring Renewal",
             "text": "Play with the cards in your hand face up on the table. If you draw a creature card from your library, discard it. Whenever a creature goes to your graveyard from play, put that creature into your hand.",
             "colours": [
@@ -738,7 +738,7 @@
         },
         {
             "id": "917a8faa-2f99-5a28-9a3f-3b1d11fb80ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3955e358-4285-44e2-9e24-9804346a6e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3955e358-4285-44e2-9e24-9804346a6e58.jpg?1",
             "name": "Energy Storm",
             "text": "Cumulative Upkeep: o1\nDamage dealt by instants, interrupts, and sorceries is reduced to 0.\nCreatures with flying do not untap during their controller's untap phase.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "c2f34a21-2828-5912-8652-c125a50268d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78446ead-61b0-485f-a5a9-b3e72d8075a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78446ead-61b0-485f-a5a9-b3e72d8075a7.jpg?1",
             "name": "Formation",
             "text": "Target creature gains banding until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "4c976a10-48f9-5557-9601-75e8b0ef89e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6358a1-37f0-4b40-93d4-4f1652c38404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6358a1-37f0-4b40-93d4-4f1652c38404.jpg?1",
             "name": "Fylgja",
             "text": "When Fylgja comes into play, put four healing counters on it.\no0: Remove a healing counter from Fylgja to prevent 1 damage to creature Fylgja enchants.\no2oo\nW Put a healing counter on Fylgja.",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "8acad1d6-f8e9-5bbb-b135-fd57dc4f30a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4f5a28-0bd2-4cc4-b67f-324e89193caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4f5a28-0bd2-4cc4-b67f-324e89193caa.jpg?1",
             "name": "General Jarkeld",
             "text": "oc\nT: Switch the blocking creatures of two target attacking creatures; all defense must remain legal. Use this ability only during combat after defense is chosen and before damage is dealt.",
             "colours": [
@@ -869,7 +869,7 @@
         },
         {
             "id": "8e44adfb-7dae-561e-a792-2cc415963f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9266-c97e-4666-b0fa-1802a69a62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9266-c97e-4666-b0fa-1802a69a62cc.jpg?1",
             "name": "Green Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any green cards. That creature cannot be blocked by green creatures.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "47322217-3b88-55ae-8c82-31f1da0972f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b35c0f4-5633-4ea9-9bda-daaf787aebdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b35c0f4-5633-4ea9-9bda-daaf787aebdd.jpg?1",
             "name": "Hallowed Ground",
             "text": "o\nWoo\nW Return target non-snow-covered land you control to owner's hand.",
             "colours": [
@@ -933,7 +933,7 @@
         },
         {
             "id": "c19009e7-339f-5196-809b-87722141bce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6b2704-685e-4c74-875a-25846175e5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6b2704-685e-4c74-875a-25846175e5e4.jpg?1",
             "name": "Heal",
             "text": "Prevent 1 damage to any creature or player. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "c2cf9a59-f2f0-5a27-96eb-94a8fc84edba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5969875a-f647-4daf-b76c-d1514d45c312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5969875a-f647-4daf-b76c-d1514d45c312.jpg?1",
             "name": "Hipparion",
             "text": "Cannot be assigned to block a creature with power 3 or greater unless you pay an additional o1.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "2e7e1758-4fe7-5cdc-8426-6308f3faf40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6e0c8d-0fc1-4f52-8357-e550b0ac579a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6e0c8d-0fc1-4f52-8357-e550b0ac579a.jpg?1",
             "name": "Justice",
             "text": "During your upkeep, pay o\nWo\nW or destroy Justice. Whenever a red creature or spell deals damage, Justice deals an equal amount of damage to the controller of that creature or spell. If another spell or effect reduces the amount of damage a red creature or spell deals, it does not reduce the amount of damage dealt by Justice.",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "2e031458-479d-57e1-92d8-633e09796520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8402543e-5406-404f-95c4-800a1dce35f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8402543e-5406-404f-95c4-800a1dce35f1.jpg?1",
             "name": "Kelsinko Ranger",
             "text": "o1oo\nW Target green creature gains first strike until end of turn.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "2ef05878-1d21-5f6e-ba20-fa28096e77cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73bc4b6-f7d0-494c-9e60-48279c11b7b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73bc4b6-f7d0-494c-9e60-48279c11b7b6.jpg?1",
             "name": "Kjeldoran Elite Guard",
             "text": "oc\nT: Target creature gets +2/+2 until end of turn. If that creature leaves play this turn, bury Kjeldoran Elite Guard. Use this ability only when attack or defense is announced.",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "3202ccd3-9ca3-52d8-b417-1e5e64878a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf41f17-8f82-4a8c-adec-0f3804faff3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf41f17-8f82-4a8c-adec-0f3804faff3b.jpg?1",
             "name": "Kjeldoran Guard",
             "text": "oc\nT: Target creature gets +1/+1 until end of turn. If that creature leaves play this turn, bury Kjeldoran Guard. Use this ability only when attack or defense is announced and only if defending player controls no snow-covered lands.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "0f407d33-d0bd-52ed-b458-fd2cb294ad36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg?1",
             "name": "Kjeldoran Knight",
             "text": "Banding\no1oo\nW +1/+0 until end of turn\no\nWoo\nW +0/+2 until end of turn",
             "colours": [
@@ -1164,7 +1164,7 @@
         },
         {
             "id": "8cd4fe98-e14f-5297-9fb1-44cdbca6aebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg?1",
             "name": "Kjeldoran Phalanx",
             "text": "Banding, first strike",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "be127cf9-c410-5b23-bc75-5201f2f7ae90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66343008-c38a-48a9-b767-fd2243103690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66343008-c38a-48a9-b767-fd2243103690.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: Redirect to Kjeldoran Royal Guard all damage dealt to you from unblocked creatures this turn.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "a7032ea7-d2bb-5930-875c-fed81407f377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0115e0-6192-48a9-9e58-f3ef77ef77c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0115e0-6192-48a9-9e58-f3ef77ef77c2.jpg?1",
             "name": "Kjeldoran Skycaptain",
             "text": "Banding, flying, first strike",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "52d79e0a-44e5-5744-aeff-2080b923d6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f794665a-8353-482a-b065-2a0777a8acda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f794665a-8353-482a-b065-2a0777a8acda.jpg?1",
             "name": "Kjeldoran Skyknight",
             "text": "Banding, flying, first strike",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "c34e5926-adff-5bf1-bbe1-ff02d819f493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce76f38f-566e-49ff-b197-510cfa1cb51c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce76f38f-566e-49ff-b197-510cfa1cb51c.jpg?1",
             "name": "Kjeldoran Warrior",
             "text": "Banding",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "11d1b80c-5af1-5c40-99c6-2dbcf26682b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4ed99-f38c-4e0f-9ff2-2e1e9126e6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4ed99-f38c-4e0f-9ff2-2e1e9126e6ef.jpg?1",
             "name": "Lightning Blow",
             "text": "Target creature gains first strike until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "86974850-7c07-52ff-ac2e-be1285523078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe1e5-69d2-401f-97cb-3cc01064bad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe1e5-69d2-401f-97cb-3cc01064bad3.jpg?1",
             "name": "Lost Order of Jarkeld",
             "text": "Lost Order of Jarkeld has power and toughness each equal to 1 plus the number of creatures target opponent controls.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "9598c560-1d64-5c63-b885-c59a036c59fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b28762d-1ab7-460e-b433-27f5fa858959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b28762d-1ab7-460e-b433-27f5fa858959.jpg?1",
             "name": "Mercenaries",
             "text": "Whenever Mercenaries damages a player, that player may pay o3 to prevent that damage.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "0ae5943a-3bc1-5d1a-a5cc-fe5ed747b161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5cb36-c43d-4c71-8019-9b683e160a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5cb36-c43d-4c71-8019-9b683e160a0a.jpg?1",
             "name": "Order of the Sacred Torch",
             "text": "oc\nT: Pay 1 life to destroy target black spell. Effects that prevent or redirect damage cannot be used to counter this loss of life. Play this ability as an interrupt.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "ca59939b-a659-5073-af99-ab7bc85b7f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e55b10-375f-4b4f-b676-3b9b8085fdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e55b10-375f-4b4f-b676-3b9b8085fdd2.jpg?1",
             "name": "Order of the White Shield",
             "text": "Protection from black\noo\nW First strike until end of turn\no\nWoo\nW +1/+0 until end of turn",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "6028800a-0a4c-54bd-93e9-e7558bf98322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8b50fd-3d1d-4ea8-a3c7-98ca7a8a455e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8b50fd-3d1d-4ea8-a3c7-98ca7a8a455e.jpg?1",
             "name": "Prismatic Ward",
             "text": "When Prismatic Ward comes into play, choose a color; all damage dealt to target creature by sources of that color is reduced to 0.",
             "colours": [
@@ -1534,7 +1534,7 @@
         },
         {
             "id": "58a52255-1173-508e-8698-b9837596a251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e9f80e-5d75-45b7-9c66-c0f30996f4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e9f80e-5d75-45b7-9c66-c0f30996f4dc.jpg?1",
             "name": "Rally",
             "text": "All blocking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "c1c98e7a-8c5b-5800-bd6e-ee781c99cc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a734154-5944-42f4-a02e-c426a45847f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a734154-5944-42f4-a02e-c426a45847f3.jpg?1",
             "name": "Red Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any red cards. That creature cannot be blocked by red creatures.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "f6d1f3ed-c56b-53dc-826c-adaca31cfaba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d721569d-9cf2-4c3c-b11c-4c46c258a0d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d721569d-9cf2-4c3c-b11c-4c46c258a0d2.jpg?1",
             "name": "Sacred Boon",
             "text": "Prevent up to 3 damage to target creature. At end of turn, put a +0/+1 counter on that creature for each 1 damage prevented by Sacred Boon.",
             "colours": [
@@ -1629,7 +1629,7 @@
         },
         {
             "id": "fe46c86a-069d-58bb-9f7c-6bd439e382a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab675291-3189-43f3-b11b-0724eca8b941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab675291-3189-43f3-b11b-0724eca8b941.jpg?1",
             "name": "Seraph",
             "text": "Flying\nAt the end of a turn in which any creature is damaged by Seraph and put into the graveyard, put that creature directly into play under your control as though it were just summoned. If you lose control of Seraph or if Seraph leaves play, bury the creature.",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "0a6b613a-60cc-5303-b39c-887b73163340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ff2da-d309-469c-8e2f-fa3c7517a15a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ff2da-d309-469c-8e2f-fa3c7517a15a.jpg?1",
             "name": "Shield Bearer",
             "text": "Banding",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "d9bf2cf5-f6b5-5c0f-aaea-a8f0b90c460a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084437ba-26d4-4af6-ab00-dcb145dd2cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084437ba-26d4-4af6-ab00-dcb145dd2cd0.jpg?1",
             "name": "Snow Hound",
             "text": "o1,oc\nT: Return Snow Hound to owner's hand and target blue or green creature you control to owner's hand.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "545d6490-df91-5d62-af72-3f40bd0e4cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fd2cb-443b-4be4-ad60-6d1a8e74f510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fd2cb-443b-4be4-ad60-6d1a8e74f510.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Remove target creature from the game. That creature's controller gains life equal to its power.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "a14074a2-790d-5149-945e-a0b13a380f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca5b4a7-df11-4635-a147-df12cd13a67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca5b4a7-df11-4635-a147-df12cd13a67c.jpg?1",
             "name": "Warning",
             "text": "Target attacking creature deals no damage in combat this turn.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "b77a7121-b13f-5b1a-8735-d7c9ff6756d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57726b5-dfdd-4e47-bc52-ebf6eedbf3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57726b5-dfdd-4e47-bc52-ebf6eedbf3bd.jpg?1",
             "name": "White Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any white cards. That creature cannot be blocked by white creatures.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "76f7c342-0da9-53c2-adfe-5ada4c99d732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2307fb16-8b77-45b5-8a02-51a13214791d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2307fb16-8b77-45b5-8a02-51a13214791d.jpg?1",
             "name": "Arnjlot's Ascent",
             "text": "Cumulative Upkeep: o\nU\no1: Target creature gains flying until end of turn.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "42fada9e-e376-5304-b72c-656b3748ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b616963-fac0-451c-8df4-2cacc9466b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b616963-fac0-451c-8df4-2cacc9466b17.jpg?1",
             "name": "Balduvian Conjurer",
             "text": "oc\nT: Target snow-covered land becomes a 2/2 creature until end of turn. The target still counts as land but cannot be tapped for mana if it came into play on a side this turn.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "0bc7a822-3667-5dca-9783-8b8e879304b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74859723-8ddf-4ee6-a0a7-87192c84e8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74859723-8ddf-4ee6-a0a7-87192c84e8ad.jpg?1",
             "name": "Balduvian Shaman",
             "text": "oc\nT: Permanently change the text of target white enchantment you control that does not have cumulative upkeep by replacing all instances of one color word with another. For example, you may change \"Counters black spells\" to \"Counters blue spells.\" Balduvian Shaman cannot change mana symbols. That enchantment now has Cumulative Upkeep: o1.",
             "colours": [
@@ -1924,7 +1924,7 @@
         },
         {
             "id": "1f4bff84-b5ff-557e-b86d-6cd341583954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b086186-5fbf-4ba7-af0d-ee3ad61d27bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b086186-5fbf-4ba7-af0d-ee3ad61d27bb.jpg?1",
             "name": "Binding Grasp",
             "text": "During your upkeep, pay o1o\nU or bury Binding Grasp.\nGain control of target creature; that creature gets +0/+1.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "c1683c57-1795-53bd-98a9-8e0a05c5a406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d42d7aa-7f53-4cfc-842a-086aab2448d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d42d7aa-7f53-4cfc-842a-086aab2448d1.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards; then, take two cards from your hand and put them on top of your library in any order.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "e121c45d-7f2b-57fb-86d6-3b41587a5d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40c9657-fab4-489d-8eb0-960ba2605add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40c9657-fab4-489d-8eb0-960ba2605add.jpg?1",
             "name": "Breath of Dreams",
             "text": "Cumulative Upkeep: o\nU\nGreen creatures each require an additional Cumulative Upkeep: o1.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "4bd5f141-8622-578c-a1e1-85970666299e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46740353-e2ba-4d80-a97d-1368bc67bf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46740353-e2ba-4d80-a97d-1368bc67bf30.jpg?1",
             "name": "Clairvoyance",
             "text": "Look at target player's hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "4e5f706e-e67b-5cc9-bf93-dc853d738d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedbcbaa-40f0-485f-8427-778edc2d2ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedbcbaa-40f0-485f-8427-778edc2d2ec0.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "81695af1-c685-5185-b2bd-51d1a988af04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a00a-6a0e-44cb-abea-37e2e53125e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a00a-6a0e-44cb-abea-37e2e53125e2.jpg?1",
             "name": "Deflection",
             "text": "Target spell, which must have a single target, targets a new legal target of your choice.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "0db901db-db12-5822-8b69-fb2917a0df88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93372854-57e7-4db7-a1a6-376c9f49a514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93372854-57e7-4db7-a1a6-376c9f49a514.jpg?1",
             "name": "Dreams of the Dead",
             "text": "o1oo\nU Take target white or black creature from your graveyard and put it directly into play as though it were just summoned. That creature now requires an additional Cumulative Upkeep: o2. If the creature leaves play, remove it from the game.",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "6748f29b-1044-53d5-8709-783205cfe350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fdfc5b-c2ab-4c4d-b120-301e17f3d9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fdfc5b-c2ab-4c4d-b120-301e17f3d9c6.jpg?1",
             "name": "Enervate",
             "text": "Tap target artifact, creature, or land. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "55a7f0d0-f714-586f-b81f-eb726439e83b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61648ddb-6efb-43d0-b2b1-418cc957854c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61648ddb-6efb-43d0-b2b1-418cc957854c.jpg?1",
             "name": "Errant Minion",
             "text": "During target creature's controller's upkeep, Errant Minion deals 2 damage to him or her. He or she may pay o1 for each 1 damage he or she wishes to prevent from Errant Minion.",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "8962a3f3-972b-585d-b743-e82da1acce58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ebb5dd-d7f1-4b06-8585-7004045be542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ebb5dd-d7f1-4b06-8585-7004045be542.jpg?1",
             "name": "Essence Flare",
             "text": "Target creature gets +2/+0. During each of its controller's upkeeps, put a -0/-1 counter on the creature. These counters remain even if Essence Flare is removed.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "3abaa8cd-0c40-5069-9103-1771454c0793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226555ba-22af-45f1-a3f4-d265f8685dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226555ba-22af-45f1-a3f4-d265f8685dd5.jpg?1",
             "name": "Force Void",
             "text": "Counter target spell unless that spell's caster pays an additional o1. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "49564e5d-6cec-5bcf-8186-d81ed903ebbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b71bc1-d9a2-4e99-a8fa-cd696925328d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b71bc1-d9a2-4e99-a8fa-cd696925328d.jpg?1",
             "name": "Glacial Wall",
             "text": "",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "fa48c996-f891-5e01-b6bf-001b386ecc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62716f0-fde2-49ef-b8a4-c1b03f451194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62716f0-fde2-49ef-b8a4-c1b03f451194.jpg?1",
             "name": "Hydroblast",
             "text": "Counter target spell if it is red or destroy target permanent if it is red.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "b0becf20-d1c5-5a62-9506-1d6c2532d9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f70e49-17fa-4033-bd45-63374f7f5ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f70e49-17fa-4033-bd45-63374f7f5ec5.jpg?1",
             "name": "Iceberg",
             "text": "When Iceberg comes into play, put X ice counters on it.\no3: Put an ice counter on Iceberg.\no0: Remove an ice counter from Iceberg to add one colorless mana to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "431d6245-86b1-5c68-a8d3-671660cdae84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7e496-8d2e-49db-b298-475d9017537a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7e496-8d2e-49db-b298-475d9017537a.jpg?1",
             "name": "Icy Prison",
             "text": "When Icy Prison comes into play, remove target creature from the game. When Icy Prison leaves play, return that creature to play under its owner's control as though it were just summoned. During your upkeep, destroy Icy Prison. Any player may pay o3 to prevent this.",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "2c6a8071-2b56-573d-8f99-5d7c9d37af21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab02268e-01cf-4729-95ca-5773afd40b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab02268e-01cf-4729-95ca-5773afd40b56.jpg?1",
             "name": "Illusionary Forces",
             "text": "Flying\nCumulative Upkeep: o\nU",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "e695ac6c-45cf-58ac-b8b8-017d7741ec29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa31efed-4a11-4f59-a623-bac45d20091d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa31efed-4a11-4f59-a623-bac45d20091d.jpg?1",
             "name": "Illusionary Presence",
             "text": "Cumulative Upkeep: o\nU\nDuring your upkeep, Illusionary Presence gains a landwalk ability of your choice until end of turn.",
             "colours": [
@@ -2463,7 +2463,7 @@
         },
         {
             "id": "36ef2500-08a5-5f96-aafc-c3515c81587b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691f4a1b-4706-41aa-82da-ae920739f036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691f4a1b-4706-41aa-82da-ae920739f036.jpg?1",
             "name": "Illusionary Terrain",
             "text": "Cumulative Upkeep: o2\nAll basic lands of one type become basic lands of a different type of your choice.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "a5460c85-3154-5439-8868-4366381c5e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430e8e2-fee3-4744-820e-d6e16cb992bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430e8e2-fee3-4744-820e-d6e16cb992bd.jpg?1",
             "name": "Illusionary Wall",
             "text": "Flying, first strike\nCumulative Upkeep: o\nU",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "a16252b5-83ec-5709-b42a-00fed3941629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eeeef2-2ced-42b8-a5e0-1095c9e13b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eeeef2-2ced-42b8-a5e0-1095c9e13b02.jpg?1",
             "name": "Illusions of Grandeur",
             "text": "Cumulative Upkeep: o2\nWhen Illusions of Grandeur comes into play, gain 20 life. When Illusions of Grandeur leaves play, lose 20 life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "fdb5493b-3165-535f-9164-e592f6eb5ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223287b6-224c-4e00-946c-e7ac5539bd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223287b6-224c-4e00-946c-e7ac5539bd45.jpg?1",
             "name": "Infuse",
             "text": "Untap target artifact, creature, or land. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "afb52a89-909e-53f7-a850-c50ecae2857e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc053-7b0b-4e76-bf87-ccdb1e8752ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc053-7b0b-4e76-bf87-ccdb1e8752ed.jpg?1",
             "name": "Krovikan Sorcerer",
             "text": "oc\nT: Choose and discard a card from your hand to draw a card. If the card discarded was black, draw two cards instead of one; keep one and discard the other.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "8e7b054e-1a32-5ac4-9f71-4ea0a3181fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86da04e9-b94d-42af-add3-02baf772bd33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86da04e9-b94d-42af-add3-02baf772bd33.jpg?1",
             "name": "Magus of the Unseen",
             "text": "o1o\nU,oc\nT: Untap target artifact opponent controls and gain control of it until end of turn. If that artifact is an artifact creature, it can attack, and you may use any of its abilities that require oc\nT as part of the activation cost. When you lose control of the artifact, tap it.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "f1de1621-c0fb-5f31-82fd-e840110fa10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3df593-e9d5-479d-9a9a-1c7262dd9c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3df593-e9d5-479d-9a9a-1c7262dd9c6c.jpg?1",
             "name": "Mesmeric Trance",
             "text": "Cumulative Upkeep: o1\noo\nU Discard a card from your hand to draw a card.",
             "colours": [
@@ -2689,7 +2689,7 @@
         },
         {
             "id": "412c085c-d9bc-5724-8699-6e7a78ad4338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3f4d4e-ca4a-4fba-b9fd-cd1d9457cfa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3f4d4e-ca4a-4fba-b9fd-cd1d9457cfa1.jpg?1",
             "name": "Mistfolk",
             "text": "oo\nU Counter target spell that targets Mistfolk.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "23e343b1-e95c-5770-9c7c-f85f71b06bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8d2247-a10e-413a-b497-2add3918f991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8d2247-a10e-413a-b497-2add3918f991.jpg?1",
             "name": "Musician",
             "text": "Cumulative Upkeep: o1\noc\nT: Put a music counter on target creature. During that creature's controller's upkeep, he or she pays o1 for each music counter on the creature, or destroy the creature.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "71cacf5e-ac7f-503d-bf34-e7df5f7f874e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d7f08-0687-41bd-8c53-31a49adabb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d7f08-0687-41bd-8c53-31a49adabb11.jpg?1",
             "name": "Mystic Might",
             "text": "Cumulative Upkeep: o1o\nU\nWhen Mystic Might comes into play, choose target land you control.\no0: Tap land Mystic Might enchants to give target creature +2/+2 until end of turn.",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "be4b3a20-f148-54bb-b25c-a619a9c1714a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e93dff-b774-4765-b7bd-d3957e42ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e93dff-b774-4765-b7bd-d3957e42ff4a.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative Upkeep: o1\nWhenever target opponent successfully casts a non-creature spell, you may draw a card. That player may pay o4 to counter this effect.",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "391d2a9a-192a-529f-b830-1ac09f489b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75afdbe6-a3f9-49cf-b4ef-f370e518e960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75afdbe6-a3f9-49cf-b4ef-f370e518e960.jpg?1",
             "name": "Phantasmal Mount",
             "text": "Flying\noc\nT: Target creature you control, which has toughness less than 3, gains flying and gets +1/+1 until end of turn. Other effects may later be used to increase that creature's toughness beyond 3. If Phantasmal Mount leaves play before end of turn, bury the creature. If the creature leaves play before end of turn, bury Phantasmal Mount.",
             "colours": [
@@ -2854,7 +2854,7 @@
         },
         {
             "id": "5581a0c9-a0b6-5657-a970-dcbb6d1132c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee01e9c-0445-4228-a73a-3e5744844ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee01e9c-0445-4228-a73a-3e5744844ed3.jpg?1",
             "name": "Polar Kraken",
             "text": "Trample\nCumulative Upkeep: Sacrifice a land.\nComes into play tapped.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "4a3afe72-ac2a-56f9-90ab-49ab0773e1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040be83-3fb5-4da5-ba7a-4923b8854b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040be83-3fb5-4da5-ba7a-4923b8854b74.jpg?1",
             "name": "Portent",
             "text": "Look at the top three cards of target player's library; then, either shuffle that library or put those three cards on top of the library in any order. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2918,7 +2918,7 @@
         },
         {
             "id": "11f7a079-9451-5c4b-9cac-ca7c849f1f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbec45-81b4-40cc-b356-d6713a6a9b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbec45-81b4-40cc-b356-d6713a6a9b2b.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless that spell's caster pays an additional o\nX. That player must draw and pay all available mana from lands and mana pool until o\nX is paid; he or she may also pay mana from other sources if desired.",
             "colours": [
@@ -2949,7 +2949,7 @@
         },
         {
             "id": "de467bc1-2b2f-546a-a4a6-c75991b04d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/638abe5f-2a8a-42ca-bcdf-a52a3df66946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/638abe5f-2a8a-42ca-bcdf-a52a3df66946.jpg?1",
             "name": "Ray of Command",
             "text": "Untap target creature opponent controls and gain control of it until end of turn. That creature can attack or use abilities that require oc\nT as part of the activation cost. When you lose control of the creature, tap it.",
             "colours": [
@@ -2980,7 +2980,7 @@
         },
         {
             "id": "ee323db5-29a5-52b8-a80a-6a2ca987399d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a09fc0b-7b9c-4283-8336-f2607f5ffaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a09fc0b-7b9c-4283-8336-f2607f5ffaf5.jpg?1",
             "name": "Ray of Erasure",
             "text": "Target player takes the top card of his or her library and puts it in his or her graveyard. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "959da211-25a3-5f3f-b6a0-ba8d919139c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7e955c-3de2-430c-93b9-0b39ccea5420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7e955c-3de2-430c-93b9-0b39ccea5420.jpg?1",
             "name": "Reality Twist",
             "text": "Cumulative Upkeep: o1o\nUo\nU\nInstead of their normal mana, plains produce o\nR, swamps produce o\nG, mountains produce o\nW, and forests produce o\nB.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "4734ed73-7ca7-57d4-9aa6-fc3e439df990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d93d05-98bc-4504-9045-dedb925895ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d93d05-98bc-4504-9045-dedb925895ae.jpg?1",
             "name": "Sea Spirit",
             "text": "o\nU: +1/+0 until end of turn",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "662d53a0-8a76-538e-9033-3179df8c99ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a60c33-b641-42c4-870d-95d07bc975dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a60c33-b641-42c4-870d-95d07bc975dc.jpg?1",
             "name": "Shyft",
             "text": "During your upkeep, you may change the color of Shyft to any color or combination of colors.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "a0e507d7-762e-5695-ad6e-b21424d6efca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47364ad2-5ce9-4b19-a9d2-f6a33188b882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47364ad2-5ce9-4b19-a9d2-f6a33188b882.jpg?1",
             "name": "Sibilant Spirit",
             "text": "Flying\nWhenever Sibilant Spirit is declared as an attacker, defending player may draw a card.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "2ac01bf8-8601-5577-bcdf-63e47d42f58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685076cc-098c-4f98-918c-0ad825eda10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685076cc-098c-4f98-918c-0ad825eda10f.jpg?1",
             "name": "Silver Erne",
             "text": "Flying, trample",
             "colours": [
@@ -3179,7 +3179,7 @@
         },
         {
             "id": "0cfdfb12-f1bf-5738-9dab-61bca7102adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dc9f02-11ad-4c4a-8199-9d20c23d31a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dc9f02-11ad-4c4a-8199-9d20c23d31a7.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of target spell or permanent by replacing all instances of one color word with another. For example, you may change \"Counters black spells\" to \"Counters blue spells.\" Sleight of Mind cannot change mana symbols.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "b2da5329-48e7-5c83-a55a-a3cb0b75777c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be3a9a5-2ac5-4ea4-915d-8cff35c0e72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be3a9a5-2ac5-4ea4-915d-8cff35c0e72f.jpg?1",
             "name": "Snow Devil",
             "text": "Target creature gains flying. As long as you control any snow-covered lands, that creature also gains first strike when blocking.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "b9e7a694-2ce8-5ff5-b4e1-a9054206162f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788ed793-3993-4a63-b9f9-9ac3947c3108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788ed793-3993-4a63-b9f9-9ac3947c3108.jpg?1",
             "name": "Snowfall",
             "text": "Cumulative Upkeep: o\nU\nIslands may produce an additional o\nU when tapped for mana. This mana is usable only for cumulative upkeep.\nSnow-covered islands may produce either an additional o\nUo\nU or an additional o\nU when tapped for mana. This mana is usable only for cumulative upkeep.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "0d68baeb-b2a3-52d0-9682-215413b62ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0999df-2f94-499e-b9af-fe377d515400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0999df-2f94-499e-b9af-fe377d515400.jpg?1",
             "name": "Soldevi Machinist",
             "text": "oc\nT: Add two colorless mana to your mana pool. This mana may only be used to pay the activation cost of an artifact. Play this ability as an interrupt.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "d3a73b6a-88de-5640-b7c5-c483e2cdc954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad7fac7-db4d-45b2-aba6-16f4fd1a586f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad7fac7-db4d-45b2-aba6-16f4fd1a586f.jpg?1",
             "name": "Soul Barrier",
             "text": "Whenever target opponent casts a summon spell, Soul Barrier deals 2 damage to him or her. That player may pay o2 to prevent this damage.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "6f36f973-da16-5bc3-b829-e8e91eaa6362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc5d510-c4f7-4a09-bf86-83c3fa3f8928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc5d510-c4f7-4a09-bf86-83c3fa3f8928.jpg?1",
             "name": "Thunder Wall",
             "text": "Flying\noo\nU +1/+1 until end of turn",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "eacea80e-6f00-5ba8-951b-cc6305fc6a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bd4e16-27fe-4c7b-ae25-78ed77d8e8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bd4e16-27fe-4c7b-ae25-78ed77d8e8e7.jpg?1",
             "name": "Updraft",
             "text": "Target creature gains flying until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "90d18407-e9bd-57f1-8981-d0e27b960c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d882447-9594-4aab-b1a7-8bb275f250cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d882447-9594-4aab-b1a7-8bb275f250cf.jpg?1",
             "name": "Wind Spirit",
             "text": "Flying\nCannot be blocked by only one creature.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "c9d28c5a-afd6-5a11-9830-26cc26aae107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a779aca7-ff2c-48d8-9484-6ad04b2c6bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a779aca7-ff2c-48d8-9484-6ad04b2c6bcb.jpg?1",
             "name": "Winter's Chill",
             "text": "Cast only during combat before defense is chosen. At end of combat, destroy X target attacking creatures; X cannot be greater than the number of snow-covered lands you control. For each attacking creature, its controller may pay o1 or o2 to prevent it from being destroyed in this way. If that player pays o1, the creature neither deals nor receives damage in combat. If that player pays o2, the creature deals and receives damage in combat as normal.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "1af5ebdf-c7ba-5ba1-a2bb-d6310ebdad53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b04476-5a5d-4843-a948-82db209c4218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b04476-5a5d-4843-a948-82db209c4218.jpg?1",
             "name": "Word of Undoing",
             "text": "Return target creature to owner's hand. Return any white enchantments you own on that creature to your hand.",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "7857b1ba-dd49-5537-bd4e-9a8b9910347a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d512f5c-0327-4d49-8a26-672574a49102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d512f5c-0327-4d49-8a26-672574a49102.jpg?1",
             "name": "Wrath of Marit Lage",
             "text": "When Wrath of Marit Lage comes into play, tap all red creatures. Red creatures do not untap during their controller's untap phase.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "c42a00e8-8293-509a-a2fa-a217c61fba20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f8531f-19ca-48a2-baf2-c5dc6f18d79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f8531f-19ca-48a2-baf2-c5dc6f18d79c.jpg?1",
             "name": "Zur's Weirding",
             "text": "All players play with the cards in their hands face up on the table. Whenever any player draws a card, any other player may pay 2 life to force the drawing player to discard that card. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "64d14fb3-68b8-5988-a715-154fb3ef9bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721edcef-f40a-4d43-9d80-26161dc425cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721edcef-f40a-4d43-9d80-26161dc425cb.jpg?1",
             "name": "Zuran Enchanter",
             "text": "o2o\nB,oc\nT: Target player chooses and discards one card from his or her hand. Ignore this ability if that player has no cards in his or her hand. Use this ability only during your turn.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "85eb7278-b8d8-5702-a3eb-43a62fc0b7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152a72b1-a7b7-4e5c-8558-fab97465f549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152a72b1-a7b7-4e5c-8558-fab97465f549.jpg?1",
             "name": "Zuran Spellcaster",
             "text": "oc\nT: Zuran Spellcaster deals 1 damage to target creature or player.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "2cf7a942-363c-5b65-bad8-9bcfe73dce28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26f19c-bcf7-4bd8-af42-4757dbe47fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26f19c-bcf7-4bd8-af42-4757dbe47fb1.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter damages any player, that player chooses and discards a card from his or her hand. Ignore this ability if the player has no cards in hand.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "3d2c108c-be12-5331-85b6-8764580a9ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb83301-5662-4628-b536-6a3ee0296f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb83301-5662-4628-b536-6a3ee0296f2e.jpg?1",
             "name": "Ashen Ghoul",
             "text": "Ashen Ghoul can attack the turn it comes into play.\noo\nB Return Ashen Ghoul to play under your control. Use this ability only at the end of your upkeep and only if Ashen Ghoul is in your graveyard with at least three creature cards above it.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "75113f4e-ea1e-5a57-9f72-1a9fb91f30b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f445962c-44a1-4f3f-88d4-17048f8ca9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f445962c-44a1-4f3f-88d4-17048f8ca9dc.jpg?1",
             "name": "Brine Shaman",
             "text": "oc\nT: Sacrifice a creature to give target creature +2/+2 until end of turn.\no1o\nUo\nU: Sacrifice a creature to counter target summon spell.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "71e56940-b579-5ce5-819e-8592d6d6830c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dae52a2-3af7-4b97-9d2e-2448b7c413fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dae52a2-3af7-4b97-9d2e-2448b7c413fb.jpg?1",
             "name": "Burnt Offering",
             "text": "Sacrifice a creature to add that creature's casting cost in any combination of red and/or black mana to your mana pool.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "7e64809d-bd1f-51b9-b9ea-d8325a95d7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45d103-0fca-4431-a5c0-869f0f9be93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45d103-0fca-4431-a5c0-869f0f9be93e.jpg?1",
             "name": "Cloak of Confusion",
             "text": "If target creature you control attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, that player discards a card at random from his or her hand. Ignore this ability if that player has no cards in hand.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "06baa505-be67-5ef7-b963-6d24caf844e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c53ba4-9956-4cd6-85ca-2d6b61a5127c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c53ba4-9956-4cd6-85ca-2d6b61a5127c.jpg?1",
             "name": "Dance of the Dead",
             "text": "Take target creature from any graveyard and put it directly into play under your control, tapped, with +1/+1. Treat that creature as though it were just summoned. The creature does not untap during its controller's untap phase. At the end of his or her upkeep, its controller may pay an additional o1o\nB to untap it. If Dance of the Dead is removed, bury the creature in its owner's graveyard.",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "9b6a9e9f-e8e6-5492-a73b-1a3ae2d16046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc2716-ed62-4797-ad2b-227eca5408d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc2716-ed62-4797-ad2b-227eca5408d0.jpg?1",
             "name": "Dark Banishing",
             "text": "Bury target non-black creature.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "da8cb874-99d3-5ce7-bf1b-8253245975f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebcd681-1871-4914-bcd7-6bd95829f6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebcd681-1871-4914-bcd7-6bd95829f6e0.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "78c65636-9830-51b2-aaa9-f3bd30487c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d727b9b-6114-414d-9172-16b6e1db41cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d727b9b-6114-414d-9172-16b6e1db41cc.jpg?1",
             "name": "Demonic Consultation",
             "text": "Name a card. Remove the top six cards of your library from the game and reveal the next card to all players. If it is the card named, put it into your hand. If not, remove that card from the game and continue revealing the top card of your library and removing it from the game until the named card appears.",
             "colours": [
@@ -3924,7 +3924,7 @@
         },
         {
             "id": "a90cbb75-da04-5f5a-817d-a1687c6455cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d332e2-4b2d-4131-84f7-862cb138c477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d332e2-4b2d-4131-84f7-862cb138c477.jpg?1",
             "name": "Dread Wight",
             "text": "At end of combat, put a paralyzation counter on any creature blocking or blocked by Dread Wight and tap that creature. As long as the creature has a paralyzation counter on it, it does not untap during its controller's untap phase. As a non-interrupt fast effect, the creature's controller may pay o4 to remove a paralyzation counter.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "119552b0-cf3f-5d6b-8043-14520b4d5151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b65656-9f8c-4179-81aa-4b15d8280baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b65656-9f8c-4179-81aa-4b15d8280baa.jpg?1",
             "name": "Drift of the Dead",
             "text": "Drift of the Dead has power and toughness each equal to the number of snow-covered lands you control.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "9ad7da13-cbd4-52cd-9204-90889b1bbb70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5709398f-0744-4780-a1d2-eead96c8f348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5709398f-0744-4780-a1d2-eead96c8f348.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked except by artifact creatures or black creatures.",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "fa1c0d08-15dd-566e-bba7-d492ba3fcae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6880a4d3-5cbc-4a01-9190-3565617efcc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6880a4d3-5cbc-4a01-9190-3565617efcc9.jpg?1",
             "name": "Flow of Maggots",
             "text": "Cumulative Upkeep: o1\nCannot be blocked by non-wall creatures.",
             "colours": [
@@ -4056,7 +4056,7 @@
         },
         {
             "id": "551ece0c-cc65-5c5d-a29c-b674f5686a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad3541-8e40-4a2f-ac9d-f7b61f3d75a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad3541-8e40-4a2f-ac9d-f7b61f3d75a1.jpg?1",
             "name": "Foul Familiar",
             "text": "Cannot be declared as a blocking creature.\noo\nB Pay 1 life to return Foul Familiar to owner's hand. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "da8b3da6-7402-58cf-9833-ec809c663574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be4d83-99be-4360-90f1-104dee1c3c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be4d83-99be-4360-90f1-104dee1c3c2f.jpg?1",
             "name": "Gangrenous Zombies",
             "text": "oc\nT: Sacrifice Gangrenous Zombies to have it deal 1 damage to each creature and player. If you control any snow-covered swamps, Gangrenous Zombies instead deals 2 damage to each creature and player.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "8d18962c-8573-5e83-b0e7-fccea1abd2fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48401643-ec4b-444a-8f9a-1a5ea471ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48401643-ec4b-444a-8f9a-1a5ea471ff4a.jpg?1",
             "name": "Gaze of Pain",
             "text": "For each creature you control that attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, it instead deals damage equal to its power to any target creature.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "7db89ce2-c636-57ae-bfb6-7005894379e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4782fd4f-2474-4d0d-8301-e0b52af93746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4782fd4f-2474-4d0d-8301-e0b52af93746.jpg?1",
             "name": "Gravebind",
             "text": "Target creature cannot regenerate this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "2e680461-4712-5c9c-97d3-cea9137c6d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f59620f-ff9e-44d8-9c4e-be9de1a919e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f59620f-ff9e-44d8-9c4e-be9de1a919e8.jpg?1",
             "name": "Hecatomb",
             "text": "When Hecatomb comes into play, sacrifice four creatures.\no0: Tap target swamp you control to have Hecatomb deal 1 damage to target creature or player.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "a4f54ec7-a14c-5918-839f-3a1fe6352c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72242dff-15ca-4da0-b3ae-9984d037b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72242dff-15ca-4da0-b3ae-9984d037b31f.jpg?1",
             "name": "Hoar Shade",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "d729c97a-3581-54c8-9595-930e8df27acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d0d6b-056e-4b94-8de5-a325768f67b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d0d6b-056e-4b94-8de5-a325768f67b6.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "255d872c-7080-5f94-9a21-c0bc52a93d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e037-f4d5-46fd-b439-56bee6fb2ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e037-f4d5-46fd-b439-56bee6fb2ad3.jpg?1",
             "name": "Hyalopterous Lemure",
             "text": "o0: Flying and -1/-0 until end of turn",
             "colours": [
@@ -4312,7 +4312,7 @@
         },
         {
             "id": "5b37c31c-8b11-5821-8a93-c6280f0f8d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b4dd4d-c617-4603-8a87-761ec6fc6883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b4dd4d-c617-4603-8a87-761ec6fc6883.jpg?1",
             "name": "Icequake",
             "text": "Destroy target land. If that land is a snow-covered land, Icequake deals 1 damage to the land's controller.",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "12c336ea-bdc6-5810-a963-56e329926d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3475eb3-909d-450b-9597-b241b259b425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3475eb3-909d-450b-9597-b241b259b425.jpg?1",
             "name": "Infernal Darkness",
             "text": "Cumulative Upkeep: o\nB and 1 life\nAll mana-producing lands produce o\nB instead of their normal mana.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "168e6384-1ed3-5968-a4d9-5a4cda65a9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ac9a6-aaa5-4659-97d1-c5f6b0d5ccfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ac9a6-aaa5-4659-97d1-c5f6b0d5ccfe.jpg?1",
             "name": "Infernal Denizen",
             "text": "During your upkeep, sacrifice two swamps. If you cannot, tap Infernal Denizen, and target opponent may gain control of target creature of his or her choice you control. The opponent loses control of that creature if Infernal Denizen leaves play.\noc\nT: Gain control of target creature. Lose control of that creature if Infernal Denizen leaves play.",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "33f96886-32fa-58b6-bf9f-a7e7090e2aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f7b614-6075-4b7c-acc7-ab63185b570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f7b614-6075-4b7c-acc7-ab63185b570b.jpg?1",
             "name": "Kjeldoran Dead",
             "text": "When Kjeldoran Dead comes into play, sacrifice a creature.\noo\nB Regenerate",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "da806ea3-7c84-5c8a-9fde-6b8c97b37439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b87069b-ebaf-4705-b5da-446932af9b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b87069b-ebaf-4705-b5da-446932af9b73.jpg?1",
             "name": "Knight of Stromgald",
             "text": "Protection from white\no\nBo\nB: +1/+0 until end of turn\no\nB: First strike until end of turn",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "cf0cb215-b429-5976-8900-ea8864476d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedca18-a074-4441-b0a9-7b14fdb07412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedca18-a074-4441-b0a9-7b14fdb07412.jpg?1",
             "name": "Krovikan Elementalist",
             "text": "o2oo\nR Target creature gets +1/+0 until end of turn.\no\nUoo\nU Target creature you control gains flying until end of turn. At end of turn, bury that creature.",
             "colours": [
@@ -4510,7 +4510,7 @@
         },
         {
             "id": "5e771f10-04fe-504f-9984-11c19be0b1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e73e6-b201-4b2e-b46a-b719484fba0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e73e6-b201-4b2e-b46a-b719484fba0e.jpg?1",
             "name": "Krovikan Fetish",
             "text": "Draw a card at the beginning of the upkeep of the turn after Krovikan Fetish comes into play.\nTarget creature gets +1/+1.",
             "colours": [
@@ -4543,7 +4543,7 @@
         },
         {
             "id": "9d984957-07c8-54a0-86f4-116fb8ba24e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5dda-8e38-4c76-b241-685198402284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5dda-8e38-4c76-b241-685198402284.jpg?1",
             "name": "Krovikan Vampire",
             "text": "At the end of a turn in which any creature is damaged by Krovikan Vampire and put into any graveyard, put that creature directly into play under your control. Treat the creature as though it were just summoned. If you lose control of Krovikan Vampire or Krovikan Vampire leaves play, bury the creature.",
             "colours": [
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "a73354e2-1be3-51d6-bb17-dea0c1423ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b67eb2-b60e-46b4-9d48-11c284957bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b67eb2-b60e-46b4-9d48-11c284957bec.jpg?1",
             "name": "Legions of Lim-D\u00fbl",
             "text": "Snow-covered swampwalk",
             "colours": [
@@ -4609,7 +4609,7 @@
         },
         {
             "id": "b7b5a6b9-125e-51bb-9611-a14f7801d4df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0a6b4e-95b4-40f6-bb19-568dbd908a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0a6b4e-95b4-40f6-bb19-568dbd908a2b.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Target creature gains swampwalk.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "225d9950-d771-5849-82aa-e8c61274003b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ba7ee-d6df-4b62-a8a1-c81e6fca392a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ba7ee-d6df-4b62-a8a1-c81e6fca392a.jpg?1",
             "name": "Leshrac's Sigil",
             "text": "o\nBoo\nB When any opponent successfully casts a green spell, look at that player's hand and choose a card; he or she then discards that card. Use this ability only once each time a green spell is cast.\no\nBoo\nB Return Leshrac's Sigil to owner's hand.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "85c3ee77-6ee4-5a92-bfb0-7a39490275c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0006f6-2f96-453d-9145-eaefa588efbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0006f6-2f96-453d-9145-eaefa588efbc.jpg?1",
             "name": "Lim-D\u00fbl's Cohort",
             "text": "Creatures blocking or blocked by Lim-D\u00fbl's Cohort cannot regenerate this turn.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "b4916725-be57-566a-b08d-765dd4b08ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af976f42-3d56-4e32-8294-970a276a4bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af976f42-3d56-4e32-8294-970a276a4bf3.jpg?1",
             "name": "Lim-D\u00fbl's Hex",
             "text": "During your upkeep, Lim-D\u00fbl's Hex deals 1 damage to each player. Each player may pay o\nB or o3 to prevent the damage to himself or herself.",
             "colours": [
@@ -4737,7 +4737,7 @@
         },
         {
             "id": "b3450b1d-f04f-543e-b682-a6371ed57938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf3ac5-985d-4b48-b230-d5ae4ab1ace8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf3ac5-985d-4b48-b230-d5ae4ab1ace8.jpg?1",
             "name": "Mind Ravel",
             "text": "Target player chooses and discards a card from his or her hand.\nIgnore this ability if that player has no cards in hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "74ad44ab-12ea-58ec-923f-a4c6795fa36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de150cd6-0bbc-47f7-a781-cd1aa10eabc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de150cd6-0bbc-47f7-a781-cd1aa10eabc6.jpg?1",
             "name": "Mind Warp",
             "text": "Look at target player's hand and choose X cards; that player then discards those cards. If the player does not have enough cards in hand, his or her entire hand is discarded.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "50a1bef7-5c76-5ece-a13a-d815118f726e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3ff5fb-4126-4a18-b540-2beaae382e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3ff5fb-4126-4a18-b540-2beaae382e59.jpg?1",
             "name": "Mind Whip",
             "text": "During target creature's controller's upkeep, he or she pays o3 or Mind Whip deals 2 damage to him or her. If Mind Whip deals damage in this way, tap that creature.",
             "colours": [
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "d6e9ca83-4769-5d8b-9e80-e258434c5e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61278908-a1b4-4b4c-84f5-498ca41fc6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61278908-a1b4-4b4c-84f5-498ca41fc6b6.jpg?1",
             "name": "Minion of Leshrac",
             "text": "Protection from black\nDuring your upkeep, sacrifice a creature or Minion of Leshrac deals 5 damage to you. If Minion of Leshrac deals damage to you in this way, tap it. You cannot sacrifice Minion of Leshrac to itself.\noc\nT: Destroy target creature or land.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "289d6fbd-b1fa-53d1-b60a-0c13c0ce3927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f3ab5-6a31-47db-b8bf-4c56a7ff19d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f3ab5-6a31-47db-b8bf-4c56a7ff19d1.jpg?1",
             "name": "Minion of Tevesh Szat",
             "text": "During your upkeep, pay o\nBo\nB or Minion of Tevesh Szat deals 2 damage to you.\noc\nT: Target creature gets +3/-2 until end of turn.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "1d7b1c45-edd3-5460-a105-2206f024db59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4914f6fc-e3e7-426b-8688-12157c7df9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4914f6fc-e3e7-426b-8688-12157c7df9e7.jpg?1",
             "name": "Mole Worms",
             "text": "You may choose not to untap Mole Worms during your untap phase.\noc\nT: Tap target land. As long as Mole Worms remains tapped, that land does not untap during its controller's untap phase.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "a3c2296b-45b6-5679-8b59-0163765eb937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57089dd4-e30d-498d-9341-43c104c6f3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57089dd4-e30d-498d-9341-43c104c6f3f9.jpg?1",
             "name": "Moor Fiend",
             "text": "Swampwalk",
             "colours": [
@@ -4966,7 +4966,7 @@
         },
         {
             "id": "403ed7f3-4bfc-5187-97c8-dde8c7299d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d7a0c1-efb4-4a8d-ad92-a96d43835052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d7a0c1-efb4-4a8d-ad92-a96d43835052.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw phase. If you discard a card from your hand, remove that card from the game.\no0: Pay 1 life to set aside the top card of your library. At the beginning of your next discard phase, put that card into your hand. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "5e204e66-0d0b-5ee9-8fc6-6e68692716a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35abefe6-c39b-4fe5-b2e3-d213f0c4f447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35abefe6-c39b-4fe5-b2e3-d213f0c4f447.jpg?1",
             "name": "Norritt",
             "text": "oc\nT: Untap target blue creature.\noc\nT: Force target non-wall creature to attack. If creature cannot attack, destroy it at end of turn. Use this ability only during target creature's controller's turn, before the attack. Cannot target creatures brought under their controller's control this turn.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "db82f03f-6db9-52eb-90e3-0f89de183ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df768-06de-43a0-b548-44fb0887490b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df768-06de-43a0-b548-44fb0887490b.jpg?1",
             "name": "Oath of Lim-D\u00fbl",
             "text": "For each 1 damage dealt to you or 1 life you lose, sacrifice a permanent you control or choose and discard a card from your hand. You cannot sacrifice Oath of Lim-D\u00fbl in this way. Ignore this effect if you control no permanents other than Oath of Lim-D\u00fbl and have no cards in hand.\no\nBo\nB: Draw a card.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "9eb8128f-6c76-54c6-8437-f9a9c84dfcdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff7f6a6-0e90-4eb4-b76e-d98454975fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff7f6a6-0e90-4eb4-b76e-d98454975fb6.jpg?1",
             "name": "Pestilence Rats",
             "text": "Pestilence Rats has power equal to the total number of other Rats in play, no matter who controls them. For example, as long as there are two other Rats in play, Pestilence Rats has power and toughness 2/3.",
             "colours": [
@@ -5094,7 +5094,7 @@
         },
         {
             "id": "f168c218-5d8e-587b-9496-f2ca57c30ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a914138c-a593-414c-bbcb-83d3c1bc4f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a914138c-a593-414c-bbcb-83d3c1bc4f6f.jpg?1",
             "name": "Pox",
             "text": "Each player loses 1/3 of his or her life; then chooses and discards 1/3 of the cards in his or her hand; then sacrifices 1/3 of the creatures he or she controls; and finally sacrifices 1/3 of the lands he or she controls. Round each loss up. Effects that prevent or redirect damage cannot be used to counter the this loss of life.",
             "colours": [
@@ -5125,7 +5125,7 @@
         },
         {
             "id": "2300531d-4497-57da-b0db-f161a0d010e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da369c86-7e17-43d8-b626-b6842e3d2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da369c86-7e17-43d8-b626-b6842e3d2d50.jpg?1",
             "name": "Seizures",
             "text": "Whenever target creature becomes tapped, that creature's controller pays o3 or Seizures deals 3 damage to him or her.",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "611c30f7-85a6-5423-a4c7-9e3706c82d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff3547-8c72-439a-91fe-ebe729dab748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff3547-8c72-439a-91fe-ebe729dab748.jpg?1",
             "name": "Songs of the Damned",
             "text": "Add o\nB to your mana pool for each creature in your graveyard.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "a0cb9a39-7a8f-51f3-9e8d-720b2e585adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8e00d2-2381-4d45-bed8-c9bf738a9419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8e00d2-2381-4d45-bed8-c9bf738a9419.jpg?1",
             "name": "Soul Burn",
             "text": "Soul Burn deals 1 damage to a single target creature or player for each o\nB or o\nR you pay in addition to the casting cost. Gain 1 life for each o\nB you spend in this way. You cannot gain more life than the toughness of the creature or the total life of the targeted player.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "34cc3b28-9e8f-593c-a965-d9c0217e9bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fbf6a5-86fe-41a3-891e-f72f11ad0aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fbf6a5-86fe-41a3-891e-f72f11ad0aee.jpg?1",
             "name": "Soul Kiss",
             "text": "When Soul Kiss comes into play, choose target creature.\no\nB: Pay 1 life to give creature Soul Kiss enchants +2/+2 until end of turn. You cannot spend more than o\nBo\nBo\nB in this way each turn. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "c3027065-4403-5577-993c-921961b76e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd368eb6-72f0-42d4-afa5-3daa7de949ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd368eb6-72f0-42d4-afa5-3daa7de949ff.jpg?1",
             "name": "Spoils of Evil",
             "text": "For each artifact or creature in target opponent's graveyard, add one colorless mana to your mana pool and gain 1 life.",
             "colours": [
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "de617743-3583-5309-bb10-da89829294ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38af8bd-d927-46d0-a1b1-fb437ea9ea66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38af8bd-d927-46d0-a1b1-fb437ea9ea66.jpg?1",
             "name": "Spoils of War",
             "text": "Put X +1/+1 counters on any number of target creatures, distributed any way you choose, where X is equal to the number of creatures and artifacts in target opponent's graveyard.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "55fd585f-98ab-5a2b-8cf6-06255a5221b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7065a2-f819-4cbe-b453-a55e904f0461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7065a2-f819-4cbe-b453-a55e904f0461.jpg?1",
             "name": "Stench of Evil",
             "text": "Destroy all plains. Stench of Evil deals 1 damage to each player for each plains he or she controls that is destroyed in this way. Each player may pay o2 for each 1 damage he or she wishes to prevent from Stench of Evil.",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "d7861879-4a2a-5941-be32-c8a57827d113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac6fa0c-753e-4fbc-8a70-0f956503cf4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac6fa0c-753e-4fbc-8a70-0f956503cf4e.jpg?1",
             "name": "Stromgald Cabal",
             "text": "oc\nT: Pay 1 life to counter target white spell. Effects that prevent or redirect damage cannot be used to counter this loss of life. Play this ability as an interrupt.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "a4e26f72-10e0-557e-9c4b-abd55a7ffd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c658f-e657-490b-af1f-e67e48d0046e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c658f-e657-490b-af1f-e67e48d0046e.jpg?1",
             "name": "Touch of Death",
             "text": "Touch of Death deals 1 damage to target player, and you gain 1 life. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "6d4f65e6-4bcc-522e-8e5e-d3ba705cb50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1e6ae5-c972-42c0-ae78-f203873aeeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1e6ae5-c972-42c0-ae78-f203873aeeb1.jpg?1",
             "name": "Withering Wisps",
             "text": "At the end of any turn, if there are no creatures in play, bury Withering Wisps.\noo\nB Withering Wisps deals 1 damage to each creature and each player. You cannot spend more o\nB in this way each turn than the number of snow-covered swamps you control.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "5ba9eca8-0e78-52e0-968a-7e4bf9869cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f26060-0c24-496c-b8e2-4dac7ea6166b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f26060-0c24-496c-b8e2-4dac7ea6166b.jpg?1",
             "name": "Aggression",
             "text": "Target non-wall creature gains first strike and trample. At the end of its controller's turn, destroy that creature if it did not attack that turn.",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "c2d83dfc-a70f-5b54-b757-272765bd7db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d941da-b5cb-4b7e-84f2-ece883f89af3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d941da-b5cb-4b7e-84f2-ece883f89af3.jpg?1",
             "name": "Anarchy",
             "text": "Destroy all white permanents.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "c507dd9d-e3d1-55a7-8200-ff4a2f85e40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a925e5-0d0a-42ec-b1c6-9793b8e11625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a925e5-0d0a-42ec-b1c6-9793b8e11625.jpg?1",
             "name": "Avalanche",
             "text": "Destroy X target snow-covered lands.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "c11548bb-8bc3-5634-beb0-32d80fc38b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeabe8e-8107-4d19-8a43-362aa79cdd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeabe8e-8107-4d19-8a43-362aa79cdd92.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "7baec890-cb6e-50c8-8ae8-0ad462a5a13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a3b37f-daa6-4502-bb12-c72afe3df035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a3b37f-daa6-4502-bb12-c72afe3df035.jpg?1",
             "name": "Balduvian Hydra",
             "text": "When Balduvian Hydra comes into play, put X +1/+0 counters on it.\no0: Remove a +1/+0 counter from Balduvian Hydra to prevent 1 damage to Balduvian Hydra.\no\nRo\nRo\nR: Put a +1/+0 counter on Balduvian Hydra. Use this ability only during your upkeep.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "e0af987b-6715-5be3-9dfe-f263fa026abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65a045-dacb-4392-bcb6-843394ef98c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65a045-dacb-4392-bcb6-843394ef98c9.jpg?1",
             "name": "Barbarian Guides",
             "text": "o2o\nR,oc\nT: Target creature you control gains a snow-covered landwalk ability of your choice until end of turn. At end of turn, return that creature to its owner's hand.",
             "colours": [
@@ -5638,7 +5638,7 @@
         },
         {
             "id": "bac57e15-6629-5ad6-b31a-858000347988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85ae675-56ca-4a00-83d2-ee035f33d6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85ae675-56ca-4a00-83d2-ee035f33d6d1.jpg?1",
             "name": "Battle Frenzy",
             "text": "All green creatures you control get +1/+1 until end of turn. All non-green creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "e80acd3a-10b7-578c-93a5-f03706fc9419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e3d54-4dc4-482b-8ecc-bb819ba03d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e3d54-4dc4-482b-8ecc-bb819ba03d2c.jpg?1",
             "name": "Bone Shaman",
             "text": "oo\nB Any creature damaged by Bone Shaman this turn cannot regenerate until end of turn.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "c4024b1e-1077-55c7-87be-5ea88971ae61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceeb7bbc-2d41-4709-95be-1ceb952ed1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceeb7bbc-2d41-4709-95be-1ceb952ed1fb.jpg?1",
             "name": "Brand of Ill Omen",
             "text": "Cumulative Upkeep: o\nR\nTarget creature's controller cannot cast summon spells.",
             "colours": [
@@ -5737,7 +5737,7 @@
         },
         {
             "id": "a51f3f5a-6caa-54ca-9975-cb4a1c244271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee245922-b380-4b2e-a43f-ab1ba8078943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee245922-b380-4b2e-a43f-ab1ba8078943.jpg?1",
             "name": "Chaos Lord",
             "text": "First strike\nChaos Lord can attack the first turn it comes into play on a side, except the turn it first comes into play. During your upkeep, count the number of permanents. If that number is even, target opponent gains control of Chaos Lord.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "15d5e88f-005e-53c3-812a-370cd19354a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae0543f-7f8b-4327-b735-ac21244e9936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae0543f-7f8b-4327-b735-ac21244e9936.jpg?1",
             "name": "Chaos Moon",
             "text": "During each player's upkeep, count the number of permanents. If that number is odd, all red creatures get +1/+1 and mountains produce an additional o\nR when tapped for mana until end of turn. If the number is even, all red creatures get -1/-1 and mountains produce colorless mana instead of their normal mana until end of turn.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "0cb58851-b9b4-5003-8023-68b6d4ea033f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae610e66-7bcb-40ec-bed5-86dcfd098654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae610e66-7bcb-40ec-bed5-86dcfd098654.jpg?1",
             "name": "Conquer",
             "text": "Gain control of target land.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "981a54a8-d154-5dd3-bcef-6284aef39f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b381c1-aa71-4d40-a320-70f58a440d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b381c1-aa71-4d40-a320-70f58a440d51.jpg?1",
             "name": "Curse of Marit Lage",
             "text": "When Curse of Marit Lage comes into play, tap all islands. Islands do not untap during their controller's untap phase.",
             "colours": [
@@ -5865,7 +5865,7 @@
         },
         {
             "id": "4200b26a-57ab-5d05-ad06-a5d844e15bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d14a430-6e08-40cf-970a-cae84bba6ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d14a430-6e08-40cf-970a-cae84bba6ef7.jpg?1",
             "name": "Dwarven Armory",
             "text": "o2: Sacrifice a land to put a +2/+2 counter on target creature. Use this ability only during upkeep.",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "a9d37160-06f3-50d7-9009-c38d7d438881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8346e741-61f8-4283-be51-f5f80e9595a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8346e741-61f8-4283-be51-f5f80e9595a5.jpg?1",
             "name": "Errantry",
             "text": "Target creature gets +3/+0. If that creature attacks, no other creatures can attack this turn.",
             "colours": [
@@ -5929,7 +5929,7 @@
         },
         {
             "id": "45bff88e-be44-5094-81f6-87ab28d624b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add2b82a-9aa5-4d5c-a1c2-e313541f12c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add2b82a-9aa5-4d5c-a1c2-e313541f12c8.jpg?1",
             "name": "Flame Spirit",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "ef066205-82d0-5792-b9f0-3683ca0acd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5350236-7bd2-462d-9768-50087626c764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5350236-7bd2-462d-9768-50087626c764.jpg?1",
             "name": "Flare",
             "text": "Flare deals 1 damage to target creature or player. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "52bb1349-ef1e-5cf8-8962-eb33d1434628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08265332-2c0e-4c42-8c51-83ac20462eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08265332-2c0e-4c42-8c51-83ac20462eed.jpg?1",
             "name": "Game of Chaos",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, you gain 1 life and that opponent loses 1 life. Otherwise, you lose 1 life and the opponent gains 1 life. Effects that prevent or redirect damage cannot be used to counter this loss of life. The winner of each round decides whether to continue. Double the stakes in life each round.",
             "colours": [
@@ -6025,7 +6025,7 @@
         },
         {
             "id": "e4a23cc9-02f8-57e4-b9ae-3dec6e93d185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2726b192-f239-470b-8ad6-69887405e7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2726b192-f239-470b-8ad6-69887405e7f9.jpg?1",
             "name": "Glacial Crevasses",
             "text": "o0: Sacrifice a snow-covered mountain. No creatures deal damage in combat this turn.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "ea1753a9-bcb3-5291-bf51-9ddced017fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db54f95-6652-45a3-b960-c2fc118beca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db54f95-6652-45a3-b960-c2fc118beca1.jpg?1",
             "name": "Goblin Mutant",
             "text": "Trample\nCannot attack if defending player controls an untapped creature with power greater than 2. Cannot be assigned to block any creature with power greater than 2.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "b786ac3e-1f06-5010-92ff-83ed68b6e85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de839540-a7b9-4f91-91df-3fd4f5c0bc4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de839540-a7b9-4f91-91df-3fd4f5c0bc4e.jpg?1",
             "name": "Goblin Sappers",
             "text": "o\nRo\nR,oc\nT: Target creature you control cannot be blocked this turn. At end of combat, destroy that creature and Goblin Sappers.\no\nRo\nRo\nRo\nR,oc\nT: Target creature you control cannot be blocked this turn. At end of combat, destroy that creature.",
             "colours": [
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "88eba857-dab3-555b-80dc-3edb4f46aee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1c8b5-1e01-4920-8d02-bf80d5b238c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1c8b5-1e01-4920-8d02-bf80d5b238c5.jpg?1",
             "name": "Goblin Ski Patrol",
             "text": "o1oo\nR Flying and +2/+0. At end of turn, bury Goblin Ski Patrol. Use this ability only once and only if you control any snow-covered mountains.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "8dc1c5cc-f864-523c-9d52-214c3ed0ead8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb260a-6763-4d1c-a009-4e34cd572519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb260a-6763-4d1c-a009-4e34cd572519.jpg?1",
             "name": "Goblin Snowman",
             "text": "When blocking, Goblin Snowman neither deals nor receives damage in combat.\noc\nT: Goblin Snowman deals 1 damage to target creature it blocks.",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "6ccf4b79-7a50-5e37-b7f3-f9a15ff64ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bb17b9-55c4-4cc1-83f6-75490b9a97d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bb17b9-55c4-4cc1-83f6-75490b9a97d0.jpg?1",
             "name": "Grizzled Wolverine",
             "text": "oo\nR +2/+0 until end of turn. Use this ability only when a creature is assigned to block Grizzled Wolverine and only once each turn.",
             "colours": [
@@ -6222,7 +6222,7 @@
         },
         {
             "id": "74e608f5-bac6-5592-9441-15e48b58d145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca42b74-9b42-482b-b12a-79cafdcd087e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca42b74-9b42-482b-b12a-79cafdcd087e.jpg?1",
             "name": "Imposing Visage",
             "text": "Target creature cannot be blocked by only one creature.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "1b0f4d49-e6c3-59c3-8db3-464f3cc2f565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f00af-010d-4485-b8b7-47400d99c496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f00af-010d-4485-b8b7-47400d99c496.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. No creature damaged by Incinerate can regenerate this turn.",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "cd34ab68-3523-5b09-b81c-8d3bbca57d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf0d325-5928-4593-8faa-64ffa414cb48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf0d325-5928-4593-8faa-64ffa414cb48.jpg?1",
             "name": "Jokulhaups",
             "text": "Bury all artifacts, creatures, and lands.",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "0d92a072-c221-5e73-b5b2-737a0bd5a8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c524ac2a-294c-4b19-b00b-999e370a3b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c524ac2a-294c-4b19-b00b-999e370a3b95.jpg?1",
             "name": "Karplusan Giant",
             "text": "o0: Tap target snow-covered land you control to give Karplusan Giant +1/+1 until end of turn.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "a65ce270-da6b-514c-8643-e77869693c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9b214-d9fe-4c2e-b45b-7145ad98c408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9b214-d9fe-4c2e-b45b-7145ad98c408.jpg?1",
             "name": "Karplusan Yeti",
             "text": "oc\nT: Karplusan Yeti deals an amount of damage equal to its power to target creature. That creature deals an amount of damage equal to its power to Karplusan Yeti.",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "aa0886d5-c183-51d8-84f5-3e1887e015c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc0e20-5790-4927-8432-cf0e9b7381d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc0e20-5790-4927-8432-cf0e9b7381d4.jpg?1",
             "name": "Lava Burst",
             "text": "Lava Burst deals X damage to target creature or player. Effects that prevent or redirect damage cannot be used to protect that creature.",
             "colours": [
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "17e143c6-0bf6-508d-a49d-468565f7fa67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880e815-53e7-43e0-befd-e368f00a75d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880e815-53e7-43e0-befd-e368f00a75d8.jpg?1",
             "name": "M\u00e1rton Stromgald",
             "text": "If M\u00e1rton Stromgald attacks, all other attacking creatures get +*/+* until end of turn, where * is equal to the number of other attacking creatures. If M\u00e1rton blocks, all other blocking creatures get +*/+* until end of turn, where * is equal to the number of other blocking creatures.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "0b3ef975-9577-5338-ab19-04d33bfd4a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13a064d-bff4-4a48-a158-1b61951b0ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13a064d-bff4-4a48-a158-1b61951b0ac3.jpg?1",
             "name": "Melee",
             "text": "Cast only on your turn during combat before defense is chosen. Choose how attacking creatures you control are blocked; all defense must be legal. After declaring blocking, untap any unblocked attacking creature. Treat those creatures as though they had not attacked.",
             "colours": [
@@ -6481,7 +6481,7 @@
         },
         {
             "id": "668b773d-93e4-542f-bb6c-5ba373a9cb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90065e-2c7e-44e5-9f59-015d468214bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90065e-2c7e-44e5-9f59-015d468214bf.jpg?1",
             "name": "Melting",
             "text": "All snow-covered lands become non-snow-covered lands of the same type.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "6d0828a8-e6ce-552d-81da-8897b5a9fbdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4851e-677b-468e-9baa-e47a3b4b8339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4851e-677b-468e-9baa-e47a3b4b8339.jpg?1",
             "name": "Meteor Shower",
             "text": "Meteor Shower deals X+1 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "29388aa8-52fd-5c9c-a4cb-b1d7037dcdc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf70276-a40c-4d25-b584-4c8a07a00602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf70276-a40c-4d25-b584-4c8a07a00602.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk",
             "colours": [
@@ -6576,7 +6576,7 @@
         },
         {
             "id": "6fe2704f-7e37-52ed-a175-a078edd568cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65acce56-8674-471e-9d5e-91b7e3f672c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65acce56-8674-471e-9d5e-91b7e3f672c1.jpg?1",
             "name": "Mudslide",
             "text": "Creatures without flying do not untap during their controller's untap phase. At the end of his or her upkeep, each player may pay an additional o2 per creature to untap a creature without flying he or she controls.",
             "colours": [
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "2caf7b1c-a0d9-5653-b8d1-1e0d44db7380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4309a2f-27f5-4652-b0b4-6a6119436f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4309a2f-27f5-4652-b0b4-6a6119436f75.jpg?1",
             "name": "Orcish Cannoneers",
             "text": "oc\nT: Orcish Cannoneers deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -6641,7 +6641,7 @@
         },
         {
             "id": "39f92a5f-712d-5504-a376-973c56aedb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71394f8-3038-4cad-adea-a704f004777f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71394f8-3038-4cad-adea-a704f004777f.jpg?1",
             "name": "Orcish Conscripts",
             "text": "Cannot be declared as attacking unless at least two other creatures are also declared as attacking. Cannot be assigned to block unless at least two other creatures are also assigned to block.",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "4d9bfded-19f6-5499-8576-9ce12b9ff95f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa5beef-d609-4809-a813-621b0b4cff7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa5beef-d609-4809-a813-621b0b4cff7f.jpg?1",
             "name": "Orcish Farmer",
             "text": "oc\nT: Target land becomes a swamp until its controller's next untap phase.",
             "colours": [
@@ -6707,7 +6707,7 @@
         },
         {
             "id": "672f25f2-bcc7-50f1-bd43-a31459075bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff511f3-416e-4919-acd6-fd8183bf5c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff511f3-416e-4919-acd6-fd8183bf5c60.jpg?1",
             "name": "Orcish Healer",
             "text": "o\nRo\nR,oc\nT: Target creature cannot regenerate this turn.\no\nRo\nBo\nB,oc\nT: Regenerate target black or green creature.\no\nRo\nGo\nG,oc\nT: Regenerate target black or green creature.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "eed9cb1a-8aea-58f4-9a62-77df82800471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed908d6-6d06-4ccb-9577-37ef2d01c1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed908d6-6d06-4ccb-9577-37ef2d01c1a5.jpg?1",
             "name": "Orcish Librarian",
             "text": "o\nR,oc\nT: Take the top eight cards of your library; remove four of them at random from the game. Put the remaining four on top of your library in any order.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "c75c9fce-b455-5e80-8676-5764e18005ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ef13e3-658c-43a3-a290-4c5dde8e8b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ef13e3-658c-43a3-a290-4c5dde8e8b55.jpg?1",
             "name": "Orcish Lumberjack",
             "text": "oc\nT: Sacrifice a forest to add three mana in any combination of red and/or green to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "9ed2768c-b7b4-5a50-940f-b5b860237c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ee7bd5-612b-4916-a914-1294805b8f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ee7bd5-612b-4916-a914-1294805b8f64.jpg?1",
             "name": "Orcish Squatters",
             "text": "If Orcish Squatters attacks and is not blocked, you may gain control of target land controlled by defending player. If you do so, Orcish Squatters deals no damage in combat this turn. Lose control of that land if Orcish Squatters leaves play or if you lose control of Orcish Squatters.",
             "colours": [
@@ -6843,7 +6843,7 @@
         },
         {
             "id": "f52d4e53-e256-5993-938d-1e3493be8c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ab85ac-311c-4e36-943a-817e43a3c8a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ab85ac-311c-4e36-943a-817e43a3c8a8.jpg?1",
             "name": "Panic",
             "text": "Target creature cannot block this turn. Cast only during combat before defense is chosen. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "4640459b-f0f5-5118-93df-70f841fbdf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342cac5-08ae-4428-9c2c-f6c5904e54d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342cac5-08ae-4428-9c2c-f6c5904e54d2.jpg?1",
             "name": "Pyroblast",
             "text": "Counter target spell if it is blue or destroy target permanent if it is blue.",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "9236cd11-1292-524f-94a3-563507f2af9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040748-ad76-4b9a-bd4e-87e5980e9816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040748-ad76-4b9a-bd4e-87e5980e9816.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -6936,7 +6936,7 @@
         },
         {
             "id": "7c92629d-3649-520a-a5c1-d3e649e7cb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914c5a8-2114-41c5-a471-ca97524d622f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914c5a8-2114-41c5-a471-ca97524d622f.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "0b54482a-650f-5022-92bd-ee72a5de3ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb18d53-20de-43d7-86f7-97a6d14d54b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb18d53-20de-43d7-86f7-97a6d14d54b8.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "43463ae6-abd2-5dcb-af70-e52af0508be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a002e6d-ea59-4694-b3e5-075d6020b0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a002e6d-ea59-4694-b3e5-075d6020b0d9.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -7031,7 +7031,7 @@
         },
         {
             "id": "d69c7237-8d1e-560e-bff9-8a3015497e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789dfae7-fe23-4e2e-9f5f-304535d22a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789dfae7-fe23-4e2e-9f5f-304535d22a78.jpg?1",
             "name": "Stone Spirit",
             "text": "Cannot be blocked by creatures with flying.",
             "colours": [
@@ -7065,7 +7065,7 @@
         },
         {
             "id": "75e44e13-2e9c-5169-914c-ad1b7e3dd43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23fa1af-78e5-4d23-bbf6-cd62bc54b4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23fa1af-78e5-4d23-bbf6-cd62bc54b4e9.jpg?1",
             "name": "Stonehands",
             "text": "Target creature gets +0/+2.\no\nR: Creature Stonehands enchants gets +1/+0 until end of turn.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "82b30b8a-62a3-59dc-8c95-09e4852a2e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef8f279-1a10-4685-99d6-bc971a7f922b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef8f279-1a10-4685-99d6-bc971a7f922b.jpg?1",
             "name": "Tor Giant",
             "text": "",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "1ad34cbe-82ac-5d3c-9fa5-9d3054246d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6107388b-ec1e-401e-a407-a821c908ed8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6107388b-ec1e-401e-a407-a821c908ed8d.jpg?1",
             "name": "Total War",
             "text": "Whenever any player declares an attack, destroy all untapped non-wall creatures that player controls that don't attack. Do not destroy creatures the player did not control at the beginning of the turn.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "805eb62e-e48b-57a4-9a97-aeee11f226f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067e7af-7bbd-48c1-9f1d-df2a91a0ec54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067e7af-7bbd-48c1-9f1d-df2a91a0ec54.jpg?1",
             "name": "Vertigo",
             "text": "Vertigo deals 2 damage to target creature with flying; that creature loses flying until end of turn.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "f14837a2-aa63-557a-b201-2894760d8626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99d6d11-b3f7-4d73-967c-3049af82a9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99d6d11-b3f7-4d73-967c-3049af82a9d8.jpg?1",
             "name": "Wall of Lava",
             "text": "oo\nR +1/+1 until end of turn",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "2a091400-b7af-5ef3-9f43-98673abb76e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b383c8-d604-4131-a869-9e9d13e30b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b383c8-d604-4131-a869-9e9d13e30b94.jpg?1",
             "name": "Word of Blasting",
             "text": "Bury target wall. Word of Blasting deals an amount of damage equal to that wall's casting cost to the wall's controller.",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "d185fcb8-51ed-55f0-9926-3fded47c2960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e973a84-7f7d-4524-9f2f-ec9a014d52ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e973a84-7f7d-4524-9f2f-ec9a014d52ee.jpg?1",
             "name": "Aurochs",
             "text": "Trample\nWhen attacking, Aurochs gets +1/+0 for each other Aurochs that attacks.",
             "colours": [
@@ -7290,7 +7290,7 @@
         },
         {
             "id": "3e523230-9699-5657-82f2-a10d238f599e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5297cb-e763-4871-9cd3-0e2dbcc52095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5297cb-e763-4871-9cd3-0e2dbcc52095.jpg?1",
             "name": "Balduvian Bears",
             "text": "",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "5ff129c4-2bc1-52dd-8896-fb5cb88a8cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c369e4f9-0f2b-446c-9e2d-d3eefab0586d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c369e4f9-0f2b-446c-9e2d-d3eefab0586d.jpg?1",
             "name": "Blizzard",
             "text": "Cumulative Upkeep: o2\nYou cannot cast Blizzard if you control no snow-covered lands. Creatures with flying do not untap during their controller's untap phase.",
             "colours": [
@@ -7354,7 +7354,7 @@
         },
         {
             "id": "56918c03-a823-5835-89db-60fded342089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ce35b-ba65-451d-a5ed-e1db6f1d0c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ce35b-ba65-451d-a5ed-e1db6f1d0c6f.jpg?1",
             "name": "Brown Ouphe",
             "text": "o1o\nG,oc\nT: Counter target artifact ability requiring an activation cost. Play this ability as an interrupt.",
             "colours": [
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "97e48cb1-8d79-5e95-bd6f-6fa5329f292d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ebcc1d-0c5c-4bc2-ade7-41944f69162e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ebcc1d-0c5c-4bc2-ade7-41944f69162e.jpg?1",
             "name": "Chub Toad",
             "text": "Chub Toad gets +2/+2 until end of turn when blocking or blocked.",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "5f7fb126-7b22-5687-b627-77c32079ad6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602c93d-e00f-4b4f-a7ff-95316b7e7641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602c93d-e00f-4b4f-a7ff-95316b7e7641.jpg?1",
             "name": "Dire Wolves",
             "text": "Gains banding if you control any plains.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "4a1cc629-d7e4-50fd-a22e-3f5481ca7e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319d252e-7c43-47d6-8873-f69b0e063256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319d252e-7c43-47d6-8873-f69b0e063256.jpg?1",
             "name": "Earthlore",
             "text": "When Earthlore comes into play, choose target land you control.\no0: Tap land Earthlore enchants to give target blocking creature +1/+2 until end of turn.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "790b090e-ceef-58e3-9328-2c4acf459a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210f6fab-62f0-42ab-bd01-00d647bd25e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210f6fab-62f0-42ab-bd01-00d647bd25e7.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG,oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "9e9704cd-9311-56d0-84ee-6c88615c206d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b610103-dafd-4248-9d79-ce57f84b9e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b610103-dafd-4248-9d79-ce57f84b9e03.jpg?1",
             "name": "Essence Filter",
             "text": "Destroy all enchantments or destroy all non-white enchantments.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "ad0dffca-2613-5afa-af49-25fa03b9e1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abba7f1-5d07-4137-88a2-5967396a3e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abba7f1-5d07-4137-88a2-5967396a3e42.jpg?1",
             "name": "Fanatical Fever",
             "text": "Target creature gains trample and gets +3/+0 until end of turn.",
             "colours": [
@@ -7583,7 +7583,7 @@
         },
         {
             "id": "cd8dea58-8b3e-57c1-b388-fd4ace182366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13311d-db83-483f-ba2b-4f54ceb8b026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13311d-db83-483f-ba2b-4f54ceb8b026.jpg?1",
             "name": "Folk of the Pines",
             "text": "o1oo\nG +1/+0 until end of turn",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "91f5d46e-3382-5724-bd74-6cb8787f0b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc225cf-4fe2-4a5b-828e-ffcb99e404e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc225cf-4fe2-4a5b-828e-ffcb99e404e8.jpg?1",
             "name": "Forbidden Lore",
             "text": "When Forbidden Lore comes into play, choose target land.\no0: Tap land Forbidden Lore enchants to give target creature +2/+1 until end of turn.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "3d0d1d9a-bade-5d31-bf49-c797a58ed2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01dd39-a957-4c1a-86cf-f31a699a154a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01dd39-a957-4c1a-86cf-f31a699a154a.jpg?1",
             "name": "Forgotten Lore",
             "text": "Target opponent chooses target card from your graveyard. You may pay o\nG to have that opponent choose a new target that he or she has not already chosen. Put the last target card in your hand.",
             "colours": [
@@ -7680,7 +7680,7 @@
         },
         {
             "id": "dabe77dd-e762-505b-a952-8e2d0b352650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db9685-6a2f-4548-b6c4-669918d653b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db9685-6a2f-4548-b6c4-669918d653b4.jpg?1",
             "name": "Foxfire",
             "text": "Untap target attacking creature. That creature neither receives nor deals damage in combat this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "69abb5b4-ab80-5a3b-9672-4efd4adeb380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1e718a-882a-4bdc-9d62-4dda88da0ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1e718a-882a-4bdc-9d62-4dda88da0ba0.jpg?1",
             "name": "Freyalise Supplicant",
             "text": "oc\nT: Sacrifice a red or white creature to have Freyalise Supplicant deal an amount of damage equal to half the creature's power, rounded down, to target creature or player.",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "69c448ad-599e-5103-8281-c63b8b115b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e147ac1-d221-49c7-966e-5e665ddeab6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e147ac1-d221-49c7-966e-5e665ddeab6b.jpg?1",
             "name": "Freyalise's Charm",
             "text": "o\nGoo\nG When any opponent successfully casts a black spell, draw a card. Use this ability only once each time a black spell is cast.\no\nGoo\nG Return Freyalise's Charm to owner's hand.",
             "colours": [
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "20acbfce-2c8b-58d4-a2fe-cb1d36e8dd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11cd2e0-9419-4267-807e-5b73915c748a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11cd2e0-9419-4267-807e-5b73915c748a.jpg?1",
             "name": "Freyalise's Winds",
             "text": "Whenever a permanent becomes tapped, put a wind counter on it. Permanents with any wind counters on them do not untap during their controller's untap phase; instead, remove all wind counters from those permanents.",
             "colours": [
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "1b0a58fd-f196-5e29-ab55-7121bc2f98ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06204e82-9dfd-4334-a23a-f8240fc37772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06204e82-9dfd-4334-a23a-f8240fc37772.jpg?1",
             "name": "Fyndhorn Brownie",
             "text": "o2o\nG,oc\nT: Untap target creature.",
             "colours": [
@@ -7840,7 +7840,7 @@
         },
         {
             "id": "44119bef-1f16-5692-b4eb-301458525c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8aa11-f7cb-4f88-a041-30098579f1d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8aa11-f7cb-4f88-a041-30098579f1d2.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7874,7 +7874,7 @@
         },
         {
             "id": "eae94fdd-0349-5d88-aa4c-2a8e882e8610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba95ffa-990a-4013-98b7-5d8c0b34e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba95ffa-990a-4013-98b7-5d8c0b34e9c4.jpg?1",
             "name": "Fyndhorn Elves",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "44a9d80c-b272-5e50-b928-626e14474d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efbe59d-bebc-40b1-85ac-2e4c1ff3731e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efbe59d-bebc-40b1-85ac-2e4c1ff3731e.jpg?1",
             "name": "Fyndhorn Pollen",
             "text": "Cumulative Upkeep: o1\nAll creatures get -1/-0.\no1o\nG: All creatures get -1/-0 until end of turn.",
             "colours": [
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "4d8015a0-c296-5e32-927b-9e07a7a957fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431c9749-fd7b-4960-a910-8d41d3704e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431c9749-fd7b-4960-a910-8d41d3704e6c.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7970,7 +7970,7 @@
         },
         {
             "id": "91da4fba-6574-53ee-b422-e094192c45c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046f6b76-5f17-4728-aa34-72b7eff1d4c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046f6b76-5f17-4728-aa34-72b7eff1d4c9.jpg?1",
             "name": "Gorilla Pack",
             "text": "Gorilla Pack cannot attack if defending player controls no forests. Bury Gorilla Pack if you control no forests.",
             "colours": [
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "320bf49e-17a6-5b77-8c93-7bb4376009d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4fe072-81a7-424e-8d21-aaca010d5b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4fe072-81a7-424e-8d21-aaca010d5b1d.jpg?1",
             "name": "Hot Springs",
             "text": "When Hot Springs comes into play, choose target land you control.\no0: Tap land Hot Springs enchants to prevent 1 damage to any creature or player.",
             "colours": [
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "fe7bedb9-6459-5107-b45e-61bc06fd4d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cc6db7-1f40-40e3-a7ea-92f1d05e2e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cc6db7-1f40-40e3-a7ea-92f1d05e2e3d.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "a60bac10-d818-501b-b366-106b7868c005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a22e88-f7b1-48c8-a199-e57edcd50654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a22e88-f7b1-48c8-a199-e57edcd50654.jpg?1",
             "name": "Johtull Wurm",
             "text": "For each blocking creature assigned to Johtull Worm beyond the first, Johtull Worm gets -2/-1 until end of turn.",
             "colours": [
@@ -8100,7 +8100,7 @@
         },
         {
             "id": "f15efc3c-0727-5037-87b8-16f6f5647ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb211704-ff8e-498b-b7bb-f8384f198ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb211704-ff8e-498b-b7bb-f8384f198ffd.jpg?1",
             "name": "Juniper Order Druid",
             "text": "oc\nT: Untap target land. Play this ability as an interrupt.",
             "colours": [
@@ -8135,7 +8135,7 @@
         },
         {
             "id": "8c4715a2-b4bd-5043-9af2-168535e9e498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee6d385-d44b-4f1a-beb1-13aeebde063e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee6d385-d44b-4f1a-beb1-13aeebde063e.jpg?1",
             "name": "Lhurgoyf",
             "text": "Lhurgoyf has power equal to the total number of creatures in all graveyards and toughness equal to 1 plus the total number of creatures in all graveyards.",
             "colours": [
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "d5868753-b721-5ba0-9226-f06f4901ab4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87af69ee-c2bb-46ea-8d36-d484d04a3c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87af69ee-c2bb-46ea-8d36-d484d04a3c8a.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. Lure does not prevent a creature from blocking more than one creature if blocker has that ability. If blocker is forced to block more creatures than it is allowed to, defender chooses which of these creatures to block, but must block as many creatures as allowed.",
             "colours": [
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "fa4db3bd-ed29-57b3-be92-5151f3b385c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277656c-70f5-4660-bd58-7d9261d53fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277656c-70f5-4660-bd58-7d9261d53fb5.jpg?1",
             "name": "Maddening Wind",
             "text": "Cumulative Upkeep: o\nG\nDuring target creature's controller's upkeep, Maddening Wind deals 2 damage to that player.",
             "colours": [
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "09ff3dd6-0cf6-5a26-aada-bea1567a2603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668d2969-b6b7-4507-bdd4-20bbaa68035a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668d2969-b6b7-4507-bdd4-20bbaa68035a.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for any forest and put it directly into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards.",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "445260c1-85c5-5417-9554-1d8a31cc48b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg?1",
             "name": "Pale Bears",
             "text": "Islandwalk",
             "colours": [
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "c95df579-4d1b-5de1-80b7-4a589808bf4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg?1",
             "name": "Pygmy Allosaurus",
             "text": "Swampwalk",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "6758456f-642c-5e7a-a4d0-b67a07b51844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffc64e4-ae3c-49f9-8ed6-518dd497bfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffc64e4-ae3c-49f9-8ed6-518dd497bfe6.jpg?1",
             "name": "Pyknite",
             "text": "Draw a card at the beginning of the upkeep of the turn after Pyknite comes into play.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "5d54b40e-25f8-5ef9-84d1-58a7797c4b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dacfaec-6b61-450d-a134-2087c38a298a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dacfaec-6b61-450d-a134-2087c38a298a.jpg?1",
             "name": "Regeneration",
             "text": "When Regeneration comes into play, choose target creature.\noo\nG Regenerate creature Regeneration enchants.",
             "colours": [
@@ -8397,7 +8397,7 @@
         },
         {
             "id": "e72c2777-c999-5b05-ad55-c42a839a663f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93e6ce-1295-41f8-b454-2dfe321481a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93e6ce-1295-41f8-b454-2dfe321481a6.jpg?1",
             "name": "Rime Dryad",
             "text": "Snow-covered forestwalk",
             "colours": [
@@ -8430,7 +8430,7 @@
         },
         {
             "id": "dc35b53c-0cdb-5d89-ae3e-26a8bd4df6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5c01e7-8116-45fc-afc3-d52a31a635cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5c01e7-8116-45fc-afc3-d52a31a635cb.jpg?1",
             "name": "Ritual of Subdual",
             "text": "Cumulative Upkeep: o2\nAll mana-producing lands produce colorless mana instead of their normal mana.",
             "colours": [
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "57802a82-d97e-5ad6-8ed3-7e4d4fdf0250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cd7fa-c86c-4a5f-b36d-8160e8a6af1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cd7fa-c86c-4a5f-b36d-8160e8a6af1f.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "f26d2597-8c83-5711-b8dd-7d402d3a8ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8886ba2d-b25a-4b74-9299-911c509ae864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8886ba2d-b25a-4b74-9299-911c509ae864.jpg?1",
             "name": "Shambling Strider",
             "text": "o\nRoo\nG +1/-1 until end of turn",
             "colours": [
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "57ae69f9-f643-5ab0-a0cd-87478b50c0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f62c376-487a-42bc-bd85-ab8b0480f7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f62c376-487a-42bc-bd85-ab8b0480f7dc.jpg?1",
             "name": "Snowblind",
             "text": "Target creature gets -*/-*. When that creature attacks, * is equal to the number of snow-covered lands defending player controls. At other times, * is equal to the number of snow-covered lands its controller controls. If this reduces the creature's toughness to less than 1, the creature's toughness is 1.",
             "colours": [
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "3637f9ef-9692-5c9c-b012-8d9846078923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8265a1-4621-4d25-8f7f-f0179951a694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8265a1-4621-4d25-8f7f-f0179951a694.jpg?1",
             "name": "Stampede",
             "text": "All attacking creatures gain trample and get +1/+0 until end of turn.",
             "colours": [
@@ -8592,7 +8592,7 @@
         },
         {
             "id": "2b21c9c4-4115-5be0-9166-3fcfd2d68ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9b7393-eb35-4c99-bbf5-bcf924aa8ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9b7393-eb35-4c99-bbf5-bcf924aa8ff3.jpg?1",
             "name": "Stunted Growth",
             "text": "Target player chooses three cards from his or her hand and puts them on top of his or her library in any order. If that player does not have enough cards in hand, his or her entire hand is put on top of his or her library in any order.",
             "colours": [
@@ -8623,7 +8623,7 @@
         },
         {
             "id": "1c211aac-f76a-5b3b-b1e7-7c5d5d1f1e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1420ec5-367c-4514-86c5-3993bf339e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1420ec5-367c-4514-86c5-3993bf339e37.jpg?1",
             "name": "Tarpan",
             "text": "If Tarpan is put into the graveyard from play, gain 1 life.",
             "colours": [
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "fdbab131-b8f8-5a92-ab66-e55f708b19ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ae906b-2c4d-48e9-9f2d-217777e22292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ae906b-2c4d-48e9-9f2d-217777e22292.jpg?1",
             "name": "Thermokarst",
             "text": "Destroy target land. If that land is a snow-covered land, gain 1 life.",
             "colours": [
@@ -8687,7 +8687,7 @@
         },
         {
             "id": "fb4759c4-18c5-5a14-bb54-fff7d3350a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe7f9d-644f-48d0-93fa-d9a536f1f755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe7f9d-644f-48d0-93fa-d9a536f1f755.jpg?1",
             "name": "Thoughtleech",
             "text": "Whenever an island controlled by target opponent becomes tapped, gain 1 life.",
             "colours": [
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "0f2bebf5-e2a8-560e-8820-f7b37405cece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7c6489-21e9-4b86-a54a-b1e2f1fce318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7c6489-21e9-4b86-a54a-b1e2f1fce318.jpg?1",
             "name": "Tinder Wall",
             "text": "o0: Sacrifice Tinder Wall to add o\nRo\nR to your mana pool. Play this ability as an interrupt.\noo\nR Sacrifice Tinder Wall to have it deal 2 damage to target creature it blocks.",
             "colours": [
@@ -8753,7 +8753,7 @@
         },
         {
             "id": "f2986bfe-9c4e-5974-8364-7ee38e4d98ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d2cd18-a24d-40e0-a654-777d9e623ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d2cd18-a24d-40e0-a654-777d9e623ae2.jpg?1",
             "name": "Touch of Vitae",
             "text": "Target creature may untap one additional time this turn. That creature may attack or use abilities that require oc\nT as part of the activation cost this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "19bc52d1-8c69-5626-97b7-9582b498bfbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg?1",
             "name": "Trailblazer",
             "text": "Target creature cannot be blocked this turn.",
             "colours": [
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "00378fdb-e65f-5279-8b34-c0d03bce6c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eeb9e02-1d26-4959-a878-2ef8db2358bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eeb9e02-1d26-4959-a878-2ef8db2358bc.jpg?1",
             "name": "Venomous Breath",
             "text": "At end of combat, destroy all creatures blocking or blocked by target creature this turn.",
             "colours": [
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "a60de631-485b-56d1-9ae8-c375df9ff2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d879923-55fc-46ab-9306-5e1f10441c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d879923-55fc-46ab-9306-5e1f10441c89.jpg?1",
             "name": "Wall of Pine Needles",
             "text": "oo\nG Regenerate",
             "colours": [
@@ -8880,7 +8880,7 @@
         },
         {
             "id": "1af1d448-1b0d-53cb-9ccd-570f193fae16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8645e4f-eaa8-4420-a6a3-eb53c311fab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8645e4f-eaa8-4420-a6a3-eb53c311fab1.jpg?1",
             "name": "Whiteout",
             "text": "All creatures with flying lose flying until end of turn.\nIf Whiteout is in your graveyard, you may sacrifice a snow-covered land to return Whiteout to your hand.",
             "colours": [
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "5aa56110-912b-5b71-8d5a-c7c3c49307cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee86bf2-6c54-4c6e-8394-eb39f98d5a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee86bf2-6c54-4c6e-8394-eb39f98d5a85.jpg?1",
             "name": "Wiitigo",
             "text": "When Wiitigo comes into play, put six +1/+1 counters on it.\nDuring your upkeep, put a +1/+1 counter on Wiitigo if it has blocked or been blocked since your last upkeep. Otherwise, remove a +1/+1 counter from Wiitigo. Ignore this effect if there are no counters left on Wiitigo.",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "45e2c20e-c9b2-54ab-9979-e0c43236ff5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8047ab9-a0fc-4933-bcbc-e761aa0f622b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8047ab9-a0fc-4933-bcbc-e761aa0f622b.jpg?1",
             "name": "Wild Growth",
             "text": "Wild Growth adds o\nG to your mana pool whenever target land is tapped for mana.",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "cca2682d-06b8-5df7-99d9-44872ba7e0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca1216-99c8-4ad5-a51a-3c4ff3b82097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca1216-99c8-4ad5-a51a-3c4ff3b82097.jpg?1",
             "name": "Woolly Mammoths",
             "text": "Gains trample as long as you control any snow-covered lands.",
             "colours": [
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "79dd7339-911b-540e-a72a-a15546e3eac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10520b2-b5a7-4328-84c8-20443b6f588a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10520b2-b5a7-4328-84c8-20443b6f588a.jpg?1",
             "name": "Woolly Spider",
             "text": "Can block creatures with flying.\nIf Woolly Spider is assigned to block a creature with flying, Woolly Spider gets +0/+2 until end of turn.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "931e96ac-74b4-50c7-b9c5-f6dd6b6fc770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8b7020-ca8f-4867-bc51-13d824daf154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8b7020-ca8f-4867-bc51-13d824daf154.jpg?1",
             "name": "Yavimaya Gnats",
             "text": "Flying\noo\nG Regenerate",
             "colours": [
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "2bc9f88e-bcae-5d1a-ab86-4fbfa3cee2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5b014-8675-4d91-a539-ac5c31d44b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5b014-8675-4d91-a539-ac5c31d44b35.jpg?1",
             "name": "Altar of Bone",
             "text": "Sacrifice a creature to look through your library for a creature card; put that card into your hand after showing it to all other players. Reshuffle your library afterwards.",
             "colours": [
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "7c96948b-b232-5e32-850f-ee21b074f10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e275c295-72da-4a86-82c6-cfd75b38b19c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e275c295-72da-4a86-82c6-cfd75b38b19c.jpg?1",
             "name": "Centaur Archer",
             "text": "oc\nT: Centaur Archer deals 1 damage to target creature with flying.",
             "colours": [
@@ -9145,7 +9145,7 @@
         },
         {
             "id": "f0df0044-1348-5649-92fe-c8cbd216d49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2657e85b-8f77-41fa-9df2-233443efef43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2657e85b-8f77-41fa-9df2-233443efef43.jpg?1",
             "name": "Chromatic Armor",
             "text": "When Chromatic Armor comes into play, put a sleight counter on it and choose a color. Any damage dealt to target creature by a source of that color is reduced to 0.\noo\nX Put a sleight counter on Chromatic Armor and change the color that it protects against. X is equal to the number of sleight counters on Chromatic Armor.",
             "colours": [
@@ -9180,7 +9180,7 @@
         },
         {
             "id": "5a371d02-c58d-538c-a01b-45ae934909cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea01324-1cfb-498c-8299-f690373864bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea01324-1cfb-498c-8299-f690373864bd.jpg?1",
             "name": "Diabolic Vision",
             "text": "Look at the top five cards of your library and put one of them into your hand. Put the remaining four on top of your library in any order.",
             "colours": [
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "87ec80cf-db55-55a0-b9d9-549345b061b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83cb1c4-7c5b-4a5e-b15e-138d644f5cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83cb1c4-7c5b-4a5e-b15e-138d644f5cdb.jpg?1",
             "name": "Earthlink",
             "text": "During your upkeep, pay o2 or bury Earthlink.\nWhenever a creature is put into the graveyard from play, that creature's controller sacrifices a land. Ignore this effect if that player controls no lands.",
             "colours": [
@@ -9248,7 +9248,7 @@
         },
         {
             "id": "3a6b07fe-188a-576b-8d50-24a7b8902d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbff2a-5109-400a-961b-eacffb9aed67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbff2a-5109-400a-961b-eacffb9aed67.jpg?1",
             "name": "Elemental Augury",
             "text": "o3: Look at the top three cards of target player's library. Put them on the top of that player's library in any order.",
             "colours": [
@@ -9283,7 +9283,7 @@
         },
         {
             "id": "28782c7c-b868-5d54-a9dc-fe44a528ecb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe07e496-5070-4116-a91a-a3bbe19c12af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe07e496-5070-4116-a91a-a3bbe19c12af.jpg?1",
             "name": "Essence Vortex",
             "text": "Bury target creature. That creature's controller may counter this spell by paying the creature's toughness in life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -9316,7 +9316,7 @@
         },
         {
             "id": "78dd7139-236e-5770-a45e-aa0723ded776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965ce61-0522-4f77-a82d-89441d1ba867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965ce61-0522-4f77-a82d-89441d1ba867.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided any way you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
             "colours": [
@@ -9351,7 +9351,7 @@
         },
         {
             "id": "8dc3762d-d641-5cd8-8d25-413f2d5a557c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0139c2-ad86-4c71-ab6d-4840c37d5d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0139c2-ad86-4c71-ab6d-4840c37d5d20.jpg?1",
             "name": "Fire Covenant",
             "text": "Fire Covenant deals X damage, divided any way you choose among any number of target creatures, where X is equal to the amount of life you pay. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -9384,7 +9384,7 @@
         },
         {
             "id": "eab6520c-0923-5850-aa83-473f9a15464d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de89e9e1-485b-42e5-9728-5d6f948999e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de89e9e1-485b-42e5-9728-5d6f948999e1.jpg?1",
             "name": "Flooded Woodlands",
             "text": "No green creature can attack unless its controller sacrifices a land whenever that creature attacks.",
             "colours": [
@@ -9417,7 +9417,7 @@
         },
         {
             "id": "6435102d-1b91-56ff-8007-50d200fd99b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa53e9a-0d7c-4d17-b2be-56930edfa2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa53e9a-0d7c-4d17-b2be-56930edfa2c2.jpg?1",
             "name": "Fumarole",
             "text": "Pay 3 life to destroy target creature and target land. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -9450,7 +9450,7 @@
         },
         {
             "id": "dd19f61b-0c2a-56bf-afb4-fa7888f19d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6314344b-6493-4142-9c76-da9b90b8d3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6314344b-6493-4142-9c76-da9b90b8d3e1.jpg?1",
             "name": "Ghostly Flame",
             "text": "Both black and red permanents and spells are considered colorless sources of damage.",
             "colours": [
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "da208fa7-3acb-5bc1-adf2-b06087476a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965dfa8-dc90-4cf2-a93b-72bf88b58936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965dfa8-dc90-4cf2-a93b-72bf88b58936.jpg?1",
             "name": "Giant Trap Door Spider",
             "text": "o1o\nRo\nG,oc\nT: Remove from the game target creature, which doesn't have flying and is attacking you, and Giant Trap Door Spider.",
             "colours": [
@@ -9518,7 +9518,7 @@
         },
         {
             "id": "c4bf7eb8-e087-5889-95b6-1f544d05436e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86e159b-ecf1-4b4a-9041-4e97fdf935e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86e159b-ecf1-4b4a-9041-4e97fdf935e5.jpg?1",
             "name": "Glaciers",
             "text": "During your upkeep, pay o\nWo\nU or destroy Glaciers. All mountains become plains.",
             "colours": [
@@ -9551,7 +9551,7 @@
         },
         {
             "id": "39f364b0-c0a9-5b77-bb88-f7f26cb12fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d0f2f2-f6e2-4b8a-8418-10b17c5e0ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d0f2f2-f6e2-4b8a-8418-10b17c5e0ea9.jpg?1",
             "name": "Hymn of Rebirth",
             "text": "Take target creature from any graveyard and put it directly into play under your control as though it were just summoned.",
             "colours": [
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "87ed46bc-25c4-5a38-94b2-523b59b78b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fccb1d0-b324-4780-bb9e-4533240da06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fccb1d0-b324-4780-bb9e-4533240da06d.jpg?1",
             "name": "Kjeldoran Frostbeast",
             "text": "At end of combat, destroy all creatures blocking or blocked by Kjeldoran Frostbeast.",
             "colours": [
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "d6b51e69-9891-578e-bb2d-0c02bcbc54cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf47c0a-5c17-47d0-b663-becff62fbdf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf47c0a-5c17-47d0-b663-becff62fbdf8.jpg?1",
             "name": "Merieke Ri Berit",
             "text": "Does not untap during your untap phase.\noc\nT: Gain control of target creature. Lose control of that creature if you lose control of Merieke Ri Berit. If Merieke Ri Berit leaves play or becomes untapped, bury the creature.",
             "colours": [
@@ -9659,7 +9659,7 @@
         },
         {
             "id": "b517df89-a133-5999-8a0b-ea8fe0a3baee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fcc50-79a5-40cd-b028-e78dde3f8480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fcc50-79a5-40cd-b028-e78dde3f8480.jpg?1",
             "name": "Monsoon",
             "text": "Whenever any island is untapped at the end of its controller's turn, tap it; Monsoon deals 1 damage to that player.",
             "colours": [
@@ -9692,7 +9692,7 @@
         },
         {
             "id": "82a9e176-d9f4-51df-8712-02e07d17c2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1d589-02a2-4896-a283-9d0385534667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1d589-02a2-4896-a283-9d0385534667.jpg?1",
             "name": "Mountain Titan",
             "text": "o1o\nRoo\nR For the rest of the turn, put a +1/+1 counter on Mountain Titan whenever you successfully cast a black spell.",
             "colours": [
@@ -9727,7 +9727,7 @@
         },
         {
             "id": "befdd0c7-f240-5cb4-af67-204833c90698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca335f4f-d345-4eb9-9bc6-74595c501078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca335f4f-d345-4eb9-9bc6-74595c501078.jpg?1",
             "name": "Reclamation",
             "text": "No black creature can attack unless its controller sacrifices a land whenever that creature attacks.",
             "colours": [
@@ -9760,7 +9760,7 @@
         },
         {
             "id": "1ce305d1-f51b-5754-bd6a-2e5ad2102565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271c8a7c-0f71-4f9d-ab0e-ca7c8c4aca50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271c8a7c-0f71-4f9d-ab0e-ca7c8c4aca50.jpg?1",
             "name": "Skeleton Ship",
             "text": "If at any time you control no islands, bury Skeleton Ship.\noc\nT: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -9797,7 +9797,7 @@
         },
         {
             "id": "0caafc44-08a9-586f-acca-b8e639b74c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe0a783-d086-4dc8-ae4a-59f3c2daaca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe0a783-d086-4dc8-ae4a-59f3c2daaca0.jpg?1",
             "name": "Spectral Shield",
             "text": "Target creature gets +0/+2. That creature cannot be the target of further spells.",
             "colours": [
@@ -9832,7 +9832,7 @@
         },
         {
             "id": "156ac927-52cd-51cb-a34b-da1c26d22c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a383a5f-4814-4b92-aa80-2a6440a719bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a383a5f-4814-4b92-aa80-2a6440a719bc.jpg?1",
             "name": "Storm Spirit",
             "text": "Flying\noc\nT: Storm Spirit deals 2 damage to target creature.",
             "colours": [
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "54cb2bcb-bd46-51e3-8464-c5b45c506eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5d91b-aeb4-4d7e-b748-77f9960da55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5d91b-aeb4-4d7e-b748-77f9960da55f.jpg?1",
             "name": "Stormbind",
             "text": "o2: Discard a card at random from your hand to have Stormbind deal 2 damage to target creature or player.",
             "colours": [
@@ -9903,7 +9903,7 @@
         },
         {
             "id": "3a32e591-282a-5a68-9d0c-b329d68863ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb0282d-ccec-4556-8b70-b6f665077afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb0282d-ccec-4556-8b70-b6f665077afe.jpg?1",
             "name": "Wings of Aesthir",
             "text": "Target creature gains flying and first strike and gets +1/+0.",
             "colours": [
@@ -9938,7 +9938,7 @@
         },
         {
             "id": "016d3929-b1f9-5716-9712-162cf635ea58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff62754b-f4f0-4731-8dd7-327a820f60a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff62754b-f4f0-4731-8dd7-327a820f60a8.jpg?1",
             "name": "Adarkar Sentinel",
             "text": "o1: +0/+1 until end of turn",
             "colours": [],
@@ -9968,7 +9968,7 @@
         },
         {
             "id": "ce9127eb-27e2-5f18-b2c0-c02fdc93c46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d272051-f442-4f6e-8c64-df28b398d2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d272051-f442-4f6e-8c64-df28b398d2e8.jpg?1",
             "name": "Aegis of the Meek",
             "text": "o1,oc\nT: Target 1/1 creature gets +1/+2 until end of turn.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "32ad8104-985a-5247-a789-eb46dbe8d177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764ec6a8-a878-446c-b7e4-6026c2a3e9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764ec6a8-a878-446c-b7e4-6026c2a3e9a4.jpg?1",
             "name": "Amulet of Quoz",
             "text": "Remove Amulet of Quoz from your deck before playing if you are not playing for ante.\no0,oc\nT: Sacrifice Amulet of Quoz. Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, that opponent loses the game. Otherwise, you lose the game.\nEffects that prevent or redirect damage cannot be used to prevent this loss of life. Use this ability only during your upkeep. The opponent may ante an additional card to counter this effect.",
             "colours": [],
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "8a0ef859-3471-5aa6-b3da-78597b8ba0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9780ce2-756c-48e5-9936-45f6a224f61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9780ce2-756c-48e5-9936-45f6a224f61d.jpg?1",
             "name": "Arcum's Sleigh",
             "text": "o2,oc\nT: Attacking this turn does not cause target creature to tap. You cannot use this ability if defending player controls no snow-covered lands.",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "be34f080-b656-5a02-b01a-947a6623cc7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e142435-6930-4596-bc3b-60abde1229df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e142435-6930-4596-bc3b-60abde1229df.jpg?1",
             "name": "Arcum's Weathervane",
             "text": "o2,oc\nT: Target snow-covered land becomes a non-snow-covered land of the same type. Mark the changed land with a counter.\no2,oc\nT: Target non-snow-covered basic land becomes a snow-covered land of the same type. Mark the changed land with a counter.",
             "colours": [],
@@ -10076,7 +10076,7 @@
         },
         {
             "id": "ba982969-c132-5828-ae20-b146d3b99657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c07c87-0e44-4a5a-92b7-728350cd02de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c07c87-0e44-4a5a-92b7-728350cd02de.jpg?1",
             "name": "Arcum's Whistle",
             "text": "o3,oc\nT: Target non-wall creature must attack. At end of turn, destroy that creature if it could not attack. Use this ability only during the creature's controller's turn before the attack. The creature's controller may counter this effect by paying X, where X is equal to the creature's casting cost. Arcum's Whistle does not affect creatures brought under their controller's control this turn.",
             "colours": [],
@@ -10103,7 +10103,7 @@
         },
         {
             "id": "5f89d18d-829f-58b3-b999-36bb3f0461e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb82654-de12-4dce-8c6b-f28d68f0fbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb82654-de12-4dce-8c6b-f28d68f0fbe1.jpg?1",
             "name": "Barbed Sextant",
             "text": "o1,oc\nT: Sacrifice Barbed Sextant to add one mana of any color to your mana pool. Play this ability as an interrupt. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -10130,7 +10130,7 @@
         },
         {
             "id": "1ca7fad9-6a44-5d49-958f-84d890ab436d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc29872-b1a2-4851-9eca-f3e67ae6e14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc29872-b1a2-4851-9eca-f3e67ae6e14c.jpg?1",
             "name": "Baton of Morale",
             "text": "o2: Target creature gains banding until end of turn.",
             "colours": [],
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "8e4f7daa-f3d0-5fcc-9f06-f3c53b622ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc0e8d3-633b-4281-863f-c51c69eed0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc0e8d3-633b-4281-863f-c51c69eed0b6.jpg?1",
             "name": "Celestial Sword",
             "text": "o3,oc\nT: Target creature you control gets +3/+3 until end of turn. At end of turn, bury that creature.",
             "colours": [],
@@ -10184,7 +10184,7 @@
         },
         {
             "id": "b117b005-7430-5188-be8d-e0b09ce75954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce2991f-48e1-4cfe-af0a-18b6d9400493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce2991f-48e1-4cfe-af0a-18b6d9400493.jpg?1",
             "name": "Crown of the Ages",
             "text": "o4,oc\nT: Switch target enchantment from one creature to another; the enchantment's new target must be legal. The controller of the enchantment does not change. Treat the enchantment as though it were just cast on the new target.",
             "colours": [],
@@ -10211,7 +10211,7 @@
         },
         {
             "id": "54598ef4-511b-5448-a616-492943730780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e381a4-810e-4b75-aed3-c16cf0eb06fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e381a4-810e-4b75-aed3-c16cf0eb06fa.jpg?1",
             "name": "Despotic Scepter",
             "text": "oc\nT: Bury target permanent you own.",
             "colours": [],
@@ -10238,7 +10238,7 @@
         },
         {
             "id": "5d47742d-d305-51a8-9a17-7b3277da382c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49301c19-55a0-4146-9474-0b86cd320e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49301c19-55a0-4146-9474-0b86cd320e31.jpg?1",
             "name": "Elkin Bottle",
             "text": "o3,oc\nT: Take the top card from your library and place it face up in front of you. You may play that card as though it were in your hand; if you do not play it by your next upkeep, remove it from the game.",
             "colours": [],
@@ -10265,7 +10265,7 @@
         },
         {
             "id": "bccdfc31-1eb0-5b82-8b45-d1eed4529c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd0a41-cc51-4728-b597-fdb2510accd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd0a41-cc51-4728-b597-fdb2510accd8.jpg?1",
             "name": "Fyndhorn Bow",
             "text": "o3,oc\nT: Target creature gains first strike until end of turn.",
             "colours": [],
@@ -10292,7 +10292,7 @@
         },
         {
             "id": "6ee07778-0366-5daf-bdb5-568509250b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951114fb-5ae5-4eb0-8e03-6e39b0b634b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951114fb-5ae5-4eb0-8e03-6e39b0b634b5.jpg?1",
             "name": "Goblin Lyre",
             "text": "o0: Sacrifice Goblin Lyre. Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, Goblin Lyre deals * damage to that opponent, where * is equal to the number of creatures you control. Otherwise, Goblin Lyre deals * damage to you, where * is equal to the number of creatures the opponent controls.",
             "colours": [],
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "49613970-d3fe-5607-8416-9b2e2a2c109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83585337-56a9-44d2-9ed1-8a959bcfb010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83585337-56a9-44d2-9ed1-8a959bcfb010.jpg?1",
             "name": "Hematite Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a red spell is successfully cast and only once for each red spell cast.",
             "colours": [],
@@ -10346,7 +10346,7 @@
         },
         {
             "id": "8ccae383-15b4-5c93-9f75-af5506e61e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3e095a-7056-4df3-bf7d-9c217d591446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3e095a-7056-4df3-bf7d-9c217d591446.jpg?1",
             "name": "Ice Cauldron",
             "text": "X,oc\nT: Put a charge counter on Ice Cauldron, and put a spell card face up on Ice Cauldron. Note the type and amount of mana used to pay this activation cost. Use this ability only if there are no charge counters on Ice Cauldron. You may play that spell card as though it were in your hand.\noc\nT: Remove the charge counter from Ice Cauldron to add mana of the type and amount last used to put a charge counter on Ice Cauldron to your mana pool. This mana is usable only to cast the spell on top of Ice Cauldron.",
             "colours": [],
@@ -10373,7 +10373,7 @@
         },
         {
             "id": "ef5664d7-4d0f-5764-9c67-36aa368a1ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eda936f-7691-4440-9b83-eb0c6035b109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eda936f-7691-4440-9b83-eb0c6035b109.jpg?1",
             "name": "Icy Manipulator",
             "text": "o1,oc\nT: Tap target artifact, creature, or land.",
             "colours": [],
@@ -10400,7 +10400,7 @@
         },
         {
             "id": "0329458a-a2cf-5daf-8468-6a92baae32b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a42152-32c0-47ff-aaac-8deaf01873ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a42152-32c0-47ff-aaac-8deaf01873ca.jpg?1",
             "name": "Infinite Hourglass",
             "text": "During your upkeep, put a time counter on Infinite Hourglass. During any upkeep, any player may pay o3 to remove a time counter from Infinite Hourglass. All creatures get +1/+0 for each time counter on Infinite Hourglass.",
             "colours": [],
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "d8498c13-56b6-5e60-a74d-4a8b4ec839b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ac44d0-8090-4e7b-ac47-c567294f185e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ac44d0-8090-4e7b-ac47-c567294f185e.jpg?1",
             "name": "Jester's Cap",
             "text": "o2,oc\nT: Sacrifice Jester's Cap to look through target player's library and remove any three of those cards from the game. Reshuffle that library afterwards.",
             "colours": [],
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "509f7e05-1222-5932-9457-448808d12384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1ba0c-cb89-4bb2-8a35-6a4a4eecccf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1ba0c-cb89-4bb2-8a35-6a4a4eecccf7.jpg?1",
             "name": "Jester's Mask",
             "text": "Comes into play tapped.\no1,oc\nT: Sacrifice Jester's Mask to look through target opponent's hand and library. Give that player a new hand of as many cards as he or she had before. Reshuffle the remaining cards afterwards.",
             "colours": [],
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "4bbd7dce-304d-541e-93ff-cd36336428d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f7bad2-d28f-42d2-9246-fe3545ef49a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f7bad2-d28f-42d2-9246-fe3545ef49a7.jpg?1",
             "name": "Jeweled Amulet",
             "text": "o1,oc\nT: Put a charge counter on Jeweled Amulet. Note what type of mana was used to pay this activation cost. Use this ability only if there are no charge counters on Jeweled Amulet.\noc\nT: Remove the charge counter from Jeweled Amulet to add one mana of the type last used to put a charge counter on Jeweled Amulet to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -10508,7 +10508,7 @@
         },
         {
             "id": "56d086c1-aa66-5732-8a6c-a7370ae4d5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce00bb19-983e-427d-be54-ae6daf0ccdde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce00bb19-983e-427d-be54-ae6daf0ccdde.jpg?1",
             "name": "Lapis Lazuli Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a blue spell is successfully cast and only once for each blue spell cast.",
             "colours": [],
@@ -10535,7 +10535,7 @@
         },
         {
             "id": "96d99e6f-45be-5898-842a-21e658330898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb8a24-ce53-4a69-be2a-55c6dbba5ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb8a24-ce53-4a69-be2a-55c6dbba5ee7.jpg?1",
             "name": "Malachite Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a green spell is successfully cast and only once for each green spell cast.",
             "colours": [],
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "2d275d3e-5028-5ad3-b34a-2e16602bacec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06912236-8225-4eb0-8086-c6a163c69892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06912236-8225-4eb0-8086-c6a163c69892.jpg?1",
             "name": "Nacre Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a white spell is successfully cast and only once for each white spell cast.",
             "colours": [],
@@ -10589,7 +10589,7 @@
         },
         {
             "id": "760145a0-712f-5be9-8cbd-a25d34f66924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabadfb2-93cd-4c7a-b901-59c3dd1a7c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabadfb2-93cd-4c7a-b901-59c3dd1a7c3c.jpg?1",
             "name": "Naked Singularity",
             "text": "Cumulative Upkeep: o3\nInstead of their normal mana, plains produce o\nR, islands produce o\nG, swamps produce o\nW, mountains produce o\nU, and forests produce o\nB.",
             "colours": [],
@@ -10622,7 +10622,7 @@
         },
         {
             "id": "49b9a971-324d-553c-98a9-427cbcea9f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b2368-1180-4821-bcb8-8161c18e5538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b2368-1180-4821-bcb8-8161c18e5538.jpg?1",
             "name": "Onyx Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a black spell is successfully cast and only once for each black spell cast.",
             "colours": [],
@@ -10649,7 +10649,7 @@
         },
         {
             "id": "70d98211-2f97-5370-8d13-c6e313e3309a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d889a5-f6c7-410d-97f9-acf08b9091c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d889a5-f6c7-410d-97f9-acf08b9091c8.jpg?1",
             "name": "Pentagram of the Ages",
             "text": "o4,oc\nT: Prevent all damage dealt to you from one source. Pentagram of the Ages does not prevent the same source damaging you again later this turn.",
             "colours": [],
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "bbb34d44-5c4d-573b-8a6b-a263d2b5fdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c588fe7f-945d-4459-904c-67442f88b4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c588fe7f-945d-4459-904c-67442f88b4e1.jpg?1",
             "name": "Pit Trap",
             "text": "o2,oc\nT: Sacrifice Pit Trap to bury target creature without flying that is attacking you.",
             "colours": [],
@@ -10703,7 +10703,7 @@
         },
         {
             "id": "fbb7ad7e-5457-5b20-9437-99fa47e44f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca02861b-9639-480d-8e54-e024f0c70158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca02861b-9639-480d-8e54-e024f0c70158.jpg?1",
             "name": "Runed Arch",
             "text": "Comes into play tapped.\no\nX,oc\nT: Sacrifice Runed Arch. X target creatures with power no greater than 2 cannot be blocked this turn. Other effects may later be used to increase a creature's power beyond 2.",
             "colours": [],
@@ -10730,7 +10730,7 @@
         },
         {
             "id": "74345aae-0bdd-5f29-b9d7-33de661368a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7411ab40-47f6-44d1-8e33-9ff5301dcd9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7411ab40-47f6-44d1-8e33-9ff5301dcd9b.jpg?1",
             "name": "Shield of the Ages",
             "text": "o2: Prevent 1 damage to you.",
             "colours": [],
@@ -10757,7 +10757,7 @@
         },
         {
             "id": "9f901b87-edcf-519a-aa37-dd2f4ea3d289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb92a3e6-dc30-4a08-baba-e125290cadc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb92a3e6-dc30-4a08-baba-e125290cadc5.jpg?1",
             "name": "Skull Catapult",
             "text": "o1,oc\nT: Sacrifice a creature to have Skull Catapult deal 2 damage to target creature or player.",
             "colours": [],
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "ef55e806-1ff4-50e0-9441-5bce1f5d914a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c480e07-fb26-4760-865f-47985f7447bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c480e07-fb26-4760-865f-47985f7447bb.jpg?1",
             "name": "Snow Fortress",
             "text": "Counts as a wall\no1: +1/+0 until end of turn\no1: +0/+1 until end of turn\no3: Snow Fortress deals 1 damage to target creature without flying that is attacking you.",
             "colours": [],
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "c27e8144-7edb-58e6-a219-d3472f15b116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d35e88-81d3-4a54-aa79-190615abc616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d35e88-81d3-4a54-aa79-190615abc616.jpg?1",
             "name": "Soldevi Golem",
             "text": "Does not untap during your untap phase.\no0: Untap target creature opponent controls to untap Soldevi Golem at the end of your upkeep. Use this ability only during your upkeep.",
             "colours": [],
@@ -10844,7 +10844,7 @@
         },
         {
             "id": "4727a338-9aa7-5a63-a37a-7e8fa1b2ff6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fabc7b6-e766-4e3c-816e-04cfeceaff09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fabc7b6-e766-4e3c-816e-04cfeceaff09.jpg?1",
             "name": "Soldevi Simulacrum",
             "text": "Cumulative Upkeep: o1\no1: +1/+0 until end of turn",
             "colours": [],
@@ -10874,7 +10874,7 @@
         },
         {
             "id": "15e1df4a-1858-5d0c-a71a-57f096aa2def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c709836-55b6-4de9-b190-b5f66dc53c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c709836-55b6-4de9-b190-b5f66dc53c87.jpg?1",
             "name": "Staff of the Ages",
             "text": "Creatures with any landwalk ability may be blocked as though they did not have those abilities.",
             "colours": [],
@@ -10901,7 +10901,7 @@
         },
         {
             "id": "59a98f7b-6fc2-57c5-a31a-4d96c370ae73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1c67fa-ff88-4a61-b8a5-8a872b3dc44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1c67fa-ff88-4a61-b8a5-8a872b3dc44f.jpg?1",
             "name": "Sunstone",
             "text": "o2: Sacrifice a snow-covered land to have all creatures deal no damage in combat this turn.",
             "colours": [],
@@ -10928,7 +10928,7 @@
         },
         {
             "id": "0c802afe-1f40-5416-9f3f-ff3534df8f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092ec691-4729-46d3-a4e2-0cfc5df42a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092ec691-4729-46d3-a4e2-0cfc5df42a31.jpg?1",
             "name": "Time Bomb",
             "text": "During your upkeep, put a time counter on Time Bomb.\no1,oc\nT: Sacrifice Time Bomb to have it deal * damage to each creature and player, where * is equal to the number of time counters on Time Bomb.",
             "colours": [],
@@ -10955,7 +10955,7 @@
         },
         {
             "id": "07599f31-afe4-543a-ac68-30715778febc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c9e9a7-e170-4361-b7d5-22fc0771c489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c9e9a7-e170-4361-b7d5-22fc0771c489.jpg?1",
             "name": "Urza's Bauble",
             "text": "oc\nT: Sacrifice Urza's Bauble to choose a card at random from target player's hand; look at that card. Ignore this ability if that player has no cards left in hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "66dae17d-a742-51b4-ba09-0b37d7c64265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ea118-6a19-4e1b-aa5a-9b2729efc096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ea118-6a19-4e1b-aa5a-9b2729efc096.jpg?1",
             "name": "Vexing Arcanix",
             "text": "o3,oc\nT: Target player names a card and then turns over the top card of his or her library. If that is the card named, put it into the player's hand. Otherwise, put it into the player's graveyard, and Vexing Arcanix deals 2 damage to that player.",
             "colours": [],
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "aa2b9332-fbaa-569d-b7e4-c8a658956ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f93ded-ecf6-4a70-8ca3-a9c0c3201c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f93ded-ecf6-4a70-8ca3-a9c0c3201c21.jpg?1",
             "name": "Vibrating Sphere",
             "text": "During your turn, all creatures you control get +2/+0. During all other turns, all creatures you control get -0/-2.",
             "colours": [],
@@ -11036,7 +11036,7 @@
         },
         {
             "id": "df2959a6-183d-54b3-831f-787c64abb4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba1238c-1969-452d-8112-124cbbd49417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba1238c-1969-452d-8112-124cbbd49417.jpg?1",
             "name": "Walking Wall",
             "text": "Counts as a wall\no3: Walking Wall gets +3/-1 until end of turn and can attack this turn. Walking Wall cannot attack the turn it comes under your control. Use this ability only once a turn.",
             "colours": [],
@@ -11066,7 +11066,7 @@
         },
         {
             "id": "9ddffd7f-7024-5d35-81f8-35cce55a00f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376c7c4-aaca-4625-83d4-a49f01aec535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376c7c4-aaca-4625-83d4-a49f01aec535.jpg?1",
             "name": "Wall of Shields",
             "text": "Banding, counts as a wall",
             "colours": [],
@@ -11096,7 +11096,7 @@
         },
         {
             "id": "d33c67f3-55a0-5270-916e-692aebf3885f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ea0c6c-aa76-4b16-bc99-2ff46dc56d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ea0c6c-aa76-4b16-bc99-2ff46dc56d4e.jpg?1",
             "name": "War Chariot",
             "text": "o3,oc\nT: Target creature gains trample until end of turn.",
             "colours": [],
@@ -11123,7 +11123,7 @@
         },
         {
             "id": "df236003-fe5f-5aa1-91a6-e146c918b832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b75adf0-9501-4776-a213-456c2b821070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b75adf0-9501-4776-a213-456c2b821070.jpg?1",
             "name": "Whalebone Glider",
             "text": "o2,oc\nT: Target creature with power no greater than 3 gains flying until end of turn. Other effects may later be used to increase that creature's power beyond 3.",
             "colours": [],
@@ -11150,7 +11150,7 @@
         },
         {
             "id": "3f7e3f20-4dd5-58a9-a251-d38e9589062c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg?1",
             "name": "Zuran Orb",
             "text": "o0: Sacrifice a land to gain 2 life.",
             "colours": [],
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "95b07c7f-fb51-555f-835b-e04e3a53fcc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd9023-f7ee-4e99-8821-7059deb83730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd9023-f7ee-4e99-8821-7059deb83730.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nW to your mana pool. Adarkar Wastes deals 1 damage to you.\noc\nT: Add o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -11207,7 +11207,7 @@
         },
         {
             "id": "78e56ab8-b0e8-5c84-9c4b-8177228fff7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e5ccd-54bf-4c6d-86b4-0359ca8f36e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e5ccd-54bf-4c6d-86b4-0359ca8f36e8.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nW to your mana pool. Brushland deals 1 damage to you.\noc\nT: Add o\nG to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -11237,7 +11237,7 @@
         },
         {
             "id": "cf0b9ecf-2f58-54e1-92d4-d212ef73a08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d23f800-7a6f-40e3-b242-9f5955e47a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d23f800-7a6f-40e3-b242-9f5955e47a75.jpg?1",
             "name": "Glacial Chasm",
             "text": "Cumulative Upkeep: 2 life\nWhen Glacial Chasm comes into play, sacrifice a land. You cannot attack. All damage dealt to you is reduced to 0.",
             "colours": [],
@@ -11264,7 +11264,7 @@
         },
         {
             "id": "b3ba2b45-4416-5f3a-9d32-384224890ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b926a189-90b6-47bb-b5d6-b033e57007b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b926a189-90b6-47bb-b5d6-b033e57007b4.jpg?1",
             "name": "Halls of Mist",
             "text": "Cumulative Upkeep: o1\nNo creature can attack if it attacked during its controller's last turn.",
             "colours": [],
@@ -11291,7 +11291,7 @@
         },
         {
             "id": "9058c0de-6a91-5d38-b085-afd5cb1c2735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce04fb-e687-41e0-ae9a-16a51df5d943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce04fb-e687-41e0-ae9a-16a51df5d943.jpg?1",
             "name": "Ice Floe",
             "text": "You may choose not to untap Ice Floe during your untap phase.\noc\nT: Tap target creature without flying that is attacking you. As long as Ice Floe remains tapped, that creature does not untap during its controller's untap phase.",
             "colours": [],
@@ -11318,7 +11318,7 @@
         },
         {
             "id": "b7dfa867-04fd-5693-a534-1259fe97da09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f1263-d598-49fb-b5f8-09f11822ebd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f1263-d598-49fb-b5f8-09f11822ebd0.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nR to your mana pool. Karplusan Forest deals 1 damage to you.\noc\nT: Add o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -11348,7 +11348,7 @@
         },
         {
             "id": "e31e6ec6-f9ee-52e2-8ea7-bd50cef363fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4806c02-7a4d-42e3-affd-0338084bd3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4806c02-7a4d-42e3-affd-0338084bd3ab.jpg?1",
             "name": "Land Cap",
             "text": "If there are any depletion counters on Land Cap, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Land Cap.\noc\nT: Add o\nW to your mana pool. Put a depletion counter on Land Cap.\noc\nT: Add o\nU to your mana pool. Put a depletion counter on Land Cap.",
             "colours": [],
@@ -11378,7 +11378,7 @@
         },
         {
             "id": "3125c9e2-9d66-507a-bb8c-2921def54074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7c2cf6-f36f-451b-bba5-19a82c659c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7c2cf6-f36f-451b-bba5-19a82c659c4c.jpg?1",
             "name": "Lava Tubes",
             "text": "If there are any depletion counters on Lava Tubes, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Lava Tubes.\noc\nT: Add o\nB to your mana pool. Put a depletion counter on Lava Tubes.\noc\nT: Add o\nR to your mana pool. Put a depletion counter on Lava Tubes.",
             "colours": [],
@@ -11408,7 +11408,7 @@
         },
         {
             "id": "8e173647-85f6-5c73-a33a-3ad835f881f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea335fc0-0591-4acd-9ae8-7858222770da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea335fc0-0591-4acd-9ae8-7858222770da.jpg?1",
             "name": "River Delta",
             "text": "If there are any depletion counters on River Delta, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from River Delta.\noc\nT: Add o\nU to your mana pool. Put a depletion counter on River Delta.\noc\nT: Add o\nB to your mana pool. Put a depletion counter on River Delta.",
             "colours": [],
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "fc50a57b-07d0-57c8-a4ed-b2bf2180feb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdeab50-b45f-412b-85a3-c6cf009ce567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdeab50-b45f-412b-85a3-c6cf009ce567.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nB to your mana pool. Sulfurous Springs deals 1 damage to you.\noc\nT: Add o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -11468,7 +11468,7 @@
         },
         {
             "id": "68961a04-fa12-53a7-ae79-d8547e0455b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2fc9-0a24-4ac1-afcc-9317b90c7178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2fc9-0a24-4ac1-afcc-9317b90c7178.jpg?1",
             "name": "Timberline Ridge",
             "text": "If there are any depletion counters on Timberline Ridge, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Timberline Ridge.\noc\nT: Add o\nR to your mana pool. Put a depletion counter on Timberline Ridge.\noc\nT: Add o\nG to your mana pool. Put a depletion counter on Timberline Ridge.",
             "colours": [],
@@ -11498,7 +11498,7 @@
         },
         {
             "id": "b2afa72f-d1f4-5743-bb3e-99f3ffda5ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92369d7e-5e5a-46f9-bb31-c57d62410283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92369d7e-5e5a-46f9-bb31-c57d62410283.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nU to your mana pool. Underground River deals 1 damage to you.\noc\nT: Add o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -11528,7 +11528,7 @@
         },
         {
             "id": "3909534e-20b9-5337-ac8f-6881691bbdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987534fb-74a9-46a3-805f-fe2fe2df4a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987534fb-74a9-46a3-805f-fe2fe2df4a90.jpg?1",
             "name": "Veldt",
             "text": "If there are any depletion counters on Veldt, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Veldt.\noc\nT: Add o\nW to your mana pool. Put a depletion counter on Veldt.\noc\nT: Add o\nG to your mana pool. Put a depletion counter on Veldt.",
             "colours": [],
@@ -11558,7 +11558,7 @@
         },
         {
             "id": "314b47fb-c976-55e8-a1ab-3560f91cb230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b68bdb0-41cc-48f6-905e-7da1ff4ba5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b68bdb0-41cc-48f6-905e-7da1ff4ba5e0.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11594,7 +11594,7 @@
         },
         {
             "id": "28ee6407-45c4-5572-9d0e-27c921b3a5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3e94f7-9f97-4652-a1f1-381feb15f688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3e94f7-9f97-4652-a1f1-381feb15f688.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11630,7 +11630,7 @@
         },
         {
             "id": "9a9f3101-eb5f-526d-89a6-bed45e684830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ac1fc7-0698-4a94-8353-cc4c13bd6ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ac1fc7-0698-4a94-8353-cc4c13bd6ffa.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11666,7 +11666,7 @@
         },
         {
             "id": "9263e828-8c92-5fb1-b515-cadac67a58f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3ac778-fb45-4fd3-a9af-8a0791f833e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3ac778-fb45-4fd3-a9af-8a0791f833e8.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11700,7 +11700,7 @@
         },
         {
             "id": "9bf5a479-a60a-5534-885c-3080d282683f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2d6fc9-ddad-4dd2-b218-afa1a5449b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2d6fc9-ddad-4dd2-b218-afa1a5449b7e.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11736,7 +11736,7 @@
         },
         {
             "id": "6a1301db-b2f4-500e-ad97-bdb57349599b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a467ab-4460-4e5e-94c1-8150bfe0c954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a467ab-4460-4e5e-94c1-8150bfe0c954.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11772,7 +11772,7 @@
         },
         {
             "id": "690d9344-68b1-5629-957e-499f8c7b4a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f11c42-9d67-4833-9519-e165e6a7e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f11c42-9d67-4833-9519-e165e6a7e9c4.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11808,7 +11808,7 @@
         },
         {
             "id": "cab1b8bb-d941-5eb4-86b3-eabfc6f6a9e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1",
             "name": "Snow-Covered Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11842,7 +11842,7 @@
         },
         {
             "id": "0748a698-c3ab-5db0-bf2c-077a16ac0457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a3c27f-6b15-49b6-ac89-36cfb79b3b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a3c27f-6b15-49b6-ac89-36cfb79b3b54.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "98e0ddf7-54e9-51c9-b80d-f7ed8a0c13a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4695653a-5c4c-4ff3-b80c-f4b6c685f370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4695653a-5c4c-4ff3-b80c-f4b6c685f370.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11912,7 +11912,7 @@
         },
         {
             "id": "0717c6ba-ae0f-5d7f-831c-b65a01f9aba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90b49f-53b3-4ce0-92c1-bcd76d6981ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90b49f-53b3-4ce0-92c1-bcd76d6981ea.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "0d5747b2-250f-53d3-b107-cbdd8bf42640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddca7e2e-bb0a-47ed-ade3-31900da992dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddca7e2e-bb0a-47ed-ade3-31900da992dc.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11984,7 +11984,7 @@
         },
         {
             "id": "54cbdc4d-0171-55ab-8efc-cfbe26b720f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf39c3-3b5f-4263-a7b5-9881bded3494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf39c3-3b5f-4263-a7b5-9881bded3494.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12020,7 +12020,7 @@
         },
         {
             "id": "1596fbf7-9101-5fef-b063-1b4c0f18c0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb15b42-be2a-4663-b064-aad6c7cb2714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb15b42-be2a-4663-b064-aad6c7cb2714.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12056,7 +12056,7 @@
         },
         {
             "id": "40105434-e292-5e94-987c-026a576daeee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ac61e4-b543-4c37-9bfa-43f0c928152d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ac61e4-b543-4c37-9bfa-43f0c928152d.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12092,7 +12092,7 @@
         },
         {
             "id": "9f5e5e8f-07f4-5121-b405-0736d90d1c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3afb3-5574-4f2d-adbe-969a428f1c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3afb3-5574-4f2d-adbe-969a428f1c63.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12126,7 +12126,7 @@
         },
         {
             "id": "e01ef1d8-d531-5749-900e-e536f5c369b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdcbd97-90a9-45ea-94f6-2a1c6faaf965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdcbd97-90a9-45ea-94f6-2a1c6faaf965.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -12162,7 +12162,7 @@
         },
         {
             "id": "e2d5b6af-3744-598e-819c-a0a792f04e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b346b784-7bde-49d0-bfa9-56236cbe19d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b346b784-7bde-49d0-bfa9-56236cbe19d9.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -12198,7 +12198,7 @@
         },
         {
             "id": "be7aaccd-487b-50c5-aa95-36581728726d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c4d8f-5700-4f0a-9ff2-58422aeb1dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c4d8f-5700-4f0a-9ff2-58422aeb1dac.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -12234,7 +12234,7 @@
         },
         {
             "id": "fd5c9890-c319-52ca-bb80-8f1ba3ec83ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0ad95c-d62c-4138-ada0-fa39a63a449e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0ad95c-d62c-4138-ada0-fa39a63a449e.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/IKO.json
+++ b/Assets/Resources/Sets/IKO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d1bedeac-8dfb-5014-930a-7c2d5796f890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a2e243-e446-46c6-8a37-e26620951c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a2e243-e446-46c6-8a37-e26620951c41.jpg?1",
             "name": "Adaptive Shimmerer",
             "text": "Flash\nAdaptive Shimmerer enters the battlefield with three +1/+1 counters on it.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "053bc238-3d0a-53d0-ada0-c6284fb70351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f63f40-46f1-4b9e-b447-ff9274f2b926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f63f40-46f1-4b9e-b447-ff9274f2b926.jpg?1",
             "name": "Farfinder",
             "text": "Vigilance\nWhen Farfinder enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "d71d5711-8598-5e61-96a9-72e0c53a9b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfac3c3-7f38-49d6-bd88-dc0f5001116f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfac3c3-7f38-49d6-bd88-dc0f5001116f.jpg?1",
             "name": "Mysterious Egg",
             "text": "Whenever this creature mutates, put a +1/+1 counter on it.",
             "colours": [],
@@ -96,7 +96,7 @@
         },
         {
             "id": "89c3ce43-d694-5402-96cd-338e174a926b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a30091-7f68-4a67-b47e-f44318fc93b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a30091-7f68-4a67-b47e-f44318fc93b2.jpg?1",
             "name": "Blade Banish",
             "text": "Exile target creature with power 4 or greater.",
             "colours": [
@@ -128,7 +128,7 @@
         },
         {
             "id": "e9b7b5ee-97c7-5355-85c7-f844e931053b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e12f5-7b15-4a8c-b045-35bcbf1fbb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e12f5-7b15-4a8c-b045-35bcbf1fbb90.jpg?1",
             "name": "Checkpoint Officer",
             "text": "{1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -163,7 +163,7 @@
         },
         {
             "id": "a50cb538-9233-5289-a807-315a59315aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129c404b-2c1e-4f0b-bb4e-7e8e627a69a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129c404b-2c1e-4f0b-bb4e-7e8e627a69a8.jpg?1",
             "name": "Coordinated Charge",
             "text": "Creatures you control get +2/+1 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "b178049d-5bb8-581e-8b69-dedc93bdcffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc322744-5d8f-448d-b868-381bb86b68f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc322744-5d8f-448d-b868-381bb86b68f9.jpg?1",
             "name": "Cubwarden",
             "text": "Mutate {2}{W}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nLifelink\nWhenever this creature mutates, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "a4355de7-039a-50e4-b203-5293ef7a206d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d566bd-f272-49d1-bffb-588f2a42046a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d566bd-f272-49d1-bffb-588f2a42046a.jpg?1",
             "name": "Daysquad Marshal",
             "text": "When Daysquad Marshal enters the battlefield, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -266,7 +266,7 @@
         },
         {
             "id": "d1af5b4e-78d3-576d-af87-ab17648ea361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b29acc2-5749-4e8a-924d-3c82406e6393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b29acc2-5749-4e8a-924d-3c82406e6393.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -298,7 +298,7 @@
         },
         {
             "id": "7c5b82ab-81c5-5fd7-996d-dc97774f22c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a821c-eaec-4f69-97c7-8299cdebc2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a821c-eaec-4f69-97c7-8299cdebc2f4.jpg?1",
             "name": "Drannith Healer",
             "text": "Whenever you cycle another card, you gain 1 life.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -333,7 +333,7 @@
         },
         {
             "id": "051a8365-78af-5f9d-b82b-65678cf22476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b0a4a8-9319-451b-9b79-b0bca7a41e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b0a4a8-9319-451b-9b79-b0bca7a41e91.jpg?1",
             "name": "Drannith Magistrate",
             "text": "Your opponents can't cast spells from anywhere other than their hands.",
             "colours": [
@@ -370,7 +370,7 @@
         },
         {
             "id": "75311d84-76ee-5b04-b382-156ff443bcdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62ea13-9bd5-46ce-a861-68cf9a2c6f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62ea13-9bd5-46ce-a861-68cf9a2c6f8c.jpg?1",
             "name": "Fight as One",
             "text": "Choose one or both \u2014\n\u2022 Target Human creature you control gets +1/+1 and gains indestructible until end of turn.\n\u2022 Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn.",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "8e2f9c84-fd93-503e-87f4-f842bad9569c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b81339-746d-4f71-9943-01c0f6a5683a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b81339-746d-4f71-9943-01c0f6a5683a.jpg?1",
             "name": "Flourishing Fox",
             "text": "Whenever you cycle another card, put a +1/+1 counter on Flourishing Fox.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "d20069ec-c5ac-53ba-8160-1053e2acb6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ff8345-227c-43b4-bed5-af3a34c0a990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ff8345-227c-43b4-bed5-af3a34c0a990.jpg?1",
             "name": "Garrison Cat",
             "text": "When Garrison Cat dies, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -472,7 +472,7 @@
         },
         {
             "id": "c1f207e0-471f-51e2-a6c3-30751349f997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc88fe0-2424-49a7-9abf-4773a547d010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc88fe0-2424-49a7-9abf-4773a547d010.jpg?1",
             "name": "Helica Glider",
             "text": "Helica Glider enters the battlefield with your choice of a flying counter or a first strike counter on it.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "585f1a62-cd0b-5d30-8fd5-3e74f95ea1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058d6a7d-12b0-4d82-a5bd-91fa44bbc5e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058d6a7d-12b0-4d82-a5bd-91fa44bbc5e1.jpg?1",
             "name": "Huntmaster Liger",
             "text": "Mutate {2}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, other creatures you control get +X/+X until end of turn, where X is the number of times this creature has mutated.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "1a50c117-99fb-5b3e-b97f-d83bb950321f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fa5feb-f5e9-4079-acc9-84e458044769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fa5feb-f5e9-4079-acc9-84e458044769.jpg?1",
             "name": "Imposing Vantasaur",
             "text": "Vigilance\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "b4e13fda-df34-538d-93ff-cd5593d00bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0583065-9a6c-4ea4-b6dd-2edfbaed1181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0583065-9a6c-4ea4-b6dd-2edfbaed1181.jpg?1",
             "name": "Keensight Mentor",
             "text": "When Keensight Mentor enters the battlefield, put a vigilance counter on target non-Human creature you control.\n{1}{W}, {T}: Put a +1/+1 counter on each creature you control with vigilance.",
             "colours": [
@@ -613,7 +613,7 @@
         },
         {
             "id": "565ef74e-8efa-5ed6-a3ff-259b407467dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0d9d6-c9c7-4169-8106-400445643a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0d9d6-c9c7-4169-8106-400445643a1a.jpg?1",
             "name": "Lavabrink Venturer",
             "text": "As Lavabrink Venturer enters the battlefield, choose odd or even. (Zero is even.)\nLavabrink Venturer has protection from each converted mana cost of the chosen value.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "edeca4ca-2378-5505-9727-26d683c36a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb00599-e082-49b0-88f3-ef91b75595e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb00599-e082-49b0-88f3-ef91b75595e4.jpg?1",
             "name": "Light of Hope",
             "text": "Choose one \u2014\n\u2022 You gain 4 life.\n\u2022 Destroy target enchantment.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "39ebc226-262a-58fa-a44a-8db82796b6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb65df55-d6a6-4a57-a903-e5eb17637982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb65df55-d6a6-4a57-a903-e5eb17637982.jpg?1",
             "name": "Luminous Broodmoth",
             "text": "Flying\nWhenever a creature you control without flying dies, return it to the battlefield under its owner's control with a flying counter on it.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "5b2871e7-63f0-53fa-afeb-db3dea3b28bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df320c9-449a-457e-8688-f611aceb3352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df320c9-449a-457e-8688-f611aceb3352.jpg?1",
             "name": "Majestic Auricorn",
             "text": "Mutate {3}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nVigilance\nWhenever this creature mutates, you gain 4 life.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "9963ab3e-e478-5404-8449-001999905568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac51e35-e2c5-4457-981c-e59894584288.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac51e35-e2c5-4457-981c-e59894584288.jpg?1",
             "name": "Maned Serval",
             "text": "Vigilance",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "a2e2a441-848e-5718-b827-6e81a717e409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2712a1a3-dd28-44c8-a661-5bcf68d3acaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2712a1a3-dd28-44c8-a661-5bcf68d3acaa.jpg?1",
             "name": "Mythos of Snapdax",
             "text": "Each player chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest. If {B}{R} was spent to cast this spell, you choose the permanents for each player instead.",
             "colours": [
@@ -825,7 +825,7 @@
         },
         {
             "id": "da8641e7-9004-59b3-b525-51ee2e35613a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47adc9fc-d620-4cb7-a03c-8d9578992249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47adc9fc-d620-4cb7-a03c-8d9578992249.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "3902ae75-aae1-5c86-a0e8-98c12586d3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be398100-89e2-432b-8017-74fb7e4dbc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be398100-89e2-432b-8017-74fb7e4dbc26.jpg?1",
             "name": "Patagia Tiger",
             "text": "Flying\nWhen Patagia Tiger enters the battlefield, target Human you control gets +2/+2 until end of turn.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "03a3705f-c9e3-50bc-92a5-e2fda593f87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a174587-d964-48b3-8f69-fa576c1b8bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a174587-d964-48b3-8f69-fa576c1b8bba.jpg?1",
             "name": "Perimeter Sergeant",
             "text": "Whenever Perimeter Sergeant attacks, other Humans you control get +1/+0 until end of turn.",
             "colours": [
@@ -928,7 +928,7 @@
         },
         {
             "id": "059af630-c21d-5684-afc3-8ee50b501862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1387b7be-f69e-4919-9070-a89654c656f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1387b7be-f69e-4919-9070-a89654c656f3.jpg?1",
             "name": "Sanctuary Lockdown",
             "text": "Humans you control get +1/+1.\n{2}, Tap two untapped Humans you control: Tap target creature an opponent controls.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "729f2470-8092-571b-8a75-7f5aa0400c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46702b0-7e10-462a-9aac-7564efe91804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46702b0-7e10-462a-9aac-7564efe91804.jpg?1",
             "name": "Savai Sabertooth",
             "text": "",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "cc9c2e9c-a554-5b5f-965c-9457e0044877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f640e0c-298d-4a5f-94d0-d839cf06ca86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f640e0c-298d-4a5f-94d0-d839cf06ca86.jpg?1",
             "name": "Snare Tactician",
             "text": "Whenever you cycle a card, tap target creature an opponent controls.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "2268d512-fedc-5d06-a15c-3acb312fbe5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900a8d1-a1b1-48c9-8af1-726a623c7d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900a8d1-a1b1-48c9-8af1-726a623c7d74.jpg?1",
             "name": "Solid Footing",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nAs long as enchanted creature has vigilance, it assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "ceebc01d-402c-58e3-8cf3-f5f438d41d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535ccc75-b24e-4071-b6a0-fc5267a454e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535ccc75-b24e-4071-b6a0-fc5267a454e3.jpg?1",
             "name": "Splendor Mare",
             "text": "Lifelink\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Splendor Mare, put a lifelink counter on target creature you control.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "4236010e-f9e6-5c48-b5b8-13db4b0b56de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc24dd4-d259-4687-8247-f56aa7abb5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc24dd4-d259-4687-8247-f56aa7abb5b9.jpg?1",
             "name": "Spontaneous Flight",
             "text": "Target creature gets +2/+2 until end of turn. Put a flying counter on it.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "4353d0d5-d5a8-541e-a3d3-5d36d5404397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afded81-2fc1-4285-bf48-d25f72e72138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afded81-2fc1-4285-bf48-d25f72e72138.jpg?1",
             "name": "Stormwild Capridor",
             "text": "Flying\nIf noncombat damage would be dealt to Stormwild Capridor, prevent that damage. Put a +1/+1 counter on Stormwild Capridor for each 1 damage prevented this way.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "d2cd94e6-6b94-5ab9-b4d2-e1fb9d6fb9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b9140b-848f-4886-8c28-eccd3829a607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b9140b-848f-4886-8c28-eccd3829a607.jpg?1",
             "name": "Swallow Whole",
             "text": "As an additional cost to cast this spell, tap an untapped creature you control.\nExile target tapped creature. Put a +1/+1 counter on the creature tapped to pay this spell's additional cost.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "843093dc-01ce-5cf5-8ceb-a349f5a064c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b13ff6-67e9-4760-aef4-a8548ea44344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b13ff6-67e9-4760-aef4-a8548ea44344.jpg?1",
             "name": "Valiant Rescuer",
             "text": "Whenever you cycle another card for the first time each turn, create a 1/1 white Human Soldier creature token.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "09188393-b9c6-5eee-937d-c163dec589a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bce816-3d18-4ca1-b88f-7307ec7c345d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bce816-3d18-4ca1-b88f-7307ec7c345d.jpg?1",
             "name": "Vulpikeet",
             "text": "Mutate {2}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying\nWhenever this creature mutates, put a +1/+1 counter on it.",
             "colours": [
@@ -1269,7 +1269,7 @@
         },
         {
             "id": "1b1bcc70-a0c0-5b64-8ff1-3fd8cb49be27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7acbfa-ce3b-424d-886d-6865bc5fc085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7acbfa-ce3b-424d-886d-6865bc5fc085.jpg?1",
             "name": "Will of the All-Hunter",
             "text": "Target creature gets +2/+2 until end of turn. If it's blocking, instead put two +1/+1 counters on it.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1301,7 +1301,7 @@
         },
         {
             "id": "0c77895d-7bc7-56cd-a53b-a64be05966b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e433e7f0-7417-4dfe-a7a4-3f222b0a835f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e433e7f0-7417-4dfe-a7a4-3f222b0a835f.jpg?1",
             "name": "Aegis Turtle",
             "text": "",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "511819bc-6693-5487-95ab-0215ab09524a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b6dfb2-ffe4-44fb-bfd9-df11bc3193df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b6dfb2-ffe4-44fb-bfd9-df11bc3193df.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "65d4b44a-86e8-54be-8880-73b29c653834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b1030-64d5-4c94-a04c-1d9520bfddab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b1030-64d5-4c94-a04c-1d9520bfddab.jpg?1",
             "name": "Archipelagore",
             "text": "Mutate {5}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, tap up to X target creatures, where X is the number of times this creature has mutated. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "7aeac403-5fb4-5ca2-ae87-117d8ae18ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f325873b-97de-4701-910f-ec5cdb66de33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f325873b-97de-4701-910f-ec5cdb66de33.jpg?1",
             "name": "Avian Oddity",
             "text": "Flying\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\nWhen you cycle Avian Oddity, put a flying counter on target creature you control.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "7443819c-67d8-56b6-94a5-122a88e53752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e790851-f0f7-4f1a-80e6-94be649499b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e790851-f0f7-4f1a-80e6-94be649499b6.jpg?1",
             "name": "Boon of the Wish-Giver",
             "text": "Draw four cards.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "45d9f2a4-1ce0-5595-ac37-c4bdebbdffbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1d2d9d-6eee-4334-bbbe-87e026fa6fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1d2d9d-6eee-4334-bbbe-87e026fa6fc0.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "fdbb8ef6-bc84-5772-9c61-420a8f1d8b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd8e607-8179-4ae8-ba7f-f5f22649dc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd8e607-8179-4ae8-ba7f-f5f22649dc18.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "db3c347b-506c-5074-bb93-27ffa3f9f550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32afec8a-dbae-446e-919a-3efb556f5cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32afec8a-dbae-446e-919a-3efb556f5cb1.jpg?1",
             "name": "Crystacean",
             "text": "Flash",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "a607f3cf-3a34-556d-8530-469c1429f39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca777d40-736a-4cd6-85c4-5afd52f2fadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca777d40-736a-4cd6-85c4-5afd52f2fadd.jpg?1",
             "name": "Dreamtail Heron",
             "text": "Mutate {3}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying\nWhenever this creature mutates, draw a card.",
             "colours": [
@@ -1606,7 +1606,7 @@
         },
         {
             "id": "8540ff2d-cb92-5dd7-8c70-db705397019c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3eeddd-c86d-4f35-ba57-3caa9565fcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3eeddd-c86d-4f35-ba57-3caa9565fcb0.jpg?1",
             "name": "Escape Protocol",
             "text": "Whenever you cycle a card, you may pay {1}. When you do, exile target artifact or creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1638,7 +1638,7 @@
         },
         {
             "id": "be6c70b1-01c6-5b10-8c63-3da184a3e53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f79c8a0-291e-4e13-b765-4cf8c726cf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f79c8a0-291e-4e13-b765-4cf8c726cf30.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1670,7 +1670,7 @@
         },
         {
             "id": "39d53ee7-48bd-5bc7-bcd3-42b083f47e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1199596-ae77-4192-ae70-3e2ebd009b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1199596-ae77-4192-ae70-3e2ebd009b64.jpg?1",
             "name": "Facet Reader",
             "text": "{1}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "51ecace6-3298-5015-899e-59d77243b64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcaeccc-fc8c-4a9e-80d5-b48da71d7ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcaeccc-fc8c-4a9e-80d5-b48da71d7ff1.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1740,7 +1740,7 @@
         },
         {
             "id": "0adc8631-644f-58b7-acaf-8648e1a1305d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deef1197-e40a-4c9d-919a-213f1bdf3e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deef1197-e40a-4c9d-919a-213f1bdf3e3e.jpg?1",
             "name": "Frostveil Ambush",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -1772,7 +1772,7 @@
         },
         {
             "id": "9886384a-d2a0-5f5f-b7f1-418e3854a1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f71f8a-546a-465e-a254-09a3ae873ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f71f8a-546a-465e-a254-09a3ae873ef4.jpg?1",
             "name": "Glimmerbell",
             "text": "Flying\n{1}{U}: Untap Glimmerbell.",
             "colours": [
@@ -1807,7 +1807,7 @@
         },
         {
             "id": "3d5b01a2-d862-5430-bc1d-a54a1aa72716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabea92-d8cf-4591-b528-3e597d56b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabea92-d8cf-4591-b528-3e597d56b31f.jpg?1",
             "name": "Gust of Wind",
             "text": "This spell costs {2} less to cast if you control a creature with flying.\nReturn target nonland permanent you don't control to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "27b242b7-a855-5e93-a6ba-3e76ec699027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7b331a-bd21-429b-a49f-88da9a31c98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7b331a-bd21-429b-a49f-88da9a31c98e.jpg?1",
             "name": "Hampering Snare",
             "text": "Creatures your opponents control get -2/-0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "c843e078-3cc1-564d-b99b-5cc2fb02502a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfa682-76ae-4979-a40c-c1eae1121f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfa682-76ae-4979-a40c-c1eae1121f3c.jpg?1",
             "name": "Keep Safe",
             "text": "Counter target spell that targets a permanent you control.\nDraw a card.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "f4e7def7-6be0-5cad-8794-86744b48acbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c2111-b7d7-40bc-aa30-57d72338b32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c2111-b7d7-40bc-aa30-57d72338b32d.jpg?1",
             "name": "Mystic Subdual",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-0 and loses all abilities. (Mutating onto the creature won't give it new abilities. It can gain abilities in other ways.)",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "42983ebf-1f1e-5b1d-928e-b2ad932b6683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b07082-c5a5-4283-a2f5-5b1e0120d752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b07082-c5a5-4283-a2f5-5b1e0120d752.jpg?1",
             "name": "Mythos of Illuna",
             "text": "Create a token that's a copy of target permanent. If {R}{G} was spent to cast this spell, instead create a token that's a copy of that permanent, except the token has \"When this permanent enters the battlefield, if it's a creature, it fights up to one target creature you don't control.\"",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "4cc87779-ba91-5824-a5c6-6d7b1fbce572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430da3c-9460-4b62-ae28-2e7e6f4d06a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430da3c-9460-4b62-ae28-2e7e6f4d06a4.jpg?1",
             "name": "Neutralize",
             "text": "Counter target spell.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "409ad1e6-dc39-5429-b486-8d61f836c036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95fb136-f21d-4f3a-82b7-bcf490b7e90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95fb136-f21d-4f3a-82b7-bcf490b7e90c.jpg?1",
             "name": "Of One Mind",
             "text": "This spell costs {2} less to cast if you control a Human creature and a non-Human creature.\nDraw two cards.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "7d31e624-2cd0-5b37-a432-b4cc4cbc06f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8965f2-756a-4461-a643-db024a11c2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8965f2-756a-4461-a643-db024a11c2de.jpg?1",
             "name": "Ominous Seas",
             "text": "Whenever you draw a card, put a foreshadow counter on Ominous Seas.\nRemove eight foreshadow counters from Ominous Seas: Create an 8/8 blue Kraken creature token.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "0a74790b-dca1-5608-8204-6ade2516551b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4042-e9c1-4b0f-b1f6-4180b0d79663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4042-e9c1-4b0f-b1f6-4180b0d79663.jpg?1",
             "name": "Phase Dolphin",
             "text": "Whenever Phase Dolphin attacks, another target attacking creature can't be blocked this turn.",
             "colours": [
@@ -2104,7 +2104,7 @@
         },
         {
             "id": "233db185-ba73-50fa-a8b6-b36976a0a770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77adf375-e7d7-4ebd-8c86-ad7e822a5483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77adf375-e7d7-4ebd-8c86-ad7e822a5483.jpg?1",
             "name": "Pollywog Symbiote",
             "text": "Each creature spell you cast costs {1} less to cast if it has mutate.\nWhenever you cast a creature spell, if it has mutate, draw a card, then discard a card.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "3ba6b275-197e-5c04-99d1-1e04f984f360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859b339-b55b-41fe-948c-27502e3b3ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859b339-b55b-41fe-948c-27502e3b3ea8.jpg?1",
             "name": "Pouncing Shoreshark",
             "text": "Mutate {3}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlash\nWhenever this creature mutates, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "3181822e-5828-5fb5-af83-ebf01f99eec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f7efa-d125-4f83-825e-172ea099a62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f7efa-d125-4f83-825e-172ea099a62a.jpg?1",
             "name": "Reconnaissance Mission",
             "text": "Whenever a creature you control deals combat damage to a player, you may draw a card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "ffed3087-c310-5a19-a05c-f87c9e8a0d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f59d9e-6c1b-437a-934c-7c776c8dd1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f59d9e-6c1b-437a-934c-7c776c8dd1d5.jpg?1",
             "name": "Sea-Dasher Octopus",
             "text": "Mutate {1}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlash\nWhenever this creature deals combat damage to a player, draw a card.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "9bae2632-4472-5fa3-bad8-08cc4d34e878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da4d4f3-b3cb-4b61-81b8-06ae441c41bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da4d4f3-b3cb-4b61-81b8-06ae441c41bf.jpg?1",
             "name": "Shark Typhoon",
             "text": "Whenever you cast a noncreature spell, create an X/X blue Shark creature token with flying, where X is that spell's converted mana cost.\nCycling {X}{1}{U} ({X}{1}{U}, Discard this card: Draw a card.)\nWhen you cycle Shark Typhoon, create an X/X blue Shark creature token with flying.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "3941e293-975c-563c-bb45-0db114ae306e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12680db-957f-48c1-9062-2edd9115ba26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12680db-957f-48c1-9062-2edd9115ba26.jpg?1",
             "name": "Startling Development",
             "text": "Until end of turn, target creature becomes a blue Serpent with base power and toughness 4/4.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "34046de0-b79a-5f3a-a29a-c809405c551b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f84b0a-37d9-4b0f-8d75-1fab45a12d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f84b0a-37d9-4b0f-8d75-1fab45a12d44.jpg?1",
             "name": "Thieving Otter",
             "text": "Whenever Thieving Otter deals damage to an opponent, draw a card.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "62dbc03d-30e1-5159-9a95-e34a93ffbb52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg?1",
             "name": "Voracious Greatshark",
             "text": "Flash\nWhen Voracious Greatshark enters the battlefield, counter target artifact or creature spell.",
             "colours": [
@@ -2381,7 +2381,7 @@
         },
         {
             "id": "a0205859-d1ae-5e1e-bfe2-4259704a67f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e21a5f-fae7-4488-9463-f0af6e4c5233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e21a5f-fae7-4488-9463-f0af6e4c5233.jpg?1",
             "name": "Wingfold Pteron",
             "text": "Wingfold Pteron enters the battlefield with your choice of a flying counter or a hexproof counter on it. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "9dc77e83-8edc-5efe-8d61-e796c2675de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89348a02-29f6-40b9-b39f-cb5f8c230a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89348a02-29f6-40b9-b39f-cb5f8c230a02.jpg?1",
             "name": "Wingspan Mentor",
             "text": "When Wingspan Mentor enters the battlefield, put a flying counter on target non-Human creature you control.\n{2}{U}, {T}: Put a +1/+1 counter on each creature you control with flying.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "603cba6d-572b-52db-822f-2f096b08f039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd354dd-939e-4b1a-8ed6-fe89a7fd64bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd354dd-939e-4b1a-8ed6-fe89a7fd64bf.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "When Bastion of Remembrance enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "2ca635de-cfb1-58a3-96e8-1dfb91cb5226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9b5bde-a851-480b-b45e-d384fd1c11bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9b5bde-a851-480b-b45e-d384fd1c11bb.jpg?1",
             "name": "Blitz Leech",
             "text": "Flash\nWhen Blitz Leech enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn. Remove all counters from that creature.",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "2476cf61-4054-5b39-8e42-977853fcb38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4184c851-1419-476c-ba9c-9f0cb1137114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4184c851-1419-476c-ba9c-9f0cb1137114.jpg?1",
             "name": "Blood Curdle",
             "text": "Destroy target creature. Put a menace counter on a creature you control. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "b63ba2bd-dbfd-59f6-82b4-bb7c83428bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5a5b8-f823-4429-acd8-c4f34a676cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5a5b8-f823-4429-acd8-c4f34a676cb4.jpg?1",
             "name": "Boot Nipper",
             "text": "Boot Nipper enters the battlefield with your choice of a deathtouch counter or a lifelink counter on it.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "6cc8eed0-b8dd-50cf-be55-8e9a87780003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc01faf4-fabb-40c9-a1d6-359280535f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc01faf4-fabb-40c9-a1d6-359280535f91.jpg?1",
             "name": "Bushmeat Poacher",
             "text": "{1}, {T}, Sacrifice another creature: You gain life equal to that creature's toughness. Draw a card.",
             "colours": [
@@ -2617,7 +2617,7 @@
         },
         {
             "id": "06d17c40-e524-5b03-a6ee-0edceca5730a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e34017-0aeb-4a93-9edf-596bf3597a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e34017-0aeb-4a93-9edf-596bf3597a0e.jpg?1",
             "name": "Call of the Death-Dweller",
             "text": "Return up to two target creature cards with total converted mana cost 3 or less from your graveyard to the battlefield. Put a deathtouch counter on either of them. Then put a menace counter on either of them.",
             "colours": [
@@ -2649,7 +2649,7 @@
         },
         {
             "id": "8e61fd42-99eb-5a94-8542-28bbcad882b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae7651-4a5c-41f3-b528-41b9b0f2e5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae7651-4a5c-41f3-b528-41b9b0f2e5d8.jpg?1",
             "name": "Cavern Whisperer",
             "text": "Mutate {3}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nMenace (This creature can't be blocked except by two or more creatures.)\nWhenever this creature mutates, each opponent discards a card.",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "5437928c-138e-539c-a46b-63efffb6db7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51a0700-d4d3-4b7e-bdb5-6cd913c948d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51a0700-d4d3-4b7e-bdb5-6cd913c948d9.jpg?1",
             "name": "Chittering Harvester",
             "text": "Mutate {4}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, each opponent sacrifices a creature.",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "af3367f8-3fe3-5e5d-b4e3-ae2b463b9509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0c764-791d-4181-8f7a-147554d97d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0c764-791d-4181-8f7a-147554d97d97.jpg?1",
             "name": "Corpse Churn",
             "text": "Put the top three cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "711bc45f-00bb-59f9-b882-1a520c4d27a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6f861-90ef-4e1d-9f17-1dd306e7d0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6f861-90ef-4e1d-9f17-1dd306e7d0af.jpg?1",
             "name": "Dark Bargain",
             "text": "Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard. Dark Bargain deals 2 damage to you.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "404cf848-a6ac-519e-ab6f-b2873f7ebdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf18476-f67b-46e6-905c-e6808981c58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf18476-f67b-46e6-905c-e6808981c58a.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "793cba6b-4f65-5834-b055-b83822576a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59677c76-8148-4b6f-95b0-0e3ccf137a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59677c76-8148-4b6f-95b0-0e3ccf137a3f.jpg?1",
             "name": "Dirge Bat",
             "text": "Mutate {4}{B}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlash\nFlying\nWhenever this creature mutates, destroy target creature or planeswalker an opponent controls.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "43644d4c-dca3-567e-866a-2768ad55e1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cbdfb6-c029-440f-bc07-c95e03c20110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cbdfb6-c029-440f-bc07-c95e03c20110.jpg?1",
             "name": "Durable Coilbug",
             "text": "{4}{B}: Return Durable Coilbug from your graveyard to your hand.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "2939b0c6-fcf0-53f7-8123-db3ef7e02d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc38fe5d-6c35-4fff-8f1b-726a0685c6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc38fe5d-6c35-4fff-8f1b-726a0685c6f8.jpg?1",
             "name": "Duskfang Mentor",
             "text": "When Duskfang Mentor enters the battlefield, put a lifelink counter on target non-Human creature you control.\n{1}{B}, {T}: Put a +1/+1 counter on each creature you control with lifelink.",
             "colours": [
@@ -2925,7 +2925,7 @@
         },
         {
             "id": "65801db8-4a90-5e61-830d-6af547269832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312fb6e4-1eb1-4fbb-b7a4-125829a6e96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312fb6e4-1eb1-4fbb-b7a4-125829a6e96a.jpg?1",
             "name": "Easy Prey",
             "text": "Destroy target creature with converted mana cost 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "32ea8570-3565-5ce1-8705-697ce1e7bff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725a869-462b-4381-880a-b4bcc63a655b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725a869-462b-4381-880a-b4bcc63a655b.jpg?1",
             "name": "Extinction Event",
             "text": "Choose odd or even. Exile each creature with converted mana cost of the chosen value. (Zero is even.)",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "bde3d656-05f1-51b5-b219-a25902e5c5cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f135dd7-2a4f-4c83-9a90-76bcab3cc33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f135dd7-2a4f-4c83-9a90-76bcab3cc33d.jpg?1",
             "name": "Gloom Pangolin",
             "text": "",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "3263bab7-7d1c-594a-a204-aa4ef58510bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819257c8-9806-48bd-ba49-e117ca31de54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819257c8-9806-48bd-ba49-e117ca31de54.jpg?1",
             "name": "Grimdancer",
             "text": "Grimdancer enters the battlefield with your choice of two different counters on it from among menace, deathtouch, and lifelink.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "9765302f-7eb2-5f70-8d1a-95c53b492b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6794a-feeb-4fc8-a2ee-38c75c18aaae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6794a-feeb-4fc8-a2ee-38c75c18aaae.jpg?1",
             "name": "Heartless Act",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with no counters on it.\n\u2022 Remove up to three counters from target creature.",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "3cf92ac2-0ca8-5608-acc6-ae1422595a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2dddce-583e-4af3-b144-a60dd268e84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2dddce-583e-4af3-b144-a60dd268e84f.jpg?1",
             "name": "Hunted Nightmare",
             "text": "Menace\nWhen Hunted Nightmare enters the battlefield, target opponent puts a deathtouch counter on a creature they control.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "dda806e1-a2e9-5436-8436-fa0e1a0f6907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70419590-2e0d-4232-b596-a5359b284647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70419590-2e0d-4232-b596-a5359b284647.jpg?1",
             "name": "Insatiable Hemophage",
             "text": "Mutate {2}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nDeathtouch\nWhenever this creature mutates, each opponent loses X life and you gain X life, where X is the number of times this creature has mutated.",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "55568114-ee69-5bff-ba9e-7fc2d8d5cb2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43925a8d-dd02-4907-929e-c015d678bb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43925a8d-dd02-4907-929e-c015d678bb49.jpg?1",
             "name": "Lurking Deadeye",
             "text": "Flash\nWhen Lurking Deadeye enters the battlefield, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -3201,7 +3201,7 @@
         },
         {
             "id": "b74c3b04-c822-593b-b557-2011712d9f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b45a493-a1c2-430e-a45c-abc1ba554877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b45a493-a1c2-430e-a45c-abc1ba554877.jpg?1",
             "name": "Memory Leak",
             "text": "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -3233,7 +3233,7 @@
         },
         {
             "id": "f872a733-2f8e-5dee-8219-e3ea98cf5563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ac0b25-80bf-4871-a6f6-5cf4d5b9496e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ac0b25-80bf-4871-a6f6-5cf4d5b9496e.jpg?1",
             "name": "Mutual Destruction",
             "text": "This spell has flash as long as you control a permanent with flash.\nAs an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -3265,7 +3265,7 @@
         },
         {
             "id": "2bfa0603-2a5c-5c32-b6b3-d0828f643b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abc24e1-e721-471a-9efd-547f320675b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abc24e1-e721-471a-9efd-547f320675b0.jpg?1",
             "name": "Mythos of Nethroi",
             "text": "Destroy target nonland permanent if it's a creature or if {G}{W} was spent to cast this spell.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "c015085e-1634-5025-9af7-42850464547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80306d10-0da7-4ee7-b975-ef6c9b535a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80306d10-0da7-4ee7-b975-ef6c9b535a2a.jpg?1",
             "name": "Nightsquad Commando",
             "text": "When Nightsquad Commando enters the battlefield, if you attacked this turn, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -3336,7 +3336,7 @@
         },
         {
             "id": "d284ed49-e301-5683-9385-bbe8a69bee80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8f0242-35e1-4409-9321-56e742e8fef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8f0242-35e1-4409-9321-56e742e8fef4.jpg?1",
             "name": "Serrated Scorpion",
             "text": "When Serrated Scorpion dies, it deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "b89918e0-c401-597f-801e-af5a91c29580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b562e4-35df-4aee-848d-ceb4204bbe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b562e4-35df-4aee-848d-ceb4204bbe58.jpg?1",
             "name": "Suffocating Fumes",
             "text": "Creatures your opponents control get -1/-1 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "28280ba9-cb20-52c8-a132-2fa210e5ac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9da02a1-7b39-4a0e-8466-6512a02f3e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9da02a1-7b39-4a0e-8466-6512a02f3e3b.jpg?1",
             "name": "Unbreakable Bond",
             "text": "Return target creature card from your graveyard to the battlefield with a lifelink counter on it.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "86a4e4b5-37fb-53af-8913-41c90ecbef1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6494ad-a35e-4b09-8623-7740f3c20b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6494ad-a35e-4b09-8623-7740f3c20b0b.jpg?1",
             "name": "Unexpected Fangs",
             "text": "Put a +1/+1 counter and a lifelink counter on target creature.",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "f58458a9-e3ff-53cf-9758-649e1cfce1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac3409e-7c24-43b0-9956-5f0cdeae6468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac3409e-7c24-43b0-9956-5f0cdeae6468.jpg?1",
             "name": "Unlikely Aid",
             "text": "Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "e2fb0a41-862d-5872-b87b-26ce48a48964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1523cda-c47d-4419-a5d3-fd6ed9867c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1523cda-c47d-4419-a5d3-fd6ed9867c56.jpg?1",
             "name": "Void Beckoner",
             "text": "Deathtouch\nCycling {2}{B} ({2}{B}, Discard this card: Draw a card.)\nWhen you cycle Void Beckoner, put a deathtouch counter on target creature you control.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "f49ba7c8-499f-547e-8b91-8a7286c6c885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097eeb32-cfd5-4adb-ac30-d7762e6ea48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097eeb32-cfd5-4adb-ac30-d7762e6ea48f.jpg?1",
             "name": "Whisper Squad",
             "text": "{1}{B}: Search your library for a card named Whisper Squad, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "fe65b63c-5e63-5bd9-87d2-0d21ced18d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce945f7e-ded9-4819-9313-d50d3aad40fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce945f7e-ded9-4819-9313-d50d3aad40fa.jpg?1",
             "name": "Zagoth Mamba",
             "text": "Whenever this creature mutates, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "787cdfa5-413b-54fe-8dd8-4bd071f24380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adc0288-acdf-4a99-9bfb-919cae1aeb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adc0288-acdf-4a99-9bfb-919cae1aeb69.jpg?1",
             "name": "Blazing Volley",
             "text": "Blazing Volley deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -3638,7 +3638,7 @@
         },
         {
             "id": "4695331e-f056-50ff-924e-1cf1e1cb0bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec65b97-d5c0-4609-8a60-3c4daa3e59c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec65b97-d5c0-4609-8a60-3c4daa3e59c1.jpg?1",
             "name": "Blisterspit Gremlin",
             "text": "{1}, {T}: Blisterspit Gremlin deals 1 damage to each opponent.\nWhenever you cast a noncreature spell, untap Blisterspit Gremlin.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "3ac10a7d-419a-578e-a047-3c5fd983fac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0174556-9f9b-4756-84ca-d14a5a60720c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0174556-9f9b-4756-84ca-d14a5a60720c.jpg?1",
             "name": "Blitz of the Thunder-Raptor",
             "text": "Blitz of the Thunder-Raptor deals damage to target creature or planeswalker equal to the number of instant and sorcery cards in your graveyard. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "9f55fa9b-8ec5-5626-8b57-9168118ad13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d93cfd-06d1-4c6a-87f6-9b6eaa2a995f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d93cfd-06d1-4c6a-87f6-9b6eaa2a995f.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "17b71251-5a61-5671-b6bf-59888a332634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10e2b8-a317-4c98-a866-43bf274e82cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10e2b8-a317-4c98-a866-43bf274e82cb.jpg?1",
             "name": "Clash of Titans",
             "text": "Target creature fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "4ec947f3-913e-5f24-965f-0ba554fc715d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec5f005-d8fb-48b8-8ac5-74445cc83273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec5f005-d8fb-48b8-8ac5-74445cc83273.jpg?1",
             "name": "Cloudpiercer",
             "text": "Mutate {3}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nReach\nWhenever this creature mutates, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3804,7 +3804,7 @@
         },
         {
             "id": "951230fb-eee0-568a-8868-e5e5c12d8a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ee4be-e7a2-423c-a37c-7c6ca97f630e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ee4be-e7a2-423c-a37c-7c6ca97f630e.jpg?1",
             "name": "Drannith Stinger",
             "text": "Whenever you cycle another card, Drannith Stinger deals 1 damage to each opponent.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "df2fd1f3-1b61-53ec-87a2-cc959b65af71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3953157f-2deb-4ab7-b4b3-592ebb7c7a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3953157f-2deb-4ab7-b4b3-592ebb7c7a9c.jpg?1",
             "name": "Everquill Phoenix",
             "text": "Mutate {3}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying\nWhenever this creature mutates, create a red artifact token named Feather with \"{1}, Sacrifice Feather: Return target Phoenix card from your graveyard to the battlefield tapped.\"",
             "colours": [
@@ -3876,7 +3876,7 @@
         },
         {
             "id": "24887078-1ab7-5d40-831e-00d6e2ed4dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976e8d8-5122-4423-b3eb-61170390ad7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976e8d8-5122-4423-b3eb-61170390ad7a.jpg?1",
             "name": "Ferocious Tigorilla",
             "text": "Ferocious Tigorilla enters the battlefield with your choice of a trample counter or a menace counter on it. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "29eefa63-921a-5ffc-b894-184608814eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2029e5-cf7d-461f-b7b9-bf96399d8f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2029e5-cf7d-461f-b7b9-bf96399d8f49.jpg?1",
             "name": "Fire Prophecy",
             "text": "Fire Prophecy deals 3 damage to target creature. You may put a card from your hand on the bottom of your library. If you do, draw a card.",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "136e00ed-9b7f-57a6-9c3c-5039228e17c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3090004-d7dd-47bc-92e5-977be4fd9ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3090004-d7dd-47bc-92e5-977be4fd9ae5.jpg?1",
             "name": "Flame Spill",
             "text": "Flame Spill deals 4 damage to target creature. Excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "3759805e-0d98-5a71-9eb2-134695354852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b75aac-54e3-4181-bac5-5a142757ec05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b75aac-54e3-4181-bac5-5a142757ec05.jpg?1",
             "name": "Footfall Crater",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature gains trample and haste until end of turn.\"\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "80499d53-40ce-5438-a578-467e2b4980ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e634baa3-2cdd-412a-9407-c347fe46f9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e634baa3-2cdd-412a-9407-c347fe46f9b8.jpg?1",
             "name": "Forbidden Friendship",
             "text": "Create a 1/1 red Dinosaur creature token with haste and a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "50b63c8c-ebb4-5ba8-8210-af7406bf4823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb22ac0-3863-4165-8c93-f2ec1775474f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb22ac0-3863-4165-8c93-f2ec1775474f.jpg?1",
             "name": "Frenzied Raptor",
             "text": "",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "cb80a309-4210-57a0-982b-ac280fd094b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7d034-6403-41e2-9e44-4d58ef54cf10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7d034-6403-41e2-9e44-4d58ef54cf10.jpg?1",
             "name": "Frillscare Mentor",
             "text": "When Frillscare Mentor enters the battlefield, put a menace counter on target non-Human creature you control. (It can't be blocked except by two or more creatures.)\n{2}{R}, {T}: Put a +1/+1 counter on each creature you control with menace.",
             "colours": [
@@ -4112,7 +4112,7 @@
         },
         {
             "id": "d2f35809-877d-565a-8c57-97d78cbdd79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67315df9-99a1-45ba-8ade-ddc476368a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67315df9-99a1-45ba-8ade-ddc476368a86.jpg?1",
             "name": "Go for Blood",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "625d6d0a-50cf-51e6-add0-b12ed8c7c01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7cc8e7-3002-4ee0-869f-931438d8362d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7cc8e7-3002-4ee0-869f-931438d8362d.jpg?1",
             "name": "Heightened Reflexes",
             "text": "Target creature gets +1/+0 until end of turn. Put a first strike counter on it.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "00e252b2-7dd3-5ebf-84ca-2f6349cbd13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ebd57f-7f7c-41b0-aa56-511c1816bc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ebd57f-7f7c-41b0-aa56-511c1816bc14.jpg?1",
             "name": "Lava Serpent",
             "text": "Haste\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "cc7b9bd8-7943-5ae5-9a2b-ed50e2227966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5798fdf0-d178-43d9-b821-8f3f654654b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5798fdf0-d178-43d9-b821-8f3f654654b4.jpg?1",
             "name": "Lukka, Coppercoat Outcast",
             "text": "+1: Exile the top three cards of your library. Creature cards exiled this way gain \"You may cast this card from exile as long as you control a Lukka planeswalker.\"\n\u22122: Exile target creature you control, then reveal cards from the top of your library until you reveal a creature card with higher converted mana cost. Put that card onto the battlefield and the rest on the bottom of your library in a random order.\n\u22127: Each creature you control deals damage equal to its power to each opponent.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "ca31b7fc-03bf-526a-9c10-8f2f60d01cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3587f450-c1ba-4074-84bb-47978a2b6116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3587f450-c1ba-4074-84bb-47978a2b6116.jpg?1",
             "name": "Momentum Rumbler",
             "text": "Whenever Momentum Rumbler attacks, if it doesn't have first strike, put a first strike counter on it.\nWhenever Momentum Rumbler attacks, if it has first strike, it gains double strike until end of turn.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "ff03a839-b8f5-5a82-b995-d5889491efe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe99a7-3b58-4f23-bf86-e1e35b0bec2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe99a7-3b58-4f23-bf86-e1e35b0bec2e.jpg?1",
             "name": "Mythos of Vadrok",
             "text": "Mythos of Vadrok deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers. If {W}{U} was spent to cast this spell, until your next turn, those permanents can't attack or block and their activated abilities can't be activated.",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "a971530c-47a6-593c-a13b-118c1b25d19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856892c8-ba47-46d0-aec2-0416b55b9e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856892c8-ba47-46d0-aec2-0416b55b9e88.jpg?1",
             "name": "Porcuparrot",
             "text": "Mutate {2}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\n{T}: This creature deals X damage to any target, where X is the number of times this creature has mutated.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "723961d9-0bbc-5e02-b89b-d02e0179e6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad8512f-31b9-48ba-bb10-1497303dcfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad8512f-31b9-48ba-bb10-1497303dcfba.jpg?1",
             "name": "Prickly Marmoset",
             "text": "First strike\nWhenever you cycle a card, Prickly Marmoset gets +2/+0 until end of turn.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "b777dd8b-155e-5830-9560-c1374c6d6b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6599645-dbb5-4174-bd26-8556af6d89c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6599645-dbb5-4174-bd26-8556af6d89c3.jpg?1",
             "name": "Pyroceratops",
             "text": "Trample\nWhenever you cast a noncreature spell, put a +1/+1 counter on Pyroceratops.",
             "colours": [
@@ -4425,7 +4425,7 @@
         },
         {
             "id": "32142ce6-5228-5c8b-8c69-d5854f46cf3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb0d9a2-f9bb-4d8e-a1ca-896c42f8ad56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb0d9a2-f9bb-4d8e-a1ca-896c42f8ad56.jpg?1",
             "name": "Raking Claws",
             "text": "Target creature gains double strike until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4457,7 +4457,7 @@
         },
         {
             "id": "d7f614a9-12af-5ebf-a62a-4775787639e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7871b4dd-9085-4a3f-a1ae-9a292f73689b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7871b4dd-9085-4a3f-a1ae-9a292f73689b.jpg?1",
             "name": "Reptilian Reflection",
             "text": "Whenever you cycle a card, you may have Reptilian Reflection become a 5/4 Dinosaur creature with trample and haste in addition to its other types until end of turn.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "842a9e81-ac38-50d6-b575-0d080590f332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2fd581-5cf8-4154-90dd-922afddcd556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2fd581-5cf8-4154-90dd-922afddcd556.jpg?1",
             "name": "Rooting Moloch",
             "text": "When Rooting Moloch enters the battlefield, exile target card with a cycling ability from your graveyard. Until the end of your next turn, you may play that card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "8838190f-cb0c-5376-824f-893d18f07aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9aaa7-11c7-4cd0-9803-9471c14ab846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9aaa7-11c7-4cd0-9803-9471c14ab846.jpg?1",
             "name": "Rumbling Rockslide",
             "text": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "bc794588-6e67-55ee-8c6d-a43047cdbb65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc634c10-42c5-4bdc-bc22-f862ae285492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc634c10-42c5-4bdc-bc22-f862ae285492.jpg?1",
             "name": "Sanctuary Smasher",
             "text": "First strike\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Sanctuary Smasher, put a first strike counter on target creature you control.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "c6f914d2-676d-5a14-950d-5735854670ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b10219a-aa72-4431-9a6a-984109a605c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b10219a-aa72-4431-9a6a-984109a605c8.jpg?1",
             "name": "Shredded Sails",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Shredded Sails deals 4 damage to target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "6a6e7756-f264-5a85-b9f8-1cc2d422b1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f03ffd-dcdb-441c-8dfc-4fe06a289b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f03ffd-dcdb-441c-8dfc-4fe06a289b22.jpg?1",
             "name": "Spelleater Wolverine",
             "text": "Spelleater Wolverine has double strike as long as there are three or more instant and/or sorcery cards in your graveyard.",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "b4d76539-5a7b-567b-aa45-513e603d5dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c40fd33-bb95-48f3-a10f-a33eb27c48f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c40fd33-bb95-48f3-a10f-a33eb27c48f1.jpg?1",
             "name": "Tentative Connection",
             "text": "This spell costs {3} less to cast if you control a creature with menace.\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4688,7 +4688,7 @@
         },
         {
             "id": "672fd934-b146-5bf7-8455-1a19e0500766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0462f6-a027-43c0-8e01-c0591d9a45d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0462f6-a027-43c0-8e01-c0591d9a45d9.jpg?1",
             "name": "Unpredictable Cyclone",
             "text": "If a cycling ability of another nonland card would cause you to draw a card, instead exile cards from the top of your library until you exile a card that shares a card type with the cycled card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of your library in a random order.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "377f94bd-0dd7-5c2c-a2e9-026e34168125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bba622-a0ab-4c0e-88b1-9120690ea5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bba622-a0ab-4c0e-88b1-9120690ea5a0.jpg?1",
             "name": "Weaponize the Monsters",
             "text": "{2}, Sacrifice a creature: Weaponize the Monsters deals 2 damage to any target.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "1ed1090b-a684-5560-ae82-946f39d710b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b540c7c6-5b9e-4606-ac84-e583a62a3647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b540c7c6-5b9e-4606-ac84-e583a62a3647.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "Trample, haste\nCycling {1}{R}\nWhen you cycle Yidaro, Wandering Monster, shuffle it into your library from your graveyard. If you've cycled a card named Yidaro, Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead. (Do this before you draw.)",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "d45823a8-9df1-5b4a-83d9-5f837b3af415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30811fb2-5767-4106-9a8d-6091f61969c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30811fb2-5767-4106-9a8d-6091f61969c6.jpg?1",
             "name": "Adventurous Impulse",
             "text": "Look at the top three cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "b0dfbceb-48c2-5b56-8090-de2be047eed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2b7ac-8742-468d-b6a3-87881cb522ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2b7ac-8742-468d-b6a3-87881cb522ff.jpg?1",
             "name": "Almighty Brushwagg",
             "text": "Trample\n{3}{G}: Almighty Brushwagg gets +3/+3 until end of turn.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "aedf0bf6-d36e-564a-9d2d-8a6fe01069e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ae1e4-d4dd-4691-af5a-5fa25ace4ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ae1e4-d4dd-4691-af5a-5fa25ace4ebe.jpg?1",
             "name": "Auspicious Starrix",
             "text": "Mutate {5}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, exile cards from the top of your library until you exile X permanent cards, where X is the number of times this creature has mutated. Put those permanent cards onto the battlefield.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "56c4aaeb-7d62-516d-9160-a70706651987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822f8403-77a7-4e75-88af-60d604632f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822f8403-77a7-4e75-88af-60d604632f5d.jpg?1",
             "name": "Barrier Breach",
             "text": "Exile up to three target enchantments.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "ae7fa4b6-d018-5ad7-a7e9-5ee48929f26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c3243c-e9af-4b7d-8296-f7714436e571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c3243c-e9af-4b7d-8296-f7714436e571.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -4963,7 +4963,7 @@
         },
         {
             "id": "13b25102-77c8-54ae-a360-63f66b47ee30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf147a6-2282-4120-9cbd-d0309fc9b02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf147a6-2282-4120-9cbd-d0309fc9b02b.jpg?1",
             "name": "Charge of the Forever-Beast",
             "text": "As an additional cost to cast this spell, reveal a creature card from your hand.\nCharge of the Forever-Beast deals damage to target creature or planeswalker equal to the revealed card's power.",
             "colours": [
@@ -4995,7 +4995,7 @@
         },
         {
             "id": "2475f50a-a574-5a8a-a6d8-9726a235b82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6e6f2a-5015-44c6-aa8d-85188494d1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6e6f2a-5015-44c6-aa8d-85188494d1a6.jpg?1",
             "name": "Colossification",
             "text": "Enchant creature\nWhen Colossification enters the battlefield, tap enchanted creature.\nEnchanted creature gets +20/+20.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "b9c1c37f-00ae-5207-a646-0b0c876f0a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09ddf0-91f0-4e76-809f-c39ca7418ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09ddf0-91f0-4e76-809f-c39ca7418ed5.jpg?1",
             "name": "Essence Symbiote",
             "text": "Whenever a creature you control mutates, put a +1/+1 counter on that creature and you gain 2 life.",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "e7b1a653-0eea-52bf-b9db-4fe334a65fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1712dc-8f4c-407f-83ea-3a1c59c437d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1712dc-8f4c-407f-83ea-3a1c59c437d1.jpg?1",
             "name": "Excavation Mole",
             "text": "Trample\nWhen Excavation Mole enters the battlefield, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "e737042c-0e62-5fef-8057-96336b57b870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8ff0da-fbe3-4c95-bc39-c975c55b6aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8ff0da-fbe3-4c95-bc39-c975c55b6aea.jpg?1",
             "name": "Exuberant Wolfbear",
             "text": "Whenever Exuberant Wolfbear attacks, you may change the base power and toughness of target Human you control to Exuberant Wolfbear's power and toughness until end of turn.",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "21d51948-8631-569a-9feb-e43cef9bee67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6b39b9-0615-4899-8de2-b579d5b12f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6b39b9-0615-4899-8de2-b579d5b12f1c.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles their library.",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "6e894fba-f57e-5cf0-a101-7567c1d26ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1988e220-d746-46e4-a534-164203e63c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1988e220-d746-46e4-a534-164203e63c14.jpg?1",
             "name": "Flycatcher Giraffid",
             "text": "Flycatcher Giraffid enters the battlefield with your choice of a vigilance counter or a reach counter on it.",
             "colours": [
@@ -5204,7 +5204,7 @@
         },
         {
             "id": "a206b2d5-e1f1-5ee0-b324-ce5ec3600a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b683d3f-025c-4b8d-89d7-3513488649d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b683d3f-025c-4b8d-89d7-3513488649d5.jpg?1",
             "name": "Fully Grown",
             "text": "Target creature gets +3/+3 until end of turn. Put a trample counter on it.",
             "colours": [
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "ad472671-1604-5585-8ae8-603a73b41915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0095245c-a30e-4e2a-88c9-632c678e9f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0095245c-a30e-4e2a-88c9-632c678e9f03.jpg?1",
             "name": "Gemrazer",
             "text": "Mutate {1}{G}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nReach, trample\nWhenever this creature mutates, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "4a1ce1e7-1762-5ba4-bbca-02edf4511be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a9698d-400c-4c31-82cd-28d0897fe28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a9698d-400c-4c31-82cd-28d0897fe28c.jpg?1",
             "name": "Glowstone Recluse",
             "text": "Mutate {3}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nReach\nWhenever this creature mutates, put two +1/+1 counters on it.",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "9f9b4392-3d30-5a5c-99d2-0d4aa0b5023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90c5650-7eb2-480a-856e-a04406096830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90c5650-7eb2-480a-856e-a04406096830.jpg?1",
             "name": "Greater Sandwurm",
             "text": "Greater Sandwurm can't be blocked by creatures with power 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "c947d54e-4642-51a5-a118-f3e6c55db70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b9bee2-b973-4de7-b72d-7f36f8e8153c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b9bee2-b973-4de7-b72d-7f36f8e8153c.jpg?1",
             "name": "Honey Mammoth",
             "text": "When Honey Mammoth enters the battlefield, you gain 4 life.",
             "colours": [
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "60588665-84ac-567f-9c48-38e3d0a1a070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47d2596-a321-44c0-a9f6-87bf80abc1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47d2596-a321-44c0-a9f6-87bf80abc1c4.jpg?1",
             "name": "Hornbash Mentor",
             "text": "When Hornbash Mentor enters the battlefield, put a trample counter on target non-Human creature you control.\n{2}{G}, {T}: Put a +1/+1 counter on each creature you control with trample.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "4e3ea897-8f79-5148-ade4-936f9995c17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f56705d-eb64-4cef-b716-edbeac60bf79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f56705d-eb64-4cef-b716-edbeac60bf79.jpg?1",
             "name": "Humble Naturalist",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.",
             "colours": [
@@ -5447,7 +5447,7 @@
         },
         {
             "id": "397d416b-c473-50ee-9322-c793e089201a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8aea71-02aa-4799-86fb-efd2a36efc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8aea71-02aa-4799-86fb-efd2a36efc22.jpg?1",
             "name": "Ivy Elemental",
             "text": "Ivy Elemental enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5481,7 +5481,7 @@
         },
         {
             "id": "23fa3b37-12b6-53fb-a77d-345b29e0db3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c35ca79-eb72-427a-a8ed-404b2214389a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c35ca79-eb72-427a-a8ed-404b2214389a.jpg?1",
             "name": "Kogla, the Titan Ape",
             "text": "When Kogla, the Titan Ape enters the battlefield, it fights up to one target creature you don't control.\nWhenever Kogla attacks, destroy target artifact or enchantment defending player controls.\n{1}{G}: Return target Human you control to its owner's hand. Kogla gains indestructible until end of turn.",
             "colours": [
@@ -5519,7 +5519,7 @@
         },
         {
             "id": "e2d5f174-b324-51a4-b334-debd13570880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76b676-c7a3-4de6-a78d-3059a0df83f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76b676-c7a3-4de6-a78d-3059a0df83f2.jpg?1",
             "name": "Lead the Stampede",
             "text": "Look at the top five cards of your library. You may reveal any number of creature cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "d79467e9-930e-53dd-9bc8-0128a346631e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345ca63-16a3-4988-93f5-d0e00e8d6ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345ca63-16a3-4988-93f5-d0e00e8d6ab0.jpg?1",
             "name": "Migration Path",
             "text": "Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5585,7 +5585,7 @@
         },
         {
             "id": "02c2a74f-2618-5b3b-aa9f-0c95bf63aa0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2a287b-b83f-444f-84f7-e388beb616c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2a287b-b83f-444f-84f7-e388beb616c2.jpg?1",
             "name": "Migratory Greathorn",
             "text": "Mutate {2}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5621,7 +5621,7 @@
         },
         {
             "id": "8c2f1a9f-6bd7-5840-ad24-5aed4ee8e561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893f300b-a823-4156-90f2-0636e9f499b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893f300b-a823-4156-90f2-0636e9f499b0.jpg?1",
             "name": "Monstrous Step",
             "text": "Target creature gets +7/+7 until end of turn. Up to one other target creature blocks it this turn if able.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "f3735ccb-b2f8-5b83-a987-ca7c275f5a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23139d4-0db5-4683-8d49-f4600fbe29e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23139d4-0db5-4683-8d49-f4600fbe29e2.jpg?1",
             "name": "Mosscoat Goriak",
             "text": "Vigilance",
             "colours": [
@@ -5687,7 +5687,7 @@
         },
         {
             "id": "57716ae0-695a-5165-836b-7e80a720f655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4fc5b1-6666-4c60-898f-f927212c7923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4fc5b1-6666-4c60-898f-f927212c7923.jpg?1",
             "name": "Mythos of Brokkos",
             "text": "If {U}{B} was spent to cast this spell, search your library for a card, put that card into your graveyard, then shuffle your library.\nReturn up to two permanent cards from your graveyard to your hand.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "860e1116-2025-53b8-af0f-66b4b9506b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d884b2f2-946e-4d5d-b8cf-ef035726a188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d884b2f2-946e-4d5d-b8cf-ef035726a188.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -5755,7 +5755,7 @@
         },
         {
             "id": "52f3bb82-119b-5b69-b311-55e2b26beb80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0b24e7-14e7-45ee-b5d8-bdb8674b669c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0b24e7-14e7-45ee-b5d8-bdb8674b669c.jpg?1",
             "name": "Ram Through",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -5787,7 +5787,7 @@
         },
         {
             "id": "4d4201cf-6acb-5f8a-a0bb-2ebb61c6a9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3730996a-96d2-4311-a4dc-0045a2f8ccc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3730996a-96d2-4311-a4dc-0045a2f8ccc9.jpg?1",
             "name": "Sudden Spinnerets",
             "text": "Target creature gets +1/+3 until end of turn. Put a reach counter on it. Untap it.",
             "colours": [
@@ -5819,7 +5819,7 @@
         },
         {
             "id": "996fc1b6-e384-51b6-bb2b-d8f37397428f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ff2a1-6447-4653-a661-d9a39156d6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ff2a1-6447-4653-a661-d9a39156d6fa.jpg?1",
             "name": "Survivors' Bond",
             "text": "Choose one or both \u2014\n\u2022 Return target Human creature card from your graveyard to your hand.\n\u2022 Return target non-Human creature card from your graveyard to your hand.",
             "colours": [
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "ce25b8c1-2886-5f35-b48a-74fad6eecd9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7101f35-d8c9-4320-bffc-8bb25000d103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7101f35-d8c9-4320-bffc-8bb25000d103.jpg?1",
             "name": "Thwart the Enemy",
             "text": "Prevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "8c9f38a6-4e08-5d56-a07c-aa39f211d0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d02e1e8-b85b-4e26-8ab8-ca2f49d05b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d02e1e8-b85b-4e26-8ab8-ca2f49d05b88.jpg?1",
             "name": "Titanoth Rex",
             "text": "Trample\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)\nWhen you cycle Titanoth Rex, put a trample counter on target creature you control.",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "193ae10e-2032-5153-994d-567deff6d5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504ebb84-7e7b-4119-a128-a9c183c5d9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504ebb84-7e7b-4119-a128-a9c183c5d9de.jpg?1",
             "name": "Vivien, Monsters' Advocate",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n+1: Create a 3/3 green Beast creature token. Put your choice of a vigilance counter, a reach counter, or a trample counter on it.\n\u22122: When you cast your next creature spell this turn, search your library for a creature card with lesser converted mana cost, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5958,7 +5958,7 @@
         },
         {
             "id": "1bc81524-6b20-5ca9-8494-09b368315759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55987bab-c24f-4261-b97e-f0ad4474b0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55987bab-c24f-4261-b97e-f0ad4474b0a0.jpg?1",
             "name": "Wilt",
             "text": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "7c87d0da-939b-505a-984e-526f254ca0e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc7210c-da23-4cec-9195-4de75587f40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc7210c-da23-4cec-9195-4de75587f40f.jpg?1",
             "name": "Back for More",
             "text": "Return target creature card from your graveyard to the battlefield. When you do, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "2f2b609d-b867-5091-9498-e29c1c301471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e4df5b-ec53-4f8a-8c26-272b3177c0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e4df5b-ec53-4f8a-8c26-272b3177c0a6.jpg?1",
             "name": "Boneyard Lurker",
             "text": "Mutate {2}{BG}{BG} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "575bd36a-9beb-505b-8df8-4447687bfa8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f07625-fbd8-4581-8568-eb3cfb2a4c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f07625-fbd8-4581-8568-eb3cfb2a4c1e.jpg?1",
             "name": "Brokkos, Apex of Forever",
             "text": "Mutate {2}{UB}{G}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nTrample\nYou may cast Brokkos, Apex of Forever from your graveyard using its mutate ability.",
             "colours": [
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "e70df510-8c9c-5968-ae01-927db32851a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8918d24e-8ae8-4028-9f06-ba6fafcc717e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8918d24e-8ae8-4028-9f06-ba6fafcc717e.jpg?1",
             "name": "Channeled Force",
             "text": "As an additional cost to cast this spell, discard X cards.\nTarget player draws X cards. Channeled Force deals X damage to up to one target creature or planeswalker.",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "01fe85be-8ff0-5b6c-b900-e688e0a69f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecbf0a3-ebe1-43b6-a720-462ba19002eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecbf0a3-ebe1-43b6-a720-462ba19002eb.jpg?1",
             "name": "Chevill, Bane of Monsters",
             "text": "Deathtouch\nAt the beginning of your upkeep, if your opponents control no permanents with bounty counters on them, put a bounty counter on target creature or planeswalker an opponent controls.\nWhenever a permanent an opponent controls with a bounty counter on it dies, you gain 3 life and draw a card.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "5a6e08c6-80af-5b09-852f-d93daae34df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112e2cca-bae7-4296-9514-e6058f4b38a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112e2cca-bae7-4296-9514-e6058f4b38a5.jpg?1",
             "name": "Death's Oasis",
             "text": "Whenever a nontoken creature you control dies, put the top two cards of your library into your graveyard. Then return a creature card with lesser converted mana cost than the creature that died from your graveyard to your hand.\n{1}, Sacrifice Death's Oasis: You gain life equal to the greatest converted mana cost among creatures you control.",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "f02b95df-5856-5db7-8659-a1029d0b150f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3974e-3753-4f25-8930-6d96b40332ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3974e-3753-4f25-8930-6d96b40332ce.jpg?1",
             "name": "Dire Tactics",
             "text": "Exile target creature. If you don't control a Human, you lose life equal to that creature's toughness.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "d52eafb7-8a90-5ab0-a917-57f457333b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb2db-228f-4d48-acdf-6330baf356c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb2db-228f-4d48-acdf-6330baf356c7.jpg?1",
             "name": "Eerie Ultimatum",
             "text": "Return any number of permanent cards with different names from your graveyard to the battlefield.",
             "colours": [
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "8c7efa00-c2a1-5e45-8ca9-8a930dbdd245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6a52ab-6d38-4429-9969-90064e615152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6a52ab-6d38-4429-9969-90064e615152.jpg?1",
             "name": "Emergent Ultimatum",
             "text": "Search your library for up to three monocolored cards with different names and exile them. An opponent chooses one of those cards. Shuffle that card into your library. You may cast the other cards without paying their mana costs. Exile Emergent Ultimatum.",
             "colours": [
@@ -6331,7 +6331,7 @@
         },
         {
             "id": "98445397-a664-59a9-a422-e94879cc2ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab220695-e1a9-45ec-a1b1-5a82c9c90a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab220695-e1a9-45ec-a1b1-5a82c9c90a03.jpg?1",
             "name": "Frondland Felidar",
             "text": "Vigilance\nCreatures you control with vigilance have \"{1}, {T}: Tap target creature.\"",
             "colours": [
@@ -6370,7 +6370,7 @@
         },
         {
             "id": "6b186c14-725d-5eb4-9412-631b186ae694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3227ae-0c72-478a-a6dd-661aaf718038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3227ae-0c72-478a-a6dd-661aaf718038.jpg?1",
             "name": "General Kudro of Drannith",
             "text": "Other Humans you control get +1/+1.\nWhenever General Kudro of Drannith or another Human enters the battlefield under your control, exile target card from an opponent's graveyard.\n{2}, Sacrifice two Humans: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "498b22ef-7cf7-562a-af5d-38e718ab5bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a45d0e-582a-4ec1-b83b-71b6a0ff6249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a45d0e-582a-4ec1-b83b-71b6a0ff6249.jpg?1",
             "name": "General's Enforcer",
             "text": "Legendary Humans you control have indestructible.\n{2}{W}{B}: Exile target card from a graveyard. If it was a creature card, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "194b1848-3516-5bf5-8c2f-4c92e090d813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556dfe7a-43e8-4801-ad79-89ab2148eca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556dfe7a-43e8-4801-ad79-89ab2148eca6.jpg?1",
             "name": "Genesis Ultimatum",
             "text": "Look at the top five cards of your library. Put any number of permanent cards from among them onto the battlefield and the rest into your hand. Exile Genesis Ultimatum.",
             "colours": [
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "f3f01bdc-5679-5f7d-94cc-caa5c889f620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc99c81-d112-4811-9bba-77a14d904692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc99c81-d112-4811-9bba-77a14d904692.jpg?1",
             "name": "Illuna, Apex of Wishes",
             "text": "Mutate {3}{RG}{U}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying, trample\nWhenever this creature mutates, exile cards from the top of your library until you exile a nonland permanent card. Put that card onto the battlefield or into your hand.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "c9959ad6-f277-5374-b1bf-2977d0e679fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64f064-8f05-41ef-b95b-1b723137f846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64f064-8f05-41ef-b95b-1b723137f846.jpg?1",
             "name": "Inspired Ultimatum",
             "text": "Target player gains 5 life, Inspired Ultimatum deals 5 damage to any target, then you draw five cards.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "f0b4b160-806a-5d29-bfc8-c9ae5e33f30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cda4a0-0dff-4edb-ae67-a2b7e2971350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cda4a0-0dff-4edb-ae67-a2b7e2971350.jpg?1",
             "name": "Kinnan, Bonder Prodigy",
             "text": "Whenever you tap a nonland permanent for mana, add one mana of any type that permanent produced.\n{5}{G}{U}: Look at the top five cards of your library. You may put a non-Human creature card from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6610,7 +6610,7 @@
         },
         {
             "id": "d9d2e9c0-b1dc-52df-9ae4-b4cbde877399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c608543d-cb60-44c3-a437-e4a18c311420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c608543d-cb60-44c3-a437-e4a18c311420.jpg?1",
             "name": "Labyrinth Raptor",
             "text": "Menace\nWhenever a creature you control with menace becomes blocked, defending player sacrifices a creature blocking it.\n{B}{R}: Creatures you control with menace get +1/+0 until end of turn.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "9e3c6d03-12e9-5a50-bb09-6adfea01bebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e035ca-eccd-4b63-817c-f2c676b9c98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e035ca-eccd-4b63-817c-f2c676b9c98d.jpg?1",
             "name": "Lore Drakkis",
             "text": "Mutate {UR}{UR} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "34e92a87-95e4-5849-97c4-f2473912b2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7b28d8-b835-44a0-978d-cadfd392fff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7b28d8-b835-44a0-978d-cadfd392fff5.jpg?1",
             "name": "Narset of the Ancient Way",
             "text": "+1: You gain 2 life. Add {U}, {R}, or {W}. Spend this mana only to cast a noncreature spell.\n\u22122: Draw a card, then you may discard a card. When you discard a nonland card this way, Narset of the Ancient Way deals damage equal to that card's converted mana cost to target creature or planeswalker.\n\u22126: You get an emblem with \"Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.\"",
             "colours": [
@@ -6730,7 +6730,7 @@
         },
         {
             "id": "01b418a4-f982-57f8-bd75-8874e3c7fd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1ed055-8988-4625-9d57-8ce8a4e04aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1ed055-8988-4625-9d57-8ce8a4e04aea.jpg?1",
             "name": "Necropanther",
             "text": "Mutate {2}{WB}{WB} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "6468e77d-1c96-59a8-8ef9-94b8732f1c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca6eb5a-8bc9-4091-bcfb-b207f0afd188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca6eb5a-8bc9-4091-bcfb-b207f0afd188.jpg?1",
             "name": "Nethroi, Apex of Death",
             "text": "Mutate {4}{RW}{B}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nDeathtouch, lifelink\nWhenever this creature mutates, return any number of target creature cards with total power 10 or less from your graveyard to the battlefield.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "8be785cd-792e-531e-bce9-d1557ba86884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78619ffb-f514-4f9f-9d77-3ab49e045f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78619ffb-f514-4f9f-9d77-3ab49e045f7c.jpg?1",
             "name": "Offspring's Revenge",
             "text": "At the beginning of combat on your turn, exile target red, white, or black creature card from your graveyard. Create a token that's a copy of that card, except it's 1/1. It gains haste until your next turn.",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "be0e5b03-253c-52ef-b71c-403a45dc85a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610bb98c-d66a-44cc-92e2-a80d700b59e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610bb98c-d66a-44cc-92e2-a80d700b59e4.jpg?1",
             "name": "Parcelbeast",
             "text": "Mutate {G}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\n{1}, {T}: Look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -6891,7 +6891,7 @@
         },
         {
             "id": "490673db-70ac-5cc7-95c3-385f020d8f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0afb-7787-4cb8-8bb4-cf6997dbf7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0afb-7787-4cb8-8bb4-cf6997dbf7e4.jpg?1",
             "name": "Primal Empathy",
             "text": "At the beginning of your upkeep, draw a card if you control a creature with the greatest power among creatures on the battlefield. Otherwise, put a +1/+1 counter on a creature you control.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "aae34a9e-d9d5-5ad3-b0e0-682a68337583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e4c609-19c9-433b-a852-7999e375ee4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e4c609-19c9-433b-a852-7999e375ee4f.jpg?1",
             "name": "Quartzwood Crasher",
             "text": "Trample\nWhenever one or more creatures you control with trample deal combat damage to a player, create an X/X green Dinosaur Beast creature token with trample, where X is the amount of damage those creatures dealt to that player.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "59e38a29-d0b7-5450-b867-dfdac5c17072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fdf313-740b-4976-911f-9fb5eb54afce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fdf313-740b-4976-911f-9fb5eb54afce.jpg?1",
             "name": "Regal Leosaur",
             "text": "Mutate {1}{GU}{GU} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, other creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "884118a6-cd59-50e2-b880-463ce370d951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f03c944-1929-4cb2-a373-d57eefa29ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f03c944-1929-4cb2-a373-d57eefa29ed1.jpg?1",
             "name": "Rielle, the Everwise",
             "text": "Rielle, the Everwise gets +1/+0 for each instant and sorcery card in your graveyard.\nWhenever you discard one or more cards for the first time each turn, draw that many cards.",
             "colours": [
@@ -7044,7 +7044,7 @@
         },
         {
             "id": "51357e44-65f8-5a51-8bf6-8334147c27c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1d6ca-7789-46b5-bc89-85cc3915cb85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1d6ca-7789-46b5-bc89-85cc3915cb85.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "Destroy all nonland permanents your opponents control.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "239980f4-b020-585f-96aa-edda4a32dcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d3925c-cf7d-4546-bc70-33f04d4b7566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d3925c-cf7d-4546-bc70-33f04d4b7566.jpg?1",
             "name": "Savai Thundermane",
             "text": "Whenever you cycle a card, you may pay {2}. When you do, Savai Thundermane deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -7119,7 +7119,7 @@
         },
         {
             "id": "fce9f3c3-bbcb-5e63-8f17-1b02fd090a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5ec787-79f6-4922-a0f7-debde8f7a4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5ec787-79f6-4922-a0f7-debde8f7a4be.jpg?1",
             "name": "Skull Prophet",
             "text": "{T}: Add {B} or {G}.\n{T}: Put the top two cards of your library into your graveyard.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "08ed7fb5-f8df-555b-84e7-f50b5ce00f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209dbfd-b765-44c5-b3ad-94f6e0705926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209dbfd-b765-44c5-b3ad-94f6e0705926.jpg?1",
             "name": "Skycat Sovereign",
             "text": "Flying\nSkycat Sovereign gets +1/+1 for each other creature you control with flying.\n{2}{W}{U}: Create a 1/1 white Cat Bird creature token with flying.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "aa40e2e5-c032-580a-b296-f9359ee12fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8067f195-8b6e-4329-a34e-43e52f67c571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8067f195-8b6e-4329-a34e-43e52f67c571.jpg?1",
             "name": "Slitherwisp",
             "text": "Flash\nWhenever you cast another spell that has flash, you draw a card and each opponent loses 1 life.",
             "colours": [
@@ -7234,7 +7234,7 @@
         },
         {
             "id": "a7c56c17-1fe6-5520-bf32-10c4573ad68d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdeeb7-9868-4fc2-9c53-806244cd5488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdeeb7-9868-4fc2-9c53-806244cd5488.jpg?1",
             "name": "Snapdax, Apex of the Hunt",
             "text": "Mutate {2}{BR}{W}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nDouble strike\nWhenever this creature mutates, it deals 4 damage to target creature or planeswalker an opponent controls and you gain 4 life.",
             "colours": [
@@ -7279,7 +7279,7 @@
         },
         {
             "id": "9e11b64e-86e5-5936-b34c-2e93410110bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7320233-1c83-4f61-8c08-cc8361867256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7320233-1c83-4f61-8c08-cc8361867256.jpg?1",
             "name": "Song of Creation",
             "text": "You may play an additional land on each of your turns.\nWhenever you cast a spell, draw two cards.\nAt the beginning of your end step, discard your hand.",
             "colours": [
@@ -7317,7 +7317,7 @@
         },
         {
             "id": "f3a94132-ce71-5556-bfd3-1461601a810d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f6118-adb8-4a7d-9c77-5570f3399e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f6118-adb8-4a7d-9c77-5570f3399e6e.jpg?1",
             "name": "Sprite Dragon",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on Sprite Dragon.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "89cebc6e-20fd-5107-a9dc-675281f145f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d4e6f3-73cb-4799-bcb9-c1f5bc234a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d4e6f3-73cb-4799-bcb9-c1f5bc234a02.jpg?1",
             "name": "Titans' Nest",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\nExile a card from your graveyard: Add {C}. Spend this mana only to cast a colored spell without {X} in its mana cost.",
             "colours": [
@@ -7395,7 +7395,7 @@
         },
         {
             "id": "e9e82e36-bf89-5b5d-bf33-2e7aa3a92580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063a95ee-3fda-436f-9ff8-de80cc874dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063a95ee-3fda-436f-9ff8-de80cc874dde.jpg?1",
             "name": "Trumpeting Gnarr",
             "text": "Mutate {3}{GW}{GW} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, create a 3/3 green Beast creature token.",
             "colours": [
@@ -7433,7 +7433,7 @@
         },
         {
             "id": "f07d63b4-4708-56d6-930d-abae98a2d071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7b0256-d342-4523-9516-6a007bf51825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7b0256-d342-4523-9516-6a007bf51825.jpg?1",
             "name": "Vadrok, Apex of Thunder",
             "text": "Mutate {1}{WU}{R}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying, first strike\nWhenever this creature mutates, you may cast target noncreature card with converted mana cost 3 or less from your graveyard without paying its mana cost.",
             "colours": [
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "2f045425-0d27-540c-ad03-0c339adc6207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0699cbc-b499-44a6-82e1-631491aaaec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0699cbc-b499-44a6-82e1-631491aaaec6.jpg?1",
             "name": "Whirlwind of Thought",
             "text": "Whenever you cast a noncreature spell, draw a card.",
             "colours": [
@@ -7516,7 +7516,7 @@
         },
         {
             "id": "d943182b-88a8-5103-a306-667f862b1935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd13a6c-23d3-44ce-a628-cb1c19d777c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd13a6c-23d3-44ce-a628-cb1c19d777c4.jpg?1",
             "name": "Winota, Joiner of Forces",
             "text": "Whenever a non-Human creature you control attacks, look at the top six cards of your library. You may put a Human creature card from among them onto the battlefield tapped and attacking. It gains indestructible until end of turn. Put the rest of the cards on the bottom of your library in a random order.",
             "colours": [
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "d318b77d-ea8f-5260-b3f7-a8830c4633e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf6e906-9305-4003-b040-1dfecca590c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf6e906-9305-4003-b040-1dfecca590c1.jpg?1",
             "name": "A-Winota, Joiner of Forces",
             "text": "",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "5a87360a-16dc-532d-b272-b765026b202f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efac1ed-3f01-487c-86be-8239568b4425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efac1ed-3f01-487c-86be-8239568b4425.jpg?1",
             "name": "Zenith Flare",
             "text": "Zenith Flare deals X damage to any target and you gain X life, where X is the number of cards with a cycling ability in your graveyard.",
             "colours": [
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "86cf4d49-4698-576b-ae97-e16fceeee184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2ccae-c322-4e99-a094-a68fc5d52ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2ccae-c322-4e99-a094-a68fc5d52ea3.jpg?1",
             "name": "Alert Heedbonder",
             "text": "Vigilance\nAt the beginning of your end step, you gain 1 life for each creature you control with vigilance.",
             "colours": [
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "f23ed192-57c8-5e0f-a4d9-783aa05ac489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb202e7-f9a4-4785-840d-18aa6aa663b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb202e7-f9a4-4785-840d-18aa6aa663b4.jpg?1",
             "name": "Cunning Nightbonder",
             "text": "Flash\nSpells with flash you cast cost {1} less to cast and can't be countered.",
             "colours": [
@@ -7703,7 +7703,7 @@
         },
         {
             "id": "aed0fad6-b599-5d55-ab16-35391b7716e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd9d800-6d31-42e2-87d2-772db0ff95ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd9d800-6d31-42e2-87d2-772db0ff95ed.jpg?1",
             "name": "Fiend Artisan",
             "text": "Fiend Artisan gets +1/+1 for each creature card in your graveyard.\n{X}{BG}, {T}, Sacrifice another creature: Search your library for a creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "6f3fc058-f695-5b01-8262-a88b95dd1d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eb1804-6fd8-4917-af36-87fdfce39d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eb1804-6fd8-4917-af36-87fdfce39d3a.jpg?1",
             "name": "Gyruda, Doom of Depths",
             "text": "Companion \u2014 Your starting deck contains only cards with even converted mana costs. (If this card is your chosen companion, you may cast it once from outside the game.)\nWhen Gyruda enters the battlefield, each player puts the top four cards of their library into their graveyard. Put a creature card with an even converted mana cost from among those cards onto the battlefield under your control.",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "02a724f6-4a37-5321-81a3-a2fb658b4566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d52e527-3835-4350-8c01-0f2d5d623b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d52e527-3835-4350-8c01-0f2d5d623b9c.jpg?1",
             "name": "Jegantha, the Wellspring",
             "text": "Companion \u2014 No card in your starting deck has more than one of the same mana symbol in its mana cost. (If this card is your chosen companion, you may cast it once from outside the game.)\n{T}: Add {W}{U}{B}{R}{G}. This mana can't be spent to pay generic mana costs.",
             "colours": [
@@ -7827,7 +7827,7 @@
         },
         {
             "id": "049ec717-52bf-56ce-99d3-005092acdcef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8f2d69-fba9-40e5-8ef7-75e14ef4070a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8f2d69-fba9-40e5-8ef7-75e14ef4070a.jpg?1",
             "name": "Jubilant Skybonder",
             "text": "Flying\nCreatures you control with flying have \"Spells your opponents cast that target this creature cost {2} more to cast.\"",
             "colours": [
@@ -7864,7 +7864,7 @@
         },
         {
             "id": "1a9f0cd9-e4fc-5c3d-951e-b7f37fefad78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebed0b-8060-4a7b-a060-5cfcd2172b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebed0b-8060-4a7b-a060-5cfcd2172b16.jpg?1",
             "name": "Kaheera, the Orphanguard",
             "text": "Companion \u2014 Each creature card in your starting deck is a Cat, Elemental, Nightmare, Dinosaur, or Beast card. (If this card is your chosen companion, you may cast it once from outside the game.)\nVigilance\nEach other creature you control that's a Cat, Elemental, Nightmare, Dinosaur, or Beast gets +1/+1 and has vigilance.",
             "colours": [
@@ -7905,7 +7905,7 @@
         },
         {
             "id": "90b4baf3-db2a-5171-8df3-2b463509a456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ee952-de7a-420f-993c-a38db89bc8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ee952-de7a-420f-993c-a38db89bc8ac.jpg?1",
             "name": "Keruga, the Macrosage",
             "text": "Companion \u2014 Your starting deck contains only cards with converted mana cost 3 or greater and land cards. (If this card is your chosen companion, you may cast it once from outside the game.)\nWhen Keruga, the Macrosage enters the battlefield, draw a card for each other permanent you control with converted mana cost 3 or greater.",
             "colours": [
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "d15f90a4-afd5-57d0-b303-07e32be36648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad36fb2-c44e-4085-ba0d-54277841ad3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad36fb2-c44e-4085-ba0d-54277841ad3a.jpg?1",
             "name": "Lurrus of the Dream-Den",
             "text": "Companion \u2014 Each permanent card in your starting deck has converted mana cost 2 or less. (If this card is your chosen companion, you may cast it once from outside the game.)\nLifelink\nDuring each of your turns, you may cast one permanent spell with converted mana cost 2 or less from your graveyard.",
             "colours": [
@@ -7987,7 +7987,7 @@
         },
         {
             "id": "e70f447c-6386-50bf-b376-a4cbb807d125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1189c9-7842-466e-8238-1e02677d8494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1189c9-7842-466e-8238-1e02677d8494.jpg?1",
             "name": "Lutri, the Spellchaser",
             "text": "Companion \u2014 Each nonland card in your starting deck has a different name. (If this card is your chosen companion, you may cast it once from outside the game.)\nFlash\nWhen Lutri, the Spellchaser enters the battlefield, if you cast it, copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "310e4b40-8931-5d39-8e63-399d913e7285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451507de-9c42-43ee-b9ba-1f69e9aa29d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451507de-9c42-43ee-b9ba-1f69e9aa29d2.jpg?1",
             "name": "Obosh, the Preypiercer",
             "text": "Companion \u2014 Your starting deck contains only cards with odd converted mana costs and land cards. (If this card is your chosen companion, you may cast it once from outside the game.)\nIf a source you control with an odd converted mana cost would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -8069,7 +8069,7 @@
         },
         {
             "id": "89e28082-be28-5525-805b-4938046638f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4876e17-a206-4351-9c0b-0845db4569a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4876e17-a206-4351-9c0b-0845db4569a3.jpg?1",
             "name": "Proud Wildbonder",
             "text": "Trample\nCreatures you control with trample have \"You may have this creature assign its combat damage as though it weren't blocked.\"",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "9c072db1-b96f-5f77-8b89-2c0e2b6494f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f0b25-6e6e-43c4-a4a0-903920067df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f0b25-6e6e-43c4-a4a0-903920067df1.jpg?1",
             "name": "Sonorous Howlbonder",
             "text": "Menace\nEach creature you control with menace can't be blocked except by three or more creatures.",
             "colours": [
@@ -8143,7 +8143,7 @@
         },
         {
             "id": "69f1601a-c4b3-5596-a73a-bc8d1955e531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac31e0-ac70-4ee6-b2b1-cc445ffa1da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac31e0-ac70-4ee6-b2b1-cc445ffa1da9.jpg?1",
             "name": "Umori, the Collector",
             "text": "Companion \u2014 Each nonland card in your starting deck shares a card type. (If this card is your chosen companion, you may cast it once from outside the game.)\nAs Umori, the Collector enters the battlefield, choose a card type.\nSpells you cast of the chosen type cost {1} less to cast.",
             "colours": [
@@ -8183,7 +8183,7 @@
         },
         {
             "id": "1b6b455a-34dd-5426-99c5-13f60e9bfcb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275426c4-c14e-47d0-a9d4-24da7f6f6911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275426c4-c14e-47d0-a9d4-24da7f6f6911.jpg?1",
             "name": "Yorion, Sky Nomad",
             "text": "Companion \u2014 Your starting deck contains at least twenty cards more than the minimum deck size. (If this card is your chosen companion, you may cast it once from outside the game.)\nFlying\nWhen Yorion enters the battlefield, exile any number of other nonland permanents you own and control. Return those cards to the battlefield at the beginning of the next end step.",
             "colours": [
@@ -8224,7 +8224,7 @@
         },
         {
             "id": "35f3951f-5ed3-5ede-858d-4c26986cdbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e61c-2ee8-4243-a848-7008810db8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e61c-2ee8-4243-a848-7008810db8a0.jpg?1",
             "name": "Zirda, the Dawnwaker",
             "text": "Companion \u2014 Each permanent card in your starting deck has an activated ability. (If this card is your chosen companion, you may cast it once from outside the game.)\nAbilities you activate that aren't mana abilities cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.\n{1}, {T}: Target creature can't block this turn.",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "f81c079e-64da-596c-9777-fdd7c06c3010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1146c418-2176-466e-8a06-f2ef6bf2b1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1146c418-2176-466e-8a06-f2ef6bf2b1a9.jpg?1",
             "name": "Crystalline Giant",
             "text": "At the beginning of combat on your turn, choose a kind of counter at random that Crystalline Giant doesn't have on it from among flying, first strike, deathtouch, hexproof, lifelink, menace, reach, trample, vigilance, and +1/+1. Put a counter of that kind on Crystalline Giant.",
             "colours": [],
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "58315e6e-4f1c-5ac1-8782-f95466fa1ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdace59f-f025-4717-8eb4-3d1e13b31d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdace59f-f025-4717-8eb4-3d1e13b31d2b.jpg?1",
             "name": "Indatha Crystal",
             "text": "{T}: Add {W}, {B}, or {G}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "6520246f-261e-5d5a-bf61-1c4e9c885074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df435cb-3aeb-490a-8fca-91f3b6936965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df435cb-3aeb-490a-8fca-91f3b6936965.jpg?1",
             "name": "Ketria Crystal",
             "text": "{T}: Add {G}, {U}, or {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8363,7 +8363,7 @@
         },
         {
             "id": "a5308950-4946-5cf2-808d-26e644d9f30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9341ed06-53db-4604-b60a-3ea9129afbc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9341ed06-53db-4604-b60a-3ea9129afbc2.jpg?1",
             "name": "The Ozolith",
             "text": "Whenever a creature you control leaves the battlefield, if it had counters on it, put those counters on The Ozolith.\nAt the beginning of combat on your turn, if The Ozolith has counters on it, you may move all counters from The Ozolith onto target creature.",
             "colours": [],
@@ -8395,7 +8395,7 @@
         },
         {
             "id": "5bea6a67-2a4a-5f41-94aa-7c7eb0e99387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bce0fb-53d6-47ee-8c5a-a99e50f67fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bce0fb-53d6-47ee-8c5a-a99e50f67fc9.jpg?1",
             "name": "Raugrin Crystal",
             "text": "{T}: Add {U}, {R}, or {W}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "499d23a0-db63-5085-9f03-b2267e37ec58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954a5c1-89b1-4edd-814e-8f88fd49cda3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954a5c1-89b1-4edd-814e-8f88fd49cda3.jpg?1",
             "name": "Savai Crystal",
             "text": "{T}: Add {R}, {W}, or {B}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "0cc5661e-5119-5b55-9b6f-318f950bc253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311f827a-1585-483e-b0fd-3dc05969b485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311f827a-1585-483e-b0fd-3dc05969b485.jpg?1",
             "name": "Sleeper Dart",
             "text": "When Sleeper Dart enters the battlefield, draw a card.\n{T}, Sacrifice Sleeper Dart: Target creature doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "bf55db75-7524-534d-85c0-e58fc6e210ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741de51-ea92-493a-8058-e0f2000e7701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741de51-ea92-493a-8058-e0f2000e7701.jpg?1",
             "name": "Springjaw Trap",
             "text": "Flash\n{4}, {T}, Sacrifice Springjaw Trap: It deals 3 damage to any target.",
             "colours": [],
@@ -8515,7 +8515,7 @@
         },
         {
             "id": "71fd817e-cd28-582b-96fd-675b8ab46316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9138a442-8e8b-465f-bb76-b6af7e6dab6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9138a442-8e8b-465f-bb76-b6af7e6dab6f.jpg?1",
             "name": "Zagoth Crystal",
             "text": "{T}: Add {B}, {G}, or {U}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8547,7 +8547,7 @@
         },
         {
             "id": "acc56d9e-c2ca-5459-bb54-4a99390d9460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8269e6-b30c-4fdc-82a7-d503c133afa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8269e6-b30c-4fdc-82a7-d503c133afa6.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8578,7 +8578,7 @@
         },
         {
             "id": "05234d95-db8f-51c6-8693-70af0008e0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828044d6-0f53-4caf-a581-d71919df4175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828044d6-0f53-4caf-a581-d71919df4175.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8609,7 +8609,7 @@
         },
         {
             "id": "45824e6d-9aad-524c-a537-cd4a245614a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe9388d-b1ee-4f35-9fbd-5f504528b398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe9388d-b1ee-4f35-9fbd-5f504528b398.jpg?1",
             "name": "Bonders' Enclave",
             "text": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate this ability only if you control a creature with power 4 or greater.",
             "colours": [],
@@ -8639,7 +8639,7 @@
         },
         {
             "id": "5e8c5056-91cd-5b48-8d3f-4e71f9347c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0981e-54fc-4919-96a4-a9608a5452fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0981e-54fc-4919-96a4-a9608a5452fc.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "c818af25-ca69-596a-8902-1483205fd27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3d6745-8904-4905-a98f-d43f18b51d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3d6745-8904-4905-a98f-d43f18b51d6d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "4a559698-608b-5d25-8ac1-1ae604e30383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b74bb81-fb9a-40e5-a941-e517430b52f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b74bb81-fb9a-40e5-a941-e517430b52f5.jpg?1",
             "name": "Indatha Triome",
             "text": "({T}: Add {W}, {B}, or {G}.)\nIndatha Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "9c8b8080-228f-5cec-8ed4-1a3dc93e5fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01926862-bf2d-4a2b-af94-1ea5e4dd7444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01926862-bf2d-4a2b-af94-1ea5e4dd7444.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "d110dabf-b35c-5392-b1c8-bb2331a01148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249b1f4-2b22-4b67-a207-e0c4ae95d2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249b1f4-2b22-4b67-a207-e0c4ae95d2e1.jpg?1",
             "name": "Ketria Triome",
             "text": "({T}: Add {G}, {U}, or {R}.)\nKetria Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "1d9c469f-5526-5262-ade1-9bcc627d7247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02138fbb-3962-4348-8d31-faaefba0b8b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02138fbb-3962-4348-8d31-faaefba0b8b2.jpg?1",
             "name": "Raugrin Triome",
             "text": "({T}: Add {U}, {R}, or {W}.)\nRaugrin Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8843,7 +8843,7 @@
         },
         {
             "id": "cbcb76fe-0e86-57ce-a41a-74bdc73bf0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a69fa8f-1c2b-453d-8d54-2748890ce925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a69fa8f-1c2b-453d-8d54-2748890ce925.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "d570b77b-cd78-55d3-965d-09cd27030416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748e6a61-9c1f-4225-9f04-e54002f63ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748e6a61-9c1f-4225-9f04-e54002f63ac3.jpg?1",
             "name": "Savai Triome",
             "text": "({T}: Add {R}, {W}, or {B}.)\nSavai Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "2f71fa70-5939-50ac-aae1-de3ad5615e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2282018a-46c8-41ca-ab93-f7dbf32cd295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2282018a-46c8-41ca-ab93-f7dbf32cd295.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "8f6aeeea-333b-5ea5-9e09-81bdc01a8f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7108c071-5f1c-4cf5-90c6-530cee3f7685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7108c071-5f1c-4cf5-90c6-530cee3f7685.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8974,7 +8974,7 @@
         },
         {
             "id": "6ab08d15-01fd-5401-9348-54c0a679d4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d011b0f-1681-4a51-9f5d-47ad135d03fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d011b0f-1681-4a51-9f5d-47ad135d03fe.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9005,7 +9005,7 @@
         },
         {
             "id": "fae4a3bb-b350-56dd-ae3a-d5b5fc93a404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ac097-39cb-4401-87c7-1dd73bf34329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ac097-39cb-4401-87c7-1dd73bf34329.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9036,7 +9036,7 @@
         },
         {
             "id": "8ef17795-afce-5f19-8a2c-0e3ac9469174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86367edc-9587-4f3b-aa95-c3a2bfc8c6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86367edc-9587-4f3b-aa95-c3a2bfc8c6f4.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9067,7 +9067,7 @@
         },
         {
             "id": "7bfbe058-d513-58e2-8892-a4c5cf67e0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc520518-2063-4b57-a0d4-10cf62a7175e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc520518-2063-4b57-a0d4-10cf62a7175e.jpg?1",
             "name": "Zagoth Triome",
             "text": "({T}: Add {B}, {G}, or {U}.)\nZagoth Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9105,7 +9105,7 @@
         },
         {
             "id": "d64c14d1-f545-5e71-bae0-0ed02d9196aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebbce9-fd10-4c14-b52d-cf82c0c1a58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebbce9-fd10-4c14-b52d-cf82c0c1a58c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "d7ffb076-7251-5eb2-bc70-ec035ed40af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84f2b9b-1412-476f-8739-17d35ea48a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84f2b9b-1412-476f-8739-17d35ea48a51.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "4ae4552c-ba52-5bd9-8c9b-631717f225ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65b379-47a9-48f2-be6e-abb4e7868ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65b379-47a9-48f2-be6e-abb4e7868ad0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "738ccbb2-ed6c-54d4-b512-1cab22bd5ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2ad5b3-7257-4521-8916-6b1cbfb89e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2ad5b3-7257-4521-8916-6b1cbfb89e27.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "52a1331b-d6ba-5411-8385-fe1e21bc9d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9bbc32-a89a-4bed-ab52-ac6569ec74ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9bbc32-a89a-4bed-ab52-ac6569ec74ce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "01a62c88-be14-508e-8eb6-15673668ad45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be169f8c-6472-40ec-9b4a-0edcb63e9e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be169f8c-6472-40ec-9b4a-0edcb63e9e2f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "f9b97388-17d6-54f3-9f3d-923863e14786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c3f0e-7af4-410b-a675-9ea84f51e812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c3f0e-7af4-410b-a675-9ea84f51e812.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "a147c37c-143f-53c8-9708-b841f8e5ebb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d99025-46bc-4848-bcbc-bee858ed906c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d99025-46bc-4848-bcbc-bee858ed906c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9401,7 +9401,7 @@
         },
         {
             "id": "89b5d419-161e-5be9-8a41-4396f37e21c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45991831-1018-4f98-a4ad-0998a9577d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45991831-1018-4f98-a4ad-0998a9577d97.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "7a72e9a9-0fda-5ab9-914e-3125c03fcf3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3d2fcd-11e0-4071-8c53-cb3315b7360a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3d2fcd-11e0-4071-8c53-cb3315b7360a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9475,7 +9475,7 @@
         },
         {
             "id": "a5b50a68-1485-5f52-acaa-07ceee3bcba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ba09d-ecdd-48c0-af0b-3dc5ef908f9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ba09d-ecdd-48c0-af0b-3dc5ef908f9e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9512,7 +9512,7 @@
         },
         {
             "id": "4b1d8e05-2031-5883-a1e8-b8c758dcf632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609028b-43b8-4aea-9f9a-25aa127482db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609028b-43b8-4aea-9f9a-25aa127482db.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9549,7 +9549,7 @@
         },
         {
             "id": "9f6b7e5a-4770-5c59-80c5-86b4320ffa3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c348494-f60c-4bd1-9077-bff24f2e634b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c348494-f60c-4bd1-9077-bff24f2e634b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9586,7 +9586,7 @@
         },
         {
             "id": "8c1f6c17-f5f4-5605-a321-ca21ee6b1f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb61e54a-646b-4c0a-88fe-f55d514202aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb61e54a-646b-4c0a-88fe-f55d514202aa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "902f5e18-a61b-5678-ade8-4b135bf07881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cf3bbf-acc0-4fe7-a631-aca698190ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cf3bbf-acc0-4fe7-a631-aca698190ce2.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9660,7 +9660,7 @@
         },
         {
             "id": "bf553e3b-7b79-5cf1-a40e-a0115baa6b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0639a0-c898-4a07-975c-a02bdd53175b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0639a0-c898-4a07-975c-a02bdd53175b.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "Trample\nLethal damage dealt to creatures you control is determined by their power rather than their toughness.",
             "colours": [
@@ -9700,7 +9700,7 @@
         },
         {
             "id": "30c3ae76-75b2-5fee-be86-2a847ce7c954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c48ddf5-c2da-4fbc-95f2-8a3f2f5737ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c48ddf5-c2da-4fbc-95f2-8a3f2f5737ba.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "",
             "colours": [
@@ -9739,7 +9739,7 @@
         },
         {
             "id": "62ec689f-4d8b-5ea0-9b13-9cff3d9c990e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f74c3-c552-4331-a47c-e8155841bb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f74c3-c552-4331-a47c-e8155841bb27.jpg?1",
             "name": "Lukka, Coppercoat Outcast",
             "text": "",
             "colours": [
@@ -9777,7 +9777,7 @@
         },
         {
             "id": "5e52bd2a-f453-58d1-ab8a-9d42295f445e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7ce2ee-2ebc-4336-a9f3-02380ea9784b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7ce2ee-2ebc-4336-a9f3-02380ea9784b.jpg?1",
             "name": "Vivien, Monsters' Advocate",
             "text": "",
             "colours": [
@@ -9815,7 +9815,7 @@
         },
         {
             "id": "f0aedec3-750f-5e6c-89d4-8bb95bf57d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ac6589-75ee-4fbf-8056-1860c1482592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ac6589-75ee-4fbf-8056-1860c1482592.jpg?1",
             "name": "Narset of the Ancient Way",
             "text": "",
             "colours": [
@@ -9857,7 +9857,7 @@
         },
         {
             "id": "6661f745-7e01-5d62-b31f-edd24558d501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17398d7f-baf3-4605-aced-21582a81c73a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17398d7f-baf3-4605-aced-21582a81c73a.jpg?1",
             "name": "Cubwarden",
             "text": "",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "be11fd9c-0c32-5df5-a169-fee93da35ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208084f5-35d4-4042-bdc6-dc2bf14c9990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208084f5-35d4-4042-bdc6-dc2bf14c9990.jpg?1",
             "name": "Huntmaster Liger",
             "text": "",
             "colours": [
@@ -9930,7 +9930,7 @@
         },
         {
             "id": "08457d1c-cb77-506c-b0d5-56e5ca653cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d63b878-4d0d-444c-9db2-05cf5dd3fa8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d63b878-4d0d-444c-9db2-05cf5dd3fa8c.jpg?1",
             "name": "Majestic Auricorn",
             "text": "",
             "colours": [
@@ -9966,7 +9966,7 @@
         },
         {
             "id": "2cebf1ad-2a90-5fda-970c-bb9b8fb10bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dae1f-a767-49f8-b4e2-85161f2685d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dae1f-a767-49f8-b4e2-85161f2685d5.jpg?1",
             "name": "Vulpikeet",
             "text": "",
             "colours": [
@@ -10003,7 +10003,7 @@
         },
         {
             "id": "c3f98d3c-210b-5e32-bed5-cd17f643912e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cda84f-7bd8-4166-b496-a04a4baa9b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cda84f-7bd8-4166-b496-a04a4baa9b62.jpg?1",
             "name": "Archipelagore",
             "text": "",
             "colours": [
@@ -10039,7 +10039,7 @@
         },
         {
             "id": "02d174b8-5d9e-55bf-abff-b53218b1cdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1828b1-a6eb-4346-b405-7642e34b3e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1828b1-a6eb-4346-b405-7642e34b3e71.jpg?1",
             "name": "Dreamtail Heron",
             "text": "",
             "colours": [
@@ -10076,7 +10076,7 @@
         },
         {
             "id": "98363b5d-e614-5cdd-8c60-6a9373cd567c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428228-83a0-440f-afe9-573c9d8640cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428228-83a0-440f-afe9-573c9d8640cc.jpg?1",
             "name": "Pouncing Shoreshark",
             "text": "",
             "colours": [
@@ -10113,7 +10113,7 @@
         },
         {
             "id": "f2bd9f3f-bc04-5aa8-b022-899c84d83062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6986a8-e258-46f0-88a9-8f84732f359e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6986a8-e258-46f0-88a9-8f84732f359e.jpg?1",
             "name": "Sea-Dasher Octopus",
             "text": "",
             "colours": [
@@ -10149,7 +10149,7 @@
         },
         {
             "id": "82765c2e-f409-5d50-afb7-5a57dc5bfb0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecae13c-fbbf-4199-a1dc-0e14263ed887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecae13c-fbbf-4199-a1dc-0e14263ed887.jpg?1",
             "name": "Cavern Whisperer",
             "text": "",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "128a058f-36f4-5c48-bb54-4bd107913482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd157ee-d17e-402c-a97d-206445dcf864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd157ee-d17e-402c-a97d-206445dcf864.jpg?1",
             "name": "Chittering Harvester",
             "text": "",
             "colours": [
@@ -10221,7 +10221,7 @@
         },
         {
             "id": "cc2778a4-a8dc-55c8-8b0d-e5e09c4a868d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef6998d-bda7-4847-b3d6-30e1596bf730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef6998d-bda7-4847-b3d6-30e1596bf730.jpg?1",
             "name": "Dirge Bat",
             "text": "",
             "colours": [
@@ -10258,7 +10258,7 @@
         },
         {
             "id": "71e3079a-c62e-51c9-ac7e-5c8d3ed94712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada6588b-3efc-4464-ae83-11586eb54775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada6588b-3efc-4464-ae83-11586eb54775.jpg?1",
             "name": "Insatiable Hemophage",
             "text": "",
             "colours": [
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "df9e0cea-e7ce-5fbe-ae04-72edadded0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db7d906-1794-40eb-9d73-1f2a4db3a13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db7d906-1794-40eb-9d73-1f2a4db3a13f.jpg?1",
             "name": "Cloudpiercer",
             "text": "",
             "colours": [
@@ -10330,7 +10330,7 @@
         },
         {
             "id": "be20d529-183f-5f99-82d6-a3d35cc4c7e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe3c735-d091-4a32-8d10-38a7f23e5c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe3c735-d091-4a32-8d10-38a7f23e5c65.jpg?1",
             "name": "Everquill Phoenix",
             "text": "",
             "colours": [
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "65778d61-cfd7-51b4-a9da-a378c19c0a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6373fe1-c834-419e-8a0b-590fb5dc555e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6373fe1-c834-419e-8a0b-590fb5dc555e.jpg?1",
             "name": "Porcuparrot",
             "text": "",
             "colours": [
@@ -10404,7 +10404,7 @@
         },
         {
             "id": "79c14bf3-53b3-5eec-9972-83a5e39c231d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b41cfa-b22e-4d34-bfe9-68c9d8740704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b41cfa-b22e-4d34-bfe9-68c9d8740704.jpg?1",
             "name": "Auspicious Starrix",
             "text": "",
             "colours": [
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "14c9bb0e-89a9-5b12-8f95-cae9eda7cf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75546a5-81fd-41c1-a081-d8980f6bd60a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75546a5-81fd-41c1-a081-d8980f6bd60a.jpg?1",
             "name": "Gemrazer",
             "text": "",
             "colours": [
@@ -10478,7 +10478,7 @@
         },
         {
             "id": "b1b23fc8-bab7-5719-b483-1eb8adf2c131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980dcb8f-fc04-49d2-9859-830ca3d12af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980dcb8f-fc04-49d2-9859-830ca3d12af6.jpg?1",
             "name": "Glowstone Recluse",
             "text": "",
             "colours": [
@@ -10514,7 +10514,7 @@
         },
         {
             "id": "5178eae1-be17-50cc-a52e-7b41a465885c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e31f56d-bf75-4e14-94de-5c77193abf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e31f56d-bf75-4e14-94de-5c77193abf3a.jpg?1",
             "name": "Migratory Greathorn",
             "text": "",
             "colours": [
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "d1372a9c-a5b0-5c5f-8b97-c6aa7cececd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0232c0-0867-4217-8e5d-b3454c0c8dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0232c0-0867-4217-8e5d-b3454c0c8dab.jpg?1",
             "name": "Boneyard Lurker",
             "text": "",
             "colours": [
@@ -10589,7 +10589,7 @@
         },
         {
             "id": "7b0aad4c-3f93-5250-a60a-3a121d8eac02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4dfeb-d2a8-4b34-8605-75a79c706fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4dfeb-d2a8-4b34-8605-75a79c706fe0.jpg?1",
             "name": "Brokkos, Apex of Forever",
             "text": "",
             "colours": [
@@ -10634,7 +10634,7 @@
         },
         {
             "id": "0898a67d-e593-5028-b0e2-66f9fe5c11b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c974c68-1a9f-457a-8bcb-265d29fee8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c974c68-1a9f-457a-8bcb-265d29fee8e4.jpg?1",
             "name": "Illuna, Apex of Wishes",
             "text": "",
             "colours": [
@@ -10679,7 +10679,7 @@
         },
         {
             "id": "efd0dbcd-0256-5e31-85dd-efadd95ce2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e938fac3-544a-4f27-9726-a67153392031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e938fac3-544a-4f27-9726-a67153392031.jpg?1",
             "name": "Lore Drakkis",
             "text": "",
             "colours": [
@@ -10718,7 +10718,7 @@
         },
         {
             "id": "53b63b9f-d5a4-5511-9d55-9bb45826805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776f88b-65f5-4cac-8207-c7e6b976d206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776f88b-65f5-4cac-8207-c7e6b976d206.jpg?1",
             "name": "Necropanther",
             "text": "",
             "colours": [
@@ -10757,7 +10757,7 @@
         },
         {
             "id": "5be41c2f-a7dc-5933-84b1-44c341c78e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba04c102-e4c1-43a8-9c2f-d1f3c9bf5edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba04c102-e4c1-43a8-9c2f-d1f3c9bf5edf.jpg?1",
             "name": "Nethroi, Apex of Death",
             "text": "",
             "colours": [
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "fe77f67e-02e8-5a3b-944d-2b8bbf0c00b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac98e5-a22c-41b5-94a9-b37b5aeb124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac98e5-a22c-41b5-94a9-b37b5aeb124f.jpg?1",
             "name": "Parcelbeast",
             "text": "",
             "colours": [
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "c6efa4d1-2a6b-515e-a46d-87a77ed14717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8801b-6cfd-4ada-b6cc-bac09117f4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8801b-6cfd-4ada-b6cc-bac09117f4d5.jpg?1",
             "name": "Regal Leosaur",
             "text": "",
             "colours": [
@@ -10880,7 +10880,7 @@
         },
         {
             "id": "c0f52b87-d699-5af0-9baf-54bdc823a027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceffd13b-8039-44ed-bd7f-68d46476dbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceffd13b-8039-44ed-bd7f-68d46476dbe7.jpg?1",
             "name": "Snapdax, Apex of the Hunt",
             "text": "",
             "colours": [
@@ -10925,7 +10925,7 @@
         },
         {
             "id": "678ab9f6-d88f-5f28-9319-97a13f63f258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe88a45-a420-4998-b242-b475c6b5b0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe88a45-a420-4998-b242-b475c6b5b0bc.jpg?1",
             "name": "Trumpeting Gnarr",
             "text": "",
             "colours": [
@@ -10963,7 +10963,7 @@
         },
         {
             "id": "517e63e2-22dd-5747-9d10-608850ce3c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b75a1-c12c-4904-8a65-4eb75d1d32f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b75a1-c12c-4904-8a65-4eb75d1d32f7.jpg?1",
             "name": "Vadrok, Apex of Thunder",
             "text": "",
             "colours": [
@@ -11008,7 +11008,7 @@
         },
         {
             "id": "3bda577e-629e-5ddf-9f2a-ded7a7718307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf2b208-79c6-4c4c-bf66-871352ed600f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf2b208-79c6-4c4c-bf66-871352ed600f.jpg?1",
             "name": "Indatha Triome",
             "text": "",
             "colours": [],
@@ -11046,7 +11046,7 @@
         },
         {
             "id": "b1d108dc-bbe1-58fa-bf01-ffb40f5f2c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b5b9bb-ee9f-4a52-bd74-fd2759c8e3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b5b9bb-ee9f-4a52-bd74-fd2759c8e3d3.jpg?1",
             "name": "Ketria Triome",
             "text": "",
             "colours": [],
@@ -11084,7 +11084,7 @@
         },
         {
             "id": "1c93509b-3a8c-5ce2-a710-2cb545d9f73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303a627-cce3-4045-81f8-fe7427e0a941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303a627-cce3-4045-81f8-fe7427e0a941.jpg?1",
             "name": "Raugrin Triome",
             "text": "",
             "colours": [],
@@ -11122,7 +11122,7 @@
         },
         {
             "id": "f8371146-020e-5455-952e-4a4c041eb2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21ef9e6-e2dd-4e0a-a36c-e07034ac4ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21ef9e6-e2dd-4e0a-a36c-e07034ac4ba3.jpg?1",
             "name": "Savai Triome",
             "text": "",
             "colours": [],
@@ -11160,7 +11160,7 @@
         },
         {
             "id": "f082ca30-a227-5c88-b95a-37ca03cefcd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f809f970-25a7-4c34-b98f-1cb08012080d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f809f970-25a7-4c34-b98f-1cb08012080d.jpg?1",
             "name": "Zagoth Triome",
             "text": "",
             "colours": [],
@@ -11198,7 +11198,7 @@
         },
         {
             "id": "b64d9b40-d67d-5467-82cc-5a068ba139cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adaf8f6a-9559-4b47-8e67-2c4c3d6d8c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adaf8f6a-9559-4b47-8e67-2c4c3d6d8c60.jpg?1",
             "name": "Drannith Magistrate",
             "text": "",
             "colours": [
@@ -11235,7 +11235,7 @@
         },
         {
             "id": "19529a83-ff94-5029-9ce9-c4850280ac95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ab4e55-7c55-4480-83df-c9d9fd4df65a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ab4e55-7c55-4480-83df-c9d9fd4df65a.jpg?1",
             "name": "Lavabrink Venturer",
             "text": "",
             "colours": [
@@ -11272,7 +11272,7 @@
         },
         {
             "id": "91cff9f4-41ec-5359-8723-dd2e6ba6efc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535c823-f6e9-4a2f-8adf-f69b6f0fea1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535c823-f6e9-4a2f-8adf-f69b6f0fea1f.jpg?1",
             "name": "Luminous Broodmoth",
             "text": "",
             "colours": [
@@ -11309,7 +11309,7 @@
         },
         {
             "id": "9d8cb1a2-9dac-57d7-919e-f437dea2a16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a12b361-ed36-4a89-a973-1e4c7fb56fa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a12b361-ed36-4a89-a973-1e4c7fb56fa9.jpg?1",
             "name": "Mythos of Snapdax",
             "text": "",
             "colours": [
@@ -11345,7 +11345,7 @@
         },
         {
             "id": "8dc764a0-42bf-586d-934c-167b1b632d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf1cdf3-2543-4b91-b6a8-ac0d04a9c045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf1cdf3-2543-4b91-b6a8-ac0d04a9c045.jpg?1",
             "name": "Mythos of Illuna",
             "text": "",
             "colours": [
@@ -11381,7 +11381,7 @@
         },
         {
             "id": "72b12a9c-73b0-5b62-bbd3-b13df3cb69de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd8d35-3f73-4181-80a3-d4d69badcc47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd8d35-3f73-4181-80a3-d4d69badcc47.jpg?1",
             "name": "Shark Typhoon",
             "text": "",
             "colours": [
@@ -11415,7 +11415,7 @@
         },
         {
             "id": "738277a8-7f70-5d73-b487-45933ded0456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5ee3a2-c683-4657-98c8-daebaa7819f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5ee3a2-c683-4657-98c8-daebaa7819f1.jpg?1",
             "name": "Voracious Greatshark",
             "text": "",
             "colours": [
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "96cc5938-2198-5017-9ac0-2a2733ba030e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb788cd-a6ab-44a9-adcf-13bdfc3be2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb788cd-a6ab-44a9-adcf-13bdfc3be2e8.jpg?1",
             "name": "Extinction Event",
             "text": "",
             "colours": [
@@ -11485,7 +11485,7 @@
         },
         {
             "id": "ca3071e9-1051-54d7-a678-ff565425acef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ee8cfc-5d76-4e30-8b53-6ac6c9637d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ee8cfc-5d76-4e30-8b53-6ac6c9637d5d.jpg?1",
             "name": "Hunted Nightmare",
             "text": "",
             "colours": [
@@ -11521,7 +11521,7 @@
         },
         {
             "id": "3aae731c-22fd-5802-9cbc-26bd5faf5ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfb70ec-c9c8-4359-b2d4-e116bf5ad669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfb70ec-c9c8-4359-b2d4-e116bf5ad669.jpg?1",
             "name": "Mythos of Nethroi",
             "text": "",
             "colours": [
@@ -11557,7 +11557,7 @@
         },
         {
             "id": "3814ee98-8b22-5e01-bcad-84fc73a1d735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce59b5b6-97d8-4678-9381-2800667fdb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce59b5b6-97d8-4678-9381-2800667fdb41.jpg?1",
             "name": "Mythos of Vadrok",
             "text": "",
             "colours": [
@@ -11593,7 +11593,7 @@
         },
         {
             "id": "4868aadd-57a7-5514-b011-6bae0287d64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b94e1d-f328-4e4c-b112-45d6c6f98376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b94e1d-f328-4e4c-b112-45d6c6f98376.jpg?1",
             "name": "Unpredictable Cyclone",
             "text": "",
             "colours": [
@@ -11627,7 +11627,7 @@
         },
         {
             "id": "11a2496e-22c2-5ac8-b094-20dc58815110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9679442a-ecd4-4220-aae4-01b95dc18486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9679442a-ecd4-4220-aae4-01b95dc18486.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "",
             "colours": [
@@ -11667,7 +11667,7 @@
         },
         {
             "id": "5a54f9ba-dde1-5f3d-a21c-a5926df007a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9111b3dc-63da-45c7-bbe6-42a443ac2015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9111b3dc-63da-45c7-bbe6-42a443ac2015.jpg?1",
             "name": "Colossification",
             "text": "",
             "colours": [
@@ -11704,7 +11704,7 @@
         },
         {
             "id": "510fa7e1-2e2d-5f4e-95cd-968dda27d03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a5905f-4d53-4f7e-8af8-3d802978ec03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a5905f-4d53-4f7e-8af8-3d802978ec03.jpg?1",
             "name": "Kogla, the Titan Ape",
             "text": "",
             "colours": [
@@ -11742,7 +11742,7 @@
         },
         {
             "id": "cd1c7c32-61c9-5f56-a5d3-caef4245321c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e3e1ed-eeb6-4d7e-ab50-0b0f104606b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e3e1ed-eeb6-4d7e-ab50-0b0f104606b9.jpg?1",
             "name": "Mythos of Brokkos",
             "text": "",
             "colours": [
@@ -11778,7 +11778,7 @@
         },
         {
             "id": "99d90e5e-58a4-5f2d-9a33-01a66107952d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f90d92a-2297-4a52-80cb-10b56943b828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f90d92a-2297-4a52-80cb-10b56943b828.jpg?1",
             "name": "Chevill, Bane of Monsters",
             "text": "",
             "colours": [
@@ -11819,7 +11819,7 @@
         },
         {
             "id": "a910922c-1f79-5512-b71d-8d182858fdd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c4e70-81fb-42b9-9725-4d5206520037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c4e70-81fb-42b9-9725-4d5206520037.jpg?1",
             "name": "Death's Oasis",
             "text": "",
             "colours": [
@@ -11857,7 +11857,7 @@
         },
         {
             "id": "186bd0a4-49cd-505c-9c25-b469edd74dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe5a6f-82a2-4c6b-a69d-3a07917e15c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe5a6f-82a2-4c6b-a69d-3a07917e15c9.jpg?1",
             "name": "Eerie Ultimatum",
             "text": "",
             "colours": [
@@ -11895,7 +11895,7 @@
         },
         {
             "id": "3e1c22c8-08c8-5c9c-b136-1ff0731c3f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400d79b0-102a-406c-8369-8d024b18c4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400d79b0-102a-406c-8369-8d024b18c4e9.jpg?1",
             "name": "Emergent Ultimatum",
             "text": "",
             "colours": [
@@ -11933,7 +11933,7 @@
         },
         {
             "id": "a92bc3bd-5e5e-5ba8-99ad-df458d684196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9438c0-080b-4541-bfb7-6214be694584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9438c0-080b-4541-bfb7-6214be694584.jpg?1",
             "name": "Frondland Felidar",
             "text": "",
             "colours": [
@@ -11972,7 +11972,7 @@
         },
         {
             "id": "8d1f2aab-ce6d-5648-bcc9-e58ad973a45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6eb6b97-8b87-4565-940a-01a7fd79a989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6eb6b97-8b87-4565-940a-01a7fd79a989.jpg?1",
             "name": "General Kudro of Drannith",
             "text": "",
             "colours": [
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "46b52728-b5f5-5016-8ac1-b1be8c36584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51e3a2-c188-4212-8cc0-ef2d4722cb84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51e3a2-c188-4212-8cc0-ef2d4722cb84.jpg?1",
             "name": "Genesis Ultimatum",
             "text": "",
             "colours": [
@@ -12051,7 +12051,7 @@
         },
         {
             "id": "11af04cd-381e-5d18-8623-737141fdc849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e96967-d694-4c26-8e10-d904e1e64c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e96967-d694-4c26-8e10-d904e1e64c09.jpg?1",
             "name": "Inspired Ultimatum",
             "text": "",
             "colours": [
@@ -12089,7 +12089,7 @@
         },
         {
             "id": "aa39adc4-e9d7-5cb9-a78b-5e81a2a370e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532746e2-f822-4920-ab31-94e0c8baaa84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532746e2-f822-4920-ab31-94e0c8baaa84.jpg?1",
             "name": "Kinnan, Bonder Prodigy",
             "text": "",
             "colours": [
@@ -12130,7 +12130,7 @@
         },
         {
             "id": "8bb7f287-f17d-5eaa-a17a-4095006e4553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4a7b3-9eb3-4f96-b151-8b1c4c85118b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4a7b3-9eb3-4f96-b151-8b1c4c85118b.jpg?1",
             "name": "Labyrinth Raptor",
             "text": "",
             "colours": [
@@ -12169,7 +12169,7 @@
         },
         {
             "id": "a04cb183-8792-5c92-aa38-80cbffd6640f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd7462d-0dfb-4f3f-96c4-43c281f0beb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd7462d-0dfb-4f3f-96c4-43c281f0beb5.jpg?1",
             "name": "Offspring's Revenge",
             "text": "",
             "colours": [
@@ -12207,7 +12207,7 @@
         },
         {
             "id": "15fe057d-e982-58ae-9bce-7d66b7a8159c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e1effa-92a6-4e8c-9cd6-fc57ae7b3cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e1effa-92a6-4e8c-9cd6-fc57ae7b3cbf.jpg?1",
             "name": "Quartzwood Crasher",
             "text": "",
             "colours": [
@@ -12246,7 +12246,7 @@
         },
         {
             "id": "f3415317-1bc3-5924-8039-262847510a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbe5ae7-5c50-476f-9022-cfb61ced107b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbe5ae7-5c50-476f-9022-cfb61ced107b.jpg?1",
             "name": "Rielle, the Everwise",
             "text": "",
             "colours": [
@@ -12287,7 +12287,7 @@
         },
         {
             "id": "b2d7e7f1-9bf9-5e77-ab24-9b70f64b96b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa531e0-a3e5-4b40-a824-354ed7a13fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa531e0-a3e5-4b40-a824-354ed7a13fd5.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "",
             "colours": [
@@ -12325,7 +12325,7 @@
         },
         {
             "id": "b57cc6aa-5901-5f71-8857-febc9dcd17e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b08d66-4168-433d-9655-08f64b72e2cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b08d66-4168-433d-9655-08f64b72e2cc.jpg?1",
             "name": "Skycat Sovereign",
             "text": "",
             "colours": [
@@ -12364,7 +12364,7 @@
         },
         {
             "id": "0f1d6363-a216-5c94-98f8-13bb56a657a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a641ad-4268-46c4-a5fb-c1515e52d648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a641ad-4268-46c4-a5fb-c1515e52d648.jpg?1",
             "name": "Slitherwisp",
             "text": "",
             "colours": [
@@ -12403,7 +12403,7 @@
         },
         {
             "id": "69eb66c2-2339-5024-936a-369df521209b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e98d2e6-8247-4915-928b-25d6e2efc908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e98d2e6-8247-4915-928b-25d6e2efc908.jpg?1",
             "name": "Song of Creation",
             "text": "",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "52963a7b-e488-5bbb-9256-2d64a69a3429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894502fb-1ec7-4520-90e5-5f97de1c9151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894502fb-1ec7-4520-90e5-5f97de1c9151.jpg?1",
             "name": "Titans' Nest",
             "text": "",
             "colours": [
@@ -12479,7 +12479,7 @@
         },
         {
             "id": "b1f420dc-cf58-571d-878b-984dee5f155d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c48195-074a-4236-a82d-603b5dd1aa66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c48195-074a-4236-a82d-603b5dd1aa66.jpg?1",
             "name": "Whirlwind of Thought",
             "text": "",
             "colours": [
@@ -12517,7 +12517,7 @@
         },
         {
             "id": "98ad6967-41e5-5b24-8e6e-b3c43cd5b11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c7d63-b07d-456d-95ca-d3c3f346715e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c7d63-b07d-456d-95ca-d3c3f346715e.jpg?1",
             "name": "Winota, Joiner of Forces",
             "text": "",
             "colours": [
@@ -12558,7 +12558,7 @@
         },
         {
             "id": "6c4f8edd-fd45-5471-a1dc-0b547b94c6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e706a-5506-4efd-a86b-2a25bb66a2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e706a-5506-4efd-a86b-2a25bb66a2ae.jpg?1",
             "name": "Fiend Artisan",
             "text": "",
             "colours": [
@@ -12596,7 +12596,7 @@
         },
         {
             "id": "c852305e-6481-59c0-b540-5372cdaee0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d59bf12-f898-40ad-a8a9-2f31f733cf15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d59bf12-f898-40ad-a8a9-2f31f733cf15.jpg?1",
             "name": "Gyruda, Doom of Depths",
             "text": "",
             "colours": [
@@ -12638,7 +12638,7 @@
         },
         {
             "id": "ffc8293d-e340-5dd4-9005-67d9292d3f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592378-f9e7-4c50-8425-2105744aa85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592378-f9e7-4c50-8425-2105744aa85c.jpg?1",
             "name": "Jegantha, the Wellspring",
             "text": "",
             "colours": [
@@ -12682,7 +12682,7 @@
         },
         {
             "id": "8b9dacbb-5ca7-5827-9472-d4c3c5125d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe646123-c399-4ead-96a9-f7b46215f9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe646123-c399-4ead-96a9-f7b46215f9d9.jpg?1",
             "name": "Kaheera, the Orphanguard",
             "text": "",
             "colours": [
@@ -12723,7 +12723,7 @@
         },
         {
             "id": "ba5e4137-7bbb-59de-a870-c25e15113687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1206f4fc-6ebf-4205-90d3-1cb3a9caaa82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1206f4fc-6ebf-4205-90d3-1cb3a9caaa82.jpg?1",
             "name": "Keruga, the Macrosage",
             "text": "",
             "colours": [
@@ -12764,7 +12764,7 @@
         },
         {
             "id": "e7bac34f-6ff3-5884-bb57-a6c5fda48119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c89beb2-3467-4be0-a066-919f54331942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c89beb2-3467-4be0-a066-919f54331942.jpg?1",
             "name": "Lurrus of the Dream-Den",
             "text": "",
             "colours": [
@@ -12805,7 +12805,7 @@
         },
         {
             "id": "7fa9d199-8e60-519a-b3b6-459c43f83229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c01a00-2128-4b6c-874f-a206eca3a756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c01a00-2128-4b6c-874f-a206eca3a756.jpg?1",
             "name": "Lutri, the Spellchaser",
             "text": "",
             "colours": [
@@ -12846,7 +12846,7 @@
         },
         {
             "id": "08b95ec1-e566-5108-8c79-775f9557b6ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8cf901-1452-4664-be10-0bacc5bef83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8cf901-1452-4664-be10-0bacc5bef83a.jpg?1",
             "name": "Obosh, the Preypiercer",
             "text": "",
             "colours": [
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "1c5f808b-2224-5beb-a8ef-e9720c0c99c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10576f29-1ab8-4157-b5a0-8ad94a1ff634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10576f29-1ab8-4157-b5a0-8ad94a1ff634.jpg?1",
             "name": "Umori, the Collector",
             "text": "",
             "colours": [
@@ -12927,7 +12927,7 @@
         },
         {
             "id": "4902cb6d-64cd-5c4c-8745-647a23a94d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b05368-1661-42de-9319-bbe987d27327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b05368-1661-42de-9319-bbe987d27327.jpg?1",
             "name": "Yorion, Sky Nomad",
             "text": "",
             "colours": [
@@ -12968,7 +12968,7 @@
         },
         {
             "id": "d28ba5df-a066-53bb-b9c4-53bddccc4748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7301bd-05db-436b-8a49-5840c4cb9995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7301bd-05db-436b-8a49-5840c4cb9995.jpg?1",
             "name": "Zirda, the Dawnwaker",
             "text": "",
             "colours": [
@@ -13009,7 +13009,7 @@
         },
         {
             "id": "3ba9d8e5-055d-5fc5-b1ec-6d2a5637819e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b4c21-342f-4b46-86bb-8e8f38659f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b4c21-342f-4b46-86bb-8e8f38659f82.jpg?1",
             "name": "Crystalline Giant",
             "text": "",
             "colours": [],
@@ -13043,7 +13043,7 @@
         },
         {
             "id": "6f54548f-4f36-5f32-b0cf-a43257050527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3b5f52-ce33-4e67-aca0-6d417fe7f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3b5f52-ce33-4e67-aca0-6d417fe7f5fa.jpg?1",
             "name": "The Ozolith",
             "text": "",
             "colours": [],
@@ -13075,7 +13075,7 @@
         },
         {
             "id": "0429fd9d-969f-59b6-bd87-0dfedbf8efdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a26d0b-cf19-4c3e-bc81-6ffdc21757fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a26d0b-cf19-4c3e-bc81-6ffdc21757fa.jpg?1",
             "name": "Bonders' Enclave",
             "text": "",
             "colours": [],
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "e498d8c9-6429-5948-9b7f-407bd3b89668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa8a7b-d886-4005-950d-bad589b6e03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa8a7b-d886-4005-950d-bad589b6e03a.jpg?1",
             "name": "Colossification",
             "text": "",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "6ac4db46-e6de-59ea-9cc2-835f4c85ff99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b6981-0fd4-4f58-bba4-a7efd4c633d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b6981-0fd4-4f58-bba4-a7efd4c633d0.jpg?1",
             "name": "Flourishing Fox",
             "text": "",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "45fd1ad0-0fc6-5f17-8212-74bb15f2a645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928b0234-fc62-4ab8-b257-3fddcc52376b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928b0234-fc62-4ab8-b257-3fddcc52376b.jpg?1",
             "name": "Heartless Act",
             "text": "",
             "colours": [
@@ -13212,7 +13212,7 @@
         },
         {
             "id": "0a3f4dca-d27c-5658-b875-fdc057b2930d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae39803e-e67a-4d1b-a3fe-2e255d502656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae39803e-e67a-4d1b-a3fe-2e255d502656.jpg?1",
             "name": "Forbidden Friendship",
             "text": "",
             "colours": [
@@ -13246,7 +13246,7 @@
         },
         {
             "id": "86a9a5bb-391f-5c14-8cdd-69b2835ad118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363428be-0f89-4de5-a804-93172da4d99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363428be-0f89-4de5-a804-93172da4d99f.jpg?1",
             "name": "Migration Path",
             "text": "",
             "colours": [
@@ -13280,7 +13280,7 @@
         },
         {
             "id": "70647cee-589b-5e81-9fc6-142f30ce95de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172db88-2208-47c4-8226-bc094fd04a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172db88-2208-47c4-8226-bc094fd04a9b.jpg?1",
             "name": "Sprite Dragon",
             "text": "",
             "colours": [
@@ -13320,7 +13320,7 @@
         },
         {
             "id": "9648c4a5-4e32-53d3-8332-95e8cdf2d69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f741e3-82d8-4842-8054-25e20a10dddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f741e3-82d8-4842-8054-25e20a10dddd.jpg?1",
             "name": "Huntmaster Liger",
             "text": "Mutate {2}{W}\nWhenever this creature mutates, other creatures you control get +X/+X until end of turn, where X is the number of times this creature has mutated.",
             "colours": [
@@ -13357,7 +13357,7 @@
         },
         {
             "id": "60a33c1a-8430-5be7-802f-e2ab5dd563f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d393cc4-0e6b-44fe-a74a-822c52678ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d393cc4-0e6b-44fe-a74a-822c52678ec9.jpg?1",
             "name": "Luminous Broodmoth",
             "text": "Flying\nWhenever a creature you control without flying dies, return it to the battlefield under its owner's control with a flying counter on it.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "3aa21396-8dcd-5f9a-9243-677182293d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60a4f8-cb75-42e9-8a33-347e0f4bb458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60a4f8-cb75-42e9-8a33-347e0f4bb458.jpg?1",
             "name": "Pollywog Symbiote",
             "text": "Each creature spell you cast costs {1} less to cast if it has mutate.\nWhenever you cast a creature spell, if it has mutate, draw a card, then discard a card.",
             "colours": [
@@ -13430,7 +13430,7 @@
         },
         {
             "id": "5b62d7ac-440b-58f9-8086-a002d074cfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca7065e-88c1-44bb-ac68-e6e1df9e0726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca7065e-88c1-44bb-ac68-e6e1df9e0726.jpg?1",
             "name": "Void Beckoner",
             "text": "",
             "colours": [
@@ -13468,7 +13468,7 @@
         },
         {
             "id": "15c513ba-f3be-56b0-b991-bbde1ecf5b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ae88c2-1f9b-4515-9f2e-78e1dc5468b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ae88c2-1f9b-4515-9f2e-78e1dc5468b1.jpg?1",
             "name": "Void Beckoner",
             "text": "",
             "colours": [
@@ -13506,7 +13506,7 @@
         },
         {
             "id": "1a8426ed-5ac5-5715-9d28-9f0c41c12b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e93bf3-94e8-408c-94ba-e83796077548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e93bf3-94e8-408c-94ba-e83796077548.jpg?1",
             "name": "Everquill Phoenix",
             "text": "Mutate {3}{R}\nFlying\nWhenever this creature mutates, create a red artifact token named Feather with \"{1}, Sacrifice Feather: Return target Phoenix card from your graveyard to the battlefield tapped.\"",
             "colours": [
@@ -13543,7 +13543,7 @@
         },
         {
             "id": "ada1956b-bb99-5e73-b440-e6c320ba133a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6b4c7-4f18-4bea-b927-916c7bb987ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6b4c7-4f18-4bea-b927-916c7bb987ee.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "Trample, haste\nCycling {1}{R}\nWhen you cycle Yidaro, Wandering Monster, shuffle it into your library from your graveyard. If you've cycled a card named Yidaro, Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead.",
             "colours": [
@@ -13583,7 +13583,7 @@
         },
         {
             "id": "72af5eef-c83e-5498-b3ea-4245b9e4c376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c811c0d4-e2fc-45eb-8a76-b89c38a95536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c811c0d4-e2fc-45eb-8a76-b89c38a95536.jpg?1",
             "name": "Gemrazer",
             "text": "Mutate {1}{G}{G}\nReach, trample\nWhenever this creature mutates, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -13620,7 +13620,7 @@
         },
         {
             "id": "65a430c8-6201-5667-8606-0bd8512e0d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4817b86-d55a-4334-82ee-603f8c4b3e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4817b86-d55a-4334-82ee-603f8c4b3e93.jpg?1",
             "name": "Titanoth Rex",
             "text": "Trample\nCycling {1}{G}\nWhen you cycle Titanoth Rex, put a trample counter on target creature you control.",
             "colours": [
@@ -13657,7 +13657,7 @@
         },
         {
             "id": "a95d4adb-9fc8-5331-816e-a26c844e4195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf6ca85-0ef5-4104-b0e6-1137c4975579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf6ca85-0ef5-4104-b0e6-1137c4975579.jpg?1",
             "name": "Brokkos, Apex of Forever",
             "text": "Mutate {2}{UB}{G}{G}\nTrample\nYou may cast Brokkos, Apex of Forever from your graveyard using its mutate ability.",
             "colours": [
@@ -13702,7 +13702,7 @@
         },
         {
             "id": "824d322b-6117-5f32-a56a-5c67cb6a6baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb1fba6-8eb3-4338-9249-cec888c892dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb1fba6-8eb3-4338-9249-cec888c892dc.jpg?1",
             "name": "Illuna, Apex of Wishes",
             "text": "Mutate {3}{RG}{U}{U}\nFlying, trample\nWhenever this creature mutates, exile cards from the top of your library until you exile a nonland permanent card. Put that card onto the battlefield or into your hand.",
             "colours": [
@@ -13747,7 +13747,7 @@
         },
         {
             "id": "6f8ddb82-805d-573a-beca-5d8f369c8108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ebe73b-29d7-4a07-b7dc-a885dad61a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ebe73b-29d7-4a07-b7dc-a885dad61a88.jpg?1",
             "name": "Nethroi, Apex of Death",
             "text": "Mutate {4}{RW}{B}{B}\nDeathtouch, lifelink\nWhenever this creature mutates, return any number of target creature cards with total power 10 or less from your graveyard to the battlefield.",
             "colours": [
@@ -13792,7 +13792,7 @@
         },
         {
             "id": "277249ba-20b2-5f24-8439-828c86f81386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673d14b1-e93a-4594-b2c9-792696adb991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673d14b1-e93a-4594-b2c9-792696adb991.jpg?1",
             "name": "Snapdax, Apex of the Hunt",
             "text": "Mutate {2}{BR}{W}{W}\nDouble strike\nWhenever this creature mutates, it deals 4 damage to target creature or planeswalker an opponent controls and you gain 4 life.",
             "colours": [
@@ -13837,7 +13837,7 @@
         },
         {
             "id": "7a8fdc89-bdd8-5f81-8fe1-af8c5663907f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d3b231-d15d-4186-826c-452009cd5c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d3b231-d15d-4186-826c-452009cd5c5e.jpg?1",
             "name": "Sprite Dragon",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on Sprite Dragon.",
             "colours": [
@@ -13877,7 +13877,7 @@
         },
         {
             "id": "fe1607a2-4ffe-566c-a75f-dcbb6fa17b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3346674-43cf-4006-b829-bf824560f413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3346674-43cf-4006-b829-bf824560f413.jpg?1",
             "name": "Vadrok, Apex of Thunder",
             "text": "Mutate {1}{WU}{R}{R}\nFlying, first strike\nWhenever this creature mutates, you may cast target noncreature card with converted mana cost 3 or less from your graveyard without paying its mana cost.",
             "colours": [
@@ -13922,7 +13922,7 @@
         },
         {
             "id": "f4d96a33-af22-5177-92a8-c79537b530d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206739b3-9b6a-4855-a2c3-721879bdbfb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206739b3-9b6a-4855-a2c3-721879bdbfb7.jpg?1",
             "name": "Gyruda, Doom of Depths",
             "text": "Companion \u2014 Your starting deck contains only cards with even converted mana costs.\nWhen Gyruda enters the battlefield, each player puts the top four cards of their library into their graveyard. Put a creature card with an even converted mana cost from among those cards onto the battlefield under your control.",
             "colours": [
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "5df3565b-ab85-5cc7-83c4-9cd3bb5674da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333b41d-e42c-4b12-be08-742eefb4e401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333b41d-e42c-4b12-be08-742eefb4e401.jpg?1",
             "name": "Mysterious Egg",
             "text": "",
             "colours": [],
@@ -13996,7 +13996,7 @@
         },
         {
             "id": "fd9ff43c-fee9-5bdb-ab0a-d4c55f2178fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb53dbd-b35f-414a-9f99-d340ef9398dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb53dbd-b35f-414a-9f99-d340ef9398dc.jpg?1",
             "name": "Dirge Bat",
             "text": "",
             "colours": [
@@ -14033,7 +14033,7 @@
         },
         {
             "id": "f192bfef-50ef-535f-818e-b8a57f93a498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c2de2f-bb56-4713-861a-34523b331e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c2de2f-bb56-4713-861a-34523b331e26.jpg?1",
             "name": "Crystalline Giant",
             "text": "",
             "colours": [],
@@ -14067,7 +14067,7 @@
         },
         {
             "id": "720b698d-92f0-5cd9-b953-d8108b15e2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d754e09c-efc0-4536-9f2a-6bd7e2f860ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d754e09c-efc0-4536-9f2a-6bd7e2f860ab.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -14102,7 +14102,7 @@
         },
         {
             "id": "5507c5a3-2bd1-5db3-9db5-31a60cd2c7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816da759-e224-4960-b2b6-453cadc2faf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816da759-e224-4960-b2b6-453cadc2faf1.jpg?1",
             "name": "Cat Bird",
             "text": "",
             "colours": [
@@ -14138,7 +14138,7 @@
         },
         {
             "id": "26de75d4-7184-5138-b179-db16f1884a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de6d1e-e654-4f4a-8014-061ce69e540f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de6d1e-e654-4f4a-8014-061ce69e540f.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -14174,7 +14174,7 @@
         },
         {
             "id": "619dbf5b-bede-500d-b138-137233fa1b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9669b1-04bd-4620-9856-04ea0473ec57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9669b1-04bd-4620-9856-04ea0473ec57.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -14210,7 +14210,7 @@
         },
         {
             "id": "9fbf46e4-9f16-5f2f-a41c-55abad4ed523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e406949f-c629-48fa-9fb0-ba6191054d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e406949f-c629-48fa-9fb0-ba6191054d35.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -14246,7 +14246,7 @@
         },
         {
             "id": "d298041b-f7af-592d-b0ce-eeb017859086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17c7b2-180a-4bd1-9ab2-152f8f656dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17c7b2-180a-4bd1-9ab2-152f8f656dba.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -14281,7 +14281,7 @@
         },
         {
             "id": "0c16da93-98d7-5037-a250-30d1e5482f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d12226-6417-4b98-beb5-89a36c774141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d12226-6417-4b98-beb5-89a36c774141.jpg?1",
             "name": "Shark",
             "text": "",
             "colours": [
@@ -14316,7 +14316,7 @@
         },
         {
             "id": "94878ed5-7735-56d2-9946-ec24d08d7338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f918b740-1984-4090-8886-9e290a698b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f918b740-1984-4090-8886-9e290a698b95.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -14351,7 +14351,7 @@
         },
         {
             "id": "0ba68999-e73c-5667-84e4-7093a5671128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc7c63-5d13-4fd6-af9d-4a26c2bab8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc7c63-5d13-4fd6-af9d-4a26c2bab8e6.jpg?1",
             "name": "Feather",
             "text": "",
             "colours": [
@@ -14384,7 +14384,7 @@
         },
         {
             "id": "e532a629-e171-5745-a730-c6e5152d15f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c9241-9cba-4c99-85cc-7e74286d1dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c9241-9cba-4c99-85cc-7e74286d1dc1.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -14419,7 +14419,7 @@
         },
         {
             "id": "f1bed91d-6add-5945-ac41-be69ba306baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d447365-3aca-4996-9098-efcbe6f28f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d447365-3aca-4996-9098-efcbe6f28f57.jpg?1",
             "name": "Dinosaur Beast",
             "text": "",
             "colours": [
@@ -14455,7 +14455,7 @@
         },
         {
             "id": "8ce14edc-833b-5117-b87b-fbb30f5b094f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e573150-9f7e-4398-8997-aecb6057a020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e573150-9f7e-4398-8997-aecb6057a020.jpg?1",
             "name": "Narset of the Ancient Way Emblem",
             "text": "",
             "colours": [],
@@ -14483,7 +14483,7 @@
         },
         {
             "id": "502291fe-ef30-5ac4-8f22-f5037bc492a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b95e8bd-2686-4790-afeb-9b17d482f156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b95e8bd-2686-4790-afeb-9b17d482f156.jpg?1",
             "name": "Companion",
             "text": "",
             "colours": [],
@@ -14510,7 +14510,7 @@
         },
         {
             "id": "54864471-3b86-5b6f-ad6b-28239f7e5ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe8eefe-c9f8-43f7-a348-8afee8b0ec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe8eefe-c9f8-43f7-a348-8afee8b0ec68.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],
@@ -14537,7 +14537,7 @@
         },
         {
             "id": "bad84a92-ad05-569f-8d74-9c8dd65b3a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff073ee-117f-4e86-aeb5-f970caff95fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff073ee-117f-4e86-aeb5-f970caff95fa.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/IMA.json
+++ b/Assets/Resources/Sets/IMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ee7d1427-ff03-5e2d-8afd-3b25b13c7b7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2904aaaa-cd25-4c05-9d57-4c5a951ac6d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2904aaaa-cd25-4c05-9d57-4c5a951ac6d9.jpg?1",
             "name": "Scion of Ugin",
             "text": "Flying",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "fc447e94-37b1-503f-a535-adb83277d966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2877ac-195b-4397-89bd-0bee3220b2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2877ac-195b-4397-89bd-0bee3220b2a4.jpg?1",
             "name": "Abzan Battle Priest",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has lifelink.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "363cd6b7-0413-582a-961c-b75bffe9d8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c06621d-a0c9-4c84-8b1a-cb0abd8390c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c06621d-a0c9-4c84-8b1a-cb0abd8390c4.jpg?1",
             "name": "Abzan Falconer",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "5e34e263-cfe7-5a5e-88ab-a11d7b1a610a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32c514-36b9-4e1f-86e8-1d36e5282062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32c514-36b9-4e1f-86e8-1d36e5282062.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "4da7afe2-d883-507e-9b92-78d0c5e4f1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d0c32-1b7d-4c91-8675-2543c97a3753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d0c32-1b7d-4c91-8675-2543c97a3753.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f46a4fbd-ad07-5483-9766-c6a85245584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19caada3-7548-44d4-bf3f-680f7d3fa7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19caada3-7548-44d4-bf3f-680f7d3fa7b8.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy enters the battlefield, you gain 3 life.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "2feb2bb4-a064-5976-91d3-dfdd84503704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e8190-15fd-44ed-a821-9a5f3615d2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e8190-15fd-44ed-a821-9a5f3615d2d9.jpg?1",
             "name": "Angelic Accord",
             "text": "At the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "770409d7-ea90-5896-9bd4-0c68e26f4fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff10db6-f9bf-4fc8-b3ef-c4c11f192f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff10db6-f9bf-4fc8-b3ef-c4c11f192f53.jpg?1",
             "name": "Archangel of Thune",
             "text": "Flying, lifelink\nWhenever you gain life, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "610c24d1-772a-5c49-8460-7ca3bccc326e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b769c1-48a0-448b-98d9-0d86526ef51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b769c1-48a0-448b-98d9-0d86526ef51e.jpg?1",
             "name": "Auriok Champion",
             "text": "Protection from black and from red\nWhenever another creature enters the battlefield, you may gain 1 life.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "d1004636-96b0-5bff-b60d-600efaa03101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef16a71-5ed2-4f30-a844-c02a0754f679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef16a71-5ed2-4f30-a844-c02a0754f679.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "43afb785-fd4b-56bc-8716-063c95441b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb92ef6-0ef8-4b1d-8a45-3064fea23926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb92ef6-0ef8-4b1d-8a45-3064fea23926.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "cbba1a83-c4bb-570f-9693-01181d29483a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf59723-fa84-40e3-b63e-b735addfdb43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf59723-fa84-40e3-b63e-b735addfdb43.jpg?1",
             "name": "Benevolent Ancestor",
             "text": "Defender\n{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "00b2f49b-2f4c-5772-905f-145a52cce877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173675c1-685c-4f4c-a6dc-b42a3ae69137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173675c1-685c-4f4c-a6dc-b42a3ae69137.jpg?1",
             "name": "Blinding Mage",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "f0069b21-9445-5691-8358-73a8b14ef440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd31ae-f252-449b-9d79-749a9a255763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd31ae-f252-449b-9d79-749a9a255763.jpg?1",
             "name": "Burrenton Forge-Tender",
             "text": "Protection from red\nSacrifice Burrenton Forge-Tender: Prevent all damage a red source of your choice would deal this turn.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "0122dacc-4b11-5911-bce0-b9b22f476db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfcbc11-bf1a-438b-9c66-0928cea6d297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfcbc11-bf1a-438b-9c66-0928cea6d297.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "76839172-bb45-5d0e-800a-87dca37db93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbfd61b-fba3-4826-817a-e0eed7b8eda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbfd61b-fba3-4826-817a-e0eed7b8eda0.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -549,7 +549,7 @@
         },
         {
             "id": "efd1dac9-246f-50d9-8efb-15d7ab207de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1244c95-a066-412d-bd04-c906ea4b4dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1244c95-a066-412d-bd04-c906ea4b4dd0.jpg?1",
             "name": "Dragon Bell Monk",
             "text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "394b774b-49f2-5f20-8ac8-bcb4f2ed2eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c2bfef-06a5-4c7f-8283-ea3fb673b7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c2bfef-06a5-4c7f-8283-ea3fb673b7a1.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "Vigilance\nOther creatures you control get +2/+2.\nCreatures your opponents control get -2/-2.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "0d568b51-dccc-5167-8b06-05450327b488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d016f166-183e-4d9e-9292-9bfb1ca0d72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d016f166-183e-4d9e-9292-9bfb1ca0d72b.jpg?1",
             "name": "Emerge Unscathed",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "dc539eeb-dbd6-58f9-9afc-aa9593e69382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ba1fa-3ace-488b-97e6-d9f3b389c602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ba1fa-3ace-488b-97e6-d9f3b389c602.jpg?1",
             "name": "Emeria Angel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "10815618-3c1e-5303-b4a6-45a4c31f3553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc449dc-60c7-4b78-9a73-afa1de64a41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc449dc-60c7-4b78-9a73-afa1de64a41e.jpg?1",
             "name": "Great Teacher's Decree",
             "text": "Creatures you control get +2/+1 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "fbf5789b-dca0-5ec9-8978-81b826215b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584687fd-59e1-46cb-aca2-3104349407d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584687fd-59e1-46cb-aca2-3104349407d9.jpg?1",
             "name": "Guard Duty",
             "text": "Enchant creature\nEnchanted creature has defender.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "ea007a5d-11a8-599a-99ec-e3a5b2c7f12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9696feed-e8e3-434d-b155-1f5734966b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9696feed-e8e3-434d-b155-1f5734966b49.jpg?1",
             "name": "Guided Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "a29674fe-c919-55fe-873a-8cfe6ba7379a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4b0fd0-045d-4a96-9a57-c7ba1548b4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4b0fd0-045d-4a96-9a57-c7ba1548b4cd.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "2d1c020d-14f8-5741-9ede-ac6401831929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad15a-82c8-4cdd-84e7-02ef66fd0d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad15a-82c8-4cdd-84e7-02ef66fd0d19.jpg?1",
             "name": "Iona's Judgment",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "afec5425-e5d6-5765-a45b-8139e4e5c946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760f7e0a-51bc-417b-9f69-38a9f2d2c78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760f7e0a-51bc-417b-9f69-38a9f2d2c78f.jpg?1",
             "name": "Path of Bravery",
             "text": "As long as your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "49ba997e-8d63-5849-aec0-09c22537dc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455d6d8-f116-46b5-9e6d-615b752b8455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455d6d8-f116-46b5-9e6d-615b752b8455.jpg?1",
             "name": "Pentarch Ward",
             "text": "Enchant creature\nAs Pentarch Ward enters the battlefield, choose a color.\nWhen Pentarch Ward enters the battlefield, draw a card.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Pentarch Ward.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "3ce6cbc0-c25d-525b-b3ab-a654a0679efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5233ff-03bc-4053-9b49-c4185c2de38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5233ff-03bc-4053-9b49-c4185c2de38d.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "50fd60ef-afd9-5df8-8636-326472fc45ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d7aafb-969f-4a39-9af3-125f7f5c99f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d7aafb-969f-4a39-9af3-125f7f5c99f3.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "cc3580e4-0a41-5afa-a74f-28f6c7432b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd88ba4-4b2a-479c-9ff8-e02092afe9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd88ba4-4b2a-479c-9ff8-e02092afe9de.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "3beb5c78-8b36-558c-9a7c-3b64be174941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a22ee47-fc56-436d-8570-88fbff421027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a22ee47-fc56-436d-8570-88fbff421027.jpg?1",
             "name": "Serra Ascendant",
             "text": "Lifelink\nAs long as you have 30 or more life, Serra Ascendant gets +5/+5 and has flying.",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "8dcbc896-f46a-55fd-bf36-b05b7b8fafc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4248b993-87c6-42a8-b800-75d958805440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4248b993-87c6-42a8-b800-75d958805440.jpg?1",
             "name": "Stalwart Aven",
             "text": "Flying\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "923b4237-fb71-58e0-b460-a71b3869c2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df49884b-9e12-488c-8381-ec543349b97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df49884b-9e12-488c-8381-ec543349b97b.jpg?1",
             "name": "Student of Ojutai",
             "text": "Whenever you cast a noncreature spell, you gain 2 life.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "eb5a8c87-0608-5bc3-9cb2-d9969d6bfa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b8d1e-a144-432e-b3ac-63c37be55191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b8d1e-a144-432e-b3ac-63c37be55191.jpg?1",
             "name": "Survival Cache",
             "text": "You gain 2 life. Then if you have more life than an opponent, draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "f11b8a78-47fc-59f4-9c19-b89694f7b039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7e21e-d4d8-4d6c-9530-b17d5204e9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7e21e-d4d8-4d6c-9530-b17d5204e9e7.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "Flying\nWhenever Sustainer of the Realm blocks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "4de36700-b684-5e69-a81c-b7f545d5f579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0ae49-8aca-44fe-abea-2cff92a6adbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0ae49-8aca-44fe-abea-2cff92a6adbc.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "33490b70-2f28-5db1-abb4-f8c70b2544f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e953224-6ea0-4580-b2a2-c1ff133fb991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e953224-6ea0-4580-b2a2-c1ff133fb991.jpg?1",
             "name": "Topan Freeblade",
             "text": "Vigilance\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "755c3598-7293-52e1-99b7-57488c81073a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ebbf-e3a5-406a-941d-ca7ade992d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ebbf-e3a5-406a-941d-ca7ade992d64.jpg?1",
             "name": "Wing Shards",
             "text": "Target player sacrifices an attacking creature.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "74ad56c6-d604-5ac0-9710-85f0a8f63a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47af956c-e2ba-47c5-bc5d-ec0ab345ce57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47af956c-e2ba-47c5-bc5d-ec0ab345ce57.jpg?1",
             "name": "Yosei, the Morning Star",
             "text": "Flying\nWhen Yosei, the Morning Star dies, target player skips his or her next untap step. Tap up to five target permanents that player controls.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "fe17e926-146e-5fe5-b6c5-658918497812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8dc68c-da77-4ba4-a0a0-d00b93904932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8dc68c-da77-4ba4-a0a0-d00b93904932.jpg?1",
             "name": "Aetherize",
             "text": "Return all attacking creatures to their owner's hand.",
             "colours": [
@@ -1360,7 +1360,7 @@
         },
         {
             "id": "c2cad87f-b77e-54be-9cd2-9ffbd87e1416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36521a7-8997-45da-aaa6-dd70d5c4e7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36521a7-8997-45da-aaa6-dd70d5c4e7f4.jpg?1",
             "name": "Amass the Components",
             "text": "Draw three cards, then put a card from your hand on the bottom of your library.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "29b56bcc-337a-58e5-aea1-db29989194a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dc736d-7e61-4909-973f-61f7adb82b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dc736d-7e61-4909-973f-61f7adb82b64.jpg?1",
             "name": "Ancestral Vision",
             "text": "Suspend 4\u2014{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "a4ba5759-8f8a-53dc-917c-7ffb82fab0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ad45e5-8a80-4a6c-b9da-36d5f778ca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ad45e5-8a80-4a6c-b9da-36d5f778ca51.jpg?1",
             "name": "Bewilder",
             "text": "Target creature gets -3/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "b499e19f-85bc-54dd-a02f-c4931c01b25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b435ee-82cc-41df-a09f-cf3602e31c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b435ee-82cc-41df-a09f-cf3602e31c23.jpg?1",
             "name": "Cephalid Broker",
             "text": "{T}: Target player draws two cards, then discards two cards.",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "328ee5af-d4a3-5b93-b2ac-edd34ab9217c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4bc422-2378-4be8-8d81-ac4c30fcce9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4bc422-2378-4be8-8d81-ac4c30fcce9a.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "ebd8bf85-e1ab-5ae4-8e00-3899194359f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba16c0f-dd42-4a2a-8f08-bc8c8478952b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba16c0f-dd42-4a2a-8f08-bc8c8478952b.jpg?1",
             "name": "Condescend",
             "text": "Counter target spell unless its controller pays {X}. Scry 2.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "c5833736-7615-53ee-b642-58ce113be50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030e46a1-64a7-47e3-9b9f-82a22fe3734b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030e46a1-64a7-47e3-9b9f-82a22fe3734b.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "a51aea16-7c5f-58de-998c-ca4ceca1a398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6fca9-003b-4f6b-9d6e-1e88adda4155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6fca9-003b-4f6b-9d6e-1e88adda4155.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Counter target spell.\n\u2022 Return target permanent to its owner's hand.\n\u2022 Tap all creatures your opponents control.\n\u2022 Draw a card.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "68b44134-0027-54f3-8e91-0a98f734b26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d702a9-efdc-4e88-afe1-451f3a5b3ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d702a9-efdc-4e88-afe1-451f3a5b3ebb.jpg?1",
             "name": "Day of the Dragons",
             "text": "When Day of the Dragons enters the battlefield, exile all creatures you control. Then create that many 5/5 red Dragon creature tokens with flying.\nWhen Day of the Dragons leaves the battlefield, sacrifice all Dragons you control. Then return the exiled cards to the battlefield under your control.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "57608f24-7b0e-5613-bd72-1b68be51c3b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d468111-f7af-4ea2-a250-cd8c15ba60cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d468111-f7af-4ea2-a250-cd8c15ba60cc.jpg?1",
             "name": "Diminish",
             "text": "Target creature has base power and toughness 1/1 until end of turn.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "e93e81d3-440e-5f4f-aaed-979dfdc81dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb87ab-8595-459a-a5f2-087296d9b120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb87ab-8595-459a-a5f2-087296d9b120.jpg?1",
             "name": "Dissolve",
             "text": "Counter target spell. Scry 1.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "ba53b2cd-082d-5d8a-a4bf-553ba4d90478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57556595-8ede-4a35-b3a4-0e6f8bfc4d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57556595-8ede-4a35-b3a4-0e6f8bfc4d9d.jpg?1",
             "name": "Distortion Strike",
             "text": "Target creature gets +1/+0 until end of turn and can't be blocked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "6a410259-3a20-54d3-8c18-7115316ccb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca527a9e-3a01-4e0b-add4-a6882f1c89d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca527a9e-3a01-4e0b-add4-a6882f1c89d1.jpg?1",
             "name": "Doorkeeper",
             "text": "Defender\n{2}{U}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of creatures with defender you control.",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "c9b7c3e9-9889-5d10-a22b-05a5c123cd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac94901-f4ec-4888-82ef-87fd2b20cf11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac94901-f4ec-4888-82ef-87fd2b20cf11.jpg?1",
             "name": "Elusive Spellfist",
             "text": "Whenever you cast a noncreature spell, Elusive Spellfist gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "7363e17a-f74b-58a4-b17f-8b480bc71936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f900eeb7-7c45-44bc-ad3a-0bbe594ecf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f900eeb7-7c45-44bc-ad3a-0bbe594ecf50.jpg?1",
             "name": "Flusterstorm",
             "text": "Counter target instant or sorcery spell unless its controller pays {1}.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "20776bf6-9812-5ec7-bae8-9b7adbe7dce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f234849-42c7-4862-aee1-863a77eeacb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f234849-42c7-4862-aee1-863a77eeacb7.jpg?1",
             "name": "Fog Bank",
             "text": "Defender, flying\nPrevent all combat damage that would be dealt to and dealt by Fog Bank.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "7058bf1b-93fa-5e60-8547-7a5aabb6466d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce19a8d-ab1b-415a-ab55-c402c78da5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce19a8d-ab1b-415a-ab55-c402c78da5f0.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "fa6b9fb5-b580-54fd-95e4-2c171774745f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d5a82-3089-403a-8a27-5e4d53d793f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d5a82-3089-403a-8a27-5e4d53d793f0.jpg?1",
             "name": "Illusory Ambusher",
             "text": "Flash\nWhenever Illusory Ambusher is dealt damage, draw that many cards.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "1361f4d0-afac-5b7a-9c2f-bed3e9504be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a88a855-827c-4b08-bc1c-2c8f7cf92660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a88a855-827c-4b08-bc1c-2c8f7cf92660.jpg?1",
             "name": "Illusory Angel",
             "text": "Flying\nCast Illusory Angel only if you've cast another spell this turn.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "7e5d5a58-0cea-59f3-9173-d2e36f222c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a1803-552e-4eb4-b48c-04b359acb14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a1803-552e-4eb4-b48c-04b359acb14a.jpg?1",
             "name": "Jace's Phantasm",
             "text": "Flying\nJace's Phantasm gets +4/+4 as long as an opponent has ten or more cards in his or her graveyard.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "150204e7-8b5e-5224-aa63-3749889ced7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1227fb31-2780-48e2-9790-4a7e9a413f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1227fb31-2780-48e2-9790-4a7e9a413f75.jpg?1",
             "name": "Jhessian Thief",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jhessian Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "b0a94e61-889f-5265-8a18-ca1271694239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a360b6-c7b4-4b25-8288-b3bb8d527bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a360b6-c7b4-4b25-8288-b3bb8d527bda.jpg?1",
             "name": "Jin-Gitaxias, Core Augur",
             "text": "Flash\nAt the beginning of your end step, draw seven cards.\nEach opponent's maximum hand size is reduced by seven.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "8a215c21-cf5e-5d85-baf0-6461a5ee2360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040f57ef-cea4-4935-9207-b3108e175ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040f57ef-cea4-4935-9207-b3108e175ed5.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star dies, gain control of target creature.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "e7ae7655-e573-54c7-97de-d21202c58c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707b0ace-6826-4a07-a9fb-ac06cb96398c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707b0ace-6826-4a07-a9fb-ac06cb96398c.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "916d15ce-1bbf-57cd-b4d8-fc05458160e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416d2d51-8f29-4e95-b037-e8c32b081e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416d2d51-8f29-4e95-b037-e8c32b081e6c.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} to your mana pool equal to that spell's converted mana cost.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "3c05be88-9a60-5955-90b9-af78b8cf3467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247939d9-87e9-4f01-b223-fb4cfa7dbbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247939d9-87e9-4f01-b223-fb4cfa7dbbe1.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "8bc13470-a121-5523-bb51-3c398c51a774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e6784b-78e8-4f0b-8d27-d49c7cea9252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e6784b-78e8-4f0b-8d27-d49c7cea9252.jpg?1",
             "name": "Mnemonic Wall",
             "text": "Defender\nWhen Mnemonic Wall enters the battlefield, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2265,7 +2265,7 @@
         },
         {
             "id": "97c8de76-97e9-5a98-ad12-cc1fe7d87984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428c4985-95de-4703-9cda-7762d7fee04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428c4985-95de-4703-9cda-7762d7fee04f.jpg?1",
             "name": "Ojutai's Breath",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2297,7 +2297,7 @@
         },
         {
             "id": "6261ba76-8c2b-5c1f-bca3-a71b13ba547c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cddd47-8c2b-47de-bf82-e810d4cf4df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cddd47-8c2b-47de-bf82-e810d4cf4df4.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "ea4abe77-cabb-51bb-948b-b44ebb44f228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8ccab7-cc10-4fe8-a302-25d7518f4823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8ccab7-cc10-4fe8-a302-25d7518f4823.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2363,7 +2363,7 @@
         },
         {
             "id": "ee1c1fe2-fde7-5d69-8b8e-f82daf45ae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1d59d6-7f53-4139-b2f2-3189f24bdc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1d59d6-7f53-4139-b2f2-3189f24bdc84.jpg?1",
             "name": "Riverwheel Aerialists",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "1cdbb7f8-27a3-5977-8d5a-2e5ea5168979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b08b1-d9a3-4f18-a5ef-0f46698ac7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b08b1-d9a3-4f18-a5ef-0f46698ac7ed.jpg?1",
             "name": "Shriekgeist",
             "text": "Flying\nWhenever Shriekgeist deals combat damage to a player, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "d0e4e6da-6884-530a-9613-1a30efa34725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ba092-abc0-49ba-b756-6cb714165fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ba092-abc0-49ba-b756-6cb714165fec.jpg?1",
             "name": "Skywise Teachings",
             "text": "Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, create a 2/2 blue Djinn Monk creature token with flying.",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "c549ab52-45f1-57a5-9f78-95cd2a8292eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616676e6-8751-4dfd-a722-be644979dd48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616676e6-8751-4dfd-a722-be644979dd48.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "1db955b3-a78f-5ab7-b350-c2c4d77b78ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19573a69-5022-4d63-9252-c8789602d051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19573a69-5022-4d63-9252-c8789602d051.jpg?1",
             "name": "Teferi, Mage of Zhalfir",
             "text": "Flash\nCreature cards you own that aren't on the battlefield have flash.\nEach opponent can cast spells only any time he or she could cast a sorcery.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "cd22f5a4-a9d9-5654-adbb-ccd1665e315e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d32e59-54e7-4be0-99b7-261cd433bd03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d32e59-54e7-4be0-99b7-261cd433bd03.jpg?1",
             "name": "Thought Scour",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard.\nDraw a card.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "ec0b41de-f985-50b6-b41f-0636ef6b25c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cf802-2d66-49a4-bf43-ab3bc30ab825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cf802-2d66-49a4-bf43-ab3bc30ab825.jpg?1",
             "name": "Windfall",
             "text": "Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way.",
             "colours": [
@@ -2599,7 +2599,7 @@
         },
         {
             "id": "91fe5adc-b3f5-50a0-9e28-dc021a4203f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b9f27-459c-4585-9051-b83ffe053a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b9f27-459c-4585-9051-b83ffe053a74.jpg?1",
             "name": "Abyssal Persecutor",
             "text": "Flying, trample\nYou can't win the game and your opponents can't lose the game.",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "ea6f36c2-a795-51bd-b871-e178aecc378c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6234dca-088f-4888-98d3-0d5a50eb5e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6234dca-088f-4888-98d3-0d5a50eb5e61.jpg?1",
             "name": "Bala Ged Scorpion",
             "text": "When Bala Ged Scorpion enters the battlefield, you may destroy target creature with power 1 or less.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "219f367a-cb98-567a-8d4b-cd3f7421556f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d295ef8c-fe8f-49f2-8588-7f5782315fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d295ef8c-fe8f-49f2-8588-7f5782315fc7.jpg?1",
             "name": "Balustrade Spy",
             "text": "Flying\nWhen Balustrade Spy enters the battlefield, target player reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2702,7 +2702,7 @@
         },
         {
             "id": "354f5f66-ca93-5222-a062-e020372031a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63d3d8-5699-4577-a908-4415bc96b404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63d3d8-5699-4577-a908-4415bc96b404.jpg?1",
             "name": "Bladewing's Thrall",
             "text": "Bladewing's Thrall has flying as long as you control a Dragon.\nWhen a Dragon enters the battlefield, you may return Bladewing's Thrall from your graveyard to the battlefield.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "fb5049b0-b52b-54ef-85a6-bee6e815386b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730c521f-ba12-48fb-b18f-6bb55423a551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730c521f-ba12-48fb-b18f-6bb55423a551.jpg?1",
             "name": "Bloodghast",
             "text": "Bloodghast can't block.\nBloodghast has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may return Bloodghast from your graveyard to the battlefield.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "5ea0f728-c00c-5315-ba8c-6e983a4ef7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d57d94-0507-49b0-84fc-a84b885d355d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d57d94-0507-49b0-84fc-a84b885d355d.jpg?1",
             "name": "Bogbrew Witch",
             "text": "{2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "4af16209-f626-5fe2-b588-956958c523e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a00c8d-9dac-4edc-b66c-ab3245d80969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a00c8d-9dac-4edc-b66c-ab3245d80969.jpg?1",
             "name": "Butcher's Glee",
             "text": "Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "006a38e6-eba7-5a0a-b24b-be7bf351f9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6124cc-1106-4cf6-8499-26fff83a9611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6124cc-1106-4cf6-8499-26fff83a9611.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "d630dd0f-1267-5f1e-823c-924cc8685b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e52f38-2991-429a-a312-a02696c86b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e52f38-2991-429a-a312-a02696c86b05.jpg?1",
             "name": "Dead Reveler",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "eea83330-4fc0-53bd-9af4-20c14a5f5612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90699423-2556-40f7-b8f5-c9d82f22d52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90699423-2556-40f7-b8f5-c9d82f22d52e.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "7008e4b3-c543-530a-a382-9aa3cd36ae7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02eba7-f9ef-418d-9c8e-6e7d2bd3869d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02eba7-f9ef-418d-9c8e-6e7d2bd3869d.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "64ebaa90-b83d-58c2-a94c-411acafa8f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ab1802-1756-44cf-8cf5-ca69f24875f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ab1802-1756-44cf-8cf5-ca69f24875f2.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "5fb53a0a-8b27-5e64-9078-ac5a57e29564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05764968-0abe-4a6f-9f8a-066a4d484571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05764968-0abe-4a6f-9f8a-066a4d484571.jpg?1",
             "name": "Festering Newt",
             "text": "When Festering Newt dies, target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "f9576a0f-7f00-58f4-b255-46af0d3c98cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b77ed75-05d4-4eb3-8c19-dada6b8bb116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b77ed75-05d4-4eb3-8c19-dada6b8bb116.jpg?1",
             "name": "Foul-Tongue Invocation",
             "text": "As an additional cost to cast Foul-Tongue Invocation, you may reveal a Dragon card from your hand.\nTarget player sacrifices a creature. If you revealed a Dragon card or controlled a Dragon as you cast Foul-Tongue Invocation, you gain 4 life.",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "a5a88363-de22-5a13-9e91-92028d084da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce3816e-0f81-40b6-a592-ba2c65243c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce3816e-0f81-40b6-a592-ba2c65243c6d.jpg?1",
             "name": "Grisly Spectacle",
             "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "6b6be42d-e842-5f78-a564-d3cbb77c20a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be041f3-482d-40f3-a525-39e3d6890c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be041f3-482d-40f3-a525-39e3d6890c56.jpg?1",
             "name": "Haunting Hymn",
             "text": "Target player discards two cards. If you cast this spell during your main phase, that player discards four cards instead.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "2d51993e-22e0-5bbc-865b-5ee909ed3b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af042ca9-c57d-4477-965e-182fc557ca6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af042ca9-c57d-4477-965e-182fc557ca6b.jpg?1",
             "name": "Indulgent Tormentor",
             "text": "Flying\nAt the beginning of your upkeep, draw a card unless target opponent sacrifices a creature or pays 3 life.",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "b997771b-6c7c-5d79-a13d-5a4b0d6972b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab56cedb-1bcd-48a5-8503-a8e324e236ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab56cedb-1bcd-48a5-8503-a8e324e236ad.jpg?1",
             "name": "Kokusho, the Evening Star",
             "text": "Flying\nWhen Kokusho, the Evening Star dies, each opponent loses 5 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "df47cae6-8594-57d7-973f-8f65c54a3369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b626ab2-4cf6-42e8-a7e2-9c9f310d2f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b626ab2-4cf6-42e8-a7e2-9c9f310d2f00.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature other than Lord of the Pit. If you can't, Lord of the Pit deals 7 damage to you.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "8cbaaef7-c12b-592e-a4f3-3abab04476af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f32c-d188-4a36-98a4-584b6ef95902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f32c-d188-4a36-98a4-584b6ef95902.jpg?1",
             "name": "Mer-Ek Nightblade",
             "text": "Outlast {B} ({B}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has deathtouch.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "3eba331c-856f-5c6a-89a6-416ee37f4616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "adf1907e-c3b0-5c60-8020-af85662ee5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42c5234-7395-4c9f-a885-8b63cf02c5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42c5234-7395-4c9f-a885-8b63cf02c5e8.jpg?1",
             "name": "Night of Souls' Betrayal",
             "text": "All creatures get -1/-1.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "a7dbfdc1-239c-5779-916b-af4c227eff3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a6facd-0b7f-436d-9529-bf9c931cd492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a6facd-0b7f-436d-9529-bf9c931cd492.jpg?1",
             "name": "Noxious Dragon",
             "text": "Flying\nWhen Noxious Dragon dies, you may destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "cbd981ba-7d0d-5c1a-9e18-74780cab8b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5769888-78e0-4d06-b6b6-b4602f7cd462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5769888-78e0-4d06-b6b6-b4602f7cd462.jpg?1",
             "name": "Ob Nixilis, the Fallen",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have target player lose 3 life. If you do, put three +1/+1 counters on Ob Nixilis, the Fallen.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "95036636-509b-5382-ae2d-f8a5832edd70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8253166-0bf4-4d50-bea3-516a9f60b039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8253166-0bf4-4d50-bea3-516a9f60b039.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "965b0512-51cb-56a7-a1c2-d231b16718b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f619f3-37aa-4f37-9df6-f455c0800f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f619f3-37aa-4f37-9df6-f455c0800f87.jpg?1",
             "name": "Rakdos Drake",
             "text": "Flying\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "3429a010-889b-5db0-8744-712e94dba1ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018ae45-64b8-4e65-8949-586d62b97132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018ae45-64b8-4e65-8949-586d62b97132.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -3511,7 +3511,7 @@
         },
         {
             "id": "f4004310-741b-5ffc-b96e-cdb3f6f189f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857631-8cd5-424f-b93e-d3e98a929988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857631-8cd5-424f-b93e-d3e98a929988.jpg?1",
             "name": "Rotfeaster Maggot",
             "text": "When Rotfeaster Maggot enters the battlefield, exile target creature card from a graveyard. You gain life equal to that card's toughness.",
             "colours": [
@@ -3545,7 +3545,7 @@
         },
         {
             "id": "09263bc9-fd4b-5170-92ef-dc6a5733c300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ed184c-bb2a-47cc-a8e3-ba46b2fc4f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ed184c-bb2a-47cc-a8e3-ba46b2fc4f64.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "4d1afc71-6bd5-5c36-88a3-d445b7fa8132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc236d85-dfe5-4bc8-b116-8306b0922abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc236d85-dfe5-4bc8-b116-8306b0922abf.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "8c2f6201-1543-52f9-a26a-3b8164b01887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd672c9-46ae-4d2b-93d9-16271d2f71ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd672c9-46ae-4d2b-93d9-16271d2f71ff.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "Swampwalk\nAt the beginning of your upkeep, return target creature card from your graveyard to the battlefield.\nAt the beginning of each opponent's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "a09a07fc-adaf-538f-a109-6234e7e8027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86557e1-6960-42a2-8d18-baafc22fbb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86557e1-6960-42a2-8d18-baafc22fbb90.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "bfb6439a-52c9-5eb9-a543-afb9af8a9b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1c46-8331-4a09-9fcb-d942f8102364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1c46-8331-4a09-9fcb-d942f8102364.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "5e87e8ed-1a41-5063-9bab-32e79ca17631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23915972-2009-4363-a791-24be90a4fbe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23915972-2009-4363-a791-24be90a4fbe0.jpg?1",
             "name": "Thrill-Kill Assassin",
             "text": "Deathtouch\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "31a8856b-717c-514a-b4ae-f89ba3f5e948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78ab496-a19f-4c70-a56c-09a512d40c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78ab496-a19f-4c70-a56c-09a512d40c87.jpg?1",
             "name": "Ulcerate",
             "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
             "colours": [
@@ -3782,7 +3782,7 @@
         },
         {
             "id": "99466d84-9471-5724-a592-4d1c109591f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d6ca74-70f5-44c6-82f7-dae8980bdd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d6ca74-70f5-44c6-82f7-dae8980bdd44.jpg?1",
             "name": "Virulent Swipe",
             "text": "Target creature gets +2/+0 and gains deathtouch until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -3814,7 +3814,7 @@
         },
         {
             "id": "6446c0ab-cc72-59b3-a380-c22b6e2317d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8698868-2aff-4973-8fc6-e2ac7202384d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8698868-2aff-4973-8fc6-e2ac7202384d.jpg?1",
             "name": "Wight of Precinct Six",
             "text": "Wight of Precinct Six gets +1/+1 for each creature card in your opponents' graveyards.",
             "colours": [
@@ -3848,7 +3848,7 @@
         },
         {
             "id": "3413f32a-9953-580f-9bf5-5c6d25c3570d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360a6ada-b257-44b8-b830-aaa122474bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360a6ada-b257-44b8-b830-aaa122474bce.jpg?1",
             "name": "Wrench Mind",
             "text": "Target player discards two cards unless he or she discards an artifact card.",
             "colours": [
@@ -3880,7 +3880,7 @@
         },
         {
             "id": "8fc6df75-ddd9-57b8-8df4-c2c6916684a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ecae08-bcc6-4074-822c-3dfe1d46ae39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ecae08-bcc6-4074-822c-3dfe1d46ae39.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "5c049347-1731-56d7-a0d1-aee3c6cb6855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccbfd3f-da15-46aa-9ffc-b6bfdf9d1d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccbfd3f-da15-46aa-9ffc-b6bfdf9d1d91.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "2d76d5fa-4975-5950-b25e-37cfe3faaac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99ee7b4-7a9b-4ccf-830b-adf203e2fe7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99ee7b4-7a9b-4ccf-830b-adf203e2fe7f.jpg?1",
             "name": "Bogardan Hellkite",
             "text": "Flash\nFlying\nWhen Bogardan Hellkite enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "ecf568ce-69fd-57dc-b32c-aa03fd6c11c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93bd9ae-a514-44f0-91b9-8889c1039555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93bd9ae-a514-44f0-91b9-8889c1039555.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "ad0b53de-e58e-557e-9598-02ca7a605444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2f3a3-7f5f-4ddf-aadb-9ddfe0a9197c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2f3a3-7f5f-4ddf-aadb-9ddfe0a9197c.jpg?1",
             "name": "Charmbreaker Devils",
             "text": "At the beginning of your upkeep, return an instant or sorcery card at random from your graveyard to your hand.\nWhenever you cast an instant or sorcery spell, Charmbreaker Devils gets +4/+0 until end of turn.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "ec3dec6e-744b-5b86-8cce-f89e51b09df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08654c6-9073-4c37-b23d-02136248cf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08654c6-9073-4c37-b23d-02136248cf37.jpg?1",
             "name": "Coordinated Assault",
             "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "045a4000-75e9-5956-9c9c-19b594e9721e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a6f4dd-29c9-4084-a622-098b197a6eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a6f4dd-29c9-4084-a622-098b197a6eb7.jpg?1",
             "name": "Crucible of Fire",
             "text": "Dragon creatures you control get +3/+3.",
             "colours": [
@@ -4114,7 +4114,7 @@
         },
         {
             "id": "b38f158d-05c4-53cb-88d9-1eae6560af4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c57c26-500b-4ca2-9c47-f2a0e31975b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c57c26-500b-4ca2-9c47-f2a0e31975b3.jpg?1",
             "name": "Draconic Roar",
             "text": "As an additional cost to cast Draconic Roar, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast Draconic Roar, Draconic Roar deals 3 damage to that creature's controller.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "b8d6c839-2cfc-541f-a48c-72b7384d85ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9fb609-3df9-42e9-b15e-39d18661526a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9fb609-3df9-42e9-b15e-39d18661526a.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4181,7 +4181,7 @@
         },
         {
             "id": "2469fcfb-c4c6-5157-974b-52ecfeadb806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1933d08-07fe-45ea-9b60-d9afb98d5753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1933d08-07fe-45ea-9b60-d9afb98d5753.jpg?1",
             "name": "Dragon Tempest",
             "text": "Whenever a creature with flying enters the battlefield under your control, it gains haste until end of turn.\nWhenever a Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.",
             "colours": [
@@ -4213,7 +4213,7 @@
         },
         {
             "id": "998dc952-b4f9-5ef4-b85b-95b93da983e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e387494-a184-49f8-bbf6-37dce964e702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e387494-a184-49f8-bbf6-37dce964e702.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "06e40daa-7ce9-586c-adf7-f58fe93b792f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67562b9-7f07-4bfd-b049-6216cbcb1cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67562b9-7f07-4bfd-b049-6216cbcb1cd2.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "c00057a6-1cc1-5753-b694-1e2a09685270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7220aaa0-c457-4067-b1ff-360b161c34e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7220aaa0-c457-4067-b1ff-360b161c34e5.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "3055acc3-ceab-5187-8398-0cc0770e681c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267597a-bbfe-4fb7-91b7-7fee371f0dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267597a-bbfe-4fb7-91b7-7fee371f0dfd.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "bb86d9b1-794b-5c26-94ce-7bbfddbeae53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d585cf04-b823-49c1-a33a-9cd8f3116eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d585cf04-b823-49c1-a33a-9cd8f3116eda.jpg?1",
             "name": "Fury Charm",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target creature gets +1/+1 and gains trample until end of turn.\n\u2022 Remove two time counters from target permanent or suspended card.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "4c4926c4-4ec6-56f2-8c74-24cd8de67732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9923ad-67a3-4d2a-be67-3b8063e2f3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9923ad-67a3-4d2a-be67-3b8063e2f3b3.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "3eb68c53-4cb2-5aaf-9d33-88f9a7821fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f980def6-9a87-4948-9d02-956d568a95fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f980def6-9a87-4948-9d02-956d568a95fe.jpg?1",
             "name": "Hammerhand",
             "text": "Enchant creature\nWhen Hammerhand enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "9c83694d-a891-569e-b58f-c4687d1cc935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59a9859-c50a-4dc5-aae2-56fcafb1792d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59a9859-c50a-4dc5-aae2-56fcafb1792d.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "43fc2b80-9f04-5de9-b765-d4a43ad6ce1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cd59a-f184-4e8e-885e-36fbceddfc06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cd59a-f184-4e8e-885e-36fbceddfc06.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle your library.\nWhen Hoarding Dragon dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -4515,7 +4515,7 @@
         },
         {
             "id": "2a47e451-f719-5e62-83d2-3ef5e57e4385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed95d07-5a9b-4fd9-85ff-9860f6a492d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed95d07-5a9b-4fd9-85ff-9860f6a492d0.jpg?1",
             "name": "Keldon Halberdier",
             "text": "First strike\nSuspend 4\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "5615514f-e5d0-5ff9-acbc-0b95da651c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ff0ee3-9600-4c7d-acec-6ec90595384e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ff0ee3-9600-4c7d-acec-6ec90595384e.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Create a token that's a copy of target nonlegendary creature you control. That token has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "bec536b9-3fe5-50ae-a4a9-5f29540491ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89e7c4-7864-4031-a9e5-38b5d47290ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89e7c4-7864-4031-a9e5-38b5d47290ff.jpg?1",
             "name": "Kiln Fiend",
             "text": "Whenever you cast an instant or sorcery spell, Kiln Fiend gets +3/+0 until end of turn.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "7221a224-b29f-58e5-ac5a-990ab5fa2184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f685078-c9b3-42aa-be5a-be16be89ecc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f685078-c9b3-42aa-be5a-be16be89ecc6.jpg?1",
             "name": "Magus of the Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "2ed72dc6-8943-5c5d-9b99-d827c6a015d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8882153-ad51-4bef-91bd-275a46688320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8882153-ad51-4bef-91bd-275a46688320.jpg?1",
             "name": "Mark of Mutiny",
             "text": "Gain control of target creature until end of turn. Put a +1/+1 counter on it and untap it. That creature gains haste until end of turn.",
             "colours": [
@@ -4689,7 +4689,7 @@
         },
         {
             "id": "2be739f0-348c-5a0b-9649-432b0b573941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58db2f81-6ff5-402c-8aef-0b667e82cdc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58db2f81-6ff5-402c-8aef-0b667e82cdc4.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4724,7 +4724,7 @@
         },
         {
             "id": "89831bc4-79e6-5618-b916-94c07f66b52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16b001f-dffd-4e7c-a7ab-daa00221bfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16b001f-dffd-4e7c-a7ab-daa00221bfbf.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "fd3a8347-4cf1-5a69-817c-98ac4d7ddeae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf1c10f-b1f7-480e-8e8b-f98c26fe9b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf1c10f-b1f7-480e-8e8b-f98c26fe9b4b.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "df108e80-69ea-56b1-aef5-1bed6e2d08b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98895a-bfc3-4b0b-a8a6-2c202f6edf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98895a-bfc3-4b0b-a8a6-2c202f6edf0d.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to target creature or player.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "db37a632-442c-51a7-a825-99f10ee64e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e62328-fe29-4097-b45c-66cd62f93f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e62328-fe29-4097-b45c-66cd62f93f86.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "35731d41-bf4a-51a7-b0fb-a36a5409a18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f59f13a-653d-4883-a18b-bc030c51e61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f59f13a-653d-4883-a18b-bc030c51e61e.jpg?1",
             "name": "Scourge of Valkas",
             "text": "Flying\nWhenever Scourge of Valkas or another Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.\n{R}: Scourge of Valkas gets +1/+0 until end of turn.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "b9c83afe-679c-5bcd-ba38-91b66558c34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80656711-0e36-4bf6-9ba2-ef4fbdfa433a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80656711-0e36-4bf6-9ba2-ef4fbdfa433a.jpg?1",
             "name": "Splatter Thug",
             "text": "First strike\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "9b5735d5-5c7d-5330-ba81-ff1aca5a4818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312ada22-0085-4103-b20d-a5bbfacb6ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312ada22-0085-4103-b20d-a5bbfacb6ec1.jpg?1",
             "name": "Staggershock",
             "text": "Staggershock deals 2 damage to target creature or player.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "0f9bc623-9fcc-5b4a-85e0-a9052314025f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681912e7-9dee-436f-a115-1701287f8a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681912e7-9dee-436f-a115-1701287f8a49.jpg?1",
             "name": "Surreal Memoir",
             "text": "Return an instant card at random from your graveyard to your hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "9f74c981-f478-5a64-af04-13fc8ba668e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75f6bb4-ab06-42ca-a0df-326d9a098a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75f6bb4-ab06-42ca-a0df-326d9a098a26.jpg?1",
             "name": "Thundermaw Hellkite",
             "text": "Flying, haste\nWhen Thundermaw Hellkite enters the battlefield, it deals 1 damage to each creature with flying your opponents control. Tap those creatures.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "05e75111-7491-53d3-ab91-2a122d959d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d373ce86-c92d-4d91-b3bb-739aba7d09a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d373ce86-c92d-4d91-b3bb-739aba7d09a1.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "110556d2-6f5d-5839-8801-b6da1a123f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a3e069-856a-4fe7-9357-56697fb665fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a3e069-856a-4fe7-9357-56697fb665fc.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5091,7 +5091,7 @@
         },
         {
             "id": "7b68c5d8-6b32-53bf-bf7d-7f2aa88a977b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba50b62-710e-4c92-9e02-736c1a987bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba50b62-710e-4c92-9e02-736c1a987bb9.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "Creatures you control have haste.\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "5350060b-b240-5360-8431-d46638cebbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6f563e-4f94-4caf-83b9-bfc64e18bc9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6f563e-4f94-4caf-83b9-bfc64e18bc9c.jpg?1",
             "name": "Vent Sentinel",
             "text": "Defender\n{1}{R}, {T}: Vent Sentinel deals damage to target player equal to the number of creatures with defender you control.",
             "colours": [
@@ -5162,7 +5162,7 @@
         },
         {
             "id": "661e985f-4b24-5908-9dbc-3a3b9450f506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b405858-83eb-4939-b86d-4ba190fca048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b405858-83eb-4939-b86d-4ba190fca048.jpg?1",
             "name": "Aerial Predation",
             "text": "Destroy target creature with flying. You gain 2 life.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "6e7e86be-c23e-5082-a172-e17bb9d6e890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72a45f-16e9-4040-acf1-927133ba198e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72a45f-16e9-4040-acf1-927133ba198e.jpg?1",
             "name": "Assault Formation",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -5226,7 +5226,7 @@
         },
         {
             "id": "30267ddf-c87b-5c7c-b435-0e223e4c2922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbc15e-003b-4d8b-9840-d0d2f74f44c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbc15e-003b-4d8b-9840-d0d2f74f44c0.jpg?1",
             "name": "Carven Caryatid",
             "text": "Defender\nWhen Carven Caryatid enters the battlefield, draw a card.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "1a7f0997-6994-5513-8999-418adaba306d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce54c7c1-3401-4414-8da0-5846cb0ae1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce54c7c1-3401-4414-8da0-5846cb0ae1b4.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "e40aeaf0-f5f7-5d53-8757-0a73b15181d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc5264-e27e-4286-9feb-0dda0b074097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc5264-e27e-4286-9feb-0dda0b074097.jpg?1",
             "name": "Crowned Ceratok",
             "text": "Trample\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "3e419f27-f1f9-5b65-93ac-b0617de30fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf631ad-762f-4bec-9588-aca88507cad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf631ad-762f-4bec-9588-aca88507cad5.jpg?1",
             "name": "Curse of Predation",
             "text": "Enchant player\nWhenever a creature attacks enchanted player, put a +1/+1 counter on it.",
             "colours": [
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "16c94c7e-5d9c-567a-b9fe-e7fff0b1e008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df027117-9cb2-428f-b5ab-eb4491493fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df027117-9cb2-428f-b5ab-eb4491493fa3.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "a9f79770-5a98-5a63-bdb9-2520e7e2730c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6879321-9a61-4c4f-9513-81ad5684c99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6879321-9a61-4c4f-9513-81ad5684c99e.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample",
             "colours": [
@@ -5429,7 +5429,7 @@
         },
         {
             "id": "5634df34-59ef-5cd3-9e78-3624fbd8dd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f2e230-4c40-4e2a-a39e-81560122cd88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f2e230-4c40-4e2a-a39e-81560122cd88.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "1f6c3e16-0000-5a4d-b84f-441ac68ffc08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0118e-4449-4394-b4c1-5b4f83d7bc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0118e-4449-4394-b4c1-5b4f83d7bc4a.jpg?1",
             "name": "Genesis Hydra",
             "text": "When you cast Genesis Hydra, reveal the top X cards of your library. You may put a nonland permanent card with converted mana cost X or less from among them onto the battlefield. Then shuffle the rest into your library.\nGenesis Hydra enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "bbe4bec3-68ef-5f20-a7c5-f4d597a132ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5007919b-27d3-46e7-a588-ce796709d565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5007919b-27d3-46e7-a588-ce796709d565.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "e8509fef-27d9-5bb7-90ab-822192b0956b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886e40d7-5677-493d-9ea4-205f50d2aefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886e40d7-5677-493d-9ea4-205f50d2aefe.jpg?1",
             "name": "Greater Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "2449e94e-2e01-5aae-9dc7-6f139336b9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f060ff2-d2cb-4203-85b8-ad531029575a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f060ff2-d2cb-4203-85b8-ad531029575a.jpg?1",
             "name": "Heroes' Bane",
             "text": "Heroes' Bane enters the battlefield with four +1/+1 counters on it.\n{2}{G}{G}: Put X +1/+1 counters on Heroes' Bane, where X is its power.",
             "colours": [
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "1c4a5a75-4dcf-58f8-bba8-8714540240ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f763a4-8a79-4056-8066-74899a0fb304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f763a4-8a79-4056-8066-74899a0fb304.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5628,7 +5628,7 @@
         },
         {
             "id": "f3d7129f-8363-5561-a3d5-8e59b2034fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06224230-d4cb-437d-87d5-956251c6f03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06224230-d4cb-437d-87d5-956251c6f03d.jpg?1",
             "name": "Hunting Pack",
             "text": "Create a 4/4 green Beast creature token.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "d8ee97ef-71a1-54e9-ac77-13bc33caa996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ed4a28-50b6-4349-82d2-165e6f08956e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ed4a28-50b6-4349-82d2-165e6f08956e.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn.",
             "colours": [
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "5165834a-c648-5819-b3f1-0dc43afc9ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704a2367-823f-4e40-8b3c-91115bb9b755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704a2367-823f-4e40-8b3c-91115bb9b755.jpg?1",
             "name": "Ivy Elemental",
             "text": "Ivy Elemental enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5726,7 +5726,7 @@
         },
         {
             "id": "ead5a52f-84fe-5624-b327-62a4546f3ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e69772-50b7-496e-a7b1-702f57a66d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e69772-50b7-496e-a7b1-702f57a66d64.jpg?1",
             "name": "Jaddi Offshoot",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "7944f8e1-71ea-5ea5-9782-c3ccd23e4f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d897caab-3720-4f1a-bf38-4ba266352567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d897caab-3720-4f1a-bf38-4ba266352567.jpg?1",
             "name": "Jugan, the Rising Star",
             "text": "Flying\nWhen Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "d2dedaa9-9713-5c98-ac1f-5611c350f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc160fd-e34f-46a1-9a38-5c51a49fe64e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc160fd-e34f-46a1-9a38-5c51a49fe64e.jpg?1",
             "name": "Lead the Stampede",
             "text": "Look at the top five cards of your library. You may reveal any number of creature cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "f8847b9d-b990-5b1f-ab15-b979fad936e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6365c6-bd12-4d02-a403-60d0c5290c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6365c6-bd12-4d02-a403-60d0c5290c06.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may add one mana of any color to your mana pool.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "1d2b38a3-55a1-5db2-83d6-adc6cdcde05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c8336d-54cf-45af-a9ef-a1428facf91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c8336d-54cf-45af-a9ef-a1428facf91b.jpg?1",
             "name": "Lure",
             "text": "Enchant creature\nAll creatures able to block enchanted creature do so.",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "c59f1c2b-76c9-5fd9-8cc4-3525a51e1851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdfbff4-32fb-4228-a5ec-4bdeb8bb8e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdfbff4-32fb-4228-a5ec-4bdeb8bb8e70.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman enters the battlefield, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than cast this card from your hand, you may pay {2}{G}{G} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "5f6f49d1-1d16-5698-b9d5-0cbaacb391f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b6640-ef2f-4c92-beb3-afdf78f9c2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b6640-ef2f-4c92-beb3-afdf78f9c2d5.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -5964,7 +5964,7 @@
         },
         {
             "id": "7be8f82e-f02c-5503-8a9c-65c90d9a2105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bc55d3-dd1c-40da-9197-76cb1b5d29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bc55d3-dd1c-40da-9197-76cb1b5d29c2.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "165f861a-01b6-5952-834a-3e08441f8346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d12669-ca08-4a3c-b30f-15168b75abe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d12669-ca08-4a3c-b30f-15168b75abe4.jpg?1",
             "name": "Obstinate Baloth",
             "text": "When Obstinate Baloth enters the battlefield, you gain 4 life.\nIf a spell or ability an opponent controls causes you to discard Obstinate Baloth, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "e0d3f715-4530-5a3f-9914-afa4a6f255d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43ea5d8-d7b7-4518-b37c-32668e4fd5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43ea5d8-d7b7-4518-b37c-32668e4fd5d4.jpg?1",
             "name": "Overgrown Battlement",
             "text": "Defender\n{T}: Add {G} to your mana pool for each creature with defender you control.",
             "colours": [
@@ -6066,7 +6066,7 @@
         },
         {
             "id": "44b4ed57-1d2c-5e36-a313-f2d73774405d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f8a506-04e4-4f6f-9f81-f31db562f7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f8a506-04e4-4f6f-9f81-f31db562f7c6.jpg?1",
             "name": "Phantom Tiger",
             "text": "Phantom Tiger enters the battlefield with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Tiger, prevent that damage. Remove a +1/+1 counter from Phantom Tiger.",
             "colours": [
@@ -6101,7 +6101,7 @@
         },
         {
             "id": "e7773706-622d-5236-9786-7ecacaa16f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7992e-494b-4b1b-bd5d-8f9bb19b275e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7992e-494b-4b1b-bd5d-8f9bb19b275e.jpg?1",
             "name": "Prey's Vengeance",
             "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "10753ea0-ab77-56bd-83f4-1d309402cec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5537da-112e-4679-a113-b5d7ce32a66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5537da-112e-4679-a113-b5d7ce32a66b.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "4ff8f18e-d3a0-5099-b560-bcaa94213fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5667d8e-c72e-478a-9e90-633d608b8c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5667d8e-c72e-478a-9e90-633d608b8c31.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "882b5b60-321b-529c-8699-0d2da20e9823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a950b3-5083-474a-8f56-fec7637cc402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a950b3-5083-474a-8f56-fec7637cc402.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -6233,7 +6233,7 @@
         },
         {
             "id": "21488745-e445-5f11-a458-c46adffbc2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50d74eb-07df-48b5-8788-8b5f5fc0b22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50d74eb-07df-48b5-8788-8b5f5fc0b22b.jpg?1",
             "name": "Sultai Flayer",
             "text": "Whenever a creature you control with toughness 4 or greater dies, you gain 4 life.",
             "colours": [
@@ -6268,7 +6268,7 @@
         },
         {
             "id": "33316a29-d7fa-535c-872c-301f2905dbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50965f7e-a4e2-41b7-8b81-4a2ffa9db123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50965f7e-a4e2-41b7-8b81-4a2ffa9db123.jpg?1",
             "name": "Timberland Guide",
             "text": "When Timberland Guide enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -6303,7 +6303,7 @@
         },
         {
             "id": "2aebe2d5-7bff-5273-8ec8-c135a9339a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe1ebf9-8378-444b-870a-5be12aa1f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe1ebf9-8378-444b-870a-5be12aa1f5fa.jpg?1",
             "name": "Undercity Troll",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{2}{G}: Regenerate Undercity Troll.",
             "colours": [
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "55520b71-3a90-5333-9634-a93c7b91d095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe3af8c-109d-486c-aa34-3f023abda5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe3af8c-109d-486c-aa34-3f023abda5b7.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "Trample\nWhenever you tap a land for mana, add one mana to your mana pool of any type that land produced.\nWhenever an opponent taps a land for mana, that land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "ff944f8f-fdcb-5a2e-985b-cc3583223610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65cb901-bfb0-454a-97ef-138021e524ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65cb901-bfb0-454a-97ef-138021e524ff.jpg?1",
             "name": "Wall of Roots",
             "text": "Defender\nPut a -0/-1 counter on Wall of Roots: Add {G} to your mana pool. Activate this ability only once each turn.",
             "colours": [
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "e3fd21bc-2982-56c6-9775-d4d747ff0095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b80bc77-eee4-4384-904a-b746be5987ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b80bc77-eee4-4384-904a-b746be5987ac.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "4d268678-6b7a-530e-b3a6-6eb132728e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9740ceaf-4ef9-48dd-ab7d-cd5eb3be8cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9740ceaf-4ef9-48dd-ab7d-cd5eb3be8cec.jpg?1",
             "name": "Azorius Charm",
             "text": "Choose one \u2014\n\u2022 Creatures you control gain lifelink until end of turn.\n\u2022 Draw a card.\n\u2022 Put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "fe335f04-3b8f-516f-8c38-2a7906f756d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce43cb-44f4-4d94-8700-d9f3cc043989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce43cb-44f4-4d94-8700-d9f3cc043989.jpg?1",
             "name": "Bladewing the Risen",
             "text": "Flying\nWhen Bladewing the Risen enters the battlefield, you may return target Dragon permanent card from your graveyard to the battlefield.\n{B}{R}: Dragon creatures get +1/+1 until end of turn.",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "36248f46-9639-5085-878b-36322b86729c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0167df83-3bf4-4442-897d-c4ed06fa05a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0167df83-3bf4-4442-897d-c4ed06fa05a6.jpg?1",
             "name": "Blizzard Specter",
             "text": "Flying\nWhenever Blizzard Specter deals combat damage to a player, choose one \u2014\n\u2022 That player returns a permanent he or she controls to its owner's hand.\n\u2022 That player discards a card.",
             "colours": [
@@ -6552,7 +6552,7 @@
         },
         {
             "id": "0256edf3-a8de-52b6-a571-62396989e056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56955e63-db6f-4f1d-b3c4-dd268c902653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56955e63-db6f-4f1d-b3c4-dd268c902653.jpg?1",
             "name": "Blood Baron of Vizkopa",
             "text": "Lifelink, protection from white and from black\nAs long as you have 30 or more life and an opponent has 10 or less life, Blood Baron of Vizkopa gets +6/+6 and has flying.",
             "colours": [
@@ -6588,7 +6588,7 @@
         },
         {
             "id": "0922d44c-1f86-5328-a6b2-4c33c6f82d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4d6cc-bbd1-471e-888b-33e20a96ce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4d6cc-bbd1-471e-888b-33e20a96ce60.jpg?1",
             "name": "Chronicler of Heroes",
             "text": "When Chronicler of Heroes enters the battlefield, draw a card if you control a creature with a +1/+1 counter on it.",
             "colours": [
@@ -6625,7 +6625,7 @@
         },
         {
             "id": "9e324151-fbd8-59e0-8c4b-d8f874ce8239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74fbb14-d7ad-47ff-9171-37ed0fc2acff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74fbb14-d7ad-47ff-9171-37ed0fc2acff.jpg?1",
             "name": "Corpsejack Menace",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on it instead.",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "c9b1530b-7d91-5f74-a8ae-382480e6c9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112af09-1305-4e00-8273-403eac40786f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112af09-1305-4e00-8273-403eac40786f.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "19a589fd-fca1-5c4b-b2e5-5fca23bdc2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16384575-d0bc-4826-966e-a4bf6ae6ab97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16384575-d0bc-4826-966e-a4bf6ae6ab97.jpg?1",
             "name": "Firemane Angel",
             "text": "Flying, first strike\nAt the beginning of your upkeep, if Firemane Angel is in your graveyard or on the battlefield, you may gain 1 life.\n{6}{R}{R}{W}{W}: Return Firemane Angel from your graveyard to the battlefield. Activate this ability only during your upkeep.",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "6cf6586d-f193-5686-9e69-388d187e7e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afde7ce-b0d7-4ac0-947b-ae298a61c37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afde7ce-b0d7-4ac0-947b-ae298a61c37b.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player puts the top ten cards of his or her library into his or her graveyard.",
             "colours": [
@@ -6765,7 +6765,7 @@
         },
         {
             "id": "1f6488a5-3c3c-58ff-afb2-8b3363aa743e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99dc07bf-7c55-442b-9260-5ea74a42af41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99dc07bf-7c55-442b-9260-5ea74a42af41.jpg?1",
             "name": "Hypersonic Dragon",
             "text": "Flying, haste\nYou may cast sorcery spells as though they had flash.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "7623d88d-602c-5feb-9167-eea9cdd7d5c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8097e6e-c04e-4266-a8f4-07e5fb0638d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8097e6e-c04e-4266-a8f4-07e5fb0638d4.jpg?1",
             "name": "Jungle Barrier",
             "text": "Defender\nWhen Jungle Barrier enters the battlefield, draw a card.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "9b872a91-9bad-51c1-b0c2-82d4c1a92c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205df311-a72d-40f1-b2ea-9b30274bc9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205df311-a72d-40f1-b2ea-9b30274bc9bd.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "7668caf0-7ee0-54a1-996c-df75e8c3ca15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7053b773-a369-45b8-912f-ee66de3a63c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7053b773-a369-45b8-912f-ee66de3a63c6.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "38c0af39-8839-5dc4-a1b0-25e22bbe9de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010a4b07-c2d5-433e-9898-6e148104e9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010a4b07-c2d5-433e-9898-6e148104e9e0.jpg?1",
             "name": "Malfegor",
             "text": "Flying\nWhen Malfegor enters the battlefield, discard your hand. Each opponent sacrifices a creature for each card discarded this way.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "0c1a2bac-c9cd-5e30-8959-09ca1d50f752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472efa7f-203f-4c48-b9ad-505e18f2976f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472efa7f-203f-4c48-b9ad-505e18f2976f.jpg?1",
             "name": "Rosheen Meanderer",
             "text": "{T}: Add {C}{C}{C}{C} to your mana pool. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -6987,7 +6987,7 @@
         },
         {
             "id": "5eef1e9e-d910-5acf-b4e5-f8d647dea13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a2043-d8e1-42e4-bbd4-0e6163ecd91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a2043-d8e1-42e4-bbd4-0e6163ecd91f.jpg?1",
             "name": "Savageborn Hydra",
             "text": "Double strike\nSavageborn Hydra enters the battlefield with X +1/+1 counters on it.\n{1}{RG}: Put a +1/+1 counter on Savageborn Hydra. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "de92be69-7e40-513f-bddd-c58bdaca2176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18816df-9b73-4a3f-a1d5-ceabf76d3fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18816df-9b73-4a3f-a1d5-ceabf76d3fb0.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -7059,7 +7059,7 @@
         },
         {
             "id": "f3eda7dd-5468-5dbe-bb72-9e32a02885f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c2ce16-840b-4971-b4cc-89c8cdc5b093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c2ce16-840b-4971-b4cc-89c8cdc5b093.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\n{B}: Regenerate Spiritmonger.\n{G}: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "6c4528f2-6b15-5a8e-b827-a5e33460a3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a679cc74-6119-468f-8c64-5dcf216438d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a679cc74-6119-468f-8c64-5dcf216438d1.jpg?1",
             "name": "Supreme Verdict",
             "text": "Supreme Verdict can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "c19afd60-9a58-582a-931d-08154bbea6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdce9d1-a163-40e1-a70a-1f09cf400a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdce9d1-a163-40e1-a70a-1f09cf400a6c.jpg?1",
             "name": "Vizkopa Guildmage",
             "text": "{1}{W}{B}: Target creature gains lifelink until end of turn.\n{1}{W}{B}: Whenever you gain life this turn, each opponent loses that much life.",
             "colours": [
@@ -7166,7 +7166,7 @@
         },
         {
             "id": "effa7a1c-5b96-50e5-8308-bc8a1b5d5893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14cdc38-dd46-495e-93bd-d2694b64d5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14cdc38-dd46-495e-93bd-d2694b64d5ad.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "9ce99de8-bbd0-5043-9670-7f69ec41c1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9262dc-2b12-49c8-b339-4394694c81d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9262dc-2b12-49c8-b339-4394694c81d7.jpg?1",
             "name": "Bubbling Cauldron",
             "text": "{1}, {T}, Sacrifice a creature: You gain 4 life.\n{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.",
             "colours": [],
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "fa51b456-075b-5bdb-8148-59f07a6f4b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091da355-a253-443b-ad97-1908bd1a40ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091da355-a253-443b-ad97-1908bd1a40ab.jpg?1",
             "name": "Darksteel Axe",
             "text": "Indestructible\nEquipped creature gets +2/+0.\nEquip {2}",
             "colours": [],
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "6b1f6f5b-e98e-5376-a987-06f1ff7ef638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdff68c-ad98-48b0-9e00-8c5032a3cdb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdff68c-ad98-48b0-9e00-8c5032a3cdb1.jpg?1",
             "name": "Dragonloft Idol",
             "text": "As long as you control a Dragon, Dragonloft Idol gets +1/+1 and has flying and trample.",
             "colours": [],
@@ -7283,7 +7283,7 @@
         },
         {
             "id": "df473eeb-3575-5be1-bfda-4970bab3d046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75ea55-294f-40d5-b155-448fe363466a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75ea55-294f-40d5-b155-448fe363466a.jpg?1",
             "name": "Guardian Idol",
             "text": "Guardian Idol enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}: Guardian Idol becomes a 2/2 Golem artifact creature until end of turn.",
             "colours": [],
@@ -7311,7 +7311,7 @@
         },
         {
             "id": "1c53959c-79ed-5b38-82fa-e92608fea71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efb210e-00a9-470e-ac30-4036a7befd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efb210e-00a9-470e-ac30-4036a7befd4c.jpg?1",
             "name": "Kolaghan Monument",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{4}{B}{R}: Kolaghan Monument becomes a 4/4 black and red Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -7342,7 +7342,7 @@
         },
         {
             "id": "31f30861-89e1-5a4b-b193-2894fe0f511f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f91e78e-9297-4ae3-b55f-d73e79d0d21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f91e78e-9297-4ae3-b55f-d73e79d0d21a.jpg?1",
             "name": "Manakin",
             "text": "{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -7373,7 +7373,7 @@
         },
         {
             "id": "2ea8ec31-3f12-50db-bd7f-a53a809a1cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54814f1-3598-4859-b956-b39d8335e6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54814f1-3598-4859-b956-b39d8335e6d3.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "b5e9ebe8-3086-5bf7-93a7-8123046b795b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679a847-7196-4a45-8610-229aa2e124d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679a847-7196-4a45-8610-229aa2e124d6.jpg?1",
             "name": "Mindcrank",
             "text": "Whenever an opponent loses life, that player puts that many cards from the top of his or her library into his or her graveyard. (Damage causes loss of life.)",
             "colours": [],
@@ -7429,7 +7429,7 @@
         },
         {
             "id": "c9e0717e-efe4-5615-b1da-6dec83f0a9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbe32c7-180f-4b9e-b260-0ff1d9017e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbe32c7-180f-4b9e-b260-0ff1d9017e28.jpg?1",
             "name": "Mishra's Bauble",
             "text": "{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -7457,7 +7457,7 @@
         },
         {
             "id": "8c2b2d7c-0285-51bd-a9eb-433090686e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d016c5f-265b-4426-8dd8-87872f075f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d016c5f-265b-4426-8dd8-87872f075f33.jpg?1",
             "name": "Moonglove Extract",
             "text": "Sacrifice Moonglove Extract: It deals 2 damage to target creature or player.",
             "colours": [],
@@ -7485,7 +7485,7 @@
         },
         {
             "id": "d6c9378c-7bd7-580f-9f23-346780810ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5876108-ffaa-4690-9dba-20f43aea29fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5876108-ffaa-4690-9dba-20f43aea29fe.jpg?1",
             "name": "Oblivion Stone",
             "text": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice Oblivion Stone: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
             "colours": [],
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "94bce371-c6ad-5c82-bb45-adc8e028da9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086c355-596d-40f0-95e0-a52d710c5f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086c355-596d-40f0-95e0-a52d710c5f80.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "a79f7da0-8b00-5498-9c8c-f58c415359bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f59820b-462e-4023-8b00-d8b5fafe15a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f59820b-462e-4023-8b00-d8b5fafe15a3.jpg?1",
             "name": "Pristine Talisman",
             "text": "{T}: Add {C} to your mana pool. You gain 1 life.",
             "colours": [],
@@ -7572,7 +7572,7 @@
         },
         {
             "id": "c22a2453-5b8a-5d7d-b443-0c1250032859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876340a5-2dbd-44e2-bfd6-720f53b7115d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876340a5-2dbd-44e2-bfd6-720f53b7115d.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "2ee6b092-d6f7-598c-af67-a864c15d9d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e917fe-648c-4b26-ae9a-c3b1a8c55c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e917fe-648c-4b26-ae9a-c3b1a8c55c86.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "f14e41a1-51d1-5fbc-b9f0-c5dbbbf73da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8753b80-aa9e-4f82-9a02-6b3997169dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8753b80-aa9e-4f82-9a02-6b3997169dbb.jpg?1",
             "name": "Serum Powder",
             "text": "{T}: Add {C} to your mana pool.\nAny time you could mulligan and Serum Powder is in your hand, you may exile all the cards from your hand, then draw that many cards. (You can do this in addition to taking mulligans.)",
             "colours": [],
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "e6c75b16-a101-52ce-ba6b-b742e03d442c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010712-7f42-4c55-9a63-aca2452aac05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010712-7f42-4c55-9a63-aca2452aac05.jpg?1",
             "name": "Star Compass",
             "text": "Star Compass enters the battlefield tapped.\n{T}: Add to your mana pool one mana of any color that a basic land you control could produce.",
             "colours": [],
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "073f6484-d2f3-558e-8a44-824196d4963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508a8735-642c-4f22-bbd9-4a189d93e7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508a8735-642c-4f22-bbd9-4a189d93e7b7.jpg?1",
             "name": "Thran Dynamo",
             "text": "{T}: Add {C}{C}{C} to your mana pool.",
             "colours": [],
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "d9caf228-a9c7-5bb6-bd87-53f6bec9f853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1bab36-3fb7-48f3-b3ed-90863d244641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1bab36-3fb7-48f3-b3ed-90863d244641.jpg?1",
             "name": "Trepanation Blade",
             "text": "Whenever equipped creature attacks, defending player reveals cards from the top of his or her library until he or she reveals a land card. The creature gets +1/+0 until end of turn for each card revealed this way. That player puts the revealed cards into his or her graveyard.\nEquip {2}",
             "colours": [],
@@ -7748,7 +7748,7 @@
         },
         {
             "id": "55bf1e79-5055-5a35-9603-738e8dc164a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118fd026-3777-4ce4-bea9-6fdfa05e7110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118fd026-3777-4ce4-bea9-6fdfa05e7110.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -7779,7 +7779,7 @@
         },
         {
             "id": "2381da18-66df-5995-99db-bc0196db2d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a4cfa-e306-4024-8ece-8bf2c1d0cce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a4cfa-e306-4024-8ece-8bf2c1d0cce8.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -7810,7 +7810,7 @@
         },
         {
             "id": "3d72b1e7-ad39-5de7-b31a-4dbef5f6f1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01a793a-e6ad-4778-b87d-cc0bbdd5846f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01a793a-e6ad-4778-b87d-cc0bbdd5846f.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "da99f8e5-72f0-5d60-a127-b7ab9512ddb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a2804d-d925-4950-8542-608f6e92387a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a2804d-d925-4950-8542-608f6e92387a.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -7869,7 +7869,7 @@
         },
         {
             "id": "44c4c3e3-6c66-5077-8e90-261b3b9e09f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501425e3-31ae-4d19-997c-33ad89733969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501425e3-31ae-4d19-997c-33ad89733969.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "53aa25ac-7206-57a6-9a15-163527ed42b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9140b-3886-4f4d-82f1-76144c5501c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9140b-3886-4f4d-82f1-76144c5501c2.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {C} to your mana pool.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "63c7fabf-d6b9-57ab-be43-f6a9f85e962e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b75ad-7539-4184-a940-6014a0327b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b75ad-7539-4184-a940-6014a0327b3a.jpg?1",
             "name": "Grove of the Burnwillows",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Each opponent gains 1 life.",
             "colours": [],
@@ -7962,7 +7962,7 @@
         },
         {
             "id": "e6ab32e6-57f4-5407-8f0e-8f0e5928ecc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fcea4c-1fc4-4476-8b95-90134d7841e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fcea4c-1fc4-4476-8b95-90134d7841e7.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "21375a3d-db0f-58d7-8371-885d53373ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f7c880-9bae-4d29-b7b6-b6be6b2ffa89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f7c880-9bae-4d29-b7b6-b6be6b2ffa89.jpg?1",
             "name": "Horizon Canopy",
             "text": "{T}, Pay 1 life: Add {G} or {W} to your mana pool.\n{1}, {T}, Sacrifice Horizon Canopy: Draw a card.",
             "colours": [],
@@ -8024,7 +8024,7 @@
         },
         {
             "id": "2fda16ef-2d24-52f5-bae4-ce8ceb3fe3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a1f12-0c2e-4c72-839d-ae13bffa1ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a1f12-0c2e-4c72-839d-ae13bffa1ef0.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "327291af-ef7b-5987-a0fa-0e61ae59ba50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152c6a1-7c78-483e-b13f-cb43a6bd4001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152c6a1-7c78-483e-b13f-cb43a6bd4001.jpg?1",
             "name": "Nimbus Maze",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add {W} to your mana pool. Activate this ability only if you control an Island.\n{T}: Add {U} to your mana pool. Activate this ability only if you control a Plains.",
             "colours": [],
@@ -8086,7 +8086,7 @@
         },
         {
             "id": "2e44168c-03c3-5c01-85e3-091a1331aa26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd942b9a-1802-41bb-a33a-344bfa353c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd942b9a-1802-41bb-a33a-344bfa353c47.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "5994fd26-0c8f-5f52-970d-128b4376d0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff618efc-ebea-476e-9c88-0383a5272aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff618efc-ebea-476e-9c88-0383a5272aae.jpg?1",
             "name": "Radiant Fountain",
             "text": "When Radiant Fountain enters the battlefield, you gain 2 life.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "02a9dc8c-7634-585c-9fae-19e16823ea52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25665f-6af2-46c8-b5f9-88e1caa8395c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25665f-6af2-46c8-b5f9-88e1caa8395c.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -8176,7 +8176,7 @@
         },
         {
             "id": "5032e4e4-018e-5aa2-bbed-9b1f867957ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8de9ac4-e03f-4d08-b836-83f461159bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8de9ac4-e03f-4d08-b836-83f461159bd3.jpg?1",
             "name": "River of Tears",
             "text": "{T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.",
             "colours": [],
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "a7283339-3881-537e-8fcd-cae62c096afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636539f-67f1-4fcd-ab0b-70c4a20bbdc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636539f-67f1-4fcd-ab0b-70c4a20bbdc4.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "7cb00676-9128-5dc1-a8ac-bdb0b56d9c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f2594-c6e8-4758-86b4-885d1dba3a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f2594-c6e8-4758-86b4-885d1dba3a91.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8266,7 +8266,7 @@
         },
         {
             "id": "2156432f-72d3-5fc6-990d-032fab36af4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5101e712-2b4f-422b-ae80-6fd1a18c82ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5101e712-2b4f-422b-ae80-6fd1a18c82ec.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "f34494e6-8d2a-5361-a2c7-5c5a1ef80dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc88baf-217f-4b25-9945-75c33ae37dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc88baf-217f-4b25-9945-75c33ae37dc2.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "fd437463-78d9-5de9-812f-ec1bfd3ccebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1b1f2-f067-4c8a-b134-4567e4d5a7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1b1f2-f067-4c8a-b134-4567e4d5a7c6.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "aef0ca69-5e0e-5874-b13b-1b4c657a8c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcd7257-ca21-4847-802b-94e2957993c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcd7257-ca21-4847-802b-94e2957993c3.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "1d22fdd3-3211-52da-98ae-49971402c894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5e32a-b86b-4f8b-ae93-19f0b95c4514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5e32a-b86b-4f8b-ae93-19f0b95c4514.jpg?1",
             "name": "Djinn Monk",
             "text": "",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "cb3aa9a9-4404-53ec-b965-b4c26b82b625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83e8599-49e0-4a70-b8a8-883af4b1b7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83e8599-49e0-4a70-b8a8-883af4b1b7bc.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "75f1aaaf-4e2a-5338-91b8-21c4ac47076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a341b61-c945-4ea1-89a3-217a97f98ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a341b61-c945-4ea1-89a3-217a97f98ae3.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "19e07859-3b54-5489-adb5-0f318c486276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e02247-42ad-4bbc-9c89-0265c3ad85db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e02247-42ad-4bbc-9c89-0265c3ad85db.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/INV.json
+++ b/Assets/Resources/Sets/INV.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c4f9d9ad-7322-5398-82ed-dc66558cda8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b45d9-aba6-4c09-8605-037754ba7fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b45d9-aba6-4c09-8605-037754ba7fd4.jpg?1",
             "name": "Alabaster Leech",
             "text": "White spells you play cost o\nW more to play.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "c78b4058-dc49-57f4-9fbf-06812602f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6de688-685f-4389-be35-a472ada988e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6de688-685f-4389-be35-a472ada988e1.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "652edad7-0c26-5677-b2af-5b3c24eb9160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dce974-846f-4365-b0a5-851e38668e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dce974-846f-4365-b0a5-851e38668e7d.jpg?1",
             "name": "Ardent Soldier",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nAttacking doesn't cause Ardent Soldier to tap.\nIf you paid the kicker cost, Ardent Soldier comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "f9034461-a72c-5a84-8be1-c55c4e142631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90500e7a-f76d-453a-bda0-d56d3f7c7534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90500e7a-f76d-453a-bda0-d56d3f7c7534.jpg?1",
             "name": "Atalya, Samite Master",
             "text": "o\nX, oc\nT: Choose one Prevent the next X damage that would be dealt to target creature this turn; or you gain X life. Spend only white mana this way.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "d98108f4-a14a-516e-a240-9986c180204a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b82d56e-80d7-4be9-ac22-de3257efc458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b82d56e-80d7-4be9-ac22-de3257efc458.jpg?1",
             "name": "Benalish Emissary",
             "text": "Kicker o1o\nG (You may pay an additional o1o\nG as you play this spell.)\nWhen Benalish Emissary comes into play, if you paid the kicker cost, destroy target land.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "ddbd6700-07c1-5680-ae77-4837785adb3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6e51d-54eb-4e5b-9ec9-54521b16b8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6e51d-54eb-4e5b-9ec9-54521b16b8d1.jpg?1",
             "name": "Benalish Heralds",
             "text": "o3o\nU, oc\nT: Draw a card.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "3a1bcbc6-4c4f-59cd-8a88-036e891d766b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a38d40a-e745-4fee-b179-f8c27e9b2fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a38d40a-e745-4fee-b179-f8c27e9b2fbd.jpg?1",
             "name": "Benalish Lancer",
             "text": "Kicker o2o\nW (You may pay an additional o2o\nW as you play this spell.)\nIf you paid the kicker cost, Benalish Lancer comes into play with two +1/+1 counters on it and has first strike.",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "e714a71d-cbdf-55c8-941a-f9386e51d255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312653d-c3e1-4c79-90d2-0963419b618c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312653d-c3e1-4c79-90d2-0963419b618c.jpg?1",
             "name": "Benalish Trapper",
             "text": "o\nW, oc\nT: Tap target creature.",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "5bcc7ef8-791b-5d01-b42b-c9d8b16be1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882c1e15-b508-4885-9626-4c8d2598a006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882c1e15-b508-4885-9626-4c8d2598a006.jpg?1",
             "name": "Blinding Light",
             "text": "Tap all nonwhite creatures.",
             "colours": [
@@ -318,7 +318,7 @@
         },
         {
             "id": "9b0dfd1a-e602-5dc8-816a-42b98255337d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3e5741-88d7-4837-9b43-ba8304d9ee74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3e5741-88d7-4837-9b43-ba8304d9ee74.jpg?1",
             "name": "Capashen Unicorn",
             "text": "o1o\nW, oc\nT, Sacrifice Capashen Unicorn: Destroy target artifact or enchantment.",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "101301c0-f31b-5561-af3d-d0d4dd7d8478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1718028-3009-4bdd-9f6f-59c17edd1344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1718028-3009-4bdd-9f6f-59c17edd1344.jpg?1",
             "name": "Crimson Acolyte",
             "text": "Protection from red\noo\nW Target creature gains protection from red until end of turn.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "9010338f-40eb-5790-8660-cea74342b31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab4640-1871-41dd-bd21-64741e21ba37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab4640-1871-41dd-bd21-64741e21ba37.jpg?1",
             "name": "Crusading Knight",
             "text": "Protection from black\nCrusading Knight gets +1/+1 for each swamp your opponents control.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "98dec30c-156b-5b0d-bb98-1f200a835825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f967c9-b38d-489d-96cc-44a6b1804e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f967c9-b38d-489d-96cc-44a6b1804e10.jpg?1",
             "name": "Death or Glory",
             "text": "Separate all creature cards in your graveyard into two face-up piles. Remove the pile of an opponent's choice from the game and return the other to play.",
             "colours": [
@@ -454,7 +454,7 @@
         },
         {
             "id": "c92a66e5-d0f2-5bc6-a90e-feda6e23a29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39514d54-cb6c-4b3b-a3be-46db991be4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39514d54-cb6c-4b3b-a3be-46db991be4d4.jpg?1",
             "name": "Dismantling Blow",
             "text": "Kicker o2o\nU (You may pay an additional o2o\nU as you play this spell.)\nDestroy target artifact or enchantment.\nIf you paid the kicker cost, draw two cards.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "05455c12-377b-5678-bcef-4f6f52be22f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb898d-d6ce-410a-83bf-37962cca2735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb898d-d6ce-410a-83bf-37962cca2735.jpg?1",
             "name": "Divine Presence",
             "text": "If a source would deal 4 damage or more to a creature or player, that source deals 3 damage to that creature or player instead.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "b6c6b278-f759-5134-8edb-d0cd077781f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bde162-3737-4b93-a27a-63b909a4183d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bde162-3737-4b93-a27a-63b909a4183d.jpg?1",
             "name": "Fight or Flight",
             "text": "At the beginning of each opponent's combat phase, separate all creatures that player controls into two face-up piles. Only creatures in the pile of his or her choice may attack this turn.",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "57bf9439-dc0f-51de-9fef-f833c254aa62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f55e4-eded-4a86-87f4-b8fa6f30bc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f55e4-eded-4a86-87f4-b8fa6f30bc0f.jpg?1",
             "name": "Glimmering Angel",
             "text": "Flying\noo\nU Glimmering Angel can't be the target of spells or abilities this turn.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "90c0c53f-366a-590e-8dcd-166a1fdfd7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336474b4-2cf5-44c0-b72c-f75f1a7ed928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336474b4-2cf5-44c0-b72c-f75f1a7ed928.jpg?1",
             "name": "Global Ruin",
             "text": "Each player chooses from the lands he or she controls a land of each basic land type, then sacrifices the rest.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "a16975c9-b37b-5cbf-b1a2-b1797d86ca61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c78dee-ab45-4638-b89a-10686145b19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c78dee-ab45-4638-b89a-10686145b19a.jpg?1",
             "name": "Harsh Judgment",
             "text": "As Harsh Judgment comes into play, choose a color.\nIf an instant or sorcery of the chosen color would deal damage to you, it deals that damage to its controller instead.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "52ec468c-9f49-56d7-8dd5-a9af40c2e3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa91fd4e-4e1f-4cfa-b10f-456bd875238f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa91fd4e-4e1f-4cfa-b10f-456bd875238f.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "ab985f9a-81a8-54ba-a3f8-4a718ef88382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96794470-31ea-478f-b11c-dc8342a508e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96794470-31ea-478f-b11c-dc8342a508e2.jpg?1",
             "name": "Liberate",
             "text": "Remove target creature you control from the game. At end of turn, return that card to play under its owner's control.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "13f4b3d4-6c41-5f51-8ca0-1715d52a0209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868efcee-bb13-4b6f-b81b-99408685e4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868efcee-bb13-4b6f-b81b-99408685e4c4.jpg?1",
             "name": "Obsidian Acolyte",
             "text": "Protection from black\noo\nW Target creature gains protection from black until end of turn.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "2f95572e-c41e-5680-a10c-f52b5c6e6007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559f551e-7891-4c6d-8798-a25c0255fa3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559f551e-7891-4c6d-8798-a25c0255fa3b.jpg?1",
             "name": "Orim's Touch",
             "text": "Kicker o1 (You may pay an additional o1 as you play this spell.)\nPrevent the next 2 damage that would be dealt to target creature or player this turn. If you paid the kicker cost, prevent the next 4 damage that would be dealt to that creature or player this turn instead.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "78ec0235-7898-5eb5-a345-5cc5a4d3be81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f98c26-5b30-400c-8af1-8c6c43065f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f98c26-5b30-400c-8af1-8c6c43065f63.jpg?1",
             "name": "Pledge of Loyalty",
             "text": "Enchanted creature has protection from the colors of permanents you control. This effect doesn't remove Pledge of Loyalty.",
             "colours": [
@@ -815,7 +815,7 @@
         },
         {
             "id": "92aeb134-8a09-51d4-a13f-50bb91300cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c4800-8718-4593-a61e-03ad7f348c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c4800-8718-4593-a61e-03ad7f348c6d.jpg?1",
             "name": "Prison Barricade",
             "text": "(Walls can't attack.)\nKicker o1o\nW (You may pay an additional o1o\nW as you play this spell.)\nIf you paid the kicker cost, Prison Barricade comes into play with a +1/+1 counter on it and may attack as though it weren't a Wall.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "88e63265-7e94-5dc6-89d8-20ec010ab9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5ef13e-1cf0-42a9-95d0-30ade254d6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5ef13e-1cf0-42a9-95d0-30ade254d6a8.jpg?1",
             "name": "Protective Sphere",
             "text": "o1, Pay 1 life: Prevent all damage that would be dealt to you this turn by a source of your choice that shares a color with the mana spent on this activation cost. (Colorless mana prevents no damage.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "c6400cf0-5d96-50e4-9bba-c8aab1a6f994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbff85a6-a51b-424e-a86b-da52c9b3a9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbff85a6-a51b-424e-a86b-da52c9b3a9da.jpg?1",
             "name": "Pure Reflection",
             "text": "Whenever a player plays a creature spell, destroy all Reflections. Then that player puts a white Reflection creature token into play with power and toughness each equal to the converted mana cost of that spell.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "fce16d7e-67f0-56e7-a048-26c04393eb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752642d2-3dad-4f58-b154-beb5982141dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752642d2-3dad-4f58-b154-beb5982141dc.jpg?1",
             "name": "Rampant Elephant",
             "text": "oo\nG Target creature blocks Rampant Elephant this turn if able.",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "28260ce8-5b15-5083-acb4-715b2020466a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819e2046-9b78-4fd0-92f8-798bfac51195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819e2046-9b78-4fd0-92f8-798bfac51195.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "d02c249d-6963-564b-a0f9-286711fa934d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b5c765-619c-4db9-b509-91892fb65e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b5c765-619c-4db9-b509-91892fb65e8f.jpg?1",
             "name": "Restrain",
             "text": "Prevent all combat damage that would be dealt by target attacking creature this turn.\nDraw a card.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "69b5afab-ca82-514c-9dc2-2e7659d33f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d44dd88-ad20-4d89-8831-d2dfa6873428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d44dd88-ad20-4d89-8831-d2dfa6873428.jpg?1",
             "name": "Reviving Dose",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1046,7 +1046,7 @@
         },
         {
             "id": "e8900247-ace1-5709-aade-848ef64c15ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04116b38-8fb1-47c6-b68d-060d0fc4a60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04116b38-8fb1-47c6-b68d-060d0fc4a60d.jpg?1",
             "name": "Rewards of Diversity",
             "text": "Whenever an opponent plays a multicolored spell, you gain 4 life.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "d8c4ada2-c353-53b4-84e8-bb62085edbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e0e72b-e65e-4578-b610-9f529daa32d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e0e72b-e65e-4578-b610-9f529daa32d7.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "Flying\nAt the beginning of your upkeep, you may return target creature card from your graveyard to play.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "7439f91b-7327-5c33-86bd-02026015c4e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bc55ed-b89b-4e22-b3f1-4ce0f8d180d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bc55ed-b89b-4e22-b3f1-4ce0f8d180d7.jpg?1",
             "name": "Rout",
             "text": "You may play Rout any time you could play an instant if you pay o2 more to play it.\nDestroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "0f7e3e41-f801-555b-90ec-ea073dc89d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46c7718-1ecc-418c-b213-13be9de5cb7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46c7718-1ecc-418c-b213-13be9de5cb7f.jpg?1",
             "name": "Ruham Djinn",
             "text": "First strike\nRuham Djinn gets -2/-2 as long as white is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "267b8f06-47ed-571d-959b-cc58ffb3c0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1de62ed-79e6-4daf-a2ab-dc0726e1f7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1de62ed-79e6-4daf-a2ab-dc0726e1f7df.jpg?1",
             "name": "Samite Ministration",
             "text": "Prevent all damage that would be dealt by a source of your choice to you this turn. Whenever damage from a black or red source is prevented this way, you gain life equal to that damage.",
             "colours": [
@@ -1212,7 +1212,7 @@
         },
         {
             "id": "3631085b-00fd-5040-8f38-837904400dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3da05-9a3e-4827-96b8-5de244128db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3da05-9a3e-4827-96b8-5de244128db3.jpg?1",
             "name": "Shackles",
             "text": "Enchanted creature doesn't untap during its controller's untap step.\noo\nW Return Shackles to its owner's hand.",
             "colours": [
@@ -1246,7 +1246,7 @@
         },
         {
             "id": "e3054de8-11b8-5ae2-9485-afac9305143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb66439-df73-4a01-a8d4-6f2334297fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb66439-df73-4a01-a8d4-6f2334297fdf.jpg?1",
             "name": "Spirit of Resistance",
             "text": "If you control a permanent of each color, prevent all damage that would be dealt to you.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "68d2c03d-beb7-538b-9a26-afb55d189283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0ef47-cb22-4146-a17e-e49a6031a7e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0ef47-cb22-4146-a17e-e49a6031a7e6.jpg?1",
             "name": "Spirit Weaver",
             "text": "o2: Target green or blue creature gets +0/+1 until end of turn.",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "09fec7ae-64e3-5a0f-a08b-db8ad0f742cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d4ff8-af35-413f-9aa2-f4c6e34fade2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d4ff8-af35-413f-9aa2-f4c6e34fade2.jpg?1",
             "name": "Strength of Unity",
             "text": "Enchanted creature gets +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "8638b750-d5e1-5b24-81d6-e66ab2922a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d6bd19-77c9-4a1a-a2d5-6f9737693fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d6bd19-77c9-4a1a-a2d5-6f9737693fea.jpg?1",
             "name": "Sunscape Apprentice",
             "text": "o\nG, oc\nT: Target creature gets +1/+1 until end of turn.\no\nU, oc\nT: Put target creature you control on top of its owner's library.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "c9d8ba2b-c213-50cf-9635-05ba6b64c951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7203d-529d-45d2-8e03-cd342c153f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7203d-529d-45d2-8e03-cd342c153f38.jpg?1",
             "name": "Sunscape Master",
             "text": "o\nGo\nG, oc\nT: Creatures you control get +2/+2 until end of turn.\no\nUo\nU, oc\nT: Return target creature to its owner's hand.",
             "colours": [
@@ -1421,7 +1421,7 @@
         },
         {
             "id": "ae218dc9-951f-558c-9bc6-b1c0ce7d8b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b1cc1-4468-4bc5-85c0-c22dce131225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b1cc1-4468-4bc5-85c0-c22dce131225.jpg?1",
             "name": "Teferi's Care",
             "text": "o\nW, Sacrifice an enchantment: Destroy target enchantment.\no3o\nUoo\nU Counter target enchantment spell.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "b2f89ca8-96ed-5a09-b09d-0aafaec4a5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e45de5-0e8b-41d3-979b-ec5a29cac682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e45de5-0e8b-41d3-979b-ec5a29cac682.jpg?1",
             "name": "Wayfaring Giant",
             "text": "Wayfaring Giant gets +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "c577e4e2-3445-5cf0-9eaa-5bf966f3c015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61748dd-4010-47da-8717-ca0147877057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61748dd-4010-47da-8717-ca0147877057.jpg?1",
             "name": "Winnow",
             "text": "Destroy target nonland permanent if another permanent with the same name is in play.\nDraw a card.",
             "colours": [
@@ -1520,7 +1520,7 @@
         },
         {
             "id": "c1848238-5699-5783-8633-6c02a16071e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4cecb0-12b5-4678-b5e7-8cec8fc86cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4cecb0-12b5-4678-b5e7-8cec8fc86cef.jpg?1",
             "name": "Barrin's Unmaking",
             "text": "Return target permanent to its owner's hand if that permanent shares a color with the most common color among all permanents or the color tied for most common.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "f9959e9b-4401-5b8a-9862-01a8ab312422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c54ec26-c7f1-4258-9cc9-1709987f293c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c54ec26-c7f1-4258-9cc9-1709987f293c.jpg?1",
             "name": "Blind Seer",
             "text": "o1oo\nU Target spell or permanent becomes the color of your choice until end of turn.",
             "colours": [
@@ -1589,7 +1589,7 @@
         },
         {
             "id": "4b3db33c-9706-5235-91d3-9a36eceb9c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b39cd77-97aa-4099-8405-366f82079758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b39cd77-97aa-4099-8405-366f82079758.jpg?1",
             "name": "Breaking Wave",
             "text": "You may play Breaking Wave any time you could play an instant if you pay o2 more to play it.\nSimultaneously untap all tapped creatures and tap all untapped creatures.",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "0fca98b9-1743-5051-8d07-48807edf09ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71daa57-ac02-4dd9-8c90-d38bdd45fb51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71daa57-ac02-4dd9-8c90-d38bdd45fb51.jpg?1",
             "name": "Collective Restraint",
             "text": "Creatures can't attack you unless their controller pays o\nX for each creature attacking you, where X is the number of basic land types among lands you control. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -1653,7 +1653,7 @@
         },
         {
             "id": "a37dd042-4c96-5ba6-a37f-ea1c122adc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798a4f1-34bb-449d-a8cc-faf8bda8e0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798a4f1-34bb-449d-a8cc-faf8bda8e0ab.jpg?1",
             "name": "Crystal Spray",
             "text": "Change the text of target spell or permanent by replacing all instances of one color word or basic land type with another until end of turn.\nDraw a card.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "20e2d573-cd8f-5e54-86d5-61606bb53116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg?1",
             "name": "Disrupt",
             "text": "Counter target instant or sorcery spell unless its controller pays o1.\nDraw a card.",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "d3fc5bb8-6380-526e-a6f6-db1e043090e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf48eec9-96be-4f53-9d9a-c6f02d44c995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf48eec9-96be-4f53-9d9a-c6f02d44c995.jpg?1",
             "name": "Distorting Wake",
             "text": "Return X target nonland permanents to their owners' hands.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "11ab299d-6003-5b61-8dcf-6933af2e6448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258217df-ae88-4d93-895a-3fd242baacd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258217df-ae88-4d93-895a-3fd242baacd1.jpg?1",
             "name": "Dream Thrush",
             "text": "Flying\noc\nT: Target land becomes a land of the basic land type of your choice until end of turn.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "7eec70cb-3af0-5305-a751-d2fbd897b819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6851dbc7-f072-41e7-a899-897445d99425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6851dbc7-f072-41e7-a899-897445d99425.jpg?1",
             "name": "Empress Galina",
             "text": "o\nUo\nU, oc\nT: Gain control of target Legend or legendary permanent. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "23cbd9fe-fea5-50c2-b043-0335f10b06a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099b2e6-9ed8-4a9c-97ca-77cc47678228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099b2e6-9ed8-4a9c-97ca-77cc47678228.jpg?1",
             "name": "Essence Leak",
             "text": "If enchanted permanent is red or green, it has \"At the beginning of your upkeep, sacrifice this permanent unless you pay its mana cost.\"",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "46438b6d-1586-5c5c-be5e-2e5ae8abbac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb359c8-209c-455f-84b2-970e5678a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb359c8-209c-455f-84b2-970e5678a9fa.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "d2387533-6426-533f-879a-74cbd3d9d174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4d018-dcf3-4439-8445-02d66e44f7d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4d018-dcf3-4439-8445-02d66e44f7d3.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two face-up piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "9452fc71-7a11-5f01-8add-ede60a0ad95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c707c81-dbbd-43be-a79a-7bc92a584839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c707c81-dbbd-43be-a79a-7bc92a584839.jpg?1",
             "name": "Faerie Squadron",
             "text": "Kicker o3o\nU (You may pay an additional o3o\nU as you play this spell.)\nIf you paid the kicker cost, Faerie Squadron comes into play with two +1/+1 counters on it and has flying.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "3323b377-4f9c-55b1-b969-7e3a271344a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62cc17-8fa3-495c-a098-ffbbec89fa53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62cc17-8fa3-495c-a098-ffbbec89fa53.jpg?1",
             "name": "Mana Maze",
             "text": "Players can't play spells that share a color with the spell last played this turn.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "e27fb2a2-56d7-5f54-8a9d-22b6f13e6a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb52acb-dedb-4ed6-a6da-8c036f2b2958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb52acb-dedb-4ed6-a6da-8c036f2b2958.jpg?1",
             "name": "Manipulate Fate",
             "text": "Search your library for three cards, remove them from the game, then shuffle your library.\nDraw a card.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "d9378d7c-f5d1-53da-b5be-f080d46d319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f34850-fb6f-4ac5-8309-4d53d770e28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f34850-fb6f-4ac5-8309-4d53d770e28c.jpg?1",
             "name": "Metathran Aerostat",
             "text": "Flying\no\nXoo\nU You may put a creature card with converted mana cost X from your hand into play. If you do, return Metathran Aerostat to its owner's hand.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "34afe4f2-b5f2-5df2-84cb-78b6057ba6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa9048d-1599-44a5-b4b2-45382c5b238d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa9048d-1599-44a5-b4b2-45382c5b238d.jpg?1",
             "name": "Metathran Transport",
             "text": "Flying\nMetathran Transport can't be blocked by blue creatures.\noo\nU Target creature becomes blue until end of turn.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "2d2f4492-45b8-58bc-a1cf-1a977523ba67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6676a0f7-8213-4547-b2ac-b904cd418073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6676a0f7-8213-4547-b2ac-b904cd418073.jpg?1",
             "name": "Metathran Zombie",
             "text": "oo\nB Regenerate Metathran Zombie.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "c784eb6c-0b15-58cc-a9ae-ff19bc1167ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958262ec-8e52-40cf-a9fd-a60e42643e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958262ec-8e52-40cf-a9fd-a60e42643e15.jpg?1",
             "name": "Opt",
             "text": "Look at the top card of your library. You may put that card on the bottom of your library.\nDraw a card.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "0bcd790f-b0f1-5c5d-b331-a1986a6b62c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56a1bb-f52c-4c6b-a089-1f78600f3db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56a1bb-f52c-4c6b-a089-1f78600f3db0.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "As Phantasmal Terrain comes into play, choose a basic land type.\nEnchanted land is a land of the chosen type.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "f27cea1a-a22e-57c6-9f54-e59727fad31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a58d18-3d52-4178-86b2-7590d4164e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a58d18-3d52-4178-86b2-7590d4164e76.jpg?1",
             "name": "Probe",
             "text": "Kicker o1o\nB (You may pay an additional o1o\nB as you play this spell.)\nDraw three cards, then discard two cards from your hand.\nIf you paid the kicker cost, target player discards two cards from his or her hand.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "b412a4b2-be0e-5cb1-a4e6-98da53f51de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daa5458-2a97-40d0-b18d-2381a7a68ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daa5458-2a97-40d0-b18d-2381a7a68ee1.jpg?1",
             "name": "Prohibit",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nCounter target spell if its converted mana cost is 2 or less. If you paid the kicker cost, counter that spell if its converted mana cost is 4 or less instead.",
             "colours": [
@@ -2251,7 +2251,7 @@
         },
         {
             "id": "48291028-a206-5589-bd45-28220f3d2b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8758ca24-e613-43bf-be58-4cf557f82d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8758ca24-e613-43bf-be58-4cf557f82d0c.jpg?1",
             "name": "Psychic Battle",
             "text": "Whenever a player chooses one or more targets, each player reveals the top card of his or her library. The player who reveals the card with the highest converted mana cost may change the target or targets. If two or more cards are tied for highest cost, the target or targets remain unchanged.",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "91242a90-c914-5809-ba16-47cff6d34bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e622ad2-473f-489e-b4cf-bbdcc44d0cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e622ad2-473f-489e-b4cf-bbdcc44d0cde.jpg?1",
             "name": "Rainbow Crow",
             "text": "Flying\no1: Rainbow Crow becomes the color of your choice until end of turn.",
             "colours": [
@@ -2317,7 +2317,7 @@
         },
         {
             "id": "2e2bf688-9778-5c5f-b31d-87ceeb2533ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a04e9be-48be-440e-9825-cfffd4c2b1a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a04e9be-48be-440e-9825-cfffd4c2b1a4.jpg?1",
             "name": "Repulse",
             "text": "Return target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "baf3477b-0d60-59d1-9c99-21590de5fed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6763ffd-9d89-4f26-871a-be24fbdef38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6763ffd-9d89-4f26-871a-be24fbdef38d.jpg?1",
             "name": "Sapphire Leech",
             "text": "Flying\nBlue spells you play cost o\nU more to play.",
             "colours": [
@@ -2383,7 +2383,7 @@
         },
         {
             "id": "0dce6096-9bee-59df-aecc-977d0c34e344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9615a6c2-1732-4a04-9be1-cc0a8d39de3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9615a6c2-1732-4a04-9be1-cc0a8d39de3f.jpg?1",
             "name": "Shimmering Wings",
             "text": "Enchanted creature has flying.\noo\nU Return Shimmering Wings to its owner's hand.",
             "colours": [
@@ -2417,7 +2417,7 @@
         },
         {
             "id": "b02850ee-5f10-530b-837b-5151ddc9d737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895b3b8-2acc-4c9f-8341-f651c1255b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895b3b8-2acc-4c9f-8341-f651c1255b7c.jpg?1",
             "name": "Shoreline Raider",
             "text": "Protection from Kavu",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "c7850b1d-e6ba-5971-9d7c-5765526faba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04974146-42a8-4f10-b443-67bfeaa54d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04974146-42a8-4f10-b443-67bfeaa54d5d.jpg?1",
             "name": "Sky Weaver",
             "text": "o2: Target white or black creature gains flying until end of turn.",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "fe029ebb-be6e-580e-a0d7-d1dd715b98e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb42f39-9187-44e4-aa34-14ab31977199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb42f39-9187-44e4-aa34-14ab31977199.jpg?1",
             "name": "Stormscape Apprentice",
             "text": "o\nW, oc\nT: Tap target creature.\no\nB, oc\nT: Target player loses 1 life.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "81993508-51fb-519c-96a8-836311b1f026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b704165-4587-48f1-8830-c5a07ec666cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b704165-4587-48f1-8830-c5a07ec666cc.jpg?1",
             "name": "Stormscape Master",
             "text": "o\nWo\nW, oc\nT: Target creature gains protection from the color of your choice until end of turn.\no\nBo\nB, oc\nT: Target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "b0ecb4f9-7dd3-558b-a432-d595545636b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff65e386-9aec-4deb-a4ec-d9a97bd87645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff65e386-9aec-4deb-a4ec-d9a97bd87645.jpg?1",
             "name": "Sway of Illusion",
             "text": "Any number of target creatures become the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "4e47953d-ff4d-5f40-b575-3bdb0443e094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bb2df8-c559-4a34-83b0-d48fbc694cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bb2df8-c559-4a34-83b0-d48fbc694cc8.jpg?1",
             "name": "Teferi's Response",
             "text": "Counter target spell or ability an opponent controls that targets a land you control. If a permanent's ability is countered this way, destroy that permanent.\nDraw two cards.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "65020fc1-e766-5ab4-8e9d-e32cc1b2a68d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd0d14-8d26-403f-9405-d0dcdecd1a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd0d14-8d26-403f-9405-d0dcdecd1a49.jpg?1",
             "name": "Temporal Distortion",
             "text": "Whenever a creature or land becomes tapped, put an hourglass counter on it.\nPermanents with an hourglass counter on them don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, remove all hourglass counters from permanents that player controls.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "5f245587-25fa-5791-8d33-1094c62d5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72a3051-7f46-4b6b-b4fb-0f170d9687ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72a3051-7f46-4b6b-b4fb-0f170d9687ab.jpg?1",
             "name": "Tidal Visionary",
             "text": "oc\nT: Target creature becomes the color of your choice until end of turn.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "9f56b7d0-ea6a-536e-adee-5ea848f5a804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbc55e5-b84c-4449-a288-ec26cdd3997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbc55e5-b84c-4449-a288-ec26cdd3997c.jpg?1",
             "name": "Tolarian Emissary",
             "text": "Kicker o1o\nW (You may pay an additional o1o\nW as you play this spell.)\nFlying\nWhen Tolarian Emissary comes into play, if you paid the kicker cost, destroy target enchantment.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "6a484c98-c5e6-5b21-b1ed-d2080af6c757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef97b38-f7a5-4db7-9550-24aa1a1ebbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef97b38-f7a5-4db7-9550-24aa1a1ebbda.jpg?1",
             "name": "Tower Drake",
             "text": "Flying\noo\nW Tower Drake gets +0/+1 until end of turn.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "c3939f24-038b-5d90-94a2-81bab4c3ed75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f0f82-0542-40c9-9a48-73077941dbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f0f82-0542-40c9-9a48-73077941dbd1.jpg?1",
             "name": "Traveler's Cloak",
             "text": "As Traveler's Cloak comes into play, choose a land type.\nEnchanted creature has landwalk of the chosen type. (It's unblockable as long as defending player controls a land of that type.)\nWhen Traveler's Cloak comes into play, draw a card.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "9207ae01-6d06-521a-921d-d7abf21489f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721fd877-0a28-4002-8b47-058bac4ac44d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721fd877-0a28-4002-8b47-058bac4ac44d.jpg?1",
             "name": "Vodalian Hypnotist",
             "text": "o2o\nB, oc\nT: Target player discards a card from his or her hand. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "5ff22f54-5ad4-5855-900f-025f553d285e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0effa-a4b8-4166-a66a-90cf01c6ea0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0effa-a4b8-4166-a66a-90cf01c6ea0d.jpg?1",
             "name": "Vodalian Merchant",
             "text": "When Vodalian Merchant comes into play, draw a card, then discard a card from your hand.",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "b07d8231-4ff5-52be-ac3e-d6de6634845b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adcf6c-ab14-414c-a5cb-56feae048c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adcf6c-ab14-414c-a5cb-56feae048c84.jpg?1",
             "name": "Vodalian Serpent",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nVodalian Serpent can't attack unless defending player controls an island.\nIf you paid the kicker cost, Vodalian Serpent comes into play with four +1/+1 counters on it.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "60ffe39c-6325-5ac7-b4e5-fd0b2326b8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7719d043-5827-4479-825b-23d9e979ead7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7719d043-5827-4479-825b-23d9e979ead7.jpg?1",
             "name": "Wash Out",
             "text": "Return all permanents of the color of your choice to their owners' hands.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "5f2b3879-c962-5274-89a8-2f1da2b56a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c55eb8f-925a-42c1-9e48-d7f99cab3b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c55eb8f-925a-42c1-9e48-d7f99cab3b01.jpg?1",
             "name": "Well-Laid Plans",
             "text": "Prevent all damage that would be dealt to a creature by another creature if they share a color.",
             "colours": [
@@ -2964,7 +2964,7 @@
         },
         {
             "id": "db31e8c4-6791-5472-b9e5-ba7abfa21aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc66fbf-f411-4607-aece-7c35d9a07c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc66fbf-f411-4607-aece-7c35d9a07c80.jpg?1",
             "name": "Worldly Counsel",
             "text": "Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "5a04c60c-8cca-5f51-8738-fbe47761c8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a3c1d5-0ca8-443b-ae7a-66e0363e377b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a3c1d5-0ca8-443b-ae7a-66e0363e377b.jpg?1",
             "name": "Zanam Djinn",
             "text": "Flying\nZanam Djinn gets -2/-2 as long as blue is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -3030,7 +3030,7 @@
         },
         {
             "id": "3a4be75a-5d5d-5931-9b29-16c76ed5e892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afb9d0-affa-4599-bf29-729cfe64703b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afb9d0-affa-4599-bf29-729cfe64703b.jpg?1",
             "name": "Addle",
             "text": "Choose a color. Look at target player's hand and choose a card of that color from it. That player discards that card.",
             "colours": [
@@ -3062,7 +3062,7 @@
         },
         {
             "id": "febd181c-6159-555c-bd07-d3e20ea1b4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539ac5e1-4bad-4f70-abac-e70c406bebec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539ac5e1-4bad-4f70-abac-e70c406bebec.jpg?1",
             "name": "Agonizing Demise",
             "text": "Kicker o1o\nR (You may pay an additional o1o\nR as you play this spell.)\nDestroy target nonblack creature. It can't be regenerated. If you paid the kicker cost, Agonizing Demise deals damage equal to that creature's power to the creature's controller.",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "00e0694f-aced-5fe0-a555-caab009a87df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da0d4f3-9216-406c-8f3e-b9bb0a11dc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da0d4f3-9216-406c-8f3e-b9bb0a11dc75.jpg?1",
             "name": "Andradite Leech",
             "text": "Black spells you play cost o\nB more to play.\noo\nB Andradite Leech gets +1/+1 until end of turn.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "12fc2cac-1a35-5847-8f86-1249cf72894c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3bf039-ecf6-477e-997c-e32c55323c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3bf039-ecf6-477e-997c-e32c55323c01.jpg?1",
             "name": "Annihilate",
             "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "4debc721-34df-5532-9229-30518b62d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8962dc3b-24ca-4c3c-ba1d-933c29cf7b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8962dc3b-24ca-4c3c-ba1d-933c29cf7b73.jpg?1",
             "name": "Bog Initiate",
             "text": "o1: Add o\nB to your mana pool.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "c5d3abb5-6a9f-5f8b-86e2-631784477b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1095cdfe-8060-4a73-bacf-9f983152b486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1095cdfe-8060-4a73-bacf-9f983152b486.jpg?1",
             "name": "Cremate",
             "text": "Remove target card in a graveyard from the game.\nDraw a card.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "5772e08b-9e83-5a9d-94dd-1dc70fe05a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522ddc6f-ec13-4a70-8f4c-b3c846b102fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522ddc6f-ec13-4a70-8f4c-b3c846b102fd.jpg?1",
             "name": "Crypt Angel",
             "text": "Flying, protection from white\nWhen Crypt Angel comes into play, return target blue or red creature card from your graveyard to your hand.",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "6375b288-08f7-55be-afed-a0668942af0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb151ae8-9281-434d-ba8d-9ce34f0875eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb151ae8-9281-434d-ba8d-9ce34f0875eb.jpg?1",
             "name": "Cursed Flesh",
             "text": "Enchanted creature gets -1/-1 and can't be blocked except by artifact creatures and/or black creatures.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "6aa40c6f-5195-592e-aa90-2d21a65866e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7cba29-9472-4874-bd54-37edf70645b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7cba29-9472-4874-bd54-37edf70645b2.jpg?1",
             "name": "Defiling Tears",
             "text": "Until end of turn, target creature becomes black, gets +1/-1, and gains \"oo\nB Regenerate this creature.\"",
             "colours": [
@@ -3328,7 +3328,7 @@
         },
         {
             "id": "d029ca15-9518-52dc-9f6c-a097d84306fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42ac7e-4a27-488c-a2e7-338b18103b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42ac7e-4a27-488c-a2e7-338b18103b02.jpg?1",
             "name": "Desperate Research",
             "text": "Name a card other than a basic land. Then reveal the top seven cards of your library and put all of them with that name into your hand. Remove the rest from the game.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "c3b55f8a-cc3a-5532-8a7c-2dd08414d7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064f013f-e74f-419d-8d17-7748bd91885e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064f013f-e74f-419d-8d17-7748bd91885e.jpg?1",
             "name": "Devouring Strossus",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature.\nSacrifice a creature: Regenerate Devouring Strossus.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "24074ca4-9a25-56a8-b8b2-aa0c3a94575d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f63cd9-e82b-4cf8-b8ce-f0aa0157692b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f63cd9-e82b-4cf8-b8ce-f0aa0157692b.jpg?1",
             "name": "Do or Die",
             "text": "Separate all creatures target player controls into two face-up piles. Destroy all creatures in the pile of that player's choice. They can't be regenerated.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "63a6d7f8-7465-59a2-8177-744515409916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bfa3d5-0f0b-4684-9567-f1478da01df7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bfa3d5-0f0b-4684-9567-f1478da01df7.jpg?1",
             "name": "Dredge",
             "text": "Sacrifice a creature or land.\nDraw a card.",
             "colours": [
@@ -3459,7 +3459,7 @@
         },
         {
             "id": "a40b88a5-b9ef-5d71-8f69-09ed2ea69563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4a026-f44e-40e1-9942-a3d8448aca70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4a026-f44e-40e1-9942-a3d8448aca70.jpg?1",
             "name": "Duskwalker",
             "text": "Kicker o3o\nB (You may pay an additional o3o\nB as you play this spell.)\nIf you paid the kicker cost, Duskwalker comes into play with two +1/+1 counters on it and has \"Duskwalker can't be blocked except by artifact creatures and/or black creatures.\"",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "086e9217-ffc6-5b0e-87e7-750f8b81569a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee35d99-9a8a-421b-bf43-74446909d87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee35d99-9a8a-421b-bf43-74446909d87d.jpg?1",
             "name": "Exotic Curse",
             "text": "Enchanted creature gets -1/-1 for each basic land type among lands you control.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "59bd5992-531e-5e3d-822c-c36d215df867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155a2213-bf6e-4a54-924b-e450b7d06f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155a2213-bf6e-4a54-924b-e450b7d06f26.jpg?1",
             "name": "Firescreamer",
             "text": "oo\nR Firescreamer gets +1/+0 until end of turn.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "1aa34a3e-e415-5354-9182-986cdcfc26ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67796c7-4d93-4c50-8839-bb69e075bc42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67796c7-4d93-4c50-8839-bb69e075bc42.jpg?1",
             "name": "Goham Djinn",
             "text": "o1oo\nB Regenerate Goham Djinn.\nGoham Djinn gets -2/-2 as long as black is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "b90e7b0f-92a7-53ab-9604-859383a284ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8328e131-b44d-4dd0-9ce4-454c6afe6fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8328e131-b44d-4dd0-9ce4-454c6afe6fa6.jpg?1",
             "name": "Hate Weaver",
             "text": "o2: Target blue or red creature gets +1/+0 until end of turn.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "413e11a5-35a1-51c7-928b-219b4453a094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7502ea2-7555-449e-baee-6ecef5573a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7502ea2-7555-449e-baee-6ecef5573a3b.jpg?1",
             "name": "Hypnotic Cloud",
             "text": "Kicker o4 (You may pay an additional o4 as you play this spell.)\nTarget player discards a card from his or her hand. If you paid the kicker cost, that player discards three cards from his or her hand instead.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "c0a47623-83c5-5d0e-8923-7346780ec650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2a7de-c67e-4541-be8c-e5ef7b64d94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2a7de-c67e-4541-be8c-e5ef7b64d94a.jpg?1",
             "name": "Marauding Knight",
             "text": "Protection from white\nMarauding Knight gets +1/+1 for each plains your opponents control.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "34eddaca-b90b-5604-b36e-678f4433833e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4649d881-709f-4ed0-91de-744d232a82f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4649d881-709f-4ed0-91de-744d232a82f5.jpg?1",
             "name": "Mourning",
             "text": "Enchanted creature gets -2/-0.\noo\nB Return Mourning to its owner's hand.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "bcbda174-b210-5a8b-97ee-673832a98758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7498ca4c-614a-4776-8886-0a6ed58520f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7498ca4c-614a-4776-8886-0a6ed58520f6.jpg?1",
             "name": "Nightscape Apprentice",
             "text": "o\nU, oc\nT: Put target creature you control on top of its owner's library.\no\nR, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "70ef2dac-1e75-5411-8a05-9ea40197a1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86174b8-dd9e-4ece-bc23-4f9ac50bccd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86174b8-dd9e-4ece-bc23-4f9ac50bccd3.jpg?1",
             "name": "Nightscape Master",
             "text": "o\nUo\nU, oc\nT: Return target creature to its owner's hand.\no\nRo\nR, oc\nT: Nightscape Master deals 2 damage to target creature.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "33befc85-e9ca-562d-a982-393369fa53d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da27c489-c541-4b0d-a844-71aa65e55ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da27c489-c541-4b0d-a844-71aa65e55ceb.jpg?1",
             "name": "Phyrexian Battleflies",
             "text": "Flying\noo\nB Phyrexian Battleflies gets +1/+0 until end of turn. This ability may be played no more than twice each turn.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "daefd3ce-d1c6-5e15-8466-54738e480927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d87a5-7b67-4ec5-b5e2-518d67123118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d87a5-7b67-4ec5-b5e2-518d67123118.jpg?1",
             "name": "Phyrexian Delver",
             "text": "When Phyrexian Delver comes into play, return target creature card from your graveyard to play. You lose life equal to that card's converted mana cost.",
             "colours": [
@@ -3878,7 +3878,7 @@
         },
         {
             "id": "50ae50a1-054d-5636-a92b-ad4d0a7d6282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224b8254-553d-4d88-8163-1f15e1244bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224b8254-553d-4d88-8163-1f15e1244bd2.jpg?1",
             "name": "Phyrexian Infiltrator",
             "text": "o2o\nUoo\nU Exchange control of Phyrexian Infiltrator and target creature.",
             "colours": [
@@ -3914,7 +3914,7 @@
         },
         {
             "id": "47a6a551-927f-5487-9129-9f10568c8691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd498b-1081-43fe-8193-518337a5a3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd498b-1081-43fe-8193-518337a5a3ea.jpg?1",
             "name": "Phyrexian Reaper",
             "text": "Whenever Phyrexian Reaper becomes blocked by a green creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "fa178034-087c-5cc7-aff5-adbd6cf47dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa8c604-343f-4c94-ac25-439ab1845c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa8c604-343f-4c94-ac25-439ab1845c19.jpg?1",
             "name": "Phyrexian Slayer",
             "text": "Flying\nWhenever Phyrexian Slayer becomes blocked by a white creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "371b6df9-312e-5118-99a9-4f3e2ce4ab9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8845e6bd-40ee-45ca-a099-53f19ff20a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8845e6bd-40ee-45ca-a099-53f19ff20a8a.jpg?1",
             "name": "Plague Spitter",
             "text": "At the beginning of your upkeep, Plague Spitter deals 1 damage to each creature and each player.\nWhen Plague Spitter is put into a graveyard from play, Plague Spitter deals 1 damage to each creature and each player.",
             "colours": [
@@ -4019,7 +4019,7 @@
         },
         {
             "id": "6c53c7fc-9f2a-5d4a-baf2-856e3adfa497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e29069-add5-4099-b800-9f1e4402cc1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e29069-add5-4099-b800-9f1e4402cc1a.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card from his or her hand.",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "4d154391-beba-50ab-be1d-37c2f5cdf496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2412497b-cae5-444d-9beb-7761d15cd5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2412497b-cae5-444d-9beb-7761d15cd5c5.jpg?1",
             "name": "Reckless Spite",
             "text": "Destroy two target nonblack creatures. You lose 5 life.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "50d9ba15-b5de-5e05-9ca4-3e9e113aa5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e695b-24e1-4c65-81e0-1624bda646e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e695b-24e1-4c65-81e0-1624bda646e7.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "0d2e327e-a1ea-5ace-95b4-360906b1f7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8072a9-2699-4c6c-9556-67d91bd67a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8072a9-2699-4c6c-9556-67d91bd67a4b.jpg?1",
             "name": "Scavenged Weaponry",
             "text": "When Scavenged Weaponry comes into play, draw a card.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "495da4d1-1fae-5329-9221-5f16b03768c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70515cd2-97d5-4491-a758-bc7188fdc6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70515cd2-97d5-4491-a758-bc7188fdc6dc.jpg?1",
             "name": "Soul Burn",
             "text": "Spend only black and/or red mana on X.\nSoul Burn deals X damage to target creature or player. You gain life equal to the damage dealt, but not more than the amount of o\nB spent on X, the player's life total before Soul Burn dealt damage, or the creature's toughness.",
             "colours": [
@@ -4185,7 +4185,7 @@
         },
         {
             "id": "f01277b4-7a9c-59d3-bcbd-40578c7cbee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb3278a-1a23-4e0a-b541-0c37b2bc3f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb3278a-1a23-4e0a-b541-0c37b2bc3f3c.jpg?1",
             "name": "Soul Burn",
             "text": "",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "0cf600b3-347b-5482-8737-2c5f8dc6f3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86055d-ce08-4b05-a92c-45e007ca0ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86055d-ce08-4b05-a92c-45e007ca0ba4.jpg?1",
             "name": "Spreading Plague",
             "text": "Whenever a creature comes into play, destroy all other creatures that share a color with it. They can't be regenerated.",
             "colours": [
@@ -4251,7 +4251,7 @@
         },
         {
             "id": "3368c5dd-74ac-521e-81a9-489a725b0aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec00a1-7e12-42d2-8f46-de8ab7323c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec00a1-7e12-42d2-8f46-de8ab7323c2c.jpg?1",
             "name": "Tainted Well",
             "text": "When Tainted Well comes into play, draw a card.\nEnchanted land is a swamp.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "7c6ec3ea-63df-58d1-b1d5-ba21825adbc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b076f85-d1bf-491a-af9d-f35b8e1bd163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b076f85-d1bf-491a-af9d-f35b8e1bd163.jpg?1",
             "name": "Trench Wurm",
             "text": "o2o\nR, oc\nT: Destroy target nonbasic land.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "e7b418f9-50c6-554e-8f5e-5d1f074c283d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0047302d-4e3d-4327-9bb2-ecd5b00b00e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0047302d-4e3d-4327-9bb2-ecd5b00b00e3.jpg?1",
             "name": "Tsabo's Assassin",
             "text": "oc\nT: Destroy target creature if it shares a color with the most common color among all permanents or the color tied for most common. A creature destroyed this way can't be regenerated.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "441b0f88-3545-596e-b0a2-ba853174e42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1a0ebd-1add-49e6-b5e6-5b26abb1de88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1a0ebd-1add-49e6-b5e6-5b26abb1de88.jpg?1",
             "name": "Tsabo's Decree",
             "text": "Choose a creature type. Target player reveals his or her hand and discards all creature cards of that type from it. Then destroy all creatures of that type that player controls. They can't be regenerated.",
             "colours": [
@@ -4388,7 +4388,7 @@
         },
         {
             "id": "1bedc034-0609-51db-b7f6-7e99f83648a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c97c8a5-33b3-4f7f-a224-bb4df7b4bcc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c97c8a5-33b3-4f7f-a224-bb4df7b4bcc0.jpg?1",
             "name": "Twilight's Call",
             "text": "You may play Twilight's Call any time you could play an instant if you pay o2 more to play it.\nEach player returns all creature cards from his or her graveyard to play.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "5c6d92e9-5a7d-52e7-b4b0-981ad1d5b6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6912c71-1836-4e87-9a65-d577d903d03c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6912c71-1836-4e87-9a65-d577d903d03c.jpg?1",
             "name": "Urborg Emissary",
             "text": "Kicker o1o\nU (You may pay an additional o1o\nU as you play this spell.)\nWhen Urborg Emissary comes into play, if you paid the kicker cost, return target permanent to its owner's hand.",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "fcd81b2d-6156-5272-a894-ea63dffb17e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397355b9-5b67-4973-972e-3505c500d116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397355b9-5b67-4973-972e-3505c500d116.jpg?1",
             "name": "Urborg Phantom",
             "text": "Urborg Phantom can't block.\noo\nU Prevent all combat damage that would be dealt to and dealt by Urborg Phantom this turn.",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "df120759-82cf-59ba-aa5d-05f8f1af1a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaedd5c8-03c6-4bbb-bf83-632551830bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaedd5c8-03c6-4bbb-bf83-632551830bd4.jpg?1",
             "name": "Urborg Shambler",
             "text": "All other black creatures get -1/-1.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "b5bd9208-d7ff-54ad-8a3b-073e367566da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e522a62-fbca-4362-9006-d4356c525704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e522a62-fbca-4362-9006-d4356c525704.jpg?1",
             "name": "Urborg Skeleton",
             "text": "Kicker o3 (You may pay an additional o3 as you play this spell.)\noo\nB Regenerate Urborg Skeleton.\nIf you paid the kicker cost, Urborg Skeleton comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -4562,7 +4562,7 @@
         },
         {
             "id": "95764259-fc5d-550d-9d1b-d59c89ccbb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819c2f5-29a2-46d2-af36-c22b64338807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819c2f5-29a2-46d2-af36-c22b64338807.jpg?1",
             "name": "Urborg Skeleton",
             "text": "",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "07058277-1671-5b3d-a742-70ff6d8ad094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7ea7f-4f17-4f78-b68e-693e265ca829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7ea7f-4f17-4f78-b68e-693e265ca829.jpg?1",
             "name": "Yawgmoth's Agenda",
             "text": "Play no more than one spell each turn.\nYou may play cards in your graveyard as though they were in your hand.\nIf a card would be put into your graveyard from anywhere, remove it from the game instead.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "2af472c9-a63d-56f0-87c9-234be3c1a1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ccb5d0-735b-443f-addd-8b70f5f2c60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ccb5d0-735b-443f-addd-8b70f5f2c60d.jpg?1",
             "name": "Ancient Kavu",
             "text": "o2: Ancient Kavu becomes colorless until end of turn.",
             "colours": [
@@ -4664,7 +4664,7 @@
         },
         {
             "id": "05f2aa8e-dab5-5fd3-9182-3326d81e2410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76b6660-d4b2-44de-a1a7-8d00811f90f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76b6660-d4b2-44de-a1a7-8d00811f90f6.jpg?1",
             "name": "Bend or Break",
             "text": "Each player separates all land cards he or she controls into two face-up piles. For each player, an opponent chooses a pile. Destroy all lands in that pile. Tap all lands in the other pile.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "3548f788-f5ea-5ee5-abc5-6044c22c7aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bb7e3-df03-454d-ada0-592ef8a4a6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bb7e3-df03-454d-ada0-592ef8a4a6f0.jpg?1",
             "name": "Breath of Darigaaz",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nBreath of Darigaaz deals 1 damage to each creature without flying and each player. If you paid the kicker cost, Breath of Darigaaz deals 4 damage to each creature without flying and each player instead.",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "5bf770dc-1c03-57b4-b5e8-364a4532d617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330028c4-8e91-4fe3-a87d-1660dfd2507e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330028c4-8e91-4fe3-a87d-1660dfd2507e.jpg?1",
             "name": "Callous Giant",
             "text": "If a source would deal 3 damage or less to Callous Giant, prevent that damage.",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "30d298c6-17fb-56a9-b203-58969406e57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df8e4-6947-4bbb-9fe7-52ca4fd95d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df8e4-6947-4bbb-9fe7-52ca4fd95d65.jpg?1",
             "name": "Chaotic Strike",
             "text": "Play Chaotic Strike only during combat after blockers are declared.\nChoose target creature and flip a coin. If you win the flip, that creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "b5541427-f489-5e6b-b472-1ad6c7ea3b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc019633-788e-4095-9610-6c0a432f7656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc019633-788e-4095-9610-6c0a432f7656.jpg?1",
             "name": "Collapsing Borders",
             "text": "At the beginning of each player's upkeep, that player gains 1 life for each basic land type among lands he or she controls. Then Collapsing Borders deals 3 damage to him or her.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "10f10731-d750-564b-94d4-4b09e3f30b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46239c-3de7-48ca-8f5c-b51f307fd0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46239c-3de7-48ca-8f5c-b51f307fd0e5.jpg?1",
             "name": "Crown of Flames",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.\noo\nR Return Crown of Flames to its owner's hand.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "052552e9-576d-50c5-ba7c-08469a393ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee05211e-cf08-4dea-9740-ed06f8682153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee05211e-cf08-4dea-9740-ed06f8682153.jpg?1",
             "name": "Firebrand Ranger",
             "text": "o\nG, oc\nT: Put a basic land card from your hand into play.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "72747668-04db-5143-b04d-7dfa74c833e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78827acd-a526-411b-bd22-ab9b538c75dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78827acd-a526-411b-bd22-ab9b538c75dd.jpg?1",
             "name": "Ghitu Fire",
             "text": "You may play Ghitu Fire any time you could play an instant if you pay o2 more to play it.\nGhitu Fire deals X damage to target creature or player.",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "d57cb13d-5b4f-517b-a1b3-7bb70ce09bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a89a099-8805-4b26-babd-5d9f48ee406a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a89a099-8805-4b26-babd-5d9f48ee406a.jpg?1",
             "name": "Goblin Spy",
             "text": "Play with the top card of your library revealed.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "12d4842b-e7d2-5e3e-b996-9f3590605aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369ade1f-e909-47ae-bb01-19588269ad8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369ade1f-e909-47ae-bb01-19588269ad8f.jpg?1",
             "name": "Halam Djinn",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nHalam Djinn gets -2/-2 as long as red is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "066f6e7d-3078-5343-a6bd-7f94dc90be28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5464b80a-22fe-42c7-a839-31667712fb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5464b80a-22fe-42c7-a839-31667712fb2d.jpg?1",
             "name": "Hooded Kavu",
             "text": "oo\nB Hooded Kavu can't be blocked this turn except by artifact creatures and/or black creatures.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "6a195f11-4888-57ba-bf9a-d33597ba2a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2832ad3-ce7f-44d2-beb2-c95d982905a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2832ad3-ce7f-44d2-beb2-c95d982905a6.jpg?1",
             "name": "Kavu Aggressor",
             "text": "Kicker o4 (You may pay an additional o4 as you play this spell.)\nKavu Aggressor can't block.\nIf you paid the kicker cost, Kavu Aggressor comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "04b5c40e-0fef-5237-847c-89d5ba750c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea63dfd5-d8d7-45b8-8219-1cc2b3de5666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea63dfd5-d8d7-45b8-8219-1cc2b3de5666.jpg?1",
             "name": "Kavu Monarch",
             "text": "All Kavu have trample.\nWhenever another Kavu comes into play, put a +1/+1 counter on Kavu Monarch.",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "9471d778-a436-5441-abde-f54fd72c92c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b462-4e3c-47cc-87c5-f6e29dd70c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b462-4e3c-47cc-87c5-f6e29dd70c01.jpg?1",
             "name": "Kavu Runner",
             "text": "Kavu Runner has haste as long as no opponent controls a white or blue creature. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "7b71ff13-8242-53b0-a703-0c0c45010065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc2670d-a3f4-47c2-b424-01fd379ff186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc2670d-a3f4-47c2-b424-01fd379ff186.jpg?1",
             "name": "Kavu Scout",
             "text": "Kavu Scout gets +1/+0 for each basic land type among lands you control.",
             "colours": [
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "cd16094c-e503-5b06-ac2a-26ed7e2ea9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d05157-d154-4203-bf3e-add110cb1cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d05157-d154-4203-bf3e-add110cb1cee.jpg?1",
             "name": "Lightning Dart",
             "text": "Lightning Dart deals 1 damage to target creature. If that creature is white or blue, Lightning Dart deals 4 damage to it instead.",
             "colours": [
@@ -5202,7 +5202,7 @@
         },
         {
             "id": "117fc415-2a6f-5ca9-9ee2-adf325dce4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5f738-04d0-44c9-88ec-28469b668040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5f738-04d0-44c9-88ec-28469b668040.jpg?1",
             "name": "Loafing Giant",
             "text": "Whenever Loafing Giant attacks or blocks, put the top card of your library into your graveyard. If that card is a land card, prevent all combat damage that Loafing Giant would deal this turn.",
             "colours": [
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "ac7b6979-01ca-543d-b448-9d430ff02e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516861c-68d9-4d02-a343-689dba0526c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516861c-68d9-4d02-a343-689dba0526c6.jpg?1",
             "name": "Mages' Contest",
             "text": "You and target spell's controller bid life. You start the bidding with a high bid of 1. In turn order, each player may top the high bid. The bidding ends when the high bid stands. The highest bidder loses life equal to the high bid. If you win the bidding, counter that spell.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "9cc446d6-4469-545a-bd5d-75314cd835fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d17886c-fffd-4f0d-b4da-4b5fba18b811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d17886c-fffd-4f0d-b4da-4b5fba18b811.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -5302,7 +5302,7 @@
         },
         {
             "id": "6ffb5a5d-2ade-5d29-865d-83ef12aa8baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabde40-2143-4677-b7b4-ea8fbf9b1f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabde40-2143-4677-b7b4-ea8fbf9b1f25.jpg?1",
             "name": "Obliterate",
             "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "288f0d14-483b-5029-94b0-35b6afe34d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91fca91-7296-422e-b251-d571b710ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91fca91-7296-422e-b251-d571b710ff71.jpg?1",
             "name": "Overload",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nDestroy target artifact if its converted mana cost is 2 or less. If you paid the kicker cost, destroy that artifact if its converted mana cost is 5 or less instead.",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "201720cd-1495-5769-bbf0-f3ce7a3616c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e2e49-7bde-43c1-8caf-43d237dfc052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e2e49-7bde-43c1-8caf-43d237dfc052.jpg?1",
             "name": "Pouncing Kavu",
             "text": "Kicker o2o\nR (You may pay an additional o2o\nR as you play this spell.)\nFirst strike\nIf you paid the kicker cost, Pouncing Kavu comes into play with two +1/+1 counters on it and has haste. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "c5079439-b847-5a42-954c-dcee2b4dab9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a654295d-b63c-4025-bf36-899023a8ba1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a654295d-b63c-4025-bf36-899023a8ba1d.jpg?1",
             "name": "Rage Weaver",
             "text": "o2: Target black or green creature gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "1cf11188-4623-588b-812d-2a180feb7c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e1a445-129d-4bb9-a8b0-3f55e3e0bc58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e1a445-129d-4bb9-a8b0-3f55e3e0bc58.jpg?1",
             "name": "Rogue Kavu",
             "text": "Whenever Rogue Kavu attacks alone, it gets +2/+0 until end of turn.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "32df9034-78e2-51b2-a79a-71b8088b43f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be621b12-4f4e-43a6-b65e-da4223e742b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be621b12-4f4e-43a6-b65e-da4223e742b5.jpg?1",
             "name": "Ruby Leech",
             "text": "First strike\nRed spells you play cost o\nR more to play.",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "066a6c8e-8fb1-5f20-a9da-0c3011cf0a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356744f3-e444-4f4e-bf00-80bb6b2ef76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356744f3-e444-4f4e-bf00-80bb6b2ef76f.jpg?1",
             "name": "Savage Offensive",
             "text": "Kicker o\nG (You may pay an additional o\nG as you play this spell.)\nCreatures you control gain first strike until end of turn. If you paid the kicker cost, they get +1/+1 until end of turn.",
             "colours": [
@@ -5536,7 +5536,7 @@
         },
         {
             "id": "74640888-5937-5b0e-ae9a-b3702afcd1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067ff95e-c4dc-41bb-9677-67f51a09b05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067ff95e-c4dc-41bb-9677-67f51a09b05a.jpg?1",
             "name": "Scarred Puma",
             "text": "Scarred Puma can't attack unless a black or green creature also attacks.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "3f245e3d-b773-52e3-9910-4247079ae02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a85437f-052e-494c-a9ee-265c4624a409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a85437f-052e-494c-a9ee-265c4624a409.jpg?1",
             "name": "Scorching Lava",
             "text": "Kicker o\nR (You may pay an additional o\nR as you play this spell.)\nScorching Lava deals 2 damage to target creature or player. If you paid the kicker cost, that creature can't be regenerated this turn and if it would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "0608aeee-6efb-52de-b018-a38551928568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f66ff2d-f2d2-4a6b-bf26-b510de60c0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f66ff2d-f2d2-4a6b-bf26-b510de60c0b6.jpg?1",
             "name": "Searing Rays",
             "text": "Choose a color. Searing Rays deals damage to each player equal to the number of creatures of that color that player controls.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "89a20b6d-961d-5b0b-a8c2-7f0513a50dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c596e-492e-4cf5-857c-4ddbbdd78485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c596e-492e-4cf5-857c-4ddbbdd78485.jpg?1",
             "name": "Shivan Emissary",
             "text": "Kicker o1o\nB (You may pay an additional o1o\nB as you play this spell.)\nWhen Shivan Emissary comes into play, if you paid the kicker cost, destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "75267792-5843-5ec4-a0e8-6160aae00b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dbd765-d7ea-4181-bd22-5c749ad081af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dbd765-d7ea-4181-bd22-5c749ad081af.jpg?1",
             "name": "Shivan Harvest",
             "text": "o1o\nR, Sacrifice a creature: Destroy target nonbasic land.",
             "colours": [
@@ -5702,7 +5702,7 @@
         },
         {
             "id": "f1d08a87-9980-573a-814a-e46bb5fbffb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be806378-50a7-4416-9d99-1ea2c1f2b7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be806378-50a7-4416-9d99-1ea2c1f2b7cb.jpg?1",
             "name": "Skittish Kavu",
             "text": "Skittish Kavu gets +1/+1 as long as no opponent controls a white or blue creature.",
             "colours": [
@@ -5736,7 +5736,7 @@
         },
         {
             "id": "8f32584c-1bd4-5cfb-8893-864d7e9e42c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7732bc-e168-44d9-923a-db7e985bd6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7732bc-e168-44d9-923a-db7e985bd6db.jpg?1",
             "name": "Skizzik",
             "text": "Kicker o\nR (You may pay an additional o\nR as you play this spell.)\nTrample; haste (This creature may attack and oc\nT the turn it comes under your control.)\nAt end of turn, sacrifice Skizzik unless the kicker cost was paid.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "7c2e88d5-72d9-50af-8553-c9cef160bb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e82044d-88cd-4ee4-8ec9-e71a0a85ed46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e82044d-88cd-4ee4-8ec9-e71a0a85ed46.jpg?1",
             "name": "Slimy Kavu",
             "text": "oc\nT: Target land becomes a swamp until end of turn.",
             "colours": [
@@ -5804,7 +5804,7 @@
         },
         {
             "id": "1a00b769-32a5-5ed9-b39e-0948a00a69e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c34970-a106-490c-ac37-6156eb7f34ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c34970-a106-490c-ac37-6156eb7f34ce.jpg?1",
             "name": "Stand or Fall",
             "text": "At the beginning of your combat phase, separate all creatures defending player controls into two face-up piles. Only creatures in the pile of that player's choice may block this turn.",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "a07ddef0-5661-5d4c-b41c-0aadda87006b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22f3ae8-a40b-4dab-abf4-3ab7b05191f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22f3ae8-a40b-4dab-abf4-3ab7b05191f7.jpg?1",
             "name": "Stun",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -5868,7 +5868,7 @@
         },
         {
             "id": "40d0b1e1-b623-596c-8242-2e2500729d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0476cc6b-ecc6-44d6-9f44-a90d4ee85daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0476cc6b-ecc6-44d6-9f44-a90d4ee85daa.jpg?1",
             "name": "Tectonic Instability",
             "text": "Whenever a land comes into play, tap all lands its controller controls.",
             "colours": [
@@ -5900,7 +5900,7 @@
         },
         {
             "id": "b3f43efb-56eb-5cb7-bd8e-ae2f68041b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a0b075-5414-48d3-a2b1-47dc20213e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a0b075-5414-48d3-a2b1-47dc20213e96.jpg?1",
             "name": "Thunderscape Apprentice",
             "text": "o\nB, oc\nT: Target player loses 1 life.\no\nG, oc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -5937,7 +5937,7 @@
         },
         {
             "id": "1be1d3bf-0b18-525d-bf3e-bf3e68b8be38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22abdc2f-bdc8-46c4-8ce2-f06befedbc32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22abdc2f-bdc8-46c4-8ce2-f06befedbc32.jpg?1",
             "name": "Thunderscape Master",
             "text": "o\nBo\nB, oc\nT: Target player loses 2 life and you gain 2 life.\no\nGo\nG, oc\nT: Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "44172f98-4dc7-5202-b576-164297e0d495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32531e-c759-4603-abd0-1724e8df70db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32531e-c759-4603-abd0-1724e8df70db.jpg?1",
             "name": "Tribal Flames",
             "text": "Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -6006,7 +6006,7 @@
         },
         {
             "id": "cbe9edd6-bde9-5d9e-8a9b-971fd00b7835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91392e9f-f96a-4ac5-b1f1-c73540cf249e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91392e9f-f96a-4ac5-b1f1-c73540cf249e.jpg?1",
             "name": "Turf Wound",
             "text": "Target player can't play land cards this turn.\nDraw a card.",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "9815060f-b2f5-55c7-8852-532c73fc9632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25a35-3ae4-471e-adcd-d8baf2f77b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25a35-3ae4-471e-adcd-d8baf2f77b68.jpg?1",
             "name": "Urza's Rage",
             "text": "Kicker o8o\nR (You may pay an additional o8o\nR as you play this spell.)\nUrza's Rage can't be countered by spells or abilities.\nUrza's Rage deals 3 damage to target creature or player. If you paid the kicker cost, instead Urza's Rage deals 10 damage to that creature or player and the damage can't be prevented.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "04a50982-107e-5b6b-9cc2-a77c3b103ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a94aeb4-349c-4394-848d-c1c9133856e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a94aeb4-349c-4394-848d-c1c9133856e2.jpg?1",
             "name": "Viashino Grappler",
             "text": "oo\nG Viashino Grappler gains trample until end of turn.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "d46f9ede-4479-5fda-b775-ebc32ebf7f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7502ce01-b762-40fe-a064-c7b20b08a722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7502ce01-b762-40fe-a064-c7b20b08a722.jpg?1",
             "name": "Zap",
             "text": "Zap deals 1 damage to target creature or player.\nDraw a card.",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "0153d3a5-b120-509b-8d6b-3cbe0d6c880f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e3154d-9b1c-4f93-9bc3-a39e68d59d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e3154d-9b1c-4f93-9bc3-a39e68d59d23.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "7590c9e7-2a83-5ee5-a77c-8bc5a1bcaf38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa51783-9ef8-4e51-ba0d-ce8439d83bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa51783-9ef8-4e51-ba0d-ce8439d83bdf.jpg?1",
             "name": "Bind",
             "text": "Counter target activated ability. (Mana abilities can't be countered.)\nDraw a card.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "80ad9a81-3a81-5935-a96a-062a2424c4ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073e3f-6a6f-495a-ab16-39d906b660f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073e3f-6a6f-495a-ab16-39d906b660f1.jpg?1",
             "name": "Blurred Mongoose",
             "text": "Blurred Mongoose can't be countered.\nBlurred Mongoose can't be the target of spells or abilities.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "841f1940-9744-5498-9c45-b5911bfdea34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19d68e-7554-4627-a316-beb1f75fa494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19d68e-7554-4627-a316-beb1f75fa494.jpg?1",
             "name": "Canopy Surge",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nCanopy Surge deals 1 damage to each creature with flying and each player. If you paid the kicker cost, Canopy Surge deals 4 damage to each creature with flying and each player instead.",
             "colours": [
@@ -6267,7 +6267,7 @@
         },
         {
             "id": "ba756da2-f8a5-58a0-abe2-adc16a058cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab9a90c-5fd8-4f8c-b692-f98a2974810c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab9a90c-5fd8-4f8c-b692-f98a2974810c.jpg?1",
             "name": "Elfhame Sanctuary",
             "text": "At the beginning of your upkeep, you may search your library for a basic land card, reveal that card, and put it into your hand. If you do, skip your draw step this turn and shuffle your library.",
             "colours": [
@@ -6299,7 +6299,7 @@
         },
         {
             "id": "4fb137a3-5fb7-5691-9294-19cacf292cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19bb473-03b0-4e6d-a7da-0ec1e7707a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19bb473-03b0-4e6d-a7da-0ec1e7707a68.jpg?1",
             "name": "Elvish Champion",
             "text": "All Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -6333,7 +6333,7 @@
         },
         {
             "id": "abd2b195-2ec6-57e9-86d1-e08ad22c8b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc1e77-404c-436b-bde1-be1b21d00584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc1e77-404c-436b-bde1-be1b21d00584.jpg?1",
             "name": "Explosive Growth",
             "text": "Kicker o5 (You may pay an additional o5 as you play this spell.)\nTarget creature gets +2/+2 until end of turn. If you paid the kicker cost, that creature gets +5/+5 until end of turn instead.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "0ca3e334-293f-56fc-8e2d-b7c845c6d33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789e3582-b541-4916-ac7e-015214d7a27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789e3582-b541-4916-ac7e-015214d7a27a.jpg?1",
             "name": "Fertile Ground",
             "text": "Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool.",
             "colours": [
@@ -6399,7 +6399,7 @@
         },
         {
             "id": "6fa83f5d-b589-5c30-8db2-f2ffb3c0e521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0f633e-7238-4d02-ad8b-06dd20453030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0f633e-7238-4d02-ad8b-06dd20453030.jpg?1",
             "name": "Harrow",
             "text": "As an additional cost to play Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them into play. Then shuffle your library.",
             "colours": [
@@ -6431,7 +6431,7 @@
         },
         {
             "id": "219c31c4-6f89-57de-8bbb-b49d3485b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3392171d-ed25-46a1-91cc-a4f24537617d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3392171d-ed25-46a1-91cc-a4f24537617d.jpg?1",
             "name": "Jade Leech",
             "text": "Green spells you play cost o\nG more to play.",
             "colours": [
@@ -6465,7 +6465,7 @@
         },
         {
             "id": "9e536848-aabd-569a-ac23-cc0860147bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726437b-a41a-4ee9-b0ee-e09327508615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726437b-a41a-4ee9-b0ee-e09327508615.jpg?1",
             "name": "Kavu Chameleon",
             "text": "Kavu Chameleon can't be countered.\noo\nG Kavu Chameleon becomes the color of your choice until end of turn.",
             "colours": [
@@ -6499,7 +6499,7 @@
         },
         {
             "id": "d4adcce9-399b-5378-a245-b077b127d1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2063f31e-d972-411e-a265-1d409153b49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2063f31e-d972-411e-a265-1d409153b49c.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber comes into play, draw a card.",
             "colours": [
@@ -6533,7 +6533,7 @@
         },
         {
             "id": "42ee6189-af57-50d0-bf0d-a3c6f14582e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4581b53-23a0-4ca6-a77c-97d79e7a6570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4581b53-23a0-4ca6-a77c-97d79e7a6570.jpg?1",
             "name": "Kavu Lair",
             "text": "Whenever a creature with power 4 or greater comes into play, its controller draws a card.",
             "colours": [
@@ -6565,7 +6565,7 @@
         },
         {
             "id": "245123d4-ed59-5436-a692-9905ba00726c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fb86d-1d9a-4da2-bb5b-4266faa20197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fb86d-1d9a-4da2-bb5b-4266faa20197.jpg?1",
             "name": "Kavu Titan",
             "text": "Kicker o2o\nG (You may pay an additional o2o\nG as you play this spell.)\nIf you paid the kicker cost, Kavu Titan comes into play with three +1/+1 counters on it and has trample.",
             "colours": [
@@ -6599,7 +6599,7 @@
         },
         {
             "id": "e95861b3-4774-5f3a-be25-35d7379f7ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d92191-a743-4916-bbe4-5e207e964d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d92191-a743-4916-bbe4-5e207e964d9b.jpg?1",
             "name": "Llanowar Cavalry",
             "text": "oo\nW Attacking doesn't cause Llanowar Cavalry to tap this turn.",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "dc4bc380-0f1c-5c65-a2e5-defb30ca2792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e207863-de68-47e1-8c63-413b5fa48943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e207863-de68-47e1-8c63-413b5fa48943.jpg?1",
             "name": "Llanowar Elite",
             "text": "Kicker o8 (You may pay an additional o8 as you play this spell.)\nTrample\nIf you paid the kicker cost, Llanowar Elite comes into play with five +1/+1 counters on it.",
             "colours": [
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "84e65f14-c7e3-54b1-8b2e-e2796b8ec82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e6ed79-bdfd-49f9-bfa4-be4196880487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e6ed79-bdfd-49f9-bfa4-be4196880487.jpg?1",
             "name": "Llanowar Vanguard",
             "text": "oc\nT: Llanowar Vanguard gets +0/+4 until end of turn.",
             "colours": [
@@ -6703,7 +6703,7 @@
         },
         {
             "id": "918c16ed-f450-5ea9-a7e6-3209f41df3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032a4ec7-82ce-4ea0-b0dd-ebc40823a014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032a4ec7-82ce-4ea0-b0dd-ebc40823a014.jpg?1",
             "name": "Might Weaver",
             "text": "o2: Target red or white creature gains trample until end of turn.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "d154e3e4-7e7b-5084-9082-479db0b849ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d3475-ae72-42c1-ae4d-638f8e7c6d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d3475-ae72-42c1-ae4d-638f8e7c6d1a.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -6774,7 +6774,7 @@
         },
         {
             "id": "293b0202-3595-56db-89e7-48f5f582753e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69e57a-5b19-450c-9cf5-c189e8505781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69e57a-5b19-450c-9cf5-c189e8505781.jpg?1",
             "name": "Nomadic Elf",
             "text": "o1oo\nG Add one mana of any color to your mana pool.",
             "colours": [
@@ -6809,7 +6809,7 @@
         },
         {
             "id": "c4df0559-a430-5463-a7f0-8a3edfc1e911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23271658-19ae-420d-beeb-4bed4fdbb891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23271658-19ae-420d-beeb-4bed4fdbb891.jpg?1",
             "name": "Pincer Spider",
             "text": "Kicker o3 (You may pay an additional o3 as you play this spell.)\nPincer Spider may block as though it had flying.\nIf you paid the kicker cost, Pincer Spider comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -6843,7 +6843,7 @@
         },
         {
             "id": "b02523e9-281a-5f38-84ff-bd195a070b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db09afe5-5f01-4f77-a239-12d7a6e59024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db09afe5-5f01-4f77-a239-12d7a6e59024.jpg?1",
             "name": "Pulse of Llanowar",
             "text": "If a basic land you control is tapped for mana, it produces mana of any one color instead of its normal type.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "daf26542-c17b-5118-9301-23f28078300f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c660a748-82a9-4d6a-8023-56aeafe1bdce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c660a748-82a9-4d6a-8023-56aeafe1bdce.jpg?1",
             "name": "Quirion Elves",
             "text": "As Quirion Elves comes into play, choose a color.\noc\nT: Add o\nG to your mana pool.\noc\nT: Add one mana of the chosen color to your mana pool.",
             "colours": [
@@ -6910,7 +6910,7 @@
         },
         {
             "id": "16ceb35a-725a-50eb-aa45-89c39636114d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc639ea-a925-4f1e-879f-b8fcb12bf257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc639ea-a925-4f1e-879f-b8fcb12bf257.jpg?1",
             "name": "Quirion Sentinel",
             "text": "When Quirion Sentinel comes into play, add one mana of any color to your mana pool.",
             "colours": [
@@ -6945,7 +6945,7 @@
         },
         {
             "id": "694df494-c86d-575b-aafc-45fc5d6caf81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b258c1-5fb4-4072-bb32-ad364df1874a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b258c1-5fb4-4072-bb32-ad364df1874a.jpg?1",
             "name": "Quirion Trailblazer",
             "text": "When Quirion Trailblazer comes into play, you may search your library for a basic land card and put that card into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -6980,7 +6980,7 @@
         },
         {
             "id": "26ea6f4c-017e-52fe-97b8-b232f6eafbfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a013ff-7c99-445a-b9e0-0fc45036f068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a013ff-7c99-445a-b9e0-0fc45036f068.jpg?1",
             "name": "Restock",
             "text": "Return two target cards from your graveyard to your hand. Remove Restock from the game.",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "53ed4fee-3377-5d7f-a912-61fab6d150f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c25a4c-d93a-402b-999f-0b9919123cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c25a4c-d93a-402b-999f-0b9919123cc5.jpg?1",
             "name": "Rooting Kavu",
             "text": "When Rooting Kavu is put into a graveyard from play, you may remove Rooting Kavu from the game. If you do, shuffle all creature cards from your graveyard into your library.",
             "colours": [
@@ -7046,7 +7046,7 @@
         },
         {
             "id": "072eb147-bca8-5e01-8011-eece50d384a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8642e530-914c-4149-944a-c4966ee27299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8642e530-914c-4149-944a-c4966ee27299.jpg?1",
             "name": "Saproling Infestation",
             "text": "Whenever a player pays a kicker cost, you put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "1e76216a-6bc9-5682-b987-a5a60f30eb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb63748-5c84-43a0-8f17-a2a17f658337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb63748-5c84-43a0-8f17-a2a17f658337.jpg?1",
             "name": "Saproling Symbiosis",
             "text": "You may play Saproling Symbiosis any time you could play an instant if you pay o2 more to play it.\nPut a 1/1 green Saproling creature token into play for each creature you control.",
             "colours": [
@@ -7110,7 +7110,7 @@
         },
         {
             "id": "db27ccce-79fa-5a60-9db3-f495cc600f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b882e68-5c03-4ec6-9982-8c3b09847969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b882e68-5c03-4ec6-9982-8c3b09847969.jpg?1",
             "name": "Scouting Trek",
             "text": "Search your library for any number of basic land cards, reveal them, and set them aside. Shuffle your library, then put those cards on top of it in any order.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "acd79a2e-7ec5-55ab-b830-f0907637dd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699f1fe8-02c6-4d95-9231-3f8aefe603da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699f1fe8-02c6-4d95-9231-3f8aefe603da.jpg?1",
             "name": "Serpentine Kavu",
             "text": "oo\nR Serpentine Kavu gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "273addd9-bfed-5758-a579-9776d112e229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aeab16f-e104-47e7-81c7-b6e0123120d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aeab16f-e104-47e7-81c7-b6e0123120d7.jpg?1",
             "name": "Sulam Djinn",
             "text": "Trample\nSulam Djinn gets -2/-2 as long as green is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "2bed758b-472a-5996-b3a4-22746106425f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b37e39c-8aa4-4938-a492-7dac5de98dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b37e39c-8aa4-4938-a492-7dac5de98dfb.jpg?1",
             "name": "Tangle",
             "text": "Prevent all combat damage that would be dealt this turn.\nAttacking creatures don't untap during their controllers' next untap steps.",
             "colours": [
@@ -7243,7 +7243,7 @@
         },
         {
             "id": "9d00ac75-fb42-56d0-a458-d62f675c1115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80a56ed-3ebb-4e20-bf6a-e27127f762e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80a56ed-3ebb-4e20-bf6a-e27127f762e8.jpg?1",
             "name": "Thicket Elemental",
             "text": "Kicker o1o\nG (You may pay an additional o1o\nG as you play this spell.)\nWhen Thicket Elemental comes into play, if you paid the kicker cost, you may reveal cards from the top of your library until you reveal a creature card. If you do, put that card into play and shuffle all other cards revealed this way into your library.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "54ba1fb1-9146-50e1-9455-e08f70017499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505da522-73a8-4232-ae1a-d3365f3e598f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505da522-73a8-4232-ae1a-d3365f3e598f.jpg?1",
             "name": "Thornscape Apprentice",
             "text": "o\nW, oc\nT: Tap target creature.\no\nR, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "132611c4-6938-584d-98b8-7118db10fca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8f164d-3782-4eaa-a4db-ab7082d45ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8f164d-3782-4eaa-a4db-ab7082d45ee7.jpg?1",
             "name": "Thornscape Master",
             "text": "o\nRo\nR, oc\nT: Thornscape Master deals 2 damage to target creature.\no\nWo\nW, oc\nT: Target creature gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "268cc350-17ee-566c-a743-3c99bf81b126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97019ba5-ce2a-460c-8a4e-2b22053ced65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97019ba5-ce2a-460c-8a4e-2b22053ced65.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -7383,7 +7383,7 @@
         },
         {
             "id": "99e00888-9322-5725-8bd9-b2a73d5998a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6f5c0-686d-4b3a-add7-487f9fff5faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6f5c0-686d-4b3a-add7-487f9fff5faa.jpg?1",
             "name": "Treefolk Healer",
             "text": "o2o\nW, oc\nT: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "952deb18-a6f5-5f83-90b8-1042d92e9849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720452e9-3245-4b0e-94b6-843cbcb641a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720452e9-3245-4b0e-94b6-843cbcb641a5.jpg?1",
             "name": "Utopia Tree",
             "text": "oc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "5fcbd11c-114b-558a-8878-4346a9c6f75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5fab1-fa20-4006-b19d-179d36238c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5fab1-fa20-4006-b19d-179d36238c9b.jpg?1",
             "name": "Verdeloth the Ancient",
             "text": "Kicker o\nX (You may pay an additional o\nX as you play this spell.)\nAll other Treefolk and all Saprolings get +1/+1.\nWhen Verdeloth the Ancient comes into play, if you paid the kicker cost, put X 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "ed883ebe-bd25-530b-9b40-3cfcd7089f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f3361b-e2e7-4297-85c2-94323f90cc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f3361b-e2e7-4297-85c2-94323f90cc90.jpg?1",
             "name": "Verduran Emissary",
             "text": "Kicker o1o\nR (You may pay an additional o1o\nR as you play this spell.)\nWhen Verduran Emissary comes into play, if you paid the kicker cost, destroy target artifact. It can't be regenerated.",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "38857791-44b9-5c9a-abc0-6268c0d34885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6f57ad-d370-4c81-8da0-c15d87725ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6f57ad-d370-4c81-8da0-c15d87725ab1.jpg?1",
             "name": "Vigorous Charge",
             "text": "Kicker o\nW (You may pay an additional o\nW as you play this spell.)\nTarget creature gains trample until end of turn. Whenever that creature deals combat damage this turn, if you paid the kicker cost, you gain life equal to that damage.",
             "colours": [
@@ -7558,7 +7558,7 @@
         },
         {
             "id": "4a1ddbb5-132e-562d-bc68-6d13ef1c0cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ce5126-e7b1-41ab-9e56-1e12927c4d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ce5126-e7b1-41ab-9e56-1e12927c4d27.jpg?1",
             "name": "Wallop",
             "text": "Destroy target blue or black creature with flying.",
             "colours": [
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "645b4b5b-1727-50b2-a826-3daa9021f16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da5cb6c-253b-44f0-98f9-d75f42c6e14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da5cb6c-253b-44f0-98f9-d75f42c6e14b.jpg?1",
             "name": "Wandering Stream",
             "text": "You gain 2 life for each basic land type among lands you control.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "f4354647-67c8-5ac6-92e5-c9b44c865286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10566804-fd15-4ef0-ad7d-cc979f4cc8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10566804-fd15-4ef0-ad7d-cc979f4cc8c5.jpg?1",
             "name": "Whip Silk",
             "text": "Enchanted creature may block as though it had flying.\noo\nG Return Whip Silk to its owner's hand.",
             "colours": [
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "d6fa9c57-71c2-5e2b-a28e-c2416c13b467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6a0f3e-457f-41f5-be26-5fb249874f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6a0f3e-457f-41f5-be26-5fb249874f1a.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "0c71533f-09b0-51db-927b-c615ac909e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692c186a-997c-4f7e-a339-bf84884e1019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692c186a-997c-4f7e-a339-bf84884e1019.jpg?1",
             "name": "Aether Rift",
             "text": "At the beginning of your upkeep, discard a card at random from your hand. If you discard a creature card this way, put that card into play unless any player pays 5 life.",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "8cbffc6d-c248-5f00-8e41-ffdcef757646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaa3e4e-4e08-4df2-9e0c-66e15a10fec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaa3e4e-4e08-4df2-9e0c-66e15a10fec4.jpg?1",
             "name": "Angelic Shield",
             "text": "Creatures you control get +0/+1.\nSacrifice Angelic Shield: Return target creature to its owner's hand.",
             "colours": [
@@ -7758,7 +7758,7 @@
         },
         {
             "id": "a47b330a-ac90-5b76-b4ea-2c0d67fa22a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d816f98-6cb6-432c-b0a4-a0eed21658ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d816f98-6cb6-432c-b0a4-a0eed21658ac.jpg?1",
             "name": "Armadillo Cloak",
             "text": "Enchanted creature gets +2/+2 and has trample.\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -7794,7 +7794,7 @@
         },
         {
             "id": "24aa424d-dbd8-53a3-9333-a9a892dde939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de5e1bd-1d31-4f9f-b18d-d6f49bc7ef10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de5e1bd-1d31-4f9f-b18d-d6f49bc7ef10.jpg?1",
             "name": "Armored Guardian",
             "text": "o1o\nWo\nW Target creature you control gains protection from the color of your choice until end of turn.\no1o\nUo\nU Armored Guardian can't be the target of spells or abilities this turn.",
             "colours": [
@@ -7831,7 +7831,7 @@
         },
         {
             "id": "ebace84a-ad06-54eb-ba91-c864b5e88823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eef49c-a80f-4622-ba77-999f9151c841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eef49c-a80f-4622-ba77-999f9151c841.jpg?1",
             "name": "Artifact Mutation",
             "text": "Destroy target artifact. It can't be regenerated. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "850d9673-72b6-5a09-bce9-c494659eec46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38421179-615e-4aba-91a4-503bfee05403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38421179-615e-4aba-91a4-503bfee05403.jpg?1",
             "name": "Aura Mutation",
             "text": "Destroy target enchantment. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -7899,7 +7899,7 @@
         },
         {
             "id": "c27d1814-e867-5f08-bc75-d4ad0d57b5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4039ef-af72-4267-ade9-fdb7c921279e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4039ef-af72-4267-ade9-fdb7c921279e.jpg?1",
             "name": "Aura Shards",
             "text": "Whenever a creature comes into play under your control, you may destroy target artifact or enchantment.",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "5315a8ae-0945-5c8e-ad7b-f5e5a94dec9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadf030d-5451-43fc-bf0c-c1629fdf88ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadf030d-5451-43fc-bf0c-c1629fdf88ec.jpg?1",
             "name": "Backlash",
             "text": "Tap target untapped creature. That creature deals damage equal to its power to its controller.",
             "colours": [
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "991bafe8-ad32-5981-a173-f41d4a9a4818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8ec4dc-c74a-4d49-856e-95703675fe9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8ec4dc-c74a-4d49-856e-95703675fe9b.jpg?1",
             "name": "Barrin's Spite",
             "text": "Choose two target creatures controlled by one player. That player chooses and sacrifices one of them. Return the other to its owner's hand.",
             "colours": [
@@ -8001,7 +8001,7 @@
         },
         {
             "id": "0714ccbf-5744-5ebf-af59-b77055767760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd397be-0e61-4f41-b0cf-f0c9d2440da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd397be-0e61-4f41-b0cf-f0c9d2440da7.jpg?1",
             "name": "Blazing Specter",
             "text": "Flying; haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhenever Blazing Specter deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -8037,7 +8037,7 @@
         },
         {
             "id": "c772e5f6-1801-5f7b-bbc4-06f1dd8282dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d441c-f37f-44fe-8a93-f5c89df807e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d441c-f37f-44fe-8a93-f5c89df807e4.jpg?1",
             "name": "Captain Sisay",
             "text": "oc\nT: Search your library for a Legend or legendary card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "7fb5c732-3aa0-5669-87a9-6b34d45a4cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dadcae0-f2b2-487c-bb93-0a2c073044c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dadcae0-f2b2-487c-bb93-0a2c073044c0.jpg?1",
             "name": "Cauldron Dance",
             "text": "Play Cauldron Dance only during combat.\nReturn target creature card from your graveyard to play. That creature gains haste. Return it to your hand at end of turn.\nPut a creature card from your hand into play. That creature gains haste. Put it into your graveyard at end of turn.",
             "colours": [
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "9f2cf254-e41d-58a0-903b-10aeea4184bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58956099-6b97-4c7b-ab23-9f9b4d50ef95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58956099-6b97-4c7b-ab23-9f9b4d50ef95.jpg?1",
             "name": "Charging Troll",
             "text": "Attacking doesn't cause Charging Troll to tap.\noo\nG Regenerate Charging Troll.",
             "colours": [
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "9fff4c32-dc8f-56ab-81e7-011ff29b33de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd933a-19ed-4d30-a94a-bfb2f66f8f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd933a-19ed-4d30-a94a-bfb2f66f8f13.jpg?1",
             "name": "Cinder Shade",
             "text": "oo\nB Cinder Shade gets +1/+1 until end of turn.\no\nR, Sacrifice Cinder Shade: Cinder Shade deals damage equal to its power to target creature.",
             "colours": [
@@ -8182,7 +8182,7 @@
         },
         {
             "id": "4325d429-05f6-5549-b104-9c80c6ce21f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ad3aa-3225-45ae-8343-5991f5b52269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ad3aa-3225-45ae-8343-5991f5b52269.jpg?1",
             "name": "Coalition Victory",
             "text": "You win the game if you control a land of each basic land type and a creature of each color.",
             "colours": [
@@ -8222,7 +8222,7 @@
         },
         {
             "id": "07eb5558-bd9d-5a21-a410-677031c63cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f336d8-12a4-482d-8ffd-c205858c72ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f336d8-12a4-482d-8ffd-c205858c72ba.jpg?1",
             "name": "Crosis, the Purger",
             "text": "Flying\nWhenever Crosis, the Purger deals combat damage to a player, you may pay o2o\nB. If you do, choose a color. That player reveals his or her hand and discards all cards of that color from it.",
             "colours": [
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "109b1c56-f677-5a3b-a3e1-a7da68b82463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dcf5e3-4303-41a3-b54c-24a9d462ce07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dcf5e3-4303-41a3-b54c-24a9d462ce07.jpg?1",
             "name": "Darigaaz, the Igniter",
             "text": "Flying\nWhenever Darigaaz, the Igniter deals combat damage to a player, you may pay o2o\nR. If you do, choose a color. That player reveals his or her hand and Darigaaz deals X damage to him or her, where X is the number of cards revealed of that color.",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "a3b1b0b0-f51c-5fcd-a198-325f08a96b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc3c72-fff5-454c-814c-eb952fd23ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc3c72-fff5-454c-814c-eb952fd23ba9.jpg?1",
             "name": "Dromar, the Banisher",
             "text": "Flying\nWhenever Dromar, the Banisher deals combat damage to a player, you may pay o2o\nU. If you do, choose a color. Return all creatures of that color to their owners' hands.",
             "colours": [
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "e4ea6495-37c7-5702-94e9-bf8adeb856c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52760183-bee0-4ce0-96c0-074b88f78980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52760183-bee0-4ce0-96c0-074b88f78980.jpg?1",
             "name": "Dueling Grounds",
             "text": "No more than one creature may attack each turn.\nNo more than one creature may block each turn.",
             "colours": [
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "6a853699-3d59-52f7-a8ac-24b8a6fe0e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967f1658-8777-46fc-a648-07fb19e46745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967f1658-8777-46fc-a648-07fb19e46745.jpg?1",
             "name": "Fires of Yavimaya",
             "text": "Creatures you control have haste. (They may attack and oc\nT the turn they come under your control.)\nSacrifice Fires of Yavimaya: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "8850b430-c617-5152-929e-b0ebded0aef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15875876-3341-40fb-866f-5587c3638538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15875876-3341-40fb-866f-5587c3638538.jpg?1",
             "name": "Frenzied Tilling",
             "text": "Destroy target land. Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "310edd9a-0fe4-5fd7-a78c-015553cb8a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b492d6-5e28-4f4b-942c-080d03cb0e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b492d6-5e28-4f4b-942c-080d03cb0e92.jpg?1",
             "name": "Galina's Knight",
             "text": "Protection from red",
             "colours": [
@@ -8481,7 +8481,7 @@
         },
         {
             "id": "eadc61a4-a3b4-5b8c-8611-5cfe24dbab37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a4e48d-6452-4245-bdad-63fe3263550e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a4e48d-6452-4245-bdad-63fe3263550e.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "o1o\nWo\nU, oc\nT: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -8520,7 +8520,7 @@
         },
         {
             "id": "53728906-e771-5f7e-9c3a-fbf5621f4ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d6043-5ec1-4ad4-8296-41fe23f11cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d6043-5ec1-4ad4-8296-41fe23f11cb9.jpg?1",
             "name": "Heroes' Reunion",
             "text": "Target player gains 7 life.",
             "colours": [
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "5d51907a-3db1-5501-a905-c0e452a5d63d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ad983-ce91-40b6-a1ce-fe36ec7fbce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ad983-ce91-40b6-a1ce-fe36ec7fbce8.jpg?1",
             "name": "Horned Cheetah",
             "text": "Whenever Horned Cheetah deals damage, you gain that much life.",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "b2b8dc5e-ee46-54f6-b9d5-ec5d8642077c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8943304a-89c9-48b0-97b4-3e1aa690ca4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8943304a-89c9-48b0-97b4-3e1aa690ca4d.jpg?1",
             "name": "Hunting Kavu",
             "text": "o1o\nRo\nG, oc\nT: Remove from the game Hunting Kavu and target creature without flying that's attacking you.",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "ac22c757-ce78-5cd1-896d-b0b0d84b1d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afd7e8e-4fcc-4003-9791-7baf10ef1880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afd7e8e-4fcc-4003-9791-7baf10ef1880.jpg?1",
             "name": "Kangee, Aerie Keeper",
             "text": "Kicker o2o\nX (You may pay an additional o2o\nX as you play this spell.)\nFlying\nWhen Kangee, Aerie Keeper comes into play, if you paid the kicker cost, put X feather counters on it.\nAll Birds get +1/+1 for each feather counter on Kangee, Aerie Keeper.",
             "colours": [
@@ -8665,7 +8665,7 @@
         },
         {
             "id": "8c607d03-8945-5a57-9504-8faaf8aef642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c75d89-e432-49aa-a407-555b223b7eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c75d89-e432-49aa-a407-555b223b7eff.jpg?1",
             "name": "Llanowar Knight",
             "text": "Protection from black",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "d709042f-ba40-5e8f-b08c-5f044b263bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff307dbb-4ab6-457b-be56-47106864bf61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff307dbb-4ab6-457b-be56-47106864bf61.jpg?1",
             "name": "Lobotomy",
             "text": "Look at target player's hand and choose a card other than a basic land card from it. Search that player's graveyard, hand, and library for all cards with the same name as the chosen card and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "e22268a3-6e28-53db-a5d5-f221b4a0ffde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36489b24-f8a8-46b6-b879-0a5ce400a6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36489b24-f8a8-46b6-b879-0a5ce400a6dc.jpg?1",
             "name": "Meteor Storm",
             "text": "o2o\nRo\nG, Discard two cards at random from your hand: Meteor Storm deals 4 damage to target creature or player.",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "85447ea1-ad6b-5f00-bab7-f306c9477f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f327818-8222-4295-8cef-118757b34d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f327818-8222-4295-8cef-118757b34d17.jpg?1",
             "name": "Noble Panther",
             "text": "o1: Noble Panther gains first strike until end of turn.",
             "colours": [
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "ad9a256b-78b4-5ee1-9d41-bf77362b2fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d83a07-6054-45f1-bdf9-07f2006238d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d83a07-6054-45f1-bdf9-07f2006238d2.jpg?1",
             "name": "Ordered Migration",
             "text": "Put a 1/1 blue Bird creature token with flying into play for each basic land type among lands you control.",
             "colours": [
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "9ca122f6-78d5-5a94-abe0-e4c6798fb1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4183e73d-609a-4292-b173-e39eb51949f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4183e73d-609a-4292-b173-e39eb51949f3.jpg?1",
             "name": "Overabundance",
             "text": "Whenever a player taps a land for mana, that player adds one additional mana to his or her mana pool of the same type, and Overabundance deals 1 damage to him or her.",
             "colours": [
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "00551690-1726-5f86-a5f1-a7d2e7f64c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d106d56-a688-49cc-8d5d-0279a5a7c0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d106d56-a688-49cc-8d5d-0279a5a7c0a7.jpg?1",
             "name": "Plague Spores",
             "text": "Destroy target nonblack creature and target land. They can't be regenerated.",
             "colours": [
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "e3e337a0-1acd-5490-b09d-77b1b41478ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c030108-2995-4fb0-9b80-efdfdd0f11e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c030108-2995-4fb0-9b80-efdfdd0f11e0.jpg?1",
             "name": "Pyre Zombie",
             "text": "At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay o1o\nBo\nB. If you do, return Pyre Zombie from your graveyard to your hand.\no1o\nRo\nR, Sacrifice Pyre Zombie: Pyre Zombie deals 2 damage to target creature or player.",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "1cae53a0-e015-52a1-9527-293bf58349d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573679-e9e5-4bfc-b5d5-85d4648b01b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573679-e9e5-4bfc-b5d5-85d4648b01b6.jpg?1",
             "name": "Raging Kavu",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nYou may play Raging Kavu any time you could play an instant.",
             "colours": [
@@ -8980,7 +8980,7 @@
         },
         {
             "id": "937458fe-54dd-5d84-a42d-2d56b2643f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0f568e-4d3a-40a5-b72a-63040ec5402d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0f568e-4d3a-40a5-b72a-63040ec5402d.jpg?1",
             "name": "Reckless Assault",
             "text": "o1, Pay 2 life: Reckless Assault deals 1 damage to target creature or player.",
             "colours": [
@@ -9014,7 +9014,7 @@
         },
         {
             "id": "d35caa38-6f96-5dd7-acae-788238dcc861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a77be3-e3b0-40f5-a470-414bac49da60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a77be3-e3b0-40f5-a470-414bac49da60.jpg?1",
             "name": "Recoil",
             "text": "Return target permanent to its owner's hand. Then that player discards a card from his or her hand.",
             "colours": [
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "57810cc8-f3bf-54d6-87da-c24d59afb833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a23c32-e122-400b-b252-e636ea2e684b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a23c32-e122-400b-b252-e636ea2e684b.jpg?1",
             "name": "Reviving Vapors",
             "text": "Reveal the top three cards of your library and put one of them into your hand. You gain life equal to that card's converted mana cost. Put the other cards revealed this way into your graveyard.",
             "colours": [
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "0e7f60e9-03bd-5dcd-8306-414c2d1c31f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e42ae1d-62b4-4b19-aafc-f12bdd6fb8cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e42ae1d-62b4-4b19-aafc-f12bdd6fb8cc.jpg?1",
             "name": "Riptide Crab",
             "text": "Attacking doesn't cause Riptide Crab to tap.\nWhen Riptide Crab is put into a graveyard from play, draw a card.",
             "colours": [
@@ -9118,7 +9118,7 @@
         },
         {
             "id": "407c7653-cdb7-5fc8-becd-a33a1e5817cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30be387-280d-49bd-a3d1-c1636ee931ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30be387-280d-49bd-a3d1-c1636ee931ce.jpg?1",
             "name": "Rith, the Awakener",
             "text": "Flying\nWhenever Rith, the Awakener deals combat damage to a player, you may pay o2o\nG. If you do, choose a color. Put a 1/1 green Saproling creature token into play for each permanent of that color.",
             "colours": [
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "55d31234-d3b2-5ec7-9309-b7609f4d7f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8338c296-cf3f-41d7-b380-3fb4237cb41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8338c296-cf3f-41d7-b380-3fb4237cb41c.jpg?1",
             "name": "Sabertooth Nishoba",
             "text": "Trample, protection from blue, protection from red",
             "colours": [
@@ -9196,7 +9196,7 @@
         },
         {
             "id": "3070d12c-3e50-5e11-a9d8-9f251cece574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a262d7-6d0c-43d0-89b6-9f46a1a9eb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a262d7-6d0c-43d0-89b6-9f46a1a9eb69.jpg?1",
             "name": "Samite Archer",
             "text": "oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\noc\nT: Samite Archer deals 1 damage to target creature or player.",
             "colours": [
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "10964488-7fa3-558c-84ec-335fa2d9011e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c94618a-808c-4b3c-8f34-45e64d0414d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c94618a-808c-4b3c-8f34-45e64d0414d3.jpg?1",
             "name": "Seer's Vision",
             "text": "All opponents play with their hands revealed.\nSacrifice Seer's Vision: Look at target player's hand and choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -9268,7 +9268,7 @@
         },
         {
             "id": "203bf647-b1f7-547b-a5ea-86dbcbc9f759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c99269-f730-4d33-bbce-9e855e9ad0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c99269-f730-4d33-bbce-9e855e9ad0fc.jpg?1",
             "name": "Shivan Zombie",
             "text": "Protection from white",
             "colours": [
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "093a9087-e840-52a3-bc44-d69f8b81f886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b1930d-2e4b-472f-98a9-008fd632f3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b1930d-2e4b-472f-98a9-008fd632f3be.jpg?1",
             "name": "Simoon",
             "text": "Simoon deals 1 damage to each creature target opponent controls.",
             "colours": [
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "19b06952-090b-559d-8311-63be9b224846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411f0fd-8b85-4d0d-a202-701a24ffac9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411f0fd-8b85-4d0d-a202-701a24ffac9f.jpg?1",
             "name": "Sleeper's Robe",
             "text": "Enchanted creature can't be blocked except by artifact creatures and/or black creatures.\nWhenever enchanted creature deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -9376,7 +9376,7 @@
         },
         {
             "id": "5d987cb6-127f-53e7-9e84-11d386012ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a7004-5a28-4ccb-8640-ad6b07b51ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a7004-5a28-4ccb-8640-ad6b07b51ece.jpg?1",
             "name": "Slinking Serpent",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -9412,7 +9412,7 @@
         },
         {
             "id": "24eb4558-a7a2-5659-a8e6-3170165f002f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdc55c0-c8ac-49d5-969b-9bf0ee8e696c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdc55c0-c8ac-49d5-969b-9bf0ee8e696c.jpg?1",
             "name": "Smoldering Tar",
             "text": "At the beginning of your upkeep, target player loses 1 life.\nSacrifice Smoldering Tar: Smoldering Tar deals 4 damage to target creature. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -9446,7 +9446,7 @@
         },
         {
             "id": "683d145b-14ba-5acc-8949-1fa8bf01b66c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ad1eb-62a3-4560-bf8e-35f7db73c7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ad1eb-62a3-4560-bf8e-35f7db73c7a3.jpg?1",
             "name": "Spinal Embrace",
             "text": "Play Spinal Embrace only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At end of turn, sacrifice it. If you do, you gain life equal to its toughness. (The creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -9480,7 +9480,7 @@
         },
         {
             "id": "be22a23d-18dc-527a-a2c2-161c2b9e74e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8cc71f-3070-497f-908f-35aa13a8a857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8cc71f-3070-497f-908f-35aa13a8a857.jpg?1",
             "name": "Stalking Assassin",
             "text": "o3o\nU, oc\nT: Tap target creature.\no3o\nB, oc\nT: Destroy target tapped creature.",
             "colours": [
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "7173fd5f-9402-5f9a-afea-2874eacd6aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b26aa3-8169-4978-9554-bd2fc8e18e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b26aa3-8169-4978-9554-bd2fc8e18e3b.jpg?1",
             "name": "Sterling Grove",
             "text": "All other enchantments you control can't be the targets of spells or abilities.\no1, Sacrifice Sterling Grove: Search your library for an enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -9551,7 +9551,7 @@
         },
         {
             "id": "48757829-4add-5c06-b25b-8c190937b1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5845c-ef6d-4a7b-b725-b09d3e9bbc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5845c-ef6d-4a7b-b725-b09d3e9bbc17.jpg?1",
             "name": "Teferi's Moat",
             "text": "As Teferi's Moat comes into play, choose a color.\nCreatures of the chosen color without flying can't attack you.",
             "colours": [
@@ -9585,7 +9585,7 @@
         },
         {
             "id": "f458838a-42ee-5ea4-ba79-0d84f3639f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee67039-6cee-4a2d-b973-570f5060f550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee67039-6cee-4a2d-b973-570f5060f550.jpg?1",
             "name": "Treva, the Renewer",
             "text": "Flying\nWhenever Treva, the Renewer deals combat damage to a player, you may pay o2o\nW. If you do, choose a color. You gain 1 life for each permanent of that color.",
             "colours": [
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "969e8310-2492-5803-90eb-4dbfb49b1be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbe2539-7a7c-468b-a270-7ca1bdcccb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbe2539-7a7c-468b-a270-7ca1bdcccb1e.jpg?1",
             "name": "Tsabo Tavoc",
             "text": "First strike, protection from Legends\no\nBo\nB, oc\nT: Destroy target Legend. It can't be regenerated.",
             "colours": [
@@ -9664,7 +9664,7 @@
         },
         {
             "id": "5f17ee2f-3b46-532a-ad55-ef35d163877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2334bc71-5f85-47ff-b393-601a1e746a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2334bc71-5f85-47ff-b393-601a1e746a4e.jpg?1",
             "name": "Undermine",
             "text": "Counter target spell. Its controller loses 3 life.",
             "colours": [
@@ -9698,7 +9698,7 @@
         },
         {
             "id": "4d7300a1-8a5e-5acc-950a-8abc4a11c5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d1327e-bf87-423f-8a04-8124e45b9ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d1327e-bf87-423f-8a04-8124e45b9ae0.jpg?1",
             "name": "Urborg Drake",
             "text": "Flying\nUrborg Drake attacks each turn if able.",
             "colours": [
@@ -9734,7 +9734,7 @@
         },
         {
             "id": "24510a16-8953-555d-8142-9d01b0e9b440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e9e629-7c25-4d45-aa35-9ba5f95b43cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e9e629-7c25-4d45-aa35-9ba5f95b43cb.jpg?1",
             "name": "Vicious Kavu",
             "text": "Whenever Vicious Kavu attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -9770,7 +9770,7 @@
         },
         {
             "id": "688e6e69-91d9-5cde-a7d1-924b5c172605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e5716-77f3-45d2-a40a-f5bf500f6ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e5716-77f3-45d2-a40a-f5bf500f6ad7.jpg?1",
             "name": "Vile Consumption",
             "text": "All creatures have \"At the beginning of your upkeep, sacrifice this creature unless you pay 1 life.\"",
             "colours": [
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "84417e9d-98e0-592e-aca5-b4dff3107db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30a5a06-32ce-4d71-b71f-e3e1d8d4511a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30a5a06-32ce-4d71-b71f-e3e1d8d4511a.jpg?1",
             "name": "Vodalian Zombie",
             "text": "Protection from green",
             "colours": [
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "b140423a-9454-5665-a886-fdacf8ae482d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dc1df7-b9db-4f5f-a340-08287cd3d9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dc1df7-b9db-4f5f-a340-08287cd3d9e5.jpg?1",
             "name": "Void",
             "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards from it all nonland cards with converted mana cost equal to the number.",
             "colours": [
@@ -9875,7 +9875,7 @@
         },
         {
             "id": "523f5d45-c048-5eb6-a2cd-af4ee0b345ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8c5669-11a9-4d95-8431-7065037f1fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8c5669-11a9-4d95-8431-7065037f1fb6.jpg?1",
             "name": "Voracious Cobra",
             "text": "First strike\nWhenever Voracious Cobra deals combat damage to a creature, destroy that creature.",
             "colours": [
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "1b28e5aa-9f17-5eaa-95f2-1d7aa096bf51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0d2402-f1ef-4a71-ac01-c7099c4ce54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0d2402-f1ef-4a71-ac01-c7099c4ce54c.jpg?1",
             "name": "Wings of Hope",
             "text": "Enchanted creature gets +1/+3 and has flying.",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "3d6edfdd-0298-5aee-b394-defb04a70052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17377d-4dad-4144-b0ce-c849636096a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17377d-4dad-4144-b0ce-c849636096a2.jpg?1",
             "name": "Yavimaya Barbarian",
             "text": "Protection from blue",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "137cb1a7-427e-522e-aa59-f62dcd193409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1872f104-7cf1-41e3-b1b4-ca75c678e08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1872f104-7cf1-41e3-b1b4-ca75c678e08b.jpg?1",
             "name": "Yavimaya Kavu",
             "text": "Yavimaya Kavu's power is equal to the number of red creatures in play.\nYavimaya Kavu's toughness is equal to the number of green creatures in play.",
             "colours": [
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "e083d28d-dbae-5c2b-a7a1-308052cd9483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg?1",
             "name": "Stand // Deliver",
             "text": "Prevent the next 2 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -10053,7 +10053,7 @@
         },
         {
             "id": "729b77ee-d817-5981-bda1-d13b592a2af2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg?1",
             "name": "Stand // Deliver",
             "text": "Prevent the next 2 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "fef58ab8-d9d8-53ba-b6bd-d9de6dd60137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg?1",
             "name": "Spite // Malice",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -10119,7 +10119,7 @@
         },
         {
             "id": "b3344b6d-5b60-506a-ab2b-833eaedde3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg?1",
             "name": "Spite // Malice",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -10152,7 +10152,7 @@
         },
         {
             "id": "7fe20b60-6f9f-5956-aa75-baff3f07a1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg?1",
             "name": "Pain // Suffering",
             "text": "Target player discards a card from his or her hand.",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "7cd8bb84-271e-55a0-9b5a-4e96437b49e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg?1",
             "name": "Pain // Suffering",
             "text": "Target player discards a card from his or her hand.",
             "colours": [
@@ -10218,7 +10218,7 @@
         },
         {
             "id": "1407fbbd-8bc8-52e3-9b35-ee9df8017530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg?1",
             "name": "Assault // Battery",
             "text": "Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "85344e88-7453-5e12-b621-b0fb8362560a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg?1",
             "name": "Assault // Battery",
             "text": "Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -10284,7 +10284,7 @@
         },
         {
             "id": "fc84f5cd-fd2f-5402-ac0f-ad92bf25e493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg?1",
             "name": "Wax // Wane",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "a5cca3be-220e-5bbb-a6f0-98252ed72871",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg?1",
             "name": "Wax // Wane",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -10350,7 +10350,7 @@
         },
         {
             "id": "216c366c-c7f9-5a99-be05-3cdc801cbc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb6d6a1-9d71-405b-9c93-1a7f06c67abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb6d6a1-9d71-405b-9c93-1a7f06c67abd.jpg?1",
             "name": "Alloy Golem",
             "text": "As Alloy Golem comes into play, choose a color.\nAlloy Golem is the chosen color. (It's still an artifact.)",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "3f8395f6-a708-5bf5-810f-1186b9a5a5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db32fa-64b2-4ef6-88f2-28e758d420bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db32fa-64b2-4ef6-88f2-28e758d420bb.jpg?1",
             "name": "Bloodstone Cameo",
             "text": "oc\nT: Add o\nB or o\nR to your mana pool.",
             "colours": [],
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "f14f94ca-8041-5a7f-9411-2308e8230d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920cd17f-9274-443e-906f-c9904f0658d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920cd17f-9274-443e-906f-c9904f0658d5.jpg?1",
             "name": "Chromatic Sphere",
             "text": "o1, oc\nT, Sacrifice Chromatic Sphere: Add one mana of any color to your mana pool. Draw a card.",
             "colours": [],
@@ -10440,7 +10440,7 @@
         },
         {
             "id": "67913c1b-e26d-5a8e-8a6e-3e41f45ef70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45edc18c-2046-4d0e-92fe-a6cf4aaf1c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45edc18c-2046-4d0e-92fe-a6cf4aaf1c6f.jpg?1",
             "name": "Crosis's Attendant",
             "text": "o1, Sacrifice Crosis's Attendant: Add o\nUo\nBo\nR to your mana pool.",
             "colours": [],
@@ -10475,7 +10475,7 @@
         },
         {
             "id": "4631013f-ce7b-553f-8d72-eec26a17e917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22b575-443a-4c06-8e75-d4140cbd3660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22b575-443a-4c06-8e75-d4140cbd3660.jpg?1",
             "name": "Darigaaz's Attendant",
             "text": "o1, Sacrifice Darigaaz's Attendant: Add o\nBo\nRo\nG to your mana pool.",
             "colours": [],
@@ -10510,7 +10510,7 @@
         },
         {
             "id": "8699d1db-7277-50c5-a544-aff0876b9989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ce135-9c2f-45bd-b2db-c0e00c50c964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ce135-9c2f-45bd-b2db-c0e00c50c964.jpg?1",
             "name": "Drake-Skull Cameo",
             "text": "oc\nT: Add o\nU or o\nB to your mana pool.",
             "colours": [],
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "6321fbfb-367e-546c-a88d-9b08e67c99e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24936fa9-41a3-4da5-91cf-c28fa45f47c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24936fa9-41a3-4da5-91cf-c28fa45f47c9.jpg?1",
             "name": "Dromar's Attendant",
             "text": "o1, Sacrifice Dromar's Attendant: Add o\nWo\nUo\nB to your mana pool.",
             "colours": [],
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "fd3a0f4b-57ab-504b-a37f-43a982b8dfb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab7cf53-f62d-47e1-af70-ab12be0d22e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab7cf53-f62d-47e1-af70-ab12be0d22e2.jpg?1",
             "name": "Juntu Stakes",
             "text": "Creatures with power 1 or less don't untap during their controllers' untap steps.",
             "colours": [],
@@ -10604,7 +10604,7 @@
         },
         {
             "id": "fe6296c7-1e0f-51dc-90c3-a73ada8ea690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfc6396-5377-4ab3-9c10-8abcdeae2aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfc6396-5377-4ab3-9c10-8abcdeae2aa1.jpg?1",
             "name": "Lotus Guardian",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10635,7 +10635,7 @@
         },
         {
             "id": "f152bcf8-73a3-5bd0-9368-5ccdaeeac21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25158cd5-749b-408c-9ab1-0f83e38730f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25158cd5-749b-408c-9ab1-0f83e38730f7.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "970e17f1-fb18-5869-b9f7-0f4b403769c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec9a91d-7af0-44a8-839f-fb9960be0ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec9a91d-7af0-44a8-839f-fb9960be0ddd.jpg?1",
             "name": "Phyrexian Lens",
             "text": "oc\nT, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "a4086680-d0d9-50f4-bb2f-9254eda1ef63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24315eaa-ef55-4fd6-9145-e75b3de6f492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24315eaa-ef55-4fd6-9145-e75b3de6f492.jpg?1",
             "name": "Planar Portal",
             "text": "o6, oc\nT: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -10719,7 +10719,7 @@
         },
         {
             "id": "2c2f3218-c1a7-5603-aa98-8475a5417fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1981dd-c0f3-4e9d-a1f1-8bea823326ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1981dd-c0f3-4e9d-a1f1-8bea823326ef.jpg?1",
             "name": "Power Armor",
             "text": "o3, oc\nT: Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "85ba5c25-d19e-5a57-87a9-89037bdc8122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e8130-7fe9-4ef4-98af-928814f5b130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e8130-7fe9-4ef4-98af-928814f5b130.jpg?1",
             "name": "Rith's Attendant",
             "text": "o1, Sacrifice Rith's Attendant: Add o\nRo\nGo\nW to your mana pool.",
             "colours": [],
@@ -10782,7 +10782,7 @@
         },
         {
             "id": "c65fbd79-9741-5c5a-b84a-92df1e1ba59c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efdbcad-e2e4-4f54-ade5-920b1853109e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efdbcad-e2e4-4f54-ade5-920b1853109e.jpg?1",
             "name": "Seashell Cameo",
             "text": "oc\nT: Add o\nW or o\nU to your mana pool.",
             "colours": [],
@@ -10813,7 +10813,7 @@
         },
         {
             "id": "91b3ee98-48a8-5e61-a85d-54352b071e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d829d9de-83fa-4feb-8efc-0075315163c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d829d9de-83fa-4feb-8efc-0075315163c6.jpg?1",
             "name": "Sparring Golem",
             "text": "Whenever Sparring Golem becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [],
@@ -10844,7 +10844,7 @@
         },
         {
             "id": "c4a55c52-53ae-5232-affe-5ddd29ec5e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f38104-a699-4bb9-930a-699f7bbc338a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f38104-a699-4bb9-930a-699f7bbc338a.jpg?1",
             "name": "Tek",
             "text": "Tek gets +0/+2 as long as you control a plains, has flying as long as you control an island, gets +2/+0 as long as you control a swamp, has first strike as long as you control a mountain, and has trample as long as you control a forest.",
             "colours": [],
@@ -10875,7 +10875,7 @@
         },
         {
             "id": "084c5f0b-05a1-5b5f-8268-9b54681e5f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976da8-338d-4f46-b8ea-78a0aa3daa35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976da8-338d-4f46-b8ea-78a0aa3daa35.jpg?1",
             "name": "Tigereye Cameo",
             "text": "oc\nT: Add o\nG or o\nW to your mana pool.",
             "colours": [],
@@ -10906,7 +10906,7 @@
         },
         {
             "id": "34474b38-e8b2-591e-ad21-62fb6a432e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9857af81-fb95-4dc4-b048-9ce4e96d1eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9857af81-fb95-4dc4-b048-9ce4e96d1eca.jpg?1",
             "name": "Treva's Attendant",
             "text": "o1, Sacrifice Treva's Attendant: Add o\nGo\nWo\nU to your mana pool.",
             "colours": [],
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "0a0cff55-60f0-534c-914a-fa6112fabbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b1ca6c-6ca0-4b02-885a-58cee3fa2aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b1ca6c-6ca0-4b02-885a-58cee3fa2aa8.jpg?1",
             "name": "Troll-Horn Cameo",
             "text": "oc\nT: Add o\nR or o\nG to your mana pool.",
             "colours": [],
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "ce1fdecd-639d-5191-9158-1561d66de3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee69f8-cceb-41b9-a0ee-6b2ac9f4bad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee69f8-cceb-41b9-a0ee-6b2ac9f4bad9.jpg?1",
             "name": "Tsabo's Web",
             "text": "When Tsabo's Web comes into play, draw a card.\nLands with an activated ability that doesn't produce mana don't untap during their controllers' untap steps.",
             "colours": [],
@@ -11000,7 +11000,7 @@
         },
         {
             "id": "0d7dedbc-ef99-5e2e-b756-2e469f1331f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680c75b1-e766-40be-84d7-2332047bb3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680c75b1-e766-40be-84d7-2332047bb3de.jpg?1",
             "name": "Urza's Filter",
             "text": "Multicolored spells cost up to o2 less to play.",
             "colours": [],
@@ -11028,7 +11028,7 @@
         },
         {
             "id": "f0731bdc-7aa9-573f-b0f9-dcbb56f2a9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004eefa4-947b-45fc-b45c-5263bfd763bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004eefa4-947b-45fc-b45c-5263bfd763bc.jpg?1",
             "name": "Ancient Spring",
             "text": "Ancient Spring comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Ancient Spring: Add o\nWo\nB to your mana pool.",
             "colours": [],
@@ -11060,7 +11060,7 @@
         },
         {
             "id": "6621f943-df23-554e-addb-19248fb135c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f55af0-5a46-4900-b3d0-ca796b710e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f55af0-5a46-4900-b3d0-ca796b710e07.jpg?1",
             "name": "Archaeological Dig",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Archaeological Dig: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -11088,7 +11088,7 @@
         },
         {
             "id": "690a4cdc-74ca-5e46-bba4-db98275948ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d115dbff-e35b-495f-a1e3-19651895927e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d115dbff-e35b-495f-a1e3-19651895927e.jpg?1",
             "name": "Coastal Tower",
             "text": "Coastal Tower comes into play tapped.\noc\nT: Add o\nW or o\nU to your mana pool.",
             "colours": [],
@@ -11119,7 +11119,7 @@
         },
         {
             "id": "26f0932f-c2fe-558e-a169-3d9476d150fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65986555-a5d7-497e-876f-b8d967d6aa5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65986555-a5d7-497e-876f-b8d967d6aa5b.jpg?1",
             "name": "Elfhame Palace",
             "text": "Elfhame Palace comes into play tapped.\noc\nT: Add o\nG or o\nW to your mana pool.",
             "colours": [],
@@ -11150,7 +11150,7 @@
         },
         {
             "id": "c5647e00-0000-5c53-8326-ddf62d6d856b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744b593-13fe-4967-b492-ac02f5815e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744b593-13fe-4967-b492-ac02f5815e57.jpg?1",
             "name": "Geothermal Crevice",
             "text": "Geothermal Crevice comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Geothermal Crevice: Add o\nBo\nG to your mana pool.",
             "colours": [],
@@ -11182,7 +11182,7 @@
         },
         {
             "id": "f7118c50-5239-5cf9-9c3a-4665b1193310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f1b44-166c-4faf-8a7b-d431707e90ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f1b44-166c-4faf-8a7b-d431707e90ce.jpg?1",
             "name": "Irrigation Ditch",
             "text": "Irrigation Ditch comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Irrigation Ditch: Add o\nGo\nU to your mana pool.",
             "colours": [],
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "1aa1d14d-6dd5-53f0-9afc-8f73b0b11cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0cccf6-b79b-4fff-89aa-801341598532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0cccf6-b79b-4fff-89aa-801341598532.jpg?1",
             "name": "Keldon Necropolis",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no4o\nR, oc\nT, Sacrifice a creature: Keldon Necropolis deals 2 damage to target creature or player.",
             "colours": [],
@@ -11246,7 +11246,7 @@
         },
         {
             "id": "b625f84b-4311-5bf1-b322-923ad0a6b3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed64934b-0e64-4b2f-97aa-c3fb7e6ce0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed64934b-0e64-4b2f-97aa-c3fb7e6ce0b0.jpg?1",
             "name": "Salt Marsh",
             "text": "Salt Marsh comes into play tapped.\noc\nT: Add o\nU or o\nB to your mana pool.",
             "colours": [],
@@ -11277,7 +11277,7 @@
         },
         {
             "id": "7a50bb98-2817-5c7c-ba99-b6aa52a59b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9841f7e8-162c-44a3-96f3-af944fce15d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9841f7e8-162c-44a3-96f3-af944fce15d1.jpg?1",
             "name": "Shivan Oasis",
             "text": "Shivan Oasis comes into play tapped.\noc\nT: Add o\nR or o\nG to your mana pool.",
             "colours": [],
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "2c5574f1-0a2f-5166-9838-0252f4c4ddaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c66ed6-55fb-4c65-aac4-26d9cc3053b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c66ed6-55fb-4c65-aac4-26d9cc3053b8.jpg?1",
             "name": "Sulfur Vent",
             "text": "Sulfur Vent comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Sulfur Vent: Add o\nUo\nR to your mana pool.",
             "colours": [],
@@ -11340,7 +11340,7 @@
         },
         {
             "id": "49d78aa3-d60e-580d-b17d-91e9a2b1e584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b5901-aeb0-4a48-8c53-3b0ec0e0deba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b5901-aeb0-4a48-8c53-3b0ec0e0deba.jpg?1",
             "name": "Tinder Farm",
             "text": "Tinder Farm comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Tinder Farm: Add o\nRo\nW to your mana pool.",
             "colours": [],
@@ -11372,7 +11372,7 @@
         },
         {
             "id": "345dfcdd-8f08-5bc4-9cee-fb2206c90967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76f346c-ae34-4f5f-8e3b-6c77b0c4d530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76f346c-ae34-4f5f-8e3b-6c77b0c4d530.jpg?1",
             "name": "Urborg Volcano",
             "text": "Urborg Volcano comes into play tapped.\noc\nT: Add o\nB or o\nR to your mana pool.",
             "colours": [],
@@ -11403,7 +11403,7 @@
         },
         {
             "id": "fa297738-0842-56f0-aeec-14198e170cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba9ef2e-d3ec-41f7-802e-e1414f14dd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba9ef2e-d3ec-41f7-802e-e1414f14dd10.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11441,7 +11441,7 @@
         },
         {
             "id": "288a2e5f-7f6e-57bd-9019-efcb8669fa0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73d7ff-bbef-4df9-ae7f-aa2ac8ac7025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73d7ff-bbef-4df9-ae7f-aa2ac8ac7025.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11479,7 +11479,7 @@
         },
         {
             "id": "32392b7b-a27f-5099-88ce-1aebe05dc1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a66868-2efa-4985-b4fc-405d7fa8d410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a66868-2efa-4985-b4fc-405d7fa8d410.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11517,7 +11517,7 @@
         },
         {
             "id": "08a06a68-cf93-5948-8867-cdfc9bdd7ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4963b-c706-439f-9800-ff5d70003dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4963b-c706-439f-9800-ff5d70003dcf.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11555,7 +11555,7 @@
         },
         {
             "id": "aa3c2c3b-9211-51e6-9e1c-067d95abba2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3fc29c-f5cb-49b9-aabf-a5fef97e7a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3fc29c-f5cb-49b9-aabf-a5fef97e7a7e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11593,7 +11593,7 @@
         },
         {
             "id": "6c4c7c1a-5b2d-586e-8725-adc242cd63ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc04e1e-6a14-41cc-9fff-6dcd92cc6a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc04e1e-6a14-41cc-9fff-6dcd92cc6a3b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11631,7 +11631,7 @@
         },
         {
             "id": "77dd338f-de06-52e9-9cca-d02dee0f1113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f849f726-c6a2-400d-9b90-fe050f8ef5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f849f726-c6a2-400d-9b90-fe050f8ef5eb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11669,7 +11669,7 @@
         },
         {
             "id": "fd39852e-488e-5a26-8a1f-ec77689f4e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07d1982-56ff-47ef-87aa-62978f1fcf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07d1982-56ff-47ef-87aa-62978f1fcf30.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11707,7 +11707,7 @@
         },
         {
             "id": "8bf0ad54-3d61-5121-ba09-208f68f986fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7ce037-e04d-404a-afde-9122518e6a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7ce037-e04d-404a-afde-9122518e6a31.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11745,7 +11745,7 @@
         },
         {
             "id": "db4cf100-f94f-5d21-9c52-8ec1834a3dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8b9d-2573-4162-9255-50a281dfb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8b9d-2573-4162-9255-50a281dfb775.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "7d0ce87e-b3d4-5f0c-8c13-6bd459b592f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2bba7-8889-460c-a18f-fcd1e350ef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2bba7-8889-460c-a18f-fcd1e350ef4e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11821,7 +11821,7 @@
         },
         {
             "id": "596f16b5-8dda-524c-9603-acf99b5b038e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a756b0-f430-4286-afe1-97c641e4f3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a756b0-f430-4286-afe1-97c641e4f3b4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "8ecd02fd-331e-55e0-b6b6-3fe195d4ab3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6694bb-f3b7-48ff-9d93-cbed84fac210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6694bb-f3b7-48ff-9d93-cbed84fac210.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11897,7 +11897,7 @@
         },
         {
             "id": "9a6f52e7-0fff-5a2b-a47b-b824bb1cf2b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977527da-2953-493f-8e8c-ffc64ddeaf10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977527da-2953-493f-8e8c-ffc64ddeaf10.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "72c802c9-7e14-5507-b557-ebc2a4f70719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68df89dc-3909-4051-adc1-a86589d0e99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68df89dc-3909-4051-adc1-a86589d0e99d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11973,7 +11973,7 @@
         },
         {
             "id": "3916c2ee-9698-5fe4-9d53-bb0a83eb8d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8ae541-98e2-4a84-90a6-b17502f4442d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8ae541-98e2-4a84-90a6-b17502f4442d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -12011,7 +12011,7 @@
         },
         {
             "id": "b1c6d4ef-8f7d-5735-9e5c-24afa0341a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82d0a1c-5812-4254-a000-e4ff9aece3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82d0a1c-5812-4254-a000-e4ff9aece3d9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "90bbb35f-73ad-5f91-8d7b-12835b49a28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24788990-42ff-4b2b-8d01-fa2d0ec66a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24788990-42ff-4b2b-8d01-fa2d0ec66a03.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -12087,7 +12087,7 @@
         },
         {
             "id": "6bffc76b-ecfb-50e0-a5ae-fc6581d9b750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b741c86-a563-4180-a857-7850de6ee366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b741c86-a563-4180-a857-7850de6ee366.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -12125,7 +12125,7 @@
         },
         {
             "id": "a0df9fb2-4e23-550a-b6e5-768ad873a6f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacc498-f089-4ae4-8ce8-697cc671f445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacc498-f089-4ae4-8ce8-697cc671f445.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/ISD.json
+++ b/Assets/Resources/Sets/ISD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1a077ae3-343a-57ab-acfa-0b13e431dc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87803b-e7c6-4122-add4-72e596167b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87803b-e7c6-4122-add4-72e596167b7e.jpg?1",
             "name": "Abbey Griffin",
             "text": "Flying, vigilance",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "ba8648ea-4e93-5fbb-a864-f00023e188ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfe629f-485c-4619-9713-32d2ae406e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfe629f-485c-4619-9713-32d2ae406e63.jpg?1",
             "name": "Angel of Flight Alabaster",
             "text": "Flying\nAt the beginning of your upkeep, return target Spirit card from your graveyard to your hand.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "35690667-41c7-5456-910d-08f20d3ce643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221d999c-dde1-4a0f-87cf-9e9f44969f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221d999c-dde1-4a0f-87cf-9e9f44969f94.jpg?1",
             "name": "Angelic Overseer",
             "text": "Flying\nAs long as you control a Human, Angelic Overseer has hexproof and is indestructible.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "63004079-b2bd-5797-a3e6-b7379f8f8138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a47828-a79a-4189-9eef-2a5fc5125b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a47828-a79a-4189-9eef-2a5fc5125b61.jpg?1",
             "name": "Avacynian Priest",
             "text": "{1}, {T}: Tap target non-Human creature.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "15214e71-3d36-52cf-bd42-a268420ef5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8d1ce0-78c5-4e97-9cca-33e7b6ff3440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8d1ce0-78c5-4e97-9cca-33e7b6ff3440.jpg?1",
             "name": "Bonds of Faith",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Human. Otherwise, it can't attack or block.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f7d2da7f-6c15-5a21-90b9-935f5e0eb2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7314414-c2d2-48ed-af2c-764cf0207c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7314414-c2d2-48ed-af2c-764cf0207c62.jpg?1",
             "name": "Champion of the Parish",
             "text": "Whenever another Human enters the battlefield under your control, put a +1/+1 counter on Champion of the Parish.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "0a49beff-7d7c-5809-b405-7e144d96164c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790cdf67-80d6-4ade-aecf-f77120b509b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790cdf67-80d6-4ade-aecf-f77120b509b0.jpg?1",
             "name": "Chapel Geist",
             "text": "Flying",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "eb91f1bf-734e-56a4-bb04-544b94889fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg?1",
             "name": "Cloistered Youth // Unholy Fiend",
             "text": "At the beginning of your upkeep, you may transform Cloistered Youth.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "ccab0ddd-6403-5ec4-a03c-e8a63bed55d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg?1",
             "name": "Cloistered Youth // Unholy Fiend",
             "text": "At the beginning of your end step, you lose 1 life.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "aa9eded6-a821-5e01-941b-95d0e138b336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008061f-cda4-4bcf-b6b3-d1b4a251cc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008061f-cda4-4bcf-b6b3-d1b4a251cc66.jpg?1",
             "name": "Dearly Departed",
             "text": "Flying\nAs long as Dearly Departed is in your graveyard, each Human creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "f68ee59c-d335-5d7a-84fe-b4fb5d7c67aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ea3a4-206a-4097-87c1-c04bb7812972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ea3a4-206a-4097-87c1-c04bb7812972.jpg?1",
             "name": "Divine Reckoning",
             "text": "Each player chooses a creature he or she controls. Destroy the rest.\nFlashback {5}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "ed0c9224-8216-5130-b505-0078009546b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652c3bbb-cac8-47ad-81de-41e954e17a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652c3bbb-cac8-47ad-81de-41e954e17a29.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "37f6953d-2b2b-59de-8897-d410f4981948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b9e51-fecd-4f9a-9354-a6dc1613feb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b9e51-fecd-4f9a-9354-a6dc1613feb3.jpg?1",
             "name": "Elder Cathar",
             "text": "When Elder Cathar dies, put a +1/+1 counter on target creature you control. If that creature is a Human, put two +1/+1 counters on it instead.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "fab06692-10f2-5db2-81ee-e4063ba71cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9411c44-92a8-4f5d-b3de-d80046649c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9411c44-92a8-4f5d-b3de-d80046649c8c.jpg?1",
             "name": "Elite Inquisitor",
             "text": "First strike, vigilance\nProtection from Vampires, from Werewolves, and from Zombies",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "ca800b48-8f28-5a9d-ab34-5b9c58952d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846a2f9e-ad4f-4666-b152-fdeab7559d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846a2f9e-ad4f-4666-b152-fdeab7559d86.jpg?1",
             "name": "Feeling of Dread",
             "text": "Tap up to two target creatures.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "f42979d6-cee0-5b71-8d57-6aba880bdd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4c7d8-11a5-40fe-962b-7e938bf08616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4c7d8-11a5-40fe-962b-7e938bf08616.jpg?1",
             "name": "Fiend Hunter",
             "text": "When Fiend Hunter enters the battlefield, you may exile another target creature.\nWhen Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "3204b2c9-576a-57d5-9d47-978d38522fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15947b20-8c8e-42ed-9599-8b180a382d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15947b20-8c8e-42ed-9599-8b180a382d21.jpg?1",
             "name": "Gallows Warden",
             "text": "Flying\nOther Spirit creatures you control get +0/+1.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "00f83362-5805-54fd-8e72-677a9c23d305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51355e-55fa-43bb-a5de-fc55ac7b6446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51355e-55fa-43bb-a5de-fc55ac7b6446.jpg?1",
             "name": "Geist-Honored Monk",
             "text": "Vigilance\nGeist-Honored Monk's power and toughness are each equal to the number of creatures you control.\nWhen Geist-Honored Monk enters the battlefield, put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "3c133cbd-4331-59e9-8eec-bbaaaf740e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f048d9-ca13-485d-ad92-de4695b7dc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f048d9-ca13-485d-ad92-de4695b7dc18.jpg?1",
             "name": "Ghostly Possession",
             "text": "Enchant creature\nEnchanted creature has flying.\nPrevent all combat damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "1953c8c6-ce8e-5634-bd66-22fff2a1a752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd21f5e-d284-4072-87b9-7f0e6140fe60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd21f5e-d284-4072-87b9-7f0e6140fe60.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "7d3b740e-6199-522a-90ac-836f331ed6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b19de-96a6-4590-bfc3-31b0c7b2e25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b19de-96a6-4590-bfc3-31b0c7b2e25e.jpg?1",
             "name": "Mausoleum Guard",
             "text": "When Mausoleum Guard dies, put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -723,7 +723,7 @@
         },
         {
             "id": "7ba22fb3-08c1-5220-a79d-d78a10d17ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8f179a-f6ab-4d4c-8195-ed077a7770d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8f179a-f6ab-4d4c-8195-ed077a7770d3.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -758,7 +758,7 @@
         },
         {
             "id": "18f51323-7a84-59a1-b4bc-e5a1a2adc3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1eb098-7128-4ec8-8218-51fdde3e8326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1eb098-7128-4ec8-8218-51fdde3e8326.jpg?1",
             "name": "Midnight Haunting",
             "text": "Put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -790,7 +790,7 @@
         },
         {
             "id": "7bcfe418-879d-5b24-8211-8ef4fa2a0f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22dc283-ea54-4344-b1ca-fd6cc05080d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22dc283-ea54-4344-b1ca-fd6cc05080d9.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -827,7 +827,7 @@
         },
         {
             "id": "bcf39801-5fbc-5faf-89be-b9538389ca36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8d15bc-889d-4fd0-9688-00e22db30036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8d15bc-889d-4fd0-9688-00e22db30036.jpg?1",
             "name": "Moment of Heroism",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "635e92f3-4179-5244-8627-e222e48b7170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b610fe-36ee-4d58-8ed4-04e7a12587b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b610fe-36ee-4d58-8ed4-04e7a12587b2.jpg?1",
             "name": "Nevermore",
             "text": "As Nevermore enters the battlefield, name a nonland card.\nThe named card can't be cast.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "e940c646-696c-5600-9b60-8fa97193ed1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406380ab-2695-4084-99a5-f5560304f8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406380ab-2695-4084-99a5-f5560304f8cb.jpg?1",
             "name": "Paraselene",
             "text": "Destroy all enchantments. You gain 1 life for each enchantment destroyed this way.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "89d2a8a7-7c07-5f75-803f-13ee92df148d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf39365-e468-46ac-bb5b-7f43faa19458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf39365-e468-46ac-bb5b-7f43faa19458.jpg?1",
             "name": "Purify the Grave",
             "text": "Exile target card from a graveyard.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "771a0638-8c17-5867-97a6-4a969f75b366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514fe7de-16b2-42c0-adb1-f0af1c89cfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514fe7de-16b2-42c0-adb1-f0af1c89cfd6.jpg?1",
             "name": "Rally the Peasants",
             "text": "Creatures you control get +2/+0 until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "05083315-739f-5370-ab69-7383fc655998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267185ac-a176-423e-a7f8-ee966d1d9a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267185ac-a176-423e-a7f8-ee966d1d9a1e.jpg?1",
             "name": "Rebuke",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "ea2eed7c-f377-5423-88da-4a662335a1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1dc067-1972-4d46-ad5d-56e6a563f638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1dc067-1972-4d46-ad5d-56e6a563f638.jpg?1",
             "name": "Selfless Cathar",
             "text": "{1}{W}, Sacrifice Selfless Cathar: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "c6e08592-0eee-571f-8f89-0f01326c61e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a81bfab-3397-4562-8b82-5f24cef167e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a81bfab-3397-4562-8b82-5f24cef167e3.jpg?1",
             "name": "Silverchase Fox",
             "text": "{1}{W}, Sacrifice Silverchase Fox: Exile target enchantment.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "a8f8640c-186e-5d19-a49e-4aabfb4cc965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2cd68e-ff4c-49c7-ba0d-f2299d9c21f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2cd68e-ff4c-49c7-ba0d-f2299d9c21f4.jpg?1",
             "name": "Slayer of the Wicked",
             "text": "When Slayer of the Wicked enters the battlefield, you may destroy target Vampire, Werewolf, or Zombie.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "07e96493-9c17-55c9-ba27-8575580f2c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0103f3b1-88c2-4cbf-a67c-49420f92970f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0103f3b1-88c2-4cbf-a67c-49420f92970f.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "9313aa66-9ad0-52fe-9b0f-fb8f839c7ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01b5d97-b5ae-42a7-944a-feb12febd63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01b5d97-b5ae-42a7-944a-feb12febd63c.jpg?1",
             "name": "Spare from Evil",
             "text": "Creatures you control gain protection from non-Human creatures until end of turn.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "cad6031e-8a79-5691-936e-914fac7abfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e4e56-8bde-480d-b59c-17a017665b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e4e56-8bde-480d-b59c-17a017665b19.jpg?1",
             "name": "Spectral Rider",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "5758f73d-3642-572a-8818-7fa2b8016014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56a5a73-5f10-4f97-989f-7cea0a8d95e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56a5a73-5f10-4f97-989f-7cea0a8d95e3.jpg?1",
             "name": "Stony Silence",
             "text": "Activated abilities of artifacts can't be activated.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "b4a6efd2-6a14-5ceb-9188-bb04c4ab17ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db28f4-3d96-42f5-a264-592fdc2d4196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db28f4-3d96-42f5-a264-592fdc2d4196.jpg?1",
             "name": "Thraben Purebloods",
             "text": "",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "f33004f5-507c-5e10-b22a-64e2a6d2da90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg?1",
             "name": "Thraben Sentry // Thraben Militia",
             "text": "Vigilance\nWhenever another creature you control dies, you may transform Thraben Sentry.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "2f2c2e6a-01e3-5f19-8f63-16f71d4cd9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg?1",
             "name": "Thraben Sentry // Thraben Militia",
             "text": "Trample",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "baf120ca-66cf-50b8-b18d-dc9f6bf97950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491c6e40-151a-4efd-980c-e6b6a1057c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491c6e40-151a-4efd-980c-e6b6a1057c58.jpg?1",
             "name": "Unruly Mob",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Unruly Mob.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "d204849c-a646-545a-be15-f5c110f6a855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a437c-a2ee-43c6-876c-1a63a455c97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a437c-a2ee-43c6-876c-1a63a455c97c.jpg?1",
             "name": "Urgent Exorcism",
             "text": "Destroy target Spirit or enchantment.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "fe1a6c65-49ea-5397-8ca9-8f95f93c1cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6912b3-bab9-4937-afdd-3711e6d792a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6912b3-bab9-4937-afdd-3711e6d792a0.jpg?1",
             "name": "Village Bell-Ringer",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Village Bell-Ringer enters the battlefield, untap all creatures you control.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "ae78c49c-290b-5104-ba95-6029471224c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d9bd7-5721-4436-a86f-35e376727f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d9bd7-5721-4436-a86f-35e376727f46.jpg?1",
             "name": "Voiceless Spirit",
             "text": "Flying, first strike",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "d5c55822-3121-5d64-8ab4-765eea73ff17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4d00f2-30e6-41d5-b997-c66350fe783c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4d00f2-30e6-41d5-b997-c66350fe783c.jpg?1",
             "name": "Armored Skaab",
             "text": "When Armored Skaab enters the battlefield, put the top four cards of your library into your graveyard.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "27690860-adeb-56e9-a45b-ca1faca6b002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bba140-5c06-4542-9ae0-b2517104ab7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bba140-5c06-4542-9ae0-b2517104ab7c.jpg?1",
             "name": "Back from the Brink",
             "text": "Exile a creature card from your graveyard and pay its mana cost: Put a token onto the battlefield that's a copy of that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "4483f334-324e-5fdb-a707-92ae879d1346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129905ef-5b3b-4860-923c-109a7d7cad80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129905ef-5b3b-4860-923c-109a7d7cad80.jpg?1",
             "name": "Battleground Geist",
             "text": "Flying\nOther Spirit creatures you control get +1/+0.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "943f0833-6bfa-5b59-a7e4-89df1883f370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a2b93-94dc-4285-a6fd-455a796426bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a2b93-94dc-4285-a6fd-455a796426bc.jpg?1",
             "name": "Cackling Counterpart",
             "text": "Put a token onto the battlefield that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1627,7 +1627,7 @@
         },
         {
             "id": "8bdfb070-3dc7-5199-93eb-ba458a84eb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg?1",
             "name": "Civilized Scholar // Homicidal Brute",
             "text": "{T}: Draw a card, then discard a card. If a creature card is discarded this way, untap Civilized Scholar, then transform it.",
             "colours": [
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "a6c93bba-9e3e-5232-8f0c-a165ca3ff3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg?1",
             "name": "Civilized Scholar // Homicidal Brute",
             "text": "At the beginning of your end step, if Homicidal Brute didn't attack this turn, tap Homicidal Brute, then transform it.",
             "colours": [
@@ -1699,7 +1699,7 @@
         },
         {
             "id": "9059c584-4185-5f94-8880-14aa735cb7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e5f600-4d19-42a4-b57e-650c76041798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e5f600-4d19-42a4-b57e-650c76041798.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1733,7 +1733,7 @@
         },
         {
             "id": "ec51a706-8912-502e-8841-053b9aaa010e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b212c36a-6d1f-4217-b384-1c2b0e07b68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b212c36a-6d1f-4217-b384-1c2b0e07b68a.jpg?1",
             "name": "Curiosity",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "b64b5e28-51f0-597b-ab43-700956cd5bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7865e11-263b-4d61-af54-907c1acbb54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7865e11-263b-4d61-af54-907c1acbb54f.jpg?1",
             "name": "Curse of the Bloody Tome",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1802,7 +1802,7 @@
         },
         {
             "id": "88d06769-564f-5474-a0a4-50b95b409224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform Delver of Secrets.",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "ba2cd594-ce42-589e-b166-5509ab0cd60f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "Flying",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "e719e615-91fc-5811-9ca5-543cd47daa22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c03171-5ff0-4f79-bb03-16decf7d34ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c03171-5ff0-4f79-bb03-16decf7d34ce.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Put the top card of your library into your graveyard: Add {1} to your mana pool.",
             "colours": [
@@ -1907,7 +1907,7 @@
         },
         {
             "id": "98ffe750-2e11-5d75-a601-1426d3eca3f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778082-bcdb-423a-b16f-57ac0d4dace7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778082-bcdb-423a-b16f-57ac0d4dace7.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1939,7 +1939,7 @@
         },
         {
             "id": "ee42fe61-c118-5681-b212-0c89aa328cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dd8790-bfdf-427d-8e8d-a5c3a64a3063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dd8790-bfdf-427d-8e8d-a5c3a64a3063.jpg?1",
             "name": "Dream Twist",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "41ff5992-98c0-5e76-97b4-c9c27f96e718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb22ae62-6207-4693-87cf-7adf0fc1fe29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb22ae62-6207-4693-87cf-7adf0fc1fe29.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "4623dded-8574-57be-bc66-5cbf7738fbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca16d4-089f-42a7-a648-55301a77faea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca16d4-089f-42a7-a648-55301a77faea.jpg?1",
             "name": "Fortress Crab",
             "text": "",
             "colours": [
@@ -2038,7 +2038,7 @@
         },
         {
             "id": "dc916d31-1be0-5662-a28a-b427dc225277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c9ba98-90b4-4c28-9eef-a4fe0913b921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c9ba98-90b4-4c28-9eef-a4fe0913b921.jpg?1",
             "name": "Frightful Delusion",
             "text": "Counter target spell unless its controller pays {1}. That player discards a card.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "ba4cf547-490c-5764-b927-f4e81b1ad3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02655d3d-82d0-4be6-bb64-25e1478edfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02655d3d-82d0-4be6-bb64-25e1478edfc3.jpg?1",
             "name": "Grasp of Phantoms",
             "text": "Put target creature on top of its owner's library.\nFlashback {7}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "ec88d4a6-225b-558d-b0d6-80e8f362c499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeaa757-e3b0-4606-a689-e8a20a686c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeaa757-e3b0-4606-a689-e8a20a686c3a.jpg?1",
             "name": "Hysterical Blindness",
             "text": "Creatures your opponents control get -4/-0 until end of turn.",
             "colours": [
@@ -2134,7 +2134,7 @@
         },
         {
             "id": "f8dded67-7714-5d36-a8ea-26ee0677c97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1",
             "name": "Invisible Stalker",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nInvisible Stalker is unblockable.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "b006bae5-a67f-571b-80c4-d63a9fcf2724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg?1",
             "name": "Laboratory Maniac",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "151da55d-1574-5643-a9f2-58f29a9ea4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50a5772-f411-458a-97f9-9f3967bb79c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50a5772-f411-458a-97f9-9f3967bb79c5.jpg?1",
             "name": "Lantern Spirit",
             "text": "Flying\n{U}: Return Lantern Spirit to its owner's hand.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "2406cbe2-1efc-5ea5-8c30-da2864ae87a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5fc39d-590a-436b-ab90-a1741d2ae3da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5fc39d-590a-436b-ab90-a1741d2ae3da.jpg?1",
             "name": "Lost in the Mist",
             "text": "Counter target spell. Return target permanent to its owner's hand.",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "43140b4f-aa7f-5ef5-b27a-488dcb0c76a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg?1",
             "name": "Ludevic's Test Subject // Ludevic's Abomination",
             "text": "Defender\n{1}{U}: Put a hatchling counter on Ludevic's Test Subject. Then if there are five or more hatchling counters on it, remove all of them and transform it.",
             "colours": [
@@ -2305,7 +2305,7 @@
         },
         {
             "id": "f56b147e-e593-59a9-9585-385d51419dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg?1",
             "name": "Ludevic's Test Subject // Ludevic's Abomination",
             "text": "Trample",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "dc198743-15bb-5fcc-954e-c6d6409cc0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d869de57-9454-47ff-af14-eaefd387047a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d869de57-9454-47ff-af14-eaefd387047a.jpg?1",
             "name": "Makeshift Mauler",
             "text": "As an additional cost to cast Makeshift Mauler, exile a creature card from your graveyard.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "cdd140b4-b5e7-5c0a-a93d-36e39a995fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aaa73-1a1e-4282-a860-f7c422f21db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aaa73-1a1e-4282-a860-f7c422f21db3.jpg?1",
             "name": "Memory's Journey",
             "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "d348c1b2-3c49-5a52-a006-a1ce66ab8314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1e52af-6746-4ec6-afbf-008594c874f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1e52af-6746-4ec6-afbf-008594c874f8.jpg?1",
             "name": "Mindshrieker",
             "text": "Flying\n{2}: Target player puts the top card of his or her library into his or her graveyard. Mindshrieker gets +X/+X until end of turn, where X is that card's converted mana cost.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "b878cb7f-df20-5c10-ab89-0eabb7521f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eea41-9daf-4ac1-8bad-bb4aa211bb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eea41-9daf-4ac1-8bad-bb4aa211bb53.jpg?1",
             "name": "Mirror-Mad Phantasm",
             "text": "Flying\n{1}{U}: Mirror-Mad Phantasm's owner shuffles it into his or her library. If that player does, he or she reveals cards from the top of that library until a card named Mirror-Mad Phantasm is revealed. The player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "b53ac8ce-56e5-55ff-8cb1-c96dddf1c67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24de601-1d7b-41c4-aba1-fdb6fd8d5251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24de601-1d7b-41c4-aba1-fdb6fd8d5251.jpg?1",
             "name": "Moon Heron",
             "text": "Flying",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "0b2a9217-c3be-5426-afc0-eeac3b90c371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f914f7e4-06fc-4943-8597-b7f834938c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f914f7e4-06fc-4943-8597-b7f834938c00.jpg?1",
             "name": "Murder of Crows",
             "text": "Flying\nWhenever another creature dies, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2546,7 +2546,7 @@
         },
         {
             "id": "f0158766-07e4-5c03-afcd-10f6d13ea979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab01d871-ba50-400a-95e7-09af9e34405f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab01d871-ba50-400a-95e7-09af9e34405f.jpg?1",
             "name": "Rooftop Storm",
             "text": "You may pay {0} rather than pay the mana cost for Zombie creature spells you cast.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "443229b8-62eb-552f-ada3-be75e0aebca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e47ba6-3a55-41b4-b8fe-580041669408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e47ba6-3a55-41b4-b8fe-580041669408.jpg?1",
             "name": "Runic Repetition",
             "text": "Return target exiled card with flashback you own to your hand.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "a272f431-fb39-551b-a5aa-fd32b9778631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeac4885-bd04-42bd-8e10-06c3efbce108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeac4885-bd04-42bd-8e10-06c3efbce108.jpg?1",
             "name": "Selhoff Occultist",
             "text": "Whenever Selhoff Occultist or another creature dies, target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "3f8a7b6e-4981-5adf-941c-e002b6ad26f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454739db-a3d6-45e8-849a-287438c36627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454739db-a3d6-45e8-849a-287438c36627.jpg?1",
             "name": "Sensory Deprivation",
             "text": "Enchant creature\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "06a2c1b0-53d8-52a0-880e-3dcefc7f6bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18dea16-d535-4310-94ff-836645253d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18dea16-d535-4310-94ff-836645253d73.jpg?1",
             "name": "Silent Departure",
             "text": "Return target creature to its owner's hand.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "271a12c9-9433-54a4-9681-ecdf7bb7ec59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg?1",
             "name": "Skaab Goliath",
             "text": "As an additional cost to cast Skaab Goliath, exile two creature cards from your graveyard.\nTrample",
             "colours": [
@@ -2746,7 +2746,7 @@
         },
         {
             "id": "6dd09f44-0099-5243-b74c-907b4e40adb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c40cdc-a11a-47df-b902-d8fbe9014d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c40cdc-a11a-47df-b902-d8fbe9014d03.jpg?1",
             "name": "Skaab Ruinator",
             "text": "As an additional cost to cast Skaab Ruinator, exile three creature cards from your graveyard.\nFlying\nYou may cast Skaab Ruinator from your graveyard.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "00ae2026-8987-569e-afa8-726e1a65fad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b279e-4670-4a1e-87d0-3cab7e4f9e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b279e-4670-4a1e-87d0-3cab7e4f9e58.jpg?1",
             "name": "Snapcaster Mage",
             "text": "Flash\nWhen Snapcaster Mage enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "6bcd6f69-aa1d-52c3-a9cf-037c4b05eed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7149f2a-6917-4ad7-8035-c7a1babd4d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7149f2a-6917-4ad7-8035-c7a1babd4d4b.jpg?1",
             "name": "Spectral Flight",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2850,7 +2850,7 @@
         },
         {
             "id": "214ad2d5-64c2-5012-bb00-201e48510186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad81266a-488f-449a-9daf-637727564865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad81266a-488f-449a-9daf-637727564865.jpg?1",
             "name": "Stitched Drake",
             "text": "As an additional cost to cast Stitched Drake, exile a creature card from your graveyard.\nFlying",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "28236fed-0318-5d2f-a20b-0a1910c7d907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fcc53-cd0b-4b4c-b6de-5d301232106a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fcc53-cd0b-4b4c-b6de-5d301232106a.jpg?1",
             "name": "Stitcher's Apprentice",
             "text": "{1}{U}, {T}: Put a 2/2 blue Homunculus creature token onto the battlefield, then sacrifice a creature.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "a090eef1-8ee7-511d-b6d9-401ee2cc0f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c409d1d0-fc45-40bf-adac-83b680209a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c409d1d0-fc45-40bf-adac-83b680209a38.jpg?1",
             "name": "Sturmgeist",
             "text": "Flying\nSturmgeist's power and toughness are each equal to the number of cards in your hand.\nWhenever Sturmgeist deals combat damage to a player, draw a card.",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "096299f9-864f-5c66-ae91-3da67ac1228f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e44060-a9a2-4095-9f5b-f60297525315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e44060-a9a2-4095-9f5b-f60297525315.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "01aa9a14-1daf-5555-872c-1f71e93fb2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f4592-6c81-43ac-8975-f6d5d6710310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f4592-6c81-43ac-8975-f6d5d6710310.jpg?1",
             "name": "Undead Alchemist",
             "text": "If a Zombie you control would deal combat damage to a player, instead that player puts that many cards from the top of his or her library into his or her graveyard.\nWhenever a creature card is put into an opponent's graveyard from his or her library, exile that card and put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "c10fb040-85d0-53ae-b78e-4dcca2a41921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0906-04fa-4b30-a7a6-3d117931154f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0906-04fa-4b30-a7a6-3d117931154f.jpg?1",
             "name": "Abattoir Ghoul",
             "text": "First strike\nWhenever a creature dealt damage by Abattoir Ghoul this turn dies, you gain life equal to that creature's toughness.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "fd6423d6-8d9a-54e4-bec3-5b5b2516a0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2eec4-7e68-45d5-8736-6b32a47c671b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2eec4-7e68-45d5-8736-6b32a47c671b.jpg?1",
             "name": "Altar's Reap",
             "text": "As an additional cost to cast Altar's Reap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "ed93ff62-7df9-5dd9-b990-2616998638c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260a4544-a1eb-4d07-943f-0401ae288e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260a4544-a1eb-4d07-943f-0401ae288e13.jpg?1",
             "name": "Army of the Damned",
             "text": "Put thirteen 2/2 black Zombie creature tokens onto the battlefield tapped.\nFlashback {7}{B}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "d7ff9c20-5971-5832-b3c9-715992841783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ff2b4-8f40-42c0-af3c-b55bfa8839be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ff2b4-8f40-42c0-af3c-b55bfa8839be.jpg?1",
             "name": "Bitterheart Witch",
             "text": "Deathtouch\nWhen Bitterheart Witch dies, you may search your library for a Curse card, put it onto the battlefield attached to target player, then shuffle your library.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "f72da99c-ac8e-5f00-ba2b-40932124da47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271addb-e267-4397-b181-f1eaeabbfe71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271addb-e267-4397-b181-f1eaeabbfe71.jpg?1",
             "name": "Bloodgift Demon",
             "text": "Flying\nAt the beginning of your upkeep, target player draws a card and loses 1 life.",
             "colours": [
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "1c12ea60-ce46-594e-a588-cfe5b2ef44b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "Flying\n{T}: Put a 2/2 black Vampire creature token with flying onto the battlefield.\n{B}: Transform Bloodline Keeper. Activate this ability only if you control five or more Vampires.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "27453e61-7297-57fb-b0fe-e43557e96607",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "Flying\nOther Vampire creatures you control get +2/+2.\n{T}: Put a 2/2 black Vampire creature token with flying onto the battlefield.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "46e738d0-b7f7-58c1-b5f0-070de44c5fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1bd88-939a-4adc-8693-210a7ba9a5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1bd88-939a-4adc-8693-210a7ba9a5a1.jpg?1",
             "name": "Brain Weevil",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nSacrifice Brain Weevil: Target player discards two cards. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "5e1d407d-06ba-5c75-8bc8-36890f41b9f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3ec389-a267-484f-994d-4a29ef494eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3ec389-a267-484f-994d-4a29ef494eb1.jpg?1",
             "name": "Bump in the Night",
             "text": "Target opponent loses 3 life.\nFlashback {5}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "16cbff86-dd33-5cea-9df2-af3acb681ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a74b987-527a-4560-a018-19d6bdf7e8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a74b987-527a-4560-a018-19d6bdf7e8b7.jpg?1",
             "name": "Corpse Lunge",
             "text": "As an additional cost to cast Corpse Lunge, exile a creature card from your graveyard.\nCorpse Lunge deals damage equal to the exiled card's power to target creature.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "e7fd5543-5774-5a62-809d-7e0fc5d429ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774d0a8-1cd3-4582-ace0-1caff92af0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774d0a8-1cd3-4582-ace0-1caff92af0e7.jpg?1",
             "name": "Curse of Death's Hold",
             "text": "Enchant player\nCreatures enchanted player controls get -1/-1.",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "e90d0843-520b-5815-ba5a-d9fb22a689f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15cbd2f-8bbf-423a-81fe-521fd99bc8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15cbd2f-8bbf-423a-81fe-521fd99bc8bf.jpg?1",
             "name": "Curse of Oblivion",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player exiles two cards from his or her graveyard.",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "dcb5376b-9211-5788-9f87-2eb88e97dce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7933987e-7b8c-4d5a-804a-708d6bb6d231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7933987e-7b8c-4d5a-804a-708d6bb6d231.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "ffc1accf-0302-50bd-b3fe-fb30c1c98cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed5790a-3354-49c2-89b6-3fc0de8dcc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed5790a-3354-49c2-89b6-3fc0de8dcc7c.jpg?1",
             "name": "Diregraf Ghoul",
             "text": "Diregraf Ghoul enters the battlefield tapped.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "ffac58b6-08b8-5f4e-b184-d11bc69e5797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4acaa1-7d99-41ce-81ce-f6aef3e4dc1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4acaa1-7d99-41ce-81ce-f6aef3e4dc1d.jpg?1",
             "name": "Disciple of Griselbrand",
             "text": "{1}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "8d382fa4-f010-5c7f-8f83-6d39a1f67a52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db15c5f-80b7-4f7f-985a-9bbec3199ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db15c5f-80b7-4f7f-985a-9bbec3199ad9.jpg?1",
             "name": "Endless Ranks of the Dead",
             "text": "At the beginning of your upkeep, put X 2/2 black Zombie creature tokens onto the battlefield, where X is half the number of Zombies you control, rounded down.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "f96bfb2d-cf71-5487-b798-f29ed821e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2286f94-4cf9-4462-b5d7-cee7f6910018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2286f94-4cf9-4462-b5d7-cee7f6910018.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3593,7 +3593,7 @@
         },
         {
             "id": "2f34e74a-8773-56b0-871e-184339503df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8c1b10-2155-404a-8f20-eb8f643849d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8c1b10-2155-404a-8f20-eb8f643849d6.jpg?1",
             "name": "Ghoulcaller's Chant",
             "text": "Choose one \u2014 Return target creature card from your graveyard to your hand; or return two target Zombie cards from your graveyard to your hand.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "32be090b-2acc-5061-9523-7d42ccbb1e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c537d1-2d57-4a87-9dac-594d40d95633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c537d1-2d57-4a87-9dac-594d40d95633.jpg?1",
             "name": "Ghoulraiser",
             "text": "When Ghoulraiser enters the battlefield, return a Zombie card at random from your graveyard to your hand.",
             "colours": [
@@ -3659,7 +3659,7 @@
         },
         {
             "id": "3182195e-83a0-526c-bab1-20ed987bb477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5696db03-206f-4e7e-9b65-ccef31bfd7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5696db03-206f-4e7e-9b65-ccef31bfd7d2.jpg?1",
             "name": "Gruesome Deformity",
             "text": "Enchant creature\nEnchanted creature has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "af0a2bbf-520e-53bd-b998-79647dc29e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8f638-b7fc-4e38-8623-ce7d2ebc82e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8f638-b7fc-4e38-8623-ce7d2ebc82e6.jpg?1",
             "name": "Heartless Summoning",
             "text": "Creature spells you cast cost {2} less to cast.\nCreatures you control get -1/-1.",
             "colours": [
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "fb346729-7d16-5e5b-993d-49b713b8ed06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac506c17-adc8-49c6-9d8d-43db7cb1ec9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac506c17-adc8-49c6-9d8d-43db7cb1ec9d.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n-2: Target player sacrifices a creature.\n-6: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of his or her choice.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "fa89e15a-4496-5144-beb7-f665ecc48376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b45197-d5c2-48c8-b72e-00236552e338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b45197-d5c2-48c8-b72e-00236552e338.jpg?1",
             "name": "Manor Skeleton",
             "text": "Haste\n{1}{B}: Regenerate Manor Skeleton.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "ebf0992e-90c5-524d-ab1a-0ef6d194a5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3d3f7-5e28-4fec-8422-87856fcd1e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3d3f7-5e28-4fec-8422-87856fcd1e8e.jpg?1",
             "name": "Markov Patrician",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "e4434970-f5ca-56f8-a19d-27ef4982a730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b34a03-3270-412c-90ca-03c1b3e61222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b34a03-3270-412c-90ca-03c1b3e61222.jpg?1",
             "name": "Maw of the Mire",
             "text": "Destroy target land. You gain 4 life.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "71884a86-1b60-549a-8b0d-52cf4030080d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5a8f-c03a-40ab-8390-ff6b5b654717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5a8f-c03a-40ab-8390-ff6b5b654717.jpg?1",
             "name": "Moan of the Unhallowed",
             "text": "Put two 2/2 black Zombie creature tokens onto the battlefield.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "f1ad4e26-b1e3-5e9a-ad10-2abf2ee0ac1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff9989f-77a3-4f73-ade6-c04306c98501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff9989f-77a3-4f73-ade6-c04306c98501.jpg?1",
             "name": "Morkrut Banshee",
             "text": "Morbid \u2014 When Morkrut Banshee enters the battlefield, if a creature died this turn, target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "7980c3c3-80f8-5f6b-bcb3-e87600175432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5091658c-0314-42ee-87d8-95d3f457c4ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5091658c-0314-42ee-87d8-95d3f457c4ab.jpg?1",
             "name": "Night Terrors",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. Exile that card.",
             "colours": [
@@ -3959,7 +3959,7 @@
         },
         {
             "id": "bf5545f5-f132-5b8e-b768-a5a688bdce80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d74c3e-8370-419b-808d-96b8d9306024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d74c3e-8370-419b-808d-96b8d9306024.jpg?1",
             "name": "Reaper from the Abyss",
             "text": "Flying\nMorbid \u2014 At the beginning of each end step, if a creature died this turn, destroy target non-Demon creature.",
             "colours": [
@@ -3993,7 +3993,7 @@
         },
         {
             "id": "bb4d590e-bfdd-599b-95e9-e5319d4574ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21cbb10-9157-4887-a752-29b9e94fc77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21cbb10-9157-4887-a752-29b9e94fc77a.jpg?1",
             "name": "Rotting Fensnake",
             "text": "",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "a9f8a44e-3551-5410-a569-effd4c440ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg?1",
             "name": "Screeching Bat // Stalking Vampire",
             "text": "Flying\nAt the beginning of your upkeep, you may pay {2}{B}{B}. If you do, transform Screeching Bat.",
             "colours": [
@@ -4062,7 +4062,7 @@
         },
         {
             "id": "a41f8938-eef7-5a30-a0a9-cb13174029f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg?1",
             "name": "Screeching Bat // Stalking Vampire",
             "text": "At the beginning of your upkeep, you may pay {2}{B}{B}. If you do, transform Stalking Vampire.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "f3052302-8cae-5b11-9208-ebe93536a793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6da820-dfb9-4b61-aff8-56dfc9f4894e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6da820-dfb9-4b61-aff8-56dfc9f4894e.jpg?1",
             "name": "Sever the Bloodline",
             "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "52fa72be-fac4-5c42-bd69-af59232c2709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b28f37-d6b8-4d35-95e9-9533aea0a071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b28f37-d6b8-4d35-95e9-9533aea0a071.jpg?1",
             "name": "Skeletal Grimace",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "7dd4e02c-6c50-563a-85e8-ebb68febeb70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa6b66-f69b-4f89-b802-e30c247f90e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa6b66-f69b-4f89-b802-e30c247f90e3.jpg?1",
             "name": "Skirsdag High Priest",
             "text": "Morbid \u2014 {T}, Tap two untapped creatures you control: Put a 5/5 black Demon creature token with flying onto the battlefield. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -4197,7 +4197,7 @@
         },
         {
             "id": "d06be91d-e6e7-5fec-bbfa-a3a0bca90dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86634a1-7016-4500-8857-924d51857bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86634a1-7016-4500-8857-924d51857bad.jpg?1",
             "name": "Stromkirk Patrol",
             "text": "Whenever Stromkirk Patrol deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4232,7 +4232,7 @@
         },
         {
             "id": "ba1322e2-797a-5e86-91d6-c19b8ee116ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e0f88-2285-4b59-9165-9948c75d77a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e0f88-2285-4b59-9165-9948c75d77a3.jpg?1",
             "name": "Tribute to Hunger",
             "text": "Target opponent sacrifices a creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -4264,7 +4264,7 @@
         },
         {
             "id": "668cad9d-70d2-57dc-8b5d-d890b932788a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4490ce65-c73a-4809-abd1-ccc3175bd2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4490ce65-c73a-4809-abd1-ccc3175bd2a4.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "01ec1605-7bdc-5e49-a157-8f51e41fb6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91ea47-0c06-4333-a309-ac360c5cc9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91ea47-0c06-4333-a309-ac360c5cc9bd.jpg?1",
             "name": "Unbreathing Horde",
             "text": "Unbreathing Horde enters the battlefield with a +1/+1 counter on it for each other Zombie you control and each Zombie card in your graveyard.\nIf Unbreathing Horde would be dealt damage, prevent that damage and remove a +1/+1 counter from it.",
             "colours": [
@@ -4332,7 +4332,7 @@
         },
         {
             "id": "9b549ebe-fc73-53aa-b167-a4eb51e1ec87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794c82b-e5ce-4369-894e-bf56c6402ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794c82b-e5ce-4369-894e-bf56c6402ae1.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "d13f2b59-b0e0-584a-9168-c6f9128f8695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48105c2e-ee36-4117-b56b-3440298da995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48105c2e-ee36-4117-b56b-3440298da995.jpg?1",
             "name": "Vampire Interloper",
             "text": "Flying\nVampire Interloper can't block.",
             "colours": [
@@ -4400,7 +4400,7 @@
         },
         {
             "id": "dea2f57b-9c5a-528a-a7e5-48da498c08bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4c6135-eee9-43ec-bbe8-76912352dcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4c6135-eee9-43ec-bbe8-76912352dcac.jpg?1",
             "name": "Victim of Night",
             "text": "Destroy target non-Vampire, non-Werewolf, non-Zombie creature.",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "3356cd31-2500-5483-bb5e-e85505d8fdb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5400460-da9d-437b-bb81-cf382beb371e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5400460-da9d-437b-bb81-cf382beb371e.jpg?1",
             "name": "Village Cannibals",
             "text": "Whenever another Human creature dies, put a +1/+1 counter on Village Cannibals.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "2ec59d3a-daa3-587e-a102-cb25ad5a8b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e033384-3334-4082-9541-f2443d3bc424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e033384-3334-4082-9541-f2443d3bc424.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -4500,7 +4500,7 @@
         },
         {
             "id": "3e84c735-5599-58a6-8691-d67bc79a4467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e7b966-7c5b-44e6-a6df-4bd7af4edaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e7b966-7c5b-44e6-a6df-4bd7af4edaa9.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "c5ad8418-0ca8-5373-b73c-f00ba2031128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900ff07e-e5d2-4fe6-ad1a-d0d7e1a272ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900ff07e-e5d2-4fe6-ad1a-d0d7e1a272ea.jpg?1",
             "name": "Ashmouth Hound",
             "text": "Whenever Ashmouth Hound blocks or becomes blocked by a creature, Ashmouth Hound deals 1 damage to that creature.",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "4bd792c7-fa65-5a48-94c1-5d348e881f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dce4ac-f472-4f3b-b01a-eff0902a578f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dce4ac-f472-4f3b-b01a-eff0902a578f.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "c4ee8111-7247-502e-9c8a-e82593e0ebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509ce648-fb76-486d-8b39-183e368b7cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509ce648-fb76-486d-8b39-183e368b7cb7.jpg?1",
             "name": "Blasphemous Act",
             "text": "Blasphemous Act costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -4634,7 +4634,7 @@
         },
         {
             "id": "685abfe5-b100-5653-9ab1-fdc7ea6e6d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2452e-309d-44ae-9360-9d6e22a15e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2452e-309d-44ae-9360-9d6e22a15e2b.jpg?1",
             "name": "Bloodcrazed Neonate",
             "text": "Bloodcrazed Neonate attacks each turn if able.\nWhenever Bloodcrazed Neonate deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "0bc593fa-d23d-5399-9281-36bf68b74cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6960f2da-6b84-4680-8ab2-f0567a5d1b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6960f2da-6b84-4680-8ab2-f0567a5d1b0a.jpg?1",
             "name": "Brimstone Volley",
             "text": "Brimstone Volley deals 3 damage to target creature or player.\nMorbid \u2014 Brimstone Volley deals 5 damage to that creature or player instead if a creature died this turn.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "00f89f38-6490-5806-b3f0-cf36d2cd8bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd403810-840b-46ac-ae6e-5df23ce16fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd403810-840b-46ac-ae6e-5df23ce16fec.jpg?1",
             "name": "Burning Vengeance",
             "text": "Whenever you cast a spell from your graveyard, Burning Vengeance deals 2 damage to target creature or player.",
             "colours": [
@@ -4732,7 +4732,7 @@
         },
         {
             "id": "c7092035-27af-5a10-b0f0-9c6464bf6647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9197a67-6609-496c-9aae-825ede4f755b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9197a67-6609-496c-9aae-825ede4f755b.jpg?1",
             "name": "Charmbreaker Devils",
             "text": "At the beginning of your upkeep, return an instant or sorcery card at random from your graveyard to your hand.\nWhenever you cast an instant or sorcery spell, Charmbreaker Devils gets +4/+0 until end of turn.",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "00f80e99-75f6-5cce-9330-071a7c019c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7a137f-e19e-43a6-aab8-02b175c9d626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7a137f-e19e-43a6-aab8-02b175c9d626.jpg?1",
             "name": "Crossway Vampire",
             "text": "When Crossway Vampire enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "9b0bd2d0-126d-5f73-ab27-843336440c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a18883-8990-40a0-bcb2-e01d0e82bfad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a18883-8990-40a0-bcb2-e01d0e82bfad.jpg?1",
             "name": "Curse of Stalked Prey",
             "text": "Enchant player\nWhenever a creature deals combat damage to enchanted player, put a +1/+1 counter on that creature.",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "b52f7a23-4a3f-5ee0-b2ba-338469f3a5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cbfcf2-462e-4bbf-a529-a70816eb1436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cbfcf2-462e-4bbf-a529-a70816eb1436.jpg?1",
             "name": "Curse of the Nightly Hunt",
             "text": "Enchant player\nCreatures enchanted player controls attack each turn if able.",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "342d55d2-9796-57ec-afec-562d2a0403bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71010182-c004-4d18-adab-80319cd1e625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71010182-c004-4d18-adab-80319cd1e625.jpg?1",
             "name": "Curse of the Pierced Heart",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, Curse of the Pierced Heart deals 1 damage to that player.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "7f2463aa-595b-5199-83dd-df792d07207c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba3ab3e-d16c-492f-a860-6d8efcadf679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba3ab3e-d16c-492f-a860-6d8efcadf679.jpg?1",
             "name": "Desperate Ravings",
             "text": "Draw two cards, then discard a card at random.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "982876df-48d7-598e-ba4e-f5e29dc6882a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80596a4-b464-4b9e-8186-94a1c44838eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80596a4-b464-4b9e-8186-94a1c44838eb.jpg?1",
             "name": "Devil's Play",
             "text": "Devil's Play deals X damage to target creature or player.\nFlashback {X}{R}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "6f4bd7f1-db65-5f2f-8478-b062edac2e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09887-6d2b-48b4-a483-16b8a45babd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09887-6d2b-48b4-a483-16b8a45babd0.jpg?1",
             "name": "Falkenrath Marauders",
             "text": "Flying, haste\nWhenever Falkenrath Marauders deals combat damage to a player, put two +1/+1 counters on it.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "92e35209-36e2-5c7a-8037-8cb7f85216b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c66cc0-cb0f-4daf-8141-0923ad46a834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c66cc0-cb0f-4daf-8141-0923ad46a834.jpg?1",
             "name": "Feral Ridgewolf",
             "text": "Trample\n{1}{R}: Feral Ridgewolf gets +2/+0 until end of turn.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "5b023322-846c-5f65-bfef-c419aacceb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a4c19-6427-4a03-a543-992c910e668f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a4c19-6427-4a03-a543-992c910e668f.jpg?1",
             "name": "Furor of the Bitten",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "c8108506-da66-5c94-9f1a-5067d6387dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b856f31-ac80-4338-95a5-3f8acda74cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b856f31-ac80-4338-95a5-3f8acda74cfe.jpg?1",
             "name": "Geistflame",
             "text": "Geistflame deals 1 damage to target creature or player.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "7c6ae2f4-0799-5164-8c9d-a5f51e35a3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1",
             "name": "Hanweir Watchkeep // Bane of Hanweir",
             "text": "Defender\nAt the beginning of each upkeep, if no spells were cast last turn, transform Hanweir Watchkeep.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "986c3997-7a5b-5651-9536-278adaa3ba4f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1",
             "name": "Hanweir Watchkeep // Bane of Hanweir",
             "text": "Bane of Hanweir attacks each turn if able.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Bane of Hanweir.",
             "colours": [
@@ -5175,7 +5175,7 @@
         },
         {
             "id": "dd62be7e-378a-599d-be04-688d53d4f815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6220b4-a5b8-45c8-9422-fab9eb32322c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6220b4-a5b8-45c8-9422-fab9eb32322c.jpg?1",
             "name": "Harvest Pyre",
             "text": "As an additional cost to cast Harvest Pyre, exile X cards from your graveyard.\nHarvest Pyre deals X damage to target creature.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "a56cfa22-dbd4-570a-92bb-6a2516d08c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e963-bb0c-4490-8238-9476b924abf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e963-bb0c-4490-8238-9476b924abf7.jpg?1",
             "name": "Heretic's Punishment",
             "text": "{3}{R}: Choose target creature or player, then put the top three cards of your library into your graveyard.  Heretic's Punishment deals damage to that creature or player equal to the highest converted mana cost among those cards.",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "139c7008-0558-51c1-b62e-59ec50d498ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f50e17-c29c-4d2c-b3e7-45d1216b81ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f50e17-c29c-4d2c-b3e7-45d1216b81ea.jpg?1",
             "name": "Infernal Plunge",
             "text": "As an additional cost to cast Infernal Plunge, sacrifice a creature.\nAdd {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5271,7 +5271,7 @@
         },
         {
             "id": "2fb42e68-8ae1-538e-8635-bc23172e088d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg?1",
             "name": "Instigator Gang // Wildblood Pack",
             "text": "Attacking creatures you control get +1/+0.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Instigator Gang.",
             "colours": [
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "30d3650b-56cf-531f-a20f-0dec057b0ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg?1",
             "name": "Instigator Gang // Wildblood Pack",
             "text": "Trample\nAttacking creatures you control get +3/+0.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Wildblood Pack.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "cd38b4f5-8e5c-589c-9ba1-3743b407b14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d188d9b-7a12-4eaf-855b-af4f0204dc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d188d9b-7a12-4eaf-855b-af4f0204dc5a.jpg?1",
             "name": "Into the Maw of Hell",
             "text": "Destroy target land. Into the Maw of Hell deals 13 damage to target creature.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "12b09b42-7012-5446-a1d3-fe9c99a89450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3255480b-c1cf-43d9-a40e-43e38112bb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3255480b-c1cf-43d9-a40e-43e38112bb18.jpg?1",
             "name": "Kessig Wolf",
             "text": "{1}{R}: Kessig Wolf gains first strike until end of turn.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "61017f5c-3ae5-5bfa-bbf5-7c702a61c335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1",
             "name": "Kruin Outlaw // Terror of Kruin Pass",
             "text": "First strike\nAt the beginning of each upkeep, if no spells were cast last turn, transform Kruin Outlaw.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "37a06508-33c9-53fc-ba87-067967c5458d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1",
             "name": "Kruin Outlaw // Terror of Kruin Pass",
             "text": "Double strike\nEach Werewolf you control can't be blocked except by two or more creatures.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Terror of Kruin Pass.",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "9db05e04-cc5c-5711-b7f4-d5e1ceaacc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f82c5c-77fa-45f3-a91e-4c2489444855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f82c5c-77fa-45f3-a91e-4c2489444855.jpg?1",
             "name": "Night Revelers",
             "text": "Night Revelers has haste as long as an opponent controls a Human.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "821e4cae-44ae-56a3-b22c-837369f962c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c7410d-b69b-41a3-b469-e12c6ffc7578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c7410d-b69b-41a3-b469-e12c6ffc7578.jpg?1",
             "name": "Nightbird's Clutches",
             "text": "Up to two target creatures can't block this turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "48e0a904-63f2-5db2-80e4-f0af03dbbdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23af6033-4930-48e4-821d-14cbbe1754b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23af6033-4930-48e4-821d-14cbbe1754b4.jpg?1",
             "name": "Past in Flames",
             "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "310d4242-0c3f-5c71-bab6-21e749c05f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d3de5-4028-457f-8eba-82e829061a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d3de5-4028-457f-8eba-82e829061a40.jpg?1",
             "name": "Pitchburn Devils",
             "text": "When Pitchburn Devils dies, it deals 3 damage to target creature or player.",
             "colours": [
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "ceb1cc1c-8ed4-5ec1-9d19-6d75d8249f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16db004-3e0c-491b-b8b6-0ae046d11761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16db004-3e0c-491b-b8b6-0ae046d11761.jpg?1",
             "name": "Rage Thrower",
             "text": "Whenever another creature dies, Rage Thrower deals 2 damage to target player.",
             "colours": [
@@ -5643,7 +5643,7 @@
         },
         {
             "id": "2c6a220e-609c-55be-a4b7-600e0f199470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afab3a6-95e3-4786-94f2-d9aa7365a4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afab3a6-95e3-4786-94f2-d9aa7365a4de.jpg?1",
             "name": "Rakish Heir",
             "text": "Whenever a Vampire you control deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "3e6bbc8a-f285-5a36-9d97-10325c411b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg?1",
             "name": "Reckless Waif // Merciless Predator",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Reckless Waif.",
             "colours": [
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "09018ca4-a360-57ba-a381-5cb6203d2da0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg?1",
             "name": "Reckless Waif // Merciless Predator",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Merciless Predator.",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "2820d884-ada0-53eb-bb5c-7f58d51df869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd35107b-6aaf-4fd8-bf1c-12b724d1482e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd35107b-6aaf-4fd8-bf1c-12b724d1482e.jpg?1",
             "name": "Riot Devils",
             "text": "",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "fd053e1e-ca2e-50fc-9583-86a5a82335e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060ce982-94dd-4b9e-b240-15da297e29f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060ce982-94dd-4b9e-b240-15da297e29f9.jpg?1",
             "name": "Rolling Temblor",
             "text": "Rolling Temblor deals 2 damage to each creature without flying.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5813,7 +5813,7 @@
         },
         {
             "id": "98f55859-6f07-502c-9ad6-5406a9c40274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c25932-96e7-4ae5-b544-8780f92d0be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c25932-96e7-4ae5-b544-8780f92d0be7.jpg?1",
             "name": "Scourge of Geier Reach",
             "text": "Scourge of Geier Reach gets +1/+1 for each creature your opponents control.",
             "colours": [
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "5cb09172-ea91-5334-8c5c-e57378dc3723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63fa0de-2ec3-41ff-8e5d-0b54f400f27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63fa0de-2ec3-41ff-8e5d-0b54f400f27f.jpg?1",
             "name": "Skirsdag Cultist",
             "text": "{R}, {T}, Sacrifice a creature: Skirsdag Cultist deals 2 damage to target creature or player.",
             "colours": [
@@ -5882,7 +5882,7 @@
         },
         {
             "id": "87329a40-2cb1-5c58-bd81-6ab8b7763450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c16cf74-f9e0-4d80-9a29-b91dec0b6b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c16cf74-f9e0-4d80-9a29-b91dec0b6b38.jpg?1",
             "name": "Stromkirk Noble",
             "text": "Stromkirk Noble can't be blocked by Humans.\nWhenever Stromkirk Noble deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "d3fb28e3-3d23-5aeb-958b-ef4af1bd283f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg?1",
             "name": "Tormented Pariah // Rampaging Werewolf",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Tormented Pariah.",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "cbc388a8-db73-5439-a889-02e674e2f605",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg?1",
             "name": "Tormented Pariah // Rampaging Werewolf",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Rampaging Werewolf.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "ffdaaf00-7c99-58cd-9bdb-14a0485f21a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8220f18a-f23f-4fe6-bb58-58b6c5f36c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8220f18a-f23f-4fe6-bb58-58b6c5f36c79.jpg?1",
             "name": "Traitorous Blood",
             "text": "Gain control of target creature until end of turn. Untap it. It gains trample and haste until end of turn.",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "590e1d1b-d6d0-5619-9768-0214b0c17318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4fd254-0ae9-498d-b9da-4fb3d6a1a55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4fd254-0ae9-498d-b9da-4fb3d6a1a55c.jpg?1",
             "name": "Vampiric Fury",
             "text": "Vampire creatures you control get +2/+0 and gain first strike until end of turn.",
             "colours": [
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "205ffd26-5560-547d-be97-0fbb2e4d4a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg?1",
             "name": "Village Ironsmith // Ironfang",
             "text": "First strike\nAt the beginning of each upkeep, if no spells were cast last turn, transform Village Ironsmith.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "1663bf35-5b02-5f55-aacf-48ed9f134037",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg?1",
             "name": "Village Ironsmith // Ironfang",
             "text": "First strike\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ironfang.",
             "colours": [
@@ -6120,7 +6120,7 @@
         },
         {
             "id": "92172320-16e6-5162-9654-530a910ce461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1",
             "name": "Ambush Viper",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "0a149d34-ff47-578d-aae0-7aae555b5f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb39e97-53c2-4df0-9fb3-a3d6a24ec41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb39e97-53c2-4df0-9fb3-a3d6a24ec41f.jpg?1",
             "name": "Avacyn's Pilgrim",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "3ffa5ed0-afc8-55e1-8e91-7a656fc6cbad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f3d9eb-462c-41b5-ad1a-baab7dc5eac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f3d9eb-462c-41b5-ad1a-baab7dc5eac3.jpg?1",
             "name": "Boneyard Wurm",
             "text": "Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "813eeaf1-d45b-5f7e-84a0-f9adb14113fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60fa219e-5dba-4d49-9cae-40d254f140e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60fa219e-5dba-4d49-9cae-40d254f140e4.jpg?1",
             "name": "Bramblecrush",
             "text": "Destroy target noncreature permanent.",
             "colours": [
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "0003caab-9ff5-5d1a-bc06-976dd0457f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8dfb98-a975-41bf-8aac-c0001c9ddaa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8dfb98-a975-41bf-8aac-c0001c9ddaa7.jpg?1",
             "name": "Caravan Vigil",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nMorbid \u2014 You may put that card onto the battlefield instead of putting it into your hand if a creature died this turn.",
             "colours": [
@@ -6288,7 +6288,7 @@
         },
         {
             "id": "4f1b5687-98d7-5af0-96a4-7546dc027786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b965069d-8513-41ab-98f6-3fbd46c19e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b965069d-8513-41ab-98f6-3fbd46c19e2d.jpg?1",
             "name": "Creeping Renaissance",
             "text": "Choose a permanent type. Return all cards of the chosen type from your graveyard to your hand.\nFlashback {5}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "b6ec2af8-9a2f-581b-903a-5b4838b7557e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec37c5a-8223-441c-a8a6-8da1a2dfc3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec37c5a-8223-441c-a8a6-8da1a2dfc3fb.jpg?1",
             "name": "Darkthicket Wolf",
             "text": "{2}{G}: Darkthicket Wolf gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "bf0aa055-3635-5efd-930d-4f0a7caaa411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg?1",
             "name": "Daybreak Ranger // Nightfall Predator",
             "text": "{T}: Daybreak Ranger deals 2 damage to target creature with flying.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Daybreak Ranger.",
             "colours": [
@@ -6392,7 +6392,7 @@
         },
         {
             "id": "4f8f89b1-0dc0-5012-a980-c2197ebb0a96",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg?1",
             "name": "Daybreak Ranger // Nightfall Predator",
             "text": "{R}, {T}: Nightfall Predator fights target creature. (Each deals damage equal to its power to the other.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Nightfall Predator.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "2ec3427e-6972-5aac-bb03-3eb0c3490d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b82ef0-c974-4357-b21a-4c2a28ec7279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b82ef0-c974-4357-b21a-4c2a28ec7279.jpg?1",
             "name": "Elder of Laurels",
             "text": "{3}{G}: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "5fb1dcd8-0daf-5280-96e5-af6101d9a719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec48cba-1b5d-44e7-9e25-16922dedb67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec48cba-1b5d-44e7-9e25-16922dedb67d.jpg?1",
             "name": "Essence of the Wild",
             "text": "Creatures you control enter the battlefield as a copy of Essence of the Wild.",
             "colours": [
@@ -6496,7 +6496,7 @@
         },
         {
             "id": "9cb62c63-8fba-51a5-a8c6-aa788c13d6a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31740fe9-27d2-416e-93de-509ac1a7b7cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31740fe9-27d2-416e-93de-509ac1a7b7cd.jpg?1",
             "name": "Festerhide Boar",
             "text": "Trample\nMorbid \u2014 Festerhide Boar enters the battlefield with two +1/+1 counters on it if a creature died this turn.",
             "colours": [
@@ -6530,7 +6530,7 @@
         },
         {
             "id": "e4f312ea-46b1-5e1a-bf76-c55c701bf046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a35eac-b962-466e-a4da-a4010c68ef16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a35eac-b962-466e-a4da-a4010c68ef16.jpg?1",
             "name": "Full Moon's Rise",
             "text": "Werewolf creatures you control get +1/+0 and have trample.\nSacrifice Full Moon's Rise: Regenerate all Werewolf creatures you control.",
             "colours": [
@@ -6562,7 +6562,7 @@
         },
         {
             "id": "d4254138-884d-5c33-a2fd-a5c86ccfdf34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg?1",
             "name": "Garruk Relentless // Garruk, the Veil-Cursed",
             "text": "When Garruk Relentless has two or fewer loyalty counters on him, transform him.\n0: Garruk Relentless deals 3 damage to target creature. That creature deals damage equal to its power to him.\n0: Put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -6599,7 +6599,7 @@
         },
         {
             "id": "d9116cba-0917-551f-bc20-c1a15659a173",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg?1",
             "name": "Garruk Relentless // Garruk, the Veil-Cursed",
             "text": "+1: Put a 1/1 black Wolf creature token with deathtouch onto the battlefield.\n-1: Sacrifice a creature. If you do, search your library for a creature card, reveal it, put it into your hand, then shuffle your library.\n-3: Creatures you control gain trample and get +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "597ba0c2-2ab3-5ca2-a320-b29c3ec61e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg?1",
             "name": "Gatstaf Shepherd // Gatstaf Howler",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Gatstaf Shepherd.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "308ee849-5c1a-5824-bb17-2fb033dfd623",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg?1",
             "name": "Gatstaf Shepherd // Gatstaf Howler",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Gatstaf Howler.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "04e5f1b2-6ef9-59b6-b31a-a98ec2b111f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416148c8-13d3-46d3-ac93-6eb7cbab2881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416148c8-13d3-46d3-ac93-6eb7cbab2881.jpg?1",
             "name": "Gnaw to the Bone",
             "text": "You gain 2 life for each creature card in your graveyard.\nFlashback {2}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "571b8305-a169-5f73-8aed-941be0dcd6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be1d4d2-5215-44b2-9b67-627d088efdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be1d4d2-5215-44b2-9b67-627d088efdb5.jpg?1",
             "name": "Grave Bramble",
             "text": "Defender, protection from Zombies",
             "colours": [
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "704bc6b2-505b-5d21-a0cc-6014a5d4b8e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg?1",
             "name": "Grizzled Outcasts // Krallenhorde Wantons",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Grizzled Outcasts.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "8f9e65d3-a135-51cc-98b6-bb138810cbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg?1",
             "name": "Grizzled Outcasts // Krallenhorde Wantons",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Krallenhorde Wantons.",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "a28f0442-2775-5723-b275-af0314259bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d007a2-163d-4e09-a70b-280a6fa3203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d007a2-163d-4e09-a70b-280a6fa3203b.jpg?1",
             "name": "Gutter Grime",
             "text": "Whenever a nontoken creature you control dies, put a slime counter on Gutter Grime, then put a green Ooze creature token onto the battlefield with \"This creature's power and toughness are each equal to the number of slime counters on Gutter Grime.\"",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "c242c074-067d-578d-a338-e25f0e2545de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203ae4f-4d69-490f-8a7c-dadbefa6d697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203ae4f-4d69-490f-8a7c-dadbefa6d697.jpg?1",
             "name": "Hamlet Captain",
             "text": "Whenever Hamlet Captain attacks or blocks, other Human creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "8447046d-c7a9-5ba9-9f25-d8b322aee599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9ff632-0e27-4521-9e9d-5725e618f5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9ff632-0e27-4521-9e9d-5725e618f5dd.jpg?1",
             "name": "Hollowhenge Scavenger",
             "text": "Morbid \u2014 When Hollowhenge Scavenger enters the battlefield, if a creature died this turn, you gain 5 life.",
             "colours": [
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "c6ffd50d-795f-5a5a-97d4-7e2e48e95cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae22886-da03-49f2-873c-98a7ea2ee17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae22886-da03-49f2-873c-98a7ea2ee17d.jpg?1",
             "name": "Kessig Cagebreakers",
             "text": "Whenever Kessig Cagebreakers attacks, put a 2/2 green Wolf creature token onto the battlefield tapped and attacking for each creature card in your graveyard.",
             "colours": [
@@ -6977,7 +6977,7 @@
         },
         {
             "id": "6270375b-b162-5b21-b478-f6f8c2482acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4954e8a3-e72b-4f28-8762-2b1c658c31b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4954e8a3-e72b-4f28-8762-2b1c658c31b6.jpg?1",
             "name": "Kindercatch",
             "text": "",
             "colours": [
@@ -7011,7 +7011,7 @@
         },
         {
             "id": "e01bba9b-674c-54a5-a55e-4bec90a9c77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c86c84e-9bab-4a2c-b594-7f7b4b6bba88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c86c84e-9bab-4a2c-b594-7f7b4b6bba88.jpg?1",
             "name": "Lumberknot",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever a creature dies, put a +1/+1 counter on Lumberknot.",
             "colours": [
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "06cdec9f-7843-5cf9-986a-a3ab0ab0a989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a8508d-25a7-4fb2-8aa3-349275f80c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a8508d-25a7-4fb2-8aa3-349275f80c42.jpg?1",
             "name": "Make a Wish",
             "text": "Return two cards at random from your graveyard to your hand.",
             "colours": [
@@ -7077,7 +7077,7 @@
         },
         {
             "id": "3d534857-3daf-558b-a0ba-f0e231db7a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1",
             "name": "Mayor of Avabruck // Howlpack Alpha",
             "text": "Other Human creatures you control get +1/+1.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Mayor of Avabruck.",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "cd567de0-8d69-58f6-823a-7dcfe5cbc65b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1",
             "name": "Mayor of Avabruck // Howlpack Alpha",
             "text": "Other Werewolf and Wolf creatures you control get +1/+1.\nAt the beginning of your end step, put a 2/2 green Wolf creature token onto the battlefield.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Howlpack Alpha.",
             "colours": [
@@ -7147,7 +7147,7 @@
         },
         {
             "id": "ea51f57d-1986-5dcf-b49c-ff8b329e6b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f387c86a-702f-4f86-bcb9-d2bfa46fd211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f387c86a-702f-4f86-bcb9-d2bfa46fd211.jpg?1",
             "name": "Moldgraf Monstrosity",
             "text": "Trample\nWhen Moldgraf Monstrosity dies, exile it, then return two creature cards at random from your graveyard to the battlefield.",
             "colours": [
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "7b25c01a-2300-5615-ba70-cdf6e4c6d662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57153c3f-9e55-418c-b67b-36901f29f9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57153c3f-9e55-418c-b67b-36901f29f9c1.jpg?1",
             "name": "Moonmist",
             "text": "Transform all Humans. Prevent all combat damage that would be dealt this turn by creatures other than Werewolves and Wolves. (Only double-faced cards can be transformed.)",
             "colours": [
@@ -7213,7 +7213,7 @@
         },
         {
             "id": "2eae6225-3a93-5e4a-92cb-736170dd8ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1dabd-82df-4814-9d64-bf7bf9c1018d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1dabd-82df-4814-9d64-bf7bf9c1018d.jpg?1",
             "name": "Mulch",
             "text": "Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -7245,7 +7245,7 @@
         },
         {
             "id": "13daf309-cdf6-5716-9a54-570ad74e6fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236f1a8c-13ab-4ab3-b11f-082054d297e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236f1a8c-13ab-4ab3-b11f-082054d297e5.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "486005f2-2484-5a65-86da-0a590c770b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac43ced-35b0-4e70-a049-1a65db9b2b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac43ced-35b0-4e70-a049-1a65db9b2b1e.jpg?1",
             "name": "Orchard Spirit",
             "text": "Orchard Spirit can't be blocked except by creatures with flying or reach.",
             "colours": [
@@ -7311,7 +7311,7 @@
         },
         {
             "id": "b88545f8-42bd-5193-8199-5d630d36b502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01033dae-fec1-41f2-b7f2-cc6a43331790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01033dae-fec1-41f2-b7f2-cc6a43331790.jpg?1",
             "name": "Parallel Lives",
             "text": "If an effect would put one or more tokens onto the battlefield under your control, it puts twice that many of those tokens onto the battlefield instead.",
             "colours": [
@@ -7343,7 +7343,7 @@
         },
         {
             "id": "b44558d5-c9ea-5d76-be3b-37ae49911978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b3eaf0-4207-4bac-923d-29f348c95a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b3eaf0-4207-4bac-923d-29f348c95a35.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "d07fd1a4-abb0-5eda-9d6e-a28c599f99d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90742ae-c48b-4d32-a6b7-aa51a94018bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90742ae-c48b-4d32-a6b7-aa51a94018bd.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "a2c1228b-bf31-54b4-8817-1939380f875f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43003ad7-2f42-4c85-8b00-77cbf3f50a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43003ad7-2f42-4c85-8b00-77cbf3f50a7b.jpg?1",
             "name": "Somberwald Spider",
             "text": "Reach (This creature can block creatures with flying.)\nMorbid \u2014 Somberwald Spider enters the battlefield with two +1/+1 counters on it if a creature died this turn.",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "b8e1bf7a-5029-5e79-b364-895d22ce52f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97007af-6642-4105-8d8c-4223681e1cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97007af-6642-4105-8d8c-4223681e1cf9.jpg?1",
             "name": "Spider Spawning",
             "text": "Put a 1/2 green Spider creature token with reach onto the battlefield for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "0ecd9ed3-96a7-584b-8516-619a3e6a7f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdfd82-d025-4070-a1f5-4ee759978bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdfd82-d025-4070-a1f5-4ee759978bcb.jpg?1",
             "name": "Spidery Grasp",
             "text": "Untap target creature. It gets +2/+4 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -7506,7 +7506,7 @@
         },
         {
             "id": "c1e3cce9-2e29-5edf-aae2-9b876caff1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37068a41-bc5c-44b9-a307-5d3919794233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37068a41-bc5c-44b9-a307-5d3919794233.jpg?1",
             "name": "Splinterfright",
             "text": "Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -7540,7 +7540,7 @@
         },
         {
             "id": "2d0da2d1-f477-5456-97ac-cea9d040b55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654ae7-af2c-4956-be3a-68befa33f523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654ae7-af2c-4956-be3a-68befa33f523.jpg?1",
             "name": "Travel Preparations",
             "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "26ee394e-eef4-5206-828a-0785d159aad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6110bba-5c2d-4183-9dd0-d85a4cc42753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6110bba-5c2d-4183-9dd0-d85a4cc42753.jpg?1",
             "name": "Tree of Redemption",
             "text": "Defender\n{T}: Exchange your life total with Tree of Redemption's toughness.",
             "colours": [
@@ -7607,7 +7607,7 @@
         },
         {
             "id": "0e9264fb-abc0-5ba1-a635-716a62dbc26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg?1",
             "name": "Ulvenwald Mystics // Ulvenwald Primordials",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Ulvenwald Mystics.",
             "colours": [
@@ -7643,7 +7643,7 @@
         },
         {
             "id": "297b1abb-ee3e-5511-bff0-92e8140d874d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg?1",
             "name": "Ulvenwald Mystics // Ulvenwald Primordials",
             "text": "{G}: Regenerate Ulvenwald Primordials.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ulvenwald Primordials.",
             "colours": [
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "95948ae1-917d-5a8d-a319-1d576958f525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1",
             "name": "Villagers of Estwald // Howlpack of Estwald",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Villagers of Estwald.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "6e4196be-ec3d-5343-a232-de8f1c05e28a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1",
             "name": "Villagers of Estwald // Howlpack of Estwald",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Howlpack of Estwald.",
             "colours": [
@@ -7746,7 +7746,7 @@
         },
         {
             "id": "da2e432b-3d50-5891-a7d3-88df48946c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088a924-58c6-4ab7-baf0-842d6688fcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088a924-58c6-4ab7-baf0-842d6688fcec.jpg?1",
             "name": "Woodland Sleuth",
             "text": "Morbid \u2014 When Woodland Sleuth enters the battlefield, if a creature died this turn, return a creature card at random from your graveyard to your hand.",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "f0072bed-ca26-5116-aa36-9bdc166f4a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604e22e-1f29-4a8f-b887-b18f43e3745e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604e22e-1f29-4a8f-b887-b18f43e3745e.jpg?1",
             "name": "Wreath of Geists",
             "text": "Enchant creature\nEnchanted creature gets +X/+X, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -7815,7 +7815,7 @@
         },
         {
             "id": "5c6227bf-f0a9-568c-96cf-b6e4a6726e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53487a-c00b-42da-904c-f022a0c5b1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53487a-c00b-42da-904c-f022a0c5b1ed.jpg?1",
             "name": "Evil Twin",
             "text": "You may have Evil Twin enter the battlefield as a copy of any creature on the battlefield except it gains \"{U}{B}, {T}: Destroy target creature with the same name as this creature.\"",
             "colours": [
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "0f691827-756c-5373-a87a-7bdfd95cdbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b57113-b39a-460b-b4aa-02606b40bbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b57113-b39a-460b-b4aa-02606b40bbd0.jpg?1",
             "name": "Geist of Saint Traft",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Geist of Saint Traft attacks, put a 4/4 white Angel creature token with flying onto the battlefield tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "83039e0c-241b-5e45-aedb-ecc6e8d363b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8648734-ed6c-471f-91a1-6b710bbaf370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8648734-ed6c-471f-91a1-6b710bbaf370.jpg?1",
             "name": "Grimgrin, Corpse-Born",
             "text": "Grimgrin, Corpse-Born enters the battlefield tapped and doesn't untap during your untap step.\nSacrifice another creature: Untap Grimgrin and put a +1/+1 counter on it.\nWhenever Grimgrin attacks, destroy target creature defending player controls, then put a +1/+1 counter on Grimgrin.",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "b3f04750-9511-54bc-892f-7ac78dc3aae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed750692-ba6a-4a89-ad6d-92fda7edc2cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed750692-ba6a-4a89-ad6d-92fda7edc2cb.jpg?1",
             "name": "Olivia Voldaren",
             "text": "Flying\n{1}{R}: Olivia Voldaren deals 1 damage to another target creature. That creature becomes a Vampire in addition to its other types. Put a +1/+1 counter on Olivia Voldaren.\n{3}{B}{B}: Gain control of target Vampire for as long as you control Olivia Voldaren.",
             "colours": [
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "cbb12edb-d200-593f-94f7-03f45741efb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e14fc60-f300-40f0-b712-4e339dc27929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e14fc60-f300-40f0-b712-4e339dc27929.jpg?1",
             "name": "Blazing Torch",
             "text": "Equipped creature can't be blocked by Vampires or Zombies.\nEquipped creature has \"{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to target creature or player.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "b66b5d73-6147-5ab5-8328-01b8a9c387c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e141fe62-515e-4fe4-b032-81f169ec58d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e141fe62-515e-4fe4-b032-81f169ec58d6.jpg?1",
             "name": "Butcher's Cleaver",
             "text": "Equipped creature gets +3/+0.\nAs long as equipped creature is a Human, it has lifelink.\nEquip {3}",
             "colours": [],
@@ -8027,7 +8027,7 @@
         },
         {
             "id": "a5eecbf5-ffc3-511e-91f9-5179ee0f9619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97bdfb00-7773-4af6-895c-c90088a96b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97bdfb00-7773-4af6-895c-c90088a96b07.jpg?1",
             "name": "Cellar Door",
             "text": "{3}, {T}: Target player puts the bottom card of his or her library into his or her graveyard. If it's a creature card, you put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [],
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "8859c78a-95de-5487-9841-2aa1c3e6b2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24abd762-e533-491a-97b6-aed40c214e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24abd762-e533-491a-97b6-aed40c214e9d.jpg?1",
             "name": "Cobbled Wings",
             "text": "Equipped creature has flying.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8085,7 +8085,7 @@
         },
         {
             "id": "ccd2c10d-e621-5f88-bb97-71e4fb046035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762a598b-8753-47ec-9dd6-2c3d8882fda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762a598b-8753-47ec-9dd6-2c3d8882fda6.jpg?1",
             "name": "Creepy Doll",
             "text": "Creepy Doll is indestructible.\nWhenever Creepy Doll deals combat damage to a creature, flip a coin. If you win the flip, destroy that creature.",
             "colours": [],
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "66fa7495-c2a1-5ebb-8ecd-afc01d84c9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33caa8-2a07-4f6c-a6c2-d21cf2d61193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33caa8-2a07-4f6c-a6c2-d21cf2d61193.jpg?1",
             "name": "Demonmail Hauberk",
             "text": "Equipped creature gets +4/+2.\nEquip\u2014\nSacrifice a creature.",
             "colours": [],
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "e4893d07-6e28-516f-9bbd-f7e43d331838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14bc109-d5d5-4777-90e4-bef26d106571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14bc109-d5d5-4777-90e4-bef26d106571.jpg?1",
             "name": "Galvanic Juggernaut",
             "text": "Galvanic Juggernaut attacks each turn if able.\nGalvanic Juggernaut doesn't untap during your untap step.\nWhenever another creature dies, untap Galvanic Juggernaut.",
             "colours": [],
@@ -8177,7 +8177,7 @@
         },
         {
             "id": "f12ebdd2-8557-566d-a8c9-27797d8fa606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb8ecf0-8c12-4a14-9a75-4cc5bf9e47f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb8ecf0-8c12-4a14-9a75-4cc5bf9e47f1.jpg?1",
             "name": "Geistcatcher's Rig",
             "text": "When Geistcatcher's Rig enters the battlefield, you may have it deal 4 damage to target creature with flying.",
             "colours": [],
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "c6a59256-70a8-5952-a1e5-7a80c9684591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e7c2a-698c-4dce-a10b-ca58e4affa57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e7c2a-698c-4dce-a10b-ca58e4affa57.jpg?1",
             "name": "Ghoulcaller's Bell",
             "text": "{T}: Each player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "fd58d17f-2970-58d5-90f8-d38225697a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b8888-a10c-48b1-ba19-c041e5667b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b8888-a10c-48b1-ba19-c041e5667b29.jpg?1",
             "name": "Graveyard Shovel",
             "text": "{2}, {T}: Target player exiles a card from his or her graveyard. If it's a creature card, you gain 2 life.",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "cae9598b-a1ec-5550-86b5-c6e715a067c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d268d078-b854-47c1-bc7f-7698723405a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d268d078-b854-47c1-bc7f-7698723405a2.jpg?1",
             "name": "Grimoire of the Dead",
             "text": "{1}, {T}, Discard a card: Put a study counter on Grimoire of the Dead.\n{T}, Remove three study counters from Grimoire of the Dead and sacrifice it: Put all creature cards from all graveyards onto the battlefield under your control. They're black Zombies in addition to their other colors and types.",
             "colours": [],
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "8d4e85a2-a10b-5078-9173-49b824281162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014f59d-9012-473a-8bb1-8085c6e91632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014f59d-9012-473a-8bb1-8085c6e91632.jpg?1",
             "name": "Inquisitor's Flail",
             "text": "If equipped creature would deal combat damage, it deals double that damage instead.\nIf another creature would deal combat damage to equipped creature, it deals double that damage to equipped creature instead.\nEquip {2}",
             "colours": [],
@@ -8324,7 +8324,7 @@
         },
         {
             "id": "4b1a8cdb-fe3f-5211-b9ae-7fe000176b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb40965-9096-4a19-b71d-4da2a5b36baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb40965-9096-4a19-b71d-4da2a5b36baa.jpg?1",
             "name": "Manor Gargoyle",
             "text": "Defender\nManor Gargoyle is indestructible as long as it has defender.\n{1}: Until end of turn, Manor Gargoyle loses defender and gains flying.",
             "colours": [],
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "3bb08bfb-e286-5b11-a612-5d38ba8c5664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff1acce-bed4-452c-8416-06726004f2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff1acce-bed4-452c-8416-06726004f2e8.jpg?1",
             "name": "Mask of Avacyn",
             "text": "Equipped creature gets +1/+2 and has hexproof. (It can't be the target of spells or abilities your opponents control.)\nEquip {3}",
             "colours": [],
@@ -8385,7 +8385,7 @@
         },
         {
             "id": "d33d5bc3-88d4-578a-a86a-d68c38ce6905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d495d85-6458-44d5-b3b4-5e09569057e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d495d85-6458-44d5-b3b4-5e09569057e3.jpg?1",
             "name": "One-Eyed Scarecrow",
             "text": "Defender\nCreatures with flying your opponents control get -1/-0.",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "3892a8b9-981e-5592-a5a7-7d39a3d3a69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f54e38b-b4a0-4406-a635-7a5ab3722f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f54e38b-b4a0-4406-a635-7a5ab3722f25.jpg?1",
             "name": "Runechanter's Pike",
             "text": "Equipped creature has first strike and gets +X/+0, where X is the number of instant and sorcery cards in your graveyard.\nEquip {2}",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "78047ea9-ac61-5cde-ac78-1c9d55e127f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce20f19-a159-40e6-bb67-6108872ac1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce20f19-a159-40e6-bb67-6108872ac1e0.jpg?1",
             "name": "Sharpened Pitchfork",
             "text": "Equipped creature has first strike.\nAs long as equipped creature is a Human, it gets +1/+1.\nEquip {1}",
             "colours": [],
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "b3d5dc51-1b1c-53ca-adb1-af85acbe9df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8162a-68f0-45df-bb25-8fd4487257a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8162a-68f0-45df-bb25-8fd4487257a4.jpg?1",
             "name": "Silver-Inlaid Dagger",
             "text": "Equipped creature gets +2/+0.\nAs long as equipped creature is a Human, it gets an additional +1/+0.\nEquip {2}",
             "colours": [],
@@ -8506,7 +8506,7 @@
         },
         {
             "id": "035aa89b-2000-5b7f-af94-4dca4df1aed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0afa7-e9f9-4751-af36-d85343fabc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0afa7-e9f9-4751-af36-d85343fabc26.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -8534,7 +8534,7 @@
         },
         {
             "id": "ba5ed461-d12f-5b20-9d83-842a3cfef745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182be77-9186-4d16-a070-9577d4392999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182be77-9186-4d16-a070-9577d4392999.jpg?1",
             "name": "Trepanation Blade",
             "text": "Whenever equipped creature attacks, defending player reveals cards from the top of his or her library until he or she reveals a land card. The creature gets +1/+0 until end of turn for each card revealed this way. That player puts the revealed cards into his or her graveyard.\nEquip {2}",
             "colours": [],
@@ -8564,7 +8564,7 @@
         },
         {
             "id": "2e9f7a06-56d1-55a8-aa41-adefbdee3128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e0bf16-62f5-4b62-96e8-bc7e049bcf89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e0bf16-62f5-4b62-96e8-bc7e049bcf89.jpg?1",
             "name": "Witchbane Orb",
             "text": "When Witchbane Orb enters the battlefield, destroy all Curses attached to you.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control, including Aura spells.)",
             "colours": [],
@@ -8592,7 +8592,7 @@
         },
         {
             "id": "697fdd69-a0b2-5c25-998f-8e5dfc65b6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2825f5-8112-4108-910a-4303b2d57356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2825f5-8112-4108-910a-4303b2d57356.jpg?1",
             "name": "Wooden Stake",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature blocks or becomes blocked by a Vampire, destroy that creature. It can't be regenerated.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "64fcf5f2-dfee-58d3-b51d-73d33acad0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7e1bf9-bd6a-48e3-9331-178e5142c06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7e1bf9-bd6a-48e3-9331-178e5142c06a.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8653,7 +8653,7 @@
         },
         {
             "id": "2b8085eb-adaa-5437-a57f-e427f57d9b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f73443-2fe8-424f-8e71-fc7ce1f3a3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f73443-2fe8-424f-8e71-fc7ce1f3a3eb.jpg?1",
             "name": "Gavony Township",
             "text": "{T}: Add {1} to your mana pool.\n{2}{G}{W}, {T}: Put a +1/+1 counter on each creature you control.",
             "colours": [],
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "2a765b32-392e-5b70-a62f-228726c3ffc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6456ed-0ffb-4d22-b252-5775076030ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6456ed-0ffb-4d22-b252-5775076030ce.jpg?1",
             "name": "Ghost Quarter",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
             "colours": [],
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "9ea20892-1722-5c60-979b-60f59fec347e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f15306-56fe-4643-bb4c-4c7c12378d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f15306-56fe-4643-bb4c-4c7c12378d01.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "c25228bb-836f-568a-b545-0b61bb3e1f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c1a371-5ded-4a3a-bf96-503c4f1a665d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c1a371-5ded-4a3a-bf96-503c4f1a665d.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8774,7 +8774,7 @@
         },
         {
             "id": "ea377195-f7f7-5197-890f-a2d03a06bc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8447fe-7368-470a-911a-1083ec6cc831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8447fe-7368-470a-911a-1083ec6cc831.jpg?1",
             "name": "Kessig Wolf Run",
             "text": "{T}: Add {1} to your mana pool.\n{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",
             "colours": [],
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "e44f2e95-4e18-5f22-b85c-c3a9c2fe8f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5569e3-278c-4cf3-860e-712010333fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5569e3-278c-4cf3-860e-712010333fe6.jpg?1",
             "name": "Moorland Haunt",
             "text": "{T}: Add {1} to your mana pool.\n{W}{U}, {T}, Exile a creature card from your graveyard: Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [],
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "4666d86f-3ce5-596c-a653-4d7c9b2b11fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef058312-6926-49f8-ae72-a8d60fedbf6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef058312-6926-49f8-ae72-a8d60fedbf6c.jpg?1",
             "name": "Nephalia Drownyard",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}{B}, {T}: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "d6aedd57-456b-5165-b06a-aba0ccfa40c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e7a7a-574f-4850-9697-8cb276a5812c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e7a7a-574f-4850-9697-8cb276a5812c.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8895,7 +8895,7 @@
         },
         {
             "id": "143ce35a-0735-59fa-9838-2ab17aabd337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2741d8-2c02-4acd-8ca2-55b4bf6aef1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2741d8-2c02-4acd-8ca2-55b4bf6aef1c.jpg?1",
             "name": "Stensia Bloodhall",
             "text": "{T}: Add {1} to your mana pool.\n{3}{B}{R}, {T}: Stensia Bloodhall deals 2 damage to target player.",
             "colours": [],
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "7e794845-14f6-59f9-8f7a-1a3d2f0f4899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4968b65d-50e5-4d7e-b78b-cdada1cbf7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4968b65d-50e5-4d7e-b78b-cdada1cbf7a7.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "1d1ddd51-4eb8-5ff9-8ae1-ab6cb7135c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67139101-ec5e-434b-be3a-21338cc33840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67139101-ec5e-434b-be3a-21338cc33840.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "b672236a-463d-5445-8fcd-492da1f4d640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d595ba72-3334-48f4-9ea9-a43f5e824aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d595ba72-3334-48f4-9ea9-a43f5e824aa8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9025,7 +9025,7 @@
         },
         {
             "id": "b291a163-6c22-5c4b-ae1d-e4ea5465a501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceab58a-304a-40e4-8830-837a7b51d31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceab58a-304a-40e4-8830-837a7b51d31b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9062,7 +9062,7 @@
         },
         {
             "id": "965b9128-1c32-56ee-9997-2a18a979f120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ca372-c110-4321-b497-8841547f3c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ca372-c110-4321-b497-8841547f3c2b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "83d1c051-092f-5eee-9263-5276255c876c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf258641-b73c-4813-8a23-da47cf79eca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf258641-b73c-4813-8a23-da47cf79eca5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "331b43de-b1a9-5120-b5a5-2d73a3855e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b51501-d3b3-480f-9bcb-e66420c4db06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b51501-d3b3-480f-9bcb-e66420c4db06.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "54b07438-0c7a-5242-a803-c8a8e87524ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19f6dd-9eed-4656-b8c7-e64b61446d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19f6dd-9eed-4656-b8c7-e64b61446d7f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "51412986-6d35-50ac-91b9-a1c78f583940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a14894-2936-4fc4-b6a5-f9c73c32b177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a14894-2936-4fc4-b6a5-f9c73c32b177.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "4d5a56d8-438e-5c3a-8d85-50f128df18f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d37e23b-7898-4b5d-b088-d4e54947f579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d37e23b-7898-4b5d-b088-d4e54947f579.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9284,7 +9284,7 @@
         },
         {
             "id": "71acb144-fd1b-5ec9-a600-12751b7f0d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2ecdd-37ee-4351-833a-f4eac3c55eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2ecdd-37ee-4351-833a-f4eac3c55eca.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9321,7 +9321,7 @@
         },
         {
             "id": "0513d4ed-2c32-59a8-a849-e315fa8fd18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17de9f2c-e051-404c-8ec0-c35f500efd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17de9f2c-e051-404c-8ec0-c35f500efd67.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9358,7 +9358,7 @@
         },
         {
             "id": "bffefb78-504d-589e-aac6-67fdf021b88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a200286-67f3-4bff-8a53-3e76733414fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a200286-67f3-4bff-8a53-3e76733414fa.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9395,7 +9395,7 @@
         },
         {
             "id": "09906734-1fd1-5907-8c2e-5356059310a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2075dfe-b48c-46e3-bde1-f9f8e3b9d928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2075dfe-b48c-46e3-bde1-f9f8e3b9d928.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9432,7 +9432,7 @@
         },
         {
             "id": "24cf042e-99d1-5ff3-9419-930fedce261a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b606f644-1728-4cb3-90ed-121838875de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b606f644-1728-4cb3-90ed-121838875de1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "b8bdbcb5-e9ff-5f79-bda9-ef7cbec2bc96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f52885-1f01-4f06-90a8-1a0ecf291ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f52885-1f01-4f06-90a8-1a0ecf291ab5.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "b1e5e7a3-13ca-5dca-85ab-e5b80e60cb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea3762-c6ae-4304-aee4-6c3f56685319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea3762-c6ae-4304-aee4-6c3f56685319.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9543,7 +9543,7 @@
         },
         {
             "id": "dd1f7bad-5e81-5704-b567-b4b38de6cd0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7d857-2a54-4d0e-a97c-11400053194c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7d857-2a54-4d0e-a97c-11400053194c.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9577,7 +9577,7 @@
         },
         {
             "id": "d5e3dcb8-b8a8-5cf5-ad80-db6cba8eb0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbede5b-8e61-4ed8-bccb-8b54f69cccee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbede5b-8e61-4ed8-bccb-8b54f69cccee.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9611,7 +9611,7 @@
         },
         {
             "id": "eca3f5bc-09cb-59c4-a0e4-048bf9d1b6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2020f53-d012-4d26-be13-87ed0f196c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2020f53-d012-4d26-be13-87ed0f196c53.jpg?1",
             "name": "Homunculus",
             "text": "",
             "colours": [
@@ -9645,7 +9645,7 @@
         },
         {
             "id": "6ae55f03-ae8e-55dd-9147-40771507c8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "dbd2113f-ed9f-54b3-b54a-f23fb12971fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68c2ab-5131-4620-920f-7ba99522ccf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68c2ab-5131-4620-920f-7ba99522ccf0.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -9713,7 +9713,7 @@
         },
         {
             "id": "9138077f-b563-55d5-a333-de099c084a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a49607c-427a-474c-ad77-60cd05844b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a49607c-427a-474c-ad77-60cd05844b3c.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "7e030759-9fde-5bea-bc2a-2c4d71647eab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85357-3cad-4a1e-805b-ea4146d8b05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85357-3cad-4a1e-805b-ea4146d8b05f.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9781,7 +9781,7 @@
         },
         {
             "id": "4a67628e-a40c-55eb-abba-72f5bd6f7adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afec06c5-28e3-462c-9e15-4b0c405cc810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afec06c5-28e3-462c-9e15-4b0c405cc810.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9815,7 +9815,7 @@
         },
         {
             "id": "85ffe86f-9a69-5300-8743-96097fe44c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a98d0bf-4106-4ff1-89d4-3f6040b2cd5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a98d0bf-4106-4ff1-89d4-3f6040b2cd5e.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9849,7 +9849,7 @@
         },
         {
             "id": "f0a5b981-cd82-54db-8950-0c824031c19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f22cfdb-15af-46b9-b5c9-d0c76d5b15d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f22cfdb-15af-46b9-b5c9-d0c76d5b15d6.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9883,7 +9883,7 @@
         },
         {
             "id": "af261c63-c918-5bdb-b816-93cba9f0afcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71031ff1-17dc-46b7-a72b-3297137a83bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71031ff1-17dc-46b7-a72b-3297137a83bb.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -9917,7 +9917,7 @@
         },
         {
             "id": "b573ea1a-b988-52ca-b27c-d0b1f2a3cf61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -9951,7 +9951,7 @@
         },
         {
             "id": "7ee63a2d-9bea-5cf6-b74d-dd9e0b4c2411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ce1bee-8f95-4284-8e06-9de9bfcb53b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ce1bee-8f95-4284-8e06-9de9bfcb53b5.jpg?1",
             "name": "Innistrad Checklist",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/J22.json
+++ b/Assets/Resources/Sets/J22.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "85eabd47-bc5f-5e56-9baa-73da77eb7abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea531418-6c7c-4e23-b681-6bfdd4a3eb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea531418-6c7c-4e23-b681-6bfdd4a3eb79.jpg?1",
             "name": "Agrus Kos, Eternal Soldier",
             "text": "Vigilance\nWhenever Agrus Kos, Eternal Soldier becomes the target of an ability that targets only it, you may pay {1}{GU}. If you do, copy that ability for each other creature you control that ability could target. Each copy targets a different one of those creatures. ({GU} can be paid with either {R} or {W}.)",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "9edb262c-fd1d-5242-aeb9-c7434567c475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45e1832-1070-4d12-aba9-dcad47a02eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45e1832-1070-4d12-aba9-dcad47a02eda.jpg?1",
             "name": "Angelic Cub",
             "text": "Whenever Angelic Cub becomes the target of a spell or ability for the first time each turn, put a +1/+1 counter on it.\nAs long as Angelic Cub has three or more +1/+1 counters on it, it has flying.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "7dc970af-bbc9-510b-9e80-19926c6e80dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a1a840-bcdc-4d6f-a28d-9805578473f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a1a840-bcdc-4d6f-a28d-9805578473f6.jpg?1",
             "name": "Chains of Custody",
             "text": "Enchant creature you control\nWhen Chains of Custody enters the battlefield, exile target nonland permanent an opponent controls until Chains of Custody leaves the battlefield.\nEnchanted creature has ward {2}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "fe9b2d17-f79a-556e-ab6d-17b46aae8cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0eaeec2-d1d4-4494-9c5d-cebfd7f088de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0eaeec2-d1d4-4494-9c5d-cebfd7f088de.jpg?1",
             "name": "Distinguished Conjurer",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.\n{4}{W}, {T}: Exile another target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "7c997788-8162-565d-82d3-b32ce6587509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6fd0bf-3f02-46f3-9c9a-931eab190584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6fd0bf-3f02-46f3-9c9a-931eab190584.jpg?1",
             "name": "Ingenious Leonin",
             "text": "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature is a Cat, it gains first strike until end of turn.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "7faa79a8-306e-599b-a501-235ee75a36ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a5a044-d474-43f4-95a9-e67808908e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a5a044-d474-43f4-95a9-e67808908e6c.jpg?1",
             "name": "Lita, Mechanical Engineer",
             "text": "Vigilance\nAt the beginning of your end step, untap each other artifact creature you control.\n{3}{W}, {T}: Create a 5/5 colorless Vehicle artifact token named Zeppelin with flying and crew 3. (It has \"Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.\")",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "48adc7b3-5692-5fcc-87e3-49592f9c6726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6649e6c-bbd8-43db-9f3f-a24b32aed4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6649e6c-bbd8-43db-9f3f-a24b32aed4e4.jpg?1",
             "name": "Magnanimous Magistrate",
             "text": "Magnanimous Magistrate enters the battlefield with five reprieve counters on it.\nWhenever another nontoken creature you control dies, if its mana value was 1 or greater, you may remove that many reprieve counters from Magnanimous Magistrate. If you do, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "e823032c-89bd-54c8-8aad-4c3d3666f4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb0b3-a6b7-4279-8833-3d8890b2d005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb0b3-a6b7-4279-8833-3d8890b2d005.jpg?1",
             "name": "Preston, the Vanisher",
             "text": "Whenever another nontoken creature enters the battlefield under your control, if it wasn't cast, create a token that's a copy of that creature, except it's a 0/1 white Illusion.\n{1}{W}, Sacrifice five Illusions: Exile target nonland permanent.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "82ad647b-f5e6-57ac-9794-748db01fb0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61561585-f4fb-4e47-a65a-0c43a855ebcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61561585-f4fb-4e47-a65a-0c43a855ebcf.jpg?1",
             "name": "Alandra, Sky Dreamer",
             "text": "Whenever you draw your second card each turn, create a 2/2 blue Drake creature token with flying.\nWhenever you draw your fifth card each turn, Alandra, Sky Dreamer and Drakes you control each get +X/+X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -318,7 +318,7 @@
         },
         {
             "id": "ec0f6f84-7049-52a3-9a8f-9b05783367a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f69f0bf-6626-4418-9335-b79d75c99df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f69f0bf-6626-4418-9335-b79d75c99df1.jpg?1",
             "name": "Biblioplex Kraken",
             "text": "When Biblioplex Kraken enters the battlefield, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\nWhenever Biblioplex Kraken attacks, you may return another creature you control to its owner's hand. If you do, Biblioplex Kraken can't be blocked this turn.",
             "colours": [
@@ -351,7 +351,7 @@
         },
         {
             "id": "7fd51d5c-5912-5c2d-844e-4417c6ff4d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74004b11-53dc-475c-8d29-cf52403456cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74004b11-53dc-475c-8d29-cf52403456cf.jpg?1",
             "name": "Hold for Questioning",
             "text": "Enchant creature or planeswalker\nWhen Hold for Questioning enters the battlefield, tap enchanted permanent and investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
             "colours": [
@@ -384,7 +384,7 @@
         },
         {
             "id": "13eec19e-18c2-590e-8074-8b4f5e70acc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1d50c3-3219-49cb-8f63-c1faff93215c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1d50c3-3219-49cb-8f63-c1faff93215c.jpg?1",
             "name": "Isu the Abominable",
             "text": "You may look at the top card of your library any time.\nYou may play snow lands and cast snow spells from the top of your library.\nWhenever another snow permanent enters the battlefield under your control, you may pay {G}, {W}, or {U}. If you do, put a +1/+1 counter on Isu the Abominable.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "da92201f-0c11-5973-96da-abfea41a547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba97da8-0106-4e8b-b58b-8f2d63e3d618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba97da8-0106-4e8b-b58b-8f2d63e3d618.jpg?1",
             "name": "Kenessos, Priest of Thassa",
             "text": "If you would scry a number of cards, scry that many cards plus one instead.\n{3}{GW}: Look at the top card of your library. If it's a Kraken, Leviathan, Octopus, or Serpent creature card, you may put it onto the battlefield. If you don't put the card onto the battlefield, you may put it on the bottom of your library.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "4921b064-d9ff-51ef-95da-5361787e3a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc561d3-9e52-41fd-8311-60cc9dfffdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc561d3-9e52-41fd-8311-60cc9dfffdd1.jpg?1",
             "name": "Launch Mishap",
             "text": "Counter target creature or planeswalker spell. Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "1e10d522-a7d1-55d0-baf2-8a9984d83777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aacf99-39d1-4299-8557-6cc10ce9e35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aacf99-39d1-4299-8557-6cc10ce9e35f.jpg?1",
             "name": "Merfolk Pupil",
             "text": "When Merfolk Pupil enters the battlefield, draw a card, then discard a card.\n{1}{U}, Exile Merfolk Pupil from your graveyard: Draw a card, then discard a card.",
             "colours": [
@@ -524,7 +524,7 @@
         },
         {
             "id": "9f6b99af-486e-581d-b865-557843e325e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0567fb-2b4f-4fa9-8dfe-df4e665a4c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0567fb-2b4f-4fa9-8dfe-df4e665a4c5c.jpg?1",
             "name": "Pirated Copy",
             "text": "You may have Pirated Copy enter the battlefield as a copy of any creature on the battlefield, except it's a Pirate in addition to its other types and it has \"Whenever this creature or another creature with the same name deals combat damage to a player, you draw a card.\"",
             "colours": [
@@ -558,7 +558,7 @@
         },
         {
             "id": "77defcfd-f43b-528d-8be0-f4a60c0da4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cebbfa1-e709-45bb-9b86-c6b09e7866b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cebbfa1-e709-45bb-9b86-c6b09e7866b2.jpg?1",
             "name": "Soul Read",
             "text": "Choose one \u2014\n\u2022 Counter target spell unless its controller pays {4}.\n\u2022 Draw two cards.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "7402a36f-50fb-5a5b-8460-ffe4bbe136b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f10249-8cd0-4366-bd9a-755f8e1c3592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f10249-8cd0-4366-bd9a-755f8e1c3592.jpg?1",
             "name": "Synchronized Eviction",
             "text": "This spell costs {2} less to cast if you control at least two creatures that share a creature type.\nPut target nonland permanent into its owner's library second from the top.",
             "colours": [
@@ -620,7 +620,7 @@
         },
         {
             "id": "e8828925-5655-5bdc-8edb-ec59d185d383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fce5989-a2a0-4825-b90a-a1f78659b6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fce5989-a2a0-4825-b90a-a1f78659b6e0.jpg?1",
             "name": "Ashcoat of the Shadow Swarm",
             "text": "Whenever Ashcoat of the Shadow Swarm attacks or blocks, other Rats you control get +X/+X until end of turn, where X is the number of Rats you control.\nAt the beginning of your end step, you may mill four cards. If you do, return up to two Rat creature cards from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "e7564f59-90fa-519f-b38e-a2492f083f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4f19b-3c4e-4aa0-90f5-6cf397a5ad6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4f19b-3c4e-4aa0-90f5-6cf397a5ad6d.jpg?1",
             "name": "Conductor of Cacophony",
             "text": "Conductor of Cacophony enters the battlefield with two +1/+1 counters on it.\n{B}, Remove a +1/+1 counter from Conductor of Cacophony: It deals 1 damage to each other creature and each player.",
             "colours": [
@@ -689,7 +689,7 @@
         },
         {
             "id": "3153c071-7d57-5dae-9b20-756702c6b2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e3a9e1-fafe-4859-a550-7ae09804aced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e3a9e1-fafe-4859-a550-7ae09804aced.jpg?1",
             "name": "Creeping Bloodsucker",
             "text": "At the beginning of your upkeep, Creeping Bloodsucker deals 1 damage to each opponent. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "bc61d70f-1113-5156-9361-130f34c19ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78da23-e7ec-4a3d-9f79-09fb86993b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78da23-e7ec-4a3d-9f79-09fb86993b26.jpg?1",
             "name": "Deadly Plot",
             "text": "Choose one \u2014\n\u2022 Destroy target creature or planeswalker.\n\u2022 Return target Zombie creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "4f6c344f-356b-598c-90a9-a732bc91d4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9abb9b-5d52-401f-aa6b-189aad72bfc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9abb9b-5d52-401f-aa6b-189aad72bfc2.jpg?1",
             "name": "Disciple of Perdition",
             "text": "When Disciple of Perdition dies, choose one. If you have exactly 13 life, you may choose both.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Exile target opponent's graveyard. That player loses 1 life.",
             "colours": [
@@ -787,7 +787,7 @@
         },
         {
             "id": "50d11f75-2872-5524-baa1-13ea3252e845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dc52c-6f62-45cc-a5e2-95f794e04b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dc52c-6f62-45cc-a5e2-95f794e04b94.jpg?1",
             "name": "Ossuary Rats",
             "text": "When Ossuary Rats enters the battlefield, it deals X damage to target creature or planeswalker an opponent controls, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "aaf65fee-3a84-5564-bbc9-b921e2009208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9afd47b-ff94-4fdd-bb04-bdf9b8b61a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9afd47b-ff94-4fdd-bb04-bdf9b8b61a6d.jpg?1",
             "name": "Rodolf Duskbringer",
             "text": "Flying, deathtouch, lifelink\nWhenever you gain life, Rodolf Duskbringer gains indestructible until end of turn.\nAt the beginning of your end step, you may pay {1}{WB}. When you do, return target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of life you gained this turn.",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "ba3d790a-c047-5046-acf6-10483fa3c8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd4db9-8cab-4df2-ae65-0d7546c2d06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd4db9-8cab-4df2-ae65-0d7546c2d06b.jpg?1",
             "name": "Skullslither Worm",
             "text": "When Skullslither Worm enters the battlefield, each opponent discards a card. For each opponent who can't, put two +1/+1 counters on Skullslither Worm.",
             "colours": [
@@ -890,7 +890,7 @@
         },
         {
             "id": "d57037ae-4a1e-5db2-850f-5abac0caa7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff36347c-1fc1-4493-8e45-ef3372ecce45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff36347c-1fc1-4493-8e45-ef3372ecce45.jpg?1",
             "name": "Suspicious Shambler",
             "text": "{4}{B}{B}, Exile Suspicious Shambler from your graveyard: Create two 2/2 black Zombie creature tokens. Activate only as a sorcery.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "fa13e3ac-8fc8-577f-900e-79dff03639b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db59164-f0b1-4b5a-b821-ad0b2e1612d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db59164-f0b1-4b5a-b821-ad0b2e1612d1.jpg?1",
             "name": "Termination Facilitator",
             "text": "{T}: Put a bounty counter on target creature or planeswalker. Activate only as a sorcery.\nWhenever a creature or planeswalker an opponent controls with a bounty counter on it is dealt damage, destroy it.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "30f58c9c-9270-5820-96a5-9312b563ecac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a012f05-0009-42cf-8a69-07140b2a2aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a012f05-0009-42cf-8a69-07140b2a2aef.jpg?1",
             "name": "Ardoz, Cobbler of War",
             "text": "Haste\nWhenever Ardoz, Cobbler of War or another creature enters the battlefield under your control, that creature gets +2/+0 until end of turn.\n{3}{R}: Create a 1/1 red Goblin creature token with haste. Activate only as a sorcery.",
             "colours": [
@@ -993,7 +993,7 @@
         },
         {
             "id": "48cacc08-44a5-524a-a96a-32d8473c9e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c18d01-62cd-45c2-94b8-a63a4239311d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c18d01-62cd-45c2-94b8-a63a4239311d.jpg?1",
             "name": "Auntie Blyte, Bad Influence",
             "text": "Flying\nWhenever a source you control deals damage to you, put that many +1/+1 counters on Auntie Blyte, Bad Influence.\n{1}{R}, {T}, Remove X +1/+1 counters from Auntie Blyte: It deals X damage to any target.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "d8711ce6-7256-5dfd-9199-495464132f67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcbad10-475e-41cf-b3fb-68c1ca6c2caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcbad10-475e-41cf-b3fb-68c1ca6c2caa.jpg?1",
             "name": "Brazen Cannonade",
             "text": "Whenever an attacking creature you control dies, Brazen Cannonade deals 2 damage to each opponent.\nRaid \u2014 At the beginning of your postcombat main phase, if you attacked with a creature this turn, exile the top card of your library. Until end of combat on your next turn, you may play that card.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "7b9d2c02-3aad-5deb-9edf-0ae6121fc2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d581e4f-77a7-4ad1-a263-882babffded8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d581e4f-77a7-4ad1-a263-882babffded8.jpg?1",
             "name": "Coalborn Entity",
             "text": "{2}{R}: Coalborn Entity deals 1 damage to target creature token, player, or planeswalker.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "871d9699-898c-5f9b-a726-75a535bf9156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6ce176-a4f3-44dd-b66a-a23b6cf512e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6ce176-a4f3-44dd-b66a-a23b6cf512e4.jpg?1",
             "name": "Daring Piracy",
             "text": "At the beginning of combat on your turn, create a 1/1 red Pirate creature token with menace and haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "b0136741-ee78-54ca-8355-c2035db55f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529e62a1-a32f-477a-ae5c-955f3df2a628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529e62a1-a32f-477a-ae5c-955f3df2a628.jpg?1",
             "name": "Goblin Researcher",
             "text": "When Goblin Researcher enters the battlefield, exile the top card of your library. During any turn you attacked with Goblin Researcher, you may play that card.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "7bcc7917-d2d3-5d2f-81fe-78041a2e8087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf1d83-3b6b-4e07-a024-3dfd37c29814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf1d83-3b6b-4e07-a024-3dfd37c29814.jpg?1",
             "name": "Mizzix, Replica Rider",
             "text": "Flying\nWhenever you cast a spell from anywhere other than your hand, you may pay {1}{UR}. If you do, copy that spell and you may choose new targets for the copy. If the copy is a permanent spell, it gains haste and \"At the beginning of your end step, sacrifice this permanent.\" (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "b0abaf92-f014-528e-98b9-e921a0a159ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f1ab2-4c66-4d91-8f6a-1bad230632df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f1ab2-4c66-4d91-8f6a-1bad230632df.jpg?1",
             "name": "Ogre Battlecaster",
             "text": "First strike\nWhenever Ogre Battlecaster attacks, you may cast target instant or sorcery card from your graveyard by paying {R}{R} in addition to its other costs. If that spell would be put into a graveyard, exile it instead. When you cast that spell, Ogre Battlecaster gets +X/+0 until end of turn, where X is that spell's mana value.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "0a17b823-106b-5d15-82a4-a7014ace465d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b3f46-0e62-4f44-8064-857cd3040659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b3f46-0e62-4f44-8064-857cd3040659.jpg?1",
             "name": "Plundering Predator",
             "text": "Flying\nWhen Plundering Predator enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "ab80e21e-d66b-5962-bdb4-1f15728cf82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575ed35-6357-4b48-9d20-e4249577142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575ed35-6357-4b48-9d20-e4249577142b.jpg?1",
             "name": "Benevolent Hydra",
             "text": "Benevolent Hydra enters the battlefield with X +1/+1 counters on it.\nIf one or more +1/+1 counters would be put on another creature you control, that many plus one +1/+1 counters are put on it instead.\n{T}, Remove a +1/+1 counter from Benevolent Hydra: Put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "c24753a8-1e19-5f75-b4df-13f3e587d4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg?1",
             "name": "Giant Ladybug",
             "text": "Reach\nWhen Giant Ladybug enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "43cc81e1-bd9e-5e64-9bb1-178b1b8984db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71345a-c3e8-4b35-beb7-6347e41d7626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71345a-c3e8-4b35-beb7-6347e41d7626.jpg?1",
             "name": "Kibo, Uktabi Prince",
             "text": "{T}: Each player creates a colorless artifact token named Banana with \"{T}, Sacrifice this artifact: Add {R} or {G}. You gain 2 life.\"\nWhenever an artifact an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on each creature you control that's an Ape or a Monkey.\nWhenever Kibo attacks, defending player sacrifices an artifact.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "531f53cf-59d9-524d-8584-f5b8b17d116d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg?1",
             "name": "Mild-Mannered Librarian",
             "text": "{3}{G}: Mild-Mannered Librarian becomes a Werewolf. Put two +1/+1 counters on it and you draw a card. Activate only once.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "c07fae46-278a-5525-bca6-53c8a7c45a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0a91b-246b-4c1f-9b98-2ad6ff1ba124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0a91b-246b-4c1f-9b98-2ad6ff1ba124.jpg?1",
             "name": "Primeval Herald",
             "text": "Trample\nWhenever Primeval Herald enters the battlefield or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1434,7 +1434,7 @@
         },
         {
             "id": "09fc5efd-3c5a-5eef-8a91-abbb4988a11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218779-7e18-4fa2-a0bb-c07052951a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218779-7e18-4fa2-a0bb-c07052951a78.jpg?1",
             "name": "Rampaging Growth",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle. Until end of turn, that land becomes a 4/3 Insect creature with reach and haste. It's still a land.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "c6db5f0b-3eab-57de-85ee-28e11bb7718a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f5500f-e82c-44f3-8be8-cee4c86824b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f5500f-e82c-44f3-8be8-cee4c86824b1.jpg?1",
             "name": "Runadi, Behemoth Caller",
             "text": "Whenever you cast a creature spell with mana value 5 or greater, that creature enters the battlefield with X additional +1/+1 counters on it, where X is its mana value minus 4.\nCreatures you control with three or more +1/+1 counters on them have haste.\n{T}: Add {G}.",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "cbf446f2-5681-5375-b921-8be3fc2813a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg?1",
             "name": "Spectral Hunt-Caller",
             "text": "{5}{G}: Creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "e8db91ce-0042-533c-8aec-6250020c2097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a22aa-0f79-4497-a7ff-08d92d14bc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a22aa-0f79-4497-a7ff-08d92d14bc0f.jpg?1",
             "name": "Towering Gibbon",
             "text": "Reach\nTowering Gibbon's power is equal to the greatest mana value among creatures you control.",
             "colours": [
@@ -1568,7 +1568,7 @@
         },
         {
             "id": "a3a6fac1-797f-5012-960f-1a3cb5de6486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eafc507-973a-4aec-91b9-c29d70b0e25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eafc507-973a-4aec-91b9-c29d70b0e25d.jpg?1",
             "name": "Zask, Skittering Swarmlord",
             "text": "You may play lands and cast Insect spells from your graveyard.\nWhenever another Insect you control dies, put it on the bottom of its owner's library, then mill two cards. (Put the top two cards of your library into your graveyard.)\n{1}{BG}: Target Insect gets +1/+0 and gains deathtouch until end of turn. ({BG} can be paid with either {B} or {G}.)",
             "colours": [
@@ -1604,7 +1604,7 @@
         },
         {
             "id": "288f5d55-8f1b-5a94-bf7e-c6fe70867341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de6fc60-89ad-4c6f-a734-5344e5b954fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de6fc60-89ad-4c6f-a734-5344e5b954fa.jpg?1",
             "name": "Dutiful Replicator",
             "text": "When Dutiful Replicator enters the battlefield, you may pay {1}. When you do, create a token that's a copy of target token you control not named Dutiful Replicator.",
             "colours": [],
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "2b1dcc69-8919-5dd2-9dc7-dcfb77bef15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d986229-c8d5-462c-bf74-ae94326a5aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d986229-c8d5-462c-bf74-ae94326a5aa0.jpg?1",
             "name": "Infernal Idol",
             "text": "{T}: Add {B}.\n{1}{B}{B}, {T}, Sacrifice Infernal Idol: You draw two cards and you lose 2 life.",
             "colours": [],
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "e3a78c5c-9e24-5ee4-a9db-1ab20c00ffea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9526bea2-8d47-4a82-a617-6c57c7abc69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9526bea2-8d47-4a82-a617-6c57c7abc69a.jpg?1",
             "name": "Instruments of War",
             "text": "Flash\nAs Instruments of War enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "289437fb-5421-55ee-b59e-fc215f1cebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909b15e4-c6c8-44bf-a993-13a97de40e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909b15e4-c6c8-44bf-a993-13a97de40e36.jpg?1",
             "name": "Planar Atlas",
             "text": "Planar Atlas enters the battlefield tapped.\nWhen Planar Atlas enters the battlefield, you may look at the top four cards of your library. If you do, reveal up to one land card from among them, then put that card on top of your library and the rest on the bottom in a random order.\n{T}: Add {C}.",
             "colours": [],
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "20f06f2f-7c32-55cc-95a9-3dbb76f88b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b9897-a473-4c47-994a-a6d7e9e81ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b9897-a473-4c47-994a-a6d7e9e81ef2.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "7d605089-ac8e-5774-9f7d-68df32080ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f6da2e-3759-4550-999f-2c0fa6c76c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f6da2e-3759-4550-999f-2c0fa6c76c73.jpg?1",
             "name": "Balan, Wandering Knight",
             "text": "First strike\nBalan, Wandering Knight has double strike as long as two or more Equipment are attached to it.\n{1}{W}: Attach all Equipment you control to Balan.",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "7e05b848-0153-588b-9e96-6a318a45cb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ad5c0-a343-4d1a-9a85-1f4d5fa64079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ad5c0-a343-4d1a-9a85-1f4d5fa64079.jpg?1",
             "name": "Eidolon of Rhetoric",
             "text": "Each player can't cast more than one spell each turn.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "6a461222-0483-5713-82b6-aefb33672a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5927be-dd6b-4ebb-a7f9-affd66d78b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5927be-dd6b-4ebb-a7f9-affd66d78b3a.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "091046f6-5173-5a6c-8a95-1df1b016b0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6417e616-0490-4d89-a8ab-9b92fcc62a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6417e616-0490-4d89-a8ab-9b92fcc62a29.jpg?1",
             "name": "Flicker of Fate",
             "text": "Exile target creature or enchantment, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "91b0d2ec-fd9a-57f1-902e-83490239d7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b8343f-0554-42b1-9e32-431dcc4b0346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b8343f-0554-42b1-9e32-431dcc4b0346.jpg?1",
             "name": "King of the Pride",
             "text": "Other Cats you control get +2/+1.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "9dba7db2-8719-5a06-9dd3-fedd67dfda9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef561541-c64a-419a-87b3-b2c71d8161c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef561541-c64a-419a-87b3-b2c71d8161c5.jpg?1",
             "name": "Sage's Reverie",
             "text": "Enchant creature\nWhen Sage's Reverie enters the battlefield, draw a card for each Aura you control that's attached to a creature.\nEnchanted creature gets +1/+1 for each Aura you control that's attached to a creature.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "b2ce5f75-a792-5ac7-95f3-01757a2660af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7297c43-41bf-41f0-8df0-c1b1c2e5e951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7297c43-41bf-41f0-8df0-c1b1c2e5e951.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "daecbcfc-6f21-5596-9b4b-78b315be6484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2b53e2-aa6a-4cb2-899c-8e022e822ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2b53e2-aa6a-4cb2-899c-8e022e822ffc.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "Spells your opponents cast that target a creature or planeswalker you control cost {2} more to cast.\n\u22122: Create a 2/2 blue Wizard creature token. Draw a card, then discard a card.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "086cd5da-d9aa-56f3-84f7-342a37bf659a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6487eeae-95c9-4aa6-b1a9-1af8e405f0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6487eeae-95c9-4aa6-b1a9-1af8e405f0df.jpg?1",
             "name": "Merrow Reejerey",
             "text": "Other Merfolk creatures you control get +1/+1.\nWhenever you cast a Merfolk spell, you may tap or untap target permanent.",
             "colours": [
@@ -2052,7 +2052,7 @@
         },
         {
             "id": "c101c8d3-5164-5609-884a-f86a4423cbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b7f07-cffb-4797-94a6-3279714b1c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b7f07-cffb-4797-94a6-3279714b1c88.jpg?1",
             "name": "Mirror Image",
             "text": "You may have Mirror Image enter the battlefield as a copy of a creature you control.",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "fdaf13d4-35e4-5fed-b8f1-7a58484d2bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95460ec-153d-4fe0-a261-f9840a174308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95460ec-153d-4fe0-a261-f9840a174308.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2116,7 +2116,7 @@
         },
         {
             "id": "9b2264ed-b29d-549a-b676-48d1d960b036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7743b587-e498-4761-9173-e803c9eed86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7743b587-e498-4761-9173-e803c9eed86b.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "3566a8c3-a2d3-5c76-aa66-5d034ecd5461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e262a3-0e69-4d61-8143-b9d137c31496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e262a3-0e69-4d61-8143-b9d137c31496.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "Flash\nFlying\nWhen Spellstutter Sprite enters the battlefield, counter target spell with mana value X or less, where X is the number of Faeries you control.",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "e07d1c4e-22db-5e1e-8dee-5ed329e88407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62a27a8-271c-4ac8-97a5-2efb192e3a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62a27a8-271c-4ac8-97a5-2efb192e3a15.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "99fd1ed6-6f82-56d4-be6f-f57cf5b11475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abd138-b840-4222-88ad-7b0ed64a927b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abd138-b840-4222-88ad-7b0ed64a927b.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "dc5745c8-0e21-500f-bcbe-4582f5842620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0f98c-264e-4d82-893a-5f84fc890705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0f98c-264e-4d82-893a-5f84fc890705.jpg?1",
             "name": "Feast on the Fallen",
             "text": "At the beginning of each upkeep, if an opponent lost life last turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "a09b0f04-0276-5859-8716-f3314a75bbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67c2c4c-f593-4e46-910c-616d3135a8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67c2c4c-f593-4e46-910c-616d3135a8b1.jpg?1",
             "name": "Lord of the Accursed",
             "text": "Other Zombies you control get +1/+1.\n{1}{B}, {T}: All Zombies gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2314,7 +2314,7 @@
         },
         {
             "id": "ca13cd47-74cf-5cee-af3d-6748ffb19a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04099735-bc73-40ae-bc28-0ad5c96feb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04099735-bc73-40ae-bc28-0ad5c96feb12.jpg?1",
             "name": "Oathsworn Vampire",
             "text": "Oathsworn Vampire enters the battlefield tapped.\nYou may cast Oathsworn Vampire from your graveyard if you gained life this turn.",
             "colours": [
@@ -2348,7 +2348,7 @@
         },
         {
             "id": "1f08a6dd-cada-56e8-898c-5e54d044f5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f176f9-d353-479e-a808-54dc5e8ff746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f176f9-d353-479e-a808-54dc5e8ff746.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "9438892d-99dc-59f6-9c35-78ee4f9e014f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad4b00-b56b-4b55-9e6f-3de3e3748fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad4b00-b56b-4b55-9e6f-3de3e3748fe9.jpg?1",
             "name": "Plaguecrafter",
             "text": "When Plaguecrafter enters the battlefield, each player sacrifices a creature or planeswalker. Each player who can't discards a card.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "ca47e990-94a0-5b13-a870-13658b1ecf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e65e74-14fc-4286-84d3-36c70d6dcf46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e65e74-14fc-4286-84d3-36c70d6dcf46.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "When Stitcher's Supplier enters the battlefield or dies, mill three cards. (Put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "aefd11fd-6f77-584c-8546-ea69986d0c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecbe209-7f91-4add-98e0-e6ffa1739631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecbe209-7f91-4add-98e0-e6ffa1739631.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -2484,7 +2484,7 @@
         },
         {
             "id": "00101d47-ae6f-54fd-9fd6-b265478229a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4aef6f-10f8-4376-8518-a3165d0df062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4aef6f-10f8-4376-8518-a3165d0df062.jpg?1",
             "name": "Tree of Perdition",
             "text": "Defender\n{T}: Exchange target opponent's life total with Tree of Perdition's toughness.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "5289db83-25b9-5341-a13f-be28b581e908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686d43eb-ea91-4ae1-bdc4-dcd885688acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686d43eb-ea91-4ae1-bdc4-dcd885688acd.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -2550,7 +2550,7 @@
         },
         {
             "id": "950e280a-0dcc-5ca4-8581-dd7874eab1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f4ae10-a3da-4d4f-8706-87ccb076c1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f4ae10-a3da-4d4f-8706-87ccb076c1f2.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever Dragon Mage deals combat damage to a player, each player discards their hand, then draws seven cards.",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "e9b37e98-82f0-5e9b-9af3-c37d0264925d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b5d44-a314-4d72-b4fe-25d6921d51cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b5d44-a314-4d72-b4fe-25d6921d51cb.jpg?1",
             "name": "Drannith Stinger",
             "text": "Whenever you cycle another card, Drannith Stinger deals 1 damage to each opponent.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "2c06c445-882b-5641-8085-f5f66b21a402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6fc996-17ba-4090-bf82-0c2eba93a81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6fc996-17ba-4090-bf82-0c2eba93a81e.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Create a token that's a copy of target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "04e49223-23e4-5793-9ddd-c35d16c48a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5d5f0b-7574-43d9-b9ab-b4d0fa419212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5d5f0b-7574-43d9-b9ab-b4d0fa419212.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "5676abff-b841-50ea-a937-a9415f70e3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2bc701-2a18-4e49-acef-5e18ebfba64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2bc701-2a18-4e49-acef-5e18ebfba64f.jpg?1",
             "name": "Rigging Runner",
             "text": "First strike\nRaid \u2014 Rigging Runner enters the battlefield with a +1/+1 counter on it if you attacked this turn.",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "d7642caa-82fa-5183-ace7-98b0eb9d693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77d7286-fb41-4078-ada0-38622b84ddd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77d7286-fb41-4078-ada0-38622b84ddd0.jpg?1",
             "name": "Spear Spewer",
             "text": "Defender\n{T}: Spear Spewer deals 1 damage to each player.",
             "colours": [
@@ -2755,7 +2755,7 @@
         },
         {
             "id": "cc40557d-d036-567e-ba41-a2db2836fe37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd33b2c2-9f1c-4304-bbc3-e9bee5d4052f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd33b2c2-9f1c-4304-bbc3-e9bee5d4052f.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "c8c0fe27-9312-58e7-a023-8d4a09d1b2f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3b2cb7-06a3-4c2e-9684-480b0e4c005f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3b2cb7-06a3-4c2e-9684-480b0e4c005f.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "a8382f74-e7fb-5224-a1fa-4e392b189b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bee15d-6868-4dfc-9dd9-b437c5f3d6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bee15d-6868-4dfc-9dd9-b437c5f3d6db.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "Each creature you control that's a Wolf or a Werewolf enters the battlefield with an additional +1/+1 counter on it.\n\u22122: Create a 2/2 green Wolf creature token.",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "5714c157-5505-5cd7-b075-ee939f2a8713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0e3e1-a578-4c3d-95d1-f1c6c243779d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0e3e1-a578-4c3d-95d1-f1c6c243779d.jpg?1",
             "name": "Caustic Caterpillar",
             "text": "{1}{G}, Sacrifice Caustic Caterpillar: Destroy target artifact or enchantment.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "62518ada-ad4a-527b-bbf9-8de7ddbc61bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1764f-9b62-4977-9fee-1266f0ea01aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1764f-9b62-4977-9fee-1266f0ea01aa.jpg?1",
             "name": "Colossal Majesty",
             "text": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "4f3b29ca-8882-5629-9254-b359e3cf2760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d657f45-ee7f-4114-a570-314688138b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d657f45-ee7f-4114-a570-314688138b4f.jpg?1",
             "name": "Elvish Rejuvenator",
             "text": "When Elvish Rejuvenator enters the battlefield, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "417a8939-38e1-5833-bc04-4beca8a8a06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095a1dcb-fb19-4449-9148-851b7e06c16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095a1dcb-fb19-4449-9148-851b7e06c16f.jpg?1",
             "name": "Hydra's Growth",
             "text": "Enchant creature\nWhen Hydra's Growth enters the battlefield, put a +1/+1 counter on enchanted creature.\nAt the beginning of your upkeep, double the number of +1/+1 counters on enchanted creature.",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "376a7178-fdb0-55f0-8021-f5a3573b7f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9079b4-71c9-4afb-ba81-3d3bece084e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9079b4-71c9-4afb-ba81-3d3bece084e7.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "a01bcc41-3b8b-5e0b-8398-43c817b3c4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d41ca70-8a47-44a7-9494-265e2f401028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d41ca70-8a47-44a7-9494-265e2f401028.jpg?1",
             "name": "Ram Through",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "069f2dc0-229f-5a0f-81b7-43b819e706fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a65e7c-3f2e-44d1-8f85-4acf5f147c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a65e7c-3f2e-44d1-8f85-4acf5f147c17.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "b98fb339-afaf-520d-933b-9d7252184ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2979d4b-2a95-4178-a204-b2df09042135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2979d4b-2a95-4178-a204-b2df09042135.jpg?1",
             "name": "World Breaker",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, exile target artifact, enchantment, or land.\nReach\n{2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand. ({C} represents colorless mana.)",
             "colours": [],
@@ -3114,7 +3114,7 @@
         },
         {
             "id": "facb7d51-4e64-5cfc-8b09-16cbeda5d0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2599b027-1ff8-48b8-8a90-8ac1fac7ed63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2599b027-1ff8-48b8-8a90-8ac1fac7ed63.jpg?1",
             "name": "Coldsteel Heart",
             "text": "Coldsteel Heart enters the battlefield tapped.\nAs Coldsteel Heart enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "7d41aef0-fdc0-5404-a0b2-8d83e9b0b9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db997a7-d54c-4821-9e9f-56292f9e7e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db997a7-d54c-4821-9e9f-56292f9e7e5a.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "cf6c02be-67cf-5f9c-8ba3-a649e85821ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae799ee8-f1cf-4259-9e78-def9fc13b63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae799ee8-f1cf-4259-9e78-def9fc13b63a.jpg?1",
             "name": "Peacewalker Colossus",
             "text": "{1}{W}: Another target Vehicle you control becomes an artifact creature until end of turn.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -3201,7 +3201,7 @@
         },
         {
             "id": "784adfff-ed29-557e-9289-fdab2885fa97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740dbebf-9e0b-4918-850b-8c1aa0b06c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740dbebf-9e0b-4918-850b-8c1aa0b06c18.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -3232,7 +3232,7 @@
         },
         {
             "id": "8d85452d-cbb7-56ab-af92-737a8dade8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a479838-b6b1-4d83-9104-0a79f3b934c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a479838-b6b1-4d83-9104-0a79f3b934c7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3268,7 +3268,7 @@
         },
         {
             "id": "3a5e8b25-5db5-5de4-ade0-9131700eb16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464fa166-82be-4f28-8fd8-0c9cc4393012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464fa166-82be-4f28-8fd8-0c9cc4393012.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "1feb83ee-4542-576a-9f09-5a08d3c7d0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4b8bde-412b-4d12-b296-7364c95e0510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4b8bde-412b-4d12-b296-7364c95e0510.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "be47edd4-58d7-5216-9ab3-541c33934457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0559d67-e151-4c6b-b8eb-5e9b5603f487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0559d67-e151-4c6b-b8eb-5e9b5603f487.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "078dbb69-e17b-5d0a-967e-887d605796da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49050cb4-1d8b-4f2f-ba48-206a107eb09c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49050cb4-1d8b-4f2f-ba48-206a107eb09c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3412,7 +3412,7 @@
         },
         {
             "id": "6b885758-9973-5e10-8113-89e02702cfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4237eaa8-1169-47b2-9009-ac529831a36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4237eaa8-1169-47b2-9009-ac529831a36e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "093129a3-934b-56cd-a114-4f90aeb254af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fec83d-8260-478e-a20f-94d265036e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fec83d-8260-478e-a20f-94d265036e31.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "15996ac2-4d38-58bf-9d76-b1267c4bb75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a442a-16a0-459a-8c24-cd0c72edee03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a442a-16a0-459a-8c24-cd0c72edee03.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "0d43138e-22ce-505d-af04-d6e80c162104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802ec1c-4d12-45d0-930b-6b4ca77487e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802ec1c-4d12-45d0-930b-6b4ca77487e8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "dd775312-0618-5a75-bf7e-6a8c8dab755a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577aff75-67f7-42c8-b31f-50026c5ba5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577aff75-67f7-42c8-b31f-50026c5ba5c6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "096fa466-11da-51cd-86a2-c246cafe95c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c79d57-a8eb-427d-86ac-b203c0bb7cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c79d57-a8eb-427d-86ac-b203c0bb7cda.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3628,7 +3628,7 @@
         },
         {
             "id": "4c4b9005-a05a-5c95-ab52-d7db96b20954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cfd796-50a5-404f-acc1-21dbf543ccc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cfd796-50a5-404f-acc1-21dbf543ccc1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "08bb8f11-5a93-5121-9f05-f55d07e2dc6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee97ab6-8e81-4396-a788-db0ed0da62d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee97ab6-8e81-4396-a788-db0ed0da62d2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "bda821c9-421f-5543-b713-e1d664914488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee56689a-da7b-4cd7-8767-e3f514b6db9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee56689a-da7b-4cd7-8767-e3f514b6db9e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "4a472a30-00d1-56f4-b8d2-cc23f616fcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900eedf8-71b0-4b82-9709-019018bc29fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900eedf8-71b0-4b82-9709-019018bc29fe.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3772,7 +3772,7 @@
         },
         {
             "id": "6b58ba9e-91ae-5537-81a1-64ca79215d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1db6ef2-92a7-4dc1-bb7f-f9ad1dd76593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1db6ef2-92a7-4dc1-bb7f-f9ad1dd76593.jpg?1",
             "name": "Task Force",
             "text": "Whenever Task Force becomes the target of a spell or ability, it gets +0/+3 until end of turn.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "0f989a90-c73e-5f4e-ac54-7a347c674907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f37c5b6-a59c-45cd-9a99-e9357fe9ea1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f37c5b6-a59c-45cd-9a99-e9357fe9ea1b.jpg?1",
             "name": "Rhystic Study",
             "text": "Whenever an opponent casts a spell, you may draw a card unless that player pays {1}.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "bece7cc1-1965-5ccb-9f5e-4dec700800f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31430e8-538b-4361-ba80-b91b2ca0fe36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31430e8-538b-4361-ba80-b91b2ca0fe36.jpg?1",
             "name": "Tragic Lesson",
             "text": "Draw two cards. Then discard a card unless you return a land you control to its owner's hand.",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "6cf4e3a3-56dc-57d2-a55f-43617912b8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24faaf5-f63f-4c46-9bed-ae4693ff8e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24faaf5-f63f-4c46-9bed-ae4693ff8e9a.jpg?1",
             "name": "Wizard Mentor",
             "text": "{T}: Return Wizard Mentor and target creature you control to their owner's hand.",
             "colours": [
@@ -3902,7 +3902,7 @@
         },
         {
             "id": "0b2c58ab-1164-54df-a994-22811199e0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1641d-c4ea-4657-a0ae-db09bba83a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1641d-c4ea-4657-a0ae-db09bba83a0f.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "c5b8d910-3f73-5c43-85a9-695eb647ce47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f576f3b6-59c5-4710-b238-7fb2bbcf563e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f576f3b6-59c5-4710-b238-7fb2bbcf563e.jpg?1",
             "name": "Feast of Blood",
             "text": "Cast this spell only if you control two or more Vampires.\nDestroy target creature. You gain 4 life.",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "42346c9e-7dc9-573e-8fb6-6deb499d3cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc58d8cd-f1f8-4a3e-9052-12e319802cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc58d8cd-f1f8-4a3e-9052-12e319802cb5.jpg?1",
             "name": "Festering Evil",
             "text": "At the beginning of your upkeep, Festering Evil deals 1 damage to each creature and each player.\n{B}{B}, Sacrifice Festering Evil: It deals 3 damage to each creature and each player.",
             "colours": [
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "21022eb6-a898-5d6e-8cb7-877718d43de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be82e102-b62d-4590-85d4-dd9b5811510d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be82e102-b62d-4590-85d4-dd9b5811510d.jpg?1",
             "name": "Ghoul's Feast",
             "text": "Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "42d37abd-e345-5044-a2d0-99e0789d9836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28e4a2-5ed6-43f5-a38d-b8bb30d935d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28e4a2-5ed6-43f5-a38d-b8bb30d935d9.jpg?1",
             "name": "Morkrut Banshee",
             "text": "Morbid \u2014 When Morkrut Banshee enters the battlefield, if a creature died this turn, target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "7ba330df-12e7-51bb-ba6c-390bab78a6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987aa13-8d61-4db7-9680-63421e729325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987aa13-8d61-4db7-9680-63421e729325.jpg?1",
             "name": "Nezumi Bone-Reader",
             "text": "{B}, Sacrifice a creature: Target player discards a card. Activate only as a sorcery.",
             "colours": [
@@ -4095,7 +4095,7 @@
         },
         {
             "id": "b9600289-ccf7-5152-88bd-de6fe46f7da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e537802-164f-4ba2-8f3a-9ebc845e05fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e537802-164f-4ba2-8f3a-9ebc845e05fd.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "{T}, Sacrifice Phyrexian Plaguelord: Target creature gets -4/-4 until end of turn.\nSacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "89ede49e-e620-5ec6-98cf-e820d4626639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a82ea-6d35-4121-84bb-93adff381f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a82ea-6d35-4121-84bb-93adff381f99.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4160,7 +4160,7 @@
         },
         {
             "id": "ef55f5c6-5620-5a54-92ab-56888c4a0436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835da43-0a3e-40fb-a7e8-4fa118c7d975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835da43-0a3e-40fb-a7e8-4fa118c7d975.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -4194,7 +4194,7 @@
         },
         {
             "id": "573573a8-6427-548d-8620-fdc274e79ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee747f-4a9e-4752-815a-dc7ebabccd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee747f-4a9e-4752-815a-dc7ebabccd6b.jpg?1",
             "name": "Renegade Demon",
             "text": "",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "e1a710e8-3af7-5c6d-8348-4c1a491875cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675b8a4-3cbc-458f-bdc3-1ec85f95dde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675b8a4-3cbc-458f-bdc3-1ec85f95dde9.jpg?1",
             "name": "Swarm of Bloodflies",
             "text": "Flying\nSwarm of Bloodflies enters the battlefield with two +1/+1 counters on it.\nWhenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "7cc0160f-9b0c-5d0e-a665-3309442781cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd24ce-6b37-4801-b10f-5e2dbada7a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd24ce-6b37-4801-b10f-5e2dbada7a41.jpg?1",
             "name": "Wakedancer",
             "text": "Morbid \u2014 When Wakedancer enters the battlefield, if a creature died this turn, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "354359de-d4ac-533c-a724-6393f6dea88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc85084-f948-4d66-ae3c-67fd82fb3acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc85084-f948-4d66-ae3c-67fd82fb3acf.jpg?1",
             "name": "Aftershock",
             "text": "Destroy target artifact, creature, or land. Aftershock deals 3 damage to you.",
             "colours": [
@@ -4325,7 +4325,7 @@
         },
         {
             "id": "bbfbdfda-a70d-5993-bb74-dcc10fd5aaf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb92c7-29d0-40fc-80ae-3c7f0cdd2218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb92c7-29d0-40fc-80ae-3c7f0cdd2218.jpg?1",
             "name": "Fireslinger",
             "text": "{T}: Fireslinger deals 1 damage to any target and 1 damage to you.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "5a689668-9ee1-5a1d-b5da-61a364e96850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02d939-cca4-4f80-b4e8-0bc92032c23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02d939-cca4-4f80-b4e8-0bc92032c23e.jpg?1",
             "name": "Flameblade Adept",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever you cycle or discard a card, Flameblade Adept gets +1/+0 until end of turn.",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "fcbad822-4c25-5860-9091-3ca4c8204186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291d064-b191-4ff6-940a-c9cfc4289ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291d064-b191-4ff6-940a-c9cfc4289ff8.jpg?1",
             "name": "Ruin in Their Wake",
             "text": "Devoid (This card has no color.)\nSearch your library for a basic land card and reveal it. You may put that card onto the battlefield tapped if you control a land named Wastes. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "cd3848b8-d5b1-5056-bdf7-2d0997916e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cff91-9f18-4ebc-8deb-3d4bf617fdb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cff91-9f18-4ebc-8deb-3d4bf617fdb9.jpg?1",
             "name": "Uktabi Orangutan",
             "text": "When Uktabi Orangutan enters the battlefield, destroy target artifact.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "9342833e-4694-5fbd-97e4-1ea68fb2b02b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecca4c21-a076-4ddf-b61c-c1164eba5513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecca4c21-a076-4ddf-b61c-c1164eba5513.jpg?1",
             "name": "Wicked Wolf",
             "text": "When Wicked Wolf enters the battlefield, it fights up to one target creature you don't control.\nSacrifice a Food: Put a +1/+1 counter on Wicked Wolf. It gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "18cec106-80c4-5fb3-8b7a-ab3a9c24b410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a14f1-7230-4b4e-998b-543a2971324e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a14f1-7230-4b4e-998b-543a2971324e.jpg?1",
             "name": "Clockwork Hydra",
             "text": "Clockwork Hydra enters the battlefield with four +1/+1 counters on it.\nWhenever Clockwork Hydra attacks or blocks, remove a +1/+1 counter from it. If you do, Clockwork Hydra deals 1 damage to any target.\n{T}: Put a +1/+1 counter on Clockwork Hydra.",
             "colours": [],
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "5ed7986f-1c80-5f11-9519-2efb7a872cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f1ece0-83be-4f46-8c17-3fb0af900b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f1ece0-83be-4f46-8c17-3fb0af900b7a.jpg?1",
             "name": "Spawning Pit",
             "text": "Sacrifice a creature: Put a charge counter on Spawning Pit.\n{1}, Remove two charge counters from Spawning Pit: Create a 2/2 colorless Spawn artifact creature token.",
             "colours": [],
@@ -4545,7 +4545,7 @@
         },
         {
             "id": "d8aa6791-b267-5bf8-affb-0aca12a2d7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e96d842-721d-4662-b94d-e6c6cc1f32ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e96d842-721d-4662-b94d-e6c6cc1f32ed.jpg?1",
             "name": "Leechridden Swamp",
             "text": "({T}: Add {B}.)\nLeechridden Swamp enters the battlefield tapped.\n{B}, {T}: Each opponent loses 1 life. Activate only if you control two or more black permanents.",
             "colours": [],
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "a9cd935b-1238-5771-808f-179a530a6c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fd2df9-496b-440a-8667-17af4fb62731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fd2df9-496b-440a-8667-17af4fb62731.jpg?1",
             "name": "Acrobatic Maneuver",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "a10844fb-2fa3-5395-bc44-5d2f3bb9ac26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a54d1-64d0-4dc6-99a2-148052af1e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a54d1-64d0-4dc6-99a2-148052af1e61.jpg?1",
             "name": "Aerial Modification",
             "text": "Enchant creature or Vehicle\nAs long as enchanted permanent is a Vehicle, it's a creature in addition to its other types.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "aead2360-3fbc-5df2-a1c1-79698ce23620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd33b41-e8f4-46e2-9a44-9cba5758a6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd33b41-e8f4-46e2-9a44-9cba5758a6fb.jpg?1",
             "name": "Aethershield Artificer",
             "text": "At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "3f2d717e-3c46-5d37-a7e9-53321d192708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58deb8a-1c4b-4e3d-9c00-63f615f358c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58deb8a-1c4b-4e3d-9c00-63f615f358c0.jpg?1",
             "name": "Ajani, Strength of the Pride",
             "text": "+1: You gain life equal to the number of creatures you control plus the number of planeswalkers you control.\n\u22122: Create a 2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.\"\n0: If you have at least 15 life more than your starting life total, exile Ajani, Strength of the Pride and each artifact and creature your opponents control.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "5a148e45-8603-5f94-84d4-2d5a726fd614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc35481-1f63-4c04-aee9-b3fe8eb89916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc35481-1f63-4c04-aee9-b3fe8eb89916.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "1dea6f81-f036-547b-9e01-653c70537465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dbfdac-059c-411c-aeac-6d849ee54212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dbfdac-059c-411c-aeac-6d849ee54212.jpg?1",
             "name": "Alseid of Life's Bounty",
             "text": "Lifelink\n{1}, Sacrifice Alseid of Life's Bounty: Target creature or enchantment you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "6c2c59d0-ffd0-50f3-b6ff-74a3779c4219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39a1e1-9784-4cb0-b8ed-98e659b32edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39a1e1-9784-4cb0-b8ed-98e659b32edd.jpg?1",
             "name": "Angel of Flight Alabaster",
             "text": "Flying\nAt the beginning of your upkeep, return target Spirit card from your graveyard to your hand.",
             "colours": [
@@ -4810,7 +4810,7 @@
         },
         {
             "id": "0bb208c2-df50-5958-ab09-178726dc4ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef1f8f-42bc-4e0a-96d3-4904fbdcc923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef1f8f-42bc-4e0a-96d3-4904fbdcc923.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "380f1ef9-1177-5ae4-8fe1-98a5a1261335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623d9e1d-4154-4d77-bd0e-e6204117dc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623d9e1d-4154-4d77-bd0e-e6204117dc83.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "a9193791-fa6a-589f-83b9-13524e16b200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4586e3c-9463-4663-8746-021a7496f3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4586e3c-9463-4663-8746-021a7496f3c5.jpg?1",
             "name": "Angelic Protector",
             "text": "Flying\nWhenever Angelic Protector becomes the target of a spell or ability, Angelic Protector gets +0/+3 until end of turn.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "6bb0e2df-93a3-5091-8422-8bf54545c2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570bb02-394c-424c-98ad-30824a097d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570bb02-394c-424c-98ad-30824a097d1b.jpg?1",
             "name": "Anointer of Valor",
             "text": "Flying\nWhenever a creature attacks, you may pay {3}. When you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "92590b11-6354-51ab-988b-1257288b1bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dfc4f5-5103-4e60-9c54-2aff113dc4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dfc4f5-5103-4e60-9c54-2aff113dc4b7.jpg?1",
             "name": "Apothecary Geist",
             "text": "Flying\nWhen Apothecary Geist enters the battlefield, if you control another Spirit, you gain 3 life.",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "c8969453-92d2-5840-8afb-e6de0b19fe05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c4f01-78c4-4635-86e0-46596e6e6ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c4f01-78c4-4635-86e0-46596e6e6ec6.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice dies, exile target permanent.",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "319f71cf-3442-5929-80c8-fe343246a22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895da74d-26ce-4e0c-baef-6eabc40bf0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895da74d-26ce-4e0c-baef-6eabc40bf0de.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, create a 2/2 white Pegasus creature token with flying.",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "39026542-5e15-5fe8-b57a-6e2ac67d1d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae2fa8-032a-49d5-8e5f-de742cded9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae2fa8-032a-49d5-8e5f-de742cded9c2.jpg?1",
             "name": "Attended Healer",
             "text": "Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.\n{2}{W}: Another target Cleric gains lifelink until end of turn.",
             "colours": [
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "16e11dfb-4e09-5a6e-8ccf-fa175f38deb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3b21e-a05c-4603-b4d1-68353273d4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3b21e-a05c-4603-b4d1-68353273d4a9.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "7527ebe6-1063-5c41-b822-e846dcb75f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c9c3ac-4ffe-4f83-a3d2-fa2e834f8e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c9c3ac-4ffe-4f83-a3d2-fa2e834f8e29.jpg?1",
             "name": "Basri's Acolyte",
             "text": "Lifelink\nWhen Basri's Acolyte enters the battlefield, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -5142,7 +5142,7 @@
         },
         {
             "id": "1126db4f-d3c6-5985-aee5-71df19eab6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc79ad-6616-4166-9cf2-4e663d81de2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc79ad-6616-4166-9cf2-4e663d81de2d.jpg?1",
             "name": "Benalish Honor Guard",
             "text": "Benalish Honor Guard gets +1/+0 for each legendary creature you control.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "8cc051d1-7644-5144-93d8-c4e81b76f6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333e35c-ca90-4aaa-950a-48b5623c31a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333e35c-ca90-4aaa-950a-48b5623c31a6.jpg?1",
             "name": "Blessed Defiance",
             "text": "Target creature you control gets +2/+0 and gains lifelink until end of turn. When that creature dies this turn, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "fdf58db8-2f29-5d4e-ba9d-73c6c6669f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737cfc4d-2a11-4f5e-a871-8c081d08a961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737cfc4d-2a11-4f5e-a871-8c081d08a961.jpg?1",
             "name": "Blessed Sanctuary",
             "text": "Prevent all noncombat damage that would be dealt to you and creatures you control.\nWhenever a nontoken creature enters the battlefield under your control, create a 2/2 white Unicorn creature token.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "e6b0a528-3bd2-5201-8e2d-4d004a803c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41adcf82-1cb2-4b38-8607-c6229e9948cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41adcf82-1cb2-4b38-8607-c6229e9948cb.jpg?1",
             "name": "Blessed Spirits",
             "text": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on Blessed Spirits.",
             "colours": [
@@ -5271,7 +5271,7 @@
         },
         {
             "id": "20ba15d4-d019-528f-b9da-ba8617a4cd4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb4aab6-144d-437d-8936-7220a27aae13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb4aab6-144d-437d-8936-7220a27aae13.jpg?1",
             "name": "Brightmare",
             "text": "When Brightmare enters the battlefield, tap up to one target creature. You gain life equal to that creature's power.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "f427744a-2c30-53a1-a42c-ab8f294ca7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444d7e10-0d5b-47f4-b29c-730d1d08a59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444d7e10-0d5b-47f4-b29c-730d1d08a59a.jpg?1",
             "name": "Bring to Trial",
             "text": "Exile target creature with power 4 or greater.",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "619a4460-2476-56e4-a9bc-434b689ed65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f3d01-a61a-4702-8331-28f911e8358f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f3d01-a61a-4702-8331-28f911e8358f.jpg?1",
             "name": "Built to Last",
             "text": "Target creature gets +2/+2 until end of turn. If it's an artifact creature, it gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "c1507d96-cc97-5de2-bbfc-7ea90e7f798b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7635b128-5d14-43fb-9f6a-5da8aeb21172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7635b128-5d14-43fb-9f6a-5da8aeb21172.jpg?1",
             "name": "Cage of Hands",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.",
             "colours": [
@@ -5399,7 +5399,7 @@
         },
         {
             "id": "141a647f-eb2b-59da-9005-27d7ec25d084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5364ee-cfa3-48b0-93e9-c14c55ecc8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5364ee-cfa3-48b0-93e9-c14c55ecc8ba.jpg?1",
             "name": "Captivating Unicorn",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "3a4f9e38-8913-52ba-8c87-396c87d9313b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d4b46-b12f-4819-8d75-1540e2b402e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d4b46-b12f-4819-8d75-1540e2b402e5.jpg?1",
             "name": "Caught in the Brights",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen a Vehicle you control attacks, exile enchanted creature.",
             "colours": [
@@ -5465,7 +5465,7 @@
         },
         {
             "id": "ec56e9f8-f90d-5f3c-a481-2cf32cce60ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db546a-f117-41ad-a917-69e6086a43dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db546a-f117-41ad-a917-69e6086a43dd.jpg?1",
             "name": "Cavalry Drillmaster",
             "text": "When Cavalry Drillmaster enters the battlefield, target creature gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5499,7 +5499,7 @@
         },
         {
             "id": "bd27feba-b220-5b60-9eeb-4ad97e9f399b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a37ed7-223e-4e19-b318-83cac54f6b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a37ed7-223e-4e19-b318-83cac54f6b16.jpg?1",
             "name": "The Circle of Loyalty",
             "text": "This spell costs {1} less to cast for each Knight you control.\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "5b99321f-fa2f-53c4-adb3-bec0008448a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8e9d2-8c5b-4f75-ac03-df23435f3404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8e9d2-8c5b-4f75-ac03-df23435f3404.jpg?1",
             "name": "Combat Professor",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn.",
             "colours": [
@@ -5566,7 +5566,7 @@
         },
         {
             "id": "a95520b0-d702-5833-827b-40c4e83a3948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5569b514-9049-4b44-b69e-78552a7bbf97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5569b514-9049-4b44-b69e-78552a7bbf97.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "51143163-3085-5c38-ab8c-ed0217b8ff42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66cf2f-191d-4cbf-a340-a516973a7751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66cf2f-191d-4cbf-a340-a516973a7751.jpg?1",
             "name": "Dawn of Hope",
             "text": "Whenever you gain life, you may pay {2}. If you do, draw a card.\n{3}{W}: Create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "ae4e4091-cb8f-50ff-a4f6-a6b63533452e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326e1569-3394-468d-addd-c0a5346f7031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326e1569-3394-468d-addd-c0a5346f7031.jpg?1",
             "name": "Dawning Angel",
             "text": "Flying\nWhen Dawning Angel enters the battlefield, you gain 4 life.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "b3cc74a2-d830-54f2-a3b6-33195d9db626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0877c7da-e606-4c24-822a-2af987527361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0877c7da-e606-4c24-822a-2af987527361.jpg?1",
             "name": "Daybreak Chaplain",
             "text": "Lifelink",
             "colours": [
@@ -5700,7 +5700,7 @@
         },
         {
             "id": "7f22b87f-8bed-5170-9bdd-4ac42d4e88be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ea7a5-c096-4216-b6bd-a848f2540c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ea7a5-c096-4216-b6bd-a848f2540c31.jpg?1",
             "name": "Daybreak Charger",
             "text": "When Daybreak Charger enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "ae56853d-80ae-5f5f-8e91-d995061b53f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cecbd0-87a7-45e5-bf10-e97b298803fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cecbd0-87a7-45e5-bf10-e97b298803fd.jpg?1",
             "name": "Decree of Justice",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
             "colours": [
@@ -5764,7 +5764,7 @@
         },
         {
             "id": "8b1f6a4c-23bd-5a88-bba5-3614706a8ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500edf50-7d23-453d-baf9-e755939cabdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500edf50-7d23-453d-baf9-e755939cabdc.jpg?1",
             "name": "Defy Death",
             "text": "Return target creature card from your graveyard to the battlefield. If it's an Angel, put two +1/+1 counters on it.",
             "colours": [
@@ -5795,7 +5795,7 @@
         },
         {
             "id": "545ff4b5-9365-563f-9fc8-013e73e099fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ef2107-1d92-482c-a7ea-6847e6c50aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ef2107-1d92-482c-a7ea-6847e6c50aed.jpg?1",
             "name": "Devouring Light",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "cd10cef5-64f3-52c9-a0e6-ae0f65cde8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b54945-444f-45db-bffa-0d844291f579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b54945-444f-45db-bffa-0d844291f579.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "a1e0933c-e62a-5ac2-b0ea-85890670cb1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb9d872-3ea5-4f8a-891e-00707c4ff5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb9d872-3ea5-4f8a-891e-00707c4ff5c0.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -5888,7 +5888,7 @@
         },
         {
             "id": "5f05ced8-4bc7-5850-84ed-d6eb03f3f977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98c3007-c45f-4502-ae4b-693bd64f23ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98c3007-c45f-4502-ae4b-693bd64f23ba.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -5922,7 +5922,7 @@
         },
         {
             "id": "65b20dfb-e04d-5e51-8412-622e2a184553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2778f8ac-6abc-4e28-838d-fd68ce34120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2778f8ac-6abc-4e28-838d-fd68ce34120e.jpg?1",
             "name": "Dreadful Apathy",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "b7b257b7-98fc-5ba7-8578-c6417b322cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2aec96-a679-475c-9c71-4fe06a890880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2aec96-a679-475c-9c71-4fe06a890880.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead. ({RW} can be paid with either {G} or {W}.)",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "06440101-cf9a-5438-8acf-df4598ee23b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc226022-c422-4e9d-a359-5c2104e0a5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc226022-c422-4e9d-a359-5c2104e0a5f2.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "72276473-22be-58aa-a089-26d2a90fe8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888a511d-218e-49a9-a57a-ee0e9e4ddc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888a511d-218e-49a9-a57a-ee0e9e4ddc5d.jpg?1",
             "name": "Favored of Iroas",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Favored of Iroas gains double strike until end of turn.",
             "colours": [
@@ -6058,7 +6058,7 @@
         },
         {
             "id": "bfd061b1-19ea-5397-9b31-0a00240660ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b096d925-a76d-494e-8f72-ebb14263748b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b096d925-a76d-494e-8f72-ebb14263748b.jpg?1",
             "name": "Felidar Cub",
             "text": "Sacrifice Felidar Cub: Destroy target enchantment.",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "f3392524-3259-5f0f-91ca-ac1bf2d3d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b3b925-743d-4f88-97d6-d0847c0d7d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b3b925-743d-4f88-97d6-d0847c0d7d6a.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "b0feedd0-9cc8-5965-95df-00b00c8a2491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db741799-0b2f-429c-a978-aa2ab9681d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db741799-0b2f-429c-a978-aa2ab9681d1c.jpg?1",
             "name": "Forced Worship",
             "text": "Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "903e2f88-8084-58a8-8ed5-038b7360f9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f370a9-1401-4018-bbd3-0a8737f9fbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f370a9-1401-4018-bbd3-0a8737f9fbea.jpg?1",
             "name": "Gallant Cavalry",
             "text": "Vigilance\nWhen Gallant Cavalry enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "07995e2a-2583-5de0-ba9e-f73223c420fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa9a592-9495-41ea-918e-09f81bd10309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa9a592-9495-41ea-918e-09f81bd10309.jpg?1",
             "name": "Gallows Warden",
             "text": "Flying\nOther Spirit creatures you control get +0/+1.",
             "colours": [
@@ -6223,7 +6223,7 @@
         },
         {
             "id": "f7789136-feb3-5f88-9e10-6dff7f92441a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f4dbc9-baa5-407b-a96c-43f356a0875b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f4dbc9-baa5-407b-a96c-43f356a0875b.jpg?1",
             "name": "Giant Ox",
             "text": "Giant Ox crews Vehicles using its toughness rather than its power.",
             "colours": [
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "34cef839-95bb-5454-8fbf-3d826e18fdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9eadb92-2a87-4b3b-90b5-f10cb1cfda0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9eadb92-2a87-4b3b-90b5-f10cb1cfda0f.jpg?1",
             "name": "Gideon, Champion of Justice",
             "text": "+1: Put a loyalty counter on Gideon, Champion of Justice for each creature target opponent controls.\n0: Until end of turn, Gideon, Champion of Justice becomes a Human Soldier creature with power and toughness each equal to the number of loyalty counters on him and gains indestructible. He's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n\u221215: Exile all other permanents.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "4e7ee0e2-82ac-5c2f-80db-d6c3a397fd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e4e1a-9c21-4296-9bfc-ba1c007c1cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e4e1a-9c21-4296-9bfc-ba1c007c1cdd.jpg?1",
             "name": "Gideon's Lawkeeper",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -6325,7 +6325,7 @@
         },
         {
             "id": "f76be773-30db-5588-aed9-345938d6fb3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0f1eb3-379d-4dc0-a3c8-618cfd3414b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0f1eb3-379d-4dc0-a3c8-618cfd3414b2.jpg?1",
             "name": "Glory Bearers",
             "text": "Whenever another creature you control attacks, it gets +0/+1 until end of turn.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "7d74229d-ac3f-5c85-bfe4-c638cd6d2eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889f5a07-3b5c-494b-834a-3a5e444e38cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889f5a07-3b5c-494b-834a-3a5e444e38cc.jpg?1",
             "name": "Goldnight Commander",
             "text": "Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "7b97d70f-7b2a-55ca-8adb-2cea4204a798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8e6238-0716-4ed0-b405-05330b7abc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8e6238-0716-4ed0-b405-05330b7abc54.jpg?1",
             "name": "Hotshot Mechanic",
             "text": "Hotshot Mechanic crews Vehicles as though its power were 2 greater.",
             "colours": [
@@ -6430,7 +6430,7 @@
         },
         {
             "id": "c7680fee-1903-5a42-ba1e-c0c4a1ec8882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c50249-4039-4442-bc6c-a9318f8ffe9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c50249-4039-4442-bc6c-a9318f8ffe9d.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
             "colours": [
@@ -6461,7 +6461,7 @@
         },
         {
             "id": "597bd00e-fd85-51ee-a525-477781814794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4202dc3-3299-4bf3-a37e-78588e07bb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4202dc3-3299-4bf3-a37e-78588e07bb1e.jpg?1",
             "name": "Impeccable Timing",
             "text": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "c9771780-3066-5db4-aa24-a8f6b5e0b963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27048b6-5412-428f-aa3c-c50c6ed70500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27048b6-5412-428f-aa3c-c50c6ed70500.jpg?1",
             "name": "Imperial Aerosaur",
             "text": "Flying\nWhen Imperial Aerosaur enters the battlefield, another target creature you control gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -6525,7 +6525,7 @@
         },
         {
             "id": "2eb3497d-266d-5f2f-8c53-9a8c0873ae3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8004e33-ec53-4f37-b035-6765004fa1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8004e33-ec53-4f37-b035-6765004fa1f3.jpg?1",
             "name": "Imperial Recovery Unit",
             "text": "Whenever Imperial Recovery Unit attacks, return target creature or Vehicle card with mana value 2 or less from your graveyard to your hand.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "dbf522f8-ca1f-52dc-baac-e98920e9df16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d42086a-74b3-4700-b070-95e1357ae527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d42086a-74b3-4700-b070-95e1357ae527.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -6592,7 +6592,7 @@
         },
         {
             "id": "733a8a9b-2f10-5508-98e0-845f5bd75057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc56f47-ae0a-498b-8730-2096937887e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc56f47-ae0a-498b-8730-2096937887e5.jpg?1",
             "name": "Inspiring Cleric",
             "text": "When Inspiring Cleric enters the battlefield, you gain 4 life.",
             "colours": [
@@ -6626,7 +6626,7 @@
         },
         {
             "id": "49de0ed3-6f80-56bd-9b01-143db9bcd79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa372561-4c23-4aea-8186-9fcf8b230ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa372561-4c23-4aea-8186-9fcf8b230ce2.jpg?1",
             "name": "Inspiring Overseer",
             "text": "Flying\nWhen Inspiring Overseer enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "b9eae505-2bb5-58b3-86ed-5af4491e564d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e66b0f2-262e-4feb-8ae5-ad1f60b6611c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e66b0f2-262e-4feb-8ae5-ad1f60b6611c.jpg?1",
             "name": "Isamaru, Hound of Konda",
             "text": "",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "55a6a701-6bab-5e2f-8d37-b542904eccf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8383ce-b8db-4c32-8564-79a3b6196e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8383ce-b8db-4c32-8564-79a3b6196e4c.jpg?1",
             "name": "Justiciar's Portal",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. It gains first strike until end of turn.",
             "colours": [
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "5520b4d9-cad2-5859-bb9d-10d63eefeed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d39bae5-780c-489c-87b6-4a60336afe31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d39bae5-780c-489c-87b6-4a60336afe31.jpg?1",
             "name": "Kami of Ancient Law",
             "text": "Sacrifice Kami of Ancient Law: Destroy target enchantment.",
             "colours": [
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "a64ab5b2-b73d-5505-98c5-17b210de919a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abff1b-1f9e-48a6-825f-1e7336fab70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abff1b-1f9e-48a6-825f-1e7336fab70c.jpg?1",
             "name": "Kitsune Ace",
             "text": "Whenever a Vehicle you control attacks, choose one \u2014\n\u2022 That Vehicle gains first strike until end of turn.\n\u2022 Untap Kitsune Ace.",
             "colours": [
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "1fe187a0-8520-5114-ae59-45e6bda6e81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff87191-2325-4230-8af1-ebbfdff56a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff87191-2325-4230-8af1-ebbfdff56a0f.jpg?1",
             "name": "Kwende, Pride of Femeref",
             "text": "Double strike\nCreatures you control with first strike have double strike.",
             "colours": [
@@ -6829,7 +6829,7 @@
         },
         {
             "id": "4c1fe0bb-d259-5ef1-809a-d7914024fabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8430557a-9e31-4ab1-8fef-0dc7d07e018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8430557a-9e31-4ab1-8fef-0dc7d07e018f.jpg?1",
             "name": "Law-Rune Enforcer",
             "text": "{1}, {T}: Tap target creature with mana value 2 or greater.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "115cac8d-061d-5717-9547-46eebe0eee04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708124d5-8447-4c22-a3c9-268ccece7854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708124d5-8447-4c22-a3c9-268ccece7854.jpg?1",
             "name": "Leonin Snarecaster",
             "text": "When Leonin Snarecaster enters the battlefield, you may tap target creature.",
             "colours": [
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "d1267721-f1e1-52c5-8973-8cb8399c4cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24820fa-7cef-4396-920c-810dd06e3887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24820fa-7cef-4396-920c-810dd06e3887.jpg?1",
             "name": "Leonin Warleader",
             "text": "Whenever Leonin Warleader attacks, create two 1/1 white Cat creature tokens with lifelink that are tapped and attacking.",
             "colours": [
@@ -6931,7 +6931,7 @@
         },
         {
             "id": "ca2f4a58-fa54-53da-97e4-e3c2b5ba38f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fcdd23-7535-4995-b5db-c004bfc40566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fcdd23-7535-4995-b5db-c004bfc40566.jpg?1",
             "name": "Light of Hope",
             "text": "Choose one \u2014\n\u2022 You gain 4 life.\n\u2022 Destroy target enchantment.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -6962,7 +6962,7 @@
         },
         {
             "id": "ed26c884-6ac9-5359-8f77-f6f99ddc9c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a395674-3b3e-43bf-8384-2ffc63fe84dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a395674-3b3e-43bf-8384-2ffc63fe84dd.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -6997,7 +6997,7 @@
         },
         {
             "id": "4cbf7953-c2be-59f5-a2fb-af23bb380042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d0d4a3-7ce9-4881-a94b-bac5cbbf4dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d0d4a3-7ce9-4881-a94b-bac5cbbf4dc0.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "3b87afa8-c1c4-5d1c-b406-c1d3787ab853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820036e8-3f3c-4166-a5a7-6ca9d0f15323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820036e8-3f3c-4166-a5a7-6ca9d0f15323.jpg?1",
             "name": "Martyr's Soul",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Martyr's Soul enters the battlefield, if you control no tapped lands, put two +1/+1 counters on it.",
             "colours": [
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "79190bfe-fd01-5eb8-8c8f-74f9e875a535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43227caf-f902-46b4-936f-125d879eb54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43227caf-f902-46b4-936f-125d879eb54a.jpg?1",
             "name": "Mausoleum Guard",
             "text": "When Mausoleum Guard dies, create two 1/1 white Spirit creature tokens with flying.",
             "colours": [
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "79ac432b-f61f-57fa-bd37-77a7afb30c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfcac-4912-4b34-b00e-16a18ee49823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfcac-4912-4b34-b00e-16a18ee49823.jpg?1",
             "name": "Mesa Lynx",
             "text": "As long as it's not your turn, Mesa Lynx gets +0/+2.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "db7f977e-1b1c-52e0-921d-b6ffb29bc137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4124fc-c9c5-4752-9618-dfe722c38d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4124fc-c9c5-4752-9618-dfe722c38d0b.jpg?1",
             "name": "Michiko Konda, Truth Seeker",
             "text": "Whenever a source an opponent controls deals damage to you, that player sacrifices a permanent.",
             "colours": [
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "b6bb1081-a835-55c6-941a-c5fe3c5e232f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d2cc-5380-4be1-ab67-a755b2e02016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d2cc-5380-4be1-ab67-a755b2e02016.jpg?1",
             "name": "Midnight Guard",
             "text": "Whenever another creature enters the battlefield, untap Midnight Guard.",
             "colours": [
@@ -7199,7 +7199,7 @@
         },
         {
             "id": "10d4c867-bc90-514f-9a39-486214058cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a193b7b6-0ec6-4225-9f23-67294a957f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a193b7b6-0ec6-4225-9f23-67294a957f06.jpg?1",
             "name": "Miraculous Recovery",
             "text": "Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.",
             "colours": [
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "c69b5580-9894-52cf-9d83-8fa50aa3f773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffffb3e-253e-4e93-9ed1-9c2455220dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffffb3e-253e-4e93-9ed1-9c2455220dac.jpg?1",
             "name": "Moment of Triumph",
             "text": "Target creature gets +2/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "cf6b4fc7-f67c-58b8-b7f3-0b34ccbededc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612da129-c8dd-4f89-a505-548ad5c2f7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612da129-c8dd-4f89-a505-548ad5c2f7e1.jpg?1",
             "name": "Murder Investigation",
             "text": "Enchant creature you control\nWhen enchanted creature dies, create X 1/1 white Soldier creature tokens, where X is its power.",
             "colours": [
@@ -7294,7 +7294,7 @@
         },
         {
             "id": "8acad8ba-6fe4-56d7-a4b6-9a1b25ecf45a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb360f53-0013-4c0e-b7db-d2fc8029473a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb360f53-0013-4c0e-b7db-d2fc8029473a.jpg?1",
             "name": "Nightguard Patrol",
             "text": "First strike, vigilance",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "f57331c7-993d-5ad0-8e03-c8784db50599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260ca48-e932-4396-a726-eefc30935c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260ca48-e932-4396-a726-eefc30935c35.jpg?1",
             "name": "Ninth Bridge Patrol",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Ninth Bridge Patrol.",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "ce5212ff-d4ea-5834-9ea2-a05975d192dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05860b72-fb1b-44d8-9275-12863724a9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05860b72-fb1b-44d8-9275-12863724a9ef.jpg?1",
             "name": "Not Forgotten",
             "text": "Put target card from a graveyard on the top or bottom of its owner's library. Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -7393,7 +7393,7 @@
         },
         {
             "id": "36a3b3c0-a52a-569f-acd4-c2aa4427f2e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcf25b6-b4a6-4077-b827-3d44a6f5d744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcf25b6-b4a6-4077-b827-3d44a6f5d744.jpg?1",
             "name": "Order of the Golden Cricket",
             "text": "Whenever Order of the Golden Cricket attacks, you may pay {W}. If you do, it gains flying until end of turn.",
             "colours": [
@@ -7427,7 +7427,7 @@
         },
         {
             "id": "c7a222ef-0585-507d-b9de-189a5b0436fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944c5ac7-09ab-4b6f-b809-5422c22ea6a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944c5ac7-09ab-4b6f-b809-5422c22ea6a1.jpg?1",
             "name": "Phalanx Tactics",
             "text": "Target creature you control gets +2/+1 until end of turn. Each other creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -7458,7 +7458,7 @@
         },
         {
             "id": "a025f87d-ec23-51d2-8a4e-9493ecb260df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca680ef-07e1-4e95-bf11-d2f7672857d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca680ef-07e1-4e95-bf11-d2f7672857d8.jpg?1",
             "name": "Pilgrim of the Ages",
             "text": "When Pilgrim of the Ages enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n{6}: Return Pilgrim of the Ages from your graveyard to your hand.",
             "colours": [
@@ -7491,7 +7491,7 @@
         },
         {
             "id": "ad5b016a-a873-5f3b-b46c-86835ea626f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e4175b-d498-4f89-9dd0-559b22690312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e4175b-d498-4f89-9dd0-559b22690312.jpg?1",
             "name": "Pillardrop Rescuer",
             "text": "Flying\nWhen Pillardrop Rescuer enters the battlefield, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "bdc88741-fbda-50bf-848d-d5363d474eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52429695-4146-4b68-98b7-72b31c854070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52429695-4146-4b68-98b7-72b31c854070.jpg?1",
             "name": "Pious Wayfarer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "7848ec13-c66b-5dcc-a558-aa1d166d8fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e00f43-bd0e-4664-8ef3-fb0aeb0d281e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e00f43-bd0e-4664-8ef3-fb0aeb0d281e.jpg?1",
             "name": "Pouncing Lynx",
             "text": "As long as it's your turn, Pouncing Lynx has first strike.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "a39436ef-e6c5-5d1b-a267-f57796230fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bb131e-b659-4caa-98c5-505b72ac26ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bb131e-b659-4caa-98c5-505b72ac26ac.jpg?1",
             "name": "Prowling Felidar",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Prowling Felidar.",
             "colours": [
@@ -7626,7 +7626,7 @@
         },
         {
             "id": "e4176bc9-e130-5939-8df9-6b006469bfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f8f288-69da-438d-967b-167060fdcbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f8f288-69da-438d-967b-167060fdcbb9.jpg?1",
             "name": "Radiant's Judgment",
             "text": "Destroy target creature with power 4 or greater.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -7657,7 +7657,7 @@
         },
         {
             "id": "6d1e3f9c-7fcf-50f6-b059-e290268e96a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc371de-3e82-4d66-8636-f9c03579ba10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc371de-3e82-4d66-8636-f9c03579ba10.jpg?1",
             "name": "Rambunctious Mutt",
             "text": "When Rambunctious Mutt enters the battlefield, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "024d5938-d8c7-56d3-a527-71d914ac1db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8511fb74-dd0c-492d-87f6-7d27d39d101a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8511fb74-dd0c-492d-87f6-7d27d39d101a.jpg?1",
             "name": "Regal Caracal",
             "text": "Other Cats you control get +1/+1 and have lifelink.\nWhen Regal Caracal enters the battlefield, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -7723,7 +7723,7 @@
         },
         {
             "id": "d4920bb5-7b54-5d7f-b596-d68a257d4da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee6fbf-4562-4c73-afa7-2c573d6acd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee6fbf-4562-4c73-afa7-2c573d6acd77.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -7756,7 +7756,7 @@
         },
         {
             "id": "16507506-2fb0-5dec-9bca-e2e26d94a960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e8e2a9-8dcb-40dd-8079-6c8484c3b157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e8e2a9-8dcb-40dd-8079-6c8484c3b157.jpg?1",
             "name": "Righteous Valkyrie",
             "text": "Flying\nWhenever another Angel or Cleric enters the battlefield under your control, you gain life equal to that creature's toughness.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "97eb9e93-04dd-5230-baf0-cbae27f5d5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7ee36d-fdaa-4520-a86a-0feb93a7f9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7ee36d-fdaa-4520-a86a-0feb93a7f9b4.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "e4194759-91d9-5788-96a8-1b0c6999d00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e6ab8-d778-4cf6-ab21-1352618d093b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e6ab8-d778-4cf6-ab21-1352618d093b.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle enters the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -7855,7 +7855,7 @@
         },
         {
             "id": "9f4a2a5c-9306-5e8a-bbea-ce71cffa31f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b77ad5-1585-49dc-b635-780143e1e1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b77ad5-1585-49dc-b635-780143e1e1c8.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -7888,7 +7888,7 @@
         },
         {
             "id": "e8eca721-2f5e-5e90-bf32-6e52ea191336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9edf976-bf2e-4528-9001-0c70bdc94762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9edf976-bf2e-4528-9001-0c70bdc94762.jpg?1",
             "name": "Savannah Sage",
             "text": "When Savannah Sage enters the battlefield, you gain 2 life.",
             "colours": [
@@ -7922,7 +7922,7 @@
         },
         {
             "id": "94ed2ec2-f05c-5460-b2e0-c895e7127987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc30cb5-e845-472c-8bdb-659ce7ece6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc30cb5-e845-472c-8bdb-659ce7ece6de.jpg?1",
             "name": "Selfless Spirit",
             "text": "Flying\nSacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -7956,7 +7956,7 @@
         },
         {
             "id": "91e5cda2-c8a7-5eb3-90da-2354af7f1be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b2176-958a-42e0-b88e-5b3416b40150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b2176-958a-42e0-b88e-5b3416b40150.jpg?1",
             "name": "Seller of Songbirds",
             "text": "When Seller of Songbirds enters the battlefield, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "01b6e333-6797-509d-b5f8-126febf66adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746381e7-1695-40c0-a830-ab58bb240180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746381e7-1695-40c0-a830-ab58bb240180.jpg?1",
             "name": "Serene Steward",
             "text": "Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8024,7 +8024,7 @@
         },
         {
             "id": "501f2c55-38e0-5af9-90a0-a6ddf928a9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8eb805-70ac-4680-bcee-83ed40b43881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8eb805-70ac-4680-bcee-83ed40b43881.jpg?1",
             "name": "Settle Beyond Reality",
             "text": "Choose one or both \u2014\n\u2022 Exile target creature you don't control.\n\u2022 Exile target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "e3c4ec11-9f3c-5ccb-8311-95295dfb5771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0dcfeb-27b9-4455-bb79-06059006b006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0dcfeb-27b9-4455-bb79-06059006b006.jpg?1",
             "name": "Shining Armor",
             "text": "Flash\nWhen Shining Armor enters the battlefield, attach it to target Knight you control.\nEquipped creature gets +0/+2 and has vigilance.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "d3ca9344-7602-5703-a16d-140bcfb73e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733e1156-39a3-49a2-af5d-75c978107b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733e1156-39a3-49a2-af5d-75c978107b2a.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -8119,7 +8119,7 @@
         },
         {
             "id": "8cdadd74-aa28-5d38-994f-6646eee76197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028bd68c-24bf-4808-80d7-051012ff90e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028bd68c-24bf-4808-80d7-051012ff90e1.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "Flying, first strike",
             "colours": [
@@ -8153,7 +8153,7 @@
         },
         {
             "id": "00290eac-3475-5574-a73f-444a1d3779d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2014229c-11cd-4289-bf06-1b55d1f2939a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2014229c-11cd-4289-bf06-1b55d1f2939a.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying, vigilance",
             "colours": [
@@ -8187,7 +8187,7 @@
         },
         {
             "id": "dd608c88-5b1a-59e9-a2fc-815fe0a6da68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa7a9a0-43ca-4bce-9ed8-dfe0b258dca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa7a9a0-43ca-4bce-9ed8-dfe0b258dca7.jpg?1",
             "name": "Spectral Steel",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\n{1}{W}, Exile Spectral Steel from your graveyard: Return another target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "f6a131c3-fcf8-53e2-9714-a901b49ecbf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28a16-e119-456d-ad8b-c37cec069ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28a16-e119-456d-ad8b-c37cec069ab0.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -8254,7 +8254,7 @@
         },
         {
             "id": "16a11c80-7b36-5b17-9012-fee063ff2eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc7746a-ff2a-4bc1-bc30-45eb53a94ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc7746a-ff2a-4bc1-bc30-45eb53a94ddc.jpg?1",
             "name": "Stalwart Valkyrie",
             "text": "You may pay {1}{W} and exile a creature card from your graveyard rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -8288,7 +8288,7 @@
         },
         {
             "id": "f5e59da3-e93c-58b4-854e-1a2348f1e0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170914cc-3c3d-4929-a45d-836a5b8a4090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170914cc-3c3d-4929-a45d-836a5b8a4090.jpg?1",
             "name": "Starnheim Aspirant",
             "text": "Angel spells you cast cost {2} less to cast.",
             "colours": [
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "711a6ada-c3f8-521e-92a1-70785b50a0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff6978-a794-4f4c-9039-594b15e7dbfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff6978-a794-4f4c-9039-594b15e7dbfe.jpg?1",
             "name": "Steppe Lynx",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Steppe Lynx gets +2/+2 until end of turn.",
             "colours": [
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "a2adaa75-18db-5b1d-a691-5d9a11d79433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2d3b-a1aa-435d-b46d-0cecd1ef1c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2d3b-a1aa-435d-b46d-0cecd1ef1c40.jpg?1",
             "name": "Syr Alin, the Lion's Claw",
             "text": "First strike\nWhenever Syr Alin, the Lion's Claw attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "b88090e3-f8d5-50bd-9a3d-910c521eede8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623be150-7440-428f-9f57-73cf46189205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623be150-7440-428f-9f57-73cf46189205.jpg?1",
             "name": "Taranika, Akroan Veteran",
             "text": "Vigilance\nWhenever Taranika, Akroan Veteran attacks, untap another target creature you control. Until end of turn, that creature has base power and toughness 4/4 and gains indestructible.",
             "colours": [
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "e60158d9-6fad-5eab-b789-a59d087e073c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7af30c-3486-4a29-8bb2-736c6cd8c7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7af30c-3486-4a29-8bb2-736c6cd8c7c7.jpg?1",
             "name": "Tempered Veteran",
             "text": "{W}, {T}: Put a +1/+1 counter on target creature with a +1/+1 counter on it.\n{4}{W}{W}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "ba8cdd57-3821-5225-9759-2759a4018f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b65852b-b748-4263-a5aa-7a44e891c582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b65852b-b748-4263-a5aa-7a44e891c582.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "d6e1b5fe-3096-5286-9f3f-9affb3033bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c299243b-5ccf-44e8-82f7-fce496f237d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c299243b-5ccf-44e8-82f7-fce496f237d1.jpg?1",
             "name": "Trained Caracal",
             "text": "Lifelink",
             "colours": [
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "81057fc2-690d-50a1-a68c-65a7a42c6a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39830f8b-3c92-4bce-9ddc-e71d402f599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39830f8b-3c92-4bce-9ddc-e71d402f599a.jpg?1",
             "name": "Transcendent Envoy",
             "text": "Flying\nAura spells you cast cost {1} less to cast.",
             "colours": [
@@ -8562,7 +8562,7 @@
         },
         {
             "id": "61fde2ea-28aa-5d9c-9128-261ca9e48a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f.jpg?1",
             "name": "Triplicate Spirits",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 white Spirit creature tokens with flying.",
             "colours": [
@@ -8593,7 +8593,7 @@
         },
         {
             "id": "2fe3d363-0020-5615-920b-e173e67fa66c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e05f939-f5bb-4813-b2fe-ed79df1818ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e05f939-f5bb-4813-b2fe-ed79df1818ec.jpg?1",
             "name": "Trove Warden",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, exile target permanent card with mana value 3 or less from your graveyard.\nWhen Trove Warden dies, put each permanent card exiled with it onto the battlefield under the control of that card's owner.",
             "colours": [
@@ -8627,7 +8627,7 @@
         },
         {
             "id": "c9756d49-d0ac-599c-a232-c3104dc44b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd305056-c22f-4f2b-9082-26a377d6bb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd305056-c22f-4f2b-9082-26a377d6bb53.jpg?1",
             "name": "Unquestioned Authority",
             "text": "Enchant creature\nWhen Unquestioned Authority enters the battlefield, draw a card.\nEnchanted creature has protection from creatures.",
             "colours": [
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "aa52a606-f166-5068-8171-9cacc9a45c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9828a61-bc29-4a6d-8a41-e439dcb822db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9828a61-bc29-4a6d-8a41-e439dcb822db.jpg?1",
             "name": "Valkyrie Harbinger",
             "text": "Flying, lifelink\nAt the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.",
             "colours": [
@@ -8694,7 +8694,7 @@
         },
         {
             "id": "590cddc4-2552-5a6b-aa34-5bee104a51a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e20c0de-c9fa-463c-965a-2e868f7965b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e20c0de-c9fa-463c-965a-2e868f7965b1.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8725,7 +8725,7 @@
         },
         {
             "id": "aefd4c2b-6512-5154-884a-5fc9499dde95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab54275-240c-4f32-9e80-c6a74f90a55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab54275-240c-4f32-9e80-c6a74f90a55e.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -8758,7 +8758,7 @@
         },
         {
             "id": "002554a0-2669-58ee-8f01-d59b45970248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c80b7-6cbb-4f3f-b279-55048b90ad1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c80b7-6cbb-4f3f-b279-55048b90ad1c.jpg?1",
             "name": "Valorous Steed",
             "text": "Vigilance\nWhen Valorous Steed enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -8791,7 +8791,7 @@
         },
         {
             "id": "7f74afc0-0d32-55a1-9067-b3d2950a0ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51406b6f-7402-4641-9e0b-7b4a59ffaa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51406b6f-7402-4641-9e0b-7b4a59ffaa52.jpg?1",
             "name": "Weight of Conscience",
             "text": "Enchant creature\nEnchanted creature can't attack.\nTap two untapped creatures you control that share a creature type: Exile enchanted creature.",
             "colours": [
@@ -8824,7 +8824,7 @@
         },
         {
             "id": "36d033b3-c077-5148-b4c6-df86af483aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47a35-1992-4827-af08-b53efab2a46d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47a35-1992-4827-af08-b53efab2a46d.jpg?1",
             "name": "Wispweaver Angel",
             "text": "Flying\nWhen Wispweaver Angel enters the battlefield, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "4c6bdf2c-258a-586e-907a-4ecc5456f9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a88507f-8089-42a6-a722-d07d04a59295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a88507f-8089-42a6-a722-d07d04a59295.jpg?1",
             "name": "Academy Journeymage",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nWhen Academy Journeymage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "e2dbb8ba-2136-5329-873f-b770f3c3a8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86920134-b45d-4690-af61-c9c1488d70e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86920134-b45d-4690-af61-c9c1488d70e0.jpg?1",
             "name": "Aeronaut Tinkerer",
             "text": "Aeronaut Tinkerer has flying as long as you control an artifact.",
             "colours": [
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "3391bf53-bfa2-59c0-ac28-cc1d526f3c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559a14ce-de7a-4ce4-8c46-99818372187f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559a14ce-de7a-4ce4-8c46-99818372187f.jpg?1",
             "name": "Amoeboid Changeling",
             "text": "Changeling (This card is every creature type.)\n{T}: Target creature gains all creature types until end of turn.\n{T}: Target creature loses all creature types until end of turn.",
             "colours": [
@@ -8958,7 +8958,7 @@
         },
         {
             "id": "00fd5954-b876-52f0-ae88-a58d808cc198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57976884-2a67-41c6-bf06-c10b6c3afb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57976884-2a67-41c6-bf06-c10b6c3afb4b.jpg?1",
             "name": "Anchor to the Aether",
             "text": "Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "532639ab-5faa-5926-a2d1-f2e17ac6c477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e7566ac-e9b3-4220-9b25-84d5b33f5842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e7566ac-e9b3-4220-9b25-84d5b33f5842.jpg?1",
             "name": "Aquatic Incursion",
             "text": "When Aquatic Incursion enters the battlefield, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)\n{3}{U}: Target Merfolk can't be blocked this turn.",
             "colours": [
@@ -9020,7 +9020,7 @@
         },
         {
             "id": "3c453e23-9883-5db9-9f9d-d2023f9b138f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90d050-65e3-4ed3-9ea1-347a05022b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90d050-65e3-4ed3-9ea1-347a05022b3e.jpg?1",
             "name": "Artificer's Epiphany",
             "text": "Draw two cards. If you control no artifacts, discard a card.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "22ecb5ea-cf3c-50f8-8ced-e8fb48b2f909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25dd284-ccc5-423c-830d-d3d331212293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25dd284-ccc5-423c-830d-d3d331212293.jpg?1",
             "name": "Augury Owl",
             "text": "Flying\nWhen Augury Owl enters the battlefield, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "8dbfc2b0-bd0d-527f-93ec-91d91ec2a998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e20032-685c-47e0-98cd-f48ddc2de90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e20032-685c-47e0-98cd-f48ddc2de90e.jpg?1",
             "name": "Avalanche Caller",
             "text": "{2}: Target snow land you control becomes a 4/4 Elemental creature with hexproof and haste until end of turn. It's still a land. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "e3ee4b90-615e-563b-b4c8-50c7bbce2851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4165233d-8651-4498-91b6-d3e5e6d613a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4165233d-8651-4498-91b6-d3e5e6d613a5.jpg?1",
             "name": "Aviation Pioneer",
             "text": "When Aviation Pioneer enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "ced8e38a-67d2-5539-966d-6ccc6512d0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba45332-1231-41be-ae79-454674b70ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba45332-1231-41be-ae79-454674b70ff4.jpg?1",
             "name": "Barrin, Tolarian Archmage",
             "text": "When Barrin, Tolarian Archmage enters the battlefield, return up to one other target creature or planeswalker to its owner's hand.\nAt the beginning of your end step, if a permanent was put into your hand from the battlefield this turn, draw a card.",
             "colours": [
@@ -9190,7 +9190,7 @@
         },
         {
             "id": "c17592e4-a50e-5edf-8da3-cb3a5ed25078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27b52dd-bbdf-4f00-b070-1b12a1f4d650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27b52dd-bbdf-4f00-b070-1b12a1f4d650.jpg?1",
             "name": "Berg Strider",
             "text": "When Berg Strider enters the battlefield, tap target artifact or creature an opponent controls. If {S} was spent to cast this spell, that permanent doesn't untap during its controller's next untap step. ({S} is mana from a snow source.)",
             "colours": [
@@ -9226,7 +9226,7 @@
         },
         {
             "id": "52c6701a-02c5-5ea1-86ca-25204b875f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9021592a-1170-4e8e-a9bd-3086bbc0d435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9021592a-1170-4e8e-a9bd-3086bbc0d435.jpg?1",
             "name": "Brineborn Cutthroat",
             "text": "Flash\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on Brineborn Cutthroat.",
             "colours": [
@@ -9260,7 +9260,7 @@
         },
         {
             "id": "c2e1ff5b-50af-5b9f-bb5d-35e6f7935ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e18c93-7707-471a-a5f0-4079a9c6003b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e18c93-7707-471a-a5f0-4079a9c6003b.jpg?1",
             "name": "Bury in Books",
             "text": "This spell costs {2} less to cast if it targets an attacking creature.\nPut target creature into its owner's library second from the top.",
             "colours": [
@@ -9291,7 +9291,7 @@
         },
         {
             "id": "b6b4ef19-1bfa-5752-8c34-0119d9172b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae18cc3-af8d-458c-8441-a3f661d38505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae18cc3-af8d-458c-8441-a3f661d38505.jpg?1",
             "name": "Chillerpillar",
             "text": "{4}{S}{S}: Monstrosity 2. (If this creature isn't monstrous, put two +1/+1 counters on it and it becomes monstrous. {S} can be paid with one mana from a snow source.)\nAs long as Chillerpillar is monstrous, it has flying.",
             "colours": [
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "477b1588-e7ad-516f-bd04-cf52e78e551b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f33bb-4796-4890-a209-d9d4b3afa601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f33bb-4796-4890-a209-d9d4b3afa601.jpg?1",
             "name": "Chilling Trap",
             "text": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
             "colours": [
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "a76e1e28-7584-5c21-8d97-b0f2026a5c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e29ea-d7b4-4255-83da-f29b312f1813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e29ea-d7b4-4255-83da-f29b312f1813.jpg?1",
             "name": "Condescend",
             "text": "Counter target spell unless its controller pays {X}. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -9388,7 +9388,7 @@
         },
         {
             "id": "0b699d53-146e-5dd5-a603-3d6055dff20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba21250-baae-4f40-8efc-6a58a287bcdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba21250-baae-4f40-8efc-6a58a287bcdc.jpg?1",
             "name": "Crashing Tide",
             "text": "This spell has flash as long as you control a Merfolk.\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "47e1d546-f155-5611-80dd-012d68460a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28885f-9a4a-4364-b95c-7544b2efa7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28885f-9a4a-4364-b95c-7544b2efa7da.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -9450,7 +9450,7 @@
         },
         {
             "id": "37868b2c-28b5-5814-a1f4-beb16e4b55af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc3e4cd-022d-48e4-abc9-b8ddfb0c8c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc3e4cd-022d-48e4-abc9-b8ddfb0c8c5c.jpg?1",
             "name": "Cryptic Serpent",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "8acaa85d-cead-5878-beff-a7daa18dfb3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ada66-9da3-4a88-81f7-111dfa737874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ada66-9da3-4a88-81f7-111dfa737874.jpg?1",
             "name": "Dismiss",
             "text": "Counter target spell.\nDraw a card.",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "89671daf-0bf6-5c1d-bd2b-04680f93cf4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8477e664-3a2f-4ba2-a3cb-ded3c376b3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8477e664-3a2f-4ba2-a3cb-ded3c376b3a5.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -9547,7 +9547,7 @@
         },
         {
             "id": "aadb9dd8-50b2-5c7d-bef1-501106f63c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa465d-0e36-4294-b363-fabca95223d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa465d-0e36-4294-b363-fabca95223d9.jpg?1",
             "name": "Drag Under",
             "text": "Return target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -9578,7 +9578,7 @@
         },
         {
             "id": "6c044e55-3c67-59da-a8e6-5513d0bdfa80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7a4792-0d24-47d7-a1df-818d97d40904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7a4792-0d24-47d7-a1df-818d97d40904.jpg?1",
             "name": "Drownyard Explorers",
             "text": "When Drownyard Explorers enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -9612,7 +9612,7 @@
         },
         {
             "id": "5856be2c-6d05-563f-9a0b-067029938f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64fa3b1-fbaa-4b35-bd09-007b95fb54a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64fa3b1-fbaa-4b35-bd09-007b95fb54a4.jpg?1",
             "name": "Elite Instructor",
             "text": "When Elite Instructor enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "35026be0-d72f-5a69-a286-a4a1d6aed86e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbfd62-0318-4f77-ab91-37e56233e493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbfd62-0318-4f77-ab91-37e56233e493.jpg?1",
             "name": "Erdwal Illuminator",
             "text": "Flying\nWhenever you investigate for the first time each turn, investigate an additional time.",
             "colours": [
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "aba70716-c51b-5d10-b0d0-87be619e82ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095ccd82-4898-4506-84dc-87da136470c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095ccd82-4898-4506-84dc-87da136470c6.jpg?1",
             "name": "Eternity Snare",
             "text": "Enchant creature\nWhen Eternity Snare enters the battlefield, draw a card.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "32c8ef14-6cef-5dd9-98b3-05610d35ff1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc1849-f601-4519-a92e-c4d4216b209a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc1849-f601-4519-a92e-c4d4216b209a.jpg?1",
             "name": "Eyekite",
             "text": "Flying\nEyekite gets +2/+0 as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -9745,7 +9745,7 @@
         },
         {
             "id": "74715da6-ab7f-5368-b3d6-c6f0201b7c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86682959-6720-44e0-8fe3-982f0b3e94ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86682959-6720-44e0-8fe3-982f0b3e94ce.jpg?1",
             "name": "Faerie Formation",
             "text": "Flying\n{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card.",
             "colours": [
@@ -9778,7 +9778,7 @@
         },
         {
             "id": "c1130ce3-706b-5041-9c69-e32c7647aaf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05949b2-abb4-4431-b047-f4381a2a920e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05949b2-abb4-4431-b047-f4381a2a920e.jpg?1",
             "name": "Faerie Seer",
             "text": "Flying\nWhen Faerie Seer enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -9812,7 +9812,7 @@
         },
         {
             "id": "b736f382-b4ce-5aff-b469-4e3c426da0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc487c86-caae-4bc0-b41b-5227404e761f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc487c86-caae-4bc0-b41b-5227404e761f.jpg?1",
             "name": "Faerie Vandal",
             "text": "Flash\nFlying\nWhenever you draw your second card each turn, put a +1/+1 counter on Faerie Vandal.",
             "colours": [
@@ -9846,7 +9846,7 @@
         },
         {
             "id": "61a5a996-7e36-5d62-bc3b-55a0060a7be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc890f39-e506-497c-ab0b-3e548fd2676d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc890f39-e506-497c-ab0b-3e548fd2676d.jpg?1",
             "name": "Fallowsage",
             "text": "Whenever Fallowsage becomes tapped, you may draw a card.",
             "colours": [
@@ -9880,7 +9880,7 @@
         },
         {
             "id": "ebd0c479-2096-5af5-a905-7ff84a17d0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70d6006-9f57-4db1-8e65-f2392689b5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70d6006-9f57-4db1-8e65-f2392689b5dd.jpg?1",
             "name": "Filigree Attendant",
             "text": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
             "colours": [
@@ -9914,7 +9914,7 @@
         },
         {
             "id": "c06c4eac-97ef-5dd6-acb5-8c22d4be83af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a7507f-2f18-4a94-9b56-814f26b4490b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a7507f-2f18-4a94-9b56-814f26b4490b.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -9945,7 +9945,7 @@
         },
         {
             "id": "517b7167-628e-5cef-aed2-28f6d424d199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ca694c-f0ee-4994-92a2-be2a840c7e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ca694c-f0ee-4994-92a2-be2a840c7e07.jpg?1",
             "name": "Floodhound",
             "text": "{3}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -9979,7 +9979,7 @@
         },
         {
             "id": "832a532b-a504-5fde-911c-ce06b8eeb872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328aade2-6196-48df-a19b-e61845c5d3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328aade2-6196-48df-a19b-e61845c5d3a9.jpg?1",
             "name": "Frostpeak Yeti",
             "text": "{1}{S}: Frostpeak Yeti can't be blocked this turn. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -10014,7 +10014,7 @@
         },
         {
             "id": "dd84a17c-5070-5c10-a048-fd0c94da16b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ff91c-3d6c-45ed-bc58-28b17e8a213d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ff91c-3d6c-45ed-bc58-28b17e8a213d.jpg?1",
             "name": "Gearseeker Serpent",
             "text": "This spell costs {1} less to cast for each artifact you control.\n{5}{U}: Gearseeker Serpent can't be blocked this turn.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "229a71af-2a40-51af-b570-815b6762f904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c0b9b-3c92-44b3-90b4-a725c7b68a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c0b9b-3c92-44b3-90b4-a725c7b68a73.jpg?1",
             "name": "Gearsmith Prodigy",
             "text": "Gearsmith Prodigy gets +1/+0 as long as you control an artifact.",
             "colours": [
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "2853268c-94b5-57a8-8fe7-72d05c3710c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4264fa-11cb-4d3c-9a8e-c2e18829ddb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4264fa-11cb-4d3c-9a8e-c2e18829ddb0.jpg?1",
             "name": "Gigantoplasm",
             "text": "You may have Gigantoplasm enter the battlefield as a copy of any creature on the battlefield, except it has \"{X}: This creature has base power and toughness X/X.\"",
             "colours": [
@@ -10114,7 +10114,7 @@
         },
         {
             "id": "85eceee4-a65b-58af-908b-eba4fdccb079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6696207-cc2e-4b7a-8992-5101ded5c51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6696207-cc2e-4b7a-8992-5101ded5c51f.jpg?1",
             "name": "Glen Elendra Pranksters",
             "text": "Flying\nWhenever you cast a spell during an opponent's turn, you may return target creature you control to its owner's hand.",
             "colours": [
@@ -10148,7 +10148,7 @@
         },
         {
             "id": "8b9e769c-2620-5ce4-975b-182250bc11a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ef0d68-d9bb-4a46-a063-332d4bd4cf73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ef0d68-d9bb-4a46-a063-332d4bd4cf73.jpg?1",
             "name": "Harbinger of the Tides",
             "text": "You may cast Harbinger of the Tides as though it had flash if you pay {2} more to cast it.\nWhen Harbinger of the Tides enters the battlefield, you may return target tapped creature an opponent controls to its owner's hand.",
             "colours": [
@@ -10182,7 +10182,7 @@
         },
         {
             "id": "a656bf3b-4450-5fc0-92b9-39001de4ab91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbaf939-e475-4fb6-b5cd-440632bba505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbaf939-e475-4fb6-b5cd-440632bba505.jpg?1",
             "name": "Hieroglyphic Illumination",
             "text": "Draw two cards.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -10213,7 +10213,7 @@
         },
         {
             "id": "8be7ff92-e2ca-5f33-97b7-0e141ee87c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a4bbc-660f-442b-9300-69c4141348f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a4bbc-660f-442b-9300-69c4141348f6.jpg?1",
             "name": "Icebind Pillar",
             "text": "{S}, {T}: Tap target artifact or creature. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -10246,7 +10246,7 @@
         },
         {
             "id": "2fd2c443-6ecd-51ee-a279-2688e7d3554c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc72645-d2c3-40cd-81d7-77142e495c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc72645-d2c3-40cd-81d7-77142e495c8d.jpg?1",
             "name": "Interpret the Signs",
             "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's mana value. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -10277,7 +10277,7 @@
         },
         {
             "id": "0578dd86-8a51-5655-b544-7032a183f515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b870094-08bf-41fc-b9d6-e435e02dc4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b870094-08bf-41fc-b9d6-e435e02dc4e0.jpg?1",
             "name": "Jace, Arcane Strategist",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on target creature you control.\n+1: Draw a card.\n\u22127: Creatures you control can't be blocked this turn.",
             "colours": [
@@ -10312,7 +10312,7 @@
         },
         {
             "id": "aecd6a26-7a82-5658-b8d3-a41d22e7cdaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e8e533-350b-4558-98d3-b7fcab3770f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e8e533-350b-4558-98d3-b7fcab3770f5.jpg?1",
             "name": "Jace's Scrutiny",
             "text": "Target creature gets -4/-0 until end of turn.\nInvestigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -10343,7 +10343,7 @@
         },
         {
             "id": "82accfdb-83ef-5231-b73a-1ddfa4a13a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d2ab42-8178-4a6d-9605-976a430491ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d2ab42-8178-4a6d-9605-976a430491ef.jpg?1",
             "name": "Lay Claim",
             "text": "Enchant permanent\nYou control enchanted permanent.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -10376,7 +10376,7 @@
         },
         {
             "id": "3bf0f655-4e32-5523-b715-77e2647db61c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e30459a-4114-4074-a70f-615d84e75a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e30459a-4114-4074-a70f-615d84e75a61.jpg?1",
             "name": "Leave in the Dust",
             "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
             "colours": [
@@ -10407,7 +10407,7 @@
         },
         {
             "id": "0cad779f-bec8-5740-9dbf-43111e7c01ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3287f1-aaef-4db2-bed6-63fc7dfa39c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3287f1-aaef-4db2-bed6-63fc7dfa39c7.jpg?1",
             "name": "Library Larcenist",
             "text": "Whenever Library Larcenist attacks, draw a card.",
             "colours": [
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "9795b56e-d87f-5bca-a990-fafd3aa04383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209a1c1e-7fe8-42b4-81d7-3ad0d14f0549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209a1c1e-7fe8-42b4-81d7-3ad0d14f0549.jpg?1",
             "name": "Littjara Kinseekers",
             "text": "Changeling (This card is every creature type.)\nWhen Littjara Kinseekers enters the battlefield, if you control three or more creatures that share a creature type, put a +1/+1 counter on Littjara Kinseekers, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -10474,7 +10474,7 @@
         },
         {
             "id": "95447692-0930-5a76-a3d9-030d08b668f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7f1f29-dabb-4887-8930-30c9dc797a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7f1f29-dabb-4887-8930-30c9dc797a31.jpg?1",
             "name": "Lookout's Dispersal",
             "text": "This spell costs {1} less to cast if you control a Pirate.\nCounter target spell unless its controller pays {4}.",
             "colours": [
@@ -10505,7 +10505,7 @@
         },
         {
             "id": "8a299fcf-5d6a-581d-943b-6f0666751eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8763fe5-ae09-48c9-ada6-0b05f3c0adc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8763fe5-ae09-48c9-ada6-0b05f3c0adc3.jpg?1",
             "name": "Lumengrid Sentinel",
             "text": "Flying\nWhenever an artifact enters the battlefield under your control, you may tap target permanent.",
             "colours": [
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "b86199d2-e69f-5da4-9d5c-269c0170e13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de64b61-4fb7-4e01-8c30-626b8650325c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de64b61-4fb7-4e01-8c30-626b8650325c.jpg?1",
             "name": "Mantle of Tides",
             "text": "Equipped creature gets +1/+2.\nWhenever you draw your second card each turn, attach Mantle of Tides to target creature you control.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -10572,7 +10572,7 @@
         },
         {
             "id": "82a99308-78ac-597c-b431-75a72f4bc481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8538685-e36b-43ee-b756-7a89bc24f330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8538685-e36b-43ee-b756-7a89bc24f330.jpg?1",
             "name": "Marit Lage's Slumber",
             "text": "Whenever Marit Lage's Slumber or another snow permanent enters the battlefield under your control, scry 1.\nAt the beginning of your upkeep, if you control ten or more snow permanents, sacrifice Marit Lage's Slumber. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [
@@ -10606,7 +10606,7 @@
         },
         {
             "id": "d0ac929c-b7ba-5acb-bd98-bdeef2fc701e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a954372-7bd9-4af8-bef4-91035ba2bd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a954372-7bd9-4af8-bef4-91035ba2bd6b.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "25909400-ac56-5b36-9e3d-e6d655a5cbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6436ac-e129-461c-a40d-9388ec7a0d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6436ac-e129-461c-a40d-9388ec7a0d27.jpg?1",
             "name": "Merfolk Sovereign",
             "text": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature can't be blocked this turn.",
             "colours": [
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "e472ba35-d0ad-5dca-9fce-09b007979edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7d0a1e-4d80-4ae5-be07-38ab6d48df36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7d0a1e-4d80-4ae5-be07-38ab6d48df36.jpg?1",
             "name": "Military Intelligence",
             "text": "Whenever you attack with two or more creatures, draw a card.",
             "colours": [
@@ -10704,7 +10704,7 @@
         },
         {
             "id": "8313c0ff-6b87-5b92-baa3-aa60b3cd8c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397551c-5609-4353-aa43-504af1b27f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397551c-5609-4353-aa43-504af1b27f5a.jpg?1",
             "name": "Mistwalker",
             "text": "Changeling (This card is every creature type.)\nFlying\n{1}{U}: Mistwalker gets +1/-1 until end of turn.",
             "colours": [
@@ -10737,7 +10737,7 @@
         },
         {
             "id": "f57e944e-9f42-5610-8dcc-294717970d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a67010c-9136-48cf-b12a-0032e4e5ec2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a67010c-9136-48cf-b12a-0032e4e5ec2c.jpg?1",
             "name": "Moonfolk Puzzlemaker",
             "text": "Flying\nWhenever Moonfolk Puzzlemaker becomes tapped, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "1f4fa8f4-8f6c-5d76-96a4-ae823be667ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b23e7-4f4c-46bc-a512-4e2e6ff303cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b23e7-4f4c-46bc-a512-4e2e6ff303cd.jpg?1",
             "name": "Multiple Choice",
             "text": "If X is 1, scry 1, then draw a card.\nIf X is 2, you may choose a player. They return a creature they control to its owner's hand.\nIf X is 3, create a 4/4 blue and red Elemental creature token.\nIf X is 4 or more, do all of the above.",
             "colours": [
@@ -10803,7 +10803,7 @@
         },
         {
             "id": "fdcb9f4d-80c6-5067-8eaa-9cd993d4e843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c18de8-4448-4c32-8161-dc23ab237880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c18de8-4448-4c32-8161-dc23ab237880.jpg?1",
             "name": "Mystic Skyfish",
             "text": "Whenever you draw your second card each turn, Mystic Skyfish gains flying until end of turn.",
             "colours": [
@@ -10836,7 +10836,7 @@
         },
         {
             "id": "15385700-2e7b-5d07-a200-ca01a2b074d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a897be4-95e2-4fab-bd08-565afe19533b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a897be4-95e2-4fab-bd08-565afe19533b.jpg?1",
             "name": "Neutralize",
             "text": "Counter target spell.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -10867,7 +10867,7 @@
         },
         {
             "id": "6165f216-7b9a-5eca-8c66-a5424514cdb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc8b95e-250d-432c-968c-1bc81a15716e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc8b95e-250d-432c-968c-1bc81a15716e.jpg?1",
             "name": "No Escape",
             "text": "Counter target creature or planeswalker spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "1e6bdcc8-fa69-5977-81e9-cc05f15bff45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84622757-064b-4323-b4ea-0a87084f57cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84622757-064b-4323-b4ea-0a87084f57cd.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -10931,7 +10931,7 @@
         },
         {
             "id": "c399342e-85f4-54a3-a7ee-1dc176a2d7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a897196-85d0-4e49-a617-b30fb33b145a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a897196-85d0-4e49-a617-b30fb33b145a.jpg?1",
             "name": "One With the Wind",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -10964,7 +10964,7 @@
         },
         {
             "id": "c634c8bf-0eb3-5006-b4ae-7d4a846fc6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67084738-bfda-4996-906e-5a0b0bae5de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67084738-bfda-4996-906e-5a0b0bae5de3.jpg?1",
             "name": "Oneirophage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on Oneirophage.",
             "colours": [
@@ -10998,7 +10998,7 @@
         },
         {
             "id": "cbab3661-e669-5158-a5a3-ce6e776c9127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f63d984-5638-4167-a7ba-1ac2454df8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f63d984-5638-4167-a7ba-1ac2454df8a5.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -11029,7 +11029,7 @@
         },
         {
             "id": "3e88f1d0-684a-5b7b-aea3-f830e7e96f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788cc7f3-f688-472e-a784-aabf7bc8c1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788cc7f3-f688-472e-a784-aabf7bc8c1ea.jpg?1",
             "name": "Overwhelmed Apprentice",
             "text": "When Overwhelmed Apprentice enters the battlefield, each opponent mills two cards. Then you scry 2. (To mill a card, a player puts the top card of their library into their graveyard. To scry 2, look at the top two cards card of your library, then then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11063,7 +11063,7 @@
         },
         {
             "id": "7eeb64bf-cbde-5355-ab3f-364821e0e082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a07251-005c-4f09-8310-a934e3b9d5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a07251-005c-4f09-8310-a934e3b9d5c1.jpg?1",
             "name": "Perilous Voyage",
             "text": "Return target nonland permanent you don't control to its owner's hand. If its mana value was 2 or less, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11094,7 +11094,7 @@
         },
         {
             "id": "8d1bcc7c-e0f9-526c-8850-07ec1cbea13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c961027c-b311-48f2-9fbc-3882ad6f0fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c961027c-b311-48f2-9fbc-3882ad6f0fe6.jpg?1",
             "name": "Pestermite",
             "text": "Flash\nFlying\nWhen Pestermite enters the battlefield, you may tap or untap target permanent.",
             "colours": [
@@ -11128,7 +11128,7 @@
         },
         {
             "id": "8732ddf0-80ed-5239-88a2-342fdf0267a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d98bb7-911b-410b-a4d3-54d411900717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d98bb7-911b-410b-a4d3-54d411900717.jpg?1",
             "name": "Pilfering Hawk",
             "text": "Flying\n{S}, {T}: Draw a card, then discard a card. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -11163,7 +11163,7 @@
         },
         {
             "id": "01fd6cfb-b3f3-509b-84dd-1099e7153daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7854c3f-8c89-4ac6-8cfe-3b5b3b651918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7854c3f-8c89-4ac6-8cfe-3b5b3b651918.jpg?1",
             "name": "Press for Answers",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "cdcabf2c-17de-5504-8fba-86d1124f1d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc02d1-6203-47ee-b834-29f9fd9edb83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc02d1-6203-47ee-b834-29f9fd9edb83.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -11228,7 +11228,7 @@
         },
         {
             "id": "7b9b49d0-8cf2-5354-89e6-50a132f9cbe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac32ebc-c7c6-49fd-a2e3-1ace1bc979ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac32ebc-c7c6-49fd-a2e3-1ace1bc979ae.jpg?1",
             "name": "River Sneak",
             "text": "River Sneak can't be blocked.\nWhenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.",
             "colours": [
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "bf7fba4f-8746-5946-88db-3ab10f397875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0d5c00-0936-445b-8a97-235aec4159b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0d5c00-0936-445b-8a97-235aec4159b3.jpg?1",
             "name": "Sage of the Falls",
             "text": "Whenever Sage of the Falls or another non-Human creature enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "69879e9e-a05b-5be6-ba43-9a1dea89d203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5c9852-bd90-42fd-bf8f-87e131c96461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5c9852-bd90-42fd-bf8f-87e131c96461.jpg?1",
             "name": "Sage's Row Savant",
             "text": "When Sage's Row Savant enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11330,7 +11330,7 @@
         },
         {
             "id": "18f3ebd0-d154-5485-8127-343c06e52bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f660ef24-5cdc-4757-b972-0ea94bb6e074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f660ef24-5cdc-4757-b972-0ea94bb6e074.jpg?1",
             "name": "Saltwater Stalwart",
             "text": "Whenever Saltwater Stalwart deals damage to an opponent, target player draws a card.",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "33721431-3da2-5f01-b66e-4174c6dacdc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479aff39-d9b0-411d-bcc5-a4d1d495f11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479aff39-d9b0-411d-bcc5-a4d1d495f11c.jpg?1",
             "name": "Seafloor Oracle",
             "text": "Whenever a Merfolk you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -11398,7 +11398,7 @@
         },
         {
             "id": "1d41c42c-5a13-5993-b556-bcc23f8cd232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccd614d-f57b-413f-9177-830964a65150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccd614d-f57b-413f-9177-830964a65150.jpg?1",
             "name": "Sentinels of Glen Elendra",
             "text": "Flash\nFlying",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "a1bb9963-2adc-5b69-8772-84118d33f506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44d8329-fe4c-4102-a5ee-3c058b84e315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44d8329-fe4c-4102-a5ee-3c058b84e315.jpg?1",
             "name": "Serum Visions",
             "text": "Draw a card. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11463,7 +11463,7 @@
         },
         {
             "id": "d8493987-e7cb-5140-bf12-24c676a5a61c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95febc2d-e12c-41fa-9e21-be775d5ca164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95febc2d-e12c-41fa-9e21-be775d5ca164.jpg?1",
             "name": "Shaper Apprentice",
             "text": "Shaper Apprentice has flying as long as you control another Merfolk.",
             "colours": [
@@ -11497,7 +11497,7 @@
         },
         {
             "id": "9462d0e7-b0fd-5210-8baf-a3ea4ca279c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4de1a9-18c2-4dcd-9377-e8dc6ac6190c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4de1a9-18c2-4dcd-9377-e8dc6ac6190c.jpg?1",
             "name": "Shimmer Dragon",
             "text": "Flying\nAs long as you control four or more artifacts, Shimmer Dragon has hexproof.\nTap two untapped artifacts you control: Draw a card.",
             "colours": [
@@ -11530,7 +11530,7 @@
         },
         {
             "id": "c2428f7f-348e-52a8-aba6-d83c12a31cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86625fda-c9aa-44ec-874b-351d66012b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86625fda-c9aa-44ec-874b-351d66012b66.jpg?1",
             "name": "Skilled Animator",
             "text": "When Skilled Animator enters the battlefield, target artifact you control becomes an artifact creature with base power and toughness 5/5 for as long as Skilled Animator remains on the battlefield.",
             "colours": [
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "60fe4891-7802-5b83-b785-273789601287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f13eb3-4f41-4b42-b5c9-e3b5a25b722f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f13eb3-4f41-4b42-b5c9-e3b5a25b722f.jpg?1",
             "name": "So Tiny",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-0. It gets -6/-0 instead as long as its controller has seven or more cards in their graveyard.",
             "colours": [
@@ -11597,7 +11597,7 @@
         },
         {
             "id": "b6027553-fa5c-5f34-b841-64ec483fac45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4858a8d-a31a-471f-a740-6c6774ec7dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4858a8d-a31a-471f-a740-6c6774ec7dac.jpg?1",
             "name": "Startling Development",
             "text": "Until end of turn, target creature becomes a blue Serpent with base power and toughness 4/4.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -11628,7 +11628,7 @@
         },
         {
             "id": "00b588b6-ce9e-5c09-9ec4-eaefe0f92918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bce8db-803b-4eda-af98-e131d39525ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bce8db-803b-4eda-af98-e131d39525ec.jpg?1",
             "name": "Steelgaze Griffin",
             "text": "Flying\nWhenever you draw your second card each turn, Steelgaze Griffin gets +2/+0 until end of turn.",
             "colours": [
@@ -11661,7 +11661,7 @@
         },
         {
             "id": "fed53c1f-7daa-5a34-b8cd-6ab35a6539e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fc6a86-d778-4407-8db2-1c15ce827e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fc6a86-d778-4407-8db2-1c15ce827e01.jpg?1",
             "name": "Stinging Lionfish",
             "text": "Whenever you cast your first spell during each opponent's turn, you may tap or untap target nonland permanent.",
             "colours": [
@@ -11695,7 +11695,7 @@
         },
         {
             "id": "3e332f0a-75c0-547d-94f6-f15c87d491d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d00b7-af88-483c-a209-6dde97d6e3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d00b7-af88-483c-a209-6dde97d6e3c8.jpg?1",
             "name": "Stolen by the Fae",
             "text": "Return target creature with mana value X to its owner's hand. You create X 1/1 blue Faerie creature tokens with flying.",
             "colours": [
@@ -11726,7 +11726,7 @@
         },
         {
             "id": "c5b64e78-6bab-59c0-9e08-38aed8ebf3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef312a-43c4-43cc-a7bb-942c580e9aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef312a-43c4-43cc-a7bb-942c580e9aef.jpg?1",
             "name": "Stonybrook Angler",
             "text": "{1}{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -11760,7 +11760,7 @@
         },
         {
             "id": "0c049e4f-b46b-5459-9875-76eaea53c39b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18b6d8d-5226-414b-a000-3e9e02d76980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18b6d8d-5226-414b-a000-3e9e02d76980.jpg?1",
             "name": "Storm Sculptor",
             "text": "Storm Sculptor can't be blocked.\nWhen Storm Sculptor enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -11794,7 +11794,7 @@
         },
         {
             "id": "c8d92935-a9fa-5604-a0d2-be60eff31116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7369d6-54bb-4070-b5fb-fd6fe5886820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7369d6-54bb-4070-b5fb-fd6fe5886820.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}. (Whenever another Merfolk you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "0e3d2337-87ee-5191-b44d-c6c65bd5e329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2b141-b7bb-4033-aed8-a521fcd76d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2b141-b7bb-4033-aed8-a521fcd76d4f.jpg?1",
             "name": "Syr Elenora, the Discerning",
             "text": "Syr Elenora, the Discerning's power is equal to the number of cards in your hand.\nWhen Syr Elenora enters the battlefield, draw a card.\nSpells your opponents cast that target Syr Elenora cost {2} more to cast.",
             "colours": [
@@ -11866,7 +11866,7 @@
         },
         {
             "id": "65fadea0-861f-56ce-86cf-77c9ca552e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f635017-d773-46ce-aecd-39f6e00430d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f635017-d773-46ce-aecd-39f6e00430d0.jpg?1",
             "name": "Tamiyo, the Moon Sage",
             "text": "+1: Tap target permanent. It doesn't untap during its controller's next untap step.\n\u22122: Draw a card for each tapped creature target player controls.\n\u22128: You get an emblem with \"You have no maximum hand size\" and \"Whenever a card is put into your graveyard from anywhere, you may return it to your hand.\"",
             "colours": [
@@ -11901,7 +11901,7 @@
         },
         {
             "id": "30fdf9cb-bab3-5c81-aa76-448fa45711f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662ccce8-c49a-4890-a725-fe01733d07f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662ccce8-c49a-4890-a725-fe01733d07f3.jpg?1",
             "name": "Teferi's Protege",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "a2591dfc-b6eb-5b5a-b81d-113dd872ad47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03fbb-10e9-4bf8-8fd3-e99e8c1cd84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03fbb-10e9-4bf8-8fd3-e99e8c1cd84f.jpg?1",
             "name": "Tezzeret, Artifice Master",
             "text": "+1: Create a 1/1 colorless Thopter artifact creature token with flying.\n0: Draw a card. If you control three or more artifacts, draw two cards instead.\n\u22129: You get an emblem with \"At the beginning of your end step, search your library for a permanent card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -11970,7 +11970,7 @@
         },
         {
             "id": "a1bc75d7-a8b8-5fe2-bab7-bbada1b41f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc605d26-417f-4ef6-a3c4-8482ea05ee12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc605d26-417f-4ef6-a3c4-8482ea05ee12.jpg?1",
             "name": "Thopter Spy Network",
             "text": "At the beginning of your upkeep, if you control an artifact, create a 1/1 colorless Thopter artifact creature token with flying.\nWhenever one or more artifact creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -12001,7 +12001,7 @@
         },
         {
             "id": "9d98a293-7e65-509b-8cc9-8b933a314f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc11641f-a3bd-4282-8c86-fafa63d2d6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc11641f-a3bd-4282-8c86-fafa63d2d6ab.jpg?1",
             "name": "Tolarian Kraken",
             "text": "Whenever you draw a card, you may pay {1}. When you do, you may tap or untap target creature.",
             "colours": [
@@ -12034,7 +12034,7 @@
         },
         {
             "id": "71a6c4cb-f822-5112-8b4c-02669db4f055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92867aa1-698d-47cf-bed7-b758a2cc0e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92867aa1-698d-47cf-bed7-b758a2cc0e5d.jpg?1",
             "name": "Tolarian Sentinel",
             "text": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -12068,7 +12068,7 @@
         },
         {
             "id": "09751ab8-a6a5-59f5-a73c-676a9dca4a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bab5274-99e0-458b-afd5-fe8fb2a753d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bab5274-99e0-458b-afd5-fe8fb2a753d6.jpg?1",
             "name": "Tome Anima",
             "text": "Tome Anima can't be blocked as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -12101,7 +12101,7 @@
         },
         {
             "id": "dc37e8eb-dc0e-5362-b036-4881d2a55fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5213d8-2848-4cb3-b05e-226e08676b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5213d8-2848-4cb3-b05e-226e08676b18.jpg?1",
             "name": "Triton Shorestalker",
             "text": "Triton Shorestalker can't be blocked.",
             "colours": [
@@ -12135,7 +12135,7 @@
         },
         {
             "id": "63c4e1f7-9b64-56e4-a764-ca9342131d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68eb319b-e455-4803-8884-3b28d207ead0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68eb319b-e455-4803-8884-3b28d207ead0.jpg?1",
             "name": "Undersea Invader",
             "text": "Flash\nUndersea Invader enters the battlefield tapped.",
             "colours": [
@@ -12169,7 +12169,7 @@
         },
         {
             "id": "c78c5f8d-55bc-5d63-ba1b-e2308ac5127d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46f0f64-4c1d-4a65-af67-a675c34119f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46f0f64-4c1d-4a65-af67-a675c34119f1.jpg?1",
             "name": "Vedalken Engineer",
             "text": "{T}: Add two mana of any one color. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -12203,7 +12203,7 @@
         },
         {
             "id": "6c38a506-d719-5d7e-856f-b7cc25a7b5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0208c551-a4de-43c7-bd4c-12d24ae179c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0208c551-a4de-43c7-bd4c-12d24ae179c1.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of their library, then draws a card.",
             "colours": [
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "2abe056e-ffe1-5c46-81c7-e4f6772141db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606ffebe-1b17-4770-ab0c-f57ae549fc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606ffebe-1b17-4770-ab0c-f57ae549fc3f.jpg?1",
             "name": "Wake Thrasher",
             "text": "Whenever a permanent you control becomes untapped, Wake Thrasher gets +1/+1 until end of turn.",
             "colours": [
@@ -12273,7 +12273,7 @@
         },
         {
             "id": "6c43149a-ed5d-5a84-9532-de6a3bba4efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42adbafd-1f0d-46b0-a1a5-07c2e2ef41e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42adbafd-1f0d-46b0-a1a5-07c2e2ef41e6.jpg?1",
             "name": "Watertrap Weaver",
             "text": "When Watertrap Weaver enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -12307,7 +12307,7 @@
         },
         {
             "id": "284ecf46-d0a3-5797-852e-e3db427327c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0b6f3-d2c7-441a-9b8f-3269d196a106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0b6f3-d2c7-441a-9b8f-3269d196a106.jpg?1",
             "name": "Wavebreak Hippocamp",
             "text": "Whenever you cast your first spell during each opponent's turn, draw a card.",
             "colours": [
@@ -12342,7 +12342,7 @@
         },
         {
             "id": "2897425c-bae4-54db-9e9f-5c7ff88203ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2494e2a-847a-4605-80dd-a5a6ce80abf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2494e2a-847a-4605-80dd-a5a6ce80abf5.jpg?1",
             "name": "Weldfast Wingsmith",
             "text": "Whenever an artifact enters the battlefield under your control, Weldfast Wingsmith gains flying until end of turn.",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "d74e9278-8044-55c2-911c-caa64c2dc261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9978703f-30bc-4126-a8e5-e7fcb654956c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9978703f-30bc-4126-a8e5-e7fcb654956c.jpg?1",
             "name": "Windrider Patrol",
             "text": "Flying\nWhenever Windrider Patrol deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "b78d5c85-54ad-5d57-bfa1-c12289440bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4a71ea-ac26-4f61-96fc-bb7152cb5341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4a71ea-ac26-4f61-96fc-bb7152cb5341.jpg?1",
             "name": "Winter's Rest",
             "text": "Enchant creature\nWhen Winter's Rest enters the battlefield, tap enchanted creature.\nAs long as you control another snow permanent, enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -12445,7 +12445,7 @@
         },
         {
             "id": "a5a9c075-985c-5cf1-9661-a170696ec67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b168d5-b111-4a1c-a4b8-d3cd376bfa3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b168d5-b111-4a1c-a4b8-d3cd376bfa3b.jpg?1",
             "name": "Alley Strangler",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -12479,7 +12479,7 @@
         },
         {
             "id": "ec7289bc-b92f-5163-8e51-51c83af71963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a46159-2a91-4c89-87d7-13b52bfb0fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a46159-2a91-4c89-87d7-13b52bfb0fdf.jpg?1",
             "name": "Ancient Craving",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -12510,7 +12510,7 @@
         },
         {
             "id": "03f77afc-d055-559a-89b2-de199cb8f083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ede129-83fc-42b7-8941-fa649d3329e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ede129-83fc-42b7-8941-fa649d3329e5.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "f8740c1c-247b-5815-b4b2-384b96bf4c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8458f030-f333-486e-8b52-b7422c1ff059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8458f030-f333-486e-8b52-b7422c1ff059.jpg?1",
             "name": "Blight Keeper",
             "text": "Flying\n{7}{B}, {T}, Sacrifice Blight Keeper: Target opponent loses 4 life and you gain 4 life.",
             "colours": [
@@ -12578,7 +12578,7 @@
         },
         {
             "id": "b4045dd8-7e5b-5c71-9cd3-1cdf0d791be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53782723-0a1e-483f-86e0-9a13650d29b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53782723-0a1e-483f-86e0-9a13650d29b7.jpg?1",
             "name": "Blood Price",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order. You lose 2 life.",
             "colours": [
@@ -12609,7 +12609,7 @@
         },
         {
             "id": "61358ea0-9266-5fa4-a355-4a06b8195ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2937cc19-d0bb-4695-b4c1-5e72000e08b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2937cc19-d0bb-4695-b4c1-5e72000e08b4.jpg?1",
             "name": "Bloodbond Vampire",
             "text": "Whenever you gain life, put a +1/+1 counter on Bloodbond Vampire.",
             "colours": [
@@ -12644,7 +12644,7 @@
         },
         {
             "id": "e64552e5-e34d-517f-8621-10996e02168b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5196ae-2fec-43c3-b6d4-b446646438e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5196ae-2fec-43c3-b6d4-b446646438e6.jpg?1",
             "name": "Bloodthirsty Aerialist",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on Bloodthirsty Aerialist.",
             "colours": [
@@ -12678,7 +12678,7 @@
         },
         {
             "id": "d466574f-2a9a-5e8b-bb31-2fda82afafcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73041c8a-2282-40f6-b2bf-592e8091f1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73041c8a-2282-40f6-b2bf-592e8091f1de.jpg?1",
             "name": "Bloodtracker",
             "text": "Flying\n{B}, Pay 2 life: Put a +1/+1 counter on Bloodtracker.\nWhen Bloodtracker leaves the battlefield, draw a card for each +1/+1 counter on it.",
             "colours": [
@@ -12712,7 +12712,7 @@
         },
         {
             "id": "ea7e63e3-d46d-5cf8-9f4f-ffbbfae0c0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ce1b-a28f-45d5-8643-cc4d955a2350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ce1b-a28f-45d5-8643-cc4d955a2350.jpg?1",
             "name": "Bone Picker",
             "text": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -12745,7 +12745,7 @@
         },
         {
             "id": "96bfc507-8635-51f5-8526-8a901107c15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8bb46d-acc2-4631-89c7-b92f927a5940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8bb46d-acc2-4631-89c7-b92f927a5940.jpg?1",
             "name": "Burglar Rat",
             "text": "When Burglar Rat enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -12778,7 +12778,7 @@
         },
         {
             "id": "a6d52c3b-5d5a-57d1-94a8-726c5c3761d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3897e9f-363d-42f9-85b1-28143b223b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3897e9f-363d-42f9-85b1-28143b223b08.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "1c5145d5-d038-5bf7-bc99-0e76a67a8334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe14b9b-4341-4a1b-96f1-5cb1bb253eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe14b9b-4341-4a1b-96f1-5cb1bb253eba.jpg?1",
             "name": "Certain Death",
             "text": "Destroy target creature. Its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -12840,7 +12840,7 @@
         },
         {
             "id": "b567624b-2f35-5d16-83dd-a0e5bb69ccc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9993c2-eaf7-4163-bd19-8161025cad56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9993c2-eaf7-4163-bd19-8161025cad56.jpg?1",
             "name": "Chittering Rats",
             "text": "When Chittering Rats enters the battlefield, target opponent puts a card from their hand on top of their library.",
             "colours": [
@@ -12873,7 +12873,7 @@
         },
         {
             "id": "9a28a0ed-6b92-5626-b24f-af540e0ea9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d00252-f2db-4065-8242-d4bf2b30e201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d00252-f2db-4065-8242-d4bf2b30e201.jpg?1",
             "name": "Consign to the Pit",
             "text": "Destroy target creature. Consign to the Pit deals 2 damage to that creature's controller.",
             "colours": [
@@ -12904,7 +12904,7 @@
         },
         {
             "id": "0c50e594-fd6f-5b29-8be9-ee9d32c88458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135d748-0da5-4ec4-a7cc-b0b731cb272c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135d748-0da5-4ec4-a7cc-b0b731cb272c.jpg?1",
             "name": "Corpse Churn",
             "text": "Mill three cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -12935,7 +12935,7 @@
         },
         {
             "id": "cf6a56a6-06ec-507b-8221-3ee6d297719c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e541e7a0-7162-482b-8c46-ad9481d24b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e541e7a0-7162-482b-8c46-ad9481d24b48.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -12969,7 +12969,7 @@
         },
         {
             "id": "c4154992-460a-5750-a97f-9a1cf7624904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b948b2a2-0864-4dd8-89f7-27a8c6748911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b948b2a2-0864-4dd8-89f7-27a8c6748911.jpg?1",
             "name": "Cruel Sadist",
             "text": "{B}, {T}, Pay 1 life: Put a +1/+1 counter on Cruel Sadist.\n{2}{B}, {T}, Remove X +1/+1 counters from Cruel Sadist: It deals X damage to target creature.",
             "colours": [
@@ -13003,7 +13003,7 @@
         },
         {
             "id": "0afa24bd-af2b-5cf4-bd77-fd53c7e28e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccdaba-7504-4df6-a079-d7fe450934ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccdaba-7504-4df6-a079-d7fe450934ab.jpg?1",
             "name": "Crypt Rats",
             "text": "{X}: Crypt Rats deals X damage to each creature and each player. Spend only black mana on X.",
             "colours": [
@@ -13036,7 +13036,7 @@
         },
         {
             "id": "ade9ef73-eeea-5160-81c1-8ec4c1bbb318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7776aa09-158a-4286-a6db-8c94cea22855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7776aa09-158a-4286-a6db-8c94cea22855.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "e3b9711e-afa3-5d39-9c5b-69a343d5196e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829de1a5-93b9-4c5a-a47f-691a81a7b76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829de1a5-93b9-4c5a-a47f-691a81a7b76f.jpg?1",
             "name": "Death Wind",
             "text": "Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "2d5c3865-b553-5d34-a0fa-dbb7a764af5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e.jpg?1",
             "name": "Deathbloom Thallid",
             "text": "When Deathbloom Thallid dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13133,7 +13133,7 @@
         },
         {
             "id": "f44998bd-5591-5ba5-8dbd-4994e6780438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78229484-b07a-4b6c-ae27-74c7dac3d620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78229484-b07a-4b6c-ae27-74c7dac3d620.jpg?1",
             "name": "Deathbringer Regent",
             "text": "Flying\nWhen Deathbringer Regent enters the battlefield, if you cast it from your hand and there are five or more other creatures on the battlefield, destroy all other creatures.",
             "colours": [
@@ -13166,7 +13166,7 @@
         },
         {
             "id": "1427b029-5506-5ba8-a41d-699aa9887405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861100dd-376a-4a8b-862a-76ad4edda725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861100dd-376a-4a8b-862a-76ad4edda725.jpg?1",
             "name": "Demon of Catastrophes",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample",
             "colours": [
@@ -13199,7 +13199,7 @@
         },
         {
             "id": "0ea7cd86-cadd-5272-824e-fa02ac625b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6721bbf0-b268-4030-aa90-713f0e9360c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6721bbf0-b268-4030-aa90-713f0e9360c5.jpg?1",
             "name": "Demonic Gifts",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -13230,7 +13230,7 @@
         },
         {
             "id": "e0f3aa87-c7ea-5da5-8e59-1a3355ddf936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c09c4b8-dcb3-4dfe-a892-718e0d1c5a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c09c4b8-dcb3-4dfe-a892-718e0d1c5a8a.jpg?1",
             "name": "Demon's Disciple",
             "text": "When Demon's Disciple enters the battlefield, each player sacrifices a creature or planeswalker.",
             "colours": [
@@ -13264,7 +13264,7 @@
         },
         {
             "id": "4bbf6048-8156-5333-aa01-0551ab103065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305f55c-6bcf-464b-aa80-e227bf30c9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305f55c-6bcf-464b-aa80-e227bf30c9ea.jpg?1",
             "name": "Demon's Grasp",
             "text": "Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -13295,7 +13295,7 @@
         },
         {
             "id": "fbc19476-8ab0-56ea-95f7-3d8ba94b5fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1065b467-f24b-4add-bced-1d4709df1adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1065b467-f24b-4add-bced-1d4709df1adb.jpg?1",
             "name": "Devouring Swarm",
             "text": "Flying\nSacrifice a creature: Devouring Swarm gets +1/+1 until end of turn.",
             "colours": [
@@ -13328,7 +13328,7 @@
         },
         {
             "id": "4bb91315-43d2-5f94-922e-cc8c671467b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d3ce5-3e71-44f1-ab0e-98d399287722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d3ce5-3e71-44f1-ab0e-98d399287722.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -13361,7 +13361,7 @@
         },
         {
             "id": "d0ea4273-31ae-524a-929d-cefc44331bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98f8d65-e326-42a1-97e3-630416595eeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98f8d65-e326-42a1-97e3-630416595eeb.jpg?1",
             "name": "Dread Presence",
             "text": "Whenever a Swamp enters the battlefield under your control, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Dread Presence deals 2 damage to any target and you gain 2 life.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "03476ae9-fb22-5a36-a30c-638f408b1dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3cdb0f-3e08-47cc-841f-80f34d6cce49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3cdb0f-3e08-47cc-841f-80f34d6cce49.jpg?1",
             "name": "Dread Rider",
             "text": "{1}{B}, {T}, Exile a creature card from your graveyard: Target opponent loses 3 life.",
             "colours": [
@@ -13428,7 +13428,7 @@
         },
         {
             "id": "e9bc4f84-3eb2-5d5e-8154-4f023c1f59d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b84820d-187c-4d3b-b7a7-7999d4efe443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b84820d-187c-4d3b-b7a7-7999d4efe443.jpg?1",
             "name": "Dread Slaver",
             "text": "Whenever a creature dealt damage by Dread Slaver this turn dies, return it to the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -13462,7 +13462,7 @@
         },
         {
             "id": "ead8986f-5384-54c9-b796-414201c38968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12f259-2c62-4196-8786-dfb75b40f5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12f259-2c62-4196-8786-dfb75b40f5c0.jpg?1",
             "name": "Dreadhound",
             "text": "When Dreadhound enters the battlefield, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhenever a creature dies or a creature card is put into a graveyard from a library, each opponent loses 1 life.",
             "colours": [
@@ -13496,7 +13496,7 @@
         },
         {
             "id": "c298df8b-75a0-5656-a4c7-8d3ddfcfe87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd4f7da-5200-4c1b-8c42-95d601952995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd4f7da-5200-4c1b-8c42-95d601952995.jpg?1",
             "name": "Dune Beetle",
             "text": "",
             "colours": [
@@ -13529,7 +13529,7 @@
         },
         {
             "id": "04f34648-9e22-582f-89fa-245ef8446821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58725475-ff77-4511-9797-c44b0fa9909d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58725475-ff77-4511-9797-c44b0fa9909d.jpg?1",
             "name": "Durable Coilbug",
             "text": "{4}{B}: Return Durable Coilbug from your graveyard to your hand.",
             "colours": [
@@ -13562,7 +13562,7 @@
         },
         {
             "id": "a630b9df-8644-5563-93d5-c2663c75bafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73686b22-0ef3-41b6-a7d4-a226bde458c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73686b22-0ef3-41b6-a7d4-a226bde458c0.jpg?1",
             "name": "Eaten Alive",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nExile target creature or planeswalker.",
             "colours": [
@@ -13593,7 +13593,7 @@
         },
         {
             "id": "a32bf872-7776-57ed-a017-5396f701c972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920b00c-d4ed-4d21-abfa-da270a1ae94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920b00c-d4ed-4d21-abfa-da270a1ae94f.jpg?1",
             "name": "Endless Ranks of the Dead",
             "text": "At the beginning of your upkeep, create X 2/2 black Zombie creature tokens, where X is half the number of Zombies you control, rounded down.",
             "colours": [
@@ -13624,7 +13624,7 @@
         },
         {
             "id": "1902ba46-f5b2-5812-b82f-19280698a93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f71ff90-13ff-4ac6-8bdd-2cf53cc24ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f71ff90-13ff-4ac6-8bdd-2cf53cc24ec1.jpg?1",
             "name": "Epicure of Blood",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -13657,7 +13657,7 @@
         },
         {
             "id": "8ef62094-5b9c-5128-ab88-1bb62be5fb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e215786-5c2a-4f08-afab-78342ad8fa17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e215786-5c2a-4f08-afab-78342ad8fa17.jpg?1",
             "name": "Eviscerate",
             "text": "Destroy target creature.",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "7c4936d3-468c-57a7-9cba-9e9d34a1335a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ffebc3-8ad4-42da-b4f2-837ae22dee72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ffebc3-8ad4-42da-b4f2-837ae22dee72.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -13719,7 +13719,7 @@
         },
         {
             "id": "7a52c6b4-f8af-5d4d-b6ae-ce659615b43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b55746e-28b3-4446-a695-2711836ab1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b55746e-28b3-4446-a695-2711836ab1b6.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -13753,7 +13753,7 @@
         },
         {
             "id": "e0d44a5b-7af0-5501-abc4-b369a37f971d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3353a2-b443-4084-b43f-0ff3a22b26c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3353a2-b443-4084-b43f-0ff3a22b26c1.jpg?1",
             "name": "Fetid Imp",
             "text": "Flying\n{B}: Fetid Imp gains deathtouch until end of turn.",
             "colours": [
@@ -13786,7 +13786,7 @@
         },
         {
             "id": "78567cff-7fba-5dc5-8e14-6c17295791bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727a589a-2248-478f-825f-932bfb456675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727a589a-2248-478f-825f-932bfb456675.jpg?1",
             "name": "Fungal Infection",
             "text": "Target creature gets -1/-1 until end of turn. Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13817,7 +13817,7 @@
         },
         {
             "id": "9cf79cfb-876e-51d3-a5eb-ae0c2324c558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d8209-cd48-465b-8f39-f337e0e0a820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d8209-cd48-465b-8f39-f337e0e0a820.jpg?1",
             "name": "Gavony Unhallowed",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Gavony Unhallowed.",
             "colours": [
@@ -13850,7 +13850,7 @@
         },
         {
             "id": "0f059647-2236-5fe5-a236-20a7a00fce4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc0588-6feb-475c-817d-c71385419cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc0588-6feb-475c-817d-c71385419cac.jpg?1",
             "name": "Ghoulraiser",
             "text": "When Ghoulraiser enters the battlefield, return a Zombie card at random from your graveyard to your hand.",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "e48b753a-12c1-5c26-994d-a22c7b28d793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d82703-20a5-4e81-a396-c5e22655b8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d82703-20a5-4e81-a396-c5e22655b8ba.jpg?1",
             "name": "Gnawing Zombie",
             "text": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -13916,7 +13916,7 @@
         },
         {
             "id": "654e6d8e-0964-5e37-a8b0-626bd5df8a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06488720-9875-483a-b163-f620692ef627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06488720-9875-483a-b163-f620692ef627.jpg?1",
             "name": "Gorging Vulture",
             "text": "Flying\nWhen Gorging Vulture enters the battlefield, mill four cards. You gain 1 life for each creature card milled this way. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -13949,7 +13949,7 @@
         },
         {
             "id": "93d84038-7d56-50dd-8f16-64431ffc16ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f2413f-987f-4eab-96c1-f662821546a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f2413f-987f-4eab-96c1-f662821546a5.jpg?1",
             "name": "Graf Harvest",
             "text": "Zombies you control have menace. (They can't be blocked except by two or more creatures.)\n{3}{B}, Exile a creature card from your graveyard: Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "cce2729d-f845-5fe5-8343-9174c44b3e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5c03c6-123b-4d4d-878e-0158659bf27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5c03c6-123b-4d4d-878e-0158659bf27b.jpg?1",
             "name": "Graveblade Marauder",
             "text": "Deathtouch\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -14014,7 +14014,7 @@
         },
         {
             "id": "66f62828-b89c-562c-b484-3449d5eae0da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128351fb-2ce0-4439-982a-9cc741936992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128351fb-2ce0-4439-982a-9cc741936992.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -14047,7 +14047,7 @@
         },
         {
             "id": "f6c37f61-2593-590a-aa59-404065242cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80467e94-81b3-4b2f-865d-69e3d531e845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80467e94-81b3-4b2f-865d-69e3d531e845.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -14080,7 +14080,7 @@
         },
         {
             "id": "49562caa-a866-5fcd-aed7-031d9e6437d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db61b56-6bfb-448f-ae6d-932d96760917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db61b56-6bfb-448f-ae6d-932d96760917.jpg?1",
             "name": "Grotesque Mutation",
             "text": "Target creature gets +3/+1 and gains lifelink until end of turn.",
             "colours": [
@@ -14111,7 +14111,7 @@
         },
         {
             "id": "2f6581c7-81a0-5f49-8b27-06925d89b5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a8a789-cda2-4ef6-b82a-7e46d609c835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a8a789-cda2-4ef6-b82a-7e46d609c835.jpg?1",
             "name": "Hooded Assassin",
             "text": "When Hooded Assassin enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Hooded Assassin.\n\u2022 Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -14145,7 +14145,7 @@
         },
         {
             "id": "d6e62bcc-f651-55d7-9e84-56c6ad7b8a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc24cd32-e275-4fc1-9fde-834db4564663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc24cd32-e275-4fc1-9fde-834db4564663.jpg?1",
             "name": "Ill-Gotten Inheritance",
             "text": "At the beginning of your upkeep, Ill-Gotten Inheritance deals 1 damage to each opponent and you gain 1 life.\n{5}{B}, Sacrifice Ill-Gotten Inheritance: It deals 4 damage to target opponent and you gain 4 life.",
             "colours": [
@@ -14176,7 +14176,7 @@
         },
         {
             "id": "c9e3acd4-f4c8-5776-8451-05037ed0df51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa312f39-8076-4ef7-8890-02c1f2771766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa312f39-8076-4ef7-8890-02c1f2771766.jpg?1",
             "name": "Inner Demon",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has flying, and is a Demon in addition to its other types.\nWhen Inner Demon enters the battlefield, all non-Demon creatures get -2/-2 until end of turn.",
             "colours": [
@@ -14209,7 +14209,7 @@
         },
         {
             "id": "331193d7-ff17-559e-af22-a97d5da846b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdadf8-d4f2-4273-b7b6-02866ba54610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdadf8-d4f2-4273-b7b6-02866ba54610.jpg?1",
             "name": "Kalastria Nightwatch",
             "text": "Whenever you gain life, Kalastria Nightwatch gains flying until end of turn.",
             "colours": [
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "848ce683-26fc-5952-898f-2e19c87c062c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2e14c7-1bee-4bc6-ad26-03dc55e149d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2e14c7-1bee-4bc6-ad26-03dc55e149d5.jpg?1",
             "name": "Karfell Kennel-Master",
             "text": "When Karfell Kennel-Master enters the battlefield, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -14278,7 +14278,7 @@
         },
         {
             "id": "3137e55f-d7cd-5feb-92a7-96ad9a4f70a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3414d-3c79-4771-a6ba-812608855922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3414d-3c79-4771-a6ba-812608855922.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "Flying\nWhenever a permanent owned by another player is put into a graveyard from the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -14313,7 +14313,7 @@
         },
         {
             "id": "8234bdec-bc47-5a28-81df-56be04855583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5758460-d1bc-49ba-80de-c0849958f705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5758460-d1bc-49ba-80de-c0849958f705.jpg?1",
             "name": "Kraul Swarm",
             "text": "Flying\n{2}{B}, Discard a creature card: Return Kraul Swarm from your graveyard to your hand.",
             "colours": [
@@ -14347,7 +14347,7 @@
         },
         {
             "id": "c7a97583-bdc6-5e2c-aa6e-fe1e35431930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42b0052-0758-489f-b7e2-208686ad82af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42b0052-0758-489f-b7e2-208686ad82af.jpg?1",
             "name": "Liliana, Death's Majesty",
             "text": "+1: Create a 2/2 black Zombie creature token. Mill two cards.\n\u22123: Return target creature card from your graveyard to the battlefield. That creature is a black Zombie in addition to its other colors and types.\n\u22127: Destroy all non-Zombie creatures.",
             "colours": [
@@ -14382,7 +14382,7 @@
         },
         {
             "id": "3424a20a-f396-5b34-870a-0e80b388e86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f826404-3df5-4b0c-9739-837938ac8401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f826404-3df5-4b0c-9739-837938ac8401.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "6ef0926c-9ef9-5742-bfa7-f3c890d66d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28b5fce-ac73-44ec-be2c-c95d8d3579fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28b5fce-ac73-44ec-be2c-c95d8d3579fe.jpg?1",
             "name": "Liliana's Mastery",
             "text": "Zombies you control get +1/+1.\nWhen Liliana's Mastery enters the battlefield, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -14446,7 +14446,7 @@
         },
         {
             "id": "7d6753b4-9ac6-56e0-98db-7cdeec80e3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9f9747-5320-43b7-b8ca-92330be64272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9f9747-5320-43b7-b8ca-92330be64272.jpg?1",
             "name": "Liliana's Steward",
             "text": "{T}, Sacrifice Liliana's Steward: Target opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -14479,7 +14479,7 @@
         },
         {
             "id": "1e1a46f6-08b0-52d4-bf2f-23d8713fc444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ba7512-54cc-40cc-b13a-5d8990fa33bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ba7512-54cc-40cc-b13a-5d8990fa33bc.jpg?1",
             "name": "Lurking Deadeye",
             "text": "Flash\nWhen Lurking Deadeye enters the battlefield, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -14513,7 +14513,7 @@
         },
         {
             "id": "018e7bee-4fa0-5817-8b77-4299a56649c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cce8a-43b4-42aa-abbd-0835583e74bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cce8a-43b4-42aa-abbd-0835583e74bd.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When Maalfeld Twins dies, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -14546,7 +14546,7 @@
         },
         {
             "id": "783bbd0d-a8be-5cf9-bf83-80cd8de6ae06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9de75b-5295-4c7f-b149-b9cd508db1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9de75b-5295-4c7f-b149-b9cd508db1f2.jpg?1",
             "name": "Marauding Blight-Priest",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -14580,7 +14580,7 @@
         },
         {
             "id": "64eee1ee-1ec6-5400-a6fb-3533b72f33c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df47291-c285-49db-a4eb-b9a150979127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df47291-c285-49db-a4eb-b9a150979127.jpg?1",
             "name": "Marauding Boneslasher",
             "text": "Marauding Boneslasher can't block unless you control another Zombie.",
             "colours": [
@@ -14614,7 +14614,7 @@
         },
         {
             "id": "4296d634-e782-5e17-8388-a69812f18917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38fda1-8008-4b2d-a2b6-eb02a8b125e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38fda1-8008-4b2d-a2b6-eb02a8b125e8.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -14648,7 +14648,7 @@
         },
         {
             "id": "caa106d8-27ae-5406-b07a-056e79443c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1702ed-3a74-41f4-af6d-3fda3876c221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1702ed-3a74-41f4-af6d-3fda3876c221.jpg?1",
             "name": "Mire Blight",
             "text": "Enchant creature\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -14681,7 +14681,7 @@
         },
         {
             "id": "78cc2eb2-b687-547c-9d83-25e093d7fc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56246461-67f3-46cb-a2df-ef90ea89ceb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56246461-67f3-46cb-a2df-ef90ea89ceb3.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "69d4e2e0-f5f5-5752-b693-fb73782fed02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a506f54f-b25b-4b15-99b9-cdf0af9df79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a506f54f-b25b-4b15-99b9-cdf0af9df79a.jpg?1",
             "name": "Moment of Craving",
             "text": "Target creature gets -2/-2 until end of turn. You gain 2 life.",
             "colours": [
@@ -14746,7 +14746,7 @@
         },
         {
             "id": "d352ead0-69be-5f1a-b967-7771aeee3fb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50101d86-5cda-4dbd-aa6b-c6da791ef73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50101d86-5cda-4dbd-aa6b-c6da791ef73b.jpg?1",
             "name": "Moodmark Painter",
             "text": "Undergrowth \u2014 When Moodmark Painter enters the battlefield, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -14780,7 +14780,7 @@
         },
         {
             "id": "15bef1e7-a44f-5320-afb8-73701f51ce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdec536-d233-40f1-9448-82c3c845ead6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdec536-d233-40f1-9448-82c3c845ead6.jpg?1",
             "name": "Necromancer's Stockpile",
             "text": "{1}{B}, Discard a creature card: Draw a card. If the discarded card was a Zombie card, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -14811,7 +14811,7 @@
         },
         {
             "id": "c8d776a3-4cde-5107-8978-e7c9e8513fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4819311f-fc0a-4662-8f5b-48e2a409f1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4819311f-fc0a-4662-8f5b-48e2a409f1d5.jpg?1",
             "name": "Necrotic Wound",
             "text": "Undergrowth \u2014 Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -14842,7 +14842,7 @@
         },
         {
             "id": "3c09aa35-c8a0-5fd7-9b5f-78f7efbaead1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a296bf5f-3358-4bd1-83b0-3220aaba049f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a296bf5f-3358-4bd1-83b0-3220aaba049f.jpg?1",
             "name": "Nested Ghoul",
             "text": "Whenever a source deals damage to Nested Ghoul, create a 2/2 black Phyrexian Zombie creature token.",
             "colours": [
@@ -14877,7 +14877,7 @@
         },
         {
             "id": "2034fd28-163e-5ab1-9d86-59ece6907e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959fb12c-3ea2-4caa-80d9-2a844e83ba0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959fb12c-3ea2-4caa-80d9-2a844e83ba0f.jpg?1",
             "name": "Nirkana Assassin",
             "text": "Whenever you gain life, Nirkana Assassin gains deathtouch until end of turn.",
             "colours": [
@@ -14912,7 +14912,7 @@
         },
         {
             "id": "9025ff85-83f0-5739-a22a-5cbc4942064c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7400da3-22f2-4238-8e8a-969794790209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7400da3-22f2-4238-8e8a-969794790209.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "Whenever an opponent draws a card, Ob Nixilis, the Hate-Twisted deals 1 damage to that player.\n\u22122: Destroy target creature. Its controller draws two cards.",
             "colours": [
@@ -14947,7 +14947,7 @@
         },
         {
             "id": "afe0cd82-6cd6-56f7-b6f5-15452729975e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4832271-ba68-4bed-a0ee-9da4bc3bedaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4832271-ba68-4bed-a0ee-9da4bc3bedaa.jpg?1",
             "name": "Ob Nixilis's Cruelty",
             "text": "Target creature gets -5/-5 until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -14978,7 +14978,7 @@
         },
         {
             "id": "89d4f477-169c-506d-ad3c-9192c7c89537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44fca9-3a41-41c3-aa74-f0f5a81e8b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44fca9-3a41-41c3-aa74-f0f5a81e8b7d.jpg?1",
             "name": "Ophiomancer",
             "text": "At the beginning of each upkeep, if you control no Snakes, create a 1/1 black Snake creature token with deathtouch.",
             "colours": [
@@ -15012,7 +15012,7 @@
         },
         {
             "id": "69422ff4-d823-55d9-a896-7553767c09f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649ec97-fb5e-49ee-a15a-1acbb54344a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649ec97-fb5e-49ee-a15a-1acbb54344a6.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15043,7 +15043,7 @@
         },
         {
             "id": "b7885367-0e55-5ba7-b040-9c34e975dd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f3efc2-2b36-4e69-8bcc-54385b78519a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f3efc2-2b36-4e69-8bcc-54385b78519a.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\n{T}, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -15077,7 +15077,7 @@
         },
         {
             "id": "250bf232-a8cd-5499-a0cd-f0b43312fe3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef90fdf-a88b-4060-85cf-e0180f685bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef90fdf-a88b-4060-85cf-e0180f685bd1.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper enters the battlefield, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "16ee9771-43a2-564a-add6-f4f51107ef8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c8cfe-79b1-463e-a0bd-5bc003ce26cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c8cfe-79b1-463e-a0bd-5bc003ce26cd.jpg?1",
             "name": "Plague Spitter",
             "text": "At the beginning of your upkeep, Plague Spitter deals 1 damage to each creature and each player.\nWhen Plague Spitter dies, it deals 1 damage to each creature and each player.",
             "colours": [
@@ -15145,7 +15145,7 @@
         },
         {
             "id": "cc17f22a-3c39-54aa-b53c-2e0d2199a803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f77674-dd03-4f19-bd87-aec2359b620e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f77674-dd03-4f19-bd87-aec2359b620e.jpg?1",
             "name": "Priest of the Blood Rite",
             "text": "When Priest of the Blood Rite enters the battlefield, create a 5/5 black Demon creature token with flying.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -15179,7 +15179,7 @@
         },
         {
             "id": "3827ebc2-eccf-5014-a86e-50ccfd5e9c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29595671-fcec-41a0-a361-91c6be3af6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29595671-fcec-41a0-a361-91c6be3af6b7.jpg?1",
             "name": "Reaper from the Abyss",
             "text": "Flying\nMorbid \u2014 At the beginning of each end step, if a creature died this turn, destroy target non-Demon creature.",
             "colours": [
@@ -15212,7 +15212,7 @@
         },
         {
             "id": "e7c8e908-3318-54cf-8423-3e44a7a3bf36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f7a6-d7ef-462c-9e6c-980c35bb81ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f7a6-d7ef-462c-9e6c-980c35bb81ed.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -15243,7 +15243,7 @@
         },
         {
             "id": "beafeef8-e254-5fe1-b028-316de268e7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4beadd29-e445-42f5-bf0f-75050b701b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4beadd29-e445-42f5-bf0f-75050b701b2c.jpg?1",
             "name": "Returned Reveler",
             "text": "When Returned Reveler dies, each player mills three cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -15277,7 +15277,7 @@
         },
         {
             "id": "11577ee4-3d2d-5b8d-a2b4-3cb627a209a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e36bf-021f-4a17-99a3-3e87fd7e39bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e36bf-021f-4a17-99a3-3e87fd7e39bd.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -15310,7 +15310,7 @@
         },
         {
             "id": "49d7bc1d-9a32-5cd9-8ea8-557b45c0add4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9e959-7a17-4641-aa91-f10beae99cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9e959-7a17-4641-aa91-f10beae99cdc.jpg?1",
             "name": "Ruthless Disposal",
             "text": "As an additional cost to cast this spell, discard a card and sacrifice a creature.\nTwo target creatures each get -13/-13 until end of turn.",
             "colours": [
@@ -15341,7 +15341,7 @@
         },
         {
             "id": "22e80360-0fc4-566f-842d-8ae1ae207545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690c472e-98a9-464a-84de-78dda6d111c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690c472e-98a9-464a-84de-78dda6d111c8.jpg?1",
             "name": "Seizan, Perverter of Truth",
             "text": "At the beginning of each player's upkeep, that player loses 2 life and draws two cards.",
             "colours": [
@@ -15377,7 +15377,7 @@
         },
         {
             "id": "026975c1-e081-565e-ba9c-45ce10e222fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0410803-7337-4537-bcae-e677014640d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0410803-7337-4537-bcae-e677014640d4.jpg?1",
             "name": "Shadowborn Demon",
             "text": "Flying\nWhen Shadowborn Demon enters the battlefield, destroy target non-Demon creature.\nAt the beginning of your upkeep, if there are fewer than six creature cards in your graveyard, sacrifice a creature.",
             "colours": [
@@ -15410,7 +15410,7 @@
         },
         {
             "id": "f5cfa921-5922-50d3-a152-ff78f2df5ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1258c7d4-cc4f-47c2-b346-27274bfee151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1258c7d4-cc4f-47c2-b346-27274bfee151.jpg?1",
             "name": "Shambling Ghoul",
             "text": "Shambling Ghoul enters the battlefield tapped.",
             "colours": [
@@ -15443,7 +15443,7 @@
         },
         {
             "id": "37a213a3-0714-590d-9a34-8e54394f272a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c61e2-4af4-4e19-bee6-4b8c90a33f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c61e2-4af4-4e19-bee6-4b8c90a33f03.jpg?1",
             "name": "Sinuous Vermin",
             "text": "{3}{B}{B}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nAs long as Sinuous Vermin is monstrous, it has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -15477,7 +15477,7 @@
         },
         {
             "id": "51577307-7b95-5137-9966-4336cc9005a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265ed45-2954-4fca-b13f-5c1afd1ef134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265ed45-2954-4fca-b13f-5c1afd1ef134.jpg?1",
             "name": "Skirsdag High Priest",
             "text": "Morbid \u2014 {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token with flying. Activate only if a creature died this turn.",
             "colours": [
@@ -15511,7 +15511,7 @@
         },
         {
             "id": "f37bb4fa-b646-579c-a649-a05277528e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb107063-d6fc-4572-914d-3f0382134ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb107063-d6fc-4572-914d-3f0382134ac5.jpg?1",
             "name": "Skirsdag Supplicant",
             "text": "{B}, {T}, Discard a card: Each player loses 2 life.",
             "colours": [
@@ -15545,7 +15545,7 @@
         },
         {
             "id": "b2d21963-206a-52eb-bd37-a96a01ccb21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8d27af-e4cf-4e18-825e-8f6c972e64ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8d27af-e4cf-4e18-825e-8f6c972e64ba.jpg?1",
             "name": "Sling-Gang Lieutenant",
             "text": "When Sling-Gang Lieutenant enters the battlefield, create two 1/1 red Goblin creature tokens.\nSacrifice a Goblin: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -15578,7 +15578,7 @@
         },
         {
             "id": "f3cfa639-58b0-5414-b33e-cd47d4600a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f1d112-4c62-41c0-8be6-da78c1036b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f1d112-4c62-41c0-8be6-da78c1036b4d.jpg?1",
             "name": "Soulcage Fiend",
             "text": "When Soulcage Fiend dies, each player loses 3 life.",
             "colours": [
@@ -15611,7 +15611,7 @@
         },
         {
             "id": "896d142f-7a9f-5efb-bf47-40ce5139b3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6f8cfe-20b1-430a-8aa8-dcaebc94ca2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6f8cfe-20b1-430a-8aa8-dcaebc94ca2a.jpg?1",
             "name": "Spark Reaper",
             "text": "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card.",
             "colours": [
@@ -15644,7 +15644,7 @@
         },
         {
             "id": "dd66f55a-2c0c-51ca-837f-fa5d050f597d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44e634-7a1f-4e7d-afdd-e7fd9a0bab06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44e634-7a1f-4e7d-afdd-e7fd9a0bab06.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "When Stitcher's Supplier enters the battlefield or dies, mill three cards. (Put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -15679,7 +15679,7 @@
         },
         {
             "id": "c6493d2c-d0c7-5786-8b56-a1cd527e2257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c87f47-419f-4551-9e74-29f1df81dfbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c87f47-419f-4551-9e74-29f1df81dfbe.jpg?1",
             "name": "Strangling Spores",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -15710,7 +15710,7 @@
         },
         {
             "id": "5adae475-4597-543b-89bd-4c929fe42fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754baf3f-4bad-4739-9f55-65040c96825c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754baf3f-4bad-4739-9f55-65040c96825c.jpg?1",
             "name": "Syr Konrad, the Grim",
             "text": "Whenever another creature dies, or a creature card is put into a graveyard from anywhere other than the battlefield, or a creature card leaves your graveyard, Syr Konrad, the Grim deals 1 damage to each opponent.\n{1}{B}: Each player mills a card.",
             "colours": [
@@ -15746,7 +15746,7 @@
         },
         {
             "id": "57753dc7-48d6-57a2-a126-ae0961f5a830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6e6918-7941-46f0-b6d7-83e0c95c6938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6e6918-7941-46f0-b6d7-83e0c95c6938.jpg?1",
             "name": "Takenuma Bleeder",
             "text": "Whenever Takenuma Bleeder attacks or blocks, you lose 1 life if you don't control a Demon.",
             "colours": [
@@ -15780,7 +15780,7 @@
         },
         {
             "id": "107245d2-4cbf-59a3-88a6-342cb17b712c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f930f102-ad69-4b70-ae0f-641f5c05f40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f930f102-ad69-4b70-ae0f-641f5c05f40c.jpg?1",
             "name": "Tivash, Gloom Summoner",
             "text": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay X life, where X is the amount of life you gained this turn. If you do, create an X/X black Demon creature token with flying.",
             "colours": [
@@ -15816,7 +15816,7 @@
         },
         {
             "id": "1eba62e7-677c-5ac4-936d-51e14138fc16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97012a9c-34cb-4d66-bb2c-3127be4c0f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97012a9c-34cb-4d66-bb2c-3127be4c0f28.jpg?1",
             "name": "Tormented Soul",
             "text": "Tormented Soul can't block and can't be blocked.",
             "colours": [
@@ -15849,7 +15849,7 @@
         },
         {
             "id": "bf6076dc-877c-5998-92a1-69d160f7348f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08cadcd-7e2d-48a6-8900-ca92499fdaff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08cadcd-7e2d-48a6-8900-ca92499fdaff.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "13b7df9b-c94b-5336-beb1-95fef6a3e3cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99a9bc1-8ee2-48b2-bb36-c8b3b8ace470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99a9bc1-8ee2-48b2-bb36-c8b3b8ace470.jpg?1",
             "name": "Triskaidekaphobia",
             "text": "At the beginning of your upkeep, choose one \u2014\n\u2022 Each player with exactly 13 life loses the game, then each player gains 1 life.\n\u2022 Each player with exactly 13 life loses the game, then each player loses 1 life.",
             "colours": [
@@ -15913,7 +15913,7 @@
         },
         {
             "id": "2a1bd527-2d38-5efe-82cd-5fba1a811c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec112cf-aa50-4246-9730-e034a3656c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec112cf-aa50-4246-9730-e034a3656c3d.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch",
             "colours": [
@@ -15946,7 +15946,7 @@
         },
         {
             "id": "d21e6edd-35ec-5760-a21b-e1b42c3443f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b01b24-67a7-44a5-80ab-b058d8b0f593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b01b24-67a7-44a5-80ab-b058d8b0f593.jpg?1",
             "name": "Ulcerate",
             "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
             "colours": [
@@ -15977,7 +15977,7 @@
         },
         {
             "id": "7578a411-febe-537d-aff7-2e8aa1f1f4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a4dce7-f13a-4109-8da0-81da89397eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a4dce7-f13a-4109-8da0-81da89397eb0.jpg?1",
             "name": "Undead Augur",
             "text": "Whenever Undead Augur or another Zombie you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -16011,7 +16011,7 @@
         },
         {
             "id": "ef4802a6-c61a-5f5e-93a1-bf6edbcccca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf33f08-eb13-4bed-b286-aef9e2e84abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf33f08-eb13-4bed-b286-aef9e2e84abb.jpg?1",
             "name": "Vampire Envoy",
             "text": "Flying\nWhenever Vampire Envoy becomes tapped, you gain 1 life.",
             "colours": [
@@ -16046,7 +16046,7 @@
         },
         {
             "id": "795c057e-7996-51cb-a29e-13b9cad2ca84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afbfbc-55d3-4cea-be37-9c6c015d121d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afbfbc-55d3-4cea-be37-9c6c015d121d.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -16077,7 +16077,7 @@
         },
         {
             "id": "10b0f3e4-f50a-5d4f-ba10-b57ab4581b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3af160-3993-4b49-b4ec-065e458951fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3af160-3993-4b49-b4ec-065e458951fd.jpg?1",
             "name": "Vermin Gorger",
             "text": "{T}, Sacrifice another creature: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -16110,7 +16110,7 @@
         },
         {
             "id": "8bd2c774-fc7e-5661-b6c5-2013de86bcd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a27914-5e4f-48d4-ba2a-9d3187a39606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a27914-5e4f-48d4-ba2a-9d3187a39606.jpg?1",
             "name": "Village Rites",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -16141,7 +16141,7 @@
         },
         {
             "id": "fd61018d-b6ca-5ba9-8eb3-bd9bc3c5b14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c61e0ef-4dc7-4acc-a4a1-e63c35a854ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c61e0ef-4dc7-4acc-a4a1-e63c35a854ba.jpg?1",
             "name": "Vito, Thorn of the Dusk Rose",
             "text": "Whenever you gain life, target opponent loses that much life.\n{3}{B}{B}: Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -16177,7 +16177,7 @@
         },
         {
             "id": "bb9ec9b7-56d6-500e-99e8-e7e80d9e5010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155d1aa-929d-46eb-ab9d-02a40d6e9782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155d1aa-929d-46eb-ab9d-02a40d6e9782.jpg?1",
             "name": "Wailing Ghoul",
             "text": "When Wailing Ghoul enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -16210,7 +16210,7 @@
         },
         {
             "id": "20948163-b5a7-5042-b1a5-19f69faf5803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c6b02-64c6-486d-b38b-be0f7327e9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c6b02-64c6-486d-b38b-be0f7327e9c6.jpg?1",
             "name": "Wicked Guardian",
             "text": "When Wicked Guardian enters the battlefield, you may have it deal 2 damage to another creature you control. If you do, draw a card.",
             "colours": [
@@ -16244,7 +16244,7 @@
         },
         {
             "id": "e6e5f988-bc80-5e8b-9891-2338f0a71849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d11924-23c5-485e-9c56-9efcaf6cd9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d11924-23c5-485e-9c56-9efcaf6cd9d2.jpg?1",
             "name": "Witch's Cauldron",
             "text": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -16275,7 +16275,7 @@
         },
         {
             "id": "2c960118-8bd9-56bd-bbff-ccb33efac11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a4a591-92e0-4318-a71c-376fbfe2b14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a4a591-92e0-4318-a71c-376fbfe2b14f.jpg?1",
             "name": "Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -16311,7 +16311,7 @@
         },
         {
             "id": "776eac93-ac4d-5be9-a622-a39f8c38ba25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4fd9dc-5cf9-4f10-836a-8b7aaf8aca29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4fd9dc-5cf9-4f10-836a-8b7aaf8aca29.jpg?1",
             "name": "Act on Impulse",
             "text": "Exile the top three cards of your library. Until end of turn, you may play those cards. (If you cast a spell this way, you still pay its costs. You can play a land this way only if you have an available land play remaining.)",
             "colours": [
@@ -16342,7 +16342,7 @@
         },
         {
             "id": "06c6b0ea-067b-59de-8b27-d38515672948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa460a11-afd1-4997-89ac-6a64af63db55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa460a11-afd1-4997-89ac-6a64af63db55.jpg?1",
             "name": "Arms Dealer",
             "text": "{1}{R}, Sacrifice a Goblin: Arms Dealer deals 4 damage to target creature.",
             "colours": [
@@ -16376,7 +16376,7 @@
         },
         {
             "id": "6d6fa705-cc97-596c-8b91-dc1809f8d4fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e16bc35-5237-4a13-9179-aaa0347ceffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e16bc35-5237-4a13-9179-aaa0347ceffe.jpg?1",
             "name": "Axgard Cavalry",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -16410,7 +16410,7 @@
         },
         {
             "id": "60f477ce-ed09-5667-ba9f-6ea2f2439b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7688ad33-62b2-46ab-b15b-2e20c28710de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7688ad33-62b2-46ab-b15b-2e20c28710de.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to any target.\nIf X is 5 or more, this spell can't be countered and the damage can't be prevented.",
             "colours": [
@@ -16441,7 +16441,7 @@
         },
         {
             "id": "7e347fe3-c7bc-528e-882c-a6c94795d939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a335cb-e437-4957-9675-6eaa0316abd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a335cb-e437-4957-9675-6eaa0316abd2.jpg?1",
             "name": "Barrage Ogre",
             "text": "{T}, Sacrifice an artifact: Barrage Ogre deals 2 damage to any target.",
             "colours": [
@@ -16475,7 +16475,7 @@
         },
         {
             "id": "89d089cb-e489-5ae0-8244-8211e5533b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca05c60-edef-4107-bd86-31b7d4a38398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca05c60-edef-4107-bd86-31b7d4a38398.jpg?1",
             "name": "Battle Squadron",
             "text": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -16508,7 +16508,7 @@
         },
         {
             "id": "a1ebd60c-d23a-5c93-991e-253bcf40a484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb7413-af44-4038-a56c-8cc3ca645a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb7413-af44-4038-a56c-8cc3ca645a58.jpg?1",
             "name": "Big Score",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -16539,7 +16539,7 @@
         },
         {
             "id": "5d1c8a51-41b5-554f-9f8e-d9ef3b5293d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e27dd9-5b6a-4dab-9ee6-ad083b5c0911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e27dd9-5b6a-4dab-9ee6-ad083b5c0911.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any target.",
             "colours": [
@@ -16570,7 +16570,7 @@
         },
         {
             "id": "9500abac-ccd8-596a-be8c-2875b54ffeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fed3bc-6ce1-409c-9eac-ce6fd12d9ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fed3bc-6ce1-409c-9eac-ce6fd12d9ea8.jpg?1",
             "name": "Blisterspit Gremlin",
             "text": "{1}, {T}: Blisterspit Gremlin deals 1 damage to each opponent.\nWhenever you cast a noncreature spell, untap Blisterspit Gremlin.",
             "colours": [
@@ -16603,7 +16603,7 @@
         },
         {
             "id": "8894c2a0-403f-5aaa-82cf-b808e7770338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fa2529-e00e-457b-928f-b1c378f31cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fa2529-e00e-457b-928f-b1c378f31cb5.jpg?1",
             "name": "Blood Aspirant",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Blood Aspirant.\n{1}{R}, {T}, Sacrifice a creature or enchantment: Blood Aspirant deals 1 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -16637,7 +16637,7 @@
         },
         {
             "id": "61b0da9b-362a-517c-a4b1-d18d074bbd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dfd4f1-abe4-4300-aa16-54a515f0c1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dfd4f1-abe4-4300-aa16-54a515f0c1e3.jpg?1",
             "name": "Bloodhaze Wolverine",
             "text": "Whenever you draw your second card each turn, Bloodhaze Wolverine gets +1/+1 and gains first strike until end of turn.",
             "colours": [
@@ -16670,7 +16670,7 @@
         },
         {
             "id": "36af5937-a550-597e-8ba0-88861d78edfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c174e1f1-d7ed-4784-bf22-791102855022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c174e1f1-d7ed-4784-bf22-791102855022.jpg?1",
             "name": "Bogardan Dragonheart",
             "text": "Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.",
             "colours": [
@@ -16704,7 +16704,7 @@
         },
         {
             "id": "72f41c70-b481-5cf9-949e-9b78d0c3e6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df5b536-6098-4352-8172-ec11d656d4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df5b536-6098-4352-8172-ec11d656d4a9.jpg?1",
             "name": "Bolt Hound",
             "text": "Haste\nWhenever Bolt Hound attacks, other creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -16738,7 +16738,7 @@
         },
         {
             "id": "b706f793-c086-5b8a-88a8-eff100da3012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eef6f1-318b-4f0b-b269-94b09a039c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eef6f1-318b-4f0b-b269-94b09a039c97.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -16772,7 +16772,7 @@
         },
         {
             "id": "34d32f09-4fbc-5f7b-b1d9-3c8460c173e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a1e6e9-5e5f-4431-9732-fd313df843df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a1e6e9-5e5f-4431-9732-fd313df843df.jpg?1",
             "name": "Brazen Freebooter",
             "text": "When Brazen Freebooter enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -16806,7 +16806,7 @@
         },
         {
             "id": "a8c2c6d0-ae06-5ab9-8c9d-fbc59df51894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f94348-6c9a-4d0e-975c-618b4a540ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f94348-6c9a-4d0e-975c-618b4a540ad4.jpg?1",
             "name": "Brazen Wolves",
             "text": "Whenever Brazen Wolves attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -16839,7 +16839,7 @@
         },
         {
             "id": "25883dc2-a9a2-5b4d-b41c-c342665ceebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8836ea09-9136-4f97-9b38-1aeb9c155d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8836ea09-9136-4f97-9b38-1aeb9c155d03.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -16870,7 +16870,7 @@
         },
         {
             "id": "047f1861-67eb-590f-b630-504a3c878333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d910f-f378-4b55-9587-2101faefe0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d910f-f378-4b55-9587-2101faefe0fa.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "Haste\nWhenever Captain Lannery Storm attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever you sacrifice a Treasure, Captain Lannery Storm gets +1/+0 until end of turn.",
             "colours": [
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "64013b40-e3cc-57eb-87ea-fda08171ae0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9b5c4-0911-4d0a-92bf-2d0107329671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9b5c4-0911-4d0a-92bf-2d0107329671.jpg?1",
             "name": "Catalyst Elemental",
             "text": "Sacrifice Catalyst Elemental: Add {R}{R}.",
             "colours": [
@@ -16939,7 +16939,7 @@
         },
         {
             "id": "f5b5ed43-791d-58eb-ad31-d9a369d39f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6872aa6f-2a81-4ea6-acd7-f7457e245533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6872aa6f-2a81-4ea6-acd7-f7457e245533.jpg?1",
             "name": "Chandra, Flame's Fury",
             "text": "+1: Chandra, Flame's Fury deals 2 damage to any target.\n\u22122: Chandra, Flame's Fury deals 4 damage to target creature and 2 damage to that creature's controller.\n\u22128: Chandra, Flame's Fury deals 10 damage to target player and each creature that player controls.",
             "colours": [
@@ -16974,7 +16974,7 @@
         },
         {
             "id": "debaf74d-0018-5b51-bdbc-5e0852a31e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6eb9-dd25-4a1d-ae0a-ad5d235073c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6eb9-dd25-4a1d-ae0a-ad5d235073c3.jpg?1",
             "name": "Chandra's Magmutt",
             "text": "{T}: Chandra's Magmutt deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -17008,7 +17008,7 @@
         },
         {
             "id": "1af80db7-b113-5917-ac4c-17ff9a8bc950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64106412-36ad-46f1-a7df-7dbff296473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64106412-36ad-46f1-a7df-7dbff296473e.jpg?1",
             "name": "Chandra's Pyreling",
             "text": "Whenever a source you control deals noncombat damage to an opponent, Chandra's Pyreling gets +1/+0 and gains double strike until end of turn.",
             "colours": [
@@ -17042,7 +17042,7 @@
         },
         {
             "id": "204b7a7c-d158-5dfb-ba32-21e2370533d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc6a24c-2927-4aed-94c1-9cab2c95682e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc6a24c-2927-4aed-94c1-9cab2c95682e.jpg?1",
             "name": "Chandra's Pyrohelix",
             "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -17073,7 +17073,7 @@
         },
         {
             "id": "b0c59241-d9bb-5d9e-a612-dac73f307db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e823359-865d-4ef4-8e55-e170527b1b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e823359-865d-4ef4-8e55-e170527b1b42.jpg?1",
             "name": "Chandra's Spitfire",
             "text": "Flying\nWhenever an opponent is dealt noncombat damage, Chandra's Spitfire gets +3/+0 until end of turn.",
             "colours": [
@@ -17106,7 +17106,7 @@
         },
         {
             "id": "65f47537-406a-5166-a1de-d4c60d26496c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b5e55b-e888-4bd5-a6a9-d253f6e406a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b5e55b-e888-4bd5-a6a9-d253f6e406a6.jpg?1",
             "name": "Coalhauler Swine",
             "text": "Whenever Coalhauler Swine is dealt damage, it deals that much damage to each player.",
             "colours": [
@@ -17140,7 +17140,7 @@
         },
         {
             "id": "98cb8edd-ddff-5d45-b63d-dda88d8820e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89872245-6be7-4d28-8b0a-d8df42e2f150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89872245-6be7-4d28-8b0a-d8df42e2f150.jpg?1",
             "name": "Cone of Flame",
             "text": "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target.",
             "colours": [
@@ -17171,7 +17171,7 @@
         },
         {
             "id": "12a35473-0c6f-5355-becb-e8b70fa54c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427e31b2-2c53-46c8-af51-16a1ad6c66fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427e31b2-2c53-46c8-af51-16a1ad6c66fd.jpg?1",
             "name": "Cyclops Electromancer",
             "text": "When Cyclops Electromancer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -17205,7 +17205,7 @@
         },
         {
             "id": "567fc9d3-d5c9-5040-b345-dec70db0b240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f0b72-fc78-415c-9999-4ce362ed037d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f0b72-fc78-415c-9999-4ce362ed037d.jpg?1",
             "name": "Dance with Devils",
             "text": "Create two 1/1 red Devil creature tokens. They have \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -17236,7 +17236,7 @@
         },
         {
             "id": "64619845-bcdc-5e7a-9130-ea215e6493b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955e94dd-f3f1-4f5a-8940-54190d5f2f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955e94dd-f3f1-4f5a-8940-54190d5f2f77.jpg?1",
             "name": "Deem Worthy",
             "text": "Deem Worthy deals 7 damage to target creature.\nCycling {3}{R} ({3}{R}, Discard this card: Draw a card.)\nWhen you cycle Deem Worthy, you may have it deal 2 damage to target creature.",
             "colours": [
@@ -17267,7 +17267,7 @@
         },
         {
             "id": "7503627e-26a0-53c9-b559-b8ef6610c1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1c3c1-3afc-48be-83e4-05df11d3e7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1c3c1-3afc-48be-83e4-05df11d3e7da.jpg?1",
             "name": "Destructive Tampering",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Creatures without flying can't block this turn.",
             "colours": [
@@ -17298,7 +17298,7 @@
         },
         {
             "id": "b0d9fda1-0c56-5587-ad00-97bcd43ada62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d31ba0-6cec-4d8b-950f-f0b70bb8b0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d31ba0-6cec-4d8b-950f-f0b70bb8b0dd.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -17332,7 +17332,7 @@
         },
         {
             "id": "a218dab8-4f7e-5ab1-9384-e57842a429a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27238e0e-c676-44f5-841c-6e4a3a3f6374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27238e0e-c676-44f5-841c-6e4a3a3f6374.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -17365,7 +17365,7 @@
         },
         {
             "id": "22650984-4f37-5a05-8be0-a15b1121d753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac2c18-a26b-4683-b326-97f0e75b4f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac2c18-a26b-4683-b326-97f0e75b4f2a.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -17399,7 +17399,7 @@
         },
         {
             "id": "aaa6f387-d6b8-541a-997b-e2e0819e5487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7098bac-9e43-41e7-a891-780fe4232940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7098bac-9e43-41e7-a891-780fe4232940.jpg?1",
             "name": "Dragonspeaker Shaman",
             "text": "Dragon spells you cast cost {2} less to cast.",
             "colours": [
@@ -17434,7 +17434,7 @@
         },
         {
             "id": "fec0da09-e832-5d1d-8070-f40e85308ec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e628-3a8f-44ea-aec2-60c8fbd1baae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e628-3a8f-44ea-aec2-60c8fbd1baae.jpg?1",
             "name": "Electric Revelation",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -17465,7 +17465,7 @@
         },
         {
             "id": "947a215f-8cb2-5555-a7f5-cdcb4f14631d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0538bd14-fc75-4e1b-8183-8e852b78fa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0538bd14-fc75-4e1b-8183-8e852b78fa9d.jpg?1",
             "name": "Electrify",
             "text": "Electrify deals 4 damage to target creature.",
             "colours": [
@@ -17496,7 +17496,7 @@
         },
         {
             "id": "8a7e472d-0d9a-5de3-8444-e81c0ede5b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d927-c8ed-4bb3-abfe-ae4f12571377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d927-c8ed-4bb3-abfe-ae4f12571377.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to any target.",
             "colours": [
@@ -17530,7 +17530,7 @@
         },
         {
             "id": "b90e49dc-0256-5c02-ac5e-f4271290a407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9555482-f0b8-4b1d-8557-4138e9d20126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9555482-f0b8-4b1d-8557-4138e9d20126.jpg?1",
             "name": "Fervent Strike",
             "text": "Target creature gets +1/+0 and gains first strike and haste until end of turn.",
             "colours": [
@@ -17561,7 +17561,7 @@
         },
         {
             "id": "8b012952-355d-56dc-b6ae-93bafd4c44d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aef50c-2d73-49a9-8458-0d7c2dc3e658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aef50c-2d73-49a9-8458-0d7c2dc3e658.jpg?1",
             "name": "Fiery Conclusion",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFiery Conclusion deals 5 damage to target creature.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "9e5473ad-bd6f-5040-8f7b-f9f8cd8fffdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85cfa83-27bd-4bd5-92e3-65aab37e2ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85cfa83-27bd-4bd5-92e3-65aab37e2ae6.jpg?1",
             "name": "Fiery Intervention",
             "text": "Choose one \u2014\n\u2022 Fiery Intervention deals 5 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -17623,7 +17623,7 @@
         },
         {
             "id": "2ebed4d2-fa2e-5d8b-b838-b5612631539d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bbf30c-795c-4580-a0e6-5e2665e6b6fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bbf30c-795c-4580-a0e6-5e2665e6b6fc.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to any target.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -17654,7 +17654,7 @@
         },
         {
             "id": "eca7388e-156a-5827-8df7-e0c17f5950ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd242c8-c146-4d5a-86f8-6009ed29fe5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd242c8-c146-4d5a-86f8-6009ed29fe5a.jpg?1",
             "name": "Firecannon Blast",
             "text": "Firecannon Blast deals 3 damage to target creature.\nRaid \u2014 Firecannon Blast deals 6 damage instead if you attacked this turn.",
             "colours": [
@@ -17685,7 +17685,7 @@
         },
         {
             "id": "1d919981-67fc-5ce9-98e7-c20c4338afb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a0053-f9a3-43f4-a317-07eb801dbb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a0053-f9a3-43f4-a317-07eb801dbb9b.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to any target.",
             "colours": [
@@ -17716,7 +17716,7 @@
         },
         {
             "id": "767d1e38-3f50-5960-a059-449b2ac49fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19866e42-5248-42c5-a2a1-13fe0d646068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19866e42-5248-42c5-a2a1-13fe0d646068.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -17747,7 +17747,7 @@
         },
         {
             "id": "ed511d77-1303-5ae4-993c-de6a78b2bfba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e68ddf0-5cf6-4024-ab71-827f28a0b0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e68ddf0-5cf6-4024-ab71-827f28a0b0ee.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -17781,7 +17781,7 @@
         },
         {
             "id": "d5f7aa84-e1c5-5f8c-953a-fb4f4b78ffb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ba3f5-3ad5-47e7-86c9-31954f015b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ba3f5-3ad5-47e7-86c9-31954f015b91.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -17814,7 +17814,7 @@
         },
         {
             "id": "4bc14e68-b23d-55ef-ae1b-0abda3d675c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb13721-e6f7-439c-8993-a896de5d6892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb13721-e6f7-439c-8993-a896de5d6892.jpg?1",
             "name": "Gadrak, the Crown-Scourge",
             "text": "Flying\nGadrak, the Crown-Scourge can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -17849,7 +17849,7 @@
         },
         {
             "id": "2a5e4ba3-ccec-521a-8bfa-9cc678aa832c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884ffe1-4f4c-40a4-88c2-d34a19d80dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884ffe1-4f4c-40a4-88c2-d34a19d80dd9.jpg?1",
             "name": "Glint-Horn Buccaneer",
             "text": "Haste\nWhenever you discard a card, Glint-Horn Buccaneer deals 1 damage to each opponent.\n{1}{R}, Discard a card: Draw a card. Activate only if Glint-Horn Buccaneer is attacking.",
             "colours": [
@@ -17883,7 +17883,7 @@
         },
         {
             "id": "f873c2a5-8fb9-5559-b84b-02d3147d5a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40185b55-7693-429f-8d0a-2853d6beda90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40185b55-7693-429f-8d0a-2853d6beda90.jpg?1",
             "name": "Go for Blood",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -17914,7 +17914,7 @@
         },
         {
             "id": "dba570f7-2356-5629-bd52-7bd3914dfd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee809c0-eb2c-4576-a077-e030d4402045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee809c0-eb2c-4576-a077-e030d4402045.jpg?1",
             "name": "Goblin Artillery",
             "text": "{T}: Goblin Artillery deals 2 damage to any target and 3 damage to you.",
             "colours": [
@@ -17948,7 +17948,7 @@
         },
         {
             "id": "455f3d8a-8299-51c8-9f1e-bc4d327a5927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dacb5a-68d7-4eb0-b3ba-b1b96a100d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dacb5a-68d7-4eb0-b3ba-b1b96a100d3c.jpg?1",
             "name": "Goblin Grenade",
             "text": "As an additional cost to cast this spell, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to any target.",
             "colours": [
@@ -17979,7 +17979,7 @@
         },
         {
             "id": "3ee524c3-7535-5d5a-8015-ecbd4a468388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e00348c-bfa7-4254-9a13-8f7e3d38f6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e00348c-bfa7-4254-9a13-8f7e3d38f6f0.jpg?1",
             "name": "Goblin Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -18010,7 +18010,7 @@
         },
         {
             "id": "16a48e2c-1b1f-524d-8e06-deb99c366da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879b406-c382-47e6-af33-439a164438ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879b406-c382-47e6-af33-439a164438ae.jpg?1",
             "name": "Goblin Psychopath",
             "text": "Whenever Goblin Psychopath attacks or blocks, flip a coin. If you lose the flip, the next time it would deal combat damage this turn, it deals that damage to you instead.",
             "colours": [
@@ -18044,7 +18044,7 @@
         },
         {
             "id": "1423814d-ed3c-580b-b94e-152bd4cbd3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecbe76-5118-4844-9a20-b227c924189d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecbe76-5118-4844-9a20-b227c924189d.jpg?1",
             "name": "Goblin Rabblemaster",
             "text": "Other Goblin creatures you control attack each combat if able.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token with haste.\nWhenever Goblin Rabblemaster attacks, it gets +1/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -18078,7 +18078,7 @@
         },
         {
             "id": "95de004a-4276-5a69-8abf-74bcab992044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b0a697-e901-42d9-9833-fedfcb6db9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b0a697-e901-42d9-9833-fedfcb6db9b3.jpg?1",
             "name": "Goblin Rally",
             "text": "Create four 1/1 red Goblin creature tokens.",
             "colours": [
@@ -18109,7 +18109,7 @@
         },
         {
             "id": "5d4210c1-e7e3-5f9f-83fd-95ea5ea431a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b16412-3e91-415a-9444-3ca4d30bd8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b16412-3e91-415a-9444-3ca4d30bd8d6.jpg?1",
             "name": "Goblin Trailblazer",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -18143,7 +18143,7 @@
         },
         {
             "id": "64c76398-f0e8-51b2-b859-0d89e6df354c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8567a329-9e3a-4c3d-b74d-2a2d2d4c8c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8567a329-9e3a-4c3d-b74d-2a2d2d4c8c41.jpg?1",
             "name": "Goblin Warchief",
             "text": "Goblin spells you cast cost {1} less to cast.\nGoblins you control have haste.",
             "colours": [
@@ -18177,7 +18177,7 @@
         },
         {
             "id": "a0e8bf44-72d9-579b-bf56-c9bc16c096c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed08f2-b251-43ea-818a-7ad833151284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed08f2-b251-43ea-818a-7ad833151284.jpg?1",
             "name": "Goldhound",
             "text": "First strike\nMenace (This creature can't be blocked except by two or more creatures.)\n{T}, Sacrifice Goldhound: Add one mana of any color.",
             "colours": [
@@ -18212,7 +18212,7 @@
         },
         {
             "id": "de018edd-f0be-524b-8021-9d93211a172a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c67a683-4e1d-4a64-952d-a1c27a34ed1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c67a683-4e1d-4a64-952d-a1c27a34ed1d.jpg?1",
             "name": "Goldspan Dragon",
             "text": "Flying, haste\nWhenever Goldspan Dragon attacks or becomes the target of a spell, create a Treasure token.\nTreasures you control have \"{T}, Sacrifice this artifact: Add two mana of any one color.\"",
             "colours": [
@@ -18245,7 +18245,7 @@
         },
         {
             "id": "f81c7037-f430-5a57-96ce-08a66dba5be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c690b-5d10-4fbc-9ca1-12627bf070f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c690b-5d10-4fbc-9ca1-12627bf070f3.jpg?1",
             "name": "Grotag Night-Runner",
             "text": "Whenever Grotag Night-Runner deals combat damage to a player, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -18279,7 +18279,7 @@
         },
         {
             "id": "d27f9e9c-3ca5-5e54-b2e0-4df291cf4ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b98d04-937e-47ee-8f97-775c77e33de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b98d04-937e-47ee-8f97-775c77e33de9.jpg?1",
             "name": "Hordeling Outburst",
             "text": "Create three 1/1 red Goblin creature tokens.",
             "colours": [
@@ -18310,7 +18310,7 @@
         },
         {
             "id": "40b88d72-a254-5271-9fc4-1108ccb55269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e7ec98-fd08-479b-ace6-10c7c700ab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e7ec98-fd08-479b-ace6-10c7c700ab51.jpg?1",
             "name": "Hungry Flames",
             "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player or planeswalker.",
             "colours": [
@@ -18341,7 +18341,7 @@
         },
         {
             "id": "740a611d-b585-516b-bae1-fcbe481c6c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09f9597-c2a9-4c1a-8375-ab06b1a21ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09f9597-c2a9-4c1a-8375-ab06b1a21ee3.jpg?1",
             "name": "Ib Halfheart, Goblin Tactician",
             "text": "Whenever another Goblin you control becomes blocked, sacrifice it. If you do, it deals 4 damage to each creature blocking it.\nSacrifice two Mountains: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -18377,7 +18377,7 @@
         },
         {
             "id": "b2bac41a-babc-5a22-b8de-133ee724cdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272a9a89-6318-487a-b6f6-cc4ccd744f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272a9a89-6318-487a-b6f6-cc4ccd744f54.jpg?1",
             "name": "Ignite the Future",
             "text": "Exile the top three cards of your library. Until the end of your next turn, you may play those cards. If this spell was cast from a graveyard, you may play cards this way without paying their mana costs.\nFlashback {7}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -18408,7 +18408,7 @@
         },
         {
             "id": "5bc156b1-24ef-5fcf-a0e7-be6e293ed5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11fd96f-9adb-4227-b1cb-4300c0621789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11fd96f-9adb-4227-b1cb-4300c0621789.jpg?1",
             "name": "Immersturm Raider",
             "text": "When Immersturm Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -18442,7 +18442,7 @@
         },
         {
             "id": "a204fad0-bca0-543a-b64b-b8904bcb123b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b813e554-12ea-4675-bc90-f161f80de50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b813e554-12ea-4675-bc90-f161f80de50e.jpg?1",
             "name": "Impending Doom",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and attacks each combat if able.\nWhen enchanted creature dies, Impending Doom deals 3 damage to that creature's controller.",
             "colours": [
@@ -18475,7 +18475,7 @@
         },
         {
             "id": "b1d915e8-0bab-53a4-9309-e325ea0659ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828a5005-0b19-49a2-bc9a-5b32c719c74c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828a5005-0b19-49a2-bc9a-5b32c719c74c.jpg?1",
             "name": "Improvised Weaponry",
             "text": "Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -18506,7 +18506,7 @@
         },
         {
             "id": "11d1e47e-70fb-52d8-a6be-be5223c3a594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a950b05-fcdf-4d3e-b038-76dc31a9dff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a950b05-fcdf-4d3e-b038-76dc31a9dff2.jpg?1",
             "name": "Irencrag Pyromancer",
             "text": "Whenever you draw your second card each turn, Irencrag Pyromancer deals 3 damage to any target.",
             "colours": [
@@ -18540,7 +18540,7 @@
         },
         {
             "id": "5581f555-c2e7-59ae-92b5-9226f2bcf566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5690c-7c11-4b04-9a50-9d3dc6aa8d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5690c-7c11-4b04-9a50-9d3dc6aa8d49.jpg?1",
             "name": "Irreverent Revelers",
             "text": "When Irreverent Revelers enters the battlefield, choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Irreverent Revelers gains haste until end of turn.",
             "colours": [
@@ -18573,7 +18573,7 @@
         },
         {
             "id": "aa77f530-25a4-5a1a-a9f8-7cb1f36d10d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069b3c69-ee4c-4fc9-981e-62db77f9821d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069b3c69-ee4c-4fc9-981e-62db77f9821d.jpg?1",
             "name": "Kargan Dragonrider",
             "text": "As long as you control a Dragon, Kargan Dragonrider has flying.",
             "colours": [
@@ -18607,7 +18607,7 @@
         },
         {
             "id": "41bbe598-6940-58e3-8564-0fd0ade69166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9638a43f-6b61-4455-8e0f-4142652c4b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9638a43f-6b61-4455-8e0f-4142652c4b54.jpg?1",
             "name": "Kari Zev, Skyship Raider",
             "text": "First strike, menace\nWhenever Kari Zev, Skyship Raider attacks, create Ragavan, a legendary 2/1 red Monkey creature token. Ragavan enters the battlefield tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -18643,7 +18643,7 @@
         },
         {
             "id": "4116b342-579d-5a95-a0e4-367e2b72b6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524677a-d27c-41e1-9122-f471980a1fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524677a-d27c-41e1-9122-f471980a1fff.jpg?1",
             "name": "Keldon Raider",
             "text": "When Keldon Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -18677,7 +18677,7 @@
         },
         {
             "id": "f8de2b57-afd2-5434-bab7-bc96fb291d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9c68ff-1fe4-42ef-8d1f-43120de5c1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9c68ff-1fe4-42ef-8d1f-43120de5c1ff.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -18713,7 +18713,7 @@
         },
         {
             "id": "97bf04b6-9026-56ee-bb43-ac664580dabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d7412-d779-4154-a1f7-747ed1356c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d7412-d779-4154-a1f7-747ed1356c1a.jpg?1",
             "name": "Kuldotha Flamefiend",
             "text": "When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.",
             "colours": [
@@ -18746,7 +18746,7 @@
         },
         {
             "id": "7bd23f0c-66f5-5009-90ca-f51a4c85a880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8435c03c-b9a2-40fa-a979-879bd120a011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8435c03c-b9a2-40fa-a979-879bd120a011.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon enters the battlefield under your control, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -18781,7 +18781,7 @@
         },
         {
             "id": "48d29c47-674b-5028-9045-75e1df781669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772df6a2-315b-4516-93e1-623a90b802c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772df6a2-315b-4516-93e1-623a90b802c7.jpg?1",
             "name": "Lava Serpent",
             "text": "Haste\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -18815,7 +18815,7 @@
         },
         {
             "id": "8ad5a5e3-35c0-5a38-856c-c45fea662943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a6b01-1a0e-46bb-8576-80eaf2490f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a6b01-1a0e-46bb-8576-80eaf2490f21.jpg?1",
             "name": "Lavastep Raider",
             "text": "{2}{R}: Lavastep Raider gets +2/+0 until end of turn.",
             "colours": [
@@ -18849,7 +18849,7 @@
         },
         {
             "id": "045edd04-1e7c-5dd7-8e13-efede82dbe42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e43b0f-118c-4abe-a1f2-f3bacbba57c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e43b0f-118c-4abe-a1f2-f3bacbba57c8.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -18880,7 +18880,7 @@
         },
         {
             "id": "adaac217-f437-5d8c-a696-a6541d9de869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b15eb3-ad86-48cd-b414-b8a06f61635d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b15eb3-ad86-48cd-b414-b8a06f61635d.jpg?1",
             "name": "Mad Ratter",
             "text": "Whenever you draw your second card each turn, create two 1/1 black Rat creature tokens.",
             "colours": [
@@ -18913,7 +18913,7 @@
         },
         {
             "id": "6004db22-840c-5193-b71f-ee40f13a21f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd4da60-5ae2-458e-a4dd-fbba0cfe497b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd4da60-5ae2-458e-a4dd-fbba0cfe497b.jpg?1",
             "name": "Magmatic Channeler",
             "text": "As long as there are four or more instant and/or sorcery cards in your graveyard, Magmatic Channeler gets +3/+1.\n{T}, Discard a card: Exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -18947,7 +18947,7 @@
         },
         {
             "id": "6ee20ce2-bf38-55f7-a71d-1e87072ffa30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee5683-0131-47ca-b9e4-5ef94e367b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee5683-0131-47ca-b9e4-5ef94e367b26.jpg?1",
             "name": "Mardu Heart-Piercer",
             "text": "Raid \u2014 When Mardu Heart-Piercer enters the battlefield, if you attacked this turn, Mardu Heart-Piercer deals 2 damage to any target.",
             "colours": [
@@ -18981,7 +18981,7 @@
         },
         {
             "id": "9d7f91a4-fb78-585f-b3e2-b9af8a3d7237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3659dccd-7b20-4807-9cd9-fa869c75f260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3659dccd-7b20-4807-9cd9-fa869c75f260.jpg?1",
             "name": "Markov Warlord",
             "text": "Haste\nWhen Markov Warlord enters the battlefield, up to two target creatures can't block this turn.",
             "colours": [
@@ -19015,7 +19015,7 @@
         },
         {
             "id": "81a39997-ad84-57c7-b0a4-3302c973941e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696b42b-02c7-4389-bc37-15fa1fa4f01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696b42b-02c7-4389-bc37-15fa1fa4f01b.jpg?1",
             "name": "Mudbutton Torchrunner",
             "text": "When Mudbutton Torchrunner dies, it deals 3 damage to any target.",
             "colours": [
@@ -19049,7 +19049,7 @@
         },
         {
             "id": "c35b1245-fbef-544a-baff-43cc46d48ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de974053-a1b2-4ee6-96be-3b5e9f9b290a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de974053-a1b2-4ee6-96be-3b5e9f9b290a.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "When Muxus, Goblin Grandee enters the battlefield, reveal the top six cards of your library. Put all Goblin creature cards with mana value 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.\nWhenever Muxus attacks, it gets +1/+1 until end of turn for each other Goblin you control.",
             "colours": [
@@ -19085,7 +19085,7 @@
         },
         {
             "id": "e895a570-738e-529f-8e2c-eace9aeb307d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3135dfde-ad52-4b93-9356-107d0efad93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3135dfde-ad52-4b93-9356-107d0efad93c.jpg?1",
             "name": "Nest Robber",
             "text": "Haste",
             "colours": [
@@ -19118,7 +19118,7 @@
         },
         {
             "id": "78ff763f-8cd7-5365-9241-d23cd46fec4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0265b7d1-5646-4974-ae6a-34b1fa2281b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0265b7d1-5646-4974-ae6a-34b1fa2281b4.jpg?1",
             "name": "Ordeal of Purphoros",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Purphoros.\nWhen you sacrifice Ordeal of Purphoros, it deals 3 damage to any target.",
             "colours": [
@@ -19151,7 +19151,7 @@
         },
         {
             "id": "b24ca34f-2f4e-5b38-971e-ae87f1e25a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf73acce-3159-458b-a0d3-28a02959b7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf73acce-3159-458b-a0d3-28a02959b7f5.jpg?1",
             "name": "Outnumber",
             "text": "Outnumber deals damage to target creature equal to the number of creatures you control.",
             "colours": [
@@ -19182,7 +19182,7 @@
         },
         {
             "id": "298ac924-d32e-5a17-a4d7-20f17d738fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cdfbb2-8c85-4302-9114-de25f59af10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cdfbb2-8c85-4302-9114-de25f59af10e.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -19213,7 +19213,7 @@
         },
         {
             "id": "8e890979-8088-5f0d-a6b1-0962ef097f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb0f9f2-4434-40aa-a683-481ec1f3aadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb0f9f2-4434-40aa-a683-481ec1f3aadd.jpg?1",
             "name": "Prickly Marmoset",
             "text": "First strike\nWhenever you cycle a card, Prickly Marmoset gets +2/+0 until end of turn.",
             "colours": [
@@ -19246,7 +19246,7 @@
         },
         {
             "id": "b4e27e35-13c1-514a-959b-6bca01537995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2561e6-c5b6-4c88-896e-67b33b8cf6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2561e6-c5b6-4c88-896e-67b33b8cf6bc.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "Menace\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nSacrifice a Treasure: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -19280,7 +19280,7 @@
         },
         {
             "id": "e947ad58-abc9-5976-abae-8e151822e5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7413f4db-d560-4c26-902d-27282b202339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7413f4db-d560-4c26-902d-27282b202339.jpg?1",
             "name": "Pyre-Sledge Arsonist",
             "text": "{1}, {T}: Pyre-Sledge Arsonist deals X damage to any target, where X is the number of permanents you've sacrificed this turn.",
             "colours": [
@@ -19314,7 +19314,7 @@
         },
         {
             "id": "fb4786bc-ff61-5166-b871-b6e3ba6da3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23538c0-ef71-4bbe-b500-7d61aa8b269b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23538c0-ef71-4bbe-b500-7d61aa8b269b.jpg?1",
             "name": "Quakefoot Cyclops",
             "text": "When Quakefoot Cyclops enters the battlefield, up to two target creatures can't block this turn.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Quakefoot Cyclops, target creature can't block this turn.",
             "colours": [
@@ -19347,7 +19347,7 @@
         },
         {
             "id": "47774546-20ab-5640-ae16-ca95dca7a419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018be5c-0357-47cc-ac8c-2929f90c4097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018be5c-0357-47cc-ac8c-2929f90c4097.jpg?1",
             "name": "Raking Claws",
             "text": "Target creature gains double strike until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -19378,7 +19378,7 @@
         },
         {
             "id": "e4b6f56b-8ba5-563f-b31c-9f9e710c8e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f781d608-6bc6-4ab8-beb1-b8e73643d01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f781d608-6bc6-4ab8-beb1-b8e73643d01b.jpg?1",
             "name": "Ravenous Giant",
             "text": "At the beginning of your upkeep, Ravenous Giant deals 1 damage to you.",
             "colours": [
@@ -19411,7 +19411,7 @@
         },
         {
             "id": "84123be4-4f53-5fe6-b923-df3db8617316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4277a7f-13c3-4e7b-a489-3116ae9d21bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4277a7f-13c3-4e7b-a489-3116ae9d21bc.jpg?1",
             "name": "Raze the Effigy",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target attacking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -19442,7 +19442,7 @@
         },
         {
             "id": "7e3616a4-5c33-5d57-8101-88d243137efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7dbe7ba-d4a0-42b7-ba8c-ade413333622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7dbe7ba-d4a0-42b7-ba8c-ade413333622.jpg?1",
             "name": "Reckless Fireweaver",
             "text": "Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent.",
             "colours": [
@@ -19476,7 +19476,7 @@
         },
         {
             "id": "e00bb97f-0059-5956-9070-2656e5100b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33386da8-48cf-47df-9b17-3ffc4c3f7af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33386da8-48cf-47df-9b17-3ffc4c3f7af9.jpg?1",
             "name": "Reptilian Reflection",
             "text": "Whenever you cycle a card, you may have Reptilian Reflection become a 5/4 Dinosaur creature with trample and haste in addition to its other types until end of turn.",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "a476f172-0b6d-52a6-8772-f9c13e7e20c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bf7caa-cf00-4b94-8cc8-40b31c7cb3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bf7caa-cf00-4b94-8cc8-40b31c7cb3a5.jpg?1",
             "name": "Ripscale Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -19540,7 +19540,7 @@
         },
         {
             "id": "77bdf4b6-216c-5b46-99b3-73753e66fff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ec71-33c0-4a86-8110-30977e574341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ec71-33c0-4a86-8110-30977e574341.jpg?1",
             "name": "Rooting Moloch",
             "text": "When Rooting Moloch enters the battlefield, exile target card with a cycling ability from your graveyard. Until the end of your next turn, you may play that card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -19573,7 +19573,7 @@
         },
         {
             "id": "50e99e04-1e49-5c1d-92d7-c702ddffa4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d300a9e8-4611-4728-b54d-bb73005091d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d300a9e8-4611-4728-b54d-bb73005091d1.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -19607,7 +19607,7 @@
         },
         {
             "id": "290ea9a8-9c2e-5d24-9d70-9a0cc3a57f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b5383-f4cf-45e7-aefc-7f3a42748a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b5383-f4cf-45e7-aefc-7f3a42748a8e.jpg?1",
             "name": "Rush of Adrenaline",
             "text": "Target creature gets +2/+1 and gains trample until end of turn.",
             "colours": [
@@ -19638,7 +19638,7 @@
         },
         {
             "id": "7908e855-e8f3-56b3-a576-3e55fc3fe7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadef4eb-d1fc-4b27-9d37-938f8893b9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadef4eb-d1fc-4b27-9d37-938f8893b9e7.jpg?1",
             "name": "Sarkhan, the Dragonspeaker",
             "text": "+1: Until end of turn, Sarkhan, the Dragonspeaker becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste. (He doesn't lose loyalty while he's not a planeswalker.)\n\u22123: Sarkhan, the Dragonspeaker deals 4 damage to target creature.\n\u22126: You get an emblem with \"At the beginning of your draw step, draw two additional cards\" and \"At the beginning of your end step, discard your hand.\"",
             "colours": [
@@ -19673,7 +19673,7 @@
         },
         {
             "id": "a3ea4fcc-0168-5d93-a987-a91cf6b74e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a34a4-2f2c-4c9c-a8d4-73953b62e189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a34a4-2f2c-4c9c-a8d4-73953b62e189.jpg?1",
             "name": "Sarkhan's Rage",
             "text": "Sarkhan's Rage deals 5 damage to any target. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
             "colours": [
@@ -19704,7 +19704,7 @@
         },
         {
             "id": "30693e30-578b-51f8-91ac-1117a3c3c7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeb27bc-bbdf-4ef1-89f5-ec91916c0d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeb27bc-bbdf-4ef1-89f5-ec91916c0d4e.jpg?1",
             "name": "Sarkhan's Whelp",
             "text": "Flying\nWhenever you activate an ability of a Sarkhan planeswalker, Sarkhan's Whelp deals 1 damage to any target.",
             "colours": [
@@ -19737,7 +19737,7 @@
         },
         {
             "id": "f19ec4c8-d107-53ca-9dd2-6cbd92dd189e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f3c49-dbfa-4eab-a561-656e74266834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f3c49-dbfa-4eab-a561-656e74266834.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -19768,7 +19768,7 @@
         },
         {
             "id": "48ddcb8d-1754-5833-995f-d78d03c6e34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9154f49f-229f-4362-a8e1-616666a81bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9154f49f-229f-4362-a8e1-616666a81bee.jpg?1",
             "name": "Searing Spear",
             "text": "Searing Spear deals 3 damage to any target.",
             "colours": [
@@ -19799,7 +19799,7 @@
         },
         {
             "id": "b7bafcff-0e3a-5263-aad3-7a68c5947c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3.jpg?1",
             "name": "Seize the Storm",
             "text": "Create a red Elemental creature token with trample and \"This creature's power and toughness are each equal to the number of instant and sorcery cards in your graveyard plus the number of cards with flashback you own in exile.\"\nFlashback {6}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -19830,7 +19830,7 @@
         },
         {
             "id": "a4aa57ab-b554-568f-807d-b6a69dbdda98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e9434-5db8-4497-9dc9-a42f3675a1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e9434-5db8-4497-9dc9-a42f3675a1cc.jpg?1",
             "name": "Shredded Sails",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Shredded Sails deals 4 damage to target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -19861,7 +19861,7 @@
         },
         {
             "id": "fefdd1f6-3b1d-5044-b03a-bca632863b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ff279f-0ad2-4bbd-8eb2-2ddd422c65cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ff279f-0ad2-4bbd-8eb2-2ddd422c65cf.jpg?1",
             "name": "Smoldering Efreet",
             "text": "When Smoldering Efreet dies, it deals 2 damage to you.",
             "colours": [
@@ -19895,7 +19895,7 @@
         },
         {
             "id": "45e784e8-c104-52e8-8829-61b20b53889d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ec8275-80c0-4c1e-9432-a940a83756a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ec8275-80c0-4c1e-9432-a940a83756a0.jpg?1",
             "name": "Sokenzan Smelter",
             "text": "At the beginning of combat on your turn, you may pay {1} and sacrifice an artifact. If you do, create a 3/1 red Construct artifact creature token with haste.",
             "colours": [
@@ -19929,7 +19929,7 @@
         },
         {
             "id": "ad148878-780e-5c89-9d77-76960638b36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cfd7b9-bf10-4fad-b66b-896fcce451d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cfd7b9-bf10-4fad-b66b-896fcce451d6.jpg?1",
             "name": "Spark of Creativity",
             "text": "Choose target creature. Exile the top card of your library. You may have Spark of Creativity deal damage to that creature equal to the exiled card's mana value. If you don't, you may play that card until end of turn.",
             "colours": [
@@ -19960,7 +19960,7 @@
         },
         {
             "id": "a30ade37-6dd1-5af5-8f48-8dc1d05f321b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b652-f429-4b2a-ab43-ce551eb0a59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b652-f429-4b2a-ab43-ce551eb0a59d.jpg?1",
             "name": "Sparkmage Apprentice",
             "text": "When Sparkmage Apprentice enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -19994,7 +19994,7 @@
         },
         {
             "id": "49553bd9-9785-5d2b-8660-a2b1ab4e3ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af09cfd-1dd1-45a8-869b-b21bcb03f7ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af09cfd-1dd1-45a8-869b-b21bcb03f7ce.jpg?1",
             "name": "Sparktongue Dragon",
             "text": "Flying\nWhen Sparktongue Dragon enters the battlefield, you may pay {2}{R}. When you do, it deals 3 damage to any target.",
             "colours": [
@@ -20027,7 +20027,7 @@
         },
         {
             "id": "a93fb07e-b75f-5773-8753-2b3e5b0c2622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312069a7-bbe2-44a2-b00c-5f3b827f21ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312069a7-bbe2-44a2-b00c-5f3b827f21ae.jpg?1",
             "name": "Spellgorger Weird",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.",
             "colours": [
@@ -20060,7 +20060,7 @@
         },
         {
             "id": "44c2512a-ee85-5fe6-be2f-5528677f50d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972040b8-1033-4c5a-8c3b-369b942fc594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972040b8-1033-4c5a-8c3b-369b942fc594.jpg?1",
             "name": "Spiteful Prankster",
             "text": "As long as it's your turn, Spiteful Prankster has first strike.\nWhenever another creature dies, Spiteful Prankster deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -20093,7 +20093,7 @@
         },
         {
             "id": "a4b67343-2ea4-501e-ac4e-040a9b124dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2b0910-33e3-484c-97fc-2938d15e0d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2b0910-33e3-484c-97fc-2938d15e0d92.jpg?1",
             "name": "Starstorm",
             "text": "Starstorm deals X damage to each creature.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -20124,7 +20124,7 @@
         },
         {
             "id": "7db1cac0-b9db-5391-9bac-94783c41ac34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f40a0c-89f1-4d6d-9297-99c90615d8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f40a0c-89f1-4d6d-9297-99c90615d8ed.jpg?1",
             "name": "Storm Fleet Pyromancer",
             "text": "Raid \u2014 When Storm Fleet Pyromancer enters the battlefield, if you attacked this turn, Storm Fleet Pyromancer deals 2 damage to any target.",
             "colours": [
@@ -20159,7 +20159,7 @@
         },
         {
             "id": "84415bb1-e330-5fa0-abb1-dabb18eaab69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502f2f7-e12b-4a3b-85ae-c0e69f210e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502f2f7-e12b-4a3b-85ae-c0e69f210e8b.jpg?1",
             "name": "Subterranean Scout",
             "text": "When Subterranean Scout enters the battlefield, target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -20193,7 +20193,7 @@
         },
         {
             "id": "fea7a0ae-bbd9-535f-bc1a-0b59c56d18c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78dd917-7748-41dd-b294-943302bdab34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78dd917-7748-41dd-b294-943302bdab34.jpg?1",
             "name": "Sudden Breakthrough",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -20224,7 +20224,7 @@
         },
         {
             "id": "54d39676-f453-5aa2-b008-c450a843532e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09baa4e-4ae0-4509-ab48-51d31d367649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09baa4e-4ae0-4509-ab48-51d31d367649.jpg?1",
             "name": "Swaggering Corsair",
             "text": "Raid \u2014 Swaggering Corsair enters the battlefield with a +1/+1 counter on it if you attacked this turn.",
             "colours": [
@@ -20258,7 +20258,7 @@
         },
         {
             "id": "0fefbff6-c4a3-5a3d-b4c0-acac489a09fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1a9476-83bf-42a5-8194-b3681e3c95e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1a9476-83bf-42a5-8194-b3681e3c95e8.jpg?1",
             "name": "Swift Kick",
             "text": "Target creature you control gets +1/+0 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -20289,7 +20289,7 @@
         },
         {
             "id": "d59ead28-1d95-591f-8546-8e6618f7623c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46f4a46-50ee-4a1f-8ebf-36689e8184a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46f4a46-50ee-4a1f-8ebf-36689e8184a6.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -20325,7 +20325,7 @@
         },
         {
             "id": "ad3d079f-0fbd-57ef-9698-fb84b7c3358e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74130f80-5e62-41a5-80c5-8b08ee9f8a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74130f80-5e62-41a5-80c5-8b08ee9f8a10.jpg?1",
             "name": "Torch Courier",
             "text": "Haste\nSacrifice Torch Courier: Another target creature gains haste until end of turn.",
             "colours": [
@@ -20358,7 +20358,7 @@
         },
         {
             "id": "cfb3081e-7133-50c4-b300-9c034476abf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c337af5-35bf-4a80-8cc0-bb9af20305b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c337af5-35bf-4a80-8cc0-bb9af20305b3.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -20389,7 +20389,7 @@
         },
         {
             "id": "576ea51e-79fa-5758-803c-5ec09a52f662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf67f7a-00da-422b-b517-fb55990a1999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf67f7a-00da-422b-b517-fb55990a1999.jpg?1",
             "name": "Trove of Temptation",
             "text": "Each opponent must attack you or a planeswalker you control with at least one creature each combat if able.\nAt the beginning of your end step, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -20420,7 +20420,7 @@
         },
         {
             "id": "d9d061e2-4f63-5630-851f-fb7f139c86f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f67518-b5ea-4b9b-96b5-e01de054b348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f67518-b5ea-4b9b-96b5-e01de054b348.jpg?1",
             "name": "Vault Robber",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -20454,7 +20454,7 @@
         },
         {
             "id": "109da23e-05c7-520c-ab01-0b186f147244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379a456f-ebc7-4e15-8750-b710dd1edcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379a456f-ebc7-4e15-8750-b710dd1edcec.jpg?1",
             "name": "Viashino Pyromancer",
             "text": "When Viashino Pyromancer enters the battlefield, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -20488,7 +20488,7 @@
         },
         {
             "id": "e1dc4fa9-6d63-5307-94f7-6d42ce4fb257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e618a-eec3-4077-841e-4503b6a06963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e618a-eec3-4077-841e-4503b6a06963.jpg?1",
             "name": "Volley Veteran",
             "text": "When Volley Veteran enters the battlefield, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -20522,7 +20522,7 @@
         },
         {
             "id": "40779e33-4030-52ac-a7c0-0d95f9ab5d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c688b-7eb4-4741-9f6f-6f8d21b22cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c688b-7eb4-4741-9f6f-6f8d21b22cc5.jpg?1",
             "name": "War-Name Aspirant",
             "text": "Raid \u2014 War-Name Aspirant enters the battlefield with a +1/+1 counter on it if you attacked this turn.\nWar-Name Aspirant can't be blocked by creatures with power 1 or less.",
             "colours": [
@@ -20556,7 +20556,7 @@
         },
         {
             "id": "47230f93-9854-59d2-92bc-0f3ae9c06b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3824c432-38c2-40cc-a371-ba797dd963e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3824c432-38c2-40cc-a371-ba797dd963e4.jpg?1",
             "name": "Warcry Phoenix",
             "text": "Flying, haste\nWhenever you attack with three or more creatures, you may pay {2}{R}. If you do, return Warcry Phoenix from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -20589,7 +20589,7 @@
         },
         {
             "id": "8479920c-fb45-58ed-a21e-8e9adaca02d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6e6945-ce52-4e50-a558-9c974b08e781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6e6945-ce52-4e50-a558-9c974b08e781.jpg?1",
             "name": "Weaselback Redcap",
             "text": "{1}{R}: Weaselback Redcap gets +2/+0 until end of turn.",
             "colours": [
@@ -20623,7 +20623,7 @@
         },
         {
             "id": "a9a3c4b7-532d-5931-a9bf-45ffa089dc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed0ceb6-f0cf-410d-977d-68889f4b9a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed0ceb6-f0cf-410d-977d-68889f4b9a4f.jpg?1",
             "name": "Welding Sparks",
             "text": "Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.",
             "colours": [
@@ -20654,7 +20654,7 @@
         },
         {
             "id": "9f2e4d58-e706-5c0a-a0dc-0518509a42c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7b16f9-11f2-4612-9ef3-152826d0ae45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7b16f9-11f2-4612-9ef3-152826d0ae45.jpg?1",
             "name": "Wildfire Elemental",
             "text": "Whenever an opponent is dealt noncombat damage, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -20687,7 +20687,7 @@
         },
         {
             "id": "7998ada8-77d4-5434-8285-084fc351151a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d00a73-4699-4a94-b121-159a0d17c817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d00a73-4699-4a94-b121-159a0d17c817.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "Trample, haste\nCycling {1}{R}\nWhen you cycle Yidaro, Wandering Monster, shuffle it into your library from your graveyard. If you've cycled a card named Yidaro, Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead. (Do this before you draw.)",
             "colours": [
@@ -20723,7 +20723,7 @@
         },
         {
             "id": "5eff27c4-93d5-5c34-a02b-c49c82e1e9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -20757,7 +20757,7 @@
         },
         {
             "id": "7590d812-7a64-5139-a6ce-b2263f9a16c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a20507-7db5-4f6d-92cd-8065191fd002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a20507-7db5-4f6d-92cd-8065191fd002.jpg?1",
             "name": "Adventurous Impulse",
             "text": "Look at the top three cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -20788,7 +20788,7 @@
         },
         {
             "id": "934f2489-da80-5609-b0ec-0d10741da272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0ef635-3642-484a-beb9-d977e6cca9aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0ef635-3642-484a-beb9-d977e6cca9aa.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -20819,7 +20819,7 @@
         },
         {
             "id": "4ebba11d-3a48-5327-babd-958482708da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5f7be6-c30a-43f0-a371-e93a24cc5636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5f7be6-c30a-43f0-a371-e93a24cc5636.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -20852,7 +20852,7 @@
         },
         {
             "id": "c82debd2-d502-5ab7-9556-ba2ffb9f2bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ce531-48cb-4a52-a0ea-9cba5dcb4060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ce531-48cb-4a52-a0ea-9cba5dcb4060.jpg?1",
             "name": "Baloth Woodcrasher",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Baloth Woodcrasher gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -20885,7 +20885,7 @@
         },
         {
             "id": "d5804f64-bbb5-5e0c-8f77-071611dec7f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e35b793-1b2c-4194-8186-c907197ff89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e35b793-1b2c-4194-8186-c907197ff89c.jpg?1",
             "name": "Band Together",
             "text": "Up to two target creatures you control each deal damage equal to their power to another target creature.",
             "colours": [
@@ -20916,7 +20916,7 @@
         },
         {
             "id": "33b67a02-614c-56e4-b77e-a8cc76419707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db1cc35-8901-4528-9100-38f12d89540c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db1cc35-8901-4528-9100-38f12d89540c.jpg?1",
             "name": "Blisterpod",
             "text": "Devoid (This card has no color.)\nWhen Blisterpod dies, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -20948,7 +20948,7 @@
         },
         {
             "id": "2fa1d1fc-5bbd-5321-bf35-c023382fdb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515d4a0a-61db-4be0-b9a3-cfd4c163f31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515d4a0a-61db-4be0-b9a3-cfd4c163f31b.jpg?1",
             "name": "Bounding Wolf",
             "text": "Flash\nReach",
             "colours": [
@@ -20981,7 +20981,7 @@
         },
         {
             "id": "8cfa7780-de75-5eb5-845c-07967a4885e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c145-3ddf-45d8-a5f0-f757dbd94ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c145-3ddf-45d8-a5f0-f757dbd94ad1.jpg?1",
             "name": "Briarpack Alpha",
             "text": "Flash\nWhen Briarpack Alpha enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -21014,7 +21014,7 @@
         },
         {
             "id": "11296d69-0f27-52f7-8288-d958ee75f10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27591452-2750-4eed-bded-832bdee79e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27591452-2750-4eed-bded-832bdee79e00.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -21047,7 +21047,7 @@
         },
         {
             "id": "d94be596-c487-5f6c-8504-41e75dd970f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e084d745-ce11-4819-81c3-957b913fbe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e084d745-ce11-4819-81c3-957b913fbe4d.jpg?1",
             "name": "Broken Bond",
             "text": "Destroy target artifact or enchantment. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -21078,7 +21078,7 @@
         },
         {
             "id": "6ec0e878-d763-580e-a699-27e910d13a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5a6be1-f706-4681-9f95-512381be123e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5a6be1-f706-4681-9f95-512381be123e.jpg?1",
             "name": "Brood Monitor",
             "text": "Devoid (This card has no color.)\nWhen Brood Monitor enters the battlefield, create three 1/1 colorless Eldrazi Scion creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -21110,7 +21110,7 @@
         },
         {
             "id": "dd0526f6-f0fe-5ec7-8c5a-95c9b298b411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20920ff-ccfe-46a2-9b2e-0dc342f2e057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20920ff-ccfe-46a2-9b2e-0dc342f2e057.jpg?1",
             "name": "Canopy Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Canopy Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -21143,7 +21143,7 @@
         },
         {
             "id": "599c145a-ccbb-5c9b-9036-5eeed6aef072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef77d59-ad3d-4888-894b-7439f9a57999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef77d59-ad3d-4888-894b-7439f9a57999.jpg?1",
             "name": "Challenger Troll",
             "text": "Each creature you control with power 4 or greater can't be blocked by more than one creature.",
             "colours": [
@@ -21176,7 +21176,7 @@
         },
         {
             "id": "362c9c94-533b-527e-93f3-ff304b7357fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35fd2a8-cccd-4b35-b791-d70e74e203bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35fd2a8-cccd-4b35-b791-d70e74e203bc.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -21209,7 +21209,7 @@
         },
         {
             "id": "9602f337-7397-5b14-b2e4-ae1fa55039df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccc9e96-b3dd-4443-935e-621ec37f595b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccc9e96-b3dd-4443-935e-621ec37f595b.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play lands from the top of your library.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -21243,7 +21243,7 @@
         },
         {
             "id": "d4e97bba-a39a-5478-9c1a-88ebbd037258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedb008c-c89b-4093-8622-ee18e217de15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedb008c-c89b-4093-8622-ee18e217de15.jpg?1",
             "name": "Crawling Sensation",
             "text": "At the beginning of your upkeep, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nWhenever one or more land cards are put into your graveyard from anywhere for the first time each turn, create a 1/1 green Insect creature token.",
             "colours": [
@@ -21274,7 +21274,7 @@
         },
         {
             "id": "a89fcd55-0699-507c-b9f4-2b7dead9e14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd21b3ae-37f0-4415-8f12-20aba6afbae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd21b3ae-37f0-4415-8f12-20aba6afbae4.jpg?1",
             "name": "Creeperhulk",
             "text": "Trample\n{1}{G}: Until end of turn, target creature you control has base power and toughness 5/5 and gains trample.",
             "colours": [
@@ -21308,7 +21308,7 @@
         },
         {
             "id": "d3a30b09-04c6-5130-988c-5b05310446ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075cac04-9397-4edb-b49a-485dd58dcae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075cac04-9397-4edb-b49a-485dd58dcae1.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -21339,7 +21339,7 @@
         },
         {
             "id": "bfdbc97e-fd7c-5c15-9f31-0f501fbca190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fce3a3a-56d8-4895-8110-27e5480e15fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fce3a3a-56d8-4895-8110-27e5480e15fd.jpg?1",
             "name": "Deadbridge Goliath",
             "text": "Scavenge {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -21372,7 +21372,7 @@
         },
         {
             "id": "ef52be6e-5262-56b1-8e2c-fe1ea205c36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f56fa52-9d92-4bf7-9dbc-a3da91e98087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f56fa52-9d92-4bf7-9dbc-a3da91e98087.jpg?1",
             "name": "Declare Dominance",
             "text": "Target creature gets +3/+3 until end of turn. All creatures able to block it this turn do so.",
             "colours": [
@@ -21403,7 +21403,7 @@
         },
         {
             "id": "2e38a170-e6c0-5276-aabb-b42aab7ce42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f1435-5900-47db-b7ec-57f71896f94b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f1435-5900-47db-b7ec-57f71896f94b.jpg?1",
             "name": "Domesticated Hydra",
             "text": "{X}{G}{G}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nAs long as Domesticated Hydra is monstrous, it has trample.",
             "colours": [
@@ -21436,7 +21436,7 @@
         },
         {
             "id": "0f32827e-5e02-5451-bd12-843fcaebaad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59954cf9-2ea3-45c4-88e4-6c5005011f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59954cf9-2ea3-45c4-88e4-6c5005011f44.jpg?1",
             "name": "Drowsing Tyrannodon",
             "text": "Defender\nAs long as you control a creature with power 4 or greater, Drowsing Tyrannodon can attack as though it didn't have defender.",
             "colours": [
@@ -21469,7 +21469,7 @@
         },
         {
             "id": "a788eb80-8361-56f1-90e3-9b3bb4c2629e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931d53de-a1c7-4ed7-a8b9-e8e76ad4bfd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931d53de-a1c7-4ed7-a8b9-e8e76ad4bfd0.jpg?1",
             "name": "Drudge Beetle",
             "text": "Scavenge {5}{G} ({5}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -21502,7 +21502,7 @@
         },
         {
             "id": "e6f05fdf-8435-55b6-9a68-da5cb9d53290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c0088-124d-45ea-9214-f0a440681403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c0088-124d-45ea-9214-f0a440681403.jpg?1",
             "name": "Duskshell Crawler",
             "text": "When Duskshell Crawler enters the battlefield, put a +1/+1 counter on target creature.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -21535,7 +21535,7 @@
         },
         {
             "id": "00af7adf-9109-5029-8ce0-1e8b9aa9a49a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31eee7a7-af13-4de5-9f4b-5f803335cfc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31eee7a7-af13-4de5-9f4b-5f803335cfc5.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When Dwynen's Elite enters the battlefield, if you control another Elf, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -21569,7 +21569,7 @@
         },
         {
             "id": "0ffdd220-49b9-5f5e-a67e-e966b95b1247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175c5cf-b33d-481d-b093-57072f6f671e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175c5cf-b33d-481d-b093-57072f6f671e.jpg?1",
             "name": "Elderleaf Mentor",
             "text": "When Elderleaf Mentor enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -21603,7 +21603,7 @@
         },
         {
             "id": "23f99fa9-8e1c-57a9-b614-26f62edb1c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d986c6e3-dabc-4422-94b9-f7154935a355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d986c6e3-dabc-4422-94b9-f7154935a355.jpg?1",
             "name": "Elven Bow",
             "text": "When Elven Bow enters the battlefield, you may pay {2}. If you do, create a 1/1 green Elf Warrior creature token, then attach Elven Bow to it.\nEquipped creature gets +1/+2 and has reach.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -21636,7 +21636,7 @@
         },
         {
             "id": "8b64a3ed-f18f-5332-b20f-513c65a43ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc94b52-1cb1-4c1e-8b17-5632abc2490d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc94b52-1cb1-4c1e-8b17-5632abc2490d.jpg?1",
             "name": "Elvish Warmaster",
             "text": "Whenever one or more other Elves enter the battlefield under your control, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
             "colours": [
@@ -21670,7 +21670,7 @@
         },
         {
             "id": "15ab7bed-0e41-5206-a9b0-97e3a6eaf41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9180de1c-27ad-48f1-b9c1-2008623911d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9180de1c-27ad-48f1-b9c1-2008623911d0.jpg?1",
             "name": "Engulfing Slagwurm",
             "text": "Whenever Engulfing Slagwurm blocks or becomes blocked by a creature, destroy that creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -21703,7 +21703,7 @@
         },
         {
             "id": "7e2792af-ac73-5066-b9fa-1546e25f5f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33bd73-e15f-4bc2-8053-b34f849c1a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33bd73-e15f-4bc2-8053-b34f849c1a85.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -21734,7 +21734,7 @@
         },
         {
             "id": "3c537876-6d10-5c28-b5a5-def01765b781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81df4f6c-fa65-43cd-bad1-4f255d75d1aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81df4f6c-fa65-43cd-bad1-4f255d75d1aa.jpg?1",
             "name": "Feed the Pack",
             "text": "At the beginning of your end step, you may sacrifice a nontoken creature. If you do, create X 2/2 green Wolf creature tokens, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -21765,7 +21765,7 @@
         },
         {
             "id": "069fa98c-0471-5084-b942-f956f35a7f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d621a3-c613-44f2-a986-25d72dfa4ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d621a3-c613-44f2-a986-25d72dfa4ff6.jpg?1",
             "name": "Feral Hydra",
             "text": "Feral Hydra enters the battlefield with X +1/+1 counters on it.\n{3}: Put a +1/+1 counter on Feral Hydra. Any player may activate this ability.",
             "colours": [
@@ -21799,7 +21799,7 @@
         },
         {
             "id": "a4f8e843-21bf-5cc0-9124-ed7e04ca38e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee53763-7344-4627-93c3-b4a5b26b1f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee53763-7344-4627-93c3-b4a5b26b1f16.jpg?1",
             "name": "Ferocious Pup",
             "text": "When Ferocious Pup enters the battlefield, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -21832,7 +21832,7 @@
         },
         {
             "id": "74f8ae4a-295d-50b0-a13b-17deca4561e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f511123-4a07-4e80-aa85-e52ee4c7ea4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f511123-4a07-4e80-aa85-e52ee4c7ea4d.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles.",
             "colours": [
@@ -21865,7 +21865,7 @@
         },
         {
             "id": "c8df57aa-7e7a-5359-86cf-03c14ac7ac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797744c0-cfcc-43cb-baeb-bc2be3f7523d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797744c0-cfcc-43cb-baeb-bc2be3f7523d.jpg?1",
             "name": "Fierce Witchstalker",
             "text": "Trample\nWhen Fierce Witchstalker enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -21898,7 +21898,7 @@
         },
         {
             "id": "2e9cb1f0-40ba-530d-b062-420396d9cfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c03c782-cd45-45a6-8089-a603509ef0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c03c782-cd45-45a6-8089-a603509ef0ec.jpg?1",
             "name": "Flourishing Hunter",
             "text": "When Flourishing Hunter enters the battlefield, you gain life equal to the greatest toughness among other creatures you control.",
             "colours": [
@@ -21932,7 +21932,7 @@
         },
         {
             "id": "d17782e5-12dd-5910-8d8a-91191ba00d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86d6a38-78c9-4045-b72b-e6a3fa87861f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86d6a38-78c9-4045-b72b-e6a3fa87861f.jpg?1",
             "name": "Frontier Mastodon",
             "text": "Ferocious \u2014 Frontier Mastodon enters the battlefield with a +1/+1 counter on it if you control a creature with power 4 or greater.",
             "colours": [
@@ -21965,7 +21965,7 @@
         },
         {
             "id": "524e2890-cf28-5ae0-ab15-f68dbe05a273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b335f-16f3-474e-8bdc-7453b2fc62bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b335f-16f3-474e-8bdc-7453b2fc62bc.jpg?1",
             "name": "Gaea's Protector",
             "text": "Gaea's Protector must be blocked if able.",
             "colours": [
@@ -21999,7 +21999,7 @@
         },
         {
             "id": "c4f59c4e-5eed-5d1f-93d6-db1d8225c40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b093537-962b-4707-8e17-a6a2b089a863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b093537-962b-4707-8e17-a6a2b089a863.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -22033,7 +22033,7 @@
         },
         {
             "id": "3433c88d-58c3-541f-b8a2-6a037ec66c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf3c63-2f8c-4f43-b08b-35a974214ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf3c63-2f8c-4f43-b08b-35a974214ad3.jpg?1",
             "name": "Giant Caterpillar",
             "text": "{G}, Sacrifice Giant Caterpillar: Create a 1/1 green Insect creature token with flying named Butterfly at the beginning of the next end step.",
             "colours": [
@@ -22066,7 +22066,7 @@
         },
         {
             "id": "2ff40ef1-904c-5283-a52c-dbd74a6eea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018fba0-a475-4df1-bb81-447c48f2e320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018fba0-a475-4df1-bb81-447c48f2e320.jpg?1",
             "name": "Gift of the Gargantuan",
             "text": "Look at the top four cards of your library. You may reveal a creature card and/or a land card from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -22097,7 +22097,7 @@
         },
         {
             "id": "c9976617-0722-5822-909a-a2450fbe1acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6367056d-c066-40a3-b744-21a921bccc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6367056d-c066-40a3-b744-21a921bccc2c.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "Creature spells you cast with power 4 or greater cost {2} less to cast.\nWhenever Goreclaw, Terror of Qal Sisma attacks, each creature you control with power 4 or greater gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -22132,7 +22132,7 @@
         },
         {
             "id": "896a0fd7-93e5-5a02-a967-50818bd91aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fac3f2-68f5-4f6f-940d-285508fccdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fac3f2-68f5-4f6f-940d-285508fccdea.jpg?1",
             "name": "Groundswell",
             "text": "Target creature gets +2/+2 until end of turn.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -22163,7 +22163,7 @@
         },
         {
             "id": "d16cb2ba-e01a-537e-b177-3cc927eafc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3577918-58a0-4bcb-a037-f3932c1cdc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3577918-58a0-4bcb-a037-f3932c1cdc8a.jpg?1",
             "name": "Havenwood Wurm",
             "text": "Flash\nTrample",
             "colours": [
@@ -22196,7 +22196,7 @@
         },
         {
             "id": "75f83b98-4723-5301-a297-d8ff1769dcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829f217-4d59-442a-8a03-21bd93d84103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829f217-4d59-442a-8a03-21bd93d84103.jpg?1",
             "name": "Hooting Mandrills",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTrample",
             "colours": [
@@ -22229,7 +22229,7 @@
         },
         {
             "id": "f692e3fc-849a-5b08-9cf1-120d7760a8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ca3780-5eff-439f-bdf6-23c449efce3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ca3780-5eff-439f-bdf6-23c449efce3c.jpg?1",
             "name": "Howl of the Hunt",
             "text": "Flash\nEnchant creature\nWhen Howl of the Hunt enters the battlefield, if enchanted creature is a Wolf or Werewolf, untap that creature.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -22262,7 +22262,7 @@
         },
         {
             "id": "2a7d2aa0-8dd3-514c-8243-c92f59e9565b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00502ed1-4364-41cd-b717-1f9e38d1afe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00502ed1-4364-41cd-b717-1f9e38d1afe6.jpg?1",
             "name": "Howlgeist",
             "text": "Creatures with power less than Howlgeist's power can't block it.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -22296,7 +22296,7 @@
         },
         {
             "id": "3243e8b3-5254-55f4-82a6-0ce7f227c197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a0d9c-315a-416e-a8af-ad12bc9b62fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a0d9c-315a-416e-a8af-ad12bc9b62fa.jpg?1",
             "name": "Hunger of the Howlpack",
             "text": "Put a +1/+1 counter on target creature.\nMorbid \u2014 Put three +1/+1 counters on that creature instead if a creature died this turn.",
             "colours": [
@@ -22327,7 +22327,7 @@
         },
         {
             "id": "39d5df03-bd5a-546e-9492-3702d496663f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ba254e-84bb-4d5c-8372-66f73e556b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ba254e-84bb-4d5c-8372-66f73e556b39.jpg?1",
             "name": "Hunter's Edge",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -22358,7 +22358,7 @@
         },
         {
             "id": "3b4223be-41a3-5adb-b9ee-5e871101eb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e931e8ec-78c1-473c-b772-d359842d8350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e931e8ec-78c1-473c-b772-d359842d8350.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -22391,7 +22391,7 @@
         },
         {
             "id": "ae8fd6d2-f9b7-5a8c-96cc-5b2921f7652e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525cf980-275e-423e-9470-e782ce4796dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525cf980-275e-423e-9470-e782ce4796dd.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elves you control get +1/+1.\n{G}, {T}: Create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -22425,7 +22425,7 @@
         },
         {
             "id": "26183c0e-6290-52ae-83e3-266237084025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424f3f1e-f61d-4130-8f1c-52698074cc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424f3f1e-f61d-4130-8f1c-52698074cc90.jpg?1",
             "name": "Iridescent Hornbeetle",
             "text": "At the beginning of your end step, create a 1/1 green Insect creature token for each +1/+1 counter you've put on creatures under your control this turn.",
             "colours": [
@@ -22458,7 +22458,7 @@
         },
         {
             "id": "f719eca7-10e9-5825-880d-8408483471d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ffe5ca-9b60-4882-ad17-5657bff0ae20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ffe5ca-9b60-4882-ad17-5657bff0ae20.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -22491,7 +22491,7 @@
         },
         {
             "id": "fbecb5e5-5ae7-5548-9c81-69c90a5594dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90202611-961d-48b5-87b6-58486b572216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90202611-961d-48b5-87b6-58486b572216.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.",
             "colours": [
@@ -22525,7 +22525,7 @@
         },
         {
             "id": "8c484010-ea76-5be3-b4f2-1a6d11e701b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d305e7c-81b2-460e-8f56-63cfbb018f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d305e7c-81b2-460e-8f56-63cfbb018f15.jpg?1",
             "name": "Kessig Cagebreakers",
             "text": "Whenever Kessig Cagebreakers attacks, create a 2/2 green Wolf creature token that's tapped and attacking for each creature card in your graveyard.",
             "colours": [
@@ -22559,7 +22559,7 @@
         },
         {
             "id": "55c0e09e-214d-545f-b06a-3bfa21fee46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae954a-faf5-47db-bdee-312652086df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae954a-faf5-47db-bdee-312652086df5.jpg?1",
             "name": "Kraul Foragers",
             "text": "Undergrowth \u2014 When Kraul Foragers enters the battlefield, you gain 1 life for each creature card in your graveyard.",
             "colours": [
@@ -22593,7 +22593,7 @@
         },
         {
             "id": "a42d4592-e1c6-5af6-be88-77f612683e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce45a70-7fbc-42f8-8608-980eb4aee2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce45a70-7fbc-42f8-8608-980eb4aee2b8.jpg?1",
             "name": "Kraul Harpooner",
             "text": "Reach\nUndergrowth \u2014 When Kraul Harpooner enters the battlefield, choose up to one target creature with flying you don't control. Kraul Harpooner gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have Kraul Harpooner fight that creature.",
             "colours": [
@@ -22627,7 +22627,7 @@
         },
         {
             "id": "0f790f0b-0e16-5aec-9ca4-e1a0e8b1b10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7b87d-cd5c-45de-a7bd-e834337f3400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7b87d-cd5c-45de-a7bd-e834337f3400.jpg?1",
             "name": "Kraul Warrior",
             "text": "{5}{G}: Kraul Warrior gets +3/+3 until end of turn.",
             "colours": [
@@ -22661,7 +22661,7 @@
         },
         {
             "id": "cc0baea2-76d0-555a-8ba8-d2f367acd93c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d81bf-a573-441f-9593-41af41d927d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d81bf-a573-441f-9593-41af41d927d2.jpg?1",
             "name": "Kujar Seedsculptor",
             "text": "When Kujar Seedsculptor enters the battlefield, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -22695,7 +22695,7 @@
         },
         {
             "id": "4321844b-2a3a-5f0a-a508-a410cd99a487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df23b1-7d28-403f-bf12-d4ec81500c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df23b1-7d28-403f-bf12-d4ec81500c36.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "Whenever you cast an Elf spell, you may create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -22729,7 +22729,7 @@
         },
         {
             "id": "952958a2-dd72-5f04-8931-b49379067208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac46277-1980-40aa-8356-dd283bda297b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac46277-1980-40aa-8356-dd283bda297b.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach",
             "colours": [
@@ -22762,7 +22762,7 @@
         },
         {
             "id": "bc25cb65-b9d8-522d-a18e-94202529001e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cace1a3-34df-45d0-b653-b120b3617d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cace1a3-34df-45d0-b653-b120b3617d40.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "At the beginning of your upkeep, create a 2/2 green Wolf creature token.\n{T}: Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves.",
             "colours": [
@@ -22796,7 +22796,7 @@
         },
         {
             "id": "84273559-faf7-58eb-8173-4674a3627b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0fef06-aaf8-4476-a321-199a466f8400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0fef06-aaf8-4476-a321-199a466f8400.jpg?1",
             "name": "Master's Rebuke",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -22827,7 +22827,7 @@
         },
         {
             "id": "a771240c-9c0f-55ac-8cc3-34706b67bd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a87b43-84bb-4878-85c3-490d283a2a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a87b43-84bb-4878-85c3-490d283a2a77.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -22858,7 +22858,7 @@
         },
         {
             "id": "e7f9369b-3cd1-5968-92cc-0e176bc7e978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fc5e1-013d-485d-a4a1-bf616a53098d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fc5e1-013d-485d-a4a1-bf616a53098d.jpg?1",
             "name": "Moldgraf Millipede",
             "text": "When Moldgraf Millipede enters the battlefield, mill three cards, then put a +1/+1 counter on Moldgraf Millipede for each creature card in your graveyard. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -22892,7 +22892,7 @@
         },
         {
             "id": "d4216332-2653-5a0a-833d-444558a8666f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7afc6-dcc2-45ce-99e8-696cd5a11466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7afc6-dcc2-45ce-99e8-696cd5a11466.jpg?1",
             "name": "Moonlight Hunt",
             "text": "Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf deals damage equal to its power to that creature.",
             "colours": [
@@ -22923,7 +22923,7 @@
         },
         {
             "id": "f4847337-7591-5b8f-a17b-daa853dab1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a6d4d-693e-4170-bda8-2e21540e69c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a6d4d-693e-4170-bda8-2e21540e69c9.jpg?1",
             "name": "Naga Vitalist",
             "text": "{T}: Add one mana of any type that a land you control could produce.",
             "colours": [
@@ -22957,7 +22957,7 @@
         },
         {
             "id": "c322bc99-c1d3-54a3-ab8a-8132b681ab1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069a7b3-adad-4d46-a0ed-09fb62790699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069a7b3-adad-4d46-a0ed-09fb62790699.jpg?1",
             "name": "Nantuko Cultivator",
             "text": "When Nantuko Cultivator enters the battlefield, you may discard any number of land cards. Put that many +1/+1 counters on Nantuko Cultivator and draw that many cards.",
             "colours": [
@@ -22991,7 +22991,7 @@
         },
         {
             "id": "c47ace5b-86b0-50da-a5bd-480d5a4d8a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7f2302-9bd2-45fe-b27c-1e3eed74a465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7f2302-9bd2-45fe-b27c-1e3eed74a465.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on Nessian Hornbeetle.",
             "colours": [
@@ -23024,7 +23024,7 @@
         },
         {
             "id": "01e3f008-f1fc-5c71-95ec-555b3ddb21eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd67241-6ff1-41bc-9bda-4a87fd4f6bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd67241-6ff1-41bc-9bda-4a87fd4f6bdd.jpg?1",
             "name": "Nightpack Ambusher",
             "text": "Flash\nOther Wolves and Werewolves you control get +1/+1.\nAt the beginning of your end step, if you didn't cast a spell this turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -23057,7 +23057,7 @@
         },
         {
             "id": "9de9f6da-cbc3-5a3a-93b2-6c5ef2ac9c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a8c23-4d30-4b0b-8561-b8c22bbc194a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a8c23-4d30-4b0b-8561-b8c22bbc194a.jpg?1",
             "name": "Oashra Cultivator",
             "text": "{2}{G}, {T}, Sacrifice Oashra Cultivator: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -23091,7 +23091,7 @@
         },
         {
             "id": "408eea16-861b-586d-b8d1-47621363e590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af65ef1-d4e4-4fdb-819f-a0dbe7b62376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af65ef1-d4e4-4fdb-819f-a0dbe7b62376.jpg?1",
             "name": "Ondu Giant",
             "text": "When Ondu Giant enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -23125,7 +23125,7 @@
         },
         {
             "id": "1e79f430-7c60-5c61-9a79-97ed58779545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f551c983-8bbd-4698-b6af-f22c8eba1ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f551c983-8bbd-4698-b6af-f22c8eba1ea5.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea.\nWhen you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -23158,7 +23158,7 @@
         },
         {
             "id": "52dd3981-8293-5ec6-8c6d-39375522c5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac24ccd-8db0-4c93-9542-0eac3b369d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac24ccd-8db0-4c93-9542-0eac3b369d61.jpg?1",
             "name": "Ornery Dilophosaur",
             "text": "Deathtouch\nWhenever Ornery Dilophosaur attacks, if you control a creature with power 4 or greater, Ornery Dilophosaur gets +2/+2 until end of turn.",
             "colours": [
@@ -23191,7 +23191,7 @@
         },
         {
             "id": "6e7d7427-ef7c-56ae-a4b9-ef8a714befa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f1dab-24c5-4bcd-bcc0-d282f28c8689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f1dab-24c5-4bcd-bcc0-d282f28c8689.jpg?1",
             "name": "Overcome",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -23222,7 +23222,7 @@
         },
         {
             "id": "daa2d181-5f01-56e9-9886-d59d40da9362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce941f72-27b6-4fb5-a303-630686fb97a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce941f72-27b6-4fb5-a303-630686fb97a9.jpg?1",
             "name": "Overgrowth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}{G}.",
             "colours": [
@@ -23255,7 +23255,7 @@
         },
         {
             "id": "2733e9d8-789b-5964-ab27-c343d3389994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565640bf-cc41-4365-b1f7-54f66ebcfa01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565640bf-cc41-4365-b1f7-54f66ebcfa01.jpg?1",
             "name": "Packsong Pup",
             "text": "At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1 counter on Packsong Pup.\nWhen Packsong Pup dies, you gain life equal to its power.",
             "colours": [
@@ -23288,7 +23288,7 @@
         },
         {
             "id": "df415314-e60a-5d2c-8c30-c494bfbe8441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863cac64-ceb6-4c3c-8f66-72c579ff2954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863cac64-ceb6-4c3c-8f66-72c579ff2954.jpg?1",
             "name": "Paradise Druid",
             "text": "Paradise Druid has hexproof as long as it's untapped.(It can't be the target of spells or abilities your opponents control.)\n{T}: Add one mana of any color.",
             "colours": [
@@ -23322,7 +23322,7 @@
         },
         {
             "id": "84caf057-2a8e-5a54-951d-481f47882ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed46aa9c-bcf1-4853-abbe-8bae3499aa2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed46aa9c-bcf1-4853-abbe-8bae3499aa2d.jpg?1",
             "name": "Pestilent Wolf",
             "text": "{2}{G}: Pestilent Wolf gains deathtouch until end of turn.",
             "colours": [
@@ -23355,7 +23355,7 @@
         },
         {
             "id": "479a1dbb-24d4-5ad6-90f4-68cad113c27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0b9478-0fe5-4c4c-b634-bde8bc225195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0b9478-0fe5-4c4c-b634-bde8bc225195.jpg?1",
             "name": "Phantom Nantuko",
             "text": "Trample\nPhantom Nantuko enters the battlefield with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Nantuko, prevent that damage. Remove a +1/+1 counter from Phantom Nantuko.\n{T}: Put a +1/+1 counter on Phantom Nantuko.",
             "colours": [
@@ -23389,7 +23389,7 @@
         },
         {
             "id": "4a388f38-8170-5bcc-99b1-bef673e7b90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052864bb-6f76-482a-961e-b427af135da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052864bb-6f76-482a-961e-b427af135da0.jpg?1",
             "name": "Pounce",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -23420,7 +23420,7 @@
         },
         {
             "id": "d7c83e60-9087-51ba-81cf-634dd7a6df45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0976212-1e3f-4a31-ac56-15827fdbe28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0976212-1e3f-4a31-ac56-15827fdbe28d.jpg?1",
             "name": "Predator's Howl",
             "text": "Create a 2/2 green Wolf creature token.\nMorbid \u2014 Create three 2/2 green Wolf creature tokens instead if a creature died this turn.",
             "colours": [
@@ -23451,7 +23451,7 @@
         },
         {
             "id": "8b966590-69b4-5d25-82f3-30bb980ac71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fcba6c-c078-4a0d-be68-984536d91831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fcba6c-c078-4a0d-be68-984536d91831.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Create a 1/1 green Elf Warrior creature token.\"",
             "colours": [
@@ -23484,7 +23484,7 @@
         },
         {
             "id": "3b281663-bef9-5f14-b249-14a5480139a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8c721f-93b8-4c43-9054-2168f66726db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8c721f-93b8-4c43-9054-2168f66726db.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -23515,7 +23515,7 @@
         },
         {
             "id": "854167f9-906d-5b2c-91e3-a9cd9ef6d172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd004c-50a8-43df-9dec-a7822b720966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd004c-50a8-43df-9dec-a7822b720966.jpg?1",
             "name": "Pridemalkin",
             "text": "When Pridemalkin enters the battlefield, put a +1/+1 counter on target creature you control.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -23548,7 +23548,7 @@
         },
         {
             "id": "8a5e4a2d-fde9-583e-b790-4070d94de4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a83f0aa-55bc-4528-b521-7b4223ed4a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a83f0aa-55bc-4528-b521-7b4223ed4a6e.jpg?1",
             "name": "Primordial Hydra",
             "text": "Primordial Hydra enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Primordial Hydra.\nPrimordial Hydra has trample as long as it has ten or more +1/+1 counters on it.",
             "colours": [
@@ -23581,7 +23581,7 @@
         },
         {
             "id": "4802de1e-9d6a-5cdb-999c-82cccbc56c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d1c576-0203-4ede-8728-1efa87c33d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d1c576-0203-4ede-8728-1efa87c33d20.jpg?1",
             "name": "Prowling Serpopard",
             "text": "This spell can't be countered.\nCreature spells you control can't be countered.",
             "colours": [
@@ -23615,7 +23615,7 @@
         },
         {
             "id": "39690413-5256-505a-ad2f-23b63028bf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0614fe56-aafb-4e7b-96b9-a940735da560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0614fe56-aafb-4e7b-96b9-a940735da560.jpg?1",
             "name": "Quarry Beetle",
             "text": "When Quarry Beetle enters the battlefield, you may return target land card from your graveyard to the battlefield.",
             "colours": [
@@ -23648,7 +23648,7 @@
         },
         {
             "id": "f55eb810-667d-5695-a37e-4ce1dea278f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4de4-c6f5-43f5-b9f0-f1e9414b7748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4de4-c6f5-43f5-b9f0-f1e9414b7748.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -23681,7 +23681,7 @@
         },
         {
             "id": "f5f20528-35bc-56c6-a50f-745bd4861a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71235882-5d2e-4250-8b2a-24a5d502e88d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71235882-5d2e-4250-8b2a-24a5d502e88d.jpg?1",
             "name": "Reckless Amplimancer",
             "text": "{4}{G}: Double Reckless Amplimancer's power and toughness until end of turn.",
             "colours": [
@@ -23715,7 +23715,7 @@
         },
         {
             "id": "f9107300-cac6-5536-a637-b21e7cd88897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67127e1-accb-49a5-99c6-4508d5dd81da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67127e1-accb-49a5-99c6-4508d5dd81da.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -23749,7 +23749,7 @@
         },
         {
             "id": "137cfc2f-af2d-50bb-bb81-e109e2122016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f6140e-4e96-478b-8a77-dc5100a9f95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f6140e-4e96-478b-8a77-dc5100a9f95e.jpg?1",
             "name": "Relentless Pursuit",
             "text": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -23780,7 +23780,7 @@
         },
         {
             "id": "df8f5e10-be1e-5f64-8281-9217478d3826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bd038-727f-4e7e-8b87-fccc7b2ca0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bd038-727f-4e7e-8b87-fccc7b2ca0a6.jpg?1",
             "name": "Rhonas the Indomitable",
             "text": "Deathtouch, indestructible\nRhonas the Indomitable can't attack or block unless you control another creature with power 4 or greater.\n{2}{G}: Another target creature gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -23815,7 +23815,7 @@
         },
         {
             "id": "cb9aba3a-16ab-53a9-8d7c-d11925df721c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f303e0-4832-4d8d-b1b1-9ff16283f4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f303e0-4832-4d8d-b1b1-9ff16283f4b5.jpg?1",
             "name": "Roar of Challenge",
             "text": "All creatures able to block target creature this turn do so.\nFerocious \u2014 That creature gains indestructible until end of turn if you control a creature with power 4 or greater. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -23846,7 +23846,7 @@
         },
         {
             "id": "251de176-9a6a-5e83-a862-b24a3ca8a4bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacd6f7b-3bb7-4957-afb6-f59881b55bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacd6f7b-3bb7-4957-afb6-f59881b55bb1.jpg?1",
             "name": "Roots of Wisdom",
             "text": "Mill three cards, then return a land card or Elf card from your graveyard to your hand. If you can't, draw a card. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -23877,7 +23877,7 @@
         },
         {
             "id": "e805b7e0-1c10-5d52-9a99-8f6c37b8a5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9c52ec-5ca1-43d9-85bf-6f2c515a6151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9c52ec-5ca1-43d9-85bf-6f2c515a6151.jpg?1",
             "name": "Rosethorn Halberd",
             "text": "When Rosethorn Halberd enters the battlefield, attach it to target non-Human creature you control.\nEquipped creature gets +2/+1.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -23910,7 +23910,7 @@
         },
         {
             "id": "6aa480c9-a679-5f05-b9ae-a667a084eaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39db8020-86a6-4ff2-8715-654121c2f3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39db8020-86a6-4ff2-8715-654121c2f3a2.jpg?1",
             "name": "Savage Punch",
             "text": "Target creature you control fights target creature you don't control.\nFerocious \u2014 The creature you control gets +2/+2 until end of turn before it fights if you control a creature with power 4 or greater. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -23941,7 +23941,7 @@
         },
         {
             "id": "6b93ecca-5810-53be-b1ef-cf8820a9a9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f2f01-ff8f-48db-8bad-cb0eba2346d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f2f01-ff8f-48db-8bad-cb0eba2346d1.jpg?1",
             "name": "Scale the Heights",
             "text": "Put a +1/+1 counter on up to one target creature. You gain 2 life. You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -23972,7 +23972,7 @@
         },
         {
             "id": "288ada96-3b03-5c0d-ab6f-1b56114bc974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709bf1f-9bbb-4da7-a1ea-7deb94858b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709bf1f-9bbb-4da7-a1ea-7deb94858b8c.jpg?1",
             "name": "Scion Summoner",
             "text": "Devoid (This card has no color.)\nWhen Scion Summoner enters the battlefield, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -24004,7 +24004,7 @@
         },
         {
             "id": "231b75d4-27d7-56a7-8984-ad9d604599a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f050b4-ae64-47ae-8e55-047e7a588d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f050b4-ae64-47ae-8e55-047e7a588d9c.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -24038,7 +24038,7 @@
         },
         {
             "id": "48c4652a-f5fa-578f-8374-866364ac98c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1091-01bd-4540-8681-344085b5ff84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1091-01bd-4540-8681-344085b5ff84.jpg?1",
             "name": "Servant of the Scale",
             "text": "Servant of the Scale enters the battlefield with a +1/+1 counter on it.\nWhen Servant of the Scale dies, put X +1/+1 counters on target creature you control, where X is the number of +1/+1 counters on Servant of the Scale.",
             "colours": [
@@ -24072,7 +24072,7 @@
         },
         {
             "id": "dad769f3-0c82-55bb-8f74-ad699af341a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49463346-99b6-422f-9577-34873dd13d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49463346-99b6-422f-9577-34873dd13d36.jpg?1",
             "name": "Silverback Shaman",
             "text": "Trample\nWhen Silverback Shaman dies, draw a card.",
             "colours": [
@@ -24106,7 +24106,7 @@
         },
         {
             "id": "5343629e-f495-52c5-aeaf-a80fd845645a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20f5455-70ac-416c-8cf4-021b41e51a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20f5455-70ac-416c-8cf4-021b41e51a7e.jpg?1",
             "name": "Simian Brawler",
             "text": "Discard a land card: Simian Brawler gets +1/+1 until end of turn.",
             "colours": [
@@ -24140,7 +24140,7 @@
         },
         {
             "id": "2c1c129a-56b6-524a-872a-26c08d48fc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062c430-c8a4-4f35-83b5-21519b6c0edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062c430-c8a4-4f35-83b5-21519b6c0edc.jpg?1",
             "name": "Snapping Gnarlid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Snapping Gnarlid gets +1/+1 until end of turn.",
             "colours": [
@@ -24173,7 +24173,7 @@
         },
         {
             "id": "9632036d-d83a-5e15-b629-3816b562007c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a912a5-8318-4cb3-aa62-6f826eaeb22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a912a5-8318-4cb3-aa62-6f826eaeb22b.jpg?1",
             "name": "Soul's Might",
             "text": "Put X +1/+1 counters on target creature, where X is that creature's power.",
             "colours": [
@@ -24204,7 +24204,7 @@
         },
         {
             "id": "03a7737c-6081-5321-9d2b-63c64186929a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37992e3-93b9-4c9d-b9a3-99c38df7464b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37992e3-93b9-4c9d-b9a3-99c38df7464b.jpg?1",
             "name": "Sporeback Wolf",
             "text": "As long as it's your turn, Sporeback Wolf gets +0/+2.",
             "colours": [
@@ -24237,7 +24237,7 @@
         },
         {
             "id": "364e71b7-3508-5fa6-8c42-d24675877bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301cb90-5b50-4ea6-968c-3641baccb140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301cb90-5b50-4ea6-968c-3641baccb140.jpg?1",
             "name": "Stalking Drone",
             "text": "Devoid (This card has no color.)\n{C}: Stalking Drone gets +1/+2 until end of turn. Activate only once each turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -24269,7 +24269,7 @@
         },
         {
             "id": "34e7fdf8-19ca-5570-8d2b-254576a683b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ccad14-ec2b-4235-a917-c0355c16599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ccad14-ec2b-4235-a917-c0355c16599a.jpg?1",
             "name": "Swarm Shambler",
             "text": "Swarm Shambler enters the battlefield with a +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.\n{1}, {T}: Put a +1/+1 counter on Swarm Shambler.",
             "colours": [
@@ -24303,7 +24303,7 @@
         },
         {
             "id": "28cb4dce-216b-5f7a-9d8f-c43c144baaed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d6534c-c77d-4d58-ab9a-a4897ca17e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d6534c-c77d-4d58-ab9a-a4897ca17e6a.jpg?1",
             "name": "Titanic Brawl",
             "text": "This spell costs {1} less to cast if it targets a creature you control with a +1/+1 counter on it.\nTarget creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -24334,7 +24334,7 @@
         },
         {
             "id": "32e83893-5f84-5e89-b737-a8184b6b1113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee515542-a636-45bf-a63a-04ffcf2b23c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee515542-a636-45bf-a63a-04ffcf2b23c6.jpg?1",
             "name": "Turntimber Basilisk",
             "text": "Deathtouch\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target creature block Turntimber Basilisk this turn if able.",
             "colours": [
@@ -24367,7 +24367,7 @@
         },
         {
             "id": "2d298f5a-723f-521a-ab68-dc298f7d75bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3785a6d2-4120-4190-b398-d63ab1eb36fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3785a6d2-4120-4190-b398-d63ab1eb36fe.jpg?1",
             "name": "Unnatural Aggression",
             "text": "Devoid (This card has no color.)\nTarget creature you control fights target creature an opponent controls. If the creature an opponent controls would die this turn, exile it instead. (Creatures that fight each deal damage equal to their power to the other.)",
             "colours": [],
@@ -24396,7 +24396,7 @@
         },
         {
             "id": "fefc2c50-610e-5670-921a-419dd6731b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ab77b-cd98-4889-afcc-884940999d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ab77b-cd98-4889-afcc-884940999d48.jpg?1",
             "name": "Wildborn Preserver",
             "text": "Flash\nReach\nWhenever another non-Human creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on Wildborn Preserver.",
             "colours": [
@@ -24430,7 +24430,7 @@
         },
         {
             "id": "af6cd4c4-de5c-5211-a40e-d2f50c699bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4fe963-5bf3-473a-afbd-0b93f5791279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4fe963-5bf3-473a-afbd-0b93f5791279.jpg?1",
             "name": "Wily Bandar",
             "text": "{2}{G}: Wily Bandar gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -24464,7 +24464,7 @@
         },
         {
             "id": "59747f7e-30ba-53ed-b7e8-2c2dc11ccdab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2f778-2ad0-4b80-9296-f37c6090f8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2f778-2ad0-4b80-9296-f37c6090f8ff.jpg?1",
             "name": "Wolf's Quarry",
             "text": "Create three 1/1 green Boar creature tokens with \"When this creature dies, create a Food token.\" (A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -24495,7 +24495,7 @@
         },
         {
             "id": "f6baebec-efe5-5367-bf32-607cbaf4e660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40101dc6-4354-4f0a-aa90-946ed78d731e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40101dc6-4354-4f0a-aa90-946ed78d731e.jpg?1",
             "name": "Wolfkin Bond",
             "text": "Enchant creature\nWhen Wolfkin Bond enters the battlefield, create a 2/2 green Wolf creature token.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -24528,7 +24528,7 @@
         },
         {
             "id": "7feba69a-ee66-5425-b006-f530465bdd01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d135a17-2d93-41d9-be1d-80aa55f1050a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d135a17-2d93-41d9-be1d-80aa55f1050a.jpg?1",
             "name": "Wolfwillow Haven",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.\n{4}{G}, Sacrifice Wolfwillow Haven: Create a 2/2 green Wolf creature token. Activate only during your turn.",
             "colours": [
@@ -24561,7 +24561,7 @@
         },
         {
             "id": "5118fa0b-3d27-54c8-9274-b33979415022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575d407c-c37e-4664-b2e3-217dfd5a78a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575d407c-c37e-4664-b2e3-217dfd5a78a2.jpg?1",
             "name": "Wolverine Riders",
             "text": "At the beginning of each upkeep, create a 1/1 green Elf Warrior creature token.\nWhenever another Elf enters the battlefield under your control, you gain life equal to its toughness.",
             "colours": [
@@ -24595,7 +24595,7 @@
         },
         {
             "id": "bf4d9218-56ef-5a11-acb1-f07013d43c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f887474-760c-4f33-8051-35b9d2e65307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f887474-760c-4f33-8051-35b9d2e65307.jpg?1",
             "name": "Woodborn Behemoth",
             "text": "As long as you control eight or more lands, Woodborn Behemoth gets +4/+4 and has trample.",
             "colours": [
@@ -24628,7 +24628,7 @@
         },
         {
             "id": "8a6df0af-b79c-5395-9168-3009f4d9b899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c0f16f-55c5-4334-bcec-08bf46d71d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c0f16f-55c5-4334-bcec-08bf46d71d88.jpg?1",
             "name": "Woodland Champion",
             "text": "Whenever one or more tokens enter the battlefield under your control, put that many +1/+1 counters on Woodland Champion.",
             "colours": [
@@ -24662,7 +24662,7 @@
         },
         {
             "id": "76dd4de4-ae74-5d30-b8e5-8a20672bd895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dccb5f-dca4-44d1-bbbf-a84dd016fbb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dccb5f-dca4-44d1-bbbf-a84dd016fbb1.jpg?1",
             "name": "Young Wolf",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -24695,7 +24695,7 @@
         },
         {
             "id": "a77bf30b-bc2e-5b01-aa69-3e775bc6b3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0768ee-aa58-48ca-91e8-64332af5dcfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0768ee-aa58-48ca-91e8-64332af5dcfe.jpg?1",
             "name": "Zendikar's Roil",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 2/2 green Elemental creature token.",
             "colours": [
@@ -24726,7 +24726,7 @@
         },
         {
             "id": "8e2c465d-3654-59ad-872b-f11ca3ac01e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ee3947-e147-4d04-bb01-161a72ffdf0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ee3947-e147-4d04-bb01-161a72ffdf0e.jpg?1",
             "name": "Endbringer",
             "text": "Untap Endbringer during each other player's untap step.\n{T}: Endbringer deals 1 damage to any target.\n{C}, {T}: Target creature can't attack or block this turn.\n{C}{C}, {T}: Draw a card.",
             "colours": [],
@@ -24755,7 +24755,7 @@
         },
         {
             "id": "388cbef6-9d0f-52c4-98d0-a7b716c92988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca258b-981f-4762-a398-ae8de81f6713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca258b-981f-4762-a398-ae8de81f6713.jpg?1",
             "name": "Titan's Presence",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
             "colours": [],
@@ -24782,7 +24782,7 @@
         },
         {
             "id": "cc9c0fd0-d6c5-5cfa-8381-07f40e69d7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c06a62-ae48-4732-94d8-659917201726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c06a62-ae48-4732-94d8-659917201726.jpg?1",
             "name": "Warden of Geometries",
             "text": "Vigilance\n{T}: Add {C}. ({C} represents colorless mana.)",
             "colours": [],
@@ -24812,7 +24812,7 @@
         },
         {
             "id": "869124e7-1ecd-5712-9e3d-496a2a44e14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7493ccb-98a1-4032-9e01-5535d29e106b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7493ccb-98a1-4032-9e01-5535d29e106b.jpg?1",
             "name": "Adventuring Gear",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -24841,7 +24841,7 @@
         },
         {
             "id": "6fb877a3-c4bd-50fa-9ac2-252099306414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee539bda-62b4-40fb-95d3-c7d1fc0a7e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee539bda-62b4-40fb-95d3-c7d1fc0a7e09.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice Aether Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice Aether Spellbomb: Draw a card.",
             "colours": [],
@@ -24870,7 +24870,7 @@
         },
         {
             "id": "2cb892be-cb66-512f-8f6f-8da5469573cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d22523a-bb2d-489d-994e-65455def4fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d22523a-bb2d-489d-994e-65455def4fc5.jpg?1",
             "name": "Alchemist's Vial",
             "text": "When Alchemist's Vial enters the battlefield, draw a card.\n{1}, {T}, Sacrifice Alchemist's Vial: Target creature can't attack or block this turn.",
             "colours": [],
@@ -24897,7 +24897,7 @@
         },
         {
             "id": "a866000b-b1f1-5159-8074-58bc67ea3d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28fa0c-5c88-40cd-8295-8d56c76a7938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28fa0c-5c88-40cd-8295-8d56c76a7938.jpg?1",
             "name": "Aradara Express",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -24926,7 +24926,7 @@
         },
         {
             "id": "318b1c56-af64-5f40-a60a-063b1ef63c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af30619-272f-4574-a9cf-f2e83167ac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af30619-272f-4574-a9cf-f2e83167ac35.jpg?1",
             "name": "Assembly-Worker",
             "text": "{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -24956,7 +24956,7 @@
         },
         {
             "id": "ea80de57-0905-5bd2-83a1-2095869e8d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e799bd-87c7-4f62-87a9-6f8f8d459db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e799bd-87c7-4f62-87a9-6f8f8d459db8.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -24983,7 +24983,7 @@
         },
         {
             "id": "7606f3f7-a808-5f4d-81c2-3cae5ec4c1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69696834-d306-4431-9279-37143c9ac00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69696834-d306-4431-9279-37143c9ac00a.jpg?1",
             "name": "Bloodline Pretender",
             "text": "Changeling (This card is every creature type.)\nAs Bloodline Pretender enters the battlefield, choose a creature type.\nWhenever another creature of the chosen type enters the battlefield under your control, put a +1/+1 counter on Bloodline Pretender.",
             "colours": [],
@@ -25013,7 +25013,7 @@
         },
         {
             "id": "5f0478c7-1ae6-59fe-b46f-876518e49ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7655790-d091-47d6-8387-08bfa4333f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7655790-d091-47d6-8387-08bfa4333f19.jpg?1",
             "name": "Campus Guide",
             "text": "When Campus Guide enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -25043,7 +25043,7 @@
         },
         {
             "id": "ef9dab8d-58a2-5c4b-b64c-f4f69f6379d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b217c-c3d4-4cdb-9ee7-2cf7c8d0eb7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b217c-c3d4-4cdb-9ee7-2cf7c8d0eb7b.jpg?1",
             "name": "Cellar Door",
             "text": "{3}, {T}: Target player puts the bottom card of their library into their graveyard. If it's a creature card, you create a 2/2 black Zombie creature token.",
             "colours": [],
@@ -25070,7 +25070,7 @@
         },
         {
             "id": "d1a14288-8f6d-5907-8f3b-10d596b29eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6fc201-9365-40be-bc59-f3715fd3d15d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6fc201-9365-40be-bc59-f3715fd3d15d.jpg?1",
             "name": "Circuit Mender",
             "text": "When Circuit Mender enters the battlefield, you gain 2 life.\nWhen Circuit Mender leaves the battlefield, draw a card.",
             "colours": [],
@@ -25100,7 +25100,7 @@
         },
         {
             "id": "e0590b02-514c-5868-8b68-7b0f518bc008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7c162-4c29-481c-8157-a2bd04760225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7c162-4c29-481c-8157-a2bd04760225.jpg?1",
             "name": "Cogwork Assembler",
             "text": "{7}: Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -25130,7 +25130,7 @@
         },
         {
             "id": "3c71ff50-ac81-5f35-b90b-7591d2652d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aed32a2-01db-4416-bd27-666f3abe04a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aed32a2-01db-4416-bd27-666f3abe04a1.jpg?1",
             "name": "Dragon Blood",
             "text": "{3}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -25157,7 +25157,7 @@
         },
         {
             "id": "f1096b64-3cc3-5c4b-b881-4b46b6a9655f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48e23fe-f0ed-4c5a-b90b-30cf096a9d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48e23fe-f0ed-4c5a-b90b-30cf096a9d02.jpg?1",
             "name": "Dragon's Hoard",
             "text": "Whenever a Dragon enters the battlefield under your control, put a gold counter on Dragon's Hoard.\n{T}, Remove a gold counter from Dragon's Hoard: Draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -25184,7 +25184,7 @@
         },
         {
             "id": "0bedc91d-0f1d-5d95-8794-ba172d7726b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7807f8ba-f597-4567-98c4-7086df7ab92c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7807f8ba-f597-4567-98c4-7086df7ab92c.jpg?1",
             "name": "Edifice of Authority",
             "text": "{1}, {T}: Target creature can't attack this turn. Put a brick counter on Edifice of Authority.\n{1}, {T}: Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate only if there are three or more brick counters on Edifice of Authority.",
             "colours": [],
@@ -25211,7 +25211,7 @@
         },
         {
             "id": "9a3f852c-0b54-56c4-91b5-c5ee4eaf7e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02f3e9-7bee-486c-9f19-9fac52c93418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02f3e9-7bee-486c-9f19-9fac52c93418.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -25238,7 +25238,7 @@
         },
         {
             "id": "41ed8611-f5e3-5072-9e10-9ca0425fb5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f614775-1c15-4eeb-8405-a829d5eccafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f614775-1c15-4eeb-8405-a829d5eccafe.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25267,7 +25267,7 @@
         },
         {
             "id": "e1104cb6-49dd-5f37-9762-6c7aedb11cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a89661-47a3-4827-8c60-532c3934aa45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a89661-47a3-4827-8c60-532c3934aa45.jpg?1",
             "name": "Gearsmith Guardian",
             "text": "Gearsmith Guardian gets +2/+0 as long as you control a blue creature.",
             "colours": [],
@@ -25297,7 +25297,7 @@
         },
         {
             "id": "f2fa5815-bad0-547f-a842-bb31816bc0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen Gleaming Barrier dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -25327,7 +25327,7 @@
         },
         {
             "id": "90fb9d99-14ef-58e0-9f31-d4dc7eb3c2a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd33b5fc-9901-493b-8d7f-5e98223fdcad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd33b5fc-9901-493b-8d7f-5e98223fdcad.jpg?1",
             "name": "Goldvein Pick",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25356,7 +25356,7 @@
         },
         {
             "id": "e9a8f5f5-230b-58d4-a8ce-8a779b829f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a673d71-58a5-4cd4-b9bc-d7819269d693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a673d71-58a5-4cd4-b9bc-d7819269d693.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -25386,7 +25386,7 @@
         },
         {
             "id": "7d839020-e5f1-5845-90e4-33287e6d01b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09e0f4-87d9-46ef-a45e-2036a2779b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09e0f4-87d9-46ef-a45e-2036a2779b48.jpg?1",
             "name": "Hammer of Ruin",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, you may destroy target Equipment that player controls.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25415,7 +25415,7 @@
         },
         {
             "id": "db4286f9-7b49-5018-a967-b1dfa213785d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b2624-0396-4576-aedc-2b7980f76241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b2624-0396-4576-aedc-2b7980f76241.jpg?1",
             "name": "Hangarback Walker",
             "text": "Hangarback Walker enters the battlefield with X +1/+1 counters on it.\nWhen Hangarback Walker dies, create a 1/1 colorless Thopter artifact creature token with flying for each +1/+1 counter on Hangarback Walker.\n{1}, {T}: Put a +1/+1 counter on Hangarback Walker.",
             "colours": [],
@@ -25445,7 +25445,7 @@
         },
         {
             "id": "6cedb91f-4a7e-585a-a7d5-b3bff93d6296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e9077e-084c-4146-8330-567f815bd3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e9077e-084c-4146-8330-567f815bd3d9.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25474,7 +25474,7 @@
         },
         {
             "id": "6f53d355-8c51-57cc-ba74-fff59902ad97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d324d-3576-4f1a-9025-db84703ef10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d324d-3576-4f1a-9025-db84703ef10f.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -25501,7 +25501,7 @@
         },
         {
             "id": "de9edba5-6eda-50cb-865b-47920f6e3e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a1fdeb-3569-4c2e-81ab-f746e08527eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a1fdeb-3569-4c2e-81ab-f746e08527eb.jpg?1",
             "name": "Heirloom Blade",
             "text": "Equipped creature gets +3/+1.\nWhenever equipped creature dies, you may reveal cards from the top of your library until you reveal a creature card that shares a creature type with it. Put that card into your hand and the rest on the bottom of your library in a random order.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25530,7 +25530,7 @@
         },
         {
             "id": "8d97c56e-273f-5c25-a1e8-17fdac4fb416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b342fb32-d1a0-4fb3-9765-af7674bc6628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b342fb32-d1a0-4fb3-9765-af7674bc6628.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25559,7 +25559,7 @@
         },
         {
             "id": "3caae4ab-c4de-57b7-9d43-1c16ad47f930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e59c9b-5959-4e44-b09b-d378b3b39021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e59c9b-5959-4e44-b09b-d378b3b39021.jpg?1",
             "name": "Infiltration Lens",
             "text": "Whenever equipped creature becomes blocked by a creature, you may draw two cards.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25588,7 +25588,7 @@
         },
         {
             "id": "acb7e0c8-f166-5290-8873-1e7e091a7c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fd4e1d-359c-46b3-ae99-50a4b90b3032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fd4e1d-359c-46b3-ae99-50a4b90b3032.jpg?1",
             "name": "Iron Bully",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Iron Bully enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -25618,7 +25618,7 @@
         },
         {
             "id": "2e87fdbb-9b9f-5179-b186-de1e8e18380f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060518c9-a76c-410e-8a90-fc1d24747f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060518c9-a76c-410e-8a90-fc1d24747f74.jpg?1",
             "name": "Jousting Lance",
             "text": "Equipped creature gets +2/+0.\nAs long as it's your turn, equipped creature has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25647,7 +25647,7 @@
         },
         {
             "id": "3a5a49fd-1476-5be4-8fee-3aafdac4256f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9510b0-925d-49f4-8237-d634f66230bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9510b0-925d-49f4-8237-d634f66230bd.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -25677,7 +25677,7 @@
         },
         {
             "id": "5d72d4b0-d627-5a2e-b9e5-d647b253d3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557dc342-b265-4370-969e-ecb9de5bc01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557dc342-b265-4370-969e-ecb9de5bc01d.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25706,7 +25706,7 @@
         },
         {
             "id": "2274ea99-ffba-5fa0-a679-40ecddee64e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f30adfa-2581-47ca-946f-d1a193523be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f30adfa-2581-47ca-946f-d1a193523be3.jpg?1",
             "name": "Leonin Scimitar",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25735,7 +25735,7 @@
         },
         {
             "id": "a91b1fee-a704-5814-9c7f-7737917d809f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372b3c3a-ed78-43a1-b117-9e2793d77bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372b3c3a-ed78-43a1-b117-9e2793d77bbc.jpg?1",
             "name": "Locthwain Gargoyle",
             "text": "{4}: Locthwain Gargoyle gets +2/+0 and gains flying until end of turn.",
             "colours": [],
@@ -25765,7 +25765,7 @@
         },
         {
             "id": "f6eff2e9-4ca7-5369-b4c3-5460bbe7e733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca896a-6f1e-4235-a725-aa5d57c06181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca896a-6f1e-4235-a725-aa5d57c06181.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0 and has trample and lifelink.\nEquip {3}",
             "colours": [],
@@ -25794,7 +25794,7 @@
         },
         {
             "id": "f90dd507-2daa-5719-bb8a-af5e623f1b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990b3d4-50cd-4c54-9068-5403796ab394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990b3d4-50cd-4c54-9068-5403796ab394.jpg?1",
             "name": "Manakin",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -25824,7 +25824,7 @@
         },
         {
             "id": "948cf873-ee6f-5aaa-b85f-c347e9aa7043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cda05e-a1c8-451f-9d1f-b47b4e2b1e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cda05e-a1c8-451f-9d1f-b47b4e2b1e95.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -25854,7 +25854,7 @@
         },
         {
             "id": "f7a92935-0b07-5ea7-a7ef-826d988afe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97a43ed-f69a-435c-8ede-62e664f60ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97a43ed-f69a-435c-8ede-62e664f60ee0.jpg?1",
             "name": "Monkey Cage",
             "text": "When a creature enters the battlefield, sacrifice Monkey Cage and create X 2/2 green Monkey creature tokens, where X is that creature's mana value.",
             "colours": [],
@@ -25881,7 +25881,7 @@
         },
         {
             "id": "3824cce9-3fbd-55d0-850c-1727a075c17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d1335e-f83e-41f6-b125-a906cee67af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d1335e-f83e-41f6-b125-a906cee67af8.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -25908,7 +25908,7 @@
         },
         {
             "id": "4db1dbf4-67ea-51b1-8860-28bd50694a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b504fd00-f71d-4675-8f11-b19ea7b27739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b504fd00-f71d-4675-8f11-b19ea7b27739.jpg?1",
             "name": "Phyrexian Ironfoot",
             "text": "Phyrexian Ironfoot doesn't untap during your untap step.\n{1}{S}: Untap Phyrexian Ironfoot. ({S} can be paid with one mana from a snow source.)",
             "colours": [],
@@ -25941,7 +25941,7 @@
         },
         {
             "id": "2c7e41b4-1180-575a-a867-f1792cf60eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d2ea2-54b1-4274-992b-c8f0b0206ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d2ea2-54b1-4274-992b-c8f0b0206ca1.jpg?1",
             "name": "Pierce Strider",
             "text": "When Pierce Strider enters the battlefield, target opponent loses 3 life.",
             "colours": [],
@@ -25972,7 +25972,7 @@
         },
         {
             "id": "a413fd7a-5e44-5f9c-8825-b02cd5e54fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ec1dd3-cc5c-4bd1-b9a8-b3035e67a290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ec1dd3-cc5c-4bd1-b9a8-b3035e67a290.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -26002,7 +26002,7 @@
         },
         {
             "id": "3783a8d1-96df-5550-b2a1-2411307bbaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94609a6-ae39-4770-9ff1-9e483102a8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94609a6-ae39-4770-9ff1-9e483102a8df.jpg?1",
             "name": "Psychosis Crawler",
             "text": "Psychosis Crawler's power and toughness are each equal to the number of cards in your hand.\nWhenever you draw a card, each opponent loses 1 life.",
             "colours": [],
@@ -26033,7 +26033,7 @@
         },
         {
             "id": "67ba1a01-0083-5bbf-93f3-6a8921d8977e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd47aa1a-d398-460e-b95c-b903297468d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd47aa1a-d398-460e-b95c-b903297468d6.jpg?1",
             "name": "Raiders' Karve",
             "text": "Whenever Raiders' Karve attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -26062,7 +26062,7 @@
         },
         {
             "id": "16e272ab-a08f-5381-9a43-268fb85fc7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb77b0ac-7e6a-4411-8b3c-c43b55439361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb77b0ac-7e6a-4411-8b3c-c43b55439361.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -26092,7 +26092,7 @@
         },
         {
             "id": "f112dee9-83c5-52d5-a2e3-c99d31cd5caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e77f29-8ce1-4a18-871c-d69853bfd9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e77f29-8ce1-4a18-871c-d69853bfd9db.jpg?1",
             "name": "Self-Assembler",
             "text": "When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -26122,7 +26122,7 @@
         },
         {
             "id": "a4a0f134-2346-55a2-a538-a908f45508f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d73e18d-ad7a-4b6a-829e-43f58b70afbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d73e18d-ad7a-4b6a-829e-43f58b70afbc.jpg?1",
             "name": "Shambling Suit",
             "text": "Shambling Suit's power is equal to the number of artifacts and/or enchantments you control.",
             "colours": [],
@@ -26152,7 +26152,7 @@
         },
         {
             "id": "53ecb78e-cfd4-5a9a-9c7c-b2302632d880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f8e1cd-8f4d-4bc7-a400-bbee02260ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f8e1cd-8f4d-4bc7-a400-bbee02260ab0.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -26182,7 +26182,7 @@
         },
         {
             "id": "6a84241c-541a-59e5-bf05-2eb2d9a477c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e51fec0-0412-48d8-ad33-538075248abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e51fec0-0412-48d8-ad33-538075248abb.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -26212,7 +26212,7 @@
         },
         {
             "id": "87225bc6-9434-5432-b5d4-4df3bb647048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1ff17a-7a30-42b1-a299-1219d4309407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1ff17a-7a30-42b1-a299-1219d4309407.jpg?1",
             "name": "Talon of Pain",
             "text": "Whenever a source you control other than Talon of Pain deals damage to an opponent, put a charge counter on Talon of Pain.\n{X}, {T}, Remove X charge counters from Talon of Pain: It deals X damage to any target.",
             "colours": [],
@@ -26239,7 +26239,7 @@
         },
         {
             "id": "78284847-a173-59c2-b172-c58ebd089b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b623e860-febb-4e30-9423-e8b1fadd5ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b623e860-febb-4e30-9423-e8b1fadd5ee2.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "At the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{T}, Sacrifice three Clues: Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [],
@@ -26268,7 +26268,7 @@
         },
         {
             "id": "b460f622-17fc-51ad-a618-16336b91877a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c98eb-3b75-43c3-843c-25fb93c1b8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c98eb-3b75-43c3-843c-25fb93c1b8af.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in their hand on the bottom of their library in any order, then draws that many cards. (That player draws their card for the turn first.)",
             "colours": [],
@@ -26295,7 +26295,7 @@
         },
         {
             "id": "3fd32f9a-af8a-5d6b-8507-aeff72b63b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1858f5-16b8-4a58-8f31-b60f926fdbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1858f5-16b8-4a58-8f31-b60f926fdbf8.jpg?1",
             "name": "Thaumaturge's Familiar",
             "text": "Flying\nWhen Thaumaturge's Familiar enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -26325,7 +26325,7 @@
         },
         {
             "id": "4319a40e-7aba-5688-ac18-bd692c113be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16ddbcb-b28d-4a67-857b-5c30ccf055f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16ddbcb-b28d-4a67-857b-5c30ccf055f0.jpg?1",
             "name": "Universal Automaton",
             "text": "Changeling (This card is every creature type.)",
             "colours": [],
@@ -26355,7 +26355,7 @@
         },
         {
             "id": "2300cefd-75f7-5345-901c-45d436db6c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db05aef5-07b4-46d3-bad7-6568c00b2aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db05aef5-07b4-46d3-bad7-6568c00b2aef.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -26382,7 +26382,7 @@
         },
         {
             "id": "825b54e9-f293-52f8-b906-0b3308692769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eca56b1-0e1f-4473-a427-fba3f8200b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eca56b1-0e1f-4473-a427-fba3f8200b2e.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.",
             "colours": [],
@@ -26409,7 +26409,7 @@
         },
         {
             "id": "67b10c80-d3a8-5289-977d-ef88fd681283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c353a09f-8a5a-41ce-97dc-60e7350460c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c353a09f-8a5a-41ce-97dc-60e7350460c0.jpg?1",
             "name": "Walking Ballista",
             "text": "Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to any target.",
             "colours": [],
@@ -26439,7 +26439,7 @@
         },
         {
             "id": "3a27890b-ee1c-5b84-a9f1-de1e3a2d030a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6baaf6-832c-4352-8b7b-872ca559fe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6baaf6-832c-4352-8b7b-872ca559fe3b.jpg?1",
             "name": "Weapon Rack",
             "text": "Weapon Rack enters the battlefield with three +1/+1 counters on it.\n{T}: Move a +1/+1 counter from Weapon Rack onto target creature. Activate only as a sorcery.",
             "colours": [],
@@ -26466,7 +26466,7 @@
         },
         {
             "id": "44510db6-a20f-56cc-a0fc-0c093b1d1c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e02966-ff20-4e5e-b27d-adc6156c802d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e02966-ff20-4e5e-b27d-adc6156c802d.jpg?1",
             "name": "Whirlermaker",
             "text": "{4}, {T}: Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [],
@@ -26493,7 +26493,7 @@
         },
         {
             "id": "a28f4c79-d3ed-5461-89a7-23b8b012f944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b20e63c-f9fa-46c0-a3f8-30ea70e07fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b20e63c-f9fa-46c0-a3f8-30ea70e07fc6.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -26520,7 +26520,7 @@
         },
         {
             "id": "f7b24301-81fc-5f8a-a085-47353122966f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09994b67-4b83-4b23-834b-73bae87e8272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09994b67-4b83-4b23-834b-73bae87e8272.jpg?1",
             "name": "Blighted Fen",
             "text": "{T}: Add {C}.\n{4}{B}, {T}, Sacrifice Blighted Fen: Target opponent sacrifices a creature.",
             "colours": [],
@@ -26549,7 +26549,7 @@
         },
         {
             "id": "c6d76caa-c21f-57ba-a148-aa4de53d29ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f06a2-9d89-4cf7-aa4c-fe7ca4163511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f06a2-9d89-4cf7-aa4c-fe7ca4163511.jpg?1",
             "name": "Bonders' Enclave",
             "text": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater.",
             "colours": [],
@@ -26576,7 +26576,7 @@
         },
         {
             "id": "4dad9a47-2f12-591d-8fb8-e8d329ff9a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf14f8a-373b-4244-9427-a5a3224bf21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf14f8a-373b-4244-9427-a5a3224bf21f.jpg?1",
             "name": "Desert of the Mindful",
             "text": "Desert of the Mindful enters the battlefield tapped.\n{T}: Add {U}.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -26607,7 +26607,7 @@
         },
         {
             "id": "9eb2d879-e8ce-55af-a6db-aab46a41fa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a27ba-bd56-4f07-bd29-260180bd5eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a27ba-bd56-4f07-bd29-260180bd5eb0.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -26634,7 +26634,7 @@
         },
         {
             "id": "19b1f5e0-c8d6-5d55-8767-ff33650ae980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501d59-b253-4449-966f-8922803d84a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501d59-b253-4449-966f-8922803d84a0.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave enters the battlefield tapped.\n{T}: Add {R}.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -26663,7 +26663,7 @@
         },
         {
             "id": "f0faf9b0-d74b-538a-aa63-155ea80d4771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238a5103-6688-4fe5-ab93-b949afd0c2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238a5103-6688-4fe5-ab93-b949afd0c2ca.jpg?1",
             "name": "Memorial to Genius",
             "text": "Memorial to Genius enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards.",
             "colours": [],
@@ -26692,7 +26692,7 @@
         },
         {
             "id": "d751e5c9-51cf-5003-9ef3-f0b51278a448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f292de-238a-4b19-a6da-f164158b79dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f292de-238a-4b19-a6da-f164158b79dc.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -26719,7 +26719,7 @@
         },
         {
             "id": "025330d7-0a19-54e3-b000-b61fc24d0ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c237554-e345-474a-88db-faf628ba6667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c237554-e345-474a-88db-faf628ba6667.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.\n{T}: Add {B}.",
             "colours": [],
@@ -26748,7 +26748,7 @@
         },
         {
             "id": "831127e0-acd9-585e-a685-57497c57954c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9332ac39-1a34-42e2-9c84-645cbf1721cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9332ac39-1a34-42e2-9c84-645cbf1721cf.jpg?1",
             "name": "Piranha Marsh",
             "text": "Piranha Marsh enters the battlefield tapped.\nWhen Piranha Marsh enters the battlefield, target player loses 1 life.\n{T}: Add {B}.",
             "colours": [],
@@ -26777,7 +26777,7 @@
         },
         {
             "id": "aff9670e-ae7b-54e1-be57-d2041e7b3cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb3d37e-5118-405a-906d-529ec1d90dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb3d37e-5118-405a-906d-529ec1d90dce.jpg?1",
             "name": "Sandstone Bridge",
             "text": "Sandstone Bridge enters the battlefield tapped.\nWhen Sandstone Bridge enters the battlefield, target creature gets +1/+1 and gains vigilance until end of turn.\n{T}: Add {W}.",
             "colours": [],
@@ -26806,7 +26806,7 @@
         },
         {
             "id": "73c74309-e0f4-5f84-8ff9-37ecf3508b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0633d38e-de0b-4f14-abbb-ac9260887c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0633d38e-de0b-4f14-abbb-ac9260887c4d.jpg?1",
             "name": "Seat of the Synod",
             "text": "{T}: Add {U}.",
             "colours": [],
@@ -26836,7 +26836,7 @@
         },
         {
             "id": "cdf44c36-19c3-52b0-b301-6e0eeb8a991a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a5b62-f0db-41de-b3f4-aa6d7a51d376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a5b62-f0db-41de-b3f4-aa6d7a51d376.jpg?1",
             "name": "Shimmerdrift Vale",
             "text": "Shimmerdrift Vale enters the battlefield tapped.\nAs Shimmerdrift Vale enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -26865,7 +26865,7 @@
         },
         {
             "id": "370b63bb-41ee-5e90-94c1-ec3dabf5afe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3593aa-e33c-4482-a0bb-c843ac70a824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3593aa-e33c-4482-a0bb-c843ac70a824.jpg?1",
             "name": "Thriving Bluff",
             "text": "Thriving Bluff enters the battlefield tapped.\nAs Thriving Bluff enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -26894,7 +26894,7 @@
         },
         {
             "id": "da0d956f-c612-5cc9-a850-a87e8c2a20a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23829580-9ae9-41c1-9b58-aea07389110d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23829580-9ae9-41c1-9b58-aea07389110d.jpg?1",
             "name": "Thriving Grove",
             "text": "Thriving Grove enters the battlefield tapped.\nAs Thriving Grove enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -26923,7 +26923,7 @@
         },
         {
             "id": "a04e9563-a925-5006-9eff-d8d21379a5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa01378-4d7f-4700-9303-f0535468dc62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa01378-4d7f-4700-9303-f0535468dc62.jpg?1",
             "name": "Thriving Heath",
             "text": "Thriving Heath enters the battlefield tapped.\nAs Thriving Heath enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -26952,7 +26952,7 @@
         },
         {
             "id": "52c3e9b6-7653-5c90-9796-c3838f55dd98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464168e8-e11f-4826-a709-bf1e725ef62b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464168e8-e11f-4826-a709-bf1e725ef62b.jpg?1",
             "name": "Thriving Isle",
             "text": "Thriving Isle enters the battlefield tapped.\nAs Thriving Isle enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -26981,7 +26981,7 @@
         },
         {
             "id": "22a8fe67-ad5e-56fc-940e-cc5ea4e71f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26096a40-fc6a-42ce-acbf-ce0ebc4ad3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26096a40-fc6a-42ce-acbf-ce0ebc4ad3b4.jpg?1",
             "name": "Thriving Moor",
             "text": "Thriving Moor enters the battlefield tapped.\nAs Thriving Moor enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -27010,7 +27010,7 @@
         },
         {
             "id": "00db824d-2f12-59ea-8e5d-343b7debc0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d39df-aaab-4733-b7c4-f33c9b4fb10c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d39df-aaab-4733-b7c4-f33c9b4fb10c.jpg?1",
             "name": "Treetop Village",
             "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G}.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land.",
             "colours": [],
@@ -27039,7 +27039,7 @@
         },
         {
             "id": "1065e810-0498-5800-ad36-74f31d2a83e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d9f428-8ce0-4a73-ac38-2dcbdcf12584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d9f428-8ce0-4a73-ac38-2dcbdcf12584.jpg?1",
             "name": "Urza's Factory",
             "text": "{T}: Add {C}.\n{7}, {T}: Create a 2/2 colorless Assembly-Worker artifact creature token.",
             "colours": [],
@@ -27068,7 +27068,7 @@
         },
         {
             "id": "5dcaeb56-8991-5696-88ad-3c2199426741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1c8759-ec90-420b-b9c3-33515e91b705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1c8759-ec90-420b-b9c3-33515e91b705.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -27098,7 +27098,7 @@
         },
         {
             "id": "012d62c1-77f8-57c0-b522-c15e462c1800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ced23-1991-4335-9ead-83ae4a6d09cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ced23-1991-4335-9ead-83ae4a6d09cf.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -27128,7 +27128,7 @@
         },
         {
             "id": "7ad877e6-1ebc-5251-ad11-a1cf681a5ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba9d0e3-9ff3-4aeb-9de6-c7695d88a31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba9d0e3-9ff3-4aeb-9de6-c7695d88a31d.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -27158,7 +27158,7 @@
         },
         {
             "id": "8482240c-664d-5f6b-8af3-425cb53c8941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f4e5e-e83e-4ec8-8db0-259b85219b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f4e5e-e83e-4ec8-8db0-259b85219b89.jpg?1",
             "name": "Warped Landscape",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Warped Landscape: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -27185,7 +27185,7 @@
         },
         {
             "id": "dff3aea1-e7ea-5795-9d4d-317917c1ef4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6b4706-5452-4c50-872d-2d04f96407a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6b4706-5452-4c50-872d-2d04f96407a8.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -27219,7 +27219,7 @@
         },
         {
             "id": "d555be17-8953-5e74-811c-019a5c102229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef693d-7c48-46cb-8f52-abc660a2736e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef693d-7c48-46cb-8f52-abc660a2736e.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -27248,7 +27248,7 @@
         },
         {
             "id": "53a89e07-979b-5bb6-9a09-9b643b48ac2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da105c2f-017e-4df0-b45e-a9482c02a29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da105c2f-017e-4df0-b45e-a9482c02a29d.jpg?1",
             "name": "Kibo, Uktabi Prince",
             "text": "{T}: Each player creates a colorless artifact token named Banana with \"{T}, Sacrifice this artifact: Add {R} or {G}. You gain 2 life.\"\nWhenever an artifact an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on each creature you control that's an Ape or a Monkey.\nWhenever Kibo attacks, defending player sacrifices an artifact.",
             "colours": [

--- a/Assets/Resources/Sets/JMP.json
+++ b/Assets/Resources/Sets/JMP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3c466bee-9fe3-516b-aef0-2eef8e13c85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff80029e-650e-469d-8393-0edf7d9cd695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff80029e-650e-469d-8393-0edf7d9cd695.jpg?1",
             "name": "Blessed Sanctuary",
             "text": "Prevent all noncombat damage that would be dealt to you and creatures you control.\nWhenever a nontoken creature enters the battlefield under your control, create a 2/2 white Unicorn creature token.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "989ba589-6801-50d1-b111-12d126220d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc18921-59f5-413f-a221-dc47d31b2ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc18921-59f5-413f-a221-dc47d31b2ec8.jpg?1",
             "name": "Brightmare",
             "text": "When Brightmare enters the battlefield, tap up to one target creature. You gain life equal to that creature's power.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "1a0a7cd9-87cb-504a-a793-7883a233a9f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74dfd07-d17c-4890-82c3-4b12a6029940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74dfd07-d17c-4890-82c3-4b12a6029940.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead. ({RW} can be paid with either {G} or {W}.)",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "dfb02544-b29a-5982-8d20-f295ff76b001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9.jpg?1",
             "name": "Release the Dogs",
             "text": "Create four 1/1 white Dog creature tokens.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "e19db0d1-0058-589d-9a98-6669a4406e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbcb165-0a60-493a-8cbb-ba8b36c527da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbcb165-0a60-493a-8cbb-ba8b36c527da.jpg?1",
             "name": "Steel-Plume Marshal",
             "text": "Flying\nWhenever Steel-Plume Marshal attacks, other attacking creatures you control with flying get +2/+2 until end of turn.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "31f4b3c7-4979-5354-b7cd-2faaedd94bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd3287d-e4d8-4670-a2dd-b683055ae4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd3287d-e4d8-4670-a2dd-b683055ae4b9.jpg?1",
             "name": "Stone Haven Pilgrim",
             "text": "Whenever Stone Haven Pilgrim attacks, if you control an artifact or enchantment, Stone Haven Pilgrim gets +1/+1 and gains lifelink until end of turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "102443fd-8673-57cc-9664-91338718041c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c10c77-1446-4581-9587-dc2860fe78fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c10c77-1446-4581-9587-dc2860fe78fe.jpg?1",
             "name": "Supply Runners",
             "text": "When Supply Runners enters the battlefield, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "3c9345f4-6f88-5c82-8931-5d482bdde9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4eb490-acd0-4162-8e8a-7e7ff003d0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4eb490-acd0-4162-8e8a-7e7ff003d0f3.jpg?1",
             "name": "Trusty Retriever",
             "text": "When Trusty Retriever enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Trusty Retriever.\n\u2022 Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "edce7d82-8373-533f-9733-7f0a8695196b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb8779-ac19-43d6-b818-86eb8ee2f87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb8779-ac19-43d6-b818-86eb8ee2f87d.jpg?1",
             "name": "Archaeomender",
             "text": "When Archaeomender enters the battlefield, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -303,7 +303,7 @@
         },
         {
             "id": "b122f4b4-34b1-5e58-9495-afca777eb070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b43bdc7-e49e-4848-9101-6cad2ecab4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b43bdc7-e49e-4848-9101-6cad2ecab4dc.jpg?1",
             "name": "Bruvac the Grandiloquent",
             "text": "If an opponent would mill one or more cards, they mill twice that many cards instead. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "23247265-3fec-56d0-8598-b54be228be59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b016d4-ddf6-47d6-b934-a0b979b60680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b016d4-ddf6-47d6-b934-a0b979b60680.jpg?1",
             "name": "Corsair Captain",
             "text": "When Corsair Captain enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nOther Pirates you control get +1/+1.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "f4031181-f475-5a38-83a8-38ae5c28decf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b238485f-ef67-4295-892b-a10235368f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b238485f-ef67-4295-892b-a10235368f74.jpg?1",
             "name": "Inniaz, the Gale Force",
             "text": "Flying\n{2}{WU}: Attacking creatures with flying get +1/+1 until end of turn. ({WU} can be paid with either {W} or {U}.)\nWhenever three or more creatures you control with flying attack, each player gains control of a nonland permanent of your choice controlled by the player to their right.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "9e8d42f7-cf3b-5345-bcbc-11794c0d28a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711412f1-9ab3-48b6-91a4-77232b416a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711412f1-9ab3-48b6-91a4-77232b416a32.jpg?1",
             "name": "Ormos, Archive Keeper",
             "text": "Flying\nIf you would draw a card while your library has no cards in it, instead put five +1/+1 counters on Ormos, Archive Keeper.\n{1}{U}{U}, Discard three cards with different names: Draw five cards.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "21af8cb5-f5ce-505f-a3c3-97b9a5b1e2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa254a86-3c30-408d-9c14-befd472f9740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa254a86-3c30-408d-9c14-befd472f9740.jpg?1",
             "name": "Scholar of the Lost Trove",
             "text": "Flying\nWhen Scholar of the Lost Trove enters the battlefield, you may cast target instant, sorcery, or artifact card from your graveyard without paying its mana cost. If an instant or sorcery spell cast this way would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "9b235a8a-cf52-5a0c-bf61-2ba2ad7aee33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70d445b-d3d6-4f7c-b9ea-bed6a26d4a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70d445b-d3d6-4f7c-b9ea-bed6a26d4a2a.jpg?1",
             "name": "Kels, Fight Fixer",
             "text": "Menace\nWhenever you sacrifice a creature, you may pay {UB}. If you do, draw a card. ({UB} can be paid with either {U} or {B}.)\n{1}, Sacrifice a creature: Kels, Fight Fixer gains indestructible until end of turn.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "d26fc1a8-9368-5596-882b-d881290bf642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487aced8-e018-4c93-8e13-bb68b43096a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487aced8-e018-4c93-8e13-bb68b43096a4.jpg?1",
             "name": "Nocturnal Feeder",
             "text": "Flying\nWhen Nocturnal Feeder dies, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "1f3b873f-1419-5b33-a965-b191d23491ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4063be5b-bfd9-43c5-bc39-09a40bc793bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4063be5b-bfd9-43c5-bc39-09a40bc793bf.jpg?1",
             "name": "Tinybones, Trinket Thief",
             "text": "At the beginning of each end step, if an opponent discarded a card this turn, you draw a card and you lose 1 life.\n{4}{B}{B}: Each opponent with no cards in hand loses 10 life.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "4f06427c-71af-5c58-9367-1276228adcf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484f19a-0121-4173-a70b-6698cc5f6303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484f19a-0121-4173-a70b-6698cc5f6303.jpg?1",
             "name": "Witch of the Moors",
             "text": "Deathtouch\nAt the beginning of your end step, if you gained life this turn, each opponent sacrifices a creature and you return up to one target creature card from your graveyard to your hand.",
             "colours": [
@@ -620,7 +620,7 @@
         },
         {
             "id": "2da1bc53-e3da-5789-9306-040ff1436372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4e5c23-3a7f-4a6b-99c4-6a1487a9b097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4e5c23-3a7f-4a6b-99c4-6a1487a9b097.jpg?1",
             "name": "Chained Brute",
             "text": "Chained Brute doesn't untap during your untap step.\n{1}, Sacrifice another creature: Untap Chained Brute. Activate this ability only during your turn.",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "0d349696-9abb-5937-b3c3-7deb2184dbd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0b8aee-fbfb-470f-9ac2-64fce0b4b2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0b8aee-fbfb-470f-9ac2-64fce0b4b2fb.jpg?1",
             "name": "Immolating Gyre",
             "text": "Immolating Gyre deals X damage to each creature and planeswalker you don't control, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "9bab6d93-3255-5991-88ac-b3e20b1a1815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52a3f11-6d55-4492-9a2c-c128c09b3d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52a3f11-6d55-4492-9a2c-c128c09b3d77.jpg?1",
             "name": "Lightning Phoenix",
             "text": "Flying, haste\nLightning Phoenix can't block.\nAt the beginning of your end step, if an opponent was dealt 3 or more damage this turn, you may pay {R}. If you do, return Lightning Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "c1a8f157-536c-5b22-a532-c9c29d91cf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af648aaf-a8e0-4291-acf9-5f8533728f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af648aaf-a8e0-4291-acf9-5f8533728f92.jpg?1",
             "name": "Lightning Visionary",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "3eefb7ec-dc61-506c-9dfb-e9089a9c1379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84379a-369e-4a9f-8c8b-bf47ab524c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84379a-369e-4a9f-8c8b-bf47ab524c4e.jpg?1",
             "name": "Living Lightning",
             "text": "When Living Lightning dies, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "d99ec328-d83c-571c-af45-e0fb474b023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c716d10-2130-43b7-a939-349d437e1091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c716d10-2130-43b7-a939-349d437e1091.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "When Muxus, Goblin Grandee enters the battlefield, reveal the top six cards of your library. Put all Goblin creature cards with converted mana cost 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.\nWhenever Muxus attacks, it gets +1/+1 until end of turn for each other Goblin you control.",
             "colours": [
@@ -821,7 +821,7 @@
         },
         {
             "id": "9a54ef89-8a73-5481-a56a-b06477f984d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg?1",
             "name": "Sethron, Hurloon General",
             "text": "Whenever Sethron, Hurloon General or another nontoken Minotaur enters the battlefield under your control, create a 2/3 red Minotaur creature token.\n{2}{BR}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn. ({BR} can be paid with either {B} or {R}.)",
             "colours": [
@@ -858,7 +858,7 @@
         },
         {
             "id": "7b1e21a9-f002-545e-85d1-9acba400a854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ee7a6-3dfa-44c7-8f00-0183137c4d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ee7a6-3dfa-44c7-8f00-0183137c4d31.jpg?1",
             "name": "Spiteful Prankster",
             "text": "As long as it's your turn, Spiteful Prankster has first strike.\nWhenever another creature dies, Spiteful Prankster deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "5e0d039d-f1c2-5bdf-aa4a-c647d214c6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d94b4c3-7944-41b6-8c92-78fd6e50658d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d94b4c3-7944-41b6-8c92-78fd6e50658d.jpg?1",
             "name": "Zurzoth, Chaos Rider",
             "text": "Whenever an opponent draws their first card each turn, if it's not their turn, you create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\nWhenever one or more Devils you control attack one or more players, you and those players each draw a card, then discard a card at random.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "4cb25159-6cd8-59e2-92e5-d3fd295a76bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee4a931-5d61-49ba-affc-f022263938ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee4a931-5d61-49ba-affc-f022263938ca.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "Allosaurus Shepherd can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "71f56814-0776-5b9f-a9c2-c8853ffe8fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6971ad-cbb4-4f66-9bc4-b407c5805e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6971ad-cbb4-4f66-9bc4-b407c5805e85.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "c808e414-d95b-58bd-8ef7-201a0f304d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1eed0f-9692-44c0-b1ad-afa691165d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1eed0f-9692-44c0-b1ad-afa691165d52.jpg?1",
             "name": "Neyith of the Dire Hunt",
             "text": "Whenever one or more creatures you control fight or become blocked, draw a card.\nAt the beginning of combat on your turn, you may pay {2}{RG}. If you do, double target creature's power until end of turn. That creature must be blocked this combat if able. ({RG} can be paid with either {R} or {G}.)",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "7244b00e-be44-50ff-a6b0-cf5c40681712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c3eac5-3354-44ce-97c2-bafce78433ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c3eac5-3354-44ce-97c2-bafce78433ca.jpg?1",
             "name": "Towering Titan",
             "text": "Towering Titan enters the battlefield with X +1/+1 counters on it, where X is the total toughness of other creatures you control.\nSacrifice a creature with defender: All creatures gain trample until end of turn.",
             "colours": [
@@ -1061,7 +1061,7 @@
         },
         {
             "id": "5d3ff4ef-14ae-5cbb-9a9f-96fe3d1ec9c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b959af-bb23-42e7-8848-7405ed597c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b959af-bb23-42e7-8848-7405ed597c8d.jpg?1",
             "name": "Lightning-Core Excavator",
             "text": "{5}, {T}, Sacrifice Lightning-Core Excavator: It deals 3 damage to any target.",
             "colours": [],
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "115710ca-4067-5c4d-8800-9955aa264285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15481459-3703-4185-ad27-105d95691e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15481459-3703-4185-ad27-105d95691e9d.jpg?1",
             "name": "Thriving Bluff",
             "text": "Thriving Bluff enters the battlefield tapped.\nAs Thriving Bluff enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "556a45ee-13ad-5940-b9e6-e358dc7b925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cabbe0-1c44-4888-8ebc-25a4c3e2c5d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cabbe0-1c44-4888-8ebc-25a4c3e2c5d7.jpg?1",
             "name": "Thriving Grove",
             "text": "Thriving Grove enters the battlefield tapped.\nAs Thriving Grove enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "9c8d7f2c-a1cc-58b7-8432-c005eca33629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe424eb3-7df8-4317-8776-6d960afbb90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe424eb3-7df8-4317-8776-6d960afbb90a.jpg?1",
             "name": "Thriving Heath",
             "text": "Thriving Heath enters the battlefield tapped.\nAs Thriving Heath enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -1178,7 +1178,7 @@
         },
         {
             "id": "08993e0c-4387-561b-84fa-c087e1ffd799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb8fd94-2b59-4b05-b4d0-c93497301d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb8fd94-2b59-4b05-b4d0-c93497301d19.jpg?1",
             "name": "Thriving Isle",
             "text": "Thriving Isle enters the battlefield tapped.\nAs Thriving Isle enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "cac4131a-2bd5-5280-a579-5d5354359428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18756fe5-70f0-48d9-a4f1-ea78f77d2084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18756fe5-70f0-48d9-a4f1-ea78f77d2084.jpg?1",
             "name": "Thriving Moor",
             "text": "Thriving Moor enters the battlefield tapped.\nAs Thriving Moor enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "bc5af6ce-b68a-562d-a6ee-d991096581c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d283ba-9d88-45d2-80d3-7e4fffea6d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d283ba-9d88-45d2-80d3-7e4fffea6d22.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1277,7 +1277,7 @@
         },
         {
             "id": "43a09983-5ffe-584d-9a7e-b2456766ded6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bcd008d-446e-41ba-a92e-871b9296fead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bcd008d-446e-41ba-a92e-871b9296fead.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "7743d92d-5965-517c-9fc2-814701a245c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c3424f-0500-48ce-9779-b77e7763e253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c3424f-0500-48ce-9779-b77e7763e253.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "7f8f84ac-0c12-5d17-8aa3-81cd0cbd496e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0690e60-e11e-4903-b1e0-e36854213b65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0690e60-e11e-4903-b1e0-e36854213b65.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "b1a5f044-35b2-56b2-8d3b-5c5066224c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999d82f8-6c64-4b6a-a8ac-fbc48dd1750c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999d82f8-6c64-4b6a-a8ac-fbc48dd1750c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1441,7 +1441,7 @@
         },
         {
             "id": "96a94835-2cf2-5518-887f-a9d610127f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a334360b-2943-4442-8557-e0a5efd272b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a334360b-2943-4442-8557-e0a5efd272b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "dac3cc6e-ddde-5d7a-a32b-0c2f6f426d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d96d9e-c6c2-4c51-ac57-b63dee0cf27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d96d9e-c6c2-4c51-ac57-b63dee0cf27a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "f7397177-fb1c-578a-b133-d189c54190e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe75b38-c145-420e-9446-f2ac443ab3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe75b38-c145-420e-9446-f2ac443ab3a5.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1564,7 +1564,7 @@
         },
         {
             "id": "347a70ad-739b-5be0-ba7a-7f61c87f463a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a837f2-dbb0-435f-adf9-7632b97f94ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a837f2-dbb0-435f-adf9-7632b97f94ab.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "13e7b016-30c3-542a-9efe-08e4e32fe9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4a655-0051-47c6-a683-c4c3f56e45fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4a655-0051-47c6-a683-c4c3f56e45fc.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "a60243d7-54c6-533a-a09f-6473afcba061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3c7c06-76e4-487d-a63f-4aed3bbb4638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3c7c06-76e4-487d-a63f-4aed3bbb4638.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "1995b285-2adb-51e9-b9e5-8da0b33a9dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f7338-8edc-4579-b92f-86b02527682c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f7338-8edc-4579-b92f-86b02527682c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "fcca533d-a708-5ed1-8e59-20075ed79470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed351e4f-7ee7-4e84-a69d-02b59cebd180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed351e4f-7ee7-4e84-a69d-02b59cebd180.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "17ab34ed-0c8d-5ce2-a658-bd463cea96df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cd2ccc-3148-4507-856d-55140c54d09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cd2ccc-3148-4507-856d-55140c54d09d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "c4ab5c0a-bfec-5a22-82ca-829e16bbf326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c61b0c-408a-4ba5-9a1c-5208b5f7f8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c61b0c-408a-4ba5-9a1c-5208b5f7f8d0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "97ee4c33-4bc6-5cda-ba06-4ea21be43c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a4dfac-2a47-48be-8611-d7f69e261c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a4dfac-2a47-48be-8611-d7f69e261c60.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "333fe9a6-c1f0-5bb1-a016-14f6946ed17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e0edda-1943-47a3-9ad3-673b38f42c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e0edda-1943-47a3-9ad3-673b38f42c86.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "2d81ccd9-e85f-5849-b429-8003e64ee100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a189653-dc0b-4b04-9544-5314cebf23fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a189653-dc0b-4b04-9544-5314cebf23fd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "6d7b4877-ad57-5508-92cc-4a060c83e09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3810ec60-3f93-46c0-af39-7628b77bacec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3810ec60-3f93-46c0-af39-7628b77bacec.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "542926fc-a893-5212-bf00-6a0e8eaef071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ea7816-e501-4384-9176-61819a1784f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ea7816-e501-4384-9176-61819a1784f6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "fe954474-dc50-5624-9539-3a316f2321dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577198f-8b2d-4cee-b400-ebab8fb0df8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577198f-8b2d-4cee-b400-ebab8fb0df8c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "cc96d27b-558e-5fd4-83df-3ae246958b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "874535cd-2277-52c2-9d92-ba5dd2defa06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e597d5-37e7-4add-b454-c3399b4e3704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e597d5-37e7-4add-b454-c3399b4e3704.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "0b3a8dd2-71f2-5213-8267-27f9c1a4c95b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f7b339-cce2-421e-83b8-1764c53dee47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f7b339-cce2-421e-83b8-1764c53dee47.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "2a7ca032-f5a6-5f6a-85d9-d56f38a10962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d1535-68e7-4ca0-aa71-fc7fc63090fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d1535-68e7-4ca0-aa71-fc7fc63090fc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2261,7 +2261,7 @@
         },
         {
             "id": "e6d85336-b24d-5180-b9aa-5ceb86db19d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92c5c74-d5b5-40bf-be86-39ac5e4c4f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92c5c74-d5b5-40bf-be86-39ac5e4c4f1a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "16c51de0-a63d-5030-8f0a-9bf62e7b0004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb524a84-34a4-43bf-9872-b4a053a141b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb524a84-34a4-43bf-9872-b4a053a141b5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2343,7 +2343,7 @@
         },
         {
             "id": "bc5d5a2c-0237-5157-8577-ae4e17e49bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0d802-2bd2-444f-81e0-4cc2f8ece38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0d802-2bd2-444f-81e0-4cc2f8ece38f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "4b7d8a15-3c56-5f5e-ac05-d2f3cff4ea7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55498ad-f474-4805-b9e9-592ec1c8a8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55498ad-f474-4805-b9e9-592ec1c8a8e5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "cf82442b-636d-5efc-a977-cb986936a2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bce91-f1e6-40d4-9ecc-cafa8d2586b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bce91-f1e6-40d4-9ecc-cafa8d2586b6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "8d156bd9-7abb-54c8-b532-0fe5d7570ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6382b-ceff-4092-9ec3-328cefab440e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6382b-ceff-4092-9ec3-328cefab440e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "3e9318de-15bf-53df-b89f-a73ff9930714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c3decf-4a32-45ff-b7f6-ea2d52387c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c3decf-4a32-45ff-b7f6-ea2d52387c89.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "4b21f80d-f675-5ab8-b781-fe7e4862b156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6712361-976a-4ef9-bae9-48505344904e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6712361-976a-4ef9-bae9-48505344904e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "7cdae8aa-c236-5389-ac58-91c6a77d8b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88adbda4-7818-4888-a908-de6073bd0152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88adbda4-7818-4888-a908-de6073bd0152.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2630,7 +2630,7 @@
         },
         {
             "id": "3706ebe6-05ec-5342-8c47-7aab97104caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01838859-51ef-474a-9653-23dd37eed1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01838859-51ef-474a-9653-23dd37eed1d6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "91a5dad4-e78b-5962-bb1f-92fd5b486308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b534b1-2d78-4de3-afc8-8bdd6ee6da82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b534b1-2d78-4de3-afc8-8bdd6ee6da82.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "2058d91b-51bb-5aa7-8ac4-bb0f44b6a420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea556a69-c487-45ca-8f60-7e89407ec7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea556a69-c487-45ca-8f60-7e89407ec7b7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "2c57ac89-ceb9-506f-8f23-d7c72e2a2a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a4d3de-e004-4a15-9f45-4d50813de533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a4d3de-e004-4a15-9f45-4d50813de533.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "802acea3-c322-5786-850d-86ad11615696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4e14a-ab24-4740-b727-165ee9d22e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4e14a-ab24-4740-b727-165ee9d22e99.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "4f636989-6e64-57a0-bc0f-6dcc150daf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c301150-16a8-4ce3-818c-16d6fb0df1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c301150-16a8-4ce3-818c-16d6fb0df1b7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "34823ef8-826d-54b5-82e7-f7fdcd08ad0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ab0de-6691-4a45-95ac-9b75721c6c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ab0de-6691-4a45-95ac-9b75721c6c5a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "ec985c99-db22-5127-ab0e-90aeb325ee4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f356d-4714-4500-8fb0-1ac68ec5c1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f356d-4714-4500-8fb0-1ac68ec5c1cf.jpg?1",
             "name": "Aegis of the Heavens",
             "text": "Target creature gets +1/+7 until end of turn.",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "3728056e-fb4a-5cde-992f-dcbc2cf8fc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e84a4a-034f-4f55-a827-e62f2b61f091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e84a4a-034f-4f55-a827-e62f2b61f091.jpg?1",
             "name": "Aerial Assault",
             "text": "Destroy target tapped creature. You gain 1 life for each creature you control with flying.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "26d7aaca-f5bb-5f3c-a2b7-65761926835f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f762546c-f5eb-420d-a8f7-c3566cd8f506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f762546c-f5eb-420d-a8f7-c3566cd8f506.jpg?1",
             "name": "Affa Guard Hound",
             "text": "Flash\nWhen Affa Guard Hound enters the battlefield, target creature gets +0/+3 until end of turn.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "b3538201-e921-521b-9235-a414cb21343e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea009c1-505e-4307-b8f3-2d37e36507a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea009c1-505e-4307-b8f3-2d37e36507a6.jpg?1",
             "name": "Ajani's Chosen",
             "text": "Whenever an enchantment enters the battlefield under your control, create a 2/2 white Cat creature token. If that enchantment is an Aura, you may attach it to the token.",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "22f9577a-744b-5ba2-acb8-c543038d44d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7026ffb-98de-4da7-84a8-1198639873f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7026ffb-98de-4da7-84a8-1198639873f4.jpg?1",
             "name": "Alabaster Mage",
             "text": "{1}{W}: Target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -3066,7 +3066,7 @@
         },
         {
             "id": "416d29af-9188-5bb3-b985-76f17b3a1438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d22fdde-5590-4a4c-af2e-09711f4b5ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d22fdde-5590-4a4c-af2e-09711f4b5ffd.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy enters the battlefield, you gain 3 life.",
             "colours": [
@@ -3099,7 +3099,7 @@
         },
         {
             "id": "fa45e6a2-43cd-5e35-8a8d-c8ed573bc6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ab81d4-aaf7-4c72-9651-5e1482126928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ab81d4-aaf7-4c72-9651-5e1482126928.jpg?1",
             "name": "Angel of the Dire Hour",
             "text": "Flash\nFlying\nWhen Angel of the Dire Hour enters the battlefield, if you cast it from your hand, exile all attacking creatures.",
             "colours": [
@@ -3132,7 +3132,7 @@
         },
         {
             "id": "ec5c29a9-72f5-56e1-9785-b18131569613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8637d263-5d7e-45bc-aad3-d97f57e6898e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8637d263-5d7e-45bc-aad3-d97f57e6898e.jpg?1",
             "name": "Angelic Arbiter",
             "text": "Flying\nEach opponent who cast a spell this turn can't attack with creatures.\nEach opponent who attacked with a creature this turn can't cast spells.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "1b974154-e35e-57a3-8e6a-ea03fced5890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14ed7f7-83c4-425b-a2b7-5bd76558ce76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14ed7f7-83c4-425b-a2b7-5bd76558ce76.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "66e1863a-caf0-5646-9629-14f28547f156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf5db14-f2aa-4088-9894-7bd3a56dfe1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf5db14-f2aa-4088-9894-7bd3a56dfe1e.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "a161d4af-138b-57b2-98c3-5e2708945306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b0148-5821-4105-9cda-a0e405eb8bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b0148-5821-4105-9cda-a0e405eb8bee.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice dies, exile target permanent.",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "d078d4ca-c601-51f1-bb3d-1bc3c3ad661d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e8eb41-3800-4553-843b-ec27a44e8d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e8eb41-3800-4553-843b-ec27a44e8d55.jpg?1",
             "name": "Archon of Redemption",
             "text": "Flying\nWhenever Archon of Redemption or another creature with flying enters the battlefield under your control, you may gain life equal to that creature's power.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "fd5e0e71-2e8c-56ad-a14e-3f247235b62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bac081-a946-4278-90f0-c0f262b7abf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bac081-a946-4278-90f0-c0f262b7abf2.jpg?1",
             "name": "Battlefield Promotion",
             "text": "Put a +1/+1 counter on target creature. That creature gains first strike until end of turn. You gain 2 life.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "4c6c3a19-8fc9-5174-9f21-059cdd69f2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f060a74-dd75-4625-8842-27cb13a279e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f060a74-dd75-4625-8842-27cb13a279e6.jpg?1",
             "name": "Blessed Spirits",
             "text": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on Blessed Spirits.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "cdbd962c-d0d0-5155-b8f5-dc86ded4efdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5104d4fe-4c20-4106-b405-a2b35140c942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5104d4fe-4c20-4106-b405-a2b35140c942.jpg?1",
             "name": "Bulwark Giant",
             "text": "When Bulwark Giant enters the battlefield, you gain 5 life.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "1628b256-762a-5b5b-b6e4-b9d9fbdb3972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291a964-1117-4fbd-9193-9719b273c348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291a964-1117-4fbd-9193-9719b273c348.jpg?1",
             "name": "Cathar's Companion",
             "text": "Whenever you cast a noncreature spell, Cathar's Companion gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "82c3c0b6-de7e-5b30-b94e-b4d3d3720acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb70e7b-2a68-436e-96a4-32a88fb87da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb70e7b-2a68-436e-96a4-32a88fb87da0.jpg?1",
             "name": "Cathars' Crusade",
             "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "28ae5d92-6559-5b72-9826-6ccddd535cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136dfcf5-130a-4d75-9785-a090215a29b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136dfcf5-130a-4d75-9785-a090215a29b1.jpg?1",
             "name": "Celestial Mantle",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nWhenever enchanted creature deals combat damage to a player, double its controller's life total.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "556be442-68d0-57fc-9944-c0c7d6ff13ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc7fdf0-3e1e-487c-833d-7c74aa02c0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc7fdf0-3e1e-487c-833d-7c74aa02c0c1.jpg?1",
             "name": "Cloudshift",
             "text": "Exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "1bdf5331-a59d-5898-a3cc-29b9eee3056b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caae1f4-dfb0-466f-9fa6-eb014767e3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caae1f4-dfb0-466f-9fa6-eb014767e3c8.jpg?1",
             "name": "Cradle of Vitality",
             "text": "Whenever you gain life, you may pay {1}{W}. If you do, put a +1/+1 counter on target creature for each 1 life you gained.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "8a73b5a5-a5d9-5a95-9d70-97cbcf54136f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae001aa-10a0-482a-86fe-bf6ca7fc0866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae001aa-10a0-482a-86fe-bf6ca7fc0866.jpg?1",
             "name": "Dauntless Onslaught",
             "text": "Up to two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "b0fa2882-d2b6-5264-a6b2-8a98ab79d6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c4997-2b96-45da-a4e1-70a86453c6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c4997-2b96-45da-a4e1-70a86453c6fa.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "796b821f-e1cd-5c1b-a106-1868c5a45173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefef556-dd3c-49b9-a6f5-8b86af64416e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefef556-dd3c-49b9-a6f5-8b86af64416e.jpg?1",
             "name": "Duelist's Heritage",
             "text": "Whenever one or more creatures attack, you may have target attacking creature gain double strike until end of turn.",
             "colours": [
@@ -3646,7 +3646,7 @@
         },
         {
             "id": "8ebe4905-a7e1-583c-8225-2b3cf511f0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2a972a-a953-485d-920d-8f4f978ef758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2a972a-a953-485d-920d-8f4f978ef758.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "afa7c72a-5480-575a-856f-ade0c75e4ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207b7c60-ecf0-4661-8022-1e1714237e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207b7c60-ecf0-4661-8022-1e1714237e9f.jpg?1",
             "name": "Face of Divinity",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nAs long as another Aura is attached to enchanted creature, it has first strike and lifelink.",
             "colours": [
@@ -3712,7 +3712,7 @@
         },
         {
             "id": "3c58b463-d5b7-568e-a089-96b663bf5d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4004b7-89b6-43f5-8d6e-13db1b08f3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4004b7-89b6-43f5-8d6e-13db1b08f3b8.jpg?1",
             "name": "Forced Worship",
             "text": "Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "75184ed2-f823-526a-8d7d-feea7b24e794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4b138-5edc-4c12-b526-5c258bc1555c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4b138-5edc-4c12-b526-5c258bc1555c.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "499d476a-cff8-5235-969d-7f36f4612530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77238879-6dc7-46ff-8354-89e60c2a04e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77238879-6dc7-46ff-8354-89e60c2a04e9.jpg?1",
             "name": "Gird for Battle",
             "text": "Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -3807,7 +3807,7 @@
         },
         {
             "id": "912101c7-cb9f-59df-8761-7eccdbb05c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39dd28-1dc2-46a5-a3cf-9b5d267e16d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39dd28-1dc2-46a5-a3cf-9b5d267e16d6.jpg?1",
             "name": "Healer's Hawk",
             "text": "Flying, lifelink",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "751801e9-c5b4-5cb4-bcd3-44461cae9c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2002d263-3fe0-481a-b389-84e281b009d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2002d263-3fe0-481a-b389-84e281b009d7.jpg?1",
             "name": "High Sentinels of Arashin",
             "text": "Flying\nHigh Sentinels of Arashin gets +1/+1 for each other creature you control with a +1/+1 counter on it.\n{3}{W}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "89eb4a1a-a424-55ab-aef3-3b20fe2421c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ba5d4b-5dbb-43d6-8f44-a2f80944df98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ba5d4b-5dbb-43d6-8f44-a2f80944df98.jpg?1",
             "name": "Indomitable Will",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "019eb95e-4c16-5a56-b859-4212ba174ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9822b57-8e42-4158-981d-f0b0b0646fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9822b57-8e42-4158-981d-f0b0b0646fc9.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "92c7efe5-1b37-555b-b33f-c17df336b8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac9c0ee-97a1-4c31-8a42-30408ef3a49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac9c0ee-97a1-4c31-8a42-30408ef3a49c.jpg?1",
             "name": "Inspiring Captain",
             "text": "When Inspiring Captain enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "356b1fcd-717f-5559-8d37-b36b777bd2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3320865c-ef02-4f18-82b0-47a6d845de0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3320865c-ef02-4f18-82b0-47a6d845de0f.jpg?1",
             "name": "Inspiring Unicorn",
             "text": "Whenever Inspiring Unicorn attacks, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "8f988512-19df-526e-9f80-169168570933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afead32-3542-44c4-82d6-b6a81beb9f90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afead32-3542-44c4-82d6-b6a81beb9f90.jpg?1",
             "name": "Isamaru, Hound of Konda",
             "text": "",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "fcc627aa-2b6a-5a28-a041-f23fdf59983d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f81d2a0-5301-4cae-ac83-ad51647146e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f81d2a0-5301-4cae-ac83-ad51647146e3.jpg?1",
             "name": "Knight of the Tusk",
             "text": "Vigilance",
             "colours": [
@@ -4074,7 +4074,7 @@
         },
         {
             "id": "a9c184c6-e9ce-59f5-bdff-416b91b7dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f463b5-188f-4ecc-8cbf-0f200515bb09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f463b5-188f-4ecc-8cbf-0f200515bb09.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, create a 2/2 white Knight creature token with vigilance.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "1e9f8f5c-4adf-5808-a1c2-44ebf4834ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59813c47-e779-404d-8a1c-70ea29bc7023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59813c47-e779-404d-8a1c-70ea29bc7023.jpg?1",
             "name": "Kor Spiritdancer",
             "text": "Kor Spiritdancer gets +2/+2 for each Aura attached to it.\nWhenever you cast an Aura spell, you may draw a card.",
             "colours": [
@@ -4141,7 +4141,7 @@
         },
         {
             "id": "4fe5c999-93d5-5c4e-8a7e-88e3d8d6dcaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1fb1a6-7f64-45a6-9fc0-a325b7600afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1fb1a6-7f64-45a6-9fc0-a325b7600afa.jpg?1",
             "name": "Lena, Selfless Champion",
             "text": "When Lena, Selfless Champion enters the battlefield, create a 1/1 white Soldier creature token for each nontoken creature you control.\nSacrifice Lena: Creatures you control with power less than Lena's power gain indestructible until end of turn.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "929df165-cac5-5580-9a54-5819bd930b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cfd373-148d-4073-8867-3d9ccae20fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cfd373-148d-4073-8867-3d9ccae20fd1.jpg?1",
             "name": "Lightwalker",
             "text": "Lightwalker has flying as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "5fe46713-f615-59af-a1e5-28cb941190e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dded98c3-17cb-4a43-a209-289ceb11df39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dded98c3-17cb-4a43-a209-289ceb11df39.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "Flying\nActivated abilities of creatures your opponents control can't be activated.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "f5b54576-8dc4-50aa-9553-4fb87fbbba47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504698a9-1512-4288-b5ef-392d41ebcd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504698a9-1512-4288-b5ef-392d41ebcd05.jpg?1",
             "name": "Long Road Home",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "020fcfb8-2d43-59d3-a175-9bc88931a18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46150e35-bcaf-4b53-871d-d1d9091a36ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46150e35-bcaf-4b53-871d-d1d9091a36ab.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "c4a84543-6375-559e-a96e-01bd85ad2dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e321bbb0-1660-4452-a9b7-d41674f7f743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e321bbb0-1660-4452-a9b7-d41674f7f743.jpg?1",
             "name": "Mesa Unicorn",
             "text": "Lifelink",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "0fb104f2-5985-5774-865b-c1e6c0e4057e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b24d60d-bd80-4363-829c-a9d7f8c61fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b24d60d-bd80-4363-829c-a9d7f8c61fdf.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "79850572-a228-55f8-bddc-a39c2e94c784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17da4d0-f9fd-43af-85fc-ede9fa3962bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17da4d0-f9fd-43af-85fc-ede9fa3962bf.jpg?1",
             "name": "Moment of Heroism",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "c1788f37-5a9a-525a-aa33-80d35ebdd56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da7c6dc-9325-4866-8c09-78c7021f8f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da7c6dc-9325-4866-8c09-78c7021f8f17.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -4444,7 +4444,7 @@
         },
         {
             "id": "602a5fab-a84a-5144-a728-9b32b2a1c61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389a05-2e1a-471d-a865-1c3b68a03e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389a05-2e1a-471d-a865-1c3b68a03e01.jpg?1",
             "name": "Path of Bravery",
             "text": "As long as your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
             "colours": [
@@ -4475,7 +4475,7 @@
         },
         {
             "id": "b7ac0ff5-d80f-5e94-86a3-aec781167970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40386-6ea6-4b77-8c61-2a9a16a88a01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40386-6ea6-4b77-8c61-2a9a16a88a01.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle their library.",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "4bdaf4f3-8f64-506a-8032-6d9bcefa5f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f43272-6681-41dd-8bfd-d18cc68171c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f43272-6681-41dd-8bfd-d18cc68171c1.jpg?1",
             "name": "Patron of the Valiant",
             "text": "Flying\nWhen Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "c15e881a-ee01-5704-9a82-30ff9e9e60d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f552f9b6-0a60-44d8-985e-249617e04866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f552f9b6-0a60-44d8-985e-249617e04866.jpg?1",
             "name": "Raise the Alarm",
             "text": "Create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "1bc581eb-d021-5a03-975d-ba2d0325f31f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62498e3c-2e9b-4444-a61c-fae3f8906010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62498e3c-2e9b-4444-a61c-fae3f8906010.jpg?1",
             "name": "Rhox Faithmender",
             "text": "Lifelink\nIf you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -4604,7 +4604,7 @@
         },
         {
             "id": "35233dab-225b-5f72-b3dc-0b11782faf45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb993412-69bc-4000-ac8f-b2f62161fc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb993412-69bc-4000-ac8f-b2f62161fc55.jpg?1",
             "name": "Ronom Unicorn",
             "text": "Sacrifice Ronom Unicorn: Destroy target enchantment.",
             "colours": [
@@ -4637,7 +4637,7 @@
         },
         {
             "id": "7224e18f-ce5f-58ca-9e32-61624dde9ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f035-3437-4c5c-bae9-d3c9001a3411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f035-3437-4c5c-bae9-d3c9001a3411.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "f56199c9-bbc1-578d-8cda-24b8de3f4f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b4430-95c0-424b-a365-4ae467bb303d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b4430-95c0-424b-a365-4ae467bb303d.jpg?1",
             "name": "Sky Tether",
             "text": "Enchant creature\nEnchanted creature has defender and loses flying.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "b4ae1aa2-ad8f-5434-81e2-7ba15da4f910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457eb507-bbbf-4064-bdb0-cfeefe2195df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457eb507-bbbf-4064-bdb0-cfeefe2195df.jpg?1",
             "name": "Take Heart",
             "text": "Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "4b66b455-796e-59a3-8ea1-eecbf5f09df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acd58e4-7dc7-4ca0-8750-2558ff97b5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acd58e4-7dc7-4ca0-8750-2558ff97b5da.jpg?1",
             "name": "Tandem Tactics",
             "text": "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "1328f914-a639-5581-993b-d79497e70453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20516400-b37a-46d2-89c8-d6be88f5ab3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20516400-b37a-46d2-89c8-d6be88f5ab3d.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -4796,7 +4796,7 @@
         },
         {
             "id": "516871bf-0498-518d-a52d-4347cb65e251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a78066-c52e-48fd-bcf9-d0b60f00fddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a78066-c52e-48fd-bcf9-d0b60f00fddc.jpg?1",
             "name": "Voice of the Provinces",
             "text": "Flying\nWhen Voice of the Provinces enters the battlefield, create a 1/1 white Human creature token.",
             "colours": [
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "ec8a23a0-6dd8-5d3d-af5b-fea3d44edaf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7003ebae-5d82-4360-ae63-0e51c37977ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7003ebae-5d82-4360-ae63-0e51c37977ed.jpg?1",
             "name": "Aegis Turtle",
             "text": "",
             "colours": [
@@ -4862,7 +4862,7 @@
         },
         {
             "id": "c7012778-e33d-515f-a634-a1adecdd4afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b2d108-16f2-4d9b-abc8-83ee3d2e8baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b2d108-16f2-4d9b-abc8-83ee3d2e8baf.jpg?1",
             "name": "Battleground Geist",
             "text": "Flying\nOther Spirit creatures you control get +1/+0.",
             "colours": [
@@ -4895,7 +4895,7 @@
         },
         {
             "id": "d20bbda6-0791-518c-a5f6-926ade37424a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c1f80e-65b7-4534-bfd4-1ae88274945b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c1f80e-65b7-4534-bfd4-1ae88274945b.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "52fde117-f750-5959-ad0d-91d9a09a9f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef04340d-284c-4e7b-afd7-444d21a6b382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef04340d-284c-4e7b-afd7-444d21a6b382.jpg?1",
             "name": "Belltower Sphinx",
             "text": "Flying\nWhenever a source deals damage to Belltower Sphinx, that source's controller mills that many cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "c78c983b-7b74-51e1-8185-83b7653ae773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6f256b-943e-4cfb-9fc9-d1ded68b5f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6f256b-943e-4cfb-9fc9-d1ded68b5f97.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked with a creature this turn.",
             "colours": [
@@ -4990,7 +4990,7 @@
         },
         {
             "id": "4de3b876-fe1c-50d4-a132-c14adf4ab2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149d4f00-106b-4aa7-a667-6360d2e149e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149d4f00-106b-4aa7-a667-6360d2e149e7.jpg?1",
             "name": "Cloudreader Sphinx",
             "text": "Flying\nWhen Cloudreader Sphinx enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "7420c28c-4f35-5c7d-aa6a-5e19cb1c7b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c4e43-71b2-4483-ba54-4be1dcffcd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c4e43-71b2-4483-ba54-4be1dcffcd5f.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "0fc2254b-27af-52b3-8edb-4c10f026f2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4e2977-b518-4fa3-83e4-5af326ded290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4e2977-b518-4fa3-83e4-5af326ded290.jpg?1",
             "name": "Crookclaw Transmuter",
             "text": "Flash\nFlying\nWhen Crookclaw Transmuter enters the battlefield, switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -5088,7 +5088,7 @@
         },
         {
             "id": "5b4f5d47-071b-5552-ad08-54951904f279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a636f74-3bac-4b88-a24f-32a66a94e340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a636f74-3bac-4b88-a24f-32a66a94e340.jpg?1",
             "name": "Cryptic Serpent",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "3bf05e06-5609-5e30-be6c-6af8107835f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a0be10-c20f-4ac0-89a5-1770ecf48aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a0be10-c20f-4ac0-89a5-1770ecf48aad.jpg?1",
             "name": "Curiosity",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "04f147d0-f3c0-537a-a52f-ebacdb318184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cf3030-dc92-45ab-9c26-f2e6aef67e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cf3030-dc92-45ab-9c26-f2e6aef67e56.jpg?1",
             "name": "Curious Obsession",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, you may draw a card.\"\nAt the beginning of your end step, if you didn't attack with a creature this turn, sacrifice Curious Obsession.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "1e053d94-1d40-5cab-b019-bfeafc8bb626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b3c3e3-151f-4f16-bb40-167978180bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b3c3e3-151f-4f16-bb40-167978180bbc.jpg?1",
             "name": "Departed Deckhand",
             "text": "When Departed Deckhand becomes the target of a spell, sacrifice it.\nDeparted Deckhand can't be blocked except by Spirits.\n{3}{U}: Another target creature you control can't be blocked this turn except by Spirits.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "7ad06b4c-1465-5f46-809c-c142579533ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dfe354-d527-4f56-8457-b95884700a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dfe354-d527-4f56-8457-b95884700a40.jpg?1",
             "name": "Erratic Visionary",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -5255,7 +5255,7 @@
         },
         {
             "id": "b890057e-f663-53d8-b594-20a8fe9f0aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2600a51b-0dae-431e-a0a7-2b1421706a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2600a51b-0dae-431e-a0a7-2b1421706a6a.jpg?1",
             "name": "Essence Flux",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. If it's a Spirit, put a +1/+1 counter on it.",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "68348971-73b8-5703-97dc-4b8f6461e671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1455f59e-f487-4195-ab25-8fc7695903e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1455f59e-f487-4195-ab25-8fc7695903e4.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -5317,7 +5317,7 @@
         },
         {
             "id": "3edf8a32-9ac2-5d84-a1b1-8f593fe5df58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6344ecd-ca57-4104-a77a-d7d14264776d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6344ecd-ca57-4104-a77a-d7d14264776d.jpg?1",
             "name": "Exclusion Mage",
             "text": "When Exclusion Mage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -5351,7 +5351,7 @@
         },
         {
             "id": "5c73bba7-3d61-5fd2-bbcc-8cf22ac86d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437ded6e-4e53-49fa-a5ca-fd76b9165a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437ded6e-4e53-49fa-a5ca-fd76b9165a47.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability for the first time each turn, counter that spell or ability.\"",
             "colours": [
@@ -5386,7 +5386,7 @@
         },
         {
             "id": "0bc3b035-99df-5363-b8a6-476402e22039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36056deb-a7f8-4bb3-9c51-890e96f41482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36056deb-a7f8-4bb3-9c51-890e96f41482.jpg?1",
             "name": "Kitesail Corsair",
             "text": "Kitesail Corsair has flying as long as it's attacking.",
             "colours": [
@@ -5420,7 +5420,7 @@
         },
         {
             "id": "19d8a18f-69a5-5be4-bf07-254bc1e20650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049955c6-63f5-4f80-8c60-34c890f3c71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049955c6-63f5-4f80-8c60-34c890f3c71a.jpg?1",
             "name": "Leave in the Dust",
             "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "8bf759d4-0cc8-55b1-ba39-8b0fa69ad495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c1aaff-ab26-437e-a88a-494683aec831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c1aaff-ab26-437e-a88a-494683aec831.jpg?1",
             "name": "Murmuring Phantasm",
             "text": "Defender",
             "colours": [
@@ -5484,7 +5484,7 @@
         },
         {
             "id": "48087c07-e7ce-57fe-bf51-2d5a2c9d0f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de19d2db-604b-4d5f-8184-9bb0a31c7405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de19d2db-604b-4d5f-8184-9bb0a31c7405.jpg?1",
             "name": "Mystic Archaeologist",
             "text": "{3}{U}{U}: Draw two cards.",
             "colours": [
@@ -5518,7 +5518,7 @@
         },
         {
             "id": "35c102de-7840-51bd-9e1b-f2ec95088087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95681c43-ba2e-41a5-8a51-e66db8ec6cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95681c43-ba2e-41a5-8a51-e66db8ec6cb9.jpg?1",
             "name": "Narcolepsy",
             "text": "Enchant creature\nAt the beginning of each upkeep, if enchanted creature is untapped, tap it.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "506e03ac-b060-5b77-aa1b-481a8e0501cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c0715-416c-4316-98ef-ff90bb3112ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c0715-416c-4316-98ef-ff90bb3112ae.jpg?1",
             "name": "Nebelgast Herald",
             "text": "Flash\nFlying\nWhenever Nebelgast Herald or another Spirit enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "fb3cbb52-2077-5e88-b828-f2cbeb8a1f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbb3f9d-8629-4815-8b7d-f8ec9368b9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbb3f9d-8629-4815-8b7d-f8ec9368b9b0.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "cbdf3c42-7abc-5f6d-840b-36be1d1ea850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61921b05-ee83-4768-a405-4d3355c0ad6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61921b05-ee83-4768-a405-4d3355c0ad6e.jpg?1",
             "name": "Oneirophage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on Oneirophage.",
             "colours": [
@@ -5651,7 +5651,7 @@
         },
         {
             "id": "6e04a465-8a37-5d49-9392-12aeaea09f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d0f29b-fcc4-4135-af36-6539912ab3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d0f29b-fcc4-4135-af36-6539912ab3bb.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "87a37b24-0f70-515f-9a6c-6f671e19fe04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bb655d-8d62-4a79-9a9d-7384d1cb2cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bb655d-8d62-4a79-9a9d-7384d1cb2cc0.jpg?1",
             "name": "Prescient Chimera",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5715,7 +5715,7 @@
         },
         {
             "id": "a17b04aa-9df5-5b48-b6d7-4e7cc69fef2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db054e-8303-44c7-8c96-d031a8c85b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db054e-8303-44c7-8c96-d031a8c85b34.jpg?1",
             "name": "Prosperous Pirates",
             "text": "When Prosperous Pirates enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5749,7 +5749,7 @@
         },
         {
             "id": "3661764e-6764-5057-9067-0b01b9e456ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505e7f2c-c040-427a-a3a1-e7b36066e4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505e7f2c-c040-427a-a3a1-e7b36066e4fe.jpg?1",
             "name": "Rattlechains",
             "text": "Flash\nFlying\nWhen Rattlechains enters the battlefield, target Spirit gains hexproof until end of turn.\nYou may cast Spirit spells as though they had flash.",
             "colours": [
@@ -5782,7 +5782,7 @@
         },
         {
             "id": "ac655828-e102-540e-9590-3b03466b6065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65088f-bbbd-4e8d-b482-58181069bef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65088f-bbbd-4e8d-b482-58181069bef2.jpg?1",
             "name": "Read the Runes",
             "text": "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.",
             "colours": [
@@ -5813,7 +5813,7 @@
         },
         {
             "id": "252a6a8d-6c67-54c6-9a5e-3fddc553e63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad3313a-61ef-42c8-a092-390adb51e17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad3313a-61ef-42c8-a092-390adb51e17e.jpg?1",
             "name": "Reckless Scholar",
             "text": "{T}: Target player draws a card, then discards a card.",
             "colours": [
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "41b36bfa-1fb6-5f4e-87ba-94143495b70c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914dba-0d27-4055-ac34-b3ebf5802221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914dba-0d27-4055-ac34-b3ebf5802221.jpg?1",
             "name": "Rhystic Study",
             "text": "Whenever an opponent casts a spell, you may draw a card unless that player pays {1}.",
             "colours": [
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "0fdba264-519c-57d1-8d3d-0f572e57fc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ea87f1-fbe2-4905-8a97-ceef9d3d0faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ea87f1-fbe2-4905-8a97-ceef9d3d0faf.jpg?1",
             "name": "Rishadan Airship",
             "text": "Flying\nRishadan Airship can block only creatures with flying.",
             "colours": [
@@ -5912,7 +5912,7 @@
         },
         {
             "id": "c6575626-15f6-5e99-b6ba-13146c089c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c17066-c551-4aed-9258-1e5ed947385b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c17066-c551-4aed-9258-1e5ed947385b.jpg?1",
             "name": "Sage's Row Savant",
             "text": "When Sage's Row Savant enters the battlefield, scry 2.",
             "colours": [
@@ -5946,7 +5946,7 @@
         },
         {
             "id": "99005fa0-d3c1-52da-b62e-e805787e536c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c1e6ad-1227-4049-89bf-69ace48c3076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c1e6ad-1227-4049-89bf-69ace48c3076.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5980,7 +5980,7 @@
         },
         {
             "id": "6934ade8-bb25-5eb7-999f-03be7a2c7cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b3006-16cb-4752-908e-3c9f37ac249c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b3006-16cb-4752-908e-3c9f37ac249c.jpg?1",
             "name": "Sea Gate Oracle",
             "text": "When Sea Gate Oracle enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "156dd28e-3c5f-5cae-b113-a89c4b07a4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94975b02-f678-4442-9d1a-cf586aee8789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94975b02-f678-4442-9d1a-cf586aee8789.jpg?1",
             "name": "Selhoff Occultist",
             "text": "Whenever Selhoff Occultist or another creature dies, target player mills a card. (They put the top card of their library into their graveyard.)",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "d21ae4ed-adc4-5459-95c7-71670e8dd412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30032a0b-dece-42a4-9309-fa9e9e277603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30032a0b-dece-42a4-9309-fa9e9e277603.jpg?1",
             "name": "Serendib Efreet",
             "text": "Flying\nAt the beginning of your upkeep, Serendib Efreet deals 1 damage to you.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "bfbab9a0-1fb0-5ec9-b80c-60e4a20fc21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df1ce35-1f1c-40ab-8e4d-cb087b4656d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df1ce35-1f1c-40ab-8e4d-cb087b4656d8.jpg?1",
             "name": "Sharding Sphinx",
             "text": "Flying\nWhenever an artifact creature you control deals combat damage to a player, you may create a 1/1 blue Thopter artifact creature token with flying.",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "91f6855e-e113-5a2c-8cf6-84a036da3fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1a93c3-8561-4c65-bea8-a9c3a898a48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1a93c3-8561-4c65-bea8-a9c3a898a48c.jpg?1",
             "name": "Sigiled Starfish",
             "text": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "d263be8d-d432-5627-9b3c-5e71c78b8740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b591fef-21ca-4a3b-990b-d7897a405511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b591fef-21ca-4a3b-990b-d7897a405511.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "e6cc1636-dd92-5e4b-920d-584441a035b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9ac55-4bb4-4447-b214-6a108ddb3f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9ac55-4bb4-4447-b214-6a108ddb3f07.jpg?1",
             "name": "Storm Sculptor",
             "text": "Storm Sculptor can't be blocked.\nWhen Storm Sculptor enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -6216,7 +6216,7 @@
         },
         {
             "id": "943b118f-b104-5bd7-92b7-08aaa9e17102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad50269-6e80-47ea-a027-fa274f904e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad50269-6e80-47ea-a027-fa274f904e86.jpg?1",
             "name": "Sweep Away",
             "text": "Return target creature to its owner's hand. If that creature is attacking, you may put it on top of its owner's library instead.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "d7666baf-973f-5532-a0e3-58850da10630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c1a1-1896-4360-b123-52d82a6871d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c1a1-1896-4360-b123-52d82a6871d4.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "a010065c-d4b1-5bfd-83fb-69fd85952729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b153c2f-fc87-49bc-9d1e-d5e7e25b2142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b153c2f-fc87-49bc-9d1e-d5e7e25b2142.jpg?1",
             "name": "Talrand's Invocation",
             "text": "Create two 2/2 blue Drake creature tokens with flying.",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "9e120b5e-f42d-5579-8a93-a9618a590a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e40cb2-d306-4c8d-859b-ac288e9dc78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e40cb2-d306-4c8d-859b-ac288e9dc78d.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "cd895cab-a26f-544b-9eb5-761b3f9981a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a932a37-a1db-4df9-9b65-27ee7b46957d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a932a37-a1db-4df9-9b65-27ee7b46957d.jpg?1",
             "name": "Thought Collapse",
             "text": "Counter target spell. Its controller mills three cards. (They put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -6376,7 +6376,7 @@
         },
         {
             "id": "f819df36-2daa-5092-b9fc-c8becb5b3ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142944d5-1b11-4ec4-b6b4-b5c03e682cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142944d5-1b11-4ec4-b6b4-b5c03e682cd3.jpg?1",
             "name": "Thought Scour",
             "text": "Target player mills two cards. (They put the top two cards of their library into their graveyard.)\nDraw a card.",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "937912d9-d0d2-58e3-8f2f-53c9aa350e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8203f709-0fac-41c1-a056-3fa1a2c1d127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8203f709-0fac-41c1-a056-3fa1a2c1d127.jpg?1",
             "name": "Towering-Wave Mystic",
             "text": "Whenever Towering-Wave Mystic deals damage, target player mills that many cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "1c14f9bd-9563-56ff-83dd-9f64a743bb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b3cb7-b434-4524-8ef0-7db7f7f22edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b3cb7-b434-4524-8ef0-7db7f7f22edd.jpg?1",
             "name": "Vedalken Archmage",
             "text": "Whenever you cast an artifact spell, draw a card.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "ee8dc4d8-1478-5875-9493-c8bacc3945d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bdfd6-8baf-430d-a4c4-5acf81e58b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bdfd6-8baf-430d-a4c4-5acf81e58b62.jpg?1",
             "name": "Vedalken Entrancer",
             "text": "{U}, {T}: Target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "704c1976-a74f-5d30-b8ae-4ceee05f3a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55c60dc-40ed-4a36-9daa-702f79ffe818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55c60dc-40ed-4a36-9daa-702f79ffe818.jpg?1",
             "name": "Voyage's End",
             "text": "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6540,7 +6540,7 @@
         },
         {
             "id": "cede2da9-cbd5-5a24-a73d-135698ddf566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e3084c-c690-4cc7-9d79-42b1cde073ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e3084c-c690-4cc7-9d79-42b1cde073ad.jpg?1",
             "name": "Wall of Lost Thoughts",
             "text": "Defender\nWhen Wall of Lost Thoughts enters the battlefield, target player mills four cards. (They put the top four cards of their library into their graveyard.)",
             "colours": [
@@ -6573,7 +6573,7 @@
         },
         {
             "id": "24f55bbe-0e03-5ca5-9d04-b45fa1c90703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58807d-1663-486a-ac94-627a8677f2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58807d-1663-486a-ac94-627a8677f2b3.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "a27c4eb5-7c98-5be9-9ae5-19a584f42540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada68b91-3379-483e-93a0-b6c7c675c1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada68b91-3379-483e-93a0-b6c7c675c1dc.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "cef870f4-6fa3-53f8-9f45-473cbd02605e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84fb92-bb66-4f1a-b360-f87fdbcd45b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84fb92-bb66-4f1a-b360-f87fdbcd45b7.jpg?1",
             "name": "Whelming Wave",
             "text": "Return all creatures to their owners' hands except for Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "c94b4137-a58a-514e-b841-be298da3b528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0346326-6bdf-4385-ab41-7b06e9f66ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0346326-6bdf-4385-ab41-7b06e9f66ffd.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "fb945500-8c4b-56d1-b792-1c17957364f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff4bd1-2b61-46be-b547-38916ea08298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff4bd1-2b61-46be-b547-38916ea08298.jpg?1",
             "name": "Windstorm Drake",
             "text": "Flying\nOther creatures you control with flying get +1/+0.",
             "colours": [
@@ -6737,7 +6737,7 @@
         },
         {
             "id": "ca80a818-4061-5f97-9bed-5f4acaffe6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48ebd79-95d7-4860-9785-45e34a94755d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48ebd79-95d7-4860-9785-45e34a94755d.jpg?1",
             "name": "Winged Words",
             "text": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "6011787a-fe2b-5fce-8f5f-83eb11cff445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a7809-4bef-48e9-afbc-e473eb7072e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a7809-4bef-48e9-afbc-e473eb7072e8.jpg?1",
             "name": "Wishful Merfolk",
             "text": "Defender\n{1}{U}: Wishful Merfolk loses defender and becomes a Human until end of turn.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "3da2d1e2-c435-5c4d-8bca-a2404523d7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979cd394-80ce-4559-9f3a-57cd84299182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979cd394-80ce-4559-9f3a-57cd84299182.jpg?1",
             "name": "Wizard's Retort",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nCounter target spell.",
             "colours": [
@@ -6832,7 +6832,7 @@
         },
         {
             "id": "1a0e33f4-34ae-51fd-9040-87139d7d2b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532a279-b8e1-4124-bcd7-d7f4c71673eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532a279-b8e1-4124-bcd7-d7f4c71673eb.jpg?1",
             "name": "Agonizing Syphon",
             "text": "Agonizing Syphon deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "3b11977a-2822-5a2f-a061-3d2e1661be42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aacb3ae-c889-4912-bc2d-2aa0adfd20bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aacb3ae-c889-4912-bc2d-2aa0adfd20bd.jpg?1",
             "name": "Assassin's Strike",
             "text": "Destroy target creature. Its controller discards a card.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "dcdf79ab-fd4e-5430-add7-96a9b65f4176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6e5b25-b721-45ee-894a-697de1310b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6e5b25-b721-45ee-894a-697de1310b8c.jpg?1",
             "name": "Bake into a Pie",
             "text": "Destroy target creature. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "96a0dcf9-3e94-5ff0-9d5a-d100e45bf70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23986add-b33d-4bad-86f3-e2d0f99cf949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23986add-b33d-4bad-86f3-e2d0f99cf949.jpg?1",
             "name": "Barter in Blood",
             "text": "Each player sacrifices two creatures.",
             "colours": [
@@ -6956,7 +6956,7 @@
         },
         {
             "id": "c30dd503-6e0f-5b25-9aee-d9834b8ae97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90a12af-b453-4d83-9a14-5411b562d480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90a12af-b453-4d83-9a14-5411b562d480.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "8c30f906-3bc9-5059-bc5f-b3790375603a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f51ced8-9384-4b8d-aa60-efb281ac9439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f51ced8-9384-4b8d-aa60-efb281ac9439.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "5947d4f3-869c-5035-ba76-0e428496d9f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0cc3d9-85f1-49ed-bf8a-81fc6c60bd2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0cc3d9-85f1-49ed-bf8a-81fc6c60bd2a.jpg?1",
             "name": "Blighted Bat",
             "text": "Flying\n{1}: Blighted Bat gains haste until end of turn.",
             "colours": [
@@ -7055,7 +7055,7 @@
         },
         {
             "id": "96834c94-3b08-5745-98f4-9deaf255b926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8c18-c76b-488a-a4ec-ec0d2267a307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8c18-c76b-488a-a4ec-ec0d2267a307.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -7088,7 +7088,7 @@
         },
         {
             "id": "dd37d438-c478-53c5-ab67-ab0608ffb929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab76e956-5d6c-49b8-991c-c39d5b18b876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab76e956-5d6c-49b8-991c-c39d5b18b876.jpg?1",
             "name": "A-Blood Artist",
             "text": "",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "64ef2474-11af-525f-a10a-e2990883b250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51278b56-5056-4a37-a1e8-daca45d8e360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51278b56-5056-4a37-a1e8-daca45d8e360.jpg?1",
             "name": "Blood Divination",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "ee7d209e-5469-5f6b-8373-3904f260f434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d0839b-a021-4227-aa0f-1fa2ff806892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d0839b-a021-4227-aa0f-1fa2ff806892.jpg?1",
             "name": "Blood Host",
             "text": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Blood Host and you gain 2 life.",
             "colours": [
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "a0db9b74-4c60-54e0-b5ff-3218d5c25fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c6df1d-7709-41e4-a79f-0dc722600191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c6df1d-7709-41e4-a79f-0dc722600191.jpg?1",
             "name": "Bloodbond Vampire",
             "text": "Whenever you gain life, put a +1/+1 counter on Bloodbond Vampire.",
             "colours": [
@@ -7220,7 +7220,7 @@
         },
         {
             "id": "fd5d6dc7-1046-5407-92f8-7df9a2118ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a14228-3716-4448-a8c3-93928b9b85d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a14228-3716-4448-a8c3-93928b9b85d6.jpg?1",
             "name": "Bloodhunter Bat",
             "text": "Flying\nWhen Bloodhunter Bat enters the battlefield, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -7253,7 +7253,7 @@
         },
         {
             "id": "bb0afd85-2b16-50bc-bb91-11e58c58a141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce1aa49-fe00-4390-8c4b-d1203cc337cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce1aa49-fe00-4390-8c4b-d1203cc337cd.jpg?1",
             "name": "Bogbrew Witch",
             "text": "{2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "f4f67a4a-6f82-5392-9bb9-fe8b2930fa20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c57801-cc6f-4f1f-b401-7f621fdcfaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c57801-cc6f-4f1f-b401-7f621fdcfaaa.jpg?1",
             "name": "Bone Picker",
             "text": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "92633608-1527-5938-b7d9-00abce133c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc676672-1aeb-420a-b909-5a3215cc2ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc676672-1aeb-420a-b909-5a3215cc2ca6.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "dd98a74e-8c6c-5f39-a0c1-9dff9303ab66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb457c05-2a60-437a-8138-cfd581b22996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb457c05-2a60-437a-8138-cfd581b22996.jpg?1",
             "name": "Burglar Rat",
             "text": "When Burglar Rat enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "62a73824-4d69-5233-976f-d0079356159f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fefd7f9-57ff-41bb-aef6-b1d568a7588b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fefd7f9-57ff-41bb-aef6-b1d568a7588b.jpg?1",
             "name": "Cadaver Imp",
             "text": "Flying\nWhen Cadaver Imp enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7417,7 +7417,7 @@
         },
         {
             "id": "1bc98625-6339-5841-9f38-ef73bcd61a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf273e-b8f7-434b-9d5d-883dfd6f7423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf273e-b8f7-434b-9d5d-883dfd6f7423.jpg?1",
             "name": "Cauldron Familiar",
             "text": "When Cauldron Familiar enters the battlefield, each opponent loses 1 life and you gain 1 life.\nSacrifice a Food: Return Cauldron Familiar from your graveyard to the battlefield.",
             "colours": [
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "01f26f87-b1da-53e2-bbc1-d2d5bf9d47c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88531c36-2330-474b-9426-1e4dd0fe4e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88531c36-2330-474b-9426-1e4dd0fe4e3e.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "93bc2731-3ff6-517a-86c9-086d0e72864c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3887af00-a87d-4396-b82b-38b88c084e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3887af00-a87d-4396-b82b-38b88c084e8e.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "704b900a-5115-56c9-992c-d06823f1e10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7bdf8-505e-4ed2-8a3b-aba263afd196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7bdf8-505e-4ed2-8a3b-aba263afd196.jpg?1",
             "name": "Corpse Hauler",
             "text": "{2}{B}, Sacrifice Corpse Hauler: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -7548,7 +7548,7 @@
         },
         {
             "id": "419538bb-fe35-56e9-b6a4-a776fd1a44de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd6d782-ce5a-4994-8310-34faf9c41de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd6d782-ce5a-4994-8310-34faf9c41de2.jpg?1",
             "name": "Corpse Traders",
             "text": "{2}{B}, Sacrifice a creature: Target opponent reveals their hand. You choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7582,7 +7582,7 @@
         },
         {
             "id": "8f54f230-cf2e-5342-b15d-aca62bcf1bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beed7579-f4f1-4545-9653-4c1179e88dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beed7579-f4f1-4545-9653-4c1179e88dc8.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "5cd7143a-db8f-561a-999b-bcf4b306b2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954e983-397c-4fdc-a6a1-142d03bfec7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954e983-397c-4fdc-a6a1-142d03bfec7e.jpg?1",
             "name": "Death's Approach",
             "text": "Enchant creature\nEnchanted creature gets -X/-X, where X is the number of creature cards in its controller's graveyard.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "45294c1b-960a-5e3d-93b9-567b43552b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fa15b-4559-4a8f-aa29-5c43eb4eeef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fa15b-4559-4a8f-aa29-5c43eb4eeef9.jpg?1",
             "name": "Douse in Gloom",
             "text": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -7680,7 +7680,7 @@
         },
         {
             "id": "940ddc2c-40c4-500d-a2da-2b7f31f5a4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f2f66-a43b-422e-94b7-3c068314b7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f2f66-a43b-422e-94b7-3c068314b7ec.jpg?1",
             "name": "Drainpipe Vermin",
             "text": "When Drainpipe Vermin dies, you may pay {B}. If you do, target player discards a card.",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "6002a5b6-04e3-582b-83e3-5c12347356d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d0c37f-ebce-4362-9400-6b9a6e439247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d0c37f-ebce-4362-9400-6b9a6e439247.jpg?1",
             "name": "Drana, Liberator of Malakir",
             "text": "Flying, first strike\nWhenever Drana, Liberator of Malakir deals combat damage to a player, put a +1/+1 counter on each attacking creature you control.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "4bab0d43-2519-522d-bb40-8dbba82655be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35fd9cd-795f-4a8b-b2e9-648f6273927e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35fd9cd-795f-4a8b-b2e9-648f6273927e.jpg?1",
             "name": "Dutiful Attendant",
             "text": "When Dutiful Attendant dies, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "b297842d-35dc-5c14-b7d7-e3f261ddbca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39498cd-9b44-4563-b0fd-9258a52a85b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39498cd-9b44-4563-b0fd-9258a52a85b2.jpg?1",
             "name": "Entomber Exarch",
             "text": "When Entomber Exarch enters the battlefield, choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target opponent reveals their hand. You choose a noncreature card from it. That player discards that card.",
             "colours": [
@@ -7817,7 +7817,7 @@
         },
         {
             "id": "4e8f6993-3a8e-558c-9c65-584df8bba4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a6644a-52e6-454e-a479-44b086240974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a6644a-52e6-454e-a479-44b086240974.jpg?1",
             "name": "Eternal Taskmaster",
             "text": "Eternal Taskmaster enters the battlefield tapped.\nWhenever Eternal Taskmaster attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7850,7 +7850,7 @@
         },
         {
             "id": "03784467-adb4-5213-85a0-fd20ebd09f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbc405d-0cfb-45c6-baa1-75845d82e713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbc405d-0cfb-45c6-baa1-75845d82e713.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -7883,7 +7883,7 @@
         },
         {
             "id": "921746cb-3e67-57ed-9b9d-813692f7c830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1cdcba-a04a-4a2f-8bc1-0dd7fa03754d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1cdcba-a04a-4a2f-8bc1-0dd7fa03754d.jpg?1",
             "name": "Exhume",
             "text": "Each player puts a creature card from their graveyard onto the battlefield.",
             "colours": [
@@ -7914,7 +7914,7 @@
         },
         {
             "id": "aca1da85-f6e1-5a14-affd-a5d39dd23812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1653811-1c2c-4e6c-bf1c-287d1b496d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1653811-1c2c-4e6c-bf1c-287d1b496d51.jpg?1",
             "name": "Exquisite Blood",
             "text": "Whenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -7945,7 +7945,7 @@
         },
         {
             "id": "bac6195f-7e31-5fe7-b2bb-ead2feb8e24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60b3c77-62e4-4718-9ddb-cb2e3f1f861f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60b3c77-62e4-4718-9ddb-cb2e3f1f861f.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -7979,7 +7979,7 @@
         },
         {
             "id": "db99bdc7-17f1-5592-9a69-43573caa3728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b3bb-90b1-4241-a9ca-fdd7a0e0f0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b3bb-90b1-4241-a9ca-fdd7a0e0f0ac.jpg?1",
             "name": "Fell Specter",
             "text": "Flying\nWhen Fell Specter enters the battlefield, target opponent discards a card.\nWhenever an opponent discards a card, that player loses 2 life.",
             "colours": [
@@ -8012,7 +8012,7 @@
         },
         {
             "id": "a367c69f-add9-5fb0-a787-8b4f36872697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d7d31e-eaa7-4edf-8e98-5a191ec3b91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d7d31e-eaa7-4edf-8e98-5a191ec3b91d.jpg?1",
             "name": "Festering Newt",
             "text": "When Festering Newt dies, target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch.",
             "colours": [
@@ -8045,7 +8045,7 @@
         },
         {
             "id": "8c9bc777-d4ec-50b1-9ad9-4514ecf94c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb5fb06-d7b3-4871-a530-9004110596ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb5fb06-d7b3-4871-a530-9004110596ad.jpg?1",
             "name": "Funeral Rites",
             "text": "You draw two cards, lose 2 life, then mill two cards. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "99f1abe1-ce4f-5ff0-90f8-b221f93d62f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcba8d3-725b-49f9-8281-eafac15208c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcba8d3-725b-49f9-8281-eafac15208c5.jpg?1",
             "name": "Ghoulcaller Gisa",
             "text": "{B}, {T}, Sacrifice another creature: Create X 2/2 black Zombie creature tokens, where X is the sacrificed creature's power.",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "ca52b885-c462-5ab4-8500-b6136b0b9c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b62aaf-cc36-4235-b802-828b2c4d6341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b62aaf-cc36-4235-b802-828b2c4d6341.jpg?1",
             "name": "Ghoulcaller's Accomplice",
             "text": "{3}{B}, Exile Ghoulcaller's Accomplice from your graveyard: Create a 2/2 black Zombie creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "c8ea4da3-fb96-54f0-b86b-165a024cec96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850ccdcb-2cd7-4f27-aa9b-917a62a5e94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850ccdcb-2cd7-4f27-aa9b-917a62a5e94d.jpg?1",
             "name": "Ghoulraiser",
             "text": "When Ghoulraiser enters the battlefield, return a Zombie card at random from your graveyard to your hand.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "0b955ae7-2979-5b7f-9c96-1bb45a7d35f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644d4d1-8499-40a8-a01f-68172c82bf58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644d4d1-8499-40a8-a01f-68172c82bf58.jpg?1",
             "name": "Gifted Aetherborn",
             "text": "Deathtouch, lifelink",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "d99be31c-b176-530a-bb17-88056d2e06b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb69961-0053-476f-b58e-20b6df0e2649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb69961-0053-476f-b58e-20b6df0e2649.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -8249,7 +8249,7 @@
         },
         {
             "id": "d77d7b84-30e6-560c-a2d6-33bf7833881b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c5eb7a-abb2-46bd-8fbd-19af63e70c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c5eb7a-abb2-46bd-8fbd-19af63e70c9c.jpg?1",
             "name": "Gravewaker",
             "text": "Flying\n{5}{B}{B}: Return target creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "28f84ef1-a6e9-514b-96b5-249ff409ac5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d6e32e-6479-48b3-93ae-da5378c09bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d6e32e-6479-48b3-93ae-da5378c09bb1.jpg?1",
             "name": "Gristle Grinner",
             "text": "Whenever a creature dies, Gristle Grinner gets +2/+2 until end of turn.",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "5cbad187-bf77-51f4-a81c-8e45f1081cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ebc0b-b748-4a21-b939-a48811451bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ebc0b-b748-4a21-b939-a48811451bba.jpg?1",
             "name": "Harvester of Souls",
             "text": "Deathtouch\nWhenever another nontoken creature dies, you may draw a card.",
             "colours": [
@@ -8349,7 +8349,7 @@
         },
         {
             "id": "830d71c5-dfe4-5f17-9d1a-52c84c98d810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29184c64-03f3-4a50-ac18-e34b6c89635e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29184c64-03f3-4a50-ac18-e34b6c89635e.jpg?1",
             "name": "Innocent Blood",
             "text": "Each player sacrifices a creature.",
             "colours": [
@@ -8380,7 +8380,7 @@
         },
         {
             "id": "2e52b35b-76ef-5d7c-924f-911eb81182c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527faa-9d06-4f46-b2f7-c78aedacc3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527faa-9d06-4f46-b2f7-c78aedacc3a4.jpg?1",
             "name": "Kalastria Nightwatch",
             "text": "Whenever you gain life, Kalastria Nightwatch gains flying until end of turn.",
             "colours": [
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "4aca0ce6-b840-5fce-97c9-e44090e4cdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53ce1b-9353-42ad-89a0-36e907ba576a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53ce1b-9353-42ad-89a0-36e907ba576a.jpg?1",
             "name": "Languish",
             "text": "All creatures get -4/-4 until end of turn.",
             "colours": [
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "42bf1b73-fa25-5864-83f5-791a0b7fad9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d3b392-cbd0-437a-a21f-a36d5093a719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d3b392-cbd0-437a-a21f-a36d5093a719.jpg?1",
             "name": "Last Gasp",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -8477,7 +8477,7 @@
         },
         {
             "id": "7b303957-cf7e-58eb-a8f3-ebfe16d68366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49b95d9-2b64-4f33-97b1-db350026aa95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49b95d9-2b64-4f33-97b1-db350026aa95.jpg?1",
             "name": "Launch Party",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature. Its controller loses 2 life.",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "a4384e1f-a116-57a4-9a34-3ffbd2cec9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381b4e3b-85d7-4f61-b395-f278f212bda7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381b4e3b-85d7-4f61-b395-f278f212bda7.jpg?1",
             "name": "Lawless Broker",
             "text": "When Lawless Broker dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8542,7 +8542,7 @@
         },
         {
             "id": "039cc762-9b5f-5478-950e-c28d8e92e0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd4dbd9-982c-43cf-b14c-c3179427d5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd4dbd9-982c-43cf-b14c-c3179427d5a1.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "75c9432e-282c-5008-8689-898c0e34ca41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9396f3-a93c-47ee-91da-78af864c86c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9396f3-a93c-47ee-91da-78af864c86c3.jpg?1",
             "name": "Liliana's Reaver",
             "text": "Deathtouch\nWhenever Liliana's Reaver deals combat damage to a player, that player discards a card and you create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -8608,7 +8608,7 @@
         },
         {
             "id": "69874c03-2da0-5077-83c1-1ccd603620c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5776bc9-7295-4143-a453-64e3c681f8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5776bc9-7295-4143-a453-64e3c681f8e7.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -8639,7 +8639,7 @@
         },
         {
             "id": "85010d5f-824f-5a80-9053-4cdddfcb6888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fe5c92-7da2-47b5-ad13-f95590e93ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fe5c92-7da2-47b5-ad13-f95590e93ac2.jpg?1",
             "name": "Malakir Familiar",
             "text": "Flying, deathtouch\nWhenever you gain life, Malakir Familiar gets +1/+1 until end of turn.",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "9c947bfb-391d-538b-a6a6-cc4178081d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908bf00-86ba-4911-b15b-1af2a79dff85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908bf00-86ba-4911-b15b-1af2a79dff85.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
             "colours": [
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "fde8bcd2-a0a2-5867-a4f7-22f7d20a94ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b6e993-1988-4b6d-970e-be71d95cf21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b6e993-1988-4b6d-970e-be71d95cf21a.jpg?1",
             "name": "Mausoleum Turnkey",
             "text": "When Mausoleum Turnkey enters the battlefield, return target creature card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "657acdcf-e116-51be-9c80-8c8428b7ddef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405c096c-a94b-4817-8c7f-f0551f6513e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405c096c-a94b-4817-8c7f-f0551f6513e3.jpg?1",
             "name": "Miasmic Mummy",
             "text": "When Miasmic Mummy enters the battlefield, each player discards a card.",
             "colours": [
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "259f6c3c-0e90-5793-85f4-8e96533d34ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9dc87b3-60b2-4cf8-b620-334700db1aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9dc87b3-60b2-4cf8-b620-334700db1aa9.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -8807,7 +8807,7 @@
         },
         {
             "id": "0dc56561-5480-5cbb-922a-17d38fd72b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c894372f-7d28-4035-b45a-384c5bf8fd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c894372f-7d28-4035-b45a-384c5bf8fd1f.jpg?1",
             "name": "Nightshade Stinger",
             "text": "Flying\nNightshade Stinger can't block.",
             "colours": [
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "bec37ce6-0bc3-5419-8d36-f5875276e86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9843f26-83ed-4517-8ad6-0e288833d140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9843f26-83ed-4517-8ad6-0e288833d140.jpg?1",
             "name": "Nyxathid",
             "text": "As Nyxathid enters the battlefield, choose an opponent.\nNyxathid gets -1/-1 for each card in the chosen player's hand.",
             "colours": [
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "0ccac2f3-a3ad-5850-a7b6-b21b06d8a505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342052f-6b6b-40b9-bbc9-7ba3e8365fe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342052f-6b6b-40b9-bbc9-7ba3e8365fe1.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "e10ca2f9-f2da-58ad-9bac-cb5d1abfe524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b4b7f9-dfc6-4995-bd41-ff04c98d4c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b4b7f9-dfc6-4995-bd41-ff04c98d4c37.jpg?1",
             "name": "Oona's Blackguard",
             "text": "Flying\nEach other Rogue creature you control enters the battlefield with an additional +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it deals combat damage to a player, that player discards a card.",
             "colours": [
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "6b0b81d4-489e-5c21-afff-a652731777e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43296ce8-f055-4778-a187-363a642001e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43296ce8-f055-4778-a187-363a642001e4.jpg?1",
             "name": "Parasitic Implant",
             "text": "Enchant creature\nAt the beginning of your upkeep, enchanted creature's controller sacrifices it and you create a 1/1 colorless Myr artifact creature token.",
             "colours": [
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "24d93c0d-3afb-5419-aa1a-917ffef0a10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf4c9e1-eff6-4abc-ad4e-ffd7f1895d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf4c9e1-eff6-4abc-ad4e-ffd7f1895d8d.jpg?1",
             "name": "Phyrexian Broodlings",
             "text": "{1}, Sacrifice a creature: Put a +1/+1 counter on Phyrexian Broodlings.",
             "colours": [
@@ -9009,7 +9009,7 @@
         },
         {
             "id": "e90fe02c-5202-516b-aa2c-e72c64da3b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e19435-59e5-44d4-b26f-f140f8bcaeb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e19435-59e5-44d4-b26f-f140f8bcaeb0.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\n{T}, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "d6c721ae-03aa-5625-bc21-8acdaa84c013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4497c0-6e0a-4645-b04e-454d8fe97f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4497c0-6e0a-4645-b04e-454d8fe97f05.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -9077,7 +9077,7 @@
         },
         {
             "id": "2879f6de-5c53-50df-80a5-e688222d52c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb76e0-11ed-4f89-a2f4-04bc67f3c94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb76e0-11ed-4f89-a2f4-04bc67f3c94d.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -9111,7 +9111,7 @@
         },
         {
             "id": "668ff59a-ab30-56b7-badf-b68c1c803b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0271e4-8ad1-4ad9-9b3e-7abf911f3059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0271e4-8ad1-4ad9-9b3e-7abf911f3059.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "f6ec0e94-4a60-53aa-bb50-33de1062da9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bcfb24-1649-4c8f-ba76-346914d11572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bcfb24-1649-4c8f-ba76-346914d11572.jpg?1",
             "name": "Plagued Rusalka",
             "text": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "d0c8027a-46bf-5d58-96bc-97602a2b79bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d3e58e-f989-4169-9e2c-a66a23170dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d3e58e-f989-4169-9e2c-a66a23170dcf.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -9209,7 +9209,7 @@
         },
         {
             "id": "b4dff1a5-0f59-5173-b6e8-57539a4f6e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652271a0-80e8-4b9b-8823-26c1528378fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652271a0-80e8-4b9b-8823-26c1528378fc.jpg?1",
             "name": "Reanimate",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
             "colours": [
@@ -9240,7 +9240,7 @@
         },
         {
             "id": "d1723bd4-1c48-5aca-9ef6-7e023564ddae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0e1064-47c3-4f03-a1f2-3bcb356db82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0e1064-47c3-4f03-a1f2-3bcb356db82b.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -9271,7 +9271,7 @@
         },
         {
             "id": "03750fe9-206c-54eb-9ede-dfffd3675dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdebdfd-a29b-4482-ab83-012d5faba2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdebdfd-a29b-4482-ab83-012d5faba2e4.jpg?1",
             "name": "Sangromancer",
             "text": "Flying\nWhenever a creature an opponent controls dies, you may gain 3 life.\nWhenever an opponent discards a card, you may gain 3 life.",
             "colours": [
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "088a4082-784e-5507-90df-5db92f574ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e78a44-fff3-4cbf-929b-8dfed4e45d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e78a44-fff3-4cbf-929b-8dfed4e45d62.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -9338,7 +9338,7 @@
         },
         {
             "id": "e431615a-bf25-5ced-98b7-5f5106764ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39ee60-c467-4145-8ca7-123eef01791e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39ee60-c467-4145-8ca7-123eef01791e.jpg?1",
             "name": "Scourge of Nel Toth",
             "text": "Flying\nYou may cast Scourge of Nel Toth from your graveyard by paying {B}{B} and sacrificing two creatures rather than paying its mana cost.",
             "colours": [
@@ -9372,7 +9372,7 @@
         },
         {
             "id": "64df5f27-df16-5a4f-bafb-be729c7404a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de652420-eacf-4f9d-9f13-c6bc02b0fa72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de652420-eacf-4f9d-9f13-c6bc02b0fa72.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "09428411-3a3f-56f1-af8e-470e725490d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee181d58-fed1-4f6d-96a3-4bf057ddd36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee181d58-fed1-4f6d-96a3-4bf057ddd36e.jpg?1",
             "name": "Settle the Score",
             "text": "Exile target creature. Put two loyalty counters on a planeswalker you control.",
             "colours": [
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "c250b590-84e0-5a20-a3ae-f4f1288cfb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab1d6c-09a6-4f6a-9549-94b439a46680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab1d6c-09a6-4f6a-9549-94b439a46680.jpg?1",
             "name": "Shambling Goblin",
             "text": "When Shambling Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -9470,7 +9470,7 @@
         },
         {
             "id": "7103821b-b53f-5e49-8608-5c89c1bd2d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b207a4a-47d1-4905-81d3-455c59bfd7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b207a4a-47d1-4905-81d3-455c59bfd7da.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nAt the beginning of your upkeep, return target creature card from your graveyard to the battlefield.\nAt the beginning of each opponent's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "7581a137-edc9-5e23-95c6-3462f0a12258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d683abb8-46b4-424e-8a10-325519477419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d683abb8-46b4-424e-8a10-325519477419.jpg?1",
             "name": "Slate Street Ruffian",
             "text": "Whenever Slate Street Ruffian becomes blocked, defending player discards a card.",
             "colours": [
@@ -9540,7 +9540,7 @@
         },
         {
             "id": "ac51bcbd-ede0-5cc5-8e42-0f07ec1d381d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db574719-746a-433e-a5be-06d232a01021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db574719-746a-433e-a5be-06d232a01021.jpg?1",
             "name": "Soul Salvage",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -9571,7 +9571,7 @@
         },
         {
             "id": "4af76f37-49b3-5a2d-8923-098a95f6f3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8dd5c5-823a-47f2-8b12-8005d89fe948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8dd5c5-823a-47f2-8b12-8005d89fe948.jpg?1",
             "name": "Stab Wound",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 2 life.",
             "colours": [
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "526939fa-9bfa-53d2-89d9-356c6865c5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fb56fc-47a4-44ba-8b55-4d0ceb8ce62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fb56fc-47a4-44ba-8b55-4d0ceb8ce62f.jpg?1",
             "name": "Swarm of Bloodflies",
             "text": "Flying\nSwarm of Bloodflies enters the battlefield with two +1/+1 counters on it.\nWhenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies.",
             "colours": [
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "923b34d2-a6cc-513e-af57-23f6e2bfe578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adbd4a5-3171-495a-a540-0ecf280b77fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adbd4a5-3171-495a-a540-0ecf280b77fc.jpg?1",
             "name": "Tempting Witch",
             "text": "When Tempting Witch enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}, {T}, Sacrifice a Food: Target player loses 3 life.",
             "colours": [
@@ -9671,7 +9671,7 @@
         },
         {
             "id": "59cab43a-edaf-5939-96c5-6bff0d034ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bddc9-0b0b-4d6d-a708-019356f9649e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bddc9-0b0b-4d6d-a708-019356f9649e.jpg?1",
             "name": "Tithebearer Giant",
             "text": "When Tithebearer Giant enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -9705,7 +9705,7 @@
         },
         {
             "id": "4c3e85e8-0fd9-5d90-a428-2d25f408024f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7649d57-3537-45a2-b57e-98e7d32025c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7649d57-3537-45a2-b57e-98e7d32025c9.jpg?1",
             "name": "Vampire Neonate",
             "text": "{2}, {T}: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "759dd82a-b7a5-5543-92cf-2f9c2653ce52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e35a461-9a8e-4d08-b963-14c8b5237eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e35a461-9a8e-4d08-b963-14c8b5237eec.jpg?1",
             "name": "Wailing Ghoul",
             "text": "When Wailing Ghoul enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -9771,7 +9771,7 @@
         },
         {
             "id": "92553688-b71b-5eb0-a933-019fc2d5a10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aec0ec-0feb-4276-ab9c-5bb18b5005a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aec0ec-0feb-4276-ab9c-5bb18b5005a0.jpg?1",
             "name": "Wight of Precinct Six",
             "text": "Wight of Precinct Six gets +1/+1 for each creature card in your opponents' graveyards.",
             "colours": [
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "d6a7a111-fc80-54fe-bc88-e559066f6420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce5007-56ab-4361-8130-df48add1492b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce5007-56ab-4361-8130-df48add1492b.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards: Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -9835,7 +9835,7 @@
         },
         {
             "id": "a81a38f6-3d14-583d-9eb0-13d0a31ca304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fec7e6-5ed9-46dc-93b4-7a054d763403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fec7e6-5ed9-46dc-93b4-7a054d763403.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -9866,7 +9866,7 @@
         },
         {
             "id": "8abca07f-f1a0-5828-8801-991eb81c92d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b4cbb7-c9ad-4320-9322-a6a3afbc4a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b4cbb7-c9ad-4320-9322-a6a3afbc4a50.jpg?1",
             "name": "Ashmouth Hound",
             "text": "Whenever Ashmouth Hound blocks or becomes blocked by a creature, Ashmouth Hound deals 1 damage to that creature.",
             "colours": [
@@ -9900,7 +9900,7 @@
         },
         {
             "id": "37d618df-0012-55a1-b8c5-90d0619b2ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b53218-804b-4992-9c93-a797dd6b2a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b53218-804b-4992-9c93-a797dd6b2a04.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample, haste\nAt the beginning of the end step, sacrifice Ball Lightning.",
             "colours": [
@@ -9933,7 +9933,7 @@
         },
         {
             "id": "77676bda-1341-5418-87b0-09a292f2db38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94ff00-0821-4743-b693-2ba310466306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94ff00-0821-4743-b693-2ba310466306.jpg?1",
             "name": "Barrage of Expendables",
             "text": "{R}, Sacrifice a creature: Barrage of Expendables deals 1 damage to any target.",
             "colours": [
@@ -9964,7 +9964,7 @@
         },
         {
             "id": "65fe1242-e26f-557d-b997-30208a7eec92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102740d0-ca74-460d-af30-c71bddad87c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102740d0-ca74-460d-af30-c71bddad87c4.jpg?1",
             "name": "Bathe in Dragonfire",
             "text": "Bathe in Dragonfire deals 4 damage to target creature.",
             "colours": [
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "14c409aa-a9b5-5484-b54b-687e90702196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a514b9-8a67-47aa-8218-8d6fe8040128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a514b9-8a67-47aa-8218-8d6fe8040128.jpg?1",
             "name": "Beetleback Chief",
             "text": "When Beetleback Chief enters the battlefield, create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -10029,7 +10029,7 @@
         },
         {
             "id": "3405c527-5627-55e9-b76c-4069f01ddb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9feaa623-3422-4997-af7b-f75074af5fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9feaa623-3422-4997-af7b-f75074af5fa1.jpg?1",
             "name": "Blindblast",
             "text": "Blindblast deals 1 damage to target creature. That creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -10060,7 +10060,7 @@
         },
         {
             "id": "3567c50e-129d-549b-bf3b-8d65f044a16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b633bf-a77e-4b78-b729-a83896abf17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b633bf-a77e-4b78-b729-a83896abf17c.jpg?1",
             "name": "Bloodrage Brawler",
             "text": "When Bloodrage Brawler enters the battlefield, discard a card.",
             "colours": [
@@ -10094,7 +10094,7 @@
         },
         {
             "id": "43dfdc39-ab26-503c-9e43-0e251df1a0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128f37ff-eb63-4417-87c2-96a3a026fcf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128f37ff-eb63-4417-87c2-96a3a026fcf4.jpg?1",
             "name": "Bloodrock Cyclops",
             "text": "Bloodrock Cyclops attacks each combat if able.",
             "colours": [
@@ -10127,7 +10127,7 @@
         },
         {
             "id": "9cbd8fd0-9684-5cf8-882f-73aa95f191e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1a398b-4551-4522-a90a-620c90bd92c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1a398b-4551-4522-a90a-620c90bd92c7.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -10161,7 +10161,7 @@
         },
         {
             "id": "e4ababf7-5d6c-58f7-a89f-f0240f7d6880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6de3a7-30a7-49d7-8e39-494355c6edae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6de3a7-30a7-49d7-8e39-494355c6edae.jpg?1",
             "name": "Boggart Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -10195,7 +10195,7 @@
         },
         {
             "id": "b1aa5f51-1544-5bae-87bc-991e0fb5628b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3132919-58a7-429f-8a0f-9210d3c2c734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3132919-58a7-429f-8a0f-9210d3c2c734.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -10229,7 +10229,7 @@
         },
         {
             "id": "f06e1f63-dac1-5018-a784-1610122f9b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c80ea-7b29-4335-ba7b-3e51a5a104a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c80ea-7b29-4335-ba7b-3e51a5a104a9.jpg?1",
             "name": "Borderland Minotaur",
             "text": "",
             "colours": [
@@ -10263,7 +10263,7 @@
         },
         {
             "id": "5c519912-8ee5-5a08-a6ce-d7e88e5ca6c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cef88c-0ad6-47c4-b6c8-f989586aa635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cef88c-0ad6-47c4-b6c8-f989586aa635.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "1e78f5e3-dcf4-5333-af38-dac3e328ce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47361f61-b717-4468-8050-5f28a8fe6754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47361f61-b717-4468-8050-5f28a8fe6754.jpg?1",
             "name": "Charmbreaker Devils",
             "text": "At the beginning of your upkeep, return an instant or sorcery card at random from your graveyard to your hand.\nWhenever you cast an instant or sorcery spell, Charmbreaker Devils gets +4/+0 until end of turn.",
             "colours": [
@@ -10327,7 +10327,7 @@
         },
         {
             "id": "31059d36-aab4-5ebd-9e33-0d127c238c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c3c616-1f95-41b1-a624-79d6362d4f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c3c616-1f95-41b1-a624-79d6362d4f16.jpg?1",
             "name": "Cinder Elemental",
             "text": "{X}{R}, {T}, Sacrifice Cinder Elemental: It deals X damage to any target.",
             "colours": [
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "d98e7d6e-ba62-5bb8-8cda-58b222e0f386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81232b04-a4a0-48d8-b8af-a6e3d50173e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81232b04-a4a0-48d8-b8af-a6e3d50173e5.jpg?1",
             "name": "Collateral Damage",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nCollateral Damage deals 3 damage to any target.",
             "colours": [
@@ -10391,7 +10391,7 @@
         },
         {
             "id": "69044e15-b193-5de9-a563-20202750dda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9189fafa-f30f-49a1-b07d-e432640d2bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9189fafa-f30f-49a1-b07d-e432640d2bc5.jpg?1",
             "name": "Dance with Devils",
             "text": "Create two 1/1 red Devil creature tokens. They have \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -10422,7 +10422,7 @@
         },
         {
             "id": "a136fb3e-ec7d-5835-951b-fd858f90a1cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a3153e-4259-4e03-bf79-8979d3c0db36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a3153e-4259-4e03-bf79-8979d3c0db36.jpg?1",
             "name": "Doublecast",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -10453,7 +10453,7 @@
         },
         {
             "id": "e9ced5a5-5b81-5258-b386-0dcb5c11eddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a0ec06-7c48-4334-ac50-c249e7e91dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a0ec06-7c48-4334-ac50-c249e7e91dbe.jpg?1",
             "name": "Draconic Roar",
             "text": "As an additional cost to cast this spell, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast this spell, Draconic Roar deals 3 damage to that creature's controller.",
             "colours": [
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "572e343e-cc53-593c-86b5-6271506fb6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb5eab0-5397-4c00-8cef-7d3baf38a171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb5eab0-5397-4c00-8cef-7d3baf38a171.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "e3aa537b-f9f0-5923-8eec-acc348ad5ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d3a18c-d030-494d-b7b1-4d1d1e27fbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d3a18c-d030-494d-b7b1-4d1d1e27fbbf.jpg?1",
             "name": "Dragon Hatchling",
             "text": "Flying\n{R}: Dragon Hatchling gets +1/+0 until end of turn.",
             "colours": [
@@ -10548,7 +10548,7 @@
         },
         {
             "id": "610626f7-a9f4-5434-8e36-fead585c33a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e5f3d8-c468-412c-a32b-92c5d8fc1e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e5f3d8-c468-412c-a32b-92c5d8fc1e14.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -10582,7 +10582,7 @@
         },
         {
             "id": "cc0ae380-99cc-5644-82df-2bbf81b5de15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca8335b-21b1-40bc-970a-480e74874d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca8335b-21b1-40bc-970a-480e74874d03.jpg?1",
             "name": "Dragonspeaker Shaman",
             "text": "Dragon spells you cast cost {2} less to cast.",
             "colours": [
@@ -10617,7 +10617,7 @@
         },
         {
             "id": "03e3a827-5867-5214-abe5-b63eed54d511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d294e8-ed96-4584-b4f2-1b03ae6d1314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d294e8-ed96-4584-b4f2-1b03ae6d1314.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "ce0787cb-e94f-5821-b681-f2cf34343b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c40669-87fa-4b1e-885f-2d0a626c3a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c40669-87fa-4b1e-885f-2d0a626c3a25.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "f5ace32a-b38e-511f-813a-5e8c49641a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05469d01-0d2b-47b9-8a69-16cf0c3d43f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05469d01-0d2b-47b9-8a69-16cf0c3d43f8.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to any target.",
             "colours": [
@@ -10721,7 +10721,7 @@
         },
         {
             "id": "6532ea14-2353-59e9-9ea4-344a036d5369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8383e698-0dd7-4f35-aecb-53f0ee746999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8383e698-0dd7-4f35-aecb-53f0ee746999.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to any target.",
             "colours": [
@@ -10752,7 +10752,7 @@
         },
         {
             "id": "b772ef86-a55e-5f9a-9ab1-6f089fbad1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584cdb52-08f8-425b-8407-8192b1dc6843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584cdb52-08f8-425b-8407-8192b1dc6843.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "85e4bcfb-d6b7-5ed1-b9be-4ade336f62da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b32bb8a-ff23-436d-8e63-bbaf05e830ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b32bb8a-ff23-436d-8e63-bbaf05e830ca.jpg?1",
             "name": "Flames of the Raze-Boar",
             "text": "Flames of the Raze-Boar deals 4 damage to target creature an opponent controls. Then Flames of the Raze-Boar deals 2 damage to each other creature that player controls if you control a creature with power 4 or greater.",
             "colours": [
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "55dd4324-5f50-5774-8962-1e104e34cc38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3f8d6-80ff-4292-871e-e19907841448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3f8d6-80ff-4292-871e-e19907841448.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -10847,7 +10847,7 @@
         },
         {
             "id": "e115dca8-8480-5a88-b474-310c1dd48782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42d773-c742-4465-b6d5-31feaba49146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42d773-c742-4465-b6d5-31feaba49146.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to any target.",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "6674a4a5-cc16-52aa-a35e-52d4f1070339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be522ae8-9cf4-4c63-9a1c-0010d482c00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be522ae8-9cf4-4c63-9a1c-0010d482c00a.jpg?1",
             "name": "Flurry of Horns",
             "text": "Create two 2/3 red Minotaur creature tokens with haste.",
             "colours": [
@@ -10909,7 +10909,7 @@
         },
         {
             "id": "4b938616-a61d-56a4-b224-c45c9e3e570a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7308e6-4303-4f01-928b-f154b376e1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7308e6-4303-4f01-928b-f154b376e1a5.jpg?1",
             "name": "Forge Devil",
             "text": "When Forge Devil enters the battlefield, it deals 1 damage to target creature and 1 damage to you.",
             "colours": [
@@ -10942,7 +10942,7 @@
         },
         {
             "id": "429a224c-c3c5-5037-97b2-a2350619cd01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce76e86-39f3-4ebf-b550-88ea7f23a91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce76e86-39f3-4ebf-b550-88ea7f23a91f.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -10975,7 +10975,7 @@
         },
         {
             "id": "cc5ceae0-871f-5f89-8dfd-d5b39fd35c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fcc35b-76fa-4408-8620-a1e11b2caf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fcc35b-76fa-4408-8620-a1e11b2caf1f.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -11008,7 +11008,7 @@
         },
         {
             "id": "9a6f0222-3590-5590-929e-ee380a6ba1a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c742d940-1a8d-487a-a787-2ad96a96ef1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c742d940-1a8d-487a-a787-2ad96a96ef1f.jpg?1",
             "name": "Goblin Commando",
             "text": "When Goblin Commando enters the battlefield, it deals 2 damage to target creature.",
             "colours": [
@@ -11041,7 +11041,7 @@
         },
         {
             "id": "01457c99-b554-516b-b188-6ac79bb8260e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7.jpg?1",
             "name": "Goblin Goon",
             "text": "Goblin Goon can't attack unless you control more creatures than defending player.\nGoblin Goon can't block unless you control more creatures than attacking player.",
             "colours": [
@@ -11075,7 +11075,7 @@
         },
         {
             "id": "a7d4f50e-491d-58e1-a39c-fd48ee637c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32d7ce5-078b-40ff-8ecb-34309a0e3719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32d7ce5-078b-40ff-8ecb-34309a0e3719.jpg?1",
             "name": "Goblin Instigator",
             "text": "When Goblin Instigator enters the battlefield, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "6eef3253-0da2-5e26-ad66-2e632581b786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660e7067-9f1d-4e2c-bd12-0ad752a3cec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660e7067-9f1d-4e2c-bd12-0ad752a3cec8.jpg?1",
             "name": "Goblin Lore",
             "text": "Draw four cards, then discard three cards at random.",
             "colours": [
@@ -11140,7 +11140,7 @@
         },
         {
             "id": "eb853940-d92f-5090-b0c9-8291841dd691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6a2d0-d855-4b87-9f4c-58dda0b81c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6a2d0-d855-4b87-9f4c-58dda0b81c82.jpg?1",
             "name": "Goblin Rally",
             "text": "Create four 1/1 red Goblin creature tokens.",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "6097e46e-52ea-55c9-a3c8-bffa2dfeee01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a98be-e7d9-4cb7-a7ed-de2bf593170d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a98be-e7d9-4cb7-a7ed-de2bf593170d.jpg?1",
             "name": "Goblin Shortcutter",
             "text": "When Goblin Shortcutter enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -11205,7 +11205,7 @@
         },
         {
             "id": "72cb65e2-9014-51e8-a4e6-d2d833c4640c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a359f4a8-3c06-441a-81bd-e3773b122e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a359f4a8-3c06-441a-81bd-e3773b122e45.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -11239,7 +11239,7 @@
         },
         {
             "id": "dfe5fccf-d934-5734-8c20-d389d364d2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee4e3-c9eb-4898-99cd-bbe148936f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee4e3-c9eb-4898-99cd-bbe148936f99.jpg?1",
             "name": "Hamletback Goliath",
             "text": "Whenever another creature enters the battlefield, you may put X +1/+1 counters on Hamletback Goliath, where X is that creature's power.",
             "colours": [
@@ -11273,7 +11273,7 @@
         },
         {
             "id": "714d2ff8-8798-52fa-b06a-49151dc268b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af482a14-a144-4e60-bd04-a548a3c89f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af482a14-a144-4e60-bd04-a548a3c89f5a.jpg?1",
             "name": "Heartfire",
             "text": "As an additional cost to cast this spell, sacrifice a creature or planeswalker.\nHeartfire deals 4 damage to any target.",
             "colours": [
@@ -11304,7 +11304,7 @@
         },
         {
             "id": "70928977-e5d9-5945-b0e6-f7e4081c9dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbfd905-8c71-4389-9174-6e84bcbcf05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbfd905-8c71-4389-9174-6e84bcbcf05c.jpg?1",
             "name": "Hellrider",
             "text": "Haste\nWhenever a creature you control attacks, Hellrider deals 1 damage to the player or planeswalker it's attacking.",
             "colours": [
@@ -11337,7 +11337,7 @@
         },
         {
             "id": "8e77e38a-0e28-56d6-8327-1902df2b0173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212e27a-d2e1-430d-86ff-1f7abaad46d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212e27a-d2e1-430d-86ff-1f7abaad46d4.jpg?1",
             "name": "Homing Lightning",
             "text": "Homing Lightning deals 4 damage to target creature and each other creature with the same name as that creature.",
             "colours": [
@@ -11368,7 +11368,7 @@
         },
         {
             "id": "0552eb00-02d9-5ecd-b0b3-588154966b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392a36-e63a-4648-b8df-1172403922eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392a36-e63a-4648-b8df-1172403922eb.jpg?1",
             "name": "Hungry Flames",
             "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player or planeswalker.",
             "colours": [
@@ -11399,7 +11399,7 @@
         },
         {
             "id": "7199116d-4551-57bd-b8e9-ad58cc5640f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c59a4db-5806-40da-8752-cec05af6bf51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c59a4db-5806-40da-8752-cec05af6bf51.jpg?1",
             "name": "Inferno Hellion",
             "text": "Trample\nAt the beginning of each end step, if Inferno Hellion attacked or blocked this turn, its owner shuffles it into their library.",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "21a9c1b2-6ccb-55df-8097-eeaec624ae1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c957c94-3d2d-4b98-8990-cd8909462081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c957c94-3d2d-4b98-8990-cd8909462081.jpg?1",
             "name": "Kiln Fiend",
             "text": "Whenever you cast an instant or sorcery spell, Kiln Fiend gets +3/+0 until end of turn.",
             "colours": [
@@ -11466,7 +11466,7 @@
         },
         {
             "id": "d63e5f07-a342-5957-851c-2dec9b6bc0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9fec9d-23c8-4d35-97c1-9499527198fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9fec9d-23c8-4d35-97c1-9499527198fb.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "137bcbfd-9dd4-52f4-82ea-f21dc4771dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9460e3c6-e745-41d3-8e17-0b92fb126a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9460e3c6-e745-41d3-8e17-0b92fb126a16.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon enters the battlefield under your control, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -11537,7 +11537,7 @@
         },
         {
             "id": "cb3d28cb-9cbc-5de1-8b25-185dbb899e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65ea432-9ece-40bf-9cdc-95e01a85b78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65ea432-9ece-40bf-9cdc-95e01a85b78f.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -11568,7 +11568,7 @@
         },
         {
             "id": "f5e9103b-8b91-54fc-88bc-57ca415bdb44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce711943-c1a1-43a0-8b89-8d169cfb8e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce711943-c1a1-43a0-8b89-8d169cfb8e06.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -11599,7 +11599,7 @@
         },
         {
             "id": "3c699c2c-4ba4-5e6d-be85-691d03ce1743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9223ac16-e6fc-4ba6-91d9-7ff27cc17271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9223ac16-e6fc-4ba6-91d9-7ff27cc17271.jpg?1",
             "name": "Lightning Diadem",
             "text": "Enchant creature\nWhen Lightning Diadem enters the battlefield, it deals 2 damage to any target.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -11632,7 +11632,7 @@
         },
         {
             "id": "5927428d-9c25-5d68-9748-541678867207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a959e-7c17-4226-afcb-bc0bb5a4492b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a959e-7c17-4226-afcb-bc0bb5a4492b.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste",
             "colours": [
@@ -11665,7 +11665,7 @@
         },
         {
             "id": "83b3cd54-8152-5bdd-9336-76f5e518227a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017f94bc-f7f0-4eed-9ca0-392872405f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017f94bc-f7f0-4eed-9ca0-392872405f32.jpg?1",
             "name": "Lightning Shrieker",
             "text": "Flying, trample, haste\nAt the beginning of the end step, Lightning Shrieker's owner shuffles it into their library.",
             "colours": [
@@ -11698,7 +11698,7 @@
         },
         {
             "id": "0b1a422b-b757-5a4e-ad97-23e40acc3dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975ce11-589a-4da8-a016-854bbaeb869c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975ce11-589a-4da8-a016-854bbaeb869c.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to any target. Scry 2.",
             "colours": [
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "71c0d11d-9b14-5f90-b032-be9739542675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feebd1ba-758f-4029-9f5c-19b07146b80d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feebd1ba-758f-4029-9f5c-19b07146b80d.jpg?1",
             "name": "Magmaquake",
             "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
             "colours": [
@@ -11760,7 +11760,7 @@
         },
         {
             "id": "5053af10-bad4-50bc-927e-008db77c3277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8669513f-4fc2-47ee-a919-f4b538be2385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8669513f-4fc2-47ee-a919-f4b538be2385.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "0d6d100f-67b9-548b-81f4-99ede2f74521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fef9f8-ff3e-4a3f-a3ff-4534ff0c3946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fef9f8-ff3e-4a3f-a3ff-4534ff0c3946.jpg?1",
             "name": "Minotaur Skullcleaver",
             "text": "Haste\nWhen Minotaur Skullcleaver enters the battlefield, it gets +2/+0 until end of turn.",
             "colours": [
@@ -11825,7 +11825,7 @@
         },
         {
             "id": "e7365281-c30f-5c12-908f-866349a71ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd65150-a698-4f23-836c-5cd0fb153eb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd65150-a698-4f23-836c-5cd0fb153eb3.jpg?1",
             "name": "Minotaur Sureshot",
             "text": "Reach\n{1}{R}: Minotaur Sureshot gets +1/+0 until end of turn.",
             "colours": [
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "8ea83f8b-ca1a-5846-bb39-09b169b7e6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5664b7d-b553-4e0a-93ec-3d70e8e4f63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5664b7d-b553-4e0a-93ec-3d70e8e4f63b.jpg?1",
             "name": "Molten Ravager",
             "text": "{R}: Molten Ravager gets +1/+0 until end of turn.",
             "colours": [
@@ -11892,7 +11892,7 @@
         },
         {
             "id": "fff24045-ad81-5683-bf9d-871a85c3bbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d36724e-0669-43f9-9d10-f67562b8c6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d36724e-0669-43f9-9d10-f67562b8c6bc.jpg?1",
             "name": "Mugging",
             "text": "Mugging deals 2 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "1df212c5-830b-52f5-b2f6-10a14e1cc5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164e358-cbb4-4c3a-aea2-48f1891757df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164e358-cbb4-4c3a-aea2-48f1891757df.jpg?1",
             "name": "Ornery Goblin",
             "text": "Whenever Ornery Goblin blocks or becomes blocked by a creature, Ornery Goblin deals 1 damage to that creature.",
             "colours": [
@@ -11957,7 +11957,7 @@
         },
         {
             "id": "8bf734d1-d968-5299-8b76-1b1499270ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1214fc4-26ac-4a57-b894-6fd634d4d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1214fc4-26ac-4a57-b894-6fd634d4d4fd.jpg?1",
             "name": "Outnumber",
             "text": "Outnumber deals damage to target creature equal to the number of creatures you control.",
             "colours": [
@@ -11988,7 +11988,7 @@
         },
         {
             "id": "9b8f0a3f-adcd-5c01-bdad-73302ac3b307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdb47a8-130b-4ca9-ad29-9484b5c0c582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdb47a8-130b-4ca9-ad29-9484b5c0c582.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -12019,7 +12019,7 @@
         },
         {
             "id": "a2c506a6-ca96-5e3e-860d-529d83d798e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15148b4e-19e2-4e39-8e6f-1dc94ea03463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15148b4e-19e2-4e39-8e6f-1dc94ea03463.jpg?1",
             "name": "Pyroclastic Elemental",
             "text": "{1}{R}{R}: Pyroclastic Elemental deals 1 damage to target player.",
             "colours": [
@@ -12052,7 +12052,7 @@
         },
         {
             "id": "fabc3c66-884d-53be-9e30-87be142c91e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568a31c0-799b-48b6-a91c-95d176b22670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568a31c0-799b-48b6-a91c-95d176b22670.jpg?1",
             "name": "Rageblood Shaman",
             "text": "Trample\nOther Minotaur creatures you control get +1/+1 and have trample.",
             "colours": [
@@ -12086,7 +12086,7 @@
         },
         {
             "id": "f8a973cc-cbb3-5d88-8249-eae31fbb5d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495c0dbf-1671-40f9-809c-98ef6d588512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495c0dbf-1671-40f9-809c-98ef6d588512.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -12119,7 +12119,7 @@
         },
         {
             "id": "77f6f67b-4216-506c-bbbf-3f61974929bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14f36e-54b8-4019-bc85-0d9218c52ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14f36e-54b8-4019-bc85-0d9218c52ad2.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose any target. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that permanent or player. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -12150,7 +12150,7 @@
         },
         {
             "id": "a1eefe68-fd12-5c1f-a74d-ab3bfde9eb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47daba07-1f1e-48e1-a500-ef94d0a3b327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47daba07-1f1e-48e1-a500-ef94d0a3b327.jpg?1",
             "name": "Sarkhan's Rage",
             "text": "Sarkhan's Rage deals 5 damage to any target. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
             "colours": [
@@ -12181,7 +12181,7 @@
         },
         {
             "id": "dbbc2146-8a91-5d64-b4cb-b06be26ed6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9c6068-cfd8-4371-b549-e474d573e52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9c6068-cfd8-4371-b549-e474d573e52e.jpg?1",
             "name": "Sarkhan's Unsealing",
             "text": "Whenever you cast a creature spell with power 4, 5, or 6, Sarkhan's Unsealing deals 4 damage to any target.\nWhenever you cast a creature spell with power 7 or greater, Sarkhan's Unsealing deals 4 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -12212,7 +12212,7 @@
         },
         {
             "id": "b8b46109-8d29-5a54-9abc-10c39d767aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dcec0d7-897e-4593-bd09-460207e28c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dcec0d7-897e-4593-bd09-460207e28c90.jpg?1",
             "name": "Seismic Elemental",
             "text": "When Seismic Elemental enters the battlefield, creatures without flying can't block this turn.",
             "colours": [
@@ -12245,7 +12245,7 @@
         },
         {
             "id": "3d9ab48d-a868-5b88-80c6-1d37a211be88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89172e-0542-4858-9e65-38b1bac8cdeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89172e-0542-4858-9e65-38b1bac8cdeb.jpg?1",
             "name": "Sin Prodder",
             "text": "Menace\nAt the beginning of your upkeep, reveal the top card of your library. Any opponent may have you put that card into your graveyard. If a player does, Sin Prodder deals damage to that player equal to that card's converted mana cost. Otherwise, put that card into your hand.",
             "colours": [
@@ -12278,7 +12278,7 @@
         },
         {
             "id": "912b6a5a-8ff3-5335-9ed7-1f48e4acf599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1aa8f9-8200-4ddd-9ab5-1a8181cc1792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1aa8f9-8200-4ddd-9ab5-1a8181cc1792.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals damage to target creature equal to the number of Mountains you control.",
             "colours": [
@@ -12309,7 +12309,7 @@
         },
         {
             "id": "e54bda3a-a33a-5895-8e33-0646f017178f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c1b56-621a-4908-89b2-21622d195223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c1b56-621a-4908-89b2-21622d195223.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -12343,7 +12343,7 @@
         },
         {
             "id": "cf592ada-e494-5531-a0a8-3cbfba7aa2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2947ad7e-d365-45ff-b107-35819b308f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2947ad7e-d365-45ff-b107-35819b308f8c.jpg?1",
             "name": "Tibalt's Rager",
             "text": "When Tibalt's Rager dies, it deals 1 damage to any target.\n{1}{R}: Tibalt's Rager gets +2/+0 until end of turn.",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "a545392b-84e3-5074-856a-58de0a30a927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c3aa66-2436-40a3-a541-185f457bd55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c3aa66-2436-40a3-a541-185f457bd55a.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -12409,7 +12409,7 @@
         },
         {
             "id": "9291d782-dfb6-5ad7-9c39-3d518d9d4ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba926b-915c-4dd2-84f3-019775e1cc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba926b-915c-4dd2-84f3-019775e1cc14.jpg?1",
             "name": "Volcanic Fallout",
             "text": "This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
             "colours": [
@@ -12440,7 +12440,7 @@
         },
         {
             "id": "e8d8a466-152c-5131-abf6-a2487f761813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8e3b3-c8bb-415d-a19f-45ec679108ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8e3b3-c8bb-415d-a19f-45ec679108ee.jpg?1",
             "name": "Volley Veteran",
             "text": "When Volley Veteran enters the battlefield, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -12474,7 +12474,7 @@
         },
         {
             "id": "a15ee6fd-aec0-57c9-b5a0-1423cc2a0a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9ea25-7a5e-4b6d-b071-e929f6b652c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9ea25-7a5e-4b6d-b071-e929f6b652c4.jpg?1",
             "name": "Warfire Javelineer",
             "text": "When Warfire Javelineer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -12508,7 +12508,7 @@
         },
         {
             "id": "0946fda8-a1c7-59cc-9c67-5712986e0673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ec5d2-ea36-415c-9aa6-808c88a17932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ec5d2-ea36-415c-9aa6-808c88a17932.jpg?1",
             "name": "Weaver of Lightning",
             "text": "Reach\nWhenever you cast an instant or sorcery spell, Weaver of Lightning deals 1 damage to target creature an opponent controls.",
             "colours": [
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "aa7ffa26-75b6-5918-8c37-5967f7f28dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218af707-cc60-407e-af20-e21879a0e902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218af707-cc60-407e-af20-e21879a0e902.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -12576,7 +12576,7 @@
         },
         {
             "id": "b72038e6-f8b2-55df-8994-14a31550e8f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f13bda-9157-437d-b58b-20d34d03fc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f13bda-9157-437d-b58b-20d34d03fc49.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -12609,7 +12609,7 @@
         },
         {
             "id": "0665d2a7-0643-5678-b31d-16e205ae5b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff69e6a8-f34f-4aea-9a54-c4b64ed3116c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff69e6a8-f34f-4aea-9a54-c4b64ed3116c.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -12640,7 +12640,7 @@
         },
         {
             "id": "6fa14f89-73eb-5e60-bf16-372173d708c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8664d29-dacc-49cb-949f-e00ceeb75ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8664d29-dacc-49cb-949f-e00ceeb75ff6.jpg?1",
             "name": "Ambassador Oak",
             "text": "When Ambassador Oak enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -12674,7 +12674,7 @@
         },
         {
             "id": "4a1fb4cb-c1aa-5e93-bba0-24ff8d74a612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c10923-a5b3-4b50-ae51-59982e05963a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c10923-a5b3-4b50-ae51-59982e05963a.jpg?1",
             "name": "Arbor Armament",
             "text": "Put a +1/+1 counter on target creature. That creature gains reach until end of turn.",
             "colours": [
@@ -12705,7 +12705,7 @@
         },
         {
             "id": "93d597a4-a224-5ebe-bfd9-f4b93dd4eb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bd60d3-d2d3-4b69-bd08-04833ff2394e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bd60d3-d2d3-4b69-bd08-04833ff2394e.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -12739,7 +12739,7 @@
         },
         {
             "id": "5c6c8f4e-46d1-54fc-a21d-9c4434347eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf261c8-98e4-491e-9e51-a9058ff2c03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf261c8-98e4-491e-9e51-a9058ff2c03a.jpg?1",
             "name": "Assault Formation",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -12770,7 +12770,7 @@
         },
         {
             "id": "e401d3e3-4a92-5253-9958-82365f0a9a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de98df4-9552-4ba6-a324-1669dc077d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de98df4-9552-4ba6-a324-1669dc077d4c.jpg?1",
             "name": "Awakener Druid",
             "text": "When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature for as long as Awakener Druid remains on the battlefield. It's still a land.",
             "colours": [
@@ -12804,7 +12804,7 @@
         },
         {
             "id": "04ca4a31-cb1c-5fa7-900f-5e12356672d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a41e3-1c5a-467e-9ffb-e6a5f817f8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a41e3-1c5a-467e-9ffb-e6a5f817f8fe.jpg?1",
             "name": "Brindle Shoat",
             "text": "When Brindle Shoat dies, create a 3/3 green Boar creature token.",
             "colours": [
@@ -12837,7 +12837,7 @@
         },
         {
             "id": "8ec6e5d4-e491-5239-a40c-3577839bfda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6649d5e9-22fb-4134-a4d9-ee05e6668f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6649d5e9-22fb-4134-a4d9-ee05e6668f94.jpg?1",
             "name": "Brushstrider",
             "text": "Vigilance",
             "colours": [
@@ -12870,7 +12870,7 @@
         },
         {
             "id": "edae399a-534f-5a88-8218-29c8d4a98755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53847a21-aded-4aaa-9bf1-8592e67763ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53847a21-aded-4aaa-9bf1-8592e67763ef.jpg?1",
             "name": "Carven Caryatid",
             "text": "Defender\nWhen Carven Caryatid enters the battlefield, draw a card.",
             "colours": [
@@ -12903,7 +12903,7 @@
         },
         {
             "id": "dee52dd6-6cf2-5393-80e0-aa90fc2af2b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d851d8-d7d0-4b8a-b520-f3863b78bc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d851d8-d7d0-4b8a-b520-f3863b78bc66.jpg?1",
             "name": "Champion of Lambholt",
             "text": "Creatures with power less than Champion of Lambholt's power can't block creatures you control.\nWhenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.",
             "colours": [
@@ -12937,7 +12937,7 @@
         },
         {
             "id": "dd7304ff-0283-5f91-9539-c1f15024e4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66d2ddc-b4d4-4387-bde0-16d81ef2b1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66d2ddc-b4d4-4387-bde0-16d81ef2b1a7.jpg?1",
             "name": "Commune with Dinosaurs",
             "text": "Look at the top five cards of your library. You may reveal a Dinosaur or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -12968,7 +12968,7 @@
         },
         {
             "id": "1b7a8f63-73e1-52bb-965d-109747f5e2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44afd414-cc69-4888-ba12-7ea87e60b1f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44afd414-cc69-4888-ba12-7ea87e60b1f7.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "2f96a3a8-d104-543d-a004-6c8381505dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01398f5f-f38e-45a7-b755-e65c8fa779f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01398f5f-f38e-45a7-b755-e65c8fa779f8.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -13032,7 +13032,7 @@
         },
         {
             "id": "2c91be93-dae1-55f9-97ac-4c428b75bad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fab2b-ff28-4e02-9f25-e038c754b2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fab2b-ff28-4e02-9f25-e038c754b2cf.jpg?1",
             "name": "Dawntreader Elk",
             "text": "{G}, Sacrifice Dawntreader Elk: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -13065,7 +13065,7 @@
         },
         {
             "id": "e2bc98cb-a9c0-51f7-a1ec-589d2d0d92c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f1d2e6-ffa4-4c4e-8179-671deb9f5a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f1d2e6-ffa4-4c4e-8179-671deb9f5a7f.jpg?1",
             "name": "Drover of the Mighty",
             "text": "Drover of the Mighty gets +2/+2 as long as you control a Dinosaur.\n{T}: Add one mana of any color.",
             "colours": [
@@ -13099,7 +13099,7 @@
         },
         {
             "id": "ea37311b-1dfb-5f50-828f-83ebcaf025cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95d4f15-613c-42f1-a49b-f4f604e69feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95d4f15-613c-42f1-a49b-f4f604e69feb.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When Dwynen's Elite enters the battlefield, if you control another Elf, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -13133,7 +13133,7 @@
         },
         {
             "id": "ee84ac29-c684-5e50-97b9-7be6dc33f337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819f4-cabf-4a31-86f4-3213deb6b719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819f4-cabf-4a31-86f4-3213deb6b719.jpg?1",
             "name": "Elemental Uprising",
             "text": "Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. It must be blocked this turn if able.",
             "colours": [
@@ -13164,7 +13164,7 @@
         },
         {
             "id": "9fb57475-aa6b-508f-a59f-78d2f343d977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc63793-9bf9-4c69-8f6d-74484bb40fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc63793-9bf9-4c69-8f6d-74484bb40fda.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} for each Elf you control.",
             "colours": [
@@ -13198,7 +13198,7 @@
         },
         {
             "id": "7c31a37a-70a9-530e-8e41-9c6ce8e641ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9f4647-4214-4f11-8995-72e149592e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9f4647-4214-4f11-8995-72e149592e2f.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -13229,7 +13229,7 @@
         },
         {
             "id": "a013de81-5792-53c9-add8-c13c4b41c4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea6c234-ede2-4543-ab8e-38d7a503a5e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea6c234-ede2-4543-ab8e-38d7a503a5e1.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -13260,7 +13260,7 @@
         },
         {
             "id": "47bb07a5-2824-5330-a127-3cb4c8982bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70180e04-1453-43dc-9bbb-ab0d6291a8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70180e04-1453-43dc-9bbb-ab0d6291a8b5.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -13294,7 +13294,7 @@
         },
         {
             "id": "541dfbc3-207a-53f3-90f3-e4412f8f75bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bc8745-9aaf-4b3c-922f-5a577324bb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bc8745-9aaf-4b3c-922f-5a577324bb1f.jpg?1",
             "name": "Feral Hydra",
             "text": "Feral Hydra enters the battlefield with X +1/+1 counters on it.\n{3}: Put a +1/+1 counter on Feral Hydra. Any player may activate this ability.",
             "colours": [
@@ -13328,7 +13328,7 @@
         },
         {
             "id": "eb213985-6a31-5290-91d0-3ccedb88c726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ad379-1a0f-4598-b5b1-453955846597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ad379-1a0f-4598-b5b1-453955846597.jpg?1",
             "name": "Feral Invocation",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -13361,7 +13361,7 @@
         },
         {
             "id": "28ddd8ce-2afb-5f6b-931a-8ce0dbbe0124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59d92b0-5ad1-42a7-9c06-1cb31a63bd64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59d92b0-5ad1-42a7-9c06-1cb31a63bd64.jpg?1",
             "name": "Feral Prowler",
             "text": "When Feral Prowler dies, draw a card.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "a634bc58-f109-53dd-8cc8-e7181a6083b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ca48-b34c-4b9f-bd58-e85e75d94508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ca48-b34c-4b9f-bd58-e85e75d94508.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles their library.",
             "colours": [
@@ -13427,7 +13427,7 @@
         },
         {
             "id": "965d0f5f-5a52-5464-a891-3e054728960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c342309-aef7-4733-ac1c-ff0b704539a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c342309-aef7-4733-ac1c-ff0b704539a7.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -13463,7 +13463,7 @@
         },
         {
             "id": "07858405-7725-5d5b-b000-085a0e61d028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23680a1a-7c8d-4ea0-a62c-a302f07b6ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23680a1a-7c8d-4ea0-a62c-a302f07b6ed5.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -13497,7 +13497,7 @@
         },
         {
             "id": "683af11a-714e-5bda-87ba-18856f9d8e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084446ca-fec5-446f-b6f8-edf32ecb57e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084446ca-fec5-446f-b6f8-edf32ecb57e3.jpg?1",
             "name": "Grave Bramble",
             "text": "Defender\nProtection from Zombies (This creature can't be blocked, targeted, or dealt damage by Zombies.)",
             "colours": [
@@ -13530,7 +13530,7 @@
         },
         {
             "id": "44c9f13f-a65b-56d4-9da7-f35046578a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12cf74d-aad9-41d8-959e-66557c39204d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12cf74d-aad9-41d8-959e-66557c39204d.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -13561,7 +13561,7 @@
         },
         {
             "id": "7563a3b7-24f8-56ea-8767-6bf6663e2c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e83c1-e5e3-49b2-bbf3-fad8cc7d020a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e83c1-e5e3-49b2-bbf3-fad8cc7d020a.jpg?1",
             "name": "Initiate's Companion",
             "text": "Whenever Initiate's Companion deals combat damage to a player, untap target creature or land.",
             "colours": [
@@ -13594,7 +13594,7 @@
         },
         {
             "id": "4b34c85f-e508-5c8a-83c3-e962a83d3827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a443d-ab85-4c3e-9fd4-f84afcea2665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a443d-ab85-4c3e-9fd4-f84afcea2665.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "6111893c-4e84-5b27-b1eb-4e0803dac91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5573f8-5fdd-4050-af2a-fbdec51e4f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5573f8-5fdd-4050-af2a-fbdec51e4f37.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -13658,7 +13658,7 @@
         },
         {
             "id": "cac5bfdf-7b08-5a7c-a41b-c41552f82899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb613e46-af18-4195-883b-cdd35b2eaf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb613e46-af18-4195-883b-cdd35b2eaf50.jpg?1",
             "name": "Irresistible Prey",
             "text": "Target creature must be blocked this turn if able.\nDraw a card.",
             "colours": [
@@ -13689,7 +13689,7 @@
         },
         {
             "id": "e372c550-2f00-5d73-88cc-06fb9e0e05cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c21c795-e455-4ecf-a7a2-8f204c114c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c21c795-e455-4ecf-a7a2-8f204c114c81.jpg?1",
             "name": "Keeper of Fables",
             "text": "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -13722,7 +13722,7 @@
         },
         {
             "id": "8543f61a-2620-5ed3-875f-613ae8d6099d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b3bd44-3b01-4507-b9be-ab94601ea736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b3bd44-3b01-4507-b9be-ab94601ea736.jpg?1",
             "name": "Leaf Gilder",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -13756,7 +13756,7 @@
         },
         {
             "id": "9ef954f7-912c-5e26-99b5-6956aa447c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c622c-03ed-492d-baf9-6412cf5e50f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c622c-03ed-492d-baf9-6412cf5e50f4.jpg?1",
             "name": "Lifecrafter's Gift",
             "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -13787,7 +13787,7 @@
         },
         {
             "id": "64b0ec38-b064-5676-8fa6-2e46aabdb3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9952da7c-3cfc-413f-8849-0f10e9c8dceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9952da7c-3cfc-413f-8849-0f10e9c8dceb.jpg?1",
             "name": "Lurking Predators",
             "text": "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.",
             "colours": [
@@ -13818,7 +13818,7 @@
         },
         {
             "id": "d0aa6513-a61e-5354-9f7d-691d77e6b161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a6f558-a754-4437-8328-00a6ca47f9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a6f558-a754-4437-8328-00a6ca47f9b5.jpg?1",
             "name": "Momentous Fall",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nYou draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness.",
             "colours": [
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "8b5d05b2-9356-501a-9489-1a0f0a8940e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cf9d11-936f-4e02-8595-0cbcabaafb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cf9d11-936f-4e02-8595-0cbcabaafb1e.jpg?1",
             "name": "Nature's Way",
             "text": "Target creature you control gains vigilance and trample until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -13880,7 +13880,7 @@
         },
         {
             "id": "70f03e8e-ec4a-5dea-b9d3-c1b790dfa471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1900efd-262a-4eef-a8e8-238801466a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1900efd-262a-4eef-a8e8-238801466a88.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on Nessian Hornbeetle.",
             "colours": [
@@ -13913,7 +13913,7 @@
         },
         {
             "id": "7695e2ba-5879-5e06-8604-c2d08b952d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7df29a3-c40f-4cd8-a6fe-c1b95085cfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7df29a3-c40f-4cd8-a6fe-c1b95085cfed.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen New Horizons enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -13946,7 +13946,7 @@
         },
         {
             "id": "d2a0499e-ded9-57c3-85b5-c72443730390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de097e5-e960-4404-a370-defe93ce892f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de097e5-e960-4404-a370-defe93ce892f.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "db627403-b4c6-55bd-af6d-941101497380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20471a3b-90f9-4463-9b43-fc7b9b28f5d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20471a3b-90f9-4463-9b43-fc7b9b28f5d1.jpg?1",
             "name": "Orazca Frillback",
             "text": "",
             "colours": [
@@ -14013,7 +14013,7 @@
         },
         {
             "id": "1e430d89-a75d-54c8-b482-2856eb0e6d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50974264-b509-4df9-802b-623805a4cbee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50974264-b509-4df9-802b-623805a4cbee.jpg?1",
             "name": "Overgrown Battlement",
             "text": "Defender\n{T}: Add {G} for each creature with defender you control.",
             "colours": [
@@ -14046,7 +14046,7 @@
         },
         {
             "id": "043e3a13-a2db-5c12-8df1-0c2a3d99e37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cce86-ff61-4d24-8d37-8c27acaff21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cce86-ff61-4d24-8d37-8c27acaff21c.jpg?1",
             "name": "Penumbra Bobcat",
             "text": "When Penumbra Bobcat dies, create a 2/1 black Cat creature token.",
             "colours": [
@@ -14079,7 +14079,7 @@
         },
         {
             "id": "7dda9c07-4513-5919-9496-5cb162d8d571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f5156b-b200-41f7-8b93-557c4cdc2bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f5156b-b200-41f7-8b93-557c4cdc2bf7.jpg?1",
             "name": "Pouncing Cheetah",
             "text": "Flash",
             "colours": [
@@ -14112,7 +14112,7 @@
         },
         {
             "id": "cc99ec88-fe9c-5582-8849-f5a04c7347fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba661af-c4a8-4230-830e-a9ee22b25d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba661af-c4a8-4230-830e-a9ee22b25d6b.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Create a 1/1 green Elf Warrior creature token.\"",
             "colours": [
@@ -14145,7 +14145,7 @@
         },
         {
             "id": "51e6f431-5f75-5cb9-a15e-69f30d3d651b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8123d01-da65-4d03-9f23-3842fba5fc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8123d01-da65-4d03-9f23-3842fba5fc28.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nWhenever a land enters the battlefield under your control, you gain 3 life.",
             "colours": [
@@ -14176,7 +14176,7 @@
         },
         {
             "id": "e80b5e3d-ef57-5f3a-943f-3797dd66b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0d8dec-e139-4565-9259-3c24c54c1d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0d8dec-e139-4565-9259-3c24c54c1d45.jpg?1",
             "name": "Primordial Sage",
             "text": "Whenever you cast a creature spell, you may draw a card.",
             "colours": [
@@ -14209,7 +14209,7 @@
         },
         {
             "id": "bd859129-fe7b-52f4-81dc-ad9983ded5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9a1e7-fe87-40e0-bff9-a1fa84b3b949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9a1e7-fe87-40e0-bff9-a1fa84b3b949.jpg?1",
             "name": "Rampaging Brontodon",
             "text": "Trample\nWhenever Rampaging Brontodon attacks, it gets +1/+1 until end of turn for each land you control.",
             "colours": [
@@ -14242,7 +14242,7 @@
         },
         {
             "id": "10694fbf-a753-56ec-ad7d-4313e6d7a77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48df6c-8d5d-4d8a-b98a-793f6a56184d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48df6c-8d5d-4d8a-b98a-793f6a56184d.jpg?1",
             "name": "Ravenous Baloth",
             "text": "Sacrifice a Beast: You gain 4 life.",
             "colours": [
@@ -14275,7 +14275,7 @@
         },
         {
             "id": "67d38ff2-926d-5a06-8032-24f92ae10c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a35e69-145f-4cb0-b7f1-0eac8638afbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a35e69-145f-4cb0-b7f1-0eac8638afbe.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -14311,7 +14311,7 @@
         },
         {
             "id": "c8c9bce7-3471-5f69-92f2-adbc454c7c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a56610-482b-4ddf-88e1-e4a2edf4fa0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a56610-482b-4ddf-88e1-e4a2edf4fa0f.jpg?1",
             "name": "Rumbling Baloth",
             "text": "",
             "colours": [
@@ -14344,7 +14344,7 @@
         },
         {
             "id": "f5c1bb68-c447-5cee-8a93-b6ac874a3f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf15ef-91e9-433f-a4c8-e670adef904c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf15ef-91e9-433f-a4c8-e670adef904c.jpg?1",
             "name": "Savage Stomp",
             "text": "This spell costs {2} less to cast if it targets a Dinosaur you control.\nPut a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -14375,7 +14375,7 @@
         },
         {
             "id": "9a44f479-d867-5411-a410-bf34b3f673d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f2163-5e08-4465-9669-a5a176a2b810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f2163-5e08-4465-9669-a5a176a2b810.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -14409,7 +14409,7 @@
         },
         {
             "id": "cec8cd30-796e-5802-93ad-2f742b5940bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87782d-e9c7-440b-bd96-aa043d18e185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87782d-e9c7-440b-bd96-aa043d18e185.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "005b2fd7-9d34-56fa-a3d1-72f457355830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cc1d52-04bd-4546-a20f-d2993654c830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cc1d52-04bd-4546-a20f-d2993654c830.jpg?1",
             "name": "Silhana Wayfinder",
             "text": "When Silhana Wayfinder enters the battlefield, look at the top four cards of your library. You may reveal a creature or land card from among them and put it on top of your library. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14479,7 +14479,7 @@
         },
         {
             "id": "7cbb18cb-ee86-589c-ae30-d06ca93d1d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbe1270-7300-4408-a4c8-92157a8a076f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbe1270-7300-4408-a4c8-92157a8a076f.jpg?1",
             "name": "Somberwald Stag",
             "text": "When Somberwald Stag enters the battlefield, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "dfabb7ac-81ff-54f8-84f6-15e3b67c2ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce9104-0ad3-4d3d-bb2c-c456c25030f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce9104-0ad3-4d3d-bb2c-c456c25030f6.jpg?1",
             "name": "Soul of the Harvest",
             "text": "Trample\nWhenever another nontoken creature enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -14545,7 +14545,7 @@
         },
         {
             "id": "b551c6ec-0557-5383-ac95-7dabe1d0c0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2799310-c77a-47b2-b1a5-50c029600020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2799310-c77a-47b2-b1a5-50c029600020.jpg?1",
             "name": "Sporemound",
             "text": "Whenever a land enters the battlefield under your control, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -14578,7 +14578,7 @@
         },
         {
             "id": "55325d46-debe-5bb0-a4c3-965460d36f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16482e12-7a8d-4999-8438-da227e6d1305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16482e12-7a8d-4999-8438-da227e6d1305.jpg?1",
             "name": "Sylvan Brushstrider",
             "text": "When Sylvan Brushstrider enters the battlefield, you gain 2 life.",
             "colours": [
@@ -14611,7 +14611,7 @@
         },
         {
             "id": "2d767e35-75fc-59d6-a91a-d1e8c26aacc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a5be0-a730-4cb7-9d1e-6ae84b5bc872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a5be0-a730-4cb7-9d1e-6ae84b5bc872.jpg?1",
             "name": "Sylvan Ranger",
             "text": "When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -14646,7 +14646,7 @@
         },
         {
             "id": "72b3cedb-5e09-58a5-bbbc-e7b42f697b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0594c41-0361-4a3b-a9cd-60f4e3b0cffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0594c41-0361-4a3b-a9cd-60f4e3b0cffe.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -14679,7 +14679,7 @@
         },
         {
             "id": "41deef35-5b23-5105-977e-5b593961a115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e40ded-6daf-423e-8d74-2c6d448e0853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e40ded-6daf-423e-8d74-2c6d448e0853.jpg?1",
             "name": "Thundering Spineback",
             "text": "Other Dinosaurs you control get +1/+1.\n{5}{G}: Create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -14712,7 +14712,7 @@
         },
         {
             "id": "e643aca7-7caa-54ec-a910-995ec63a321b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e89e51-fd37-4f41-ad13-d1b8a93e5277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e89e51-fd37-4f41-ad13-d1b8a93e5277.jpg?1",
             "name": "Time to Feed",
             "text": "Choose target creature an opponent controls. When that creature dies this turn, you gain 3 life. Target creature you control fights that creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "657d1ea5-f1ed-53c3-9e7b-12b371c0f2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0700d1c1-faab-4a1a-b55d-a2fa4582a2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0700d1c1-faab-4a1a-b55d-a2fa4582a2b4.jpg?1",
             "name": "Ulvenwald Hydra",
             "text": "Reach\nUlvenwald Hydra's power and toughness are each equal to the number of lands you control.\nWhen Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -14776,7 +14776,7 @@
         },
         {
             "id": "b52b487c-f407-5ec6-bbc7-81e9d0bbe1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00cb59d-de35-45b2-a7f8-f8c1e821f6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00cb59d-de35-45b2-a7f8-f8c1e821f6ee.jpg?1",
             "name": "Vastwood Zendikon",
             "text": "Enchant land\nEnchanted land is a 6/4 green Elemental creature. It's still a land.\nWhen enchanted land dies, return that card to its owner's hand.",
             "colours": [
@@ -14809,7 +14809,7 @@
         },
         {
             "id": "c0cd4a49-c31c-5182-aa50-de434153d882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c915a4-a75f-40e7-b78a-9c304dcdd83e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c915a4-a75f-40e7-b78a-9c304dcdd83e.jpg?1",
             "name": "Verdant Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has \"At the beginning of each upkeep, create a 1/1 green Saproling creature token.\"",
             "colours": [
@@ -14842,7 +14842,7 @@
         },
         {
             "id": "72ab390b-86b8-5905-aee8-9b4ea42ececa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836b155-8829-460b-91f8-4cd00b988196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836b155-8829-460b-91f8-4cd00b988196.jpg?1",
             "name": "Wall of Blossoms",
             "text": "Defender\nWhen Wall of Blossoms enters the battlefield, draw a card.",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "523436a7-6490-53cf-bc3d-e9c28a77de0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b7563-752b-4391-95d1-f5e3960d35c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b7563-752b-4391-95d1-f5e3960d35c1.jpg?1",
             "name": "Wall of Vines",
             "text": "Defender, reach",
             "colours": [
@@ -14910,7 +14910,7 @@
         },
         {
             "id": "b49632ec-ef0f-53c3-892a-f7b4a10aa005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b146ba7-591c-4553-b250-0a6eed24f0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b146ba7-591c-4553-b250-0a6eed24f0b5.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -14944,7 +14944,7 @@
         },
         {
             "id": "4e28037c-25ec-5292-b209-15205b8c9506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44ec73-169a-4354-8ee1-238b8abd8d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44ec73-169a-4354-8ee1-238b8abd8d81.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -14975,7 +14975,7 @@
         },
         {
             "id": "4cd1c704-2dec-5a05-8363-bc4c03a9bd51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e49925-a4ab-4960-ad83-20583dcd2c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e49925-a4ab-4960-ad83-20583dcd2c2c.jpg?1",
             "name": "Woodborn Behemoth",
             "text": "As long as you control eight or more lands, Woodborn Behemoth gets +4/+4 and has trample.",
             "colours": [
@@ -15008,7 +15008,7 @@
         },
         {
             "id": "b9abb6bf-6f38-5dd4-ba23-7f853f5afc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61eae36-9c4a-4d72-9431-6cac34dbb527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61eae36-9c4a-4d72-9431-6cac34dbb527.jpg?1",
             "name": "Wren's Run Vanquisher",
             "text": "As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}.\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -15042,7 +15042,7 @@
         },
         {
             "id": "f0265693-ac53-5192-9776-ceadc7ea766e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180aa3d6-8475-4c98-a140-af736a9c135e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180aa3d6-8475-4c98-a140-af736a9c135e.jpg?1",
             "name": "Zendikar's Roil",
             "text": "Whenever a land enters the battlefield under your control, create a 2/2 green Elemental creature token.",
             "colours": [
@@ -15073,7 +15073,7 @@
         },
         {
             "id": "e028b633-2e69-5a0b-ab73-3fcf5087e56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0092a-b642-41be-a907-4c8931962ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0092a-b642-41be-a907-4c8931962ef9.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -15106,7 +15106,7 @@
         },
         {
             "id": "d6b74aae-cf37-5dfd-b0f3-e4039e8ddfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da93bf0-2075-4e36-b69b-3db3d4288e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da93bf0-2075-4e36-b69b-3db3d4288e7a.jpg?1",
             "name": "Dinrova Horror",
             "text": "When Dinrova Horror enters the battlefield, return target permanent to its owner's hand, then that player discards a card.",
             "colours": [
@@ -15141,7 +15141,7 @@
         },
         {
             "id": "c003349a-aeda-57ab-aae2-e60041d8e7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538bc51-e320-437e-867d-0d01621e31fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538bc51-e320-437e-867d-0d01621e31fb.jpg?1",
             "name": "Fusion Elemental",
             "text": "",
             "colours": [
@@ -15182,7 +15182,7 @@
         },
         {
             "id": "24c3b9c0-1d99-5422-b8b3-4f06757ef303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78765aa-f952-47f5-b6fc-8aca93fc4104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78765aa-f952-47f5-b6fc-8aca93fc4104.jpg?1",
             "name": "Ironroot Warlord",
             "text": "Ironroot Warlord's power is equal to the number of creatures you control.\n{3}{G}{W}: Create a 1/1 white Soldier creature token.",
             "colours": [
@@ -15218,7 +15218,7 @@
         },
         {
             "id": "00b74be4-bd80-5924-800f-653fd3587f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64771e8-94bb-452b-b028-619ed3b4327c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64771e8-94bb-452b-b028-619ed3b4327c.jpg?1",
             "name": "Lawmage's Binding",
             "text": "Flash\nEnchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -15253,7 +15253,7 @@
         },
         {
             "id": "ce1b965b-1595-5d6b-8525-f458c09d5cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed111116-c2cc-4c97-a84c-f9576ea2ada7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed111116-c2cc-4c97-a84c-f9576ea2ada7.jpg?1",
             "name": "Maelstrom Archangel",
             "text": "Flying\nWhenever Maelstrom Archangel deals combat damage to a player, you may cast a spell from your hand without paying its mana cost.",
             "colours": [
@@ -15294,7 +15294,7 @@
         },
         {
             "id": "e21c85ab-3eae-53cf-973c-2e33056ae9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1632bd-30bc-40a2-963f-44be3b42efb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1632bd-30bc-40a2-963f-44be3b42efb3.jpg?1",
             "name": "Raging Regisaur",
             "text": "Whenever Raging Regisaur attacks, it deals 1 damage to any target.",
             "colours": [
@@ -15329,7 +15329,7 @@
         },
         {
             "id": "cf1cf1ac-4c9b-520e-865a-e2a45ad4af42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e8ce9-edd7-4ae7-9521-6fb6727cf63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e8ce9-edd7-4ae7-9521-6fb6727cf63b.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice Aether Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice Aether Spellbomb: Draw a card.",
             "colours": [],
@@ -15358,7 +15358,7 @@
         },
         {
             "id": "e23eb20e-7f05-5a67-be7a-98988c2a1d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d2180b-f54c-47a9-9458-28e7a19e35ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d2180b-f54c-47a9-9458-28e7a19e35ee.jpg?1",
             "name": "Alloy Myr",
             "text": "{T}: Add one mana of any color.",
             "colours": [],
@@ -15388,7 +15388,7 @@
         },
         {
             "id": "9d8527f7-0023-5e24-a9b0-65c695cde5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4113be-6dd9-4c15-9f57-a146bc520df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4113be-6dd9-4c15-9f57-a146bc520df8.jpg?1",
             "name": "Ancestral Statue",
             "text": "When Ancestral Statue enters the battlefield, return a nonland permanent you control to its owner's hand.",
             "colours": [],
@@ -15418,7 +15418,7 @@
         },
         {
             "id": "bccd2f2e-5021-5db3-9fc8-cf05eacfdc10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416a2796-08c7-4370-8bc5-2152877e9034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416a2796-08c7-4370-8bc5-2152877e9034.jpg?1",
             "name": "Arcane Encyclopedia",
             "text": "{3}, {T}: Draw a card.",
             "colours": [],
@@ -15445,7 +15445,7 @@
         },
         {
             "id": "d34f647d-6d14-5b6a-a946-df8a6ae8e09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955aa79b-448e-4752-8e36-0fe80c18280c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955aa79b-448e-4752-8e36-0fe80c18280c.jpg?1",
             "name": "Bubbling Cauldron",
             "text": "{1}, {T}, Sacrifice a creature: You gain 4 life.\n{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.",
             "colours": [],
@@ -15472,7 +15472,7 @@
         },
         {
             "id": "ee07a3d9-b20c-5769-83df-5a1f979cf3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3260793-bf43-4862-9e1f-122edfc35ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3260793-bf43-4862-9e1f-122edfc35ee4.jpg?1",
             "name": "Chamber Sentry",
             "text": "Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.\n{X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.\n{W}{U}{B}{R}{G}: Return Chamber Sentry from your graveyard to your hand.",
             "colours": [],
@@ -15508,7 +15508,7 @@
         },
         {
             "id": "73748a64-e411-57d1-9e5b-783c30e28ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc8b2-4413-48e4-8d6f-521b19d839a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc8b2-4413-48e4-8d6f-521b19d839a6.jpg?1",
             "name": "Chromatic Sphere",
             "text": "{1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color. Draw a card.",
             "colours": [],
@@ -15535,7 +15535,7 @@
         },
         {
             "id": "94c4ced9-3209-5f2b-8c83-374b45ba88b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa21a-a92e-4bcd-84fe-a7aa159fd0eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa21a-a92e-4bcd-84fe-a7aa159fd0eb.jpg?1",
             "name": "Dragonloft Idol",
             "text": "As long as you control a Dragon, Dragonloft Idol gets +1/+1 and has flying and trample.",
             "colours": [],
@@ -15565,7 +15565,7 @@
         },
         {
             "id": "010490e9-ac24-5762-b23d-c3376c44d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58382d72-9b2b-44cf-8a02-b745deafc286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58382d72-9b2b-44cf-8a02-b745deafc286.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {C}{C}{C}.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -15592,7 +15592,7 @@
         },
         {
             "id": "2e50e011-c5df-58a7-af81-73df57ce4cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5abd21-9736-4e9e-b195-813461cfcd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5abd21-9736-4e9e-b195-813461cfcd0a.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -15622,7 +15622,7 @@
         },
         {
             "id": "cce45bf7-46a0-54a1-8455-22e0c5f2c0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1195ec5-979b-4c4a-9c04-62bb53c2b011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1195ec5-979b-4c4a-9c04-62bb53c2b011.jpg?1",
             "name": "Gingerbrute",
             "text": "Haste\n{1}: Gingerbrute can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice Gingerbrute: You gain 3 life.",
             "colours": [],
@@ -15653,7 +15653,7 @@
         },
         {
             "id": "8021cdef-65ba-5764-b55a-e0ec89573b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393ef742-6968-4266-ae07-a4564b7f6ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393ef742-6968-4266-ae07-a4564b7f6ede.jpg?1",
             "name": "Guardian Idol",
             "text": "Guardian Idol enters the battlefield tapped.\n{T}: Add {C}.\n{2}: Guardian Idol becomes a 2/2 Golem artifact creature until end of turn.",
             "colours": [],
@@ -15680,7 +15680,7 @@
         },
         {
             "id": "8460c269-ce91-5d1d-b0e3-b6a5fd7a53d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5112871-dd07-4257-9a11-a86523c4a8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5112871-dd07-4257-9a11-a86523c4a8b6.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -15707,7 +15707,7 @@
         },
         {
             "id": "246b9b2b-2ee2-5693-b93e-6b6e786ddb8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d51b3-20a2-4cc3-bd70-7f165940c157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d51b3-20a2-4cc3-bd70-7f165940c157.jpg?1",
             "name": "Herald's Horn",
             "text": "As Herald's Horn enters the battlefield, choose a creature type.\nCreature spells you cast of the chosen type cost {1} less to cast.\nAt the beginning of your upkeep, look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand.",
             "colours": [],
@@ -15734,7 +15734,7 @@
         },
         {
             "id": "451ba3ff-0e23-5540-a83d-e37d32c30e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0c95b0-7b63-40e8-92ad-5ae5ffd3c4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0c95b0-7b63-40e8-92ad-5ae5ffd3c4c1.jpg?1",
             "name": "Jousting Dummy",
             "text": "{3}: Jousting Dummy gets +1/+0 until end of turn.",
             "colours": [],
@@ -15765,7 +15765,7 @@
         },
         {
             "id": "930e76a5-9efe-50b6-9c68-fc6e142745b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc90cf8-9dd6-4dac-8cbb-21677d81e4d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc90cf8-9dd6-4dac-8cbb-21677d81e4d3.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -15795,7 +15795,7 @@
         },
         {
             "id": "5947ec44-ef0e-5d78-a793-62e7d08c1be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54d41-683e-42fd-8aa4-371dddf3bcb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54d41-683e-42fd-8aa4-371dddf3bcb3.jpg?1",
             "name": "Mana Geode",
             "text": "When Mana Geode enters the battlefield, scry 1.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -15822,7 +15822,7 @@
         },
         {
             "id": "58262196-0805-53b2-9965-ae21df793890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d8aa8a-3e87-42ac-9c79-2baec771c1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d8aa8a-3e87-42ac-9c79-2baec771c1ef.jpg?1",
             "name": "Marauder's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "d48244b1-87a2-51e2-99cd-cab907192a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a086bf-19d2-4827-af2c-a6f57d640782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a086bf-19d2-4827-af2c-a6f57d640782.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -15881,7 +15881,7 @@
         },
         {
             "id": "3e210eb5-283e-5166-b610-2216a2e60ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f2e2e5-5ed2-4040-92ba-ad1ac13f03f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f2e2e5-5ed2-4040-92ba-ad1ac13f03f6.jpg?1",
             "name": "Myr Sire",
             "text": "When Myr Sire dies, create a 1/1 colorless Myr artifact creature token.",
             "colours": [],
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "39c83432-a4fc-5a73-8381-b81d159c981f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0aa3726-038f-4522-a7bd-1877a4fef350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0aa3726-038f-4522-a7bd-1877a4fef350.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr dies, it deals 2 damage to any target.",
             "colours": [],
@@ -15943,7 +15943,7 @@
         },
         {
             "id": "343d884d-4181-5f12-8499-d77ff33cf899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff526b-3822-4073-baab-8ea5f95daf91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff526b-3822-4073-baab-8ea5f95daf91.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When Pirate's Cutlass enters the battlefield, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15972,7 +15972,7 @@
         },
         {
             "id": "1b58506a-3f40-5a2e-a58f-51ae4dffa4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f25660-97ec-4308-bc5b-1ee405b23399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f25660-97ec-4308-bc5b-1ee405b23399.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -15999,7 +15999,7 @@
         },
         {
             "id": "f4c7032e-786e-547f-b467-7824769255b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794fe9d4-2af4-40b0-bbb2-8015b6206972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794fe9d4-2af4-40b0-bbb2-8015b6206972.jpg?1",
             "name": "Rogue's Gloves",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16028,7 +16028,7 @@
         },
         {
             "id": "0ca2ca78-7b6e-5f29-a62d-3052c71aab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e64bc76-c6df-4b3c-b37f-f9386d30cab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e64bc76-c6df-4b3c-b37f-f9386d30cab9.jpg?1",
             "name": "Roving Keep",
             "text": "Defender\n{7}: Roving Keep gets +2/+0 and gains trample until end of turn. It can attack this turn as though it didn't have defender.",
             "colours": [],
@@ -16058,7 +16058,7 @@
         },
         {
             "id": "c044e9d3-d25b-5ae8-b730-95a382cca81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedf97b-8901-4558-8bd0-3f488097f686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedf97b-8901-4558-8bd0-3f488097f686.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -16088,7 +16088,7 @@
         },
         {
             "id": "10549c66-5677-5b3c-8f8e-0b8b3272b00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c9d86a-54a3-457c-b9b4-61f914de6e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c9d86a-54a3-457c-b9b4-61f914de6e14.jpg?1",
             "name": "Scarecrone",
             "text": "{1}, Sacrifice a Scarecrow: Draw a card.\n{4}, {T}: Return target artifact creature card from your graveyard to the battlefield.",
             "colours": [],
@@ -16118,7 +16118,7 @@
         },
         {
             "id": "efc23a3d-d27a-5fe3-8416-28fb919a4785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2d0981-0af6-42d6-b926-16f8f2327320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2d0981-0af6-42d6-b926-16f8f2327320.jpg?1",
             "name": "Scroll of Avacyn",
             "text": "{1}, Sacrifice Scroll of Avacyn: Draw a card. If you control an Angel, you gain 5 life.",
             "colours": [],
@@ -16145,7 +16145,7 @@
         },
         {
             "id": "91414b8f-624c-50d3-ac6b-5c612705ce58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd8e7c-13cb-4aea-a3cb-c7ed29d43163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd8e7c-13cb-4aea-a3cb-c7ed29d43163.jpg?1",
             "name": "Scuttlemutt",
             "text": "{T}: Add one mana of any color.\n{T}: Target creature becomes the color or colors of your choice until end of turn.",
             "colours": [],
@@ -16175,7 +16175,7 @@
         },
         {
             "id": "fd366051-085f-5d09-8981-a2f90a1bd8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77f544c-1d27-4632-8ca5-7dfb38f42b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77f544c-1d27-4632-8ca5-7dfb38f42b1c.jpg?1",
             "name": "Signpost Scarecrow",
             "text": "Vigilance\n{2}: Add one mana of any color.",
             "colours": [],
@@ -16205,7 +16205,7 @@
         },
         {
             "id": "301d0cd7-084f-57ee-b547-09735b4cd41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e9f488-db24-4bcd-bdf9-38c1e50f5504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e9f488-db24-4bcd-bdf9-38c1e50f5504.jpg?1",
             "name": "Skittering Surveyor",
             "text": "When Skittering Surveyor enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -16235,7 +16235,7 @@
         },
         {
             "id": "3e301354-c7f2-5743-b2e0-05ca5d492c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b14ff70-6817-4539-b19b-142f8f6b6b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b14ff70-6817-4539-b19b-142f8f6b6b1f.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -16265,7 +16265,7 @@
         },
         {
             "id": "2cc6e8dc-1fcd-57d1-87b3-9212a0e82163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eda056-e00f-4e28-ad26-9150a4704d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eda056-e00f-4e28-ad26-9150a4704d21.jpg?1",
             "name": "Terrarion",
             "text": "Terrarion enters the battlefield tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana in any combination of colors.\nWhen Terrarion is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -16292,7 +16292,7 @@
         },
         {
             "id": "35db08cf-f047-5ad6-a51e-e1dae36a3f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d3681a-78d8-469f-9109-5f8faf04b707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d3681a-78d8-469f-9109-5f8faf04b707.jpg?1",
             "name": "Unstable Obelisk",
             "text": "{T}: Add {C}.\n{7}, {T}, Sacrifice Unstable Obelisk: Destroy target permanent.",
             "colours": [],
@@ -16319,7 +16319,7 @@
         },
         {
             "id": "defb3ebe-be6c-5f21-ab66-705473db4b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7321473-5747-4430-86b2-b5029d9f6486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7321473-5747-4430-86b2-b5029d9f6486.jpg?1",
             "name": "Warmonger's Chariot",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature has defender, it can attack as though it didn't have defender.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16348,7 +16348,7 @@
         },
         {
             "id": "970aa41f-c757-5777-b6ba-cd47a33683a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bc5b7-c4d5-4c4c-af0d-aa0853d63f3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bc5b7-c4d5-4c4c-af0d-aa0853d63f3a.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -16375,7 +16375,7 @@
         },
         {
             "id": "14330b46-8937-5173-baff-564b0cc8354d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9fbb3-9fe4-4ec6-82f0-3bb101524e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9fbb3-9fe4-4ec6-82f0-3bb101524e1e.jpg?1",
             "name": "Mirrodin's Core",
             "text": "{T}: Add {C}.\n{T}: Put a charge counter on Mirrodin's Core.\n{T}, Remove a charge counter from Mirrodin's Core: Add one mana of any color.",
             "colours": [],
@@ -16402,7 +16402,7 @@
         },
         {
             "id": "8e186e43-08f8-5e67-a5ac-552acb092b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b2cc68-1d20-421f-9800-af0996071554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b2cc68-1d20-421f-9800-af0996071554.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -16433,7 +16433,7 @@
         },
         {
             "id": "afe4b64c-1c8b-5bef-9600-2b1f81aaf134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6eadd8-71d8-4a87-8395-efe8cc9f0676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6eadd8-71d8-4a87-8395-efe8cc9f0676.jpg?1",
             "name": "Riptide Laboratory",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Return target Wizard you control to its owner's hand.",
             "colours": [],
@@ -16462,7 +16462,7 @@
         },
         {
             "id": "2e521012-305f-5697-b831-1d65282dd203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2c2fea-d657-49f1-af03-d5d3fef3ead0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2c2fea-d657-49f1-af03-d5d3fef3ead0.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -16489,7 +16489,7 @@
         },
         {
             "id": "412013dc-8a6a-54f8-beb7-77b56baa5057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390a53e5-2392-403d-9105-338e0c8320a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390a53e5-2392-403d-9105-338e0c8320a2.jpg?1",
             "name": "Scholar of the Lost Trove",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/JOU.json
+++ b/Assets/Resources/Sets/JOU.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "0abbf519-365e-57df-81e9-192d6e6b8f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2f381-86a2-42ac-b694-dcde437d574f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2f381-86a2-42ac-b694-dcde437d574f.jpg?1",
             "name": "Aegis of the Gods",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "eadb867f-d5f6-50ed-be4a-00903ef39b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77e2fd5-5c46-4f6b-ac43-ec23fab57a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77e2fd5-5c46-4f6b-ac43-ec23fab57a1a.jpg?1",
             "name": "Ajani's Presence",
             "text": "Strive \u2014 Ajani's Presence costs {2}{W} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+1 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "6d4b4554-b880-532f-b9b0-21c873a2d9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e21938b-46b1-4b2f-8269-0cd0e998cddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e21938b-46b1-4b2f-8269-0cd0e998cddc.jpg?1",
             "name": "Akroan Mastiff",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "b5df9263-354a-5ee0-9abc-2713b224632f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4203df15-dd44-496b-889a-d7a8fe320330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4203df15-dd44-496b-889a-d7a8fe320330.jpg?1",
             "name": "Armament of Nyx",
             "text": "Enchant creature\nEnchanted creature has double strike as long as it's an enchantment. Otherwise, prevent all damage that would be dealt by enchanted creature. (A creature with double strike deals both first-strike and regular combat damage.)",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "e8e230e9-b40e-5b94-b341-b3a1091c48f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaa4800-30cc-4a80-a6cc-9a24ada9eb40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaa4800-30cc-4a80-a6cc-9a24ada9eb40.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield. (That permanent returns under its owner's control.)",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "937bb8fa-dec5-5d1d-995e-545e32e79ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca7b7d9-8b69-411a-8a1d-9b7d0492e7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca7b7d9-8b69-411a-8a1d-9b7d0492e7d0.jpg?1",
             "name": "Dawnbringer Charioteers",
             "text": "Flying, lifelink\nHeroic \u2014 Whenever you cast a spell that targets Dawnbringer Charioteers, put a +1/+1 counter on Dawnbringer Charioteers.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "e571eb4c-33be-5264-9447-a5d12b5ed5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6012964c-eb76-4581-82ae-aec2d36f0d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6012964c-eb76-4581-82ae-aec2d36f0d56.jpg?1",
             "name": "Deicide",
             "text": "Exile target enchantment. If the exiled card is a God card, search its controller's graveyard, hand, and library for any number of cards with the same name as that card and exile them, then that player shuffles his or her library.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "49159197-1934-5c68-a665-8de2bd72a12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95602d52-988c-472b-ba8e-cf25aa92f1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95602d52-988c-472b-ba8e-cf25aa92f1fc.jpg?1",
             "name": "Dictate of Heliod",
             "text": "Flash\nCreatures you control get +2/+2.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "aba2a762-dd00-5bdb-8edc-5e0d8fd1259f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg?1",
             "name": "Eagle of the Watch",
             "text": "Flying, vigilance",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "54b6bd3d-341c-5c88-87a0-31e0545abd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bc8b9e-4d22-41ba-b593-d383fd301ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bc8b9e-4d22-41ba-b593-d383fd301ef9.jpg?1",
             "name": "Eidolon of Rhetoric",
             "text": "Each player can't cast more than one spell each turn.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "a95c27bb-674e-56a3-937a-32910ced5606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef3a8e-ef8b-417a-a3a9-cb0ce88cb0c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef3a8e-ef8b-417a-a3a9-cb0ce88cb0c9.jpg?1",
             "name": "Font of Vigor",
             "text": "{2}{W}, Sacrifice Font of Vigor: You gain 7 life.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "3f62a2dd-79e2-5a05-aef3-b8aa2a55c386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcf3975-7f81-4bdd-810d-476f46444b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcf3975-7f81-4bdd-810d-476f46444b7a.jpg?1",
             "name": "Godsend",
             "text": "Equipped creature gets +3/+3.\nWhenever equipped creature blocks or becomes blocked by one or more creatures, you may exile one of those creatures.\nOpponents can't cast cards with the same name as cards exiled with Godsend.\nEquip {3}",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "cbf343f7-28f6-5b18-bf01-798eaf631e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9256e2-b59c-4997-91c1-4c565746d53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9256e2-b59c-4997-91c1-4c565746d53d.jpg?1",
             "name": "Harvestguard Alseids",
             "text": "Constellation \u2014 Whenever Harvestguard Alseids or another enchantment enters the battlefield under your control, prevent all damage that would be dealt to target creature this turn.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "78d4d192-b09e-5345-84ef-2633bad01443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a6f533-6acb-4c24-ae9d-fe4977230156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a6f533-6acb-4c24-ae9d-fe4977230156.jpg?1",
             "name": "Lagonna-Band Trailblazer",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Lagonna-Band Trailblazer, put a +1/+1 counter on Lagonna-Band Trailblazer.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "407b9968-a592-5990-8aa1-4114b56c40c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e52c0-2f79-4537-8f1c-70b68836bac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e52c0-2f79-4537-8f1c-70b68836bac0.jpg?1",
             "name": "Launch the Fleet",
             "text": "Strive \u2014 Launch the Fleet costs {1} more to cast for each target beyond the first.\nUntil end of turn, any number of target creatures each gain \"Whenever this creature attacks, put a 1/1 white Soldier creature token onto the battlefield tapped and attacking.\"",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "e0ae1ea6-55ff-5db1-806e-385fc6338fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfaa12e-f1d9-4a39-804f-14cdaf382257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfaa12e-f1d9-4a39-804f-14cdaf382257.jpg?1",
             "name": "Leonin Iconoclast",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Leonin Iconoclast, destroy target enchantment creature an opponent controls.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "0f81d745-41fe-5c30-b329-8a75e02c763a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67652df1-f2cc-44cd-ac66-9722d4cd86e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67652df1-f2cc-44cd-ac66-9722d4cd86e9.jpg?1",
             "name": "Mortal Obstinacy",
             "text": "Enchant creature you control\nEnchanted creature gets +1/+1.\nWhenever enchanted creature deals combat damage to a player, you may sacrifice Mortal Obstinacy. If you do, destroy target enchantment.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "7b96a227-773e-5234-a9df-687cf7baaa6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d13a98-e715-49a8-a59e-a2adfcdec70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d13a98-e715-49a8-a59e-a2adfcdec70b.jpg?1",
             "name": "Nyx-Fleece Ram",
             "text": "At the beginning of your upkeep, you gain 1 life.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "1ebe9ef7-1969-54ac-bf65-e4e832385145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac995f-514d-4c65-8135-417f2b1a6fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac995f-514d-4c65-8135-417f2b1a6fba.jpg?1",
             "name": "Oppressive Rays",
             "text": "Enchant creature\nEnchanted creature can't attack or block unless its controller pays {3}.\nActivated abilities of enchanted creature cost {3} more to activate.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "4a837bdb-7088-5933-be6a-e49111fe2e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c67b91-7f05-44b1-9e99-3e2094434f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c67b91-7f05-44b1-9e99-3e2094434f6a.jpg?1",
             "name": "Oreskos Swiftclaw",
             "text": "",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "ed457f38-f18d-5bc0-9886-c6c545ec8176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9aaba1-e480-4667-b3c9-d5665a3b4806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9aaba1-e480-4667-b3c9-d5665a3b4806.jpg?1",
             "name": "Phalanx Formation",
             "text": "Strive \u2014 Phalanx Formation costs {1}{W} more to cast for each target beyond the first.\nAny number of target creatures each gain double strike until end of turn. (They deal both first-strike and regular combat damage.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "13d2f915-7a37-5e1b-894a-67ca628a24c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921128a-ebfd-4e3c-8728-481a8c3c03f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921128a-ebfd-4e3c-8728-481a8c3c03f3.jpg?1",
             "name": "Quarry Colossus",
             "text": "When Quarry Colossus enters the battlefield, put target creature into its owner's library just beneath the top X cards of that library, where X is the number of Plains you control.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "50d40046-ddcc-5c0b-97bd-b0d2d135511d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343baad1-dd58-4d64-9b0a-258618094ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343baad1-dd58-4d64-9b0a-258618094ceb.jpg?1",
             "name": "Reprisal",
             "text": "Destroy target creature with power 4 or greater. It can't be regenerated.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "950586fd-94b2-5618-a861-71bd2594af0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2fcd27-c068-468f-9825-2825c0cf217d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2fcd27-c068-468f-9825-2825c0cf217d.jpg?1",
             "name": "Sightless Brawler",
             "text": "Bestow {4}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nSightless Brawler can't attack alone.\nEnchanted creature gets +3/+2 and can't attack alone.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "37485e19-54db-52da-9900-07876c605c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e3117a-0955-47fc-81c0-7a662c8c487f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e3117a-0955-47fc-81c0-7a662c8c487f.jpg?1",
             "name": "Skybind",
             "text": "Constellation \u2014 Whenever Skybind or another enchantment enters the battlefield under your control, exile target nonenchantment permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "46c0a1dc-e2db-5fa2-a35c-e787cae25044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86ab26f-0959-476f-9f83-939e9138ca8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86ab26f-0959-476f-9f83-939e9138ca8d.jpg?1",
             "name": "Skyspear Cavalry",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "32141275-a415-5d16-9af8-8da38add24f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1cd291-92a0-4f0f-b73a-64fc498da1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1cd291-92a0-4f0f-b73a-64fc498da1ef.jpg?1",
             "name": "Stonewise Fortifier",
             "text": "{4}{W}: Prevent all damage that would be dealt to Stonewise Fortifier by target creature this turn.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "3ff400a7-063c-5650-9a49-6680f510cf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764bd86e-4156-4c58-9ce0-ca3dffbc7298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764bd86e-4156-4c58-9ce0-ca3dffbc7298.jpg?1",
             "name": "Supply-Line Cranes",
             "text": "Flying\nWhen Supply-Line Cranes enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "93723983-17a5-524b-b724-f0fb3bd30c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d901b9d7-6af9-40ce-afb7-d3c9f9143c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d901b9d7-6af9-40ce-afb7-d3c9f9143c18.jpg?1",
             "name": "Tethmos High Priest",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Tethmos High Priest, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "885b1ed5-0bce-536c-a5bd-f6fcef09522e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce86785-bc03-451e-8422-8bb53082cc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce86785-bc03-451e-8422-8bb53082cc12.jpg?1",
             "name": "Aerial Formation",
             "text": "Strive \u2014 Aerial Formation costs {2}{U} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+1 and gain flying until end of turn.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "6c4c32d4-7226-5bec-a8cd-931c7c6f566a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffc93-b107-457c-af04-a1b682a4b886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffc93-b107-457c-af04-a1b682a4b886.jpg?1",
             "name": "Battlefield Thaumaturge",
             "text": "Each instant and sorcery spell you cast costs {1} less to cast for each creature it targets.\nHeroic \u2014 Whenever you cast a spell that targets Battlefield Thaumaturge, Battlefield Thaumaturge gains hexproof until end of turn.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "be6525ff-544b-536d-b5c1-23b5ec2d423f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a639aa-91f4-49df-8671-122710073084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a639aa-91f4-49df-8671-122710073084.jpg?1",
             "name": "Cloaked Siren",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "e39ae191-0bf5-51d3-bf6b-be09aca12c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07815e32-0b64-4c2b-84e6-a72336c45cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07815e32-0b64-4c2b-84e6-a72336c45cf5.jpg?1",
             "name": "Countermand",
             "text": "Counter target spell. Its controller puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "db7cd569-ee9b-59bb-9de4-19c27581af68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a60d25-b97f-40e7-a5ac-c456cee02aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a60d25-b97f-40e7-a5ac-c456cee02aeb.jpg?1",
             "name": "Crystalline Nautilus",
             "text": "Bestow {3}{U}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhen Crystalline Nautilus becomes the target of a spell or ability, sacrifice it.\nEnchanted creature gets +4/+4 and has \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "b707ed88-dacb-5aae-b889-b4f817c18702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5f71ca-e7d9-4f9a-adf1-40353693deea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5f71ca-e7d9-4f9a-adf1-40353693deea.jpg?1",
             "name": "Dakra Mystic",
             "text": "{U}, {T}: Each player reveals the top card of his or her library. You may put the revealed cards into their owners' graveyards. If you don't, each player draws a card.",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "da6a7da7-620d-509e-8726-fe111295e831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d9378d-e553-48b5-8a23-59a35329eda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d9378d-e553-48b5-8a23-59a35329eda2.jpg?1",
             "name": "Daring Thief",
             "text": "Inspired \u2014 Whenever Daring Thief becomes untapped, you may exchange control of target nonland permanent you control and target permanent an opponent controls that shares a card type with it.",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "5302975e-13be-5e99-a8f4-8c846e37e009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7916c-f39a-48a0-a47d-7e83ebf028fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7916c-f39a-48a0-a47d-7e83ebf028fa.jpg?1",
             "name": "Dictate of Kruphix",
             "text": "Flash\nAt the beginning of each player's draw step, that player draws an additional card.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "23cd2416-bf35-52c2-b7a6-ba1ee1bcc458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de3481-9b0d-4747-a97b-171b6aa41073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de3481-9b0d-4747-a97b-171b6aa41073.jpg?1",
             "name": "Font of Fortunes",
             "text": "{1}{U}, Sacrifice Font of Fortunes: Draw two cards.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "a7fa8bd2-0b0c-568d-806d-96cb5d4cca13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da106c23-fd1c-461b-9301-159f93ef489b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da106c23-fd1c-461b-9301-159f93ef489b.jpg?1",
             "name": "Godhunter Octopus",
             "text": "Godhunter Octopus can't attack unless defending player controls an enchantment or an enchanted permanent.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "aadc6659-6cae-5997-bfd8-3f3098f32d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737b859d-d81e-4da3-a8bf-9a8f23c75a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737b859d-d81e-4da3-a8bf-9a8f23c75a50.jpg?1",
             "name": "Hour of Need",
             "text": "Strive \u2014 Hour of Need costs {1}{U} more to cast for each target beyond the first.\nExile any number of target creatures. For each creature exiled this way, its controller puts a 4/4 blue Sphinx creature token with flying onto the battlefield.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "bc7698e0-c578-5fbc-ae51-5255d9289180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f5b473-edad-43a9-b4e7-b6d3fc877cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f5b473-edad-43a9-b4e7-b6d3fc877cf2.jpg?1",
             "name": "Hubris",
             "text": "Return target creature and all Auras attached to it to their owners' hands.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "f0c07171-29bc-5bd2-86b1-aae6f04ff923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f562f-00d1-41da-a6ac-bc019cce7fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f562f-00d1-41da-a6ac-bc019cce7fe7.jpg?1",
             "name": "Hypnotic Siren",
             "text": "Bestow {5}{U}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying\nYou control enchanted creature.\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "292ce9d2-e05c-5b79-87dc-8585f0c58fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696f2da6-3943-4555-9610-e6b925b3d6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696f2da6-3943-4555-9610-e6b925b3d6bc.jpg?1",
             "name": "Interpret the Signs",
             "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's converted mana cost. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "136f23bf-06b6-500e-9d3b-28bed18e0359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b040e5-651b-42ca-b487-66cf1d8180f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b040e5-651b-42ca-b487-66cf1d8180f9.jpg?1",
             "name": "Kiora's Dismissal",
             "text": "",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "8dd349a9-8d2c-5ef7-9aa8-cffd25d21c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04e6915-39b0-4fbc-9114-2ecf371b6f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04e6915-39b0-4fbc-9114-2ecf371b6f72.jpg?1",
             "name": "Pin to the Earth",
             "text": "Enchant creature\nEnchanted creature gets -6/-0.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "716c68a3-6e9f-5f82-9c5a-f2e8da1758c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5f703-339f-430c-b342-77bcc2c63222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5f703-339f-430c-b342-77bcc2c63222.jpg?1",
             "name": "Polymorphous Rush",
             "text": "Strive \u2014 Polymorphous Rush costs {1}{U} more to cast for each target beyond the first.\nChoose a creature on the battlefield. Any number of target creatures you control each become a copy of that creature until end of turn.",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "2d7131a8-122c-5a0d-9695-2762d1466637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051b622-fa1d-4694-aef7-0fcdd7bff8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051b622-fa1d-4694-aef7-0fcdd7bff8d2.jpg?1",
             "name": "Pull from the Deep",
             "text": "Return up to one target instant card and up to one target sorcery card from your graveyard to your hand. Exile Pull from the Deep.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "f398bb28-f7fc-59af-b669-aa9fddef49ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f88da5-b013-478a-8a0b-da9d1e8eb2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f88da5-b013-478a-8a0b-da9d1e8eb2c9.jpg?1",
             "name": "Riptide Chimera",
             "text": "Flying\nAt the beginning of your upkeep, return an enchantment you control to its owner's hand.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "adba7118-81e2-5f3f-a54e-88fdf5139f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b5b278-b883-4703-9bfa-bab5a6da4660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b5b278-b883-4703-9bfa-bab5a6da4660.jpg?1",
             "name": "Rise of Eagles",
             "text": "Put two 2/2 blue Bird enchantment creature tokens with flying onto the battlefield. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "5272a65c-b493-5b75-bb14-683cf1339a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb55caf-fc95-40dc-80af-5144f94333ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb55caf-fc95-40dc-80af-5144f94333ee.jpg?1",
             "name": "Sage of Hours",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Sage of Hours, put a +1/+1 counter on it.\nRemove all +1/+1 counters from Sage of Hours: For each five counters removed this way, take an extra turn after this one.",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "a05b942e-3934-5c0e-b53a-028140b67c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1de7-1476-4f8d-b8b3-67675891df23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1de7-1476-4f8d-b8b3-67675891df23.jpg?1",
             "name": "Scourge of Fleets",
             "text": "When Scourge of Fleets enters the battlefield, return each creature your opponents control with toughness X or less to its owner's hand, where X is the number of Islands you control.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "41de6a6c-a651-5eb8-a8be-086f6886880d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a61f99-44f8-4a2b-b7f2-7899a694552d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a61f99-44f8-4a2b-b7f2-7899a694552d.jpg?1",
             "name": "Sigiled Starfish",
             "text": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "68e88c94-ae29-5ead-8651-8542ac4bac29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebd8c0-bb03-434d-b669-d9b35d07b2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebd8c0-bb03-434d-b669-d9b35d07b2c6.jpg?1",
             "name": "Thassa's Devourer",
             "text": "Constellation \u2014 Whenever Thassa's Devourer or another enchantment enters the battlefield under your control, target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "32bfae5c-a2f8-5e7a-adfc-f51d6af69966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc6245f-c60f-4674-8c6d-24fe3b78e00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc6245f-c60f-4674-8c6d-24fe3b78e00e.jpg?1",
             "name": "Thassa's Ire",
             "text": "{3}{U}: You may tap or untap target creature.",
             "colours": [
@@ -1822,7 +1822,7 @@
         },
         {
             "id": "6a4b9573-518e-5b3c-b52b-00667e5bc4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b6c6b-35f8-4c8a-aa29-ae71d5166121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b6c6b-35f8-4c8a-aa29-ae71d5166121.jpg?1",
             "name": "Triton Cavalry",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Triton Cavalry, you may return target enchantment to its owner's hand.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "967f9454-301d-515a-b360-7bcdfdcb6df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881c554e-2324-41e2-89f1-db9f4017bc31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881c554e-2324-41e2-89f1-db9f4017bc31.jpg?1",
             "name": "Triton Shorestalker",
             "text": "Triton Shorestalker can't be blocked.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "dad824cf-9938-5d85-9a67-9c678224b3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d88c942-3a69-4975-a08d-80405a549beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d88c942-3a69-4975-a08d-80405a549beb.jpg?1",
             "name": "War-Wing Siren",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets War-Wing Siren, put a +1/+1 counter on War-Wing Siren.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "25b3bd7a-aa42-56c8-9a53-3cc093e9c818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f61c85c-03cf-411a-aa66-cbe178aeaa02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f61c85c-03cf-411a-aa66-cbe178aeaa02.jpg?1",
             "name": "Whitewater Naiads",
             "text": "Constellation \u2014 Whenever Whitewater Naiads or another enchantment enters the battlefield under your control, target creature can't be blocked this turn.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "846d8310-4e55-5d42-b813-242549bc1501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07a595-5579-4d5a-b07c-84239d690459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07a595-5579-4d5a-b07c-84239d690459.jpg?1",
             "name": "Agent of Erebos",
             "text": "Constellation \u2014 Whenever Agent of Erebos or another enchantment enters the battlefield under your control, exile all cards from target player's graveyard.",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "ba8fd57e-11b3-5780-bff2-dbb7b1c63ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8956d0-5502-415d-bead-d8bbddf9871d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8956d0-5502-415d-bead-d8bbddf9871d.jpg?1",
             "name": "Aspect of Gorgon",
             "text": "Enchant creature\nEnchanted creature gets +1/+3 and has deathtouch. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "a879c447-f82e-533e-bce2-b168859ed3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a6556b-a4f1-4ff5-8e6e-a47618c8c66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a6556b-a4f1-4ff5-8e6e-a47618c8c66e.jpg?1",
             "name": "Bloodcrazed Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Bloodcrazed Hoplite, put a +1/+1 counter on it.\nWhenever a +1/+1 counter is placed on Bloodcrazed Hoplite, remove a +1/+1 counter from target creature an opponent controls.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "3d17b973-b0e6-5af0-9b33-59ff5d21cdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdc31d5-6726-453e-94e0-69d2fe9447af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdc31d5-6726-453e-94e0-69d2fe9447af.jpg?1",
             "name": "Brain Maggot",
             "text": "When Brain Maggot enters the battlefield, target opponent reveals his or her hand and you choose a nonland card from it. Exile that card until Brain Maggot leaves the battlefield.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "439b67da-fa04-5499-a5fd-17e09c9b247b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1880d4-90c7-46a2-bbc9-d2b52971d11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1880d4-90c7-46a2-bbc9-d2b52971d11c.jpg?1",
             "name": "Cast into Darkness",
             "text": "Enchant creature\nEnchanted creature gets -2/-0 and can't block.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "b580f6a4-570e-5c61-ae92-08b35b8b45e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53624ee-2925-4a56-8706-e278db5d963d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53624ee-2925-4a56-8706-e278db5d963d.jpg?1",
             "name": "Cruel Feeding",
             "text": "Strive \u2014 Cruel Feeding costs {2}{B} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+0 and gain lifelink until end of turn. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "9ee74cdc-17f8-5e59-91e9-f50edd57fd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06db70-95f9-41eb-8e5f-8bc56fd34c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06db70-95f9-41eb-8e5f-8bc56fd34c09.jpg?1",
             "name": "Dictate of Erebos",
             "text": "Flash\nWhenever a creature you control dies, each opponent sacrifices a creature.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "fbe397b3-77ab-5dcd-aa8c-a4988b893cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eabfb-f086-45dd-97e2-b2ed5286bc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eabfb-f086-45dd-97e2-b2ed5286bc3c.jpg?1",
             "name": "Doomwake Giant",
             "text": "Constellation \u2014 Whenever Doomwake Giant or another enchantment enters the battlefield under your control, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "a6383684-f5c5-5ea0-8532-54dec753f469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2b4819-8aeb-49c0-b40a-3ff280604970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2b4819-8aeb-49c0-b40a-3ff280604970.jpg?1",
             "name": "Dreadbringer Lampads",
             "text": "Constellation \u2014 Whenever Dreadbringer Lampads or another enchantment enters the battlefield under your control, target creature gains intimidate until end of turn. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "62a6e01b-b638-57ec-825b-b700c07ae68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6895024f-a04b-46cf-b020-df4487d0c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6895024f-a04b-46cf-b020-df4487d0c758.jpg?1",
             "name": "Extinguish All Hope",
             "text": "Destroy all nonenchantment creatures.",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "43979580-4b2c-58ff-a8d1-cc9f95243ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de07e21e-c12a-47a6-ad2c-ef6fed343407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de07e21e-c12a-47a6-ad2c-ef6fed343407.jpg?1",
             "name": "Feast of Dreams",
             "text": "Destroy target enchanted creature or enchantment creature.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "c5b528b3-db93-5dfc-bcd0-8b72638bf29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cce01-a0cb-4059-a0ad-fbf7d9b998b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cce01-a0cb-4059-a0ad-fbf7d9b998b8.jpg?1",
             "name": "Felhide Petrifier",
             "text": "Deathtouch\nOther Minotaur creatures you control have deathtouch.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "2d278097-8bef-53fd-a01b-26ebc324640c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13eacff-0fd1-4e2e-8213-5bf5fff973c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13eacff-0fd1-4e2e-8213-5bf5fff973c8.jpg?1",
             "name": "Font of Return",
             "text": "{3}{B}, Sacrifice Font of Return: Return up to three target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "a7fb1c3c-ff89-5df5-80cb-12b8d0517717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040af9b9-1e94-4dd1-b347-b54b6b9e0275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040af9b9-1e94-4dd1-b347-b54b6b9e0275.jpg?1",
             "name": "Gnarled Scarhide",
             "text": "Bestow {3}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nGnarled Scarhide can't block.\nEnchanted creature gets +2/+1 and can't block.",
             "colours": [
@@ -2435,7 +2435,7 @@
         },
         {
             "id": "a71da27e-cc68-599f-8712-03e47dfad99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732b5444-0410-430b-87ca-cf2d9f165bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732b5444-0410-430b-87ca-cf2d9f165bd7.jpg?1",
             "name": "Grim Guardian",
             "text": "Constellation \u2014 Whenever Grim Guardian or another enchantment enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "b2f58460-d5d8-57b8-93d6-3c7190354222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5987ab-570a-426c-ae4a-a270fac6b346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5987ab-570a-426c-ae4a-a270fac6b346.jpg?1",
             "name": "King Macar, the Gold-Cursed",
             "text": "Inspired \u2014 Whenever King Macar, the Gold-Cursed becomes untapped, you may exile target creature. If you do, put a colorless artifact token named Gold onto the battlefield. It has \"Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "355904cb-b923-5f9c-8218-ca6d150c09f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528f7a3-0a7b-42e3-8e4f-f1eeab02e23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528f7a3-0a7b-42e3-8e4f-f1eeab02e23a.jpg?1",
             "name": "Master of the Feast",
             "text": "Flying\nAt the beginning of your upkeep, each opponent draws a card.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "6ebff1db-aef6-5f6f-ae18-5d37cdcf40e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bab0e0a-7eb9-4422-a1d4-82cc05b4374d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bab0e0a-7eb9-4422-a1d4-82cc05b4374d.jpg?1",
             "name": "Nightmarish End",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "70d2fbb3-13b2-5161-97f4-f74eb445b46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1910d072-1660-4918-a338-d9f87926541d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1910d072-1660-4918-a338-d9f87926541d.jpg?1",
             "name": "Nyx Infusion",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's an enchantment. Otherwise, it gets -2/-2.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "9172053c-54c7-5c60-a389-020c2a145231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119ce0c-d709-463c-9abc-f7025673ea72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119ce0c-d709-463c-9abc-f7025673ea72.jpg?1",
             "name": "Pharika's Chosen",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "237a15e5-1786-59d8-aa78-00f84eb39023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea61098-2c6a-48d2-b99f-f3065c67d8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea61098-2c6a-48d2-b99f-f3065c67d8e3.jpg?1",
             "name": "Returned Reveler",
             "text": "When Returned Reveler dies, each player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "88ec8031-77aa-57b7-b13e-3af0330f7a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bdf00a-e7f1-42f4-997f-388f3b28bf8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bdf00a-e7f1-42f4-997f-388f3b28bf8f.jpg?1",
             "name": "Ritual of the Returned",
             "text": "Exile target creature card from your graveyard. Put a black Zombie creature token onto the battlefield. Its power is equal to that card's power and its toughness is equal to that card's toughness.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "05c9779f-d955-5f2d-a20e-449b9b2d5e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1066644a-ac62-4809-805c-607c645613c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1066644a-ac62-4809-805c-607c645613c5.jpg?1",
             "name": "Rotted Hulk",
             "text": "",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "408f3550-d44f-5a15-ab18-0633390816aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dc2bd1-a980-4eab-8bb3-1ce28c3f9ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dc2bd1-a980-4eab-8bb3-1ce28c3f9ef4.jpg?1",
             "name": "Silence the Believers",
             "text": "Strive \u2014 Silence the Believers costs {2}{B} more to cast for each target beyond the first.\nExile any number of target creatures and all Auras attached to them.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "cbf58d23-5195-5267-a1f7-2cccd768306e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafaa798-e534-4cd0-b369-9e767a02fe3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafaa798-e534-4cd0-b369-9e767a02fe3d.jpg?1",
             "name": "Spiteful Blow",
             "text": "Destroy target creature and target land.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "d663dd37-efe3-59b0-92bb-c1b3827280c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3fff48-ebc9-4fca-a098-77d973e7d238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3fff48-ebc9-4fca-a098-77d973e7d238.jpg?1",
             "name": "Squelching Leeches",
             "text": "Squelching Leeches's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "3a79c074-0808-5a4d-99bd-cbac31ef58a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69799971-6e24-4b90-ba72-44c6393fc3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69799971-6e24-4b90-ba72-44c6393fc3c4.jpg?1",
             "name": "Thoughtrender Lamia",
             "text": "Constellation \u2014 Whenever Thoughtrender Lamia or another enchantment enters the battlefield under your control, each opponent discards a card.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "aeeb647d-d2a0-54b2-b583-d3a55c0e5123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130655e0-af82-4d91-acc2-270eaa33e3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130655e0-af82-4d91-acc2-270eaa33e3d1.jpg?1",
             "name": "Tormented Thoughts",
             "text": "As an additional cost to cast Tormented Thoughts, sacrifice a creature.\nTarget player discards a number of cards equal to the sacrificed creature's power.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "e28539b2-26da-5ddc-b4c2-b9337495a1af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e21ac-4f3e-4a3e-83c0-0a59a1b84020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e21ac-4f3e-4a3e-83c0-0a59a1b84020.jpg?1",
             "name": "Worst Fears",
             "text": "You control target player during that player's next turn. Exile Worst Fears. (You see all cards that player could see and make all decisions for the player.)",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "50109836-f262-5205-ad02-f832ecbb0382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5114db5-b545-43dc-85a3-c0e68ab22a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5114db5-b545-43dc-85a3-c0e68ab22a95.jpg?1",
             "name": "Akroan Line Breaker",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Line Breaker, Akroan Line Breaker gets +2/+0 and gains intimidate until end of turn.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "2131387e-6da4-540a-a1cd-201ccb158208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d9fa5-a8e0-4263-9804-22d648554eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d9fa5-a8e0-4263-9804-22d648554eba.jpg?1",
             "name": "Bearer of the Heavens",
             "text": "When Bearer of the Heavens dies, destroy all permanents at the beginning of the next end step.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "9d1a2910-6003-5934-bcfe-f5091fb258b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f157fb0-81ac-4108-aafc-7ee81df965a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f157fb0-81ac-4108-aafc-7ee81df965a9.jpg?1",
             "name": "Bladetusk Boar",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "3a4a3f27-f083-536d-95e1-b4695af58566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07f43b6-e07f-4d0c-90d2-e5b0d23ba0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07f43b6-e07f-4d0c-90d2-e5b0d23ba0f9.jpg?1",
             "name": "Blinding Flare",
             "text": "Strive \u2014 Blinding Flare costs {R} more to cast for each target beyond the first.\nAny number of target creatures can't block this turn.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "24176295-f89f-58eb-a2d2-6bd14b2ecc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a92b7a-7119-45b3-b9ed-5dbf5abca818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a92b7a-7119-45b3-b9ed-5dbf5abca818.jpg?1",
             "name": "Cyclops of Eternal Fury",
             "text": "Creatures you control have haste.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "9cf3e08b-568f-516f-b00f-d693812bf157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cc93f2-8198-45b1-9193-7cfd1cf7ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cc93f2-8198-45b1-9193-7cfd1cf7ced4.jpg?1",
             "name": "Dictate of the Twin Gods",
             "text": "Flash\nIf a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "a28f645f-3672-5c3d-8dcc-000a66686123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6c10816-e825-452a-90b0-80eb9f20bd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6c10816-e825-452a-90b0-80eb9f20bd6d.jpg?1",
             "name": "Eidolon of the Great Revel",
             "text": "Whenever a player casts a spell with converted mana cost 3 or less, Eidolon of the Great Revel deals 2 damage to that player.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "9e4a689e-3656-555d-9b84-f45fba53d46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b5e3bb-f9e8-4a74-9798-41d8f8515e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b5e3bb-f9e8-4a74-9798-41d8f8515e12.jpg?1",
             "name": "Flamespeaker's Will",
             "text": "Enchant creature you control\nEnchanted creature gets +1/+1.\nWhenever enchanted creature deals combat damage to a player, you may sacrifice Flamespeaker's Will. If you do, destroy target artifact.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "82929508-3ea4-5108-a473-81daf8da2a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333ff270-4bc7-48ee-9738-f8c70b8a7e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333ff270-4bc7-48ee-9738-f8c70b8a7e40.jpg?1",
             "name": "Flurry of Horns",
             "text": "Put two 2/3 red Minotaur creature tokens with haste onto the battlefield.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "e7613acb-a554-5a49-aa38-88fff17503fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41509414-9faf-472d-8d38-391d9594cd56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41509414-9faf-472d-8d38-391d9594cd56.jpg?1",
             "name": "Font of Ire",
             "text": "{3}{R}, Sacrifice Font of Ire: Font of Ire deals 5 damage to target player.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "a4575acc-0c7c-521c-acd0-b88b6e21c961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80038ed-4206-4e44-943e-f332e4ce2f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80038ed-4206-4e44-943e-f332e4ce2f14.jpg?1",
             "name": "Forgeborn Oreads",
             "text": "Constellation \u2014 Whenever Forgeborn Oreads or another enchantment enters the battlefield under your control, Forgeborn Oreads deals 1 damage to target creature or player.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "5424c657-a096-5d0d-9b78-8483cfdb8490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e583f6be-3d78-4085-9059-c3c989a4977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e583f6be-3d78-4085-9059-c3c989a4977f.jpg?1",
             "name": "Gluttonous Cyclops",
             "text": "{5}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -3344,7 +3344,7 @@
         },
         {
             "id": "93b2ef33-99ad-58a7-959a-207661e5dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde89c1-aafa-43d9-adbf-671fa2b52d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde89c1-aafa-43d9-adbf-671fa2b52d4f.jpg?1",
             "name": "Harness by Force",
             "text": "Strive \u2014 Harness by Force costs {2}{R} more to cast for each target beyond the first.\nGain control of any number of target creatures until end of turn. Untap those creatures. They gain haste until end of turn.",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "a104cd0d-bd78-5acd-b310-ac87076d8acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd48a18-df3d-4381-a7e7-a3e9ae18d4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd48a18-df3d-4381-a7e7-a3e9ae18d4d7.jpg?1",
             "name": "Knowledge and Power",
             "text": "Whenever you scry, you may pay {2}. If you do, Knowledge and Power deals 2 damage to target creature or player.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "4ae93464-ee13-5e87-8dc4-6b1935f0c0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce3f1c6-2e6f-4087-8619-a01fdcc6d4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce3f1c6-2e6f-4087-8619-a01fdcc6d4a3.jpg?1",
             "name": "Lightning Diadem",
             "text": "Enchant creature\nWhen Lightning Diadem enters the battlefield, it deals 2 damage to target creature or player.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "a3805b84-4e34-5096-abf6-41fb4ec6b1e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9710889c-0fc6-43a9-83df-484ab0659030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9710889c-0fc6-43a9-83df-484ab0659030.jpg?1",
             "name": "Magma Spray",
             "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "48dc1127-ca3c-5204-b7ef-801af019a6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e73e06-d708-41dc-b20c-1f71651230e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e73e06-d708-41dc-b20c-1f71651230e1.jpg?1",
             "name": "Mogis's Warhound",
             "text": "Bestow {2}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nMogis's Warhound attacks each turn if able.\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "119932d7-ef43-5c1f-8b2f-61a807b416ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902b462a-a552-42d4-91f0-bd33cd9cb719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902b462a-a552-42d4-91f0-bd33cd9cb719.jpg?1",
             "name": "Pensive Minotaur",
             "text": "",
             "colours": [
@@ -3544,7 +3544,7 @@
         },
         {
             "id": "f725830e-e94a-5474-890f-ffa8d190e8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73326c79-f884-42d5-8546-3db46ce4fe52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73326c79-f884-42d5-8546-3db46ce4fe52.jpg?1",
             "name": "Prophetic Flamespeaker",
             "text": "Double strike, trample\nWhenever Prophetic Flamespeaker deals combat damage to a player, exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "b2f17c81-7e65-5802-9b15-973e000fda18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4250b-4493-4054-b0b2-465f76f0c2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4250b-4493-4054-b0b2-465f76f0c2f0.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose target creature or player. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that creature or player. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "dd1b7725-1799-5a8a-b136-48d67dd13fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a80c4-8119-437d-bf5b-549c5679c90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a80c4-8119-437d-bf5b-549c5679c90a.jpg?1",
             "name": "Rollick of Abandon",
             "text": "All creatures get +2/-2 until end of turn.",
             "colours": [
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "e97eb768-c625-5419-b7d4-f6dad355ccaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a07e7d-e203-4ecd-98bf-f8ef08c38d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a07e7d-e203-4ecd-98bf-f8ef08c38d78.jpg?1",
             "name": "Rouse the Mob",
             "text": "Strive \u2014 Rouse the Mob costs {2}{R} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+0 and gain trample until end of turn.",
             "colours": [
@@ -3675,7 +3675,7 @@
         },
         {
             "id": "23054dde-a803-5968-a4e0-0b5b2c2a389f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8754d66-facb-432e-a6c2-91430a6dec94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8754d66-facb-432e-a6c2-91430a6dec94.jpg?1",
             "name": "Satyr Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Satyr Hoplite, put a +1/+1 counter on Satyr Hoplite.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "d97f3acb-e168-5dfb-9caa-edba4c8848a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f84b4d-82db-4e3a-a099-2e438c0a6418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f84b4d-82db-4e3a-a099-2e438c0a6418.jpg?1",
             "name": "Sigiled Skink",
             "text": "Whenever Sigiled Skink attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "6f815155-38e8-562f-afec-d3cb05dda422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13aa40e-c626-486d-8abc-10aa68542c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13aa40e-c626-486d-8abc-10aa68542c5b.jpg?1",
             "name": "Spawn of Thraxes",
             "text": "Flying\nWhen Spawn of Thraxes enters the battlefield, it deals damage to target creature or player equal to the number of Mountains you control.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "14f06994-b870-50e8-97d0-8fb53c94d9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5676d255-707e-4621-a0df-3305f999f124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5676d255-707e-4621-a0df-3305f999f124.jpg?1",
             "name": "Spite of Mogis",
             "text": "Spite of Mogis deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "72d5d224-023a-5848-8076-803a762eed3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13921f0d-f163-4275-b025-045c1ccd99e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13921f0d-f163-4275-b025-045c1ccd99e5.jpg?1",
             "name": "Starfall",
             "text": "Starfall deals 3 damage to target creature. If that creature is an enchantment, Starfall deals 3 damage to that creature's controller.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "c28f4206-0029-533d-823f-26e882fbb2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207128b3-2de3-495a-bf29-eec50c3bd752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207128b3-2de3-495a-bf29-eec50c3bd752.jpg?1",
             "name": "Twinflame",
             "text": "Strive \u2014 Twinflame costs {2}{R} more to cast for each target beyond the first.\nChoose any number of target creatures you control. For each of them, put a token that's a copy of that creature onto the battlefield. Those tokens have haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "2d7319ad-1f07-5c91-81c7-c832ae520e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a26c23-abb9-41c3-aea1-bb241093119d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a26c23-abb9-41c3-aea1-bb241093119d.jpg?1",
             "name": "Wildfire Cerberus",
             "text": "{5}{R}{R}: Monstrosity 1. (If this creature isn't monstrous, put a +1/+1 counter on it and it becomes monstrous.)\nWhen Wildfire Cerberus becomes monstrous, it deals 2 damage to each opponent and each creature your opponents control.",
             "colours": [
@@ -3908,7 +3908,7 @@
         },
         {
             "id": "6327aad3-1d36-512b-bcf5-8feff15aebf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a1e5c2-7f5b-4ae4-83d9-06e334ba57ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a1e5c2-7f5b-4ae4-83d9-06e334ba57ea.jpg?1",
             "name": "Bassara Tower Archer",
             "text": "Hexproof, reach",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "f6c4c158-eb08-525a-b3a5-50b4dde902e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6139443-e31c-4eea-a99e-df9498fe18a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6139443-e31c-4eea-a99e-df9498fe18a8.jpg?1",
             "name": "Colossal Heroics",
             "text": "Strive \u2014 Colossal Heroics costs {1}{G} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+2 until end of turn. Untap those creatures.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "8d0dd104-5b15-5256-abee-31cb2c00b72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28c0ba-7305-4b64-8cb8-3ecd9c284c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28c0ba-7305-4b64-8cb8-3ecd9c284c4a.jpg?1",
             "name": "Consign to Dust",
             "text": "Strive \u2014 Consign to Dust costs {2}{G} more to cast for each target beyond the first.\nDestroy any number of target artifacts and/or enchantments.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "4cc2c070-9ae6-52bf-9eda-363324c8af79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbc5e5-5d46-47f7-a700-b65781a13c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbc5e5-5d46-47f7-a700-b65781a13c7a.jpg?1",
             "name": "Desecration Plague",
             "text": "Destroy target enchantment or land.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "95d8a02a-51d8-5613-90b8-7fa1ac3e4ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5114607-df8f-4e44-8ef5-b6af89964bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5114607-df8f-4e44-8ef5-b6af89964bbc.jpg?1",
             "name": "Dictate of Karametra",
             "text": "Flash\nWhenever a player taps a land for mana, that player adds one mana to his or her mana pool of any type that land produced.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "e764c891-f985-587a-a738-c52a1aa02ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb2112-85b9-49cf-9ed5-9273829c34f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb2112-85b9-49cf-9ed5-9273829c34f1.jpg?1",
             "name": "Eidolon of Blossoms",
             "text": "Constellation \u2014 Whenever Eidolon of Blossoms or another enchantment enters the battlefield under your control, draw a card.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "5456439b-e09a-5139-9266-6fdd42060548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d1ecb-de7c-4641-81da-13117820195c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d1ecb-de7c-4641-81da-13117820195c.jpg?1",
             "name": "Font of Fertility",
             "text": "{1}{G}, Sacrifice Font of Fertility: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "a2a9eb75-3189-5ae3-af6b-24ad07d4debd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae883ea-191e-4571-be3d-1e3149e6965e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae883ea-191e-4571-be3d-1e3149e6965e.jpg?1",
             "name": "Golden Hind",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "7c52333f-ac56-5bed-8526-238abcf2e092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d107c72f-483a-4af9-b86f-681669d99c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d107c72f-483a-4af9-b86f-681669d99c46.jpg?1",
             "name": "Goldenhide Ox",
             "text": "Constellation \u2014 Whenever Goldenhide Ox or another enchantment enters the battlefield under your control, target creature must be blocked this turn if able.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "029aa49a-7182-513e-beec-519424a43f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e82f6-30ee-49c5-b5a2-85c5cf3e9bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e82f6-30ee-49c5-b5a2-85c5cf3e9bb1.jpg?1",
             "name": "Heroes' Bane",
             "text": "Heroes' Bane enters the battlefield with four +1/+1 counters on it.\n{2}{G}{G}: Put X +1/+1 counters on Heroes' Bane, where X is its power.",
             "colours": [
@@ -4241,7 +4241,7 @@
         },
         {
             "id": "da0b015d-f105-5c69-ae83-4f66512ffc79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12149b9-b450-4ad6-ab5d-9a0eeb36997e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12149b9-b450-4ad6-ab5d-9a0eeb36997e.jpg?1",
             "name": "Humbler of Mortals",
             "text": "Constellation \u2014 Whenever Humbler of Mortals or another enchantment enters the battlefield under your control, creatures you control gain trample until end of turn.",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "55bdab22-a2f5-522a-b778-a95ddeea027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b465289-676d-4c34-84d3-ce8daf0fd40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b465289-676d-4c34-84d3-ce8daf0fd40e.jpg?1",
             "name": "Hydra Broodmaster",
             "text": "{X}{X}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen Hydra Broodmaster becomes monstrous, put X X/X green Hydra creature tokens onto the battlefield.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "67abbd3c-2507-5d4f-8668-632585edbc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e14f09-9629-443a-bc55-03152eabb2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e14f09-9629-443a-bc55-03152eabb2e7.jpg?1",
             "name": "Kruphix's Insight",
             "text": "Reveal the top six cards of your library. Put up to three enchantment cards from among them into your hand and the rest of the revealed cards into your graveyard.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "5ab5863c-57fb-59f3-87cf-6f489ff24311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a70329-ecae-4647-b912-75d936a6c8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a70329-ecae-4647-b912-75d936a6c8c5.jpg?1",
             "name": "Market Festival",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds two mana in any combination of colors to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "4476d1b1-5ec0-54f3-bddc-a3630ed871d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32177b9c-eef3-4eea-b623-74bfea1afad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32177b9c-eef3-4eea-b623-74bfea1afad6.jpg?1",
             "name": "Nature's Panoply",
             "text": "Strive \u2014 Nature's Panoply costs {2}{G} more to cast for each target beyond the first.\nChoose any number of target creatures. Put a +1/+1 counter on each of them.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "1c8392d9-0c7d-5b93-8f8c-10a628843817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5099d18d-c8b5-4706-bc93-40d1bb12988d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5099d18d-c8b5-4706-bc93-40d1bb12988d.jpg?1",
             "name": "Nessian Game Warden",
             "text": "When Nessian Game Warden enters the battlefield, look at the top X cards of your library, where X is the number of Forests you control. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "fcf59a9e-26f6-58cd-9710-b1b2d30ce23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ef63b9-c021-40fe-910e-93c06d660c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ef63b9-c021-40fe-910e-93c06d660c20.jpg?1",
             "name": "Oakheart Dryads",
             "text": "Constellation \u2014 Whenever Oakheart Dryads or another enchantment enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "61ce3558-b8e2-505d-a17e-73c27550668f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19a2e8e-9d8f-4537-838c-ac60e09d78bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19a2e8e-9d8f-4537-838c-ac60e09d78bf.jpg?1",
             "name": "Pheres-Band Thunderhoof",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Pheres-Band Thunderhoof, put two +1/+1 counters on Pheres-Band Thunderhoof.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "39d7dac7-a0b1-5ff0-b642-a0be45c981d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8456730a-607c-44c0-b18e-0df8f35b0634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8456730a-607c-44c0-b18e-0df8f35b0634.jpg?1",
             "name": "Pheres-Band Warchief",
             "text": "Vigilance, trample\nOther Centaur creatures you control get +1/+1 and have vigilance and trample.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "d9ac7620-3b3b-54c6-aeb4-5d56e8e656b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e91524b-4885-45fc-b22d-f9e5ee55845d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e91524b-4885-45fc-b22d-f9e5ee55845d.jpg?1",
             "name": "Ravenous Leucrocota",
             "text": "Vigilance\n{6}{G}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -4582,7 +4582,7 @@
         },
         {
             "id": "42f873e4-921a-51e5-b297-0817c53a9d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240830be-53f8-4f46-a0fb-6ecc439d1349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240830be-53f8-4f46-a0fb-6ecc439d1349.jpg?1",
             "name": "Renowned Weaver",
             "text": "{1}{G}, Sacrifice Renowned Weaver: Put a 1/3 green Spider enchantment creature token with reach onto the battlefield. (It can block creatures with flying.)",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "d1507b98-c122-58de-8294-8218d7428834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b152cc-d39f-470e-8b62-e4a833db7b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b152cc-d39f-470e-8b62-e4a833db7b88.jpg?1",
             "name": "Reviving Melody",
             "text": "Choose one or both \u2014 Return target creature card from your graveyard to your hand; and/or return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "b91244b4-c044-5001-bb26-63fad68a70de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46febca-f3c0-4467-aef4-4dfcdf3009fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46febca-f3c0-4467-aef4-4dfcdf3009fe.jpg?1",
             "name": "Satyr Grovedancer",
             "text": "When Satyr Grovedancer enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "db8d1336-fd9d-55d1-8a8b-268a6afad088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385a1939-15e5-4f13-b01b-7cdc6835da2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385a1939-15e5-4f13-b01b-7cdc6835da2a.jpg?1",
             "name": "Setessan Tactics",
             "text": "Strive \u2014 Setessan Tactics costs {G} more to cast for each target beyond the first.\nUntil end of turn, any number of target creatures each get +1/+1 and gain \"{T}: This creature fights another target creature.\"",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "29052076-172e-588a-89f2-41e03b623908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba88e10-d306-44df-bdbf-f5ba85887fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba88e10-d306-44df-bdbf-f5ba85887fe8.jpg?1",
             "name": "Solidarity of Heroes",
             "text": "Strive \u2014 Solidarity of Heroes costs {1}{G} more to cast for each target beyond the first.\nChoose any number of target creatures. Double the number of +1/+1 counters on each of them.",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "66d2b8e6-27b1-5693-90eb-228cf2e71e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71491f-3027-4257-a18f-ba4de6041feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71491f-3027-4257-a18f-ba4de6041feb.jpg?1",
             "name": "Spirespine",
             "text": "Bestow {4}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nSpirespine blocks each turn if able.\nEnchanted creature gets +4/+1 and blocks each turn if able.",
             "colours": [
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "c3d118c3-4bcc-5178-bf37-27bc5bb0b8fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b3a8e-3cbb-47c4-9535-dfdeece7ee02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b3a8e-3cbb-47c4-9535-dfdeece7ee02.jpg?1",
             "name": "Strength from the Fallen",
             "text": "Constellation \u2014 Whenever Strength from the Fallen or another enchantment enters the battlefield under your control, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "e7c39f0c-0e23-5876-af90-fe9bdfdda951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ddf9-b682-4691-bb1d-abd1d3486f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ddf9-b682-4691-bb1d-abd1d3486f59.jpg?1",
             "name": "Swarmborn Giant",
             "text": "When you're dealt combat damage, sacrifice Swarmborn Giant.\n{4}{G}{G}: Monstrosity 2. (If this creature isn't monstrous, put two +1/+1 counters on it and it becomes monstrous.)\nAs long as Swarmborn Giant is monstrous, it has reach.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "fde92a39-11b7-585e-ba93-fd7f6f3df608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a30bcfa-6f95-450f-aea7-885983d7c6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a30bcfa-6f95-450f-aea7-885983d7c6a5.jpg?1",
             "name": "Ajani, Mentor of Heroes",
             "text": "+1: Distribute three +1/+1 counters among one, two, or three target creatures you control.\n+1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\n-8: You gain 100 life.",
             "colours": [
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "fd3b3599-01f3-59ca-84d0-96b0b61294f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705c53-883e-4b6a-9c08-3fa35f6f17d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705c53-883e-4b6a-9c08-3fa35f6f17d5.jpg?1",
             "name": "Athreos, God of Passage",
             "text": "Indestructible\nAs long as your devotion to white and black is less than seven, Athreos isn't a creature.\nWhenever another creature you own dies, return it to your hand unless target opponent pays 3 life.",
             "colours": [
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "309215af-9e17-5680-8eb5-0a6288bc7179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a4fb8d-8ddd-4d1d-92c7-2bf6b0e6c488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a4fb8d-8ddd-4d1d-92c7-2bf6b0e6c488.jpg?1",
             "name": "Desperate Stand",
             "text": "Strive \u2014 Desperate Stand costs {R}{W} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+0 and gain first strike and vigilance until end of turn.",
             "colours": [
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "a7586d95-a9da-52f4-8d9f-9d513aa0eb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfe88fd-9bb9-42af-8134-96fd264b8405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfe88fd-9bb9-42af-8134-96fd264b8405.jpg?1",
             "name": "Disciple of Deceit",
             "text": "Inspired \u2014 Whenever Disciple of Deceit becomes untapped, you may discard a nonland card. If you do, search your library for a card with the same converted mana cost as that card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "355d9fe2-77e6-5a52-aeb3-1124a53badd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1139236e-5d71-4fc1-937d-ba1efadee031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1139236e-5d71-4fc1-937d-ba1efadee031.jpg?1",
             "name": "Fleetfeather Cockatrice",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying, deathtouch\n{5}{G}{U}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "1a2cded1-cd1b-503a-b189-5b4e81eacfa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacf28cb-feea-4afb-b22e-1b8d50ee66c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacf28cb-feea-4afb-b22e-1b8d50ee66c1.jpg?1",
             "name": "Iroas, God of Victory",
             "text": "Indestructible\nAs long as your devotion to red and white is less than seven, Iroas isn't a creature.\nCreatures you control can't be blocked except by two or more creatures.\nPrevent all damage that would be dealt to attacking creatures you control.",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "a9077792-12d9-52b0-b596-7d59578d444a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab70c262-37a9-4dcd-80bb-d4422368eade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab70c262-37a9-4dcd-80bb-d4422368eade.jpg?1",
             "name": "Keranos, God of Storms",
             "text": "Indestructible\nAs long as your devotion to blue and red is less than seven, Keranos isn't a creature.\nReveal the first card you draw on each of your turns. Whenever you reveal a land card this way, draw a card. Whenever you reveal a nonland card this way, Keranos deals 3 damage to target creature or player.",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "5902ed50-a569-5aed-aeeb-a962a60192af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27427233-da58-45af-ade8-e0727929efaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27427233-da58-45af-ade8-e0727929efaa.jpg?1",
             "name": "Kruphix, God of Horizons",
             "text": "Indestructible\nAs long as your devotion to green and blue is less than seven, Kruphix isn't a creature.\nYou have no maximum hand size.\nIf unused mana would empty from your mana pool, that mana becomes colorless instead.",
             "colours": [
@@ -5150,7 +5150,7 @@
         },
         {
             "id": "d21e0d48-504c-5a56-a96b-6e6940112017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8553cc-8f61-4022-97c9-e31183b65059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8553cc-8f61-4022-97c9-e31183b65059.jpg?1",
             "name": "Nyx Weaver",
             "text": "Reach\nAt the beginning of your upkeep, put the top two cards of your library into your graveyard.\n{1}{B}{G}, Exile Nyx Weaver: Return target card from your graveyard to your hand.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "f3b851d6-266d-5830-b229-43ed904396f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec8548-5790-4eac-8780-cdd126438192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec8548-5790-4eac-8780-cdd126438192.jpg?1",
             "name": "Pharika, God of Affliction",
             "text": "Indestructible\nAs long as your devotion to black and green is less than seven, Pharika isn't a creature.\n{B}{G}: Exile target creature card from a graveyard. Its owner puts a 1/1 black and green Snake enchantment creature token with deathtouch onto the battlefield.",
             "colours": [
@@ -5226,7 +5226,7 @@
         },
         {
             "id": "d52365e8-4064-5cc9-bf38-b5c6b86cfa0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2c774-aab9-4747-af91-da792ed7cfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2c774-aab9-4747-af91-da792ed7cfe1.jpg?1",
             "name": "Revel of the Fallen God",
             "text": "Put four 2/2 red and green Satyr creature tokens with haste onto the battlefield.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "fdad4a7c-736f-5ea6-9a2e-a3ebcfc88040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6621dd-7220-4b53-a30f-7dd05b2e0134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6621dd-7220-4b53-a30f-7dd05b2e0134.jpg?1",
             "name": "Stormchaser Chimera",
             "text": "Flying\n{2}{U}{R}: Scry 1, then reveal the top card of your library. Stormchaser Chimera gets +X/+0 until end of turn, where X is that card's converted mana cost. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "12eba0de-18d9-52b4-b3f5-f59a59d1c30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5346e3-3fe4-47ea-a184-e237091cc4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5346e3-3fe4-47ea-a184-e237091cc4a1.jpg?1",
             "name": "Underworld Coinsmith",
             "text": "Constellation \u2014 Whenever Underworld Coinsmith or another enchantment enters the battlefield under your control, you gain 1 life.\n{W}{B}, Pay 1 life: Each opponent loses 1 life.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "51e6af22-a51f-5e5e-a03d-2fba83456018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac44e4b-25ba-4b32-ad56-c87c202c310a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac44e4b-25ba-4b32-ad56-c87c202c310a.jpg?1",
             "name": "Armory of Iroas",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on it.\nEquip {2}",
             "colours": [],
@@ -5364,7 +5364,7 @@
         },
         {
             "id": "59ce28fa-099b-567f-be43-84927a2f2a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dd03d2-05ef-4929-b973-3dbe49fc7592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dd03d2-05ef-4929-b973-3dbe49fc7592.jpg?1",
             "name": "Chariot of Victory",
             "text": "Equipped creature has first strike, trample, and haste.\nEquip {1}",
             "colours": [],
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "593c4059-368b-526f-902e-945fb2aca67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7d3b2d-e06e-4d30-9ed8-2a52aa7e31c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7d3b2d-e06e-4d30-9ed8-2a52aa7e31c6.jpg?1",
             "name": "Deserter's Quarters",
             "text": "You may choose not to untap Deserter's Quarters during your untap step.\n{6}, {T}: Tap target creature. It doesn't untap during its controller's untap step for as long as Deserter's Quarters remains tapped.",
             "colours": [],
@@ -5422,7 +5422,7 @@
         },
         {
             "id": "24251725-9101-5407-bbb9-26441c51178a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg?1",
             "name": "Gold-Forged Sentinel",
             "text": "Flying",
             "colours": [],
@@ -5453,7 +5453,7 @@
         },
         {
             "id": "0b527f6e-914b-5f23-9b3e-bf428c4796e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634fd988-5d5c-4637-b7fd-05a41798ead8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634fd988-5d5c-4637-b7fd-05a41798ead8.jpg?1",
             "name": "Hall of Triumph",
             "text": "As Hall of Triumph enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+1.",
             "colours": [],
@@ -5483,7 +5483,7 @@
         },
         {
             "id": "1e9e0cc1-7d8a-5adb-ba7d-1857078c4bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504a69eb-3c2d-4bb1-b117-252b15acf0c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504a69eb-3c2d-4bb1-b117-252b15acf0c2.jpg?1",
             "name": "Mana Confluence",
             "text": "{T}, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "782827da-a997-530c-ba18-51210b03b03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b882c6bf-b795-49fe-8242-a928aadb6f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b882c6bf-b795-49fe-8242-a928aadb6f13.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "3c58b880-5407-5d50-8f6c-77e848bf475e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30220f1-1992-4b5c-9e13-1762fb673155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30220f1-1992-4b5c-9e13-1762fb673155.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "f6fa1566-66f9-535e-90dd-5446b9519420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f1983-e9ac-47f0-836d-843a53c054cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f1983-e9ac-47f0-836d-843a53c054cc.jpg?1",
             "name": "Sphinx",
             "text": "",
             "colours": [
@@ -5607,7 +5607,7 @@
         },
         {
             "id": "675dfee7-ab2e-5b06-9d0d-07e567aa9b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c59642-575f-4356-ae1a-20b90895545b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c59642-575f-4356-ae1a-20b90895545b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "88185341-ad20-5d1b-acc3-edaf04f6dac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a3833-ab5b-4f84-b39c-d0eeb7b474d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a3833-ab5b-4f84-b39c-d0eeb7b474d3.jpg?1",
             "name": "Minotaur",
             "text": "",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "2429f52e-1661-533b-bc09-9bad24c35085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1af553-ec9f-46fd-9c6d-49436e93e682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1af553-ec9f-46fd-9c6d-49436e93e682.jpg?1",
             "name": "Hydra",
             "text": "",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "07cb6e21-be71-51ff-8686-2bc7387fda26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0275af-708d-4c43-b226-c88cb9a8054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0275af-708d-4c43-b226-c88cb9a8054c.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "316d0b61-ce39-5800-91b0-f047750e64f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5910a7f2-71a7-4e85-8feb-4a0da228eb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5910a7f2-71a7-4e85-8feb-4a0da228eb15.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/JUD.json
+++ b/Assets/Resources/Sets/JUD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7a7e2e9b-93ad-5616-8e3f-ed53a06acfd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cf71e1-3c57-47f9-a4ef-e0d0ad1ee329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cf71e1-3c57-47f9-a4ef-e0d0ad1ee329.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "First strike\nWhen Ancestor's Chosen comes into play, you gain 1 life for each card in your graveyard.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "01c000d7-f083-528c-b410-cb0047909751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd5d21a-b151-4fea-ac0d-6659af131bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd5d21a-b151-4fea-ac0d-6659af131bf9.jpg?1",
             "name": "Aven Warcraft",
             "text": "Creatures you control get +0/+2 until end of turn.\nThreshold Creatures you control also gain protection from the color of your choice until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "ed6bc7a0-d1e6-5a0b-a8fb-12c993b2dd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c38264-0d79-47d4-bca2-a20a991bbac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c38264-0d79-47d4-bca2-a20a991bbac9.jpg?1",
             "name": "Battle Screech",
             "text": "Put two 1/1 white Bird creature tokens with flying into play.\nFlashback\u2014\nTap three untapped white creatures you control. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d5d0080a-9936-52c8-99bb-60e7a9acb853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca363409-cba9-43ed-bf88-3519521e1983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca363409-cba9-43ed-bf88-3519521e1983.jpg?1",
             "name": "Battlewise Aven",
             "text": "Flying\nThreshold Battlewise Aven gets +1/+1 and has first strike. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "6e47abf7-7a40-5f42-8e20-54bc36a6dd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22492fb3-5ceb-4d5e-ba82-ae1a6a69c105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22492fb3-5ceb-4d5e-ba82-ae1a6a69c105.jpg?1",
             "name": "Benevolent Bodyguard",
             "text": "Sacrifice Benevolent Bodyguard: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "c00ed446-053c-5fc2-aff0-766d9f762a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a85c8-3516-4dda-b16b-bf1bf890becb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a85c8-3516-4dda-b16b-bf1bf890becb.jpg?1",
             "name": "Border Patrol",
             "text": "Attacking doesn't cause Border Patrol to tap.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "5a20b5c3-0f24-5a4d-9af0-6c0f120f1522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ab91ab-2bcf-4617-bec3-2bf040d4997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ab91ab-2bcf-4617-bec3-2bf040d4997c.jpg?1",
             "name": "Cagemail",
             "text": "Enchanted creature gets +2/+2 and can't attack.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "03141537-5877-56c8-8bf3-e2e83dbd99d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1169dab7-8f4c-474d-9289-42765a275376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1169dab7-8f4c-474d-9289-42765a275376.jpg?1",
             "name": "Chastise",
             "text": "Destroy target attacking creature. You gain life equal to its power.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "896d66a4-57e2-5850-98cc-6f45ea9d0a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607f6a9-b8d2-4119-9f70-95dcedc0662d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607f6a9-b8d2-4119-9f70-95dcedc0662d.jpg?1",
             "name": "Commander Eesha",
             "text": "Flying, protection from creatures",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "ed26b57c-d705-5023-903f-645e00e54227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8542f6-ee34-42c6-acd5-07b0c7cc2f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8542f6-ee34-42c6-acd5-07b0c7cc2f63.jpg?1",
             "name": "Funeral Pyre",
             "text": "Remove target card in a graveyard from the game. Its owner puts a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "a7438ac8-0aba-5c4f-8e2b-71866b86887c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a414f0e-b157-4570-8213-1c58a96bf7a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a414f0e-b157-4570-8213-1c58a96bf7a5.jpg?1",
             "name": "Glory",
             "text": "Flying\no2o\nW: Creatures you control gain protection from the color of your choice until end of turn. Play this ability only if Glory is in your graveyard.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "90b8e495-1d89-5abb-be0c-8429906ab699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc409ded-41f3-4f14-8199-72a9fe98bac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc409ded-41f3-4f14-8199-72a9fe98bac0.jpg?1",
             "name": "Golden Wish",
             "text": "Choose an artifact or enchantment card you own from outside the game, reveal that card, and put it into your hand. Remove Golden Wish from the game.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "737bd22c-dfae-5a96-b016-4d1a5ab53b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13138c1-e98f-4803-8c68-ffc80139c168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13138c1-e98f-4803-8c68-ffc80139c168.jpg?1",
             "name": "Guided Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "0faaddc4-02e1-535c-a551-9d1c65f48b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a8fd2f-11fa-4879-be89-ea7833cf60d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a8fd2f-11fa-4879-be89-ea7833cf60d4.jpg?1",
             "name": "Lead Astray",
             "text": "Tap up to two target creatures.",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "a362d31b-1250-5864-bfa6-85cbb48c4efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5694fe-57d2-4359-857a-63213d986747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5694fe-57d2-4359-857a-63213d986747.jpg?1",
             "name": "Nomad Mythmaker",
             "text": "o\nW, oc\nT: Put target enchant creature card from a graveyard into play enchanting a creature you control. (You control that enchantment.)",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "67c87a40-e0f6-5139-964a-b3468a9eeb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617d4246-c827-4742-ab6a-c5170c12cb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617d4246-c827-4742-ab6a-c5170c12cb87.jpg?1",
             "name": "Phantom Flock",
             "text": "Flying\nPhantom Flock comes into play with three +1/+1 counters on it.\nIf damage would be dealt to Phantom Flock, prevent that damage. Remove a +1/+1 counter from Phantom Flock.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "b9fd7e91-c85b-5e6d-bd1f-79e611b6f1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5309f5-8b32-4a57-99f2-dcf7a8341898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5309f5-8b32-4a57-99f2-dcf7a8341898.jpg?1",
             "name": "Phantom Nomad",
             "text": "Phantom Nomad comes into play with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Nomad, prevent that damage. Remove a +1/+1 counter from Phantom Nomad.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "ef7a8ba7-fff4-5c5d-b64b-ced6e0f45a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3454ef42-2e0b-4ce4-945f-e4ec3e83c39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3454ef42-2e0b-4ce4-945f-e4ec3e83c39d.jpg?1",
             "name": "Prismatic Strands",
             "text": "Prevent all damage that sources of the color of your choice would deal this turn.\nFlashback\u2014\nTap an untapped white creature you control. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "5099e18d-5634-51b2-b92b-5f393fabc711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce0e8f-9ad6-42b6-af61-c883613efc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce0e8f-9ad6-42b6-af61-c883613efc97.jpg?1",
             "name": "Pulsemage Advocate",
             "text": "oc\nT: Return three target cards in an opponent's graveyard to his or her hand.  Return target creature card from your graveyard to play.",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "291037b6-e159-5013-952b-633fbf2ad9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d762c8c-6172-4dc0-8fcc-d0f6dd8ca013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d762c8c-6172-4dc0-8fcc-d0f6dd8ca013.jpg?1",
             "name": "Ray of Revelation",
             "text": "Destroy target enchantment.\nFlashback o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "61421ae5-b0ee-5e98-b6f7-73dfeba393ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1c300-aec3-4512-9902-309615e86c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1c300-aec3-4512-9902-309615e86c73.jpg?1",
             "name": "Selfless Exorcist",
             "text": "oc\nT: Remove target creature card in a graveyard from the game. That card deals damage equal to its power to Selfless Exorcist. (A * on a card not in play is 0.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "71b0b715-3c69-5950-9494-3f00dd6d48c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea66a41-cb2e-49d6-81fe-3f69b0dfd40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea66a41-cb2e-49d6-81fe-3f69b0dfd40e.jpg?1",
             "name": "Shieldmage Advocate",
             "text": "oc\nT: Return target card in an opponent's graveyard to his or her hand. Prevent all damage that would be dealt to target creature or player this turn by a source of your choice.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "49185d7f-ff5a-5dbb-8ab0-4ed95dcc76db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1465ca9e-a997-4b8c-9677-6c7961f67eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1465ca9e-a997-4b8c-9677-6c7961f67eba.jpg?1",
             "name": "Silver Seraph",
             "text": "Flying\nThreshold Other creatures you control get +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "643ed0d6-0fc3-595a-8fd0-dd763dc03a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a8eb7a-eb3f-405e-8f44-d8ea64d76386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a8eb7a-eb3f-405e-8f44-d8ea64d76386.jpg?1",
             "name": "Solitary Confinement",
             "text": "At the beginning of your upkeep, sacrifice Solitary Confinement unless you discard a card from your hand.\nSkip your draw step.\nYou can't be the target of spells or abilities.\nPrevent all damage that would be dealt to you.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "2151bde1-c7e3-52a4-8ea0-8efc401004fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30df994-bb09-4d16-8443-223c6ce342dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30df994-bb09-4d16-8443-223c6ce342dc.jpg?1",
             "name": "Soulcatchers' Aerie",
             "text": "Whenever a Bird is put into your graveyard from play, put a feather counter on Soulcatchers' Aerie.\nAll Birds get +1/+1 for each feather counter on Soulcatchers' Aerie.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "0897ea48-4bb6-5e1f-b26d-1f67a3bf2adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8baf60f-c20b-4b2f-9fe1-df008a9273c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8baf60f-c20b-4b2f-9fe1-df008a9273c6.jpg?1",
             "name": "Spirit Cairn",
             "text": "Whenever a player discards a card from his or her hand, you may pay o\nW. If you do, put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "e5942620-dcbe-5cf4-a801-c89aa960c9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008c8d72-097e-472d-88c8-78bf29e42e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008c8d72-097e-472d-88c8-78bf29e42e32.jpg?1",
             "name": "Spurnmage Advocate",
             "text": "oc\nT: Return two target cards in an opponent's graveyard to his or her hand. Destroy target attacking creature.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "46c195e8-e30c-54b1-8bb5-6765eabf8bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbdae0b-b4aa-40ff-9017-b4349bd6b627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbdae0b-b4aa-40ff-9017-b4349bd6b627.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "6c4deccc-cc1a-5f4d-9a3a-0f9751bccb95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16bd6b-e99c-4da3-bd03-11f63b7ee85d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16bd6b-e99c-4da3-bd03-11f63b7ee85d.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "9c93bc58-8be0-57ef-b16d-21e7eef23d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ec745-226c-4211-974f-e04a4f9e1902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ec745-226c-4211-974f-e04a4f9e1902.jpg?1",
             "name": "Trained Pronghorn",
             "text": "Discard a card from your hand: Prevent all damage that would be dealt to Trained Pronghorn this turn.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "99215223-80c5-580c-8080-489c77376a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015205e-5895-4038-9c2f-ed4766c498ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015205e-5895-4038-9c2f-ed4766c498ff.jpg?1",
             "name": "Unquestioned Authority",
             "text": "When Unquestioned Authority comes into play, draw a card.\nEnchanted creature has protection from creatures.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "f1f72c0c-eade-5fe9-a9b8-b54ec4c6bdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58095f6b-d937-4871-b3af-5c6a1d9c04b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58095f6b-d937-4871-b3af-5c6a1d9c04b3.jpg?1",
             "name": "Valor",
             "text": "First strike\nAs long as Valor is in your graveyard and you control a plains, creatures you control have first strike.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "82644810-d000-53d9-b3c6-a054fe8010c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3790282-ea04-4600-8912-dac541ffd081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3790282-ea04-4600-8912-dac541ffd081.jpg?1",
             "name": "Vigilant Sentry",
             "text": "Threshold Vigilant Sentry gets +1/+1 and has \"oc\nT: Target attacking or blocking creature gets +3/+3 until end of turn.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1118,7 +1118,7 @@
         },
         {
             "id": "440b861f-e5c3-5d57-bcea-1598f5065f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee9e09-c4b1-4133-90a3-350677f0b72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee9e09-c4b1-4133-90a3-350677f0b72a.jpg?1",
             "name": "Aven Fogbringer",
             "text": "Flying\nWhen Aven Fogbringer comes into play, return target land to its owner's hand.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "01addd4f-0150-5053-93a2-9ff979ffa8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d98f05b-ddfe-4b93-b247-dbd1a89e0731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d98f05b-ddfe-4b93-b247-dbd1a89e0731.jpg?1",
             "name": "Cephalid Constable",
             "text": "Whenever Cephalid Constable deals combat damage to a player, return up to X target permanents that player controls to their owners' hands, where X is the damage it dealt to that player.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "3f3904ec-bb64-5939-8cff-5949a8328342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3e8c80-690b-4d79-9dee-99d1a3876160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3e8c80-690b-4d79-9dee-99d1a3876160.jpg?1",
             "name": "Cephalid Inkshrouder",
             "text": "Discard a card from your hand: Cephalid Inkshrouder can't be the target of spells or abilities and is unblockable this turn.",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "68626111-485b-57d5-9ff4-e7ee0fa10005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca097675-5e82-493d-beab-9fc11efd7492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca097675-5e82-493d-beab-9fc11efd7492.jpg?1",
             "name": "Cunning Wish",
             "text": "Choose an instant card you own from outside the game, reveal that card, and put it into your hand. Remove Cunning Wish from the game.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "fe1bb942-926d-5ec1-a9b5-f3120307331d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461413fe-0392-41c1-b50f-05e87ea1c338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461413fe-0392-41c1-b50f-05e87ea1c338.jpg?1",
             "name": "Defy Gravity",
             "text": "Target creature gains flying until end of turn.\nFlashback o\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "719a5b65-a9e3-5ccf-8932-c0b6adb9dd51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ed250e-12d0-4ebc-9410-5711e71c6d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ed250e-12d0-4ebc-9410-5711e71c6d1f.jpg?1",
             "name": "Envelop",
             "text": "Counter target sorcery spell.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "7796a097-7b69-5ba8-bfce-10fd15291fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaab905-0b97-42c2-a1a3-1e72275caa82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaab905-0b97-42c2-a1a3-1e72275caa82.jpg?1",
             "name": "Flash of Insight",
             "text": "Look at the top X cards of your library. Put one of them into your hand and the rest on the bottom of your library.\nFlashback\u2014o1o\nU, Remove X blue cards in your graveyard from the game. (You can't remove Flash of Insight to pay for its own flashback cost.)",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "3c89e06a-8a7e-5e00-8e8f-3f0771f04fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc7e2a-5b9b-4f0f-8b2e-a7c7f847e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc7e2a-5b9b-4f0f-8b2e-a7c7f847e1f1.jpg?1",
             "name": "Grip of Amnesia",
             "text": "Counter target spell unless its controller removes his or her graveyard from the game.\nDraw a card.",
             "colours": [
@@ -1382,7 +1382,7 @@
         },
         {
             "id": "61ec1a1f-ea3d-5800-9102-d67a5d1f4020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ed0ee7-6749-4f38-8e53-c11b46b17e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ed0ee7-6749-4f38-8e53-c11b46b17e5d.jpg?1",
             "name": "Hapless Researcher",
             "text": "Sacrifice Hapless Researcher: Draw a card, then discard a card from your hand.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "1a346e5b-1d30-5b81-8021-daddc0f6a57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e702ee4-62b5-4d3b-a202-8cac4b84591c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e702ee4-62b5-4d3b-a202-8cac4b84591c.jpg?1",
             "name": "Keep Watch",
             "text": "Draw a card for each attacking creature.",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "00a39a4c-05f5-5ee3-af89-68cfe4e10fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ea5448-2d72-42eb-814c-197153d8e06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ea5448-2d72-42eb-814c-197153d8e06a.jpg?1",
             "name": "Laquatus's Disdain",
             "text": "Counter target spell played from a graveyard.\nDraw a card.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "1bc2fa3d-e3a5-54a2-b78e-96a781e06eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fb391a-2687-461d-b5ef-a494287ddb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fb391a-2687-461d-b5ef-a494287ddb5d.jpg?1",
             "name": "Lost in Thought",
             "text": "Enchanted creature can't attack or block and its activated abilities can't be played. Its controller may remove three cards in his or her graveyard from the game to ignore this ability until end of turn.",
             "colours": [
@@ -1515,7 +1515,7 @@
         },
         {
             "id": "f5173f9d-bab5-567d-a0d2-e1607b5e911e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f343724-6ecd-494f-8bfc-93676af4e173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f343724-6ecd-494f-8bfc-93676af4e173.jpg?1",
             "name": "Mental Note",
             "text": "Put the top two cards of your library into your graveyard.\nDraw a card.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "711cf147-b2b1-584b-bf01-f7ae82ae8aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e52b73-ebdf-4339-8780-84327a59ca57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e52b73-ebdf-4339-8780-84327a59ca57.jpg?1",
             "name": "Mirror Wall",
             "text": "(Walls can't attack.)\no\nW: Mirror Wall may attack this turn as though it weren't a Wall.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "fb81f19b-c854-5d5e-a544-bbcaaec6dbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d03121-9515-4101-9d60-e01225533f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d03121-9515-4101-9d60-e01225533f44.jpg?1",
             "name": "Mist of Stagnation",
             "text": "Permanents don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player untaps a permanent for each card in his or her graveyard.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "cdfdd998-cc0d-5f1f-987a-eac5642622d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a314fa-293b-486f-95d8-267d340e4d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a314fa-293b-486f-95d8-267d340e4d8e.jpg?1",
             "name": "Quiet Speculation",
             "text": "Search target player's library for up to three cards with flashback and put them into that player's graveyard. Then the player shuffles his or her library.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "44eb6589-2d32-5b91-8dc8-16bbbef6570e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3b7fa-78e7-4a0c-bcdc-4b829638e3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3b7fa-78e7-4a0c-bcdc-4b829638e3f6.jpg?1",
             "name": "Scalpelexis",
             "text": "Flying\nWhenever Scalpelexis deals combat damage to a player, that player removes the top four cards of his or her library from the game. If two or more of those cards have the same name, repeat this process.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "9a4409eb-2cad-5a0a-875e-8052622a2ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eda8c7b-ce35-482a-bece-52a30cc78a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eda8c7b-ce35-482a-bece-52a30cc78a9a.jpg?1",
             "name": "Spelljack",
             "text": "Counter target spell. If it's countered this way, remove it from the game instead of putting it into its owner's graveyard. As long as it remains removed from the game, you may play it as though it were in your hand without paying its mana cost. If it has X in its mana cost, X is 0.",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "23c6e83b-728a-5b5b-b4d0-74e35cec93c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fad1d-a517-433a-b939-d0635e8f5535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fad1d-a517-433a-b939-d0635e8f5535.jpg?1",
             "name": "Telekinetic Bonds",
             "text": "Whenever a player discards a card from his or her hand, you may pay o1o\nU. If you do, tap or untap target permanent.",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "6a70f792-4bf7-5ab6-b2bf-8d7a1692b0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6d2721-1dfc-4f4f-a914-9352ca6981c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6d2721-1dfc-4f4f-a914-9352ca6981c0.jpg?1",
             "name": "Web of Inertia",
             "text": "At the beginning of each opponent's combat phase, that player may remove a card in his or her graveyard from the game. If the player doesn't, creatures he or she controls can't attack you this turn.",
             "colours": [
@@ -1776,7 +1776,7 @@
         },
         {
             "id": "622bd240-9967-590a-89b1-4ba908cb94d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44670666-9028-4b4a-a5af-a3bf35fc6a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44670666-9028-4b4a-a5af-a3bf35fc6a21.jpg?1",
             "name": "Wonder",
             "text": "Flying\nAs long as Wonder is in your graveyard and you control an island, creatures you control have flying.",
             "colours": [
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "072b032c-e6cd-5253-89bf-31ca6b67f713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7f29aa-c069-4adb-b313-6a56849905d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7f29aa-c069-4adb-b313-6a56849905d4.jpg?1",
             "name": "Wormfang Behemoth",
             "text": "When Wormfang Behemoth comes into play, remove all cards in your hand from the game.\nWhen Wormfang Behemoth leaves play, return the removed cards to their owner's hand.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "194fe638-d45e-52d1-94e2-d3442bcbb428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf56dcf-ec1a-4298-8644-1fe248443b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf56dcf-ec1a-4298-8644-1fe248443b7e.jpg?1",
             "name": "Wormfang Crab",
             "text": "Wormfang Crab is unblockable.\nWhen Wormfang Crab comes into play, an opponent chooses a permanent you control and removes it from the game.\nWhen Wormfang Crab leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1881,7 +1881,7 @@
         },
         {
             "id": "b2396bb8-c1d4-5a28-b821-44b8ded36ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6afd312-6448-4bd1-8539-0910cefead0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6afd312-6448-4bd1-8539-0910cefead0d.jpg?1",
             "name": "Wormfang Drake",
             "text": "Flying\nWhen Wormfang Drake comes into play, sacrifice it unless you remove a creature you control other than Wormfang Drake from the game.\nWhen Wormfang Drake leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1916,7 +1916,7 @@
         },
         {
             "id": "b445ad8c-e598-5349-86c6-e8573257ec0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bf91d-6f7c-4fb5-bbc6-c012212e62e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bf91d-6f7c-4fb5-bbc6-c012212e62e9.jpg?1",
             "name": "Wormfang Manta",
             "text": "Flying\nWhen Wormfang Manta comes into play, you skip your next turn.\nWhen Wormfang Manta leaves play, you take an extra turn after this one.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "2af801f0-9fc3-5001-ba08-391469ecd106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8012c1-76ec-4c36-8b38-5bc41ce5e156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8012c1-76ec-4c36-8b38-5bc41ce5e156.jpg?1",
             "name": "Wormfang Newt",
             "text": "When Wormfang Newt comes into play, remove a land you control from the game.\nWhen Wormfang Newt leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "d23caf34-9ea4-5a2d-a8db-e16b1ea430e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48404362-7579-4896-a71a-8eb40e5ac416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48404362-7579-4896-a71a-8eb40e5ac416.jpg?1",
             "name": "Wormfang Turtle",
             "text": "When Wormfang Turtle comes into play, remove a land you control from the game.\nWhen Wormfang Turtle leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "053098a5-f78e-578e-a299-f0f30e97c1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4cc273-adc3-4f46-9743-134b552d1d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4cc273-adc3-4f46-9743-134b552d1d56.jpg?1",
             "name": "Balthor the Defiled",
             "text": "All Minions get +1/+1.\no\nBo\nBo\nB, Remove Balthor the Defiled from the game: Each player returns all black and all red creature cards from his or her graveyard to play.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "f9ccee15-8fd3-5c09-a17c-60e4f46df39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5df970-c6ba-4824-b8ba-67244aec2b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5df970-c6ba-4824-b8ba-67244aec2b82.jpg?1",
             "name": "Cabal Therapy",
             "text": "Name a nonland card. Target player reveals his or her hand and discards from it all cards with that name.\nFlashback\u2014\nSacrifice a creature. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "24da3a0b-7d07-5a57-9bc4-df56eecdfd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345d702-b205-4391-985a-6201e707f0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345d702-b205-4391-985a-6201e707f0ba.jpg?1",
             "name": "Cabal Trainee",
             "text": "Sacrifice Cabal Trainee: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "aca2c582-8b97-58cc-91ca-f7fb1309967b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf134c9-a50d-4eff-a5a8-7cfe6a010080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf134c9-a50d-4eff-a5a8-7cfe6a010080.jpg?1",
             "name": "Death Wish",
             "text": "Choose a card you own from outside the game and put it into your hand. You lose half your life, rounded up. Remove Death Wish from the game.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "e1845684-358b-52c4-814b-aabcd8a5a99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dad63b5-ced3-4150-ad84-1ca05a892840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dad63b5-ced3-4150-ad84-1ca05a892840.jpg?1",
             "name": "Earsplitting Rats",
             "text": "When Earsplitting Rats comes into play, each player discards a card from his or her hand.\nDiscard a card from your hand: Regenerate Earsplitting Rats.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "23f05bb8-3ef5-5753-b3dd-8238764ed899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37de06dc-c0c1-4edb-9732-2d16dbabfb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37de06dc-c0c1-4edb-9732-2d16dbabfb31.jpg?1",
             "name": "Filth",
             "text": "Swampwalk\nAs long as Filth is in your graveyard and you control a swamp, creatures you control have swampwalk.",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "625e6a02-ba01-5f38-946e-f84899eb63ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad5f9f2-282a-4ee0-a259-cc24404ddf6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad5f9f2-282a-4ee0-a259-cc24404ddf6f.jpg?1",
             "name": "Grave Consequences",
             "text": "Each player may remove any number of cards in his or her graveyard from the game. Then each player loses 1 life for each card in his or her graveyard.\nDraw a card.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "5af2c2a5-1d6b-515f-a8b4-ca70a5ce4fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e9af4e-bd02-4d91-898f-68d192446904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e9af4e-bd02-4d91-898f-68d192446904.jpg?1",
             "name": "Guiltfeeder",
             "text": "Guiltfeeder can't be blocked except by artifact creatures and/or black creatures.\nWhenever Guiltfeeder attacks and isn't blocked, defending player loses 1 life for each card in his or her graveyard.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "65412394-3815-5c46-bd76-8c4e82f2640a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62728b-b834-4fa8-aed5-6348033ee69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62728b-b834-4fa8-aed5-6348033ee69c.jpg?1",
             "name": "Masked Gorgon",
             "text": "Green creatures and white creatures have protection from Gorgons.\nThreshold Masked Gorgon has protection from green and from white. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2328,7 +2328,7 @@
         },
         {
             "id": "1445cbde-08a6-518b-8631-20352639de86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c83e4d-ccc1-4ebf-9e74-2cc1ff9a7b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c83e4d-ccc1-4ebf-9e74-2cc1ff9a7b07.jpg?1",
             "name": "Morality Shift",
             "text": "Exchange your graveyard and library. Then shuffle your library.",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "0f355726-a3cd-5ddd-b251-92475937f315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b243ce02-4fff-444c-acc4-e1a199621a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b243ce02-4fff-444c-acc4-e1a199621a53.jpg?1",
             "name": "Rats' Feast",
             "text": "Remove X target cards in a single graveyard from the game.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "df30a48e-a6af-5a30-865c-f4ec6939b90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6172-2400-4038-8b8b-c62f2fbfce39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6172-2400-4038-8b8b-c62f2fbfce39.jpg?1",
             "name": "Stitch Together",
             "text": "Return target creature card from your graveyard to your hand.\nThreshold Instead return that card from your graveyard to play. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "db696a05-394b-5767-b9e7-12e3accefc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f769536f-def1-40b8-863f-ba12c7cb0d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f769536f-def1-40b8-863f-ba12c7cb0d87.jpg?1",
             "name": "Sutured Ghoul",
             "text": "Trample\nAs Sutured Ghoul comes into play, remove any number of creature cards in your graveyard from the game.\nSutured Ghoul's power is equal to the total power of the removed cards and its toughness is equal to their total toughness. (A * on a card not in play is 0.)",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "6cde041f-b8b2-562a-90d7-340e6fb41ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d1f59-0dba-4b83-8386-ae564fb4b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d1f59-0dba-4b83-8386-ae564fb4b771.jpg?1",
             "name": "Toxic Stench",
             "text": "Target nonblack creature gets -1/-1 until end of turn.\nThreshold Instead destroy that creature. It can't be regenerated. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "df811622-5d3f-559f-9406-7b898ef4d56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00562ae-b8b4-4f8f-8ea8-15d20568997d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00562ae-b8b4-4f8f-8ea8-15d20568997d.jpg?1",
             "name": "Treacherous Vampire",
             "text": "Flying\nWhenever Treacherous Vampire attacks or blocks, sacrifice it unless you remove a card in your graveyard from the game.\nThreshold Treacherous Vampire gets +2/+2 and has \"When Treacherous Vampire is put into a graveyard from play, you lose 6 life.\"",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "20a87733-3d64-5492-bd63-263f1de9e962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9647726-302b-4fc4-91d7-2aa0bba0b653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9647726-302b-4fc4-91d7-2aa0bba0b653.jpg?1",
             "name": "Treacherous Werewolf",
             "text": "Threshold Treacherous Werewolf gets +2/+2 and has \"When Treacherous Werewolf is put into a graveyard from play, you lose 4 life.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "91d7e0ce-339b-5c90-8583-7b966baa89c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2920af-e6a1-4939-ab59-67af4430e5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2920af-e6a1-4939-ab59-67af4430e5b8.jpg?1",
             "name": "Anger",
             "text": "Haste\nAs long as Anger is in your graveyard and you control a mountain, creatures you control have haste.",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "9e467003-0ded-5220-85ad-c5a2d31fdfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c56677-c8e2-4500-9ee0-0b102496f454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c56677-c8e2-4500-9ee0-0b102496f454.jpg?1",
             "name": "Arcane Teachings",
             "text": "Enchanted creature gets +2/+2 and has \"oc\nT: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "9cbf931d-9df0-50d0-885f-0d0b36286a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38f0f9f-ad7b-48da-89f3-b3e5346a3b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38f0f9f-ad7b-48da-89f3-b3e5346a3b71.jpg?1",
             "name": "Barbarian Bully",
             "text": "Discard a card at random from your hand: Barbarian Bully gets +2/+2 until end of turn unless a player has Barbarian Bully deal 4 damage to him or her. Play this ability only once each turn.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "8abb1ade-7f72-53d9-8212-ff84bc144f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead678c-7b6a-4668-9919-623312e08a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead678c-7b6a-4668-9919-623312e08a65.jpg?1",
             "name": "Book Burning",
             "text": "Unless a player has Book Burning deal 6 damage to him or her, put the top six cards of target player's library into his or her graveyard.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "7a37aa81-7c88-5932-a6d7-f6d07c88d2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765ec2c9-8ffe-488a-bebe-e5dd63825a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765ec2c9-8ffe-488a-bebe-e5dd63825a8c.jpg?1",
             "name": "Breaking Point",
             "text": "Destroy all creatures unless a player has Breaking Point deal 6 damage to him or her. Creatures destroyed this way can't be regenerated.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "a6d9549a-a329-5b13-b815-3acbb3288127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f20068-f225-4055-be7a-5c4a18e33b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f20068-f225-4055-be7a-5c4a18e33b0b.jpg?1",
             "name": "Browbeat",
             "text": "Unless a player has Browbeat deal 5 damage to him or her, target player draws three cards.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "e6cf6ff3-1d24-5e3b-9651-395b111fdbdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9b692a-e832-4612-a6ec-93b52f6a0410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9b692a-e832-4612-a6ec-93b52f6a0410.jpg?1",
             "name": "Burning Wish",
             "text": "Choose a sorcery card you own from outside the game, reveal that card, and put it into your hand. Remove Burning Wish from the game.",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "c1bddc1f-9587-5c76-8ac5-a7e4c2bc85ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac576b2-cda4-4aea-aa5c-933ec0457dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac576b2-cda4-4aea-aa5c-933ec0457dda.jpg?1",
             "name": "Dwarven Bloodboiler",
             "text": "Tap an untapped Dwarf you control: Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "02bd7cd3-668e-56c7-bec0-230c4abf8215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d815d3-7e33-4de9-aa36-ff5ffb893d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d815d3-7e33-4de9-aa36-ff5ffb893d73.jpg?1",
             "name": "Dwarven Driller",
             "text": "oc\nT: Destroy target land unless its controller has Dwarven Driller deal 2 damage to him or her.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "4f06d306-462c-5bb3-a410-66692964f94c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099873b1-7181-4b9d-8ce1-8ec63c814afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099873b1-7181-4b9d-8ce1-8ec63c814afe.jpg?1",
             "name": "Dwarven Scorcher",
             "text": "Sacrifice Dwarven Scorcher: Dwarven Scorcher deals 1 damage to target creature unless that creature's controller has Dwarven Scorcher deal 2 damage to him or her.",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "8bf8c0f7-bdee-5748-827b-92f492f4f846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9eb72b-9ae2-4b64-bbb9-187446b5fd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9eb72b-9ae2-4b64-bbb9-187446b5fd2f.jpg?1",
             "name": "Ember Shot",
             "text": "Ember Shot deals 3 damage to target creature or player.\nDraw a card.",
             "colours": [
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "cb093ab4-635b-5ee4-b28c-e886af80ada5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e1d485-02d5-4a07-bcc6-d2a8d95763e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e1d485-02d5-4a07-bcc6-d2a8d95763e8.jpg?1",
             "name": "Firecat Blitz",
             "text": "Put X 1/1 red Cat creature tokens with haste into play. Remove them from the game at end of turn.\nFlashback\u2014o\nRo\nR, Sacrifice X mountains. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "cd0fb2f4-32b9-5739-8fd1-45373a8bf5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb5c96a-1d16-459d-9968-ced9a8f1c520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb5c96a-1d16-459d-9968-ced9a8f1c520.jpg?1",
             "name": "Flaring Pain",
             "text": "Damage can't be prevented this turn.\nFlashback o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "37c0e137-e376-5b42-9fae-1e342498801c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e5b4e-ae58-412a-be27-c4ef4899fbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e5b4e-ae58-412a-be27-c4ef4899fbbd.jpg?1",
             "name": "Fledgling Dragon",
             "text": "Flying\nThreshold Fledgling Dragon gets +3/+3 and has \"o\nR: Fledgling Dragon gets +1/+0 until end of turn.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "06a1c206-b968-5e39-b2d0-68ec7451e28f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919d2dd-d6a1-4d45-b6aa-227ed05d7051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919d2dd-d6a1-4d45-b6aa-227ed05d7051.jpg?1",
             "name": "Goretusk Firebeast",
             "text": "When Goretusk Firebeast comes into play, it deals 4 damage to target player.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "c968f289-ad5f-533e-a8c8-c8d1e1ebd9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8569cdf7-e0e9-4733-98b5-56fac216fad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8569cdf7-e0e9-4733-98b5-56fac216fad3.jpg?1",
             "name": "Infectious Rage",
             "text": "Enchanted creature gets +2/-1.\nWhen enchanted creature is put into a graveyard, choose a creature at random Infectious Rage can enchant. Return Infectious Rage to play enchanting that creature.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "cf1a3802-786c-5418-992c-e1131263d85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf96a59-8b7d-4a5b-adfd-17eeedd95db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf96a59-8b7d-4a5b-adfd-17eeedd95db5.jpg?1",
             "name": "Jeska, Warrior Adept",
             "text": "First strike, haste\noc\nT: Jeska, Warrior Adept deals 1 damage to target creature or player.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "a04d8985-a9f5-526a-8203-e04ef0c6b730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865bb1d3-5b7d-40e9-87cc-96be9524a105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865bb1d3-5b7d-40e9-87cc-96be9524a105.jpg?1",
             "name": "Lava Dart",
             "text": "Lava Dart deals 1 damage to target creature or player.\nFlashback\u2014\nSacrifice a mountain. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "cccad65c-b324-58bd-a396-1de036fb64a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c07842-9b70-40b1-9b97-9a9279b7ebc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c07842-9b70-40b1-9b97-9a9279b7ebc4.jpg?1",
             "name": "Liberated Dwarf",
             "text": "o\nR, Sacrifice Liberated Dwarf: Target green creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "3a542300-84b9-5c88-b326-b0fa78a3ef93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452d78d-eafc-4ccb-a478-d1f46bcefffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452d78d-eafc-4ccb-a478-d1f46bcefffe.jpg?1",
             "name": "Lightning Surge",
             "text": "Lightning Surge deals 4 damage to target creature or player.\nThreshold Instead Lightning Surge deals 6 damage to that creature or player and the damage can't be prevented.\nFlashback o5o\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "4513df8b-c3b9-5f34-b5e1-4eb377fb12f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae5e16-d2fc-488c-9c53-d35c377d6a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae5e16-d2fc-488c-9c53-d35c377d6a00.jpg?1",
             "name": "Planar Chaos",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, sacrifice Planar Chaos.\nWhenever a player plays a spell, that player flips a coin. If he or she loses the flip, counter that spell.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "07c30dd5-3d86-5c7c-bcae-6621d1191954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc33a4f-9ec2-4324-82a1-a4b9700572f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc33a4f-9ec2-4324-82a1-a4b9700572f2.jpg?1",
             "name": "Shaman's Trance",
             "text": "Until end of turn, other players can't play cards from their graveyards, and you may play cards from other players' graveyards as though they were in your graveyard.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "c0875fca-2af2-5906-82a4-e2127b52cc67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aef55b8-5813-4aff-a35d-4b3cbd4a9ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aef55b8-5813-4aff-a35d-4b3cbd4a9ffb.jpg?1",
             "name": "Soulgorger Orgg",
             "text": "Trample\nWhen Soulgorger Orgg comes into play, you lose all but 1 life.\nWhen Soulgorger Orgg leaves play, you gain life equal to the life you lost when it came into play.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "db76df95-a913-5746-a820-10246482fa1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043fcf80-dd20-4cc2-a0d5-4bb22b8b0789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043fcf80-dd20-4cc2-a0d5-4bb22b8b0789.jpg?1",
             "name": "Spellgorger Barbarian",
             "text": "When Spellgorger Barbarian comes into play, discard a card at random from your hand.\nWhen Spellgorger Barbarian leaves play, draw a card.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "c0d6d35d-a381-534c-9bbe-d6e8459558c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f667c26-40f5-4ac5-87a4-cb03f70590a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f667c26-40f5-4ac5-87a4-cb03f70590a2.jpg?1",
             "name": "Swelter",
             "text": "Swelter deals 2 damage to each of two target creatures.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "e6f46738-e24b-5de4-8af1-0127e43caa37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d757ec3-c15f-4d6e-8e18-36ebae985448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d757ec3-c15f-4d6e-8e18-36ebae985448.jpg?1",
             "name": "Swirling Sandstorm",
             "text": "Threshold Swirling Sandstorm deals 5 damage to each creature without flying. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "7c9ef54a-a0e6-598a-a372-b57929407cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99783a2b-a95a-457b-82d6-001933aee5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99783a2b-a95a-457b-82d6-001933aee5ec.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon comes into play, remove all other permanents you control from the game.\nWhen Worldgorger Dragon leaves play, return the removed cards to play under their owners' control.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "c814b7ac-6b6a-50a4-be59-6d2fe8eb9b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33255dfd-f8a9-4a15-aac5-c53dc0257859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33255dfd-f8a9-4a15-aac5-c53dc0257859.jpg?1",
             "name": "Anurid Barkripper",
             "text": "Threshold Anurid Barkripper gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "7d58689a-f636-5b39-a189-31c9f818acca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3636a9f8-d1d7-4452-8a53-788b514fdb97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3636a9f8-d1d7-4452-8a53-788b514fdb97.jpg?1",
             "name": "Anurid Swarmsnapper",
             "text": "Anurid Swarmsnapper may block as though it had flying.\no1o\nG: Anurid Swarmsnapper may block an additional creature this turn.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "65f17551-f79e-541c-b7aa-2da05ec3d038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac74bc-1198-4a9a-bcde-668cca08b274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac74bc-1198-4a9a-bcde-668cca08b274.jpg?1",
             "name": "Battlefield Scrounger",
             "text": "Threshold Put three cards from your graveyard on the bottom of your library: Battlefield Scrounger gets +3/+3 until end of turn. Play this ability only once each turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "c72ec57d-e51f-568f-8e61-20f3b69925b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f4b7fc-8793-43af-ade3-b23846a80457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f4b7fc-8793-43af-ade3-b23846a80457.jpg?1",
             "name": "Brawn",
             "text": "Trample\nAs long as Brawn is in your graveyard and you control a forest, creatures you control have trample.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "d5d3c5a2-eec6-5a69-8018-3807881714df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4530da2-fd04-40d9-ad69-5c2847921509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4530da2-fd04-40d9-ad69-5c2847921509.jpg?1",
             "name": "Canopy Claws",
             "text": "Target creature loses flying until end of turn.\nFlashback o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "d62b675d-c7c9-57fd-a758-39440ed2519c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f10dfd9-9889-4d9e-872a-07623dee6b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f10dfd9-9889-4d9e-872a-07623dee6b6b.jpg?1",
             "name": "Centaur Rootcaster",
             "text": "Whenever Centaur Rootcaster deals combat damage to a player, you may search your library for a basic land card and put that card into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "826d0b2e-0fbf-5b08-afe2-e6f23c9af25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a924b3-3bd6-43ad-acbd-1303dd670db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a924b3-3bd6-43ad-acbd-1303dd670db4.jpg?1",
             "name": "Crush of Wurms",
             "text": "Put three 6/6 green Wurm creature tokens into play.\nFlashback o9o\nGo\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "58a5553c-77a7-5438-b1a0-8873c8172172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3a7226-f574-430e-9b8f-4e531a21540f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3a7226-f574-430e-9b8f-4e531a21540f.jpg?1",
             "name": "Elephant Guide",
             "text": "Enchanted creature gets +3/+3.\nWhen enchanted creature is put into a graveyard, put a 3/3 green Elephant creature token into play.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "2609efb1-c26a-59dc-aa13-196faca5ce84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc71f6f-f831-409e-aafd-3fa82a318e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc71f6f-f831-409e-aafd-3fa82a318e72.jpg?1",
             "name": "Epic Struggle",
             "text": "At the beginning of your upkeep, if you control twenty or more creatures, you win the game.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "0ad0ebf6-53a3-596d-a786-c773b4bb4da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcf61ba-37fd-4029-b299-add7cf9d70bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcf61ba-37fd-4029-b299-add7cf9d70bc.jpg?1",
             "name": "Erhnam Djinn",
             "text": "At the beginning of your upkeep, target non-Wall creature an opponent controls gains forestwalk until your next upkeep.",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "e0fd73c1-303d-5b8d-a3e4-e18c97b00a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e111fcab-17f7-4a02-b4eb-606ba18812b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e111fcab-17f7-4a02-b4eb-606ba18812b3.jpg?1",
             "name": "Exoskeletal Armor",
             "text": "Enchanted creature gets +X/+X, where X is the number of creature cards in all graveyards.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "bee95889-b188-5a01-a635-1b6046589137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751bd716-5352-41d7-89fb-d5f100f6646b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751bd716-5352-41d7-89fb-d5f100f6646b.jpg?1",
             "name": "Folk Medicine",
             "text": "You gain 1 life for each creature you control.\nFlashback o1o\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "1a04576f-aee3-5287-b0d4-0323c73e364f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad217fe-9309-4c67-8a6a-cfb8b1ce91f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad217fe-9309-4c67-8a6a-cfb8b1ce91f1.jpg?1",
             "name": "Forcemage Advocate",
             "text": "oc\nT: Return target card in an opponent's graveyard to his or her hand. Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "5cee42fb-7749-55f5-88b2-4c7ba4cd9da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43aee5e-b12e-43ea-9fae-16310acdc640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43aee5e-b12e-43ea-9fae-16310acdc640.jpg?1",
             "name": "Genesis",
             "text": "At the beginning of your upkeep, if Genesis is in your graveyard, you may pay o2o\nG. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "3e9d4b09-ced5-58be-b29a-f0a27266d7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c402ef0e-51e7-4da6-a434-b99c5d435698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c402ef0e-51e7-4da6-a434-b99c5d435698.jpg?1",
             "name": "Giant Warthog",
             "text": "Trample",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "c7c64803-ae75-58b2-800e-b8cee8b41308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d23432-6181-44c3-8d36-d7632a8a329f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d23432-6181-44c3-8d36-d7632a8a329f.jpg?1",
             "name": "Grizzly Fate",
             "text": "Put two 2/2 green Bear creature tokens into play.\nThreshold Instead put four 2/2 green Bear creature tokens into play.\nFlashback o5o\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "f516c108-df9c-58ae-a656-3e6ff48f692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97337e6e-1b3f-43a2-91f2-ca8f6c5dea88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97337e6e-1b3f-43a2-91f2-ca8f6c5dea88.jpg?1",
             "name": "Harvester Druid",
             "text": "oc\nT: Add to your mana pool one mana of any color that a land you control could produce.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "b4b7f1c1-f9bb-5428-a39b-7ea4b92d04d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9299cc-6f21-4185-ac63-2fd92e843faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9299cc-6f21-4185-ac63-2fd92e843faa.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle comes into play, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "83578199-11b6-583f-b246-64d74205c2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c5144-7e15-46c6-b819-d729ecb30bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c5144-7e15-46c6-b819-d729ecb30bb1.jpg?1",
             "name": "Krosan Reclamation",
             "text": "Target player shuffles up to two target cards from his or her graveyard into his or her library.\nFlashback o1o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "404eb72f-c3da-57a4-a362-ffac2b6d64db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356e684-c2fc-465e-a16c-7300824d2a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356e684-c2fc-465e-a16c-7300824d2a8d.jpg?1",
             "name": "Krosan Wayfarer",
             "text": "Sacrifice Krosan Wayfarer: Put a land card from your hand into play.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "77feda65-5bc2-59a1-972c-6b474644c4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2478a8d2-ca44-4c42-8d75-dd9cb1b59f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2478a8d2-ca44-4c42-8d75-dd9cb1b59f61.jpg?1",
             "name": "Living Wish",
             "text": "Choose a creature or land card you own from outside the game, reveal that card, and put it into your hand. Remove Living Wish from the game.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "eaa286d4-1c0e-5902-b163-df67e4fc2a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b93c93-5944-4289-bc5a-30b6e73b0dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b93c93-5944-4289-bc5a-30b6e73b0dfd.jpg?1",
             "name": "Nantuko Tracer",
             "text": "When Nantuko Tracer comes into play, you may put target card from a graveyard on the bottom of its owner's library.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "e2e49da7-53e0-5196-92ff-73d8ea9513d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c29991d-82f2-479d-95ca-5c88e9f3f219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c29991d-82f2-479d-95ca-5c88e9f3f219.jpg?1",
             "name": "Nullmage Advocate",
             "text": "oc\nT: Return two target cards in an opponent's graveyard to his or her hand. Destroy target artifact or enchantment.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "922b25d8-875c-5058-b6fd-8b398d23ca4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c421c2f1-2137-41bd-9a89-74d8a76fb5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c421c2f1-2137-41bd-9a89-74d8a76fb5c5.jpg?1",
             "name": "Phantom Centaur",
             "text": "Protection from black\nPhantom Centaur comes into play with three +1/+1 counters on it.\nIf damage would be dealt to Phantom Centaur, prevent that damage. Remove a +1/+1 counter from Phantom Centaur.",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "b92bd98a-19e3-59ef-a0e0-54363c2c8755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ca45-b60f-4bb9-9f7e-1b5e13478f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ca45-b60f-4bb9-9f7e-1b5e13478f22.jpg?1",
             "name": "Phantom Nantuko",
             "text": "Trample\nPhantom Nantuko comes into play with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Nantuko, prevent that damage. Remove a +1/+1 counter from Phantom Nantuko.\noc\nT: Put a +1/+1 counter on Phantom Nantuko.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "25c9f3f2-3dab-51e2-9f54-16594b391755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32839296-e583-4f71-aa44-dbe16408665e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32839296-e583-4f71-aa44-dbe16408665e.jpg?1",
             "name": "Phantom Tiger",
             "text": "Phantom Tiger comes into play with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Tiger, prevent that damage. Remove a +1/+1 counter from Phantom Tiger.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "eb9bc7dc-5705-56a0-aee2-f186386e716d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5c52-f260-400c-b088-8792282509a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5c52-f260-400c-b088-8792282509a5.jpg?1",
             "name": "Seedtime",
             "text": "Play Seedtime only during your turn.\nTake an extra turn after this one if an opponent played a blue spell this turn.",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "453a3438-07c6-5d82-8d23-e814485a7a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6ded26-b748-406d-8740-9b8590be2bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6ded26-b748-406d-8740-9b8590be2bb1.jpg?1",
             "name": "Serene Sunset",
             "text": "Prevent all combat damage X target creatures would deal this turn.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "a5e7b429-848e-5ad0-872a-4213f6b8d81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca1108-ccf2-48ea-8ca7-986aa45d5fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca1108-ccf2-48ea-8ca7-986aa45d5fe8.jpg?1",
             "name": "Sudden Strength",
             "text": "Target creature gets +3/+3 until end of turn.\nDraw a card.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "1f488419-db27-5dc2-8923-b24b06ab3b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8413f-c9fc-4cea-b416-a1fcf651b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8413f-c9fc-4cea-b416-a1fcf651b009.jpg?1",
             "name": "Sylvan Safekeeper",
             "text": "Sacrifice a land: Target creature you control can't be the target of spells or abilities this turn.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "eddbde35-0722-580f-b68a-78933fc5224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9e647d-903f-4a77-a56c-cd5c0c2f12cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9e647d-903f-4a77-a56c-cd5c0c2f12cf.jpg?1",
             "name": "Thriss, Nantuko Primus",
             "text": "o\nG, oc\nT: Target creature gets +5/+5 until end of turn.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "26eb099e-12cd-5552-8194-3b0eeb658f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e246c8-3b3f-47c4-8a1b-b5f2d36f0ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e246c8-3b3f-47c4-8a1b-b5f2d36f0ca4.jpg?1",
             "name": "Tunneler Wurm",
             "text": "Discard a card from your hand: Regenerate Tunneler Wurm.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "c0bd0272-9f61-5db2-983d-1e974d67c480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10359c-1ea8-4453-bc01-f638ad20a5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10359c-1ea8-4453-bc01-f638ad20a5ec.jpg?1",
             "name": "Venomous Vines",
             "text": "Destroy target enchanted permanent.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "8d5ada0f-11f4-5bdd-a8e8-2fa9cb3b25f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09204c7-3e3d-484a-a4f7-da1b818e3884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09204c7-3e3d-484a-a4f7-da1b818e3884.jpg?1",
             "name": "Anurid Brushhopper",
             "text": "Discard two cards from your hand: Remove Anurid Brushhopper from the game. Return it to play under its owner's control at end of turn.",
             "colours": [
@@ -4616,7 +4616,7 @@
         },
         {
             "id": "00ce940b-8ade-5680-aa7a-0ff5e654cb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14a736-5223-457b-9d4e-f4a2d6ed9a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14a736-5223-457b-9d4e-f4a2d6ed9a8d.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold Whenever an opponent plays a spell, you may put a creature card from your hand into play. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "f1a96030-8882-536d-8857-03bad5af0988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ddad46-5e2e-43c9-8c91-7aca6ca23562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ddad46-5e2e-43c9-8c91-7aca6ca23562.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana to your mana pool of any type that land produced.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "28d6205e-c666-5a14-8871-3cd175277bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ebc372-aabd-4174-a943-c7bf59e5028d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ebc372-aabd-4174-a943-c7bf59e5028d.jpg?1",
             "name": "Phantom Nishoba",
             "text": "Trample\nPhantom Nishoba comes into play with seven +1/+1 counters on it.\nWhenever Phantom Nishoba deals damage, you gain that much life.\nIf damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "1ba799db-9db6-5432-bd0a-a92143efb8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae25abc-22c2-436d-9e08-f123543a0911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae25abc-22c2-436d-9e08-f123543a0911.jpg?1",
             "name": "Krosan Verge",
             "text": "Krosan Verge comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\no2, oc\nT, Sacrifice Krosan Verge: Search your library for a forest card and a plains card and put them into play tapped. Then shuffle your library.",
             "colours": [],
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "981c3ce4-1a4d-5763-b5f1-3fc9b18ba717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb870406-9d59-4493-9f81-0f4b84642001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb870406-9d59-4493-9f81-0f4b84642001.jpg?1",
             "name": "Nantuko Monastery",
             "text": "oc\nT: Add one colorless mana to your mana pool.\nThreshold o\nGo\nW: Nantuko Monastery becomes a 4/4 green and white creature with first strike until end of turn. It's still a land. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "ebfe17e0-abc8-591a-9784-55c93743b98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ece630-e484-4221-911f-e32048894f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ece630-e484-4221-911f-e32048894f23.jpg?1",
             "name": "Riftstone Portal",
             "text": "oc\nT: Add one colorless mana to your mana pool.\nAs long as Riftstone Portal is in your graveyard, lands you control have \"oc\nT: Add o\nG or o\nW to your mana pool.\"",
             "colours": [],

--- a/Assets/Resources/Sets/KHM.json
+++ b/Assets/Resources/Sets/KHM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "027d4611-2917-5151-87a9-9ff81dc88ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5ff64-6fe7-4fc5-be27-cdbaa14545ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5ff64-6fe7-4fc5-be27-cdbaa14545ab.jpg?1",
             "name": "Axgard Braggart",
             "text": "Boast \u2014 {1}{W}: Untap Axgard Braggart. Put a +1/+1 counter on it. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "e4106261-b91b-5d2f-90d1-798026a0b096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb79dc85-f85a-4846-9ac3-c75c64ea9c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb79dc85-f85a-4846-9ac3-c75c64ea9c0a.jpg?1",
             "name": "Battershield Warrior",
             "text": "Boast \u2014 {1}{W}: Creatures you control get +1/+1 until end of turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "820067e6-1a5b-565d-85a4-aadd6a664d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f0045-218d-41cd-bdca-8a9a0ab1b31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f0045-218d-41cd-bdca-8a9a0ab1b31b.jpg?1",
             "name": "Battlefield Raptor",
             "text": "Flying, first strike",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "80d5aab5-5ac8-51a2-a205-3befbe472d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc1df84-9c47-444b-9d58-d9c7bed51c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc1df84-9c47-444b-9d58-d9c7bed51c66.jpg?1",
             "name": "Beskir Shieldmate",
             "text": "When Beskir Shieldmate dies, create a 1/1 white Human Warrior creature token.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "da812f7a-5e1f-57d6-8884-22002508a926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074d526a-1eef-4045-bd38-f6d68c4bc4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074d526a-1eef-4045-bd38-f6d68c4bc4b9.jpg?1",
             "name": "Bound in Gold",
             "text": "Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "670eed3c-ea36-5a99-a417-199a86c5105e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a4c348-1012-4339-960a-c7bc7fd84fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a4c348-1012-4339-960a-c7bc7fd84fbb.jpg?1",
             "name": "Clarion Spirit",
             "text": "Whenever you cast your second spell each turn, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "ce0eab62-b27a-5457-9210-fb12f5a28739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1316a74e-da55-4668-87f2-98389a90a2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1316a74e-da55-4668-87f2-98389a90a2a4.jpg?1",
             "name": "Codespell Cleric",
             "text": "Vigilance\nWhen Codespell Cleric enters the battlefield, if it was the second spell you cast this turn, put a +1/+1 counter on target creature.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "28836cd7-2aae-592c-8613-211b3df1cc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a8c12-4a1f-4b96-a921-538fa1a2de43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a8c12-4a1f-4b96-a921-538fa1a2de43.jpg?1",
             "name": "Divine Gambit",
             "text": "Exile target artifact, creature, or enchantment an opponent controls. That player may put a permanent card from their hand onto the battlefield.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "61698655-73a4-5419-9650-2d09121e39ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg?1",
             "name": "Doomskar",
             "text": "Destroy all creatures.\nForetell {1}{W}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "a66eba61-8efb-5734-ab72-35bfbac9b827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dae01c8-15bb-44ad-a2c6-9bcf7a9e8c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dae01c8-15bb-44ad-a2c6-9bcf7a9e8c17.jpg?1",
             "name": "Doomskar Oracle",
             "text": "Whenever you cast your second spell each turn, you gain 2 life.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -347,7 +347,7 @@
         },
         {
             "id": "938396d7-6f6d-5e0f-beac-7018b57060a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71d8ca-c613-4534-bc9d-bc1e13202a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71d8ca-c613-4534-bc9d-bc1e13202a2c.jpg?1",
             "name": "Giant Ox",
             "text": "Giant Ox crews Vehicles using its toughness rather than its power.",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "0bc75517-1165-56c2-a37b-b979cd258829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f08552-7f1a-4fdb-9a70-d99cdbf75910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f08552-7f1a-4fdb-9a70-d99cdbf75910.jpg?1",
             "name": "Glorious Protector",
             "text": "Flash\nFlying\nWhen Glorious Protector enters the battlefield, you may exile any number of non-Angel creatures you control until Glorious Protector leaves the battlefield.\nForetell {2}{W}",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "ea839ef5-2602-5fcc-bb8e-b886b256561a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e645c8-90ac-4865-b441-e64251d6c9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e645c8-90ac-4865-b441-e64251d6c9a8.jpg?1",
             "name": "Gods' Hall Guardian",
             "text": "Vigilance\nForetell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "4d5d790f-dc9f-5fec-993b-4501717e2f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4cd64-8560-48f5-b0bc-f75286c1c91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4cd64-8560-48f5-b0bc-f75286c1c91c.jpg?1",
             "name": "Goldmaw Champion",
             "text": "Boast \u2014 {1}{W}: Tap target creature. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "4d175cbb-33c1-5e06-a9a5-bfd90cac55ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "c87e91b0-9117-538e-800f-f8c915aaea8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "4f28efd1-494a-57ff-8c74-1462d2966a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7213d9e1-e9c6-45d8-bb7f-336c41e7b6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7213d9e1-e9c6-45d8-bb7f-336c41e7b6f7.jpg?1",
             "name": "Invoke the Divine",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -595,7 +595,7 @@
         },
         {
             "id": "224fc334-346e-5777-b2c9-03a96813616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb38f5b-a2c2-4b06-8c9c-9615475a43e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb38f5b-a2c2-4b06-8c9c-9615475a43e7.jpg?1",
             "name": "Iron Verdict",
             "text": "Iron Verdict deals 5 damage to target tapped creature.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -627,7 +627,7 @@
         },
         {
             "id": "32ccf42b-4943-50db-b076-f317ef4f747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28e151f-b61b-486f-b7f8-7abde207c442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28e151f-b61b-486f-b7f8-7abde207c442.jpg?1",
             "name": "Kaya's Onslaught",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -659,7 +659,7 @@
         },
         {
             "id": "fe1fe8c7-a986-5d62-8553-aafe64f8d2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b269e27-8e17-4bf2-b28a-a83ecc7d22c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b269e27-8e17-4bf2-b28a-a83ecc7d22c0.jpg?1",
             "name": "Master Skald",
             "text": "When Master Skald enters the battlefield, you may exile a creature card from your graveyard. If you do, return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "9bdc2764-ce8a-5f56-862f-c73f481660bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03595195-3be2-4d18-b5c0-43b2dcc1c0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03595195-3be2-4d18-b5c0-43b2dcc1c0f5.jpg?1",
             "name": "Rally the Ranks",
             "text": "As Rally the Ranks enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "f0c356e8-740c-5363-9fde-56f4902492ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "fb2bf34b-1c20-5fc2-97f1-5d5170a94364",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "e15b22fa-863c-524d-921a-6c2b01a3460a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e849bec-2ee6-4c83-83e6-bf9f5543e414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e849bec-2ee6-4c83-83e6-bf9f5543e414.jpg?1",
             "name": "Resplendent Marshal",
             "text": "Flying\nWhen Resplendent Marshal enters the battlefield or dies, you may exile another creature card from your graveyard. When you do, put a +1/+1 counter on each creature you control other than Resplendent Marshal that shares a creature type with the exiled card.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "2561f771-1cbd-5f10-bf7c-e7622c4c4988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb75e-c8e5-417b-83d4-5105af9c66c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb75e-c8e5-417b-83d4-5105af9c66c1.jpg?1",
             "name": "Revitalize",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "6c26c3fb-aa25-5880-9e3e-e6560db70228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb5f9f-8750-4eb5-a03a-6dacc60e0b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb5f9f-8750-4eb5-a03a-6dacc60e0b90.jpg?1",
             "name": "Righteous Valkyrie",
             "text": "Flying\nWhenever another Angel or Cleric enters the battlefield under your control, you gain life equal to that creature's toughness.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "2639591a-f2bd-5087-aac0-12b1c55c3d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e31b716-f325-445a-9098-9ca75d7b35a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e31b716-f325-445a-9098-9ca75d7b35a4.jpg?1",
             "name": "Rune of Sustenance",
             "text": "Enchant permanent\nWhen Rune of Sustenance enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it has lifelink.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature has lifelink.\"",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "486134a9-1763-591a-abd3-3dea7ac17f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4368b087-05a0-4a88-ab43-0cd16446239b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4368b087-05a0-4a88-ab43-0cd16446239b.jpg?1",
             "name": "Runeforge Champion",
             "text": "When Runeforge Champion enters the battlefield, you may search your library and/or graveyard for a Rune card, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nYou may pay {1} rather than pay the mana cost for Rune spells you cast.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "94a38469-de92-573a-84e5-578b30c236c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65c215d-562d-4c7c-bc9f-b1d741050158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65c215d-562d-4c7c-bc9f-b1d741050158.jpg?1",
             "name": "Search for Glory",
             "text": "Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle your library. You gain 1 life for each {S} spent to cast this spell. ({S} is mana from a snow source.)",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "c9afcddd-da73-5f8f-9cf4-985a91481149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33c84e-008c-48d8-a8e8-77cd19cc4f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33c84e-008c-48d8-a8e8-77cd19cc4f1f.jpg?1",
             "name": "Shepherd of the Cosmos",
             "text": "Flying\nWhen Shepherd of the Cosmos enters the battlefield, return target permanent card with converted mana cost 2 or less from your graveyard to the battlefield.\nForetell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "dee928bb-c1f3-5599-8ff7-372b648f94ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec3c1e-e612-4700-888e-300912932552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec3c1e-e612-4700-888e-300912932552.jpg?1",
             "name": "Sigrid, God-Favored",
             "text": "Flash\nFirst strike, protection from God creatures\nWhen Sigrid, God-Favored enters the battlefield, exile up to one target attacking or blocking creature until Sigrid leaves the battlefield.",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "181edc9e-78b3-5d7a-ae23-e89f6007dfbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf036489-ef9e-40ee-a1bb-24ee37c554f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf036489-ef9e-40ee-a1bb-24ee37c554f1.jpg?1",
             "name": "Spectral Steel",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\n{1}{W}, Exile Spectral Steel from your graveyard: Return another target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "13f1d349-5c08-5c4a-86d8-484b3f92960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ecb530-e429-4b50-a24c-8437614cf224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ecb530-e429-4b50-a24c-8437614cf224.jpg?1",
             "name": "Stalwart Valkyrie",
             "text": "You may pay {1}{W} and exile a creature card from your graveyard rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "70dcac83-8e4c-5031-b3f5-bec4b0f6e07a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5373dd-4aec-4e93-97fb-a639aa096764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5373dd-4aec-4e93-97fb-a639aa096764.jpg?1",
             "name": "Starnheim Courser",
             "text": "Flying\nArtifact and enchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "ec0b00a6-1568-561d-a960-958263e5950b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea660d42-a441-48d8-98c1-00933cde94a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea660d42-a441-48d8-98c1-00933cde94a4.jpg?1",
             "name": "Starnheim Unleashed",
             "text": "Create a 4/4 white Angel Warrior creature token with flying and vigilance. If this spell was foretold, create X of those tokens instead.\nForetell {X}{X}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "7617afa5-06e9-56dc-81a4-6ec48d69c85c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dae817-3db1-4edf-86ba-c2c2b238fcf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dae817-3db1-4edf-86ba-c2c2b238fcf5.jpg?1",
             "name": "Story Seeker",
             "text": "Lifelink",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "a2f896c9-857f-5ad8-aa4e-06fe8af109ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e58478-c6a8-4f86-854a-a489c99bd777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e58478-c6a8-4f86-854a-a489c99bd777.jpg?1",
             "name": "Usher of the Fallen",
             "text": "Boast \u2014 {1}{W}: Create a 1/1 white Human Warrior creature token. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "cf3cd246-f5f2-5622-9ede-002c3152980b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97873c66-6bff-4d79-850c-1e2663098ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97873c66-6bff-4d79-850c-1e2663098ef4.jpg?1",
             "name": "Valkyrie's Sword",
             "text": "When Valkyrie's Sword enters the battlefield, you may pay {4}{W}. If you do, create a 4/4 white Angel Warrior creature token with flying and vigilance, then attach Valkyrie's Sword to it.\nEquipped creature gets +2/+1.\nEquip {3}",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "ef594038-38fb-5c7c-bd4c-58234de87400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83632e73-be3f-43fc-932f-45cb1af4f8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83632e73-be3f-43fc-932f-45cb1af4f8fb.jpg?1",
             "name": "Valor of the Worthy",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nWhen enchanted creature leaves the battlefield, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "ee6cba4d-91a8-5449-973e-e222bd277959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc98aff-edc0-4f78-ae4f-e08735c9e512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc98aff-edc0-4f78-ae4f-e08735c9e512.jpg?1",
             "name": "Warhorn Blast",
             "text": "Creatures you control get +2/+1 until end of turn.\nForetell {2}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "225ff3ef-7b44-5df0-a69e-27e2f0166a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b26c95-f90d-43fb-8c99-2a3aa13ac2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b26c95-f90d-43fb-8c99-2a3aa13ac2c6.jpg?1",
             "name": "Wings of the Cosmos",
             "text": "Target creature gets +1/+3 and gains flying until end of turn. Untap it.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "45a682a9-a941-5d1b-b101-314eda89ac87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "ae4e6e88-7801-54f1-8372-8e78386ae6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "ec1f62d3-ec77-5fa9-925b-e036225bb625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg?1",
             "name": "A-Alrund, God of the Cosmos // A-Hakka, Whispering Raven",
             "text": "",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "27a2189a-fe39-5e71-8b33-2d2ca13b02a2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg?1",
             "name": "A-Alrund, God of the Cosmos // A-Hakka, Whispering Raven",
             "text": "",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "1541782c-db65-5e33-af0f-cda3c626b648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94fcb53-a7bd-4a80-a536-9fb0eb24261a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94fcb53-a7bd-4a80-a536-9fb0eb24261a.jpg?1",
             "name": "Alrund's Epiphany",
             "text": "Create two 1/1 blue Bird creature tokens with flying. Take an extra turn after this one. Exile Alrund's Epiphany.\nForetell {4}{U}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "992dcf7e-b4d3-54ad-88f8-b28f57125206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f81dc-2346-4bd9-aa3b-aaa2d3873415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f81dc-2346-4bd9-aa3b-aaa2d3873415.jpg?1",
             "name": "A-Alrund's Epiphany",
             "text": "",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "3f2e7535-d519-55b1-bd9b-2ad30b737cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d4a59-11a0-4a55-8ac0-07377a9e6dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d4a59-11a0-4a55-8ac0-07377a9e6dc8.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "01d0a0f3-3139-50e0-9f8e-7b18deefb7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56de43-c0fd-4627-846d-41a962b95f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56de43-c0fd-4627-846d-41a962b95f17.jpg?1",
             "name": "Ascendant Spirit",
             "text": "{S}{S}: Ascendant Spirit becomes a Spirit Warrior with base power and toughness 2/3.|{S}{S}{S}: If Ascendant Spirit is a Warrior, put a flying counter on it and it becomes a Spirit Warrior Angel with base power and toughness 4/4.|{S}{S}{S}{S}: If Ascendant Spirit is an Angel, put two +1/+1 counters on it and it gains \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "c362004f-bbb4-5f7c-a0fa-300abfb1c0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9947cfd-91d6-479e-a7f6-2a2050f020f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9947cfd-91d6-479e-a7f6-2a2050f020f3.jpg?1",
             "name": "Augury Raven",
             "text": "Flying\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "44fe7d0d-ddda-52ef-9e58-1f7e61374694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cef049-6a47-4264-b2bc-b9d291a09c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cef049-6a47-4264-b2bc-b9d291a09c4c.jpg?1",
             "name": "Avalanche Caller",
             "text": "{2}: Target snow land you control becomes a 4/4 Elemental creature with hexproof and haste until end of turn. It's still a land. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "21a797d8-808a-5a9f-b9d8-3fb7eb97d56c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27855a38-a682-4f97-ad22-ac625e86faec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27855a38-a682-4f97-ad22-ac625e86faec.jpg?1",
             "name": "Behold the Multiverse",
             "text": "Scry 2, then draw two cards.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "d29e6261-9ec8-50bd-b0c5-f035845cdd65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3567bdc-450e-4481-9349-a80fe52fe431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3567bdc-450e-4481-9349-a80fe52fe431.jpg?1",
             "name": "Berg Strider",
             "text": "When Berg Strider enters the battlefield, tap target artifact or creature an opponent controls. If {S} was spent to cast this spell, that permanent doesn't untap during its controller's next untap step. ({S} is mana from a snow source.)",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "572bcdd9-157f-55ae-b35e-0f3f51742857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080be8d1-e453-4250-b917-f0eb26644895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080be8d1-e453-4250-b917-f0eb26644895.jpg?1",
             "name": "Bind the Monster",
             "text": "Enchant creature\nWhen Bind the Monster enters the battlefield, tap enchanted creature. It deals damage to you equal to its power.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "87e805b9-599d-5572-96f7-746b0cdee3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89960a74-9e17-4e30-874a-4286dd4c917d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89960a74-9e17-4e30-874a-4286dd4c917d.jpg?1",
             "name": "Brinebarrow Intruder",
             "text": "Flash\nWhen Brinebarrow Intruder enters the battlefield, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "1e55fcba-f46e-596f-b567-73fc2f83c71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "81538024-f662-55ea-9818-c2778f6203b2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "6190b354-a423-572f-87a3-a5ba81401a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec318c6-b718-436f-b9e8-e0c6154e5010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec318c6-b718-436f-b9e8-e0c6154e5010.jpg?1",
             "name": "Cosmos Charger",
             "text": "Flash\nFlying|\nForetelling cards from your hand costs {1} less and can be done on any player's turn.\nForetell {2}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "0e67b98d-22a8-5b34-a067-85dfdd36152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfd73e2-1fad-46f6-90c5-ea35a380dbef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfd73e2-1fad-46f6-90c5-ea35a380dbef.jpg?1",
             "name": "A-Cosmos Charger",
             "text": "",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "0fba284f-2fd5-5bc6-9d97-59ee1083e393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d40071-cadf-48de-a8ed-d55adbfab632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d40071-cadf-48de-a8ed-d55adbfab632.jpg?1",
             "name": "Cyclone Summoner",
             "text": "When Cyclone Summoner enters the battlefield, if you cast it from your hand, return all permanents to their owners' hands except for Giants, Wizards, and lands.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "bd37123e-a700-5ff8-9b63-4203c428d372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce0403d-76ed-4eb0-abdd-74ed28f96137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce0403d-76ed-4eb0-abdd-74ed28f96137.jpg?1",
             "name": "Depart the Realm",
             "text": "Return target nonland permanent to its owner's hand.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "215312ae-6b48-52d9-880c-84c2ef1e8564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7691ac89-f8ba-493e-aa11-5674a783dffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7691ac89-f8ba-493e-aa11-5674a783dffb.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "abdac51e-36bb-5ea7-87c7-16fb2f1c8cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31da60a2-d4d3-4954-be59-c7ff61fa2905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31da60a2-d4d3-4954-be59-c7ff61fa2905.jpg?1",
             "name": "Draugr Thought-Thief",
             "text": "When Draugr Thought-Thief enters the battlefield, look at the top card of target player's library. You may put that card into their graveyard.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "2bdfe8cc-a1fc-5266-bbf3-3c10ce5c6ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae592f-caf6-445a-970b-f8101998e657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae592f-caf6-445a-970b-f8101998e657.jpg?1",
             "name": "Frost Augur",
             "text": "{S}, {T}: Look at the top card of your library. If it's a snow card, you may reveal it and put it into your hand. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "b32c4fb8-3d37-5a07-b727-2ad987d3bd0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f406ce3-dce1-42d3-b76c-8e8c4b2770cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f406ce3-dce1-42d3-b76c-8e8c4b2770cb.jpg?1",
             "name": "Frostpeak Yeti",
             "text": "{1}{S}: Frostpeak Yeti can't be blocked this turn. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "f7715482-1676-59c4-af22-1f04ce353c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f8abd-4d39-4b50-876f-9c6713bc4ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f8abd-4d39-4b50-876f-9c6713bc4ab5.jpg?1",
             "name": "Frostpyre Arcanist",
             "text": "This spell costs {1} less to cast if you control a Giant or a Wizard.\nWhen Frostpyre Arcanist enters the battlefield, search your library for an instant or sorcery card with the same name as a card in your graveyard, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "c0c08a05-726c-5ad2-be6c-b61dfdfc1aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8b1ec2-9303-4722-8644-b3bc1a5c387f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8b1ec2-9303-4722-8644-b3bc1a5c387f.jpg?1",
             "name": "Giant's Amulet",
             "text": "When Giant's Amulet enters the battlefield, you may pay {3}{U}. If you do, create a 4/4 blue Giant Wizard creature token, then attach Giant's Amulet to it.\nEquipped creature gets +0/+1 and has \"This creature has hexproof as long as it's untapped.\"(It can't be the target of spells or abilities your opponents control.)\nEquip {2}",
             "colours": [
@@ -2346,7 +2346,7 @@
         },
         {
             "id": "9e651cdd-76b9-5239-a93f-d35ff01d50a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc96ebe8-f4b3-4788-a6f5-2a50b6c0d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc96ebe8-f4b3-4788-a6f5-2a50b6c0d935.jpg?1",
             "name": "Glimpse the Cosmos",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\nAs long as you control a Giant, you may cast Glimpse the Cosmos from your graveyard by paying {U} rather than paying its mana cost. If you cast Glimpse the Cosmos this way and it would be put into your graveyard, exile it instead.",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "508d6e65-942d-529b-a9d2-ae976e1b7075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4386e5c-32b1-4096-a93f-fedd1a4801fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4386e5c-32b1-4096-a93f-fedd1a4801fc.jpg?1",
             "name": "Graven Lore",
             "text": "Scry X, where X is the amount of {S} spent to cast this spell, then draw three cards. ({S} is mana from a snow source.)",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "2b89173e-c5ac-5df3-adfc-c4743e8df05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3152f1f-5d3f-4bc4-9b6f-f2983ab3f691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3152f1f-5d3f-4bc4-9b6f-f2983ab3f691.jpg?1",
             "name": "Icebind Pillar",
             "text": "{S}, {T}: Tap target artifact or creature. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2448,7 +2448,7 @@
         },
         {
             "id": "3be6b457-a5e5-5139-bf4d-1346f716b5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fdb9bb-09a2-4ff7-bcd4-35ea33c1b752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fdb9bb-09a2-4ff7-bcd4-35ea33c1b752.jpg?1",
             "name": "Icebreaker Kraken",
             "text": "This spell costs {1} less to cast for each snow land you control.\nWhen Icebreaker Kraken enters the battlefield, artifacts and creatures target opponent controls don't untap during that player's next untap step.\nReturn three snow lands you control to their owner's hand: Return Icebreaker Kraken to its owner's hand.",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "8c04332b-4e7b-541c-a47f-c361633e145f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6f095-5beb-42a8-af8f-d40eef27150e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6f095-5beb-42a8-af8f-d40eef27150e.jpg?1",
             "name": "Inga Rune-Eyes",
             "text": "When Inga Rune-Eyes enters the battlefield, scry 3.\nWhen Inga Rune-Eyes dies, draw three cards if three or more creatures died this turn.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "40b80c8b-8fcb-56a3-ad06-dc58068c67c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4911016c-b92a-47cc-9553-b424d7be196a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4911016c-b92a-47cc-9553-b424d7be196a.jpg?1",
             "name": "Karfell Harbinger",
             "text": "{T}: Add {U}. Spend this mana only to foretell a card from your hand or cast an instant or sorcery spell.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "e7ac699e-d07d-5eb1-8104-6271fd16ea67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c119f836-0707-49e2-b6d4-25f849d054a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c119f836-0707-49e2-b6d4-25f849d054a4.jpg?1",
             "name": "Littjara Kinseekers",
             "text": "Changeling (This card is every creature type.)\nWhen Littjara Kinseekers enters the battlefield, if you control three or more creatures that share a creature type, put a +1/+1 counter on Littjara Kinseekers, then scry 1.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "20474ed9-5d72-5d30-ace0-90dfe4d34a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfd4944-790f-4835-a8a1-c23ef7047648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfd4944-790f-4835-a8a1-c23ef7047648.jpg?1",
             "name": "Mists of Littjara",
             "text": "Flash\nEnchant creature or Vehicle\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "119d316d-24b8-5822-9d8d-0f3600317151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f64b49-327c-473b-a492-f020a322aed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f64b49-327c-473b-a492-f020a322aed7.jpg?1",
             "name": "Mistwalker",
             "text": "Changeling (This card is every creature type.)\nFlying\n{1}{U}: Mistwalker gets +1/-1 until end of turn.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "ebe4fc82-fd5d-510f-bc01-b6eaa005253c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b877e2-60eb-46cd-acd7-8555b9e7e993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b877e2-60eb-46cd-acd7-8555b9e7e993.jpg?1",
             "name": "Mystic Reflection",
             "text": "Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "2cd061b1-487b-5778-89aa-4489f48f0ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f36775e-9e48-49cc-a771-d58481712edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f36775e-9e48-49cc-a771-d58481712edc.jpg?1",
             "name": "Orvar, the All-Form",
             "text": "Changeling\nWhenever you cast an instant or sorcery spell, if it targets one or more other permanents you control, create a token that's a copy of one of those permanents.\nWhen a spell or ability an opponent controls causes you to discard this card, create a token that's a copy of target permanent.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "a5e400f1-e666-56a2-af7c-1efd6345151b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ee3829-8dec-4c0f-a6c2-ad47a1c94cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ee3829-8dec-4c0f-a6c2-ad47a1c94cfc.jpg?1",
             "name": "Pilfering Hawk",
             "text": "Flying\n{S}, {T}: Draw a card, then discard a card. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "b22c18db-2eb8-5639-8864-8120f121f2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2cfcd7-b43a-4dad-a033-e661f55ceecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2cfcd7-b43a-4dad-a033-e661f55ceecd.jpg?1",
             "name": "Ravenform",
             "text": "Exile target artifact or creature. Its controller creates a 1/1 blue Bird creature token with flying.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "689dcbcb-fead-5baa-a6d4-cbc8c07b03be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadee447-ce9a-4dea-a074-bfd04197548e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadee447-ce9a-4dea-a074-bfd04197548e.jpg?1",
             "name": "Reflections of Littjara",
             "text": "As Reflections of Littjara enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, copy that spell. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "81f26664-186d-5f9c-b009-4abee5319bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eed5a2d-d7a4-4f64-a96b-04c5d4206c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eed5a2d-d7a4-4f64-a96b-04c5d4206c5a.jpg?1",
             "name": "Run Ashore",
             "text": "Choose one or both \u2014\n\u2022 The owner of target nonland permanent puts it on the top or bottom of their library.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "d3313ae2-bad5-5567-ab89-ab573eacf3f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c1a271-2107-462a-9d4a-9c7fbcfa8d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c1a271-2107-462a-9d4a-9c7fbcfa8d77.jpg?1",
             "name": "Rune of Flight",
             "text": "Enchant permanent\nWhen Rune of Flight enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it has flying.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature has flying.\"",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "b1baf88d-9c85-5a60-918b-8b87bd875b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877a1bb9-5eae-453a-bec0-a9de20ea6815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877a1bb9-5eae-453a-bec0-a9de20ea6815.jpg?1",
             "name": "Saw It Coming",
             "text": "Counter target spell.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "b8712f01-997b-5fe4-9157-9656b80cc897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29306305-cb71-4fef-bf86-f5deb4e7e561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29306305-cb71-4fef-bf86-f5deb4e7e561.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "70a8163d-984f-50f7-8b8f-ce52c846dba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550c745b-64e8-4d20-9cf0-024248ddbd57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550c745b-64e8-4d20-9cf0-024248ddbd57.jpg?1",
             "name": "Undersea Invader",
             "text": "Flash\nUndersea Invader enters the battlefield tapped.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "95642a75-7397-5156-870b-7f7f04aa5aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8606f40-0af4-443b-a413-a88dc3e8f32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8606f40-0af4-443b-a413-a88dc3e8f32e.jpg?1",
             "name": "Blood on the Snow",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all planeswalkers.|\nThen return a creature or planeswalker card with converted mana cost X or less from your graveyard to the battlefield, where X is the amount of {S} spent to cast this spell. ({S} is mana from a snow source.)",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "660fa2e6-3608-516b-909f-47d464d6f3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6308a53-de07-4ed9-80a1-3579843466c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6308a53-de07-4ed9-80a1-3579843466c2.jpg?1",
             "name": "Bloodsky Berserker",
             "text": "Whenever you cast your second spell each turn, put two +1/+1 counters on Bloodsky Berserker. It gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "1ece5168-111a-5844-94fd-d6317ff0f029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f358a52b-8044-404e-8d04-2ec5903386cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f358a52b-8044-404e-8d04-2ec5903386cc.jpg?1",
             "name": "Burning-Rune Demon",
             "text": "Flying\nWhen Burning-Rune Demon enters the battlefield, you may search your library for exactly two cards not named Burning-Rune Demon that have different names. If you do, reveal those cards. An opponent chooses one of them. Put the chosen card into your hand and the other into your graveyard, then shuffle your library.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "dfd3f415-e9a1-5fed-ad2c-fdd87b075fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9bd181-b99f-477e-bcfb-9b78cbf51224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9bd181-b99f-477e-bcfb-9b78cbf51224.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "6254f38b-e7c9-5ab3-8ee3-9e5fc4fc1c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f2029f-ffda-4374-9a78-79866ac23fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f2029f-ffda-4374-9a78-79866ac23fca.jpg?1",
             "name": "Deathknell Berserker",
             "text": "When Deathknell Berserker dies, if its power was 3 or greater, create a 2/2 black Zombie Berserker creature token.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "1853e26f-51f9-5af2-96c8-a7d35efc45e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f23c487-ac4a-475b-ad5e-ec6f8678e668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f23c487-ac4a-475b-ad5e-ec6f8678e668.jpg?1",
             "name": "Demonic Gifts",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "913234cf-0a8a-5aa2-9e69-cd73f6196d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f6a159-b969-4767-802e-409f8bf286fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f6a159-b969-4767-802e-409f8bf286fe.jpg?1",
             "name": "Dogged Pursuit",
             "text": "At the beginning of your end step, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "a791e5b5-3145-59ff-ba54-7cadfc74e5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d8e0ff-e720-41ca-af69-35585a2d7ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d8e0ff-e720-41ca-af69-35585a2d7ae2.jpg?1",
             "name": "Draugr Necromancer",
             "text": "If a nontoken creature an opponent controls would die, exile that card with an ice counter on it instead.\nYou may cast spells from among cards in exile your opponents own with ice counters on them, and you may spend mana from snow sources as though it were mana of any color to cast those spells.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "96904f2e-58aa-5d8e-a03d-48e690bb60e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0fe66b-0067-4e5c-9b3a-b014b2f0daf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0fe66b-0067-4e5c-9b3a-b014b2f0daf2.jpg?1",
             "name": "Draugr Recruiter",
             "text": "Boast \u2014 {3}{B}: Return target creature card from your graveyard to your hand. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "ee684323-f641-5cd3-9a9f-23f2e888ae97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4aade3-b1e3-43d1-b4a8-6b55ecdb4327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4aade3-b1e3-43d1-b4a8-6b55ecdb4327.jpg?1",
             "name": "Draugr's Helm",
             "text": "When Draugr's Helm enters the battlefield, you may pay {2}{B}. If you do, create a 2/2 black Zombie Berserker creature token, then attach Draugr's Helm to it.\nEquipped creature gets +2/+2 and has menace. (It can't be blocked except by two or more creatures.)\nEquip {4}",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "5b50bd95-9b83-55c8-b2d9-87ba068f23fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205eb029-68a0-4895-b142-2eb09987b5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205eb029-68a0-4895-b142-2eb09987b5cb.jpg?1",
             "name": "Dread Rider",
             "text": "{1}{B}, {T}, Exile a creature card from your graveyard: Target opponent loses 3 life.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "fe095c0a-560b-5b73-a038-01e8d0e85d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1d88a6-a74d-44b5-b7a8-866e866807f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1d88a6-a74d-44b5-b7a8-866e866807f1.jpg?1",
             "name": "Dream Devourer",
             "text": "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}. (During your turn, you may pay {2} and exile it from your hand face down. Cast it on a later turn for its foretell cost.)\nWhenever you foretell a card, Dream Devourer gets +2/+0 until end of turn.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "b18a5fb2-dd2a-560c-9267-d1a7aaba48f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5490b8-5652-40f5-8678-e1263ef69b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5490b8-5652-40f5-8678-e1263ef69b5a.jpg?1",
             "name": "Duskwielder",
             "text": "Boast \u2014 {1}: Target opponent loses 1 life and you gain 1 life. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "a6cd429a-386e-51c9-8014-33af45d5c689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "e7619d66-eed8-5e0d-9b45-26e299de2ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "84376211-7d68-5498-a0e1-51941efe5cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3a6148-d005-49c1-a7fc-867c4e8251cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3a6148-d005-49c1-a7fc-867c4e8251cd.jpg?1",
             "name": "Elderfang Disciple",
             "text": "When Elderfang Disciple enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -3570,7 +3570,7 @@
         },
         {
             "id": "cd5b549d-434c-53e1-8095-3654011e2366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00edda3-ddbc-44ee-a14b-47a701445bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00edda3-ddbc-44ee-a14b-47a701445bb0.jpg?1",
             "name": "Eradicator Valkyrie",
             "text": "Flying, lifelink, hexproof from planeswalkers\nBoast \u2014 {1}{B}, Sacrifice a creature: Each opponent sacrifices a creature or planeswalker. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "d2db699c-fb42-5d8c-81e6-949ad41377a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a1a75b-20cf-4db9-a244-cc54411446c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a1a75b-20cf-4db9-a244-cc54411446c4.jpg?1",
             "name": "Feed the Serpent",
             "text": "Exile target creature or planeswalker.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "8870b7aa-0a0c-52e0-9df0-e0f0e7667be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54340c59-03a9-4d9d-bd27-9aed337ce75a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54340c59-03a9-4d9d-bd27-9aed337ce75a.jpg?1",
             "name": "Grim Draugr",
             "text": "{1}{S}: Grim Draugr gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures. {S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "2964bf60-eb4b-5f70-b891-4cf88241d3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a272b3-aaab-4c98-86a8-85c67a5f3d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a272b3-aaab-4c98-86a8-85c67a5f3d4d.jpg?1",
             "name": "Hailstorm Valkyrie",
             "text": "Flying, trample\n{S}{S}: Hailstorm Valkyrie gets +2/+2 until end of turn. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -3713,7 +3713,7 @@
         },
         {
             "id": "4ec399b4-03a0-56f5-be98-99db7854bb83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac5bca0-35fe-47be-a78c-d5eac68a3bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac5bca0-35fe-47be-a78c-d5eac68a3bfa.jpg?1",
             "name": "Haunting Voyage",
             "text": "Choose a creature type. Return up to two creature cards of that type from your graveyard to the battlefield. If this spell was foretold, return all creature cards of that type from your graveyard to the battlefield instead.\nForetell {5}{B}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "696ed9e8-c0ee-5ace-832d-68b01466842d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80340582-655b-4bf1-88fb-14bcbe17aa04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80340582-655b-4bf1-88fb-14bcbe17aa04.jpg?1",
             "name": "Infernal Pet",
             "text": "Whenever you cast your second spell each turn, put a +1/+1 counter on Infernal Pet and it gains flying until end of turn.",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "fae554e0-15ee-5a46-9dab-3afbbf28f763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b12c6c-c3d6-4b8a-bed4-d61f67f565b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b12c6c-c3d6-4b8a-bed4-d61f67f565b9.jpg?1",
             "name": "Jarl of the Forsaken",
             "text": "Flash\nWhen Jarl of the Forsaken enters the battlefield, destroy target creature or planeswalker an opponent controls that was dealt damage this turn.\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "e4e41312-71a8-504b-a589-594be121b4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670c380-6faa-42ec-ab41-6be8137169b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670c380-6faa-42ec-ab41-6be8137169b2.jpg?1",
             "name": "Karfell Kennel-Master",
             "text": "When Karfell Kennel-Master enters the battlefield, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "27d5bbe9-af5a-5b4a-9fca-b8168d1f02df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f1a90-af64-4122-9c1a-954edf8fa240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f1a90-af64-4122-9c1a-954edf8fa240.jpg?1",
             "name": "Koma's Faithful",
             "text": "Lifelink\nWhen Koma's Faithful dies, each player mills three cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "4a8a71e4-e1b6-5643-b4d3-10ea03fc351f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb94456-5266-47db-b514-a0e17e34b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb94456-5266-47db-b514-a0e17e34b771.jpg?1",
             "name": "Poison the Cup",
             "text": "Destroy target creature. If this spell was foretold, scry 2.\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "faab7c5d-3a2c-58bd-bb0f-80afb8966ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde0f4d-5acc-4a25-a3d6-c6b9b734360c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde0f4d-5acc-4a25-a3d6-c6b9b734360c.jpg?1",
             "name": "Priest of the Haunted Edge",
             "text": "{T}, Sacrifice Priest of the Haunted Edge: Target creature gets -X/-X until end of turn, where X is the number of snow lands you control. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "537c2606-8a99-5415-ad7b-2f7ed7f03b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67c196-632c-4c7b-a132-de07d894e634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67c196-632c-4c7b-a132-de07d894e634.jpg?1",
             "name": "Raise the Draugr",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return two target creature cards that share a creature type from your graveyard to your hand.",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "fdab4ad2-153d-54bd-a999-5384666906b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470601b0-9598-487f-bb14-4bfec7ca6d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470601b0-9598-487f-bb14-4bfec7ca6d61.jpg?1",
             "name": "Return Upon the Tide",
             "text": "Return target creature card from your graveyard to the battlefield. If it's an Elf, create two 1/1 green Elf Warrior creature tokens.\nForetell {3}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "98482a2e-0257-534b-8fba-5493893c4ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238560c-4633-4507-828e-4e96ecf62e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238560c-4633-4507-828e-4e96ecf62e11.jpg?1",
             "name": "A-Return Upon the Tide",
             "text": "",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "8c57873b-d158-5296-9f91-adbf61471829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a1ec1-f362-494d-a23b-6a963ce44fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a1ec1-f362-494d-a23b-6a963ce44fdd.jpg?1",
             "name": "Rise of the Dread Marn",
             "text": "Create X 2/2 black Zombie Berserker creature tokens, where X is the number of nontoken creatures that died this turn.\nForetell {B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "34c7416b-4b40-5fe7-8ee9-b07ebe3c280b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75a5e5-70df-49c3-abe1-8cc6975f5171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75a5e5-70df-49c3-abe1-8cc6975f5171.jpg?1",
             "name": "Rune of Mortality",
             "text": "Enchant permanent\nWhen Rune of Mortality enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it has deathtouch.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature has deathtouch.\"",
             "colours": [
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "a70e1ab6-ff9e-5cde-bfe6-58d8139e5f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad2c6d4-03dd-4dab-861c-77c55bda0db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad2c6d4-03dd-4dab-861c-77c55bda0db7.jpg?1",
             "name": "Skemfar Avenger",
             "text": "Whenever another nontoken Elf or Berserker you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "eee4cd76-b77f-5707-a2f8-1d656f2f7316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886b815b-ffcb-4239-b161-68983e091124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886b815b-ffcb-4239-b161-68983e091124.jpg?1",
             "name": "A-Skemfar Avenger",
             "text": "",
             "colours": [
@@ -4192,7 +4192,7 @@
         },
         {
             "id": "623ffec9-2b27-58f5-8789-6a359194ffd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204130f-0483-49ed-8512-03a74894702e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204130f-0483-49ed-8512-03a74894702e.jpg?1",
             "name": "Skemfar Shadowsage",
             "text": "When Skemfar Shadowsage enters the battlefield, choose one \u2014\n\u2022 Each opponent loses X life, where X is the greatest number of creatures you control that have a creature type in common.\n\u2022 You gain X life, where X is the greatest number of creatures you control that have a creature type in common.",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "1ce4b8ac-8b77-5f81-80c8-4c03fe84dbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4589c520-4db3-47bf-bfb2-5d7e02ede4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4589c520-4db3-47bf-bfb2-5d7e02ede4bf.jpg?1",
             "name": "Skull Raid",
             "text": "Target opponent discards two cards. If fewer than two cards were discarded this way, you draw cards equal to the difference.\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4259,7 +4259,7 @@
         },
         {
             "id": "8430581c-d266-5713-b712-f9c507ab5fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -4297,7 +4297,7 @@
         },
         {
             "id": "90c4d598-dd83-566a-9138-2eb1e255ec8e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "7d59a82c-b5c1-5b89-aeae-6317ec5a246b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/417f71d2-d7da-4279-8847-d27c67e9ea9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/417f71d2-d7da-4279-8847-d27c67e9ea9d.jpg?1",
             "name": "Tergrid's Shadow",
             "text": "Each player sacrifices two creatures.\nForetell {2}{B}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "6161b207-65da-513c-b322-c6c1c75ad21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "cd94f98e-85bb-5eea-b1c1-5d5b39e2e9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "13fecfa5-7f0a-56c0-ae90-848d4fb262e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa8dbf0-4e5a-452b-826f-5813e8cd9d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa8dbf0-4e5a-452b-826f-5813e8cd9d85.jpg?1",
             "name": "Varragoth, Bloodsky Sire",
             "text": "Deathtouch\nBoast \u2014 {1}{B}: Target player searches their library for a card, then shuffles their library and puts that card on top of it. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "5bd29a84-04bb-5c91-8800-f8a4e07770f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c99fd-71ba-40b7-98cf-b783f01a77b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c99fd-71ba-40b7-98cf-b783f01a77b4.jpg?1",
             "name": "Vengeful Reaper",
             "text": "Flying, deathtouch, haste|\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "66d20282-5804-54f0-a579-ffc6351a6fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fab9ee8-776a-48e5-b309-bcd381e67bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fab9ee8-776a-48e5-b309-bcd381e67bf7.jpg?1",
             "name": "Village Rites",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -4552,7 +4552,7 @@
         },
         {
             "id": "43c61b32-95c0-5e67-80da-a36c28219d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffa795d-2211-49b0-a6df-812599758f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffa795d-2211-49b0-a6df-812599758f7b.jpg?1",
             "name": "Weigh Down",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nTarget creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "926dc4cd-682d-5909-b5c1-2e535769090f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597fe119-64a7-4499-8b69-738af5a71a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597fe119-64a7-4499-8b69-738af5a71a20.jpg?1",
             "name": "Withercrown",
             "text": "Enchant creature\nEnchanted creature has base power 0 and has \"At the beginning of your upkeep, you lose 1 life unless you sacrifice this creature.\"",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "16837722-fc11-58c7-aa4a-d1b08ee584e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff334bba-0805-4d5d-86c4-99185fe9a77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff334bba-0805-4d5d-86c4-99185fe9a77a.jpg?1",
             "name": "Arni Brokenbrow",
             "text": "Haste\nBoast \u2014 {1}: You may change Arni Brokenbrow's base power to 1 plus the greatest power among other creatures you control until end of turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "066332db-776e-5646-8f3d-aba9d1817e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2411c341-a470-4484-9248-7c1d3ca12978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2411c341-a470-4484-9248-7c1d3ca12978.jpg?1",
             "name": "Axgard Cavalry",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "1b414b20-21c1-53e9-86c4-98944dd9d36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32aea04-04f7-48a8-a8ab-8b38fa53da3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32aea04-04f7-48a8-a8ab-8b38fa53da3b.jpg?1",
             "name": "Basalt Ravager",
             "text": "When Basalt Ravager enters the battlefield, it deals X damage to any target, where X is the greatest number of creatures you control that have a creature type in common.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "750b2eca-e9c3-52bf-919f-b45eaf865193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "3511fd42-d534-5dd8-9e31-ef81bfc49949",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -4801,7 +4801,7 @@
         },
         {
             "id": "a516071c-7025-5fd1-b664-6849648752a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6eb23c9-6061-4ad1-a8f3-2c791c49f352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6eb23c9-6061-4ad1-a8f3-2c791c49f352.jpg?1",
             "name": "Breakneck Berserker",
             "text": "Haste",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "2e2b8656-c379-5efa-b798-3d71eb82e924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15edad1-ff68-4f20-95f6-99fe549bea98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15edad1-ff68-4f20-95f6-99fe549bea98.jpg?1",
             "name": "Calamity Bearer",
             "text": "If a Giant source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "9768d7da-4b97-50c4-b317-9f70af933db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4802e6c-6921-4dac-bf44-7e09d6942b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4802e6c-6921-4dac-bf44-7e09d6942b71.jpg?1",
             "name": "Cinderheart Giant",
             "text": "Trample\nWhen Cinderheart Giant dies, it deals 7 damage to a creature an opponent controls chosen at random.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "7967c0f7-bacc-58dc-b549-0c81c1507cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be804ab-1024-4eee-b339-48ed8b84d363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be804ab-1024-4eee-b339-48ed8b84d363.jpg?1",
             "name": "Craven Hulk",
             "text": "Craven Hulk can't block alone.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "869ffe36-ec84-500f-85c2-287eb4d0e07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a20c2-1d17-46ea-b4d2-3e70bc05aae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a20c2-1d17-46ea-b4d2-3e70bc05aae3.jpg?1",
             "name": "Crush the Weak",
             "text": "Crush the Weak deals 2 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "9e1d970b-0b62-5df9-b27f-45ee15ee0df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f856b0e-b413-49b0-9aa7-d935ad40ae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f856b0e-b413-49b0-9aa7-d935ad40ae53.jpg?1",
             "name": "Demon Bolt",
             "text": "Demon Bolt deals 4 damage to target creature or planeswalker.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "f1df6271-d786-572c-b6ee-318e5a8b04a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e125e4-103f-4a68-b85f-1382646da71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e125e4-103f-4a68-b85f-1382646da71e.jpg?1",
             "name": "Doomskar Titan",
             "text": "When Doomskar Titan enters the battlefield, creatures you control get +1/+0 and gain haste until end of turn.\nForetell {4}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "446fc63a-ba05-54fe-996e-4b01de172f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f22fe4-2390-4c3d-8b5e-0cf398d97f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f22fe4-2390-4c3d-8b5e-0cf398d97f6a.jpg?1",
             "name": "Dragonkin Berserker",
             "text": "First strike\nBoast abilities you activate cost {1} less to activate for each Dragon you control.\nBoast \u2014 {4}{R}: Create a 5/5 red Dragon creature token with flying. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "3d0256fd-0186-57dc-8827-8175eeb21af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef580f8-efec-4d31-8dc3-2018dd48b6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef580f8-efec-4d31-8dc3-2018dd48b6f4.jpg?1",
             "name": "Dual Strike",
             "text": "When you cast your next instant or sorcery spell with converted mana cost 4 or less this turn, copy that spell. You may choose new targets for the copy.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "b45fa37b-16a6-5e6b-91bb-25e227327d69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cc132f-d4c1-4bc4-9c9e-f63ab5e7d094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cc132f-d4c1-4bc4-9c9e-f63ab5e7d094.jpg?1",
             "name": "Dwarven Hammer",
             "text": "When Dwarven Hammer enters the battlefield, you may pay {2}. If you do, create a 2/1 red Dwarf Berserker creature token, then attach Dwarven Hammer to it.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "7df02a24-2cf9-5feb-a4ba-524c1537a217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bcc7cb-65dd-4bc6-8606-a162fa6c65f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bcc7cb-65dd-4bc6-8606-a162fa6c65f7.jpg?1",
             "name": "Dwarven Reinforcements",
             "text": "Create two 2/1 red Dwarf Berserker creature tokens.\nForetell {1}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "64a2f326-fa76-5101-af28-a8e592c7d6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212462b7-e23e-4c87-93aa-9cadefbf1ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212462b7-e23e-4c87-93aa-9cadefbf1ac8.jpg?1",
             "name": "Fearless Liberator",
             "text": "Boast \u2014 {2}{R}: Create a 2/1 red Dwarf Berserker creature token. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "cb67b8d3-adf3-5d7c-9743-f3916d541472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eba2250-0e9b-46fd-a4b5-23f30329e063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eba2250-0e9b-46fd-a4b5-23f30329e063.jpg?1",
             "name": "Fearless Pup",
             "text": "First strike\nBoast \u2014 {2}{R}: Fearless Pup gets +2/+0 until end of turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5246,7 +5246,7 @@
         },
         {
             "id": "00393b64-7072-55fe-8342-26e6be96086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c59e0b-5b78-4cf5-9c2a-92ccf833778f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c59e0b-5b78-4cf5-9c2a-92ccf833778f.jpg?1",
             "name": "Frenzied Raider",
             "text": "Whenever you activate a boast ability, put a +1/+1 counter on Frenzied Raider.",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "e3bd9213-4bf8-575b-b201-6b41879d3aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423318a-c5a8-48d2-92f5-280d15a050a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423318a-c5a8-48d2-92f5-280d15a050a6.jpg?1",
             "name": "Frost Bite",
             "text": "Frost Bite deals 2 damage to target creature or planeswalker. If you control three or more snow permanents, it deals 3 damage instead.",
             "colours": [
@@ -5317,7 +5317,7 @@
         },
         {
             "id": "1784be5d-fcfe-5b33-9fa5-53e396a602eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d914868-9000-4df2-a818-0ef8a7f636ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d914868-9000-4df2-a818-0ef8a7f636ae.jpg?1",
             "name": "Goldspan Dragon",
             "text": "Flying, haste\nWhenever Goldspan Dragon attacks or becomes the target of a spell, create a Treasure token.\nTreasures you control have \"{T}, Sacrifice this artifact: Add two mana of any one color.\"",
             "colours": [
@@ -5353,7 +5353,7 @@
         },
         {
             "id": "2369993b-6535-5bc9-a24c-9a43cb4718bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b18cdb-bc17-42ae-bfb7-4eafce01cd39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b18cdb-bc17-42ae-bfb7-4eafce01cd39.jpg?1",
             "name": "Hagi Mob",
             "text": "Boast \u2014 {1}{R}: Hagi Mob deals 1 damage to any target. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5388,7 +5388,7 @@
         },
         {
             "id": "40774957-fa82-5429-965b-af22a04d23eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77da4de2-4d34-40e5-8fc0-850aef05356b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77da4de2-4d34-40e5-8fc0-850aef05356b.jpg?1",
             "name": "Immersturm Raider",
             "text": "When Immersturm Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5423,7 +5423,7 @@
         },
         {
             "id": "dbad2e98-aeee-5810-9602-8661463f52ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e6263-e54c-4899-a336-5315909b9322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e6263-e54c-4899-a336-5315909b9322.jpg?1",
             "name": "Magda, Brazen Outlaw",
             "text": "Other Dwarves you control get +1/+0.\nWhenever a Dwarf you control becomes tapped, create a Treasure token.\nSacrifice five Treasures: Search your library for an artifact or Dragon card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "9fe6f71e-1a3d-5787-80a6-ed474572da75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4023c8-8e7f-42b9-99e5-87e80fc3d6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4023c8-8e7f-42b9-99e5-87e80fc3d6c8.jpg?1",
             "name": "Open the Omenpaths",
             "text": "Choose one \u2014\n\u2022 Add two mana of any one color and two mana of any other color. Spend this mana only to cast creature or enchantment spells.\n\u2022 Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5494,7 +5494,7 @@
         },
         {
             "id": "bfa674e2-af8d-53c4-99b0-12e41c3d200e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2727b05a-0c86-4c59-b7b4-425bdd8e775d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2727b05a-0c86-4c59-b7b4-425bdd8e775d.jpg?1",
             "name": "Provoke the Trolls",
             "text": "Provoke the Trolls deals 3 damage to any target. If a creature is dealt damage this way, it gets +5/+0 until end of turn.",
             "colours": [
@@ -5526,7 +5526,7 @@
         },
         {
             "id": "0e67ecba-a8f6-57d3-89a7-f4444026a238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bbffb9-1f1c-40e5-97f4-29bf1fc68625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bbffb9-1f1c-40e5-97f4-29bf1fc68625.jpg?1",
             "name": "Quakebringer",
             "text": "Your opponents can't gain life.\nAt the beginning of your upkeep, Quakebringer deals 2 damage to each opponent. This ability triggers only if Quakebringer is on the battlefield or if Quakebringer is in your graveyard and you control a Giant.\nForetell {2}{R}{R}",
             "colours": [
@@ -5563,7 +5563,7 @@
         },
         {
             "id": "6444b6a9-12e2-55e3-afbf-c43f8941ff34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd68d9d-b0b9-4915-8a12-658eb0e3dd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd68d9d-b0b9-4915-8a12-658eb0e3dd4a.jpg?1",
             "name": "Reckless Crew",
             "text": "Create X 2/1 red Dwarf Berserker creature tokens, where X is the number of Vehicles you control plus the number of Equipment you control. For each of those tokens, you may attach an Equipment you control to it.",
             "colours": [
@@ -5597,7 +5597,7 @@
         },
         {
             "id": "a35e52f9-1e8f-5bd2-9605-5dea92a5d76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c8136f-2826-476c-a103-7094670506a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c8136f-2826-476c-a103-7094670506a6.jpg?1",
             "name": "Run Amok",
             "text": "Target attacking creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "3d4ce9e8-7a81-57d5-94a4-9e36307bde18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47faee66-b274-466a-890e-bb396dda943d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47faee66-b274-466a-890e-bb396dda943d.jpg?1",
             "name": "Rune of Speed",
             "text": "Enchant permanent\nWhen Rune of Speed enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it gets +1/+0 and has haste.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature gets +1/+0 and has haste.\"",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "e079879b-0a43-52fe-b93d-1af4bb8808f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b7a69c-75d2-49a6-ab56-ef608d0b0208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b7a69c-75d2-49a6-ab56-ef608d0b0208.jpg?1",
             "name": "Seize the Spoils",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "0e766ded-2ce3-5dab-b3e2-2a34af815683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db743c6e-1385-468e-921a-7a525b88a1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db743c6e-1385-468e-921a-7a525b88a1b6.jpg?1",
             "name": "Shackles of Treachery",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and \"Whenever this creature deals damage, destroy target Equipment attached to it.\"",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "6ff16380-e799-5ddd-9871-6c1f781b2a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c7383-ba4d-4b3c-91d6-2d6528e19825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c7383-ba4d-4b3c-91d6-2d6528e19825.jpg?1",
             "name": "Smashing Success",
             "text": "Destroy target artifact or land. If an artifact is destroyed this way, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "a57fd155-198c-5e9c-8fc0-3ffec03809c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b99299-bf84-4654-a331-e4406768b33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b99299-bf84-4654-a331-e4406768b33c.jpg?1",
             "name": "Squash",
             "text": "This spell costs {3} less to cast if you control a Giant.\nSquash deals 6 damage to target creature or planeswalker.",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "d6ce0e70-92a3-5248-abdf-d9859aa80b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd921e27-3e08-438c-bec2-723226d35175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd921e27-3e08-438c-bec2-723226d35175.jpg?1",
             "name": "Tibalt's Trickery",
             "text": "Counter target spell. Choose 1, 2, or 3 at random. Its controller mills that many cards, then exiles cards from the top of their library until they exile a nonland card with a different name than that spell. They may cast that card without paying its mana cost. Then they put the exiled cards on the bottom of their library in a random order.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "0c820b30-6cf7-5cce-a853-496c13c78916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "ea3f8349-f3e6-519a-9d65-04d8434360d0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "16527db5-21c4-57bd-aeef-d9316a31bfa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2318d4f8-309e-4645-b6d1-46572edd6996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2318d4f8-309e-4645-b6d1-46572edd6996.jpg?1",
             "name": "Tormentor's Helm",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature becomes blocked, it deals 1 damage to defending player.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "9ecdc572-126e-5dfc-8646-20a229c9df6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b251aa7c-d011-4b52-ab92-415d536c0182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b251aa7c-d011-4b52-ab92-415d536c0182.jpg?1",
             "name": "Tundra Fumarole",
             "text": "Tundra Fumarole deals 4 damage to target creature or planeswalker. Add {C} for each {S} spent to cast this spell. Until end of turn, you don't lose this mana as steps and phases end. ({S} is mana from a snow source.)",
             "colours": [
@@ -5972,7 +5972,7 @@
         },
         {
             "id": "551687da-151e-52a8-b7a3-97a295065375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54d0170-a375-4e65-b98d-3e94a3aeef90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54d0170-a375-4e65-b98d-3e94a3aeef90.jpg?1",
             "name": "Tuskeri Firewalker",
             "text": "Boast \u2014 {1}: Exile the top card of your library. You may play that card this turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "5d007d60-9d54-5778-b9b6-c8a590d09316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f68014-489d-4f51-a959-0f335541cb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f68014-489d-4f51-a959-0f335541cb4e.jpg?1",
             "name": "Vault Robber",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6042,7 +6042,7 @@
         },
         {
             "id": "16d7623e-49bc-54f5-8d13-7448c11649dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe560b-f7b5-4614-91f1-b669a39abc16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe560b-f7b5-4614-91f1-b669a39abc16.jpg?1",
             "name": "Arachnoform",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has reach, and is every creature type.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "6d187592-205b-527e-ba98-60f50f15f3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3377d9-eec3-49b9-a3a7-e540d2038f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3377d9-eec3-49b9-a3a7-e540d2038f51.jpg?1",
             "name": "Battle Mammoth",
             "text": "Trample\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\nForetell {2}{G}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -6112,7 +6112,7 @@
         },
         {
             "id": "bc380b5a-d4f5-5d41-ae34-c5ebb42f4314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01f4d-491e-4f25-a017-a0d9c437ac8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01f4d-491e-4f25-a017-a0d9c437ac8c.jpg?1",
             "name": "Blessing of Frost",
             "text": "Distribute X +1/+1 counters among any number of creatures you control, where X is the amount of {S} spent to cast this spell. Then draw a card for each creature you control with power 4 or greater.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "fea48b09-0f75-525a-8506-034130c0f6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6318918f-34e4-4bbf-9816-8e88f21ae324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6318918f-34e4-4bbf-9816-8e88f21ae324.jpg?1",
             "name": "Blizzard Brawl",
             "text": "Choose target creature you control and target creature you don't control. If you control three or more snow permanents, the creature you control gets +1/+0 and gains indestructible until end of turn. Then those creatures fight each other. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "6f0fc214-213d-5610-ad39-a3fa750e9bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455ae615-20d7-4251-828d-72a3345d06f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455ae615-20d7-4251-828d-72a3345d06f1.jpg?1",
             "name": "Boreal Outrider",
             "text": "Whenever you cast a creature spell, if {S} of any of that spell's colors was spent to cast it, that creature enters the battlefield with an additional +1/+1 counter on it. ({S} is mana from a snow source.)",
             "colours": [
@@ -6219,7 +6219,7 @@
         },
         {
             "id": "b43a1f9f-c13b-52ae-869d-e3a3f7178d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6201f78e-ff45-4c59-ac85-c8447c14a496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6201f78e-ff45-4c59-ac85-c8447c14a496.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "fa644feb-bf18-5bcc-8f1a-496c8dc3836b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8bded3-46c3-474f-9d09-978df8705ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8bded3-46c3-474f-9d09-978df8705ad1.jpg?1",
             "name": "Elderleaf Mentor",
             "text": "When Elderleaf Mentor enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "5e40dfb9-7f0d-5439-b8a2-6ce62d91c6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1d225c-8a49-43f9-a9d2-aef7e406ab52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1d225c-8a49-43f9-a9d2-aef7e406ab52.jpg?1",
             "name": "A-Elderleaf Mentor",
             "text": "",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "33d7a5fb-9375-5328-98ae-59a639ddd7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c599c7-bcc1-4005-b830-1fa4811af66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c599c7-bcc1-4005-b830-1fa4811af66e.jpg?1",
             "name": "Elven Bow",
             "text": "When Elven Bow enters the battlefield, you may pay {2}. If you do, create a 1/1 green Elf Warrior creature token, then attach Elven Bow to it.\nEquipped creature gets +1/+2 and has reach.\nEquip {3}",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "b762f92a-af34-5a2f-a3fd-c1c005963a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6310bf62-6016-4987-83ed-671283a7ff61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6310bf62-6016-4987-83ed-671283a7ff61.jpg?1",
             "name": "A-Elven Bow",
             "text": "",
             "colours": [
@@ -6387,7 +6387,7 @@
         },
         {
             "id": "c8e48eb0-f316-51f7-b1f7-c828a86731dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg?1",
             "name": "Elvish Warmaster",
             "text": "Whenever one or more other Elves enters the battlefield under your control, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
             "colours": [
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "51cea10e-7235-567e-9339-292571210ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "1d918ac9-583f-5063-bfe9-c3a3597f21f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -6510,7 +6510,7 @@
         },
         {
             "id": "70b489a6-0907-5607-a494-fa4fcc95e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87606cc-fbf0-4e2c-9798-f1c935d0573d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87606cc-fbf0-4e2c-9798-f1c935d0573d.jpg?1",
             "name": "Esika's Chariot",
             "text": "When Esika's Chariot enters the battlefield, create two 2/2 green Cat creature tokens.\nWhenever Esika's Chariot attacks, create a token that's a copy of target token you control.\nCrew 4",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "e96eb9bf-9e06-52ea-84ca-a970a5ebba2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7a8a90-13c1-4b0c-ab2e-fc8d91ccefd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7a8a90-13c1-4b0c-ab2e-fc8d91ccefd9.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "Deathtouch|\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -6587,7 +6587,7 @@
         },
         {
             "id": "c492a467-330b-5150-b578-618582d3fe41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60fbc33-6198-4661-967e-cc94f2788e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60fbc33-6198-4661-967e-cc94f2788e4a.jpg?1",
             "name": "Glittering Frost",
             "text": "Enchant land\nEnchanted land is snow.\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -6623,7 +6623,7 @@
         },
         {
             "id": "2e6cca3c-78ca-55c3-a76e-9025d20a04bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46c8c8-5dfa-4ebb-b0b9-cd25d01dd432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46c8c8-5dfa-4ebb-b0b9-cd25d01dd432.jpg?1",
             "name": "Gnottvold Recluse",
             "text": "Reach",
             "colours": [
@@ -6657,7 +6657,7 @@
         },
         {
             "id": "2c2bc6eb-da19-554c-a303-d4a0b90557ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1d4473-5317-4bdd-9cb9-93670acf52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1d4473-5317-4bdd-9cb9-93670acf52e9.jpg?1",
             "name": "Grizzled Outrider",
             "text": "",
             "colours": [
@@ -6692,7 +6692,7 @@
         },
         {
             "id": "219aed18-2b7e-515c-b216-233bc8ad02b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587eed42-5111-4161-9af5-bf76556c542a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587eed42-5111-4161-9af5-bf76556c542a.jpg?1",
             "name": "Guardian Gladewalker",
             "text": "Changeling (This card is every creature type.)\nWhen Guardian Gladewalker enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "d61ea09b-d6ea-587a-91b6-be39545db745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17f4b21-6478-407d-b567-2888349f3b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17f4b21-6478-407d-b567-2888349f3b66.jpg?1",
             "name": "Horizon Seeker",
             "text": "Boast \u2014 {1}{G}: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -6761,7 +6761,7 @@
         },
         {
             "id": "0c42baf0-07ca-5275-837b-19a8b872495f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f3aaed-a01f-4c6a-b9bb-cd70b0f6ceb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f3aaed-a01f-4c6a-b9bb-cd70b0f6ceb1.jpg?1",
             "name": "Icehide Troll",
             "text": "{S}{S}: Icehide Troll gets +2/+0 and gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it. {S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "2be7749d-f12d-5536-b6d1-4745e43c062e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0e50fa-5114-4f96-89f4-000906da7c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0e50fa-5114-4f96-89f4-000906da7c76.jpg?1",
             "name": "In Search of Greatness",
             "text": "At the beginning of your upkeep, you may cast a permanent spell from your hand with converted mana cost equal to 1 plus the highest converted mana cost among other permanents you control without paying its mana cost. If you don't, scry 1.",
             "colours": [
@@ -6832,7 +6832,7 @@
         },
         {
             "id": "54d42105-776e-535a-ae4d-5f84f7107482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68615d-9808-479d-aa80-50651246954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68615d-9808-479d-aa80-50651246954e.jpg?1",
             "name": "Jaspera Sentinel",
             "text": "Reach\n{T}, Tap an untapped creature you control: Add one mana of any color.",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "c7de6c34-97b3-52c7-91bf-843da36f13f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "952b18a4-86b1-504c-8ba4-29d11c6e7589",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "92886584-8cca-55d7-9eae-3ad213545a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a659b6-c4a8-4c0a-8b2a-07b6c9e27dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a659b6-c4a8-4c0a-8b2a-07b6c9e27dfc.jpg?1",
             "name": "King Harald's Revenge",
             "text": "Until end of turn, target creature gets +1/+1 for each creature you control and gains trample. It must be blocked this turn if able.",
             "colours": [
@@ -6980,7 +6980,7 @@
         },
         {
             "id": "f3e6f720-2c59-5be0-90d8-98a0bd311ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "257919a8-f3fc-5b1c-878b-0ac385b9d12a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "f02f2920-b3ec-5de0-8836-ccde95d62343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92dde51-310e-4f28-bd3b-d43b639785ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92dde51-310e-4f28-bd3b-d43b639785ec.jpg?1",
             "name": "Littjara Glade-Warden",
             "text": "Changeling (This card is every creature type.)\n{2}{G}, {T}, Exile a creature card from your graveyard: Put two +1/+1 counters on target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7088,7 +7088,7 @@
         },
         {
             "id": "6902c497-9f91-5883-9e6e-e1b07f39ee8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e55041f-69a5-4bcf-899f-a4b44c208b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e55041f-69a5-4bcf-899f-a4b44c208b4d.jpg?1",
             "name": "Mammoth Growth",
             "text": "Target creature gets +4/+4 until end of turn.\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "b2937b8c-cde1-5b9b-a93f-c73a26d2befc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a9c72a-e450-41e3-80e5-06f2f1171245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a9c72a-e450-41e3-80e5-06f2f1171245.jpg?1",
             "name": "Masked Vandal",
             "text": "Changeling (This card is every creature type.)\nWhen Masked Vandal enters the battlefield, you may exile a creature card from your graveyard. If you do, exile target artifact or enchantment an opponent controls.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "6c1c10d9-566d-5814-8d29-3fc6934401f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759b0f6-342c-4bba-89f1-8451835d8c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759b0f6-342c-4bba-89f1-8451835d8c45.jpg?1",
             "name": "Old-Growth Troll",
             "text": "Trample\nWhen Old-Growth Troll dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add {G}{G}' and \u2018{1}, {T}, Sacrifice this land: Create a tapped 4/4 green Troll Warrior creature token with trample.'\"",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "5cbf1933-af61-5974-9c64-69e592a1842c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606da75d-382a-47a8-9739-644438594700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606da75d-382a-47a8-9739-644438594700.jpg?1",
             "name": "Path to the World Tree",
             "text": "When Path to the World Tree enters the battlefield, search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\n{2}{W}{U}{B}{R}{G}, Sacrifice Path to the World Tree: You gain 2 life and draw two cards. Target opponent loses 2 life. Path to the World Tree deals 2 damage to up to one target creature. You create a 2/2 green Bear creature token.",
             "colours": [
@@ -7229,7 +7229,7 @@
         },
         {
             "id": "a1509526-ac48-5371-ab77-d78561dfdf5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961e3fc-167e-4043-8510-cc5cf08d473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961e3fc-167e-4043-8510-cc5cf08d473e.jpg?1",
             "name": "Ravenous Lindwurm",
             "text": "When Ravenous Lindwurm enters the battlefield, you gain 4 life.",
             "colours": [
@@ -7263,7 +7263,7 @@
         },
         {
             "id": "6bc0737d-fb9a-5483-bff2-3ba4a875c0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8212667-7e18-42a5-9f36-4f8a6ad12f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8212667-7e18-42a5-9f36-4f8a6ad12f83.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling (This card is every creature type.)\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -7300,7 +7300,7 @@
         },
         {
             "id": "690f64b2-a443-5ca7-9fb4-829f726e3d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992aba3f-e1cb-4f5a-8b6f-328a069102a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992aba3f-e1cb-4f5a-8b6f-328a069102a4.jpg?1",
             "name": "Rootless Yew",
             "text": "When Rootless Yew dies, search your library for a creature card with power or toughness 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -7334,7 +7334,7 @@
         },
         {
             "id": "c3dd351f-ea57-5b1c-9b3f-692d0310ea9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734afb5b-3163-47fa-856f-8a85b9da22d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734afb5b-3163-47fa-856f-8a85b9da22d3.jpg?1",
             "name": "Roots of Wisdom",
             "text": "Mill three cards, then return a land card or Elf card from your graveyard to your hand. If you can't, draw a card. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -7366,7 +7366,7 @@
         },
         {
             "id": "9f916177-0dec-566e-9017-e6cf77fd7964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0d507b-fc08-46cb-b092-484fa4adeef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0d507b-fc08-46cb-b092-484fa4adeef6.jpg?1",
             "name": "Rune of Might",
             "text": "Enchant permanent\nWhen Rune of Might enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it gets +1/+1 and has trample.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature gets +1/+1 and has trample.\"",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "6478c624-a012-5c22-acc1-a252d892e8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6061113e-7dd8-4739-b4dd-55bb7f9e39a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6061113e-7dd8-4739-b4dd-55bb7f9e39a2.jpg?1",
             "name": "Sarulf's Packmate",
             "text": "When Sarulf's Packmate enters the battlefield, draw a card.\nForetell {1}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "7d35d671-86ad-5f1e-8b9f-3e899ff50c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab2ca2-0039-4eac-a7dc-68756362737d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab2ca2-0039-4eac-a7dc-68756362737d.jpg?1",
             "name": "Sculptor of Winter",
             "text": "{T}: Untap target snow land.",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "e853058d-143c-5383-912f-1d168473f5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e692c208-c171-4964-9207-43c2cbc62845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e692c208-c171-4964-9207-43c2cbc62845.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "fab1f3db-e724-5bf7-a5b3-c931f3bd2ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220df551-3820-4910-a206-14501ba02e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220df551-3820-4910-a206-14501ba02e69.jpg?1",
             "name": "Spirit of the Aldergard",
             "text": "When Spirit of the Aldergard enters the battlefield, search your library for a snow land card, reveal it, put it into your hand, then shuffle your library.\nSpirit of the Aldergard gets +1/+0 for each other snow permanent you control.",
             "colours": [
@@ -7541,7 +7541,7 @@
         },
         {
             "id": "41439043-57d3-5073-9916-f68ef0d6c039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67747a9-3299-4b4a-a4e0-e8a269c4f927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67747a9-3299-4b4a-a4e0-e8a269c4f927.jpg?1",
             "name": "Struggle for Skemfar",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "4b17f191-b422-5fb0-9ff5-f18237690bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e79b59-94c8-4697-bf88-f0a0433170f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e79b59-94c8-4697-bf88-f0a0433170f5.jpg?1",
             "name": "Toski, Bearer of Secrets",
             "text": "This spell can't be countered.\nIndestructible\nToski, Bearer of Secrets attacks each combat if able.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -7611,7 +7611,7 @@
         },
         {
             "id": "6a808233-2aa7-596d-9532-6be1bd4f3bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d18008f-10d2-4cdf-b4b5-7675782a8b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d18008f-10d2-4cdf-b4b5-7675782a8b0d.jpg?1",
             "name": "Tyvar Kell",
             "text": "Elves you control have \"{T}: Add {B}.\"\n+1: Put a +1/+1 counter on up to one target Elf. Untap it. It gains deathtouch until end of turn.\n0: Create a 1/1 green Elf Warrior creature token.\n\u22126: You get an emblem with \"Whenever you cast an Elf spell, it gains haste until end of turn and you draw two cards.\"",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "926de766-bd14-5c8f-9e2c-5095caa1b675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16492772-1a2a-4935-95ff-c2416633d064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16492772-1a2a-4935-95ff-c2416633d064.jpg?1",
             "name": "A-Tyvar Kell",
             "text": "",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "9d9018f2-42b3-5930-9663-f8a9a026d0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92613468-205e-488b-930d-11908477e9f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92613468-205e-488b-930d-11908477e9f8.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "Trample, haste\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.",
             "colours": [
@@ -7728,7 +7728,7 @@
         },
         {
             "id": "f8c45cab-5635-56ae-bfde-3c5a5cb0d702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68011f60-6202-48f4-8255-fb94764e2951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68011f60-6202-48f4-8255-fb94764e2951.jpg?1",
             "name": "Aegar, the Freezing Flame",
             "text": "Whenever a creature or planeswalker an opponent controls is dealt excess damage, if a Giant, Wizard, or spell you controlled dealt damage to it this turn, draw a card.",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "b0301776-03fc-5236-a655-2db74c554b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18396f9-ae20-4471-84ab-a2148319bc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18396f9-ae20-4471-84ab-a2148319bc39.jpg?1",
             "name": "Arni Slays the Troll",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Target creature you control fights up to one target creature you don't control.\nII \u2014 Add {R}. Put two +1/+1 counters on up to one target creature you control.\nIII \u2014 You gain life equal to the greatest power among creatures you control.",
             "colours": [
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "3e83e4ab-9aff-5967-8fee-e7ab005c74db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf01666-0fbf-4b15-a33d-964165bbfafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf01666-0fbf-4b15-a33d-964165bbfafb.jpg?1",
             "name": "Ascent of the Worthy",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Choose a creature you control. Until your next turn, all damage that would be dealt to creatures you control is dealt to that creature instead.\nIII \u2014 Return target creature card from your graveyard to the battlefield with a flying counter on it. That creature is an Angel Warrior in addition to its other types.",
             "colours": [
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "163dac49-fd7c-5d40-ad76-662be57810b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31ec15-2fe0-40ab-b320-bc4333db4787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31ec15-2fe0-40ab-b320-bc4333db4787.jpg?1",
             "name": "Battle for Bretagard",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human Warrior creature token.\nII \u2014 Create a 1/1 green Elf Warrior creature token.\nIII \u2014 Choose any number of artifact tokens and/or creature tokens you control with different names. For each of them, create a token that's a copy of it.",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "36dfdbcc-da55-51f9-bc38-aa48d6f598a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620ed5b7-8874-40d0-9245-98876bdec153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620ed5b7-8874-40d0-9245-98876bdec153.jpg?1",
             "name": "Battle of Frost and Fire",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Battle of Frost and Fire deals 4 damage to each non-Giant creature and each planeswalker.\nII \u2014 Scry 3.\nIII \u2014 Whenever you cast a spell with converted mana cost 5 or greater this turn, draw two cards, then discard a card.",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "70f3d028-7bee-510c-ba98-7c3f2117d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be43a643-6cb7-4bb6-a28d-8ad30b7fbb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be43a643-6cb7-4bb6-a28d-8ad30b7fbb6d.jpg?1",
             "name": "The Bears of Littjara",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 2/2 blue Shapeshifter creature token with changeling.\nII \u2014 Any number of target Shapeshifter creatures you control have base power and toughness 4/4.\nIII \u2014 Choose up to one target creature or planeswalker. Each creature with power 4 or greater you control deals damage equal to its power to that permanent.",
             "colours": [
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "20698034-14fa-58cc-8e6c-fbd3af624448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93ee644-d7d7-48d8-a04b-fb479b74edb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93ee644-d7d7-48d8-a04b-fb479b74edb0.jpg?1",
             "name": "Binding the Old Gods",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target nonland permanent an opponent controls.\nII \u2014 Search your library for a Forest card, put it onto the battlefield tapped, then shuffle your library.\nIII \u2014 Creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "744ccac0-1a2f-50b1-9a7a-97fcf619179a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669975ed-0501-4b48-988d-29c1215179a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669975ed-0501-4b48-988d-29c1215179a4.jpg?1",
             "name": "The Bloodsky Massacre",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 2/3 red Demon Berserker creature token with menace.\nII \u2014 Whenever a Berserker attacks this turn, you draw a card and you lose 1 life.\nIII \u2014 Add {R} for each Berserker you control. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "d757bcb3-e373-533f-8baa-054d7d35fb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7de696a-49c2-421d-a86c-bcffd68870c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7de696a-49c2-421d-a86c-bcffd68870c6.jpg?1",
             "name": "Fall of the Impostor",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put a +1/+1 counter on up to one target creature.\nIII \u2014 Exile a creature with the greatest power among creatures target opponent controls.",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "53c29ebf-2d32-5d5c-b724-6d8aed0fdcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe02fae-3e0a-402e-9f2e-f0e9c553cc1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe02fae-3e0a-402e-9f2e-f0e9c553cc1a.jpg?1",
             "name": "A-Fall of the Impostor",
             "text": "",
             "colours": [
@@ -8092,7 +8092,7 @@
         },
         {
             "id": "bcc9befa-0ae6-54a1-ba1b-abea4f724e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df87077c-85d8-499e-bce0-27697caada5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df87077c-85d8-499e-bce0-27697caada5a.jpg?1",
             "name": "Firja, Judge of Valor",
             "text": "Flying, lifelink\nWhenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "1f806470-d830-5799-8b97-3f059daebca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dff23e-d7e3-4d75-a9dc-fdf4a42f31e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dff23e-d7e3-4d75-a9dc-fdf4a42f31e0.jpg?1",
             "name": "Firja's Retribution",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 4/4 white Angel Warrior creature token with flying and vigilance.\nII \u2014 Until end of turn, Angels you control gain \"{T}: Destroy target creature with power less than this creature's power.\"\nIII \u2014 Angels you control gain double strike until end of turn.",
             "colours": [
@@ -8169,7 +8169,7 @@
         },
         {
             "id": "58156fd3-f584-5c9c-972c-c8985f897068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce46100-461d-424e-afa4-7a0bb7d0a822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce46100-461d-424e-afa4-7a0bb7d0a822.jpg?1",
             "name": "Forging the Tyrite Sword",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a Treasure token.\nIII \u2014 Search your library for a card named Halvar, God of Battle or an Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -8205,7 +8205,7 @@
         },
         {
             "id": "e97518a4-53fa-58ad-8bb4-10423e99bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac78a2-599f-4dba-aec7-982c5ae3f75a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac78a2-599f-4dba-aec7-982c5ae3f75a.jpg?1",
             "name": "Harald, King of Skemfar",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Harald, King of Skemfar enters the battlefield, look at the top five cards of your library. You may reveal an Elf, Warrior, or Tyvar card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "d173be02-e112-56c0-8ea6-bcd613c1cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3987c7-4114-44ea-bd40-1a6054e06f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3987c7-4114-44ea-bd40-1a6054e06f09.jpg?1",
             "name": "A-Harald, King of Skemfar",
             "text": "",
             "colours": [
@@ -8284,7 +8284,7 @@
         },
         {
             "id": "f626416d-72ba-536c-aa94-36e1e3d39320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c5f681-0145-45e9-b943-ca9784cfdea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c5f681-0145-45e9-b943-ca9784cfdea0.jpg?1",
             "name": "Harald Unites the Elves",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Mill three cards. You may put an Elf or Tyvar card from your graveyard onto the battlefield.\nII \u2014 Put a +1/+1 counter on each Elf you control.\nIII \u2014 Whenever an Elf you control attacks this turn, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "30306284-3c15-5313-beef-84f0fd3e360c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db8705b7-e851-483e-a2af-bd309e62f079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db8705b7-e851-483e-a2af-bd309e62f079.jpg?1",
             "name": "A-Harald Unites the Elves",
             "text": "",
             "colours": [
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "6aedbadc-331a-5320-b8bb-111db0234182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d83d2d9-b9d0-47f5-989b-f2c726401ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d83d2d9-b9d0-47f5-989b-f2c726401ade.jpg?1",
             "name": "Immersturm Predator",
             "text": "Flying\nWhenever Immersturm Predator becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on Immersturm Predator.\nSacrifice another creature: Immersturm Predator gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -8394,7 +8394,7 @@
         },
         {
             "id": "4f22dbaf-f2bf-5264-a1d6-0b16194135b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5075a0-c72a-474c-937c-95dc9205d14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5075a0-c72a-474c-937c-95dc9205d14f.jpg?1",
             "name": "Invasion of the Giants",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Scry 2.\nII \u2014 Draw a card. Then you may reveal a Giant card from your hand. When you do, Invasion of the Giants deals 2 damage to target opponent or planeswalker.\nIII \u2014 The next Giant spell you cast this turn costs {2} less to cast.",
             "colours": [
@@ -8430,7 +8430,7 @@
         },
         {
             "id": "20e0d713-4555-526d-b1aa-16aba4b2c41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9685e2a0-5573-41bc-a914-f40c3011459b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9685e2a0-5573-41bc-a914-f40c3011459b.jpg?1",
             "name": "Kardur, Doomscourge",
             "text": "When Kardur, Doomscourge enters the battlefield, until your next turn, creatures your opponents control attack each combat if able and attack a player other than you if able.\nWhenever an attacking creature dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "7b9d0f54-9e17-59c3-86f4-f9660e6468fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233e4774-e701-42d9-aa25-e7e06c14e43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233e4774-e701-42d9-aa25-e7e06c14e43d.jpg?1",
             "name": "Kardur's Vicious Return",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You may sacrifice a creature. When you do, Kardur's Vicious Return deals 3 damage to any target.\nII \u2014 Each player discards a card.\nIII \u2014 Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it. It gains haste until your next turn.",
             "colours": [
@@ -8507,7 +8507,7 @@
         },
         {
             "id": "a337df42-7f64-5a2f-ad35-50020e3d953d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166c0bd1-b59d-4644-832f-888a4ca3a0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166c0bd1-b59d-4644-832f-888a4ca3a0aa.jpg?1",
             "name": "Kaya the Inexorable",
             "text": "+1: Put a ghostform counter on up to one target nontoken creature. It gains \"When this creature dies or is put into exile, return it to its owner's hand and create a 1/1 white Spirit creature token with flying.\"\n\u22123: Exile target nonland permanent.\n\u22127: You get an emblem with \"At the beginning of your upkeep, you may cast a legendary spell from your hand, from your graveyard, or from among cards you own in exile without paying its mana cost.\"",
             "colours": [
@@ -8547,7 +8547,7 @@
         },
         {
             "id": "95a7da1e-f1d5-5b8e-a32f-38c18700f4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30ff1fa-6639-492a-b257-934e5818c98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30ff1fa-6639-492a-b257-934e5818c98f.jpg?1",
             "name": "King Narfi's Betrayal",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player mills four cards. Then you may exile a creature or planeswalker card from each graveyard.\nII, III \u2014 Until end of turn, you may cast spells from among cards exiled with King Narfi's Betrayal, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -8583,7 +8583,7 @@
         },
         {
             "id": "7a802cbb-a47c-593f-8839-ad3a4b3c7378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f68b53-0cf7-434d-9da5-1d18c0828a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f68b53-0cf7-434d-9da5-1d18c0828a46.jpg?1",
             "name": "Koll, the Forgemaster",
             "text": "Whenever another nontoken creature you control dies, if it was enchanted or equipped, return it to its owner's hand.\nCreature tokens you control that are enchanted or equipped get +1/+1.",
             "colours": [
@@ -8624,7 +8624,7 @@
         },
         {
             "id": "30d3f784-0175-52c6-90f6-3856a4a742be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de25ea4-284a-4c16-b823-048ff00c6a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de25ea4-284a-4c16-b823-048ff00c6a03.jpg?1",
             "name": "Koma, Cosmos Serpent",
             "text": "This spell can't be countered.|\nAt the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.\nSacrifice another Serpent: Choose one \u2014\n\u2022 Tap target permanent. Its activated abilities can't be activated this turn.\n\u2022 Koma, Cosmos Serpent gains indestructible until end of turn.",
             "colours": [
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "f047c96c-816a-504a-bb9b-c2c027c5c256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3707f1-ed9d-412e-a7be-b6d8b554bd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3707f1-ed9d-412e-a7be-b6d8b554bd6c.jpg?1",
             "name": "Maja, Bretagard Protector",
             "text": "Other creatures you control get +1/+1.\nWhenever a land enters the battlefield under your control, create a 1/1 white Human Warrior creature token.",
             "colours": [
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "72fa27c5-56cc-55a8-9144-72f695cd7b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fdbe71-abca-4e48-99b2-1cb6b35d930b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fdbe71-abca-4e48-99b2-1cb6b35d930b.jpg?1",
             "name": "Moritte of the Frost",
             "text": "Changeling (This card is every creature type.)\nYou may have Moritte of the Frost enter the battlefield as a copy of a permanent you control, except it's legendary and snow in addition to its other types and, if it's a creature, it enters with two additional +1/+1 counters on it and has changeling.",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "01568f6b-7838-54f3-bd56-ea98115218a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421376e4-a4ad-427c-bc9c-d315308dcf68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421376e4-a4ad-427c-bc9c-d315308dcf68.jpg?1",
             "name": "Narfi, Betrayer King",
             "text": "Other snow and Zombie creatures you control get +1/+1.\n{S}{S}{S}: Return Narfi, Betrayer King from your graveyard to the battlefield tapped. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "13e6361e-d2a0-51de-9ebc-52fa7fd94fb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d689fc6-c7b5-46f8-9ec2-2bc4b4af87c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d689fc6-c7b5-46f8-9ec2-2bc4b4af87c0.jpg?1",
             "name": "A-Narfi, Betrayer King",
             "text": "",
             "colours": [
@@ -8827,7 +8827,7 @@
         },
         {
             "id": "a0d0f918-cfe2-5a3a-9221-dba672053ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4e9cfe-e72e-46a1-a8d8-9fda5f2bae73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4e9cfe-e72e-46a1-a8d8-9fda5f2bae73.jpg?1",
             "name": "Niko Aris",
             "text": "When Niko Aris enters the battlefield, create X Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n+1: Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.|\u22121: Niko Aris deals 2 damage to target tapped creature for each card you've drawn this turn.|\u22121: Create a Shard token.",
             "colours": [
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "8d4dd5f5-dff7-5361-afb6-8be79f5d448d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19312f53-5b9d-4e76-91e8-65f444bb68c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19312f53-5b9d-4e76-91e8-65f444bb68c9.jpg?1",
             "name": "Niko Defies Destiny",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You gain 2 life for each foretold card you own in exile.\nII \u2014 Add {W}{U}. Spend this mana only to foretell cards or cast spells that have foretell.\nIII \u2014 Return target card with foretell from your graveyard to your hand.",
             "colours": [
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "3df34d29-1d60-52df-84c6-e922a78bf6f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bd457-e1cc-45e1-8b2e-58f886bd6df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bd457-e1cc-45e1-8b2e-58f886bd6df8.jpg?1",
             "name": "The Raven's Warning",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 blue Bird creature token with flying. You gain 2 life.\nII \u2014 Whenever one or more creatures you control with flying deal combat damage to a player this turn, look at that player's hand and draw a card.\nIII \u2014 You may put a card you own from outside the game on top of your library.",
             "colours": [
@@ -8939,7 +8939,7 @@
         },
         {
             "id": "cb02366a-23e2-5811-bdeb-ad57260ef512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcecf9ba-36da-490a-9460-99ff87d99fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcecf9ba-36da-490a-9460-99ff87d99fbd.jpg?1",
             "name": "Sarulf, Realm Eater",
             "text": "Whenever a permanent an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on Sarulf, Realm Eater.|\nAt the beginning of your upkeep, if Sarulf has one or more +1/+1 counters on it, you may remove all of them. If you do, exile each other nonland permanent with converted mana cost less than or equal to the number of counters removed this way.",
             "colours": [
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "5ae6c426-9021-5c9f-9883-b5dca4d7f888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9d840e-1f13-44e3-a4de-903cfa58a346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9d840e-1f13-44e3-a4de-903cfa58a346.jpg?1",
             "name": "Showdown of the Skalds",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile the top four cards of your library. Until the end of your next turn, you may play those cards.\nII, III \u2014 Whenever you cast a spell this turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -9015,7 +9015,7 @@
         },
         {
             "id": "014d710c-d4fa-5be2-bee8-1fa58c646f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7054d48-5ed3-43a1-85e5-9f306b081b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7054d48-5ed3-43a1-85e5-9f306b081b4f.jpg?1",
             "name": "Svella, Ice Shaper",
             "text": "{3}, {T}: Create a colorless snow artifact token named Icy Manalith with \"{T}: Add one mana of any color.\"\n{6}{R}{G}, {T}: Look at the top four cards of your library. You may cast a spell from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9057,7 +9057,7 @@
         },
         {
             "id": "9b4bfcad-0328-535b-a92b-291939ab2812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ce03b3-ec7c-46df-b89a-55405f3b5245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ce03b3-ec7c-46df-b89a-55405f3b5245.jpg?1",
             "name": "The Three Seasons",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Mill three cards.\nII \u2014 Return up to two target snow permanent cards from your graveyard to your hand.\nIII \u2014 Choose three cards in each graveyard. Their owners shuffle those cards into their libraries.",
             "colours": [
@@ -9093,7 +9093,7 @@
         },
         {
             "id": "833a7b24-19c0-5709-916a-58c89ff3d052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa19a68-0d71-4123-a64d-8cb76f93cd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa19a68-0d71-4123-a64d-8cb76f93cd74.jpg?1",
             "name": "The Trickster-God's Heist",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You may exchange control of two target creatures.\nII \u2014 You may exchange control of two target nonbasic, noncreature permanents that share a card type.|\nIII \u2014 Target player loses 3 life and you gain 3 life.",
             "colours": [
@@ -9129,7 +9129,7 @@
         },
         {
             "id": "203290b7-1c21-5e40-b74c-d94b06c308f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fced7f-3078-4a54-8f76-0ef14c732e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fced7f-3078-4a54-8f76-0ef14c732e97.jpg?1",
             "name": "Vega, the Watcher",
             "text": "Flying\nWhenever you cast a spell from anywhere other than your hand, draw a card.",
             "colours": [
@@ -9170,7 +9170,7 @@
         },
         {
             "id": "5c349f97-c4ad-588f-aedb-ecd639993d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f471133-db82-4610-81fb-736fbd3b1c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f471133-db82-4610-81fb-736fbd3b1c6c.jpg?1",
             "name": "A-Vega, the Watcher",
             "text": "",
             "colours": [
@@ -9208,7 +9208,7 @@
         },
         {
             "id": "eaae0c5a-05ec-547c-aa69-4f2376bc7186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36016324-384c-4c68-8f73-8f39a244c879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36016324-384c-4c68-8f73-8f39a244c879.jpg?1",
             "name": "Waking the Trolls",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target land.\nII \u2014 Put target land card from a graveyard onto the battlefield under your control.\nIII \u2014 Choose target opponent. If they control fewer lands than you, create a number of 4/4 green Troll Warrior creature tokens with trample equal to the difference.",
             "colours": [
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "0c907b47-fa7c-5b2a-b406-66d711763f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8a16f6-55c1-40eb-998f-592bf31916b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8a16f6-55c1-40eb-998f-592bf31916b1.jpg?1",
             "name": "Bloodline Pretender",
             "text": "Changeling (This card is every creature type.)\nAs Bloodline Pretender enters the battlefield, choose a creature type.\nWhenever another creature of the chosen type enters the battlefield under your control, put a +1/+1 counter on Bloodline Pretender.",
             "colours": [],
@@ -9275,7 +9275,7 @@
         },
         {
             "id": "1d2c1a0f-49a7-5627-8205-379018d5d506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3fe29-067f-4c7e-8b3b-779f3b37712a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3fe29-067f-4c7e-8b3b-779f3b37712a.jpg?1",
             "name": "Colossal Plow",
             "text": "Whenever Colossal Plow attacks, add {W}{W}{W} and you gain 3 life. Until end of turn, you don't lose this mana as steps and phases end.\nCrew 6 (Tap any number of creatures you control with total power 6 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "2c18f906-ba7b-517c-82ec-5e8bab52cc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf084fe-7762-49c5-974a-cdecc10666b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf084fe-7762-49c5-974a-cdecc10666b3.jpg?1",
             "name": "Cosmos Elixir",
             "text": "At the beginning of your end step, draw a card if your life total is greater than your starting life total. Otherwise, you gain 2 life.",
             "colours": [],
@@ -9337,7 +9337,7 @@
         },
         {
             "id": "c7da89b2-0300-5ab9-b79d-96d192839ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f1ce0b-6668-4d16-8fe0-07c65ce4bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f1ce0b-6668-4d16-8fe0-07c65ce4bc82.jpg?1",
             "name": "A-Cosmos Elixir",
             "text": "",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "b45d821f-e930-5ee2-b2d0-dd2b632ae1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c48042-178f-432e-9eee-10bfa1e0795f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c48042-178f-432e-9eee-10bfa1e0795f.jpg?1",
             "name": "Funeral Longboat",
             "text": "Vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9394,7 +9394,7 @@
         },
         {
             "id": "0b22426f-ecc6-5764-a565-773defb71153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf5e4ad-a6e9-4b7c-a1ec-8246d3a3b6ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf5e4ad-a6e9-4b7c-a1ec-8246d3a3b6ca.jpg?1",
             "name": "Goldvein Pick",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9424,7 +9424,7 @@
         },
         {
             "id": "bf98c5a0-5e1f-571a-b850-5ece0783cdd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471d2aef-cfd4-4131-bbc7-62eeed9f3343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471d2aef-cfd4-4131-bbc7-62eeed9f3343.jpg?1",
             "name": "Maskwood Nexus",
             "text": "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling. (It is every creature type.)",
             "colours": [],
@@ -9454,7 +9454,7 @@
         },
         {
             "id": "1df7dbb3-9309-5b56-a3c6-d0114c1f25f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9a8e44-f5de-497d-be48-adf1bcbaec97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9a8e44-f5de-497d-be48-adf1bcbaec97.jpg?1",
             "name": "Pyre of Heroes",
             "text": "{2}, {T}, Sacrifice a creature: Search your library for a creature card that shares a creature type with the sacrificed creature and has converted mana cost equal to 1 plus that creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -9484,7 +9484,7 @@
         },
         {
             "id": "745ab8ec-53b1-5724-899e-bff47f9c162a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f572cbb1-49ee-4c95-90a3-82704cf92454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f572cbb1-49ee-4c95-90a3-82704cf92454.jpg?1",
             "name": "Raiders' Karve",
             "text": "Whenever Raiders' Karve attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "10bad46d-c75f-5116-983b-5d355ff250de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60916ebe-6d84-4873-bd91-351bbe219c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60916ebe-6d84-4873-bd91-351bbe219c57.jpg?1",
             "name": "Raven Wings",
             "text": "Equipped creature gets +1/+0, has flying, and is a Bird in addition to its other types.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "e4a3fcb0-8fc9-55ff-86a6-415cea36ff2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b079e285-8431-46aa-bb04-70cac586ed0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b079e285-8431-46aa-bb04-70cac586ed0b.jpg?1",
             "name": "Replicating Ring",
             "text": "{T}: Add one mana of any color.\nAt the beginning of your upkeep, put a night counter on Replicating Ring. Then if it has eight or more night counters on it, remove all of them and create eight colorless snow artifact tokens named Replicated Ring with \"{T}: Add one mana of any color.\"",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "0def5d43-5a96-5654-8956-b901fea294fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef89770-2dbb-4a57-99f7-191591bb8e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef89770-2dbb-4a57-99f7-191591bb8e38.jpg?1",
             "name": "Runed Crown",
             "text": "When Runed Crown enters the battlefield, you may search your library, hand, and/or graveyard for a Rune card and put it onto the battlefield attached to Runed Crown. If you search your library this way, shuffle it.\nEquipped creature gets +1/+1.\nEquip {2}",
             "colours": [],
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "72001f9b-f2aa-5063-91c3-7a4e6f83e44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa13084-3e68-49f4-8cc9-6d02286fd150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa13084-3e68-49f4-8cc9-6d02286fd150.jpg?1",
             "name": "Scorn Effigy",
             "text": "Foretell {0} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [],
@@ -9635,7 +9635,7 @@
         },
         {
             "id": "bf0b86d0-8f3f-57ac-9696-f7a93661a4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc2478f-e624-46fb-85af-1254564cd4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc2478f-e624-46fb-85af-1254564cd4d2.jpg?1",
             "name": "Weathered Runestone",
             "text": "Nonland permanent cards in graveyards and libraries can't enter the battlefield.\nPlayers can't cast spells from graveyards or libraries.",
             "colours": [],
@@ -9663,7 +9663,7 @@
         },
         {
             "id": "6d49419f-fc98-58a7-93b0-0f5fbaf57c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702d6b9-bb01-4841-a76d-4a576066c772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702d6b9-bb01-4841-a76d-4a576066c772.jpg?1",
             "name": "Alpine Meadow",
             "text": "({T}: Add {R} or {W}.)\nAlpine Meadow enters the battlefield tapped.",
             "colours": [],
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "66df352f-9038-570b-9a8f-d0a8442e01a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20e3117-f1e4-4449-ae9d-0b66abfc717d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20e3117-f1e4-4449-ae9d-0b66abfc717d.jpg?1",
             "name": "Arctic Treeline",
             "text": "({T}: Add {G} or {W}.)\nArctic Treeline enters the battlefield tapped.",
             "colours": [],
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "0cb9e2c6-80cc-543c-bcb2-2a7112497a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c77d35-8418-48fb-b7d7-7cfa763545c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c77d35-8418-48fb-b7d7-7cfa763545c5.jpg?1",
             "name": "Axgard Armory",
             "text": "Axgard Armory enters the battlefield tapped.\n{T}: Add {W}.\n{1}{R}{R}{W}, {T}, Sacrifice Axgard Armory: Search your library for an Aura card and/or an Equipment card, reveal them, put them into your hand, then shuffle your library.",
             "colours": [],
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "6d56c60a-3436-5c1d-8d1d-a5d64c4fe544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "c277aee9-4263-5fbe-ad24-57f5533f14da",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -9832,7 +9832,7 @@
         },
         {
             "id": "02af4608-bbde-591b-ab12-42ce070b3b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -9865,7 +9865,7 @@
         },
         {
             "id": "71ed444a-156b-5689-8923-39c30c908a69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -9898,7 +9898,7 @@
         },
         {
             "id": "0f109fda-eb89-5646-9c28-83afc2246518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0f2e2-cfd7-4374-a172-4357d5de47bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0f2e2-cfd7-4374-a172-4357d5de47bb.jpg?1",
             "name": "Bretagard Stronghold",
             "text": "Bretagard Stronghold enters the battlefield tapped.\n{T}: Add {G}.\n{G}{W}{W}, {T}, Sacrifice Bretagard Stronghold: Put a +1/+1 counter on each of up to two target creatures you control. They gain vigilance and lifelink until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -9929,7 +9929,7 @@
         },
         {
             "id": "1a89e81d-5138-5d66-a9af-34d775d7e37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88010fdf-41e5-4303-82e2-19cfe9082270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88010fdf-41e5-4303-82e2-19cfe9082270.jpg?1",
             "name": "A-Bretagard Stronghold",
             "text": "",
             "colours": [],
@@ -9959,7 +9959,7 @@
         },
         {
             "id": "06fa03a6-0e18-5b6b-bd56-0c024cdf6026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -9992,7 +9992,7 @@
         },
         {
             "id": "72f2e3ba-ff92-51e4-b38f-5c8f3ad5652d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "5b0de032-d690-5556-b888-7c4a514e73bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cd82e5-6072-4334-a493-01ca4ad6b4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cd82e5-6072-4334-a493-01ca4ad6b4eb.jpg?1",
             "name": "Faceless Haven",
             "text": "{T}: Add {C}.\n{S}{S}{S}: Faceless Haven becomes a 4/3 creature with vigilance and all creature types until end of turn. It's still a land. ({S} can be paid with one mana from a snow source.)",
             "colours": [],
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "d547ed81-1310-5c5b-a5f4-122662e39879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2627acb7-57d9-4429-9bc5-e7dd444d8d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2627acb7-57d9-4429-9bc5-e7dd444d8d48.jpg?1",
             "name": "Gates of Istfell",
             "text": "Gates of Istfell enters the battlefield tapped.\n{T}: Add {W}.\n{2}{W}{U}{U}, {T}, Sacrifice Gates of Istfell: You gain 2 life and draw two cards.",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "d0b666aa-d8d8-5c7a-8b3c-e56f4d593822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5fadd-4559-479f-b45d-abe792f0f6e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5fadd-4559-479f-b45d-abe792f0f6e5.jpg?1",
             "name": "Glacial Floodplain",
             "text": "({T}: Add {W} or {U}.)\nGlacial Floodplain enters the battlefield tapped.",
             "colours": [],
@@ -10124,7 +10124,7 @@
         },
         {
             "id": "943714fc-e75d-56a9-9f56-22c102a4d188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735470df-65d8-43e9-837e-4869c8e4f052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735470df-65d8-43e9-837e-4869c8e4f052.jpg?1",
             "name": "Gnottvold Slumbermound",
             "text": "Gnottvold Slumbermound enters the battlefield tapped.\n{T}: Add {R}.\n{3}{R}{G}{G}, {T}, Sacrifice Gnottvold Slumbermound: Destroy target land. Create a 4/4 green Troll Warrior creature token with trample.",
             "colours": [],
@@ -10155,7 +10155,7 @@
         },
         {
             "id": "f4cbd428-ce23-57db-88b6-a9467099d787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23c757e-5944-47ce-b06f-27b4c403044c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23c757e-5944-47ce-b06f-27b4c403044c.jpg?1",
             "name": "Great Hall of Starnheim",
             "text": "Great Hall of Starnheim enters the battlefield tapped.\n{T}: Add {B}.\n{W}{W}{B}, {T}, Sacrifice Great Hall of Starnheim and a creature you control: Create a 4/4 white Angel Warrior creature token with flying and vigilance. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10186,7 +10186,7 @@
         },
         {
             "id": "9606bf17-5049-5e6d-bcdc-994c68397b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -10219,7 +10219,7 @@
         },
         {
             "id": "5ac020f0-ccbe-52a9-99fa-fcc244cb9874",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "38302237-8c95-5b98-b71f-57dbdbac1043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682eee5f-7986-45d3-910f-407303fdbcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682eee5f-7986-45d3-910f-407303fdbcc4.jpg?1",
             "name": "Highland Forest",
             "text": "({T}: Add {R} or {G}.)\nHighland Forest enters the battlefield tapped.",
             "colours": [],
@@ -10288,7 +10288,7 @@
         },
         {
             "id": "3fa97c34-f069-59ca-8bc1-f439569cf53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cff3ef0-4dfb-472e-aa1e-77613dd0f6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cff3ef0-4dfb-472e-aa1e-77613dd0f6d8.jpg?1",
             "name": "Ice Tunnel",
             "text": "({T}: Add {U} or {B}.)\nIce Tunnel enters the battlefield tapped.",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "2bbf3b7a-6bc3-5cc3-9b92-3d96b5ac2f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ed97de-736d-43d8-977b-308ac54f88f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ed97de-736d-43d8-977b-308ac54f88f4.jpg?1",
             "name": "Immersturm Skullcairn",
             "text": "Immersturm Skullcairn enters the battlefield tapped.\n{T}: Add {B}.\n{1}{B}{R}{R}, {T}, Sacrifice Immersturm Skullcairn: It deals 3 damage to target player. That player discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10355,7 +10355,7 @@
         },
         {
             "id": "b64e273d-95a3-5aab-936c-2cda71f352f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf2bb3e-828f-4d53-9d0a-26bbc5e7f3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf2bb3e-828f-4d53-9d0a-26bbc5e7f3cc.jpg?1",
             "name": "Littjara Mirrorlake",
             "text": "Littjara Mirrorlake enters the battlefield tapped.\n{T}: Add {U}.\n{2}{G}{G}{U}, {T}, Sacrifice Littjara Mirrorlake: Create a token that's a copy of target creature you control, except it enters the battlefield with an additional +1/+1 counter on it. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10386,7 +10386,7 @@
         },
         {
             "id": "ab6f2438-1dad-5c71-8ca6-314adc02aa2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9465a6-d009-4ecd-9fd1-d046547de902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9465a6-d009-4ecd-9fd1-d046547de902.jpg?1",
             "name": "Port of Karfell",
             "text": "Port of Karfell enters the battlefield tapped.\n{T}: Add {U}.\n{3}{U}{B}{B}, {T}, Sacrifice Port of Karfell: Mill four cards, then return a creature card from your graveyard to the battlefield tapped. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -10417,7 +10417,7 @@
         },
         {
             "id": "20d52f69-a760-5bed-a044-121dec642bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1db084-f235-4e26-8867-5f0835a0d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1db084-f235-4e26-8867-5f0835a0d283.jpg?1",
             "name": "Rimewood Falls",
             "text": "({T}: Add {G} or {U}.)\nRimewood Falls enters the battlefield tapped.",
             "colours": [],
@@ -10453,7 +10453,7 @@
         },
         {
             "id": "1310bf39-aa1a-5d51-be17-2b428cb5c0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d98db-0176-41a7-b99b-ead29876cdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d98db-0176-41a7-b99b-ead29876cdab.jpg?1",
             "name": "Shimmerdrift Vale",
             "text": "Shimmerdrift Vale enters the battlefield tapped.\nAs Shimmerdrift Vale enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "92f2748b-86d9-5e5f-9817-30b26d851deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2a0f7-0f53-4627-8be8-227fde331a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2a0f7-0f53-4627-8be8-227fde331a69.jpg?1",
             "name": "Skemfar Elderhall",
             "text": "Skemfar Elderhall enters the battlefield tapped.\n{T}: Add {G}.\n{2}{B}{B}{G}, {T}, Sacrifice Skemfar Elderhall: Up to one target creature you don't control gets -2/-2 until end of turn. Create two 1/1 green Elf Warrior creature tokens. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10514,7 +10514,7 @@
         },
         {
             "id": "9db8841f-6850-5f1f-8128-3ff431b3668f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d305dd37-2764-46cb-8cb9-d3d2c049b36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d305dd37-2764-46cb-8cb9-d3d2c049b36c.jpg?1",
             "name": "A-Skemfar Elderhall",
             "text": "",
             "colours": [],
@@ -10544,7 +10544,7 @@
         },
         {
             "id": "31c34df2-fdef-5be4-943c-eedc7b505681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6611dc5e-6acc-48df-b8c4-4b327314578b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6611dc5e-6acc-48df-b8c4-4b327314578b.jpg?1",
             "name": "Snowfield Sinkhole",
             "text": "({T}: Add {W} or {B}.)\nSnowfield Sinkhole enters the battlefield tapped.",
             "colours": [],
@@ -10580,7 +10580,7 @@
         },
         {
             "id": "0d72a768-d9e2-5ce7-9669-5fb60a8df59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ebe245-ebb5-493c-b9c1-56fbfda9bd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ebe245-ebb5-493c-b9c1-56fbfda9bd66.jpg?1",
             "name": "Sulfurous Mire",
             "text": "({T}: Add {B} or {R}.)\nSulfurous Mire enters the battlefield tapped.",
             "colours": [],
@@ -10616,7 +10616,7 @@
         },
         {
             "id": "0980cb87-d0a4-561f-8cad-a3d8cfb3313e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b02149a-4a8f-4be9-9944-3d216248b549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b02149a-4a8f-4be9-9944-3d216248b549.jpg?1",
             "name": "Surtland Frostpyre",
             "text": "Surtland Frostpyre enters the battlefield tapped.\n{T}: Add {R}.\n{2}{U}{U}{R}, {T}, Sacrifice Surtland Frostpyre: Scry 2. Surtland Frostpyre deals 2 damage to each creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10647,7 +10647,7 @@
         },
         {
             "id": "cbc7c862-6993-5a2a-b823-37a6cdc5cc24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ff3bf-acd3-4bea-b518-6e25f6cfce61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ff3bf-acd3-4bea-b518-6e25f6cfce61.jpg?1",
             "name": "Tyrite Sanctum",
             "text": "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice Tyrite Sanctum: Put an indestructible counter on target God.",
             "colours": [],
@@ -10677,7 +10677,7 @@
         },
         {
             "id": "35800369-cffd-577a-af13-db87d5251ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2392fbb-d9c4-4688-b99c-4e7614c60c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2392fbb-d9c4-4688-b99c-4e7614c60c12.jpg?1",
             "name": "Volatile Fjord",
             "text": "({T}: Add {U} or {R}.)\nVolatile Fjord enters the battlefield tapped.",
             "colours": [],
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "eafca210-0895-5530-bf33-f42d940c3366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd0b71-5a60-418c-82fc-f13d1b5075d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd0b71-5a60-418c-82fc-f13d1b5075d0.jpg?1",
             "name": "Woodland Chasm",
             "text": "({T}: Add {B} or {G}.)\nWoodland Chasm enters the battlefield tapped.",
             "colours": [],
@@ -10749,7 +10749,7 @@
         },
         {
             "id": "e381a6b6-dd5b-5932-bb49-9a628871a0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70cb6d9-3955-4064-917b-11dec26440c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70cb6d9-3955-4064-917b-11dec26440c5.jpg?1",
             "name": "The World Tree",
             "text": "The World Tree enters the battlefield tapped.\n{T}: Add {G}.\nAs long as you control six or more lands, lands you control have \"{T}: Add one mana of any color.\"\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice The World Tree: Search your library for any number of God cards, put them onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -10785,7 +10785,7 @@
         },
         {
             "id": "e465e355-ab30-52dc-be34-457f7efbf059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2730f-878e-47ee-ad2a-73f8fa4e0794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2730f-878e-47ee-ad2a-73f8fa4e0794.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -10822,7 +10822,7 @@
         },
         {
             "id": "735b562f-3493-51d3-b05d-ac1345b5e52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb78693-354a-49d0-a493-430a89c6e6f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb78693-354a-49d0-a493-430a89c6e6f6.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -10859,7 +10859,7 @@
         },
         {
             "id": "74deed74-3933-5e68-988a-f08094168137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfa5ebc-5623-4eec-89ea-dc187489ee4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfa5ebc-5623-4eec-89ea-dc187489ee4a.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -10896,7 +10896,7 @@
         },
         {
             "id": "19bff48a-5ca1-5d8a-80bc-a24646ad3e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcf8c0a-cf91-42a0-a54e-da5e7c697ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcf8c0a-cf91-42a0-a54e-da5e7c697ee3.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -10933,7 +10933,7 @@
         },
         {
             "id": "55df79fb-15ed-52e0-ae57-640b8d75017b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa85af8-15f5-4620-8aea-0b45c28372ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa85af8-15f5-4620-8aea-0b45c28372ed.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -10970,7 +10970,7 @@
         },
         {
             "id": "835738a8-792c-5adb-bfb5-44e7a6b9a705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160baf7-5796-4815-8e9d-e804af70cb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160baf7-5796-4815-8e9d-e804af70cb74.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "e6be6f72-a8f7-5482-9d9b-8c590834d628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474e67c-628f-41b0-aa31-3d85a267265a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474e67c-628f-41b0-aa31-3d85a267265a.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -11044,7 +11044,7 @@
         },
         {
             "id": "d72df22a-c715-5e98-ac07-2073ddd29bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54aa46b-4b7c-4846-bf19-a289ed36c172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54aa46b-4b7c-4846-bf19-a289ed36c172.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "58d852c8-bfda-5a91-a64e-0be4e9cdae33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17acea-f079-4e53-8176-a2f5c5c408a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17acea-f079-4e53-8176-a2f5c5c408a1.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -11118,7 +11118,7 @@
         },
         {
             "id": "9726c83a-67d0-5b08-b262-2f642844344f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe241460-f7c1-4ba8-a156-6720b494ac97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe241460-f7c1-4ba8-a156-6720b494ac97.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -11155,7 +11155,7 @@
         },
         {
             "id": "987b5b69-552c-5f3a-b7af-70a700817cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -11195,7 +11195,7 @@
         },
         {
             "id": "88be86ce-90b6-5d9d-b132-044c41baf7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -11236,7 +11236,7 @@
         },
         {
             "id": "ea11f54d-b663-5a65-94b5-56feb74a68ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b35ee-03ba-43f0-8c57-29718c899719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b35ee-03ba-43f0-8c57-29718c899719.jpg?1",
             "name": "Tyvar Kell",
             "text": "Elves you control have \"{T}: Add {B}.\"\n+1: Put a +1/+1 counter on up to one target Elf. Untap it. It gains deathtouch until end of turn.\n0: Create a 1/1 green Elf Warrior creature token.\n\u22126: You get an emblem with \"Whenever you cast an Elf spell, it gains haste until end of turn and you draw two cards.\"",
             "colours": [
@@ -11275,7 +11275,7 @@
         },
         {
             "id": "19b2a48b-35b5-5831-a151-622d341b48dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e3a516-2989-4cac-892f-deb3d754ba7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e3a516-2989-4cac-892f-deb3d754ba7d.jpg?1",
             "name": "Kaya the Inexorable",
             "text": "+1: Put a ghostform counter on up to one target nontoken creature. It gains \"When this creature dies or is put into exile, return it to its owner's hand and create a 1/1 white Spirit creature token with flying.\"\n\u22123: Exile target nonland permanent.\n\u22127: You get an emblem with \"At the beginning of your upkeep, you may cast a legendary spell from your hand, from your graveyard, or from among cards you own in exile without paying its mana cost.\"",
             "colours": [
@@ -11315,7 +11315,7 @@
         },
         {
             "id": "1bb3764c-9153-568d-82e0-7b4635f81f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974a54b8-4f76-45db-a2f3-b2ed28a16cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974a54b8-4f76-45db-a2f3-b2ed28a16cac.jpg?1",
             "name": "Niko Aris",
             "text": "When Niko Aris enters the battlefield, create X Shard tokens.\n+1: Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.\n\u22121: Niko Aris deals 2 damage to target tapped creature for each card you've drawn this turn.\n\u22121: Create a Shard token.",
             "colours": [
@@ -11355,7 +11355,7 @@
         },
         {
             "id": "82253240-82f9-5aa3-88b0-20d1b611f696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -11388,7 +11388,7 @@
         },
         {
             "id": "1bd0076a-80ad-59f7-bb8d-9dc5e3cc92ef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -11421,7 +11421,7 @@
         },
         {
             "id": "f77952ce-3925-5753-b2b1-45b332ab893d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11454,7 +11454,7 @@
         },
         {
             "id": "1da37e87-57bf-5a70-aaf2-aad976848548",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11487,7 +11487,7 @@
         },
         {
             "id": "7fc805f8-b23b-5935-8148-0ebc156f2a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11520,7 +11520,7 @@
         },
         {
             "id": "8dbc37a4-d21a-5539-8e45-ef2955a0456d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "d34646f9-c799-5b3c-9ef8-eab6776a6d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11586,7 +11586,7 @@
         },
         {
             "id": "033eb1e7-7536-52c0-a371-44267b8fb9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11619,7 +11619,7 @@
         },
         {
             "id": "32ee01b6-0341-5578-b2dd-322a805318d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86999e06-62a3-4878-8db0-dc36b52d9794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86999e06-62a3-4878-8db0-dc36b52d9794.jpg?1",
             "name": "Starnheim Unleashed",
             "text": "Create a 4/4 white Angel Warrior creature token with flying and vigilance. If this spell was foretold, create X of those tokens instead.\nForetell {X}{X}{W}",
             "colours": [
@@ -11653,7 +11653,7 @@
         },
         {
             "id": "bac6e8a9-f20c-5240-91ef-2d1cf0c233e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd24105-4202-4690-bb62-16d0b9c291c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd24105-4202-4690-bb62-16d0b9c291c9.jpg?1",
             "name": "Alrund's Epiphany",
             "text": "Create two 1/1 blue Bird creature tokens with flying. Take an extra turn after this one. Exile Alrund's Epiphany.\nForetell {4}{U}{U}",
             "colours": [
@@ -11687,7 +11687,7 @@
         },
         {
             "id": "5431111e-d54e-534f-b42a-39719fa54568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fb42a-9faf-4873-bf46-c80af7d34934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fb42a-9faf-4873-bf46-c80af7d34934.jpg?1",
             "name": "Haunting Voyage",
             "text": "Choose a creature type. Return up to two creature cards of that type from your graveyard to the battlefield. If this spell was foretold, return all creature cards of that type from your graveyard to the battlefield instead.\nForetell {5}{B}{B}",
             "colours": [
@@ -11721,7 +11721,7 @@
         },
         {
             "id": "d104d1ed-d847-5ffc-a62b-47ece43a746b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f7850-8fe6-4487-9b1e-52e27e9f7244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f7850-8fe6-4487-9b1e-52e27e9f7244.jpg?1",
             "name": "Quakebringer",
             "text": "Your opponents can't gain life.\nAt the beginning of your upkeep, Quakebringer deals 2 damage to each opponent. This ability triggers only if Quakebringer is on the battlefield or if Quakebringer is in your graveyard and you control a Giant.\nForetell {2}{R}{R}",
             "colours": [
@@ -11758,7 +11758,7 @@
         },
         {
             "id": "0c720d6c-2c0f-53cb-8e5c-34c6215b48c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87cd73-9149-4e48-acff-dcfce4bd1b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87cd73-9149-4e48-acff-dcfce4bd1b11.jpg?1",
             "name": "Battle Mammoth",
             "text": "Trample\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\nForetell {2}{G}{G}",
             "colours": [
@@ -11794,7 +11794,7 @@
         },
         {
             "id": "435e9aeb-7f95-51aa-8e18-bf324fe3187d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -11832,7 +11832,7 @@
         },
         {
             "id": "52b1b2b0-0e53-5c80-b62b-de28b4582171",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -11870,7 +11870,7 @@
         },
         {
             "id": "40fe6ac7-6154-5d84-8431-394c4d6ca155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -11908,7 +11908,7 @@
         },
         {
             "id": "1ab602f9-7872-538e-8e22-a7de15590101",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -11944,7 +11944,7 @@
         },
         {
             "id": "e938a863-bbaa-5a20-9b62-56cc3b62f14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4654f703-db16-4221-8ec2-bc6832b4ef83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4654f703-db16-4221-8ec2-bc6832b4ef83.jpg?1",
             "name": "Sigrid, God-Favored",
             "text": "Flash\nFirst strike, protection from God creatures\nWhen Sigrid, God-Favored enters the battlefield, exile up to one target attacking or blocking creature until Sigrid leaves the battlefield.",
             "colours": [
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "fdeede86-c85a-56cb-8106-5734d7505b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -12021,7 +12021,7 @@
         },
         {
             "id": "94d856f7-f456-574b-b962-a2dcebc08e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -12059,7 +12059,7 @@
         },
         {
             "id": "4aa56cf4-4ed0-512e-bf2c-06b27c4aea33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -12097,7 +12097,7 @@
         },
         {
             "id": "ac4ffd71-aa91-5694-8a0d-b0e303ca5385",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -12135,7 +12135,7 @@
         },
         {
             "id": "058089cf-8130-5735-b7c5-d0a974bb36bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d1b1a2-3861-4fbb-955b-4f3f8fcca9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d1b1a2-3861-4fbb-955b-4f3f8fcca9a7.jpg?1",
             "name": "Inga Rune-Eyes",
             "text": "When Inga Rune-Eyes enters the battlefield, scry 3.\nWhen Inga Rune-Eyes dies, draw three cards if three or more creatures died this turn.",
             "colours": [
@@ -12174,7 +12174,7 @@
         },
         {
             "id": "c61cdb9b-6888-59c2-8aec-9dd6777a2c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d700064-1fda-4de0-9576-17a3faa5f04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d700064-1fda-4de0-9576-17a3faa5f04c.jpg?1",
             "name": "Orvar, the All-Form",
             "text": "Changeling\nWhenever you cast an instant or sorcery spell, if it targets one or more other permanents you control, create a token that's a copy of one of those permanents.\nWhen a spell or ability an opponent controls causes you to discard this card, create a token that's a copy of target permanent.",
             "colours": [
@@ -12212,7 +12212,7 @@
         },
         {
             "id": "da81c5e0-e073-54ee-b4c9-8467e5fd3c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -12250,7 +12250,7 @@
         },
         {
             "id": "d6d2604f-d6b2-5b02-b10a-f74d2ffb2142",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -12286,7 +12286,7 @@
         },
         {
             "id": "ebba06ad-eae1-5a32-9fe6-ebc7d3eeeec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -12324,7 +12324,7 @@
         },
         {
             "id": "c67bd337-137d-5f48-aaa9-9eab721bc018",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -12360,7 +12360,7 @@
         },
         {
             "id": "7d929665-72d1-578b-b2e2-c0695f343242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "As Tibalt enters the battlefield, you get an emblem with \"You may play cards exiled with Tibalt, Cosmic Impostor, and you may spend mana as though it were mana of any color to cast those spells.\"\n+2: Exile the top card of each player's library.\n\u22123: Exile target artifact or creature.\n\u22128: Exile all cards from all graveyards. Add {R}{R}{R}.\n\n\nGod\n{1}{B}",
             "colours": [
@@ -12400,7 +12400,7 @@
         },
         {
             "id": "98eb886b-7695-52c2-9cc7-b7017e62d44a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "As Tibalt enters the battlefield, you get an emblem with \"You may play cards exiled with Tibalt, Cosmic Impostor, and you may spend mana as though it were mana of any color to cast those spells.\"\n+2: Exile the top card of each player's library.\n\u22123: Exile target artifact or creature.\n\u22128: Exile all cards from all graveyards. Add {R}{R}{R}.\n\n\nGod\n{1}{B}",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "5c3a0a89-86c1-548c-974e-c3104e65475b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656a371-639f-4e4b-889f-4ee0bc085030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656a371-639f-4e4b-889f-4ee0bc085030.jpg?1",
             "name": "Varragoth, Bloodsky Sire",
             "text": "Deathtouch\nBoast \u2014 {1}{B}: Target player searches their library for a card, then shuffles their library and puts that card on top of it.",
             "colours": [
@@ -12480,7 +12480,7 @@
         },
         {
             "id": "4bde37de-39a2-50d3-ae4b-4dc60b9ca526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29945a0a-5d40-4305-b996-579177c8e8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29945a0a-5d40-4305-b996-579177c8e8bf.jpg?1",
             "name": "Arni Brokenbrow",
             "text": "Haste\nBoast \u2014 {1}: You may change Arni Brokenbrow's base power to 1 plus the greatest power among other creatures you control until end of turn.",
             "colours": [
@@ -12519,7 +12519,7 @@
         },
         {
             "id": "a79d2038-b76f-5112-8cf8-78c91050d0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -12557,7 +12557,7 @@
         },
         {
             "id": "af16a633-1a07-5752-8bb4-503c859c8e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -12593,7 +12593,7 @@
         },
         {
             "id": "6f4c1e6b-ff04-5fd4-95aa-0ac2c3c1a30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab551f0e-7a9c-4c99-b199-042ab018dd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab551f0e-7a9c-4c99-b199-042ab018dd9a.jpg?1",
             "name": "Magda, Brazen Outlaw",
             "text": "Other Dwarves you control get +1/+0.\nWhenever a Dwarf you control becomes tapped, create a Treasure token.\nSacrifice five Treasures: Search your library for an artifact or Dragon card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -12632,7 +12632,7 @@
         },
         {
             "id": "0c779216-7abd-56f1-aa40-f4953b6f9324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -12670,7 +12670,7 @@
         },
         {
             "id": "6a91169d-f7bc-554e-b366-2aca4666101a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -12708,7 +12708,7 @@
         },
         {
             "id": "04d0bed8-7fde-5991-9d53-27fc0732646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -12750,7 +12750,7 @@
         },
         {
             "id": "b8e15f58-1152-5c18-ae93-70ae50f71024",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -12794,7 +12794,7 @@
         },
         {
             "id": "bb5621e2-a916-5081-bc15-7f31b32b5b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a7d7e5-428d-4f42-8f13-9908fc65dcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a7d7e5-428d-4f42-8f13-9908fc65dcb4.jpg?1",
             "name": "Esika's Chariot",
             "text": "When Esika's Chariot enters the battlefield, create two 2/2 green Cat creature tokens.\nWhenever Esika's Chariot attacks, create a token that's a copy of target token you control.\nCrew 4",
             "colours": [
@@ -12832,7 +12832,7 @@
         },
         {
             "id": "2e7d93a4-1be2-591c-8404-b6ab0a1b5aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb2319b-e23b-46df-87e6-c256f0cb111e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb2319b-e23b-46df-87e6-c256f0cb111e.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters.",
             "colours": [
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "c46d13c0-1daa-551c-86e0-9c6b0d00aa8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -12912,7 +12912,7 @@
         },
         {
             "id": "e6be0e0d-28b6-5d0f-8cbd-0a4ccaab2774",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -12952,7 +12952,7 @@
         },
         {
             "id": "27010f7d-06fe-5438-a4fb-9b6696868694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "66d1354d-0c08-5695-b698-2fd6defbb16c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -13026,7 +13026,7 @@
         },
         {
             "id": "f3ccaee9-e1ab-5311-b434-89c8c1103403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eb31f3-7686-4d6b-a0e4-5d6ece6fba82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eb31f3-7686-4d6b-a0e4-5d6ece6fba82.jpg?1",
             "name": "Toski, Bearer of Secrets",
             "text": "This spell can't be countered.\nIndestructible\nToski, Bearer of Secrets attacks each combat if able.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -13064,7 +13064,7 @@
         },
         {
             "id": "f85a6483-b319-54a8-ac93-3dfe883fd166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db03ef-db89-43c4-89b4-d48e0620e101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db03ef-db89-43c4-89b4-d48e0620e101.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "Trample, haste\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.",
             "colours": [
@@ -13106,7 +13106,7 @@
         },
         {
             "id": "49afd9b6-c8dc-5e1d-aa41-08a75e709b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edac3fd7-8124-4614-ae50-651608d45adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edac3fd7-8124-4614-ae50-651608d45adb.jpg?1",
             "name": "Aegar, the Freezing Flame",
             "text": "Whenever a creature or planeswalker an opponent controls is dealt excess damage, if a Giant, Wizard, or spell you controlled dealt damage to it this turn, draw a card.",
             "colours": [
@@ -13147,7 +13147,7 @@
         },
         {
             "id": "77565329-79b3-5a18-aa5a-26a0883f256f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8cdd5-e55b-40e0-a61e-f28890f5628d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8cdd5-e55b-40e0-a61e-f28890f5628d.jpg?1",
             "name": "Firja, Judge of Valor",
             "text": "Flying, lifelink\nWhenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -13188,7 +13188,7 @@
         },
         {
             "id": "11e878e6-9c60-55d5-9784-76e68e41aaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc37772-7052-46a9-a34e-f982331595a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc37772-7052-46a9-a34e-f982331595a3.jpg?1",
             "name": "Harald, King of Skemfar",
             "text": "Menace\nWhen Harald, King of Skemfar enters the battlefield, look at the top five cards of your library. You may reveal an Elf, Warrior, or Tyvar card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13229,7 +13229,7 @@
         },
         {
             "id": "5cd6ce63-9906-58e9-9ab3-793f71be3e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc779ac-a418-4cd0-aa73-8d0d91d51f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc779ac-a418-4cd0-aa73-8d0d91d51f1c.jpg?1",
             "name": "Kardur, Doomscourge",
             "text": "When Kardur, Doomscourge enters the battlefield, until your next turn, creatures your opponents control attack each combat if able and attack a player other than you if able.\nWhenever an attacking creature dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -13270,7 +13270,7 @@
         },
         {
             "id": "13a9e01b-606c-5429-b6ee-5854ef24b251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37533179-8e58-40bc-af16-0d2c58b773ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37533179-8e58-40bc-af16-0d2c58b773ba.jpg?1",
             "name": "Koll, the Forgemaster",
             "text": "Whenever another nontoken creature you control dies, if it was enchanted or equipped, return it to its owner's hand.\nCreature tokens you control that are enchanted or equipped get +1/+1.",
             "colours": [
@@ -13311,7 +13311,7 @@
         },
         {
             "id": "1e259488-4036-5d9c-b3f6-78dce29a9e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876ad1df-e926-4d89-aad7-499a37b27f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876ad1df-e926-4d89-aad7-499a37b27f4c.jpg?1",
             "name": "Koma, Cosmos Serpent",
             "text": "This spell can't be countered.\nAt the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.\nSacrifice another Serpent: Choose one \u2014\n\u2022 Tap target permanent. Its activated abilities can't be activated this turn.\n\u2022 Koma, Cosmos Serpent gains indestructible until end of turn.",
             "colours": [
@@ -13351,7 +13351,7 @@
         },
         {
             "id": "09dca96c-7cf2-5107-9fe8-180743b9ad55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8832509-497d-4253-bbb1-92adfb69368f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8832509-497d-4253-bbb1-92adfb69368f.jpg?1",
             "name": "Maja, Bretagard Protector",
             "text": "Other creatures you control get +1/+1.\nWhenever a land enters the battlefield under your control, create a 1/1 white Human Warrior creature token.",
             "colours": [
@@ -13392,7 +13392,7 @@
         },
         {
             "id": "a5abb453-3513-5a78-98bc-3d27950fcdde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47d29bb-8710-4a3d-8789-38956fa7a2be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47d29bb-8710-4a3d-8789-38956fa7a2be.jpg?1",
             "name": "Moritte of the Frost",
             "text": "Changeling\nYou may have Moritte of the Frost enter the battlefield as a copy of a permanent you control, except it's legendary and snow in addition to its other types and, if it's a creature, it enters with two additional +1/+1 counters on it and has changeling.",
             "colours": [
@@ -13433,7 +13433,7 @@
         },
         {
             "id": "43368cb3-36ff-5773-b8b7-2edb19ef829b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ecbec4-0f29-4795-a16c-15e7ca55af4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ecbec4-0f29-4795-a16c-15e7ca55af4f.jpg?1",
             "name": "Narfi, Betrayer King",
             "text": "Other snow and Zombie creatures you control get +1/+1.\n{S}{S}{S}: Return Narfi, Betrayer King from your graveyard to the battlefield tapped.",
             "colours": [
@@ -13475,7 +13475,7 @@
         },
         {
             "id": "a29c8fbd-de53-5e70-86d7-09560c186ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b31046-d84d-4afa-a207-bb6cccac4339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b31046-d84d-4afa-a207-bb6cccac4339.jpg?1",
             "name": "Sarulf, Realm Eater",
             "text": "Whenever a permanent an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on Sarulf, Realm Eater.\nAt the beginning of your upkeep, if Sarulf has one or more +1/+1 counters on it, you may remove all of them. If you do, exile each other nonland permanent with converted mana cost less than or equal to the number of counters removed this way.",
             "colours": [
@@ -13515,7 +13515,7 @@
         },
         {
             "id": "5497f0a8-6f0c-55ba-aa13-4a3726276bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec553af-5254-4812-bb68-cd6d853f693a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec553af-5254-4812-bb68-cd6d853f693a.jpg?1",
             "name": "Svella, Ice Shaper",
             "text": "{3}, {T}: Create a colorless snow artifact token named Icy Manalith with \"{T}: Add one mana of any color.\"\n{6}{R}{G}, {T}: Look at the top four cards of your library. You may cast a spell from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "d79921bd-c201-5eb5-9900-8c98ad47bc04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd1fc45-531e-4e0c-9e1b-c665447e88ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd1fc45-531e-4e0c-9e1b-c665447e88ef.jpg?1",
             "name": "Vega, the Watcher",
             "text": "Flying\nWhenever you cast a spell from anywhere other than your hand, draw a card.",
             "colours": [
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "1128b16a-0e6a-50aa-b4e7-f188fea3f0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4b4019-b73d-4be3-991e-2deb811ee675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4b4019-b73d-4be3-991e-2deb811ee675.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "Trample, haste\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.",
             "colours": [
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "cc57e6e7-a690-5c21-88e7-6e1c384bbc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdeb7c77-0507-4534-a314-696a6871bdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdeb7c77-0507-4534-a314-696a6871bdbf.jpg?1",
             "name": "Doomskar",
             "text": "Destroy all creatures.\nForetell {1}{W}{W}",
             "colours": [
@@ -13674,7 +13674,7 @@
         },
         {
             "id": "7826b2ca-8cfb-525a-97c5-512e682cbcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5008bc-edbc-4ad1-9a06-7eea5723db26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5008bc-edbc-4ad1-9a06-7eea5723db26.jpg?1",
             "name": "Glorious Protector",
             "text": "Flash\nFlying\nWhen Glorious Protector enters the battlefield, you may exile any number of non-Angel creatures you control until Glorious Protector leaves the battlefield.\nForetell {2}{W}",
             "colours": [
@@ -13711,7 +13711,7 @@
         },
         {
             "id": "10ef2283-d844-5dfb-b15b-045c9cc2377a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661481d-62cc-4c00-a53f-1cee380d9d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661481d-62cc-4c00-a53f-1cee380d9d75.jpg?1",
             "name": "Rally the Ranks",
             "text": "As Rally the Ranks enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.",
             "colours": [
@@ -13745,7 +13745,7 @@
         },
         {
             "id": "5c4bc0fd-fe23-5f9a-9e35-3f146f28f477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39906ca0-0f52-42fa-8266-add1860c7a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39906ca0-0f52-42fa-8266-add1860c7a4d.jpg?1",
             "name": "Resplendent Marshal",
             "text": "Flying\nWhen Resplendent Marshal enters the battlefield or dies, you may exile another creature card from your graveyard. When you do, put a +1/+1 counter on each creature you control other than Resplendent Marshal that shares a creature type with the exiled card.",
             "colours": [
@@ -13782,7 +13782,7 @@
         },
         {
             "id": "59783387-ba17-5e95-8a00-d89153b8102f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ff8c9f-a865-4570-8bd3-8229a18e5c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ff8c9f-a865-4570-8bd3-8229a18e5c99.jpg?1",
             "name": "Righteous Valkyrie",
             "text": "Flying\nWhenever another Angel or Cleric enters the battlefield under your control, you gain life equal to that creature's toughness.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -13819,7 +13819,7 @@
         },
         {
             "id": "ac9c1ada-8cb7-5fa1-ac1b-6b4cc3b04b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5a934-3a6c-43b6-b369-2b422f0bc8a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5a934-3a6c-43b6-b369-2b422f0bc8a2.jpg?1",
             "name": "Runeforge Champion",
             "text": "When Runeforge Champion enters the battlefield, you may search your library and/or graveyard for a Rune card, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nYou may pay {1} rather than pay the mana cost for Rune spells you cast.",
             "colours": [
@@ -13856,7 +13856,7 @@
         },
         {
             "id": "106ead4a-be16-5c0d-80ca-a14830b8ee90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd06b52f-f14d-48f1-9eb8-b17b2af4689e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd06b52f-f14d-48f1-9eb8-b17b2af4689e.jpg?1",
             "name": "Search for Glory",
             "text": "Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle your library. You gain 1 life for each {S} spent to cast this spell.",
             "colours": [
@@ -13892,7 +13892,7 @@
         },
         {
             "id": "0abcb984-49c1-5a7c-946d-f42327922986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336490d-5a97-49e9-b772-3435eeede65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336490d-5a97-49e9-b772-3435eeede65d.jpg?1",
             "name": "Ascendant Spirit",
             "text": "{S}{S}: Ascendant Spirit becomes a Spirit Warrior with base power and toughness 2/3.\n{S}{S}{S}: If Ascendant Spirit is a Warrior, put a flying counter on it and it becomes a Spirit Warrior Angel with base power and toughness 4/4.\n{S}{S}{S}{S}: If Ascendant Spirit is an Angel, put two +1/+1 counters on it and it gains \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -13930,7 +13930,7 @@
         },
         {
             "id": "6426097b-5bf6-5b0b-a15f-25a582007b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058feb-4331-49cc-aab2-33908cfafe1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058feb-4331-49cc-aab2-33908cfafe1b.jpg?1",
             "name": "Cosmos Charger",
             "text": "Flash\nFlying\nForetelling cards from your hand costs {1} less and can be done on any player's turn.\nForetell {2}{U}",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "de072243-47ac-5d5e-8dc1-440a34d867e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3420845c-bcb3-4969-9c21-bf4732babfe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3420845c-bcb3-4969-9c21-bf4732babfe2.jpg?1",
             "name": "Cyclone Summoner",
             "text": "When Cyclone Summoner enters the battlefield, if you cast it from your hand, return all permanents to their owners' hands except for Giants, Wizards, and lands.",
             "colours": [
@@ -14004,7 +14004,7 @@
         },
         {
             "id": "813110fd-4705-5e46-8dbe-307661d287d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2d932-0051-4efd-8dd0-3711c5645744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2d932-0051-4efd-8dd0-3711c5645744.jpg?1",
             "name": "Graven Lore",
             "text": "Scry X, where X is the amount of {S} spent to cast this spell, then draw three cards.",
             "colours": [
@@ -14040,7 +14040,7 @@
         },
         {
             "id": "b354d699-e2ce-5325-960f-ced4ac9343ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91f3b0-70fa-48f6-901b-756790a26100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91f3b0-70fa-48f6-901b-756790a26100.jpg?1",
             "name": "Icebreaker Kraken",
             "text": "This spell costs {1} less to cast for each snow land you control.\nWhen Icebreaker Kraken enters the battlefield, artifacts and creatures target opponent controls don't untap during that player's next untap step.\nReturn three snow lands you control to their owner's hand: Return Icebreaker Kraken to its owner's hand.",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "ab0add61-5a41-5597-bbbd-6abbbec66657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557b3c7-98c6-4362-9a89-b71f0feaaaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557b3c7-98c6-4362-9a89-b71f0feaaaec.jpg?1",
             "name": "Mystic Reflection",
             "text": "Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.\nForetell {U}",
             "colours": [
@@ -14112,7 +14112,7 @@
         },
         {
             "id": "51c5d32d-cc3f-5478-bcf1-176c0eeb5cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694973a3-cf8b-4e5f-a0cd-40b7396c2550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694973a3-cf8b-4e5f-a0cd-40b7396c2550.jpg?1",
             "name": "Reflections of Littjara",
             "text": "As Reflections of Littjara enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, copy that spell.",
             "colours": [
@@ -14147,7 +14147,7 @@
         },
         {
             "id": "28e2958c-e66c-590b-b35b-b86a9ca9aecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd7d506-2f02-47a2-8786-fdccbb60f28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd7d506-2f02-47a2-8786-fdccbb60f28c.jpg?1",
             "name": "Blood on the Snow",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all planeswalkers.\nThen return a creature or planeswalker card with converted mana cost X or less from your graveyard to the battlefield, where X is the amount of {S} spent to cast this spell.",
             "colours": [
@@ -14183,7 +14183,7 @@
         },
         {
             "id": "7983b00b-d4ab-5a5c-b46d-3b42fc2d61aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3b0c3b-896e-4d1e-b7fb-670718ba97d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3b0c3b-896e-4d1e-b7fb-670718ba97d4.jpg?1",
             "name": "Burning-Rune Demon",
             "text": "Flying\nWhen Burning-Rune Demon enters the battlefield, you may search your library for exactly two cards not named Burning-Rune Demon that have different names. If you do, reveal those cards. An opponent chooses one of them. Put the chosen card into your hand and the other into your graveyard, then shuffle your library.",
             "colours": [
@@ -14220,7 +14220,7 @@
         },
         {
             "id": "7fc965d6-1ff2-5deb-86e1-8f6e063d48ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7aaf8-f0e0-481f-bca4-25c612f2d63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7aaf8-f0e0-481f-bca4-25c612f2d63b.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -14254,7 +14254,7 @@
         },
         {
             "id": "eb77ab35-313e-5968-bfb7-22805372d87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a6725d-7a76-40e6-ace3-e19d0ac8e817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a6725d-7a76-40e6-ace3-e19d0ac8e817.jpg?1",
             "name": "Draugr Necromancer",
             "text": "If a nontoken creature an opponent controls would die, exile that card with an ice counter on it instead.\nYou may cast spells from among cards in exile your opponents own with ice counters on them, and you may spend mana from snow sources as though it were mana of any color to cast those spells.",
             "colours": [
@@ -14293,7 +14293,7 @@
         },
         {
             "id": "980f24ab-b5b8-5f49-aa37-82df58f5f995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c01887-d4b3-46d2-af6b-2877659d057f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c01887-d4b3-46d2-af6b-2877659d057f.jpg?1",
             "name": "Dream Devourer",
             "text": "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}.\nWhenever you foretell a card, Dream Devourer gets +2/+0 until end of turn.",
             "colours": [
@@ -14330,7 +14330,7 @@
         },
         {
             "id": "e794e047-18d4-539c-97d9-3b88cf45a688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41fdfb7-4d0d-4030-a085-9c692f1783ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41fdfb7-4d0d-4030-a085-9c692f1783ed.jpg?1",
             "name": "Eradicator Valkyrie",
             "text": "Flying, lifelink, hexproof from planeswalkers\nBoast \u2014 {1}{B}, Sacrifice a creature: Each opponent sacrifices a creature or planeswalker.",
             "colours": [
@@ -14367,7 +14367,7 @@
         },
         {
             "id": "44d02f77-f2db-56d3-b6eb-d70cffa50796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68e39-e3a9-4f9e-ba43-bd4b126a9137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68e39-e3a9-4f9e-ba43-bd4b126a9137.jpg?1",
             "name": "Rise of the Dread Marn",
             "text": "Create X 2/2 black Zombie Berserker creature tokens, where X is the number of nontoken creatures that died this turn.\nForetell {B}",
             "colours": [
@@ -14401,7 +14401,7 @@
         },
         {
             "id": "0b62b8b9-b190-55ec-ae81-677f7ace049a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b5346e-b9d1-4214-a15e-c082fb0e0949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b5346e-b9d1-4214-a15e-c082fb0e0949.jpg?1",
             "name": "Skemfar Avenger",
             "text": "Whenever another nontoken Elf or Berserker you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -14438,7 +14438,7 @@
         },
         {
             "id": "4f631924-efe9-5363-ae54-e3e2a388bf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b7a0b-4657-4f89-a2da-933199fa58fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b7a0b-4657-4f89-a2da-933199fa58fa.jpg?1",
             "name": "Calamity Bearer",
             "text": "If a Giant source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -14475,7 +14475,7 @@
         },
         {
             "id": "66858e4d-d847-53eb-bdbe-47ac067c6209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fadbe4-ecb4-4e89-8db4-1cf910b510cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fadbe4-ecb4-4e89-8db4-1cf910b510cf.jpg?1",
             "name": "Dragonkin Berserker",
             "text": "First strike\nBoast abilities you activate cost {1} less to activate for each Dragon you control.\nBoast \u2014 {4}{R}: Create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "847a7d02-dc3b-5e26-9a7f-2ecfdda2f9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cec498-e2ac-4ca0-9aa2-ef98ba634c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cec498-e2ac-4ca0-9aa2-ef98ba634c32.jpg?1",
             "name": "Goldspan Dragon",
             "text": "Flying, haste\nWhenever Goldspan Dragon attacks or becomes the target of a spell, create a Treasure token.\nTreasures you control have \"{T}, Sacrifice this artifact: Add two mana of any one color.\"",
             "colours": [
@@ -14548,7 +14548,7 @@
         },
         {
             "id": "1806d520-92ba-52e8-a7ed-b5dc495f6d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328adc1b-2e28-4615-a65b-4874dd2a1af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328adc1b-2e28-4615-a65b-4874dd2a1af5.jpg?1",
             "name": "Reckless Crew",
             "text": "Create X 2/1 red Dwarf Berserker creature tokens, where X is the number of Vehicles you control plus the number of Equipment you control. For each of those tokens, you may attach an Equipment you control to it.",
             "colours": [
@@ -14582,7 +14582,7 @@
         },
         {
             "id": "45429708-a0c4-5133-8293-df48914bb825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f5b3-1685-42b6-b838-3e19f1f6b36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f5b3-1685-42b6-b838-3e19f1f6b36e.jpg?1",
             "name": "Tibalt's Trickery",
             "text": "Counter target spell. Choose 1, 2, or 3 at random. Its controller mills that many cards, then exiles cards from the top of their library until they exile a nonland card with a different name than that spell. They may cast that card without paying its mana cost. Then they put the exiled cards on the bottom of their library in a random order.",
             "colours": [
@@ -14616,7 +14616,7 @@
         },
         {
             "id": "48ffebf4-c0ae-5ca7-bef6-341b874a5edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50112dbc-275c-47ab-adb1-e9c4de002f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50112dbc-275c-47ab-adb1-e9c4de002f40.jpg?1",
             "name": "Tundra Fumarole",
             "text": "Tundra Fumarole deals 4 damage to target creature or planeswalker. Add {C} for each {S} spent to cast this spell. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -14652,7 +14652,7 @@
         },
         {
             "id": "d6f30239-7c91-5673-aa12-d715ca07dfd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8018046-568d-4550-863a-dbab6f5d2210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8018046-568d-4550-863a-dbab6f5d2210.jpg?1",
             "name": "Blessing of Frost",
             "text": "Distribute X +1/+1 counters among any number of creatures you control, where X is the amount of {S} spent to cast this spell. Then draw a card for each creature you control with power 4 or greater.",
             "colours": [
@@ -14688,7 +14688,7 @@
         },
         {
             "id": "669c1fe3-a30f-5c31-9e19-487c27bc1bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e59380e-2c82-46a9-9749-4dcb978d5419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e59380e-2c82-46a9-9749-4dcb978d5419.jpg?1",
             "name": "Elvish Warmaster",
             "text": "Whenever one or more other Elves enters the battlefield under your control, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
             "colours": [
@@ -14725,7 +14725,7 @@
         },
         {
             "id": "0ccf7083-1532-5b35-8c16-40b6a46fec73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f75c3ad-839a-4658-9706-5d9df7ce6dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f75c3ad-839a-4658-9706-5d9df7ce6dff.jpg?1",
             "name": "In Search of Greatness",
             "text": "At the beginning of your upkeep, you may cast a permanent spell from your hand with converted mana cost equal to 1 plus the highest converted mana cost among other permanents you control without paying its mana cost. If you don't, scry 1.",
             "colours": [
@@ -14759,7 +14759,7 @@
         },
         {
             "id": "902d4447-e251-574b-99b6-0e27b09c8372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125915dd-0499-4690-8897-4c8906e9817c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125915dd-0499-4690-8897-4c8906e9817c.jpg?1",
             "name": "Old-Growth Troll",
             "text": "Trample\nWhen Old-Growth Troll dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add {G}{G}' and \u2018{1}, {T}, Sacrifice this land: Create a tapped 4/4 green Troll Warrior creature token with trample.'\"",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "6de10eb7-1660-56c2-a9c0-1f7a477d27c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367b007-5985-448d-9203-67c22195d708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367b007-5985-448d-9203-67c22195d708.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "e8996db8-1529-5b93-b75c-b7359f629b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222d66-137b-4707-b28a-a23549b1ee35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222d66-137b-4707-b28a-a23549b1ee35.jpg?1",
             "name": "Immersturm Predator",
             "text": "Flying\nWhenever Immersturm Predator becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on Immersturm Predator.\nSacrifice another creature: Immersturm Predator gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -14872,7 +14872,7 @@
         },
         {
             "id": "deb656e8-0c16-5d01-aa57-6c38be5c5bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea524e81-4898-4a41-8b34-06defd26e4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea524e81-4898-4a41-8b34-06defd26e4c7.jpg?1",
             "name": "Cosmos Elixir",
             "text": "At the beginning of your end step, draw a card if your life total is greater than your starting life total. Otherwise, you gain 2 life.",
             "colours": [],
@@ -14902,7 +14902,7 @@
         },
         {
             "id": "571409c8-c232-53d4-9879-824c4859ba81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45887949-7cc6-4f83-a659-fb3284685c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45887949-7cc6-4f83-a659-fb3284685c7d.jpg?1",
             "name": "Maskwood Nexus",
             "text": "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling.",
             "colours": [],
@@ -14932,7 +14932,7 @@
         },
         {
             "id": "b7312844-152b-5f08-be4e-6e43e1abda93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba697b79-e3e4-4574-87bd-b7f8c4ce6c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba697b79-e3e4-4574-87bd-b7f8c4ce6c52.jpg?1",
             "name": "Pyre of Heroes",
             "text": "{2}, {T}, Sacrifice a creature: Search your library for a creature card that shares a creature type with the sacrificed creature and has converted mana cost equal to 1 plus that creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -14962,7 +14962,7 @@
         },
         {
             "id": "7a0792e7-91c3-5c07-98a3-fab3b2322804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21481b68-2396-4c94-956d-55d7427eeeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21481b68-2396-4c94-956d-55d7427eeeb6.jpg?1",
             "name": "Faceless Haven",
             "text": "{T}: Add {C}.\n{S}{S}{S}: Faceless Haven becomes a 4/3 creature with vigilance and all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -14994,7 +14994,7 @@
         },
         {
             "id": "a137a199-75bb-5edd-8a5c-0f0cf3bbb4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cc143-3ef2-4e08-a5e3-41753f0f704c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cc143-3ef2-4e08-a5e3-41753f0f704c.jpg?1",
             "name": "Tyrite Sanctum",
             "text": "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice Tyrite Sanctum: Put an indestructible counter on target God.",
             "colours": [],
@@ -15024,7 +15024,7 @@
         },
         {
             "id": "21ed76d8-d964-5ee1-9d7c-d0d3bf45e0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999fa01b-4e54-4e3e-973d-7af137a53684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999fa01b-4e54-4e3e-973d-7af137a53684.jpg?1",
             "name": "The World Tree",
             "text": "The World Tree enters the battlefield tapped.\n{T}: Add {G}.\nAs long as you control six or more lands, lands you control have \"{T}: Add one mana of any color.\"\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice The World Tree: Search your library for any number of God cards, put them onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -15060,7 +15060,7 @@
         },
         {
             "id": "ce2706eb-94b9-5647-9b5f-55c3ce7cbbd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab83a9-35b5-4312-b8ee-1c042c02aa31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab83a9-35b5-4312-b8ee-1c042c02aa31.jpg?1",
             "name": "Valkyrie Harbinger",
             "text": "Flying, lifelink\nAt the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.",
             "colours": [
@@ -15095,7 +15095,7 @@
         },
         {
             "id": "5d34cfb8-272f-50e1-93b9-e56f3facf192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9e7fdc-676f-4901-83ff-bfea3a96d937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9e7fdc-676f-4901-83ff-bfea3a96d937.jpg?1",
             "name": "Surtland Elementalist",
             "text": "As an additional cost to cast this spell, reveal a Giant card from your hand or pay {2}.\nWhenever Surtland Elementalist attacks, you may cast an instant or sorcery spell from your hand without paying its mana cost.",
             "colours": [
@@ -15130,7 +15130,7 @@
         },
         {
             "id": "f49e77ac-9441-51e2-8418-efd1fc1f64bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59dadef-74e5-47c7-a3e0-51075ddb82b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59dadef-74e5-47c7-a3e0-51075ddb82b1.jpg?1",
             "name": "Cleaving Reaper",
             "text": "Flying, trample\nPay 3 life: Return Cleaving Reaper from your graveyard to your hand. Activate this ability only if you had an Angel or Berserker enter the battlefield under your control this turn.",
             "colours": [
@@ -15165,7 +15165,7 @@
         },
         {
             "id": "ff9fa178-10c5-5888-8bea-f750cc90c51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a628052-8175-495f-bfab-eeb3a0388e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a628052-8175-495f-bfab-eeb3a0388e4e.jpg?1",
             "name": "Surtland Flinger",
             "text": "Whenever Surtland Flinger attacks, you may sacrifice another creature. When you do, Surtland Flinger deals damage equal to the sacrificed creature's power to any target. If the sacrificed creature was a Giant, Surtland Flinger deals twice that much damage instead.",
             "colours": [
@@ -15200,7 +15200,7 @@
         },
         {
             "id": "46b99860-424f-5dd8-8b32-fd627985e3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg?1",
             "name": "Canopy Tactician",
             "text": "Other Elves you control get +1/+1.\n{T}: Add {G}{G}{G}.",
             "colours": [
@@ -15235,7 +15235,7 @@
         },
         {
             "id": "2f2df7f1-fc88-5aab-a5b5-b8778a0f167c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693eb7cb-a78c-4d79-b4de-f59da76cce31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693eb7cb-a78c-4d79-b4de-f59da76cce31.jpg?1",
             "name": "A-Canopy Tactician",
             "text": "",
             "colours": [
@@ -15269,7 +15269,7 @@
         },
         {
             "id": "28986538-dd9b-5b18-a7d4-d6114163e049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c1253-7eba-454b-9269-3695ba746a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c1253-7eba-454b-9269-3695ba746a7a.jpg?1",
             "name": "Armed and Armored",
             "text": "Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.",
             "colours": [
@@ -15301,7 +15301,7 @@
         },
         {
             "id": "4752c551-540f-5a4a-9325-213cdb119608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea007a18-b31a-4881-92c4-86120dc5729b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea007a18-b31a-4881-92c4-86120dc5729b.jpg?1",
             "name": "Starnheim Aspirant",
             "text": "Angel spells you cast cost {2} less to cast.",
             "colours": [
@@ -15336,7 +15336,7 @@
         },
         {
             "id": "8c06a9af-089d-55ea-91b4-c878b4727047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79c5e95-f6c6-4e2f-9c6c-d99addb757ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79c5e95-f6c6-4e2f-9c6c-d99addb757ac.jpg?1",
             "name": "Warchanter Skald",
             "text": "Whenever Warchanter Skald becomes tapped, if it's enchanted or equipped, create a 2/1 red Dwarf Berserker creature token.",
             "colours": [
@@ -15371,7 +15371,7 @@
         },
         {
             "id": "3b29814d-2076-5ce8-9bee-532ae666436c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe93b27-f8ae-4abf-8ade-90f503f132c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe93b27-f8ae-4abf-8ade-90f503f132c2.jpg?1",
             "name": "Youthful Valkyrie",
             "text": "Flying\nWhenever another Angel enters the battlefield under your control, put a +1/+1 counter on Youthful Valkyrie.",
             "colours": [
@@ -15405,7 +15405,7 @@
         },
         {
             "id": "fa3e1540-8f7c-5fcc-9aaf-19b6b4af1c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c6bcc-2d43-4ea9-a93f-019793616869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c6bcc-2d43-4ea9-a93f-019793616869.jpg?1",
             "name": "Absorb Identity",
             "text": "Return target creature to its owner's hand. You may have Shapeshifters you control become copies of that creature until end of turn.",
             "colours": [
@@ -15437,7 +15437,7 @@
         },
         {
             "id": "c75e8a57-0bf6-5ffa-96e2-b38b3e229e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c92d48-504a-4320-b9f4-c1d2d06fa223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c92d48-504a-4320-b9f4-c1d2d06fa223.jpg?1",
             "name": "Giant's Grasp",
             "text": "Enchant Giant you control\nWhen Giant's Grasp enters the battlefield, gain control of target nonland permanent for as long as Giant's Grasp remains on the battlefield.",
             "colours": [
@@ -15471,7 +15471,7 @@
         },
         {
             "id": "785ced98-24fe-5498-9ad8-264c1229b471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57348f93-8764-4b1a-b02e-4e7881337fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57348f93-8764-4b1a-b02e-4e7881337fa2.jpg?1",
             "name": "Elderfang Ritualist",
             "text": "When Elderfang Ritualist dies, return another target Elf card from your graveyard to your hand.",
             "colours": [
@@ -15506,7 +15506,7 @@
         },
         {
             "id": "5c799e07-7291-5d9e-b5ca-a4d252b97cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62872f7d-26ab-40b7-96db-955e576ec110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62872f7d-26ab-40b7-96db-955e576ec110.jpg?1",
             "name": "A-Elderfang Ritualist",
             "text": "",
             "colours": [
@@ -15540,7 +15540,7 @@
         },
         {
             "id": "8e5de290-77a4-5746-b232-20b9d24a9d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5675655-dc9f-45ad-9cd0-ce28fba1f972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5675655-dc9f-45ad-9cd0-ce28fba1f972.jpg?1",
             "name": "Renegade Reaper",
             "text": "Flying\nWhen Renegade Reaper enters the battlefield, mill four cards. If at least one Angel card is milled this way, you gain 4 life.(To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -15575,7 +15575,7 @@
         },
         {
             "id": "a530a668-ef38-5b6f-bed2-f3e190787554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b6477-cefa-40e2-a96a-72794c7eb815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b6477-cefa-40e2-a96a-72794c7eb815.jpg?1",
             "name": "Thornmantle Striker",
             "text": "When Thornmantle Striker enters the battlefield, choose one \u2014\n\u2022 Remove X counters from target permanent, where X is the number of Elves you control.\n\u2022 Target creature an opponent controls gets -X/-X until end of turn, where X is the number of Elves you control.",
             "colours": [
@@ -15610,7 +15610,7 @@
         },
         {
             "id": "4112d86a-7e8d-5d58-89ee-48b957a9ac78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7a57af-b44d-476d-8f11-43c54eff52b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7a57af-b44d-476d-8f11-43c54eff52b2.jpg?1",
             "name": "A-Thornmantle Striker",
             "text": "",
             "colours": [
@@ -15644,7 +15644,7 @@
         },
         {
             "id": "366277a8-08f5-5867-bb66-7918fd8e4157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2381dbab-e968-4bbc-b3a7-a1e55b066039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2381dbab-e968-4bbc-b3a7-a1e55b066039.jpg?1",
             "name": "Bearded Axe",
             "text": "Equipped creature gets +1/+1 for each Dwarf, Equipment, and/or Vehicle you control.\nEquip {2}",
             "colours": [
@@ -15678,7 +15678,7 @@
         },
         {
             "id": "2322de92-1215-5212-89bc-6200ff7d2708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f05d49-dfc1-4dad-89e0-07174330d98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f05d49-dfc1-4dad-89e0-07174330d98e.jpg?1",
             "name": "Fire Giant's Fury",
             "text": "Target Giant you control gets +2/+2 and gains trample until end of turn. Whenever it deals combat damage to a player this turn, exile that many cards from the top of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -15710,7 +15710,7 @@
         },
         {
             "id": "e011c8a1-ed28-53e1-85a1-8c5d44f4c9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5274c2fa-eb0e-438b-8a48-d0b58829083a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5274c2fa-eb0e-438b-8a48-d0b58829083a.jpg?1",
             "name": "Gilded Assault Cart",
             "text": "Trample\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)\nSacrifice two Treasures: Return Gilded Assault Cart from your graveyard to your hand.",
             "colours": [
@@ -15744,7 +15744,7 @@
         },
         {
             "id": "346d97d0-2040-56f9-ab3d-cfb8a0971adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70479c44-da7c-48c7-8c6a-47210dc03277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70479c44-da7c-48c7-8c6a-47210dc03277.jpg?1",
             "name": "Elven Ambush",
             "text": "Create a 1/1 green Elf Warrior creature token for each Elf you control.",
             "colours": [
@@ -15776,7 +15776,7 @@
         },
         {
             "id": "c9b1157c-70df-5cea-97ce-3beb853b8ca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8053b888-a680-4318-88c3-0924e596e780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8053b888-a680-4318-88c3-0924e596e780.jpg?1",
             "name": "Gladewalker Ritualist",
             "text": "Changeling (This card is every creature type.)\nWhenever another creature named Gladewalker Ritualist enters the battlefield under your control, draw a card.",
             "colours": [
@@ -15810,7 +15810,7 @@
         },
         {
             "id": "feaebc0f-001b-5f90-b56d-2b1e63400986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e928b7c-ca30-4e2d-adf7-965f111c8bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e928b7c-ca30-4e2d-adf7-965f111c8bf1.jpg?1",
             "name": "Rampage of the Valkyries",
             "text": "When Rampage of the Valkyries enters the battlefield, create a 4/4 white Angel creature token with flying and vigilance.\nWhenever an Angel you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -15844,7 +15844,7 @@
         },
         {
             "id": "805b69dc-31dd-50fb-bd2b-4051f90916ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbfbafa-f58f-40b2-a374-68ac35b77d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbfbafa-f58f-40b2-a374-68ac35b77d89.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15878,7 +15878,7 @@
         },
         {
             "id": "8c527336-7b37-5dba-bfbf-297cfaf76765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a25a714-c7f3-4697-8b69-8f966b4d370a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a25a714-c7f3-4697-8b69-8f966b4d370a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "dd6ddc65-4585-5a60-9bdf-798201c5270d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e61c0-b185-4704-913f-9284ed0ce250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e61c0-b185-4704-913f-9284ed0ce250.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15946,7 +15946,7 @@
         },
         {
             "id": "e59d6211-1b9d-567a-8dd0-84f2c90524b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69419307-53d5-40d7-82da-cab2e7bfbda4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69419307-53d5-40d7-82da-cab2e7bfbda4.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15980,7 +15980,7 @@
         },
         {
             "id": "4ac153f5-8a7c-5128-8135-64b1c0c851e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e307c-b2e3-47ac-aac2-59f0c3542fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e307c-b2e3-47ac-aac2-59f0c3542fa6.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16014,7 +16014,7 @@
         },
         {
             "id": "63ef8762-36b8-5891-97ae-744d0e5d3f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a0877c-5217-422d-89b8-92f951068693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a0877c-5217-422d-89b8-92f951068693.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling (This card is every creature type.)\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -16050,7 +16050,7 @@
         },
         {
             "id": "2153dd69-cac3-5c07-8647-ed32b4008c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebaa07d-68f6-4cdb-a5cd-cd715e50abf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebaa07d-68f6-4cdb-a5cd-cd715e50abf5.jpg?1",
             "name": "Reflections of Littjara",
             "text": "",
             "colours": [
@@ -16084,7 +16084,7 @@
         },
         {
             "id": "b9a54462-1cff-5826-9fdf-dd95d9f3278c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7811579-0d01-4fae-b621-98eb6c0355f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7811579-0d01-4fae-b621-98eb6c0355f6.jpg?1",
             "name": "Usher of the Fallen",
             "text": "",
             "colours": [
@@ -16121,7 +16121,7 @@
         },
         {
             "id": "8c6c9d42-9ede-5959-9807-0f3761eb91ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994fff9f-ded1-4741-b48a-e95fd88f9b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994fff9f-ded1-4741-b48a-e95fd88f9b3b.jpg?1",
             "name": "Strategic Planning",
             "text": "",
             "colours": [
@@ -16155,7 +16155,7 @@
         },
         {
             "id": "8e6646e0-0ab6-5fc8-968e-2ec1deeaaf92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397f533-204b-4187-b4fe-4e7f067ea3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397f533-204b-4187-b4fe-4e7f067ea3f4.jpg?1",
             "name": "Poison the Cup",
             "text": "",
             "colours": [
@@ -16189,7 +16189,7 @@
         },
         {
             "id": "010e3000-b734-55f2-b6c2-f12d112b224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24345ae-c2c9-435e-a578-1835bb1a9a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24345ae-c2c9-435e-a578-1835bb1a9a00.jpg?1",
             "name": "Frost Bite",
             "text": "",
             "colours": [
@@ -16225,7 +16225,7 @@
         },
         {
             "id": "c9e37fc8-0563-5573-9d67-9405afa5d92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ace8e69-7550-4c40-bf63-59cb95603391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ace8e69-7550-4c40-bf63-59cb95603391.jpg?1",
             "name": "Masked Vandal",
             "text": "",
             "colours": [
@@ -16261,7 +16261,7 @@
         },
         {
             "id": "e4febcb9-880e-5548-a4f2-961c29296f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff018fe2-9feb-431d-b4c5-61b2ed0d919d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff018fe2-9feb-431d-b4c5-61b2ed0d919d.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "",
             "colours": [
@@ -16303,7 +16303,7 @@
         },
         {
             "id": "0eaaec31-25c2-517e-9ec4-977c85c63ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7412d90-b864-4a9c-9f8b-a28e86b9a03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7412d90-b864-4a9c-9f8b-a28e86b9a03d.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "",
             "colours": [
@@ -16344,7 +16344,7 @@
         },
         {
             "id": "872a2f10-d48f-541d-a27b-a8f3ae7bb23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df826c7d-5508-4e21-848c-91bc3e3f447a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df826c7d-5508-4e21-848c-91bc3e3f447a.jpg?1",
             "name": "Shard",
             "text": "",
             "colours": [],
@@ -16375,7 +16375,7 @@
         },
         {
             "id": "cb069841-fefe-546d-a730-38c9abe208e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd871a3-3802-4bdc-8033-3ecfd01c0449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd871a3-3802-4bdc-8033-3ecfd01c0449.jpg?1",
             "name": "Angel Warrior",
             "text": "",
             "colours": [
@@ -16411,7 +16411,7 @@
         },
         {
             "id": "6804f50f-17f5-5b4e-bac5-c5bc7fbdc337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06fbcd85-c54e-492e-9e42-5e101cac4255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06fbcd85-c54e-492e-9e42-5e101cac4255.jpg?1",
             "name": "Human Warrior",
             "text": "",
             "colours": [
@@ -16447,7 +16447,7 @@
         },
         {
             "id": "8afdab41-b0bd-517e-9bc1-728e671c0f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95694c03-2b3b-455c-8361-0799c078bf04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95694c03-2b3b-455c-8361-0799c078bf04.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16482,7 +16482,7 @@
         },
         {
             "id": "b5963847-fa34-5396-84fd-23bd855482af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0cb299-057d-4c39-9d73-3a3512526e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0cb299-057d-4c39-9d73-3a3512526e4a.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16517,7 +16517,7 @@
         },
         {
             "id": "87d70064-55f4-5d8b-a130-f794038946b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40a0cb8-0caf-4dd1-b7d0-abbc626985d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40a0cb8-0caf-4dd1-b7d0-abbc626985d2.jpg?1",
             "name": "Giant Wizard",
             "text": "",
             "colours": [
@@ -16553,7 +16553,7 @@
         },
         {
             "id": "7fe69ac3-3746-5976-a53c-e4d06492050c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1c6a9-3531-4432-9157-e4400dbc89fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1c6a9-3531-4432-9157-e4400dbc89fd.jpg?1",
             "name": "Koma's Coil",
             "text": "",
             "colours": [
@@ -16588,7 +16588,7 @@
         },
         {
             "id": "4619d1ad-f2df-56e6-b96e-c8e204239231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef775ad0-b1a9-4254-ab6f-304558bb77a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef775ad0-b1a9-4254-ab6f-304558bb77a1.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [
@@ -16623,7 +16623,7 @@
         },
         {
             "id": "5ee687f2-f19b-59a0-b6c9-e881606998a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bbd379-6728-4c6b-b375-295926fe6b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bbd379-6728-4c6b-b375-295926fe6b00.jpg?1",
             "name": "Zombie Berserker",
             "text": "",
             "colours": [
@@ -16659,7 +16659,7 @@
         },
         {
             "id": "1e44480c-8578-5b74-b4d4-a5e3a4729f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58def55-f2ca-4c41-b891-c32e5220fc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58def55-f2ca-4c41-b891-c32e5220fc66.jpg?1",
             "name": "Demon Berserker",
             "text": "",
             "colours": [
@@ -16695,7 +16695,7 @@
         },
         {
             "id": "ff07ac7d-b9fe-5fa5-8402-45ce70e5a9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029c9790-d5f3-4fe2-a2f5-6da5d27de835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029c9790-d5f3-4fe2-a2f5-6da5d27de835.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "11581c55-ec27-5d91-83fe-0b7cd7d7257a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142bbbe1-4446-4d80-b82d-0df8ef17eac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142bbbe1-4446-4d80-b82d-0df8ef17eac1.jpg?1",
             "name": "Dwarf Berserker",
             "text": "",
             "colours": [
@@ -16766,7 +16766,7 @@
         },
         {
             "id": "6e8cb570-6b9b-5a4e-b1a5-dcae91a6b8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53abaa-b316-496d-9351-318a9dd9de4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53abaa-b316-496d-9351-318a9dd9de4d.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -16801,7 +16801,7 @@
         },
         {
             "id": "f7683af3-3bef-5b9d-8b81-9e78afc97371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e07758f-0d1c-47d9-ba5a-43bc2a7423cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e07758f-0d1c-47d9-ba5a-43bc2a7423cd.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16836,7 +16836,7 @@
         },
         {
             "id": "ba573e3a-81c4-55a0-97c6-2aa6f0c7269e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118d0655-5719-4512-8bc1-fe759669811b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118d0655-5719-4512-8bc1-fe759669811b.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -16872,7 +16872,7 @@
         },
         {
             "id": "dbeac9d3-edd3-574a-9bdb-c8d419f6a373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8869a8cc-d196-417f-bba5-5ed31bae6a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8869a8cc-d196-417f-bba5-5ed31bae6a18.jpg?1",
             "name": "Troll Warrior",
             "text": "",
             "colours": [
@@ -16908,7 +16908,7 @@
         },
         {
             "id": "bc456a8c-3810-5b38-aa34-abc21261ee4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db39e3b-fad4-4c9b-911f-69883ac7e0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db39e3b-fad4-4c9b-911f-69883ac7e0e1.jpg?1",
             "name": "Icy Manalith",
             "text": "",
             "colours": [],
@@ -16939,7 +16939,7 @@
         },
         {
             "id": "51e0d2f4-5611-5adb-9795-be83c6b7d516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ce1236-ec2f-4cd1-9701-ba6ead74c220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ce1236-ec2f-4cd1-9701-ba6ead74c220.jpg?1",
             "name": "Replicated Ring",
             "text": "",
             "colours": [],
@@ -16970,7 +16970,7 @@
         },
         {
             "id": "fc9da973-a626-5457-808e-f83f5ae6c6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae9f454-4f8c-4123-9886-674bc439dfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae9f454-4f8c-4123-9886-674bc439dfe7.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17001,7 +17001,7 @@
         },
         {
             "id": "4e0e50a2-acf1-5745-b605-8a1800110fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b149bbf-5d2a-4f7e-aa87-23edd5848cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b149bbf-5d2a-4f7e-aa87-23edd5848cde.jpg?1",
             "name": "Kaya the Inexorable Emblem",
             "text": "",
             "colours": [],
@@ -17029,7 +17029,7 @@
         },
         {
             "id": "e887464c-161a-5e13-9b5b-1335a033042b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62490ac-4838-4b68-baff-18d9823a2a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62490ac-4838-4b68-baff-18d9823a2a7f.jpg?1",
             "name": "Tibalt, Cosmic Impostor Emblem",
             "text": "",
             "colours": [],
@@ -17057,7 +17057,7 @@
         },
         {
             "id": "6ffda757-579d-563a-862f-3c64eab1edb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53162f62-5327-4f2d-8f34-e90de2a1c818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53162f62-5327-4f2d-8f34-e90de2a1c818.jpg?1",
             "name": "Tyvar Kell Emblem",
             "text": "",
             "colours": [],
@@ -17085,7 +17085,7 @@
         },
         {
             "id": "8e042dc9-2a57-525d-b26f-eae5ef1fdadf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb02637f-1385-4d3d-8dc0-de513db7633a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb02637f-1385-4d3d-8dc0-de513db7633a.jpg?1",
             "name": "Foretell",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/KLD.json
+++ b/Assets/Resources/Sets/KLD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c31d87c4-6781-55fe-ba94-0ca2e7bc1594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f92174-f38f-4623-a5f7-f5be7f7dcc9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f92174-f38f-4623-a5f7-f5be7f7dcc9d.jpg?1",
             "name": "Acrobatic Maneuver",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "0ca3c205-8e19-50f7-8495-4cbc8f9041ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956adc86-c0d9-4408-837e-b5def19af1ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956adc86-c0d9-4408-837e-b5def19af1ec.jpg?1",
             "name": "Aerial Responder",
             "text": "Flying, vigilance, lifelink",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "efefd57d-cce8-56b2-9f1e-939472dc779f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb7541-7a27-40a5-aabd-fce26df03485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb7541-7a27-40a5-aabd-fce26df03485.jpg?1",
             "name": "Aetherstorm Roc",
             "text": "Flying\nWhenever Aetherstorm Roc or another creature enters the battlefield under your control, you get {E} (an energy counter).\nWhenever Aetherstorm Roc attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it and tap up to one target creature defending player controls.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "b06601ed-b1ae-5e9a-9da8-f043fed7b3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3920f7d-8559-40f8-95be-860c16bf7700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3920f7d-8559-40f8-95be-860c16bf7700.jpg?1",
             "name": "Angel of Invention",
             "text": "Flying, vigilance, lifelink\nFabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)\nOther creatures you control get +1/+1.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "d8dcf5ee-fd60-53a0-b89e-2849dcde901f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b2f55-1e09-490e-8f7e-bfde85a91ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b2f55-1e09-490e-8f7e-bfde85a91ac4.jpg?1",
             "name": "Authority of the Consuls",
             "text": "Creatures your opponents control enter the battlefield tapped.\nWhenever a creature enters the battlefield under an opponent's control, you gain 1 life.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "5d3e543d-bfd1-5bcc-a335-0886bee0cf3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97b0767-4308-4e5d-bc12-6cf8d8724797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97b0767-4308-4e5d-bc12-6cf8d8724797.jpg?1",
             "name": "Aviary Mechanic",
             "text": "When Aviary Mechanic enters the battlefield, you may return another permanent you control to its owner's hand.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "bd45ddb7-aa4f-5b94-88b7-57c8d4060cf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e09a4-93d0-4ed7-bbee-82108672d5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e09a4-93d0-4ed7-bbee-82108672d5f8.jpg?1",
             "name": "Built to Last",
             "text": "Target creature gets +2/+2 until end of turn. If it's an artifact creature, it gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "8be2a739-990a-5c4d-a723-ca3875735b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c20018-4446-4c2b-bdc5-53fcf1fbc3bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c20018-4446-4c2b-bdc5-53fcf1fbc3bf.jpg?1",
             "name": "Captured by the Consulate",
             "text": "Enchant creature you don't control\nEnchanted creature can't attack.\nWhenever an opponent casts a spell, if it has a single target, change the target to enchanted creature if able.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "1dddca31-23ef-59bc-8e31-f8467082079a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b10947b-c276-41c4-b72c-efcddd94d13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b10947b-c276-41c4-b72c-efcddd94d13b.jpg?1",
             "name": "Cataclysmic Gearhulk",
             "text": "Vigilance\nWhen Cataclysmic Gearhulk enters the battlefield, each player chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents he or she controls, then sacrifices the rest.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "a8225a76-2a58-5325-9616-2868821b8840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c92238-7765-48ee-a799-9e8b68ec118d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c92238-7765-48ee-a799-9e8b68ec118d.jpg?1",
             "name": "Consulate Surveillance",
             "text": "When Consulate Surveillance enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}{E}: Prevent all damage that would be dealt to you this turn by a source of your choice.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "bfaa801a-00c1-585e-8437-e81396b6a7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b66d65-1981-4abf-b27f-e9a1b2800110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b66d65-1981-4abf-b27f-e9a1b2800110.jpg?1",
             "name": "Consul's Shieldguard",
             "text": "When Consul's Shieldguard enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Consul's Shieldguard attacks, you may pay {E}. If you do, another target attacking creature gains indestructible until end of turn.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "7c9d36be-d510-551a-b755-f812968f5d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dcaec6-4cb9-46d8-aed1-46f33c67dff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dcaec6-4cb9-46d8-aed1-46f33c67dff2.jpg?1",
             "name": "Eddytrail Hawk",
             "text": "Flying\nWhen Eddytrail Hawk enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Eddytrail Hawk attacks, you may pay {E}. If you do, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "fc0dc38f-4342-5bd0-851e-28d3df2ed9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b6c8f3-76b7-4954-8608-023304cdec3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b6c8f3-76b7-4954-8608-023304cdec3e.jpg?1",
             "name": "Fairgrounds Warden",
             "text": "When Fairgrounds Warden enters the battlefield, exile target creature an opponent controls until Fairgrounds Warden leaves the battlefield.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "26b455c8-f3dd-5b58-a02d-e87dfda4c5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf09deb-2607-4eb0-94a7-9584e771fdfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf09deb-2607-4eb0-94a7-9584e771fdfb.jpg?1",
             "name": "Fragmentize",
             "text": "Destroy target artifact or enchantment with converted mana cost 4 or less.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "33354b1a-4224-5379-8a97-ff4f232b0875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00f27a7-9e92-4fbf-baa8-f47a5eee48a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00f27a7-9e92-4fbf-baa8-f47a5eee48a6.jpg?1",
             "name": "Fumigate",
             "text": "Destroy all creatures. You gain 1 life for each creature destroyed this way.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "ff1947a9-823d-50f7-8a63-ff3d65d2a292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c6a9d-6169-40f8-8b3e-53ebf75be663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c6a9d-6169-40f8-8b3e-53ebf75be663.jpg?1",
             "name": "Gearshift Ace",
             "text": "First strike\nWhenever Gearshift Ace crews a Vehicle, that Vehicle gains first strike until end of turn.",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "4cd3c928-9dec-50c4-af10-8568f154e54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e39e79b-2755-4fb4-86b5-b6e350ce9514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e39e79b-2755-4fb4-86b5-b6e350ce9514.jpg?1",
             "name": "Glint-Sleeve Artisan",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "77add2f5-00c6-59fc-9349-4f364ec7a682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9ed217-8378-4a58-a00d-fa4e4cb27c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9ed217-8378-4a58-a00d-fa4e4cb27c9d.jpg?1",
             "name": "Herald of the Fair",
             "text": "When Herald of the Fair enters the battlefield, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "ae790286-c000-5b15-ae41-0a9ad9cca1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2921c95e-bf2f-409b-a41d-86d873690562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2921c95e-bf2f-409b-a41d-86d873690562.jpg?1",
             "name": "Impeccable Timing",
             "text": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "7cc84310-01a8-5a70-9a8e-9b5d48243262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca67eb3-44e7-4315-9808-870057915a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca67eb3-44e7-4315-9808-870057915a84.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "32cecb79-3b0f-5287-9317-94944002e9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb6beb3-1669-4e7b-9c76-65424673eb36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb6beb3-1669-4e7b-9c76-65424673eb36.jpg?1",
             "name": "Master Trinketeer",
             "text": "Servos and Thopters you control get +1/+1.\n{3}{W}: Create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "f489a8fa-dcac-523f-a2f3-4c58f5fe441b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a22cf8-4441-48ab-8adc-ae071cbc5999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a22cf8-4441-48ab-8adc-ae071cbc5999.jpg?1",
             "name": "Ninth Bridge Patrol",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Ninth Bridge Patrol.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "0a34b9bd-48e9-5565-9335-d330fb32b7a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d28b806-88a3-4852-982e-0d6be0a2edac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d28b806-88a3-4852-982e-0d6be0a2edac.jpg?1",
             "name": "Pressure Point",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "8b3e8239-b5fc-5e9a-9bf7-5bea2efddb10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee60224-960a-4f92-996a-7b0b878109e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee60224-960a-4f92-996a-7b0b878109e4.jpg?1",
             "name": "Propeller Pioneer",
             "text": "Flying\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "bb851d66-b3e4-5bf0-a418-88fb8caf4a99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60e2ac4-f21f-4232-abc8-db078472408b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60e2ac4-f21f-4232-abc8-db078472408b.jpg?1",
             "name": "Refurbish",
             "text": "Return target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "e793472e-a1d9-5e8f-a301-990c5422619f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e44502-f4e4-440a-92b1-97bfb6314820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e44502-f4e4-440a-92b1-97bfb6314820.jpg?1",
             "name": "Revoke Privileges",
             "text": "Enchant creature\nEnchanted creature can't attack, block, or crew Vehicles.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "afa6c398-1eb8-5a69-953a-9f13aee76d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0c60-78e2-4e1c-a6ad-6f1c001ad7ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0c60-78e2-4e1c-a6ad-6f1c001ad7ee.jpg?1",
             "name": "Servo Exhibition",
             "text": "Create two 1/1 colorless Servo artifact creature tokens.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "e6b6ad27-7baf-5fb2-a4e2-f821146be223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b951bc89-be0b-4330-8a13-e196e084d53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b951bc89-be0b-4330-8a13-e196e084d53c.jpg?1",
             "name": "Skyswirl Harrier",
             "text": "Flying",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "e3bae8e0-8c3a-5323-8898-163615c849f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dd4948-dc79-4fe5-b4a0-fb257058f9dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dd4948-dc79-4fe5-b4a0-fb257058f9dd.jpg?1",
             "name": "Skywhaler's Shot",
             "text": "Destroy target creature with power 3 or greater. Scry 1.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "eafa69f2-c89d-5d7f-817c-7df423033359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cef3bf2-55cf-4f42-9ec0-fa921ef22311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cef3bf2-55cf-4f42-9ec0-fa921ef22311.jpg?1",
             "name": "Tasseled Dromedary",
             "text": "",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "dcac3976-5bd3-534b-8da8-343d1616f851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edc7c57-9298-4fad-a0c2-4b75b944e2ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edc7c57-9298-4fad-a0c2-4b75b944e2ce.jpg?1",
             "name": "Thriving Ibex",
             "text": "When Thriving Ibex enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Ibex attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "0a522504-ac7f-5600-a284-b973b9133f22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daae3dae-3297-4750-9bca-c8aadaf815ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daae3dae-3297-4750-9bca-c8aadaf815ea.jpg?1",
             "name": "Toolcraft Exemplar",
             "text": "At the beginning of combat on your turn, if you control an artifact, Toolcraft Exemplar gets +2/+1 until end of turn. If you control three or more artifacts, it also gains first strike until end of turn.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "d66ab00c-7c09-5c3d-a78c-869060ca2338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79eefb-50a4-41c4-93cf-378fa546f539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79eefb-50a4-41c4-93cf-378fa546f539.jpg?1",
             "name": "Trusty Companion",
             "text": "Vigilance\nTrusty Companion can't attack alone.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "91ea152b-c0fb-5ee9-bc1f-777ff2f5df6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918691b1-f927-4027-a444-adc418f3ab16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918691b1-f927-4027-a444-adc418f3ab16.jpg?1",
             "name": "Visionary Augmenter",
             "text": "Fabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "10d13bc5-171d-5c3e-8650-017cab213d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57300d02-faad-43b2-afa9-023d1c3a0901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57300d02-faad-43b2-afa9-023d1c3a0901.jpg?1",
             "name": "Wispweaver Angel",
             "text": "Flying\nWhen Wispweaver Angel enters the battlefield, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "a8b26f48-48b6-5f60-aba4-5b23634f8cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f99614-45e2-4688-8403-f3a6b9162b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f99614-45e2-4688-8403-f3a6b9162b08.jpg?1",
             "name": "Aether Meltdown",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature or Vehicle\nWhen Aether Meltdown enters the battlefield, you get {E}{E} (two energy counters).\nEnchanted permanent gets -4/-0.",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "e1a652fb-9348-53a5-aae5-738e2660f53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b5580-ee23-4d65-a2b3-82475d6faf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b5580-ee23-4d65-a2b3-82475d6faf8e.jpg?1",
             "name": "Aether Theorist",
             "text": "When Aether Theorist enters the battlefield, you get {E}{E}{E} (three energy counters).\n{T}, Pay {E}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "3f20f026-afad-5796-bfe8-d8ba042d6f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fe4768-fe18-4698-885d-86f5ad150125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fe4768-fe18-4698-885d-86f5ad150125.jpg?1",
             "name": "Aether Tradewinds",
             "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "65446995-0178-5d75-9f64-f7b58e94feae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55127a25-dc64-4f26-ae50-ed7247c22ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55127a25-dc64-4f26-ae50-ed7247c22ae6.jpg?1",
             "name": "Aethersquall Ancient",
             "text": "Flying\nAt the beginning of your upkeep, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}{E}{E}{E}{E}{E}: Return all other creatures to their owners' hands. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1317,7 +1317,7 @@
         },
         {
             "id": "1d04b55f-5403-54fc-8813-e6b1757fc41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5ed8e-4804-4042-8a1d-ad24c6846816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5ed8e-4804-4042-8a1d-ad24c6846816.jpg?1",
             "name": "Ceremonious Rejection",
             "text": "Counter target colorless spell.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "58339c18-3c9c-575d-9677-937bad434837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf453f-54be-4346-831d-a0434aa086fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf453f-54be-4346-831d-a0434aa086fe.jpg?1",
             "name": "Confiscation Coup",
             "text": "Choose target artifact or creature. You get {E}{E}{E}{E} (four energy counters), then you may pay an amount of {E} equal to that permanent's converted mana cost. If you do, gain control of it.",
             "colours": [
@@ -1381,7 +1381,7 @@
         },
         {
             "id": "ee5e91e2-ae65-56d4-a4d3-7c9890c5cd19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598054a-26fa-40e7-8497-3da8eaf12aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598054a-26fa-40e7-8497-3da8eaf12aac.jpg?1",
             "name": "Curio Vendor",
             "text": "",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "a23c9e44-c15c-5dd3-9f7b-dd188e83f9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4a6d56-9bed-444c-aae8-383c315779a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4a6d56-9bed-444c-aae8-383c315779a0.jpg?1",
             "name": "Disappearing Act",
             "text": "As an additional cost to cast Disappearing Act, return a permanent you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "c0d9f0a6-e438-5fbf-8e0f-e8320ddbc751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb59045-2743-48ae-8063-727e551b1c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb59045-2743-48ae-8063-727e551b1c41.jpg?1",
             "name": "Dramatic Reversal",
             "text": "Untap all nonland permanents you control.",
             "colours": [
@@ -1479,7 +1479,7 @@
         },
         {
             "id": "6daf1bd3-b497-5036-9a52-d3370b4a3c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae3b1f-6a31-4a8a-9e44-063f8f670134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae3b1f-6a31-4a8a-9e44-063f8f670134.jpg?1",
             "name": "Era of Innovation",
             "text": "Whenever an artifact or Artificer enters the battlefield under your control, you may pay {1}. If you do, you get {E}{E} (two energy counters).\nPay {E}{E}{E}{E}{E}{E}, Sacrifice Era of Innovation: Draw three cards.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "ef6eb655-d2da-5105-9bb9-f7c36304b736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962dc573-612d-434b-82fb-af9c3e3c9aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962dc573-612d-434b-82fb-af9c3e3c9aca.jpg?1",
             "name": "Experimental Aviator",
             "text": "Flying\nWhen Experimental Aviator enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "2236b149-e6bf-553f-8f5d-0812f54f0d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900f91-cb17-4f99-a5ce-15819369beb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900f91-cb17-4f99-a5ce-15819369beb8.jpg?1",
             "name": "Failed Inspection",
             "text": "Counter target spell. Draw a card, then discard a card.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "2bf1d408-f956-5b23-80c5-2486eab84a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d8327-6ec2-4d43-b254-b04407612715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d8327-6ec2-4d43-b254-b04407612715.jpg?1",
             "name": "Gearseeker Serpent",
             "text": "Gearseeker Serpent costs {1} less to cast for each artifact you control.\n{5}{U}: Gearseeker Serpent can't be blocked this turn.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "817cf5fb-6268-54b7-afc9-d78cbd5c16cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1673d-c92c-43be-8648-af7fbc790421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1673d-c92c-43be-8648-af7fbc790421.jpg?1",
             "name": "Glimmer of Genius",
             "text": "Scry 2, then draw two cards. You get {E}{E} (two energy counters).",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "a3a2c344-9ca7-55ce-ab88-c2568d031841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa5b030-23a6-4fca-b318-c580e3ea2bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa5b030-23a6-4fca-b318-c580e3ea2bad.jpg?1",
             "name": "Glint-Nest Crane",
             "text": "Flying\nWhen Glint-Nest Crane enters the battlefield, look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "3791cc91-b81a-5783-9408-62e5db89e87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c871fa-d333-4c73-9d5c-f5cfec5954da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c871fa-d333-4c73-9d5c-f5cfec5954da.jpg?1",
             "name": "Hightide Hermit",
             "text": "Defender\nWhen Hightide Hermit enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}{E}: Hightide Hermit can attack this turn as though it didn't have defender.",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "9ae8f83f-8bfc-59b1-a569-515d895d5d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eafb2bb-58bf-4c6b-ae8f-91bcea12c7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eafb2bb-58bf-4c6b-ae8f-91bcea12c7d2.jpg?1",
             "name": "Insidious Will",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 You may choose new targets for target spell.\n\u2022 Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "08f0d733-8b47-5cf6-b642-4712e50045ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826b9080-2b6d-4f4e-93a6-cf977d40654f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826b9080-2b6d-4f4e-93a6-cf977d40654f.jpg?1",
             "name": "Janjeet Sentry",
             "text": "When Janjeet Sentry enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}{E}: You may tap or untap target artifact or creature.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "647980d2-fba9-5dd1-b6aa-da3eb80c8295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e9472-c710-474e-b8e9-54662330a592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e9472-c710-474e-b8e9-54662330a592.jpg?1",
             "name": "Long-Finned Skywhale",
             "text": "Flying\nLong-Finned Skywhale can block only creatures with flying.",
             "colours": [
@@ -1813,7 +1813,7 @@
         },
         {
             "id": "c05a374a-dbdc-58fd-b331-2e0d7dcb6288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41f907f-4512-4c5d-827b-fef04613d641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41f907f-4512-4c5d-827b-fef04613d641.jpg?1",
             "name": "Malfunction",
             "text": "Enchant artifact or creature\nWhen Malfunction enters the battlefield, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -1847,7 +1847,7 @@
         },
         {
             "id": "6565451f-499a-545d-b40e-2e7dd99d6d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ac06f9-5c9f-4d4f-be57-7c58bd8da568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ac06f9-5c9f-4d4f-be57-7c58bd8da568.jpg?1",
             "name": "Metallurgic Summonings",
             "text": "Whenever you cast an instant or sorcery spell, create an X/X colorless Construct artifact creature token, where X is that spell's converted mana cost.\n{3}{U}{U}, Exile Metallurgic Summonings: Return all instant and sorcery cards from your graveyard to your hand. Activate this ability only if you control six or more artifacts.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "f827983d-6990-53fb-9364-16ea109f5ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6c31d1-6e2a-41b3-aa4f-d30a7cd997d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6c31d1-6e2a-41b3-aa4f-d30a7cd997d2.jpg?1",
             "name": "Minister of Inquiries",
             "text": "When Minister of Inquiries enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "b464ba9c-abdb-5294-8c9a-6c0cde5ae7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dbf333-23b5-47d9-9e55-1e8fbd5a72cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dbf333-23b5-47d9-9e55-1e8fbd5a72cb.jpg?1",
             "name": "Nimble Innovator",
             "text": "When Nimble Innovator enters the battlefield, draw a card.",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "19dfefa0-5679-58d2-adce-11051f57763a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b30a7-13e8-408e-a758-60e6e9290808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b30a7-13e8-408e-a758-60e6e9290808.jpg?1",
             "name": "Padeem, Consul of Innovation",
             "text": "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the highest converted mana cost or tied for the highest converted mana cost, draw a card.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "0bafe6f5-e6bf-5791-978d-11d8ffb6c7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e50157-bf49-4c5f-9b8a-bf73484e63a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e50157-bf49-4c5f-9b8a-bf73484e63a5.jpg?1",
             "name": "Paradoxical Outcome",
             "text": "Return any number of target nonland, nontoken permanents you control to their owners' hands. Draw a card for each card returned to your hand this way.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "a0353866-85e4-545b-88ae-185095debe42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea63dad-6afe-464e-ab19-fabd9709c6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea63dad-6afe-464e-ab19-fabd9709c6f9.jpg?1",
             "name": "Revolutionary Rebuff",
             "text": "Counter target nonartifact spell unless its controller pays {2}.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "b38939e8-00a3-5502-9df5-e497ef15efb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42237c1d-5579-4c15-b97b-bcaaaf0b1ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42237c1d-5579-4c15-b97b-bcaaaf0b1ab2.jpg?1",
             "name": "Saheeli's Artistry",
             "text": "Choose one or both \u2014\n\u2022 Create a token that's a copy of target artifact.\n\u2022 Create a token that's a copy of target creature, except it's an artifact in addition to its other types.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "ac7aafa0-d22b-5c13-aa7c-1a7496e9e7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f0fb0-4831-4759-b58c-05c4be90a4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f0fb0-4831-4759-b58c-05c4be90a4af.jpg?1",
             "name": "Select for Inspection",
             "text": "Return target tapped creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2114,7 +2114,7 @@
         },
         {
             "id": "38add4d6-14c8-5b19-9ac0-061268c449d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37900980-c2e2-4b70-8511-405f0a8389cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37900980-c2e2-4b70-8511-405f0a8389cd.jpg?1",
             "name": "Shrewd Negotiation",
             "text": "Exchange control of target artifact you control and target artifact or creature you don't control.",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "b737a8de-5cb7-59de-84a3-9df2e537474c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3700b0-d6b5-4967-add8-3adc2bc8ca86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3700b0-d6b5-4967-add8-3adc2bc8ca86.jpg?1",
             "name": "Tezzeret's Ambition",
             "text": "Draw three cards. If you control no artifacts, discard a card.",
             "colours": [
@@ -2178,7 +2178,7 @@
         },
         {
             "id": "f723451c-d2da-5985-a93e-36eb2669adcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a112a3-ae4e-4aba-86ac-74a8960a6326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a112a3-ae4e-4aba-86ac-74a8960a6326.jpg?1",
             "name": "Thriving Turtle",
             "text": "When Thriving Turtle enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Turtle attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "2fbc9f1c-129a-51ee-9651-366e556d8b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52868cb-087e-4f91-91bc-455f2e2e7cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52868cb-087e-4f91-91bc-455f2e2e7cd7.jpg?1",
             "name": "Torrential Gearhulk",
             "text": "Flash\nWhen Torrential Gearhulk enters the battlefield, you may cast target instant card from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "9f6ac51b-f9bf-5788-aad4-23983c6c7409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572c15ab-2229-4536-b586-638ec77d9cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572c15ab-2229-4536-b586-638ec77d9cb7.jpg?1",
             "name": "Vedalken Blademaster",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2282,7 +2282,7 @@
         },
         {
             "id": "5ae5e1fd-a5de-5485-bcb4-be5f530fa974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b115a65-e273-4264-9db7-317e1855f492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b115a65-e273-4264-9db7-317e1855f492.jpg?1",
             "name": "Weldfast Wingsmith",
             "text": "Whenever an artifact enters the battlefield under your control, Weldfast Wingsmith gains flying until end of turn.",
             "colours": [
@@ -2317,7 +2317,7 @@
         },
         {
             "id": "e1b8fc9f-e974-51cd-972f-624b3e9d0c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e227a63-abea-494e-9d66-6ff0a3da14ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e227a63-abea-494e-9d66-6ff0a3da14ca.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "992c07f2-f9b9-5c7a-a66c-efd497c3c9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5a14b-8fd2-4a62-90dc-4adb1cee4505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5a14b-8fd2-4a62-90dc-4adb1cee4505.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "2711fdbc-e7b9-53a1-a438-c16f38118ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce02ef8-1731-43a9-9bd0-9ec592e3883f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce02ef8-1731-43a9-9bd0-9ec592e3883f.jpg?1",
             "name": "Aetherborn Marauder",
             "text": "Flying, lifelink\nWhen Aetherborn Marauder enters the battlefield, move any number of +1/+1 counters from other permanents you control onto Aetherborn Marauder.",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "b51dbe10-b24d-5783-aaa7-13f487f5812f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cb628e-fa83-4d7e-92cb-8779ea02193f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cb628e-fa83-4d7e-92cb-8779ea02193f.jpg?1",
             "name": "Ambitious Aetherborn",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "0f863059-5f1b-5376-987b-edcf1cc222fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c99736-5c9c-4d2f-946d-05606fcdd039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c99736-5c9c-4d2f-946d-05606fcdd039.jpg?1",
             "name": "Demon of Dark Schemes",
             "text": "Flying\nWhen Demon of Dark Schemes enters the battlefield, all other creatures get -2/-2 until end of turn.\nWhenever another creature dies, you get {E} (an energy counter).\n{2}{B}, Pay {E}{E}{E}{E}: Put target creature card from a graveyard onto the battlefield under your control tapped.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "06ad011a-2e2a-57e9-b9dc-f42375f940ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f91094-5214-4268-8f91-5ba0b891256d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f91094-5214-4268-8f91-5ba0b891256d.jpg?1",
             "name": "Dhund Operative",
             "text": "As long as you control an artifact, Dhund Operative gets +1/+0 and has deathtouch. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "0e1ae14b-5c2e-5354-8cb9-6c54b9eca962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06750380-a9a9-4ab4-a03b-d4d35a31132a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06750380-a9a9-4ab4-a03b-d4d35a31132a.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "b0675cda-a353-5972-85e6-3ff94770989b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf7bb52-013f-4d8d-b4ea-53d1fa4bb694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf7bb52-013f-4d8d-b4ea-53d1fa4bb694.jpg?1",
             "name": "Die Young",
             "text": "Choose target creature. You get {E}{E} (two energy counters), then you may pay any amount of {E}. The creature gets -1/-1 until end of turn for each {E} paid this way.",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "fed26485-0d0f-5a0a-ad3a-68120185ca43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81591264-1342-418d-b5c6-9d700b729c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81591264-1342-418d-b5c6-9d700b729c51.jpg?1",
             "name": "Dukhara Scavenger",
             "text": "When Dukhara Scavenger enters the battlefield, you may put target artifact or creature card from your graveyard on top of your library.",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "0789c94b-9c62-5d17-b0b0-f2766b26986f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf09460-2e54-4434-ab03-95eef77265dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf09460-2e54-4434-ab03-95eef77265dc.jpg?1",
             "name": "Eliminate the Competition",
             "text": "As an additional cost to cast Eliminate the Competition, sacrifice X creatures.\nDestroy X target creatures.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "dd57be96-6ac2-5330-9c19-853440f68dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f90f877-4033-4892-a6e7-22d2b393c65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f90f877-4033-4892-a6e7-22d2b393c65d.jpg?1",
             "name": "Embraal Bruiser",
             "text": "Embraal Bruiser enters the battlefield tapped.\nEmbraal Bruiser has menace as long as you control an artifact.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "b6d18a41-f810-52b1-82c3-25c6630999f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7693c10-5ebb-4896-bb60-63d03577dd60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7693c10-5ebb-4896-bb60-63d03577dd60.jpg?1",
             "name": "Essence Extraction",
             "text": "Essence Extraction deals 3 damage to target creature and you gain 3 life.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "ff08b208-bbbf-5ffd-a0ae-9bd7bd132b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7706bbb1-c94a-4169-9f12-a54cfcc3a7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7706bbb1-c94a-4169-9f12-a54cfcc3a7ad.jpg?1",
             "name": "Fortuitous Find",
             "text": "Choose one or both \u2014\n\u2022 Return target artifact card from your graveyard to your hand.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "662d0b2e-9cf0-56e6-bb80-a00a024124f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4313802f-b969-47d0-b4aa-b049df0755c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4313802f-b969-47d0-b4aa-b049df0755c0.jpg?1",
             "name": "Foundry Screecher",
             "text": "Flying\nFoundry Screecher gets +1/+0 as long as you control an artifact.",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "a1e03ebe-0ea4-5fdd-bdbe-0d401002ceaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bf6ae3-352b-416c-a404-de51cd624198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bf6ae3-352b-416c-a404-de51cd624198.jpg?1",
             "name": "Fretwork Colony",
             "text": "Fretwork Colony can't block.\nAt the beginning of your upkeep, put a +1/+1 counter on Fretwork Colony and you lose 1 life.",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "7475ced3-0585-55c6-a3ee-0efb3fe77c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7735ecda-9bb0-4ef9-86b2-16e5b6592e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7735ecda-9bb0-4ef9-86b2-16e5b6592e61.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. For as long as that card remains exiled, you may look at it, you may cast it, and you may spend mana as though it were mana of any type to cast it.",
             "colours": [
@@ -2861,7 +2861,7 @@
         },
         {
             "id": "9f6622b0-8f40-57c5-9ab5-509faa771f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe68b484-cc8d-4a0b-94c2-1fec9090dfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe68b484-cc8d-4a0b-94c2-1fec9090dfcd.jpg?1",
             "name": "Harsh Scrutiny",
             "text": "Target opponent reveals his or her hand. You choose a creature card from it. That player discards that card. Scry 1.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "cd103a17-51a8-5d27-957f-5720a3372171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5bfff7-aa23-42ef-af1b-bc3304bd3a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5bfff7-aa23-42ef-af1b-bc3304bd3a17.jpg?1",
             "name": "Lawless Broker",
             "text": "When Lawless Broker dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "f7d85f15-6da9-52b7-889c-47b7fbea6da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0bb8da-ad05-43d9-aba3-d917744168fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0bb8da-ad05-43d9-aba3-d917744168fe.jpg?1",
             "name": "Live Fast",
             "text": "You draw two cards, lose 2 life, and get {E}{E} (two energy counters).",
             "colours": [
@@ -2960,7 +2960,7 @@
         },
         {
             "id": "06023b8e-fb5a-5189-912e-cef93a8731c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d0e447-d98e-43d5-9b53-166221c34be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d0e447-d98e-43d5-9b53-166221c34be2.jpg?1",
             "name": "Lost Legacy",
             "text": "Name a nonartifact, nonland card. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles his or her library, then draws a card for each card exiled from hand this way.",
             "colours": [
@@ -2992,7 +2992,7 @@
         },
         {
             "id": "75dc9c88-dc56-5176-920a-6b1f29d46496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a96feb-accc-4c30-8ecd-7d9272ebd45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a96feb-accc-4c30-8ecd-7d9272ebd45b.jpg?1",
             "name": "Make Obsolete",
             "text": "Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "fb6344e8-3412-57c9-8bca-e9a02708ac15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358a87a3-c76e-4c7d-ac84-464894ed9a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358a87a3-c76e-4c7d-ac84-464894ed9a31.jpg?1",
             "name": "Marionette Master",
             "text": "Fabricate 3 (When this creature enters the battlefield, put three +1/+1 counters on it or create three 1/1 colorless Servo artifact creature tokens.)\nWhenever an artifact you control is put into a graveyard from the battlefield, target opponent loses life equal to Marionette Master's power.",
             "colours": [
@@ -3059,7 +3059,7 @@
         },
         {
             "id": "7db7cd2f-bc33-5268-b46a-5ea753d8cd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4cd13a-66b6-4c65-a5a0-82f93145d16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4cd13a-66b6-4c65-a5a0-82f93145d16a.jpg?1",
             "name": "Maulfist Squad",
             "text": "Menace\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "01b149da-86ae-544d-bb1e-7ba4ada438a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14875840-044d-482f-845e-79240cad66f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14875840-044d-482f-845e-79240cad66f3.jpg?1",
             "name": "Midnight Oil",
             "text": "Midnight Oil enters the battlefield with seven hour counters on it.\nAt the beginning of your draw step, draw an additional card and remove two hour counters from Midnight Oil.\nYour maximum hand size is equal to the number of hour counters on Midnight Oil.\nWhenever you discard a card, you lose 1 life.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "af14876e-5471-58ff-ab13-9b7bc93e019f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317ff1a-9104-44e6-acb9-5ee09648138f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317ff1a-9104-44e6-acb9-5ee09648138f.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "55b34d5e-5696-550f-8574-038a1dc56c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f26722e-e7fc-4a90-9a5b-cefda096e5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f26722e-e7fc-4a90-9a5b-cefda096e5fe.jpg?1",
             "name": "Morbid Curiosity",
             "text": "As an additional cost to cast Morbid Curiosity, sacrifice an artifact or creature.\nDraw cards equal to the converted mana cost of the sacrificed permanent.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "5749731e-46d9-554f-98cd-3b368b8e44c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb03b7-e5a2-4ba1-b0ec-bfbfeaa94efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb03b7-e5a2-4ba1-b0ec-bfbfeaa94efd.jpg?1",
             "name": "Night Market Lookout",
             "text": "Whenever Night Market Lookout becomes tapped, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "cfbdefd7-7a88-5f5f-af0d-e0f6551f23cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f86e5fe-8723-4494-b4cc-b7ac3a047bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f86e5fe-8723-4494-b4cc-b7ac3a047bd1.jpg?1",
             "name": "Noxious Gearhulk",
             "text": "Menace\nWhen Noxious Gearhulk enters the battlefield, you may destroy another target creature. If a creature is destroyed this way, you gain life equal to its toughness.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "e5547975-b09b-50a3-9cec-318e4e161a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a323a495-e154-4541-ba4e-25b66b84d692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a323a495-e154-4541-ba4e-25b66b84d692.jpg?1",
             "name": "Ovalchase Daredevil",
             "text": "Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "98e59455-09f9-5bf8-9e2b-793303579de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b73ce-cb25-4104-bccd-6b6a131790a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b73ce-cb25-4104-bccd-6b6a131790a9.jpg?1",
             "name": "Prakhata Club Security",
             "text": "",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "86a47955-77ec-5226-8cc0-15d77f790c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e53cd8b-18f8-4950-84d4-7aafa26c7ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e53cd8b-18f8-4950-84d4-7aafa26c7ae4.jpg?1",
             "name": "Rush of Vitality",
             "text": "Target creature gets +1/+0 and gains lifelink and indestructible until end of turn. (Damage dealt by that creature also causes its controller to gain that much life, and it can't be destroyed by damage or effects that say \"destroy.\")",
             "colours": [
@@ -3362,7 +3362,7 @@
         },
         {
             "id": "e78171d2-ca60-579b-b4bf-c8d85f3feacc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a8cb98-7ee7-4f90-bfba-0a406a5e6d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a8cb98-7ee7-4f90-bfba-0a406a5e6d6b.jpg?1",
             "name": "Subtle Strike",
             "text": "Choose one or both \u2014\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "3f1b90c9-b8df-5930-b65c-68e88c12d120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89427f0-08d5-49a1-9684-ebe8769430f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89427f0-08d5-49a1-9684-ebe8769430f6.jpg?1",
             "name": "Syndicate Trafficker",
             "text": "{1}, Sacrifice an artifact: Put a +1/+1 counter on Syndicate Trafficker. It gains indestructible until end of turn.",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "b440aed5-2892-5f77-90c9-ad29efe9e6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba911b-6a52-4430-8f61-63bdae25c16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba911b-6a52-4430-8f61-63bdae25c16a.jpg?1",
             "name": "Thriving Rats",
             "text": "When Thriving Rats enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Rats attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "3186d105-afba-5641-bc56-eb93583edad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf6849-4fac-41b9-8e70-dc77c4562a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf6849-4fac-41b9-8e70-dc77c4562a42.jpg?1",
             "name": "Tidy Conclusion",
             "text": "Destroy target creature. You gain 1 life for each artifact you control.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "6ed73eba-d5fa-5b1f-8d6e-f08fb9169a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4392fe0a-a15e-46c6-9a3d-8e30e4dab17f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4392fe0a-a15e-46c6-9a3d-8e30e4dab17f.jpg?1",
             "name": "Underhanded Designs",
             "text": "Whenever an artifact enters the battlefield under your control, you may pay {1}. If you do, each opponent loses 1 life and you gain 1 life.\n{1}{B}, Sacrifice Underhanded Designs: Destroy target creature. Activate this ability only if you control two or more artifacts.",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "9faf516a-e0b1-5b92-91b8-fdbb23dc23ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe99535a-cc81-4e79-9d30-d514c86b849c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe99535a-cc81-4e79-9d30-d514c86b849c.jpg?1",
             "name": "Weaponcraft Enthusiast",
             "text": "Fabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "3b1a773a-66e4-589a-8054-28e1015f8ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c443e1-fd13-4627-85a9-8e9a340a2786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c443e1-fd13-4627-85a9-8e9a340a2786.jpg?1",
             "name": "Aethertorch Renegade",
             "text": "When Aethertorch Renegade enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\n{T}, Pay {E}{E}: Aethertorch Renegade deals 1 damage to target creature.\n{T}, Pay {E}{E}{E}{E}{E}{E}{E}{E}: Aethertorch Renegade deals 6 damage to target player.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "ed666e7c-ca2d-5210-a46b-b544030720c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c6fbdb-7b5c-4ad0-88f5-4779deae16ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c6fbdb-7b5c-4ad0-88f5-4779deae16ce.jpg?1",
             "name": "Brazen Scourge",
             "text": "Haste",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "4606ce47-6a66-52dd-ac5b-d3339cc30c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d002f9-ae69-4e07-943f-95036f083dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d002f9-ae69-4e07-943f-95036f083dea.jpg?1",
             "name": "Brazen Scourge",
             "text": "",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "14282035-7cc2-5f63-ad88-11088e18f776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f054978-446c-4565-b51e-8f1f0e0f01e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f054978-446c-4565-b51e-8f1f0e0f01e2.jpg?1",
             "name": "Built to Smash",
             "text": "Target attacking creature gets +3/+3 until end of turn. If it's an artifact creature, it gains trample until end of turn.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "2f47e1cd-7d29-52c7-a4fb-d6f6b5f7437b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68a6226-6dd7-4e1a-9e8a-124eef2caa13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68a6226-6dd7-4e1a-9e8a-124eef2caa13.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast Cathartic Reunion, discard two cards.\nDraw three cards.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "4b95a228-8ad7-53a7-b861-a23820c94989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8086cd-b868-4f4e-823e-2635ad7ebc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8086cd-b868-4f4e-823e-2635ad7ebc07.jpg?1",
             "name": "Chandra, Torch of Defiance",
             "text": "+1: Exile the top card of your library. You may cast that card. If you don't, Chandra, Torch of Defiance deals 2 damage to each opponent.\n+1: Add {R}{R} to your mana pool.\n\u22123: Chandra, Torch of Defiance deals 4 damage to target creature.\n\u22127: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to target creature or player.\"",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "549f269f-5bad-59d4-99e2-f0af81bdb731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05659715-3002-4bd0-919e-664814c1ca57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05659715-3002-4bd0-919e-664814c1ca57.jpg?1",
             "name": "Chandra's Pyrohelix",
             "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two target creatures and/or players.",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "d4be3ea7-77ad-588c-96fa-f994831adeb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f43147-4552-48fd-be0a-0629b9a0ad69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f43147-4552-48fd-be0a-0629b9a0ad69.jpg?1",
             "name": "Combustible Gearhulk",
             "text": "First strike\nWhen Combustible Gearhulk enters the battlefield, target opponent may have you draw three cards. If the player doesn't, put the top three cards of your library into your graveyard, then Combustible Gearhulk deals damage to that player equal to the total converted mana cost of those cards.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "a8cf8115-8400-5826-bf6e-7a0e286c0a69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d231d40-c113-4a8d-897c-ed3120a1363e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d231d40-c113-4a8d-897c-ed3120a1363e.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "f76bf155-2d02-59b6-a085-df55fb77f284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19d5bdd-7f45-4ff1-bd1a-ac4e87572bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19d5bdd-7f45-4ff1-bd1a-ac4e87572bcb.jpg?1",
             "name": "Fateful Showdown",
             "text": "Fateful Showdown deals damage to target creature or player equal to the number of cards in your hand. Discard all the cards in your hand, then draw that many cards.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "14f37ef5-f210-5209-8c7e-acc9cdbf8050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeeecd-1d62-49f3-82b0-60f1f5e57d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeeecd-1d62-49f3-82b0-60f1f5e57d97.jpg?1",
             "name": "Furious Reprisal",
             "text": "Furious Reprisal deals 2 damage to each of two target creatures and/or players.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "0fdd14ec-288f-5ff2-8626-43b854f99544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c425337-6f1f-494e-a7ae-7d533d7a0b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c425337-6f1f-494e-a7ae-7d533d7a0b4e.jpg?1",
             "name": "Giant Spectacle",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "c3274e9d-de1a-5c89-ad59-45ceef0bd8d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9be9b5c-eed4-4a5d-962f-3482da5a6f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9be9b5c-eed4-4a5d-962f-3482da5a6f1d.jpg?1",
             "name": "Harnessed Lightning",
             "text": "Choose target creature. You get {E}{E}{E} (three energy counters), then you may pay any amount of {E}. Harnessed Lightning deals that much damage to that creature.",
             "colours": [
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "c7d7d871-f681-51ec-8132-aba1788b4be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e925954-faa3-4d16-8442-e34af1f85fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e925954-faa3-4d16-8442-e34af1f85fb6.jpg?1",
             "name": "Hijack",
             "text": "Gain control of target artifact or creature until end of turn. Untap it. It gains haste until end of turn.",
             "colours": [
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "165e4950-0120-56c1-8470-23682a21c53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee44ca0-1989-42fa-8024-b6b3e5c3883c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee44ca0-1989-42fa-8024-b6b3e5c3883c.jpg?1",
             "name": "Incendiary Sabotage",
             "text": "As an additional cost to cast Incendiary Sabotage, sacrifice an artifact.\nIncendiary Sabotage deals 3 damage to each creature.",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "92b95ff9-85c1-56c3-8205-44ad9ba1015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737109b-15fb-4b92-9007-99a33ae68628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737109b-15fb-4b92-9007-99a33ae68628.jpg?1",
             "name": "Inventor's Apprentice",
             "text": "Inventor's Apprentice gets +1/+1 as long as you control an artifact.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "a7958417-0e9b-5dc6-97aa-5bd6a6e33ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14050179-84af-46f6-89be-338f8e7131cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14050179-84af-46f6-89be-338f8e7131cc.jpg?1",
             "name": "Lathnu Hellion",
             "text": "Haste\nWhen Lathnu Hellion enters the battlefield, you get {E}{E} (two energy counters).\nAt the beginning of your end step, sacrifice Lathnu Hellion unless you pay {E}{E}.",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "442b94d7-8ca0-530f-a9ea-f6730575bc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05768b87-d2df-42fc-bf63-e471d31b32e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05768b87-d2df-42fc-bf63-e471d31b32e3.jpg?1",
             "name": "Madcap Experiment",
             "text": "Reveal cards from the top of your library until you reveal an artifact card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Madcap Experiment deals damage to you equal to the number of cards revealed this way.",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "c6e2faff-4de9-5902-a549-33afb9f2eb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53681384-b72d-42a6-b134-aa420115ea12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53681384-b72d-42a6-b134-aa420115ea12.jpg?1",
             "name": "Maulfist Doorbuster",
             "text": "When Maulfist Doorbuster enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Maulfist Doorbuster attacks, you may pay {E}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4197,7 +4197,7 @@
         },
         {
             "id": "4c8af9ce-2523-5644-847e-39f0e3e2cae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2954-0734-4219-b6df-c6cc3dcd8d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2954-0734-4219-b6df-c6cc3dcd8d5a.jpg?1",
             "name": "Pia Nalaar",
             "text": "When Pia Nalaar enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{R}: Target artifact creature gets +1/+0 until end of turn.\n{1}, Sacrifice an artifact: Target creature can't block this turn.",
             "colours": [
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "c45e3b8e-25ad-515f-b1c8-0efcc1e2ce51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f1dc85-3cda-45d6-8d65-3cb93854bb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f1dc85-3cda-45d6-8d65-3cb93854bb16.jpg?1",
             "name": "Quicksmith Genius",
             "text": "Whenever an artifact enters the battlefield under your control, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4269,7 +4269,7 @@
         },
         {
             "id": "5b1f84cd-9047-5a7d-a33c-0ff679303857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ffac51-62c4-4170-85b3-a43d7cfae7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ffac51-62c4-4170-85b3-a43d7cfae7d7.jpg?1",
             "name": "Reckless Fireweaver",
             "text": "Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent.",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "0f7356e9-507e-5175-8047-74fe2de753a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c06a39c-68bb-4e65-9a6d-9d9bc745201f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c06a39c-68bb-4e65-9a6d-9d9bc745201f.jpg?1",
             "name": "Renegade Tactics",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -4336,7 +4336,7 @@
         },
         {
             "id": "b7f64991-5dd3-5397-81e4-e708e6490801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88067bc3-6ec9-4a96-8077-817c57e032d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88067bc3-6ec9-4a96-8077-817c57e032d0.jpg?1",
             "name": "Ruinous Gremlin",
             "text": "{2}{R}, Sacrifice Ruinous Gremlin: Destroy target artifact.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "140519bb-6896-55ba-988c-963a463bfb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e0187a-438f-407c-a0ef-f62517c44994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e0187a-438f-407c-a0ef-f62517c44994.jpg?1",
             "name": "Salivating Gremlins",
             "text": "Whenever an artifact enters the battlefield under your control, Salivating Gremlins gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "0666b86c-976b-53bc-b7af-581f797df993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a35be7b-d693-4433-9b13-8e019adc594e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a35be7b-d693-4433-9b13-8e019adc594e.jpg?1",
             "name": "Skyship Stalker",
             "text": "Flying\n{R}: Skyship Stalker gets +1/+0 until end of turn.\n{R}: Skyship Stalker gains first strike until end of turn.\n{R}: Skyship Stalker gains haste until end of turn.",
             "colours": [
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "bbe5d9df-576a-527a-b9c2-fa9c01f3768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718bf224-5e1b-439c-a998-ceec5c0a8903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718bf224-5e1b-439c-a998-ceec5c0a8903.jpg?1",
             "name": "Spark of Creativity",
             "text": "Choose target creature. Exile the top card of your library. You may have Spark of Creativity deal damage to that creature equal to the exiled card's converted mana cost. If you don't, you may play that card until end of turn.",
             "colours": [
@@ -4470,7 +4470,7 @@
         },
         {
             "id": "6d362f42-942e-5e69-bdcd-e19824c1f80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436ce901-6ac6-4f8c-8ff0-18103f2642b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436ce901-6ac6-4f8c-8ff0-18103f2642b8.jpg?1",
             "name": "Speedway Fanatic",
             "text": "Haste\nWhenever Speedway Fanatic crews a Vehicle, that Vehicle gains haste until end of turn.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "2f754bf8-ca18-578f-a491-53be9afe928a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9551190-9764-47a6-b414-8411beec89d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9551190-9764-47a6-b414-8411beec89d2.jpg?1",
             "name": "Spireside Infiltrator",
             "text": "Whenever Spireside Infiltrator becomes tapped, it deals 1 damage to each opponent.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "36dd0a5d-37e0-5022-a4fd-53651f1ca145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bbeb22-5e50-4b90-b756-9d420f9cfe7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bbeb22-5e50-4b90-b756-9d420f9cfe7f.jpg?1",
             "name": "Spontaneous Artist",
             "text": "When Spontaneous Artist enters the battlefield, you get {E} (an energy counter).\nPay {E}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "db29d150-bb59-585f-8fa4-3ed4f8921f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae1eb8-697d-43e1-b03e-f4246a9f225e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae1eb8-697d-43e1-b03e-f4246a9f225e.jpg?1",
             "name": "Start Your Engines",
             "text": "Vehicles you control become artifact creatures until end of turn. Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "ce45c6ef-7c7f-59f6-bba4-7b62fe9463ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3525ad1-3c17-4959-ab61-ae0e784c526a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3525ad1-3c17-4959-ab61-ae0e784c526a.jpg?1",
             "name": "Territorial Gorger",
             "text": "Trample\nWhenever you get one or more {E} (energy counters), Territorial Gorger gets +2/+2 until end of turn.",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "27ec79d6-ad98-5d09-bbc0-071a4cb86950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04623df9-8fa9-44cc-b528-c2c484626d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04623df9-8fa9-44cc-b528-c2c484626d1f.jpg?1",
             "name": "Terror of the Fairgrounds",
             "text": "",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "b1081f78-2a11-577b-9189-6040dd188039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3184a-eeda-4f22-92de-257c20cff6e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3184a-eeda-4f22-92de-257c20cff6e2.jpg?1",
             "name": "Thriving Grubs",
             "text": "When Thriving Grubs enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Grubs attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "2eeaa359-f43b-5072-9d5d-6e4407c9f358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db01e574-7a96-472c-8e5a-bbd503280c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db01e574-7a96-472c-8e5a-bbd503280c71.jpg?1",
             "name": "Wayward Giant",
             "text": "Menace",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "ac13691b-b128-53a2-ada7-3929041ea469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d98db-64c4-40b4-b6c8-61da8cc09f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d98db-64c4-40b4-b6c8-61da8cc09f42.jpg?1",
             "name": "Welding Sparks",
             "text": "Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.",
             "colours": [
@@ -4775,7 +4775,7 @@
         },
         {
             "id": "0a366615-031b-5973-ab70-4e9d62309163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa8840-31f8-4263-b992-40584e31595a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa8840-31f8-4263-b992-40584e31595a.jpg?1",
             "name": "Appetite for the Unnatural",
             "text": "Destroy target artifact or enchantment. You gain 2 life.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "4cae7cfc-6fd7-5972-ac73-895709213982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788b9d55-6679-4fcc-a3af-11d31e477421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788b9d55-6679-4fcc-a3af-11d31e477421.jpg?1",
             "name": "Arborback Stomper",
             "text": "Trample\nWhen Arborback Stomper enters the battlefield, you gain 5 life.",
             "colours": [
@@ -4843,7 +4843,7 @@
         },
         {
             "id": "fd84a5fe-8891-591c-b4e2-8a321e57d0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d228ad88-669a-435f-a2fd-6188261988ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d228ad88-669a-435f-a2fd-6188261988ea.jpg?1",
             "name": "Arborback Stomper",
             "text": "",
             "colours": [
@@ -4878,7 +4878,7 @@
         },
         {
             "id": "ad8d56bf-892a-5df9-9172-a042224ac137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc540f5-96a1-44d8-910d-914b9e61b2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc540f5-96a1-44d8-910d-914b9e61b2a5.jpg?1",
             "name": "Architect of the Untamed",
             "text": "Whenever a land enters the battlefield under your control, you get {E} (an energy counter).\nPay {E}{E}{E}{E}{E}{E}{E}{E}: Create a 6/6 colorless Beast artifact creature token.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "550f46ca-5f04-5606-98e4-1b2fef94242e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b54854-c21f-47d3-99b2-72829fc66071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b54854-c21f-47d3-99b2-72829fc66071.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "90e65980-a445-5071-ad9c-f4baaf004b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b0707d-241e-4ced-9251-b16af4fef2cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b0707d-241e-4ced-9251-b16af4fef2cb.jpg?1",
             "name": "Attune with Aether",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library. You get {E}{E} (two energy counters).",
             "colours": [
@@ -4981,7 +4981,7 @@
         },
         {
             "id": "f4065088-c736-5050-a7ba-a8b65727da29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c026c39-b09c-408a-844f-fb5eb785862a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c026c39-b09c-408a-844f-fb5eb785862a.jpg?1",
             "name": "Blossoming Defense",
             "text": "Target creature you control gets +2/+2 and gains hexproof until end of turn.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "4598840b-dd90-5705-8b7c-13c64a114ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf38096-05bc-4734-b33c-eb1e8f2986de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf38096-05bc-4734-b33c-eb1e8f2986de.jpg?1",
             "name": "Bristling Hydra",
             "text": "When Bristling Hydra enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}: Put a +1/+1 counter on Bristling Hydra. It gains hexproof until end of turn.",
             "colours": [
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "e36f0677-7f0c-5190-8d55-6dc5c64c741c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724602-2ae1-40a4-aeb0-51a483a6948c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724602-2ae1-40a4-aeb0-51a483a6948c.jpg?1",
             "name": "Commencement of Festivities",
             "text": "Prevent all combat damage that would be dealt to players this turn.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "ee338a61-055c-58eb-b7cd-2b913420b005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1b25f4-f50c-4210-a03f-080a5e4e5708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1b25f4-f50c-4210-a03f-080a5e4e5708.jpg?1",
             "name": "Cowl Prowler",
             "text": "",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "20b420df-4eb4-5982-8035-e996a4835736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277b549c-8691-42b2-9867-802b158a506c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277b549c-8691-42b2-9867-802b158a506c.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "2c842f91-4cae-5ca1-bce6-d0653f9b367c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21d35b-1b4e-43aa-8fb7-0dd7a2fa91a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21d35b-1b4e-43aa-8fb7-0dd7a2fa91a1.jpg?1",
             "name": "Cultivator of Blades",
             "text": "Fabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)\nWhenever Cultivator of Blades attacks, you may have other attacking creatures get +X/+X until end of turn, where X is Cultivator of Blades's power.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "5c419f0d-2d2e-548a-9c37-90851caa649e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92965a78-277d-4a27-8174-fc2564bd1ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92965a78-277d-4a27-8174-fc2564bd1ee3.jpg?1",
             "name": "Dubious Challenge",
             "text": "Look at the top ten cards of your library, exile up to two creature cards from among them, then shuffle your library. Target opponent may choose one of the exiled cards and put it onto the battlefield under his or her control. Put the rest onto the battlefield under your control.",
             "colours": [
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "dd12878f-136c-5962-b973-a7b29613e12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d5e2ff-dc8a-4ed5-989a-4b4b79591b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d5e2ff-dc8a-4ed5-989a-4b4b79591b3f.jpg?1",
             "name": "Durable Handicraft",
             "text": "Whenever a creature enters the battlefield under your control, you may pay {1}. If you do, put a +1/+1 counter on that creature.\n{5}{G}, Sacrifice Durable Handicraft: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -5244,7 +5244,7 @@
         },
         {
             "id": "613eba59-2ec9-5082-b3af-613222eedc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352941f3-951e-428d-bec4-7790c3ea7cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352941f3-951e-428d-bec4-7790c3ea7cb2.jpg?1",
             "name": "Elegant Edgecrafters",
             "text": "Elegant Edgecrafters can't be blocked by creatures with power 2 or less.\nFabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "7dbdee9a-788a-59ec-bdc5-f56d55f0242b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65983338-8806-4386-94a6-4670eb853848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65983338-8806-4386-94a6-4670eb853848.jpg?1",
             "name": "Fairgrounds Trumpeter",
             "text": "At the beginning of each end step, if a +1/+1 counter was placed on a permanent under your control this turn, put a +1/+1 counter on Fairgrounds Trumpeter.",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "ab5d6ee9-5b81-569c-9bd8-66fd3bd8cb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b6ad4a-3701-4ee8-8e1e-46cdab8e730f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b6ad4a-3701-4ee8-8e1e-46cdab8e730f.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -5348,7 +5348,7 @@
         },
         {
             "id": "2286d559-3d0b-5780-84c0-3cf7a6b4994d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a26cb0-655f-4bf8-899a-952d5bfe2b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a26cb0-655f-4bf8-899a-952d5bfe2b42.jpg?1",
             "name": "Highspire Artisan",
             "text": "Reach (This creature can block creatures with flying.)\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "9c4f01ea-520c-561f-92c2-993a687efebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acbe3e-cc60-4e17-97da-ac4c803e8a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acbe3e-cc60-4e17-97da-ac4c803e8a5a.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "0fefe3fd-6595-55a9-8db3-ef0a324c303b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8664c65-77ca-4881-959a-e1923e1a6b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8664c65-77ca-4881-959a-e1923e1a6b98.jpg?1",
             "name": "Kujar Seedsculptor",
             "text": "When Kujar Seedsculptor enters the battlefield, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "a90b01fd-d1bd-589b-82fa-abc52e7e22dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0da994-d3e7-41b9-ae8f-6f1a3b779f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0da994-d3e7-41b9-ae8f-6f1a3b779f23.jpg?1",
             "name": "Larger Than Life",
             "text": "Target creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5482,7 +5482,7 @@
         },
         {
             "id": "5328c170-6589-55d5-9b8e-0bd8a20d6adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4de778a-4419-49a5-9dcf-5d0095c873fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4de778a-4419-49a5-9dcf-5d0095c873fa.jpg?1",
             "name": "Longtusk Cub",
             "text": "Whenever Longtusk Cub deals combat damage to a player, you get {E}{E} (two energy counters).\nPay {E}{E}: Put a +1/+1 counter on Longtusk Cub.",
             "colours": [
@@ -5516,7 +5516,7 @@
         },
         {
             "id": "7608a288-c5ca-586b-8487-a4a48070561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122287-fe33-4ac3-803c-f5173cae50a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122287-fe33-4ac3-803c-f5173cae50a7.jpg?1",
             "name": "Nature's Way",
             "text": "Target creature you control gains vigilance and trample until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5548,7 +5548,7 @@
         },
         {
             "id": "bccf1730-d3ee-5e29-9ad1-4e78a51fad2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaaa98a-ec40-4ff1-8762-a719cf1c475d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaaa98a-ec40-4ff1-8762-a719cf1c475d.jpg?1",
             "name": "Nissa, Vital Force",
             "text": "+1: Untap target land you control. Until your next turn, it becomes a 5/5 Elemental creature with haste. It's still a land.\n\u22123: Return target permanent card from your graveyard to your hand.\n\u22126: You get an emblem with \"Whenever a land enters the battlefield under your control, you may draw a card.\"",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "5df32589-14b8-52d1-9e7f-b7e02a488080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0c49ab-da04-4461-8440-d6c9086443c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0c49ab-da04-4461-8440-d6c9086443c6.jpg?1",
             "name": "Ornamental Courage",
             "text": "Untap target creature. It gets +1/+3 until end of turn.",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "fe63c06d-d540-5aff-8eee-57f23c7507bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eb9d40-958b-41b8-b04b-7f45adc0a862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eb9d40-958b-41b8-b04b-7f45adc0a862.jpg?1",
             "name": "Oviya Pashiri, Sage Lifecrafter",
             "text": "{2}{G}, {T}: Create a 1/1 colorless Servo artifact creature token.\n{4}{G}, {T}: Create an X/X colorless Construct artifact creature token, where X is the number of creatures you control.",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "0edaf98f-3d13-500b-a35a-13b4cfc49db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab38bd5-64bb-41aa-851b-c6bc6b44bcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab38bd5-64bb-41aa-851b-c6bc6b44bcf0.jpg?1",
             "name": "Peema Outrider",
             "text": "Trample\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -5688,7 +5688,7 @@
         },
         {
             "id": "874bca0d-5151-5969-af7b-e4bcb27095d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf7e050-9631-431c-bcae-f74d91d537b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf7e050-9631-431c-bcae-f74d91d537b0.jpg?1",
             "name": "Riparian Tiger",
             "text": "Trample\nWhen Riparian Tiger enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Riparian Tiger attacks, you may pay {E}{E}. If you do, it gets +2/+2 until end of turn.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "060273cd-726e-5dbc-971d-a25d13bae406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d29a-2043-4341-89d5-5e34bb6507e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d29a-2043-4341-89d5-5e34bb6507e2.jpg?1",
             "name": "Sage of Shaila's Claim",
             "text": "When Sage of Shaila's Claim enters the battlefield, you get {E}{E}{E} (three energy counters).",
             "colours": [
@@ -5757,7 +5757,7 @@
         },
         {
             "id": "2c07fdf8-1400-519a-b960-8d56d0d05784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9cf30-4baa-4f28-84e8-b9b1168a40e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9cf30-4baa-4f28-84e8-b9b1168a40e0.jpg?1",
             "name": "Servant of the Conduit",
             "text": "When Servant of the Conduit enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "6c2bf99c-52bb-53c5-876a-647f8ee5d819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e702db-8c73-4947-9c13-5dcb50f4efab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e702db-8c73-4947-9c13-5dcb50f4efab.jpg?1",
             "name": "Take Down",
             "text": "Choose one \u2014\n\u2022 Take Down deals 4 damage to target creature with flying.\n\u2022 Take Down deals 1 damage to each creature with flying.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "b7baf46d-ee02-55cd-9d33-cd929e3328d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acf10ec-f2dd-4569-909b-ac52a9ed6adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acf10ec-f2dd-4569-909b-ac52a9ed6adf.jpg?1",
             "name": "Thriving Rhino",
             "text": "When Thriving Rhino enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Rhino attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "026df6af-8896-560f-b0a5-156ea2a9a28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0130b99e-5b2f-4482-b141-752e59b72c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0130b99e-5b2f-4482-b141-752e59b72c31.jpg?1",
             "name": "Verdurous Gearhulk",
             "text": "Trample\nWhen Verdurous Gearhulk enters the battlefield, distribute four +1/+1 counters among any number of target creatures you control.",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "8cf79162-87e0-52a6-8c94-0b3ea4a49195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d20e020-30e1-4deb-8dfc-4c5fe056193d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d20e020-30e1-4deb-8dfc-4c5fe056193d.jpg?1",
             "name": "Wild Wanderer",
             "text": "When Wild Wanderer enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5928,7 +5928,7 @@
         },
         {
             "id": "a21e62f3-be94-5c65-b0e2-d74f0937b697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fedd63c-22e4-4c36-8a7a-a167a070678f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fedd63c-22e4-4c36-8a7a-a167a070678f.jpg?1",
             "name": "Wildest Dreams",
             "text": "Return X target cards from your graveyard to your hand. Exile Wildest Dreams.",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "f784394b-124d-5779-bfd0-9b267923c12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6ece3-9889-47fa-9140-420b4f31dd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6ece3-9889-47fa-9140-420b4f31dd1b.jpg?1",
             "name": "Wily Bandar",
             "text": "{2}{G}: Wily Bandar gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -5995,7 +5995,7 @@
         },
         {
             "id": "4e854018-4059-5acd-9b3e-e78dcea9c632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb12355-abd8-4bf3-aac1-f710ac162585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb12355-abd8-4bf3-aac1-f710ac162585.jpg?1",
             "name": "Cloudblazer",
             "text": "Flying\nWhen Cloudblazer enters the battlefield, you gain 2 life and draw two cards.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "305f050f-c180-55ed-bcd0-c585e0014277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beafcd-6c90-40c2-afff-0bd82377febf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beafcd-6c90-40c2-afff-0bd82377febf.jpg?1",
             "name": "Contraband Kingpin",
             "text": "Lifelink\nWhenever an artifact enters the battlefield under your control, scry 1.",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "264276da-019d-589e-880f-9bc99c37d7ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592f3a92-787e-4180-9d0b-06c973ce8975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592f3a92-787e-4180-9d0b-06c973ce8975.jpg?1",
             "name": "Depala, Pilot Exemplar",
             "text": "Other Dwarves you control get +1/+1.\nEach Vehicle you control gets +1/+1 as long as it's a creature.\nWhenever Depala, Pilot Exemplar becomes tapped, you may pay {X}. If you do, reveal the top X cards of your library, put all Dwarf and Vehicle cards from among them into your hand, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "67ae4127-0adf-5088-b3bd-fa66c6b7548f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2344e710-4570-41b6-af84-a3e7d784003a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2344e710-4570-41b6-af84-a3e7d784003a.jpg?1",
             "name": "Dovin Baan",
             "text": "+1: Until your next turn, up to one target creature gets -3/-0 and its activated abilities can't be activated.\n\u22121: You gain 2 life and draw a card.\n\u22127: You get an emblem with \"Your opponents can't untap more than two permanents during their untap steps.\"",
             "colours": [
@@ -6146,7 +6146,7 @@
         },
         {
             "id": "8965fba9-530a-5e2b-821c-fa3b5990eb1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4554b10e-9c3e-4eb4-b0fe-044e483e872f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4554b10e-9c3e-4eb4-b0fe-044e483e872f.jpg?1",
             "name": "Empyreal Voyager",
             "text": "Flying, trample\nWhenever Empyreal Voyager deals combat damage to a player, you get that many {E} (energy counters).",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "59ed559a-b6b8-5729-98e1-8abd41c5f8ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b5fc7-51b2-4425-b053-a5d19c1595e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b5fc7-51b2-4425-b053-a5d19c1595e0.jpg?1",
             "name": "Engineered Might",
             "text": "Choose one \u2014\n\u2022 Target creature gets +5/+5 and gains trample until end of turn.\n\u2022 Creatures you control get +2/+2 and gain vigilance until end of turn.",
             "colours": [
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "4e3a61fe-a281-5851-8772-d06927893d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa9b08b-c56f-480e-874e-069e72d979c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa9b08b-c56f-480e-874e-069e72d979c8.jpg?1",
             "name": "Hazardous Conditions",
             "text": "Creatures with no counters on them get -2/-2 until end of turn.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "70e592bb-18c1-5946-adb6-faeb6fe93110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d61ddb-2662-427c-a97d-21e41b86130d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d61ddb-2662-427c-a97d-21e41b86130d.jpg?1",
             "name": "Kambal, Consul of Allocation",
             "text": "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -6290,7 +6290,7 @@
         },
         {
             "id": "df694982-825d-5904-b7e2-19a0315db30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce37555-49a2-4112-95b4-f3376b55b45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce37555-49a2-4112-95b4-f3376b55b45b.jpg?1",
             "name": "Rashmi, Eternities Crafter",
             "text": "Whenever you cast your first spell each turn, reveal the top card of your library. If it's a nonland card with converted mana cost less than that spell's, you may cast it without paying its mana cost. If you don't cast the revealed card, put it into your hand.",
             "colours": [
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "a79ab97d-d3cf-5623-b37c-48e06f0f78c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228ea9c6-5732-4a2a-ac25-a768ea7d433b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228ea9c6-5732-4a2a-ac25-a768ea7d433b.jpg?1",
             "name": "Restoration Gearsmith",
             "text": "When Restoration Gearsmith enters the battlefield, return target artifact or creature card from your graveyard to your hand.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "c907a265-5aa6-503d-8351-049d3bfb10c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b38464-39cd-4ee6-b9bf-a0bc1e128d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b38464-39cd-4ee6-b9bf-a0bc1e128d9a.jpg?1",
             "name": "Saheeli Rai",
             "text": "+1: Scry 1. Saheeli Rai deals 1 damage to each opponent.\n\u22122: Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. That token gains haste. Exile it at the beginning of the next end step.\n\u22127: Search your library for up to three artifact cards with different names, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "ceecfdc9-bd9a-5f28-a1f3-71fbe130580d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ad8f86-7860-4896-a161-07bf347bbd5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ad8f86-7860-4896-a161-07bf347bbd5b.jpg?1",
             "name": "Unlicensed Disintegration",
             "text": "Destroy target creature. If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller.",
             "colours": [
@@ -6438,7 +6438,7 @@
         },
         {
             "id": "3c94a913-5819-5828-aed3-4513ac8973e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5be9c1-cb28-42bd-b159-5548124ba8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5be9c1-cb28-42bd-b159-5548124ba8d1.jpg?1",
             "name": "Veteran Motorist",
             "text": "When Veteran Motorist enters the battlefield, scry 2.\nWhenever Veteran Motorist crews a Vehicle, that Vehicle gets +1/+1 until end of turn.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "cd6e48ec-e6fb-5538-a846-bd49da99dd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb038fd3-51b7-4de7-9b38-cbad7c8717c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb038fd3-51b7-4de7-9b38-cbad7c8717c2.jpg?1",
             "name": "Voltaic Brawler",
             "text": "When Voltaic Brawler enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Voltaic Brawler attacks, you may pay {E}. If you do, it gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "a3497e66-3050-5355-8374-b247289a2c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae429806-28b5-4bee-b0e1-1bd876f282c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae429806-28b5-4bee-b0e1-1bd876f282c2.jpg?1",
             "name": "Whirler Virtuoso",
             "text": "When Whirler Virtuoso enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}: Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "5b04effe-37f7-52fd-bd96-dbf3b9bdd98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2362-f901-4ec6-9bc4-1988f30380fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2362-f901-4ec6-9bc4-1988f30380fd.jpg?1",
             "name": "Accomplished Automaton",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "41e9b210-f525-526b-abe6-723471722d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b6b2e1-c3e6-464c-8a13-b15deb34e862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b6b2e1-c3e6-464c-8a13-b15deb34e862.jpg?1",
             "name": "Aetherflux Reservoir",
             "text": "Whenever you cast a spell, you gain 1 life for each spell you've cast this turn.\nPay 50 life: Aetherflux Reservoir deals 50 damage to target creature or player.",
             "colours": [],
@@ -6608,7 +6608,7 @@
         },
         {
             "id": "ed07b8c1-c93f-523e-b722-cfcb7190b52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884f6948-3e03-48c6-8be2-6f2539386c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884f6948-3e03-48c6-8be2-6f2539386c9d.jpg?1",
             "name": "Aetherworks Marvel",
             "text": "Whenever a permanent you control is put into a graveyard, you get {E} (an energy counter).\n{T}, Pay {E}{E}{E}{E}{E}{E}: Look at the top six cards of your library. You may cast a card from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "6855c4c7-e56b-5ab9-8955-bb3a412d4682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bdc973-db45-46a6-ac48-ce88fb59920a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bdc973-db45-46a6-ac48-ce88fb59920a.jpg?1",
             "name": "Animation Module",
             "text": "Whenever one or more +1/+1 counters are placed on a permanent you control, you may pay {1}. If you do, create a 1/1 colorless Servo artifact creature token.\n{3}, {T}: Choose a counter on target permanent or player. Give that permanent or player another counter of that kind.",
             "colours": [],
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "ff2ea7fa-2f4f-5df0-b132-46ca000a9938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0d1f7-c81c-4329-92b7-c4df227cc56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0d1f7-c81c-4329-92b7-c4df227cc56c.jpg?1",
             "name": "Aradara Express",
             "text": "Menace\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6696,7 +6696,7 @@
         },
         {
             "id": "f116bb6a-36cd-5d61-8cea-dcfbb40e3ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd3f376-1075-42c9-91df-80dc2d5faacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd3f376-1075-42c9-91df-80dc2d5faacf.jpg?1",
             "name": "Ballista Charger",
             "text": "Whenever Ballista Charger attacks, it deals 1 damage to target creature or player.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "3ea7966c-16e4-5e81-bb4e-3539fd1f2ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ea690f-fd4e-4d05-b815-22d97736e894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ea690f-fd4e-4d05-b815-22d97736e894.jpg?1",
             "name": "Bastion Mastodon",
             "text": "{W}: Bastion Mastodon gains vigilance until end of turn.",
             "colours": [],
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "36b1e0c7-7431-5f6d-810f-c05cb63257fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32be75-979d-43a9-9132-2cf013ddaf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32be75-979d-43a9-9132-2cf013ddaf3b.jpg?1",
             "name": "Bomat Bazaar Barge",
             "text": "When Bomat Bazaar Barge enters the battlefield, draw a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "cebb4bb9-27ab-564e-a4c4-1eaa6f07fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bff89-ad15-4d22-bce9-a4a07dbafd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bff89-ad15-4d22-bce9-a4a07dbafd87.jpg?1",
             "name": "Bomat Courier",
             "text": "Haste\nWhenever Bomat Courier attacks, exile the top card of your library face down. (You can't look at it.)\n{R}, Discard your hand, Sacrifice Bomat Courier: Put all cards exiled with Bomat Courier into their owners' hands.",
             "colours": [],
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "b87074ef-2796-5472-9164-3db65d481b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a6f80-3ff9-4d9e-8b1e-cb07c3dc326a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a6f80-3ff9-4d9e-8b1e-cb07c3dc326a.jpg?1",
             "name": "Chief of the Foundry",
             "text": "Other artifact creatures you control get +1/+1.",
             "colours": [],
@@ -6853,7 +6853,7 @@
         },
         {
             "id": "edc76636-08ef-5781-a9eb-df37036a3dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d594df-c51b-4936-9af1-536dab1792ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d594df-c51b-4936-9af1-536dab1792ae.jpg?1",
             "name": "Cogworker's Puzzleknot",
             "text": "When Cogworker's Puzzleknot enters the battlefield, create a 1/1 colorless Servo artifact creature token.\n{1}{W}, Sacrifice Cogworker's Puzzleknot: Create a 1/1 colorless Servo artifact creature token.",
             "colours": [],
@@ -6883,7 +6883,7 @@
         },
         {
             "id": "973bfec9-cdbc-5cab-bb5c-0be3d11fb121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7922c3-1baa-41ed-bd06-b5a97cddb90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7922c3-1baa-41ed-bd06-b5a97cddb90e.jpg?1",
             "name": "Consulate Skygate",
             "text": "Defender\nReach (This creature can block creatures with flying.)",
             "colours": [],
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "e4ceee6b-13c9-5006-935d-47d3a129d4ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b3726-4bc8-4e3a-bc6d-402c81663712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b3726-4bc8-4e3a-bc6d-402c81663712.jpg?1",
             "name": "Cultivator's Caravan",
             "text": "{T}: Add one mana of any color to your mana pool.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "195efc9d-0cf1-5dcd-ae32-b80f6162049f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f956dedc-2cf4-4039-8302-feab94b78426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f956dedc-2cf4-4039-8302-feab94b78426.jpg?1",
             "name": "Deadlock Trap",
             "text": "Deadlock Trap enters the battlefield tapped.\nWhen Deadlock Trap enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Tap target creature or planeswalker. Its activated abilities can't be activated this turn.",
             "colours": [],
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "149888c1-b432-56b6-92bb-779069f76c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08ae769-0070-47a6-aae0-1a3bcfd40d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08ae769-0070-47a6-aae0-1a3bcfd40d07.jpg?1",
             "name": "Decoction Module",
             "text": "Whenever a creature enters the battlefield under your control, you get {E} (an energy counter).\n{4}, {T}: Return target creature you control to its owner's hand.",
             "colours": [],
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "36108ccc-7a00-568f-8444-a7c3b542e04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9af13a0-a9c1-454c-992d-ce79ff161187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9af13a0-a9c1-454c-992d-ce79ff161187.jpg?1",
             "name": "Demolition Stomper",
             "text": "Demolition Stomper can't be blocked by creatures with power 2 or less.\nCrew 5 (Tap any number of creatures you control with total power 5 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "bcb8ebd6-ff17-5a3a-8ddb-39ae2e178a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c54795-d555-4972-b72d-b2d2374bed9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c54795-d555-4972-b72d-b2d2374bed9b.jpg?1",
             "name": "Dukhara Peafowl",
             "text": "{U}: Dukhara Peafowl gains flying until end of turn.",
             "colours": [],
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "4be340f4-8345-5904-8096-44b4fda777da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45fd2ae-0f91-47ca-99bd-22ddf946df9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45fd2ae-0f91-47ca-99bd-22ddf946df9f.jpg?1",
             "name": "Dynavolt Tower",
             "text": "Whenever you cast an instant or sorcery spell, you get {E}{E} (two energy counters).\n{T}, Pay {E}{E}{E}{E}{E}: Dynavolt Tower deals 3 damage to target creature or player.",
             "colours": [],
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "3af562b0-5fdf-5f94-98bc-8bcd3c9b4605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ae7b-02a5-45ce-8a63-aa880b1e582a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ae7b-02a5-45ce-8a63-aa880b1e582a.jpg?1",
             "name": "Eager Construct",
             "text": "When Eager Construct enters the battlefield, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [],
@@ -7122,7 +7122,7 @@
         },
         {
             "id": "36faeb35-bce9-558c-80d7-053d391e3def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565d11b-a57e-4de4-9d18-2be48a2ef742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565d11b-a57e-4de4-9d18-2be48a2ef742.jpg?1",
             "name": "Electrostatic Pummeler",
             "text": "When Electrostatic Pummeler enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}: Electrostatic Pummeler gets +X/+X until end of turn, where X is its power.",
             "colours": [],
@@ -7153,7 +7153,7 @@
         },
         {
             "id": "6147870f-bd46-5ffd-8bb2-26609bfe082d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93a9693-f899-47ac-8ee0-3549d9333fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93a9693-f899-47ac-8ee0-3549d9333fff.jpg?1",
             "name": "Fabrication Module",
             "text": "Whenever you get one or more {E} (energy counters), put a +1/+1 counter on target creature you control.\n{4}, {T}: You get {E}.",
             "colours": [],
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "b971b0e4-be13-588e-b487-ef6acd35d024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc9ecfd-6cf0-4488-a14a-afec1bc0d253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc9ecfd-6cf0-4488-a14a-afec1bc0d253.jpg?1",
             "name": "Filigree Familiar",
             "text": "When Filigree Familiar enters the battlefield, you gain 2 life.\nWhen Filigree Familiar dies, draw a card.",
             "colours": [],
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "3e44be5b-7c66-51e8-a17d-575fc1a25cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c11ca-c81b-451e-a767-68865827e06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c11ca-c81b-451e-a767-68865827e06d.jpg?1",
             "name": "Fireforger's Puzzleknot",
             "text": "When Fireforger's Puzzleknot enters the battlefield, it deals 1 damage to target creature or player.\n{2}{R}, Sacrifice Fireforger's Puzzleknot: It deals 1 damage to target creature or player.",
             "colours": [],
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "866614dc-c787-5205-bc85-15572825a2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdaca1e-5741-456e-ae98-e2c45fd1731b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdaca1e-5741-456e-ae98-e2c45fd1731b.jpg?1",
             "name": "Fleetwheel Cruiser",
             "text": "Trample, haste\nWhen Fleetwheel Cruiser enters the battlefield, it becomes an artifact creature until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "a398c156-3766-5d2a-96e0-9e447b64cfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f827e8-1cc4-4a15-a4be-2e74323963b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f827e8-1cc4-4a15-a4be-2e74323963b9.jpg?1",
             "name": "Foundry Inspector",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [],
@@ -7303,7 +7303,7 @@
         },
         {
             "id": "576eaf10-ed9d-567d-a2cb-d3326d047580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bff744-873b-4fa1-8088-5f28bbcdc7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bff744-873b-4fa1-8088-5f28bbcdc7b8.jpg?1",
             "name": "Ghirapur Orrery",
             "text": "Each player may play an additional land on each of his or her turns.\nAt the beginning of each player's upkeep, if that player has no cards in hand, that player draws three cards.",
             "colours": [],
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "fa76b3fa-64a9-55db-8129-6ac64cc2d26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d123031-6702-4d49-a788-42eb6dbc569e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d123031-6702-4d49-a788-42eb6dbc569e.jpg?1",
             "name": "Glassblower's Puzzleknot",
             "text": "When Glassblower's Puzzleknot enters the battlefield, scry 2, then you get {E}{E}. (You get two energy counters. To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{2}{U}, Sacrifice Glassblower's Puzzleknot: Scry 2, then you get {E}{E}.",
             "colours": [],
@@ -7361,7 +7361,7 @@
         },
         {
             "id": "99214e46-9fac-5bd2-8284-519450d41c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a26fdf-fdce-4939-8c6a-c9dff623072f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a26fdf-fdce-4939-8c6a-c9dff623072f.jpg?1",
             "name": "Inventor's Goggles",
             "text": "Equipped creature gets +1/+2.\nWhenever an Artificer enters the battlefield under your control, you may attach Inventor's Goggles to it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "416f481f-fd07-5003-ad0e-c32f1736f3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47993b2-694d-4697-8b06-64aa5663598b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47993b2-694d-4697-8b06-64aa5663598b.jpg?1",
             "name": "Iron League Steed",
             "text": "Haste\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -7422,7 +7422,7 @@
         },
         {
             "id": "a2e94f9a-73a1-5a61-b813-480000b7d4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66154969-5c69-40ce-8bc9-c9bc5e280d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66154969-5c69-40ce-8bc9-c9bc5e280d4c.jpg?1",
             "name": "Key to the City",
             "text": "{T}, Discard a card: Up to one target creature can't be blocked this turn.\nWhenever Key to the City becomes untapped, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "774e793b-e9b8-5d5c-b5fd-87b85268f32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1639c3-f22d-4246-9252-219a4b2b2999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1639c3-f22d-4246-9252-219a4b2b2999.jpg?1",
             "name": "Metalspinner's Puzzleknot",
             "text": "When Metalspinner's Puzzleknot enters the battlefield, you draw a card and you lose 1 life.\n{2}{B}, Sacrifice Metalspinner's Puzzleknot: You draw a card and you lose 1 life.",
             "colours": [],
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "8f079cbd-8419-5f5f-9f30-ea601918ebb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474480b5-c60b-4c7f-9d3e-751bca43d074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474480b5-c60b-4c7f-9d3e-751bca43d074.jpg?1",
             "name": "Metalwork Colossus",
             "text": "Metalwork Colossus costs {X} less to cast, where X is the total converted mana cost of noncreature artifacts you control.\nSacrifice two artifacts: Return Metalwork Colossus from your graveyard to your hand.",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "f2ef411d-bea9-5527-b154-9d144a4622d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6956c1-36e2-4c9c-9f69-00b459f094d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6956c1-36e2-4c9c-9f69-00b459f094d8.jpg?1",
             "name": "Multiform Wonder",
             "text": "When Multiform Wonder enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}: Multiform Wonder gains your choice of flying, vigilance, or lifelink until end of turn.\nPay {E}: Multiform Wonder gets +2/-2 or -2/+2 until end of turn.",
             "colours": [],
@@ -7542,7 +7542,7 @@
         },
         {
             "id": "87b8b93b-7118-5a62-aca5-2c849c4061eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1a67-61f7-4f03-b677-a874b64c989e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1a67-61f7-4f03-b677-a874b64c989e.jpg?1",
             "name": "Narnam Cobra",
             "text": "{G}: Narnam Cobra gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [],
@@ -7575,7 +7575,7 @@
         },
         {
             "id": "1b0e6722-7fb3-5256-89ad-f77175b70fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20411aa0-f87b-49dd-b943-ca82d59db185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20411aa0-f87b-49dd-b943-ca82d59db185.jpg?1",
             "name": "Ovalchase Dragster",
             "text": "Trample, haste\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "32ea8ed5-f64a-5359-8327-4230078fcf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15856326-d943-476a-9d31-898b9f990bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15856326-d943-476a-9d31-898b9f990bb6.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "4372cce1-c534-558c-9f33-beece9127f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc87a27-93d9-4ce0-a022-0309242c1e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc87a27-93d9-4ce0-a022-0309242c1e89.jpg?1",
             "name": "Perpetual Timepiece",
             "text": "{T}: Put the top two cards of your library into your graveyard.\n{2}, Exile Perpetual Timepiece: Shuffle any number of target cards from your graveyard into your library.",
             "colours": [],
@@ -7661,7 +7661,7 @@
         },
         {
             "id": "006e08e7-5c3d-53a4-b8b3-d726573887fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c91b356-b5d8-4239-bb45-dec7f673868d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c91b356-b5d8-4239-bb45-dec7f673868d.jpg?1",
             "name": "Prakhata Pillar-Bug",
             "text": "{B}: Prakhata Pillar-Bug gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [],
@@ -7694,7 +7694,7 @@
         },
         {
             "id": "c5312b5e-f7aa-5526-8110-7f121fc375c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06450be5-0634-4aef-bda7-4d4fbb9ec00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06450be5-0634-4aef-bda7-4d4fbb9ec00a.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "7b0f8369-d8e1-5466-a818-782f4cbca145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10e2c3-0132-4eb2-94f0-5915caca2a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10e2c3-0132-4eb2-94f0-5915caca2a17.jpg?1",
             "name": "Renegade Freighter",
             "text": "Whenever Renegade Freighter attacks, it gets +1/+1 and gains trample until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "58aac6d5-3929-5005-a5cb-f65a7c65f536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a8e4e-ea7b-41c7-a982-b5751025ff25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a8e4e-ea7b-41c7-a982-b5751025ff25.jpg?1",
             "name": "Scrapheap Scrounger",
             "text": "Scrapheap Scrounger can't block.\n{1}{B}, Exile another creature card from your graveyard: Return Scrapheap Scrounger from your graveyard to the battlefield.",
             "colours": [],
@@ -7785,7 +7785,7 @@
         },
         {
             "id": "d6cb6e6b-c5fd-5058-a595-19730fb53931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d05c6c2-4bb3-468a-b23c-b0425a9982f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d05c6c2-4bb3-468a-b23c-b0425a9982f1.jpg?1",
             "name": "Self-Assembler",
             "text": "When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "56e4847a-887e-597a-8f54-d6b03ceaacfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4939-130b-40d7-8a0f-e31eb931d2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4939-130b-40d7-8a0f-e31eb931d2d5.jpg?1",
             "name": "Sky Skiff",
             "text": "Flying\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7846,7 +7846,7 @@
         },
         {
             "id": "2e4cda99-296f-5113-9724-1b8a79d9cff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df70ef3-8919-43ac-9317-23548437a181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df70ef3-8919-43ac-9317-23548437a181.jpg?1",
             "name": "Skysovereign, Consul Flagship",
             "text": "Flying\nWhenever Skysovereign, Consul Flagship enters the battlefield or attacks, it deals 3 damage to target creature or planeswalker an opponent controls.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "33da5ee5-1ff3-54ae-851f-2d686fcb764d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832abb5-5107-4603-904e-491b221bd3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832abb5-5107-4603-904e-491b221bd3e3.jpg?1",
             "name": "Smuggler's Copter",
             "text": "Flying\nWhenever Smuggler's Copter attacks or blocks, you may draw a card. If you do, discard a card.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "90494316-350c-5176-83a5-1e87adc982c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687febd3-1825-4fd2-b9ab-bd32a9baffc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687febd3-1825-4fd2-b9ab-bd32a9baffc7.jpg?1",
             "name": "Snare Thopter",
             "text": "Flying, haste",
             "colours": [],
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "64e0867d-7e0c-5d5a-bc0f-317194d2047e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf9a88-c5f8-4c26-a2ee-d2827e9a31d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf9a88-c5f8-4c26-a2ee-d2827e9a31d8.jpg?1",
             "name": "Torch Gauntlet",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7969,7 +7969,7 @@
         },
         {
             "id": "e7c8a81a-aec9-57fa-92b8-f39c702efad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75720c1b-8b04-4e45-ab47-018c04576e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75720c1b-8b04-4e45-ab47-018c04576e83.jpg?1",
             "name": "Weldfast Monitor",
             "text": "{R}: Weldfast Monitor gains menace until end of turn.",
             "colours": [],
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "8a4ca27c-1a81-53f1-a676-489ee099ea48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1a1246-d5a0-43dc-825a-062a3bb4def9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1a1246-d5a0-43dc-825a-062a3bb4def9.jpg?1",
             "name": "Whirlermaker",
             "text": "{4}, {T}: Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "1fc70f38-7785-571d-ac9d-e4d1349341d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d7420-f16d-4910-adf7-6deff47ecf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d7420-f16d-4910-adf7-6deff47ecf1e.jpg?1",
             "name": "Woodweaver's Puzzleknot",
             "text": "When Woodweaver's Puzzleknot enters the battlefield, you gain 3 life and get {E}{E}{E} (three energy counters).\n{2}{G}, Sacrifice Woodweaver's Puzzleknot: You gain 3 life and get {E}{E}{E}.",
             "colours": [],
@@ -8060,7 +8060,7 @@
         },
         {
             "id": "7784a6eb-2ff2-5ee3-9649-e48834093f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509a1a3a-d9a6-4903-95f6-dae6b330f4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509a1a3a-d9a6-4903-95f6-dae6b330f4ea.jpg?1",
             "name": "Workshop Assistant",
             "text": "When Workshop Assistant dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -8091,7 +8091,7 @@
         },
         {
             "id": "57b404f8-1969-5262-9bfa-b9b2e3729752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea04d8-5d85-49d3-8d8d-7fe123d0ed6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea04d8-5d85-49d3-8d8d-7fe123d0ed6c.jpg?1",
             "name": "Aether Hub",
             "text": "When Aether Hub enters the battlefield, you get {E} (an energy counter).\n{T}: Add {C} to your mana pool.\n{T}, Pay {E}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8119,7 +8119,7 @@
         },
         {
             "id": "64d39ad9-7e16-544e-b531-483cbf6c5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da33d4-fe9c-42fe-b326-2fe337dc3ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da33d4-fe9c-42fe-b326-2fe337dc3ecd.jpg?1",
             "name": "Blooming Marsh",
             "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8150,7 +8150,7 @@
         },
         {
             "id": "d769cf36-47e1-5a43-bb74-5a1777bc0f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8744471b-a528-47d9-84d0-4526273f55e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8744471b-a528-47d9-84d0-4526273f55e9.jpg?1",
             "name": "Botanical Sanctum",
             "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8181,7 +8181,7 @@
         },
         {
             "id": "86995bdf-9a82-5501-8efa-7434a241bf54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8769e97-aee8-4466-a9d7-0f4245ae4a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8769e97-aee8-4466-a9d7-0f4245ae4a97.jpg?1",
             "name": "Concealed Courtyard",
             "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8212,7 +8212,7 @@
         },
         {
             "id": "c43fae16-a919-5d77-b952-7b9fbea71868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160ac412-005f-48ca-a204-10207307c6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160ac412-005f-48ca-a204-10207307c6c2.jpg?1",
             "name": "Inspiring Vantage",
             "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8243,7 +8243,7 @@
         },
         {
             "id": "65378049-749a-535a-9021-b028a54d57be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275471e3-ded1-40ac-91ef-369dce5764d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275471e3-ded1-40ac-91ef-369dce5764d9.jpg?1",
             "name": "Inventors' Fair",
             "text": "At the beginning of your upkeep, if you control three or more artifacts, you gain 1 life.\n{T}: Add {C} to your mana pool.\n{4}, {T}, Sacrifice Inventors' Fair: Search your library for an artifact card, reveal it, put it into your hand, then shuffle your library. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -8273,7 +8273,7 @@
         },
         {
             "id": "c300440d-c031-58d9-8cab-1150dda8ac18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a17084-bb96-4e81-bff0-005bd44a1fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a17084-bb96-4e81-bff0-005bd44a1fbd.jpg?1",
             "name": "Sequestered Stash",
             "text": "{T}: Add {C} to your mana pool.\n{4}, {T}, Sacrifice Sequestered Stash: Put the top five cards of your library into your graveyard. Then you may put an artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -8301,7 +8301,7 @@
         },
         {
             "id": "5f092bac-80d7-5e97-bd98-8ffb5a2c2346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e587ea7-0632-4789-ba75-3c410da2bb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e587ea7-0632-4789-ba75-3c410da2bb96.jpg?1",
             "name": "Spirebluff Canal",
             "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8332,7 +8332,7 @@
         },
         {
             "id": "1ab8edeb-254e-514d-9b07-ce07fd415806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32912b82-bbe5-4d70-817d-cd18bfdecacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32912b82-bbe5-4d70-817d-cd18bfdecacb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8369,7 +8369,7 @@
         },
         {
             "id": "a8d9d2fd-1eab-571c-8ef5-bd25d5a33321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41416-bc0f-4e49-9137-df8572e91ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41416-bc0f-4e49-9137-df8572e91ae5.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "0e4dd86c-f308-597e-8087-8858e9b83da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879162e8-3a10-40da-8d86-9a7dff67c961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879162e8-3a10-40da-8d86-9a7dff67c961.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8443,7 +8443,7 @@
         },
         {
             "id": "aa56ca7c-430a-53ca-8800-3bca8f56fa3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca139d8-08a1-45d4-be9d-2ee5c9b3de43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca139d8-08a1-45d4-be9d-2ee5c9b3de43.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "c75cfb4e-9620-5124-b30c-653c8bb19863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086d6aed-1f7e-4a80-8d66-01d995f344ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086d6aed-1f7e-4a80-8d66-01d995f344ed.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8517,7 +8517,7 @@
         },
         {
             "id": "d9e2677d-9074-5383-9dd1-ef53f8c40cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197080a9-ebb5-4a8b-81f8-0368c5bba35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197080a9-ebb5-4a8b-81f8-0368c5bba35a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "64242f9e-d81a-5f75-82fa-3f3be1aad9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4760cdcc-e973-439c-a74a-5cb73b4fa22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4760cdcc-e973-439c-a74a-5cb73b4fa22f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "ed1e67b6-87df-51a2-806c-e439b2648322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f8ee-1416-4be8-9da1-f4546164c522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f8ee-1416-4be8-9da1-f4546164c522.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8628,7 +8628,7 @@
         },
         {
             "id": "7d10c362-6fee-540c-8ee0-a800f68b63ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364ee0ec-4970-4a30-bf5b-b045a6122860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364ee0ec-4970-4a30-bf5b-b045a6122860.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8665,7 +8665,7 @@
         },
         {
             "id": "8428ca03-8964-5acb-ae86-c82fc07316df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b4a0e0-3d27-414b-80cb-352f16389a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b4a0e0-3d27-414b-80cb-352f16389a83.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "cd5c0124-6ae4-591c-8401-81a4a1b319ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72d883e-d194-4154-a96c-35e601c5f797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72d883e-d194-4154-a96c-35e601c5f797.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "61f00e71-8554-5dfd-b0ae-f0986ceb6bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b65f77-85c1-49cd-bb2e-70e5225ace9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b65f77-85c1-49cd-bb2e-70e5225ace9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "57869970-bb45-5cdf-8944-2f541d141a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e67efe-cc8a-4132-9019-26ddfc72a735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e67efe-cc8a-4132-9019-26ddfc72a735.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8813,7 +8813,7 @@
         },
         {
             "id": "1542ff69-86bd-53aa-913d-07d747e0b0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2864a75-2945-4467-be00-3b4b71831f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2864a75-2945-4467-be00-3b4b71831f4f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "53dee5ae-d118-5654-8bee-c24c9abec4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8bd63e-303e-402c-9ad2-4f6e55ed0e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8bd63e-303e-402c-9ad2-4f6e55ed0e14.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8887,7 +8887,7 @@
         },
         {
             "id": "d3d00dce-d9b9-5670-94c8-17e0035620ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab8435b-5fe8-4074-8809-46aa6e5504c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab8435b-5fe8-4074-8809-46aa6e5504c8.jpg?1",
             "name": "Chandra, Pyrogenius",
             "text": "+2: Chandra, Pyrogenius deals 2 damage to each opponent.\n\u22123: Chandra, Pyrogenius deals 4 damage to target creature.\n\u221210: Chandra, Pyrogenius deals 6 damage to target player and each creature he or she controls.",
             "colours": [
@@ -8922,7 +8922,7 @@
         },
         {
             "id": "66ed454d-05ae-5d41-9946-759cec012075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44e3cb-cc69-4222-87bc-ffa54b7ab34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44e3cb-cc69-4222-87bc-ffa54b7ab34a.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to target creature or player.",
             "colours": [
@@ -8953,7 +8953,7 @@
         },
         {
             "id": "5053131a-c727-5221-b521-4c630c26f8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d2156e-2d54-440e-b0fd-7bef702afbfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d2156e-2d54-440e-b0fd-7bef702afbfc.jpg?1",
             "name": "Liberating Combustion",
             "text": "Liberating Combustion deals 6 damage to target creature. You may search your library and/or graveyard for a card named Chandra, Pyrogenius, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "c04950de-e529-5740-99ae-76473e8e5762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633884-867c-4b51-bd5b-5f246d0ecd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633884-867c-4b51-bd5b-5f246d0ecd4e.jpg?1",
             "name": "Renegade Firebrand",
             "text": "As long as you control a Chandra planeswalker, Renegade Firebrand gets +1/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "83ceb0e5-8ffc-5717-adf0-a3b8b1ba212b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214a439-b388-4f41-a897-725e56d23fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214a439-b388-4f41-a897-725e56d23fe8.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "6ad705b1-8a3d-5215-a97f-abd4e589b050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777533c3-0a87-4625-8987-d850fc236ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777533c3-0a87-4625-8987-d850fc236ddb.jpg?1",
             "name": "Nissa, Nature's Artisan",
             "text": "+3: You gain 3 life.\n\u22124: Reveal the top two cards of your library. Put all land cards from among them onto the battlefield and the rest into your hand.\n\u221212: Creatures you control get +5/+5 and gain trample until end of turn.",
             "colours": [
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "19c7b9e5-e941-5111-9be9-31364fa0191d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72638ac5-84fd-4688-9b81-0eea3c05e53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72638ac5-84fd-4688-9b81-0eea3c05e53e.jpg?1",
             "name": "Guardian of the Great Conduit",
             "text": "Reach (This creature can block creatures with flying.)\nAs long as you control a Nissa planeswalker, Guardian of the Great Conduit gets +2/+0 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "31b35586-4796-552a-88e7-4f8dc6284c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b89e5c-ffb4-406f-99d1-ec2797aca061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b89e5c-ffb4-406f-99d1-ec2797aca061.jpg?1",
             "name": "Terrain Elemental",
             "text": "",
             "colours": [
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "d32f5f06-897f-57d8-a1db-9df47647717e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07997554-9fd7-4d6f-abaf-6c3fda9644d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07997554-9fd7-4d6f-abaf-6c3fda9644d2.jpg?1",
             "name": "Terrain Elemental",
             "text": "",
             "colours": [
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "79c058d4-18f7-516b-aed3-e38cba54a21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea890019-f48f-4164-b057-773499ef273f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea890019-f48f-4164-b057-773499ef273f.jpg?1",
             "name": "Verdant Crescendo",
             "text": "Search your library for a basic land card and put it onto the battlefield tapped. Search your library and graveyard for a card named Nissa, Nature's Artisan, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -9217,7 +9217,7 @@
         },
         {
             "id": "355a3df3-6b53-5b55-b89c-3f09d11b8da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a333bbdc-5af7-4679-b263-3aaa056452a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a333bbdc-5af7-4679-b263-3aaa056452a0.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "43d997bc-e6fb-5d74-8c96-9f7bb8c8e8f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de1d095-459f-42fd-9d9f-8f71d002a5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de1d095-459f-42fd-9d9f-8f71d002a5b2.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [],
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "1322fef2-b30e-5895-aa28-f0fa0879a89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a08d1-f5ff-48b7-bdb6-54b8d7a4b931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a08d1-f5ff-48b7-bdb6-54b8d7a4b931.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -9309,7 +9309,7 @@
         },
         {
             "id": "36d79a78-afc0-5abc-8157-037512af9d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f071a-f250-4a2b-9060-da27f2fc0f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f071a-f250-4a2b-9060-da27f2fc0f48.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "c2951084-f8a8-5e6c-bb0b-4cd5f3a8b26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60842b1a-6ae7-4b3b-a23f-0d94a3d89884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60842b1a-6ae7-4b3b-a23f-0d94a3d89884.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "0c159f1d-c5e0-5ff5-9634-772cd3526dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79e2bf1-d26d-4be3-a5ad-a43346ed445a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79e2bf1-d26d-4be3-a5ad-a43346ed445a.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "150509ae-ac3b-5e5a-9670-0cc97ab89d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1980809-4c81-4080-92cd-31776962a4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1980809-4c81-4080-92cd-31776962a4e1.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "fc01d548-995f-5697-80d7-301382c1c049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd03a2b9-bfd7-4e1d-b660-e9f945699b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd03a2b9-bfd7-4e1d-b660-e9f945699b78.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "9d0d0374-386c-58e1-aa0f-6a517a1af119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d39524b-a4af-44ed-8f04-50680628c28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d39524b-a4af-44ed-8f04-50680628c28f.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -9495,7 +9495,7 @@
         },
         {
             "id": "6d455809-dce4-52fe-964c-02a3bbdf7eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9a3d08-040a-4fec-b86d-c41a074f925c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9a3d08-040a-4fec-b86d-c41a074f925c.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -9526,7 +9526,7 @@
         },
         {
             "id": "8a6cb21e-58b7-5eb0-9990-2602c22ce8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ce1db3-417c-4c22-84e5-c463addde476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ce1db3-417c-4c22-84e5-c463addde476.jpg?1",
             "name": "Chandra, Torch of Defiance Emblem",
             "text": "",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "95e9e55d-9581-5f65-a0d8-a2f73241a09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54986eaa-1bbb-4d34-ae09-fa7de2627ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54986eaa-1bbb-4d34-ae09-fa7de2627ba0.jpg?1",
             "name": "Nissa, Vital Force Emblem",
             "text": "",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "990e91b7-c20e-54eb-aa7f-f8246d36c48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ccde7-c78d-4f4a-9fe4-ad6986e2cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ccde7-c78d-4f4a-9fe4-ad6986e2cb8e.jpg?1",
             "name": "Dovin Baan Emblem",
             "text": "",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "9327a71d-09d2-5918-ad9f-b1949f3cf34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a446b9f8-cb22-408a-93ff-bee44a0dccc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a446b9f8-cb22-408a-93ff-bee44a0dccc0.jpg?1",
             "name": "Energy Reserve",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/KTK.json
+++ b/Assets/Resources/Sets/KTK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f7e45242-33fa-5e09-8632-868d89b2fb9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5427b1-f1c2-4bb3-8736-701667ac2256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5427b1-f1c2-4bb3-8736-701667ac2256.jpg?1",
             "name": "Abzan Battle Priest",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has lifelink.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "ec479532-374c-551a-864d-a9b939527cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ee4f3c-dc94-4156-b0ed-60fe6310451a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ee4f3c-dc94-4156-b0ed-60fe6310451a.jpg?1",
             "name": "Abzan Falconer",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "155497e8-9b23-51e7-aead-c3eae36e29d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2a844-17fc-4628-9591-684555e98f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2a844-17fc-4628-9591-684555e98f7b.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "678ac4fd-f92e-5c9f-836e-3ff03b051b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1ce529-06ed-4e85-9988-8c8b58401ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1ce529-06ed-4e85-9988-8c8b58401ed5.jpg?1",
             "name": "Alabaster Kirin",
             "text": "Flying, vigilance",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "ed5e70e0-034f-5fef-ae07-50131c1f92ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9c2b8a-148c-4393-b691-e333ad11c44e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9c2b8a-148c-4393-b691-e333ad11c44e.jpg?1",
             "name": "Brave the Sands",
             "text": "Creatures you control have vigilance.\nEach creature you control can block an additional creature.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "b3ee3be5-37b9-50a6-8fe0-80d5750f908f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce43a2df-4305-4ab1-ae45-96cca597650e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce43a2df-4305-4ab1-ae45-96cca597650e.jpg?1",
             "name": "Dazzling Ramparts",
             "text": "Defender\n{1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "804021f9-9979-5423-ac2b-948f2f74c5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ec83fa-5cb4-4633-8827-36d874a2d2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ec83fa-5cb4-4633-8827-36d874a2d2e7.jpg?1",
             "name": "Defiant Strike",
             "text": "Target creature gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "b97cf8a9-26d2-5a20-9b3d-1164ad4ff4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a53ed7-a7b7-40d8-9239-cf6f205dbc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a53ed7-a7b7-40d8-9239-cf6f205dbc59.jpg?1",
             "name": "End Hostilities",
             "text": "Destroy all creatures and all permanents attached to creatures.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "c2e995b6-07f1-59a5-9539-1c769a230430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd0e10-2ad7-467f-8d4b-c70b95bf2e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd0e10-2ad7-467f-8d4b-c70b95bf2e9c.jpg?1",
             "name": "Erase",
             "text": "Exile target enchantment.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "085b7d80-1a2c-5002-bc68-3427ae850695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6173466-30db-4b95-a556-dd69e03b731e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6173466-30db-4b95-a556-dd69e03b731e.jpg?1",
             "name": "Feat of Resistance",
             "text": "Put a +1/+1 counter on target creature you control. It gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "0e7b0b5b-4cdb-5cfd-a071-8a5f7bccacb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2b284-f79c-41eb-a25f-4710d4a5228f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2b284-f79c-41eb-a25f-4710d4a5228f.jpg?1",
             "name": "Firehoof Cavalry",
             "text": "{3}{R}: Firehoof Cavalry gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "c41509e1-fb42-5d53-875a-bd54138d7eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf6ed4-48f3-419f-bafd-d1ee4d798482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf6ed4-48f3-419f-bafd-d1ee4d798482.jpg?1",
             "name": "Herald of Anafenza",
             "text": "Outlast {2}{W} ({2}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nWhenever you activate Herald of Anafenza's outlast ability, put a 1/1 white Warrior creature token onto the battlefield.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "c8caeaeb-c01a-50c6-88ca-5444189a3097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5f4bab-f918-4b42-b82c-cfcf5ff0c58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5f4bab-f918-4b42-b82c-cfcf5ff0c58a.jpg?1",
             "name": "High Sentinels of Arashin",
             "text": "Flying\nHigh Sentinels of Arashin gets +1/+1 for each other creature you control with a +1/+1 counter on it.\n{3}{W}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "f2574b13-1166-5ddb-962d-0935bd65c4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9007c528-0107-40fd-a97e-e5576f297eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9007c528-0107-40fd-a97e-e5576f297eb2.jpg?1",
             "name": "Jeskai Student",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "74627ab2-3f44-55b4-9c67-6eafce3077c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30d4136-78a3-4760-83af-d365cc97d118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30d4136-78a3-4760-83af-d365cc97d118.jpg?1",
             "name": "Kill Shot",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "89cd914c-63e1-5c45-87b3-c28359a9014e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d1cdfa-834c-4028-8036-c4bfb7da071b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d1cdfa-834c-4028-8036-c4bfb7da071b.jpg?1",
             "name": "Mardu Hateblade",
             "text": "{B}: Mardu Hateblade gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "4b098f64-f37a-5b65-8ed7-e3dcf83a66eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23426221-30a8-4be2-9c70-f0eb022edad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23426221-30a8-4be2-9c70-f0eb022edad7.jpg?1",
             "name": "Mardu Hordechief",
             "text": "Raid \u2014 When Mardu Hordechief enters the battlefield, if you attacked with a creature this turn, put a 1/1 white Warrior creature token onto the battlefield.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "8c87011a-b42e-5653-8aa4-f9509039ace8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8455229-6fec-4843-b888-e701c09620af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8455229-6fec-4843-b888-e701c09620af.jpg?1",
             "name": "Master of Pearls",
             "text": "Morph {3}{W}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Master of Pearls is turned face up, creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "a8cc72f0-0862-5dd0-81e6-f5ccac89f49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47d8aa-59c8-4e2c-bb48-328ae924dbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47d8aa-59c8-4e2c-bb48-328ae924dbb3.jpg?1",
             "name": "Rush of Battle",
             "text": "Creatures you control get +2/+1 until end of turn. Warrior creatures you control gain lifelink until end of turn. (Damage dealt by those Warriors also causes their controller to gain that much life.)",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "3566d8a7-9f24-5308-ad65-faf520f88879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc7b4c3-647e-48da-86f8-f55e3e990ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc7b4c3-647e-48da-86f8-f55e3e990ac1.jpg?1",
             "name": "Sage-Eye Harrier",
             "text": "Flying\nMorph {3}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "87d49a97-0939-5be4-8ec8-84c6f226867d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ee84d-e5b9-4103-8ba7-ccd79a272c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ee84d-e5b9-4103-8ba7-ccd79a272c0f.jpg?1",
             "name": "Salt Road Patrol",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "f1b82e29-f4b4-5df3-aee7-790b3d157456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c17e350-44f7-4413-ad24-7c5d6616effd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c17e350-44f7-4413-ad24-7c5d6616effd.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "38e62d02-c08d-5a5e-8444-2557961711d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd17ef9-9f1b-4937-a60a-d7175f04eef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd17ef9-9f1b-4937-a60a-d7175f04eef2.jpg?1",
             "name": "Siegecraft",
             "text": "Enchant creature\nEnchanted creature gets +2/+4.",
             "colours": [
@@ -787,7 +787,7 @@
         },
         {
             "id": "0438b370-c689-5534-9968-fca3c760aa30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1405bb2e-2204-43ab-82a3-5d0c8537325a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1405bb2e-2204-43ab-82a3-5d0c8537325a.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "fcb9bedb-5317-5a95-880d-88b1a73cdeb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5c9628-1801-43d9-8bb4-4cca168510b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5c9628-1801-43d9-8bb4-4cca168510b2.jpg?1",
             "name": "Suspension Field",
             "text": "When Suspension Field enters the battlefield, you may exile target creature with toughness 3 or greater until Suspension Field leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "42066ed7-12c8-50b7-98c6-d8a1bfa27bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc783f49-f58a-4783-87b4-4dbc7e896f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc783f49-f58a-4783-87b4-4dbc7e896f2e.jpg?1",
             "name": "Take Up Arms",
             "text": "Put three 1/1 white Warrior creature tokens onto the battlefield.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "1f90370b-66f2-526c-8b47-bb2a19f6ce0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb3c08e-b591-421a-898a-533021cbabd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb3c08e-b591-421a-898a-533021cbabd2.jpg?1",
             "name": "Timely Hordemate",
             "text": "Raid \u2014 When Timely Hordemate enters the battlefield, if you attacked with a creature this turn, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "b0bc7985-4f23-5b8b-9bda-738994b208db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229919ef-e39f-4bdc-bcc5-46224a3eb7b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229919ef-e39f-4bdc-bcc5-46224a3eb7b4.jpg?1",
             "name": "Venerable Lammasu",
             "text": "Flying",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "c6f4c9f2-4693-5610-be11-b61a7dbfb312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652109b9-d607-42b6-945d-0c0dd5bba89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652109b9-d607-42b6-945d-0c0dd5bba89c.jpg?1",
             "name": "War Behemoth",
             "text": "Morph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "e4ba6ef9-7d05-5598-8a49-a75b8e4dd0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8684039-e4d9-4e48-9a41-7ccf4a795507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8684039-e4d9-4e48-9a41-7ccf4a795507.jpg?1",
             "name": "Watcher of the Roost",
             "text": "Flying\nMorph\u2014\nReveal a white card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Watcher of the Roost is turned face up, you gain 2 life.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "4a7a9d0c-b5a5-5dac-b653-b1d7e4a03207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f0f6a2-b392-45e6-97c4-4f00016144d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f0f6a2-b392-45e6-97c4-4f00016144d3.jpg?1",
             "name": "Wingmate Roc",
             "text": "Flying\nRaid \u2014 When Wingmate Roc enters the battlefield, if you attacked with a creature this turn, put a 3/4 white Bird creature token with flying onto the battlefield.\nWhenever Wingmate Roc attacks, you gain 1 life for each attacking creature.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "2b914584-70b8-5b16-82a3-06d9ad1c8f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b588355-c349-458d-aeb7-0e2780caa3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b588355-c349-458d-aeb7-0e2780caa3f9.jpg?1",
             "name": "Blinding Spray",
             "text": "Creatures your opponents control get -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "c95e0357-f3fa-52f8-9a3d-b3b27149a976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f540dcb-8d0b-4d33-8c0d-893fa5db54eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f540dcb-8d0b-4d33-8c0d-893fa5db54eb.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "e502db19-a246-5e79-ab37-640acc996e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8fffd3-81ad-47e3-a27b-d8059f2b506f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8fffd3-81ad-47e3-a27b-d8059f2b506f.jpg?1",
             "name": "Clever Impersonator",
             "text": "You may have Clever Impersonator enter the battlefield as a copy of any nonland permanent on the battlefield.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "9db0fc97-db9b-5ce8-8725-40de514e9745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf53a79-7573-43c2-bd3a-93abea58ba80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf53a79-7573-43c2-bd3a-93abea58ba80.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "9544ddce-b079-522d-8282-541baee0ca0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18c2d8-995c-4736-bdef-464abcd1d31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18c2d8-995c-4736-bdef-464abcd1d31a.jpg?1",
             "name": "Dig Through Time",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nLook at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "939b6ffe-85f5-5cb8-ae23-c93587d478ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180425c9-1898-48d4-9932-ddfb1a28e6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180425c9-1898-48d4-9932-ddfb1a28e6b0.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "d80095ab-f5c1-5556-b865-e1ed13ac35da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff29b2c-2156-45fd-a2dd-655b8d208197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff29b2c-2156-45fd-a2dd-655b8d208197.jpg?1",
             "name": "Dragon's Eye Savants",
             "text": "Morph\u2014\nReveal a blue card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Dragon's Eye Savants is turned face up, look at target opponent's hand.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "810d8b57-81d6-5270-bee7-6cee7a06d553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e07226-f180-4972-b7f8-90c743d45fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e07226-f180-4972-b7f8-90c743d45fb8.jpg?1",
             "name": "Embodiment of Spring",
             "text": "{1}{G}, {T}, Sacrifice Embodiment of Spring: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "56965aa8-caf8-57a8-a4c7-f4423daa7ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda70b3e-4b70-404e-a579-41dd126be084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda70b3e-4b70-404e-a579-41dd126be084.jpg?1",
             "name": "Force Away",
             "text": "Return target creature to its owner's hand.\nFerocious \u2014 If you control a creature with power 4 or greater, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "0957f09e-86fd-5dbd-ba60-20915c704421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8821c7b9-702b-416f-b006-941ad57f9e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8821c7b9-702b-416f-b006-941ad57f9e11.jpg?1",
             "name": "Glacial Stalker",
             "text": "Morph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1385,7 +1385,7 @@
         },
         {
             "id": "164f13ab-4fd7-55af-91bd-34a6eb153904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b098f029-6b5d-49e4-9a81-f497ebbdb5ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b098f029-6b5d-49e4-9a81-f497ebbdb5ce.jpg?1",
             "name": "Icy Blast",
             "text": "Tap X target creatures.\nFerocious \u2014 If you control a creature with power 4 or greater, those creatures don't untap during their controllers' next untap steps.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "daa2d15e-d56e-5450-926c-553c3e19fe7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff9907c-4090-4dcc-aaf5-bc2a8dacce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff9907c-4090-4dcc-aaf5-bc2a8dacce8b.jpg?1",
             "name": "Jeskai Elder",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jeskai Elder deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "c41480f6-a666-50c4-a897-b4bd44837c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66356e38-38e1-4b09-80c2-be26007ff99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66356e38-38e1-4b09-80c2-be26007ff99c.jpg?1",
             "name": "Jeskai Windscout",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "d519d779-eae0-5e00-a55b-2a7b6851f247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e15117f-f05e-4c5d-9ef5-98f21f4d7529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e15117f-f05e-4c5d-9ef5-98f21f4d7529.jpg?1",
             "name": "Kheru Spellsnatcher",
             "text": "Morph {4}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Kheru Spellsnatcher is turned face up, counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may cast that card without paying its mana cost for as long as it remains exiled.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "5c24ba9e-0178-5ecd-947b-16d50e5e5248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8003a31f-7662-4e9e-8165-1ceea04fdf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8003a31f-7662-4e9e-8165-1ceea04fdf20.jpg?1",
             "name": "Mistfire Weaver",
             "text": "Flying\nMorph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Mistfire Weaver is turned face up, target creature you control gains hexproof until end of turn.",
             "colours": [
@@ -1557,7 +1557,7 @@
         },
         {
             "id": "9db7837b-8c85-5b83-8c92-50fd2ad6644f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53c0e50-4b0b-43d8-80c0-2c216722c87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53c0e50-4b0b-43d8-80c0-2c216722c87a.jpg?1",
             "name": "Monastery Flock",
             "text": "Defender, flying\nMorph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "394de2e1-fe82-57ef-860d-83eea6cacd97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5de843-e05d-43b5-a5d0-a737484fbd71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5de843-e05d-43b5-a5d0-a737484fbd71.jpg?1",
             "name": "Mystic of the Hidden Way",
             "text": "Mystic of the Hidden Way can't be blocked.\nMorph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "05f453ea-19e7-5ca7-8cd3-04da14190ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbee4d2f-6b41-4717-a1c6-831034452bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbee4d2f-6b41-4717-a1c6-831034452bec.jpg?1",
             "name": "Pearl Lake Ancient",
             "text": "Flash\nPearl Lake Ancient can't be countered.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nReturn three lands you control to their owner's hand: Return Pearl Lake Ancient to its owner's hand.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "836d8b9d-53b6-59af-906c-4cf3f88f3eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc7c9d5-904e-4ab6-9773-5c4f1c6d34c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc7c9d5-904e-4ab6-9773-5c4f1c6d34c4.jpg?1",
             "name": "Quiet Contemplation",
             "text": "Whenever you cast a noncreature spell, you may pay {1}. If you do, tap target creature an opponent controls and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "ade59e7d-abe1-5b68-b469-7eb080b3ba38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c210b102-8a94-4b5e-858a-777fa8ad18b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c210b102-8a94-4b5e-858a-777fa8ad18b9.jpg?1",
             "name": "Riverwheel Aerialists",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "36d9a760-2dd1-53a7-8798-84214a25a017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8110eb0a-63dc-43df-b55a-9241f45b1cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8110eb0a-63dc-43df-b55a-9241f45b1cc6.jpg?1",
             "name": "Scaldkin",
             "text": "Flying\n{2}{R}, Sacrifice Scaldkin: Scaldkin deals 2 damage to target creature or player.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "46397bb9-edbf-5ee9-8d61-4a81f3ed9116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e370939-831b-4c42-8291-8ffb0b6c1af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e370939-831b-4c42-8291-8ffb0b6c1af7.jpg?1",
             "name": "Scion of Glaciers",
             "text": "{U}: Scion of Glaciers gets +1/-1 until end of turn.",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "618d3fcf-e257-5326-8ea0-1540ab5fb36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad122d-a872-449f-9a7c-0f054b711d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad122d-a872-449f-9a7c-0f054b711d11.jpg?1",
             "name": "Set Adrift",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nPut target nonland permanent on top of its owner's library.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "ae6f842b-feab-5564-9b6a-07bfd71c3562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670f24e1-dec9-42e6-b762-c447366ed16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670f24e1-dec9-42e6-b762-c447366ed16c.jpg?1",
             "name": "Singing Bell Strike",
             "text": "Enchant creature\nWhen Singing Bell Strike enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"{6}: Untap this creature.\"",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "c7142e4e-7699-5f3b-b11b-677c6a546112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8626c4-306f-4e9d-8840-2bb73fe87e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8626c4-306f-4e9d-8840-2bb73fe87e87.jpg?1",
             "name": "Stubborn Denial",
             "text": "Counter target noncreature spell unless its controller pays {1}.\nFerocious \u2014 If you control a creature with power 4 or greater, counter that spell instead.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "a97153ce-63eb-5a79-9813-389cabe77913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f4b533-7113-4b36-9c7a-e4cf798c88a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f4b533-7113-4b36-9c7a-e4cf798c88a9.jpg?1",
             "name": "Taigam's Scheming",
             "text": "Look at the top five cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "75836a21-9c64-563e-9e24-e8cb3aa60e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249b453c-0d5b-4af9-aaec-ebd2f19c5d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249b453c-0d5b-4af9-aaec-ebd2f19c5d23.jpg?1",
             "name": "Thousand Winds",
             "text": "Flying\nMorph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Thousand Winds is turned face up, return all other tapped creatures to their owners' hands.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "61fda89e-aaa0-5dbe-ba17-714876581301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a59d4b1-6cf4-44ec-8a96-1bb7094fea21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a59d4b1-6cf4-44ec-8a96-1bb7094fea21.jpg?1",
             "name": "Treasure Cruise",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "df4fd2b8-676c-54d9-97a2-bce3a72938ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd58503-d269-4756-a71c-a6a2bfb1658d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd58503-d269-4756-a71c-a6a2bfb1658d.jpg?1",
             "name": "Waterwhirl",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "9d175471-3de8-59e5-95de-72bf8237488d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a1f9c1-25a3-465f-b3d8-98f0867c9bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a1f9c1-25a3-465f-b3d8-98f0867c9bb6.jpg?1",
             "name": "Weave Fate",
             "text": "Draw two cards.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "bbc16600-0878-5bd5-9667-84c4e4b5f25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71a86e0-d15a-4fba-94f6-bfbaade8d837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71a86e0-d15a-4fba-94f6-bfbaade8d837.jpg?1",
             "name": "Wetland Sambar",
             "text": "",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "e4d030e8-02fb-5a04-9cd4-4e6a37329542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c9bd9c-900a-48a1-9cfe-2f8d031af6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c9bd9c-900a-48a1-9cfe-2f8d031af6b8.jpg?1",
             "name": "Whirlwind Adept",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2125,7 +2125,7 @@
         },
         {
             "id": "b072e17d-1490-5012-ab41-696edfe1abfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939b5d-e24f-4e4b-b4c5-8bdb232d8926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939b5d-e24f-4e4b-b4c5-8bdb232d8926.jpg?1",
             "name": "Bellowing Saddlebrute",
             "text": "Raid \u2014 When Bellowing Saddlebrute enters the battlefield, you lose 4 life unless you attacked with a creature this turn.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "0a499de7-798f-5cc5-bb42-434e0ec6f340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42f5aa9-2a47-47c3-ab87-dc25735b0e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42f5aa9-2a47-47c3-ab87-dc25735b0e54.jpg?1",
             "name": "Bitter Revelation",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.",
             "colours": [
@@ -2192,7 +2192,7 @@
         },
         {
             "id": "8112b0cf-129b-55a5-b363-721b7b546e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bc9bb0-5ec1-400f-89e7-b450980a3391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bc9bb0-5ec1-400f-89e7-b450980a3391.jpg?1",
             "name": "Bloodsoaked Champion",
             "text": "Bloodsoaked Champion can't block.\nRaid \u2014 {1}{B}: Return Bloodsoaked Champion from your graveyard to the battlefield. Activate this ability only if you attacked with a creature this turn.",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "cd62e815-dad4-548f-9427-99a50dd9b39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff25a19a-8f98-47ef-847c-ba526c82b290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff25a19a-8f98-47ef-847c-ba526c82b290.jpg?1",
             "name": "Dead Drop",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget player sacrifices two creatures.",
             "colours": [
@@ -2259,7 +2259,7 @@
         },
         {
             "id": "426d02df-8015-5e71-b263-349007089762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b2b263-34db-4961-bf41-1eaaba3701da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b2b263-34db-4961-bf41-1eaaba3701da.jpg?1",
             "name": "Debilitating Injury",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "7a90835a-b9ab-5fb1-bc81-1016b5e614e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64216ce3-945e-42d8-9127-cf11c687da67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64216ce3-945e-42d8-9127-cf11c687da67.jpg?1",
             "name": "Despise",
             "text": "Target opponent reveals his or her hand. You choose a creature or planeswalker card from it. That player discards that card.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "8255a511-c747-5359-986f-8a38967e817d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd496-632d-4d6d-a529-f35cf3222de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd496-632d-4d6d-a529-f35cf3222de7.jpg?1",
             "name": "Disowned Ancestor",
             "text": "Outlast {1}{B} ({1}{B}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "0e21cda2-d4a3-50c3-b4c1-e4e893dc3396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f83b3a-ce34-4179-8745-059181dd79b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f83b3a-ce34-4179-8745-059181dd79b8.jpg?1",
             "name": "Dutiful Return",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "2d633e3a-7718-5002-ba9e-7ad687ed7419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b1ac7-dd7b-46a1-a74e-aa0563bab3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b1ac7-dd7b-46a1-a74e-aa0563bab3cd.jpg?1",
             "name": "Empty the Pits",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nPut X 2/2 black Zombie creature tokens onto the battlefield tapped.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "438539a6-87d5-5167-897e-48c9ffa30556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1fe2bf-1640-4781-87b4-09a1f7d35831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1fe2bf-1640-4781-87b4-09a1f7d35831.jpg?1",
             "name": "Grim Haruspex",
             "text": "Morph {B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever another nontoken creature you control dies, draw a card.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "123ef5b4-c5df-57b6-bc7a-e2302e8ca49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7492918-b3c6-468f-9484-d73f0a27b37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7492918-b3c6-468f-9484-d73f0a27b37b.jpg?1",
             "name": "Gurmag Swiftwing",
             "text": "Flying, first strike, haste",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "f16e8452-b761-5917-a1cd-955e399ca200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf15cd4-13be-48e7-b3f5-a5106eb02c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf15cd4-13be-48e7-b3f5-a5106eb02c45.jpg?1",
             "name": "Kheru Bloodsucker",
             "text": "Whenever a creature you control with toughness 4 or greater dies, each opponent loses 2 life and you gain 2 life.\n{2}{B}, Sacrifice another creature: Put a +1/+1 counter on Kheru Bloodsucker.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "67838960-9277-5cd6-8a87-00b9f0831038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b10468-18b8-4321-a791-0cbd18ea9c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b10468-18b8-4321-a791-0cbd18ea9c4d.jpg?1",
             "name": "Kheru Dreadmaw",
             "text": "Defender\n{1}{G}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "a7898d26-cecb-5f98-9bae-ef1e968eb918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f38391-ffb7-4420-9a38-f791627b12b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f38391-ffb7-4420-9a38-f791627b12b3.jpg?1",
             "name": "Krumar Bond-Kin",
             "text": "Morph {4}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "669c7bd3-7817-5efb-a1bb-aab786430887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3ca5e7-96f3-4326-9315-34bb396a054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3ca5e7-96f3-4326-9315-34bb396a054c.jpg?1",
             "name": "Mardu Skullhunter",
             "text": "Mardu Skullhunter enters the battlefield tapped.\nRaid \u2014 When Mardu Skullhunter enters the battlefield, if you attacked with a creature this turn, target opponent discards a card.",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "863e4aa1-7f5b-5bf2-87b8-ac86360ca2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8589b2-9527-46ba-bf9e-0dec7d84d5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8589b2-9527-46ba-bf9e-0dec7d84d5d2.jpg?1",
             "name": "Mer-Ek Nightblade",
             "text": "Outlast {B} ({B}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has deathtouch.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "fe05f26f-26be-56bb-ba41-8c1dc036d7ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b781cbcf-dbba-41c1-be02-2396b824a217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b781cbcf-dbba-41c1-be02-2396b824a217.jpg?1",
             "name": "Molting Snakeskin",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"{2}{B}: Regenerate this creature.\"",
             "colours": [
@@ -2702,7 +2702,7 @@
         },
         {
             "id": "cf935c91-b1d8-534b-a68b-cc025bb16875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dadff2-883f-4134-a881-be145cdcbd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dadff2-883f-4134-a881-be145cdcbd84.jpg?1",
             "name": "Murderous Cut",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDestroy target creature.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "cb1262a1-93f2-5e44-bf2b-0060edc0e413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093426d2-29e0-49e4-b02a-a70cce3b25d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093426d2-29e0-49e4-b02a-a70cce3b25d5.jpg?1",
             "name": "Necropolis Fiend",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying\n{X}, {T}, Exile X cards from your graveyard: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "9ab096bf-3531-599d-aa1a-6e2b75ac3ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3e423e-cb62-43e1-9d0c-e702f823c8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3e423e-cb62-43e1-9d0c-e702f823c8e1.jpg?1",
             "name": "Raiders' Spoils",
             "text": "Creatures you control get +1/+0.\nWhenever a Warrior you control deals combat damage to a player, you may pay 1 life. If you do, draw a card.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "f6e38d97-a63e-568a-92fb-589c4ca2d84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae62a43e-36ce-471e-93f1-21fe674858b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae62a43e-36ce-471e-93f1-21fe674858b5.jpg?1",
             "name": "Rakshasa's Secret",
             "text": "Target opponent discards two cards. Put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "e99347b2-054a-584f-a0d7-828e15865fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3ee29d-b374-471d-80c3-bcad7a4226e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3ee29d-b374-471d-80c3-bcad7a4226e6.jpg?1",
             "name": "Retribution of the Ancients",
             "text": "{B}, Remove X +1/+1 counters from among creatures you control: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "2ad79f27-3760-54d1-b88f-641f928e843f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005b9fec-66de-4079-88e0-c7de7e22d18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005b9fec-66de-4079-88e0-c7de7e22d18e.jpg?1",
             "name": "Rite of the Serpent",
             "text": "Destroy target creature. If that creature had a +1/+1 counter on it, put a 1/1 green Snake creature token onto the battlefield.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "72c9300e-cf9d-5208-828d-315b0897c864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1564a20a-0e57-4ced-9eda-7acff74274e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1564a20a-0e57-4ced-9eda-7acff74274e7.jpg?1",
             "name": "Rotting Mastodon",
             "text": "",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "7307d81e-33a2-528f-915f-fad3a9189880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c67b11-a82e-4a25-88a4-5771ab5c4f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c67b11-a82e-4a25-88a4-5771ab5c4f00.jpg?1",
             "name": "Ruthless Ripper",
             "text": "Deathtouch\nMorph\u2014\nReveal a black card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Ruthless Ripper is turned face up, target player loses 2 life.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "004157f3-5c88-5c8c-a264-b297ed080622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459ca25c-775f-4110-8d70-59720692ab27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459ca25c-775f-4110-8d70-59720692ab27.jpg?1",
             "name": "Shambling Attendants",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "08e321c9-82b1-57eb-b207-ea85b683aa84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e02a99-da37-4cea-9182-39ccb1e35ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e02a99-da37-4cea-9182-39ccb1e35ee9.jpg?1",
             "name": "Sidisi's Pet",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nMorph {1}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "46d181f1-3596-5762-802c-4043e2d57987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8e423-f7e7-4ac3-acc2-2a3722e409e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8e423-f7e7-4ac3-acc2-2a3722e409e7.jpg?1",
             "name": "Sultai Scavenger",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "7b481c7d-2ba5-54be-8165-a5559993377d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd36319-e05d-4a9e-a6d4-48fba9111648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd36319-e05d-4a9e-a6d4-48fba9111648.jpg?1",
             "name": "Swarm of Bloodflies",
             "text": "Flying\nSwarm of Bloodflies enters the battlefield with two +1/+1 counters on it.\nWhenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "77f738f3-62d1-578d-8e67-8cb6a56abe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c00-3f38-47dc-90bc-6464d346c098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c00-3f38-47dc-90bc-6464d346c098.jpg?1",
             "name": "Throttle",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "17247d46-698c-5bfc-8e29-9617686c78c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a232d196-490d-4712-b2a2-466751b28d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a232d196-490d-4712-b2a2-466751b28d11.jpg?1",
             "name": "Unyielding Krumar",
             "text": "{1}{W}: Unyielding Krumar gains first strike until end of turn.",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "94a859ae-a4f7-5dfe-9662-2e1afc07e589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20d6dfd-5f7b-4c71-89e6-8f996d85801d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20d6dfd-5f7b-4c71-89e6-8f996d85801d.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "5dba7143-a462-5211-b2f8-694e87b9210d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff9400d-4842-471f-bf7e-3b21df352e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff9400d-4842-471f-bf7e-3b21df352e0a.jpg?1",
             "name": "Ainok Tracker",
             "text": "First strike\nMorph {4}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "9da4572d-c440-5e52-80a1-aa0325bf9e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7c392-6782-40c8-bb24-6aad24f14660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7c392-6782-40c8-bb24-6aad24f14660.jpg?1",
             "name": "Arc Lightning",
             "text": "Arc Lightning deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -3271,7 +3271,7 @@
         },
         {
             "id": "e2ed71b1-572a-5e9d-a087-84506848064e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57534fb-2591-4003-aeec-6452faa4a759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57534fb-2591-4003-aeec-6452faa4a759.jpg?1",
             "name": "Arrow Storm",
             "text": "Arrow Storm deals 4 damage to target creature or player.\nRaid \u2014 If you attacked with a creature this turn, instead Arrow Storm deals 5 damage to that creature or player and the damage can't be prevented.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "309ed39c-7886-52bd-a537-dedf4f9f74a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a53752c-5689-4939-9a8b-bf59d88d7c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a53752c-5689-4939-9a8b-bf59d88d7c6b.jpg?1",
             "name": "Ashcloud Phoenix",
             "text": "Flying\nWhen Ashcloud Phoenix dies, return it to the battlefield face down.\nMorph {4}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Ashcloud Phoenix is turned face up, it deals 2 damage to each player.",
             "colours": [
@@ -3337,7 +3337,7 @@
         },
         {
             "id": "3a214a87-3e85-579e-bfb2-d6c434d5291d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb1a9f7-32ba-48fd-a7f7-788b0ec052c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb1a9f7-32ba-48fd-a7f7-788b0ec052c6.jpg?1",
             "name": "Barrage of Boulders",
             "text": "Barrage of Boulders deals 1 damage to each creature you don't control.\nFerocious \u2014 If you control a creature with power 4 or greater, creatures can't block this turn.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "45a8fce8-3dc2-5faa-965c-f4286fee4332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0742564e-f7a7-4107-b9ed-63703ca4702c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0742564e-f7a7-4107-b9ed-63703ca4702c.jpg?1",
             "name": "Bloodfire Expert",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "6c530f37-0983-51ed-a398-3ae9672d0eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4836fb70-a8f3-44ed-bae4-890ef7d07f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4836fb70-a8f3-44ed-bae4-890ef7d07f88.jpg?1",
             "name": "Bloodfire Mentor",
             "text": "{2}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "8edb7a3c-2471-5566-9386-530851d372cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba5e7bf-2ad8-4061-937a-ef1e9b63da3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba5e7bf-2ad8-4061-937a-ef1e9b63da3d.jpg?1",
             "name": "Bring Low",
             "text": "Bring Low deals 3 damage to target creature. If that creature has a +1/+1 counter on it, Bring Low deals 5 damage to it instead.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "2f21fd55-d43e-550e-adb2-44acd5287258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b24e40-c0f0-4472-973e-d3b0e88fc93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b24e40-c0f0-4472-973e-d3b0e88fc93e.jpg?1",
             "name": "Burn Away",
             "text": "Burn Away deals 6 damage to target creature. When that creature dies this turn, exile all cards from its controller's graveyard.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "719cc261-11f0-5f03-963e-37bafecff314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6c56d1-6eca-43be-9834-0478bea67b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6c56d1-6eca-43be-9834-0478bea67b48.jpg?1",
             "name": "Canyon Lurkers",
             "text": "Morph {3}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "93275283-9982-5a2c-bd33-e982766a4632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dde66b-b4a1-4a1e-8c9e-0bec4790b1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dde66b-b4a1-4a1e-8c9e-0bec4790b1e5.jpg?1",
             "name": "Crater's Claws",
             "text": "Crater's Claws deals X damage to target creature or player.\nFerocious \u2014 Crater's Claws deals X plus 2 damage to that creature or player instead if you control a creature with power 4 or greater.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "03186774-1137-5a8b-9451-8476de7644e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0269d5bd-d8aa-465b-bfe9-6703937f933c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0269d5bd-d8aa-465b-bfe9-6703937f933c.jpg?1",
             "name": "Dragon Grip",
             "text": "Ferocious \u2014 If you control a creature with power 4 or greater, you may cast Dragon Grip as though it had flash. (You may cast it any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+0 and has first strike.",
             "colours": [
@@ -3605,7 +3605,7 @@
         },
         {
             "id": "e6af7c1c-2c1c-5dda-b885-b0543db75c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646edf58-4bc5-4d87-af68-b8b006ccb806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646edf58-4bc5-4d87-af68-b8b006ccb806.jpg?1",
             "name": "Dragon-Style Twins",
             "text": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "7f29a7e7-8a95-59ea-acec-13193e6c559f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d80e96-3956-4408-84fb-5f94a364eb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d80e96-3956-4408-84fb-5f94a364eb41.jpg?1",
             "name": "Goblinslide",
             "text": "Whenever you cast a noncreature spell, you may pay {1}. If you do, put a 1/1 red Goblin creature token with haste onto the battlefield.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "d1ef0b7e-6c1a-5108-8b70-27412f487e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53926b92-adf0-4bb2-873f-103d9a1bdda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53926b92-adf0-4bb2-873f-103d9a1bdda8.jpg?1",
             "name": "Horde Ambusher",
             "text": "Whenever Horde Ambusher blocks, it deals 1 damage to you.\nMorph\u2014\nReveal a red card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Horde Ambusher is turned face up, target creature can't block this turn.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "ffeef7c1-8ef2-5322-bbe0-4817db9143ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c1bf52-2737-423a-b340-07448afcaea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c1bf52-2737-423a-b340-07448afcaea6.jpg?1",
             "name": "Hordeling Outburst",
             "text": "Put three 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "fa149d64-0700-525c-85a9-9c4d55567f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4baf3-f0dc-4b27-8323-a76764332590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4baf3-f0dc-4b27-8323-a76764332590.jpg?1",
             "name": "Howl of the Horde",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nRaid \u2014 If you attacked with a creature this turn, when you cast your next instant or sorcery spell this turn, copy that spell an additional time. You may choose new targets for the copy.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "904455bd-cf23-555d-b15f-3c4b411362b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72777ccf-1cd8-45e8-8dfb-0a42550b5607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72777ccf-1cd8-45e8-8dfb-0a42550b5607.jpg?1",
             "name": "Jeering Instigator",
             "text": "Morph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Jeering Instigator is turned face up, if it's your turn, gain control of another target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "838fc418-3e02-5bc1-82a3-48e54011780a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f786a1d-4703-4bac-abba-632506d2726c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f786a1d-4703-4bac-abba-632506d2726c.jpg?1",
             "name": "Leaping Master",
             "text": "{2}{W}: Leaping Master gains flying until end of turn.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "2986f351-15fc-5561-8e83-7b91548dcf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf7a797-f32a-4ed2-b835-a356120f5817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf7a797-f32a-4ed2-b835-a356120f5817.jpg?1",
             "name": "Mardu Blazebringer",
             "text": "When Mardu Blazebringer attacks or blocks, sacrifice it at end of combat.",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "dfb5aee3-76b4-5a5a-943b-6f136edd1403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17b6eee-da22-48aa-ba8a-cbd1a3389bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17b6eee-da22-48aa-ba8a-cbd1a3389bcb.jpg?1",
             "name": "Mardu Heart-Piercer",
             "text": "Raid \u2014 When Mardu Heart-Piercer enters the battlefield, if you attacked with a creature this turn, Mardu Heart-Piercer deals 2 damage to target creature or player.",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "eb0c06a5-5887-5b6c-855c-79fda9301419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381ae25-0d44-4d06-beae-48e4bbb4bb45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381ae25-0d44-4d06-beae-48e4bbb4bb45.jpg?1",
             "name": "Mardu Warshrieker",
             "text": "Raid \u2014 When Mardu Warshrieker enters the battlefield, if you attacked with a creature this turn, add {R}{W}{B} to your mana pool.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "c2dfe6ed-8fcf-54f6-822c-c637f725a65a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81c6c8b-a9cf-4866-89ba-7f8ad077b836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81c6c8b-a9cf-4866-89ba-7f8ad077b836.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "1eb3ada8-f422-5524-bf92-8463cddd8051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58064fd-4d8b-4f54-812f-0bb1d7e2ddc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58064fd-4d8b-4f54-812f-0bb1d7e2ddc2.jpg?1",
             "name": "Sarkhan, the Dragonspeaker",
             "text": "+1: Until end of turn, Sarkhan, the Dragonspeaker becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste. (He doesn't lose loyalty while he's not a planeswalker.)\n\u22123: Sarkhan, the Dragonspeaker deals 4 damage to target creature.\n\u22126: You get an emblem with \"At the beginning of your draw step, draw two additional cards\" and \"At the beginning of your end step, discard your hand.\"",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "0e17b309-4d64-5f56-9de4-d28326a6b032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4ecaa0-a85f-4771-a829-1ab440b29165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4ecaa0-a85f-4771-a829-1ab440b29165.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "b16d21b2-a033-5eec-9e7f-bfb11703a7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f998fb-4518-4a0c-8b1e-55393b6ff9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f998fb-4518-4a0c-8b1e-55393b6ff9c4.jpg?1",
             "name": "Summit Prowler",
             "text": "",
             "colours": [
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "9de10a1a-00b6-5f9c-b5c8-13c844a09e16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc3120c-7e04-4c4a-af16-da264593a1d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc3120c-7e04-4c4a-af16-da264593a1d1.jpg?1",
             "name": "Swift Kick",
             "text": "Target creature you control gets +1/+0 until end of turn. It fights target creature you don't control.",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "faa1832a-f2d0-5fe4-98a9-06c082f40a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25af9ac1-a03b-4be7-b726-fb66427b1caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25af9ac1-a03b-4be7-b726-fb66427b1caa.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "9d2dae80-0601-55c3-adfa-8a8645db319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6deef5-876f-4c81-8af5-6e91e0c4656a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6deef5-876f-4c81-8af5-6e91e0c4656a.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "b9790ed3-7c2e-5b0c-a363-5ca88aaed8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8543adbd-0dd1-47d3-ac41-2ec72d6a5d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8543adbd-0dd1-47d3-ac41-2ec72d6a5d35.jpg?1",
             "name": "Valley Dasher",
             "text": "Haste\nValley Dasher attacks each turn if able.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "c511fa2c-5bfc-5516-af13-672215b763ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d1714b-ff65-4c5c-ad21-b469f2c72286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d1714b-ff65-4c5c-ad21-b469f2c72286.jpg?1",
             "name": "War-Name Aspirant",
             "text": "Raid \u2014 War-Name Aspirant enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.\nWar-Name Aspirant can't be blocked by creatures with power 1 or less.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "0bd12511-6170-5fc0-9dc2-83f0b7baf31f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bbf983-df71-4403-86f3-2e86aa8765b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bbf983-df71-4403-86f3-2e86aa8765b8.jpg?1",
             "name": "Alpine Grizzly",
             "text": "",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "47f48b76-e451-524a-bc3d-82f7f05579c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ac0667-8ecc-4034-89bb-dce0af531014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ac0667-8ecc-4034-89bb-dce0af531014.jpg?1",
             "name": "Archers' Parapet",
             "text": "Defender\n{1}{B}, {T}: Each opponent loses 1 life.",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "87c115d2-a3f7-5e35-9509-a69e84cae0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803a6ac7-9327-4c2f-b023-93f5f65f83b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803a6ac7-9327-4c2f-b023-93f5f65f83b8.jpg?1",
             "name": "Awaken the Bear",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "195dfacd-7c27-5ec5-acf0-d29418bf8a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17b65e-56c3-4e12-a774-780514dfd8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17b65e-56c3-4e12-a774-780514dfd8ba.jpg?1",
             "name": "Become Immense",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget creature gets +6/+6 until end of turn.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "bb06fc41-4ffc-5277-90e3-64dfd202197a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aadb382-f912-4ccb-98bc-1abdef733126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aadb382-f912-4ccb-98bc-1abdef733126.jpg?1",
             "name": "Dragonscale Boon",
             "text": "Put two +1/+1 counters on target creature and untap it.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "067aac58-286e-5e72-a99d-91499bf53d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f7c53d-0b53-400f-aa67-967547f3e394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f7c53d-0b53-400f-aa67-967547f3e394.jpg?1",
             "name": "Feed the Clan",
             "text": "You gain 5 life.\nFerocious \u2014 You gain 10 life instead if you control a creature with power 4 or greater.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "6aeb4c60-b77e-5054-bd4c-45212f128091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdf1db-bfaf-4160-8003-1fa2e56b00dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdf1db-bfaf-4160-8003-1fa2e56b00dc.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be placed on a creature you control, that many plus one +1/+1 counters are placed on it instead.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "3cfe2e23-dbaf-5520-8172-38ac5ed1af3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0995e041-fe90-4459-8c70-fd9851ecf830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0995e041-fe90-4459-8c70-fd9851ecf830.jpg?1",
             "name": "Heir of the Wilds",
             "text": "Deathtouch\nFerocious \u2014 Whenever Heir of the Wilds attacks, if you control a creature with power 4 or greater, Heir of the Wilds gets +1/+1 until end of turn.",
             "colours": [
@@ -4516,7 +4516,7 @@
         },
         {
             "id": "3d0804e7-ca3e-5010-9d1c-edf5c2595625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb10a9-486a-4b9a-b3f5-c17f661af2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb10a9-486a-4b9a-b3f5-c17f661af2b2.jpg?1",
             "name": "Highland Game",
             "text": "When Highland Game dies, you gain 2 life.",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "69f40292-e955-5a4f-9687-621000767a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7e651f-4187-44c5-99bf-34042d6dd9a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7e651f-4187-44c5-99bf-34042d6dd9a2.jpg?1",
             "name": "Hooded Hydra",
             "text": "Hooded Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Hooded Hydra dies, put a 1/1 green Snake creature token onto the battlefield for each +1/+1 counter on it.\nMorph {3}{G}{G}\nAs Hooded Hydra is turned face up, put five +1/+1 counters on it.",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "163a4224-b8f3-5e88-8c6f-6506c228879d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090d678c-f0e4-4757-8900-93dfe67aefe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090d678c-f0e4-4757-8900-93dfe67aefe9.jpg?1",
             "name": "Hooting Mandrills",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTrample",
             "colours": [
@@ -4619,7 +4619,7 @@
         },
         {
             "id": "e233ab6e-b5a9-5a96-ba7a-001c6e9ae39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7d833-f71b-4ec4-aad1-07b7583bad64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7d833-f71b-4ec4-aad1-07b7583bad64.jpg?1",
             "name": "Incremental Growth",
             "text": "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "6dbb9aab-c2d9-59dd-8ea3-d954c6a29acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddafbc-590b-4610-894a-b91335a60528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddafbc-590b-4610-894a-b91335a60528.jpg?1",
             "name": "Kin-Tree Warden",
             "text": "{2}: Regenerate Kin-Tree Warden.\nMorph {G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4686,7 +4686,7 @@
         },
         {
             "id": "46fc8fab-0155-5b26-aed3-cb7dfcd5ba36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9edd62-dc18-4887-a020-4464e31b79c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9edd62-dc18-4887-a020-4464e31b79c2.jpg?1",
             "name": "Longshot Squad",
             "text": "Outlast {1}{G} ({1}{G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has reach. (A creature with reach can block creatures with flying.)",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "90a1d9f3-479d-5eac-b339-7232aedd0652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a945b43d-39bc-4ce4-be03-0109e1a681b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a945b43d-39bc-4ce4-be03-0109e1a681b1.jpg?1",
             "name": "Meandering Towershell",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Meandering Towershell attacks, exile it. Return it to the battlefield under your control tapped and attacking at the beginning of the declare attackers step on your next turn.",
             "colours": [
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "20d2b003-6c96-535c-9199-279fde626b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b129b44e-a1ce-41f2-a0cf-b6c879c7cbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b129b44e-a1ce-41f2-a0cf-b6c879c7cbbd.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "7293bbd2-1aa0-5d40-9bd5-cc4415d7607b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a49d9c-8fe7-494b-9a26-cf4bde71e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a49d9c-8fe7-494b-9a26-cf4bde71e420.jpg?1",
             "name": "Pine Walker",
             "text": "Morph {4}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever Pine Walker or another creature you control is turned face up, untap that creature.",
             "colours": [
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "7f45dd41-6a5b-5d40-b2e8-1fad3726fd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb6c2e0-eeaa-4d60-aab7-2b8c739a9278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb6c2e0-eeaa-4d60-aab7-2b8c739a9278.jpg?1",
             "name": "Rattleclaw Mystic",
             "text": "{T}: Add {G}, {U}, or {R} to your mana pool.\nMorph {2} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Rattleclaw Mystic is turned face up, add {G}{U}{R} to your mana pool.",
             "colours": [
@@ -4858,7 +4858,7 @@
         },
         {
             "id": "feeb98b4-633b-5490-996a-84469333ab85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83456f8f-8a1a-403c-816b-25e454ba1edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83456f8f-8a1a-403c-816b-25e454ba1edf.jpg?1",
             "name": "Roar of Challenge",
             "text": "All creatures able to block target creature this turn do so.\nFerocious \u2014 That creature gains indestructible until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "b044519a-9cc9-5fcd-9fdd-c34ea72366d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a26baca-467e-4d94-873e-f266bebd5fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a26baca-467e-4d94-873e-f266bebd5fd8.jpg?1",
             "name": "Sagu Archer",
             "text": "Reach (This creature can block creatures with flying.)\nMorph {4}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "50fe4e88-abab-5a44-afe5-ef1a6e6c4927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6b50dc-244a-4df5-a9a9-5a2b8f30d40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6b50dc-244a-4df5-a9a9-5a2b8f30d40c.jpg?1",
             "name": "Savage Punch",
             "text": "Target creature you control fights target creature you don't control.\nFerocious \u2014 The creature you control gets +2/+2 until end of turn before it fights if you control a creature with power 4 or greater.",
             "colours": [
@@ -4957,7 +4957,7 @@
         },
         {
             "id": "90971b83-48fd-5b7b-8fec-a9cb391c356e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb15c6c7-8fe6-496c-9977-3e7942b920c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb15c6c7-8fe6-496c-9977-3e7942b920c4.jpg?1",
             "name": "Scout the Borders",
             "text": "Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "75fe9de3-71f2-5ad2-90bd-cdef0e1a2347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689a7f1-9713-412e-a030-9cba463c170e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689a7f1-9713-412e-a030-9cba463c170e.jpg?1",
             "name": "See the Unwritten",
             "text": "Reveal the top eight cards of your library. You may put a creature card from among them onto the battlefield. Put the rest into your graveyard.\nFerocious \u2014 If you control a creature with power 4 or greater, you may put two creature cards onto the battlefield instead of one.",
             "colours": [
@@ -5021,7 +5021,7 @@
         },
         {
             "id": "4542aa9f-2f2c-5c3b-803f-f1b80ee5f938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5269292-11be-4647-9074-7ce8115bf36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5269292-11be-4647-9074-7ce8115bf36f.jpg?1",
             "name": "Seek the Horizon",
             "text": "Search your library for up to three basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -5053,7 +5053,7 @@
         },
         {
             "id": "f811931c-810f-58cd-86e4-50be261ec920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1916a2d9-4747-4118-b1b2-7a5ce492e3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1916a2d9-4747-4118-b1b2-7a5ce492e3fc.jpg?1",
             "name": "Smoke Teller",
             "text": "{1}{U}: Look at target face-down creature.",
             "colours": [
@@ -5089,7 +5089,7 @@
         },
         {
             "id": "18d9f0ca-add0-580e-bcf8-3ad995978533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3b2ef3-551d-4782-8dce-a923c0e2965e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3b2ef3-551d-4782-8dce-a923c0e2965e.jpg?1",
             "name": "Sultai Flayer",
             "text": "Whenever a creature you control with toughness 4 or greater dies, you gain 4 life.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "2a448bb0-e87f-5978-a6bc-4dd4bead18fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77258fc-8683-4656-84a3-4df4ea2a8435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77258fc-8683-4656-84a3-4df4ea2a8435.jpg?1",
             "name": "Temur Charger",
             "text": "Morph\u2014\nReveal a green card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Temur Charger is turned face up, target creature gains trample until end of turn.",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "1f26c293-6045-54c3-aa23-d250ad3cbfde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6149685f-cb05-4c1f-95a4-3810505d1a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6149685f-cb05-4c1f-95a4-3810505d1a95.jpg?1",
             "name": "Trail of Mystery",
             "text": "Whenever a face-down creature enters the battlefield under your control, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nWhenever a permanent you control is turned face up, if it's a creature, it gets +2/+2 until end of turn.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "ed9bc771-3f64-5cf5-baee-a50927400d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d511407-0c1e-4342-a578-ca557c6886fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d511407-0c1e-4342-a578-ca557c6886fd.jpg?1",
             "name": "Tusked Colossodon",
             "text": "",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "04beb49a-2af1-5107-ae08-d4ad1172114f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b341cc65-d316-41bb-95b8-294afa019a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b341cc65-d316-41bb-95b8-294afa019a71.jpg?1",
             "name": "Tuskguard Captain",
             "text": "Outlast {G} ({G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "ba313f3c-4230-5b9d-a267-a06eaa6ad9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154dc31c-ac9d-4b78-b92b-e7bacc532915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154dc31c-ac9d-4b78-b92b-e7bacc532915.jpg?1",
             "name": "Windstorm",
             "text": "Windstorm deals X damage to each creature with flying.",
             "colours": [
@@ -5291,7 +5291,7 @@
         },
         {
             "id": "58ad74dd-6e19-5f96-9694-f2cee61a442e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890c55a-8746-4233-b75a-19cc760c1e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890c55a-8746-4233-b75a-19cc760c1e8e.jpg?1",
             "name": "Woolly Loxodon",
             "text": "Morph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "8e8670b3-323a-563b-b83c-2ada06e4023f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df9759e-1072-4a6a-be57-f73b15bf3847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df9759e-1072-4a6a-be57-f73b15bf3847.jpg?1",
             "name": "Abomination of Gudul",
             "text": "Flying\nWhenever Abomination of Gudul deals combat damage to a player, you may draw a card. If you do, discard a card.\nMorph {2}{B}{G}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5364,7 +5364,7 @@
         },
         {
             "id": "f2572440-4d6c-53ac-9729-1a13e54b5034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af53a53-d30a-4289-a043-953cd81ee241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af53a53-d30a-4289-a043-953cd81ee241.jpg?1",
             "name": "Abzan Ascendancy",
             "text": "When Abzan Ascendancy enters the battlefield, put a +1/+1 counter on each creature you control.\nWhenever a nontoken creature you control dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "c7722ac3-3e52-5854-a9cb-abaaf28737e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b7598-35b0-4bb5-8347-8c868500f846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b7598-35b0-4bb5-8347-8c868500f846.jpg?1",
             "name": "Abzan Charm",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power 3 or greater.\n\u2022 You draw two cards and you lose 2 life.\n\u2022 Distribute two +1/+1 counters among one or two target creatures.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "49b03c62-9c50-525f-aa26-63e666065b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7f7158-4a31-4a1c-bf3b-574c0b09276a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7f7158-4a31-4a1c-bf3b-574c0b09276a.jpg?1",
             "name": "Abzan Guide",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nMorph {2}{W}{B}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "4e2a75aa-1a3a-51c0-9f44-d393baf50d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b432a7-53da-4480-b571-e6feb1364a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b432a7-53da-4480-b571-e6feb1364a3a.jpg?1",
             "name": "Anafenza, the Foremost",
             "text": "Whenever Anafenza, the Foremost attacks, put a +1/+1 counter on another target tapped creature you control.\nIf a creature card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -5516,7 +5516,7 @@
         },
         {
             "id": "f9202e4e-465e-51b0-a0c0-92631f65294d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5bb5d2-181a-44ea-9b56-87f8d96bf634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5bb5d2-181a-44ea-9b56-87f8d96bf634.jpg?1",
             "name": "Ankle Shanker",
             "text": "Haste\nWhenever Ankle Shanker attacks, creatures you control gain first strike and deathtouch until end of turn.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "d16c4f56-d1b1-58f0-8f08-77bf51f5921e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c69876-809d-4af3-9fd6-3bac41541dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c69876-809d-4af3-9fd6-3bac41541dad.jpg?1",
             "name": "Armament Corps",
             "text": "When Armament Corps enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "a075afeb-1f0f-55f5-bd8b-5bc1f096a709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e3f12-53d5-45f4-8ccc-6c00f8a9c6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e3f12-53d5-45f4-8ccc-6c00f8a9c6fe.jpg?1",
             "name": "Avalanche Tusker",
             "text": "Whenever Avalanche Tusker attacks, target creature defending player controls blocks it this combat if able.",
             "colours": [
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "157b7cc9-d634-5a18-b749-5c0815355815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6912c5b-6aff-4506-96ca-acb5ce660322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6912c5b-6aff-4506-96ca-acb5ce660322.jpg?1",
             "name": "Bear's Companion",
             "text": "When Bear's Companion enters the battlefield, put a 4/4 green Bear creature token onto the battlefield.",
             "colours": [
@@ -5672,7 +5672,7 @@
         },
         {
             "id": "733231e4-96f4-5fe3-badc-19c8190423ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c76027b-9c8d-4181-9311-270fed0212e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c76027b-9c8d-4181-9311-270fed0212e3.jpg?1",
             "name": "Butcher of the Horde",
             "text": "Flying\nSacrifice another creature: Butcher of the Horde gains your choice of vigilance, lifelink, or haste until end of turn.",
             "colours": [
@@ -5710,7 +5710,7 @@
         },
         {
             "id": "5d88416e-4f22-53cc-9c10-2d3659aa6999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28822a9a-97fa-4784-ad97-072fcfc7b9ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28822a9a-97fa-4784-ad97-072fcfc7b9ed.jpg?1",
             "name": "Chief of the Edge",
             "text": "Other Warrior creatures you control get +1/+0.",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "f94b22e7-f5c5-57a8-9f2b-073a81622884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a227b8cc-cbe5-4955-ad1b-a354704a82e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a227b8cc-cbe5-4955-ad1b-a354704a82e8.jpg?1",
             "name": "Chief of the Scale",
             "text": "Other Warrior creatures you control get +0/+1.",
             "colours": [
@@ -5784,7 +5784,7 @@
         },
         {
             "id": "20011f49-5e60-54ed-ae75-9a46bf3182c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c7d53-2599-42a9-ae96-a2699c5164cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c7d53-2599-42a9-ae96-a2699c5164cb.jpg?1",
             "name": "Crackling Doom",
             "text": "Crackling Doom deals 2 damage to each opponent. Each opponent sacrifices a creature with the greatest power among creatures he or she controls.",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "734cfa5f-a4dc-5f80-b9a4-e917abbbac10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92096311-a3fa-41fc-b7a9-71ac2310f7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92096311-a3fa-41fc-b7a9-71ac2310f7fe.jpg?1",
             "name": "Death Frenzy",
             "text": "All creatures get -2/-2 until end of turn. Whenever a creature dies this turn, you gain 1 life.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "91890210-3060-58ba-8780-e5b78c43da4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32374918-1bcb-4516-96af-f27da752517e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32374918-1bcb-4516-96af-f27da752517e.jpg?1",
             "name": "Deflecting Palm",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. If damage is prevented this way, Deflecting Palm deals that much damage to that source's controller.",
             "colours": [
@@ -5888,7 +5888,7 @@
         },
         {
             "id": "e50d72a0-2f86-53d3-93eb-3d0129096c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d076ea5f-630a-4670-9b15-29fd2cececd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d076ea5f-630a-4670-9b15-29fd2cececd2.jpg?1",
             "name": "Duneblast",
             "text": "Choose up to one creature. Destroy the rest.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "26489b74-cbae-5621-93a4-cfcfbcde9588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8986cb2e-76e0-41f3-8810-3d11c39a527a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8986cb2e-76e0-41f3-8810-3d11c39a527a.jpg?1",
             "name": "Efreet Weaponmaster",
             "text": "First strike\nWhen Efreet Weaponmaster enters the battlefield or is turned face up, another target creature you control gets +3/+0 until end of turn.\nMorph {2}{U}{R}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "0535aecf-976a-5f7e-84ae-8ce9c27a68fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba7efe-ae5a-4d11-b535-1c2e5e6f5982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba7efe-ae5a-4d11-b535-1c2e5e6f5982.jpg?1",
             "name": "Flying Crane Technique",
             "text": "Untap all creatures you control. They gain flying and double strike until end of turn.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "aefa7f7b-b935-5582-800d-9c6742a98109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d3708b-dd40-4515-bf8f-36cbc5de6b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d3708b-dd40-4515-bf8f-36cbc5de6b67.jpg?1",
             "name": "Highspire Mantis",
             "text": "Flying, trample",
             "colours": [
@@ -6035,7 +6035,7 @@
         },
         {
             "id": "79ec3cee-14ca-5bd9-88f2-a131eb78ef81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdee089-8e89-4c99-9390-e8f4c189cffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdee089-8e89-4c99-9390-e8f4c189cffb.jpg?1",
             "name": "Icefeather Aven",
             "text": "Flying\nMorph {1}{G}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Icefeather Aven is turned face up, you may return another target creature to its owner's hand.",
             "colours": [
@@ -6072,7 +6072,7 @@
         },
         {
             "id": "4ed470b4-ec07-59b7-ab19-863b2ac121d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a8df73-0141-4c07-87d8-b1f34a4b374b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a8df73-0141-4c07-87d8-b1f34a4b374b.jpg?1",
             "name": "Ivorytusk Fortress",
             "text": "Untap each creature you control with a +1/+1 counter on it during each other player's untap step.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "95f4615c-23d6-5c97-bd0c-461af4855cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9c2522-5606-4bbd-863d-f0ab0a612b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9c2522-5606-4bbd-863d-f0ab0a612b4e.jpg?1",
             "name": "Jeskai Ascendancy",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn. Untap those creatures.\nWhenever you cast a noncreature spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -6146,7 +6146,7 @@
         },
         {
             "id": "0d835ec5-be0d-5009-8dac-6f933394d7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca268705-ef04-4bf1-8a5d-866bb3e5bb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca268705-ef04-4bf1-8a5d-866bb3e5bb61.jpg?1",
             "name": "Jeskai Charm",
             "text": "Choose one \u2014\n\u2022 Put target creature on top of its owner's library.\n\u2022 Jeskai Charm deals 4 damage to target opponent.\n\u2022 Creatures you control get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "cd110822-4eb9-52a3-a959-9e7ff0c9a8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbca8d-34a3-4df1-986a-36fca142a758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbca8d-34a3-4df1-986a-36fca142a758.jpg?1",
             "name": "Kheru Lich Lord",
             "text": "At the beginning of your upkeep, you may pay {2}{B}. If you do, return a creature card at random from your graveyard to the battlefield. It gains flying, trample, and haste. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "14a8c494-07b0-59ca-9410-6b47074054c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926b49a1-f220-41ab-8c67-8354a91a15e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926b49a1-f220-41ab-8c67-8354a91a15e8.jpg?1",
             "name": "Kin-Tree Invocation",
             "text": "Put an X/X black and green Spirit Warrior creature token onto the battlefield, where X is the greatest toughness among creatures you control.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "b2e0b768-e6c8-5576-9552-c7828a86e9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d5ce46-7118-4ede-ba1d-c387e7ce16e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d5ce46-7118-4ede-ba1d-c387e7ce16e7.jpg?1",
             "name": "Mantis Rider",
             "text": "Flying, vigilance, haste",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "6217fc46-b910-59b2-9272-bd0c51687190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bc2415-b1d1-467a-9578-3948dda166cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bc2415-b1d1-467a-9578-3948dda166cf.jpg?1",
             "name": "Mardu Ascendancy",
             "text": "Whenever a nontoken creature you control attacks, put a 1/1 red Goblin creature token onto the battlefield tapped and attacking.\nSacrifice Mardu Ascendancy: Creatures you control get +0/+3 until end of turn.",
             "colours": [
@@ -6330,7 +6330,7 @@
         },
         {
             "id": "37032212-1ca0-5c1c-ac96-5f282ea03f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35fb7a3-7c7f-4470-b1ad-5b8709a608e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35fb7a3-7c7f-4470-b1ad-5b8709a608e6.jpg?1",
             "name": "Mardu Charm",
             "text": "Choose one \u2014\n\u2022 Mardu Charm deals 4 damage to target creature.\n\u2022 Put two 1/1 white Warrior creature tokens onto the battlefield. They gain first strike until end of turn.\n\u2022 Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "81645c5f-c3c9-52b9-993d-ac7629fe612d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6341345-55a6-43f3-915a-c03afea92ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6341345-55a6-43f3-915a-c03afea92ec3.jpg?1",
             "name": "Mardu Roughrider",
             "text": "Whenever Mardu Roughrider attacks, target creature can't block this turn.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "c15f231e-2a1a-549a-ac39-cdaa4f99b93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704743a8-27d6-4db9-8fe1-f65f5f3a955f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704743a8-27d6-4db9-8fe1-f65f5f3a955f.jpg?1",
             "name": "Master the Way",
             "text": "Draw a card. Master the Way deals damage to target creature or player equal to the number of cards in your hand.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "9d69f2f9-1a9d-5de3-b455-e4c7501c9b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557e8303-a021-4257-b41a-7d25f04618c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557e8303-a021-4257-b41a-7d25f04618c8.jpg?1",
             "name": "Mindswipe",
             "text": "Counter target spell unless its controller pays {X}. Mindswipe deals X damage to that spell's controller.",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "15e45fe0-92ea-52dc-8665-7105ac30db70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f210adb7-b389-4672-a3eb-0ced9bfe190c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f210adb7-b389-4672-a3eb-0ced9bfe190c.jpg?1",
             "name": "Narset, Enlightened Master",
             "text": "First strike, hexproof\nWhenever Narset, Enlightened Master attacks, exile the top four cards of your library. Until end of turn, you may cast noncreature cards exiled with Narset this turn without paying their mana costs.",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "8a895088-0510-51fd-88ae-0791142517e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192d77ef-e8b5-44e2-842b-2c1f342c1e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192d77ef-e8b5-44e2-842b-2c1f342c1e69.jpg?1",
             "name": "Ponyback Brigade",
             "text": "When Ponyback Brigade enters the battlefield or is turned face up, put three 1/1 red Goblin creature tokens onto the battlefield.\nMorph {2}{R}{W}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6553,7 +6553,7 @@
         },
         {
             "id": "8f5602ef-0d92-50eb-9a29-4b7c79ddfe0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4e0b33-dad1-4443-a7c7-a7bab067d04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4e0b33-dad1-4443-a7c7-a7bab067d04a.jpg?1",
             "name": "Rakshasa Deathdealer",
             "text": "{B}{G}: Rakshasa Deathdealer gets +2/+2 until end of turn.\n{B}{G}: Regenerate Rakshasa Deathdealer.",
             "colours": [
@@ -6590,7 +6590,7 @@
         },
         {
             "id": "34f28b82-8280-54d5-9620-0b1e89d29ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb39e674-919d-4db6-9ac1-cfa1cca02207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb39e674-919d-4db6-9ac1-cfa1cca02207.jpg?1",
             "name": "Rakshasa Vizier",
             "text": "Whenever one or more cards are put into exile from your graveyard, put that many +1/+1 counters on Rakshasa Vizier.",
             "colours": [
@@ -6629,7 +6629,7 @@
         },
         {
             "id": "c339c58e-15b4-58ce-9d48-5a533dd580e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc9a434-9617-4a20-88f0-355b20f2c538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc9a434-9617-4a20-88f0-355b20f2c538.jpg?1",
             "name": "Ride Down",
             "text": "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn.",
             "colours": [
@@ -6663,7 +6663,7 @@
         },
         {
             "id": "be8f07e8-044f-5890-b960-34db19988c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c336b-3f70-4518-b1f1-7b773774895d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c336b-3f70-4518-b1f1-7b773774895d.jpg?1",
             "name": "Sage of the Inward Eye",
             "text": "Flying\nWhenever you cast a noncreature spell, creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "71a285ac-c477-54e8-ad38-1323491b66e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c64af58-963d-497b-ab95-104839d96b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c64af58-963d-497b-ab95-104839d96b94.jpg?1",
             "name": "Sagu Mauler",
             "text": "Trample, hexproof\nMorph {3}{G}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "dc7d4d17-7d6f-5b4b-a250-797a5e5de1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9dddd3-7c8d-4669-8298-58149b142b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9dddd3-7c8d-4669-8298-58149b142b8a.jpg?1",
             "name": "Savage Knuckleblade",
             "text": "{2}{G}: Savage Knuckleblade gets +2/+2 until end of turn. Activate this ability only once each turn.\n{2}{U}: Return Savage Knuckleblade to its owner's hand.\n{R}: Savage Knuckleblade gains haste until end of turn.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "231b76c5-779e-5d67-9ecf-85a6a42978ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01589046-a969-400f-b4ac-90cbbb814504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01589046-a969-400f-b4ac-90cbbb814504.jpg?1",
             "name": "Secret Plans",
             "text": "Face-down creatures you control get +0/+1.\nWhenever a permanent you control is turned face up, draw a card.",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "fd4ff2e8-9b8a-5c18-85db-09b42750b049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa2b070-952e-4242-83bb-3e73135ceeeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa2b070-952e-4242-83bb-3e73135ceeeb.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, put the top three cards of your library into your graveyard.\nWhenever one or more creature cards are put into your graveyard from your library, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "a1913893-a1a9-556b-be7d-0f166dc57b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9011126a-20bd-4c86-a63b-1691f79ac247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9011126a-20bd-4c86-a63b-1691f79ac247.jpg?1",
             "name": "Siege Rhino",
             "text": "Trample\nWhen Siege Rhino enters the battlefield, each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -6890,7 +6890,7 @@
         },
         {
             "id": "3846b095-6dca-577f-8aaf-b1d5cb301445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d9aa9b-1ed4-46db-89d1-6c9593c29f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d9aa9b-1ed4-46db-89d1-6c9593c29f55.jpg?1",
             "name": "Snowhorn Rider",
             "text": "Trample\nMorph {2}{G}{U}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6929,7 +6929,7 @@
         },
         {
             "id": "ceaf8582-0037-5541-8a7e-55ed61d6b64c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1a9643-34d6-4b4b-b896-2d4626eca40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1a9643-34d6-4b4b-b896-2d4626eca40a.jpg?1",
             "name": "Sorin, Solemn Visitor",
             "text": "+1: Until your next turn, creatures you control get +1/+0 and gain lifelink.\n\u22122: Put a 2/2 black Vampire creature token with flying onto the battlefield.\n\u22126: You get an emblem with \"At the beginning of each opponent's upkeep, that player sacrifices a creature.\"",
             "colours": [
@@ -6967,7 +6967,7 @@
         },
         {
             "id": "5aa6a4d0-6ba1-53aa-82d4-80fbb61a4aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3314d77a-039f-43e4-a457-6ceba20c0ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3314d77a-039f-43e4-a457-6ceba20c0ffe.jpg?1",
             "name": "Sultai Ascendancy",
             "text": "At the beginning of your upkeep, look at the top two cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "47c2a2bf-a9c8-56fd-a6f0-b15a299b37db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c9028-9b1b-4903-81b2-3cf4f37b7229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c9028-9b1b-4903-81b2-3cf4f37b7229.jpg?1",
             "name": "Sultai Charm",
             "text": "Choose one \u2014\n\u2022 Destroy target monocolored creature.\n\u2022 Destroy target artifact or enchantment.\n\u2022 Draw two cards, then discard a card.",
             "colours": [
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "bd290ebd-615c-57ac-bbf4-b8b026e220ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0de2c9-957e-41ee-8899-b93e6f1091dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0de2c9-957e-41ee-8899-b93e6f1091dc.jpg?1",
             "name": "Sultai Soothsayer",
             "text": "When Sultai Soothsayer enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "aa8f9334-998d-5452-81eb-73e3f490e0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03032d89-caca-43ff-b2ea-028e376c829c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03032d89-caca-43ff-b2ea-028e376c829c.jpg?1",
             "name": "Surrak Dragonclaw",
             "text": "Flash\nSurrak Dragonclaw can't be countered.\nCreature spells you control can't be countered.\nOther creatures you control have trample.",
             "colours": [
@@ -7119,7 +7119,7 @@
         },
         {
             "id": "3337f951-d608-50b4-aa19-954d1c3a2fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11746bf1-d813-4ade-8ce4-9935cebef856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11746bf1-d813-4ade-8ce4-9935cebef856.jpg?1",
             "name": "Temur Ascendancy",
             "text": "Creatures you control have haste.\nWhenever a creature with power 4 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -7155,7 +7155,7 @@
         },
         {
             "id": "7caa1fbd-ca51-59a3-b11f-78d0f5e1bcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee3e36-a849-42b0-b84b-027a08427c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee3e36-a849-42b0-b84b-027a08427c35.jpg?1",
             "name": "Temur Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+1 until end of turn. It fights target creature you don't control.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Creatures with power 3 or less can't block this turn.",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "760f946c-0849-5eb6-9289-4bb7871f36f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb37bd9-10a0-48d5-87f0-23a03b5c1072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb37bd9-10a0-48d5-87f0-23a03b5c1072.jpg?1",
             "name": "Trap Essence",
             "text": "Counter target creature spell. Put two +1/+1 counters on up to one target creature.",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "505d315a-2c03-54f5-82d4-8608d3fda3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39643107-8873-42f6-9b4d-b546a0a976ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39643107-8873-42f6-9b4d-b546a0a976ba.jpg?1",
             "name": "Utter End",
             "text": "Exile target nonland permanent.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "0294f8a5-33ba-5c4b-9e10-a640f9d7d87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610e69b-8b7c-40e4-bb10-28ee4411f861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610e69b-8b7c-40e4-bb10-28ee4411f861.jpg?1",
             "name": "Villainous Wealth",
             "text": "Target opponent exiles the top X cards of his or her library. You may cast any number of nonland cards with converted mana cost X or less from among them without paying their mana costs.",
             "colours": [
@@ -7297,7 +7297,7 @@
         },
         {
             "id": "48218cd4-8bf2-5deb-9611-d0626280ab6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04135bf7-2bcf-4a92-80f0-6d5eefca551b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04135bf7-2bcf-4a92-80f0-6d5eefca551b.jpg?1",
             "name": "Warden of the Eye",
             "text": "When Warden of the Eye enters the battlefield, return target noncreature, nonland card from your graveyard to your hand.",
             "colours": [
@@ -7336,7 +7336,7 @@
         },
         {
             "id": "17dfef20-c08a-5f61-a784-8699bb3f0739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8924ab9-fa55-4348-b67d-b2b9e48a357a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8924ab9-fa55-4348-b67d-b2b9e48a357a.jpg?1",
             "name": "Winterflame",
             "text": "Choose one or both \u2014\n\u2022 Tap target creature.\n\u2022 Winterflame deals 2 damage to target creature.",
             "colours": [
@@ -7370,7 +7370,7 @@
         },
         {
             "id": "cde24b01-b97c-5f77-9961-6d9ac24ab172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f4bafe-0d21-47ba-8f16-0274107d618c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f4bafe-0d21-47ba-8f16-0274107d618c.jpg?1",
             "name": "Zurgo Helmsmasher",
             "text": "Haste\nZurgo Helmsmasher attacks each combat if able.\nZurgo Helmsmasher has indestructible as long as it's your turn.\nWhenever a creature dealt damage by Zurgo Helmsmasher this turn dies, put a +1/+1 counter on Zurgo Helmsmasher.",
             "colours": [
@@ -7411,7 +7411,7 @@
         },
         {
             "id": "b182ef0f-ff19-5503-abdd-1ad3791953d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7855528a-ede9-49a9-8749-795a004fd927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7855528a-ede9-49a9-8749-795a004fd927.jpg?1",
             "name": "Abzan Banner",
             "text": "{T}: Add {W}, {B}, or {G} to your mana pool.\n{W}{B}{G}, {T}, Sacrifice Abzan Banner: Draw a card.",
             "colours": [],
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "c733921a-daa0-5737-8a1a-a7d853cea260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d59d264-87ee-4305-bffb-110549331a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d59d264-87ee-4305-bffb-110549331a82.jpg?1",
             "name": "Altar of the Brood",
             "text": "Whenever another permanent enters the battlefield under your control, each opponent puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "0b985fa4-6e59-587b-a05a-0d882121f162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9951f1-ca51-44a2-8480-602df466f0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9951f1-ca51-44a2-8480-602df466f0ab.jpg?1",
             "name": "Briber's Purse",
             "text": "Briber's Purse enters the battlefield with X gem counters on it.\n{1}, {T}, Remove a gem counter from Briber's Purse: Target creature can't attack or block this turn.",
             "colours": [],
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "146f1d09-ddf7-596d-b5b2-c1e881cc7550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1284b15f-2a70-48d6-89d3-e787af3f07eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1284b15f-2a70-48d6-89d3-e787af3f07eb.jpg?1",
             "name": "Cranial Archive",
             "text": "{2}, Exile Cranial Archive: Target player shuffles his or her graveyard into his or her library. Draw a card.",
             "colours": [],
@@ -7527,7 +7527,7 @@
         },
         {
             "id": "7d9d9762-2d52-5b91-9345-07919a778c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d508e6a6-034c-424d-993e-7354ce212f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d508e6a6-034c-424d-993e-7354ce212f13.jpg?1",
             "name": "Dragon Throne of Tarkir",
             "text": "Equipped creature has defender and \"{2}, {T}: Other creatures you control gain trample and get +X/+X until end of turn, where X is this creature's power.\"\nEquip {3}",
             "colours": [],
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "8bd92644-918c-5569-8059-e355539b3aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711145d8-5178-4fdc-8494-4ab680f55b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711145d8-5178-4fdc-8494-4ab680f55b1a.jpg?1",
             "name": "Ghostfire Blade",
             "text": "Equipped creature gets +2/+2.\nEquip {3}\nGhostfire Blade's equip ability costs {2} less to activate if it targets a colorless creature.",
             "colours": [],
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "33988b65-7cef-5bbf-b3c5-58682832723e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48168005-65cc-43dc-9d45-17ea5dd4848f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48168005-65cc-43dc-9d45-17ea5dd4848f.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1}",
             "colours": [],
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "4f5e39be-4271-5bc0-bff1-d8820ae9fe1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684dc050-a66b-4364-9880-56f383db6c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684dc050-a66b-4364-9880-56f383db6c0a.jpg?1",
             "name": "Jeskai Banner",
             "text": "{T}: Add {U}, {R}, or {W} to your mana pool.\n{U}{R}{W}, {T}, Sacrifice Jeskai Banner: Draw a card.",
             "colours": [],
@@ -7651,7 +7651,7 @@
         },
         {
             "id": "40c624d5-8c84-596d-a91a-a8ac1bfd1471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c82e2b8-f0f6-44da-83ee-8a671344ac62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c82e2b8-f0f6-44da-83ee-8a671344ac62.jpg?1",
             "name": "Lens of Clarity",
             "text": "You may look at the top card of your library and at face-down creatures you don't control. (You may do this at any time.)",
             "colours": [],
@@ -7679,7 +7679,7 @@
         },
         {
             "id": "fcb9218c-1c1a-545f-8c05-acb9d030e8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10c56d-a8e1-495d-a03a-0b920b44182f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10c56d-a8e1-495d-a03a-0b920b44182f.jpg?1",
             "name": "Mardu Banner",
             "text": "{T}: Add {R}, {W}, or {B} to your mana pool.\n{R}{W}{B}, {T}, Sacrifice Mardu Banner: Draw a card.",
             "colours": [],
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "72f86169-a42f-59a9-b63c-5820a9ae64c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695cf35-8f7c-4674-bfd3-43520b13d084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695cf35-8f7c-4674-bfd3-43520b13d084.jpg?1",
             "name": "Sultai Banner",
             "text": "{T}: Add {B}, {G}, or {U} to your mana pool.\n{B}{G}{U}, {T}, Sacrifice Sultai Banner: Draw a card.",
             "colours": [],
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "03efd706-c54a-5a3d-88e8-04b07f6e090a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990bdff-c27a-447f-b530-d8b7614fe9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990bdff-c27a-447f-b530-d8b7614fe9a0.jpg?1",
             "name": "Temur Banner",
             "text": "{T}: Add {G}, {U}, or {R} to your mana pool.\n{G}{U}{R}, {T}, Sacrifice Temur Banner: Draw a card.",
             "colours": [],
@@ -7775,7 +7775,7 @@
         },
         {
             "id": "e908dc61-420a-5c93-b850-db8505186549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94002868-a48a-4ea8-bfce-17257078f5db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94002868-a48a-4ea8-bfce-17257078f5db.jpg?1",
             "name": "Ugin's Nexus",
             "text": "If a player would begin an extra turn, that player skips that turn instead.\nIf Ugin's Nexus would be put into a graveyard from the battlefield, instead exile it and take an extra turn after this one.",
             "colours": [],
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "bc4e670d-cade-5571-a1c0-ef1b58b02aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763ac4c4-af2d-4b71-9fb3-244c96f93860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763ac4c4-af2d-4b71-9fb3-244c96f93860.jpg?1",
             "name": "Witness of the Ages",
             "text": "Morph {5} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "abff8f9f-b24b-5aa2-8818-488ba2739361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a7b30a-c59f-4a87-9e8a-b29daea27422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a7b30a-c59f-4a87-9e8a-b29daea27422.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7867,7 +7867,7 @@
         },
         {
             "id": "efe7b30c-c659-5316-91cd-6ece7955c546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f430794-0d86-4f6a-97e0-4bbb6716d613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f430794-0d86-4f6a-97e0-4bbb6716d613.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "3c6e2867-643e-59a9-9367-58268ab3b70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a1c0b-f6ea-475a-aa01-3618ea7d8647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a1c0b-f6ea-475a-aa01-3618ea7d8647.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "5b0dd831-547e-5b95-a8c6-452633ea7ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63742780-47ee-4a66-993a-69e06c14967d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63742780-47ee-4a66-993a-69e06c14967d.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "de3ca801-1eb9-5fa1-b4fd-87f76b1cc576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2996d9-3287-4480-8c04-7a378e37e3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2996d9-3287-4480-8c04-7a378e37e3cf.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "7444d7ca-9be4-5121-b562-1ea60e1f7b61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4335951-e73e-45cb-b2a5-6e9d14ba87ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4335951-e73e-45cb-b2a5-6e9d14ba87ee.jpg?1",
             "name": "Frontier Bivouac",
             "text": "Frontier Bivouac enters the battlefield tapped.\n{T}: Add {G}, {U}, or {R} to your mana pool.",
             "colours": [],
@@ -8017,7 +8017,7 @@
         },
         {
             "id": "60963fb2-9880-5d92-8346-46d49cec36b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea27aa7-7fcf-4198-b03a-5034a03ba81f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea27aa7-7fcf-4198-b03a-5034a03ba81f.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "1ebd09c5-d32a-58e4-9d57-49fffed50805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae51d77-e06b-4e5a-9543-a17dd0b2a333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae51d77-e06b-4e5a-9543-a17dd0b2a333.jpg?1",
             "name": "Mystic Monastery",
             "text": "Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W} to your mana pool.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "5d833dca-ecb2-5b6e-9592-68e2dfa85b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6ae4a5-227d-465b-9e99-bae158b7d410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6ae4a5-227d-465b-9e99-bae158b7d410.jpg?1",
             "name": "Nomad Outpost",
             "text": "Nomad Outpost enters the battlefield tapped.\n{T}: Add {R}, {W}, or {B} to your mana pool.",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "9ecc9b74-d125-59cb-9eb8-27cccba77b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21326575-80b9-4a4e-a93c-6880ec6575d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21326575-80b9-4a4e-a93c-6880ec6575d5.jpg?1",
             "name": "Opulent Palace",
             "text": "Opulent Palace enters the battlefield tapped.\n{T}: Add {B}, {G}, or {U} to your mana pool.",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "dbc76978-5109-550a-b0e5-5768cdd1f6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2f5f58-9a95-4ca6-93a0-813738f0072f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2f5f58-9a95-4ca6-93a0-813738f0072f.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "edb6225d-bbfa-53ed-accd-4d99fb33c81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ce6cb-0324-4cca-bc79-903cefe1ac1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ce6cb-0324-4cca-bc79-903cefe1ac1f.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "bc9ad76c-3095-5f3b-8bc3-d9deac347cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd40d90-c939-458a-9a98-27d10da6ff2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd40d90-c939-458a-9a98-27d10da6ff2f.jpg?1",
             "name": "Sandsteppe Citadel",
             "text": "Sandsteppe Citadel enters the battlefield tapped.\n{T}: Add {W}, {B}, or {G} to your mana pool.",
             "colours": [],
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "1d37ee26-50db-5dc6-8179-a91616cc8c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0824a960-dd89-45c5-90f0-3ec9eb47d9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0824a960-dd89-45c5-90f0-3ec9eb47d9ce.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8266,7 +8266,7 @@
         },
         {
             "id": "0064afc8-3d2b-5225-8e72-3b3fb9e9655c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782d005-a563-4738-978a-73a3465de78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782d005-a563-4738-978a-73a3465de78f.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "54774062-bf44-5b1c-9014-8ea7c15dd979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e57abd9-e864-4047-a3c8-618952071858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e57abd9-e864-4047-a3c8-618952071858.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "3cde416a-c757-53d2-aa89-7bfcb01dd98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6be7ab-8fad-4606-b623-f2188219d60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6be7ab-8fad-4606-b623-f2188219d60b.jpg?1",
             "name": "Tomb of the Spirit Dragon",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: You gain 1 life for each colorless creature you control.",
             "colours": [],
@@ -8356,7 +8356,7 @@
         },
         {
             "id": "7e80184a-fe9e-56d9-84a3-bae686a8f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f840bd2-c4f5-4ac4-918c-91b4feeb8783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f840bd2-c4f5-4ac4-918c-91b4feeb8783.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "39d7f920-a910-511d-8504-c99ae44a85d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b296781-78ac-411f-88fc-2d924ad22986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b296781-78ac-411f-88fc-2d924ad22986.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "982bc8f7-d9ee-5a79-9c05-718b31a375df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b28650-cddc-4878-b1d1-b5a764f4df49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b28650-cddc-4878-b1d1-b5a764f4df49.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "71dc1055-b9e8-5574-9232-8eba92030e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8503cca-7e7d-44c4-8587-81376b396398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8503cca-7e7d-44c4-8587-81376b396398.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8474,7 +8474,7 @@
         },
         {
             "id": "3501b3cf-a81d-545c-b46d-c541875eb061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576dc74-1847-44b8-aef9-9d74f333b9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576dc74-1847-44b8-aef9-9d74f333b9cc.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8512,7 +8512,7 @@
         },
         {
             "id": "a9a6d82c-3f49-57ad-84db-531a339ed836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40337e60-065e-425d-ae35-c639d2bb5b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40337e60-065e-425d-ae35-c639d2bb5b42.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "6fce0f8e-d1fd-54c4-a9c4-ba66d75188c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bfb654-ab99-4272-a184-b95e1022af5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bfb654-ab99-4272-a184-b95e1022af5c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "00f1765b-bb43-5ef8-96aa-5006f2725270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b97fb-da4a-4867-abde-825383c74b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b97fb-da4a-4867-abde-825383c74b63.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "b839452f-ea03-5b5a-81a5-0e7e0bec01b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010ca5-b609-4ae9-8c23-adf5723a9daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010ca5-b609-4ae9-8c23-adf5723a9daa.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "b8f7d4ad-2834-59b8-af83-7c1bdd9ade65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65c53-7b35-4ba0-9344-b311eee087cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65c53-7b35-4ba0-9344-b311eee087cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "6a84a69e-e14f-5edf-8c4e-c17b17cc3a2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45827e8-d4b9-4a42-8516-22560568e678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45827e8-d4b9-4a42-8516-22560568e678.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8740,7 +8740,7 @@
         },
         {
             "id": "f89d6a77-cf24-55ac-a6cc-b3e7ec453f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61c4c14-e45d-45a8-87c7-fec98d46ee79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61c4c14-e45d-45a8-87c7-fec98d46ee79.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "987de836-90f8-5a41-9f7c-f228d2f21c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d7e861-8dda-4073-bfd6-4ade3bca5cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d7e861-8dda-4073-bfd6-4ade3bca5cff.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "8db4472f-9bea-5bc8-884a-bac960170536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a8d790-61e5-4b46-94b8-54ea68ed18ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a8d790-61e5-4b46-94b8-54ea68ed18ea.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8854,7 +8854,7 @@
         },
         {
             "id": "bb1f754e-6519-56bb-805a-c1c3e5f1ecd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11fd2a-d872-4abc-ac2b-c0678c1be773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11fd2a-d872-4abc-ac2b-c0678c1be773.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "c0b457f1-8542-5a5e-b5ad-c7a4484b9cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cac8b-6609-42ac-a594-002068e02de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cac8b-6609-42ac-a594-002068e02de4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "cf1e944d-a871-5433-86a4-0d70d37f7bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802b1bb0-6c73-481a-ac3e-7d4e1682b4c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802b1bb0-6c73-481a-ac3e-7d4e1682b4c2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8968,7 +8968,7 @@
         },
         {
             "id": "f34e090e-ee1b-5375-a0d0-49b4c82ebd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5037330a-6e9b-4ce5-ba81-ae1ccef63334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5037330a-6e9b-4ce5-ba81-ae1ccef63334.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "94cff076-2400-592a-a3f2-7ea72131591b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45c7ed-cf98-455b-b665-81103fdc9331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45c7ed-cf98-455b-b665-81103fdc9331.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "c2f44642-9883-5c3b-b815-8d82dd274218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ad8df0-20f3-4372-8b2b-7c4ccfc2e9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ad8df0-20f3-4372-8b2b-7c4ccfc2e9c0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "f0250715-4061-54be-8dc3-ef9dc1971575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5342f9-3f91-48e4-bfd1-49fbf9ca89cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5342f9-3f91-48e4-bfd1-49fbf9ca89cf.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "be22b604-ef97-586a-8870-857be59e59d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722111d4-99f4-463b-b232-96821c18f189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722111d4-99f4-463b-b232-96821c18f189.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "8cd482f1-be96-5baf-a8a3-769ade3fd503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe7f25-71c5-4fd2-8696-0a4ce8c4b0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe7f25-71c5-4fd2-8696-0a4ce8c4b0b6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9196,7 +9196,7 @@
         },
         {
             "id": "4b9b8783-ccc0-5962-913b-44ff1769bc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742ffa7-915f-45ce-b3f2-8391723bb34c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742ffa7-915f-45ce-b3f2-8391723bb34c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "e5ffaf0b-de4f-539d-a767-45f9c5d3f2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa788dea-2968-45e8-9e08-c89e3e227d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa788dea-2968-45e8-9e08-c89e3e227d88.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -9268,7 +9268,7 @@
         },
         {
             "id": "4a9e435a-f448-5ee1-bfd3-4ff47dbc59e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7071930c-689a-44b9-b52d-45027fd14446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7071930c-689a-44b9-b52d-45027fd14446.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9302,7 +9302,7 @@
         },
         {
             "id": "9e097860-c9e4-545a-be49-9b86757b0646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46bcc76-181c-4e06-aa04-590a3e651dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46bcc76-181c-4e06-aa04-590a3e651dc7.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -9336,7 +9336,7 @@
         },
         {
             "id": "9f33f0a5-ce38-5c8c-8bed-4fe07868f39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4c9101-85bf-4a4f-a496-ff6db7b531b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4c9101-85bf-4a4f-a496-ff6db7b531b7.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -9370,7 +9370,7 @@
         },
         {
             "id": "658c8c34-5aeb-5ffc-adee-d69d421b4d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71496671-f7ba-4014-a895-d70a27979db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71496671-f7ba-4014-a895-d70a27979db7.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -9404,7 +9404,7 @@
         },
         {
             "id": "3a0c9727-c93a-54d6-abba-0d6a723e839c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7da3d0-2471-48ab-8e7c-af8046d9e0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7da3d0-2471-48ab-8e7c-af8046d9e0be.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "10ecaa3d-ccc8-5277-9969-6af572f03b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9472,7 +9472,7 @@
         },
         {
             "id": "3d6a2993-34db-51c3-a046-bd879aa312d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3dae7d-3880-4c0a-acfb-8fd227cf9fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3dae7d-3880-4c0a-acfb-8fd227cf9fab.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "801f9c59-c1c6-5332-b3d7-6537990e7c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e9f9d-b1e5-4724-9b80-e51500d12d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e9f9d-b1e5-4724-9b80-e51500d12d5b.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -9540,7 +9540,7 @@
         },
         {
             "id": "58572f10-72f2-5f42-9216-1fb08db52d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc7ce0-387f-413c-a387-2952b990ff3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc7ce0-387f-413c-a387-2952b990ff3f.jpg?1",
             "name": "Spirit Warrior",
             "text": "",
             "colours": [
@@ -9577,7 +9577,7 @@
         },
         {
             "id": "10de7c9d-7fed-5f6d-8f60-ded881c3eb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc513990-b4e8-498b-84d5-8317bc79a667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc513990-b4e8-498b-84d5-8317bc79a667.jpg?1",
             "name": "Morph",
             "text": "",
             "colours": [],
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "fcbf401e-2b30-502c-af40-14a0b8d701b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0430bc-5b7e-431e-a8d0-168f679fe79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0430bc-5b7e-431e-a8d0-168f679fe79c.jpg?1",
             "name": "Sarkhan, the Dragonspeaker Emblem",
             "text": "",
             "colours": [],
@@ -9633,7 +9633,7 @@
         },
         {
             "id": "4876ec20-452c-5752-b24f-1ca65a840966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6e8950-5b1e-48b6-8d32-2a463455499d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6e8950-5b1e-48b6-8d32-2a463455499d.jpg?1",
             "name": "Sorin, Solemn Visitor Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/LCI.json
+++ b/Assets/Resources/Sets/LCI.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7a692863-f331-512c-8b66-9371923a1833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b725e-2b9c-4830-ac54-b2562afe09bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b725e-2b9c-4830-ac54-b2562afe09bb.jpg?1",
             "name": "Abuelo's Awakening",
             "text": "Return target artifact or non-Aura enchantment card from your graveyard to the battlefield with X additional +1/+1 counters on it. It's a 1/1 Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "2d693bd9-e99e-5a40-a90c-b2bcc7bff2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f82d84-03ad-42dd-80ce-f0ac5e353e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f82d84-03ad-42dd-80ce-f0ac5e353e46.jpg?1",
             "name": "Acrobatic Leap",
             "text": "Target creature gets +1/+3 and gains flying until end of turn. Untap it.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "6cebbfac-215c-5586-96b1-c2ed6164f4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c91e24-b7e8-4040-80cb-d1b375002c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c91e24-b7e8-4040-80cb-d1b375002c10.jpg?1",
             "name": "Adaptive Gemguard",
             "text": "Tap two untapped artifacts and/or creatures you control: Put a +1/+1 counter on Adaptive Gemguard. Activate only as a sorcery.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "072b67a9-271f-5708-ac99-93f749aa49c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1a0159-7f00-429c-9318-b028b1e03ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1a0159-7f00-429c-9318-b028b1e03ba8.jpg?1",
             "name": "Attentive Sunscribe",
             "text": "Whenever Attentive Sunscribe becomes tapped, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "4dc2e7b3-8049-54c1-bb93-3ad9a4e6350e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c02134c-ec9f-4090-820e-8ba7ae4a8c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c02134c-ec9f-4090-820e-8ba7ae4a8c2b.jpg?1",
             "name": "Bat Colony",
             "text": "When Bat Colony enters the battlefield, create a 1/1 black Bat creature token with flying for each mana from a Cave spent to cast it.\nWhenever a Cave enters the battlefield under your control, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "32480bfd-5be9-5eb9-989d-6650eb53c16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1",
             "name": "Clay-Fired Bricks // Cosmium Kiln",
             "text": "",
             "colours": [
@@ -204,7 +204,7 @@
         },
         {
             "id": "16466dc8-409b-5570-ab4d-29e847d1321c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1",
             "name": "Clay-Fired Bricks // Cosmium Kiln",
             "text": "",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "8e33fd00-f101-5568-9096-f369858cbe16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d1eac-ede7-4f75-9c74-05133b215f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d1eac-ede7-4f75-9c74-05133b215f93.jpg?1",
             "name": "Cosmium Blast",
             "text": "Cosmium Blast deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "36858ec4-1791-54ef-86c1-9d5c17aa8b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg?1",
             "name": "Dauntless Dismantler",
             "text": "Artifacts your opponents control enter the battlefield tapped.\n{X}{X}{W}, Sacrifice Dauntless Dismantler: Destroy each artifact with mana value X.",
             "colours": [
@@ -303,7 +303,7 @@
         },
         {
             "id": "ea9697c6-0a8b-5467-a1c7-a8cd6a5ac370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ba382-18c4-4833-b3d2-bd469ae2ad77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ba382-18c4-4833-b3d2-bd469ae2ad77.jpg?1",
             "name": "Deconstruction Hammer",
             "text": "Equipped creature gets +1/+1 and has \"{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "c5da07c5-0146-5aea-9976-eb7c21a01237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f231ef-4167-4b0a-b54c-a098b2eb2f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f231ef-4167-4b0a-b54c-a098b2eb2f6f.jpg?1",
             "name": "Dusk Rose Reliquary",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nWard {2}\nWhen Dusk Rose Reliquary enters the battlefield, exile target artifact or creature an opponent controls until Dusk Rose Reliquary leaves the battlefield.",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "73281fe7-14de-5cec-a901-a19a618c0f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96de0741-9270-4118-bb8e-f3480c75a582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96de0741-9270-4118-bb8e-f3480c75a582.jpg?1",
             "name": "Envoy of Okinec Ahau",
             "text": "{4}{W}: Create a 1/1 colorless Gnome artifact creature token.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "1d237770-d605-5369-ad94-28cf9168114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323a05ee-8296-41c0-94ab-00913d9d84f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323a05ee-8296-41c0-94ab-00913d9d84f1.jpg?1",
             "name": "Fabrication Foundry",
             "text": "{T}: Add {W}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.\n{2}{W}, {T}, Exile one or more other artifacts you control with total mana value X: Return target artifact card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "117078e4-1d82-5d7b-a1ca-e8d464f190ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2cfbdc-8d40-4abb-afca-6c6d8e36185b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2cfbdc-8d40-4abb-afca-6c6d8e36185b.jpg?1",
             "name": "Family Reunion",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +1/+1 until end of turn.\n\u2022 Creatures you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "db1015f4-e493-5b91-8dbc-92ca13870e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522aa72b-2b8c-484c-872b-f082101cee35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522aa72b-2b8c-484c-872b-f082101cee35.jpg?1",
             "name": "Get Lost",
             "text": "Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "adf80616-0390-5266-a40d-a0bcd8f364a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7580ad36-7362-4dee-9511-d119173b70e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7580ad36-7362-4dee-9511-d119173b70e8.jpg?1",
             "name": "Glorifier of Suffering",
             "text": "When Glorifier of Suffering enters the battlefield, you may sacrifice another creature or artifact. When you do, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "8fab2c14-6455-5197-ad12-28cb21226e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86f3cb2-7822-4c19-bd84-cea177e5b6e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86f3cb2-7822-4c19-bd84-cea177e5b6e9.jpg?1",
             "name": "Guardian of the Great Door",
             "text": "As an additional cost to cast this spell, tap four untapped artifacts, creatures, and/or lands you control.\nFlying",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "06c75fc4-258a-5af7-ab9e-eaca18a07e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa7126-5df3-42dd-b4a3-0d0ea59eeebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa7126-5df3-42dd-b4a3-0d0ea59eeebd.jpg?1",
             "name": "Helping Hand",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped.",
             "colours": [
@@ -605,7 +605,7 @@
         },
         {
             "id": "2228c4c3-ad1c-5b86-ab33-a65912691b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70689a0-ac69-4052-84fc-9055e9e1c54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70689a0-ac69-4052-84fc-9055e9e1c54b.jpg?1",
             "name": "Ironpaw Aspirant",
             "text": "When Ironpaw Aspirant enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -640,7 +640,7 @@
         },
         {
             "id": "f76ad1f5-6c5e-5f80-957a-6c22ef599082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4c527c-6963-47f4-bcad-841d06bb2211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4c527c-6963-47f4-bcad-841d06bb2211.jpg?1",
             "name": "Kinjalli's Dawnrunner",
             "text": "Double strike\nWhen Kinjalli's Dawnrunner enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "aa1e494f-d58b-5f10-94aa-15fce78fa083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1201811-54ab-4c4e-b6e1-19b0d07e5ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1201811-54ab-4c4e-b6e1-19b0d07e5ede.jpg?1",
             "name": "Kutzil's Flanker",
             "text": "Flash\nWhen Kutzil's Flanker enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Kutzil's Flanker for each creature that left the battlefield under your control this turn.\n\u2022 You gain 2 life and scry 2.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "9e976fc8-ad61-54ac-8f94-29fca305a0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a6ba0-cea0-4084-92f1-2bd60ea25fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a6ba0-cea0-4084-92f1-2bd60ea25fb0.jpg?1",
             "name": "Malamet War Scribe",
             "text": "When Malamet War Scribe enters the battlefield, creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "29ae111d-2d91-540b-9dc3-5c1bf1ae6ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dafcd6-ce4e-4a27-bd8c-fa1a3bffc99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dafcd6-ce4e-4a27-bd8c-fa1a3bffc99e.jpg?1",
             "name": "Market Gnome",
             "text": "When Market Gnome dies, you gain 1 life and draw a card.\nWhen Market Gnome is exiled from the battlefield while you're activating a craft ability, you gain 1 life and draw a card.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "0bec44e8-e176-52c8-8340-b2516ef6af37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f82c95-8bc1-4df9-9120-86ffc059c7dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f82c95-8bc1-4df9-9120-86ffc059c7dd.jpg?1",
             "name": "Might of the Ancestors",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 and gains vigilance until end of turn.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "dfac90ed-6531-5f92-bec8-54137933df8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9048cd9d-df3f-4705-a5f4-e5b09760c631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9048cd9d-df3f-4705-a5f4-e5b09760c631.jpg?1",
             "name": "Miner's Guidewing",
             "text": "Flying, vigilance\nWhen Miner's Guidewing dies, target creature you control explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "d4c3219b-f534-5b24-8331-6ee05ffb1147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c219861-f808-456f-b551-37512764062d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c219861-f808-456f-b551-37512764062d.jpg?1",
             "name": "Mischievous Pup",
             "text": "Flash\nWhen Mischievous Pup enters the battlefield, return up to one other target permanent you control to its owner's hand.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "c531ac32-d1b4-5d22-bbf7-1d1f4aeb40ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "f8514939-0b54-5ae5-9454-b06c2497b12e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [],
@@ -952,7 +952,7 @@
         },
         {
             "id": "1351680e-dce6-55bf-bd77-2554747b0ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c21561-2213-4524-89a6-30a305843e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c21561-2213-4524-89a6-30a305843e5a.jpg?1",
             "name": "Oltec Archaeologists",
             "text": "When Oltec Archaeologists enters the battlefield, choose one \u2014\n\u2022 Return target artifact card from your graveyard to your hand.\n\u2022 Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "aa281663-d72d-5be3-98bb-0ce8db132f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d68a38-2e0b-401b-b67d-a55e2af5b18d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d68a38-2e0b-401b-b67d-a55e2af5b18d.jpg?1",
             "name": "Oltec Cloud Guard",
             "text": "Flying\nWhen Oltec Cloud Guard enters the battlefield, create a 1/1 colorless Gnome artifact creature token.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "635d1144-b4a3-5bb2-be79-b03bf77c39a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1",
             "name": "Oteclan Landmark // Oteclan Levitator",
             "text": "",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "55997d2c-bc8f-55a0-bb4b-6e4adc9a0c81",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1",
             "name": "Oteclan Landmark // Oteclan Levitator",
             "text": "",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "5dc96eb4-ac6c-5bbf-ac5d-81714824f3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc5f28f-6361-455f-ac82-260a70e59316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc5f28f-6361-455f-ac82-260a70e59316.jpg?1",
             "name": "Petrify",
             "text": "Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "c15cff24-93f0-55ad-9ff3-9a4cae67ec68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74ddccb-ebbd-4fad-a9b6-6b9e9bafae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74ddccb-ebbd-4fad-a9b6-6b9e9bafae31.jpg?1",
             "name": "Quicksand Whirlpool",
             "text": "This spell costs {3} less to cast if it targets a tapped creature.\nExile target creature.",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "d26ab600-e360-55ae-a1c7-bf82b0249af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59adbd35-9959-4a0f-babf-46ea3c15f018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59adbd35-9959-4a0f-babf-46ea3c15f018.jpg?1",
             "name": "Resplendent Angel",
             "text": "Flying\nAt the beginning of each end step, if you gained 5 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.\n{3}{W}{W}{W}: Until end of turn, Resplendent Angel gets +2/+2 and gains lifelink.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "ac833432-0ad7-51ef-bf2c-e42045ac7603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bedf13-c2bc-4e5d-aba3-3c0d5495a9bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bedf13-c2bc-4e5d-aba3-3c0d5495a9bb.jpg?1",
             "name": "Ruin-Lurker Bat",
             "text": "Flying, lifelink\nAt the beginning of your end step, if you descended this turn, scry 1. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "0347638d-968d-5ddb-8327-84667caab72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269ddd84-fdc4-4c94-b183-32ecec56967c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269ddd84-fdc4-4c94-b183-32ecec56967c.jpg?1",
             "name": "Sanguine Evangelist",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhen Sanguine Evangelist enters the battlefield or dies, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "aaa28fa4-e75b-5029-8fd3-50d0cbda3a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7833724-aec6-41a4-a7ea-2aa722467732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7833724-aec6-41a4-a7ea-2aa722467732.jpg?1",
             "name": "Soaring Sandwing",
             "text": "Flying\nWhen Soaring Sandwing enters the battlefield, you gain 3 life.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "b1955388-df25-58b2-8db5-d6eb6b2cc537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24417388-f2bb-4783-bdce-264774531838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1",
             "name": "Spring-Loaded Sawblades // Bladewheel Chariot",
             "text": "",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "14531b23-2ee9-540d-80e6-2a2f44ede4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24417388-f2bb-4783-bdce-264774531838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1",
             "name": "Spring-Loaded Sawblades // Bladewheel Chariot",
             "text": "",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "7cab183a-0bc8-5eb4-b184-0fb7cd731d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a7439-965d-49f2-b43e-053f29196e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a7439-965d-49f2-b43e-053f29196e6b.jpg?1",
             "name": "Thousand Moons Crackshot",
             "text": "Whenever Thousand Moons Crackshot attacks, you may pay {2}{W}. When you do, tap target creature.",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "536d940c-12ac-580b-81c4-84e4d5d72ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg?1",
             "name": "Thousand Moons Infantry",
             "text": "Untap Thousand Moons Infantry during each other player's untap step.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "d8c50305-4946-5619-b77a-bd5b08b80897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "9c6b2e2a-0bda-5b77-87aa-56ed24b18fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [],
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "44ca2991-ee4a-5122-bd66-b8f3e9f9b824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321857e-7977-46dd-8357-d732312e5261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321857e-7977-46dd-8357-d732312e5261.jpg?1",
             "name": "Tinker's Tote",
             "text": "When Tinker's Tote enters the battlefield, create two 1/1 colorless Gnome artifact creature tokens.\n{W}, Sacrifice Tinker's Tote: You gain 3 life.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "163f7f19-c6b4-5ff9-9fd9-a53cc31432f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "9c1aa948-6d98-599c-a152-1f37e0d772ea",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "ef0f87cc-2352-58bb-83dc-c0b4af0050d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200c504-9137-4bc2-9cd4-eaf0643a2855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200c504-9137-4bc2-9cd4-eaf0643a2855.jpg?1",
             "name": "Vanguard of the Rose",
             "text": "{1}, Sacrifice another creature or artifact: Vanguard of the Rose gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "1e422d91-fe93-5e4e-9cfe-a4f78c8882ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549fd992-ed37-431d-97cb-9ca017db1d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549fd992-ed37-431d-97cb-9ca017db1d47.jpg?1",
             "name": "Warden of the Inner Sky",
             "text": "As long as Warden of the Inner Sky has three or more counters on it, it has flying and vigilance.\nTap three untapped artifacts and/or creatures you control: Put a +1/+1 counter on Warden of the Inner Sky. Scry 1. Activate only as a sorcery.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "8e1d7eca-f254-5b53-bf02-56d81c1b19f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg?1",
             "name": "Akal Pakal, First Among Equals",
             "text": "At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "077a0f3a-b18d-52f3-b390-4ea2a9004b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625690d3-7131-45de-adea-9c927241e661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625690d3-7131-45de-adea-9c927241e661.jpg?1",
             "name": "Ancestral Reminiscence",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "6c3ed12f-d8da-59f2-b25c-50abfdc49a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea3d0f4-76f5-416f-93ba-8b003b967816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea3d0f4-76f5-416f-93ba-8b003b967816.jpg?1",
             "name": "Brackish Blunder",
             "text": "Return target creature to its owner's hand. If it was tapped, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "12121978-97f4-588f-99c0-2b0ed31cde6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "43017d21-c6f5-53e5-b0db-a4589bcf8baa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "70b425f8-4758-5044-bade-0d4eb5354f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233beaac-37a4-4824-8f31-438b6bfe794b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233beaac-37a4-4824-8f31-438b6bfe794b.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked this turn.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "2b482c81-5966-5c56-973b-c0543abafa72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d329ad-6b19-4aa7-a53f-38c7b76c4c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d329ad-6b19-4aa7-a53f-38c7b76c4c96.jpg?1",
             "name": "Cogwork Wrestler",
             "text": "Flash\nWhen Cogwork Wrestler enters the battlefield, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "cfe1987b-7f2e-5421-8519-debcdf8bfdd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ae23db-c391-402c-9568-65447cada66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ae23db-c391-402c-9568-65447cada66e.jpg?1",
             "name": "Confounding Riddle",
             "text": "Choose one \u2014\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\n\u2022 Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "634edc8f-4780-5342-a64b-e6fcabac6815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg?1",
             "name": "Council of Echoes",
             "text": "Flying\nDescend 4 \u2014 When Council of Echoes enters the battlefield, if there are four or more permanent cards in your graveyard, return up to one target nonland permanent other than Council of Echoes to its owner's hand.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "4caf2f73-688e-501d-ad3f-ef3db8952e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2449311-a705-4a31-a345-a36d436ae561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2449311-a705-4a31-a345-a36d436ae561.jpg?1",
             "name": "Deeproot Pilgrimage",
             "text": "Whenever one or more nontoken Merfolk you control become tapped, create a 1/1 blue Merfolk creature token with hexproof.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "88f6f49d-4c48-55e5-87fc-6777a8f5978b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c068b2e-17cc-4fb8-bd79-b775a4713d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c068b2e-17cc-4fb8-bd79-b775a4713d74.jpg?1",
             "name": "Didact Echo",
             "text": "When Didact Echo enters the battlefield, draw a card.\nDescend 4 \u2014 Didact Echo has flying as long as there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -2053,7 +2053,7 @@
         },
         {
             "id": "40dff87f-3950-5fe4-aeac-1e97fe0ef8fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c504ef-2382-4174-9b1d-5f38e12a28fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c504ef-2382-4174-9b1d-5f38e12a28fc.jpg?1",
             "name": "Eaten by Piranhas",
             "text": "Flash\nEnchant creature\nEnchanted creature loses all abilities and is a black Skeleton creature with base power and toughness 1/1. (It loses all other card types and creature types.)",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "7425b8e1-e6d4-53c4-9a72-0db911baa48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "a353f5d9-8fbd-5125-81c6-3e88351619b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "eb44b7cf-6a50-51ee-ac08-8047874c5e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [
@@ -2195,7 +2195,7 @@
         },
         {
             "id": "241f7226-4d6b-5542-a24d-e72c006d450b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [],
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "9fc37be7-9981-5732-b501-81d651d10d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65e1bc-fade-4fdf-a1fd-de068bff9e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65e1bc-fade-4fdf-a1fd-de068bff9e4c.jpg?1",
             "name": "Frilled Cave-Wurm",
             "text": "Descend 4 \u2014 Frilled Cave-Wurm gets +2/+0 as long as there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -2265,7 +2265,7 @@
         },
         {
             "id": "ada46e23-22c3-52af-a341-8dcc894615ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545503f8-a8c6-4518-9ad6-76e4996397fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545503f8-a8c6-4518-9ad6-76e4996397fc.jpg?1",
             "name": "Hermitic Nautilus",
             "text": "Vigilance\n{1}{U}: Hermitic Nautilus gets +3/-3 until end of turn.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "1e8f44a5-fd9c-5ba1-bdec-186df38d2ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5946463a-2240-4376-b6f5-fd6e3a9cc51c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5946463a-2240-4376-b6f5-fd6e3a9cc51c.jpg?1",
             "name": "Hurl into History",
             "text": "Counter target artifact or creature spell. Discover X, where X is that spell's mana value. (Exile cards from the top of your library until you exile a nonland card with that mana value or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "feb9c975-368a-50fd-9ece-c3a6c734e841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1",
             "name": "Inverted Iceberg // Iceberg Titan",
             "text": "",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "cf9082d6-607b-54c6-addb-32d2540822dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1",
             "name": "Inverted Iceberg // Iceberg Titan",
             "text": "",
             "colours": [
@@ -2399,7 +2399,7 @@
         },
         {
             "id": "ac7a2020-caaf-571a-a2ac-58266aaea366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03207457-70d8-4462-8c8b-ed39791d56a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03207457-70d8-4462-8c8b-ed39791d56a1.jpg?1",
             "name": "Kitesail Larcenist",
             "text": "Flying, ward {1}\nWhen Kitesail Larcenist enters the battlefield, for each player, choose up to one other target artifact or creature that player controls. For as long as Kitesail Larcenist remains on the battlefield, the chosen permanents become Treasure artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color\" and lose all other abilities.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "7e5745ac-a79d-53f2-90f8-bc20797cd8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1",
             "name": "Lodestone Needle // Guidestone Compass",
             "text": "",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "3ed12a09-70ff-5e04-8f96-123cb4378c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1",
             "name": "Lodestone Needle // Guidestone Compass",
             "text": "",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "e4dba3c8-4cee-5610-8b6c-e933a81b455c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6834d-afa3-4747-a62d-0654f4d9729f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6834d-afa3-4747-a62d-0654f4d9729f.jpg?1",
             "name": "Malcolm, Alluring Scoundrel",
             "text": "Flash\nFlying\nWhenever Malcolm, Alluring Scoundrel deals combat damage to a player, put a chorus counter on it. Draw a card, then discard a card. If there are four or more chorus counters on Malcolm, you may cast the discarded card without paying its mana cost.",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "5e7dfaef-5bfa-5029-b359-8ca0b1455ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78328899-7996-4cfd-bf00-d2a0d0ff3ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78328899-7996-4cfd-bf00-d2a0d0ff3ef8.jpg?1",
             "name": "Marauding Brinefang",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "066767b1-f7a7-50f0-91e8-1382d50a79b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0fe81c-b8ef-49ff-8743-f03d0220cb9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0fe81c-b8ef-49ff-8743-f03d0220cb9e.jpg?1",
             "name": "Merfolk Cave-Diver",
             "text": "Whenever a creature you control explores, Merfolk Cave-Diver gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "d108f286-3454-54cc-8094-b6c0aa4cc554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg?1",
             "name": "Oaken Siren",
             "text": "Flying, vigilance\n{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "ae8f37ef-6177-5f65-9df8-3c19da12d793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "5e9aeb7f-7f3e-5c3a-8e45-e938230b14bc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [],
@@ -2714,7 +2714,7 @@
         },
         {
             "id": "55e3737b-e0c3-5795-a092-951a4c3598b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27acf726-52f5-493d-8678-c12485f67747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27acf726-52f5-493d-8678-c12485f67747.jpg?1",
             "name": "Orazca Puzzle-Door",
             "text": "{1}, {T}, Sacrifice Orazca Puzzle-Door: Look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
             "colours": [
@@ -2746,7 +2746,7 @@
         },
         {
             "id": "cf8d1748-d194-55e4-8b63-49d5ed81e84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg?1",
             "name": "Out of Air",
             "text": "This spell costs {2} less to cast if it targets a creature spell.\nCounter target spell.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "25b0b6dd-e86f-5456-8c0e-b3003a5462ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d11e3d4-769d-47aa-8d3a-ce1ac60b68b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d11e3d4-769d-47aa-8d3a-ce1ac60b68b8.jpg?1",
             "name": "Pirate Hat",
             "text": "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, draw a card, then discard a card.\"\nEquip Pirate {1}\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "9708c4f1-921d-5880-ad70-5d3c8d8c2482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35096eb3-ad7b-4b6e-b799-cb4cc447883e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35096eb3-ad7b-4b6e-b799-cb4cc447883e.jpg?1",
             "name": "Relic's Roar",
             "text": "Until end of turn, target artifact or creature becomes a Dinosaur artifact creature with base power and toughness 4/3 in addition to its other types.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "63e1d6de-83b0-564b-8118-787228e33d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae8ab66-5840-4b2e-bd4e-94ead0c79b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae8ab66-5840-4b2e-bd4e-94ead0c79b61.jpg?1",
             "name": "River Herald Scout",
             "text": "When River Herald Scout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "013b2841-8007-5c68-a6b9-a053c0c49224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e53495-c76c-4cd4-b93e-b2c491d2c13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e53495-c76c-4cd4-b93e-b2c491d2c13a.jpg?1",
             "name": "Sage of Days",
             "text": "When Sage of Days enters the battlefield, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
             "colours": [
@@ -2914,7 +2914,7 @@
         },
         {
             "id": "ad7803e2-7dc5-5741-981b-5e4a10fb96dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1242203d-c9b5-4ab6-802e-e222f92291e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1242203d-c9b5-4ab6-802e-e222f92291e9.jpg?1",
             "name": "Self-Reflection",
             "text": "Create a token that's a copy of target creature you control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "51288f6c-be62-5ed2-a535-8cdf6ab510b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814803bc-72cd-46db-b957-4322f2a7b28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814803bc-72cd-46db-b957-4322f2a7b28a.jpg?1",
             "name": "Shipwreck Sentry",
             "text": "Defender\nAs long as an artifact entered the battlefield under your control this turn, Shipwreck Sentry can attack as though it didn't have defender.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "f6e6b59f-1f80-51b8-9e44-20b74ebddce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58639c-001f-4cb1-89fd-0a0967b86977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58639c-001f-4cb1-89fd-0a0967b86977.jpg?1",
             "name": "Sinuous Benthisaur",
             "text": "When Sinuous Benthisaur enters the battlefield, look at the top X cards of your library, where X is the number of Caves you control plus the number of Cave cards in your graveyard. Put two of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "795c4128-5608-5cfa-8ef0-4e4bc6245081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8f7a75-df5e-43b3-8c33-328ad0dc3c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8f7a75-df5e-43b3-8c33-328ad0dc3c40.jpg?1",
             "name": "Song of Stupefaction",
             "text": "Enchant creature or Vehicle\nWhen Song of Stupefaction enters the battlefield, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nFathomless descent \u2014 Enchanted permanent gets -X/-0, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "9560dd53-5303-54e2-b5fc-bfae92db36a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e54343-95e5-4dc4-9f18-e4a415fe5e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e54343-95e5-4dc4-9f18-e4a415fe5e0a.jpg?1",
             "name": "Spyglass Siren",
             "text": "Flying\nWhen Spyglass Siren enters the battlefield, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -3086,7 +3086,7 @@
         },
         {
             "id": "d84e0e4c-0ed2-5aed-bb30-1f73c5a1b88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9845-8a11-4fc4-b116-29a929985146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9845-8a11-4fc4-b116-29a929985146.jpg?1",
             "name": "Staunch Crewmate",
             "text": "When Staunch Crewmate enters the battlefield, look at the top four cards of your library. You may reveal an artifact or Pirate card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "1dc0553b-6e6f-5982-a43d-697a18aae0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b6881a-b00e-4e90-92e6-602ed8e0e090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b6881a-b00e-4e90-92e6-602ed8e0e090.jpg?1",
             "name": "Subterranean Schooner",
             "text": "Whenever Subterranean Schooner attacks, target creature that crewed it this turn explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)\nCrew 1",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "d9c396f8-c423-54d6-87d8-cff54b358593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b3d1d-8c85-4707-80b5-c4d832df9846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b3d1d-8c85-4707-80b5-c4d832df9846.jpg?1",
             "name": "Tishana's Tidebinder",
             "text": "Flash\nWhen Tishana's Tidebinder enters the battlefield, counter up to one target activated or triggered ability. If an ability of an artifact, creature, or planeswalker is countered this way, that permanent loses all abilities for as long as Tishana's Tidebinder remains on the battlefield. (Mana abilities can't be targeted.)",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "335eb602-64d9-5657-ac0c-9e5fc77c1ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebb2df-8891-434e-9cd0-f25b848cb754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebb2df-8891-434e-9cd0-f25b848cb754.jpg?1",
             "name": "Unlucky Drop",
             "text": "Target artifact or creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -3226,7 +3226,7 @@
         },
         {
             "id": "2f43b4c8-b207-5fcb-b9f4-f33bcc9c4f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1",
             "name": "Waterlogged Hulk // Watertight Gondola",
             "text": "",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "2d2facd0-de51-52cc-b3a9-4d851512fd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1",
             "name": "Waterlogged Hulk // Watertight Gondola",
             "text": "",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "c38fba30-7f25-57df-a674-aecb47d1031f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7738fb-0a1b-4010-b8c0-e1129739c765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7738fb-0a1b-4010-b8c0-e1129739c765.jpg?1",
             "name": "Waterwind Scout",
             "text": "Flying\nWhen Waterwind Scout enters the battlefield, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "51bc29a8-78c8-548e-9cfb-db0c412ddde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2bb06-7163-47fe-bede-9c192c9b8952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2bb06-7163-47fe-bede-9c192c9b8952.jpg?1",
             "name": "Waylaying Pirates",
             "text": "When Waylaying Pirates enters the battlefield, if you control an artifact, tap target artifact or creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -3362,7 +3362,7 @@
         },
         {
             "id": "65e895e7-a6ea-5f56-9778-51be4bc4bf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f498ac-179e-4055-9b83-97bcc5ab1bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f498ac-179e-4055-9b83-97bcc5ab1bb9.jpg?1",
             "name": "Zoetic Glyph",
             "text": "Enchant artifact\nEnchanted artifact is a Golem creature with base power and toughness 5/4 in addition to its other types.\nWhen Zoetic Glyph is put into a graveyard from the battlefield, discover 3.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "9dab74b6-103d-5dad-a7eb-91b66fd0f2ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559f77f-1f10-475b-9361-7f297d50f254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559f77f-1f10-475b-9361-7f297d50f254.jpg?1",
             "name": "Abyssal Gorestalker",
             "text": "When Abyssal Gorestalker enters the battlefield, each player sacrifices two creatures.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "d5b57b40-e57e-5c6a-8fc8-52a57dec51fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "028b6a88-806f-5c4d-b0e7-de3fe6f50ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [],
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "2140ad02-1240-5bc1-aa78-1b5b608f14c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99009400-ffa4-40af-8305-78295ae605ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99009400-ffa4-40af-8305-78295ae605ac.jpg?1",
             "name": "Acolyte of Aclazotz",
             "text": "{T}, Sacrifice another creature or artifact: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "10444841-d550-553e-8190-d2fb3294ef32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d9eb9f-2fcc-49f0-99c1-bad748239466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d9eb9f-2fcc-49f0-99c1-bad748239466.jpg?1",
             "name": "Another Chance",
             "text": "You may mill two cards. Then return up to two creature cards from your graveyard to your hand. (To mill two cards, put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "35789897-27ae-532f-a8de-90c01b62c57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bdd22c-3e11-4c29-bdfa-d3dfc0e90a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bdd22c-3e11-4c29-bdfa-d3dfc0e90a9f.jpg?1",
             "name": "Bitter Triumph",
             "text": "As an additional cost to cast this spell, discard a card or pay 3 life.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "dce4a5ae-3282-5a05-907d-9284a6880f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6027a-003a-4f9d-929a-0b6da1fa42c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6027a-003a-4f9d-929a-0b6da1fa42c9.jpg?1",
             "name": "Bloodletter of Aclazotz",
             "text": "Flying\nIf an opponent would lose life during your turn, they lose twice that much life instead. (Damage causes loss of life.)",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "0a2e07fa-bc01-5b6e-ba2d-fffee4f7f019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db38babd-57e8-4e59-9701-11a0682baa77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db38babd-57e8-4e59-9701-11a0682baa77.jpg?1",
             "name": "Bloodthorn Flail",
             "text": "Equipped creature gets +2/+1.\nEquip\u2014\nPay {3} or discard a card.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "b55489ac-5af3-58a2-ac12-df7006b2aaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19775c18-4cc0-49d3-86e4-0841768cbf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19775c18-4cc0-49d3-86e4-0841768cbf4d.jpg?1",
             "name": "Bringer of the Last Gift",
             "text": "Flying\nWhen Bringer of the Last Gift enters the battlefield, if you cast it, each player sacrifices all other creatures they control. Then each player returns all creature cards from their graveyard that weren't put there this way to the battlefield.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "2eac678e-b95a-5014-82ce-e2c3fff11a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08318a16-a9ed-42c8-9433-876b7a72e368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08318a16-a9ed-42c8-9433-876b7a72e368.jpg?1",
             "name": "Broodrage Mycoid",
             "text": "At the beginning of your end step, if you descended this turn, create a 1/1 black Fungus creature token with \"This creature can't block.\" (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "b3795668-9527-5409-8f49-46148dffc32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b6892-5dfc-4607-b511-cf83544a9357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b6892-5dfc-4607-b511-cf83544a9357.jpg?1",
             "name": "Canonized in Blood",
             "text": "At the beginning of your end step, if you descended this turn, put a +1/+1 counter on target creature you control. (You descended if a permanent card was put into your graveyard from anywhere.)\n{5}{B}{B}, Sacrifice Canonized in Blood: Create a 4/3 white and black Vampire Demon creature token with flying.",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "8c30794f-3057-5775-ab5e-03c351ebe356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd8eed6-91da-4454-a5e3-7bbfac614f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd8eed6-91da-4454-a5e3-7bbfac614f47.jpg?1",
             "name": "Chupacabra Echo",
             "text": "Fathomless descent \u2014 When Chupacabra Echo enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "31c7fe65-e9db-5c1b-bce8-da06b60668d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1",
             "name": "Corpses of the Lost",
             "text": "Skeletons you control get +1/+0 and have haste.\nWhen Corpses of the Lost enters the battlefield, create a 2/2 black Skeleton Pirate creature token.\nAt the beginning of your end step, if you descended this turn, you may pay 1 life. If you do, return Corpses of the Lost to its owner's hand. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -3844,7 +3844,7 @@
         },
         {
             "id": "e30a2047-0552-5b4f-9fa3-9bb571e0f91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e6b971-3f5b-47e7-8209-98d72ee781fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e6b971-3f5b-47e7-8209-98d72ee781fc.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -3878,7 +3878,7 @@
         },
         {
             "id": "5c29a9cd-52d7-5b6f-8f46-67c23d4f7e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc9d22c-dfce-4136-aed8-a5fe9bb852f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc9d22c-dfce-4136-aed8-a5fe9bb852f2.jpg?1",
             "name": "Deathcap Marionette",
             "text": "Deathtouch\nWhen Deathcap Marionette enters the battlefield, you may mill two cards. (You may put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "931027c6-7291-5ca5-bc17-128a5483c6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b24bb7c-6b34-48b6-af94-f312ebdbb759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b24bb7c-6b34-48b6-af94-f312ebdbb759.jpg?1",
             "name": "Deep Goblin Skulltaker",
             "text": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Deep Goblin Skulltaker. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "45db1587-d9aa-55d5-a64a-7437928a2564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c68c95-b788-43b1-9f22-1b22c5a00b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c68c95-b788-43b1-9f22-1b22c5a00b25.jpg?1",
             "name": "Deep-Cavern Bat",
             "text": "Flying, lifelink\nWhen Deep-Cavern Bat enters the battlefield, look at target opponent's hand. You may exile a nonland card from it until Deep-Cavern Bat leaves the battlefield.",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "a50ff94a-727c-564f-9c64-13ece44f823f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9abaec-af72-4399-b162-5e62e7487242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9abaec-af72-4399-b162-5e62e7487242.jpg?1",
             "name": "Defossilize",
             "text": "Return target creature card from your graveyard to the battlefield. That creature explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "d85f3081-9d6e-5ec0-b2bf-ec2957e1f4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319a457c-89b7-47f6-a13c-20bb50d41138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319a457c-89b7-47f6-a13c-20bb50d41138.jpg?1",
             "name": "Echo of Dusk",
             "text": "Descend 4 \u2014 As long as there are four or more permanent cards in your graveyard, Echo of Dusk gets +1/+1 and has lifelink.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "76b0e955-6216-5a7e-900a-55c9ebbe8925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d896dd52-b134-4b55-ab91-ccb05ecc50f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d896dd52-b134-4b55-ab91-ccb05ecc50f4.jpg?1",
             "name": "Fanatical Offering",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "4ef7a422-64f0-5588-8185-1b8a66c8bb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2bd0ca-521c-45d9-85ed-2f36f583408e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2bd0ca-521c-45d9-85ed-2f36f583408e.jpg?1",
             "name": "Fungal Fortitude",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+0.\nWhen enchanted creature dies, return it to the battlefield tapped under its owner's control.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "d04430dc-b671-5ae6-af29-78bdc6eb92cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94724efb-4785-4751-9fe1-07f243dd6008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94724efb-4785-4751-9fe1-07f243dd6008.jpg?1",
             "name": "Gargantuan Leech",
             "text": "This spell costs {1} less to cast for each Cave you control and each Cave card in your graveyard.\nLifelink",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "5f9f8a16-6934-5635-b915-83ef9ec9fe98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg?1",
             "name": "Grasping Shadows // Shadows' Lair",
             "text": "",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "5c7acdf9-cf71-5973-9690-d7fd32ecb5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg?1",
             "name": "Grasping Shadows // Shadows' Lair",
             "text": "",
             "colours": [],
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "e7530ea8-4bfd-531c-82c1-8fec496afb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692fe4e8-13b4-4bec-938e-a8073a7fbd71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692fe4e8-13b4-4bec-938e-a8073a7fbd71.jpg?1",
             "name": "Greedy Freebooter",
             "text": "When Greedy Freebooter dies, scry 1 and create a Treasure token. (To scry 1, look at the top card of your library. You may put that card on the bottom. A Treasure token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "402fc9fe-c387-5771-9e03-e4f863d7a0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg?1",
             "name": "Join the Dead",
             "text": "Target creature gets -5/-5 until end of turn.\nDescend 4 \u2014 That creature gets -10/-10 until end of turn instead if there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "2b7892c8-fb92-53a6-9d62-93884c6b6e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2796fffa-8cbf-4ec9-91a8-7b6f39fd50ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2796fffa-8cbf-4ec9-91a8-7b6f39fd50ec.jpg?1",
             "name": "Malicious Eclipse",
             "text": "All creatures get -2/-2 until end of turn. If a creature an opponent controls would die this turn, exile it instead.",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "5204fa9e-de36-578b-b7d4-23483c68970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcae196-dbcc-44d5-b700-c57b0b646483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcae196-dbcc-44d5-b700-c57b0b646483.jpg?1",
             "name": "Mephitic Draught",
             "text": "When Mephitic Draught enters the battlefield or is put into a graveyard from the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "e756d193-31e8-530c-a0ae-0040ec733ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89345f55-2b32-4356-945a-d56dded39909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89345f55-2b32-4356-945a-d56dded39909.jpg?1",
             "name": "Preacher of the Schism",
             "text": "Deathtouch\nWhenever Preacher of the Schism attacks the player with the most life or tied for most life, create a 1/1 white Vampire creature token with lifelink.\nWhenever Preacher of the Schism attacks while you have the most life or are tied for most life, you draw a card and you lose 1 life.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "fb20199b-547b-593f-a0bc-3140d3907e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f5ad0-e9c1-4e45-b245-2946e29baecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f5ad0-e9c1-4e45-b245-2946e29baecb.jpg?1",
             "name": "Primordial Gnawer",
             "text": "When Primordial Gnawer dies, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "40d30848-c5a7-566f-a252-9db8fbeb84ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg?1",
             "name": "Queen's Bay Paladin",
             "text": "Whenever Queen's Bay Paladin enters the battlefield or attacks, return up to one target Vampire card from your graveyard to the battlefield with a finality counter on it. You lose life equal to its mana value. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "f8787d76-bdc6-5b8b-bbbd-e3bb01d9910e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad0adcb-80e5-4c6d-bcdd-9e5d18c017b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad0adcb-80e5-4c6d-bcdd-9e5d18c017b3.jpg?1",
             "name": "Rampaging Spiketail",
             "text": "When Rampaging Spiketail enters the battlefield, target creature you control gets +2/+0 and gains indestructible until end of turn.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "b2ab463f-6623-5954-b940-095697450ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d440d90e-ac7e-4715-971a-700c977c7fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d440d90e-ac7e-4715-971a-700c977c7fde.jpg?1",
             "name": "Ray of Ruin",
             "text": "Exile target creature, Vehicle, or nonbasic land. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "fbc70c15-74b8-5c39-a308-9dde4fc1495c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2f3efb-1526-48c0-842a-374af63ea467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2f3efb-1526-48c0-842a-374af63ea467.jpg?1",
             "name": "Screaming Phantom",
             "text": "Flying\nWhenever Screaming Phantom attacks, mill a card. (Put the top card of your library into your graveyard.)",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "9e8802df-a81e-5a17-a27c-3c870581f4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d96d019-5d80-468a-b891-e3e99346372a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d96d019-5d80-468a-b891-e3e99346372a.jpg?1",
             "name": "Skullcap Snail",
             "text": "When Skullcap Snail enters the battlefield, target opponent exiles a card from their hand.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "bb94f29d-dea5-5f3a-b2a5-3656385bdc00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1125fdf2-2dbb-49a6-b76f-8cd6c3d6fab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1125fdf2-2dbb-49a6-b76f-8cd6c3d6fab4.jpg?1",
             "name": "Soulcoil Viper",
             "text": "{B}, {T}, Sacrifice Soulcoil Viper: Return target creature card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "c175fbcf-103a-5e70-b87b-a0e7808dfa85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg?1",
             "name": "Souls of the Lost",
             "text": "As an additional cost to cast this spell, discard a card or sacrifice a permanent.\nFathomless descent \u2014 Souls of the Lost's power is equal to the number of permanent cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "e56cdb90-3c68-5d53-a6fa-529c65c075ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5319c0b1-de54-492a-bdea-85a5a75d693e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5319c0b1-de54-492a-bdea-85a5a75d693e.jpg?1",
             "name": "Stalactite Stalker",
             "text": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Stalactite Stalker. (You descended if a permanent card was put into your graveyard from anywhere.)\n{2}{B}, Sacrifice Stalactite Stalker: Target creature gets -X/-X until end of turn, where X is Stalactite Stalker's power.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "d2bcd953-b25c-5f72-9487-9b69ec6891ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg?1",
             "name": "Starving Revenant",
             "text": "When Starving Revenant enters the battlefield, surveil 2. Then for each card you put on top of your library, you draw a card and you lose 3 life.\nDescend 8 \u2014 Whenever you draw a card, if there are eight or more permanent cards in your graveyard, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "3e84981b-fafc-524e-8d81-5b63bb5b897e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a230208-84ae-4f48-afbd-a0d50596ad27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a230208-84ae-4f48-afbd-a0d50596ad27.jpg?1",
             "name": "Stinging Cave Crawler",
             "text": "Deathtouch\nDescend 4 \u2014 Whenever Stinging Cave Crawler attacks, if there are four or more permanent cards in your graveyard, you draw a card and you lose 1 life.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "8c19468c-3738-560e-8419-ba1e52e73ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg?1",
             "name": "Synapse Necromage",
             "text": "When Synapse Necromage dies, create two 1/1 black Fungus creature tokens with \"This creature can't block.\"",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "149669b4-972d-5e3d-8f16-5cc4a12f632e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "376b2c19-7693-522d-abca-39d852e3a5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [],
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "338a9018-33f9-52ba-9464-44328acd9e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a281d2c-20b9-4887-a924-9be6c07b7629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a281d2c-20b9-4887-a924-9be6c07b7629.jpg?1",
             "name": "Terror Tide",
             "text": "Fathomless descent \u2014 All creatures get -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "e395ab8e-ec66-5f5c-a7d2-5ce3f1591998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1",
             "name": "Tithing Blade // Consuming Sepulcher",
             "text": "",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "b574deaa-3d3c-5ee9-8d1e-467200e376d6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1",
             "name": "Tithing Blade // Consuming Sepulcher",
             "text": "",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "022d74a3-def7-59a2-ae7b-3c66fa53b87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg?1",
             "name": "Visage of Dread // Dread Osseosaur",
             "text": "",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "90f77a9f-ab73-5a50-af96-ea120f211dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg?1",
             "name": "Visage of Dread // Dread Osseosaur",
             "text": "",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "8973b27b-24b7-5888-91e8-123d52f82051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9030048a-b866-4a89-8d4a-aa55411463e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9030048a-b866-4a89-8d4a-aa55411463e4.jpg?1",
             "name": "Vito's Inquisitor",
             "text": "{B}, Sacrifice another creature or artifact: Put a +1/+1 counter on Vito's Inquisitor. It gains menace until end of turn.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "44eabec6-851c-5942-8b3f-50ba39452c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f39b5e-2e85-4f31-bbab-0b0bf58f701d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f39b5e-2e85-4f31-bbab-0b0bf58f701d.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "1d42fece-0e15-57d8-b675-3f547045be94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d5b7d-e27d-42d6-ba7a-d4a6b0dd8549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d5b7d-e27d-42d6-ba7a-d4a6b0dd8549.jpg?1",
             "name": "Ancestors' Aid",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "ae40803c-d58f-5ada-8c28-debf22a9a52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2debca-8535-4cf6-a461-c268faaacaae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2debca-8535-4cf6-a461-c268faaacaae.jpg?1",
             "name": "Belligerent Yearling",
             "text": "Trample\nWhenever another Dinosaur enters the battlefield under your control, you may have Belligerent Yearling's base power become equal to that creature's power until end of turn.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "b09fa20f-c822-51bd-b0f9-0d669b182b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220ed60-3f8f-4dd2-8319-6a06896a5350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220ed60-3f8f-4dd2-8319-6a06896a5350.jpg?1",
             "name": "Bonehoard Dracosaur",
             "text": "Flying, first strike\nAt the beginning of your upkeep, exile the top two cards of your library. You may play them this turn. If you exiled a land card this way, create a 3/1 red Dinosaur creature token. If you exiled a nonland card this way, create a Treasure token.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "295fd7d7-e6c0-55c2-b75a-ac769832b5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "3890c69d-65fa-55c2-95e1-fd5f03159372",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [],
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "f2befba0-297a-5cec-907b-f88caa066bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9e0c66-f64a-428c-be13-a52691833df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9e0c66-f64a-428c-be13-a52691833df1.jpg?1",
             "name": "Brazen Blademaster",
             "text": "Whenever Brazen Blademaster attacks while you control two or more artifacts, it gets +2/+1 until end of turn.",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "7fb9b8a4-421d-5542-9d93-e0551944dd0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf5028-8dfe-40d3-89b4-22bd7ed0aae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf5028-8dfe-40d3-89b4-22bd7ed0aae6.jpg?1",
             "name": "Breeches, Eager Pillager",
             "text": "First strike\nWhenever a Pirate you control attacks, choose one that hasn't been chosen this turn \u2014\n\u2022 Create a Treasure token.\n\u2022 Target creature can't block this turn.\n\u2022 Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -5359,7 +5359,7 @@
         },
         {
             "id": "044adcac-fcff-5081-8df9-cd517cd6aab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c491ac0-4752-47a7-967e-456b6e4245de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c491ac0-4752-47a7-967e-456b6e4245de.jpg?1",
             "name": "Burning Sun Cavalry",
             "text": "Whenever Burning Sun Cavalry attacks or blocks while you control a Dinosaur, Burning Sun Cavalry gets +1/+1 until end of turn.",
             "colours": [
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "d1837b03-64d6-5952-b831-9aba1ed54243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8341ddd9-aac1-4773-b8ce-51e35f696263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8341ddd9-aac1-4773-b8ce-51e35f696263.jpg?1",
             "name": "Calamitous Cave-In",
             "text": "Calamitous Cave-In deals X damage to each creature and each planeswalker, where X is the number of Caves you control plus the number of Cave cards in your graveyard.",
             "colours": [
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "6b3121dc-fa61-570e-9075-804c20e4a989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e964f026-9cbf-4fa2-acdc-60d19b88f183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e964f026-9cbf-4fa2-acdc-60d19b88f183.jpg?1",
             "name": "Child of the Volcano",
             "text": "Trample\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Child of the Volcano. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -5460,7 +5460,7 @@
         },
         {
             "id": "8c180975-85da-50b2-ad3f-57bb3b8e4879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a144d0b3-678d-4f4c-a9b0-22af19f5cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a144d0b3-678d-4f4c-a9b0-22af19f5cf9f.jpg?1",
             "name": "Curator of Sun's Creation",
             "text": "Whenever you discover, discover again for the same value. This ability triggers only once each turn.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "af6f662a-bed6-5be9-8cc0-e7d0a789e07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95018a4-be10-4c46-b14d-4b1eba838bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95018a4-be10-4c46-b14d-4b1eba838bc0.jpg?1",
             "name": "Daring Discovery",
             "text": "Up to three target creatures can't block this turn.\nDiscover 4. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -5527,7 +5527,7 @@
         },
         {
             "id": "47daaac6-622d-5e66-a709-820a9ba2a0da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae30fa7-3d1d-417f-80d7-a668236cb2c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae30fa7-3d1d-417f-80d7-a668236cb2c1.jpg?1",
             "name": "Diamond Pick-Axe",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.)\nEquipped creature gets +1/+1 and has \"Whenever this creature attacks, create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquip {2}",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "a5089709-142c-5ddd-ace5-01cae951323f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1a93e-ec71-45fa-b0b8-2c21123e390c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1a93e-ec71-45fa-b0b8-2c21123e390c.jpg?1",
             "name": "Dinotomaton",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Dinotomaton enters the battlefield, target creature you control gains menace until end of turn.",
             "colours": [
@@ -5597,7 +5597,7 @@
         },
         {
             "id": "a6794b02-f81e-5574-bf66-80bbc0114d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "ca41e9ce-b7c4-5fc1-8ddc-2b21b31a7f10",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "df02e122-9e54-57f9-a0e8-b27c3b6776f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg?1",
             "name": "Dowsing Device // Geode Grotto",
             "text": "",
             "colours": [
@@ -5701,7 +5701,7 @@
         },
         {
             "id": "fe27fbe8-9d40-5c99-93e7-a4aabdd91fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg?1",
             "name": "Dowsing Device // Geode Grotto",
             "text": "",
             "colours": [],
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "30134751-b231-529d-8b69-6bac974f8a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062e00a1-f1dc-4089-b640-800ab781c590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062e00a1-f1dc-4089-b640-800ab781c590.jpg?1",
             "name": "Dreadmaw's Ire",
             "text": "Until end of turn, target attacking creature gets +2/+2 and gains trample and \"Whenever this creature deals combat damage to a player, destroy target artifact that player controls.\"",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "d59284e8-5616-59da-8975-5ed6723b2c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44420f52-2ed8-4f81-93e4-5decc77bed01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44420f52-2ed8-4f81-93e4-5decc77bed01.jpg?1",
             "name": "Enterprising Scallywag",
             "text": "At the beginning of your end step, if you descended this turn, create a Treasure token. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "e28c0841-80f2-56cd-9a85-4edf22ca4ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4075a8-c15d-4078-bf4b-0f85c03fecec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4075a8-c15d-4078-bf4b-0f85c03fecec.jpg?1",
             "name": "Etali's Favor",
             "text": "Enchant creature you control\nWhen Etali's Favor enters the battlefield, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)\nEnchanted creature gets +1/+1 and has trample.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "8d055292-a68b-5883-b9f8-92d4f15565d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c1a82-695b-4df2-8e51-2d71a62e7baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c1a82-695b-4df2-8e51-2d71a62e7baf.jpg?1",
             "name": "Geological Appraiser",
             "text": "When Geological Appraiser enters the battlefield, if you cast it, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -5871,7 +5871,7 @@
         },
         {
             "id": "a3aa44df-8e58-5f56-b9e5-6de02348a9fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dec77b-e790-48b8-8c13-91305d9f97ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dec77b-e790-48b8-8c13-91305d9f97ce.jpg?1",
             "name": "A-Geological Appraiser",
             "text": "",
             "colours": [
@@ -5905,7 +5905,7 @@
         },
         {
             "id": "01490ea5-eac1-5be1-b95f-e1af9f2c0f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018160fe-f602-43f5-8495-241a08eaa69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018160fe-f602-43f5-8495-241a08eaa69c.jpg?1",
             "name": "Goblin Tomb Raider",
             "text": "As long as you control an artifact, Goblin Tomb Raider gets +1/+0 and has haste.",
             "colours": [
@@ -5940,7 +5940,7 @@
         },
         {
             "id": "5cbea8fc-d00d-505d-8ab3-256cf510e2b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415904fe-b77f-4c1a-850f-688484d629e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415904fe-b77f-4c1a-850f-688484d629e6.jpg?1",
             "name": "Goldfury Strider",
             "text": "Trample\nTap two untapped artifacts and/or creatures you control: Target creature gets +2/+0 until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "9734b99b-7c13-576b-a05e-14a405aee7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg?1",
             "name": "Hit the Mother Lode",
             "text": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference. (To discover 10, exile cards from the top of your library until you exile a nonland card with mana value 10 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -6010,7 +6010,7 @@
         },
         {
             "id": "72777e08-b27c-5bf2-942c-d8f3da90677b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87468b6b-6f78-42e4-ab0d-6730aeecdc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87468b6b-6f78-42e4-ab0d-6730aeecdc3f.jpg?1",
             "name": "Hotfoot Gnome",
             "text": "Haste\n{T}: Another target creature gains haste until end of turn.",
             "colours": [
@@ -6045,7 +6045,7 @@
         },
         {
             "id": "8f6ce616-2351-5977-a5cb-36d8b81081f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1",
             "name": "Idol of the Deep King // Sovereign's Macuahuitl",
             "text": "",
             "colours": [
@@ -6077,7 +6077,7 @@
         },
         {
             "id": "ab79e26b-c7be-5443-b42e-37a1242c18fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1",
             "name": "Idol of the Deep King // Sovereign's Macuahuitl",
             "text": "",
             "colours": [
@@ -6111,7 +6111,7 @@
         },
         {
             "id": "2bdacef4-4c48-53b9-8644-1d890fb4a2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7a55aa-ae61-4933-b7a4-dcc55dac6fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7a55aa-ae61-4933-b7a4-dcc55dac6fcd.jpg?1",
             "name": "Inti, Seneschal of the Sun",
             "text": "Whenever you attack, you may discard a card. When you do, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.\nWhenever you discard one or more cards, exile the top card of your library. You may play that card until your next end step.",
             "colours": [
@@ -6150,7 +6150,7 @@
         },
         {
             "id": "ed27cd7c-8283-565d-af99-6eab078080e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471a833-11b9-4146-a9c0-84a6896c94d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471a833-11b9-4146-a9c0-84a6896c94d8.jpg?1",
             "name": "Magmatic Galleon",
             "text": "When Magmatic Galleon enters the battlefield, it deals 5 damage to target creature an opponent controls.\nWhenever one or more creatures your opponents control are dealt excess noncombat damage, create a Treasure token.\nCrew 2",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "b1ff7c42-75e8-5c0c-8c29-a2f0bb987517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "cec0ffae-7a03-51be-a750-0f958492ff20",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [],
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "12259bd4-a689-5887-a8cd-686652faba7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad371c97-a266-4a88-9d28-2e889a37ba00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad371c97-a266-4a88-9d28-2e889a37ba00.jpg?1",
             "name": "Panicked Altisaur",
             "text": "Reach\n{T}: Panicked Altisaur deals 2 damage to each opponent.",
             "colours": [
@@ -6290,7 +6290,7 @@
         },
         {
             "id": "5e684366-7a6c-5619-8fd4-77dc41b17175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb2552f-8370-4931-83e1-93706d51413a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb2552f-8370-4931-83e1-93706d51413a.jpg?1",
             "name": "Plundering Pirate",
             "text": "When Plundering Pirate enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6325,7 +6325,7 @@
         },
         {
             "id": "9ad52490-8541-5257-aa4c-b465cc93a808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg?1",
             "name": "Poetic Ingenuity",
             "text": "Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.\nWhenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. This ability triggers only once each turn.",
             "colours": [
@@ -6359,7 +6359,7 @@
         },
         {
             "id": "01811d3f-d839-5da0-9099-8e0d7a299720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bab3f8f-cb06-466d-a35d-0b5e1a2b524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bab3f8f-cb06-466d-a35d-0b5e1a2b524c.jpg?1",
             "name": "Rampaging Ceratops",
             "text": "Rampaging Ceratops can't be blocked except by three or more creatures.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "b72fa5f6-9ae5-5af1-a099-a5599629584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg?1",
             "name": "Rumbling Rockslide",
             "text": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "abb5d688-c918-5421-9ef6-08e48504f014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg?1",
             "name": "Saheeli's Lattice // Mastercraft Raptor",
             "text": "",
             "colours": [
@@ -6459,7 +6459,7 @@
         },
         {
             "id": "e9034943-a625-5536-bb00-32adf8527499",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg?1",
             "name": "Saheeli's Lattice // Mastercraft Raptor",
             "text": "",
             "colours": [
@@ -6494,7 +6494,7 @@
         },
         {
             "id": "4e6b69d4-5106-531c-b604-9a288ec9cbc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9436cf62-56d6-4662-9982-72e9be80d25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9436cf62-56d6-4662-9982-72e9be80d25c.jpg?1",
             "name": "Scytheclaw Raptor",
             "text": "Whenever a player casts a spell, if it's not their turn, Scytheclaw Raptor deals 4 damage to them.",
             "colours": [
@@ -6530,7 +6530,7 @@
         },
         {
             "id": "1adb623f-d228-5068-a2d9-cc376794ba34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeb9dc-18f9-4120-ac3d-226c62a1dc1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeb9dc-18f9-4120-ac3d-226c62a1dc1d.jpg?1",
             "name": "Seismic Monstrosaur",
             "text": "Trample\n{2}{R}, Sacrifice a land: Draw a card.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "797dff5f-db54-51f1-8389-df7b5322ef49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb040fc7-f728-4482-92af-9a320c03bb54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb040fc7-f728-4482-92af-9a320c03bb54.jpg?1",
             "name": "Sunfire Torch",
             "text": "Equipped creature gets +1/+0 and has \"Whenever this creature attacks, you may sacrifice Sunfire Torch. When you do, this creature deals 2 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6598,7 +6598,7 @@
         },
         {
             "id": "e5c00766-0c58-5e7b-9bc7-d8eb624a81ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg?1",
             "name": "Sunshot Militia",
             "text": "Tap two untapped artifacts and/or creatures you control: Sunshot Militia deals 1 damage to each opponent. Activate only as a sorcery.",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "5e2633d6-7d30-5b59-a3a2-a3f41a78f99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg?1",
             "name": "Tectonic Hazard",
             "text": "Tectonic Hazard deals 1 damage to each opponent and each creature they control.",
             "colours": [
@@ -6665,7 +6665,7 @@
         },
         {
             "id": "429832e0-540f-5205-9633-33045c3f00db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b28139-efa7-4818-a012-cf8150692b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b28139-efa7-4818-a012-cf8150692b43.jpg?1",
             "name": "Triumphant Chomp",
             "text": "Triumphant Chomp deals damage to target creature equal to 2 or the greatest power among Dinosaurs you control, whichever is greater.",
             "colours": [
@@ -6697,7 +6697,7 @@
         },
         {
             "id": "99a8aaf4-b7b6-51f3-910f-59eaaeb187d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg?1",
             "name": "Trumpeting Carnosaur",
             "text": "Trample\nWhen Trumpeting Carnosaur enters the battlefield, discover 5.\n{2}{R}, Discard Trumpeting Carnosaur: It deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "a144c634-6789-5801-ab91-24f5d4c447c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101921a-d26f-4a00-a0db-1b418f2e6b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101921a-d26f-4a00-a0db-1b418f2e6b01.jpg?1",
             "name": "Volatile Wanderglyph",
             "text": "Whenever Volatile Wanderglyph becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "bb47f068-9a4f-5f7a-8547-5878594708f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04839717-d2f9-481d-9d13-e4038dbcbb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04839717-d2f9-481d-9d13-e4038dbcbb0e.jpg?1",
             "name": "Zoyowa's Justice",
             "text": "The owner of target artifact or creature with mana value 1 or greater shuffles it into their library. Then that player discovers X, where X is its mana value. (They exile cards from the top of their library until they exile a nonland card with that mana value or less. They cast it without paying its mana cost or put it into their hand. They put the rest on the bottom in a random order.)",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "26bf283a-8554-5bce-8301-c6126e3ff357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76a46a1-a63e-460a-98c5-699dd1c827aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76a46a1-a63e-460a-98c5-699dd1c827aa.jpg?1",
             "name": "Armored Kincaller",
             "text": "When Armored Kincaller enters the battlefield, you may reveal a Dinosaur card from your hand. If you do or if you control another Dinosaur, you gain 3 life.",
             "colours": [
@@ -6834,7 +6834,7 @@
         },
         {
             "id": "5821e64b-cd62-53e2-960e-0cb705877f22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a2ba4-dfa8-49d6-95e9-04b7a14d0c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a2ba4-dfa8-49d6-95e9-04b7a14d0c6c.jpg?1",
             "name": "Basking Capybara",
             "text": "Descend 4 \u2014 Basking Capybara gets +3/+0 as long as there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -6868,7 +6868,7 @@
         },
         {
             "id": "2c71599f-3508-5a69-8685-9db73d9faa43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bd623-3100-44dc-adec-53fa3a95ab19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bd623-3100-44dc-adec-53fa3a95ab19.jpg?1",
             "name": "Bedrock Tortoise",
             "text": "As long as it's your turn, creatures you control have hexproof.\nEach creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -6904,7 +6904,7 @@
         },
         {
             "id": "13d37ab9-5775-5acf-8c72-1588bc4c9588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decdfd6b-55ab-47fd-9f98-1845261f1caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decdfd6b-55ab-47fd-9f98-1845261f1caf.jpg?1",
             "name": "Cavern Stomper",
             "text": "When Cavern Stomper enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{3}{G}: Cavern Stomper can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "77bf1d38-ed87-5674-9ad9-c97cbf25d293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce4b7bc-636b-4723-a7c1-2c859f333492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce4b7bc-636b-4723-a7c1-2c859f333492.jpg?1",
             "name": "Cenote Scout",
             "text": "When Cenote Scout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6975,7 +6975,7 @@
         },
         {
             "id": "ee2cc6e3-921e-5d59-aeb0-ba5fd4cb05d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c70d86-1764-487d-a415-15ae79ba570c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c70d86-1764-487d-a415-15ae79ba570c.jpg?1",
             "name": "Coati Scavenger",
             "text": "Descend 4 \u2014 When Coati Scavenger enters the battlefield, if there are four or more permanent cards in your graveyard, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -7009,7 +7009,7 @@
         },
         {
             "id": "c1fe450c-9007-534e-a1b5-46c4763a04f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702e776-be2c-48a9-9bc5-bb8ea514333b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702e776-be2c-48a9-9bc5-bb8ea514333b.jpg?1",
             "name": "Colossadactyl",
             "text": "Reach, trample",
             "colours": [
@@ -7043,7 +7043,7 @@
         },
         {
             "id": "292d0b2f-2844-59f8-bc76-339fc2c84d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1",
             "name": "Cosmium Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n\u2022 Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -7077,7 +7077,7 @@
         },
         {
             "id": "13725885-cc9e-5bef-a23f-3ae5ff9b41da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404b8d6-3673-4d82-b9ed-d28e9b54e1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404b8d6-3673-4d82-b9ed-d28e9b54e1f6.jpg?1",
             "name": "Disturbed Slumber",
             "text": "Until end of turn, target land you control becomes a 4/4 Dinosaur creature with reach and haste. It's still a land. It must be blocked this turn if able.",
             "colours": [
@@ -7109,7 +7109,7 @@
         },
         {
             "id": "dc8df2e0-327e-5e09-a416-814a61a8ae0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcbba6f-aa54-44be-a3b0-f712fa8bd5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcbba6f-aa54-44be-a3b0-f712fa8bd5ad.jpg?1",
             "name": "Earthshaker Dreadmaw",
             "text": "Trample\nWhen Earthshaker Dreadmaw enters the battlefield, draw a card for each other Dinosaur you control.",
             "colours": [
@@ -7145,7 +7145,7 @@
         },
         {
             "id": "dde14eea-5f8c-5079-9b34-b5777b9ef0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b36214-9c7e-4a24-93d4-17b2d00cbc51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b36214-9c7e-4a24-93d4-17b2d00cbc51.jpg?1",
             "name": "Explorer's Cache",
             "text": "Explorer's Cache enters the battlefield with two +1/+1 counters on it.\nWhenever a creature you control with a +1/+1 counter on it dies, put a +1/+1 counter on Explorer's Cache.\n{T}: Move a +1/+1 counter from Explorer's Cache onto target creature. Activate only as a sorcery.",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "44f9a407-0765-5b35-a73d-7267770b065c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e805e9-69be-45c1-aa04-f460641a0c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e805e9-69be-45c1-aa04-f460641a0c1e.jpg?1",
             "name": "Ghalta, Stampede Tyrant",
             "text": "Trample\nWhen Ghalta, Stampede Tyrant enters the battlefield, put any number of creature cards from your hand onto the battlefield.",
             "colours": [
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "f2e69c4c-9d6a-5c5a-a81e-3b277ba65715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7d6aed-3dc8-417d-a190-1660cfc8ee4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7d6aed-3dc8-417d-a190-1660cfc8ee4a.jpg?1",
             "name": "Glimpse the Core",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic Forest card, put that card onto the battlefield tapped, then shuffle.\n\u2022 Return target Cave card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "84e0cdb7-592f-5967-bbf2-80a9116ad1b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafde87c-743d-4307-93e0-fbd30f5d92f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafde87c-743d-4307-93e0-fbd30f5d92f6.jpg?1",
             "name": "Glowcap Lantern",
             "text": "Equipped creature has \"You may look at the top card of your library any time\" and \"Whenever this creature attacks, it explores.\" (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)\nEquip {2}",
             "colours": [
@@ -7282,7 +7282,7 @@
         },
         {
             "id": "9487b866-aa46-5666-b5b8-981dcedf8901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [
@@ -7318,7 +7318,7 @@
         },
         {
             "id": "040aedf7-51db-585e-89a1-90a136e2447b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [],
@@ -7352,7 +7352,7 @@
         },
         {
             "id": "d022ea1f-57b6-573a-ac29-8207e848f770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -7395,7 +7395,7 @@
         },
         {
             "id": "a05b81eb-b74a-5432-9fc6-a23cc2fba41c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "2cbe916e-3064-52c5-83d8-d664bb115094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1247a5fa-b50a-4ab1-96ca-dbeb45bd0b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1247a5fa-b50a-4ab1-96ca-dbeb45bd0b56.jpg?1",
             "name": "Huatli's Final Strike",
             "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "eee137b8-79fe-5fde-b9b5-28d0df5d713e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg?1",
             "name": "Hulking Raptor",
             "text": "Ward {2}\nAt the beginning of your precombat main phase, add {G}{G}.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "ff6a85ce-0bc6-5340-988b-ee527216d030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b1be22-3177-49af-bb06-42497d717c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b1be22-3177-49af-bb06-42497d717c21.jpg?1",
             "name": "In the Presence of Ages",
             "text": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -7536,7 +7536,7 @@
         },
         {
             "id": "74e5efac-cfdc-597a-adaa-f534e5a54501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg?1",
             "name": "Intrepid Paleontologist",
             "text": "{T}: Add one mana of any color.\n{2}: Exile target card from a graveyard.\nYou may cast Dinosaur creature spells from among cards you own exiled with Intrepid Paleontologist. If you cast a spell this way, that creature enters the battlefield with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "df9b840b-c755-54d2-b82a-cce4d9fdf14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc94ded-458d-4458-9c0b-136d825b885d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc94ded-458d-4458-9c0b-136d825b885d.jpg?1",
             "name": "Ixalli's Lorekeeper",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or activate an ability of a Dinosaur source.",
             "colours": [
@@ -7608,7 +7608,7 @@
         },
         {
             "id": "f06b16be-fe66-5ff7-a91e-ffa4bebf8533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg?1",
             "name": "Jade Seedstones // Jadeheart Attendant",
             "text": "",
             "colours": [
@@ -7640,7 +7640,7 @@
         },
         {
             "id": "b5c58f34-9eac-5611-a8f9-4d5e0b647fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg?1",
             "name": "Jade Seedstones // Jadeheart Attendant",
             "text": "",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "14709ded-825a-5985-8d1b-653adea072a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1",
             "name": "Jadelight Spelunker",
             "text": "When Jadelight Spelunker enters the battlefield, it explores X times. (To have it explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "9323ab60-32fd-5e98-a20d-5f4cb4fe6e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1",
             "name": "Kaslem's Stonetree // Kaslem's Strider",
             "text": "",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "74473b7d-1a47-5403-9dd5-8a1a22c29a75",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1",
             "name": "Kaslem's Stonetree // Kaslem's Strider",
             "text": "",
             "colours": [
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "8fbfd0c1-1d36-525f-9a83-4ad0de864859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259f959-ca97-4df9-8d50-0532090fb967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259f959-ca97-4df9-8d50-0532090fb967.jpg?1",
             "name": "Malamet Battle Glyph",
             "text": "Choose target creature you control and target creature you don't control. If the creature you control entered the battlefield this turn, put a +1/+1 counter on it. Then those creatures fight each other.",
             "colours": [
@@ -7812,7 +7812,7 @@
         },
         {
             "id": "f62e5c57-9ac7-5ecc-aff6-2e507dbb26d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d2fb65-cc3d-4664-bee0-8cf1cba5d8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d2fb65-cc3d-4664-bee0-8cf1cba5d8fa.jpg?1",
             "name": "Malamet Brawler",
             "text": "Whenever Malamet Brawler attacks, target attacking creature gains trample until end of turn.",
             "colours": [
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "d33e51cc-1ebe-511e-b534-2bf8630d1ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6776a4-cc01-46a3-90df-04e1e3ba513c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6776a4-cc01-46a3-90df-04e1e3ba513c.jpg?1",
             "name": "Malamet Scythe",
             "text": "Flash\nWhen Malamet Scythe enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+2.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "adb9b1c9-7757-5448-9bb4-b25861b6a78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg?1",
             "name": "Malamet Veteran",
             "text": "Trample\nDescend 4 \u2014 Whenever Malamet Veteran attacks, if there are four or more permanent cards in your graveyard, put a +1/+1 counter on target creature.",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "e23969ed-502d-52f8-be34-47e0ec65be94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a3639-a917-4700-a093-14a4cda78d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a3639-a917-4700-a093-14a4cda78d9f.jpg?1",
             "name": "Mineshaft Spider",
             "text": "Reach\nWhen Mineshaft Spider enters the battlefield, you may mill two cards. (You may put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -7950,7 +7950,7 @@
         },
         {
             "id": "5e40961e-1ad2-522c-86dd-7a9d8cdc5b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081d5c9e-71da-4454-ae4e-c76cb7790d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081d5c9e-71da-4454-ae4e-c76cb7790d20.jpg?1",
             "name": "Nurturing Bristleback",
             "text": "When Nurturing Bristleback enters the battlefield, create a 3/3 green Dinosaur creature token.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -7984,7 +7984,7 @@
         },
         {
             "id": "8724735e-4349-56f1-8d98-1531271db650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [
@@ -8022,7 +8022,7 @@
         },
         {
             "id": "5f85ce74-4276-5f18-ad1e-4f4366ac9f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [],
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "88f6dbaa-7ee2-5636-a857-08fd8d8c1ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg?1",
             "name": "Over the Edge",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Target creature you control explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
             "colours": [
@@ -8086,7 +8086,7 @@
         },
         {
             "id": "aa5cbbbf-fd46-52bc-9422-804d9c94852d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f619075-ca5d-4e09-bd84-31e6b61eaa7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f619075-ca5d-4e09-bd84-31e6b61eaa7e.jpg?1",
             "name": "Pathfinding Axejaw",
             "text": "When Pathfinding Axejaw enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8120,7 +8120,7 @@
         },
         {
             "id": "e673cf81-a7b6-5a88-9268-2b08adc61325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c1f09a-9d17-415c-8afa-cd0b62abe48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c1f09a-9d17-415c-8afa-cd0b62abe48d.jpg?1",
             "name": "Poison Dart Frog",
             "text": "Reach\n{T}: Add one mana of any color.\n{2}: Poison Dart Frog gains deathtouch until end of turn.",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "08438fca-8883-50fe-9ae0-2da1a52dbd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg?1",
             "name": "Pugnacious Hammerskull",
             "text": "Whenever Pugnacious Hammerskull attacks while you don't control another Dinosaur, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -8190,7 +8190,7 @@
         },
         {
             "id": "823f92a2-4742-5831-b27d-37e7753c91bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7e323-f329-4928-b25a-c0b44c5ac058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7e323-f329-4928-b25a-c0b44c5ac058.jpg?1",
             "name": "River Herald Guide",
             "text": "Vigilance\nWhen River Herald Guide enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "9c6c81de-b720-5e86-b261-4a86a8086443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdb10f-4bad-4f89-8e7c-daa5c0c69230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdb10f-4bad-4f89-8e7c-daa5c0c69230.jpg?1",
             "name": "Seeker of Sunlight",
             "text": "{2}{G}: Seeker of Sunlight explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8260,7 +8260,7 @@
         },
         {
             "id": "382be9f4-71e3-5683-bf92-3cc855a97cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeffc0b-dc92-458e-ad58-86ff6077a508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeffc0b-dc92-458e-ad58-86ff6077a508.jpg?1",
             "name": "Sentinel of the Nameless City",
             "text": "Vigilance\nWhenever Sentinel of the Nameless City enters the battlefield or attacks, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "a2daecfc-94f5-5d67-90e3-76111fb05fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56a7631-5f94-468d-aab7-7e9e129c5f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56a7631-5f94-468d-aab7-7e9e129c5f49.jpg?1",
             "name": "The Skullspore Nexus",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nWhenever one or more nontoken creatures you control die, create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.\n{2}, {T}: Double target creature's power until end of turn.",
             "colours": [
@@ -8334,7 +8334,7 @@
         },
         {
             "id": "8461af88-7209-5107-9d80-dd290a94881a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be4257-2316-4a2e-b347-f71c0368a947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be4257-2316-4a2e-b347-f71c0368a947.jpg?1",
             "name": "Spelunking",
             "text": "When Spelunking enters the battlefield, draw a card, then you may put a land card from your hand onto the battlefield. If you put a Cave onto the battlefield this way, you gain 4 life.\nLands you control enter the battlefield untapped.",
             "colours": [
@@ -8366,7 +8366,7 @@
         },
         {
             "id": "7a8587d9-2b24-591b-810a-59b68f32eb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34c4946-6c21-4ae1-9595-35933d38da52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34c4946-6c21-4ae1-9595-35933d38da52.jpg?1",
             "name": "Staggering Size",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "fff91eab-59ee-5d56-abde-243fcec668d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg?1",
             "name": "Tendril of the Mycotyrant",
             "text": "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes a 0/0 Fungus creature with haste. It's still a land.",
             "colours": [
@@ -8433,7 +8433,7 @@
         },
         {
             "id": "c8e76f08-1576-5c61-86ea-3828cf292ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52ef7c1-dacb-4204-b64e-5fa3ae3b1ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52ef7c1-dacb-4204-b64e-5fa3ae3b1ace.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -8469,7 +8469,7 @@
         },
         {
             "id": "c230d168-692a-5fd7-b9d7-d2b6f43535b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg?1",
             "name": "Twists and Turns // Mycoid Maze",
             "text": "",
             "colours": [
@@ -8501,7 +8501,7 @@
         },
         {
             "id": "93b16110-9cb5-5021-b4fc-915c79287e68",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg?1",
             "name": "Twists and Turns // Mycoid Maze",
             "text": "",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "dba4ae92-1b13-512e-81f8-afa39692867e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f85b-5ef8-4526-9c86-7cb71508b4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f85b-5ef8-4526-9c86-7cb71508b4c0.jpg?1",
             "name": "Walk with the Ancestors",
             "text": "Return up to one target permanent card from your graveyard to your hand. Discover 4. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "bd5e9bd7-ee6d-56dc-b5f1-b2bb05a83ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eee689-2514-421a-8056-eb7668be66ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eee689-2514-421a-8056-eb7668be66ff.jpg?1",
             "name": "Abuelo, Ancestral Echo",
             "text": "Flying, ward {2}\n{1}{W}{U}: Exile another target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -8605,7 +8605,7 @@
         },
         {
             "id": "5574d56c-59bd-57cc-9def-d191f400278e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee62dd1-97d0-4e5d-8937-26c9e51e9414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee62dd1-97d0-4e5d-8937-26c9e51e9414.jpg?1",
             "name": "Akawalli, the Seething Tower",
             "text": "Descend 4 \u2014 As long as there are four or more permanent cards in your graveyard, Akawalli, the Seething Tower gets +2/+2 and has trample.\nDescend 8 \u2014 As long as there are eight or more permanent cards in your graveyard, Akawalli gets an additional +2/+2 and can't be blocked by more than one creature.",
             "colours": [
@@ -8645,7 +8645,7 @@
         },
         {
             "id": "92e26b32-eea8-5d45-989e-47b7b0c2e33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acf80a5-f2ca-45b4-aca8-fbc690e35401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acf80a5-f2ca-45b4-aca8-fbc690e35401.jpg?1",
             "name": "Amalia Benavides Aguirre",
             "text": "Ward\u2014\nPay 3 life.\nWhenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other creatures if its power is exactly 20. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "92fed694-d3df-538e-9533-68d183aa21a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66dd43d7-76a7-46ea-b431-097fcea417af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66dd43d7-76a7-46ea-b431-097fcea417af.jpg?1",
             "name": "The Ancient One",
             "text": "Descend 8 \u2014 The Ancient One can't attack or block unless there are eight or more permanent cards in your graveyard.\n{2}{U}{B}: Draw a card, then discard a card. When you discard a card this way, target player mills cards equal to its mana value.",
             "colours": [
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "7ae780f2-759e-50cc-9476-b612f0b7fba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868856b7-8875-43c1-8249-0f8fb2c8319b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868856b7-8875-43c1-8249-0f8fb2c8319b.jpg?1",
             "name": "Anim Pakal, Thousandth Moon",
             "text": "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal, then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where X is the number of +1/+1 counters on Anim Pakal.",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "a3e92b17-ceac-5d35-8165-d98bbc66d62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690ccdc7-6c43-4902-9d11-2f07b7a36b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690ccdc7-6c43-4902-9d11-2f07b7a36b11.jpg?1",
             "name": "Bartolom\u00e9 del Presidio",
             "text": "Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolom\u00e9 del Presidio.",
             "colours": [
@@ -8810,7 +8810,7 @@
         },
         {
             "id": "a0a90611-f9a8-53e0-a99f-99a7003b7fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454af8c-bce9-47d3-890f-283e2fea2cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454af8c-bce9-47d3-890f-283e2fea2cf2.jpg?1",
             "name": "The Belligerent",
             "text": "Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the top card of your library any time, and you may play lands and cast spells from the top of your library.\nCrew 3",
             "colours": [
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "5499e2d7-3392-57e4-b0bc-ebd3ec3a2296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea82964-fd9c-48e3-962f-94954476b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea82964-fd9c-48e3-962f-94954476b31f.jpg?1",
             "name": "Caparocti Sunborn",
             "text": "Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you control. If you do, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "bd28cd6c-9e22-5e5c-b62c-257991ae2793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c65f5a-10bd-4f9b-b816-46c2240b11ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c65f5a-10bd-4f9b-b816-46c2240b11ff.jpg?1",
             "name": "Captain Storm, Cosmium Raider",
             "text": "Whenever an artifact enters the battlefield under your control, put a +1/+1 counter on target Pirate you control.",
             "colours": [
@@ -8932,7 +8932,7 @@
         },
         {
             "id": "ab4790bb-6930-51ec-b876-306f30091ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg?1",
             "name": "Deepfathom Echo",
             "text": "At the beginning of combat on your turn, Deepfathom Echo explores. Then you may have it become a copy of another creature you control until end of turn. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8971,7 +8971,7 @@
         },
         {
             "id": "495959e0-860d-5fb6-994b-dc6a85fd002f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4a65de-23b5-48f0-b8b7-94608eaced3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4a65de-23b5-48f0-b8b7-94608eaced3e.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "Vigilance, trample, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9014,7 +9014,7 @@
         },
         {
             "id": "7c9bedaa-5795-5d34-a3f9-4f56b41a1e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg?1",
             "name": "Itzquinth, Firstborn of Gishath",
             "text": "Haste\nWhen Itzquinth, Firstborn of Gishath enters the battlefield, you may pay {2}. When you do, target Dinosaur you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -9054,7 +9054,7 @@
         },
         {
             "id": "8bbe4ff8-20b8-5ea9-adaf-9497f57aaae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -9095,7 +9095,7 @@
         },
         {
             "id": "8f783ba6-daad-58a4-a5bd-c32649960fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -9132,7 +9132,7 @@
         },
         {
             "id": "5e6b6b27-9e33-5449-bec6-e9d77b0b079d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f88a40-a6ed-4c1f-a309-011aca1acddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f88a40-a6ed-4c1f-a309-011aca1acddd.jpg?1",
             "name": "Kutzil, Malamet Exemplar",
             "text": "Your opponents can't cast spells during your turn.\nWhenever one or more creatures you control each with power greater than its base power deals combat damage to a player, draw a card.",
             "colours": [
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "8f4e4696-c78d-58e0-939b-3285dca7b366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1",
             "name": "Master's Guide-Mural // Master's Manufactory",
             "text": "",
             "colours": [
@@ -9207,7 +9207,7 @@
         },
         {
             "id": "66480aff-06b9-57e3-a6d5-d713fb285e22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1",
             "name": "Master's Guide-Mural // Master's Manufactory",
             "text": "",
             "colours": [
@@ -9241,7 +9241,7 @@
         },
         {
             "id": "8350e263-3d7a-5e58-90db-2571939e044e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg?1",
             "name": "Molten Collapse",
             "text": "Choose one. If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)\n\u2022 Destroy target creature or planeswalker.\n\u2022 Destroy target noncreature, nonland permanent with mana value 1 or less.",
             "colours": [
@@ -9277,7 +9277,7 @@
         },
         {
             "id": "18570bf6-2ef0-55d4-908e-503ce8545322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caef93cc-70d0-4cce-9aaa-13c0931b2ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caef93cc-70d0-4cce-9aaa-13c0931b2ef7.jpg?1",
             "name": "The Mycotyrant",
             "text": "Trample\nThe Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings.\nAt the beginning of your end step, create X 1/1 black Fungus creature tokens with \"This creature can't block,\" where X is the number of times you descended this turn. (You descend each time a permanent card is put into your graveyard from anywhere.)",
             "colours": [
@@ -9318,7 +9318,7 @@
         },
         {
             "id": "df7ec6a1-45d7-5d71-b4c2-0de9a20a7347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f4aba-3500-4fb7-ab78-02f63c03778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f4aba-3500-4fb7-ab78-02f63c03778a.jpg?1",
             "name": "Nicanzil, Current Conductor",
             "text": "Whenever a creature you control explores a land card, you may put a land card from your hand onto the battlefield tapped.\nWhenever a creature you control explores a nonland card, put a +1/+1 counter on Nicanzil, Current Conductor.",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "c9f0b51a-4240-56df-828e-7f4c3eb60ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff73c7-428c-469c-b564-6aa9f4eeca14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff73c7-428c-469c-b564-6aa9f4eeca14.jpg?1",
             "name": "Palani's Hatcher",
             "text": "Other Dinosaurs you control have haste.\nWhen Palani's Hatcher enters the battlefield, create two 0/1 green Dinosaur Egg creature tokens.\nAt the beginning of combat on your turn, if you control one or more Eggs, sacrifice an Egg, then create a 3/3 green Dinosaur creature token.",
             "colours": [
@@ -9397,7 +9397,7 @@
         },
         {
             "id": "c5604d70-ed5e-55fe-b987-d86371b0fb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4382fa49-9e34-45b3-8495-4916dcd995ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4382fa49-9e34-45b3-8495-4916dcd995ec.jpg?1",
             "name": "Quintorius Kand",
             "text": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n\u22123: Discover 4.\n\u22126: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
             "colours": [
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "5cf3c5ed-7a69-52a8-8426-62c3f235a12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba99b60-c7d0-4041-a065-f2c510745223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba99b60-c7d0-4041-a065-f2c510745223.jpg?1",
             "name": "Saheeli, the Sun's Brilliance",
             "text": "{U}{R}, {T}: Create a token that's a copy of another target creature or artifact you control, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "6e64e137-2cb5-5ede-a28d-0741f6ffb5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c75aa7-e2f9-4a69-8086-c982019ca714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c75aa7-e2f9-4a69-8086-c982019ca714.jpg?1",
             "name": "Sovereign Okinec Ahau",
             "text": "Ward {2}\nWhenever Sovereign Okinec Ahau attacks, for each creature you control with power greater than that creature's base power, put a number of +1/+1 counters on that creature equal to the difference.",
             "colours": [
@@ -9520,7 +9520,7 @@
         },
         {
             "id": "d1eaf6a9-4d49-51cf-abca-6f456179b8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee16629-f9be-4cdb-bf52-1d640781ee00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee16629-f9be-4cdb-bf52-1d640781ee00.jpg?1",
             "name": "Squirming Emergence",
             "text": "Fathomless descent \u2014 Return to the battlefield target nonland permanent card in your graveyard with mana value less than or equal to the number of permanent cards in your graveyard.",
             "colours": [
@@ -9556,7 +9556,7 @@
         },
         {
             "id": "0dd5f52b-fe94-507a-8de7-282e601739a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062202c-f9fb-4dd6-989a-c3083644f1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062202c-f9fb-4dd6-989a-c3083644f1c0.jpg?1",
             "name": "Uchbenbak, the Great Mistake",
             "text": "Vigilance, menace\nDescend 8 \u2014 {4}{U}{B}: Return Uchbenbak, the Great Mistake from your graveyard to the battlefield with a finality counter on it. Activate only if there are eight or more permanent cards in your graveyard and only as a sorcery. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "0532b7be-82cd-57ec-9bcb-3cc332a60db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd9047-df91-4d82-be00-c623acae0f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd9047-df91-4d82-be00-c623acae0f01.jpg?1",
             "name": "Vito, Fanatic of Aclazotz",
             "text": "Flying\nWhenever you sacrifice another permanent, you gain 2 life if this is the first time this ability has resolved this turn. If it's the second time, each opponent loses 2 life. If it's the third time, create a 4/3 white and black Vampire Demon creature token with flying.",
             "colours": [
@@ -9638,7 +9638,7 @@
         },
         {
             "id": "87c21b24-662f-5ca6-9165-f09111646527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67108256-b7da-44bd-9639-4264931d348f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67108256-b7da-44bd-9639-4264931d348f.jpg?1",
             "name": "Wail of the Forgotten",
             "text": "Descend 8 \u2014 Choose one. If there are eight or more permanent cards in your graveyard as you cast this spell, choose one or more instead.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Target opponent discards a card.\n\u2022 Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "b0a4f156-f40c-55a0-a1d2-60bafbdf6e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06f0ff2-d42f-4854-bbe5-4b022fb26d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06f0ff2-d42f-4854-bbe5-4b022fb26d7d.jpg?1",
             "name": "Zoyowa Lava-Tongue",
             "text": "Deathtouch\nAt the beginning of your end step, if you descended this turn, each opponent may discard a card or sacrifice a permanent. Zoyowa Lava-Tongue deals 3 damage to each opponent who didn't. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -9715,7 +9715,7 @@
         },
         {
             "id": "19de3ddb-5d5c-5d9c-b6f4-0b92c69cfe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c45b6-dedd-4481-a06a-c83ace2f18fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c45b6-dedd-4481-a06a-c83ace2f18fa.jpg?1",
             "name": "Buried Treasure",
             "text": "{T}, Sacrifice Buried Treasure: Add one mana of any color.\n{5}, Exile Buried Treasure from your graveyard: Discover 5. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -9745,7 +9745,7 @@
         },
         {
             "id": "4b7f649e-8d74-5961-8103-74726d24ef44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a96d8ae-200a-40be-95a8-72b53638a090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a96d8ae-200a-40be-95a8-72b53638a090.jpg?1",
             "name": "Careening Mine Cart",
             "text": "Whenever Careening Mine Cart attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9775,7 +9775,7 @@
         },
         {
             "id": "9de98774-b4ce-549a-bf00-688df842d2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd8115e-4cb3-49b6-b74f-8fcfa28c6404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd8115e-4cb3-49b6-b74f-8fcfa28c6404.jpg?1",
             "name": "Cartographer's Companion",
             "text": "When Cartographer's Companion enters the battlefield, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "98b92e5d-406a-53b1-9605-65371cbc89da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a1bfb5-ddfc-49cf-baa3-5d1958d2067a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a1bfb5-ddfc-49cf-baa3-5d1958d2067a.jpg?1",
             "name": "Chimil, the Inner Sun",
             "text": "Spells you control can't be countered.\nAt the beginning of your end step, discover 5. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "e43aee9d-524e-52c8-81a0-d8d8ebf4e0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e1030e-2b95-4807-9111-e495a2fc8813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e1030e-2b95-4807-9111-e495a2fc8813.jpg?1",
             "name": "Compass Gnome",
             "text": "When Compass Gnome enters the battlefield, you may search your library for a basic land card or Cave card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -9867,7 +9867,7 @@
         },
         {
             "id": "9c5d7951-8eea-59df-8f51-62e181af9b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cb7776-a6af-4efb-b536-6b9b4f3d3874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cb7776-a6af-4efb-b536-6b9b4f3d3874.jpg?1",
             "name": "Contested Game Ball",
             "text": "Whenever you're dealt combat damage, the attacking player gains control of Contested Game Ball and untaps it.\n{2}, {T}: Draw a card and put a point counter on Contested Game Ball. Then if it has five or more point counters on it, sacrifice it and create a Treasure token.",
             "colours": [],
@@ -9895,7 +9895,7 @@
         },
         {
             "id": "3adad123-bea7-526c-bd5c-8f86055ff808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa3cd5e-b727-479d-9a77-9f320b92f3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa3cd5e-b727-479d-9a77-9f320b92f3f2.jpg?1",
             "name": "Digsite Conservator",
             "text": "Sacrifice Digsite Conservator: Exile up to four target cards from a single graveyard. Activate only as a sorcery.\nWhen Digsite Conservator dies, you may pay {4}. If you do, discover 4. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -9926,7 +9926,7 @@
         },
         {
             "id": "af3baa78-a0c6-5459-becc-78040bbde782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802ca61-6fcc-4965-9f8f-dd58fe82c6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802ca61-6fcc-4965-9f8f-dd58fe82c6bf.jpg?1",
             "name": "Disruptor Wanderglyph",
             "text": "Whenever Disruptor Wanderglyph attacks, exile target card from an opponent's graveyard.",
             "colours": [],
@@ -9957,7 +9957,7 @@
         },
         {
             "id": "7dca6111-56f2-5ee3-a2d5-5c36ae6c677a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7e12ee-3db6-4df7-9859-7a8dee9171c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7e12ee-3db6-4df7-9859-7a8dee9171c7.jpg?1",
             "name": "Hoverstone Pilgrim",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\n{2}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "ee6f96c2-3000-5aa2-9d37-14804c0d3c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3348abe7-6aa3-47f7-8203-a15f75007e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3348abe7-6aa3-47f7-8203-a15f75007e33.jpg?1",
             "name": "Hunter's Blowgun",
             "text": "Equipped creature gets +1/+1.\nEquipped creature has deathtouch as long as it's your turn. Otherwise, it has reach.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "a18a4a85-32e6-5a15-8ed3-bf21149a5ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -10050,7 +10050,7 @@
         },
         {
             "id": "33d8bf64-2cb9-526b-bc1c-0e967234f8df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "2219dbc8-e90e-5652-bc2b-c1bf67b850eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabba7f-05ef-41cf-ae3a-d950d051cf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabba7f-05ef-41cf-ae3a-d950d051cf1e.jpg?1",
             "name": "The Millennium Calendar",
             "text": "Whenever you untap one or more permanents during your untap step, put that many time counters on The Millennium Calendar.\n{2}, {T}: Double the number of time counters on The Millennium Calendar.\nWhen there are 1,000 or more time counters on The Millennium Calendar, sacrifice it and each opponent loses 1,000 life.",
             "colours": [],
@@ -10114,7 +10114,7 @@
         },
         {
             "id": "080b0062-4aa4-5fd6-a1b3-081655cabf99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32fd8b7c-baf3-4d3d-be6f-044a917b11a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32fd8b7c-baf3-4d3d-be6f-044a917b11a0.jpg?1",
             "name": "Roaming Throne",
             "text": "Ward {2}\nAs Roaming Throne enters the battlefield, choose a creature type.\nRoaming Throne is the chosen type in addition to its other types.\nIf a triggered ability of another creature you control of the chosen type triggers, it triggers an additional time.",
             "colours": [],
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "cab9b259-d917-56d0-ae6e-691c2a762e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d47a3b-dc66-48d8-981b-dde0ccc34ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d47a3b-dc66-48d8-981b-dde0ccc34ad5.jpg?1",
             "name": "Runaway Boulder",
             "text": "Flash\nWhen Runaway Boulder enters the battlefield, it deals 6 damage to target creature an opponent controls.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10175,7 +10175,7 @@
         },
         {
             "id": "0e1c53e2-fdf7-5089-aecd-3b7f2cc01ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb2a90-d4c0-4c83-8ee7-2ac3a23b4402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb2a90-d4c0-4c83-8ee7-2ac3a23b4402.jpg?1",
             "name": "Scampering Surveyor",
             "text": "When Scampering Surveyor enters the battlefield, search your library for a basic land card or Cave card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10206,7 +10206,7 @@
         },
         {
             "id": "2ef6aff8-e149-5393-b2d3-82e3f9839f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7899-6b44-4ecc-8ddc-ec24304eb14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7899-6b44-4ecc-8ddc-ec24304eb14c.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -10234,7 +10234,7 @@
         },
         {
             "id": "4ccb3303-fe0b-5de4-9c42-86d9931e67f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg?1",
             "name": "Sunbird Standard // Sunbird Effigy",
             "text": "",
             "colours": [],
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "d8cf7462-ba69-5aa2-bbdf-5529f94d67c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg?1",
             "name": "Sunbird Standard // Sunbird Effigy",
             "text": "",
             "colours": [],
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "db1ca080-50a2-5a7d-a5d2-d475c27d9865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg?1",
             "name": "Swashbuckler's Whip",
             "text": "Equipped creature has reach, \"{2}, {T}: Tap target artifact or creature,\" and \"{8}, {T}: Discover 10.\" (Exile cards from the top of your library until you exile a nonland card with mana value 10 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)\nEquip {1}",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "9cfda85c-978d-5858-aae8-b59806955b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg?1",
             "name": "Tarrian's Soulcleaver",
             "text": "Equipped creature has vigilance.\nWhenever another artifact or creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature.\nEquip {2}",
             "colours": [],
@@ -10358,7 +10358,7 @@
         },
         {
             "id": "ca175461-c8c6-55e4-9a63-c8db8c01d077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917c62f-d463-43eb-87ad-89ffbc88b6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917c62f-d463-43eb-87ad-89ffbc88b6fe.jpg?1",
             "name": "Threefold Thunderhulk",
             "text": "Threefold Thunderhulk enters the battlefield with three +1/+1 counters on it.\nWhenever Threefold Thunderhulk enters the battlefield or attacks, create a number of 1/1 colorless Gnome artifact creature tokens equal to its power.\n{2}, Sacrifice another artifact: Put a +1/+1 counter on Threefold Thunderhulk.",
             "colours": [],
@@ -10391,7 +10391,7 @@
         },
         {
             "id": "fc545235-e269-5f46-b9ee-c39523679fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [],
@@ -10425,7 +10425,7 @@
         },
         {
             "id": "5b8baf43-2d81-5b24-aa90-aae148e48902",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [
@@ -10465,7 +10465,7 @@
         },
         {
             "id": "7df9a00a-a5cb-5cc8-875f-d73a69d5132f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -10495,7 +10495,7 @@
         },
         {
             "id": "94eaa7a6-dbe7-5c6a-85d4-4883a2d38144",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -10525,7 +10525,7 @@
         },
         {
             "id": "18b81dbe-d9fe-57b7-9219-e9501812c65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1a645e-85c7-4044-b817-6e24744d245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1a645e-85c7-4044-b817-6e24744d245e.jpg?1",
             "name": "Captivating Cave",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Sacrifice Captivating Cave: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
             "colours": [],
@@ -10555,7 +10555,7 @@
         },
         {
             "id": "00a2f73d-1eda-5265-8a4f-834ff8786a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aad15a2-8a1b-4460-9b06-e85863081878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aad15a2-8a1b-4460-9b06-e85863081878.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "caab6ae5-f9c4-5100-a807-cfafa37860df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a51ebf6-a465-42e2-82b7-d2cb928ca632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a51ebf6-a465-42e2-82b7-d2cb928ca632.jpg?1",
             "name": "Cavernous Maw",
             "text": "{T}: Add {C}.\n{2}: Cavernous Maw becomes a 3/3 Elemental creature until end of turn. It's still a Cave land. Activate only if the number of other Caves you control plus the number of Cave cards in your graveyard is three or greater.",
             "colours": [],
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "ea4f5993-ef28-596f-8a68-c6e2e23278c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244c06b3-532d-426e-8bee-ee9461d092a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244c06b3-532d-426e-8bee-ee9461d092a6.jpg?1",
             "name": "Echoing Deeps",
             "text": "You may have Echoing Deeps enter the battlefield tapped as a copy of any land card in a graveyard, except it's a Cave in addition to its other types.\n{T}: Add {C}.",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "d519f054-83a1-52aa-b76c-49e3330118cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8c1c02-e533-46b2-a3eb-91dff561854b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8c1c02-e533-46b2-a3eb-91dff561854b.jpg?1",
             "name": "Forgotten Monument",
             "text": "{T}: Add {C}.\nOther Caves you control have \"{T}, Pay 1 life: Add one mana of any color.\"",
             "colours": [],
@@ -10683,7 +10683,7 @@
         },
         {
             "id": "eb32f123-eba7-5103-81db-f9403beb1266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f317fc-f603-45b5-9208-545be4dcbf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f317fc-f603-45b5-9208-545be4dcbf36.jpg?1",
             "name": "Hidden Cataract",
             "text": "Hidden Cataract enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Hidden Cataract: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10715,7 +10715,7 @@
         },
         {
             "id": "2de8cdb6-5126-55ce-9f6b-18d8cd2c1b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8685d46-99fc-44b3-be95-707a4b7b8327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8685d46-99fc-44b3-be95-707a4b7b8327.jpg?1",
             "name": "Hidden Courtyard",
             "text": "Hidden Courtyard enters the battlefield tapped.\n{T}: Add {W}.\n{4}{W}, {T}, Sacrifice Hidden Courtyard: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "16b9ae6a-ab36-5fd1-8a0c-51f56c1972cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67fd04f-05da-4418-97de-abeb7346cc69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67fd04f-05da-4418-97de-abeb7346cc69.jpg?1",
             "name": "Hidden Necropolis",
             "text": "Hidden Necropolis enters the battlefield tapped.\n{T}: Add {B}.\n{4}{B}, {T}, Sacrifice Hidden Necropolis: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10779,7 +10779,7 @@
         },
         {
             "id": "8b77aeb5-fc61-5795-9e37-d3a003c363a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a942939a-c06e-4b90-a404-ae5acfffcff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a942939a-c06e-4b90-a404-ae5acfffcff9.jpg?1",
             "name": "Hidden Nursery",
             "text": "Hidden Nursery enters the battlefield tapped.\n{T}: Add {G}.\n{4}{G}, {T}, Sacrifice Hidden Nursery: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10811,7 +10811,7 @@
         },
         {
             "id": "da7b6277-6281-5be8-b55f-036b380b9cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa06aed-52c1-48f1-9906-362db12a3cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa06aed-52c1-48f1-9906-362db12a3cf7.jpg?1",
             "name": "Hidden Volcano",
             "text": "Hidden Volcano enters the battlefield tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice Hidden Volcano: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10843,7 +10843,7 @@
         },
         {
             "id": "818b20ff-f1cb-5d02-a0d2-ed3037f0faba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7d3957-b483-4a1f-a244-293c90032f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7d3957-b483-4a1f-a244-293c90032f5e.jpg?1",
             "name": "Pit of Offerings",
             "text": "Pit of Offerings enters the battlefield tapped.\nWhen Pit of Offerings enters the battlefield, exile up to three target cards from graveyards.\n{T}: Add {C}.\n{T}: Add one mana of any of the exiled cards' colors.",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "8071f5e3-665e-57d4-83ad-080be4e6e7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9681a54-6413-4ff4-b6b1-ee4decb25bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9681a54-6413-4ff4-b6b1-ee4decb25bfa.jpg?1",
             "name": "Promising Vein",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Promising Vein: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10903,7 +10903,7 @@
         },
         {
             "id": "12906a7f-5ef1-50d2-86ff-a9dfd12086fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cab352-734e-454b-8b58-733165f4b3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cab352-734e-454b-8b58-733165f4b3b3.jpg?1",
             "name": "Restless Anchorage",
             "text": "Restless Anchorage enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{1}{W}{U}: Until end of turn, Restless Anchorage becomes a 2/3 white and blue Bird creature with flying. It's still a land.\nWhenever Restless Anchorage attacks, create a Map token.",
             "colours": [],
@@ -10936,7 +10936,7 @@
         },
         {
             "id": "d0e3fbe3-dd33-5d36-9e64-52d8a061810b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ef116-6aff-4f53-a7f9-be5e21c7afa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ef116-6aff-4f53-a7f9-be5e21c7afa4.jpg?1",
             "name": "Restless Prairie",
             "text": "Restless Prairie enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}: Restless Prairie becomes a 3/3 green and white Llama creature until end of turn. It's still a land.\nWhenever Restless Prairie attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [],
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "1fc03e51-0e51-5474-bd35-d01416b8016e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8121c9-2480-419c-aa9c-5b8b55f65014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8121c9-2480-419c-aa9c-5b8b55f65014.jpg?1",
             "name": "Restless Reef",
             "text": "Restless Reef enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}: Until end of turn, Restless Reef becomes a 4/4 blue and black Shark creature with deathtouch. It's still a land.\nWhenever Restless Reef attacks, target player mills four cards.",
             "colours": [],
@@ -11002,7 +11002,7 @@
         },
         {
             "id": "d6342dd6-39e7-5649-bda4-8eaa17ebe2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde5bed-dc4e-4b2b-820c-18d4d0cf8042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde5bed-dc4e-4b2b-820c-18d4d0cf8042.jpg?1",
             "name": "Restless Ridgeline",
             "text": "Restless Ridgeline enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Restless Ridgeline becomes a 3/4 red and green Dinosaur creature until end of turn. It's still a land.\nWhenever Restless Ridgeline attacks, another target attacking creature gets +2/+0 until end of turn. Untap that creature.",
             "colours": [],
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "1911a5f1-e523-5ea8-a593-5bc1e0f02a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e628e89b-bee9-408d-bb05-1784fda6b8a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e628e89b-bee9-408d-bb05-1784fda6b8a1.jpg?1",
             "name": "Restless Vents",
             "text": "Restless Vents enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{1}{B}{R}: Until end of turn, Restless Vents becomes a 2/3 black and red Insect creature with menace. It's still a land.\nWhenever Restless Vents attacks, you may discard a card. If you do, draw a card.",
             "colours": [],
@@ -11068,7 +11068,7 @@
         },
         {
             "id": "7fbc77f2-7967-5135-ae91-de9f57432b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1c9b1a-e306-47bb-9f68-2083660319c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1c9b1a-e306-47bb-9f68-2083660319c0.jpg?1",
             "name": "Sunken Citadel",
             "text": "Sunken Citadel enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{T}: Add two mana of the chosen color. Spend this mana only to activate abilities of land sources.",
             "colours": [],
@@ -11100,7 +11100,7 @@
         },
         {
             "id": "18702c50-a428-5c07-833d-af12e86474ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9385abf3-b067-4586-bf3d-175526cf8f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9385abf3-b067-4586-bf3d-175526cf8f0a.jpg?1",
             "name": "Volatile Fault",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Volatile Fault: Destroy target nonbasic land an opponent controls. That player may search their library for a basic land card, put it onto the battlefield, then shuffle. You create a Treasure token.",
             "colours": [],
@@ -11130,7 +11130,7 @@
         },
         {
             "id": "fc786cb5-6c36-5dc1-bec0-5b634818a5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5453630-bfff-4403-a9a9-49f1534e1d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5453630-bfff-4403-a9a9-49f1534e1d42.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11167,7 +11167,7 @@
         },
         {
             "id": "2f69ab92-2dc8-58a2-8059-47f9135e5237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338e5b63-1fee-4a7c-af9b-483d383f79b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338e5b63-1fee-4a7c-af9b-483d383f79b7.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "4a4f04ac-4837-5397-a39d-519fb6891401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a825ac86-d642-42fd-b6aa-94aa804907d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a825ac86-d642-42fd-b6aa-94aa804907d9.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11241,7 +11241,7 @@
         },
         {
             "id": "bccb6971-59b5-5d0c-b3ca-018a88f58d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb82fdb-5090-45c0-ae67-4846667c8625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb82fdb-5090-45c0-ae67-4846667c8625.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "96ff3340-29d4-5278-ac7a-c8456d3d7d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c13cafb-3078-4856-a5b0-c38aace8a34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c13cafb-3078-4856-a5b0-c38aace8a34a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11315,7 +11315,7 @@
         },
         {
             "id": "b2a4dce9-2de0-505a-904c-c5d7f3634932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acaf4dbe-5b63-4948-bc85-b5d288378d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acaf4dbe-5b63-4948-bc85-b5d288378d4e.jpg?1",
             "name": "Akal Pakal, First Among Equals",
             "text": "At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -11354,7 +11354,7 @@
         },
         {
             "id": "b4f0a58e-840c-5de2-b003-be4eab23d69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed6341-59f4-44f3-99c9-80f636fa484d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed6341-59f4-44f3-99c9-80f636fa484d.jpg?1",
             "name": "Malcolm, Alluring Scoundrel",
             "text": "Flash\nFlying\nWhenever Malcolm, Alluring Scoundrel deals combat damage to a player, put a chorus counter on it. Draw a card, then discard a card. If there are four or more chorus counters on Malcolm, you may cast the discarded card without paying its mana cost.",
             "colours": [
@@ -11393,7 +11393,7 @@
         },
         {
             "id": "fd8102df-14d1-5275-a81d-1d78cf2f64bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb60b23-2397-4897-9462-56b09f45f321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb60b23-2397-4897-9462-56b09f45f321.jpg?1",
             "name": "Breeches, Eager Pillager",
             "text": "First strike\nWhenever a Pirate you control attacks, choose one that hasn't been chosen this turn \u2014\n\u2022 Create a Treasure token.\n\u2022 Target creature can't block this turn.\n\u2022 Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "39033b89-71b2-53c1-a2ed-92d7df0f2dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0548ddb6-5301-4911-93fd-bb988275f44a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0548ddb6-5301-4911-93fd-bb988275f44a.jpg?1",
             "name": "Inti, Seneschal of the Sun",
             "text": "Whenever you attack, you may discard a card. When you do, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.\nWhenever you discard one or more cards, exile the top card of your library. You may play that card until your next end step.",
             "colours": [
@@ -11471,7 +11471,7 @@
         },
         {
             "id": "486e5452-4d52-5412-9666-c18ad3598aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -11514,7 +11514,7 @@
         },
         {
             "id": "f8ef2981-611f-530a-b34b-250f62b24e94",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -11555,7 +11555,7 @@
         },
         {
             "id": "a55758bb-352a-5080-ae78-47d83ecd6195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bcc6f3-bae4-485c-82da-56c15c97c7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bcc6f3-bae4-485c-82da-56c15c97c7f8.jpg?1",
             "name": "Abuelo, Ancestral Echo",
             "text": "Flying, ward {2}\n{1}{W}{U}: Exile another target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -11595,7 +11595,7 @@
         },
         {
             "id": "7956880f-d308-5cd9-b9fd-0c9a375c0986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e9dbe6-5685-480d-b0d7-828a7058fb22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e9dbe6-5685-480d-b0d7-828a7058fb22.jpg?1",
             "name": "Akawalli, the Seething Tower",
             "text": "Descend 4 \u2014 As long as there are four or more permanent cards in your graveyard, Akawalli, the Seething Tower gets +2/+2 and has trample.\nDescend 8 \u2014 As long as there are eight or more permanent cards in your graveyard, Akawalli gets an additional +2/+2 and can't be blocked by more than one creature.",
             "colours": [
@@ -11635,7 +11635,7 @@
         },
         {
             "id": "ba612d76-f889-5e7a-9838-8ad336fe7ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ae96c-012c-4bd4-81f0-5944fc03a8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ae96c-012c-4bd4-81f0-5944fc03a8a9.jpg?1",
             "name": "Amalia Benavides Aguirre",
             "text": "Ward\u2014\nPay 3 life.\nWhenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other creatures if its power is exactly 20.",
             "colours": [
@@ -11676,7 +11676,7 @@
         },
         {
             "id": "195b35d5-b888-5327-ae7e-af33e1bec9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc97d16-c54c-4a2b-9691-39e8a41c7777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc97d16-c54c-4a2b-9691-39e8a41c7777.jpg?1",
             "name": "Anim Pakal, Thousandth Moon",
             "text": "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal, then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where X is the number of +1/+1 counters on Anim Pakal.",
             "colours": [
@@ -11717,7 +11717,7 @@
         },
         {
             "id": "054f2fac-092b-5916-89cf-d1482d3c925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82bb486-7009-4b53-973f-477fc13ad7e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82bb486-7009-4b53-973f-477fc13ad7e7.jpg?1",
             "name": "Bartolom\u00e9 del Presidio",
             "text": "Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolom\u00e9 del Presidio.",
             "colours": [
@@ -11759,7 +11759,7 @@
         },
         {
             "id": "23c77d59-e524-5968-bf0f-3b0c7bf0f02b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380ed1dc-afa2-4b00-8da6-6177295965b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380ed1dc-afa2-4b00-8da6-6177295965b5.jpg?1",
             "name": "Caparocti Sunborn",
             "text": "Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you control. If you do, discover 3.",
             "colours": [
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "a4aaf3a2-7b5a-5f0b-a4c4-033b7ba15ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e13dad-e326-4b8e-91c7-dc0d6c3bf51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e13dad-e326-4b8e-91c7-dc0d6c3bf51d.jpg?1",
             "name": "Captain Storm, Cosmium Raider",
             "text": "Whenever an artifact enters the battlefield under your control, put a +1/+1 counter on target Pirate you control.",
             "colours": [
@@ -11841,7 +11841,7 @@
         },
         {
             "id": "b6cfb36d-c699-5598-8cc6-102c9fa69f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fede45-8c95-45eb-915c-c3ee5101dfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fede45-8c95-45eb-915c-c3ee5101dfcc.jpg?1",
             "name": "Kutzil, Malamet Exemplar",
             "text": "Your opponents can't cast spells during your turn.\nWhenever one or more creatures you control each with power greater than its base power deals combat damage to a player, draw a card.",
             "colours": [
@@ -11882,7 +11882,7 @@
         },
         {
             "id": "7fbf5b47-c636-51d0-abe6-95f11f4ef255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e6494-6f64-4adf-96ca-65a17100b8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e6494-6f64-4adf-96ca-65a17100b8fe.jpg?1",
             "name": "The Mycotyrant",
             "text": "Trample\nThe Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings.\nAt the beginning of your end step, create X 1/1 black Fungus creature tokens with \"This creature can't block,\" where X is the number of times you descended this turn.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "af0083df-758e-5a0a-86c6-570ec397bcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6059b64c-3064-46de-af47-6dc6542dca23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6059b64c-3064-46de-af47-6dc6542dca23.jpg?1",
             "name": "Nicanzil, Current Conductor",
             "text": "Whenever a creature you control explores a land card, you may put a land card from your hand onto the battlefield tapped.\nWhenever a creature you control explores a nonland card, put a +1/+1 counter on Nicanzil, Current Conductor.",
             "colours": [
@@ -11964,7 +11964,7 @@
         },
         {
             "id": "ebf1df23-2bc3-5c68-998e-76d3131e235f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfc085d-4c11-416c-ae00-d41d32f32bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfc085d-4c11-416c-ae00-d41d32f32bb4.jpg?1",
             "name": "Quintorius Kand",
             "text": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n\u22123: Discover 4.\n\u22126: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
             "colours": [
@@ -12005,7 +12005,7 @@
         },
         {
             "id": "66ad3ab4-2918-5373-a21b-920592535701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a16ca40-2210-4f94-bfb1-960b34a7d98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a16ca40-2210-4f94-bfb1-960b34a7d98e.jpg?1",
             "name": "Saheeli, the Sun's Brilliance",
             "text": "{U}{R}, {T}: Create a token that's a copy of another target creature or artifact you control, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -12046,7 +12046,7 @@
         },
         {
             "id": "54cc50e0-017f-5987-a6d2-74e9866321ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6e7f53-d8c4-4356-a31d-ed3d5e0627cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6e7f53-d8c4-4356-a31d-ed3d5e0627cc.jpg?1",
             "name": "Sovereign Okinec Ahau",
             "text": "Ward {2}\nWhenever Sovereign Okinec Ahau attacks, for each creature you control with power greater than that creature's base power, put a number of +1/+1 counters on that creature equal to the difference.",
             "colours": [
@@ -12087,7 +12087,7 @@
         },
         {
             "id": "f538802c-8bf0-5e5a-aba2-526ff50b4473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30c23d7-8a3b-4162-89dd-5f7895c55625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30c23d7-8a3b-4162-89dd-5f7895c55625.jpg?1",
             "name": "Uchbenbak, the Great Mistake",
             "text": "Vigilance, menace\nDescend 8 \u2014 {4}{U}{B}: Return Uchbenbak, the Great Mistake from your graveyard to the battlefield with a finality counter on it. Activate only if there are eight or more permanent cards in your graveyard and only as a sorcery.",
             "colours": [
@@ -12128,7 +12128,7 @@
         },
         {
             "id": "328474d6-a636-5809-b1a9-b50d89795a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58c496-2b70-48a9-befa-9cc7baef8597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58c496-2b70-48a9-befa-9cc7baef8597.jpg?1",
             "name": "Vito, Fanatic of Aclazotz",
             "text": "Flying\nWhenever you sacrifice another permanent, you gain 2 life if this is the first time this ability has resolved this turn. If it's the second time, each opponent loses 2 life. If it's the third time, create a 4/3 white and black Vampire Demon creature token with flying.",
             "colours": [
@@ -12169,7 +12169,7 @@
         },
         {
             "id": "8028315f-36de-58f0-ac50-0204caa496cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd2cf8-95e4-4df5-a803-66e7c4eb065a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd2cf8-95e4-4df5-a803-66e7c4eb065a.jpg?1",
             "name": "Zoyowa Lava-Tongue",
             "text": "Deathtouch\nAt the beginning of your end step, if you descended this turn, each opponent may discard a card or sacrifice a permanent. Zoyowa Lava-Tongue deals 3 damage to each opponent who didn't.",
             "colours": [
@@ -12210,7 +12210,7 @@
         },
         {
             "id": "a69b835a-495a-53c9-8054-1820413266a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [],
@@ -12244,7 +12244,7 @@
         },
         {
             "id": "f0c117f4-54bb-5596-baf2-47bfc9c6e3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [
@@ -12284,7 +12284,7 @@
         },
         {
             "id": "97be3b78-3dd8-5dc8-99cd-1407b931a9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [
@@ -12322,7 +12322,7 @@
         },
         {
             "id": "760119c9-7eb0-5431-bf41-1c0ef9387d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [],
@@ -12354,7 +12354,7 @@
         },
         {
             "id": "45d11672-2dec-574e-9ff8-fbca25d67b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [
@@ -12392,7 +12392,7 @@
         },
         {
             "id": "1e4ca96e-efa4-584e-b613-a95a53769bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [],
@@ -12424,7 +12424,7 @@
         },
         {
             "id": "a8aae7c7-c478-56e2-974b-7dc6b7db5edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95775b13-2761-424e-9828-2275ec987368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95775b13-2761-424e-9828-2275ec987368.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [
@@ -12463,7 +12463,7 @@
         },
         {
             "id": "41232c29-a075-53e1-9b43-1ec89d089882",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95775b13-2761-424e-9828-2275ec987368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95775b13-2761-424e-9828-2275ec987368.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [],
@@ -12495,7 +12495,7 @@
         },
         {
             "id": "f551bcb3-dd2b-569e-b2fb-cf7139c9ab40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [
@@ -12533,7 +12533,7 @@
         },
         {
             "id": "21139b7d-3432-5a9d-bffb-264cb602a743",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [],
@@ -12565,7 +12565,7 @@
         },
         {
             "id": "38c70afb-c100-574a-b629-f67ba0af0d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [
@@ -12603,7 +12603,7 @@
         },
         {
             "id": "18e323e8-1e14-5ed6-b316-48cc9085462c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [],
@@ -12635,7 +12635,7 @@
         },
         {
             "id": "0c39d9f8-fbc4-5386-b26d-9f5fa3d678e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebe99d-4994-450e-9abb-f0bc3750f098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebe99d-4994-450e-9abb-f0bc3750f098.jpg?1",
             "name": "The Ancient One",
             "text": "Descend 8 \u2014 The Ancient One can't attack or block unless there are eight or more permanent cards in your graveyard.\n{2}{U}{B}: Draw a card, then discard a card. When you discard a card this way, target player mills cards equal to its mana value.",
             "colours": [
@@ -12676,7 +12676,7 @@
         },
         {
             "id": "b2c16d25-1329-590c-87a1-29a7328c2a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4639ca-d4dc-4630-b696-a8107767cf1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4639ca-d4dc-4630-b696-a8107767cf1a.jpg?1",
             "name": "Belligerent Yearling",
             "text": "Trample\nWhenever another Dinosaur enters the battlefield under your control, you may have Belligerent Yearling's base power become equal to that creature's power until end of turn.",
             "colours": [
@@ -12712,7 +12712,7 @@
         },
         {
             "id": "f4e26835-a3b1-523c-ab83-f0ea5407053a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22897e93-bb69-4ad3-bdcc-723c7020a378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22897e93-bb69-4ad3-bdcc-723c7020a378.jpg?1",
             "name": "Bonehoard Dracosaur",
             "text": "Flying, first strike\nAt the beginning of your upkeep, exile the top two cards of your library. You may play them this turn. If you exiled a land card this way, create a 3/1 red Dinosaur creature token. If you exiled a nonland card this way, create a Treasure token.",
             "colours": [
@@ -12749,7 +12749,7 @@
         },
         {
             "id": "ae75aa6c-8c3c-5099-a669-ddad3c0308ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8d613-7697-413b-a107-0a25c1662835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8d613-7697-413b-a107-0a25c1662835.jpg?1",
             "name": "Rampaging Ceratops",
             "text": "Rampaging Ceratops can't be blocked except by three or more creatures.",
             "colours": [
@@ -12785,7 +12785,7 @@
         },
         {
             "id": "fb171192-4b4f-59cc-99e4-3ce39b23dcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffe37-f466-4eea-8efc-50b53e2c27da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffe37-f466-4eea-8efc-50b53e2c27da.jpg?1",
             "name": "Scytheclaw Raptor",
             "text": "Whenever a player casts a spell, if it's not their turn, Scytheclaw Raptor deals 4 damage to them.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "d6ff6f08-b88d-500d-a026-b4f4919761c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35957bfb-c75f-4181-9726-19956992a6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35957bfb-c75f-4181-9726-19956992a6e6.jpg?1",
             "name": "Trumpeting Carnosaur",
             "text": "Trample\nWhen Trumpeting Carnosaur enters the battlefield, discover 5.\n{2}{R}, Discard Trumpeting Carnosaur: It deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -12857,7 +12857,7 @@
         },
         {
             "id": "f5b99fb6-9d66-5f72-b50c-80df662acad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158ad2e4-5e81-439b-9629-a9d217c45d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158ad2e4-5e81-439b-9629-a9d217c45d83.jpg?1",
             "name": "Earthshaker Dreadmaw",
             "text": "Trample\nWhen Earthshaker Dreadmaw enters the battlefield, draw a card for each other Dinosaur you control.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "66956536-1c2c-5603-8a62-594917804405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591b6a9-ac99-42ad-9b01-c09a3e90201b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591b6a9-ac99-42ad-9b01-c09a3e90201b.jpg?1",
             "name": "Ghalta, Stampede Tyrant",
             "text": "Trample\nWhen Ghalta, Stampede Tyrant enters the battlefield, put any number of creature cards from your hand onto the battlefield.",
             "colours": [
@@ -12932,7 +12932,7 @@
         },
         {
             "id": "f007f9cd-4d90-5575-a277-aae8ec71e507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b95a76-688c-4bd9-a759-f83f1aa18e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b95a76-688c-4bd9-a759-f83f1aa18e2a.jpg?1",
             "name": "Hulking Raptor",
             "text": "Ward {2}\nAt the beginning of your precombat main phase, add {G}{G}.",
             "colours": [
@@ -12968,7 +12968,7 @@
         },
         {
             "id": "7df81431-c6dd-504c-91b1-59ca0529162c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83cb05bc-5137-477e-b7f4-e914f7fa543f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83cb05bc-5137-477e-b7f4-e914f7fa543f.jpg?1",
             "name": "Pugnacious Hammerskull",
             "text": "Whenever Pugnacious Hammerskull attacks while you don't control another Dinosaur, put a stun counter on it.",
             "colours": [
@@ -13004,7 +13004,7 @@
         },
         {
             "id": "6cbf7eea-0737-5054-8912-079b757a647f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb1c91a-398c-437a-9a77-5b8515fc3ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb1c91a-398c-437a-9a77-5b8515fc3ef2.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -13040,7 +13040,7 @@
         },
         {
             "id": "2a298154-24a8-594a-ad4f-a5fae1fde812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cef59-bc7a-48e0-b05a-d9bdd6e05927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cef59-bc7a-48e0-b05a-d9bdd6e05927.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "Vigilance, trample, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13083,7 +13083,7 @@
         },
         {
             "id": "66ab685c-e934-5052-972e-591c25ec52d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f2aa6b-a092-4348-a24f-5edf46544eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f2aa6b-a092-4348-a24f-5edf46544eb7.jpg?1",
             "name": "Itzquinth, Firstborn of Gishath",
             "text": "Haste\nWhen Itzquinth, Firstborn of Gishath enters the battlefield, you may pay {2}. When you do, target Dinosaur you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -13123,7 +13123,7 @@
         },
         {
             "id": "42fdaa9f-634f-528b-8d8f-8b3c3f4d02de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0817334-d7ba-4de9-ade7-67beef358d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0817334-d7ba-4de9-ade7-67beef358d1f.jpg?1",
             "name": "Palani's Hatcher",
             "text": "Other Dinosaurs you control have haste.\nWhen Palani's Hatcher enters the battlefield, create two 0/1 green Dinosaur Egg creature tokens.\nAt the beginning of combat on your turn, if you control one or more Eggs, sacrifice an Egg, then create a 3/3 green Dinosaur creature token.",
             "colours": [
@@ -13161,7 +13161,7 @@
         },
         {
             "id": "752dfd16-7cd8-5da5-8170-1a4a9e853715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d60e0bc-1ce1-4b91-9952-16b394b5a348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d60e0bc-1ce1-4b91-9952-16b394b5a348.jpg?1",
             "name": "Get Lost",
             "text": "Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens.",
             "colours": [
@@ -13195,7 +13195,7 @@
         },
         {
             "id": "17cbf82c-79c1-50ea-b68f-e7b8cb6f9b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e827612d-5a43-4a29-b0c1-ab7f3285ad98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e827612d-5a43-4a29-b0c1-ab7f3285ad98.jpg?1",
             "name": "Resplendent Angel",
             "text": "Flying\nAt the beginning of each end step, if you gained 5 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.\n{3}{W}{W}{W}: Until end of turn, Resplendent Angel gets +2/+2 and gains lifelink.",
             "colours": [
@@ -13231,7 +13231,7 @@
         },
         {
             "id": "e9e6f23a-4a14-5ad5-81dc-faf62b3e8143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604e2bfc-655d-4d3e-98aa-374780ca4016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604e2bfc-655d-4d3e-98aa-374780ca4016.jpg?1",
             "name": "Tishana's Tidebinder",
             "text": "Flash\nWhen Tishana's Tidebinder enters the battlefield, counter up to one target activated or triggered ability. If an ability of an artifact, creature, or planeswalker is countered this way, that permanent loses all abilities for as long as Tishana's Tidebinder remains on the battlefield.",
             "colours": [
@@ -13268,7 +13268,7 @@
         },
         {
             "id": "10b72655-aac7-5bff-94dd-f6e79a86f52c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c5b98d-73cd-4b69-9933-4867da6e8389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c5b98d-73cd-4b69-9933-4867da6e8389.jpg?1",
             "name": "Bloodletter of Aclazotz",
             "text": "Flying\nIf an opponent would lose life during your turn, they lose twice that much life instead.",
             "colours": [
@@ -13305,7 +13305,7 @@
         },
         {
             "id": "7277115b-4b3f-5254-aa52-b6400f6476bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e732f7-85d7-4b2e-b332-9be30bfba3d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e732f7-85d7-4b2e-b332-9be30bfba3d5.jpg?1",
             "name": "Bringer of the Last Gift",
             "text": "Flying\nWhen Bringer of the Last Gift enters the battlefield, if you cast it, each player sacrifices all other creatures they control. Then each player returns all creature cards from their graveyard that weren't put there this way to the battlefield.",
             "colours": [
@@ -13342,7 +13342,7 @@
         },
         {
             "id": "b5610a6b-2149-58f0-a0f0-5a53ca8559b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ff99a-9ecc-4f1b-9c85-e0820f3a5729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ff99a-9ecc-4f1b-9c85-e0820f3a5729.jpg?1",
             "name": "Starving Revenant",
             "text": "When Starving Revenant enters the battlefield, surveil 2. Then for each card you put on top of your library, you draw a card and you lose 3 life.\nDescend 8 \u2014 Whenever you draw a card, if there are eight or more permanent cards in your graveyard, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -13379,7 +13379,7 @@
         },
         {
             "id": "caec88df-bfbb-5854-94d1-ba5772a12687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -13422,7 +13422,7 @@
         },
         {
             "id": "64569a27-df1e-574a-a784-1f26689232c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -13463,7 +13463,7 @@
         },
         {
             "id": "49985e27-e056-517f-a28f-f12d712b0f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c4b837-1557-4dda-a324-9646ce702dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c4b837-1557-4dda-a324-9646ce702dfd.jpg?1",
             "name": "The Skullspore Nexus",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nWhenever one or more nontoken creatures you control die, create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.\n{2}, {T}: Double target creature's power until end of turn.",
             "colours": [
@@ -13499,7 +13499,7 @@
         },
         {
             "id": "43f32809-0855-56ca-bb11-9d53cadcbd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -13540,7 +13540,7 @@
         },
         {
             "id": "5a587554-a633-5267-a4d2-0a18482a3b86",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -13577,7 +13577,7 @@
         },
         {
             "id": "4bc137f8-7fbd-5a46-b518-df1bd477ca21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda9470-7150-48bf-8fbf-1cb0cc80d2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda9470-7150-48bf-8fbf-1cb0cc80d2e1.jpg?1",
             "name": "Molten Collapse",
             "text": "Choose one. If you descended this turn, you may choose both instead.\n\u2022 Destroy target creature or planeswalker.\n\u2022 Destroy target noncreature, nonland permanent with mana value 1 or less.",
             "colours": [
@@ -13613,7 +13613,7 @@
         },
         {
             "id": "1ddbebb2-fa6d-5481-9240-8edec2216bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e435c3bf-2b64-4db4-b9a2-322095b566bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e435c3bf-2b64-4db4-b9a2-322095b566bf.jpg?1",
             "name": "Wail of the Forgotten",
             "text": "Descend 8 \u2014 Choose one. If there are eight or more permanent cards in your graveyard as you cast this spell, choose one or more instead.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Target opponent discards a card.\n\u2022 Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -13649,7 +13649,7 @@
         },
         {
             "id": "f2bc10a7-25d8-5908-ab9a-d28ff8fe8c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff7858d-f18d-4e5a-9467-ebef3ef53ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff7858d-f18d-4e5a-9467-ebef3ef53ac1.jpg?1",
             "name": "Roaming Throne",
             "text": "Ward {2}\nAs Roaming Throne enters the battlefield, choose a creature type.\nRoaming Throne is the chosen type in addition to its other types.\nIf a triggered ability of another creature you control of the chosen type triggers, it triggers an additional time.",
             "colours": [],
@@ -13682,7 +13682,7 @@
         },
         {
             "id": "10fdba40-033e-508a-8791-3233802f1522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d842f91-a04c-4b11-8ac9-0c0536b82d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d842f91-a04c-4b11-8ac9-0c0536b82d03.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -13718,7 +13718,7 @@
         },
         {
             "id": "0de04c7c-f731-51ee-a009-8e735c8f9346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6392d30-07c4-4c63-acb4-ad12d08c080b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6392d30-07c4-4c63-acb4-ad12d08c080b.jpg?1",
             "name": "Echoing Deeps",
             "text": "You may have Echoing Deeps enter the battlefield tapped as a copy of any land card in a graveyard, except it's a Cave in addition to its other types.\n{T}: Add {C}.",
             "colours": [],
@@ -13750,7 +13750,7 @@
         },
         {
             "id": "05afa715-06ac-576d-8a8d-7df5bb281585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc7725d-eb04-4778-8f5e-4c1239ed08b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc7725d-eb04-4778-8f5e-4c1239ed08b8.jpg?1",
             "name": "Restless Anchorage",
             "text": "Restless Anchorage enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{1}{W}{U}: Until end of turn, Restless Anchorage becomes a 2/3 white and blue Bird creature with flying. It's still a land.\nWhenever Restless Anchorage attacks, create a Map token.",
             "colours": [],
@@ -13783,7 +13783,7 @@
         },
         {
             "id": "d84c2655-31a6-51f7-98f3-b7ff88b9b758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802788a-8a40-40e7-9d33-58191d1d678a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802788a-8a40-40e7-9d33-58191d1d678a.jpg?1",
             "name": "Restless Prairie",
             "text": "Restless Prairie enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}: Restless Prairie becomes a 3/3 green and white Llama creature until end of turn. It's still a land.\nWhenever Restless Prairie attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [],
@@ -13816,7 +13816,7 @@
         },
         {
             "id": "4c0d1004-8408-57db-a933-7cd0f3c0ad99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315e121-cf10-4442-91c0-036ca5bbc652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315e121-cf10-4442-91c0-036ca5bbc652.jpg?1",
             "name": "Restless Reef",
             "text": "Restless Reef enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}: Until end of turn, Restless Reef becomes a 4/4 blue and black Shark creature with deathtouch. It's still a land.\nWhenever Restless Reef attacks, target player mills four cards.",
             "colours": [],
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "5b95bbbf-ef03-56d5-aa0c-07ec811479bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2634eb9f-d797-4af4-90d3-7a39fae8300b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2634eb9f-d797-4af4-90d3-7a39fae8300b.jpg?1",
             "name": "Restless Ridgeline",
             "text": "Restless Ridgeline enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Restless Ridgeline becomes a 3/4 red and green Dinosaur creature until end of turn. It's still a land.\nWhenever Restless Ridgeline attacks, another target attacking creature gets +2/+0 until end of turn. Untap that creature.",
             "colours": [],
@@ -13882,7 +13882,7 @@
         },
         {
             "id": "c949d99f-b5b0-5b7a-bbd5-51eaa670b459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9200f9b5-20fc-4ff0-97f7-ef22da5acb72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9200f9b5-20fc-4ff0-97f7-ef22da5acb72.jpg?1",
             "name": "Restless Vents",
             "text": "Restless Vents enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{1}{B}{R}: Until end of turn, Restless Vents becomes a 2/3 black and red Insect creature with menace. It's still a land.\nWhenever Restless Vents attacks, you may discard a card. If you do, draw a card.",
             "colours": [],
@@ -13915,7 +13915,7 @@
         },
         {
             "id": "a373f6d0-8f23-5e2b-bb98-e1d9d35aa0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c80368-0fe6-481a-bee0-7d9f65afb233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c80368-0fe6-481a-bee0-7d9f65afb233.jpg?1",
             "name": "Quintorius Kand",
             "text": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n\u22123: Discover 4.\n\u22126: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
             "colours": [
@@ -13956,7 +13956,7 @@
         },
         {
             "id": "08dc4efb-1e2e-518d-bcb7-e22c36198727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d2fe5-674d-4b3d-b658-ae6901e8044f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d2fe5-674d-4b3d-b658-ae6901e8044f.jpg?1",
             "name": "Abuelo's Awakening",
             "text": "Return target artifact or non-Aura enchantment card from your graveyard to the battlefield with X additional +1/+1 counters on it. It's a 1/1 Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -13990,7 +13990,7 @@
         },
         {
             "id": "adff9ae1-933b-5b2a-a0a6-f19c1cf88cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5efc5e-1582-4bb7-9ae1-bc4c0487ee94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5efc5e-1582-4bb7-9ae1-bc4c0487ee94.jpg?1",
             "name": "Fabrication Foundry",
             "text": "{T}: Add {W}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.\n{2}{W}, {T}, Exile one or more other artifacts you control with total mana value X: Return target artifact card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -14024,7 +14024,7 @@
         },
         {
             "id": "ea0d914f-dae2-5087-b3a6-933adf319e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685b735e-52a6-4fd6-a12e-d059c13d4afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685b735e-52a6-4fd6-a12e-d059c13d4afc.jpg?1",
             "name": "Kutzil's Flanker",
             "text": "Flash\nWhen Kutzil's Flanker enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Kutzil's Flanker for each creature that left the battlefield under your control this turn.\n\u2022 You gain 2 life and scry 2.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -14061,7 +14061,7 @@
         },
         {
             "id": "e93dffaa-f89f-5c28-8edb-33a2b2b1c5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a046c0df-7dba-4a05-b4b4-a76321b15480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a046c0df-7dba-4a05-b4b4-a76321b15480.jpg?1",
             "name": "Sanguine Evangelist",
             "text": "Battle cry\nWhen Sanguine Evangelist enters the battlefield or dies, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -14098,7 +14098,7 @@
         },
         {
             "id": "572cb3d6-339a-5519-b456-1fedaf99f177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [
@@ -14134,7 +14134,7 @@
         },
         {
             "id": "e1f0d32a-b10d-5d41-9e12-5518c49077d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [],
@@ -14169,7 +14169,7 @@
         },
         {
             "id": "4cd93cdc-ad41-54c4-ba08-3bbc70df38c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -14203,7 +14203,7 @@
         },
         {
             "id": "1927ed25-1535-5917-b4c4-e36e5c5216f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -14240,7 +14240,7 @@
         },
         {
             "id": "f8b95775-f106-5833-856e-20d95ead785b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1e97-d1c7-450e-a935-50b386b6b762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1e97-d1c7-450e-a935-50b386b6b762.jpg?1",
             "name": "Warden of the Inner Sky",
             "text": "As long as Warden of the Inner Sky has three or more counters on it, it has flying and vigilance.\nTap three untapped artifacts and/or creatures you control: Put a +1/+1 counter on Warden of the Inner Sky. Scry 1. Activate only as a sorcery.",
             "colours": [
@@ -14277,7 +14277,7 @@
         },
         {
             "id": "4dbf6ee8-d7c2-52b1-91d7-d6d12c38baf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -14311,7 +14311,7 @@
         },
         {
             "id": "0215052b-69d2-5ebc-9c39-0a802f9e9253",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -14345,7 +14345,7 @@
         },
         {
             "id": "6a0af0f9-3302-52f3-810a-d9ccce83ebb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790d70a9-ff02-4676-a804-ee0e030dfe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790d70a9-ff02-4676-a804-ee0e030dfe3b.jpg?1",
             "name": "Deeproot Pilgrimage",
             "text": "Whenever one or more nontoken Merfolk you control become tapped, create a 1/1 blue Merfolk creature token with hexproof.",
             "colours": [
@@ -14379,7 +14379,7 @@
         },
         {
             "id": "56e7b95c-f3c0-52bc-b52d-8eba42951694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "1c21b95b-6a47-591a-859a-9e6bda216ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -14451,7 +14451,7 @@
         },
         {
             "id": "fa524300-996d-5c35-ab8e-f5425e9eb67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [
@@ -14487,7 +14487,7 @@
         },
         {
             "id": "bc79f063-cc10-5e70-ab0b-d506ada99cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [],
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "8f4da1dc-be0f-510a-b1fc-d1aac87e1300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2a1f9-7846-4f96-b20d-ceb638e9ed42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2a1f9-7846-4f96-b20d-ceb638e9ed42.jpg?1",
             "name": "Kitesail Larcenist",
             "text": "Flying, ward {1}\nWhen Kitesail Larcenist enters the battlefield, for each player, choose up to one other target artifact or creature that player controls. For as long as Kitesail Larcenist remains on the battlefield, the chosen permanents become Treasure artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color\" and lose all other abilities.",
             "colours": [
@@ -14559,7 +14559,7 @@
         },
         {
             "id": "db391da6-e32a-5227-bd0f-e2eb87e290cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c87307e-59f0-4747-b0d2-e8b65f4b260e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c87307e-59f0-4747-b0d2-e8b65f4b260e.jpg?1",
             "name": "Subterranean Schooner",
             "text": "Whenever Subterranean Schooner attacks, target creature that crewed it this turn explores.\nCrew 1",
             "colours": [
@@ -14595,7 +14595,7 @@
         },
         {
             "id": "909da4eb-201b-57a3-b65a-a717f88f98c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3eb24e-bba4-463b-ad7e-e3daebda1e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3eb24e-bba4-463b-ad7e-e3daebda1e74.jpg?1",
             "name": "Corpses of the Lost",
             "text": "Skeletons you control get +1/+0 and have haste.\nWhen Corpses of the Lost enters the battlefield, create a 2/2 black Skeleton Pirate creature token.\nAt the beginning of your end step, if you descended this turn, you may pay 1 life. If you do, return Corpses of the Lost to its owner's hand.",
             "colours": [
@@ -14629,7 +14629,7 @@
         },
         {
             "id": "e738981f-1ada-5d88-bf50-6dde2a09c353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0db433-7ca2-48d6-b60c-0a9a9149378a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0db433-7ca2-48d6-b60c-0a9a9149378a.jpg?1",
             "name": "Preacher of the Schism",
             "text": "Deathtouch\nWhenever Preacher of the Schism attacks the player with the most life or tied for most life, create a 1/1 white Vampire creature token with lifelink.\nWhenever Preacher of the Schism attacks while you have the most life or are tied for most life, you draw a card and you lose 1 life.",
             "colours": [
@@ -14666,7 +14666,7 @@
         },
         {
             "id": "87688b52-5113-557e-b1b4-f9d5fe91a2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cdb01-d303-438c-9c87-ca334ac68582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cdb01-d303-438c-9c87-ca334ac68582.jpg?1",
             "name": "Queen's Bay Paladin",
             "text": "Whenever Queen's Bay Paladin enters the battlefield or attacks, return up to one target Vampire card from your graveyard to the battlefield with a finality counter on it. You lose life equal to its mana value.",
             "colours": [
@@ -14703,7 +14703,7 @@
         },
         {
             "id": "404ad07e-3c71-5d11-b0c7-869e0e59feb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc2f3d3-6bac-4ca7-9c42-badf649269f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc2f3d3-6bac-4ca7-9c42-badf649269f5.jpg?1",
             "name": "Souls of the Lost",
             "text": "As an additional cost to cast this spell, discard a card or sacrifice a permanent.\nFathomless descent \u2014 Souls of the Lost's power is equal to the number of permanent cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -14739,7 +14739,7 @@
         },
         {
             "id": "f2e10670-e226-5194-a930-e327167aebd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8754c3b-2deb-45af-9024-1f070496b45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8754c3b-2deb-45af-9024-1f070496b45b.jpg?1",
             "name": "Stalactite Stalker",
             "text": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Stalactite Stalker.\n{2}{B}, Sacrifice Stalactite Stalker: Target creature gets -X/-X until end of turn, where X is Stalactite Stalker's power.",
             "colours": [
@@ -14776,7 +14776,7 @@
         },
         {
             "id": "ecfe6f19-6826-54f2-98f1-e4cc58458373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [
@@ -14812,7 +14812,7 @@
         },
         {
             "id": "be88500c-b388-5980-b6d4-96c44536a981",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [],
@@ -14848,7 +14848,7 @@
         },
         {
             "id": "3e4d8447-4ece-5d1c-8cb5-6ffb07577e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39776030-4a89-4b22-952b-4a7f33f655b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39776030-4a89-4b22-952b-4a7f33f655b5.jpg?1",
             "name": "Terror Tide",
             "text": "Fathomless descent \u2014 All creatures get -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -14882,7 +14882,7 @@
         },
         {
             "id": "db43f4a0-330f-5191-928b-9e0f230a04db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [
@@ -14918,7 +14918,7 @@
         },
         {
             "id": "648ec2a1-aef1-5233-aded-e57641491a44",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [],
@@ -14954,7 +14954,7 @@
         },
         {
             "id": "96977cb5-eab7-5ad3-8dae-149136ee012b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -14990,7 +14990,7 @@
         },
         {
             "id": "e015cc79-fcb6-5712-88a8-8513f79bca4c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -15026,7 +15026,7 @@
         },
         {
             "id": "9658fd0c-94d2-5c21-a5c7-fa7dc5586cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e794c1-33a3-462f-b8e5-479c3acf91d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e794c1-33a3-462f-b8e5-479c3acf91d3.jpg?1",
             "name": "Hit the Mother Lode",
             "text": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference.",
             "colours": [
@@ -15061,7 +15061,7 @@
         },
         {
             "id": "3921693b-0752-57a6-9131-2e93c065319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba4238b-e7fb-4859-87e4-c192e7e6c047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba4238b-e7fb-4859-87e4-c192e7e6c047.jpg?1",
             "name": "Magmatic Galleon",
             "text": "When Magmatic Galleon enters the battlefield, it deals 5 damage to target creature an opponent controls.\nWhenever one or more creatures your opponents control are dealt excess noncombat damage, create a Treasure token.\nCrew 2",
             "colours": [
@@ -15097,7 +15097,7 @@
         },
         {
             "id": "d6a013b5-76e6-59c5-832a-86ad2f07635c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9bec4a-084b-4972-9a6b-58050088168b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9bec4a-084b-4972-9a6b-58050088168b.jpg?1",
             "name": "Poetic Ingenuity",
             "text": "Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.\nWhenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. This ability triggers only once each turn.",
             "colours": [
@@ -15131,7 +15131,7 @@
         },
         {
             "id": "c3517f50-9474-5c62-b602-af533a07e245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fea4c57-326e-4783-b5b5-0b28fcf6fe7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fea4c57-326e-4783-b5b5-0b28fcf6fe7f.jpg?1",
             "name": "Bedrock Tortoise",
             "text": "As long as it's your turn, creatures you control have hexproof.\nEach creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -15167,7 +15167,7 @@
         },
         {
             "id": "766a6710-e69f-5b2b-955a-4ee1910ab3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8f827d-300a-4d75-b894-c6dd2e5997ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8f827d-300a-4d75-b894-c6dd2e5997ce.jpg?1",
             "name": "Cosmium Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n\u2022 Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -15201,7 +15201,7 @@
         },
         {
             "id": "af702d72-2f65-5131-872c-c8e01a05407f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [
@@ -15237,7 +15237,7 @@
         },
         {
             "id": "f52142c7-caa7-58e7-a08a-5ae2a2b5ce45",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [],
@@ -15271,7 +15271,7 @@
         },
         {
             "id": "2e547af8-b3af-521f-aac2-ca0c057c19cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112da23d-3f13-4438-b027-10c5493808bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112da23d-3f13-4438-b027-10c5493808bd.jpg?1",
             "name": "Intrepid Paleontologist",
             "text": "{T}: Add one mana of any color.\n{2}: Exile target card from a graveyard.\nYou may cast Dinosaur creature spells from among cards you own exiled with Intrepid Paleontologist. If you cast a spell this way, that creature enters the battlefield with a finality counter on it.",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "c7b76ea0-b86f-51db-a3dd-ceba01f4286e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d47f-8a4b-47fc-9c5d-641f57631af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d47f-8a4b-47fc-9c5d-641f57631af0.jpg?1",
             "name": "Jadelight Spelunker",
             "text": "When Jadelight Spelunker enters the battlefield, it explores X times.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "61fb8d6b-3c60-544c-8b18-b31ca8690e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0563531-ccd5-4dc4-88dd-a1e438507cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0563531-ccd5-4dc4-88dd-a1e438507cba.jpg?1",
             "name": "Sentinel of the Nameless City",
             "text": "Vigilance\nWhenever Sentinel of the Nameless City enters the battlefield or attacks, create a Map token.",
             "colours": [
@@ -15384,7 +15384,7 @@
         },
         {
             "id": "99fb02b3-d05d-5b70-a55a-15ccf11b1ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a31f6e4-9fc7-46b3-85f8-82025817a35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a31f6e4-9fc7-46b3-85f8-82025817a35d.jpg?1",
             "name": "The Belligerent",
             "text": "Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the top card of your library any time, and you may play lands and cast spells from the top of your library.\nCrew 3",
             "colours": [
@@ -15424,7 +15424,7 @@
         },
         {
             "id": "6ddb62cf-51c7-528f-98be-0984db8e65eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78301-333a-428e-9af9-588a103cc527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78301-333a-428e-9af9-588a103cc527.jpg?1",
             "name": "Deepfathom Echo",
             "text": "At the beginning of combat on your turn, Deepfathom Echo explores. Then you may have it become a copy of another creature you control until end of turn.",
             "colours": [
@@ -15463,7 +15463,7 @@
         },
         {
             "id": "7b612c46-42ee-50d1-a649-7e9d3f97ad44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d165f708-65e9-4dbb-8a8c-085c5a2881d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d165f708-65e9-4dbb-8a8c-085c5a2881d6.jpg?1",
             "name": "Squirming Emergence",
             "text": "Fathomless descent \u2014 Return to the battlefield target nonland permanent card in your graveyard with mana value less than or equal to the number of permanent cards in your graveyard.",
             "colours": [
@@ -15499,7 +15499,7 @@
         },
         {
             "id": "863b2f60-f7a0-5dd6-909c-231cca0b9578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -15531,7 +15531,7 @@
         },
         {
             "id": "c6ad4f67-f146-561a-9af7-f4dfbd9bb4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -15563,7 +15563,7 @@
         },
         {
             "id": "386bddec-429a-50e8-87fa-dfcc0f981cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a710ed-6a2a-4702-9648-7807e8c24edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a710ed-6a2a-4702-9648-7807e8c24edc.jpg?1",
             "name": "The Millennium Calendar",
             "text": "Whenever you untap one or more permanents during your untap step, put that many time counters on The Millennium Calendar.\n{2}, {T}: Double the number of time counters on The Millennium Calendar.\nWhen there are 1,000 or more time counters on The Millennium Calendar, sacrifice it and each opponent loses 1,000 life.",
             "colours": [],
@@ -15595,7 +15595,7 @@
         },
         {
             "id": "fd8b94e7-d518-534a-9c7f-0facf84d13fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8cca6-d92c-40e8-b657-b708a08b63ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8cca6-d92c-40e8-b657-b708a08b63ed.jpg?1",
             "name": "Tarrian's Soulcleaver",
             "text": "Equipped creature has vigilance.\nWhenever another artifact or creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature.\nEquip {2}",
             "colours": [],
@@ -15629,7 +15629,7 @@
         },
         {
             "id": "1b036bfb-451e-595f-9b8d-6083caa9cc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d3058-cc7d-4bb7-a312-4d2d7365ef19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d3058-cc7d-4bb7-a312-4d2d7365ef19.jpg?1",
             "name": "Threefold Thunderhulk",
             "text": "Threefold Thunderhulk enters the battlefield with three +1/+1 counters on it.\nWhenever Threefold Thunderhulk enters the battlefield or attacks, create a number of 1/1 colorless Gnome artifact creature tokens equal to its power.\n{2}, Sacrifice another artifact: Put a +1/+1 counter on Threefold Thunderhulk.",
             "colours": [],
@@ -15662,7 +15662,7 @@
         },
         {
             "id": "8b5dac36-303a-5a94-8615-1dfcbc3bdc91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "ae0cc7e5-bd90-5d00-9a01-ffe1dd6c1f98",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -15722,7 +15722,7 @@
         },
         {
             "id": "6d703da8-11a3-5c08-bac7-163e31926877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4843c-8033-4775-9ffe-4f3980fabfeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4843c-8033-4775-9ffe-4f3980fabfeb.jpg?1",
             "name": "Sunken Citadel",
             "text": "Sunken Citadel enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{T}: Add two mana of the chosen color. Spend this mana only to activate abilities of land sources.",
             "colours": [],
@@ -15754,7 +15754,7 @@
         },
         {
             "id": "0debfcd6-f09c-5d01-87d9-62db4ec6a0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716a32c-91a6-470a-a686-d5eb3d27f46e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716a32c-91a6-470a-a686-d5eb3d27f46e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15791,7 +15791,7 @@
         },
         {
             "id": "ea6de305-b334-532f-8a8b-083227c886f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06c72cb-03ce-48eb-b5dc-b2301c6871a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06c72cb-03ce-48eb-b5dc-b2301c6871a2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "dd273d2e-9bcb-5e58-afac-91bfcc8b4621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e3ed2c-342b-44aa-8e3e-0c53602397c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e3ed2c-342b-44aa-8e3e-0c53602397c3.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15865,7 +15865,7 @@
         },
         {
             "id": "7acde3a9-8029-5876-87b7-e0fb903f417e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f9dab5-4b13-4a98-8a64-76e69f0ba511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f9dab5-4b13-4a98-8a64-76e69f0ba511.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15902,7 +15902,7 @@
         },
         {
             "id": "db27fc4f-d97d-50ef-a942-d11f205bb537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f893107-84b0-4e3f-b1f5-b04632f192c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f893107-84b0-4e3f-b1f5-b04632f192c5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15939,7 +15939,7 @@
         },
         {
             "id": "1b193b42-8ab7-5f25-b2b9-63aeb10e7e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0b0b4f-2b31-4fe1-aedb-be9d34fce688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0b0b4f-2b31-4fe1-aedb-be9d34fce688.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15976,7 +15976,7 @@
         },
         {
             "id": "8dff7df4-2465-57cf-a655-b080fa7569b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82fc4bc-ac81-4ad6-8b33-781d047f60d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82fc4bc-ac81-4ad6-8b33-781d047f60d5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16013,7 +16013,7 @@
         },
         {
             "id": "4b6a107d-dffc-583f-b095-ba0c2173b8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8e09c2-3384-4d00-a2d0-65d6b8056e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8e09c2-3384-4d00-a2d0-65d6b8056e30.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16050,7 +16050,7 @@
         },
         {
             "id": "c45f48f7-49a7-58eb-b756-dc059692c30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954219a-fd4b-4fb1-945f-7950efc1d975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954219a-fd4b-4fb1-945f-7950efc1d975.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16087,7 +16087,7 @@
         },
         {
             "id": "e724da3a-fd41-5cdb-b639-b03449261da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1069841a-0642-4fb6-b831-d45ff7fda3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1069841a-0642-4fb6-b831-d45ff7fda3af.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16124,7 +16124,7 @@
         },
         {
             "id": "2245132f-5fa6-503c-9230-7db0f57102fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee66a2c-0684-4324-82fc-60c13a55602e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee66a2c-0684-4324-82fc-60c13a55602e.jpg?1",
             "name": "Jadelight Spelunker",
             "text": "When Jadelight Spelunker enters the battlefield, it explores X times.",
             "colours": [
@@ -16161,7 +16161,7 @@
         },
         {
             "id": "4cb52155-331b-500d-88a0-e25fedf3b048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3ed0f5-b476-4595-bdff-531488961a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3ed0f5-b476-4595-bdff-531488961a87.jpg?1",
             "name": "Hit the Mother Lode",
             "text": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference.",
             "colours": [
@@ -16195,7 +16195,7 @@
         },
         {
             "id": "ae3e80ce-44c9-5c0a-87be-1ced8eaacd49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24643b00-9062-42bd-9ecd-f6990ddbca91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24643b00-9062-42bd-9ecd-f6990ddbca91.jpg?1",
             "name": "Spyglass Siren",
             "text": "Flying\nWhen Spyglass Siren enters the battlefield, create a Map token.",
             "colours": [
@@ -16232,7 +16232,7 @@
         },
         {
             "id": "a7f931a4-0828-505d-bf89-2e0eada89465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444190a9-5ad7-4132-aae4-247ad3d9ea01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444190a9-5ad7-4132-aae4-247ad3d9ea01.jpg?1",
             "name": "Deep-Cavern Bat",
             "text": "Flying, lifelink\nWhen Deep-Cavern Bat enters the battlefield, look at target opponent's hand. You may exile a nonland card from it until Deep-Cavern Bat leaves the battlefield.",
             "colours": [
@@ -16268,7 +16268,7 @@
         },
         {
             "id": "48b79211-8b51-5a7f-b6ac-dc677e4701ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb48483-5990-46cf-b200-032500c4a6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb48483-5990-46cf-b200-032500c4a6b3.jpg?1",
             "name": "Geological Appraiser",
             "text": "When Geological Appraiser enters the battlefield, if you cast it, discover 3.",
             "colours": [
@@ -16305,7 +16305,7 @@
         },
         {
             "id": "43a114ce-0f55-5f7c-a2c5-e00a5cf3da6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f338f13-eac2-4088-a33c-cb389fbe967a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f338f13-eac2-4088-a33c-cb389fbe967a.jpg?1",
             "name": "Cenote Scout",
             "text": "When Cenote Scout enters the battlefield, it explores.",
             "colours": [
@@ -16342,7 +16342,7 @@
         },
         {
             "id": "1a9d0c05-e986-5062-b1f0-08098283b3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aade7c6c-fa34-4f69-9b5d-cf57a5341ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aade7c6c-fa34-4f69-9b5d-cf57a5341ccc.jpg?1",
             "name": "Bartolom\u00e9 del Presidio",
             "text": "Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolom\u00e9 del Presidio.",
             "colours": [
@@ -16384,7 +16384,7 @@
         },
         {
             "id": "479e911d-ce0e-5e90-93c7-be72198cbd40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6675d55-5960-4da4-a31c-45654ab9974d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6675d55-5960-4da4-a31c-45654ab9974d.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16419,7 +16419,7 @@
         },
         {
             "id": "38e8a848-e9d9-5edc-90dd-4d7460c0ca4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc626a1-cfb0-4e1f-80fc-7c1ff07ee424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc626a1-cfb0-4e1f-80fc-7c1ff07ee424.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16454,7 +16454,7 @@
         },
         {
             "id": "21e9a9c1-aa60-5b55-b568-54b54dc4a589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f9b3b8-090e-4152-8d44-52d92375905b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f9b3b8-090e-4152-8d44-52d92375905b.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16489,7 +16489,7 @@
         },
         {
             "id": "06d530fd-f068-599d-9ebe-05e870779ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89bcbd5-772a-4ff2-b48b-6fea07830578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89bcbd5-772a-4ff2-b48b-6fea07830578.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16524,7 +16524,7 @@
         },
         {
             "id": "60319026-82e9-55e9-9f21-25a9d173238b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b773b4e-7af3-4836-8c7f-3897f968a33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b773b4e-7af3-4836-8c7f-3897f968a33e.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16559,7 +16559,7 @@
         },
         {
             "id": "237f6389-2174-55ff-84a6-26a34f80b679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9dbec-ad25-488b-8472-4bd85fd6c757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9dbec-ad25-488b-8472-4bd85fd6c757.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16594,7 +16594,7 @@
         },
         {
             "id": "f7f1c18a-ecbe-5b99-ad80-2fcce898fc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c3b739-89b3-4ad8-aab9-76e8f87cf123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c3b739-89b3-4ad8-aab9-76e8f87cf123.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -16622,7 +16622,7 @@
         },
         {
             "id": "e24726ce-7c3e-57fe-a261-7854152027d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0d80ce-9397-4c6d-9a07-31172d46f42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0d80ce-9397-4c6d-9a07-31172d46f42a.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "f326fd73-8e67-59c0-9b29-3772bc573f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe7c36a-77b7-4418-9e2d-b6aeea61502e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe7c36a-77b7-4418-9e2d-b6aeea61502e.jpg?1",
             "name": "Gnome Soldier",
             "text": "",
             "colours": [],
@@ -16690,7 +16690,7 @@
         },
         {
             "id": "53c31212-83ec-5487-b11a-e5de4593b4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0484390e-1167-4407-84de-7ddc726e8926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0484390e-1167-4407-84de-7ddc726e8926.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -16725,7 +16725,7 @@
         },
         {
             "id": "53f2e6e3-6a5b-5c8a-a897-a95bf644e8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d353ad-7160-41fa-809c-d76b36478a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d353ad-7160-41fa-809c-d76b36478a2a.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -16760,7 +16760,7 @@
         },
         {
             "id": "3e43a418-8c17-5ed2-b92b-42dbe4c96b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00841e4b-0995-4fb5-93d6-e177beba4934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00841e4b-0995-4fb5-93d6-e177beba4934.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -16795,7 +16795,7 @@
         },
         {
             "id": "201e2405-5ffc-50f4-80e0-a1e5df6fc25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff66e3-ea24-4542-887f-c41abb1759e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff66e3-ea24-4542-887f-c41abb1759e6.jpg?1",
             "name": "Fungus",
             "text": "",
             "colours": [
@@ -16830,7 +16830,7 @@
         },
         {
             "id": "c38fcdac-0cef-58a9-aae8-5071361460ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec83fe2-173b-4aa6-bfa1-892b092bd1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec83fe2-173b-4aa6-bfa1-892b092bd1f6.jpg?1",
             "name": "Skeleton Pirate",
             "text": "",
             "colours": [
@@ -16866,7 +16866,7 @@
         },
         {
             "id": "f7f3d0b9-14a8-5d0e-90fa-3c12688444ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0702f9-769b-40c0-96a7-508dc8f2652c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0702f9-769b-40c0-96a7-508dc8f2652c.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -16901,7 +16901,7 @@
         },
         {
             "id": "b99d12bc-ca42-5446-b731-e1ac531ee248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb7151-cf71-49bc-8d99-b0230d5465e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb7151-cf71-49bc-8d99-b0230d5465e5.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -16936,7 +16936,7 @@
         },
         {
             "id": "b0b8168a-9a4e-540e-b086-9372074c0e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e24a8f-3663-47c6-94b1-4525ae9da3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e24a8f-3663-47c6-94b1-4525ae9da3b5.jpg?1",
             "name": "Dinosaur Egg",
             "text": "",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "7af4122b-94af-5e15-9d75-54f15bbb442a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92f2858-e524-4d23-b947-d4dff20e7f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92f2858-e524-4d23-b947-d4dff20e7f59.jpg?1",
             "name": "Fungus Dinosaur",
             "text": "",
             "colours": [
@@ -17008,7 +17008,7 @@
         },
         {
             "id": "3100cd00-1cab-50ce-a8a1-848a984781c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [
@@ -17046,7 +17046,7 @@
         },
         {
             "id": "30bd97e4-466f-5f43-8a2c-2ed182bfd961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072cd10b-98d3-452e-bf8d-13a75cc3d72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072cd10b-98d3-452e-bf8d-13a75cc3d72e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17083,7 +17083,7 @@
         },
         {
             "id": "6cdd4a0c-4ac3-5cca-8626-57bf2b08a6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3005eb0a-5c96-4a07-a6b9-a907d1095cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3005eb0a-5c96-4a07-a6b9-a907d1095cdf.jpg?1",
             "name": "Vampire Demon",
             "text": "",
             "colours": [
@@ -17121,7 +17121,7 @@
         },
         {
             "id": "f70d7ddc-2d93-55bf-937e-1719faea6c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg?1",
             "name": "Gnome",
             "text": "",
             "colours": [],
@@ -17153,7 +17153,7 @@
         },
         {
             "id": "cd91506e-6a64-5e5c-948e-851ed31ac543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64839118-09d2-4645-9d3c-f80755ac781f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64839118-09d2-4645-9d3c-f80755ac781f.jpg?1",
             "name": "Map",
             "text": "",
             "colours": [],
@@ -17184,7 +17184,7 @@
         },
         {
             "id": "f7e12dcc-910d-5b82-b637-0b972542ead5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfaedeb-f8ec-4f0e-b243-c850770a86f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfaedeb-f8ec-4f0e-b243-c850770a86f2.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17215,7 +17215,7 @@
         },
         {
             "id": "886bac3e-f93f-5f3d-9d82-eabd315b3779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004f309-5833-4058-ac71-d203c648897f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004f309-5833-4058-ac71-d203c648897f.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],
@@ -17243,7 +17243,7 @@
         },
         {
             "id": "390a4800-1f2f-595f-bcfa-8a968f6fa64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f2a22b-26a5-4eb6-8430-74f5de4832ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f2a22b-26a5-4eb6-8430-74f5de4832ba.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/LEA.json
+++ b/Assets/Resources/Sets/LEA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2b304dc1-8d7d-50a7-a310-2d0e5427935f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c83259-9b90-47c2-b48e-c7d78519e792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c83259-9b90-47c2-b48e-c7d78519e792.jpg?1",
             "name": "Animate Wall",
             "text": "Target wall can now attack. Target wall's power and toughness are unchanged, even if its power is 0.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "22bf9c94-5e17-5b7d-ae82-e18f992a2ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ddce7-b9c5-431d-a0b0-46d4aa93cbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ddce7-b9c5-431d-a0b0-46d4aa93cbcb.jpg?1",
             "name": "Armageddon",
             "text": "All lands in play are destroyed.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "a1aa90b2-1c25-5c8f-8fed-46c295ef03b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9ea46a-411f-40ce-a873-a905180093f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9ea46a-411f-40ce-a873-a905180093f4.jpg?1",
             "name": "Balance",
             "text": "Whichever player has more lands in play must discard enough lands of his or her choice to equalize the number of lands both players have in play. Cards in hand and creatures in play must be equalized the same way. Creatures lost in this manner may not be regenerated.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "e645151c-9c01-5246-890d-becf25c794c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11600105-56c6-4073-a4a6-8469030b39c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11600105-56c6-4073-a4a6-8469030b39c9.jpg?1",
             "name": "Benalish Hero",
             "text": "Bands",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "5d993530-bac0-5533-b005-d098ea6071ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15967a39-303f-457d-bcde-51837c8d63e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15967a39-303f-457d-bcde-51837c8d63e1.jpg?1",
             "name": "Black Ward",
             "text": "Target creature gains protection from black.",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "b933aca1-28f1-5d5b-9bdc-39304ff2f338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fba951-c5bb-497c-9292-ce1b2a1e1247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fba951-c5bb-497c-9292-ce1b2a1e1247.jpg?1",
             "name": "Blaze of Glory",
             "text": "Target defending creature can and must block all attacking creatures it can legally block. For example, a normal non-flying target defender can and must block all normal non-flying attackers at once, but it cannot block any flying attackers. Controller of target defender may distribute damage among attackers as desired. Play before defense is chosen.",
             "colours": [
@@ -197,7 +197,7 @@
         },
         {
             "id": "f32aac96-64ef-5e9c-8fab-4456f5f35e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131fd27-18da-47ca-b59f-135bcac83abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131fd27-18da-47ca-b59f-135bcac83abd.jpg?1",
             "name": "Blessing",
             "text": "oo\nW Target creature gains +1/+1 until end of turn.",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "120a6ac1-3ade-5bec-8d86-621a731eaac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f9f0f2-e1cc-4740-888c-1336c6de0a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f9f0f2-e1cc-4740-888c-1336c6de0a27.jpg?1",
             "name": "Blue Ward",
             "text": "Target creature gains protection from blue.",
             "colours": [
@@ -263,7 +263,7 @@
         },
         {
             "id": "dbb22974-ea92-5579-a923-fcf1cd64be68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0da8d56-3178-44c2-9344-95d2346d326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0da8d56-3178-44c2-9344-95d2346d326f.jpg?1",
             "name": "Castle",
             "text": "Your untapped creatures gain +0/+2. Attacking creatures lose this bonus.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "35f986fe-6ece-5ea5-9171-e7d5143b20a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1a7f-e8ba-40b5-92b7-af1e963a0319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1a7f-e8ba-40b5-92b7-af1e963a0319.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevents all damage against you from one blue source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "618ccc94-8a8f-5297-b4e6-b37905729848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae32d20-b438-4f43-b603-e8f706ecfb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae32d20-b438-4f43-b603-e8f706ecfb03.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevents all damage against you from one green source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "5b0ccc9a-8cb0-5917-97e2-27ea377c6db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd94c5-42f6-4148-be6e-2a3a4226cc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd94c5-42f6-4148-be6e-2a3a4226cc0e.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevents all damage against you from one red source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "7473cc4e-3dba-542c-b4c8-fe7166cb4d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92df19c9-e127-42d9-8dd2-7fa5a7095428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92df19c9-e127-42d9-8dd2-7fa5a7095428.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevents all damage against you from one white source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "cfdd4922-8a07-5c94-b1c5-62121ab37b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2379f78-c03f-447f-b3c9-10a918d556e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2379f78-c03f-447f-b3c9-10a918d556e9.jpg?1",
             "name": "Consecrate Land",
             "text": "All enchantments on target land are destroyed. Land cannot be destroyed or further enchanted until Consecrate Land has been destroyed.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "68d62155-7920-5d65-8f99-3c69a4a12ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13186bc9-8d9c-433b-ba15-121ef94dd68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13186bc9-8d9c-433b-ba15-121ef94dd68a.jpg?1",
             "name": "Conversion",
             "text": "All mountains are considered plains while Conversion is in play. Pay o\nWo\nW during upkeep or Conversion is discarded.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "4660fa94-7346-5bc3-bc05-caae99f003ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057986c7-20c0-4157-b4df-beae4ef5c66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057986c7-20c0-4157-b4df-beae4ef5c66d.jpg?1",
             "name": "Crusade",
             "text": "All white creatures gain +1/+1.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "aeb78872-677a-53a9-b91a-de8c7b814a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5466cc-aa57-4a7f-8b21-d92b2fe02e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5466cc-aa57-4a7f-8b21-d92b2fe02e13.jpg?1",
             "name": "Death Ward",
             "text": "Regenerates target creature.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "cd10b3e5-780b-57e1-a825-77fce7cce5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2722d7e2-61c6-4934-9c21-875ee78fd06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2722d7e2-61c6-4934-9c21-875ee78fd06c.jpg?1",
             "name": "Disenchant",
             "text": "Target enchantment or artifact must be discarded.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "731d6876-056c-5873-8fd8-a5e3794b1540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3455b006-9ea5-4aef-8ad2-d0701eb0cacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3455b006-9ea5-4aef-8ad2-d0701eb0cacf.jpg?1",
             "name": "Farmstead",
             "text": "Target land's controller gains 1 life each upkeep if o\nWo\nW is spent. Target land still generates mana as usual.",
             "colours": [
@@ -608,7 +608,7 @@
         },
         {
             "id": "7de3b02f-3de7-581c-b23f-435ac582dbad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6118b2-fe01-425a-a2ed-6d7c42286c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6118b2-fe01-425a-a2ed-6d7c42286c8e.jpg?1",
             "name": "Green Ward",
             "text": "Target creature gains protection from green.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "4145bd67-79d4-5c23-af1d-db7ef44fa038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f84d676-5327-454c-a033-b4498a9d28e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f84d676-5327-454c-a033-b4498a9d28e2.jpg?1",
             "name": "Guardian Angel",
             "text": "Prevents X damage from being dealt to any one target. Any further damage to the same target this turn can be canceled by spending 1 mana per point of damage to be canceled.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "c80e8d50-823e-5df8-a820-0901eb8cdf54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de37e-84d5-4dc7-b36c-e14da5924729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de37e-84d5-4dc7-b36c-e14da5924729.jpg?1",
             "name": "Healing Salve",
             "text": "Gain 3 life, or prevent up to 3 damage from being dealt to a single target.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "0e532415-391e-56c2-b10f-29ac5e4b9186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01041d2-687e-4972-81c8-16690809275b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01041d2-687e-4972-81c8-16690809275b.jpg?1",
             "name": "Holy Armor",
             "text": "Target creature gains +0/+2. oo\nW Target creature gets extra +0/+1 until end of turn.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "66a6b1ba-51c6-5d79-8e34-d0958b5f0b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e945a4cd-0eb1-4f54-898d-169ce2748a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e945a4cd-0eb1-4f54-898d-169ce2748a03.jpg?1",
             "name": "Holy Strength",
             "text": "Target creature gains +1/+2.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "cf0fd935-7303-56a9-b9bd-1cadd70294c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e8a42-89de-42bc-8d5f-33426d207c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e8a42-89de-42bc-8d5f-33426d207c3a.jpg?1",
             "name": "Island Sanctuary",
             "text": "You may decline to draw a card from your library during draw phase. In exchange, until start of your next turn the only creatures that can damage you are those that fly or have islandwalk.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "79c65929-ec55-5c5d-8a61-69d61ff3d87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f30ad61-fcb7-4d55-ba86-94de1bf545e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f30ad61-fcb7-4d55-ba86-94de1bf545e4.jpg?1",
             "name": "Karma",
             "text": "Karma does 1 damage to player for each swamp player has in play. Damage occurs during player's upkeep. Affects both players.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "5914987f-9629-5f00-bc01-38775f9edb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb633f5-cc4d-4157-8217-def90cb15e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb633f5-cc4d-4157-8217-def90cb15e24.jpg?1",
             "name": "Lance",
             "text": "Target creature gains first strike.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "34703503-e481-52de-9b59-df3f81a1a21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaac88da-d19e-4771-944c-3709963d04e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaac88da-d19e-4771-944c-3709963d04e7.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Flying, bands",
             "colours": [
@@ -897,7 +897,7 @@
         },
         {
             "id": "f2c18dec-8757-5f3a-b65d-a46faec3a127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6303233b-35eb-49ca-b844-ba6b9fe1cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6303233b-35eb-49ca-b844-ba6b9fe1cbd2.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW and tap: Destroys a black card in play. Cannot be used to cancel a black spell as it is being cast.",
             "colours": [
@@ -931,7 +931,7 @@
         },
         {
             "id": "613e79c1-1e0d-5bda-a728-f32583b38070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf1aab-1e58-4a5a-bc66-cb3f7c86e0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf1aab-1e58-4a5a-bc66-cb3f7c86e0e8.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "340d1f1d-ca26-560a-a749-1f9d178a3107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9cef4-0f2d-478a-b119-fe1967687f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9cef4-0f2d-478a-b119-fe1967687f74.jpg?1",
             "name": "Personal Incarnation",
             "text": "Caster can redirect any or all damage done to Personal Incarnation to self instead. The source of the damage is unchanged. If Personal Incarnation is destroyed, caster loses half his or her remaining life points, rounding up the loss.",
             "colours": [
@@ -998,7 +998,7 @@
         },
         {
             "id": "a2d40bbc-395a-5873-a0bb-2c138c1bd117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2facf462-55cd-4da4-997f-2cf4add75628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2facf462-55cd-4da4-997f-2cf4add75628.jpg?1",
             "name": "Purelace",
             "text": "Changes the color of one card either being played or already in play to white. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "914dd48d-b0f9-503a-83ea-5ef7274d0ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c64c01-c2aa-470b-88c6-3d3e4a969649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c64c01-c2aa-470b-88c6-3d3e4a969649.jpg?1",
             "name": "Red Ward",
             "text": "Target creature gains protection from red.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "edba49ed-f92c-57d4-b3b5-ff889997aab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fff6e6f-4ebd-4ec8-9443-59efb22d376c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fff6e6f-4ebd-4ec8-9443-59efb22d376c.jpg?1",
             "name": "Resurrection",
             "text": "Take a creature from your graveyard and put it directly into play. You can't tap it until your next turn.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "a10a3368-7d24-5fce-a54b-343a58bdae8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943baea8-b173-4863-a3ab-dd217d483cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943baea8-b173-4863-a3ab-dd217d483cd9.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage you have taken from any one source this turn is added to your life total instead of subtracted from it.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "94b0396b-fbc6-560d-b41a-6d1a65fca97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ba7b76-f3d0-47d0-8a35-0c08e67200fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ba7b76-f3d0-47d0-8a35-0c08e67200fb.jpg?1",
             "name": "Righteousness",
             "text": "Target defending creature gains +7/+7 until end of turn.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "799abda3-a719-5205-adb7-aeb26f706f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efba235e-04e5-449c-906c-0ac33f6d7929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efba235e-04e5-449c-906c-0ac33f6d7929.jpg?1",
             "name": "Samite Healer",
             "text": "Tap to prevent 1 damage to any target.",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "4bd37a8c-2e55-5451-9716-1dc9b1b0ce71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b92bd-797e-413f-a8b0-32e0937a1ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b92bd-797e-413f-a8b0-32e0937a1ee0.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "52b0a40b-22db-5632-8ca7-a1c55bc68195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ac5006-91bd-4803-93da-f87cf196dd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ac5006-91bd-4803-93da-f87cf196dd2f.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nDoes not tap when attacking.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "6c789760-0018-5c69-b36a-5cb819c80706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ea9eb-abc1-4862-aa2d-8fb808d79490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ea9eb-abc1-4862-aa2d-8fb808d79490.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Target creature is removed from game entirely; return to owner's deck only when game is over. Creature's controller gains life points equal to creature's power.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "954dfa06-45e8-516a-abf6-73e9e734db04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd9ab01-a833-4fa4-8dee-151bd9800835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd9ab01-a833-4fa4-8dee-151bd9800835.jpg?1",
             "name": "Veteran Bodyguard",
             "text": "Unless Bodyguard is tapped, any damage done to you by unblocked creatures is done instead to Bodyguard. You may not take this damage yourself, though you can prevent it if possible.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "53e8e411-6329-51e3-b840-60ba16ebd5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4723-b36c-4015-b361-736a6523e8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4723-b36c-4015-b361-736a6523e8f5.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -1352,7 +1352,7 @@
         },
         {
             "id": "eb39e5eb-fff7-539c-8f58-5ecbd897f26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50abfba8-c9f9-4ebf-965a-4b425fe83129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50abfba8-c9f9-4ebf-965a-4b425fe83129.jpg?1",
             "name": "White Knight",
             "text": "Protection from black, first strike",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "b56436d1-6aaa-546c-937b-f9ea007197b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b22665-1501-420a-82ad-f71f6768bcf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b22665-1501-420a-82ad-f71f6768bcf8.jpg?1",
             "name": "White Ward",
             "text": "Target creature gains protection from white.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "608d0aa6-2a48-5596-842a-63abe1ec29cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2788d69-6a3a-42f0-8736-cc6b57755ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2788d69-6a3a-42f0-8736-cc6b57755ecd.jpg?1",
             "name": "Wrath of God",
             "text": "All creatures in play are destroyed and cannot regenerate.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "27e92f54-0084-57c2-85e5-197e026fab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c3b2a3-0daa-4d42-832d-fcdfda6555ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c3b2a3-0daa-4d42-832d-fcdfda6555ea.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "1c17ce18-bf3e-558b-9389-632588f93851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e7ddf2-5604-41e7-bb9d-ddd03d3e9d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e7ddf2-5604-41e7-bb9d-ddd03d3e9d0b.jpg?1",
             "name": "Ancestral Recall",
             "text": "Draw 3 cards or force opponent to draw 3 cards.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "e035e37e-cb8e-5f12-a5db-fe7f927a3457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664b46f5-0424-4f4e-9f26-6bd2cf5e0357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664b46f5-0424-4f4e-9f26-6bd2cf5e0357.jpg?1",
             "name": "Animate Artifact",
             "text": "Target artifact is now a creature with both power and toughness equal to its casting cost; target retains all its original abilities as well. This will destroy artifacts with 0 casting cost.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "5b2fbe34-84d6-553b-a276-fc95be592646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d666ef-39bf-4fbf-8201-5f1056539da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d666ef-39bf-4fbf-8201-5f1056539da2.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Counters a red spell being cast or destroys a red card in play.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "fdd488e3-cbe3-5684-b7b8-38997728f653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b19a12-6914-430e-81ce-dcfca47884df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b19a12-6914-430e-81ce-dcfca47884df.jpg?1",
             "name": "Braingeyser",
             "text": "Draw X cards or force opponent to draw X cards.",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "f060a053-c376-5aa9-91ca-908a9a4c72eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d33dd-4eb2-4446-9813-1923d8e2d2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d33dd-4eb2-4446-9813-1923d8e2d2f3.jpg?1",
             "name": "Clone",
             "text": "Upon summoning, Clone acquires all normal characteristics, including color, of any one creature in play on either side; any enchantments on original creature are not copied. Clone retains these characteristics even after original creature is destroyed. Clone cannot be played if there are no creatures in play.",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "cbe924ee-7b84-5d9f-8917-dbc618d5df9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b52f459-c703-4a0b-9114-ff69eec61287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b52f459-c703-4a0b-9114-ff69eec61287.jpg?1",
             "name": "Control Magic",
             "text": "You control target creature until enchantment is discarded or game ends. You can't tap target creature this turn, but if it was already tapped it stays tapped until you can untap it. If destroyed, target creature is put in its owner's graveyard.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "a654be23-d457-54b9-89bf-d04708d21ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5ed955-1193-4e6a-a3e2-f54c1f9bf063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5ed955-1193-4e6a-a3e2-f54c1f9bf063.jpg?1",
             "name": "Copy Artifact",
             "text": "Select any artifact in play. This enchantment acts as a duplicate of that artifact; enchantment copy is affected by cards that affect either enchantments or artifacts.\nEnchantment copy remains even if original artifact is destroyed.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "a431d592-5825-5ed3-8201-cd7571860083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df55e3f-14de-46ef-b6b1-616618724d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df55e3f-14de-46ef-b6b1-616618724d9e.jpg?1",
             "name": "Counterspell",
             "text": "Counters target spell as it is being cast.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "3d70b00c-3c10-5e66-a11b-3751dbabf87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4bd7d1-77e5-46e5-a594-c24469e88c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4bd7d1-77e5-46e5-a594-c24469e88c4c.jpg?1",
             "name": "Creature Bond",
             "text": "If target creature is destroyed, Creature Bond does an amount of damage equal to creature's toughness to creature's controller.",
             "colours": [
@@ -1770,7 +1770,7 @@
         },
         {
             "id": "48ae8d15-eb7f-5ef4-8952-849237cbd53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3830c5-cc66-453e-9e53-0636e00ee0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3830c5-cc66-453e-9e53-0636e00ee0ee.jpg?1",
             "name": "Drain Power",
             "text": "Tap all opponent's lands, taking all this mana and all mana in opponent's mana pool into your mana pool. You can't tap fewer than all opponent's lands.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "548f6bc3-0a88-5987-bc52-b345a7a6f336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb8f591-d763-49bf-8ef9-86265aaa72f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb8f591-d763-49bf-8ef9-86265aaa72f7.jpg?1",
             "name": "Feedback",
             "text": "Feedback does 1 damage to controller of target enchantment during each upkeep.",
             "colours": [
@@ -1834,7 +1834,7 @@
         },
         {
             "id": "6ba1a1f5-1959-5dc7-9e97-45bc45e40fb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c7784b-6b79-4268-a714-895c82809aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c7784b-6b79-4268-a714-895c82809aff.jpg?1",
             "name": "Flight",
             "text": "Target creature is now a flying creature.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "596c1f92-9661-5d65-9330-aa00138c0e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ac51-e6a7-48d7-8759-166070ca13d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ac51-e6a7-48d7-8759-166070ca13d8.jpg?1",
             "name": "Invisibility",
             "text": "Target creature can be blocked only by walls.",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "df47b61f-551a-5288-9746-8de91d5af3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3f4b11-ad1b-48e2-a500-787d351b0174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3f4b11-ad1b-48e2-a500-787d351b0174.jpg?1",
             "name": "Jump",
             "text": "Target creature is a flying creature until end of turn.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "1630aa04-271c-59b2-bdd6-e616dd730b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11add837-7ee4-4104-b031-c161bce459ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11add837-7ee4-4104-b031-c161bce459ae.jpg?1",
             "name": "Lifetap",
             "text": "You gain 1 life each time any forest of opponent's becomes tapped.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "e4a2b1cc-84e2-5d2e-8786-b3f4b8f8b1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210c4a90-fc7a-4c76-aeaa-20a005e45386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210c4a90-fc7a-4c76-aeaa-20a005e45386.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk in play gain islandwalk and +1/+1 while this card is in play.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "6a1886ab-1744-5a05-9a83-d1ef9595af97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd4202c-0477-45aa-82fd-83c85d6d4bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd4202c-0477-45aa-82fd-83c85d6d4bef.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of any card being played or already in play by replacing one basic land type with another. For example, you can change \"swampwalk\" to \"plainswalk.\"",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "304ecd98-07f7-5242-abef-84a8793bf997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36204ddd-ddf7-4b44-ae3c-b4a5a41ac9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36204ddd-ddf7-4b44-ae3c-b4a5a41ac9cb.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "85f136e4-2225-57f2-a7dc-5dfd954ecfce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3e0b3-5284-464f-8c62-0f7801c966f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3e0b3-5284-464f-8c62-0f7801c966f5.jpg?1",
             "name": "Mana Short",
             "text": "All opponent's lands are tapped, and opponent's mana pool is emptied.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "5a120339-05d7-5049-aec2-ef09f2a17a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b871039-6a66-4ac3-95e7-24759c1f2f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b871039-6a66-4ac3-95e7-24759c1f2f92.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "14959484-e122-52a9-a405-94b59eb3ad1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0631c7c8-9aa5-4333-8e20-20247fc47033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0631c7c8-9aa5-4333-8e20-20247fc47033.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nController must spend U during upkeep to maintain or Phantasmal Forces are destroyed.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "f9a670d0-10e8-58bc-8546-e336fbedec02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c371aa1-1619-41e3-8364-7bc9b8cf5d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c371aa1-1619-41e3-8364-7bc9b8cf5d14.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Target land changes to any basic land type of caster's choice. Land type is set when cast and may not be further altered by this enchantment.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "9a5a5647-6004-521c-ac24-8717505ce425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d2cf5-e8d0-4fb2-b950-252d52084b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d2cf5-e8d0-4fb2-b950-252d52084b63.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "45b22f88-db04-5121-a378-0f358c38ca6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7cb23-d229-43c5-addd-dcf423984b0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7cb23-d229-43c5-addd-dcf423984b0c.jpg?1",
             "name": "Pirate Ship",
             "text": "Tap to do 1 damage to any target. Cannot attack unless opponent has islands in play, though controller may still tap. Pirate Ship is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2256,7 +2256,7 @@
         },
         {
             "id": "4fdbe46e-e92f-5fcc-9bb1-d2bcba4eaf57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc982b6-35b2-4e33-ace2-86cb79123e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc982b6-35b2-4e33-ace2-86cb79123e4f.jpg?1",
             "name": "Power Leak",
             "text": "Target enchantment costs 2 extra mana each turn during upkeep. If target enchantment's controller cannot or will not pay this extra mana, Power Leak does 1 damage to him or her for each unpaid mana.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "7157f9fc-c989-5f60-b894-8305f9cdfc7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b342dd3-09b9-4108-bf12-a65d4cef4eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b342dd3-09b9-4108-bf12-a65d4cef4eb9.jpg?1",
             "name": "Power Sink",
             "text": "Target spell is countered unless its caster spends X more mana; caster of target spell can't choose to let it be countered. If caster of target spell doesn't have enough mana, all available mana from lands and mana pool must be paid but target spell will still be countered.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "7a874dfe-b338-5ea0-884f-9f5c777ec1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dc1103-7bf1-47f6-9006-d3ed9ccd7a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dc1103-7bf1-47f6-9006-d3ed9ccd7a6a.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "Tap to do 1 damage to any target.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "477c092f-c30f-5d95-b7bd-bf25cdd31c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a86e6e-bfff-46af-9d36-c912901fea92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a86e6e-bfff-46af-9d36-c912901fea92.jpg?1",
             "name": "Psionic Blast",
             "text": "Psionic Blast does 4 damage to any target, but it does 2 damage to you as well.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "63ebd8c5-6779-504a-b248-0bdf6ccdf2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f5b68a-6b0e-431e-89f0-ff60f17687a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f5b68a-6b0e-431e-89f0-ff60f17687a5.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever target land is tapped, Psychic Venom does 2 damage to target land's controller.",
             "colours": [
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "f9bc9c80-659a-53f1-8fe4-981bff249836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b333b7-db4d-4439-b0de-60414cbf8d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b333b7-db4d-4439-b0de-60414cbf8d7b.jpg?1",
             "name": "Sea Serpent",
             "text": "Serpent cannot attack unless opponent has islands in play.\nSerpent is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "09224989-61eb-5508-8361-79f7413f9703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d992b336-3b6e-43e1-8662-d85664349b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d992b336-3b6e-43e1-8662-d85664349b44.jpg?1",
             "name": "Siren's Call",
             "text": "All of opponent's creatures that can attack must do so. Any non-wall creatures that cannot attack are destroyed at end of turn. Play only during opponent's turn, before opponent's attack. Creatures summoned this turn are unaffected by Siren's Call.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "0ca9de33-b216-5db1-8199-9b004b1f0a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427790c-e322-446e-8d7d-a6b48ad41a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427790c-e322-446e-8d7d-a6b48ad41a42.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of any card being played or already in play by replacing one color word with another. For example, you can change \"Counters red spells\" to \"Counters black spells.\" Cannot change mana symbols.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "31371fdf-4292-54a0-a138-87b07d020ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845734da-ab03-4dbc-bb5f-96481d3b8e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845734da-ab03-4dbc-bb5f-96481d3b8e88.jpg?1",
             "name": "Spell Blast",
             "text": "Target spell is countered; X is cost of target spell.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "906eab23-4f12-5ce0-b88d-890ba533e47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cef408-5b4b-49f6-9531-be544815b93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cef408-5b4b-49f6-9531-be544815b93f.jpg?1",
             "name": "Stasis",
             "text": "Players do not get an untap phase. Pay o\nU during your upkeep or Stasis is destroyed.",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "29ca858e-31f0-5e75-bba3-bb7a45d9bee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83316930-d6ad-46ce-9b40-48eea856d95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83316930-d6ad-46ce-9b40-48eea856d95b.jpg?1",
             "name": "Steal Artifact",
             "text": "You control target artifact until enchantment is discarded or game ends. If target artifact was tapped when stolen, it stays tapped until you can untap it. If destroyed, target artifact is put in its owner's graveyard.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "05cbd19a-d524-5109-8df1-75dea6269186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23749375-1416-47a4-9251-52f41fe2fae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23749375-1416-47a4-9251-52f41fe2fae9.jpg?1",
             "name": "Thoughtlace",
             "text": "Changes the color of one card either being played or already in play to blue. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "daae9119-9316-538f-b9ae-ba871f5cb185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0139f60-d48e-46fb-9f5a-1e3d7558c834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0139f60-d48e-46fb-9f5a-1e3d7558c834.jpg?1",
             "name": "Time Walk",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "6306bc8b-629a-5487-828c-b3d757972728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a49dc44-616e-4bdd-8220-0bb71eccc512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a49dc44-616e-4bdd-8220-0bb71eccc512.jpg?1",
             "name": "Timetwister",
             "text": "Set Timetwister aside in a new graveyard pile. Shuffle your hand, library, and graveyard together into a new library and draw a new hand of seven cards, leaving all cards in play where they are; opponent must do the same.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "1853ba5e-1859-5f9b-8aa7-bc434b34a4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e811f-26a3-4a7c-bd13-3b1cc3e184eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e811f-26a3-4a7c-bd13-3b1cc3e184eb.jpg?1",
             "name": "Twiddle",
             "text": "Caster may tap or untap any one land, creature, or artifact in play.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "888c0ccc-2de9-50c7-9bb1-175880894460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8512f2c1-6361-4b79-843f-80b6bceeeb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8512f2c1-6361-4b79-843f-80b6bceeeb99.jpg?1",
             "name": "Unsummon",
             "text": "Return creature to owner's hand; enchantments on creature are CARD ed. Unsummon cannot be played during the damage-dealing phase of an attack.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "2561a0da-cb24-5246-bd0f-52e4b1ccbde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768f3a05-bd06-4a23-b9f2-94f6e618fd9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768f3a05-bd06-4a23-b9f2-94f6e618fd9f.jpg?1",
             "name": "Vesuvan Doppelganger",
             "text": "Upon summoning, Doppelganger acquires all normal characteristics (except color) of any one creature in play on either side; any enchantments on the original creature are not copied. During controller's upkeep, Doppelganger may take on the characteristics of a different creature in play instead. Doppelganger may continue to copy a creature even after that creature leaves play, but if it switches it won't be able to switch back.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "5d1822d2-b796-551b-b8db-0d7ca279dd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80582b1-09db-45f8-b362-0e5207a5a8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80582b1-09db-45f8-b362-0e5207a5a8e6.jpg?1",
             "name": "Volcanic Eruption",
             "text": "Destroys X mountains of your choice, and does X damage to each player and each creature in play.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "e94ce1de-53e7-589c-b264-8826780bd7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da56fdf3-6a8f-4833-a5c3-197650cc4889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da56fdf3-6a8f-4833-a5c3-197650cc4889.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "08913973-f7d6-52c7-b113-ca317a8d84e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41faed1a-ded8-49ee-8e2a-c60d377775d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41faed1a-ded8-49ee-8e2a-c60d377775d7.jpg?1",
             "name": "Wall of Water",
             "text": "oo\nU +1/+0 until end of turn.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "29d37155-b404-5972-a4b4-de7c1d57d552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de940d6-98c0-46a9-b5fd-e2b0899ea19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de940d6-98c0-46a9-b5fd-e2b0899ea19e.jpg?1",
             "name": "Water Elemental",
             "text": "",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "a5421ca2-32e5-5b31-bc12-979c626fc6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd7861d-925f-4b4c-a4ab-60be6f43d50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd7861d-925f-4b4c-a4ab-60be6f43d50b.jpg?1",
             "name": "Animate Dead",
             "text": "Any creature in either player's graveyard comes into play on your side with -1 to its original power. If this enchantment is removed, or at end of game, target creature is returned to its owner's graveyard. Target creature may be killed as normal.",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "460935e9-fb06-5a06-98ba-e0b2883c01ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43572906-ea74-4411-a549-5dc401591d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43572906-ea74-4411-a549-5dc401591d2a.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures in play gain +1/+1.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "79be3c98-be7a-5d7e-b7e3-1174b6dafa03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1662949-0d69-49a3-8c69-daf10717ed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1662949-0d69-49a3-8c69-daf10717ed4e.jpg?1",
             "name": "Black Knight",
             "text": "Protection from white, first strike",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "e9d3658d-3b1f-586c-ae28-fc571620e0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701874e-986e-4b81-9268-90b6171e6187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701874e-986e-4b81-9268-90b6171e6187.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "cee140cd-3ed0-536e-9a5e-aeb41cbb2f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9853b0ce-4763-4877-9741-f9145a3659c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9853b0ce-4763-4877-9741-f9145a3659c6.jpg?1",
             "name": "Contract from Below",
             "text": "Discard your current hand and draw eight new cards, adding the first drawn to your ante. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "4dc84cea-65a5-5f08-b764-46516d15e92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5f3c61-1e54-4eea-bf82-311cfa988e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5f3c61-1e54-4eea-bf82-311cfa988e6a.jpg?1",
             "name": "Cursed Land",
             "text": "Cursed Land does 1 damage to target land's controller during each upkeep.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "508ac644-b955-5708-80e5-bcdc36e12e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb6664d-23ca-456e-9916-afcd6f26aa7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb6664d-23ca-456e-9916-afcd6f26aa7f.jpg?1",
             "name": "Dark Ritual",
             "text": "Add 3 black mana to your mana pool.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "0bc207f2-a026-5163-b065-cae388c2a7cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78db688-93a2-47f5-9aa5-9158a72cd973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78db688-93a2-47f5-9aa5-9158a72cd973.jpg?1",
             "name": "Darkpact",
             "text": "Without looking at it first, swap top card of your library with either card of the ante; this swap is permanent. You must have a card in your library to cast this spell. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "f9e9b0f1-8869-5da9-8ad7-dc81681f9913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371c126-f19a-472a-ba5f-3b1366274ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371c126-f19a-472a-ba5f-3b1366274ea0.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Destroy a green spell as it is being cast. This action may be played as an interrupt, and does not affect green cards already in play.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "33c9d266-9aa0-53d2-8fdc-f82ca024ad21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff1cefc-62cb-4525-b0c5-2b09603b4314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff1cefc-62cb-4525-b0c5-2b09603b4314.jpg?1",
             "name": "Deathlace",
             "text": "Changes the color of one card either being played or already in play to black. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "ac4202e5-116b-552f-a03a-c6023db2cfe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd891fc6-d9d6-494e-ae65-8bea8f44b575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd891fc6-d9d6-494e-ae65-8bea8f44b575.jpg?1",
             "name": "Demonic Attorney",
             "text": "If opponent doesn't concede the game immediately, each player must ante an additional card from the top of his or her library. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "eb7ab5c5-70ac-5081-b9dd-a218e6ff8f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9bb8b1-fb79-4b99-ba09-c6e6c860de50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9bb8b1-fb79-4b99-ba09-c6e6c860de50.jpg?1",
             "name": "Demonic Hordes",
             "text": "Tap to destroy 1 land. Pay o\nBo\nBo\nB during upkeep or the Hordes become tapped and you lose a land of opponent's choice.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "09ba97e8-43f1-5288-8703-b10f7c1afec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711d4d54-5520-4de8-9b93-79902ed8e562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711d4d54-5520-4de8-9b93-79902ed8e562.jpg?1",
             "name": "Demonic Tutor",
             "text": "You may search your library for one card and take it into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "4d49377c-186e-5ee5-b7ba-bf2ace531292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d077a49-73d4-4958-b42a-31b814e110e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d077a49-73d4-4958-b42a-31b814e110e8.jpg?1",
             "name": "Drain Life",
             "text": "Drain Life does 1 damage to a single target for each B spent in addition to the casting cost. Caster gains 1 life for each damage inflicted. If you drain life from a creature, you cannot gain more life than the creature's toughness.",
             "colours": [
@@ -3371,7 +3371,7 @@
         },
         {
             "id": "d001d4f4-6312-5bb1-8621-ce580507c406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23614289-0d73-4747-a849-5cb67cc97d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23614289-0d73-4747-a849-5cb67cc97d6a.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "0ec1cbb1-e7f6-5196-b6a7-53eaa2fb8f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0551d66e-8cd4-48f0-aa17-15f26be9d85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0551d66e-8cd4-48f0-aa17-15f26be9d85f.jpg?1",
             "name": "Evil Presence",
             "text": "Target land is now a swamp.",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "06f4a6aa-babf-542c-aa8c-f7c569997001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd927be-e63f-4371-a1d8-7a0489cb187e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd927be-e63f-4371-a1d8-7a0489cb187e.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked by any creatures other than artifact creatures and black creatures.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "ac39a7ba-8c4a-5459-9657-d6c5f7d45895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bd76c8-4cff-4c15-9686-7a299b589814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bd76c8-4cff-4c15-9686-7a299b589814.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "af4f979d-ba13-5cec-a788-89f0616e7917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d10bc7-daeb-4c0d-9e4a-8eae8d11699f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d10bc7-daeb-4c0d-9e4a-8eae8d11699f.jpg?1",
             "name": "Gloom",
             "text": "White spells cost 3 more mana to cast. Circles of Protection cost 3 more mana to use.",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "c4737240-d764-5e55-b5d1-24ed6083978a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ec17e1-174b-4d07-a27f-91a333c4b2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ec17e1-174b-4d07-a27f-91a333c4b2fb.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gains +X/+0 until end of turn.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "8b2db882-51f7-581c-ac85-117c87647d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b900f-2d9b-442b-9699-058483604ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b900f-2d9b-442b-9699-058483604ec9.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nAn opponent damaged by Specter must discard a card at random from his or her hand. Ignore this effect if opponent has no cards left in hand.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "52c72312-401b-5441-a6a8-d0d5f4e4955f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4250caec-0e37-41be-9ec4-8938deb5f0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4250caec-0e37-41be-9ec4-8938deb5f0d0.jpg?1",
             "name": "Lich",
             "text": "You lose all life. If you gain life later in the game, instead draw one card from your library for each life. For each point of damage you suffer, you must destroy one of your cards in play. Creatures destroyed in this way cannot be regenerated. You lose if this enchantment is destroyed or if you suffer a point of damage without sending a card to the graveyard.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "0d47279a-a159-53ac-9185-24189ed8ecf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2926777a-4f6e-4965-ba83-22cf7df02602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2926777a-4f6e-4965-ba83-22cf7df02602.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nYou must sacrifice one of your own creatures during upkeep or Lord of the Pit does 7 damage to you. You may still attack with Lord of the Pit even if you failed to sacrifice a creature.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "54896cc7-cdfd-578b-9869-777d06d0a8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9e106-a248-49d2-b8c8-6bbcd56ce739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9e106-a248-49d2-b8c8-6bbcd56ce739.jpg?1",
             "name": "Mind Twist",
             "text": "Opponent must discard X cards at random from hand. If opponent doesn't have enough cards in hand, entire hand is discarded.",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "9f1d1b9a-a7ac-5749-9506-d79cd1fe4592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ad58a-6f9b-420a-bac1-40929f5e616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ad58a-6f9b-420a-bac1-40929f5e616a.jpg?1",
             "name": "Nether Shadow",
             "text": "If Shadow is in graveyard with any combination of cards above it that includes at least three creatures, it can be returned to play during upkeep for its normal casting cost. Shadow can attack on same turn summoned or returned to play.",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "88eb5732-3937-519a-b5f0-771669428bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8105973c-a94d-444c-ba20-ab0fa978bee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8105973c-a94d-444c-ba20-ab0fa978bee8.jpg?1",
             "name": "Nettling Imp",
             "text": "Tap to force a particular one of opponent's non-wall creatures to attack. If target creature cannot attack, it is destroyed at end of turn. This tap should be played during opponent's turn, before the attack. May not be used on creatures summoned this turn.",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "96e1d01d-5d3c-5b36-b1ee-e6e77ebb45ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cdd6a7-f772-4ccb-914f-63f52ed54d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cdd6a7-f772-4ccb-914f-63f52ed54d6b.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness both equal the number of swamps its controller has in play.",
             "colours": [
@@ -3793,7 +3793,7 @@
         },
         {
             "id": "42d4be3c-97e9-5f54-a585-68aa27f8bc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be33a155-de26-43d1-88f1-c926f1b7cb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be33a155-de26-43d1-88f1-c926f1b7cb7c.jpg?1",
             "name": "Paralyze",
             "text": "Target creature is not untapped as normal during untap phase unless 4 mana are spent. Tap target creature when Paralyze is cast.",
             "colours": [
@@ -3826,7 +3826,7 @@
         },
         {
             "id": "3a6a0d86-c65c-5623-99ca-0de799e5bdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a6350-b16b-4e10-a273-e6cbb55dcb7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a6350-b16b-4e10-a273-e6cbb55dcb7a.jpg?1",
             "name": "Pestilence",
             "text": "oo\nB Do 1 damage to each creature and to both players. Pestilence must be discarded at end of any turn in which there are no creatures in play at end of turn.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "52bdd23d-6a8f-5101-80c9-68b9d888055f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3724e40-0622-4aee-9334-6c9fff88bcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3724e40-0622-4aee-9334-6c9fff88bcd5.jpg?1",
             "name": "Plague Rats",
             "text": "The Xs below are the number of Plague Rats in play, counting both sides. Thus if there are 2 Plague Rats in play, each has power and toughness 2/2.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "353d0742-ac6c-5c57-99bb-d9936e8604d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce07bede-2219-427c-a61a-56518751de42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce07bede-2219-427c-a61a-56518751de42.jpg?1",
             "name": "Raise Dead",
             "text": "Return creature from your graveyard to your hand.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "764d1489-df08-5a67-a8da-5c48b23ab25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59590768-fa96-4869-8763-9d5ab6ac22ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59590768-fa96-4869-8763-9d5ab6ac22ad.jpg?1",
             "name": "Royal Assassin",
             "text": "Tap to destroy any tapped creature.",
             "colours": [
@@ -3955,7 +3955,7 @@
         },
         {
             "id": "3cda4428-1519-577a-8c5a-fa88f8e96eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12164aee-6a27-4246-8d15-2d6dd20d92e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12164aee-6a27-4246-8d15-2d6dd20d92e9.jpg?1",
             "name": "Sacrifice",
             "text": "Destroy one of your creatures without regenerating it, and add to your mana pool a number of black mana equal to black creature's casting cost.",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "cb7125d4-0821-56ea-84da-2b96f105da6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be6dcf-5e25-4b8c-9cd0-badf3771f81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be6dcf-5e25-4b8c-9cd0-badf3771f81e.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -4019,7 +4019,7 @@
         },
         {
             "id": "ec8d49a5-0c45-5b5b-a865-6fef793d963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426984e0-88e1-4a2d-9a1c-798b95864df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426984e0-88e1-4a2d-9a1c-798b95864df3.jpg?1",
             "name": "Scavenging Ghoul",
             "text": "At the end of each turn, put one counter on the Ghoul for each other creature that was destroyed without regenerating during the turn. If Ghoul dies, you may use a counter to regenerate it; counters remain until used.",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "1b8edacc-510b-5355-8db5-44763f995bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/510840f4-7c0e-4b47-8ebf-23c20cac4bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/510840f4-7c0e-4b47-8ebf-23c20cac4bd9.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nVampire gets a +1/+1 counter each time a creature dies during a turn in which Vampire damaged it, unless the dead creature is regenerated.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "effd01ab-78f5-51c0-b4db-3850d8b66bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c3a78d-cc79-4187-929a-8aa1d1469990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c3a78d-cc79-4187-929a-8aa1d1469990.jpg?1",
             "name": "Simulacrum",
             "text": "All damage done to you so far this turn is instead retroactively applied to one of your creatures in play. If this damage kills the creature it can be regenerated; even if there's more than enough damage to kill the creature, you don't suffer any of it. Further damage this turn is treated normally.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "962e3157-5720-5b9c-a4ea-9527fdfbb606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b31611-9053-4eaf-b392-21bb644fef5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b31611-9053-4eaf-b392-21bb644fef5f.jpg?1",
             "name": "Sinkhole",
             "text": "Destroys any one land.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "0a46dd05-7bb0-5f29-9a15-af9601cacbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21004958-2c7e-4a55-bc80-411c4d780106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21004958-2c7e-4a55-bc80-411c4d780106.jpg?1",
             "name": "Terror",
             "text": "Destroys target creature without possibility of regeneration. Does not affect black creatures and artifact creatures.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "ef192ed1-2f4a-527e-b3ec-1129b4bf822b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90563f90-0127-4164-b43b-f0321dc63a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90563f90-0127-4164-b43b-f0321dc63a1d.jpg?1",
             "name": "Unholy Strength",
             "text": "Target creature gains +2/+1.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "b4717a30-5747-501f-970c-b9c35b8ae274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae20d442-a544-4a03-9ebf-5ecb137c67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae20d442-a544-4a03-9ebf-5ecb137c67dd.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "4862a946-679b-5305-ab8a-e40776851727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e07a2-fbdf-4c4c-996a-fce40bab5de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e07a2-fbdf-4c4c-996a-fce40bab5de5.jpg?1",
             "name": "Warp Artifact",
             "text": "Warp Artifact does 1 damage to target artifact's controller at start of each turn.",
             "colours": [
@@ -4278,7 +4278,7 @@
         },
         {
             "id": "f7b537bb-ec8e-5894-9ec8-12239fc95a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ca06a1-9b9a-49a2-9c47-9b72228621bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ca06a1-9b9a-49a2-9c47-9b72228621bc.jpg?1",
             "name": "Weakness",
             "text": "Target creature loses -2/-1; if this drops the creature's toughness below 1, it is dead.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "42cada5b-dbdf-5840-9001-4a935c176417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6f8e9-7bc1-4151-b55f-acf877b1a7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6f8e9-7bc1-4151-b55f-acf877b1a7a6.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying; oo\nB Regenerates",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "f43fc579-c9ea-576f-966e-b2275ce19eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c21429-98d3-416b-be00-6aa9c4c5a006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c21429-98d3-416b-be00-6aa9c4c5a006.jpg?1",
             "name": "Word of Command",
             "text": "You may look at opponent's hand and choose any card opponent can legally play using mana from his or her mana pool or lands. Opponent must play this card immediately; you make all the decisions it calls for. This spell may not be countered after you have looked at opponent's hand.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "8bc67a2a-9df2-5f27-a372-266cb978c485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4255a0-d445-4c00-b936-bbf07851e1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4255a0-d445-4c00-b936-bbf07851e1c8.jpg?1",
             "name": "Zombie Master",
             "text": "All zombies in play gain swampwalk and \"oo\nB Regenerates\" for as long as this card remains in play.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "7aec3b0e-923c-5af6-9d00-49d33e9089a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c05e4-8df3-450b-8a98-5028e73b14c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c05e4-8df3-450b-8a98-5028e73b14c1.jpg?1",
             "name": "Burrowing",
             "text": "Target creature gains mountainwalk.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "d2eeffa5-34f1-5daf-b9e1-c39e3f2b7a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ea2048-57bc-43d5-8987-33ca727f1a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ea2048-57bc-43d5-8987-33ca727f1a97.jpg?1",
             "name": "Chaoslace",
             "text": "Changes the color of one card either being played or already in play to red. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "f39505a8-56c6-52c9-937d-a9888a13ea71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8712c49e-f171-4669-bed9-87575a37af11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8712c49e-f171-4669-bed9-87575a37af11.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate does X damage to one target. If target dies this turn, it is removed from game entirely and cannot be regenerated. Return target to its owner's deck only when game is over.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "4a9490f1-0ef2-58c6-900f-1843bdac02ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf1eab-bc32-4835-b566-8634b1fe81b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf1eab-bc32-4835-b566-8634b1fe81b0.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\noo\nR +1/+0 until end of turn; if more than o\nRo\nRo\nR is spent in this way, Dragon Whelp is destroyed at end of turn.",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "347fb6f4-843f-5838-b594-800fb74f3d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03482c9c-1f25-4d73-9243-17462ea37ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03482c9c-1f25-4d73-9243-17462ea37ac4.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "Tap to destroy a wall.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "0ab08584-90c8-5e25-8864-5cf41efe9e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4d87a3-5f8b-4152-9a8b-538ab49d62e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4d87a3-5f8b-4152-9a8b-538ab49d62e8.jpg?1",
             "name": "Dwarven Warriors",
             "text": "Tap to make a creature of power no greater than 2 unblockable until end of turn. Other cards may be used to increase target creature's power beyond 2 after defense is chosen.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "f6b8cd82-851f-5ebc-b345-be774439fa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b5864-44c0-4bc8-8705-9504f83b2c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b5864-44c0-4bc8-8705-9504f83b2c03.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "a5cceeaa-a07b-5401-80e6-4b684ae45cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d492b7-b0b3-420e-8d00-6dacb11de77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d492b7-b0b3-420e-8d00-6dacb11de77e.jpg?1",
             "name": "Earthbind",
             "text": "Earthbind does 2 damage to target flying creature, which also loses flying ability.",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "e1356b6c-0173-5076-ae61-e5a8932e8f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68ac362-6cdc-48a6-bdd3-4f8ea32add64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68ac362-6cdc-48a6-bdd3-4f8ea32add64.jpg?1",
             "name": "Earthquake",
             "text": "Does X damage to each player and each non-flying creature in play.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "7f6a554a-b169-50ed-875b-64b8af6944c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb71ac4-796d-4011-9002-1129bc09c284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb71ac4-796d-4011-9002-1129bc09c284.jpg?1",
             "name": "False Orders",
             "text": "You decide whether and how one defending creature blocks, though you can't make a choice the defender couldn't legally make. Play after defender has chosen defense but before damage is dealt.",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "174f78a0-6094-5ca6-ad04-a9c97aec6f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da237992-2919-4e37-8f56-2164095f59b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da237992-2919-4e37-8f56-2164095f59b5.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4764,7 +4764,7 @@
         },
         {
             "id": "195d63e4-3ad8-5ac0-8e20-1bccc8e1d390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7623c00-144b-4a8f-9c6c-f5e9e4f65ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7623c00-144b-4a8f-9c6c-f5e9e4f65ece.jpg?1",
             "name": "Fireball",
             "text": "Fireball does X damage total, divided evenly (round down) among any number of targets. Pay 1 extra mana for each target beyond the first.",
             "colours": [
@@ -4795,7 +4795,7 @@
         },
         {
             "id": "aed82be0-1119-5e14-901c-3a0a634698a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb27381-505d-4e47-bf66-9e7ba91a5075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb27381-505d-4e47-bf66-9e7ba91a5075.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR +1/+0",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "b84e0ae2-8059-57bc-9f96-3cce76badc38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a05a4-0ce3-4abe-bb60-08af53cf08e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a05a4-0ce3-4abe-bb60-08af53cf08e5.jpg?1",
             "name": "Flashfires",
             "text": "All plains in play are destroyed.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "15e40e30-e542-5bb7-8a47-883a71e6f15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b43916-fe2d-417a-a550-d7c795023297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b43916-fe2d-417a-a550-d7c795023297.jpg?1",
             "name": "Fork",
             "text": "Any sorcery or instant spell just cast is doubled. Treat Fork as an exact copy of target spell except that Fork remains red. Copy and original may have different targets.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "3a8b0b9d-ce12-5182-a70d-481fc4d01fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5129b422-7a35-4bc5-b14b-c814012a0d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5129b422-7a35-4bc5-b14b-c814012a0d8f.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "oo\nR Goblins gain flying ability until end of turn. Controller may not choose to make Goblins fly after they have been blocked.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "dde409a5-9a3a-568b-8612-4d3ff1915f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5873672d-37ea-4c0f-97f3-12b74fde112d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5873672d-37ea-4c0f-97f3-12b74fde112d.jpg?1",
             "name": "Goblin King",
             "text": "Goblins in play gain mountainwalk and +1/+1 while this card remains in play.",
             "colours": [
@@ -4957,7 +4957,7 @@
         },
         {
             "id": "9ef18237-6f91-5e42-8b25-5734b28756db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf2b2-6848-4fbd-b89a-8d8da8ae1cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf2b2-6848-4fbd-b89a-8d8da8ae1cdc.jpg?1",
             "name": "Granite Gargoyle",
             "text": "Flying; oo\nR +0/+1 until end of turn.",
             "colours": [
@@ -4990,7 +4990,7 @@
         },
         {
             "id": "e82a4022-c732-511b-82ec-9c4f732a7a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ae5276-b607-4f23-a9d2-e8cc7b8e3693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ae5276-b607-4f23-a9d2-e8cc7b8e3693.jpg?1",
             "name": "Gray Ogre",
             "text": "",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "a7955714-78cc-5230-83d0-eb3bd2aa01c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddb98e8-13fe-4786-83f7-b72c56db135a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddb98e8-13fe-4786-83f7-b72c56db135a.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -5056,7 +5056,7 @@
         },
         {
             "id": "04a1cf0c-7c18-59ed-80fa-b58d3230c3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a9088f-8755-47cb-aa93-51d992ccab90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a9088f-8755-47cb-aa93-51d992ccab90.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -5089,7 +5089,7 @@
         },
         {
             "id": "3d471026-1fca-52ec-a2be-3f7a04fc4fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56421a8-34ae-4033-943f-c59a7bf2b6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56421a8-34ae-4033-943f-c59a7bf2b6f9.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Cannot be used to block any creature of power more than 1.",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "30707455-efcd-5433-b61f-ac041fd984f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3fd83-969c-4add-888f-86f4306b067c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3fd83-969c-4add-888f-86f4306b067c.jpg?1",
             "name": "Keldon Warlord",
             "text": "The Xs below are the number of non-wall creatures on your side, including Warlord. Thus if you have 2 other non-wall creatures, Warlord is 3/3. If one of those creatures is killed during the turn, Warlord immediately becomes 2/2.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "c65fcd18-dc47-50d4-bdb1-518bbf0ef820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573ef03-4730-45aa-93dd-e45ac1dbaf4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573ef03-4730-45aa-93dd-e45ac1dbaf4a.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt does 3 damage to one target.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "1d0129d0-c309-5cfd-8bfa-eaf6c23769e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb99a26-beeb-4aca-bb02-b2d2ce0595f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb99a26-beeb-4aca-bb02-b2d2ce0595f9.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever either player taps land for mana, each land produces 1 extra mana of the appropriate type.",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "0babd4f5-5eb3-50a8-ad2c-8891c613cf25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6121f72f-680f-4bb4-ae4d-37ee4ebed4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6121f72f-680f-4bb4-ae4d-37ee4ebed4d8.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever any land is tapped, Manabarbs does 1 damage to the land's controller.",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "0581bf53-8935-5476-b230-08e75da69aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4eb3db3-6a7c-488a-9433-d5d1d3133816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4eb3db3-6a7c-488a-9433-d5d1d3133816.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -5282,7 +5282,7 @@
         },
         {
             "id": "d0b91299-b163-54a9-9ba8-6cb0e43e5e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97208b1-a91b-4129-8a00-2f97b418accc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97208b1-a91b-4129-8a00-2f97b418accc.jpg?1",
             "name": "Orcish Artillery",
             "text": "Tap to do 2 damage to any target, but you suffer 3 damage as well.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "83c72bb2-5cdf-5a61-849e-751fe7516448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911538ea-322c-4c40-a9c3-35e47fe60fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911538ea-322c-4c40-a9c3-35e47fe60fce.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "When attacking, all of your attacking creatures gain +1/+0.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "72ab1ee8-662f-5189-ad60-93e961d10e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62858604-ca5a-4f69-a045-a7515ebfabf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62858604-ca5a-4f69-a045-a7515ebfabf2.jpg?1",
             "name": "Power Surge",
             "text": "Before untapping lands at the start of a turn, each player takes 1 damage for each land he or she controls but did not tap during the previous turn.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "28a8715a-6372-5462-80a5-737e42f57150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e4f56d-1f4f-49f2-8534-0d09196a3327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e4f56d-1f4f-49f2-8534-0d09196a3327.jpg?1",
             "name": "Raging River",
             "text": "When you attack, non-flying defending creatures must be divided as opponent wishes between the left and right sides of the River. You then choose on which side of the River to place each attacking creature, and attacking creatures can only be blocked by flying creatures or those on the same side of the River.",
             "colours": [
@@ -5409,7 +5409,7 @@
         },
         {
             "id": "412bfec8-a55f-594f-ac19-0ce6204afc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776ad9be-3309-4f1d-9f27-6219d9477662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776ad9be-3309-4f1d-9f27-6219d9477662.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Counters a blue spell being cast or destroys a blue card in play.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "729e7476-95e1-52d7-90ae-be95f0f53798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/731a4b86-c213-4d8e-bf01-0a0e8cff0ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/731a4b86-c213-4d8e-bf01-0a0e8cff0ff1.jpg?1",
             "name": "Roc of Kher Ridges",
             "text": "Flying",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "2eb79bb1-e34c-5303-b1ef-38710f4e89fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410ac9e6-fbc1-4cc8-84db-84e2eb1bab97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410ac9e6-fbc1-4cc8-84db-84e2eb1bab97.jpg?1",
             "name": "Rock Hydra",
             "text": "Put X +1/+1 counters (heads) on Hydra. Each point of damage Hydra suffers destroys one head unless R is spent. During upkeep, new heads may be grown for o\nRo\nRo\nR apiece.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "d322346d-70c8-5cf5-9cf9-7e1293aa4a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13bf496-f3c0-4c13-8282-e7abfab6a198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13bf496-f3c0-4c13-8282-e7abfab6a198.jpg?1",
             "name": "Sedge Troll",
             "text": "Troll gains +1/+1 if controller has any swamps in play. oo\nB Regenerates",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "d7d630fc-cc86-53ae-87b3-853a78164950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50dc7fc1-cb6a-4c68-b993-1a25cf16226e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50dc7fc1-cb6a-4c68-b993-1a25cf16226e.jpg?1",
             "name": "Shatter",
             "text": "Shatter destroys target artifact.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "87188ba2-baa8-538c-baf4-debdc3c29edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefbf149-f988-4f8b-9f53-56f5878116a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefbf149-f988-4f8b-9f53-56f5878116a6.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying, oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "75dea13c-11ac-530e-b1c9-383bc6129329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67788e-d713-47c3-ab9f-b8a6212ae24f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67788e-d713-47c3-ab9f-b8a6212ae24f.jpg?1",
             "name": "Smoke",
             "text": "Each player can only untap one creature during his or her untap phase.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "180c774b-6d75-5758-ab6a-0c0dca7bba6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaedb9-25f8-4304-9085-e12505b93312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaedb9-25f8-4304-9085-e12505b93312.jpg?1",
             "name": "Stone Giant",
             "text": "Tap to make one of your own creatures a flying creature until end of turn. Target creature, which must have toughness less than Stone Giant's power, is destroyed at end of turn.",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "38833469-bac9-5edf-ab12-3182e4aad7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ff74cb-a2ed-4123-ac42-f72f9820049e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ff74cb-a2ed-4123-ac42-f72f9820049e.jpg?1",
             "name": "Stone Rain",
             "text": "Destroys any one land.",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "03fdba94-cbe3-5422-9832-ecd9a41d3a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21ebc9f-a93e-4d18-b3e8-8459e3abbf31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21ebc9f-a93e-4d18-b3e8-8459e3abbf31.jpg?1",
             "name": "Tunnel",
             "text": "Destroys 1 wall. Target wall cannot be regenerated.",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "3384d608-23a3-51ab-8009-c111787d6a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c687dc-ee0c-4e54-a2b3-5d8e633b3245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c687dc-ee0c-4e54-a2b3-5d8e633b3245.jpg?1",
             "name": "Two-Headed Giant of Foriys",
             "text": "Trample\nMay block two attacking creatures; divide damage between them however controller likes.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "7d8283ea-b60e-5d4f-8505-9717492f7f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff21a6f-83a7-4bf3-a078-294e303232cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff21a6f-83a7-4bf3-a078-294e303232cc.jpg?1",
             "name": "Uthden Troll",
             "text": "oo\nR Regenerates",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "c5fd5a58-1445-557c-85bb-e76f655542ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf12cd-fb70-444e-9641-73ffa0e8f16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf12cd-fb70-444e-9641-73ffa0e8f16e.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "ad4195d1-31cb-5e00-b559-da852b67e674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140e567c-6e4a-42b0-8084-d6c9695ae802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140e567c-6e4a-42b0-8084-d6c9695ae802.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "4ae3911d-f48e-5218-adc5-bb79f917c6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b369c4-faa8-45c8-a1b9-98f228b69682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b369c4-faa8-45c8-a1b9-98f228b69682.jpg?1",
             "name": "Wheel of Fortune",
             "text": "Both players must discard their hands and draw seven new cards.",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "ee469ce3-fa83-5890-9311-50774b3e199d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9ac9e6-1395-4fbd-80e2-645f0d910c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9ac9e6-1395-4fbd-80e2-645f0d910c29.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Target creature's power and toughness are increased by half the number of forests you have in play, rounding down for power and up for toughness.",
             "colours": [
@@ -5926,7 +5926,7 @@
         },
         {
             "id": "9a4936c7-2b0d-5043-ae37-9d6ed48b950a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e173c8ce-2352-405e-ad00-e3bb94ced1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e173c8ce-2352-405e-ad00-e3bb94ced1ad.jpg?1",
             "name": "Berserk",
             "text": "Until end of turn, target creature's current power doubles and it gains trample ability. If it attacks, target creature is destroyed at end of turn. This spell cannot be cast after current turn's attack is completed.",
             "colours": [
@@ -5957,7 +5957,7 @@
         },
         {
             "id": "e9cb448e-c625-5b5e-b6b4-8eed9a359834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fe6449-1f23-43dc-adee-d144cd505b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fe6449-1f23-43dc-adee-d144cd505b5c.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying// Tap to add one mana of any color to your mana pool. This tap may be played as an interrupt.",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "19b63ade-88e7-5c10-91fd-34e62e9d7251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3838c2a3-7fab-4976-9c1b-2891aee24e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3838c2a3-7fab-4976-9c1b-2891aee24e52.jpg?1",
             "name": "Camouflage",
             "text": "You may rearrange your attacking creatures and place them face down, revealing which is which only after defense is chosen. If this results in impossible blocks, such as non-flying creatures blocking flying creatures, illegal blockers cannot block this turn.",
             "colours": [
@@ -6021,7 +6021,7 @@
         },
         {
             "id": "5519d329-90ca-5fc0-896e-1f17a83a36df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1862c47-71cc-45a3-8805-a5ddc62e55ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1862c47-71cc-45a3-8805-a5ddc62e55ea.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, you may add colorless mana to your mana pool for 1 life each. These additions are played with the speed of an interrupt. Life spent this way is not considered damage.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "0c2c0ea4-fc9f-5c2c-b32b-630d1fc3eb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd91814-6177-4a3d-a1c1-a3be7d7c7957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd91814-6177-4a3d-a1c1-a3be7d7c7957.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nAny non-wall creature blocking Cockatrice is destroyed, as is any creature blocked by Cockatrice. Creatures destroyed in this way deal their damage before dying.",
             "colours": [
@@ -6085,7 +6085,7 @@
         },
         {
             "id": "b859e07a-6506-59ad-9ddb-449a15c79fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfed1a95-bd67-4e16-a781-81866028af2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfed1a95-bd67-4e16-a781-81866028af2f.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "c0512381-6e2d-533e-94ee-43f1a7bf9fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb9d405-f2b5-4e10-a405-feafd2a87d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb9d405-f2b5-4e10-a405-feafd2a87d90.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -6152,7 +6152,7 @@
         },
         {
             "id": "a3249a03-d73f-55c0-b27d-aa7dd000434d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a575a9af-e1de-4a1d-91d8-440585377e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a575a9af-e1de-4a1d-91d8-440585377e4f.jpg?1",
             "name": "Fastbond",
             "text": "You may put as many lands into play as you want each turn. Fastbond does 1 damage to you for every land beyond the first that you play in a single turn.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "ef85fb5f-8cab-5f69-9dd2-59f6782cb848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba606d-bb55-43ba-aa0c-299649958788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba606d-bb55-43ba-aa0c-299649958788.jpg?1",
             "name": "Fog",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is dealt.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "e0aedb56-be8f-50e7-99de-274c4bb2e91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21551cb6-3a53-42dd-9bbd-4bc56304d6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21551cb6-3a53-42dd-9bbd-4bc56304d6d3.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nYou must pay o\nGo\nGo\nGo\nG during upkeep or Force of Nature does 8 damage to you. You may still attack with Force of Nature even if you failed to pay the upkeep.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "d087d94e-05dd-559b-b2ea-fdb9c65e9a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad89f0d-b09b-40a0-84d6-3ee60dec7e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad89f0d-b09b-40a0-84d6-3ee60dec7e23.jpg?1",
             "name": "Fungusaur",
             "text": "Each time Fungusaur is damaged but not destroyed, put a +1/+1 counter on it.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "327b5837-a9b6-57c3-97c3-980460b59faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b15221-c8b0-4861-9f8b-8a65834ad499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b15221-c8b0-4861-9f8b-8a65834ad499.jpg?1",
             "name": "Gaea's Liege",
             "text": "When defending, Gaea's Liege has power and toughness equal to the number of forests you have in play; when it's attacking, they are equal to the number of forests opponent has in play. Tap to turn any one land into a forest until Gaea's Liege leaves play. Mark changed lands with counters, removing the counters when Gaea's Liege leaves play.",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "c2d7fc5f-09eb-5f6e-ac5a-37363728010c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dbefe-3366-408e-9fcf-7dc00f8cc201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dbefe-3366-408e-9fcf-7dc00f8cc201.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gains +3/+3 until end of turn.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "0e34f75e-e3e8-53ec-a446-36c0562a926b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77636b4c-faea-4bf5-b88c-dd5bb88dc930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77636b4c-faea-4bf5-b88c-dd5bb88dc930.jpg?1",
             "name": "Giant Spider",
             "text": "Does not fly, but can block flying creatures.",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "5a6b23d0-6859-5f88-983b-e03c9931780c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d603a-3231-4a8c-bf39-1617586ea870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d603a-3231-4a8c-bf39-1617586ea870.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "1cf51e00-236b-5c4b-a7fb-9a0aeb423eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f5a19f-16e4-4d35-89e1-969ac8202f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f5a19f-16e4-4d35-89e1-969ac8202f88.jpg?1",
             "name": "Hurricane",
             "text": "All players and flying creatures suffer X damage.",
             "colours": [
@@ -6442,7 +6442,7 @@
         },
         {
             "id": "1b8fc8f8-dfaf-575a-afd6-e90e197f17f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9914836e-2fa6-4390-94b2-431427848a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9914836e-2fa6-4390-94b2-431427848a54.jpg?1",
             "name": "Ice Storm",
             "text": "Destroys any one land.",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "4914c3e8-2ea5-529e-af34-da31f4b6b7c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd38716-874c-4e3c-a315-837839a6258c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd38716-874c-4e3c-a315-837839a6258c.jpg?1",
             "name": "Instill Energy",
             "text": "You may untap target creature both during your untap phase and one additional time during your turn. Target creature may attack the turn it comes into play.",
             "colours": [
@@ -6506,7 +6506,7 @@
         },
         {
             "id": "966cd12b-ddb8-5dc5-ae69-7c9c0f8935c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93c5869-7777-44bb-967a-e9439b25ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93c5869-7777-44bb-967a-e9439b25ced4.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -6539,7 +6539,7 @@
         },
         {
             "id": "54fdd74b-45b1-58d0-a424-7942bce3d612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b72dcd-9ea1-4729-baae-ecd262fdff67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b72dcd-9ea1-4729-baae-ecd262fdff67.jpg?1",
             "name": "Kudzu",
             "text": "When target land is tapped, it is destroyed. Unless that was the last land in play, Kudzu is not discarded; instead, the player whose land it just destroyed may place it on another land of his or her choice.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "4a43d2d8-4465-57b2-af9f-6fa73b3dc62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9232508-d363-4ef3-987a-741f6bff331f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9232508-d363-4ef3-987a-741f6bff331f.jpg?1",
             "name": "Ley Druid",
             "text": "Tap Druid to untap a land of your choice. This action can be played as an interrupt.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "c9952ca6-3d06-50c5-b0e9-47fe6726d869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292577e-6232-44fa-a9c2-cc09949c6ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292577e-6232-44fa-a9c2-cc09949c6ed3.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Destroy a black spell as it is being cast. This use may be played as an interrupt, and does not affect black cards already in play.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "5caac84e-5d0e-5a30-9723-aebf4a833f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38cb601b-a35c-412e-b386-e77dad3daa54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38cb601b-a35c-412e-b386-e77dad3daa54.jpg?1",
             "name": "Lifelace",
             "text": "Changes the color of one card either being played or already in play to green. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "67c8fd62-a3be-55a5-9064-1512dce373bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e753a2-a7d0-4d37-ae65-b5a1b5039a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e753a2-a7d0-4d37-ae65-b5a1b5039a6e.jpg?1",
             "name": "Living Artifact",
             "text": "Put a counter on target artifact for each life you lose. During upkeep you may trade one counter for one life, but you can only trade in one counter each turn.",
             "colours": [
@@ -6701,7 +6701,7 @@
         },
         {
             "id": "bb6003e9-527b-5912-9514-1843dc869d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80be0580-7948-4d8e-8c0f-5e2797ac411b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80be0580-7948-4d8e-8c0f-5e2797ac411b.jpg?1",
             "name": "Living Lands",
             "text": "Treat all forests in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. The living lands have no color; they are not considered green cards.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "302e86fb-7c0f-5e54-a86f-e4e07726cd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1cc9e-4f99-4c26-ac1b-8ef069fa8ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1cc9e-4f99-4c26-ac1b-8ef069fa8ceb.jpg?1",
             "name": "Llanowar Elves",
             "text": "Tap to add 1 green mana to your mana pool. This tap can be played as an interrupt.",
             "colours": [
@@ -6766,7 +6766,7 @@
         },
         {
             "id": "f5b464d6-f0b3-591f-8ab3-e5889780443c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a87b26e-0431-42e9-b44f-94ba8546111a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a87b26e-0431-42e9-b44f-94ba8546111a.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. If a creature has the ability to block more than one creature, Lure does not prevent this. If there is more than one attacking creature with Lure, defender may choose which of them each defending creature blocks.",
             "colours": [
@@ -6799,7 +6799,7 @@
         },
         {
             "id": "a65fe493-250f-52f5-80af-a834c111910e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8917dc8-01c0-4e72-9310-c4d501775411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8917dc8-01c0-4e72-9310-c4d501775411.jpg?1",
             "name": "Natural Selection",
             "text": "Look at top three cards of any player's library. You may opt to rearrange those three cards or shuffle the entire library.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "a6064531-356e-5a9d-910c-fb59ff57e997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b7aa34-b4f8-41b4-82ce-ab2e204c3bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b7aa34-b4f8-41b4-82ce-ab2e204c3bf4.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Target creature regenerates.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "4a102b79-3e73-5505-ada4-8f7038deae5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc73ec-3728-4246-90c7-5f4eb7051ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc73ec-3728-4246-90c7-5f4eb7051ed5.jpg?1",
             "name": "Regrowth",
             "text": "Return any card from your graveyard to your hand.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "38334b47-e568-5c1d-ae4e-f4dd90bf00e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929c38-91e6-457c-937a-d1884f4bba44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929c38-91e6-457c-937a-d1884f4bba44.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "68091432-8d00-5562-90eb-b51a482ac716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814cf35c-f1ad-4bf4-8c10-a5592c3b1be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814cf35c-f1ad-4bf4-8c10-a5592c3b1be8.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk",
             "colours": [
@@ -6961,7 +6961,7 @@
         },
         {
             "id": "d9dedeb6-eb90-553f-9f49-08ca5cf65253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c4d4b-2645-4cd9-823e-3c9bb2eb48f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c4d4b-2645-4cd9-823e-3c9bb2eb48f9.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "1470385e-e891-59a8-9577-930d40dd955b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cce01-b3bd-4307-aae5-9a7c8fa386ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cce01-b3bd-4307-aae5-9a7c8fa386ab.jpg?1",
             "name": "Thicket Basilisk",
             "text": "Any non-wall creature blocking Basilisk is destroyed, as is any creature blocked by Basilisk. Creatures destroyed this way deal their damage before dying.",
             "colours": [
@@ -7025,7 +7025,7 @@
         },
         {
             "id": "4b1b5ad1-e5d8-5db9-9ec9-b3452d49ec60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2570a4-eef9-430d-b6c2-cd51d29b9d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2570a4-eef9-430d-b6c2-cd51d29b9d01.jpg?1",
             "name": "Timber Wolves",
             "text": "Bands",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "fc5a1fc7-deb1-5e12-b7fa-b57b1c2b9015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cc5a6-3a69-4812-add4-eb5eb6389238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cc5a6-3a69-4812-add4-eb5eb6389238.jpg?1",
             "name": "Tranquility",
             "text": "All enchantments in play must be discarded.",
             "colours": [
@@ -7089,7 +7089,7 @@
         },
         {
             "id": "c152cc9c-6ae0-5395-8b15-4805f43dbc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed67d61-cf47-446b-b454-eb404a8686b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed67d61-cf47-446b-b454-eb404a8686b7.jpg?1",
             "name": "Tsunami",
             "text": "All islands in play are destroyed.",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "b9fd3523-92aa-50fc-a18d-96b943ce6a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87178b-1221-4d7a-a7a5-20d7f01b8089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87178b-1221-4d7a-a7a5-20d7f01b8089.jpg?1",
             "name": "Verduran Enchantress",
             "text": "While Enchantress is in play, you may immediately draw a card from your library each time you cast an enchantment.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "e3a964d1-4d7c-5f50-937a-9acfdb26ca0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a4558-db6e-41b2-aff6-b164d93282a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a4558-db6e-41b2-aff6-b164d93282a0.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerates",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "a81c09b7-fa97-5d51-a863-766ef3bdd147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc743a03-867c-4bb0-8fb0-2bcaa0a8a756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc743a03-867c-4bb0-8fb0-2bcaa0a8a756.jpg?1",
             "name": "Wall of Ice",
             "text": "",
             "colours": [
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "b1d09fde-c795-5a7f-9fae-1ce3baf441d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df80424-3bd9-4982-ad79-e55d9ba3b43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df80424-3bd9-4982-ad79-e55d9ba3b43d.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "d55ea838-65d9-5786-87c8-c94a1aa921ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220a03ca-8c9b-4acb-821d-f6577fbb20fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220a03ca-8c9b-4acb-821d-f6577fbb20fb.jpg?1",
             "name": "Wanderlust",
             "text": "Wanderlust does 1 damage to target creature's controller during upkeep.",
             "colours": [
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "9aedecd6-b119-5587-8894-3119038a77ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d6081e-f686-4263-a0a2-21c0d9af5fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d6081e-f686-4263-a0a2-21c0d9af5fdb.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "44726e0f-a668-52cc-8541-5205dc26d360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c7890a-86dc-4a97-a7ce-1436fa22d0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c7890a-86dc-4a97-a7ce-1436fa22d0c0.jpg?1",
             "name": "Web",
             "text": "Target creature gains +0/+2 and can now block flying creatures, though it does not gain the power to fly.",
             "colours": [
@@ -7353,7 +7353,7 @@
         },
         {
             "id": "a73440ee-3ff6-52d2-a8b1-edb483c49834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd896dfa-66c0-4327-8e5b-489bbe350c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd896dfa-66c0-4327-8e5b-489bbe350c95.jpg?1",
             "name": "Wild Growth",
             "text": "When tapped, target land provides 1 green mana in addition to the mana it normally provides.",
             "colours": [
@@ -7386,7 +7386,7 @@
         },
         {
             "id": "33b9ca30-0296-52b7-a8e2-7d4715404b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f594b7aa-d44e-47c4-989b-565f881e25f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f594b7aa-d44e-47c4-989b-565f881e25f1.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Ankh does 2 damage to anyone who puts a new land into play.",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "f592d20b-1974-569e-82ab-aa59f3a66765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a74c89-6f86-4ec8-af17-391cd5026054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a74c89-6f86-4ec8-af17-391cd5026054.jpg?1",
             "name": "Basalt Monolith",
             "text": "Tap to add 3 colorless mana to your mana pool. Does not untap as normal during untap phase, but can be untapped at any time for 3 mana. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7440,7 +7440,7 @@
         },
         {
             "id": "d4d8c9f9-31ed-53ed-ab67-eba86e2198fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0faa7f2-b547-42c4-a810-839da50dadfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0faa7f2-b547-42c4-a810-839da50dadfe.jpg?1",
             "name": "Black Lotus",
             "text": "Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7467,7 +7467,7 @@
         },
         {
             "id": "3cbbae60-d9e0-5ef4-9dff-0ee9810cef84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac72f8-5b1e-4d67-a796-ef69cde27424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac72f8-5b1e-4d67-a796-ef69cde27424.jpg?1",
             "name": "Black Vise",
             "text": "If opponent has more than four cards in hand during upkeep, black vise does 1 damage to opponent for each card in excess of four.",
             "colours": [],
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "f337d434-8b68-5bb0-bf4d-af096f722fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47417cb-1ea7-4f65-ba06-e27a99373114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47417cb-1ea7-4f65-ba06-e27a99373114.jpg?1",
             "name": "Celestial Prism",
             "text": "o2: Provides 1 mana of any color. This use can be played as an interrupt.",
             "colours": [],
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "249e6587-885e-5fbc-8593-b13114de5e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92274971-7c4a-4326-b0fe-75e2d124f718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92274971-7c4a-4326-b0fe-75e2d124f718.jpg?1",
             "name": "Chaos Orb",
             "text": "o1: Flip Chaos Orb onto the playing area from a height of at least one foot. Chaos Orb must turn completely over at least once or it is discarded with no effect. When Chaos Orb lands, any cards in play that it touches are destroyed, as is Chaos Orb.",
             "colours": [],
@@ -7548,7 +7548,7 @@
         },
         {
             "id": "ed68798d-872d-5bf6-82e2-6122ed4b25a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f916a2-0ace-44b5-99dc-72979af34db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f916a2-0ace-44b5-99dc-72979af34db9.jpg?1",
             "name": "Clockwork Beast",
             "text": "Put seven +1/+0 counters on Beast. After Beast attacks or blocks a creature, discard a counter. During the untap phase, controller may buy back lost counters for 1 mana per counter instead of untapping Beast; this taps Beast if it wasn't tapped already.",
             "colours": [],
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "0d67f98a-5fd5-55e4-84b8-f571fea1dd1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7824e2a-4eff-4f72-9216-0db30a4f4252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7824e2a-4eff-4f72-9216-0db30a4f4252.jpg?1",
             "name": "Conservator",
             "text": "o3: Prevent the loss of up to 2 life.",
             "colours": [],
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "3f1d01ec-a192-5cb2-8c2f-348bbca84877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30935e4a-013e-4c46-ad05-304df8e5dfa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30935e4a-013e-4c46-ad05-304df8e5dfa4.jpg?1",
             "name": "Copper Tablet",
             "text": "Copper Tablet does 1 damage to each player during his or her upkeep.",
             "colours": [],
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "3f41a94d-ecd3-56eb-b4be-48b7e7f7dc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76693233-7961-4b7e-80f2-ed90e494c4aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76693233-7961-4b7e-80f2-ed90e494c4aa.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Any blue spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7659,7 +7659,7 @@
         },
         {
             "id": "49177581-b077-5528-bf49-3ddabce4cfbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894c5cf2-8ae2-427a-bcbc-67df0bdfee9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894c5cf2-8ae2-427a-bcbc-67df0bdfee9d.jpg?1",
             "name": "Cyclopean Tomb",
             "text": "o2: Turn any one non-swamp land into swamp during upkeep. Mark the changed lands with tokens. If Cyclopean Tomb is destroyed, remove one token of your choice each upkeep, returning that land to its original nature.",
             "colours": [],
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "7e658839-6217-5fdd-ab8e-cf554f7910d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb6cda-e512-40a8-9c1f-335b713409ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb6cda-e512-40a8-9c1f-335b713409ff.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever anyone loses a land, Egg does 2 damage to that player for each land lost.",
             "colours": [],
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "c9fdfe37-f685-5cfc-93be-603a5cb15d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca571ee8-07a2-43b8-9acf-89cbfd3cf7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca571ee8-07a2-43b8-9acf-89cbfd3cf7c9.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3: Opponent must discard one card of his or her choice. Can only be used during your turn.",
             "colours": [],
@@ -7740,7 +7740,7 @@
         },
         {
             "id": "09947465-87b1-57b3-a9b8-7577ccb3a793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2004c1-8efe-407f-bf48-27b807422eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2004c1-8efe-407f-bf48-27b807422eea.jpg?1",
             "name": "Forcefield",
             "text": "o1: Lose only 1 life to an unblocked creature.",
             "colours": [],
@@ -7767,7 +7767,7 @@
         },
         {
             "id": "f312d00f-072f-5e53-a819-a95a6f22b2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da248001-ed75-4b68-9532-37d3cd5afc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da248001-ed75-4b68-9532-37d3cd5afc4c.jpg?1",
             "name": "Gauntlet of Might",
             "text": "All red creatures gain +1/+1 and all mountains provide an extra red mana when tapped.",
             "colours": [],
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "b46d8839-8c5e-5750-8446-32f1fba6f576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafc2350-5d64-4379-9198-79a114654d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafc2350-5d64-4379-9198-79a114654d45.jpg?1",
             "name": "Glasses of Urza",
             "text": "You may look at opponent's hand.",
             "colours": [],
@@ -7823,7 +7823,7 @@
         },
         {
             "id": "784c27df-1796-5d92-8d37-1bb82c1dcd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3792c6ef-c4e6-4923-9a51-7d28fbc5c393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3792c6ef-c4e6-4923-9a51-7d28fbc5c393.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1: You may give one creature the ability to band until end of turn.",
             "colours": [],
@@ -7850,7 +7850,7 @@
         },
         {
             "id": "fcf21c7c-b0a3-5835-b832-c791c6268572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f8f6e1-a451-4262-90d3-5107caf54175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f8f6e1-a451-4262-90d3-5107caf54175.jpg?1",
             "name": "Howling Mine",
             "text": "Each player draws one extra card each turn during his or her draw phase.",
             "colours": [],
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "f6ffcf8f-af06-5e23-9b98-f96f29d82aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dc1596-a2e7-4d60-9f99-89babaef8a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dc1596-a2e7-4d60-9f99-89babaef8a06.jpg?1",
             "name": "Icy Manipulator",
             "text": "o1: You may tap any land, creature, or artifact in play on either side.",
             "colours": [],
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "eedfcb4e-e08a-5070-98f5-15c3a107d8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ef2f37-b8ad-47ad-89ca-d6abcb7ff21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ef2f37-b8ad-47ad-89ca-d6abcb7ff21b.jpg?1",
             "name": "Illusionary Mask",
             "text": "oo\nX You can summon a creature face down so opponent doesn't know what it is. The X cost can be any amount of mana, even 0; it serves to hide the true casting cost of the creature, which you still have to spend. As soon as a face-down creature receives damage, deals damage, or is tapped, you must turn it face up.",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "20a7a1b9-a056-54cc-b9fe-245ce6d0d250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5786de12-cade-43c2-a6b0-0c5b294b9d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5786de12-cade-43c2-a6b0-0c5b294b9d0e.jpg?1",
             "name": "Iron Star",
             "text": "o1: Any red spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7958,7 +7958,7 @@
         },
         {
             "id": "7ffb42ec-f0c8-568e-b83f-0678bcaa3681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964d8d8-dc97-4e5f-9f52-173f7e2c37fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964d8d8-dc97-4e5f-9f52-173f7e2c37fd.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Any white spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "f5615af0-ce72-51ca-b998-209fbb8c36c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a77e0f1-449d-4a7d-9fa0-ba7598f7a73a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a77e0f1-449d-4a7d-9fa0-ba7598f7a73a.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: You may take damage done to any creature on yourself instead, but you must take all of it. Source of damage is unchanged.",
             "colours": [],
@@ -8012,7 +8012,7 @@
         },
         {
             "id": "ca502ec9-12b3-5458-85e8-401a710d80d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d82d94b-ceef-4533-a4f2-b6442a61b839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d82d94b-ceef-4533-a4f2-b6442a61b839.jpg?1",
             "name": "Jade Statue",
             "text": "o2: Jade Statue becomes a creature for the duration of the current attack exchange. Can be a creature only during an attack or defense.",
             "colours": [],
@@ -8039,7 +8039,7 @@
         },
         {
             "id": "5b4feaeb-a044-5b52-a059-e8c7999d2e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8c421-5b92-481d-b2de-560c0231ab58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8c421-5b92-481d-b2de-560c0231ab58.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4: You may draw one extra card.",
             "colours": [],
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "5b3b7079-c372-5c74-b0f6-b1c20f1ca809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd6a291-5282-4f49-8203-d9b416083c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd6a291-5282-4f49-8203-d9b416083c48.jpg?1",
             "name": "Juggernaut",
             "text": "Must attack each turn if possible. Can't be blocked by walls.",
             "colours": [],
@@ -8096,7 +8096,7 @@
         },
         {
             "id": "cd845e02-8333-5476-9a55-14071a11fdcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef7a1-148d-44ac-89ed-0ef379cca0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef7a1-148d-44ac-89ed-0ef379cca0c6.jpg?1",
             "name": "Kormus Bell",
             "text": "Treat all swamps in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. Swamps have no color; they are not considered black cards.",
             "colours": [],
@@ -8123,7 +8123,7 @@
         },
         {
             "id": "bd0c867e-977f-51d8-ba5c-930aca1a25f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340edcb-8cd5-4ccd-99e2-b9a29f72c495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340edcb-8cd5-4ccd-99e2-b9a29f72c495.jpg?1",
             "name": "Library of Leng",
             "text": "There is no limit to size of your hand. If a card forces you to discard, you may choose to discard to top of your library rather than to graveyard. If discard is random, you may look at card before deciding where to discard it.",
             "colours": [],
@@ -8150,7 +8150,7 @@
         },
         {
             "id": "fe12d2bc-3059-5e2e-9864-d060fa94db4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a98ada6-923a-44a5-bdef-ea6a160b481e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a98ada6-923a-44a5-bdef-ea6a160b481e.jpg?1",
             "name": "Living Wall",
             "text": "Counts as a wall. o1: Regenerates.",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "a5d6cd48-7605-566f-98f3-64974a2bad5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19499cb7-eccb-4e69-af32-6002d447a160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19499cb7-eccb-4e69-af32-6002d447a160.jpg?1",
             "name": "Mana Vault",
             "text": "Tap to add 3 colorless mana to your mana pool. Mana Vault doesn't untap normally during untap phase; to untap it, you must pay 4 mana. If Mana Vault remains tapped during upkeep it does 1 damage to you. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "f04e8da0-627d-5997-8660-15631af07ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68a17-22ee-47c9-870a-83e911862b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68a17-22ee-47c9-870a-83e911862b94.jpg?1",
             "name": "Meekstone",
             "text": "Any creature with power greater than 2 may not be untapped as normal during the untap phase.",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "3876cd4c-db88-534e-877c-307fa2e2b160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e1427c-05cd-465b-be59-97ed6e39f7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e1427c-05cd-465b-be59-97ed6e39f7ba.jpg?1",
             "name": "Mox Emerald",
             "text": "Add 1 green mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "173fc1fb-c465-5d62-b34e-60d76df02fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bcd1ce-19b1-4d78-8b09-95242ca08d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bcd1ce-19b1-4d78-8b09-95242ca08d76.jpg?1",
             "name": "Mox Jet",
             "text": "Add 1 black mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "bdbc1b80-5371-5af3-9c7c-6ec166c2cf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebe4be7-e12a-4596-a899-fbd5b152e879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebe4be7-e12a-4596-a899-fbd5b152e879.jpg?1",
             "name": "Mox Pearl",
             "text": "Add 1 white mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8321,7 +8321,7 @@
         },
         {
             "id": "25292565-ce32-5533-a526-ce41d41c0516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945585f-4773-493d-a0fe-d707db910b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945585f-4773-493d-a0fe-d707db910b38.jpg?1",
             "name": "Mox Ruby",
             "text": "Add 1 red mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8350,7 +8350,7 @@
         },
         {
             "id": "5dd1158c-6210-5a8c-a9bb-63df7f25d10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82da0972-b17b-4600-9efd-e9430a0db04b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82da0972-b17b-4600-9efd-e9430a0db04b.jpg?1",
             "name": "Mox Sapphire",
             "text": "Add 1 blue mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "93e3a468-1767-5a8f-93d6-1dca85707915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12926dc8-8e6f-4a47-a12b-4d674189615a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12926dc8-8e6f-4a47-a12b-4d674189615a.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "o1: Destroys all creatures, enchantments, and artifacts in play. Disk begins tapped but can be untapped as usual. Disk destroys itself when used.",
             "colours": [],
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "f3ba896e-7170-53ac-93ab-dbef4b2eb30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8e9f5c-deba-4443-bf9d-fb2be75c5418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8e9f5c-deba-4443-bf9d-fb2be75c5418.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -8436,7 +8436,7 @@
         },
         {
             "id": "9365bbe8-ef38-53cd-949b-0dd87eca1467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af957200-c538-4f52-b105-6db7a7abb4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af957200-c538-4f52-b105-6db7a7abb4dc.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3: Rod of Ruin does 1 damage to any target.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "075d914c-d9c8-5130-8146-b2a75389d184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4300d24-1cae-4dd5-be7e-38cc677cf5bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4300d24-1cae-4dd5-be7e-38cc677cf5bd.jpg?1",
             "name": "Sol Ring",
             "text": "Add 2 colorless mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "d1682a39-ccfa-599f-8cb3-4dd621d4bcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b814198-814b-4619-a158-327af675f8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b814198-814b-4619-a158-327af675f8f2.jpg?1",
             "name": "Soul Net",
             "text": "o1: You gain 1 life every time a creature is destroyed, unless it is then regenerated.",
             "colours": [],
@@ -8517,7 +8517,7 @@
         },
         {
             "id": "3598ae2b-12fe-5ff0-8e13-ab5cf917ef03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d433a4-76c0-4f27-836d-4c0c13a511fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d433a4-76c0-4f27-836d-4c0c13a511fb.jpg?1",
             "name": "Sunglasses of Urza",
             "text": "White mana in your mana pool can be used as either white or red mana.",
             "colours": [],
@@ -8544,7 +8544,7 @@
         },
         {
             "id": "c6ac7b37-14f2-5406-84a4-0f963bf1c5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a7138-eae8-4ff9-9e17-680bfa717183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a7138-eae8-4ff9-9e17-680bfa717183.jpg?1",
             "name": "The Hive",
             "text": "o5: Creates one Giant Wasp, a 1/1 flying creature. Represent Wasps with tokens, making sure to indicate when each Wasp is tapped. Wasps can't attack during the turn created. Treat Wasps like artifact creatures in every way, except that they are removed from the game entirely if they ever leave play. If the Hive is destroyed, the Wasps must still be killed individually.",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "b7fa2cea-fda3-50da-bc19-3d3924a276b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2931ae0-7836-4000-b9ec-f2029ebf5d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2931ae0-7836-4000-b9ec-f2029ebf5d96.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Any black spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "1c2ca7fa-61fb-50f3-bbc3-98a87eba487a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902441dc-c976-4c92-b897-6376eaa0fe38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902441dc-c976-4c92-b897-6376eaa0fe38.jpg?1",
             "name": "Time Vault",
             "text": "Tap to gain an additional turn after the current one. Time Vault doesn't untap normally during untap phase; to untap it, you must skip a turn. Time Vault begins tapped.",
             "colours": [],
@@ -8625,7 +8625,7 @@
         },
         {
             "id": "8e7bfb2e-4109-5074-a96c-5b6fbd481c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9359f60c-9a27-4e53-b35b-964a121a6fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9359f60c-9a27-4e53-b35b-964a121a6fba.jpg?1",
             "name": "Winter Orb",
             "text": "Players can untap only one land each during untap phase. Creatures and artifacts are untapped as normal.",
             "colours": [],
@@ -8652,7 +8652,7 @@
         },
         {
             "id": "57c329c5-0179-5536-b7d1-88e360194702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcae01a2-171b-47cd-87be-f1e4e5314326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcae01a2-171b-47cd-87be-f1e4e5314326.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Any green spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8679,7 +8679,7 @@
         },
         {
             "id": "0b71a1cd-ae02-5540-b1da-457fa985fb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f6d10-9144-4ade-9ac6-a481cc66b875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f6d10-9144-4ade-9ac6-a481cc66b875.jpg?1",
             "name": "Badlands",
             "text": "Counts as both mountains and swamp and is affected by spells that affect either. Tap to add either o\nR or o\nB to your mana pool.",
             "colours": [],
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "02748612-1f51-5ead-ac83-ad4b99ab7e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412ceddd-2b9a-4551-a6bf-ae2830a2010a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412ceddd-2b9a-4551-a6bf-ae2830a2010a.jpg?1",
             "name": "Bayou",
             "text": "Counts as both swamp and forest and is affected by spells that affect either. Tap to add either o\nB or o\nG to your mana pool.",
             "colours": [],
@@ -8745,7 +8745,7 @@
         },
         {
             "id": "295c94f5-b864-531c-8eb9-4e6a41885685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eafa00b-c628-40f6-86eb-88e1361fc7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eafa00b-c628-40f6-86eb-88e1361fc7a0.jpg?1",
             "name": "Plateau",
             "text": "Counts as both mountains and plains and is affected by spells that affect either. Tap to add either o\nR or o\nW to your mana pool.",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "af353fc0-f840-5b76-916a-f4ada4f7ad18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7e24c-2546-41b6-81ad-5e920b07e64e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7e24c-2546-41b6-81ad-5e920b07e64e.jpg?1",
             "name": "Savannah",
             "text": "Counts as both plains and forest and is affected by spells that affect either. Tap to add either o\nW or o\nG to your mana pool.",
             "colours": [],
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "41bee624-763f-5876-85a9-4db6770ebfed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebe39d4-21fb-46a4-a1ec-b97102e46c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebe39d4-21fb-46a4-a1ec-b97102e46c15.jpg?1",
             "name": "Scrubland",
             "text": "Counts as both plains and swamp and is affected by spells that affect either. Tap to add either o\nW or o\nB to your mana pool.",
             "colours": [],
@@ -8844,7 +8844,7 @@
         },
         {
             "id": "a5d7c20b-6437-5533-aa5a-ca7a3f34d723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60df6592-0b3b-4b87-aeb2-8fa94b4fb7be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60df6592-0b3b-4b87-aeb2-8fa94b4fb7be.jpg?1",
             "name": "Taiga",
             "text": "Counts as both forest and mountains and is affected by spells that affect either. Tap to add either o\nG or o\nR to your mana pool.",
             "colours": [],
@@ -8877,7 +8877,7 @@
         },
         {
             "id": "a605c54b-a689-5a2f-b877-bfda0ce56b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6c759-aabf-44e7-ba8c-33c5df232b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6c759-aabf-44e7-ba8c-33c5df232b56.jpg?1",
             "name": "Tropical Island",
             "text": "Counts as both forest and islands and is affected by spells that affect either. Tap to add either o\nG or o\nU to your mana pool.",
             "colours": [],
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "2528555c-f5d6-5c40-b5cc-ffe6798706fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03e8c5b-f4ed-4fd7-ba05-db813ccc05eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03e8c5b-f4ed-4fd7-ba05-db813ccc05eb.jpg?1",
             "name": "Tundra",
             "text": "Counts as both islands and plains and is affected by spells that affect either. Tap to add either o\nU or o\nW to your mana pool.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "63020af6-192a-52de-ab67-7afaa76c9c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff76ac86-8a8a-47fe-9388-8950ca3e26c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff76ac86-8a8a-47fe-9388-8950ca3e26c3.jpg?1",
             "name": "Underground Sea",
             "text": "Counts as both swamp and islands and is affected by spells that affect either. Tap to add either o\nB or o\nU to your mana pool.",
             "colours": [],
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "ab963052-f43e-5d99-970d-30502610b353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1623d57-4729-4796-b3f7-f1837a05c6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1623d57-4729-4796-b3f7-f1837a05c6ed.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "764759be-ff7d-53d5-abe5-8ad0a745c8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51662253-789f-4a02-9937-688e36775024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51662253-789f-4a02-9937-688e36775024.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9046,7 +9046,7 @@
         },
         {
             "id": "a3fa938c-157a-5762-bf66-3187a5facb1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a57c0e-fa61-45ef-955d-d296403967d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a57c0e-fa61-45ef-955d-d296403967d5.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9081,7 +9081,7 @@
         },
         {
             "id": "ea3ed63f-cb6c-5296-a471-191c3ae7cbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ea08d-7991-4a57-a1e3-abd508426970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ea08d-7991-4a57-a1e3-abd508426970.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "2e49af91-8005-516d-8ceb-fd714c45d7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176936d-72e2-4205-8871-4c5a4f1cb2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176936d-72e2-4205-8871-4c5a4f1cb2d8.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "2f4e125b-ef7c-5b61-904e-2230a1802c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeba4e1-9012-4962-8797-3a1f6a660952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeba4e1-9012-4962-8797-3a1f6a660952.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "827201c7-c2c1-57c5-8769-ae3c5edb0d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eace2c85-976c-425e-9800-5a6ccbd91b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eace2c85-976c-425e-9800-5a6ccbd91b56.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9221,7 +9221,7 @@
         },
         {
             "id": "df6d7458-bd61-5b97-be4f-7d7de6fadeda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a96315d-edc6-4d68-a260-d14f61281dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a96315d-edc6-4d68-a260-d14f61281dc1.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9256,7 +9256,7 @@
         },
         {
             "id": "0c5dd930-00c3-5655-9fd0-c889f8a38eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1c8cb0-38eb-408b-94e8-16db83999b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1c8cb0-38eb-408b-94e8-16db83999b3b.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],
@@ -9291,7 +9291,7 @@
         },
         {
             "id": "75e9547d-7f05-5d15-839a-157242ea4edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c89d9-71c9-45f5-a9cb-6e253b0a7cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c89d9-71c9-45f5-a9cb-6e253b0a7cca.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/LEB.json
+++ b/Assets/Resources/Sets/LEB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2e646d16-a318-545d-9e2f-397d552e5b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5b4738-20bb-465d-b67e-c6146dce9d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5b4738-20bb-465d-b67e-c6146dce9d0b.jpg?1",
             "name": "Animate Wall",
             "text": "Target wall can now attack. Target wall's power and toughness are unchanged, even if its power is 0.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "4b4558ed-4bda-5123-94d3-64590e3797ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c4edfa-7822-40bc-88d1-d051b3a64df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c4edfa-7822-40bc-88d1-d051b3a64df1.jpg?1",
             "name": "Armageddon",
             "text": "All lands in play are destroyed.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "fa7907ce-3f80-5075-a9fc-874d8e27b6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c32a0-ee97-4239-94e3-aabab91dab83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c32a0-ee97-4239-94e3-aabab91dab83.jpg?1",
             "name": "Balance",
             "text": "Whichever player has more lands in play must discard enough lands of his or her choice to equalize the number of lands both players have in play. Cards in hand and creatures in play must be equalized the same way. Creatures lost in this manner may not be regenerated.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "3694886b-6253-54b7-aeb8-5d3dae38e218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62c68d0-9b1e-4abe-991d-a645effeb676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62c68d0-9b1e-4abe-991d-a645effeb676.jpg?1",
             "name": "Benalish Hero",
             "text": "Bands",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "874039c1-d145-5f98-9e5a-1b5dda66351f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5d3fe-5741-40f7-8f45-dadb818d79b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5d3fe-5741-40f7-8f45-dadb818d79b0.jpg?1",
             "name": "Black Ward",
             "text": "Target creature gains protection from black.",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "e5e18503-db69-5536-a15d-a722f1ca4b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78aef20-e3bb-484c-9fa1-d2859408b04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78aef20-e3bb-484c-9fa1-d2859408b04a.jpg?1",
             "name": "Blaze of Glory",
             "text": "Target defending creature can and must block all attacking creatures it can legally block. For example, a normal non-flying target defender can and must block all normal non-flying attackers at once, but it cannot block any flying attackers. Controller of target defender may distribute damage among attackers as desired. Play before defense is chosen.",
             "colours": [
@@ -197,7 +197,7 @@
         },
         {
             "id": "c94ff6f2-2694-515d-8c06-b19afc3c037a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd624c8-f06e-4181-865e-6a14ffc9302f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd624c8-f06e-4181-865e-6a14ffc9302f.jpg?1",
             "name": "Blessing",
             "text": "oo\nW Target creature gains +1/+1 until end of turn.",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "cd7f4c22-091a-57fc-bdf3-7f8ae98b5108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafae6f4-0880-4532-9224-44545bfa5eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafae6f4-0880-4532-9224-44545bfa5eb4.jpg?1",
             "name": "Blue Ward",
             "text": "Target creature gains protection from blue.",
             "colours": [
@@ -263,7 +263,7 @@
         },
         {
             "id": "0d210195-f733-5c64-9ec0-8e0ee95ed0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6b09-b24f-40cb-b219-ad8a1fd6692c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6b09-b24f-40cb-b219-ad8a1fd6692c.jpg?1",
             "name": "Castle",
             "text": "Your untapped creatures gain +0/+2. Attacking creatures lose this bonus.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "6f391170-b170-509e-923d-a03746448c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47b4cd-8da4-4544-b011-ba92b7009203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47b4cd-8da4-4544-b011-ba92b7009203.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevents all damage against you from one black source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "8655215e-4d47-5bc8-8dd2-99e392589c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a86eb1-f6a0-4a4e-bd59-e19e22ec487d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a86eb1-f6a0-4a4e-bd59-e19e22ec487d.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevents all damage against you from one blue source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "e135e756-0cf8-5f4e-91a7-24c5eecd348c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e041b0ea-4a57-4950-9f8e-72d6e6ab2968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e041b0ea-4a57-4950-9f8e-72d6e6ab2968.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevents all damage against you from one green source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "9871110e-e0e3-578a-bc9d-c694a82b19b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de9dc85-d566-4cb0-a2e3-1ed4e5fe2f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de9dc85-d566-4cb0-a2e3-1ed4e5fe2f14.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevents all damage against you from one red source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "a1dde3c2-7567-52cc-a5bf-cf34787d39c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671aca82-6c55-43ef-b452-d6a2e706a7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671aca82-6c55-43ef-b452-d6a2e706a7ae.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevents all damage against you from one white source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "876e7f33-8587-5ef1-8b1b-5f53e7351f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077cf242-f866-497f-a23c-70e1b04a748e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077cf242-f866-497f-a23c-70e1b04a748e.jpg?1",
             "name": "Consecrate Land",
             "text": "All enchantments on target land are destroyed. Land cannot be destroyed or further enchanted until Consecrate Land has been destroyed.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "d19c555b-fd57-53e3-bb68-8d621a2109d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a5bb5-23cd-4f9a-8c8e-d009fb7bdf59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a5bb5-23cd-4f9a-8c8e-d009fb7bdf59.jpg?1",
             "name": "Conversion",
             "text": "All mountains are considered plains while Conversion is in play. Pay o\nWo\nW during upkeep or Conversion is discarded.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "95735427-7021-54f4-a59b-db078792db2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5fbd9d-48bf-4600-8ca4-2ce2ca48128e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5fbd9d-48bf-4600-8ca4-2ce2ca48128e.jpg?1",
             "name": "Crusade",
             "text": "All white creatures gain +1/+1.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "50f5951c-4dfd-55af-a8a5-2c42c3377729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b119edd8-7801-475e-943a-6cbf10f2d303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b119edd8-7801-475e-943a-6cbf10f2d303.jpg?1",
             "name": "Death Ward",
             "text": "Regenerates target creature.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "4661a2e0-2536-51c2-aee7-560b0674023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d61d0a5-7e92-4413-9121-925e1876b64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d61d0a5-7e92-4413-9121-925e1876b64d.jpg?1",
             "name": "Disenchant",
             "text": "Target enchantment or artifact must be discarded.",
             "colours": [
@@ -606,7 +606,7 @@
         },
         {
             "id": "9eec79ef-c101-56a3-9d61-95cca9f21015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49ecc66-dccb-4026-8c6e-0b275a635a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49ecc66-dccb-4026-8c6e-0b275a635a1f.jpg?1",
             "name": "Farmstead",
             "text": "Target land's controller gains 1 life each upkeep if o\nWo\nW is spent. Target land still generates mana as usual.",
             "colours": [
@@ -639,7 +639,7 @@
         },
         {
             "id": "6d6b1c10-5e60-50d4-a630-d69cf327db54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a488ce63-1adb-4051-9521-703bad8d02f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a488ce63-1adb-4051-9521-703bad8d02f6.jpg?1",
             "name": "Green Ward",
             "text": "Target creature gains protection from green.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "ba30b42c-5d5b-5cac-8c27-7eaed2d8f928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4e8259-b369-4b59-85fa-fe9edb1887c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4e8259-b369-4b59-85fa-fe9edb1887c5.jpg?1",
             "name": "Guardian Angel",
             "text": "Prevents X damage from being dealt to any one target. Any further damage to the same target this turn can be canceled by spending 1 mana per point of damage to be canceled.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "3346717e-fea3-5537-9914-e49203aa31e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9f2eeb-fea5-4b33-9723-8be3c1914f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9f2eeb-fea5-4b33-9723-8be3c1914f63.jpg?1",
             "name": "Healing Salve",
             "text": "Gain 3 life, or prevent up to 3 damage from being dealt to a single target.",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "6c7aebfa-8afd-5c76-a487-8d8d636ac09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab1d885-989c-4d71-8139-9e35d2f16d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab1d885-989c-4d71-8139-9e35d2f16d03.jpg?1",
             "name": "Holy Armor",
             "text": "Target creature gains +0/+2. oo\nW Target creature gets extra +0/+1 until end of turn.",
             "colours": [
@@ -767,7 +767,7 @@
         },
         {
             "id": "1c183fe0-f313-591b-907b-3f9eea14c918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de989395-50bf-458a-a010-e12abe2e15a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de989395-50bf-458a-a010-e12abe2e15a6.jpg?1",
             "name": "Holy Strength",
             "text": "Target creature gains +1/+2.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "e4c7572f-6200-5f07-b05f-5446d29a32c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273fb2b6-3d11-4f0d-9fb0-0364353c2060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273fb2b6-3d11-4f0d-9fb0-0364353c2060.jpg?1",
             "name": "Island Sanctuary",
             "text": "You may decline to draw a card from your library during draw phase. In exchange, until start of your next turn the only creatures that may attack you are those that fly or have islandwalk.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "6b4009cf-6b07-5123-8c0e-3986494a9854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bea2eb6-dfae-4bdc-9ab3-b2b491c69c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bea2eb6-dfae-4bdc-9ab3-b2b491c69c59.jpg?1",
             "name": "Karma",
             "text": "For each swamp in play, Karma does 1 damage to the swamp owner during the swamp owner's upkeep.",
             "colours": [
@@ -862,7 +862,7 @@
         },
         {
             "id": "d0242d2c-cdb3-55cf-b986-9bea14cdc9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aa3a93-3765-49f0-8ff2-b6843509c34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aa3a93-3765-49f0-8ff2-b6843509c34a.jpg?1",
             "name": "Lance",
             "text": "Target creature gains first strike.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "e4e21757-ebb8-590c-ae6b-f906c9236860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bff46a-6725-4918-9bdf-38efaaf50236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bff46a-6725-4918-9bdf-38efaaf50236.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Flying, bands",
             "colours": [
@@ -928,7 +928,7 @@
         },
         {
             "id": "4210b6bc-31ad-5306-a301-9fc623e7345b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8493c-ae69-48d1-a050-a887ae27c83f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8493c-ae69-48d1-a050-a887ae27c83f.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW and tap: Destroys a black card in play. Cannot be used to cancel a black spell as it is being cast.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "3b9ca0fa-c7ed-55f5-8b38-184f75a86930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47024d6d-dc55-4c35-b2bb-1b8bb0ee4e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47024d6d-dc55-4c35-b2bb-1b8bb0ee4e38.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "6e34bd86-a170-5b04-9df1-b5c22ac36793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb9f31-0818-4422-8533-99a4e6845a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb9f31-0818-4422-8533-99a4e6845a02.jpg?1",
             "name": "Personal Incarnation",
             "text": "Caster can redirect any or all damage done to Personal Incarnation to self instead. The source of the damage is unchanged. If Personal Incarnation is destroyed, caster loses half his or her remaining life points, rounding up the loss.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "6e766144-0ae2-5211-a29b-6b6e92e2bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11986e-42bd-4f54-8624-7b34b1783a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11986e-42bd-4f54-8624-7b34b1783a40.jpg?1",
             "name": "Purelace",
             "text": "Changes the color of one card either being played or already in play to white. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "7c41faad-311d-58c4-9a96-2cc9b068de33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057237bb-e1e6-4bcc-8639-ca0dcdd4846c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057237bb-e1e6-4bcc-8639-ca0dcdd4846c.jpg?1",
             "name": "Red Ward",
             "text": "Target creature gains protection from red.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "1ccb7ce4-6c34-546f-ace4-2146886be164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e3c741-5095-48a6-bd93-b9c4db265004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e3c741-5095-48a6-bd93-b9c4db265004.jpg?1",
             "name": "Resurrection",
             "text": "Take a creature from your graveyard and put it directly into play. You can't tap it until your next turn.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "dd12b726-a11a-5225-acb6-595a3f9cb396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cf22e4-cc5c-4723-a9cb-ae7ce7a55a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cf22e4-cc5c-4723-a9cb-ae7ce7a55a1a.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage you have taken from any one source this turn is added to your life total instead of subtracted from it.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "0be4ca6f-2309-5a69-a568-6a33172ca5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b847a2d1-5912-4f88-a68f-06790d0795dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b847a2d1-5912-4f88-a68f-06790d0795dc.jpg?1",
             "name": "Righteousness",
             "text": "Target defending creature gains +7/+7 until end of turn.",
             "colours": [
@@ -1186,7 +1186,7 @@
         },
         {
             "id": "0d022914-c2d6-5c7d-af5f-28a449732666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbfb106-29d8-4065-b306-51dba0ed11a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbfb106-29d8-4065-b306-51dba0ed11a4.jpg?1",
             "name": "Samite Healer",
             "text": "Tap to prevent 1 damage to any target.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "2ccde13d-9f95-5dad-b10d-18ec3eb79b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d1945d-d228-4dc3-a593-859408b2016b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d1945d-d228-4dc3-a593-859408b2016b.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "4bf63972-d46f-52a0-bceb-f7d8be54d6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5669f9c8-2e94-47e2-a551-7efff317fb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5669f9c8-2e94-47e2-a551-7efff317fb34.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nDoes not tap when attacking.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "5feec087-0137-5171-b1b8-fdc92b3240c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255099be-c64e-4f6a-8463-4fc058d6908d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255099be-c64e-4f6a-8463-4fc058d6908d.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Target creature is removed from game entirely; return to owner's deck only when game is over. Creature's controller gains life points equal to creature's power.",
             "colours": [
@@ -1317,7 +1317,7 @@
         },
         {
             "id": "c11aa0e0-39f4-5288-b131-72ce5f4c4faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d888b7-26e2-465d-b5ee-bb2f2af5c621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d888b7-26e2-465d-b5ee-bb2f2af5c621.jpg?1",
             "name": "Veteran Bodyguard",
             "text": "Unless Bodyguard is tapped, any damage done to you by unblocked creatures is done instead to Bodyguard. You may not take this damage yourself, though you can prevent it if possible.",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "5b0b3e1b-2c70-5fc4-972b-310563872d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be955e9a-e722-4cd7-8e3d-bab1889c255b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be955e9a-e722-4cd7-8e3d-bab1889c255b.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "416fec99-4c35-5ba2-8569-c2148b2d9a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a231e0b8-b3e3-4f4a-8baa-c56626b01685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a231e0b8-b3e3-4f4a-8baa-c56626b01685.jpg?1",
             "name": "White Knight",
             "text": "Protection from black, first strike",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "6e164f77-a25f-5dab-b978-e83d668568d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988dc3e-2ed8-4de3-9d1b-838003c9c9e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988dc3e-2ed8-4de3-9d1b-838003c9c9e3.jpg?1",
             "name": "White Ward",
             "text": "Target creature gains protection from white.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "618e4b6a-4a53-526d-a15a-fba92942996c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96dd2d61-a43d-4582-b730-71d4fac0fa23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96dd2d61-a43d-4582-b730-71d4fac0fa23.jpg?1",
             "name": "Wrath of God",
             "text": "All creatures in play are destroyed and cannot regenerate.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "4dd53ecf-d055-5ea1-8b55-6a63935ef413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a94a6d-26b1-4486-9444-ec366e6f4d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a94a6d-26b1-4486-9444-ec366e6f4d6e.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "011dd694-86e0-546e-899e-82bd1f5d240c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0a5c2-ac85-448e-9e87-12fc74fd4147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0a5c2-ac85-448e-9e87-12fc74fd4147.jpg?1",
             "name": "Ancestral Recall",
             "text": "Draw 3 cards or force opponent to draw 3 cards.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "c4712f3b-15dd-500a-87cb-a85c381dd4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb575b27-d2ca-4d90-a650-dc670484f607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb575b27-d2ca-4d90-a650-dc670484f607.jpg?1",
             "name": "Animate Artifact",
             "text": "Target artifact is now a creature with both power and toughness equal to its casting cost; target retains all its original abilities as well. This will destroy artifacts with 0 casting cost.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "37ff98ca-83e4-5fb7-9d65-49cf930e1829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f07e272-6cc7-46d6-ad5c-473d1021c179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f07e272-6cc7-46d6-ad5c-473d1021c179.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Counters a red spell being cast or destroys a red card in play.",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "c1121a0a-8e38-5dfa-bb54-03adf4cabaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd8dbb-9538-4786-b20c-0ea2f446f323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd8dbb-9538-4786-b20c-0ea2f446f323.jpg?1",
             "name": "Braingeyser",
             "text": "Draw X cards or force opponent to draw X cards.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "417bdd87-f904-5ee0-acdb-8f77d7d3eb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af53b5fc-c31a-4f26-93bf-0c45c1f4e1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af53b5fc-c31a-4f26-93bf-0c45c1f4e1e5.jpg?1",
             "name": "Clone",
             "text": "Upon summoning, Clone acquires all characteristics, including color, of any one creature in play on either side; any creature enchantments on original creature are not copied. Clone retains these characteristics even after original creature is destroyed. Clone cannot be played if there are no creatures in play.",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "14166966-b025-5236-bdc6-09cc2fa0c0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133315bd-3c46-4eff-938e-4dba63631c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133315bd-3c46-4eff-938e-4dba63631c1b.jpg?1",
             "name": "Control Magic",
             "text": "You control target creature until enchantment is discarded or game ends. You can't tap target creature this turn, but if it was already tapped it stays tapped until you can untap it. If destroyed, target creature is put in its owner's graveyard.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "32c0ce62-a95a-5e04-97da-7f669c833518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe07d-1328-4165-b7a0-622b60cec481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe07d-1328-4165-b7a0-622b60cec481.jpg?1",
             "name": "Copy Artifact",
             "text": "Select any artifact in play. This enchantment acts as a duplicate of that artifact; enchantment copy is affected by cards that affect either enchantments or artifacts. Enchantment copy remains even if original artifact is destroyed.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "340bc5b9-5ffb-5236-a465-7ea6a02ec0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11bf7c-f439-4529-b29a-d711359807ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11bf7c-f439-4529-b29a-d711359807ef.jpg?1",
             "name": "Counterspell",
             "text": "Counters target spell as it is being cast.",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "84228684-4e5c-5292-9163-ef15d1245d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce48b24-a65e-42d9-a147-8f89028fada7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce48b24-a65e-42d9-a147-8f89028fada7.jpg?1",
             "name": "Creature Bond",
             "text": "If target creature is destroyed, Creature Bond does an amount of damage equal to creature's toughness to creature's controller.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "73239221-d7ae-5d9c-980d-69280fdac38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9672caeb-5cf8-4b40-a371-005c911a67d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9672caeb-5cf8-4b40-a371-005c911a67d9.jpg?1",
             "name": "Drain Power",
             "text": "Tap all opponent's land, taking all this mana and all mana in opponent's mana pool into your mana pool. You can't tap fewer than all opponent's lands.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "5e96ae27-f64d-57e6-8c08-ff345e15f520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644288e8-e0b1-418f-b105-01a557a3e497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644288e8-e0b1-418f-b105-01a557a3e497.jpg?1",
             "name": "Feedback",
             "text": "Feedback does 1 damage to controller of target enchantment during each upkeep.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "55115de5-31da-51e6-9cb0-096f652962c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24584ffa-8ed1-4930-b6d8-ac1d02738ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24584ffa-8ed1-4930-b6d8-ac1d02738ed0.jpg?1",
             "name": "Flight",
             "text": "Target creature is now a flying creature.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "40bc65b6-360d-5632-a207-96be666df237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde97b8f-7c10-48d3-8ae2-9f86158973ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde97b8f-7c10-48d3-8ae2-9f86158973ec.jpg?1",
             "name": "Invisibility",
             "text": "Target creature can be blocked only by walls.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "b3e13894-c6a6-5a7f-b389-3f802c8b02eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e8a6e-1da8-4e6f-8433-9f0695926f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e8a6e-1da8-4e6f-8433-9f0695926f04.jpg?1",
             "name": "Jump",
             "text": "Target creature is a flying creature until end of turn.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "9cb644ca-753a-5930-b5be-fcc999565a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e7775b-b03b-4fc0-bcd9-3681cce5e70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e7775b-b03b-4fc0-bcd9-3681cce5e70c.jpg?1",
             "name": "Lifetap",
             "text": "You gain 1 life each time any forest of opponent's becomes tapped.",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "0bb43e99-c884-51a9-ad92-e6a88b5f535e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7ac1f-2243-4c70-95a4-2b7343c8d92d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7ac1f-2243-4c70-95a4-2b7343c8d92d.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk in play gain islandwalk and +1/+1 while this card is in play.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "0658b6cc-a7cf-5b86-812b-12cf8be75523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa81390-4e0b-484b-a5be-a9449cd41860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa81390-4e0b-484b-a5be-a9449cd41860.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of any card being played or already in play by replacing one basic land type with another. For example, you can change \"swampwalk\" to \"plainswalk.\"",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "98796ed3-1de9-505f-a828-bc24e5369ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f76c8-3e6d-4de5-b408-2f2394faed5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f76c8-3e6d-4de5-b408-2f2394faed5c.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "3de9176c-6993-5433-85c6-fb47338c257d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da4f9a8-024b-4707-b300-ccb11bd87cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da4f9a8-024b-4707-b300-ccb11bd87cea.jpg?1",
             "name": "Mana Short",
             "text": "All opponent's lands are tapped, and opponent's mana pool is emptied. Opponent takes no damage from unspent mana.",
             "colours": [
@@ -2121,7 +2121,7 @@
         },
         {
             "id": "68b0f289-a393-55fa-8ad6-7c4960770c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca142de-906d-4143-8f77-4acea1f1e6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca142de-906d-4143-8f77-4acea1f1e6b1.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "71c27857-2164-561f-b3e9-a094c1f241a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c6d792-0abb-474e-8c05-c4e843242ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c6d792-0abb-474e-8c05-c4e843242ef0.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nController must spend o\nU during upkeep to maintain or Phantasmal Forces are destroyed.",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "cbc64fd6-1cfd-54db-b015-d6f39aa1ba0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29369c-d909-45a7-be70-3181ddac9728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29369c-d909-45a7-be70-3181ddac9728.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Target land changes to any basic land type of caster's choice. Land type is set when cast and may not be further altered by this enchantment.",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "a6b9842f-2bf4-5d4b-a79b-e1b10bcd4d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782e90-383b-4aed-8fa0-99c8cf8b2cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782e90-383b-4aed-8fa0-99c8cf8b2cec.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "82f31f30-7aaf-5c77-aa6e-8396356ffccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925ce0a7-ae09-4220-9e67-314dbc231c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925ce0a7-ae09-4220-9e67-314dbc231c94.jpg?1",
             "name": "Pirate Ship",
             "text": "Tap to do 1 damage to any target. Cannot attack unless opponent has islands in play, though controller may still tap. Pirate Ship is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "532a4d32-82e8-50d2-ac5e-aab53d65aef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fdfb7b-1bcf-485a-be70-0130fc1fceef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fdfb7b-1bcf-485a-be70-0130fc1fceef.jpg?1",
             "name": "Power Leak",
             "text": "Target enchantment costs 2 extra mana during upkeep. If target enchantment's controller cannot or will not pay this extra mana, Power Leak does 1 damage to him or her for each unpaid mana.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "821f788d-7dfb-51d4-939d-b8ccfb5b334e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954b04e3-861a-45c9-8897-9cb4a99f04c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954b04e3-861a-45c9-8897-9cb4a99f04c3.jpg?1",
             "name": "Power Sink",
             "text": "Target spell is countered unless its caster spends X more mana; caster of target spell can't choose to let it be countered. If caster of target spell doesn't have enough mana, all available mana from lands and mana pool must be paid but target spell will still be countered.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "eb3ddb8d-1515-5b2a-872b-9d0fe3d49f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c420abf2-05ec-4623-8a6c-353736a4edeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c420abf2-05ec-4623-8a6c-353736a4edeb.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "Tap to do 1 damage to any target.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "09982730-2223-52e0-a77e-2a575e5ef09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6b789-00c5-4d72-8fb3-6808bfbf0144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6b789-00c5-4d72-8fb3-6808bfbf0144.jpg?1",
             "name": "Psionic Blast",
             "text": "Psionic Blast does 4 damage to any target, but it does 2 damage to you as well.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "d24f81af-db8c-55a5-97bb-0f10f6dc2aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c8a81f-bf05-4504-ac87-4fd4b41e88c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c8a81f-bf05-4504-ac87-4fd4b41e88c1.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever target land is tapped, Psychic Venom does 2 damage to target land's controller.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "b3d9d798-a994-5dcb-8eca-af04f9f751bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b21f91-51fd-407d-bab2-63c11f23b680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b21f91-51fd-407d-bab2-63c11f23b680.jpg?1",
             "name": "Sea Serpent",
             "text": "Serpent cannot attack unless opponent has islands in play. Serpent is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "5832570f-33b6-5b47-9216-4344552542b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ce03f3-ddc0-4cf3-8f07-551c960e8639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ce03f3-ddc0-4cf3-8f07-551c960e8639.jpg?1",
             "name": "Siren's Call",
             "text": "All of opponent's creatures that can attack must do so. Any non-wall creatures that cannot attack are destroyed at end of turn. Play only during opponent's turn, before opponent's attack. Creatures summoned this turn are unaffected by Siren's Call.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "836b6e7f-e3cc-50e0-a0a0-440cfbdfc867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4da609-6c08-4a18-b7d9-fb2f9b11bab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4da609-6c08-4a18-b7d9-fb2f9b11bab2.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of any card being played or already in play by replacing one color word with another. For example, you can change \"Counters red spells\" to \"Counters black spells.\" Cannot change mana symbols.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "936cf5f7-9efb-5117-b6bd-41c8516841fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f599b73-1d55-4acc-8931-f5ab39d1d4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f599b73-1d55-4acc-8931-f5ab39d1d4e9.jpg?1",
             "name": "Spell Blast",
             "text": "Target spell is countered; X is cost of target spell.",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "9883d8ae-f767-5351-867e-f5fad2a1bb44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c76f5d-d866-4eb7-b2d2-fc6ecf982f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c76f5d-d866-4eb7-b2d2-fc6ecf982f8e.jpg?1",
             "name": "Stasis",
             "text": "Players do not get an untap phase. Pay o\nU during your upkeep or Stasis is destroyed.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "a05efb90-b8a2-52fe-ac44-70af1c6c8bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c14d4d-abaa-411a-aaa1-0b79fccee8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c14d4d-abaa-411a-aaa1-0b79fccee8c1.jpg?1",
             "name": "Steal Artifact",
             "text": "You control target artifact until enchantment is discarded or game ends. If target artifact was tapped when stolen, it stays tapped until you can untap it. If destroyed, target artifact is put in its owner's graveyard.",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "d70950cf-aa35-5d84-be25-b16d50103d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2b2b9e-5abf-4c41-a85c-ef95e6ab84d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2b2b9e-5abf-4c41-a85c-ef95e6ab84d6.jpg?1",
             "name": "Thoughtlace",
             "text": "Changes the color of one card either being played or already in play to blue. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "6cd228a2-686c-5324-9421-a55c3c221043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54992fda-45a9-4ed1-b380-34d167feec90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54992fda-45a9-4ed1-b380-34d167feec90.jpg?1",
             "name": "Time Walk",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "4a94a818-169e-56d0-8940-11ba01014a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f1958a-50cc-43cc-80e1-988800e44ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f1958a-50cc-43cc-80e1-988800e44ca8.jpg?1",
             "name": "Timetwister",
             "text": "Set Timetwister aside in a new graveyard pile. Shuffle your hand, library, and graveyard together into a new library and draw a new hand of seven cards, leaving all cards in play where they are; opponent must do the same.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "6fc5dc32-20c9-5f71-b862-1bbb0ed42c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bd24da-f156-494e-86cb-80707863e40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bd24da-f156-494e-86cb-80707863e40b.jpg?1",
             "name": "Twiddle",
             "text": "Caster may tap or untap any one land, creature, or artifact in play. No effects are generated by the target card.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "9aaab08d-800f-5fb4-ae78-7866aeb0c3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686843c8-8c8a-4af6-bca8-e7f7583cc886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686843c8-8c8a-4af6-bca8-e7f7583cc886.jpg?1",
             "name": "Unsummon",
             "text": "Return creature to owner's hand; enchantments on creature are discarded. Unsummon cannot be played during the damage-dealing phase of an attack.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "6edf91de-2571-50ac-8946-505f88eed659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18e952b-ab4d-4f90-bf5e-4db490e4e203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18e952b-ab4d-4f90-bf5e-4db490e4e203.jpg?1",
             "name": "Vesuvan Doppelganger",
             "text": "Upon summoning, Doppelganger acquires all normal characteristics (except color) of any one creature in play on either side; any enchantments on the original creature are not copied. During controller's upkeep, Doppelganger may take on the characteristics of a different creature in play instead. Doppleganger may continue to copy a creature even after that creature leaves play, but if it switches it won't be able to switch back.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "2b3b9d93-8b06-51b9-91c8-8f6316016d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca669988-e009-4b3e-af20-ee5885554d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca669988-e009-4b3e-af20-ee5885554d34.jpg?1",
             "name": "Volcanic Eruption",
             "text": "Destroys X mountains of your choice, and does X damage to each player and each creature in play.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "82e05b90-0eb7-5398-af57-8975b5337744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71904b59-55dd-4074-9d50-c5bb0fb7266f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71904b59-55dd-4074-9d50-c5bb0fb7266f.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -2891,7 +2891,7 @@
         },
         {
             "id": "7e3bd38f-08f2-54f3-a4f7-3f221e3ddc2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34887689-0adb-4ead-87a5-1d8fd77b6278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34887689-0adb-4ead-87a5-1d8fd77b6278.jpg?1",
             "name": "Wall of Water",
             "text": "oo\nU +1/+0 until end of turn.",
             "colours": [
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "06e764b8-0450-5614-951d-21b0e594d8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f729e2-565b-4cdb-8b6f-0a14babe5680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f729e2-565b-4cdb-8b6f-0a14babe5680.jpg?1",
             "name": "Water Elemental",
             "text": "",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "94c91084-5d0b-5fee-afd6-405cefc05270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5059a-60a4-4135-863f-85a48bff8731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5059a-60a4-4135-863f-85a48bff8731.jpg?1",
             "name": "Animate Dead",
             "text": "Any creature in either player's graveyard comes into play on your side with -1 to its original power. If this enchantment is removed, or at end of game, target creature is returned to its owner's graveyard. Target creature may be killed as normal.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "04191054-a64f-557a-b230-075f74e6f57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf812f48-633c-46ab-b0c3-4819ab1b4e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf812f48-633c-46ab-b0c3-4819ab1b4e49.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures in play gain +1/+1.",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "72c9016c-10c3-5ecc-90c3-61f260c7f1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eced352-d49c-4e91-a368-52904d77a69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eced352-d49c-4e91-a368-52904d77a69d.jpg?1",
             "name": "Black Knight",
             "text": "Protection from white, first strike",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "5ef7ecba-a8ed-57ed-a00d-8439be31f09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da26289f-e0e6-4aae-8782-ebdbabf39819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da26289f-e0e6-4aae-8782-ebdbabf39819.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "bffdcbd9-13a2-5dcb-a74c-e32ec6c363cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f96e43-aebd-4de2-969a-37cd1d62f127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f96e43-aebd-4de2-969a-37cd1d62f127.jpg?1",
             "name": "Contract from Below",
             "text": "Discard your current hand and draw eight new cards, adding the first drawn to your ante. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "7bbbcfc3-0f78-5708-b13e-a3010f11b9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eea8122-00c2-4d00-b87b-12eea86b16ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eea8122-00c2-4d00-b87b-12eea86b16ba.jpg?1",
             "name": "Cursed Land",
             "text": "Cursed Land does 1 damage to target land's controller during each upkeep.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "bd31334e-07d3-5099-bd5e-f53ee99916a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0690f724-eb95-416b-b064-f1239e2a30e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0690f724-eb95-416b-b064-f1239e2a30e8.jpg?1",
             "name": "Dark Ritual",
             "text": "Add 3 black mana to your mana pool.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "8a4f09ad-0398-50ba-9bab-55a5bb43f154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b12bcb-a935-48be-a5e8-abbb890e91ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b12bcb-a935-48be-a5e8-abbb890e91ca.jpg?1",
             "name": "Darkpact",
             "text": "Without looking at it first, swap top card of your library with either card of the ante; this swap is permanent. You must have a card in your library to cast this spell. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "4a867653-e892-54fa-ad6e-99be07c94884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c942a9af-e449-4f10-916c-6eb9e944de6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c942a9af-e449-4f10-916c-6eb9e944de6a.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Destroy a green spell as it is being cast. This action may be played as an interrupt, and does not affect green cards already in play.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "c6613047-d05f-505f-9f0a-a010e599d143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16fc59a-17da-462a-86ea-31f8a9ac18a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16fc59a-17da-462a-86ea-31f8a9ac18a1.jpg?1",
             "name": "Deathlace",
             "text": "Changes the color of one card either being played or already in play to black. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "da94f103-f91b-5a01-aff0-79f317c5a33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f37eac-e8fa-48d3-b936-74461ea1853c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f37eac-e8fa-48d3-b936-74461ea1853c.jpg?1",
             "name": "Demonic Attorney",
             "text": "If opponent doesn't concede the game immediately, each player must ante an additional card from the top of his or her library. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "24d8da49-81e3-5c2e-80e3-69308954d51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20c19b-7216-4f23-a3bb-70d4dcd3865e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20c19b-7216-4f23-a3bb-70d4dcd3865e.jpg?1",
             "name": "Demonic Hordes",
             "text": "Tap to destroy 1 land. Pay o\nBo\nBo\nB during upkeep or the Hordes become tapped and you lose a land of opponent's choice.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "657d58ca-104f-57a6-9440-88b11a3e2419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e571ef-1645-4584-ab53-e7ea5d443dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e571ef-1645-4584-ab53-e7ea5d443dea.jpg?1",
             "name": "Demonic Tutor",
             "text": "You may search your library for one card and take it into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -3371,7 +3371,7 @@
         },
         {
             "id": "4aa601c3-0972-5d50-9f47-6690202363b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbc6761-c4fc-4b4c-afb5-94ad4d21bc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbc6761-c4fc-4b4c-afb5-94ad4d21bc05.jpg?1",
             "name": "Drain Life",
             "text": "Drain Life does 1 damage to a single target for each o\nB spent in addition to the casting cost. Caster gains 1 life for each damage inflicted. If you drain life from a creature, you cannot gain more life than the creature's toughness.",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "68f29fed-7dcb-5940-8524-85acc67d2f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f3a1b9-d192-49d9-87bb-ca50e99edbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f3a1b9-d192-49d9-87bb-ca50e99edbd1.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -3435,7 +3435,7 @@
         },
         {
             "id": "23f18bd6-0e44-5155-8636-6583fc102d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e995f4b-efd3-4ac7-8fec-adb913294815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e995f4b-efd3-4ac7-8fec-adb913294815.jpg?1",
             "name": "Evil Presence",
             "text": "Target land is now a swamp.",
             "colours": [
@@ -3468,7 +3468,7 @@
         },
         {
             "id": "b27c4779-a0d6-5903-b100-c473ddb6a4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67830531-970a-4339-8673-40954376455d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67830531-970a-4339-8673-40954376455d.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked by any creatures other than artifact creatures and black creatures.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "82c50a36-5a71-59c5-afe8-23f6fe391466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b6a352-40f5-4d7c-b2b6-2617539a1c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b6a352-40f5-4d7c-b2b6-2617539a1c1c.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "5b9e0158-f6a0-5f29-adb2-766112ae5655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640770d9-c0f8-40fd-9467-ebc099a27a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640770d9-c0f8-40fd-9467-ebc099a27a4b.jpg?1",
             "name": "Gloom",
             "text": "White spells cost 3 more mana to cast. Circles of Protection cost 3 more mana to use.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "1b9aa14e-20b4-5da5-8eaf-c70ed696224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018459-d09b-489a-81be-933fd7d854c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018459-d09b-489a-81be-933fd7d854c1.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gains +X/+0 until end of turn.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "77612523-a819-5015-9815-87f1e393e29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc56a0-1dc0-4261-8f9c-5a88ce83f9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc56a0-1dc0-4261-8f9c-5a88ce83f9e9.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nAn opponent damaged by Specter must discard a card at random from his or her hand. Ignore this effect if opponent has no cards left in hand.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "9dc18ee0-d355-55b4-a8bf-1d9731435e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a9c089-0aad-4c14-9bfc-c0b39c976777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a9c089-0aad-4c14-9bfc-c0b39c976777.jpg?1",
             "name": "Lich",
             "text": "You lose all life. If you gain life later in the game, instead draw one card from your library for each life. For each point of damage you suffer, you must destroy one of your cards in play. Creatures destroyed in this way cannot be regenerated. You lose if this enchantment is destroyed or if you suffer a point of damage without sending a card to the graveyard.",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "9a47152b-49a6-547e-bc64-98682de6915d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24626988-81df-44c9-9a8e-ecb9f82c383b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24626988-81df-44c9-9a8e-ecb9f82c383b.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nYou must sacrifice one of your own creatures during upkeep or Lord of the Pit does 7 damage to you. You may still attack with Lord of the Pit even if you failed to sacrifice a creature.",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "a50d26a8-53de-58e2-827d-2b74fdfcd6ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb6cbbe-c3e9-4d14-a6b8-fb74e6a02b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb6cbbe-c3e9-4d14-a6b8-fb74e6a02b33.jpg?1",
             "name": "Mind Twist",
             "text": "Opponent must discard X cards at random from hand. If opponent doesn't have enough cards in hand, entire hand is discarded.",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "b9a79dc0-f694-5db4-bc42-b1a0ff2c678b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38396ae3-a48f-44c7-96bf-ea41b5aaeebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38396ae3-a48f-44c7-96bf-ea41b5aaeebc.jpg?1",
             "name": "Nether Shadow",
             "text": "If Shadow is in graveyard with any combination of cards above it that includes at least three creatures, it can be returned to play during upkeep for its normal casting cost. Shadow can attack on same turn summoned or returned to play.",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "20136dc6-ff36-5134-9235-d91f1b9f92c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576220c3-1e6b-43f3-a47e-5e8246ee7d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576220c3-1e6b-43f3-a47e-5e8246ee7d46.jpg?1",
             "name": "Nettling Imp",
             "text": "Tap to force a particular one of opponent's non-wall creatures to attack. If target creature cannot attack, it is destroyed at end of turn. This tap should be played during opponent's turn, before the attack. May not be used on creatures summoned this turn.",
             "colours": [
@@ -3790,7 +3790,7 @@
         },
         {
             "id": "72560582-e0a0-5d83-b6fc-e6889075c88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc78dced-27d2-441a-b63b-32356bc33747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc78dced-27d2-441a-b63b-32356bc33747.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness both equal the number of swamps its controller has in play.",
             "colours": [
@@ -3824,7 +3824,7 @@
         },
         {
             "id": "3ba38f1b-03df-5c0d-b559-a1d62f60c593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106d8401-f0e2-461e-b8ea-16d475db98da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106d8401-f0e2-461e-b8ea-16d475db98da.jpg?1",
             "name": "Paralyze",
             "text": "Target creature is not untapped as normal during untap phase unless 4 mana are spent. Tap target creature when Paralyze is cast.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "7e447cde-ff9c-5d23-b992-99d3ae3ee13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1313b7e6-4acb-435a-bde5-1def5e5350ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1313b7e6-4acb-435a-bde5-1def5e5350ac.jpg?1",
             "name": "Pestilence",
             "text": "o\nB: Do 1 damage to each creature and to both players. Pestilence must be discarded at end of any turn in which there are no creatures in play at end of turn.",
             "colours": [
@@ -3888,7 +3888,7 @@
         },
         {
             "id": "b494440f-d68f-50c9-9d16-e2e8ed89a46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995b58e6-5c69-4fdf-9c41-61cef7a610c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995b58e6-5c69-4fdf-9c41-61cef7a610c4.jpg?1",
             "name": "Plague Rats",
             "text": "The Xs below are the number of Plague Rats in play, counting both sides. Thus if there are 2 Plague Rats in play, each has power and toughness 2/2.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "2ea11ca6-a92d-5b15-b457-4ccee5f29885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0066c7a6-7775-43ba-81cd-35fbc5621bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0066c7a6-7775-43ba-81cd-35fbc5621bc3.jpg?1",
             "name": "Raise Dead",
             "text": "Return creature from your graveyard to your hand.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "e753af51-d3a9-5a4d-99f6-87a72ad0f89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e33c5e-6d99-4e7e-b611-4b271a47b4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e33c5e-6d99-4e7e-b611-4b271a47b4d2.jpg?1",
             "name": "Royal Assassin",
             "text": "Tap to destroy any tapped creature.",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "69a4e235-58df-5d6c-8f58-9c8fb31326d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abe7d62-6a99-4d1f-9b81-cff0485997a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abe7d62-6a99-4d1f-9b81-cff0485997a8.jpg?1",
             "name": "Sacrifice",
             "text": "Destroy one of your creatures without regenerating it, and add to your mana pool a number of black mana equal to creature's casting cost.",
             "colours": [
@@ -4017,7 +4017,7 @@
         },
         {
             "id": "0547b280-42e2-5696-972a-b57e5ade4c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30abb09-2f80-46cf-a839-b4dac5c23dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30abb09-2f80-46cf-a839-b4dac5c23dce.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "e7408228-9282-5bec-8328-724136d99e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bfa6bb-cf7b-4a79-83f5-178a633c499e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bfa6bb-cf7b-4a79-83f5-178a633c499e.jpg?1",
             "name": "Scavenging Ghoul",
             "text": "At the end of each turn, put one counter on the Ghoul for each other creature that was destroyed without regenerating during the turn. If Ghoul dies, you may use a counter to regenerate it; counters remain until used.",
             "colours": [
@@ -4083,7 +4083,7 @@
         },
         {
             "id": "041eb3ba-68f0-51aa-b8dc-b8dcfcc75e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd5fbb-f689-4ff0-8f23-17e4cb0925a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd5fbb-f689-4ff0-8f23-17e4cb0925a2.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nVampire gets a +1/+1 counter each time a creature dies during a turn in which Vampire damaged it, unless the dead creature is regenerated.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "101b4586-bdf9-5be6-85b9-d624d1a4625e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcda143-55f8-4d02-918f-975d9090d03f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcda143-55f8-4d02-918f-975d9090d03f.jpg?1",
             "name": "Simulacrum",
             "text": "All damage done to you so far this turn is instead retroactively applied to one of your creatures in play. If this damage kills the creature it can be regenerated; even if there's more than enough damage to kill the creature, you don't suffer any of it. Further damage this turn is treated normally.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "d066587f-d805-56e3-bc26-402f1c3b1bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea4387-f23c-430c-99d6-0248a4ab1713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea4387-f23c-430c-99d6-0248a4ab1713.jpg?1",
             "name": "Sinkhole",
             "text": "Destroys any one land.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "ce417f3f-8953-54f6-8f51-3b7e1e2ecebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8598b-35e5-414f-aee0-52137236f642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8598b-35e5-414f-aee0-52137236f642.jpg?1",
             "name": "Terror",
             "text": "Destroys target creature without possibility of regeneration. Does not affect black creatures and artifact creatures.",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "134fb7c3-b25c-58a6-92a9-121cc3ee9edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1c781d-1f27-40e3-9d79-0ebb6677e835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1c781d-1f27-40e3-9d79-0ebb6677e835.jpg?1",
             "name": "Unholy Strength",
             "text": "Target creature gains +2/+1.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "fb261176-27fd-5f1b-852d-2ad02835e2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7930666c-12ac-420b-8ced-0e924925b075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7930666c-12ac-420b-8ced-0e924925b075.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "c44f8b2c-6c6d-5a4a-96e6-3a8cc5f93ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a289787-2d30-4e0b-ac97-3767818d0387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a289787-2d30-4e0b-ac97-3767818d0387.jpg?1",
             "name": "Warp Artifact",
             "text": "Warp Artifact does 1 damage to target artifact's controller at start of each turn.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "f190c81f-b708-52c1-924f-957e59fc8136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16137fa6-1b5c-49e7-ad79-dda4b7019a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16137fa6-1b5c-49e7-ad79-dda4b7019a59.jpg?1",
             "name": "Weakness",
             "text": "Target creature loses -2/-1; if this drops the creature's toughness below 1, it is dead.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "27093f7d-ffb0-5844-a277-56139be49ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b60630c-f97c-43be-8410-53a68613b735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b60630c-f97c-43be-8410-53a68613b735.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying; oo\nB Regenerates",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "e5e250c7-3ccb-5e36-8beb-059535d6ae72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d37b529-8a41-4177-abef-614f363e69d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d37b529-8a41-4177-abef-614f363e69d1.jpg?1",
             "name": "Word of Command",
             "text": "You may look at opponent's hand and choose any card opponent can legally play using mana from his or her mana pool or lands. Opponent must play this card immediately; you make all the decisions it calls for. This spell may not be countered after you have looked at opponent's hand.",
             "colours": [
@@ -4406,7 +4406,7 @@
         },
         {
             "id": "1ed0d05d-3536-5a47-914e-42eea5baebc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bfda92-b932-46d8-b549-e2bc2b584a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bfda92-b932-46d8-b549-e2bc2b584a17.jpg?1",
             "name": "Zombie Master",
             "text": "All zombies in play gain swampwalk and \"oo\nB Regenerates\" for as long as this card remains in play.",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "84c96da8-aa05-5684-88fc-dce6b495d698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8795bab7-ced2-4a1d-8c57-636bc4c0a977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8795bab7-ced2-4a1d-8c57-636bc4c0a977.jpg?1",
             "name": "Burrowing",
             "text": "Target creature gains mountainwalk.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "db5c89a5-8c83-5f7b-aaea-f8e7c805631f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d980e9c0-db88-41f9-8dbf-89f0e1ac6c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d980e9c0-db88-41f9-8dbf-89f0e1ac6c20.jpg?1",
             "name": "Chaoslace",
             "text": "Changes the color of one card either being played or already in play to red. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "e3d68ddd-942a-56dd-8c44-49fd832d2b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb3a6b9-a119-49c0-9baf-b552fdd00b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb3a6b9-a119-49c0-9baf-b552fdd00b28.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate does X damage to one target. If target dies this turn, it is removed from game entirely and cannot be regenerated. Return target to its owner's deck only when game is over.",
             "colours": [
@@ -4534,7 +4534,7 @@
         },
         {
             "id": "7ea698e4-9bd9-59a9-a759-8c4ac8bcb07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e009adf-aded-4d64-ba3e-ddc3448c967a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e009adf-aded-4d64-ba3e-ddc3448c967a.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\noo\nR +1/+0 until end of turn; if more than o\nRo\nRo\nR is spent in this way, Dragon Whelp is destroyed at end of turn.",
             "colours": [
@@ -4567,7 +4567,7 @@
         },
         {
             "id": "6f3c2477-2f04-5981-9258-1932b8391be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e552dfb6-b8a5-419d-b098-5aedc0500684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e552dfb6-b8a5-419d-b098-5aedc0500684.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "Tap to destroy a wall.",
             "colours": [
@@ -4600,7 +4600,7 @@
         },
         {
             "id": "f4af3479-b54d-5f48-b414-29f74721b4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de88cf-b9e5-4611-a16f-2787d8d9d269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de88cf-b9e5-4611-a16f-2787d8d9d269.jpg?1",
             "name": "Dwarven Warriors",
             "text": "Tap to make a creature of power no greater than 2 unblockable until end of turn. Other cards may later be used to increase target creature's power beyond 2 after defense is chosen.",
             "colours": [
@@ -4634,7 +4634,7 @@
         },
         {
             "id": "46b8fb31-5370-523f-9168-d9aa6d777689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427e8cc-d908-4b88-931d-a540fc8bfe74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427e8cc-d908-4b88-931d-a540fc8bfe74.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "90240413-36d5-5dfd-a76f-61c9861d3184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5955a9d-8a0e-4e57-9433-ed3392b2f308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5955a9d-8a0e-4e57-9433-ed3392b2f308.jpg?1",
             "name": "Earthbind",
             "text": "Earthbind does 2 damage to target flying creature, which also loses flying ability.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "fa320e2a-f1bc-58ff-8a2a-762140d6d347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86435875-ac92-4348-b41e-19570cf62a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86435875-ac92-4348-b41e-19570cf62a1c.jpg?1",
             "name": "Earthquake",
             "text": "Does X damage to each player and each non-flying creature in play.",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "d5e33baf-ad85-5f3b-ad69-d225ea04cacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ebc485-f1b7-436d-8c90-9acf2f7d92e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ebc485-f1b7-436d-8c90-9acf2f7d92e5.jpg?1",
             "name": "False Orders",
             "text": "You decide whether and how one defending creature blocks, though you can't make a choice the defender couldn't legally make. Play after defender has chosen defense but before damage is dealt.",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "56f8c120-24ab-5461-909b-cf43308c8061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376cb9e5-89fb-4091-8a20-140bb6de0ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376cb9e5-89fb-4091-8a20-140bb6de0ef6.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4795,7 +4795,7 @@
         },
         {
             "id": "c2751942-7426-5dd5-ae0a-90c8da1265bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285ab2e-836e-45b0-894e-574f733cf3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285ab2e-836e-45b0-894e-574f733cf3db.jpg?1",
             "name": "Fireball",
             "text": "Fireball does X damage total, divided evenly (round down) among any number of targets. Pay 1 extra mana for each target beyond the first.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "30171700-f418-5af5-b63b-f9ea0c41b46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e4321-0216-4d6a-a57b-72ebff427b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e4321-0216-4d6a-a57b-72ebff427b09.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR +1/+0",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "66acebdc-6fdc-51f5-880c-5bd79e3c015c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2a91b9-c45f-4e3d-b3c4-944493bdd86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2a91b9-c45f-4e3d-b3c4-944493bdd86a.jpg?1",
             "name": "Flashfires",
             "text": "All plains in play are destroyed.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "d8df45dc-4f88-5dee-88c7-7dfa8430fbac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8144418b-e3e5-459f-8db2-f2e348fba4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8144418b-e3e5-459f-8db2-f2e348fba4da.jpg?1",
             "name": "Fork",
             "text": "Any sorcery or instant spell just cast is doubled. Treat Fork as an exact copy of target spell except that Fork remains red. Copy and original may have different targets.",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "988813af-944c-5355-a740-2a189a8a2202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdb52dd-4fc5-4594-b53b-ea169325be0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdb52dd-4fc5-4594-b53b-ea169325be0b.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "oo\nR Goblins gain flying ability until end of turn. Controller may not choose to make Goblins fly after they have been blocked.",
             "colours": [
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "2af24f79-08c5-54bc-a7de-03a19669bc00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65705a8d-6bb1-4289-b8b0-8546ccc478dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65705a8d-6bb1-4289-b8b0-8546ccc478dc.jpg?1",
             "name": "Goblin King",
             "text": "Goblins in play gain mountainwalk and +1/+1 while this card remains in play.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "4a010564-94bc-56d5-9fbf-afb4d0c9cf66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affb57f4-273a-425c-a1b3-d0a5407f43d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affb57f4-273a-425c-a1b3-d0a5407f43d5.jpg?1",
             "name": "Granite Gargoyle",
             "text": "Flying; oo\nR +0/+1 until end of turn.",
             "colours": [
@@ -5021,7 +5021,7 @@
         },
         {
             "id": "c7e1ada3-0b96-519c-b42d-135b60e11666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41023495-d3cb-4cb0-b95c-f717480a76a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41023495-d3cb-4cb0-b95c-f717480a76a5.jpg?1",
             "name": "Gray Ogre",
             "text": "",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "0113d0ae-30c1-5f04-a61d-64351dce2bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4905e98f-0c5a-4ec7-b85b-dc2c3549d5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4905e98f-0c5a-4ec7-b85b-dc2c3549d5d0.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "91b461e3-6506-502b-9adb-62ed21b633af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29573-99a1-42fc-8941-2466cda2465f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29573-99a1-42fc-8941-2466cda2465f.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "9cef3df3-b846-52e6-858d-49a8fb3d7d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7be8a25-a744-426e-8e66-7fdff2789af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7be8a25-a744-426e-8e66-7fdff2789af4.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Cannot be used to block any creature of power more than 1.",
             "colours": [
@@ -5153,7 +5153,7 @@
         },
         {
             "id": "dcb9af0f-6963-5267-a494-2fe6a1253e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07deb9b-5b88-4658-8ae8-041568992019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07deb9b-5b88-4658-8ae8-041568992019.jpg?1",
             "name": "Keldon Warlord",
             "text": "The Xs below are the number of non-wall creatures on your side, including Warlord. Thus if you have 2 other non-wall creatures, Warlord is 3/3. If one of those creatures is killed during the turn, Warlord immediately becomes 2/2.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "50654227-37ac-56b0-a2fb-a1a804dc9133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d3dcab-2260-479d-9ef6-dfb92d4f6061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d3dcab-2260-479d-9ef6-dfb92d4f6061.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt does 3 damage to one target.",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "ee38dc46-ba64-5ef0-885b-2394ea1b725f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44d3087-ced3-40e8-a63b-1733b7e7f34c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44d3087-ced3-40e8-a63b-1733b7e7f34c.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever either player taps land for mana, each land produces 1 extra mana of the appropriate type.",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "a06b241a-00b1-565b-b841-635068536411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c01cae0-4d61-4bf7-a145-82d9bb11d816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c01cae0-4d61-4bf7-a145-82d9bb11d816.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever any land is tapped, Manabarbs does 1 damage to the land's controller.",
             "colours": [
@@ -5280,7 +5280,7 @@
         },
         {
             "id": "c2bcbd45-b335-51d3-a920-d587d0afb6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf039d-0ab9-4c42-a0a3-cbfa3ea1dd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf039d-0ab9-4c42-a0a3-cbfa3ea1dd6e.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "4d771d7e-547f-580b-a76a-fcbfc0a97930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2354ee-2ce0-4adb-b48c-0e30b952e545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2354ee-2ce0-4adb-b48c-0e30b952e545.jpg?1",
             "name": "Orcish Artillery",
             "text": "Tap to do 2 damage to any target, but you suffer 3 damage as well.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "fcced834-775f-50c1-81e5-7b3cfcbc91cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2752cf2-9a48-49a8-98ff-2e32a9121d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2752cf2-9a48-49a8-98ff-2e32a9121d78.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "When attacking, all of your attacking creatures gain +1/+0.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "1ae90d89-e8f6-5cff-b0bf-36f125e2a978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52eb10a-a9eb-44b7-95ae-12fb551c8fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52eb10a-a9eb-44b7-95ae-12fb551c8fa5.jpg?1",
             "name": "Power Surge",
             "text": "Before untapping lands at the start of a turn, each player takes 1 damage for each land he or she controls but did not tap during the previous turn.",
             "colours": [
@@ -5409,7 +5409,7 @@
         },
         {
             "id": "61bfffcf-e05c-5972-b439-41b32a4b8690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14746bb-aa00-4be2-9740-d87f976296d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14746bb-aa00-4be2-9740-d87f976296d2.jpg?1",
             "name": "Raging River",
             "text": "When you attack, non-flying defending creatures must be divided as opponent wishes between the left and right sides of the River. You then choose on which side of the River to place each attacking creature, and attacking creatures can only be blocked by flying creatures or those on the same side of the River.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "d975fbda-c3bd-5d07-bfe2-65e0f4af14f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fafd3f9-f7de-4d6e-8824-6b60866fc50f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fafd3f9-f7de-4d6e-8824-6b60866fc50f.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Counters a blue spell being cast or destroys a blue card in play.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "895e664f-2486-549c-9ebd-399145f864d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b9e3ae-c7e9-455f-abfe-220262719beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b9e3ae-c7e9-455f-abfe-220262719beb.jpg?1",
             "name": "Roc of Kher Ridges",
             "text": "Flying",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "51c1045f-0173-5047-83f7-c1a98ca52459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17a982d-466d-4fec-b85a-a44161e5dad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17a982d-466d-4fec-b85a-a44161e5dad5.jpg?1",
             "name": "Rock Hydra",
             "text": "Put X +1/+1 counters (heads) on Hydra. Each point of damage Hydra suffers destroys one head unless o\nR is spent. During upkeep, new heads may be grown for o\nRo\nRo\nR apiece.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "3fb1a1db-0edb-5b44-9954-b9b16414fd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec317b-52a6-4490-80e5-a56826b06771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec317b-52a6-4490-80e5-a56826b06771.jpg?1",
             "name": "Sedge Troll",
             "text": "oo\nB Regenerates. Troll gains +1/+1 if controller has swamps in play.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "81e13939-7297-5c0e-ab0a-8509d0bb74ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ddf3f4-1305-4599-bf4c-f9e148bdda4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ddf3f4-1305-4599-bf4c-f9e148bdda4d.jpg?1",
             "name": "Shatter",
             "text": "Shatter destroys target artifact.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "1fab4a0e-c5e7-554f-a72b-7e7862acbbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e64822a-6817-4e1e-8155-3e95f8e3763f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e64822a-6817-4e1e-8155-3e95f8e3763f.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying, oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "0322ba30-a22b-519a-83dd-e64884653a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb0cb82-d930-43c3-a6d6-f947018d45d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb0cb82-d930-43c3-a6d6-f947018d45d6.jpg?1",
             "name": "Smoke",
             "text": "Each player can only untap one creature during his or her untap phase.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "7b199ae5-f53c-5a79-a975-2cb8c7e1ca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b5f545-a87d-4292-880f-5cd2f6755748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b5f545-a87d-4292-880f-5cd2f6755748.jpg?1",
             "name": "Stone Giant",
             "text": "Tap to make one of your own creatures a flying creature until end of turn. Target creature, which must have toughness less than Stone Giant's power, is destroyed at end of turn.",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "39b9acca-60c7-5739-a654-9725fd20e528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901831ad-1840-4287-b6a0-bea310598dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901831ad-1840-4287-b6a0-bea310598dc2.jpg?1",
             "name": "Stone Rain",
             "text": "Destroys any one land.",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "068f88f6-8228-5d06-8c6f-8eb9c1cb0a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc738025-a771-4186-b08c-7b37c0e9713b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc738025-a771-4186-b08c-7b37c0e9713b.jpg?1",
             "name": "Tunnel",
             "text": "Destroys 1 wall. Target wall cannot be regenerated.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "dd154c88-8235-5ca0-9925-11391b89669a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fcbb16-f8e7-4f6e-a806-541ef54aa025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fcbb16-f8e7-4f6e-a806-541ef54aa025.jpg?1",
             "name": "Two-Headed Giant of Foriys",
             "text": "Trample\nMay block two attacking creatures; divide damage between them however controller likes.",
             "colours": [
@@ -5794,7 +5794,7 @@
         },
         {
             "id": "ce318d91-f714-5314-b4ba-249a050cd9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f46e9a-6075-4fa5-8f60-f81e2024b13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f46e9a-6075-4fa5-8f60-f81e2024b13d.jpg?1",
             "name": "Uthden Troll",
             "text": "oo\nR Regenerates",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "3e7f7656-df0c-583c-b7e0-fdebf2d4ced2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88baaea5-69ec-4756-86c2-9c9d73ca8ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88baaea5-69ec-4756-86c2-9c9d73ca8ef1.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "5eeee0c2-8b98-5853-95eb-960e772762bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ba196-a107-41ac-b02a-5f8b10ecd130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ba196-a107-41ac-b02a-5f8b10ecd130.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "9abfc13a-e504-5419-84bf-dab7efe86f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1",
             "name": "Wheel of Fortune",
             "text": "Both players must discard their hands and draw seven new cards.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "b3c3b0f0-b472-5a68-b66f-2cf474e3dd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7dc8e-e02a-4ceb-8767-2875f86e6811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7dc8e-e02a-4ceb-8767-2875f86e6811.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Target creature's power and toughness are increased by half the number of forests you have in play, rounding down for power and up for toughness.",
             "colours": [
@@ -5957,7 +5957,7 @@
         },
         {
             "id": "e4c0ac51-5d98-5d36-901d-36d68ec4c8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d6f431-a7ea-4508-a52c-86d33e12e4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d6f431-a7ea-4508-a52c-86d33e12e4e4.jpg?1",
             "name": "Berserk",
             "text": "Until end of turn, target creature's current power doubles and it gains trample ability. If it attacks, target creature is destroyed at end of turn. This spell cannot be cast after current turn's attack is completed.",
             "colours": [
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "b89cfede-bd9c-54d8-a020-55b8eb8f9bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d7a68-8682-4073-a44b-f10f5613879c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d7a68-8682-4073-a44b-f10f5613879c.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\nTap to add one mana of any color to your mana pool. This tap may be played as an interrupt.",
             "colours": [
@@ -6021,7 +6021,7 @@
         },
         {
             "id": "b7fb288e-f597-5bfb-8a27-b58978c57bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55ff95-32a3-43ba-82e5-a5a3bc2cc9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55ff95-32a3-43ba-82e5-a5a3bc2cc9e5.jpg?1",
             "name": "Camouflage",
             "text": "You may rearrange your attacking creatures and place them face down, revealing which is which only after defense is chosen. If this results in impossible blocks, such as non-flying creatures blocking flying creatures, illegal blockers cannot block this turn.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "4a69ad5a-4b5b-5775-908b-fe295a3db6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa6468a-335a-467d-aef6-e537af9d5c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa6468a-335a-467d-aef6-e537af9d5c1c.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, you may add colorless mana to your mana pool, at a cost of 1 life each. These additions are played with the speed of an interrupt. Effects that prevent damage may not be used to counter this loss of life.",
             "colours": [
@@ -6083,7 +6083,7 @@
         },
         {
             "id": "798ae1a4-bc5a-59d9-8905-d7f37bdd5eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71dd0f-dffe-4671-b9e3-ddec70626688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71dd0f-dffe-4671-b9e3-ddec70626688.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nAny non-wall creature blocking Cockatrice is destroyed, as is any creature blocked by Cockatrice. Creatures destroyed in this way deal their damage before dying.",
             "colours": [
@@ -6116,7 +6116,7 @@
         },
         {
             "id": "622f5419-ef70-570a-893c-4f1c1a069342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d5c1c7-a882-479a-9077-0784e83b462d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d5c1c7-a882-479a-9077-0784e83b462d.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -6149,7 +6149,7 @@
         },
         {
             "id": "ea5a852d-fa5e-5595-8b0e-8adb6a022606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3240d5e-b3d4-4368-b09b-c309bc935152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3240d5e-b3d4-4368-b09b-c309bc935152.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "6b623389-f575-5033-b405-059a976efb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48ed192-c1a1-437a-80dd-647a616b46e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48ed192-c1a1-437a-80dd-647a616b46e3.jpg?1",
             "name": "Fastbond",
             "text": "You may put as many lands into play as you want each turn. Fastbond does 1 damage to you for every land beyond the first that you play in a single turn.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "c1ca5f28-73d2-5997-a51c-f50ac5874a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e9597a-4489-47e9-8b15-888acb402ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e9597a-4489-47e9-8b15-888acb402ddd.jpg?1",
             "name": "Fog",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is dealt.",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "9a62b1bb-cbc5-5808-9824-dffd19a833e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25a61b3-c828-491c-868d-e4eff770c1bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25a61b3-c828-491c-868d-e4eff770c1bb.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nYou must pay o\nGo\nGo\nGo\nG during upkeep or Force of Nature does 8 damage to you. You may still attack with Force of Nature even if you failed to pay the upkeep.",
             "colours": [
@@ -6278,7 +6278,7 @@
         },
         {
             "id": "10b07e34-67f6-578a-b516-65ec1a3e19cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a58f0b-c772-4254-8686-182d26889f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a58f0b-c772-4254-8686-182d26889f9c.jpg?1",
             "name": "Fungusaur",
             "text": "Each time Fungusaur is damaged but not destroyed, put a +1/+1 counter on it.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "4ed4d91d-f008-56d7-b510-21f5c6edad5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554362d7-97b3-4a55-9292-15e90435088d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554362d7-97b3-4a55-9292-15e90435088d.jpg?1",
             "name": "Gaea's Liege",
             "text": "When defending, Gaea's Liege has power and toughness equal to the number of forests you have in play; when it's attacking, they are equal to the number of forests opponent has in play. Tap to turn any one land into a forest until Gaea's Liege leaves play. Mark changed lands with counters, removing the counters when Gaea's Liege leaves play.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "01107f75-2e0e-51f0-8dcb-3dce8b96fff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755a45bd-8fe6-4e4d-8065-024a2836751b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755a45bd-8fe6-4e4d-8065-024a2836751b.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gains +3/+3 until end of turn.",
             "colours": [
@@ -6376,7 +6376,7 @@
         },
         {
             "id": "6072aabc-56d1-5f2d-a39b-0139f10f74ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea35ce-8aa1-4818-8ad5-7e462452f10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea35ce-8aa1-4818-8ad5-7e462452f10e.jpg?1",
             "name": "Giant Spider",
             "text": "Does not fly, but can block flying creatures.",
             "colours": [
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "4b35d338-f8cd-5d65-86f8-49cc76756592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7aa2b93-0a84-4318-bf2d-58164f0a846f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7aa2b93-0a84-4318-bf2d-58164f0a846f.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -6442,7 +6442,7 @@
         },
         {
             "id": "aca2bee1-7244-5064-af35-b45bb455d233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3939f72-1ec6-4b2c-b37e-b1ebb024bb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3939f72-1ec6-4b2c-b37e-b1ebb024bb8f.jpg?1",
             "name": "Hurricane",
             "text": "All players and flying creatures suffer X damage.",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "220090b2-c5f8-504f-803d-5e48015bc0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c439c5a-b4a5-411b-9e68-fb8438ccdfb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c439c5a-b4a5-411b-9e68-fb8438ccdfb0.jpg?1",
             "name": "Ice Storm",
             "text": "Destroys any one land.",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "c0bc6296-8259-5e1f-a4cf-abdef148043d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58334cf9-5186-4fba-963c-fffb21f2b8de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58334cf9-5186-4fba-963c-fffb21f2b8de.jpg?1",
             "name": "Instill Energy",
             "text": "You may untap target creature both during your untap phase and one additional time during your turn. Target creature may attack the turn it comes into play.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "97467c42-0f9d-5dc8-a34b-acc114ab6eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9479ae-2b42-4137-9e62-ef4d7fd17d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9479ae-2b42-4137-9e62-ef4d7fd17d0c.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "2a132c39-996c-5665-afe5-fe089ff19e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced83afa-9718-4b8a-961b-394f8595c480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced83afa-9718-4b8a-961b-394f8595c480.jpg?1",
             "name": "Kudzu",
             "text": "When target land becomes tapped, it is destroyed. Unless that was the last land in play, Kudzu is not discarded; instead, the player whose land it just destroyed may place it on another land of his or her choice.",
             "colours": [
@@ -6603,7 +6603,7 @@
         },
         {
             "id": "c69e8737-137d-5e98-8a54-a24d82d67c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58867ec-0b1a-4804-bc2e-1c88d338c29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58867ec-0b1a-4804-bc2e-1c88d338c29e.jpg?1",
             "name": "Ley Druid",
             "text": "Tap Druid to untap a land of your choice. This action can be played as an interrupt.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "6500e96c-11d4-5d3b-9323-0d1b74b58fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3715abe2-5a8e-4bf4-ac02-6c755d86bb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3715abe2-5a8e-4bf4-ac02-6c755d86bb4c.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Destroy a black spell as it is being cast. This use may be played as an interrupt, and does not affect black cards already in play.",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "d67e0e36-1dd1-53aa-bc2f-84edc786cfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9379e159-43ac-4bd2-8b33-f3de8e20cfe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9379e159-43ac-4bd2-8b33-f3de8e20cfe0.jpg?1",
             "name": "Lifelace",
             "text": "Changes the color of one card either being played or already in play to green. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -6699,7 +6699,7 @@
         },
         {
             "id": "09107d1e-fda6-5e13-8b29-9e66cd55d2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf6678-f597-407d-9a95-02bbe6c4bcf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf6678-f597-407d-9a95-02bbe6c4bcf3.jpg?1",
             "name": "Living Artifact",
             "text": "Put a counter on target artifact for each life you lose. During upkeep you may trade one counter for one life, but you can only trade in one counter each turn.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "b2746850-a960-59ff-a407-80edfcd28d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f132acbd-53e5-430a-8f93-8b7469633c0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f132acbd-53e5-430a-8f93-8b7469633c0e.jpg?1",
             "name": "Living Lands",
             "text": "Treat all forests in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. The living lands have no color; they are not considered green cards.",
             "colours": [
@@ -6763,7 +6763,7 @@
         },
         {
             "id": "e6ea1921-72aa-57c5-be67-04b72fc0f33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd80204-e9ba-483f-9b75-a69712545ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd80204-e9ba-483f-9b75-a69712545ba9.jpg?1",
             "name": "Llanowar Elves",
             "text": "Tap to add 1 green mana to your mana pool. This tap can be played as an interrupt.",
             "colours": [
@@ -6797,7 +6797,7 @@
         },
         {
             "id": "5c70cc67-9382-5018-ac4f-d4ff0dd026f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31495ab-e6ed-40a6-b82d-aa6092b049e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31495ab-e6ed-40a6-b82d-aa6092b049e2.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. If a creature has the ability to block more than one creature, Lure does not prevent this. If there is more than one attacking creature with Lure, defender may choose which of them each defending creature blocks.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "b265c419-f858-5a74-aac1-b04572011c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a594299e-fc3a-4d46-bd58-1a9cf7ddbdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a594299e-fc3a-4d46-bd58-1a9cf7ddbdd7.jpg?1",
             "name": "Natural Selection",
             "text": "Look at top three cards of any player's library. You may opt to rearrange those three cards or shuffle the entire library.",
             "colours": [
@@ -6861,7 +6861,7 @@
         },
         {
             "id": "b46c0526-96a3-55ec-a58f-bb1f166adba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ad2d7f-34a5-4b17-ae11-16b322601d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ad2d7f-34a5-4b17-ae11-16b322601d73.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Target creature regenerates.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "1c119481-b437-5dd2-8083-b3f502d82262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898cd314-9060-4f1c-a821-1d61a292a12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898cd314-9060-4f1c-a821-1d61a292a12b.jpg?1",
             "name": "Regrowth",
             "text": "Return any card from your graveyard to your hand.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "b6248eea-1ca9-5e8d-b074-20bc57829f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafe9639-e9d0-4aa2-8a16-f4ec24c140c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafe9639-e9d0-4aa2-8a16-f4ec24c140c0.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "072a9489-b64f-5239-97eb-49d3b0ed9b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac8bdb0-2dfd-4531-a4d9-420f2f2a90be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac8bdb0-2dfd-4531-a4d9-420f2f2a90be.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "8f2f1a46-ecba-503e-81e0-17ebb413e9dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a2c9-850e-400d-b0b3-edd8a946e380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a2c9-850e-400d-b0b3-edd8a946e380.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "f864b601-6c8d-5ab8-a0a0-209893028cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6321e16b-0b4b-4d36-ab94-97bf5816acf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6321e16b-0b4b-4d36-ab94-97bf5816acf4.jpg?1",
             "name": "Thicket Basilisk",
             "text": "Any non-wall creature blocking Basilisk is destroyed, as is any creature blocked by Basilisk. Creatures destroyed this way deal their damage before dying.",
             "colours": [
@@ -7056,7 +7056,7 @@
         },
         {
             "id": "6ea81f58-0f7f-596c-bb31-776e27e82f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa598db8-c0c7-4a9a-bd89-6d3da0d3dfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa598db8-c0c7-4a9a-bd89-6d3da0d3dfba.jpg?1",
             "name": "Timber Wolves",
             "text": "Bands",
             "colours": [
@@ -7089,7 +7089,7 @@
         },
         {
             "id": "0905b77a-a16d-550f-8469-8f2426f254ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee21b620-4dfa-4e06-872e-8d8ffce12f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee21b620-4dfa-4e06-872e-8d8ffce12f76.jpg?1",
             "name": "Tranquility",
             "text": "All enchantments in play must be discarded.",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "bb2a37de-ceac-5c14-8d98-1bbd1168c3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b6f5a-1ba2-409d-9b9b-91e2c1470f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b6f5a-1ba2-409d-9b9b-91e2c1470f62.jpg?1",
             "name": "Tsunami",
             "text": "All islands in play are destroyed.",
             "colours": [
@@ -7151,7 +7151,7 @@
         },
         {
             "id": "5d6d240c-29a5-5f07-8dbf-cd46c882cda3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f051c-6be3-4f92-8f66-9f72d75dbcf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f051c-6be3-4f92-8f66-9f72d75dbcf5.jpg?1",
             "name": "Verduran Enchantress",
             "text": "While Enchantress is in play, you may immediately draw a card from your library each time you cast an enchantment.",
             "colours": [
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "47b89da4-bf4b-5f38-8541-325d63e20412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fca52b-80b3-4b6b-9a49-110c66557894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fca52b-80b3-4b6b-9a49-110c66557894.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerates",
             "colours": [
@@ -7219,7 +7219,7 @@
         },
         {
             "id": "fa96e843-693f-5914-99a2-1c49a73c934e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05a648-7719-4ed3-aa3b-648463ee2869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05a648-7719-4ed3-aa3b-648463ee2869.jpg?1",
             "name": "Wall of Ice",
             "text": "",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "98c3fb5a-ec1d-5f51-a1f7-54e35d700775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5054a4-599d-49df-9a80-77eeed47891f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5054a4-599d-49df-9a80-77eeed47891f.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "442981e3-98ec-5e25-9dea-e583c83376ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393f08a2-7aa8-443f-aab5-4287240e9167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393f08a2-7aa8-443f-aab5-4287240e9167.jpg?1",
             "name": "Wanderlust",
             "text": "Wanderlust does 1 damage to target creature's controller during upkeep.",
             "colours": [
@@ -7318,7 +7318,7 @@
         },
         {
             "id": "1b0edb7b-d6a3-5577-afdf-e253b7d39dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67175d-ac5c-4947-b243-d5206b552bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67175d-ac5c-4947-b243-d5206b552bdc.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "68c3b0d2-3f8c-5e88-a8fd-7e1ded6a7022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f84dc2-5a29-447d-97ab-a10afd9ee538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f84dc2-5a29-447d-97ab-a10afd9ee538.jpg?1",
             "name": "Web",
             "text": "Target creature gains +0/+2 and can now block flying creatures, though it does not gain the power to fly.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "4d0b1b76-14c7-53b6-aace-40bec393f21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f299eb-9cd6-40bc-ad44-22e3aeb5c930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f299eb-9cd6-40bc-ad44-22e3aeb5c930.jpg?1",
             "name": "Wild Growth",
             "text": "When tapped, target land provides 1 green mana in addition to the mana it normally provides.",
             "colours": [
@@ -7417,7 +7417,7 @@
         },
         {
             "id": "b8799a7d-def4-5562-bad1-ce2ec0adc148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0367e54-eb07-475a-b06b-f869a046a86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0367e54-eb07-475a-b06b-f869a046a86c.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Ankh does 2 damage to anyone who puts a new land into play.",
             "colours": [],
@@ -7444,7 +7444,7 @@
         },
         {
             "id": "84ba630e-a657-5400-a650-55af3a5887ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d73362-43c1-4dd0-87dd-9aa7ae13ff2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d73362-43c1-4dd0-87dd-9aa7ae13ff2f.jpg?1",
             "name": "Basalt Monolith",
             "text": "Tap to add 3 colorless mana to your mana pool. Does not untap as normal during untap phase; spend o3 to untap. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "7415e72a-f2f7-53e5-bcec-0a8c61ff3a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a69a1c-c80f-4413-a6fd-ae54cabbce28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a69a1c-c80f-4413-a6fd-ae54cabbce28.jpg?1",
             "name": "Black Lotus",
             "text": "Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7498,7 +7498,7 @@
         },
         {
             "id": "ac2c123f-5601-56d9-bd3b-8a98fb580ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d234f3d7-2f15-4fbf-92db-16c3433d644b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d234f3d7-2f15-4fbf-92db-16c3433d644b.jpg?1",
             "name": "Black Vise",
             "text": "If opponent has more than four cards in hand during upkeep, black vise does 1 damage to opponent for each card in excess of four.",
             "colours": [],
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "be3005a3-29fb-529a-8452-6af86ba3f60a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c5460-8d4c-47a7-8a9c-ab626daa520a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c5460-8d4c-47a7-8a9c-ab626daa520a.jpg?1",
             "name": "Celestial Prism",
             "text": "o2: Provides 1 mana of any color. This use can be played as an interrupt.",
             "colours": [],
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "f7c254d4-621b-5df2-bb8d-6020749f55be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bec436c-2869-432a-b3cf-633a58af6d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bec436c-2869-432a-b3cf-633a58af6d4c.jpg?1",
             "name": "Chaos Orb",
             "text": "o1: Flip Chaos Orb onto the playing area from a height of at least one foot. Chaos Orb must turn completely over at least once or it is discarded with no effect. When Chaos Orb lands, any cards in play that it touches are destroyed, as is Chaos Orb.",
             "colours": [],
@@ -7579,7 +7579,7 @@
         },
         {
             "id": "86d70180-aa7f-587a-b7d8-f058109769ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efe95-ae57-4ff1-8f8a-0d6f3bd36d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efe95-ae57-4ff1-8f8a-0d6f3bd36d9c.jpg?1",
             "name": "Clockwork Beast",
             "text": "Put seven +1/+0 counters on Beast. After Beast attacks or blocks a creature, discard a counter. During the untap phase, controller may buy back lost counters for 1 mana per counter instead of tapping Beast; this taps Beast if it wasn't tapped already.",
             "colours": [],
@@ -7609,7 +7609,7 @@
         },
         {
             "id": "214a886d-5704-5c18-8251-ca3126663016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54af3-7c85-43da-b0ce-df4a44af4736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54af3-7c85-43da-b0ce-df4a44af4736.jpg?1",
             "name": "Conservator",
             "text": "o3: Prevent the loss of up to 2 life.",
             "colours": [],
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "57647c77-deef-5672-b9e8-3b702a634f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93842064-a0a8-4e4d-9c8a-e8a86448d225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93842064-a0a8-4e4d-9c8a-e8a86448d225.jpg?1",
             "name": "Copper Tablet",
             "text": "Copper Tablet does 1 damage to each player during his or her upkeep.",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "6ee10abb-c738-5bb1-8f96-7d3c2dd29c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44d892f-a975-4062-8a54-5777d2600504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44d892f-a975-4062-8a54-5777d2600504.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Any blue spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "4e0fc1eb-c219-5df1-8ca5-aa51ea3f634a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00775f44-fbe6-41ee-9977-d13d1fb5b6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00775f44-fbe6-41ee-9977-d13d1fb5b6fb.jpg?1",
             "name": "Cyclopean Tomb",
             "text": "o2: Turn any one non-swamp land into swamp during upkeep. Mark the changed lands with tokens. If Cyclopean Tomb is destroyed, remove one token of your choice each upkeep, returning that land to its original nature.",
             "colours": [],
@@ -7717,7 +7717,7 @@
         },
         {
             "id": "bc02ffe6-a793-5057-801e-10a19f9b34af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8ecaee-0de3-45ee-8428-09dc400d63d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8ecaee-0de3-45ee-8428-09dc400d63d8.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever anyone loses a land, Egg does 2 damage to that player for each land lost.",
             "colours": [],
@@ -7744,7 +7744,7 @@
         },
         {
             "id": "bce77c6a-feb1-5aa0-b68e-b402d0d60751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae91e07c-ad6d-41d9-bd65-184f92761334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae91e07c-ad6d-41d9-bd65-184f92761334.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3: Opponent must discard one card of his or her choice. Can only be used during your turn.",
             "colours": [],
@@ -7771,7 +7771,7 @@
         },
         {
             "id": "434beda4-9cb7-5616-9adb-4cc55d29beb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34855fa8-959d-45a2-ad91-8b17019755be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34855fa8-959d-45a2-ad91-8b17019755be.jpg?1",
             "name": "Forcefield",
             "text": "o1: Lose only 1 life to an unblocked creature.",
             "colours": [],
@@ -7798,7 +7798,7 @@
         },
         {
             "id": "1c3459ab-998c-5db6-8350-9a9780d89744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e240-07b0-45fb-90af-f4fce18c604e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e240-07b0-45fb-90af-f4fce18c604e.jpg?1",
             "name": "Gauntlet of Might",
             "text": "All red creatures gain +1/+1 and all mountains provide an extra red mana when tapped.",
             "colours": [],
@@ -7827,7 +7827,7 @@
         },
         {
             "id": "f87b5e2c-0859-50c4-9b0d-44e40ae5d5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6953fd-ee48-49dc-9c9c-bfb9a9dc06d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6953fd-ee48-49dc-9c9c-bfb9a9dc06d0.jpg?1",
             "name": "Glasses of Urza",
             "text": "You may look at opponent's hand.",
             "colours": [],
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "a9720f7f-3cda-5f2e-8028-47a70ae079f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d3329-9053-4301-b867-1b49c248fe31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d3329-9053-4301-b867-1b49c248fe31.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1: You may give one creature the ability to band until end of turn.",
             "colours": [],
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "6719b567-4ccf-569f-ae6e-3e03618f6483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37634ffe-788f-4262-88e8-5ab7c7ca74d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37634ffe-788f-4262-88e8-5ab7c7ca74d6.jpg?1",
             "name": "Howling Mine",
             "text": "Each player draws one extra card each turn during his or her draw phase.",
             "colours": [],
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "15c248ca-cd1f-5ec1-bd58-8b323ddffb67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27608e7-6539-4813-95b6-d8847cdc6a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27608e7-6539-4813-95b6-d8847cdc6a12.jpg?1",
             "name": "Icy Manipulator",
             "text": "o1: You may tap any land, creature, or artifact in play on either side. No effects are generated by the target card.",
             "colours": [],
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "20b4e2fc-4165-533f-ad73-b4debce5c02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ea96b1-4428-4951-88d4-f79338955981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ea96b1-4428-4951-88d4-f79338955981.jpg?1",
             "name": "Illusionary Mask",
             "text": "oo\nX You can summon a creature face down so opponent doesn't know what it is. The X cost can be any amount of mana, even 0; it serves to hide the true casting cost of the creature, which you still have to spend. As soon as a face-down creature receives damage, deals damage, or is tapped, you must turn it face up.",
             "colours": [],
@@ -7962,7 +7962,7 @@
         },
         {
             "id": "03410e19-420c-54a0-9f31-9330cd34898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08fff47-c3c8-40a9-b3d3-296954aa4ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08fff47-c3c8-40a9-b3d3-296954aa4ed4.jpg?1",
             "name": "Iron Star",
             "text": "o1: Any red spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "23673ab5-68ed-53d2-9d1b-b846401a3c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32516ab8-43be-4207-a7d5-4916933ce155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32516ab8-43be-4207-a7d5-4916933ce155.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Any white spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "7b9bf6e6-07c4-50f7-8f3c-96ded60b1921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeea32ba-dfe4-4a9b-b403-43c2abc80b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeea32ba-dfe4-4a9b-b403-43c2abc80b78.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: You may take damage done to any creature on yourself instead, but you must take all of it. Source of damage is unchanged.",
             "colours": [],
@@ -8043,7 +8043,7 @@
         },
         {
             "id": "28b3a5d7-2987-5152-99fa-b66f6bb1b39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985164ba-0c30-42b1-a8b6-3be19251359c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985164ba-0c30-42b1-a8b6-3be19251359c.jpg?1",
             "name": "Jade Statue",
             "text": "o2: Jade Statue becomes a creature for the duration of the current attack exchange. Can be a creature only during an attack or defense.",
             "colours": [],
@@ -8070,7 +8070,7 @@
         },
         {
             "id": "9cceb7e5-42cd-5848-9d89-6fbfaf452507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48b1c51-c0fd-4c08-8631-80f507b04d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48b1c51-c0fd-4c08-8631-80f507b04d28.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4: You may draw one extra card.",
             "colours": [],
@@ -8097,7 +8097,7 @@
         },
         {
             "id": "59f45ff7-ad96-5a63-a462-83fffb9597a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870eb49c-f62d-4986-b492-601feb68a307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870eb49c-f62d-4986-b492-601feb68a307.jpg?1",
             "name": "Juggernaut",
             "text": "Must attack each turn if possible. Can't be blocked by walls.",
             "colours": [],
@@ -8127,7 +8127,7 @@
         },
         {
             "id": "ca3f8821-e537-5a1f-aa77-b0819673a0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2a4f9-8f80-4ee3-8068-73e686d6eeb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2a4f9-8f80-4ee3-8068-73e686d6eeb9.jpg?1",
             "name": "Kormus Bell",
             "text": "Treat all swamps in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. Swamps have no color; they are not considered black cards.",
             "colours": [],
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "910e0e45-0d29-570b-843b-e578373f69f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254bff2-a3a7-434e-980a-2d30355793fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254bff2-a3a7-434e-980a-2d30355793fc.jpg?1",
             "name": "Library of Leng",
             "text": "There is no limit to size of your hand. If a card forces you to discard, you may choose to discard to top of your library rather than to graveyard. If discard is random, you may look at card before deciding where to discard it.",
             "colours": [],
@@ -8181,7 +8181,7 @@
         },
         {
             "id": "6efd1763-56b7-58e3-8e0a-402b3a067e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2cd1c8-8734-4534-ae92-def4d94ef5bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2cd1c8-8734-4534-ae92-def4d94ef5bc.jpg?1",
             "name": "Living Wall",
             "text": "Counts as a wall. o1: Regenerates.",
             "colours": [],
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "7b845dc2-29bb-5d5b-b59e-81acbee9e722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f55e8-7f86-4ca9-b737-9a920d9cf282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f55e8-7f86-4ca9-b737-9a920d9cf282.jpg?1",
             "name": "Mana Vault",
             "text": "Tap to add 3 colorless mana to your mana pool. Mana Vault doesn't untap normally during untap phase; to untap it, you must pay 4 mana. If Mana Vault remains tapped during upkeep it does 1 damage to you. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "eb9e0903-ef42-5a79-823d-b1968dc664bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b22007-9def-4c0f-921c-555483cc3deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b22007-9def-4c0f-921c-555483cc3deb.jpg?1",
             "name": "Meekstone",
             "text": "Any creature with power greater than 2 may not be untapped as normal during the untap phase.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "bc924c9e-b4fc-5a05-9803-59c108546a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d9476-76be-48e7-b6a0-49ced25cb092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d9476-76be-48e7-b6a0-49ced25cb092.jpg?1",
             "name": "Mox Emerald",
             "text": "Add 1 green mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "ff19b91f-c815-558a-897a-4b8c4f3e61db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133204e4-fef8-4851-aa50-c96ffa35b802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133204e4-fef8-4851-aa50-c96ffa35b802.jpg?1",
             "name": "Mox Jet",
             "text": "Add 1 black mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "d43a8822-4241-5a60-897b-f141247a9fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da892c5-071f-416f-9e42-c4bff102eb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da892c5-071f-416f-9e42-c4bff102eb88.jpg?1",
             "name": "Mox Pearl",
             "text": "Add 1 white mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8352,7 +8352,7 @@
         },
         {
             "id": "75579c49-8efe-5cc4-b645-5fff52736424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdac742b-16db-4e03-be8f-c600dbd522d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdac742b-16db-4e03-be8f-c600dbd522d5.jpg?1",
             "name": "Mox Ruby",
             "text": "Add 1 red mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8381,7 +8381,7 @@
         },
         {
             "id": "8a513c25-1eec-5c18-9cf5-3068a1eb94bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb3178b-dac5-4b34-9d3e-4f5a170d1c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb3178b-dac5-4b34-9d3e-4f5a170d1c87.jpg?1",
             "name": "Mox Sapphire",
             "text": "Add 1 blue mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "622397bf-673a-5885-a4bf-7900ec745b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb21f21-668a-4d57-8d05-8db11fb82d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb21f21-668a-4d57-8d05-8db11fb82d99.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "o1: Destroys all creatures, enchantments, and artifacts in play. Disk begins tapped but can be untapped as usual. Disk destroys itself when used.",
             "colours": [],
@@ -8437,7 +8437,7 @@
         },
         {
             "id": "3074f009-6c15-5bf1-85dc-3f2f4e93f33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ed6669-e340-46d5-906b-e24e76464e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ed6669-e340-46d5-906b-e24e76464e75.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "2d3c3a23-39a4-5204-9a4f-86f5564e73ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45810c0a-0a35-4bd4-ba66-5a45f8973fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45810c0a-0a35-4bd4-ba66-5a45f8973fa4.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3: Rod of Ruin does 1 damage to any target.",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "570b9c70-eb8b-5c23-b952-01797b13164f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fb91ec-20a8-4c13-9469-18885b1ecca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fb91ec-20a8-4c13-9469-18885b1ecca3.jpg?1",
             "name": "Sol Ring",
             "text": "Add 2 colorless mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8521,7 +8521,7 @@
         },
         {
             "id": "e6992605-a1af-5a8d-937d-d66b31c1b8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ba41ec-4fff-4192-80ff-2afcd706ea59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ba41ec-4fff-4192-80ff-2afcd706ea59.jpg?1",
             "name": "Soul Net",
             "text": "o1: You gain 1 life every time a creature is destroyed, unless it is then regenerated.",
             "colours": [],
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "1b66c092-e1db-5340-985d-1bf81dac19dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fcf47d-0f1d-469e-a8c4-d5c97be7a1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fcf47d-0f1d-469e-a8c4-d5c97be7a1ef.jpg?1",
             "name": "Sunglasses of Urza",
             "text": "White mana in your mana pool can be used as either white or red mana.",
             "colours": [],
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "7dd52da8-08dd-5314-8b20-bfee51e278e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b83106-a10d-469a-99eb-56110ef34ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b83106-a10d-469a-99eb-56110ef34ba1.jpg?1",
             "name": "The Hive",
             "text": "o5: Creates one Giant Wasp, a 1/1 flying creature. Represent Wasps with tokens, making sure to indicate when each Wasp is tapped. Wasps can't attack during the turn created. Treat Wasps like artifact creatures in every way, except that they are removed from the game entirely if they ever leave play. If the Hive is destroyed, the Wasps must still be killed individually.",
             "colours": [],
@@ -8602,7 +8602,7 @@
         },
         {
             "id": "981789d7-4a6b-5db5-b197-c5da241a5998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655b6265-3030-4c68-af5b-b9e636b1a778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655b6265-3030-4c68-af5b-b9e636b1a778.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Any black spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8629,7 +8629,7 @@
         },
         {
             "id": "472bc7dc-5874-5c8f-9a65-f6c0f28d999f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1164f22f-2706-4f35-9f58-d0eb8c344396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1164f22f-2706-4f35-9f58-d0eb8c344396.jpg?1",
             "name": "Time Vault",
             "text": "Tap to gain an additional turn after the current one. Time Vault doesn't untap normally during untap phase; to untap it, you must skip a turn. Time Vault begins tapped.",
             "colours": [],
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "05a2b7c9-47d7-5b66-8658-c40c983ac77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847de6a4-a268-492e-a4d2-5b12237bc130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847de6a4-a268-492e-a4d2-5b12237bc130.jpg?1",
             "name": "Winter Orb",
             "text": "Players can untap only one land each during untap phase. Creatures and artifacts are untapped as normal.",
             "colours": [],
@@ -8683,7 +8683,7 @@
         },
         {
             "id": "2681fed4-9f19-53b3-b6cf-1fca7f27700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eee156-54bd-46fc-8804-a73aab87f0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eee156-54bd-46fc-8804-a73aab87f0ba.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Any green spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "3146e838-1792-582e-88bb-ec0bf8735241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3393436-3426-4903-8f41-7abcbf6c18c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3393436-3426-4903-8f41-7abcbf6c18c2.jpg?1",
             "name": "Badlands",
             "text": "Counts as both mountains and swamp and is affected by spells that affect either. Tap to add either o\nR or o\nB to your mana pool.",
             "colours": [],
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "49dde090-f045-5a13-ba57-782a8fbf0606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db2b6a-eaa8-4a08-9e86-370bbd058574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db2b6a-eaa8-4a08-9e86-370bbd058574.jpg?1",
             "name": "Bayou",
             "text": "Counts as both swamp and forest and is affected by spells that affect either. Tap to add either o\nB or o\nG to your mana pool.",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "1a8d61f7-a5ac-5461-82bf-e081633bc38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad0bbc4-f760-47a2-aab6-0dbb66ee3a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad0bbc4-f760-47a2-aab6-0dbb66ee3a95.jpg?1",
             "name": "Plateau",
             "text": "Counts as both mountains and plains and is affected by spells that affect either. Tap to add either o\nR or o\nW to your mana pool.",
             "colours": [],
@@ -8809,7 +8809,7 @@
         },
         {
             "id": "8161cb22-ccff-5844-9ee9-36e8fa40590d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9aeaa8-9a75-4719-992f-cbb316f72175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9aeaa8-9a75-4719-992f-cbb316f72175.jpg?1",
             "name": "Savannah",
             "text": "Counts as both plains and forest and is affected by spells that affect either. Tap to add either o\nW or o\nG to your mana pool.",
             "colours": [],
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "f48023cc-b84b-5517-83c9-9ff67ce509fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf99186-3167-4092-8efb-e7448609ceba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf99186-3167-4092-8efb-e7448609ceba.jpg?1",
             "name": "Scrubland",
             "text": "Counts as both plains and swamp and is affected by spells that affect either. Tap to add either o\nW or o\nB to your mana pool.",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "520a6a31-e483-5e66-a681-304a508aa2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ce1bf0-7561-418f-a217-3ce10f28be82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ce1bf0-7561-418f-a217-3ce10f28be82.jpg?1",
             "name": "Taiga",
             "text": "Counts as both forest and mountains and is affected by spells that affect either. Tap to add either o\nG or o\nR to your mana pool.",
             "colours": [],
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "e384e9fe-8204-5e83-b0da-d6d6720aa601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac19c5a1-ca13-4443-920b-83b567167ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac19c5a1-ca13-4443-920b-83b567167ed4.jpg?1",
             "name": "Tropical Island",
             "text": "Counts as both forest and islands and is affected by spells that affect either. Tap to add either o\nG or o\nU to your mana pool.",
             "colours": [],
@@ -8941,7 +8941,7 @@
         },
         {
             "id": "c50b0b0b-0068-5a93-ab38-e4dd17d7b854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b93ce48-219c-49ea-9ad0-b7357bea4606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b93ce48-219c-49ea-9ad0-b7357bea4606.jpg?1",
             "name": "Tundra",
             "text": "Counts as both islands and plains and is affected by spells that affect either. Tap to add either o\nU or o\nW to your mana pool.",
             "colours": [],
@@ -8974,7 +8974,7 @@
         },
         {
             "id": "48d3a108-3274-5407-b6fd-ffc0112fb9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e91ce41-053e-4203-8860-49cbf854cc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e91ce41-053e-4203-8860-49cbf854cc18.jpg?1",
             "name": "Underground Sea",
             "text": "Counts as both swamp and islands and is affected by spells that affect either. Tap to add either o\nB or o\nU to your mana pool.",
             "colours": [],
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "70b18ac5-0a70-58a3-af92-d5709be0c014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0324641d-af55-4c53-b4dc-c8262e967da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0324641d-af55-4c53-b4dc-c8262e967da5.jpg?1",
             "name": "Volcanic Island",
             "text": "Counts as both islands and mountains and is affected by spells that affect either. Tap to add either o\nU or o\nR to your mana pool.",
             "colours": [],
@@ -9040,7 +9040,7 @@
         },
         {
             "id": "119abc5e-4dcb-56ae-807d-fda05bc1f5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7331b03-be66-419c-94bc-ed494c042ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7331b03-be66-419c-94bc-ed494c042ea3.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "92b7e982-790c-5407-853a-9e1d3f8b3b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff493a-6336-416e-af5e-1eb6d10c080e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff493a-6336-416e-af5e-1eb6d10c080e.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9112,7 +9112,7 @@
         },
         {
             "id": "0350483c-f9ac-5692-8238-ff5e39c0c1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e2b0ff-8fdf-4db0-85c0-c1010bacd36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e2b0ff-8fdf-4db0-85c0-c1010bacd36b.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9148,7 +9148,7 @@
         },
         {
             "id": "60d23779-cb0d-5236-a94b-218299479a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff33e91-8e52-43f2-b8ae-603b456b08fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff33e91-8e52-43f2-b8ae-603b456b08fc.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9184,7 +9184,7 @@
         },
         {
             "id": "2922a8a8-f3dc-554f-ae1e-d5e77f8bf5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c5cf64-9844-4b5b-8e6b-b97c50cce053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c5cf64-9844-4b5b-8e6b-b97c50cce053.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "89e18bbf-c8e0-5d67-9eee-c8193e9c4fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a612c4-b4ac-4dd2-a06e-92516599fafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a612c4-b4ac-4dd2-a06e-92516599fafd.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9256,7 +9256,7 @@
         },
         {
             "id": "12a742ea-5fbf-504c-a9c5-3c0c4c2b7496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1309a80-a761-4b80-8cf1-1a8b83190511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1309a80-a761-4b80-8cf1-1a8b83190511.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9292,7 +9292,7 @@
         },
         {
             "id": "300bd941-b06e-5a41-bcf3-d34f81469353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ad2444-9985-423c-ad36-387218866409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ad2444-9985-423c-ad36-387218866409.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "c6dfe056-bee2-599b-8516-5c044966fa2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3544148-49b2-4320-8e3a-5bab81e0f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3544148-49b2-4320-8e3a-5bab81e0f7fd.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "477a849f-9eb7-57e0-b97e-580768ebe704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af9c715-8d72-4eae-b412-fc89138ff588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af9c715-8d72-4eae-b412-fc89138ff588.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9400,7 +9400,7 @@
         },
         {
             "id": "a8ff458f-c5db-58b1-8c2d-a4847ec26ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb88a03-7092-4d31-a9f1-4f16e39bc537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb88a03-7092-4d31-a9f1-4f16e39bc537.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "7cdc091f-c424-5b3c-998d-d2752919cf7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ad645-e605-4048-bf4c-d636584f315b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ad645-e605-4048-bf4c-d636584f315b.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9472,7 +9472,7 @@
         },
         {
             "id": "74d92721-f3a0-544c-8f34-ca0de97a9872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a922eb-49c7-45f0-92bc-671d7a8758f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a922eb-49c7-45f0-92bc-671d7a8758f4.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],
@@ -9508,7 +9508,7 @@
         },
         {
             "id": "e2f95b85-7bf3-5dce-8555-2d9fb844890b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad91fc-50c2-44e0-b88e-2c13610377f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad91fc-50c2-44e0-b88e-2c13610377f9.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "24aa6993-b0c7-5f2d-b99f-d6eefb5b66ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4075bbc-dbad-4a1e-a992-70aed713a459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4075bbc-dbad-4a1e-a992-70aed713a459.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/LEG.json
+++ b/Assets/Resources/Sets/LEG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "11c51522-5e12-50d5-b537-55d0b5e52186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d074af2-8dbd-42d3-87eb-30f6e7d171ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d074af2-8dbd-42d3-87eb-30f6e7d171ff.jpg?1",
             "name": "Akron Legionnaire",
             "text": "None of your non-artifact creatures may attack except Akron Legionnaire.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "04991927-a413-52e1-a21d-03f612231f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2806c7f6-8fdd-4e65-9c71-f2e8b0cdede2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2806c7f6-8fdd-4e65-9c71-f2e8b0cdede2.jpg?1",
             "name": "Alabaster Potion",
             "text": "Target player gains X life or prevents X damage to any one creature or player.",
             "colours": [
@@ -69,7 +69,7 @@
         },
         {
             "id": "d2252942-4e1b-571e-9cdf-ca99e217235a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbce1c55-123c-4a05-bde4-18a1601fcc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbce1c55-123c-4a05-bde4-18a1601fcc5a.jpg?1",
             "name": "Amrou Kithkin",
             "text": "Creatures with power greater than 2 may not be assigned to block Kithkin. Blocker's power may be increased after blocking has been assigned.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "e7f975c2-3ce7-52e2-b1b9-ac8d947c303d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068c263-e5fa-4449-8887-418e9d0a4da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068c263-e5fa-4449-8887-418e9d0a4da4.jpg?1",
             "name": "Angelic Voices",
             "text": "As long as the only creatures you control are white or artifact creatures all your creatures gain +1/+1.",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "ebf2ac99-ae5d-593a-8dc2-44d1fe9c98ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbd611b-ac97-4516-bad7-cc9ee4ef74f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbd611b-ac97-4516-bad7-cc9ee4ef74f7.jpg?1",
             "name": "Cleanse",
             "text": "All black creatures in play are destroyed.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "7a817107-fa2b-55e0-883b-c3ed2b06ba04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1f578f-fa3b-4447-953b-1490852b6c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1f578f-fa3b-4447-953b-1490852b6c80.jpg?1",
             "name": "Clergy of the Holy Nimbus",
             "text": "When Clergy are destroyed or take lethal damage, unless opponent pays o1 Clergy are regenerated.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "9c21c6f1-98ce-55bd-84dc-2446c9988b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09aee5c-8b9e-46c2-b4d4-508062f8af05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09aee5c-8b9e-46c2-b4d4-508062f8af05.jpg?1",
             "name": "D'Avenant Archer",
             "text": "oc\nT: Archer does 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -233,7 +233,7 @@
         },
         {
             "id": "81e98212-6726-50e8-9d35-95321e19e32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae0ba1-1383-4505-b4e7-4f17dd8f20c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae0ba1-1383-4505-b4e7-4f17dd8f20c5.jpg?1",
             "name": "Divine Intervention",
             "text": "Put two counters on this card. Remove a counter during your upkeep. When you remove the last counter from Divine Intervention, the game is over and considered a draw.",
             "colours": [
@@ -264,7 +264,7 @@
         },
         {
             "id": "4ae8b487-2e2c-5c59-b4d1-14936d6238e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78c2f3-2f40-48ad-9dc4-55d1fa399a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78c2f3-2f40-48ad-9dc4-55d1fa399a56.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. You gain life points equal to casting cost of artifact.",
             "colours": [
@@ -295,7 +295,7 @@
         },
         {
             "id": "b5249544-5260-5071-b514-ae425010b97c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg?1",
             "name": "Divine Transformation",
             "text": "Target creature gains +3/+3.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "a9bcd66a-ed17-5f3e-9a85-a533266f044a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3651d4-969c-464d-a444-40a640d0c6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3651d4-969c-464d-a444-40a640d0c6ba.jpg?1",
             "name": "Elder Land Wurm",
             "text": "Trample\nWurm cannot attack until it has been assigned as a blocker.",
             "colours": [
@@ -362,7 +362,7 @@
         },
         {
             "id": "4aedad47-507d-5c9f-9305-d278b08f8384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c2880d-b37a-43ea-9fee-cd5a8ed75a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c2880d-b37a-43ea-9fee-cd5a8ed75a7e.jpg?1",
             "name": "Enchanted Being",
             "text": "Any damage dealt to Enchanted Being during combat by creatures with one or more enchantment cards played on them is reduced to 0.",
             "colours": [
@@ -395,7 +395,7 @@
         },
         {
             "id": "80df6eaa-2a40-5af3-bacb-15140dae4f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840c6586-a7a9-4ae8-96be-a995a0693eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840c6586-a7a9-4ae8-96be-a995a0693eb6.jpg?1",
             "name": "Equinox",
             "text": "Tap land enchanted with Equinox to counter a spell that destroys one or more of your lands. This ability is played as an interrupt.",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "86c408a9-7b87-5e8a-9aa3-0418b0128d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc64f19c-5b2b-4697-b4dc-2be9c3790794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc64f19c-5b2b-4697-b4dc-2be9c3790794.jpg?1",
             "name": "Fortified Area",
             "text": "All your walls gain +1/+0 and banding.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "6a28421d-7fcb-54ad-b243-d7dc73587ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1384e5-d140-4074-9548-250af09cb413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1384e5-d140-4074-9548-250af09cb413.jpg?1",
             "name": "Glyph of Life",
             "text": "Damage done to target wall by attacking creatures is added to your life point total.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "c45b65e6-87bc-55c6-badd-bcdd0a6bbbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a8653-1538-4f78-a3d3-a900a4d9499b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a8653-1538-4f78-a3d3-a900a4d9499b.jpg?1",
             "name": "Great Defender",
             "text": "Target creature gains +0/+X until end of turn where X is the creature's casting cost.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "6050f22d-866d-5883-a3bd-665b6807c1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd860a1d-aa17-4579-b9b1-d101d2416387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd860a1d-aa17-4579-b9b1-d101d2416387.jpg?1",
             "name": "Great Wall",
             "text": "Creatures with plainswalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "8e2af06e-53c7-5f1c-ae21-a5f42e923408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e236816-0c49-4b48-b18b-03add5a80d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e236816-0c49-4b48-b18b-03add5a80d72.jpg?1",
             "name": "Greater Realm of Preservation",
             "text": "o1oo\nW Prevents all damage against you from one red or black source. If a source does damage to you more than once in a turn, you must pay o1o\nW each time you want to prevent the damage.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "332a5758-f8ef-5e2f-8f8d-b7dee65083c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461d7c11-3a7d-42c2-bb6b-0a43779e6842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461d7c11-3a7d-42c2-bb6b-0a43779e6842.jpg?1",
             "name": "Heaven's Gate",
             "text": "Changes the color of one or more target creatures to white until end of turn. You choose which and how many creatures are affected. Costs to tap, maintain, or use a special ability of target creatures remain entirely unchanged.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "185b9748-4858-50ce-9ee3-b59f0d8c8a55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c95a2b-bf44-4ff2-9c6a-916773346edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c95a2b-bf44-4ff2-9c6a-916773346edd.jpg?1",
             "name": "Holy Day",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is assigned.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "3140b56e-06fb-5fcc-94e6-7a679cb213a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2a7333-c9ce-4011-b00e-1304e1eec25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2a7333-c9ce-4011-b00e-1304e1eec25e.jpg?1",
             "name": "Indestructible Aura",
             "text": "Any damage dealt to target creature for remainder of turn is reduced to 0.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "6996ecef-c1fe-525e-b099-2551c2b472c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc60077f-d577-4a6c-a78f-697317024c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc60077f-d577-4a6c-a78f-697317024c40.jpg?1",
             "name": "Infinite Authority",
             "text": "All creatures with toughness 3 or less blocking target creature or blocked by target creature are destroyed at end of combat. At the end of the turn put a +1/+1 counter on the target creature for each creature destroyed in this manner during the turn. Counters remain on creature even if enchantment leaves play.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "54f3030a-a119-5c7f-b79d-c3107e68b04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf9cccd-fe97-4632-a90a-9eeb0d41135e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf9cccd-fe97-4632-a90a-9eeb0d41135e.jpg?1",
             "name": "Ivory Guardians",
             "text": "Protection from red\nAll guardians gain +1/+1 if an opponent controls any red cards.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "13363413-17a7-5ad0-ab90-f1ce00089d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63a69ae-99ce-4d26-88b7-784793c43cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63a69ae-99ce-4d26-88b7-784793c43cd4.jpg?1",
             "name": "Keepers of the Faith",
             "text": "",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "dbef4677-f4c4-5796-bbf3-a32bf2f7cf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0651ad-6901-4f9b-8807-d66e53a4ada8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0651ad-6901-4f9b-8807-d66e53a4ada8.jpg?1",
             "name": "Kismet",
             "text": "All creatures, lands, and artifacts played by opponent come into play tapped.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "5ec3bb47-7a0b-54d8-b38b-4e644ab2ff3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53b20b0-67bc-4587-817b-efbf21cb2512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53b20b0-67bc-4587-817b-efbf21cb2512.jpg?1",
             "name": "Land Tax",
             "text": "During your upkeep, if an opponent controls more land than you, you may search your library and remove up to three basic land cards and put them into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "f3de7ac8-b380-580a-84b1-034da548d117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecb1362-9a67-4d4c-8d69-9ac2ebf4d0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecb1362-9a67-4d4c-8d69-9ac2ebf4d0b0.jpg?1",
             "name": "Lifeblood",
             "text": "You gain 1 life point each time one of opponent's mountains becomes tapped.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "14e3f882-a766-5c2e-bdad-08fbfd4f4c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952ba126-0915-47f0-9b6a-a0a6dcd22c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952ba126-0915-47f0-9b6a-a0a6dcd22c6f.jpg?1",
             "name": "Moat",
             "text": "Non-flying creatures cannot attack.",
             "colours": [
@@ -901,7 +901,7 @@
         },
         {
             "id": "7555ce50-d5aa-515c-b08a-7ad4e7188b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85614b3-62a3-4da9-a74a-7ea40fad1b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85614b3-62a3-4da9-a74a-7ea40fad1b52.jpg?1",
             "name": "Osai Vultures",
             "text": "Flying\nAt the end of any turn in which a creature is placed in the graveyard from play, put a counter on the Vultures. Remove two counters to give Vultures +1/+1 until end of turn.",
             "colours": [
@@ -934,7 +934,7 @@
         },
         {
             "id": "f4179384-5f32-51e1-825c-2d77cd9e0eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef99f07-c987-451a-b18a-2719eea654cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef99f07-c987-451a-b18a-2719eea654cd.jpg?1",
             "name": "Petra Sphinx",
             "text": "oc\nT: Target player names a card and then turns over the top card of his or her library. If it matches the named card, the card is put in the player's hand; otherwise it is put into the graveyard.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "3c540848-d4ca-5441-a098-51a295e39aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb86b2f-116d-4952-b35a-1398341baaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb86b2f-116d-4952-b35a-1398341baaf5.jpg?1",
             "name": "Presence of the Master",
             "text": "While Presence of the Master is in play, any new enchantments cast are countered.",
             "colours": [
@@ -998,7 +998,7 @@
         },
         {
             "id": "cf343112-4a3d-5752-8c7f-34c0b2601cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26e7c9c-e6de-47f4-8394-7e853408f84c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26e7c9c-e6de-47f4-8394-7e853408f84c.jpg?1",
             "name": "Rapid Fire",
             "text": "Play before defense is chosen. Target creature gains first strike until end of turn. If the creature does not already have rampage, then it also gains rampage: 2 until end of turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "aa0b0767-5034-52b0-a782-74a1d6a5029f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2e3a8a-b386-474d-b8e9-4c2d56a2b742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2e3a8a-b386-474d-b8e9-4c2d56a2b742.jpg?1",
             "name": "Remove Enchantments",
             "text": "Remove all enchantments you control and remove all enchantment cards played on all permanents you control. If this spell is cast during opponent's attack, also remove all enchantment cards played on attacking creatures. All enchantments you own are returned to your hand; all other enchantments are destroyed.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "3bceac63-f942-586c-a4d8-bfaa525a7baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b463e-9579-4e7b-87c2-342527b91e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b463e-9579-4e7b-87c2-342527b91e7c.jpg?1",
             "name": "Righteous Avengers",
             "text": "Plainswalk",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "fb98161e-b515-50d8-8d34-bab313bfe2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df608b59-cc07-4e1d-b6d6-f15e69b15b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df608b59-cc07-4e1d-b6d6-f15e69b15b92.jpg?1",
             "name": "Seeker",
             "text": "Target creature cannot be blocked by any creatures except white creatures and artifact creatures.",
             "colours": [
@@ -1127,7 +1127,7 @@
         },
         {
             "id": "13c43247-a5ae-506d-a874-440f3c5e3943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5032bf0-f9c0-4ef0-8ec2-fe7ccea9bdf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5032bf0-f9c0-4ef0-8ec2-fe7ccea9bdf3.jpg?1",
             "name": "Shield Wall",
             "text": "All your creatures gain +0/+2 until end of turn.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "e5cd7252-19f6-51f3-af01-ecc5cb1363b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d35f8-3cf6-4843-9030-0e9a885d836c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d35f8-3cf6-4843-9030-0e9a885d836c.jpg?1",
             "name": "Spirit Link",
             "text": "For every point of damage target creature does, you gain 1 life.",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "c5ad543a-676d-5b2b-81ba-591d408dab40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654dd1e0-a91d-44ee-af20-c025bf360c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654dd1e0-a91d-44ee-af20-c025bf360c3f.jpg?1",
             "name": "Spiritual Sanctuary",
             "text": "All players with plains under his or her control gains 1 life point during upkeep.",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "5e031eba-cc13-5f54-b3ce-0c003f303dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg?1",
             "name": "Thunder Spirit",
             "text": "First strike, flying.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "733c99cf-d28d-5cbb-8123-10ad1b037af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f649cb5-e19c-453f-b062-4fd452d92257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f649cb5-e19c-453f-b062-4fd452d92257.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "585e27c4-9f7a-515a-9802-dd31c429c27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d00299-e183-4b3d-b015-18808e7135b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d00299-e183-4b3d-b015-18808e7135b9.jpg?1",
             "name": "Visions",
             "text": "You may look at the top five cards of any library. You may then choose to shuffle that library.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "3ed8ac93-6565-5245-9d01-267ff9593750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664ad588-3002-4f63-93bd-38663171018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664ad588-3002-4f63-93bd-38663171018f.jpg?1",
             "name": "Wall of Caltrops",
             "text": "If Wall of Caltrops and one or more other walls join to block an attacker and no other creatures besides walls block that attacker, Wall of Caltrops gains banding ability until end of turn.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "ef7ec323-2920-5f2b-8d09-7b9a32dde212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5758e82-f901-42b7-b705-0e68ca7ba59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5758e82-f901-42b7-b705-0e68ca7ba59e.jpg?1",
             "name": "Wall of Light",
             "text": "Protection from black",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "e974bf34-a99a-5fee-bc91-9a4e96b21687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba93c50a-2440-4e92-9cba-d97e20b1d29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba93c50a-2440-4e92-9cba-d97e20b1d29c.jpg?1",
             "name": "Acid Rain",
             "text": "Destroys all forests in play.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "d425d50e-6e80-57d1-a664-c1dcafbb2a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff78eef1-efaa-4a12-bf5d-fec83c14aff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff78eef1-efaa-4a12-bf5d-fec83c14aff8.jpg?1",
             "name": "Anti-Magic Aura",
             "text": "All enchantments on target creature are destroyed. Target creature cannot be further targeted by instants, sorceries, or enchantments.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "b529e9ac-989b-59ca-91c8-70ad8ef2d37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f13a2-0896-4230-8957-6ad1cb2b895b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f13a2-0896-4230-8957-6ad1cb2b895b.jpg?1",
             "name": "Azure Drake",
             "text": "Flying",
             "colours": [
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "60f52971-4f40-5d4a-8098-4d8897171339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bc57aa-d4d9-4bd9-ba09-984370c7e23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bc57aa-d4d9-4bd9-ba09-984370c7e23b.jpg?1",
             "name": "Backfire",
             "text": "For each point of damage done to you from target creature Backfire does one point of damage to target creature's controller.",
             "colours": [
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "b91d537b-803f-57a3-b778-fca2dc594d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8286edd-644b-4135-8dca-af97f3920de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8286edd-644b-4135-8dca-af97f3920de3.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to owner's hand; enchantments on target permanent are destroyed.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "27f3fb1a-d5a2-5409-8cdc-6742404db038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1e7796-fbfb-4976-879f-bb748429d5c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1e7796-fbfb-4976-879f-bb748429d5c7.jpg?1",
             "name": "Brine Hag",
             "text": "On the turn during which Hag is placed in the graveyard, all creatures who dealt damage to Hag that turn become 0/2 creatures. Use counters to mark these creatures.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "20b4c0c7-99a0-5e04-a8b4-9fa63ebd491d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0855a5a8-8c40-4396-9ad1-8fa0fc6a0c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0855a5a8-8c40-4396-9ad1-8fa0fc6a0c59.jpg?1",
             "name": "Devouring Deep",
             "text": "Islandwalk",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "e79bb28c-e531-5cad-bdaa-a3de1ebadc7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07edbbf4-c3d6-4ec1-ae9b-4ae202fb6998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07edbbf4-c3d6-4ec1-ae9b-4ae202fb6998.jpg?1",
             "name": "Dream Coat",
             "text": "Caster may change target creature's color to any other color. This ability is played as an interrupt. Limit of one change per turn. Cost to tap, maintain, or use a special ability of target creature remains entirely unchanged.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "07e8321b-194d-5966-a367-b9012fa01978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc045e-01a8-4f14-a86d-0a67ec35d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc045e-01a8-4f14-a86d-0a67ec35d6b7.jpg?1",
             "name": "Elder Spawn",
             "text": "Elder Spawn cannot be blocked by red creatures. Sacrifice one of your islands during your upkeep or Elder Spawn does 6 damage to you and is buried.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "6cb043bc-c7c3-5fb6-8716-6bab4c55a538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf52f8a0-d027-47f1-bb91-508ef1a74409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf52f8a0-d027-47f1-bb91-508ef1a74409.jpg?1",
             "name": "Enchantment Alteration",
             "text": "Switch target enchantment from one creature to another or from one land to another. The controller of the enchantment does not change. New target of enchantment must be valid or this spell has no effect. Treat this as if the enchantment had just been cast on the new target.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "fbe83fc3-59b1-5f48-8408-afe0c9936fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e69940-bdc8-48ff-a296-540343910adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e69940-bdc8-48ff-a296-540343910adf.jpg?1",
             "name": "Energy Tap",
             "text": "Target untapped creature you control becomes tapped. Add an amount of colorless mana equal to target creature's casting cost to your mana pool.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "d8ff3b14-1714-5e3d-926c-aec8115f5ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63e119-3b1b-4964-a4b9-b10170ff542b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63e119-3b1b-4964-a4b9-b10170ff542b.jpg?1",
             "name": "Field of Dreams",
             "text": "The top card of each player's library is always face up.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "f19ea71b-d13c-5b2a-99a6-d667d1167fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3cd450-f1cd-416b-9271-37d95815c089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3cd450-f1cd-416b-9271-37d95815c089.jpg?1",
             "name": "Flash Counter",
             "text": "Counters target interrupt or instant spell.",
             "colours": [
@@ -1805,7 +1805,7 @@
         },
         {
             "id": "8382cc1d-37cd-55a2-b30e-498bcf8d7422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae88c06-f28c-4fbc-a28c-5eb203a04722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae88c06-f28c-4fbc-a28c-5eb203a04722.jpg?1",
             "name": "Flash Flood",
             "text": "Destroy target red permanent, or return target mountain to owner's hand. Enchantments on target land are destroyed.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "4d4b0796-90a3-59a2-8c70-bd6eb5218d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e64028-ae96-4950-aa6c-9d347409fad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e64028-ae96-4950-aa6c-9d347409fad3.jpg?1",
             "name": "Force Spike",
             "text": "Target spell is countered unless its caster spends an additional o1.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "4268218f-cbd2-5304-bb65-8369f2dd0764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0266dd4-31da-480b-9a44-4e217f748f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0266dd4-31da-480b-9a44-4e217f748f06.jpg?1",
             "name": "Gaseous Form",
             "text": "Damage done to target creature by creatures it blocks, or that block it, is reduced to 0. Creature deals no damage during combat.",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "040b2b91-c7ed-5d58-8dcf-cf464acbe8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee39da13-4b8a-4796-a7c2-aaa11992d573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee39da13-4b8a-4796-a7c2-aaa11992d573.jpg?1",
             "name": "Glyph of Delusion",
             "text": "Put X counters on one target creature that target wall blocked during this turn; X is the power of the blocked creature. Creature does not untap as normal while it has one or more of these counters on it. Remove one counter during creature's controller's upkeep.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "0ddb65ad-b6ff-5b5a-8a17-7cd7a7da484f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733933dd-c871-4f75-8b08-d7c010dddbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733933dd-c871-4f75-8b08-d7c010dddbe6.jpg?1",
             "name": "In the Eye of Chaos",
             "text": "All instants and interrupts are countered unless their caster pays an additional o\nX, where X is the casting cost of the spell being cast.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "9d1270ef-f7bc-5a39-8b59-d2cdbbdaa9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d9fde-d7da-4a0e-a337-b63023c6d74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d9fde-d7da-4a0e-a337-b63023c6d74b.jpg?1",
             "name": "Invoke Prejudice",
             "text": "If opponent casts a Summon spell that does not match the color of one of the creatures under your control, that spell is countered unless the caster pays an additional o\nX where X is the casting cost of the Summon spell.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "b850d43e-465d-5908-bb24-05c0b69305a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d78db-d982-4c28-9308-2d57dc2b947e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d78db-d982-4c28-9308-2d57dc2b947e.jpg?1",
             "name": "Juxtapose",
             "text": "Target player and caster each choose one of the creatures they control with the highest casting cost. Exchange control of these creatures. Then do the same for artifacts. Juxtapose does not tap or untap these cards. The control of any enchantment cards played on these permanents is unchanged. If one player does not have an artifact or creature do not trade that type of card.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "775ee10b-4795-5857-941e-2d7453474dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c406b25-03f8-4aaa-9ea7-48bf754166b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c406b25-03f8-4aaa-9ea7-48bf754166b7.jpg?1",
             "name": "Land Equilibrium",
             "text": "If your opponent controls at least as much land as you do, he or she must sacrifice a land for each land he or she puts into play.",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "67d70c16-209e-59df-b744-f439187420db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e691adef-3027-4e6a-889f-9f4e2df36a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e691adef-3027-4e6a-889f-9f4e2df36a7c.jpg?1",
             "name": "Mana Drain",
             "text": "Counters target spell. At the beginning of your next main phase, add o\nX to your mana pool, where X is the casting cost of target spell.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "24e91a88-a77c-5c29-bb3a-4b61ceda1c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b659475-c8b7-493d-af63-04f34d8cc3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b659475-c8b7-493d-af63-04f34d8cc3b1.jpg?1",
             "name": "Part Water",
             "text": "X target creatures gain islandwalk until end of turn.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "b23e462a-6cc4-56ff-accd-124ad87bc02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec082062-5394-4340-bc29-0efd2af4b822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec082062-5394-4340-bc29-0efd2af4b822.jpg?1",
             "name": "Psionic Entity",
             "text": "oc\nT: Psionic Entity does 2 damage to any target but does 3 damage to itself.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "a7be223f-e961-5160-8c62-7fa340b64957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1103d4d-b50a-4e2c-b18a-a181bc819881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1103d4d-b50a-4e2c-b18a-a181bc819881.jpg?1",
             "name": "Psychic Purge",
             "text": "Psychic Purge does 1 damage to any target. If a spell cast by opponent or a permanent under opponent's control causes you to discard this card, opponent loses 5 life. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "f160bae7-ee96-5b28-a01c-7d955133d705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d26ddc-ad1e-4a97-85fb-34da685c3142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d26ddc-ad1e-4a97-85fb-34da685c3142.jpg?1",
             "name": "Puppet Master",
             "text": "If target creature is placed in the graveyard, return creature to owner's hand. All enchantments on target creature are destroyed. You may pay o\nUo\nUo\nU to return Puppet Master to its owner's hand if target creature returns to its owner's hand.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "c748b0a1-b117-5fa0-b233-e0edfa4be6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33296718-0625-4422-a65c-b21cf99c52ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33296718-0625-4422-a65c-b21cf99c52ec.jpg?1",
             "name": "Recall",
             "text": "Sacrifice X cards from your hand and then bring X cards from your graveyard to your hand. Then remove Recall from the game.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "c6712ebd-6359-5a58-b7f4-47f44bf8afe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b07dc4-21ad-410b-8f8a-2b034253bfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b07dc4-21ad-410b-8f8a-2b034253bfee.jpg?1",
             "name": "Relic Bind",
             "text": "When target artifact is tapped, the controller of Relic Bind can choose to do 1 damage to any player or give 1 life to any player.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "c8382bad-fdb5-5a74-af52-e40c4899d8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63de147c-2e62-41b9-8ada-93406387f08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63de147c-2e62-41b9-8ada-93406387f08b.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target summon spell.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "822d74e7-3e55-5ca7-be6c-0c96475ae60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c829d83-d5b8-4be7-80f7-55b42f52b309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c829d83-d5b8-4be7-80f7-55b42f52b309.jpg?1",
             "name": "Reset",
             "text": "All your lands untap. Reset can only be played on an opponent's turn after his or her upkeep phase.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "cc48ddb5-c30b-5329-aa86-565d3f93c0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d1f470-058d-41b7-acaf-4f68431de9ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d1f470-058d-41b7-acaf-4f68431de9ed.jpg?1",
             "name": "Reverberation",
             "text": "Damage from one sorcery spell is redirected to its caster.",
             "colours": [
@@ -2373,7 +2373,7 @@
         },
         {
             "id": "5f2ce379-cb59-5d73-945c-f5390b14f2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d1f02d-533e-4b77-a72a-ff5f91ae0626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d1f02d-533e-4b77-a72a-ff5f91ae0626.jpg?1",
             "name": "Sea Kings' Blessing",
             "text": "Changes the color of one or more target creatures to blue until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or use a special ability of target creature(s) remains entirely unchanged.",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "323b6051-24b8-5388-a7bc-f16cbcebeea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a814f1-7f8d-4c2c-b706-ee0ed5892f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a814f1-7f8d-4c2c-b706-ee0ed5892f7b.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "2aed96a7-c2f0-5efa-b9d1-90e5cc65e6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d6fac6-9a23-465f-a813-92e1ed1cd742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d6fac6-9a23-465f-a813-92e1ed1cd742.jpg?1",
             "name": "Silhouette",
             "text": "Until end of turn, damage done to target creature by spells or effects that target it is reduced to 0.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "2696fc21-8e28-572b-9d9e-4aa42c4b093d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7524fd0d-a675-41d6-bc99-bd3ba336893b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7524fd0d-a675-41d6-bc99-bd3ba336893b.jpg?1",
             "name": "Spectral Cloak",
             "text": "Target creature cannot be the target of instants, sorceries, fast effects, or enchantments unless creature is tapped.",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "5c3cbcc2-d370-5724-be48-950d4fd65da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa920e-b93f-41c2-b505-a9350353be8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa920e-b93f-41c2-b505-a9350353be8b.jpg?1",
             "name": "Telekinesis",
             "text": "Target creature deals no damage during combat this turn. Creature becomes tapped and may not untap as normal during its controller's next two untap phases.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "34ad101e-d0ed-516e-8af6-1f1cf4888f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f86e13-f942-423e-b175-930d768cb811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f86e13-f942-423e-b175-930d768cb811.jpg?1",
             "name": "Teleport",
             "text": "Target creature cannot be blocked until end of turn. Play after attack is declared and before defense is chosen.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "3893def6-fccf-552b-8b46-1be0a97a2a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61510e88-97d0-410a-9431-ebf12990e33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61510e88-97d0-410a-9431-ebf12990e33d.jpg?1",
             "name": "Time Elemental",
             "text": "o2o\nUo\nUoc\nT: Return target permanent to owner's hand. Cannot target permanents with enchantment cards played on them.\nIf Time Elemental blocks or attacks it is destroyed and does 5 damage to controller.",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "2a98eff4-6b97-57a8-bbb4-0a8e7f2e7870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf05e5c9-b7e4-4bd8-ab73-b54565710527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf05e5c9-b7e4-4bd8-ab73-b54565710527.jpg?1",
             "name": "Undertow",
             "text": "Creatures with islandwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "16953d03-8753-5e09-a729-6b123b2a2ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fb92c0-bb1e-463a-a6b6-887a5d0cb873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fb92c0-bb1e-463a-a6b6-887a5d0cb873.jpg?1",
             "name": "Venarian Gold",
             "text": "Put X counters on target creature. Target creature becomes tapped when Venarian Gold is cast. Creature does not untap as normal if it has any of these counters on it. Remove one counter during creature's controller's upkeep phase.",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "85bbe0b5-e3a1-5d73-86e8-7c3f23e67c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6c0a27-d410-4ded-a842-70e1656ea21e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6c0a27-d410-4ded-a842-70e1656ea21e.jpg?1",
             "name": "Wall of Vapor",
             "text": "Damage done to Wall of Vapor by creatures it blocks is reduced to 0.",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "bf8a877b-abfd-5fac-9f22-02687976c426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd9af40-b46c-44b4-878e-8eb026c96b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd9af40-b46c-44b4-878e-8eb026c96b51.jpg?1",
             "name": "Wall of Wonder",
             "text": "o2o\nUoo\nU Gain +4/-4 and allow Wall of Wonder to attack this turn.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "b7e8d67c-e2e2-55ee-81d1-1880fcd35af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a173fd-e10c-45f8-a6e5-ad7a747a8050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a173fd-e10c-45f8-a6e5-ad7a747a8050.jpg?1",
             "name": "Zephyr Falcon",
             "text": "Flying\nAttacking does not cause Zephyr Falcon to tap.",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "935da0d0-4fed-5e61-bd8c-cb3850859634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e2cf8-5ecb-485a-92a2-b4e0a7959f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e2cf8-5ecb-485a-92a2-b4e0a7959f1f.jpg?1",
             "name": "Abomination",
             "text": "All green or white creatures blocking or blocked by Abomination are destroyed at the end of combat.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e9746ea2-4546-5b19-83f6-4b3efb1c32ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18787a2d-6688-47e9-94bc-ccf229df823f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18787a2d-6688-47e9-94bc-ccf229df823f.jpg?1",
             "name": "All Hallow's Eve",
             "text": "Put two counters on this card. Remove a counter during your upkeep. When you remove the last counter from All Hallow's Eve, all players take all creatures from their graveyards and put them directly into play. Treat these creatures as though they were just summoned. You choose what order they come into play.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "86665152-ea0e-5932-a222-4ec1a75d9f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca19b39-4201-463c-bd40-fbffa31c9eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca19b39-4201-463c-bd40-fbffa31c9eda.jpg?1",
             "name": "Blight",
             "text": "If target land becomes tapped, it is destroyed at the end of the turn.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "940ff3f3-7748-5e44-b6e1-613610fa3426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg?1",
             "name": "Carrion Ants",
             "text": "o1: +1/+1 until end of turn.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "89a165f5-7976-5219-87fc-c96e184bd927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb0e884-5bb4-41f3-b04b-6f638357c166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb0e884-5bb4-41f3-b04b-6f638357c166.jpg?1",
             "name": "Chains of Mephistopheles",
             "text": "Every time a player draws a card, that player must first discard a card from his or her hand. If there are no cards in player's hand, take top card from library and place it in the graveyard instead of drawing. This enchantment does not apply to the first card drawn by a player during the draw phase.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "abc5e16b-b289-561b-a8e5-b3bbeb9fae4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc6ac2-19e0-4765-852b-e303a5bb4040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc6ac2-19e0-4765-852b-e303a5bb4040.jpg?1",
             "name": "Cosmic Horror",
             "text": "First strike\nPay o3o\nBo\nBo\nB during your upkeep or Cosmic Horror does 7 damage to you and is destroyed.",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "2fa0d3e0-d0f8-53d7-bee8-77faba54b567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479ccc50-2d72-4adc-901e-fbd4eef2cf92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479ccc50-2d72-4adc-901e-fbd4eef2cf92.jpg?1",
             "name": "Cyclopean Mummy",
             "text": "If Mummy is placed in the graveyard from play, remove it from the game.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "a12b855b-7277-5252-af5b-3b5f89234f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b04dab-45b7-418b-a0f0-bcf35145fc53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b04dab-45b7-418b-a0f0-bcf35145fc53.jpg?1",
             "name": "Darkness",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is assigned.",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "47e5daf6-bafc-5978-9014-30fd4f3c34df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec14bc-95e9-47ce-b51e-d5eac9b345fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec14bc-95e9-47ce-b51e-d5eac9b345fe.jpg?1",
             "name": "Demonic Torment",
             "text": "Target creature deals no damage during combat. Creature cannot attack.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "608d8365-b614-5e57-87e2-73ba15e371f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060f747-f65c-4ee0-923a-76298cb51a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060f747-f65c-4ee0-923a-76298cb51a03.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "None of your creatures can attack except for Evil Eyes. Evil Eye can only be blocked by walls.",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "eb25d39d-7d45-5322-a6b5-82f869fe9b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4174e4-0be8-49b5-8c52-22001790f6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4174e4-0be8-49b5-8c52-22001790f6eb.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature to give Fallen Angel +2/+1 until end of turn.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "e3c21be2-a20c-5dbb-a77f-b442c7d257cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20275678-3488-43d8-a93b-993e2267ab07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20275678-3488-43d8-a93b-993e2267ab07.jpg?1",
             "name": "Ghosts of the Damned",
             "text": "oc\nT: Target creature gets -1/-0 until end of turn.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "77063398-d2bd-591c-8f7f-3a8594e3d243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a612e5-a680-4c5b-8ce7-432a86240a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a612e5-a680-4c5b-8ce7-432a86240a6c.jpg?1",
             "name": "Giant Slug",
             "text": "o5: During controller's next upkeep Giant Slug gains landwalk ability of controller's choice until end of turn. The type of landwalk chosen must correspond with one of the five basic land types.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "f9e68a21-b3e9-597c-b8e7-52e7caa6fdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332bfce9-052d-42e9-a407-4a1dd59e0f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332bfce9-052d-42e9-a407-4a1dd59e0f2a.jpg?1",
             "name": "Glyph of Doom",
             "text": "All creatures blocked by target wall are destroyed at the end of combat.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "e2547fe0-8576-5524-a0ff-bb0a19ddf997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111a16a2-e875-4756-80db-290f9e8606db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111a16a2-e875-4756-80db-290f9e8606db.jpg?1",
             "name": "Greed",
             "text": "oo\nB Draw an extra card and lose 2 life. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "55819b20-b066-5b0d-8407-8e8243aba632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa37c8-98fa-4984-b09b-cf65ad84e97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa37c8-98fa-4984-b09b-cf65ad84e97b.jpg?1",
             "name": "Headless Horseman",
             "text": "",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "dc8de30c-4916-5660-ba09-f55a7e503d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64164d1b-75f4-456e-a717-90ce554dc16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64164d1b-75f4-456e-a717-90ce554dc16c.jpg?1",
             "name": "Hell Swarm",
             "text": "All creatures get -1/-0 until end of turn.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "a9b066dd-028f-5569-99ac-bab5752696cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336b3b8f-d104-4f06-ad4f-c92b8a9038ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336b3b8f-d104-4f06-ad4f-c92b8a9038ca.jpg?1",
             "name": "Hell's Caretaker",
             "text": "oc\nT: During your upkeep sacrifice a creature and take a creature from your graveyard and put it directly into play. Treat this creature as though it were just summoned.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "7760329d-5af4-5f46-9b0d-c26a24873f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362f1fe9-20af-434c-9957-7a1a564d89e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362f1fe9-20af-434c-9957-7a1a564d89e6.jpg?1",
             "name": "Hellfire",
             "text": "All non-black creatures are destroyed. Hellfire does X + 3 damage to you; X is the number of creatures placed in the graveyard.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "f08606fc-ed57-5088-b483-70c14872c38d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68dc2-c048-41ec-b237-c36fdd99c27d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68dc2-c048-41ec-b237-c36fdd99c27d.jpg?1",
             "name": "Horror of Horrors",
             "text": "Allows caster to sacrifice a swamp to regenerate a target black creature.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "36ae1e1d-ed0e-5ef0-9583-b808981c5f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12671381-beb7-41b8-9484-97f8aca5c981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12671381-beb7-41b8-9484-97f8aca5c981.jpg?1",
             "name": "Imprison",
             "text": "Pay 1 each time target creature attempts to attack, block, or tap. That action is prevented and the creature becomes tapped. Destroy enchantment if mana is not paid.",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "964c44cd-3763-5a54-ae69-d85bf01944b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5333f-2761-42b8-ae8b-1d360b109daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5333f-2761-42b8-ae8b-1d360b109daf.jpg?1",
             "name": "Infernal Medusa",
             "text": "All non-wall creatures blocking Medusa are destroyed at the end of combat, as are all creatures blocked by Medusa.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "03a1e3b8-2c6a-571e-9ed8-0479478c56ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c993c74c-a574-423b-81c8-96b0a7a6e529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c993c74c-a574-423b-81c8-96b0a7a6e529.jpg?1",
             "name": "Jovial Evil",
             "text": "Jovial Evil does 2 damage to opponent for each white creature he or she controls.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "7debb295-1e36-5de7-84da-1218fcb95e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baae02e4-7db9-4a7b-a4ee-ecb22fcb77bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baae02e4-7db9-4a7b-a4ee-ecb22fcb77bd.jpg?1",
             "name": "Lesser Werewolf",
             "text": "oo\nB Lesser Werewolf gets -1/-0 until end of turn. Put a -0/-1 counter on target creature that blocks or is blocked by the Werewolf. Use this ability after defense is chosen but before damage is dealt. You may not use this ability to reduce the Lesser Werewolf's power below 0.",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "ef2099bc-9fdc-5ece-a15f-19e4e8e963d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601eed5c-436d-425b-a45f-07881ad893c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601eed5c-436d-425b-a45f-07881ad893c8.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "4fe0e29e-e4fa-56e1-9621-97211387b906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg?1",
             "name": "Mold Demon",
             "text": "When Mold Demon is brought into play, controller must sacrifice two swamps or Mold Demon is buried.",
             "colours": [
@@ -3602,7 +3602,7 @@
         },
         {
             "id": "481ea771-cfa8-526f-95d2-602953bcfaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e72f8cb-5bc3-4711-9b7c-a6eea9a0beaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e72f8cb-5bc3-4711-9b7c-a6eea9a0beaf.jpg?1",
             "name": "Nether Void",
             "text": "All spells cast are countered unless their casters pay an additional o3.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "f981bc41-6f91-5bf0-8a05-38aa4bc5eb80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc564f84-0d6e-4e09-a58d-a694d918cf12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc564f84-0d6e-4e09-a58d-a694d918cf12.jpg?1",
             "name": "Pit Scorpion",
             "text": "If Scorpion damages opponent, opponent gets a poison counter. If opponent ever has ten or more poison counters, opponent loses game.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "9bfb49d7-ab44-5d3b-a965-558e13edbcc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2aa9e-af6a-41c6-99a8-ca9335730ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2aa9e-af6a-41c6-99a8-ca9335730ddb.jpg?1",
             "name": "Quagmire",
             "text": "Creatures with swampwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "be893e09-7d98-58a5-9c0a-bf718ac291b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e04a1b9-c561-4e34-86d9-129ea0346631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e04a1b9-c561-4e34-86d9-129ea0346631.jpg?1",
             "name": "Shimian Night Stalker",
             "text": "o\nBoc\nT: Redirect all damage done to you from any one attacking creature to the Shimian Night Stalker.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "193d7287-eeb6-5088-b6d5-b816e739d7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb266-5bd1-4998-ae94-56f0f3354167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb266-5bd1-4998-ae94-56f0f3354167.jpg?1",
             "name": "Spirit Shackle",
             "text": "Put a -0/-2 counter on target creature every time it becomes tapped. Counters remain even if enchantment is removed.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "39dd18cc-462e-5fb3-aa74-7a7a47981364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3020304-7a39-411e-b055-3ade72b4bff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3020304-7a39-411e-b055-3ade72b4bff8.jpg?1",
             "name": "Syphon Soul",
             "text": "Syphon Soul does 2 damage to all players except caster. Caster gains life points equal to the amount of damage done by Syphon Soul.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "52dfb274-6e76-53f6-b8cd-d4ba4701b9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f49b3d-7fcb-4169-9298-cdf7a1dbe3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f49b3d-7fcb-4169-9298-cdf7a1dbe3f5.jpg?1",
             "name": "Takklemaggot",
             "text": "Put a 0/-1 counter on target creature during its controller's upkeep. If the creature is placed in the graveyard, its controller chooses a new target for Takklemaggot. If there are no legal targets, Takklemaggot becomes an enchantment and does 1 damage to the controller of the last creature Takklemaggot was on, during his or her upkeep. Takklemaggot does not revert to a creature enchantment even if other creatures are afterwards brought into play.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "5641f5a1-6aef-563d-89dc-47aa6915b423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27d68-3e58-4ade-976d-36381beed451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27d68-3e58-4ade-976d-36381beed451.jpg?1",
             "name": "The Abyss",
             "text": "All players bury one target non-artifact creature under their control, if they have any, during their upkeep.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "c6b6edda-23ce-5330-933b-94bcfa949fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c45416-a826-42e9-9967-8838158cf16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c45416-a826-42e9-9967-8838158cf16d.jpg?1",
             "name": "The Wretched",
             "text": "At the end of combat take control of all creatures that blocked The Wretched. The Wretched does not tap or untap these creatures. You lose control of these creatures if The Wretched leaves play or if you lose control of The Wretched.",
             "colours": [
@@ -3895,7 +3895,7 @@
         },
         {
             "id": "fd1ea316-80f1-54e5-a33c-ab07336fc096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7177f-1354-4008-aaaa-2c8b823ed5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7177f-1354-4008-aaaa-2c8b823ed5e9.jpg?1",
             "name": "Touch of Darkness",
             "text": "Changes the color of one or more target creatures to black until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or to use a special ability of target creatures remains entirely unchanged.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "8f78bf44-85a3-54a1-a2ad-816974db5af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f7eb2-eadf-46ec-aed4-63152051f3c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f7eb2-eadf-46ec-aed4-63152051f3c1.jpg?1",
             "name": "Transmutation",
             "text": "Until end of turn, target creature's power and toughness are switched. Effects that alter power alter toughness instead, and vice versa.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "13bce7a8-7e65-599b-8a7c-a7a245fca182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8f8d8-eac0-451c-a167-be84667a8e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8f8d8-eac0-451c-a167-be84667a8e3d.jpg?1",
             "name": "Underworld Dreams",
             "text": "Underworld Dreams does one damage to opponent for each card he or she draws.",
             "colours": [
@@ -3988,7 +3988,7 @@
         },
         {
             "id": "1282d553-ff57-571d-8a8f-b71c1975e23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6a6f50-7b86-461e-80a7-e35d0e7cf52f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6a6f50-7b86-461e-80a7-e35d0e7cf52f.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying, oo\nB +1/+0 until end of turn. No more than o\nBo\nB may be spent in this way per turn.",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "e95de950-a9e4-53ad-9c49-35fdee7f463c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7533a72-77d1-40cd-b3a1-7597d566c428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7533a72-77d1-40cd-b3a1-7597d566c428.jpg?1",
             "name": "Walking Dead",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "46f5045f-a04c-5652-9d16-55c19c6c4da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a17b74-a9c9-419a-8369-9ab4fec213f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a17b74-a9c9-419a-8369-9ab4fec213f2.jpg?1",
             "name": "Wall of Putrid Flesh",
             "text": "Protection from white\nDamage done to wall by creatures with enchantment cards played on them is reduced to 0.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "c21e45b0-6512-57a1-b481-6d6672726a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb351900-cffd-4d23-b82f-5fb12a4874d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb351900-cffd-4d23-b82f-5fb12a4874d9.jpg?1",
             "name": "Wall of Shadows",
             "text": "Damage Wall of Shadows receives from creatures it blocks is reduced to 0. Effects that target only walls may not target Wall of Shadows.",
             "colours": [
@@ -4120,7 +4120,7 @@
         },
         {
             "id": "3c1cec32-4af2-528a-bdee-3cf3dcf37c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55da1e86-fe18-486a-b510-f941e6f6e378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55da1e86-fe18-486a-b510-f941e6f6e378.jpg?1",
             "name": "Wall of Tombstones",
             "text": "At the end of your upkeep, the * below is set to the number of creatures in your graveyard.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "6e860b2d-cfcb-52d0-a851-65563806c15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad402e65-6fac-4005-a2d4-592983df0c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad402e65-6fac-4005-a2d4-592983df0c30.jpg?1",
             "name": "Active Volcano",
             "text": "Destroy target blue permanent or return target island to owner's hand. Enchantments on target land are destroyed.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "ee9d3291-4c9a-50d2-8a99-d1e2106489b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06673800-22a7-4ee3-92fa-7c7cd4865d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06673800-22a7-4ee3-92fa-7c7cd4865d30.jpg?1",
             "name": "Aerathi Berserker",
             "text": "Rampage: 3",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "2b873b8c-164a-508d-a2ee-b830e54b3067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d5b9fe-b66a-48c9-94c4-db783e605f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d5b9fe-b66a-48c9-94c4-db783e605f37.jpg?1",
             "name": "Backdraft",
             "text": "Backdraft does half of the damage (rounded down) done by one sorcery cast this turn to the caster of the sorcery.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "d2170d22-5ed7-54ea-ad7f-3276510e4526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f885d776-2953-4ed4-b63f-91dc2b42783b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f885d776-2953-4ed4-b63f-91dc2b42783b.jpg?1",
             "name": "Beasts of Bogardan",
             "text": "Protection from red\nGains +1/+1 if an opponent controls any white cards.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "560a9204-7473-5fb6-ac58-744d927fa26e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921011ff-1696-4575-9198-abe993a0ee7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921011ff-1696-4575-9198-abe993a0ee7a.jpg?1",
             "name": "Blazing Effigy",
             "text": "When placed in the graveyard from play, Effigy does 3 damage to target creature. If an Effigy is damaged by another Effigy in this manner and is placed in the graveyard that turn, it deals the amount of damage received from the other Effigy in addition to its normal 3.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "b8c56ee1-097d-5fc1-95ea-2315fc1ed017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf1a9c-8b94-4ee7-92db-65b531149990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf1a9c-8b94-4ee7-92db-65b531149990.jpg?1",
             "name": "Blood Lust",
             "text": "Target creatures gain +4/-4 until end of turn. If this reduces creature's toughness below 1, creature's toughness is 1.",
             "colours": [
@@ -4346,7 +4346,7 @@
         },
         {
             "id": "efb2e80d-0ee3-5ac1-9722-eb30ffe8c4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f7479-b3a0-4c27-9602-78babb8d2e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f7479-b3a0-4c27-9602-78babb8d2e99.jpg?1",
             "name": "Caverns of Despair",
             "text": "All players may attack with no more than two creatures each turn and block with no more than two creatures each turn.",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "d6da3fe9-2974-592b-9920-1e9a607fca2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5883762-ca0a-4932-8d2a-41a45796a5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5883762-ca0a-4932-8d2a-41a45796a5f8.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning does 3 damage to one target. Each time Chain Lightning does damage, the target or target's controller may then pay o\nRo\nR to have Chain Lightning do 3 damage to any target of that player's choice.",
             "colours": [
@@ -4410,7 +4410,7 @@
         },
         {
             "id": "0f399135-929d-50d7-8cac-4dd4596cf367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432d6ae-a17f-484b-ad55-4b4b6674ba8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432d6ae-a17f-484b-ad55-4b4b6674ba8d.jpg?1",
             "name": "Crevasse",
             "text": "Creatures with mountainwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "cb095146-6d10-53f9-981c-efa45e0ef8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg?1",
             "name": "Crimson Kobolds",
             "text": "This card is a red spell when cast and Kobolds are a red creature.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "e5f8703a-76b4-5a88-ad63-ced142387262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f73f9c-1c4e-4343-bfa0-cc5c4a7a562e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f73f9c-1c4e-4343-bfa0-cc5c4a7a562e.jpg?1",
             "name": "Crimson Manticore",
             "text": "Flying\no\nRoc\nT: Manticore does 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "c3a321a6-4bbe-502d-be48-87241c47aa8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6b119-7db4-49dd-aaa4-044b8c133f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6b119-7db4-49dd-aaa4-044b8c133f13.jpg?1",
             "name": "Crookshank Kobolds",
             "text": "This card is a red spell when cast and Kobolds are a red creature.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "32559338-0de7-5357-80e4-ef1a33ccdfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09a6b9b-eb0e-475d-8558-08e347412790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09a6b9b-eb0e-475d-8558-08e347412790.jpg?1",
             "name": "Disharmony",
             "text": "Target attacking creature comes under your control untapped. Return to former controller at end of turn. This creature is no longer considered to have attacked. Play before defense is chosen.",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "7202b9a9-0b78-5fc3-bca2-4756c1cbda8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a50f72-9524-4440-9380-9d3e0b693351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a50f72-9524-4440-9380-9d3e0b693351.jpg?1",
             "name": "Dwarven Song",
             "text": "Changes the color of one or more target creatures to red until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or use a special ability of target creatures remains entirely unchanged.",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "7b3ed14e-1e89-57be-aafa-2b944e040d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cdc38e-1d96-4de2-98e2-713f5d4d2180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cdc38e-1d96-4de2-98e2-713f5d4d2180.jpg?1",
             "name": "Eternal Warrior",
             "text": "Attacking does not tap target creature.",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "12f9e555-70e8-5646-8bf9-db3e8f559f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b9983e-20d4-4d12-9e2c-ec6d9a345787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b9983e-20d4-4d12-9e2c-ec6d9a345787.jpg?1",
             "name": "Falling Star",
             "text": "Flip Star onto the playing area from a height of at least one foot. Star must turn at least 360 degrees or it has no effect. When Falling Star lands, Falling Star does 3 damage to each creature that it touches. Any creatures damaged by Falling Star that are not destroyed become tapped.",
             "colours": [
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "5c13c76b-bcf4-5773-ad92-35ccb23fe283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b265bc-a94d-403b-8232-8fdfa0f8d9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b265bc-a94d-403b-8232-8fdfa0f8d9d5.jpg?1",
             "name": "Feint",
             "text": "All creatures blocking target attacking creature become tapped. Target attacking creature and all creatures blocking it deal no damage during combat.",
             "colours": [
@@ -4697,7 +4697,7 @@
         },
         {
             "id": "2c29490f-d8ed-5291-8685-67e1dc4101f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3247a7dd-f48c-4cb4-8475-4864acccef7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3247a7dd-f48c-4cb4-8475-4864acccef7a.jpg?1",
             "name": "Firestorm Phoenix",
             "text": "Flying\nIf Phoenix is placed in the graveyard from play, return it to owner's hand instead. It may not be summoned again until owner's next turn.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "3a02b4e7-ec81-5e0b-98ae-192bf2246b34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955d54f-7b37-4e43-8183-51677fb1ee11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955d54f-7b37-4e43-8183-51677fb1ee11.jpg?1",
             "name": "Frost Giant",
             "text": "Rampage: 2",
             "colours": [
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "8af2099b-9fb0-54d6-95ab-acc85ac16381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86190bb-1f41-4128-b9fb-dfb1d178359d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86190bb-1f41-4128-b9fb-dfb1d178359d.jpg?1",
             "name": "Giant Strength",
             "text": "Target creature gains +2/+2",
             "colours": [
@@ -4796,7 +4796,7 @@
         },
         {
             "id": "f1cbd9eb-c6d3-5248-841c-7077d0ee2e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9c153c-9224-491b-bc84-8a9f0a83ee5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9c153c-9224-491b-bc84-8a9f0a83ee5a.jpg?1",
             "name": "Glyph of Destruction",
             "text": "Target wall you control gains +10/+0 when blocking. Any damage dealt to target wall is reduced to zero. Target wall is destroyed at end of turn.",
             "colours": [
@@ -4827,7 +4827,7 @@
         },
         {
             "id": "b4fbe9ef-0763-50db-9be2-cdfda2ac3c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2749332-e99a-4a0c-b3a3-5578b552fa11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2749332-e99a-4a0c-b3a3-5578b552fa11.jpg?1",
             "name": "Gravity Sphere",
             "text": "All creatures lose flying ability.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "39273797-77d8-515a-b95f-0649d38508c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d499a9-fe7c-4a1a-9eb3-a7fd9f85ae08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d499a9-fe7c-4a1a-9eb3-a7fd9f85ae08.jpg?1",
             "name": "Hyperion Blacksmith",
             "text": "oc\nT: Target artifact controlled by opponent becomes tapped or untapped.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "6d8bba47-ceff-5e5b-bdce-0666585af390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3d34fa-398c-4ea0-a392-6690bd3a615c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3d34fa-398c-4ea0-a392-6690bd3a615c.jpg?1",
             "name": "Immolation",
             "text": "Target creature gains +2/-2.",
             "colours": [
@@ -4927,7 +4927,7 @@
         },
         {
             "id": "b52a5ad9-3920-5c32-981b-d207b06a480c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741b14f8-625d-41be-a734-0efe042a6ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741b14f8-625d-41be-a734-0efe042a6ee8.jpg?1",
             "name": "Kobold Drill Sergeant",
             "text": "All your Kobolds gain +0/+1 and Trample.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "bf47889a-892b-560f-8648-fadbc02dd7b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg?1",
             "name": "Kobold Overlord",
             "text": "First strike\nAll your Kobolds gain first strike.",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "c386689e-322e-5a59-b79b-dfbe44e08e7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c63eb-8d4e-4d8b-8637-308459ef036b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c63eb-8d4e-4d8b-8637-308459ef036b.jpg?1",
             "name": "Kobold Taskmaster",
             "text": "All your Kobolds gain +1/+0.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "803ce90e-d290-5101-94bc-f8bc8802e81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0320d9-7c2a-456a-9159-1b4fae67bfb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0320d9-7c2a-456a-9159-1b4fae67bfb5.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "This card is a red spell when cast and Kobolds are a red creature.",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "6624739f-883b-5194-9f7b-f35ae7713a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3d9b29-948c-4768-b5ea-db2512817c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3d9b29-948c-4768-b5ea-db2512817c30.jpg?1",
             "name": "Land's Edge",
             "text": "Any player may discard a card from hand at any time. If that player discards a land, Land's Edge does 2 damage to target player of the discarding player's choice.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "3253cff5-c72b-51d7-9ea5-4f88a1f2f10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09242f08-3bfc-4082-b32f-703c7fed62a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09242f08-3bfc-4082-b32f-703c7fed62a0.jpg?1",
             "name": "Mountain Yeti",
             "text": "Mountainwalk, protection from white.",
             "colours": [
@@ -5126,7 +5126,7 @@
         },
         {
             "id": "975c6f81-6b63-5562-83fb-18542be410f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e47e1-8639-48f7-94c4-5f9e9666839a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e47e1-8639-48f7-94c4-5f9e9666839a.jpg?1",
             "name": "Primordial Ooze",
             "text": "Must attack each turn if possible. Gains +1/+1 at end of your upkeep. Use counters. Then pay o1 per counter or Ooze deals 1 damage to you for each counter and becomes tapped.",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "a5e53790-5fac-52e2-8db0-30a12dc0e5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2646284b-a94d-4c99-98d4-7becbb473e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2646284b-a94d-4c99-98d4-7becbb473e2b.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics does 4 damage divided any way you choose among any number of targets.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "274a1532-1be8-53f6-9bc5-bf76729e3b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3b33bf-3074-406e-86f3-2a9843cf4862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3b33bf-3074-406e-86f3-2a9843cf4862.jpg?1",
             "name": "Quarum Trench Gnomes",
             "text": "oc\nT: Target plains produces o1 instead of o\nW until end of game. Use counters.",
             "colours": [
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "8ff26340-95f8-5fd7-8d7e-42c1e3720526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec10a51c-d2c3-4d14-9a71-9e59155bf980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec10a51c-d2c3-4d14-9a71-9e59155bf980.jpg?1",
             "name": "Raging Bull",
             "text": "",
             "colours": [
@@ -5256,7 +5256,7 @@
         },
         {
             "id": "fbcadb52-7bc6-53d6-b28c-9ba7cdd1ae2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg?1",
             "name": "Spinal Villain",
             "text": "oc\nT: Destroy target blue creature.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "6df54ceb-8978-5106-8ca7-22a6b1e3da9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0afa6-7003-454d-9b8a-e3328aaf29ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0afa6-7003-454d-9b8a-e3328aaf29ed.jpg?1",
             "name": "Storm World",
             "text": "If any player has less than four cards in hand at the end of his or her upkeep, Storm World does one damage to that player for each card less than four.",
             "colours": [
@@ -5322,7 +5322,7 @@
         },
         {
             "id": "7f277fad-f4b1-5188-b0ad-7a840a0f7001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb562143-fdf0-4eed-83ac-551627c576d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb562143-fdf0-4eed-83ac-551627c576d2.jpg?1",
             "name": "Tempest Efreet",
             "text": "oc\nT: Pick a card at random from opponent's hand and place it in yours. Bury Tempest Efreet in opponent's graveyard. The change in ownership is permanent. Play as an interrupt, but opponent may prevent effect by paying 10 life or conceding game before the card to be switched is chosen\u2014if this is done, Tempest Efreet is buried. Effects that prevent or redirect damage may not be used to counter this loss of life. Remove this card from deck if not playing for ante.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "e6c85ec7-b012-53ea-af29-6b49f5bd0062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ffb265-872f-47b3-974c-92bcbebd557e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ffb265-872f-47b3-974c-92bcbebd557e.jpg?1",
             "name": "The Brute",
             "text": "Target creature gains +1/+0\no\nRo\nRoo\nR Regenerates",
             "colours": [
@@ -5388,7 +5388,7 @@
         },
         {
             "id": "9760f211-9f93-58db-bbfd-aab0f4249173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf53dfe-5d48-4811-b2f5-5a5c1cb462ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf53dfe-5d48-4811-b2f5-5a5c1cb462ca.jpg?1",
             "name": "Wall of Dust",
             "text": "Creatures blocked by Wall of Dust cannot attack during your opponent's next turn. Use counters to mark these creatures.",
             "colours": [
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "7c51edf1-2b5c-5975-a550-3a19431a5b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12e97c1-ca28-432a-8140-3f08bb4485a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12e97c1-ca28-432a-8140-3f08bb4485a3.jpg?1",
             "name": "Wall of Earth",
             "text": "",
             "colours": [
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "30d33f97-5dc3-5fdd-886c-24f8f0448698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38059a8-be69-4cc1-969b-951c610f2f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38059a8-be69-4cc1-969b-951c610f2f11.jpg?1",
             "name": "Wall of Heat",
             "text": "",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "697032a5-757d-59ce-a748-ea046dbf07f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg?1",
             "name": "Wall of Opposition",
             "text": "o1: +1/+0 until end of turn.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "82b7ec4c-2a59-5580-91f0-a132c8b20b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186fd917-8d65-4de5-8546-a32a5f6d3bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186fd917-8d65-4de5-8546-a32a5f6d3bab.jpg?1",
             "name": "Winds of Change",
             "text": "All players shuffle their hands into their libraries, and then draw the same number of cards they originally held.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "5cabc9a2-65cf-55a1-a6a3-e541ff86af21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a161d-ad7b-4e5b-8f2d-d3753cb9daa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a161d-ad7b-4e5b-8f2d-d3753cb9daa3.jpg?1",
             "name": "Aisling Leprechaun",
             "text": "All creatures that block or are blocked by Leprechaun become green creatures. Use counters to indicate changed creatures. Cost to tap, maintain, or use a special ability of target creature remains entirely unchanged.",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "10b3a27c-5ce5-527a-8119-6f63323abcbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095078b0-0f26-442f-9d3b-45e30cdb33c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095078b0-0f26-442f-9d3b-45e30cdb33c4.jpg?1",
             "name": "Arboria",
             "text": "If a player does not cast a spell or put a card into play on his or her turn, no creatures may attack that player until after his or her next turn.",
             "colours": [
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "e7e65bcf-65e4-53bb-b6bc-f5996c842b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f1509e-6ed5-4009-a031-ea84b43cbd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f1509e-6ed5-4009-a031-ea84b43cbd1b.jpg?1",
             "name": "Avoid Fate",
             "text": "Counters target interrupt or enchantment. Can only counter spells that target a permanent under your control.",
             "colours": [
@@ -5648,7 +5648,7 @@
         },
         {
             "id": "f6fa4651-107d-55b1-8192-cc9974fa1508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df25ffdd-995d-46ae-856b-f6368f9438ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df25ffdd-995d-46ae-856b-f6368f9438ed.jpg?1",
             "name": "Barbary Apes",
             "text": "",
             "colours": [
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "41d3bdcd-910f-591a-9773-328eea425ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2187a64-2823-4f58-ad35-70f8913db2dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2187a64-2823-4f58-ad35-70f8913db2dc.jpg?1",
             "name": "Cat Warriors",
             "text": "Forestwalk",
             "colours": [
@@ -5715,7 +5715,7 @@
         },
         {
             "id": "bdda0e11-80af-59e0-a1d2-b64a14865bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82c87b1-de37-4423-a1a4-533a1d8108b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82c87b1-de37-4423-a1a4-533a1d8108b2.jpg?1",
             "name": "Cocoon",
             "text": "Tap target creature you control and put three counters on it. Target creature does not untap as normal while it has one or more of these counters on it. Remove one counter during your upkeep. During the upkeep phase after the one in which the last counter was removed, Cocoon is destroyed and target creature gains a +1/+1 counter and flying ability.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "a8ad1bb7-3b26-5b41-9832-395216aa27a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcfae4-86c9-4d8a-bcfe-f0a928ec29db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcfae4-86c9-4d8a-bcfe-f0a928ec29db.jpg?1",
             "name": "Concordant Crossroads",
             "text": "Creatures may attack or use abilities that include the oc\nT symbol during the turn they are brought into play.",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "db995c07-c39b-50de-a4b1-94b1530439fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707dadf0-735f-445d-9240-e49660913314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707dadf0-735f-445d-9240-e49660913314.jpg?1",
             "name": "Craw Giant",
             "text": "Trample\nRampage: 2",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "2c021b4c-af1b-5eab-94f4-6354d712c897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d78f0fc-3ab2-46ee-b5a9-55ae97d08c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d78f0fc-3ab2-46ee-b5a9-55ae97d08c1a.jpg?1",
             "name": "Deadfall",
             "text": "Creatures with forestwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "1269f848-d369-5a77-bb62-95b84a6b310c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d41f08b-68fb-45f2-bdc9-488baedc7d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d41f08b-68fb-45f2-bdc9-488baedc7d6f.jpg?1",
             "name": "Durkwood Boars",
             "text": "",
             "colours": [
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "6206691a-ed43-5cfe-9a5c-ba61d250a61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1d349b-b5ab-4b2b-9b39-f8d8f6374aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1d349b-b5ab-4b2b-9b39-f8d8f6374aa5.jpg?1",
             "name": "Elven Riders",
             "text": "Cannot be blocked by any creatures except walls and flying creatures.",
             "colours": [
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "66495412-96c6-5c0b-994e-0dbe9e258e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e81250-52c3-49f6-be43-17c34339e177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e81250-52c3-49f6-be43-17c34339e177.jpg?1",
             "name": "Emerald Dragonfly",
             "text": "Flying, o\nGoo\nG First strike until end of turn.",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "c90d5031-4984-55e9-a90d-cfca2be8a536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520db5fb-d961-45a3-af74-6f054b8be3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520db5fb-d961-45a3-af74-6f054b8be3ab.jpg?1",
             "name": "Eureka",
             "text": "Both players may take any permanent in their hand and put it directly into play. Players take turns playing one card from their hand until neither wants to play more permanents. No other spells or effects of any kind may be used while Eureka is in effect. If a spell has an X in its casting cost, X is 0.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "49eb3c61-9d95-56ac-bcce-12d663d20d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26fa79a-ede8-4c80-98d5-f49696f8104d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26fa79a-ede8-4c80-98d5-f49696f8104d.jpg?1",
             "name": "Fire Sprites",
             "text": "Flying\no\nGoc\nT: Add o\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "9bbbbdc5-04a6-5700-aaed-99d7392d0b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141b9e3-7129-41e5-8b44-d3867e1c7e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141b9e3-7129-41e5-8b44-d3867e1c7e1d.jpg?1",
             "name": "Floral Spuzzem",
             "text": "If Floral Spuzzem attacks an opponent and is not blocked, then Floral Spuzzem may choose to destroy a target artifact under that opponent's control and deal no damage.",
             "colours": [
@@ -6042,7 +6042,7 @@
         },
         {
             "id": "db374883-6b63-5319-baee-e67c445fd63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5fc19-3b10-476f-9a73-e8bf4b5fbec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5fc19-3b10-476f-9a73-e8bf4b5fbec0.jpg?1",
             "name": "Giant Turtle",
             "text": "Giant Turtle may not attack if it attacked during your last turn.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "3925efd6-5fc4-5982-8b80-b6b6f8b5cded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67e8214-a192-4143-9d5e-d0e254e1bf6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67e8214-a192-4143-9d5e-d0e254e1bf6e.jpg?1",
             "name": "Glyph of Reincarnation",
             "text": "Play after combat is over. All surviving creatures blocked by target wall this turn are buried. For each creature buried in this manner, choose one creature from attacker's graveyard and return it to play under attacker's control. Treat these creatures as if they were just summoned. If there are not enough creatures in attacker's graveyard, all creatures in attacker's graveyard are returned to play.",
             "colours": [
@@ -6106,7 +6106,7 @@
         },
         {
             "id": "90d8f347-eceb-5be6-b5da-7f96ce4c9ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27180bad-9bbc-462b-8832-626dc403a3fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27180bad-9bbc-462b-8832-626dc403a3fd.jpg?1",
             "name": "Hornet Cobra",
             "text": "First strike",
             "colours": [
@@ -6139,7 +6139,7 @@
         },
         {
             "id": "ab6b0028-442e-5e7d-a79b-aa552c313304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2313bb-6f9b-49d6-b069-9f3b77b6e107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2313bb-6f9b-49d6-b069-9f3b77b6e107.jpg?1",
             "name": "Ichneumon Druid",
             "text": "Ichneumon Druid does 4 damage to any opponent casting an instant. This does not apply to the first instant cast by that opponent in each turn.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "b22043e4-cd5b-5435-9e87-6adad2326fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg?1",
             "name": "Killer Bees",
             "text": "Flying\noo\nG +1/+1 until end of turn.",
             "colours": [
@@ -6206,7 +6206,7 @@
         },
         {
             "id": "60e3edb5-58c6-52d3-bc77-35369a6ca58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0341da27-3d77-4959-b7fa-5929b2cc7141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0341da27-3d77-4959-b7fa-5929b2cc7141.jpg?1",
             "name": "Living Plane",
             "text": "Treat all land in play as both lands and 1/1 creatures. They may not be tapped for mana the first turn they are brought into play.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "d8e574d3-7144-594d-b0f1-d457296320de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bf56e-2d74-4e4d-a667-885853979377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bf56e-2d74-4e4d-a667-885853979377.jpg?1",
             "name": "Master of the Hunt",
             "text": "o2o\nGoo\nG Put a Wolves of the Hunt token into play. Treat this token as a 1/1 green creature with the ability bands with other Wolves of the Hunt.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "17d02e1f-c7e9-5bd8-9919-654cc86b1ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9903c043-9a7a-4994-b532-136d4c46edfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9903c043-9a7a-4994-b532-136d4c46edfd.jpg?1",
             "name": "Moss Monster",
             "text": "",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "a939cedb-3624-5a8d-b6fc-d05f79b5aa52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg?1",
             "name": "Pixie Queen",
             "text": "Flying\no\nGo\nGo\nGoc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -6338,7 +6338,7 @@
         },
         {
             "id": "bafbdba4-117c-5028-a2fa-26525658d1d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0370330d-83d9-44d2-a1ed-c4827edc60fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0370330d-83d9-44d2-a1ed-c4827edc60fd.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nGoc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "eb2cd02b-555a-5e0c-8502-9aa48d0f287c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9b9eb8-6367-4ab5-8e00-a9c9e1d69032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9b9eb8-6367-4ab5-8e00-a9c9e1d69032.jpg?1",
             "name": "Rabid Wombat",
             "text": "Wombat gains +2/+2 for each creature enchantment on it. Attacking does not cause Rabid Wombat to tap.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "a4e27505-74b8-5815-806e-8844b7b41d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3ab1a-5714-4b69-bc51-3752312b2d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3ab1a-5714-4b69-bc51-3752312b2d1f.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying ability until end of turn.",
             "colours": [
@@ -6438,7 +6438,7 @@
         },
         {
             "id": "36bf70e3-9a2d-55d5-8a08-2529058a522f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d3ce01-e344-4608-b709-320be3600019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d3ce01-e344-4608-b709-320be3600019.jpg?1",
             "name": "Rebirth",
             "text": "Each player may choose to be healed to 20 life. Any player choosing to be healed antes an additional card from the top of his or her library. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -6469,7 +6469,7 @@
         },
         {
             "id": "f83fe8a1-f522-5808-b045-6935b1b0931e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969c104e-daf4-480d-99a2-dd93c498b48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969c104e-daf4-480d-99a2-dd93c498b48e.jpg?1",
             "name": "Reincarnation",
             "text": "If target creature is placed in graveyard this turn, bring a creature from that graveyard directly into play under the control of the owner of the target creature. Treat this creature as though it were just summoned.",
             "colours": [
@@ -6500,7 +6500,7 @@
         },
         {
             "id": "d8b6aead-97e5-5a87-8a18-31c10359a40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07892b6c-08d2-47b5-8d64-0e4d1bdc3080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07892b6c-08d2-47b5-8d64-0e4d1bdc3080.jpg?1",
             "name": "Revelation",
             "text": "All players play with the cards in their hands face up on the table.",
             "colours": [
@@ -6533,7 +6533,7 @@
         },
         {
             "id": "30abae36-744a-529f-a3f9-f3f32847b70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4974c8-34c5-4290-b325-7586a67f6d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4974c8-34c5-4290-b325-7586a67f6d56.jpg?1",
             "name": "Rust",
             "text": "Counter target artifact effect, which must require an activation cost.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "0118ea0d-4957-58d7-8e6b-fe368578b940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddcc557-871d-425b-b4ee-bc0c9bc717aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddcc557-871d-425b-b4ee-bc0c9bc717aa.jpg?1",
             "name": "Shelkin Brownie",
             "text": "oc\nT: Remove the bands with other ability from target creature until end of turn.",
             "colours": [
@@ -6597,7 +6597,7 @@
         },
         {
             "id": "c8ef7ca0-20ba-595e-9890-a0c11b1c174f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b66d0cc-84d7-41ad-b0e7-74ebf604543f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b66d0cc-84d7-41ad-b0e7-74ebf604543f.jpg?1",
             "name": "Storm Seeker",
             "text": "Storm Seeker does 1 damage to opponent for every card in his or her hand.",
             "colours": [
@@ -6628,7 +6628,7 @@
         },
         {
             "id": "ba419cad-6632-5ac5-8896-5c7615e9e8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d6097-8021-46cd-a8c3-01013245e347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d6097-8021-46cd-a8c3-01013245e347.jpg?1",
             "name": "Subdue",
             "text": "Target creature deals no damage during combat but gains X toughness until end of turn; X is target creature's casting cost.",
             "colours": [
@@ -6659,7 +6659,7 @@
         },
         {
             "id": "9ecb374f-fc0d-54d3-a26b-f590306026a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f486df00-7c4a-4ff0-bb0b-c8b5432ac742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f486df00-7c4a-4ff0-bb0b-c8b5432ac742.jpg?1",
             "name": "Sylvan Library",
             "text": "You may draw two extra cards during your draw phase, then either put two of the cards drawn this turn back on top of your library (in any order), or lose 4 lives per card not replaced. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "483f8346-bb6c-50df-bade-04cb80b9f51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f323c3bb-cece-4035-b1a7-c4817cf7a08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f323c3bb-cece-4035-b1a7-c4817cf7a08c.jpg?1",
             "name": "Sylvan Paradise",
             "text": "Changes the color of one or more target creatures to green until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or use a special ability of target creatures remains entirely unchanged.",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "e8c7f3ba-f72f-5cac-86bb-33a3bff58fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254e0403-67d8-4e73-8d89-c901ebeba49f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254e0403-67d8-4e73-8d89-c901ebeba49f.jpg?1",
             "name": "Typhoon",
             "text": "Typhoon does 1 damage to each opponent for each island he or she controls.",
             "colours": [
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "c5d95ac2-9635-542d-b3b7-391b6e77c407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887f22af-8b92-422a-9cd5-f3977674bcdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887f22af-8b92-422a-9cd5-f3977674bcdc.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for any one basic land and put it into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards.",
             "colours": [
@@ -6783,7 +6783,7 @@
         },
         {
             "id": "146d1889-65ce-523a-b6d6-40a58c2fcdbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba294e7-7097-4bc3-b396-72e85dd4f441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba294e7-7097-4bc3-b396-72e85dd4f441.jpg?1",
             "name": "Whirling Dervish",
             "text": "Protection from black\nGains +1/+1 (use counters) at the end of each turn in which it does damage to opponent.",
             "colours": [
@@ -6817,7 +6817,7 @@
         },
         {
             "id": "f6284f28-12a4-5573-86b3-98a9cd570b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8b1f49-550e-405f-b17c-1d94589494ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8b1f49-550e-405f-b17c-1d94589494ad.jpg?1",
             "name": "Willow Satyr",
             "text": "oc\nT: Gain control of target legend. If Willow Satyr becomes untapped, you lose control of this legend; you may choose not to untap Willow Satyr as normal. You also lose control of legend if Willow Satyr leaves play, if you lose control of Willow Satyr, or if the game ends.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "e7ab9874-04dc-577b-ba2a-1d3b2ccb1e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb846366-2105-4999-8af1-a11687f42e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb846366-2105-4999-8af1-a11687f42e17.jpg?1",
             "name": "Winter Blast",
             "text": "X target creatures become tapped. Winter Blast does 2 damage to each target creature that has flying.",
             "colours": [
@@ -6881,7 +6881,7 @@
         },
         {
             "id": "19ad9944-c2e0-5c66-8f2d-7db887f256d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5aee52-095e-4c69-93eb-5adac11ed1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5aee52-095e-4c69-93eb-5adac11ed1fc.jpg?1",
             "name": "Wolverine Pack",
             "text": "Rampage: 2",
             "colours": [
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "013417c9-81f6-58c0-852a-0c5773203b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71122-2951-43eb-8ca8-1cda6d231013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71122-2951-43eb-8ca8-1cda6d231013.jpg?1",
             "name": "Wood Elemental",
             "text": "*s in the lower right-hand corner are set to the number of untapped forests you sacrifice when Wood Elemental is brought into play.",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "72e5915f-cdb3-543f-a3d2-13f7727b0ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60252226-a102-4d88-9b80-42d021b5184d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60252226-a102-4d88-9b80-42d021b5184d.jpg?1",
             "name": "Adun Oakenshield",
             "text": "o\nGo\nRo\nBoc\nT: Select one creature from your graveyard and place it in your hand.",
             "colours": [
@@ -6987,7 +6987,7 @@
         },
         {
             "id": "22c1e09e-8fd3-562c-99f0-81e259267b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57264bd9-94f6-4d4d-baff-2b2900585635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57264bd9-94f6-4d4d-baff-2b2900585635.jpg?1",
             "name": "Angus Mackenzie",
             "text": "o\nWo\nUo\nGoc\nT: Creatures attack and block as normal, but none deal any damage during combat. All attacking creatures are still tapped. Use this ability any time before attack damage is dealt.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "68e7f3ce-0a8b-57c7-8f0d-3ba5736f9002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbc62-ceb5-4540-ae38-901e5deafc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbc62-ceb5-4540-ae38-901e5deafc75.jpg?1",
             "name": "Arcades Sabboth",
             "text": "Flying\noo\nW +0/+1 until end of turn.\nYour untapped creatures gain +0/+2. Attacking creatures do not get this bonus. Pay o\nWo\nGo\nU during your upkeep or Arcades Sabboth is buried.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "d8cac55c-ed33-556a-be60-44cfd5d9d811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce83cf-965b-4e45-8efb-63f814df7a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce83cf-965b-4e45-8efb-63f814df7a35.jpg?1",
             "name": "Axelrod Gunnarson",
             "text": "Trample\nEach time a creature is placed in the graveyard during a turn in which Axelrod damaged it, you gain 1 life and Axelrod does 1 damage to target player.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "9d577d2e-a5ce-5309-9183-57dfd2b173da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bd3d4b-d01a-475d-bf3b-cf96f43bc9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bd3d4b-d01a-475d-bf3b-cf96f43bc9ef.jpg?1",
             "name": "Ayesha Tanaka",
             "text": "Banding\noc\nT: Artifact effect which requires an activation cost is countered unless its controller spends o\nW. This ability is played as an interrupt.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "c640a280-c135-5f08-935c-5e163bca7b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea52228-f8ad-4623-9e05-f162473bfc03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea52228-f8ad-4623-9e05-f162473bfc03.jpg?1",
             "name": "Barktooth Warbeard",
             "text": "",
             "colours": [
@@ -7180,7 +7180,7 @@
         },
         {
             "id": "2753bbff-d5e7-5dd8-9bbb-dc85f3d51412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a42691-98bb-4234-9b56-085e6677f3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a42691-98bb-4234-9b56-085e6677f3e4.jpg?1",
             "name": "Bartel Runeaxe",
             "text": "Bartel Runeaxe cannot be the target of enchant creature spells. Attacking does not cause Bartel Runeaxe to tap.",
             "colours": [
@@ -7220,7 +7220,7 @@
         },
         {
             "id": "8d74bc45-aca9-5f99-9ce0-d386f8e0f495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ae30e8-2dcd-46b8-925b-cc24e11fb95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ae30e8-2dcd-46b8-925b-cc24e11fb95d.jpg?1",
             "name": "Boris Devilboon",
             "text": "o2o\nBo\nRoc\nT: Put a minor demon token into play. Treat this token as a 1/1 red and black creature.",
             "colours": [
@@ -7258,7 +7258,7 @@
         },
         {
             "id": "43b3744b-1cf9-5f0e-99a5-78656a03666a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd7d7e1-f928-4429-9a59-ba0590a78e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd7d7e1-f928-4429-9a59-ba0590a78e98.jpg?1",
             "name": "Chromium",
             "text": "Flying, Rampage: 2\nPay o\nBo\nUo\nW during your upkeep or Chromium is buried.",
             "colours": [
@@ -7298,7 +7298,7 @@
         },
         {
             "id": "d8ec196f-b7bc-551e-85b8-6c40ba331128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd1278-1486-4516-8846-007ce1985ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd1278-1486-4516-8846-007ce1985ee9.jpg?1",
             "name": "Dakkon Blackblade",
             "text": "The *s below equal the number of lands you control.",
             "colours": [
@@ -7338,7 +7338,7 @@
         },
         {
             "id": "ec4b1732-0447-5073-8a0a-ea0f4446fa7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4ce350-b6ed-4e0e-8c70-efc6e5f18a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4ce350-b6ed-4e0e-8c70-efc6e5f18a5d.jpg?1",
             "name": "Gabriel Angelfire",
             "text": "During your upkeep, Gabriel gains one of the following abilities until your next upkeep: flying, first strike, trample, or rampage: 3.",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "eae8f11c-49b5-5412-8a36-370c8765bc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ef316b-dd22-40d1-82e8-8890976684c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ef316b-dd22-40d1-82e8-8890976684c0.jpg?1",
             "name": "Gosta Dirk",
             "text": "First strike\nCreatures with islandwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "90c67a70-5fb0-5036-b95c-97bce453d37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d70b6-a88c-49f4-9415-19919c4468ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d70b6-a88c-49f4-9415-19919c4468ae.jpg?1",
             "name": "Gwendlyn Di Corci",
             "text": "oc\nT: Target player discards one card from his or her hand at random. This power may only be used during your turn.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "6ea8a616-76c5-5f6d-a49d-37db204e9a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e939761-3542-4044-9038-d1d30c6a38fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e939761-3542-4044-9038-d1d30c6a38fc.jpg?1",
             "name": "Halfdane",
             "text": "When Halfdane comes into play he is 3/3. During your upkeep, Halfdane acquires the current power and toughness of target creature other than Halfdane. If there are no legal targets, Halfdane becomes 3/3.",
             "colours": [
@@ -7492,7 +7492,7 @@
         },
         {
             "id": "69cabfcb-ef26-5a95-835a-15ebd8033755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc3a85-c6b9-4fd2-a6a2-d3210708e5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc3a85-c6b9-4fd2-a6a2-d3210708e5ea.jpg?1",
             "name": "Hazezon Tamar",
             "text": "On your next upkeep after Hazezon is put into play, put * token Sand Warriors into play, where * is the number of lands under your control. Treat the Warriors as 1/1 white, green, and red creatures. If Hazezon leaves play, all Sand Warriors are also removed from game.",
             "colours": [
@@ -7532,7 +7532,7 @@
         },
         {
             "id": "bf61d85e-5d45-5be3-b4df-842cef79e21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8e501-6857-4a52-a3b9-2bf0bee5b08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8e501-6857-4a52-a3b9-2bf0bee5b08c.jpg?1",
             "name": "Hunding Gjornersen",
             "text": "Rampage: 1",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "770a46bd-d300-519c-94f3-1d4ad3a49be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5a45b1-169b-468e-9251-424c09cd7f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5a45b1-169b-468e-9251-424c09cd7f0f.jpg?1",
             "name": "Jacques le Vert",
             "text": "All your green creatures gain +0/+2.",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "eba70b87-1e30-5a0c-8803-63ff5ce07d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6ef678-4ce9-48d6-aa4f-2afd9a1ad724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6ef678-4ce9-48d6-aa4f-2afd9a1ad724.jpg?1",
             "name": "Jasmine Boreal",
             "text": "",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "52c59855-7571-5927-a62f-144fb8aae3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b80124-2b59-425c-93cc-9b032e631c6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b80124-2b59-425c-93cc-9b032e631c6e.jpg?1",
             "name": "Jedit Ojanen",
             "text": "",
             "colours": [
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "1b0fc555-c168-5e10-b82b-af7acecaf55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f841918-813b-4784-ab57-907185b0a355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f841918-813b-4784-ab57-907185b0a355.jpg?1",
             "name": "Jerrard of the Closed Fist",
             "text": "",
             "colours": [
@@ -7723,7 +7723,7 @@
         },
         {
             "id": "c81a5b45-7948-5b34-8667-3d0d9d34bb1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851d5b4-7991-49d4-8a52-bf233f960cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851d5b4-7991-49d4-8a52-bf233f960cbf.jpg?1",
             "name": "Johan",
             "text": "If Johan does not attack and is not tapped, any of your creatures may attack without tapping.",
             "colours": [
@@ -7763,7 +7763,7 @@
         },
         {
             "id": "c069947b-cb8c-574e-bc8f-04300cfe2cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b1e60d-54dd-41cd-b9a2-00890725a3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b1e60d-54dd-41cd-b9a2-00890725a3df.jpg?1",
             "name": "Kasimir the Lone Wolf",
             "text": "",
             "colours": [
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "4b6b1964-111d-5d61-9ae4-c26ffecc25c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a524a-fdc7-432d-994b-953808528349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a524a-fdc7-432d-994b-953808528349.jpg?1",
             "name": "Kei Takahashi",
             "text": "oc\nT: Prevent up to 2 damage to one creature.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "c45bc7ec-1f35-5e46-895e-072a4bcf58ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914ed2-9207-4689-9166-11d2f8949fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914ed2-9207-4689-9166-11d2f8949fdd.jpg?1",
             "name": "Lady Caleria",
             "text": "oc\nT: Lady Caleria does 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "fabe1e0f-3fa0-5e47-a911-420f2f576334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e122e9-ffa3-48dd-94d6-8f2886668e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e122e9-ffa3-48dd-94d6-8f2886668e59.jpg?1",
             "name": "Lady Evangela",
             "text": "o\nBo\nWoc\nT: Target creature does no damage during combat this turn.",
             "colours": [
@@ -7917,7 +7917,7 @@
         },
         {
             "id": "87ac0e4e-1c81-5f07-b5d7-8f2330e28774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2779553-74eb-42ba-97d0-96269f48c269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2779553-74eb-42ba-97d0-96269f48c269.jpg?1",
             "name": "Lady Orca",
             "text": "",
             "colours": [
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "b9e71596-36e7-53db-9410-14afeb6e12a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9211949-66a5-4039-ac6d-3e42b008b58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9211949-66a5-4039-ac6d-3e42b008b58e.jpg?1",
             "name": "Livonya Silone",
             "text": "First strike, Legendary Land-walk.",
             "colours": [
@@ -7992,7 +7992,7 @@
         },
         {
             "id": "06ea4bd5-292d-52d0-b1ed-57298aa3e444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02aabb-c464-4672-b37b-d5d713ef8939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02aabb-c464-4672-b37b-d5d713ef8939.jpg?1",
             "name": "Lord Magnus",
             "text": "First strike\nCreatures with plainswalk or forestwalk may be blocked as if they did not have either ability.",
             "colours": [
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "c3adc9a3-a3f3-5b47-a3e2-c93669345e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67330004-6720-46d9-9de0-c79230110583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67330004-6720-46d9-9de0-c79230110583.jpg?1",
             "name": "Marhault Elsdragon",
             "text": "Rampage: 1",
             "colours": [
@@ -8068,7 +8068,7 @@
         },
         {
             "id": "f886ce0b-5c9e-576e-80e6-c37b824e3a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f17ce3-711b-4bd9-addf-dd440fa7d2b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f17ce3-711b-4bd9-addf-dd440fa7d2b7.jpg?1",
             "name": "Nebuchadnezzar",
             "text": "o\nXoc\nT: Name a card. Opponent reveals X cards from his or her hand at random, or entire hand if he or she does not have enough cards. Opponent then discards any of those cards that match the one you named. May only use this power during your turn.",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "900f92ee-bc2d-5080-8d8c-eb5a46d520ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729feb73-4581-4f9d-ba47-bece72481b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729feb73-4581-4f9d-ba47-bece72481b86.jpg?1",
             "name": "Nicol Bolas",
             "text": "Flying\nAn opponent damaged by Nicol Bolas must discard entire hand. Ignore this effect if opponent has no cards left in hand. Pay o\nUo\nBo\nR during your upkeep or Nicol Bolas is buried.",
             "colours": [
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "27ea505d-e047-5c3b-9953-7c9ec58d5ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad64874d-ce33-4e0a-bcca-723f129ef415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad64874d-ce33-4e0a-bcca-723f129ef415.jpg?1",
             "name": "Palladia-Mors",
             "text": "Flying, Trample\nPay o\nWo\nGo\nR during your upkeep or Palladia-Mors is buried.",
             "colours": [
@@ -8186,7 +8186,7 @@
         },
         {
             "id": "dca88195-868d-57f1-9639-7c8b2c5fccdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304f9d39-3ea2-4274-b23e-e4eaabbc1c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304f9d39-3ea2-4274-b23e-e4eaabbc1c4b.jpg?1",
             "name": "Pavel Maliki",
             "text": "o\nBoo\nR +1/+0 until end of turn.",
             "colours": [
@@ -8223,7 +8223,7 @@
         },
         {
             "id": "cb52c789-bf9a-51cf-a059-70fac32417e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dcf48c-2700-4024-807e-9244e4c649ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dcf48c-2700-4024-807e-9244e4c649ac.jpg?1",
             "name": "Princess Lucrezia",
             "text": "oc\nT: Add o\nU to your mana pool.\nThis ability is played as an interrupt.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "28386f0b-271a-5a78-8c29-600d8588cb1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf6a3a3-4a06-4eb7-981a-b70cf05b2473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf6a3a3-4a06-4eb7-981a-b70cf05b2473.jpg?1",
             "name": "Ragnar",
             "text": "o\nWo\nUo\nGoc\nT: Regenerate target creature.",
             "colours": [
@@ -8301,7 +8301,7 @@
         },
         {
             "id": "e769e526-3c66-5b8b-969f-92d98bdf4dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c66c61-aadf-433b-9958-fc9b44b327b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c66c61-aadf-433b-9958-fc9b44b327b9.jpg?1",
             "name": "Ramirez DePietro",
             "text": "First strike",
             "colours": [
@@ -8339,7 +8339,7 @@
         },
         {
             "id": "aa7c2070-91d2-54d7-9e1b-5832ad36f263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079c74e-a39a-40f9-9c7e-9319c0c189c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079c74e-a39a-40f9-9c7e-9319c0c189c6.jpg?1",
             "name": "Ramses Overdark",
             "text": "oc\nT: Destroys a target creature which has an enchantment card played on it.",
             "colours": [
@@ -8377,7 +8377,7 @@
         },
         {
             "id": "e4d22f5c-e825-5e40-ada5-bcdd0b32ded7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503256f8-3aab-49d0-b78b-6502aa29ce52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503256f8-3aab-49d0-b78b-6502aa29ce52.jpg?1",
             "name": "Rasputin Dreamweaver",
             "text": "Put seven counters on Rasputin when brought into play. You may remove a counter to prevent one damage to Rasputin or add o1 to your mana pool. This ability is played as an interrupt. Put one counter on Rasputin during your upkeep if he started the turn untapped. You may not have more than seven of these counters on Rasputin at any time.",
             "colours": [
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "59fcbe91-3831-5410-852c-2a044a34a695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11f90e7-ced1-4d80-8083-99acbf459ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11f90e7-ced1-4d80-8083-99acbf459ad7.jpg?1",
             "name": "Riven Turnbull",
             "text": "oc\nT: Add o\nB to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -8453,7 +8453,7 @@
         },
         {
             "id": "e8483533-37a9-552a-af3c-55b9fcf00caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0891f0-83ce-4eb7-b0a9-cbc8168bafff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0891f0-83ce-4eb7-b0a9-cbc8168bafff.jpg?1",
             "name": "Rohgahh of Kher Keep",
             "text": "All your Kobolds of Kher Keep gain +2/+2. Pay o\nRo\nRo\nR during your upkeep, or Rohgahh and all Kobolds of Kher Keep become tapped and come under opponent's control.",
             "colours": [
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "b063948d-2d92-578a-8000-6f37dcc57425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13e8dc9-8d0f-4a2c-8c0e-be70a3a7dc8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13e8dc9-8d0f-4a2c-8c0e-be70a3a7dc8e.jpg?1",
             "name": "Rubinia Soulsinger",
             "text": "oc\nT: Gain control of target creature. Rubinia does not tap or untap this creature. If Rubinia becomes untapped you lose control of this creature; you may choose not to untap Rubinia as normal during your untap phase. You also lose control of target creature if either Rubinia leaves play or you lose control of Rubinia.",
             "colours": [
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "737c4466-0af8-5090-b9fc-a711c06e1b93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31570ded-f5e3-44c4-b95f-294ac10b2cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31570ded-f5e3-44c4-b95f-294ac10b2cd2.jpg?1",
             "name": "Sir Shandlar of Eberyn",
             "text": "",
             "colours": [
@@ -8567,7 +8567,7 @@
         },
         {
             "id": "42e420b4-efe7-5c42-be15-23ea78138160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c12ee9e-db13-4b4d-a061-b6566f538f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c12ee9e-db13-4b4d-a061-b6566f538f09.jpg?1",
             "name": "Sivitri Scarzam",
             "text": "",
             "colours": [
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "4c1caee9-82b5-5108-b8bc-8f1078cdfdb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20dcb0-5350-40e0-82d3-c8d0186fc9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20dcb0-5350-40e0-82d3-c8d0186fc9d2.jpg?1",
             "name": "Sol'kanar the Swamp King",
             "text": "Swampwalk\nSol'kanar's controller gains 1 life each time a black spell is cast.",
             "colours": [
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "168406bb-37a7-5d7c-b60c-f18dbdb33fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a277775a-6b48-4238-a618-3ae94c4cc85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a277775a-6b48-4238-a618-3ae94c4cc85c.jpg?1",
             "name": "Stangg",
             "text": "When Stangg is brought into play, also put a Stangg Twin token into play. Stangg Twin token is a 3/4 green and red legend. If Stangg leaves play, remove Stangg Twin token from game. If Stangg Twin leaves play, bury Stangg.",
             "colours": [
@@ -8681,7 +8681,7 @@
         },
         {
             "id": "f609cf1c-409c-5393-ac0b-1e8012502304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587075f3-a568-4089-83ca-fe1e473c025d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587075f3-a568-4089-83ca-fe1e473c025d.jpg?1",
             "name": "Sunastian Falconer",
             "text": "oc\nT: Add o2 to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -8719,7 +8719,7 @@
         },
         {
             "id": "2396d88c-b597-5de1-92c7-7e0ed7e22db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8384f87b-26c2-45b7-98ef-352c384f205e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8384f87b-26c2-45b7-98ef-352c384f205e.jpg?1",
             "name": "Tetsuo Umezawa",
             "text": "o\nRo\nBo\nBo\nUoc\nT: Destroy target tapped creature or target blocking creature. Tetsuo may not be a target of an enchant creature spell.",
             "colours": [
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "54bf1568-c0d3-5189-80bf-649d3bd1fbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83717eb2-220e-4086-be09-dee9174798b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83717eb2-220e-4086-be09-dee9174798b8.jpg?1",
             "name": "The Lady of the Mountain",
             "text": "",
             "colours": [
@@ -8796,7 +8796,7 @@
         },
         {
             "id": "dee65f5d-98b7-5300-a46f-2e9a4f952853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac56eda-5ed3-4abd-beec-f5063fbf930a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac56eda-5ed3-4abd-beec-f5063fbf930a.jpg?1",
             "name": "Tobias Andrion",
             "text": "",
             "colours": [
@@ -8834,7 +8834,7 @@
         },
         {
             "id": "0634c861-eb9a-5f3a-8df0-3de328232dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a4854-e62c-4be4-a9cc-1e14db4eede9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a4854-e62c-4be4-a9cc-1e14db4eede9.jpg?1",
             "name": "Tor Wauki",
             "text": "oc\nT: Tor Wauki does 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -8872,7 +8872,7 @@
         },
         {
             "id": "4783f2d0-bb74-5f64-82e0-9edf9e922e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd99522-4a91-4ccd-91bf-5f32a6ac3510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd99522-4a91-4ccd-91bf-5f32a6ac3510.jpg?1",
             "name": "Torsten Von Ursus",
             "text": "",
             "colours": [
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "cda86298-0a05-5618-98c0-94867d36b96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfbcb4d-a9ae-4d76-8dde-7312fbad56b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfbcb4d-a9ae-4d76-8dde-7312fbad56b0.jpg?1",
             "name": "Tuknir Deathlock",
             "text": "Flying\no\nGo\nRoc\nT: Target creature gains +2/+2 until end of turn.",
             "colours": [
@@ -8948,7 +8948,7 @@
         },
         {
             "id": "e13c4418-9042-5e2a-bd2b-fcdc0026a0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a40f34-fc26-4d05-9c52-6ffbf1766a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a40f34-fc26-4d05-9c52-6ffbf1766a3b.jpg?1",
             "name": "Ur-Drago",
             "text": "First strike\nCreatures with swampwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -8985,7 +8985,7 @@
         },
         {
             "id": "f4772000-8440-5f63-9505-7897a0b7851c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ea73ec-1325-4437-a23f-dcda1767c713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ea73ec-1325-4437-a23f-dcda1767c713.jpg?1",
             "name": "Vaevictis Asmadi",
             "text": "Flying\noo\nB Gain +1/+0 until end of turn.\noo\nR Gain +1/+0 until end of turn.\noo\nG Gain +1/+0 until end of turn.\nPay o\nBo\nRo\nG during your upkeep or Vaevictis Asmadi is buried.",
             "colours": [
@@ -9025,7 +9025,7 @@
         },
         {
             "id": "dec36047-ba60-5d1c-bd5a-77d78a15f42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6c7d89-32e7-4c3f-ac90-7db3a46eed4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6c7d89-32e7-4c3f-ac90-7db3a46eed4b.jpg?1",
             "name": "Xira Arien",
             "text": "Flying\no\nGo\nRo\nBoc\nT: Target player draws one card.",
             "colours": [
@@ -9065,7 +9065,7 @@
         },
         {
             "id": "af4419d9-7120-5e09-b553-679e34f9b7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d5aae6e-fe20-4363-9589-5a54bcbbb77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d5aae6e-fe20-4363-9589-5a54bcbbb77e.jpg?1",
             "name": "Al-abara's Carpet",
             "text": "o5oc\nT: Prevents all damage done to you by attacking non-flying creatures.",
             "colours": [],
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "4d43c97d-6895-54d5-b5ac-72315abd3135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4395b19-2118-4a09-8932-f9ce9bc54d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4395b19-2118-4a09-8932-f9ce9bc54d6d.jpg?1",
             "name": "Alchor's Tomb",
             "text": "o2oc\nT: Change the color of target permanent you control to a color of your choice. Use counters. Cost to cast, tap, maintain, or use a special ability of card remains unchanged.",
             "colours": [],
@@ -9119,7 +9119,7 @@
         },
         {
             "id": "114fa246-0937-563f-9164-cb14b3ac8e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9337996e-a119-4529-b422-f6d286c78e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9337996e-a119-4529-b422-f6d286c78e3f.jpg?1",
             "name": "Arena of the Ancients",
             "text": "All legends become tapped when Arena comes into play. Legends do not untap as normal during the untap phase.",
             "colours": [],
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "34b56838-266b-561b-9437-094651dab3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c66e64-e357-457d-8302-b3a1fc0c56ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c66e64-e357-457d-8302-b3a1fc0c56ce.jpg?1",
             "name": "Black Mana Battery",
             "text": "o2oc\nT: Put one counter on Black Mana Battery.\noc\nT: Add o\nB to your mana pool. Remove as many counters as you wish. For each counter removed add o\nB to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "f8d363da-a391-5cc7-b9d9-f97bb9f55bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35393661-2c53-46f0-bb33-2390d552b060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35393661-2c53-46f0-bb33-2390d552b060.jpg?1",
             "name": "Blue Mana Battery",
             "text": "o2oc\nT: Put one counter on Blue Mana Battery.\noc\nT: Add o\nU to your mana pool. Remove as many counters as you wish. For each counter removed add o\nU to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9204,7 +9204,7 @@
         },
         {
             "id": "a094a1ae-e4e3-5546-8041-34ca8969dc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936a03a5-73ba-436c-9d49-70e176d118e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936a03a5-73ba-436c-9d49-70e176d118e6.jpg?1",
             "name": "Bronze Horse",
             "text": "Trample\nDamage done to Bronze Horse by spells which target it is reduced to zero as long as you control another creature.",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "0797316a-4523-5a86-840a-232e6bd4096f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f53d3-0a84-4c55-8495-786f0f0783db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f53d3-0a84-4c55-8495-786f0f0783db.jpg?1",
             "name": "Forethought Amulet",
             "text": "Pay o3 during your upkeep or Forethought Amulet is destroyed. If you receive more than 2 damage from a sorcery or instant source, that damage is reduced to 2.",
             "colours": [],
@@ -9261,7 +9261,7 @@
         },
         {
             "id": "a8a9cc41-362e-5699-adb7-1b3cd6dd2fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8f11b5-3ba8-4913-b76a-fb469a74864d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8f11b5-3ba8-4913-b76a-fb469a74864d.jpg?1",
             "name": "Gauntlets of Chaos",
             "text": "o5: Sacrifice Gauntlets of Chaos. Take control of target land, creature, or artifact. Then give former controller of that permanent control of a target permanent of the same type under your control. You each control these permanents until game ends. Gauntlets of Chaos does not tap or untap these permanents. Enchantments on traded permanents are destroyed.",
             "colours": [],
@@ -9288,7 +9288,7 @@
         },
         {
             "id": "d73792b8-7fc6-596c-b242-cc1cefdc74e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4671fa01-4a9e-4cd9-8154-b0d45e11b702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4671fa01-4a9e-4cd9-8154-b0d45e11b702.jpg?1",
             "name": "Green Mana Battery",
             "text": "o2oc\nT: Put one counter on Green Mana Battery.\noc\nT: Add o\nG to your mana pool. Remove as many counters as you wish. For each counter removed add o\nG to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "8b5f3249-1e52-5aee-a9b1-7de4bb5162d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eff8d9-86de-4f19-bf00-5f20dc1373d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eff8d9-86de-4f19-bf00-5f20dc1373d4.jpg?1",
             "name": "Horn of Deafening",
             "text": "o2oc\nT: Target creature deals no damage during combat this turn.",
             "colours": [],
@@ -9344,7 +9344,7 @@
         },
         {
             "id": "40bbd54e-1da7-563e-a1f2-83691c57728b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65947312-75c2-4baa-805c-238a154156ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65947312-75c2-4baa-805c-238a154156ef.jpg?1",
             "name": "Knowledge Vault",
             "text": "o2oc\nT: Take a card from your library without looking at it and place it face down under Knowledge Vault. Sacrifice Knowledge Vault to discard entire hand and take the cards under the vault into your hand. If Knowledge Vault leaves play, put all cards under it in your graveyard.",
             "colours": [],
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "84fcd23e-8267-5f1b-bd17-519957053304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558f23c-c2ce-40d0-b894-f8ccbff8f622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558f23c-c2ce-40d0-b894-f8ccbff8f622.jpg?1",
             "name": "Kry Shield",
             "text": "o2oc\nT: Target creature you control deals no damage this turn, but gains +0/+X until end of turn, where X is the casting cost of target creature.",
             "colours": [],
@@ -9398,7 +9398,7 @@
         },
         {
             "id": "6b770bbb-edc8-5c98-b710-1266098ded5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50052f9a-d667-4a96-a9b1-b4169ee495e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50052f9a-d667-4a96-a9b1-b4169ee495e6.jpg?1",
             "name": "Life Chisel",
             "text": "Sacrifice a creature during your upkeep to gain life equal to creature's toughness.",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "fc20170d-4dd8-5121-9810-8448c531b768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99a3abc-e2a3-4eee-8f72-b1b25dcd1d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99a3abc-e2a3-4eee-8f72-b1b25dcd1d0b.jpg?1",
             "name": "Life Matrix",
             "text": "o4oc\nT: During your upkeep, put one counter on target creature. You may remove this counter at any time to regenerate that creature.",
             "colours": [],
@@ -9452,7 +9452,7 @@
         },
         {
             "id": "c3744515-4616-505e-8268-1abdd18b2b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eedc11-0b47-430c-8391-577a2d05c2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eedc11-0b47-430c-8391-577a2d05c2ae.jpg?1",
             "name": "Mana Matrix",
             "text": "Pay up to o2 less than required whenever casting an instant, interrupt, or enchantment spell.",
             "colours": [],
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "d1e09988-4cab-50e5-a4c5-3043ec0f864d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459b71d7-34c1-43b9-93ff-364f95aa4789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459b71d7-34c1-43b9-93ff-364f95aa4789.jpg?1",
             "name": "Marble Priest",
             "text": "All walls able to block Marble Priest must do so. Walls able to block more than one creature can still do so. If blocking wall is compelled to block more creatures than it is legally able to, defender chooses which of these attacking creatures to block, but must block as many creatures as it legally can. Damage dealt to Marble Priest from walls during combat is reduced to 0.",
             "colours": [],
@@ -9509,7 +9509,7 @@
         },
         {
             "id": "05b8a1d8-1df1-5193-9140-80452edd2789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f05d5e-bb7d-4554-b880-f0c6b4688357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f05d5e-bb7d-4554-b880-f0c6b4688357.jpg?1",
             "name": "Mirror Universe",
             "text": "oc\nT: Sacrifice Mirror Universe during your upkeep, and trade your number of live points with opponent. For example, if you had 2 life points and your opponent had 10, you would now have 10 life points and your opponent would have 2. Effects that prevent or redirect damage may not be used to counter this change of life.",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "7c0e57b8-7b89-5a92-bbe6-8183649fbb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daac2a6b-27c8-4567-9e0c-7b262628d331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daac2a6b-27c8-4567-9e0c-7b262628d331.jpg?1",
             "name": "North Star",
             "text": "o4oc\nT: You may cast one spell this turn by paying its casting cost with any type of mana. For example, o2o\nGo\nG becomes o4. However, the card still retains its original color. This ability is played as an interrupt.",
             "colours": [],
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "7b1ee3de-ed56-50bd-bcaa-2a0a424502d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60e209-aa29-48aa-9128-9bb175403c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60e209-aa29-48aa-9128-9bb175403c0c.jpg?1",
             "name": "Nova Pentacle",
             "text": "o3oc\nT: Redirect damage done to you from one source to target creature of opponent's choice.",
             "colours": [],
@@ -9590,7 +9590,7 @@
         },
         {
             "id": "b98b67d9-2e25-5abd-beb7-5b7ef31b77bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27f0fe-c032-4f61-9f3d-98a6d2e2c426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27f0fe-c032-4f61-9f3d-98a6d2e2c426.jpg?1",
             "name": "Planar Gate",
             "text": "Pay up to o2 less than required whenever casting a summon spell.",
             "colours": [],
@@ -9617,7 +9617,7 @@
         },
         {
             "id": "b423e2f6-c41d-5726-9fbf-5147d9e4bcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cc5d6-70f8-4a3c-92bd-8f49774bdce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cc5d6-70f8-4a3c-92bd-8f49774bdce2.jpg?1",
             "name": "Red Mana Battery",
             "text": "o2oc\nT: Put one counter on Red Mana Battery.\noc\nT: Add o\nR to your mana pool. Remove as many counters as you wish. For each counter removed add o\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "3552fe1e-1997-5e3a-8d31-8bb87fbca661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062cbae-ce5e-43be-9932-c81a0a3622e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062cbae-ce5e-43be-9932-c81a0a3622e8.jpg?1",
             "name": "Relic Barrier",
             "text": "oc\nT: Target artifact becomes tapped.",
             "colours": [],
@@ -9673,7 +9673,7 @@
         },
         {
             "id": "8a3eefec-4b22-508d-97fc-cbcfe4b58e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61706102-67fd-4167-bd7d-ec6da41db362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61706102-67fd-4167-bd7d-ec6da41db362.jpg?1",
             "name": "Ring of Immortals",
             "text": "o3oc\nT: Counter target interrupt or enchantment. Can only counter spells which target a permanent under your control. This ability is played as an interrupt.",
             "colours": [],
@@ -9700,7 +9700,7 @@
         },
         {
             "id": "b65ad9ed-dee4-5f65-a656-f6d61f1c49a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c970830-95cf-4471-af28-43da635073d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c970830-95cf-4471-af28-43da635073d0.jpg?1",
             "name": "Sentinel",
             "text": "The * in the lower right hand corner is 1 when cast. While blocking, you may choose to change * to equal one plus the power of target creature sentinel blocks this turn. While attacking, you may choose to change * to equal one plus the power of target creature that blocks Sentinel this turn.",
             "colours": [],
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "f88e6347-97f5-5ed7-b353-fd3851c30d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c350c38-6cbb-4b8b-823f-45d6a16568cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c350c38-6cbb-4b8b-823f-45d6a16568cc.jpg?1",
             "name": "Serpent Generator",
             "text": "o4oc\nT: Put a Poison Snake token into play. Treat this token as a 1/1 artifact creature. If this creature damages opponent, opponent gets a poison counter. If opponent ever has ten or more poison counters, opponent loses game.",
             "colours": [],
@@ -9757,7 +9757,7 @@
         },
         {
             "id": "be370790-9f48-5692-86e3-9adcfda47da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37fd4cc-ab5c-4c65-80ff-8f905b31e801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37fd4cc-ab5c-4c65-80ff-8f905b31e801.jpg?1",
             "name": "Sword of the Ages",
             "text": "Sword of the Ages comes into play tapped.\noc\nT: Sacrifice Sword of the Ages and as many creatures as you choose. Sword does the combined power of these creatures in damage to one target. Sacrificed creatures and Sword are then removed from the game entirely.",
             "colours": [],
@@ -9784,7 +9784,7 @@
         },
         {
             "id": "a1d4efdf-f807-5d34-bd04-3c896be47719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3756f7-0d99-4562-b32d-66de18a58fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3756f7-0d99-4562-b32d-66de18a58fdf.jpg?1",
             "name": "Triassic Egg",
             "text": "o3oc\nT: Put one counter on Triassic Egg. If there are at least two such counters, you may sacrifice Triassic Egg to take any creature from your hand or graveyard and put it directly into play. Treat this creature as though it were just summoned.",
             "colours": [],
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "51a7bdb8-9078-5c31-8b28-1045b957f16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0418672d-056e-416d-91b4-8ee6e47201dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0418672d-056e-416d-91b4-8ee6e47201dc.jpg?1",
             "name": "Voodoo Doll",
             "text": "Put one counter on Voodoo Doll during your upkeep. If Voodoo Doll is not tapped at end of your turn, it does X damage to you and is destroyed. X equals the number of counters on Voodoo Doll.\no\nXo\nXoc\nT: Voodoo Doll does X damage to any one target.",
             "colours": [],
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "38eb264d-ca29-5c5e-b067-bbe4a211dc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fbbe41-d21b-4028-905f-054c44d30eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fbbe41-d21b-4028-905f-054c44d30eb2.jpg?1",
             "name": "White Mana Battery",
             "text": "o2oc\nT: Put one counter on White Mana Battery.\noc\nT: Add o\nW to your mana pool. Remove as many counters as you wish. For each counter removed add o\nW to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9867,7 +9867,7 @@
         },
         {
             "id": "5e61872e-fc24-5a87-a340-00a282a846e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32865e68-5842-4f17-b2ea-4ffa743b511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32865e68-5842-4f17-b2ea-4ffa743b511f.jpg?1",
             "name": "Adventurers' Guildhouse",
             "text": "All your green legends gain bands with other legends.",
             "colours": [],
@@ -9894,7 +9894,7 @@
         },
         {
             "id": "26beca12-5a81-53b9-91a6-6dd2845b3d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65356e6-0ead-49fd-b069-be1ea9b1c105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65356e6-0ead-49fd-b069-be1ea9b1c105.jpg?1",
             "name": "Cathedral of Serra",
             "text": "All your white legends gain bands with other legends.",
             "colours": [],
@@ -9921,7 +9921,7 @@
         },
         {
             "id": "2ae796c6-ab14-5c32-b1c4-19d26558498f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816d30e-1e52-4323-b30e-1688fba23368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816d30e-1e52-4323-b30e-1688fba23368.jpg?1",
             "name": "Hammerheim",
             "text": "oc\nT: Add o\nR to your mana pool\noc\nT: Remove all landwalking ability from target creature until end of turn.",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "fb2bab3e-27f1-54f9-8f92-89db750eeef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d2422a-bb7d-4cdd-9aac-e5a936a4be3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d2422a-bb7d-4cdd-9aac-e5a936a4be3b.jpg?1",
             "name": "Karakas",
             "text": "oc\nT: Add o\nW to your mana pool\noc\nT: Return target legend to owner's hand; enchantments on target legend are destroyed.",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "f933b066-686b-5be8-9dff-09156878af0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314fd1d7-4bd8-4d95-b7c2-1aa6660ab88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314fd1d7-4bd8-4d95-b7c2-1aa6660ab88a.jpg?1",
             "name": "Mountain Stronghold",
             "text": "All your red legends may band with other legends.",
             "colours": [],
@@ -10010,7 +10010,7 @@
         },
         {
             "id": "6ac3b062-9d5d-5856-b89a-8f264564ad76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79427109-c1f3-476d-a029-0049217237b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79427109-c1f3-476d-a029-0049217237b5.jpg?1",
             "name": "Pendelhaven",
             "text": "oc\nT: Add o\nG to your mana pool\noc\nT: Target 1/1 creature gains +1/+2 until end of turn.",
             "colours": [],
@@ -10041,7 +10041,7 @@
         },
         {
             "id": "eafc027a-1cfc-5945-b209-b4a1b69adbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66641d88-b3f0-4bcd-8d2d-29aa2de69e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66641d88-b3f0-4bcd-8d2d-29aa2de69e30.jpg?1",
             "name": "Seafarer's Quay",
             "text": "All your blue legends gain bands with other legends.",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "5282ac88-2396-52fe-b8f6-736d6061c740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bc9b1d-5818-4d9e-b771-e49af4ff9a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bc9b1d-5818-4d9e-b771-e49af4ff9a5c.jpg?1",
             "name": "The Tabernacle at Pendrell Vale",
             "text": "All creatures now require an upkeep cost of o1 in addition to any other upkeep costs they may have. If the upkeep cost for a creature is not paid, the creature is destroyed.",
             "colours": [],
@@ -10097,7 +10097,7 @@
         },
         {
             "id": "52a98eb6-2120-5352-b1c5-b2607b18c08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43c01b7-443d-4061-a934-6863d230c9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43c01b7-443d-4061-a934-6863d230c9b8.jpg?1",
             "name": "Tolaria",
             "text": "oc\nT: Add o\nU to your mana pool\noc\nT: During upkeep remove the banding or bands with other ability from target creature until end of turn.",
             "colours": [],
@@ -10128,7 +10128,7 @@
         },
         {
             "id": "5782d956-9fb7-58ff-9d0d-969356a054df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de534ff-fb48-4692-bd0f-dd237ca28502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de534ff-fb48-4692-bd0f-dd237ca28502.jpg?1",
             "name": "Unholy Citadel",
             "text": "All your black legends gain bands with other legends.",
             "colours": [],
@@ -10155,7 +10155,7 @@
         },
         {
             "id": "079e2bfa-a3bc-5b4e-ab66-51e592dcb78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a261d0-7678-46f7-9285-d541486567d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a261d0-7678-46f7-9285-d541486567d8.jpg?1",
             "name": "Urborg",
             "text": "oc\nT: Add o\nB to your mana pool\noc\nT: Remove first strike ability or swampwalk ability from target creature until end of turn.",
             "colours": [],

--- a/Assets/Resources/Sets/LGN.json
+++ b/Assets/Resources/Sets/LGN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d047cdf7-3205-5261-83ec-80a202ce2748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814245de-6105-43ef-acbf-d12d304b6331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814245de-6105-43ef-acbf-d12d304b6331.jpg?1",
             "name": "Akroma, Angel of Wrath",
             "text": "Flying, first strike, trample, haste, protection from black, protection from red\nAttacking doesn't cause Akroma, Angel of Wrath to tap.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "3f83b84d-9fa6-550e-85bb-6599b721a8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798893df-e720-471d-822d-50284de23efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798893df-e720-471d-822d-50284de23efd.jpg?1",
             "name": "Akroma's Devoted",
             "text": "Attacking doesn't cause Clerics to tap.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "7e90d907-1c9b-5542-a174-c9064c0487e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2fa0a3-e40f-49e4-a4fd-427e7e808afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2fa0a3-e40f-49e4-a4fd-427e7e808afd.jpg?1",
             "name": "Aven Redeemer",
             "text": "Flying\n{T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "a5b97da9-bb84-58ec-a6d8-c86a73a468b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386a7062-6da8-4663-a218-75d894f7c0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386a7062-6da8-4663-a218-75d894f7c0e0.jpg?1",
             "name": "Aven Warhawk",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Bird and/or Soldier card you reveal in your hand.)\nFlying",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "0417d9d5-d5ae-5fb8-ba69-5efbaca7ad95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b1cad7-4e96-4ebe-8c99-4ed9217becf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b1cad7-4e96-4ebe-8c99-4ed9217becf3.jpg?1",
             "name": "Beacon of Destiny",
             "text": "{T}: The next time a source of your choice would deal damage to you this turn, that damage is dealt to Beacon of Destiny instead.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "3c35ffd7-29ae-5b3f-8c4a-eafc2178b35a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4dc1d3-53a1-411b-abf9-f5e4e80edc63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4dc1d3-53a1-411b-abf9-f5e4e80edc63.jpg?1",
             "name": "Celestial Gatekeeper",
             "text": "Flying\nWhen Celestial Gatekeeper is put into a graveyard from play, remove it from the game, then return up to two target Bird and/or Cleric cards from your graveyard to play.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "85de5708-6658-511b-b419-ffe8dc4a2143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65680bda-b999-4c2a-99a8-b03287e00807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65680bda-b999-4c2a-99a8-b03287e00807.jpg?1",
             "name": "Cloudreach Cavalry",
             "text": "Cloudreach Cavalry gets +2/+2 and has flying as long as you control a Bird.",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "5d4390f7-56f4-5dcc-8725-540df590b46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de13fba8-3fee-4ce2-b84d-b518a99eefe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de13fba8-3fee-4ce2-b84d-b518a99eefe0.jpg?1",
             "name": "Daru Mender",
             "text": "Morph {W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Daru Mender is turned face up, regenerate target creature.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "3904d239-d9a6-5cf0-ab53-5e481e9af8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b14a24-c74a-4465-9b36-8f5309e0a333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b14a24-c74a-4465-9b36-8f5309e0a333.jpg?1",
             "name": "Daru Sanctifier",
             "text": "Morph {1}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Daru Sanctifier is turned face up, destroy target enchantment.",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "61da696b-7e69-5c29-be3e-b6b43ee903f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5866a4-f4c0-45bc-9b33-b77387441d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5866a4-f4c0-45bc-9b33-b77387441d34.jpg?1",
             "name": "Daru Stinger",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Soldier card you reveal in your hand.)\n{T}: Daru Stinger deals damage equal to the number of +1/+1 counters on it to target attacking or blocking creature.",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "d5afbdb3-7bb2-5dc0-aa5d-0a3ad27a0b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b1c88-20a0-479e-91fb-16bb77f699fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b1c88-20a0-479e-91fb-16bb77f699fe.jpg?1",
             "name": "Defender of the Order",
             "text": "Morph {W}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Defender of the Order is turned face up, creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "9d950aec-8dab-5ef3-9265-464123dfdc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffbae4-7aad-493c-86a0-c6e6425da8fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffbae4-7aad-493c-86a0-c6e6425da8fd.jpg?1",
             "name": "Deftblade Elite",
             "text": "Provoke (When this attacks, you may have target creature defending player controls untap and block it if able.)\n{1}{W}: Prevent all combat damage that would be dealt to and dealt by Deftblade Elite this turn.",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "81817245-40bd-5a65-b5f5-155150de2e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1346fa14-1d9f-4c6a-887d-d3a93de00743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1346fa14-1d9f-4c6a-887d-d3a93de00743.jpg?1",
             "name": "Essence Sliver",
             "text": "Whenever a Sliver deals damage, its controller gains that much life.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "1d8c017c-a253-532a-b766-e091e4c4ad89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc66291-fdcc-4106-8875-94d2b0a70deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc66291-fdcc-4106-8875-94d2b0a70deb.jpg?1",
             "name": "Gempalm Avenger",
             "text": "Cycling {2}{W} ({2}{W}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Avenger, all Soldiers get +1/+1 and gain first strike until end of turn.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "42e4a16b-b177-5a3c-89ee-285ae7540a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad94e39-0aac-46bb-a7f2-bd88c537cb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad94e39-0aac-46bb-a7f2-bd88c537cb9c.jpg?1",
             "name": "Glowrider",
             "text": "Noncreature spells cost {1} more to play.",
             "colours": [
@@ -528,7 +528,7 @@
         },
         {
             "id": "2d5b72e5-9059-5d9c-9a50-b07d74f6bc44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb518bf0-17ad-4bbf-b922-42ee76ffcbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb518bf0-17ad-4bbf-b922-42ee76ffcbea.jpg?1",
             "name": "Liege of the Axe",
             "text": "Attacking doesn't cause Liege of the Axe to tap.\nMorph {1}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Liege of the Axe is turned face up, untap it.",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "beaf0f12-253b-53a4-bc86-6c60fbd25c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eaaded-b18a-4614-b5b5-b4bb49a2e1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eaaded-b18a-4614-b5b5-b4bb49a2e1b1.jpg?1",
             "name": "Lowland Tracker",
             "text": "First strike\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "166556b7-bcbd-5007-8cc7-b480785ec13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7087cb1e-f2e2-4b75-bacf-bc4153e398e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7087cb1e-f2e2-4b75-bacf-bc4153e398e3.jpg?1",
             "name": "Planar Guide",
             "text": "{3}{W}, Remove Planar Guide from the game: Remove all creatures from the game. At end of turn, return those cards to play under their owners' control.",
             "colours": [
@@ -633,7 +633,7 @@
         },
         {
             "id": "322df5e0-d0f4-58c7-b43a-7af3619e8b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82846d31-4981-4ef1-85c3-703569146a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82846d31-4981-4ef1-85c3-703569146a84.jpg?1",
             "name": "Plated Sliver",
             "text": "All Slivers get +0/+1.",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "949a2212-6695-5ee7-900f-783442803a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66afc4-3d6d-4ce7-acfc-a4ad34aa3e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66afc4-3d6d-4ce7-acfc-a4ad34aa3e99.jpg?1",
             "name": "Starlight Invoker",
             "text": "{7}{W}: You gain 5 life.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "9a9eaa8e-aed2-51c4-8117-bce5386bb429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b69d619-c31b-472b-9ae8-d4503704680d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b69d619-c31b-472b-9ae8-d4503704680d.jpg?1",
             "name": "Stoic Champion",
             "text": "Whenever a player cycles a card, Stoic Champion gets +2/+2 until end of turn.",
             "colours": [
@@ -738,7 +738,7 @@
         },
         {
             "id": "02f2ebd1-adb1-5671-a51a-f3663f20a99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5d519a-9f11-4b10-97ad-edccfda639bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5d519a-9f11-4b10-97ad-edccfda639bb.jpg?1",
             "name": "Sunstrike Legionnaire",
             "text": "Sunstrike Legionnaire doesn't untap during your untap step.\nWhenever another creature comes into play, untap Sunstrike Legionnaire.\n{T}: Tap target creature with converted mana cost 3 or less.",
             "colours": [
@@ -773,7 +773,7 @@
         },
         {
             "id": "176bc9ee-496f-5cb3-bb2f-8665816b04f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3d19c-d4c6-4c5c-85eb-11d55959a89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3d19c-d4c6-4c5c-85eb-11d55959a89c.jpg?1",
             "name": "Swooping Talon",
             "text": "Flying\n{1}: Swooping Talon loses flying until end of turn.\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "780d80a9-8a52-5da7-ac3e-7b1db1c1a279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b463b3e1-e314-4a65-a89e-0712f630b016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b463b3e1-e314-4a65-a89e-0712f630b016.jpg?1",
             "name": "Wall of Hope",
             "text": "(Walls can't attack.)\nWhenever Wall of Hope is dealt damage, you gain that much life.",
             "colours": [
@@ -842,7 +842,7 @@
         },
         {
             "id": "dcf9aae3-2dd0-5a2f-94e5-9b1322d46179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264369a-ab81-4938-9fa6-7c3e069442f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264369a-ab81-4938-9fa6-7c3e069442f4.jpg?1",
             "name": "Ward Sliver",
             "text": "As Ward Sliver comes into play, choose a color.\nAll Slivers have protection from the chosen color.",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "bbfdedc1-2598-5202-bb3e-66ac9e149f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b18b09-b1ff-479d-bd1c-cb8620a34fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b18b09-b1ff-479d-bd1c-cb8620a34fe4.jpg?1",
             "name": "Whipgrass Entangler",
             "text": "{1}{W}: Until end of turn, target creature gains \"This creature can't attack or block unless its controller pays {1} for each Cleric in play. (This cost is paid as attackers or blockers are declared.)\"",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "227ea980-8fd8-5266-adc8-41415ebeeef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9cb8ed-7abb-4e71-b42f-5041dd0c0394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9cb8ed-7abb-4e71-b42f-5041dd0c0394.jpg?1",
             "name": "White Knight",
             "text": "First strike, protection from black",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "d4111022-5cd5-5b1a-b6bb-9b4c2238a7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c45fd87-7b44-4e1a-b30f-41220b69d9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c45fd87-7b44-4e1a-b30f-41220b69d9e6.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature attacking you. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "cf0627e3-ee37-5dd8-9602-72a7b33fa46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd58d164-861d-4c80-ad2f-6283ed82faa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd58d164-861d-4c80-ad2f-6283ed82faa1.jpg?1",
             "name": "Wingbeat Warrior",
             "text": "Flying\nMorph {2}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Wingbeat Warrior is turned face up, target creature gains first strike until end of turn.",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "6ff28085-564d-59dc-a768-51a01f947d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ead30e-9f96-4fca-b619-fdc8d1b5e2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ead30e-9f96-4fca-b619-fdc8d1b5e2e0.jpg?1",
             "name": "Aven Envoy",
             "text": "Flying",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "685ddf02-5523-5ff4-b35f-bc13dfcbbc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88528929-4953-452a-b85e-dac15786e094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88528929-4953-452a-b85e-dac15786e094.jpg?1",
             "name": "Cephalid Pathmage",
             "text": "Cephalid Pathmage is unblockable.\n{T}, Sacrifice Cephalid Pathmage: Target creature is unblockable this turn.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "d8fef6b0-8295-5024-b8f0-dfe7c848677c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02a40a4-fa61-4595-810a-3796e0d71507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02a40a4-fa61-4595-810a-3796e0d71507.jpg?1",
             "name": "Chromeshell Crab",
             "text": "Morph {4}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Chromeshell Crab is turned face up, you may exchange control of target creature you control and target creature an opponent controls.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "20d52b3c-730e-56b7-b077-bdbfe88a9677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbda6799-3b55-4714-8305-713e1e198a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbda6799-3b55-4714-8305-713e1e198a15.jpg?1",
             "name": "Covert Operative",
             "text": "Covert Operative is unblockable.",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "f4a05b3d-6951-5926-84ad-4f664565d463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ced7275-3935-4bba-877d-81282bd171fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ced7275-3935-4bba-877d-81282bd171fd.jpg?1",
             "name": "Crookclaw Elder",
             "text": "Flying\nTap two untapped Birds you control: Draw a card.\nTap two untapped Wizards you control: Target creature gains flying until end of turn.",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "fee47ed7-aa28-59c6-b172-00d05d1e3f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2f5dca-e01f-41e3-bb6f-a60162118c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2f5dca-e01f-41e3-bb6f-a60162118c6d.jpg?1",
             "name": "Dermoplasm",
             "text": "Flying\nMorph {2}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Dermoplasm is turned face up, you may put a creature card with morph from your hand into play face up. If you do, return Dermoplasm to its owner's hand.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "dd2d1938-1abe-545f-b1d6-a86751d20194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e36cf11-5dfb-4593-8335-f739b7c7829c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e36cf11-5dfb-4593-8335-f739b7c7829c.jpg?1",
             "name": "Dreamborn Muse",
             "text": "At the beginning of each player's upkeep, that player puts the top X cards from his or her library into his or her graveyard, where X is the number of cards in his or her hand.",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "df3dc7ea-127d-5d69-aa37-da37fd6a4d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63390760-35a7-4b4c-8c68-5c84f90d0c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63390760-35a7-4b4c-8c68-5c84f90d0c58.jpg?1",
             "name": "Echo Tracer",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Echo Tracer is turned face up, return target creature to its owner's hand.",
             "colours": [
@@ -1294,7 +1294,7 @@
         },
         {
             "id": "1cba44ba-6466-55a9-9d82-ef832fd40256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1020538-89c8-4986-9687-78ab326acb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1020538-89c8-4986-9687-78ab326acb3e.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "48d395ec-9777-59a7-bd16-a9bd0b2d7fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bda65b-2e26-4531-9f6a-952df314c8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bda65b-2e26-4531-9f6a-952df314c8f7.jpg?1",
             "name": "Gempalm Sorcerer",
             "text": "Cycling {2}{U} ({2}{U}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Sorcerer, all Wizards gain flying until end of turn.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "ea36f9f2-011d-5239-a37b-83c84d68d908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16184709-f370-40cc-91f2-849a44ac451a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16184709-f370-40cc-91f2-849a44ac451a.jpg?1",
             "name": "Glintwing Invoker",
             "text": "{7}{U}: Glintwing Invoker gets +3/+3 and gains flying until end of turn.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "55fc0d0e-1c46-550e-8c7b-c09c6b7880ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a355c58-cd28-4d2d-9df1-91b4196b01ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a355c58-cd28-4d2d-9df1-91b4196b01ef.jpg?1",
             "name": "Keeneye Aven",
             "text": "Flying\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "cd45e77e-80ea-502a-a647-a53928b0eeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75eef50-b474-44bb-8222-3e473928304a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75eef50-b474-44bb-8222-3e473928304a.jpg?1",
             "name": "Keeper of the Nine Gales",
             "text": "Flying\n{T}, Tap two untapped Birds you control: Return target permanent to its owner's hand.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "e5593a9e-7da1-5622-bb79-56aafbd0235c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce1755-9f4a-4741-b6e5-288595ec494d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce1755-9f4a-4741-b6e5-288595ec494d.jpg?1",
             "name": "Master of the Veil",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Master of the Veil is turned face up, you may turn target creature with morph face down.",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "8ee62e2e-1e3a-52bf-9a2e-3be262d6f222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1109bdd-a5ce-4e63-adee-54e43a4c4a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1109bdd-a5ce-4e63-adee-54e43a4c4a1e.jpg?1",
             "name": "Merchant of Secrets",
             "text": "When Merchant of Secrets comes into play, draw a card.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "9e84dd67-1d4d-516a-8ef1-e4be5b5b4c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f6c73c-8162-499f-8d16-92f17c0c2bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f6c73c-8162-499f-8d16-92f17c0c2bee.jpg?1",
             "name": "Mistform Seaswift",
             "text": "Flying\n{1}: Mistform Seaswift's type becomes the creature type of your choice until end of turn.\nMorph {1}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "2053371e-6a38-5697-bed7-e84e32dea646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a53c29-6753-4f6b-b4ee-00c1adf7e9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a53c29-6753-4f6b-b4ee-00c1adf7e9c6.jpg?1",
             "name": "Mistform Sliver",
             "text": "All Slivers have \"{1}: This creature's type becomes the creature type of your choice in addition to its other types until end of turn.\"",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "f7964cf4-2d23-5da4-b326-268eac991968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be21c3-9b83-430b-be0a-792de9a680e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be21c3-9b83-430b-be0a-792de9a680e3.jpg?1",
             "name": "Mistform Ultimus",
             "text": "Mistform Ultimus is every creature type (even if this card isn't in play).\nMistform Ultimus may attack as though it weren't a Wall.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "668e3bad-5731-52d6-aac1-9cecf848ce83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5cbfb9-9bd0-4f8b-a444-a480de4b9662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5cbfb9-9bd0-4f8b-a444-a480de4b9662.jpg?1",
             "name": "Mistform Wakecaster",
             "text": "Flying\n{1}: Mistform Wakecaster's type becomes the creature type of your choice until end of turn.\n{2}{U}{U}, {T}: Choose a creature type. The type of each creature you control becomes that type until end of turn.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "a8b6c9d9-c5c9-5144-9d92-69bc5b8a6564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cb3e72-bb64-4b1e-a54b-1fe4fb4ad4c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cb3e72-bb64-4b1e-a54b-1fe4fb4ad4c9.jpg?1",
             "name": "Primoc Escapee",
             "text": "Flying\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "85af368f-a552-5cb8-85e0-f47d6ecb84b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d07de3-b176-4ac7-aaa7-497c06c08b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d07de3-b176-4ac7-aaa7-497c06c08b55.jpg?1",
             "name": "Riptide Director",
             "text": "{2}{U}{U}, {T}: Draw a card for each Wizard you control.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "e05fb82f-de0f-542a-aafa-9574f40ed57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314a802-85d6-4d7b-ae9a-ca64eec652cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314a802-85d6-4d7b-ae9a-ca64eec652cf.jpg?1",
             "name": "Riptide Mangler",
             "text": "{1}{U}: Change Riptide Mangler's power to target creature's power. (It doesn't change back at end of turn.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "22a426df-d521-500c-9e9b-7287163f9366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68c4c2-91b5-4ffe-9dff-a6834038aa94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68c4c2-91b5-4ffe-9dff-a6834038aa94.jpg?1",
             "name": "Shifting Sliver",
             "text": "Slivers can't be blocked except by Slivers.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "aecf601c-b7c6-5758-861e-bd0742cb3aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf966ff-0fd0-404d-be91-5b0c21035d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf966ff-0fd0-404d-be91-5b0c21035d73.jpg?1",
             "name": "Synapse Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may draw a card.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "1103143b-89f1-5608-8e82-ee23b45a2f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55924a25-e749-48f6-8ef1-1fa8376f96b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55924a25-e749-48f6-8ef1-1fa8376f96b1.jpg?1",
             "name": "Voidmage Apprentice",
             "text": "Morph {2}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Voidmage Apprentice is turned face up, counter target spell.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "02c68aea-ec27-5f67-9b3b-bd4733fc631a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1496d941-88fd-433e-8fae-1218316ef3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1496d941-88fd-433e-8fae-1218316ef3a9.jpg?1",
             "name": "Wall of Deceit",
             "text": "(Walls can't attack.)\n{3}: Turn Wall of Deceit face down.\nMorph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "5eff3001-2c9c-51ae-9711-f0a3aa4ee619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df94a4e-1371-4b75-a557-eeb83c23cf9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df94a4e-1371-4b75-a557-eeb83c23cf9d.jpg?1",
             "name": "Warped Researcher",
             "text": "Whenever a player cycles a card, Warped Researcher gains flying until end of turn and can't be the target of spells or abilities this turn.",
             "colours": [
@@ -1956,7 +1956,7 @@
         },
         {
             "id": "01ff277a-47a4-5612-b00f-7f6c735da1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12172d0e-0c73-4482-9f83-2c23ace9b7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12172d0e-0c73-4482-9f83-2c23ace9b7a0.jpg?1",
             "name": "Weaver of Lies",
             "text": "Morph {4}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Weaver of Lies is turned face up, turn any number of target creatures with morph other than Weaver of Lies face down.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "327e9043-f65e-550f-bf97-d902fd488ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb33b35b-33c9-4d59-9ed6-7ad40ea82cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb33b35b-33c9-4d59-9ed6-7ad40ea82cb0.jpg?1",
             "name": "Willbender",
             "text": "Morph {1}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Willbender is turned face up, change the target of target spell or ability with a single target.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "9a3e4479-ef2c-503a-a417-2e192f3b8c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8f63-daf2-4dbe-bb07-2b246145cdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8f63-daf2-4dbe-bb07-2b246145cdab.jpg?1",
             "name": "Aphetto Exterminator",
             "text": "Morph {3}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Aphetto Exterminator is turned face up, target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "4f5563be-d910-5df4-b376-068123c9f801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45ebf65-77b8-41bc-b913-d864c4a00549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45ebf65-77b8-41bc-b913-d864c4a00549.jpg?1",
             "name": "Bane of the Living",
             "text": "Morph {X}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Bane of the Living is turned face up, all creatures get -X/-X until end of turn.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "2201379c-1d42-5ce4-93e5-9654eb2f4a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805de325-6f14-4a52-bb85-f9a9545d82a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805de325-6f14-4a52-bb85-f9a9545d82a4.jpg?1",
             "name": "Blood Celebrant",
             "text": "{B}, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "c3ef71c2-bd0d-5e59-b09c-1f6a67ba3811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09c2c8-526b-4693-bbaa-109911ce5281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09c2c8-526b-4693-bbaa-109911ce5281.jpg?1",
             "name": "Corpse Harvester",
             "text": "{1}{B}, {T}, Sacrifice a creature: Search your library for a Zombie card and a swamp card, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "eb2c7395-9e59-5b37-981a-e055d91a7089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507097eb-6b50-47ae-a545-df76b743b2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507097eb-6b50-47ae-a545-df76b743b2bd.jpg?1",
             "name": "Crypt Sliver",
             "text": "All Slivers have \"{T}: Regenerate target Sliver.\"",
             "colours": [
@@ -2198,7 +2198,7 @@
         },
         {
             "id": "c3e81d27-f6b0-5ff5-96f7-490bde928d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb685932-5df5-4f26-9633-b1daa8925359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb685932-5df5-4f26-9633-b1daa8925359.jpg?1",
             "name": "Dark Supplicant",
             "text": "{T}, Sacrifice three Clerics: Search your graveyard, hand, and/or library for a card named Scion of Darkness and put it into play. If you search your library this way, shuffle it.",
             "colours": [
@@ -2233,7 +2233,7 @@
         },
         {
             "id": "36c49a97-1d92-57f4-96dc-f4147ec89efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54fb4b2-ecce-4a6c-8d76-4b5879ba836f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54fb4b2-ecce-4a6c-8d76-4b5879ba836f.jpg?1",
             "name": "Deathmark Prelate",
             "text": "{2}{B}, {T}, Sacrifice a Zombie: Destroy target non-Zombie creature. It can't be regenerated. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "e9af6c42-21b5-5d1f-921b-98047449bab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc8758b-68cc-45ab-85d0-b870cef7dd85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc8758b-68cc-45ab-85d0-b870cef7dd85.jpg?1",
             "name": "Drinker of Sorrow",
             "text": "Drinker of Sorrow can't block.\nWhenever Drinker of Sorrow deals combat damage, sacrifice a permanent.",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "5aa61697-2235-5253-ad0b-ad0299d0ffce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3b483-01a8-4f54-9a3a-0d3f5aa3cd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3b483-01a8-4f54-9a3a-0d3f5aa3cd8b.jpg?1",
             "name": "Dripping Dead",
             "text": "Dripping Dead can't block.\nWhenever Dripping Dead deals combat damage to a creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -2336,7 +2336,7 @@
         },
         {
             "id": "d4e55da6-30ec-56ae-a67c-154dbe93a322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830a4048-48ac-4856-9af9-5052ec146518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830a4048-48ac-4856-9af9-5052ec146518.jpg?1",
             "name": "Earthblighter",
             "text": "{2}{B}, {T}, Sacrifice a Goblin: Destroy target land.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "bfd6cf0d-7236-521f-a191-5dfa0e862539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e214da0-68c0-4cf6-ba12-e2b2394909c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e214da0-68c0-4cf6-ba12-e2b2394909c1.jpg?1",
             "name": "Embalmed Brawler",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nWhenever Embalmed Brawler attacks or blocks, you lose 1 life for each +1/+1 counter on it.",
             "colours": [
@@ -2405,7 +2405,7 @@
         },
         {
             "id": "ffa601ca-22dd-50ea-9aed-99593816fe81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9943ac-9e3f-4ee0-b5fd-3b0fb17097d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9943ac-9e3f-4ee0-b5fd-3b0fb17097d8.jpg?1",
             "name": "Gempalm Polluter",
             "text": "Cycling {B}{B} ({B}{B}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Polluter, you may have target player lose 1 life for each Zombie in play.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "9a0c80ee-63c7-5d90-9838-65da46a6e5e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e67323-df54-4043-a6b6-18bb89ef1f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e67323-df54-4043-a6b6-18bb89ef1f62.jpg?1",
             "name": "Ghastly Remains",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nAt the beginning of your upkeep, if Ghastly Remains is in your graveyard, you may pay {B}{B}{B}. If you do, return Ghastly Remains to your hand.",
             "colours": [
@@ -2473,7 +2473,7 @@
         },
         {
             "id": "519d3cec-277e-5bfa-af7b-e9e73329c235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac74e64-8831-4af2-9c6d-22c533389144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac74e64-8831-4af2-9c6d-22c533389144.jpg?1",
             "name": "Goblin Turncoat",
             "text": "Sacrifice a Goblin: Regenerate Goblin Turncoat.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "b5479269-b96f-513d-ad78-aceacac17aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa432e4e-ff23-4ad2-8d0a-403efee86f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa432e4e-ff23-4ad2-8d0a-403efee86f11.jpg?1",
             "name": "Graveborn Muse",
             "text": "At the beginning of your upkeep, you draw X cards and you lose X life, where X is the number of Zombies you control.",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "ed2b2260-41f9-5814-8f6b-5f9cd330450b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477802a-349d-41e1-b050-58da0d806abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477802a-349d-41e1-b050-58da0d806abf.jpg?1",
             "name": "Havoc Demon",
             "text": "Flying\nWhen Havoc Demon is put into a graveyard from play, all creatures get -5/-5 until end of turn.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "f9ceb186-7297-51d2-ad6a-0b9483d8a6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db779fd-0e01-417b-aee2-786db2c0b8c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db779fd-0e01-417b-aee2-786db2c0b8c8.jpg?1",
             "name": "Hollow Specter",
             "text": "Flying\nWhenever Hollow Specter deals combat damage to a player, you may pay {X}. If you do, that player reveals X cards from his or her hand and you choose one of them. That player discards that card.",
             "colours": [
@@ -2611,7 +2611,7 @@
         },
         {
             "id": "15ad5e18-3f8a-55b6-8063-83f4c91336d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a028a30-6242-4d87-9501-d1826ecb69b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a028a30-6242-4d87-9501-d1826ecb69b0.jpg?1",
             "name": "Infernal Caretaker",
             "text": "Morph {3}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Infernal Caretaker is turned face up, return all Zombie cards from all graveyards to their owners' hands.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "faf52df1-c6cc-5ecd-ae23-dd2cbcb26b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d3b33d-25b4-42b4-a93e-2a6b69832030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d3b33d-25b4-42b4-a93e-2a6b69832030.jpg?1",
             "name": "Noxious Ghoul",
             "text": "Whenever Noxious Ghoul or another Zombie comes into play, all non-Zombie creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "12ea9045-f0ca-5190-b7f3-71707554e20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410b933-99d0-4383-b54b-4839a76eb6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410b933-99d0-4383-b54b-4839a76eb6fe.jpg?1",
             "name": "Phage the Untouchable",
             "text": "When Phage the Untouchable comes into play, if you didn't play it from your hand, you lose the game.\nWhenever Phage deals combat damage to a creature, destroy that creature. It can't be regenerated.\nWhenever Phage deals combat damage to a player, that player loses the game.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "9eab83c7-206a-5ee8-a007-44e67ae1a9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497c2629-1263-48a4-9c31-7f052808b2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497c2629-1263-48a4-9c31-7f052808b2b8.jpg?1",
             "name": "Scion of Darkness",
             "text": "Trample\nWhenever Scion of Darkness deals combat damage to a player, you may put target creature card from that player's graveyard into play under your control.\nCycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "b6e4f9d8-c3d5-5908-b5c6-ee5873e26e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b8c392-da68-4894-b6e8-eb430141a0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b8c392-da68-4894-b6e8-eb430141a0d7.jpg?1",
             "name": "Skinthinner",
             "text": "Morph {3}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Skinthinner is turned face up, destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "959a16e0-a64e-546c-9c54-a45e541d5243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea393a4-58c8-4a42-bd95-a3312504f2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea393a4-58c8-4a42-bd95-a3312504f2e2.jpg?1",
             "name": "Smokespew Invoker",
             "text": "{7}{B}: Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "c25dddbd-32fd-5ef7-aee7-4dd707720f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a2ccc-8847-452b-b030-27d8506675bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a2ccc-8847-452b-b030-27d8506675bd.jpg?1",
             "name": "Sootfeather Flock",
             "text": "Flying\nMorph {3}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2854,7 +2854,7 @@
         },
         {
             "id": "414ea154-acd2-5b0b-83cb-8ab0d7889707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec97e3c-7b75-4abb-a50e-86bc8cc3bf06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec97e3c-7b75-4abb-a50e-86bc8cc3bf06.jpg?1",
             "name": "Spectral Sliver",
             "text": "All Slivers have \"{2}: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "522370cc-6f34-57a5-9555-a42fdeb49db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04ab6b6-27ee-4c93-a87c-cbc3743f4faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04ab6b6-27ee-4c93-a87c-cbc3743f4faf.jpg?1",
             "name": "Toxin Sliver",
             "text": "Whenever a Sliver deals combat damage to a creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "de83ec85-da7c-5436-8dc9-b29513635b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2641bd5-c845-47a1-8038-bb28b06f896e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2641bd5-c845-47a1-8038-bb28b06f896e.jpg?1",
             "name": "Vile Deacon",
             "text": "Whenever Vile Deacon attacks, it gets +X/+X until end of turn, where X is the number of Clerics in play.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "258488cc-0015-55ff-82cf-d49d7522ee1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a82948-503f-4ad4-9e3c-c080c16afd63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a82948-503f-4ad4-9e3c-c080c16afd63.jpg?1",
             "name": "Withered Wretch",
             "text": "{1}: Remove target card in a graveyard from the game.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "2e2d15b4-ec05-59a1-ae4f-79f9aad359da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37db470-3aef-4fc4-98ce-63b5fb2546f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37db470-3aef-4fc4-98ce-63b5fb2546f6.jpg?1",
             "name": "Zombie Brute",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nTrample",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "6bdef813-2ded-5692-9e32-053b7aca9a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d6f7a6-7b6a-44f4-be04-7c02806b9f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d6f7a6-7b6a-44f4-be04-7c02806b9f09.jpg?1",
             "name": "Blade Sliver",
             "text": "All Slivers get +1/+0.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "a1808ac4-998c-522d-88cd-1b61f67079e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743779d4-fee8-4b8d-a5ac-27f355e006e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743779d4-fee8-4b8d-a5ac-27f355e006e5.jpg?1",
             "name": "Bloodstoke Howler",
             "text": "Morph {6}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Bloodstoke Howler is turned face up, Beasts you control get +3/+0 until end of turn.",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "6b73fc2b-3973-5e8e-a4a9-fdf45c8049e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c3f62-f275-46e1-8c26-c219683effb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c3f62-f275-46e1-8c26-c219683effb1.jpg?1",
             "name": "Clickslither",
             "text": "Haste\nSacrifice a Goblin: Clickslither gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "77ded0b9-2884-54db-b382-42179de0c1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadb40c8-3d54-4705-82dc-54e8d6e315d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadb40c8-3d54-4705-82dc-54e8d6e315d5.jpg?1",
             "name": "Crested Craghorn",
             "text": "Haste\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "9ab4fefb-f4fb-57c7-bad5-c4b94457136b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68534-2d9a-47e9-9d2a-cb6df4362aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68534-2d9a-47e9-9d2a-cb6df4362aa9.jpg?1",
             "name": "Flamewave Invoker",
             "text": "{7}{R}: Flamewave Invoker deals 5 damage to target player.",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "835baff3-9990-5137-910b-064f517e049c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6bc3c0-2d6e-4a09-84c4-b26a352186bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6bc3c0-2d6e-4a09-84c4-b26a352186bb.jpg?1",
             "name": "Frenetic Raptor",
             "text": "Beasts can't block.",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "d35f9114-8c85-545b-823a-fa25a5d8bae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2687c311-fd0c-4fe0-bce8-e3f412216796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2687c311-fd0c-4fe0-bce8-e3f412216796.jpg?1",
             "name": "Gempalm Incinerator",
             "text": "Cycling {1}{R} ({1}{R}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins in play.",
             "colours": [
@@ -3268,7 +3268,7 @@
         },
         {
             "id": "d4122d7e-ed59-5538-9257-52463fa805c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ec836f-6dcf-45f9-8e95-487762742a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ec836f-6dcf-45f9-8e95-487762742a1e.jpg?1",
             "name": "Goblin Assassin",
             "text": "Whenever Goblin Assassin or another Goblin comes into play, each player flips a coin. Each player whose coin comes up tails sacrifices a creature.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "a36c7ee2-ab86-51ef-b9d8-99cdb44a6075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c0cae-852c-444c-8994-68a6d81b4cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c0cae-852c-444c-8994-68a6d81b4cd4.jpg?1",
             "name": "Goblin Clearcutter",
             "text": "{T}, Sacrifice a forest: Add three mana in any combination of red and/or green to your mana pool.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "63bcb884-820d-545e-a457-5b50703ebe8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9462cb4e-a38c-4a41-bad2-4ea3b22b0edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9462cb4e-a38c-4a41-bad2-4ea3b22b0edb.jpg?1",
             "name": "Goblin Dynamo",
             "text": "{T}: Goblin Dynamo deals 1 damage to target creature or player.\n{X}{R}, {T}, Sacrifice Goblin Dynamo: Goblin Dynamo deals X damage to target creature or player.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "f0de9259-f2c4-5006-8816-442467e04bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2370d319-d1d2-4bca-9275-ff72fb400709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2370d319-d1d2-4bca-9275-ff72fb400709.jpg?1",
             "name": "Goblin Firebug",
             "text": "When Goblin Firebug leaves play, sacrifice a land.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "4fd98cde-ac72-5642-8f1a-c8ed16bfdd99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c77cac8-fe95-4925-a815-8c514cc41b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c77cac8-fe95-4925-a815-8c514cc41b22.jpg?1",
             "name": "Goblin Goon",
             "text": "Goblin Goon can't attack unless you control more creatures than defending player.\nGoblin Goon can't block unless you control more creatures than attacking player.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "99673d00-9c00-51cf-b6e3-3ec67ee76030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c948872-295c-41b9-8094-db7db7578b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c948872-295c-41b9-8094-db7db7578b0d.jpg?1",
             "name": "Goblin Grappler",
             "text": "Provoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "c92b123a-7f8a-51a5-9d4c-fa7957acaef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bbe84a-8857-467a-a4a1-e57086cc9501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bbe84a-8857-467a-a4a1-e57086cc9501.jpg?1",
             "name": "Goblin Lookout",
             "text": "{T}, Sacrifice a Goblin: All Goblins get +2/+0 until end of turn.",
             "colours": [
@@ -3510,7 +3510,7 @@
         },
         {
             "id": "61056a91-7fe0-5ae7-8304-cd1b75be50ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9aea1a-6f50-4f66-9f36-2e214dce41b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9aea1a-6f50-4f66-9f36-2e214dce41b4.jpg?1",
             "name": "Hunter Sliver",
             "text": "All Slivers have provoke. (When a Sliver attacks, its controller may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -3544,7 +3544,7 @@
         },
         {
             "id": "943a48ef-2055-5d6e-9a94-ee99f6627d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc3c5f3-f71b-4a1e-bd90-365d23889925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc3c5f3-f71b-4a1e-bd90-365d23889925.jpg?1",
             "name": "Imperial Hellkite",
             "text": "Flying\nMorph {6}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Imperial Hellkite is turned face up, you may search your library for a Dragon card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "0e445688-9fac-5a5f-aef6-a910a0d172bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe13c3-3c8b-4faa-bdd4-491039bfa82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe13c3-3c8b-4faa-bdd4-491039bfa82b.jpg?1",
             "name": "Kilnmouth Dragon",
             "text": "Amplify 3 (As this card comes into play, put three +1/+1 counters on it for each Dragon card you reveal in your hand.)\nFlying\n{T}: Kilnmouth Dragon deals damage equal to the number of +1/+1 counters on it to target creature or player.",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "84629309-151a-57f1-9eda-1ab4cd8b8982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc94fb-9e3f-4075-bb6a-8f04862dc585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc94fb-9e3f-4075-bb6a-8f04862dc585.jpg?1",
             "name": "Lavaborn Muse",
             "text": "At the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Lavaborn Muse deals 3 damage to him or her.",
             "colours": [
@@ -3646,7 +3646,7 @@
         },
         {
             "id": "e19f2099-717e-5910-ae33-10bfd85ad949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8451ab3f-5d61-4f35-ab70-5a5060caf53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8451ab3f-5d61-4f35-ab70-5a5060caf53d.jpg?1",
             "name": "Macetail Hystrodon",
             "text": "First strike, haste\nCycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3680,7 +3680,7 @@
         },
         {
             "id": "4f6b945d-e7a4-5ccf-81dd-30a8caf519c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091d908-456f-4127-857d-b22fdb4f2fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091d908-456f-4127-857d-b22fdb4f2fd9.jpg?1",
             "name": "Magma Sliver",
             "text": "All Slivers have \"{T}: Target Sliver gets +X/+0 until end of turn, where X is the number of Slivers in play.\"",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "dd404ecf-1ad2-5130-94b6-1c8ad1a760f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013cbc4-09f4-484f-b328-9f7403225149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013cbc4-09f4-484f-b328-9f7403225149.jpg?1",
             "name": "Ridgetop Raptor",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "fe8314d6-fcec-5394-8562-49c65711d160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6343c0-3fb5-4bac-bea7-cba36498cd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6343c0-3fb5-4bac-bea7-cba36498cd69.jpg?1",
             "name": "Rockshard Elemental",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nMorph {4}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "07fc0ee6-8f6d-51c4-8983-87e3e24d583d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42658b33-9a12-403b-bc7d-807fbe1f1a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42658b33-9a12-403b-bc7d-807fbe1f1a36.jpg?1",
             "name": "Shaleskin Plower",
             "text": "Morph {4}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Shaleskin Plower is turned face up, destroy target land.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "80345ec8-caef-54a8-b748-11f781a49916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c1d41-8666-4c1d-9498-0e259472958d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c1d41-8666-4c1d-9498-0e259472958d.jpg?1",
             "name": "Skirk Alarmist",
             "text": "Haste\n{T}: Turn target face-down creature you control face up. At end of turn, sacrifice it.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "928fdb7c-d1c2-5f41-ab9c-f389aedb0007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2d1a-4027-46d9-b780-bcac8d60ecdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2d1a-4027-46d9-b780-bcac8d60ecdb.jpg?1",
             "name": "Skirk Drill Sergeant",
             "text": "Whenever Skirk Drill Sergeant or another Goblin is put into a graveyard from play, you may pay {2}{R}. If you do, reveal the top card of your library. If it's a Goblin card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "2f5f5637-725a-5dfe-850d-dba261431406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd2ff12-c6f7-4986-801f-225ad6f59278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd2ff12-c6f7-4986-801f-225ad6f59278.jpg?1",
             "name": "Skirk Marauder",
             "text": "Morph {2}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Skirk Marauder is turned face up, it deals 2 damage to target creature or player.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "e31beb95-9126-5eb3-9c1a-6939d3e2950b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416de0f4-1540-4286-a1ac-4f57301c54e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416de0f4-1540-4286-a1ac-4f57301c54e9.jpg?1",
             "name": "Skirk Outrider",
             "text": "Skirk Outrider gets +2/+2 and has trample as long as you control a Beast.",
             "colours": [
@@ -3954,7 +3954,7 @@
         },
         {
             "id": "0eb9319b-6e9a-5e84-8ab7-c7bbc9175793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cfde2-42fa-4278-ae4e-7e4dd993cda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cfde2-42fa-4278-ae4e-7e4dd993cda8.jpg?1",
             "name": "Unstable Hulk",
             "text": "Morph {3}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Unstable Hulk is turned face up, it gets +6/+6 and gains trample until end of turn. You skip your next turn.",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "61f87fab-ac2e-5461-b092-f3e173020262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc942957-1067-428c-8ee1-01f9e260efe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc942957-1067-428c-8ee1-01f9e260efe1.jpg?1",
             "name": "Warbreak Trumpeter",
             "text": "Morph {X}{X}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Warbreak Trumpeter is turned face up, put X 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "c2c583b1-7e04-58e7-a297-98f64748221e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c4674-dd9f-4848-8447-721f842a0213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c4674-dd9f-4848-8447-721f842a0213.jpg?1",
             "name": "Berserk Murlodont",
             "text": "Whenever a Beast becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -4057,7 +4057,7 @@
         },
         {
             "id": "11f318e6-0da0-59fc-8dc4-c15597c03962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52118ff1-ad76-4b97-9fdc-6adfe80140f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52118ff1-ad76-4b97-9fdc-6adfe80140f8.jpg?1",
             "name": "Branchsnap Lorian",
             "text": "Trample\nMorph {G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4091,7 +4091,7 @@
         },
         {
             "id": "51ca5353-fca4-546c-be46-7ea3b0076015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a171f5e2-ed3d-4675-a4fc-953ebb907aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a171f5e2-ed3d-4675-a4fc-953ebb907aa0.jpg?1",
             "name": "Brontotherium",
             "text": "Trample\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "57c66987-de4e-5dca-8751-b7f651f049c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33803c12-1d78-49fe-a3a3-7f47c60a96b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33803c12-1d78-49fe-a3a3-7f47c60a96b6.jpg?1",
             "name": "Brood Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may put a 1/1 colorless Sliver creature token into play.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "ab6da8d9-b56b-5e5d-955c-136f59157f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a073459e-1f00-47e0-a1b3-d30203aa35d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a073459e-1f00-47e0-a1b3-d30203aa35d1.jpg?1",
             "name": "Caller of the Claw",
             "text": "You may play Caller of the Claw any time you could play an instant.\nWhen Caller of the Claw comes into play, put a 2/2 green Bear creature token into play for each nontoken creature put into your graveyard from play this turn.",
             "colours": [
@@ -4193,7 +4193,7 @@
         },
         {
             "id": "0b0efc90-f094-5a6f-b2ad-8ad842da6342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccdc9d7-71b5-4304-8d19-a63952e17a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccdc9d7-71b5-4304-8d19-a63952e17a6b.jpg?1",
             "name": "Canopy Crawler",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Beast card you reveal in your hand.)\n{T}: Target creature gets +1/+1 until end of turn for each +1/+1 counter on Canopy Crawler.",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "3f6f3eb7-d2d6-5dd2-afc5-87a66ed3a880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7a0b8f-6942-40b0-8efc-234ae77855b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7a0b8f-6942-40b0-8efc-234ae77855b4.jpg?1",
             "name": "Defiant Elf",
             "text": "Trample",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "12310578-7547-5e61-881d-be553a74ff25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2c8de5-bc80-4fad-af09-6d0a639f6e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2c8de5-bc80-4fad-af09-6d0a639f6e18.jpg?1",
             "name": "Elvish Soultiller",
             "text": "When Elvish Soultiller is put into a graveyard from play, choose a creature type. Shuffle all creature cards of that type from your graveyard into your library.",
             "colours": [
@@ -4296,7 +4296,7 @@
         },
         {
             "id": "634c9d56-a13f-5176-8f40-1ee0bd0f73c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebfb5a6-9052-47be-b931-834b5064df31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebfb5a6-9052-47be-b931-834b5064df31.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "d1ae017c-2312-52a5-bc8e-d4ed262ba9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e0c5e5-b293-419e-aac5-3b81af4b6498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e0c5e5-b293-419e-aac5-3b81af4b6498.jpg?1",
             "name": "Feral Throwback",
             "text": "Amplify 2 (As this card comes into play, put two +1/+1 counters on it for each Beast card you reveal in your hand.)\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "8f1d2c61-f191-5256-b1e5-71a5195ae1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d89f5-3e77-4dc0-935b-e6f6a3e968d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d89f5-3e77-4dc0-935b-e6f6a3e968d2.jpg?1",
             "name": "Gempalm Strider",
             "text": "Cycling {2}{G}{G} ({2}{G}{G}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Strider, all Elves get +2/+2 until end of turn.",
             "colours": [
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "98e6c52d-9fa9-5087-ac6b-7c48052550f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974b0881-bd26-4074-93dd-a1e3600347c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974b0881-bd26-4074-93dd-a1e3600347c4.jpg?1",
             "name": "Glowering Rogon",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Beast card you reveal in your hand.)",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "e5cc1438-666c-53ab-b84b-3a3248291b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525c356-88ca-4e2e-8f06-663be101e34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525c356-88ca-4e2e-8f06-663be101e34f.jpg?1",
             "name": "Hundroog",
             "text": "Cycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "d2680f13-b8b2-5078-9d9a-c18158eafd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ef4cda-e55b-45a8-9c02-4e77e5b15a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ef4cda-e55b-45a8-9c02-4e77e5b15a9e.jpg?1",
             "name": "Krosan Cloudscraper",
             "text": "At the beginning of your upkeep, sacrifice Krosan Cloudscraper unless you pay {G}{G}.\nMorph {7}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "8168b98b-0d78-5c87-a8c8-b32011d58e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d1c6c6-16b3-4a52-aeda-683b1aeb0e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d1c6c6-16b3-4a52-aeda-683b1aeb0e7f.jpg?1",
             "name": "Krosan Vorine",
             "text": "Provoke (When this attacks, you may have target creature defending player controls untap and block it if able.)\nKrosan Vorine can't be blocked by more than one creature.",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "c09f8235-9bd2-5a83-9399-369145573f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7474849-a6b4-4f3b-a836-37b88c26047b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7474849-a6b4-4f3b-a836-37b88c26047b.jpg?1",
             "name": "Nantuko Vigilante",
             "text": "Morph {1}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Nantuko Vigilante is turned face up, destroy target artifact or enchantment.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "3aabf95b-e31c-5a9e-a66d-c7d559d99d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b1628d-aacd-4e19-9ebb-bcd9b2842c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b1628d-aacd-4e19-9ebb-bcd9b2842c91.jpg?1",
             "name": "Needleshot Gourna",
             "text": "Needleshot Gourna may block as though it had flying.",
             "colours": [
@@ -4606,7 +4606,7 @@
         },
         {
             "id": "eba773f3-d908-59a4-b268-bb14f5dee69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a0810-3970-454f-8381-700d6c6aefdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a0810-3970-454f-8381-700d6c6aefdc.jpg?1",
             "name": "Patron of the Wild",
             "text": "Morph {2}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Patron of the Wild is turned face up, target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "f3275338-4cb9-5b79-8437-c8d69360d0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777432f-7965-4ad8-8d53-93919ae767d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777432f-7965-4ad8-8d53-93919ae767d4.jpg?1",
             "name": "Primal Whisperer",
             "text": "Primal Whisperer gets +2/+2 for each face-down creature in play.\nMorph {3}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "03122b07-59f6-5352-8a9e-0d5cb972e5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a60b2d-aeeb-4dbf-bf1a-20a274fe323f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a60b2d-aeeb-4dbf-bf1a-20a274fe323f.jpg?1",
             "name": "Quick Sliver",
             "text": "You may play Quick Sliver any time you could play an instant.\nAny player may play Sliver cards any time he or she could play an instant.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "67147a39-a02b-561d-9957-8e4053cbac75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf5a106-5fb7-40e4-82a7-db559302a923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf5a106-5fb7-40e4-82a7-db559302a923.jpg?1",
             "name": "Root Sliver",
             "text": "Root Sliver can't be countered.\nSliver spells can't be countered.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "7993e139-846b-52ae-9096-6ce8f256f782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13321-e429-4497-aef2-93a9df421d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13321-e429-4497-aef2-93a9df421d38.jpg?1",
             "name": "Seedborn Muse",
             "text": "Untap all permanents you control during each other player's untap step.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "90e39758-c6dc-5def-943a-b41a5e52f747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d0235d-7176-44a2-8e95-eb231f4af441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d0235d-7176-44a2-8e95-eb231f4af441.jpg?1",
             "name": "Stonewood Invoker",
             "text": "{7}{G}: Stonewood Invoker gets +5/+5 until end of turn.",
             "colours": [
@@ -4812,7 +4812,7 @@
         },
         {
             "id": "174d052d-a88b-5cdd-9004-a485a01dfd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045ae4ec-07f2-4098-a2d9-4bfcbd0273b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045ae4ec-07f2-4098-a2d9-4bfcbd0273b2.jpg?1",
             "name": "Timberwatch Elf",
             "text": "{T}: Target creature gets +X/+X until end of turn, where X is the number of Elves in play.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "df838e91-e28e-5c70-87ff-ef75456111e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12115b-2667-47f7-bd24-17c982a4f79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12115b-2667-47f7-bd24-17c982a4f79a.jpg?1",
             "name": "Totem Speaker",
             "text": "Whenever a Beast comes into play, you may gain 3 life.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "32a54d96-3a03-5625-992e-5a1b7478ea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104735d7-6cea-4d4a-8cc8-e1934883da97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104735d7-6cea-4d4a-8cc8-e1934883da97.jpg?1",
             "name": "Tribal Forcemage",
             "text": "Morph {1}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Tribal Forcemage is turned face up, creatures of the type of your choice get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "ecb1a118-5fca-5f8e-b6fb-306b44c32f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d599d35f-1b73-498b-9a21-831c908a95d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d599d35f-1b73-498b-9a21-831c908a95d8.jpg?1",
             "name": "Vexing Beetle",
             "text": "Vexing Beetle can't be countered.\nVexing Beetle gets +3/+3 as long as no opponent controls a creature.",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "139786eb-5640-58e2-9981-53301246748c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e5579e-dab7-49db-a141-a5bc5b5aee90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e5579e-dab7-49db-a141-a5bc5b5aee90.jpg?1",
             "name": "Wirewood Channeler",
             "text": "{T}: Add X mana of any one color to your mana pool, where X is the number of Elves in play.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "964d0b5d-3838-5a7d-b7f0-fc46bd24de0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55b4fc-366f-4906-9eaa-9085f6a22612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55b4fc-366f-4906-9eaa-9085f6a22612.jpg?1",
             "name": "Wirewood Hivemaster",
             "text": "Whenever another nontoken Elf comes into play, you may put a 1/1 green Insect creature token into play.",
             "colours": [

--- a/Assets/Resources/Sets/LRW.json
+++ b/Assets/Resources/Sets/LRW.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d712035d-7510-5298-8433-0e8e83460c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1470a6-d09d-4a2a-84a6-d56e32ed237a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1470a6-d09d-4a2a-84a6-d56e32ed237a.jpg?1",
             "name": "Ajani Goldmane",
             "text": "+1: You gain 2 life.\n-1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n-6: Put a white Avatar creature token into play with \"This creature's power and toughness are each equal to your life total.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "0b83cbf6-73bd-5186-a285-342e9e5160db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b598cf2-c327-422b-9527-1b28645ba70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b598cf2-c327-422b-9527-1b28645ba70c.jpg?1",
             "name": "Arbiter of Knollridge",
             "text": "Vigilance\nWhen Arbiter of Knollridge comes into play, each player's life total becomes the highest life total among all players.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "84c75b0c-b035-57c9-9f23-5606ae1b6b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee73fe8-d52b-43bb-ab91-5545192be676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee73fe8-d52b-43bb-ab91-5545192be676.jpg?1",
             "name": "Austere Command",
             "text": "Choose two Destroy all artifacts; or destroy all enchantments; or destroy all creatures with converted mana cost 3 or less; or destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "d87fd174-be97-5202-bd08-4d31eff4c2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2258bd3-e38b-4029-a9fb-f9ae86dbbc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2258bd3-e38b-4029-a9fb-f9ae86dbbc3a.jpg?1",
             "name": "Avian Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nFlying",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "c8e73f26-14dd-5518-895a-c41b5caf29a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e234ce-6d61-4d62-a8cd-fa985a6aba60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e234ce-6d61-4d62-a8cd-fa985a6aba60.jpg?1",
             "name": "Battle Mastery",
             "text": "Enchant creature\nEnchanted creature has double strike.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "4694d5a5-bc6f-543f-aeef-7eb3704f12a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg?1",
             "name": "Brigid, Hero of Kinsbaile",
             "text": "First strike\n{T}: Brigid, Hero of Kinsbaile deals 2 damage to each attacking or blocking creature target player controls.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "1064caa6-76e1-541e-a9ee-185fab7a7c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000c3e4-d71a-43c8-8ded-f3da54bc088d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000c3e4-d71a-43c8-8ded-f3da54bc088d.jpg?1",
             "name": "Burrenton Forge-Tender",
             "text": "Protection from red\nSacrifice Burrenton Forge-Tender: Prevent all damage a red source of your choice would deal this turn.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "70cdbd36-ec45-5271-84fc-8b4e3ebf1c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7610d2f-e35f-42fa-a3fb-fcae54bf5a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7610d2f-e35f-42fa-a3fb-fcae54bf5a1d.jpg?1",
             "name": "Cenn's Heir",
             "text": "Whenever Cenn's Heir attacks, it gets +1/+1 until end of turn for each other attacking Kithkin.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "d4316b40-e194-5b2a-8073-4cf09958be59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0c586-a1a5-4907-801a-7815c4dceb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0c586-a1a5-4907-801a-7815c4dceb39.jpg?1",
             "name": "Changeling Hero",
             "text": "Changeling (This card is every creature type at all times.)\nChampion a creature (When this comes into play, sacrifice it unless you remove another creature you control from the game. When this leaves play, that card returns to play.)\nLifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "bbdbfee9-845a-5127-9c00-feeede0536b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e344859-7248-4498-8303-252f196a007b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e344859-7248-4498-8303-252f196a007b.jpg?1",
             "name": "Cloudgoat Ranger",
             "text": "When Cloudgoat Ranger comes into play, put three 1/1 white Kithkin Soldier creature tokens into play.\nTap three untapped Kithkin you control: Cloudgoat Ranger gets +2/+0 and gains flying until end of turn.",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "c5b57141-fbae-56d4-8f04-7edeec9f48a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9044585-4d44-42fb-ad7b-e0e224fbc502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9044585-4d44-42fb-ad7b-e0e224fbc502.jpg?1",
             "name": "Crib Swap",
             "text": "Changeling (This card is every creature type at all times.)\nRemove target creature from the game. Its controller puts a 1/1 colorless Shapeshifter creature token with changeling into play.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "df35dbcc-d67a-5177-a9de-79403166bde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8968bc0-518f-4c41-bf00-2bf295065e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8968bc0-518f-4c41-bf00-2bf295065e33.jpg?1",
             "name": "Dawnfluke",
             "text": "Flash\nWhen Dawnfluke comes into play, prevent the next 3 damage that would be dealt to target creature or player this turn.\nEvoke {W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -421,7 +421,7 @@
         },
         {
             "id": "7d2a2d2e-4c45-5838-ba31-c9efd1acb360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1cec6f-5308-4bff-b19a-df9e3325bb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1cec6f-5308-4bff-b19a-df9e3325bb06.jpg?1",
             "name": "Entangling Trap",
             "text": "Whenever you clash, tap target creature an opponent controls. If you won, that creature doesn't untap during its controller's next untap step. (This ability triggers after the clash ends.)",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "9e2191b4-046f-5f89-8804-91d92d9692bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg?1",
             "name": "Favor of the Mighty",
             "text": "Each creature with the highest converted mana cost has protection from all colors.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "3eaa5fe9-cfdd-5473-bc94-3df0a5429780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8152999d-5e65-4ea6-b1e7-94b41808faa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8152999d-5e65-4ea6-b1e7-94b41808faa0.jpg?1",
             "name": "Galepowder Mage",
             "text": "Flying\nWhenever Galepowder Mage attacks, remove another target creature from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "a3a73eac-8a49-5447-acbe-474c02bcf77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5305b5c6-2af6-4b5c-9a57-0a2d2628e2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5305b5c6-2af6-4b5c-9a57-0a2d2628e2f4.jpg?1",
             "name": "Goldmeadow Dodger",
             "text": "Goldmeadow Dodger can't be blocked by creatures with power 4 or greater.",
             "colours": [
@@ -558,7 +558,7 @@
         },
         {
             "id": "28743c04-4365-542f-988f-6c03aee3c09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7508c-2815-40eb-92f7-3e66dfb28484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7508c-2815-40eb-92f7-3e66dfb28484.jpg?1",
             "name": "Goldmeadow Harrier",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -593,7 +593,7 @@
         },
         {
             "id": "eb7ce02e-149c-55d3-81fe-e915f12f1fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7a9110-6aea-460b-91fa-5f8a507160e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7a9110-6aea-460b-91fa-5f8a507160e7.jpg?1",
             "name": "Goldmeadow Stalwart",
             "text": "As an additional cost to play Goldmeadow Stalwart, reveal a Kithkin card from your hand or pay {3}.",
             "colours": [
@@ -628,7 +628,7 @@
         },
         {
             "id": "a6952215-551c-5fa2-86c0-5bac634329b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10ccaef-2a75-43d6-95f2-c3690ae5c87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10ccaef-2a75-43d6-95f2-c3690ae5c87a.jpg?1",
             "name": "Harpoon Sniper",
             "text": "{W}, {T}: Harpoon Sniper deals X damage to target attacking or blocking creature, where X is the number of Merfolk you control.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "fd9ae846-ca31-5d1f-9f54-36c55f6271f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a785a2-462d-4321-9e48-eb98698b7591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a785a2-462d-4321-9e48-eb98698b7591.jpg?1",
             "name": "Hillcomber Giant",
             "text": "Mountainwalk",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "fec8d20f-f53f-5af8-a983-4aaf3e6c035a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11187c6-f213-45db-9de3-314df1f43589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11187c6-f213-45db-9de3-314df1f43589.jpg?1",
             "name": "Hoofprints of the Stag",
             "text": "Whenever you draw a card, you may put a hoofprint counter on Hoofprints of the Stag.\n{2}{W}, Remove four hoofprint counters from Hoofprints of the Stag: Put a 4/4 white Elemental creature token with flying into play. Play this ability only during your turn.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "4816525a-5c61-57d4-b79b-be0d5c01e419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3073f3f5-bff8-4ec1-a68f-c83d63435843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3073f3f5-bff8-4ec1-a68f-c83d63435843.jpg?1",
             "name": "Judge of Currents",
             "text": "Whenever a Merfolk you control becomes tapped, you may gain 1 life.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "bfd4ee68-aab4-5075-93ae-bd994d53842f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6053c20-3632-43e2-8560-259d0c12f235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6053c20-3632-43e2-8560-259d0c12f235.jpg?1",
             "name": "Kinsbaile Balloonist",
             "text": "Flying\nWhenever Kinsbaile Balloonist attacks, you may have target creature gain flying until end of turn.",
             "colours": [
@@ -803,7 +803,7 @@
         },
         {
             "id": "fa4cf6f4-2502-50cd-9a68-6713dfb69300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6145bcd5-a583-4a04-9a13-a64ecdf4425a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6145bcd5-a583-4a04-9a13-a64ecdf4425a.jpg?1",
             "name": "Kinsbaile Skirmisher",
             "text": "When Kinsbaile Skirmisher comes into play, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -838,7 +838,7 @@
         },
         {
             "id": "ef24efc7-1bbd-59d8-999f-b666853ea4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75283b6-1b70-4e89-bf21-f85c21454aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75283b6-1b70-4e89-bf21-f85c21454aae.jpg?1",
             "name": "Kithkin Greatheart",
             "text": "As long as you control a Giant, Kithkin Greatheart gets +1/+1 and has first strike.",
             "colours": [
@@ -873,7 +873,7 @@
         },
         {
             "id": "7648eaed-6f6c-59d3-b8f7-10900759f482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64735178-3dc5-4a95-92fa-e15bd04e5733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64735178-3dc5-4a95-92fa-e15bd04e5733.jpg?1",
             "name": "Kithkin Harbinger",
             "text": "When Kithkin Harbinger comes into play, you may search your library for a Kithkin card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "d77fc601-7828-572a-8885-ad0dc49d9d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44032574-a5bc-4366-af65-9824fd4302a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44032574-a5bc-4366-af65-9824fd4302a2.jpg?1",
             "name": "Kithkin Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "3c92fb4e-8665-5a25-81ae-288f7f6084e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb33901-1f97-4080-a9dd-922ef29f42c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb33901-1f97-4080-a9dd-922ef29f42c9.jpg?1",
             "name": "Knight of Meadowgrain",
             "text": "First strike\nLifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "4b85ce47-5393-58ab-aaa3-725f97b1efa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ba1c8-b93a-4169-9ba0-d3fc5bf57676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ba1c8-b93a-4169-9ba0-d3fc5bf57676.jpg?1",
             "name": "Lairwatch Giant",
             "text": "Lairwatch Giant can block an additional creature.\nWhenever Lairwatch Giant blocks two or more creatures, it gains first strike until end of turn.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "bf19bbe8-f380-56c0-8455-c726a46ba4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg?1",
             "name": "Militia's Pride",
             "text": "Whenever a nontoken creature you control attacks, you may pay {W}. If you do, put a 1/1 white Kithkin Soldier creature token into play tapped and attacking.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "9359c573-7cc0-59d9-96a4-e9354919a6c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfff880-cbf6-4085-bc05-c72658b75f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfff880-cbf6-4085-bc05-c72658b75f25.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type at all times.)\n{X}: Creatures you control become X/X and gain all creature types until end of turn.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "defa2e4a-f5d1-50c5-bdcb-035ab19ba63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc326b79-363e-4c14-86e4-23041f2d6b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc326b79-363e-4c14-86e4-23041f2d6b4f.jpg?1",
             "name": "Neck Snap",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "7ab88704-f9e1-5bb6-b3d7-6ed06d83591c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fdb060-8f4d-453a-9516-92c390fbc85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fdb060-8f4d-453a-9516-92c390fbc85a.jpg?1",
             "name": "Oaken Brawler",
             "text": "When Oaken Brawler comes into play, clash with an opponent. If you win, put a +1/+1 counter on Oaken Brawler. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "e7bcad5c-8164-5338-8bdf-fbac006cbb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7fffe8-709c-4cb4-bbad-e4a0c35b616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7fffe8-709c-4cb4-bbad-e4a0c35b616a.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring comes into play, remove another target nonland permanent from the game.\nWhen Oblivion Ring leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "e05445a7-987a-5c3f-8616-9bfc27ab8859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2de26e-4cb3-4d7e-b884-54d6056dc9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2de26e-4cb3-4d7e-b884-54d6056dc9e9.jpg?1",
             "name": "Plover Knights",
             "text": "Flying, first strike",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "062fd783-14b0-5a04-b452-40d54e39a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2156a-8a77-4954-b557-1bdaf3ba171a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2156a-8a77-4954-b557-1bdaf3ba171a.jpg?1",
             "name": "Pollen Lullaby",
             "text": "Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win, creatures that player controls don't untap during the player's next untap step. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "f784396b-bcca-5f3d-815f-833b5dfac379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154a335d-188d-49c3-af6d-c8e702b4b3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154a335d-188d-49c3-af6d-c8e702b4b3ba.jpg?1",
             "name": "Purity",
             "text": "Flying\nIf a spell or ability would deal damage to you, prevent that damage. You gain life equal to the damage prevented this way.\nWhen Purity is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "8895a3c9-eed9-5a91-88be-cc0c224686ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab09d6d7-e2f0-4e78-a9a3-ac37f02f4096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab09d6d7-e2f0-4e78-a9a3-ac37f02f4096.jpg?1",
             "name": "Sentry Oak",
             "text": "Defender\nAt the beginning of combat on your turn, you may clash with an opponent. If you win, Sentry Oak gets +2/+0 and loses defender until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "4f41d0a1-c5f5-5066-9fd4-79b34aeb25d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f550f44f-8b8f-4c1d-a583-9fd986d3061c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f550f44f-8b8f-4c1d-a583-9fd986d3061c.jpg?1",
             "name": "Shields of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nCreatures target player controls get +0/+1 and gain all creature types until end of turn.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "ac9897cf-3025-5d26-bba8-4acb208266e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6c24b1-af9d-4a9c-9167-faa8a397a361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6c24b1-af9d-4a9c-9167-faa8a397a361.jpg?1",
             "name": "Soaring Hope",
             "text": "Enchant creature\nWhen Soaring Hope comes into play, you gain 3 life.\nEnchanted creature has flying.\n{W}: Put Soaring Hope on top of its owner's library.",
             "colours": [
@@ -1387,7 +1387,7 @@
         },
         {
             "id": "e465e08b-b77b-50fd-83ef-0899c06804bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa0c72-427b-4797-b5b1-15f07fc5fa07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa0c72-427b-4797-b5b1-15f07fc5fa07.jpg?1",
             "name": "Springjack Knight",
             "text": "Whenever Springjack Knight attacks, clash with an opponent. If you win, target creature gains double strike until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "c0b773d4-a88e-593c-a083-baa6d7ed6c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a4c124-216b-44b1-b49a-3db3f033e4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a4c124-216b-44b1-b49a-3db3f033e4cd.jpg?1",
             "name": "Summon the School",
             "text": "Put two 1/1 blue Merfolk Wizard creature tokens into play.\nTap four untapped Merfolk you control: Return Summon the School from your graveyard to your hand.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "1457ce13-1ea1-5c9d-9223-fd9e02be6435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b61fb2-11e5-45ae-873d-85f79f161950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b61fb2-11e5-45ae-873d-85f79f161950.jpg?1",
             "name": "Surge of Thoughtweft",
             "text": "Creatures you control get +1/+1 until end of turn. If you control a Kithkin, draw a card.",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "9c2135d7-f3aa-535f-9727-991e1c4e1948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg?1",
             "name": "Thoughtweft Trio",
             "text": "First strike, vigilance\nChampion a Kithkin (When this comes into play, sacrifice it unless you remove another Kithkin you control from the game. When this leaves play, that card returns to play.)\nThoughtweft Trio can block any number of creatures.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "78f4982d-f85c-5404-8ff1-ae71386a2be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b5d72-ac5b-43d2-b5dc-0cc4bf63e43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b5d72-ac5b-43d2-b5dc-0cc4bf63e43d.jpg?1",
             "name": "Triclopean Sight",
             "text": "Flash\nEnchant creature\nWhen Triclopean Sight comes into play, untap enchanted creature.\nEnchanted creature gets +1/+1 and has vigilance.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "6398fe9c-2688-59c1-b023-c7e94792d000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36fe821-e9b1-453d-8e44-f8dce111a6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36fe821-e9b1-453d-8e44-f8dce111a6de.jpg?1",
             "name": "Veteran of the Depths",
             "text": "Whenever Veteran of the Depths becomes tapped, you may put a +1/+1 counter on it.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "228357b1-305d-573d-bb8d-ac35ed7b78e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg?1",
             "name": "Wellgabber Apothecary",
             "text": "{1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "8c51ae85-2c32-5a93-b1ed-56eaea9cbda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56389c91-a470-4c43-9368-98df4d38f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56389c91-a470-4c43-9368-98df4d38f7fd.jpg?1",
             "name": "Wispmare",
             "text": "Flying\nWhen Wispmare comes into play, destroy target enchantment.\nEvoke {W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "1096034a-1b5a-516b-8af4-2fca450f2f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585f1c8e-6898-4def-8e3f-d45cd263f776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585f1c8e-6898-4def-8e3f-d45cd263f776.jpg?1",
             "name": "Wizened Cenn",
             "text": "Other Kithkin creatures you control get +1/+1.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "843a8237-161b-5940-a0ef-06cc4a30f9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44c623e-9ae1-495d-b72d-166f2ed4cf2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44c623e-9ae1-495d-b72d-166f2ed4cf2c.jpg?1",
             "name": "Aethersnipe",
             "text": "When \u00c6thersnipe comes into play, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1734,7 +1734,7 @@
         },
         {
             "id": "a8cecdb4-a4db-5083-90ae-ea93e06f73ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068518d2-f061-4061-b208-158e991156b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068518d2-f061-4061-b208-158e991156b6.jpg?1",
             "name": "Amoeboid Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{T}: Target creature gains all creature types until end of turn.\n{T}: Target creature loses all creature types until end of turn.",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "70999b8b-3d59-5a73-875e-64a5ab7b4b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd13d2c1-3db7-4fdc-9321-57c9d6e8c3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd13d2c1-3db7-4fdc-9321-57c9d6e8c3ae.jpg?1",
             "name": "Aquitect's Will",
             "text": "Put a flood counter on target land. That land is an Island in addition to its other types as long as it has a flood counter on it. If you control a Merfolk, draw a card.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "5082bf73-d9fc-51bd-9e50-0cda7273fe83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240d225-9fbf-438a-93c3-5fef325035e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240d225-9fbf-438a-93c3-5fef325035e8.jpg?1",
             "name": "Benthicore",
             "text": "When Benthicore comes into play, put two 1/1 blue Merfolk Wizard creature tokens into play.\nTap two untapped Merfolk you control: Untap Benthicore. It gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "289d778c-1508-5948-8eb3-b7561f938ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8052d90b-bc49-4a9e-9211-159a54aa2bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8052d90b-bc49-4a9e-9211-159a54aa2bcd.jpg?1",
             "name": "Broken Ambitions",
             "text": "Counter target spell unless its controller pays {X}. Clash with an opponent. If you win, that spell's controller puts the top four cards of his or her library into his or her graveyard. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "57a525f4-aa03-5d62-9371-2625e5abe5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642be353-a46a-4d14-a35a-7716fd552870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642be353-a46a-4d14-a35a-7716fd552870.jpg?1",
             "name": "Captivating Glance",
             "text": "Enchant creature\nAt the end of your turn, clash with an opponent. If you win, gain control of enchanted creature. Otherwise, that player gains control of enchanted creature. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "e6f027c2-fc8e-57b7-9070-3bded2d56144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829e3d6e-5d7c-4cc4-a7a6-7cbf5a7442ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829e3d6e-5d7c-4cc4-a7a6-7cbf5a7442ba.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two Counter target spell; or return target permanent to its owner's hand; or tap all creatures your opponents control; or draw a card.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "9ccbcc46-fee2-5fab-b39c-7f93609d84cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ebd6ff-2b1c-4e93-81cc-81998459c5c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ebd6ff-2b1c-4e93-81cc-81998459c5c7.jpg?1",
             "name": "Deeptread Merrow",
             "text": "{U}: Deeptread Merrow gains islandwalk until end of turn.",
             "colours": [
@@ -1970,7 +1970,7 @@
         },
         {
             "id": "ef65bf00-4d8b-5597-ae28-f6ab5be81b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149aa77e-fc10-4b9b-8f38-cc6db5be7b79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149aa77e-fc10-4b9b-8f38-cc6db5be7b79.jpg?1",
             "name": "Drowner of Secrets",
             "text": "Tap an untapped Merfolk you control: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "41a0767f-5881-5296-8a55-22f3c6afd338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f577831b-2aa2-44a1-bd6b-ef111bc2e211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f577831b-2aa2-44a1-bd6b-ef111bc2e211.jpg?1",
             "name": "Ego Erasure",
             "text": "Changeling (This card is every creature type at all times.)\nCreatures target player controls get -2/-0 and lose all creature types until end of turn.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "c71c907f-5c72-5023-bf27-f4231eae4c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fa774-fb6d-4a2f-96d5-a449a423312e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fa774-fb6d-4a2f-96d5-a449a423312e.jpg?1",
             "name": "Ethereal Whiskergill",
             "text": "Flying\nEthereal Whiskergill can't attack unless defending player controls an Island.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "b305a14b-3eed-59d1-97d6-345a231bd2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9bdc319-4e06-420b-ba54-6cb994d4e279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9bdc319-4e06-420b-ba54-6cb994d4e279.jpg?1",
             "name": "Faerie Harbinger",
             "text": "Flash\nFlying\nWhen Faerie Harbinger comes into play, you may search your library for a Faerie card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "d55e8047-dc13-5c35-88d8-5cd71823970c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defb9f0b-195e-4aeb-92c1-8f827ad6724b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defb9f0b-195e-4aeb-92c1-8f827ad6724b.jpg?1",
             "name": "Faerie Trickery",
             "text": "Counter target non-Faerie spell. If that spell is countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "fa30f14e-a55b-5ec1-a1d9-3ab07e8171f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4237352-4e0e-4f40-946b-2a61753674d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4237352-4e0e-4f40-946b-2a61753674d4.jpg?1",
             "name": "Fallowsage",
             "text": "Whenever Fallowsage becomes tapped, you may draw a card.",
             "colours": [
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "24af9461-ce43-5900-b229-146d93630b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9be91-f3a1-49ce-8a3e-2ecd30e2e692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9be91-f3a1-49ce-8a3e-2ecd30e2e692.jpg?1",
             "name": "Familiar's Ruse",
             "text": "As an additional cost to play Familiar's Ruse, return a creature you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "f9efdbe5-0ea6-518c-aaf7-fec4edd10e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg?1",
             "name": "Fathom Trawl",
             "text": "Reveal cards from the top of your library until you reveal three nonland cards. Put the nonland cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "4e3940fe-d7d5-589f-b9af-f96353056624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg?1",
             "name": "Forced Fruition",
             "text": "Whenever an opponent plays a spell, that player draws seven cards.",
             "colours": [
@@ -2275,7 +2275,7 @@
         },
         {
             "id": "1c5226f7-ae03-545f-b5d0-264ad2850af9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a71800f-3e67-4cfb-a3b1-8c073a91b909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a71800f-3e67-4cfb-a3b1-8c073a91b909.jpg?1",
             "name": "Glen Elendra Pranksters",
             "text": "Flying\nWhenever you play a spell during an opponent's turn, you may return target creature you control to its owner's hand.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "daafe653-0e32-544c-8796-10f08be61c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05a4ce4-dbd5-4c47-8b40-c145c7f5d06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05a4ce4-dbd5-4c47-8b40-c145c7f5d06c.jpg?1",
             "name": "Glimmerdust Nap",
             "text": "Enchant tapped creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "e1e1cc96-4a34-55f1-ae59-6327b2d82c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec6ab7-afbe-46ea-a7a6-6b678256f33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec6ab7-afbe-46ea-a7a6-6b678256f33e.jpg?1",
             "name": "Guile",
             "text": "Guile can't be blocked except by three or more creatures.\nIf a spell or ability you control would counter a spell, instead remove that spell from the game and you may play that card without paying its mana cost.\nWhen Guile is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "c24c28b9-ec54-567f-85be-ae0cfa3bdcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7ce6e-0d84-4d66-a1dd-26ddac73d47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7ce6e-0d84-4d66-a1dd-26ddac73d47b.jpg?1",
             "name": "Inkfathom Divers",
             "text": "Islandwalk\nWhen Inkfathom Divers comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "59554d01-b3a8-50be-9257-f0a47a74c6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdffb058-1af0-41bb-956a-ae10e092c389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdffb058-1af0-41bb-956a-ae10e092c389.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n-1: Target player draws a card.\n-10: Target player puts the top twenty cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "b19a81d2-c174-58f9-8794-9524697d48d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad0c3b4-fd24-44ad-8b30-4176f07be3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad0c3b4-fd24-44ad-8b30-4176f07be3d6.jpg?1",
             "name": "Merrow Commerce",
             "text": "At the end of your turn, untap all Merfolk you control.",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "9f632ee4-2fbd-5cc1-8169-a85afb5ac506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af11c-1090-4f0a-8eea-64a3b639e535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af11c-1090-4f0a-8eea-64a3b639e535.jpg?1",
             "name": "Merrow Harbinger",
             "text": "Islandwalk\nWhen Merrow Harbinger comes into play, you may search your library for a Merfolk card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "a5a515c8-36ce-5c9e-ac64-48aa90fb0747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57434d9-6fa5-43a6-98b9-044d2259d699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57434d9-6fa5-43a6-98b9-044d2259d699.jpg?1",
             "name": "Merrow Reejerey",
             "text": "Other Merfolk creatures you control get +1/+1.\nWhenever you play a Merfolk spell, you may tap or untap target permanent.",
             "colours": [
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "c420d3ad-3a65-5717-8a34-3c0a5a4a99cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg?1",
             "name": "Mistbind Clique",
             "text": "Flash\nFlying\nChampion a Faerie (When this comes into play, sacrifice it unless you remove another Faerie you control from the game. When this leaves play, that card returns to play.)\nWhen a Faerie is championed with Mistbind Clique, tap all lands target player controls.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "f7f20fb8-d1c9-5b6d-8757-f2409f9d072b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97cfefa-ade7-49f6-b2aa-1118b9db4935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97cfefa-ade7-49f6-b2aa-1118b9db4935.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter comes into play, draw two cards.\nEvoke {2}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "b332ec72-d1b2-55a0-811f-db52a1bc7b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a439c0ca-0cb2-4293-825e-1a72159953b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a439c0ca-0cb2-4293-825e-1a72159953b9.jpg?1",
             "name": "Paperfin Rascal",
             "text": "When Paperfin Rascal comes into play, clash with an opponent. If you win, put a +1/+1 counter on Paperfin Rascal. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "b17ec02b-0b99-572c-b0b0-67d1ee3966df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ae53-443c-4a27-b8f0-639a9a2b8598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ae53-443c-4a27-b8f0-639a9a2b8598.jpg?1",
             "name": "Pestermite",
             "text": "Flash\nFlying\nWhen Pestermite comes into play, you may tap or untap target permanent.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "9993fc86-2ca1-58b8-98cd-e64c50ad5e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6b6fc5-5077-4812-b8e9-906783dbaf67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6b6fc5-5077-4812-b8e9-906783dbaf67.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "94b62495-e5b8-5e30-8d84-eb445e572a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab1db58-66b6-4b92-9dcd-e044fa383469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab1db58-66b6-4b92-9dcd-e044fa383469.jpg?1",
             "name": "Protective Bubble",
             "text": "Enchant creature\nEnchanted creature is unblockable and has shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "5aaa0934-ed94-5b02-b01f-0fbad10ea468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d3ae1f-5442-4725-a16a-502f13359a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d3ae1f-5442-4725-a16a-502f13359a85.jpg?1",
             "name": "Ringskipper",
             "text": "Flying\nWhen Ringskipper is put into a graveyard from play, clash with an opponent. If you win, return Ringskipper to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "76cc8370-eee1-51cd-846e-4c6c15275ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c536c1ce-a012-4d77-ab29-8574be164731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c536c1ce-a012-4d77-ab29-8574be164731.jpg?1",
             "name": "Scattering Stroke",
             "text": "Counter target spell. Clash with an opponent. If you win, at the beginning of your next main phase, you may add {X} to your mana pool, where X is that spell's converted mana cost. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "53cd4bcd-2017-54fa-a472-5504368bfd65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75fc1eb-09ac-4800-a55d-c0e723f5786b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75fc1eb-09ac-4800-a55d-c0e723f5786b.jpg?1",
             "name": "Scion of Oona",
             "text": "Flash\nFlying\nOther Faerie creatures you control get +1/+1.\nOther Faeries you control have shroud. (A permanent with shroud can't be the target of spells or abilities.)",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "a1abe36e-7015-53c2-b9e6-2befb6d9b494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48daf7e-2f8e-4179-a145-a6b36dd11d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48daf7e-2f8e-4179-a145-a6b36dd11d44.jpg?1",
             "name": "Sentinels of Glen Elendra",
             "text": "Flash\nFlying",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "ed2a06c3-a3f5-5673-97a7-50d8f4198c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg?1",
             "name": "Shapesharer",
             "text": "Changeling (This card is every creature type at all times.)\n{2}{U}: Target Shapeshifter becomes a copy of target creature until your next turn.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "3b3df2f3-63cf-5b24-ba39-224f02554ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e07a38a-2d88-4b01-9634-f24cbc8d96d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e07a38a-2d88-4b01-9634-f24cbc8d96d6.jpg?1",
             "name": "Silvergill Adept",
             "text": "As an additional cost to play Silvergill Adept, reveal a Merfolk card from your hand or pay {3}.\nWhen Silvergill Adept comes into play, draw a card.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "809af707-0ad7-52cd-9498-7c637e277014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8875c883-8d56-406b-bd89-42199a6e79f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8875c883-8d56-406b-bd89-42199a6e79f5.jpg?1",
             "name": "Silvergill Douser",
             "text": "{T}: Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "67cf3648-4174-5cc9-a762-15b3ea31bb33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5320da-7214-4348-84d8-74bf951c9f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5320da-7214-4348-84d8-74bf951c9f2f.jpg?1",
             "name": "Sower of Temptation",
             "text": "Flying\nWhen Sower of Temptation comes into play, gain control of target creature as long as Sower of Temptation remains in play.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "021875f5-e4da-5807-aea6-9403c9336bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ba4a9-a282-4d4b-b25a-179e05e458f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ba4a9-a282-4d4b-b25a-179e05e458f4.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "Flash\nFlying\nWhen Spellstutter Sprite comes into play, counter target spell with converted mana cost X or less, where X is the number of Faeries you control.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "18d0575d-4f6c-5897-8935-ceae3cfceedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047709e7-c44f-47e4-a9cc-1d941264e454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047709e7-c44f-47e4-a9cc-1d941264e454.jpg?1",
             "name": "Stonybrook Angler",
             "text": "{1}{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "5e11de0d-fe85-514e-8e18-7a0117b09382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed908f4-630c-4f3c-9e61-4725b88b93ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed908f4-630c-4f3c-9e61-4725b88b93ff.jpg?1",
             "name": "Streambed Aquitects",
             "text": "{T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn.\n{T}: Target land becomes an Island until end of turn.",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "9b8c0013-5e7e-5d65-9f4a-b8463605ffca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5b00cb-ebc3-44e8-970d-724150eb7876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5b00cb-ebc3-44e8-970d-724150eb7876.jpg?1",
             "name": "Surgespanner",
             "text": "Whenever Surgespanner becomes tapped, you may pay {1}{U}. If you do, return target permanent to its owner's hand.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "8b7b3075-2ac8-5460-b6c3-83b07bba128a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e526ebbf-2041-4c3e-9a20-73bbf6f90251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e526ebbf-2041-4c3e-9a20-73bbf6f90251.jpg?1",
             "name": "Tideshaper Mystic",
             "text": "{T}: Target land becomes the basic land type of your choice until end of turn. Play this ability only during your turn.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "1e1df2e9-5e93-534b-880e-d07ac43ff1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b078e-e324-4775-9d38-08943017a48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b078e-e324-4775-9d38-08943017a48e.jpg?1",
             "name": "Turtleshell Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{U}: Switch Turtleshell Changeling's power and toughness until end of turn.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "bca9e94e-dd9b-59e1-88e7-ebbb1bde09a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg?1",
             "name": "Wanderwine Prophets",
             "text": "Champion a Merfolk (When this comes into play, sacrifice it unless you remove another Merfolk you control from the game. When this leaves play, that card returns to play.)\nWhenever Wanderwine Prophets deals combat damage to a player, you may sacrifice a Merfolk. If you do, take an extra turn after this one.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "2c82c07a-5b12-5d52-888c-92266918a403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1934c34a-c163-4fac-a80d-8b17e8d64efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1934c34a-c163-4fac-a80d-8b17e8d64efa.jpg?1",
             "name": "Whirlpool Whelm",
             "text": "Clash with an opponent, then return target creature to its owner's hand. If you win, you may put that creature on top of its owner's library instead. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3312,7 +3312,7 @@
         },
         {
             "id": "860e56e2-c33f-52c7-93e1-764130b23690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3c1f39-b6ac-4663-9623-bd573a1117b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3c1f39-b6ac-4663-9623-bd573a1117b0.jpg?1",
             "name": "Wings of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nTarget creature becomes 4/4, gains all creature types, and gains flying until end of turn.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "df3778ca-c634-5d56-a75a-6606a298703b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8996-388f-4704-a4c8-ef99d4701805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8996-388f-4704-a4c8-ef99d4701805.jpg?1",
             "name": "Zephyr Net",
             "text": "Enchant creature\nEnchanted creature has defender and flying.",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "ec6d12d6-3c02-5784-99a1-26c702fe0a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a1fc03-5719-49ed-9d53-d8ea5693373e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a1fc03-5719-49ed-9d53-d8ea5693373e.jpg?1",
             "name": "Black Poplar Shaman",
             "text": "{2}{B}: Regenerate target Treefolk.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "02d7b486-f029-5ac8-99dc-a40b1dee459c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2459953-a4b5-4a9c-85ed-928b684d7240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2459953-a4b5-4a9c-85ed-928b684d7240.jpg?1",
             "name": "Bog Hoodlums",
             "text": "Bog Hoodlums can't block.\nWhen Bog Hoodlums comes into play, clash with an opponent. If you win, put a +1/+1 counter on Bog Hoodlums. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "824901ed-9593-528d-adf7-f295d48d8b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb4916d-ab50-45c9-bf7e-e7a7e761aef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb4916d-ab50-45c9-bf7e-e7a7e761aef4.jpg?1",
             "name": "Boggart Birth Rite",
             "text": "Return target Goblin card from your graveyard to your hand.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "9b73cc2d-2e57-5f05-b365-76ccb881141c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea8d2b8-bcac-410d-aa5a-e4a74f7d5315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea8d2b8-bcac-410d-aa5a-e4a74f7d5315.jpg?1",
             "name": "Boggart Harbinger",
             "text": "When Boggart Harbinger comes into play, you may search your library for a Goblin card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "7688a486-23c2-51a2-8757-cd103553a4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed9a638-c3f9-48dd-9633-5c52146e0dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed9a638-c3f9-48dd-9633-5c52146e0dcd.jpg?1",
             "name": "Boggart Loggers",
             "text": "Forestwalk\n{2}{B}, Sacrifice Boggart Loggers: Destroy target Treefolk or Forest.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "87f6b8e9-061c-51bd-a15c-548b283533c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg?1",
             "name": "Boggart Mob",
             "text": "Champion a Goblin (When this comes into play, sacrifice it unless you remove another Goblin you control from the game. When this leaves play, that card returns to play.)\nWhenever a Goblin you control deals combat damage to a player, you may put a 1/1 black Goblin Rogue creature token into play.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "b65d054b-4ee7-59c7-9196-cf1d3663574a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b870a7aa-0836-4e3e-8be9-3299bdaded81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b870a7aa-0836-4e3e-8be9-3299bdaded81.jpg?1",
             "name": "Cairn Wanderer",
             "text": "Changeling (This card is every creature type at all times.)\nAs long as a creature card with flying is in a graveyard, Cairn Wanderer has flying. The same is true for fear, first strike, double strike, deathtouch, haste, landwalk, lifelink, protection, reach, trample, shroud, and vigilance.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "32f34f06-c4b2-5059-8667-41f7829e6558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg?1",
             "name": "Colfenor's Plans",
             "text": "When Colfenor's Plans comes into play, remove the top seven cards of your library from the game face down.\nYou may look at and play cards removed from the game with Colfenor's Plans.\nSkip your draw step.\nYou can't play more than one spell each turn.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "95ccf54f-275a-546b-affc-6f4b81e9e30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg?1",
             "name": "Dread",
             "text": "Fear\nWhenever a creature deals damage to you, destroy it.\nWhen Dread is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "6961c7b9-f5c3-53cc-9a9b-5b7fdaf07796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5c2487-5da0-4d9a-beb2-598feeb068a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5c2487-5da0-4d9a-beb2-598feeb068a1.jpg?1",
             "name": "Dreamspoiler Witches",
             "text": "Flying\nWhenever you play a spell during an opponent's turn, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "db70e6d9-f309-57bf-87e0-cbab571be038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe41509-02db-415c-964e-971ea1d5485c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe41509-02db-415c-964e-971ea1d5485c.jpg?1",
             "name": "Exiled Boggart",
             "text": "When Exiled Boggart is put into a graveyard from play, discard a card.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "15d5d12d-25be-5044-95b6-821f6040f3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c08701-7038-4d6b-bbf8-056fd8ffb226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c08701-7038-4d6b-bbf8-056fd8ffb226.jpg?1",
             "name": "Eyeblight's Ending",
             "text": "Destroy target non-Elf creature.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "b1dd00c8-e970-51be-8fac-516868c751b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc973d3-39cf-4d0c-a3e9-70af2be3cd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc973d3-39cf-4d0c-a3e9-70af2be3cd68.jpg?1",
             "name": "Facevaulter",
             "text": "{B}, Sacrifice a Goblin: Facevaulter gets +2/+2 until end of turn.",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "6dd6b5d2-f16e-5a52-bb9b-39bc16b93b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33727782-dafd-4a7c-96dd-6ffaf667cc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33727782-dafd-4a7c-96dd-6ffaf667cc6b.jpg?1",
             "name": "Faerie Tauntings",
             "text": "Whenever you play a spell during an opponent's turn, you may have each opponent lose 1 life.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "d9239199-edea-5c60-9369-adf479c4551e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f3744a-71c4-4a54-9e1c-92420526b792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f3744a-71c4-4a54-9e1c-92420526b792.jpg?1",
             "name": "Final Revels",
             "text": "Choose one All creatures get +2/+0 until end of turn; or all creatures get -0/-2 until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "a6db408d-712e-5e8e-b3db-6c1359abf7b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000670f-1151-4abf-a7ec-b35a6e587183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000670f-1151-4abf-a7ec-b35a6e587183.jpg?1",
             "name": "Fodder Launch",
             "text": "As an additional cost to play Fodder Launch, sacrifice a Goblin.\nTarget creature gets -5/-5 until end of turn. Fodder Launch deals 5 damage to that creature's controller.",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "3b7f5ba7-1a5d-5ccb-ab0c-52e8d3169811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc04f820-9505-4ccd-98e7-1bb861161af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc04f820-9505-4ccd-98e7-1bb861161af5.jpg?1",
             "name": "Footbottom Feast",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "a8eb1bd7-913e-59b6-a11a-49e87be9a47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7218726-dfa2-4d13-a210-5d54024e2d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7218726-dfa2-4d13-a210-5d54024e2d27.jpg?1",
             "name": "Ghostly Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{B}: Ghostly Changeling gets +1/+1 until end of turn.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "327e27d3-0880-58f4-a29f-90f0c5acd34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666a328-cc51-4be1-abef-06bbe41dd866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666a328-cc51-4be1-abef-06bbe41dd866.jpg?1",
             "name": "Hoarder's Greed",
             "text": "You lose 2 life and draw two cards, then clash with an opponent. If you win, repeat this process. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "30329e3c-cd61-5aea-93b3-73c7cd5437be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45598727-a8b1-4b3e-87c6-70c36f0d4fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45598727-a8b1-4b3e-87c6-70c36f0d4fe8.jpg?1",
             "name": "Hornet Harasser",
             "text": "When Hornet Harasser is put into a graveyard from play, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "6b8f6fdb-53a1-5395-bf6f-5734ebb38cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5b8db-4a56-45bd-9704-a1316016ec5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5b8db-4a56-45bd-9704-a1316016ec5b.jpg?1",
             "name": "Hunter of Eyeblights",
             "text": "When Hunter of Eyeblights comes into play, put a +1/+1 counter on target creature you don't control.\n{2}{B}, {T}: Destroy target creature with a counter on it.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "ea801f2c-b1a9-59b5-a28e-1cf5978b21c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg?1",
             "name": "Knucklebone Witch",
             "text": "Whenever a Goblin you control is put into a graveyard from play, you may put a +1/+1 counter on Knucklebone Witch.",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "a328988f-dd91-5855-9213-3c9bc106a431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1662fcb1-f142-43ff-b682-6827dea2ff7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1662fcb1-f142-43ff-b682-6827dea2ff7e.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n-2: Search your library for a card, then shuffle your library and put that card on top of it.\n-8: Put all creature cards in all graveyards into play under your control.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "acab84b4-cbd8-5807-ae5e-a6f72e75a123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7614e3e7-708f-4717-b798-97f0c391a673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7614e3e7-708f-4717-b798-97f0c391a673.jpg?1",
             "name": "Lys Alana Scarblade",
             "text": "{T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control.",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "84caad14-f852-5463-8242-5b960373ae4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b1655b-ab0a-40d9-8d4d-55d13310ede1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b1655b-ab0a-40d9-8d4d-55d13310ede1.jpg?1",
             "name": "Mad Auntie",
             "text": "Other Goblin creatures you control get +1/+1.\n{T}: Regenerate another target Goblin.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "c7364e04-e120-5908-9d61-f3ea86fa36cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79029161-a2c9-4cf6-94c0-31400daa0e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79029161-a2c9-4cf6-94c0-31400daa0e8e.jpg?1",
             "name": "Makeshift Mannequin",
             "text": "Return target creature card from your graveyard to play with a mannequin counter on it. As long as that creature has a mannequin counter on it, it has \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "3bbd7b6b-b9a6-56d3-8f21-c01a295481f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040e1039-1943-4c2d-aa98-b7f9519de321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040e1039-1943-4c2d-aa98-b7f9519de321.jpg?1",
             "name": "Marsh Flitter",
             "text": "Flying\nWhen Marsh Flitter comes into play, put two 1/1 black Goblin Rogue creature tokens into play.\nSacrifice a Goblin: Marsh Flitter becomes 3/3 until end of turn.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "4084fa60-05ee-5a72-97d7-a163fc4a3848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effb7761-98a8-4cb8-883a-ddcb91d30c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effb7761-98a8-4cb8-883a-ddcb91d30c08.jpg?1",
             "name": "Moonglove Winnower",
             "text": "Deathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "8363719d-769c-535d-bfc0-ce37fd5c18fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a62a282-5f94-444b-9095-4c36fabdad57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a62a282-5f94-444b-9095-4c36fabdad57.jpg?1",
             "name": "Mournwhelk",
             "text": "When Mournwhelk comes into play, target player discards two cards.\nEvoke {3}{B} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "a8806d15-3b45-50c1-a1c2-3f19705c8a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4e4d2-2358-48d2-9a2a-3d17afea28f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4e4d2-2358-48d2-9a2a-3d17afea28f5.jpg?1",
             "name": "Nameless Inversion",
             "text": "Changeling (This card is every creature type at all times.)\nTarget creature gets +3/-3 and loses all creature types until end of turn.",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "a3445c8f-6449-544d-9e88-e73514cb03a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f077d2-34ab-45fa-84db-eb408c5a9996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f077d2-34ab-45fa-84db-eb408c5a9996.jpg?1",
             "name": "Nath's Buffoon",
             "text": "Protection from Elves",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "c6c86b94-09b5-5725-b382-d419a9d6512c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d943b877-805d-4bc8-a3ae-abec00fa51a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d943b877-805d-4bc8-a3ae-abec00fa51a6.jpg?1",
             "name": "Nectar Faerie",
             "text": "Flying\n{B}, {T}: Target Faerie or Elf gains lifelink until end of turn. (Whenever it deals damage, its controller gains that much life.)",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "c275e4cb-4eca-5442-909e-44efd10dd8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg?1",
             "name": "Nettlevine Blight",
             "text": "Enchant creature or land\nEnchanted permanent has \"At the end of your turn, sacrifice this permanent and attach Nettlevine Blight to a creature or land you control.\"",
             "colours": [
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "4bf50a90-b38e-527f-8251-dae35822ed87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa341824-bf3a-49ce-a8a0-ee53f537d626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa341824-bf3a-49ce-a8a0-ee53f537d626.jpg?1",
             "name": "Nightshade Stinger",
             "text": "Flying\nNightshade Stinger can't block.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "48edfe39-f25b-5d87-a12f-32eba761ee63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9675b8ea-47f9-440e-9535-de879da53f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9675b8ea-47f9-440e-9535-de879da53f76.jpg?1",
             "name": "Oona's Prowler",
             "text": "Flying\nDiscard a card: Oona's Prowler gets -2/-0 until end of turn. Any player may play this ability.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "f5652c93-dce6-57c3-a297-90c10d4ae9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568586ca-8a02-4a77-bd65-c0b4a74c429d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568586ca-8a02-4a77-bd65-c0b4a74c429d.jpg?1",
             "name": "Peppersmoke",
             "text": "Target creature gets -1/-1 until end of turn. If you control a Faerie, draw a card.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "c41c6e2c-c5ce-5573-9b0a-4c1a9b3c60a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf7fd-c49e-42fa-bbdd-8ca5d4c89b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf7fd-c49e-42fa-bbdd-8ca5d4c89b2b.jpg?1",
             "name": "Profane Command",
             "text": "Choose two Target player loses X life; or return target creature card with converted mana cost X or less from your graveyard to play; or target creature gets -X/-X until end of turn; or up to X target creatures gain fear until end of turn.",
             "colours": [
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "853dbcd9-9eb3-5dd6-869a-c7f8ab017e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099badba-1c8a-4a74-80e9-133f2bafb94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099badba-1c8a-4a74-80e9-133f2bafb94d.jpg?1",
             "name": "Prowess of the Fair",
             "text": "Whenever another nontoken Elf is put into your graveyard from play, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -4690,7 +4690,7 @@
         },
         {
             "id": "74fafc88-d68b-54f5-97fe-6d2dc18e6300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a15a9d-46d7-4181-8131-50ba46a11c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a15a9d-46d7-4181-8131-50ba46a11c7b.jpg?1",
             "name": "Quill-Slinger Boggart",
             "text": "Whenever a player plays a Kithkin spell, you may have target player lose 1 life.",
             "colours": [
@@ -4725,7 +4725,7 @@
         },
         {
             "id": "061fe681-9068-56f9-ba21-5c5f67ef30f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60c51c2-3a24-4376-850c-cebd4d75adca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60c51c2-3a24-4376-850c-cebd4d75adca.jpg?1",
             "name": "Scarred Vinebreeder",
             "text": "{2}{B}, Remove an Elf card in your graveyard from the game: Scarred Vinebreeder gets +3/+3 until end of turn.",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "4afff67e-8e8f-5bc6-9af1-796919d27990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea19eb5e-0d70-42e6-bda2-b13757e08ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea19eb5e-0d70-42e6-bda2-b13757e08ca6.jpg?1",
             "name": "Shriekmaw",
             "text": "Fear\nWhen Shriekmaw comes into play, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "47995907-16ac-5a93-bc73-f7af8eb0b9e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1d8e26-304b-4571-9b33-7713265d9bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1d8e26-304b-4571-9b33-7713265d9bbf.jpg?1",
             "name": "Skeletal Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{B}: Regenerate Skeletal Changeling.",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "22027565-643e-5d07-b30f-6c7a4eb61edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e77c10-b569-485f-ba3e-16ef0c57dd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e77c10-b569-485f-ba3e-16ef0c57dd81.jpg?1",
             "name": "Spiderwig Boggart",
             "text": "When Spiderwig Boggart comes into play, target creature gains fear until end of turn.",
             "colours": [
@@ -4863,7 +4863,7 @@
         },
         {
             "id": "8d145e52-0bf1-5fe5-bff4-9f4adf068508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7184715-3ed3-4f56-9bf3-ff431cca86be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7184715-3ed3-4f56-9bf3-ff431cca86be.jpg?1",
             "name": "Squeaking Pie Sneak",
             "text": "As an additional cost to play Squeaking Pie Sneak, reveal a Goblin card from your hand or pay {3}.\nFear",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "4ac0ff5b-3eb5-5746-9611-b0587b1fa537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5b51c3-60a8-45b2-9de0-605388091e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5b51c3-60a8-45b2-9de0-605388091e8a.jpg?1",
             "name": "Thieving Sprite",
             "text": "Flying\nWhen Thieving Sprite comes into play, target player reveals X cards from his or her hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "186fe99a-d71e-5141-9211-5098f0123964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140265a2-61c3-4731-989c-9d55c27400ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140265a2-61c3-4731-989c-9d55c27400ec.jpg?1",
             "name": "Thorntooth Witch",
             "text": "Whenever you play a Treefolk spell, you may have target creature get +3/-3 until end of turn.",
             "colours": [
@@ -4968,7 +4968,7 @@
         },
         {
             "id": "fb23c3c4-7059-5442-b195-6611a593cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df8c148-e87d-4043-9d8b-ec72bf8b6d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df8c148-e87d-4043-9d8b-ec72bf8b6d5d.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "8c14cddd-2a0a-574f-ad8e-0ee400f18722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc98177b-34a6-44e1-9abd-6fd8df09fc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc98177b-34a6-44e1-9abd-6fd8df09fc70.jpg?1",
             "name": "Warren Pilferers",
             "text": "When Warren Pilferers comes into play, return target creature card from your graveyard to your hand. If that card is a Goblin card, Warren Pilferers gains haste until end of turn.",
             "colours": [
@@ -5035,7 +5035,7 @@
         },
         {
             "id": "07276404-49cd-5185-b0f6-1d9759685e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f7fb79-19a8-483a-bf91-e687f7da4e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f7fb79-19a8-483a-bf91-e687f7da4e9c.jpg?1",
             "name": "Weed Strangle",
             "text": "Destroy target creature. Clash with an opponent. If you win, you gain life equal to that creature's toughness. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "0d774eda-c985-57eb-9f41-e35c81b802b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116839f-6a3a-4a2e-a3ab-ea177c012746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116839f-6a3a-4a2e-a3ab-ea177c012746.jpg?1",
             "name": "Adder-Staff Boggart",
             "text": "When Adder-Staff Boggart comes into play, clash with an opponent. If you win, put a +1/+1 counter on Adder-Staff Boggart. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -5102,7 +5102,7 @@
         },
         {
             "id": "d6914b7f-6b4b-5164-9c39-8e068dfde1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056eb9-4257-4530-8ff4-6909a2cedf47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056eb9-4257-4530-8ff4-6909a2cedf47.jpg?1",
             "name": "Ashling the Pilgrim",
             "text": "{1}{R}: Put a +1/+1 counter on Ashling the Pilgrim. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling the Pilgrim, and it deals that much damage to each creature and each player.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "de596bca-1ff5-58b4-b14a-8ba122dd5446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg?1",
             "name": "Ashling's Prerogative",
             "text": "As Ashling's Prerogative comes into play, choose odd or even. (Zero is even.)\nEach creature with converted mana cost of the chosen value has haste.\nEach creature without converted mana cost of the chosen value comes into play tapped.",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "48cb95c3-f6b0-5c6f-9fb7-ff982f01d4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8595e9a1-010e-48a7-91e4-3d2722c8dbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8595e9a1-010e-48a7-91e4-3d2722c8dbc0.jpg?1",
             "name": "Axegrinder Giant",
             "text": "",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "8fc25ba5-320d-51b0-8178-d6b10dbd2c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac629-a8c9-4b84-a8ea-b775d7913238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac629-a8c9-4b84-a8ea-b775d7913238.jpg?1",
             "name": "Blades of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nUp to two target creatures each get +2/+0 and gain all creature types until end of turn.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "53582834-2c7e-5879-9dd5-36d5f02b003a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75aaca31-8ed5-4e8a-8332-1cca77903f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75aaca31-8ed5-4e8a-8332-1cca77903f88.jpg?1",
             "name": "Blind-Spot Giant",
             "text": "Blind-Spot Giant can't attack or block unless you control another Giant.",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "67d6dc5e-6828-5ace-9139-8fc0ba4f8a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc26374-d8de-4740-b1ec-ac92cfedbebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc26374-d8de-4740-b1ec-ac92cfedbebc.jpg?1",
             "name": "Boggart Forager",
             "text": "{R}, Sacrifice Boggart Forager: Target player shuffles his or her library.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "7e892daf-230e-5b43-a923-c8e3a70da7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3c0ea9-270d-4738-9462-7f48fecb4bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3c0ea9-270d-4738-9462-7f48fecb4bf4.jpg?1",
             "name": "Boggart Shenanigans",
             "text": "Whenever another Goblin you control is put into a graveyard from play, you may have Boggart Shenanigans deal 1 damage to target player.",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "a7a2379d-b10e-5b05-bbfa-fde1a29f1efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6341b73b-a035-45a2-908d-879c8eed4bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6341b73b-a035-45a2-908d-879c8eed4bbd.jpg?1",
             "name": "Boggart Sprite-Chaser",
             "text": "As long as you control a Faerie, Boggart Sprite-Chaser gets +1/+1 and has flying.",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "df5f934b-ce05-540a-aeb7-6b707a02658b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8337bf-9fe8-45a0-974c-8911306b19ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8337bf-9fe8-45a0-974c-8911306b19ea.jpg?1",
             "name": "Caterwauling Boggart",
             "text": "Each Goblin you control can't be blocked except by two or more creatures.\nEach Elemental you control can't be blocked except by two or more creatures.",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "04d2a65d-8ab3-5bec-b3f3-9bf84d34bb76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e103a3-555c-4b68-9768-42637bfd2478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e103a3-555c-4b68-9768-42637bfd2478.jpg?1",
             "name": "Ceaseless Searblades",
             "text": "Whenever you play an activated ability of an Elemental, Ceaseless Searblades gets +1/+0 until end of turn.",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "bdc84b1f-fcc3-5320-9988-2225c6d5c046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317e7ab7-7639-4877-aae2-3746563f2ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317e7ab7-7639-4877-aae2-3746563f2ec9.jpg?1",
             "name": "Chandra Nalaar",
             "text": "+1: Chandra Nalaar deals 1 damage to target player.\n-X: Chandra Nalaar deals X damage to target creature.\n-8: Chandra Nalaar deals 10 damage to target player and each creature he or she controls.",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "125eeb55-4f0b-5ec0-9f8d-12ee9ade6e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2e8f24-2ee1-4516-bf60-7fe6a0c4baec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2e8f24-2ee1-4516-bf60-7fe6a0c4baec.jpg?1",
             "name": "Changeling Berserker",
             "text": "Changeling (This card is every creature type at all times.)\nHaste\nChampion a creature (When this comes into play, sacrifice it unless you remove another creature you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "bc6ec1ad-3a02-5fab-b73b-56cc531a269c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a4ec08-5029-4f7b-a93b-a5dad4be5113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a4ec08-5029-4f7b-a93b-a5dad4be5113.jpg?1",
             "name": "Consuming Bonfire",
             "text": "Choose one Consuming Bonfire deals 4 damage to target non-Elemental creature; or Consuming Bonfire deals 7 damage to target Treefolk creature.",
             "colours": [
@@ -5556,7 +5556,7 @@
         },
         {
             "id": "9e7f8940-4ec8-5c9a-a9e1-0195be5f5c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0386925-53bc-4902-ac30-cbdcb099936d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0386925-53bc-4902-ac30-cbdcb099936d.jpg?1",
             "name": "Crush Underfoot",
             "text": "Choose a Giant creature you control. It deals damage equal to its power to target creature.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "21783532-942c-50ad-acca-2fdfc7dbe04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88b32a-986c-4317-b4a3-119f67e13b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88b32a-986c-4317-b4a3-119f67e13b83.jpg?1",
             "name": "Faultgrinder",
             "text": "Trample\nWhen Faultgrinder comes into play, destroy target land.\nEvoke {4}{R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "996cccb8-9484-5ad2-a1d2-54994c6f68f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4732342-71a4-4079-b549-f4454945273a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4732342-71a4-4079-b549-f4454945273a.jpg?1",
             "name": "Fire-Belly Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{R}: Fire-Belly Changeling gets +1/+0 until end of turn. Play this ability no more than twice each turn.",
             "colours": [
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "419008ea-4561-5fca-a024-719925bd6fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ea1c8-ca58-4240-adb7-71cd49664414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ea1c8-ca58-4240-adb7-71cd49664414.jpg?1",
             "name": "Flamekin Bladewhirl",
             "text": "As an additional cost to play Flamekin Bladewhirl, reveal an Elemental card from your hand or pay {3}.",
             "colours": [
@@ -5694,7 +5694,7 @@
         },
         {
             "id": "79a77f55-165a-5746-8b8f-4a73dca55de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301abe8f-916a-4e5b-bf25-f1e12ae9cee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301abe8f-916a-4e5b-bf25-f1e12ae9cee2.jpg?1",
             "name": "Flamekin Brawler",
             "text": "{R}: Flamekin Brawler gets +1/+0 until end of turn.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "f9e4c83d-7397-5d00-9458-25c4f611ab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f330c0f4-13d2-4432-9ced-f044bef98ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f330c0f4-13d2-4432-9ced-f044bef98ec8.jpg?1",
             "name": "Flamekin Harbinger",
             "text": "When Flamekin Harbinger comes into play, you may search your library for an Elemental card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -5764,7 +5764,7 @@
         },
         {
             "id": "6d026b77-b25d-5f41-ab2b-2f3bce48d427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7878e5-fcb0-4de5-8dda-fcdb4b138ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7878e5-fcb0-4de5-8dda-fcdb4b138ec1.jpg?1",
             "name": "Flamekin Spitfire",
             "text": "{3}{R}: Flamekin Spitfire deals 1 damage to target creature or player.",
             "colours": [
@@ -5799,7 +5799,7 @@
         },
         {
             "id": "eae0738e-4677-5f6a-b1b6-73931d662138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f72f461-98d7-45e0-9968-9afb240fbf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f72f461-98d7-45e0-9968-9afb240fbf1e.jpg?1",
             "name": "Giant Harbinger",
             "text": "When Giant Harbinger comes into play, you may search your library for a Giant card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "cfdb33c2-4459-5476-bc4d-e99317c8a0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fa2db-4c73-401a-b9a4-b039554be625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fa2db-4c73-401a-b9a4-b039554be625.jpg?1",
             "name": "Giant's Ire",
             "text": "Giant's Ire deals 4 damage to target player. If you control a Giant, draw a card.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "28a21701-487e-5d54-9bb2-22f862734499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc845-7165-40f3-a082-21a502b3f0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc845-7165-40f3-a082-21a502b3f0f6.jpg?1",
             "name": "Glarewielder",
             "text": "Haste\nWhen Glarewielder comes into play, up to two target creatures can't block this turn.\nEvoke {1}{R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "78007150-1ebe-5c52-9a1f-1c0e803cf813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f32852-2a18-453d-910a-829c3a2b5b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f32852-2a18-453d-910a-829c3a2b5b1b.jpg?1",
             "name": "Goatnapper",
             "text": "When Goatnapper comes into play, untap target Goat and gain control of it until end of turn. It gains haste until end of turn.",
             "colours": [
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "771f45e1-2fb0-5a3a-a64f-65edce4d0705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f71692-6389-462f-933e-b18b5aa7d76b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f71692-6389-462f-933e-b18b5aa7d76b.jpg?1",
             "name": "Hamletback Goliath",
             "text": "Whenever another creature comes into play, you may put X +1/+1 counters on Hamletback Goliath, where X is that creature's power.",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "cbd339fb-18a8-59f1-a699-9dc1d74c2a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg?1",
             "name": "Hearthcage Giant",
             "text": "When Hearthcage Giant comes into play, put two 3/1 red Elemental Shaman creature tokens into play.\nSacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "3fbe5c80-413e-5006-99c8-0c96ed0b046c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432470c-7f68-4429-970a-3da8eabcf0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432470c-7f68-4429-970a-3da8eabcf0b8.jpg?1",
             "name": "Heat Shimmer",
             "text": "Put a token into play that's a copy of target creature. It has haste and \"At end of turn, remove this permanent from the game.\"",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "1217f146-ffa8-5d43-9929-84f8fe062572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f560199-7703-4e2a-8e2d-5728f6efef46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f560199-7703-4e2a-8e2d-5728f6efef46.jpg?1",
             "name": "Hostility",
             "text": "Haste\nIf a spell you control would deal damage to an opponent, prevent that damage. Put a 3/1 red Elemental Shaman creature token with haste into play for each 1 damage prevented this way.\nWhen Hostility is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "485b75ec-22c8-5e41-abb3-8a5ccec4336b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e0b97-c2a9-4cd6-957e-87e9b22f7b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e0b97-c2a9-4cd6-957e-87e9b22f7b48.jpg?1",
             "name": "Hurly-Burly",
             "text": "Choose one Hurly-Burly deals 1 damage to each creature without flying; or Hurly-Burly deals 1 damage to each creature with flying.",
             "colours": [
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "101c62b3-9d27-564d-8fe2-91bc8d1952d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8829b3c-5267-44c6-b709-c2dfc683b0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8829b3c-5267-44c6-b709-c2dfc683b0a8.jpg?1",
             "name": "Incandescent Soulstoke",
             "text": "Other Elemental creatures you control get +1/+1.\n{1}{R}, {T}: You may put an Elemental creature card from your hand into play. That creature gains haste until end of turn. Sacrifice it at end of turn.",
             "colours": [
@@ -6143,7 +6143,7 @@
         },
         {
             "id": "1b2a8b46-8cb6-59aa-ba80-a56601249cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512367a2-f8f6-4c28-9eb3-8e04d2694e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512367a2-f8f6-4c28-9eb3-8e04d2694e4b.jpg?1",
             "name": "Incendiary Command",
             "text": "Choose two Incendiary Command deals 4 damage to target player; or Incendiary Command deals 2 damage to each creature; or destroy target nonbasic land; or each player discards all the cards in his or her hand, then draws that many cards.",
             "colours": [
@@ -6175,7 +6175,7 @@
         },
         {
             "id": "b0f882fc-4b46-5509-aa39-0c4cc17d5e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ceb9ae9-d153-446f-8835-1c53672fc9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ceb9ae9-d153-446f-8835-1c53672fc9ca.jpg?1",
             "name": "Ingot Chewer",
             "text": "When Ingot Chewer comes into play, destroy target artifact.\nEvoke {R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "e2fc64c9-e44d-5585-a5d0-82ea89cb1b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99a113a-013a-411b-9f16-975cebd5ea5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99a113a-013a-411b-9f16-975cebd5ea5f.jpg?1",
             "name": "Inner-Flame Acolyte",
             "text": "When Inner-Flame Acolyte comes into play, target creature gets +2/+0 and gains haste until end of turn.\nEvoke {R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "61884589-3719-5022-b3a2-15a273ebb043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced8a0-1caa-4737-b863-eb244a3d388a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced8a0-1caa-4737-b863-eb244a3d388a.jpg?1",
             "name": "Inner-Flame Igniter",
             "text": "{2}{R}: Creatures you control get +1/+0 until end of turn. If this is the third time this ability has resolved this turn, creatures you control gain first strike until end of turn.",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "caddad48-59a1-56c4-9b25-9c3b9af2211c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2c0c8b-5442-44fb-9686-d3dff5742501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2c0c8b-5442-44fb-9686-d3dff5742501.jpg?1",
             "name": "Lash Out",
             "text": "Lash Out deals 3 damage to target creature. Clash with an opponent. If you win, Lash Out deals 3 damage to that creature's controller. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -6311,7 +6311,7 @@
         },
         {
             "id": "3127789f-5373-503f-b0dd-50ecd94eee2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaa7f6a-9639-4bee-aa12-20054d7975d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaa7f6a-9639-4bee-aa12-20054d7975d5.jpg?1",
             "name": "Lowland Oaf",
             "text": "{T}: Target Goblin creature you control gets +1/+0 and gains flying until end of turn. Sacrifice that creature at end of turn.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "dff4ad41-1cc3-50c8-8100-f2850b978096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50575eab-6c23-4f63-9667-458416c5caa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50575eab-6c23-4f63-9667-458416c5caa5.jpg?1",
             "name": "Mudbutton Torchrunner",
             "text": "When Mudbutton Torchrunner is put into a graveyard from play, it deals 3 damage to target creature or player.",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "cbf2ef16-dbf8-5121-81e0-8e0dcbe437c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f89bcf-46f8-4598-a949-7f10134606aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f89bcf-46f8-4598-a949-7f10134606aa.jpg?1",
             "name": "Needle Drop",
             "text": "Needle Drop deals 1 damage to target creature or player that was dealt damage this turn.\nDraw a card.",
             "colours": [
@@ -6413,7 +6413,7 @@
         },
         {
             "id": "2e3ae227-7eba-5af1-aca4-1e0fd2c4a971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg?1",
             "name": "Nova Chaser",
             "text": "Trample\nChampion an Elemental (When this comes into play, sacrifice it unless you remove another Elemental you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "3720a2a8-a6d2-528c-a756-033abf1de838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2c8cb-4852-4bde-b2cf-72ceb9b0dd3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2c8cb-4852-4bde-b2cf-72ceb9b0dd3e.jpg?1",
             "name": "Rebellion of the Flamekin",
             "text": "Whenever you clash, you may pay {1}. If you do, put a 3/1 red Elemental Shaman creature token into play. If you won, that token gains haste until end of turn. (This ability triggers after the clash ends.)",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "b746c640-8bca-50a6-98ba-40f8edf0339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c6227b-bd43-47e8-927f-f8a78c532591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c6227b-bd43-47e8-927f-f8a78c532591.jpg?1",
             "name": "Smokebraider",
             "text": "{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to play Elemental spells or activated abilities of Elementals.",
             "colours": [
@@ -6518,7 +6518,7 @@
         },
         {
             "id": "3712e236-3d82-5391-b94b-0db29e8cd242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf72b4d-a399-49fb-a890-653b184a9e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf72b4d-a399-49fb-a890-653b184a9e95.jpg?1",
             "name": "Soulbright Flamekin",
             "text": "{2}: Target creature gains trample until end of turn. If this is the third time this ability has resolved this turn, you may add {R}{R}{R}{R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -6553,7 +6553,7 @@
         },
         {
             "id": "d799a598-2c60-5d20-8847-a91136c16c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428ba328-a0d8-4c52-ac2c-e9698486cc08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428ba328-a0d8-4c52-ac2c-e9698486cc08.jpg?1",
             "name": "Stinkdrinker Daredevil",
             "text": "Giant spells you play cost {2} less to play.",
             "colours": [
@@ -6588,7 +6588,7 @@
         },
         {
             "id": "f94b0d25-867e-591c-a572-614a6e16c226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62a4703-9e8d-4164-a529-b2dbc4069aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62a4703-9e8d-4164-a529-b2dbc4069aa8.jpg?1",
             "name": "Sunrise Sovereign",
             "text": "Other Giant creatures you control get +2/+2 and have trample.",
             "colours": [
@@ -6623,7 +6623,7 @@
         },
         {
             "id": "d21232ce-62c2-5163-a554-56e6ab9f51eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2ec11-eb65-488d-a857-b5020113c429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2ec11-eb65-488d-a857-b5020113c429.jpg?1",
             "name": "Tar Pitcher",
             "text": "{T}, Sacrifice a Goblin: Tar Pitcher deals 2 damage to target creature or player.",
             "colours": [
@@ -6658,7 +6658,7 @@
         },
         {
             "id": "4fbef074-c393-53f9-8647-15284ceee46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a898e-6a97-4fd9-980e-3bfd8d755386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a898e-6a97-4fd9-980e-3bfd8d755386.jpg?1",
             "name": "Tarfire",
             "text": "Tarfire deals 2 damage to target creature or player.",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "41724361-c6c8-5e03-943e-ab4688e64593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864f207-2878-461b-8ff6-76475abc324d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864f207-2878-461b-8ff6-76475abc324d.jpg?1",
             "name": "Thundercloud Shaman",
             "text": "When Thundercloud Shaman comes into play, it deals damage equal to the number of Giants you control to each non-Giant creature.",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "937387ef-b35b-5dd9-a8d5-e88800010239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76f09bc-b49a-4ad2-be2d-2a191d41b86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76f09bc-b49a-4ad2-be2d-2a191d41b86d.jpg?1",
             "name": "Wild Ricochet",
             "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -6760,7 +6760,7 @@
         },
         {
             "id": "dcd7bf2d-3df8-5825-9f78-895469346fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a128ea6-cd00-4410-8dc4-cf66ce6f0fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a128ea6-cd00-4410-8dc4-cf66ce6f0fa1.jpg?1",
             "name": "Battlewand Oak",
             "text": "Whenever a Forest comes into play under your control, Battlewand Oak gets +2/+2 until end of turn.\nWhenever you play a Treefolk spell, Battlewand Oak gets +2/+2 until end of turn.",
             "colours": [
@@ -6795,7 +6795,7 @@
         },
         {
             "id": "e8fcbe58-5adf-5ed3-bdd8-eef8fef53922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1b54-56d9-496a-b910-90cc55996ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1b54-56d9-496a-b910-90cc55996ad4.jpg?1",
             "name": "Bog-Strider Ash",
             "text": "Swampwalk\nWhenever a player plays a Goblin spell, you may pay {G}. If you do, you gain 2 life.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "308b969f-0a93-536d-9a81-7beaac3ad231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734a0a8-aa21-4fc0-b20d-5fea172884f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734a0a8-aa21-4fc0-b20d-5fea172884f6.jpg?1",
             "name": "Briarhorn",
             "text": "Flash\nWhen Briarhorn comes into play, target creature gets +3/+3 until end of turn.\nEvoke {1}{G} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6864,7 +6864,7 @@
         },
         {
             "id": "5388109b-5c4f-5e62-a568-bbb17ddb21be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b9719-2861-477e-bb78-225fd03d7bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b9719-2861-477e-bb78-225fd03d7bbc.jpg?1",
             "name": "Changeling Titan",
             "text": "Changeling (This card is every creature type at all times.)\nChampion a creature (When this comes into play, sacrifice it unless you remove another creature you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -6898,7 +6898,7 @@
         },
         {
             "id": "5643d5aa-b3a4-5682-b83c-2cd718102ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742366f-e726-406e-bcbe-51a3bfd0151e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742366f-e726-406e-bcbe-51a3bfd0151e.jpg?1",
             "name": "Cloudcrown Oak",
             "text": "Reach (This can block creatures with flying.)",
             "colours": [
@@ -6933,7 +6933,7 @@
         },
         {
             "id": "c803a91d-9f5a-5af4-ac3e-5b47c5937734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c759c561-829d-483d-a433-fe1213f20236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c759c561-829d-483d-a433-fe1213f20236.jpg?1",
             "name": "Cloudthresher",
             "text": "Flash\nReach (This can block creatures with flying.)\nWhen Cloudthresher comes into play, it deals 2 damage to each creature with flying and each player.\nEvoke {2}{G}{G} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6967,7 +6967,7 @@
         },
         {
             "id": "693b5541-6682-5d9a-b1aa-5eb1a2b81fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg?1",
             "name": "Dauntless Dourbark",
             "text": "Dauntless Dourbark's power and toughness are each equal to the number of Forests you control plus the number of Treefolk you control.\nDauntless Dourbark has trample as long as you control another Treefolk.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "64767abc-dcca-5ce9-b634-fee0b34fdeda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5154fc12-a8f2-4a16-8b1f-f7415c87566d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5154fc12-a8f2-4a16-8b1f-f7415c87566d.jpg?1",
             "name": "Elvish Branchbender",
             "text": "{T}: Until end of turn, target Forest becomes an X/X Treefolk creature in addition to its other types, where X is the number of Elves you control.",
             "colours": [
@@ -7037,7 +7037,7 @@
         },
         {
             "id": "af2fb7b6-552a-5c9a-a062-ac887049aab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b9d31-3079-45e3-acb3-a74169aa332e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b9d31-3079-45e3-acb3-a74169aa332e.jpg?1",
             "name": "Elvish Eulogist",
             "text": "Sacrifice Elvish Eulogist: You gain 1 life for each Elf card in your graveyard.",
             "colours": [
@@ -7072,7 +7072,7 @@
         },
         {
             "id": "791b6fa2-bdf7-5359-afde-70387b21a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854f9a9-160c-4c96-b871-0f85914597d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854f9a9-160c-4c96-b871-0f85914597d0.jpg?1",
             "name": "Elvish Handservant",
             "text": "Whenever a player plays a Giant spell, you may put a +1/+1 counter on Elvish Handservant.",
             "colours": [
@@ -7107,7 +7107,7 @@
         },
         {
             "id": "75fe0a7b-fa16-55a5-8456-25ba0c3fd75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de789231-8358-4cbd-b8eb-1da4ce5b34c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de789231-8358-4cbd-b8eb-1da4ce5b34c0.jpg?1",
             "name": "Elvish Harbinger",
             "text": "When Elvish Harbinger comes into play, you may search your library for an Elf card, reveal it, then shuffle your library and put that card on top of it.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "ec18f396-9469-5208-9ed6-ad5c866a1f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d5049-c1a6-4186-952e-bd7481b1974a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d5049-c1a6-4186-952e-bd7481b1974a.jpg?1",
             "name": "Elvish Promenade",
             "text": "Put a 1/1 green Elf Warrior creature token into play for each Elf you control.",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "25abbac9-2e6e-5e2e-9c0f-c16655283610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7ffca1-c73c-4de1-b811-bd1876ea6d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7ffca1-c73c-4de1-b811-bd1876ea6d6f.jpg?1",
             "name": "Epic Proportions",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +5/+5 and has trample.",
             "colours": [
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "dd6f709e-ee0a-5c6c-9dae-34237b95d4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg?1",
             "name": "Eyes of the Wisent",
             "text": "Whenever an opponent plays a blue spell during your turn, you may put a 4/4 green Elemental creature token into play.",
             "colours": [
@@ -7246,7 +7246,7 @@
         },
         {
             "id": "d61bb6f2-01ca-5e94-aafc-0a9bb9365bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05edfbbc-34e8-4046-966c-3a979468b95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05edfbbc-34e8-4046-966c-3a979468b95e.jpg?1",
             "name": "Fertile Ground",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool.",
             "colours": [
@@ -7280,7 +7280,7 @@
         },
         {
             "id": "9fe479be-885b-5fda-9cea-afc19a3c07db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f77c7e-d35f-477e-acc4-a393044319ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f77c7e-d35f-477e-acc4-a393044319ea.jpg?1",
             "name": "Fistful of Force",
             "text": "Target creature gets +2/+2 until end of turn. Clash with an opponent. If you win, that creature gets an additional +2/+2 and gains trample until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -7312,7 +7312,7 @@
         },
         {
             "id": "c404bfb3-6dfe-5112-909e-4e07a2907ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f13a2-9243-4ce9-9f71-bed74355b781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f13a2-9243-4ce9-9f71-bed74355b781.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "+1: Untap two target lands.\n-1: Put a 3/3 green Beast creature token into play.\n-4: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -7348,7 +7348,7 @@
         },
         {
             "id": "271ab442-2158-545b-b5a4-4a273a7aaf0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bf7254-4302-41a0-bc87-d7dc437ff38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bf7254-4302-41a0-bc87-d7dc437ff38d.jpg?1",
             "name": "Gilt-Leaf Ambush",
             "text": "Put two 1/1 green Elf Warrior creature tokens into play. Clash with an opponent. If you win, those creatures gain deathtouch until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost. Whenever a creature with deathtouch deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -7383,7 +7383,7 @@
         },
         {
             "id": "997808e4-122b-56d6-91c5-aaf9f5af56ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cc889-9bc1-48dd-b1d1-95daa73b8fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cc889-9bc1-48dd-b1d1-95daa73b8fbe.jpg?1",
             "name": "Gilt-Leaf Seer",
             "text": "{G}, {T}: Look at the top two cards of your library, then put them back in any order.",
             "colours": [
@@ -7418,7 +7418,7 @@
         },
         {
             "id": "e15bc5ce-e372-510d-87bf-79883c5fc1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311c5f1d-7e3b-4397-b05b-f20bde2dc164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311c5f1d-7e3b-4397-b05b-f20bde2dc164.jpg?1",
             "name": "Guardian of Cloverdell",
             "text": "When Guardian of Cloverdell comes into play, put three 1/1 white Kithkin Soldier creature tokens into play.\n{G}, Sacrifice a Kithkin: You gain 1 life.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "ecb84a76-d818-53cd-86b1-383a0078b555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802a7fe-9c8b-4bc3-95d8-4a5dafcf2c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802a7fe-9c8b-4bc3-95d8-4a5dafcf2c75.jpg?1",
             "name": "Heal the Scars",
             "text": "Regenerate target creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -7485,7 +7485,7 @@
         },
         {
             "id": "f1deb83f-232d-5e1d-8cbf-bd6981b7f5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb783652-6450-4789-8ec1-b057b39c6a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb783652-6450-4789-8ec1-b057b39c6a4b.jpg?1",
             "name": "Hunt Down",
             "text": "Target creature blocks target creature this turn if able.",
             "colours": [
@@ -7517,7 +7517,7 @@
         },
         {
             "id": "14ef47ee-b10f-5876-8854-89e5359078f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbf6137-4f50-4915-b608-7a03512476a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbf6137-4f50-4915-b608-7a03512476a2.jpg?1",
             "name": "Immaculate Magistrate",
             "text": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "6a90afb9-3c6f-57d8-959a-c770bbbdd098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fce74-fed9-4bf7-949d-7df6bef29238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fce74-fed9-4bf7-949d-7df6bef29238.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elf creatures you control get +1/+1.\n{G}, {T}: Put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -7587,7 +7587,7 @@
         },
         {
             "id": "91e0e1e7-17cf-5d2d-b534-4c3ed87b8265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356793ec-3285-4bda-9b8e-23bf2d60f124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356793ec-3285-4bda-9b8e-23bf2d60f124.jpg?1",
             "name": "Incremental Growth",
             "text": "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "c2655774-61c3-543c-ac74-371d06355a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fd5232-2dac-4bd9-a1f6-eb1a40154367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fd5232-2dac-4bd9-a1f6-eb1a40154367.jpg?1",
             "name": "Jagged-Scar Archers",
             "text": "Jagged-Scar Archers's power and toughness are each equal to the number of Elves you control.\n{T}: Jagged-Scar Archers deals damage equal to its power to target creature with flying.",
             "colours": [
@@ -7654,7 +7654,7 @@
         },
         {
             "id": "b0e9093f-b458-5185-82c1-4178c355e992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d0d7fd-a580-41af-8e9d-fee74094ec47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d0d7fd-a580-41af-8e9d-fee74094ec47.jpg?1",
             "name": "Kithkin Daggerdare",
             "text": "{G}, {T}: Target attacking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -7689,7 +7689,7 @@
         },
         {
             "id": "2e1e648a-ebb3-5f6d-af75-7380ef1d7fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b6f90-c609-4ffd-9136-9fd7a833ebb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b6f90-c609-4ffd-9136-9fd7a833ebb3.jpg?1",
             "name": "Kithkin Mourncaller",
             "text": "Whenever an attacking Kithkin or Elf is put into your graveyard from play, you may draw a card.",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "1ed98de7-475e-5878-8b0c-2c9531000477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f209d6-c194-4208-864d-f8a44b88997f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f209d6-c194-4208-864d-f8a44b88997f.jpg?1",
             "name": "Lace with Moonglove",
             "text": "Target creature gains deathtouch until end of turn. (Whenever it deals damage to a creature, destroy that creature.)\nDraw a card.",
             "colours": [
@@ -7756,7 +7756,7 @@
         },
         {
             "id": "97d32887-471c-5b34-8c3c-b27c59a669bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667fd7ab-de75-48e7-8d4b-a96130ae4666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667fd7ab-de75-48e7-8d4b-a96130ae4666.jpg?1",
             "name": "Lammastide Weave",
             "text": "Name a card, then target player puts the top card of his or her library into his or her graveyard. If that card is the named card, you gain life equal to its converted mana cost.\nDraw a card.",
             "colours": [
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "3d2c874d-37f8-5715-9193-7af51c7f848c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg?1",
             "name": "Leaf Gilder",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -7823,7 +7823,7 @@
         },
         {
             "id": "14519ca4-3d9c-5bc3-80d5-6e9fe0cdaf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264fd6c5-8d73-4928-aed7-5ed637426780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264fd6c5-8d73-4928-aed7-5ed637426780.jpg?1",
             "name": "Lignify",
             "text": "Enchant creature\nEnchanted creature is a 0/4 Treefolk with no abilities.",
             "colours": [
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "e64f2b80-32e7-59cf-9d6c-982e8213eb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d21f992-f982-415e-9d77-d11d8c931741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d21f992-f982-415e-9d77-d11d8c931741.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "Whenever you play an Elf spell, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -7894,7 +7894,7 @@
         },
         {
             "id": "dcf57709-b5a4-58c0-abfe-2dbdccf61200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cf01d6-7d5d-4638-9884-733797c9f502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cf01d6-7d5d-4638-9884-733797c9f502.jpg?1",
             "name": "Masked Admirers",
             "text": "When Masked Admirers comes into play, draw a card.\nWhenever you play a creature spell, you may pay {G}{G}. If you do, return Masked Admirers from your graveyard to your hand.",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "73e5001f-771a-5180-aa52-53112fb717f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a2b029-02ba-46b0-88a2-99025727cc56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a2b029-02ba-46b0-88a2-99025727cc56.jpg?1",
             "name": "Nath's Elite",
             "text": "All creatures able to block Nath's Elite do so.\nWhen Nath's Elite comes into play, clash with an opponent. If you win, put a +1/+1 counter on Nath's Elite. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "9f1fe642-8b37-52e0-83b0-b2c1522ab06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fe818e-6dbc-4100-8552-b0393c87b052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fe818e-6dbc-4100-8552-b0393c87b052.jpg?1",
             "name": "Oakgnarl Warrior",
             "text": "Vigilance, trample",
             "colours": [
@@ -7999,7 +7999,7 @@
         },
         {
             "id": "eb0a4d88-395c-5c90-a498-3694bd89b3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d2c5b9-cef9-4763-8e65-e3b1418c0ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d2c5b9-cef9-4763-8e65-e3b1418c0ad3.jpg?1",
             "name": "Primal Command",
             "text": "Choose two Target player gains 7 life; or put target noncreature permanent on top of its owner's library; or target player shuffles his or her graveyard into his or her library; or search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -8031,7 +8031,7 @@
         },
         {
             "id": "5f6fd6e2-209f-5061-a30d-893dde1173e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe6051f-6252-4ad1-90ab-d21705a708d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe6051f-6252-4ad1-90ab-d21705a708d1.jpg?1",
             "name": "Rootgrapple",
             "text": "Destroy target noncreature permanent. If you control a Treefolk, draw a card.",
             "colours": [
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "fa2bd2d2-8d89-51b0-a3d0-dbe6f425ff45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca605c0-6270-4238-bb77-0bbfd7568807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca605c0-6270-4238-bb77-0bbfd7568807.jpg?1",
             "name": "Seedguide Ash",
             "text": "When Seedguide Ash is put into a graveyard from play, you may search your library for up to three Forest cards and put them into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -8101,7 +8101,7 @@
         },
         {
             "id": "7abf6ff8-6e23-5b90-aa8c-c3cfe38952de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20ef13-e97f-454c-8295-7bb8a7c4e4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20ef13-e97f-454c-8295-7bb8a7c4e4be.jpg?1",
             "name": "Spring Cleaning",
             "text": "Destroy target enchantment. Clash with an opponent. If you win, destroy all enchantments your opponents control. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "190de764-72e0-5908-b827-08bdeff0830e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b55fa6-4c94-4ab4-bc30-4fb8b1d3e38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b55fa6-4c94-4ab4-bc30-4fb8b1d3e38f.jpg?1",
             "name": "Sylvan Echoes",
             "text": "Whenever you clash and win, you may draw a card. (This ability triggers after the clash ends.)",
             "colours": [
@@ -8165,7 +8165,7 @@
         },
         {
             "id": "aa0afa4c-daa1-57c8-a87d-87e57bc74ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg?1",
             "name": "Timber Protector",
             "text": "Other Treefolk creatures you control get +1/+1.\nOther Treefolk and Forests you control are indestructible.",
             "colours": [
@@ -8200,7 +8200,7 @@
         },
         {
             "id": "5b73280b-3442-50b4-a8d3-398ef664b2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef45cdc-2e1c-40c7-8978-b09a50f511fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef45cdc-2e1c-40c7-8978-b09a50f511fb.jpg?1",
             "name": "Treefolk Harbinger",
             "text": "When Treefolk Harbinger comes into play, you may search your library for a Treefolk or Forest card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "41ea75fe-fad9-566a-ab7c-56c94cf77309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cede0be-1bdd-4392-beaf-b83d0b780eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cede0be-1bdd-4392-beaf-b83d0b780eb7.jpg?1",
             "name": "Vigor",
             "text": "Trample\nIf damage would be dealt to a creature you control other than Vigor, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way.\nWhen Vigor is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -8270,7 +8270,7 @@
         },
         {
             "id": "798f3c7c-1b73-51e8-90ad-912edb30f2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5fe17-5499-427b-9267-3b3a9676a087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5fe17-5499-427b-9267-3b3a9676a087.jpg?1",
             "name": "Warren-Scourge Elf",
             "text": "Protection from Goblins",
             "colours": [
@@ -8305,7 +8305,7 @@
         },
         {
             "id": "e5163cd6-0967-58f2-8fa4-2e2db8a74bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa41edf8-88a1-46dd-8315-b0afe7e14b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa41edf8-88a1-46dd-8315-b0afe7e14b7e.jpg?1",
             "name": "Woodland Changeling",
             "text": "Changeling (This card is every creature type at all times.)",
             "colours": [
@@ -8339,7 +8339,7 @@
         },
         {
             "id": "93246a5d-8bfb-564d-8105-8fa03c1d7489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adead0-f8b4-4c49-b4ce-d9253980ee03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adead0-f8b4-4c49-b4ce-d9253980ee03.jpg?1",
             "name": "Woodland Guidance",
             "text": "Return target card from your graveyard to your hand. Clash with an opponent. If you win, untap all Forests you control. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)\nRemove Woodland Guidance from the game.",
             "colours": [
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "b731c4cd-39b9-58f3-b7a0-12183e18df2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97f29a-1551-4e75-80e8-2dd31cb6c0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97f29a-1551-4e75-80e8-2dd31cb6c0db.jpg?1",
             "name": "Wren's Run Packmaster",
             "text": "Champion an Elf (When this comes into play, sacrifice it unless you remove another Elf you control from the game. When this leaves play, that card returns to play.)\n{2}{G}: Put a 2/2 green Wolf creature token into play.\nEach Wolf you control has deathtouch. (When it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "5f6a9851-c6f2-5638-a324-289b30eb6a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c411a0-b8dd-4394-852a-a29dbcec953b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c411a0-b8dd-4394-852a-a29dbcec953b.jpg?1",
             "name": "Wren's Run Vanquisher",
             "text": "As an additional cost to play Wren's Run Vanquisher, reveal an Elf card from your hand or pay {3}.\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "aa98af82-e8a9-5301-b2b1-d18f940fd07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21cfc2-9671-4bf3-b922-2f436f284cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21cfc2-9671-4bf3-b922-2f436f284cb1.jpg?1",
             "name": "Brion Stoutarm",
             "text": "Lifelink (Whenever this creature deals damage, you gain that much life.)\n{R}, {T}, Sacrifice a creature other than Brion Stoutarm: Brion Stoutarm deals damage equal to the sacrificed creature's power to target player.",
             "colours": [
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "1d8c1972-5a1d-5ccf-8a89-17084779a075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b006b169-295d-4ead-8e8e-29a9c3246025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b006b169-295d-4ead-8e8e-29a9c3246025.jpg?1",
             "name": "Doran, the Siege Tower",
             "text": "Each creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -8521,7 +8521,7 @@
         },
         {
             "id": "a10f3494-8288-5894-9272-5e5e353e1c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c16e1b-f4ce-409f-928a-42c666adac9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c16e1b-f4ce-409f-928a-42c666adac9d.jpg?1",
             "name": "Gaddock Teeg",
             "text": "Noncreature spells with converted mana cost 4 or greater can't be played.\nNoncreature spells with {X} in their mana costs can't be played.",
             "colours": [
@@ -8560,7 +8560,7 @@
         },
         {
             "id": "73e644a6-5a57-51fe-a000-5ac9dd28bc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b9ea46-ae9b-4729-b206-0ba3ddc7660d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b9ea46-ae9b-4729-b206-0ba3ddc7660d.jpg?1",
             "name": "Horde of Notions",
             "text": "Vigilance, trample, haste\n{W}{U}{B}{R}{G}: You may play target Elemental card from your graveyard without paying its mana cost.",
             "colours": [
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "97c6e6c6-7d0a-52d6-828e-27e126ba5af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c69bd-a8bf-4085-85fa-364b8e92b88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c69bd-a8bf-4085-85fa-364b8e92b88a.jpg?1",
             "name": "Nath of the Gilt-Leaf",
             "text": "At the beginning of your upkeep, you may have target opponent discard a card at random.\nWhenever an opponent discards a card, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "acb5837c-4c4b-5e80-9f03-b71e816bb9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aefaf-1b96-4c08-a73e-98e401655965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aefaf-1b96-4c08-a73e-98e401655965.jpg?1",
             "name": "Sygg, River Guide",
             "text": "Islandwalk\n{1}{W}: Target Merfolk you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "f4033c80-962b-57e8-9704-327b1db3d059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08a1377-dede-47c8-8447-c9df125f3b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08a1377-dede-47c8-8447-c9df125f3b14.jpg?1",
             "name": "Wort, Boggart Auntie",
             "text": "Fear\nAt the beginning of your upkeep, you may return target Goblin card from your graveyard to your hand.",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "8cfcd931-c773-57d0-8a1f-05121d194eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6b558b-74a5-497d-8be4-474c375d7ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6b558b-74a5-497d-8be4-474c375d7ca7.jpg?1",
             "name": "Wydwen, the Biting Gale",
             "text": "Flash\nFlying\n{U}{B}, Pay 1 life: Return Wydwen, the Biting Gale to its owner's hand.",
             "colours": [
@@ -8760,7 +8760,7 @@
         },
         {
             "id": "6294454d-37ec-53b3-8463-3dc5707c92ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fea28-3813-4e65-8b90-6d335fdf0a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fea28-3813-4e65-8b90-6d335fdf0a0b.jpg?1",
             "name": "Colfenor's Urn",
             "text": "Whenever a creature with toughness 4 or greater is put into your graveyard from play, you may remove it from the game.\nAt end of turn, if three or more cards have been removed from the game with Colfenor's Urn, sacrifice it. If you do, return those cards to play under their owner's control.",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "9166e6c8-922b-55c9-9547-5fef623ebd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd836fe0-932c-4d5c-9a52-94fc423c3d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd836fe0-932c-4d5c-9a52-94fc423c3d57.jpg?1",
             "name": "Deathrender",
             "text": "Equipped creature gets +2/+2.\nWhenever equipped creature is put into a graveyard from play, you may put a creature card from your hand into play and attach Deathrender to it.\nEquip {2}",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "f607f056-5beb-5e18-ae2f-9090d7c1d63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbf10e-32f2-41c5-a7a2-5f24662892d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbf10e-32f2-41c5-a7a2-5f24662892d2.jpg?1",
             "name": "Dolmen Gate",
             "text": "Prevent all combat damage that would be dealt to attacking creatures you control.",
             "colours": [],
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "fe56bf4d-60c3-5d86-af3d-cd30e88c48c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20925a3-dd4f-477c-806a-a3ec0fd2e00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20925a3-dd4f-477c-806a-a3ec0fd2e00d.jpg?1",
             "name": "Herbal Poultice",
             "text": "{3}, Sacrifice Herbal Poultice: Regenerate target creature.",
             "colours": [],
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "a5f72e58-bf83-5e25-8cce-e6819af5ba70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97377416-35e8-4cf3-be1f-edc2ec3f6eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97377416-35e8-4cf3-be1f-edc2ec3f6eb2.jpg?1",
             "name": "Moonglove Extract",
             "text": "Sacrifice Moonglove Extract: Moonglove Extract deals 2 damage to target creature or player.",
             "colours": [],
@@ -8902,7 +8902,7 @@
         },
         {
             "id": "aa04739d-8c69-5170-ac4a-7a8675399425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd3898-cb06-4bb9-9d52-b319e1fa2217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd3898-cb06-4bb9-9d52-b319e1fa2217.jpg?1",
             "name": "Rings of Brighthearth",
             "text": "Whenever you play an activated ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "6c86028f-a89a-5ff1-b35e-e82c0d47622a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be88336-83c7-422d-8826-13ceb8db5534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be88336-83c7-422d-8826-13ceb8db5534.jpg?1",
             "name": "Runed Stalactite",
             "text": "Equipped creature gets +1/+1 and is every creature type.\nEquip {2}",
             "colours": [],
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "29b00632-304f-5d09-b4a2-441eadb63b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8b09d0-fbd2-4441-9d87-02450412e0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8b09d0-fbd2-4441-9d87-02450412e0db.jpg?1",
             "name": "Springleaf Drum",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "e9804db3-35cf-59c7-bd64-78c0041f603d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e472d4f5-add4-4de3-8718-31a47a35277c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e472d4f5-add4-4de3-8718-31a47a35277c.jpg?1",
             "name": "Thorn of Amethyst",
             "text": "Noncreature spells cost {1} more to play.",
             "colours": [],
@@ -9016,7 +9016,7 @@
         },
         {
             "id": "df7c1ebe-315d-505e-a323-f445c2213477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18743fd4-2a15-40a2-ac90-e3f0fef07e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18743fd4-2a15-40a2-ac90-e3f0fef07e37.jpg?1",
             "name": "Thousand-Year Elixir",
             "text": "You may play the activated abilities of creatures you control as though those creatures had haste.\n{1}, {T}: Untap target creature.",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "f6468ec7-87a7-5ed4-9925-64c84125eb0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0138c42-77ea-45f0-b2ca-cda03f3f50d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0138c42-77ea-45f0-b2ca-cda03f3f50d1.jpg?1",
             "name": "Twinning Glass",
             "text": "{1}, {T}: You may play a nonland card from your hand without paying its mana cost if it has the same name as a spell that was played this turn.",
             "colours": [],
@@ -9072,7 +9072,7 @@
         },
         {
             "id": "fd9a8d8f-260d-5056-82f7-eb062949e65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea7b2c0-c641-478f-b8d9-17aa17fa1cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea7b2c0-c641-478f-b8d9-17aa17fa1cbe.jpg?1",
             "name": "Wanderer's Twig",
             "text": "{1}, Sacrifice Wanderer's Twig: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -9100,7 +9100,7 @@
         },
         {
             "id": "4c538ca4-52a8-544a-9598-af957e05fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff3a82d-e794-4c3b-994d-b28b8eb7eac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff3a82d-e794-4c3b-994d-b28b8eb7eac4.jpg?1",
             "name": "Ancient Amphitheater",
             "text": "As Ancient Amphitheater comes into play, you may reveal a Giant card from your hand. If you don't, Ancient Amphitheater comes into play tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "d5f8de32-daa2-5e61-8912-3482c058cecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098685c9-cd85-4279-a3b5-b495485bba35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098685c9-cd85-4279-a3b5-b495485bba35.jpg?1",
             "name": "Auntie's Hovel",
             "text": "As Auntie's Hovel comes into play, you may reveal a Goblin card from your hand. If you don't, Auntie's Hovel comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -9162,7 +9162,7 @@
         },
         {
             "id": "17b27a89-ee32-53ea-9b4b-8a4b244f1f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4bbbb5-4218-4b2a-9ca2-de4d5f5dda19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4bbbb5-4218-4b2a-9ca2-de4d5f5dda19.jpg?1",
             "name": "Gilt-Leaf Palace",
             "text": "As Gilt-Leaf Palace comes into play, you may reveal an Elf card from your hand. If you don't, Gilt-Leaf Palace comes into play tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "8b59c32b-3d30-531f-b57b-bb41d5045f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c678643-6640-49e1-a5b0-2954123bcabc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c678643-6640-49e1-a5b0-2954123bcabc.jpg?1",
             "name": "Howltooth Hollow",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {B} to your mana pool.\n{B}, {T}: You may play the removed card without paying its mana cost if each player has no cards in hand.",
             "colours": [],
@@ -9223,7 +9223,7 @@
         },
         {
             "id": "10507154-fa7a-55d3-b0af-30bdc4242e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38234590-812c-4d29-80c1-32b9e1282580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38234590-812c-4d29-80c1-32b9e1282580.jpg?1",
             "name": "Mosswort Bridge",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {G} to your mana pool.\n{G}, {T}: You may play the removed card without paying its mana cost if creatures you control have total power 10 or greater.",
             "colours": [],
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "7ec0d252-a89b-5c21-ac47-08dec64be939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4afa65-7933-4a64-b50f-a9a9f832b112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4afa65-7933-4a64-b50f-a9a9f832b112.jpg?1",
             "name": "Secluded Glen",
             "text": "As Secluded Glen comes into play, you may reveal a Faerie card from your hand. If you don't, Secluded Glen comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -9284,7 +9284,7 @@
         },
         {
             "id": "db77e9fe-f266-5002-aa66-dbbbf61331d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216656e-90e8-45fc-a0f6-0d0d79d0a021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216656e-90e8-45fc-a0f6-0d0d79d0a021.jpg?1",
             "name": "Shelldock Isle",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {U} to your mana pool.\n{U}, {T}: You may play the removed card without paying its mana cost if a library has twenty or fewer cards in it.",
             "colours": [],
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "e3f9a706-1348-5358-b4da-e07151a27b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e85acc-ed12-4036-8193-739721c3e178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e85acc-ed12-4036-8193-739721c3e178.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "dc872f75-9844-5059-a3c1-f096d1b8d44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec6abed-8fbb-4d3e-8f89-64ea1b3913db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec6abed-8fbb-4d3e-8f89-64ea1b3913db.jpg?1",
             "name": "Spinerock Knoll",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {R} to your mana pool.\n{R}, {T}: You may play the removed card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
             "colours": [],
@@ -9372,7 +9372,7 @@
         },
         {
             "id": "cd1033fb-7e0d-55d8-83cc-9a8885d571a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539001dc-69f0-42c0-b5c3-37d7b12eb79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539001dc-69f0-42c0-b5c3-37d7b12eb79e.jpg?1",
             "name": "Vivid Crag",
             "text": "Vivid Crag comes into play tapped with two charge counters on it.\n{T}: Add {R} to your mana pool.\n{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "0150dec1-c0d8-5a4f-93c8-de395cd91ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3c2935-84ee-446d-b247-2f574ea84a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3c2935-84ee-446d-b247-2f574ea84a8f.jpg?1",
             "name": "Vivid Creek",
             "text": "Vivid Creek comes into play tapped with two charge counters on it.\n{T}: Add {U} to your mana pool.\n{T}, Remove a charge counter from Vivid Creek: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9432,7 +9432,7 @@
         },
         {
             "id": "380656e2-f4b7-5d9f-a4c6-01c449891dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6646babe-edd8-4367-ba8f-89af4f859dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6646babe-edd8-4367-ba8f-89af4f859dd8.jpg?1",
             "name": "Vivid Grove",
             "text": "Vivid Grove comes into play tapped with two charge counters on it.\n{T}: Add {G} to your mana pool.\n{T}, Remove a charge counter from Vivid Grove: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9462,7 +9462,7 @@
         },
         {
             "id": "ad02fa8c-e1b5-5c96-afa1-d35d8e98dd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f806c7-0063-4270-b37c-5363c41a7621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f806c7-0063-4270-b37c-5363c41a7621.jpg?1",
             "name": "Vivid Marsh",
             "text": "Vivid Marsh comes into play tapped with two charge counters on it.\n{T}: Add {B} to your mana pool.\n{T}, Remove a charge counter from Vivid Marsh: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "2d326d13-b3b6-54e3-b07c-99ded6eb8aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a535790b-d416-4807-bca0-acf6b192101c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a535790b-d416-4807-bca0-acf6b192101c.jpg?1",
             "name": "Vivid Meadow",
             "text": "Vivid Meadow comes into play tapped with two charge counters on it.\n{T}: Add {W} to your mana pool.\n{T}, Remove a charge counter from Vivid Meadow: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "ede85584-e8b3-5b2e-b56f-5a8f2c6957c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccec69de-7203-4810-a8ec-8748705ee3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccec69de-7203-4810-a8ec-8748705ee3a2.jpg?1",
             "name": "Wanderwine Hub",
             "text": "As Wanderwine Hub comes into play, you may reveal a Merfolk card from your hand. If you don't, Wanderwine Hub comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -9553,7 +9553,7 @@
         },
         {
             "id": "55313bd0-6d1b-5fd1-8539-39ef73176442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df6a31a-5c49-4506-b8f8-84c9ab4a2ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df6a31a-5c49-4506-b8f8-84c9ab4a2ece.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {W} to your mana pool.\n{W}, {T}: You may play the removed card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -9583,7 +9583,7 @@
         },
         {
             "id": "5ffbe829-8a22-52f1-95e8-7ff447c19334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e41010-a7d2-4e78-8f7b-502347f8c47d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e41010-a7d2-4e78-8f7b-502347f8c47d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9621,7 +9621,7 @@
         },
         {
             "id": "f6e6b0e4-34e2-55ae-a5bd-097688eb8be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5db4d0-61f4-4cc6-89c4-02a2060b556d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5db4d0-61f4-4cc6-89c4-02a2060b556d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9659,7 +9659,7 @@
         },
         {
             "id": "a17c3246-d67c-51e0-8f5f-fe6517272bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d4bb5-9da7-4d21-9cdc-1732ea61121a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d4bb5-9da7-4d21-9cdc-1732ea61121a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "cae39c87-fbd5-517f-baf9-e06b8518a7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5900e-100c-44e8-97e9-b0c15379fea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5900e-100c-44e8-97e9-b0c15379fea1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "97183a9e-2a66-58df-b8d5-490b50f723b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885738f-a51d-418c-b194-0ba8ef6af556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885738f-a51d-418c-b194-0ba8ef6af556.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9773,7 +9773,7 @@
         },
         {
             "id": "f6ceed64-7813-5064-9c26-7c97e39e60a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ffadeb-cf20-4da9-a140-1fdcc7484c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ffadeb-cf20-4da9-a140-1fdcc7484c7a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "bc9c4be7-5fb1-5e66-b69a-042eb91ba829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d714d196-8cbc-4b53-8219-21044a017bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d714d196-8cbc-4b53-8219-21044a017bce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9849,7 +9849,7 @@
         },
         {
             "id": "6a7fc913-a939-507d-bac9-f2f5e759dd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d9548-f495-43ef-af66-e13a84c1f12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d9548-f495-43ef-af66-e13a84c1f12a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9887,7 +9887,7 @@
         },
         {
             "id": "b06f3c21-8077-5143-90ee-9e286455c63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f799604-bbbf-4d57-83c8-13a0eafa974e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f799604-bbbf-4d57-83c8-13a0eafa974e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9925,7 +9925,7 @@
         },
         {
             "id": "20846bde-8778-5927-9f06-601ef514b51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9dc477-a3e4-4fc0-af62-c8b8eb68d360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9dc477-a3e4-4fc0-af62-c8b8eb68d360.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9963,7 +9963,7 @@
         },
         {
             "id": "2176f831-b6e1-5b03-8c64-c9f8d099c337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4ad69e-843c-4f33-be2f-711568f8aac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4ad69e-843c-4f33-be2f-711568f8aac7.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10001,7 +10001,7 @@
         },
         {
             "id": "b6eafa2c-084d-52da-889b-012af093ce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38625a65-868f-4cbf-a512-9142f1eddf4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38625a65-868f-4cbf-a512-9142f1eddf4a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10039,7 +10039,7 @@
         },
         {
             "id": "44b34316-729e-5332-bc97-bb04dfe37902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83beeef7-2bb5-4c3a-9be4-79a968696d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83beeef7-2bb5-4c3a-9be4-79a968696d65.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10077,7 +10077,7 @@
         },
         {
             "id": "53700962-2535-5de3-a21c-ff74b254fa3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e0823-cbf3-4cf7-8fe1-a032cf33ee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e0823-cbf3-4cf7-8fe1-a032cf33ee66.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10115,7 +10115,7 @@
         },
         {
             "id": "b5e09225-bc11-5cf1-9333-dc23b3710a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd842290-fd0d-419d-b793-bd84b43f5d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd842290-fd0d-419d-b793-bd84b43f5d9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "db3b7481-ec28-5f3f-abf3-ec80e3e407e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaaad2-5512-46f8-9bdb-84aa3ef0c2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaaad2-5512-46f8-9bdb-84aa3ef0c2ac.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "af87faff-e6f7-5f45-9716-755b0fa55ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3a661e-d890-4211-bc9c-8266001ebfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3a661e-d890-4211-bc9c-8266001ebfba.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10229,7 +10229,7 @@
         },
         {
             "id": "892764f6-77b2-501b-bc48-c0d61954addc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081c1f03-3251-42dc-b356-3454ebdabc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081c1f03-3251-42dc-b356-3454ebdabc2e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10267,7 +10267,7 @@
         },
         {
             "id": "625403b7-37d0-5661-a0d3-9c1100849421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608a10-6bd4-4579-a08a-f7e2da383794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608a10-6bd4-4579-a08a-f7e2da383794.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10305,7 +10305,7 @@
         },
         {
             "id": "1e58945b-d8b0-5ac6-9b16-ecc1eaa38c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7104a533-42df-4430-87dc-e0adeb7f2320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7104a533-42df-4430-87dc-e0adeb7f2320.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10343,7 +10343,7 @@
         },
         {
             "id": "8bccbab9-7c5c-5b31-917b-eb5427b6471f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "b0b8ed9f-ec8b-59bb-9fe5-3b367a9c3275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c791044-be86-47d8-8c1b-299f6ab254e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c791044-be86-47d8-8c1b-299f6ab254e6.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "4a600caa-ca0a-5aac-b3de-38899af4e50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1",
             "name": "Kithkin Soldier",
             "text": "",
             "colours": [
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "de575099-679b-5fa4-bfdc-ac1339abefac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg?1",
             "name": "Merfolk Wizard",
             "text": "",
             "colours": [
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "84647b7c-b2dd-5033-8d00-9858c1991cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg?1",
             "name": "Goblin Rogue",
             "text": "",
             "colours": [
@@ -10516,7 +10516,7 @@
         },
         {
             "id": "c41f0130-98d9-53c5-8d14-2d2b9864db4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg?1",
             "name": "Elemental Shaman",
             "text": "",
             "colours": [
@@ -10551,7 +10551,7 @@
         },
         {
             "id": "3123891e-65ca-55e0-a1c4-0fbaa5528aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -10585,7 +10585,7 @@
         },
         {
             "id": "1537811d-76c4-59f0-bf3a-8f85a1ccb897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10619,7 +10619,7 @@
         },
         {
             "id": "4439bff3-437b-5152-bc45-2bc023f0b292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -10654,7 +10654,7 @@
         },
         {
             "id": "0ac06155-35dc-574c-9937-2da6f006e4ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -10688,7 +10688,7 @@
         },
         {
             "id": "6a0a382f-100d-51fe-be51-b0db4877cfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7d89ca-8611-4bda-b5c8-0350ce091102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7d89ca-8611-4bda-b5c8-0350ce091102.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/LTR.json
+++ b/Assets/Resources/Sets/LTR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9b3292e8-01ad-5489-8116-a27f8bdf1bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93de9042-cc62-4ade-8d8d-68fdbc84bfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93de9042-cc62-4ade-8d8d-68fdbc84bfae.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -37,7 +37,7 @@
         },
         {
             "id": "33413ff7-336f-5340-888f-cbca91e3caa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4410076-e1fe-45f3-a0ca-a91ab0133ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4410076-e1fe-45f3-a0ca-a91ab0133ff4.jpg?1",
             "name": "Banish from Edoras",
             "text": "",
             "colours": [
@@ -69,7 +69,7 @@
         },
         {
             "id": "40b249cb-e103-5c37-9dcb-1ec6a206f2f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae7a4d-9117-43c5-a048-80a0ddadc034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae7a4d-9117-43c5-a048-80a0ddadc034.jpg?1",
             "name": "The Battle of Bywater",
             "text": "",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d4f0c01f-9b7b-5233-9783-cabad66364a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac68519-ed7f-4f38-9549-c02975f88eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac68519-ed7f-4f38-9549-c02975f88eed.jpg?1",
             "name": "Bill the Pony",
             "text": "",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "15714ad7-584b-53f1-8ead-2f064dc5ed4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg?1",
             "name": "Boromir, Warden of the Tower",
             "text": "",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "8890df6e-d22e-5dc0-8730-03962a9f1bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966ee6-bf1b-4bb6-9277-8de6f3918ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966ee6-bf1b-4bb6-9277-8de6f3918ae2.jpg?1",
             "name": "Dawn of a New Age",
             "text": "",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "fe23cdbf-630c-56bc-8907-867bff6c7213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5f92bf-e4e7-487a-834c-964fdd6ad674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5f92bf-e4e7-487a-834c-964fdd6ad674.jpg?1",
             "name": "D\u00fanedain Blade",
             "text": "",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "704de46c-382b-5e06-8469-f5f5400fb671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd3bc0-77bd-40fe-b4f1-835a04cb6e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd3bc0-77bd-40fe-b4f1-835a04cb6e41.jpg?1",
             "name": "Eagles of the North",
             "text": "",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "707db285-cc31-5956-92c2-b8e2f394f239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb65ba-d605-4b79-a700-4a08ec5a90b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb65ba-d605-4b79-a700-4a08ec5a90b4.jpg?1",
             "name": "Eastfarthing Farmer",
             "text": "",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "67398b56-bf76-5804-9d40-7c9cf9e246d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be412c0-45d4-4856-a8cf-63a5a822dc5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be412c0-45d4-4856-a8cf-63a5a822dc5c.jpg?1",
             "name": "East-Mark Cavalier",
             "text": "",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "f29f6e6a-f483-55d1-b416-74c9c413c42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59710c4-24de-419e-a8a0-e8392d450c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59710c4-24de-419e-a8a0-e8392d450c23.jpg?1",
             "name": "\u00c9owyn, Lady of Rohan",
             "text": "",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "20f13999-4704-538d-807d-cbe09d78ba07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f990e7-54a3-4893-8510-645b2065447b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f990e7-54a3-4893-8510-645b2065447b.jpg?1",
             "name": "Errand-Rider of Gondor",
             "text": "",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "8e2a55cf-1ba0-5bed-95db-fb5bedb3091b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff3330-dcca-4435-87e7-871be91a68b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff3330-dcca-4435-87e7-871be91a68b0.jpg?1",
             "name": "Escape from Orthanc",
             "text": "",
             "colours": [
@@ -456,7 +456,7 @@
         },
         {
             "id": "f5bd70a1-e09e-5997-b940-d2159d0b9b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa6dded-ab08-43d0-b2fb-008854582cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa6dded-ab08-43d0-b2fb-008854582cba.jpg?1",
             "name": "Esquire of the King",
             "text": "",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "956e6d01-3c5a-5d18-92f4-b8e5bc7631ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2250a-9af1-40de-9f09-7e8c7daec520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2250a-9af1-40de-9f09-7e8c7daec520.jpg?1",
             "name": "Faramir, Field Commander",
             "text": "",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "dba83adc-decf-5a6a-8970-8d25ae3bdd56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203b2cd-48e5-471a-85fe-dc81012e5d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203b2cd-48e5-471a-85fe-dc81012e5d61.jpg?1",
             "name": "Flowering of the White Tree",
             "text": "",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "cb73984f-9c08-530d-94bc-5b7c24b75248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0cda3a-20d7-425a-89fe-b0a3cd7ced03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0cda3a-20d7-425a-89fe-b0a3cd7ced03.jpg?1",
             "name": "Fog on the Barrow-Downs",
             "text": "",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "f20cf347-a9d5-5ffb-a35b-8cbbc778ea20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56274b88-6e3f-4538-bb0c-eb5e52a58ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56274b88-6e3f-4538-bb0c-eb5e52a58ef3.jpg?1",
             "name": "Forge Anew",
             "text": "",
             "colours": [
@@ -635,7 +635,7 @@
         },
         {
             "id": "b5dbf4a8-bf04-50e9-a7cf-c44a760fd527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg?1",
             "name": "Frodo, Sauron's Bane",
             "text": "",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "adadd47a-0b15-54a0-b47e-5dcefbdc519a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "0e6123cc-508c-531d-a3bd-59578eb09a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019eab42-9e0c-4958-ac97-74d3db5580f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019eab42-9e0c-4958-ac97-74d3db5580f3.jpg?1",
             "name": "Hobbit's Sting",
             "text": "",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "0a9559b8-6279-5f11-a4d6-dc096557a8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5684483b-9a6a-499b-a5e1-e2815ee03cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5684483b-9a6a-499b-a5e1-e2815ee03cdb.jpg?1",
             "name": "Landroval, Horizon Witness",
             "text": "",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "e91f682c-9a33-5a13-9226-df0c6338a272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e40481-aeaa-4b3d-a020-e9b6d7c11992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e40481-aeaa-4b3d-a020-e9b6d7c11992.jpg?1",
             "name": "Lost to Legend",
             "text": "",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "5f3ea33a-80f1-5437-821b-53ffaf000c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cd0756-7bf3-4cb6-9687-1f9346b0bb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cd0756-7bf3-4cb6-9687-1f9346b0bb92.jpg?1",
             "name": "Nimble Hobbit",
             "text": "",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "a5804f3e-985b-5895-a447-ffecfaf0b09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e2c80d-7581-46ba-8237-7886b91c19b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e2c80d-7581-46ba-8237-7886b91c19b3.jpg?1",
             "name": "Now for Wrath, Now for Ruin!",
             "text": "",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "2ad5a4d0-5e54-5715-97c3-d10c46e92df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85708748-40ca-4066-a287-7a6a189ff3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85708748-40ca-4066-a287-7a6a189ff3df.jpg?1",
             "name": "Protector of Gondor",
             "text": "",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "edd3f8d9-d90d-52f0-982b-cffbaaa91d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3fa8a-6c50-4f7f-9ae3-0810eec5e3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3fa8a-6c50-4f7f-9ae3-0810eec5e3db.jpg?1",
             "name": "Reprieve",
             "text": "",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "a0b5488f-f649-5c1f-ab86-c4510d6c4cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75338f49-1f02-4333-87e4-5779ef14e688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75338f49-1f02-4333-87e4-5779ef14e688.jpg?1",
             "name": "Rosie Cotton of South Lane",
             "text": "",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "c12477c2-8713-500c-8ba3-3121812ae1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214c270e-29ca-4d69-bea6-9252ae7707ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214c270e-29ca-4d69-bea6-9252ae7707ad.jpg?1",
             "name": "Samwise the Stouthearted",
             "text": "",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "62a5eae4-59cd-587e-98f6-fd574ee53d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1",
             "name": "Second Breakfast",
             "text": "",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "8db96eb4-371e-50b2-a2ba-3c42df50c682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b687f-2571-4c55-a497-d24b9e18bc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b687f-2571-4c55-a497-d24b9e18bc0f.jpg?1",
             "name": "Shire Shirriff",
             "text": "",
             "colours": [
@@ -1100,7 +1100,7 @@
         },
         {
             "id": "8fc0bb7f-19c7-5f27-ba15-395516531125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e20c2b8-ffe3-4d14-8588-f89719358e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e20c2b8-ffe3-4d14-8588-f89719358e3d.jpg?1",
             "name": "Slip On the Ring",
             "text": "",
             "colours": [
@@ -1132,7 +1132,7 @@
         },
         {
             "id": "d68d0d4f-5216-57eb-8e93-f8dfe3ed626c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79999df-af8c-4724-9631-20eee5a00e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79999df-af8c-4724-9631-20eee5a00e49.jpg?1",
             "name": "Soldier of the Grey Host",
             "text": "",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "3043b5a1-b4ec-553d-85f3-6e18a9498ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acb8240-8e0e-4adf-a884-4986c116e704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acb8240-8e0e-4adf-a884-4986c116e704.jpg?1",
             "name": "Stalwarts of Osgiliath",
             "text": "",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "3a018e50-684e-531f-b1c3-08f674a713a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae65f96-7bfd-4390-88bf-764c26bf4668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae65f96-7bfd-4390-88bf-764c26bf4668.jpg?1",
             "name": "Tale of Tin\u00faviel",
             "text": "",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "8c186cc7-b14f-53f8-979a-c1eb6283a78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da7fc15-f894-496e-ba18-a02d42e9bedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da7fc15-f894-496e-ba18-a02d42e9bedc.jpg?1",
             "name": "Took Reaper",
             "text": "",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "7e33f35e-c2fe-5fcd-a0e3-42a811e79479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf2cd-5b33-4c8a-a610-8e6a15404dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf2cd-5b33-4c8a-a610-8e6a15404dde.jpg?1",
             "name": "War of the Last Alliance",
             "text": "",
             "colours": [
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "1b73e76d-88c8-5cd9-b7cc-abc984c80387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ed2e4b-c732-472a-a589-f1f53086d9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ed2e4b-c732-472a-a589-f1f53086d9ee.jpg?1",
             "name": "Westfold Rider",
             "text": "",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "2be6553a-0be1-541c-9aa6-7e1c92145339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116d4030-acd2-4aa2-8254-aaaff1264459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116d4030-acd2-4aa2-8254-aaaff1264459.jpg?1",
             "name": "You Cannot Pass!",
             "text": "",
             "colours": [
@@ -1372,7 +1372,7 @@
         },
         {
             "id": "3986a32f-44b8-52b4-8d1b-d1e60356d843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e1ec49-ad4f-4623-aeeb-dba07d6e6251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e1ec49-ad4f-4623-aeeb-dba07d6e6251.jpg?1",
             "name": "Arwen's Gift",
             "text": "",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "bbd3058f-54d5-5235-a579-a406aa8a6e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11c04f-6f17-4da4-bbf6-0bd09de6e544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11c04f-6f17-4da4-bbf6-0bd09de6e544.jpg?1",
             "name": "The Bath Song",
             "text": "",
             "colours": [
@@ -1438,7 +1438,7 @@
         },
         {
             "id": "562a96d5-0032-542b-96a0-36d3d3671a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612452e-b8a8-4a5a-82a8-01fd463cfc77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612452e-b8a8-4a5a-82a8-01fd463cfc77.jpg?1",
             "name": "Bewitching Leechcraft",
             "text": "",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "c3c4ac6a-efcd-5a85-a72a-dde842c52b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac63cb-fa4d-4340-8062-1029c8bd5ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac63cb-fa4d-4340-8062-1029c8bd5ec8.jpg?1",
             "name": "Bill Ferny, Bree Swindler",
             "text": "",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "d20f5466-0361-50b3-b16a-2de5c6ca2cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42db2313-b13d-4292-bef2-bf86f989d32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42db2313-b13d-4292-bef2-bf86f989d32f.jpg?1",
             "name": "Birthday Escape",
             "text": "",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "93a4d344-a5c8-5d96-bc7c-c31a24a9b9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9379675-1a32-4e2b-8aaf-5f908c595f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9379675-1a32-4e2b-8aaf-5f908c595f31.jpg?1",
             "name": "Borne Upon a Wind",
             "text": "",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "928e5797-b84a-596c-9f1a-ba1e32d89ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c222577d-a3c7-41d9-b11b-62065bdb98ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c222577d-a3c7-41d9-b11b-62065bdb98ef.jpg?1",
             "name": "Captain of Umbar",
             "text": "",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "7a5833e0-cc55-5f02-a0d0-27d348a4a081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651503a2-5d1e-408a-9cdc-0cee05ab3ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651503a2-5d1e-408a-9cdc-0cee05ab3ef0.jpg?1",
             "name": "Council's Deliberation",
             "text": "",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "2659535e-6a30-55ed-9dc4-9f660f632126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2984bc6-7c12-46e4-8dd3-b23e29a7a7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2984bc6-7c12-46e4-8dd3-b23e29a7a7ec.jpg?1",
             "name": "Deceive the Messenger",
             "text": "",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "aedc2dee-caa0-5957-bb37-d8ae58ec4339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e0b4ff-85b5-485f-a78f-1a58bb343238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e0b4ff-85b5-485f-a78f-1a58bb343238.jpg?1",
             "name": "Dreadful as the Storm",
             "text": "",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "d668c848-9f90-5ee2-a4ef-508b596f52db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62a5e55-fa1b-4c70-9293-740dd513d52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62a5e55-fa1b-4c70-9293-740dd513d52e.jpg?1",
             "name": "Elrond, Lord of Rivendell",
             "text": "",
             "colours": [
@@ -1745,7 +1745,7 @@
         },
         {
             "id": "7e1ba2ce-076e-5859-ae7b-00e7749ac45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9cfcc7-be64-4871-8d52-851e43fe3305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9cfcc7-be64-4871-8d52-851e43fe3305.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "53ae60b7-4e99-5dc4-8bae-7fb0399a752d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1057de-5710-415c-9a51-1d8bd86021a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1057de-5710-415c-9a51-1d8bd86021a3.jpg?1",
             "name": "Glorious Gale",
             "text": "",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "b5abcf92-bf7c-58b8-abab-e33184e8bf91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg?1",
             "name": "Goldberry, River-Daughter",
             "text": "",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "30df98ea-7c04-52f7-bef5-835a90d521a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd89994-bdff-47ca-a65d-10afcc7e773e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd89994-bdff-47ca-a65d-10afcc7e773e.jpg?1",
             "name": "Grey Havens Navigator",
             "text": "",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "8ec4ecf0-c686-559c-9b68-2cc5e6219102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcc27e7-cbe4-45c2-b157-7251a10e7ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcc27e7-cbe4-45c2-b157-7251a10e7ba4.jpg?1",
             "name": "Hithlain Knots",
             "text": "",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "d110cfd7-0211-5f15-8b40-df17ffb582eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7725dc2-2654-4ffb-b6b3-510ae64ec6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7725dc2-2654-4ffb-b6b3-510ae64ec6af.jpg?1",
             "name": "Horses of the Bruinen",
             "text": "",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "b479ff36-4d5a-5fb8-840d-06d9cc81385e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab74cd-978a-49eb-9d38-bc8b472b3cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab74cd-978a-49eb-9d38-bc8b472b3cef.jpg?1",
             "name": "Ioreth of the Healing House",
             "text": "",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "4de0be3a-ce97-58f3-8c3b-e39032b6feae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9c323-ac9b-4864-bd57-81b557f44114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9c323-ac9b-4864-bd57-81b557f44114.jpg?1",
             "name": "Isolation at Orthanc",
             "text": "",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "fb7a277c-1865-5bf6-a76c-87db4e725680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c29762-6859-4564-9e1d-a87fa63b951a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c29762-6859-4564-9e1d-a87fa63b951a.jpg?1",
             "name": "Ithilien Kingfisher",
             "text": "",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "0fa45604-526f-5b99-ba99-5895ab258275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661338ff-a192-4007-a144-63d00f2e9ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661338ff-a192-4007-a144-63d00f2e9ecb.jpg?1",
             "name": "Knights of Dol Amroth",
             "text": "",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "74668c89-536f-51a2-802c-d96904a83eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce44270-a684-4489-9077-521456e6dfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce44270-a684-4489-9077-521456e6dfaa.jpg?1",
             "name": "L\u00f3rien Revealed",
             "text": "",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "7435f2fd-6b30-556f-8cb7-a7b06e53da4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg?1",
             "name": "Lost Isle Calling",
             "text": "",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "1fe36d78-8060-5a7e-8fc9-3bdd9cf4e2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2ee20-abbc-4a9d-8d30-4223242123e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2ee20-abbc-4a9d-8d30-4223242123e8.jpg?1",
             "name": "Meneldor, Swift Savior",
             "text": "",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "26b35b3d-f8f7-5fd0-894b-5413615d995e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c253ee40-41c9-4cb5-a1a3-94b0aaed09d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c253ee40-41c9-4cb5-a1a3-94b0aaed09d4.jpg?1",
             "name": "Nimrodel Watcher",
             "text": "",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "457b4c9c-40e9-5b59-b10c-6a8af0a0e4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa59141a-4645-4316-b714-bbf2c139786e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa59141a-4645-4316-b714-bbf2c139786e.jpg?1",
             "name": "Pelargir Survivor",
             "text": "",
             "colours": [
@@ -2267,7 +2267,7 @@
         },
         {
             "id": "e519bc4f-91fe-516c-b415-30beb8f0c7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg?1",
             "name": "Press the Enemy",
             "text": "",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "9cd1bfa0-4639-5937-97a8-2104fc88e1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg?1",
             "name": "Rangers of Ithilien",
             "text": "",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "c019f61c-6668-5088-af5a-a774aa2ae320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfccbab-29fa-4e92-8919-6cd4815fb655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfccbab-29fa-4e92-8919-6cd4815fb655.jpg?1",
             "name": "Saruman the White",
             "text": "",
             "colours": [
@@ -2377,7 +2377,7 @@
         },
         {
             "id": "704070ea-6537-5cb9-8c51-082d56bfe76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6c23b-e52e-4533-9625-884eb0a4d866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6c23b-e52e-4533-9625-884eb0a4d866.jpg?1",
             "name": "Saruman's Trickery",
             "text": "",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "5ccae70e-2215-5b20-95b3-f75c8e9519a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195821f4-ba3d-4412-930f-f3656b319dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195821f4-ba3d-4412-930f-f3656b319dfd.jpg?1",
             "name": "Scroll of Isildur",
             "text": "",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "c11e1655-c736-5092-91eb-57cd92c5de1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6400e8-7f99-4005-9a92-ffbc359d3871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6400e8-7f99-4005-9a92-ffbc359d3871.jpg?1",
             "name": "Soothing of Sm\u00e9agol",
             "text": "",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "0886a7ac-9776-5815-b032-f40589d37266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca1e1de-b916-445f-b3b2-0f4d0cc7ceeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca1e1de-b916-445f-b3b2-0f4d0cc7ceeb.jpg?1",
             "name": "Stern Scolding",
             "text": "",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "47a23eea-cdb5-5730-913a-df4f23d60faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52884e67-c742-4799-9afd-55bc70b2cf40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52884e67-c742-4799-9afd-55bc70b2cf40.jpg?1",
             "name": "Storm of Saruman",
             "text": "",
             "colours": [
@@ -2541,7 +2541,7 @@
         },
         {
             "id": "28de4ac2-ad7e-5a70-8844-c165747ed8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c50d4c8-2311-4394-b73f-389eb81e898b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c50d4c8-2311-4394-b73f-389eb81e898b.jpg?1",
             "name": "Surrounded by Orcs",
             "text": "",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "6aa7f6c2-6cc7-55b1-97e5-25f697c09270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f97505-c961-4890-acd0-32a63919ac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f97505-c961-4890-acd0-32a63919ac2a.jpg?1",
             "name": "Treason of Isengard",
             "text": "",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "8a2e0bab-8d47-53d3-b711-14d1d34d2d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8e8bb-75a0-4b5e-b4b3-5d8f3795032d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8e8bb-75a0-4b5e-b4b3-5d8f3795032d.jpg?1",
             "name": "The Watcher in the Water",
             "text": "",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "e24e1d5a-5bdf-567a-93ed-918dc8f0341a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adc3bff-0eb1-40e9-b954-5515babd07a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adc3bff-0eb1-40e9-b954-5515babd07a3.jpg?1",
             "name": "Willow-Wind",
             "text": "",
             "colours": [
@@ -2678,7 +2678,7 @@
         },
         {
             "id": "11b3efec-158e-561b-a241-0dcb7476bee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b83aa1-33ce-4b8d-ae5a-72f64eef5f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b83aa1-33ce-4b8d-ae5a-72f64eef5f09.jpg?1",
             "name": "Bitter Downfall",
             "text": "",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "f3997261-240f-5e7e-9130-07a5114f7fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63983d-c36b-4440-b9e1-baaa6c7c0ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63983d-c36b-4440-b9e1-baaa6c7c0ba9.jpg?1",
             "name": "The Black Breath",
             "text": "",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "917d80bd-4a05-5a96-98af-1e90392095cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg?1",
             "name": "Call of the Ring",
             "text": "",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "7c8d4766-9b13-590b-abc0-a284c97d31a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03837-37cc-4f6c-8e22-e3b0ff635462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03837-37cc-4f6c-8e22-e3b0ff635462.jpg?1",
             "name": "Cirith Ungol Patrol",
             "text": "",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "385fccc5-8b07-5118-98a5-a30b6db94991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121c12c4-83ea-463e-8fdf-30718968a2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121c12c4-83ea-463e-8fdf-30718968a2bd.jpg?1",
             "name": "Claim the Precious",
             "text": "",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "e48b284c-585c-5955-8e50-0b49aad3907c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695c05ab-e46e-46c7-bd2e-ef0b2307e449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695c05ab-e46e-46c7-bd2e-ef0b2307e449.jpg?1",
             "name": "Dunland Crebain",
             "text": "",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "0d9f0be7-1ce4-5d3c-8466-b51e78ee838a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e860dd40-07c5-47c3-92a8-1ee95a953c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e860dd40-07c5-47c3-92a8-1ee95a953c2f.jpg?1",
             "name": "Easterling Vanguard",
             "text": "",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "e42ad5d6-01fd-502e-9646-dce09f2178fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddda7d4-0226-404f-8418-f1f5720dcef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddda7d4-0226-404f-8418-f1f5720dcef8.jpg?1",
             "name": "Gollum, Patient Plotter",
             "text": "",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "813a27e0-642a-5290-b1e3-e77e4ade00d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1e790e-ff82-4888-8aee-9986c646241a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1e790e-ff82-4888-8aee-9986c646241a.jpg?1",
             "name": "Gollum's Bite",
             "text": "",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "8ea25c3d-026c-5376-bf97-588d7b813df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aafdb6-1c8c-4fc4-a52e-3e601be7fb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aafdb6-1c8c-4fc4-a52e-3e601be7fb0c.jpg?1",
             "name": "Gorbag of Minas Morgul",
             "text": "",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "b3eca218-38f9-54fe-a254-55061f42865d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c10e93-88eb-46b9-8adc-583661807990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c10e93-88eb-46b9-8adc-583661807990.jpg?1",
             "name": "Gothmog, Morgul Lieutenant",
             "text": "",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "7796e52d-52f2-555e-8f6e-3a746c66339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3bd86b-e8ca-4885-a823-78fb967e6caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3bd86b-e8ca-4885-a823-78fb967e6caf.jpg?1",
             "name": "Gr\u00edma Wormtongue",
             "text": "",
             "colours": [
@@ -3100,7 +3100,7 @@
         },
         {
             "id": "a7f879f2-a554-5e1c-a907-18122e8135e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61b28-afdd-4de9-829b-ffe5ca7c7f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61b28-afdd-4de9-829b-ffe5ca7c7f19.jpg?1",
             "name": "Grond, the Gatebreaker",
             "text": "",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "ca51deab-4471-5c5f-a792-b81c57365dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c6c12-2513-4d1b-acf0-6a1f741d49dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c6c12-2513-4d1b-acf0-6a1f741d49dd.jpg?1",
             "name": "Haunt of the Dead Marshes",
             "text": "",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "01f6ac51-abb5-5518-9956-e010ec943ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf08071-fbf8-463e-9a57-59dbf0280dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf08071-fbf8-463e-9a57-59dbf0280dd8.jpg?1",
             "name": "Isildur's Fateful Strike",
             "text": "",
             "colours": [
@@ -3208,7 +3208,7 @@
         },
         {
             "id": "51c139bd-4a22-53b2-a99a-246cefdbefcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812fee97-e145-4458-b495-bc6ad227335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812fee97-e145-4458-b495-bc6ad227335b.jpg?1",
             "name": "Lash of the Balrog",
             "text": "",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "276fde0f-41ee-500f-820c-40768d893487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87500b92-3d68-42f3-afa9-f8206b2ebcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87500b92-3d68-42f3-afa9-f8206b2ebcbb.jpg?1",
             "name": "Lobelia Sackville-Baggins",
             "text": "",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "db18d235-c31e-5cfd-a140-4b1992f1628a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57815d4-b21f-4ceb-a3f1-73cff5f0e612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57815d4-b21f-4ceb-a3f1-73cff5f0e612.jpg?1",
             "name": "March from the Black Gate",
             "text": "",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "ea035e62-c9a7-5cba-a616-1ffa3a3ddb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f035df-784a-4dc8-b7f5-77139a4e6e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f035df-784a-4dc8-b7f5-77139a4e6e99.jpg?1",
             "name": "Mirkwood Bats",
             "text": "",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "be388ea0-f2cf-5f75-93cc-b629dac2ad2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae2f15a-0629-453e-992c-a199af194a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae2f15a-0629-453e-992c-a199af194a3c.jpg?1",
             "name": "Mordor Muster",
             "text": "",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "935eba1c-d1aa-5336-b9b7-0c35feb34e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648bc8ae-1798-4c2f-a372-0487a90ba4d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648bc8ae-1798-4c2f-a372-0487a90ba4d3.jpg?1",
             "name": "Mordor Trebuchet",
             "text": "",
             "colours": [
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "280a6f6c-9e32-567b-b5ce-f110882e4af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae08177-48ee-4404-834d-d3cd7482ae81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae08177-48ee-4404-834d-d3cd7482ae81.jpg?1",
             "name": "Morgul-Knife Wound",
             "text": "",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "dcefadcd-0490-5ee3-bbf3-7890cddf8838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34f88d7-15a1-434f-88d7-3d4fcf406d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34f88d7-15a1-434f-88d7-3d4fcf406d54.jpg?1",
             "name": "Nasty End",
             "text": "",
             "colours": [
@@ -3485,7 +3485,7 @@
         },
         {
             "id": "14b5deae-0d5a-5050-9b42-8bb5bdd1abf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833936c6-9381-4c0b-a81c-4a938be95040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833936c6-9381-4c0b-a81c-4a938be95040.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "ddc4895d-3043-59dd-bbff-7468e2a55a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a780abd-f276-40d3-b2af-d2e47d858d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a780abd-f276-40d3-b2af-d2e47d858d3d.jpg?1",
             "name": "Oath of the Grey Host",
             "text": "",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "3428febd-4e31-56ff-8dfc-8e3dd035d07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg?1",
             "name": "One Ring to Rule Them All",
             "text": "",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "a99e8451-669e-5dcb-93de-1ceb4d4fefd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c024bae-5631-4e20-ac69-df392ac9e109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c024bae-5631-4e20-ac69-df392ac9e109.jpg?1",
             "name": "Orcish Bowmasters",
             "text": "",
             "colours": [
@@ -3634,7 +3634,7 @@
         },
         {
             "id": "048d6fa3-ead2-5a0e-a977-ad226b356772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fae9ab-2302-4dea-a4e8-701938a0ef09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fae9ab-2302-4dea-a4e8-701938a0ef09.jpg?1",
             "name": "Orcish Medicine",
             "text": "",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "33696a33-914f-5401-a94b-d6aa850bf452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd4d735-8cda-47c1-865b-48b51ac8f666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd4d735-8cda-47c1-865b-48b51ac8f666.jpg?1",
             "name": "Sam's Desperate Rescue",
             "text": "",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "637aec80-1542-50d7-b222-b911f5b08c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg?1",
             "name": "Sauron, the Necromancer",
             "text": "",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "d981753e-7a5d-5fa2-9f25-9d6219c462f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47cab70-55cb-481c-b4cd-32a41251f210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47cab70-55cb-481c-b4cd-32a41251f210.jpg?1",
             "name": "Shadow of the Enemy",
             "text": "",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "14ac9612-6f26-5170-9514-fed07949324b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e69fa8-7339-4bfa-8e35-9cbfe0001d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e69fa8-7339-4bfa-8e35-9cbfe0001d8b.jpg?1",
             "name": "Shelob's Ambush",
             "text": "",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "de2448a1-04fe-5d6a-815e-5b59dcfefaf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ad561c-ccb4-480a-88a4-0555d0ef245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ad561c-ccb4-480a-88a4-0555d0ef245e.jpg?1",
             "name": "Snarling Warg",
             "text": "",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "bc140348-74a3-5d18-a172-b16230a93614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2c8c25-1fa9-4cc4-a378-5eccc25bacf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2c8c25-1fa9-4cc4-a378-5eccc25bacf0.jpg?1",
             "name": "The Torment of Gollum",
             "text": "",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "17763f38-5973-509a-b290-e6ca1de5f440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6539e26-b63b-4725-9407-caaf451de084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6539e26-b63b-4725-9407-caaf451de084.jpg?1",
             "name": "Troll of Khazad-d\u00fbm",
             "text": "",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "185762a4-3f06-50d6-a6d4-2a75b7106056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936421a0-2c2a-4410-941d-4e6b88166bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936421a0-2c2a-4410-941d-4e6b88166bd1.jpg?1",
             "name": "Uruk-hai Berserker",
             "text": "",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "2055d801-2a16-570d-9e00-ef6aeaf8a5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b7d7f8-503d-4660-9a18-6a8e2fcaa25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b7d7f8-503d-4660-9a18-6a8e2fcaa25f.jpg?1",
             "name": "Voracious Fell Beast",
             "text": "",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "c09d214e-e175-5bbb-9319-6edcb7abecbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg?1",
             "name": "Witch-king of Angmar",
             "text": "",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "a8bad690-b02e-5a33-9b63-170766350794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91859de-1983-4c9c-a9e6-289c7dba1eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91859de-1983-4c9c-a9e6-289c7dba1eb4.jpg?1",
             "name": "Battle-Scarred Goblin",
             "text": "",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "f1f05aef-aa21-58cd-9c5d-b12e2ec1da82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcef75-6f98-4233-ae32-6fe41724c8e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcef75-6f98-4233-ae32-6fe41724c8e0.jpg?1",
             "name": "Book of Mazarbul",
             "text": "",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "8c96986c-9f2a-5d5f-9b5d-3501394454e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130f60d0-4fac-4e4e-a938-58f3b96e5335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130f60d0-4fac-4e4e-a938-58f3b96e5335.jpg?1",
             "name": "Breaking of the Fellowship",
             "text": "",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "6e46a0cf-8816-56f8-b537-a6cb67eb9249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef878cb-27b6-47d8-ad11-bd20529b0e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef878cb-27b6-47d8-ad11-bd20529b0e7e.jpg?1",
             "name": "Cast into the Fire",
             "text": "",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "8e1420d4-266b-5e22-b6c9-2e1016885cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg?1",
             "name": "Display of Power",
             "text": "",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "11d6dc8d-063b-5ac4-bf8b-e7e9cdcc4fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd31ce9-9551-4efe-8bd2-b97d8efbf75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd31ce9-9551-4efe-8bd2-b97d8efbf75e.jpg?1",
             "name": "\u00c9omer, Marshal of Rohan",
             "text": "",
             "colours": [
@@ -4221,7 +4221,7 @@
         },
         {
             "id": "92209989-aca4-5241-a0e2-b13f399ce871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920fcaf-4988-4186-962d-cdda25d79e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920fcaf-4988-4186-962d-cdda25d79e7b.jpg?1",
             "name": "\u00c9omer of the Riddermark",
             "text": "",
             "colours": [
@@ -4258,7 +4258,7 @@
         },
         {
             "id": "d8a2117b-facb-54ac-abc1-0791b95c5bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552730c5-e3a6-468f-91b2-82c272dda400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552730c5-e3a6-468f-91b2-82c272dda400.jpg?1",
             "name": "Erebor Flamesmith",
             "text": "",
             "colours": [
@@ -4293,7 +4293,7 @@
         },
         {
             "id": "6466cdca-c4bf-5718-baab-a0d0e8d05a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f81e68-cddd-47f4-b1d1-a297c3298c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f81e68-cddd-47f4-b1d1-a297c3298c25.jpg?1",
             "name": "Erkenbrand, Lord of Westfold",
             "text": "",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "d4c70311-25df-547f-b1cb-252324fea239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b4623-50a0-41f1-ad1e-7dd6ac3852df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b4623-50a0-41f1-ad1e-7dd6ac3852df.jpg?1",
             "name": "Fall of Cair Andros",
             "text": "",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "1f4cdc19-a3bd-5b5d-8d7c-257bf285cb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37be98a4-0cba-46b4-be93-a9805fe77160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37be98a4-0cba-46b4-be93-a9805fe77160.jpg?1",
             "name": "Fear, Fire, Foes!",
             "text": "",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "ed8d98d8-965a-5e80-8e91-473c4aa785e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c321159-43e5-40fc-9f0c-4ecc4f6cfd20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c321159-43e5-40fc-9f0c-4ecc4f6cfd20.jpg?1",
             "name": "Fiery Inscription",
             "text": "",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "ff2f21f3-d76e-5513-b206-d65866f6f30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5871c5-bb94-4803-93ba-cd1a630b00d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5871c5-bb94-4803-93ba-cd1a630b00d6.jpg?1",
             "name": "Fire of Orthanc",
             "text": "",
             "colours": [
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "2bd6ffdf-e892-5c3f-9ed5-749d196ac32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fea0c66-c776-4dc7-a235-f3822521cacd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fea0c66-c776-4dc7-a235-f3822521cacd.jpg?1",
             "name": "Foray of Orcs",
             "text": "",
             "colours": [
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "e30e52e4-c773-53fe-8031-d6ac9fb52a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41c48-0715-49d9-98e5-e82b706da816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41c48-0715-49d9-98e5-e82b706da816.jpg?1",
             "name": "Gimli, Counter of Kills",
             "text": "",
             "colours": [
@@ -4534,7 +4534,7 @@
         },
         {
             "id": "fc9d3454-32ee-59bb-997f-b55efe44e3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999b6c-e501-48d0-ae51-a35b96f996ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999b6c-e501-48d0-ae51-a35b96f996ec.jpg?1",
             "name": "Gimli's Axe",
             "text": "",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "c5f118c8-ed01-5e14-af2f-ac7be7d56a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efde011d-8732-49b3-9204-8b114a3d81ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efde011d-8732-49b3-9204-8b114a3d81ba.jpg?1",
             "name": "Gimli's Fury",
             "text": "",
             "colours": [
@@ -4600,7 +4600,7 @@
         },
         {
             "id": "e43008b2-3cf6-5a9a-9c7b-ea914e184dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868a2aa7-bcaf-409b-8802-d00ee1f2ae77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868a2aa7-bcaf-409b-8802-d00ee1f2ae77.jpg?1",
             "name": "Gl\u00f3in, Dwarf Emissary",
             "text": "",
             "colours": [
@@ -4639,7 +4639,7 @@
         },
         {
             "id": "4dc2bc5e-4ddb-5294-922e-e859db7ac34f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec120dae-8c40-4053-9341-1f7774464634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec120dae-8c40-4053-9341-1f7774464634.jpg?1",
             "name": "Goblin Fireleaper",
             "text": "",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "75cb1797-8b01-5498-a4cc-549cff1f69ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6385e769-f805-499d-9f47-494533362152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6385e769-f805-499d-9f47-494533362152.jpg?1",
             "name": "Grishn\u00e1kh, Brash Instigator",
             "text": "",
             "colours": [
@@ -4711,7 +4711,7 @@
         },
         {
             "id": "d81ddadd-4b84-5ad5-9a5f-3727f153955b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6050cf98-cdce-4825-9ab8-2294a2b63faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6050cf98-cdce-4825-9ab8-2294a2b63faf.jpg?1",
             "name": "Haradrim Spearmaster",
             "text": "",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "d2d4273d-cb74-54da-9029-7a6bd4f11b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg?1",
             "name": "Hew the Entwood",
             "text": "",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "df328f62-4a16-5c81-9185-cf024423f48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8397d13-eeaf-4b4e-b3cd-9a9ac231873a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8397d13-eeaf-4b4e-b3cd-9a9ac231873a.jpg?1",
             "name": "Improvised Club",
             "text": "",
             "colours": [
@@ -4812,7 +4812,7 @@
         },
         {
             "id": "e21ee1b0-c9ff-54d2-ab31-5de26c08d9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d5394-2248-4654-bec5-33b144752586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d5394-2248-4654-bec5-33b144752586.jpg?1",
             "name": "Moria Marauder",
             "text": "",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "467dfbee-9a17-578a-8089-0f6b99084f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6989018c-37b1-4282-a4af-9cc97f160b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6989018c-37b1-4282-a4af-9cc97f160b4d.jpg?1",
             "name": "Oliphaunt",
             "text": "",
             "colours": [
@@ -4885,7 +4885,7 @@
         },
         {
             "id": "ad8ac3d6-5603-56a3-8c64-d6a9865ebcc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33bf593-62e0-491a-a31a-328bce6d8735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33bf593-62e0-491a-a31a-328bce6d8735.jpg?1",
             "name": "Olog-hai Crusher",
             "text": "",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "dbe3c4d2-73e2-562f-b976-fd13e7bce0f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e61a6-c602-4089-ae45-828d8e516a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e61a6-c602-4089-ae45-828d8e516a63.jpg?1",
             "name": "Quarrel's End",
             "text": "",
             "colours": [
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "9f918221-4b14-56f2-a80d-23fea66db3eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7292f7-1c7e-449c-9c52-7584d6a14c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7292f7-1c7e-449c-9c52-7584d6a14c2c.jpg?1",
             "name": "Rally at the Hornburg",
             "text": "",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "93d95103-767c-5f5e-b324-4a893af9bec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06541200-fa4c-4b98-bdc4-44708fd2ddf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06541200-fa4c-4b98-bdc4-44708fd2ddf6.jpg?1",
             "name": "Ranger's Firebrand",
             "text": "",
             "colours": [
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "aa0d762c-8373-50b3-a6f4-0b5da7d4fe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b7606a-6a4c-4bf0-b311-1883383161d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b7606a-6a4c-4bf0-b311-1883383161d2.jpg?1",
             "name": "Relentless Rohirrim",
             "text": "",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "7c5c9212-ade2-5edf-a96b-3d0b176e2489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbcac6-8ac9-44a8-9d1a-03d0799ac253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbcac6-8ac9-44a8-9d1a-03d0799ac253.jpg?1",
             "name": "Rising of the Day",
             "text": "",
             "colours": [
@@ -5085,7 +5085,7 @@
         },
         {
             "id": "e1185b93-4dc4-5121-9e85-46c53fc15c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f506f9f-4c0d-44e8-9f81-8403d808d0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f506f9f-4c0d-44e8-9f81-8403d808d0e4.jpg?1",
             "name": "Rohirrim Lancer",
             "text": "",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "2b64717e-6f69-5426-82ad-a97d16289321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525b727-acde-427b-9c33-20964e8cf613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525b727-acde-427b-9c33-20964e8cf613.jpg?1",
             "name": "Rush the Room",
             "text": "",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "40c2fe04-10c3-5b1d-b4c5-1971f5e79435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b716fcc-c4cc-4987-be82-2897a9888d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b716fcc-c4cc-4987-be82-2897a9888d23.jpg?1",
             "name": "Smite the Deathless",
             "text": "",
             "colours": [
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "371768fc-2054-5681-8329-b670079c9892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a82bc-49f3-4694-b688-808a541146db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a82bc-49f3-4694-b688-808a541146db.jpg?1",
             "name": "Spiteful Banditry",
             "text": "",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "dc505921-b3ef-524c-ad8c-df31b311e425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1bd073-4351-4c56-9b07-4430d0d83084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1bd073-4351-4c56-9b07-4430d0d83084.jpg?1",
             "name": "Swarming of Moria",
             "text": "",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "83d3f0fd-9148-57a7-9c93-e285418bf25f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b0bd0-24ea-45de-a2d3-37bbf6a3e6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b0bd0-24ea-45de-a2d3-37bbf6a3e6f9.jpg?1",
             "name": "There and Back Again",
             "text": "",
             "colours": [
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "3587abca-58c2-5a54-9050-37325d49e3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eeecb9e-fbde-429b-b3da-18a4dbadf6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eeecb9e-fbde-429b-b3da-18a4dbadf6de.jpg?1",
             "name": "Warbeast of Gorgoroth",
             "text": "",
             "colours": [
@@ -5318,7 +5318,7 @@
         },
         {
             "id": "ffbef8ce-0257-590c-8ab4-c5ee8e3e4c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7557170-39a2-49df-823e-958c3eb34801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7557170-39a2-49df-823e-958c3eb34801.jpg?1",
             "name": "Bag End Porter",
             "text": "",
             "colours": [
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "d9b6f57c-b936-52b1-b9fe-a78040752c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391699e-987a-499f-9fec-96f2362760b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391699e-987a-499f-9fec-96f2362760b9.jpg?1",
             "name": "Bombadil's Song",
             "text": "",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "7d8f9dd1-d341-51b0-8087-5d733197f0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c24b5fa-506d-4eaf-881b-bc282c74a16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c24b5fa-506d-4eaf-881b-bc282c74a16c.jpg?1",
             "name": "Brandywine Farmer",
             "text": "",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "f38edf12-2a77-51f5-bfc1-d5fc905d0bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daf449a-5f3e-44fd-968e-55d8517ae797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daf449a-5f3e-44fd-968e-55d8517ae797.jpg?1",
             "name": "Celeborn the Wise",
             "text": "",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "da127948-9346-56b6-a72b-36d33095e583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa57431-39e2-4152-8a30-1c1e8faef153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa57431-39e2-4152-8a30-1c1e8faef153.jpg?1",
             "name": "Chance-Met Elves",
             "text": "",
             "colours": [
@@ -5491,7 +5491,7 @@
         },
         {
             "id": "777c22a7-9c2b-5204-8952-22eff61e3ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71384418-173a-4f77-adab-56e52fa23692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71384418-173a-4f77-adab-56e52fa23692.jpg?1",
             "name": "Delighted Halfling",
             "text": "",
             "colours": [
@@ -5529,7 +5529,7 @@
         },
         {
             "id": "fab00dcb-e13e-59af-9413-136e2cdd62e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630e1e36-2f5d-44d4-9ff2-19ae75295016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630e1e36-2f5d-44d4-9ff2-19ae75295016.jpg?1",
             "name": "D\u00fanedain Rangers",
             "text": "",
             "colours": [
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "d3baabfe-a9c6-5b85-a793-0b414ace96f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616cfb94-3faf-44fe-bf04-e90643765e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616cfb94-3faf-44fe-bf04-e90643765e48.jpg?1",
             "name": "Elven Chorus",
             "text": "",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "9aa5653d-8c32-5782-976b-b7bf2860e198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d135b2-d2b8-499c-84d9-824370c19ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d135b2-d2b8-499c-84d9-824370c19ccc.jpg?1",
             "name": "Elven Farsight",
             "text": "",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "c8874974-d070-5d92-b139-ec11605a5fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b48836-6d37-46eb-8c41-a3eeecc72ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b48836-6d37-46eb-8c41-a3eeecc72ae1.jpg?1",
             "name": "Enraged Huorn",
             "text": "",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "c5c13457-99af-54f6-845a-ce11ac3a476b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4dbf80-187b-40e3-9e0b-526f78d9a34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4dbf80-187b-40e3-9e0b-526f78d9a34e.jpg?1",
             "name": "Entish Restoration",
             "text": "",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "e68ce95f-acfc-545c-974b-b4399a4bca99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7946af6-69ab-47a1-955c-1954a04752df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7946af6-69ab-47a1-955c-1954a04752df.jpg?1",
             "name": "Ent's Fury",
             "text": "",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "2f423dda-aa05-5bab-9b85-9c83a19f1a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaab2c0-ea18-4b2f-b75b-506cbbea97e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaab2c0-ea18-4b2f-b75b-506cbbea97e1.jpg?1",
             "name": "Fall of Gil-galad",
             "text": "",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "f3c66315-195e-5cdd-9ef8-5c326b846d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb0f946-2127-4aa3-88ac-9bd2e94d8983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb0f946-2127-4aa3-88ac-9bd2e94d8983.jpg?1",
             "name": "Fangorn, Tree Shepherd",
             "text": "",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "f221e698-583e-5d98-9de3-84b874881dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df34f21-798f-440d-8b09-ec5b5c0b8c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df34f21-798f-440d-8b09-ec5b5c0b8c12.jpg?1",
             "name": "Galadhrim Bow",
             "text": "",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "77d66745-9063-55bf-8031-2dafe809a239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4603f59-f899-4caf-a874-bf234d2045fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4603f59-f899-4caf-a874-bf234d2045fb.jpg?1",
             "name": "Galadhrim Guide",
             "text": "",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "7c574b96-38e1-500d-8328-3bbe6b64a3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d22d5d-3875-42ff-b51e-c6e21db201f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d22d5d-3875-42ff-b51e-c6e21db201f5.jpg?1",
             "name": "Generous Ent",
             "text": "",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "0768c4b8-f151-580e-b4b7-a307390fe74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c54ee0c-1432-4f20-9a92-2cdfcbab30ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c54ee0c-1432-4f20-9a92-2cdfcbab30ac.jpg?1",
             "name": "Gift of Strands",
             "text": "",
             "colours": [
@@ -5937,7 +5937,7 @@
         },
         {
             "id": "6a4f1adb-db3c-5f85-91f1-96793c29a5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf7a546-8a8b-4396-ab64-9a5b9abffe79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf7a546-8a8b-4396-ab64-9a5b9abffe79.jpg?1",
             "name": "Glorfindel, Dauntless Rescuer",
             "text": "",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "6a7524e1-b528-5098-a6cb-855fafcabd3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b99e0-ffb7-4f98-8ee5-4357bb79dd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b99e0-ffb7-4f98-8ee5-4357bb79dd2e.jpg?1",
             "name": "Last March of the Ents",
             "text": "",
             "colours": [
@@ -6008,7 +6008,7 @@
         },
         {
             "id": "44b27ba5-a476-5814-80b1-66efc71bdcb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg?1",
             "name": "Legolas, Master Archer",
             "text": "",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "55a56fd3-d8df-5bd0-8d5f-4f5a23e66e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347256-2ac4-4b12-b288-0a8d578a1ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347256-2ac4-4b12-b288-0a8d578a1ff2.jpg?1",
             "name": "Long List of the Ents",
             "text": "",
             "colours": [
@@ -6082,7 +6082,7 @@
         },
         {
             "id": "6ac30f60-d016-5b89-889c-538a0470dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3639c1-ebc3-4a0b-ab93-549e45aff0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3639c1-ebc3-4a0b-ab93-549e45aff0f7.jpg?1",
             "name": "Lothl\u00f3rien Lookout",
             "text": "",
             "colours": [
@@ -6117,7 +6117,7 @@
         },
         {
             "id": "6142584c-6ec2-5c7e-ab5f-1a0e22eda8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d179dbbe-9c79-4dbc-955a-5209a3e2745a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d179dbbe-9c79-4dbc-955a-5209a3e2745a.jpg?1",
             "name": "Many Partings",
             "text": "",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "67387d5a-a288-5974-a068-51d6b1b79f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885a3277-ef10-4dcf-ac63-eb8971cd627c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885a3277-ef10-4dcf-ac63-eb8971cd627c.jpg?1",
             "name": "Meriadoc Brandybuck",
             "text": "",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "181a3981-f935-5ea3-8e4c-fce2c2dc4e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad961ba1-c74f-4a44-87fe-b30e2b63e378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad961ba1-c74f-4a44-87fe-b30e2b63e378.jpg?1",
             "name": "Mirkwood Spider",
             "text": "",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "9870b989-dc04-509e-a074-912da74b0d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315d7cc-fc2c-45b1-8340-11ff2af3beb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315d7cc-fc2c-45b1-8340-11ff2af3beb5.jpg?1",
             "name": "Mirrormere Guardian",
             "text": "",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "59122894-4b93-5552-9e9b-52a219322880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fd66d-fa7e-411d-9014-a56caa879d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fd66d-fa7e-411d-9014-a56caa879d93.jpg?1",
             "name": "Mushroom Watchdogs",
             "text": "",
             "colours": [
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "506abb4b-e7d8-536c-a573-7fbb4829e37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5baee8d-88e7-4468-94a9-66ca8e2caf15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5baee8d-88e7-4468-94a9-66ca8e2caf15.jpg?1",
             "name": "Peregrin Took",
             "text": "",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "688a6f7d-d370-5922-9766-608767053b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60dc65-6813-4d57-877b-df195ed00d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60dc65-6813-4d57-877b-df195ed00d00.jpg?1",
             "name": "Pippin's Bravery",
             "text": "",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "9f88d10b-5dd4-579b-bb8d-395132ad74b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b889037f-b95f-4756-80aa-04097d2818c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b889037f-b95f-4756-80aa-04097d2818c3.jpg?1",
             "name": "Quickbeam, Upstart Ent",
             "text": "",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "a140b891-adf9-5f03-b3d3-9af316289b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg?1",
             "name": "Radagast the Brown",
             "text": "",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "e40babfb-a79b-5ded-9cb3-e2d6a4cd87ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b7f493-1b57-4b07-8510-30703282f879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b7f493-1b57-4b07-8510-30703282f879.jpg?1",
             "name": "Revive the Shire",
             "text": "",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "40630572-595c-52e2-8e91-d75e47c2b8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg?1",
             "name": "The Ring Goes South",
             "text": "",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "00281c06-7d6c-5df9-9851-e934d8b22a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bc14f9-c90c-499d-9024-3182d78e0a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bc14f9-c90c-499d-9024-3182d78e0a88.jpg?1",
             "name": "Shortcut to Mushrooms",
             "text": "",
             "colours": [
@@ -6541,7 +6541,7 @@
         },
         {
             "id": "9f3b7ee5-8d4c-5c3f-b5b7-a710593d712c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92cd3884-18d1-4200-b28e-a52349ef37aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92cd3884-18d1-4200-b28e-a52349ef37aa.jpg?1",
             "name": "Shower of Arrows",
             "text": "",
             "colours": [
@@ -6573,7 +6573,7 @@
         },
         {
             "id": "d4f13ffb-ba09-58af-b0c6-c75a928958f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7c41c-f416-457e-91ba-1f338f45eeac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7c41c-f416-457e-91ba-1f338f45eeac.jpg?1",
             "name": "Stew the Coneys",
             "text": "",
             "colours": [
@@ -6605,7 +6605,7 @@
         },
         {
             "id": "4585507b-e37a-5021-b488-ce9561e695c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589b339-9067-4e9b-bfdb-c49f8b3ef2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589b339-9067-4e9b-bfdb-c49f8b3ef2d4.jpg?1",
             "name": "Wose Pathfinder",
             "text": "",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "7774f19e-1737-59b3-8e6a-d50d0ecf21ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca5f48-0117-49d6-8b00-b8482e3545b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca5f48-0117-49d6-8b00-b8482e3545b3.jpg?1",
             "name": "Aragorn, Company Leader",
             "text": "",
             "colours": [
@@ -6682,7 +6682,7 @@
         },
         {
             "id": "3ad5be8a-e07b-5079-b5cf-065b21d60fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d5321-ec09-456c-a9ea-c8ca2cfc6205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d5321-ec09-456c-a9ea-c8ca2cfc6205.jpg?1",
             "name": "Aragorn, the Uniter",
             "text": "",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "585e7eb7-2dd0-5cc2-b11a-916f7bda7bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f92d4-cd1d-4ca7-a6e2-6473b4d3c832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f92d4-cd1d-4ca7-a6e2-6473b4d3c832.jpg?1",
             "name": "Arwen, Mortal Queen",
             "text": "",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "7f7ff3fc-4c48-5358-9405-30a940dbbaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c544e301-13b4-4dec-b65c-d54809bb7736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c544e301-13b4-4dec-b65c-d54809bb7736.jpg?1",
             "name": "Arwen Und\u00f3miel",
             "text": "",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "c875f12e-8b08-5e7c-8a3a-484091016d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416880c3-cefb-45ea-bcc3-2ec7a70c8097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416880c3-cefb-45ea-bcc3-2ec7a70c8097.jpg?1",
             "name": "The Balrog, Durin's Bane",
             "text": "",
             "colours": [
@@ -6849,7 +6849,7 @@
         },
         {
             "id": "f9d57a26-8e57-50d1-86c1-0c4180a647e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527df93e-cc2b-4216-909a-4ada1abcbfd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527df93e-cc2b-4216-909a-4ada1abcbfd3.jpg?1",
             "name": "Bilbo, Retired Burglar",
             "text": "",
             "colours": [
@@ -6890,7 +6890,7 @@
         },
         {
             "id": "e6015db1-0a99-5f93-ac3d-9c8cb6d5c36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3fd9ff1-278b-4e6a-b30b-90250d8b5762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3fd9ff1-278b-4e6a-b30b-90250d8b5762.jpg?1",
             "name": "Butterbur, Bree Innkeeper",
             "text": "",
             "colours": [
@@ -6929,7 +6929,7 @@
         },
         {
             "id": "745d595a-274f-5e5f-a679-b644381be34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8654cf-431c-427b-b78f-0e48f6007e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8654cf-431c-427b-b78f-0e48f6007e9e.jpg?1",
             "name": "Denethor, Ruling Steward",
             "text": "",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "21220aa5-453c-59cb-a8d5-6b31f7df1838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd8813-4aaf-48bf-9243-3ec4099b8372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd8813-4aaf-48bf-9243-3ec4099b8372.jpg?1",
             "name": "Doors of Durin",
             "text": "",
             "colours": [
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "1a24e767-e41b-5fd9-9c58-bac026ffb8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26ffb2c-f7a5-4a4f-9b99-c8de9dfd49da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26ffb2c-f7a5-4a4f-9b99-c8de9dfd49da.jpg?1",
             "name": "Elrond, Master of Healing",
             "text": "",
             "colours": [
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "5999091a-16e1-5560-9de1-238c7afc673d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffb389-c9a3-41c4-b078-292a2bcf870d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffb389-c9a3-41c4-b078-292a2bcf870d.jpg?1",
             "name": "\u00c9owyn, Fearless Knight",
             "text": "",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "59a8387e-cb7c-5d4f-96f1-ede9e6bbe4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700923a-e9ff-4ced-87fe-1ab26554623a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700923a-e9ff-4ced-87fe-1ab26554623a.jpg?1",
             "name": "Faramir, Prince of Ithilien",
             "text": "",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "8aa4f067-2ae2-5cc0-bb2e-cece106e3190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04779a7e-b453-48b9-b392-6d6fd0b8d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04779a7e-b453-48b9-b392-6d6fd0b8d283.jpg?1",
             "name": "Flame of Anor",
             "text": "",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "f970838a-20a5-5735-85d8-d8eb6c292c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24076763-88ba-4dee-b548-9c27bd34fdb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24076763-88ba-4dee-b548-9c27bd34fdb7.jpg?1",
             "name": "Friendly Rivalry",
             "text": "",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "6c26c3b2-9c45-51b8-81fa-baa1adce0e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0399-9db8-4901-b72e-0010eb9b92b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0399-9db8-4901-b72e-0010eb9b92b0.jpg?1",
             "name": "Frodo Baggins",
             "text": "",
             "colours": [
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "5887a825-058a-59af-9e4c-0714514ab167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5c3b3-9a70-4a1c-bfb3-db27e51c4b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5c3b3-9a70-4a1c-bfb3-db27e51c4b8d.jpg?1",
             "name": "Galadriel of Lothl\u00f3rien",
             "text": "",
             "colours": [
@@ -7286,7 +7286,7 @@
         },
         {
             "id": "201594d1-4828-5a29-995b-7f6c6dc6c2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b975e6-e709-481f-bfbc-41a832508283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b975e6-e709-481f-bfbc-41a832508283.jpg?1",
             "name": "Gandalf the Grey",
             "text": "",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "45f6b0b7-ea9b-51ec-b5b0-dd0efbab711b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebf2a25-9bee-4146-af83-f22aab6db2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebf2a25-9bee-4146-af83-f22aab6db2a8.jpg?1",
             "name": "Gandalf's Sanction",
             "text": "",
             "colours": [
@@ -7361,7 +7361,7 @@
         },
         {
             "id": "891d6f34-c369-51af-bb68-96e42a931e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4be38c-3f93-4ff4-bff4-94753b96f2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4be38c-3f93-4ff4-bff4-94753b96f2f3.jpg?1",
             "name": "Gimli, Mournful Avenger",
             "text": "",
             "colours": [
@@ -7403,7 +7403,7 @@
         },
         {
             "id": "66fe976b-6bd1-5f03-a5e4-ddd183d5e8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a42c951-1146-4f49-a690-7d385962b191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a42c951-1146-4f49-a690-7d385962b191.jpg?1",
             "name": "Gwaihir the Windlord",
             "text": "",
             "colours": [
@@ -7442,7 +7442,7 @@
         },
         {
             "id": "bb79e5e2-40e4-5e28-aad2-7ea6fc012b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857755-62e6-4d29-95f5-82f5d4bde522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857755-62e6-4d29-95f5-82f5d4bde522.jpg?1",
             "name": "King of the Oathbreakers",
             "text": "",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "0189f201-541e-5408-98c4-ba8b21fa58fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bd408c-9e6d-436d-9c4f-9ef3203aeb64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bd408c-9e6d-436d-9c4f-9ef3203aeb64.jpg?1",
             "name": "Legolas, Counter of Kills",
             "text": "",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "b204188d-e58c-5c9d-b824-115b823a692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce01ff8f-a037-484f-9148-c847ffaabc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce01ff8f-a037-484f-9148-c847ffaabc5a.jpg?1",
             "name": "Lotho, Corrupt Shirriff",
             "text": "",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "fb4b8ca4-ba42-5534-89b2-3074d534ce31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e9a757-7ed4-4cc0-bb6f-a59fa69b32a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e9a757-7ed4-4cc0-bb6f-a59fa69b32a5.jpg?1",
             "name": "Mauh\u00far, Uruk-hai Captain",
             "text": "",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "0c710a11-2ebc-5af8-a3ee-c14f9a2fe853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5fe73-1684-4edc-9f9b-976b2246d5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5fe73-1684-4edc-9f9b-976b2246d5ea.jpg?1",
             "name": "Merry, Esquire of Rohan",
             "text": "",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "46dbd044-1564-565f-bdcc-df602337b431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a88814-aa30-4297-b338-3d851bfe7256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a88814-aa30-4297-b338-3d851bfe7256.jpg?1",
             "name": "The Mouth of Sauron",
             "text": "",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "24c7a4f6-7955-52da-865b-22224297b3b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0362b7c4-fff5-4bc2-b32d-913f85c23cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0362b7c4-fff5-4bc2-b32d-913f85c23cc4.jpg?1",
             "name": "Old Man Willow",
             "text": "",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "5e3b012e-dfa5-5be4-9481-6e55c8345b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg?1",
             "name": "Pippin, Guard of the Citadel",
             "text": "",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "959f66ce-b87a-56cb-98da-e9bec5fd63f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d486def-7c3f-41e9-bb28-4582450a7b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d486def-7c3f-41e9-bb28-4582450a7b9e.jpg?1",
             "name": "Prince Imrahil the Fair",
             "text": "",
             "colours": [
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "dd1c0411-6333-54c3-94a1-f48bc5adce87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a65c-6f54-4d56-9c6f-8364c45a058c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a65c-6f54-4d56-9c6f-8364c45a058c.jpg?1",
             "name": "Ringsight",
             "text": "",
             "colours": [
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "21909cc1-0827-5704-81a8-a61a6caf417b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f440fa1-5387-41d6-a80f-5b19dbb21514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f440fa1-5387-41d6-a80f-5b19dbb21514.jpg?1",
             "name": "Rise of the Witch-king",
             "text": "",
             "colours": [
@@ -7875,7 +7875,7 @@
         },
         {
             "id": "9ab2a77a-e7fc-5e5c-ae40-d23ffe605089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b6f13e-63d0-46bf-aa57-23c2dbdf62dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b6f13e-63d0-46bf-aa57-23c2dbdf62dd.jpg?1",
             "name": "Samwise Gamgee",
             "text": "",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "7a3f0093-51cb-563e-8606-391f7d9222e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfcc7ec-87a2-4712-8d82-217bd8600891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfcc7ec-87a2-4712-8d82-217bd8600891.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -7961,7 +7961,7 @@
         },
         {
             "id": "090129f4-bf9c-5fb9-a592-288f1ed0c486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0929-b2c7-4b5f-94f2-8eaf4fb1a2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0929-b2c7-4b5f-94f2-8eaf4fb1a2a1.jpg?1",
             "name": "Sauron, the Dark Lord",
             "text": "",
             "colours": [
@@ -8004,7 +8004,7 @@
         },
         {
             "id": "56a37820-f546-5796-b5d5-eede345852fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b98850c-ad69-42da-b91a-8dc5e226c444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b98850c-ad69-42da-b91a-8dc5e226c444.jpg?1",
             "name": "Sauron's Ransom",
             "text": "",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "faf4bf7c-6195-5285-9b8a-b51f6deb7bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0984b2-bed6-41b1-9087-2cfd16749037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0984b2-bed6-41b1-9087-2cfd16749037.jpg?1",
             "name": "Shadow Summoning",
             "text": "",
             "colours": [
@@ -8074,7 +8074,7 @@
         },
         {
             "id": "092e1a40-7baf-5117-9135-da4fa23dd4df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d861d-7832-4c15-8d6c-8c07a9a57891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d861d-7832-4c15-8d6c-8c07a9a57891.jpg?1",
             "name": "Shadowfax, Lord of Horses",
             "text": "",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "28b2ace9-8e4f-574d-9f7b-ecee026085c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0731f64a-15da-4814-82e9-3a42e1657f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0731f64a-15da-4814-82e9-3a42e1657f36.jpg?1",
             "name": "Shagrat, Loot Bearer",
             "text": "",
             "colours": [
@@ -8153,7 +8153,7 @@
         },
         {
             "id": "b803bff5-785f-5bd8-9648-4b0659bd982e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e446bd-8295-4fca-957a-e4710a15d8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e446bd-8295-4fca-957a-e4710a15d8e8.jpg?1",
             "name": "Sharkey, Tyrant of the Shire",
             "text": "",
             "colours": [
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "4cc7aaf3-99c2-5eac-92d3-ff87fed3baa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c4b29-3363-45ce-9190-0f79e1a0ef7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c4b29-3363-45ce-9190-0f79e1a0ef7f.jpg?1",
             "name": "Shelob, Child of Ungoliant",
             "text": "",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "0c0b7035-e342-5cc5-9617-1e20852a12a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13253f8d-1897-41e8-a904-9e57ac7eff0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13253f8d-1897-41e8-a904-9e57ac7eff0a.jpg?1",
             "name": "Sm\u00e9agol, Helpful Guide",
             "text": "",
             "colours": [
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "2ebdaac2-6699-5cc3-9a54-e9bee7a05576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54461d61-a745-467f-9fbe-b5e7a8edbdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54461d61-a745-467f-9fbe-b5e7a8edbdbf.jpg?1",
             "name": "Strider, Ranger of the North",
             "text": "",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "8c9345d9-7983-5534-a1f9-aa99be3d4f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcd1ca-4943-46e4-bb5d-c14949e21e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcd1ca-4943-46e4-bb5d-c14949e21e23.jpg?1",
             "name": "Th\u00e9oden, King of Rohan",
             "text": "",
             "colours": [
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "824274bf-fd35-533f-824c-b51480baff76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab04c49-76a1-4896-8dca-8cb4c615f489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab04c49-76a1-4896-8dca-8cb4c615f489.jpg?1",
             "name": "Tom Bombadil",
             "text": "",
             "colours": [
@@ -8402,7 +8402,7 @@
         },
         {
             "id": "ea65d73c-b863-5c58-be73-5be7cd5ab1e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e914c7fc-be3c-4346-bf37-6e10f4998204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e914c7fc-be3c-4346-bf37-6e10f4998204.jpg?1",
             "name": "Ugl\u00fak of the White Hand",
             "text": "",
             "colours": [
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "548d68d4-152f-5994-bb8c-2287aba8637c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7b9eea-a224-4db1-a089-cb385f7af20c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7b9eea-a224-4db1-a089-cb385f7af20c.jpg?1",
             "name": "And\u00faril, Flame of the West",
             "text": "",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "f955c7de-4395-582c-b8a3-76d963b19f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb7284-78a5-4b5e-8f6d-6be540e0bef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb7284-78a5-4b5e-8f6d-6be540e0bef8.jpg?1",
             "name": "Barrow-Blade",
             "text": "",
             "colours": [],
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "56b1f40a-a555-5c90-9720-27e091df4fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1500126f-fbe4-4c39-bb06-1a36e2c4682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1500126f-fbe4-4c39-bb06-1a36e2c4682f.jpg?1",
             "name": "Ent-Draught Basin",
             "text": "",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "b817eb9d-48e7-5b63-bf2d-438469e3eb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296ebf7-45ed-4b38-acf2-b48d9fb3e706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296ebf7-45ed-4b38-acf2-b48d9fb3e706.jpg?1",
             "name": "Glamdring",
             "text": "",
             "colours": [],
@@ -8568,7 +8568,7 @@
         },
         {
             "id": "f31869fb-59b9-5b3a-a6c3-0a02f4d41ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14eaeec-d7ce-462a-90d3-2ae5ff605fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14eaeec-d7ce-462a-90d3-2ae5ff605fdb.jpg?1",
             "name": "Horn of Gondor",
             "text": "",
             "colours": [],
@@ -8600,7 +8600,7 @@
         },
         {
             "id": "ca77a15a-f7f5-5c2c-b86f-873219c6400c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd86b71f-d736-426f-bf15-013bc8da1a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd86b71f-d736-426f-bf15-013bc8da1a08.jpg?1",
             "name": "Horn of the Mark",
             "text": "",
             "colours": [],
@@ -8632,7 +8632,7 @@
         },
         {
             "id": "680df12c-678d-5ee8-857f-99e923a363ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b590d028-ea6a-4550-b5e2-ba328a81bbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b590d028-ea6a-4550-b5e2-ba328a81bbc0.jpg?1",
             "name": "Inherited Envelope",
             "text": "",
             "colours": [],
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "c1765f91-dfe1-5ca5-915d-5288bac252d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b46aacf-b31a-4380-9e4b-82795fbaba3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b46aacf-b31a-4380-9e4b-82795fbaba3b.jpg?1",
             "name": "Lembas",
             "text": "",
             "colours": [],
@@ -8690,7 +8690,7 @@
         },
         {
             "id": "09abd31e-00fa-57e1-b930-dd8b8a176bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95036f-98f2-4ea7-93bb-542ad7064540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95036f-98f2-4ea7-93bb-542ad7064540.jpg?1",
             "name": "Mirror of Galadriel",
             "text": "",
             "colours": [],
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "aba95144-6c94-5ed0-ab52-6861bea46fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd1fc09-a09d-45e6-8a07-3a8a83b4e6ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd1fc09-a09d-45e6-8a07-3a8a83b4e6ec.jpg?1",
             "name": "Mithril Coat",
             "text": "",
             "colours": [],
@@ -8754,7 +8754,7 @@
         },
         {
             "id": "78a27b2c-c2ae-5e62-a5a1-af239e8b4c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5806e68-1054-458e-866d-1f2470f682b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5806e68-1054-458e-866d-1f2470f682b2.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "9b7b3c79-5b36-588b-989b-08449c1be334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb6a69-562c-4d95-858d-b067444cfd7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb6a69-562c-4d95-858d-b067444cfd7e.jpg?1",
             "name": "Palant\u00edr of Orthanc",
             "text": "",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "43a67d67-3bb9-547d-9280-84c735d5010d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d60fe-681b-495e-813c-c8418f3f29e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d60fe-681b-495e-813c-c8418f3f29e5.jpg?1",
             "name": "Phial of Galadriel",
             "text": "",
             "colours": [],
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "661e5b7a-5787-54e3-a3fd-433ae6c94ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60b4f2e-ff47-4762-a803-30e81b665c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60b4f2e-ff47-4762-a803-30e81b665c09.jpg?1",
             "name": "Shire Scarecrow",
             "text": "",
             "colours": [],
@@ -8883,7 +8883,7 @@
         },
         {
             "id": "39ab81ef-0c7a-59d9-9df4-e7073a97e159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbec7e7-f5b9-407e-bf96-2e088710e791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbec7e7-f5b9-407e-bf96-2e088710e791.jpg?1",
             "name": "Sting, the Glinting Dagger",
             "text": "",
             "colours": [],
@@ -8917,7 +8917,7 @@
         },
         {
             "id": "8bb09cbb-443d-5422-90b4-b1a939fa71a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc02e193-df33-4eb1-adc1-b51ee931218a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc02e193-df33-4eb1-adc1-b51ee931218a.jpg?1",
             "name": "Stone of Erech",
             "text": "",
             "colours": [],
@@ -8947,7 +8947,7 @@
         },
         {
             "id": "d796f25b-eeda-534a-9c93-e2c8ed509968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ed742-dfb1-41e2-8f19-184555109e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ed742-dfb1-41e2-8f19-184555109e34.jpg?1",
             "name": "Wizard's Rockets",
             "text": "",
             "colours": [],
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "aed39ba4-ac8d-5640-9661-c18502c1a4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5038af-06b0-401e-8dea-a1a8483788ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5038af-06b0-401e-8dea-a1a8483788ae.jpg?1",
             "name": "Barad-d\u00fbr",
             "text": "",
             "colours": [],
@@ -9012,7 +9012,7 @@
         },
         {
             "id": "647201cf-d6dc-5d6c-9348-e5350bd2c697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c7b57-b62b-42d1-85d9-4b57624a3f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c7b57-b62b-42d1-85d9-4b57624a3f54.jpg?1",
             "name": "Great Hall of the Citadel",
             "text": "",
             "colours": [],
@@ -9040,7 +9040,7 @@
         },
         {
             "id": "8465e7ef-4a81-5e9b-815b-a8db94214774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd698f10-b0fc-42fc-84ec-f5a0d96bfa1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd698f10-b0fc-42fc-84ec-f5a0d96bfa1d.jpg?1",
             "name": "The Grey Havens",
             "text": "",
             "colours": [],
@@ -9072,7 +9072,7 @@
         },
         {
             "id": "6cf7db9d-778e-5b35-9653-5870c438a98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38b6760-616f-4b11-8ce7-ac1223c7fd53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38b6760-616f-4b11-8ce7-ac1223c7fd53.jpg?1",
             "name": "Minas Tirith",
             "text": "",
             "colours": [],
@@ -9107,7 +9107,7 @@
         },
         {
             "id": "0e0ce59d-4a6b-5c04-968e-a9fa7fde6119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723d6-4ada-4c3f-b87b-8ab83a4bbb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723d6-4ada-4c3f-b87b-8ab83a4bbb8f.jpg?1",
             "name": "Mines of Moria",
             "text": "",
             "colours": [],
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "dcc21aef-945e-5532-9efd-a7e7fd86932b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg?1",
             "name": "Mount Doom",
             "text": "",
             "colours": [],
@@ -9177,7 +9177,7 @@
         },
         {
             "id": "dbab4b26-fa75-544a-8124-6f2eaba4186d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacd500c-1389-4314-a53e-0ad510d6fb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacd500c-1389-4314-a53e-0ad510d6fb79.jpg?1",
             "name": "Rivendell",
             "text": "",
             "colours": [],
@@ -9211,7 +9211,7 @@
         },
         {
             "id": "f8aa140c-16cc-5f05-af64-313e5afad680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5178a1b-588b-4414-a370-ac6eed51187a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5178a1b-588b-4414-a370-ac6eed51187a.jpg?1",
             "name": "The Shire",
             "text": "",
             "colours": [],
@@ -9245,7 +9245,7 @@
         },
         {
             "id": "cb082690-5abc-50a0-83df-c95de4462a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25932483-58cd-4ae5-82bf-ab455177d117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25932483-58cd-4ae5-82bf-ab455177d117.jpg?1",
             "name": "Shire Terrace",
             "text": "",
             "colours": [],
@@ -9273,7 +9273,7 @@
         },
         {
             "id": "19879902-f0c5-53aa-b4c1-e7893804102b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f724ae86-b968-4f49-8267-c2c34c22f1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f724ae86-b968-4f49-8267-c2c34c22f1b6.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9311,7 +9311,7 @@
         },
         {
             "id": "5323a02e-4b51-5846-b965-b738e1bfd1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb495cc-9908-455e-bec9-3993d595f4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb495cc-9908-455e-bec9-3993d595f4f9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9349,7 +9349,7 @@
         },
         {
             "id": "58915ced-ae13-5ffa-9034-73c7ffeab8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeca27a-6c5b-40b9-83a4-a3a2096ff6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeca27a-6c5b-40b9-83a4-a3a2096ff6f8.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "5a126d7d-7224-5ffd-b748-127fe7ba6143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671516eb-b088-4a15-aec9-1781ca016e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671516eb-b088-4a15-aec9-1781ca016e11.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "22d9a3af-9586-5a7b-ac8a-8f445666d5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0fba6e-54d2-498c-83bc-41024307e608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0fba6e-54d2-498c-83bc-41024307e608.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9463,7 +9463,7 @@
         },
         {
             "id": "dd5b7377-ab8d-525a-9ba1-905e7557340f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86cd8fb-4ba7-4311-b0f3-b06fa112eda5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86cd8fb-4ba7-4311-b0f3-b06fa112eda5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9501,7 +9501,7 @@
         },
         {
             "id": "de2b1817-4044-5900-897f-dc6be40a23ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3731001-4e6a-4a91-9e7d-fc2ea039a60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3731001-4e6a-4a91-9e7d-fc2ea039a60b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "d47fcdea-cd66-508b-a78b-c4ac424fe1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf13285-d127-4534-9f49-aa86914da175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf13285-d127-4534-9f49-aa86914da175.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9577,7 +9577,7 @@
         },
         {
             "id": "dbe1201b-4cd7-5169-9a5e-c2c0d79fc5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe793e4-c034-4a22-929d-d743c0255bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe793e4-c034-4a22-929d-d743c0255bf1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9615,7 +9615,7 @@
         },
         {
             "id": "71e17af3-ed2c-5b7e-b556-ce1a5c500b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07264de1-4322-4adb-8f08-c0aa236747c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07264de1-4322-4adb-8f08-c0aa236747c7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9653,7 +9653,7 @@
         },
         {
             "id": "47bc6508-fbe0-5da8-906d-a24856d9aa56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9fbf5-de6f-4ef9-a6ab-56da4b341b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9fbf5-de6f-4ef9-a6ab-56da4b341b77.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9691,7 +9691,7 @@
         },
         {
             "id": "0dbc5f13-d6d0-5d84-bf3a-4758ccb1bc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8538a97f-302d-468a-8a6c-50c800d614e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8538a97f-302d-468a-8a6c-50c800d614e5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "fd4ad7c0-5271-5da6-8b87-a9b6c8fc8ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0c7c5-ed63-41a5-93e1-a979a6f983b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0c7c5-ed63-41a5-93e1-a979a6f983b9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9767,7 +9767,7 @@
         },
         {
             "id": "dfc1cadb-f399-5273-a613-f2eda5a44e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee8302-39ca-43c3-b139-62e591559306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee8302-39ca-43c3-b139-62e591559306.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9805,7 +9805,7 @@
         },
         {
             "id": "17efcc65-d71d-5928-8e8d-84a17c792204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f68bc-1842-4efd-b85a-d897cfd63bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f68bc-1842-4efd-b85a-d897cfd63bde.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9843,7 +9843,7 @@
         },
         {
             "id": "515d91ec-654c-5d4f-8316-e28c6b260418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d412d727-4fe8-4c21-a2cb-609395935dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d412d727-4fe8-4c21-a2cb-609395935dd8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "8dfaa766-5d3c-50ab-9074-f46622ccf1c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1902b98-7579-4b7a-8cb8-9bd0e0da5f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1902b98-7579-4b7a-8cb8-9bd0e0da5f67.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "58dbbe79-4466-51d1-a296-be45b544a036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1b83d9-078b-44dc-a118-4659201f4854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1b83d9-078b-44dc-a118-4659201f4854.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9957,7 +9957,7 @@
         },
         {
             "id": "4d7c9fb7-7502-5842-8070-8a8f989e129e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b488e-d725-4ef7-90f4-71091325c0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b488e-d725-4ef7-90f4-71091325c0b6.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "c03c4c6f-a319-5f74-a542-a5f462fc4f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efeaa30-9db9-4e68-a658-9064d6e67516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efeaa30-9db9-4e68-a658-9064d6e67516.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "c7df7048-2e3a-5192-9d25-4a834ee1f04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65a1fb5-cc2c-4556-b109-05c3d966ded9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65a1fb5-cc2c-4556-b109-05c3d966ded9.jpg?1",
             "name": "Saradoc, Master of Buckland",
             "text": "",
             "colours": [
@@ -10071,7 +10071,7 @@
         },
         {
             "id": "fb85173e-e30c-5b5d-8b0e-b18ab219e9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604d357-4196-421f-a5c3-c7cbe79f35cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604d357-4196-421f-a5c3-c7cbe79f35cb.jpg?1",
             "name": "Elvish Mariner",
             "text": "",
             "colours": [
@@ -10107,7 +10107,7 @@
         },
         {
             "id": "4a162e51-288f-5284-a2b3-46ef677bc05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8495c3-96cf-40ab-b68a-1b5711b7659e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8495c3-96cf-40ab-b68a-1b5711b7659e.jpg?1",
             "name": "Ringwraiths",
             "text": "",
             "colours": [
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "3705f3e4-3899-5a6c-90e6-e81eb7068da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2549b70a-6bd0-4c9b-96b7-4ab775a30cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2549b70a-6bd0-4c9b-96b7-4ab775a30cd3.jpg?1",
             "name": "Assault on Osgiliath",
             "text": "",
             "colours": [
@@ -10176,7 +10176,7 @@
         },
         {
             "id": "15daffdb-78f2-58f3-bde9-0bb60d777c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165eb73-49a8-4337-aa5d-7d9d48b916c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165eb73-49a8-4337-aa5d-7d9d48b916c9.jpg?1",
             "name": "Elanor Gardner",
             "text": "",
             "colours": [
@@ -10214,7 +10214,7 @@
         },
         {
             "id": "66208885-03b9-5005-85a9-00bcc3ef3515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d4c97a-9319-4534-9a49-da000f41a02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d4c97a-9319-4534-9a49-da000f41a02d.jpg?1",
             "name": "Aragorn and Arwen, Wed",
             "text": "",
             "colours": [
@@ -10255,7 +10255,7 @@
         },
         {
             "id": "f7ecd2d6-6234-5a19-a49c-50f88cf7add3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82a4c78-d2fc-425a-8d0e-2e64509a08f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82a4c78-d2fc-425a-8d0e-2e64509a08f1.jpg?1",
             "name": "Sauron, the Lidless Eye",
             "text": "",
             "colours": [
@@ -10295,7 +10295,7 @@
         },
         {
             "id": "21d22fde-eb11-57a5-b00c-b5eb6f7bdcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d1b37c-a8c6-4690-8701-3395397711e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d1b37c-a8c6-4690-8701-3395397711e7.jpg?1",
             "name": "Frodo, Determined Hero",
             "text": "",
             "colours": [
@@ -10333,7 +10333,7 @@
         },
         {
             "id": "0c4cb33e-70f6-5878-8856-e29ffb2f0330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b422ce26-06fb-4748-9c01-32c4be914a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b422ce26-06fb-4748-9c01-32c4be914a77.jpg?1",
             "name": "Gandalf, White Rider",
             "text": "",
             "colours": [
@@ -10371,7 +10371,7 @@
         },
         {
             "id": "1176361c-4666-5c18-aaab-6948c3612fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af21576-3793-4796-ab60-112fbbb5fc0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af21576-3793-4796-ab60-112fbbb5fc0d.jpg?1",
             "name": "Knight of the Keep",
             "text": "",
             "colours": [
@@ -10405,7 +10405,7 @@
         },
         {
             "id": "be70f91b-088e-560f-8cd6-4189b7e6670d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg?1",
             "name": "Gollum, Scheming Guide",
             "text": "",
             "colours": [
@@ -10443,7 +10443,7 @@
         },
         {
             "id": "4efce628-10be-5529-8301-6d3d99a9ab72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da1d3e-dbcb-4b1e-a606-d4fc1a60a8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da1d3e-dbcb-4b1e-a606-d4fc1a60a8fe.jpg?1",
             "name": "Witch-king, Bringer of Ruin",
             "text": "",
             "colours": [
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "5088fbe4-c82a-5bec-8962-6d014f8d46c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg?1",
             "name": "Fires of Mount Doom",
             "text": "",
             "colours": [
@@ -10516,7 +10516,7 @@
         },
         {
             "id": "9e84037f-9baf-53c7-b31e-43706b823828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bda198-7ab4-4c6b-9fb1-93ac54c06a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bda198-7ab4-4c6b-9fb1-93ac54c06a85.jpg?1",
             "name": "Goblin Assailant",
             "text": "",
             "colours": [
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "ca74febf-c641-592e-adad-af09d8a7e21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8229264e-af6c-4f1f-b86a-257889ace9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8229264e-af6c-4f1f-b86a-257889ace9ce.jpg?1",
             "name": "Galadriel, Gift-Giver",
             "text": "",
             "colours": [
@@ -10588,7 +10588,7 @@
         },
         {
             "id": "eb3cb717-1584-521a-9d6b-f702add80323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905e7424-2d0b-4877-a7dc-272ea9392ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905e7424-2d0b-4877-a7dc-272ea9392ff0.jpg?1",
             "name": "The Balrog, Flame of Ud\u00fbn",
             "text": "",
             "colours": [
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "15df7bd2-82f4-5ba4-9e08-a16296f92f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91dbeac4-1c39-4a4f-84e7-1b71f7468c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91dbeac4-1c39-4a4f-84e7-1b71f7468c8f.jpg?1",
             "name": "Bilbo's Ring",
             "text": "",
             "colours": [],
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "2f4bd8b0-a5b0-543d-b139-c6ad4621fbae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae4a761-6203-419c-8d49-499b6e74252c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae4a761-6203-419c-8d49-499b6e74252c.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -10702,7 +10702,7 @@
         },
         {
             "id": "d1dddf8e-94bc-5890-80d4-fe061e42bc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853e4841-7e2f-4f0c-8f4f-cbfac22c298c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853e4841-7e2f-4f0c-8f4f-cbfac22c298c.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "1acdf41c-5157-5476-bd33-2adcb454dd08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e186ef93-f369-4b4d-a683-36f338b6ce3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e186ef93-f369-4b4d-a683-36f338b6ce3f.jpg?1",
             "name": "Boromir, Warden of the Tower",
             "text": "",
             "colours": [
@@ -10786,7 +10786,7 @@
         },
         {
             "id": "733a458c-6a15-5e1a-81b2-219dd7e3d789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008b953a-da2b-4c30-9424-6d6e3e938251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008b953a-da2b-4c30-9424-6d6e3e938251.jpg?1",
             "name": "Faramir, Field Commander",
             "text": "",
             "colours": [
@@ -10825,7 +10825,7 @@
         },
         {
             "id": "f613f7cc-5533-5004-9334-5bbd09ba6a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d08e637-c2b3-4b38-9b07-5bba1f13efc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d08e637-c2b3-4b38-9b07-5bba1f13efc3.jpg?1",
             "name": "Frodo, Sauron's Bane",
             "text": "",
             "colours": [
@@ -10866,7 +10866,7 @@
         },
         {
             "id": "7869ca48-3ef0-5dad-ab8e-9ef2bd9d5c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9dc67a-5c26-4044-82b6-d5b6e195ae64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9dc67a-5c26-4044-82b6-d5b6e195ae64.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "e319f976-55ab-5e73-b885-a4711ff72454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c6a273-9307-432a-96f5-3e536da70f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c6a273-9307-432a-96f5-3e536da70f95.jpg?1",
             "name": "Samwise the Stouthearted",
             "text": "",
             "colours": [
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "56707047-134f-588a-96b0-6a93f8769e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308465a9-2143-49f2-b9d0-a09272dd1b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308465a9-2143-49f2-b9d0-a09272dd1b62.jpg?1",
             "name": "Elrond, Lord of Rivendell",
             "text": "",
             "colours": [
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "404aad16-523a-54a7-baff-fb7f56e667ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae80537-f355-4aa3-8952-b08f3d1a1e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae80537-f355-4aa3-8952-b08f3d1a1e41.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -11026,7 +11026,7 @@
         },
         {
             "id": "e7dd0108-465e-5474-b142-d91f04f66c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a881aa61-fc7c-4ffb-a129-f75be8b2e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a881aa61-fc7c-4ffb-a129-f75be8b2e498.jpg?1",
             "name": "Gollum, Patient Plotter",
             "text": "",
             "colours": [
@@ -11066,7 +11066,7 @@
         },
         {
             "id": "fc5a68c5-434e-506d-b5f0-6f54e6c25743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24521350-ffa6-46d9-95ed-6573c681e095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24521350-ffa6-46d9-95ed-6573c681e095.jpg?1",
             "name": "Sauron, the Necromancer",
             "text": "",
             "colours": [
@@ -11105,7 +11105,7 @@
         },
         {
             "id": "36517477-0505-5bd2-aa0f-cdad330c9111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944f01f2-b736-42ff-a871-6b6e726b231b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944f01f2-b736-42ff-a871-6b6e726b231b.jpg?1",
             "name": "Witch-king of Angmar",
             "text": "",
             "colours": [
@@ -11145,7 +11145,7 @@
         },
         {
             "id": "af01c812-a07e-5d12-85ce-04c988f2e594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72c5bd1-cca1-4735-b4fc-7a5182fb8cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72c5bd1-cca1-4735-b4fc-7a5182fb8cd6.jpg?1",
             "name": "Gimli, Counter of Kills",
             "text": "",
             "colours": [
@@ -11184,7 +11184,7 @@
         },
         {
             "id": "07c3bcaa-ef5b-55a2-bc72-1cbdd5425c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84cea85e-dfcc-438e-8b24-4b2e251b86dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84cea85e-dfcc-438e-8b24-4b2e251b86dc.jpg?1",
             "name": "Legolas, Master Archer",
             "text": "",
             "colours": [
@@ -11224,7 +11224,7 @@
         },
         {
             "id": "9652865c-7249-5619-a11c-7ec1d9ad8368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7cea33-4d46-450a-a54e-b8d70910eee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7cea33-4d46-450a-a54e-b8d70910eee8.jpg?1",
             "name": "Meriadoc Brandybuck",
             "text": "",
             "colours": [
@@ -11263,7 +11263,7 @@
         },
         {
             "id": "a59bca1d-9b5a-5447-a251-89be7f89edd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbdd288-83ec-4be9-b55f-17771fd5ecc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbdd288-83ec-4be9-b55f-17771fd5ecc4.jpg?1",
             "name": "Peregrin Took",
             "text": "",
             "colours": [
@@ -11302,7 +11302,7 @@
         },
         {
             "id": "07dc1dd3-e8a2-530f-9b6e-d1df96be4adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c3004-fe39-4ca3-bf14-f4af8b20fa80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c3004-fe39-4ca3-bf14-f4af8b20fa80.jpg?1",
             "name": "Aragorn, Company Leader",
             "text": "",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "affe7fa7-9d4a-58b6-b4f0-341c97681cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e287844c-a829-4f7f-8c4c-ab856e6815f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e287844c-a829-4f7f-8c4c-ab856e6815f6.jpg?1",
             "name": "Aragorn, the Uniter",
             "text": "",
             "colours": [
@@ -11390,7 +11390,7 @@
         },
         {
             "id": "3568f7c8-5f35-5a5c-900a-3beeb6f3c850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476e2a30-4410-432d-9c8a-beaaa40220c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476e2a30-4410-432d-9c8a-beaaa40220c1.jpg?1",
             "name": "Elrond, Master of Healing",
             "text": "",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "8402dbd1-837f-5cf9-bdf0-4c4081534b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf5eee-c378-4ddf-a172-c0a703757fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf5eee-c378-4ddf-a172-c0a703757fff.jpg?1",
             "name": "Faramir, Prince of Ithilien",
             "text": "",
             "colours": [
@@ -11473,7 +11473,7 @@
         },
         {
             "id": "e43a1abb-6811-582f-b7ee-fa439faeca1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a266c-b2e9-4981-93ef-843cea95ca76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a266c-b2e9-4981-93ef-843cea95ca76.jpg?1",
             "name": "Frodo Baggins",
             "text": "",
             "colours": [
@@ -11515,7 +11515,7 @@
         },
         {
             "id": "b48b9bf4-f91e-5f59-aab1-01d53b36c8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a971745b-5d5c-46bb-95ca-329b6ee7ed75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a971745b-5d5c-46bb-95ca-329b6ee7ed75.jpg?1",
             "name": "Galadriel of Lothl\u00f3rien",
             "text": "",
             "colours": [
@@ -11557,7 +11557,7 @@
         },
         {
             "id": "438d5de3-9c0f-5cd5-8fe8-54da21b031b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ff7dea-1ed2-4987-b42a-6d1d8c493f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ff7dea-1ed2-4987-b42a-6d1d8c493f5a.jpg?1",
             "name": "Gandalf the Grey",
             "text": "",
             "colours": [
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "5db7e47f-c04f-5304-bdea-6f123af26d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72778dc1-0d93-4ba8-a194-51df78d4beba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72778dc1-0d93-4ba8-a194-51df78d4beba.jpg?1",
             "name": "Gimli, Mournful Avenger",
             "text": "",
             "colours": [
@@ -11640,7 +11640,7 @@
         },
         {
             "id": "b72b1169-3d58-53e9-a3ef-5d5c8ee70a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe0cb4-71f0-4acb-af1a-a48775826487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe0cb4-71f0-4acb-af1a-a48775826487.jpg?1",
             "name": "Legolas, Counter of Kills",
             "text": "",
             "colours": [
@@ -11681,7 +11681,7 @@
         },
         {
             "id": "378586ba-6a2f-5f77-a479-1506055acc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d21bce-a381-4c5d-9e0f-b2cdc96a20b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d21bce-a381-4c5d-9e0f-b2cdc96a20b6.jpg?1",
             "name": "Merry, Esquire of Rohan",
             "text": "",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "00920b73-8588-5362-9491-0ff41bf0a241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25630509-c9ba-4faf-b154-32be8649d9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25630509-c9ba-4faf-b154-32be8649d9fa.jpg?1",
             "name": "Pippin, Guard of the Citadel",
             "text": "",
             "colours": [
@@ -11765,7 +11765,7 @@
         },
         {
             "id": "9fad50ed-5770-5f18-b957-c9017254b513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ecb73-2720-4c1c-8f67-78983f16e584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ecb73-2720-4c1c-8f67-78983f16e584.jpg?1",
             "name": "Samwise Gamgee",
             "text": "",
             "colours": [
@@ -11806,7 +11806,7 @@
         },
         {
             "id": "883feeee-5c07-5146-8add-883485f3ff3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018238ae-b740-4185-8747-b68f6d1e7989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018238ae-b740-4185-8747-b68f6d1e7989.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -11851,7 +11851,7 @@
         },
         {
             "id": "e997918a-1829-59c8-a35d-6472d8d98b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83261ba-c239-4b6a-88eb-bdfc411916b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83261ba-c239-4b6a-88eb-bdfc411916b3.jpg?1",
             "name": "Sauron, the Dark Lord",
             "text": "",
             "colours": [
@@ -11894,7 +11894,7 @@
         },
         {
             "id": "ae03d20f-c0fd-564e-9d87-3d95440367f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ebf3a3-3dd1-48e0-ad84-c3295de2e032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ebf3a3-3dd1-48e0-ad84-c3295de2e032.jpg?1",
             "name": "Sm\u00e9agol, Helpful Guide",
             "text": "",
             "colours": [
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "15f1c7ab-4cd1-56bc-ab09-593fff6d821b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ce623-bcf8-4d42-8a88-450bea7d7529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ce623-bcf8-4d42-8a88-450bea7d7529.jpg?1",
             "name": "Tom Bombadil",
             "text": "",
             "colours": [
@@ -11982,7 +11982,7 @@
         },
         {
             "id": "236de2ae-b43c-51a2-bba1-b5ec76335b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65226a-12cd-416a-bb60-12e9b35f609b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65226a-12cd-416a-bb60-12e9b35f609b.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12026,7 +12026,7 @@
         },
         {
             "id": "efbc5975-04b1-5c32-a07f-0f3757e2985b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b32f90-b32f-41a6-af0c-1c967ec49b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b32f90-b32f-41a6-af0c-1c967ec49b73.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12070,7 +12070,7 @@
         },
         {
             "id": "b7176c76-1079-5d73-8137-d2211affa5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9c9901-c329-4a68-96ab-f33d7c12aefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9c9901-c329-4a68-96ab-f33d7c12aefe.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12114,7 +12114,7 @@
         },
         {
             "id": "20b42ebf-64dd-56e4-9b65-f22c3f513b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16e3fe-cc9f-414e-8643-3f66c0ab2536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16e3fe-cc9f-414e-8643-3f66c0ab2536.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12158,7 +12158,7 @@
         },
         {
             "id": "77692ee1-fa24-5db8-8651-97c29fa2146f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92d5a03-a4c9-4432-b3bb-f5bb21f65db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92d5a03-a4c9-4432-b3bb-f5bb21f65db0.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12202,7 +12202,7 @@
         },
         {
             "id": "73b1bcfe-e9a9-5b75-920e-42472e8b3047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a5630d-325f-4f7a-9885-b249c6480023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a5630d-325f-4f7a-9885-b249c6480023.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12246,7 +12246,7 @@
         },
         {
             "id": "8f93542f-670f-5707-8432-3d31f0defe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf96c268-c86b-4d5e-bf04-200c427e5fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf96c268-c86b-4d5e-bf04-200c427e5fa5.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12290,7 +12290,7 @@
         },
         {
             "id": "354190b4-0cd5-5093-8134-c2ef297eb1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4023a6de-3ac7-488a-b1a9-b1e26681d9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4023a6de-3ac7-488a-b1a9-b1e26681d9bc.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12334,7 +12334,7 @@
         },
         {
             "id": "067fcb63-b786-5280-8505-8dada3c15378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b2b1ca-c05d-443a-af59-e608ffa251bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b2b1ca-c05d-443a-af59-e608ffa251bf.jpg?1",
             "name": "Barad-d\u00fbr",
             "text": "",
             "colours": [],
@@ -12369,7 +12369,7 @@
         },
         {
             "id": "013ab825-483e-5507-8d29-0fd2a58ef118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e8a91c-74ee-411b-9d74-4e72df24258b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e8a91c-74ee-411b-9d74-4e72df24258b.jpg?1",
             "name": "Minas Tirith",
             "text": "",
             "colours": [],
@@ -12404,7 +12404,7 @@
         },
         {
             "id": "836f4d60-2a69-5db3-bf4f-4b640a4b8e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6cbb58-8c82-49b5-ae9c-f3baaa8bcc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6cbb58-8c82-49b5-ae9c-f3baaa8bcc22.jpg?1",
             "name": "Mines of Moria",
             "text": "",
             "colours": [],
@@ -12439,7 +12439,7 @@
         },
         {
             "id": "d38c282b-e6fa-5b8a-bf5e-e7645e1c2d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a087f9-57c3-4743-b03b-7bfd2b86eefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a087f9-57c3-4743-b03b-7bfd2b86eefd.jpg?1",
             "name": "Mount Doom",
             "text": "",
             "colours": [],
@@ -12474,7 +12474,7 @@
         },
         {
             "id": "01edb97c-5a2d-5a55-ac33-a613bbe0bcec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650fa2f4-2916-427c-a0f9-37e2dbe8e1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650fa2f4-2916-427c-a0f9-37e2dbe8e1fc.jpg?1",
             "name": "Rivendell",
             "text": "",
             "colours": [],
@@ -12508,7 +12508,7 @@
         },
         {
             "id": "5a347f11-89a9-586b-813a-b51f07a531c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248ed7a6-982a-4ff4-ba9b-3c1f47e7605c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248ed7a6-982a-4ff4-ba9b-3c1f47e7605c.jpg?1",
             "name": "The Shire",
             "text": "",
             "colours": [],
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "0ca56615-3ee3-5078-b7a9-5198f4b5f35a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c922a8-28b7-4831-8314-2ce41762955f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c922a8-28b7-4831-8314-2ce41762955f.jpg?1",
             "name": "The Battle of Bywater",
             "text": "",
             "colours": [
@@ -12575,7 +12575,7 @@
         },
         {
             "id": "e9f1d00f-23fb-56f6-96e5-2088ee012a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a867c49-1842-4207-99d7-655cade4d357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a867c49-1842-4207-99d7-655cade4d357.jpg?1",
             "name": "Dawn of a New Age",
             "text": "",
             "colours": [
@@ -12608,7 +12608,7 @@
         },
         {
             "id": "959085d7-6eee-51ca-afd1-e6a707550830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe33c8a-ae61-44d2-a996-d99bb2ce89e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe33c8a-ae61-44d2-a996-d99bb2ce89e6.jpg?1",
             "name": "Flowering of the White Tree",
             "text": "",
             "colours": [
@@ -12643,7 +12643,7 @@
         },
         {
             "id": "70bd5b28-bb7e-5647-8a08-7b5b65a4ed88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1bec-a90d-4d1b-8096-42a1455e86d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1bec-a90d-4d1b-8096-42a1455e86d2.jpg?1",
             "name": "Forge Anew",
             "text": "",
             "colours": [
@@ -12678,7 +12678,7 @@
         },
         {
             "id": "b144d912-05b3-5640-a17f-b3035be2438e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ebd6a8-2e93-40ee-951a-4fcf12c85e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ebd6a8-2e93-40ee-951a-4fcf12c85e3d.jpg?1",
             "name": "Borne Upon a Wind",
             "text": "",
             "colours": [
@@ -12711,7 +12711,7 @@
         },
         {
             "id": "500cc4b1-0f96-564a-b1f3-e2953aec7153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb2cce1-11b7-49ab-ba9c-1d95db26ca19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb2cce1-11b7-49ab-ba9c-1d95db26ca19.jpg?1",
             "name": "Goldberry, River-Daughter",
             "text": "",
             "colours": [
@@ -12748,7 +12748,7 @@
         },
         {
             "id": "2644765e-c539-59dc-b841-48b9e0f9b9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158662c6-04ee-4a79-9199-d0ba68c18650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158662c6-04ee-4a79-9199-d0ba68c18650.jpg?1",
             "name": "Press the Enemy",
             "text": "",
             "colours": [
@@ -12782,7 +12782,7 @@
         },
         {
             "id": "ef58cd93-8e85-5239-a5c8-46e328b72cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684c02e-ee8a-4d26-aa20-5620944bceeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684c02e-ee8a-4d26-aa20-5620944bceeb.jpg?1",
             "name": "Rangers of Ithilien",
             "text": "",
             "colours": [
@@ -12820,7 +12820,7 @@
         },
         {
             "id": "0a1a255a-afbb-566b-ba30-37058620986b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47b68e6-6ad7-4773-a199-cd88c3d010b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47b68e6-6ad7-4773-a199-cd88c3d010b1.jpg?1",
             "name": "The Watcher in the Water",
             "text": "",
             "colours": [
@@ -12858,7 +12858,7 @@
         },
         {
             "id": "d8ccabc9-285c-5280-bee9-89c70ee2b682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ef1d06-7410-4dfb-8897-96aa29df9bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ef1d06-7410-4dfb-8897-96aa29df9bfd.jpg?1",
             "name": "Call of the Ring",
             "text": "",
             "colours": [
@@ -12892,7 +12892,7 @@
         },
         {
             "id": "29844906-c8be-58f9-9bb5-b7176399ca39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8eedbd-ba74-476f-97c4-ffee9fb66444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8eedbd-ba74-476f-97c4-ffee9fb66444.jpg?1",
             "name": "Isildur's Fateful Strike",
             "text": "",
             "colours": [
@@ -12928,7 +12928,7 @@
         },
         {
             "id": "53faba7f-17f4-596a-861e-62e3227f6cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c94c38-7ff7-4177-ba41-573b389301c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c94c38-7ff7-4177-ba41-573b389301c3.jpg?1",
             "name": "Lobelia Sackville-Baggins",
             "text": "",
             "colours": [
@@ -12967,7 +12967,7 @@
         },
         {
             "id": "de834bc2-ddba-5b65-8b95-520277306d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139e0697-12b7-40b4-a7c5-a296e0c1ed27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139e0697-12b7-40b4-a7c5-a296e0c1ed27.jpg?1",
             "name": "Display of Power",
             "text": "",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "3ab3381e-e6fd-5ba3-aee8-16a1a162f8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fdf85-ae3c-409d-a515-0051e25c116c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fdf85-ae3c-409d-a515-0051e25c116c.jpg?1",
             "name": "Fall of Cair Andros",
             "text": "",
             "colours": [
@@ -13035,7 +13035,7 @@
         },
         {
             "id": "8bd7ed28-6cfb-51c1-bbf8-f3fded0fdfa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74d1af-5cc6-422e-949c-de9e39b76154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74d1af-5cc6-422e-949c-de9e39b76154.jpg?1",
             "name": "Gl\u00f3in, Dwarf Emissary",
             "text": "",
             "colours": [
@@ -13073,7 +13073,7 @@
         },
         {
             "id": "87e92a14-3d24-5ef8-ae88-8d83f92e5bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0f4510-5f40-4733-8379-2526e4f1cc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0f4510-5f40-4733-8379-2526e4f1cc79.jpg?1",
             "name": "Hew the Entwood",
             "text": "",
             "colours": [
@@ -13106,7 +13106,7 @@
         },
         {
             "id": "5376ecd1-3e5d-58d3-bf53-82efaa3f58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e36249-02f5-4c11-9a2b-6be81eb6b490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e36249-02f5-4c11-9a2b-6be81eb6b490.jpg?1",
             "name": "Moria Marauder",
             "text": "",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "84492551-7c4a-5045-a7f5-adf58ce6e64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a04912-633d-4f67-b200-d55735438f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a04912-633d-4f67-b200-d55735438f76.jpg?1",
             "name": "Delighted Halfling",
             "text": "",
             "colours": [
@@ -13179,7 +13179,7 @@
         },
         {
             "id": "c7b6aea4-5f54-500d-90ad-ecccbc10e008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9523a73-6b62-48ee-9775-cf1f3b6babb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9523a73-6b62-48ee-9775-cf1f3b6babb3.jpg?1",
             "name": "Elven Chorus",
             "text": "",
             "colours": [
@@ -13212,7 +13212,7 @@
         },
         {
             "id": "378ec0c8-4348-59a2-aa4d-9a8b9eacd759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9684292b-804d-4019-a2f3-95c6ea6f97b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9684292b-804d-4019-a2f3-95c6ea6f97b7.jpg?1",
             "name": "Radagast the Brown",
             "text": "",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "eaae9675-24b3-50b9-b114-f40d833958cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ee6b2e-7e6d-4f8d-a75e-ff30722e08d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ee6b2e-7e6d-4f8d-a75e-ff30722e08d3.jpg?1",
             "name": "The Ring Goes South",
             "text": "",
             "colours": [
@@ -13284,7 +13284,7 @@
         },
         {
             "id": "4eefb7e7-b1e9-5790-9309-10185f8a25c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718ae3af-a365-4593-a44c-6684ef308d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718ae3af-a365-4593-a44c-6684ef308d4c.jpg?1",
             "name": "Arwen, Mortal Queen",
             "text": "",
             "colours": [
@@ -13325,7 +13325,7 @@
         },
         {
             "id": "a391990c-ec69-5086-993c-57718d60494e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e2fd90-95b0-4b12-846c-80bb979f0724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e2fd90-95b0-4b12-846c-80bb979f0724.jpg?1",
             "name": "Doors of Durin",
             "text": "",
             "colours": [
@@ -13363,7 +13363,7 @@
         },
         {
             "id": "1f540547-d016-580a-9876-60932ce7b8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4796aa-0aee-43c6-9c34-e4d66da776cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4796aa-0aee-43c6-9c34-e4d66da776cc.jpg?1",
             "name": "King of the Oathbreakers",
             "text": "",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "334e2023-1d62-54e8-8bfd-3bcdf62522c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d97af0-8af0-4124-b56f-2633d34e5574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d97af0-8af0-4124-b56f-2633d34e5574.jpg?1",
             "name": "Lotho, Corrupt Shirriff",
             "text": "",
             "colours": [
@@ -13446,7 +13446,7 @@
         },
         {
             "id": "27a2bac5-05f3-5b04-9ac6-0b214a1e46ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6d22a-8ccf-4e12-ab5c-5c5ba06809e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6d22a-8ccf-4e12-ab5c-5c5ba06809e5.jpg?1",
             "name": "Sauron's Ransom",
             "text": "",
             "colours": [
@@ -13482,7 +13482,7 @@
         },
         {
             "id": "73e63592-deed-5d10-bfda-f798c2ee0b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1922e391-54c3-4df5-a8b1-c7cd07598e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1922e391-54c3-4df5-a8b1-c7cd07598e08.jpg?1",
             "name": "Shagrat, Loot Bearer",
             "text": "",
             "colours": [
@@ -13522,7 +13522,7 @@
         },
         {
             "id": "4d2e92c9-7426-553e-aada-b293bcde38d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad2707-6805-4c10-a54e-c1cc63a7108f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad2707-6805-4c10-a54e-c1cc63a7108f.jpg?1",
             "name": "Sharkey, Tyrant of the Shire",
             "text": "",
             "colours": [
@@ -13562,7 +13562,7 @@
         },
         {
             "id": "5f5504b6-5712-5d69-a43c-5c657b68185c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d427a8-a237-4053-b90d-0f1dd249e9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d427a8-a237-4053-b90d-0f1dd249e9c1.jpg?1",
             "name": "Shelob, Child of Ungoliant",
             "text": "",
             "colours": [
@@ -13604,7 +13604,7 @@
         },
         {
             "id": "fc39f008-95fa-5983-8a3b-f6c52716ee69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5236343-8035-477c-8221-b835d01b8a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5236343-8035-477c-8221-b835d01b8a8b.jpg?1",
             "name": "And\u00faril, Flame of the West",
             "text": "",
             "colours": [],
@@ -13638,7 +13638,7 @@
         },
         {
             "id": "c97069a1-5cff-557d-9005-1c4f3b484bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1128f94f-9980-4bb8-a5db-21a82ce9e680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1128f94f-9980-4bb8-a5db-21a82ce9e680.jpg?1",
             "name": "Glamdring",
             "text": "",
             "colours": [],
@@ -13672,7 +13672,7 @@
         },
         {
             "id": "5b42d559-4597-5574-8284-1adb878aa79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9ca30-c336-4977-91af-184ed98eea99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9ca30-c336-4977-91af-184ed98eea99.jpg?1",
             "name": "Horn of Gondor",
             "text": "",
             "colours": [],
@@ -13704,7 +13704,7 @@
         },
         {
             "id": "f14f7e41-22c5-575e-b346-bcc2b60b6395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af151b54-3d90-4bb2-8cfa-36e7d865d227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af151b54-3d90-4bb2-8cfa-36e7d865d227.jpg?1",
             "name": "Horn of the Mark",
             "text": "",
             "colours": [],
@@ -13736,7 +13736,7 @@
         },
         {
             "id": "21b1da93-c40f-5d44-8932-e5db087a61bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65ec6ad-80d8-4c76-8b69-fc401a8f1ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65ec6ad-80d8-4c76-8b69-fc401a8f1ce8.jpg?1",
             "name": "Mithril Coat",
             "text": "",
             "colours": [],
@@ -13770,7 +13770,7 @@
         },
         {
             "id": "6398a529-ed1f-5c67-bb88-5a61f9ba07fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db80391f-1643-4b72-a397-d141bb5702ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db80391f-1643-4b72-a397-d141bb5702ee.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -13804,7 +13804,7 @@
         },
         {
             "id": "604470c5-cac5-5fdf-8fa6-bee364ae7278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c27c6ac-889f-4591-8789-4a6f1a264d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c27c6ac-889f-4591-8789-4a6f1a264d98.jpg?1",
             "name": "Palant\u00edr of Orthanc",
             "text": "",
             "colours": [],
@@ -13836,7 +13836,7 @@
         },
         {
             "id": "e97d0e93-e3a3-5efc-8eee-a74dfe80a421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d163a60b-c7ca-4d69-be6c-3a94c7f9a4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d163a60b-c7ca-4d69-be6c-3a94c7f9a4c7.jpg?1",
             "name": "Phial of Galadriel",
             "text": "",
             "colours": [],
@@ -13868,7 +13868,7 @@
         },
         {
             "id": "83a494b0-e949-5b7a-8e59-b5932375d710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf608ed2-f193-4bcc-99fc-a9cd0cf97993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf608ed2-f193-4bcc-99fc-a9cd0cf97993.jpg?1",
             "name": "Saradoc, Master of Buckland",
             "text": "",
             "colours": [
@@ -13906,7 +13906,7 @@
         },
         {
             "id": "5810213c-b332-5dfe-8104-1d69993061ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c05a4d9-37f9-42ac-8dca-b31480904b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c05a4d9-37f9-42ac-8dca-b31480904b51.jpg?1",
             "name": "Elvish Mariner",
             "text": "",
             "colours": [
@@ -13942,7 +13942,7 @@
         },
         {
             "id": "a82966cb-8783-5a28-b728-32d5768cd54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff818c30-0a50-4986-a236-ddaf41fddf12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff818c30-0a50-4986-a236-ddaf41fddf12.jpg?1",
             "name": "Ringwraiths",
             "text": "",
             "colours": [
@@ -13978,7 +13978,7 @@
         },
         {
             "id": "df263dba-74c5-56bf-9a39-2bb9887f6e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c07f3-5854-4243-b4ac-eed9a9711ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c07f3-5854-4243-b4ac-eed9a9711ce9.jpg?1",
             "name": "Assault on Osgiliath",
             "text": "",
             "colours": [
@@ -14011,7 +14011,7 @@
         },
         {
             "id": "ae06b6fa-9c19-51fc-80b2-c693601ac24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b35ec3c-6da6-435d-b094-14a56cec58fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b35ec3c-6da6-435d-b094-14a56cec58fe.jpg?1",
             "name": "Elanor Gardner",
             "text": "",
             "colours": [
@@ -14049,7 +14049,7 @@
         },
         {
             "id": "63ab2030-3d6a-5f9d-beaa-493039906356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226694d7-ba9b-4e79-b45a-634769815e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226694d7-ba9b-4e79-b45a-634769815e74.jpg?1",
             "name": "Frodo, Determined Hero",
             "text": "",
             "colours": [
@@ -14087,7 +14087,7 @@
         },
         {
             "id": "ee928bc4-03d8-595d-a635-26bd0eaec945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187807bc-0058-49a1-9a67-01019c5440c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187807bc-0058-49a1-9a67-01019c5440c2.jpg?1",
             "name": "Gandalf, White Rider",
             "text": "",
             "colours": [
@@ -14125,7 +14125,7 @@
         },
         {
             "id": "84b2255d-a1d3-535c-a2f5-7d7b06975da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76aa1492-579f-4e36-8931-b2bf203e2d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76aa1492-579f-4e36-8931-b2bf203e2d76.jpg?1",
             "name": "Gollum, Scheming Guide",
             "text": "",
             "colours": [
@@ -14163,7 +14163,7 @@
         },
         {
             "id": "9e257d93-23e4-56d7-938a-28bc9790b444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0305f6-a0c6-4197-9aa6-789fa855cb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0305f6-a0c6-4197-9aa6-789fa855cb17.jpg?1",
             "name": "Witch-king, Bringer of Ruin",
             "text": "",
             "colours": [
@@ -14201,7 +14201,7 @@
         },
         {
             "id": "1e36df8b-ac5c-5561-9124-f7a36ab67308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d9aab-5673-4a6a-be86-13508b8929bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d9aab-5673-4a6a-be86-13508b8929bd.jpg?1",
             "name": "Fires of Mount Doom",
             "text": "",
             "colours": [
@@ -14236,7 +14236,7 @@
         },
         {
             "id": "61e1231c-bb49-582e-8631-807f06f21d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbc8de9-6f74-468f-834c-46d10864e36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbc8de9-6f74-468f-834c-46d10864e36b.jpg?1",
             "name": "Galadriel, Gift-Giver",
             "text": "",
             "colours": [
@@ -14274,7 +14274,7 @@
         },
         {
             "id": "7b37991b-1dce-514b-b657-edb9fe3b5b3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31540016-1896-47f7-9c4d-f07598c75421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31540016-1896-47f7-9c4d-f07598c75421.jpg?1",
             "name": "Aragorn and Arwen, Wed",
             "text": "",
             "colours": [
@@ -14315,7 +14315,7 @@
         },
         {
             "id": "6c902346-27f2-5714-a76a-d85f07e9c7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c33afe-24fe-4aff-b30a-f4370815dfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c33afe-24fe-4aff-b30a-f4370815dfd6.jpg?1",
             "name": "The Balrog, Flame of Ud\u00fbn",
             "text": "",
             "colours": [
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "dcf08870-2596-52a6-8b1d-f197e28ae8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b80de80-8b4e-46e2-9145-b9f3031d32d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b80de80-8b4e-46e2-9145-b9f3031d32d7.jpg?1",
             "name": "Sauron, the Lidless Eye",
             "text": "",
             "colours": [
@@ -14395,7 +14395,7 @@
         },
         {
             "id": "7042e93e-cf30-5de1-be1b-af603df94c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2bc8e-79cf-471e-8d9f-0e34703f1808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2bc8e-79cf-471e-8d9f-0e34703f1808.jpg?1",
             "name": "Bilbo's Ring",
             "text": "",
             "colours": [],
@@ -14428,7 +14428,7 @@
         },
         {
             "id": "6b34cdf6-e464-5ec2-a5e1-fcc30f618834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ee958c-ae8c-49bd-9d85-0128ca19901c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ee958c-ae8c-49bd-9d85-0128ca19901c.jpg?1",
             "name": "Trailblazer's Boots",
             "text": "",
             "colours": [],
@@ -14457,7 +14457,7 @@
         },
         {
             "id": "67b9dca5-58e3-5979-b37e-2fc02b2dc9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecea0ba-da29-45f1-b72b-50b873309483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecea0ba-da29-45f1-b72b-50b873309483.jpg?1",
             "name": "Lobelia Sackville-Baggins",
             "text": "",
             "colours": [
@@ -14497,7 +14497,7 @@
         },
         {
             "id": "885282dc-8db3-5aa4-ab1e-ed202be83445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541faaf0-4832-47b5-bb92-881dd70d6309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541faaf0-4832-47b5-bb92-881dd70d6309.jpg?1",
             "name": "Wizard's Rockets",
             "text": "",
             "colours": [],
@@ -14527,7 +14527,7 @@
         },
         {
             "id": "f154f3d9-bf7b-563e-8971-cc1d0202da72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646ff18e-9d6a-4a55-838c-0bd88b8c9fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646ff18e-9d6a-4a55-838c-0bd88b8c9fae.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -14567,7 +14567,7 @@
         },
         {
             "id": "3b598e5f-d03f-5627-b70a-c2713065737e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87f082-1596-43fd-b971-720090ac6733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87f082-1596-43fd-b971-720090ac6733.jpg?1",
             "name": "Delighted Halfling",
             "text": "",
             "colours": [
@@ -14605,7 +14605,7 @@
         },
         {
             "id": "6886c505-d8a9-55a4-9446-147f67285e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14d6a77-eb1e-4f1a-ac5c-7513952fd1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14d6a77-eb1e-4f1a-ac5c-7513952fd1ce.jpg?1",
             "name": "Bilbo, Retired Burglar",
             "text": "",
             "colours": [
@@ -14645,7 +14645,7 @@
         },
         {
             "id": "03ac29f3-ced3-5857-a8ff-610091d3c541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ea046-3008-4d4e-b316-e6c5e80422d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ea046-3008-4d4e-b316-e6c5e80422d3.jpg?1",
             "name": "Frodo Baggins",
             "text": "",
             "colours": [
@@ -14686,7 +14686,7 @@
         },
         {
             "id": "798391fd-b564-556a-9b16-1e14a01b84c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a2d7f8-0055-4d53-8e1e-9810d384cdb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a2d7f8-0055-4d53-8e1e-9810d384cdb8.jpg?1",
             "name": "The Balrog, Durin's Bane",
             "text": "",
             "colours": [
@@ -14727,7 +14727,7 @@
         },
         {
             "id": "07bbab5d-71d6-5d84-97f2-fe1d35513a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882ef7d-ddff-40f5-a4f5-bff5c8169dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882ef7d-ddff-40f5-a4f5-bff5c8169dc1.jpg?1",
             "name": "Flame of Anor",
             "text": "",
             "colours": [
@@ -14763,7 +14763,7 @@
         },
         {
             "id": "78fc2ba3-1b4e-5123-a5bd-b6a8485c6768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec04f9-0563-4490-b252-714df2ddbf58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec04f9-0563-4490-b252-714df2ddbf58.jpg?1",
             "name": "Boromir, Warden of the Tower",
             "text": "",
             "colours": [
@@ -14803,7 +14803,7 @@
         },
         {
             "id": "b8780032-b29b-50ae-80fb-0eec70da732e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bb0051-3ba3-4e22-9098-42ee0d9b645c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bb0051-3ba3-4e22-9098-42ee0d9b645c.jpg?1",
             "name": "Lash of the Balrog",
             "text": "",
             "colours": [
@@ -14837,7 +14837,7 @@
         },
         {
             "id": "2329e8b8-2f60-5505-85fb-bc8a25f89404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3485e-2190-412a-a7b0-6a6ffdbef77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3485e-2190-412a-a7b0-6a6ffdbef77c.jpg?1",
             "name": "Sting, the Glinting Dagger",
             "text": "",
             "colours": [],
@@ -14871,7 +14871,7 @@
         },
         {
             "id": "8b12c07d-4a15-56e6-a8e7-b41e1cc6d7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb70f9-c8f6-4082-9d63-4efdd6a20527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb70f9-c8f6-4082-9d63-4efdd6a20527.jpg?1",
             "name": "Aragorn, Company Leader",
             "text": "",
             "colours": [
@@ -14913,7 +14913,7 @@
         },
         {
             "id": "4b76dc38-2b07-54b5-aca4-702c0c1e81b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b90963-2a4c-4e0a-9d00-5d3df258c880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b90963-2a4c-4e0a-9d00-5d3df258c880.jpg?1",
             "name": "Dunland Crebain",
             "text": "",
             "colours": [
@@ -14950,7 +14950,7 @@
         },
         {
             "id": "fdba1416-2de8-583c-a894-dba56d7d4205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7fc17a-00e6-48f2-a1b9-970d7720f87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7fc17a-00e6-48f2-a1b9-970d7720f87d.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "34215407-85ed-5155-b077-db0a1c0ef310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02fac3-8990-4bd1-8e34-beec6332088c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02fac3-8990-4bd1-8e34-beec6332088c.jpg?1",
             "name": "Storm of Saruman",
             "text": "",
             "colours": [
@@ -15029,7 +15029,7 @@
         },
         {
             "id": "fd833db5-3dc4-53cf-9016-f98d797a890b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dc9616-83e5-451f-aaa8-d0c81802fa13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dc9616-83e5-451f-aaa8-d0c81802fa13.jpg?1",
             "name": "Pippin's Bravery",
             "text": "",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "350c1ce1-fa70-53be-92af-30fc2a47b3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486c2171-aa41-47d4-a499-d6cff078a587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486c2171-aa41-47d4-a499-d6cff078a587.jpg?1",
             "name": "Fangorn, Tree Shepherd",
             "text": "",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "d896b6f0-e0b9-5eb1-b82a-776d05014bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37271b8b-3c58-43aa-b120-f0aa12fb3ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37271b8b-3c58-43aa-b120-f0aa12fb3ad5.jpg?1",
             "name": "Nasty End",
             "text": "",
             "colours": [
@@ -15135,7 +15135,7 @@
         },
         {
             "id": "731d5c07-41ed-584f-97f0-71e5c618e60e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef083f43-4748-42e6-bc22-fc2570db5ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef083f43-4748-42e6-bc22-fc2570db5ca3.jpg?1",
             "name": "Foray of Orcs",
             "text": "",
             "colours": [
@@ -15169,7 +15169,7 @@
         },
         {
             "id": "465f8451-957b-5312-8d8e-d025f8b0bcb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66763118-6a1e-465a-bfe0-6fe18c419875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66763118-6a1e-465a-bfe0-6fe18c419875.jpg?1",
             "name": "Last March of the Ents",
             "text": "",
             "colours": [
@@ -15203,7 +15203,7 @@
         },
         {
             "id": "561787bf-0c29-5d79-a585-539f7ed9d6f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402d829d-9d99-48ac-9ffe-14405ec56302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402d829d-9d99-48ac-9ffe-14405ec56302.jpg?1",
             "name": "Quickbeam, Upstart Ent",
             "text": "",
             "colours": [
@@ -15241,7 +15241,7 @@
         },
         {
             "id": "09fc3c95-2d50-50b8-bd64-6e19a61bf78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa1dea-e74f-44c4-bfed-7dfaa3ecd332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa1dea-e74f-44c4-bfed-7dfaa3ecd332.jpg?1",
             "name": "Minas Tirith",
             "text": "",
             "colours": [],
@@ -15276,7 +15276,7 @@
         },
         {
             "id": "462f08e7-d7ba-5c7b-9e5b-ffcc2d510f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882747f9-b4fe-42be-8fe9-f871cd0779bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882747f9-b4fe-42be-8fe9-f871cd0779bd.jpg?1",
             "name": "Mirkwood Bats",
             "text": "",
             "colours": [
@@ -15312,7 +15312,7 @@
         },
         {
             "id": "575bd80c-6206-5e42-9d98-e1053acf299b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce6be0-ebfe-4d50-87c6-8c1fc7536f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce6be0-ebfe-4d50-87c6-8c1fc7536f1f.jpg?1",
             "name": "Voracious Fell Beast",
             "text": "",
             "colours": [
@@ -15349,7 +15349,7 @@
         },
         {
             "id": "1e1b51c4-c337-5110-8cb1-2fa45d747151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77759762-8684-4513-92c5-72c86d43b8bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77759762-8684-4513-92c5-72c86d43b8bd.jpg?1",
             "name": "Witch-king of Angmar",
             "text": "",
             "colours": [
@@ -15389,7 +15389,7 @@
         },
         {
             "id": "ef84d8c0-4c7d-5701-b855-9e966008d44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357a1e7c-19f1-42ea-8a68-511a10ab699a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357a1e7c-19f1-42ea-8a68-511a10ab699a.jpg?1",
             "name": "Shadow of the Enemy",
             "text": "",
             "colours": [
@@ -15423,7 +15423,7 @@
         },
         {
             "id": "ebfe97f7-3f3b-53b6-892d-a42aea9b190d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1aa00f-aa33-4c89-9014-6184356649ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1aa00f-aa33-4c89-9014-6184356649ca.jpg?1",
             "name": "Barad-d\u00fbr",
             "text": "",
             "colours": [],
@@ -15458,7 +15458,7 @@
         },
         {
             "id": "b425054e-2a63-50c2-bf77-78776964bed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa65958a-f601-472e-a9b6-42650b97fa44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa65958a-f601-472e-a9b6-42650b97fa44.jpg?1",
             "name": "Oliphaunt",
             "text": "",
             "colours": [
@@ -15494,7 +15494,7 @@
         },
         {
             "id": "6dc09a5e-555c-5966-a4bd-84896e0dc0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a06a653-eca1-4fee-add5-45d2594885c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a06a653-eca1-4fee-add5-45d2594885c3.jpg?1",
             "name": "Rising of the Day",
             "text": "",
             "colours": [
@@ -15528,7 +15528,7 @@
         },
         {
             "id": "586f0c82-3d81-5b2f-a6b0-edac55f88a69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c8be5-68be-4e29-baf5-0590ace77319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c8be5-68be-4e29-baf5-0590ace77319.jpg?1",
             "name": "\u00c9omer, Marshal of Rohan",
             "text": "",
             "colours": [
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "7047a5b2-ee94-50af-a569-0f87f28a2b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9af0ce-db08-4ccf-a9f3-b7c1eea14423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9af0ce-db08-4ccf-a9f3-b7c1eea14423.jpg?1",
             "name": "Gothmog, Morgul Lieutenant",
             "text": "",
             "colours": [
@@ -15606,7 +15606,7 @@
         },
         {
             "id": "edc006d0-d07e-5e3a-9fb1-dc07f2619d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b6da81-dc24-45b3-b94c-0d6fa00fad0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b6da81-dc24-45b3-b94c-0d6fa00fad0c.jpg?1",
             "name": "\u00c9owyn, Fearless Knight",
             "text": "",
             "colours": [
@@ -15647,7 +15647,7 @@
         },
         {
             "id": "4a8aafeb-d8df-5278-8359-382706374c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9c814-df6b-4b54-a233-9bed31009bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9c814-df6b-4b54-a233-9bed31009bed.jpg?1",
             "name": "Prince Imrahil the Fair",
             "text": "",
             "colours": [
@@ -15688,7 +15688,7 @@
         },
         {
             "id": "9354d7b2-b54d-5629-847d-17d7e86a1677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c511371-97d7-47cc-934c-939dfbdd1c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c511371-97d7-47cc-934c-939dfbdd1c0b.jpg?1",
             "name": "Knights of Dol Amroth",
             "text": "",
             "colours": [
@@ -15725,7 +15725,7 @@
         },
         {
             "id": "f07b5dd5-e0ab-56a2-b95d-05235b092331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de055-5246-408b-80fe-cd01688c145e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de055-5246-408b-80fe-cd01688c145e.jpg?1",
             "name": "Orcish Bowmasters",
             "text": "",
             "colours": [
@@ -15762,7 +15762,7 @@
         },
         {
             "id": "9083f929-7a0b-53c6-a039-c45b37079782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52471b8-c962-496e-8634-127337eede01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52471b8-c962-496e-8634-127337eede01.jpg?1",
             "name": "Aragorn, the Uniter",
             "text": "",
             "colours": [
@@ -15808,7 +15808,7 @@
         },
         {
             "id": "89d924df-03b6-5c42-b3ac-868856cbcab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddc39b-9bc9-4106-86aa-a086b5f5c301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddc39b-9bc9-4106-86aa-a086b5f5c301.jpg?1",
             "name": "Legolas, Master Archer",
             "text": "",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "720d317e-04a8-554d-8265-f8ea0583e403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8bd920-5e70-4c3d-bd15-ccb8d1c87e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8bd920-5e70-4c3d-bd15-ccb8d1c87e2e.jpg?1",
             "name": "Gimli, Mournful Avenger",
             "text": "",
             "colours": [
@@ -15890,7 +15890,7 @@
         },
         {
             "id": "436d9040-71f4-5d0e-9dea-f1e59f8b4b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ff889-fc9a-42f7-998d-0ab23c94ad8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ff889-fc9a-42f7-998d-0ab23c94ad8a.jpg?1",
             "name": "Merry, Esquire of Rohan",
             "text": "",
             "colours": [
@@ -15932,7 +15932,7 @@
         },
         {
             "id": "810fdfd6-2ecf-5737-bbc9-ff38ed992cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96ccfa-153c-459e-9e75-f87ff1ed334a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96ccfa-153c-459e-9e75-f87ff1ed334a.jpg?1",
             "name": "Pippin, Guard of the Citadel",
             "text": "",
             "colours": [
@@ -15974,7 +15974,7 @@
         },
         {
             "id": "ac6634a0-7177-5482-ae12-0dab3faec33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564871f-0f17-4196-bd1d-617b6738c87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564871f-0f17-4196-bd1d-617b6738c87d.jpg?1",
             "name": "Spiteful Banditry",
             "text": "",
             "colours": [
@@ -16008,7 +16008,7 @@
         },
         {
             "id": "acdfce1b-404f-544c-8c79-747f7066bcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56cbc2-6fc2-4443-90fe-59acd526f562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56cbc2-6fc2-4443-90fe-59acd526f562.jpg?1",
             "name": "Rosie Cotton of South Lane",
             "text": "",
             "colours": [
@@ -16047,7 +16047,7 @@
         },
         {
             "id": "d73da607-d6af-5ca0-bab3-c8e70a6e4c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b50fec-28e0-4eaf-9184-73cc7234577f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b50fec-28e0-4eaf-9184-73cc7234577f.jpg?1",
             "name": "Shire Shirriff",
             "text": "",
             "colours": [
@@ -16084,7 +16084,7 @@
         },
         {
             "id": "a8e19557-bc56-59c1-a0dc-4e1f15b92424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61741337-1f9d-42f2-8e79-c7bae436ec59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61741337-1f9d-42f2-8e79-c7bae436ec59.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -16125,7 +16125,7 @@
         },
         {
             "id": "30a35770-8ebd-5f59-847c-053df00354f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9714aa30-1db2-4670-9a0b-72acfc3f703c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9714aa30-1db2-4670-9a0b-72acfc3f703c.jpg?1",
             "name": "The Grey Havens",
             "text": "",
             "colours": [],
@@ -16157,7 +16157,7 @@
         },
         {
             "id": "2d8e7abc-2fad-5afc-95a7-c0a596c8b9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab613e1-390c-4581-9c3e-4c4b26464d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab613e1-390c-4581-9c3e-4c4b26464d10.jpg?1",
             "name": "Lost Isle Calling",
             "text": "",
             "colours": [
@@ -16191,7 +16191,7 @@
         },
         {
             "id": "7a95bc7a-d831-54a4-8b20-39faaca6afef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769f0ce-b31b-4cb5-8635-2b9b70114180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769f0ce-b31b-4cb5-8635-2b9b70114180.jpg?1",
             "name": "Many Partings",
             "text": "",
             "colours": [
@@ -16225,7 +16225,7 @@
         },
         {
             "id": "d4b47ac8-666e-5fcc-8919-bb5180c2e860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f28ce3f-a82b-4d4c-8803-340873cc5814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f28ce3f-a82b-4d4c-8803-340873cc5814.jpg?1",
             "name": "Galadriel of Lothl\u00f3rien",
             "text": "",
             "colours": [
@@ -16267,7 +16267,7 @@
         },
         {
             "id": "c57affc1-6484-5e9d-a3c6-e119a4d2f3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a037b81-28a3-4ecb-9c18-e9cd5cabad16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a037b81-28a3-4ecb-9c18-e9cd5cabad16.jpg?1",
             "name": "Elrond, Master of Healing",
             "text": "",
             "colours": [
@@ -16309,7 +16309,7 @@
         },
         {
             "id": "5f6c4039-8530-59fe-9359-0cc2ae3be3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5a5971-2f93-40f3-b5a2-97b1f0129399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5a5971-2f93-40f3-b5a2-97b1f0129399.jpg?1",
             "name": "Frodo, Sauron's Bane",
             "text": "",
             "colours": [
@@ -16350,7 +16350,7 @@
         },
         {
             "id": "dc4a6746-3731-5be3-af6e-93c93efad9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16891fb5-1388-465c-8d86-97de0ee94ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16891fb5-1388-465c-8d86-97de0ee94ef1.jpg?1",
             "name": "Samwise the Stouthearted",
             "text": "",
             "colours": [
@@ -16390,7 +16390,7 @@
         },
         {
             "id": "6ed2be56-03df-5bc6-a063-6f8d2a22321a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ef56-4649-43f4-829c-af28278833a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ef56-4649-43f4-829c-af28278833a2.jpg?1",
             "name": "Gollum, Patient Plotter",
             "text": "",
             "colours": [
@@ -16430,7 +16430,7 @@
         },
         {
             "id": "86b023d0-5971-5ecd-9478-eeecf3fd8b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ea71a-9a64-4d1e-a8ca-1efce3b8346f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ea71a-9a64-4d1e-a8ca-1efce3b8346f.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -16464,7 +16464,7 @@
         },
         {
             "id": "c70a05ad-6c8e-5514-a89b-2e453aead9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6839fd15-5656-4006-a11b-d0e1cbea05b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6839fd15-5656-4006-a11b-d0e1cbea05b3.jpg?1",
             "name": "Denethor, Ruling Steward",
             "text": "",
             "colours": [
@@ -16505,7 +16505,7 @@
         },
         {
             "id": "e6c0292e-af8b-55c0-8855-2bf82f0755a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e354fe8-fc03-42a0-8795-3d267fea9da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e354fe8-fc03-42a0-8795-3d267fea9da0.jpg?1",
             "name": "Mines of Moria",
             "text": "",
             "colours": [],
@@ -16539,7 +16539,7 @@
         },
         {
             "id": "12d73473-bf4e-57f7-98e2-488253642d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59358af2-98b7-490b-b84f-1ddd3a5cb387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59358af2-98b7-490b-b84f-1ddd3a5cb387.jpg?1",
             "name": "Forge Anew",
             "text": "",
             "colours": [
@@ -16573,7 +16573,7 @@
         },
         {
             "id": "6e512c77-21ea-5af1-8e54-cea780104ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7814651-0542-4c64-a034-404fe40c8f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7814651-0542-4c64-a034-404fe40c8f29.jpg?1",
             "name": "Press the Enemy",
             "text": "",
             "colours": [
@@ -16607,7 +16607,7 @@
         },
         {
             "id": "1e572441-605c-5dc7-ae6e-69f98698cdaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039d3ce-0e5c-4fca-8c84-acf19971436d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039d3ce-0e5c-4fca-8c84-acf19971436d.jpg?1",
             "name": "Rangers of Ithilien",
             "text": "",
             "colours": [
@@ -16644,7 +16644,7 @@
         },
         {
             "id": "4b2b82e9-658e-5c2e-8135-21d2764d6726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951527ef-0561-43b6-8293-4f74dd3f157c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951527ef-0561-43b6-8293-4f74dd3f157c.jpg?1",
             "name": "The Watcher in the Water",
             "text": "",
             "colours": [
@@ -16682,7 +16682,7 @@
         },
         {
             "id": "44d3057e-fc87-51bf-9156-ab1c2e2e4f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f84040-6879-4da4-b46d-f5d32088b8c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f84040-6879-4da4-b46d-f5d32088b8c2.jpg?1",
             "name": "Isildur's Fateful Strike",
             "text": "",
             "colours": [
@@ -16718,7 +16718,7 @@
         },
         {
             "id": "510e029a-c42f-5e55-9751-e632d2abf247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcfd032-ab7f-48e1-a02a-7611aa7354e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcfd032-ab7f-48e1-a02a-7611aa7354e1.jpg?1",
             "name": "Fall of Cair Andros",
             "text": "",
             "colours": [
@@ -16752,7 +16752,7 @@
         },
         {
             "id": "e425ee6a-a982-5c6d-8cc5-041580aefc85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb35e78-97cc-4300-9da9-797eeef9491e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb35e78-97cc-4300-9da9-797eeef9491e.jpg?1",
             "name": "King of the Oathbreakers",
             "text": "",
             "colours": [
@@ -16793,7 +16793,7 @@
         },
         {
             "id": "644b8d22-6044-5d23-8cc8-92d7848c7750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2138bd-da85-46af-8f22-fe8b737f6080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2138bd-da85-46af-8f22-fe8b737f6080.jpg?1",
             "name": "Shelob, Child of Ungoliant",
             "text": "",
             "colours": [
@@ -16834,7 +16834,7 @@
         },
         {
             "id": "da2f9db2-b23f-5f0b-9a89-878bf724cb40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c30e7a3-836a-4239-84dc-bc000ad22afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c30e7a3-836a-4239-84dc-bc000ad22afd.jpg?1",
             "name": "Glamdring",
             "text": "",
             "colours": [],
@@ -16868,7 +16868,7 @@
         },
         {
             "id": "430b2a53-73f5-51ac-ac3f-b210c522a984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab4309-daca-42d9-ad0b-0457717c4503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab4309-daca-42d9-ad0b-0457717c4503.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -16903,7 +16903,7 @@
         },
         {
             "id": "53df89a4-8aa8-5438-a21f-f9f2c28a3b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6df0025-8f6a-43e1-8f07-36f18da3a485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6df0025-8f6a-43e1-8f07-36f18da3a485.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -16938,7 +16938,7 @@
         },
         {
             "id": "a7f12aa2-377c-58bb-b229-43e1ba2a69f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b674ef-f541-4ee8-9727-1c5b3c0c8f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b674ef-f541-4ee8-9727-1c5b3c0c8f4e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "194140f0-66d9-51af-aa9d-a1db03958201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea4e628-4ae2-4e33-a3b6-176ed87c1840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea4e628-4ae2-4e33-a3b6-176ed87c1840.jpg?1",
             "name": "Tentacle",
             "text": "",
             "colours": [
@@ -17006,7 +17006,7 @@
         },
         {
             "id": "7150c706-2db0-511c-b889-7d2fc93d4b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8b43e8-dd89-452e-b572-8559e19fdea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8b43e8-dd89-452e-b572-8559e19fdea2.jpg?1",
             "name": "Orc Army",
             "text": "",
             "colours": [
@@ -17041,7 +17041,7 @@
         },
         {
             "id": "47a358be-d201-542d-85e1-cf32d9d75d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db598f33-2ff9-4e0b-a067-05fecc03435f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db598f33-2ff9-4e0b-a067-05fecc03435f.jpg?1",
             "name": "Orc Army",
             "text": "",
             "colours": [
@@ -17076,7 +17076,7 @@
         },
         {
             "id": "c176be8a-06ef-5d2f-bd91-1d65ccfaf48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2b87e-f8f9-4756-9ea2-64bc5c13bb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2b87e-f8f9-4756-9ea2-64bc5c13bb96.jpg?1",
             "name": "Smaug",
             "text": "",
             "colours": [
@@ -17112,7 +17112,7 @@
         },
         {
             "id": "68262339-1714-5dd5-947c-6c53866245c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d70342-9d3c-44cb-9026-db5e5941b9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d70342-9d3c-44cb-9026-db5e5941b9fc.jpg?1",
             "name": "Ballistic Boulder",
             "text": "",
             "colours": [],
@@ -17143,7 +17143,7 @@
         },
         {
             "id": "7fb92a7a-6cb2-58d1-a606-deb2a770881f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f04cd9-63ef-4dda-948a-0be76628900c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f04cd9-63ef-4dda-948a-0be76628900c.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -17174,7 +17174,7 @@
         },
         {
             "id": "161b2d5b-de0e-5b90-8a8f-fd23073a928a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcff41e-b6ff-4ddd-bcb6-8943f7d88aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcff41e-b6ff-4ddd-bcb6-8943f7d88aef.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -17205,7 +17205,7 @@
         },
         {
             "id": "9effde9d-e6e2-5820-a315-e32038382b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b7e3b5-2f3c-4eb7-abc9-322a049a9e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b7e3b5-2f3c-4eb7-abc9-322a049a9e1a.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -17236,7 +17236,7 @@
         },
         {
             "id": "d7e8ec2d-f7a8-5356-9a08-eb7d3ab43fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2c363-c879-4c36-b08a-dd57e3da19ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2c363-c879-4c36-b08a-dd57e3da19ae.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17266,7 +17266,7 @@
         },
         {
             "id": "50a05a15-a231-58a9-92a1-916e628d89c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg?1",
             "name": "The Ring // The Ring Tempts You",
             "text": "",
             "colours": [],
@@ -17294,7 +17294,7 @@
         },
         {
             "id": "6670b85a-2726-50b8-9c8d-0dde8ec08275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg?1",
             "name": "The Ring // The Ring Tempts You",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M10.json
+++ b/Assets/Resources/Sets/M10.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "19b4fa74-a88f-5793-9b14-fe824aefa268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c50891-af21-4427-a495-0e66aef54809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c50891-af21-4427-a495-0e66aef54809.jpg?1",
             "name": "Ajani Goldmane",
             "text": "+1: You gain 2 life.\n-1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n-6: Put a white Avatar creature token onto the battlefield with \"This creature's power and toughness are each equal to your life total.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "ce97d815-3eea-5017-8102-3b803b565ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911124-3646-4014-b574-13fee44bfad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911124-3646-4014-b574-13fee44bfad5.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "15198b4d-8302-50f2-93fb-3855dcf146b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebbb4e-9e1d-49f5-b05b-ae59df0deb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebbb4e-9e1d-49f5-b05b-ae59df0deb17.jpg?1",
             "name": "Armored Ascension",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "ab3c9995-0bca-5f1a-9a40-bc4e2ffe3df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6764ea7b-ccb3-4f39-b8ba-654a186210b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6764ea7b-ccb3-4f39-b8ba-654a186210b9.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "629745a6-f228-5b86-b140-539d4d5c46d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420de077-7ee0-446c-aefc-ca8d7ac698b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420de077-7ee0-446c-aefc-ca8d7ac698b5.jpg?1",
             "name": "Blinding Mage",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "a740b9a3-6944-579d-87c1-5ca44f99a324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c26b98-790e-403b-b94b-261a4c92e721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c26b98-790e-403b-b94b-261a4c92e721.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "cdd2de0a-f409-57b3-ab48-eaec7437ae33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f693c3db-a9e3-418c-afdd-e2e245461e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f693c3db-a9e3-418c-afdd-e2e245461e71.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "173e9717-287d-5b08-bd4c-c5d247ddc326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48444e14-c73b-47d1-9c55-0ff4dc3c6034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48444e14-c73b-47d1-9c55-0ff4dc3c6034.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "051980a5-d7f6-5f76-97c5-105ce256fbc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bda0b4b-ab5a-4d91-9dd1-7a5a145b67f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bda0b4b-ab5a-4d91-9dd1-7a5a145b67f5.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "d814d4e0-f586-5ff4-904a-a40181537b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12aad375-653e-47ed-b8e3-34dd90d43420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12aad375-653e-47ed-b8e3-34dd90d43420.jpg?1",
             "name": "Excommunicate",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "bb72f1a7-c482-5c89-8ec4-b7502ddf2746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6dfcf8-a09b-4402-af80-90fe15b2ce0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6dfcf8-a09b-4402-af80-90fe15b2ce0a.jpg?1",
             "name": "Glorious Charge",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "970be000-af2e-543f-89a3-2e4a541b2a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6784b663-b117-45a2-bde4-72e080058ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6784b663-b117-45a2-bde4-72e080058ea7.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -407,7 +407,7 @@
         },
         {
             "id": "711fc60a-a939-5634-999e-1e7ae9a2efb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84613ce-9b59-4ef6-8c76-5b208ff9de88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84613ce-9b59-4ef6-8c76-5b208ff9de88.jpg?1",
             "name": "Guardian Seraph",
             "text": "Flying\nIf a source an opponent controls would deal damage to you, prevent 1 of that damage.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "e39554d8-a4ae-5a62-8ef5-18a62bac9024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e8a22d-a94e-4dfa-86a3-edb80a03d82a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e8a22d-a94e-4dfa-86a3-edb80a03d82a.jpg?1",
             "name": "Harm's Way",
             "text": "The next 2 damage that a source of your choice would deal to you or a permanent you control this turn is dealt to target creature or player instead.",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "92be80fb-077b-59bf-b6d9-d2011450b623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae8ba7-bbf4-44ab-a8b6-742764a7bc5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae8ba7-bbf4-44ab-a8b6-742764a7bc5b.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "a7009a1e-0c68-52b0-9348-1fd06c5f0313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a40f09-d16a-43c7-b4fd-244f45883a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a40f09-d16a-43c7-b4fd-244f45883a47.jpg?1",
             "name": "Honor of the Pure",
             "text": "White creatures you control get +1/+1.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "fe8310e8-4d16-5d1c-bd81-1f9780426636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8765a0-c2ae-4b1a-a3f5-0243b43e6da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8765a0-c2ae-4b1a-a3f5-0243b43e6da0.jpg?1",
             "name": "Indestructibility",
             "text": "Enchant permanent\nEnchanted permanent is indestructible. (Effects that say \"destroy\" don't destroy that permanent. An indestructible creature can't be destroyed by damage.)",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "f0c05ac0-4522-5f58-acfc-b81d7753b749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d881c1-24e7-4ce7-8ab1-474cb040ddd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d881c1-24e7-4ce7-8ab1-474cb040ddd7.jpg?1",
             "name": "Lifelink",
             "text": "Enchant creature\nEnchanted creature has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "83644cf1-2008-5a57-891b-b4c8294eaee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4146a2-08a2-4a9c-b208-a2d02c68e713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4146a2-08a2-4a9c-b208-a2d02c68e713.jpg?1",
             "name": "Lightwielder Paladin",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Lightwielder Paladin deals combat damage to a player, you may exile target black or red permanent that player controls.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "79b73e02-4911-517f-ab33-cf911c2c60b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dfb34b-488d-4185-94ca-99db74af99a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dfb34b-488d-4185-94ca-99db74af99a5.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "6fc2c449-8db2-55ae-8601-45ab312d135f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb29703-96de-475a-9499-b3cd2a2d6566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb29703-96de-475a-9499-b3cd2a2d6566.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control. (Auras with nothing to enchant remain in graveyards.)",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "856b674c-95a8-58ff-8fa0-e5fa2e9189e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d34551e-36a4-49ea-9d2a-4c72575fe06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d34551e-36a4-49ea-9d2a-4c72575fe06a.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "a7575d37-2ff6-5b7a-9d5b-44dfa26dea05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa60be-f989-4aa8-a3fb-a95143d32131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa60be-f989-4aa8-a3fb-a95143d32131.jpg?1",
             "name": "Palace Guard",
             "text": "Palace Guard can block any number of creatures.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "a9d38e86-554c-5b69-a1ce-cb6b00a0cc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ee0d57-e404-4599-9b6e-f8ab8a95f9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ee0d57-e404-4599-9b6e-f8ab8a95f9fa.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "e6e04921-13e6-514f-9fa9-324162808f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4d69c-f61d-4122-9e0b-c88aa905d159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4d69c-f61d-4122-9e0b-c88aa905d159.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "2e716162-3853-55fd-a05f-49c81749975f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3684a28-e819-4909-912e-dec4a9cf1b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3684a28-e819-4909-912e-dec4a9cf1b11.jpg?1",
             "name": "Rhox Pikemaster",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nOther Soldier creatures you control have first strike.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "929465e9-7a27-5a5a-8929-d85a8ad97507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d15407-c51b-47e7-befd-e9b8b5b3d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d15407-c51b-47e7-befd-e9b8b5b3d93d.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "113ddbb6-a86d-5304-8118-bc2c51a9561e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8528ef-5e7d-46da-a454-395cd38c213f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8528ef-5e7d-46da-a454-395cd38c213f.jpg?1",
             "name": "Safe Passage",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "aaaecfbb-7ceb-5733-aa11-ea78f24cdb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2befd-8a6d-43ba-97e3-5abae8067adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2befd-8a6d-43ba-97e3-5abae8067adb.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "ac5511d7-e298-5b71-925f-bffc551e5980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287d4c56-1b75-4ac4-8be8-333b1aba982a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287d4c56-1b75-4ac4-8be8-333b1aba982a.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "8ea00b71-952e-57b2-8fe3-2e3966dc21d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1559d660-8a9d-422b-95d3-710a046583dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1559d660-8a9d-422b-95d3-710a046583dd.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn. (Spells cast before this resolves are unaffected.)",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "470a3557-5460-5052-82e9-25094c1e755e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea82996f-a05f-4831-9bbd-3281ebca9a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea82996f-a05f-4831-9bbd-3281ebca9a61.jpg?1",
             "name": "Silvercoat Lion",
             "text": "",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "d4e394ae-5b56-559a-ac94-f1e6d315ed28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aafbcc-113e-4816-95d2-a192f32ea9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aafbcc-113e-4816-95d2-a192f32ea9ea.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "4befb815-c514-5aca-8d60-a95c94932296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbdd169-958f-42df-812d-f75fbed9576f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbdd169-958f-42df-812d-f75fbed9576f.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature enters the battlefield, you gain 1 life.",
             "colours": [
@@ -1144,7 +1144,7 @@
         },
         {
             "id": "6816ccc7-6088-5c03-8e01-0eb0b46027fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2429a15-ccbe-463c-9218-968709d9e878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2429a15-ccbe-463c-9218-968709d9e878.jpg?1",
             "name": "Stormfront Pegasus",
             "text": "Flying",
             "colours": [
@@ -1178,7 +1178,7 @@
         },
         {
             "id": "0687da39-0c5f-5c33-8185-9e4886cad657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9c3f-c72d-4b7b-a2c2-5249fbf0990f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9c3f-c72d-4b7b-a2c2-5249fbf0990f.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -1210,7 +1210,7 @@
         },
         {
             "id": "4d077553-f5d8-5611-adc1-9d8051c895cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3439568c-606e-4b95-b4fc-4d31e12ff30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3439568c-606e-4b95-b4fc-4d31e12ff30a.jpg?1",
             "name": "Undead Slayer",
             "text": "{W}, {T}: Exile target Skeleton, Vampire, or Zombie.",
             "colours": [
@@ -1245,7 +1245,7 @@
         },
         {
             "id": "87a06a1a-7ea8-54c9-8b78-371d0120ddaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f506b5-2e24-47fd-a41e-1e834ce48cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f506b5-2e24-47fd-a41e-1e834ce48cd1.jpg?1",
             "name": "Veteran Armorsmith",
             "text": "Other Soldier creatures you control get +0/+1.",
             "colours": [
@@ -1280,7 +1280,7 @@
         },
         {
             "id": "015ddab8-d151-5dca-a7ed-88bd282deb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50e0950-e1ef-4c5c-b758-e707ef026d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50e0950-e1ef-4c5c-b758-e707ef026d54.jpg?1",
             "name": "Veteran Swordsmith",
             "text": "Other Soldier creatures you control get +1/+0.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "d18b48e9-969e-5971-aae6-c527bf9d5ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f30f77-75ea-4145-a4a1-106cc547f482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f30f77-75ea-4145-a4a1-106cc547f482.jpg?1",
             "name": "Wall of Faith",
             "text": "Defender (This creature can't attack.)\n{W}: Wall of Faith gets +0/+1 until end of turn.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "af5abcb1-b61d-5056-baa6-d0a8cc7cea8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401c4880-5598-44e6-a54b-6ea18e542a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401c4880-5598-44e6-a54b-6ea18e542a72.jpg?1",
             "name": "White Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black.)",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "17f0c35c-bd56-5f37-9347-4839f18ccd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9de2b27-f7d1-4e2d-97b2-2bb236b6fb10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9de2b27-f7d1-4e2d-97b2-2bb236b6fb10.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "77e80580-d003-53bf-86e7-0d52382ecd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4e1cc3-4e47-4eff-9047-c6d1cc84d635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4e1cc3-4e47-4eff-9047-c6d1cc84d635.jpg?1",
             "name": "Alluring Siren",
             "text": "{T}: Target creature an opponent controls attacks you this turn if able.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "1caeac6f-d0e0-562c-811a-038a7021eed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2667f1d1-18d3-4bb4-a071-dd65b237d733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2667f1d1-18d3-4bb4-a071-dd65b237d733.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1484,7 +1484,7 @@
         },
         {
             "id": "4fe605f8-6275-5704-bd91-21792739d827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f6340-865f-437c-983e-df39aad032ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f6340-865f-437c-983e-df39aad032ab.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1518,7 +1518,7 @@
         },
         {
             "id": "7e8a98a7-deb6-5537-bd1f-ba93627cd3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb757102-4636-46ae-b202-c2095aeb187c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb757102-4636-46ae-b202-c2095aeb187c.jpg?1",
             "name": "Convincing Mirage",
             "text": "Enchant land\nAs Convincing Mirage enters the battlefield, choose a basic land type.\nEnchanted land is the chosen type.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "b4e9ea6e-a24b-5499-8450-25670b56dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be47536-d202-4a09-83cb-8a244b2aef4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be47536-d202-4a09-83cb-8a244b2aef4a.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "b6af30dd-99d6-51ff-9bab-ae4525836a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17965a3c-92b4-4f01-b076-e40c567eed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17965a3c-92b4-4f01-b076-e40c567eed33.jpg?1",
             "name": "Disorient",
             "text": "Target creature gets -7/-0 until end of turn.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "929e1ef3-279e-5cfb-b86a-0f32055dc296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102cec9-1cdc-4946-a2dd-caf04eaa8b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102cec9-1cdc-4946-a2dd-caf04eaa8b97.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "940f4a9e-fc4d-51f4-8d76-2c30cf58a9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3b0949-17e1-4f12-8999-d4638d32dd3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3b0949-17e1-4f12-8999-d4638d32dd3e.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "ad0e2d07-fca4-5839-b066-cfa5eb8a29b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c231101e-6620-46fc-a0ad-a53291d12dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c231101e-6620-46fc-a0ad-a53291d12dc2.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "e2c3279e-e3d0-5c3b-8c3e-fe4e7d6fc368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75d8c9-c15d-4474-9d3f-d35f49e46477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75d8c9-c15d-4474-9d3f-d35f49e46477.jpg?1",
             "name": "Fabricate",
             "text": "Search your library for an artifact card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "8501568d-c179-500c-8c0b-0f3031695d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa49b9-4bd3-4d2e-9378-3df209680a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa49b9-4bd3-4d2e-9378-3df209680a2c.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "67e9cf41-d028-5def-aedc-92cbf39fb986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d50518-5cfc-45de-a125-acabf97b8743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d50518-5cfc-45de-a125-acabf97b8743.jpg?1",
             "name": "Hive Mind",
             "text": "Whenever a player casts an instant or sorcery spell, each other player copies that spell. Each of those players may choose new targets for his or her copy.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "05f360a5-79f4-5360-8ddc-44e1f4e37124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabd1d9-e1c0-4f5e-88d6-a8d480cf30ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabd1d9-e1c0-4f5e-88d6-a8d480cf30ba.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "cba86f1d-8c14-54f0-81bd-776204ea3da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d18c4d7-c779-473b-9b41-f22b439bb501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d18c4d7-c779-473b-9b41-f22b439bb501.jpg?1",
             "name": "Ice Cage",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "ee065864-9f0b-5ae1-80a0-7a44d2a18f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348f3e-8c08-4250-95a9-fc5ed63cd725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348f3e-8c08-4250-95a9-fc5ed63cd725.jpg?1",
             "name": "Illusionary Servant",
             "text": "Flying\nWhen Illusionary Servant becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "7cfd2977-6f16-57d3-8dbf-5e6f66575e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a771996a-0097-4fe5-a9c0-22a047f9cf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a771996a-0097-4fe5-a9c0-22a047f9cf2e.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n-1: Target player draws a card.\n-10: Target player puts the top twenty cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "499fd085-de83-5af2-a332-c3bccfffa5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edd7be9-9334-4684-b642-1aaf2000e054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edd7be9-9334-4684-b642-1aaf2000e054.jpg?1",
             "name": "Jump",
             "text": "Target creature gains flying until end of turn.",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "a008bdb4-fa47-53d9-aeed-d6485d8291ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1489a41b-1371-41b4-9b5e-03d95bdfdd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1489a41b-1371-41b4-9b5e-03d95bdfdd7c.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "5355b507-7881-5219-9dd2-e5d382fbd32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3f76dd-6c72-4a26-a252-18dc2f6d3396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3f76dd-6c72-4a26-a252-18dc2f6d3396.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "e42f3da6-f98c-522b-9b62-249d8abec478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9826a2e-361e-4701-9177-0907c0c6dc9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9826a2e-361e-4701-9177-0907c0c6dc9f.jpg?1",
             "name": "Merfolk Sovereign",
             "text": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature is unblockable this turn.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "07180192-8736-5902-85a3-32acfb937e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37151305-e489-4df1-9b0a-c5e11c77d2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37151305-e489-4df1-9b0a-c5e11c77d2f1.jpg?1",
             "name": "Mind Control",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "e6009c2f-c44f-5649-910a-42a7232c766f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bea6b5-005c-48c8-9f2b-0dfb18039429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bea6b5-005c-48c8-9f2b-0dfb18039429.jpg?1",
             "name": "Mind Spring",
             "text": "Draw X cards.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "182aabc5-078a-54a6-a7cc-3be4fdd6d777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d196-332c-4266-aac8-a35754d74297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d196-332c-4266-aac8-a35754d74297.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "773d3f48-7cf8-5103-bf45-308c6c1e1c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235ca1b3-58aa-4cc0-8201-bcd2ef20ea58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235ca1b3-58aa-4cc0-8201-bcd2ef20ea58.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -2217,7 +2217,7 @@
         },
         {
             "id": "45e7b454-b831-57b3-a71e-6aaac1f34d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d274f4-452b-4ff2-b026-83667e9ba98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d274f4-452b-4ff2-b026-83667e9ba98f.jpg?1",
             "name": "Polymorph",
             "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "dac201d5-0fb7-57a4-9f37-499d8c565e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02b8ee-84cb-44cb-ba14-9e725a9d03ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02b8ee-84cb-44cb-ba14-9e725a9d03ee.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "36056ae2-a012-5fae-a278-6c48d1a483ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48af662-25a3-46a0-a48c-ba8cc417490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48af662-25a3-46a0-a48c-ba8cc417490c.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl enters the battlefield, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "6b9ae887-31ef-5ad5-af46-945153b9433d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d734-7e19-4c1e-a5c2-097b718df7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d734-7e19-4c1e-a5c2-097b718df7c4.jpg?1",
             "name": "Serpent of the Endless Sea",
             "text": "Serpent of the Endless Sea's power and toughness are each equal to the number of Islands you control.\nSerpent of the Endless Sea can't attack unless defending player controls an Island.",
             "colours": [
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "82166ccf-56e7-59fd-a8db-2e376c61fcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133be4f4-1daa-41b6-b509-9e64c6b00059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133be4f4-1daa-41b6-b509-9e64c6b00059.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2381,7 +2381,7 @@
         },
         {
             "id": "f13f81d3-4c3c-581b-9128-450fd391a0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16ec84d-8644-419d-9f51-5efc9f761d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16ec84d-8644-419d-9f51-5efc9f761d74.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "8a12fb74-43a5-5862-9425-51df92d49e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0937274-d5cb-4790-8c10-804f537c5581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0937274-d5cb-4790-8c10-804f537c5581.jpg?1",
             "name": "Sphinx Ambassador",
             "text": "Flying\nWhenever Sphinx Ambassador deals combat damage to a player, search that player's library for a card, then that player names a card. If you searched for a creature card that isn't the named card, you may put it onto the battlefield under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "1f1948ff-8938-5c25-84d2-9b0ab6b67e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce03b4b4-612b-4fc9-b063-b0d367712eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce03b4b4-612b-4fc9-b063-b0d367712eaf.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "a54fcc8a-1f83-5e92-807f-d5e0893f93d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21c7628-0571-4c09-8763-8e434e5e87d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21c7628-0571-4c09-8763-8e434e5e87d2.jpg?1",
             "name": "Time Warp",
             "text": "Target player takes an extra turn after this one.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "f1b63129-4904-544b-b156-c64c10048a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbdf96b-e7c5-42e5-9a16-03daafde40af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbdf96b-e7c5-42e5-9a16-03daafde40af.jpg?1",
             "name": "Tome Scour",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "ed89e69a-cab6-581f-929b-0f48fc9af63c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cdf46e-cf63-406c-b8f7-121117c6f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cdf46e-cf63-406c-b8f7-121117c6f10b.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "f209599e-e3f6-53ed-ba67-f7f29c65b69a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38eec33-a40e-4739-ad2c-2f57008cef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38eec33-a40e-4739-ad2c-2f57008cef4e.jpg?1",
             "name": "Twincast",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "d8d6b53c-5ae5-5e0b-bf28-b7a29e81a6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db75881-4d4b-4dd9-8d40-c8f89c04f713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db75881-4d4b-4dd9-8d40-c8f89c04f713.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "03b1d415-6a5d-5274-862a-c3ef9c6098cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc35a7-e38b-4c15-889a-d58c8b360315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc35a7-e38b-4c15-889a-d58c8b360315.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "81a1ef35-b5be-51f1-85ed-d367ecb96458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60db38a-1f8a-4b8e-afab-ab9a3ab46ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60db38a-1f8a-4b8e-afab-ab9a3ab46ef3.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "b1965c29-7166-5aad-9c51-0c94a81a6e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256f91a-e797-41d7-82a6-3dcd691bbeed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256f91a-e797-41d7-82a6-3dcd691bbeed.jpg?1",
             "name": "Zephyr Sprite",
             "text": "Flying",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "61049ff0-47a8-5a99-aa7f-7797a23f6e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0b14d4-41de-42ac-9894-77bbcebaabfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0b14d4-41de-42ac-9894-77bbcebaabfc.jpg?1",
             "name": "Acolyte of Xathrid",
             "text": "{1}{B}, {T}: Target player loses 1 life.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "459b0968-7de6-5989-926c-06f9b8ef6458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14171597-9bf3-441c-a844-a0e1ac4bb1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14171597-9bf3-441c-a844-a0e1ac4bb1db.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "2e2db0ae-2900-545d-acf9-ffb9917cf21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e710e692-3802-4d5c-9ba9-e55a0c602f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e710e692-3802-4d5c-9ba9-e55a0c602f52.jpg?1",
             "name": "Black Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from white (This creature can't be blocked, targeted, dealt damage, or enchanted by anything white.)",
             "colours": [
@@ -2845,7 +2845,7 @@
         },
         {
             "id": "7ec86d79-05cc-5242-9e5c-2bc7e16827d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d17210c-be39-4abc-9d4d-4f2eca9573bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d17210c-be39-4abc-9d4d-4f2eca9573bd.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "575f0825-b2ee-5df0-a9ba-543ba7736362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639b48f0-3426-46cf-b857-4611f7de4826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639b48f0-3426-46cf-b857-4611f7de4826.jpg?1",
             "name": "Cemetery Reaper",
             "text": "Other Zombie creatures you control get +1/+1.\n{2}{B}, {T}: Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -2913,7 +2913,7 @@
         },
         {
             "id": "f0f1a731-81fc-5c75-9870-6bef45736952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f7a9a7-3679-4a18-a52a-e3a8ab16ad32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f7a9a7-3679-4a18-a52a-e3a8ab16ad32.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2947,7 +2947,7 @@
         },
         {
             "id": "a4287dc6-d8d5-535f-b063-f3938c9b635b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db2f958-947b-4b52-a5cd-e8f8b5576803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db2f958-947b-4b52-a5cd-e8f8b5576803.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "979e82f1-e593-5df2-84be-682cccbc10e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61268362-f2ba-469d-8e5a-0b8da96e54a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61268362-f2ba-469d-8e5a-0b8da96e54a5.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "190918eb-d3f3-5139-8a56-4a31563d925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7af1b-97c9-4954-bb21-1e389fcb6361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7af1b-97c9-4954-bb21-1e389fcb6361.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "7fc6b88d-6a19-5155-8d04-199c05e0bede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a329a0-a14a-49b9-adcd-397b566211ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a329a0-a14a-49b9-adcd-397b566211ee.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "a1d53c52-3c92-5ef0-a1df-83ed2a553b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19acff-f3dd-417a-a9ab-ea3e36c1ba61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19acff-f3dd-417a-a9ab-ea3e36c1ba61.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "8b390e9e-a954-51dd-89d7-d7389ad60e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f964660-c2db-4995-bb16-65383362cf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f964660-c2db-4995-bb16-65383362cf19.jpg?1",
             "name": "Dread Warlock",
             "text": "Dread Warlock can't be blocked except by black creatures.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "fa067f42-db44-557c-9e04-85b258b67849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425836be-f5cd-4584-a2ff-a8cf166eccc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425836be-f5cd-4584-a2ff-a8cf166eccc0.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "8c1da832-0e27-57b6-9ee5-9974999da8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d759602b-38c9-42fe-902a-0e696ccbdf13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d759602b-38c9-42fe-902a-0e696ccbdf13.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "70922895-fa92-58f4-91b5-f89bf9113476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595fff83-78d2-454f-8099-ee2da87c4826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595fff83-78d2-454f-8099-ee2da87c4826.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "4d25c643-36d6-546e-b1ca-322a97ae2efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e9113-6e97-43af-9e61-71c7917c0870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e9113-6e97-43af-9e61-71c7917c0870.jpg?1",
             "name": "Haunting Echoes",
             "text": "Exile all cards from target player's graveyard other than basic land cards. For each card exiled this way, search that player's library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "9aee62cf-f5de-54bc-a4b6-ff5f59fc3386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e38e91-696e-4bf9-b46c-c9ed85c82b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e38e91-696e-4bf9-b46c-c9ed85c82b19.jpg?1",
             "name": "Howling Banshee",
             "text": "Flying\nWhen Howling Banshee enters the battlefield, each player loses 3 life.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "279798c9-a5d9-527a-9568-43814eb7cd8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695f390-f791-4d64-90b2-731d6d37df1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695f390-f791-4d64-90b2-731d6d37df1c.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "5bdf223f-d659-5a74-98f8-5235385c9369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542b3ec9-7800-4dea-bf39-b51a11b58339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542b3ec9-7800-4dea-bf39-b51a11b58339.jpg?1",
             "name": "Kelinore Bat",
             "text": "Flying",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "4673dc75-2421-5c04-95ad-0ae85053ac08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6045789-a75b-4b7f-acde-0fdf7f3f262c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6045789-a75b-4b7f-acde-0fdf7f3f262c.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n-2: Search your library for a card, then shuffle your library and put that card on top of it.\n-8: Put all creature cards in all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "88dd9e41-7dc5-5ccb-9453-3865b6031009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6703c-38d4-4c86-b5b0-ebfde81bb1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6703c-38d4-4c86-b5b0-ebfde81bb1bf.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3447,7 +3447,7 @@
         },
         {
             "id": "01c55ca2-176d-52a3-82df-c2380b84c563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b04fca4-b4de-4343-ba58-d8aea39edc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b04fca4-b4de-4343-ba58-d8aea39edc19.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "a01d2d5b-a5cc-5c60-b8cf-5ff6b93f6cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ae0d9d-170b-4c96-8fa2-68b81eaa13c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ae0d9d-170b-4c96-8fa2-68b81eaa13c9.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3511,7 +3511,7 @@
         },
         {
             "id": "3541af77-88a9-5383-8e87-acc6b50dc5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e089963a-f253-4e7a-9ddb-1880291a6a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e089963a-f253-4e7a-9ddb-1880291a6a23.jpg?1",
             "name": "Mind Shatter",
             "text": "Target player discards X cards at random.",
             "colours": [
@@ -3543,7 +3543,7 @@
         },
         {
             "id": "bc1d6a45-462b-5181-b5bc-f73e28b30249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d53fd-2d3b-4050-b5c5-1b75f525ca2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d53fd-2d3b-4050-b5c5-1b75f525ca2c.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "cf893bbc-78a0-5e7c-b434-12cf929a2821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700dfa3a-299d-4d4e-bb32-d29a1f6aa670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700dfa3a-299d-4d4e-bb32-d29a1f6aa670.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "f2ce76a9-ccc1-5f3f-91bb-d86328d7579c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9dd0d9-8e35-4a8c-af6f-83c7d2a3ea7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9dd0d9-8e35-4a8c-af6f-83c7d2a3ea7d.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card in a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "23c9a26d-228b-5943-bd83-a73221b4ce86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94e3cdf-8312-4824-80b0-36be988e6eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94e3cdf-8312-4824-80b0-36be988e6eb4.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "789fc945-1d7c-5d52-b19f-bbec71669bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445d6a68-ed53-4c96-973a-c29282514f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445d6a68-ed53-4c96-973a-c29282514f41.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "87598bd3-0732-5fd7-8b9d-d52cea1b1a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975ed97-acb8-4bb6-804a-e5da725d876e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975ed97-acb8-4bb6-804a-e5da725d876e.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3743,7 +3743,7 @@
         },
         {
             "id": "7208de05-109c-56fe-95d8-39266ee7aaae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54800a5a-33fe-4291-a7b4-a1eb256dfa8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54800a5a-33fe-4291-a7b4-a1eb256dfa8f.jpg?1",
             "name": "Soul Bleed",
             "text": "Enchant creature\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "88aabf3b-9768-5908-8024-7dc676c8e0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97cf3d1-4929-4161-bc5e-f7fa0fb9af68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97cf3d1-4929-4161-bc5e-f7fa0fb9af68.jpg?1",
             "name": "Tendrils of Corruption",
             "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "fa82ce0d-6461-59cf-83d0-28906e647483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f252826-d2bd-4e25-a500-423a727a7e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f252826-d2bd-4e25-a500-423a727a7e9e.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "c550afc5-38f8-585d-8dc1-0c4126e43ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523c3541-405f-47e5-8730-5c7ce0426a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523c3541-405f-47e5-8730-5c7ce0426a4e.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "86e2914f-a864-564e-a645-10684f47351e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac0b9c-0077-44c8-8982-4e7b7e7ad398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac0b9c-0077-44c8-8982-4e7b7e7ad398.jpg?1",
             "name": "Vampire Aristocrat",
             "text": "Sacrifice a creature: Vampire Aristocrat gets +2/+2 until end of turn.",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "fa9af3dd-8d1d-5603-a4af-74281fc7b8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df4f1ea-dbaa-456c-884c-97f03b64fa17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df4f1ea-dbaa-456c-884c-97f03b64fa17.jpg?1",
             "name": "Vampire Nocturnus",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is black, Vampire Nocturnus and other Vampire creatures you control get +2/+1 and have flying.",
             "colours": [
@@ -3945,7 +3945,7 @@
         },
         {
             "id": "55c6dbe9-dcb5-5cfc-a49f-bd2bf30fc3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d80ce-284a-4d22-9ea8-f8d480377212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d80ce-284a-4d22-9ea8-f8d480377212.jpg?1",
             "name": "Wall of Bone",
             "text": "Defender (This creature can't attack.)\n{B}: Regenerate Wall of Bone. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3980,7 +3980,7 @@
         },
         {
             "id": "f27419f7-a7b5-5ce8-97a5-f3a640f91fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6cc262-ba0c-4cca-ae9c-24a1824753e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6cc262-ba0c-4cca-ae9c-24a1824753e4.jpg?1",
             "name": "Warpath Ghoul",
             "text": "",
             "colours": [
@@ -4014,7 +4014,7 @@
         },
         {
             "id": "4e5e9e9e-515c-5c57-8538-39af87ff4aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb8322c-63e1-4618-8ee3-7e635cc8bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb8322c-63e1-4618-8ee3-7e635cc8bf5e.jpg?1",
             "name": "Weakness",
             "text": "Enchant creature\nEnchanted creature gets -2/-1.",
             "colours": [
@@ -4048,7 +4048,7 @@
         },
         {
             "id": "162c5c9d-e4a8-5dad-9330-9ad737a503cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8ead-f295-4ca7-a309-6768e6e765cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8ead-f295-4ca7-a309-6768e6e765cf.jpg?1",
             "name": "Xathrid Demon",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature other than Xathrid Demon, then each opponent loses life equal to the sacrificed creature's power. If you can't sacrifice a creature, tap Xathrid Demon and you lose 7 life.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "7c1ac8da-e00e-5dae-afeb-17b08941f53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc295834-af33-45ae-be4d-7a1987f85561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc295834-af33-45ae-be4d-7a1987f85561.jpg?1",
             "name": "Zombie Goliath",
             "text": "",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "ad3f4ca2-c974-5463-86c2-c95cb37f50b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63bee5-d8e5-4c2f-8514-8c86d025f7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63bee5-d8e5-4c2f-8514-8c86d025f7c9.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4149,7 +4149,7 @@
         },
         {
             "id": "28d23ebf-cad0-56ac-a713-40d31612887a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a9d0-0add-4cf1-958c-9367c7441c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a9d0-0add-4cf1-958c-9367c7441c62.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample (If this creature would deal enough damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player or planeswalker.)\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nAt the beginning of the end step, sacrifice Ball Lightning.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "2e759850-0016-58a8-89da-f6b6e033c468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485ebe59-0fdb-463f-a6ad-51881cfde3da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485ebe59-0fdb-463f-a6ad-51881cfde3da.jpg?1",
             "name": "Berserkers of Blood Ridge",
             "text": "Berserkers of Blood Ridge attacks each turn if able.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "d62fc0ba-833a-5141-972a-634744138bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3226c1aa-37b8-4499-9579-60618261f3e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3226c1aa-37b8-4499-9579-60618261f3e8.jpg?1",
             "name": "Bogardan Hellkite",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhen Bogardan Hellkite enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "fee99076-d8da-53dc-a4c7-b261883305f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a448bc9e-f5db-4507-ac40-7d8ee3598585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a448bc9e-f5db-4507-ac40-7d8ee3598585.jpg?1",
             "name": "Burning Inquiry",
             "text": "Each player draws three cards, then discards three cards at random.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "17a94ace-af65-51d2-b44a-40eff0170a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8c7aa0-2067-4513-a658-ed866279e671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8c7aa0-2067-4513-a658-ed866279e671.jpg?1",
             "name": "Burst of Speed",
             "text": "Creatures you control gain haste until end of turn. (They can attack and {T} even if they just came under your control.)",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "f84ab93d-fd82-5ca9-9143-766038085b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85b682f-f526-45a8-9a12-db3fe8c3c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85b682f-f526-45a8-9a12-db3fe8c3c8c3.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "224bec57-57c7-5141-92ee-f805897f7ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d844b29-3b5e-4824-befc-affe6aac6d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d844b29-3b5e-4824-befc-affe6aac6d87.jpg?1",
             "name": "Capricious Efreet",
             "text": "At the beginning of your upkeep, choose target nonland permanent you control and up to two target nonland permanents you don't control. Destroy one of them at random.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "141484a3-a0fd-5cfb-b9cf-7a6dc14c49c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce115a-28f8-4350-8e66-74e7a3727657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce115a-28f8-4350-8e66-74e7a3727657.jpg?1",
             "name": "Chandra Nalaar",
             "text": "+1: Chandra Nalaar deals 1 damage to target player.\n-X: Chandra Nalaar deals X damage to target creature.\n-8: Chandra Nalaar deals 10 damage to target player and each creature he or she controls.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "4e6fd3e6-3350-59b9-9278-3250ff5647f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adab786-c851-4de3-9349-65f7f01a81f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adab786-c851-4de3-9349-65f7f01a81f6.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. At the beginning of the end step, if this ability has been activated four or more times this turn, sacrifice Dragon Whelp.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "1ff8b183-e1f3-5c34-b972-b65780dc9fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb8ae1-a619-42bf-976f-2833777032d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb8ae1-a619-42bf-976f-2833777032d2.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "2a2c6531-c0d2-56de-bcd4-dd323128cda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6b2c8a-8019-4e4b-8f4e-058ab5284153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6b2c8a-8019-4e4b-8f4e-058ab5284153.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "1cfbb44c-7e0f-5809-8610-9d40cde9835f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc84106-aec3-4e52-8dcb-1ed545bf3058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc84106-aec3-4e52-8dcb-1ed545bf3058.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "be7427f2-1a04-5246-b809-1deff1d4af71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c13194-20c1-4a93-bbf4-2e02eeb9e0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c13194-20c1-4a93-bbf4-2e02eeb9e0e2.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "bc901968-77d1-54ae-8535-29e50ebbac33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bd59d-9d6d-434d-974f-3aa1cbd770b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bd59d-9d6d-434d-974f-3aa1cbd770b5.jpg?1",
             "name": "Goblin Artillery",
             "text": "{T}: Goblin Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "87b586b3-bccd-5cc4-b844-ee7fd84f3fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c8a4a4-1611-4188-9c59-8aefb016b5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c8a4a4-1611-4188-9c59-8aefb016b5ad.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "e0800520-1c7e-5124-994f-a1c686f4f45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3e1685-a34d-43fc-986f-442523cc0631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3e1685-a34d-43fc-986f-442523cc0631.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "43898865-b335-5823-8844-8f001635c1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425d61c-f224-4ba6-a32e-44e3a3954c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425d61c-f224-4ba6-a32e-44e3a3954c1b.jpg?1",
             "name": "Ignite Disorder",
             "text": "Ignite Disorder deals 3 damage divided as you choose among any number of target white and/or blue creatures.",
             "colours": [
@@ -4724,7 +4724,7 @@
         },
         {
             "id": "c6ef9981-3012-5488-94a6-03486003be7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f05a58-a801-483a-8648-8685a4eaa773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f05a58-a801-483a-8648-8685a4eaa773.jpg?1",
             "name": "Inferno Elemental",
             "text": "Whenever Inferno Elemental blocks or becomes blocked by a creature, Inferno Elemental deals 3 damage to that creature.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "3c34341d-a3d2-5a99-a238-3c5ce31dfc64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a47a2dc-f7f2-4103-9ebe-8cd8b83915ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a47a2dc-f7f2-4103-9ebe-8cd8b83915ae.jpg?1",
             "name": "Jackal Familiar",
             "text": "Jackal Familiar can't attack or block alone.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "3c986387-cc1b-5156-bb89-fc316cb3b73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004b84-ac1a-49a1-862b-ce86bcae2c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004b84-ac1a-49a1-862b-ce86bcae2c6b.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "652d63c8-0061-5307-b8bc-25b0b2da75af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cbcef1-81b1-4847-ada3-1ce84cdfdce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cbcef1-81b1-4847-ada3-1ce84cdfdce3.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "78380203-7623-50bc-ab48-577cd655ee9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435589bb-27c6-4a6d-9d63-394d5092b9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435589bb-27c6-4a6d-9d63-394d5092b9d8.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "c69451e8-2b15-592f-8898-b8c3a05ef513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8314a22b-11db-4882-835a-75f8f1ad15df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8314a22b-11db-4882-835a-75f8f1ad15df.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "6a70e3d2-e02a-5e2a-b222-1cd3a4d09d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63466db8-270e-4c68-8823-963f993de783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63466db8-270e-4c68-8823-963f993de783.jpg?1",
             "name": "Magma Phoenix",
             "text": "Flying\nWhen Magma Phoenix is put into a graveyard from the battlefield, it deals 3 damage to each creature and each player.\n{3}{R}{R}: Return Magma Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "b4bc1494-7bbe-5880-a820-5dc9a31aa3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7499cb21-a8ec-4938-884b-7085946af8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7499cb21-a8ec-4938-884b-7085946af8f8.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to that player.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "073b1930-c019-5d81-a1f3-d8591573d0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c6cbc8-e33a-4692-aff0-4de9bb65421d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c6cbc8-e33a-4692-aff0-4de9bb65421d.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "5c3e3371-9565-5e59-838b-c8fc0edc15c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea894b56-7427-4dda-a63a-65608252f13e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea894b56-7427-4dda-a63a-65608252f13e.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "f1700bec-c9dd-5322-9a63-cae2c99612e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df4f214-5db5-41ea-8e06-e8f0aaeac05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df4f214-5db5-41ea-8e06-e8f0aaeac05d.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "fd74a5d3-beea-5ca2-b590-0282dac572f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa318c3a-70ae-499a-8022-b380f03fd53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa318c3a-70ae-499a-8022-b380f03fd53f.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "734dd7ac-581a-50f6-a5bb-1b8c1c1e05f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6526a501-9402-44c1-8e3c-ce01b4ed5b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6526a501-9402-44c1-8e3c-ce01b4ed5b87.jpg?1",
             "name": "Seismic Strike",
             "text": "Seismic Strike deals damage to target creature equal to the number of Mountains you control.",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "2a837b8a-e9c9-5ee6-b086-17245aeed711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5847aac2-edb9-4c83-b36c-3a57f037c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5847aac2-edb9-4c83-b36c-3a57f037c074.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5186,7 +5186,7 @@
         },
         {
             "id": "a91b9680-80f4-5676-ad64-0153775d79cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efc94a-b644-4cc4-9598-2ce16fe68420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efc94a-b644-4cc4-9598-2ce16fe68420.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "33813ecd-bd8f-5bc3-a4ef-dcfb67c9413e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5128dd-54dd-42a8-b126-f821f87ad069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5128dd-54dd-42a8-b126-f821f87ad069.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, put three 1/1 red Goblin creature tokens onto the battlefield.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -5254,7 +5254,7 @@
         },
         {
             "id": "e3b1053f-e4ff-51d1-8b9b-10c93351a088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8344ac6f-8b79-440a-ad4d-3bd24b4d3229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8344ac6f-8b79-440a-ad4d-3bd24b4d3229.jpg?1",
             "name": "Sparkmage Apprentice",
             "text": "When Sparkmage Apprentice enters the battlefield, it deals 1 damage to target creature or player.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "8583e246-b675-5dd7-a8e7-d1abe21d34e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e3aadb-88c9-4629-bf9f-7ea5dccaacb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e3aadb-88c9-4629-bf9f-7ea5dccaacb6.jpg?1",
             "name": "Stone Giant",
             "text": "{T}: Target creature you control with toughness less than Stone Giant's power gains flying until end of turn. Destroy that creature at the beginning of the end step.",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "15ad984f-b89c-552c-89f0-9b21148fd246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ca754-7da8-49ad-a26c-8e20b37e411e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ca754-7da8-49ad-a26c-8e20b37e411e.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "d7e5d2b5-ddb3-52f1-a3e5-3e90693f4336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232226ab-918c-49b6-9f5b-fa0e0a1ba1d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232226ab-918c-49b6-9f5b-fa0e0a1ba1d3.jpg?1",
             "name": "Viashino Spearhunter",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5390,7 +5390,7 @@
         },
         {
             "id": "9914ea8a-2053-55a8-a6de-0940d9845973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a365050-196b-4513-8143-c823a96da9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a365050-196b-4513-8143-c823a96da9a0.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "2797f077-f702-59df-86dd-6b7e76feaece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6e1fb5-a06b-4e10-8cc7-785e0f0b298e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6e1fb5-a06b-4e10-8cc7-785e0f0b298e.jpg?1",
             "name": "Warp World",
             "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library.",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "1d1a0c62-e67b-5d77-80e4-b4646532742f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa364a1c-14e4-4dda-aa1f-edb879a64a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa364a1c-14e4-4dda-aa1f-edb879a64a2d.jpg?1",
             "name": "Yawning Fissure",
             "text": "Each opponent sacrifices a land.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "59689e96-0e50-5fe7-90aa-302c502208f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1377f45-edee-4922-825b-6f22163ff63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1377f45-edee-4922-825b-6f22163ff63d.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5522,7 +5522,7 @@
         },
         {
             "id": "5e41048e-28c5-550c-9ad7-82ff221acad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee46d8b-559e-4c33-99fb-b55f00aeee72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee46d8b-559e-4c33-99fb-b55f00aeee72.jpg?1",
             "name": "Ant Queen",
             "text": "{1}{G}: Put a 1/1 green Insect creature token onto the battlefield.",
             "colours": [
@@ -5556,7 +5556,7 @@
         },
         {
             "id": "5111065e-83f8-5340-8118-7627dd3d2b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821bd93c-e25e-4a8d-b4ec-b459ef37f6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821bd93c-e25e-4a8d-b4ec-b459ef37f6c8.jpg?1",
             "name": "Awakener Druid",
             "text": "When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature as long as Awakener Druid is on the battlefield. It's still a land.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "59286d08-668e-5a2a-bc18-9e0f6f5b2eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f94309b-1049-4ab4-b7f0-745938c87b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f94309b-1049-4ab4-b7f0-745938c87b3f.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "7e2d4fae-c95b-5ea9-9ae2-f740c5ccb07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd0f8c8-1a1f-4d9b-a6e1-3654f3995012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd0f8c8-1a1f-4d9b-a6e1-3654f3995012.jpg?1",
             "name": "Borderland Ranger",
             "text": "When Borderland Ranger enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "f95c405b-723c-53a9-9073-bf436b5f651a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d225382c-cc6f-4224-82b5-4309b72feb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d225382c-cc6f-4224-82b5-4309b72feb0b.jpg?1",
             "name": "Bountiful Harvest",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "c31f2fa7-e71c-539f-9b65-47e93ec7ca5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74148e2e-ac21-414a-9b6c-410988d7fdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74148e2e-ac21-414a-9b6c-410988d7fdd0.jpg?1",
             "name": "Bramble Creeper",
             "text": "Whenever Bramble Creeper attacks, it gets +5/+0 until end of turn.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "a5cf3057-7e30-51ca-884c-7598b045e0eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03354b67-7df2-4b4b-a996-a37550e58561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03354b67-7df2-4b4b-a996-a37550e58561.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "690acccd-b452-5f8b-bf35-be5bc4c80852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875f73d-6108-488b-bd34-4cf2c23ce6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875f73d-6108-488b-bd34-4cf2c23ce6b3.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "aace9e39-9048-569c-9105-03d68a3d1461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d779b14c-a100-4382-9e7c-0969efda73ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d779b14c-a100-4382-9e7c-0969efda73ec.jpg?1",
             "name": "Cudgel Troll",
             "text": "{G}: Regenerate Cudgel Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "77b27cbe-a314-5d68-a527-38516658a70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab810f1-21d6-4a98-b77a-e455370aa6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab810f1-21d6-4a98-b77a-e455370aa6cc.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "b6a5a6f6-9149-5ac1-9977-699fc13b222b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544bc214-e32d-4370-a15f-62812a0420be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544bc214-e32d-4370-a15f-62812a0420be.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "20aa30ac-f14b-5c2b-8fb7-0e02c377ccae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5666cb39-5fea-4eaa-a6da-1b2ffc5a3811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5666cb39-5fea-4eaa-a6da-1b2ffc5a3811.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -5934,7 +5934,7 @@
         },
         {
             "id": "be3a2a6d-9a43-5080-83bb-c0bb98aabb3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3ea3-fb3c-4758-8035-20ec0a94b730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3ea3-fb3c-4758-8035-20ec0a94b730.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "fe8e4418-3eed-567c-ba98-9812af12bb34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf14b5-31d0-42e3-a319-2622b489f7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf14b5-31d0-42e3-a319-2622b489f7c4.jpg?1",
             "name": "Emerald Oryx",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -6003,7 +6003,7 @@
         },
         {
             "id": "31024bab-7341-5d08-8a14-85afa47bc13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54069e65-eef4-4fb8-bb0d-932a4c9889b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54069e65-eef4-4fb8-bb0d-932a4c9889b3.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "005ff425-d8d7-550f-8ade-7d2a545031da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717a468-696c-4a84-b943-75046138f2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717a468-696c-4a84-b943-75046138f2bf.jpg?1",
             "name": "Entangling Vines",
             "text": "Enchant tapped creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -6071,7 +6071,7 @@
         },
         {
             "id": "9ad5ed11-6768-5a4e-ab47-daa359a8aa83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c61926-3671-4d5b-8d60-0b946b44c7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c61926-3671-4d5b-8d60-0b946b44c7ec.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -6103,7 +6103,7 @@
         },
         {
             "id": "c60a0c02-9695-5b99-bea9-7663356909a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799315b8-19ab-474e-bbe2-f928d4969daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799315b8-19ab-474e-bbe2-f928d4969daf.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "+1: Untap two target lands.\n-1: Put a 3/3 green Beast creature token onto the battlefield.\n-4: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -6139,7 +6139,7 @@
         },
         {
             "id": "88995d66-3237-55c9-ae85-e2d2ebd91394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df3116a-ce5c-44d1-9286-7deb5d516c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df3116a-ce5c-44d1-9286-7deb5d516c90.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "5a646be2-bedd-50be-afb0-667d151be016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1c68b1-fec9-4d96-b4ad-8d34719f1952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1c68b1-fec9-4d96-b4ad-8d34719f1952.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "4b57c65a-5957-502b-aff6-42efea6c2a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c8a79-1e8a-437d-836f-31155914c551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c8a79-1e8a-437d-836f-31155914c551.jpg?1",
             "name": "Great Sable Stag",
             "text": "Great Sable Stag can't be countered.\nProtection from blue and from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything blue or black.)",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "732eabbd-030c-54a2-a23b-4266745f3d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37ba2c4-dd92-4b23-a830-5dbabc9a972b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37ba2c4-dd92-4b23-a830-5dbabc9a972b.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "Put a 2/2 green Wolf creature token onto the battlefield for each Forest you control.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "fe378e61-da0a-5c0b-8923-1539b5b31177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77064471-d0c1-4988-8c47-f767bf9635f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77064471-d0c1-4988-8c47-f767bf9635f3.jpg?1",
             "name": "Kalonian Behemoth",
             "text": "Shroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "e82a4650-10f2-5030-bf0b-c7faa2c673db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e047c-823b-4d18-a5e9-6de3e6989858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e047c-823b-4d18-a5e9-6de3e6989858.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "1cbab4e2-9da8-5bef-a853-d719b5135368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864c824-89a1-41f6-9481-83b2284471e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864c824-89a1-41f6-9481-83b2284471e0.jpg?1",
             "name": "Lurking Predators",
             "text": "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "a3750421-8ea9-5369-b110-8550c5847dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf3169c-f01c-47f4-ba4b-e199b7ade5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf3169c-f01c-47f4-ba4b-e199b7ade5fc.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "At the beginning of your upkeep, put a 2/2 green Wolf creature token onto the battlefield.\n{T}: Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves.",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "3f555729-8bc1-59b8-bb81-e0254ee8f893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a324b-cf3e-4a0f-95c4-cd548586f7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a324b-cf3e-4a0f-95c4-cd548586f7e5.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "59c16a58-58df-55ea-84b6-4e16ce763693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3a26c7-e028-4741-803d-6384925b8500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3a26c7-e028-4741-803d-6384925b8500.jpg?1",
             "name": "Mist Leopard",
             "text": "Shroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "272e1788-423d-5374-a2e3-cdf0b7c8f51e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216a729-6283-4c2b-90fe-ec8f3b9c570f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216a729-6283-4c2b-90fe-ec8f3b9c570f.jpg?1",
             "name": "Mold Adder",
             "text": "Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on Mold Adder.",
             "colours": [
@@ -6508,7 +6508,7 @@
         },
         {
             "id": "e7f6c351-7484-5b76-ad21-c6ecd5ebc9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae52b4dc-4acd-4fa5-a6b5-613e808cf0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae52b4dc-4acd-4fa5-a6b5-613e808cf0ab.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6540,7 +6540,7 @@
         },
         {
             "id": "f722c960-10b2-509e-b0ed-51746b959905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f9d732-c112-4a80-8b28-a9f036e9b04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f9d732-c112-4a80-8b28-a9f036e9b04a.jpg?1",
             "name": "Nature's Spiral",
             "text": "Return target permanent card from your graveyard to your hand. (A permanent card is an artifact, creature, enchantment, land, or planeswalker card.)",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "d33f95f4-1315-54f6-b304-e4759e8c74db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df372a-af2b-464a-b54c-039132f70d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df372a-af2b-464a-b54c-039132f70d00.jpg?1",
             "name": "Oakenform",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "c2e60d63-8b42-5f52-87ac-f5adec7cf46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e16262-a9c1-45e1-b88a-322c752256cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e16262-a9c1-45e1-b88a-322c752256cf.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (If a creature you control would deal enough damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "c4bf05e3-9dfc-5672-a959-f6f46e35742c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde88869-5202-43e9-b0eb-4e40a50d311e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde88869-5202-43e9-b0eb-4e40a50d311e.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "3586c7c3-be63-5917-b9ea-ef86fb746bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a530d1e-2aff-4684-8f21-743a73f285ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a530d1e-2aff-4684-8f21-743a73f285ff.jpg?1",
             "name": "Protean Hydra",
             "text": "Protean Hydra enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Protean Hydra, prevent that damage and remove that many +1/+1 counters from it.\nWhenever a +1/+1 counter is removed from Protean Hydra, put two +1/+1 counters on it at the beginning of the end step.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "ac69f7ab-3705-57cd-98df-7309ad41f5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78472540-b085-4ee1-848c-de4631274919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78472540-b085-4ee1-848c-de4631274919.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "b19c5367-ada1-58cf-a039-6fdb77d3128c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1026f4-b11a-48aa-9191-e0bb51c515a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1026f4-b11a-48aa-9191-e0bb51c515a6.jpg?1",
             "name": "Regenerate",
             "text": "Regenerate target creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6770,7 +6770,7 @@
         },
         {
             "id": "66dc9783-fafb-5792-a65d-2dece74dbe0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268bd9d5-4da1-4cbf-83f9-47f7aac1cfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268bd9d5-4da1-4cbf-83f9-47f7aac1cfc3.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "e9ef92d2-4cea-5f29-8820-ea4b68b8f5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a33394-d26c-4dcd-948c-e7d370059b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a33394-d26c-4dcd-948c-e7d370059b11.jpg?1",
             "name": "Stampeding Rhino",
             "text": "Trample (If this creature would deal enough damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "a795739f-1e13-5ef8-9efd-9057de95dc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3768ec-bb3b-44dc-9fa3-7cb3d3ee9f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3768ec-bb3b-44dc-9fa3-7cb3d3ee9f8c.jpg?1",
             "name": "Windstorm",
             "text": "Windstorm deals X damage to each creature with flying.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "ec31dce7-9c6d-5900-a18f-9e674d846cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16860147-14fd-40bc-804d-0716a77294ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16860147-14fd-40bc-804d-0716a77294ad.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player casts a white spell, you may gain 1 life.",
             "colours": [],
@@ -6898,7 +6898,7 @@
         },
         {
             "id": "4f9b7d35-b5b2-5db9-997b-e2260a1631a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f77859-c92c-4851-9bab-9232d8b74cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f77859-c92c-4851-9bab-9232d8b74cdb.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
             "colours": [],
@@ -6926,7 +6926,7 @@
         },
         {
             "id": "da3b69cd-a7d6-574a-ae85-04f1b145290f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3aa1ce-8757-4541-8ac7-1e7e203b60fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3aa1ce-8757-4541-8ac7-1e7e203b60fc.jpg?1",
             "name": "Darksteel Colossus",
             "text": "Trample\nDarksteel Colossus is indestructible.\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "ba1fe1fb-6283-5285-b747-f0cd0b580d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daa7d29-b506-4576-9b0e-5897ab39c407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daa7d29-b506-4576-9b0e-5897ab39c407.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player casts a black spell, you may gain 1 life.",
             "colours": [],
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "42275ba6-770a-5eeb-935c-04801eeb9717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a08fdeb-c4ef-4602-b250-843cacf0fd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a08fdeb-c4ef-4602-b250-843cacf0fd6c.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player casts a red spell, you may gain 1 life.",
             "colours": [],
@@ -7013,7 +7013,7 @@
         },
         {
             "id": "6c4472b7-9280-55d1-ac7d-5fa1d108f07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc48cb-79aa-4e28-a736-ae9e4e2bc97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc48cb-79aa-4e28-a736-ae9e4e2bc97b.jpg?1",
             "name": "Gorgon Flail",
             "text": "Equipped creature gets +1/+1 and has deathtouch. (Creatures dealt damage by this creature are destroyed. You can divide its combat damage among any of the creatures blocking or blocked by it.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7043,7 +7043,7 @@
         },
         {
             "id": "4ab19fef-94be-5f65-9dd3-b5ffdcd46cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87c9191-1408-4aca-9061-bfb5b101c3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87c9191-1408-4aca-9061-bfb5b101c3ad.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws an additional card.",
             "colours": [],
@@ -7071,7 +7071,7 @@
         },
         {
             "id": "917ea779-fa63-565b-abca-000a359948bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c7c977-71bf-4554-a485-92e8fdef6b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c7c977-71bf-4554-a485-92e8fdef6b75.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player casts a blue spell, you may gain 1 life.",
             "colours": [],
@@ -7099,7 +7099,7 @@
         },
         {
             "id": "8bc06a62-a777-50d2-838f-79abdd6bbc79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b0f586-a100-4817-93f8-1ee2df39ce03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b0f586-a100-4817-93f8-1ee2df39ce03.jpg?1",
             "name": "Magebane Armor",
             "text": "Equipped creature gets +2/+4 and loses flying.\nPrevent all noncombat damage that would be dealt to equipped creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "8fe5e10f-c2af-5ed9-a6ea-059d7c05928e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b480c8-d899-4e63-b0e2-f4bec3a3ca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b480c8-d899-4e63-b0e2-f4bec3a3ca4f.jpg?1",
             "name": "Mirror of Fate",
             "text": "{T}, Sacrifice Mirror of Fate: Choose up to seven face-up exiled cards you own. Exile all the cards from your library, then put the chosen cards on top of your library.",
             "colours": [],
@@ -7157,7 +7157,7 @@
         },
         {
             "id": "82050b2c-0441-547f-9a73-91201e5c3344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb9825-ad45-44ad-ace2-eb6b66e3f724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb9825-ad45-44ad-ace2-eb6b66e3f724.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "5a7b33fd-cd85-57c7-b152-a843a40626f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c300dcb0-1909-47d8-9818-46b2763d2bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c300dcb0-1909-47d8-9818-46b2763d2bf9.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, name a card.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "2e0d9f53-1630-5607-9eee-b42cccc2ffb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b782865-b9d1-41ed-8a7b-a36c17022190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b782865-b9d1-41ed-8a7b-a36c17022190.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -7247,7 +7247,7 @@
         },
         {
             "id": "21321545-1de6-55e5-a6bf-b816e7e0ef6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70120666-d5c7-4c9a-81b1-7a148fba235a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70120666-d5c7-4c9a-81b1-7a148fba235a.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "658aadfa-bea3-5f6b-8480-b8a5f22a1a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f4d2b1-31d7-40d8-bd4e-cdd128076d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f4d2b1-31d7-40d8-bd4e-cdd128076d0f.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -7303,7 +7303,7 @@
         },
         {
             "id": "3fa060f2-18e7-5a88-8bc2-2ec5ca126c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9465c-cea2-491f-a6d6-9022cb3e969d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9465c-cea2-491f-a6d6-9022cb3e969d.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable.\nEquipped creature has shroud. (It can't be the target of spells or abilities.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7333,7 +7333,7 @@
         },
         {
             "id": "7037a1a7-2e93-5e49-8b26-706735c38380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4263068-b440-4d43-8f24-014bbe392297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4263068-b440-4d43-8f24-014bbe392297.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player casts a green spell, you may gain 1 life.",
             "colours": [],
@@ -7361,7 +7361,7 @@
         },
         {
             "id": "23970d59-9553-50c9-93d1-fc436712b303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4998db-13c0-412f-b02c-9f041cc45c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4998db-13c0-412f-b02c-9f041cc45c7e.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "39e8d864-5e11-5f35-bff3-f421cd7585d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6e950-38dd-46da-a1c3-58dc7495a9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6e950-38dd-46da-a1c3-58dc7495a9f9.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7423,7 +7423,7 @@
         },
         {
             "id": "c52aabb8-1286-577e-940c-16cbe7794f64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab512e43-894e-40af-ab8a-f33f258dd885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab512e43-894e-40af-ab8a-f33f258dd885.jpg?1",
             "name": "Gargoyle Castle",
             "text": "{T}: Add {1} to your mana pool.\n{5}, {T}, Sacrifice Gargoyle Castle: Put a 3/4 colorless Gargoyle artifact creature token with flying onto the battlefield.",
             "colours": [],
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "bd7704f8-45fd-516f-ad78-d30aeab9d2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee834e27-595d-4d12-8e69-e94e84ef337a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee834e27-595d-4d12-8e69-e94e84ef337a.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "f91dcb5e-5589-5cf7-b200-47b55785b6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5433b11b-efe9-4d94-8f71-6bf7c403494d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5433b11b-efe9-4d94-8f71-6bf7c403494d.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "8bd4c455-5f70-5b7d-bc2a-1498f05a42c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4e8ead-8c82-4258-bc59-551f7a74e042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4e8ead-8c82-4258-bc59-551f7a74e042.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "90861881-6202-53a5-8cb3-8c9d6665ffe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61902bad-c322-406d-aa4d-039efd4aa84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61902bad-c322-406d-aa4d-039efd4aa84f.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7572,7 +7572,7 @@
         },
         {
             "id": "7c16125e-5d53-5128-b247-332eaf1cbf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc084e24-22fe-4326-b894-54d79fbeba2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc084e24-22fe-4326-b894-54d79fbeba2f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "211beb57-789c-548d-9859-687e14f63cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322a6bc1-bb77-4913-a0b9-ac77316b30b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322a6bc1-bb77-4913-a0b9-ac77316b30b0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7648,7 +7648,7 @@
         },
         {
             "id": "24637d9d-d03b-5856-ba8b-f7148f73c0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f8793-83ed-437a-b06c-aec97205664b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f8793-83ed-437a-b06c-aec97205664b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "de9e1c22-6d3d-5be1-b1e0-6a5e53136011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851fac7-4f6e-4bba-928a-6485223ce1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851fac7-4f6e-4bba-928a-6485223ce1c8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "ba3e3cf3-9d8d-58ff-b918-a1a14c0b15dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172bb1b6-08c3-4ffd-b26d-b1c77dba06c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172bb1b6-08c3-4ffd-b26d-b1c77dba06c3.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7762,7 +7762,7 @@
         },
         {
             "id": "3d3b727b-5348-54d8-993c-37ade48b2c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79df5b20-9e04-4b71-b39a-3142306719f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79df5b20-9e04-4b71-b39a-3142306719f9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "dc6314d3-b6d9-5df0-84de-68c91274c47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0bc4a-75a8-463b-9e96-a8607fc93102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0bc4a-75a8-463b-9e96-a8607fc93102.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "459b552b-3ae1-5f8c-9f1f-94b96796f473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855eabf3-1113-410c-b30c-41a94456e408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855eabf3-1113-410c-b30c-41a94456e408.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "25744d64-6be3-574d-8195-9b7db21491c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc185cc-5b8e-43ea-aa75-94ddffb74ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc185cc-5b8e-43ea-aa75-94ddffb74ad0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7914,7 +7914,7 @@
         },
         {
             "id": "71de0af5-9eb4-513a-b9a4-7eed66113cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef713de6-daf5-45e4-b23b-19bfd6edce36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef713de6-daf5-45e4-b23b-19bfd6edce36.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7952,7 +7952,7 @@
         },
         {
             "id": "70e838c5-7630-54cc-ba2e-6d1eda03f974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62050e5d-50b3-4c4d-b8c7-b85ff20c4d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62050e5d-50b3-4c4d-b8c7-b85ff20c4d71.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "d72f366e-8304-5362-b703-59c9834ce3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2326267f-2412-4217-af73-f5392167a3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2326267f-2412-4217-af73-f5392167a3a6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "556b8683-c9f7-5c8a-9125-2a7664b6bf29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed783a0c-ba7c-48f4-aac6-ad93a02bce6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed783a0c-ba7c-48f4-aac6-ad93a02bce6b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "0a563b17-89a3-52c6-84e2-440b42250e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64729d4b-991f-45d0-aaef-4ab26746c57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64729d4b-991f-45d0-aaef-4ab26746c57e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8104,7 +8104,7 @@
         },
         {
             "id": "7d274f8d-c862-518f-8bed-b0b5ab0ecce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcd666-7724-4c55-975e-20cfa759bba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcd666-7724-4c55-975e-20cfa759bba7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "b59630e9-9622-5549-9185-f350a1d623aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f4c3f-60f2-4f68-92e1-88fee822bb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f4c3f-60f2-4f68-92e1-88fee822bb9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "fc60a059-9c0a-56d6-83f9-f82260a0f85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394d804-c0e5-4901-a8ff-c1a765cc1e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394d804-c0e5-4901-a8ff-c1a765cc1e21.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "9b1a6e1f-2603-53ad-a9e6-df0e2a910afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7ba3a-0269-4a4b-8833-7e9e5f66013a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7ba3a-0269-4a4b-8833-7e9e5f66013a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8256,7 +8256,7 @@
         },
         {
             "id": "0473e4ac-5512-59b5-bf80-55103cd19f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3156ba12-cf21-48a5-aa08-74b447cafc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3156ba12-cf21-48a5-aa08-74b447cafc2c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "c7ac9b0f-0e5a-5614-9072-9dcc3d682b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb0e22-1e19-46e0-913e-94ccbf858bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb0e22-1e19-46e0-913e-94ccbf858bb9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8332,7 +8332,7 @@
         },
         {
             "id": "de0a2314-9c8f-52b1-bc5d-861615617700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160c268c-db2f-4105-8f40-0237b59ed333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160c268c-db2f-4105-8f40-0237b59ed333.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -8366,7 +8366,7 @@
         },
         {
             "id": "e76457ac-b6a8-5b90-96ee-68e2cd0a0fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccd622-264e-4867-b34b-324c94861241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccd622-264e-4867-b34b-324c94861241.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8400,7 +8400,7 @@
         },
         {
             "id": "e2105da3-cad2-5005-b379-a532c03a8be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd51a6b5-1165-4df6-a30d-d46c729633f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd51a6b5-1165-4df6-a30d-d46c729633f7.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "c9d2973b-9b6e-5361-8bfc-ccb0114dc5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8cdaea-32da-4c18-bcd0-18bbbda54afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8cdaea-32da-4c18-bcd0-18bbbda54afb.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "99f7302e-21e5-543e-87bb-2c892b39d59e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b935437-e097-466b-a9d5-6dc0dc6a10f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b935437-e097-466b-a9d5-6dc0dc6a10f3.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "9a0f9606-cc9a-58c5-8c6f-7e0e03b7bea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67563770-a392-4f69-b93b-6029da639993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67563770-a392-4f69-b93b-6029da639993.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8536,7 +8536,7 @@
         },
         {
             "id": "d6503523-02c8-5086-a1b8-a7e18e8b68b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f63920d-18a0-4267-bb4e-a972ba86067d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f63920d-18a0-4267-bb4e-a972ba86067d.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "52ec8ec9-e235-5394-bd62-30a3b3c0dfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3aa149-00fa-4932-b004-f64c8b5d3ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3aa149-00fa-4932-b004-f64c8b5d3ca7.jpg?1",
             "name": "Gargoyle",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M11.json
+++ b/Assets/Resources/Sets/M11.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "363df90f-8afd-591d-93d8-2ef7a54bd3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d911053-a026-4b20-ba2d-dbcc367c1413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d911053-a026-4b20-ba2d-dbcc367c1413.jpg?1",
             "name": "Ajani Goldmane",
             "text": "+1: You gain 2 life.\n-1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n-6: Put a white Avatar creature token onto the battlefield. It has \"This creature's power and toughness are each equal to your life total.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "94f01d0d-0873-54d3-bacb-edbfda494b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b1057-ed1f-45a5-ba95-28aa51713764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b1057-ed1f-45a5-ba95-28aa51713764.jpg?1",
             "name": "Ajani's Mantra",
             "text": "At the beginning of your upkeep, you may gain 1 life.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "bc217875-3352-5f5b-a4da-0c6246496392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70d1452-6b61-4c63-841f-4256ac498e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70d1452-6b61-4c63-841f-4256ac498e9f.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate. (For example, if an effect causes you to gain 3 life, you may put one +1/+1 counter on this creature.)",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "c0c301a3-5f80-5dcc-8fd3-4855e6496cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f05793-9e6f-4815-9a13-f791cb4b6aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f05793-9e6f-4815-9a13-f791cb4b6aa0.jpg?1",
             "name": "Angelic Arbiter",
             "text": "Flying\nEach opponent who cast a spell this turn can't attack with creatures.\nEach opponent who attacked with a creature this turn can't cast spells.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "314a4d68-44e6-5af0-ae28-8d81cfb983f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5647c21e-5926-462c-8b01-862f8cedf777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5647c21e-5926-462c-8b01-862f8cedf777.jpg?1",
             "name": "Armored Ascension",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "0b95bc00-6f00-5ce9-86db-2a55b71950fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ced22-1f2c-4fa6-a938-8ebe2c15cc8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ced22-1f2c-4fa6-a938-8ebe2c15cc8d.jpg?1",
             "name": "Assault Griffin",
             "text": "Flying",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "4a72458c-029e-55eb-ac85-2e0a417fd5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff70c4ff-a241-4333-bd8f-9f0ed5a0333b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff70c4ff-a241-4333-bd8f-9f0ed5a0333b.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "a7aa509c-a77e-57bd-99f2-166de00aefc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2468c21b-d041-4e26-91cf-d53850e2a57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2468c21b-d041-4e26-91cf-d53850e2a57e.jpg?1",
             "name": "Blinding Mage",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "e69f6e07-4a03-573e-8ef7-319d729386fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ffb67-0454-48b1-8043-e7f8fb12bb54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ffb67-0454-48b1-8043-e7f8fb12bb54.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "b89859b8-4c0b-582e-b53a-0b8cc8be6a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce09da-6c1d-46ac-870e-ff58ceaba116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce09da-6c1d-46ac-870e-ff58ceaba116.jpg?1",
             "name": "Cloud Crusader",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "f93b369c-925e-5214-b173-834a883e3d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfae21b5-aff2-4191-aa42-d756209beaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfae21b5-aff2-4191-aa42-d756209beaaa.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "418cb111-b51d-5cca-8378-606c0d1705b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f6b25f-d11c-483a-a3e9-6b801d333482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f6b25f-d11c-483a-a3e9-6b801d333482.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "8937b089-91f9-5223-a7f5-f46f69bf07ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8969be61-afed-4483-902f-739acf57c43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8969be61-afed-4483-902f-739acf57c43c.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "cac58d74-5a05-5ede-880e-7b9056649be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec6e3f-bc90-4e21-a087-330f7e072fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec6e3f-bc90-4e21-a087-330f7e072fc6.jpg?1",
             "name": "Excommunicate",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "5b742f8c-540d-56f5-90b4-6d7fb591f89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6e31cb-98c5-4145-bdef-666f3cea7eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6e31cb-98c5-4145-bdef-666f3cea7eab.jpg?1",
             "name": "Goldenglow Moth",
             "text": "Flying\nWhenever Goldenglow Moth blocks, you may gain 4 life.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "6b3975b7-fd61-55b2-9428-a6e3ac38c1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0987b8-755e-42f1-bd6d-1401fecd4171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0987b8-755e-42f1-bd6d-1401fecd4171.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "a02fbbcc-04ca-5d5a-8886-f393a4500f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3831cb3b-0983-403b-9e0a-4720222817c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3831cb3b-0983-403b-9e0a-4720222817c4.jpg?1",
             "name": "Honor of the Pure",
             "text": "White creatures you control get +1/+1.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "384085b2-f6c2-5791-aa03-748de6c444f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12ec710-23f4-4ce6-90e1-272981a20c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12ec710-23f4-4ce6-90e1-272981a20c3d.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "95878850-cc78-5648-9b33-48301dd90ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98151986-90de-4f76-9abd-507039e7c9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98151986-90de-4f76-9abd-507039e7c9ad.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "80d75282-1408-5037-8b67-12f7c237905e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7da2c3-95d7-464f-af3d-fd891fd148f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7da2c3-95d7-464f-af3d-fd891fd148f1.jpg?1",
             "name": "Knight Exemplar",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nOther Knight creatures you control get +1/+1 and are indestructible. (Lethal damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "8ddc1a9c-8837-5463-9cf4-0e978bd3a42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262de9ae-d641-4f0e-af6a-03ce0e1c91d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262de9ae-d641-4f0e-af6a-03ce0e1c91d3.jpg?1",
             "name": "Leyline of Sanctity",
             "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "a0fe6fa6-5583-5acb-a729-a3443a6af909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8e0f93-a450-4188-a735-d601a59ab108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8e0f93-a450-4188-a735-d601a59ab108.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "c5be10a6-df7d-5e4d-8f19-83cf4cea4590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0efc23-9284-4aa4-a0ed-1f1dfdce4cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0efc23-9284-4aa4-a0ed-1f1dfdce4cbb.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "ccd09e02-52c5-5bcd-b5bb-efd19f511096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e73c28-bf82-413e-bec2-adbb52fa6993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e73c28-bf82-413e-bec2-adbb52fa6993.jpg?1",
             "name": "Palace Guard",
             "text": "Palace Guard can block any number of creatures.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "c13b3024-19a6-5df5-b2c8-38c152423646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dca2c1f-3835-478b-860c-51b2036221b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dca2c1f-3835-478b-860c-51b2036221b2.jpg?1",
             "name": "Roc Egg",
             "text": "Defender (This creature can't attack.)\nWhen Roc Egg is put into a graveyard from the battlefield, put a 3/3 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "331c1332-47f8-5b62-acbc-22be289dd8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453aab0-5e11-4fac-af69-e7950c486d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453aab0-5e11-4fac-af69-e7950c486d30.jpg?1",
             "name": "Safe Passage",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "978152f6-a91e-59da-948d-8b947fa366e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c53890f-8cf2-42ad-8b5f-66badc99630c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c53890f-8cf2-42ad-8b5f-66badc99630c.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "2df85154-4e40-5310-b3d4-7f350715bef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee65b44-eeb6-418b-b022-a0aef587c738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee65b44-eeb6-418b-b022-a0aef587c738.jpg?1",
             "name": "Serra Ascendant",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nAs long as you have 30 or more life, Serra Ascendant gets +5/+5 and has flying.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "71a75452-9503-5b4d-8f8d-a96e08f99f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d7ce0-866a-43eb-939e-3287ff00234d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d7ce0-866a-43eb-939e-3287ff00234d.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "21fd8fd5-46af-591f-80c0-7b2539626a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b70d17-e4ec-4731-8892-b444f82be7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b70d17-e4ec-4731-8892-b444f82be7a2.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn. (Spells cast before this resolves are unaffected.)",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "3dc27c84-e2a9-5481-84ec-8600bada94fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37523d3-7719-48e1-9b3e-2670772a509b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37523d3-7719-48e1-9b3e-2670772a509b.jpg?1",
             "name": "Silvercoat Lion",
             "text": "",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "2e4da88b-a65c-5fce-aac6-eb6ef43768ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d6d379-b991-48da-a6b3-a4a38931057c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d6d379-b991-48da-a6b3-a4a38931057c.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "a080e4b7-ed91-545f-a29c-d10d318d09e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beddd409-0154-45a5-a20d-833cf1b5e1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beddd409-0154-45a5-a20d-833cf1b5e1f4.jpg?1",
             "name": "Squadron Hawk",
             "text": "Flying\nWhen Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "fe048d76-fe3e-55e8-8a1b-ec3ba856898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dac80a-96ae-489a-8600-97d767ab78f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dac80a-96ae-489a-8600-97d767ab78f8.jpg?1",
             "name": "Stormfront Pegasus",
             "text": "Flying",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "f47b334b-7219-56f6-ada7-da65357b3243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8db2b8e-dce9-49b7-833f-381ee55288cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8db2b8e-dce9-49b7-833f-381ee55288cb.jpg?1",
             "name": "Sun Titan",
             "text": "Vigilance\nWhenever Sun Titan enters the battlefield or attacks, you may return target permanent card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "c6375ab0-a2b3-5770-a70e-cce2da6d60a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc42fe32-5f02-472c-a25e-d03e01546dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc42fe32-5f02-472c-a25e-d03e01546dc6.jpg?1",
             "name": "Tireless Missionaries",
             "text": "When Tireless Missionaries enters the battlefield, you gain 3 life.",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "58b90772-d07c-5dae-a0dd-ad8906b785e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a505d07f-61cf-4b00-a1d5-028747899eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a505d07f-61cf-4b00-a1d5-028747899eaa.jpg?1",
             "name": "Vengeful Archon",
             "text": "Flying\n{X}: Prevent the next X damage that would be dealt to you this turn. If damage is prevented this way, Vengeful Archon deals that much damage to target player.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "8c705ae2-1e5d-5c2d-86e2-c3b52871bd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7d96db-109d-498e-ae10-1430718c33da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7d96db-109d-498e-ae10-1430718c33da.jpg?1",
             "name": "War Priest of Thune",
             "text": "When War Priest of Thune enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "c3bb8505-60ca-5594-aef1-98ee868c1864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a02b6-2c33-40d8-ad97-39b192d7e82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a02b6-2c33-40d8-ad97-39b192d7e82d.jpg?1",
             "name": "White Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black.)",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "44346ca7-31ce-57a3-93a0-7b26983478d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35bfacf-b1a0-4c5a-9131-412682d483e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35bfacf-b1a0-4c5a-9131-412682d483e5.jpg?1",
             "name": "Wild Griffin",
             "text": "Flying",
             "colours": [
@@ -1354,7 +1354,7 @@
         },
         {
             "id": "7e1b3092-f8df-5b14-ac0d-768d535c4ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b551dab-1a81-406d-b708-b3b7300eb02e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b551dab-1a81-406d-b708-b3b7300eb02e.jpg?1",
             "name": "Aether Adept",
             "text": "When \u00c6ther Adept enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "c98835b2-a82c-5918-9a89-2555c0bc2992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f46eb67-a50d-4910-9919-1bb2ca1c0dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f46eb67-a50d-4910-9919-1bb2ca1c0dad.jpg?1",
             "name": "Air Servant",
             "text": "Flying\n{2}{U}: Tap target creature with flying.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "6637fa24-a893-57ee-9ffd-3d69ea426e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea89d38-765d-4902-b985-bcc15363c4f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea89d38-765d-4902-b985-bcc15363c4f2.jpg?1",
             "name": "Alluring Siren",
             "text": "{T}: Target creature an opponent controls attacks you this turn if able.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "b133e8fb-e72f-5139-b19d-1d76de3c1122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ef0757-8eb0-4384-bf8e-9a7340144dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ef0757-8eb0-4384-bf8e-9a7340144dfa.jpg?1",
             "name": "Armored Cancrix",
             "text": "",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "f1582c7d-1596-52ef-a957-72bfe931f02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8b752-086c-4d7c-a0a2-e359819c550e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8b752-086c-4d7c-a0a2-e359819c550e.jpg?1",
             "name": "Augury Owl",
             "text": "Flying\nWhen Augury Owl enters the battlefield, scry 3. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "e66d2587-c435-5479-9090-6efd93cf8780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6653bce7-b0fc-49e3-8f45-f0bfcade8870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6653bce7-b0fc-49e3-8f45-f0bfcade8870.jpg?1",
             "name": "Azure Drake",
             "text": "Flying",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "d4624ef7-9968-5fff-8365-af2f5c00fd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f570b1-e221-468c-a809-a79a56a51ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f570b1-e221-468c-a809-a79a56a51ced.jpg?1",
             "name": "Call to Mind",
             "text": "Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "4ed9ef6e-f132-5c70-bc02-d4d980651a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6932af-c7e7-49e9-963e-97e680a53da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6932af-c7e7-49e9-963e-97e680a53da5.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "b16759df-8be3-59f9-b159-6d23ff9eafa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf51d88c-f7a4-4f82-ab2b-f2871abd7d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf51d88c-f7a4-4f82-ab2b-f2871abd7d5b.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "858033e1-41c6-581c-a936-60e4a88a71e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb738b9-231c-47e1-980d-1cc1fb71c2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb738b9-231c-47e1-980d-1cc1fb71c2f5.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "cb54ef2d-a10e-5124-9fc5-1b52405d4373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa1afb9-a2e5-44a1-b2f1-9de75efbbe93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa1afb9-a2e5-44a1-b2f1-9de75efbbe93.jpg?1",
             "name": "Conundrum Sphinx",
             "text": "Flying\nWhenever Conundrum Sphinx attacks, each player names a card. Then each player reveals the top card of his or her library. If the card a player revealed is the card he or she named, that player puts it into his or her hand. If it's not, that player puts it on the bottom of his or her library.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "c44db315-feb5-5d80-a603-830228051222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a8e4c-2bcf-4302-bef8-f126fe865f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a8e4c-2bcf-4302-bef8-f126fe865f08.jpg?1",
             "name": "Diminish",
             "text": "Target creature becomes 1/1 until end of turn.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "e95df514-73a6-5eba-b3d7-8fc092e6e583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc68a06-9d79-4be8-b4ce-ecd4d0e4ce29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc68a06-9d79-4be8-b4ce-ecd4d0e4ce29.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "3f4a82af-ee5c-5b12-b41e-2985140e8a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d7b86-5ea5-42a3-91b6-0b09db06756c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d7b86-5ea5-42a3-91b6-0b09db06756c.jpg?1",
             "name": "Foresee",
             "text": "Scry 4, then draw two cards. (To scry 4, look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "c2a53fb7-3b8f-5065-960d-3220a02a2b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065addc8-c235-43cc-a54f-b582826e5df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065addc8-c235-43cc-a54f-b582826e5df1.jpg?1",
             "name": "Frost Titan",
             "text": "Whenever Frost Titan becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.\nWhenever Frost Titan enters the battlefield or attacks, tap target permanent. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "6624a3aa-9ef2-5004-8114-2ccb9d0a8b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa10b43f-eb63-4999-92a0-56826031b686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa10b43f-eb63-4999-92a0-56826031b686.jpg?1",
             "name": "Harbor Serpent",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "acbadbff-ca1b-5366-817b-31df270fe9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ad7d1-bdac-4409-87a2-58149bb58b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ad7d1-bdac-4409-87a2-58149bb58b0a.jpg?1",
             "name": "Ice Cage",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.",
             "colours": [
@@ -1923,7 +1923,7 @@
         },
         {
             "id": "db0f8a07-b20b-59aa-b72d-c44bd63539eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441af393-2f70-4765-ae95-730c1e1d864f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441af393-2f70-4765-ae95-730c1e1d864f.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n-1: Target player draws a card.\n-10: Target player puts the top twenty cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "2fdf6cc7-86a7-5901-81d9-179fc225f93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3662d1cc-1279-409f-9f0a-9c15c3407103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3662d1cc-1279-409f-9f0a-9c15c3407103.jpg?1",
             "name": "Jace's Erasure",
             "text": "Whenever you draw a card, you may have target player put the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "9c372b6d-e95e-50db-945e-ed69a4064ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79bea30-3210-4944-b146-3624c9869f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79bea30-3210-4944-b146-3624c9869f45.jpg?1",
             "name": "Jace's Ingenuity",
             "text": "Draw three cards.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "fca30af1-0998-51ea-b5f4-25992720df8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb092-3bb0-445e-ab26-d939cac92a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb092-3bb0-445e-ab26-d939cac92a73.jpg?1",
             "name": "Leyline of Anticipation",
             "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast nonland cards as though they had flash. (You may cast them any time you could cast an instant.)",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "0f1200f6-0f74-5c79-af79-8d8cf2414a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c7757d-8036-4b33-a1cb-07795d392588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c7757d-8036-4b33-a1cb-07795d392588.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "a6363ae6-5f84-5a09-a46c-a32914b90961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f365d82a-88a3-403b-92a6-91c9ccb3421f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f365d82a-88a3-403b-92a6-91c9ccb3421f.jpg?1",
             "name": "Maritime Guard",
             "text": "",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "961df276-5517-5fda-9cd6-324cdf77ef5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ffe61f-e52e-4d62-854b-10ac9cfbadd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ffe61f-e52e-4d62-854b-10ac9cfbadd3.jpg?1",
             "name": "Mass Polymorph",
             "text": "Exile all creatures you control, then reveal cards from the top of your library until you reveal that many creature cards. Put all creature cards revealed this way onto the battlefield, then shuffle the rest of the revealed cards into your library.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "8fe60d34-ff7c-547a-a5b4-bfc8326aacba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed43af3c-1070-45d9-9de6-17d07a6ef3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed43af3c-1070-45d9-9de6-17d07a6ef3c0.jpg?1",
             "name": "Merfolk Sovereign",
             "text": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature is unblockable this turn.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "e5108e45-e202-505e-9e3d-61cbb7302829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ae05cc-116b-4268-ba78-709aeff36ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ae05cc-116b-4268-ba78-709aeff36ab1.jpg?1",
             "name": "Merfolk Spy",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nWhenever Merfolk Spy deals combat damage to a player, that player reveals a card at random from his or her hand.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "78ec31cd-35eb-53fe-b775-e0f49c9020bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496f79d6-33ee-4e31-9601-2722b0bc9141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496f79d6-33ee-4e31-9601-2722b0bc9141.jpg?1",
             "name": "Mind Control",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "585f6835-bb38-5c39-85d8-a45f03e607fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae89bd67-3c72-449f-be72-d04bb7cca916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae89bd67-3c72-449f-be72-d04bb7cca916.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "e27ca6cd-994a-595e-b381-378fb153f595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572df99b-af44-4128-8b2c-e40b1cea816b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572df99b-af44-4128-8b2c-e40b1cea816b.jpg?1",
             "name": "Phantom Beast",
             "text": "When Phantom Beast becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "54c23a15-eecc-511c-b2b4-1c6c6ca6a22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3868c3d-4fcd-444b-866f-0f8e50ce7b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3868c3d-4fcd-444b-866f-0f8e50ce7b67.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "594c6f5c-1431-5465-8d9b-8c3fe44667bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bae44b-c6f2-40bf-a427-aee5cfbdfea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bae44b-c6f2-40bf-a427-aee5cfbdfea9.jpg?1",
             "name": "Redirect",
             "text": "You may choose new targets for target spell.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "ee420d7c-391c-5336-bd50-4dd56acfc0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2808-58d9-4e27-a6c2-6db66191151e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2808-58d9-4e27-a6c2-6db66191151e.jpg?1",
             "name": "Scroll Thief",
             "text": "Whenever Scroll Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "30b35b1d-3095-53c7-8575-3b875e378713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ba1c16-eeb2-405d-9f66-6de2f4354224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ba1c16-eeb2-405d-9f66-6de2f4354224.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "51e0ba71-b914-5012-9eb3-337b7643dc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7f3fb6-93ce-4bc9-8efd-11af5a46218f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7f3fb6-93ce-4bc9-8efd-11af5a46218f.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "77930404-fe30-5e49-abb5-3aac3a02bf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1468c851-b20e-4c78-9fcb-45e60b7149db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1468c851-b20e-4c78-9fcb-45e60b7149db.jpg?1",
             "name": "Time Reversal",
             "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. Exile Time Reversal.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "73dac9ba-a085-5633-9c9b-ac89f636ae27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6445f013-8b50-4ea3-9013-df85289c2605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6445f013-8b50-4ea3-9013-df85289c2605.jpg?1",
             "name": "Tome Scour",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "2d6b8535-768e-5360-8922-c42499d69ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf943d-497a-4720-8be0-4bc2cd7642ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf943d-497a-4720-8be0-4bc2cd7642ee.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "5a30f463-92b4-57a8-8194-88c1b224392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10c195e-9b7e-423b-9629-544cceca1ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10c195e-9b7e-423b-9629-544cceca1ce9.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "c4e3aa94-9ab7-53a3-8496-f692118a5764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56229e1-904b-4761-bb7e-35a0c8202c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56229e1-904b-4761-bb7e-35a0c8202c2e.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "cce88633-4c1f-5d45-b518-23a5d0b28847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a3062e-8b83-4ee4-8139-8eee84df37fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a3062e-8b83-4ee4-8139-8eee84df37fe.jpg?1",
             "name": "Water Servant",
             "text": "{U}: Water Servant gets +1/-1 until end of turn.\n{U}: Water Servant gets -1/+1 until end of turn.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "26b6a7f3-481a-59bc-9027-bfc73437eb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eac7cb5-b9de-4c40-ab70-3084d8145f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eac7cb5-b9de-4c40-ab70-3084d8145f58.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "fccc7086-1ea4-57dc-90a7-e4ccb930575c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88583170-7b0e-4c02-b270-4859ba05d82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88583170-7b0e-4c02-b270-4859ba05d82b.jpg?1",
             "name": "Barony Vampire",
             "text": "",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "804be284-c4a8-509f-bd0f-1201ae67b049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c198d94-248c-4f81-b8d5-e1b5a0623ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c198d94-248c-4f81-b8d5-e1b5a0623ee7.jpg?1",
             "name": "Black Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from white (This creature can't be blocked, targeted, dealt damage, or enchanted by anything white.)",
             "colours": [
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "2e49341d-df26-5541-b529-8fe05023544c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf166294-3359-4da4-84d0-006c75c183fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf166294-3359-4da4-84d0-006c75c183fd.jpg?1",
             "name": "Blood Tithe",
             "text": "Each opponent loses 3 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "37464cf9-33e6-5204-9674-1c3c6af1ed31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62f3371-8aa6-4fbf-b642-5ba6af219703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62f3371-8aa6-4fbf-b642-5ba6af219703.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "bc8eea77-d53b-5f1b-b712-565118c80955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a493521-810e-4932-bb44-16c80c3066c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a493521-810e-4932-bb44-16c80c3066c9.jpg?1",
             "name": "Bog Raiders",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "e71e4fba-3bc3-53b2-9481-f8d2b9826c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99b0735-cc3c-48dc-a7ad-b7d9eea45e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99b0735-cc3c-48dc-a7ad-b7d9eea45e54.jpg?1",
             "name": "Captivating Vampire",
             "text": "Other Vampire creatures you control get +1/+1.\nTap five untapped Vampires you control: Gain control of target creature. It becomes a Vampire in addition to its other types.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "0821bdfa-2f62-534f-8c40-0a94022848d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef351dcb-64c0-413a-81d3-38e7cd4a8f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef351dcb-64c0-413a-81d3-38e7cd4a8f78.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "511659fb-1e8c-5f49-9b9f-a47b21b36f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9938180e-31dc-45a1-a39a-dbaf12ad429b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9938180e-31dc-45a1-a39a-dbaf12ad429b.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of Swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "e3a4aa13-4a95-5355-b78c-f1f8e2055fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec3dd9f-3969-4fd7-97f7-e9868eb19a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec3dd9f-3969-4fd7-97f7-e9868eb19a64.jpg?1",
             "name": "Dark Tutelage",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "fe4dd6c4-2db7-5634-9ec6-5a7e0e01cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b32384-985b-484a-a96f-66b23f3d0208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b32384-985b-484a-a96f-66b23f3d0208.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "ab7cc67d-62ba-58e3-9c10-5c48cc7ad7ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fab4fc-c8de-47ef-a717-3adb58c2f5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fab4fc-c8de-47ef-a717-3adb58c2f5b6.jpg?1",
             "name": "Demon of Death's Gate",
             "text": "You may pay 6 life and sacrifice three black creatures rather than pay Demon of Death's Gate's mana cost.\nFlying, trample",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "19873706-58d9-5e80-a761-990ae016d720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98724907-0469-4016-87ff-02cbce8008fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98724907-0469-4016-87ff-02cbce8008fa.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "2aee8eaf-9bf5-59e1-9673-e53189d23b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5555c5-5d40-4976-ba77-54732108f120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5555c5-5d40-4976-ba77-54732108f120.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "6809dab7-fc80-5ce2-8d67-7307dbfe726f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a74bb-f158-4d0e-b840-222ecbf107d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a74bb-f158-4d0e-b840-222ecbf107d4.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "600f3784-9555-52c4-a194-05deb4b5e6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1445d6-ae16-492c-a378-d3aa5746c610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1445d6-ae16-492c-a378-d3aa5746c610.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "7fc293bb-36bb-541e-af68-191709e7ab93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa6d385-6b8e-45ad-83dc-b477799c05a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa6d385-6b8e-45ad-83dc-b477799c05a5.jpg?1",
             "name": "Grave Titan",
             "text": "Deathtouch\nWhenever Grave Titan enters the battlefield or attacks, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "791e1927-6d05-5566-b74d-a630b088ed4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ac2ce6-e5ca-44c8-bdb9-a53ed3303728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ac2ce6-e5ca-44c8-bdb9-a53ed3303728.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3281,7 +3281,7 @@
         },
         {
             "id": "c6f5717c-1c2e-5a1c-a726-460f2f2423fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96bc7-b92f-4df5-89b5-0793b9e56509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96bc7-b92f-4df5-89b5-0793b9e56509.jpg?1",
             "name": "Haunting Echoes",
             "text": "Exile all cards from target player's graveyard other than basic land cards. For each card exiled this way, search that player's library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "eb8a4e62-b6d2-517c-8e02-7750e08f1828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d40f1e-bb2f-4de2-8481-c11eb5130fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d40f1e-bb2f-4de2-8481-c11eb5130fa1.jpg?1",
             "name": "Howling Banshee",
             "text": "Flying\nWhen Howling Banshee enters the battlefield, each player loses 3 life.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "fa96b65b-ff97-5d63-857a-956877b25a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e012d4f3-c387-4910-981b-7532fd355296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e012d4f3-c387-4910-981b-7532fd355296.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3379,7 +3379,7 @@
         },
         {
             "id": "38bdf961-78b7-5c35-bb7e-72f25a1aede8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a15e31c-b208-4a52-b450-c058a75da9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a15e31c-b208-4a52-b450-c058a75da9f7.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n-2: Search your library for a card, then shuffle your library and put that card on top of it.\n-8: Put all creature cards in all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "be1f42be-a15f-575c-956a-0085dac1e877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d995382-57a6-40a4-9050-31f57cb8dae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d995382-57a6-40a4-9050-31f57cb8dae3.jpg?1",
             "name": "Liliana's Caress",
             "text": "Whenever an opponent discards a card, that player loses 2 life.",
             "colours": [
@@ -3447,7 +3447,7 @@
         },
         {
             "id": "9a010952-8cef-5359-b857-180658f14b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33122581-39fd-44a0-b928-f73e39a0c0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33122581-39fd-44a0-b928-f73e39a0c0f1.jpg?1",
             "name": "Liliana's Specter",
             "text": "Flying\nWhen Liliana's Specter enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "b22a680d-50f0-5b54-a94e-a7634cf1cead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e117056-030a-4ec6-a669-dbe6c7ccb840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e117056-030a-4ec6-a669-dbe6c7ccb840.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3513,7 +3513,7 @@
         },
         {
             "id": "a5439c8f-3f03-543f-b315-1283fc10a38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd01bab0-3241-4ebb-a378-f88cbdf16dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd01bab0-3241-4ebb-a378-f88cbdf16dc3.jpg?1",
             "name": "Nantuko Shade",
             "text": "{B}: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3548,7 +3548,7 @@
         },
         {
             "id": "b8d8dd0f-f391-50a6-a92e-55360b4fe501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7573a8-be2b-46a5-8862-db0980968088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7573a8-be2b-46a5-8862-db0980968088.jpg?1",
             "name": "Necrotic Plague",
             "text": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, sacrifice this creature.\"\nWhen enchanted creature is put into a graveyard, its controller chooses target creature one of his or her opponents controls. Return Necrotic Plague from its owner's graveyard to the battlefield attached to that creature.",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "f528946b-f957-5f04-b915-cf01946f4d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c217b672-c724-4fc2-936c-b3f0feaf6ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c217b672-c724-4fc2-936c-b3f0feaf6ea0.jpg?1",
             "name": "Nether Horror",
             "text": "",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "0f402ac4-bbd0-584f-92fa-7693f078befd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6232c3-f840-450a-8583-540aec0f17ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6232c3-f840-450a-8583-540aec0f17ed.jpg?1",
             "name": "Nightwing Shade",
             "text": "Flying\n{1}{B}: Nightwing Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3650,7 +3650,7 @@
         },
         {
             "id": "f9bcdb8f-d8b1-537d-904a-f6fd69016cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d088983-92c1-4f4d-8abf-dd20347495b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d088983-92c1-4f4d-8abf-dd20347495b5.jpg?1",
             "name": "Phylactery Lich",
             "text": "As Phylactery Lich enters the battlefield, put a phylactery counter on an artifact you control.\nPhylactery Lich is indestructible.\nWhen you control no permanents with phylactery counters on them, sacrifice Phylactery Lich.",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "a47127a6-c21b-520d-9ed8-14bf98eb1801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d56d13-b9de-44db-b235-4f7eea60f424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d56d13-b9de-44db-b235-4f7eea60f424.jpg?1",
             "name": "Quag Sickness",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 for each Swamp you control.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "acab6598-fe55-5cd9-959c-38dbd4adc3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ec6120-2de0-4166-be85-2d773fa7ebbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ec6120-2de0-4166-be85-2d773fa7ebbb.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "f671a4ab-379c-58a7-9962-01d3a1629a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f873c62a-7efc-40d8-8c0a-55e9a94847b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f873c62a-7efc-40d8-8c0a-55e9a94847b8.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -3787,7 +3787,7 @@
         },
         {
             "id": "6e5facba-4b8b-557e-9ba4-7c72c576a88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee3e6f2-a87f-415a-96f3-b72fa6f3eb07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee3e6f2-a87f-415a-96f3-b72fa6f3eb07.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card in a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "5f9fe2a1-9b95-5f1f-b6a6-cec4a31d4382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe5e62c-83ce-4c2b-a745-acd7670e115d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe5e62c-83ce-4c2b-a745-acd7670e115d.jpg?1",
             "name": "Rotting Legion",
             "text": "Rotting Legion enters the battlefield tapped.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "e1c550ad-b039-5d35-b4ec-bac7b6a6e5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0094664-9f03-414b-a890-6f535a1927ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0094664-9f03-414b-a890-6f535a1927ad.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3888,7 +3888,7 @@
         },
         {
             "id": "2429d1cb-a321-5f9e-8769-9c7e3ae7a508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705ee27-9725-42ee-8d3b-481cdb8c9250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705ee27-9725-42ee-8d3b-481cdb8c9250.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "ef4c8a1e-8c48-5fa7-af4b-2eee5241970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c31d9d-fd77-4275-b89c-f9b64073c54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c31d9d-fd77-4275-b89c-f9b64073c54b.jpg?1",
             "name": "Stabbing Pain",
             "text": "Target creature gets -1/-1 until end of turn. Tap that creature.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "5107689d-417b-5eab-bd26-6b5fb370eb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521652cf-96f7-46a6-9b25-3e988b605a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521652cf-96f7-46a6-9b25-3e988b605a10.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "9c3e9c3d-98a5-5983-94cf-2ff004a620cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179f847-e334-4f7f-9a4e-0013942a394f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179f847-e334-4f7f-9a4e-0013942a394f.jpg?1",
             "name": "Viscera Seer",
             "text": "Sacrifice a creature: Scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "f309f50d-6c31-58de-aab3-c177d5068ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64b7c8-d417-4162-8c27-5d3b16f2f381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64b7c8-d417-4162-8c27-5d3b16f2f381.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "5fe219fa-8a19-5b85-894a-fb57a7af85ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cede38-0f02-4ce0-b947-ce3d7d7c2882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cede38-0f02-4ce0-b947-ce3d7d7c2882.jpg?1",
             "name": "Ancient Hellkite",
             "text": "Flying\n{R}: Ancient Hellkite deals 1 damage to target creature defending player controls. Activate this ability only if Ancient Hellkite is attacking.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "9ccde4a0-4f8f-5ddf-a6b8-e416b389d1f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32014715-7faa-412a-b8b4-751102e6b8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32014715-7faa-412a-b8b4-751102e6b8a3.jpg?1",
             "name": "Arc Runner",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAt the beginning of the end step, sacrifice Arc Runner.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "2268b0d7-641d-54c7-8691-dd0b3f011b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033fce45-20d8-48cc-96d3-7f16c99da83d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033fce45-20d8-48cc-96d3-7f16c99da83d.jpg?1",
             "name": "Berserkers of Blood Ridge",
             "text": "Berserkers of Blood Ridge attacks each turn if able.",
             "colours": [
@@ -4157,7 +4157,7 @@
         },
         {
             "id": "e531d6cb-71cf-57ea-b4d1-e58cedd3d11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ec6fc4-efbf-4071-860e-ba244e27e2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ec6fc4-efbf-4071-860e-ba244e27e2d3.jpg?1",
             "name": "Bloodcrazed Goblin",
             "text": "Bloodcrazed Goblin can't attack unless an opponent has been dealt damage this turn.",
             "colours": [
@@ -4192,7 +4192,7 @@
         },
         {
             "id": "05d41b89-0bdb-5a56-8c0c-134336c4f5b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670dcc2-e8e3-4fd7-a1db-c3152b005d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670dcc2-e8e3-4fd7-a1db-c3152b005d39.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "b1c879ae-3cfe-5778-97ea-7999d6f334df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44125d-28de-4ecf-a55b-1299daa5539e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44125d-28de-4ecf-a55b-1299daa5539e.jpg?1",
             "name": "Chandra Nalaar",
             "text": "+1: Chandra Nalaar deals 1 damage to target player.\n-X: Chandra Nalaar deals X damage to target creature.\n-8: Chandra Nalaar deals 10 damage to target player and each creature he or she controls.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "29c7a4ed-4a85-5552-a71c-386e683fcf20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5111b5-4911-47f9-bea7-18c4550e167d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5111b5-4911-47f9-bea7-18c4550e167d.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "e52fa1ab-0c65-5455-9c81-c3cae5ba672e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a460bb-276f-45f7-b0da-8457eb3192eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a460bb-276f-45f7-b0da-8457eb3192eb.jpg?1",
             "name": "Chandra's Spitfire",
             "text": "Flying\nWhenever an opponent is dealt noncombat damage, Chandra's Spitfire gets +3/+0 until end of turn.",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "a720c4e1-a741-5298-bb45-8783663a533d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf23a422-25a7-4c8a-9cff-24563ec20ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf23a422-25a7-4c8a-9cff-24563ec20ea7.jpg?1",
             "name": "Combust",
             "text": "Combust can't be countered by spells or abilities.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "ccb03d42-21bb-5cac-a673-6d9141129fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f2eddc-b296-40d0-bf59-44899f1570e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f2eddc-b296-40d0-bf59-44899f1570e8.jpg?1",
             "name": "Cyclops Gladiator",
             "text": "Whenever Cyclops Gladiator attacks, you may have it deal damage equal to its power to target creature defending player controls. If you do, that creature deals damage equal to its power to Cyclops Gladiator.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "49497a6a-4348-53c0-be8a-920262e5a967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf8ae40-48e1-4386-9032-4caaf673c297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf8ae40-48e1-4386-9032-4caaf673c297.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4428,7 +4428,7 @@
         },
         {
             "id": "adf23180-c897-5ecb-be75-22c589adbd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abde258-08e0-4762-8142-38e08a960f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abde258-08e0-4762-8142-38e08a960f9d.jpg?1",
             "name": "Destructive Force",
             "text": "Each player sacrifices five lands. Destructive Force deals 5 damage to each creature.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "33ce40d4-78d5-5da3-9b43-88b9737aaa06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6007db49-f750-43c6-ac09-86a61efc1bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6007db49-f750-43c6-ac09-86a61efc1bb2.jpg?1",
             "name": "Earth Servant",
             "text": "Earth Servant gets +0/+1 for each Mountain you control.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "5f088a5c-ef07-5fc9-b451-a01c75c96426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9df1b79-bf3a-4da3-8d98-bdf175445f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9df1b79-bf3a-4da3-8d98-bdf175445f10.jpg?1",
             "name": "Ember Hauler",
             "text": "{1}, Sacrifice Ember Hauler: Ember Hauler deals 2 damage to target creature or player.",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "f416dd2d-c894-54a8-b16a-a2c8c4ffad8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e2db9a-d62e-4300-a9e6-a7665fcf2ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e2db9a-d62e-4300-a9e6-a7665fcf2ef7.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "ab234d03-8083-5b19-8fa6-c95a0a5de497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3af0acc-258e-4979-bab7-7792006ec7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3af0acc-258e-4979-bab7-7792006ec7bc.jpg?1",
             "name": "Fire Servant",
             "text": "If a red instant or sorcery spell you control would deal damage, it deals double that damage instead.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "aa293acb-3059-55b8-b7af-0f97055a9d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d3714-f629-4066-8eaa-08817ad01cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d3714-f629-4066-8eaa-08817ad01cbb.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "d77abd4a-7ca7-5375-87ab-f2b05aeafcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1e41a8-018b-49b3-ad2d-38ec038d738c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1e41a8-018b-49b3-ad2d-38ec038d738c.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -4661,7 +4661,7 @@
         },
         {
             "id": "aacf55f1-837f-5868-88c7-dcc1eca0e6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d78658-21a4-4133-a29c-a80be8ec2cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d78658-21a4-4133-a29c-a80be8ec2cfc.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "{R}: Goblin Balloon Brigade gains flying until end of turn.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "6e876c5d-7b48-5dc1-940f-c6bfc33c93e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78563012-b724-4b6e-94e9-8504d3f76d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78563012-b724-4b6e-94e9-8504d3f76d59.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "ae5107d7-a3e9-5f67-be96-66f30112c618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85516547-2c1a-432b-9fc5-8d2c91156c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85516547-2c1a-432b-9fc5-8d2c91156c77.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "12064e1c-4a16-5f36-aa02-cd0e7be59210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a55db6-d501-4d15-910a-1bd98df2ad0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a55db6-d501-4d15-910a-1bd98df2ad0d.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "98801534-b131-542a-b6ea-a07a86d035c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b6932-e62d-4d38-bd0e-9ab8d4a56762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b6932-e62d-4d38-bd0e-9ab8d4a56762.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle your library.\nWhen Hoarding Dragon is put into a graveyard from the battlefield, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "66e0a40f-45c3-5c37-9108-6175daa512c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba4dcc6-05a5-43e9-b445-bae83180aa79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba4dcc6-05a5-43e9-b445-bae83180aa79.jpg?1",
             "name": "Incite",
             "text": "Target creature becomes red until end of turn and attacks this turn if able.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "0c0bfb1e-04b7-54ed-9870-2e58e330cf19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4a028-6462-4373-9864-a8adfc78d52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4a028-6462-4373-9864-a8adfc78d52b.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "b57d6560-76a7-571e-b82e-466d4feb766c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd025e6-4c36-4be2-aeab-000cd8bc094c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd025e6-4c36-4be2-aeab-000cd8bc094c.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4932,7 +4932,7 @@
         },
         {
             "id": "a11d5be3-e354-56d7-a4af-6784caf8ae03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2eec5-f892-4466-b6c6-960626ba5640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2eec5-f892-4466-b6c6-960626ba5640.jpg?1",
             "name": "Leyline of Punishment",
             "text": "If Leyline of Punishment is in your opening hand, you may begin the game with it on the battlefield.\nPlayers can't gain life.\nDamage can't be prevented.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "6ca7af0b-4b6a-59ba-90be-6da4f62bcff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768c957-3a1f-42f5-853a-96942f645df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768c957-3a1f-42f5-853a-96942f645df5.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "5f9dd28b-2c18-5ea2-8254-28749c0e73f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3857c9b-136d-4e6a-bd3b-92dab1b71947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3857c9b-136d-4e6a-bd3b-92dab1b71947.jpg?1",
             "name": "Magma Phoenix",
             "text": "Flying\nWhen Magma Phoenix is put into a graveyard from the battlefield, it deals 3 damage to each creature and each player.\n{3}{R}{R}: Return Magma Phoenix from your graveyard to your hand.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "ed2683cb-d1b1-559e-9fb7-f91a2449ec1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a503697a-4940-4b8f-98b1-5ea9151866fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a503697a-4940-4b8f-98b1-5ea9151866fa.jpg?1",
             "name": "Manic Vandal",
             "text": "When Manic Vandal enters the battlefield, destroy target artifact.",
             "colours": [
@@ -5065,7 +5065,7 @@
         },
         {
             "id": "c7158f94-22c5-5bc6-925f-01cf3c5bca9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081dba98-2092-4225-8e9e-214fb9263b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081dba98-2092-4225-8e9e-214fb9263b1c.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "e7ca6b68-9677-57cc-b6dd-fbf9f0b78fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e577638-a7ed-4bcc-90fb-0cffe87d5a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e577638-a7ed-4bcc-90fb-0cffe87d5a28.jpg?1",
             "name": "Pyretic Ritual",
             "text": "Add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "07fba91f-0219-5309-89d7-4d3017a2119c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea518d8f-568e-4f4a-b729-fdf4c770b9d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea518d8f-568e-4f4a-b729-fdf4c770b9d0.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "d9813e96-8608-53be-91cf-82f7904e3a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd435013-0ab9-42f4-985c-66ea2b3760e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd435013-0ab9-42f4-985c-66ea2b3760e9.jpg?1",
             "name": "Reverberate",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "e4c80410-9ec9-5624-a996-1d69589fd9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386bfe05-602d-415d-8598-96a36b7b9a14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386bfe05-602d-415d-8598-96a36b7b9a14.jpg?1",
             "name": "Shiv's Embrace",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "fe705a28-74ba-53e3-b3da-84b179ca229b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94f88b-d928-4364-9126-231eabf14086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94f88b-d928-4364-9126-231eabf14086.jpg?1",
             "name": "Thunder Strike",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "01c0b574-36a3-5e43-a3f2-ca1c89c13a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda0bffa-c58c-4630-8899-a1b332a7b8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda0bffa-c58c-4630-8899-a1b332a7b8dc.jpg?1",
             "name": "Volcanic Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has mountainwalk. (It's unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "7d9c4f1c-1cfc-5fb2-a4d6-d56b4dbfe87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299cde5-55d1-4cda-933a-2ea2c9bdfa90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299cde5-55d1-4cda-933a-2ea2c9bdfa90.jpg?1",
             "name": "Vulshok Berserker",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "c9507f31-33c4-5b14-88e8-5dcd264d7f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39aea56-5c56-4241-81c9-928c3253d7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39aea56-5c56-4241-81c9-928c3253d7c9.jpg?1",
             "name": "Wild Evocation",
             "text": "At the beginning of each player's upkeep, that player reveals a card at random from his or her hand. If it's a land card, the player puts it onto the battlefield. Otherwise, the player casts it without paying its mana cost if able.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "cb2c3060-26cb-5a4d-9aad-a640872606de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba17c6-2a96-460e-9ad1-a09174e7710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba17c6-2a96-460e-9ad1-a09174e7710a.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5397,7 +5397,7 @@
         },
         {
             "id": "3be99955-f307-582a-a6c0-0ac275001977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e354ce5-b4c1-4a9c-99d1-7624301b594b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e354ce5-b4c1-4a9c-99d1-7624301b594b.jpg?1",
             "name": "Autumn's Veil",
             "text": "Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.",
             "colours": [
@@ -5429,7 +5429,7 @@
         },
         {
             "id": "ad829a4e-c9dd-591e-8aca-97ab8fd3ab4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ea3786-c64c-4e36-8b3b-19da0c0b46d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ea3786-c64c-4e36-8b3b-19da0c0b46d3.jpg?1",
             "name": "Awakener Druid",
             "text": "When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature for as long as Awakener Druid is on the battlefield. It's still a land.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "e7e759a7-a3b3-5b5e-b7f1-366bdd77b808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af9ebf-8935-4107-aacd-4c643b68cb6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af9ebf-8935-4107-aacd-4c643b68cb6e.jpg?1",
             "name": "Back to Nature",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "f5c99765-4a02-5a8a-a753-b50454d6a8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c9d029-c568-4728-bf74-9d02b6772f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c9d029-c568-4728-bf74-9d02b6772f48.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5530,7 +5530,7 @@
         },
         {
             "id": "72043a9a-c2fe-5595-8fa0-c9c650f07b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc665c-d507-4de3-a8e8-731cc8487840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc665c-d507-4de3-a8e8-731cc8487840.jpg?1",
             "name": "Brindle Boar",
             "text": "Sacrifice Brindle Boar: You gain 4 life.",
             "colours": [
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "d8cdf095-df9a-54cd-863d-344e08c5d2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e94674-50c3-4302-b3d8-ac4d1eb33d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e94674-50c3-4302-b3d8-ac4d1eb33d6b.jpg?1",
             "name": "Cudgel Troll",
             "text": "{G}: Regenerate Cudgel Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "5f27bb0b-7c59-5b0c-9673-17db759e0076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3dbe4-5c03-4be4-ab48-45b6689b6712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3dbe4-5c03-4be4-ab48-45b6689b6712.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "4fd02f1d-7807-5c58-a24d-390095de8309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c259509e-9f95-4566-b78a-ba34107539f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c259509e-9f95-4566-b78a-ba34107539f7.jpg?1",
             "name": "Dryad's Favor",
             "text": "Enchant creature\nEnchanted creature has forestwalk. (It's unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "d14151ef-4682-5eba-987b-49ce1d751b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9e14ba-2279-4b27-ae49-5276691eeae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9e14ba-2279-4b27-ae49-5276691eeae5.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5698,7 +5698,7 @@
         },
         {
             "id": "2a3dabe9-4940-50c7-ac27-cab141285396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb80b4c-35a1-461b-8bad-2679b1dd2e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb80b4c-35a1-461b-8bad-2679b1dd2e05.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "d04e3044-829a-5593-b184-fd279a716afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c685e4c3-eb7b-4b9e-9676-395d69d80974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c685e4c3-eb7b-4b9e-9676-395d69d80974.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -5768,7 +5768,7 @@
         },
         {
             "id": "131948a8-50f5-56ae-9d43-d983263911a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5498e4d-8ccd-4874-8ecc-3b1819b15f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5498e4d-8ccd-4874-8ecc-3b1819b15f85.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "8950a672-7223-52f2-b2cd-f0e37b37a2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f610a9-73b0-4ef8-b725-f3eee1b78fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f610a9-73b0-4ef8-b725-f3eee1b78fad.jpg?1",
             "name": "Gaea's Revenge",
             "text": "Gaea's Revenge can't be countered.\nHaste\nGaea's Revenge can't be the target of nongreen spells or abilities from nongreen sources.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "93de1f8a-89fa-54e3-a43a-085fe92132eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0135ada3-e5ae-4382-a717-872839bf1d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0135ada3-e5ae-4382-a717-872839bf1d5a.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "+1: Untap two target lands.\n-1: Put a 3/3 green Beast creature token onto the battlefield.\n-4: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "d0e56a9b-79cb-59db-b4d4-1765863ad8fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863c9a10-d83f-415b-adf2-2d0f870410b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863c9a10-d83f-415b-adf2-2d0f870410b2.jpg?1",
             "name": "Garruk's Companion",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "ff7f7252-9ebb-57cd-9345-64a81cdcb846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaef299-7879-4f52-8ee4-701ed150b930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaef299-7879-4f52-8ee4-701ed150b930.jpg?1",
             "name": "Garruk's Packleader",
             "text": "Whenever another creature with power 3 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "bdd45d23-4e43-58d0-96de-a86dd0e0a5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340c33e0-2e41-4e08-a958-124860225735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340c33e0-2e41-4e08-a958-124860225735.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "2c2da919-1e40-5367-be31-6e4b284d3a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf40263-603b-46f4-9808-065bbec5c2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf40263-603b-46f4-9808-065bbec5c2f6.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "ec92b40c-f398-5cd7-93e6-bbf000c51d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f169d-8acd-4ee3-a54c-6df6cbeb7eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f169d-8acd-4ee3-a54c-6df6cbeb7eca.jpg?1",
             "name": "Greater Basilisk",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "a1d37e8f-1811-5c6b-a726-f03135c54416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b3bf7-bd09-4f0d-a670-2efc1c6d416f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b3bf7-bd09-4f0d-a670-2efc1c6d416f.jpg?1",
             "name": "Hornet Sting",
             "text": "Hornet Sting deals 1 damage to target creature or player.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "401d44cb-ac1a-5153-8736-69cd06c03ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc0c0d2-bae4-4bec-b85c-498db713fd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc0c0d2-bae4-4bec-b85c-498db713fd4a.jpg?1",
             "name": "Hunters' Feast",
             "text": "Any number of target players each gain 6 life.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "0af5de96-8081-5dfa-812b-b0389abdde87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5318113-9dfb-492c-9151-de90951d881e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5318113-9dfb-492c-9151-de90951d881e.jpg?1",
             "name": "Leyline of Vitality",
             "text": "If Leyline of Vitality is in your opening hand, you may begin the game with it on the battlefield.\nCreatures you control get +0/+1.\nWhenever a creature enters the battlefield under your control, you may gain 1 life.",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "46722644-b19f-5022-aed6-814e146f37e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d1835a-913f-4979-953b-ddd933214538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d1835a-913f-4979-953b-ddd933214538.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "ced634da-a92c-5f83-9350-9c6ea01f7030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c8cfa-76b8-4a17-be63-947490b64d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c8cfa-76b8-4a17-be63-947490b64d85.jpg?1",
             "name": "Mitotic Slime",
             "text": "When Mitotic Slime is put into a graveyard from the battlefield, put two 2/2 green Ooze creature tokens onto the battlefield. They have \"When this creature is put into a graveyard, put two 1/1 green Ooze creature tokens onto the battlefield.\"",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "69765075-2986-505c-a418-5d340e440bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25599b-02ec-4ea7-a6e2-c90880927382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25599b-02ec-4ea7-a6e2-c90880927382.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "1605ffe7-6835-53b9-8b52-7714b9f860fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af72071d-e1d2-45f7-94ad-2bdf2c67e819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af72071d-e1d2-45f7-94ad-2bdf2c67e819.jpg?1",
             "name": "Nature's Spiral",
             "text": "Return target permanent card from your graveyard to your hand. (A permanent card is an artifact, creature, enchantment, land, or planeswalker card.)",
             "colours": [
@@ -6267,7 +6267,7 @@
         },
         {
             "id": "b2291064-ea51-5543-89ac-aec87fbe12b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694496c-45b9-4ddf-bfcd-b632441b8811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694496c-45b9-4ddf-bfcd-b632441b8811.jpg?1",
             "name": "Obstinate Baloth",
             "text": "When Obstinate Baloth enters the battlefield, you gain 4 life.\nIf a spell or ability an opponent controls causes you to discard Obstinate Baloth, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "80f4c406-8c5c-5264-8b4e-c425dafd2897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5a46d0-09fe-454c-a920-0343f846b832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5a46d0-09fe-454c-a920-0343f846b832.jpg?1",
             "name": "Overwhelming Stampede",
             "text": "Until end of turn, creatures you control gain trample and get +X/+X, where X is the greatest power among creatures you control. (If a creature you control would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6333,7 +6333,7 @@
         },
         {
             "id": "d414b367-19ba-590e-98c4-199065858a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5923f9d4-c2ec-466f-9e5b-17d24bda7f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5923f9d4-c2ec-466f-9e5b-17d24bda7f37.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "55b65445-fad0-5bd1-9998-a3bd65d52e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a75889d-8746-4516-934b-efce9c48dc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a75889d-8746-4516-934b-efce9c48dc70.jpg?1",
             "name": "Primal Cocoon",
             "text": "Enchant creature\nAt the beginning of your upkeep, put a +1/+1 counter on enchanted creature.\nWhen enchanted creature attacks or blocks, sacrifice Primal Cocoon.",
             "colours": [
@@ -6399,7 +6399,7 @@
         },
         {
             "id": "3e9e3503-c154-5dc8-9f07-a1681e3a017b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feee9327-b937-46ba-a2aa-6c015ab6cdd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feee9327-b937-46ba-a2aa-6c015ab6cdd5.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "dd46a5d3-7e73-5047-8499-77f3e62f880d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399526c2-f4c7-4407-8fed-1ca8a46181d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399526c2-f4c7-4407-8fed-1ca8a46181d2.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -6467,7 +6467,7 @@
         },
         {
             "id": "750c4b75-91a5-53e6-b394-98e30d843c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63d54c1-1b20-48c4-871d-0bb15e608996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63d54c1-1b20-48c4-871d-0bb15e608996.jpg?1",
             "name": "Protean Hydra",
             "text": "Protean Hydra enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Protean Hydra, prevent that damage and remove that many +1/+1 counters from it.\nWhenever a +1/+1 counter is removed from Protean Hydra, put two +1/+1 counters on it at the beginning of the next end step.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "8572a135-e00e-55cf-a66e-d10f1a3aaee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ef778-2acf-40f0-9a64-6415d2109093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ef778-2acf-40f0-9a64-6415d2109093.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6535,7 +6535,7 @@
         },
         {
             "id": "4144c956-bac4-5531-919d-54cf0a4efdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bffe20-c469-4ac8-a8a9-361a244f4cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bffe20-c469-4ac8-a8a9-361a244f4cfe.jpg?1",
             "name": "Sacred Wolf",
             "text": "Sacred Wolf can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "29a53cf4-f8c3-58f4-a657-18498b819ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5334998-3c84-4b04-a5c2-d66c9d99e93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5334998-3c84-4b04-a5c2-d66c9d99e93b.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -6603,7 +6603,7 @@
         },
         {
             "id": "cbecb537-e662-57fe-82a0-1463ff92dda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73ea30-c6d2-4224-ae54-f6b89e006cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73ea30-c6d2-4224-ae54-f6b89e006cf4.jpg?1",
             "name": "Sylvan Ranger",
             "text": "When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "667ce243-69a0-5603-94f9-81895f41b44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050a168-870e-4c47-bc74-bc1c90dd7b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050a168-870e-4c47-bc74-bc1c90dd7b3b.jpg?1",
             "name": "Wall of Vines",
             "text": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "efad9aec-7b9e-50c6-ab10-a621e87f2182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4516b135-3691-4be5-ab73-91fbdc6b24b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4516b135-3691-4be5-ab73-91fbdc6b24b6.jpg?1",
             "name": "Yavimaya Wurm",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6708,7 +6708,7 @@
         },
         {
             "id": "ac125b09-d683-5154-80f5-bfb81bd8c2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2caa08-1b25-4ace-9204-068777f82e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2caa08-1b25-4ace-9204-068777f82e69.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player casts a white spell, you may gain 1 life.",
             "colours": [],
@@ -6736,7 +6736,7 @@
         },
         {
             "id": "97d21040-09e3-547d-9951-6a14247d6a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e2a430-339c-46ae-a43f-61e11e018b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e2a430-339c-46ae-a43f-61e11e018b7b.jpg?1",
             "name": "Brittle Effigy",
             "text": "{4}, {T}, Exile Brittle Effigy: Exile target creature.",
             "colours": [],
@@ -6764,7 +6764,7 @@
         },
         {
             "id": "21029697-15fc-5857-993d-04f2bd0cea4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56dc98fb-a956-46f7-aca2-97929b4236ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56dc98fb-a956-46f7-aca2-97929b4236ee.jpg?1",
             "name": "Crystal Ball",
             "text": "{1}, {T}: Scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [],
@@ -6792,7 +6792,7 @@
         },
         {
             "id": "b5b82e15-1f01-5832-9436-b3d6bfa547cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1a71-c565-472d-8393-66b461f00f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1a71-c565-472d-8393-66b461f00f7e.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player casts a black spell, you may gain 1 life.",
             "colours": [],
@@ -6820,7 +6820,7 @@
         },
         {
             "id": "d43083ab-244a-59fc-852d-a2694221f7c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1406d2-b554-42d1-9e05-02fbd64523f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1406d2-b554-42d1-9e05-02fbd64523f3.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player casts a red spell, you may gain 1 life.",
             "colours": [],
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "03b1a0b3-00a6-55b9-8f56-d2ca2d6c26ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd4740-9b1f-40a6-a14d-2c0d642b848b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd4740-9b1f-40a6-a14d-2c0d642b848b.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into your library.",
             "colours": [],
@@ -6876,7 +6876,7 @@
         },
         {
             "id": "00ea5f7e-02d1-5247-a10a-250e06a8d41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af328bc-bce5-4024-9da5-853ee16eaa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af328bc-bce5-4024-9da5-853ee16eaa8a.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender (This creature can't attack.)\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -6907,7 +6907,7 @@
         },
         {
             "id": "285b3dff-b2c9-5bd5-970d-7162f08f1f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763cb2dc-c8ea-4bfc-a576-ae1641057bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763cb2dc-c8ea-4bfc-a576-ae1641057bf7.jpg?1",
             "name": "Jinxed Idol",
             "text": "At the beginning of your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol.",
             "colours": [],
@@ -6935,7 +6935,7 @@
         },
         {
             "id": "a899e8ce-c9e6-5bb7-a28e-a125859d0140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591c366-cc55-4621-8fa4-3a598b7a3230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591c366-cc55-4621-8fa4-3a598b7a3230.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -6966,7 +6966,7 @@
         },
         {
             "id": "8b4f808a-534c-57c8-bf2c-4767cdba9e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb47ef-9066-4ace-b88c-ea0d8f17ff8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb47ef-9066-4ace-b88c-ea0d8f17ff8c.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player casts a blue spell, you may gain 1 life.",
             "colours": [],
@@ -6994,7 +6994,7 @@
         },
         {
             "id": "03cc54a9-6ef0-5b23-9516-5857fe523cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331a0a01-0c12-4999-9bd7-f26991e4dad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331a0a01-0c12-4999-9bd7-f26991e4dad5.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -7025,7 +7025,7 @@
         },
         {
             "id": "3532a96e-57c4-5cd2-9013-4ac5672859c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a561bf-bddc-4ea7-bf71-9cdc07a71456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a561bf-bddc-4ea7-bf71-9cdc07a71456.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -7056,7 +7056,7 @@
         },
         {
             "id": "ffb2ac5f-363a-5c66-983a-e199abcd691f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53757410-4183-42b2-aa7f-a3d208bedcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53757410-4183-42b2-aa7f-a3d208bedcf9.jpg?1",
             "name": "Sorcerer's Strongbox",
             "text": "{2}, {T}: Flip a coin. If you win the flip, sacrifice Sorcerer's Strongbox and draw three cards.",
             "colours": [],
@@ -7084,7 +7084,7 @@
         },
         {
             "id": "42efd006-5a97-549d-8238-8277b8427dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9da673d-7cc0-4435-b5a5-5098630f7712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9da673d-7cc0-4435-b5a5-5098630f7712.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "eb083b29-0b2d-56fa-80d2-75d8df93a34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0876b-5026-4a0a-bf2f-e831593643a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0876b-5026-4a0a-bf2f-e831593643a7.jpg?1",
             "name": "Stone Golem",
             "text": "",
             "colours": [],
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "64e539d1-c459-597f-be68-05e6e3b4b99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc0138-46fc-493c-8a28-8630c4759193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc0138-46fc-493c-8a28-8630c4759193.jpg?1",
             "name": "Sword of Vengeance",
             "text": "Equipped creature gets +2/+0 and has first strike, vigilance, trample, and haste.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "85e63e64-5db9-51c9-8b54-440871dce9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99cde3-8ba5-44bf-bbaa-1a12c6cac925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99cde3-8ba5-44bf-bbaa-1a12c6cac925.jpg?1",
             "name": "Temple Bell",
             "text": "{T}: Each player draws a card.",
             "colours": [],
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "e3f675c9-4dad-520a-a92b-3019fd272076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4095a274-57a9-442e-8c53-1e1d242fd824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4095a274-57a9-442e-8c53-1e1d242fd824.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: Triskelion deals 1 damage to target creature or player.",
             "colours": [],
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "2d733393-59e3-546e-b6ec-03d52ef8b6ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd61957-f3a2-4976-8f15-88258f71406a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd61957-f3a2-4976-8f15-88258f71406a.jpg?1",
             "name": "Voltaic Key",
             "text": "{1}, {T}: Untap target artifact.",
             "colours": [],
@@ -7263,7 +7263,7 @@
         },
         {
             "id": "1ab9b963-ef07-528e-aed1-39fbed972ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ab6393-df29-475b-b56d-c56eb95de05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ab6393-df29-475b-b56d-c56eb95de05d.jpg?1",
             "name": "Warlord's Axe",
             "text": "Equipped creature gets +3/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "64a6f5bd-450a-5f73-9a98-9ca072e5c4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83821b3-a6a6-4a15-9169-5c6d1942903d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83821b3-a6a6-4a15-9169-5c6d1942903d.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable.\nEquipped creature has shroud. (It can't be the target of spells or abilities.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "daa2cfc0-9b42-5f4b-8376-002d76a348b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd67d9b-ba45-4f81-9654-a1fb8258c1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd67d9b-ba45-4f81-9654-a1fb8258c1fd.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player casts a green spell, you may gain 1 life.",
             "colours": [],
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "45c3f375-29f0-515e-a817-de943911ddc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b5408a-0fde-48d4-bcbf-b949a20b79c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b5408a-0fde-48d4-bcbf-b949a20b79c0.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "de5bcdb7-9587-512e-bba9-d621e255ed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb09397-c3cc-4ecc-aef7-bee4dfa6957f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb09397-c3cc-4ecc-aef7-bee4dfa6957f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "c4161f14-95cb-5778-a01d-25958e027897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d18532-2247-4e33-a760-bc42a727e9f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d18532-2247-4e33-a760-bc42a727e9f5.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7444,7 +7444,7 @@
         },
         {
             "id": "59c3c54c-9689-57a1-8b40-84ce366c7d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e92409-d301-49f5-a8a9-acd531a928d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e92409-d301-49f5-a8a9-acd531a928d4.jpg?1",
             "name": "Mystifying Maze",
             "text": "{T}: Add {1} to your mana pool.\n{4}, {T}: Exile target attacking creature an opponent controls. At the beginning of the next end step, return it to the battlefield tapped under its owner's control.",
             "colours": [],
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "af60ad65-d01d-5ed6-815f-c1a1ff29ca9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abacafc8-ae6f-4e7b-ad8b-4492ac29338f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abacafc8-ae6f-4e7b-ad8b-4492ac29338f.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "823fe76e-1776-5595-9afe-1cf67ded1830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeee9597-674f-4f72-90f4-5491f4432ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeee9597-674f-4f72-90f4-5491f4432ec5.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "271e81b3-1b86-5d7b-9377-c56e4a213d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b98de91-7fa3-4a9c-805b-5f573009c2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b98de91-7fa3-4a9c-805b-5f573009c2b0.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "de146c5b-fee2-56b8-9770-93f74b5aa642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a2ff8c-ac4a-425e-afd0-a9010bf87c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a2ff8c-ac4a-425e-afd0-a9010bf87c1c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "3ac3efc8-2ffd-5a09-97b5-31af26f71216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18bbfc-d624-44c5-b3bb-1e9a0fd1f784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18bbfc-d624-44c5-b3bb-1e9a0fd1f784.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7638,7 +7638,7 @@
         },
         {
             "id": "c30808bb-9d44-5f8c-9430-ff441061deed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d968b76-8787-40de-821f-46bd2754fa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d968b76-8787-40de-821f-46bd2754fa8a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7676,7 +7676,7 @@
         },
         {
             "id": "62022902-a9f3-5a6e-9d17-1b094833fbf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46198629-2099-463d-ad5a-c919ae64cded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46198629-2099-463d-ad5a-c919ae64cded.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7714,7 +7714,7 @@
         },
         {
             "id": "fdea90de-7ac5-5b31-81aa-122435e55555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8d3740-40e9-40d4-833e-8f191a43ed14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8d3740-40e9-40d4-833e-8f191a43ed14.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "d98b9187-ad97-58fe-9aca-46181a47b49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3da4bf-1a5a-42a7-bd36-f1ca080c8a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3da4bf-1a5a-42a7-bd36-f1ca080c8a5a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "032e1901-aa78-5e0a-b405-95a2872b89b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b34fc0-dc7b-4823-9ff1-5e1e84016204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b34fc0-dc7b-4823-9ff1-5e1e84016204.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "9af02639-8af6-5df0-a2d6-35d5ab3e17d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3114ce5d-c99c-4c60-b088-48ec440eafdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3114ce5d-c99c-4c60-b088-48ec440eafdb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "4b51af34-701a-5c09-a2e5-7eb9d12fddbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd3031-8284-4098-a5e6-2fdfc4362752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd3031-8284-4098-a5e6-2fdfc4362752.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "57771146-3ff1-53c2-98d2-7d691af78e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7adaa8f-18e8-4f26-9867-535b41884cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7adaa8f-18e8-4f26-9867-535b41884cff.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7942,7 +7942,7 @@
         },
         {
             "id": "21e59ad6-0450-5c33-a5be-5617c9a723bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541cd2a1-034b-4f23-8468-40891ccff9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541cd2a1-034b-4f23-8468-40891ccff9fc.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7980,7 +7980,7 @@
         },
         {
             "id": "37c89416-678f-5304-8d3a-3212c3d0d433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3b5252-afab-4994-8303-3e0bee67b687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3b5252-afab-4994-8303-3e0bee67b687.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "e7fa090b-923a-52ea-90d1-d3292c68fa61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9b48f1-7c3a-4b1f-9a00-7b75eb6ea831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9b48f1-7c3a-4b1f-9a00-7b75eb6ea831.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "629961b2-3548-5d20-8c9e-4a976673192a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a92bef-0abb-49c0-94df-10d2da6845d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a92bef-0abb-49c0-94df-10d2da6845d0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "0c6931b9-769a-5fb3-a39a-6ac69588f54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44ab4e-79fb-42eb-9c46-cf73ee5f0db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44ab4e-79fb-42eb-9c46-cf73ee5f0db5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8132,7 +8132,7 @@
         },
         {
             "id": "620ef407-d1ac-5faa-8b29-56fbd1c5cb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8b7f3-7c5b-4004-8dc4-9157288e279c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8b7f3-7c5b-4004-8dc4-9157288e279c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "5643d688-a83e-5de4-9b31-159a92b68680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36b8794-c117-4d3d-bcde-39a3ae436f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36b8794-c117-4d3d-bcde-39a3ae436f1e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "1a5c8f2d-d3ed-525e-b724-86b64b57910d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301f00e-481d-4dbc-8fda-528d9d4ba848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301f00e-481d-4dbc-8fda-528d9d4ba848.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "c860b280-53db-5fbc-9da1-98251b59e2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee4121a-cd1f-4124-8242-f0eae8ef6580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee4121a-cd1f-4124-8242-f0eae8ef6580.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8284,7 +8284,7 @@
         },
         {
             "id": "00fc5c71-3bdb-5c7a-a79a-fc50a5b32040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83caa371-9c1d-46c7-a7c9-abcaa71ebc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83caa371-9c1d-46c7-a7c9-abcaa71ebc57.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "4024e327-527f-54d0-af52-8d4953c54313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863768b5-3cf9-415c-b4fd-371dc5afee18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863768b5-3cf9-415c-b4fd-371dc5afee18.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -8356,7 +8356,7 @@
         },
         {
             "id": "1de87b8f-316e-5f5a-a7ab-e53a2ee61973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84671e-cbe8-467e-9a8a-bbecba6158fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84671e-cbe8-467e-9a8a-bbecba6158fa.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "011a9246-7f7c-50c7-ab99-3fc13469c13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b365694-e056-48b9-aae3-599180c0c29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b365694-e056-48b9-aae3-599180c0c29c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "7168a2ff-69b1-508f-a3cb-52bee903e83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664bd13a-80fd-4ffe-bc65-f02a7a087427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664bd13a-80fd-4ffe-bc65-f02a7a087427.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8458,7 +8458,7 @@
         },
         {
             "id": "6d30428c-f846-584a-8458-55de11d00213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea26341-372c-4657-8910-08e0131fe0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea26341-372c-4657-8910-08e0131fe0fc.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -8492,7 +8492,7 @@
         },
         {
             "id": "d305fa3e-e097-5f39-b89d-f2b386b9748e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24edd312-ef8e-48a0-8532-13e072daa00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24edd312-ef8e-48a0-8532-13e072daa00f.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/M12.json
+++ b/Assets/Resources/Sets/M12.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8443cd8b-0296-5f94-96b5-d7d7481d5792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdc19da-21af-45e7-ad1f-fcacd84a8d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdc19da-21af-45e7-ad1f-fcacd84a8d89.jpg?1",
             "name": "Aegis Angel",
             "text": "Flying\nWhen Aegis Angel enters the battlefield, another target permanent is indestructible for as long as you control Aegis Angel. (Effects that say \"destroy\" don't destroy that permanent. An indestructible creature can't be destroyed by damage.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "be6fd111-f405-5f3a-8057-2fe3b05a7b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82e6a81-6a45-45f9-829d-332859a32257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82e6a81-6a45-45f9-829d-332859a32257.jpg?1",
             "name": "Alabaster Mage",
             "text": "{1}{W}: Target creature you control gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "8857deb1-74c6-50f7-8009-e826f1699760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cd7438-fde2-4e26-9c34-52c476a971e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cd7438-fde2-4e26-9c34-52c476a971e9.jpg?1",
             "name": "Angelic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition to its other types.\nWhen enchanted creature dies, return Angelic Destiny to its owner's hand.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "51d4fd0e-cc2a-573e-9244-086da512b703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2b0942-423a-4378-b8cd-022a6b608a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2b0942-423a-4378-b8cd-022a6b608a2e.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "76488e69-d60d-5f55-8910-75e258159516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c839e-0aea-4754-af37-edf6292623e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c839e-0aea-4754-af37-edf6292623e1.jpg?1",
             "name": "Arbalest Elite",
             "text": "{2}{W}, {T}: Arbalest Elite deals 3 damage to target attacking or blocking creature. Arbalest Elite doesn't untap during your next untap step.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "49a75f79-7007-5c01-826f-d2d2f0c92383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaee06f-edc1-4c3a-9ecc-97882c1b911e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaee06f-edc1-4c3a-9ecc-97882c1b911e.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice dies, exile target permanent.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "8ef6f2be-2e0e-5fff-a18a-c5dbd9424865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52daf505-d436-4ea6-a157-4268af2ff7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52daf505-d436-4ea6-a157-4268af2ff7a8.jpg?1",
             "name": "Armored Warhorse",
             "text": "",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "72b30265-ca8c-5883-9cec-08d3c3a5e0d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a791d03-bcbd-437a-8222-3de97d26f0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a791d03-bcbd-437a-8222-3de97d26f0d0.jpg?1",
             "name": "Assault Griffin",
             "text": "Flying",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "d6d63ec8-1b50-5ea4-9db2-542e6271245b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b702dc6d-4c05-4313-b303-c321847ad6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b702dc6d-4c05-4313-b303-c321847ad6a9.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "9ae8cfc4-f3dd-5cd9-bddd-b2f29d876e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a5603a-88c8-4b0c-b091-6d97e873859a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a5603a-88c8-4b0c-b091-6d97e873859a.jpg?1",
             "name": "Benalish Veteran",
             "text": "Whenever Benalish Veteran attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "dc2d6c80-8dab-5018-983f-cb3cd75dafcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f75e85-9454-4008-aa51-a1d5965752d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f75e85-9454-4008-aa51-a1d5965752d6.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "598b0ad4-563b-5aae-99a3-d2c616ff2d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed43ed8-9490-4433-843f-9020cd3470a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed43ed8-9490-4433-843f-9020cd3470a1.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "69d6623a-0aff-527b-815b-82767a89bc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b042f-f059-4e9f-a459-8682688f45cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b042f-f059-4e9f-a459-8682688f45cf.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -442,7 +442,7 @@
         },
         {
             "id": "81cab6f4-2749-55ee-85cc-e91c755f6cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e053-95c2-410f-b35d-8ea3e3607e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e053-95c2-410f-b35d-8ea3e3607e82.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "110fc288-a785-56fc-87ba-7537d98ffc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03487e9-f584-4bbd-8335-4dd001a88b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03487e9-f584-4bbd-8335-4dd001a88b52.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "f288da73-12af-5d03-8e28-d316a00d35e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c58b63c-e3e5-4575-849c-9a6a00821286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c58b63c-e3e5-4575-849c-9a6a00821286.jpg?1",
             "name": "Gideon Jura",
             "text": "+2: During target opponent's next turn, creatures that player controls attack Gideon Jura if able.\n-2: Destroy target tapped creature.\n0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "e09f3d75-a45a-5453-acab-e964ffe3c5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0a0d33-8862-433b-a078-82472e5f9af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0a0d33-8862-433b-a078-82472e5f9af0.jpg?1",
             "name": "Gideon's Avenger",
             "text": "Whenever a creature an opponent controls becomes tapped, put a +1/+1 counter on Gideon's Avenger.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "3ebb1159-4281-52bc-bdd9-4214fcbbf6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71eb81-a077-4c85-a4ce-4ad664486bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71eb81-a077-4c85-a4ce-4ad664486bee.jpg?1",
             "name": "Gideon's Lawkeeper",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "52036ce0-e64b-56e2-ab48-1fa858a659b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e35a40-37dd-436c-b4ac-b17b04508c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e35a40-37dd-436c-b4ac-b17b04508c1f.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "7fef7ed1-9e2b-5327-9e2b-25b018982f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a5517-e442-4fbc-b8c3-fea28e5e44d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a5517-e442-4fbc-b8c3-fea28e5e44d2.jpg?1",
             "name": "Griffin Rider",
             "text": "As long as you control a Griffin creature, Griffin Rider gets +3/+3 and has flying.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "70536273-5cb6-5ad9-ac52-e85da6d74eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8f2fea-2bc1-49fc-91c9-83698f43262f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8f2fea-2bc1-49fc-91c9-83698f43262f.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "051a6915-eb4a-5fe0-8608-384e4d6463e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e6105c-8633-46f7-a7ca-2a5c36c6d548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e6105c-8633-46f7-a7ca-2a5c36c6d548.jpg?1",
             "name": "Guardians' Pledge",
             "text": "White creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "fb6e9fcc-e6a2-5c4d-84d0-92adc01457bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a6831-c352-4ca7-9f8f-43ea99a1cf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a6831-c352-4ca7-9f8f-43ea99a1cf33.jpg?1",
             "name": "Honor of the Pure",
             "text": "White creatures you control get +1/+1.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "d4cfdf1a-5723-53ab-8124-4c110ff6e214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e207d4-9930-4aff-a7c8-b53bd1b5d566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e207d4-9930-4aff-a7c8-b53bd1b5d566.jpg?1",
             "name": "Lifelink",
             "text": "Enchant creature\nEnchanted creature has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "8cf4a13b-1bdb-543f-9416-26c78f7ef082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691dcce5-ac3d-4970-b3ff-3db485f9f5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691dcce5-ac3d-4970-b3ff-3db485f9f5c3.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -854,7 +854,7 @@
         },
         {
             "id": "bf7a6c63-cb03-5fd9-8e43-8ee504f2ebf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e1676-ae7d-46ee-af91-bb54e4d18a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e1676-ae7d-46ee-af91-bb54e4d18a78.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "3e8bc053-3c14-5276-b5a4-34749c6ae652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efc5a2a-eb76-410d-98e6-1455108faa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efc5a2a-eb76-410d-98e6-1455108faa52.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "03887ccd-a747-5a39-9b75-5fa37e8487fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783ccfbb-4063-4614-8135-11787227ce97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783ccfbb-4063-4614-8135-11787227ce97.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "29985bf3-d4c9-5ffd-81d4-c33f40e7f1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296eaa6-f9fe-4fb8-af9c-04928d99e2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296eaa6-f9fe-4fb8-af9c-04928d99e2e2.jpg?1",
             "name": "Peregrine Griffin",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "9174dc25-e33b-5ab9-98af-469f90a86b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f10d57-687d-4ee3-8226-bae525d56e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f10d57-687d-4ee3-8226-bae525d56e9e.jpg?1",
             "name": "Personal Sanctuary",
             "text": "During your turn, prevent all damage that would be dealt to you.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "4ae95592-4b22-50d1-b985-c73c1f15f3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d8d723-743c-45d6-b11b-7213f4872cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d8d723-743c-45d6-b11b-7213f4872cf1.jpg?1",
             "name": "Pride Guardian",
             "text": "Defender (This creature can't attack.)\nWhenever Pride Guardian blocks, you gain 3 life.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "1797f899-fcf6-56c8-859b-67fd8dd3e749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ae6206-ff0d-4248-b9cb-4ffbf20504fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ae6206-ff0d-4248-b9cb-4ffbf20504fa.jpg?1",
             "name": "Roc Egg",
             "text": "Defender (This creature can't attack.)\nWhen Roc Egg dies, put a 3/3 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "6c52dc34-5513-5c17-a25b-dbda8ed3eabc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31fb9d-ec0d-4555-814d-62642d52c710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31fb9d-ec0d-4555-814d-62642d52c710.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "f573cf74-ff54-5d57-b388-4cba2b5e8fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c340a3-0118-48d3-99ab-f4a0e7099325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c340a3-0118-48d3-99ab-f4a0e7099325.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "8ca4e588-1e15-50d7-a58e-3ba32f672ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8444-ccce-411e-bc4f-e5abca749608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8444-ccce-411e-bc4f-e5abca749608.jpg?1",
             "name": "Spirit Mantle",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has protection from creatures. (It can't be blocked, targeted, or dealt damage by creatures.)",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "dbf3a8f1-aec4-57a6-98bc-1d6377ec2bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb09157-5d7a-4da2-92b6-9354489e607f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb09157-5d7a-4da2-92b6-9354489e607f.jpg?1",
             "name": "Stave Off",
             "text": "Target creature gains protection from the color of your choice until end of turn. (It can't be blocked, targeted, dealt damage, or enchanted by anything of that color.)",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "8f04aa47-fa8c-5763-8f3c-0a7c161a0ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3797f7f-489d-4735-af56-6359e0fa0a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3797f7f-489d-4735-af56-6359e0fa0a6b.jpg?1",
             "name": "Stonehorn Dignitary",
             "text": "When Stonehorn Dignitary enters the battlefield, target opponent skips his or her next combat phase.",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "9f346e40-8e28-5b2d-b6ff-a30926464d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0ba2d2-09d5-4755-a18f-40cf19d88f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0ba2d2-09d5-4755-a18f-40cf19d88f25.jpg?1",
             "name": "Stormfront Pegasus",
             "text": "Flying",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "503829b5-7b8f-5eff-8b79-b4379b7c3eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e77ed-9015-4407-b78c-494e46b67b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e77ed-9015-4407-b78c-494e46b67b07.jpg?1",
             "name": "Sun Titan",
             "text": "Vigilance\nWhenever Sun Titan enters the battlefield or attacks, you may return target permanent card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "f485837a-75dd-5bb0-8ab3-7adbf3dc14a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4669c-e526-4c24-9c25-38cb5c5ef59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4669c-e526-4c24-9c25-38cb5c5ef59b.jpg?1",
             "name": "Timely Reinforcements",
             "text": "If you have less life than an opponent, you gain 6 life. If you control fewer creatures than an opponent, put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "57a3bfa2-e40f-5bd7-8e72-6d8b406f5c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f04ca-cab7-4c86-a56c-79d6ae3b73e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f04ca-cab7-4c86-a56c-79d6ae3b73e6.jpg?1",
             "name": "Aether Adept",
             "text": "When \u00c6ther Adept enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "de83b22b-358b-5a2f-935a-8a91b34659e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6434841-6cca-4397-b1fa-5ce34dc0b7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6434841-6cca-4397-b1fa-5ce34dc0b7f3.jpg?1",
             "name": "Alluring Siren",
             "text": "{T}: Target creature an opponent controls attacks you this turn if able.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "1c5a40c9-1e5f-5fd0-8269-9cbc46a69612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd169064-9c7b-40bd-8be0-a89fcb28ae2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd169064-9c7b-40bd-8be0-a89fcb28ae2f.jpg?1",
             "name": "Amphin Cutthroat",
             "text": "",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "fdcc866b-a16f-5331-ba57-71c4207e6510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57626fd2-d101-4e23-946f-8309c9676fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57626fd2-d101-4e23-946f-8309c9676fe5.jpg?1",
             "name": "Aven Fleetwing",
             "text": "Flying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "35fb02d0-4aba-598b-9ca7-86859d2f638e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a473897f-49eb-4e0f-a5b6-ea75e10be91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a473897f-49eb-4e0f-a5b6-ea75e10be91a.jpg?1",
             "name": "Azure Mage",
             "text": "{3}{U}: Draw a card.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "a5ea754f-e9ba-53fb-bf03-d76b2d869cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6829959-dae1-4ddf-8a75-33a77e6b4612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6829959-dae1-4ddf-8a75-33a77e6b4612.jpg?1",
             "name": "Belltower Sphinx",
             "text": "Flying\nWhenever a source deals damage to Belltower Sphinx, that source's controller puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "d9e9795a-7d36-5ad4-bcfc-9032f861768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b856-e3c0-4b06-a2b0-6663a9aafd26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b856-e3c0-4b06-a2b0-6663a9aafd26.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "898c42c1-0536-557e-b321-d9231f9bf2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7e246d-92f8-4e6e-89fc-991b888fc1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7e246d-92f8-4e6e-89fc-991b888fc1e8.jpg?1",
             "name": "Chasm Drake",
             "text": "Flying\nWhenever Chasm Drake attacks, target creature you control gains flying until end of turn.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "2c3ce386-155d-5165-9f2e-fcf5c0da52cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8f212-d1c6-4140-a392-73d0e141e708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8f212-d1c6-4140-a392-73d0e141e708.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "a25e3d3f-a554-5261-9047-b1f7b66f33fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252243c-34e3-447b-b323-fffcbe128278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252243c-34e3-447b-b323-fffcbe128278.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "2ba59650-d5cc-5a26-851e-7cca72802ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c621dd-9c60-4951-beaf-eb6b597c2f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c621dd-9c60-4951-beaf-eb6b597c2f0f.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -1731,7 +1731,7 @@
         },
         {
             "id": "f3009232-794e-5826-b4d4-1b4f9f553923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425a629-371f-4624-b7a1-b34818ecccad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425a629-371f-4624-b7a1-b34818ecccad.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "f43ab53d-4b9b-5599-8753-ed9c6774087c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15316953-dcb2-4428-b90a-c90d3d4c45f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15316953-dcb2-4428-b90a-c90d3d4c45f3.jpg?1",
             "name": "Flight",
             "text": "Enchant creature\nEnchanted creature has flying.",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "eaeebd00-d559-5eec-8dab-c8b86ff9ce08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1724ec5b-5437-4688-aa10-b327a0ae2654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1724ec5b-5437-4688-aa10-b327a0ae2654.jpg?1",
             "name": "Frost Breath",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "8cd1df40-de09-5094-af91-17c2ff93dac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358baa9f-390f-4b99-a274-d28f3bd56824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358baa9f-390f-4b99-a274-d28f3bd56824.jpg?1",
             "name": "Frost Titan",
             "text": "Whenever Frost Titan becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.\nWhenever Frost Titan enters the battlefield or attacks, tap target permanent. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "aa22a75d-7587-5c11-a464-6b5eba651212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d4f1d-b378-49c3-b697-6566b3c455cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d4f1d-b378-49c3-b697-6566b3c455cd.jpg?1",
             "name": "Harbor Serpent",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "21797dd3-6da2-5cd0-b100-f2cd43b45b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e14b62-c050-4d43-aeee-873f46d1e295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e14b62-c050-4d43-aeee-873f46d1e295.jpg?1",
             "name": "Ice Cage",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "f330a423-882c-5887-aeff-3e0122fd45df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f2a5b6-c26c-4355-b760-d87f074a4921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f2a5b6-c26c-4355-b760-d87f074a4921.jpg?1",
             "name": "Jace, Memory Adept",
             "text": "+1: Draw a card. Target player puts the top card of his or her library into his or her graveyard.\n0: Target player puts the top ten cards of his or her library into his or her graveyard.\n-7: Any number of target players each draw twenty cards.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "2e41d982-1c21-5ceb-97d7-660a955d90f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c6b294-3840-4007-a4e3-67309f6581dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c6b294-3840-4007-a4e3-67309f6581dd.jpg?1",
             "name": "Jace's Archivist",
             "text": "{U}, {T}: Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "4154f6da-2abe-57cf-9eeb-a4beb67a39f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970f4f34-f834-41a7-aff1-7cef82cefc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970f4f34-f834-41a7-aff1-7cef82cefc74.jpg?1",
             "name": "Jace's Erasure",
             "text": "Whenever you draw a card, you may have target player put the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "10fc828d-121d-5088-b280-ea0631f3aab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e5124a-67c0-44ed-8085-28bf37816423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e5124a-67c0-44ed-8085-28bf37816423.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "81930905-9f68-509c-b05e-3c929c6c458b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09140f6-fa75-4bee-9ca0-3a71cd2b5a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09140f6-fa75-4bee-9ca0-3a71cd2b5a7b.jpg?1",
             "name": "Lord of the Unreal",
             "text": "Illusion creatures you control get +1/+1 and have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "abe886ec-a4e8-50c9-b70d-0b849f6e549f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b123efa-8631-4a07-970d-ff4f980a0522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b123efa-8631-4a07-970d-ff4f980a0522.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "80bb22b0-5eee-510e-b582-07a221f24dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c273d3-ef0f-40c6-baf5-e39279d10509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c273d3-ef0f-40c6-baf5-e39279d10509.jpg?1",
             "name": "Master Thief",
             "text": "When Master Thief enters the battlefield, gain control of target artifact for as long as you control Master Thief.",
             "colours": [
@@ -2168,7 +2168,7 @@
         },
         {
             "id": "ab52be6b-b9ca-5774-92e1-d7b378d4f998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad3aaec-7c88-4925-8023-0cf61bf906c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad3aaec-7c88-4925-8023-0cf61bf906c2.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "da973e22-3568-5de9-bb8c-4ea5eef5c9d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220dede5-472c-4a09-bdf0-73e722d9d4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220dede5-472c-4a09-bdf0-73e722d9d4d2.jpg?1",
             "name": "Merfolk Mesmerist",
             "text": "{U}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "0a023e18-c3e9-540f-8461-73fd3aef885e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7f77af-17d7-4746-bc83-f455b9b6f9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7f77af-17d7-4746-bc83-f455b9b6f9ea.jpg?1",
             "name": "Mind Control",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "0dcbed7a-c4b9-5f99-bcf5-98f95833c0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90cf36-9841-4adf-b5cb-0a7bf103eb93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90cf36-9841-4adf-b5cb-0a7bf103eb93.jpg?1",
             "name": "Mind Unbound",
             "text": "At the beginning of your upkeep, put a lore counter on Mind Unbound, then draw a card for each lore counter on Mind Unbound.",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "c2f46e38-039a-555b-9ef1-e203cd0a2304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f21cd05-2fdb-4c37-90a4-220a3eda23ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f21cd05-2fdb-4c37-90a4-220a3eda23ef.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2336,7 +2336,7 @@
         },
         {
             "id": "7ede0ffa-395e-563c-b5b6-5af8b1268170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06cc574a-f687-4e41-b0a0-62a0eedea7c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06cc574a-f687-4e41-b0a0-62a0eedea7c2.jpg?1",
             "name": "Phantasmal Bear",
             "text": "When Phantasmal Bear becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "a944a114-75f7-5be9-b7f7-b3a854b932b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cd015c-0569-4e7f-9daf-b39e67fc7096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cd015c-0569-4e7f-9daf-b39e67fc7096.jpg?1",
             "name": "Phantasmal Dragon",
             "text": "Flying\nWhen Phantasmal Dragon becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "1bdad99f-2a1f-523d-a244-ba1914308708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e7bf8f-dba7-4005-8cee-634c9153931d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e7bf8f-dba7-4005-8cee-634c9153931d.jpg?1",
             "name": "Phantasmal Image",
             "text": "You may have Phantasmal Image enter the battlefield as a copy of any creature on the battlefield, except it's an Illusion in addition to its other types and it gains \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "684d6a4e-8f07-53cc-97e9-034d7480cc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c908ee-e70a-4406-a32d-ab5ab17e67b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c908ee-e70a-4406-a32d-ab5ab17e67b1.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "03128760-724a-5969-8d9a-b5495bf0926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdb01f8-209d-4f8b-a280-b45e1ab0b880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdb01f8-209d-4f8b-a280-b45e1ab0b880.jpg?1",
             "name": "Redirect",
             "text": "You may choose new targets for target spell.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "b58f8227-b79f-5874-b174-9bac2b8ce5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628213e9-bde9-43fd-a0d9-8c7fb17be879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628213e9-bde9-43fd-a0d9-8c7fb17be879.jpg?1",
             "name": "Skywinder Drake",
             "text": "Flying\nSkywinder Drake can block only creatures with flying.",
             "colours": [
@@ -2538,7 +2538,7 @@
         },
         {
             "id": "7bfac845-1113-5b2a-b2a4-e69737d7461b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a290648a-63c3-400b-98d3-5a5aa5505027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a290648a-63c3-400b-98d3-5a5aa5505027.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2572,7 +2572,7 @@
         },
         {
             "id": "eebf3ec8-0679-55dc-9e42-9de64fda00ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6500a1-5aea-4b83-b4dc-560fe547590d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6500a1-5aea-4b83-b4dc-560fe547590d.jpg?1",
             "name": "Time Reversal",
             "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. Exile Time Reversal.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "cb5d132d-f963-58ae-b07e-78834df331ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43d9a1e-0767-4a9b-81b4-4ff2f3dde1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43d9a1e-0767-4a9b-81b4-4ff2f3dde1d5.jpg?1",
             "name": "Turn to Frog",
             "text": "Target creature loses all abilities and becomes a 1/1 blue Frog until end of turn.",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "4a75e87a-6c1f-5332-b140-e7b35787c750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439b79-f6f4-4d01-8404-a1e02f2aeb55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439b79-f6f4-4d01-8404-a1e02f2aeb55.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "213d835d-7b46-590a-8cae-ef0c7132e9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75657d26-b0f8-4892-8684-533c103c921d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75657d26-b0f8-4892-8684-533c103c921d.jpg?1",
             "name": "Visions of Beyond",
             "text": "Draw a card. If a graveyard has twenty or more cards in it, draw three cards instead.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "1f8fb86c-05a6-5a03-9820-f3bf05997da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8033de8d-a396-4097-aedd-f9facb800b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8033de8d-a396-4097-aedd-f9facb800b33.jpg?1",
             "name": "Blood Seeker",
             "text": "Whenever a creature enters the battlefield under an opponent's control, you may have that player lose 1 life.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "600c74d6-cc94-55ae-a13d-cbb76a147ea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125c5cff-d4e9-4655-9cc5-3ce21e577569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125c5cff-d4e9-4655-9cc5-3ce21e577569.jpg?1",
             "name": "Bloodlord of Vaasgoth",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature enters the battlefield with three +1/+1 counters on it.)\nFlying\nWhenever you cast a Vampire creature spell, it gains bloodthirst 3.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "a6ff60dc-b0a2-5251-b980-f0363ebbe1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a078e438-fcf9-4648-95dc-3d4037f9b561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a078e438-fcf9-4648-95dc-3d4037f9b561.jpg?1",
             "name": "Bloodrage Vampire",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "66a4f968-7203-524d-b514-dbea85790f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab78cd-a899-4c5d-86b3-0666adadba87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab78cd-a899-4c5d-86b3-0666adadba87.jpg?1",
             "name": "Brink of Disaster",
             "text": "Enchant creature or land\nWhen enchanted permanent becomes tapped, destroy it.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "92c831a3-4d0f-5f75-99d4-e00af045505d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1324b6-dba0-4aff-a403-a45d2b405f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1324b6-dba0-4aff-a403-a45d2b405f5b.jpg?1",
             "name": "Call to the Grave",
             "text": "At the beginning of each player's upkeep, that player sacrifices a non-Zombie creature.\nAt the beginning of the end step, if no creatures are on the battlefield, sacrifice Call to the Grave.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "5b3ab13e-ca5e-5c37-89c3-363ae53075ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56494d1e-0d7e-4c29-942c-b376ff07cdf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56494d1e-0d7e-4c29-942c-b376ff07cdf8.jpg?1",
             "name": "Cemetery Reaper",
             "text": "Other Zombie creatures you control get +1/+1.\n{2}{B}, {T}: Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "05b8518c-2709-5f2e-a7f0-52b55489760f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4780079-7f4c-4a43-883f-4722423c4fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4780079-7f4c-4a43-883f-4722423c4fec.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "d119bf49-d676-54b4-b754-55b952e66b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef144439-fc8e-4844-8ebb-3e36e05ac9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef144439-fc8e-4844-8ebb-3e36e05ac9a0.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "5cb1063b-4c97-5d4e-b0bc-537a4d1cb1d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258a235-086e-429b-9ac1-3178f902658b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258a235-086e-429b-9ac1-3178f902658b.jpg?1",
             "name": "Dark Favor",
             "text": "Enchant creature\nWhen Dark Favor enters the battlefield, you lose 1 life.\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "610fb277-a36b-5f34-9fbc-fcef521f9e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b101ff4a-8617-4c0a-8503-ed8c857ad000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b101ff4a-8617-4c0a-8503-ed8c857ad000.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "81bd72a9-d1c5-597d-ba0d-2e606281191e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735c2c79-9b4f-4f86-9dec-0749237fe9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735c2c79-9b4f-4f86-9dec-0749237fe9ce.jpg?1",
             "name": "Devouring Swarm",
             "text": "Flying\nSacrifice a creature: Devouring Swarm gets +1/+1 until end of turn.",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "87ae0da5-88f9-503f-a3fc-48b02eca0dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db75949-f8cd-4461-83c0-7eaee2196132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db75949-f8cd-4461-83c0-7eaee2196132.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "fa6cb603-b068-5686-ac3b-b5235e7e35a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10a691-a209-44a3-9925-8638a3c4e1d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10a691-a209-44a3-9925-8638a3c4e1d1.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "ba6ddc52-ee69-5676-9cdc-16b1bc6cc04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630d4080-8183-41fb-8091-740719083765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630d4080-8183-41fb-8091-740719083765.jpg?1",
             "name": "Distress",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "5f23f1e9-83c3-5da5-9b35-75e5a098ef17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d5ca8-2a94-4d79-9314-c5ca2aa4d14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d5ca8-2a94-4d79-9314-c5ca2aa4d14b.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "4b632138-ac15-5a19-8a81-ea33a40199f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dcb25e-764b-47d6-bec4-225aaace77b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dcb25e-764b-47d6-bec4-225aaace77b0.jpg?1",
             "name": "Drifting Shade",
             "text": "Flying\n{B}: Drifting Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3232,7 +3232,7 @@
         },
         {
             "id": "d9cbd2a9-f47f-5363-888f-cc646afd4882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560ee1a-1076-4ec5-a177-55ffe12e2165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560ee1a-1076-4ec5-a177-55ffe12e2165.jpg?1",
             "name": "Duskhunter Bat",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFlying",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "04ae21af-a259-501b-a9f2-2a8a09da0e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c70da33-ce5d-4b8b-9c1d-9a356a7e196f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c70da33-ce5d-4b8b-9c1d-9a356a7e196f.jpg?1",
             "name": "Grave Titan",
             "text": "Deathtouch\nWhenever Grave Titan enters the battlefield or attacks, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3300,7 +3300,7 @@
         },
         {
             "id": "dc807238-9db9-5479-a909-58fed3683503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11055d4e-3efe-493c-8c18-9e2642267511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11055d4e-3efe-493c-8c18-9e2642267511.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3334,7 +3334,7 @@
         },
         {
             "id": "99985454-6ff9-5e4c-93e8-076bdb377612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25925751-b6cb-45a3-915f-d5ec3edcda78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25925751-b6cb-45a3-915f-d5ec3edcda78.jpg?1",
             "name": "Hideous Visage",
             "text": "Creatures you control gain intimidate until end of turn. (Each of those creatures can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3366,7 +3366,7 @@
         },
         {
             "id": "94c453af-0f4d-57d4-b423-800de6175e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61ee72e-61ae-4558-8abe-f5eaf5b9fb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61ee72e-61ae-4558-8abe-f5eaf5b9fb8a.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3398,7 +3398,7 @@
         },
         {
             "id": "e9eb9506-1629-5759-af76-220f675c4780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af53d7f-7f02-4c35-b6f4-7365d121ba54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af53d7f-7f02-4c35-b6f4-7365d121ba54.jpg?1",
             "name": "Monomania",
             "text": "Target player chooses a card in his or her hand and discards the rest.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "8b15b6df-122a-51f6-90fb-d3d01e0be7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabd38e6-1e59-42d2-bd1a-555c77cf6747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabd38e6-1e59-42d2-bd1a-555c77cf6747.jpg?1",
             "name": "Onyx Mage",
             "text": "{1}{B}: Target creature you control gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "c6fd61c1-1af3-5be7-ac06-af91935e9864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c219bc-a140-4ecd-953a-eef2cc552d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c219bc-a140-4ecd-953a-eef2cc552d58.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "d1053985-b4de-5fe1-8288-3bec2570a3f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12e8109-8215-46b5-a0af-fe7e4b6b10b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12e8109-8215-46b5-a0af-fe7e4b6b10b0.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "da0c8808-3f32-5a9c-9e45-55f63e62889c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e0f81-0591-4b28-978e-a2f1c46b7427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e0f81-0591-4b28-978e-a2f1c46b7427.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "727a7585-cac0-53fe-92cf-7528f20c49a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0da3971-0145-4975-8bb1-8c2898d10ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0da3971-0145-4975-8bb1-8c2898d10ae7.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "360e0242-714b-5f70-8002-8b1328350258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c8159b-8c1d-480a-b517-dbd67bba1838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c8159b-8c1d-480a-b517-dbd67bba1838.jpg?1",
             "name": "Smallpox",
             "text": "Each player loses 1 life, discards a card, sacrifices a creature, then sacrifices a land.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "e29d2c0d-13d9-539c-bd4f-7a9db62d1b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25b3a89-3a99-4e02-bf0c-a3cf450da1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25b3a89-3a99-4e02-bf0c-a3cf450da1a1.jpg?1",
             "name": "Sorin Markov",
             "text": "+2: Sorin Markov deals 2 damage to target creature or player and you gain 2 life.\n-3: Target opponent's life total becomes 10.\n-7: You control target player during that player's next turn.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "1a58a7e1-808e-5562-a75d-10aba6886b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f14a435-811d-4057-93a9-ce74aa852a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f14a435-811d-4057-93a9-ce74aa852a09.jpg?1",
             "name": "Sorin's Thirst",
             "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "34f125eb-ab2d-56e7-97ff-32bf712fd272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb62846-c5da-4c7c-b0d7-9b677dce68d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb62846-c5da-4c7c-b0d7-9b677dce68d1.jpg?1",
             "name": "Sorin's Vengeance",
             "text": "Sorin's Vengeance deals 10 damage to target player and you gain 10 life.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "3a40af97-1e15-55a8-8b66-ac2968198edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8390d9b7-5adf-4039-8682-02bfba421ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8390d9b7-5adf-4039-8682-02bfba421ff9.jpg?1",
             "name": "Sutured Ghoul",
             "text": "Trample\nAs Sutured Ghoul enters the battlefield, exile any number of creature cards from your graveyard.\nSutured Ghoul's power is equal to the total power of the exiled cards and its toughness is equal to their total toughness.",
             "colours": [
@@ -3769,7 +3769,7 @@
         },
         {
             "id": "1e4f79e8-0216-5006-9ee2-361704377d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29268cef-da18-4c1d-9066-e0d513a61bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29268cef-da18-4c1d-9066-e0d513a61bf9.jpg?1",
             "name": "Taste of Blood",
             "text": "Taste of Blood deals 1 damage to target player and you gain 1 life.",
             "colours": [
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "320e8dfb-7057-5cf5-aeb4-71964b6a8a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2699c42-99bb-4b5a-82ec-9c6424c14ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2699c42-99bb-4b5a-82ec-9c6424c14ec1.jpg?1",
             "name": "Tormented Soul",
             "text": "Tormented Soul can't block and is unblockable.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "2579e676-bdcf-5b41-bebc-48c87aae11cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1286132d-1697-44da-ab97-387735265c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1286132d-1697-44da-ab97-387735265c01.jpg?1",
             "name": "Vampire Outcasts",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "b1718a39-096e-518f-b2f7-2ac876c1a0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e0ca97-bc57-4084-86b4-e2e06152cb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e0ca97-bc57-4084-86b4-e2e06152cb1c.jpg?1",
             "name": "Vengeful Pharaoh",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever combat damage is dealt to you or a planeswalker you control, if Vengeful Pharaoh is in your graveyard, destroy target attacking creature, then put Vengeful Pharaoh on top of your library.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "cb4f55bd-8018-5fb2-a494-77ac928ddd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94785274-fa79-47cc-9896-0f5f695abb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94785274-fa79-47cc-9896-0f5f695abb21.jpg?1",
             "name": "Warpath Ghoul",
             "text": "",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "a375e5c8-bb6d-51be-a930-15db559d8e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663df3e8-12e5-46cf-9da7-39961feaa7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663df3e8-12e5-46cf-9da7-39961feaa7f9.jpg?1",
             "name": "Wring Flesh",
             "text": "Target creature gets -3/-1 until end of turn.",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "4845ca9b-c9bc-5272-af3b-9ac3568d0299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1985e0bd-05b9-4eaf-9333-6262cf677acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1985e0bd-05b9-4eaf-9333-6262cf677acd.jpg?1",
             "name": "Zombie Goliath",
             "text": "",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "ec207d3c-1aba-5108-b4d0-18d991104e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a3e27-841a-4eb5-afcd-ddb87d4280f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a3e27-841a-4eb5-afcd-ddb87d4280f7.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards: Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -4036,7 +4036,7 @@
         },
         {
             "id": "5d40fb51-5c2d-5fd4-a62c-1abb5a158d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8984c-7176-43e5-931b-c3b6f4747a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8984c-7176-43e5-931b-c3b6f4747a8b.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "0da55720-fd35-5e30-989b-36be3cff71e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85ecba6-fc22-48c7-9f00-066cc1fce6b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85ecba6-fc22-48c7-9f00-066cc1fce6b5.jpg?1",
             "name": "Blood Ogre",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "7dd697f2-6653-5ff1-a2ce-b9ca0b66797e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc17e5c1-a6b4-401b-95eb-1c01cd1da570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc17e5c1-a6b4-401b-95eb-1c01cd1da570.jpg?1",
             "name": "Bonebreaker Giant",
             "text": "",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "66a95a90-0221-5385-8f5b-f47b92396414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb37556-186f-4660-8b75-c52ef16a6d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb37556-186f-4660-8b75-c52ef16a6d8f.jpg?1",
             "name": "Chandra, the Firebrand",
             "text": "+1: Chandra, the Firebrand deals 1 damage to target creature or player.\n-2: When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\n-6: Chandra, the Firebrand deals 6 damage to each of up to six target creatures and/or players.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "6c63b5f1-574e-581c-8f58-e395cfb84522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3850f0-13ed-40c5-8423-8b196132a97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3850f0-13ed-40c5-8423-8b196132a97a.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "23c046a8-a5a7-56bb-9d2b-72d53965c82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8371c83-d7c5-4432-8511-cb3c1dc7d59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8371c83-d7c5-4432-8511-cb3c1dc7d59f.jpg?1",
             "name": "Chandra's Phoenix",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever an opponent is dealt damage by a red instant or sorcery spell you control or by a red planeswalker you control, return Chandra's Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "835c34ce-2bb0-5dbb-b523-525a2b73f280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419b1813-9760-47b9-b6f3-e501586cfe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419b1813-9760-47b9-b6f3-e501586cfe4d.jpg?1",
             "name": "Circle of Flame",
             "text": "Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.",
             "colours": [
@@ -4271,7 +4271,7 @@
         },
         {
             "id": "00ace3ef-ff59-54ff-a3a8-5367479ed32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10346e2-46bd-4257-b191-c36c2577c534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10346e2-46bd-4257-b191-c36c2577c534.jpg?1",
             "name": "Combust",
             "text": "Combust can't be countered by spells or abilities.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "f8161aba-2135-5444-90c9-f3bebe6fefd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f69ccfc-e2a9-40af-b8ab-85bffe62c0f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f69ccfc-e2a9-40af-b8ab-85bffe62c0f4.jpg?1",
             "name": "Crimson Mage",
             "text": "{R}: Target creature you control gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "f2b8ea68-c3e4-5aec-8733-3be8ceb3fcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c96f7a0-99a3-4ba4-b0f0-9ea36c45d5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c96f7a0-99a3-4ba4-b0f0-9ea36c45d5d5.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "1c6e80d3-8eb5-500a-b232-1d273bb36f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a86f5d-cfbf-4d8e-9f8e-0f8288907396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a86f5d-cfbf-4d8e-9f8e-0f8288907396.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "2eb4c64f-d923-5fd7-9ddf-a435ba827083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbcc269-aaa3-42aa-9898-3f908aaae272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbcc269-aaa3-42aa-9898-3f908aaae272.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "0c6ba9df-7849-5586-a2db-d327bd2d98db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01ab5c8-f9b7-482c-a900-1388b727b89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01ab5c8-f9b7-482c-a900-1388b727b89f.jpg?1",
             "name": "Flameblast Dragon",
             "text": "Flying\nWhenever Flameblast Dragon attacks, you may pay {X}{R}. If you do, Flameblast Dragon deals X damage to target creature or player.",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "33f4e6b4-0da2-5e38-9e50-95f00ed87c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a439015-0c1c-4322-a6f1-a34040162ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a439015-0c1c-4322-a6f1-a34040162ac4.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "5107b953-b25a-50cf-bb22-4a85a553f94e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b735e5-da9d-4740-acff-aac9dd24334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b735e5-da9d-4740-acff-aac9dd24334c.jpg?1",
             "name": "Furyborn Hellkite",
             "text": "Bloodthirst 6 (If an opponent was dealt damage this turn, this creature enters the battlefield with six +1/+1 counters on it.)\nFlying",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "febad064-af00-5aed-9748-606421511a84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24751fd-5e9b-4d7d-83ba-e306b439bbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24751fd-5e9b-4d7d-83ba-e306b439bbe1.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist dies, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "8b9df522-4d84-57b9-87a9-aaaf09916261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ddad0-23ea-4139-a200-c76c9c46e8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ddad0-23ea-4139-a200-c76c9c46e8c5.jpg?1",
             "name": "Goblin Bangchuckers",
             "text": "{T}: Flip a coin. If you win the flip, Goblin Bangchuckers deals 2 damage to target creature or player. If you lose the flip, Goblin Bangchuckers deals 2 damage to itself.",
             "colours": [
@@ -4609,7 +4609,7 @@
         },
         {
             "id": "d053271a-bd05-574b-90a7-32783d27732b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2540ec6b-9ffa-4ab0-bbd3-ddf1efd2db60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2540ec6b-9ffa-4ab0-bbd3-ddf1efd2db60.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -4643,7 +4643,7 @@
         },
         {
             "id": "92c4b876-d935-5e73-95f1-bf1ef1fa7d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c11db78-f506-4af2-a7be-c7ac2c0ffcf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c11db78-f506-4af2-a7be-c7ac2c0ffcf3.jpg?1",
             "name": "Goblin Fireslinger",
             "text": "{T}: Goblin Fireslinger deals 1 damage to target player.",
             "colours": [
@@ -4678,7 +4678,7 @@
         },
         {
             "id": "f5363d31-4ed6-57ec-80d6-9829db065a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394cc2aa-0318-4ccd-a550-99a7eac933c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394cc2aa-0318-4ccd-a550-99a7eac933c3.jpg?1",
             "name": "Goblin Grenade",
             "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
             "colours": [
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "5599f803-81b7-5d9b-91a0-574d450cec56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083ec3e7-950c-4e9d-aba5-02ed13d723f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083ec3e7-950c-4e9d-aba5-02ed13d723f0.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -4745,7 +4745,7 @@
         },
         {
             "id": "37d7cd90-fc01-589c-8da5-2ab9e20f7362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c466bbb3-9758-47e6-8996-3615f4c31924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c466bbb3-9758-47e6-8996-3615f4c31924.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "890ac95e-0e10-5631-9934-7009c5159ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde711c9-fdef-4024-8269-a59ee0748f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde711c9-fdef-4024-8269-a59ee0748f95.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste. (It can attack and {T} no matter when it came under its controller's control.)",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "cffc9d7f-7788-585a-bc8b-75fad832dc30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1087e015-a3c4-4207-8285-5bda6bb50e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1087e015-a3c4-4207-8285-5bda6bb50e52.jpg?1",
             "name": "Gorehorn Minotaurs",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "ecf1809d-3c76-5d55-8f91-2676860af720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbe2c9-31d5-4e54-922d-1bc6a865b251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbe2c9-31d5-4e54-922d-1bc6a865b251.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to target creature or player.",
             "colours": [
@@ -4884,7 +4884,7 @@
         },
         {
             "id": "7df565e0-58c7-5d76-a5fd-62799d28fad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af92296-455a-425e-9397-a96d09937767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af92296-455a-425e-9397-a96d09937767.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "20719b2a-60bc-5bb2-b48f-c7d795ac06a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04c24cb-3c3b-4a35-9694-db512bf394fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04c24cb-3c3b-4a35-9694-db512bf394fa.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "1e7a708d-9bed-5236-9279-33357aded913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf9c3aa-9434-4a62-9bcb-0699a85de9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf9c3aa-9434-4a62-9bcb-0699a85de9cb.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "ab493c68-da10-5dd3-a553-7c878103f43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106b6af-a13c-42be-9368-9109795de517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106b6af-a13c-42be-9368-9109795de517.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "13124240-724b-5f3f-8ea5-981ee08657ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf081d5-e644-4f46-8bc8-a754b089acb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf081d5-e644-4f46-8bc8-a754b089acb4.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to that player.",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "a02c4ee8-969f-5f46-a714-727aa535dab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985a5866-8c62-46af-a0c0-e69d01d87f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985a5866-8c62-46af-a0c0-e69d01d87f4f.jpg?1",
             "name": "Manic Vandal",
             "text": "When Manic Vandal enters the battlefield, destroy target artifact.",
             "colours": [
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "46f3e2f7-c81f-5575-8352-8f115085c051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062e2f3-bf4a-4a9a-962c-b45718a464bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062e2f3-bf4a-4a9a-962c-b45718a464bc.jpg?1",
             "name": "Reverberate",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "e264b6b3-aa4e-585d-8257-1843e0dc5df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b61fa9d-3f69-4632-be0e-09924ca88501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b61fa9d-3f69-4632-be0e-09924ca88501.jpg?1",
             "name": "Scrambleverse",
             "text": "For each nonland permanent, choose a player at random. Then each player gains control of each permanent for which he or she was chosen. Untap those permanents.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "dcd1bd29-140a-5dee-bc91-faa2079f54ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fed52c-e84e-41c9-b683-d8b26fa03c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fed52c-e84e-41c9-b683-d8b26fa03c5f.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -5179,7 +5179,7 @@
         },
         {
             "id": "820c3364-89a8-5d6f-add0-c6763421e7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ec8b61-e602-41f2-ac1a-64e150b2ce18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ec8b61-e602-41f2-ac1a-64e150b2ce18.jpg?1",
             "name": "Slaughter Cry",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "57e9f218-059d-5da3-ba43-549ca6f7e4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a50af-ca3e-461a-9dcb-444f56284165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a50af-ca3e-461a-9dcb-444f56284165.jpg?1",
             "name": "Stormblood Berserker",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nStormblood Berserker can't be blocked except by two or more creatures.",
             "colours": [
@@ -5246,7 +5246,7 @@
         },
         {
             "id": "7aa1b058-9ee4-5d4e-8133-437bfcdae54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9838784-8c6d-4e64-bc34-e21efde99093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9838784-8c6d-4e64-bc34-e21efde99093.jpg?1",
             "name": "Tectonic Rift",
             "text": "Destroy target land. Creatures without flying can't block this turn.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "7b6a5e26-a322-5f4b-8969-38468218dd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56134669-9575-44bc-9203-edbd75acecbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56134669-9575-44bc-9203-edbd75acecbd.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "a3000179-5ae2-5f0f-a8eb-972505bf7581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69b92-7435-4aa8-9d90-89ea078befb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69b92-7435-4aa8-9d90-89ea078befb1.jpg?1",
             "name": "Wall of Torches",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "99705701-3460-53cf-bc76-21c751aa89ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16443df-52c6-4c9d-a7ff-89a37e593a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16443df-52c6-4c9d-a7ff-89a37e593a0a.jpg?1",
             "name": "Warstorm Surge",
             "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "0408ede8-9eb0-5e6c-b590-1502b9f8ea54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e5876-3eff-4075-9fa2-3ab6030848e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e5876-3eff-4075-9fa2-3ab6030848e9.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "394e3c5c-3889-5ecd-a330-103c6c2e868a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23321b80-d7e7-48fd-985d-1e9dc3adcd35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23321b80-d7e7-48fd-985d-1e9dc3adcd35.jpg?1",
             "name": "Arachnus Spinner",
             "text": "Reach (This creature can block creatures with flying.)\nTap an untapped Spider you control: Search your graveyard and/or library for a card named Arachnus Web and put it onto the battlefield attached to target creature. If you search your library this way, shuffle it.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "aa67063e-cb93-54ad-9bfd-de35a29dc5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4900b0-f934-42d9-92fb-0bb16d2e8bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4900b0-f934-42d9-92fb-0bb16d2e8bb1.jpg?1",
             "name": "Arachnus Web",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the end step, if enchanted creature's power is 4 or greater, destroy Arachnus Web.",
             "colours": [
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "7b91e24b-f120-57de-9c81-339ddb9168e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b911fee0-c30b-4d68-a9e2-61c40ece68b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b911fee0-c30b-4d68-a9e2-61c40ece68b0.jpg?1",
             "name": "Autumn's Veil",
             "text": "Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.",
             "colours": [
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "b82afda7-001f-5cff-bca3-b455f4f59662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d4236-1e54-43e3-83f1-063d49d16dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d4236-1e54-43e3-83f1-063d49d16dda.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5546,7 +5546,7 @@
         },
         {
             "id": "a5b4193e-1c71-51c8-9bd7-027d2ad39d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8191e3cb-ef28-40ea-9eab-23455435d49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8191e3cb-ef28-40ea-9eab-23455435d49e.jpg?1",
             "name": "Bountiful Harvest",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "0c903348-b6a8-58b8-9fc9-0e2067883241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc780658-fc10-481e-8319-d44a644e8fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc780658-fc10-481e-8319-d44a644e8fe8.jpg?1",
             "name": "Brindle Boar",
             "text": "Sacrifice Brindle Boar: You gain 4 life.",
             "colours": [
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "83672c74-6e85-5069-bfd0-8f6e041db4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086eb41-3524-4815-97c9-761ba86a30b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086eb41-3524-4815-97c9-761ba86a30b2.jpg?1",
             "name": "Carnage Wurm",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature enters the battlefield with three +1/+1 counters on it.)\nTrample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5646,7 +5646,7 @@
         },
         {
             "id": "63acd276-58d4-5980-9aed-cd4596a69040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e156b8d8-5309-494e-9709-44f98826a69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e156b8d8-5309-494e-9709-44f98826a69f.jpg?1",
             "name": "Cudgel Troll",
             "text": "{G}: Regenerate Cudgel Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "e1eeea75-a288-59a0-b885-705756438cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71dc232-9b7e-4c0e-ac05-8e48b4936aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71dc232-9b7e-4c0e-ac05-8e48b4936aa9.jpg?1",
             "name": "Doubling Chant",
             "text": "For each creature you control, you may search your library for a creature card with the same name as that creature. Put those cards onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "5fd9c7c0-d3df-524c-9b6f-387a293d28bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b4ebbf-1613-42a0-97ff-2f36dc8d984a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b4ebbf-1613-42a0-97ff-2f36dc8d984a.jpg?1",
             "name": "Dungrove Elder",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nDungrove Elder's power and toughness are each equal to the number of Forests you control.",
             "colours": [
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "21536fe2-458f-59b3-8f14-b87c5f49b22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f37891-fac7-4868-a20b-0e879f7e0859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f37891-fac7-4868-a20b-0e879f7e0859.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "882a9596-22fd-5919-a630-742ccb56364c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84387fb5-7929-4d08-9d94-ba2d94460ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84387fb5-7929-4d08-9d94-ba2d94460ef3.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5813,7 +5813,7 @@
         },
         {
             "id": "f5f8f47b-5f7c-5de3-a576-ad86eae65b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d586bf-bed3-4390-b81d-d101c2ae524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d586bf-bed3-4390-b81d-d101c2ae524c.jpg?1",
             "name": "Garruk, Primal Hunter",
             "text": "+1: Put a 3/3 green Beast creature token onto the battlefield.\n-3: Draw cards equal to the greatest power among creatures you control.\n-6: Put a 6/6 green Wurm creature token onto the battlefield for each land you control.",
             "colours": [
@@ -5849,7 +5849,7 @@
         },
         {
             "id": "4a18b2ac-9ab7-56eb-bc2c-8926c6cd12c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d8806c-43c5-4c6c-9420-6210a17ec2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d8806c-43c5-4c6c-9420-6210a17ec2b0.jpg?1",
             "name": "Garruk's Companion",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "7cf537ef-ad21-5c1b-8f7a-59501987dd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6959-9131-40a6-97ec-12baf6fb7ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6959-9131-40a6-97ec-12baf6fb7ca0.jpg?1",
             "name": "Garruk's Horde",
             "text": "Trample\nPlay with the top card of your library revealed.\nYou may cast the top card of your library if it's a creature card. (Do this only any time you could cast that creature card. You still pay the spell's costs.)",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "a34f571c-7482-5144-abc8-213dae4c2c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460133e5-00f1-47e2-91fe-c36802ef16a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460133e5-00f1-47e2-91fe-c36802ef16a8.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "936bedf0-4955-5b18-bbd2-26b1eeec40a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26710d5c-01d1-498b-9f54-521dfd195843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26710d5c-01d1-498b-9f54-521dfd195843.jpg?1",
             "name": "Gladecover Scout",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "9e92d8fb-70d1-5d42-90b4-d4637520d3f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994711cb-e85b-4acb-9460-17231e1d66ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994711cb-e85b-4acb-9460-17231e1d66ad.jpg?1",
             "name": "Greater Basilisk",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6020,7 +6020,7 @@
         },
         {
             "id": "c3a14f07-36a9-5020-a0c5-b091176a77e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4044a9f-43bd-4c32-9d53-29a27ad9be80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4044a9f-43bd-4c32-9d53-29a27ad9be80.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "b676e689-0b06-598f-a575-11fe7dffd8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d6c8d3-04a1-4b35-b7d1-18bed82beaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d6c8d3-04a1-4b35-b7d1-18bed82beaf4.jpg?1",
             "name": "Jade Mage",
             "text": "{2}{G}: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -6087,7 +6087,7 @@
         },
         {
             "id": "59ee4636-718d-54ba-99f9-aea1999e0c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c6f877-6b00-4d57-8a88-36cd3b16edbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c6f877-6b00-4d57-8a88-36cd3b16edbc.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "799c6086-6159-50d8-ad9b-afcaf314f692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9704ea0-4dad-4b37-a316-d00766e2a723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9704ea0-4dad-4b37-a316-d00766e2a723.jpg?1",
             "name": "Lure",
             "text": "Enchant creature\nAll creatures able to block enchanted creature do so.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "9c696221-ace1-5f2b-b011-e1e98282a7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd7d075-031e-4766-89e9-03a8a7197019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd7d075-031e-4766-89e9-03a8a7197019.jpg?1",
             "name": "Lurking Crocodile",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nIslandwalk (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "362295f2-3f98-5675-88b2-f6a7c479e2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf9c75f-0319-416c-904a-49358f2f943c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf9c75f-0319-416c-904a-49358f2f943c.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6222,7 +6222,7 @@
         },
         {
             "id": "988ba5a0-3536-5136-8340-b484975b82dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0559d4-0015-44e4-8ec4-08bb1c54eec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0559d4-0015-44e4-8ec4-08bb1c54eec5.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (If a creature you control would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "ca6356ab-3928-50db-b5ff-2666aaaa9d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1a949-c874-4739-9c7d-ad6fcd2aad44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1a949-c874-4739-9c7d-ad6fcd2aad44.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "7667a90c-7d35-562f-854b-f311fc04e751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6ddbca-b943-49d6-b341-509bb72dd5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6ddbca-b943-49d6-b341-509bb72dd5a6.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "44ee04fc-5fdc-566c-a94a-394c90b69940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc5521-df8f-4992-b93e-e430d8cc7715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc5521-df8f-4992-b93e-e430d8cc7715.jpg?1",
             "name": "Primordial Hydra",
             "text": "Primordial Hydra enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Primordial Hydra.\nPrimordial Hydra has trample as long as it has ten or more +1/+1 counters on it.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "28d848c2-ab24-5894-a8e9-2c1df4b854a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45a787-6d8a-48d7-ad6c-fb20a9b468a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45a787-6d8a-48d7-ad6c-fb20a9b468a4.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "dcac23c8-ce81-530c-95ca-a8b8a13e722c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f67503-2f0f-43bf-9c4f-a254cc6c501a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f67503-2f0f-43bf-9c4f-a254cc6c501a.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "277d9f39-0421-56de-804a-fffc1457f69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d43ce-8297-47f6-a877-d723b9b43fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d43ce-8297-47f6-a877-d723b9b43fdb.jpg?1",
             "name": "Rites of Flourishing",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nEach player may play an additional land on each of his or her turns.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "21532172-dd48-5716-901f-ecfc9bee3b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caf2b93-1971-4702-9aa5-bd223eb37a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caf2b93-1971-4702-9aa5-bd223eb37a39.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6484,7 +6484,7 @@
         },
         {
             "id": "107dd4f3-aed0-5eb9-9cf7-bd268ce82241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4661dd-2075-48c3-b19b-fc7f8aaba1b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4661dd-2075-48c3-b19b-fc7f8aaba1b8.jpg?1",
             "name": "Sacred Wolf",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6518,7 +6518,7 @@
         },
         {
             "id": "4b2830ab-60a6-5a0f-af4e-e18feca90c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56c82ad-5eb1-4653-8f02-e9bb1f6f3154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56c82ad-5eb1-4653-8f02-e9bb1f6f3154.jpg?1",
             "name": "Skinshifter",
             "text": "{G}: Choose one \u2014 Until end of turn, Skinshifter becomes a 4/4 Rhino and gains trample; or until end of turn, Skinshifter becomes a 2/2 Bird and gains flying; or until end of turn, Skinshifter becomes a 0/8 Plant. Activate this ability only once each turn.",
             "colours": [
@@ -6553,7 +6553,7 @@
         },
         {
             "id": "bf99e023-cf03-540c-aaaa-660842493cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d34690-f7cc-4161-9a6f-bfc5393e40b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d34690-f7cc-4161-9a6f-bfc5393e40b2.jpg?1",
             "name": "Stampeding Rhino",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6587,7 +6587,7 @@
         },
         {
             "id": "014791f3-f285-5bd5-9b15-022b76e905fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b781626-f4ce-4d00-aa7c-0e07f58f688f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b781626-f4ce-4d00-aa7c-0e07f58f688f.jpg?1",
             "name": "Stingerfling Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhen Stingerfling Spider enters the battlefield, you may destroy target creature with flying.",
             "colours": [
@@ -6621,7 +6621,7 @@
         },
         {
             "id": "57a46832-c3ce-5db8-a64b-a51956c4c3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c8982-e1c2-48be-8094-683d00c2e52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c8982-e1c2-48be-8094-683d00c2e52b.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6653,7 +6653,7 @@
         },
         {
             "id": "b7177d9e-cdfc-5810-9fc7-5b0a8e99d6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c8d6ed-4764-433b-9617-363e46e5b250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c8d6ed-4764-433b-9617-363e46e5b250.jpg?1",
             "name": "Trollhide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\" (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6687,7 +6687,7 @@
         },
         {
             "id": "04fad352-ca5a-55e0-aad8-9898bee4dce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9d448-ebd5-4e01-af88-e755833c2451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9d448-ebd5-4e01-af88-e755833c2451.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "c91df096-3f31-5066-8470-3ba20d3e080c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e42ead-df6e-4181-ae2b-a2abfc3f1d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e42ead-df6e-4181-ae2b-a2abfc3f1d7c.jpg?1",
             "name": "Adaptive Automaton",
             "text": "As Adaptive Automaton enters the battlefield, choose a creature type.\nAdaptive Automaton is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "7b3793ef-84eb-5d15-9825-7de2bffaa4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992dc7c-61c0-4d5f-9c32-8febfad4ef6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992dc7c-61c0-4d5f-9c32-8febfad4ef6d.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player casts a white spell, you may gain 1 life.",
             "colours": [],
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "8a1f8043-b4f3-50d3-9e48-27b9b20041bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e36991-7b9f-4cc7-8da2-55b8baf19d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e36991-7b9f-4cc7-8da2-55b8baf19d70.jpg?1",
             "name": "Crown of Empires",
             "text": "{3}, {T}: Tap target creature. Gain control of that creature instead if you control artifacts named Scepter of Empires and Throne of Empires.",
             "colours": [],
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "ad5e7b2c-e7d0-55a0-8da7-00fdc4936d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09afa3b-c172-4cd7-b605-bacbfbd07c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09afa3b-c172-4cd7-b605-bacbfbd07c24.jpg?1",
             "name": "Crumbling Colossus",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nWhen Crumbling Colossus attacks, sacrifice it at end of combat.",
             "colours": [],
@@ -6839,7 +6839,7 @@
         },
         {
             "id": "5f75e607-0243-5054-8cb1-76787075c68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f56b129-fe2d-4061-b1c9-f1f5a4db564a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f56b129-fe2d-4061-b1c9-f1f5a4db564a.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player casts a black spell, you may gain 1 life.",
             "colours": [],
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "ee71a086-7fbe-5195-8c92-eab8cf0db896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d732b87-08e5-41b6-8448-62dd6bf20d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d732b87-08e5-41b6-8448-62dd6bf20d9c.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player casts a red spell, you may gain 1 life.",
             "colours": [],
@@ -6895,7 +6895,7 @@
         },
         {
             "id": "858ff5ba-269a-583b-b1e8-71fb32681309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddb054f-0617-4afb-8ed1-a067f234f8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddb054f-0617-4afb-8ed1-a067f234f8e7.jpg?1",
             "name": "Druidic Satchel",
             "text": "{2}, {T}: Reveal the top card of your library. If it's a creature card, put a 1/1 green Saproling creature token onto the battlefield. If it's a land card, put that card onto the battlefield under your control. If it's a noncreature, nonland card, you gain 2 life.",
             "colours": [],
@@ -6923,7 +6923,7 @@
         },
         {
             "id": "5ba6479e-63bf-5caf-82a5-7d2af3590d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64e25a3-fcde-4d8f-a376-0c83470ba84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64e25a3-fcde-4d8f-a376-0c83470ba84f.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
             "colours": [],
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "9373d5ba-fdd1-51ff-82d0-f94b0cf71122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b4041d-7c95-4cb9-a18b-6568db05942b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b4041d-7c95-4cb9-a18b-6568db05942b.jpg?1",
             "name": "Greatsword",
             "text": "Equipped creature gets +3/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "e1fdc525-e5e3-588c-918f-ff4473b663e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a00d1e1-aaa4-4f4d-a887-1e477820d2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a00d1e1-aaa4-4f4d-a887-1e477820d2c6.jpg?1",
             "name": "Kite Shield",
             "text": "Equipped creature gets +0/+3.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7011,7 +7011,7 @@
         },
         {
             "id": "07e5678a-ecf6-5f65-a459-cc74f527476a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48052433-c4d3-434e-a609-e8400150a0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48052433-c4d3-434e-a609-e8400150a0f6.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player casts a blue spell, you may gain 1 life.",
             "colours": [],
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "e416ee2e-ccce-55fa-b55d-5133e352916e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bf5f25-82b4-460c-94da-b84daa8a53d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bf5f25-82b4-460c-94da-b84daa8a53d9.jpg?1",
             "name": "Manalith",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "1305fedc-aa15-5327-be97-e73d69244070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb10af81-8ff3-4063-a67a-b760fdba95f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb10af81-8ff3-4063-a67a-b760fdba95f8.jpg?1",
             "name": "Pentavus",
             "text": "Pentavus enters the battlefield with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from Pentavus: Put a 1/1 colorless Pentavite artifact creature token with flying onto the battlefield.\n{1}, Sacrifice a Pentavite: Put a +1/+1 counter on Pentavus.",
             "colours": [],
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "4f42cb54-d564-5a9f-9692-82df7eac0e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c0357a-e98d-4c49-83ad-d7a8ebe7e2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c0357a-e98d-4c49-83ad-d7a8ebe7e2d1.jpg?1",
             "name": "Quicksilver Amulet",
             "text": "{4}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [],
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "b2b8624c-84a5-5807-8a35-710e6bcf5cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fc44-4b9a-418b-a4e0-26d2c3a1eca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fc44-4b9a-418b-a4e0-26d2c3a1eca4.jpg?1",
             "name": "Rusted Sentinel",
             "text": "Rusted Sentinel enters the battlefield tapped.",
             "colours": [],
@@ -7157,7 +7157,7 @@
         },
         {
             "id": "d5af9af2-6b17-5f86-a808-1641450d271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f1aaef-94cc-45ab-99c9-8ffdcf331a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f1aaef-94cc-45ab-99c9-8ffdcf331a7b.jpg?1",
             "name": "Scepter of Empires",
             "text": "{T}: Scepter of Empires deals 1 damage to target player. It deals 3 damage to that player instead if you control artifacts named Crown of Empires and Throne of Empires.",
             "colours": [],
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "9c3514e4-85a9-5c7f-9a10-fe160bc6dc35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246d2ce1-6926-4acc-810a-4894dc346b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246d2ce1-6926-4acc-810a-4894dc346b8b.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "82525319-0976-5875-88a8-94e6f59a2589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d3da9c-cb7a-4cea-b6e6-6722bd16c73c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d3da9c-cb7a-4cea-b6e6-6722bd16c73c.jpg?1",
             "name": "Sundial of the Infinite",
             "text": "{1}, {T}: End the turn. Activate this ability only during your turn. (Exile all spells and abilities on the stack. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [],
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "22c4c4b3-54b4-55b8-9773-87cc655106b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b82753b-284c-44ba-9d48-d28913f02a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b82753b-284c-44ba-9d48-d28913f02a5f.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control, and it can attack and {T} as soon as it comes under your control.)\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "72049d59-97fd-5594-affe-8ac012af3075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01b98a6-5683-4b1b-a14c-d0b50fc26beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01b98a6-5683-4b1b-a14c-d0b50fc26beb.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -7305,7 +7305,7 @@
         },
         {
             "id": "70b3b905-570d-5134-aa6f-d2518cddb71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87352716-4cf6-4b2f-bb0a-b7aafae64478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87352716-4cf6-4b2f-bb0a-b7aafae64478.jpg?1",
             "name": "Throne of Empires",
             "text": "{1}, {T}: Put a 1/1 white Soldier creature token onto the battlefield. Put five of those tokens onto the battlefield instead if you control artifacts named Crown of Empires and Scepter of Empires.",
             "colours": [],
@@ -7333,7 +7333,7 @@
         },
         {
             "id": "1c97eeed-1988-5271-9884-2cf6033475bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c6b15-40f3-4556-978f-878bedb13762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c6b15-40f3-4556-978f-878bedb13762.jpg?1",
             "name": "Worldslayer",
             "text": "Whenever equipped creature deals combat damage to a player, destroy all permanents other than Worldslayer.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "c60ec1f1-c7ac-5469-adaa-ec91f3f49a84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da965767-a8b1-4725-ae20-65c18e37ad27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da965767-a8b1-4725-ae20-65c18e37ad27.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player casts a green spell, you may gain 1 life.",
             "colours": [],
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "9dd8a8af-6691-5ba1-aae3-b81786a1e8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e910cf59-f7aa-44b1-bb8a-c2211179137c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e910cf59-f7aa-44b1-bb8a-c2211179137c.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "b64ef7a4-8517-51dd-97be-4fd071bfb7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99375bc-7465-4f20-897c-1bc61f65de61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99375bc-7465-4f20-897c-1bc61f65de61.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "2ea89c0c-edf0-5e59-acf5-18576a5345cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ad4371-6c81-4b4c-98eb-d5c289c8c0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ad4371-6c81-4b4c-98eb-d5c289c8c0e2.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "b56720ad-1e63-5c60-93f6-2cc62266cbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3601d4-4091-465e-8c18-0cd717258211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3601d4-4091-465e-8c18-0cd717258211.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7512,7 +7512,7 @@
         },
         {
             "id": "8a336c29-9574-595d-ba8b-f04721524409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2dd5e-465f-47fd-8f5d-fd65ba133164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2dd5e-465f-47fd-8f5d-fd65ba133164.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "c57abe4d-2ee5-56ce-b003-c6af35fa93d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e02be-e41f-49b4-8393-c4cd2992e380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e02be-e41f-49b4-8393-c4cd2992e380.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7574,7 +7574,7 @@
         },
         {
             "id": "12b9d487-097f-52cf-9518-ecc8f3d341c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f768de9b-3d31-468d-876d-2cb7c5c601a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f768de9b-3d31-468d-876d-2cb7c5c601a3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7612,7 +7612,7 @@
         },
         {
             "id": "c8ed2c94-0587-5158-8e25-8ec0001c31d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1cad1f-c81e-4b65-905f-350b02047ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1cad1f-c81e-4b65-905f-350b02047ea9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "910ad4aa-427c-58e5-9706-02a876c3eb82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e9aad-3b06-4cef-8b91-0087bc5881f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e9aad-3b06-4cef-8b91-0087bc5881f8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "e362bca7-3bec-537d-987f-ab7b2b8113c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59dcb79-1ab1-4204-b50b-14bc3f709c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59dcb79-1ab1-4204-b50b-14bc3f709c46.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7726,7 +7726,7 @@
         },
         {
             "id": "079b1740-ff70-5182-aaa2-64c1b223fb76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29cf026-521f-4345-a885-da27f7981759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29cf026-521f-4345-a885-da27f7981759.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7764,7 +7764,7 @@
         },
         {
             "id": "4f5d5da4-8610-5b6c-b579-0d0ae9f916c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a585d9-abf8-41ff-b6f6-c9396d36906b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a585d9-abf8-41ff-b6f6-c9396d36906b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7802,7 +7802,7 @@
         },
         {
             "id": "99ae6496-c0b6-5360-b578-dcb97505c6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4f4d9-6168-4f83-b632-c369d2d6c256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4f4d9-6168-4f83-b632-c369d2d6c256.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7840,7 +7840,7 @@
         },
         {
             "id": "340d040a-cd66-57a5-8757-de96a832997b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589524db-68b9-46eb-a8ab-55986f37fbed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589524db-68b9-46eb-a8ab-55986f37fbed.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "694b863a-fe6f-5cfc-844b-0a07d2fc8679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29134a2-548b-4c80-8017-7e50a44c3585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29134a2-548b-4c80-8017-7e50a44c3585.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "8deec4d7-055b-5a77-9ae7-ad44e826078b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9e399-74fb-4650-ad43-439d79dc31ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9e399-74fb-4650-ad43-439d79dc31ed.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "dd036b05-80f2-509a-b547-ce2c301ee888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ffa5f-9bab-4c49-bd8f-aa7d970c25c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ffa5f-9bab-4c49-bd8f-aa7d970c25c4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7992,7 +7992,7 @@
         },
         {
             "id": "1468744c-b465-52d0-8de8-6d1d12804c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930f28b-0415-42db-9591-e688a2d6bcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930f28b-0415-42db-9591-e688a2d6bcd5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "ac4f6d01-e2d8-58a1-923d-1e7a0c64a486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d51676-2399-4db9-8c31-c8063be7b94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d51676-2399-4db9-8c31-c8063be7b94a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8068,7 +8068,7 @@
         },
         {
             "id": "e85b1fa1-b54d-5548-a0ed-9c7b3e7344e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c81a162-9735-4c3f-8eee-43b4f3b5a59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c81a162-9735-4c3f-8eee-43b4f3b5a59c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "20a6b5fd-3a69-57e4-9ff5-f996763e73c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8d9be0-255a-482a-b055-f483859266c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8d9be0-255a-482a-b055-f483859266c5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "ee1e1132-69de-5af0-b664-f3e106c6c0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce797d6-6773-4f34-be40-2e3443af6466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce797d6-6773-4f34-be40-2e3443af6466.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8182,7 +8182,7 @@
         },
         {
             "id": "d0351a0d-3757-5c45-8179-61427ceef17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6302ae7-0947-4a8d-ace4-5e6741aea9ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6302ae7-0947-4a8d-ace4-5e6741aea9ba.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "3c110dde-8d76-5499-a56d-18fccf861f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2dbbc-8bf4-45fd-a5c1-7597c885fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2dbbc-8bf4-45fd-a5c1-7597c885fc6b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "8d2b5f33-4813-5be9-9c8d-a50a06eb7b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c1369-68a2-4e67-979f-64decb6133a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c1369-68a2-4e67-979f-64decb6133a1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8296,7 +8296,7 @@
         },
         {
             "id": "a5c506f0-baca-5b71-a9ab-1fe10032e198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a793d3b8-aa7a-4679-ae28-e0ca2f265b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a793d3b8-aa7a-4679-ae28-e0ca2f265b1f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8334,7 +8334,7 @@
         },
         {
             "id": "428b7707-df47-55e0-86c3-7c0bf17b176d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6311cc7-8431-43a3-83ec-b2a5f07acf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6311cc7-8431-43a3-83ec-b2a5f07acf56.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8368,7 +8368,7 @@
         },
         {
             "id": "db8f7904-eafa-5c1f-a08e-91a909836667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2a26d0-2687-41f6-99b9-6ed4e5e8a5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2a26d0-2687-41f6-99b9-6ed4e5e8a5e4.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8402,7 +8402,7 @@
         },
         {
             "id": "8fbd3b00-1bd5-5c38-8949-a6f7f38687b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7e3f4-0153-425a-8edc-2747bbb89638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7e3f4-0153-425a-8edc-2747bbb89638.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8436,7 +8436,7 @@
         },
         {
             "id": "ea617788-3a90-5539-8968-d60333f7d83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb48d4f-e39f-4d51-9bb1-efca7dbfdc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb48d4f-e39f-4d51-9bb1-efca7dbfdc83.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8470,7 +8470,7 @@
         },
         {
             "id": "11f2f297-5b6a-5e31-904e-d177240eb85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2df53f-060d-464a-9c97-908e49e2dc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2df53f-060d-464a-9c97-908e49e2dc2c.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8504,7 +8504,7 @@
         },
         {
             "id": "8f416b23-6b1e-5cd1-b6d3-8b7a19265ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc847c-7a37-4c7f-b02c-30b3e4c91fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc847c-7a37-4c7f-b02c-30b3e4c91fb6.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8538,7 +8538,7 @@
         },
         {
             "id": "88954fda-9466-5a2c-b0c4-50389d7ed2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f88c3e-3532-489a-8f31-e07e8040f28e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f88c3e-3532-489a-8f31-e07e8040f28e.jpg?1",
             "name": "Pentavite",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M13.json
+++ b/Assets/Resources/Sets/M13.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "73a51320-80f3-526b-86ec-35e116533b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7f410a-7934-48ae-a90b-ffd096aed43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7f410a-7934-48ae-a90b-ffd096aed43d.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n-3: Target creature gains flying and double strike until end of turn.\n-8: Put X 2/2 white Cat creature tokens onto the battlefield, where X is your life total.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "d8719c7b-cf44-5b55-86d6-b1abc7fbccf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570c4d9-cd42-4aca-9421-ac44e057a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570c4d9-cd42-4aca-9421-ac44e057a785.jpg?1",
             "name": "Ajani's Sunstriker",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "b53f0355-e14b-51a7-afec-2a5edf7dbc51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6d650-4e96-43a3-8b94-7f044d3b2f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6d650-4e96-43a3-8b94-7f044d3b2f82.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "512e7ced-2a9d-59ab-8e40-54368fea529d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22125507-31e3-424c-9527-d994e4525d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22125507-31e3-424c-9527-d994e4525d75.jpg?1",
             "name": "Angelic Benediction",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may tap target creature.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "8ac2b09d-6c98-533d-93b4-fdcb71957895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f5cb3f-c27d-4b35-930f-00d806393796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f5cb3f-c27d-4b35-930f-00d806393796.jpg?1",
             "name": "Attended Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Attended Knight enters the battlefield, put a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "be17a632-833c-5314-902a-ee4fdbf9b03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60a0c43-9f47-404a-8acf-508173e7062f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60a0c43-9f47-404a-8acf-508173e7062f.jpg?1",
             "name": "Aven Squire",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "b4cc47dc-8c2e-5b93-b7ed-52f5c46a734c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182dbd5-8eae-4f4b-86aa-2bfc24481800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182dbd5-8eae-4f4b-86aa-2bfc24481800.jpg?1",
             "name": "Battleflight Eagle",
             "text": "Flying\nWhen Battleflight Eagle enters the battlefield, target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "802c7499-3313-5e34-a59e-c9145f164dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c18f5-89cd-4d33-8d5b-12dacad9f9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c18f5-89cd-4d33-8d5b-12dacad9f9b3.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "5612119f-4401-587c-9ddf-67aabd820b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79258432-ea35-4f2a-9e4a-4abb53f335c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79258432-ea35-4f2a-9e4a-4abb53f335c6.jpg?1",
             "name": "Captain's Call",
             "text": "Put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "b29c4bde-b14c-5446-a64b-17cf0295bcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295096bb-1857-4224-bc7b-307b38cfd338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295096bb-1857-4224-bc7b-307b38cfd338.jpg?1",
             "name": "Crusader of Odric",
             "text": "Crusader of Odric's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "6bdcd5e2-7f1c-5891-a7e1-242c23d65670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b713c1f7-9346-4f4e-8fcd-5ada5b3f95c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b713c1f7-9346-4f4e-8fcd-5ada5b3f95c0.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "336a78a8-7ffb-5fd0-8a88-894dd76ee5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc52c269-d44f-449c-af59-4c425aa10bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc52c269-d44f-449c-af59-4c425aa10bbf.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "2eae30b8-f75e-574a-aec5-a5db2f1cfcc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8618b737-faa0-4a0c-a3f2-bee685c00580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8618b737-faa0-4a0c-a3f2-bee685c00580.jpg?1",
             "name": "Erase",
             "text": "Exile target enchantment.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "b0df3a2b-5250-5a20-9504-bbce9fad9796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799ed076-4724-47bb-94a0-11b42a9826eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799ed076-4724-47bb-94a0-11b42a9826eb.jpg?1",
             "name": "Faith's Reward",
             "text": "Return to the battlefield all permanent cards in your graveyard that were put there from the battlefield this turn.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "50e9802b-c4a2-5b92-90d3-56605e0a3fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8672cfd-e34b-4587-9e24-015e03c7574d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8672cfd-e34b-4587-9e24-015e03c7574d.jpg?1",
             "name": "Glorious Charge",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "84be9a51-6181-5034-9c57-b51ae6ecc615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddae4f7a-525c-4306-81b5-b0991840a11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddae4f7a-525c-4306-81b5-b0991840a11e.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -541,7 +541,7 @@
         },
         {
             "id": "10d0889f-e026-5daa-934a-05bd37e294ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3defc506-537e-4659-815d-5dab15fbf199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3defc506-537e-4659-815d-5dab15fbf199.jpg?1",
             "name": "Guardian Lions",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "82d3ac9e-f3e1-57ba-a289-966ea9d716be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383c9aa5-30ad-4a2a-8b64-65d4b333c613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383c9aa5-30ad-4a2a-8b64-65d4b333c613.jpg?1",
             "name": "Guardians of Akrasa",
             "text": "Defender (This creature can't attack.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "a8f8331d-4560-5ea7-b73c-f5788fd38645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35716e37-1bb2-41e2-bb55-e65126b01ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35716e37-1bb2-41e2-bb55-e65126b01ce3.jpg?1",
             "name": "Healer of the Pride",
             "text": "Whenever another creature enters the battlefield under your control, you gain 2 life.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "435c1a7b-72d5-5bc9-946a-16641f1aa884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec71e9-0024-4f8f-b499-541fb7607fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec71e9-0024-4f8f-b499-541fb7607fcd.jpg?1",
             "name": "Intrepid Hero",
             "text": "{T}: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "d711f887-0f23-5e61-8cab-e065e700e611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646cb67-e0ac-4f2d-af21-618ff3613d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646cb67-e0ac-4f2d-af21-618ff3613d69.jpg?1",
             "name": "Knight of Glory",
             "text": "Protection from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "3562020a-ca51-5bf2-80ac-2d503fc547a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a73ec-39be-4d23-8c25-17d7c174dcee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a73ec-39be-4d23-8c25-17d7c174dcee.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "73f0db3c-9cd2-5509-80c4-d50e8b4f98f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1552a8-27b4-4a95-9022-6fdd59aca28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1552a8-27b4-4a95-9022-6fdd59aca28f.jpg?1",
             "name": "Odric, Master Tactician",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "261e75f7-a78e-5d9b-9052-c2a32c190eee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442e3b2-9d65-40c4-a3b9-8cb821980d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442e3b2-9d65-40c4-a3b9-8cb821980d80.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "6dc0a17f-4462-59d5-86ef-cc295539bb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e2f3ae-bf92-478b-9c63-acc3f175f02a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e2f3ae-bf92-478b-9c63-acc3f175f02a.jpg?1",
             "name": "Pillarfield Ox",
             "text": "",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "69b95218-f636-5ff8-ac3c-271029d0180e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5047b71-2359-4d9a-a168-a8eec43c5f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5047b71-2359-4d9a-a168-a8eec43c5f1b.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "0d12b8fc-cc83-52d9-b43d-566948ed494d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01597ede-94e7-44a4-93c2-7fd1db11e92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01597ede-94e7-44a4-93c2-7fd1db11e92a.jpg?1",
             "name": "Prized Elephant",
             "text": "Prized Elephant gets +1/+1 as long as you control a Forest.\n{G}: Prized Elephant gains trample until end of turn. (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "4e63e3eb-9a33-5077-8d9d-61db835a7116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bd6ca4-c4ed-41c3-834c-23e0c1741b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bd6ca4-c4ed-41c3-834c-23e0c1741b72.jpg?1",
             "name": "Rain of Blades",
             "text": "Rain of Blades deals 1 damage to each attacking creature.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "f6c2aed4-f18b-5659-9beb-ecc0c14d656f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ea185a-7b38-49f3-be73-be8180fb6295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ea185a-7b38-49f3-be73-be8180fb6295.jpg?1",
             "name": "Rhox Faithmender",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nIf you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "1b18fe55-a628-5915-8465-ff3328e5f675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc65c3f-ad29-4368-bf45-8345a7ec6f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc65c3f-ad29-4368-bf45-8345a7ec6f31.jpg?1",
             "name": "Safe Passage",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "c4539aa6-0f3e-5d95-add3-40f72c26a64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e5de6-3f95-4e1c-99ae-574074998d5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e5de6-3f95-4e1c-99ae-574074998d5e.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "af6fde2d-00ea-5ce6-a723-f029d727e693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10387b49-4978-4bb9-9139-2ddab3e184ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10387b49-4978-4bb9-9139-2ddab3e184ea.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar's power and toughness are each equal to your life total.\nWhen Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "ab79fa55-a3ce-5901-8cfe-edb5d22334cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef0e34f-5065-46af-bea3-d748ca25707c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef0e34f-5065-46af-bea3-d748ca25707c.jpg?1",
             "name": "Serra Avenger",
             "text": "You can't cast Serra Avenger during your first, second, or third turns of the game.\nFlying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "3b79cdd6-2d4d-597c-a882-bb1a93c4f225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe4d19d-1c9f-4b05-bde2-a9290b52c28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe4d19d-1c9f-4b05-bde2-a9290b52c28d.jpg?1",
             "name": "Show of Valor",
             "text": "Target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "61c57110-e47d-5fac-a1d1-26ed6a75f58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d33e866-cfd8-44e6-8070-df8df1ce965d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d33e866-cfd8-44e6-8070-df8df1ce965d.jpg?1",
             "name": "Silvercoat Lion",
             "text": "",
             "colours": [
@@ -1186,7 +1186,7 @@
         },
         {
             "id": "a3150aef-1b92-56b7-bdd0-5c9d560c9579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cc38bc-55a4-446a-b054-48fb90216946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cc38bc-55a4-446a-b054-48fb90216946.jpg?1",
             "name": "Sublime Archangel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nOther creatures you control have exalted. (If a creature has multiple instances of exalted, each triggers separately.)",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "838abc68-f8ae-5412-905e-aa58b6757769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5f0c2-99e6-42b7-aa16-61d5815d060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5f0c2-99e6-42b7-aa16-61d5815d060d.jpg?1",
             "name": "Touch of the Eternal",
             "text": "At the beginning of your upkeep, count the number of permanents you control. Your life total becomes that number.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "4fa10079-8db8-5a27-83d2-1898b5a3ca91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e092a0d-c031-4a76-86c1-7f83878a06e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e092a0d-c031-4a76-86c1-7f83878a06e8.jpg?1",
             "name": "War Falcon",
             "text": "Flying\nWar Falcon can't attack unless you control a Knight or a Soldier.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "0005d268-3fd0-5424-bc6b-573ecd713aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28eb320-aea7-466e-8718-de8652a2b191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28eb320-aea7-466e-8718-de8652a2b191.jpg?1",
             "name": "War Priest of Thune",
             "text": "When War Priest of Thune enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "43871ba3-83e7-5425-8373-fd8d8ad21be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102e48e0-8a5f-499d-ac62-005d3c075ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102e48e0-8a5f-499d-ac62-005d3c075ef3.jpg?1",
             "name": "Warclamp Mastiff",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "124da89d-9501-51a4-921e-2c019feac9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6d1be-55ad-4ee4-b044-88438e9b78cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6d1be-55ad-4ee4-b044-88438e9b78cc.jpg?1",
             "name": "Archaeomancer",
             "text": "When Archaeomancer enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "e1b03c1f-90eb-56e6-9554-4eeb1b347301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6aab1-c400-4d87-b68e-f36552e7417f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6aab1-c400-4d87-b68e-f36552e7417f.jpg?1",
             "name": "Arctic Aven",
             "text": "Flying\nArctic Aven gets +1/+1 as long as you control a Plains.\n{W}: Arctic Aven gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "740622cc-af9a-5a1a-810b-af4c151c2305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6ec8a6-ad88-45c9-ab4b-dd7de2418bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6ec8a6-ad88-45c9-ab4b-dd7de2418bb7.jpg?1",
             "name": "Augur of Bolas",
             "text": "When Augur of Bolas enters the battlefield, look at the top three cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "50b1aaf0-f6a2-52f4-bace-3dd5eebd4203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be15a4-693f-4e22-a46c-38bb440c073c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be15a4-693f-4e22-a46c-38bb440c073c.jpg?1",
             "name": "Battle of Wits",
             "text": "At the beginning of your upkeep, if you have 200 or more cards in your library, you win the game.",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "0d2de508-9375-5105-a8f5-d6ec075b0c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f0e3e-b209-4eda-81e5-b5e474a143d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f0e3e-b209-4eda-81e5-b5e474a143d5.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "801a979b-c030-5dc7-927c-08eaa9be69e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba912207-a8bf-4ffb-9967-34029cb09f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba912207-a8bf-4ffb-9967-34029cb09f7f.jpg?1",
             "name": "Courtly Provocateur",
             "text": "{T}: Target creature attacks this turn if able.\n{T}: Target creature blocks this turn if able.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "609f8720-c3d3-5d29-ac1c-0b6b44c6e38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c573ab-9013-4c2b-a039-ce5b20dba264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c573ab-9013-4c2b-a039-ce5b20dba264.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "5e784dc9-34fc-58cf-aeb0-0f6b923f8614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220afb1-8638-4b54-b6af-0043b4cc1cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220afb1-8638-4b54-b6af-0043b4cc1cef.jpg?1",
             "name": "Downpour",
             "text": "Tap up to three target creatures.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "51d85fca-2b46-5cf4-bddc-4dbb45cce649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd05474-5cec-4c71-85e7-79cf25958525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd05474-5cec-4c71-85e7-79cf25958525.jpg?1",
             "name": "Encrust",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "1c9dd617-639d-5fbe-82c5-421855a23c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd965f9-bdaa-4434-a9c8-53fc57e997db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd965f9-bdaa-4434-a9c8-53fc57e997db.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "c3a65b43-d395-5cf2-8f7a-ea92ab521a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcbc71b3-544b-4b81-8922-52744892989b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcbc71b3-544b-4b81-8922-52744892989b.jpg?1",
             "name": "Faerie Invaders",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "4fb872cb-d9c4-56d1-8788-2f1fb5c5a112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a69dc-c6f3-459b-9dcd-b3363c26ca34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a69dc-c6f3-459b-9dcd-b3363c26ca34.jpg?1",
             "name": "Fog Bank",
             "text": "Defender (This creature can't attack.)\nFlying\nPrevent all combat damage that would be dealt to and dealt by Fog Bank.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "9a508050-555c-59c2-98ac-bb4467648702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f7357-08b0-403e-8913-8965662a905e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f7357-08b0-403e-8913-8965662a905e.jpg?1",
             "name": "Harbor Serpent",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "fe716009-6845-57bf-8aa2-47e07ec9d86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a22f992-ef16-45be-8bac-bd7418ed068f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a22f992-ef16-45be-8bac-bd7418ed068f.jpg?1",
             "name": "Hydrosurge",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "ed396d6b-3ce1-5c88-803c-5d695c145b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785fd0b8-7e98-44f5-8012-b9dadb31f9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785fd0b8-7e98-44f5-8012-b9dadb31f9b0.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "4bb72ebc-4c39-55b7-bd9e-7cd7ecd6c93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a335-2f01-4ba7-a037-453dbb1045e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a335-2f01-4ba7-a037-453dbb1045e9.jpg?1",
             "name": "Jace, Memory Adept",
             "text": "+1: Draw a card. Target player puts the top card of his or her library into his or her graveyard.\n0: Target player puts the top ten cards of his or her library into his or her graveyard.\n-7: Any number of target players each draw twenty cards.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "94a69517-867c-56e6-b7d0-f9edbce24669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16829504-385c-4154-8e6d-f3fbaf273890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16829504-385c-4154-8e6d-f3fbaf273890.jpg?1",
             "name": "Jace's Phantasm",
             "text": "Flying\nJace's Phantasm gets +4/+4 as long as an opponent has ten or more cards in his or her graveyard.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "38b09125-a56c-5ff9-a4a9-8d6e40d96f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a50590-9091-4632-bf8c-792e1e0a75a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a50590-9091-4632-bf8c-792e1e0a75a8.jpg?1",
             "name": "Kraken Hatchling",
             "text": "",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "16400baf-a248-586b-bf14-808abb0df528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7decbd3-c754-451c-8d63-4f31f81412d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7decbd3-c754-451c-8d63-4f31f81412d2.jpg?1",
             "name": "Master of the Pearl Trident",
             "text": "Other Merfolk creatures you control get +1/+1 and have islandwalk. (They are unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "40d85e8e-b1f1-56ea-aa32-437612f68bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360fe4e-c9a6-42fa-a97a-8b5a0c19ef93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360fe4e-c9a6-42fa-a97a-8b5a0c19ef93.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "a208bcee-b0bd-5368-836b-c7f33ed7cca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5870d18e-0303-4722-b7f2-a751f8e372be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5870d18e-0303-4722-b7f2-a751f8e372be.jpg?1",
             "name": "Mind Sculpt",
             "text": "Target opponent puts the top seven cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "112ddf1f-3aeb-5795-b8bf-808f45beb440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da17a86-3666-46b8-932e-daafd6a0cd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da17a86-3666-46b8-932e-daafd6a0cd69.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "48f695fa-0c00-52f1-bf6e-bd1c6ef5782e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1088f33e-cb5f-4248-ae8e-280c4e41f291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1088f33e-cb5f-4248-ae8e-280c4e41f291.jpg?1",
             "name": "Omniscience",
             "text": "You may cast nonland cards from your hand without paying their mana costs.",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "a27446d7-6e68-5616-b414-d79e185c5a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eef8431-f63c-44e0-940c-e1a38c338214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eef8431-f63c-44e0-940c-e1a38c338214.jpg?1",
             "name": "Redirect",
             "text": "You may choose new targets for target spell.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "985b24fc-0c7d-57c9-a990-bcda1734c1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e1bb0-ffe8-4e5b-9a9a-f542ab439d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e1bb0-ffe8-4e5b-9a9a-f542ab439d3c.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "5bbf835e-d415-507d-b21c-6da1a80d0f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc201a82-fb48-4bb4-b072-e206e6872aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc201a82-fb48-4bb4-b072-e206e6872aa5.jpg?1",
             "name": "Scroll Thief",
             "text": "Whenever Scroll Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "c16a43df-9667-59b8-b636-c28cc193b093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e352497-1454-4917-b38c-4cc45424d876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e352497-1454-4917-b38c-4cc45424d876.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "51a71cf3-771e-5afb-81bd-4daa87b91141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d2f5ab-c6be-4661-843c-51b4977a9bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d2f5ab-c6be-4661-843c-51b4977a9bea.jpg?1",
             "name": "Spelltwine",
             "text": "Exile target instant or sorcery card from your graveyard and target instant or sorcery card from an opponent's graveyard. Copy those cards. Cast the copies if able without paying their mana costs. Exile Spelltwine.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "b5ce85b2-d557-5207-b34d-1a49c23a6d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4462978c-0076-466b-a64b-0f54d09d4f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4462978c-0076-466b-a64b-0f54d09d4f27.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "962af17c-828f-565b-994e-8e9353dbd14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9797351-eb0c-4774-8dbb-61a2404d66d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9797351-eb0c-4774-8dbb-61a2404d66d9.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "8e11e9a5-8a67-5027-86b8-b493fa5b840c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d62aaf3-0fd4-44ba-8eeb-18ac759dfe84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d62aaf3-0fd4-44ba-8eeb-18ac759dfe84.jpg?1",
             "name": "Switcheroo",
             "text": "Exchange control of two target creatures.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "28000960-fe86-5bce-b0fc-254fd7752222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1a6867-921d-4912-afae-c3c445ad81e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1a6867-921d-4912-afae-c3c445ad81e7.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, put a 2/2 blue Drake creature token with flying onto the battlefield.",
             "colours": [
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "3ffb8c00-7223-551f-881b-895c7a4ad74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg?1",
             "name": "Talrand's Invocation",
             "text": "Put two 2/2 blue Drake creature tokens with flying onto the battlefield.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "063cf2eb-3dce-5488-b906-2e6184530cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c796ef9-4061-4f82-9ee9-3bc446804ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c796ef9-4061-4f82-9ee9-3bc446804ee9.jpg?1",
             "name": "Tricks of the Trade",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and is unblockable.",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "13076da1-5077-57a8-81b0-ea8f8b961928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84402e82-bae7-470a-8b2f-929dac888018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84402e82-bae7-470a-8b2f-929dac888018.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "9d83a693-e7fe-51e4-8c25-59d0d4864c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bbd25-5ddd-4502-b582-b7d89c9f97a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bbd25-5ddd-4502-b582-b7d89c9f97a5.jpg?1",
             "name": "Vedalken Entrancer",
             "text": "{U}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "076bf295-c6d3-5f3a-b475-9d6d280d7bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc30e31-4796-4e98-992c-a56cd51ad3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc30e31-4796-4e98-992c-a56cd51ad3c9.jpg?1",
             "name": "Void Stalker",
             "text": "{2}{U}, {T}: Put Void Stalker and target creature on top of their owners' libraries, then those players shuffle their libraries.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "1e1ac4d6-e243-5f6d-8d1b-42566f281841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg?1",
             "name": "Watercourser",
             "text": "{U}: Watercourser gets +1/-1 until end of turn.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "f102fa44-7718-5a6c-b74d-0e7fe34805a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3c6dc6-4a16-4a01-822e-353ff84b363c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3c6dc6-4a16-4a01-822e-353ff84b363c.jpg?1",
             "name": "Welkin Tern",
             "text": "Flying\nWelkin Tern can block only creatures with flying.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "9d872868-5067-5cee-87ad-0c9fdc590f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dcb8d2-0da9-40fc-b0c0-2c76b3d277bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dcb8d2-0da9-40fc-b0c0-2c76b3d277bc.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "08d03e4e-6f7e-547b-b672-bb7da54a82ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24577bb2-61b0-4675-84e6-5d675b28fc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24577bb2-61b0-4675-84e6-5d675b28fc0e.jpg?1",
             "name": "Blood Reckoning",
             "text": "Whenever a creature attacks you or a planeswalker you control, that creature's controller loses 1 life.",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "91350720-e5d2-5a3f-80ec-ad280df16963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c10705-6e0e-46f6-a64c-0095b2796aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c10705-6e0e-46f6-a64c-0095b2796aaf.jpg?1",
             "name": "Bloodhunter Bat",
             "text": "Flying\nWhen Bloodhunter Bat enters the battlefield, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "0ca3149b-2bc9-505d-bb82-b76bb935514a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b87e0-d5e4-44f2-8220-325443ee9f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b87e0-d5e4-44f2-8220-325443ee9f31.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "39f03f22-4d66-5e7a-9415-6071688dffd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2d53b8-7847-4b94-9711-eca29facccba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2d53b8-7847-4b94-9711-eca29facccba.jpg?1",
             "name": "Cower in Fear",
             "text": "Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "021fdfa6-0892-522e-8cd5-c4b2dce64ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96a5d6-6527-4018-923e-7e850fda106a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96a5d6-6527-4018-923e-7e850fda106a.jpg?1",
             "name": "Crippling Blight",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 and can't block.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "04235c6c-f85e-512f-acee-f6a42623eebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aae919b-7da6-42b1-84b4-fbc2971dad1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aae919b-7da6-42b1-84b4-fbc2971dad1e.jpg?1",
             "name": "Dark Favor",
             "text": "Enchant creature\nWhen Dark Favor enters the battlefield, you lose 1 life.\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "472e4e60-e148-5070-a8e3-8216977a3619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d6d7b-1e87-47b7-baf3-d201458ad996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d6d7b-1e87-47b7-baf3-d201458ad996.jpg?1",
             "name": "Diabolic Revelation",
             "text": "Search your library for up to X cards and put those cards into your hand. Then shuffle your library.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "afd75423-f235-5e78-bc07-21e2494709a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dd57f8-27bc-4ad9-a79e-48a68af33b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dd57f8-27bc-4ad9-a79e-48a68af33b02.jpg?1",
             "name": "Disciple of Bolas",
             "text": "When Disciple of Bolas enters the battlefield, sacrifice another creature. You gain X life and draw X cards, where X is that creature's power.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "1d381318-0d8b-5296-a796-ca7e365ddff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7473bb-d092-4d76-b3c3-5036222dbdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7473bb-d092-4d76-b3c3-5036222dbdf7.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2995,7 +2995,7 @@
         },
         {
             "id": "59409e7e-5488-5244-8445-889e4b517887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7201d43-ae2e-4faa-a508-8555079c3bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7201d43-ae2e-4faa-a508-8555079c3bc7.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "99408690-6cfc-5bb3-8048-bf1d2ee7e61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb031da-d41a-496a-b78e-0773f6504303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb031da-d41a-496a-b78e-0773f6504303.jpg?1",
             "name": "Duskmantle Prowler",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3062,7 +3062,7 @@
         },
         {
             "id": "4ee1448f-022e-50a9-ab15-039f881fb9ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5150aa90-1284-4261-8625-2528139f0015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5150aa90-1284-4261-8625-2528139f0015.jpg?1",
             "name": "Duty-Bound Dead",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{3}{B}: Regenerate Duty-Bound Dead. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "2c9a3a8a-228e-57cb-9a53-230f5d1cc6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58df0c6d-3fd2-4d87-81e2-6640e6e75985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58df0c6d-3fd2-4d87-81e2-6640e6e75985.jpg?1",
             "name": "Essence Drain",
             "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "f7872890-bf93-5c14-9ee6-56d1f009ea5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4097d5dc-46d3-4054-818f-a4ad8d7effe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4097d5dc-46d3-4054-818f-a4ad8d7effe2.jpg?1",
             "name": "Giant Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "111a7a58-860f-55ca-8624-977d4336007a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8422e109-de8d-46ea-a7f8-d5ccb6340497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8422e109-de8d-46ea-a7f8-d5ccb6340497.jpg?1",
             "name": "Harbor Bandit",
             "text": "Harbor Bandit gets +1/+1 as long as you control an Island.\n{1}{U}: Harbor Bandit is unblockable this turn.",
             "colours": [
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "0b150421-dca3-56e9-969c-ae7ded06b8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e339853-5b6b-47b7-8d88-e9d3befb803f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e339853-5b6b-47b7-8d88-e9d3befb803f.jpg?1",
             "name": "Knight of Infamy",
             "text": "Protection from white (This creature can't be blocked, targeted, dealt damage, or enchanted by anything white.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3233,7 +3233,7 @@
         },
         {
             "id": "65abbbeb-78ed-517a-807e-055e275e7651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd2d81e-1388-4f34-9917-2289971cf8da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd2d81e-1388-4f34-9917-2289971cf8da.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.\n-3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.\n-6: You get an emblem with \"Swamps you control have \u2018{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "6e84ea5f-2c26-5b72-ac31-47d47d5019ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf0c01d-a4a0-43fb-970d-e428e9ac63d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf0c01d-a4a0-43fb-970d-e428e9ac63d7.jpg?1",
             "name": "Liliana's Shade",
             "text": "When Liliana's Shade enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.\n{B}: Liliana's Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "aef14ede-00d8-57d6-9629-05135dacf6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90484815-2529-4a81-9f1b-f0f7382e4b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90484815-2529-4a81-9f1b-f0f7382e4b66.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -3337,7 +3337,7 @@
         },
         {
             "id": "4ae19376-b895-5d88-af47-4035c8d7cbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab454fb8-347f-4d4d-84bb-195c9d51b06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab454fb8-347f-4d4d-84bb-195c9d51b06b.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "61210625-568f-5cad-81f5-f0a5bf2ac1cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8676f02-cf1e-4d40-a0c5-6e5a97417898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8676f02-cf1e-4d40-a0c5-6e5a97417898.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "c83a7592-5879-5d52-b27c-e866597b389f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48bc86b-df0a-4a9c-8aad-c3ffb742a5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48bc86b-df0a-4a9c-8aad-c3ffb742a5ff.jpg?1",
             "name": "Mutilate",
             "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
             "colours": [
@@ -3433,7 +3433,7 @@
         },
         {
             "id": "86f8b444-0047-536c-94f1-7b6b16a577f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc382f3-fdb9-4987-acf4-bf1ac4fd2ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc382f3-fdb9-4987-acf4-bf1ac4fd2ef7.jpg?1",
             "name": "Nefarox, Overlord of Grixis",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever Nefarox, Overlord of Grixis attacks alone, defending player sacrifices a creature.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "5f878d93-ee9e-569b-97bc-1457fa61c9eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefd084-548d-4326-901e-832a1b5f5391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefd084-548d-4326-901e-832a1b5f5391.jpg?1",
             "name": "Phylactery Lich",
             "text": "As Phylactery Lich enters the battlefield, put a phylactery counter on an artifact you control.\nPhylactery Lich is indestructible.\nWhen you control no permanents with phylactery counters on them, sacrifice Phylactery Lich.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "d0c680be-4ab8-519b-9700-a869e8db68f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48188942-d0ba-4503-bd75-c7a5329bb7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48188942-d0ba-4503-bd75-c7a5329bb7c8.jpg?1",
             "name": "Public Execution",
             "text": "Destroy target creature an opponent controls. Each other creature that player controls gets -2/-0 until end of turn.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "827a6245-3970-5fbb-8f5d-b416b2e56058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0642111c-f668-4acb-9df5-f0b920352407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0642111c-f668-4acb-9df5-f0b920352407.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats enters the battlefield, target opponent discards a card.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "f11730f2-5e97-56dc-8800-8af27fbd66ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2b187e-c489-4652-a638-390fc9ecef0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2b187e-c489-4652-a638-390fc9ecef0e.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3601,7 +3601,7 @@
         },
         {
             "id": "a8fb628c-412f-5591-9cdc-da73a05c8cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00a2b22-a473-44ae-919f-29bc8be05543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00a2b22-a473-44ae-919f-29bc8be05543.jpg?1",
             "name": "Servant of Nefarox",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "1389690c-8159-58c2-9596-41d508cc02ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca9e99b-e46c-4f7a-9c51-e2cfe8810450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca9e99b-e46c-4f7a-9c51-e2cfe8810450.jpg?1",
             "name": "Shimian Specter",
             "text": "Flying\nWhenever Shimian Specter deals combat damage to a player, that player reveals his or her hand. You choose a nonland card from it. Search that player's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "1634e202-7f16-57e8-8e6a-2bb1df01fd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f6600b-36c4-43bd-8c01-cfbca402ecd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f6600b-36c4-43bd-8c01-cfbca402ecd6.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "796d99ec-fc14-52fb-bc2d-d3dcb7b0b912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87810963-9c62-4ff2-b33b-51fcc1b628ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87810963-9c62-4ff2-b33b-51fcc1b628ac.jpg?1",
             "name": "Tormented Soul",
             "text": "Tormented Soul can't block and is unblockable.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "b8633374-5684-5594-b2a1-411cf35c2cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba96d96-8d9e-47c8-ab39-17479564aadf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba96d96-8d9e-47c8-ab39-17479564aadf.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "5162957f-dfb9-5994-8931-a2cbd902f5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daccbbb-6600-4467-810f-277f01a11771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daccbbb-6600-4467-810f-277f01a11771.jpg?1",
             "name": "Vampire Nocturnus",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is black, Vampire Nocturnus and other Vampire creatures you control get +2/+1 and have flying.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "78804616-fdb9-50c2-a6b7-afedd93925e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f49232-2853-427f-8c20-322e09a3ccde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f49232-2853-427f-8c20-322e09a3ccde.jpg?1",
             "name": "Veilborn Ghoul",
             "text": "Veilborn Ghoul can't block.\nWhenever a Swamp enters the battlefield under your control, you may return Veilborn Ghoul from your graveyard to your hand.",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "f10f36d4-5794-57c2-a13e-d349278347f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965b5a48-d0ff-47ce-b44e-a1611fab1876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965b5a48-d0ff-47ce-b44e-a1611fab1876.jpg?1",
             "name": "Vile Rebirth",
             "text": "Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3871,7 +3871,7 @@
         },
         {
             "id": "d457eb9c-d5bb-52e8-98d8-b2f871e2be3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecfc1ab-b7a1-43a8-b1d1-0c1c4358e89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecfc1ab-b7a1-43a8-b1d1-0c1c4358e89f.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "8ee895d6-5c4f-54bc-8c4a-46a0cd02165b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71298c75-533e-4ccd-a1f5-875f63a1e89b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71298c75-533e-4ccd-a1f5-875f63a1e89b.jpg?1",
             "name": "Wit's End",
             "text": "Target player discards his or her hand.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "61f82d27-9f83-5c0f-be8d-faf71b93601e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07524e0-303d-465d-b112-ca605b9b27fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07524e0-303d-465d-b112-ca605b9b27fc.jpg?1",
             "name": "Xathrid Gorgon",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{2}{B}, {T}: Put a petrification counter on target creature. It gains defender and becomes a colorless artifact in addition to its other types. Its activated abilities can't be activated. (A creature with defender can't attack.)",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "0c019a95-4852-5b61-b93b-41fa57d8271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8638edec-ddcd-4f50-9c2f-2e1668e3d175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8638edec-ddcd-4f50-9c2f-2e1668e3d175.jpg?1",
             "name": "Zombie Goliath",
             "text": "",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "fc216486-22f0-52a0-b6bc-dfbbf09d38c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910d3c33-8cda-487b-8b44-87a9d06d6749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910d3c33-8cda-487b-8b44-87a9d06d6749.jpg?1",
             "name": "Arms Dealer",
             "text": "{1}{R}, Sacrifice a Goblin: Arms Dealer deals 4 damage to target creature.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "a33d6408-0871-57c6-9839-8d34eb25423d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28442f9-06cf-4273-80a3-2b054f5881a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28442f9-06cf-4273-80a3-2b054f5881a4.jpg?1",
             "name": "Bladetusk Boar",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -4075,7 +4075,7 @@
         },
         {
             "id": "7d0dd3e2-abc7-57a1-9e02-09e3620f9563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8dc0efb-5847-4061-b386-9b4099361a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8dc0efb-5847-4061-b386-9b4099361a58.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4110,7 +4110,7 @@
         },
         {
             "id": "475afe64-6be5-5bd4-a672-535b5f28f181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb039db-7367-4af1-8d85-4951f58e2732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb039db-7367-4af1-8d85-4951f58e2732.jpg?1",
             "name": "Chandra, the Firebrand",
             "text": "+1: Chandra, the Firebrand deals 1 damage to target creature or player.\n-2: When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\n-6: Chandra, the Firebrand deals 6 damage to each of up to six target creatures and/or players.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "1f552e47-2b5a-508d-8c2f-2d5877d052a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25335fee-d320-4622-bcf4-292400dee52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25335fee-d320-4622-bcf4-292400dee52b.jpg?1",
             "name": "Chandra's Fury",
             "text": "Chandra's Fury deals 4 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "1e4ee3b4-f7ec-578b-87d8-950bd356a567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6761eacf-03fc-4ccd-a4a6-eca5357b5c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6761eacf-03fc-4ccd-a4a6-eca5357b5c5b.jpg?1",
             "name": "Cleaver Riot",
             "text": "Creatures you control gain double strike until end of turn. (They deal both first-strike and regular combat damage.)",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "aa1cbe58-fefa-5fe2-9833-7821f700bfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5459409-5103-4a97-a6fb-3e3ab896eb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5459409-5103-4a97-a6fb-3e3ab896eb66.jpg?1",
             "name": "Craterize",
             "text": "Destroy target land.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "395d4648-fc79-581e-9fdc-6d06e2ad33ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0811f91-ed92-4a8e-badd-ae5054e7707d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0811f91-ed92-4a8e-badd-ae5054e7707d.jpg?1",
             "name": "Crimson Muckwader",
             "text": "Crimson Muckwader gets +1/+1 as long as you control a Swamp.\n{2}{B}: Regenerate Crimson Muckwader. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "f9a922e1-b301-5025-869c-f6ce572ee929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed599d52-f2d9-4913-ad88-70f8aa4af7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed599d52-f2d9-4913-ad88-70f8aa4af7b9.jpg?1",
             "name": "Dragon Hatchling",
             "text": "Flying\n{R}: Dragon Hatchling gets +1/+0 until end of turn.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "b9d6d25f-065f-5d45-92e7-32b95cad4c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88515c2-4b4f-4d16-9f50-149ef012e961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88515c2-4b4f-4d16-9f50-149ef012e961.jpg?1",
             "name": "Fervor",
             "text": "Creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "f4f06594-b013-5f70-ab7b-f2f9e99b5d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39716c6-6c4f-4cd3-9d9c-893f883e6e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39716c6-6c4f-4cd3-9d9c-893f883e6e70.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "e3fae620-b080-5347-b2e1-e776ccc404f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8824674-ced2-448e-9bf0-03c1c43a5315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8824674-ced2-448e-9bf0-03c1c43a5315.jpg?1",
             "name": "Firewing Phoenix",
             "text": "Flying\n{1}{R}{R}{R}: Return Firewing Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "22f8b08f-02d6-5b78-8a11-038c85181e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca215b1-7b98-49ce-afae-eeb61058125a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca215b1-7b98-49ce-afae-eeb61058125a.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "aeb832d1-327f-5458-9a1f-cc047e0861ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e73d9c-8c17-4c3c-b535-e21f03e577bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e73d9c-8c17-4c3c-b535-e21f03e577bc.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "3208bcd9-53d3-580b-ae23-349167ad1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d131369-db00-4a11-bd47-4401188b0f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d131369-db00-4a11-bd47-4401188b0f35.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist dies, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "06770c5c-c004-5229-9832-ce9a98283a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e56b0-becc-4bc2-9ba3-23b3ca8bfe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e56b0-becc-4bc2-9ba3-23b3ca8bfe58.jpg?1",
             "name": "Goblin Battle Jester",
             "text": "Whenever you cast a red spell, target creature can't block this turn.",
             "colours": [
@@ -4546,7 +4546,7 @@
         },
         {
             "id": "261f00f6-bfae-5cba-804d-5f2d4ff7d319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ddeef1-f6f9-48c0-a93c-7bb3877c0e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ddeef1-f6f9-48c0-a93c-7bb3877c0e59.jpg?1",
             "name": "Hamletback Goliath",
             "text": "Whenever another creature enters the battlefield, you may put X +1/+1 counters on Hamletback Goliath, where X is that creature's power.",
             "colours": [
@@ -4581,7 +4581,7 @@
         },
         {
             "id": "3bd30bb4-9dea-56df-9e81-0a8519284e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35494897-b72b-46c4-8b36-b3b8865559bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35494897-b72b-46c4-8b36-b3b8865559bd.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "6f6ac82f-7964-5c58-a987-e1cf8b99088e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa078518-0ce2-4c6f-9061-aa7e22ed7493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa078518-0ce2-4c6f-9061-aa7e22ed7493.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Put X 1/1 red Goblin creature tokens onto the battlefield, where X is the number of Goblins you control.",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "26240a77-96c1-5021-8e10-b7e4bd05a6ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84df41e9-e973-4441-b17f-434517134d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84df41e9-e973-4441-b17f-434517134d46.jpg?1",
             "name": "Krenko's Command",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "af9f9a60-9ae7-5f39-8e3e-94395552950f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac85679e-17c7-4525-8eed-979d04feb8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac85679e-17c7-4525-8eed-979d04feb8f1.jpg?1",
             "name": "Magmaquake",
             "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
             "colours": [
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "5933b0ea-ce62-5d29-be1e-ad1a7bb1fa44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c6e09-3a14-4cc4-ba6b-f1f45e7d9f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c6e09-3a14-4cc4-ba6b-f1f45e7d9f2a.jpg?1",
             "name": "Mark of Mutiny",
             "text": "Gain control of target creature until end of turn. Put a +1/+1 counter on it and untap it. That creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "2e848bd5-e16b-5414-9365-5e4c22ca8443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f342fe9-aa73-4222-b908-d4035b5746be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f342fe9-aa73-4222-b908-d4035b5746be.jpg?1",
             "name": "Mindclaw Shaman",
             "text": "When Mindclaw Shaman enters the battlefield, target opponent reveals his or her hand. You may cast an instant or sorcery card from it without paying its mana cost.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "106a40e3-7d29-55e4-bd49-28d96c22be89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f1b5d-1b16-4f35-9cce-2f089905fddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f1b5d-1b16-4f35-9cce-2f089905fddd.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies can't attack or block alone.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "727403d8-c530-51a2-aa03-b6520ec7bb2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd32a9e-1d39-4792-9657-69d17e5e0134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd32a9e-1d39-4792-9657-69d17e5e0134.jpg?1",
             "name": "Reckless Brute",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nReckless Brute attacks each turn if able.",
             "colours": [
@@ -4850,7 +4850,7 @@
         },
         {
             "id": "5bed790f-4851-5883-87cc-3086b9a4a473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5996feb4-02ac-45e8-a7f2-966cf74391dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5996feb4-02ac-45e8-a7f2-966cf74391dc.jpg?1",
             "name": "Reverberate",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4882,7 +4882,7 @@
         },
         {
             "id": "e1fa03e3-9510-5a65-ae3f-992d5465e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5b622c-83a4-477e-a99c-2674e2bd6bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5b622c-83a4-477e-a99c-2674e2bd6bb9.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -4917,7 +4917,7 @@
         },
         {
             "id": "50e57ed0-8be5-5adf-9517-a65c029066e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94b7c-0216-473c-87a6-71e5a64d7799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94b7c-0216-473c-87a6-71e5a64d7799.jpg?1",
             "name": "Searing Spear",
             "text": "Searing Spear deals 3 damage to target creature or player.",
             "colours": [
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "d20d6408-52a3-51b6-9c45-f283504cb155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277cbd0d-c8da-4a37-965c-6a60771df2f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277cbd0d-c8da-4a37-965c-6a60771df2f7.jpg?1",
             "name": "Slumbering Dragon",
             "text": "Flying\nSlumbering Dragon can't attack or block unless it has five or more +1/+1 counters on it.\nWhenever a creature attacks you or a planeswalker you control, put a +1/+1 counter on Slumbering Dragon.",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "bf9f48d0-70bb-59e6-9bb7-116a924204a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723cb7e3-3f48-41fa-aa08-bdc59225e44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723cb7e3-3f48-41fa-aa08-bdc59225e44f.jpg?1",
             "name": "Smelt",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "a8201bce-861c-5ed3-a623-bdf85fd25f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0476e0f-61df-46a6-aaf1-8ee79c701160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0476e0f-61df-46a6-aaf1-8ee79c701160.jpg?1",
             "name": "Thundermaw Hellkite",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Thundermaw Hellkite enters the battlefield, it deals 1 damage to each creature with flying your opponents control. Tap those creatures.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "f0e82cfa-c495-5272-ad22-89864ab5988f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd53740-43bb-4ea2-aa01-937a5786ccda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd53740-43bb-4ea2-aa01-937a5786ccda.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "c2d8d96a-ef84-5e47-86ed-3e3b9f1161df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac9f745-236a-4302-acf2-21c14c6e6eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac9f745-236a-4302-acf2-21c14c6e6eab.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "9c9739d7-7c3b-597d-9664-a941a92f25da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275ede4-22d6-41db-91e9-3b0295abb8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275ede4-22d6-41db-91e9-3b0295abb8a9.jpg?1",
             "name": "Turn to Slag",
             "text": "Turn to Slag deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "a22888a9-1582-5a17-bea3-df355a6e06ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5bab70-3c28-48db-9ed3-64706f64f4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5bab70-3c28-48db-9ed3-64706f64f4fa.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -5179,7 +5179,7 @@
         },
         {
             "id": "0a5bf01e-c04c-5a66-b0a8-3817df77ca27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1963f08-1765-4f3e-92be-479773de47a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1963f08-1765-4f3e-92be-479773de47a0.jpg?1",
             "name": "Volcanic Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has mountainwalk. (It's unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "8cd69997-bdf1-574a-8ea7-d628995e14ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242e0b6-76c8-4cc6-b914-1dc7842d5a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242e0b6-76c8-4cc6-b914-1dc7842d5a9c.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "c4b9e162-99d9-59f1-81bb-d8b31ac07c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e513b8-25c2-4645-abcc-a6e9d5f51e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e513b8-25c2-4645-abcc-a6e9d5f51e09.jpg?1",
             "name": "Wild Guess",
             "text": "As an additional cost to cast Wild Guess, discard a card.\nDraw two cards.",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "3f5e4645-8b53-52f0-b7b8-56a7edcf51a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3d4b5-0453-4bf0-b018-23b0c3b9ae11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3d4b5-0453-4bf0-b018-23b0c3b9ae11.jpg?1",
             "name": "Worldfire",
             "text": "Exile all permanents. Exile all cards from all hands and graveyards. Each player's life total becomes 1.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "007e7aeb-7d23-51fb-8252-1b63881afdb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7bef5a-e0ab-46d3-a802-620bf2a7546f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7bef5a-e0ab-46d3-a802-620bf2a7546f.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "0ea513ec-c1e3-51cd-9193-04423fabc13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6b117-0c14-4455-92fc-29555ee75d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6b117-0c14-4455-92fc-29555ee75d97.jpg?1",
             "name": "Arbor Elf",
             "text": "{T}: Untap target Forest.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "f505cac2-a76c-55a3-8cd5-a8ec94e99778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f341ed2c-353b-49a3-b200-94ae43cb8e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f341ed2c-353b-49a3-b200-94ae43cb8e24.jpg?1",
             "name": "Bond Beetle",
             "text": "When Bond Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -5414,7 +5414,7 @@
         },
         {
             "id": "69dabc80-76ee-5f99-bb46-a761ea0fa86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c3cf16-ba81-4558-b1a6-79942a02f629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c3cf16-ba81-4558-b1a6-79942a02f629.jpg?1",
             "name": "Boundless Realms",
             "text": "Search your library for up to X basic land cards, where X is the number of lands you control, and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "2baa6de2-96c7-5de5-9101-42d0f472b7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7a4494-2ced-4405-9204-d2617961a1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7a4494-2ced-4405-9204-d2617961a1d6.jpg?1",
             "name": "Bountiful Harvest",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "d6a28ccf-e304-5bf8-aa8e-305b1209991d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a5f7db-ea4e-4af5-9d4a-0335db6ea0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a5f7db-ea4e-4af5-9d4a-0335db6ea0e9.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "5bb2b358-a9d5-5fc5-a44e-09a695614216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a5f77-7c1f-4da4-9ae6-3947504a8dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a5f77-7c1f-4da4-9ae6-3947504a8dea.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "46ac4537-310e-563f-b5b6-818395da2a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1a2d9a-e14c-4c44-8cf1-a2ce09bdae27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1a2d9a-e14c-4c44-8cf1-a2ce09bdae27.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "79bff4a9-9eb3-53e9-b9e6-b4d587a35538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f3f63d-0f04-4945-9895-940c916a2547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f3f63d-0f04-4945-9895-940c916a2547.jpg?1",
             "name": "Elderscale Wurm",
             "text": "Trample\nWhen Elderscale Wurm enters the battlefield, if your life total is less than 7, your life total becomes 7.\nAs long as you have 7 or more life, damage that would reduce your life total to less than 7 reduces it to 7 instead.",
             "colours": [
@@ -5615,7 +5615,7 @@
         },
         {
             "id": "c2cf6ae1-f244-5625-91da-25317a3cb09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8eba57-8c51-490b-995f-53eeb7ad574f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8eba57-8c51-490b-995f-53eeb7ad574f.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5650,7 +5650,7 @@
         },
         {
             "id": "686e4cf2-6f63-59ac-8d76-66d668ba7d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ea2998-ed91-43b8-bd81-b01a6c24a5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ea2998-ed91-43b8-bd81-b01a6c24a5b0.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -5685,7 +5685,7 @@
         },
         {
             "id": "da73dc10-1286-5c38-a2d0-92ae64f49690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b69d33-96dd-4844-aefa-27a885cb2ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b69d33-96dd-4844-aefa-27a885cb2ffc.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "f9c30eac-dc99-5085-80eb-54de011b0cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e380b99-0173-4083-a4a2-222ad98b904a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e380b99-0173-4083-a4a2-222ad98b904a.jpg?1",
             "name": "Flinthoof Boar",
             "text": "Flinthoof Boar gets +1/+1 as long as you control a Mountain.\n{R}: Flinthoof Boar gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -5752,7 +5752,7 @@
         },
         {
             "id": "57ae6f28-6f61-5f75-aeee-74f160fcc848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d591ad-4f3d-4cc6-a888-e30b46ee0771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d591ad-4f3d-4cc6-a888-e30b46ee0771.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5784,7 +5784,7 @@
         },
         {
             "id": "0946c734-2e89-5bb9-bf9d-6f729881dd0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97413ae3-037e-4786-85a3-e92604acd771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97413ae3-037e-4786-85a3-e92604acd771.jpg?1",
             "name": "Fungal Sprouting",
             "text": "Put X 1/1 green Saproling creature tokens onto the battlefield, where X is the greatest power among creatures you control.",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "41068a76-cd6a-556d-84bf-c9b733434010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9945307b-d49d-4d21-bba0-2aebba68d57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9945307b-d49d-4d21-bba0-2aebba68d57a.jpg?1",
             "name": "Garruk, Primal Hunter",
             "text": "+1: Put a 3/3 green Beast creature token onto the battlefield.\n-3: Draw cards equal to the greatest power among creatures you control.\n-6: Put a 6/6 green Wurm creature token onto the battlefield for each land you control.",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "73fae159-c38b-5a6b-88fd-bdf7b9e4c4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa6257-614b-4f39-b7fa-ea5f12f94b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa6257-614b-4f39-b7fa-ea5f12f94b64.jpg?1",
             "name": "Garruk's Packleader",
             "text": "Whenever another creature with power 3 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -5886,7 +5886,7 @@
         },
         {
             "id": "a652e71c-b731-52a1-972a-6f4a3d15e5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6933959a-485f-41a1-a8d9-3bfa416a0faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6933959a-485f-41a1-a8d9-3bfa416a0faa.jpg?1",
             "name": "Ground Seal",
             "text": "When Ground Seal enters the battlefield, draw a card.\nCards in graveyards can't be the targets of spells or abilities.",
             "colours": [
@@ -5918,7 +5918,7 @@
         },
         {
             "id": "131f4662-ee3a-5757-b72e-9149d14e993f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1",
             "name": "Mwonvuli Beast Tracker",
             "text": "When Mwonvuli Beast Tracker enters the battlefield, search your library for a creature card with deathtouch, hexproof, reach, or trample and reveal it. Shuffle your library and put that card on top of it.",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "1c9cf673-2db5-54d3-b52e-5cfe4288428f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2db6f65-5160-4c10-8a24-f8d4f106adcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2db6f65-5160-4c10-8a24-f8d4f106adcd.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -5985,7 +5985,7 @@
         },
         {
             "id": "b4251e1e-d773-5829-b1f0-0d8d1e60238e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d7d96-5a86-45ef-a30b-b11ece22f060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d7d96-5a86-45ef-a30b-b11ece22f060.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "91f4cde8-72bb-57ae-8d8e-722f9069bd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e054ea5-3657-4198-9715-6acc0e362da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e054ea5-3657-4198-9715-6acc0e362da3.jpg?1",
             "name": "Predatory Rampage",
             "text": "Creatures you control get +3/+3 until end of turn. Each creature your opponents control blocks this turn if able.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "18602865-c7d3-53f7-bb2e-447067534aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e074cc1d-8f94-4155-974e-574c1dd82e1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e074cc1d-8f94-4155-974e-574c1dd82e1f.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "a9a3e49b-5d9b-5aaf-b0bf-6fc61aaff778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb77f6a8-a9d6-4fdd-996e-70877199ebab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb77f6a8-a9d6-4fdd-996e-70877199ebab.jpg?1",
             "name": "Primal Huntbeast",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "8ad92b7f-de56-573e-996b-c9c6221cff82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937deb52-8888-4298-9ae5-0361c6fdbba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937deb52-8888-4298-9ae5-0361c6fdbba2.jpg?1",
             "name": "Primordial Hydra",
             "text": "Primordial Hydra enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Primordial Hydra.\nPrimordial Hydra has trample as long as it has ten or more +1/+1 counters on it.",
             "colours": [
@@ -6149,7 +6149,7 @@
         },
         {
             "id": "943f9187-1dab-5f5c-8d47-82896d631be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dba7f54-e49e-4f10-b5c5-46bb20871871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dba7f54-e49e-4f10-b5c5-46bb20871871.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you cast a white, blue, black, or red spell, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "781e925d-3b83-5253-8203-509fd8f6929e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b982558f-5b82-4918-9b54-c7ac1e6f8da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b982558f-5b82-4918-9b54-c7ac1e6f8da5.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "73f4e4b1-727d-5d8c-a591-42246df8db08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26858a53-1054-407a-b2a2-34a7c4ae0f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26858a53-1054-407a-b2a2-34a7c4ae0f10.jpg?1",
             "name": "Ranger's Path",
             "text": "Search your library for up to two Forest cards and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6249,7 +6249,7 @@
         },
         {
             "id": "de1147e8-13d2-5e16-92c0-a478b6770b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9aae03-f29b-4da6-a0cb-edd67bb111f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9aae03-f29b-4da6-a0cb-edd67bb111f5.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "12b3668d-1ac1-5453-9b19-6949cfe6c7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529b2f-03f0-469d-92d4-e2a2a933d5dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529b2f-03f0-469d-92d4-e2a2a933d5dc.jpg?1",
             "name": "Roaring Primadox",
             "text": "At the beginning of your upkeep, return a creature you control to its owner's hand.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "9b9d82ae-f3f0-5476-ab87-5e466e8bd630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f55ff4b-f0e1-498b-982b-e6ec01d30d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f55ff4b-f0e1-498b-982b-e6ec01d30d95.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "b70c1bba-851d-5959-8f45-3192e498c0e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e27503e-059e-4c44-a817-678e67254111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e27503e-059e-4c44-a817-678e67254111.jpg?1",
             "name": "Serpent's Gift",
             "text": "Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "1aed0ab9-64ca-5a61-9a96-0cc34571318c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1bb9-dbfd-4094-bda0-9a19817ce4bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1bb9-dbfd-4094-bda0-9a19817ce4bc.jpg?1",
             "name": "Silklash Spider",
             "text": "Reach (This creature can block creatures with flying.)\n{X}{G}{G}: Silklash Spider deals X damage to each creature with flying.",
             "colours": [
@@ -6415,7 +6415,7 @@
         },
         {
             "id": "421feca8-2b00-589a-be20-b42a576c7713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522777b1-a89f-4969-a962-0137018ec86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522777b1-a89f-4969-a962-0137018ec86c.jpg?1",
             "name": "Spiked Baloth",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "2f73b011-3a64-5ba0-986a-a0c1f7302e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28667c8b-d02c-4e57-a050-1549207b65d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28667c8b-d02c-4e57-a050-1549207b65d1.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, put a 3/3 green Beast creature token onto the battlefield.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "0717fbf0-b455-59ad-b0e0-7dce7dee2288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16928c9-0470-46ec-b92d-0d6ff9f23ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16928c9-0470-46ec-b92d-0d6ff9f23ef7.jpg?1",
             "name": "Timberpack Wolf",
             "text": "Timberpack Wolf gets +1/+1 for each other creature you control named Timberpack Wolf.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "77fbef90-f386-59c6-875d-123f4a97bb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1fb9f8-c070-40c9-89cd-c74eb8dbbf1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1fb9f8-c070-40c9-89cd-c74eb8dbbf1a.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "137e14b7-75c7-5fe5-bdf1-d4c26636cb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fc4a5f-1c59-4139-a506-72baebb1168f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fc4a5f-1c59-4139-a506-72baebb1168f.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "eb2bb4c5-b173-5f3d-899b-96578309e2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acb6dc-a9bd-4f12-9025-623416bdfc32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acb6dc-a9bd-4f12-9025-623416bdfc32.jpg?1",
             "name": "Yeva, Nature's Herald",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nYou may cast green creature cards as though they had flash.",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "512c6ede-df28-5bb1-adb2-ba10a0c1080e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg?1",
             "name": "Yeva's Forcemage",
             "text": "When Yeva's Forcemage enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -6655,7 +6655,7 @@
         },
         {
             "id": "8d3a3400-b08a-58b9-a984-e4433bdad645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b1fea-5c2c-4848-8109-548f56b99d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b1fea-5c2c-4848-8109-548f56b99d49.jpg?1",
             "name": "Nicol Bolas, Planeswalker",
             "text": "+3: Destroy target noncreature permanent.\n-2: Gain control of target creature.\n-9: Nicol Bolas, Planeswalker deals 7 damage to target player. That player discards seven cards, then sacrifices seven permanents.",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "9e8e7e4e-1a30-53da-80dd-a4680a2cf1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d63c3-85a5-4c2d-bdba-6213527b5e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d63c3-85a5-4c2d-bdba-6213527b5e9a.jpg?1",
             "name": "Akroma's Memorial",
             "text": "Creatures you control have flying, first strike, vigilance, trample, haste, and protection from black and from red.",
             "colours": [],
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "0dfe8c80-4df0-5fe0-862a-78a66b9a8709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac35e28-dd0e-4dc8-b8e6-4a1e33706214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac35e28-dd0e-4dc8-b8e6-4a1e33706214.jpg?1",
             "name": "Chronomaton",
             "text": "{1}, {T}: Put a +1/+1 counter on Chronomaton.",
             "colours": [],
@@ -6756,7 +6756,7 @@
         },
         {
             "id": "201dbc48-1666-54e3-ad48-798ef9eca467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b087992-9c30-4434-acb3-a12ee6f207b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b087992-9c30-4434-acb3-a12ee6f207b3.jpg?1",
             "name": "Clock of Omens",
             "text": "Tap two untapped artifacts you control: Untap target artifact.",
             "colours": [],
@@ -6784,7 +6784,7 @@
         },
         {
             "id": "be21fdd4-0800-5fec-bcf8-6d6ac01dff14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57877b1c-e91d-4941-81bd-008dff1272ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57877b1c-e91d-4941-81bd-008dff1272ed.jpg?1",
             "name": "Door to Nothingness",
             "text": "Door to Nothingness enters the battlefield tapped.\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice Door to Nothingness: Target player loses the game.",
             "colours": [],
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "e001b8c2-e945-5cb5-905f-2074dbfa0728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813d6a95-719d-474d-942a-b4c5156af7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813d6a95-719d-474d-942a-b4c5156af7ba.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
             "colours": [],
@@ -6846,7 +6846,7 @@
         },
         {
             "id": "d0034940-0ae4-5e20-a527-2e96cd3e9b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07bc36-2207-48f4-a151-4ccb0c6d851d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07bc36-2207-48f4-a151-4ccb0c6d851d.jpg?1",
             "name": "Gem of Becoming",
             "text": "{3}, {T}, Sacrifice Gem of Becoming: Search your library for an Island card, a Swamp card, and a Mountain card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [],
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "eba13bd0-36ba-5532-9c6e-3a70e353ff04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33704052-aeb1-4798-a64d-778e1879eeb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33704052-aeb1-4798-a64d-778e1879eeb9.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "d4abeaf3-7dc8-5909-b890-ef90f147dde2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0802b908-d4e1-4f58-a085-55782fc08d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0802b908-d4e1-4f58-a085-55782fc08d51.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "9f36f835-5221-5123-80a9-496814c7b49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f95cf4c-1845-4260-8571-91c03d582da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f95cf4c-1845-4260-8571-91c03d582da3.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "d514640d-dcef-513e-91c8-3189560c9c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a761426e-2138-438e-8f3b-024486165260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a761426e-2138-438e-8f3b-024486165260.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "8d5217ed-e242-5707-b05d-f4bfaafd6b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cece8-39ac-48fe-bfbe-494ec76d80ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cece8-39ac-48fe-bfbe-494ec76d80ee.jpg?1",
             "name": "Primal Clay",
             "text": "As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types. (A creature with defender can't attack.)",
             "colours": [],
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "3c134ac4-c2c4-597c-9fc6-96e22b5c07fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c740a8-1bbc-4ec8-a72c-01aee9e48f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c740a8-1bbc-4ec8-a72c-01aee9e48f3d.jpg?1",
             "name": "Ring of Evos Isle",
             "text": "{2}: Equipped creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's blue.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "4b07ee1b-6676-53ab-ab6d-72e7a38ebe5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2082e04f-f972-424e-a724-7a5975215538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2082e04f-f972-424e-a724-7a5975215538.jpg?1",
             "name": "Ring of Kalonia",
             "text": "Equipped creature has trample. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's green.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7083,7 +7083,7 @@
         },
         {
             "id": "f211492a-8e4a-5139-be1b-6dec8d424c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e94f-5b06-4df0-ba87-4499b1ee4dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e94f-5b06-4df0-ba87-4499b1ee4dba.jpg?1",
             "name": "Ring of Thune",
             "text": "Equipped creature has vigilance. (Attacking doesn't cause it to tap.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's white.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "8e97435c-b25d-5db8-9ac0-3fcf0ce3acc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e9fc1-03ff-4ae5-9488-51bf2e627486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e9fc1-03ff-4ae5-9488-51bf2e627486.jpg?1",
             "name": "Ring of Valkas",
             "text": "Equipped creature has haste. (It can attack and {T} no matter when it came under your control.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's red.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7143,7 +7143,7 @@
         },
         {
             "id": "f5a8e998-92f3-50db-82d9-f75fc223f2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e2aa59-63dc-4e28-8cdc-2ca868ff8f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e2aa59-63dc-4e28-8cdc-2ca868ff8f59.jpg?1",
             "name": "Ring of Xathrid",
             "text": "{2}: Regenerate equipped creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's black.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7173,7 +7173,7 @@
         },
         {
             "id": "c6587a62-2ac8-5679-8dd2-5cebbf2ae576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c9d3bf-c858-42f4-bb61-3292f9a7141b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c9d3bf-c858-42f4-bb61-3292f9a7141b.jpg?1",
             "name": "Sands of Delirium",
             "text": "{X}, {T}: Target player puts the top X cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -7201,7 +7201,7 @@
         },
         {
             "id": "f98efe0c-231f-5863-a908-82d15505eb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7381a-ec4a-4f1b-b81c-bdf9f9d64f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7381a-ec4a-4f1b-b81c-bdf9f9d64f31.jpg?1",
             "name": "Staff of Nin",
             "text": "At the beginning of your upkeep, draw a card.\n{T}: Staff of Nin deals 1 damage to target creature or player.",
             "colours": [],
@@ -7229,7 +7229,7 @@
         },
         {
             "id": "cb734ab6-76c0-534a-ad09-b29f3aa4754b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23038e62-9c7b-4e2a-8661-035966b6ed4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23038e62-9c7b-4e2a-8661-035966b6ed4a.jpg?1",
             "name": "Stuffy Doll",
             "text": "As Stuffy Doll enters the battlefield, choose a player.\nStuffy Doll is indestructible.\nWhenever Stuffy Doll is dealt damage, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -7260,7 +7260,7 @@
         },
         {
             "id": "1d0fbd0e-0348-5113-a1f4-0572e25572ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdfb60b-948b-40fb-b18e-08f0300624b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdfb60b-948b-40fb-b18e-08f0300624b3.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "71051836-c7f6-55ee-aaaf-ff20f0100058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20604b28-d096-40f8-a30c-3bc89e708676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20604b28-d096-40f8-a30c-3bc89e708676.jpg?1",
             "name": "Trading Post",
             "text": "{1}, {T}, Discard a card: You gain 4 life.\n{1}, {T}, Pay 1 life: Put a 0/1 white Goat creature token onto the battlefield.\n{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.\n{1}, {T}, Sacrifice an artifact: Draw a card.",
             "colours": [],
@@ -7316,7 +7316,7 @@
         },
         {
             "id": "c479c178-bc6e-503d-97f9-d8e5bf8cd46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd222c07-0b28-41cb-9237-ad7991ab078f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd222c07-0b28-41cb-9237-ad7991ab078f.jpg?1",
             "name": "Cathedral of War",
             "text": "Cathedral of War enters the battlefield tapped.\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "ba6127ca-7758-5692-b84a-6ba80395b88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e49c561-570c-43dd-a369-48bc7ad7edac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e49c561-570c-43dd-a369-48bc7ad7edac.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "aeb53bdc-a5fd-5adc-b850-9fc54a0d025f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b41b86b-58e1-4601-b8ed-0ad31f03a78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b41b86b-58e1-4601-b8ed-0ad31f03a78d.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7406,7 +7406,7 @@
         },
         {
             "id": "132d60ff-6620-5cd5-a861-d57d72ef5ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d107e1-8293-4486-9b68-4897b8b7043c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d107e1-8293-4486-9b68-4897b8b7043c.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7434,7 +7434,7 @@
         },
         {
             "id": "1162dec2-ca9c-5a34-88bb-40f10ab60c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9d29ee-1a21-4c3e-99c1-f815d40e8f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9d29ee-1a21-4c3e-99c1-f815d40e8f19.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7465,7 +7465,7 @@
         },
         {
             "id": "88ed46de-2628-5b7f-a5e7-8bc1b752891d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8274ef-a46a-4f5f-8ad1-6ce828f24210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8274ef-a46a-4f5f-8ad1-6ce828f24210.jpg?1",
             "name": "Hellion Crucible",
             "text": "{T}: Add {1} to your mana pool.\n{1}{R}, {T}: Put a pressure counter on Hellion Crucible.\n{1}{R}, {T}, Remove two pressure counters from Hellion Crucible and sacrifice it: Put a 4/4 red Hellion creature token with haste onto the battlefield. (It can attack and {T} as soon as it comes under your control.)",
             "colours": [],
@@ -7495,7 +7495,7 @@
         },
         {
             "id": "5654c84a-340d-5fac-a709-0c0406bacf2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92583e4-9749-4c11-9d32-fb81260c5b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92583e4-9749-4c11-9d32-fb81260c5b63.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "ce1b6174-7b7c-5374-bac0-704f2cc15f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76364643-bfcb-4c50-9224-bf9e35648ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76364643-bfcb-4c50-9224-bf9e35648ddf.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7554,7 +7554,7 @@
         },
         {
             "id": "5a35527e-b69d-517d-b6cb-8d95a7460ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15663129-9deb-4c34-84a0-f94cf1a723f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15663129-9deb-4c34-84a0-f94cf1a723f0.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "b5999522-3387-5199-9519-a225c72ecee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a001b-7815-469b-bd0c-c92453d80e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a001b-7815-469b-bd0c-c92453d80e9a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "219a350d-fa58-58b0-b887-88dff368328a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f8fa19-a872-4542-bf24-8bba9f0a64a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f8fa19-a872-4542-bf24-8bba9f0a64a1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7661,7 +7661,7 @@
         },
         {
             "id": "1fda811c-7837-561d-a58a-a67217247813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e094ea-3dee-47a6-997e-842113774973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e094ea-3dee-47a6-997e-842113774973.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7699,7 +7699,7 @@
         },
         {
             "id": "35d8b1c3-b33f-5538-ac33-bab020158536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80e0478-8c53-4406-acc0-b7662c9c382d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80e0478-8c53-4406-acc0-b7662c9c382d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7737,7 +7737,7 @@
         },
         {
             "id": "858edcf2-9bd3-5e58-8e85-16e571d0a1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd86b167-3fc8-4e5a-9e21-b4ce5a7a05cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd86b167-3fc8-4e5a-9e21-b4ce5a7a05cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7775,7 +7775,7 @@
         },
         {
             "id": "2858952a-8c2f-5ddb-ab3e-745acea5f066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad64d3a-1868-4404-8692-d3c54071140d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad64d3a-1868-4404-8692-d3c54071140d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "af61b110-56fc-5db6-adff-67d47eea630f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e3d45d-8c6e-430a-82d3-86f66286735d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e3d45d-8c6e-430a-82d3-86f66286735d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "0148e313-3b35-5def-99fd-9be854fb884b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956fd08b-d403-4565-84b3-e3ca0132ea89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956fd08b-d403-4565-84b3-e3ca0132ea89.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7889,7 +7889,7 @@
         },
         {
             "id": "52fa0f8a-e488-585c-86e0-8b341f6deb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b16e93-ee53-4c1b-9dea-6db7977e9c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b16e93-ee53-4c1b-9dea-6db7977e9c2f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "38b391e1-289e-5402-8892-7be81aac5683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7827d75-eb0e-4ebf-876e-7a2f9e373fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7827d75-eb0e-4ebf-876e-7a2f9e373fb3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7965,7 +7965,7 @@
         },
         {
             "id": "2542f237-548a-536f-b372-80cf8e49c8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9364178a-1963-4665-b8c1-a5096ece07e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9364178a-1963-4665-b8c1-a5096ece07e2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "31f7cb3a-0909-515a-8b54-473192ea2caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4ddbe5-1be4-47ee-b07a-74c8bec4d752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4ddbe5-1be4-47ee-b07a-74c8bec4d752.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "2d96fcea-ab9e-5be5-858a-6cec3597b279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67cf0c1-5658-4f88-9fbd-63c1dbf77ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67cf0c1-5658-4f88-9fbd-63c1dbf77ee0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8079,7 +8079,7 @@
         },
         {
             "id": "ae904c9e-957b-5efa-be8d-0ce4a2a9f2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a3144f-9b4f-4d1a-b384-6228c99b38b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a3144f-9b4f-4d1a-b384-6228c99b38b7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "bc6113e8-bc75-5215-b380-6a3984d1b1b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17990059-8368-45f8-8325-c82fc181450a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17990059-8368-45f8-8325-c82fc181450a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8155,7 +8155,7 @@
         },
         {
             "id": "816c9f6b-0ea1-5cc5-b004-ecc770dad026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cefc72a-83ba-42e4-a036-a9f45363c8cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cefc72a-83ba-42e4-a036-a9f45363c8cf.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8193,7 +8193,7 @@
         },
         {
             "id": "114750bd-3a31-57e2-bb33-163eae83d230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a55233-2e1a-4515-8fd1-354605c0c36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a55233-2e1a-4515-8fd1-354605c0c36b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8231,7 +8231,7 @@
         },
         {
             "id": "16249867-92d9-5473-b213-8237cdcae416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdf7380-56cb-4d34-ad05-43029341a57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdf7380-56cb-4d34-ad05-43029341a57a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "ae2a9bbc-ca04-52b7-bf7d-a9f0e724ecb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65aa4dcf-6e3a-4381-b5f6-5056d741ff67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65aa4dcf-6e3a-4381-b5f6-5056d741ff67.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8307,7 +8307,7 @@
         },
         {
             "id": "34f57d78-b9e2-5ed7-b7d1-7b0128940010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa35174e-c0c8-4643-bc32-9a7b7c7e7d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa35174e-c0c8-4643-bc32-9a7b7c7e7d00.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "d8d21108-a7c6-506a-bac1-98543a8ae18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97868f6-a9ce-4ce9-bc3f-b535f3202602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97868f6-a9ce-4ce9-bc3f-b535f3202602.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "25db1f75-e203-596e-a69c-79288fe596db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0f1de9-464c-4f12-bd1d-a4a5b88fe803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0f1de9-464c-4f12-bd1d-a4a5b88fe803.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -8413,7 +8413,7 @@
         },
         {
             "id": "9224d123-1274-5a2a-9b46-cbee8cbc4e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272c08-c5f2-413f-87ea-b135aca2d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272c08-c5f2-413f-87ea-b135aca2d9c5.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "67f59d92-2f7e-51ea-9fb9-298bdca35cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93679bb9-ee1c-4eea-bcdd-72785d5788af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93679bb9-ee1c-4eea-bcdd-72785d5788af.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -8481,7 +8481,7 @@
         },
         {
             "id": "5eb47612-36a1-5b9b-8f96-0666df0980e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1966d7e6-cd4a-47ff-bc3e-f8e0db8a3439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1966d7e6-cd4a-47ff-bc3e-f8e0db8a3439.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8515,7 +8515,7 @@
         },
         {
             "id": "a8d5380a-d799-5464-ae84-8cce56f4b336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e67efea-8a80-42ec-8e77-07d387d933d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e67efea-8a80-42ec-8e77-07d387d933d4.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8549,7 +8549,7 @@
         },
         {
             "id": "43952e52-6db2-531e-a791-00658bf1ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43b811-ec0f-4ad7-a152-f7f077bafaa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43b811-ec0f-4ad7-a152-f7f077bafaa4.jpg?1",
             "name": "Hellion",
             "text": "",
             "colours": [
@@ -8583,7 +8583,7 @@
         },
         {
             "id": "95cacb3b-7dc9-5f09-8c65-ad527476113d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94010f1-cd4b-4f65-8a0e-2df6eec058ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94010f1-cd4b-4f65-8a0e-2df6eec058ec.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8617,7 +8617,7 @@
         },
         {
             "id": "c01d7c89-e275-5ac5-84ca-bd5de2278f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd67de8a-3879-4d03-a716-6e907d597b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd67de8a-3879-4d03-a716-6e907d597b25.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "162c4cad-9cdf-5945-a81e-b2f988e36afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d87f38-c342-4186-8768-c3f1aceb680a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d87f38-c342-4186-8768-c3f1aceb680a.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8685,7 +8685,7 @@
         },
         {
             "id": "9cc21c43-7881-50f6-953f-bc567351c8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd1b0b9-f1bb-4808-be3f-5b3faf185cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd1b0b9-f1bb-4808-be3f-5b3faf185cf1.jpg?1",
             "name": "Liliana of the Dark Realms Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M14.json
+++ b/Assets/Resources/Sets/M14.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "79b0e970-207d-56b9-8fe3-aeb2c486444a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e44e04-8330-49ca-906c-bb9bf0bc84ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e44e04-8330-49ca-906c-bb9bf0bc84ce.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.-3: Target creature gains flying and double strike until end of turn.-8: Put X 2/2 white Cat creature tokens onto the battlefield, where X is your life total.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "8363e365-c16e-5f64-9d23-412bd6d54488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583bfbc1-638b-4de5-b865-0b00a69dd073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583bfbc1-638b-4de5-b865-0b00a69dd073.jpg?1",
             "name": "Ajani's Chosen",
             "text": "Whenever an enchantment enters the battlefield under your control, put a 2/2 white Cat creature token onto the battlefield. If that enchantment is an Aura, you may attach it to the token.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "0f9d7968-6ff2-5b12-944e-9f91a40c31ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f26bc2-53d7-4448-8021-de35aa82fcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f26bc2-53d7-4448-8021-de35aa82fcc6.jpg?1",
             "name": "Angelic Accord",
             "text": "At the beginning of each end step, if you gained 4 or more life this turn, put a 4/4 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "369d23c0-6d3d-59de-89d2-05e1b04a43c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f88e-8a51-494b-a008-fbfe624f97f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f88e-8a51-494b-a008-fbfe624f97f7.jpg?1",
             "name": "Angelic Wall",
             "text": "Defender (This creature can't attack.)\nFlying",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "07b21ac6-fefe-50c6-a22a-3560bd22f545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531cba81-afd7-4be4-adec-87edb77ba2a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531cba81-afd7-4be4-adec-87edb77ba2a9.jpg?1",
             "name": "Archangel of Thune",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhenever you gain life, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "63d3dd7d-5076-545a-8d15-ef366f0367ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dc4ab-1c45-4495-91b6-27d62087380c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dc4ab-1c45-4495-91b6-27d62087380c.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "59626b40-2528-537e-8c03-bb30bf9773f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823bf8-2fca-49e1-ba40-9b61c9ae55b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823bf8-2fca-49e1-ba40-9b61c9ae55b3.jpg?1",
             "name": "Banisher Priest",
             "text": "When Banisher Priest enters the battlefield, exile target creature an opponent controls until Banisher Priest leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "3b567d6c-60e1-50de-abff-1868df1e96f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4273cf50-db65-4b1f-95e1-f24ba6582c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4273cf50-db65-4b1f-95e1-f24ba6582c8b.jpg?1",
             "name": "Blessing",
             "text": "Enchant creature{W}: Enchanted creature gets +1/+1 until end of turn.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "40aade37-70df-5cae-84cb-4492c1e252ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bb68b-1830-470a-8cea-91edc7db0c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bb68b-1830-470a-8cea-91edc7db0c57.jpg?1",
             "name": "Bonescythe Sliver",
             "text": "Sliver creatures you control have double strike. (They deal both first-strike and regular combat damage.)",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "cdfa87d6-8d34-572f-9652-7193555ece3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7838-ae58-4306-ba0f-e914601b31b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7838-ae58-4306-ba0f-e914601b31b6.jpg?1",
             "name": "Brave the Elements",
             "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn. (They can't be blocked, targeted, dealt damage, or enchanted by anything of that color.)",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "060b9f07-8a7a-593e-a829-ee36c39fed78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78802af4-46b5-4bac-8cdf-5b77d0b19895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78802af4-46b5-4bac-8cdf-5b77d0b19895.jpg?1",
             "name": "Capashen Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.){1}{W}: Capashen Knight gets +1/+0 until end of turn.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "723d05d9-a927-56a7-8cf6-b98c9cc91c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8d1320-0f1a-4c66-86c9-9f8da0f1d9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8d1320-0f1a-4c66-86c9-9f8da0f1d9ef.jpg?1",
             "name": "Celestial Flare",
             "text": "Target player sacrifices an attacking or blocking creature.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "64fe23b2-3d41-54aa-8b14-2b897820fc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg?1",
             "name": "Charging Griffin",
             "text": "Flying\nWhenever Charging Griffin attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "d60deda4-f12c-5154-a5da-de71bd079c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792574a-4d8f-4c80-a958-7c0edbe391fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792574a-4d8f-4c80-a958-7c0edbe391fc.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "beab512f-a9d1-5284-88b5-30420176637b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5fb3-bb41-4efa-9721-2c2d169b05cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5fb3-bb41-4efa-9721-2c2d169b05cd.jpg?1",
             "name": "Dawnstrike Paladin",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "57255fbc-f882-54e2-b7c9-08c5a8c8bc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a286954-fb40-4440-9f0e-a28367c6823c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a286954-fb40-4440-9f0e-a28367c6823c.jpg?1",
             "name": "Devout Invocation",
             "text": "Tap any number of untapped creatures you control. Put a 4/4 white Angel creature token with flying onto the battlefield for each creature tapped this way.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "43fd21a5-e611-5fe7-bf25-fc78f7300217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c19a11-ff0f-4dbd-b872-30276b8ecf22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c19a11-ff0f-4dbd-b872-30276b8ecf22.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "3348d475-d115-5642-9e86-b1c8f360151e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfb0f4a-e273-4ffb-91cd-dd1a7b6f6a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfb0f4a-e273-4ffb-91cd-dd1a7b6f6a8f.jpg?1",
             "name": "Fiendslayer Paladin",
             "text": "First strike (This creature deals combat damage before creatures without first strike.) Lifelink (Damage dealt by this creature also causes you to gain that much life.)Fiendslayer Paladin can't be the target of black or red spells your opponents control.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "112d93dc-1321-50c0-8a4b-b313778fee82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eff4028-d4f9-4822-81d6-9f5e5e6f3011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eff4028-d4f9-4822-81d6-9f5e5e6f3011.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014 Creatures you control get +2/+0 until end of turn; or creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "21d3b92c-6f6c-56a2-bc5b-9659b22f0d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6626-a85f-4116-9721-19e39b83cba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6626-a85f-4116-9721-19e39b83cba0.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "dae06817-41b1-5ce9-a87c-5f02ca011da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4399e19-d05d-4bb3-9aff-c4133ddd2850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4399e19-d05d-4bb3-9aff-c4133ddd2850.jpg?1",
             "name": "Hive Stirrings",
             "text": "Put two 1/1 colorless Sliver creature tokens onto the battlefield.",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "0e06672d-5b27-5265-91dd-a3d8b255c4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f672328-3361-498e-a9f4-2d8e69a8b072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f672328-3361-498e-a9f4-2d8e69a8b072.jpg?1",
             "name": "Imposing Sovereign",
             "text": "Creatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "b5ca86cf-56df-56d5-928d-f5f37a72a667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086a062-d39b-4e2a-bde0-f4d6d1797a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086a062-d39b-4e2a-bde0-f4d6d1797a5f.jpg?1",
             "name": "Indestructibility",
             "text": "Enchant permanent\nEnchanted permanent has indestructible. (Effects that say \"destroy\" don't destroy that permanent. A creature with indestructible can't be destroyed by damage.)",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "c9423178-0be4-5944-8532-53bf9d8d580e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bec89b3-640e-4093-a6e9-5639610769b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bec89b3-640e-4093-a6e9-5639610769b9.jpg?1",
             "name": "Master of Diversion",
             "text": "Whenever Master of Diversion attacks, tap target creature defending player controls.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "cfff65e2-c752-59e1-8aa3-2b0bebc6e82e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c7ff88-c23e-4be6-989b-99d055db36df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c7ff88-c23e-4be6-989b-99d055db36df.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "85a9eb97-87b8-5197-b9cb-913db37dacf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5222e200-df1b-46c6-a194-c341e8c1d516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5222e200-df1b-46c6-a194-c341e8c1d516.jpg?1",
             "name": "Path of Bravery",
             "text": "As long your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "12303685-25f8-566d-a2d3-fb913bcd2cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb836f0-527d-445b-877e-7158a4579c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb836f0-527d-445b-877e-7158a4579c33.jpg?1",
             "name": "Pay No Heed",
             "text": "Prevent all damage a source of your choice would deal this turn.",
             "colours": [
@@ -914,7 +914,7 @@
         },
         {
             "id": "ee9b56bb-ef0d-57e6-aa42-c15df0193af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d3bba-18b0-4c56-a90b-8e28935a6a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d3bba-18b0-4c56-a90b-8e28935a6a7a.jpg?1",
             "name": "Pillarfield Ox",
             "text": "",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "04e4d2f2-c1e8-522c-b59f-92b13d7d932f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99873316-4872-4500-a225-cf483e1ebaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99873316-4872-4500-a225-cf483e1ebaa9.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "83b53117-b0fd-58ff-9643-eee69d156b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c28560-e6ac-4be9-a253-22c4613b0d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c28560-e6ac-4be9-a253-22c4613b0d90.jpg?1",
             "name": "Sentinel Sliver",
             "text": "Sliver creatures you control have vigilance. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "366df186-4f4a-5e3a-bac5-8913e878199c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9789cac-5774-4f72-82c3-18f11f9d4a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9789cac-5774-4f72-82c3-18f11f9d4a62.jpg?1",
             "name": "Seraph of the Sword",
             "text": "Flying\nPrevent all combat damage that would be dealt to Seraph of the Sword.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "8a7dec6f-0a44-57f9-a4e8-b96f09922e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475f2a7b-9bd5-4ad7-868a-7652d06f3f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475f2a7b-9bd5-4ad7-868a-7652d06f3f6c.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "02a8804e-3794-5143-bfa6-19a9886d9f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07932c2-7b97-4abe-be2b-02fc04de780f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07932c2-7b97-4abe-be2b-02fc04de780f.jpg?1",
             "name": "Show of Valor",
             "text": "Target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "1a104f30-0abd-53dd-a645-d5274c8a7a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e7a30f-bb29-4c6b-bf70-53e9e4292814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e7a30f-bb29-4c6b-bf70-53e9e4292814.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "a609898a-5720-51f5-8f25-c253d3557e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b13b1-31f0-4676-88a7-53f3a190e9a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b13b1-31f0-4676-88a7-53f3a190e9a2.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn. (Spells cast before this resolves are unaffected.)",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "f66ebfa9-51e5-5e50-abdd-6da62226379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca09fed-f9b3-49ee-be89-404581a4cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca09fed-f9b3-49ee-be89-404581a4cbd2.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1212,7 +1212,7 @@
         },
         {
             "id": "c3334be4-b4f0-5dea-bacf-3704510689ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f45133-6134-4664-9952-67c03d60f9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f45133-6134-4664-9952-67c03d60f9a0.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "41d030f4-3a85-5d7d-a294-a25e7f947cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15d6329-ffb1-43fd-8558-60c8315f5b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15d6329-ffb1-43fd-8558-60c8315f5b91.jpg?1",
             "name": "Steelform Sliver",
             "text": "Sliver creatures you control get +0/+1.",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "5589e2e3-a97c-54b7-9c6e-5a5d6b72e816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6ec61b-c039-4526-a359-a7947eeba5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6ec61b-c039-4526-a359-a7947eeba5c3.jpg?1",
             "name": "Stonehorn Chanter",
             "text": "{5}{W}: Stonehorn Chanter gains vigilance and lifelink until end of turn. (Attacking doesn't cause it to tap. Damage dealt by it also causes you to gain that much life.)",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "f21c0b06-7f95-5f64-89a5-87908249afdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1f83c-a9ef-463e-97b5-2ca3b7232f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1f83c-a9ef-463e-97b5-2ca3b7232f82.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "233a32f4-78d4-5aba-b62a-da94c9ed80a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c733fef-8372-4a40-b340-7aa32922799e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c733fef-8372-4a40-b340-7aa32922799e.jpg?1",
             "name": "Wall of Swords",
             "text": "Defender (This creature can't attack)\nFlying",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "348b4bd3-d29f-5632-869d-58806645376f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc279d-952a-4b8d-b6ff-37166daa2dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc279d-952a-4b8d-b6ff-37166daa2dd5.jpg?1",
             "name": "Air Servant",
             "text": "Flying{2}{U}: Tap target creature with flying.",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "02b9e725-0b0b-55de-9b78-e221a85bf5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d0ae8f-3d46-4692-a23c-c461f8aa6a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d0ae8f-3d46-4692-a23c-c461f8aa6a58.jpg?1",
             "name": "Archaeomancer",
             "text": "When Archaeomancer enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "3f3780ef-e321-56a9-92a9-824c76567880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b455b0f-a69c-43b4-bbf5-605ed41f10e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b455b0f-a69c-43b4-bbf5-605ed41f10e0.jpg?1",
             "name": "Armored Cancrix",
             "text": "",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "81f4f75d-e355-5307-808a-7b51b90cf33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954eec32-7e40-452d-94c2-f704b819f338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954eec32-7e40-452d-94c2-f704b819f338.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "9c1e75d7-a475-5e45-b94d-77c54ee12d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca9c638-f923-4e85-bd3c-c95854b4f0fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca9c638-f923-4e85-bd3c-c95854b4f0fb.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "e079250b-7447-500d-a95f-68dc387bae18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e648262-3b9b-4c58-8e29-48356e3cb064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e648262-3b9b-4c58-8e29-48356e3cb064.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "bb181d19-884a-5933-9126-9f32b6802a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f7caca-14ee-4d6a-97c3-e19898f86635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f7caca-14ee-4d6a-97c3-e19898f86635.jpg?1",
             "name": "Colossal Whale",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Colossal Whale attacks, you may exile target creature defending player controls until Colossal Whale leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "d855f7e4-0fbd-5f37-9e00-913fc8a1058c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ef366b-26f5-473a-ab96-e668ed54d691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ef366b-26f5-473a-ab96-e668ed54d691.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "e133ed37-16b0-5d6b-9c75-a249ff340fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cd7fe-639c-45a5-97af-9529904e3975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cd7fe-639c-45a5-97af-9529904e3975.jpg?1",
             "name": "Dismiss into Dream",
             "text": "Each creature your opponents control is an Illusion in addition to its other types and has \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "d209721e-df84-50b6-8ca4-4ccbc71e114d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b415d2-53fe-4540-aea6-9cd2c498134c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b415d2-53fe-4540-aea6-9cd2c498134c.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "e54edfc7-3f53-5722-8437-64819f60a0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdc821e-0e4b-43ff-86d6-134ac0b4e958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdc821e-0e4b-43ff-86d6-134ac0b4e958.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "86fa56eb-dd1a-518e-bceb-0f4b89e35dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0b7e3-fe3f-4710-9b92-9ffdb242e92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0b7e3-fe3f-4710-9b92-9ffdb242e92e.jpg?1",
             "name": "Domestication",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your end step, if enchanted creature's power is 4 or greater, sacrifice Domestication.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "96e51654-6928-5a53-a7ff-f49934b8392d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b225fe-c07d-4d8a-bf2b-c1777bd29061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b225fe-c07d-4d8a-bf2b-c1777bd29061.jpg?1",
             "name": "Elite Arcanist",
             "text": "When Elite Arcanist enters the battlefield, you may exile an instant card from your hand.{X}, {T}: Copy the exiled card. You may cast the copy without paying its mana cost. X is the converted mana cost of the exiled card.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "6b33b471-b1d0-5cb5-a887-994fd2aa6d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bd28e3-1612-41b3-88a0-bb5c1ee60ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bd28e3-1612-41b3-88a0-bb5c1ee60ace.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "39296abc-ee62-5334-81d1-41fff454eb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3f777-7660-48ae-8c32-6777ec8427d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3f777-7660-48ae-8c32-6777ec8427d4.jpg?1",
             "name": "Frost Breath",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "cc416055-897c-511c-85c6-25e6c2a97d89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425f5d1b-9989-4fd1-88e2-6c3108aefa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425f5d1b-9989-4fd1-88e2-6c3108aefa0b.jpg?1",
             "name": "Galerider Sliver",
             "text": "Sliver creatures you control have flying.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "1e17747b-d014-5474-9823-c823806db2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d875e9-713d-4ddb-ae0a-db8483366319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d875e9-713d-4ddb-ae0a-db8483366319.jpg?1",
             "name": "Glimpse the Future",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "612a42b6-6388-581d-aad5-7c8cc1a1f5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09346ff-6e63-499b-9265-c15a7b2cdece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09346ff-6e63-499b-9265-c15a7b2cdece.jpg?1",
             "name": "Illusionary Armor",
             "text": "Enchant creature\nEnchanted creature gets +4/+4.\nWhen enchanted creature becomes the target of a spell or ability, sacrifice Illusionary Armor.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "336b4308-eb3e-5700-a1c0-e5e14e33801b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2801a4ad-5d44-4414-af62-458c7f90dad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2801a4ad-5d44-4414-af62-458c7f90dad6.jpg?1",
             "name": "Jace, Memory Adept",
             "text": "+1: Draw a card. Target player puts the top card of his or her library into his or her graveyard.0: Target player puts the top ten cards of his or her library into his or her graveyard.-7: Any number of target players each draw twenty cards.",
             "colours": [
@@ -2020,7 +2020,7 @@
         },
         {
             "id": "9ac48b02-94cd-587a-983a-9b6fece797c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67852a6-ae75-44e7-9e2d-d458c7b9d869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67852a6-ae75-44e7-9e2d-d458c7b9d869.jpg?1",
             "name": "Jace's Mindseeker",
             "text": "Flying\nWhen Jace's Mindseeker enters the battlefield, target opponent puts the top five cards of his or her library into his or her graveyard. You may cast an instant or sorcery card from among them without paying its mana cost.",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "df89f70b-4d5f-55eb-a967-cf23f98b29f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c89aa2-3375-4681-ad26-b5d5c7d3d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c89aa2-3375-4681-ad26-b5d5c7d3d842.jpg?1",
             "name": "Merfolk Spy",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Merfolk Spy deals combat damage to a player, that player reveals a card at random from his or her hand.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "1cf0f2a3-86d2-55b7-9824-7f83b2d0796b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd3172-0b45-4dc8-adc6-9e0ba112e664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd3172-0b45-4dc8-adc6-9e0ba112e664.jpg?1",
             "name": "Messenger Drake",
             "text": "Flying\nWhen Messenger Drake dies, draw a card.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "a8652317-cc3e-529c-81fb-f0b9cd70092c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6276afe2-1bd9-456e-82d5-389909ae5ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6276afe2-1bd9-456e-82d5-389909ae5ab0.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "c340fe15-4210-506b-b8a0-198cacf3a7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39714ec8-b43c-4d61-9e53-46ac62da2c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39714ec8-b43c-4d61-9e53-46ac62da2c9f.jpg?1",
             "name": "Nephalia Seakite",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -2190,7 +2190,7 @@
         },
         {
             "id": "ac6b17d8-2ac9-51f2-830c-0838a2899014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b242f3-9398-4d65-a2c7-4de56ee58933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b242f3-9398-4d65-a2c7-4de56ee58933.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "44fe079e-7976-594c-ab9f-434caa1e7a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12a1a64-5b32-4b85-8fae-c407d7926547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12a1a64-5b32-4b85-8fae-c407d7926547.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior can't be blocked.",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "b9feebf4-6770-5bdc-b400-383a7839e519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bef3d-c785-4b25-9b91-8f676aa9906f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bef3d-c785-4b25-9b91-8f676aa9906f.jpg?1",
             "name": "Quicken",
             "text": "The next sorcery card you cast this turn can be cast as though it had flash. (It can be cast any time you could cast an instant.)\nDraw a card.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "b6bc1425-3f72-5419-b4a9-4bdb5398c248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd793eb0-0ddb-4b49-88c6-b3565574b92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd793eb0-0ddb-4b49-88c6-b3565574b92f.jpg?1",
             "name": "Scroll Thief",
             "text": "Whenever Scroll Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "692f4b20-0ef5-5514-af15-cf2d7c07e526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5333de10-a6d4-47ff-ab57-4edb49535739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5333de10-a6d4-47ff-ab57-4edb49535739.jpg?1",
             "name": "Seacoast Drake",
             "text": "Flying",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "c85ed2cc-e348-590b-9d71-b237f84441e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7050735c-b232-47a6-a342-01795bfd0d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7050735c-b232-47a6-a342-01795bfd0d46.jpg?1",
             "name": "Sensory Deprivation",
             "text": "Enchant creature\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "0988a9c9-f778-5ba9-a238-45b5c716606d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d7af6a-bfd1-4e89-965a-68336507a9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d7af6a-bfd1-4e89-965a-68336507a9ee.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "40a17b80-957b-5216-8235-3a9f5a9bbd1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e032d1dd-6efc-4f6c-ad3b-30fe74845edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e032d1dd-6efc-4f6c-ad3b-30fe74845edf.jpg?1",
             "name": "Tidebinder Mage",
             "text": "When Tidebinder Mage enters the battlefield, tap target red or green creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Tidebinder Mage.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "6e6f53ff-4c92-5530-96c2-c9504ed4e49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0c48f6-8b2e-4eff-aa1e-10e6ccae426a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0c48f6-8b2e-4eff-aa1e-10e6ccae426a.jpg?1",
             "name": "Time Ebb",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "a1955781-e999-5583-9a4a-409a48fdb7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed4cfec-5cea-4987-890e-825b2802e9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed4cfec-5cea-4987-890e-825b2802e9f9.jpg?1",
             "name": "Tome Scour",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "c5dbb37b-6430-55d5-aa6d-fc1328342d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eaa5a-3f9d-4166-b418-fd82fff86c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eaa5a-3f9d-4166-b418-fd82fff86c73.jpg?1",
             "name": "Trained Condor",
             "text": "Flying\nWhenever Trained Condor attacks, another target creature you control gains flying until end of turn.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "caec1bba-e63a-585b-bafb-f2820194d092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8784dd-83f9-41f8-aedc-f0f81073ffcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8784dd-83f9-41f8-aedc-f0f81073ffcb.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "c2687d2d-b498-52c4-962e-3cc9e385af6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4000b46-7843-4c07-8332-a10f207e2cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4000b46-7843-4c07-8332-a10f207e2cdc.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "6df9af5c-7ed2-5a1d-a1a8-97cfcc4222b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316d281-21a4-460d-9062-f0737249484e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316d281-21a4-460d-9062-f0737249484e.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "d84c0fdf-676e-5d3f-b1d1-9a715c2e5276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7562e-3e25-447d-b9f4-eb96960511b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7562e-3e25-447d-b9f4-eb96960511b8.jpg?1",
             "name": "Water Servant",
             "text": "{U}: Water Servant gets +1/-1 until end of turn.{U}: Water Servant gets -1/+1 until end of turn.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "24b8a566-d4bf-55e3-a50b-7e7e30c6d99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f566741d-a847-4f24-b6fc-7873f0797d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f566741d-a847-4f24-b6fc-7873f0797d59.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "1c38487c-efcf-527a-8bfb-0f8fd52774d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ea2808-0dde-4065-ae7d-905aae98703f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ea2808-0dde-4065-ae7d-905aae98703f.jpg?1",
             "name": "Zephyr Charge",
             "text": "{1}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "edf69359-e3df-506c-b37d-72fce1fd1531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08313b-14c9-4e0b-aad7-05cbd90b1ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08313b-14c9-4e0b-aad7-05cbd90b1ed8.jpg?1",
             "name": "Accursed Spirit",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "8fcd1837-56a2-58d6-a87c-a2611276f060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3053af2-715c-4549-9003-bf4279029a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3053af2-715c-4549-9003-bf4279029a95.jpg?1",
             "name": "Altar's Reap",
             "text": "As an additional cost to cast Altar's Reap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "e2bf8ab7-42a6-512f-945f-0a33d2a3ef94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd9a1-da2e-44ef-9f2e-352dc9f92c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd9a1-da2e-44ef-9f2e-352dc9f92c50.jpg?1",
             "name": "Artificer's Hex",
             "text": "Enchant Equipment\nAt the beginning of your upkeep, if enchanted Equipment is attached to a creature, destroy that creature.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "36d7256f-e51b-503f-b2d1-b991f1863e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61752b13-255a-44d0-9fb0-5ed5680b954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61752b13-255a-44d0-9fb0-5ed5680b954e.jpg?1",
             "name": "Blightcaster",
             "text": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "e1580707-2ee7-58cd-b269-57f167d3910f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fcbbd1-ee51-42a3-ad11-2fd41728c35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fcbbd1-ee51-42a3-ad11-2fd41728c35d.jpg?1",
             "name": "Blood Bairn",
             "text": "Sacrifice another creature: Blood Bairn gets +2/+2 until end of turn.",
             "colours": [
@@ -2927,7 +2927,7 @@
         },
         {
             "id": "07b0050a-2237-50c9-aa15-f07c2ce957d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7559cf3e-7fad-4bcf-8551-045f9150e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7559cf3e-7fad-4bcf-8551-045f9150e014.jpg?1",
             "name": "Bogbrew Witch",
             "text": "{2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "4d2f4fed-2618-5078-9a04-a638b5d7e896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b5476-5f5f-46b5-b627-398e9fcd04aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b5476-5f5f-46b5-b627-398e9fcd04aa.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "cd20da7b-b0e9-55d4-8b09-9dd4000d1292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6adc5e-9221-4a18-8d41-4675797e5d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6adc5e-9221-4a18-8d41-4675797e5d46.jpg?1",
             "name": "Corpse Hauler",
             "text": "{2}{B}, Sacrifice Corpse Hauler: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "800963d7-35d4-5696-9a26-55b552f6b56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a85ae1-7880-4612-9878-c22225bfdce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a85ae1-7880-4612-9878-c22225bfdce1.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of Swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "58d0844e-aa1b-5ba2-b5a8-5724ec20d0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1591ae-07aa-4013-bc6d-4cafd09927f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1591ae-07aa-4013-bc6d-4cafd09927f0.jpg?1",
             "name": "Dark Favor",
             "text": "Enchant creature\nWhen Dark Favor enters the battlefield, you lose 1 life.\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "47ac7946-9504-573b-a6fe-a647b0993819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf82c3b-7a35-43dd-8bf3-ebc68dc1b8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf82c3b-7a35-43dd-8bf3-ebc68dc1b8fc.jpg?1",
             "name": "Dark Prophecy",
             "text": "Whenever a creature you control dies, you draw a card and lose 1 life.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "4bff7df1-f3b0-5465-afcd-939ecf21314c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17b58c-9738-4cdb-a408-e1595c384b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17b58c-9738-4cdb-a408-e1595c384b92.jpg?1",
             "name": "Deathgaze Cockatrice",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "3f3f8d24-bafc-5e89-b5b5-52e4a1173cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7c8b-f29f-4574-96c0-daac17fc75bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7c8b-f29f-4574-96c0-daac17fc75bb.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "22cf21cb-55ab-5d19-8729-691b02055ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d96a37-bdbe-46ae-926f-8742699a0b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d96a37-bdbe-46ae-926f-8742699a0b20.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "0b41d2da-2e6d-57d4-84c2-039913f96cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccfa743c-b30a-4576-8205-8f00970d1076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccfa743c-b30a-4576-8205-8f00970d1076.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "b13a3fd2-9370-504a-a8f5-f96d0b8c0267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee5261-416c-41e9-9ad7-bf7bd169aa08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee5261-416c-41e9-9ad7-bf7bd169aa08.jpg?1",
             "name": "Festering Newt",
             "text": "When Festering Newt dies, target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "636ce0e7-4eaa-5837-8259-29d880b21515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56653d9e-0c29-440b-8724-cae746abb1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56653d9e-0c29-440b-8724-cae746abb1a9.jpg?1",
             "name": "Gnawing Zombie",
             "text": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "40f1b541-656f-588d-a20f-eb3a2f87f985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b69f74-3b54-4db4-abf3-b71db8cc9562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b69f74-3b54-4db4-abf3-b71db8cc9562.jpg?1",
             "name": "Grim Return",
             "text": "Choose target creature card in a graveyard that was put there from the battlefield this turn. Put that card onto the battlefield under your control.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "fb7325c3-bf60-595f-8a77-a41dccc8ba54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98370735-5303-40d4-9e80-cdb40dee18e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98370735-5303-40d4-9e80-cdb40dee18e2.jpg?1",
             "name": "Lifebane Zombie",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhen Lifebane Zombie enters the battlefield, target opponent reveals his or her hand. You choose a green or white creature card from it and exile that card.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "c63b699b-4d36-5dd0-865c-d77965ecdf3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cbe506-7332-4d29-9404-b7c6e1e791d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cbe506-7332-4d29-9404-b7c6e1e791d8.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.-3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.-6: You get an emblem with \"Swamps you control have \u2018{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "7df76af5-be2a-55cc-956e-b3fc20c76822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a734c33c-4fa0-4f7a-943c-14a8aecea1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a734c33c-4fa0-4f7a-943c-14a8aecea1a6.jpg?1",
             "name": "Liliana's Reaver",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Liliana's Reaver deals combat damage to a player, that player discards a card and you put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "856a4767-ebd6-56ca-b767-a135c4b21460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532105d-c550-4c20-8465-a6a19169efbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532105d-c550-4c20-8465-a6a19169efbd.jpg?1",
             "name": "Liturgy of Blood",
             "text": "Destroy target creature. Add {B}{B}{B} to your mana pool.",
             "colours": [
@@ -3496,7 +3496,7 @@
         },
         {
             "id": "afcbf4ca-ce34-5f68-8e04-1fabb7c70c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c2f0fb-3291-489c-92cf-8d326f2e6735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c2f0fb-3291-489c-92cf-8d326f2e6735.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "c79ab5d6-16e9-57fb-8d69-7de56b13b58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362e8f06-3d52-4368-a686-8fec3417b034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362e8f06-3d52-4368-a686-8fec3417b034.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "2740ba91-65e5-58d3-8a70-8efd015a81a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dca75a1-443d-4f8e-b12b-2aada3a8e3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dca75a1-443d-4f8e-b12b-2aada3a8e3e4.jpg?1",
             "name": "Minotaur Abomination",
             "text": "",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "c5d2fc1d-954e-5839-8686-6fb0b332a74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cf63e7-9143-4236-a887-afd3628d0c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cf63e7-9143-4236-a887-afd3628d0c03.jpg?1",
             "name": "Nightmare",
             "text": "FlyingNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "8ebabcfc-cbf1-5017-a597-d0a99c3967d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3112a8a-dc80-4099-966c-8fa1807a189b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3112a8a-dc80-4099-966c-8fa1807a189b.jpg?1",
             "name": "Nightwing Shade",
             "text": "Flying{1}{B}: Nightwing Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "f22f008b-874b-5778-90cb-d13f2101ca3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a759dcd2-ca07-4428-a3ea-b2e829b1fcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a759dcd2-ca07-4428-a3ea-b2e829b1fcb4.jpg?1",
             "name": "Quag Sickness",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 for each Swamp you control.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "b3e86392-ec88-50bc-ab24-e0971e55b020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073f81e8-8c0c-4430-bd3e-95ed3625340f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073f81e8-8c0c-4430-bd3e-95ed3625340f.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "ae609756-a310-5f4f-a569-2748b76e86fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e807d-b2eb-4b62-8663-8ad17eed2a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e807d-b2eb-4b62-8663-8ad17eed2a39.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "60026a8e-4703-54a6-92e8-3587cd848e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a78dbdc-1c5a-4b48-8cd1-64f7b4c29dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a78dbdc-1c5a-4b48-8cd1-64f7b4c29dd6.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "ba44cd54-e63c-5bf9-ab77-f0b42b1b25c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c2323-6589-457a-af51-5528a98e7b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c2323-6589-457a-af51-5528a98e7b30.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "A deck can have any number of cards named Shadowborn Apostle.{B}, Sacrifice six creatures named Shadowborn Apostle: Search your library for a Demon creature card and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "2a3309d4-4931-5bcb-8e92-0f91442e20d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884c05b-c10e-4f1d-a8bd-8b5118657972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884c05b-c10e-4f1d-a8bd-8b5118657972.jpg?1",
             "name": "Shadowborn Demon",
             "text": "Flying\nWhen Shadowborn Demon enters the battlefield, destroy target non-Demon creature.\nAt the beginning of your upkeep, if there are fewer than six creature cards in your graveyard, sacrifice a creature.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "edbcc56f-232c-5619-8f7e-6dc8c670c431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b2ffdd-f8a4-49e4-aab1-a8096ba2b7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b2ffdd-f8a4-49e4-aab1-a8096ba2b7cb.jpg?1",
             "name": "Shrivel",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "a1866d66-b882-5168-b646-e8857118ccfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cb40e3-c3ed-4b3f-88ad-6f1305297c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cb40e3-c3ed-4b3f-88ad-6f1305297c6f.jpg?1",
             "name": "Syphon Sliver",
             "text": "Sliver creatures you control have lifelink. (Damage dealt by a Sliver creature you control also causes you to gain that much life.)",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "2e010cce-cf13-5df3-8208-67c57b3f859d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b96fed2-0be9-4181-94ae-10f031e2aeb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b96fed2-0be9-4181-94ae-10f031e2aeb2.jpg?1",
             "name": "Tenacious Dead",
             "text": "When Tenacious Dead dies, you may pay {1}{B}. If you do, return it to the battlefield tapped under its owner's control.",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "b9adc9aa-50ab-5a33-8f5d-8668e1ded41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5ae910-ee1d-4958-92d9-0b06872913c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5ae910-ee1d-4958-92d9-0b06872913c6.jpg?1",
             "name": "Undead Minotaur",
             "text": "",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "d973974d-ad04-57fa-b31e-df7e72984130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e07929b-450c-45b0-85e6-512ad280a122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e07929b-450c-45b0-85e6-512ad280a122.jpg?1",
             "name": "Vampire Warlord",
             "text": "Sacrifice another creature: Regenerate Vampire Warlord. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "45d751ef-8ea0-5a6a-9ce7-1f3f9a32dcef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd46f2b-1458-44b1-9c65-960b261b81a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd46f2b-1458-44b1-9c65-960b261b81a5.jpg?1",
             "name": "Vile Rebirth",
             "text": "Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "4d1efa04-f564-57de-bfa1-a1feb9ffc42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b77692-08aa-40b6-b21b-c29a2dc87709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b77692-08aa-40b6-b21b-c29a2dc87709.jpg?1",
             "name": "Wring Flesh",
             "text": "Target creature gets -3/-1 until end of turn.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "14fb34c4-7524-5a21-aa22-b3bdce7f134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26494f96-1d97-4435-a116-3ade1becaab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26494f96-1d97-4435-a116-3ade1becaab4.jpg?1",
             "name": "Xathrid Necromancer",
             "text": "Whenever Xathrid Necromancer or another Human creature you control dies, put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "3526eef2-d3e5-596c-9c97-03936db26828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6652ed29-ee90-4abc-a6cf-6b18a6cbae86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6652ed29-ee90-4abc-a6cf-6b18a6cbae86.jpg?1",
             "name": "Academy Raider",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever Academy Raider deals combat damage to a player, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "01de46db-c92e-5171-b353-72859ca41141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babcfccf-83db-40e7-8a2c-f77358ba3cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babcfccf-83db-40e7-8a2c-f77358ba3cc0.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "e6daf287-f98a-50a8-bc8b-675a11bab984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4125304-fd68-4051-96d5-625ffa9b0d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4125304-fd68-4051-96d5-625ffa9b0d3c.jpg?1",
             "name": "Awaken the Ancient",
             "text": "Enchant Mountain\nEnchanted Mountain is a 7/7 red Giant creature with haste. It's still a land.",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "42181e21-2578-5526-a3b5-827d9d480e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0912d-b4b9-497c-bce7-ed80b79bab32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0912d-b4b9-497c-bce7-ed80b79bab32.jpg?1",
             "name": "Barrage of Expendables",
             "text": "{R}, Sacrifice a creature: Barrage of Expendables deals 1 damage to target creature or player.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "84f48c79-60dc-539d-935f-65ef9eda6c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68490b8c-e9d1-4f5c-9001-750be0e0569f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68490b8c-e9d1-4f5c-9001-750be0e0569f.jpg?1",
             "name": "Battle Sliver",
             "text": "Sliver creatures you control get +2/+0.",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "ab8b624d-b690-524c-abe2-fd060d572408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63227937-86cc-45e0-9e9e-8c7ab80cbaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63227937-86cc-45e0-9e9e-8c7ab80cbaef.jpg?1",
             "name": "Blur Sliver",
             "text": "Sliver creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "d7aa337f-b036-56fa-8f65-2eda51bbca6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df3a7c9-5c8d-438c-a5ad-3c9754c6ea5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df3a7c9-5c8d-438c-a5ad-3c9754c6ea5d.jpg?1",
             "name": "Burning Earth",
             "text": "Whenever a player taps a nonbasic land for mana, Burning Earth deals 1 damage to that player.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "10a98c62-bda4-5ef6-aeef-bee4501502e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3469d73e-6de1-4b91-83e3-b1714ac29268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3469d73e-6de1-4b91-83e3-b1714ac29268.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "b1781259-65cf-5045-84a8-d30e5356dca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4f983-a4b4-46df-830d-ab3d892c93bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4f983-a4b4-46df-830d-ab3d892c93bb.jpg?1",
             "name": "Chandra, Pyromaster",
             "text": "+1: Chandra, Pyromaster deals 1 damage to target player and 1 damage to up to one target creature that player controls. That creature can't block this turn.0: Exile the top card of your library. You may play it this turn.-7: Exile the top ten cards of your library. Choose an instant or sorcery card exiled this way and copy it three times. You may cast the copies without paying their mana costs.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "858e1496-03b5-5be6-8152-e7969c5fe10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d1b479-f6f6-4fec-a5a6-1a74d426fb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d1b479-f6f6-4fec-a5a6-1a74d426fb13.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "9c550df3-a05f-5232-8d27-05adf001af77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08d3ce-a3a7-49ca-aa2f-4dcdacbf923d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08d3ce-a3a7-49ca-aa2f-4dcdacbf923d.jpg?1",
             "name": "Chandra's Phoenix",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever an opponent is dealt damage by a red instant or sorcery spell you control or by a red planeswalker you control, return Chandra's Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "656f2799-a4d5-5c69-bdce-0f1a344e270b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b8e733-22a7-4696-83b3-297cbe75dadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b8e733-22a7-4696-83b3-297cbe75dadc.jpg?1",
             "name": "Cyclops Tyrant",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)Cyclops Tyrant can't block creatures with power 2 or less.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "ecf05d38-afb3-5071-9ca7-1ee71ff0034c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7827a7f9-132e-40aa-b881-423440a273bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7827a7f9-132e-40aa-b881-423440a273bd.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4573,7 +4573,7 @@
         },
         {
             "id": "7abc79b8-142e-5cbc-9d28-e317b01cc5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2048f7-0c68-4142-9aad-de9b91fe5958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2048f7-0c68-4142-9aad-de9b91fe5958.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender (This creature can't attack.)\nWhen Dragon Egg dies, put a 2/2 red Dragon creature token with flying onto the battlefield. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "d7f5fab3-8fbe-5a2f-9715-7dbb737401cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f2e830-a8ef-4c91-978d-23b5f851edae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f2e830-a8ef-4c91-978d-23b5f851edae.jpg?1",
             "name": "Dragon Hatchling",
             "text": "Flying{R}: Dragon Hatchling gets +1/+0 until end of turn.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "0348110e-2c57-58a0-bf1a-fe22c986b596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba659ce-b15c-4af9-bba1-0fb79b23f444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba659ce-b15c-4af9-bba1-0fb79b23f444.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "8dd44fd8-00b8-59ce-968d-e812eb399d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2726d3c-c182-4d8a-a723-0de2c5c4b152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2726d3c-c182-4d8a-a723-0de2c5c4b152.jpg?1",
             "name": "Fleshpulper Giant",
             "text": "When Fleshpulper Giant enters the battlefield, you may destroy target creature with toughness 2 or less.",
             "colours": [
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "5d5d9bbe-f2ee-5bea-a104-b0dc611806e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620c581-fef7-45e8-ba20-d00903c2f4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620c581-fef7-45e8-ba20-d00903c2f4c5.jpg?1",
             "name": "Goblin Diplomats",
             "text": "{T}: Each creature attacks this turn if able.",
             "colours": [
@@ -4742,7 +4742,7 @@
         },
         {
             "id": "5f269514-8236-5eca-b0ae-1cf93e68fc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b69456-c267-4f0d-bd0f-e2da96b9e053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b69456-c267-4f0d-bd0f-e2da96b9e053.jpg?1",
             "name": "Goblin Shortcutter",
             "text": "When Goblin Shortcutter enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "20b09853-6e7f-5771-a5dd-dde7111d912f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f1041-8bbe-46fa-bbe4-40cd993f53a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f1041-8bbe-46fa-bbe4-40cd993f53a2.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4809,7 +4809,7 @@
         },
         {
             "id": "27167a9e-cc99-5adf-8bc1-1ffbc44d877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87186a8a-45da-4cde-a167-c16a6abc4d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87186a8a-45da-4cde-a167-c16a6abc4d24.jpg?1",
             "name": "Lightning Talons",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4843,7 +4843,7 @@
         },
         {
             "id": "c6cfc20f-f155-5ece-be66-5e6207690e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d5e3dc-f307-4f91-a5ee-e7c5d03d8102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d5e3dc-f307-4f91-a5ee-e7c5d03d8102.jpg?1",
             "name": "Marauding Maulhorn",
             "text": "Marauding Maulhorn attacks each combat if able unless you control a creature named Advocate of the Beast.",
             "colours": [
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "4e61786d-5960-5db4-911a-4dadc40ade22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg?1",
             "name": "Mindsparker",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever an opponent casts a white or blue instant or sorcery spell, Mindsparker deals 2 damage to that player.",
             "colours": [
@@ -4911,7 +4911,7 @@
         },
         {
             "id": "39aab18d-a102-548b-9290-1ce3da6c1a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd182be-1604-47e1-858f-3c304fd0ee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd182be-1604-47e1-858f-3c304fd0ee63.jpg?1",
             "name": "Molten Birth",
             "text": "Put two 1/1 red Elemental creature tokens onto the battlefield. Then flip a coin. If you win the flip, return Molten Birth to its owner's hand.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "9204e81b-94aa-56d6-b930-78bb681ac6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff2d740-22cc-4719-ac58-28621951e68d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff2d740-22cc-4719-ac58-28621951e68d.jpg?1",
             "name": "Ogre Battledriver",
             "text": "Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4978,7 +4978,7 @@
         },
         {
             "id": "f23bf371-fac1-5c43-9d04-60cd83baebeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e0a702-6984-4ccd-9ce8-4518c9b19e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e0a702-6984-4ccd-9ce8-4518c9b19e22.jpg?1",
             "name": "Pitchburn Devils",
             "text": "When Pitchburn Devils dies, it deals 3 damage to target creature or player.",
             "colours": [
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "507d3675-e47d-57e8-8a1b-d409c37434dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4df1dd-886d-4fe7-b3f7-2dca044de41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4df1dd-886d-4fe7-b3f7-2dca044de41c.jpg?1",
             "name": "Regathan Firecat",
             "text": "",
             "colours": [
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "4bf888ed-8055-5767-82fb-5074e12bc365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce2b55-45bf-4852-a74a-d0b17c6c9c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce2b55-45bf-4852-a74a-d0b17c6c9c3f.jpg?1",
             "name": "Scourge of Valkas",
             "text": "Flying\nWhenever Scourge of Valkas or another Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.{R}: Scourge of Valkas gets +1/+0 until end of turn.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "e8f244a6-b21f-5640-9669-dec20d323642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a02a3-8b65-44a7-82ef-2d3dc05d00ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a02a3-8b65-44a7-82ef-2d3dc05d00ab.jpg?1",
             "name": "Seismic Stomp",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "bb16a2b4-7e98-5648-8844-c5e5c375b92e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a42fcd6-32ce-4a20-af4d-83bd32a7ed3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a42fcd6-32ce-4a20-af4d-83bd32a7ed3e.jpg?1",
             "name": "Shiv's Embrace",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "1674e010-6bac-55d3-8122-718d83f148e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815cf4a-b694-432b-b618-0893f8f3dc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815cf4a-b694-432b-b618-0893f8f3dc1b.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "882465eb-6c38-584c-99cf-3f76f3508438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbec2ea-7b60-4c51-9782-52ccdd96c4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbec2ea-7b60-4c51-9782-52ccdd96c4b7.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "31126d22-78c0-50c1-bb35-4f8082199054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90515c37-93cc-4bb2-8237-21e39076c995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90515c37-93cc-4bb2-8237-21e39076c995.jpg?1",
             "name": "Smelt",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "b7e7ab11-d3ca-504e-872c-9bb65a863640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee9254b-3d98-4477-a82e-1450cf3ee96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee9254b-3d98-4477-a82e-1450cf3ee96e.jpg?1",
             "name": "Striking Sliver",
             "text": "Sliver creatures you control have first strike. (They deal combat damage before creatures without first strike.)",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "949f9690-fbf2-5912-8121-82904a125528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655d837-945f-4ff5-8952-cff5f7b2d18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655d837-945f-4ff5-8952-cff5f7b2d18f.jpg?1",
             "name": "Thorncaster Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature attacks, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "d947c61a-c8d1-5e8e-8a55-55fe59791b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa445d-d734-4e4f-800d-fe7bea86eb70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa445d-d734-4e4f-800d-fe7bea86eb70.jpg?1",
             "name": "Thunder Strike",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "3a496905-95a3-5af5-8a05-a63e04b182f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2b0fdb-2209-4b98-87e1-1eb870706cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2b0fdb-2209-4b98-87e1-1eb870706cec.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "f68354f4-2bce-5d13-9162-b3372c613b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c4556f-652b-4df0-a501-d413d32e7a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c4556f-652b-4df0-a501-d413d32e7a91.jpg?1",
             "name": "Wild Guess",
             "text": "As an additional cost to cast Wild Guess, discard a card.\nDraw two cards.",
             "colours": [
@@ -5409,7 +5409,7 @@
         },
         {
             "id": "cbbbc766-4928-50b5-995e-c683ac5f88f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962273bb-2186-4e33-99c5-65eedc4a93e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962273bb-2186-4e33-99c5-65eedc4a93e9.jpg?1",
             "name": "Wild Ricochet",
             "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -5441,7 +5441,7 @@
         },
         {
             "id": "d1af1c8e-2668-5354-9cb1-e9e0d137ee39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e349c204-3a93-4bf7-b79a-5f5f261ea2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e349c204-3a93-4bf7-b79a-5f5f261ea2d3.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, put a 1/1 red Elemental creature token onto the battlefield.",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "3f6217c4-f348-5cdf-9766-695acfd2f20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1320400-5aa8-48d6-be84-197b4559456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1320400-5aa8-48d6-be84-197b4559456f.jpg?1",
             "name": "Advocate of the Beast",
             "text": "At the beginning of your end step, put a +1/+1 counter on target Beast creature you control.",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "2b448b7a-81a6-55e8-bfb6-866c4aabcbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1bd3ff-f3cd-4e9d-ae2e-2c51d0aaec7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1bd3ff-f3cd-4e9d-ae2e-2c51d0aaec7f.jpg?1",
             "name": "Bramblecrush",
             "text": "Destroy target noncreature permanent.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "e52b7a2f-421b-5b28-943b-303dc3bee654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585c11e2-4c30-436c-9dbd-354b154f6def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585c11e2-4c30-436c-9dbd-354b154f6def.jpg?1",
             "name": "Briarpack Alpha",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Briarpack Alpha enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "2b6c22b0-e549-58af-a993-1434efe37917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b4a78-afdd-4067-810e-1fa0ddf8fb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b4a78-afdd-4067-810e-1fa0ddf8fb0e.jpg?1",
             "name": "Brindle Boar",
             "text": "Sacrifice Brindle Boar: You gain 4 life.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "5375b781-1fb9-5c11-b02f-a63a98e2a23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82cc190-7ec0-4493-b3dc-dad0cbffa2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82cc190-7ec0-4493-b3dc-dad0cbffa2f8.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5645,7 +5645,7 @@
         },
         {
             "id": "0a0750cd-1705-5366-911d-98fa0431f180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d0e6a6-629a-45a7-bfcb-25ba7156788b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d0e6a6-629a-45a7-bfcb-25ba7156788b.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "0cfc8032-7d9d-5069-8a0e-0c79f412934c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd181-59d8-4d4c-a8b6-e6b38704009c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd181-59d8-4d4c-a8b6-e6b38704009c.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able. (If a creature with trample would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "9711ad15-1aeb-598e-9117-85fcf025feb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b55d04f-c52f-4b94-b25c-f5c7d8c1c18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b55d04f-c52f-4b94-b25c-f5c7d8c1c18e.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "f6fd9a27-5bbe-5447-a52d-b7e28adcbd31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d0c67-e9f4-46d9-bd74-13a8606fdfe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d0c67-e9f4-46d9-bd74-13a8606fdfe3.jpg?1",
             "name": "Garruk, Caller of Beasts",
             "text": "+1: Reveal the top five cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.-3: You may put a green creature card from your hand onto the battlefield.-7: You get an emblem with \"Whenever you cast a creature spell, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "cdddf1d7-e08e-5ad4-9896-7dee906ac040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b24651-1814-440e-a415-a96c03e51544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b24651-1814-440e-a415-a96c03e51544.jpg?1",
             "name": "Garruk's Horde",
             "text": "Trample Play with the top card of your library revealed.\nYou may cast the top card of your library if it's a creature card. (Do this only any time you could cast that creature card. You still pay the spell's costs.)",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "2ba31a82-8c51-5920-9c06-f1cc8cd860fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b32578-a074-4a46-b742-84b974748903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b32578-a074-4a46-b742-84b974748903.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "532f8a13-05d7-5511-9a63-c34dcbafb56c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253ebe04-9605-424e-8cff-51d3a54f91a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253ebe04-9605-424e-8cff-51d3a54f91a7.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5880,7 +5880,7 @@
         },
         {
             "id": "e0602c94-44b5-5d30-bca1-14460b5a7996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e112d77d-f019-4709-b31a-b02952df0e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e112d77d-f019-4709-b31a-b02952df0e35.jpg?1",
             "name": "Gladecover Scout",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5915,7 +5915,7 @@
         },
         {
             "id": "aa731742-89d3-5ff3-a72a-3d54f1f4f456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712f0ce4-9189-4c75-9c2b-d370bce89052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712f0ce4-9189-4c75-9c2b-d370bce89052.jpg?1",
             "name": "Groundshaker Sliver",
             "text": "Sliver creatures you control have trample. (If a Sliver you control would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5949,7 +5949,7 @@
         },
         {
             "id": "a7619894-502e-5f07-bba1-d0c2a4cb6121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fc5ff1-b8bd-44d5-a659-17eeae06736a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fc5ff1-b8bd-44d5-a659-17eeae06736a.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "Put a 2/2 green Wolf creature token onto the battlefield for each Forest you control.",
             "colours": [
@@ -5981,7 +5981,7 @@
         },
         {
             "id": "8a85aef4-5ca0-571a-a59a-530541792690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7a6df7-acfc-4047-b119-505f4277225c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7a6df7-acfc-4047-b119-505f4277225c.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6013,7 +6013,7 @@
         },
         {
             "id": "0f4d8de4-eca4-5598-be8c-cdd87d5fdc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa6c8d-b5b5-4b68-9ad4-c9d8169659d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa6c8d-b5b5-4b68-9ad4-c9d8169659d6.jpg?1",
             "name": "Into the Wilds",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a land card, you may put it onto the battlefield.",
             "colours": [
@@ -6045,7 +6045,7 @@
         },
         {
             "id": "a32a2437-b491-54ac-a06e-3731c83a038a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438bd3c1-98f2-4fcc-8521-995c6c5c1a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438bd3c1-98f2-4fcc-8521-995c6c5c1a79.jpg?1",
             "name": "Kalonian Hydra",
             "text": "TrampleKalonian Hydra enters the battlefield with four +1/+1 counters on it.\nWhenever Kalonian Hydra attacks, double the number of +1/+1 counters on each creature you control.",
             "colours": [
@@ -6079,7 +6079,7 @@
         },
         {
             "id": "5fbfd623-4b13-5e03-a56e-2bba50102607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135946fc-fe67-401f-821d-d7145c63f030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135946fc-fe67-401f-821d-d7145c63f030.jpg?1",
             "name": "Kalonian Tusker",
             "text": "",
             "colours": [
@@ -6113,7 +6113,7 @@
         },
         {
             "id": "25557867-c115-5b39-ae0f-0e0b92ecd142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb3410b-d6c3-4e42-b3c9-fb557f9a16f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb3410b-d6c3-4e42-b3c9-fb557f9a16f0.jpg?1",
             "name": "Lay of the Land",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6145,7 +6145,7 @@
         },
         {
             "id": "cd6bf4f4-644d-59c4-8f41-ea323c1b174c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45433b-e124-44d7-9463-dada39310148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45433b-e124-44d7-9463-dada39310148.jpg?1",
             "name": "Manaweft Sliver",
             "text": "Sliver creatures you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "9fd10c9d-a9d3-5979-91f9-2f876f68974f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7745f6a9-400c-4200-9732-86c54247de46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7745f6a9-400c-4200-9732-86c54247de46.jpg?1",
             "name": "Megantic Sliver",
             "text": "Sliver creatures you control get +3/+3.",
             "colours": [
@@ -6213,7 +6213,7 @@
         },
         {
             "id": "85143f97-476d-51f3-bf72-a7c75ac954e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bac967b-f684-4916-b7f4-8fffdd752a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bac967b-f684-4916-b7f4-8fffdd752a93.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "908307dc-33ef-5ec2-96ba-b818dd4cce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg?1",
             "name": "Oath of the Ancient Wood",
             "text": "Whenever Oath of the Ancient Wood or another enchantment enters the battlefield under your control, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -6277,7 +6277,7 @@
         },
         {
             "id": "54ad540a-5ee2-563f-be4a-00ec30b4b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbac2e5-cc3a-4be1-9891-6098b1066de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbac2e5-cc3a-4be1-9891-6098b1066de8.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "33727667-72fb-5b83-ae80-f4ba7c8e0dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e37de8-66a1-4afa-aa6f-1151f849dfa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e37de8-66a1-4afa-aa6f-1151f849dfa8.jpg?1",
             "name": "Predatory Sliver",
             "text": "Sliver creatures you control get +1/+1.",
             "colours": [
@@ -6343,7 +6343,7 @@
         },
         {
             "id": "1a1376d4-eee1-5997-b077-df070c8a93b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e750d55d-d5e8-4abe-99cf-f6b8ba86cf16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e750d55d-d5e8-4abe-99cf-f6b8ba86cf16.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, put a 3/3 green Beast creature token onto the battlefield.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nWhenever a land enters the battlefield under your control, you gain 3 life.",
             "colours": [
@@ -6375,7 +6375,7 @@
         },
         {
             "id": "acf6499d-acf3-5521-b535-f609305eac34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24976e3a-9f34-4dce-8bb3-efecfdfff160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24976e3a-9f34-4dce-8bb3-efecfdfff160.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "77871027-8a37-5b04-b44a-55830d7f172d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b84b6dc-d78d-4d6a-9e9a-2b40854a102b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b84b6dc-d78d-4d6a-9e9a-2b40854a102b.jpg?1",
             "name": "Rootwalla",
             "text": "{1}{G}: Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "949f761c-54d2-5cf1-ba97-c21dcb124eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8610ff1-064b-4c75-a8df-d3b076370d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8610ff1-064b-4c75-a8df-d3b076370d1e.jpg?1",
             "name": "Rumbling Baloth",
             "text": "",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "970ccb5c-35a8-588f-9424-a9dc4b05f1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5346ed7-2e17-4d8c-9c4b-b5efdd26380d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5346ed7-2e17-4d8c-9c4b-b5efdd26380d.jpg?1",
             "name": "Savage Summoning",
             "text": "Savage Summoning can't be countered.\nThe next creature card you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -6507,7 +6507,7 @@
         },
         {
             "id": "8a6a6e9a-6084-593a-9000-2579e24224a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec30153a-36b5-42f8-beed-9efab09f1051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec30153a-36b5-42f8-beed-9efab09f1051.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -6541,7 +6541,7 @@
         },
         {
             "id": "4d029808-52a7-5217-b922-afaea0b5ea15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256cd0-6fe9-4905-9886-fb1457292db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256cd0-6fe9-4905-9886-fb1457292db5.jpg?1",
             "name": "Sporemound",
             "text": "Whenever a land enters the battlefield under your control, put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "df55f7be-b10b-519d-a26a-a65a1cb1fe10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b9c400-dc8f-4fe6-a868-fdf0d247086a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b9c400-dc8f-4fe6-a868-fdf0d247086a.jpg?1",
             "name": "Trollhide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\" (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6609,7 +6609,7 @@
         },
         {
             "id": "79e60c6e-c744-5acf-8ba3-df08f4379582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e635174-7f7d-4c04-a6aa-8674da6863ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e635174-7f7d-4c04-a6aa-8674da6863ff.jpg?1",
             "name": "Vastwood Hydra",
             "text": "Vastwood Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Vastwood Hydra dies, you may distribute a number of +1/+1 counters equal to the number of +1/+1 counters on Vastwood Hydra among any number of creatures you control.",
             "colours": [
@@ -6643,7 +6643,7 @@
         },
         {
             "id": "dabee451-41f8-5416-b056-12563e3eb8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e37e6-6f19-4dfa-bd13-6e261177c1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e37e6-6f19-4dfa-bd13-6e261177c1cf.jpg?1",
             "name": "Verdant Haven",
             "text": "Enchant land\nWhen Verdant Haven enters the battlefield, you gain 2 life.\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -6677,7 +6677,7 @@
         },
         {
             "id": "208744aa-1889-5fc0-9807-3c98e54884de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da15100b-2934-438c-9917-84ad8bdc4181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da15100b-2934-438c-9917-84ad8bdc4181.jpg?1",
             "name": "Voracious Wurm",
             "text": "Voracious Wurm enters the battlefield with X +1/+1 counters on it, where X is the amount of life you've gained this turn.",
             "colours": [
@@ -6711,7 +6711,7 @@
         },
         {
             "id": "84d42d80-f307-536b-b352-f04a862d189f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb7d122-34e8-48e1-a978-831c78a37d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb7d122-34e8-48e1-a978-831c78a37d0c.jpg?1",
             "name": "Windstorm",
             "text": "Windstorm deals X damage to each creature with flying.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "2dbe53bc-9ecc-5260-b3ff-03fc206ee236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5ce47d-ea4f-4e15-adb6-5bb66981ed24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5ce47d-ea4f-4e15-adb6-5bb66981ed24.jpg?1",
             "name": "Witchstalker",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever an opponent casts a blue or black spell during your turn, put a +1/+1 counter on Witchstalker.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "3e8a16d5-7547-53d9-af26-c7a6d9c5c242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c73dbf3-e68e-4f21-b6ca-94302bf5574c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c73dbf3-e68e-4f21-b6ca-94302bf5574c.jpg?1",
             "name": "Woodborn Behemoth",
             "text": "As long as you control eight or more lands, Woodborn Behemoth gets +4/+4 and has trample. (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "7bd48e60-46f2-5009-b8e2-aa04f56c93a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a4c2ab-c5bc-4e07-8671-a688ebd5471c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a4c2ab-c5bc-4e07-8671-a688ebd5471c.jpg?1",
             "name": "Accorder's Shield",
             "text": "Equipped creature gets +0/+3 and has vigilance. (Attacking doesn't cause it to tap.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "3b7321a8-63a0-5e2e-a624-f001a2c31ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af87c24-a534-462b-968b-dccf6ac63299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af87c24-a534-462b-968b-dccf6ac63299.jpg?1",
             "name": "Bubbling Cauldron",
             "text": "{1}, {T}, Sacrifice a creature: You gain 4 life.{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.",
             "colours": [],
@@ -6869,7 +6869,7 @@
         },
         {
             "id": "a78b88d0-8058-5b68-9764-57aa373c720d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c95a0a1-9c2c-44df-b0fe-c22efb6d87ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c95a0a1-9c2c-44df-b0fe-c22efb6d87ee.jpg?1",
             "name": "Darksteel Forge",
             "text": "Artifacts you control have indestructible. (Effects that say \"destroy\" don't destroy them. Artifact creatures with indestructible can't be destroyed by damage.)",
             "colours": [],
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "18fb72e8-437f-530e-9e4c-a203834ee425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290a80b6-2e9e-495f-81b6-845ee80fb9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290a80b6-2e9e-495f-81b6-845ee80fb9c2.jpg?1",
             "name": "Darksteel Ingot",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.){T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "7b5a51cc-3f83-50b9-96e5-07243a69de3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6bf1a-7152-496f-a4c7-e720ef4294d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6bf1a-7152-496f-a4c7-e720ef4294d8.jpg?1",
             "name": "Door of Destinies",
             "text": "As Door of Destinies enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, put a charge counter on Door of Destinies.\nCreatures you control of the chosen type get +1/+1 for each charge counter on Door of Destinies.",
             "colours": [],
@@ -6953,7 +6953,7 @@
         },
         {
             "id": "0bffb575-588f-5431-b2a4-89d11fa9a376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d19d950-9e63-4b15-8531-f4b16f5b82fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d19d950-9e63-4b15-8531-f4b16f5b82fa.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
             "colours": [],
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "5e984032-58b2-5b2f-b5ff-4ea3a64905bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f653742-b92a-4cfa-b3b5-8d20aabdb5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f653742-b92a-4cfa-b3b5-8d20aabdb5dd.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7011,7 +7011,7 @@
         },
         {
             "id": "ab80793c-6b37-5380-9e89-b144d19db129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c825c138-97de-44b9-8aec-70608ae035b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c825c138-97de-44b9-8aec-70608ae035b6.jpg?1",
             "name": "Guardian of the Ages",
             "text": "Defender (This creature can't attack.)\nWhen a creature attacks you or a planeswalker you control, if Guardian of the Ages has defender, it loses defender and gains trample.",
             "colours": [],
@@ -7042,7 +7042,7 @@
         },
         {
             "id": "7343766d-ad54-51e9-bcbf-9fc09898e2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc1e07-7894-4f22-936d-bf5df3f8d5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc1e07-7894-4f22-936d-bf5df3f8d5a5.jpg?1",
             "name": "Haunted Plate Mail",
             "text": "Equipped creature gets +4/+4.{0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate this ability only if you control no creatures.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7072,7 +7072,7 @@
         },
         {
             "id": "6388406f-0779-50df-bcf2-cc3aaccef646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f28acb-8ccb-4b89-ba7f-ff7ce59852aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f28acb-8ccb-4b89-ba7f-ff7ce59852aa.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "d7d7391c-5d25-5048-940c-82248388caba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde6763-2102-4adb-8048-fc9fe921205b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde6763-2102-4adb-8048-fc9fe921205b.jpg?1",
             "name": "Pyromancer's Gauntlet",
             "text": "If a red instant or sorcery spell you control or a red planeswalker you control would deal damage to a permanent or player, it deals that much damage plus 2 to that permanent or player instead.",
             "colours": [],
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "7956bde2-f18b-55ca-b932-0ded3bc5ecc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9045df-3eff-4236-9bbb-77537b302e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9045df-3eff-4236-9bbb-77537b302e27.jpg?1",
             "name": "Ratchet Bomb",
             "text": "{T}: Put a charge counter on Ratchet Bomb.{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
             "colours": [],
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "782ca033-bc37-5baf-a152-48d4d538278b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219ab03a-2b3b-4eef-8a42-2cbe793d2f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219ab03a-2b3b-4eef-8a42-2cbe793d2f33.jpg?1",
             "name": "Ring of Three Wishes",
             "text": "Ring of Three Wishes enters the battlefield with three wish counters on it.{5}, {T}, Remove a wish counter from Ring of Three Wishes: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "f79b79ad-1d26-5674-bd35-c3abaff7a50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0e90b8-bc38-4e1c-92ca-ac562cc57e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0e90b8-bc38-4e1c-92ca-ac562cc57e31.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "b4e9ae08-751f-5746-a2f0-cc83b15a3439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3129645a-221c-4eb5-88fd-12cc742a1dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3129645a-221c-4eb5-88fd-12cc742a1dfe.jpg?1",
             "name": "Sliver Construct",
             "text": "",
             "colours": [],
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "647accf9-5f5c-53ca-846c-60285de37ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624fe171-8bd8-4156-b40e-74e2a847d380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624fe171-8bd8-4156-b40e-74e2a847d380.jpg?1",
             "name": "Staff of the Death Magus",
             "text": "Whenever you cast a black spell or a Swamp enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "4bcf4670-ee5e-560c-80c4-edc5bc613669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6befbd-4fe3-4338-b8ea-13b8b70a7664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6befbd-4fe3-4338-b8ea-13b8b70a7664.jpg?1",
             "name": "Staff of the Flame Magus",
             "text": "Whenever you cast a red spell or a Mountain enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7300,7 +7300,7 @@
         },
         {
             "id": "6d19452e-c89f-5168-a6d4-1082d6cdddb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86bf36b-b83f-4451-8cdc-2a4ccffb93c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86bf36b-b83f-4451-8cdc-2a4ccffb93c7.jpg?1",
             "name": "Staff of the Mind Magus",
             "text": "Whenever you cast a blue spell or an Island enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "eb89799d-deeb-5fb6-936d-30e7d6eb0ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a1f830-d19a-4ebf-9573-09b677693dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a1f830-d19a-4ebf-9573-09b677693dd6.jpg?1",
             "name": "Staff of the Sun Magus",
             "text": "Whenever you cast a white spell or a Plains enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7356,7 +7356,7 @@
         },
         {
             "id": "a34e42ec-0b13-5ec7-a994-1c50aa4e5aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d207f03d-4c7b-444f-bf95-e63f7004d525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d207f03d-4c7b-444f-bf95-e63f7004d525.jpg?1",
             "name": "Staff of the Wild Magus",
             "text": "Whenever you cast a green spell or a Forest enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "97086dd0-c41b-535c-bcb2-26e1709aa1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d1fc0f-5c8b-4e47-aaf8-8888c025f70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d1fc0f-5c8b-4e47-aaf8-8888c025f70f.jpg?1",
             "name": "Strionic Resonator",
             "text": "{2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy. (A triggered ability uses the words \"when,\" \"whenever,\" or \"at.\")",
             "colours": [],
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "adb8b2cb-4907-5501-8ce2-506f4cf085f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132c5358-c258-4b86-862a-2d140011dc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132c5358-c258-4b86-862a-2d140011dc3f.jpg?1",
             "name": "Trading Post",
             "text": "{1}, {T}, Discard a card: You gain 4 life.{1}, {T}, Pay 1 life: Put a 0/1 white Goat creature token onto the battlefield.{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.{1}, {T}, Sacrifice an artifact: Draw a card.",
             "colours": [],
@@ -7440,7 +7440,7 @@
         },
         {
             "id": "c89c8827-c118-544d-a805-541477725e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769159b-5a6a-45e5-b69b-8db2a6ef5418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769159b-5a6a-45e5-b69b-8db2a6ef5418.jpg?1",
             "name": "Vial of Poison",
             "text": "{1}, Sacrifice Vial of Poison: Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [],
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "a71a8084-4df9-57ac-8131-05c84b8a1bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad5a84b-ae9b-4ed1-a4de-b91bbf8ed0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad5a84b-ae9b-4ed1-a4de-b91bbf8ed0a5.jpg?1",
             "name": "Encroaching Wastes",
             "text": "{T}: Add {1} to your mana pool.{4}, {T}, Sacrifice Encroaching Wastes: Destroy target nonbasic land.",
             "colours": [],
@@ -7496,7 +7496,7 @@
         },
         {
             "id": "14761310-7d63-5b20-aaea-9890adce183d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927ed667-c228-4b96-a9f6-7cbadade8134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927ed667-c228-4b96-a9f6-7cbadade8134.jpg?1",
             "name": "Mutavault",
             "text": "{T}: Add {1} to your mana pool.{1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "d8bfceb1-fd8b-52ef-b802-0a4401bf8b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd26b14-a920-4b82-91b8-8de0e7d03f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd26b14-a920-4b82-91b8-8de0e7d03f6e.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {1} to your mana pool.{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "80883bcc-dd8f-5ba9-a87f-463db64f5d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ca29a-7fb3-426f-922b-5a2b905a5565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ca29a-7fb3-426f-922b-5a2b905a5565.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "235fd614-de6d-5dc2-a1d7-2d9d19d73b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8098d41-38dc-4f82-b65e-d3bc7d8e0fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8098d41-38dc-4f82-b65e-d3bc7d8e0fcc.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7628,7 +7628,7 @@
         },
         {
             "id": "8e987378-0c30-54ed-8d85-4d7df1aeb275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d9f61-b94d-4ba3-b709-791ec647a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d9f61-b94d-4ba3-b709-791ec647a716.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "b6bdcad0-63ed-5e7a-9a36-3e25807e8a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90742ab3-89fb-4ac1-9bf0-0e2d17252bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90742ab3-89fb-4ac1-9bf0-0e2d17252bff.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7704,7 +7704,7 @@
         },
         {
             "id": "1cf4fdf5-85f9-5e51-acbf-d16436a8c50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94de0250-53a6-45c8-85a7-a473f271102e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94de0250-53a6-45c8-85a7-a473f271102e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "5c67be85-200f-59a9-9a76-4aa7273a8ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2814990-4c7a-44ae-8d76-157156aa79bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2814990-4c7a-44ae-8d76-157156aa79bb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "a4240019-2093-58c2-a4f1-2eb2489abb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d37787-be3a-4ed3-94b8-e675f2beecf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d37787-be3a-4ed3-94b8-e675f2beecf0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "1751a521-5849-5e20-8d65-84fc928ff2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59cd300-c4f3-4ba6-8018-134eaf6a399c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59cd300-c4f3-4ba6-8018-134eaf6a399c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7856,7 +7856,7 @@
         },
         {
             "id": "b72fbdf6-e73a-5bd7-8fac-7011e21d40eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4510090f-b42d-4df1-af71-64a77dfbc1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4510090f-b42d-4df1-af71-64a77dfbc1b2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7894,7 +7894,7 @@
         },
         {
             "id": "a9fb6ea7-4e3c-51c5-be9c-2ba76e552ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce9570-e5d7-44e5-bc93-6d03dd1a3794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce9570-e5d7-44e5-bc93-6d03dd1a3794.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "295080c6-5d3c-558b-8a14-62c92cc1e654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4394a-14c9-4a6e-898c-056108b16e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4394a-14c9-4a6e-898c-056108b16e09.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7970,7 +7970,7 @@
         },
         {
             "id": "50bee390-5ec7-576d-a8f0-f0fc4d29833d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07504e2d-9d70-4957-bee6-abab92368a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07504e2d-9d70-4957-bee6-abab92368a33.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8008,7 +8008,7 @@
         },
         {
             "id": "7d3bb0b1-6adb-5af6-a8d2-6008b794731d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82bb8b-2a95-4935-a728-6898f64ce39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82bb8b-2a95-4935-a728-6898f64ce39a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "88ea4bb0-1e3b-5999-b75d-20cfef6f7ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffc2e95-dd9b-4581-988f-850d9e240a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffc2e95-dd9b-4581-988f-850d9e240a30.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8084,7 +8084,7 @@
         },
         {
             "id": "ba485772-4c20-5b39-b1a1-811136888938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67057abf-749d-4512-968a-832c56324e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67057abf-749d-4512-968a-832c56324e13.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8122,7 +8122,7 @@
         },
         {
             "id": "0da3cca4-2343-536f-8e2c-469cd1d9a44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c28158-fb96-4006-bc65-425dba031395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c28158-fb96-4006-bc65-425dba031395.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8160,7 +8160,7 @@
         },
         {
             "id": "20a1fbef-a42d-595e-864b-934d9809bac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5277ee-f1e0-4777-9011-d7a23c855919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5277ee-f1e0-4777-9011-d7a23c855919.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "1c8ebaac-e166-54d6-9b78-29df71faa1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd98de13-d556-4cf3-99f3-d1c0db85cb3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd98de13-d556-4cf3-99f3-d1c0db85cb3f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "53d27a73-9c44-5579-ab4e-173db0947438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04db1116-3819-4a57-a001-dfa7578f0f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04db1116-3819-4a57-a001-dfa7578f0f12.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8274,7 +8274,7 @@
         },
         {
             "id": "d8cb8522-01d2-5c56-ae5e-16390090c18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b3dce8-9c28-41f6-823f-a7d64dd9e33a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b3dce8-9c28-41f6-823f-a7d64dd9e33a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8312,7 +8312,7 @@
         },
         {
             "id": "234c2a42-59db-55aa-a13a-6c5472f4acda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68353af0-9cd0-43c0-9b39-8f904c618e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68353af0-9cd0-43c0-9b39-8f904c618e3a.jpg?1",
             "name": "Sliver",
             "text": "",
             "colours": [],
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "4208994e-f2ce-5e38-bb3d-40067c58aa9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826320b7-4ccf-4ace-8c2c-15052b6bad73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826320b7-4ccf-4ace-8c2c-15052b6bad73.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "7a31461f-de1f-510e-af84-58c841687c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41ce71-52df-4bc1-884d-b09419d8dd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41ce71-52df-4bc1-884d-b09419d8dd13.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "7f3996d0-a560-5d15-bdf9-da6965786680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e90524-bad8-4d24-85be-9402401e7b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e90524-bad8-4d24-85be-9402401e7b42.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "79987e55-364d-53c5-966f-2a56bff108b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d82a8d-4c57-401f-92c3-8fd9ba20174a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d82a8d-4c57-401f-92c3-8fd9ba20174a.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "23b163a2-b372-56f9-a1d2-17777a908e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efaa5b5-984d-4eff-81b6-9b4989f149eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efaa5b5-984d-4eff-81b6-9b4989f149eb.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8512,7 +8512,7 @@
         },
         {
             "id": "6d87df30-3dc9-5aa7-9823-a36be9d4ae94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed37fa8e-5930-4e57-8ead-73894ac40c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed37fa8e-5930-4e57-8ead-73894ac40c19.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "d4a228fe-0702-5871-83bb-6bef95c79a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7315d5-26d9-4ecc-bca2-b75c6fb12597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7315d5-26d9-4ecc-bca2-b75c6fb12597.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "80cc69dd-7da2-5f51-aed2-c9fde5de7f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fc2dc9-40df-46d8-98c0-ca4919bd5524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fc2dc9-40df-46d8-98c0-ca4919bd5524.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "a520baa5-a891-5f8a-b35f-09a9cc2622b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd66b96-eccb-44ce-9125-063d34af2ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd66b96-eccb-44ce-9125-063d34af2ff8.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8648,7 +8648,7 @@
         },
         {
             "id": "c3fdc9ac-a844-5c97-acf9-6bd0f990e7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309f1bd4-78af-4722-9d45-b5f40b001570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309f1bd4-78af-4722-9d45-b5f40b001570.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "e81a58c7-0994-5d6f-b3b7-5f91d759622f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f327de6e-c9f1-478d-9940-b500df8cef10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f327de6e-c9f1-478d-9940-b500df8cef10.jpg?1",
             "name": "Liliana of the Dark Realms Emblem",
             "text": "",
             "colours": [],
@@ -8711,7 +8711,7 @@
         },
         {
             "id": "756851aa-7534-5254-8e51-b9859dd4d8eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16429cb-9b00-4411-9ffc-252b38ad0b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16429cb-9b00-4411-9ffc-252b38ad0b8c.jpg?1",
             "name": "Garruk, Caller of Beasts Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M15.json
+++ b/Assets/Resources/Sets/M15.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "51887cb6-f868-59b3-81a0-1da796187b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9302ba8-7ff2-4eaa-a32d-eedd94f0bb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9302ba8-7ff2-4eaa-a32d-eedd94f0bb79.jpg?1",
             "name": "Ajani Steadfast",
             "text": "+1: Until end of turn, up to one target creature gets +1/+1 and gains first strike, vigilance, and lifelink.\n\u22122: Put a +1/+1 counter on each creature you control and a loyalty counter on each other planeswalker you control.\n\u22127: You get an emblem with \"If a source would deal damage to you or a planeswalker you control, prevent all but 1 of that damage.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "2458e513-4186-5765-adec-ed760a7404bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411cacd-910b-4eda-8f67-03b426c94ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411cacd-910b-4eda-8f67-03b426c94ebe.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "9ede43f0-8c1c-5da3-80bf-bd83cb4189ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79662d5-3b6f-4c5a-8540-63c201027b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79662d5-3b6f-4c5a-8540-63c201027b66.jpg?1",
             "name": "Avacyn, Guardian Angel",
             "text": "Flying, vigilance\n{1}{W}: Prevent all damage that would be dealt to another target creature this turn by sources of the color of your choice.\n{5}{W}{W}: Prevent all damage that would be dealt to target player this turn by sources of the color of your choice.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "eac62124-5958-5a83-95d8-2de5ada52734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8313a1-af64-4ffb-9110-e70d297b9343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8313a1-af64-4ffb-9110-e70d297b9343.jpg?1",
             "name": "Battle Mastery",
             "text": "Enchant creature\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "e5f07546-cd6d-51fc-9402-a9b58dbf04d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85003365-7c5f-4283-995d-e466deef444b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85003365-7c5f-4283-995d-e466deef444b.jpg?1",
             "name": "Boonweaver Giant",
             "text": "When Boonweaver Giant enters the battlefield, you may search your graveyard, hand, and/or library for an Aura card and put it onto the battlefield attached to Boonweaver Giant. If you search your library this way, shuffle it.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "be2ff809-3e7c-5125-87d3-721456a3b8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5eefd2-d8ad-43b7-a5d9-6a2ad7f19b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5eefd2-d8ad-43b7-a5d9-6a2ad7f19b6e.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "d17a8045-110b-5e1b-ba7f-2f39809d5efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9b4111-ca9f-435b-81c4-0abf65d1384b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9b4111-ca9f-435b-81c4-0abf65d1384b.jpg?1",
             "name": "Constricting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, you may exile target creature an opponent controls until this creature leaves the battlefield.\"",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "14185911-f5ed-5a69-9962-4402c2eb6fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedfd1e-5073-47e2-9137-5f2bf4e436e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedfd1e-5073-47e2-9137-5f2bf4e436e3.jpg?1",
             "name": "Dauntless River Marshal",
             "text": "Dauntless River Marshal gets +1/+1 as long as you control an Island.\n{3}{U}: Tap target creature.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "473d6f6d-3760-5f7a-b3a5-9f979f381622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c8b3d-4675-49ad-8d86-8a5d6ca9cae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c8b3d-4675-49ad-8d86-8a5d6ca9cae5.jpg?1",
             "name": "Devouring Light",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "0f787f39-064c-5b96-9fff-db072c9a7001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c1ddf8-e38a-44df-9195-40e2b0d4cd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c1ddf8-e38a-44df-9195-40e2b0d4cd5f.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "ab224d3a-8097-5593-8d31-23f70560851a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9c2cc-2516-43d5-a7dc-27509f402077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9c2cc-2516-43d5-a7dc-27509f402077.jpg?1",
             "name": "Ephemeral Shields",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "8c241143-13c1-5e0a-9ca3-b4cd10d5db13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36341d37-064e-449e-8be7-a2716ae7e317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36341d37-064e-449e-8be7-a2716ae7e317.jpg?1",
             "name": "First Response",
             "text": "At the beginning of each upkeep, if you lost life last turn, put a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "8245e39e-2de6-5a9e-894f-7066475b9c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90488074-730c-47a3-9a4b-9fec1da775ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90488074-730c-47a3-9a4b-9fec1da775ad.jpg?1",
             "name": "Geist of the Moors",
             "text": "Flying",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "1653f7a5-80ba-5ca9-a5e1-0cce230135c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea54b97-9182-4d46-9d70-3cc7f9b18ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea54b97-9182-4d46-9d70-3cc7f9b18ada.jpg?1",
             "name": "Heliod's Pilgrim",
             "text": "When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "9ebe0ea4-f67d-5f0f-a030-9fd858ef55ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b44eb0d-5a3a-4624-aee4-11d6978fb4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b44eb0d-5a3a-4624-aee4-11d6978fb4b0.jpg?1",
             "name": "Hushwing Gryff",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nCreatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "1ab00080-a2f0-566c-acdc-a883e948519e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c73b7-a242-4fca-ab96-194750c984a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c73b7-a242-4fca-ab96-194750c984a7.jpg?1",
             "name": "Kinsbaile Skirmisher",
             "text": "When Kinsbaile Skirmisher enters the battlefield, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "465248ba-4e70-5413-a258-ab85197abd9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc7e2c3-6de6-453d-ade6-8571e7d53df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc7e2c3-6de6-453d-ade6-8571e7d53df3.jpg?1",
             "name": "Marked by Honor",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "3d72255f-0234-5950-9b4c-d62d5b52b611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a2d2f-ca94-463f-ada4-2b12bce6312f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a2d2f-ca94-463f-ada4-2b12bce6312f.jpg?1",
             "name": "Mass Calcify",
             "text": "Destroy all nonwhite creatures.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "7c9cee47-15d6-5d5d-86fd-8f6276984061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f5c19-9650-4fdc-a316-866eddd29c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f5c19-9650-4fdc-a316-866eddd29c1a.jpg?1",
             "name": "Meditation Puzzle",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nYou gain 8 life.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "3b8199a2-3127-500f-91dd-8931ea32020a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b6390b-607b-4e10-946d-a4ac24908e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b6390b-607b-4e10-946d-a4ac24908e08.jpg?1",
             "name": "Midnight Guard",
             "text": "Whenever another creature enters the battlefield, untap Midnight Guard.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "f02671a6-fcd4-5384-83d2-6cde763f9e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53555768-edad-4441-b6a7-ea2a7cb38abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53555768-edad-4441-b6a7-ea2a7cb38abd.jpg?1",
             "name": "Oppressive Rays",
             "text": "Enchant creature\nEnchanted creature can't attack or block unless its controller pays {3}.\nActivated abilities of enchanted creature cost {3} more to activate.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "d2e29bf7-f0d7-51cd-93c4-eef194a2602a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32e198-8ddd-44bc-be57-17e1ff72d666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32e198-8ddd-44bc-be57-17e1ff72d666.jpg?1",
             "name": "Oreskos Swiftclaw",
             "text": "",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "fa7554b7-9e57-533a-9976-85b82dcc0668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361c66c3-b4eb-48aa-a967-255a8db60977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361c66c3-b4eb-48aa-a967-255a8db60977.jpg?1",
             "name": "Paragon of New Dawns",
             "text": "Other white creatures you control get +1/+1.\n{W}, {T}: Another target white creature you control gains vigilance until end of turn. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -787,7 +787,7 @@
         },
         {
             "id": "f2e34f02-b6b2-515e-8da1-d1af853427be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ff99e-a23d-4440-8c5c-cfb4942f1906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ff99e-a23d-4440-8c5c-cfb4942f1906.jpg?1",
             "name": "Pillar of Light",
             "text": "Exile target creature with toughness 4 or greater.",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "2d6e2203-ecef-51c4-be99-66465c56ecee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32faaece-2775-4ab5-8376-d9f68959d5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32faaece-2775-4ab5-8376-d9f68959d5ac.jpg?1",
             "name": "Preeminent Captain",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Preeminent Captain attacks, you may put a Soldier creature card from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -854,7 +854,7 @@
         },
         {
             "id": "f60c8c59-7e44-5731-8d31-1b2de65b1946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a74f052-05f7-4e5e-a765-7882a00d0f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a74f052-05f7-4e5e-a765-7882a00d0f6a.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "3564ac46-0eb9-5ee6-a84d-5aa28d8274e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d812f-4936-48e4-acbe-abccf9ab21c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d812f-4936-48e4-acbe-abccf9ab21c7.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "95528b92-9bba-5699-a6c7-2bd6017384db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37b31b8-d868-4dff-9ab0-723ce41ee7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37b31b8-d868-4dff-9ab0-723ce41ee7e4.jpg?1",
             "name": "Resolute Archangel",
             "text": "Flying\nWhen Resolute Archangel enters the battlefield, if your life total is less than your starting life total, it becomes equal to your starting life total.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "d4b527c1-6f8b-50be-958d-11ec329757fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fccce64-abac-4b90-bbe5-dbba8434b3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fccce64-abac-4b90-bbe5-dbba8434b3b4.jpg?1",
             "name": "Return to the Ranks",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nReturn X target creature cards with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "e25e0350-7698-59b4-8691-99200a0e6d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6481bf34-192c-4102-8336-4d2d007d9e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6481bf34-192c-4102-8336-4d2d007d9e3c.jpg?1",
             "name": "Sanctified Charge",
             "text": "Creatures you control get +2/+1 until end of turn. White creatures you control also gain first strike until end of turn. (They deal combat damage before creatures without first strike.)",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "b1f52059-3699-574b-9daf-a91e9570ff68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3366f6c3-3899-4585-b6d2-24406703cf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3366f6c3-3899-4585-b6d2-24406703cf34.jpg?1",
             "name": "Selfless Cathar",
             "text": "{1}{W}, Sacrifice Selfless Cathar: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "e5a08f16-525a-5084-9edc-9a232c7898e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c857a8-7df6-4a50-ae58-4aab76d7d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c857a8-7df6-4a50-ae58-4aab76d7d58c.jpg?1",
             "name": "Seraph of the Masses",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nSeraph of the Masses's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "b9510039-5d9e-5257-b4a6-4f04069b83d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d750b4-b58f-4465-8648-c86d678e0936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d750b4-b58f-4465-8648-c86d678e0936.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "3f31f6dc-9239-5369-bbd3-c79cde2034b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e391d3-cf19-4f73-9d39-22587e0f3c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e391d3-cf19-4f73-9d39-22587e0f3c0d.jpg?1",
             "name": "Soul of Theros",
             "text": "Vigilance\n{4}{W}{W}: Creatures you control get +2/+2 and gain first strike and lifelink until end of turn.\n{4}{W}{W}, Exile Soul of Theros from your graveyard: Creatures you control get +2/+2 and gain first strike and lifelink until end of turn.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "8a6c3ab9-af93-595b-bd90-a2a29eaccfea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a298e-0a41-487d-b629-aa89d25baad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a298e-0a41-487d-b629-aa89d25baad0.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "d888bf72-89d5-5743-a204-498e409299a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b7a2-a4ff-485c-9fe5-04c88e5e8886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b7a2-a4ff-485c-9fe5-04c88e5e8886.jpg?1",
             "name": "Spectra Ward",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has protection from all colors. This effect doesn't remove Auras. (It can't be blocked, targeted, or dealt damage by anything that's white, blue, black, red, or green.)",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "af42c649-173c-59db-8a23-f237282ea2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2a3aaa-e78a-48cc-b7d3-7f65e467054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2a3aaa-e78a-48cc-b7d3-7f65e467054c.jpg?1",
             "name": "Spirit Bonds",
             "text": "Whenever a nontoken creature enters the battlefield under your control, you may pay {W}. If you do, put a 1/1 white Spirit creature token with flying onto the battlefield.\n{1}{W}, Sacrifice a Spirit: Target non-Spirit creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "77536ee6-2039-523a-a4f4-f4f631fbb70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d851b9-c290-4fcc-860d-a3250923b850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d851b9-c290-4fcc-860d-a3250923b850.jpg?1",
             "name": "Sungrace Pegasus",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "f10c15f3-189f-55fb-a36c-f871deeac9b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47b7386-168f-4b8e-9a26-9da6d697a501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47b7386-168f-4b8e-9a26-9da6d697a501.jpg?1",
             "name": "Tireless Missionaries",
             "text": "When Tireless Missionaries enters the battlefield, you gain 3 life.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "e1cd349e-bbe3-5c0d-afe7-3980c5f395bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6498d3-bf1f-4bf1-a602-7c21fb44c106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6498d3-bf1f-4bf1-a602-7c21fb44c106.jpg?1",
             "name": "Triplicate Spirits",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut three 1/1 white Spirit creature tokens with flying onto the battlefield. (They can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "e858e82d-2423-52b2-a94d-ef365bb23b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734e29ed-9732-4a94-909b-226bb4955930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734e29ed-9732-4a94-909b-226bb4955930.jpg?1",
             "name": "Wall of Essence",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Essence is dealt combat damage, you gain that much life.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "c0bccbb9-e1b3-5870-9f24-c62b0161d6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7406c-8c49-4ef6-a349-902833ea8ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7406c-8c49-4ef6-a349-902833ea8ec5.jpg?1",
             "name": "Warden of the Beyond",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWarden of the Beyond gets +2/+2 as long as an opponent owns a card in exile.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "51c7f491-5d0d-5fbc-a798-6aa610b6f511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e145e85d-1eaa-4ec6-9208-ca6491577302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e145e85d-1eaa-4ec6-9208-ca6491577302.jpg?1",
             "name": "Aeronaut Tinkerer",
             "text": "Aeronaut Tinkerer has flying as long as you control an artifact. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -1459,7 +1459,7 @@
         },
         {
             "id": "f3a57e02-f18c-5080-b980-ce8b69398cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f1b48f-6528-46bd-a384-2358af25e500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f1b48f-6528-46bd-a384-2358af25e500.jpg?1",
             "name": "Aetherspouts",
             "text": "For each attacking creature, its owner puts it on the top or bottom of his or her library.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "f15f4769-06fb-5aca-893e-c1e59d89d222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafd2e27-01d0-4894-886e-2b8776904ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafd2e27-01d0-4894-886e-2b8776904ab9.jpg?1",
             "name": "Amphin Pathmage",
             "text": "{2}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "6ae90bd5-d43e-537f-9de9-e2390997c8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cf5b23-9427-4313-8af8-abf2f3800948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cf5b23-9427-4313-8af8-abf2f3800948.jpg?1",
             "name": "Chasm Skulker",
             "text": "Whenever you draw a card, put a +1/+1 counter on Chasm Skulker.\nWhen Chasm Skulker dies, put X 1/1 blue Squid creature tokens with islandwalk onto the battlefield, where X is the number of +1/+1 counters on Chasm Skulker. (They can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "db066f95-c051-5aab-aa2b-a07f63979832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483189ed-d3d9-4612-ab95-f4ae4e091238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483189ed-d3d9-4612-ab95-f4ae4e091238.jpg?1",
             "name": "Chief Engineer",
             "text": "Artifact spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting an artifact spell pays for {1} or one mana of that creature's color.)",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "520a5983-f2bf-5b11-8f30-cc0037ab71bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef107d-c19f-4af3-9236-c66123075b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef107d-c19f-4af3-9236-c66123075b41.jpg?1",
             "name": "Chronostutter",
             "text": "Put target creature into its owner's library second from the top.",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "60206434-f0d3-50a1-a065-4be35ba216d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34cd305-d823-4996-9f8f-806386491f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34cd305-d823-4996-9f8f-806386491f5d.jpg?1",
             "name": "Coral Barrier",
             "text": "Defender (This creature can't attack.)\nWhen Coral Barrier enters the battlefield, put a 1/1 blue Squid creature token with islandwalk onto the battlefield. (It can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "1289f55c-a5d8-5a52-a299-5b26f55a3723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb110a55-c8f9-4627-82c2-edb10db4f380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb110a55-c8f9-4627-82c2-edb10db4f380.jpg?1",
             "name": "Diffusion Sliver",
             "text": "Whenever a Sliver creature you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "fad5e848-1a7b-5b22-80cc-1496395cc950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcc571a-6d9c-4408-a352-ff96f9472b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcc571a-6d9c-4408-a352-ff96f9472b44.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "3366e96c-774d-5fe4-9dd4-a174232d3edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd1187d-f43f-4508-b312-7af0bb8b9789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd1187d-f43f-4508-b312-7af0bb8b9789.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "4db5276f-45c8-5812-be57-1fbd6ae52874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f531a657-9e60-453a-b72c-2ba04913698f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f531a657-9e60-453a-b72c-2ba04913698f.jpg?1",
             "name": "Encrust",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
             "colours": [
@@ -1794,7 +1794,7 @@
         },
         {
             "id": "1acbc7df-417e-50a7-aa20-a4a6c9cebd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8351efc5-a392-4ec8-877f-15d5b3dc0929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8351efc5-a392-4ec8-877f-15d5b3dc0929.jpg?1",
             "name": "Ensoul Artifact",
             "text": "Enchant artifact\nEnchanted artifact is a creature with base power and toughness 5/5 in addition to its other types.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "431cc542-a074-54a5-8c1d-7f51ffd49d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619268d2-f7a8-48cd-b17b-197e82474b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619268d2-f7a8-48cd-b17b-197e82474b13.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "106ba125-ccbe-5e5c-a0a2-726596c4da8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520ad9d0-5f41-4183-a04e-58a61ad7202b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520ad9d0-5f41-4183-a04e-58a61ad7202b.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "24ca66fe-155e-5cd5-bfc4-c61821319d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf55bf-ee38-4e68-81ca-0fdb8af779ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf55bf-ee38-4e68-81ca-0fdb8af779ef.jpg?1",
             "name": "Glacial Crasher",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nGlacial Crasher can't attack unless there is a Mountain on the battlefield.",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "594f91ce-6f1e-593c-9db9-1c911b2e5905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd4dacb-912e-4e54-ab60-16a5262d0fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd4dacb-912e-4e54-ab60-16a5262d0fbb.jpg?1",
             "name": "Hydrosurge",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "5e191f94-fa5c-5567-84d6-e514bf6d2d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58545789-0f48-46d9-9cbc-ec9a0065d2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58545789-0f48-46d9-9cbc-ec9a0065d2f8.jpg?1",
             "name": "Illusory Angel",
             "text": "Flying\nCast Illusory Angel only if you've cast another spell this turn.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "d91f6808-812d-5dd6-b96e-edececbe5985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7021c9f7-82f3-4470-aaa1-8fa25e207069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7021c9f7-82f3-4470-aaa1-8fa25e207069.jpg?1",
             "name": "Into the Void",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "642fae34-37de-5cdb-acb7-cb2146283fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348d6493-681a-4ea9-9154-ea09f2648e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348d6493-681a-4ea9-9154-ea09f2648e8a.jpg?1",
             "name": "Invisibility",
             "text": "Enchant creature\nEnchanted creature can't be blocked except by Walls.",
             "colours": [
@@ -2065,7 +2065,7 @@
         },
         {
             "id": "dd773d02-bbb9-513e-8c30-63e17f1de08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99713bb4-186f-42b6-aa66-e94ec8858e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99713bb4-186f-42b6-aa66-e94ec8858e6a.jpg?1",
             "name": "Jace, the Living Guildpact",
             "text": "+1: Look at the top two cards of your library. Put one of them into your graveyard.\n\u22123: Return another target nonland permanent to its owner's hand.\n\u22128: Each player shuffles his or her hand and graveyard into his or her library. You draw seven cards.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "d061027d-78e8-566a-ab88-4d71f46b18b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4932ba-e272-4f22-89f5-a6153ca570b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4932ba-e272-4f22-89f5-a6153ca570b5.jpg?1",
             "name": "Jace's Ingenuity",
             "text": "Draw three cards.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "27e420f2-8baf-57b6-86a5-8a6f498eb547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425da4aa-4374-41b0-a665-568a04f57c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425da4aa-4374-41b0-a665-568a04f57c38.jpg?1",
             "name": "Jalira, Master Polymorphist",
             "text": "{2}{U}, {T}, Sacrifice another creature: Reveal cards from the top of your library until you reveal a nonlegendary creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2170,7 +2170,7 @@
         },
         {
             "id": "b4ed4f59-0449-5733-a380-e884282017dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af346ac-32a6-49a8-986d-834b2c8c0478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af346ac-32a6-49a8-986d-834b2c8c0478.jpg?1",
             "name": "Jorubai Murk Lurker",
             "text": "Jorubai Murk Lurker gets +1/+1 as long as you control a Swamp.\n{1}{B}: Target creature gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "59593000-6afe-52a8-91ab-c95d9871bf2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a964c5ed-b0ed-47cb-a0f0-79d28ef7f70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a964c5ed-b0ed-47cb-a0f0-79d28ef7f70b.jpg?1",
             "name": "Kapsho Kitefins",
             "text": "Flying\nWhenever Kapsho Kitefins or another creature enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "fb173ffb-86bd-5ae0-b320-04f78bf9965d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b1720b-ab7a-4b52-a6d0-11c4fc573d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b1720b-ab7a-4b52-a6d0-11c4fc573d17.jpg?1",
             "name": "Master of Predicaments",
             "text": "Flying\nWhenever Master of Predicaments deals combat damage to a player, choose a card in your hand. That player guesses whether the card's converted mana cost is greater than 4. If the player guessed wrong, you may cast the card without paying its mana cost.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "c0360f65-eef9-5847-be34-a4e613086561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3160d28-230d-4bce-9050-6ab5895302ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3160d28-230d-4bce-9050-6ab5895302ee.jpg?1",
             "name": "Mercurial Pretender",
             "text": "You may have Mercurial Pretender enter the battlefield as a copy of any creature you control except it gains \"{2}{U}{U}: Return this creature to its owner's hand.\"",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "1b51f13b-4756-56d4-8e3d-45f96a52dc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10fafb6-3476-4cf1-a762-42fec628a579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10fafb6-3476-4cf1-a762-42fec628a579.jpg?1",
             "name": "Military Intelligence",
             "text": "Whenever you attack with two or more creatures, draw a card.",
             "colours": [
@@ -2339,7 +2339,7 @@
         },
         {
             "id": "729d307b-df81-58d0-b5ca-2af306526cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037d6277-1fc3-41a4-ade6-7cca10535b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037d6277-1fc3-41a4-ade6-7cca10535b0f.jpg?1",
             "name": "Mind Sculpt",
             "text": "Target opponent puts the top seven cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "abb6edfb-944a-5943-a018-f4a6e1ae78a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2ba6d-ada1-4f06-b135-37606b6588fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2ba6d-ada1-4f06-b135-37606b6588fc.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "ec9ed521-5658-5177-9d1d-e349b0273e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d239c66-3e3f-4dc4-bede-f264864583b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d239c66-3e3f-4dc4-bede-f264864583b1.jpg?1",
             "name": "Nimbus of the Isles",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "00ec9ff0-097b-5033-8c4f-527c8f73aacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afc32ed-c1a9-4c37-bfe0-562818c046fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afc32ed-c1a9-4c37-bfe0-562818c046fc.jpg?1",
             "name": "Paragon of Gathering Mists",
             "text": "Other blue creatures you control get +1/+1.\n{U}, {T}: Another target blue creature you control gains flying until end of turn.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "9bba4c6c-9acc-541d-b78e-6495db59967a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284cd35c-056f-45c2-822f-d50527f79625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284cd35c-056f-45c2-822f-d50527f79625.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "7deb4f3c-63e4-543f-874b-a3f773035fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83f369b-515a-43ba-8905-bc12e148beeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83f369b-515a-43ba-8905-bc12e148beeb.jpg?1",
             "name": "Polymorphist's Jest",
             "text": "Until end of turn, each creature target player controls loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "97cbce39-20d9-59c2-bdc7-abf88de72dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278fbdb9-51e3-4ed6-bcc5-c5b86f06c216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278fbdb9-51e3-4ed6-bcc5-c5b86f06c216.jpg?1",
             "name": "Quickling",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhen Quickling enters the battlefield, sacrifice it unless you return another creature you control to its owner's hand.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "f57c24a1-684f-5e3d-ab9f-5267cb7317fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac8a7c0-d935-4a60-ac32-dde73f5c75da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac8a7c0-d935-4a60-ac32-dde73f5c75da.jpg?1",
             "name": "Research Assistant",
             "text": "{3}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "74b1456f-bc46-59fa-ae7a-7bd6ebbf5fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7332471-c052-4a24-abf1-a5805d685658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7332471-c052-4a24-abf1-a5805d685658.jpg?1",
             "name": "Soul of Ravnica",
             "text": "Flying\n{5}{U}{U}: Draw a card for each color among permanents you control.\n{5}{U}{U}, Exile Soul of Ravnica from your graveyard: Draw a card for each color among permanents you control.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "3be527f3-df8c-5bfd-a091-a4dc0f37f848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13770d-dddb-4b78-9cd3-4a0dc50472f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13770d-dddb-4b78-9cd3-4a0dc50472f4.jpg?1",
             "name": "Statute of Denial",
             "text": "Counter target spell. If you control a blue creature, draw a card, then discard a card.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "39c5eb98-1a63-5814-89e0-42ae4a5fc692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fde11c-ee26-4005-87f0-300f2be838fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fde11c-ee26-4005-87f0-300f2be838fc.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "685dfa07-71d0-5611-8af2-e57f8be55168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6867e6-1785-4eb2-bc7b-86bb671fae21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6867e6-1785-4eb2-bc7b-86bb671fae21.jpg?1",
             "name": "Turn to Frog",
             "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "d43e0721-1b97-5123-9956-ca5199213409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94efe426-0fb2-4a24-9b50-914e48105b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94efe426-0fb2-4a24-9b50-914e48105b57.jpg?1",
             "name": "Void Snare",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "3c13bfe9-16ab-5e0a-9f4b-ed6bd7aef9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a80677-0d0e-440f-a64f-10ebdb5014a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a80677-0d0e-440f-a64f-10ebdb5014a2.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "cfe086f4-4380-5003-8b06-f436e909be11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea98c545-42d7-47f6-a155-4db092c178c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea98c545-42d7-47f6-a155-4db092c178c1.jpg?1",
             "name": "Welkin Tern",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWelkin Tern can block only creatures with flying.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "acde45b1-52e0-5cff-8273-a3a74fa169ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2513fe72-4e20-49e6-9970-839f1c635792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2513fe72-4e20-49e6-9970-839f1c635792.jpg?1",
             "name": "Accursed Spirit",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "28a34679-948a-5a07-9d0e-0bfc4fb230c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32efcfad-818c-4485-9022-cf94403f370b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32efcfad-818c-4485-9022-cf94403f370b.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "84a658ac-ddeb-58c2-b2ad-379095245b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454a83d-f018-446c-89fb-21460924e589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454a83d-f018-446c-89fb-21460924e589.jpg?1",
             "name": "Blood Host",
             "text": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Blood Host and you gain 2 life.",
             "colours": [
@@ -2941,7 +2941,7 @@
         },
         {
             "id": "8adbd8d2-8671-5ec0-876f-4e38d19e3cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d80cc4-f3be-4306-8126-e60f7b00d384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d80cc4-f3be-4306-8126-e60f7b00d384.jpg?1",
             "name": "Carrion Crow",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCarrion Crow enters the battlefield tapped.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "043a5dbc-c7f3-5c24-b378-162b5aae9966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ddf81d-1746-41a7-951c-0bd68954505d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ddf81d-1746-41a7-951c-0bd68954505d.jpg?1",
             "name": "Caustic Tar",
             "text": "Enchant land\nEnchanted land has \"{T}: Target player loses 3 life.\"",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "59e48fc1-2269-5bae-ac88-8302dfa72525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff5d53c-5698-4d09-b557-89d10ce4fbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff5d53c-5698-4d09-b557-89d10ce4fbbf.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "6980ca6d-b2a9-537f-922c-8441de6e7641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b7d05-19d7-4765-9bf8-05a7cb539c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b7d05-19d7-4765-9bf8-05a7cb539c3f.jpg?1",
             "name": "Covenant of Blood",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCovenant of Blood deals 4 damage to target creature or player and you gain 4 life.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "815f0247-c95a-57bc-9aba-bd5eea2779e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c1ba3-8b7c-413b-865d-0ca4b2f55903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c1ba3-8b7c-413b-865d-0ca4b2f55903.jpg?1",
             "name": "Crippling Blight",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 and can't block.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "fbf77d69-5702-5755-a341-422a5ece50ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31c94f3-c45b-4ced-b523-15e80ae1a82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31c94f3-c45b-4ced-b523-15e80ae1a82d.jpg?1",
             "name": "Cruel Sadist",
             "text": "{B}, {T}, Pay 1 life: Put a +1/+1 counter on Cruel Sadist.\n{2}{B}, {T}, Remove X +1/+1 counters from Cruel Sadist: Cruel Sadist deals X damage to target creature.",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "5320338e-2c6d-546a-a68a-83c43967922e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70ceae6-8b25-4ce2-b89b-45300401fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70ceae6-8b25-4ce2-b89b-45300401fec5.jpg?1",
             "name": "Endless Obedience",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "8764d598-e63b-5bd0-abf0-ce0096e71163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9228ea53-4aea-45f5-bec5-4a0629ec8825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9228ea53-4aea-45f5-bec5-4a0629ec8825.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\" (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "bb9045ee-522d-565b-a087-1d0ab9a806b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96a9227-14ce-4d35-b5e6-0d0c657207c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96a9227-14ce-4d35-b5e6-0d0c657207c0.jpg?1",
             "name": "Feast on the Fallen",
             "text": "At the beginning of each upkeep, if an opponent lost life last turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "f6ef2f1e-0531-5b11-b714-ca48ee0a297e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3125137-bd18-488e-b45e-6fc23828c5bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3125137-bd18-488e-b45e-6fc23828c5bd.jpg?1",
             "name": "Festergloom",
             "text": "Nonblack creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "a1f54f0c-bcd6-5e14-a964-12099f284cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b2e842-6c92-47b0-bed4-e0e64485f168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b2e842-6c92-47b0-bed4-e0e64485f168.jpg?1",
             "name": "Flesh to Dust",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "b2bcc436-c93a-52cf-973d-8d08e7a59fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98951dea-df48-4f1b-a7cf-f14b2d36300f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98951dea-df48-4f1b-a7cf-f14b2d36300f.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "4b56094c-6ed4-5bb1-a5c2-f8e551bb3499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f2c2f6-d07f-42af-9944-70d3dac8348c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f2c2f6-d07f-42af-9944-70d3dac8348c.jpg?1",
             "name": "In Garruk's Wake",
             "text": "Destroy all creatures you don't control and all planeswalkers you don't control.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "7845e532-4f03-5f82-ac6b-d3452aeddd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4d8-6d18-4588-8da9-cd32658071f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4d8-6d18-4588-8da9-cd32658071f0.jpg?1",
             "name": "Indulgent Tormentor",
             "text": "Flying\nAt the beginning of your upkeep, draw a card unless target opponent sacrifices a creature or pays 3 life.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "8927b64c-0ef2-5118-884a-2cecb78345e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888ca52b-1270-4587-804d-1d08b07d7c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888ca52b-1270-4587-804d-1d08b07d7c5d.jpg?1",
             "name": "Leeching Sliver",
             "text": "Whenever a Sliver you control attacks, defending player loses 1 life.",
             "colours": [
@@ -3441,7 +3441,7 @@
         },
         {
             "id": "fbec4c9b-c249-5e8a-b045-584315953101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6087f146-f468-472a-b248-fc7386ea3e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6087f146-f468-472a-b248-fc7386ea3e63.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n\u22122: Search your library for a card, then shuffle your library and put that card on top of it.\n\u22128: Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "b872231f-b0ea-5f28-8cb0-637520b626e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718c56b8-b5e8-4c8a-a4a2-8c1c6d368d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718c56b8-b5e8-4c8a-a4a2-8c1c6d368d13.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "025e196f-f895-5aab-a338-c3ea3a26a2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c5bca1-b0f0-4032-b2ed-71bdbaa41993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c5bca1-b0f0-4032-b2ed-71bdbaa41993.jpg?1",
             "name": "Necrobite",
             "text": "Target creature gains deathtouch until end of turn. Regenerate it. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat. Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "0f7f1ded-12f8-5716-930f-88e07d9e7cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2045ddd-fa05-4769-aa7a-17b9ab8d6fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2045ddd-fa05-4769-aa7a-17b9ab8d6fc0.jpg?1",
             "name": "Necrogen Scudder",
             "text": "Flying\nWhen Necrogen Scudder enters the battlefield, you lose 3 life.",
             "colours": [
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "dac7db24-3e93-551f-a9bf-c301bb00903b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6a8b3e-2709-4036-838b-56cc82b0d917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6a8b3e-2709-4036-838b-56cc82b0d917.jpg?1",
             "name": "Necromancer's Assistant",
             "text": "When Necromancer's Assistant enters the battlefield, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "9d071b9b-a0c6-5f99-b2c8-20efe90bf6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba07e86-fdef-4f51-808e-7780883eefe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba07e86-fdef-4f51-808e-7780883eefe3.jpg?1",
             "name": "Necromancer's Stockpile",
             "text": "{1}{B}, Discard a creature card: Draw a card. If the discarded card was a Zombie card, put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "0f88b86c-d01a-524e-89c2-17c46fb5f6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11da48a7-903d-43f5-8085-1b3790ed079a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11da48a7-903d-43f5-8085-1b3790ed079a.jpg?1",
             "name": "Nightfire Giant",
             "text": "Nightfire Giant gets +1/+1 as long as you control a Mountain.\n{4}{R}: Nightfire Giant deals 2 damage to target creature or player.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "14b20197-ca30-553c-8a17-600457115e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b28dc-c0d1-4b88-b18e-074ac0464e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b28dc-c0d1-4b88-b18e-074ac0464e03.jpg?1",
             "name": "Ob Nixilis, Unshackled",
             "text": "Flying, trample\nWhenever an opponent searches his or her library, that player sacrifices a creature and loses 10 life.\nWhenever another creature dies, put a +1/+1 counter on Ob Nixilis, Unshackled.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "301485d4-f07b-5d2a-b77d-55abe605e462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d7de75-b6e1-44f5-ae1c-e095b41e8d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d7de75-b6e1-44f5-ae1c-e095b41e8d0b.jpg?1",
             "name": "Paragon of Open Graves",
             "text": "Other black creatures you control get +1/+1.\n{2}{B}, {T}: Another target black creature you control gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "dce0ddaf-843a-5170-8b3a-147786d1a520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8e2442-0677-4ea6-8d70-4c39fbb552ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8e2442-0677-4ea6-8d70-4c39fbb552ed.jpg?1",
             "name": "Rotfeaster Maggot",
             "text": "When Rotfeaster Maggot enters the battlefield, exile target creature card from a graveyard. You gain life equal to that card's toughness.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "df962ee1-2a84-53c7-b293-38a98f2e86af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4911e9-01e6-4c41-9f2a-dfc25bedb2f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4911e9-01e6-4c41-9f2a-dfc25bedb2f7.jpg?1",
             "name": "Shadowcloak Vampire",
             "text": "Pay 2 life: Shadowcloak Vampire gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "59c6265e-f03c-5664-8d2b-2c9200b1981b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9cead6-7806-4c51-abd1-62c3b8f366b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9cead6-7806-4c51-abd1-62c3b8f366b5.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3849,7 +3849,7 @@
         },
         {
             "id": "b2911ae4-ce62-5a14-a963-b4e3cf66d5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9147b57e-e172-49ac-a556-91efbde0d325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9147b57e-e172-49ac-a556-91efbde0d325.jpg?1",
             "name": "Soul of Innistrad",
             "text": "Deathtouch\n{3}{B}{B}: Return up to three target creature cards from your graveyard to your hand.\n{3}{B}{B}, Exile Soul of Innistrad from your graveyard: Return up to three target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "20a3d5db-6d29-548c-90aa-fdab5e02cc52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c061b448-ee90-4c7d-a9c6-754a7c15966c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c061b448-ee90-4c7d-a9c6-754a7c15966c.jpg?1",
             "name": "Stab Wound",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 2 life.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "1ed57e7e-1462-5100-aade-e59e73ada56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d2b046-59bc-4e39-94ce-981179307bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d2b046-59bc-4e39-94ce-981179307bd3.jpg?1",
             "name": "Stain the Mind",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nName a nonland card. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "5f7d2f7d-a571-5bfd-9d52-46627b4c98d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8723f6-96b1-4441-8a57-435fb82d6db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8723f6-96b1-4441-8a57-435fb82d6db4.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "6467a383-2ab0-5f68-908f-0f811176de13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06e6c8-05c0-4d87-9961-605b888bc794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06e6c8-05c0-4d87-9961-605b888bc794.jpg?1",
             "name": "Ulcerate",
             "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "4aa3bb35-2533-5214-865d-d09a310055ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fd00bb-b247-45b7-9cb2-0d65b92c0360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fd00bb-b247-45b7-9cb2-0d65b92c0360.jpg?1",
             "name": "Unmake the Graves",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -4047,7 +4047,7 @@
         },
         {
             "id": "5ca2bdd3-3f45-5036-8b56-b5f62bbbd26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d46b81-3131-4561-beca-ccf4a0973610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d46b81-3131-4561-beca-ccf4a0973610.jpg?1",
             "name": "Wall of Limbs",
             "text": "Defender (This creature can't attack.)\nWhenever you gain life, put a +1/+1 counter on Wall of Limbs.\n{5}{B}{B}, Sacrifice Wall of Limbs: Target player loses X life, where X is Wall of Limbs's power.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "03134532-9322-58a5-9c4e-91562775c412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d8f7d-3981-47c1-b7b8-748277fa452f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d8f7d-3981-47c1-b7b8-748277fa452f.jpg?1",
             "name": "Waste Not",
             "text": "Whenever an opponent discards a creature card, put a 2/2 black Zombie creature token onto the battlefield.\nWhenever an opponent discards a land card, add {B}{B} to your mana pool.\nWhenever an opponent discards a noncreature, nonland card, draw a card.",
             "colours": [
@@ -4114,7 +4114,7 @@
         },
         {
             "id": "37df03cd-bd43-595c-8d88-b5bdf297c973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9f3b3b-de16-4ae5-844e-1373e0f84469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9f3b3b-de16-4ae5-844e-1373e0f84469.jpg?1",
             "name": "Witch's Familiar",
             "text": "",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "6695874d-d51a-55c4-860f-1d1fd89e8a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a9252-1e97-4e85-9648-66050f301f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a9252-1e97-4e85-9648-66050f301f8a.jpg?1",
             "name": "Xathrid Slyblade",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\n{3}{B}: Until end of turn, Xathrid Slyblade loses hexproof and gains first strike and deathtouch. (It deals combat damage before creatures without first strike. Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "dcac1eff-f85b-592b-81ed-2e180146038f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b39bdf-445c-40a8-8999-1e8fbbda4ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b39bdf-445c-40a8-8999-1e8fbbda4ae9.jpg?1",
             "name": "Zof Shade",
             "text": "{2}{B}: Zof Shade gets +2/+2 until end of turn.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "6e380915-268c-5c54-8cd5-51a2b4e4d6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe513d1-2509-4051-ba85-49a19479fa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe513d1-2509-4051-ba85-49a19479fa5c.jpg?1",
             "name": "Act on Impulse",
             "text": "Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. (If you cast a spell this way, you still pay its costs. You can play a land this way only if you have an available land play remaining.)",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "a012db1a-4b0e-519b-9c94-0c3756127148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15a3f1a-83af-4541-8d1c-bf7844f969c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15a3f1a-83af-4541-8d1c-bf7844f969c9.jpg?1",
             "name": "Aggressive Mining",
             "text": "You can't play lands.\nSacrifice a land: Draw two cards. Activate this ability only once each turn.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "95d8e6cd-3869-58fd-9e7a-e6f0c178513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dacedc-f532-43b3-a783-e1dc7ccea53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dacedc-f532-43b3-a783-e1dc7ccea53b.jpg?1",
             "name": "Altac Bloodseeker",
             "text": "Whenever a creature an opponent controls dies, Altac Bloodseeker gets +2/+0 and gains first strike and haste until end of turn. (It deals combat damage before creatures without first strike, and it can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "249428cf-5533-5ac7-bbbe-82b211d5801b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78b8268-b090-4012-a3ba-5daab491f78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78b8268-b090-4012-a3ba-5daab491f78d.jpg?1",
             "name": "Belligerent Sliver",
             "text": "Sliver creatures you control have \"This creature can't be blocked except by two or more creatures.\"",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "3c522c51-7989-54e2-9c79-5a969438dae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34774f01-5976-4ed1-b0f4-71dc7a679999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34774f01-5976-4ed1-b0f4-71dc7a679999.jpg?1",
             "name": "Blastfire Bolt",
             "text": "Blastfire Bolt deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "2535a39e-e60b-5f2b-8ea9-46c9257d4ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e29b2b-5fe3-4dee-b247-10cd139fe2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e29b2b-5fe3-4dee-b247-10cd139fe2d0.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "c72570e3-fb5d-5523-b62e-3d195ab7167a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a640a5b-c638-4ae6-ad02-eb5fe20f4662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a640a5b-c638-4ae6-ad02-eb5fe20f4662.jpg?1",
             "name": "Brood Keeper",
             "text": "Whenever an Aura becomes attached to Brood Keeper, put a 2/2 red Dragon creature token with flying onto the battlefield. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "c72858c9-61af-5485-870d-87f94e822b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058a7eb-0f78-46a4-bea5-afdfe920264f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058a7eb-0f78-46a4-bea5-afdfe920264f.jpg?1",
             "name": "Burning Anger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to target creature or player.\"",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "5b9af6c1-4171-5068-9d30-50f0e0a56327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cc35d-4e97-4be2-8c53-cce68c3374ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cc35d-4e97-4be2-8c53-cce68c3374ca.jpg?1",
             "name": "Chandra, Pyromaster",
             "text": "+1: Chandra, Pyromaster deals 1 damage to target player and 1 damage to up to one target creature that player controls. That creature can't block this turn.\n0: Exile the top card of your library. You may play it this turn.\n\u22127: Exile the top ten cards of your library. Choose an instant or sorcery card exiled this way and copy it three times. You may cast the copies without paying their mana costs.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "61d228aa-2646-5398-8bfa-77f0150b8aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cbfd4a-ac95-4191-84f9-199a9e1807c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cbfd4a-ac95-4191-84f9-199a9e1807c4.jpg?1",
             "name": "Circle of Flame",
             "text": "Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "e6028078-2a4e-5c25-b058-bca9ae7e5dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3738b0d1-06c0-4d6d-a307-478d994ff36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3738b0d1-06c0-4d6d-a307-478d994ff36e.jpg?1",
             "name": "Clear a Path",
             "text": "Destroy target creature with defender.",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "29034743-0bd3-51b7-af43-a39b57abfa46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2190a-5afd-4be1-810a-ac9a8178d629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2190a-5afd-4be1-810a-ac9a8178d629.jpg?1",
             "name": "Cone of Flame",
             "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "1c0787f8-d526-5a42-8721-3eb25ef443bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536b8104-9d8d-444b-8535-62bcbe279de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536b8104-9d8d-444b-8535-62bcbe279de2.jpg?1",
             "name": "Crowd's Favor",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "b54dd950-f210-552c-84bc-d6f6c566b939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd0f742-5cdc-4fa9-b995-df6380c1755e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd0f742-5cdc-4fa9-b995-df6380c1755e.jpg?1",
             "name": "Crucible of Fire",
             "text": "Dragon creatures you control get +3/+3.",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "d16a2caf-6eea-53e2-a180-3212488b3edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbf66a4-8fd4-4c87-89e2-c6ad6c4de7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbf66a4-8fd4-4c87-89e2-c6ad6c4de7ab.jpg?1",
             "name": "Forge Devil",
             "text": "When Forge Devil enters the battlefield, it deals 1 damage to target creature and 1 damage to you.",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "39b4f1c1-4072-5676-a606-1d7b07e0c51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08835364-f82d-4047-8f35-bd8b64760dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08835364-f82d-4047-8f35-bd8b64760dfc.jpg?1",
             "name": "Foundry Street Denizen",
             "text": "Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "3f461d73-ce4a-5a1d-a39a-78417547a0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfe382-3a80-45f3-a022-54739c4b69a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfe382-3a80-45f3-a022-54739c4b69a6.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "6c190695-f971-55b8-8746-df3b0fe338cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0c422-4201-4d6f-9df7-659e8b78b541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0c422-4201-4d6f-9df7-659e8b78b541.jpg?1",
             "name": "Generator Servant",
             "text": "{T}, Sacrifice Generator Servant: Add {2} to your mana pool. If that mana is spent on a creature spell, it gains haste until end of turn. (That creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "8c8b051d-3483-5d71-b852-6692bb7711d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e1d85a-18e5-4c6a-85fd-a009bd8fda38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e1d85a-18e5-4c6a-85fd-a009bd8fda38.jpg?1",
             "name": "Goblin Kaboomist",
             "text": "At the beginning of your upkeep, put a colorless artifact token named Land Mine onto the battlefield with \"{R}, Sacrifice this artifact: This artifact deals 2 damage to target attacking creature without flying.\" Then flip a coin. If you lose the flip, Goblin Kaboomist deals 2 damage to itself.",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "cbe90bd0-ef73-5053-9e78-9b627416598c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9c697e-d2c0-413b-9142-ecf5d7cf5322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9c697e-d2c0-413b-9142-ecf5d7cf5322.jpg?1",
             "name": "Goblin Rabblemaster",
             "text": "Other Goblin creatures you control attack each turn if able.\nAt the beginning of combat on your turn, put a 1/1 red Goblin creature token with haste onto the battlefield.\nWhenever Goblin Rabblemaster attacks, it gets +1/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "de31a38e-fc01-5249-a598-e6ada7102c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9097ec4a-6c0e-4c27-8910-29ac47612031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9097ec4a-6c0e-4c27-8910-29ac47612031.jpg?1",
             "name": "Goblin Roughrider",
             "text": "",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "9c34e975-c1fc-503b-8559-a49d5ac7fdfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a81cc6-2660-4501-b589-f8c3a26ee483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a81cc6-2660-4501-b589-f8c3a26ee483.jpg?1",
             "name": "Hammerhand",
             "text": "Enchant creature\nWhen Hammerhand enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste. (It can attack and {T} no matter when it came under your control.)",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "8a039478-97f2-52e4-bd5c-050972358e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a79bcd-573c-4882-bfab-29eef00b07a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a79bcd-573c-4882-bfab-29eef00b07a4.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "ede78a9e-4746-5ca3-872f-c679be95d1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4c4a0f-0ee4-422d-b807-f64b77dd6831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4c4a0f-0ee4-422d-b807-f64b77dd6831.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle your library.\nWhen Hoarding Dragon dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "44ab2877-d92c-503c-b835-7d63d7020c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721a42f4-5884-418f-b1f9-7cb651559ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721a42f4-5884-418f-b1f9-7cb651559ad0.jpg?1",
             "name": "Inferno Fist",
             "text": "Enchant creature you control\nEnchanted creature gets +2/+0.\n{R}, Sacrifice Inferno Fist: Inferno Fist deals 2 damage to target creature or player.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "74318fce-59e2-5578-ab1d-0b201447d9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4189a909-2e20-4dc7-894c-21446da5b0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4189a909-2e20-4dc7-894c-21446da5b0cf.jpg?1",
             "name": "Kird Chieftain",
             "text": "Kird Chieftain gets +1/+1 as long as you control a Forest.\n{4}{G}: Target creature gets +2/+2 and gains trample until end of turn. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5094,7 +5094,7 @@
         },
         {
             "id": "5f4fc218-2ef5-5d01-bba6-2103583625a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ceeb0-03b6-48bc-a084-069176ebccb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ceeb0-03b6-48bc-a084-069176ebccb2.jpg?1",
             "name": "Krenko's Enforcer",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "98c4f2f6-9776-50cc-b09d-f682f9e703e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a0e9e-0e45-4af1-9f03-6fd3652933f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a0e9e-0e45-4af1-9f03-6fd3652933f9.jpg?1",
             "name": "Kurkesh, Onakke Ancient",
             "text": "Whenever you activate an ability of an artifact, if it isn't a mana ability, you may pay {R}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -5166,7 +5166,7 @@
         },
         {
             "id": "862523ba-e2d2-5070-800d-51bd97af561c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b35586-e56d-4e7a-9a4e-8879529c082d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b35586-e56d-4e7a-9a4e-8879529c082d.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -5198,7 +5198,7 @@
         },
         {
             "id": "99b53baf-8c10-51f2-ba34-4140663e22ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5603e1f-593c-45f0-9e13-fe3492464443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5603e1f-593c-45f0-9e13-fe3492464443.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to target creature or player.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "e82b8837-40bb-5233-9261-c60a2a1fde88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c63c02-a75b-4880-b9fa-6f4bcf90ede5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c63c02-a75b-4880-b9fa-6f4bcf90ede5.jpg?1",
             "name": "Might Makes Right",
             "text": "At the beginning of combat on your turn, if you control each creature on the battlefield with the greatest power, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "3c18bb5d-48ec-518e-ab42-ef50e70bc5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d48ac-1685-4061-9907-31248ae38cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d48ac-1685-4061-9907-31248ae38cc9.jpg?1",
             "name": "Miner's Bane",
             "text": "{2}{R}: Miner's Bane gets +1/+0 and gains trample until end of turn. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "80908ba2-9abc-5773-a7b1-1cd49b1ab414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad97067-2b6b-4e60-817c-6414e2739806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad97067-2b6b-4e60-817c-6414e2739806.jpg?1",
             "name": "Paragon of Fierce Defiance",
             "text": "Other red creatures you control get +1/+1.\n{R}, {T}: Another target red creature you control gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "031bc72b-dbaa-5456-9060-113c3639a559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8f65b-022f-4599-a416-e82a6d45ceba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8f65b-022f-4599-a416-e82a6d45ceba.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "f7abb4b4-7ceb-5158-8441-a2c190986f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00bd3a-833e-4226-a73e-17c9043c0994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00bd3a-833e-4226-a73e-17c9043c0994.jpg?1",
             "name": "Scrapyard Mongrel",
             "text": "As long as you control an artifact, Scrapyard Mongrel gets +2/+0 and has trample. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "a10010e0-ffbb-517f-b460-49a48851da55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0798cec-aaa3-4a52-99f8-d000ca7d59db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0798cec-aaa3-4a52-99f8-d000ca7d59db.jpg?1",
             "name": "Shrapnel Blast",
             "text": "As an additional cost to cast Shrapnel Blast, sacrifice an artifact.\nShrapnel Blast deals 5 damage to target creature or player.",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "1663c039-c872-5c55-b50c-a631af6c8447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc18f7-f4d4-421e-869e-c2e7598a9c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc18f7-f4d4-421e-869e-c2e7598a9c77.jpg?1",
             "name": "Siege Dragon",
             "text": "Flying\nWhen Siege Dragon enters the battlefield, destroy all Walls your opponents control.\nWhenever Siege Dragon attacks, if defending player controls no Walls, it deals 2 damage to each creature without flying that player controls.",
             "colours": [
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "023e35cd-d022-5d9b-81a6-dc8ae1879484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03543d10-202b-4b07-a34b-64216a745d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03543d10-202b-4b07-a34b-64216a745d84.jpg?1",
             "name": "Soul of Shandalar",
             "text": "First strike\n{3}{R}{R}: Soul of Shandalar deals 3 damage to target player and 3 damage to up to one target creature that player controls.\n{3}{R}{R}, Exile Soul of Shandalar from your graveyard: Soul of Shandalar deals 3 damage to target player and 3 damage to up to one target creature that player controls.",
             "colours": [
@@ -5500,7 +5500,7 @@
         },
         {
             "id": "230743a8-197f-55af-a7ab-5b192f731384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94c000-52e0-4215-83af-6351dc43e636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94c000-52e0-4215-83af-6351dc43e636.jpg?1",
             "name": "Stoke the Flames",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nStoke the Flames deals 4 damage to target creature or player.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "36d71457-4b27-5e2e-bc32-4fb083d83faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d3cde7-ac3f-4178-908f-0f51c4379b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d3cde7-ac3f-4178-908f-0f51c4379b44.jpg?1",
             "name": "Thundering Giant",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5566,7 +5566,7 @@
         },
         {
             "id": "d367d8db-fe95-56bb-acf9-73ace73c2ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea18c3f-0ca3-44ba-b8f5-87ce1797c58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea18c3f-0ca3-44ba-b8f5-87ce1797c58f.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -5600,7 +5600,7 @@
         },
         {
             "id": "533ee92e-e7fb-5bd2-9fdb-fc55bfd8d535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8ac968-3d00-40d8-80b5-e6fe08025de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8ac968-3d00-40d8-80b5-e6fe08025de2.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "493cbc3f-596b-5b16-af5f-4838e4fe48ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b24ea58-0690-45d7-a84b-265b6277b59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b24ea58-0690-45d7-a84b-265b6277b59a.jpg?1",
             "name": "Ancient Silverback",
             "text": "{G}: Regenerate Ancient Silverback. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "2c1fd672-4750-5d93-8802-366f0e4aa9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49270b2-ba15-4268-adb3-16d09c09adee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49270b2-ba15-4268-adb3-16d09c09adee.jpg?1",
             "name": "Back to Nature",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -5700,7 +5700,7 @@
         },
         {
             "id": "5f9bd31a-f7e8-57a0-9021-923bc9918e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd814ce3-9555-4e9d-a212-e40717f4e546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd814ce3-9555-4e9d-a212-e40717f4e546.jpg?1",
             "name": "Carnivorous Moss-Beast",
             "text": "{5}{G}{G}: Put a +1/+1 counter on Carnivorous Moss-Beast.",
             "colours": [
@@ -5736,7 +5736,7 @@
         },
         {
             "id": "158cc3f5-dcc4-5839-b5ab-95745b1a87a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90341fb4-ac97-43ff-ae2d-0fe5995e7fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90341fb4-ac97-43ff-ae2d-0fe5995e7fd7.jpg?1",
             "name": "Charging Rhino",
             "text": "Charging Rhino can't be blocked by more than one creature.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "724311e3-c71b-5a7e-99fd-c5a758d92991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7695cc-7b6b-499d-9f5a-729082fc72e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7695cc-7b6b-499d-9f5a-729082fc72e9.jpg?1",
             "name": "Chord of Calling",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5802,7 +5802,7 @@
         },
         {
             "id": "12164058-1c8d-5809-b3ec-ac7f5ee2ac2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5ca6a-f91d-443d-ad84-6fe1e80bfb51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5ca6a-f91d-443d-ad84-6fe1e80bfb51.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "680a6374-4f12-5949-b00a-4fb66fa891a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0c7e7-81f5-4e75-8120-95488fd6ff60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0c7e7-81f5-4e75-8120-95488fd6ff60.jpg?1",
             "name": "Feral Incarnation",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut three 3/3 green Beast creature tokens onto the battlefield.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "2fe5e89c-edab-5529-baab-9a3c22cb28f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56b1112-ed25-46dd-85c8-58cc7a913198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56b1112-ed25-46dd-85c8-58cc7a913198.jpg?1",
             "name": "Gather Courage",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "dab6fc6a-0478-575e-859b-be424741b863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659eb716-bf21-4c0f-9a9a-906236ef536c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659eb716-bf21-4c0f-9a9a-906236ef536c.jpg?1",
             "name": "Genesis Hydra",
             "text": "When you cast Genesis Hydra, reveal the top X cards of your library. You may put a nonland permanent card with converted mana cost X or less from among them onto the battlefield. Then shuffle the rest into your library.\nGenesis Hydra enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "cd2951f3-6559-5221-bff8-14c506a3bf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4784dbd3-8ae0-45a0-8cde-908fba6af9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4784dbd3-8ae0-45a0-8cde-908fba6af9d2.jpg?1",
             "name": "Hornet Nest",
             "text": "Defender (This creature can't attack.)\nWhenever Hornet Nest is dealt damage, put that many 1/1 green Insect creature tokens with flying and deathtouch onto the battlefield. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "167c5417-720b-5d30-9c50-4247b44db8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494f761a-dbc4-4cfa-a258-e4de46bb825e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494f761a-dbc4-4cfa-a258-e4de46bb825e.jpg?1",
             "name": "Hornet Queen",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Hornet Queen enters the battlefield, put four 1/1 green Insect creature tokens with flying and deathtouch onto the battlefield.",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "0e2f1527-403c-56be-8b66-dca3a53b4a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546686cb-4cb1-4107-bbf5-0af943236ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546686cb-4cb1-4107-bbf5-0af943236ad2.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "ba73d19f-5339-5761-b91e-da6eba9ca425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2971049-b916-4b76-b18f-8650d8d2545d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2971049-b916-4b76-b18f-8650d8d2545d.jpg?1",
             "name": "Hunter's Ambush",
             "text": "Prevent all combat damage that would be dealt by nongreen creatures this turn.",
             "colours": [
@@ -6068,7 +6068,7 @@
         },
         {
             "id": "1dfe8f9e-908a-59c7-b504-cdc8d71fcea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb5a98-94f4-419f-850b-e3a01f17080f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb5a98-94f4-419f-850b-e3a01f17080f.jpg?1",
             "name": "Invasive Species",
             "text": "When Invasive Species enters the battlefield, return another permanent you control to its owner's hand.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "4db72e2f-cb8d-5853-80d7-fe52b2a512f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabe0865-5420-463e-9138-ccd805be8b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabe0865-5420-463e-9138-ccd805be8b31.jpg?1",
             "name": "Kalonian Twingrove",
             "text": "Kalonian Twingrove's power and toughness are each equal to the number of Forests you control.\nWhen Kalonian Twingrove enters the battlefield, put a green Treefolk Warrior creature token onto the battlefield with \"This creature's power and toughness are each equal to the number of Forests you control.\"",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "2e2d46a8-b34c-5728-bdd0-3b5f472a143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d964629-6d1d-4253-ac23-92f2199323b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d964629-6d1d-4253-ac23-92f2199323b4.jpg?1",
             "name": "Life's Legacy",
             "text": "As an additional cost to cast Life's Legacy, sacrifice a creature.\nDraw cards equal to the sacrificed creature's power.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "b9e34285-6221-5869-b556-8ed5dcdf10a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca21890c-68be-4929-913e-d28ace6b40a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca21890c-68be-4929-913e-d28ace6b40a7.jpg?1",
             "name": "Living Totem",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Living Totem enters the battlefield, you may put a +1/+1 counter on another target creature.",
             "colours": [
@@ -6204,7 +6204,7 @@
         },
         {
             "id": "c82773e5-b3fe-5b3c-bc8c-75b5f3da0989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a232db-4ee3-4e9a-bd97-722106f7a7b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a232db-4ee3-4e9a-bd97-722106f7a7b6.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6236,7 +6236,7 @@
         },
         {
             "id": "c3e2aad5-9b48-5343-b497-07d87ec84d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8702c15-5f32-453e-8d58-cadfcdaeb3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8702c15-5f32-453e-8d58-cadfcdaeb3dc.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -6270,7 +6270,7 @@
         },
         {
             "id": "68449e8c-ed30-5fb9-a5ee-b002f1e0e2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb2476-488b-4610-8567-f0456601f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb2476-488b-4610-8567-f0456601f7fd.jpg?1",
             "name": "Nissa, Worldwaker",
             "text": "+1: Target land you control becomes a 4/4 Elemental creature with trample. It's still a land.\n+1: Untap up to four target Forests.\n\u22127: Search your library for any number of basic land cards, put them onto the battlefield, then shuffle your library. Those lands become 4/4 Elemental creatures with trample. They're still lands.",
             "colours": [
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "69d2e990-ecac-56e7-92f2-cdfdb47b6c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c5cdd-9075-4bb7-88ae-9dc77a637700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c5cdd-9075-4bb7-88ae-9dc77a637700.jpg?1",
             "name": "Nissa's Expedition",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6338,7 +6338,7 @@
         },
         {
             "id": "899c917b-96ce-569d-ae25-6bfcbd27085b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01702401-9dfe-4e52-9d6d-cf594261b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01702401-9dfe-4e52-9d6d-cf594261b009.jpg?1",
             "name": "Overwhelm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -6370,7 +6370,7 @@
         },
         {
             "id": "cb563cb2-1732-52fa-b632-3d2431bf5fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c3fcca-480f-4acf-b74f-0f37b46fa799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c3fcca-480f-4acf-b74f-0f37b46fa799.jpg?1",
             "name": "Paragon of Eternal Wilds",
             "text": "Other green creatures you control get +1/+1.\n{G}, {T}: Another target green creature you control gains trample until end of turn. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "3245dbeb-5ca2-5df8-b6c0-4b47741e172d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e6eedf-8f5a-407e-b15b-48e19df20bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e6eedf-8f5a-407e-b15b-48e19df20bed.jpg?1",
             "name": "Phytotitan",
             "text": "When Phytotitan dies, return it to the battlefield tapped under its owner's control at the beginning of his or her next upkeep.",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "fd49a6df-b444-5439-8876-f97de55f695f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3de170-fdc5-4d46-9421-bb12460225ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3de170-fdc5-4d46-9421-bb12460225ca.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6472,7 +6472,7 @@
         },
         {
             "id": "c7292adc-6cc6-56d6-9167-79cd29948b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01388e24-d66f-40a8-af41-0f84dd8ed3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01388e24-d66f-40a8-af41-0f84dd8ed3fe.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "81d2cdc8-e64b-5536-b4bb-bd0d91ecda7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47227cfa-4cef-4874-b331-d2f628f29dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47227cfa-4cef-4874-b331-d2f628f29dae.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -6539,7 +6539,7 @@
         },
         {
             "id": "9fd0eced-8010-5b52-8e0c-5498dd2e8191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343994a6-b4f1-4ec5-997a-307b26601434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343994a6-b4f1-4ec5-997a-307b26601434.jpg?1",
             "name": "Restock",
             "text": "Return two target cards from your graveyard to your hand. Exile Restock.",
             "colours": [
@@ -6571,7 +6571,7 @@
         },
         {
             "id": "9a605baf-511a-5b0c-abd9-e5d891b05250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f985df-177f-4535-b681-f9bc74045b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f985df-177f-4535-b681-f9bc74045b39.jpg?1",
             "name": "Roaring Primadox",
             "text": "At the beginning of your upkeep, return a creature you control to its owner's hand.",
             "colours": [
@@ -6605,7 +6605,7 @@
         },
         {
             "id": "5a2c9068-9342-503b-bae4-270e756e437b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995238-79cc-4381-9595-71ef11ea1e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995238-79cc-4381-9595-71ef11ea1e36.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "6cd8f499-0eaa-5f6c-8d6e-24648cab52b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be07e97-2ffc-40ad-a676-a74b8b680ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be07e97-2ffc-40ad-a676-a74b8b680ea1.jpg?1",
             "name": "Satyr Wayfinder",
             "text": "When Satyr Wayfinder enters the battlefield, reveal the top four cards of your library. You may put a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6673,7 +6673,7 @@
         },
         {
             "id": "20fc62e0-c584-51a3-83f1-cdbc68799402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e974df6-d78a-43ea-ada5-17c53fcca97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e974df6-d78a-43ea-ada5-17c53fcca97b.jpg?1",
             "name": "Shaman of Spring",
             "text": "When Shaman of Spring enters the battlefield, draw a card.",
             "colours": [
@@ -6708,7 +6708,7 @@
         },
         {
             "id": "359aaa6d-2b67-5bb4-937e-93a683bb4ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40b8f1-428a-4244-ad8a-4e757aea2b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40b8f1-428a-4244-ad8a-4e757aea2b45.jpg?1",
             "name": "Siege Wurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "1f2108c6-2c99-573d-b254-2b0a5ac90fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a2514-3c36-463a-bc0a-67ab4fb2666e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a2514-3c36-463a-bc0a-67ab4fb2666e.jpg?1",
             "name": "Soul of Zendikar",
             "text": "Reach\n{3}{G}{G}: Put a 3/3 green Beast creature token onto the battlefield.\n{3}{G}{G}, Exile Soul of Zendikar from your graveyard: Put a 3/3 green Beast creature token onto the battlefield.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "7da5e8a6-1cd0-5077-b8f2-1c0a949fa585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9925c5-98d5-4eb9-8aaa-a96b63a5812d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9925c5-98d5-4eb9-8aaa-a96b63a5812d.jpg?1",
             "name": "Sunblade Elf",
             "text": "Sunblade Elf gets +1/+1 as long as you control a Plains.\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6812,7 +6812,7 @@
         },
         {
             "id": "4fa71fe1-6fa6-56b7-b145-3500648242b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e511b7-6d41-4aa2-b7bd-d4d6e075a819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e511b7-6d41-4aa2-b7bd-d4d6e075a819.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6844,7 +6844,7 @@
         },
         {
             "id": "6689b3f5-7cc4-532d-811d-4d5ddbb8d648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc77e-f003-4c25-8394-cda22e3ea039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc77e-f003-4c25-8394-cda22e3ea039.jpg?1",
             "name": "Undergrowth Scavenger",
             "text": "Undergrowth Scavenger enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "c6d148a0-4884-516a-a29c-784c9cc41728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db38bd9-bf58-41ca-84b9-f3582670143e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db38bd9-bf58-41ca-84b9-f3582670143e.jpg?1",
             "name": "Venom Sliver",
             "text": "Sliver creatures you control have deathtouch. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "7ed7148e-a2b6-511e-a159-c6c895e42f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec869b-fe2c-4f30-ae36-9ce5bdc555e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec869b-fe2c-4f30-ae36-9ce5bdc555e1.jpg?1",
             "name": "Verdant Haven",
             "text": "Enchant land\nWhen Verdant Haven enters the battlefield, you gain 2 life.\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "f3a258bd-be66-521a-8840-5cdbe6328a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578f064-e9f8-4e87-8f46-7536af6c144e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578f064-e9f8-4e87-8f46-7536af6c144e.jpg?1",
             "name": "Vineweft",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\n{4}{G}: Return Vineweft from your graveyard to your hand.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "77047ddb-d497-5829-85eb-a57bd5a5d096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ec859-59a6-45b2-bbd8-6f89453fe3ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ec859-59a6-45b2-bbd8-6f89453fe3ec.jpg?1",
             "name": "Wall of Mulch",
             "text": "Defender (This creature can't attack.)\n{G}, Sacrifice a Wall: Draw a card.",
             "colours": [
@@ -7015,7 +7015,7 @@
         },
         {
             "id": "ddd53358-202f-5f4a-8c98-615b9baca9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cd97cd-6d6e-4512-a050-6851b7527567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cd97cd-6d6e-4512-a050-6851b7527567.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "{2}{G}, {T}, Put a verse counter on Yisan, the Wanderer Bard: Search your library for a creature card with converted mana cost equal to the number of verse counters on Yisan, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "b1d509b5-cff4-5370-a31e-b89316a0bf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3957b43-4d7e-41f9-b7a1-6f57d6603ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3957b43-4d7e-41f9-b7a1-6f57d6603ab8.jpg?1",
             "name": "Garruk, Apex Predator",
             "text": "+1: Destroy another target planeswalker.\n+1: Put a 3/3 black Beast creature token with deathtouch onto the battlefield.\n\u22123: Destroy target creature. You gain life equal to its toughness.\n\u22128: Target opponent gets an emblem with \"Whenever a creature attacks you, it gets +5/+5 and gains trample until end of turn.\"",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "46d18321-fa23-5a87-89fe-e26080efbb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4106de-20c7-48cf-8a36-8c6913b46c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4106de-20c7-48cf-8a36-8c6913b46c89.jpg?1",
             "name": "Sliver Hivelord",
             "text": "Sliver creatures you control have indestructible. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "0db612cb-8e95-5fca-ba12-d488ac193f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec56727f-6280-4625-96b9-9b599af0dada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec56727f-6280-4625-96b9-9b599af0dada.jpg?1",
             "name": "Avarice Amulet",
             "text": "Equipped creature gets +2/+0 and has vigilance and \"At the beginning of your upkeep, draw a card.\"\nWhen equipped creature dies, target opponent gains control of Avarice Amulet.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "725f6e58-5590-52ed-9e29-0f97f4c4faa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eddc4ee6-7855-4dc7-9488-5e019609bd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eddc4ee6-7855-4dc7-9488-5e019609bd09.jpg?1",
             "name": "Brawler's Plate",
             "text": "Equipped creature gets +2/+2 and has trample. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "366a86c6-ffd9-5209-bf54-cfe94b435e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ba6d7d-fad0-4af1-be12-44be326a031e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ba6d7d-fad0-4af1-be12-44be326a031e.jpg?1",
             "name": "Bronze Sable",
             "text": "",
             "colours": [],
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "cdca5406-72b1-534d-b2d7-d8ce3e1ff54b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415cc0e-979e-42cc-a56d-88d13153a7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415cc0e-979e-42cc-a56d-88d13153a7de.jpg?1",
             "name": "The Chain Veil",
             "text": "At the beginning of your end step, if you didn't activate a loyalty ability of a planeswalker this turn, you lose 2 life.\n{4}, {T}: For each planeswalker you control, you may activate one of its loyalty abilities once this turn as though none of its loyalty abilities have been activated this turn.",
             "colours": [],
@@ -7256,7 +7256,7 @@
         },
         {
             "id": "b8829628-1444-50ae-8693-dd6b801ad847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38e70c-51ca-419a-b99d-a603a7f39290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38e70c-51ca-419a-b99d-a603a7f39290.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender (This creature can't attack.)\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "65569aa2-507f-5e23-b610-ec4879a48c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53498863-2e69-4b98-b0f0-7ae13dc1033e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53498863-2e69-4b98-b0f0-7ae13dc1033e.jpg?1",
             "name": "Grindclock",
             "text": "{T}: Put a charge counter on Grindclock.\n{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of charge counters on Grindclock.",
             "colours": [],
@@ -7315,7 +7315,7 @@
         },
         {
             "id": "0a589878-8ba9-5e86-9c87-4c6bcbd66569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7daae6f-fe19-4f42-b85d-75c996abe1be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7daae6f-fe19-4f42-b85d-75c996abe1be.jpg?1",
             "name": "Haunted Plate Mail",
             "text": "Equipped creature gets +4/+4.\n{0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate this ability only if you control no creatures.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "6d81c679-6106-5884-ace3-c24256a76606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46f4b0-1992-4060-8f21-643698d476f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46f4b0-1992-4060-8f21-643698d476f7.jpg?1",
             "name": "Hot Soup",
             "text": "Equipped creature can't be blocked.\nWhenever equipped creature is dealt damage, destroy it.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "3f71e2c9-d152-5a2a-af41-8a43c9f84743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc014e5-21a3-4023-a8ed-61329a96fb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc014e5-21a3-4023-a8ed-61329a96fb4e.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -7406,7 +7406,7 @@
         },
         {
             "id": "bf3e622a-f8b5-510e-a6b5-69f7ab375cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a39c1a-7615-4ac8-8984-b8459d201cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a39c1a-7615-4ac8-8984-b8459d201cb2.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to target creature or player.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7434,7 +7434,7 @@
         },
         {
             "id": "d7013de2-d4fc-5d1d-80f7-55044df6e1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7865a7-8fe2-4b5d-a625-91585d1b7d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7865a7-8fe2-4b5d-a625-91585d1b7d4a.jpg?1",
             "name": "Obelisk of Urd",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nAs Obelisk of Urd enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +2/+2.",
             "colours": [],
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "50c7953f-b0ef-5332-b8e7-9487f62494cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee98e86c-ac16-4159-8982-ed14d282811a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee98e86c-ac16-4159-8982-ed14d282811a.jpg?1",
             "name": "Ornithopter",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -7493,7 +7493,7 @@
         },
         {
             "id": "d2e911e5-ab9e-533b-84d5-95ed33d1c3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5f1810-a852-454f-b1d6-eb40ea4e0148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5f1810-a852-454f-b1d6-eb40ea4e0148.jpg?1",
             "name": "Perilous Vault",
             "text": "{5}, {T}, Exile Perilous Vault: Exile all nonland permanents.",
             "colours": [],
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "812d0333-8337-58f0-8e94-b520bde882ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ede7b6-ee03-4b4f-bc59-1759b02bd5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ede7b6-ee03-4b4f-bc59-1759b02bd5d5.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, name a nonland card.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -7553,7 +7553,7 @@
         },
         {
             "id": "d6ce54da-63aa-5581-813b-d1196e1a0bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c97632-3cf1-4b79-9d18-d8991654dcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c97632-3cf1-4b79-9d18-d8991654dcca.jpg?1",
             "name": "Profane Memento",
             "text": "Whenever a creature card is put into an opponent's graveyard from anywhere, you gain 1 life.",
             "colours": [],
@@ -7581,7 +7581,7 @@
         },
         {
             "id": "2c824aac-2cb4-5e31-a0b4-429fc33bfbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a35bd7-8f0f-421a-948d-810513e6b0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a35bd7-8f0f-421a-948d-810513e6b0a0.jpg?1",
             "name": "Rogue's Gloves",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7611,7 +7611,7 @@
         },
         {
             "id": "ed8f5aa5-ff54-50e4-a232-d45a9bdb1056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05fde97-ab24-40c9-a1db-8844c3e62fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05fde97-ab24-40c9-a1db-8844c3e62fc3.jpg?1",
             "name": "Sacred Armory",
             "text": "{2}: Target creature gets +1/+0 until end of turn.",
             "colours": [],
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "45bafed8-11ba-52df-8dec-3619846349b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6352ded6-14f5-47d6-b1cb-518f270e44e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6352ded6-14f5-47d6-b1cb-518f270e44e7.jpg?1",
             "name": "Scuttling Doom Engine",
             "text": "Scuttling Doom Engine can't be blocked by creatures with power 2 or less.\nWhen Scuttling Doom Engine dies, it deals 6 damage to target opponent.",
             "colours": [],
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "daf7b749-0ae4-51a9-b79d-029674c5221a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c2cc25-f3cd-4bfb-b9cc-53d1f42cd69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c2cc25-f3cd-4bfb-b9cc-53d1f42cd69a.jpg?1",
             "name": "Shield of the Avatar",
             "text": "If a source would deal damage to equipped creature, prevent X of that damage, where X is the number of creatures you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "f987df06-ee90-51dc-a6f6-2a642928f886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d37dec-98d6-4815-8f3e-7de26817990c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d37dec-98d6-4815-8f3e-7de26817990c.jpg?1",
             "name": "Soul of New Phyrexia",
             "text": "Trample\n{5}: Permanents you control gain indestructible until end of turn.\n{5}, Exile Soul of New Phyrexia from your graveyard: Permanents you control gain indestructible until end of turn.",
             "colours": [],
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "a2b01e8d-2406-560e-8719-b066b0724486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a341a4-8177-41cd-a3bc-eff5dee48c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a341a4-8177-41cd-a3bc-eff5dee48c94.jpg?1",
             "name": "Staff of the Death Magus",
             "text": "Whenever you cast a black spell or a Swamp enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7760,7 +7760,7 @@
         },
         {
             "id": "15e2730f-01da-5b94-9e6e-6cce5caf5e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd137db-296a-4c17-ba46-8b189d96c1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd137db-296a-4c17-ba46-8b189d96c1f9.jpg?1",
             "name": "Staff of the Flame Magus",
             "text": "Whenever you cast a red spell or a Mountain enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "378fc5f3-6d35-5a4c-89ce-7a697c68a171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf76bee3-2b69-4c7b-9b7c-1a9f4bbcfde0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf76bee3-2b69-4c7b-9b7c-1a9f4bbcfde0.jpg?1",
             "name": "Staff of the Mind Magus",
             "text": "Whenever you cast a blue spell or an Island enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "2f5a6c70-e2af-5e93-89d1-8ad7777701f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f51ff4-9b5c-4e26-b811-4000a4c8f965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f51ff4-9b5c-4e26-b811-4000a4c8f965.jpg?1",
             "name": "Staff of the Sun Magus",
             "text": "Whenever you cast a white spell or a Plains enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7844,7 +7844,7 @@
         },
         {
             "id": "40d50087-00eb-5a11-a908-e767f39e6c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64f31e8-0b49-4510-a4df-2e0bea793d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64f31e8-0b49-4510-a4df-2e0bea793d3e.jpg?1",
             "name": "Staff of the Wild Magus",
             "text": "Whenever you cast a green spell or a Forest enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7872,7 +7872,7 @@
         },
         {
             "id": "d9a15df0-88c4-583e-b7a9-df64b41fd413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314bb937-1b1e-4daa-8b9e-2d282e8f433b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314bb937-1b1e-4daa-8b9e-2d282e8f433b.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "86053aa6-7671-5e99-b9dd-5c2df302fe61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088045cd-8aec-43ff-bb8f-d17927b79cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088045cd-8aec-43ff-bb8f-d17927b79cfb.jpg?1",
             "name": "Tyrant's Machine",
             "text": "{4}, {T}: Tap target creature.",
             "colours": [],
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "9e4a1b6d-9248-535b-a919-b48d377feeb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0175bafa-dc9f-464c-8f9e-dd4131732652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0175bafa-dc9f-464c-8f9e-dd4131732652.jpg?1",
             "name": "Will-Forged Golem",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "9494d613-3a08-5c18-8b88-10f881bf0d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc57d63-5a6d-4ff2-8079-544b2c4eade1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc57d63-5a6d-4ff2-8079-544b2c4eade1.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "9b17dbac-ab14-5a87-8858-1c7b430bcaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ad0c9-77a7-4d18-9707-1e5e3d4cf7e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ad0c9-77a7-4d18-9707-1e5e3d4cf7e8.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "1a63188f-f604-59e3-991d-b463ab186c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad4395-5766-44c3-b5af-3d65d49a3333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad4395-5766-44c3-b5af-3d65d49a3333.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this land.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "947c738b-c813-51ff-badf-f3bfcee95dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2553b8ae-e5af-40ba-8b3b-d5652919c9bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2553b8ae-e5af-40ba-8b3b-d5652919c9bb.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8078,7 +8078,7 @@
         },
         {
             "id": "b6ae79c0-f142-58ed-9786-26958a1f42bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75b4559-8946-45bb-a580-318a13d1e89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75b4559-8946-45bb-a580-318a13d1e89e.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -8109,7 +8109,7 @@
         },
         {
             "id": "38f1cf4a-a253-55ac-8371-f5ee49fb2dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8090e148-2550-4156-89e3-052abda9f0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8090e148-2550-4156-89e3-052abda9f0e7.jpg?1",
             "name": "Radiant Fountain",
             "text": "When Radiant Fountain enters the battlefield, you gain 2 life.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -8137,7 +8137,7 @@
         },
         {
             "id": "7a499f0d-8def-5ff4-98cf-68afb3c6f019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07ded43-682b-417e-bcb4-0ef5186fd9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07ded43-682b-417e-bcb4-0ef5186fd9ad.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "ea931a9f-0967-5e98-ba61-da2d712fbfdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cef7ce-aa9f-4659-ac24-394c5ab9f77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cef7ce-aa9f-4659-ac24-394c5ab9f77c.jpg?1",
             "name": "Sliver Hive",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a Sliver spell.\n{5}, {T}: Put a 1/1 colorless Sliver creature token onto the battlefield. Activate this ability only if you control a Sliver.",
             "colours": [],
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "f84c5cd7-7c32-5033-b504-63b71fcb1503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa48b15c-7312-4f3f-b7aa-b2ad98234bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa48b15c-7312-4f3f-b7aa-b2ad98234bf1.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "2a3f20cd-bb50-563b-b1a8-c0ef7aa493d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb82b9a-0376-4d75-ba03-76b422aa9099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb82b9a-0376-4d75-ba03-76b422aa9099.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -8257,7 +8257,7 @@
         },
         {
             "id": "ed18787d-3787-57fd-b94b-cb67bd0ffb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e211fe-e843-4d05-a97d-b208b616179a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e211fe-e843-4d05-a97d-b208b616179a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "68b8b068-627a-50fe-83a4-4ce73ffd39b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe68013-a519-4dce-a28b-c6304dba8fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe68013-a519-4dce-a28b-c6304dba8fac.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "bacc7ee0-2dfd-5e8a-ba58-2b9c03b60968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1358ef70-1dae-4bb6-a2e2-88ff30d43b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1358ef70-1dae-4bb6-a2e2-88ff30d43b99.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "67e395eb-4512-57b8-896c-f6f5a3a12fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c9899-65c2-4f1b-8716-ab144766b385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c9899-65c2-4f1b-8716-ab144766b385.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "e13a9a69-1e87-58df-b080-857af126541f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9f55eb-2c9e-4bc7-a67c-ab2eeb127201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9f55eb-2c9e-4bc7-a67c-ab2eeb127201.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "44bdd4e9-c0ea-5052-8b3f-92d9a6ef4cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ffcc0-ca8a-43ad-8e9e-31e5b94dd6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ffcc0-ca8a-43ad-8e9e-31e5b94dd6e6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8485,7 +8485,7 @@
         },
         {
             "id": "799e2180-2c02-5a81-b731-75c301488e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d4230f-f024-4e5e-9054-0d32dace05cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d4230f-f024-4e5e-9054-0d32dace05cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "7fa850fe-7a80-5161-9c34-9729660c360c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a880c1ee-01e0-479f-a1c3-2739da8ac6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a880c1ee-01e0-479f-a1c3-2739da8ac6b9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "19e3d2ff-c9f4-5152-849c-1518ace33dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719b570c-1773-4a0c-8ea3-e75b1c14c35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719b570c-1773-4a0c-8ea3-e75b1c14c35f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8599,7 +8599,7 @@
         },
         {
             "id": "48d98898-d237-5bf1-b93c-706d21638ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148e45-3163-4cf3-a729-600729f671a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148e45-3163-4cf3-a729-600729f671a5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8637,7 +8637,7 @@
         },
         {
             "id": "d0a4d56a-8848-548a-b235-4e34cb50e13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e7a70-672e-400d-971b-63dd128f5229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e7a70-672e-400d-971b-63dd128f5229.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8675,7 +8675,7 @@
         },
         {
             "id": "40560c20-55e5-592f-85e5-6a8796ad1620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d11a38-3b0e-44d4-bf7d-28bed6303693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d11a38-3b0e-44d4-bf7d-28bed6303693.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8713,7 +8713,7 @@
         },
         {
             "id": "90704df5-237d-5b10-8c84-71d40b496f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa712fb1-8840-4e26-9211-2653919fed91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa712fb1-8840-4e26-9211-2653919fed91.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8751,7 +8751,7 @@
         },
         {
             "id": "0647ab41-7046-5e6d-9f87-30434c0a2c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5960dfdf-cba1-47d4-8e7c-f87f814b07ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5960dfdf-cba1-47d4-8e7c-f87f814b07ed.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8789,7 +8789,7 @@
         },
         {
             "id": "8213db54-e2aa-5781-8097-114cfbb515bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23596e2-72ea-478d-baa8-3df0e81b4cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23596e2-72ea-478d-baa8-3df0e81b4cdd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8827,7 +8827,7 @@
         },
         {
             "id": "fdb41e14-580f-54fe-a394-1b2ae73488f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc281cb-a583-45a7-85d1-c10d5900b966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc281cb-a583-45a7-85d1-c10d5900b966.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8865,7 +8865,7 @@
         },
         {
             "id": "4cf609ef-ab9b-5640-89dc-76cfc72c961f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d6124-1678-46b1-a12a-69644c689e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d6124-1678-46b1-a12a-69644c689e29.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "671b1dfe-a9d8-5664-aab7-4420282c53e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ecd546-2638-4338-86b5-59ab3f1303a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ecd546-2638-4338-86b5-59ab3f1303a3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8941,7 +8941,7 @@
         },
         {
             "id": "54ab0c57-87f9-52c0-a1f2-09d1402e67ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb07e09-bff6-45fd-b408-fd957f69a994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb07e09-bff6-45fd-b408-fd957f69a994.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "690ffb60-16a4-56fa-b8dd-fcd6ad1472c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ff824-f9a6-457a-b1ff-c06b246d06d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ff824-f9a6-457a-b1ff-c06b246d06d9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "d82efc36-676c-58cf-9b3a-816c7dfbcb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ae5f07-c869-49cf-b7c3-fe607ad3ee35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ae5f07-c869-49cf-b7c3-fe607ad3ee35.jpg?1",
             "name": "Aegis Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aegis Angel enters the battlefield, another target permanent gains indestructible for as long as you control Aegis Angel. (Effects that say \"destroy\" don't destroy it. A creature with indestructible can't be destroyed by damage.)",
             "colours": [
@@ -9050,7 +9050,7 @@
         },
         {
             "id": "6cff899f-86ac-590f-a093-7e1ea22100e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529d320-1240-429f-bf7a-4be29079b8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529d320-1240-429f-bf7a-4be29079b8bf.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -9081,7 +9081,7 @@
         },
         {
             "id": "91389a02-1e95-5a1f-b9f6-68cbd22851ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28c4e2-7b9b-436d-95cf-9c757eacf091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28c4e2-7b9b-436d-95cf-9c757eacf091.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -9112,7 +9112,7 @@
         },
         {
             "id": "5fab3acd-e8d7-5040-8494-90ef9a0d2b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2d063-a9b1-4693-9841-923210bf09d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2d063-a9b1-4693-9841-923210bf09d7.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9145,7 +9145,7 @@
         },
         {
             "id": "a5f66571-2b8d-5b2b-9ffa-05fc00f13656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bf9f71-c592-4064-b7b3-172c26e5605b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bf9f71-c592-4064-b7b3-172c26e5605b.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -9176,7 +9176,7 @@
         },
         {
             "id": "866f6531-70d7-5f47-8aac-bdd0b4829a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d241c7-d753-411e-9456-667fb015ee28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d241c7-d753-411e-9456-667fb015ee28.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9209,7 +9209,7 @@
         },
         {
             "id": "d8f5344a-adce-5f8d-85bc-c2605a17b661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04970ef-7aa5-42ca-9bed-5c89d55b7e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04970ef-7aa5-42ca-9bed-5c89d55b7e4d.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "2e9e9ced-487f-5d75-b95e-113c5c3fa00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28be-091d-47f9-b41e-8926cd182a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28be-091d-47f9-b41e-8926cd182a63.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -9276,7 +9276,7 @@
         },
         {
             "id": "d785e0bf-0a0c-5082-bac0-f0fbfb33a3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccba369f-f4d1-493d-bc5f-271b7e4d8090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccba369f-f4d1-493d-bc5f-271b7e4d8090.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -9309,7 +9309,7 @@
         },
         {
             "id": "edef2772-796e-5e26-84ef-4aa9720e9530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44f74e9-aaa6-41d3-8070-bf0ead4a7d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44f74e9-aaa6-41d3-8070-bf0ead4a7d77.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "65c48806-83ee-5479-8096-2875dc3fa207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972d0b03-8602-4ada-86b9-4262941bae67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972d0b03-8602-4ada-86b9-4262941bae67.jpg?1",
             "name": "Seismic Strike",
             "text": "Seismic Strike deals damage to target creature equal to the number of Mountains you control.",
             "colours": [
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "376873b0-c22c-53f0-b355-3c14945b18ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c76430-c5c9-46a4-9a3b-9bbf259e4b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c76430-c5c9-46a4-9a3b-9bbf259e4b38.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -9406,7 +9406,7 @@
         },
         {
             "id": "9bd33bdb-1597-5e13-8e27-bd2eea7bd65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b625203-6c50-4b14-928c-6b0aec1375a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b625203-6c50-4b14-928c-6b0aec1375a2.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -9440,7 +9440,7 @@
         },
         {
             "id": "8c740ea3-0166-590e-884f-e16afac6b0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91725e5-9e36-461b-b523-8490418107f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91725e5-9e36-461b-b523-8490418107f2.jpg?1",
             "name": "Garruk's Packleader",
             "text": "Whenever another creature with power 3 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -9473,7 +9473,7 @@
         },
         {
             "id": "a451239a-4e12-5b74-8a03-51c81303700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd192de8-12b7-4c3f-913c-de9f26fdbb20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd192de8-12b7-4c3f-913c-de9f26fdbb20.jpg?1",
             "name": "Terra Stomper",
             "text": "Terra Stomper can't be countered.\nTrample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "e53a3c81-f470-5ab4-9d41-b9cb03131099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec96e95-5580-4110-86ec-561007ab0f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec96e95-5580-4110-86ec-561007ab0f1e.jpg?1",
             "name": "Sliver",
             "text": "",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "891a1cf6-59bc-582f-abee-6600303f17dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83070-573c-4a06-9a2d-1263d7600b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83070-573c-4a06-9a2d-1263d7600b66.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "9f066067-1b37-593d-8881-c492916f10cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dbf439-793a-4fe6-9d4e-0333f482e364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dbf439-793a-4fe6-9d4e-0333f482e364.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "d339f647-44e2-57e0-8b22-b3277ae3d2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c366546-6da9-4daa-b0c3-1401ace5568c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c366546-6da9-4daa-b0c3-1401ace5568c.jpg?1",
             "name": "Squid",
             "text": "",
             "colours": [
@@ -9638,7 +9638,7 @@
         },
         {
             "id": "1f94e698-6428-5165-9437-8a45a5d824f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48bf5f-5fe1-41ef-a63d-85daacd941f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48bf5f-5fe1-41ef-a63d-85daacd941f7.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "1e851ec5-fc7c-52e0-b201-7c350377c8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a1ebd-a0ac-4a03-8ac2-4678d6fb03fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a1ebd-a0ac-4a03-8ac2-4678d6fb03fa.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "64acacdf-5d42-5a9d-bcff-dcbd2ddca08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9661e23a-8914-493b-a08a-e9cd29b4666e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9661e23a-8914-493b-a08a-e9cd29b4666e.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "dcbda724-f208-5d0d-9faa-bb0f1eac5b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98993a45-4aff-4f9b-a030-7d72fbb4ec6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98993a45-4aff-4f9b-a030-7d72fbb4ec6c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9774,7 +9774,7 @@
         },
         {
             "id": "8bf8cff2-b156-52de-8bad-8b3bf5f70f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81e49b-bd38-4c0c-b9fe-ce33c15621d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81e49b-bd38-4c0c-b9fe-ce33c15621d6.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9808,7 +9808,7 @@
         },
         {
             "id": "04d5a8d1-4acc-562a-9a98-d9281ac14938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101a5b1-614e-43a0-9e7e-de5a248e2e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101a5b1-614e-43a0-9e7e-de5a248e2e43.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -9842,7 +9842,7 @@
         },
         {
             "id": "19dbccd7-6f00-5b81-aba2-27e6a1cecd86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569593a-d2f2-414c-9e61-2c34e8a5832d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569593a-d2f2-414c-9e61-2c34e8a5832d.jpg?1",
             "name": "Treefolk Warrior",
             "text": "",
             "colours": [
@@ -9877,7 +9877,7 @@
         },
         {
             "id": "b4034a1c-afa9-56a2-ad50-d96ffdf03db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30093c6e-505e-4902-b535-707e364059b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30093c6e-505e-4902-b535-707e364059b4.jpg?1",
             "name": "Land Mine",
             "text": "",
             "colours": [],
@@ -9907,7 +9907,7 @@
         },
         {
             "id": "972f14ac-19ae-5bd3-9091-49bddd973efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ec39dd-8ba5-4a92-bfc8-4028a2c4691d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ec39dd-8ba5-4a92-bfc8-4028a2c4691d.jpg?1",
             "name": "Ajani Steadfast Emblem",
             "text": "",
             "colours": [],
@@ -9936,7 +9936,7 @@
         },
         {
             "id": "d706d4ff-ecf8-547e-8ac5-4d72792e8097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6fa6ba-045a-43f8-8b04-579ffe24f927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6fa6ba-045a-43f8-8b04-579ffe24f927.jpg?1",
             "name": "Garruk, Apex Predator Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M19.json
+++ b/Assets/Resources/Sets/M19.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "bab977f8-f7a6-5fbf-bdbd-7422cdef00c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503c55d-74bb-4165-9273-127c01bb2214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503c55d-74bb-4165-9273-127c01bb2214.jpg?1",
             "name": "Aegis of the Heavens",
             "text": "Target creature gets +1/+7 until end of turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "5f52bb35-0bce-514b-a1a3-db6c6a0a52a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f7c45-db9f-4d48-b575-4d2f1904c963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f7c45-db9f-4d48-b575-4d2f1904c963.jpg?1",
             "name": "Aethershield Artificer",
             "text": "At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "f1921d05-db2a-5c05-927f-2e8ea17e42a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c565076-5db2-47ea-8ee0-4a4fd7bb353d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c565076-5db2-47ea-8ee0-4a4fd7bb353d.jpg?1",
             "name": "Ajani, Adversary of Tyrants",
             "text": "+1: Put a +1/+1 counter on each of up to two target creatures.\n\u22122: Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u22127: You get an emblem with \"At the beginning of your end step, create three 1/1 white Cat creature tokens with lifelink.\"",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "5024cc18-e37b-5aad-bde0-09867eed3725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aebbb57-31b3-4289-815e-4f529e29f3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aebbb57-31b3-4289-815e-4f529e29f3ea.jpg?1",
             "name": "Ajani's Last Stand",
             "text": "Whenever a creature or planeswalker you control dies, you may sacrifice Ajani's Last Stand. If you do, create a 4/4 white Avatar creature token with flying.\nWhen a spell or ability an opponent controls causes you to discard this card, if you control a Plains, create a 4/4 white Avatar creature token with flying.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "1f028cbd-9370-5a11-8f37-4f71e21c38ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f717e04-c078-4696-9ed6-e973033d7be0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f717e04-c078-4696-9ed6-e973033d7be0.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "e875be87-ddbd-5050-a568-38f8ea46611a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9045fcb-b633-4c35-8058-6234311551ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9045fcb-b633-4c35-8058-6234311551ae.jpg?1",
             "name": "Ajani's Welcome",
             "text": "Whenever a creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "41e9c5a9-b640-5074-9abe-8708ba414ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bae0e4-1143-4dc4-afb1-e6b4201ff101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bae0e4-1143-4dc4-afb1-e6b4201ff101.jpg?1",
             "name": "Angel of the Dawn",
             "text": "Flying\nWhen Angel of the Dawn enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "38e8f17b-a318-530d-91be-b388ecb5f043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2e929-7ae3-4560-9cfa-53b89c8a6016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2e929-7ae3-4560-9cfa-53b89c8a6016.jpg?1",
             "name": "Cavalry Drillmaster",
             "text": "When Cavalry Drillmaster enters the battlefield, target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "5f6e707d-616a-512b-851d-6c9ff2ff52ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be8eed7-c033-42cc-bd21-4512db7af66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be8eed7-c033-42cc-bd21-4512db7af66c.jpg?1",
             "name": "Cleansing Nova",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all artifacts and enchantments.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "7fa1d070-ee7a-5346-ac74-48b847c1fb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f461b1-c801-4f0c-8fd7-fe68b6078ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f461b1-c801-4f0c-8fd7-fe68b6078ac6.jpg?1",
             "name": "Daybreak Chaplain",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "5370de30-c805-5376-8336-7b75542bebbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e0f13-35a6-4a5e-8666-47bc5c275be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e0f13-35a6-4a5e-8666-47bc5c275be7.jpg?1",
             "name": "Dwarven Priest",
             "text": "When Dwarven Priest enters the battlefield, you gain 1 life for each creature you control.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "4121aba6-246f-559b-972c-5c3aaf980d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e388c433-3a37-45f6-825a-d13d2223b6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e388c433-3a37-45f6-825a-d13d2223b6f7.jpg?1",
             "name": "Gallant Cavalry",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Gallant Cavalry enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "6174e1ed-f590-51dc-8e3a-a0fb30a85053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452591ca-7273-4e47-820b-3ff89697a036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452591ca-7273-4e47-820b-3ff89697a036.jpg?1",
             "name": "Herald of Faith",
             "text": "Flying\nWhenever Herald of Faith attacks, you gain 2 life.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "b847e188-ae16-5b23-ab33-233a393b2136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197743cd-249c-42ba-ac8d-027c088f8418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197743cd-249c-42ba-ac8d-027c088f8418.jpg?1",
             "name": "Hieromancer's Cage",
             "text": "When Hieromancer's Cage enters the battlefield, exile target nonland permanent an opponent controls until Hieromancer's Cage leaves the battlefield.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "68c1886c-5151-5e3b-85d5-fd7f4066afda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812cf63f-aa3d-405b-92e1-7ffa31352481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812cf63f-aa3d-405b-92e1-7ffa31352481.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "2ce01062-751c-5d25-95f5-9249b5186769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d36b5-37fb-4e52-ad85-c3a09a990ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d36b5-37fb-4e52-ad85-c3a09a990ea0.jpg?1",
             "name": "Invoke the Divine",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "41f8b27f-1b83-58ab-9042-aee19284c870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg?1",
             "name": "Isolate",
             "text": "Exile target permanent with converted mana cost 1.",
             "colours": [
@@ -574,7 +574,7 @@
         },
         {
             "id": "fbb97535-41be-5072-98b7-2565cfe28263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg?1",
             "name": "Knight of the Tusk",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "4033abc5-a23f-530d-ac74-6e12a426dc49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734ff6ac-000d-4fc6-b97b-07b9b21f745c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734ff6ac-000d-4fc6-b97b-07b9b21f745c.jpg?1",
             "name": "Knight's Pledge",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "f626d362-3d9c-5dea-88f9-637fec9f1ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ab022-967d-48ff-a1f9-4bd642dba1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ab022-967d-48ff-a1f9-4bd642dba1ae.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, create a 2/2 white Knight creature token with vigilance. (Attacking doesn't cause it to tap.)\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "7fb16f62-c398-597f-94e3-2e365341687c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffcbcda-2ba3-45e7-80c0-85ea3b7eea0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffcbcda-2ba3-45e7-80c0-85ea3b7eea0c.jpg?1",
             "name": "Lena, Selfless Champion",
             "text": "When Lena, Selfless Champion enters the battlefield, create a 1/1 white Soldier creature token for each nontoken creature you control.\nSacrifice Lena: Creatures you control with power less than Lena's power gain indestructible until end of turn.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "86a5422f-abe1-5090-ac5d-6eb7215d8d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724738ad-6a9b-4ef6-b637-558645cd8151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724738ad-6a9b-4ef6-b637-558645cd8151.jpg?1",
             "name": "Leonin Vanguard",
             "text": "At the beginning of combat on your turn, if you control three or more creatures, Leonin Vanguard gets +1/+1 until end of turn and you gain 1 life.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "a0d4b92b-2ac1-56ac-a858-7698d4e20324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e5e-6572-462a-9fa0-1b2e660099e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e5e-6572-462a-9fa0-1b2e660099e3.jpg?1",
             "name": "Leonin Warleader",
             "text": "Whenever Leonin Warleader attacks, create two 1/1 white Cat creature tokens with lifelink that are tapped and attacking.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "ca1ea422-4168-5a96-8f23-df6d456ca5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928d4250-c379-4134-a263-7811c80a8760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928d4250-c379-4134-a263-7811c80a8760.jpg?1",
             "name": "Loxodon Line Breaker",
             "text": "",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "0142bf67-cf22-58f2-9528-d6c591ee1663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db10390-725e-40f5-885b-a433e7b46f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db10390-725e-40f5-885b-a433e7b46f52.jpg?1",
             "name": "Luminous Bonds",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "52e702e5-6221-5a7d-b157-548b173355ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0857fa-f2cc-4c01-9fe5-8f74d08d1b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0857fa-f2cc-4c01-9fe5-8f74d08d1b29.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "6d87fbd0-7bd2-5ec9-bc6b-75c01c4d2a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e18bd43-6cee-40a3-88f5-c775fb705172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e18bd43-6cee-40a3-88f5-c775fb705172.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "4f588030-6648-5d70-bf16-c2af91c30ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45dcdd-ed92-43f6-b6d2-670b3252ed27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45dcdd-ed92-43f6-b6d2-670b3252ed27.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "60f75433-0c45-577a-a595-e3ab3c9b0648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c5bf25-937c-4e17-9ed4-b4c4579fa9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c5bf25-937c-4e17-9ed4-b4c4579fa9dc.jpg?1",
             "name": "Militia Bugler",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Militia Bugler enters the battlefield, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "233f6744-7ed9-5147-b230-18986bb97436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1",
             "name": "Novice Knight",
             "text": "Defender (This creature can't attack.)\nAs long as Novice Knight is enchanted or equipped, it can attack as though it didn't have defender.",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "1c0d56ca-cd8b-547c-8766-073e2d0b177e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1dfb4-1983-41f7-956c-f2a1d1489b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1dfb4-1983-41f7-956c-f2a1d1489b54.jpg?1",
             "name": "Oreskos Swiftclaw",
             "text": "",
             "colours": [
@@ -1057,7 +1057,7 @@
         },
         {
             "id": "8d80759b-9206-58dc-adc4-f9c90d78dbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c04eafe-8be0-416e-a5b9-486a3b3b5984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c04eafe-8be0-416e-a5b9-486a3b3b5984.jpg?1",
             "name": "Pegasus Courser",
             "text": "Flying\nWhenever Pegasus Courser attacks, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "a031722e-086e-569d-a0a5-66329c4de043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9620716d-9be8-4ebd-80d2-679373f4f897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9620716d-9be8-4ebd-80d2-679373f4f897.jpg?1",
             "name": "Remorseful Cleric",
             "text": "Flying\nSacrifice Remorseful Cleric: Exile all cards from target player's graveyard.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "84de6357-6e39-511f-8e6b-4f51c46871f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586854d1-edfd-4c66-873d-df459324dbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586854d1-edfd-4c66-873d-df459324dbfd.jpg?1",
             "name": "Resplendent Angel",
             "text": "Flying\nAt the beginning of each end step, if you gained 5 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.\n{3}{W}{W}{W}: Until end of turn, Resplendent Angel gets +2/+2 and gains lifelink.",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "3531d18e-cd79-5a50-a87b-1e8d77432d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbdd90c-1ae3-45e5-b1e5-5b8615a1511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbdd90c-1ae3-45e5-b1e5-5b8615a1511f.jpg?1",
             "name": "Revitalize",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "454c4f1b-9716-5b3d-aeb3-3a2560d12763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6691e62-8887-41e8-8e74-76ee2353d45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6691e62-8887-41e8-8e74-76ee2353d45e.jpg?1",
             "name": "Rustwing Falcon",
             "text": "Flying",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "99dff78a-ee04-5e0c-9329-f0d6ff0bd6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21e0516-4430-4292-850b-f5c524d7f8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21e0516-4430-4292-850b-f5c524d7f8f8.jpg?1",
             "name": "Shield Mare",
             "text": "Shield Mare can't be blocked by red creatures.\nWhen Shield Mare enters the battlefield or becomes the target of a spell or ability an opponent controls, you gain 3 life.",
             "colours": [
@@ -1260,7 +1260,7 @@
         },
         {
             "id": "fdf689c9-fd4b-53c6-9adb-eb4a2785207d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57417c7-867b-4b64-bfe3-1744dfe9b44d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57417c7-867b-4b64-bfe3-1744dfe9b44d.jpg?1",
             "name": "Star-Crowned Stag",
             "text": "Whenever Star-Crowned Stag attacks, tap target creature defending player controls.",
             "colours": [
@@ -1294,7 +1294,7 @@
         },
         {
             "id": "46a59fcf-8a91-528e-9e10-544edd3e0862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3644df41-b690-4581-ac7d-c85cec75411f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3644df41-b690-4581-ac7d-c85cec75411f.jpg?1",
             "name": "Suncleanser",
             "text": "When Suncleanser enters the battlefield, choose one \u2014\n\u2022 Remove all counters from target creature. It can't have counters put on it for as long as Suncleanser remains on the battlefield.\n\u2022 Target opponent loses all counters. That player can't get counters for as long as Suncleanser remains on the battlefield.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "6c0f288a-e4d1-5ef8-8322-04ecc6bf87b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fbde22-d98d-4f12-b4d8-1bad2a9878b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fbde22-d98d-4f12-b4d8-1bad2a9878b2.jpg?1",
             "name": "Take Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "9eeb9afe-90f9-5640-aba9-5fdfb13633ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8320e35b-15b9-4f98-b9b8-9c951696408b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8320e35b-15b9-4f98-b9b8-9c951696408b.jpg?1",
             "name": "Trusty Packbeast",
             "text": "When Trusty Packbeast enters the battlefield, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "7abe8eaa-6be5-54cd-abf6-5230b6433ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad750bc-850b-483b-8910-eb6562f925bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad750bc-850b-483b-8910-eb6562f925bc.jpg?1",
             "name": "Valiant Knight",
             "text": "Other Knights you control get +1/+1.\n{3}{W}{W}: Knights you control gain double strike until end of turn.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "7a52e6c1-591d-5cea-80df-3e42c9c586dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6178ed-6353-4733-81e1-7b3dc592c3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6178ed-6353-4733-81e1-7b3dc592c3bd.jpg?1",
             "name": "Aether Tunnel",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and can't be blocked.",
             "colours": [
@@ -1464,7 +1464,7 @@
         },
         {
             "id": "bfb9ef8c-89eb-5646-a581-1a96e99d295e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b1d89-1e6a-4e95-be89-1f03182fc470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b1d89-1e6a-4e95-be89-1f03182fc470.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "843d95de-b3e1-5c39-8cf1-8842a446bdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12dfc1-81f2-44b2-baa2-73cc21363978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12dfc1-81f2-44b2-baa2-73cc21363978.jpg?1",
             "name": "Aven Wind Mage",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Aven Wind Mage gets +1/+1 until end of turn.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "316725e0-adcc-53ec-9611-8866f7cb112b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6966738-b4fc-4854-81b0-09de305854f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6966738-b4fc-4854-81b0-09de305854f2.jpg?1",
             "name": "Aviation Pioneer",
             "text": "When Aviation Pioneer enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1566,7 +1566,7 @@
         },
         {
             "id": "6379198d-58dd-5794-abc6-d303e8793ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4579e7fc-650d-41ba-8ed7-3bd6453a3ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4579e7fc-650d-41ba-8ed7-3bd6453a3ce3.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "b589a6bc-f0f3-53d0-835b-76095d3768cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff3fae-e072-4068-a1de-27de3d89c532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff3fae-e072-4068-a1de-27de3d89c532.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "197d24e5-c4bb-5c4d-858b-b4b896bd63cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1081df25-1137-4c4d-909b-40e78723652c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1081df25-1137-4c4d-909b-40e78723652c.jpg?1",
             "name": "Departed Deckhand",
             "text": "When Departed Deckhand becomes the target of a spell, sacrifice it.\nDeparted Deckhand can't be blocked except by Spirits.\n{3}{U}: Another target creature you control can't be blocked this turn except by Spirits.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "e3f3a2e3-4519-519e-b7bc-1d0aab3463bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c89c-41dc-4ac3-bbce-38ab86f435ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c89c-41dc-4ac3-bbce-38ab86f435ea.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "13f3ff01-1980-5c63-86b5-a76657119f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b35b8-f321-46d8-a441-6b9a6efa9021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b35b8-f321-46d8-a441-6b9a6efa9021.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "c26eedec-c34c-53c1-a442-34ad226fc924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d38bba-6eb9-4dd8-81aa-722def89b163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d38bba-6eb9-4dd8-81aa-722def89b163.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "2932f1b1-11c9-5672-a902-3aaec84521df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb38f190-30f0-49ca-99c3-d3cdf21075e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb38f190-30f0-49ca-99c3-d3cdf21075e8.jpg?1",
             "name": "Dwindle",
             "text": "Enchant creature\nEnchanted creature gets -6/-0.\nWhen enchanted creature blocks, destroy it. (The attacking creature remains blocked.)",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "c99ca5d8-f631-566e-b421-d1d86906c10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f61eb-a121-4f43-93a4-c6f20c6aee84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f61eb-a121-4f43-93a4-c6f20c6aee84.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "7684e317-996e-5ab7-8acc-82a8c6eadec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad82f5-5c5c-42ad-b66e-942f0d9631ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad82f5-5c5c-42ad-b66e-942f0d9631ca.jpg?1",
             "name": "Exclusion Mage",
             "text": "When Exclusion Mage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "3c6a3997-3d4c-557a-a99b-03a587a1e074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa62c0-d24b-4bce-9f2b-d42402b0830c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa62c0-d24b-4bce-9f2b-d42402b0830c.jpg?1",
             "name": "Frilled Sea Serpent",
             "text": "{5}{U}{U}: Frilled Sea Serpent can't be blocked this turn.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "6e1664b4-1d18-52fa-afe9-b5feb1007880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9e666-d9c9-4ccd-89a5-83de79677fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9e666-d9c9-4ccd-89a5-83de79677fa6.jpg?1",
             "name": "Gearsmith Prodigy",
             "text": "Gearsmith Prodigy gets +1/+0 as long as you control an artifact.",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "8afe2d9c-668f-5a48-982e-130aa101ca42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347760a1-03f5-4cc9-87ad-e08986b1ea21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347760a1-03f5-4cc9-87ad-e08986b1ea21.jpg?1",
             "name": "Ghostform",
             "text": "Up to two target creatures can't be blocked this turn.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "9b3361b7-7f43-5325-9963-821b3cbd19f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e925a7a-da5b-4d5d-b5ff-37645ac217f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e925a7a-da5b-4d5d-b5ff-37645ac217f9.jpg?1",
             "name": "Horizon Scholar",
             "text": "Flying\nWhen Horizon Scholar enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "f8a8073e-7086-5462-bfb3-6bbbb1cdec77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff03d37-d90a-4dcc-bacd-64fd71301354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff03d37-d90a-4dcc-bacd-64fd71301354.jpg?1",
             "name": "Metamorphic Alteration",
             "text": "Enchant creature\nAs Metamorphic Alteration enters the battlefield, choose a creature.\nEnchanted creature is a copy of the chosen creature.",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "b3273d7e-f111-5853-b139-086c2451ad9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3ffc69-f21b-410e-8993-8c1b4669fc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3ffc69-f21b-410e-8993-8c1b4669fc19.jpg?1",
             "name": "Mirror Image",
             "text": "You may have Mirror Image enter the battlefield as a copy of any creature you control.",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "c8efa832-ab31-5875-ac3f-1c0b4fa69a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35c1bd0-3d1a-4e46-b74d-11db6867e0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35c1bd0-3d1a-4e46-b74d-11db6867e0d7.jpg?1",
             "name": "Mistcaller",
             "text": "Sacrifice Mistcaller: Until end of turn, if a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "2684bd97-b09a-5e1a-a662-63aa3bf34729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b19cad0-5754-4625-8303-c8310bc7cbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b19cad0-5754-4625-8303-c8310bc7cbd5.jpg?1",
             "name": "Mystic Archaeologist",
             "text": "{3}{U}{U}: Draw two cards.",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "aef0f3ec-f3f1-512f-8c49-d0759cef1fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949589c4-97bc-46b4-bc6c-4b2709fd5e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949589c4-97bc-46b4-bc6c-4b2709fd5e3a.jpg?1",
             "name": "Omenspeaker",
             "text": "When Omenspeaker enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2172,7 +2172,7 @@
         },
         {
             "id": "c594ab12-51f9-5076-91ff-4e0a8dfeff66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db534b4e-8bff-4924-baea-9988d195fb25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db534b4e-8bff-4924-baea-9988d195fb25.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "b619a560-96b4-59a2-8924-4adbcc3fa3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f2aaf5-6c1f-4663-865f-6cdd5640485a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f2aaf5-6c1f-4663-865f-6cdd5640485a.jpg?1",
             "name": "One with the Machine",
             "text": "Draw cards equal to the highest converted mana cost among artifacts you control.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "382cfc49-7b67-51d0-9466-417c8100d263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2256e07f-a35a-4393-9744-045564d5770b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2256e07f-a35a-4393-9744-045564d5770b.jpg?1",
             "name": "Patient Rebuilding",
             "text": "At the beginning of your upkeep, target opponent puts the top three cards of their library into their graveyard, then you draw a card for each land card put into that graveyard this way.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "4f4e5d1d-73ea-5fe0-9aa1-a0e5490dd7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d22fa-1623-463a-83c0-a9aa7c969ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d22fa-1623-463a-83c0-a9aa7c969ce2.jpg?1",
             "name": "Psychic Corrosion",
             "text": "Whenever you draw a card, each opponent puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "fb315a8e-dda0-52df-b51a-aa4940939fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19316cbb-d1af-4ab7-b588-78637503e986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19316cbb-d1af-4ab7-b588-78637503e986.jpg?1",
             "name": "Sai, Master Thopterist",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{U}, Sacrifice two artifacts: Draw a card.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "835be7ea-3243-53be-9b31-264b1937257b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a55f484-5734-469c-8d41-95ce44473ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a55f484-5734-469c-8d41-95ce44473ec1.jpg?1",
             "name": "Salvager of Secrets",
             "text": "When Salvager of Secrets enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "98b0f626-2ced-5719-b1b9-d5745efdfca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4664d4-fb00-4572-a60d-00336117b8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4664d4-fb00-4572-a60d-00336117b8a5.jpg?1",
             "name": "Scholar of Stars",
             "text": "When Scholar of Stars enters the battlefield, if you control an artifact, draw a card.",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "aad9f8ac-cfd8-57d8-9670-e70e3648a098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46588683-74c7-4041-a43b-95d51ba51a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46588683-74c7-4041-a43b-95d51ba51a94.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "4395ca2a-dbc7-508f-b560-926bfbea867b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586d5000-1fdb-4bfe-aa34-63b25ee94bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586d5000-1fdb-4bfe-aa34-63b25ee94bb9.jpg?1",
             "name": "Skilled Animator",
             "text": "When Skilled Animator enters the battlefield, target artifact you control becomes an artifact creature with base power and toughness 5/5 for as long as Skilled Animator remains on the battlefield.",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "63d2b8e6-5bcf-517a-abeb-163de10529aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c53e64-69cf-4296-8a1e-f8817f25c0b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c53e64-69cf-4296-8a1e-f8817f25c0b4.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "5ddf8f73-7170-589f-b9a9-fc88a81e1dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b6cbc-b25c-4221-ae65-a29fcf504f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b6cbc-b25c-4221-ae65-a29fcf504f2f.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "1d93084a-f8e9-576b-9964-67ada1e3a333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d65c22b-7640-4433-930b-4bc381ac7361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d65c22b-7640-4433-930b-4bc381ac7361.jpg?1",
             "name": "Supreme Phantom",
             "text": "Flying\nOther Spirits you control get +1/+1.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "21726898-b6a4-5329-acd5-918117c1d9d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002d0f1-ff2c-4d1c-a7db-3252ef6bebbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002d0f1-ff2c-4d1c-a7db-3252ef6bebbd.jpg?1",
             "name": "Surge Mare",
             "text": "Surge Mare can't be blocked by green creatures.\nWhenever Surge Mare deals damage to an opponent, you may draw a card. If you do, discard a card.\n{1}{U}: Surge Mare gets +2/-2 until end of turn.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "6edc6b13-32f5-5eb1-8630-dfd7cf043723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d062c-5853-44f9-b951-a264e9e0d72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d062c-5853-44f9-b951-a264e9e0d72d.jpg?1",
             "name": "Switcheroo",
             "text": "Exchange control of two target creatures.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "48a91232-a6e6-5a4c-97a8-c8f626539e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e12371-f05c-41cf-92ca-7cb17c2f7f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e12371-f05c-41cf-92ca-7cb17c2f7f1a.jpg?1",
             "name": "Tezzeret, Artifice Master",
             "text": "+1: Create a 1/1 colorless Thopter artifact creature token with flying.\n0: Draw a card. If you control three or more artifacts, draw two cards instead.\n\u22129: You get an emblem with \"At the beginning of your end step, search your library for a permanent card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "7b41090e-87f8-50e3-a853-3a6751250f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eda67da-02b5-4ecb-9038-10e026d454ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eda67da-02b5-4ecb-9038-10e026d454ec.jpg?1",
             "name": "Tolarian Scholar",
             "text": "",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "8994bb9f-fb84-5e52-a5f3-34f08c963927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0b6ce-eb70-4f42-9360-c7d09f48a5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0b6ce-eb70-4f42-9360-c7d09f48a5c5.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "727aa305-6cbd-58cb-90f7-aa58774b2a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f12d70b-fff7-4d0c-982e-2fea70018a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f12d70b-fff7-4d0c-982e-2fea70018a78.jpg?1",
             "name": "Uncomfortable Chill",
             "text": "Creatures your opponents control get -2/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "baaa5a49-9d1a-557d-b786-f5519ec1a6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb995c8-1bc2-4ff4-b8e9-f9b6bc0de0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb995c8-1bc2-4ff4-b8e9-f9b6bc0de0fe.jpg?1",
             "name": "Wall of Mist",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "684b1725-511c-5909-80d1-b2c8ed2c6e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5964daa-2f9e-4a4b-a091-91e7adc3e9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5964daa-2f9e-4a4b-a091-91e7adc3e9c3.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "3fac2447-9f15-50df-ba42-fe82f800644c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de2bd-9ba7-4b6f-94c2-dafb2011a48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de2bd-9ba7-4b6f-94c2-dafb2011a48e.jpg?1",
             "name": "Abnormal Endurance",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "f49f9957-318d-535d-abdc-21cb270172b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe72bd9-825e-4451-9314-826882f75c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe72bd9-825e-4451-9314-826882f75c85.jpg?1",
             "name": "Blood Divination",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "af389ddf-3445-5fa4-92c5-1c10f8ad7095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05145a8d-0bfb-4f07-87cf-65875310bdb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05145a8d-0bfb-4f07-87cf-65875310bdb4.jpg?1",
             "name": "Bogstomper",
             "text": "",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "f0c7dd4c-a925-54b7-a3e9-5114cecd3f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a0de62-6e9f-4ee9-9d8d-ee6f6a115307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a0de62-6e9f-4ee9-9d8d-ee6f6a115307.jpg?1",
             "name": "Bone Dragon",
             "text": "Flying\n{3}{B}{B}, Exile seven other cards from your graveyard: Return Bone Dragon from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "caab9219-1025-54ec-923c-3b3f154ed0a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3867704d-d2ef-4185-b53d-84eba6a6776f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3867704d-d2ef-4185-b53d-84eba6a6776f.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "cf1552ac-6ae6-5dc6-9342-f1c70be18cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9699446-b6f5-4e6a-a263-059cbf6e4b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9699446-b6f5-4e6a-a263-059cbf6e4b7e.jpg?1",
             "name": "Death Baron",
             "text": "Skeletons you control and other Zombies you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "06d6e2fc-10b9-531c-a509-aed54f42013c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg?1",
             "name": "Demon of Catastrophes",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "af350288-41f2-54e4-876e-6d7539607e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf2d355-404e-4c21-9bc2-973d09a845a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf2d355-404e-4c21-9bc2-973d09a845a5.jpg?1",
             "name": "Diregraf Ghoul",
             "text": "Diregraf Ghoul enters the battlefield tapped.",
             "colours": [
@@ -3114,7 +3114,7 @@
         },
         {
             "id": "e4c7b77a-9c2a-5af9-9119-653fbee39fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f70ee8-7e59-43d6-a7b2-29cb5cd1d8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f70ee8-7e59-43d6-a7b2-29cb5cd1d8b3.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "a5f5d8b5-464c-519d-8ad2-3151dd77674c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b433b9fc-69fc-4a57-a16b-f1afd3033b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b433b9fc-69fc-4a57-a16b-f1afd3033b56.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "0b4c3e23-aea1-5885-ac68-8cbab0b06ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b03528-f4ec-4825-ba4c-c485cb4eab3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b03528-f4ec-4825-ba4c-c485cb4eab3a.jpg?1",
             "name": "Epicure of Blood",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "97fd3474-b619-5311-91cc-085ccd747e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cb52a4-5fec-41a0-8030-503a61e3d33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cb52a4-5fec-41a0-8030-503a61e3d33e.jpg?1",
             "name": "Fell Specter",
             "text": "Flying\nWhen Fell Specter enters the battlefield, target opponent discards a card.\nWhenever an opponent discards a card, that player loses 2 life.",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "99638102-5fe1-50e9-84f0-b7884b6b1a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa0ad8-854a-4b4e-9f87-e1dfaa11253c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa0ad8-854a-4b4e-9f87-e1dfaa11253c.jpg?1",
             "name": "Fraying Omnipotence",
             "text": "Each player loses half their life, then discards half the cards in their hand, then sacrifices half the creatures they control. Round up each time.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "42e1f68d-08d6-5cae-8470-4cebe917111e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d2a84-5e47-4f7a-83f7-ee4e670980c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d2a84-5e47-4f7a-83f7-ee4e670980c7.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "0091568f-57f2-50fb-977c-f81365445544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc5f62c-2d29-4a94-8501-13dc6a93c5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc5f62c-2d29-4a94-8501-13dc6a93c5a1.jpg?1",
             "name": "Graveyard Marshal",
             "text": "{2}{B}, Exile a creature card from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "cea9d280-7d19-5718-9658-9e6f4d463089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7624c9aa-2f47-4fcc-a9fe-cc843e8de053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7624c9aa-2f47-4fcc-a9fe-cc843e8de053.jpg?1",
             "name": "Hired Blade",
             "text": "Flash (You may cast this spell any time you could cast an instant.)",
             "colours": [
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "823f8c2b-ec6d-5f38-b2f7-bd24039e1034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17aaa92-10ca-4f70-b45e-5a51e9192efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17aaa92-10ca-4f70-b45e-5a51e9192efb.jpg?1",
             "name": "Infectious Horror",
             "text": "Whenever Infectious Horror attacks, each opponent loses 2 life.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "6b1d1672-5f6e-5ff2-9b1f-cff4fb6e230c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e291f27-d74f-48e7-bcb4-ddcc558c2211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e291f27-d74f-48e7-bcb4-ddcc558c2211.jpg?1",
             "name": "Infernal Reckoning",
             "text": "Exile target colorless creature. You gain life equal to its power.",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "bbc7abdf-7968-5422-b76a-ce561296eea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf7ff14-0de8-4ef9-8425-df15629adc4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf7ff14-0de8-4ef9-8425-df15629adc4b.jpg?1",
             "name": "Infernal Scarring",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -3485,7 +3485,7 @@
         },
         {
             "id": "d81f47f4-2372-510c-9434-95a0e1ccd412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e49567-8ad6-4ce9-a55d-4db5e0fd9532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e49567-8ad6-4ce9-a55d-4db5e0fd9532.jpg?1",
             "name": "Isareth the Awakener",
             "text": "Deathtouch\nWhenever Isareth the Awakener attacks, you may pay {X}. When you do, return target creature card with converted mana cost X from your graveyard to the battlefield with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "166ce0e2-4960-5719-b02d-aae4379b0979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd3acd-aa62-4708-9336-e3430fd0e541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd3acd-aa62-4708-9336-e3430fd0e541.jpg?1",
             "name": "Lich's Caress",
             "text": "Destroy target creature. You gain 3 life.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "96141099-a790-5b21-9001-2114198f1dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7939170-f84e-44c6-b8bc-a180cf7f85d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7939170-f84e-44c6-b8bc-a180cf7f85d9.jpg?1",
             "name": "Liliana, Untouched by Death",
             "text": "+1: Put the top three cards of your library into your graveyard. If at least one of them is a Zombie card, each opponent loses 2 life and you gain 2 life.\n\u22122: Target creature gets -X/-X until end of turn, where X is the number of Zombies you control.\n\u22123: You may cast Zombie cards from your graveyard this turn.",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "5a6ffcc1-8cfa-58eb-80fa-17ddd20bfcfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750e6246-c28d-46ed-9966-26706f6d3172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750e6246-c28d-46ed-9966-26706f6d3172.jpg?1",
             "name": "Liliana's Contract",
             "text": "When Liliana's Contract enters the battlefield, you draw four cards and you lose 4 life.\nAt the beginning of your upkeep, if you control four or more Demons with different names, you win the game.",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "0e0fa011-8c99-595a-b43b-3e2d0b30fcf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d5f95-c8a8-4d65-9546-26c2113db817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d5f95-c8a8-4d65-9546-26c2113db817.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "c9b22514-bee6-530e-bbbc-a70073141cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8423f50f-add7-4502-9ac0-8de1ccb2603d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8423f50f-add7-4502-9ac0-8de1ccb2603d.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "327c5879-522c-527a-aef3-671a935bfe6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45368bf3-d5e9-43e6-a67d-93c2e93acc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45368bf3-d5e9-43e6-a67d-93c2e93acc72.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "c7f0005c-e8e5-5513-95dc-bbf8147f0b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12efbc0-ce88-4622-ad07-2808e651ac5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12efbc0-ce88-4622-ad07-2808e651ac5a.jpg?1",
             "name": "Nightmare's Thirst",
             "text": "You gain 1 life. Target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "1e58b5d8-f20a-522e-b8ce-132b5aab3d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ced1022-abd9-4e22-a4f2-fef738295224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ced1022-abd9-4e22-a4f2-fef738295224.jpg?1",
             "name": "Open the Graves",
             "text": "Whenever a nontoken creature you control dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3782,7 +3782,7 @@
         },
         {
             "id": "772e6914-5e28-59a0-85d2-faa047fb6297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e359c3-2a18-4240-b38a-216372161cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e359c3-2a18-4240-b38a-216372161cd8.jpg?1",
             "name": "Phylactery Lich",
             "text": "Indestructible\nAs Phylactery Lich enters the battlefield, put a phylactery counter on an artifact you control.\nWhen you control no permanents with phylactery counters on them, sacrifice Phylactery Lich.",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "4748377c-726e-5f72-b7b7-66e760865314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995596a3-343d-4272-86bf-d76fd32ab78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995596a3-343d-4272-86bf-d76fd32ab78e.jpg?1",
             "name": "Plague Mare",
             "text": "Plague Mare can't be blocked by white creatures.\nWhen Plague Mare enters the battlefield, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "40f74c44-c11f-522e-a3e8-3c6771c78b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ec702-75c4-4733-b500-eb15406778bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ec702-75c4-4733-b500-eb15406778bb.jpg?1",
             "name": "Ravenous Harpy",
             "text": "Flying\n{1}, Sacrifice another creature: Put a +1/+1 counter on Ravenous Harpy.",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "2e983418-ac75-5e8a-a4bd-284c4c9c00fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d4ac21-2203-45f4-b5f2-dc186ccdbe69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d4ac21-2203-45f4-b5f2-dc186ccdbe69.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "0994bc88-c71a-55b4-91ec-7ca3233ef3b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73644e-884c-47cd-aeec-ab80360dd5ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73644e-884c-47cd-aeec-ab80360dd5ae.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "89ba214a-4c20-5236-9499-67a6cea4d936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee5cc4-a686-4ce6-aa6b-1b8a88e6dea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee5cc4-a686-4ce6-aa6b-1b8a88e6dea3.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "0d6ef022-1f1c-547e-b534-880128d378d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f2740-a193-4b4c-af00-2dd22d74a4ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f2740-a193-4b4c-af00-2dd22d74a4ba.jpg?1",
             "name": "Skymarch Bloodletter",
             "text": "Flying\nWhen Skymarch Bloodletter enters the battlefield, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "df84e252-df11-5e67-b8f8-7e90d0a3c2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5326d251-bb91-4653-b1fa-44f14c4e0b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5326d251-bb91-4653-b1fa-44f14c4e0b88.jpg?1",
             "name": "Sovereign's Bite",
             "text": "Target player loses 3 life and you gain 3 life.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "5534ffea-51f2-5e14-a08d-19fbe6c6f1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b737126-50b5-4678-91bf-197b64086fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b737126-50b5-4678-91bf-197b64086fe4.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "When Stitcher's Supplier enters the battlefield or dies, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -4088,7 +4088,7 @@
         },
         {
             "id": "bbbad4c4-7664-5ab8-807c-3943401de8f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300468ab-fbae-42ae-97bc-b08f795efa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300468ab-fbae-42ae-97bc-b08f795efa5c.jpg?1",
             "name": "Strangling Spores",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4120,7 +4120,7 @@
         },
         {
             "id": "3ca3bc7e-5c46-5085-bfe1-3d19870b232c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc5760e-8b27-4d37-9772-c9eda90b1d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc5760e-8b27-4d37-9772-c9eda90b1d95.jpg?1",
             "name": "Two-Headed Zombie",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4154,7 +4154,7 @@
         },
         {
             "id": "5763aa53-2515-5a1b-a89c-37d8df493b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167822a5-2ab5-42f5-afa4-562fe2d7501b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167822a5-2ab5-42f5-afa4-562fe2d7501b.jpg?1",
             "name": "Vampire Neonate",
             "text": "{2}, {T}: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4188,7 +4188,7 @@
         },
         {
             "id": "75bdf5cc-0580-50fa-8c5f-0948acb53e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee338221-ead9-4b89-8b0c-12745c4ca13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee338221-ead9-4b89-8b0c-12745c4ca13d.jpg?1",
             "name": "Vampire Sovereign",
             "text": "Flying\nWhen Vampire Sovereign enters the battlefield, target opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -4223,7 +4223,7 @@
         },
         {
             "id": "26bb13c3-f943-5134-9ab0-435cb5738995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344a26ab-524f-4daa-ae0a-9d94e34c96df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344a26ab-524f-4daa-ae0a-9d94e34c96df.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -4257,7 +4257,7 @@
         },
         {
             "id": "b2caf4cf-d15a-5054-b1a0-6bac11220d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160dde8-cd77-4967-a5f3-a676376c58f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160dde8-cd77-4967-a5f3-a676376c58f7.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "f99222cb-1a21-59ef-b41a-c770187dc942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2435c810-2baf-4e3b-80ce-542b94694901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2435c810-2baf-4e3b-80ce-542b94694901.jpg?1",
             "name": "Alpine Moon",
             "text": "As Alpine Moon enters the battlefield, choose a nonbasic land card name.\nLands your opponents control with the chosen name lose all land types and abilities, and they gain \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "23068240-57a7-5b1c-9f42-63c08949f2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c827bccf-38f9-4a7c-bd0e-038594a9f63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c827bccf-38f9-4a7c-bd0e-038594a9f63b.jpg?1",
             "name": "Apex of Power",
             "text": "Exile the top seven cards of your library. Until end of turn, you may cast nonland cards exiled this way.\nIf this spell was cast from your hand, add ten mana of any one color.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "9767d93d-c253-5c72-97a6-8aa19f0e36fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b012532-1186-4dc8-9d42-867e418b0280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b012532-1186-4dc8-9d42-867e418b0280.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to any target.\nIf X is 5 or more, this spell can't be countered and the damage can't be prevented.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "5b7a1757-d881-56c9-9d88-22ae6effc37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b7438d-e905-4627-9299-e2224377c8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b7438d-e905-4627-9299-e2224377c8e7.jpg?1",
             "name": "Boggart Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "f4057b39-9fe2-5cc4-bcbc-814c63d16b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a678b-19d4-47a5-aa1c-c2437e5009c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a678b-19d4-47a5-aa1c-c2437e5009c0.jpg?1",
             "name": "Catalyst Elemental",
             "text": "Sacrifice Catalyst Elemental: Add {R}{R}.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "92c9285d-d10f-57e9-a72f-c8cbcfe21365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9737a83-8c58-44b5-816e-d8df8a577921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9737a83-8c58-44b5-816e-d8df8a577921.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)\nDraw a card.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "f1d3a50a-3b48-5826-a433-54ca9d4e9808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a57bfc-1de2-4b3a-84bc-19ec41087f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a57bfc-1de2-4b3a-84bc-19ec41087f0d.jpg?1",
             "name": "Dark-Dweller Oracle",
             "text": "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn. (You still pay its costs. You can play a land this way only if you have an available land play remaining.)",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "e6046c90-5b83-5eb7-af9d-c89a55ee5bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b73282-6207-4207-8b9c-86a8f9a263a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b73282-6207-4207-8b9c-86a8f9a263a2.jpg?1",
             "name": "Demanding Dragon",
             "text": "Flying\nWhen Demanding Dragon enters the battlefield, it deals 5 damage to target opponent unless that player sacrifices a creature.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "73ec237c-203f-5dde-9a7f-908b9604667b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg?1",
             "name": "Dismissive Pyromancer",
             "text": "{R}, {T}, Discard a card: Draw a card.\n{2}{R}, {T}, Sacrifice Dismissive Pyromancer: It deals 4 damage to target creature.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "40027480-2ea3-5e32-ba56-23ad614ed4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8875d8-fe8c-4721-aa8d-978bf72e9c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8875d8-fe8c-4721-aa8d-978bf72e9c26.jpg?1",
             "name": "Doublecast",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "1c1ac533-e2dc-5261-adca-819490904c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d330ce5b-de86-42ad-ac00-3ae1d3252956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d330ce5b-de86-42ad-ac00-3ae1d3252956.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender (This creature can't attack.)\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "4dce70b8-b75b-515d-afc9-95e356e5bb03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bee89d-d916-4095-830f-6270f8c4f0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bee89d-d916-4095-830f-6270f8c4f0d8.jpg?1",
             "name": "Electrify",
             "text": "Electrify deals 4 damage to target creature.",
             "colours": [
@@ -4689,7 +4689,7 @@
         },
         {
             "id": "9a496890-12d1-50f5-977b-f9daf2363d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e38127d-63af-4d26-9ff5-358c8a61f39c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e38127d-63af-4d26-9ff5-358c8a61f39c.jpg?1",
             "name": "Fiery Finish",
             "text": "Fiery Finish deals 7 damage to target creature.",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "bbf23452-16e4-51b4-861c-0638a8be8e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcca2f76-3db9-472b-b78e-a87b81e31d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcca2f76-3db9-472b-b78e-a87b81e31d0a.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "79e2d2ef-185e-5154-a14e-ecbffdcbf5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cef94d-d941-4e08-afec-a116626b74fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cef94d-d941-4e08-afec-a116626b74fb.jpg?1",
             "name": "Goblin Instigator",
             "text": "When Goblin Instigator enters the battlefield, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "4f6c0be9-ecbb-50db-b084-2e1790d5233e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b3a4fb-9024-45ef-a54b-cf3a9fa5b9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b3a4fb-9024-45ef-a54b-cf3a9fa5b9c2.jpg?1",
             "name": "Goblin Motivator",
             "text": "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4825,7 +4825,7 @@
         },
         {
             "id": "fc16b592-5cc8-5bb7-b918-716c0e1fe979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg?1",
             "name": "Goblin Trashmaster",
             "text": "Other Goblins you control get +1/+1.\nSacrifice a Goblin: Destroy target artifact.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "9a72fcfd-5d43-55fb-8ade-8476d38f506b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc0f3e7-a287-4624-8266-ca617448fcaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc0f3e7-a287-4624-8266-ca617448fcaa.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -4895,7 +4895,7 @@
         },
         {
             "id": "ac4743a3-0a3f-5531-a235-d5735fcadc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f003678-0f17-4f1d-87d5-83613a82044b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f003678-0f17-4f1d-87d5-83613a82044b.jpg?1",
             "name": "Havoc Devils",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "71339529-1346-5a9c-a80e-bd4ec1b5f8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6d0a11-3a9c-4de0-9a46-06d2b9356eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6d0a11-3a9c-4de0-9a46-06d2b9356eb7.jpg?1",
             "name": "Hostile Minotaur",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4963,7 +4963,7 @@
         },
         {
             "id": "54025c90-9ebf-5a00-9a72-45e5a2d45f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd11004-5b8f-4c71-bde0-eb75eed869b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd11004-5b8f-4c71-bde0-eb75eed869b0.jpg?1",
             "name": "Inferno Hellion",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nAt the beginning of each end step, if Inferno Hellion attacked or blocked this turn, its owner shuffles it into their library.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "251fe70c-bd09-5a20-9811-1db3357ef141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4c37d-5eeb-42c9-9688-c2ed0d5044cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4c37d-5eeb-42c9-9688-c2ed0d5044cd.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon enters the battlefield under your control, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "cb5046b2-26f0-51c3-9acc-094d46bf985d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dab325-8f4f-4288-9f3f-960e52b4335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dab325-8f4f-4288-9f3f-960e52b4335b.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player or planeswalker.",
             "colours": [
@@ -5065,7 +5065,7 @@
         },
         {
             "id": "63e5f984-ae97-5038-8663-8bca44998e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca822a3-4793-4cbc-a2f3-f43985e7ce8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca822a3-4793-4cbc-a2f3-f43985e7ce8f.jpg?1",
             "name": "Lightning Mare",
             "text": "This spell can't be countered.\nLightning Mare can't be blocked by blue creatures.\n{1}{R}: Lightning Mare gets +1/+0 until end of turn.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "65637b74-b4da-5224-80f4-d09cee94e55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7337-c06f-4cbf-8fc0-0b20c221f1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7337-c06f-4cbf-8fc0-0b20c221f1dc.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "d65447d0-3f36-5c71-aaba-53a0afed3f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e016da6-8800-47b4-9b96-1887677c795c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e016da6-8800-47b4-9b96-1887677c795c.jpg?1",
             "name": "Onakke Ogre",
             "text": "",
             "colours": [
@@ -5167,7 +5167,7 @@
         },
         {
             "id": "9494e4d2-25c5-57e2-86a4-a7c07afef211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553a70e-75de-4a8c-9b20-92cd4a317101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553a70e-75de-4a8c-9b20-92cd4a317101.jpg?1",
             "name": "Sarkhan, Fireblood",
             "text": "+1: You may discard a card. If you do, draw a card.\n+1: Add two mana in any combination of colors. Spend this mana only to cast Dragon spells.\n\u22127: Create four 5/5 red Dragon creature tokens with flying.",
             "colours": [
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "22353ec3-d531-5af7-9edf-7eca0abb62a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa8c8c-8013-46d5-8e80-3d9285fe81c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa8c8c-8013-46d5-8e80-3d9285fe81c8.jpg?1",
             "name": "Sarkhan's Unsealing",
             "text": "Whenever you cast a creature spell with power 4, 5, or 6, Sarkhan's Unsealing deals 4 damage to any target.\nWhenever you cast a creature spell with power 7 or greater, Sarkhan's Unsealing deals 4 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -5235,7 +5235,7 @@
         },
         {
             "id": "21da9955-4e13-5ce1-9576-028242004305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5a0e1e-5239-41f3-a63f-d9303b1b01fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5a0e1e-5239-41f3-a63f-d9303b1b01fc.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5267,7 +5267,7 @@
         },
         {
             "id": "240ca80d-f233-5a9e-937d-914e6220469e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede2b911-8eec-4993-ab1c-59b55dfb11b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede2b911-8eec-4993-ab1c-59b55dfb11b4.jpg?1",
             "name": "Siegebreaker Giant",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n{3}{R}: Target creature can't block this turn.",
             "colours": [
@@ -5302,7 +5302,7 @@
         },
         {
             "id": "69bfe778-ac67-5d98-b442-ba2f96b6df6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a13293d-89a7-400c-8309-9f62eeb4769c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a13293d-89a7-400c-8309-9f62eeb4769c.jpg?1",
             "name": "Smelt",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "7a99cfdb-0f1d-5c4d-8302-699a5113bfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0dbc86-cc12-49e7-9721-dd52b35efcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0dbc86-cc12-49e7-9721-dd52b35efcbe.jpg?1",
             "name": "Sparktongue Dragon",
             "text": "Flying\nWhen Sparktongue Dragon enters the battlefield, you may pay {2}{R}. When you do, it deals 3 damage to any target.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "b3b3191d-aacb-55cc-9362-e429d877eaf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94df6198-10c0-44e7-8226-dc96d12957c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94df6198-10c0-44e7-8226-dc96d12957c4.jpg?1",
             "name": "Spit Flame",
             "text": "Spit Flame deals 4 damage to target creature.\nWhenever a Dragon enters the battlefield under your control, you may pay {R}. If you do, return Spit Flame from your graveyard to your hand.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "1e91fd4a-e4e3-5232-aebe-aa37193c884d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e618ab0-b092-499c-b5e9-d374433ff19c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e618ab0-b092-499c-b5e9-d374433ff19c.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "e315c8b1-35e4-527f-b688-f8017dd7cc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b4db74-0c34-442f-a3f9-38194a75ef7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b4db74-0c34-442f-a3f9-38194a75ef7b.jpg?1",
             "name": "Tectonic Rift",
             "text": "Destroy target land. Creatures without flying can't block this turn.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "72efc907-9c41-5b44-977d-531726b1c4a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bed78a-c579-424a-8fcc-322ce2630dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bed78a-c579-424a-8fcc-322ce2630dbc.jpg?1",
             "name": "Thud",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nThud deals damage equal to the sacrificed creature's power to any target.",
             "colours": [
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "2b41479f-cbb3-50bf-b0f8-bcd915f692bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dbbc83-5549-480f-bf98-da90495d2a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dbbc83-5549-480f-bf98-da90495d2a29.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "72357ee9-5ef3-5bf5-9426-f9879abef3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c676a5b0-bd46-46b3-b71b-a50b86c9b0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c676a5b0-bd46-46b3-b71b-a50b86c9b0bd.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "f4935829-ca79-5b18-9177-589cdd93ec27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82fdb2f-b199-44ff-9615-90fc074cb8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82fdb2f-b199-44ff-9615-90fc074cb8b0.jpg?1",
             "name": "Viashino Pyromancer",
             "text": "When Viashino Pyromancer enters the battlefield, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "e1996af7-2bb5-5a57-a7ad-7b56eda93969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade02a6b-0025-418b-8e20-0eb538fd66b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade02a6b-0025-418b-8e20-0eb538fd66b1.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "fde7c3ea-ec9b-5d5f-9e52-b3ffdd69ed9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164960fc-6e80-4a53-90d7-5a18c0a28083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164960fc-6e80-4a53-90d7-5a18c0a28083.jpg?1",
             "name": "Volley Veteran",
             "text": "When Volley Veteran enters the battlefield, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "6536c1cd-ba12-5ff8-8c7c-3dd9ece61500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b01d243-9f68-47c7-980b-1418e5f2f3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b01d243-9f68-47c7-980b-1418e5f2f3e9.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -5698,7 +5698,7 @@
         },
         {
             "id": "d2b1cdc4-449c-54d4-821c-4d905cee13ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999030b2-2f91-4c45-981f-acdbbf9034af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999030b2-2f91-4c45-981f-acdbbf9034af.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -5732,7 +5732,7 @@
         },
         {
             "id": "ce4568da-ea07-5288-8107-f90eb5808374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6eb55-4bf9-4418-b667-a9a761f91ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6eb55-4bf9-4418-b667-a9a761f91ef9.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "b1d2c9e1-1570-58c8-a96f-df26c5fb8e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d4ce4f-8255-419b-9e7f-544d9798e5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d4ce4f-8255-419b-9e7f-544d9798e5c8.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "af5e083c-b044-5e46-9d86-c2de575764f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99796-ddc5-4ccd-b925-35622a8648b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99796-ddc5-4ccd-b925-35622a8648b8.jpg?1",
             "name": "Colossal Majesty",
             "text": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -5833,7 +5833,7 @@
         },
         {
             "id": "ab7ef3d0-82f5-59f2-99c3-f37b057c9dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc8325b-c7a8-49a5-8a54-a419800ffb93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc8325b-c7a8-49a5-8a54-a419800ffb93.jpg?1",
             "name": "Daggerback Basilisk",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "e1a488b9-c3ca-567c-abd1-61bd19a21e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78271f34-f62e-4771-b430-b121097b8fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78271f34-f62e-4771-b430-b121097b8fb6.jpg?1",
             "name": "Declare Dominance",
             "text": "Target creature gets +3/+3 until end of turn. All creatures able to block it this turn do so.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "7cecd90a-080b-5dd7-aa45-753e19cb3f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ca91ea-dffd-44a9-a54a-c664d83c357b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ca91ea-dffd-44a9-a54a-c664d83c357b.jpg?1",
             "name": "Druid of Horns",
             "text": "Whenever you cast an Aura spell that targets Druid of Horns, create a 3/3 green Beast creature token.",
             "colours": [
@@ -5934,7 +5934,7 @@
         },
         {
             "id": "920924fa-3504-599e-9f90-16485ed58e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ceff1d-9e83-41cc-b54b-8bf90d985da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ceff1d-9e83-41cc-b54b-8bf90d985da9.jpg?1",
             "name": "Druid of the Cowl",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "9b630815-2ad9-527d-b6b1-d3f90e53f3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30171803-1e7b-430b-a0de-2dfd2f1115ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30171803-1e7b-430b-a0de-2dfd2f1115ac.jpg?1",
             "name": "Dryad Greenseeker",
             "text": "{T}: Look at the top card of your library. If it's a land card, you may reveal it and put it into your hand.",
             "colours": [
@@ -6003,7 +6003,7 @@
         },
         {
             "id": "e1bffd10-4fdb-5cab-ad5b-3379ab239242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3b0bc-84da-4b85-992b-d0700c97157c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3b0bc-84da-4b85-992b-d0700c97157c.jpg?1",
             "name": "Elvish Clancaller",
             "text": "Other Elves you control get +1/+1.\n{4}{G}{G}, {T}: Search your library for a card named Elvish Clancaller, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "8331fca5-00c8-520a-b680-460981c26ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0299b00-b16c-4e7d-b67a-ec160ea81a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0299b00-b16c-4e7d-b67a-ec160ea81a54.jpg?1",
             "name": "Elvish Rejuvenator",
             "text": "When Elvish Rejuvenator enters the battlefield, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6073,7 +6073,7 @@
         },
         {
             "id": "e6716189-7ecd-538a-a67e-81a57258e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d470e441-3520-4669-aaa5-f0c57829352a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d470e441-3520-4669-aaa5-f0c57829352a.jpg?1",
             "name": "Ghastbark Twins",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nGhastbark Twins can block an additional creature each combat.",
             "colours": [
@@ -6107,7 +6107,7 @@
         },
         {
             "id": "ca2812a8-b53e-50d8-9de9-fe65cac482a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06582256-37d4-442d-b452-9cd93d285d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06582256-37d4-442d-b452-9cd93d285d2f.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "43339ee9-4e00-5e14-8cf9-7571df93a62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80996b0d-cd44-445e-96de-677e0018255c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80996b0d-cd44-445e-96de-677e0018255c.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6176,7 +6176,7 @@
         },
         {
             "id": "4132024e-f758-53eb-9399-d1cd22b610aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0338075-5e84-4a37-957a-9cf23ac261ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0338075-5e84-4a37-957a-9cf23ac261ab.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "ef1f8e94-3ec2-5278-8023-a339f7a2fd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db84d8-d426-4c0d-b44e-5be7b0f5f5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db84d8-d426-4c0d-b44e-5be7b0f5f5bf.jpg?1",
             "name": "Gigantosaurus",
             "text": "",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "d9cbb87f-1437-5fcd-a7dd-dbefc169bcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d4574a-3266-4497-b145-fb25820d8a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d4574a-3266-4497-b145-fb25820d8a7f.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "Creature spells you cast with power 4 or greater cost {2} less to cast.\nWhenever Goreclaw, Terror of Qal Sisma attacks, each creature you control with power 4 or greater gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "f271e2e6-b77f-5a67-94f6-dc1c4a7392ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eebdd18-6930-42e0-b589-fe15820db6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eebdd18-6930-42e0-b589-fe15820db6e1.jpg?1",
             "name": "Greenwood Sentinel",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "3b43311d-89f7-52da-b8c5-70c8b7199fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec59964-42c1-4c29-8c60-37b7f376c347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec59964-42c1-4c29-8c60-37b7f376c347.jpg?1",
             "name": "Highland Game",
             "text": "When Highland Game dies, you gain 2 life.",
             "colours": [
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "9dde01bc-c6a7-526d-a2e3-3d60c8384a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84127b83-e75a-4f12-92ca-46f50bb89699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84127b83-e75a-4f12-92ca-46f50bb89699.jpg?1",
             "name": "Hungering Hydra",
             "text": "Hungering Hydra enters the battlefield with X +1/+1 counters on it.\nHungering Hydra can't be blocked by more than one creature.\nWhenever Hungering Hydra is dealt damage, put that many +1/+1 counters on it. (It must survive the damage to get the counters.)",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "df3a3b28-1427-556d-a6a7-bcd6385c9bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c40ba-2464-44ae-8d67-93c72ab3c425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c40ba-2464-44ae-8d67-93c72ab3c425.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6415,7 +6415,7 @@
         },
         {
             "id": "37dd0a64-6dbf-59d0-8f24-598b93ec1074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf71f42-6e42-46c0-9e8f-394d2c4519ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf71f42-6e42-46c0-9e8f-394d2c4519ee.jpg?1",
             "name": "Oakenform",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "1a0224a8-027a-543d-9176-7963af211a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00906b47-6316-4e00-bbf5-b801ab583f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00906b47-6316-4e00-bbf5-b801ab583f4f.jpg?1",
             "name": "Pelakka Wurm",
             "text": "Trample\nWhen Pelakka Wurm enters the battlefield, you gain 7 life.\nWhen Pelakka Wurm dies, draw a card.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "c8d83099-2b70-5d6e-a8eb-a822d817efdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a29ddb-fc76-407a-aa58-ec92d011bd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a29ddb-fc76-407a-aa58-ec92d011bd44.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "22af3431-122c-581a-a352-fe1178840696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg?1",
             "name": "Prodigious Growth",
             "text": "Enchant creature\nEnchanted creature gets +7/+7 and has trample.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "1caf6913-815b-5d1c-b6fb-4f128bec0339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe53385-d63f-4d07-94ed-3ea5a48c79c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe53385-d63f-4d07-94ed-3ea5a48c79c8.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6581,7 +6581,7 @@
         },
         {
             "id": "e141be0a-39ed-56ef-b9f0-81e547deb4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2951026c-69bb-4ffc-a24f-b0795a12aa79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2951026c-69bb-4ffc-a24f-b0795a12aa79.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -6616,7 +6616,7 @@
         },
         {
             "id": "2a34034e-c6be-5bb6-9c85-554dc7485c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f127214f-3e91-4988-b593-1568d0ae1718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f127214f-3e91-4988-b593-1568d0ae1718.jpg?1",
             "name": "Recollect",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -6648,7 +6648,7 @@
         },
         {
             "id": "ed235369-8a97-5fae-be80-1782306fe61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f04d5-af45-4494-ac11-a605d3a06643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f04d5-af45-4494-ac11-a605d3a06643.jpg?1",
             "name": "Rhox Oracle",
             "text": "When Rhox Oracle enters the battlefield, draw a card.",
             "colours": [
@@ -6683,7 +6683,7 @@
         },
         {
             "id": "96173b8b-302e-51a0-8495-c1e295f49ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b01fd2-139a-47ed-a8e3-021aa9c91b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b01fd2-139a-47ed-a8e3-021aa9c91b02.jpg?1",
             "name": "Root Snare",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -6715,7 +6715,7 @@
         },
         {
             "id": "524db2d7-f699-5287-b60b-b37f787aabe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b445a0f0-2cca-4223-bd27-940d2cb6d29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b445a0f0-2cca-4223-bd27-940d2cb6d29c.jpg?1",
             "name": "Runic Armasaur",
             "text": "Whenever an opponent activates an ability of a creature or land that isn't a mana ability, you may draw a card.",
             "colours": [
@@ -6749,7 +6749,7 @@
         },
         {
             "id": "1d72c353-e7fa-59eb-ada6-e94f8868b316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175e21a3-00f7-4c51-8a8e-fbfd7089efda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175e21a3-00f7-4c51-8a8e-fbfd7089efda.jpg?1",
             "name": "Scapeshift",
             "text": "Sacrifice any number of lands. Search your library for up to that many land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "b4552ebd-bd49-5c0d-b238-b711787847e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffa2e83-bc78-4bde-9692-e5165c4ef63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffa2e83-bc78-4bde-9692-e5165c4ef63b.jpg?1",
             "name": "Talons of Wildwood",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)\n{2}{G}: Return Talons of Wildwood from your graveyard to your hand.",
             "colours": [
@@ -6815,7 +6815,7 @@
         },
         {
             "id": "76772427-8b4f-5f73-94b8-5399d795c18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812e942-eb78-48c8-857e-5f0ff1bd777b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812e942-eb78-48c8-857e-5f0ff1bd777b.jpg?1",
             "name": "Thorn Lieutenant",
             "text": "Whenever Thorn Lieutenant becomes the target of a spell or ability an opponent controls, create a 1/1 green Elf Warrior creature token.\n{5}{G}: Thorn Lieutenant gets +4/+4 until end of turn.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "fcfa637b-eb8a-5d81-9397-fdb6572de019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0f3812-bb6c-4d99-b505-9dfd84e3fd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0f3812-bb6c-4d99-b505-9dfd84e3fd95.jpg?1",
             "name": "Thornhide Wolves",
             "text": "",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "c028cf06-89b9-5458-9e82-64d16460f580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe574e49-723a-409b-9222-125eebb620ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe574e49-723a-409b-9222-125eebb620ff.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "ed739907-2e56-56ff-9086-959bd801223b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad8e5d-0c26-4588-8161-b22197715d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad8e5d-0c26-4588-8161-b22197715d63.jpg?1",
             "name": "Vigilant Baloth",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "13b0f2a1-daa3-5e8d-abf5-f91438b8c2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9980835-cd32-4870-88df-c79cd5534968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9980835-cd32-4870-88df-c79cd5534968.jpg?1",
             "name": "Vine Mare",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nVine Mare can't be blocked by black creatures.",
             "colours": [
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "529f85e6-ac3d-5125-88d5-75af9dbe573d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "8494cb28-5b1c-58de-b2db-18bdc0c0742b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784c4711-223d-4b95-a163-87e57f87b8db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784c4711-223d-4b95-a163-87e57f87b8db.jpg?1",
             "name": "Vivien's Invocation",
             "text": "Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in a random order. When a creature is put onto the battlefield this way, it deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "c0d24bd8-f776-5f36-bab0-a78f9cd028ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327e768-d90d-4677-b4dd-10837ffe8be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327e768-d90d-4677-b4dd-10837ffe8be2.jpg?1",
             "name": "Wall of Vines",
             "text": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -7088,7 +7088,7 @@
         },
         {
             "id": "73a57b65-c23c-5d35-91a5-096d82759286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314bae2-4930-4f8a-8a52-853bc3feb88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314bae2-4930-4f8a-8a52-853bc3feb88f.jpg?1",
             "name": "Aerial Engineer",
             "text": "As long as you control an artifact, Aerial Engineer gets +2/+0 and has flying.",
             "colours": [
@@ -7125,7 +7125,7 @@
         },
         {
             "id": "a330f8ef-791b-5790-a00e-52727a54e6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e90c638-d4b2-4243-bbc4-1cc10516c40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e90c638-d4b2-4243-bbc4-1cc10516c40f.jpg?1",
             "name": "Arcades, the Strategist",
             "text": "Flying, vigilance\nWhenever a creature with defender enters the battlefield under your control, draw a card.\nEach creature you control with defender assigns combat damage equal to its toughness rather than its power and can attack as though it didn't have defender.",
             "colours": [
@@ -7166,7 +7166,7 @@
         },
         {
             "id": "aa55a28b-519d-5532-abf6-5b74051967b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b9f9d7-a00d-4a90-9d7a-88ece10af328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b9f9d7-a00d-4a90-9d7a-88ece10af328.jpg?1",
             "name": "Brawl-Bash Ogre",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Brawl-Bash Ogre attacks, you may sacrifice another creature. If you do, Brawl-Bash Ogre gets +2/+2 until end of turn.",
             "colours": [
@@ -7203,7 +7203,7 @@
         },
         {
             "id": "2e5ac0dd-8760-5d1b-a054-2f19e48f62b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1de2c-1acc-47c8-9b5e-a9dae3da8a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1de2c-1acc-47c8-9b5e-a9dae3da8a49.jpg?1",
             "name": "Chromium, the Mutable",
             "text": "Flash\nThis spell can't be countered.\nFlying\nDiscard a card: Until end of turn, Chromium, the Mutable becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.",
             "colours": [
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "84987c4d-70bf-5b40-be9e-30995c581d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a353510a-30de-4891-97b9-d7d556531c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a353510a-30de-4891-97b9-d7d556531c41.jpg?1",
             "name": "Draconic Disciple",
             "text": "{T}: Add one mana of any color.\n{7}, {T}, Sacrifice Draconic Disciple: Create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "61e8b50a-ac23-5e2d-8912-dcb101f7bf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0def77-3528-40fb-a6b2-c3d1e31ade65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0def77-3528-40fb-a6b2-c3d1e31ade65.jpg?1",
             "name": "Enigma Drake",
             "text": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -7317,7 +7317,7 @@
         },
         {
             "id": "cfbeedb7-5559-5c66-a3d1-38c462efd19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c35bf8-ae43-41aa-aae9-4d7513f9058c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c35bf8-ae43-41aa-aae9-4d7513f9058c.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste. (They can attack and {T} this turn.)",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "9efa7534-f267-5e96-8ec0-ed88dff97fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "Flying\nWhen Nicol Bolas, the Ravager enters the battlefield, each opponent discards a card.\n{4}{U}{B}{R}: Exile Nicol Bolas, the Ravager, then return him to the battlefield transformed under his owner's control. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "ef9380b4-bff3-5f44-96ba-c65042673190",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "+2: Draw two cards.\n\u22123: Nicol Bolas, the Arisen deals 10 damage to target creature or planeswalker.\n\u22124: Put target creature or planeswalker card from a graveyard onto the battlefield under your control.\n\u221212: Exile all but the bottom card of target player's library.",
             "colours": [
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "f535ef50-bf20-5581-b18b-029cf1a25881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663bd13-243e-4b8c-9ca8-158576b58803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663bd13-243e-4b8c-9ca8-158576b58803.jpg?1",
             "name": "Palladia-Mors, the Ruiner",
             "text": "Flying, vigilance, trample\nPalladia-Mors, the Ruiner has hexproof if it hasn't dealt damage yet.",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "a6abe853-76b2-57b1-b56b-5eaaa92c7311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e058ff8-043c-498b-8310-0ca45466ac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e058ff8-043c-498b-8310-0ca45466ac27.jpg?1",
             "name": "Poison-Tip Archer",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever another creature dies, each opponent loses 1 life.",
             "colours": [
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "04492ba4-fb9f-5384-add2-843324a54806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3188e533-9a72-4a02-b169-a918f7c095ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3188e533-9a72-4a02-b169-a918f7c095ba.jpg?1",
             "name": "Psychic Symbiont",
             "text": "Flying\nWhen Psychic Symbiont enters the battlefield, target opponent discards a card and you draw a card.",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "88f1ef3e-5735-5712-95f9-c5239a20f243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a75d3a-58cb-4ee0-88d3-52099cb57ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a75d3a-58cb-4ee0-88d3-52099cb57ac3.jpg?1",
             "name": "Regal Bloodlord",
             "text": "Flying\nAt the beginning of each end step, if you gained life this turn, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "62f5fc8b-9fd3-510a-a003-de1544d4c147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31c544f-a748-4180-8366-9bb1622bb99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31c544f-a748-4180-8366-9bb1622bb99d.jpg?1",
             "name": "Satyr Enchanter",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -7621,7 +7621,7 @@
         },
         {
             "id": "1864b0b6-9b08-565f-b35b-8cceb1fc5a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650461af-081b-4cc9-a140-865a666f1443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650461af-081b-4cc9-a140-865a666f1443.jpg?1",
             "name": "Skyrider Patrol",
             "text": "Flying\nAt the beginning of combat on your turn, you may pay {G}{U}. When you do, put a +1/+1 counter on another target creature you control, and that creature gains flying until end of turn.",
             "colours": [
@@ -7658,7 +7658,7 @@
         },
         {
             "id": "20012eae-b7fa-53d1-be08-24f37897cbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fdc00-21eb-48dc-966a-6b634dc5a2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fdc00-21eb-48dc-966a-6b634dc5a2c4.jpg?1",
             "name": "Vaevictis Asmadi, the Dire",
             "text": "Flying\nWhenever Vaevictis Asmadi, the Dire attacks, for each player, choose target permanent that player controls. Those players sacrifice those permanents. Each player who sacrificed a permanent this way reveals the top card of their library, then puts it onto the battlefield if it's a permanent card.",
             "colours": [
@@ -7699,7 +7699,7 @@
         },
         {
             "id": "3e53d792-2be0-51ae-9ef7-32e26ea4787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45ac8dc-281f-4257-9658-80af65a0295b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45ac8dc-281f-4257-9658-80af65a0295b.jpg?1",
             "name": "Amulet of Safekeeping",
             "text": "Whenever you become the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {1}.\nCreature tokens get -1/-0.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "418e4362-3f37-5d6b-a0ff-9d0b4f12d07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg?1",
             "name": "Arcane Encyclopedia",
             "text": "{3}, {T}: Draw a card.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "cd44eae4-8f2d-5e09-864d-216063583d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff0730-6dd9-42d2-be0d-655d04adf229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff0730-6dd9-42d2-be0d-655d04adf229.jpg?1",
             "name": "Chaos Wand",
             "text": "{4}, {T}: Target opponent exiles cards from the top of their library until they exile an instant or sorcery card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of that library in a random order.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "342e0244-f1c4-5618-b5eb-b1c65f37c0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28b35c-28a5-4042-b21d-6d43658a16eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28b35c-28a5-4042-b21d-6d43658a16eb.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play land cards from your graveyard.",
             "colours": [],
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "9d68d878-5799-54bc-b37c-569ba5306791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ce930-c100-4ef5-b75a-a18051282f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ce930-c100-4ef5-b75a-a18051282f8c.jpg?1",
             "name": "Desecrated Tomb",
             "text": "Whenever one or more creature cards leave your graveyard, create a 1/1 black Bat creature token with flying.",
             "colours": [],
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "7f7c784f-4a3b-5f89-b250-2748533db6ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg?1",
             "name": "Diamond Mare",
             "text": "As Diamond Mare enters the battlefield, choose a color.\nWhenever you cast a spell of the chosen color, you gain 1 life.",
             "colours": [],
@@ -7870,7 +7870,7 @@
         },
         {
             "id": "03a1c4d8-4f2d-5f98-a1a0-cfd86f9f73d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b441fc8-bc89-47d4-8745-2525aeb6d98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b441fc8-bc89-47d4-8745-2525aeb6d98d.jpg?1",
             "name": "Dragon's Hoard",
             "text": "Whenever a Dragon enters the battlefield under your control, put a gold counter on Dragon's Hoard.\n{T}, Remove a gold counter from Dragon's Hoard: Draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "18172752-219c-5e87-8015-391046992e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608f431b-a05c-4610-94f7-928d87b2c056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608f431b-a05c-4610-94f7-928d87b2c056.jpg?1",
             "name": "Explosive Apparatus",
             "text": "{3}, {T}, Sacrifice Explosive Apparatus: It deals 2 damage to any target.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "2f004bc8-a9b2-5242-9938-4988f97428cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148c1bf-84a2-48cd-882e-ad0fd74b8f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148c1bf-84a2-48cd-882e-ad0fd74b8f0f.jpg?1",
             "name": "Field Creeper",
             "text": "",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "32f1a8b6-0662-52d0-b77e-3326e95d3db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26894980-8961-4479-85dd-5f01c899718b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26894980-8961-4479-85dd-5f01c899718b.jpg?1",
             "name": "Fountain of Renewal",
             "text": "At the beginning of your upkeep, you gain 1 life.\n{3}, Sacrifice Fountain of Renewal: Draw a card.",
             "colours": [],
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "89895162-7996-5301-b32d-16d3595c9d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381e9f97-9655-4f41-9829-4ac26c2ed6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381e9f97-9655-4f41-9829-4ac26c2ed6ac.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender (This creature can't attack.)\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "cb6a17cc-7ccd-5c4d-83fd-25a7137ceb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d532b01-8bf7-4a27-a438-db03bcd00694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d532b01-8bf7-4a27-a438-db03bcd00694.jpg?1",
             "name": "Gearsmith Guardian",
             "text": "Gearsmith Guardian gets +2/+0 as long as you control a blue creature.",
             "colours": [],
@@ -8047,7 +8047,7 @@
         },
         {
             "id": "456eb0f6-e68a-59cf-80f3-fe7da03da7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1f24f-d910-4ec6-95d2-0ecaf9f051aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1f24f-d910-4ec6-95d2-0ecaf9f051aa.jpg?1",
             "name": "Magistrate's Scepter",
             "text": "{4}, {T}: Put a charge counter on Magistrate's Scepter.\n{T}, Remove three charge counters from Magistrate's Scepter: Take an extra turn after this one.",
             "colours": [],
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "f472feb1-d8c3-55d1-affc-3cc4bcbffdd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfba61f-9a6d-43e3-ad28-f74f737ef186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfba61f-9a6d-43e3-ad28-f74f737ef186.jpg?1",
             "name": "Manalith",
             "text": "{T}: Add one mana of any color.",
             "colours": [],
@@ -8103,7 +8103,7 @@
         },
         {
             "id": "f8665bb6-235a-532f-a42e-38591e290b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ca16ee-e415-4270-a453-47111d07a07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ca16ee-e415-4270-a453-47111d07a07f.jpg?1",
             "name": "Marauder's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "84e02853-53da-5238-9cd5-8d8744c19085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb0b15-d651-4730-8be9-d0e01145311b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb0b15-d651-4730-8be9-d0e01145311b.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "d64a11c1-67c4-55ca-a0bc-cd9d78d5d07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2051fd0-99cf-4e11-a625-8294e6767e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2051fd0-99cf-4e11-a625-8294e6767e5b.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of their library into their graveyard.",
             "colours": [],
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "9a9bff27-0a48-544b-9b91-2d2b9cc95b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c7d24-7d5c-49de-b9f8-35c6d6c8c52a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c7d24-7d5c-49de-b9f8-35c6d6c8c52a.jpg?1",
             "name": "Rogue's Gloves",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8222,7 +8222,7 @@
         },
         {
             "id": "07eee774-c636-56e3-8f85-b9867a96517f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497d08a8-cffe-4164-a941-d8c8c85644c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497d08a8-cffe-4164-a941-d8c8c85644c7.jpg?1",
             "name": "Sigiled Sword of Valeron",
             "text": "Equipped creature gets +2/+0, has vigilance, and is a Knight in addition to its other types.\nWhenever equipped creature attacks, create a 2/2 white Knight creature token with vigilance that's attacking.\nEquip {3}",
             "colours": [],
@@ -8252,7 +8252,7 @@
         },
         {
             "id": "7f220924-70a0-51bb-aa93-0a2a20503bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2c1fb7-3c1d-49a9-b2c2-78ba2264df38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2c1fb7-3c1d-49a9-b2c2-78ba2264df38.jpg?1",
             "name": "Skyscanner",
             "text": "Flying\nWhen Skyscanner enters the battlefield, draw a card.",
             "colours": [],
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "a3f3a97c-966b-5ffc-a117-a58f8323ecfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf01421-856e-4cdd-8938-148928626f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf01421-856e-4cdd-8938-148928626f56.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender (This creature can't attack.)\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "e9638864-c7c7-5bda-83be-2717d9d85b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b06b670-7238-4732-85fd-ac6abebea57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b06b670-7238-4732-85fd-ac6abebea57f.jpg?1",
             "name": "Transmogrifying Wand",
             "text": "Transmogrifying Wand enters the battlefield with three charge counters on it.\n{1}, {T}, Remove a charge counter from Transmogrifying Wand: Destroy target creature. Its controller creates a 2/4 white Ox creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "9f7127ac-bee3-54bc-b6bd-318c7673968f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41b554-2bb1-4f11-be29-233d36cc955a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41b554-2bb1-4f11-be29-233d36cc955a.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8373,7 +8373,7 @@
         },
         {
             "id": "fef2730f-319e-5448-9805-6f4c6ba67c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f99756-d334-4dba-a375-ba3d91ecae62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f99756-d334-4dba-a375-ba3d91ecae62.jpg?1",
             "name": "Detection Tower",
             "text": "{T}: Add {C}.\n{1}, {T}: Until end of turn, your opponents and creatures your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.",
             "colours": [],
@@ -8401,7 +8401,7 @@
         },
         {
             "id": "f9dd7c40-e24c-5796-a7ee-a1a345675991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b376c8c9-cd35-4c2b-8b5b-95ea9735b366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b376c8c9-cd35-4c2b-8b5b-95ea9735b366.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "935132cd-4c0f-56fb-be93-a7cf9af91add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28e1e1-0813-4e4a-a7a7-058b7787272c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28e1e1-0813-4e4a-a7a7-058b7787272c.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "140dbb87-9a89-5905-9c64-7ab543e19e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b538a465-81c6-4282-9ac3-061167ac7dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b538a465-81c6-4282-9ac3-061167ac7dc3.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "82e92054-7cdd-554b-a208-a2a1eb64cf78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47ee724-da0f-4eb1-b07b-b07e04e9f5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47ee724-da0f-4eb1-b07b-b07e04e9f5b3.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "2761f630-ae18-5a6f-9c58-f29571c9c077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81766fd6-c7e0-4527-a63e-512d126c0421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81766fd6-c7e0-4527-a63e-512d126c0421.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -8553,7 +8553,7 @@
         },
         {
             "id": "8a44649a-b6fa-57f6-a9e8-2ef2c11f0df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7657f02-d1dd-448e-bc0d-c6f25fbc35ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7657f02-d1dd-448e-bc0d-c6f25fbc35ea.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "7c2b7a31-0b33-5f96-952a-e8439a42893f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac2b853-f788-4b29-a76d-880da61ad91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac2b853-f788-4b29-a76d-880da61ad91a.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8612,7 +8612,7 @@
         },
         {
             "id": "dc5a596c-89f5-5636-bbba-8db49b4747bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8c56fa-fae6-48ba-813d-0d971b640896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8c56fa-fae6-48ba-813d-0d971b640896.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "f76dc7c5-89f9-5133-9cde-3785851a0b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07076412-18fe-4e15-bdb5-17111b4a66db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07076412-18fe-4e15-bdb5-17111b4a66db.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8674,7 +8674,7 @@
         },
         {
             "id": "e84f073d-ee62-549c-928e-5e0e577f8830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b33867-5ccf-49a1-8e9b-9d2ddac78f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b33867-5ccf-49a1-8e9b-9d2ddac78f17.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "e5560fc8-f4d7-5aa2-9569-30b105d486be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303224d6-9769-4127-8e33-9129f337e2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303224d6-9769-4127-8e33-9129f337e2a8.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "91a179f3-d132-5ba6-887b-5c9d31b6422d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b55c1-d74b-4688-a3b8-8480d99524c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b55c1-d74b-4688-a3b8-8480d99524c7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8774,7 +8774,7 @@
         },
         {
             "id": "8fdfbcc3-59b6-5531-a4cc-13acc6c6137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2715553-ba9c-4753-9a1f-d13d8e2ed24f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2715553-ba9c-4753-9a1f-d13d8e2ed24f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8812,7 +8812,7 @@
         },
         {
             "id": "32625ebc-826a-5b05-b934-2fdea15ab6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1859ba05-06bc-4e80-8c0b-fd2475c6ca55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1859ba05-06bc-4e80-8c0b-fd2475c6ca55.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "4f286450-7a9f-509e-816f-37df000c55bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3645e11b-6b46-44c0-9741-f70da15692d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3645e11b-6b46-44c0-9741-f70da15692d1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8888,7 +8888,7 @@
         },
         {
             "id": "1bf5f701-d1af-5bb8-bac2-57f5f157138b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91890c11-b139-474d-b12d-6afd6b7e6aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91890c11-b139-474d-b12d-6afd6b7e6aee.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "5e84a95e-96d8-59ec-9e61-a053e8911916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c33392-c382-4e8b-812e-8b2c64cdbe8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c33392-c382-4e8b-812e-8b2c64cdbe8e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8964,7 +8964,7 @@
         },
         {
             "id": "101bdef2-4bec-5bc8-8708-a4f0b73a360b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42044efb-b6a8-46c3-90dc-b7a745e819e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42044efb-b6a8-46c3-90dc-b7a745e819e5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9002,7 +9002,7 @@
         },
         {
             "id": "242db6c0-6ed1-5ac4-95fe-eb3b6c01d802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a0c382-23c4-44a5-a689-1f65fed388b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a0c382-23c4-44a5-a689-1f65fed388b7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9040,7 +9040,7 @@
         },
         {
             "id": "6ae8aa9e-e235-50a5-8a20-6c70422e3a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfe9801-b683-45d9-924c-6734110816bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfe9801-b683-45d9-924c-6734110816bf.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9078,7 +9078,7 @@
         },
         {
             "id": "d82c379a-48df-54d0-9e3f-d7fcf2de0851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430341f3-7dd5-4161-96a2-e76350699b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430341f3-7dd5-4161-96a2-e76350699b66.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "82037bd0-ca47-5fdb-bce2-6f31912898a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8808d9dd-70c0-46ff-bd9c-dd60240dd121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8808d9dd-70c0-46ff-bd9c-dd60240dd121.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "63045ec0-153b-5e85-b6c5-2dc5d52fc871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7f974d-2634-4fc7-aa4e-bfeb6f3169ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7f974d-2634-4fc7-aa4e-bfeb6f3169ea.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9192,7 +9192,7 @@
         },
         {
             "id": "8fcb8548-81e9-5270-8c70-dc6a08478dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2030b-f622-4cc3-ac83-258ae3645fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2030b-f622-4cc3-ac83-258ae3645fd6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9230,7 +9230,7 @@
         },
         {
             "id": "6eedbcd5-d9d1-5368-a019-0123b2b5792c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6457f78b-aca6-4ebf-9e89-bf9321ceb35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6457f78b-aca6-4ebf-9e89-bf9321ceb35d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9268,7 +9268,7 @@
         },
         {
             "id": "f21a107d-1709-530c-81f6-8b97e37b7dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedbe1f9-b29f-4bdd-9718-615b7c2413b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedbe1f9-b29f-4bdd-9718-615b7c2413b4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "7cc23225-7add-5af9-97a3-058f41e640d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4004c8-c3d9-494e-a257-6d8443cbf1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4004c8-c3d9-494e-a257-6d8443cbf1b7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9344,7 +9344,7 @@
         },
         {
             "id": "99ee8aee-6842-5b09-9d08-8dba59d4fe36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52ff177-bafe-4e0a-a6c3-2cf012b1319f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52ff177-bafe-4e0a-a6c3-2cf012b1319f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9382,7 +9382,7 @@
         },
         {
             "id": "fddc5fdd-bc0f-58bc-8871-79dfc26684cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e46627-3cf3-4aca-97ba-80f9e919608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e46627-3cf3-4aca-97ba-80f9e919608c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9420,7 +9420,7 @@
         },
         {
             "id": "481dcf3d-daba-5072-b109-9c8cbe207959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32df22d3-9b65-4b43-80d9-e4c43575ec74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32df22d3-9b65-4b43-80d9-e4c43575ec74.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9458,7 +9458,7 @@
         },
         {
             "id": "18e082fd-d579-5309-aed2-d38c4ce6066f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cc8ba-ab54-46d3-9c3a-91678fd8d381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cc8ba-ab54-46d3-9c3a-91678fd8d381.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9496,7 +9496,7 @@
         },
         {
             "id": "f19f289e-38d5-5195-bbe6-9297b7680175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a22ecc-3a5c-44a1-bb52-bbeffa2dbf17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a22ecc-3a5c-44a1-bb52-bbeffa2dbf17.jpg?1",
             "name": "Ajani, Wise Counselor",
             "text": "+2: You gain 1 life for each creature you control.\n\u22123: Creatures you control get +2/+2 until end of turn.\n\u22129: Put X +1/+1 counters on target creature, where X is your life total.",
             "colours": [
@@ -9531,7 +9531,7 @@
         },
         {
             "id": "cc9f9dc5-54e4-5437-92d4-6121d880ac15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38ad178-35a5-44ad-b80a-d746f3e6a45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38ad178-35a5-44ad-b80a-d746f3e6a45c.jpg?1",
             "name": "Ajani's Influence",
             "text": "Put two +1/+1 counters on target creature.\nLook at the top five cards of your library. You may reveal a white card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9562,7 +9562,7 @@
         },
         {
             "id": "cae46171-5854-55aa-be95-0f49ccd4d12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2e1a93-4b5c-4f89-9e11-1693dee64b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2e1a93-4b5c-4f89-9e11-1693dee64b63.jpg?1",
             "name": "Court Cleric",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nCourt Cleric gets +1/+1 as long as you control an Ajani planeswalker.",
             "colours": [
@@ -9596,7 +9596,7 @@
         },
         {
             "id": "b3886033-c32b-5d6e-ab73-f939904ef39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1d95b9-aa18-41e2-b972-93fda25e0b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1d95b9-aa18-41e2-b972-93fda25e0b11.jpg?1",
             "name": "Serra's Guardian",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)\nOther creatures you control have vigilance.",
             "colours": [
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "da71714d-726a-5023-9276-689b3ff064ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b4c374-42a4-4912-8a74-a11c3fa0e065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b4c374-42a4-4912-8a74-a11c3fa0e065.jpg?1",
             "name": "Silverbeak Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "ba88ef72-2bdc-52c5-a94b-3b0a63f6fef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277dbeea-103c-4c5b-8981-3f5f7e60c66a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277dbeea-103c-4c5b-8981-3f5f7e60c66a.jpg?1",
             "name": "Tezzeret, Cruel Machinist",
             "text": "+1: Draw a card.\n0: Until your next turn, target artifact you control becomes a 5/5 creature in addition to its other types.\n\u22127: Put any number of cards from your hand onto the battlefield face down. They're 5/5 artifact creatures.",
             "colours": [
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "8d3de2c4-b886-5151-acfe-560ee7ce4c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037f6792-ab41-4bcd-a0a3-a4af4a801eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037f6792-ab41-4bcd-a0a3-a4af4a801eb7.jpg?1",
             "name": "Riddlemaster Sphinx",
             "text": "Flying\nWhen Riddlemaster Sphinx enters the battlefield, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "1b3ba2d7-eb1b-50be-a77a-73a0d8d8046a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad452a4-be42-4d2f-a161-2b327f423b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad452a4-be42-4d2f-a161-2b327f423b9c.jpg?1",
             "name": "Pendulum of Patterns",
             "text": "When Pendulum of Patterns enters the battlefield, you gain 3 life.\n{5}, {T}, Sacrifice Pendulum of Patterns: Draw a card.",
             "colours": [],
@@ -9757,7 +9757,7 @@
         },
         {
             "id": "952b8a27-8adf-588c-8902-dd310c6a49af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584e0528-01c2-49fb-aa4a-098172bb17a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584e0528-01c2-49fb-aa4a-098172bb17a7.jpg?1",
             "name": "Tezzeret's Gatebreaker",
             "text": "When Tezzeret's Gatebreaker enters the battlefield, look at the top five cards of your library. You may reveal a blue or artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n{5}{U}, {T}, Sacrifice Tezzeret's Gatebreaker: Creatures you control can't be blocked this turn.",
             "colours": [],
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "40947aad-7965-5c73-9b62-b87d22809c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf74535-31e3-4d2c-b42a-072580fa4ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf74535-31e3-4d2c-b42a-072580fa4ba0.jpg?1",
             "name": "Tezzeret's Strider",
             "text": "As long as you control a Tezzeret planeswalker, Tezzeret's Strider has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [],
@@ -9816,7 +9816,7 @@
         },
         {
             "id": "6c634c11-ac14-5715-9291-11245dbef4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2cbc2c-dbe3-4ecb-8fbe-785cb80b9e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2cbc2c-dbe3-4ecb-8fbe-785cb80b9e76.jpg?1",
             "name": "Liliana, the Necromancer",
             "text": "+1: Target player loses 2 life.\n\u22121: Return target creature card from your graveyard to your hand.\n\u22127: Destroy up to two target creatures. Put up to two creature cards from graveyards onto the battlefield under your control.",
             "colours": [
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "5e25c2a3-a36f-5a70-8223-5b1aa87fa92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39502fd-193c-4526-8dd8-0cd8c822552c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39502fd-193c-4526-8dd8-0cd8c822552c.jpg?1",
             "name": "Arisen Gorgon",
             "text": "Arisen Gorgon has deathtouch as long as you control a Liliana planeswalker. (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -9885,7 +9885,7 @@
         },
         {
             "id": "f467af65-bf88-586b-8bbb-8dedb8fc4e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee347d62-867e-40c2-bf4a-0ac2f627e24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee347d62-867e-40c2-bf4a-0ac2f627e24c.jpg?1",
             "name": "Gravewaker",
             "text": "Flying\n{5}{B}{B}: Return target creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "15a8c192-340a-5383-8d63-335074ea3de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e960fb5a-70cc-490d-99cf-99bc65485cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e960fb5a-70cc-490d-99cf-99bc65485cfb.jpg?1",
             "name": "Liliana's Spoils",
             "text": "Target opponent discards a card.\nLook at the top five cards of your library. You may reveal a black card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9950,7 +9950,7 @@
         },
         {
             "id": "9c4b2d15-24a1-5855-9e5c-d32434a7b806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27ce41-69e7-4b86-9b9c-1a724d0728e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27ce41-69e7-4b86-9b9c-1a724d0728e9.jpg?1",
             "name": "Tattered Mummy",
             "text": "When Tattered Mummy dies, each opponent loses 2 life.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "a9321096-a3a5-58e4-9881-46170038ac2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59715c84-8eed-41ad-aaf9-cfcce4445254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59715c84-8eed-41ad-aaf9-cfcce4445254.jpg?1",
             "name": "Sarkhan, Dragonsoul",
             "text": "+2: Sarkhan, Dragonsoul deals 1 damage to each opponent and each creature your opponents control.\n\u22123: Sarkhan, Dragonsoul deals 4 damage to target player or planeswalker.\n\u22129: Search your library for any number of Dragon creature cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "af270220-0b76-596d-b453-e4c8a856524a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750304-c536-47d4-922d-a3654c37ffbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750304-c536-47d4-922d-a3654c37ffbc.jpg?1",
             "name": "Kargan Dragonrider",
             "text": "As long as you control a Dragon, Kargan Dragonrider has flying. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10053,7 +10053,7 @@
         },
         {
             "id": "405d731f-ef9a-5599-a730-9b51d68e4960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96a7320-089a-4a7e-813f-49ca1620df76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96a7320-089a-4a7e-813f-49ca1620df76.jpg?1",
             "name": "Sarkhan's Dragonfire",
             "text": "Sarkhan's Dragonfire deals 3 damage to any target.\nLook at the top five cards of your library. You may reveal a red card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10084,7 +10084,7 @@
         },
         {
             "id": "5017943d-c644-53da-a710-5125691e6d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07135c4d-b4de-4054-800a-11090ed32692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07135c4d-b4de-4054-800a-11090ed32692.jpg?1",
             "name": "Sarkhan's Whelp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever you activate an ability of a Sarkhan planeswalker, Sarkhan's Whelp deals 1 damage to any target.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "fd890cf5-a0d5-55f3-b510-55fe1368aeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d389b8db-5866-4146-a379-f24b6463622b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d389b8db-5866-4146-a379-f24b6463622b.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -10150,7 +10150,7 @@
         },
         {
             "id": "d1ef30b7-200d-50f4-9046-5fcc255858d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c185555-acd4-461a-821a-b21b7b0914a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c185555-acd4-461a-821a-b21b7b0914a5.jpg?1",
             "name": "Vivien of the Arkbow",
             "text": "+2: Put two +1/+1 counters on up to one target creature.\n\u22123: Target creature you control deals damage equal to its power to target creature you don't control.\n\u22129: Creatures you control get +4/+4 and gain trample until end of turn.",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "032ae729-531d-509a-8e58-3bbc09538525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323f3c76-5e79-43e6-ae78-f555810edbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323f3c76-5e79-43e6-ae78-f555810edbc3.jpg?1",
             "name": "Aggressive Mammoth",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther creatures you control have trample.",
             "colours": [
@@ -10218,7 +10218,7 @@
         },
         {
             "id": "ed8801eb-adce-5831-9be7-3391c4e4e883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320e9f2-963d-468a-bf7a-726ef11e886d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320e9f2-963d-468a-bf7a-726ef11e886d.jpg?1",
             "name": "Skalla Wolf",
             "text": "When Skalla Wolf enters the battlefield, look at the top five cards of your library. You may reveal a green card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "35d27d78-63ff-5608-80c1-874a8baebb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60b6c02-c1f1-4ab9-bd62-ae3b447a898f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60b6c02-c1f1-4ab9-bd62-ae3b447a898f.jpg?1",
             "name": "Ursine Champion",
             "text": "{5}{G}: Ursine Champion gets +3/+3 and becomes a Bear Berserker until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -10286,7 +10286,7 @@
         },
         {
             "id": "a01f0c66-1737-5922-b6f0-04dc9874b4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b406cf-738b-4e65-ac00-b1c36ded5f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b406cf-738b-4e65-ac00-b1c36ded5f96.jpg?1",
             "name": "Vivien's Jaguar",
             "text": "Reach (This creature can block creatures with flying.)\n{2}{G}: Return Vivien's Jaguar from your graveyard to your hand. Activate this ability only if you control a Vivien planeswalker.",
             "colours": [
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "f2b2679f-0d84-5602-8014-241725c94023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f163cfbf-6df6-4af5-9fe4-23b0d511586a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f163cfbf-6df6-4af5-9fe4-23b0d511586a.jpg?1",
             "name": "Nexus of Fate",
             "text": "Take an extra turn after this one.\nIf Nexus of Fate would be put into a graveyard from anywhere, reveal Nexus of Fate and shuffle it into its owner's library instead.",
             "colours": [
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "1cae284a-cf71-5705-af66-671db364be00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd0b4d6-9753-46a3-924c-2adf3dad2819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd0b4d6-9753-46a3-924c-2adf3dad2819.jpg?1",
             "name": "Sun Sentinel",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "4d0fff67-d6dd-54a5-b261-424da0b7789a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194d52c7-cdaf-49bc-ae32-350a526af239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194d52c7-cdaf-49bc-ae32-350a526af239.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "d4379480-73c3-56f3-aea2-513f88dcd156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2115c3-aa6d-4c81-af55-5b740287b8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2115c3-aa6d-4c81-af55-5b740287b8aa.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -10449,7 +10449,7 @@
         },
         {
             "id": "3841e192-8dc5-5a21-a8f5-3e0fdd749cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574f73a7-9ff7-4ce3-9f56-002af968d35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574f73a7-9ff7-4ce3-9f56-002af968d35a.jpg?1",
             "name": "Mist-Cloaked Herald",
             "text": "Mist-Cloaked Herald can't be blocked.",
             "colours": [
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "8df0dc39-f72a-5c3f-9e68-451eea2f96ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e109e2-b8ff-47d0-a962-dc996c1656e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e109e2-b8ff-47d0-a962-dc996c1656e8.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -10516,7 +10516,7 @@
         },
         {
             "id": "a99c941b-0234-5da7-9e6d-3c3906c2aff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd574a9-2034-402c-9fd6-83c4b9db83d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd574a9-2034-402c-9fd6-83c4b9db83d1.jpg?1",
             "name": "Grasping Scoundrel",
             "text": "Grasping Scoundrel gets +1/+0 as long as it's attacking.",
             "colours": [
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "6527ad57-3614-5b55-ac81-ba53d5970ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9395fce4-11bf-4934-8323-5be4862c9779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9395fce4-11bf-4934-8323-5be4862c9779.jpg?1",
             "name": "Radiating Lightning",
             "text": "Radiating Lightning deals 3 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "9c74e719-0d75-56a3-8afc-1c2d542fb99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73542493-cd0b-4bb7-a5b8-8f889c76e4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73542493-cd0b-4bb7-a5b8-8f889c76e4d6.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -10615,7 +10615,7 @@
         },
         {
             "id": "7966e532-da34-58bf-bbd3-2961f0e8de37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc31e017-81e6-43bf-bf8e-ea0faca5d9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc31e017-81e6-43bf-bf8e-ea0faca5d9b7.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -10649,7 +10649,7 @@
         },
         {
             "id": "98f2eb2d-8171-5396-8d00-e1563e07ddcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d08909-a214-433b-a3b7-4baf916cd458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d08909-a214-433b-a3b7-4baf916cd458.jpg?1",
             "name": "Core Set 2019 Checklist",
             "text": "",
             "colours": [],
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "09221971-b901-542c-a839-079950297c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f8f97-0c27-49d6-ae9a-a0fe2a7ce38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f8f97-0c27-49d6-ae9a-a0fe2a7ce38b.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "f87c31d2-4f52-54f5-9dab-6787fcaed895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -10744,7 +10744,7 @@
         },
         {
             "id": "eb1006a1-f909-5f3e-9810-9eb2213c4ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ca5ee-7b93-4248-8f4a-b88261ee1eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ca5ee-7b93-4248-8f4a-b88261ee1eed.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -10778,7 +10778,7 @@
         },
         {
             "id": "2d7abecf-0830-5436-a81a-df51cd82f8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1d69f9-d9d7-47a9-9236-351f81ffa9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1d69f9-d9d7-47a9-9236-351f81ffa9ae.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -10812,7 +10812,7 @@
         },
         {
             "id": "ec5cc094-4b68-5646-a452-1fbc10c452c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07929ced-5c81-4b05-82e1-522fec1cf5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07929ced-5c81-4b05-82e1-522fec1cf5c0.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -10846,7 +10846,7 @@
         },
         {
             "id": "d6b17c7e-4dd6-5518-8f9b-575651d1aad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1349fcb-db31-4b1d-8063-e5c28b4472cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1349fcb-db31-4b1d-8063-e5c28b4472cc.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -10880,7 +10880,7 @@
         },
         {
             "id": "cf854a2a-2089-551a-8f99-1cf082580a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed08aac1-9e82-4049-9926-618f15222024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed08aac1-9e82-4049-9926-618f15222024.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -10914,7 +10914,7 @@
         },
         {
             "id": "2a011e54-7a5d-5059-8a10-3747237c6ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a5ec2-8898-4645-84d7-b7218682be9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a5ec2-8898-4645-84d7-b7218682be9b.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -10948,7 +10948,7 @@
         },
         {
             "id": "6ac36883-a7fc-58ec-a0dd-e7f2f5438363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9eae0-2c0b-4225-8fa5-96f04a239d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9eae0-2c0b-4225-8fa5-96f04a239d47.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "18a83d46-635f-5658-8ae9-9296d5d9ea77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f736760-60d5-412d-9877-753eb7b5f926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f736760-60d5-412d-9877-753eb7b5f926.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -11016,7 +11016,7 @@
         },
         {
             "id": "71b67905-6aed-5be8-a504-5ad9f23228b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832691a5-c638-481b-a413-3fdfc604a132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832691a5-c638-481b-a413-3fdfc604a132.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -11050,7 +11050,7 @@
         },
         {
             "id": "779d776f-7ebf-58b2-b886-64df927f86bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808b9201-6fc5-4613-85d6-6e66c6e36a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808b9201-6fc5-4613-85d6-6e66c6e36a8e.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -11085,7 +11085,7 @@
         },
         {
             "id": "1161e9df-c6ac-52a4-b867-3d3b8bf3ae8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0044cd9-2136-423e-aa2a-829e8f007535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0044cd9-2136-423e-aa2a-829e8f007535.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -11116,7 +11116,7 @@
         },
         {
             "id": "be0e87b4-77f4-5245-8c17-2258d9b75d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c97e5b2-a024-4aa7-a9b8-45f441aad138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c97e5b2-a024-4aa7-a9b8-45f441aad138.jpg?1",
             "name": "Ajani, Adversary of Tyrants Emblem",
             "text": "",
             "colours": [],
@@ -11145,7 +11145,7 @@
         },
         {
             "id": "bded6656-958c-5db6-85f0-a4137251923d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa83538-e94d-4842-ba9c-812187ecfa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa83538-e94d-4842-ba9c-812187ecfa0b.jpg?1",
             "name": "Tezzeret, Artifice Master Emblem",
             "text": "",
             "colours": [],
@@ -11174,7 +11174,7 @@
         },
         {
             "id": "b44e98da-44b0-59a6-a904-c9fdd643f0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf97003-eef0-4c01-aee1-8a8264d8ef95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf97003-eef0-4c01-aee1-8a8264d8ef95.jpg?1",
             "name": "Vivien Reid Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M20.json
+++ b/Assets/Resources/Sets/M20.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "431735d7-9961-546d-9513-8d3680a8eb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9c182-cbb3-4791-90dd-0e533ddeebda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9c182-cbb3-4791-90dd-0e533ddeebda.jpg?1",
             "name": "Aerial Assault",
             "text": "Destroy target tapped creature. You gain 1 life for each creature you control with flying.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "dcfdaecb-d1b7-5671-a4ba-1286ac0c21a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79883468-a37c-4894-8d05-6a4d150b7d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79883468-a37c-4894-8d05-6a4d150b7d59.jpg?1",
             "name": "Ajani, Strength of the Pride",
             "text": "+1: You gain life equal to the number of creatures you control plus the number of planeswalkers you control.\n\u22122: Create a 2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.\"\n0: If you have at least 15 life more than your starting life total, exile Ajani, Strength of the Pride and each artifact and creature your opponents control.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "08751dfc-cd35-59ea-886b-b8cbd7633b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba18114-af6c-48cd-82c9-eb6541d566bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba18114-af6c-48cd-82c9-eb6541d566bf.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "2f7267a2-2fc6-5466-b449-3654a5eb6fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f39777-b80a-4618-9310-a9e5b91bb2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f39777-b80a-4618-9310-a9e5b91bb2a2.jpg?1",
             "name": "Angel of Vitality",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nAngel of Vitality gets +2/+2 as long as you have 25 or more life.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "b6645784-7dc1-568a-b039-628d2da0d97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35100197-7914-450e-9205-57cb4fc345d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35100197-7914-450e-9205-57cb4fc345d6.jpg?1",
             "name": "Angelic Gift",
             "text": "Enchant creature\nWhen Angelic Gift enters the battlefield, draw a card.\nEnchanted creature has flying.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "2b4b675b-6957-5288-9790-15286545b760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f69602-b5fd-46d6-8dae-d77df35e378c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f69602-b5fd-46d6-8dae-d77df35e378c.jpg?1",
             "name": "Apostle of Purifying Light",
             "text": "Protection from black (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything black.)\n{2}: Exile target card from a graveyard.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "055a4663-72d6-540b-85b7-6d9d749904df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db6393a-88b0-4973-9832-1482f69917ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db6393a-88b0-4973-9832-1482f69917ff.jpg?1",
             "name": "Battalion Foot Soldier",
             "text": "When Battalion Foot Soldier enters the battlefield, you may search your library for any number of cards named Battalion Foot Soldier, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "7cd1c389-210a-5370-8661-87bad052538e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca42da05-330d-4050-a580-dc00f6faff24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca42da05-330d-4050-a580-dc00f6faff24.jpg?1",
             "name": "Bishop of Wings",
             "text": "Whenever an Angel enters the battlefield under your control, you gain 4 life.\nWhenever an Angel you control dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "2bee79e0-1678-5d6f-9ab2-61bcf91c79d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecdc315-95e5-450c-bedc-998eea46cf8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecdc315-95e5-450c-bedc-998eea46cf8c.jpg?1",
             "name": "Brought Back",
             "text": "Choose up to two target permanent cards in your graveyard that were put there from the battlefield this turn. Return them to the battlefield tapped.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "b001fc2c-767b-5799-abfb-1ae982cf5146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b1919e-c0c1-4ac7-9061-a337b6fe7273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b1919e-c0c1-4ac7-9061-a337b6fe7273.jpg?1",
             "name": "Cavalier of Dawn",
             "text": "Vigilance\nWhen Cavalier of Dawn enters the battlefield, destroy up to one target nonland permanent. Its controller creates a 3/3 colorless Golem artifact creature token.\nWhen Cavalier of Dawn dies, return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "d30660ed-a90c-5845-86ca-d25bf9b56972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3d90ef-6f70-4897-85c1-4e1beeb33363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3d90ef-6f70-4897-85c1-4e1beeb33363.jpg?1",
             "name": "Dawning Angel",
             "text": "Flying\nWhen Dawning Angel enters the battlefield, you gain 4 life.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "e6c49af5-d688-5952-90ec-371baa1d892a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce89a0b-d0e4-4c71-b131-0d3b0b76bc3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce89a0b-d0e4-4c71-b131-0d3b0b76bc3b.jpg?1",
             "name": "Daybreak Chaplain",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "83f3e30a-247d-57e9-b864-d9d189ce352c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcde8fe-d4a4-4c6e-926e-c4a1b45045e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcde8fe-d4a4-4c6e-926e-c4a1b45045e4.jpg?1",
             "name": "Devout Decree",
             "text": "Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "4fa0ddcf-c8c4-592b-852c-f0670dbe9372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6a2b01-da95-46fa-8673-30ffdfdee0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6a2b01-da95-46fa-8673-30ffdfdee0a5.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "4d5571ef-68fc-5878-8eb0-e3d9e533b665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021963bf-87fc-432f-b9a1-4f627885a7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021963bf-87fc-432f-b9a1-4f627885a7a9.jpg?1",
             "name": "Eternal Isolation",
             "text": "Put target creature with power 4 or greater on the bottom of its owner's library.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "4c515a98-2f75-5fb7-befb-0a9591c6ff3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f54b57-9516-424a-86a3-54843efadb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f54b57-9516-424a-86a3-54843efadb0c.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "45d89a5f-bf65-5a9f-bc68-7ad795369fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d5436-b881-45ac-b8ec-248d88714021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d5436-b881-45ac-b8ec-248d88714021.jpg?1",
             "name": "Gauntlets of Light",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and assigns combat damage equal to its toughness rather than its power.\nEnchanted creature has \"{2}{W}: Untap this creature.\"",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "0e5e6a9b-718c-5f14-94f8-6ad582ba1664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa83dc2-4ec0-4e4f-8bfd-4f6d6df06a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa83dc2-4ec0-4e4f-8bfd-4f6d6df06a2d.jpg?1",
             "name": "Glaring Aegis",
             "text": "Enchant creature\nWhen Glaring Aegis enters the battlefield, tap target creature an opponent controls.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "99598aa7-08b1-5037-a490-71996e8c2f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90883bac-bcd8-4fa9-a17c-c2402fb0714e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90883bac-bcd8-4fa9-a17c-c2402fb0714e.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything of that color.)\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "2974550e-a8df-591a-b21d-c34f7a67ce58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c32c4f2-4fa5-4874-8413-eac822121a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c32c4f2-4fa5-4874-8413-eac822121a0b.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "a5774e77-7412-5a43-b046-470d04803771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13aaa4-d40a-4fb2-9fd6-62bf76db6a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13aaa4-d40a-4fb2-9fd6-62bf76db6a13.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "52c725a4-06f5-5d1f-9769-b827362aff71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d6cea1-83d1-4045-b4da-40560af86df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d6cea1-83d1-4045-b4da-40560af86df9.jpg?1",
             "name": "Hanged Executioner",
             "text": "Flying\nWhen Hanged Executioner enters the battlefield, create a 1/1 white Spirit creature token with flying.\n{3}{W}, Exile Hanged Executioner: Exile target creature.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "8d2ef763-d299-51dc-8f60-37673521cc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c62f724-7fb4-4498-b5c1-cf65d86d8e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c62f724-7fb4-4498-b5c1-cf65d86d8e95.jpg?1",
             "name": "Herald of the Sun",
             "text": "Flying\n{3}{W}: Put a +1/+1 counter on another target creature with flying.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "1b5670df-da15-569a-8d83-3ed6e53f3555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43479f67-57b2-4a99-8928-10fc9dde33b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43479f67-57b2-4a99-8928-10fc9dde33b9.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "85c32940-0055-5326-9103-e625449d94e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d14836-0ab4-4df3-a996-76b0dda23ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d14836-0ab4-4df3-a996-76b0dda23ff6.jpg?1",
             "name": "Inspiring Captain",
             "text": "When Inspiring Captain enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "f89368ce-de20-5828-b377-eb7de4bb3aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b1acf-dd87-42ca-ad19-c27d21066030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b1acf-dd87-42ca-ad19-c27d21066030.jpg?1",
             "name": "Leyline of Sanctity",
             "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "fb0fd200-cd85-5066-9598-0f67144099b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19610e6d-61bf-4c79-bfb2-e855eb944d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19610e6d-61bf-4c79-bfb2-e855eb944d11.jpg?1",
             "name": "Loxodon Lifechanter",
             "text": "When Loxodon Lifechanter enters the battlefield, you may have your life total become the total toughness of creatures you control.\n{5}{W}: Loxodon Lifechanter gets +X/+X until end of turn, where X is your life total.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "0f9d7c08-2cd7-52c3-b581-196a14cc723d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae7971-953b-454a-84dd-ae2974946da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae7971-953b-454a-84dd-ae2974946da9.jpg?1",
             "name": "Loyal Pegasus",
             "text": "Flying\nLoyal Pegasus can't attack or block alone.",
             "colours": [
@@ -950,7 +950,7 @@
         },
         {
             "id": "7b0af0f4-4115-5852-add0-aa7ad39e87df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e463146-40a7-4274-a5a6-adf71df05c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e463146-40a7-4274-a5a6-adf71df05c4f.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolems you control get +1/+1.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "e164a265-e173-5550-8a0f-7b704cb6209f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbc462b-3736-4441-96ee-8dc5615b4529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbc462b-3736-4441-96ee-8dc5615b4529.jpg?1",
             "name": "Moment of Heroism",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "c5d34f95-1670-5766-b824-c4d580d76cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b1446-7c9f-4b62-9877-e3d1060948aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b1446-7c9f-4b62-9877-e3d1060948aa.jpg?1",
             "name": "Moorland Inquisitor",
             "text": "{2}{W}: Moorland Inquisitor gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "51124b46-0a7b-5eed-a784-5593a12a6461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31279d7c-5246-40b2-a8c7-0be4a5f24a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31279d7c-5246-40b2-a8c7-0be4a5f24a29.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "18cb8331-ad67-518e-a4e9-bb483911ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eddac86-947e-48c1-9f02-4634a7918c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eddac86-947e-48c1-9f02-4634a7918c98.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "f132a5cb-b9cc-5c02-9d01-55890124ceec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a7a53-314e-4b1f-aa33-0f312d06df71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a7a53-314e-4b1f-aa33-0f312d06df71.jpg?1",
             "name": "Raise the Alarm",
             "text": "Create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -1151,7 +1151,7 @@
         },
         {
             "id": "0004a4fb-92c6-59b2-bdbe-ceb584a9e401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f4e79b-b103-4380-afa0-61a2b1773c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f4e79b-b103-4380-afa0-61a2b1773c9e.jpg?1",
             "name": "Rule of Law",
             "text": "Each player can't cast more than one spell each turn.",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "b0ed1b16-2f51-5fe5-a0d8-558f06fb9155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95881b-8fbf-4d82-b631-5e4404ccc28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95881b-8fbf-4d82-b631-5e4404ccc28a.jpg?1",
             "name": "Sephara, Sky's Blade",
             "text": "You may pay {W} and tap four untapped creatures you control with flying rather than pay this spell's mana cost.\nFlying, lifelink\nOther creatures you control with flying have indestructible. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "7055553e-17d3-5ff4-95ae-cf15d208b824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b83ffd-bd08-48c6-98a3-811abc203f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b83ffd-bd08-48c6-98a3-811abc203f60.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "c173957a-8ee3-5851-bf44-71030982a8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7d6112-ffb2-41d8-98ed-1a7b22841dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7d6112-ffb2-41d8-98ed-1a7b22841dfd.jpg?1",
             "name": "Squad Captain",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nSquad Captain enters the battlefield with a +1/+1 counter on it for each other creature you control.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "0768c06e-5ff0-50ee-852b-5ef1e25bb8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80382963-a9d7-4c2d-8671-8dd3fdd4dbdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80382963-a9d7-4c2d-8671-8dd3fdd4dbdc.jpg?1",
             "name": "Starfield Mystic",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Starfield Mystic.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "7fdb64c5-b115-5573-af0f-cd19f4093d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d92614e-05da-4b5c-a98b-addf8ab2de7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d92614e-05da-4b5c-a98b-addf8ab2de7b.jpg?1",
             "name": "Steadfast Sentry",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Steadfast Sentry dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "c4eeba01-481b-5fb6-bee2-b6a6e2a87241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73f186b-c897-4a98-bc25-8e4aa348d8c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73f186b-c897-4a98-bc25-8e4aa348d8c9.jpg?1",
             "name": "Yoked Ox",
             "text": "",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "cc97e2e9-2017-5d78-b770-17f73931b7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da808-6698-4e55-9fac-430a6effe2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da808-6698-4e55-9fac-430a6effe2b1.jpg?1",
             "name": "Aether Gust",
             "text": "Choose target spell or permanent that's red or green. Its owner puts it on the top or bottom of their library.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "dd0b2c75-2141-55b2-b92d-c8c962f4f693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6686e6-4535-49be-b0b3-e76464656cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6686e6-4535-49be-b0b3-e76464656cd2.jpg?1",
             "name": "Agent of Treachery",
             "text": "When Agent of Treachery enters the battlefield, gain control of target permanent.\nAt the beginning of your end step, if you control three or more permanents you don't own, draw three cards.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "7e3da5ec-3e56-5fc1-a2b5-f28fc7c9c4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27efec0-40c4-48bc-a21a-3af28a6529b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27efec0-40c4-48bc-a21a-3af28a6529b5.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "db17a20c-5c80-5d85-9aa0-ba840fc53d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2080556a-6c76-4819-9eb2-c4dd4c9dbd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2080556a-6c76-4819-9eb2-c4dd4c9dbd67.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "f4dd638b-1a79-58f4-a8b8-4d6752148093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f527d1-25c0-49b9-83d5-1278ca72d009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f527d1-25c0-49b9-83d5-1278ca72d009.jpg?1",
             "name": "Atemsis, All-Seeing",
             "text": "Flying\n{2}{U}, {T}: Draw two cards, then discard a card.\nWhenever Atemsis, All-Seeing deals damage to an opponent, you may reveal your hand. If cards with at least six different converted mana costs are revealed this way, that player loses the game.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "06a1e493-adc3-59f6-ae27-e4c23d45bd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1414939c-7f15-4eb3-abeb-6e75c52d2b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1414939c-7f15-4eb3-abeb-6e75c52d2b52.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "5aeadc61-d6ae-58b9-84c0-6eb9d0fe5d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dd873-af44-45eb-9b82-a3622cc58b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dd873-af44-45eb-9b82-a3622cc58b35.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "4de2bf60-726d-50b8-ba61-3c1c5297d81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47996512-d547-491f-b481-a9c83dff04db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47996512-d547-491f-b481-a9c83dff04db.jpg?1",
             "name": "Boreal Elemental",
             "text": "Flying\nSpells your opponents cast that target Boreal Elemental cost {2} more to cast.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "cdf320ae-4c56-5db4-aca6-2730ab3bddc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0857765f-afd7-418a-a93b-c0bd1b1f037e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0857765f-afd7-418a-a93b-c0bd1b1f037e.jpg?1",
             "name": "Brineborn Cutthroat",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on Brineborn Cutthroat.",
             "colours": [
@@ -1695,7 +1695,7 @@
         },
         {
             "id": "c60d416b-3666-5ff5-b5d2-8b898f3924fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bd5c34-fa7e-4fa8-a5b1-c3aa928cc834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bd5c34-fa7e-4fa8-a5b1-c3aa928cc834.jpg?1",
             "name": "Captivating Gyre",
             "text": "Return up to three target creatures to their owners' hands.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "8266d33b-4f42-5e16-8294-18bca630403b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5356b11-e505-4838-aecb-327689eeead1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5356b11-e505-4838-aecb-327689eeead1.jpg?1",
             "name": "Cavalier of Gales",
             "text": "Flying\nWhen Cavalier of Gales enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.\nWhen Cavalier of Gales dies, shuffle it into its owner's library, then scry 2.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "a26b863c-a732-5ba8-ad23-2bd802066e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f9e7d-3f56-4e28-9908-157735f6dfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f9e7d-3f56-4e28-9908-157735f6dfa9.jpg?1",
             "name": "Cerulean Drake",
             "text": "Flying\nProtection from red (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything red.)\nSacrifice Cerulean Drake: Counter target spell that targets you.",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "54bd02d2-8a4c-59d1-b243-676d0bc6bf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2111753-a930-403f-9d94-a86dfcb069da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2111753-a930-403f-9d94-a86dfcb069da.jpg?1",
             "name": "Cloudkin Seer",
             "text": "Flying\nWhen Cloudkin Seer enters the battlefield, draw a card.",
             "colours": [
@@ -1831,7 +1831,7 @@
         },
         {
             "id": "12b77048-ebad-51b2-99e8-c7dcaccf7a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a68347-c0ef-46ff-9705-6d82d004d32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a68347-c0ef-46ff-9705-6d82d004d32c.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "fced1181-6474-5ab9-a312-14a8dd71acf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677cd48-de9f-4827-94d7-8a2301945742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677cd48-de9f-4827-94d7-8a2301945742.jpg?1",
             "name": "Drawn from Dreams",
             "text": "Look at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "7e1d2d5e-1d69-5785-bd62-219f9c8b9257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c81fda-c23d-437c-85f0-62d7b492ea32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c81fda-c23d-437c-85f0-62d7b492ea32.jpg?1",
             "name": "Dungeon Geists",
             "text": "Flying\nWhen Dungeon Geists enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Dungeon Geists.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "29ce6552-fec3-5317-8684-c5aff5a27c45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa0337-94bd-4274-b2ee-6f43747c77b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa0337-94bd-4274-b2ee-6f43747c77b3.jpg?1",
             "name": "Faerie Miscreant",
             "text": "Flying\nWhen Faerie Miscreant enters the battlefield, if you control another creature named Faerie Miscreant, draw a card.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "1f4c9e51-6723-57cb-8535-b851e9296220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3621820-4ab5-42bf-8a02-d5c066db4653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3621820-4ab5-42bf-8a02-d5c066db4653.jpg?1",
             "name": "Flood of Tears",
             "text": "Return all nonland permanents to their owners' hands. If you return four or more nontoken permanents you control this way, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "debd6eab-fddf-53a6-b433-76ec70561213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324681da-a28e-47ec-9810-5678de53e494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324681da-a28e-47ec-9810-5678de53e494.jpg?1",
             "name": "Fortress Crab",
             "text": "",
             "colours": [
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "4235b175-aa6c-5cd5-b51f-54f2aefd19da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59698a5-be76-4ce2-a337-9052821f239f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59698a5-be76-4ce2-a337-9052821f239f.jpg?1",
             "name": "Frilled Sea Serpent",
             "text": "{5}{U}{U}: Frilled Sea Serpent can't be blocked this turn.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "ec2341a2-291e-5344-924f-22fbce4944a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e1a5af-442f-4fcf-be99-6f62176be36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e1a5af-442f-4fcf-be99-6f62176be36c.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "4fe60068-722c-5288-a445-9f3ff3a65779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c9f3a-534b-42d4-9765-8d1cb15375aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c9f3a-534b-42d4-9765-8d1cb15375aa.jpg?1",
             "name": "Hard Cover",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and has \"{T}: Draw a card, then discard a card.\"",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "a1a6a517-5d25-586f-8a60-8fe69bd861f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b70152-1d7b-45c4-8c85-011d2338e0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b70152-1d7b-45c4-8c85-011d2338e0a8.jpg?1",
             "name": "Leyline of Anticipation",
             "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast spells as though they had flash.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "5775cfb2-fcd4-50bc-9c4c-a4f37ae46069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63832647-bb4d-4380-8acb-cf11e8727672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63832647-bb4d-4380-8acb-cf11e8727672.jpg?1",
             "name": "Masterful Replication",
             "text": "Choose one \u2014\n\u2022 Create two 3/3 colorless Golem artifact creature tokens.\n\u2022 Choose target artifact you control. Each other artifact you control becomes a copy of that artifact until end of turn.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "c4fe943b-975b-570a-8972-3e46d96d3fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce74849-2e08-4d08-b387-4693f1b9f653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce74849-2e08-4d08-b387-4693f1b9f653.jpg?1",
             "name": "Metropolis Sprite",
             "text": "Flying\n{U}: Metropolis Sprite gets +1/-1 until end of turn.",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "64ceb3ee-315f-56fc-9ea6-b9f3f2d3a2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543b3f69-19be-494b-928f-e16b92560e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543b3f69-19be-494b-928f-e16b92560e35.jpg?1",
             "name": "Moat Piranhas",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "639c607a-d4bf-5328-bb67-06f9fc769912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0240f9eb-e1b2-4b41-94b0-b00ad2850825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0240f9eb-e1b2-4b41-94b0-b00ad2850825.jpg?1",
             "name": "Mu Yanling, Sky Dancer",
             "text": "+2: Until your next turn, up to one target creature gets -2/-0 and loses flying.\n\u22123: Create a 4/4 blue Elemental Bird creature token with flying.\n\u22128: You get an emblem with \"Islands you control have \u2018{T}: Draw a card.'\"",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "731cf37a-0993-50db-974c-ab0fc46a7e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b83158-78b4-425e-8379-be3ef038295c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b83158-78b4-425e-8379-be3ef038295c.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2334,7 +2334,7 @@
         },
         {
             "id": "f0011bae-5c2b-5437-922f-6c15ffda5680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13becea1-e745-4c96-bfc2-6a277fb60ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13becea1-e745-4c96-bfc2-6a277fb60ee1.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "d608da39-83c7-5be4-89c4-cf00325a4e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c66692-2880-4ea2-abaf-8926c6950826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c66692-2880-4ea2-abaf-8926c6950826.jpg?1",
             "name": "Portal of Sanctuary",
             "text": "{1}, {T}: Return target creature you control and each Aura attached to it to their owners' hands. Activate this ability only during your turn.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "7e6f4425-906c-5d03-b028-3c949fd84a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec947bb8-8cb0-4e1e-8873-fe9bb9761e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec947bb8-8cb0-4e1e-8873-fe9bb9761e01.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2435,7 +2435,7 @@
         },
         {
             "id": "7d279f93-77d4-549e-ae2c-6c94f26f2e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ad3e3e-176b-48f0-af2f-fa4fc4759775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ad3e3e-176b-48f0-af2f-fa4fc4759775.jpg?1",
             "name": "Sage's Row Denizen",
             "text": "Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "97e91df4-b9a8-52ac-afcc-969ecd5589d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80137c9a-ea56-4dc7-a503-43fe192c8fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80137c9a-ea56-4dc7-a503-43fe192c8fce.jpg?1",
             "name": "Scholar of the Ages",
             "text": "When Scholar of the Ages enters the battlefield, return up to two target instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "734098f3-1179-5e26-96ea-6bff698f1250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2babef35-27ab-45aa-88cd-f21dccae5125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2babef35-27ab-45aa-88cd-f21dccae5125.jpg?1",
             "name": "Sleep Paralysis",
             "text": "Enchant creature\nWhen Sleep Paralysis enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "d8f31d72-81f6-5f63-b34b-77c0e74bd372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67483891-36d1-46f2-8b4f-b8b7bd54bdcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67483891-36d1-46f2-8b4f-b8b7bd54bdcc.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "19a7509f-08ff-5d72-96ca-954e91677ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1421115b-9a98-4ab2-bcb2-7d8899ce12db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1421115b-9a98-4ab2-bcb2-7d8899ce12db.jpg?1",
             "name": "Tale's End",
             "text": "Counter target activated ability, triggered ability, or legendary spell.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "68d068a4-95fc-5957-bb5d-9912481f3afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a960516-3864-4a7a-8117-d25dec0dd665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a960516-3864-4a7a-8117-d25dec0dd665.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "fca55f88-b8d3-569e-921a-eb5b7d27c2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0ec2d2-c004-4f6b-ba1c-29d81ad77fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0ec2d2-c004-4f6b-ba1c-29d81ad77fd1.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "a3cf1142-454e-521a-a0e5-2455f145c603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765065-b160-49b6-99ac-cd695bd0d903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765065-b160-49b6-99ac-cd695bd0d903.jpg?1",
             "name": "Winged Words",
             "text": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "9a95e2ff-1b3f-5e07-b51f-1e8d14dcb4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a8974-df86-43ee-b07f-fd2837c08a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a8974-df86-43ee-b07f-fd2837c08a6a.jpg?1",
             "name": "Yarok's Wavecrasher",
             "text": "When Yarok's Wavecrasher enters the battlefield, return another creature you control to its owner's hand.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "d148d421-9027-574b-ae54-28d5b829b180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da749962-25f2-4ddc-9e55-bf74d216284e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da749962-25f2-4ddc-9e55-bf74d216284e.jpg?1",
             "name": "Zephyr Charge",
             "text": "{1}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "ba47753d-523e-58ca-9e23-5670d7d58cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8efd95-1c2f-4dd1-b70b-3cfb10ff3a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8efd95-1c2f-4dd1-b70b-3cfb10ff3a28.jpg?1",
             "name": "Agonizing Syphon",
             "text": "Agonizing Syphon deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -2803,7 +2803,7 @@
         },
         {
             "id": "19159ba1-939b-5e73-8ecb-52f00f91389c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ff5e66-4718-43c3-8a58-1a0a8e788f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ff5e66-4718-43c3-8a58-1a0a8e788f83.jpg?1",
             "name": "Audacious Thief",
             "text": "Whenever Audacious Thief attacks, you draw a card and you lose 1 life.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "acd3c80f-9dc7-51fa-802d-8fc2d156cdde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0130d04-05f2-44f5-bd6c-8b11f798b69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0130d04-05f2-44f5-bd6c-8b11f798b69e.jpg?1",
             "name": "Barony Vampire",
             "text": "",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "dfb588e6-4ae0-5022-b014-d3ee3a693bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af78f76e-30cd-4939-9577-5a4bd1f93e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af78f76e-30cd-4939-9577-5a4bd1f93e63.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)\nDraw a card.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "c29b0b6f-083c-5425-ad89-629bec06e82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd43d44b-de27-4139-9cb8-b1f4c04fb87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd43d44b-de27-4139-9cb8-b1f4c04fb87e.jpg?1",
             "name": "Blightbeetle",
             "text": "Protection from green (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything green.)\nCreatures your opponents control can't have +1/+1 counters put on them.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "9837fd2e-8c98-548e-90e7-595b9899c995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01efd5af-ed6d-4132-8f33-37f6a9fa55d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01efd5af-ed6d-4132-8f33-37f6a9fa55d0.jpg?1",
             "name": "Blood Burglar",
             "text": "As long as it's your turn, Blood Burglar has lifelink.(Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "543b877f-daef-5476-a7d0-1e3489ed1ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7892b516-0dce-491f-8b42-031d64397e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7892b516-0dce-491f-8b42-031d64397e26.jpg?1",
             "name": "Blood for Bones",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nReturn a creature card from your graveyard to the battlefield, then return another creature card from your graveyard to your hand.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "a06ad7df-1a94-522e-928d-3ebc0e49c9f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9169431-a5b1-42ea-bcf4-6c750d2a2dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9169431-a5b1-42ea-bcf4-6c750d2a2dbb.jpg?1",
             "name": "Bloodsoaked Altar",
             "text": "{T}, Pay 2 life, Discard a card, Sacrifice a creature: Create a 5/5 black Demon creature token with flying. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "d42a67ec-1a88-582c-a5dd-ebf462843bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29156f28-38d8-4f65-b416-089f3fd97109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29156f28-38d8-4f65-b416-089f3fd97109.jpg?1",
             "name": "Bloodthirsty Aerialist",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on Bloodthirsty Aerialist.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "8862b8e7-2d6f-562d-b494-2a87bc05ee64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e75a7e9-902a-4733-8cd4-767247174a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e75a7e9-902a-4733-8cd4-767247174a4c.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "f2a1580d-9565-5110-90bc-1d8909f743ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9ed2b9-5fb9-4633-8c9a-0594ae7c49c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9ed2b9-5fb9-4633-8c9a-0594ae7c49c7.jpg?1",
             "name": "Boneclad Necromancer",
             "text": "When Boneclad Necromancer enters the battlefield, you may exile target creature card from a graveyard. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "75e92c47-bb31-579c-bf5e-cb4551b4e91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03109b9-54a8-4d68-97c2-e42c7d5c2d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03109b9-54a8-4d68-97c2-e42c7d5c2d41.jpg?1",
             "name": "Cavalier of Night",
             "text": "Lifelink\nWhen Cavalier of Night enters the battlefield, you may sacrifice another creature. When you do, destroy target creature an opponent controls.\nWhen Cavalier of Night dies, return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3174,7 +3174,7 @@
         },
         {
             "id": "4811381a-b1cf-5ed1-b8a4-15a1135f9a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18069340-a698-4f75-82cc-cc94fcf82184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18069340-a698-4f75-82cc-cc94fcf82184.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "dbaf2f58-7b36-54de-af2f-26f3d192c526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430db1a-5cad-4444-ba93-57fb32e65606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430db1a-5cad-4444-ba93-57fb32e65606.jpg?1",
             "name": "Dread Presence",
             "text": "Whenever a Swamp enters the battlefield under your control, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Dread Presence deals 2 damage to any target and you gain 2 life.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "78c2e6b4-c62a-5460-a3f4-dab0046b16f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41ff5c-9617-4033-a4fa-99323640b9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41ff5c-9617-4033-a4fa-99323640b9c3.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "6459ac30-a1fc-5b8c-a726-fd777645cfe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77972745-8689-4733-9a9d-39ae9d6273a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77972745-8689-4733-9a9d-39ae9d6273a2.jpg?1",
             "name": "Embodiment of Agonies",
             "text": "Flying, deathtouch\nEmbodiment of Agonies enters the battlefield with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard. (For example, {2}{B} and {1}{B}{B} are different mana costs.)",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "1abeffd9-3c8d-58ca-b9df-76b25fec0ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b060bc4-2d0c-46f4-b2b4-21583c2428f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b060bc4-2d0c-46f4-b2b4-21583c2428f2.jpg?1",
             "name": "Epicure of Blood",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "1f0df1bd-3429-54ed-b13b-88febe6b56b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a7004c-1952-41df-b645-b34bcbc3e401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a7004c-1952-41df-b645-b34bcbc3e401.jpg?1",
             "name": "Fathom Fleet Cutthroat",
             "text": "When Fathom Fleet Cutthroat enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "0b4881f0-a9af-58db-9a41-ea4bef5432b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2890cb5-7899-42f4-9686-a8b5ac796c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2890cb5-7899-42f4-9686-a8b5ac796c23.jpg?1",
             "name": "Feral Abomination",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3409,7 +3409,7 @@
         },
         {
             "id": "878df754-ece4-5ff3-8db3-97d61acc3f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cbe5f2-5b6b-41de-9586-c7cc83464cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cbe5f2-5b6b-41de-9586-c7cc83464cf2.jpg?1",
             "name": "Gorging Vulture",
             "text": "Flying\nWhen Gorging Vulture enters the battlefield, put the top four cards of your library into your graveyard. You gain 1 life for each creature card put into your graveyard this way.",
             "colours": [
@@ -3443,7 +3443,7 @@
         },
         {
             "id": "c9e64918-a339-5866-9a4e-d1f08d422089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb714a0-e61b-4ccf-8de6-3a6bf87c8315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb714a0-e61b-4ccf-8de6-3a6bf87c8315.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "65013578-0efd-594e-9395-636956b93a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffbb50e-76ca-4bfd-b6d1-95ab8cf3bbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffbb50e-76ca-4bfd-b6d1-95ab8cf3bbf8.jpg?1",
             "name": "Gruesome Scourger",
             "text": "When Gruesome Scourger enters the battlefield, it deals damage to target opponent or planeswalker equal to the number of creatures you control.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "7d2bc4d2-fb15-5767-b8c8-6ec4812f9959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29425426-7bf2-4872-aa35-c12c22801edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29425426-7bf2-4872-aa35-c12c22801edd.jpg?1",
             "name": "Knight of the Ebon Legion",
             "text": "{2}{B}: Knight of the Ebon Legion gets +3/+3 and gains deathtouch until end of turn.\nAt the beginning of your end step, if a player lost 4 or more life this turn, put a +1/+1 counter on Knight of the Ebon Legion. (Damage causes loss of life.)",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "6a0ea842-c04f-5765-9a57-4b0ba203e046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a1cd92-9d75-4e22-a934-a26d84967015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a1cd92-9d75-4e22-a934-a26d84967015.jpg?1",
             "name": "Legion's End",
             "text": "Exile target creature an opponent controls with converted mana cost 2 or less and all other creatures that player controls with the same name as that creature. Then that player reveals their hand and exiles all cards with that name from their hand and graveyard.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "a56c7117-f92d-5f17-ac51-df38b46f3da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d5d429-e0c6-42cc-a477-da7dabb1c295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d5d429-e0c6-42cc-a477-da7dabb1c295.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "6ec57bb9-73ab-5d0e-b620-b08eb07bec62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de3feb-5f92-43eb-b5cf-00d2b511fe68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de3feb-5f92-43eb-b5cf-00d2b511fe68.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "312592b1-ded0-5c4c-814d-4be5aa71c285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b22bc-e81b-4f27-a52b-9f3edad25439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b22bc-e81b-4f27-a52b-9f3edad25439.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3675,7 +3675,7 @@
         },
         {
             "id": "2039fba9-4482-55c6-b70b-7ecc4096abe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5758cc-1f84-455d-a983-8ec471727eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5758cc-1f84-455d-a983-8ec471727eaf.jpg?1",
             "name": "Noxious Grasp",
             "text": "Destroy target creature or planeswalker that's green or white. You gain 1 life.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "8fe4e796-97d0-5319-9f49-d108893649d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c61cb-dbf9-46c3-8795-8896ba1208d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c61cb-dbf9-46c3-8795-8896ba1208d5.jpg?1",
             "name": "Rotting Regisaur",
             "text": "At the beginning of your upkeep, discard a card.",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "0a2f85cd-f66d-5330-a9d5-314554f871a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6efdaf-bf1a-4776-8e4b-2970aa2ccd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6efdaf-bf1a-4776-8e4b-2970aa2ccd5a.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "04dd4c53-22ca-56cc-9bbb-6f40a80a7576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acc50b-856d-442d-9880-1a892b40643b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acc50b-856d-442d-9880-1a892b40643b.jpg?1",
             "name": "Scheming Symmetry",
             "text": "Choose two target players. Each of them searches their library for a card, then shuffles their library and puts that card on top of it.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "fd41578b-5e02-51fe-9e2e-a23084f51e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe9e325-fbe4-4f43-8d68-8525c4d5ce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe9e325-fbe4-4f43-8d68-8525c4d5ce8b.jpg?1",
             "name": "Sorcerer of the Fang",
             "text": "{5}{B}, {T}: Sorcerer of the Fang deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "77d443f7-0a96-5fdb-84db-aaf2db914e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764be3-dd3f-44b1-a4a6-807d1387590b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764be3-dd3f-44b1-a4a6-807d1387590b.jpg?1",
             "name": "Sorin, Imperious Bloodlord",
             "text": "+1: Target creature you control gains deathtouch and lifelink until end of turn. If it's a Vampire, put a +1/+1 counter on it.\n+1: You may sacrifice a Vampire. When you do, Sorin, Imperious Bloodlord deals 3 damage to any target and you gain 3 life.\n\u22123: You may put a Vampire creature card from your hand onto the battlefield.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "eadb8376-b491-5660-8b6f-82b136b9a139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9250f8-9085-4664-ada7-a2ef44deeac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9250f8-9085-4664-ada7-a2ef44deeac8.jpg?1",
             "name": "Soul Salvage",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "72a0b065-7e57-5b80-9a53-da08b01cec77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a9d636-6720-4d7e-8b81-12c20bce6495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a9d636-6720-4d7e-8b81-12c20bce6495.jpg?1",
             "name": "Thought Distortion",
             "text": "This spell can't be countered.\nTarget opponent reveals their hand. Exile all noncreature, nonland cards from that player's hand and graveyard.",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "ac252653-ebaa-5f7f-83f0-860f1142d650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbc0f7c-546f-4525-bb58-c99ab9b017d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbc0f7c-546f-4525-bb58-c99ab9b017d5.jpg?1",
             "name": "Undead Servant",
             "text": "When Undead Servant enters the battlefield, create a 2/2 black Zombie creature token for each card named Undead Servant in your graveyard.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "3e99571f-bfaa-5d86-9966-80c7a0dec2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e22edb-a815-413d-b62d-f32f8932b6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e22edb-a815-413d-b62d-f32f8932b6e6.jpg?1",
             "name": "Unholy Indenture",
             "text": "Enchant creature\nWhen enchanted creature dies, return that card to the battlefield under your control with a +1/+1 counter on it.",
             "colours": [
@@ -4011,7 +4011,7 @@
         },
         {
             "id": "32fbf642-6864-561f-bddf-4495208af5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c185b9-5d97-4a5a-af0b-8b9c44dcd235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c185b9-5d97-4a5a-af0b-8b9c44dcd235.jpg?1",
             "name": "Vampire of the Dire Moon",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "8c645b1e-671d-5047-9b63-7068924c498e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d405e1bc-bf58-4cce-8abe-57fb40ef0996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d405e1bc-bf58-4cce-8abe-57fb40ef0996.jpg?1",
             "name": "Vengeful Warchief",
             "text": "Whenever you lose life for the first time each turn, put a +1/+1 counter on Vengeful Warchief. (Damage causes loss of life.)",
             "colours": [
@@ -4080,7 +4080,7 @@
         },
         {
             "id": "5d53699e-bfa6-56d5-836d-439fd0854858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdf2bd9-87b9-470a-ad2e-0ebf98560f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdf2bd9-87b9-470a-ad2e-0ebf98560f87.jpg?1",
             "name": "Vilis, Broker of Blood",
             "text": "Flying\n{B}, Pay 2 life: Target creature gets -1/-1 until end of turn.\nWhenever you lose life, draw that many cards. (Damage causes loss of life.)",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "d5171138-eaef-5a1d-924c-29a232d66fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b122f8-fcd9-4b2a-92f6-f0ed7307ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b122f8-fcd9-4b2a-92f6-f0ed7307ff58.jpg?1",
             "name": "Yarok's Fenlurker",
             "text": "When Yarok's Fenlurker enters the battlefield, each opponent exiles a card from their hand.\n{2}{B}: Yarok's Fenlurker gets +1/+1 until end of turn.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "27f4b8b2-e4df-570e-94d0-0018589a2395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20234668-53ce-4cc8-892f-30ee3ecfc34c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20234668-53ce-4cc8-892f-30ee3ecfc34c.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "3d08d245-104a-5d82-88d4-854aeb393c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c18c541-758b-4237-9961-9637e996e8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c18c541-758b-4237-9961-9637e996e8a5.jpg?1",
             "name": "Cavalier of Flame",
             "text": "{1}{R}: Creatures you control get +1/+0 and gain haste until end of turn.\nWhen Cavalier of Flame enters the battlefield, discard any number of cards, then draw that many cards.\nWhen Cavalier of Flame dies, it deals X damage to each opponent and each planeswalker they control, where X is the number of land cards in your graveyard.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "6207e1e5-2e6d-5a76-b76e-4fa7fd3e9b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cabfcfe-012e-4cab-bba2-24052eac0946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cabfcfe-012e-4cab-bba2-24052eac0946.jpg?1",
             "name": "Chandra, Acolyte of Flame",
             "text": "0: Put a loyalty counter on each red planeswalker you control.\n0: Create two 1/1 red Elemental creature tokens. They gain haste. Sacrifice them at the beginning of the next end step.\n\u22122: You may cast target instant or sorcery card with converted mana cost 3 or less from your graveyard. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "a6225938-dffc-5e59-89a1-bf8125787394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d2a680-4f3b-4bfa-b77b-d2dfaced9f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d2a680-4f3b-4bfa-b77b-d2dfaced9f23.jpg?1",
             "name": "Chandra, Awakened Inferno",
             "text": "This spell can't be countered.\n+2: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n\u22123: Chandra, Awakened Inferno deals 3 damage to each non-Elemental creature.\n\u2212X: Chandra, Awakened Inferno deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "5d0e5e4f-0fee-5288-9d44-71d1691c6ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d678cf4c-60e3-40a1-a9cc-b0bd157bcf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d678cf4c-60e3-40a1-a9cc-b0bd157bcf36.jpg?1",
             "name": "Chandra, Novice Pyromancer",
             "text": "+1: Elementals you control get +2/+0 until end of turn.\n\u22121: Add {R}{R}.\n\u22122: Chandra, Novice Pyromancer deals 2 damage to any target.",
             "colours": [
@@ -4325,7 +4325,7 @@
         },
         {
             "id": "ff1482d8-6f1d-5edf-9835-cc29382fc8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f9c266-f32e-4483-9709-f83675331688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f9c266-f32e-4483-9709-f83675331688.jpg?1",
             "name": "Chandra's Embercat",
             "text": "{T}: Add {R}. Spend this mana only to cast an Elemental spell or a Chandra planeswalker spell.",
             "colours": [
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "908521f0-3203-5078-83f7-31cb890a1993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbfe793-6644-43ed-bbe1-e122c01c5e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbfe793-6644-43ed-bbe1-e122c01c5e53.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "f6e5982d-b907-56e3-8482-a89dedbe81b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b1d5c-f71e-4c68-8baf-c134e42ed6f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b1d5c-f71e-4c68-8baf-c134e42ed6f2.jpg?1",
             "name": "Chandra's Regulator",
             "text": "Whenever you activate a loyalty ability of a Chandra planeswalker, you may pay {1}. If you do, copy that ability. You may choose new targets for the copy.\n{1}, {T}, Discard a Mountain card or a red card: Draw a card.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "344324d6-0a34-5f9b-a087-49138c066d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a857da7-5438-465b-821a-bd5bfd780c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a857da7-5438-465b-821a-bd5bfd780c69.jpg?1",
             "name": "Chandra's Spitfire",
             "text": "Flying\nWhenever an opponent is dealt noncombat damage, Chandra's Spitfire gets +3/+0 until end of turn.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "38c18480-20ba-5cb7-a4d7-50f78898658d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46b090-8b03-4498-840e-cf130510892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46b090-8b03-4498-840e-cf130510892c.jpg?1",
             "name": "Daggersail Aeronaut",
             "text": "As long as it's your turn, Daggersail Aeronaut has flying.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "64359c4f-a984-5135-9d52-7c591ac684e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d981b310-5e75-4f30-baf6-37f069f00aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d981b310-5e75-4f30-baf6-37f069f00aa3.jpg?1",
             "name": "Destructive Digger",
             "text": "{3}, {T}, Sacrifice an artifact or land: Draw a card.",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "49621d10-d617-543e-af30-36c68dfc49c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5195abc4-cfa7-45dd-aa96-2e56f818a17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5195abc4-cfa7-45dd-aa96-2e56f818a17b.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever Dragon Mage deals combat damage to a player, each player discards their hand, then draws seven cards.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "a5e59b58-95fe-59e4-9c7e-83b5ac297664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09af78f-efde-4107-8406-cb12fd11c686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09af78f-efde-4107-8406-cb12fd11c686.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "8e646d78-e770-58cf-aabb-e5e9d585b6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159d476e-2f20-4f9b-adfd-9c541dc3e199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159d476e-2f20-4f9b-adfd-9c541dc3e199.jpg?1",
             "name": "Ember Hauler",
             "text": "{1}, Sacrifice Ember Hauler: It deals 2 damage to any target.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "88287869-a854-5d17-96ab-4342c5274ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df16df8-3270-4a09-8167-5b6a2068edb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df16df8-3270-4a09-8167-5b6a2068edb9.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "84ec16fb-3ce3-58c4-a1e1-95d29f61b6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702a838-8577-49b6-8b7a-f9b6d2929481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702a838-8577-49b6-8b7a-f9b6d2929481.jpg?1",
             "name": "Flame Sweep",
             "text": "Flame Sweep deals 2 damage to each creature except for creatures you control with flying.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "54b61627-cd13-5ba1-9840-4c336b63df45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d7766-a662-443c-93c5-811dbdac2480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d7766-a662-443c-93c5-811dbdac2480.jpg?1",
             "name": "Fry",
             "text": "This spell can't be countered.\nFry deals 5 damage to target creature or planeswalker that's white or blue.",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "2a487fd8-8e37-51f2-bee8-78b6f38fa993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2df9cb-14f5-470f-b438-20f4ae8d0d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2df9cb-14f5-470f-b438-20f4ae8d0d59.jpg?1",
             "name": "Glint-Horn Buccaneer",
             "text": "Haste\nWhenever you discard a card, Glint-Horn Buccaneer deals 1 damage to each opponent.\n{1}{R}, Discard a card: Draw a card. Activate this ability only if Glint-Horn Buccaneer is attacking.",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "2b7d2ea5-a3c2-5f9d-a3d1-667006d6ebfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fbbf39-cd52-474a-908e-b7a78cb5eb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fbbf39-cd52-474a-908e-b7a78cb5eb5b.jpg?1",
             "name": "Goblin Bird-Grabber",
             "text": "{R}: Goblin Bird-Grabber gains flying until end of turn. Activate this ability only if you control a creature with flying.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "f0ec9841-4452-54ee-a65a-d1cbda94a1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911af4e-4abd-4cf9-8a86-ae5d680c6f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911af4e-4abd-4cf9-8a86-ae5d680c6f12.jpg?1",
             "name": "Goblin Ringleader",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Goblin Ringleader enters the battlefield, reveal the top four cards of your library. Put all Goblin cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "5f0e31ec-9734-5e35-97d7-17ff32aab413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dc1a65-271c-455a-ae0c-f652444a53ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dc1a65-271c-455a-ae0c-f652444a53ac.jpg?1",
             "name": "Goblin Smuggler",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Another target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4869,7 +4869,7 @@
         },
         {
             "id": "13229228-ebf6-5aa8-8278-2b2765984278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac778f6-8997-47ee-a676-3eb9f8d1592f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac778f6-8997-47ee-a676-3eb9f8d1592f.jpg?1",
             "name": "Infuriate",
             "text": "Target creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "a98292e3-ce51-56cb-bc5f-650dbc950d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c47fa-7060-48da-995c-e4037640a208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c47fa-7060-48da-995c-e4037640a208.jpg?1",
             "name": "Keldon Raider",
             "text": "When Keldon Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4936,7 +4936,7 @@
         },
         {
             "id": "88cc3c2b-f3d5-5aee-ba40-77d85848b2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeea9e5-3041-4439-bc52-fd00ec83c7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeea9e5-3041-4439-bc52-fd00ec83c7a1.jpg?1",
             "name": "Lavakin Brawler",
             "text": "Whenever Lavakin Brawler attacks, it gets +1/+0 until end of turn for each Elemental you control.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "ac3fb6b8-727a-542b-a188-0c7284da1679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93c8e2-fb27-43af-83a7-2bd4d40e0eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93c8e2-fb27-43af-83a7-2bd4d40e0eff.jpg?1",
             "name": "Leyline of Combustion",
             "text": "If Leyline of Combustion is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you and/or at least one permanent you control becomes the target of a spell or ability an opponent controls, Leyline of Combustion deals 2 damage to that player.",
             "colours": [
@@ -5003,7 +5003,7 @@
         },
         {
             "id": "3a1543ab-e61d-5b45-a6b2-415d8c9b9676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a51b9b-881f-4f02-b49e-68fcca234161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a51b9b-881f-4f02-b49e-68fcca234161.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -5037,7 +5037,7 @@
         },
         {
             "id": "39db7789-71cc-587a-9f66-040fdba71190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4d2ee-e5e5-48e6-a7b8-9045dc8b10a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4d2ee-e5e5-48e6-a7b8-9045dc8b10a7.jpg?1",
             "name": "Marauding Raptor",
             "text": "Creature spells you cast cost {1} less to cast.\nWhenever another creature enters the battlefield under your control, Marauding Raptor deals 2 damage to it. If a Dinosaur is dealt damage this way, Marauding Raptor gets +2/+0 until end of turn.",
             "colours": [
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "02dfa8b1-16c9-569e-88a1-86d3b68a24e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2f4165-f87f-454b-b955-e4477c864e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2f4165-f87f-454b-b955-e4477c864e95.jpg?1",
             "name": "Mask of Immolation",
             "text": "When Mask of Immolation enters the battlefield, create a 1/1 red Elemental creature token, then attach Mask of Immolation to it.\nEquipped creature has \"Sacrifice this creature: It deals 1 damage to any target.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "8198fe5e-b984-52ba-96f9-04b0841ad868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39934090-36a6-4183-9176-97ea932d2685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39934090-36a6-4183-9176-97ea932d2685.jpg?1",
             "name": "Pack Mastiff",
             "text": "{1}{R}: Each creature you control named Pack Mastiff gets +1/+0 until end of turn.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "d2309b76-3267-5239-81cb-dbfb2c5aa888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9bf6d8-ebf6-40ff-858a-3483d19bb584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9bf6d8-ebf6-40ff-858a-3483d19bb584.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "ac16521b-fe64-530b-b41c-01bd3ae1bdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68391b41-4a17-4450-a8ac-0ce8406fe8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68391b41-4a17-4450-a8ac-0ce8406fe8c1.jpg?1",
             "name": "Reckless Air Strike",
             "text": "Choose one \u2014\n\u2022 Reckless Air Strike deals 3 damage to target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "bb947042-cd1d-5fbf-875c-9404dc33d8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe580883-cdb1-4783-9feb-1e3bea83d209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe580883-cdb1-4783-9feb-1e3bea83d209.jpg?1",
             "name": "Reduce to Ashes",
             "text": "Reduce to Ashes deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -5237,7 +5237,7 @@
         },
         {
             "id": "5d314a54-a3e3-55fe-b6bc-bafb95deb228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e94c783-e474-4cbc-a38a-27ad8dd15a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e94c783-e474-4cbc-a38a-27ad8dd15a7b.jpg?1",
             "name": "Repeated Reverberation",
             "text": "When you next cast an instant spell, cast a sorcery spell, or activate a loyalty ability this turn, copy that spell or ability twice. You may choose new targets for the copies.",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "1a7c2e29-523e-54d8-a5e3-9125e83d3f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9141d96-ad3a-4e30-b356-44e136e1f62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9141d96-ad3a-4e30-b356-44e136e1f62f.jpg?1",
             "name": "Ripscale Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "f1d33129-82b3-523e-8ee0-b7f3434941e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbe031-1547-4fa5-ba9a-caa1b1f5eb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbe031-1547-4fa5-ba9a-caa1b1f5eb5d.jpg?1",
             "name": "Scampering Scorcher",
             "text": "When Scampering Scorcher enters the battlefield, create two 1/1 red Elemental creature tokens. Elementals you control gain haste until end of turn. (They can attack and {T} this turn.)",
             "colours": [
@@ -5337,7 +5337,7 @@
         },
         {
             "id": "1c0c6aa3-8090-5e48-b435-318497ed8125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb701a84-24bd-41ed-9f06-25c8338902a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb701a84-24bd-41ed-9f06-25c8338902a5.jpg?1",
             "name": "Scorch Spitter",
             "text": "Whenever Scorch Spitter attacks, it deals 1 damage to the player or planeswalker it's attacking.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "6be0ff10-3466-5cba-ba16-14a34277d863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c866bdb-ff94-4f3f-8429-e72c2cbb94ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c866bdb-ff94-4f3f-8429-e72c2cbb94ef.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5404,7 +5404,7 @@
         },
         {
             "id": "70bdda0e-aec1-546c-a962-6e9dbf25f100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf90bd1-fa00-4af6-aa76-bd6fca7b0ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf90bd1-fa00-4af6-aa76-bd6fca7b0ac4.jpg?1",
             "name": "Tectonic Rift",
             "text": "Destroy target land. Creatures without flying can't block this turn.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "dd7b1428-f450-5d3d-8a41-06c8b5d2bbea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289b649b-c93a-44ad-bdd6-866f8b2f1bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289b649b-c93a-44ad-bdd6-866f8b2f1bc2.jpg?1",
             "name": "Thunderkin Awakener",
             "text": "Haste\nWhenever Thunderkin Awakener attacks, choose target Elemental creature card in your graveyard with toughness less than Thunderkin Awakener's toughness. Return that card to the battlefield tapped and attacking. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "f3cb8d33-9c45-51dd-b09d-de9077b88b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837557f2-6151-489c-a997-00862173cd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837557f2-6151-489c-a997-00862173cd15.jpg?1",
             "name": "Uncaged Fury",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "fbaa36e5-eaf0-5785-a3d1-c7142ba07f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5879c5-4b0a-42fa-a44f-580e0221a32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5879c5-4b0a-42fa-a44f-580e0221a32b.jpg?1",
             "name": "Unchained Berserker",
             "text": "Protection from white (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything white.)\nUnchained Berserker gets +2/+0 as long as it's attacking.",
             "colours": [
@@ -5538,7 +5538,7 @@
         },
         {
             "id": "0b77a867-5cb3-5b13-b645-133b03f4e03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd2e76-ad64-42ff-a6a2-c4cf1bec5932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd2e76-ad64-42ff-a6a2-c4cf1bec5932.jpg?1",
             "name": "Barkhide Troll",
             "text": "Barkhide Troll enters the battlefield with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from Barkhide Troll: Barkhide Troll gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "67a02663-6e5f-5e5e-a79b-46d0e445bcbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fb9767-29bf-4a69-b37c-0925d41f6b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fb9767-29bf-4a69-b37c-0925d41f6b46.jpg?1",
             "name": "Brightwood Tracker",
             "text": "{5}{G}, {T}: Look at the top four cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5607,7 +5607,7 @@
         },
         {
             "id": "86c201b9-7aa1-5392-b303-01333e18d0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4662a9c-3cbd-41f7-8c15-d048a3826a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4662a9c-3cbd-41f7-8c15-d048a3826a42.jpg?1",
             "name": "Cavalier of Thorns",
             "text": "Reach\nWhen Cavalier of Thorns enters the battlefield, reveal the top five cards of your library. Put a land card from among them onto the battlefield and the rest into your graveyard.\nWhen Cavalier of Thorns dies, you may exile it. If you do, put another target card from your graveyard on top of your library.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "2bd5a3f6-e330-57c1-b492-f7153ea6716f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b67ee8-3189-4426-8b1a-b540267768fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b67ee8-3189-4426-8b1a-b540267768fd.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "3fd4e1b7-35c9-5335-b301-2843ffe34ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c431d7-d94b-46c4-bb89-f3db56214ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c431d7-d94b-46c4-bb89-f3db56214ab4.jpg?1",
             "name": "Elvish Reclaimer",
             "text": "Elvish Reclaimer gets +2/+2 as long as there are three or more land cards in your graveyard.\n{2}, {T}, Sacrifice a land: Search your library for a land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "62bab714-5ed4-5c69-8383-5b2da4609626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d08b7a-4ed9-4e4c-a52e-9bf2a16420a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d08b7a-4ed9-4e4c-a52e-9bf2a16420a9.jpg?1",
             "name": "Feral Invocation",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "d9a56d16-552b-5df5-8ff2-9d4760dc189c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2354cb24-5c70-4aaa-8636-46866f0950c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2354cb24-5c70-4aaa-8636-46866f0950c1.jpg?1",
             "name": "Ferocious Pup",
             "text": "When Ferocious Pup enters the battlefield, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "1d8c0fdc-7cbc-547b-b25e-2abbe3d4cea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e446e90-6e31-43ed-bcb1-a01422b503c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e446e90-6e31-43ed-bcb1-a01422b503c0.jpg?1",
             "name": "Gargos, Vicious Watcher",
             "text": "Vigilance\nHydra spells you cast cost {4} less to cast.\nWhenever a creature you control becomes the target of a spell, Gargos, Vicious Watcher fights up to one target creature you don't control.",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "1b40140e-b728-578e-921b-823dc6c183a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4e2b7-2687-4ad1-99e4-0f8411b5f50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4e2b7-2687-4ad1-99e4-0f8411b5f50d.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "ef861263-5fb8-57b2-b39c-cabd4426177b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a1a70d-c146-453e-84c4-71cae4e0afaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a1a70d-c146-453e-84c4-71cae4e0afaa.jpg?1",
             "name": "Greenwood Sentinel",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -5885,7 +5885,7 @@
         },
         {
             "id": "6e8457dd-6d46-5a53-811e-9ab72c0dfdfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e619121-f2e8-4da5-8652-a2b5dae2e55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e619121-f2e8-4da5-8652-a2b5dae2e55c.jpg?1",
             "name": "Growth Cycle",
             "text": "Target creature gets +3/+3 until end of turn. It gets an additional +2/+2 until end of turn for each card named Growth Cycle in your graveyard.",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "ce9b808b-345b-5e30-a3b9-b08131b1d1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe262f2-e35b-4c85-938d-3e9e9c764c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe262f2-e35b-4c85-938d-3e9e9c764c1b.jpg?1",
             "name": "Healer of the Glade",
             "text": "When Healer of the Glade enters the battlefield, you gain 3 life.",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "74870535-4f57-51ba-b23a-ffcd303c1fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8434fd-5ee5-4be9-a28d-9e04b1b94327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8434fd-5ee5-4be9-a28d-9e04b1b94327.jpg?1",
             "name": "Howling Giant",
             "text": "Reach (This creature can block creatures with flying.)\nWhen Howling Giant enters the battlefield, create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "8559c244-3988-5849-ab3a-65acbb0a8fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8968a942-72f6-42ad-ae9d-418a1dff0ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8968a942-72f6-42ad-ae9d-418a1dff0ab3.jpg?1",
             "name": "Leafkin Druid",
             "text": "{T}: Add {G}. If you control four or more creatures, add {G}{G} instead.",
             "colours": [
@@ -6021,7 +6021,7 @@
         },
         {
             "id": "78e1d68d-9bd2-5212-83ec-5343b25dd7f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68e8342-78d2-4826-a287-64c371b97d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68e8342-78d2-4826-a287-64c371b97d19.jpg?1",
             "name": "Leyline of Abundance",
             "text": "If Leyline of Abundance is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you tap a creature for mana, add an additional {G}.\n{6}{G}{G}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6053,7 +6053,7 @@
         },
         {
             "id": "8e609100-b8b1-5c85-8335-d4bec8ab3946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2638252-f329-4d83-a705-6e369462d83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2638252-f329-4d83-a705-6e369462d83a.jpg?1",
             "name": "Loaming Shaman",
             "text": "When Loaming Shaman enters the battlefield, target player shuffles any number of target cards from their graveyard into their library.",
             "colours": [
@@ -6088,7 +6088,7 @@
         },
         {
             "id": "82041177-5a26-584a-a882-cbb61c19357a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee9bca2-1195-4bd0-aa5c-16b3726a8ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee9bca2-1195-4bd0-aa5c-16b3726a8ff2.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "757cbebf-7c2a-5a1b-8030-afa5f773816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7776d0a-e068-4cac-8848-060a2ce15b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7776d0a-e068-4cac-8848-060a2ce15b95.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "4f0ca216-cd9b-5b64-a6d2-c685a8fa7d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dcd314-f4d2-461e-a66e-7b1d8f141879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dcd314-f4d2-461e-a66e-7b1d8f141879.jpg?1",
             "name": "Natural End",
             "text": "Destroy target artifact or enchantment. You gain 3 life.",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "41f25822-345e-59e3-98de-18ae3710d19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c95074-32c8-426e-b615-8ad5427c6c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c95074-32c8-426e-b615-8ad5427c6c1c.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -6220,7 +6220,7 @@
         },
         {
             "id": "2db6f6c6-0dcc-5e88-a7af-b05767ee7342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b1f70-9861-4c66-a52f-c40002679e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b1f70-9861-4c66-a52f-c40002679e75.jpg?1",
             "name": "Nightpack Ambusher",
             "text": "Flash\nOther Wolves and Werewolves you control get +1/+1.\nAt the beginning of your end step, if you didn't cast a spell this turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "3c1b78cc-7161-5e7d-ab4c-4314885e2c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718352b9-1a68-44a1-947b-34f525f21223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718352b9-1a68-44a1-947b-34f525f21223.jpg?1",
             "name": "Overcome",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn. (They can deal excess combat damage to the player or planeswalker they're attacking.)",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "323c6a32-71d2-5acc-8a75-209812c1298b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9a13eb-2daf-43e0-b175-c6ec5b9e191e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9a13eb-2daf-43e0-b175-c6ec5b9e191e.jpg?1",
             "name": "Overgrowth Elemental",
             "text": "When Overgrowth Elemental enters the battlefield, put a +1/+1 counter on another target Elemental you control.\nWhenever another creature you control dies, you gain 1 life. If that creature was an Elemental, put a +1/+1 counter on Overgrowth Elemental.",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "96e93ba3-88fe-56c5-8296-1f18037998b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1a0c7b-ce1c-4284-9362-04b21861f69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1a0c7b-ce1c-4284-9362-04b21861f69d.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "c11e0bc0-8b46-5e44-be73-796274af1aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99851c1b-8878-4c1e-906b-f6b70e53d714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99851c1b-8878-4c1e-906b-f6b70e53d714.jpg?1",
             "name": "Pulse of Murasa",
             "text": "Return target creature or land card from a graveyard to its owner's hand. You gain 6 life.",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "f3518cf6-5696-532e-b524-65746c8d91e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8ff93-6f62-4695-85ad-d70a0b928e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8ff93-6f62-4695-85ad-d70a0b928e92.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "82bf7ddb-5752-5062-9ae5-a1005ead29fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9a718-01b9-46b2-85eb-55f6206ee5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9a718-01b9-46b2-85eb-55f6206ee5e4.jpg?1",
             "name": "Season of Growth",
             "text": "Whenever a creature enters the battlefield under your control, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nWhenever you cast a spell that targets a creature you control, draw a card.",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "21b477cf-6113-57b9-b319-fd684b89de73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9864f811-db2e-4d6d-ad59-a491a790bdd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9864f811-db2e-4d6d-ad59-a491a790bdd4.jpg?1",
             "name": "Sedge Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6482,7 +6482,7 @@
         },
         {
             "id": "3c1e73e1-2a1f-589d-814c-de80f4f5c628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1e49b6-ed0f-42f5-af22-6f4aa23ce4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1e49b6-ed0f-42f5-af22-6f4aa23ce4ef.jpg?1",
             "name": "Shared Summons",
             "text": "Search your library for up to two creature cards with different names, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "b7ddd95e-924c-561a-b80d-3405eb9a1a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e318600-21af-4003-bcfa-be926cd24c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e318600-21af-4003-bcfa-be926cd24c5c.jpg?1",
             "name": "Shifting Ceratops",
             "text": "This spell can't be countered.\nProtection from blue (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything blue.)\n{G}: Shifting Ceratops gains your choice of reach, trample, or haste until end of turn.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "fa226ce1-0696-5778-a002-a03b0c3c1518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e97e62e-4a77-4512-b5fa-400e01517e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e97e62e-4a77-4512-b5fa-400e01517e23.jpg?1",
             "name": "Silverback Shaman",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen Silverback Shaman dies, draw a card.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "0f19bb4a-95aa-5cbd-93ed-7b06bb762d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534eb449-3f1c-46ec-a965-0f5812e2c93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534eb449-3f1c-46ec-a965-0f5812e2c93e.jpg?1",
             "name": "Thicket Crasher",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther Elementals you control have trample.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "80f7fefa-0254-59a0-8e50-0d10d18656b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7367813-8be3-44a2-9a75-5f4e48cf34b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7367813-8be3-44a2-9a75-5f4e48cf34b1.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "cac60691-1936-55c1-a907-0fd3ef048fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa686c34-1c11-469f-93c2-f9891aea521f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa686c34-1c11-469f-93c2-f9891aea521f.jpg?1",
             "name": "Veil of Summer",
             "text": "Draw a card if an opponent has cast a blue or black spell this turn. Spells you control can't be countered this turn. You and permanents you control gain hexproof from blue and from black until end of turn. (You and they can't be the targets of blue or black spells or abilities your opponents control.)",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "24d6b9d8-b91d-5b08-a6e4-0882c9d67009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c5e27-c538-425e-b41f-1d6708428853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c5e27-c538-425e-b41f-1d6708428853.jpg?1",
             "name": "Vivien, Arkbow Ranger",
             "text": "+1: Distribute two +1/+1 counters among up to two target creatures. They gain trample until end of turn.\n\u22123: Target creature you control deals damage equal to its power to target creature or planeswalker.\n\u22125: You may choose a creature card you own from outside the game, reveal it, and put it into your hand.",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "f09e3e1a-4245-523a-8fde-f083efd5ef0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bbe44f-864a-446c-bfc9-5f5188e663b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bbe44f-864a-446c-bfc9-5f5188e663b8.jpg?1",
             "name": "Voracious Hydra",
             "text": "Trample\nVoracious Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Voracious Hydra enters the battlefield, choose one \u2014\n\u2022 Double the number of +1/+1 counters on Voracious Hydra.\n\u2022 Voracious Hydra fights target creature you don't control.",
             "colours": [
@@ -6754,7 +6754,7 @@
         },
         {
             "id": "4dc8ad93-2ba1-5417-b4c6-77f93293c1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79719ed0-468d-4946-8dfc-fb7e2b2e305e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79719ed0-468d-4946-8dfc-fb7e2b2e305e.jpg?1",
             "name": "Vorstclaw",
             "text": "",
             "colours": [
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "231c4105-c716-5180-b84c-65e4703ab5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9396d-28f2-40b7-908e-51db51da57a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9396d-28f2-40b7-908e-51db51da57a7.jpg?1",
             "name": "Wakeroot Elemental",
             "text": "{G}{G}{G}{G}{G}: Untap target land you control. It becomes a 5/5 Elemental creature with haste. It's still a land. (This effect lasts as long as that land remains on the battlefield.)",
             "colours": [
@@ -6823,7 +6823,7 @@
         },
         {
             "id": "7a2913ae-6696-5424-8602-3d3fad61e3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c419a2b-4389-49bc-91f1-a613ffcbfa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c419a2b-4389-49bc-91f1-a613ffcbfa0b.jpg?1",
             "name": "Wolfkin Bond",
             "text": "Enchant creature\nWhen Wolfkin Bond enters the battlefield, create a 2/2 green Wolf creature token.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6857,7 +6857,7 @@
         },
         {
             "id": "884e47dd-8e85-59e1-ac5f-cf77f8ee748d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba18cc9a-411d-45c6-bcc3-9e02ef5e2d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba18cc9a-411d-45c6-bcc3-9e02ef5e2d92.jpg?1",
             "name": "Wolfrider's Saddle",
             "text": "When Wolfrider's Saddle enters the battlefield, create a 2/2 green Wolf creature token, then attach Wolfrider's Saddle to it.\nEquipped creature gets +1/+1 and can't be blocked by more than one creature.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6891,7 +6891,7 @@
         },
         {
             "id": "56b80285-5347-5044-b47c-4d6bc2117ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f5303-428a-478c-9bd5-2410f7fcc4dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f5303-428a-478c-9bd5-2410f7fcc4dd.jpg?1",
             "name": "Woodland Champion",
             "text": "Whenever one or more tokens enter the battlefield under your control, put that many +1/+1 counters on Woodland Champion.",
             "colours": [
@@ -6926,7 +6926,7 @@
         },
         {
             "id": "d5e7b3d0-156a-5ab6-ba8f-8710e63c5809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45117b-8369-48fc-8e5d-8986e662d123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45117b-8369-48fc-8e5d-8986e662d123.jpg?1",
             "name": "Corpse Knight",
             "text": "Whenever another creature enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "abb84007-3461-5530-bdee-8e7cf7cd8300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbcf6e7-d7cf-4103-85b3-8d9d104587e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbcf6e7-d7cf-4103-85b3-8d9d104587e1.jpg?1",
             "name": "Corpse Knight",
             "text": "",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "2e2d5211-10e0-50cc-b9b1-2518b12a6f91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b96e41-caae-4e22-82f9-df5a054ea3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b96e41-caae-4e22-82f9-df5a054ea3b7.jpg?1",
             "name": "Creeping Trailblazer",
             "text": "Other Elementals you control get +1/+0.\n{2}{R}{G}: Creeping Trailblazer gets +1/+1 until end of turn for each Elemental you control.",
             "colours": [
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "37e03daa-a155-58ed-9396-87f71789df35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555709-c7cc-4c64-8a6f-8fe2bc149fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555709-c7cc-4c64-8a6f-8fe2bc149fcd.jpg?1",
             "name": "Empyrean Eagle",
             "text": "Flying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -7076,7 +7076,7 @@
         },
         {
             "id": "baa9160a-db98-5730-bdaf-1c688c16c59e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edec85ce-7daa-48c2-b25d-b22941e01e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edec85ce-7daa-48c2-b25d-b22941e01e73.jpg?1",
             "name": "Ironroot Warlord",
             "text": "Ironroot Warlord's power is equal to the number of creatures you control.\n{3}{G}{W}: Create a 1/1 white Soldier creature token.",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "c2308737-8599-57ad-ba10-92de2c88b934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f400655-f495-4b21-ab9e-57fe4d845d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f400655-f495-4b21-ab9e-57fe4d845d45.jpg?1",
             "name": "Kaalia, Zenith Seeker",
             "text": "Flying, vigilance\nWhen Kaalia, Zenith Seeker enters the battlefield, look at the top six cards of your library. You may reveal an Angel card, a Demon card, and/or a Dragon card from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "50109def-cd21-5dce-8d48-9f812005f30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe28de73-76f3-4a9e-a020-dbe5921b9be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe28de73-76f3-4a9e-a020-dbe5921b9be5.jpg?1",
             "name": "Kethis, the Hidden Hand",
             "text": "Legendary spells you cast cost {1} less to cast.\nExile two legendary cards from your graveyard: Until end of turn, each legendary card in your graveyard gains \"You may play this card from your graveyard.\"",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "2a6f2820-7490-59c3-aa5d-b33b13cab592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594cb7dc-ea88-4909-ab40-1d40fecc9817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594cb7dc-ea88-4909-ab40-1d40fecc9817.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "268366a8-3059-5b36-b760-19db02808090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c6db4e-cc37-4473-b0f5-48d8a0b82f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c6db4e-cc37-4473-b0f5-48d8a0b82f33.jpg?1",
             "name": "Lightning Stormkin",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "bb26db49-4ea6-5445-97ad-492bce69a48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618d21fe-8e3d-4887-b2e4-b92194ba1902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618d21fe-8e3d-4887-b2e4-b92194ba1902.jpg?1",
             "name": "Moldervine Reclamation",
             "text": "Whenever a creature you control dies, you gain 1 life and draw a card.",
             "colours": [
@@ -7307,7 +7307,7 @@
         },
         {
             "id": "4d306426-a1d9-5698-9f5a-8e41b53fb1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba1c64-c552-4aeb-b669-da885c8c75b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba1c64-c552-4aeb-b669-da885c8c75b2.jpg?1",
             "name": "Ogre Siegebreaker",
             "text": "{2}{B}{R}: Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "0dce71af-9bf7-5e2c-a06e-a442b8e199b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb53a29d-2de2-4874-a6f3-0fecbfa14cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb53a29d-2de2-4874-a6f3-0fecbfa14cf2.jpg?1",
             "name": "Omnath, Locus of the Roil",
             "text": "When Omnath, Locus of the Roil enters the battlefield, it deals damage to any target equal to the number of Elementals you control.\nWhenever a land enters the battlefield under your control, put a +1/+1 counter on target Elemental you control. If you control eight or more lands, draw a card.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "b604550a-0b79-5445-9de8-c09564e3928b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82389aaa-9f32-4169-a71c-1aea5af9e935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82389aaa-9f32-4169-a71c-1aea5af9e935.jpg?1",
             "name": "Risen Reef",
             "text": "Whenever Risen Reef or another Elemental enters the battlefield under your control, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "22987757-b64d-52d9-9c6e-b989ba4c2bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549634d8-1c33-401b-841d-a79ef4374dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549634d8-1c33-401b-841d-a79ef4374dd1.jpg?1",
             "name": "Skyknight Vanguard",
             "text": "Flying\nWhenever Skyknight Vanguard attacks, create a 1/1 white Soldier creature token that's tapped and attacking.",
             "colours": [
@@ -7457,7 +7457,7 @@
         },
         {
             "id": "b4549ba6-d10c-5f98-bb35-0db1c89e5e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f305027-dfd2-4b17-a6af-6b0576389623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f305027-dfd2-4b17-a6af-6b0576389623.jpg?1",
             "name": "Tomebound Lich",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhenever Tomebound Lich enters the battlefield or deals combat damage to a player, draw a card, then discard a card.",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "d3d86a4e-255d-52a4-9a6e-04ff2a9f9fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1001d43-e11b-4e5e-acd4-4a50ef89977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1001d43-e11b-4e5e-acd4-4a50ef89977f.jpg?1",
             "name": "Yarok, the Desecrated",
             "text": "Deathtouch, lifelink\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "0ef14e6a-3853-5146-8f96-46b34af0fa0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6d7bbe-0418-4a58-a97b-13b50eb0b642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6d7bbe-0418-4a58-a97b-13b50eb0b642.jpg?1",
             "name": "Anvilwrought Raptor",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "e4441670-5ff7-560b-92e6-8b8f7899953d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49283832-54f2-4619-b4a9-750493c93292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49283832-54f2-4619-b4a9-750493c93292.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -7594,7 +7594,7 @@
         },
         {
             "id": "39083845-ccae-5f27-88d9-eb330c030e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa35b2b5-3e91-4a6c-90b1-8581b4ecaf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa35b2b5-3e91-4a6c-90b1-8581b4ecaf8b.jpg?1",
             "name": "Colossus Hammer",
             "text": "Equipped creature gets +10/+10 and loses flying.\nEquip {8} ({8}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "ddabaad6-ee3c-58f3-9e03-2a712a1c0a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeab4819-dd26-4f5c-8538-50f2caca292d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeab4819-dd26-4f5c-8538-50f2caca292d.jpg?1",
             "name": "Diamond Knight",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nAs Diamond Knight enters the battlefield, choose a color.\nWhenever you cast a spell of the chosen color, put a +1/+1 counter on Diamond Knight.",
             "colours": [],
@@ -7655,7 +7655,7 @@
         },
         {
             "id": "e0f6c2a4-0d3e-596b-ab5b-9a8d8b2d5bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55c6a1-1f26-4254-ac62-fdbe94278de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55c6a1-1f26-4254-ac62-fdbe94278de5.jpg?1",
             "name": "Diviner's Lockbox",
             "text": "{1}, {T}: Choose a card name, then reveal the top card of your library. If that card has the chosen name, sacrifice Diviner's Lockbox and draw three cards. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "63570c0d-34bf-5340-94a2-81eeb3da6624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa48620-4c3d-4f75-be1f-c12c4aa59f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa48620-4c3d-4f75-be1f-c12c4aa59f51.jpg?1",
             "name": "Golos, Tireless Pilgrim",
             "text": "When Golos, Tireless Pilgrim enters the battlefield, you may search your library for a land card, put that card onto the battlefield tapped, then shuffle your library.\n{2}{W}{U}{B}{R}{G}: Exile the top three cards of your library. You may play them this turn without paying their mana costs.",
             "colours": [],
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "639e88e0-5347-50ce-bbc9-bb86bedc3824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a135e09-b534-4836-9a10-3a9a4a9f8c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a135e09-b534-4836-9a10-3a9a4a9f8c53.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "Creature cards in graveyards and libraries can't enter the battlefield.\nPlayers can't cast spells from graveyards or libraries.",
             "colours": [],
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "4bdc0de6-3e6e-5d7b-8f3f-5edc609f9586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f723-0e0b-44a4-bfc6-f48f17a805d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f723-0e0b-44a4-bfc6-f48f17a805d9.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "287f7b11-d4ff-57d0-b06b-717dab0327a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78e53c-1aec-4c49-bf58-165dd7b59d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78e53c-1aec-4c49-bf58-165dd7b59d64.jpg?1",
             "name": "Icon of Ancestry",
             "text": "As Icon of Ancestry enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{3}, {T}: Look at the top three cards of your library. You may reveal a creature card of the chosen type from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "2732a93b-2b38-547a-8a8f-24866017533c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715e637a-dfd8-45a0-b1ea-53e4abd29307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715e637a-dfd8-45a0-b1ea-53e4abd29307.jpg?1",
             "name": "Manifold Key",
             "text": "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "5ffb0c4f-b22e-53b5-a90d-22a3b5fe33fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ac5204-69ef-491d-9ca8-f522b99f1412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ac5204-69ef-491d-9ca8-f522b99f1412.jpg?1",
             "name": "Marauder's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "e38486f8-7f10-55e8-a6b0-82f0b2b25c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b748341f-557c-4b6a-a36c-c08c9cc05b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b748341f-557c-4b6a-a36c-c08c9cc05b90.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "a036efb1-6672-5126-846b-544cede09b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924a24e7-91b8-4ceb-a136-7a765d98c994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924a24e7-91b8-4ceb-a136-7a765d98c994.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast the top card of your library if it's an artifact card or a colorless nonland card.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -7925,7 +7925,7 @@
         },
         {
             "id": "653a05dc-0525-5443-bd6b-a0a1593184e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad608eb3-d387-4414-b194-703f38863896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad608eb3-d387-4414-b194-703f38863896.jpg?1",
             "name": "Pattern Matcher",
             "text": "When Pattern Matcher enters the battlefield, you may search your library for a card with the same name as another creature you control, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7956,7 +7956,7 @@
         },
         {
             "id": "93ac3f01-8375-5c4c-bfe1-e7852c80b9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9fdb01-ba52-4510-897e-0d69558fdaee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9fdb01-ba52-4510-897e-0d69558fdaee.jpg?1",
             "name": "Prismite",
             "text": "{2}: Add one mana of any color.",
             "colours": [],
@@ -7987,7 +7987,7 @@
         },
         {
             "id": "d89025fc-79e6-524b-bb47-c048d1a12000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5521cb92-03b0-44ab-a141-40dc0eb5a79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5521cb92-03b0-44ab-a141-40dc0eb5a79f.jpg?1",
             "name": "Retributive Wand",
             "text": "{3}, {T}: Retributive Wand deals 1 damage to any target.\nWhen Retributive Wand is put into a graveyard from the battlefield, it deals 5 damage to any target.",
             "colours": [],
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "3147f3de-acf2-5e66-b489-4d7e4486fbfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd2ebbe-71c6-405b-bad0-5680f0ff575c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd2ebbe-71c6-405b-bad0-5680f0ff575c.jpg?1",
             "name": "Salvager of Ruin",
             "text": "Sacrifice Salvager of Ruin: Choose target permanent card in your graveyard that was put there from the battlefield this turn. Return it to your hand.",
             "colours": [],
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "988dc032-6745-5ba0-aaec-b83924a0840c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f2d2e8-a9ed-42cc-9a8a-fc697a7251e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f2d2e8-a9ed-42cc-9a8a-fc697a7251e5.jpg?1",
             "name": "Scuttlemutt",
             "text": "{T}: Add one mana of any color.\n{T}: Target creature becomes the color or colors of your choice until end of turn.",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "c3efc1dd-d5d6-5b77-89db-91bee8ec12b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed61426-e652-4b48-b936-8be9b6b57731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed61426-e652-4b48-b936-8be9b6b57731.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "f5404ea9-21e9-5b58-abe3-11de6f13c482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4de70a-729b-4566-b6f3-c76f551405a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4de70a-729b-4566-b6f3-c76f551405a5.jpg?1",
             "name": "Stone Golem",
             "text": "",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "b086f8ca-d938-54ac-847e-99084aa0a638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57db6ba8-f6c1-41be-8bee-93e573d052d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57db6ba8-f6c1-41be-8bee-93e573d052d7.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.",
             "colours": [],
@@ -8167,7 +8167,7 @@
         },
         {
             "id": "b33a9259-82d2-5754-81c7-79a13d161b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7ec5a3-3c40-4090-b9e3-11fb5b06fb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7ec5a3-3c40-4090-b9e3-11fb5b06fb8f.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "bf105aed-8bea-56f8-8e69-f74e63d22c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31514c67-4c55-4f28-9872-08e4d9bc6505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31514c67-4c55-4f28-9872-08e4d9bc6505.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "b70c9550-362c-5fa0-a5c1-1da1128d76db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9e9cb-68ab-4856-8ad6-30f66666dd93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9e9cb-68ab-4856-8ad6-30f66666dd93.jpg?1",
             "name": "Cryptic Caves",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Cryptic Caves: Draw a card. Activate this ability only if you control five or more lands.",
             "colours": [],
@@ -8257,7 +8257,7 @@
         },
         {
             "id": "b4726b1b-3f63-5fff-9c1e-bc94525fa2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ff247f-82d1-4b79-9ac0-1471a1f0f58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ff247f-82d1-4b79-9ac0-1471a1f0f58b.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8288,7 +8288,7 @@
         },
         {
             "id": "545c25ee-cde6-56b3-8835-10b607691c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0fa2fb-6770-4a81-b830-4acfa957655a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0fa2fb-6770-4a81-b830-4acfa957655a.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "58298e4b-7194-5412-b7cd-004f0f5bbdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ca3f4-29aa-4c4c-8ff2-8cdd70c69943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ca3f4-29aa-4c4c-8ff2-8cdd70c69943.jpg?1",
             "name": "Field of the Dead",
             "text": "Field of the Dead enters the battlefield tapped.\n{T}: Add {C}.\nWhenever Field of the Dead or another land enters the battlefield under your control, if you control seven or more lands with different names, create a 2/2 black Zombie creature token.",
             "colours": [],
@@ -8344,7 +8344,7 @@
         },
         {
             "id": "f5fa0691-2dc5-5e4a-b3cd-16a73c51d511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b7a1d-943b-43f8-a70b-1a3a205476cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b7a1d-943b-43f8-a70b-1a3a205476cf.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "278921c5-23cd-5997-8771-2851004177ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013033-3995-4ba8-b0c3-0614c79aaaab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013033-3995-4ba8-b0c3-0614c79aaaab.jpg?1",
             "name": "Lotus Field",
             "text": "Hexproof\nLotus Field enters the battlefield tapped.\nWhen Lotus Field enters the battlefield, sacrifice two lands.\n{T}: Add three mana of any one color.",
             "colours": [],
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "f7c95ec2-4e2a-54e7-ac24-bfa48c932467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05dd57c-91ca-4c79-b6da-1e504d806f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05dd57c-91ca-4c79-b6da-1e504d806f28.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "da131434-b354-56a7-856d-718a05f2f194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9edd33-a64e-4526-a89f-edd31ac4b175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9edd33-a64e-4526-a89f-edd31ac4b175.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8465,7 +8465,7 @@
         },
         {
             "id": "0d39c56a-8754-50ec-82da-88907cbbbb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804db4ef-712f-4a39-a00f-51e99b05274c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804db4ef-712f-4a39-a00f-51e99b05274c.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8496,7 +8496,7 @@
         },
         {
             "id": "908ce15b-975a-5b39-b5bf-a9957e0858d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8ec3c-d2cb-477c-a7e8-ff497df646d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8ec3c-d2cb-477c-a7e8-ff497df646d6.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8527,7 +8527,7 @@
         },
         {
             "id": "2b04be75-2d71-588b-b943-62ed99e00476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e327d94-5540-49f0-b1a2-a3fb614c9651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e327d94-5540-49f0-b1a2-a3fb614c9651.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "6a906bdb-6910-52c0-ac7f-58378e69706d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c284acd-4407-42ad-9f4c-359041223609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c284acd-4407-42ad-9f4c-359041223609.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8589,7 +8589,7 @@
         },
         {
             "id": "d9c19ac4-30bf-5996-b1ad-121e9620a36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cbb241-7268-42ac-a3ae-d326c9b6247f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cbb241-7268-42ac-a3ae-d326c9b6247f.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8620,7 +8620,7 @@
         },
         {
             "id": "880e6cb6-a4d1-543b-8a35-583591dc51a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a874dfe1-eb4d-4817-877f-8a4cd75107e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a874dfe1-eb4d-4817-877f-8a4cd75107e1.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "cf48bb66-3c37-54b1-8a67-d36f63f720ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1b12d2-2f4f-4cfd-9728-edf8232c99e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1b12d2-2f4f-4cfd-9728-edf8232c99e7.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "0ac4e7fb-3a73-5645-ba65-38e76b4f95bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa37aa-ef2e-49ff-9496-86b0e69128a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa37aa-ef2e-49ff-9496-86b0e69128a7.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8713,7 +8713,7 @@
         },
         {
             "id": "6264d4f0-ee9e-5e79-855a-9e58dc079bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0b1ba-fd3d-4f1c-9e8e-22280eeeff7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0b1ba-fd3d-4f1c-9e8e-22280eeeff7d.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8744,7 +8744,7 @@
         },
         {
             "id": "4fefe700-3104-50e8-812e-2e305bc8813d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fb4a34-c11e-45e9-a986-43c0a0ae5424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fb4a34-c11e-45e9-a986-43c0a0ae5424.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8782,7 +8782,7 @@
         },
         {
             "id": "183e8311-986f-5901-93e7-a46381871de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9495172-6fde-4aae-b47e-fc887440120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9495172-6fde-4aae-b47e-fc887440120e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "ce37d84f-20ec-517a-a620-c81313fec96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd675c7-7dac-4ad1-9243-6d1eda0fa30c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd675c7-7dac-4ad1-9243-6d1eda0fa30c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "00141b2c-2eff-5228-8fbe-6383db16769d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa01578-faf9-4694-86a0-c81f5b2a0dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa01578-faf9-4694-86a0-c81f5b2a0dd8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8896,7 +8896,7 @@
         },
         {
             "id": "db340b60-f2fb-5a74-9cc3-cc8cc33b9374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7f4393-38f9-43b5-873b-58246183b874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7f4393-38f9-43b5-873b-58246183b874.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8934,7 +8934,7 @@
         },
         {
             "id": "819b16e6-ae68-571c-96ad-84985a63a32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a516f8-861b-4c3b-9d9b-0adc04ec689f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a516f8-861b-4c3b-9d9b-0adc04ec689f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "e49bf6ed-4f89-511d-bde7-a0fa8999b5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3bac6-81c9-4bb5-aca6-371cec8efa0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3bac6-81c9-4bb5-aca6-371cec8efa0d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "ef97f930-9b11-5709-bec9-5d16ac3f971f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3448b8b-8baf-492a-a1d6-4bb676c43cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3448b8b-8baf-492a-a1d6-4bb676c43cab.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "328ba861-c227-521a-aff4-f93a86e6db06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a196e-8604-49d2-a66a-6f7c0eafd5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a196e-8604-49d2-a66a-6f7c0eafd5de.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9086,7 +9086,7 @@
         },
         {
             "id": "67936d08-a4a8-5e9a-bd84-d943bc1e564a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3a387a-4bc1-4338-9d1e-0fbcb6f03b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3a387a-4bc1-4338-9d1e-0fbcb6f03b82.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9124,7 +9124,7 @@
         },
         {
             "id": "d3c8cc8e-2e01-5925-85fb-999b7796ef31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9023215-035f-4f12-9f75-04b995b5d24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9023215-035f-4f12-9f75-04b995b5d24a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9162,7 +9162,7 @@
         },
         {
             "id": "38bf423b-6983-56f6-afdb-32c83420e268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba77dad-f157-4e31-9654-921967ea98c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba77dad-f157-4e31-9654-921967ea98c0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9200,7 +9200,7 @@
         },
         {
             "id": "4066857f-e1f2-5095-9a60-ec713874fc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f7531-e137-463b-bec3-e86756b6ed71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f7531-e137-463b-bec3-e86756b6ed71.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9238,7 +9238,7 @@
         },
         {
             "id": "5ed95bbd-023f-5120-8dc7-68be367478ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe67eb3-f10d-4f34-b4b0-fd00ee8cc325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe67eb3-f10d-4f34-b4b0-fd00ee8cc325.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9276,7 +9276,7 @@
         },
         {
             "id": "36558c4d-b702-5aff-be17-98681a1d4a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf7d0ad-8fe2-4065-89e3-c2ee04062695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf7d0ad-8fe2-4065-89e3-c2ee04062695.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "0c8071e4-e111-5c01-aa86-665edc0813f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f8188-3d9e-4937-bfcb-b73acd80878d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f8188-3d9e-4937-bfcb-b73acd80878d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9352,7 +9352,7 @@
         },
         {
             "id": "c4198bae-2c2b-51bc-8d57-5b9640232e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42352899-f2f2-4dea-863b-8d685e63b454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42352899-f2f2-4dea-863b-8d685e63b454.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "cca7e094-90a7-570a-8c4d-abd1c9d8c85b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feb2af-b363-4377-98b1-6a07df7f1acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feb2af-b363-4377-98b1-6a07df7f1acd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9428,7 +9428,7 @@
         },
         {
             "id": "dd838b36-2e58-502c-af14-db43abbea37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56caba21-b773-4245-b3f8-3ae62725c14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56caba21-b773-4245-b3f8-3ae62725c14f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "5e678489-332b-5319-a5ab-4f79074775bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7e6ec-9bfe-4062-a538-2a748d2eed1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7e6ec-9bfe-4062-a538-2a748d2eed1f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "c36c2a16-d6b7-51c9-8c94-e505ab618d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd040a8-b818-465b-a78b-d68402982abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd040a8-b818-465b-a78b-d68402982abc.jpg?1",
             "name": "Rienne, Angel of Rebirth",
             "text": "Flying\nOther multicolored creatures you control get +1/+0.\nWhenever another multicolored creature you control dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -9543,7 +9543,7 @@
         },
         {
             "id": "bfbeccc8-5444-5ac9-9875-15161657a158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba41e5f-66b8-4459-8a07-bbe893216f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba41e5f-66b8-4459-8a07-bbe893216f1e.jpg?1",
             "name": "Ajani, Inspiring Leader",
             "text": "+2: You gain 2 life. Put two +1/+1 counters on up to one target creature.\n\u22123: Exile target creature. Its controller gains 2 life.\n\u221210: Creatures you control gain flying and double strike until end of turn.",
             "colours": [
@@ -9578,7 +9578,7 @@
         },
         {
             "id": "05dfdeb6-db9b-5609-9aac-25128bef36e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edcb9b-f56b-4a34-b4bd-d22ee929041a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edcb9b-f56b-4a34-b4bd-d22ee929041a.jpg?1",
             "name": "Goldmane Griffin",
             "text": "Flying, vigilance\nWhen Goldmane Griffin enters the battlefield, you may search your library and/or graveyard for a card named Ajani, Inspiring Leader, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9611,7 +9611,7 @@
         },
         {
             "id": "966742da-a549-5932-981f-62ea54e3dcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5fa4bb-e061-456f-808e-8d98b2c8abf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5fa4bb-e061-456f-808e-8d98b2c8abf5.jpg?1",
             "name": "Savannah Sage",
             "text": "When Savannah Sage enters the battlefield, you gain 2 life.",
             "colours": [
@@ -9645,7 +9645,7 @@
         },
         {
             "id": "2fd94c5a-2eed-59d1-9fde-06bbe95902bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6397d426-00e0-44da-b23c-44ccea65f5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6397d426-00e0-44da-b23c-44ccea65f5aa.jpg?1",
             "name": "Twinblade Paladin",
             "text": "Whenever you gain life, put a +1/+1 counter on Twinblade Paladin.\nAs long as you have 25 or more life, Twinblade Paladin has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "5dde6bfe-34d2-59a4-bf3d-b555a318b783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae9595-8e76-4d8c-a08c-00434be75672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae9595-8e76-4d8c-a08c-00434be75672.jpg?1",
             "name": "Mu Yanling, Celestial Wind",
             "text": "+1: Until your next turn, up to one target creature gets -5/-0.\n\u22123: Return up to two target creatures to their owners' hands.\n\u22127: Creatures you control with flying get +5/+5 until end of turn.",
             "colours": [
@@ -9714,7 +9714,7 @@
         },
         {
             "id": "9efec105-a0f7-5628-95c6-adca7f65ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e92e98-202f-4790-8411-17aebffe19fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e92e98-202f-4790-8411-17aebffe19fe.jpg?1",
             "name": "Celestial Messenger",
             "text": "Flash (You may cast this card any time you could cast an instant.)\nFlying\nCelestial Messenger gets +1/+1 as long as you control a Yanling planeswalker.",
             "colours": [
@@ -9748,7 +9748,7 @@
         },
         {
             "id": "2be113b4-b703-58d1-be21-e20e68b97931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bfbc4-1c9b-44f7-b4a7-068290db3bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bfbc4-1c9b-44f7-b4a7-068290db3bac.jpg?1",
             "name": "Waterkin Shaman",
             "text": "Whenever a creature with flying enters the battlefield under your control, Waterkin Shaman gets +1/+1 until end of turn.",
             "colours": [
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "73707c52-2398-5576-9012-c4630808ce87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aca389-6830-4297-97bc-e3a2a1a1d41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aca389-6830-4297-97bc-e3a2a1a1d41a.jpg?1",
             "name": "Yanling's Harbinger",
             "text": "Flying\nWhen Yanling's Harbinger enters the battlefield, you may search your library and/or graveyard for a card named Mu Yanling, Celestial Wind, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9815,7 +9815,7 @@
         },
         {
             "id": "354786a4-b8cd-5bc3-9789-059a0c07ff95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf20ea7b-e480-4b0e-b080-888f24d3c08d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf20ea7b-e480-4b0e-b080-888f24d3c08d.jpg?1",
             "name": "Sorin, Vampire Lord",
             "text": "+1: Up to one target creature gets +2/+0 until end of turn.\n\u22122: Sorin, Vampire Lord deals 4 damage to any target. You gain 4 life.\n\u22128: Until end of turn, each Vampire you control gains \"{T}: Gain control of target creature.\"",
             "colours": [
@@ -9850,7 +9850,7 @@
         },
         {
             "id": "62e411af-f997-5745-8094-7c863bb8cde1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25ea81f-9786-4622-978d-b082fb72622c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25ea81f-9786-4622-978d-b082fb72622c.jpg?1",
             "name": "Savage Gorger",
             "text": "Flying\nAt the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on Savage Gorger. (Damage causes loss of life.)",
             "colours": [
@@ -9883,7 +9883,7 @@
         },
         {
             "id": "f2979ff9-44d0-5632-82a4-1ed0f2df1944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416b000d-77d0-4c83-bbbd-d1107f746dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416b000d-77d0-4c83-bbbd-d1107f746dde.jpg?1",
             "name": "Sorin's Guide",
             "text": "When Sorin's Guide enters the battlefield, you may search your library and/or graveyard for a card named Sorin, Vampire Lord, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "f36017cf-df9f-583b-b55b-5e7fe8daf139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599e8ed3-4341-4373-8871-2768a90d98c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599e8ed3-4341-4373-8871-2768a90d98c1.jpg?1",
             "name": "Thirsting Bloodlord",
             "text": "Other Vampires you control get +1/+1.",
             "colours": [
@@ -9949,7 +9949,7 @@
         },
         {
             "id": "2c4461cc-fd30-50f9-9604-2b648717f64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c6c4b-62ab-4d44-a2d7-64b44d163606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c6c4b-62ab-4d44-a2d7-64b44d163606.jpg?1",
             "name": "Chandra, Flame's Fury",
             "text": "+1: Chandra, Flame's Fury deals 2 damage to any target.\n\u22122: Chandra, Flame's Fury deals 4 damage to target creature and 2 damage to that creature's controller.\n\u22128: Chandra, Flame's Fury deals 10 damage to target player and each creature that player controls.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "a7c64488-416f-59aa-a965-0bbe3dec232a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f13b6a7-fa62-4d94-a56c-f2e64c8c1666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f13b6a7-fa62-4d94-a56c-f2e64c8c1666.jpg?1",
             "name": "Chandra's Flame Wave",
             "text": "Chandra's Flame Wave deals 2 damage to target player and each creature that player controls. Search your library and/or graveyard for a card named Chandra, Flame's Fury, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10015,7 +10015,7 @@
         },
         {
             "id": "c63d90f8-0cc6-5505-9dfb-2e312f922771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57f8b5-fde9-498d-82bf-34bfb2370703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57f8b5-fde9-498d-82bf-34bfb2370703.jpg?1",
             "name": "Pyroclastic Elemental",
             "text": "{1}{R}{R}: Pyroclastic Elemental deals 1 damage to target player.",
             "colours": [
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "14635f42-59f0-5a42-b117-33d21dfe93a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e317c-55c4-43b2-91aa-3e0009cfd7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e317c-55c4-43b2-91aa-3e0009cfd7d5.jpg?1",
             "name": "Wildfire Elemental",
             "text": "Whenever an opponent is dealt noncombat damage, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "f12523f2-916c-5bcd-9b8d-19db17ff57c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ead409-3bce-47c8-ace7-498c38522369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ead409-3bce-47c8-ace7-498c38522369.jpg?1",
             "name": "Vivien, Nature's Avenger",
             "text": "+1: Put three +1/+1 counters on up to one target creature.\n\u22121: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.\n\u22126: Target creature gets +10/+10 and gains trample until end of turn.",
             "colours": [
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "eb4dfa31-77bc-5a35-ba4a-546b196513a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4d0ed2-3fc5-4cb0-b886-e30b21e76872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4d0ed2-3fc5-4cb0-b886-e30b21e76872.jpg?1",
             "name": "Ethereal Elk",
             "text": "Trample\nWhen Ethereal Elk enters the battlefield, you may search your library and/or graveyard for a card named Vivien, Nature's Avenger, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10150,7 +10150,7 @@
         },
         {
             "id": "27df42ef-84ae-5145-8743-fbf9785c1396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a69558-aca0-413d-9762-2fa115b44abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a69558-aca0-413d-9762-2fa115b44abd.jpg?1",
             "name": "Gnarlback Rhino",
             "text": "Trample  (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever you cast a spell that targets Gnarlback Rhino, draw a card.",
             "colours": [
@@ -10183,7 +10183,7 @@
         },
         {
             "id": "7bb445ee-2072-5eb2-9f22-786cda2943de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c51c6bd-2ecc-4d92-a406-fcb31e889b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c51c6bd-2ecc-4d92-a406-fcb31e889b45.jpg?1",
             "name": "Vivien's Crocodile",
             "text": "Vivien's Crocodile gets +1/+1 as long as you control a Vivien planeswalker.",
             "colours": [
@@ -10217,7 +10217,7 @@
         },
         {
             "id": "e751bbfb-1c25-56fb-8924-e401cbe01f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e058dc51-b200-42ee-a345-a63cfaa397fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e058dc51-b200-42ee-a345-a63cfaa397fe.jpg?1",
             "name": "Angelic Guardian",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever one or more creatures you control attack, they gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "5c57289c-2c3d-53f8-bf05-be120458c3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbf17a0-2dbc-4e79-9cfa-ea49b1605105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbf17a0-2dbc-4e79-9cfa-ea49b1605105.jpg?1",
             "name": "Bastion Enforcer",
             "text": "",
             "colours": [
@@ -10284,7 +10284,7 @@
         },
         {
             "id": "1c033da6-da7b-5560-8066-120876f1604f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f32ff8-3b49-4ce8-96a0-ba0d99477de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f32ff8-3b49-4ce8-96a0-ba0d99477de1.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "2dad816e-1ef7-550f-baff-927218d4fb50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766418a-eb1d-4536-ae51-7f3e8969bb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766418a-eb1d-4536-ae51-7f3e8969bb78.jpg?1",
             "name": "Haazda Officer",
             "text": "When Haazda Officer enters the battlefield, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "5a0e121f-4029-5cd9-bae2-f6b871421704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696d6c4b-69d7-498b-87d4-0a03b16cc971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696d6c4b-69d7-498b-87d4-0a03b16cc971.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "9f78ffca-f760-5f31-b744-915922165e16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd3aca5-516f-4500-9d7f-95630401d3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd3aca5-516f-4500-9d7f-95630401d3ae.jpg?1",
             "name": "Imperial Outrider",
             "text": "",
             "colours": [
@@ -10419,7 +10419,7 @@
         },
         {
             "id": "e47ab002-1e17-5894-bddd-274d7fbe3e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d57e98-e05a-4a89-900e-20fe675a62ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d57e98-e05a-4a89-900e-20fe675a62ef.jpg?1",
             "name": "Ironclad Krovod",
             "text": "",
             "colours": [
@@ -10452,7 +10452,7 @@
         },
         {
             "id": "fcc224b4-f27e-56da-9b4a-131b52243f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e689e4a-fc54-46f4-b0c5-c0e65d88340e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e689e4a-fc54-46f4-b0c5-c0e65d88340e.jpg?1",
             "name": "Prowling Caracal",
             "text": "",
             "colours": [
@@ -10485,7 +10485,7 @@
         },
         {
             "id": "da74d0e9-949a-58d7-ab5f-98f40f354429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84784231-2675-4b5b-929f-a796c091a77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84784231-2675-4b5b-929f-a796c091a77c.jpg?1",
             "name": "Serra's Guardian",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)\nOther creatures you control have vigilance.",
             "colours": [
@@ -10518,7 +10518,7 @@
         },
         {
             "id": "dbf863b4-1ed9-5366-9054-8f984830b60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab07387-a9f2-4325-804e-6383408644fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab07387-a9f2-4325-804e-6383408644fd.jpg?1",
             "name": "Show of Valor",
             "text": "Target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "72e54935-48e8-50dc-820e-5841a9d22a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fd27a8-2de6-454f-8174-a60918bfe60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fd27a8-2de6-454f-8174-a60918bfe60e.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -10582,7 +10582,7 @@
         },
         {
             "id": "44540cc0-df49-5ec4-99ce-0912a62c99ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fff340-8e2a-4182-9ece-af5749fa0d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fff340-8e2a-4182-9ece-af5749fa0d2e.jpg?1",
             "name": "Take Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -10613,7 +10613,7 @@
         },
         {
             "id": "9be5f44f-99a9-50b3-a4fe-5c460c3a0956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e3a90c-1e5c-4646-b3d5-ff46d3fa7b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e3a90c-1e5c-4646-b3d5-ff46d3fa7b35.jpg?1",
             "name": "Trusted Pegasus",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Trusted Pegasus attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -10646,7 +10646,7 @@
         },
         {
             "id": "840dc5c0-a0fb-56e6-b498-fce4c8daa011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a74ccf-8165-4db1-a87c-52c2d8ea0058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a74ccf-8165-4db1-a87c-52c2d8ea0058.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -10679,7 +10679,7 @@
         },
         {
             "id": "8d640ae6-74a2-59a6-810d-31d1fb4972e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbdf06-f6b5-4bd8-80bf-6d7e57649684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbdf06-f6b5-4bd8-80bf-6d7e57649684.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior can't be blocked.",
             "colours": [
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "91b5eab6-d892-5e18-a039-cebe8bbcd51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980e24c-bcb4-479c-8012-f19f4e87f0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980e24c-bcb4-479c-8012-f19f4e87f0bf.jpg?1",
             "name": "Riddlemaster Sphinx",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Riddlemaster Sphinx enters the battlefield, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "5a08acdf-9102-557e-9efa-675302dd4c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46580c-a204-4b0b-8526-2310b1ca32b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46580c-a204-4b0b-8526-2310b1ca32b4.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10779,7 +10779,7 @@
         },
         {
             "id": "2f9156cc-67e0-5512-8370-041654ccaf1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e41d8-317d-46ce-b858-54df716e0214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e41d8-317d-46ce-b858-54df716e0214.jpg?1",
             "name": "Bartizan Bats",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10812,7 +10812,7 @@
         },
         {
             "id": "5b41762a-7993-5a12-92bc-6760b8709b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad005eef-d4e4-4f46-81a5-9bbce87014ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad005eef-d4e4-4f46-81a5-9bbce87014ce.jpg?1",
             "name": "Bogstomper",
             "text": "",
             "colours": [
@@ -10845,7 +10845,7 @@
         },
         {
             "id": "dc4538c3-5c55-5fe1-8b78-424d04c17103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c926d38-a741-47a9-8961-f5bcf2909939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c926d38-a741-47a9-8961-f5bcf2909939.jpg?1",
             "name": "Dark Remedy",
             "text": "Target creature gets +1/+3 until end of turn.",
             "colours": [
@@ -10876,7 +10876,7 @@
         },
         {
             "id": "5a0dc207-0029-55a2-bf55-5505a739f928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7debd8f7-2f34-4fdd-8eb6-fa8f9d2a60e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7debd8f7-2f34-4fdd-8eb6-fa8f9d2a60e8.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "005128a5-0ca3-5de7-af80-728272d13938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f624f77-032f-4b28-bec2-95d3a3fcb806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f624f77-032f-4b28-bec2-95d3a3fcb806.jpg?1",
             "name": "Gravewaker",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{5}{B}{B}: Return target creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "4dc29d14-c224-508b-8847-0b008d1b8a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db03880-0138-44f8-8147-f2c07878a7d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db03880-0138-44f8-8147-f2c07878a7d8.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -10975,7 +10975,7 @@
         },
         {
             "id": "eff2ce72-a76a-5cb2-8cea-285793a73d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dacbb2-21e1-4220-bf43-75a0729cdc60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dacbb2-21e1-4220-bf43-75a0729cdc60.jpg?1",
             "name": "Sorin's Thirst",
             "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -11006,7 +11006,7 @@
         },
         {
             "id": "6fb959bd-f671-52c7-8ef9-b3bd816d50ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4b4a9-73a8-4135-b150-cd78d1558aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4b4a9-73a8-4135-b150-cd78d1558aca.jpg?1",
             "name": "Vampire Opportunist",
             "text": "{6}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -11039,7 +11039,7 @@
         },
         {
             "id": "77480c7c-d076-5c3f-b0f9-79d17d40d7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e94f0-5f64-4991-aa45-c2b05879be40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e94f0-5f64-4991-aa45-c2b05879be40.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "892697bd-a4ba-5616-b22e-287ca41f802d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f198c7e3-8a85-48f3-a7c2-93320fd4fb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f198c7e3-8a85-48f3-a7c2-93320fd4fb81.jpg?1",
             "name": "Engulfing Eruption",
             "text": "Engulfing Eruption deals 5 damage to target creature.",
             "colours": [
@@ -11103,7 +11103,7 @@
         },
         {
             "id": "e0675984-33ac-560e-a95f-581e7d32be40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f08297-f477-4330-a99e-3f0847c31364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f08297-f477-4330-a99e-3f0847c31364.jpg?1",
             "name": "Fearless Halberdier",
             "text": "",
             "colours": [
@@ -11137,7 +11137,7 @@
         },
         {
             "id": "4d7737fc-3e0e-58a4-8935-98eef2594c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfefb65-b6e4-44a1-baa9-d3c00ee8ba96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfefb65-b6e4-44a1-baa9-d3c00ee8ba96.jpg?1",
             "name": "Goblin Assailant",
             "text": "",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "a69968a6-8ee2-5bad-a338-814d25184465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1263ea-adc9-442b-b13e-9afb69596372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1263ea-adc9-442b-b13e-9afb69596372.jpg?1",
             "name": "Hostile Minotaur",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "1e4709d0-4e59-5ba4-a894-bb65f6194986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb9f15-be65-494c-9672-162d38c6f0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb9f15-be65-494c-9672-162d38c6f0a5.jpg?1",
             "name": "Immortal Phoenix",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Immortal Phoenix dies, return it to its owner's hand.",
             "colours": [
@@ -11237,7 +11237,7 @@
         },
         {
             "id": "bcd69a94-54b5-54d4-a6aa-d2389a134c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9bcbd-48fe-4a74-aae5-a447c99aa64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9bcbd-48fe-4a74-aae5-a447c99aa64b.jpg?1",
             "name": "Nimble Birdsticker",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "7fdc2d47-7737-54f0-814a-3f7423fd7dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d43107-713d-4ff2-8cbd-237c7393229f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d43107-713d-4ff2-8cbd-237c7393229f.jpg?1",
             "name": "Rubblebelt Recluse",
             "text": "Rubblebelt Recluse attacks each combat if able.",
             "colours": [
@@ -11304,7 +11304,7 @@
         },
         {
             "id": "2c2eeb5a-aebc-5e9c-94b3-ffe6b6789407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227cf1b5-f85b-41fe-be98-66e383652039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227cf1b5-f85b-41fe-be98-66e383652039.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -11337,7 +11337,7 @@
         },
         {
             "id": "899a3f69-1528-594a-8003-a5284a6549b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35574c7-c21c-4d07-87b5-9935b8da9832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35574c7-c21c-4d07-87b5-9935b8da9832.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -11370,7 +11370,7 @@
         },
         {
             "id": "4b116081-a7c3-550b-84df-151150ab152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e68b3bd-996e-4383-b134-f529bcb768de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e68b3bd-996e-4383-b134-f529bcb768de.jpg?1",
             "name": "Aggressive Mammoth",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther creatures you control have trample.",
             "colours": [
@@ -11403,7 +11403,7 @@
         },
         {
             "id": "017ca6ca-786a-53d4-9d7d-ea3b4f7a42d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9f200-cfbf-4d59-9294-2bbbd532fedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9f200-cfbf-4d59-9294-2bbbd532fedf.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -11436,7 +11436,7 @@
         },
         {
             "id": "67a00222-d84e-59f9-ab75-9d3b62a9f589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7fabb-dcb6-4c21-87ee-2893b63814be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7fabb-dcb6-4c21-87ee-2893b63814be.jpg?1",
             "name": "Canopy Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -11469,7 +11469,7 @@
         },
         {
             "id": "58426fe8-6bd9-595d-b6c0-facd81e7c3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c755ff-3fbb-4128-9357-0874eb61ff4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c755ff-3fbb-4128-9357-0874eb61ff4c.jpg?1",
             "name": "Frilled Sandwalla",
             "text": "{1}{G}: Frilled Sandwalla gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "a7cf1fa8-01a9-556b-9b04-565fe472a71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ca08a0-c58d-4c13-bf63-0401d89839b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ca08a0-c58d-4c13-bf63-0401d89839b4.jpg?1",
             "name": "Oakenform",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -11535,7 +11535,7 @@
         },
         {
             "id": "71c635c7-d4c1-5113-bf22-8a3309efbd53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1604-379f-4f03-97ae-9ec10921167c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1604-379f-4f03-97ae-9ec10921167c.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -11568,7 +11568,7 @@
         },
         {
             "id": "b0f4a723-571f-5ba6-b83b-6aa15a59a756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db41405-87a2-4a91-97f4-a8af2ffe8313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db41405-87a2-4a91-97f4-a8af2ffe8313.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -11599,7 +11599,7 @@
         },
         {
             "id": "60b4a9c4-3d29-5b6b-8fd0-6989d2b14061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6117cf-5cb3-41f3-8756-c01b5e9c760e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6117cf-5cb3-41f3-8756-c01b5e9c760e.jpg?1",
             "name": "Woodland Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "53988e4b-3d74-596f-995d-60cf887ba60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0819e8e-fb7e-43c7-a7cf-d768f43193ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0819e8e-fb7e-43c7-a7cf-d768f43193ac.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "",
             "colours": [
@@ -11668,7 +11668,7 @@
         },
         {
             "id": "f2cbf987-d22b-53f3-8380-c47500cfd063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491d9da-a58d-4423-b565-c5a99ef63132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491d9da-a58d-4423-b565-c5a99ef63132.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -11702,7 +11702,7 @@
         },
         {
             "id": "b3210763-b1ad-5c39-ac11-3e17e9686a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b17be6-2ee7-4f3b-88df-f298bb058f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b17be6-2ee7-4f3b-88df-f298bb058f46.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -11736,7 +11736,7 @@
         },
         {
             "id": "ca6d83fb-b49f-5c6a-9fb5-2a440611007e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5582cd9-97e7-426f-a084-c05e2113ad13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5582cd9-97e7-426f-a084-c05e2113ad13.jpg?1",
             "name": "Elemental Bird",
             "text": "",
             "colours": [
@@ -11771,7 +11771,7 @@
         },
         {
             "id": "82c844d0-9918-52d5-8bf1-201e32ea2acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb61889-9bc6-426d-8ce5-7b1c0e6e959b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb61889-9bc6-426d-8ce5-7b1c0e6e959b.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "15ce7217-21d5-55fe-8300-e0f4dd3af2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f0436e-9328-4266-9cf8-80b557a0c17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f0436e-9328-4266-9cf8-80b557a0c17c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -11839,7 +11839,7 @@
         },
         {
             "id": "4577d236-59d6-53d7-9331-15ff1a6effc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0574973b-a0d1-4e17-9ed7-42a98d25bb8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0574973b-a0d1-4e17-9ed7-42a98d25bb8d.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -11873,7 +11873,7 @@
         },
         {
             "id": "d5433564-9c16-55ad-bbfb-6dcb6b455128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd05e304-1a16-436d-a05c-4a38a839759b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd05e304-1a16-436d-a05c-4a38a839759b.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -11907,7 +11907,7 @@
         },
         {
             "id": "b43ba6b7-b2ce-536f-a00e-69731d200803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea4711-a951-4a1b-88cb-f628f97b6164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea4711-a951-4a1b-88cb-f628f97b6164.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -11938,7 +11938,7 @@
         },
         {
             "id": "0060ce13-67e2-5607-a29b-721c743e6770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e54aad-ec80-4914-9ba8-91bd53924778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e54aad-ec80-4914-9ba8-91bd53924778.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "2a968099-56c5-537d-9a6d-4572aca7e147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775f2b3e-4e3b-4037-b7bb-117ababf8e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775f2b3e-4e3b-4037-b7bb-117ababf8e51.jpg?1",
             "name": "Chandra, Awakened Inferno Emblem",
             "text": "",
             "colours": [],
@@ -11995,7 +11995,7 @@
         },
         {
             "id": "67788734-e110-5b49-8be6-adc6fe6872f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc0849c-3a2b-4666-8fa9-755f3ea27706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc0849c-3a2b-4666-8fa9-755f3ea27706.jpg?1",
             "name": "Mu Yanling, Sky Dancer Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/M21.json
+++ b/Assets/Resources/Sets/M21.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "043fe0a6-9b4d-53fa-8a70-822ac47c7c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c017fa9-7021-417a-9c2e-3df409644fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c017fa9-7021-417a-9c2e-3df409644fcf.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to any target.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -39,7 +39,7 @@
         },
         {
             "id": "3e14f46a-b9a6-518b-9160-f88b40ad409c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c392a7e5-6ff5-4c2f-9590-f8811a724f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c392a7e5-6ff5-4c2f-9590-f8811a724f44.jpg?1",
             "name": "Alpine Watchdog",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "5cb931df-3664-5562-a74d-6ee5158ab980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cca776-b0e4-4cd2-815f-36c1f86cf497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cca776-b0e4-4cd2-815f-36c1f86cf497.jpg?1",
             "name": "Angelic Ascension",
             "text": "Exile target creature or planeswalker. Its controller creates a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "4bfeea76-d8f7-5e4b-a89f-81949daa4820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c977c67-b0c0-40b0-b129-28de094aaf40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c977c67-b0c0-40b0-b129-28de094aaf40.jpg?1",
             "name": "Anointed Chorister",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\n{4}{W}: Anointed Chorister gets +3/+3 until end of turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "11d84ff0-bea3-5683-87d0-c4af1fc60a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b57247-81cc-44ec-b5a9-0702111a98a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b57247-81cc-44ec-b5a9-0702111a98a8.jpg?1",
             "name": "Aven Gagglemaster",
             "text": "Flying\nWhen Aven Gagglemaster enters the battlefield, you gain 2 life for each creature you control with flying.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "1ce537ed-082e-5988-aa9e-87a721070ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd3014b-94bb-4a9f-92cf-239a2dcc7e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd3014b-94bb-4a9f-92cf-239a2dcc7e97.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "7c578972-34bd-528a-80d2-f8c54ea430f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c85699-2daf-4e87-a3be-465d02bd64bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c85699-2daf-4e87-a3be-465d02bd64bb.jpg?1",
             "name": "Basri Ket",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains indestructible until end of turn.\n\u22122: Whenever one or more nontoken creatures attack this turn, create that many 1/1 white Soldier creature tokens that are tapped and attacking.\n\u22126: You get an emblem with \"At the beginning of combat on your turn, create a 1/1 white Soldier creature token, then put a +1/+1 counter on each creature you control.\"",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "0019b544-ed73-5c43-80d0-0826d38d709c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d1dd97-2675-4953-ab95-d47d23abfe05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d1dd97-2675-4953-ab95-d47d23abfe05.jpg?1",
             "name": "Basri's Acolyte",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen Basri's Acolyte enters the battlefield, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -287,7 +287,7 @@
         },
         {
             "id": "32909923-dfe2-5adf-881d-673a1716cd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1eae0-1bf8-4922-a9e3-45c01ece9005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1eae0-1bf8-4922-a9e3-45c01ece9005.jpg?1",
             "name": "Basri's Lieutenant",
             "text": "Vigilance, protection from multicolored\nWhen Basri's Lieutenant enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Basri's Lieutenant or another creature you control dies, if it had a +1/+1 counter on it, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "db960319-4880-5fa6-9db0-b8409fc91156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e6fdc0-bdd4-4bba-b8f1-bbc8dfad038e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e6fdc0-bdd4-4bba-b8f1-bbc8dfad038e.jpg?1",
             "name": "Basri's Solidarity",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "d735554e-15ae-5af7-9fb3-cc43514d976b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46666fba-d4a7-4687-8747-a42e4c6d853e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46666fba-d4a7-4687-8747-a42e4c6d853e.jpg?1",
             "name": "Celestial Enforcer",
             "text": "{1}{W}, {T}: Tap target creature. Activate this ability only if you control a creature with flying.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "fb0c0b23-7afe-55f8-ab67-54a325c7e5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600d3517-e370-47ae-ac4f-c7ef8995a89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600d3517-e370-47ae-ac4f-c7ef8995a89c.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "59df52f8-8b22-579c-acb9-2fd576785692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e8dba-5c86-4e32-8a52-61402f7fe9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e8dba-5c86-4e32-8a52-61402f7fe9f0.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -464,7 +464,7 @@
         },
         {
             "id": "7e84bd4c-c067-58e8-8a61-e819aa36a2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff87a671-054f-4357-8a62-450d36559a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff87a671-054f-4357-8a62-450d36559a1b.jpg?1",
             "name": "Daybreak Charger",
             "text": "When Daybreak Charger enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -498,7 +498,7 @@
         },
         {
             "id": "8c363ddb-c725-55a1-b13d-707237c3335b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c23869b-c99a-49dd-9e29-fcc0eb63fad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c23869b-c99a-49dd-9e29-fcc0eb63fad1.jpg?1",
             "name": "Defiant Strike",
             "text": "Target creature gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "6a7f21d2-3a0f-52ab-8f7e-94c6e34fb2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3de35fd-425d-46b8-bc7d-c2f05d86858d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3de35fd-425d-46b8-bc7d-c2f05d86858d.jpg?1",
             "name": "Dub",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has first strike, and is a Knight in addition to its other types. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "d182bba0-5e83-5d4c-92b0-6684ab627dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e742d49-e6f0-4016-ba4c-11878fad89cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e742d49-e6f0-4016-ba4c-11878fad89cb.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "4fbda3a7-9a2e-523c-8b63-ba54ed4b8be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4733e6-6fe2-4460-ac9f-82feb583d790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4733e6-6fe2-4460-ac9f-82feb583d790.jpg?1",
             "name": "Falconer Adept",
             "text": "Whenever Falconer Adept attacks, create a 1/1 white Bird creature token with flying that's tapped and attacking.",
             "colours": [
@@ -633,7 +633,7 @@
         },
         {
             "id": "56a98be7-1df5-5b21-8c00-996fbabd40b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73148b3b-73d3-4f57-8b67-1e91fbe112b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73148b3b-73d3-4f57-8b67-1e91fbe112b9.jpg?1",
             "name": "Feat of Resistance",
             "text": "Put a +1/+1 counter on target creature you control. It gains protection from the color of your choice until end of turn. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything of that color.)",
             "colours": [
@@ -665,7 +665,7 @@
         },
         {
             "id": "68ea4434-9621-5234-a20f-8674784902d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3b99c-e48e-4f4d-ba7a-e9218137b432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3b99c-e48e-4f4d-ba7a-e9218137b432.jpg?1",
             "name": "Gale Swooper",
             "text": "Flying\nWhen Gale Swooper enters the battlefield, target creature gains flying until end of turn.",
             "colours": [
@@ -699,7 +699,7 @@
         },
         {
             "id": "1561202d-3f48-529e-83e0-88c40b749637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d154d3-7ae5-43ff-9978-d974285e2c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d154d3-7ae5-43ff-9978-d974285e2c89.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "2f01a003-8001-526d-b4f9-823e579b08df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea1ee60-5644-4f78-913d-32c36065957f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea1ee60-5644-4f78-913d-32c36065957f.jpg?1",
             "name": "Griffin Aerie",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, create a 2/2 white Griffin creature token with flying.",
             "colours": [
@@ -765,7 +765,7 @@
         },
         {
             "id": "906e4af4-3d7a-5099-990c-12f9d35362ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60e84e-be05-49da-9720-4225abe9d003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60e84e-be05-49da-9720-4225abe9d003.jpg?1",
             "name": "Idol of Endurance",
             "text": "When Idol of Endurance enters the battlefield, exile all creature cards with converted mana cost 3 or less from your graveyard until Idol of Endurance leaves the battlefield.\n{1}{W}, {T}: Until end of turn, you may cast a creature spell from among the cards exiled with Idol of Endurance without paying its mana cost.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "5cd1f670-751d-5dea-81dc-a277225a0001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032f6c5a-8d88-4a55-a54b-28df42d801e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032f6c5a-8d88-4a55-a54b-28df42d801e1.jpg?1",
             "name": "Legion's Judgment",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "5dd0e7a1-30e3-59a9-8ba8-803bf34f35ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f80411-0a95-4e0a-b7a8-af23ddf385cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f80411-0a95-4e0a-b7a8-af23ddf385cc.jpg?1",
             "name": "Light of Promise",
             "text": "Enchant creature\nEnchanted creature has \"Whenever you gain life, put that many +1/+1 counters on this creature.\"",
             "colours": [
@@ -865,7 +865,7 @@
         },
         {
             "id": "d0133387-1d3f-5906-af1d-4a514eca182f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a500e6-01f5-4a3a-8839-68b9b515e919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a500e6-01f5-4a3a-8839-68b9b515e919.jpg?1",
             "name": "Makeshift Battalion",
             "text": "Whenever Makeshift Battalion and at least two other creatures attack, put a +1/+1 counter on Makeshift Battalion.",
             "colours": [
@@ -900,7 +900,7 @@
         },
         {
             "id": "7050d1d1-9e22-5f4d-8b71-eccdd07bd2ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e628f-5fc5-4c17-a07d-448d361d7e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e628f-5fc5-4c17-a07d-448d361d7e7c.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -939,7 +939,7 @@
         },
         {
             "id": "5ba544d1-5cb8-5ba4-adf5-481dfb3b561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b7a73-484e-48f1-944c-3d38866cdc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b7a73-484e-48f1-944c-3d38866cdc20.jpg?1",
             "name": "Nine Lives",
             "text": "Hexproof\nIf a source would deal damage to you, prevent that damage and put an incarnation counter on Nine Lives.\nWhen there are nine or more incarnation counters on Nine Lives, exile it.\nWhen Nine Lives leaves the battlefield, you lose the game.",
             "colours": [
@@ -973,7 +973,7 @@
         },
         {
             "id": "22c59fda-026a-58c6-b89b-6c70aff04128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b94bc1-68d1-41dc-914c-a33ecb9aeb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b94bc1-68d1-41dc-914c-a33ecb9aeb49.jpg?1",
             "name": "Pack Leader",
             "text": "Other Dogs you control get +1/+1.\nWhenever Pack Leader attacks, prevent all combat damage that would be dealt this turn to Dogs you control.",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "ad58e121-f580-5b9b-b9ef-80b2d366e56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f602ecc-c264-4f3e-adeb-d0186668653e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f602ecc-c264-4f3e-adeb-d0186668653e.jpg?1",
             "name": "Rambunctious Mutt",
             "text": "When Rambunctious Mutt enters the battlefield, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "037d5cf0-690c-5738-89ce-0d9657612404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bd4bce-8ab0-40b9-aad7-7d57a011bb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bd4bce-8ab0-40b9-aad7-7d57a011bb0b.jpg?1",
             "name": "Revitalize",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "8938f316-7700-5c85-a790-d7cd90663885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61296b2d-4e5c-419a-8775-4e6af902c7b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61296b2d-4e5c-419a-8775-4e6af902c7b1.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen card name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "71279c87-cb41-5410-b588-5196eea5a34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a5478a-1a2c-4117-b543-da083ed2b562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a5478a-1a2c-4117-b543-da083ed2b562.jpg?1",
             "name": "Sanctum of Tranquil Light",
             "text": "{5}{W}: Tap target creature. This ability costs {1} less to activate for each Shrine you control.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "52a97e8b-5446-56c9-bb11-c73311f8af09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb59931-8941-46fb-8e1c-f80ff3730dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb59931-8941-46fb-8e1c-f80ff3730dd9.jpg?1",
             "name": "Seasoned Hallowblade",
             "text": "Discard a card: Tap Seasoned Hallowblade. It gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "19da977f-bd0c-5294-9b40-676d727afbc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6467d96-e43a-4b1e-b6ce-578d991077b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6467d96-e43a-4b1e-b6ce-578d991077b5.jpg?1",
             "name": "Secure the Scene",
             "text": "Exile target nonland permanent. Its controller creates a 1/1 white Soldier creature token.",
             "colours": [
@@ -1213,7 +1213,7 @@
         },
         {
             "id": "27e7feb4-9849-5908-9632-82075e26ede7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911759c-7177-402c-a95a-f9f46efaf521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911759c-7177-402c-a95a-f9f46efaf521.jpg?1",
             "name": "Selfless Savior",
             "text": "Sacrifice Selfless Savior: Another target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "3d2d2145-2a21-50aa-b288-11f2b6df3544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ffa89-e6ee-466c-8edc-dd24c8b52e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ffa89-e6ee-466c-8edc-dd24c8b52e80.jpg?1",
             "name": "Siege Striker",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nWhenever Siege Striker attacks, you may tap any number of untapped creatures you control. Siege Striker gets +1/+1 until end of turn for each creature tapped this way.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "ba3db924-b9ec-5dcf-b0c7-73c0503e80da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44b96a-8498-414a-a4ac-54c80dfa9f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44b96a-8498-414a-a4ac-54c80dfa9f23.jpg?1",
             "name": "Speaker of the Heavens",
             "text": "Vigilance, lifelink\n{T}: Create a 4/4 white Angel creature token with flying. Activate this ability only if you have at least 7 life more than your starting life total and only any time you could cast a sorcery.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "6ab09c61-4fe7-5446-8447-c2a59ad60d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17f25a-32d1-469b-bb5f-f1761e227990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17f25a-32d1-469b-bb5f-f1761e227990.jpg?1",
             "name": "Staunch Shieldmate",
             "text": "",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "05bc36cc-4347-5061-9d1e-5772e311142c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90c1ad0-83bd-471c-8d4c-e65bc2abaa18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90c1ad0-83bd-471c-8d4c-e65bc2abaa18.jpg?1",
             "name": "Swift Response",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "9a2bd06a-61cf-56c1-96b7-784f5eda2663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43d7bc-173c-41eb-bba9-a9d94dcfc5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43d7bc-173c-41eb-bba9-a9d94dcfc5fa.jpg?1",
             "name": "Tempered Veteran",
             "text": "{W}, {T}: Put a +1/+1 counter on target creature with a +1/+1 counter on it.\n{4}{W}{W}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "b51e3999-985e-550b-a64a-aba9c0e0c767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01cb8c-f080-456b-a91a-f1d7943a70b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01cb8c-f080-456b-a91a-f1d7943a70b2.jpg?1",
             "name": "Valorous Steed",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Valorous Steed enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "c41fd96f-0995-5727-84ec-c890ac190370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b59819-4746-4c67-b6e5-4157d498a065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b59819-4746-4c67-b6e5-4157d498a065.jpg?1",
             "name": "Vryn Wingmare",
             "text": "Flying\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "6946abf5-70ea-5f10-ac99-a650b870aac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f234999b-54e9-40f5-a537-7d6ce169c710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f234999b-54e9-40f5-a537-7d6ce169c710.jpg?1",
             "name": "Warded Battlements",
             "text": "Defender (This creature can't attack.)\nAttacking creatures you control get +1/+0.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "bf4b9385-3847-56c2-a02c-6181263baef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb078fbb-beb9-4c0b-be93-ed1e73e6f8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb078fbb-beb9-4c0b-be93-ed1e73e6f8d8.jpg?1",
             "name": "Barrin, Tolarian Archmage",
             "text": "When Barrin, Tolarian Archmage enters the battlefield, return up to one other target creature or planeswalker to its owner's hand.\nAt the beginning of your end step, if a permanent was put into your hand from the battlefield this turn, draw a card.",
             "colours": [
@@ -1564,7 +1564,7 @@
         },
         {
             "id": "39888b37-6e61-521e-bf4d-95f43c11276a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e14910-ee2e-49ae-855e-46a8ab6cad82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e14910-ee2e-49ae-855e-46a8ab6cad82.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "c4b0ef6d-9e51-5328-9966-e6291576e6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ed9f08-56e8-4e24-aae2-05270d7c1ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ed9f08-56e8-4e24-aae2-05270d7c1ba8.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "aef030f4-9f94-50ff-8390-c139b7f91c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ba0a8-04e9-4df6-af20-a3ca4470cdcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ba0a8-04e9-4df6-af20-a3ca4470cdcc.jpg?1",
             "name": "Discontinuity",
             "text": "As long as it's your turn, this spell costs {2}{U}{U} less to cast.\nEnd the turn. (Exile all spells and abilities from the stack, including this card. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -1664,7 +1664,7 @@
         },
         {
             "id": "a29732cd-96f4-5d75-9a48-520d118e9e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc7176-abe0-47cf-a242-cf22a1f590be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc7176-abe0-47cf-a242-cf22a1f590be.jpg?1",
             "name": "Enthralling Hold",
             "text": "Enchant creature\nYou can't choose an untapped creature as this spell's target as you cast it.\nYou control enchanted creature.",
             "colours": [
@@ -1698,7 +1698,7 @@
         },
         {
             "id": "8eda09ee-8008-5cdc-9019-bf876dc3d46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14abb0-0e9f-448e-85d7-6cb71f756c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14abb0-0e9f-448e-85d7-6cb71f756c56.jpg?1",
             "name": "Frantic Inventory",
             "text": "Draw a card, then draw cards equal to the number of cards named Frantic Inventory in your graveyard.",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "cf5081c6-9170-5acf-9e87-7b7e6323d97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc485-d3c1-4826-933d-89f66df769d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc485-d3c1-4826-933d-89f66df769d4.jpg?1",
             "name": "Frost Breath",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1764,7 +1764,7 @@
         },
         {
             "id": "d91d2746-fef9-5c80-b20c-b76f18002c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2810631f-c55c-4947-a26f-4d3ce76024b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2810631f-c55c-4947-a26f-4d3ce76024b3.jpg?1",
             "name": "Ghostly Pilferer",
             "text": "Whenever Ghostly Pilferer becomes untapped, you may pay {2}. If you do, draw a card.\nWhenever an opponent casts a spell from anywhere other than their hand, draw a card.\nDiscard a card: Ghostly Pilferer can't be blocked this turn.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "823ea366-8342-5201-a831-ac3dd5bc5745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a188164c-01fe-4980-83a5-91d14e218cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a188164c-01fe-4980-83a5-91d14e218cf5.jpg?1",
             "name": "Jeskai Elder",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jeskai Elder deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "b696f264-dd18-5988-818f-00a21b54f4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce6289e-f665-4faa-8285-c843447f3e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce6289e-f665-4faa-8285-c843447f3e52.jpg?1",
             "name": "Keen Glidemaster",
             "text": "{2}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "69f3c1fa-7c4c-5c5c-b1c8-1fde8e77a738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb33529b-80bd-4f52-94cc-d8371c53ad75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb33529b-80bd-4f52-94cc-d8371c53ad75.jpg?1",
             "name": "Library Larcenist",
             "text": "Whenever Library Larcenist attacks, draw a card.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "b2249315-3d89-5a46-9638-1d5c048dc388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64832674-beb1-446e-b2f7-8a5e271139a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64832674-beb1-446e-b2f7-8a5e271139a5.jpg?1",
             "name": "Lofty Denial",
             "text": "Counter target spell unless its controller pays {1}. If you control a creature with flying, counter that spell unless its controller pays {4} instead.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "2d343392-9f38-57b8-ac75-8ae19b93e9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033afbd5-9937-4957-98ba-48e469a490bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033afbd5-9937-4957-98ba-48e469a490bb.jpg?1",
             "name": "Miscast",
             "text": "Counter target instant or sorcery spell unless its controller pays {3}.",
             "colours": [
@@ -1970,7 +1970,7 @@
         },
         {
             "id": "203022a6-c681-56c0-a248-0648b5ece15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d961c441-b76b-4bd8-b510-a3e073207a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d961c441-b76b-4bd8-b510-a3e073207a1b.jpg?1",
             "name": "Mistral Singer",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "ffda1ffd-b843-5c2b-896b-ed28d1fd6205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323db259-d35e-467d-9a46-4adcb2fc107c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323db259-d35e-467d-9a46-4adcb2fc107c.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2036,7 +2036,7 @@
         },
         {
             "id": "be541ae3-6bb5-58e3-8f15-401ddd1225d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1501118-5837-49b5-9446-0bc3032035ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1501118-5837-49b5-9446-0bc3032035ca.jpg?1",
             "name": "Pursued Whale",
             "text": "When Pursued Whale enters the battlefield, each opponent creates a 1/1 red Pirate creature token with \"This creature can't block\" and \"Creatures you control attack each combat if able.\"\nSpells your opponents cast that target Pursued Whale cost {3} more to cast.",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "33ccf9d0-8329-5458-9642-612efc55b56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da367981-9d6f-419f-9f58-f969b6183336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da367981-9d6f-419f-9f58-f969b6183336.jpg?1",
             "name": "Rain of Revelation",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2104,7 +2104,7 @@
         },
         {
             "id": "771703db-a675-570d-9321-117d325b06aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360fe8c-41b0-4409-b03e-072f129fb352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360fe8c-41b0-4409-b03e-072f129fb352.jpg?1",
             "name": "Read the Tides",
             "text": "Choose one \u2014\n\u2022 Draw three cards.\n\u2022 Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "189c52d6-8397-5241-9b68-0676bc7b76f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b832abcc-9ffd-47bf-827a-01b303c610ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b832abcc-9ffd-47bf-827a-01b303c610ee.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -2168,7 +2168,7 @@
         },
         {
             "id": "a97161af-27e6-5e82-8f39-b1493a140a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5acb8ef-5a57-4d10-b59c-2dbf84635084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5acb8ef-5a57-4d10-b59c-2dbf84635084.jpg?1",
             "name": "Riddleform",
             "text": "Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2200,7 +2200,7 @@
         },
         {
             "id": "920767e4-351c-533a-bc94-30f0a0a433c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbac0e4-f79f-476d-b410-d19ab3696606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbac0e4-f79f-476d-b410-d19ab3696606.jpg?1",
             "name": "Roaming Ghostlight",
             "text": "Flying\nWhen Roaming Ghostlight enters the battlefield, return up to one target non-Spirit creature to its owner's hand.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "515a5bd9-8c37-5d99-95d9-ad1fd18922d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19de7a5-c291-405b-a2e6-8d3ac56e6570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19de7a5-c291-405b-a2e6-8d3ac56e6570.jpg?1",
             "name": "Rookie Mistake",
             "text": "Until end of turn, target creature gets +0/+2 and another target creature gets -2/-0.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "37ba0484-9a11-5cbb-ba66-a48bf8ad2a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82be2ca-8350-4cf5-83b6-e8b60a9e21c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82be2ca-8350-4cf5-83b6-e8b60a9e21c6.jpg?1",
             "name": "Rousing Read",
             "text": "Enchant creature\nWhen Rousing Read enters the battlefield, draw two cards, then discard a card.\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "250d01e9-54cb-5315-bfb0-80549f1940f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b2fb65-5868-4cab-b45d-e103558ce7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b2fb65-5868-4cab-b45d-e103558ce7dc.jpg?1",
             "name": "Sanctum of Calm Waters",
             "text": "At the beginning of your precombat main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.",
             "colours": [
@@ -2336,7 +2336,7 @@
         },
         {
             "id": "f355804e-cb74-53db-942b-6b5e69b23166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af15cc-fdd5-4d72-a53a-314fa5353527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af15cc-fdd5-4d72-a53a-314fa5353527.jpg?1",
             "name": "See the Truth",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order. If this spell was cast from anywhere other than your hand, put each of those cards into your hand instead.",
             "colours": [
@@ -2370,7 +2370,7 @@
         },
         {
             "id": "9ddbda47-4142-59b2-be45-c466aa22e441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5a88e3-e73c-4b34-a645-06fe27e68cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5a88e3-e73c-4b34-a645-06fe27e68cee.jpg?1",
             "name": "Shacklegeist",
             "text": "Flying\nShacklegeist can block only creatures with flying.\nTap two untapped Spirits you control: Tap target creature you don't control.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "bc43978e-1da0-51b4-b848-6d53b084718c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d38ef7-5017-4ea3-b97f-a8fe12d03e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d38ef7-5017-4ea3-b97f-a8fe12d03e98.jpg?1",
             "name": "Shipwreck Dowser",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Shipwreck Dowser enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "3dd1c3fb-e670-5433-9dda-1434ff39356d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42d3dd-29df-44a1-89b8-994761eda77d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42d3dd-29df-44a1-89b8-994761eda77d.jpg?1",
             "name": "Spined Megalodon",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Spined Megalodon attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "06696917-5f2d-54dc-a6c6-cd8c86cfcdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0540ee72-6370-4f70-9526-6f441b3cac1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0540ee72-6370-4f70-9526-6f441b3cac1e.jpg?1",
             "name": "Stormwing Entity",
             "text": "This spell costs {2}{U} less to cast if you've cast an instant or sorcery spell this turn.\nFlying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Stormwing Entity enters the battlefield, scry 2.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "8033683f-1340-594c-b7a8-bb9ac3a3cf44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1bcb44-a562-4f66-b862-6d0ef3546ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1bcb44-a562-4f66-b862-6d0ef3546ab4.jpg?1",
             "name": "Sublime Epiphany",
             "text": "Choose one or more \u2014\n\u2022 Counter target spell.\n\u2022 Counter target activated or triggered ability.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Create a token that's a copy of target creature you control.\n\u2022 Target player draws a card.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "4fa12f9c-7b31-5907-ab9a-1404348bbc56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c61e3-9f3d-4e7f-9046-0ea336dd8a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c61e3-9f3d-4e7f-9046-0ea336dd8a2d.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "735dbf1c-a6ff-554e-b38e-481f1e8573dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d1722-96b0-4756-9da9-fe18b1c80649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d1722-96b0-4756-9da9-fe18b1c80649.jpg?1",
             "name": "Teferi's Ageless Insight",
             "text": "If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "3131b1b6-68b5-5ee0-985c-143b7e453ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5449d71c-5c1b-44c6-9407-0212aa3c3e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5449d71c-5c1b-44c6-9407-0212aa3c3e3a.jpg?1",
             "name": "Teferi's Protege",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2663,7 +2663,7 @@
         },
         {
             "id": "f5f33b1c-90b4-55b8-9901-09605512b6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26450d4-125f-423d-b074-3c959460c242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26450d4-125f-423d-b074-3c959460c242.jpg?1",
             "name": "Teferi's Tutelage",
             "text": "When Teferi's Tutelage enters the battlefield, draw a card, then discard a card.\nWhenever you draw a card, target opponent mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "f4dc6980-a12f-555e-a201-47e5d42a4f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1d595-a998-4652-931f-a1a72446f3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1d595-a998-4652-931f-a1a72446f3a6.jpg?1",
             "name": "Tide Skimmer",
             "text": "Flying\nWhenever you attack with two or more creatures with flying, draw a card.",
             "colours": [
@@ -2731,7 +2731,7 @@
         },
         {
             "id": "5e79e88d-f8a5-51cb-84b2-911e12bad722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2776694-6183-498d-9a38-e4c5c9e78179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2776694-6183-498d-9a38-e4c5c9e78179.jpg?1",
             "name": "Tolarian Kraken",
             "text": "Whenever you draw a card, you may pay {1}. When you do, you may tap or untap target creature.",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "ac48c967-b42f-58d5-8b18-66f767ee247c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0360d27b-37e1-4e00-9cfc-b574efc38ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0360d27b-37e1-4e00-9cfc-b574efc38ea0.jpg?1",
             "name": "Tome Anima",
             "text": "Tome Anima can't be blocked as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "8a1a369f-9bf4-53b2-bfa2-30abc1a4eecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc0bafd-debc-4b62-9fe0-56b4aad02484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc0bafd-debc-4b62-9fe0-56b4aad02484.jpg?1",
             "name": "Unsubstantiate",
             "text": "Return target spell or creature to its owner's hand.",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "6021ee28-4b7b-51bf-9e3f-092daa1399cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52e90c0-b012-4ce5-8462-1e33c7143de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52e90c0-b012-4ce5-8462-1e33c7143de5.jpg?1",
             "name": "Vodalian Arcanist",
             "text": "{T}: Add {C}. Spend this mana only to cast an instant or sorcery spell.",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "eceb35a5-94f6-5959-a6bc-66ca295400e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb47990-a5a9-4a22-a8bb-d229b17132c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb47990-a5a9-4a22-a8bb-d229b17132c6.jpg?1",
             "name": "Waker of Waves",
             "text": "Creatures your opponents control get -1/-0.\n{1}{U}, Discard Waker of Waves: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "3f826f5b-97cb-5cf1-bc88-a11a813959e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac0f66a-213f-463e-8ebb-35ff5940ea06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac0f66a-213f-463e-8ebb-35ff5940ea06.jpg?1",
             "name": "Wall of Runes",
             "text": "Defender (This creature can't attack.)\nWhen Wall of Runes enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "b34d5609-be96-5dc9-ad32-7ba22ec72c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348955a0-e988-48d7-a6a0-a8045fcffd25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348955a0-e988-48d7-a6a0-a8045fcffd25.jpg?1",
             "name": "Wishcoin Crab",
             "text": "",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "9eb69338-c78b-51f1-a54c-c81029909ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4c9574-1ee3-461e-848f-8f02c6a8b7ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4c9574-1ee3-461e-848f-8f02c6a8b7ee.jpg?1",
             "name": "Alchemist's Gift",
             "text": "Target creature gets +1/+1 and gains your choice of deathtouch or lifelink until end of turn. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it. Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "6e49b51d-e1e8-55c4-8127-320307502ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83437022-ba00-4370-83c2-ce1260336fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83437022-ba00-4370-83c2-ce1260336fcc.jpg?1",
             "name": "Archfiend's Vessel",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen Archfiend's Vessel enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, exile it. If you do, create a 5/5 black Demon creature token with flying.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "7e42973f-862d-5409-a6fa-8640fb403e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8bc2-ef66-474f-92a3-9c4df1670cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8bc2-ef66-474f-92a3-9c4df1670cec.jpg?1",
             "name": "Bad Deal",
             "text": "You draw two cards and each opponent discards two cards. Each player loses 2 life.",
             "colours": [
@@ -3067,7 +3067,7 @@
         },
         {
             "id": "bdf689f5-3561-57e7-abdc-6cdc07091814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ff52a2-4223-4551-b388-b4dd21cc1437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ff52a2-4223-4551-b388-b4dd21cc1437.jpg?1",
             "name": "Blood Glutton",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3101,7 +3101,7 @@
         },
         {
             "id": "d3578b01-f934-5b3f-aff0-f042cda61f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067745-35b6-4abd-9ae9-712159a26c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067745-35b6-4abd-9ae9-712159a26c89.jpg?1",
             "name": "Caged Zombie",
             "text": "{1}{B}, {T}: Each opponent loses 2 life. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "a324fb88-6544-5cf2-82de-e3930077b5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31df3d95-bbdb-449d-9601-4fa844c3c640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31df3d95-bbdb-449d-9601-4fa844c3c640.jpg?1",
             "name": "Carrion Grub",
             "text": "Carrion Grub gets +X/+0, where X is the greatest power among creature cards in your graveyard.\nWhen Carrion Grub enters the battlefield, mill four cards. (Put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -3169,7 +3169,7 @@
         },
         {
             "id": "b87e0f89-d7a3-5e59-bfaa-a7605d8a5aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bba170-5176-4fab-a10d-e23d70128875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bba170-5176-4fab-a10d-e23d70128875.jpg?1",
             "name": "Crypt Lurker",
             "text": "When Crypt Lurker enters the battlefield, you may sacrifice a creature or discard a creature card. If you do, draw a card.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "0fb4111f-564e-59a8-8312-10eda498cf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4513e1-9978-44ce-b7a5-4e2b5b63ad9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4513e1-9978-44ce-b7a5-4e2b5b63ad9e.jpg?1",
             "name": "Deathbloom Thallid",
             "text": "When Deathbloom Thallid dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "a0180d8b-6cfb-5c6d-8951-c00497010b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56149192-ddc1-45a4-b7aa-be311da5fe8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56149192-ddc1-45a4-b7aa-be311da5fe8e.jpg?1",
             "name": "Demonic Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+1, has flying, and is a Demon in addition to its other types.\nYou may cast Demonic Embrace from your graveyard by paying 3 life and discarding a card in addition to paying its other costs.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "13a974cb-f33f-5ac3-8886-5e3051edc175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c07ea0-27ff-46fb-a41f-3e378c977b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c07ea0-27ff-46fb-a41f-3e378c977b5d.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "85d83776-c1ca-5d29-9fc6-986a61504046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb4087-3a4c-4de8-8e29-f4cd71acb180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb4087-3a4c-4de8-8e29-f4cd71acb180.jpg?1",
             "name": "Eliminate",
             "text": "Destroy target creature or planeswalker with converted mana cost 3 or less.",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "c28e5e66-5cde-5236-b22d-c98174759403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a95546-c45a-4da5-b1e8-d5658b5b7d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a95546-c45a-4da5-b1e8-d5658b5b7d53.jpg?1",
             "name": "Fetid Imp",
             "text": "Flying\n{B}: Fetid Imp gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "697eedcb-fc2f-5232-a3ba-39973ab4be7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85a552-2119-4d9c-b7c1-c09c2d9f2f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85a552-2119-4d9c-b7c1-c09c2d9f2f38.jpg?1",
             "name": "Finishing Blow",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -3405,7 +3405,7 @@
         },
         {
             "id": "88f9eece-adcd-525c-b648-38b1eddb57b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b4f7ec-ea2e-4d90-98cd-0c92bd9f64c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b4f7ec-ea2e-4d90-98cd-0c92bd9f64c1.jpg?1",
             "name": "Gloom Sower",
             "text": "Whenever Gloom Sower becomes blocked by a creature, that creature's controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "f7056037-3a6b-5fba-918d-9f78d58bfd89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd537c-e40e-438f-a751-e0ad8f6e6283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd537c-e40e-438f-a751-e0ad8f6e6283.jpg?1",
             "name": "Goremand",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen Goremand enters the battlefield, each opponent sacrifices a creature.",
             "colours": [
@@ -3473,7 +3473,7 @@
         },
         {
             "id": "1d9232a3-d088-5d79-8eba-97aaf4fc66a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7737b578-8ae3-4846-b508-93ef40f25244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7737b578-8ae3-4846-b508-93ef40f25244.jpg?1",
             "name": "Grasp of Darkness",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "2ef98d9d-84ed-5ede-96ad-65a7ffee02fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928558ab-e29a-44cb-ac2f-88443571f41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928558ab-e29a-44cb-ac2f-88443571f41a.jpg?1",
             "name": "Grim Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle your library. You lose 3 life.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "bb32640c-de31-5eb2-91d0-75f21f9ddb34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac38a51f-9a3b-451c-b72d-6d4e0b296fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac38a51f-9a3b-451c-b72d-6d4e0b296fbd.jpg?1",
             "name": "Hooded Blightfang",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch attacks, each opponent loses 1 life and you gain 1 life.\nWhenever a creature you control with deathtouch deals damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "9419a761-94fa-5a33-80f7-fd6972cb891a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975e4b8e-add9-439c-9463-e2facee96c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975e4b8e-add9-439c-9463-e2facee96c10.jpg?1",
             "name": "Infernal Scarring",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -3609,7 +3609,7 @@
         },
         {
             "id": "51bf4b8d-3304-5235-a7c1-6e7d5e053cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fd1009-cd3d-4b53-b9f1-dbc47e8708ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fd1009-cd3d-4b53-b9f1-dbc47e8708ab.jpg?1",
             "name": "Kaervek, the Spiteful",
             "text": "Other creatures get -1/-1.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "54006ee4-a566-58cd-8779-2ee63b5fdfca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88496096-fd9a-451a-85d9-31ccc3580623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88496096-fd9a-451a-85d9-31ccc3580623.jpg?1",
             "name": "Kitesail Freebooter",
             "text": "Flying\nWhen Kitesail Freebooter enters the battlefield, target opponent reveals their hand. You choose a noncreature, nonland card from it. Exile that card until Kitesail Freebooter leaves the battlefield.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "084f076b-62aa-5a31-b6fa-dd20acc38d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e329a3e2-6702-4758-8aac-c3017e77b619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e329a3e2-6702-4758-8aac-c3017e77b619.jpg?1",
             "name": "Liliana, Waker of the Dead",
             "text": "+1: Each player discards a card. Each opponent who can't loses 3 life.\n\u22123: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.\n\u22127: You get an emblem with \"At the beginning of combat on your turn, put target creature card from a graveyard onto the battlefield under your control. It gains haste.\"",
             "colours": [
@@ -3722,7 +3722,7 @@
         },
         {
             "id": "6bbffe8e-c1cc-567f-bdb6-8c78ff31ad4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5d7f15-a86f-4eaa-8280-2e7f73c8ce3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5d7f15-a86f-4eaa-8280-2e7f73c8ce3a.jpg?1",
             "name": "Liliana's Devotee",
             "text": "Zombies you control get +1/+0.\nAt the beginning of your end step, if a creature died this turn, you may pay {1}{B}. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "93dfcf2c-1714-51b8-8e92-4213a27fa3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc48b87-62cb-48f6-8979-e6fb98717b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc48b87-62cb-48f6-8979-e6fb98717b52.jpg?1",
             "name": "Liliana's Standard Bearer",
             "text": "Flash\nWhen Liliana's Standard Bearer enters the battlefield, draw X cards, where X is the number of creatures that died under your control this turn.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "ec495d62-0d2c-51ed-b11b-153f2cc27dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1945fc78-8aa4-46fb-9571-eaa1c4729e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1945fc78-8aa4-46fb-9571-eaa1c4729e3d.jpg?1",
             "name": "Liliana's Steward",
             "text": "{T}, Sacrifice Liliana's Steward: Target opponent discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "175ec4e7-808b-5e69-badd-de143b3557b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e2bc57-8f18-4ba1-a11b-9d69d029f56a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e2bc57-8f18-4ba1-a11b-9d69d029f56a.jpg?1",
             "name": "Malefic Scythe",
             "text": "Malefic Scythe enters the battlefield with a soul counter on it.\nEquipped creature gets +1/+1 for each soul counter on Malefic Scythe.\nWhenever equipped creature dies, put a soul counter on Malefic Scythe.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "aa25b15c-9899-5599-b3b0-719edd5a0ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61b4b71-3cbb-4422-8ce7-657ca3bb6a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61b4b71-3cbb-4422-8ce7-657ca3bb6a82.jpg?1",
             "name": "Masked Blackguard",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\n{2}{B}: Masked Blackguard gets +1/+1 until end of turn.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "f7912e33-fa58-58fc-b194-f2437eb1431e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3185b01-0d91-4927-98e9-bc9df6c20917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3185b01-0d91-4927-98e9-bc9df6c20917.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "ea7c18c3-6b08-5519-b5f1-7b76085a16d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a8604-92d5-443b-9bc0-bd91c973ef07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a8604-92d5-443b-9bc0-bd91c973ef07.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "7c862bb1-53f1-53c7-a88e-21c147654346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c5252e-ff15-4f86-ad63-d8286427e70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c5252e-ff15-4f86-ad63-d8286427e70f.jpg?1",
             "name": "Necromentia",
             "text": "Choose a card name other than a basic land card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles their library, then creates a 2/2 black Zombie creature token for each card exiled from their hand this way.",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "8517e5f6-ba72-5fe6-aa43-b3184c6ffe6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac00055-640e-4749-8d23-d242e6d0b23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac00055-640e-4749-8d23-d242e6d0b23a.jpg?1",
             "name": "Peer into the Abyss",
             "text": "Target player draws cards equal to half the number of cards in their library and loses half their life. Round up each time.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "db612b5e-5232-550f-b9eb-42531fc5679d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b78aa8-a63a-4aa2-bb82-3fbf2595ed7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b78aa8-a63a-4aa2-bb82-3fbf2595ed7c.jpg?1",
             "name": "Pestilent Haze",
             "text": "Choose one \u2014\n\u2022 All creatures get -2/-2 until end of turn.\n\u2022 Remove two loyalty counters from each planeswalker.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "3eac6e88-416b-5e6a-af43-1dd690c3b9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ec88f-2063-404a-853e-c985e21d17b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ec88f-2063-404a-853e-c985e21d17b0.jpg?1",
             "name": "Rise Again",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "3fda88a2-5a44-5a01-a730-a456cc153ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1439412-618c-483d-89b9-5ea37f0f1edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1439412-618c-483d-89b9-5ea37f0f1edc.jpg?1",
             "name": "Sanctum of Stone Fangs",
             "text": "At the beginning of your precombat main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "0d5eaae0-c7d9-52aa-a10d-4cf7fe6226ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfcd08a-cfb5-4d34-b950-f57a88c5cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfcd08a-cfb5-4d34-b950-f57a88c5cb8e.jpg?1",
             "name": "Sanguine Indulgence",
             "text": "This spell costs {3} less to cast if you've gained 3 or more life this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "5b25893b-3557-57fc-94eb-15a3df7650cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5444cb-0ecd-4482-a8d8-09332f382dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5444cb-0ecd-4482-a8d8-09332f382dbd.jpg?1",
             "name": "Silversmote Ghoul",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, return Silversmote Ghoul from your graveyard to the battlefield tapped.\n{1}{B}, Sacrifice Silversmote Ghoul: Draw a card.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "4e46dffa-66fe-58ae-9028-80c77d53c94b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb8d414-7f80-4a61-a0f2-0f16bf53e1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb8d414-7f80-4a61-a0f2-0f16bf53e1b9.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "db8f40e6-5abe-5c53-89c7-2a4c58798dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00850e4-6be3-4246-ae45-c0e990e6d6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00850e4-6be3-4246-ae45-c0e990e6d6e1.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "2417bfad-0b47-5a34-bc3a-9535612dc500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99f770-2c39-4025-a8a2-a5890f61eb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99f770-2c39-4025-a8a2-a5890f61eb53.jpg?1",
             "name": "Thieves' Guild Enforcer",
             "text": "Flash\nWhenever Thieves' Guild Enforcer or another Rogue enters the battlefield under your control, each opponent mills two cards.\nAs long as an opponent has eight or more cards in their graveyard, Thieves' Guild Enforcer gets +2/+1 and has deathtouch.",
             "colours": [
@@ -4312,7 +4312,7 @@
         },
         {
             "id": "3ba45256-36bb-5fa4-9721-1d5e05edb688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f60a6-b5c8-4704-8b61-94e8fc463e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f60a6-b5c8-4704-8b61-94e8fc463e5d.jpg?1",
             "name": "Village Rites",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "153f8955-1146-53be-a82f-ce739de7f43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe79ee4-c3f3-4a6b-a967-203ca3b70ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe79ee4-c3f3-4a6b-a967-203ca3b70ee5.jpg?1",
             "name": "Vito, Thorn of the Dusk Rose",
             "text": "Whenever you gain life, target opponent loses that much life.\n{3}{B}{B}: Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "b14d7137-24df-5eb3-b127-22243e197cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053b59b4-a22c-4228-aadc-ae9da6bb465e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053b59b4-a22c-4228-aadc-ae9da6bb465e.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "cff036c2-37ba-5b5c-a583-28d28ee2176c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43a3eb7-3daf-4667-b824-1f5d801c9341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43a3eb7-3daf-4667-b824-1f5d801c9341.jpg?1",
             "name": "Witch's Cauldron",
             "text": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "f415d2be-239a-57e4-863c-dac8aa3fdedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca827d-0b35-48d7-acd6-13ecacc32b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca827d-0b35-48d7-acd6-13ecacc32b82.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "8b046fe7-bc24-5231-a877-7260c63e7526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8cf3f9-4e3b-4af2-b5ef-a97eb1d2b674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8cf3f9-4e3b-4af2-b5ef-a97eb1d2b674.jpg?1",
             "name": "Bolt Hound",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever Bolt Hound attacks, other creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "40ec8b56-2dbb-5915-8098-de9fecb9d55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6075e0a3-a0ab-4a11-8ad2-7dabb071d309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6075e0a3-a0ab-4a11-8ad2-7dabb071d309.jpg?1",
             "name": "Bone Pit Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Bone Pit Brute enters the battlefield, target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "57a40adb-0eed-5f72-b70e-a9173327abc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb5e613-a803-42f3-840a-7089ac6b7e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb5e613-a803-42f3-840a-7089ac6b7e3d.jpg?1",
             "name": "Brash Taunter",
             "text": "Indestructible\nWhenever Brash Taunter is dealt damage, it deals that much damage to target opponent.\n{2}{R}, {T}: Brash Taunter fights another target creature.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "0ec250b9-21e3-5679-b60d-025cecef9732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b4a80-41e1-4c5f-869a-682f08543f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b4a80-41e1-4c5f-869a-682f08543f12.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "940935aa-b607-522d-84a6-bff36ddea294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3ca8c-c77c-43b8-84ad-796313ecc813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3ca8c-c77c-43b8-84ad-796313ecc813.jpg?1",
             "name": "Chandra, Heart of Fire",
             "text": "+1: Discard your hand, then exile the top three cards of your library. Until end of turn, you may play cards exiled this way.\n+1: Chandra, Heart of Fire deals 2 damage to any target.\n\u22129: Search your graveyard and library for any number of red instant and/or sorcery cards, exile them, then shuffle your library. You may cast them this turn. Add six {R}.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "4b90cc3f-bd38-5675-91c8-d6ec3e68df8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed875705-b7b6-4464-b16f-61629ffed04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed875705-b7b6-4464-b16f-61629ffed04f.jpg?1",
             "name": "Chandra's Incinerator",
             "text": "This spell costs {X} less to cast, where X is the total amount of noncombat damage dealt to your opponents this turn.\nTrample\nWhenever a source you control deals noncombat damage to an opponent, Chandra's Incinerator deals that much damage to target creature or planeswalker that player controls.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "80f74d1f-408b-52cc-b162-91b655b77198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d3e366-4da5-42c8-bbd5-a0c178c0da28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d3e366-4da5-42c8-bbd5-a0c178c0da28.jpg?1",
             "name": "Chandra's Magmutt",
             "text": "{T}: Chandra's Magmutt deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "9b974d05-462a-5168-879d-aeac827884e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7744fcf-2336-489d-bc05-f3fce78713a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7744fcf-2336-489d-bc05-f3fce78713a9.jpg?1",
             "name": "Chandra's Pyreling",
             "text": "Whenever a source you control deals noncombat damage to an opponent, Chandra's Pyreling gets +1/+0 and gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "4bae68cd-faa5-5b6e-98c2-54d9226683c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d878dab-5ed2-4ef3-b2c7-472290892854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d878dab-5ed2-4ef3-b2c7-472290892854.jpg?1",
             "name": "Conspicuous Snoop",
             "text": "Play with the top card of your library revealed.\nYou may cast Goblin spells from the top of your library.\nAs long as the top card of your library is a Goblin card, Conspicuous Snoop has all activated abilities of that card.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "198e206d-90b2-5fee-b9d2-5357f5448896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8257c205-00cd-4d41-bd58-098575ea2343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8257c205-00cd-4d41-bd58-098575ea2343.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)\nDraw a card.",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "da7abdb3-ef74-5c0d-b218-0b8a9a8b5e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe6a3a9-8d62-47c4-a78b-9baa9133a540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe6a3a9-8d62-47c4-a78b-9baa9133a540.jpg?1",
             "name": "Destructive Tampering",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Creatures without flying can't block this turn.",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "ad70360d-196b-5825-aafd-0dd368772466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b77b4-4cc4-4e49-a7a4-667401e7e063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b77b4-4cc4-4e49-a7a4-667401e7e063.jpg?1",
             "name": "Double Vision",
             "text": "Whenever you cast your first instant or sorcery spell each turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "34c0b40e-2ab8-5919-8a06-103068c41e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b12e4b7-2c45-4795-94d3-901f89b8f290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b12e4b7-2c45-4795-94d3-901f89b8f290.jpg?1",
             "name": "Fiery Emancipation",
             "text": "If a source you control would deal damage to a permanent or player, it deals triple that damage to that permanent or player instead.",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "cf65453f-5057-5ef5-93ca-1dcc24fdb8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae12125-73a3-488b-98b8-9f982addac56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae12125-73a3-488b-98b8-9f982addac56.jpg?1",
             "name": "Furious Rise",
             "text": "At the beginning of your end step, if you control a creature with power 4 or greater, exile the top card of your library. You may play that card until you exile another card with Furious Rise.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "5108c24f-ff04-55b2-8fa6-ee7f7341748b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e6279-8a66-4124-9def-fa0c83c26db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e6279-8a66-4124-9def-fa0c83c26db9.jpg?1",
             "name": "Furor of the Bitten",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and attacks each combat if able.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "b171b413-d049-59d2-8adf-4fcdeff481f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b83bb7-00c8-4078-b27f-42a830a544b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b83bb7-00c8-4078-b27f-42a830a544b5.jpg?1",
             "name": "Gadrak, the Crown-Scourge",
             "text": "Flying\nGadrak, the Crown-Scourge can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "5efb1be1-e377-54fd-b2a4-089c260fb87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4bf664-3b92-4598-b905-2bc090958c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4bf664-3b92-4598-b905-2bc090958c8b.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist dies, you may have it deal 1 damage to any target.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "b6391ac8-3cdb-5763-900a-0751107241ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac8bdd-851f-449d-a108-70578eabf254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac8bdd-851f-449d-a108-70578eabf254.jpg?1",
             "name": "Goblin Wizardry",
             "text": "Create two 1/1 red Goblin Wizard creature tokens with prowess. (Whenever you cast a noncreature spell, they get +1/+1 until end of turn.)",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "b0d707ec-a648-5904-b381-637f45848015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386e5cb2-39c8-453d-a642-c5d9f8495601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386e5cb2-39c8-453d-a642-c5d9f8495601.jpg?1",
             "name": "Havoc Jester",
             "text": "Whenever you sacrifice a permanent, Havoc Jester deals 1 damage to any target.",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "62dc9897-a55d-507a-9424-938cb9e51fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fb9f1-0d59-4874-aa52-ac665c3cc0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fb9f1-0d59-4874-aa52-ac665c3cc0e8.jpg?1",
             "name": "Heartfire Immolator",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{R}, Sacrifice Heartfire Immolator: It deals damage equal to its power to target creature or planeswalker.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "fc0d2389-d420-52a0-81b4-80f549388852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf663d3-850b-4a24-8e4b-08311adf4ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf663d3-850b-4a24-8e4b-08311adf4ed0.jpg?1",
             "name": "Hellkite Punisher",
             "text": "Flying\n{R}: Hellkite Punisher gets +1/+0 until end of turn.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "fc1239c8-e237-570c-92e6-62f3cda735d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfffc18-b36a-4dd5-909e-60ea9f8eb60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfffc18-b36a-4dd5-909e-60ea9f8eb60b.jpg?1",
             "name": "Hobblefiend",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n{1}, Sacrifice another creature: Put a +1/+1 counter on Hobblefiend.",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "7265b62f-7956-593a-b842-64231cb852b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bfec5d-3182-415a-afe8-0b5511cfd656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bfec5d-3182-415a-afe8-0b5511cfd656.jpg?1",
             "name": "Igneous Cur",
             "text": "{1}{R}: Igneous Cur gets +2/+0 until end of turn.",
             "colours": [
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "e9d1d8b3-184b-553f-a781-512c024de394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5e8221-fc2d-4d90-80f3-729606648c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5e8221-fc2d-4d90-80f3-729606648c54.jpg?1",
             "name": "Kinetic Augur",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nKinetic Augur's power is equal to the number of instant and sorcery cards in your graveyard.\nWhen Kinetic Augur enters the battlefield, discard up to two cards, then draw that many cards.",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "962dc950-12c1-598b-8d0d-156b04c598db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e42d07-57d9-4de4-8d41-eb42dd1573ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e42d07-57d9-4de4-8d41-eb42dd1573ed.jpg?1",
             "name": "Onakke Ogre",
             "text": "",
             "colours": [
@@ -5354,7 +5354,7 @@
         },
         {
             "id": "2c4229a9-718c-55f7-93ea-4e57fd98c537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd306cf-6625-4414-b9e5-4b909bb1bb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd306cf-6625-4414-b9e5-4b909bb1bb13.jpg?1",
             "name": "Pitchburn Devils",
             "text": "When Pitchburn Devils dies, it deals 3 damage to any target.",
             "colours": [
@@ -5388,7 +5388,7 @@
         },
         {
             "id": "b5b60d85-9fac-53f5-89d7-a4d88798590b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482ae7f4-3950-4766-8392-eea753e29426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482ae7f4-3950-4766-8392-eea753e29426.jpg?1",
             "name": "Sanctum of Shattered Heights",
             "text": "{1}, Discard a land card or Shrine card: Sanctum of Shattered Heights deals X damage to target creature or planeswalker, where X is the number of Shrines you control.",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "6938b285-b621-5aa8-90ed-fd6063227c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a1cce7-1472-42fc-bfd3-c9ed9e563f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a1cce7-1472-42fc-bfd3-c9ed9e563f03.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "62d114aa-0894-5c5b-afc7-9e6c5ba0cc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa8e8d-bcb8-47bf-b71a-df11c8d0f2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa8e8d-bcb8-47bf-b71a-df11c8d0f2c9.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "80b05e9c-9081-5663-8f8f-435d32b2f527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62584e4f-dac1-4d99-ac0a-6a2451603889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62584e4f-dac1-4d99-ac0a-6a2451603889.jpg?1",
             "name": "Soul Sear",
             "text": "Soul Sear deals 5 damage to target creature or planeswalker. That permanent loses indestructible until end of turn.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "d611c797-fd23-557f-abce-87cd65aaecae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baefa06e-28ba-41b9-866e-1ed0c4969852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baefa06e-28ba-41b9-866e-1ed0c4969852.jpg?1",
             "name": "Spellgorger Weird",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.",
             "colours": [
@@ -5554,7 +5554,7 @@
         },
         {
             "id": "91d00acc-0a57-542d-8ea0-3aed30cd86f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034b8d6d-95ea-434a-967a-e6675a7ce88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034b8d6d-95ea-434a-967a-e6675a7ce88a.jpg?1",
             "name": "Subira, Tulzidi Caravanner",
             "text": "Haste\n{1}: Another target creature with power 2 or less can't be blocked this turn.\n{1}{R}, {T}, Discard your hand: Until end of turn, whenever a creature you control with power 2 or less deals combat damage to a player, draw a card.",
             "colours": [
@@ -5593,7 +5593,7 @@
         },
         {
             "id": "f23de900-1b77-554d-8701-d7e157e996c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a6f1c-a058-4cc8-b467-5dbecb5eeb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a6f1c-a058-4cc8-b467-5dbecb5eeb99.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "18d251fa-8201-598e-a80a-53987dddd25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432ecd5f-966f-4403-a973-51e175a524a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432ecd5f-966f-4403-a973-51e175a524a0.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "7d282659-47f0-5307-bf02-ab1cdd3af42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4af156d-0fbf-4a4e-b0c1-db7e95be4903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4af156d-0fbf-4a4e-b0c1-db7e95be4903.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "f5594fcb-3cdc-53a3-aed2-02074058bc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7052f1-9736-47b6-9da3-8c5ca925ab54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7052f1-9736-47b6-9da3-8c5ca925ab54.jpg?1",
             "name": "Traitorous Greed",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Add two mana of any one color. (The creature can attack and {T} this turn.)",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "6ffbe1cb-8d6f-5e48-9153-b2cb2158d586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fa5133-c238-47e8-befd-3729a3e4303a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fa5133-c238-47e8-befd-3729a3e4303a.jpg?1",
             "name": "Transmogrify",
             "text": "Exile target creature. That creature's controller reveals cards from the top of their library until they reveal a creature card. That player puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -5759,7 +5759,7 @@
         },
         {
             "id": "ce6052bf-3835-5638-a6f9-0b4893838e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c18541-e95e-4ae0-be18-3bfcafa24ca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c18541-e95e-4ae0-be18-3bfcafa24ca2.jpg?1",
             "name": "Turn to Slag",
             "text": "Turn to Slag deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "6aa9d405-5411-54f9-9d59-e2cf3b37569c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47e9653-2a3a-4d37-8f3d-3dab4f468338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47e9653-2a3a-4d37-8f3d-3dab4f468338.jpg?1",
             "name": "Turret Ogre",
             "text": "Reach (This creature can block creatures with flying.)\nWhen Turret Ogre enters the battlefield, if you control another creature with power 4 or greater, Turret Ogre deals 2 damage to each opponent.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "1cb10061-fea6-55b8-99f8-d3e687ce696f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e854e6a3-8684-43fa-9560-ef4c3b62c935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e854e6a3-8684-43fa-9560-ef4c3b62c935.jpg?1",
             "name": "Unleash Fury",
             "text": "Double the power of target creature until end of turn.",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "9fc0dd8d-5f2e-5d7b-bee0-3092ed13a110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22c791-6ef9-4f13-a14d-4f795f48bb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22c791-6ef9-4f13-a14d-4f795f48bb1c.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to any target.",
             "colours": [
@@ -5890,7 +5890,7 @@
         },
         {
             "id": "9de5df67-f0e7-5b08-ac99-cfb7b535e299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31b6817-9b63-4d6f-a945-459b44ad184c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31b6817-9b63-4d6f-a945-459b44ad184c.jpg?1",
             "name": "Volcanic Salvo",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nVolcanic Salvo deals 6 damage to each of up to two target creatures and/or planeswalkers.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "b50f15b1-c2fb-5801-8965-7df4c7e70014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8aff2c-1f7b-4507-b914-53f8c4706b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8aff2c-1f7b-4507-b914-53f8c4706b3d.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "4157e0cf-8c41-5fe0-afb1-052e4c1f4a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0ec3bd-d894-4861-abcb-7b2e4f4de05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0ec3bd-d894-4861-abcb-7b2e4f4de05c.jpg?1",
             "name": "Burlfist Oak",
             "text": "Whenever you draw a card, Burlfist Oak gets +2/+2 until end of turn.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "fb00a888-d815-5087-ae33-020d3fc10e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6a13a-ab38-49d1-8712-f9c9135a23c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6a13a-ab38-49d1-8712-f9c9135a23c8.jpg?1",
             "name": "Canopy Stalker",
             "text": "Canopy Stalker must be blocked if able.\nWhen Canopy Stalker dies, you gain 1 life for each creature that died this turn.",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "efa86053-3a6f-592b-b713-94ddf4e15746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059c52b-5d25-4052-b48a-e9e219a7a546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059c52b-5d25-4052-b48a-e9e219a7a546.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "e87a0a8c-e03d-573e-a6c7-9c2fb268a090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a433310-3fe2-4156-864d-7a6b2638340b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a433310-3fe2-4156-864d-7a6b2638340b.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "55a76c6d-e57f-552a-809b-512c9cf4b097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b056a-ea80-4fdc-990d-0ee1e9a7bf64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b056a-ea80-4fdc-990d-0ee1e9a7bf64.jpg?1",
             "name": "Drowsing Tyrannodon",
             "text": "Defender (This creature can't attack.)\nAs long as you control a creature with power 4 or greater, Drowsing Tyrannodon can attack as though it didn't have defender.",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "8850bc6d-334b-5ce7-ae47-d7cbd340803e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg?1",
             "name": "Elder Gargaroth",
             "text": "Vigilance, reach, trample\nWhenever Elder Gargaroth attacks or blocks, choose one \u2014\n\u2022 Create a 3/3 green Beast creature token.\n\u2022 You gain 3 life.\n\u2022 Draw a card.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "b1e38119-ac98-523d-99f2-09757828d42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a9485a-d356-4cbe-b257-b62008a21328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a9485a-d356-4cbe-b257-b62008a21328.jpg?1",
             "name": "Feline Sovereign",
             "text": "Other Cats you control get +1/+1 and have protection from Dogs.\nWhenever one or more Cats you control deal combat damage to a player, destroy up to one target artifact or enchantment that player controls.",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "7cc8424d-f150-5679-ba2e-f4ffba06f20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc2af0-5a1d-4319-a285-6a15cf86be83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc2af0-5a1d-4319-a285-6a15cf86be83.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "9689b99a-4dd4-5408-91cc-2fd8f24faa20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037e3b2-cb62-4f88-943d-3edcd6827c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037e3b2-cb62-4f88-943d-3edcd6827c23.jpg?1",
             "name": "Fungal Rebirth",
             "text": "Return target permanent card from your graveyard to your hand. If a creature died this turn, create two 1/1 green Saproling creature tokens.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "62e570b2-7c2e-577b-9299-41193f21c343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2fdbec-bca2-4af5-9c2a-28b0b35b18a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2fdbec-bca2-4af5-9c2a-28b0b35b18a3.jpg?1",
             "name": "Garruk, Unleashed",
             "text": "+1: Up to one target creature gets +3/+3 and gains trample until end of turn.\n\u22122: Create a 3/3 green Beast creature token. Then if an opponent controls more creatures than you, put a loyalty counter on Garruk, Unleashed.\n\u22127: You get an emblem with \"At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -6310,7 +6310,7 @@
         },
         {
             "id": "a10128ac-1a69-5f49-9711-1e76cb969589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3928bbce-87b7-4b28-9af4-20362935c909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3928bbce-87b7-4b28-9af4-20362935c909.jpg?1",
             "name": "Garruk's Gorehorn",
             "text": "",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "31f348e3-b9f9-5958-8f6e-155b28862d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0fa0b6-5f3f-4669-84e8-2c38c9593d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0fa0b6-5f3f-4669-84e8-2c38c9593d88.jpg?1",
             "name": "Garruk's Harbinger",
             "text": "Hexproof from black\nWhenever Garruk's Harbinger deals combat damage to a player or planeswalker, look at that many cards from the top of your library. You may reveal a creature card or Garruk planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6382,7 +6382,7 @@
         },
         {
             "id": "84fed12f-6a63-54c0-bf5f-08159b537598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a4860a-8bb6-45c0-b00a-b4a42da33ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a4860a-8bb6-45c0-b00a-b4a42da33ab9.jpg?1",
             "name": "Garruk's Uprising",
             "text": "When Garruk's Uprising enters the battlefield, if you control a creature with power 4 or greater, draw a card.\nCreatures you control have trample. (They can deal excess combat damage to the player or planeswalker they're attacking.)\nWhenever a creature with power 4 or greater enters the battlefield under your control, draw a card.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "7e0cac9c-f650-5252-bb53-632bd9b6febd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f22116a-8b6a-4bbe-999f-7329e1e2b2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f22116a-8b6a-4bbe-999f-7329e1e2b2d9.jpg?1",
             "name": "Gnarled Sage",
             "text": "Reach (This creature can block creatures with flying.)\nAs long as you've drawn two or more cards this turn, Gnarled Sage gets +0/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "56c8fa05-4358-5317-a854-18fde1834ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c037e3-7d1a-48ca-8ecc-276696592f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c037e3-7d1a-48ca-8ecc-276696592f62.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -6485,7 +6485,7 @@
         },
         {
             "id": "e0cc7df4-8287-51c2-9f20-7ed902ce6a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c08c80f-f27c-4e3a-b048-143aea740096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c08c80f-f27c-4e3a-b048-143aea740096.jpg?1",
             "name": "Hunter's Edge",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "f355561b-bca4-5568-ae28-4b95a611cba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531e1fc0-a3aa-4b57-87b2-79a31af5c922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531e1fc0-a3aa-4b57-87b2-79a31af5c922.jpg?1",
             "name": "Invigorating Surge",
             "text": "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on that creature.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "ff2c2e20-0ab0-5275-abe3-1b0b3e90df11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdcfce-3f32-48f9-83f8-87b9ccbf92e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdcfce-3f32-48f9-83f8-87b9ccbf92e3.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -6588,7 +6588,7 @@
         },
         {
             "id": "067fe2bd-e82e-5eb5-8932-6f26bbc60c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888197f-5da4-4413-9cad-b37a12ba1e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888197f-5da4-4413-9cad-b37a12ba1e60.jpg?1",
             "name": "Life Goes On",
             "text": "You gain 4 life. If a creature died this turn, you gain 8 life instead.",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "04c7b2db-3b3e-57be-90ef-150f3bfdcfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e23afa-7e08-4049-baf0-d4d0134ba2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e23afa-7e08-4049-baf0-d4d0134ba2c8.jpg?1",
             "name": "Llanowar Visionary",
             "text": "When Llanowar Visionary enters the battlefield, draw a card.\n{T}: Add {G}.",
             "colours": [
@@ -6657,7 +6657,7 @@
         },
         {
             "id": "0f28c631-6e22-5250-8c5d-2e09c6d5790b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c4a0e7-9ca4-4291-94de-165cc2ded822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c4a0e7-9ca4-4291-94de-165cc2ded822.jpg?1",
             "name": "Ornery Dilophosaur",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Ornery Dilophosaur attacks, if you control a creature with power 4 or greater, Ornery Dilophosaur gets +2/+2 until end of turn.",
             "colours": [
@@ -6691,7 +6691,7 @@
         },
         {
             "id": "5bd1cfab-9306-5dd9-a9aa-73e192d9f8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abd95a-4ecc-479c-b200-5aaf7c993ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abd95a-4ecc-479c-b200-5aaf7c993ef8.jpg?1",
             "name": "Portcullis Vine",
             "text": "Defender (This creature can't attack.)\n{2}, {T}, Sacrifice a creature with defender: Draw a card.",
             "colours": [
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "8cc7f84c-eb9c-5917-b78c-c5f07111a890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df520254-0c72-496b-9222-263ca9d3c5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df520254-0c72-496b-9222-263ca9d3c5d5.jpg?1",
             "name": "Pridemalkin",
             "text": "When Pridemalkin enters the battlefield, put a +1/+1 counter on target creature you control.\nEach creature you control with a +1/+1 counter on it has trample. (They can deal excess combat damage to the player or planeswalker they're attacking.)",
             "colours": [
@@ -6760,7 +6760,7 @@
         },
         {
             "id": "5ff6bd1d-a118-5037-8047-39afa0b86029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd8cee8-7ea0-4037-8a3b-39334dc064fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd8cee8-7ea0-4037-8a3b-39334dc064fb.jpg?1",
             "name": "Primal Might",
             "text": "Target creature you control gets +X/+X until end of turn. Then it fights up to one target creature you don't control.",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "31374819-ea43-5001-8fa9-39dbd6774b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20d20f7-bc4d-42fa-9f5b-5bb330eb7f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20d20f7-bc4d-42fa-9f5b-5bb330eb7f38.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -6828,7 +6828,7 @@
         },
         {
             "id": "5939c1da-fe61-58b4-b2c1-4e36af3867a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02392840-f0c4-462e-84ce-9a7cdd9f5efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02392840-f0c4-462e-84ce-9a7cdd9f5efb.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "53681a43-0d28-564e-9f2c-80331741b0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1b4490-d96d-4448-835b-6cc453c1f344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1b4490-d96d-4448-835b-6cc453c1f344.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -6892,7 +6892,7 @@
         },
         {
             "id": "895c8730-c24f-5042-b325-05bf0d027155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd328139-0dc1-403b-ad79-b1cf3479ac33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd328139-0dc1-403b-ad79-b1cf3479ac33.jpg?1",
             "name": "Run Afoul",
             "text": "Target opponent sacrifices a creature with flying.",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "e7497a43-1bb0-5b8d-9447-2b53796bc903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe39e38e-76e5-4883-b530-d3e30e88ccad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe39e38e-76e5-4883-b530-d3e30e88ccad.jpg?1",
             "name": "Sabertooth Mauler",
             "text": "At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on Sabertooth Mauler and untap it.",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "c8c294fc-2083-511a-8c51-98f7bd3db2aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca28cfd-1a1b-4176-8b07-993d3d7b7ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca28cfd-1a1b-4176-8b07-993d3d7b7ae4.jpg?1",
             "name": "Sanctum of Fruitful Harvest",
             "text": "At the beginning of your precombat main phase, add X mana of any one color, where X is the number of Shrines you control.",
             "colours": [
@@ -6994,7 +6994,7 @@
         },
         {
             "id": "e22cac69-1970-551c-b6a5-bac392e165df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487116ab-b885-406b-aa54-56cb67eb3ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487116ab-b885-406b-aa54-56cb67eb3ca5.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "6c282bbd-3a4e-5965-8405-e6cdb99e3daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947f64a-5ca0-4dda-8bbd-8472e72ecf18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947f64a-5ca0-4dda-8bbd-8472e72ecf18.jpg?1",
             "name": "Setessan Training",
             "text": "Enchant creature you control\nWhen Setessan Training enters the battlefield, draw a card.\nEnchanted creature gets +1/+0 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "d135bcc5-9bcf-5570-9ed1-d4af5ee87854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776f5b4-1292-460f-9719-e1b603cee46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776f5b4-1292-460f-9719-e1b603cee46c.jpg?1",
             "name": "Skyway Sniper",
             "text": "Reach (This creature can block creatures with flying.)\n{2}{G}: Skyway Sniper deals 1 damage to target creature with flying.",
             "colours": [
@@ -7099,7 +7099,7 @@
         },
         {
             "id": "637cfcc8-3eeb-56a3-94a0-4a51d085162f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46700ccc-0975-49d1-b3fc-edb1eda3b624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46700ccc-0975-49d1-b3fc-edb1eda3b624.jpg?1",
             "name": "Snarespinner",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Snarespinner blocks a creature with flying, Snarespinner gets +2/+0 until end of turn.",
             "colours": [
@@ -7133,7 +7133,7 @@
         },
         {
             "id": "25c584c3-bb63-5a37-a585-762082eeea7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ab63c8-0adc-4d74-aee5-a58ce5c0dad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ab63c8-0adc-4d74-aee5-a58ce5c0dad8.jpg?1",
             "name": "Sporeweb Weaver",
             "text": "Reach, hexproof from blue\nWhenever Sporeweb Weaver is dealt damage, you gain 1 life and create a 1/1 green Saproling creature token.",
             "colours": [
@@ -7169,7 +7169,7 @@
         },
         {
             "id": "523c83b0-ee94-5f0a-9ad9-f7efb5aad95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf27a3-9bcf-475c-a324-7c3af50496dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf27a3-9bcf-475c-a324-7c3af50496dd.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -7203,7 +7203,7 @@
         },
         {
             "id": "13c72999-4ee2-512e-be0a-c40461dcc911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da62557-9783-4e6c-9b5f-2b77dbf96909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da62557-9783-4e6c-9b5f-2b77dbf96909.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "3001f1f9-3062-5207-964b-31e995766280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41b6c8a-bd76-4b69-ae72-4c8acac379b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41b6c8a-bd76-4b69-ae72-4c8acac379b4.jpg?1",
             "name": "Track Down",
             "text": "Scry 3, then reveal the top card of your library. If it's a creature or land card, draw a card. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -7267,7 +7267,7 @@
         },
         {
             "id": "30a11174-b0ed-5100-bd23-6929ee570e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba47c1-a874-456e-bea3-e99e2d61cfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba47c1-a874-456e-bea3-e99e2d61cfba.jpg?1",
             "name": "Trufflesnout",
             "text": "When Trufflesnout enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Trufflesnout.\n\u2022 You gain 4 life.",
             "colours": [
@@ -7301,7 +7301,7 @@
         },
         {
             "id": "10e9e12b-0485-5fe8-bebc-c78198b6c5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d81cfc-cff8-4478-92b6-efbfc5084165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d81cfc-cff8-4478-92b6-efbfc5084165.jpg?1",
             "name": "Warden of the Woods",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever Warden of the Woods becomes the target of a spell or ability an opponent controls, you may draw two cards.",
             "colours": [
@@ -7335,7 +7335,7 @@
         },
         {
             "id": "7831fb4c-78c6-542a-b935-3b4e1e5cef76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ff0b33-d153-4b0e-ac48-7e5ed70dea09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ff0b33-d153-4b0e-ac48-7e5ed70dea09.jpg?1",
             "name": "Wildwood Scourge",
             "text": "Wildwood Scourge enters the battlefield with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on Wildwood Scourge.",
             "colours": [
@@ -7369,7 +7369,7 @@
         },
         {
             "id": "fdfa8f7c-1476-59d7-b1cf-3a576f641574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43224e74-2c51-40bd-bc34-f66e990a3e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43224e74-2c51-40bd-bc34-f66e990a3e33.jpg?1",
             "name": "Alpine Houndmaster",
             "text": "When Alpine Houndmaster enters the battlefield, you may search your library for a card named Alpine Watchdog and/or a card named Igneous Cur, reveal them, put them into your hand, then shuffle your library.\nWhenever Alpine Houndmaster attacks, it gets +X/+0 until end of turn, where X is the number of other attacking creatures.",
             "colours": [
@@ -7406,7 +7406,7 @@
         },
         {
             "id": "978d8333-d395-5f56-98f8-ca5d0ff21609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a328a93a-e720-46d5-a190-cc65d1c90cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a328a93a-e720-46d5-a190-cc65d1c90cea.jpg?1",
             "name": "Conclave Mentor",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.\nWhen Conclave Mentor dies, you gain life equal to its power.",
             "colours": [
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "2b35e1e9-9b7d-5ae1-9733-40c1d5f99941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa781df-859f-4346-9424-b3713b17e1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa781df-859f-4346-9424-b3713b17e1f6.jpg?1",
             "name": "Dire Fleet Warmonger",
             "text": "At the beginning of combat on your turn, you may sacrifice another creature. If you do, Dire Fleet Warmonger gets +2/+2 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "ea68e0a5-6841-5f40-bfab-9b2bc629705e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1bace4-a327-4eb6-a6ef-8394e76c06b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1bace4-a327-4eb6-a6ef-8394e76c06b7.jpg?1",
             "name": "Experimental Overload",
             "text": "Create an X/X blue and red Weird creature token, where X is the number of instant and sorcery cards in your graveyard. Then you may return an instant or sorcery card from your graveyard to your hand. Exile Experimental Overload.",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "9ae1d82f-8394-5b27-ad2f-17bde2a20ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642e0c48-1f77-41e0-abbe-f570b757cd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642e0c48-1f77-41e0-abbe-f570b757cd66.jpg?1",
             "name": "Indulging Patrician",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nAt the beginning of your end step, if you gained 3 or more life this turn, each opponent loses 3 life.",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "1e369dbc-6332-5a99-8abe-56336667f770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3a903-23e0-4b5a-9c7e-390d5ced8371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3a903-23e0-4b5a-9c7e-390d5ced8371.jpg?1",
             "name": "Leafkin Avenger",
             "text": "{T}: Add {G} for each creature with power 4 or greater you control.\n{7}{R}: Leafkin Avenger deals damage equal to its power to target player or planeswalker.",
             "colours": [
@@ -7588,7 +7588,7 @@
         },
         {
             "id": "c2c4f7c1-b0c7-55d2-9033-27260af6cdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be31fb0-115e-4e62-babd-16870f249f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be31fb0-115e-4e62-babd-16870f249f06.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "b7c270f4-bb13-5b73-b46f-e18b7a1eebbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21827eb-fa49-4784-a86b-aef164a5018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21827eb-fa49-4784-a86b-aef164a5018e.jpg?1",
             "name": "Niambi, Esteemed Speaker",
             "text": "Flash\nWhen Niambi, Esteemed Speaker enters the battlefield, you may return another target creature you control to its owner's hand. If you do, you gain life equal to that creature's converted mana cost.\n{1}{W}{U}, {T}, Discard a legendary card: Draw two cards.",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "eeca070e-245a-5d13-a1a2-9afa5e7f2a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e449f985-d149-49eb-87d9-7a325215f82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e449f985-d149-49eb-87d9-7a325215f82d.jpg?1",
             "name": "Obsessive Stitcher",
             "text": "{T}: Draw a card, then discard a card.\n{2}{U}{B}, {T}, Sacrifice Obsessive Stitcher: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -7702,7 +7702,7 @@
         },
         {
             "id": "f464f0bc-2b9d-568f-8eee-5cae3739c98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbd37b1-49cb-4295-9a1f-fb85368a8f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbd37b1-49cb-4295-9a1f-fb85368a8f12.jpg?1",
             "name": "Radha, Heart of Keld",
             "text": "As long as it's your turn, Radha, Heart of Keld has first strike.\nYou may look at the top card of your library any time, and you may play lands from the top of your library.\n{4}{R}{G}: Radha gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "ce8b6fed-591b-5211-b958-726ba225c1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba91338c-1f6c-4b83-851f-98c3e9dea17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba91338c-1f6c-4b83-851f-98c3e9dea17b.jpg?1",
             "name": "Sanctum of All",
             "text": "At the beginning of your upkeep, you may search your library and/or graveyard for a Shrine card and put it onto the battlefield. If you search your library this way, shuffle it.\nIf an ability of another Shrine you control triggers while you control six or more Shrines, that ability triggers an additional time.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "6f497db1-b64b-5980-aeda-5a0dd0f860ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d387b19-a0a7-45c0-b1e9-71ca55fb4adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d387b19-a0a7-45c0-b1e9-71ca55fb4adc.jpg?1",
             "name": "Twinblade Assassins",
             "text": "At the beginning of your end step, if a creature died this turn, draw a card.",
             "colours": [
@@ -7826,7 +7826,7 @@
         },
         {
             "id": "1247a793-a4ba-5329-ba05-118c96a9f3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b9ea4-3d55-48cc-b426-c46b1d1bb397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b9ea4-3d55-48cc-b426-c46b1d1bb397.jpg?1",
             "name": "Watcher of the Spheres",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.\nWhenever another creature with flying enters the battlefield under your control, Watcher of the Spheres gets +1/+1 until end of turn.",
             "colours": [
@@ -7863,7 +7863,7 @@
         },
         {
             "id": "729de37a-f21f-5b1f-adec-41f7ab187e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af78d76-ad5c-44ba-880d-b834bcde5398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af78d76-ad5c-44ba-880d-b834bcde5398.jpg?1",
             "name": "Chromatic Orrery",
             "text": "You may spend mana as though it were mana of any color.\n{T}: Add {C}{C}{C}{C}{C}.\n{5}, {T}: Draw a card for each color among permanents you control.",
             "colours": [],
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "8fdf95ad-af47-5683-8ad6-6f35321e6c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e01bcb4-e823-4da5-b433-e75be3356367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e01bcb4-e823-4da5-b433-e75be3356367.jpg?1",
             "name": "Chrome Replicator",
             "text": "When Chrome Replicator enters the battlefield, if you control two or more nonland, nontoken permanents with the same name as one another, create a 4/4 colorless Construct artifact creature token.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "77067f1a-c783-5e9c-9c66-a1dbb73f31cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7988fd09-32a4-406b-8e7f-e77393d680a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7988fd09-32a4-406b-8e7f-e77393d680a7.jpg?1",
             "name": "Epitaph Golem",
             "text": "{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "9b02cd39-c55f-5be8-8b9b-1f59352b1093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd39a06-c53a-42c2-b2df-028358f03406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd39a06-c53a-42c2-b2df-028358f03406.jpg?1",
             "name": "Forgotten Sentinel",
             "text": "Forgotten Sentinel enters the battlefield tapped.",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "d171a62d-c76c-5eac-b830-a2e89d41b294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd761f3-6b43-4150-8595-dc3abd85b06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd761f3-6b43-4150-8595-dc3abd85b06c.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on Mazemind Tome: Scry 1.\n{2}, {T}, Put a page counter on Mazemind Tome: Draw a card.\nWhen there are four or more page counters on Mazemind Tome, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "7de938bb-650f-526f-85c2-17535322ba79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to any target.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "385fa7a3-3d0c-5d1b-8666-7c4c8218e2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27305aad-f1bd-4895-8611-143bc0250bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27305aad-f1bd-4895-8611-143bc0250bee.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "0d677bb4-77d4-5834-8ea2-c9792dc57d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedce8ab-771a-4247-9504-72ae0629df83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedce8ab-771a-4247-9504-72ae0629df83.jpg?1",
             "name": "Prismite",
             "text": "{2}: Add one mana of any color.",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "3bff6225-e956-5bee-b549-bb5e5fa22386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973c166e-3e93-4ed5-b4c5-84dc158a8e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973c166e-3e93-4ed5-b4c5-84dc158a8e4f.jpg?1",
             "name": "Short Sword",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8138,7 +8138,7 @@
         },
         {
             "id": "487015ea-4f89-53f2-adb7-0b3e34d2441b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e12530d-5509-46f1-8273-dce2c1f60965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e12530d-5509-46f1-8273-dce2c1f60965.jpg?1",
             "name": "Silent Dart",
             "text": "{4}, {T}, Sacrifice Silent Dart: It deals 3 damage to target creature.",
             "colours": [],
@@ -8166,7 +8166,7 @@
         },
         {
             "id": "3675eae9-25d4-5829-9793-ad1ee008ead7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab69fbd-0179-4b02-adba-71d2a0eeea5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab69fbd-0179-4b02-adba-71d2a0eeea5c.jpg?1",
             "name": "Skyscanner",
             "text": "Flying\nWhen Skyscanner enters the battlefield, draw a card.",
             "colours": [],
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "9a343ba7-a9f1-5833-a0c3-f3bf18de6517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbd2cab-538e-4932-a828-150e3e9d52ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbd2cab-538e-4932-a828-150e3e9d52ad.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "7c9c19c2-27ee-5de1-b048-b69b3591d86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad357ed4-b4f2-45b5-b7c4-3c6013a4ea3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad357ed4-b4f2-45b5-b7c4-3c6013a4ea3d.jpg?1",
             "name": "Sparkhunter Masticore",
             "text": "As an additional cost to cast this spell, discard a card.\nProtection from planeswalkers\n{1}: Sparkhunter Masticore deals 1 damage to target planeswalker.\n{3}: Sparkhunter Masticore gains indestructible until end of turn.",
             "colours": [],
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "cea99f53-592a-543d-9f33-c80970d34a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c224bf0-5641-4160-9d5c-46141ea8372a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c224bf0-5641-4160-9d5c-46141ea8372a.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -8291,7 +8291,7 @@
         },
         {
             "id": "063f683a-a61b-56f3-ac52-39c801e3d8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d7a2c7-666d-4fc6-bac8-ef8eb66e355d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d7a2c7-666d-4fc6-bac8-ef8eb66e355d.jpg?1",
             "name": "Animal Sanctuary",
             "text": "{T}: Add {C}.\n{2}, {T}: Put a +1/+1 counter on target Bird, Cat, Dog, Goat, Ox, or Snake.",
             "colours": [],
@@ -8321,7 +8321,7 @@
         },
         {
             "id": "8b2d5936-e7bf-5e53-a5b4-aabab907b95f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89a0e2-1163-4a11-b0df-deef2e6c8108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89a0e2-1163-4a11-b0df-deef2e6c8108.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8352,7 +8352,7 @@
         },
         {
             "id": "83baa673-2d8e-5f0e-84ea-d557575bf54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8483586-9a07-4f54-a390-7dd97fcea5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8483586-9a07-4f54-a390-7dd97fcea5cb.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "4fd2a1fe-7f74-5ea9-a371-e3daad919592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b1afa0-9bb5-4566-a85e-86a5c03e0187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b1afa0-9bb5-4566-a85e-86a5c03e0187.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8414,7 +8414,7 @@
         },
         {
             "id": "26af9c7f-3f3a-5653-8a71-2ce76578deff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d313d051-7295-4884-8cbf-f2f835fd45f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d313d051-7295-4884-8cbf-f2f835fd45f4.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "656cecc7-252d-5706-8130-510e3020de6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f28d7a-6480-4725-9719-2354921e6410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f28d7a-6480-4725-9719-2354921e6410.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "a1089e2f-1717-54b2-b36d-57bb68935172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296c34b-120b-483e-8b49-6d432c04f9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296c34b-120b-483e-8b49-6d432c04f9a4.jpg?1",
             "name": "Radiant Fountain",
             "text": "When Radiant Fountain enters the battlefield, you gain 2 life.\n{T}: Add {C}.",
             "colours": [],
@@ -8503,7 +8503,7 @@
         },
         {
             "id": "a128045a-d590-5a11-bfa1-9d3be9240e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daef8db-56a5-4b1e-b4bf-734d0516557c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daef8db-56a5-4b1e-b4bf-734d0516557c.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8534,7 +8534,7 @@
         },
         {
             "id": "5afb11e8-9080-56e6-afa9-dbcaae583f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb3d45c-a28c-49d2-ab79-53ab42c7fdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb3d45c-a28c-49d2-ab79-53ab42c7fdfd.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "f1716f48-8ce5-57f3-acd8-657eaf62444b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e649fc68-fca5-4234-aff4-0ec2382a66d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e649fc68-fca5-4234-aff4-0ec2382a66d4.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8596,7 +8596,7 @@
         },
         {
             "id": "50670ecf-47ca-5788-b970-c5f41d6e5e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1652bb3c-c365-4046-b07e-3d861fa324c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1652bb3c-c365-4046-b07e-3d861fa324c6.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8629,7 +8629,7 @@
         },
         {
             "id": "80adda58-223d-5fac-a61a-558d3da745de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97929f8-ae80-4b4a-9d9b-2f3c7605edc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97929f8-ae80-4b4a-9d9b-2f3c7605edc8.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "030de441-b3cc-5285-a02c-6e351db2e053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81634185-eb67-4d13-8b82-a662b8c9a7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81634185-eb67-4d13-8b82-a662b8c9a7f0.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "dd34648e-055c-594f-955b-5df9f11517b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5b0f0a-dc16-45e2-91ab-28e0b9f66d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5b0f0a-dc16-45e2-91ab-28e0b9f66d00.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8728,7 +8728,7 @@
         },
         {
             "id": "59b50588-3c2b-5507-87bf-6689ac07ed82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366499c-9d07-46bb-8488-6cd60056fa16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366499c-9d07-46bb-8488-6cd60056fa16.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "7a30f8a8-af06-524f-877e-1f056f4429da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82851a5-5f70-488a-b21c-bdd65d2fca7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82851a5-5f70-488a-b21c-bdd65d2fca7c.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8792,7 +8792,7 @@
         },
         {
             "id": "e957e5f4-77d9-535c-a9fd-ea03235de01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee9b4b-1510-4b78-bdde-2e0bb319ee33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee9b4b-1510-4b78-bdde-2e0bb319ee33.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8823,7 +8823,7 @@
         },
         {
             "id": "7bc9cdae-86a6-51a5-8923-3153ef4abe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d7428b-25a7-4185-8c3e-69017bd1ba6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d7428b-25a7-4185-8c3e-69017bd1ba6d.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8854,7 +8854,7 @@
         },
         {
             "id": "983bac6e-2e3d-5459-8798-480e84d3b6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be96696-aff8-4ef9-97dc-8221ef745de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be96696-aff8-4ef9-97dc-8221ef745de9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "daf4f9c6-393d-54b5-9a07-78c109bca43e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4e5bc1-f0c3-4ea7-a549-c36d932103b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4e5bc1-f0c3-4ea7-a549-c36d932103b1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "364598a6-6bce-53b0-9755-4e726858f269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a299a1e-1ce9-4668-a5f5-c587081acf6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a299a1e-1ce9-4668-a5f5-c587081acf6b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8968,7 +8968,7 @@
         },
         {
             "id": "a2cfefab-7490-512e-9cef-0bd3bbc22fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a66a1-367c-4035-a22e-00fab55be5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a66a1-367c-4035-a22e-00fab55be5a0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "bfc6c856-244d-5cca-9c5b-639e94cf3f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017fb3fc-433e-4853-bbac-99fa04b40233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017fb3fc-433e-4853-bbac-99fa04b40233.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "f4dbcfc7-89d7-5b94-ac9f-b64bb35b2b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6d5-f6a1-47c3-a898-733fab10bbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6d5-f6a1-47c3-a898-733fab10bbf5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "9021fd6e-48d7-5c3d-858e-de0dd6bf5b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b3d647-3546-4ade-b395-f2370750a7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b3d647-3546-4ade-b395-f2370750a7a6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "e0a00c3e-6d17-5e85-9d1d-c704d828a576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be68e315-ffef-40a8-8a46-1c042b148c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be68e315-ffef-40a8-8a46-1c042b148c03.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "9ebb924e-395f-5e14-8be5-176d349d1dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0863a079-1cc2-4388-85bb-a24eae251e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0863a079-1cc2-4388-85bb-a24eae251e99.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9196,7 +9196,7 @@
         },
         {
             "id": "0ef985c1-e2c4-5e7b-baa9-8014da1fc934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92c8925-ecfc-4ece-b83a-f12e98a938ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92c8925-ecfc-4ece-b83a-f12e98a938ab.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "b3c01104-639b-53a0-9613-b9c00afa9daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ff4fd5-c26f-4274-b899-1f995d4d8c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ff4fd5-c26f-4274-b899-1f995d4d8c25.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9272,7 +9272,7 @@
         },
         {
             "id": "9db2788f-544b-5631-8c27-e9470cc6adfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6fd37e-a5b3-48c6-b881-cedadfd94833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6fd37e-a5b3-48c6-b881-cedadfd94833.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9310,7 +9310,7 @@
         },
         {
             "id": "6bbebbf3-912c-5f84-a73d-24230fd8eedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3279314f-d639-4489-b2ab-3621bb3ca64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3279314f-d639-4489-b2ab-3621bb3ca64b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9348,7 +9348,7 @@
         },
         {
             "id": "dcf5782a-6dd7-5f23-9fd9-d1e58ca021e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df3e89-610c-4f42-a93a-e694342307cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df3e89-610c-4f42-a93a-e694342307cc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9386,7 +9386,7 @@
         },
         {
             "id": "d2df9ae2-3b2e-5527-b3d0-c4bf5fd4142c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4558304-7c17-4aa0-bd50-cdd95547f1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4558304-7c17-4aa0-bd50-cdd95547f1a7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9424,7 +9424,7 @@
         },
         {
             "id": "095be5f8-4abc-5122-a853-b320edc139a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ff397-2445-459a-ae4e-7bf1cd48f490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ff397-2445-459a-ae4e-7bf1cd48f490.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "8f2ad15b-e5ca-5d16-9e60-2ef6278ba21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bf5708-4222-46d2-b108-0ed4cf3c83c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bf5708-4222-46d2-b108-0ed4cf3c83c3.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "a432cb96-ca34-555f-8840-d8f5b1b010a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4949a0b-e320-470a-ba54-07ac75b0053b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4949a0b-e320-470a-ba54-07ac75b0053b.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9559,7 +9559,7 @@
         },
         {
             "id": "a72ebfb7-6a0b-5d0a-87b0-5125a3b34756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d605c780-a42a-4816-8fb9-63e3114a8246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d605c780-a42a-4816-8fb9-63e3114a8246.jpg?1",
             "name": "Rin and Seri, Inseparable",
             "text": "Whenever you cast a Dog spell, create a 1/1 green Cat creature token.\nWhenever you cast a Cat spell, create a 1/1 white Dog creature token.\n{R}{G}{W}, {T}: Rin and Seri, Inseparable deals damage to any target equal to the number of Dogs you control. You gain life equal to the number of Cats you control.",
             "colours": [
@@ -9600,7 +9600,7 @@
         },
         {
             "id": "49a71576-8f2a-5e66-8829-625bfe7d9ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bacda35-bb91-4537-a14d-846650fa85f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bacda35-bb91-4537-a14d-846650fa85f6.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to any target.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -9635,7 +9635,7 @@
         },
         {
             "id": "d0a8af76-5f2f-576f-b328-a67287e2d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3906ea-df06-4299-a305-32e6ef476507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3906ea-df06-4299-a305-32e6ef476507.jpg?1",
             "name": "Basri Ket",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains indestructible until end of turn.\n\u22122: Whenever one or more nontoken creatures attack this turn, create that many 1/1 white Soldier creature tokens that are tapped and attacking.\n\u22126: You get an emblem with \"At the beginning of combat on your turn, create a 1/1 white Soldier creature token, then put a +1/+1 counter on each creature you control.\"",
             "colours": [
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "9a0efe80-9d99-5a55-82fa-0f646f13b37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba95c4fc-f0fc-4bfe-bef7-694c3d82a6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba95c4fc-f0fc-4bfe-bef7-694c3d82a6c7.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9719,7 +9719,7 @@
         },
         {
             "id": "c42fe6da-19e6-573b-b96c-6ac5e8350e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2edac86-02d4-4201-9b72-2ec64f163a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2edac86-02d4-4201-9b72-2ec64f163a72.jpg?1",
             "name": "Liliana, Waker of the Dead",
             "text": "+1: Each player discards a card. Each opponent who can't loses 3 life.\n\u22123: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard\n\u22127: You get an emblem with \"At the beginning of combat on your turn, put target creature card from a graveyard onto the battlefield under your control. It gains haste.\"",
             "colours": [
@@ -9758,7 +9758,7 @@
         },
         {
             "id": "1d5f0452-3033-5040-8efb-155a18594c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e494793-ec53-46dc-a5db-90dadc8cc015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e494793-ec53-46dc-a5db-90dadc8cc015.jpg?1",
             "name": "Chandra, Heart of Fire",
             "text": "+1: Discard your hand, then exile the top three cards of your library. Until end of turn, you may play cards exiled this way.\n+1: Chandra, Heart of Fire deals 2 damage to any target.\n\u22129: Search your graveyard and library for any number of red instant and/or sorcery cards, exile them, then shuffle your library. You may cast them this turn. Add six {R}.",
             "colours": [
@@ -9797,7 +9797,7 @@
         },
         {
             "id": "6445b1b1-3399-52dc-b2d1-0ef3801e17dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd16e1a6-0ece-44d5-8221-25892178e927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd16e1a6-0ece-44d5-8221-25892178e927.jpg?1",
             "name": "Garruk, Unleashed",
             "text": "+1: Up to one target creature gets +3/+3 and gains trample until end of turn.\n\u22122: Create a 3/3 green Beast creature token. Then if an opponent controls more creatures than you, put a loyalty counter on Garruk, Unleashed.\n\u22127: You get an emblem with \"At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "6e4dc7a9-c361-5d5c-895d-3e5e77bb6933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11e75a0-17f0-429a-a77a-268fe6257010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11e75a0-17f0-429a-a77a-268fe6257010.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to any target.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -9871,7 +9871,7 @@
         },
         {
             "id": "27a81cb8-5003-5125-9164-eb98ace7cdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca854101-5a9b-455d-bf47-ad8f3d57afa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca854101-5a9b-455d-bf47-ad8f3d57afa7.jpg?1",
             "name": "Basri Ket",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains indestructible until end of turn.\n\u22122: Whenever one or more nontoken creatures attack this turn, create that many 1/1 white Soldier creature tokens that are tapped and attacking.\n\u22126: You get an emblem with \"At the beginning of combat on your turn, create a 1/1 white Soldier creature token, then put a +1/+1 counter on each creature you control.\"",
             "colours": [
@@ -9910,7 +9910,7 @@
         },
         {
             "id": "c945537e-0dd8-55cd-a4d7-f225e2843993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6e3c8d-66c2-4e9d-a7c2-290b5695eec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6e3c8d-66c2-4e9d-a7c2-290b5695eec2.jpg?1",
             "name": "Basri's Acolyte",
             "text": "Lifelink\nWhen Basri's Acolyte enters the battlefield, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "304a63cb-bb95-5b64-a1de-4aeed771e22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26439775-7880-4e12-81eb-92185daca3fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26439775-7880-4e12-81eb-92185daca3fd.jpg?1",
             "name": "Basri's Lieutenant",
             "text": "Vigilance, protection from multicolored\nWhen Basri's Lieutenant enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Basri's Lieutenant or another creature you control dies, if it had a +1/+1 counter on it, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "54073ee6-e09e-506f-a58c-dbd57b15557b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6daf0d-d581-434e-9b5f-cea1e7fd7967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6daf0d-d581-434e-9b5f-cea1e7fd7967.jpg?1",
             "name": "Basri's Solidarity",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "330fa447-ae91-56e1-a72a-916c45f04b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f802369f-bd9f-4c2f-835b-b0b9c1ea61a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f802369f-bd9f-4c2f-835b-b0b9c1ea61a7.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10063,7 +10063,7 @@
         },
         {
             "id": "0fec5858-1168-5933-8299-e5549afa40d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ba42c9-480c-4236-b217-01910e51b290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ba42c9-480c-4236-b217-01910e51b290.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "5e0ba6ef-f87c-58e8-bb32-9ea917d431c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a271b3-c3a9-47c6-bc8b-b580ede1968b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a271b3-c3a9-47c6-bc8b-b580ede1968b.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "a96fafad-76b9-5ad3-a2b0-d964ec7febe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fda4c0-d576-40e5-8e26-fc212c09691f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fda4c0-d576-40e5-8e26-fc212c09691f.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10198,7 +10198,7 @@
         },
         {
             "id": "f2da525d-9b45-5ea1-a1d9-451fc51ed0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a3d8f-5513-42b1-a3d7-09cf781eaf94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a3d8f-5513-42b1-a3d7-09cf781eaf94.jpg?1",
             "name": "Teferi's Ageless Insight",
             "text": "If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.",
             "colours": [
@@ -10234,7 +10234,7 @@
         },
         {
             "id": "cf67232b-e5be-5c97-b644-8c7f5f755160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d63891-366b-473e-85c6-53886e26ca7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d63891-366b-473e-85c6-53886e26ca7a.jpg?1",
             "name": "Teferi's Protege",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -10271,7 +10271,7 @@
         },
         {
             "id": "0a13cd63-eb8d-522b-8a08-1506943100d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aefc721d-7c0b-4b3a-8131-f466bf3e7949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aefc721d-7c0b-4b3a-8131-f466bf3e7949.jpg?1",
             "name": "Teferi's Tutelage",
             "text": "When Teferi's Tutelage enters the battlefield, draw a card, then discard a card.\nWhenever you draw a card, target opponent mills two cards.",
             "colours": [
@@ -10305,7 +10305,7 @@
         },
         {
             "id": "b1fb9a61-6e04-5a2a-bac3-038b50d0bbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dd3fda-d778-4be6-abd4-6cf704e352ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dd3fda-d778-4be6-abd4-6cf704e352ea.jpg?1",
             "name": "Liliana, Waker of the Dead",
             "text": "+1: Each player discards a card. Each opponent who can't loses 3 life.\n\u22123: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.\n\u22127: You get an emblem with \"At the beginning of combat on your turn, put target creature card from a graveyard onto the battlefield under your control. It gains haste.\"",
             "colours": [
@@ -10344,7 +10344,7 @@
         },
         {
             "id": "05d01186-eb40-5222-8a3a-1f48f982f214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d242d3-a817-4cdb-a51e-5f8202233743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d242d3-a817-4cdb-a51e-5f8202233743.jpg?1",
             "name": "Liliana's Devotee",
             "text": "Zombies you control get +1/+0.\nAt the beginning of your end step, if a creature died this turn, you may pay {1}{B}. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "fdc43560-b754-5e79-852a-e46b21d971df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd1c4b4-57b3-4779-9c7c-b23e73e6a74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd1c4b4-57b3-4779-9c7c-b23e73e6a74b.jpg?1",
             "name": "Liliana's Standard Bearer",
             "text": "Flash\nWhen Liliana's Standard Bearer enters the battlefield, draw X cards, where X is the number of creatures that died under your control this turn.",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "91cf7efd-8943-575e-824f-e7b46d977564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ab339-5f1a-425d-abfd-0b65a33d5c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ab339-5f1a-425d-abfd-0b65a33d5c85.jpg?1",
             "name": "Liliana's Steward",
             "text": "{T}, Sacrifice Liliana's Steward: Target opponent discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "a85fe5e1-37ed-5891-8070-aec8eb690af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e6a6bc-73ac-4000-967e-c37450665e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e6a6bc-73ac-4000-967e-c37450665e03.jpg?1",
             "name": "Chandra, Heart of Fire",
             "text": "+1: Discard your hand, then exile the top three cards of your library. Until end of turn, you may play cards exiled this way.\n+1: Chandra, Heart of Fire deals 2 damage to any target.\n\u22129: Search your graveyard and library for any number of red instant and/or sorcery cards, exile them, then shuffle your library. You may cast them this turn. Add six {R}.",
             "colours": [
@@ -10493,7 +10493,7 @@
         },
         {
             "id": "f6e32440-3544-5ccf-8df5-ef148514ef06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906cdb4-6a82-4611-abde-43566f9d01eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906cdb4-6a82-4611-abde-43566f9d01eb.jpg?1",
             "name": "Chandra's Incinerator",
             "text": "This spell costs {X} less to cast, where X is the total amount of noncombat damage dealt to your opponents this turn.\nTrample\nWhenever a source you control deals noncombat damage to an opponent, Chandra's Incinerator deals that much damage to target creature or planeswalker that player controls.",
             "colours": [
@@ -10529,7 +10529,7 @@
         },
         {
             "id": "efad8416-7efe-5c22-b36f-979bc1fe7978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ebe97-730c-43bb-86da-6ef0b34c104b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ebe97-730c-43bb-86da-6ef0b34c104b.jpg?1",
             "name": "Chandra's Magmutt",
             "text": "{T}: Chandra's Magmutt deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "ad64f509-8cab-5283-a2e6-1a9aa1d57dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b807033-2273-4415-95b8-eb2dafed2967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b807033-2273-4415-95b8-eb2dafed2967.jpg?1",
             "name": "Chandra's Pyreling",
             "text": "Whenever a source you control deals noncombat damage to an opponent, Chandra's Pyreling gets +1/+0 and gains double strike until end of turn.",
             "colours": [
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "4c31e82b-c1b0-5d5b-b429-32d52caea3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e92f14-776d-4fa6-b872-1acadca1e372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e92f14-776d-4fa6-b872-1acadca1e372.jpg?1",
             "name": "Garruk, Unleashed",
             "text": "+1: Up to one target creature gets +3/+3 and gains trample until end of turn.\n\u22122: Create a 3/3 green Beast creature token. Then if an opponent controls more creatures than you, put a loyalty counter on Garruk, Unleashed.\n\u22127: You get an emblem with \"At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -10642,7 +10642,7 @@
         },
         {
             "id": "9febf0f0-0876-592c-b850-4218cb6cf4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5c6492-4934-4d61-85ef-3dd64677dee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5c6492-4934-4d61-85ef-3dd64677dee3.jpg?1",
             "name": "Garruk's Gorehorn",
             "text": "",
             "colours": [
@@ -10678,7 +10678,7 @@
         },
         {
             "id": "862bd8d2-77ab-51f2-b2d6-9ee601e86f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faee64c-2338-4b01-8e26-7b68539a998b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faee64c-2338-4b01-8e26-7b68539a998b.jpg?1",
             "name": "Garruk's Harbinger",
             "text": "Hexproof from black\nWhenever Garruk's Harbinger deals combat damage to a player or planeswalker, look at that many cards from the top of your library. You may reveal a creature card or Garruk planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10714,7 +10714,7 @@
         },
         {
             "id": "5975656a-ef92-53d0-afa7-f69b3156ac8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce84db-d331-4e5b-bdd8-9b1b3bec50cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce84db-d331-4e5b-bdd8-9b1b3bec50cc.jpg?1",
             "name": "Garruk's Uprising",
             "text": "When Garruk's Uprising enters the battlefield, if you control a creature with power 4 or greater, draw a card.\nCreatures you control have trample.\nWhenever a creature with power 4 or greater enters the battlefield under your control, draw a card.",
             "colours": [
@@ -10748,7 +10748,7 @@
         },
         {
             "id": "d6c798e1-56b7-5edf-9253-d2fdf7c6c79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6778ff-6c1c-498a-bbfa-46c35b77a72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6778ff-6c1c-498a-bbfa-46c35b77a72a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10786,7 +10786,7 @@
         },
         {
             "id": "5d68fdec-6205-571f-804a-7dc74f7811fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24aa9fd2-54d9-40d9-9279-abd5bd6ff727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24aa9fd2-54d9-40d9-9279-abd5bd6ff727.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10824,7 +10824,7 @@
         },
         {
             "id": "7a85abdd-8744-5682-a768-709e5e92d569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b8665-31f2-4142-a076-54bccdaf5a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b8665-31f2-4142-a076-54bccdaf5a15.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10862,7 +10862,7 @@
         },
         {
             "id": "3cabbf32-9716-54d5-a2b0-cf3e65bb573f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162885d-3f55-4440-b40d-e38d378c4567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162885d-3f55-4440-b40d-e38d378c4567.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10900,7 +10900,7 @@
         },
         {
             "id": "16c6758e-a4b1-5a71-b003-e953b496340e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e049ae-bb12-41af-bbe4-ceded30bad67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e049ae-bb12-41af-bbe4-ceded30bad67.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10938,7 +10938,7 @@
         },
         {
             "id": "0282d6c1-49c2-53fc-ab4c-edb0db6ae522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51bacdd-040e-45f7-9256-85f93801a10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51bacdd-040e-45f7-9256-85f93801a10e.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -10975,7 +10975,7 @@
         },
         {
             "id": "d844bf3f-d1a3-5ace-9160-dc26aae1a3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf0dded-552a-4ad2-bb62-f1bfabad9bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf0dded-552a-4ad2-bb62-f1bfabad9bac.jpg?1",
             "name": "Grim Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle your library. You lose 3 life.",
             "colours": [
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "84075610-bcac-509d-acd3-0717da7c91e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0523c0a-b9b6-4946-b90d-ed8e13cf1915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0523c0a-b9b6-4946-b90d-ed8e13cf1915.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -11046,7 +11046,7 @@
         },
         {
             "id": "8a150628-783f-50f4-9006-d36dd693f047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31233339-c5ec-40fb-badd-94ef7f0ff7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31233339-c5ec-40fb-badd-94ef7f0ff7c0.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -11080,7 +11080,7 @@
         },
         {
             "id": "38aac902-fd08-546a-86d5-8f0ce99b91c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91920a-7de3-4e9b-9cce-ff43ce0157b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91920a-7de3-4e9b-9cce-ff43ce0157b8.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -11116,7 +11116,7 @@
         },
         {
             "id": "633734ac-e0aa-56ee-9ff2-4563deb0ad82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eab51a-8dad-4a37-9551-c6bf0dc6ecf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eab51a-8dad-4a37-9551-c6bf0dc6ecf5.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -11149,7 +11149,7 @@
         },
         {
             "id": "5a985f71-05af-5d0f-8276-1527016bdc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688b45d-9d74-4d9f-9a63-29c82b48d64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688b45d-9d74-4d9f-9a63-29c82b48d64f.jpg?1",
             "name": "Basri, Devoted Paladin",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains vigilance until end of turn.\n\u22121: Whenever a creature attacks this turn, put a +1/+1 counter on it.\n\u22126: Creatures you control get +2/+2 and gain flying until end of turn.",
             "colours": [
@@ -11184,7 +11184,7 @@
         },
         {
             "id": "5a848726-7e64-54d1-9d82-90b700dec99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2bc7ad-458d-445e-a0a9-7897b596fdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2bc7ad-458d-445e-a0a9-7897b596fdd0.jpg?1",
             "name": "Adherent of Hope",
             "text": "At the beginning of combat on your turn, if you control a Basri planeswalker, put a +1/+1 counter on Adherent of Hope.",
             "colours": [
@@ -11218,7 +11218,7 @@
         },
         {
             "id": "e31a8ca4-4d7d-5c5c-9632-35fcb158620d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577657ed-162f-4104-b0af-ee9733e90f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577657ed-162f-4104-b0af-ee9733e90f20.jpg?1",
             "name": "Basri's Aegis",
             "text": "Put a +1/+1 counter on each of up to two target creatures. You may search your library and/or graveyard for a card named Basri, Devoted Paladin, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11249,7 +11249,7 @@
         },
         {
             "id": "42e7acd1-5511-5ffb-b124-500bbf5f4330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba81e67-8fa5-441c-bf14-2d75c168a617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba81e67-8fa5-441c-bf14-2d75c168a617.jpg?1",
             "name": "Sigiled Contender",
             "text": "Sigiled Contender has lifelink as long as it has a +1/+1 counter on it. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -11283,7 +11283,7 @@
         },
         {
             "id": "f3b0d979-2575-522a-8fa8-2b1d5a05c5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d05287-ad7f-4de8-9f68-8f36c62fae72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d05287-ad7f-4de8-9f68-8f36c62fae72.jpg?1",
             "name": "Teferi, Timeless Voyager",
             "text": "+1: Draw a card.\n\u22123: Put target creature on top of its owner's library.\n\u22128: Each creature target opponent controls phases out. Until the end of your next turn, they can't phase in. (Treat them and anything attached to them as though they don't exist.)",
             "colours": [
@@ -11318,7 +11318,7 @@
         },
         {
             "id": "a98d6413-0bd5-577c-a788-6b812a79b180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae981da0-f32c-49d5-bcb0-2b9255a4e1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae981da0-f32c-49d5-bcb0-2b9255a4e1fe.jpg?1",
             "name": "Historian of Zhalfir",
             "text": "Whenever Historian of Zhalfir attacks, if you control a Teferi planeswalker, draw a card.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "53ae3b74-6c04-5acd-887a-292762135057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1",
             "name": "Mystic Skyfish",
             "text": "Whenever you draw your second card each turn, Mystic Skyfish gains flying until end of turn.",
             "colours": [
@@ -11385,7 +11385,7 @@
         },
         {
             "id": "44e9b27b-905f-5559-8dbe-3b54b455be83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67e4c42-a44f-456b-87e7-21ca56dc4630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67e4c42-a44f-456b-87e7-21ca56dc4630.jpg?1",
             "name": "Teferi's Wavecaster",
             "text": "Flash\nWhen Teferi's Wavecaster enters the battlefield, you may search your library and/or graveyard for a card named Teferi, Timeless Voyager, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11419,7 +11419,7 @@
         },
         {
             "id": "77f79f88-ea4a-521c-8773-db7d0f1c659b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921e3dc3-f8eb-4498-a6a8-b424952230cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921e3dc3-f8eb-4498-a6a8-b424952230cd.jpg?1",
             "name": "Liliana, Death Mage",
             "text": "+1: Return up to one target creature card from your graveyard to your hand.\n\u22123: Destroy target creature. Its controller loses 2 life.\n\u22127: Target opponent loses 2 life for each creature card in their graveyard.",
             "colours": [
@@ -11454,7 +11454,7 @@
         },
         {
             "id": "fc55d419-9056-5814-8fff-04eddb34dec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231f941-4acb-46f2-81ae-16e5a28e65af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231f941-4acb-46f2-81ae-16e5a28e65af.jpg?1",
             "name": "Liliana's Scorn",
             "text": "Destroy target creature. You may search your library and/or graveyard for a card named Liliana, Death Mage, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11485,7 +11485,7 @@
         },
         {
             "id": "b27208c9-8b0e-5e02-b11f-e343aabef0a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a64625f-937a-449e-b1fc-cd0f25b033f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a64625f-937a-449e-b1fc-cd0f25b033f6.jpg?1",
             "name": "Liliana's Scrounger",
             "text": "At the beginning of each end step, if a creature died this turn, you may put a loyalty counter on a Liliana planeswalker you control.",
             "colours": [
@@ -11519,7 +11519,7 @@
         },
         {
             "id": "4276487f-17d6-55e2-98ca-a77381c13d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3765b7-11e2-4837-b5e5-ca24adc0e33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3765b7-11e2-4837-b5e5-ca24adc0e33c.jpg?1",
             "name": "Spirit of Malevolence",
             "text": "When Spirit of Malevolence dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11552,7 +11552,7 @@
         },
         {
             "id": "96fa6bc6-2dfa-57b8-87a3-37223a12f809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e49ce44-5286-4310-88c2-f8a1402b113b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e49ce44-5286-4310-88c2-f8a1402b113b.jpg?1",
             "name": "Chandra, Flame's Catalyst",
             "text": "+1: Chandra, Flame's Catalyst deals 3 damage to each opponent.\n\u22122: You may cast target red instant or sorcery card from your graveyard. If that spell would be put into your graveyard this turn, exile it instead.\n\u22128: Discard your hand, then draw seven cards. Until end of turn, you may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -11587,7 +11587,7 @@
         },
         {
             "id": "35499aec-5e33-5245-a357-95c44ca43a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf0b50-155f-4e65-9e48-88b378ad93a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf0b50-155f-4e65-9e48-88b378ad93a1.jpg?1",
             "name": "Chandra's Firemaw",
             "text": "Haste\nWhen Chandra's Firemaw enters the battlefield, you may search your library and/or graveyard for a card named Chandra, Flame's Catalyst, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11620,7 +11620,7 @@
         },
         {
             "id": "2229dd8b-86b5-5d2b-af16-14422a90c37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b862e46-f5a2-4fce-98b5-2c5aa49ec648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b862e46-f5a2-4fce-98b5-2c5aa49ec648.jpg?1",
             "name": "Keral Keep Disciples",
             "text": "Whenever you activate a loyalty ability of a Chandra planeswalker, Keral Keep Disciples deals 1 damage to each opponent.",
             "colours": [
@@ -11654,7 +11654,7 @@
         },
         {
             "id": "a85fc0d9-26a8-5c3d-a9ac-17f29ad9348d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d123c-c16d-43fa-b183-8a59c7e1a11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d123c-c16d-43fa-b183-8a59c7e1a11e.jpg?1",
             "name": "Storm Caller",
             "text": "When Storm Caller enters the battlefield, it deals 2 damage to each opponent.",
             "colours": [
@@ -11688,7 +11688,7 @@
         },
         {
             "id": "193f8e09-b8ca-509c-9b4c-264e29a05cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48133629-4a5b-4c91-b496-2ee94f6cbc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48133629-4a5b-4c91-b496-2ee94f6cbc4c.jpg?1",
             "name": "Garruk, Savage Herald",
             "text": "+1: Reveal the top card of your library. If it's a creature card, put it into your hand. Otherwise, put it on the bottom of your library.\n\u22122: Target creature you control deals damage equal to its power to another target creature.\n\u22127: Until end of turn, creatures you control gain \"You may have this creature assign its combat damage as though it weren't blocked.\"",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "ade144fa-2f01-5dfa-be1d-01287677f887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6099863-8d3d-44bf-8d3b-dc3602119617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6099863-8d3d-44bf-8d3b-dc3602119617.jpg?1",
             "name": "Garruk's Warsteed",
             "text": "Vigilance\nWhen Garruk's Warsteed enters the battlefield, you may search your library and/or graveyard for a card named Garruk, Savage Herald, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11756,7 +11756,7 @@
         },
         {
             "id": "9c85e879-8136-5860-89fb-e2d82c8ba3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073cbc6-11de-4d4a-bcd7-792f9b7c5219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073cbc6-11de-4d4a-bcd7-792f9b7c5219.jpg?1",
             "name": "Predatory Wurm",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nPredatory Wurm gets +2/+2 as long as you control a Garruk planeswalker.",
             "colours": [
@@ -11789,7 +11789,7 @@
         },
         {
             "id": "19a596b1-90f7-5f7c-963f-62faa5ddb99f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceaf927-261e-4d61-9fac-eb8abbe87593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceaf927-261e-4d61-9fac-eb8abbe87593.jpg?1",
             "name": "Wildwood Patrol",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -11823,7 +11823,7 @@
         },
         {
             "id": "25675646-282c-5689-81d1-3c794117a309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0974b4-b306-4026-b0a8-22bd9da3e384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0974b4-b306-4026-b0a8-22bd9da3e384.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "0f063021-459f-594f-8968-823794af5da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ba79d6-7da0-46ba-a26a-dc484bdae41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ba79d6-7da0-46ba-a26a-dc484bdae41d.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -11893,7 +11893,7 @@
         },
         {
             "id": "2984b348-efc5-58ab-9191-9c004808e643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811c396-8992-4c3c-b2f6-c866f1aefcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811c396-8992-4c3c-b2f6-c866f1aefcc5.jpg?1",
             "name": "Idol of Endurance",
             "text": "When Idol of Endurance enters the battlefield, exile all creature cards with converted mana cost 3 or less from your graveyard until Idol of Endurance leaves the battlefield.\n{1}{W}, {T}: Until end of turn, you may cast a creature spell from among the cards exiled with Idol of Endurance without paying its mana cost.",
             "colours": [
@@ -11927,7 +11927,7 @@
         },
         {
             "id": "1153a85e-d45d-5086-859b-acc5c4c198ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011cfa46-6827-4418-881b-686eb34e06ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011cfa46-6827-4418-881b-686eb34e06ce.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -11966,7 +11966,7 @@
         },
         {
             "id": "597eefbd-b0b5-5e7a-b78a-a2cee7b553e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada448c-6431-4172-b458-efa49c302dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada448c-6431-4172-b458-efa49c302dfb.jpg?1",
             "name": "Nine Lives",
             "text": "Hexproof\nIf a source would deal damage to you, prevent that damage and put an incarnation counter on Nine Lives.\nWhen there are nine or more incarnation counters on Nine Lives, exile it.\nWhen Nine Lives leaves the battlefield, you lose the game.",
             "colours": [
@@ -12000,7 +12000,7 @@
         },
         {
             "id": "e3bf017d-5853-5123-98b3-c513be5b00a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f7a7ef-aa18-4738-97db-97e50ec3b801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f7a7ef-aa18-4738-97db-97e50ec3b801.jpg?1",
             "name": "Pack Leader",
             "text": "Other Dogs you control get +1/+1.\nWhenever Pack Leader attacks, prevent all combat damage that would be dealt this turn to Dogs you control.",
             "colours": [
@@ -12037,7 +12037,7 @@
         },
         {
             "id": "bd3f6487-805c-5225-b032-6ac65b906b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1223eaa0-dee9-4bff-a4d5-3b30aa973b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1223eaa0-dee9-4bff-a4d5-3b30aa973b84.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen card name.",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "87df54a3-5090-5bb5-9774-bc78962641ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e300294d-0bbd-4d28-b2bd-c5a976de212a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e300294d-0bbd-4d28-b2bd-c5a976de212a.jpg?1",
             "name": "Speaker of the Heavens",
             "text": "Vigilance, lifelink\n{T}: Create a 4/4 white Angel creature token with flying. Activate this ability only if you have at least 7 life more than your starting life total and only any time you could cast a sorcery.",
             "colours": [
@@ -12108,7 +12108,7 @@
         },
         {
             "id": "23029e04-3066-5de6-aa29-036ce22c44ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3765b7-bd99-4c66-8761-1c9cc5bd8666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3765b7-bd99-4c66-8761-1c9cc5bd8666.jpg?1",
             "name": "Barrin, Tolarian Archmage",
             "text": "When Barrin, Tolarian Archmage enters the battlefield, return up to one other target creature or planeswalker to its owner's hand.\nAt the beginning of your end step, if a permanent was put into your hand from the battlefield this turn, draw a card.",
             "colours": [
@@ -12147,7 +12147,7 @@
         },
         {
             "id": "1f1fe2b2-68e1-597c-bcbc-249bbfd0e225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f8208-0dba-49e0-ae53-b1c9347b92b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f8208-0dba-49e0-ae53-b1c9347b92b6.jpg?1",
             "name": "Discontinuity",
             "text": "As long as it's your turn, this spell costs {2}{U}{U} less to cast.\nEnd the turn.",
             "colours": [
@@ -12181,7 +12181,7 @@
         },
         {
             "id": "52a6e270-a95c-5f45-b33d-3c495c425510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f96dc6-65ff-4527-8fe6-ff508da5b8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f96dc6-65ff-4527-8fe6-ff508da5b8b9.jpg?1",
             "name": "Ghostly Pilferer",
             "text": "Whenever Ghostly Pilferer becomes untapped, you may pay {2}. If you do, draw a card.\nWhenever an opponent casts a spell from anywhere other than their hand, draw a card.\nDiscard a card: Ghostly Pilferer can't be blocked this turn.",
             "colours": [
@@ -12218,7 +12218,7 @@
         },
         {
             "id": "2afe2c85-77fb-5734-8738-b3f0b95170a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143052f0-4fcc-4703-9147-75b65ddb8e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143052f0-4fcc-4703-9147-75b65ddb8e0f.jpg?1",
             "name": "Pursued Whale",
             "text": "When Pursued Whale enters the battlefield, each opponent creates a 1/1 red Pirate creature token with \"This creature can't block\" and \"Creatures you control attack each combat if able.\"\nSpells your opponents cast that target Pursued Whale cost {3} more to cast.",
             "colours": [
@@ -12254,7 +12254,7 @@
         },
         {
             "id": "5764ce75-6054-5e90-a5e1-86d5d23740cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de27dfa8-5790-4b42-ae57-b68814d66e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de27dfa8-5790-4b42-ae57-b68814d66e34.jpg?1",
             "name": "See the Truth",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order. If this spell was cast from anywhere other than your hand, put each of those cards into your hand instead.",
             "colours": [
@@ -12288,7 +12288,7 @@
         },
         {
             "id": "af746582-700f-5424-be4e-f76a8582ab44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6d0c71-d1c8-4eb0-96e7-b3325d5fb4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6d0c71-d1c8-4eb0-96e7-b3325d5fb4c0.jpg?1",
             "name": "Shacklegeist",
             "text": "Flying\nShacklegeist can block only creatures with flying.\nTap two untapped Spirits you control: Tap target creature you don't control.",
             "colours": [
@@ -12324,7 +12324,7 @@
         },
         {
             "id": "f255dc77-c7de-5586-85bc-2680cc1e7870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b9d2-e49d-4ac1-abda-88a83b58dc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b9d2-e49d-4ac1-abda-88a83b58dc30.jpg?1",
             "name": "Stormwing Entity",
             "text": "This spell costs {2}{U} less to cast if you've cast an instant or sorcery spell this turn.\nFlying\nProwess\nWhen Stormwing Entity enters the battlefield, scry 2.",
             "colours": [
@@ -12360,7 +12360,7 @@
         },
         {
             "id": "cfd3b24e-bae7-59f9-9634-90ccfc3f8937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c8712-0cfa-465c-a712-2bd1385d8049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c8712-0cfa-465c-a712-2bd1385d8049.jpg?1",
             "name": "Sublime Epiphany",
             "text": "Choose one or more \u2014\n\u2022 Counter target spell.\n\u2022 Counter target activated or triggered ability.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Create a token that's a copy of target creature you control.\n\u2022 Target player draws a card.",
             "colours": [
@@ -12394,7 +12394,7 @@
         },
         {
             "id": "c4074867-105a-5c21-8791-099ddb95d511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cf6c9-7e73-448c-abc1-35758d269472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cf6c9-7e73-448c-abc1-35758d269472.jpg?1",
             "name": "Demonic Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+1, has flying, and is a Demon in addition to its other types.\nYou may cast Demonic Embrace from your graveyard by paying 3 life and discarding a card in addition to paying its other costs.",
             "colours": [
@@ -12430,7 +12430,7 @@
         },
         {
             "id": "fafd13e2-9ba1-587e-b403-7bf6a6b59183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3becd8e2-677a-4e54-8839-2b9f80573aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3becd8e2-677a-4e54-8839-2b9f80573aa1.jpg?1",
             "name": "Hooded Blightfang",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch attacks, each opponent loses 1 life and you gain 1 life.\nWhenever a creature you control with deathtouch deals damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -12466,7 +12466,7 @@
         },
         {
             "id": "548ca45b-5cdf-54f4-90da-bc018fd386ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85082679-360f-48a2-a131-ce939f774749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85082679-360f-48a2-a131-ce939f774749.jpg?1",
             "name": "Kaervek, the Spiteful",
             "text": "Other creatures get -1/-1.",
             "colours": [
@@ -12505,7 +12505,7 @@
         },
         {
             "id": "75cca7f4-160f-5334-8cc7-a008c0aee672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9350ab9a-263b-4698-b4e7-2beb01c39134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9350ab9a-263b-4698-b4e7-2beb01c39134.jpg?1",
             "name": "Necromentia",
             "text": "Choose a card name other than a basic land card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles their library, then creates a 2/2 black Zombie creature token for each card exiled from their hand this way.",
             "colours": [
@@ -12539,7 +12539,7 @@
         },
         {
             "id": "7c12f551-aed1-5f24-a2d9-c346f1603701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46820e5-67a4-4b28-bd0c-7ed9443d7dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46820e5-67a4-4b28-bd0c-7ed9443d7dfb.jpg?1",
             "name": "Peer into the Abyss",
             "text": "Target player draws cards equal to half the number of cards in their library and loses half their life. Round up each time.",
             "colours": [
@@ -12573,7 +12573,7 @@
         },
         {
             "id": "83a0830b-6cf8-5201-9aa4-e92fd34f0deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8962e7d-b14d-41b5-8805-17490b6c32bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8962e7d-b14d-41b5-8805-17490b6c32bf.jpg?1",
             "name": "Thieves' Guild Enforcer",
             "text": "Flash\nWhenever Thieves' Guild Enforcer or another Rogue enters the battlefield under your control, each opponent mills two cards.\nAs long as an opponent has eight or more cards in their graveyard, Thieves' Guild Enforcer gets +2/+1 and has deathtouch.",
             "colours": [
@@ -12610,7 +12610,7 @@
         },
         {
             "id": "9a472dc4-de91-5e62-aa97-225e6a378068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a52a83-0087-4df3-995a-45e15bf664b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a52a83-0087-4df3-995a-45e15bf664b4.jpg?1",
             "name": "Vito, Thorn of the Dusk Rose",
             "text": "Whenever you gain life, target opponent loses that much life.\n{3}{B}{B}: Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -12649,7 +12649,7 @@
         },
         {
             "id": "fa3cff1a-b70e-54c2-90ba-9e948e653cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea0d236-bfd2-4f47-8592-2669834d01f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea0d236-bfd2-4f47-8592-2669834d01f1.jpg?1",
             "name": "Brash Taunter",
             "text": "Indestructible\nWhenever Brash Taunter is dealt damage, it deals that much damage to target opponent.\n{2}{R}, {T}: Brash Taunter fights another target creature.",
             "colours": [
@@ -12685,7 +12685,7 @@
         },
         {
             "id": "7a7c6116-a678-5182-b0da-3bfd7c0280bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e3cb0a-3a23-4b00-9a79-bd2d16d0b1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e3cb0a-3a23-4b00-9a79-bd2d16d0b1b2.jpg?1",
             "name": "Conspicuous Snoop",
             "text": "Play with the top card of your library revealed.\nYou may cast Goblin spells from the top of your library.\nAs long as the top card of your library is a Goblin card, Conspicuous Snoop has all activated abilities of that card.",
             "colours": [
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "4b59b687-4336-5509-9ac3-0c82aeba4e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4955455-c708-4f96-ba21-0a6de0e74336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4955455-c708-4f96-ba21-0a6de0e74336.jpg?1",
             "name": "Double Vision",
             "text": "Whenever you cast your first instant or sorcery spell each turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -12756,7 +12756,7 @@
         },
         {
             "id": "c2d28ec0-668c-5b0b-80e1-0a40dc2917f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33957ca8-babe-45d2-bcf2-15ed1add5ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33957ca8-babe-45d2-bcf2-15ed1add5ec9.jpg?1",
             "name": "Fiery Emancipation",
             "text": "If a source you control would deal damage to a permanent or player, it deals triple that damage to that permanent or player instead.",
             "colours": [
@@ -12790,7 +12790,7 @@
         },
         {
             "id": "0dda41a3-559c-5553-8e4a-b147ea8e38e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333228c5-af16-4ebd-acfc-3776b21ef044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333228c5-af16-4ebd-acfc-3776b21ef044.jpg?1",
             "name": "Gadrak, the Crown-Scourge",
             "text": "Flying\nGadrak, the Crown-Scourge can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn.",
             "colours": [
@@ -12828,7 +12828,7 @@
         },
         {
             "id": "c49c2379-d93e-545f-9251-43585a1869e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380fd52-8fee-4956-a9fa-986019bcb423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380fd52-8fee-4956-a9fa-986019bcb423.jpg?1",
             "name": "Subira, Tulzidi Caravanner",
             "text": "Haste\n{1}: Another target creature with power 2 or less can't be blocked this turn.\n{1}{R}, {T}, Discard your hand: Until end of turn, whenever a creature you control with power 2 or less deals combat damage to a player, draw a card.",
             "colours": [
@@ -12867,7 +12867,7 @@
         },
         {
             "id": "1be1135f-83ee-519b-ad48-7e97dc0520b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ea21-fef4-4000-9b22-c8d07420827b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ea21-fef4-4000-9b22-c8d07420827b.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -12903,7 +12903,7 @@
         },
         {
             "id": "20b81307-f56d-5f15-896a-f99f2a0318b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6252e7-aa4f-4d7b-a655-6564c5c124e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6252e7-aa4f-4d7b-a655-6564c5c124e6.jpg?1",
             "name": "Transmogrify",
             "text": "Exile target creature. That creature's controller reveals cards from the top of their library until they reveal a creature card. That player puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -12937,7 +12937,7 @@
         },
         {
             "id": "3287f681-2d33-5477-8cb9-8002dbc58562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a95e99-4398-4263-90bc-1b0c544b18b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a95e99-4398-4263-90bc-1b0c544b18b1.jpg?1",
             "name": "Volcanic Salvo",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nVolcanic Salvo deals 6 damage to each of up to two target creatures and/or planeswalkers.",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "1fecbcb2-2b39-5e4d-8daf-60d98ce30c45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1507b7bc-cf3d-42c7-a4c8-e5b22cea9ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1507b7bc-cf3d-42c7-a4c8-e5b22cea9ec0.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -13010,7 +13010,7 @@
         },
         {
             "id": "33207345-915a-59ef-a727-fedae6703cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee9b3ad-0774-4952-b49b-be390182b245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee9b3ad-0774-4952-b49b-be390182b245.jpg?1",
             "name": "Elder Gargaroth",
             "text": "Vigilance, reach, trample\nWhenever Elder Gargaroth attacks or blocks, choose one \u2014\n\u2022 Create a 3/3 green Beast creature token.\n\u2022 You gain 3 life.\n\u2022 Draw a card.",
             "colours": [
@@ -13046,7 +13046,7 @@
         },
         {
             "id": "3b0b5d0f-d876-5373-832d-fad4b4d49d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbea5a3c-03b7-44da-b8f7-534a962b8e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbea5a3c-03b7-44da-b8f7-534a962b8e1e.jpg?1",
             "name": "Feline Sovereign",
             "text": "Other Cats you control get +1/+1 and have protection from Dogs.\nWhenever one or more Cats you control deal combat damage to a player, destroy up to one target artifact or enchantment that player controls.",
             "colours": [
@@ -13082,7 +13082,7 @@
         },
         {
             "id": "32553924-05b7-580a-8740-c6eac3f040e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9fb88e-d13d-46d0-a3c5-da886f43ffb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9fb88e-d13d-46d0-a3c5-da886f43ffb9.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -13116,7 +13116,7 @@
         },
         {
             "id": "077244e4-aec5-593b-9590-adf1c2d9e8bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ccd23e-c883-474b-93e5-4131aa1e6e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ccd23e-c883-474b-93e5-4131aa1e6e8a.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "1e313405-c7ab-5cda-9c5d-d724a7b66321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffcaab7-674b-4e34-b09d-41414bd0022e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffcaab7-674b-4e34-b09d-41414bd0022e.jpg?1",
             "name": "Primal Might",
             "text": "Target creature you control gets +X/+X until end of turn. Then it fights up to one target creature you don't control.",
             "colours": [
@@ -13189,7 +13189,7 @@
         },
         {
             "id": "19fdf946-c2a1-571d-9ab0-101940ee7ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e999a48-27ab-429c-95cc-249d931bbbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e999a48-27ab-429c-95cc-249d931bbbd5.jpg?1",
             "name": "Sporeweb Weaver",
             "text": "Reach, hexproof from blue\nWhenever Sporeweb Weaver is dealt damage, you gain 1 life and create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13225,7 +13225,7 @@
         },
         {
             "id": "255c977d-38e8-5c67-b5b4-9be0b6f4d859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b942b9-fcf4-421d-a470-73a90f0408a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b942b9-fcf4-421d-a470-73a90f0408a5.jpg?1",
             "name": "Niambi, Esteemed Speaker",
             "text": "Flash\nWhen Niambi, Esteemed Speaker enters the battlefield, you may return another target creature you control to its owner's hand. If you do, you gain life equal to that creature's converted mana cost.\n{1}{W}{U}, {T}, Discard a legendary card: Draw two cards.",
             "colours": [
@@ -13266,7 +13266,7 @@
         },
         {
             "id": "09416767-8fe9-5863-ab61-76bef6d048a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7777bc17-88cf-41fb-9169-77149c01eec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7777bc17-88cf-41fb-9169-77149c01eec8.jpg?1",
             "name": "Radha, Heart of Keld",
             "text": "As long as it's your turn, Radha, Heart of Keld has first strike.\nYou may look at the top card of your library any time, and you may play lands from the top of your library.\n{4}{R}{G}: Radha gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -13307,7 +13307,7 @@
         },
         {
             "id": "3a6e0ee5-2af3-5474-ac7b-1683632dfd9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b401c8b-dea9-4df7-8929-52370d47bf91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b401c8b-dea9-4df7-8929-52370d47bf91.jpg?1",
             "name": "Sanctum of All",
             "text": "At the beginning of your upkeep, you may search your library and/or graveyard for a Shrine card and put it onto the battlefield. If you search your library this way, shuffle it.\nIf an ability of another Shrine you control triggers while you control six or more Shrines, that ability triggers an additional time.",
             "colours": [
@@ -13353,7 +13353,7 @@
         },
         {
             "id": "7bf1c6f7-6ec3-59bc-ac63-c7996ec6c00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d9ddf6-9283-4c93-9932-70362068ce72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d9ddf6-9283-4c93-9932-70362068ce72.jpg?1",
             "name": "Chromatic Orrery",
             "text": "You may spend mana as though it were mana of any color.\n{T}: Add {C}{C}{C}{C}{C}.\n{5}, {T}: Draw a card for each color among permanents you control.",
             "colours": [],
@@ -13385,7 +13385,7 @@
         },
         {
             "id": "9f07875a-ab6b-5feb-97b3-f83c13080343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a202f3-23e3-490a-bae9-42f2fe267ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a202f3-23e3-490a-bae9-42f2fe267ce7.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on Mazemind Tome: Scry 1.\n{2}, {T}, Put a page counter on Mazemind Tome: Draw a card.\nWhen there are four or more page counters on Mazemind Tome, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -13415,7 +13415,7 @@
         },
         {
             "id": "815a55a3-f6b4-5bc4-8a48-d796bbb529b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29d9617-734a-4516-882e-661b3effb569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29d9617-734a-4516-882e-661b3effb569.jpg?1",
             "name": "Sparkhunter Masticore",
             "text": "As an additional cost to cast this spell, discard a card.\nProtection from planeswalkers\n{1}: Sparkhunter Masticore deals 1 damage to target planeswalker.\n{3}: Sparkhunter Masticore gains indestructible until end of turn.",
             "colours": [],
@@ -13448,7 +13448,7 @@
         },
         {
             "id": "62ad3c92-19a9-5717-b6d9-572f280fc3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ec7b76-4e97-4f47-b7af-ef9c2435b20e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ec7b76-4e97-4f47-b7af-ef9c2435b20e.jpg?1",
             "name": "Animal Sanctuary",
             "text": "{T}: Add {C}.\n{2}, {T}: Put a +1/+1 counter on target Bird, Cat, Dog, Goat, Ox, or Snake.",
             "colours": [],
@@ -13478,7 +13478,7 @@
         },
         {
             "id": "6481dc40-001b-5939-9a8d-b85bd4471f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb5cd32-3e9e-407e-a501-a56793017324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb5cd32-3e9e-407e-a501-a56793017324.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -13508,7 +13508,7 @@
         },
         {
             "id": "69f5a578-5e74-5d41-837e-d4f00599ef9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b63d6-09d6-44d9-ba57-fa6c576507c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b63d6-09d6-44d9-ba57-fa6c576507c4.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -13541,7 +13541,7 @@
         },
         {
             "id": "706daedc-2ffd-5993-af42-6686b63daa42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc9f2-05ed-462b-922e-75531bccacca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc9f2-05ed-462b-922e-75531bccacca.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -13574,7 +13574,7 @@
         },
         {
             "id": "3f28e6fa-0a1a-5b9c-be97-ed17472effeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11a16d-25c9-43e7-8776-313347bab820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11a16d-25c9-43e7-8776-313347bab820.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "e53903c1-46e9-52ac-9453-6b48290169a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6a3602-8e44-4df6-9607-ba5ce2d2e733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6a3602-8e44-4df6-9607-ba5ce2d2e733.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "9f845317-38ae-5a18-9b44-a57a207e0801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7449-235f-43f0-b75d-e1b0e98c3a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7449-235f-43f0-b75d-e1b0e98c3a7d.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -13673,7 +13673,7 @@
         },
         {
             "id": "6d43057f-3da6-5663-bcf3-1eeb80808c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be82997-ad17-4977-b3a9-099889fb0aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be82997-ad17-4977-b3a9-099889fb0aa3.jpg?1",
             "name": "Pack Leader",
             "text": "",
             "colours": [
@@ -13709,7 +13709,7 @@
         },
         {
             "id": "37e02e05-7754-5a48-904c-d67e3b098d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a129ff7-72f9-4171-902d-a1b49eebfb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a129ff7-72f9-4171-902d-a1b49eebfb62.jpg?1",
             "name": "Selfless Savior",
             "text": "",
             "colours": [
@@ -13745,7 +13745,7 @@
         },
         {
             "id": "adc607e8-4797-5197-b4b5-48f2bb815c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474d7e8-6b34-4d88-bb78-c43c24d5eb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474d7e8-6b34-4d88-bb78-c43c24d5eb58.jpg?1",
             "name": "Frantic Inventory",
             "text": "",
             "colours": [
@@ -13779,7 +13779,7 @@
         },
         {
             "id": "7165c42c-7210-5564-b5a9-e666de59034a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753d3152-da9d-48af-98b0-34efb990205d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753d3152-da9d-48af-98b0-34efb990205d.jpg?1",
             "name": "Eliminate",
             "text": "",
             "colours": [
@@ -13813,7 +13813,7 @@
         },
         {
             "id": "e59c4baf-3f6b-5009-a52e-b0a9a678f5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13406fc3-4061-46b4-8738-09494c85550f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13406fc3-4061-46b4-8738-09494c85550f.jpg?1",
             "name": "Heartfire Immolator",
             "text": "",
             "colours": [
@@ -13850,7 +13850,7 @@
         },
         {
             "id": "7993b03d-4c35-50f4-a5ea-bcb6b591cf8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880c9523-717e-4903-a09e-d6c47614383d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880c9523-717e-4903-a09e-d6c47614383d.jpg?1",
             "name": "Llanowar Visionary",
             "text": "",
             "colours": [
@@ -13887,7 +13887,7 @@
         },
         {
             "id": "1468602a-b4fb-5c4a-a498-d01e1c01feb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e12d954-3ec2-46e3-b01f-1fd63159e8a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e12d954-3ec2-46e3-b01f-1fd63159e8a4.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -13922,7 +13922,7 @@
         },
         {
             "id": "c874bb19-716e-5350-ab05-04c3ae7ece4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e33dff-23d5-4f31-8dd6-270657e150d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e33dff-23d5-4f31-8dd6-270657e150d8.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -13957,7 +13957,7 @@
         },
         {
             "id": "76ed2e95-f655-5b86-a404-257876628a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaae25-d0cd-416a-a44a-5b258fd1d9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaae25-d0cd-416a-a44a-5b258fd1d9fd.jpg?1",
             "name": "Griffin",
             "text": "",
             "colours": [
@@ -13992,7 +13992,7 @@
         },
         {
             "id": "5f43c683-7b4e-566b-8ded-a6f4311df06e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076f934b-a244-45f1-bcb3-7c5e882e9911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076f934b-a244-45f1-bcb3-7c5e882e9911.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "d27f5b6a-7f5d-55d7-81e6-6192087ed01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb2914-bba2-4cb6-802e-af2aeef46de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb2914-bba2-4cb6-802e-af2aeef46de8.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -14062,7 +14062,7 @@
         },
         {
             "id": "a4dd1ba2-1b49-5196-9796-cc643e718d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54c7f9f-a1ea-4bf0-8ab3-cca49f393f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54c7f9f-a1ea-4bf0-8ab3-cca49f393f4a.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -14097,7 +14097,7 @@
         },
         {
             "id": "15f25eca-ba72-5b13-ab15-1e6bf04d5dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f170f84-6c36-43e2-91e6-3c7a136944b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f170f84-6c36-43e2-91e6-3c7a136944b1.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -14132,7 +14132,7 @@
         },
         {
             "id": "916b1421-f426-55b4-ac9a-fd9f7372e045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7094d6-6e23-47f2-a9da-4dd680294ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7094d6-6e23-47f2-a9da-4dd680294ac8.jpg?1",
             "name": "Goblin Wizard",
             "text": "",
             "colours": [
@@ -14168,7 +14168,7 @@
         },
         {
             "id": "cf9ffa43-3ce7-59ac-9f09-ac718e93a505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3002d9-7754-4c7f-a051-382cd7a86e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3002d9-7754-4c7f-a051-382cd7a86e80.jpg?1",
             "name": "Pirate",
             "text": "",
             "colours": [
@@ -14203,7 +14203,7 @@
         },
         {
             "id": "11346e2d-6867-5b89-868d-baad1f9ead92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "95dfeb5e-37c9-5637-9711-aee284aa5702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6541414-c506-449d-b3a8-79f47be531a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6541414-c506-449d-b3a8-79f47be531a9.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -14273,7 +14273,7 @@
         },
         {
             "id": "02f6f528-e3f3-596d-aac6-17589d10f095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71a5aa4-a960-4c42-b8ac-7003f6e83e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71a5aa4-a960-4c42-b8ac-7003f6e83e95.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -14308,7 +14308,7 @@
         },
         {
             "id": "570c3c71-b13b-509d-a61e-4d3ff221a8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d9c67-69ee-48c4-af4c-18cc3c2ef3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d9c67-69ee-48c4-af4c-18cc3c2ef3cd.jpg?1",
             "name": "Weird",
             "text": "",
             "colours": [
@@ -14345,7 +14345,7 @@
         },
         {
             "id": "c7a731ba-0a37-517c-b02c-f57f37c9c118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4001c4c6-647c-4ffc-9803-81df43b77e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4001c4c6-647c-4ffc-9803-81df43b77e12.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -14377,7 +14377,7 @@
         },
         {
             "id": "754fd11c-fb97-5a58-bf3a-fb4e7f179eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4306be80-d7c9-4bcf-a3de-4bf159475546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4306be80-d7c9-4bcf-a3de-4bf159475546.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -14408,7 +14408,7 @@
         },
         {
             "id": "380d3b56-c427-5911-b92c-81230f3ad738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d37b555-5931-4084-8f83-e9853e14eccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d37b555-5931-4084-8f83-e9853e14eccf.jpg?1",
             "name": "Basri Ket Emblem",
             "text": "",
             "colours": [],
@@ -14436,7 +14436,7 @@
         },
         {
             "id": "0017cb36-348b-57a4-81f5-c5b5159705ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b572a46c-8bd0-4af8-bc76-2c65841c27b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b572a46c-8bd0-4af8-bc76-2c65841c27b9.jpg?1",
             "name": "Garruk, Unleashed Emblem",
             "text": "",
             "colours": [],
@@ -14464,7 +14464,7 @@
         },
         {
             "id": "9a0f790a-f3bf-5578-a43c-d8d389202485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968f207e-8e60-4dad-935c-71e0267c2399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968f207e-8e60-4dad-935c-71e0267c2399.jpg?1",
             "name": "Liliana, Waker of the Dead Emblem",
             "text": "",
             "colours": [],
@@ -14492,7 +14492,7 @@
         },
         {
             "id": "cffaaddc-a438-57e0-a721-a22f1f350763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8107b3-8539-4b9c-8d0d-c512c940838f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8107b3-8539-4b9c-8d0d-c512c940838f.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -14526,7 +14526,7 @@
         },
         {
             "id": "6bcccfbf-347f-58c6-aa82-fd740a61e8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/MAT.json
+++ b/Assets/Resources/Sets/MAT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5a5da967-1730-5e78-a2ce-fc0d078a2317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786f05d-78a2-41b6-a185-111e8c1b216b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786f05d-78a2-41b6-a185-111e8c1b216b.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -43,7 +43,7 @@
         },
         {
             "id": "588c17e9-2bc5-57af-9923-ebb0abd42f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce799e-cb9e-4d74-8b13-a5f4559e13a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce799e-cb9e-4d74-8b13-a5f4559e13a9.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -80,7 +80,7 @@
         },
         {
             "id": "9104e97e-3e86-5b6a-adeb-e337726dd325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ed1d8-4d5c-48f8-8513-031bd8977d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ed1d8-4d5c-48f8-8513-031bd8977d75.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -118,7 +118,7 @@
         },
         {
             "id": "12ab2ed8-1044-51c1-805f-dcbaf3e91c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a3ba1-af6c-4ddc-aa82-34bfc30867d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a3ba1-af6c-4ddc-aa82-34bfc30867d0.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -158,7 +158,7 @@
         },
         {
             "id": "c1456b56-31de-5913-9036-a33dc3a06c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027a75f-4faf-4e96-9035-d1f622b9b607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027a75f-4faf-4e96-9035-d1f622b9b607.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "d6b67e7d-27d7-5074-93e6-ff214bdc6ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d0d7d-544b-4736-914d-10d5d752eb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d0d7d-544b-4736-914d-10d5d752eb42.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "5a1a4e5f-c010-537d-8441-fa64a38abf1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81a9eb1-240b-40fd-9282-0f5abec63449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81a9eb1-240b-40fd-9282-0f5abec63449.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "91905e90-ed40-5fa5-8a69-7aef7175574f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72a9deb-9329-4930-a906-136c26490d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72a9deb-9329-4930-a906-136c26490d52.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "01ff9b73-c200-5538-8264-4d8311d629a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991c27ed-f53c-48c6-8c12-282f44b8d441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991c27ed-f53c-48c6-8c12-282f44b8d441.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -350,7 +350,7 @@
         },
         {
             "id": "86825e3f-6efd-5372-9198-2b33af002ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2785902-2757-406b-bc75-6f05e0edc98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2785902-2757-406b-bc75-6f05e0edc98d.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "1a1b774e-fd44-5faf-8399-cf0244e1ba6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5330e6b7-eca3-46a4-8905-8f1de16f76af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5330e6b7-eca3-46a4-8905-8f1de16f76af.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -429,7 +429,7 @@
         },
         {
             "id": "a09ac030-3564-5eac-b773-27a761735e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424eb4c7-647e-4168-9471-f299e8e77f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424eb4c7-647e-4168-9471-f299e8e77f5f.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -465,7 +465,7 @@
         },
         {
             "id": "2315960e-5f62-5442-8b36-9742669698f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e0b5cf-39e8-454f-a942-f7865416ef81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e0b5cf-39e8-454f-a942-f7865416ef81.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "ad6bd8f3-b63f-5e56-a518-b74df148bc97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dc6b0f-09bb-4489-8022-42c700eb1191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dc6b0f-09bb-4489-8022-42c700eb1191.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "076fdeec-78fd-5b76-aa2a-718ceaa232bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbb4d8f-8ae3-4052-9c6a-e56e96cec832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbb4d8f-8ae3-4052-9c6a-e56e96cec832.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "02582576-2d92-5c99-8641-588b7fec41c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3069f-5f5a-4e11-8a63-46399eb85a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3069f-5f5a-4e11-8a63-46399eb85a95.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "dfd7fdd9-346a-53f0-a3bd-112e6c0afe6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8361d9e2-b9fc-4d46-a1ba-a24139157f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8361d9e2-b9fc-4d46-a1ba-a24139157f26.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "4a9d870a-281c-5837-9697-22b5c47717c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179a0525-a142-46f6-9b5b-06a2fbb25556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179a0525-a142-46f6-9b5b-06a2fbb25556.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "f101e92e-9ad8-5704-b268-fb9ce53e95b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239165bb-7819-4d54-a84c-2911934253d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239165bb-7819-4d54-a84c-2911934253d6.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "5fffcba2-2fdd-5944-b9b2-fb4e7e6e5f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8525ae50-7438-492a-98ae-53f0ffeaab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8525ae50-7438-492a-98ae-53f0ffeaab51.jpg?1",
             "name": "Animist's Might",
             "text": "This spell costs {2} less to cast if it targets a legendary creature you control.\nTarget creature you control deals damage equal to twice its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "30262c48-6453-5dd5-95a6-0ae3e6e390ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5adc-e14b-4c84-896f-ef5f01f7ff57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5adc-e14b-4c84-896f-ef5f01f7ff57.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "2f1a5cf5-b4a1-5b3b-8556-e2582fb1e134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248c76d3-b5cb-4582-be17-7cd1d0cb0f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248c76d3-b5cb-4582-be17-7cd1d0cb0f58.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "37634611-feb2-5292-b8f9-b446d86cb734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a911e-8291-48ca-bfc6-8907e3b57011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a911e-8291-48ca-bfc6-8907e3b57011.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "81838d73-de46-51ba-9613-6487255da134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b647377-d47e-4630-8ccc-933ef6127880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b647377-d47e-4630-8ccc-933ef6127880.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "4e90436c-ba41-50e9-8899-d0e7b36f99bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfe6957-d971-413f-b075-01b995f1d7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfe6957-d971-413f-b075-01b995f1d7a3.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -966,7 +966,7 @@
         },
         {
             "id": "bea79a6e-0000-5d49-bfdb-5a52fc10ae0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a707ab3-b9b5-422a-8b0f-e963d3ad6606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a707ab3-b9b5-422a-8b0f-e963d3ad6606.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "a02b76bd-ebb6-5268-8f4a-14519038c97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d925d13-fcd6-417b-b2b2-bbdd114aae78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d925d13-fcd6-417b-b2b2-bbdd114aae78.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "d1f589e1-e296-5aa4-956b-e7cfb8fc0ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcb225c-d18f-4b84-b2fc-91ed84ec30aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcb225c-d18f-4b84-b2fc-91ed84ec30aa.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "3284b38b-9d41-559c-83e6-cc980a67cab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039e43f2-cf3b-4c60-ac55-d2aafb20eb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039e43f2-cf3b-4c60-ac55-d2aafb20eb34.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "91ff47cc-c9a3-5992-b3ec-72b2c494473b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a90d613-a327-4dc7-b0c1-0003fe0171ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a90d613-a327-4dc7-b0c1-0003fe0171ef.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "15809e11-4a1d-57c1-96a6-d9f8443266a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6917d51b-eb61-4e7e-8336-8b4adf8d1e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6917d51b-eb61-4e7e-8336-8b4adf8d1e39.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -1211,7 +1211,7 @@
         },
         {
             "id": "ade59540-c145-51c2-8fc4-590c134a1ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0c3860-1dab-4897-8f36-f9be263bba03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0c3860-1dab-4897-8f36-f9be263bba03.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "f631ce85-d4bb-5a4a-b72a-1fe0dec78069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb93216-885c-4ec5-8b88-6cd51f593c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb93216-885c-4ec5-8b88-6cd51f593c8b.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "563bd4f6-becc-5cc4-8919-86caa1d97141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569fb73-3555-4eb8-933a-130770dd56d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569fb73-3555-4eb8-933a-130770dd56d1.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "59b9f0fa-5acb-5cfa-968f-c17a1b05534e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b599f53-614c-4b1f-9899-15d5d1e35879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b599f53-614c-4b1f-9899-15d5d1e35879.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "18f312fc-a910-570c-a218-dcc587724c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eb0859-d24e-4703-8930-1cd4ac1fb3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eb0859-d24e-4703-8930-1cd4ac1fb3b6.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "940c4eb6-8499-52f7-b3b1-e3783eab1c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9acf30-b4f4-4e99-9763-a3055e91fefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9acf30-b4f4-4e99-9763-a3055e91fefb.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "5bc9e4cf-394f-5e0d-8b7a-cdccafb1cc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827ecc44-0b00-4515-8953-bc91fa03705a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827ecc44-0b00-4515-8953-bc91fa03705a.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "f8348d8d-dd1b-5f82-9f70-d2467a801891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd7ce4-550d-41ab-8559-97efb234a0a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd7ce4-550d-41ab-8559-97efb234a0a1.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy. (You still pay its costs. A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "58b7a3d3-14de-5504-90c8-8d33ed7c2f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1ff886-d3c8-43e5-8bf0-ba4f0b259781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1ff886-d3c8-43e5-8bf0-ba4f0b259781.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start. (You may cast that card from your graveyard by discarding a card in addition to paying its other costs. Then exile it.)",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "91c6f058-4cdd-53d5-a90b-2fe14ccc8a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb68233-3683-41bd-9b6e-4f07a1b54244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb68233-3683-41bd-9b6e-4f07a1b54244.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "72029802-35c9-572e-9b64-44716f7f4062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae89461-4bce-4b49-b875-03afc2469fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae89461-4bce-4b49-b875-03afc2469fe7.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "9de80e2d-a414-5e63-a39c-1e9a63996b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7651eb7-3cbe-43de-8800-085be19e7f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7651eb7-3cbe-43de-8800-085be19e7f77.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace. (They're affected by summoning sickness.)",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "b38f69ff-2e90-5374-99e2-5a490b5feace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb53ce7-845c-4c62-98a9-4fc33c67a07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb53ce7-845c-4c62-98a9-4fc33c67a07b.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "409cfbd3-2498-5884-8824-acc586548aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f3fdb0-47ad-4df6-a95c-a2c81aaf7af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f3fdb0-47ad-4df6-a95c-a2c81aaf7af5.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "8a38a326-6926-5b99-8927-86b72407033b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6225f139-f6eb-4eb5-9776-159a599d8255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6225f139-f6eb-4eb5-9776-159a599d8255.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "dd3c9bf3-e465-5b02-bdc0-a320d0e96ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba71725-d6df-44d7-a93b-934573759711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba71725-d6df-44d7-a93b-934573759711.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "2eeb9964-29fa-5a17-b7c1-8e36c253f907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a543f0-72fe-4a30-a4a0-356971c1c68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a543f0-72fe-4a30-a4a0-356971c1c68a.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "e029e773-cb99-57d2-a5c5-39b9b6b40d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4219b5ea-a252-4d76-a60a-9674340e8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4219b5ea-a252-4d76-a60a-9674340e8ed3.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "ea2fc876-3890-5ed3-998b-de9d39558bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c07dda8-06dd-499a-9825-dc6b9a73e455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c07dda8-06dd-499a-9825-dc6b9a73e455.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -2029,7 +2029,7 @@
         },
         {
             "id": "196b7c99-b0d8-5b78-9164-ed10e1fe7503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a932af-f5bb-452d-803a-b75bd3552b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a932af-f5bb-452d-803a-b75bd3552b35.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "9e7f463a-4142-51fa-8dcb-67092f78a606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c18b82-ec70-4233-9717-f9d522b3d022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c18b82-ec70-4233-9717-f9d522b3d022.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "351cef28-9fe9-5385-bc06-59d2eae902d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19d4ace-cf49-482d-8533-fa7a948b44e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19d4ace-cf49-482d-8533-fa7a948b44e3.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "20692def-7a2b-596a-a536-f1e1fd04e1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f76739e-03fb-401a-8444-ac7fd16f21ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f76739e-03fb-401a-8444-ac7fd16f21ef.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "cd122077-902e-5cce-a873-30da9a058930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259de7b-74d2-4ef4-94d3-4a0f14dbaa44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259de7b-74d2-4ef4-94d3-4a0f14dbaa44.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "0b85caff-4c51-5ba2-b534-acab343fafdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59286512-1ec2-4d0a-aaa0-63a4a691bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59286512-1ec2-4d0a-aaa0-63a4a691bcda.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "8254ae49-058e-5df0-b212-67691dac20f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1631c564-67de-4011-be2d-c7ee96a43cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1631c564-67de-4011-be2d-c7ee96a43cb7.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "c90dea94-d29d-5392-866f-4d3ebc9e9400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ab028c-a560-4f8a-a063-2682daca799c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ab028c-a560-4f8a-a063-2682daca799c.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "3fea9219-80de-5ccd-8f52-1331189e873d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f673a7-961d-4ba3-bfc5-46107af46a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f673a7-961d-4ba3-bfc5-46107af46a61.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "51f17ea8-af8b-5544-b242-662d933f7624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fd77b6-59ed-431b-9ecf-d37e4f9c14ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fd77b6-59ed-431b-9ecf-d37e4f9c14ac.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "bda2ae37-4f11-5c82-8133-d31246500210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c154811-2f4c-4f21-8ee1-f70557b8f423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c154811-2f4c-4f21-8ee1-f70557b8f423.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "533b13cf-9db5-5e7c-bd2b-62e8e6fd72a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f2e7f-3ce9-475e-b854-1560d5a9a8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f2e7f-3ce9-475e-b854-1560d5a9a8e8.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "b5b0f284-6f1b-5780-8936-6b9c0a860267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fe078-cc60-493b-9b61-37894e1eddd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fe078-cc60-493b-9b61-37894e1eddd3.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "e8b8807b-6fc7-5a6e-b2df-e6587fe9091f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79527ca-15f5-427a-9245-6b7f4230a8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79527ca-15f5-427a-9245-6b7f4230a8b7.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B}",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "7cd11a65-9476-5a13-aa8a-d343f15c838e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88cc697-3b79-421b-9b7f-37f9aeccda36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88cc697-3b79-421b-9b7f-37f9aeccda36.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "cec3f5a8-d2f1-5a1f-a45d-373412ae19e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd3a3a-f9f8-4d83-951f-d187f2bab0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd3a3a-f9f8-4d83-951f-d187f2bab0a4.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -2649,7 +2649,7 @@
         },
         {
             "id": "6528147b-b1ed-515c-ab82-5b179baff821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d58c593-327c-4798-8bb8-811c831efb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d58c593-327c-4798-8bb8-811c831efb49.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "783d4f50-5868-534d-91bc-e22fa1b02ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4c2c09-1929-4850-b797-69b671916980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4c2c09-1929-4850-b797-69b671916980.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -2730,7 +2730,7 @@
         },
         {
             "id": "8d3f1898-d0b5-5e2a-af30-c0c8fb76c8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f43d7-8979-466a-be73-8e073b0afdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f43d7-8979-466a-be73-8e073b0afdd1.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "3a381ba1-3fa6-517f-a49f-6020c395f377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7267a33-c9b2-485d-afbc-a27e4792abf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7267a33-c9b2-485d-afbc-a27e4792abf4.jpg?1",
             "name": "Animist's Might",
             "text": "This spell costs {2} less to cast if it targets a legendary creature you control.\nTarget creature you control deals damage equal to twice its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "ec5c28e1-2640-581c-9caa-4ab1873e934e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4437a7d7-d25c-412d-b739-a122e25e1449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4437a7d7-d25c-412d-b739-a122e25e1449.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "37ba121f-b65d-5237-897f-cdfa3991b50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3998ebe6-bbfd-4d9c-9741-2fe7484dc6e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3998ebe6-bbfd-4d9c-9741-2fe7484dc6e5.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "badf5b71-d3da-5cdf-9984-6b02ea3acd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7bb58c-304a-4fb4-9ae6-bc98126cca4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7bb58c-304a-4fb4-9ae6-bc98126cca4e.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "a74519dd-3a79-573d-97e9-5386a25264c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3e0eb1-8b0c-4c6e-b394-6968d39fbd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3e0eb1-8b0c-4c6e-b394-6968d39fbd00.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "4f0c5504-3614-5995-85b9-230fac5ec477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577522b4-b3f6-43b6-92a4-4e8420ff3b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577522b4-b3f6-43b6-92a4-4e8420ff3b12.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "9199ff8a-2c3c-5a10-a57a-0024ca1cc64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ceddfa5-3a89-4ac4-8fd1-0c9918ffedc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ceddfa5-3a89-4ac4-8fd1-0c9918ffedc8.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "da704f94-7801-5d3a-a152-3b98fffae54a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d4a5b9-2594-413d-a0c1-32b09f54d9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d4a5b9-2594-413d-a0c1-32b09f54d9d2.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -3074,7 +3074,7 @@
         },
         {
             "id": "151e1b42-10c6-58db-968c-0eb7eb3d0598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896a7953-c8af-4a08-b31b-33fe65c14a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896a7953-c8af-4a08-b31b-33fe65c14a2c.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "0e9c8958-5048-56fd-b336-056e2587ae85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006eb5ef-ac0a-4e39-831c-4019512bce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006eb5ef-ac0a-4e39-831c-4019512bce60.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "b3e4dee6-eac0-5266-8398-6c1964b02e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702d2f0-b576-438c-94b6-39afe2c70821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702d2f0-b576-438c-94b6-39afe2c70821.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "e6fff2b6-e24c-5767-91bb-bc0d5e3b01f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fd9efb-afec-426f-8333-a2797b8b603f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fd9efb-afec-426f-8333-a2797b8b603f.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}.",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "54b77586-84e5-50c8-af2c-36e2c48c4752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373475d5-42a7-42ad-a235-685c3d160f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373475d5-42a7-42ad-a235-685c3d160f60.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "3fcd3c41-7d31-58fa-85c4-6ba4d84e5136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fa8aaa-46e5-467b-a237-feae3b2f6ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fa8aaa-46e5-467b-a237-feae3b2f6ddc.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "feb16889-2d0e-500f-b3bd-d8a154184035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dbb880-1cf8-41fa-84d8-41db8dde35f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dbb880-1cf8-41fa-84d8-41db8dde35f2.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -3365,7 +3365,7 @@
         },
         {
             "id": "7a944d9e-4078-5e08-845f-ee3a1bd7e25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5b27a6-caf8-4489-b949-d4d69841b9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5b27a6-caf8-4489-b949-d4d69841b9ef.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3409,7 +3409,7 @@
         },
         {
             "id": "7ec9fe5d-a3e5-5046-9289-25b39053bc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f2d1fe-e337-4a98-b861-094250068432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f2d1fe-e337-4a98-b861-094250068432.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "52de5142-f06c-5e5b-8810-b0c5f5d38511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e510b-aa06-403b-a53b-49a4ad66f286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e510b-aa06-403b-a53b-49a4ad66f286.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "beda4162-e2a7-56ce-8070-e2fef0082889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e244a5-85ae-413e-9c79-aa07103c7057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e244a5-85ae-413e-9c79-aa07103c7057.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -3538,7 +3538,7 @@
         },
         {
             "id": "2d173e40-85d4-5bbd-8187-3737b8f0b11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce21e701-bb96-4040-a7ea-a5e0c11eae9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce21e701-bb96-4040-a7ea-a5e0c11eae9b.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "8d7e1771-48f4-5b45-9c56-8367783127b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d999f-ea24-40d8-86ef-180627196749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d999f-ea24-40d8-86ef-180627196749.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -3634,7 +3634,7 @@
         },
         {
             "id": "21fbffc3-5f10-5269-9bf6-bebc3c6d51d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840a442f-a220-408f-b670-0c73e2ffa704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840a442f-a220-408f-b670-0c73e2ffa704.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -3677,7 +3677,7 @@
         },
         {
             "id": "79f2367f-1cab-59a6-8f38-fc08020ef20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28216a47-709f-41fc-834c-7e4c99c806f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28216a47-709f-41fc-834c-7e4c99c806f7.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "28d5d55a-9398-5df3-a5ab-09329e5bf23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7973b-a5b9-41e9-9382-e5107315faa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7973b-a5b9-41e9-9382-e5107315faa5.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "680938a9-ad5f-5bb9-89c9-09514d7df0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8102736a-220d-41d8-acea-79971d73db9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8102736a-220d-41d8-acea-79971d73db9a.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "7b9c0d5f-9a23-51ac-acfb-3c479b7c58c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c868b7-1600-449a-abd2-9836bce0e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c868b7-1600-449a-abd2-9836bce0e1f1.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "0ecca4a8-59ca-541b-b8de-6119bb4547c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e688bd-7652-418f-84e6-18452295623a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e688bd-7652-418f-84e6-18452295623a.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "3bb9e5f1-5e09-5570-88a4-588d330780c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c857c0-1cb4-4032-a72f-cf8d84171c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c857c0-1cb4-4032-a72f-cf8d84171c9d.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "b86ed114-28bb-5ed9-8a71-d8bb9c81cdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de88aa7f-c6e6-49a0-a68d-87a2ab1741e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de88aa7f-c6e6-49a0-a68d-87a2ab1741e3.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "de852333-e062-598a-8172-5ba707b32de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b1d426-db36-4a6d-9eb7-d093e0c0ee6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b1d426-db36-4a6d-9eb7-d093e0c0ee6a.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "14a9719d-effb-5bf7-a3d4-b6c07ea33d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8976d8-f77d-460f-82fa-d324cbd3d4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8976d8-f77d-460f-82fa-d324cbd3d4b5.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "7ddde71a-b7f4-5ddd-9e8c-b091d5010d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165275-505c-4fe7-ad2e-4e522bdb014a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165275-505c-4fe7-ad2e-4e522bdb014a.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "3c936346-332d-5e4b-b7c4-3997f1518537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c881938-da5d-4f2c-b62b-0cfbf29ae558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c881938-da5d-4f2c-b62b-0cfbf29ae558.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "3b2922e3-f919-5317-9e3b-f24d87ced6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d20243-0771-4dae-b225-4379de6be35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d20243-0771-4dae-b225-4379de6be35a.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "336413a2-2db9-500c-8c6b-cdb8f50d8f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041111e8-3b0e-4337-a7d6-20cc455ea173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041111e8-3b0e-4337-a7d6-20cc455ea173.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "fb536f6c-fb8a-55c6-8d96-3358cf2ba18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c214f916-2ec0-495c-82d5-438e321bf8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c214f916-2ec0-495c-82d5-438e321bf8e6.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "0e719629-da61-5ac4-8dc6-490b9f74306b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e86e46-ba47-4ecd-8fac-7938b9947065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e86e46-ba47-4ecd-8fac-7938b9947065.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "99646091-0e6b-51a0-973e-bf9c432c972b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b57b9-54e8-4f5c-b53a-cd5fc2fb2a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b57b9-54e8-4f5c-b53a-cd5fc2fb2a34.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "33296ce3-fbf7-5e8e-b5a9-4554cc8633a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ef89a1-b6fd-48db-bcb5-faac2fe9fe28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ef89a1-b6fd-48db-bcb5-faac2fe9fe28.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "1efe3ee0-2045-555f-bbd9-209c7d36ac74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbc432e-c35c-4f8c-bbdd-068eaa468378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbc432e-c35c-4f8c-bbdd-068eaa468378.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "5d37fa91-aa3a-552c-9a2a-f4e76671759e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec9b42-ab99-4c93-a52f-ccbe258b8954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec9b42-ab99-4c93-a52f-ccbe258b8954.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "0e812b64-4f16-584c-a5f1-3d4c257cafeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0133c618-faab-4b40-8da0-fc91edf49785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0133c618-faab-4b40-8da0-fc91edf49785.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -4468,7 +4468,7 @@
         },
         {
             "id": "86dcba51-91e1-557a-ba65-21178cd4a41e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d18cfb3-5498-4d31-8276-8d7ec893d98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d18cfb3-5498-4d31-8276-8d7ec893d98f.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "1e806a27-40a5-5225-a297-bbb838b992d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c781217-a678-4059-89ff-b5ec494dd367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c781217-a678-4059-89ff-b5ec494dd367.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "5afa94b8-bae6-5d9d-b4cf-6bc0364fa592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae882b47-e51f-42bc-89ef-2772de097b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae882b47-e51f-42bc-89ef-2772de097b88.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B}",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "422f9b48-b706-575b-a104-0e4cfc82a51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cb68f5-1e44-4d91-9ec0-d6d0559ee4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cb68f5-1e44-4d91-9ec0-d6d0559ee4a8.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "fd9bbb10-b1d6-5a29-beeb-94d22b5296e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32bf755-6b7a-4324-b219-ba953354933b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32bf755-6b7a-4324-b219-ba953354933b.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "bc20d313-1fd9-598d-9c2c-f1db27f6d6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9798fd-149b-4840-a1b1-b7c596940739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9798fd-149b-4840-a1b1-b7c596940739.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "b4d7241b-30d9-58c0-8cd8-70f31059f01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee11cfe8-4f20-468c-80ca-6af23b23184d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee11cfe8-4f20-468c-80ca-6af23b23184d.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -4737,7 +4737,7 @@
         },
         {
             "id": "913bdd2b-16b0-5b33-a2ee-ef649b546d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c41c82-937e-483a-97bf-58a14401bf11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c41c82-937e-483a-97bf-58a14401bf11.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "ca34451e-9a8e-508e-992c-23bcaf85dec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a82d30-b3ca-4bea-b055-00eee555567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a82d30-b3ca-4bea-b055-00eee555567d.jpg?1",
             "name": "Animist's Might",
             "text": "This spell costs {2} less to cast if it targets a legendary creature you control.\nTarget creature you control deals damage equal to twice its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "8ed85e23-7c77-530e-9f4d-9984835ab5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdff8723-1bc5-486f-a061-4f3ce8679c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdff8723-1bc5-486f-a061-4f3ce8679c52.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -4843,7 +4843,7 @@
         },
         {
             "id": "930a6697-b47c-5ce7-b161-a7e1fc845a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad606af-3ab5-4755-9690-540026c2edaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad606af-3ab5-4755-9690-540026c2edaa.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "f2b4f1aa-a4e5-559c-aa37-4324c4071814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ad15af-cb84-43c1-9078-459b24c5d45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ad15af-cb84-43c1-9078-459b24c5d45d.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "a041b6b1-d634-5675-8171-268cb6dc0b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8664feec-ea45-4a94-b6b1-98dd2663a268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8664feec-ea45-4a94-b6b1-98dd2663a268.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "d666bc2d-fb4b-50c1-9d13-1be92ce6d38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463fc067-9e8b-41a0-afa1-6be81861cfb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463fc067-9e8b-41a0-afa1-6be81861cfb8.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "9cca8f6c-a780-56d0-b212-a7e16387ab99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d717f-242f-4e70-9f6d-8885eac13cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d717f-242f-4e70-9f6d-8885eac13cf4.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -5035,7 +5035,7 @@
         },
         {
             "id": "a7162635-ebee-5a99-b655-5b3c1339fe93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb1105-d272-4727-929a-1716154e3e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb1105-d272-4727-929a-1716154e3e1c.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "2ba900bc-5d13-5c83-b2a2-d920e0650b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae13fac-af48-4e00-a483-e4bfc63e8af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae13fac-af48-4e00-a483-e4bfc63e8af8.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "b05dff15-339b-53c1-ade8-aa2d549b3f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e1b8e6-5cfd-4cbe-860e-a59b47643c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e1b8e6-5cfd-4cbe-860e-a59b47643c14.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "13579466-222f-5e63-a6a6-54fe4a0a7f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e82b7-d9a8-44dc-9376-03705df0c4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e82b7-d9a8-44dc-9376-03705df0c4d0.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "a0f3a491-ffa4-5a55-90e9-2619ac9cf062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e5b20e-1a72-441b-9e4c-2e7a40f096ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e5b20e-1a72-441b-9e4c-2e7a40f096ae.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "3e67d4d3-4375-5256-8553-0ecaa384f8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef36c1e9-ef1c-457f-8e02-3d773f4a1e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef36c1e9-ef1c-457f-8e02-3d773f4a1e45.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "dccc7c5a-9614-56ab-ab25-7fb31e2cf559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78266c-cbeb-4fd2-a29c-6bb9d326f057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78266c-cbeb-4fd2-a29c-6bb9d326f057.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "c438dcd7-b3e9-5a46-a740-0b4d5e4ca989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763a3015-9b22-4d81-a8c9-08046d1e5aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763a3015-9b22-4d81-a8c9-08046d1e5aef.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -5356,7 +5356,7 @@
         },
         {
             "id": "92e8ff3d-193a-545b-b0a6-10fd97386f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87993488-e31d-4456-bf87-c5a0a81e5560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87993488-e31d-4456-bf87-c5a0a81e5560.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5399,7 +5399,7 @@
         },
         {
             "id": "4d210c9e-b3f5-5020-bb14-5c7524be643f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c9437-a7e3-4098-992c-ffc929ee0e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c9437-a7e3-4098-992c-ffc929ee0e6e.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "a38958bc-c8a2-5c2a-9e7c-3f2fce478cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aaebb8-be81-4523-bcb8-fc86a2941c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aaebb8-be81-4523-bcb8-fc86a2941c45.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "2115136b-830c-5190-b9f4-0d011728da30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f311fc01-9b47-42b3-874b-2cb65a9e412c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f311fc01-9b47-42b3-874b-2cb65a9e412c.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "90b7086f-09eb-5ee1-938b-3303b565dac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d56cd5-f038-4653-987e-d1a5485ac86e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d56cd5-f038-4653-987e-d1a5485ac86e.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "be9c7ff4-9b64-52ba-b434-589cc801c517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f469c3-d50c-4066-8f46-75ce3c3f1616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f469c3-d50c-4066-8f46-75ce3c3f1616.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -5619,7 +5619,7 @@
         },
         {
             "id": "ae1b254f-ca96-5b2a-88a0-d75c8bfd72ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c9077d-fdbf-4087-85a5-1d59c2ba7678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c9077d-fdbf-4087-85a5-1d59c2ba7678.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "bb32fd21-aae9-5c4a-b37d-0ca53b909590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aafbdf8-b1cd-4dbb-863c-0d44494eec2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aafbdf8-b1cd-4dbb-863c-0d44494eec2b.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "5ddd600e-68d2-51c6-9404-3f4d3543251f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcff20d-4498-4c70-8167-c3621a293a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcff20d-4498-4c70-8167-c3621a293a72.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "69ee380e-676f-5bf9-9770-5d68c914fa5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9808e72-4143-421f-a498-dbebbd598544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9808e72-4143-421f-a498-dbebbd598544.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -5789,7 +5789,7 @@
         },
         {
             "id": "7ac52b0f-3995-5f11-a1a1-966f6c0d05b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafdd59-e22f-4f0d-aa09-77617402f04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafdd59-e22f-4f0d-aa09-77617402f04d.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -5833,7 +5833,7 @@
         },
         {
             "id": "a3b03804-f4e7-5965-a4e5-58c80e1563af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a21f8cf-5a0c-4a33-a2ed-b89b57bb4000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a21f8cf-5a0c-4a33-a2ed-b89b57bb4000.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "6c59f10a-7541-5306-9c9e-161e4b9e15d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d3d06c-8bbd-49e5-94ff-f0a9830d063e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d3d06c-8bbd-49e5-94ff-f0a9830d063e.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -5918,7 +5918,7 @@
         },
         {
             "id": "9cb35b1b-6f7a-5c91-8ae3-cce95caed6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10e9f0-24fe-4d7c-b883-37319a9ef5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10e9f0-24fe-4d7c-b883-37319a9ef5b5.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -5961,7 +5961,7 @@
         },
         {
             "id": "0a870842-a882-59be-ab10-8a557117328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc3541-c398-4d43-b1c4-4d1e1e3e1ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc3541-c398-4d43-b1c4-4d1e1e3e1ebf.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "6f05ae2a-48f2-5d55-8a91-f3cfd0fe7b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1064ec-ca4f-4498-b6c6-685276973009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1064ec-ca4f-4498-b6c6-685276973009.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -6029,7 +6029,7 @@
         },
         {
             "id": "041362a0-8b66-5a48-81b2-a6e011c52481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1436-913c-453a-8c05-4ec5bcaac4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1436-913c-453a-8c05-4ec5bcaac4b5.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -6066,7 +6066,7 @@
         },
         {
             "id": "26c2d0ae-dcff-58fd-aa6a-b644dd7366df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254b512-5ca5-4ce9-ad1d-8f90ab24f6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254b512-5ca5-4ce9-ad1d-8f90ab24f6c3.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -6106,7 +6106,7 @@
         },
         {
             "id": "8cd2ec4d-1ed9-56c8-9fee-140d9f3bee8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62243fa-32ce-4015-8e8c-ec898d1ca1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62243fa-32ce-4015-8e8c-ec898d1ca1e1.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -6143,7 +6143,7 @@
         },
         {
             "id": "f6e6e3d4-8248-5e78-81be-5f5b3731120b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c08ba6-a8a6-4cf5-83a5-c087e3272f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c08ba6-a8a6-4cf5-83a5-c087e3272f66.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "faef59a9-3ad0-5911-92f6-a8c99eca2ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24d4b9-fa3c-4390-a4b9-3e4fdfdf72b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24d4b9-fa3c-4390-a4b9-3e4fdfdf72b6.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "c20864a4-17e3-577b-ad79-f018393ec68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d71a7-2967-4006-9fe4-864868bcc642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d71a7-2967-4006-9fe4-864868bcc642.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -6265,7 +6265,7 @@
         },
         {
             "id": "d1630079-f0f8-5797-8629-b758432741e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0250da3-908c-4ec6-94a5-3dd16c6b1985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0250da3-908c-4ec6-94a5-3dd16c6b1985.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "21a80795-38b5-5b21-ae93-8a07924b9ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795222e3-1352-4adb-8a42-dde43d08e413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795222e3-1352-4adb-8a42-dde43d08e413.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -6344,7 +6344,7 @@
         },
         {
             "id": "f40ee40b-7609-5c21-89d6-e4233a7a9691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea9f761-a113-40bb-9346-fa13075e1b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea9f761-a113-40bb-9346-fa13075e1b9d.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "70a9a35b-cc7c-52dc-9605-2db4863bab03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160f048a-8813-454d-af84-1e53f33af9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160f048a-8813-454d-af84-1e53f33af9f6.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "bccd8dc7-d06b-5c80-b9e5-f6acd0660522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6765e4-0bbd-4711-b77e-b7628efcfb07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6765e4-0bbd-4711-b77e-b7628efcfb07.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "42cc8a31-4e0a-5778-9937-d51c989fc2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3f0e26-7784-452d-acc8-9f7181e0f7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3f0e26-7784-452d-acc8-9f7181e0f7d5.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6507,7 +6507,7 @@
         },
         {
             "id": "31bd8863-256a-5b8d-b149-e4d0a2a798d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f71273-4d96-4371-b6e0-98519449cdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f71273-4d96-4371-b6e0-98519449cdcf.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "4f69047e-58d8-5e74-95a5-4489a74a0daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c3a774-986d-4702-81c3-915138d3d718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c3a774-986d-4702-81c3-915138d3d718.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "9fca4e3e-010c-5b48-b633-202559584213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e61d0-95b2-433b-b835-86f00bfb840b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e61d0-95b2-433b-b835-86f00bfb840b.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -6627,7 +6627,7 @@
         },
         {
             "id": "17bafc88-6250-5e44-a3e7-bbba3bec7fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94685e-e8a0-46a5-83cf-41ccebed62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94685e-e8a0-46a5-83cf-41ccebed62cc.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "beaaa099-327a-5ab8-8aea-43431f90dc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ee4e0e-1139-42c1-b014-242c306321e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ee4e0e-1139-42c1-b014-242c306321e7.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -6715,7 +6715,7 @@
         },
         {
             "id": "d0bae3e2-c916-5f50-9cfb-ee092fd98b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053705f-df87-4f4c-8060-b43433b1d688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053705f-df87-4f4c-8060-b43433b1d688.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "9b241011-ccb0-5317-b4c3-8f9e32afa112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1536bef-bc0c-437b-bb4a-335c4ec9fbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1536bef-bc0c-437b-bb4a-335c4ec9fbf3.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "d3fee9f4-7dc1-53f7-a114-4ee9c074e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444b2d-a842-4e2c-b29b-7e578a49b3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444b2d-a842-4e2c-b29b-7e578a49b3e0.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6844,7 +6844,7 @@
         },
         {
             "id": "8f9884de-b88a-5500-a0d7-9b1d22dfa5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4891486a-9c35-4666-83b0-9fcb1da5d126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4891486a-9c35-4666-83b0-9fcb1da5d126.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "afcfb6ab-1974-5506-876f-f64c40a4cd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0443321b-e999-4bdd-8d8e-65fbaa6cabb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0443321b-e999-4bdd-8d8e-65fbaa6cabb4.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "3e4fa56d-9da0-5aa5-b739-0d569ce15d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487e81a-bb02-4d5c-86bb-fe626fa91c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487e81a-bb02-4d5c-86bb-fe626fa91c27.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -6973,7 +6973,7 @@
         },
         {
             "id": "2dee90e3-4bb7-5900-83d8-cdcea677ab88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275cea3-01ba-41ea-9665-a07a57ecfe50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275cea3-01ba-41ea-9665-a07a57ecfe50.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "9a3d0f3a-c74d-5edc-9a1d-4f5aa30809d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c167658d-1ad0-4e78-ac99-dd2ad5265311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c167658d-1ad0-4e78-ac99-dd2ad5265311.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "8adbace2-16da-5d08-8752-da4e303ef961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f613db0-3303-4d54-a060-1bd8b37a208f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f613db0-3303-4d54-a060-1bd8b37a208f.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -7112,7 +7112,7 @@
         },
         {
             "id": "3cdb74a2-9fbc-5a4c-8d15-debe38b0ee8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413eedd5-ea42-4b6f-9282-3040e517d936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413eedd5-ea42-4b6f-9282-3040e517d936.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "22c7fe5c-f895-533b-9c35-f23e5a30b03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5b2e19-dc3d-43fd-9090-050fedf93663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5b2e19-dc3d-43fd-9090-050fedf93663.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "2c062807-6ddf-5c65-be56-5fe027be074c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2ed3-be60-4814-a82c-a0e3fbb97e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2ed3-be60-4814-a82c-a0e3fbb97e63.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -7243,7 +7243,7 @@
         },
         {
             "id": "258dda74-9ddd-5a15-a74f-79db67c5a4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3f755-d70d-46d7-80dd-428ca1a355c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3f755-d70d-46d7-80dd-428ca1a355c4.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "861628e3-1a96-530e-89a7-58239eed6d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18484227-b96a-40fb-9788-656d00705d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18484227-b96a-40fb-9788-656d00705d80.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -7332,7 +7332,7 @@
         },
         {
             "id": "b28a1904-0fde-5f28-bba3-a99bbe60a632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9fcc42-1146-49c8-93c8-3a15063488c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9fcc42-1146-49c8-93c8-3a15063488c7.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "eb68b448-1704-581f-8912-46537e61fa73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7c1a22-eb7a-454e-bcd2-80ba0dc46ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7c1a22-eb7a-454e-bcd2-80ba0dc46ffa.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "a5ea391e-58fa-5991-adb8-a1c8a339b57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e6527-06f8-4783-93fc-8738673116c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e6527-06f8-4783-93fc-8738673116c1.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -7456,7 +7456,7 @@
         },
         {
             "id": "0c5eb7f4-38ec-5a23-91a5-06ac47b7382f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0712155b-a3fb-4e7d-8600-36845d71aab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0712155b-a3fb-4e7d-8600-36845d71aab6.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "95a84f80-3513-5091-a8fe-4239e61b3506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2899c19-d6bd-4399-a838-a21ed81ccc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2899c19-d6bd-4399-a838-a21ed81ccc3f.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}.",
             "colours": [
@@ -7527,7 +7527,7 @@
         },
         {
             "id": "f3976f97-2732-56b4-98cc-81cef3d0c1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4acba2-3aef-47bb-9bec-06408c3d1783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4acba2-3aef-47bb-9bec-06408c3d1783.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -7563,7 +7563,7 @@
         },
         {
             "id": "5d3fd52b-7535-5c6d-b3d0-0c944dd63e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d771-67ab-4e05-97ca-e2deee1f2dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d771-67ab-4e05-97ca-e2deee1f2dce.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "ee2554b9-a01d-5bff-96aa-b1ed2b95a52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c43285-a8f7-4fcc-be8c-115c04d3f657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c43285-a8f7-4fcc-be8c-115c04d3f657.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "97858cfc-3453-573f-807f-c22c8d4814a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e907fe-3c02-4e23-b19f-a478a54f3397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e907fe-3c02-4e23-b19f-a478a54f3397.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -7684,7 +7684,7 @@
         },
         {
             "id": "d92fcda2-aa41-5e9b-b621-5d8deca4cbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ebdda-e000-4333-9f2f-7d17e17a7cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ebdda-e000-4333-9f2f-7d17e17a7cf2.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "5e91b890-10f4-5eb7-8538-ecd9d52ec010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153dfc34-767e-4df2-a1dc-4361e94d65ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153dfc34-767e-4df2-a1dc-4361e94d65ed.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "07aae319-ec69-5abf-bdf2-994e892ef94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22299956-82c6-46dd-ac7d-b56146ab7ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22299956-82c6-46dd-ac7d-b56146ab7ed8.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "4fd2f2f4-5e3c-592f-b241-8f09f87cb4e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b6a634-0a9c-4e96-84cc-16a6c70b669d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b6a634-0a9c-4e96-84cc-16a6c70b669d.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "631996ee-8f82-5923-aeed-e3efa0ecbdf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3acf-aed9-4503-8b10-29661da4e307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3acf-aed9-4503-8b10-29661da4e307.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -7867,7 +7867,7 @@
         },
         {
             "id": "bf114b40-5b7a-5ef9-bc4f-e62ec57cb573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaefcbb-98d4-40b8-b51c-2d26f6945b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaefcbb-98d4-40b8-b51c-2d26f6945b6f.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "b8994996-1337-5226-b7af-3f83141c7bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f66c02-29dc-4798-8d88-76681215fb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f66c02-29dc-4798-8d88-76681215fb78.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "34f5f635-c455-5fa7-8782-90efb6831f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b11a6b-239b-4a2c-84d5-4e44a5366184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b11a6b-239b-4a2c-84d5-4e44a5366184.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B}",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "23abb6a5-2dbb-5d5d-89c8-870975dc71be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4453891-a94e-4057-87a3-168e9ef6d6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4453891-a94e-4057-87a3-168e9ef6d6d2.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "d9b1d5f4-8fae-5fc5-b9aa-1422f1c655e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d352a7-4575-4f92-9ded-53a23afbca5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d352a7-4575-4f92-9ded-53a23afbca5a.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "63c98b32-8835-5c57-808f-98d7b220e6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40366946-d9e7-4770-bca2-f6d1dcb73ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40366946-d9e7-4770-bca2-f6d1dcb73ff5.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "615fe45b-23cf-5c1a-a634-09fddaa78504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f7a00-18a3-4831-b005-e31b5bfb2922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f7a00-18a3-4831-b005-e31b5bfb2922.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -8136,7 +8136,7 @@
         },
         {
             "id": "95e13a1e-b031-533a-814c-b4f99e627cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677b021e-207c-42f8-9d53-1f58fe7fcd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677b021e-207c-42f8-9d53-1f58fe7fcd6d.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -8171,7 +8171,7 @@
         },
         {
             "id": "f74bd13d-9f77-532c-9468-6d94ec4dd6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd065a13-00af-4a90-9cd2-304f3d12dd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd065a13-00af-4a90-9cd2-304f3d12dd4b.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -8209,7 +8209,7 @@
         },
         {
             "id": "6273cad7-84e3-52b9-80b5-bb1ab379f3a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f0663-0a32-43ca-863b-1ddd4171b325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f0663-0a32-43ca-863b-1ddd4171b325.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -8244,7 +8244,7 @@
         },
         {
             "id": "ed02267b-47e0-59c0-b80e-5913566082b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4699973-2910-46fb-97e2-07f7ef1b27ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4699973-2910-46fb-97e2-07f7ef1b27ea.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -8288,7 +8288,7 @@
         },
         {
             "id": "e51b5f1b-9ed0-5e17-ba2b-0399c3ed3173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d12125-4fcf-4e1f-bc7b-90bf53357731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d12125-4fcf-4e1f-bc7b-90bf53357731.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "3309f301-d5c2-5fd2-9d01-7adbd677f9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bf0249-5853-47f3-96e4-f24e4e70c1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bf0249-5853-47f3-96e4-f24e4e70c1ff.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -8362,7 +8362,7 @@
         },
         {
             "id": "2f7674c3-13a7-51b0-85ad-a9f8c0eeabdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc7b44-f4a1-4edb-9fde-aa26830200e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc7b44-f4a1-4edb-9fde-aa26830200e0.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "e62eac67-3244-5cf0-ba9a-786c20107003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac806b3-17d2-4671-b4ca-0a8b85482bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac806b3-17d2-4671-b4ca-0a8b85482bdc.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -8442,7 +8442,7 @@
         },
         {
             "id": "0f5b599a-1277-59cc-ac19-70aa17d49b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e14c1e-99d5-49e1-b9ce-92393c1d408f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e14c1e-99d5-49e1-b9ce-92393c1d408f.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}.",
             "colours": [
@@ -8483,7 +8483,7 @@
         },
         {
             "id": "372cb7b6-cb0f-5c1a-952f-369a092dcbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d423ca-ccd5-4bf1-9d81-4b6d4ca025ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d423ca-ccd5-4bf1-9d81-4b6d4ca025ac.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -8526,7 +8526,7 @@
         },
         {
             "id": "708dcc48-0674-5283-9ea7-66a50fdcb2f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01a0413-1cf6-4936-bec5-b1f5174b099f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01a0413-1cf6-4936-bec5-b1f5174b099f.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -8566,7 +8566,7 @@
         },
         {
             "id": "56024a79-1965-53ba-ad17-c7589808b9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4611fd39-a212-4d04-8c9e-d5d9c2bf3c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4611fd39-a212-4d04-8c9e-d5d9c2bf3c7d.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8609,7 +8609,7 @@
         },
         {
             "id": "8f50b910-8c19-5463-a4e9-67d0c1406169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669271c6-27d3-40d3-8054-4555d38269f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669271c6-27d3-40d3-8054-4555d38269f3.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -8652,7 +8652,7 @@
         },
         {
             "id": "8c4e55b5-2464-5e20-92f6-4cfe04d33f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d002e-4ab2-48bc-ba95-9dc1c90d210d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d002e-4ab2-48bc-ba95-9dc1c90d210d.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -8690,7 +8690,7 @@
         },
         {
             "id": "338d6170-4082-5850-bd5d-bccb78be611a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143471-c144-40b9-9fcf-5c6c9ad45dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143471-c144-40b9-9fcf-5c6c9ad45dfa.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -8735,7 +8735,7 @@
         },
         {
             "id": "d01683f1-ddcd-5dff-9815-8634d357f969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a2fea-e6b6-48f1-bff8-e556dd1daae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a2fea-e6b6-48f1-bff8-e556dd1daae5.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -8780,7 +8780,7 @@
         },
         {
             "id": "93e69210-9cb9-5726-88f7-db1c5d4f2c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7554713b-825c-4c4a-9a44-9e76910a9bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7554713b-825c-4c4a-9a44-9e76910a9bfd.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -8829,7 +8829,7 @@
         },
         {
             "id": "0d65de0e-c6ed-51b1-838b-4191dabcc0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8abcef7-31b0-4c17-9807-b26079fb6ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8abcef7-31b0-4c17-9807-b26079fb6ed8.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "439ab7f9-de2d-5d3d-b143-4df344d21c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ed071-7672-44c4-bd19-66954ea0c83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ed071-7672-44c4-bd19-66954ea0c83c.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -8914,7 +8914,7 @@
         },
         {
             "id": "6571011b-212d-514c-aa00-e55317e7646e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c919f25-a57b-4671-ba30-de98262f8d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c919f25-a57b-4671-ba30-de98262f8d7a.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "fb946aee-2e40-5578-8bb8-483180aeb155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25ce46-9d1a-4d5d-b35d-ea7abb8c5e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25ce46-9d1a-4d5d-b35d-ea7abb8c5e5c.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "494b06e8-71ec-5466-91b3-970d5d99e15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363a562f-95bc-45fa-961d-50d98ed7b401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363a562f-95bc-45fa-961d-50d98ed7b401.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "b18f59db-9579-5163-bec4-7a45a5cad309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d075d-71b6-4f04-946e-e2abc9d374fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d075d-71b6-4f04-946e-e2abc9d374fa.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -9086,7 +9086,7 @@
         },
         {
             "id": "26d9ffbb-17d5-5ba7-9eac-9cf36f08c2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfd30b-24eb-4b2c-a1de-3f7e1f2a5cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfd30b-24eb-4b2c-a1de-3f7e1f2a5cb2.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -9128,7 +9128,7 @@
         },
         {
             "id": "6a045a28-efb4-5be1-81ea-df7b77f20dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64972370-4b5d-4664-9a5f-c1df947024bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64972370-4b5d-4664-9a5f-c1df947024bd.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -9171,7 +9171,7 @@
         },
         {
             "id": "bbb9cc66-bd71-54fa-9ea3-58540ea1d6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69c4055-786c-4afd-a3c5-095dbf85d178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69c4055-786c-4afd-a3c5-095dbf85d178.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -9203,7 +9203,7 @@
         },
         {
             "id": "6fbfddea-c454-59c0-94e7-1d5d72d552a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e93920-2331-494d-bd8c-8d1ee5d7ccee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e93920-2331-494d-bd8c-8d1ee5d7ccee.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "15c5d63b-3fbd-5f20-8dc4-1211963e1120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa34cf-51f8-4433-9e10-1c7e8f940962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa34cf-51f8-4433-9e10-1c7e8f940962.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [

--- a/Assets/Resources/Sets/MBS.json
+++ b/Assets/Resources/Sets/MBS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c6e259b6-498f-5d1e-81d5-a67e9e2a075b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0a4370-729d-40e7-b68b-21902648492d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0a4370-729d-40e7-b68b-21902648492d.jpg?1",
             "name": "Accorder Paladin",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "14d7ae7a-83b8-548e-b16b-f1990cde026b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c42dac-f0b3-41aa-b3b2-f203e265131d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c42dac-f0b3-41aa-b3b2-f203e265131d.jpg?1",
             "name": "Ardent Recruit",
             "text": "Metalcraft \u2014 Ardent Recruit gets +2/+2 as long as you control three or more artifacts.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "6fb2027e-6261-565b-82d1-5d97f572657a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5f605c-9d16-493e-bc44-0e15bdf8c0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5f605c-9d16-493e-bc44-0e15bdf8c0bf.jpg?1",
             "name": "Banishment Decree",
             "text": "Put target artifact, creature, or enchantment on top of its owner's library.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "780ab3a7-df81-548e-84d9-67e50c7a7b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9af543-5273-4754-ab7d-75d0b632240f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9af543-5273-4754-ab7d-75d0b632240f.jpg?1",
             "name": "Choking Fumes",
             "text": "Put a -1/-1 counter on each attacking creature.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "0fe79ebc-e7ad-52d6-8027-b3e2d6afc85b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7c7a65-5a96-4986-877b-b34583092bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7c7a65-5a96-4986-877b-b34583092bb6.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
             "colours": [
@@ -170,7 +170,7 @@
         },
         {
             "id": "3a5770d1-8e86-5a7b-a115-064c763e336b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff909bc-0bda-4e8a-b7a3-ebc963552246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff909bc-0bda-4e8a-b7a3-ebc963552246.jpg?1",
             "name": "Frantic Salvage",
             "text": "Put any number of target artifact cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "991c2a9b-404c-5e82-bb74-410be6afbda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2889bba-58a8-46e1-959c-0fd38c1732f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2889bba-58a8-46e1-959c-0fd38c1732f9.jpg?1",
             "name": "Gore Vassal",
             "text": "Sacrifice Gore Vassal: Put a -1/-1 counter on target creature. Then if that creature's toughness is 1 or greater, regenerate it.",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "e321f712-b409-5d7f-807d-b846ac85e6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3853ec-e307-46e0-96d7-0706b5c45c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3853ec-e307-46e0-96d7-0706b5c45c5e.jpg?1",
             "name": "Hero of Bladehold",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhenever Hero of Bladehold attacks, put two 1/1 white Soldier creature tokens onto the battlefield tapped and attacking.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "9fc0be95-26bf-595a-95b2-57e0ce41aad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30731756-81a8-480b-938f-48c1d0cb95d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30731756-81a8-480b-938f-48c1d0cb95d7.jpg?1",
             "name": "Kemba's Legion",
             "text": "Vigilance\nKemba's Legion can block an additional creature for each Equipment attached to Kemba's Legion.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "922a2e0f-6778-59ee-aec6-cf8d11140fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0900e1-df78-466d-b747-33f22c273d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0900e1-df78-466d-b747-33f22c273d67.jpg?1",
             "name": "Leonin Relic-Warder",
             "text": "When Leonin Relic-Warder enters the battlefield, you may exile target artifact or enchantment.\nWhen Leonin Relic-Warder leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "465d569f-1b9e-5b12-9baf-543aff89f749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb723d-aa4c-4a38-98de-1faefffab56b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb723d-aa4c-4a38-98de-1faefffab56b.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "858ed157-109c-5c38-8d1f-06c441c26512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a76016-96a1-40f5-9002-4b3bed65cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a76016-96a1-40f5-9002-4b3bed65cd5c.jpg?1",
             "name": "Loxodon Partisan",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "c40afd05-ec34-5caf-9aa7-86fa9be75ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f54188-2cfc-4964-add7-b452f32d57ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f54188-2cfc-4964-add7-b452f32d57ef.jpg?1",
             "name": "Master's Call",
             "text": "Put two 1/1 colorless Myr artifact creature tokens onto the battlefield.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "b0a7a503-6420-52e7-9697-7967147216d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf7a821-3587-4aad-8411-fca5c96ab5c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf7a821-3587-4aad-8411-fca5c96ab5c4.jpg?1",
             "name": "Mirran Crusader",
             "text": "Double strike, protection from black and from green",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "073b8f73-3fa5-5600-b9e0-5391a65494eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b7536d-6b0b-4906-ba88-7fcfe9b854ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b7536d-6b0b-4906-ba88-7fcfe9b854ee.jpg?1",
             "name": "Phyrexian Rebirth",
             "text": "Destroy all creatures, then put an X/X colorless Horror artifact creature token onto the battlefield, where X is the number of creatures destroyed this way.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "a88e514b-7413-58bd-8b86-d90944f1cbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978c49d-483a-42fe-971c-858288d07e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978c49d-483a-42fe-971c-858288d07e40.jpg?1",
             "name": "Priests of Norn",
             "text": "Vigilance\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "a7f3aaad-9f80-58d1-87a1-1619b627271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b665e-8236-4ab9-bee4-414f075461d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b665e-8236-4ab9-bee4-414f075461d2.jpg?1",
             "name": "Tine Shrike",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "66e9287c-8617-545c-8d7d-786f0f787645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac76f857-faf6-482d-a82e-7ff681f8007b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac76f857-faf6-482d-a82e-7ff681f8007b.jpg?1",
             "name": "Victory's Herald",
             "text": "Flying\nWhenever Victory's Herald attacks, attacking creatures gain flying and lifelink until end of turn.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "cae5ae9b-0e89-5751-8d16-eb35f4639b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a879940e-6632-47c5-a30e-d29a82d16e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a879940e-6632-47c5-a30e-d29a82d16e9d.jpg?1",
             "name": "White Sun's Zenith",
             "text": "Put X 2/2 white Cat creature tokens onto the battlefield. Shuffle White Sun's Zenith into its owner's library.",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "540948b9-6c76-5c82-a45f-435ff255f68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8150f78-e187-4949-9746-fec64d1675d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8150f78-e187-4949-9746-fec64d1675d1.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "f20d18b4-6f02-5948-b649-bcc93ba4edc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f6b20c-9871-433c-8557-44493447e914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f6b20c-9871-433c-8557-44493447e914.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "d227b963-34b4-5e8d-ad5b-99c619636704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7276c584-76ed-4c20-a5ea-627c8f7751e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7276c584-76ed-4c20-a5ea-627c8f7751e6.jpg?1",
             "name": "Corrupted Conscience",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has infect. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "9ba907d6-6013-578f-a3b3-db01fcb782e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a31710-c1d6-45e4-9dbe-a75453a74da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a31710-c1d6-45e4-9dbe-a75453a74da0.jpg?1",
             "name": "Cryptoplasm",
             "text": "At the beginning of your upkeep, you may have Cryptoplasm become a copy of another target creature. If you do, Cryptoplasm gains this ability.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "c1403e31-b5e9-57dd-b80a-e39786ced0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158da0aa-8317-498b-89ed-2f84317fe256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158da0aa-8317-498b-89ed-2f84317fe256.jpg?1",
             "name": "Distant Memories",
             "text": "Search your library for a card, exile it, then shuffle your library. Any opponent may have you put that card into your hand. If no player does, you draw three cards.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "f2c6d0e3-befa-53f4-8540-80c633bf4ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126e0e5-9b23-496f-8a09-7a35499f9a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126e0e5-9b23-496f-8a09-7a35499f9a09.jpg?1",
             "name": "Fuel for the Cause",
             "text": "Counter target spell, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "755e94ec-da81-5b2e-8352-67c3b762dc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e576ad-3e03-424c-8857-88ec8898a92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e576ad-3e03-424c-8857-88ec8898a92e.jpg?1",
             "name": "Mirran Spy",
             "text": "Flying\nWhenever you cast an artifact spell, you may untap target creature.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "54cee391-fa58-5337-81b0-caf320b77dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abd4521-62c8-4b2f-a406-a8ddfa8f475a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abd4521-62c8-4b2f-a406-a8ddfa8f475a.jpg?1",
             "name": "Mitotic Manipulation",
             "text": "Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "53b70775-8f36-5326-bc88-a17cccc45b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7084f3-9335-401f-9a62-6f131351338d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7084f3-9335-401f-9a62-6f131351338d.jpg?1",
             "name": "Neurok Commando",
             "text": "Shroud\nWhenever Neurok Commando deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "c723f0a0-7d1f-52cd-a83c-61f4fdca3381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673bebb4-9c82-40ca-8552-b9030e961005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673bebb4-9c82-40ca-8552-b9030e961005.jpg?1",
             "name": "Oculus",
             "text": "When Oculus is put into a graveyard from the battlefield, you may draw a card.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "4b2423de-3900-5bde-b3b2-c916b6b4846a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb209cf5-ac7b-4521-b488-ef72451e3a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb209cf5-ac7b-4521-b488-ef72451e3a25.jpg?1",
             "name": "Quicksilver Geyser",
             "text": "Return up to two target nonland permanents to their owners' hands.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "18f1846d-a13c-5b40-92b3-9a7805517a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f157d08a-7cd7-4120-a8bb-1b50fa0ba99b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f157d08a-7cd7-4120-a8bb-1b50fa0ba99b.jpg?1",
             "name": "Serum Raker",
             "text": "Flying\nWhen Serum Raker is put into a graveyard from the battlefield, each player discards a card.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "744158c6-3dba-51a4-afee-a4396a780538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14e2a4-484b-46e4-a5a1-c66cb13be178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14e2a4-484b-46e4-a5a1-c66cb13be178.jpg?1",
             "name": "Spire Serpent",
             "text": "Defender\nMetalcraft \u2014 As long as you control three or more artifacts, Spire Serpent gets +2/+2 and can attack as though it didn't have defender.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "888e02ba-8b8b-51cf-b6e4-57b413fff7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb40de7c-1905-4615-844b-4abc231fb01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb40de7c-1905-4615-844b-4abc231fb01e.jpg?1",
             "name": "Steel Sabotage",
             "text": "Choose one \u2014 Counter target artifact spell; or return target artifact to its owner's hand.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "b6c66f9e-a854-58fa-a968-c91da24535d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe4fea1-bb23-46e4-b7b0-e83f8b99ce5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe4fea1-bb23-46e4-b7b0-e83f8b99ce5d.jpg?1",
             "name": "Treasure Mage",
             "text": "When Treasure Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 6 or greater, reveal that card, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "9a11ec13-0ec5-59c8-9fb9-ec7a607e93b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc91fc7-7927-4c5d-888a-f40cbf658866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc91fc7-7927-4c5d-888a-f40cbf658866.jpg?1",
             "name": "Turn the Tide",
             "text": "Creatures your opponents control get -2/-0 until end of turn.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "2de0258e-d595-527d-b163-5eaa1283d296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13bb9b-c4e9-4b82-852a-dbd5602b1aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13bb9b-c4e9-4b82-852a-dbd5602b1aa9.jpg?1",
             "name": "Vedalken Anatomist",
             "text": "{2}{U}, {T}: Put a -1/-1 counter on target creature. You may tap or untap that creature.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "b8fdd6e6-2c6c-523e-85e9-7e58d565870b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4f4db7-913c-4dd2-931e-630d90eb98ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4f4db7-913c-4dd2-931e-630d90eb98ab.jpg?1",
             "name": "Vedalken Infuser",
             "text": "At the beginning of your upkeep, you may put a charge counter on target artifact.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "9d48363b-3022-579a-8fb8-2b53e875dc73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a3631-f2d6-4a64-a04a-893f452e3a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a3631-f2d6-4a64-a04a-893f452e3a60.jpg?1",
             "name": "Vivisection",
             "text": "As an additional cost to cast Vivisection, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "c646a6ef-6de0-540a-a48b-82049555c577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bdcf52-50b8-42c0-9665-931d83f5f314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bdcf52-50b8-42c0-9665-931d83f5f314.jpg?1",
             "name": "Black Sun's Zenith",
             "text": "Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its owner's library.",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "a6dd7462-64bf-5d42-a063-5c280d0d25d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a54115f-150a-4ae2-a5c7-20e2ba884dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a54115f-150a-4ae2-a5c7-20e2ba884dd1.jpg?1",
             "name": "Caustic Hound",
             "text": "When Caustic Hound is put into a graveyard from the battlefield, each player loses 4 life.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "83379d1f-299d-5a0e-9331-ac3cda192497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1",
             "name": "Flensermite",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "f42f27b9-71dd-56a4-ba5e-8abcd14bc12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee9f3-80fe-43b0-be5b-0c93103e1077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee9f3-80fe-43b0-be5b-0c93103e1077.jpg?1",
             "name": "Flesh-Eater Imp",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nSacrifice a creature: Flesh-Eater Imp gets +1/+1 until end of turn.",
             "colours": [
@@ -1421,7 +1421,7 @@
         },
         {
             "id": "cba9b662-1710-5952-affc-f66cc1ac53d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c665cfc-7e9a-444b-96b5-e8e4ef57a98a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c665cfc-7e9a-444b-96b5-e8e4ef57a98a.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "24cc4504-9d0f-584c-bb65-3ea09c572ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f31fb-af96-4c8c-80fa-219ebd7c3d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f31fb-af96-4c8c-80fa-219ebd7c3d4d.jpg?1",
             "name": "Gruesome Encore",
             "text": "Put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. Exile it at the beginning of the next end step. If that creature would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "e0f16d8f-5ccf-50b7-905b-a0283506a293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ff5fbd-7ce8-4188-8228-0eab0d69a7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ff5fbd-7ce8-4188-8228-0eab0d69a7a1.jpg?1",
             "name": "Horrifying Revelation",
             "text": "Target player discards a card, then puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "92b62e2c-32ad-5792-be9b-06d84b22e229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd32ec2-02a8-41fc-bf45-c9585bb2b3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd32ec2-02a8-41fc-bf45-c9585bb2b3ee.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls is put into a graveyard from the battlefield, that player loses 2 life.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "63e533c1-fb45-55b8-af54-6eb37ed4bee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6a8817-05fc-400e-9464-b7d925c5c312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6a8817-05fc-400e-9464-b7d925c5c312.jpg?1",
             "name": "Morbid Plunder",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -1584,7 +1584,7 @@
         },
         {
             "id": "c799d4ce-8444-52bf-a936-f40344a43883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035ff58-9df3-4db4-b9d0-97d58080ecfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035ff58-9df3-4db4-b9d0-97d58080ecfe.jpg?1",
             "name": "Nested Ghoul",
             "text": "Whenever a source deals damage to Nested Ghoul, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "d9f69074-8941-5315-b985-7d1106e45d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0059d21b-0725-4806-8691-2451db36787f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0059d21b-0725-4806-8691-2451db36787f.jpg?1",
             "name": "Phyresis",
             "text": "Enchant creature\nEnchanted creature has infect. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "ea0d4fa2-26e3-58be-b808-351b801bf17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aaa8b9-987b-4809-8a54-aa29bdc18805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aaa8b9-987b-4809-8a54-aa29bdc18805.jpg?1",
             "name": "Phyrexian Crusader",
             "text": "First strike, protection from red and from white\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "8ec0ee7c-9f5e-5093-9a9d-cbbc7eafe1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11889da-d5dd-4bb3-b3d0-0d90698f4f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11889da-d5dd-4bb3-b3d0-0d90698f4f34.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "0b54d5be-3e44-52be-9659-8940671b8ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0024556-0317-4c28-83c3-0a6020d72a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0024556-0317-4c28-83c3-0a6020d72a2b.jpg?1",
             "name": "Phyrexian Vatmother",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nAt the beginning of your upkeep, you get a poison counter.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "495bb943-0d08-5457-ac86-fd6a5746a7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c374193-4ebb-4f33-a24d-e567aea57b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c374193-4ebb-4f33-a24d-e567aea57b01.jpg?1",
             "name": "Sangromancer",
             "text": "Flying\nWhenever a creature an opponent controls is put into a graveyard from the battlefield, you may gain 3 life.\nWhenever an opponent discards a card, you may gain 3 life.",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "5f3072f2-2f43-57b3-8975-44a1cd5c1ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ded51b-2ced-46d6-a1d4-0f49d4b1ed2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ded51b-2ced-46d6-a1d4-0f49d4b1ed2d.jpg?1",
             "name": "Scourge Servant",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "7d2d3c51-ad9c-55af-a016-381e3093ee57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7915d9-b941-4675-9a1b-18e579977144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7915d9-b941-4675-9a1b-18e579977144.jpg?1",
             "name": "Septic Rats",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Septic Rats attacks, if defending player is poisoned, it gets +1/+1 until end of turn.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "d1a09a6c-890e-5841-8df3-32346faeae51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a771-4f5c-4295-b070-8cb857a0279e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a771-4f5c-4295-b070-8cb857a0279e.jpg?1",
             "name": "Spread the Sickness",
             "text": "Destroy target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "41b3044a-1fda-5d2d-a6cd-a1843e4b4750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae09e1a-c257-45e9-88c8-7b1a7a6d714b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae09e1a-c257-45e9-88c8-7b1a7a6d714b.jpg?1",
             "name": "Virulent Wound",
             "text": "Put a -1/-1 counter on target creature. When that creature is put into a graveyard this turn, its controller gets a poison counter.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "0a15e0db-7af2-59c5-a6e0-004504a07bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8187e90-6a60-4ed0-9b3a-3a679743b7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8187e90-6a60-4ed0-9b3a-3a679743b7d0.jpg?1",
             "name": "Blisterstick Shaman",
             "text": "When Blisterstick Shaman enters the battlefield, it deals 1 damage to target creature or player.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "9470bc79-9ead-5851-9b33-e949767944b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5641730-428d-4484-866e-ec1ac669537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5641730-428d-4484-866e-ec1ac669537f.jpg?1",
             "name": "Burn the Impure",
             "text": "Burn the Impure deals 3 damage to target creature. If that creature has infect, Burn the Impure deals 3 damage to that creature's controller.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "f1b73c2f-0dfd-5eee-8e86-da5490b56813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b68e85-a381-441d-aa18-491f9e202a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b68e85-a381-441d-aa18-491f9e202a10.jpg?1",
             "name": "Concussive Bolt",
             "text": "Concussive Bolt deals 4 damage to target player.\nMetalcraft \u2014 If you control three or more artifacts, creatures that player controls can't block this turn.",
             "colours": [
@@ -2028,7 +2028,7 @@
         },
         {
             "id": "acda07e5-0235-59d3-9323-6c539a9a6819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29d5e01-6f83-4749-8340-774054bd2956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29d5e01-6f83-4749-8340-774054bd2956.jpg?1",
             "name": "Crush",
             "text": "Destroy target noncreature artifact.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "6abf881d-cf4b-5144-b1cb-d3b5d72e2a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1a696b-642a-419f-bd43-09af39a9401b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1a696b-642a-419f-bd43-09af39a9401b.jpg?1",
             "name": "Galvanoth",
             "text": "At the beginning of your upkeep, you may look at the top card of your library. If it's an instant or sorcery card, you may cast it without paying its mana cost.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "30141d2f-f9e5-5091-887b-c9e3c6252d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27dcb0c8-e6d5-4f6b-a74f-e495b5e42606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27dcb0c8-e6d5-4f6b-a74f-e495b5e42606.jpg?1",
             "name": "Gnathosaur",
             "text": "Sacrifice an artifact: Gnathosaur gains trample until end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "f3b72539-aa3e-54c4-ac72-3a5d063bd965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e220c87-1223-4998-b0e5-23e2d930fa6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e220c87-1223-4998-b0e5-23e2d930fa6b.jpg?1",
             "name": "Goblin Wardriver",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "467eb10b-57b8-5b61-a91a-59288a9dea42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83715873-9330-4d29-b106-cf1e6a66d1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83715873-9330-4d29-b106-cf1e6a66d1e9.jpg?1",
             "name": "Hellkite Igniter",
             "text": "Flying, haste\n{1}{R}: Hellkite Igniter gets +X/+0 until end of turn, where X is the number of artifacts you control.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "9f0dc611-43a5-53f7-8829-9a74fabf7675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a516bce-3d2d-4e0f-afc7-27be3d88848c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a516bce-3d2d-4e0f-afc7-27be3d88848c.jpg?1",
             "name": "Hero of Oxid Ridge",
             "text": "Haste\nBattle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhenever Hero of Oxid Ridge attacks, creatures with power 1 or less can't block this turn.",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "4cea3d65-b73d-59e1-ba02-c0039db4a77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb91ecb-1962-4cd1-80c1-c9e2485822ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb91ecb-1962-4cd1-80c1-c9e2485822ae.jpg?1",
             "name": "Into the Core",
             "text": "Exile two target artifacts.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "e7536336-92cb-5d6b-a686-bd1a4191b426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978cc53c-c038-4442-bd46-e0b9e8cdd924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978cc53c-c038-4442-bd46-e0b9e8cdd924.jpg?1",
             "name": "Koth's Courier",
             "text": "Forestwalk",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "2b16661c-01f3-545f-ac05-f0a493c98239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189fea03-24db-4574-bbc2-4d3bc9e629a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189fea03-24db-4574-bbc2-4d3bc9e629a5.jpg?1",
             "name": "Kuldotha Flamefiend",
             "text": "When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "9da766ee-24f6-559c-842f-2a06741ae2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda5434-c0a5-4551-8e30-b1923f0001b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda5434-c0a5-4551-8e30-b1923f0001b8.jpg?1",
             "name": "Kuldotha Ringleader",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nKuldotha Ringleader attacks each turn if able.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "f6dbdc09-4bf2-5b46-8792-d1e54397b716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b939ded0-7033-4fee-864c-9e235d8720bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b939ded0-7033-4fee-864c-9e235d8720bb.jpg?1",
             "name": "Metallic Mastery",
             "text": "Gain control of target artifact until end of turn. Untap that artifact. It gains haste until end of turn.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "47a95386-5d6d-5420-b01a-2a65b85294a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7407d-f677-403b-893c-361df456009a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7407d-f677-403b-893c-361df456009a.jpg?1",
             "name": "Ogre Resister",
             "text": "",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "8feeea81-6d1a-53d0-bd7f-29611dc53162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f251c71-0e83-424d-9e0e-85790289087c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f251c71-0e83-424d-9e0e-85790289087c.jpg?1",
             "name": "Rally the Forces",
             "text": "Attacking creatures get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "7e84cb8c-2bdc-5ed1-9c77-de663eb3c636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg?1",
             "name": "Red Sun's Zenith",
             "text": "Red Sun's Zenith deals X damage to target creature or player. If a creature dealt damage this way would be put into a graveyard this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "a4901b5f-a359-5d89-911a-37192d9f0607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e318b03-2aad-462b-a2a9-8b6bdf0e93d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e318b03-2aad-462b-a2a9-8b6bdf0e93d6.jpg?1",
             "name": "Slagstorm",
             "text": "Choose one \u2014 Slagstorm deals 3 damage to each creature; or Slagstorm deals 3 damage to each player.",
             "colours": [
@@ -2530,7 +2530,7 @@
         },
         {
             "id": "401ad583-530e-518e-9c2c-d4555974ee84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ac77ab-e51a-4c5c-ab6b-3fb610a5fa27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ac77ab-e51a-4c5c-ab6b-3fb610a5fa27.jpg?1",
             "name": "Spiraling Duelist",
             "text": "Metalcraft \u2014 Spiraling Duelist has double strike as long as you control three or more artifacts.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "a41d050d-c7f3-5583-91ec-2d638e980d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26da4278-ba44-4555-8837-e24627b46533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26da4278-ba44-4555-8837-e24627b46533.jpg?1",
             "name": "Blightwidow",
             "text": "Reach (This creature can block creatures with flying.)\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "4819ce30-18ee-58fe-8217-191f55cc06c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a7b3-18b6-4b1d-85cc-2253e605390c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a7b3-18b6-4b1d-85cc-2253e605390c.jpg?1",
             "name": "Creeping Corrosion",
             "text": "Destroy all artifacts.",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "c93160df-d260-5414-910a-9a69de8fa5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cf62a2-d03a-495d-924a-bf79524175fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cf62a2-d03a-495d-924a-bf79524175fa.jpg?1",
             "name": "Fangren Marauder",
             "text": "Whenever an artifact is put into a graveyard from the battlefield, you may gain 5 life.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "9e9d599d-8b14-5187-9249-2afef50e3ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45da44df-a83a-4974-bc22-5243dcda7cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45da44df-a83a-4974-bc22-5243dcda7cbd.jpg?1",
             "name": "Glissa's Courier",
             "text": "Mountainwalk",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "8a3a1680-762c-5b06-ac86-3b1dbb2b3bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02335747-54e3-4827-ae19-4e362863da9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02335747-54e3-4827-ae19-4e362863da9b.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "6754ebf2-0cd1-5f7d-bf85-13702e7526e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ed14c8-38c6-4da5-a6ee-f814478161d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ed14c8-38c6-4da5-a6ee-f814478161d2.jpg?1",
             "name": "Lead the Stampede",
             "text": "Look at the top five cards of your library. You may reveal any number of creature cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "e46fc639-21f8-5e58-807e-3b1c21ab3786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a935b4-347c-46d9-a7c5-8c5079948959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a935b4-347c-46d9-a7c5-8c5079948959.jpg?1",
             "name": "Melira's Keepers",
             "text": "Melira's Keepers can't have counters placed on it.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "3b95c925-4632-507f-ba39-3902ae4805b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbb5778-fa9a-4a1f-be4f-627630c3e3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbb5778-fa9a-4a1f-be4f-627630c3e3ca.jpg?1",
             "name": "Mirran Mettle",
             "text": "Target creature gets +2/+2 until end of turn.\nMetalcraft \u2014 That creature gets +4/+4 until end of turn instead if you control three or more artifacts.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "e5f15a00-36a9-5926-80af-ffe023fb6f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb135aa1-9f46-4d60-a1a4-97aa0e852ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb135aa1-9f46-4d60-a1a4-97aa0e852ced.jpg?1",
             "name": "Phyrexian Hydra",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nIf damage would be dealt to Phyrexian Hydra, prevent that damage. Put a -1/-1 counter on Phyrexian Hydra for each 1 damage prevented this way.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "6a68e7d9-fb42-5674-af16-5725f31dcfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2918d6-50f7-4bc1-aef2-930a5c84be8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2918d6-50f7-4bc1-aef2-930a5c84be8d.jpg?1",
             "name": "Pistus Strike",
             "text": "Destroy target creature with flying. Its controller gets a poison counter.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "fc6a5c69-36e5-5bd5-b2c4-8f5e645c6f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52341830-8cea-421f-b901-9229004f2d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52341830-8cea-421f-b901-9229004f2d45.jpg?1",
             "name": "Plaguemaw Beast",
             "text": "{T}, Sacrifice a creature: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "622670ab-28bc-5c0b-89b0-9b3290b74a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67c8bea-d4c9-4759-8a37-10546b234472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67c8bea-d4c9-4759-8a37-10546b234472.jpg?1",
             "name": "Praetor's Counsel",
             "text": "Return all cards from your graveyard to your hand. Exile Praetor's Counsel. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "ba6fab91-413f-5d9a-b6fe-37da6042f8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c597b9-5024-42bd-b500-5ef6a3accda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c597b9-5024-42bd-b500-5ef6a3accda6.jpg?1",
             "name": "Quilled Slagwurm",
             "text": "",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "ea28e0c3-a1eb-5c92-a048-5cd44c0e4bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a81dfcf-a7c4-41a4-b1e9-b9e9c3f75742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a81dfcf-a7c4-41a4-b1e9-b9e9c3f75742.jpg?1",
             "name": "Rot Wolf",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever a creature dealt damage by Rot Wolf this turn is put into a graveyard, you may draw a card.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "b800e27b-6886-5590-a7f2-2bf9cf0d7005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4d333-78f7-4710-9b26-36e285c0d9f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4d333-78f7-4710-9b26-36e285c0d9f8.jpg?1",
             "name": "Tangle Mantis",
             "text": "Trample",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "01b9bdce-0e71-5b3b-9224-29e3a45c991d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d393da0-4cb6-4ae8-b747-8e6d0fa7f55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d393da0-4cb6-4ae8-b747-8e6d0fa7f55a.jpg?1",
             "name": "Thrun, the Last Troll",
             "text": "Thrun, the Last Troll can't be countered.\nThrun can't be the target of spells or abilities your opponents control.\n{1}{G}: Regenerate Thrun.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "f1db9818-202f-5af6-a67c-aa930fbe652c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2798fdff-0b39-41b6-b0ec-c4f449ca3314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2798fdff-0b39-41b6-b0ec-c4f449ca3314.jpg?1",
             "name": "Unnatural Predation",
             "text": "Target creature gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "24c15f17-f091-5a6e-9a9e-d99fa8bd5c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc13aee-5a74-4dab-a6af-7dc31255981d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc13aee-5a74-4dab-a6af-7dc31255981d.jpg?1",
             "name": "Viridian Corrupter",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Viridian Corrupter enters the battlefield, destroy target artifact.",
             "colours": [
@@ -3175,7 +3175,7 @@
         },
         {
             "id": "2cc1026b-3dd1-5476-9b47-4c0b8b7a0eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129fa334-f561-4fbd-9f51-2fa044b674e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129fa334-f561-4fbd-9f51-2fa044b674e1.jpg?1",
             "name": "Viridian Emissary",
             "text": "When Viridian Emissary is put into a graveyard from the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "deca8f5b-6828-5f8e-9b54-8888e1d689f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755e0fbf-4f00-4b05-a535-27e78e96d6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755e0fbf-4f00-4b05-a535-27e78e96d6b6.jpg?1",
             "name": "Glissa, the Traitor",
             "text": "First strike, deathtouch\nWhenever a creature an opponent controls is put into a graveyard from the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "b8f9c6a9-42c3-59a2-a037-50a8776ad5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c8470-1cc8-4383-8782-c022867d46e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c8470-1cc8-4383-8782-c022867d46e8.jpg?1",
             "name": "Tezzeret, Agent of Bolas",
             "text": "+1: Look at the top five cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\n-1: Target artifact becomes a 5/5 artifact creature.\n-4: Target player loses X life and you gain X life, where X is twice the number of artifacts you control.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "cc737241-cb41-574e-84e7-d034e5217ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69959c54-1350-4c64-8e5a-fc8447bb979c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69959c54-1350-4c64-8e5a-fc8447bb979c.jpg?1",
             "name": "Bladed Sentinel",
             "text": "{W}: Bladed Sentinel gains vigilance until end of turn.",
             "colours": [],
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "83b13871-d088-5b31-a3af-270b38424039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7928bb14-7631-4830-a756-26d1ea832ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7928bb14-7631-4830-a756-26d1ea832ba2.jpg?1",
             "name": "Blightsteel Colossus",
             "text": "Trample, infect\nBlightsteel Colossus is indestructible.\nIf Blightsteel Colossus would be put into a graveyard from anywhere, reveal Blightsteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "f013d4b6-8744-537e-b0dc-300d228ab013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14613bc-0083-48d6-ac10-b2839657e84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14613bc-0083-48d6-ac10-b2839657e84b.jpg?1",
             "name": "Bonehoard",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +X/+X, where X is the number of creature cards in all graveyards.\nEquip {2}",
             "colours": [],
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "ab08087a-836d-5d8d-b701-3f20068b9e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37928b90-ab31-4c73-99b2-fe31feb2afea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37928b90-ab31-4c73-99b2-fe31feb2afea.jpg?1",
             "name": "Brass Squire",
             "text": "{T}: Attach target Equipment you control to target creature you control.",
             "colours": [],
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "8e3253ab-a984-508b-a100-e86595da3dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ccb013-4641-400f-a035-86030ac55582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ccb013-4641-400f-a035-86030ac55582.jpg?1",
             "name": "Copper Carapace",
             "text": "Equipped creature gets +2/+2 and can't block.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "f9081998-9a10-5399-87b8-db1fba11d8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414ba7-0f59-4c73-931c-e599d149d3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414ba7-0f59-4c73-931c-e599d149d3ba.jpg?1",
             "name": "Core Prowler",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Core Prowler is put into a graveyard from the battlefield, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "618dc4ac-b6c6-510d-9e7d-f6e281e419f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba60731f-ed96-4eba-b2de-94965745f35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba60731f-ed96-4eba-b2de-94965745f35a.jpg?1",
             "name": "Darksteel Plate",
             "text": "Darksteel Plate is indestructible.\nEquipped creature is indestructible.\nEquip {2}",
             "colours": [],
@@ -3507,7 +3507,7 @@
         },
         {
             "id": "db31e7f8-e825-5ce3-b75e-f60b570fcd3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1fe29f-cf84-45d3-b8fe-e4de1d2bebbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1fe29f-cf84-45d3-b8fe-e4de1d2bebbf.jpg?1",
             "name": "Decimator Web",
             "text": "{4}, {T}: Target opponent loses 2 life, gets a poison counter, then puts the top six cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "6e0cdf5b-2285-50bf-92cc-88efafc58884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d54f08-53f0-41b2-8b86-8244515224eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d54f08-53f0-41b2-8b86-8244515224eb.jpg?1",
             "name": "Dross Ripper",
             "text": "{2}{B}: Dross Ripper gets +1/+1 until end of turn.",
             "colours": [],
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "7104146e-c5cb-557f-b2bf-94f602bd59c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd47a02-5a6e-4daa-9877-f65c8639c569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd47a02-5a6e-4daa-9877-f65c8639c569.jpg?1",
             "name": "Flayer Husk",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +1/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "45ab90f9-e2cd-51bf-9182-6a2b06d2347a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5970d053-e2e8-471b-b342-2e9b9177724c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5970d053-e2e8-471b-b342-2e9b9177724c.jpg?1",
             "name": "Gust-Skimmer",
             "text": "{U}: Gust-Skimmer gains flying until end of turn.",
             "colours": [],
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "13280ead-e2b3-5621-8736-35865b2e8b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b913f3-6581-45ae-9cdb-274c2ccd8899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b913f3-6581-45ae-9cdb-274c2ccd8899.jpg?1",
             "name": "Hexplate Golem",
             "text": "",
             "colours": [],
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "a3a3d64d-187e-50ee-a9b5-2c5289371098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ea522-a0f6-45a8-8985-6fcca95d60cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ea522-a0f6-45a8-8985-6fcca95d60cc.jpg?1",
             "name": "Ichor Wellspring",
             "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -3691,7 +3691,7 @@
         },
         {
             "id": "dbb4f70f-3084-59b7-ada3-ce6d6c0660df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393454c2-b256-4a6e-9bc2-56a47cab5073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393454c2-b256-4a6e-9bc2-56a47cab5073.jpg?1",
             "name": "Knowledge Pool",
             "text": "Imprint \u2014 When Knowledge Pool enters the battlefield, each player exiles the top three cards of his or her library.\nWhenever a player casts a spell from his or her hand, that player exiles it. If the player does, he or she may cast another nonland card exiled with Knowledge Pool without paying that card's mana cost.",
             "colours": [],
@@ -3719,7 +3719,7 @@
         },
         {
             "id": "b178fa6e-3f1c-539c-92d2-b1672c21fbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45350c4b-def2-4b93-ab66-9f32bd426cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45350c4b-def2-4b93-ab66-9f32bd426cff.jpg?1",
             "name": "Lumengrid Gargoyle",
             "text": "Flying",
             "colours": [],
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "fb1d2d5c-2374-56be-90cb-fbbfbf7ebcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2f7dc-3ada-4490-8c1f-1d03bd4840f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2f7dc-3ada-4490-8c1f-1d03bd4840f5.jpg?1",
             "name": "Magnetic Mine",
             "text": "Whenever another artifact is put into a graveyard from the battlefield, Magnetic Mine deals 2 damage to that artifact's controller.",
             "colours": [],
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "8dfbf825-8018-50c2-bf35-ded05597ce8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cade6dde-1edf-44b8-a37e-a22f9207db51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cade6dde-1edf-44b8-a37e-a22f9207db51.jpg?1",
             "name": "Mirrorworks",
             "text": "Whenever another nontoken artifact enters the battlefield under your control, you may pay {2}. If you do, put a token that's a copy of that artifact onto the battlefield.",
             "colours": [],
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "3f16a163-d8fe-5130-93cf-74176bd5dd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd23da5-421f-41d0-bb60-59560da7dece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd23da5-421f-41d0-bb60-59560da7dece.jpg?1",
             "name": "Mortarpod",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +0/+1 and has \"Sacrifice this creature: This creature deals 1 damage to target creature or player.\"\nEquip {2}",
             "colours": [],
@@ -3836,7 +3836,7 @@
         },
         {
             "id": "bc856aff-f8d8-5bfb-8b6c-3d7bb25394e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507979fd-5459-4933-8707-adc303750ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507979fd-5459-4933-8707-adc303750ce9.jpg?1",
             "name": "Myr Sire",
             "text": "When Myr Sire is put into a graveyard from the battlefield, put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [],
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "685446ae-f6e3-52a5-b9b4-07e7a7068ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a76840-47f7-4e1e-b68b-00cb7da98cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a76840-47f7-4e1e-b68b-00cb7da98cdf.jpg?1",
             "name": "Myr Turbine",
             "text": "{T}: Put a 1/1 colorless Myr artifact creature token onto the battlefield.\n{T}, Tap five untapped Myr you control: Search your library for a Myr creature card, put it onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "9684e32f-0a83-5aeb-af19-cc217cf3157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff75f16-413c-4618-b766-67bd8ff4d161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff75f16-413c-4618-b766-67bd8ff4d161.jpg?1",
             "name": "Myr Welder",
             "text": "Imprint \u2014 {T}: Exile target artifact card from a graveyard.\nMyr Welder has all activated abilities of all cards exiled with it.",
             "colours": [],
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "ba0f14ba-1c80-5ca5-8122-3a8041bb54ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55710eb0-ae16-420a-9f99-6a245e0f4c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55710eb0-ae16-420a-9f99-6a245e0f4c14.jpg?1",
             "name": "Peace Strider",
             "text": "When Peace Strider enters the battlefield, you gain 3 life.",
             "colours": [],
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "5de1a2fd-de8a-5c82-a417-fb6c8b40e6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112062-1a1b-462b-85d3-821ea91778b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112062-1a1b-462b-85d3-821ea91778b8.jpg?1",
             "name": "Phyrexian Digester",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "c29bc973-cc0f-585e-ba78-59beb141f5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f6ed6c-8095-4a81-b428-36b2916eec88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f6ed6c-8095-4a81-b428-36b2916eec88.jpg?1",
             "name": "Phyrexian Juggernaut",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nPhyrexian Juggernaut attacks each turn if able.",
             "colours": [],
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "23c5d6b2-79b9-5e12-bc82-b53676de22b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7bec21-61b0-4e72-848b-82f38e1910e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7bec21-61b0-4e72-848b-82f38e1910e0.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, name a nonland card.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "767f194d-2199-516b-98f9-6ee7f19fb728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b449a5-634f-47b1-a757-86a6849f6777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b449a5-634f-47b1-a757-86a6849f6777.jpg?1",
             "name": "Pierce Strider",
             "text": "When Pierce Strider enters the battlefield, target opponent loses 3 life.",
             "colours": [],
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "37083086-1079-5d9f-a396-64af892e6966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6a88da-0b51-42d1-aa63-8c4b5e5c03c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6a88da-0b51-42d1-aa63-8c4b5e5c03c3.jpg?1",
             "name": "Piston Sledge",
             "text": "When Piston Sledge enters the battlefield, attach it to target creature you control.\nEquipped creature gets +3/+1.\nEquip\u2014\nSacrifice an artifact.",
             "colours": [],
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "20f88dbb-bd22-5f21-9df9-e6e95c20a1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f932690-9a38-4a3f-8805-a192208152a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f932690-9a38-4a3f-8805-a192208152a3.jpg?1",
             "name": "Plague Myr",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "ce194166-35b9-5eb9-a91b-6400acc4869f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd84701-857e-4948-8cb8-39b8a321a177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd84701-857e-4948-8cb8-39b8a321a177.jpg?1",
             "name": "Psychosis Crawler",
             "text": "Psychosis Crawler's power and toughness are each equal to the number of cards in your hand.\nWhenever you draw a card, each opponent loses 1 life.",
             "colours": [],
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "22126eb2-3ae1-5dfd-8ee6-0e58e9e04939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a1b4-7f88-4c8a-9ef4-bdfbd2f9e9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a1b4-7f88-4c8a-9ef4-bdfbd2f9e9cc.jpg?1",
             "name": "Razorfield Rhino",
             "text": "Metalcraft \u2014 Razorfield Rhino gets +2/+2 as long as you control three or more artifacts.",
             "colours": [],
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "e04093f9-d57f-50ea-a0bb-54b124d1a14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2228ee5-507a-46ba-82ae-72ba3088a568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2228ee5-507a-46ba-82ae-72ba3088a568.jpg?1",
             "name": "Rusted Slasher",
             "text": "Sacrifice an artifact: Regenerate Rusted Slasher.",
             "colours": [],
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "0495b6b4-2b4c-5927-8d99-e78e74eb30a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c1a5b-237b-4ecb-be73-3c6dafd5ae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c1a5b-237b-4ecb-be73-3c6dafd5ae53.jpg?1",
             "name": "Shimmer Myr",
             "text": "Flash\nYou may cast artifact cards as though they had flash.",
             "colours": [],
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "6efb52c4-3c98-552b-8a38-fb1f43417b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41269f-007d-43ba-a682-d3929cc69696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41269f-007d-43ba-a682-d3929cc69696.jpg?1",
             "name": "Shriekhorn",
             "text": "Shriekhorn enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Shriekhorn: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -4302,7 +4302,7 @@
         },
         {
             "id": "ac4e9caf-42a9-5d68-9924-d6b38d09d871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be065962-f2ed-4ab9-be6b-bfc66d63ff4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be065962-f2ed-4ab9-be6b-bfc66d63ff4e.jpg?1",
             "name": "Signal Pest",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nSignal Pest can't be blocked except by creatures with flying or reach.",
             "colours": [],
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "ecb24e70-7dc6-584f-9ff5-a86d580adc76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dba839-bd1e-4ce8-ab90-005eb1f0102e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dba839-bd1e-4ce8-ab90-005eb1f0102e.jpg?1",
             "name": "Silverskin Armor",
             "text": "Equipped creature gets +1/+1 and is an artifact in addition to its other types.\nEquip {2}",
             "colours": [],
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "f33c7615-56df-56d1-94ba-a51bcc16c546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11bc5d8-378a-441f-b92a-a60005745f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11bc5d8-378a-441f-b92a-a60005745f25.jpg?1",
             "name": "Skinwing",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+2 and has flying.\nEquip {6}",
             "colours": [],
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "3f3c1745-2be0-5347-be4d-9855e9c62050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c0735-1816-489b-9793-89d1060d78f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c0735-1816-489b-9793-89d1060d78f7.jpg?1",
             "name": "Sphere of the Suns",
             "text": "Sphere of the Suns enters the battlefield tapped and with three charge counters on it.\n{T}, Remove a charge counter from Sphere of the Suns: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "f1ef7511-9605-5138-adcb-fc9ec73c627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc820134-ae9a-4c99-a869-cee7f1f6d79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc820134-ae9a-4c99-a869-cee7f1f6d79b.jpg?1",
             "name": "Spin Engine",
             "text": "{R}: Target creature can't block Spin Engine this turn.",
             "colours": [],
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "6b9b11cb-fce3-5a52-94b3-8252dcc9f43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59313b00-ac75-484a-ad74-db9d8960c0f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59313b00-ac75-484a-ad74-db9d8960c0f8.jpg?1",
             "name": "Spine of Ish Sah",
             "text": "When Spine of Ish Sah enters the battlefield, destroy target permanent.\nWhen Spine of Ish Sah is put into a graveyard from the battlefield, return Spine of Ish Sah to its owner's hand.",
             "colours": [],
@@ -4482,7 +4482,7 @@
         },
         {
             "id": "f75af259-d0e1-593e-80e1-ea5957f3a8ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d7ff8f-7733-4323-8575-c50b3e730dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d7ff8f-7733-4323-8575-c50b3e730dbc.jpg?1",
             "name": "Strandwalker",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+4 and has reach.\nEquip {4}",
             "colours": [],
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "73e9af3f-d3d4-5e5b-a02b-592077d738f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580b4818-2a01-46ad-b4d9-7d895a625bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580b4818-2a01-46ad-b4d9-7d895a625bb3.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -4542,7 +4542,7 @@
         },
         {
             "id": "f0aa4f26-80a5-5a87-9781-cbee6833442e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3c301-8d8e-45fe-902a-af03a79525be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3c301-8d8e-45fe-902a-af03a79525be.jpg?1",
             "name": "Tangle Hulk",
             "text": "{2}{G}: Regenerate Tangle Hulk.",
             "colours": [],
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "b187f3ce-a666-54b8-859f-66be5cd7a0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644ab412-0603-447d-b8ef-dfd79f78e2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644ab412-0603-447d-b8ef-dfd79f78e2a5.jpg?1",
             "name": "Thopter Assembly",
             "text": "Flying\nAt the beginning of your upkeep, if you control no Thopters other than Thopter Assembly, return Thopter Assembly to its owner's hand and put five 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.",
             "colours": [],
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "ba2c7c77-00e2-5b7f-abfd-aa3cc9e60dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3bb4ab-6fe7-4926-a929-3e37691f287a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3bb4ab-6fe7-4926-a929-3e37691f287a.jpg?1",
             "name": "Titan Forge",
             "text": "{3}, {T}: Put a charge counter on Titan Forge.\n{T}, Remove three charge counters from Titan Forge: Put a 9/9 colorless Golem artifact creature token onto the battlefield.",
             "colours": [],
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "4b9645d2-5454-585e-8edc-65162a4c8957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7e986f-5b28-46d2-8ec2-ee719b07dbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7e986f-5b28-46d2-8ec2-ee719b07dbfd.jpg?1",
             "name": "Training Drone",
             "text": "Training Drone can't attack or block unless it's equipped.",
             "colours": [],
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "28337c42-4fb1-581c-b829-f16197779c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2154e3c6-ab69-4661-b1ef-a50cc0f6f763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2154e3c6-ab69-4661-b1ef-a50cc0f6f763.jpg?1",
             "name": "Viridian Claw",
             "text": "Equipped creature gets +1/+0 and has first strike.\nEquip {1}",
             "colours": [],
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "85bade45-2337-50a0-88ae-9b9244372fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9b696-5203-4235-9bdd-f2a389d69813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9b696-5203-4235-9bdd-f2a389d69813.jpg?1",
             "name": "Contested War Zone",
             "text": "Whenever a creature deals combat damage to you, that creature's controller gains control of Contested War Zone.\n{T}: Add {1} to your mana pool.\n{1}, {T}: Attacking creatures get +1/+0 until end of turn.",
             "colours": [],
@@ -4724,7 +4724,7 @@
         },
         {
             "id": "8ba201f1-3028-5530-815d-06016aadb10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50c1c3-885e-47d3-ada7-cc0edbf09df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50c1c3-885e-47d3-ada7-cc0edbf09df1.jpg?1",
             "name": "Inkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Inkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying and infect until end of turn. It's still a land. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "fb10965b-21de-5338-b0f6-14199dab47d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb24b22-d812-466b-b8bf-6562283ee335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb24b22-d812-466b-b8bf-6562283ee335.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4788,7 +4788,7 @@
         },
         {
             "id": "03c15c6f-df43-5f7d-9420-a65897b215ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76a9b20-746c-42e5-9977-f5dce6aef0f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76a9b20-746c-42e5-9977-f5dce6aef0f2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "162a0be6-c3d2-5bd0-8a29-83f662d447e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c7b858-61e1-43ea-95b6-2a0079a802d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c7b858-61e1-43ea-95b6-2a0079a802d2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "1c996bb5-21ed-5d10-9c7c-5ee5beaa8daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37736b90-7ecd-4b74-aeb6-50d3a81bc31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37736b90-7ecd-4b74-aeb6-50d3a81bc31d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -4896,7 +4896,7 @@
         },
         {
             "id": "fd68d601-a412-51ce-afcc-d9399ee505a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98a492-5c4e-4527-8c03-2ab2442ba7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98a492-5c4e-4527-8c03-2ab2442ba7e1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -4932,7 +4932,7 @@
         },
         {
             "id": "b6117ab6-e976-5cb7-a2e2-6ed5e952c928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c794f2c8-9c64-4b93-b7d9-3040f325d43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c794f2c8-9c64-4b93-b7d9-3040f325d43c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -4968,7 +4968,7 @@
         },
         {
             "id": "b5ceafff-ebee-523d-a78d-f47edee9692d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a55065-555a-4bdb-8ab1-8830ca5ba6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a55065-555a-4bdb-8ab1-8830ca5ba6fd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "2b3deca9-48a1-5d9f-98b0-3d0f69864fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318699f3-3ee4-4355-aebd-8a5a9006e07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318699f3-3ee4-4355-aebd-8a5a9006e07d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "374414bd-e7c2-5639-8a79-90270840a03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c84076-d503-48df-9b6c-9d4a835501b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c84076-d503-48df-9b6c-9d4a835501b6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "c38dc173-1096-55f2-bbc2-475f847c5336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8aa7c-0195-4ce9-9de4-4e6d780455aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8aa7c-0195-4ce9-9de4-4e6d780455aa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "4deea936-a240-5438-9385-a36f95b532d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760dcba4-c0f1-4843-9c39-393c629aae8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760dcba4-c0f1-4843-9c39-393c629aae8e.jpg?1",
             "name": "Germ",
             "text": "",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "65392510-3980-5122-a0e1-40f6e08304b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46769d11-a7ae-43ac-8c00-e1681955949b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46769d11-a7ae-43ac-8c00-e1681955949b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "739eae77-2810-5d5e-8c6b-203db53cdd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d84926d-5892-4c62-a943-fac9f0ddc569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d84926d-5892-4c62-a943-fac9f0ddc569.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "6f296fb6-0425-553d-9744-e16a81199d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [],
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "6bab41d8-75fc-5971-9e78-e24e3a03a8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e230e-f604-4803-9cbd-fd08d2863db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e230e-f604-4803-9cbd-fd08d2863db4.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "0cda0fd0-632a-576b-be49-b41982770b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fcdd2b-dd90-458d-9b8b-5b1b9a3f8bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fcdd2b-dd90-458d-9b8b-5b1b9a3f8bd3.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MH1.json
+++ b/Assets/Resources/Sets/MH1.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e562c426-78dd-5f0e-86b7-3756069f5d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9693e59b-032d-4ddc-a7d1-88a0f52dcc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9693e59b-032d-4ddc-a7d1-88a0f52dcc6c.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -42,7 +42,7 @@
         },
         {
             "id": "2a6226fe-5f33-5727-aad6-655fdc7cb5db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175b6e34-9cb3-4c8d-9cc0-960082a9ee71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175b6e34-9cb3-4c8d-9cc0-960082a9ee71.jpg?1",
             "name": "Answered Prayers",
             "text": "Whenever a creature enters the battlefield under your control, you gain 1 life. If Answered Prayers isn't a creature, it becomes a 3/3 Angel creature with flying in addition to its other types until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "76469a16-5cbc-59fe-8679-b9d2cad9bce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be49ed9-a078-4a57-a84a-03cfaf184fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be49ed9-a078-4a57-a84a-03cfaf184fef.jpg?1",
             "name": "Astral Drift",
             "text": "Whenever you cycle Astral Drift or cycle another card while Astral Drift is on the battlefield, you may exile target creature. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "5f5cc949-a06e-570e-965c-b8ca65611b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacf7dd0-5855-4e7b-b75c-8119cc3d1460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacf7dd0-5855-4e7b-b75c-8119cc3d1460.jpg?1",
             "name": "Battle Screech",
             "text": "Create two 1/1 white Bird creature tokens with flying.\nFlashback\u2014\nTap three untapped white creatures you control. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "eac8641e-6856-518b-b87c-a3895903e21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edc5da-4477-49f6-bbcc-f208fdaae0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edc5da-4477-49f6-bbcc-f208fdaae0d3.jpg?1",
             "name": "Dismantling Blow",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nDestroy target artifact or enchantment. If this spell was kicked, draw two cards.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "263f44d1-59b7-5203-a568-4eea375aa2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed0f6a5-ed40-44fc-a5e1-3f8bb968d1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed0f6a5-ed40-44fc-a5e1-3f8bb968d1d9.jpg?1",
             "name": "Enduring Sliver",
             "text": "Outlast {2} ({2}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nOther Sliver creatures you control have outlast {2}.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "5246b5b0-e2b4-5f85-9dbe-96b95b79e0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da5f3f8-5eef-498f-ba2c-2f3fbc3745aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da5f3f8-5eef-498f-ba2c-2f3fbc3745aa.jpg?1",
             "name": "Ephemerate",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "2ed0d815-cbd4-56c6-b0d9-7dc2e768787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14167f33-00e2-41f9-b545-b476562881c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14167f33-00e2-41f9-b545-b476562881c6.jpg?1",
             "name": "Face of Divinity",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nAs long as another Aura is attached to enchanted creature, it has first strike and lifelink.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "0c26c14a-ff7c-5969-bf28-57dd9ccf5928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5c4368-4f2e-4f5f-8944-8b0d49ab3e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5c4368-4f2e-4f5f-8944-8b0d49ab3e38.jpg?1",
             "name": "First Sliver's Chosen",
             "text": "Sliver creatures you control have exalted. (Whenever a creature you control attacks alone, it gets +1/+1 until end of turn for each instance of exalted among permanents you control.)",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "6f951fbf-d74d-5b55-9711-c07a9d010ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9736d6f4-5ff6-4006-b45d-8e630382d160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9736d6f4-5ff6-4006-b45d-8e630382d160.jpg?1",
             "name": "Force of Virtue",
             "text": "If it's not your turn, you may exile a white card from your hand rather than pay this spell's mana cost.\nFlash\nCreatures you control get +1/+1.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "70bfcc81-2397-5bca-b699-9979ff4e751a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f4711-20a8-4023-8201-9a74deab10be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f4711-20a8-4023-8201-9a74deab10be.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "6d901cda-edd6-5d60-8499-b08aa35a4464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff59aa2-5e97-4e6c-b568-470ac2371bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff59aa2-5e97-4e6c-b568-470ac2371bd7.jpg?1",
             "name": "Gilded Light",
             "text": "You gain shroud until end of turn. (You can't be the target of spells or abilities.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -401,7 +401,7 @@
         },
         {
             "id": "1142eab0-65e4-5dcd-b05d-28f6f5115b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e117771-5a8b-4812-b487-32ba34b7f724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e117771-5a8b-4812-b487-32ba34b7f724.jpg?1",
             "name": "Giver of Runes",
             "text": "{T}: Another target creature you control gains protection from colorless or from the color of your choice until end of turn.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "083e0561-f36a-5b98-b427-1fdc6d1f0ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83298c8a-02c4-4ada-9a41-4b973bb58ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83298c8a-02c4-4ada-9a41-4b973bb58ac6.jpg?1",
             "name": "Impostor of the Sixth Pride",
             "text": "Changeling (This card is every creature type.)",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "5bd742b5-c9c1-5942-a868-8a791ef99348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c46961-cf1a-4f20-83aa-3d256db2388f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c46961-cf1a-4f20-83aa-3d256db2388f.jpg?1",
             "name": "Irregular Cohort",
             "text": "Changeling (This card is every creature type.)\nWhen Irregular Cohort enters the battlefield, create a 2/2 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "8b767836-5dc3-56d7-9d30-45efd3492dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e83abd-6f15-491e-9253-90af9f6f1025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e83abd-6f15-491e-9253-90af9f6f1025.jpg?1",
             "name": "King of the Pride",
             "text": "Other Cats you control get +2/+1.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "85ca3985-2e6d-57b8-babd-0e3715b13a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d919fc0-0117-4dad-a368-e76b216cdd2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d919fc0-0117-4dad-a368-e76b216cdd2a.jpg?1",
             "name": "Knight of Old Benalia",
             "text": "Suspend 5\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)\nWhen Knight of Old Benalia enters the battlefield, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "01bf4315-ca1c-5318-860d-44ef3c06fabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f8d9a-3760-449e-b8a6-72b2a641ff23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f8d9a-3760-449e-b8a6-72b2a641ff23.jpg?1",
             "name": "Lancer Sliver",
             "text": "Sliver creatures you control have first strike.",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "7bdc464b-5c06-5cb6-a2e1-3fa34a8b8005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17428c-e31d-42f3-8811-6734abd96b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17428c-e31d-42f3-8811-6734abd96b0b.jpg?1",
             "name": "Martyr's Soul",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Martyr's Soul enters the battlefield, if you control no tapped lands, put two +1/+1 counters on it.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "db8381e4-12c5-504d-8e10-90f36f2617f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d4f6b0-ea17-4374-a80c-ba4dd207e9d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d4f6b0-ea17-4374-a80c-ba4dd207e9d6.jpg?1",
             "name": "On Thin Ice",
             "text": "Enchant snow land you control\nWhen On Thin Ice enters the battlefield, exile target creature an opponent controls until On Thin Ice leaves the battlefield.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "1281ba11-7337-5e8f-8ef3-13a839c54239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3928b4-813a-4120-8799-de34235d60ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3928b4-813a-4120-8799-de34235d60ac.jpg?1",
             "name": "Ranger-Captain of Eos",
             "text": "When Ranger-Captain of Eos enters the battlefield, you may search your library for a creature card with converted mana cost 1 or less, reveal it, put it into your hand, then shuffle your library.\nSacrifice Ranger-Captain of Eos: Your opponents can't cast noncreature spells this turn.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "be828a72-5356-5aaa-a131-6cac0da61c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb025c0c-7fdf-4f71-afd5-ef11cd2804eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb025c0c-7fdf-4f71-afd5-ef11cd2804eb.jpg?1",
             "name": "Recruit the Worthy",
             "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreate a 1/1 white Soldier creature token.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "dd605264-128a-5af2-9b41-5fe1134753a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1349c3d-39ad-40ba-897e-59e5b76de853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1349c3d-39ad-40ba-897e-59e5b76de853.jpg?1",
             "name": "Reprobation",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a Coward creature with base power and toughness 0/1. (It keeps all supertypes but loses all other types and creature types.)",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "5e25efe7-aad4-5fd8-baae-8742c29697e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6384e266-d0dc-4af1-b3ab-ecaf9be2553c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6384e266-d0dc-4af1-b3ab-ecaf9be2553c.jpg?1",
             "name": "Rhox Veteran",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhenever Rhox Veteran attacks, tap target creature an opponent controls.",
             "colours": [
@@ -815,7 +815,7 @@
         },
         {
             "id": "9050ec4e-4f7a-507e-b2a4-fc2fa620c80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbaec5-502d-48c2-9e71-c12cd0bccc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbaec5-502d-48c2-9e71-c12cd0bccc6a.jpg?1",
             "name": "Segovian Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "d6a2e961-dd91-5ae0-97c9-9e1e1fb8255c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf4af9-4b14-43e7-9d50-0e6a895cece1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf4af9-4b14-43e7-9d50-0e6a895cece1.jpg?1",
             "name": "Serra the Benevolent",
             "text": "+2: Creatures you control with flying get +1/+1 until end of turn.\n\u22123: Create a 4/4 white Angel creature token with flying and vigilance.\n\u22126: You get an emblem with \"If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.\"",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "7e777eb6-0be7-5a93-8fca-518a7980aabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ed8e57-61bb-4e89-9484-ff2be800a449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ed8e57-61bb-4e89-9484-ff2be800a449.jpg?1",
             "name": "Settle Beyond Reality",
             "text": "Choose one or both \u2014\n\u2022 Exile target creature you don't control.\n\u2022 Exile target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "9fbf10c4-92ec-50dc-a13b-341c713edd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a50984b-5bf5-4432-a149-96492d1683de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a50984b-5bf5-4432-a149-96492d1683de.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "7c02548c-e041-5642-852a-942da1d7f5f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a293c45-1e73-4527-be2f-2dcd5c47b610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a293c45-1e73-4527-be2f-2dcd5c47b610.jpg?1",
             "name": "Sisay, Weatherlight Captain",
             "text": "Sisay, Weatherlight Captain gets +1/+1 for each color among other legendary permanents you control.\n{W}{U}{B}{R}{G}: Search your library for a legendary permanent card with converted mana cost less than Sisay's power, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "e7cdcc00-86f6-5e50-ad08-4439d4044b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ab5f70-8f69-467f-9fa5-f69181edcb80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ab5f70-8f69-467f-9fa5-f69181edcb80.jpg?1",
             "name": "Soul-Strike Technique",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has vigilance.\nWhen enchanted creature dies, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "77948998-dc98-5cca-b185-de27b458775c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59dfb0f-45c7-431f-b5a3-d9b429fc6dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59dfb0f-45c7-431f-b5a3-d9b429fc6dde.jpg?1",
             "name": "Splicer's Skill",
             "text": "Create a 3/3 colorless Golem artifact creature token.\nSplice onto instant or sorcery {3}{W} (As you cast an instant or sorcery spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "7efec06e-1f43-5f6c-aa24-c82ee95ba32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de3e3b0-6ecf-4bf6-9595-0e5e59ef1d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de3e3b0-6ecf-4bf6-9595-0e5e59ef1d6a.jpg?1",
             "name": "Stirring Address",
             "text": "Target creature you control gets +2/+2 until end of turn.\nOverload {5}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "a61c48a7-0a79-5b14-846c-3cd429a18a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65f118-3812-4698-8f43-669ceb6b7982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65f118-3812-4698-8f43-669ceb6b7982.jpg?1",
             "name": "Trustworthy Scout",
             "text": "{1}{W}, Exile Trustworthy Scout from your graveyard: Search your library for a card named Trustworthy Scout, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "cee731fd-1c44-5a9e-9a7c-339bc25dde37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9fadff-a506-4546-b994-71e9e971b44e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9fadff-a506-4546-b994-71e9e971b44e.jpg?1",
             "name": "Valiant Changeling",
             "text": "This spell costs {1} less to cast for each creature type among creatures you control. This effect can't reduce the amount of mana this spell costs by more than {5}.\nChangeling (This card is every creature type.)\nDouble strike",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "449b04a8-34ec-503e-9444-10b5e8b20de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32776159-3fb6-4a70-be84-837ccd1d54a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32776159-3fb6-4a70-be84-837ccd1d54a7.jpg?1",
             "name": "Vesperlark",
             "text": "Flying\nWhen Vesperlark leaves the battlefield, return target creature card with power 1 or less from your graveyard to the battlefield.\nEvoke {1}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "577256ff-2ac5-5ff9-a561-832db3b6c02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e5388a-1c1e-4809-99d0-bbdd93436c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e5388a-1c1e-4809-99d0-bbdd93436c5e.jpg?1",
             "name": "Wall of One Thousand Cuts",
             "text": "Defender, flying\n{W}: Wall of One Thousand Cuts can attack this turn as though it didn't have defender.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "9f66a541-2444-5c32-8c46-a2c757b4a74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb17913-fe4d-4acd-9b75-71f5a90f898b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb17913-fe4d-4acd-9b75-71f5a90f898b.jpg?1",
             "name": "Winds of Abandon",
             "text": "Exile target creature you don't control. For each creature exiled this way, its controller searches their library for a basic land card. Those players put those cards onto the battlefield tapped, then shuffle their libraries.\nOverload {4}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "5ec483c8-3f56-5914-bcba-6f255d4bf270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8326bd2-83a8-4600-b12a-0bda47168f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8326bd2-83a8-4600-b12a-0bda47168f7b.jpg?1",
             "name": "Wing Shards",
             "text": "Target player sacrifices an attacking creature.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "bdb89c18-7a83-5e7d-8f73-432cdd3ef487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b824c-414d-4dd5-848f-bff678a289ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b824c-414d-4dd5-848f-bff678a289ba.jpg?1",
             "name": "Zhalfirin Decoy",
             "text": "{T}: Tap target creature. Activate this ability only if you had a creature enter the battlefield under your control this turn.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "4d2be325-dab5-5a47-855b-abf8e668bcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b852b6-4388-4a41-a5c0-bba37a5c1451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b852b6-4388-4a41-a5c0-bba37a5c1451.jpg?1",
             "name": "Archmage's Charm",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Target player draws two cards.\n\u2022 Gain control of target nonland permanent with converted mana cost 1 or less.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "5545bb18-2684-55e7-b28e-6e942769d633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1",
             "name": "Bazaar Trademage",
             "text": "Flying\nWhen Bazaar Trademage enters the battlefield, draw two cards, then discard three cards.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "9b681af1-d399-56bb-8d6a-a1dc4dda9754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dfa26-d3ad-4fe8-9db4-ddd753a4b679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dfa26-d3ad-4fe8-9db4-ddd753a4b679.jpg?1",
             "name": "Blizzard Strix",
             "text": "Flash\nFlying\nWhen Blizzard Strix enters the battlefield, if you control another snow permanent, exile target permanent other than Blizzard Strix. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "61a91e1b-3a05-55b8-a085-4df74a2e9406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f57005c-414d-4c83-9b4f-cd26e547d54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f57005c-414d-4c83-9b4f-cd26e547d54d.jpg?1",
             "name": "Chillerpillar",
             "text": "{4}{S}{S}: Monstrosity 2. (If this creature isn't monstrous, put two +1/+1 counters on it and it becomes monstrous. {S} can be paid with one mana from a snow permanent.)\nAs long as Chillerpillar is monstrous, it has flying.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "8795b044-854d-5344-af3d-32f00373028a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0d0c81-8698-41db-a687-47af028e910e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0d0c81-8698-41db-a687-47af028e910e.jpg?1",
             "name": "Choking Tethers",
             "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "29fcf4e8-6602-5d4a-95fd-c9a8df481fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300a431c-48a9-4d63-8256-cb6bdaa67b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300a431c-48a9-4d63-8256-cb6bdaa67b4c.jpg?1",
             "name": "Cunning Evasion",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "4157b29a-afa4-50c8-8705-30dce1564d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff590af2-2d6c-4f16-a9b8-1a6dab6e9ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff590af2-2d6c-4f16-a9b8-1a6dab6e9ad5.jpg?1",
             "name": "Echo of Eons",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "3c694226-9983-51dc-aa1c-f5482caefeb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744c42c-6bcc-42c0-9346-102b8368c377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744c42c-6bcc-42c0-9346-102b8368c377.jpg?1",
             "name": "Everdream",
             "text": "Draw a card.\nSplice onto instant or sorcery {2}{U} (As you cast an instant or sorcery spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "9e6b9d3f-de43-57cc-b045-1d930f939167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ffa65-542f-4b83-9fcb-d3384b74633c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ffa65-542f-4b83-9fcb-d3384b74633c.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "a677ada9-8a7f-52d6-8e8f-c214c307229f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7bda8-949a-42aa-9254-f39b791cb9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7bda8-949a-42aa-9254-f39b791cb9a8.jpg?1",
             "name": "Eyekite",
             "text": "Flying\nEyekite gets +2/+0 as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "8a6a7227-2977-5928-adaf-f09659f16d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d51a2b-450c-4e6d-a660-67d58d1dd4ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d51a2b-450c-4e6d-a660-67d58d1dd4ba.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "57ef3008-8f5b-56d5-8848-5af821fa3cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg?1",
             "name": "Faerie Seer",
             "text": "Flying\nWhen Faerie Seer enters the battlefield, scry 2.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "9e4849c5-fd8e-523b-829d-6445471867e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be371c-c688-44ad-ab71-bd4c9f242d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be371c-c688-44ad-ab71-bd4c9f242d58.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1756,7 +1756,7 @@
         },
         {
             "id": "d7acd526-125a-5bb5-af2d-e39ae9ef4e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639cb483-ffe2-4abc-a050-5cdc8aebd5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639cb483-ffe2-4abc-a050-5cdc8aebd5a2.jpg?1",
             "name": "Future Sight",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "bc8c654b-0e11-5b76-ab2e-95528773ef27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1444-a609-4c23-935d-fa25aef16179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1444-a609-4c23-935d-fa25aef16179.jpg?1",
             "name": "Iceberg Cancrix",
             "text": "Whenever another snow permanent enters the battlefield under your control, you may have target player put the top two cards of their library into their graveyard.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "14d89315-826f-5abd-896f-aa5bb332c2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa4199-df9b-494a-af7a-2491e8b0ef70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa4199-df9b-494a-af7a-2491e8b0ef70.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "5ec9eb79-f5c4-5497-90b6-11c4b151668d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5d2a6e-22cd-4493-9e58-e9c2aa3a31ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5d2a6e-22cd-4493-9e58-e9c2aa3a31ab.jpg?1",
             "name": "Marit Lage's Slumber",
             "text": "Whenever Marit Lage's Slumber or another snow permanent enters the battlefield under your control, scry 1.\nAt the beginning of your upkeep, if you control ten or more snow permanents, sacrifice Marit Lage's Slumber. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "0ebdbff9-e756-511f-a17d-43951169d0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8423d8d-744a-4bbe-a853-8ad756451bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8423d8d-744a-4bbe-a853-8ad756451bdb.jpg?1",
             "name": "Mirrodin Besieged",
             "text": "As Mirrodin Besieged enters the battlefield, choose Mirran or Phyrexian.\n\u2022 Mirran \u2014 Whenever you cast an artifact spell, create a 1/1 colorless Myr artifact creature token.\n\u2022 Phyrexian \u2014 At the beginning of your end step, draw a card, then discard a card. Then if there are fifteen or more artifact cards in your graveyard, target opponent loses the game.",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "2ba3549e-249d-5b97-a420-aea6e8a3dfda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c8f074-e260-4f8e-85d1-1904ca928b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c8f074-e260-4f8e-85d1-1904ca928b51.jpg?1",
             "name": "Mist-Syndicate Naga",
             "text": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Mist-Syndicate Naga deals combat damage to a player, create a token that's a copy of Mist-Syndicate Naga.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "90ffebd3-e13e-5fc0-8e40-6eb18e5bd22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ab7f30-ca75-4656-9738-1d965f18a22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ab7f30-ca75-4656-9738-1d965f18a22d.jpg?1",
             "name": "Moonblade Shinobi",
             "text": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Moonblade Shinobi deals combat damage to a player, create a 1/1 blue Illusion creature token with flying.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "21f33421-e7e1-5a0b-ae96-9aedd5273917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caefbac6-b2a0-4a70-a912-25173eafd7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caefbac6-b2a0-4a70-a912-25173eafd7b3.jpg?1",
             "name": "Oneirophage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on Oneirophage.",
             "colours": [
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "b6d9219f-ed2e-5bbf-8676-bf453db7b6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f106e515-511a-48c7-b7a7-3ca820950122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f106e515-511a-48c7-b7a7-3ca820950122.jpg?1",
             "name": "Phantasmal Form",
             "text": "Until end of turn, up to two target creatures each have base power and toughness 3/3, gain flying, and become blue Illusions in addition to their other colors and types.\nDraw a card.",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "794c8e4c-dce6-5557-a6ab-8a31f80b8538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392b557-e809-4371-92d7-6e93caed4f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392b557-e809-4371-92d7-6e93caed4f1b.jpg?1",
             "name": "Phantom Ninja",
             "text": "Phantom Ninja can't be blocked.",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "7e5246f0-05e2-589e-a5cb-1eb0330efed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08c5ac8-5c0b-4c89-8f06-e5aadfccee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08c5ac8-5c0b-4c89-8f06-e5aadfccee01.jpg?1",
             "name": "Pondering Mage",
             "text": "When Pondering Mage enters the battlefield, look at the top three cards of your library, then put them back in any order. You may shuffle your library. Draw a card.",
             "colours": [
@@ -2132,7 +2132,7 @@
         },
         {
             "id": "bc065b64-735e-558e-91ca-409bd1482211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae544bf-7229-4b82-99ad-32c3af36e30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae544bf-7229-4b82-99ad-32c3af36e30f.jpg?1",
             "name": "Prohibit",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nCounter target spell if its converted mana cost is 2 or less. If this spell was kicked, counter that spell if its converted mana cost is 4 or less instead.",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "d8fdd084-dfd6-5777-9fd1-8e8bbf7aca20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42230b38-c81a-4d76-ad17-1166f5f62312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42230b38-c81a-4d76-ad17-1166f5f62312.jpg?1",
             "name": "Rain of Revelation",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "c7f91972-6df9-59a3-9c46-7ae6e835415b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd683b0b-1ac1-4fa7-9657-d3b29db2ae51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd683b0b-1ac1-4fa7-9657-d3b29db2ae51.jpg?1",
             "name": "Rebuild",
             "text": "Return all artifacts to their owners' hands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "407360b3-d2ed-59a0-8b93-cb7695f33711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6466cb-d1d0-4461-b48d-7497bdc9c474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6466cb-d1d0-4461-b48d-7497bdc9c474.jpg?1",
             "name": "Scour All Possibilities",
             "text": "Scry 2, then draw a card.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "8e7a8561-08df-57d1-8ee6-4b54199298b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e63efe-b5ec-426e-8860-a881c495c39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e63efe-b5ec-426e-8860-a881c495c39e.jpg?1",
             "name": "Scuttling Sliver",
             "text": "Sliver creatures you control have \"{2}: Untap this creature.\"",
             "colours": [
@@ -2295,7 +2295,7 @@
         },
         {
             "id": "fdce3e84-8726-532f-addc-73632a86f70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c876e-ae1c-4b54-8d8a-9f3fd76ca64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c876e-ae1c-4b54-8d8a-9f3fd76ca64c.jpg?1",
             "name": "Smoke Shroud",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nWhen a Ninja enters the battlefield under your control, you may return Smoke Shroud from your graveyard to the battlefield attached to that creature.",
             "colours": [
@@ -2329,7 +2329,7 @@
         },
         {
             "id": "04328cef-e6ac-5a8c-8cd9-75079103a8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efadce19-07f4-47af-abc0-a436bafcdd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efadce19-07f4-47af-abc0-a436bafcdd65.jpg?1",
             "name": "Spell Snuff",
             "text": "Counter target spell.\nFateful hour \u2014 If you have 5 or less life, draw a card.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "337f4bba-b255-563a-9d27-25eb09cec31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b75bef5-a039-4edf-8e43-56b8d089605e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b75bef5-a039-4edf-8e43-56b8d089605e.jpg?1",
             "name": "Stream of Thought",
             "text": "Target player puts the top four cards of their library into their graveyard. You shuffle up to four cards from your graveyard into your library.\nReplicate {2}{U}{U} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)",
             "colours": [
@@ -2393,7 +2393,7 @@
         },
         {
             "id": "cb605bce-c626-5971-859c-24b025a2caea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ef4f41-211c-4302-b112-1d85ab33952f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ef4f41-211c-4302-b112-1d85ab33952f.jpg?1",
             "name": "String of Disappearances",
             "text": "Return target creature to its owner's hand. Then that creature's controller may pay {U}{U}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "62aeb473-b062-5399-aaf8-dcafc670c078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c180888-6acd-401b-815a-6ed434482681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c180888-6acd-401b-815a-6ed434482681.jpg?1",
             "name": "Tribute Mage",
             "text": "When Tribute Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 2, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "eec53509-aea8-5619-b4f8-ac890b599725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4d408-df74-45f7-925b-3cbff9a0304c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4d408-df74-45f7-925b-3cbff9a0304c.jpg?1",
             "name": "Twisted Reflection",
             "text": "Choose one \u2014\n\u2022 Target creature gets -6/-0 until end of turn.\n\u2022 Switch target creature's power and toughness until end of turn.\nEntwine {B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "d9d11455-6b40-5b67-8b4b-08a8fab793db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fb3c0-5159-4d1f-8490-ce4c9a60f567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fb3c0-5159-4d1f-8490-ce4c9a60f567.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -2530,7 +2530,7 @@
         },
         {
             "id": "a195ca9c-d782-5b9c-ad1b-2dae1deb6522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f01a3c-0a66-48da-a7d2-46260e3b721f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f01a3c-0a66-48da-a7d2-46260e3b721f.jpg?1",
             "name": "Watcher for Tomorrow",
             "text": "Hideaway (This creature enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\nWhen Watcher for Tomorrow leaves the battlefield, put the exiled card into its owner's hand.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "4670c73c-252f-599b-af51-066fe3630788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d26568-be8f-4a04-82b6-4c37b55d4cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d26568-be8f-4a04-82b6-4c37b55d4cfd.jpg?1",
             "name": "Windcaller Aven",
             "text": "Flying\nCycling {U} ({U}, Discard this card: Draw a card.)\nWhen you cycle Windcaller Aven, target creature gains flying until end of turn.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "a9b11422-ad1f-5fec-84dd-0c41951f0999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdaf6b6-aca7-49e5-a4da-bf8c08b4a055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdaf6b6-aca7-49e5-a4da-bf8c08b4a055.jpg?1",
             "name": "Winter's Rest",
             "text": "Enchant creature\nWhen Winter's Rest enters the battlefield, tap enchanted creature.\nAs long as you control another snow permanent, enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "8eee2fa0-66e8-5981-ae1d-dc245a7289de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f627e521-2b8f-4d0f-a9d3-cc4e331ce57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f627e521-2b8f-4d0f-a9d3-cc4e331ce57d.jpg?1",
             "name": "Azra Smokeshaper",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen Azra Smokeshaper enters the battlefield, target creature you control gains indestructible until end of turn.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "be5c7f18-7cba-52ff-8e77-eccceff95605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa8f485-0f3d-4a0b-bcdf-6c27d1d2bce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa8f485-0f3d-4a0b-bcdf-6c27d1d2bce0.jpg?1",
             "name": "Cabal Therapist",
             "text": "Menace\nAt the beginning of your precombat main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "16765cc5-8ecf-5d31-a960-5819865e8fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19da90-880e-4eca-8cf7-6d7baf090d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19da90-880e-4eca-8cf7-6d7baf090d53.jpg?1",
             "name": "Carrion Feeder",
             "text": "Carrion Feeder can't block.\nSacrifice a creature: Put a +1/+1 counter on Carrion Feeder.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "3aa0a1cc-e913-59ed-ab66-9bc08428b1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08151d00-513a-4957-aa16-01c0f0245112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08151d00-513a-4957-aa16-01c0f0245112.jpg?1",
             "name": "Changeling Outcast",
             "text": "Changeling (This card is every creature type.)\nChangeling Outcast can't block and can't be blocked.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "0c1fff15-c9fd-5568-a595-9d64d4798929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90a1c44-ee0f-4c12-bfaf-6f371bcce167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90a1c44-ee0f-4c12-bfaf-6f371bcce167.jpg?1",
             "name": "Cordial Vampire",
             "text": "Whenever Cordial Vampire or another creature dies, put a +1/+1 counter on each Vampire you control.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "c8399b4a-007c-5ef1-894e-ef3fef3d1124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96916db2-5121-4ff1-880c-369744f11ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96916db2-5121-4ff1-880c-369744f11ecf.jpg?1",
             "name": "Crypt Rats",
             "text": "{X}: Crypt Rats deals X damage to each creature and each player. Spend only black mana on X.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "09780323-a2ed-5755-a99a-626be76c6c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f480df6d-e227-4ccb-ad6d-a4ad48a360ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f480df6d-e227-4ccb-ad6d-a4ad48a360ad.jpg?1",
             "name": "Dead of Winter",
             "text": "All nonsnow creatures get -X/-X until end of turn, where X is the number of snow permanents you control.",
             "colours": [
@@ -2873,7 +2873,7 @@
         },
         {
             "id": "02660666-aca7-5372-8e9b-a478e14d30d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcb4398-edd1-41a7-a496-b12bce22ceb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcb4398-edd1-41a7-a496-b12bce22ceb6.jpg?1",
             "name": "Defile",
             "text": "Target creature gets -1/-1 until end of turn for each Swamp you control.",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "f0f4c52d-11de-51ec-9c54-b9de5d2a1f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eabbed2-1399-4cf1-9eba-b53c56caced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eabbed2-1399-4cf1-9eba-b53c56caced4.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "a1d84b30-1a98-50e5-a93e-62b37ea73555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a835b7e-cd63-486d-8b58-2f443f686e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a835b7e-cd63-486d-8b58-2f443f686e32.jpg?1",
             "name": "Dregscape Sliver",
             "text": "Each Sliver creature card in your graveyard has unearth {2}.\nUnearth {2} ({2}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2971,7 +2971,7 @@
         },
         {
             "id": "ce0bef32-9ba7-583f-8956-fec6bfa66de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337b6047-3f8d-4530-9e45-b5ce397a2829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337b6047-3f8d-4530-9e45-b5ce397a2829.jpg?1",
             "name": "Endling",
             "text": "{B}: Endling gains menace until end of turn.\n{B}: Endling gains deathtouch until end of turn.\n{B}: Endling gains undying until end of turn. (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)\n{1}: Endling gets +1/-1 or -1/+1 until end of turn.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "80fee7ef-d6a9-5970-a7db-3d243e75b968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4472ad84-b548-4ed8-a315-ecf9ba9d49ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4472ad84-b548-4ed8-a315-ecf9ba9d49ff.jpg?1",
             "name": "Feaster of Fools",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nDevour 2 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with twice that many +1/+1 counters on it.)",
             "colours": [
@@ -3040,7 +3040,7 @@
         },
         {
             "id": "4eb52b3f-cd5c-5119-a4fb-cfda5feb06f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59f4e5c-fdc7-485f-aadb-2a71b3701dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59f4e5c-fdc7-485f-aadb-2a71b3701dcc.jpg?1",
             "name": "First-Sphere Gargantua",
             "text": "When First-Sphere Gargantua enters the battlefield, you draw a card and you lose 1 life.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "1a3e16a9-5272-5916-8211-cc939211efea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f497b0d-4448-4201-bd55-c147da1a216d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f497b0d-4448-4201-bd55-c147da1a216d.jpg?1",
             "name": "Force of Despair",
             "text": "If it's not your turn, you may exile a black card from your hand rather than pay this spell's mana cost.\nDestroy all creatures that entered the battlefield this turn.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "47a3ac67-cc2e-55f7-9601-409805189720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514ce0d-8d61-4cce-b2ad-8f417869d04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514ce0d-8d61-4cce-b2ad-8f417869d04e.jpg?1",
             "name": "Gluttonous Slug",
             "text": "Menace\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "f14d46ff-58c5-5b31-9471-fa1c1be65e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128c516b-7eb1-4f81-8b54-428bd0649d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128c516b-7eb1-4f81-8b54-428bd0649d92.jpg?1",
             "name": "Graveshifter",
             "text": "Changeling (This card is every creature type.)\nWhen Graveshifter enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "2e1e08bb-4896-5ffe-924a-05114838623f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888b4b76-6af9-4479-8cfd-cde3b8694fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888b4b76-6af9-4479-8cfd-cde3b8694fe5.jpg?1",
             "name": "Headless Specter",
             "text": "Flying\nHellbent \u2014 Whenever Headless Specter deals combat damage to a player, if you have no cards in hand, that player discards a card at random.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "1d6e0a0f-9b28-5ac0-84c7-8e88a8938faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ccb0a-5e73-462e-a035-87d4dac59779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ccb0a-5e73-462e-a035-87d4dac59779.jpg?1",
             "name": "Mind Rake",
             "text": "Target player discards two cards.\nOverload {1}{B} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "1bd21467-c325-546f-9318-7a1cdef54423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c216e13-3779-4734-b481-9aad7aba9925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c216e13-3779-4734-b481-9aad7aba9925.jpg?1",
             "name": "Mob",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "3f1295c5-b09a-5eb1-9bd2-ef5edee7c3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1f3e1-d986-4c0b-850e-5e8f2eaa0642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1f3e1-d986-4c0b-850e-5e8f2eaa0642.jpg?1",
             "name": "Nether Spirit",
             "text": "At the beginning of your upkeep, if Nether Spirit is the only creature card in your graveyard, you may return Nether Spirit to the battlefield.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "5d6bfc24-5a0a-542f-a754-e5cc5d7d7282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be60eb-15ec-4112-919c-995062a9ed54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be60eb-15ec-4112-919c-995062a9ed54.jpg?1",
             "name": "Ninja of the New Moon",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "cd20f4cc-912a-52d5-82ec-958b44f89ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f32b0e9-5eb2-4b26-8c06-5d4561f0295d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f32b0e9-5eb2-4b26-8c06-5d4561f0295d.jpg?1",
             "name": "Plague Engineer",
             "text": "Deathtouch\nAs Plague Engineer enters the battlefield, choose a creature type.\nCreatures of the chosen type your opponents control get -1/-1.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "42a0ce6e-53dc-5acb-86b7-4f134d2046f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333406d5-abcc-4629-a33b-395d0662ba1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333406d5-abcc-4629-a33b-395d0662ba1b.jpg?1",
             "name": "Putrid Goblin",
             "text": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "fb14fa55-29d8-574f-bc28-063c3d3d81f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a05edf6-ade4-4052-924d-6057faa51693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a05edf6-ade4-4052-924d-6057faa51693.jpg?1",
             "name": "Rank Officer",
             "text": "When Rank Officer enters the battlefield, you may discard a card. If you do, create a 2/2 black Zombie creature token.\n{1}{B}, {T}, Exile a creature card from your graveyard: Each opponent loses 2 life.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "03b00e5d-e96f-5be8-bb31-387a23579a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b547513d-8b69-41cd-84c9-4b08b6426f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b547513d-8b69-41cd-84c9-4b08b6426f1d.jpg?1",
             "name": "Ransack the Lab",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "359f84cf-4e79-57a1-a172-e7ebd7dce0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6db664e-f0c4-4e60-add7-89b9f210cbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6db664e-f0c4-4e60-add7-89b9f210cbc7.jpg?1",
             "name": "Return from Extinction",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return two target creature cards that share a creature type from your graveyard to your hand.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "e465962f-dea6-53b4-b34c-001c21c39af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64080d0d-163b-450d-8919-79a0465f3645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64080d0d-163b-450d-8919-79a0465f3645.jpg?1",
             "name": "Sadistic Obsession",
             "text": "Enchant creature\nEnchanted creature has \"{B}, {T}: Put a -1/-1 counter on target creature.\"",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "2f68d0a9-2f6b-5d92-93c1-269730f4d093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f224f64-513f-4c01-9b1b-bb89e366f1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f224f64-513f-4c01-9b1b-bb89e366f1c4.jpg?1",
             "name": "Shatter Assumptions",
             "text": "Choose one \u2014\n\u2022 Target opponent reveals their hand and discards all colorless nonland cards.\n\u2022 Target opponent reveals their hand and discards all multicolored cards.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "aa3a3b85-74f0-5e00-9d82-50ec4da29613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c37d70-799d-464a-972c-11a78ae31272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c37d70-799d-464a-972c-11a78ae31272.jpg?1",
             "name": "Silumgar Scavenger",
             "text": "Flying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhenever another creature you control dies, put a +1/+1 counter on Silumgar Scavenger. It gains haste until end of turn if it exploited that creature.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "7edee90d-2ed7-5f60-b2b9-f60a4307e630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82aec21-441b-4fcd-b666-61723bd79531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82aec21-441b-4fcd-b666-61723bd79531.jpg?1",
             "name": "Sling-Gang Lieutenant",
             "text": "When Sling-Gang Lieutenant enters the battlefield, create two 1/1 red Goblin creature tokens.\nSacrifice a Goblin: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3647,7 +3647,7 @@
         },
         {
             "id": "29b73da6-2bb7-567f-8214-9be5276e909f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa3e132-125a-492f-aab7-c560ea36b779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa3e132-125a-492f-aab7-c560ea36b779.jpg?1",
             "name": "Smiting Helix",
             "text": "Smiting Helix deals 3 damage to any target and you gain 3 life.\nFlashback {R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3681,7 +3681,7 @@
         },
         {
             "id": "4a38a9df-9dcb-5a6b-b2b1-37f1d251dd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07b3736-25e7-46f2-bea5-543ec13995b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07b3736-25e7-46f2-bea5-543ec13995b1.jpg?1",
             "name": "Throatseeker",
             "text": "Unblocked attacking Ninjas you control have lifelink.",
             "colours": [
@@ -3716,7 +3716,7 @@
         },
         {
             "id": "d63132d6-b995-52db-8879-6e75ebbad4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbb742-0317-4266-bcf5-cfea8d21f108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbb742-0317-4266-bcf5-cfea8d21f108.jpg?1",
             "name": "Umezawa's Charm",
             "text": "Choose one \u2014\n\u2022 Target creature gets +2/+2 until end of turn.\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 You gain 2 life.",
             "colours": [
@@ -3748,7 +3748,7 @@
         },
         {
             "id": "a31a30f1-f300-5b9f-aa0b-edb4e7ccada8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3049e-9397-4bef-914b-e9664661419c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3049e-9397-4bef-914b-e9664661419c.jpg?1",
             "name": "Undead Augur",
             "text": "Whenever Undead Augur or another Zombie you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "bf4feb3e-b558-5217-bea2-c4450b1cc27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62abd0c-ec3e-45d7-989d-da269812aeef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62abd0c-ec3e-45d7-989d-da269812aeef.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "f3dddb73-8f41-5026-af95-4119337ae836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a1d73-d102-469b-82ca-ec18f616375e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a1d73-d102-469b-82ca-ec18f616375e.jpg?1",
             "name": "Venomous Changeling",
             "text": "Changeling (This card is every creature type.)\nDeathtouch",
             "colours": [
@@ -3849,7 +3849,7 @@
         },
         {
             "id": "6ced6272-7077-539b-9401-5944d8b92255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d4dd61-cc7e-4fc5-afce-73a4b326cfdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d4dd61-cc7e-4fc5-afce-73a4b326cfdb.jpg?1",
             "name": "Warteye Witch",
             "text": "Whenever Warteye Witch or another creature you control dies, scry 1.",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "af7df0aa-b3a1-54ea-a1e6-881d1aa8663a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690cbcc-f8fd-41f7-9e28-e61c12b04014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690cbcc-f8fd-41f7-9e28-e61c12b04014.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "ff8c65bc-90f9-5347-abfb-8716dab1d846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54423c1-ebea-4b5c-b563-1d14c104eb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54423c1-ebea-4b5c-b563-1d14c104eb91.jpg?1",
             "name": "Alpine Guide",
             "text": "When Alpine Guide enters the battlefield, you may search your library for a Mountain card, put that card onto the battlefield tapped, then shuffle your library.\nAlpine Guide attacks each combat if able.\nWhen Alpine Guide leaves the battlefield, sacrifice a Mountain.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "5c67b1c5-b9aa-5eeb-b400-de9f955eafd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a96eb1-f87c-4b1d-82c7-f239bcbc62b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a96eb1-f87c-4b1d-82c7-f239bcbc62b8.jpg?1",
             "name": "Aria of Flame",
             "text": "When Aria of Flame enters the battlefield, each opponent gains 10 life.\nWhenever you cast an instant or sorcery spell, put a verse counter on Aria of Flame, then it deals damage equal to the number of verse counters on it to target player or planeswalker.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "88b101c7-90b2-528d-bc2e-a6fbd5a4a22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7066c9ab-9420-46f9-a6c7-ce4d5273e2fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7066c9ab-9420-46f9-a6c7-ce4d5273e2fa.jpg?1",
             "name": "Bladeback Sliver",
             "text": "Hellbent \u2014 As long as you have no cards in hand, Sliver creatures you control have \"{T}: This creature deals 1 damage to target player or planeswalker.\"",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "3f1e2733-bf77-5c0a-b801-4f862b903af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb81f44-8f22-4d28-a452-a50bef69a3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb81f44-8f22-4d28-a452-a50bef69a3e3.jpg?1",
             "name": "Bogardan Dragonheart",
             "text": "Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.",
             "colours": [
@@ -4059,7 +4059,7 @@
         },
         {
             "id": "cba431dc-f8fe-5719-a0ad-abeec2b3ac5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b657f0-6636-4d8a-9176-81027816e0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b657f0-6636-4d8a-9176-81027816e0ec.jpg?1",
             "name": "Cleaving Sliver",
             "text": "Sliver creatures you control get +2/+0.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "701ccf86-db93-5492-b9bb-b2093e2fd123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b8f98-ee51-4c94-a3eb-c79eb2b50d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b8f98-ee51-4c94-a3eb-c79eb2b50d78.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to any target.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "79c86f85-a790-5cfa-a796-fd0096c6aa23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3c0d8-0a3e-43b0-b81e-a3d22ce6a4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3c0d8-0a3e-43b0-b81e-a3d22ce6a4b2.jpg?1",
             "name": "Fists of Flame",
             "text": "Draw a card. Until end of turn, target creature gains trample and gets +1/+0 for each card you've drawn this turn.",
             "colours": [
@@ -4157,7 +4157,7 @@
         },
         {
             "id": "1487e6a5-e384-5475-a5b8-007ab33996ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa2d10-3725-4b3a-94fe-3c6648db9a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa2d10-3725-4b3a-94fe-3c6648db9a2a.jpg?1",
             "name": "Force of Rage",
             "text": "If it's not your turn, you may exile a red card from your hand rather than pay this spell's mana cost.\nCreate two 3/1 red Elemental creature tokens with trample and haste. Sacrifice those tokens at the beginning of your next upkeep.",
             "colours": [
@@ -4189,7 +4189,7 @@
         },
         {
             "id": "bfe60f2c-9d7b-57e7-8874-38832aaef00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b67031-76b8-4511-a6dc-433d9450496e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b67031-76b8-4511-a6dc-433d9450496e.jpg?1",
             "name": "Geomancer's Gambit",
             "text": "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle their library.\nDraw a card.",
             "colours": [
@@ -4221,7 +4221,7 @@
         },
         {
             "id": "78fd346b-0ba8-596f-9917-a5d576f4b831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d4928-e976-4c7c-ba09-cce95d1797b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d4928-e976-4c7c-ba09-cce95d1797b2.jpg?1",
             "name": "Goatnap",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If that creature is a Goat, it also gets +3/+0 until end of turn.",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "68ef70e2-d4dd-593d-b03b-6c50e542f422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543660a-6797-4719-bbe7-ff6e40709599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543660a-6797-4719-bbe7-ff6e40709599.jpg?1",
             "name": "Goblin Champion",
             "text": "Haste\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "89e56452-be00-5008-b088-189fbba2ec6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c4d47-5252-40af-961d-c08bc688028a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c4d47-5252-40af-961d-c08bc688028a.jpg?1",
             "name": "Goblin Engineer",
             "text": "When Goblin Engineer enters the battlefield, you may search your library for an artifact card, put it into your graveyard, then shuffle your library.\n{R}, {T}, Sacrifice an artifact: Return target artifact card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "6584eb09-166f-5759-95b9-a826ca9b33bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092e6db-1196-43bf-b7c9-07498fa7ca90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092e6db-1196-43bf-b7c9-07498fa7ca90.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "b6e664da-c469-5116-814e-eadf0f1188c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ec7cbe-16a0-4dbb-91fe-7e445a5268c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ec7cbe-16a0-4dbb-91fe-7e445a5268c8.jpg?1",
             "name": "Goblin Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -4389,7 +4389,7 @@
         },
         {
             "id": "783d45c3-d2d3-55bf-b9ff-05185294c74c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4155d1-0a87-4d2c-a1a0-06b2553eaae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4155d1-0a87-4d2c-a1a0-06b2553eaae4.jpg?1",
             "name": "Goblin War Party",
             "text": "Choose one \u2014\n\u2022 Create three 1/1 red Goblin creature tokens.\n\u2022 Creatures you control get +1/+1 and gain haste until end of turn.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "f4dbe19d-ffde-5991-bc45-c83245365258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f05b162-90aa-4c95-903f-775a17d20359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f05b162-90aa-4c95-903f-775a17d20359.jpg?1",
             "name": "Hollowhead Sliver",
             "text": "Sliver creatures you control have \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "58f2e1da-9796-5750-b5e1-75dcb59db63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf524-5322-4287-ac49-face12655874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf524-5322-4287-ac49-face12655874.jpg?1",
             "name": "Igneous Elemental",
             "text": "This spell costs {2} less to cast if there is a land card in your graveyard.\nWhen Igneous Elemental enters the battlefield, you may have it deal 2 damage to target creature.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "223dc54a-32f3-5b9e-91ba-7c3d6aa6cd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16dd041-451d-4914-8c46-aa315a90d802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16dd041-451d-4914-8c46-aa315a90d802.jpg?1",
             "name": "Lava Dart",
             "text": "Lava Dart deals 1 damage to any target.\nFlashback\u2014\nSacrifice a Mountain. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "8d06f8df-2bc8-5662-ab54-fcde5b632e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db1674-d72b-4c1f-b436-490e5363bee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db1674-d72b-4c1f-b436-490e5363bee7.jpg?1",
             "name": "Magmatic Sinkhole",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nMagmatic Sinkhole deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "50a9c918-b886-5ade-b964-bc683ab8d800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea32e5-b164-4a8d-9312-c35ae5cd8b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea32e5-b164-4a8d-9312-c35ae5cd8b2a.jpg?1",
             "name": "Orcish Hellraiser",
             "text": "Echo {R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Orcish Hellraiser dies, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "15dcea20-41fd-5658-a651-4c9d817e76b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789333b-21ee-4613-8eba-52a719b0f1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789333b-21ee-4613-8eba-52a719b0f1e5.jpg?1",
             "name": "Ore-Scale Guardian",
             "text": "This spell costs {1} less to cast for each land card in your graveyard.\nFlying, haste",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "3ea708ba-1942-572a-9bc0-f23740b3cb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11616853-34b1-4bb1-9590-461e12970ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11616853-34b1-4bb1-9590-461e12970ec3.jpg?1",
             "name": "Pashalik Mons",
             "text": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "25b757a3-e699-5a73-aef8-b8f524d1380f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd06d55-a40f-4b0e-905b-3cd0ce12eb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd06d55-a40f-4b0e-905b-3cd0ce12eb82.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -4691,7 +4691,7 @@
         },
         {
             "id": "6e45e58e-60d5-5d26-9df8-a2444eab5a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fb9418-a22b-4f92-b494-f68c29bcb92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fb9418-a22b-4f92-b494-f68c29bcb92a.jpg?1",
             "name": "Planebound Accomplice",
             "text": "{R}: You may put a planeswalker card from your hand onto the battlefield. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "af86452b-0066-5477-a21d-5e1b91b166dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02b3f1-d70f-4e44-bc1c-7fc90ec611dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02b3f1-d70f-4e44-bc1c-7fc90ec611dc.jpg?1",
             "name": "Pyrophobia",
             "text": "Pyrophobia deals 3 damage to target creature. Cowards can't block this turn.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "b48bb565-434b-59d9-9f5a-bc6108f2ff58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573ee0-156a-4bf3-95eb-5e7b63c638e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573ee0-156a-4bf3-95eb-5e7b63c638e7.jpg?1",
             "name": "Quakefoot Cyclops",
             "text": "When Quakefoot Cyclops enters the battlefield, up to two target creatures can't block this turn.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Quakefoot Cyclops, target creature can't block this turn.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "8fc9b897-cfe9-57db-bf49-a23c8d70b29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52337d8d-e0ee-4229-848d-9bbd989e15b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52337d8d-e0ee-4229-848d-9bbd989e15b7.jpg?1",
             "name": "Ravenous Giant",
             "text": "At the beginning of your upkeep, Ravenous Giant deals 1 damage to you.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "999b0738-ecc7-5d12-a802-aca8800d4ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754a8db-060e-470f-94c0-37f12d82978a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754a8db-060e-470f-94c0-37f12d82978a.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4858,7 +4858,7 @@
         },
         {
             "id": "e9d00cb3-a8e9-57d3-a65a-8ae8a96ffe5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e139ad1-1079-49e9-babd-6399c44ad333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e139ad1-1079-49e9-babd-6399c44ad333.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -4893,7 +4893,7 @@
         },
         {
             "id": "91128ce7-eafb-5d6a-9c72-42f9bb9bc7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580c6fe2-ab43-491e-a1b2-d076a5c2a74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580c6fe2-ab43-491e-a1b2-d076a5c2a74e.jpg?1",
             "name": "Shenanigans",
             "text": "Destroy target artifact.\nDredge 1 (If you would draw a card, instead you may put exactly one card from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "cb1e8b86-5924-5b28-b467-c24da0ffd01d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b9479d-7b6a-40c8-94ea-fdf0ec980b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b9479d-7b6a-40c8-94ea-fdf0ec980b42.jpg?1",
             "name": "Spinehorn Minotaur",
             "text": "As long as you've drawn two or more cards this turn, Spinehorn Minotaur has double strike.",
             "colours": [
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "baedc703-1c8d-5277-b0a5-5f5d507b47c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506d58f-9825-4384-9012-1d037543fb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506d58f-9825-4384-9012-1d037543fb59.jpg?1",
             "name": "Spiteful Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker.\"",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "d976a0fe-fc4d-56d6-8165-eb8c7d476205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36223e7e-bfa7-4393-b2a4-047f1dd30b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36223e7e-bfa7-4393-b2a4-047f1dd30b93.jpg?1",
             "name": "Tectonic Reformation",
             "text": "Each land card in your hand has cycling {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "55218336-e6fc-5c10-880f-c354c7f449e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02cc57-f589-4c5d-b306-cceb0ab3ce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02cc57-f589-4c5d-b306-cceb0ab3ce8b.jpg?1",
             "name": "Throes of Chaos",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -5058,7 +5058,7 @@
         },
         {
             "id": "cd18bdb4-0d54-53df-9156-904153fa60d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c91e364-c157-494e-bb1b-f2cef004900f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c91e364-c157-494e-bb1b-f2cef004900f.jpg?1",
             "name": "Urza's Rage",
             "text": "Kicker {8}{R} (You may pay an additional {8}{R} as you cast this spell.)\nThis spell can't be countered.\nUrza's Rage deals 3 damage to any target. If this spell was kicked, instead it deals 10 damage to that permanent or player and the damage can't be prevented.",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "e369423d-53cb-5517-a162-4869a3213236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265d65e-3f26-46d9-8b8b-e75048a02e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265d65e-3f26-46d9-8b8b-e75048a02e95.jpg?1",
             "name": "Vengeful Devil",
             "text": "Haste\nMorbid \u2014 {T}: Vengeful Devil deals 1 damage to any target. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "4ac7d18b-d002-5e57-8170-6b12f45ec0f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d1def0-1450-44ec-b7c4-0fa50fe12c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d1def0-1450-44ec-b7c4-0fa50fe12c15.jpg?1",
             "name": "Viashino Sandsprinter",
             "text": "Trample, haste\nAt the beginning of the end step, return Viashino Sandsprinter to its owner's hand. (Return it only if it's on the battlefield.)\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "e2da36bd-2c48-59bc-a672-8d3babc49ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb119b-dd15-40d2-8f75-c92f5d41d1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb119b-dd15-40d2-8f75-c92f5d41d1e1.jpg?1",
             "name": "Volatile Claws",
             "text": "Until end of turn, creatures you control get +2/+0 and gain all creature types.",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "a2ad1ffd-50e3-5205-8f5f-0194a38cf012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046dfb0-9ca3-4219-a6b0-d7503bc2fbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046dfb0-9ca3-4219-a6b0-d7503bc2fbd0.jpg?1",
             "name": "Ayula, Queen Among Bears",
             "text": "Whenever another Bear enters the battlefield under your control, choose one \u2014\n\u2022 Put two +1/+1 counters on target Bear.\n\u2022 Target Bear you control fights target creature you don't control.",
             "colours": [
@@ -5227,7 +5227,7 @@
         },
         {
             "id": "52673fa7-e826-553b-8e0b-26788770deff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg?1",
             "name": "Ayula's Influence",
             "text": "Discard a land card: Create a 2/2 green Bear creature token.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "05555154-b595-5a3c-93a3-199b17ac16a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6cf54-79ff-44e8-af83-786fd72867dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6cf54-79ff-44e8-af83-786fd72867dd.jpg?1",
             "name": "Bellowing Elk",
             "text": "As long as you had another creature enter the battlefield under your control this turn, Bellowing Elk has trample and indestructible.",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "6325de3c-6b1e-5490-9fa1-9b1ad3f1fafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085107a2-c1ec-473c-81d8-23e5a7197776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085107a2-c1ec-473c-81d8-23e5a7197776.jpg?1",
             "name": "Collector Ouphe",
             "text": "Activated abilities of artifacts can't be activated.",
             "colours": [
@@ -5327,7 +5327,7 @@
         },
         {
             "id": "87b68b24-3aec-5b96-a2ab-3eba622e095c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f99d23-5d3e-4f36-b1c7-3a893e4b4c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f99d23-5d3e-4f36-b1c7-3a893e4b4c32.jpg?1",
             "name": "Conifer Wurm",
             "text": "Trample\n{3}{G}: Conifer Wurm gets +X/+X until end of turn, where X is the number of snow permanents you control.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "65d0d52f-aa9d-5d20-bae9-a7997f1c1bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg?1",
             "name": "Crashing Footfalls",
             "text": "Suspend 4\u2014{G} (Rather than cast this card from your hand, pay {G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nCreate two 4/4 green Rhino creature tokens with trample.",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "7d2a984a-beb2-53c6-b687-a55811cf9c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287775f-7bec-4e8f-bb8d-daf5ce92e4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287775f-7bec-4e8f-bb8d-daf5ce92e4a8.jpg?1",
             "name": "Deep Forest Hermit",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deep Forest Hermit enters the battlefield, create four 1/1 green Squirrel creature tokens.\nSquirrels you control get +1/+1.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "4959b143-a8f8-5915-a488-dec5223c6323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a24943-0121-4c64-9624-2e4cff37e6ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a24943-0121-4c64-9624-2e4cff37e6ca.jpg?1",
             "name": "Elvish Fury",
             "text": "Buyback {4} (You may pay an additional {4} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "f9e7ef93-a694-563c-a422-b5ca9cff781b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d315-5790-417d-adf5-270df1ff34b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d315-5790-417d-adf5-270df1ff34b0.jpg?1",
             "name": "Excavating Anurid",
             "text": "When Excavating Anurid enters the battlefield, you may sacrifice a land. If you do, draw a card.\nThreshold \u2014 As long as seven or more cards are in your graveyard, Excavating Anurid gets +1/+1 and has vigilance.",
             "colours": [
@@ -5497,7 +5497,7 @@
         },
         {
             "id": "e9a04f5c-0d20-5794-aa62-94220e8114ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg?1",
             "name": "Force of Vigor",
             "text": "If it's not your turn, you may exile a green card from your hand rather than pay this spell's mana cost.\nDestroy up to two target artifacts and/or enchantments.",
             "colours": [
@@ -5529,7 +5529,7 @@
         },
         {
             "id": "af2870fc-609c-5c80-a2ad-97f52922d3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4fc18-6f2c-45e4-a2c7-c2068b4f1a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4fc18-6f2c-45e4-a2c7-c2068b4f1a92.jpg?1",
             "name": "Frostwalla",
             "text": "{S}: Frostwalla gets +2/+2 until end of turn. Activate this ability only once each turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "40ce5d37-9d88-523e-8270-8584524cd694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b741d88-513a-4f47-a4fd-af42c5e44b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b741d88-513a-4f47-a4fd-af42c5e44b6d.jpg?1",
             "name": "Genesis",
             "text": "At the beginning of your upkeep, if Genesis is in your graveyard, you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5599,7 +5599,7 @@
         },
         {
             "id": "703b529e-6791-5ba9-9f76-3e673ee2d9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615a5e9-deec-46cc-9444-de81cb0da9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615a5e9-deec-46cc-9444-de81cb0da9c0.jpg?1",
             "name": "Glacial Revelation",
             "text": "Reveal the top six cards of your library. You may put any number of snow permanent cards from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "3b494fa8-3f74-5b03-b724-0a6eaba5cdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f5cc05-5d9d-4709-b3c5-a6249c294acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f5cc05-5d9d-4709-b3c5-a6249c294acc.jpg?1",
             "name": "Hexdrinker",
             "text": "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 3-7\n4/4\nProtection from instants\nLEVEL 8+\n6/6\nProtection from everything",
             "colours": [
@@ -5665,7 +5665,7 @@
         },
         {
             "id": "6b880c14-f27f-52d7-a1a1-0ac890a182dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391ba8b-7d9a-4077-8eeb-1b2ced14d973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391ba8b-7d9a-4077-8eeb-1b2ced14d973.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle your library. (Do this before you draw.)",
             "colours": [
@@ -5700,7 +5700,7 @@
         },
         {
             "id": "1b1f89e1-bdf7-5690-aecb-bc4247e467c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d3d8d-e78b-40b8-aed5-888a2d0baa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d3d8d-e78b-40b8-aed5-888a2d0baa60.jpg?1",
             "name": "Llanowar Tribe",
             "text": "{T}: Add {G}{G}{G}.",
             "colours": [
@@ -5735,7 +5735,7 @@
         },
         {
             "id": "38d99cde-cc2b-5914-93e7-b7b902545198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efae4d84-8134-461a-a352-a5bdff7259a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efae4d84-8134-461a-a352-a5bdff7259a7.jpg?1",
             "name": "Mother Bear",
             "text": "{3}{G}{G}, Exile Mother Bear from your graveyard: Create two 2/2 green Bear creature tokens. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -5769,7 +5769,7 @@
         },
         {
             "id": "cb4f93b2-f08c-58db-b7d8-000572d3f3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480ddde1-81d3-4939-b232-cb1ced6cfc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480ddde1-81d3-4939-b232-cb1ced6cfc4d.jpg?1",
             "name": "Murasa Behemoth",
             "text": "Trample\nMurasa Behemoth gets +3/+3 as long as there is a land card in your graveyard.",
             "colours": [
@@ -5803,7 +5803,7 @@
         },
         {
             "id": "be55fe9a-70c3-538c-a126-767252899bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a7e43a-4028-41e5-b5dd-be8ef6a1b510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a7e43a-4028-41e5-b5dd-be8ef6a1b510.jpg?1",
             "name": "Nantuko Cultivator",
             "text": "When Nantuko Cultivator enters the battlefield, you may discard any number of land cards. Put that many +1/+1 counters on Nantuko Cultivator and draw that many cards.",
             "colours": [
@@ -5838,7 +5838,7 @@
         },
         {
             "id": "07822b6e-3994-580c-8a54-7f8c2ac99b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6374ad-71be-422e-bd76-4f08fbf43048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6374ad-71be-422e-bd76-4f08fbf43048.jpg?1",
             "name": "Nimble Mongoose",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nThreshold \u2014 Nimble Mongoose gets +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "243062be-c978-5130-8985-325accc87ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771fc5d-b9a1-4637-8241-3f54616b64af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771fc5d-b9a1-4637-8241-3f54616b64af.jpg?1",
             "name": "Regrowth",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "43c3e889-eef0-5be7-a0e0-b0fa3fa71745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce0ab73-4df6-479f-8710-61ef87cce3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce0ab73-4df6-479f-8710-61ef87cce3b4.jpg?1",
             "name": "Rime Tender",
             "text": "{T}: Untap another target snow permanent.",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "ed027ec2-60ec-5feb-9b5d-698058a2fe50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8491f-9c51-41c0-994e-d3f0f5f6a411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8491f-9c51-41c0-994e-d3f0f5f6a411.jpg?1",
             "name": "Saddled Rimestag",
             "text": "Saddled Rimestag gets +2/+2 as long as you had another creature enter the battlefield under your control this turn.",
             "colours": [
@@ -5977,7 +5977,7 @@
         },
         {
             "id": "847842c2-0f79-5567-ba6c-57ad49b1561a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7e77c-ede5-41bd-b766-9a76ce691607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7e77c-ede5-41bd-b766-9a76ce691607.jpg?1",
             "name": "Savage Swipe",
             "text": "Target creature you control gets +2/+2 until end of turn if its power is 2. Then it fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "0190c529-444c-5425-b85e-6e8492220123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d9bae-2753-486c-be79-2438208ac353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d9bae-2753-486c-be79-2438208ac353.jpg?1",
             "name": "Scale Up",
             "text": "Until end of turn, target creature you control becomes a green Wurm with base power and toughness 6/4.\nOverload {4}{G}{G} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "949fece0-2493-5b2e-a517-c806cb403f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42fd52-34ea-4d1b-80dc-58fb0593bb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42fd52-34ea-4d1b-80dc-58fb0593bb5b.jpg?1",
             "name": "Spore Frog",
             "text": "Sacrifice Spore Frog: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "654d2880-0526-5a4e-86f1-9672876dbd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6161d2ed-7cff-4c90-9e74-1d179a6c1498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6161d2ed-7cff-4c90-9e74-1d179a6c1498.jpg?1",
             "name": "Springbloom Druid",
             "text": "When Springbloom Druid enters the battlefield, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "1d12e001-2ba5-595d-be2d-08d31dbf2de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914d43c-bc5a-47c5-a01c-59ddb1ee8eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914d43c-bc5a-47c5-a01c-59ddb1ee8eca.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "5664c69f-10a5-5e43-9073-d43093e69a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69026075-adfa-48b0-b30e-04b0a76904c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69026075-adfa-48b0-b30e-04b0a76904c3.jpg?1",
             "name": "Tempered Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.\"",
             "colours": [
@@ -6178,7 +6178,7 @@
         },
         {
             "id": "6121a776-2f11-558c-9881-67acbb0665f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadffd6b-d707-4fc5-a600-44eb9124b195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadffd6b-d707-4fc5-a600-44eb9124b195.jpg?1",
             "name": "Thornado",
             "text": "Destroy target creature with flying.\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "aa1121c3-bc14-548e-a92a-7a3ee5d218b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677166cf-4e1e-43ac-a67b-afaf33c0d14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677166cf-4e1e-43ac-a67b-afaf33c0d14e.jpg?1",
             "name": "Treefolk Umbra",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and assigns combat damage equal to its toughness rather than its power.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "bffa81a2-e5ce-5cf0-bd4f-6e7d2b15a204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1722a55-850c-4924-be98-45539f4676a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1722a55-850c-4924-be98-45539f4676a2.jpg?1",
             "name": "Treetop Ambusher",
             "text": "Dash {1}{G} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)\nWhenever Treetop Ambusher attacks, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "7763d98e-d8d3-53eb-9aeb-2a411d201156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f3b68e-f616-4687-bc2d-075165162cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f3b68e-f616-4687-bc2d-075165162cd1.jpg?1",
             "name": "Trumpeting Herd",
             "text": "Create a 3/3 green Elephant creature token.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6311,7 +6311,7 @@
         },
         {
             "id": "38858409-ca21-5278-b343-18f76f86ca8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf3188c-879b-4b18-88b4-6237d7162271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf3188c-879b-4b18-88b4-6237d7162271.jpg?1",
             "name": "Twin-Silk Spider",
             "text": "Reach\nWhen Twin-Silk Spider enters the battlefield, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "8c7ec91f-91d0-5d95-923d-b6a20efc3825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f594d07-932e-4fe6-832d-d0a0be3530aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f594d07-932e-4fe6-832d-d0a0be3530aa.jpg?1",
             "name": "Unbound Flourishing",
             "text": "Whenever you cast a permanent spell with a mana cost that contains {X}, double the value of X.\nWhenever you cast an instant or sorcery spell or activate an ability, if that spell's mana cost or that ability's activation cost contains {X}, copy that spell or ability. You may choose new targets for the copy.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "78745b7c-47df-53d3-9401-06f9d3e5a117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ef5786-7786-4418-b245-038b58fd7123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ef5786-7786-4418-b245-038b58fd7123.jpg?1",
             "name": "Wall of Blossoms",
             "text": "Defender\nWhen Wall of Blossoms enters the battlefield, draw a card.",
             "colours": [
@@ -6412,7 +6412,7 @@
         },
         {
             "id": "0f80489e-a99a-5b99-a98f-5e46a1c084d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a9fa51-78c3-42e6-8c2e-39658f59ed87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a9fa51-78c3-42e6-8c2e-39658f59ed87.jpg?1",
             "name": "Weather the Storm",
             "text": "You gain 3 life.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "372b1cfc-428e-5ae7-abc8-ff18301b2df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91571765-8da8-49f9-a776-7778d86cfb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91571765-8da8-49f9-a776-7778d86cfb99.jpg?1",
             "name": "Webweaver Changeling",
             "text": "Changeling (This card is every creature type.)\nReach\nWhen Webweaver Changeling enters the battlefield, if there are three or more creature cards in your graveyard, you gain 5 life.",
             "colours": [
@@ -6478,7 +6478,7 @@
         },
         {
             "id": "8ca67e47-2a30-5b03-aa5f-74cca2f81104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d9776-b6ce-4ad6-8acc-69115ba5de76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d9776-b6ce-4ad6-8acc-69115ba5de76.jpg?1",
             "name": "Winding Way",
             "text": "Choose creature or land. Reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -6510,7 +6510,7 @@
         },
         {
             "id": "e72320c5-aa3a-5fd9-88d0-56f0d71f9e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eddb834-ea01-44e2-afca-bd9a4ebbdb94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eddb834-ea01-44e2-afca-bd9a4ebbdb94.jpg?1",
             "name": "Abominable Treefolk",
             "text": "Trample\nAbominable Treefolk's power and toughness are each equal to the number of snow permanents you control.\nWhen Abominable Treefolk enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "c962ac68-e335-5ae0-b20f-f697622325d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933191-dad6-43d5-b02e-a94ad8033f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933191-dad6-43d5-b02e-a94ad8033f2f.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "Sliver creatures you control have flying and haste.",
             "colours": [
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "46f38cd4-d64a-5177-a63e-67c4dce6d515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1d0ac1-e805-4213-a46e-cf124680d082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1d0ac1-e805-4213-a46e-cf124680d082.jpg?1",
             "name": "Collected Conjuring",
             "text": "Exile the top six cards of your library. You may cast up to two sorcery cards with converted mana cost 3 or less from among them without paying their mana costs. Put the exiled cards not cast this way on the bottom of your library in a random order.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "e9336e26-040a-5ff1-9c27-520d85302b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea751fe2-b64a-4265-8885-a9016b29b5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea751fe2-b64a-4265-8885-a9016b29b5b3.jpg?1",
             "name": "Eladamri's Call",
             "text": "Search your library for a creature card, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "487feb56-2948-5e84-81c4-84600eb8307f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036ab83-94a3-4634-9f0a-dde7af3be450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036ab83-94a3-4634-9f0a-dde7af3be450.jpg?1",
             "name": "Etchings of the Chosen",
             "text": "As Etchings of the Chosen enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{1}, Sacrifice a creature of the chosen type: Target creature you control gains indestructible until end of turn.",
             "colours": [
@@ -6686,7 +6686,7 @@
         },
         {
             "id": "798004e0-32fe-5d27-af0f-421ee936bb3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900c9dfd-ece1-4b09-a801-0fa05e1994b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900c9dfd-ece1-4b09-a801-0fa05e1994b9.jpg?1",
             "name": "Fallen Shinobi",
             "text": "Ninjutsu {2}{U}{B} ({2}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Fallen Shinobi deals combat damage to a player, that player exiles the top two cards of their library. Until end of turn, you may play those cards without paying their mana costs.",
             "colours": [
@@ -6723,7 +6723,7 @@
         },
         {
             "id": "635067e9-a9a1-558f-adb5-18ca30cd8829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d4fbe1-8a2f-4958-bb85-1a1e5f1e8d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d4fbe1-8a2f-4958-bb85-1a1e5f1e8d87.jpg?1",
             "name": "The First Sliver",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nSliver spells you cast have cascade.",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "ae780ff2-fe02-5c52-b3af-fd7cb75a115c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d68905-e13e-4751-b028-90c795c11cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d68905-e13e-4751-b028-90c795c11cd5.jpg?1",
             "name": "Good-Fortune Unicorn",
             "text": "Whenever another creature enters the battlefield under your control, put a +1/+1 counter on that creature.",
             "colours": [
@@ -6803,7 +6803,7 @@
         },
         {
             "id": "6157b0c4-d9da-58ef-b828-fadaa2e7aeae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0049e68d-0caf-474f-9523-dad343f1250a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0049e68d-0caf-474f-9523-dad343f1250a.jpg?1",
             "name": "Hogaak, Arisen Necropolis",
             "text": "You can't spend mana to cast this spell.\nConvoke, delve (Each creature you tap while casting this spell pays for {1} or one mana of that creature's color. Each card you exile from your graveyard pays for {1}.)\nYou may cast Hogaak, Arisen Necropolis from your graveyard.\nTrample",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "1a455a84-993f-5009-bccf-934799fcf297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a55cfed-e76c-4ade-ac78-a546e05fe8da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a55cfed-e76c-4ade-ac78-a546e05fe8da.jpg?1",
             "name": "Ice-Fang Coatl",
             "text": "Flash\nFlying\nWhen Ice-Fang Coatl enters the battlefield, draw a card.\nIce-Fang Coatl has deathtouch as long as you control at least three other snow permanents.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "87f317b5-3564-5c3d-a386-7503ed71f12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919cd266-b796-4a1c-937f-76b565c82495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919cd266-b796-4a1c-937f-76b565c82495.jpg?1",
             "name": "Ingenious Infiltrator",
             "text": "Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "403deb98-804a-593e-9b9f-ccc1c3e0d62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bd74b-c458-49d6-90ac-6075454e43dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bd74b-c458-49d6-90ac-6075454e43dd.jpg?1",
             "name": "Kaya's Guile",
             "text": "Choose two \u2014\n\u2022 Each opponent sacrifices a creature.\n\u2022 Exile all cards from each opponent's graveyard.\n\u2022 Create a 1/1 white and black Spirit creature token with flying.\n\u2022 You gain 4 life.\nEntwine {3} (Choose all if you pay the entwine cost.)",
             "colours": [
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "d9e9a2de-baca-5e66-86fb-f56d6d090272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3651483f-6077-4b4e-b2c7-9d57f22c65dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3651483f-6077-4b4e-b2c7-9d57f22c65dc.jpg?1",
             "name": "Kess, Dissident Mage",
             "text": "Flying\nDuring each of your turns, you may cast an instant or sorcery card from your graveyard. If a card cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "91c8a396-bfd9-5591-bbae-0886734c437d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f0c9d6-cffc-4d8c-b455-e9feb8748aa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f0c9d6-cffc-4d8c-b455-e9feb8748aa7.jpg?1",
             "name": "Lavabelly Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, it deals 1 damage to target player or planeswalker and you gain 1 life.\"",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "8a59bed1-52b6-52ef-a93b-89e4090093f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5734012b-31db-4125-8fea-c88666969cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5734012b-31db-4125-8fea-c88666969cd6.jpg?1",
             "name": "Lightning Skelemental",
             "text": "Trample, haste\nWhenever Lightning Skelemental deals combat damage to a player, that player discards two cards.\nAt the beginning of the end step, sacrifice Lightning Skelemental.",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "69b54775-ac39-524e-b35c-533f3d238f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8572dfd-9da1-4727-b549-47f9b119f6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8572dfd-9da1-4727-b549-47f9b119f6ac.jpg?1",
             "name": "Munitions Expert",
             "text": "Flash\nWhen Munitions Expert enters the battlefield, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.",
             "colours": [
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "aab190b2-134e-5cb5-92c4-524c56aa95d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17cbf6-3f38-4bc6-8448-881e19cffe06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17cbf6-3f38-4bc6-8448-881e19cffe06.jpg?1",
             "name": "Nature's Chant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -7134,7 +7134,7 @@
         },
         {
             "id": "cfdc49c6-186c-5b14-9910-6a158b81807d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b7e59a-5302-4a73-816a-b759adff3ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b7e59a-5302-4a73-816a-b759adff3ee6.jpg?1",
             "name": "Reap the Past",
             "text": "Return X cards at random from your graveyard to your hand. Exile Reap the Past.",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "3e19523d-eafe-5614-aa7b-e6f4dca65e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cda35eb-ae42-43be-9015-3c468c7ebede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cda35eb-ae42-43be-9015-3c468c7ebede.jpg?1",
             "name": "Rotwidow Pack",
             "text": "Reach\n{3}{B}{G}, Exile a creature card from your graveyard: Create a 1/2 green Spider creature token with reach, then each opponent loses 1 life for each Spider you control.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "f7d2721f-77fe-54d6-8209-81a984ed6d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00ac82-a884-40c4-9d09-3190a1099726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00ac82-a884-40c4-9d09-3190a1099726.jpg?1",
             "name": "Ruination Rioter",
             "text": "When Ruination Rioter dies, you may have it deal damage to any target equal to the number of land cards in your graveyard.",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "520ded19-3038-5ad2-885f-870f4a267f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea23111b-ccc1-4d5c-a9d2-9db14c728820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea23111b-ccc1-4d5c-a9d2-9db14c728820.jpg?1",
             "name": "Soulherder",
             "text": "Whenever a creature is exiled from the battlefield, put a +1/+1 counter on Soulherder.\nAt the beginning of your end step, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "5d070e6b-b945-51fc-808f-11f5454fc5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28642fbe-90c8-4beb-9950-91af28d93326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28642fbe-90c8-4beb-9950-91af28d93326.jpg?1",
             "name": "Thundering Djinn",
             "text": "Flying\nWhenever Thundering Djinn attacks, it deals damage to any target equal to the number of cards you've drawn this turn.",
             "colours": [
@@ -7313,7 +7313,7 @@
         },
         {
             "id": "0e062c5e-803d-5c89-a85a-0f57677c5c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaea2e54-ee50-47b9-a2a5-e3353831248c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaea2e54-ee50-47b9-a2a5-e3353831248c.jpg?1",
             "name": "Unsettled Mariner",
             "text": "Changeling (This card is every creature type.)\nWhenever you or a permanent you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {1}.",
             "colours": [
@@ -7349,7 +7349,7 @@
         },
         {
             "id": "7d55b1c0-0586-5936-b039-07e7d5618a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a706ecf-3277-40e3-871c-4ba4ead16e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a706ecf-3277-40e3-871c-4ba4ead16e20.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "14170061-9bc4-58a8-a7fc-c61a3b6f61c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169356e0-46dc-4096-8e66-36726454f104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169356e0-46dc-4096-8e66-36726454f104.jpg?1",
             "name": "Altar of Dementia",
             "text": "Sacrifice a creature: Target player puts a number of cards equal to the sacrificed creature's power from the top of their library into their graveyard.",
             "colours": [],
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "73c95d0a-5d66-5493-b5b0-a105656be6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149ede-3201-451a-a640-d0c10b024dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149ede-3201-451a-a640-d0c10b024dbc.jpg?1",
             "name": "Amorphous Axe",
             "text": "Equipped creature gets +3/+0 and is every creature type.\nEquip {3}",
             "colours": [],
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "cdd2af65-c719-5ec1-8146-b0560b4b9979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2462fdf-a594-47d0-8e10-b55901e350d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2462fdf-a594-47d0-8e10-b55901e350d9.jpg?1",
             "name": "Arcum's Astrolabe",
             "text": "({S} can be paid with one mana from a snow permanent.)\nWhen Arcum's Astrolabe enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "c66345a9-b381-53f6-9fe4-ba881652cf0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345ee24-ffa3-44d1-a983-f25f54cda3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345ee24-ffa3-44d1-a983-f25f54cda3f3.jpg?1",
             "name": "Birthing Boughs",
             "text": "{4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling. (It has every creature type.)",
             "colours": [],
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "a4b45b47-ff89-51af-8633-abe953511fd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edafd52f-2dda-4981-baee-404f47ee8969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edafd52f-2dda-4981-baee-404f47ee8969.jpg?1",
             "name": "Farmstead Gleaner",
             "text": "Farmstead Gleaner doesn't untap during your untap step.\n{2}, {Q}: Put a +1/+1 counter on Farmstead Gleaner. ({Q} is the untap symbol.)",
             "colours": [],
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "8aae49ea-d8c8-5419-875e-fea09ebf76b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b022a628-4883-427a-8477-0e87d1a71028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b022a628-4883-427a-8477-0e87d1a71028.jpg?1",
             "name": "Fountain of Ichor",
             "text": "{T}: Add one mana of any color.\n{3}: Fountain of Ichor becomes a 3/3 Dinosaur artifact creature until end of turn.",
             "colours": [],
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "47ca1d09-fd28-5e01-bfb2-05aa0f161e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2671c36-96fa-49e3-90dc-52820b2c8a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2671c36-96fa-49e3-90dc-52820b2c8a62.jpg?1",
             "name": "Icehide Golem",
             "text": "({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "d5f1e8fe-92ab-501f-9d6f-a1c30ea5486f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c7cba5-6111-40ce-828a-e811301bb283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c7cba5-6111-40ce-828a-e811301bb283.jpg?1",
             "name": "Lesser Masticore",
             "text": "As an additional cost to cast this spell, discard a card.\n{4}: Lesser Masticore deals 1 damage to target creature.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -7626,7 +7626,7 @@
         },
         {
             "id": "f5d3dba6-3294-5966-85b2-3a9469050829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd05b01-dc73-4dd2-970a-32ec6e153c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd05b01-dc73-4dd2-970a-32ec6e153c86.jpg?1",
             "name": "Mox Tantalite",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}: Add one mana of any color.",
             "colours": [],
@@ -7654,7 +7654,7 @@
         },
         {
             "id": "e5b0638d-e305-569d-a97e-50121fba9a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945f5e0-c143-47ca-910e-32ad9ac34487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945f5e0-c143-47ca-910e-32ad9ac34487.jpg?1",
             "name": "Scrapyard Recombiner",
             "text": "Modular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\n{T}, Sacrifice an artifact: Search your library for a Construct card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "c379ab48-a36e-5951-b56e-8e762378efae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c081e5cf-81e2-4afb-a912-8267de29e88d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c081e5cf-81e2-4afb-a912-8267de29e88d.jpg?1",
             "name": "Sword of Sinew and Steel",
             "text": "Equipped creature gets +2/+2 and has protection from black and from red.\nWhenever equipped creature deals combat damage to a player, destroy up to one target planeswalker and up to one target artifact.\nEquip {2}",
             "colours": [],
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "26abe3ef-aa4f-557a-a80a-91ee0af68071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be8d24e-1370-4e85-90f2-66b6d6e9c4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be8d24e-1370-4e85-90f2-66b6d6e9c4a4.jpg?1",
             "name": "Sword of Truth and Justice",
             "text": "Equipped creature gets +2/+2 and has protection from white and from blue.\nWhenever equipped creature deals combat damage to a player, put a +1/+1 counter on a creature you control, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEquip {2}",
             "colours": [],
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "d3bd7037-a4cd-5ad3-bc0b-d8301c0acfce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71148fd3-0c2c-459e-b8f5-735a0a8dd87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71148fd3-0c2c-459e-b8f5-735a0a8dd87f.jpg?1",
             "name": "Talisman of Conviction",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Talisman of Conviction deals 1 damage to you.",
             "colours": [],
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "e59e7b88-6e1c-57b7-af2f-e0ee3ad1e15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9dbadd-c1b6-44fe-92ac-6f69d7178342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9dbadd-c1b6-44fe-92ac-6f69d7178342.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "7caab30b-835a-53c2-b7e2-c3d7a6b5cd76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd52688a-39fd-430f-b950-cb56e0004396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd52688a-39fd-430f-b950-cb56e0004396.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Talisman of Curiosity deals 1 damage to you.",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "7bd57a2d-691b-5be6-a7b6-443df108aff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826f99c7-f534-4183-8f0d-efe1609808ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826f99c7-f534-4183-8f0d-efe1609808ac.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Talisman of Hierarchy deals 1 damage to you.",
             "colours": [],
@@ -7869,7 +7869,7 @@
         },
         {
             "id": "0e70cf6f-c09a-5f9b-8225-9f521b7171ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc25a254-edd2-4817-ab80-7373239da7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc25a254-edd2-4817-ab80-7373239da7d2.jpg?1",
             "name": "Talisman of Resilience",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Talisman of Resilience deals 1 damage to you.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "c5196bfa-540e-5cc4-8206-1355f80ce47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg?1",
             "name": "Universal Automaton",
             "text": "Changeling (This card is every creature type.)",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "83e9c3bd-df91-5c34-937e-380802388916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4d8706-1b2f-41e9-8329-d0186b401227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4d8706-1b2f-41e9-8329-d0186b401227.jpg?1",
             "name": "Barren Moor",
             "text": "Barren Moor enters the battlefield tapped.\n{T}: Add {B}.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7961,7 +7961,7 @@
         },
         {
             "id": "706e5744-2e24-561b-a055-894ce937991b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9149-6fd9-44fc-b765-3e646c7d83d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9149-6fd9-44fc-b765-3e646c7d83d6.jpg?1",
             "name": "Cave of Temptation",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Sacrifice Cave of Temptation: Put two +1/+1 counters on target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "8e4f4bb0-dbc5-5994-8023-dc305a3569d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aab13c-9d9d-4507-ae5d-da979990ae1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aab13c-9d9d-4507-ae5d-da979990ae1b.jpg?1",
             "name": "Fiery Islet",
             "text": "{T}, Pay 1 life: Add {U} or {R}.\n{1}, {T}, Sacrifice Fiery Islet: Draw a card.",
             "colours": [],
@@ -8020,7 +8020,7 @@
         },
         {
             "id": "643bf100-6993-52a4-a405-c6bfdc8533ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d41b5e4-6b9a-419a-ba49-611c4699eda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d41b5e4-6b9a-419a-ba49-611c4699eda2.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave enters the battlefield tapped.\n{T}: Add {R}.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "c760fc87-d82c-5e09-b63a-c142a55b48ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb5d83f-2b7c-4c22-ac37-938e7cd1654a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb5d83f-2b7c-4c22-ac37-938e7cd1654a.jpg?1",
             "name": "Frostwalk Bastion",
             "text": "{T}: Add {C}.\n{1}{S}: Until end of turn, Frostwalk Bastion becomes a 2/3 Construct artifact creature. It's still a land. ({S} can be paid with one mana from a snow permanent.)\nWhenever Frostwalk Bastion deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "c641bd5d-6769-5cf4-a966-aecc476cc82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cbd10a-b9a6-4c00-8280-72bb4add4390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cbd10a-b9a6-4c00-8280-72bb4add4390.jpg?1",
             "name": "Hall of Heliod's Generosity",
             "text": "{T}: Add {C}.\n{1}{W}, {T}: Put target enchantment card from your graveyard on top of your library.",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "47a61cf8-231d-55c3-ba33-8eb568ca72bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0fcc2-2409-4e00-95d5-418ffa161c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0fcc2-2409-4e00-95d5-418ffa161c20.jpg?1",
             "name": "Lonely Sandbar",
             "text": "Lonely Sandbar enters the battlefield tapped.\n{T}: Add {U}.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "4acc28ae-caf6-5a71-9bce-179410c9042d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2744ac83-a79f-4042-8720-688b5adda382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2744ac83-a79f-4042-8720-688b5adda382.jpg?1",
             "name": "Nurturing Peatland",
             "text": "{T}, Pay 1 life: Add {B} or {G}.\n{1}, {T}, Sacrifice Nurturing Peatland: Draw a card.",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "249ffe13-c104-5035-9b0b-90f804fc8c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37da81e-be12-45a2-9128-376f1ad7b3e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37da81e-be12-45a2-9128-376f1ad7b3e8.jpg?1",
             "name": "Prismatic Vista",
             "text": "{T}, Pay 1 life, Sacrifice Prismatic Vista: Search your library for a basic land card, put it onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "920f8550-4289-5201-9f7a-97d2f23c2fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb40724c-62ca-43ab-b4cd-b5fd8e454bfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb40724c-62ca-43ab-b4cd-b5fd8e454bfe.jpg?1",
             "name": "Secluded Steppe",
             "text": "Secluded Steppe enters the battlefield tapped.\n{T}: Add {W}.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8231,7 +8231,7 @@
         },
         {
             "id": "6cbcb7b0-7168-5eb8-86d1-85ff2d706432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac07e230-0297-4e1d-bdfe-119010e0ad8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac07e230-0297-4e1d-bdfe-119010e0ad8e.jpg?1",
             "name": "Silent Clearing",
             "text": "{T}, Pay 1 life: Add {W} or {B}.\n{1}, {T}, Sacrifice Silent Clearing: Draw a card.",
             "colours": [],
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "2e0cc274-32ab-527d-969b-282696f08c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36820fa-ee86-4206-9a0d-737a67cf5208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36820fa-ee86-4206-9a0d-737a67cf5208.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "{T}, Pay 1 life: Add {R} or {W}.\n{1}, {T}, Sacrifice Sunbaked Canyon: Draw a card.",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "21eb0e94-ed88-5bda-8277-d2bf16cb0fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73571bd-b6e5-4338-a9b1-d847a8ad43d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73571bd-b6e5-4338-a9b1-d847a8ad43d1.jpg?1",
             "name": "Tranquil Thicket",
             "text": "Tranquil Thicket enters the battlefield tapped.\n{T}: Add {G}.\nCycling {G} ({G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "a53ad2ab-0436-5906-a73e-725f8fb3d504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab6bfbd-d2e1-4c4c-9f91-6f69c5b8e3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab6bfbd-d2e1-4c4c-9f91-6f69c5b8e3bb.jpg?1",
             "name": "Waterlogged Grove",
             "text": "{T}, Pay 1 life: Add {G} or {U}.\n{1}, {T}, Sacrifice Waterlogged Grove: Draw a card.",
             "colours": [],
@@ -8354,7 +8354,7 @@
         },
         {
             "id": "8561bc1c-5170-540d-be31-05b69bbdb807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a961768-6166-4852-b518-23eb4cced47d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a961768-6166-4852-b518-23eb4cced47d.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "W",
             "colours": [],
@@ -8389,7 +8389,7 @@
         },
         {
             "id": "8808be9a-ae34-5460-a66a-205cf2046b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac1fceb-8427-409c-98a4-9a5c1ff980b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac1fceb-8427-409c-98a4-9a5c1ff980b4.jpg?1",
             "name": "Snow-Covered Island",
             "text": "U",
             "colours": [],
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "4d99ecc1-8eb3-5c89-8c68-e6cec675a519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c835f235-4196-4281-9788-13e5d54a92d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c835f235-4196-4281-9788-13e5d54a92d0.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "B",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "1fa76119-95c7-5c19-9f67-c1cf8064caf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2209e6f-1d9d-43bb-a314-a8fefc509e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2209e6f-1d9d-43bb-a314-a8fefc509e78.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "R",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "2c2dc850-d97a-5a1f-a0e7-40ce8ff80e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c59fc48-704b-4187-b9d3-2a2cff6dd54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c59fc48-704b-4187-b9d3-2a2cff6dd54b.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "G",
             "colours": [],
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "eaae1532-4362-54f9-8855-477ce59eab99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a00405-13ad-4531-9bfb-fea0ca57f196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a00405-13ad-4531-9bfb-fea0ca57f196.jpg?1",
             "name": "Flusterstorm",
             "text": "Counter target instant or sorcery spell unless its controller pays {1}.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -8560,7 +8560,7 @@
         },
         {
             "id": "43f9f350-30f7-533a-a744-5d2c3a07c46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33fda72-e61d-478f-bc33-ff1a23b5f45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33fda72-e61d-478f-bc33-ff1a23b5f45b.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "c63a75f7-220d-576f-9e80-0b2faaac1a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91808554-23ab-44f9-92a1-87ee7d58cd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91808554-23ab-44f9-92a1-87ee7d58cd9a.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "eeed4bdc-bea8-554a-9f62-c7271246d1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c72f53-db47-48d1-85f0-626440b0c88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c72f53-db47-48d1-85f0-626440b0c88c.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8661,7 +8661,7 @@
         },
         {
             "id": "b9a3b02c-8af5-55be-9323-013819463ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61b83cf-791a-48bf-81c8-c6c940b89d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61b83cf-791a-48bf-81c8-c6c940b89d83.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8696,7 +8696,7 @@
         },
         {
             "id": "6b081b5c-f513-562a-9a96-045bb28fe835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccb29b-8b69-4813-94bb-d96e117b609e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccb29b-8b69-4813-94bb-d96e117b609e.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "d5d9997c-f3da-5fc6-b99d-7b037f5cc097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b993828-e139-4cb6-a329-487accc1c515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b993828-e139-4cb6-a329-487accc1c515.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "61a6dd3f-8531-5e6e-bf76-12ece28a6514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c722fe8-05f1-4da0-a23b-25e20359fcef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c722fe8-05f1-4da0-a23b-25e20359fcef.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8803,7 +8803,7 @@
         },
         {
             "id": "792e0bc2-7b2e-5307-bb46-d1682fb34d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b57672-c346-42f5-ac3e-82466a13b957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b57672-c346-42f5-ac3e-82466a13b957.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8838,7 +8838,7 @@
         },
         {
             "id": "a80c9961-5303-587a-8b48-5e3d5a8dee97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/addc39de-db64-41d8-9185-67a09d3e326d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/addc39de-db64-41d8-9185-67a09d3e326d.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "ce3f025c-00d3-5c8d-becb-e4130e7f003b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5522b39-802a-4508-a671-2f73b0633032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5522b39-802a-4508-a671-2f73b0633032.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "26ae6f11-46bd-5975-a3ed-e3d2cea8be46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6610846-00d8-4cc2-a90a-4dc043ba7fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6610846-00d8-4cc2-a90a-4dc043ba7fa6.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "3e931821-df8c-5887-b360-6a18c72fa609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae11d5f-f29d-44f4-8d90-cdada1040435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae11d5f-f29d-44f4-8d90-cdada1040435.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "ef6763e4-1adc-5a73-af81-9360158d9f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007c828b-5854-41ac-9c18-f9d41c69ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007c828b-5854-41ac-9c18-f9d41c69ed33.jpg?1",
             "name": "Rhino",
             "text": "",
             "colours": [
@@ -9013,7 +9013,7 @@
         },
         {
             "id": "26784dd1-b95f-5e3c-bc1b-fd5a874b9fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01591603-d903-419d-9957-cf0ae7f79240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01591603-d903-419d-9957-cf0ae7f79240.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "db984bd7-474c-5634-81ab-d5a23a73b29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "7b27265b-043d-5a37-bcbb-c4f6b6ea77cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf24e9fa-7d7f-4693-a9ed-b8e725d0ad5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf24e9fa-7d7f-4693-a9ed-b8e725d0ad5c.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "bd5f51ee-08a2-5368-9dd0-cb3052e719ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f212cd-4fc6-42fe-b268-22d8e3b2b7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f212cd-4fc6-42fe-b268-22d8e3b2b7eb.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "40823ee3-88e6-5f75-b1e6-d8273309f57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -9184,7 +9184,7 @@
         },
         {
             "id": "ef95c68a-b227-5c19-b017-02ebfa99c966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e26b2-1f7d-4a30-a0ef-1aa91e91d551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e26b2-1f7d-4a30-a0ef-1aa91e91d551.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "61c054a4-231d-52d3-9631-0d062ddf13a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87dbb0b0-d898-491a-8ed9-efefca04e6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87dbb0b0-d898-491a-8ed9-efefca04e6e6.jpg?1",
             "name": "Serra the Benevolent Emblem",
             "text": "",
             "colours": [],
@@ -9246,7 +9246,7 @@
         },
         {
             "id": "ea5403b7-aada-5c51-84a3-7f597f7f4947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8a9fc-755a-4bff-8e13-41fbf4d9e546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8a9fc-755a-4bff-8e13-41fbf4d9e546.jpg?1",
             "name": "Wrenn and Six Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MH2.json
+++ b/Assets/Resources/Sets/MH2.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "37a15f87-1ebe-5bb4-926a-d77adf80689c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db113c47-c403-4c7f-9fa9-212c977df8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db113c47-c403-4c7f-9fa9-212c977df8d1.jpg?1",
             "name": "Abiding Grace",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 You gain 1 life.\n\u2022 Return target creature card with mana value 1 from your graveyard to the battlefield.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "e4c4c0a2-8be3-5d27-b5ec-ba665f8164ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4a2cb0-4129-451e-a946-a21ea646cc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4a2cb0-4129-451e-a946-a21ea646cc28.jpg?1",
             "name": "Arcbound Javelineer",
             "text": "{T}, Remove X +1/+1 counters from Arcbound Javelineer: It deals X damage to target attacking or blocking creature.\nModular 1 (This creature enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "81eb425e-861c-5a30-8ebd-9bd9f5284638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d66e724-49ee-4f08-a160-584350de1d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d66e724-49ee-4f08-a160-584350de1d95.jpg?1",
             "name": "Arcbound Mouser",
             "text": "Lifelink\nModular 1 (This creature enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "189f11b3-9ce8-54d2-8ced-c913c941a824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0a1a4-9216-47f8-a4e3-20fe0de6a518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0a1a4-9216-47f8-a4e3-20fe0de6a518.jpg?1",
             "name": "Arcbound Prototype",
             "text": "Modular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "cf858f04-b890-592e-8fc0-01a56c103827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c8631-e630-402b-a559-f1b1aa49763c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c8631-e630-402b-a559-f1b1aa49763c.jpg?1",
             "name": "Barbed Spike",
             "text": "When Barbed Spike enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying, then attach Barbed Spike to it.\nEquipped creature gets +1/+0.\nEquip {2}",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f22ebf80-4dc1-56a3-be02-caee37c2774e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31506792-d0ab-4c13-9ab8-6fa433220dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31506792-d0ab-4c13-9ab8-6fa433220dbf.jpg?1",
             "name": "Blacksmith's Skill",
             "text": "Target permanent gains hexproof and indestructible until end of turn. If it's an artifact creature, it gets +2/+2 until end of turn.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "69010cbb-e00a-5b4d-810e-71a633866400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792610fd-736d-43b0-8899-dbb5accddca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792610fd-736d-43b0-8899-dbb5accddca0.jpg?1",
             "name": "Blossoming Calm",
             "text": "You gain hexproof until your next turn. You gain 2 life.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "cb3c1e88-dc18-5525-a059-71bece848b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723ec2ef-aa82-449d-88b0-405d06454fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723ec2ef-aa82-449d-88b0-405d06454fc2.jpg?1",
             "name": "Break Ties",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.\nReinforce 1\u2014{W} ({W}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "a891c42d-07a1-5607-a2bd-47eadf333f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c71a1f-191b-45f6-bb34-fba3e981a711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c71a1f-191b-45f6-bb34-fba3e981a711.jpg?1",
             "name": "Caprichrome",
             "text": "Flash\nVigilance\nDevour artifact 1 (As this enters the battlefield, you may sacrifice any number of artifacts. This creature enters the battlefield with that many +1/+1 counters on it.)",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "a44e851c-452a-5496-a868-07abab4587a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b5a0a5-5486-409a-b324-668ae03fc62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b5a0a5-5486-409a-b324-668ae03fc62a.jpg?1",
             "name": "Constable of the Realm",
             "text": "Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)\nWhenever one or more +1/+1 counters are put on Constable of the Realm, exile up to one other target nonland permanent until Constable of the Realm leaves the battlefield.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "d0411f21-e175-5f7a-81a5-5bb19a1d5e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9723a1-7c5f-49ea-a8c6-24ee572d839f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9723a1-7c5f-49ea-a8c6-24ee572d839f.jpg?1",
             "name": "Disciple of the Sun",
             "text": "Lifelink\nWhen Disciple of the Sun enters the battlefield, return target permanent card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "e7c90d84-033a-5ebb-994c-b8f17977da4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3537373-ef54-4578-9d05-6216420ee349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3537373-ef54-4578-9d05-6216420ee349.jpg?1",
             "name": "Esper Sentinel",
             "text": "Whenever an opponent casts their first noncreature spell each turn, draw a card unless that player pays {X}, where X is Esper Sentinel's power.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "b11949bb-8bea-52a2-8601-7863d1be5866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e07ed-24ef-40f7-91fc-fe212d948ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e07ed-24ef-40f7-91fc-fe212d948ca8.jpg?1",
             "name": "Fairgrounds Patrol",
             "text": "{1}{W}, Exile Fairgrounds Patrol from your graveyard: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only as a sorcery.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "77c306d7-9b1c-5a29-a62b-70dc0bc2bd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1365aa-e814-471b-8c9e-cf4c5011bcc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1365aa-e814-471b-8c9e-cf4c5011bcc3.jpg?1",
             "name": "Glorious Enforcer",
             "text": "Flying, lifelink\nAt the beginning of each combat, if you have more life than an opponent, Glorious Enforcer gains double strike until end of turn.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "fb3a7f0f-11d7-5b4d-8c58-73fb10aabbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b4061-3009-46e4-8602-8349c6367cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b4061-3009-46e4-8602-8349c6367cbf.jpg?1",
             "name": "Guardian Kirin",
             "text": "Flying\nWhenever another creature you control dies, put a +1/+1 counter on Guardian Kirin.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "6031f50a-a6c1-5e81-9d70-859cd9e4ed7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b5429-8512-4ab6-9ecd-fa270e0144f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b5429-8512-4ab6-9ecd-fa270e0144f3.jpg?1",
             "name": "Healer's Flock",
             "text": "Flying, lifelink",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "af439825-2439-59bc-8956-9a046e770401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee638303-fa02-41b6-8954-156544566b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee638303-fa02-41b6-8954-156544566b57.jpg?1",
             "name": "Knighted Myr",
             "text": "{2}{W}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Knighted Myr, it gains double strike until end of turn.",
             "colours": [
@@ -591,7 +591,7 @@
         },
         {
             "id": "3f1d0578-3c6a-52fd-8424-57cc069218ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a9e86-133e-4626-a239-73ef88d9ae12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a9e86-133e-4626-a239-73ef88d9ae12.jpg?1",
             "name": "Landscaper Colos",
             "text": "When Landscaper Colos enters the battlefield, put target card from an opponent's graveyard on the bottom of their library.\nBasic landcycling {1}{W} ({1}{W}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "a337a6a0-be50-5d98-9da0-5b0274cb4002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6633cab9-23f9-474e-96f1-ca7c0c67691c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6633cab9-23f9-474e-96f1-ca7c0c67691c.jpg?1",
             "name": "Late to Dinner",
             "text": "Return target creature card from your graveyard to the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "8a7b093a-8b62-53c5-ab35-27e3b22bf5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d92f037-a121-428a-ac53-98437366ecfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d92f037-a121-428a-ac53-98437366ecfd.jpg?1",
             "name": "Lens Flare",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nLens Flare deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "ef4cf126-985e-5c57-a21e-3315c503d786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c62efb9-11f2-4f82-af08-4587d58d6e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c62efb9-11f2-4f82-af08-4587d58d6e3d.jpg?1",
             "name": "Marble Gargoyle",
             "text": "Flying\n{W}: Marble Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "3faf9d65-b3ae-5533-9531-0750455611b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2963205e-b181-44d1-809f-6577e29fa812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2963205e-b181-44d1-809f-6577e29fa812.jpg?1",
             "name": "Nykthos Paragon",
             "text": "Whenever you gain life, you may put that many +1/+1 counters on each creature you control. Do this only once each turn.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "a0cba89b-c9a5-53f0-b894-05b280fddcb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053d6b3b-72d4-4a55-a79e-0a601aecf108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053d6b3b-72d4-4a55-a79e-0a601aecf108.jpg?1",
             "name": "Out of Time",
             "text": "When Out of Time enters the battlefield, untap all creatures, then phase them out until Out of Time leaves the battlefield. Put a time counter on Out of Time for each creature phased out this way.\nVanishing (At the beginning of your upkeep, remove a time counter from this enchantment. When the last is removed, sacrifice it.)",
             "colours": [
@@ -804,7 +804,7 @@
         },
         {
             "id": "becee9de-7340-50bd-8c0b-d40aefb96389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeb9fd0-c46a-4246-838f-a5b7a8ea8eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeb9fd0-c46a-4246-838f-a5b7a8ea8eef.jpg?1",
             "name": "Piercing Rays",
             "text": "Exile target tapped creature.\nForecast \u2014 {2}{W}, Reveal Piercing Rays from your hand: Tap target untapped creature. (Activate this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "efdbf638-dbe6-5813-ba0b-dafbac1e1468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825969b9-3c70-4fca-8cab-696e9ca7cdb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825969b9-3c70-4fca-8cab-696e9ca7cdb2.jpg?1",
             "name": "Prismatic Ending",
             "text": "Converge \u2014 Exile target nonland permanent if its mana value is less than or equal to the number of colors of mana spent to cast this spell.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "7f7c551c-182a-581b-ae77-4d228aba9aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01880c6f-be00-48b5-913f-ec6c80ced184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01880c6f-be00-48b5-913f-ec6c80ced184.jpg?1",
             "name": "Resurgent Belief",
             "text": "Suspend 2\u2014{1}{W} (Rather than cast this card from your hand, pay {1}{W} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nReturn all enchantment cards from your graveyard to the battlefield. (Auras with nothing to enchant remain in your graveyard.)",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "65fe24d8-84a3-5aef-b8b9-95988dd1c629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c3cca4-23c0-4c14-ab56-51ba011f5974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c3cca4-23c0-4c14-ab56-51ba011f5974.jpg?1",
             "name": "Sanctifier en-Vec",
             "text": "Protection from black and from red\nWhen Sanctifier en-Vec enters the battlefield, exile all cards that are black or red from all graveyards.\nIf a black or red permanent, spell, or card not on the battlefield would be put into a graveyard, exile it instead.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "6441701d-0dae-5c5a-9b2d-8f93a951c191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d368f-e1e0-41ab-9da0-f07c01c8ae38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d368f-e1e0-41ab-9da0-f07c01c8ae38.jpg?1",
             "name": "Scour the Desert",
             "text": "Exile target creature card from your graveyard. Create X 1/1 white Bird creature tokens with flying, where X is the exiled card's toughness.",
             "colours": [
@@ -975,7 +975,7 @@
         },
         {
             "id": "7b3add30-ec6e-5565-85a8-ef819294b815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0345668-0cc1-41d2-8e4f-de7726fd0365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0345668-0cc1-41d2-8e4f-de7726fd0365.jpg?1",
             "name": "Search the Premises",
             "text": "Whenever a creature attacks you or a planeswalker you control, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "47613356-7f2f-5289-b4e6-7430f4dc6929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6534049-3045-4546-b1e8-e5b1b0df5f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6534049-3045-4546-b1e8-e5b1b0df5f56.jpg?1",
             "name": "Serra's Emissary",
             "text": "Flying\nAs Serra's Emissary enters the battlefield, choose a card type.\nYou and creatures you control have protection from the chosen card type.",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "e1eb68dd-7d00-522f-a860-30957ad40ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5705397-525b-4106-92ab-fe8ec9f561a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5705397-525b-4106-92ab-fe8ec9f561a2.jpg?1",
             "name": "Skyblade's Boon",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\n{2}{W}: Return Skyblade's Boon to its owner's hand. Activate only if Skyblade's Boon is on the battlefield or in your graveyard.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "0a0f438a-9c6d-5125-ab75-02d91490e324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6234f-309f-4e03-9263-66da48b57153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6234f-309f-4e03-9263-66da48b57153.jpg?1",
             "name": "Solitude",
             "text": "Flash\nLifelink\nWhen Solitude enters the battlefield, exile up to one other target creature. That creature's controller gains life equal to its power.\nEvoke\u2014\nExile a white card from your hand.",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "c0a36974-0541-505c-bcd5-724469f13815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4541217f-5e86-491b-918b-ed7a2eb3e4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4541217f-5e86-491b-918b-ed7a2eb3e4eb.jpg?1",
             "name": "Soul of Migration",
             "text": "Flying\nWhen Soul of Migration enters the battlefield, create two 1/1 white Bird creature tokens with flying.\nEvoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "2e83e51e-61f3-585c-ba4c-8eb595af0bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4e0e11-2f16-42ad-b835-c9410c4bd7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4e0e11-2f16-42ad-b835-c9410c4bd7e3.jpg?1",
             "name": "Thraben Watcher",
             "text": "Flying, vigilance\nOther nontoken creatures you control get +1/+1 and have vigilance.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "ffa57cee-f996-58f4-8383-1f39d83acc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fe8889-0ec8-421a-83a4-5d00ab4804db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fe8889-0ec8-421a-83a4-5d00ab4804db.jpg?1",
             "name": "Timeless Dragon",
             "text": "Flying\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)\nEternalize {2}{W}{W} ({2}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Dragon with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "60386fe5-bf83-5a4e-8e59-39d5e849cace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9955a344-dcd8-404d-9757-f62ed158ba22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9955a344-dcd8-404d-9757-f62ed158ba22.jpg?1",
             "name": "Unbounded Potential",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on each of up to two target creatures.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEntwine {3}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "7a244a46-f22e-5134-afa0-3dc491182aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a304f7e-0b9e-4ef6-9ad8-34350839f7d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a304f7e-0b9e-4ef6-9ad8-34350839f7d9.jpg?1",
             "name": "Aeromoeba",
             "text": "Flying\nDiscard a card: Switch Aeromoeba's power and toughness until end of turn.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "34d86643-5932-5768-9c41-7daaff57e5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8387bc7c-2e0a-4ff2-9882-e5e7c92c8463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8387bc7c-2e0a-4ff2-9882-e5e7c92c8463.jpg?1",
             "name": "Burdened Aerialist",
             "text": "When Burdened Aerialist enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever you sacrifice a token, Burdened Aerialist gains flying until end of turn.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "94493140-6d74-5ca1-8d4c-77f799b88026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9f061-67b8-4427-9fcb-b3ccfee8fc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9f061-67b8-4427-9fcb-b3ccfee8fc5d.jpg?1",
             "name": "Dress Down",
             "text": "Flash\nWhen Dress Down enters the battlefield, draw a card.\nCreatures lose all abilities.\nAt the beginning of the end step, sacrifice Dress Down.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "2c994738-4e1a-5ba7-bf35-23143c108e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8056f-4c8e-4a2b-b32f-c50c2cb7601a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8056f-4c8e-4a2b-b32f-c50c2cb7601a.jpg?1",
             "name": "Etherium Spinner",
             "text": "Whenever you cast a spell with mana value 4 or greater, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "2dc483cc-43e8-55cc-9608-73f62a0b260a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cb828c-a19b-4e6d-853f-85e5ea7cadf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cb828c-a19b-4e6d-853f-85e5ea7cadf8.jpg?1",
             "name": "Filigree Attendant",
             "text": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "acfc5721-0db2-5528-be74-05382550e12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ac05-bd87-4605-8443-0469276e1e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ac05-bd87-4605-8443-0469276e1e3a.jpg?1",
             "name": "Floodhound",
             "text": "{3}, {T}: Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "9e6493c0-8ba9-5ca4-a501-82f82c630981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d00175-5e5e-40dd-a71b-5ba56d763134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d00175-5e5e-40dd-a71b-5ba56d763134.jpg?1",
             "name": "Foul Watcher",
             "text": "Flying\nWhen Foul Watcher enters the battlefield, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\nDelirium \u2014 Foul Watcher gets +1/+0 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "5732999c-5cbc-5767-8e68-a1f02ea3d864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413ac8fb-5156-4f90-81f5-1879e273c9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413ac8fb-5156-4f90-81f5-1879e273c9e2.jpg?1",
             "name": "Fractured Sanity",
             "text": "Each opponent mills fourteen cards.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Fractured Sanity, each opponent mills four cards.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "062a2a61-1fbc-5662-b166-b1a5d526e449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8cd89e-d849-4107-a629-98eae4c91489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8cd89e-d849-4107-a629-98eae4c91489.jpg?1",
             "name": "Ghost-Lit Drifter",
             "text": "Flying\n{2}{U}: Another target creature gains flying until end of turn.\nChannel \u2014 {X}{U}, Discard Ghost-Lit Drifter: X target creatures gain flying until end of turn.",
             "colours": [
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "3d2c8485-b300-50c8-95e6-443c369313bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501599d6-1072-4124-b05d-01f96de153f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501599d6-1072-4124-b05d-01f96de153f3.jpg?1",
             "name": "Hard Evidence",
             "text": "Create a 0/3 blue Crab creature token.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "a270560f-a23d-5dbf-9c71-7ceed2dc0b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71725895-38cd-4017-bbf0-0b7dc9b5db60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71725895-38cd-4017-bbf0-0b7dc9b5db60.jpg?1",
             "name": "Inevitable Betrayal",
             "text": "Suspend 3\u2014{1}{U}{U} (Rather than cast this card from your hand, pay {1}{U}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nSearch target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -1637,7 +1637,7 @@
         },
         {
             "id": "93b96650-55c8-5b79-95c5-2b641c7409fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7833a-a6b6-4aca-b574-66a6aea471ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7833a-a6b6-4aca-b574-66a6aea471ea.jpg?1",
             "name": "Junk Winder",
             "text": "Affinity for tokens (This spell costs {1} less to cast for each token you control.)\nWhenever a token enters the battlefield under your control, tap target nonland permanent an opponent controls. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1671,7 +1671,7 @@
         },
         {
             "id": "fe525402-6ba3-52d8-8ad1-be6f35bcd496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985bdb0c-ce6c-4506-8163-76f3b2fdf5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985bdb0c-ce6c-4506-8163-76f3b2fdf5fb.jpg?1",
             "name": "Lose Focus",
             "text": "Replicate {U} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nCounter target spell unless its controller pays {2}.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "06b68235-b2d4-51e4-a604-3e0092307f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeda3d-3741-4b80-bfef-63bcc599d75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeda3d-3741-4b80-bfef-63bcc599d75b.jpg?1",
             "name": "Lucid Dreams",
             "text": "Draw X cards, where X is the number of card types among cards in your graveyard.",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "b2437450-05fd-5e92-a4f0-298b178b2a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec38124-46ae-4a38-aab2-8a73cc22b1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec38124-46ae-4a38-aab2-8a73cc22b1ef.jpg?1",
             "name": "Mental Journey",
             "text": "Draw three cards.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "4bc16cb7-51fe-514b-ba2f-69c39d255cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4aae1-7665-4df7-bd51-a1d95bf8a17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4aae1-7665-4df7-bd51-a1d95bf8a17d.jpg?1",
             "name": "Murktide Regent",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying\nMurktide Regent enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.\nWhenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on Murktide Regent.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "2e469591-d75c-52dd-9f58-f69c447b6c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f6615e-194d-43aa-815a-34dca2ff4fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f6615e-194d-43aa-815a-34dca2ff4fea.jpg?1",
             "name": "Mystic Redaction",
             "text": "At the beginning of your upkeep, scry 1.\nWhenever you discard a card, each opponent mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "ba119b30-3cb5-50b4-aa6d-c9a39882bd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f288ee5-4bf9-476a-a89f-b6b8fa7e87dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f288ee5-4bf9-476a-a89f-b6b8fa7e87dc.jpg?1",
             "name": "Parcel Myr",
             "text": "{2}, Sacrifice Parcel Myr: Draw a card.",
             "colours": [
@@ -1873,7 +1873,7 @@
         },
         {
             "id": "ecff8d32-5815-5e33-bfcd-f981ca946c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f09ddb-0dec-47a7-92d4-efbeaf8cd85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f09ddb-0dec-47a7-92d4-efbeaf8cd85c.jpg?1",
             "name": "Phantasmal Dreadmaw",
             "text": "Trample\nWhen Phantasmal Dreadmaw becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "565de634-8e4b-594e-94b3-c6b220e37234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cee3a-6e0e-43c2-85e5-531b19297c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cee3a-6e0e-43c2-85e5-531b19297c3d.jpg?1",
             "name": "Raving Visionary",
             "text": "{U}, {T}: Draw a card, then discard a card.\nDelirium \u2014 {2}{U}, {T}: Draw a card. Activate only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1945,7 +1945,7 @@
         },
         {
             "id": "9cf9ae29-7919-5112-8eb3-dd3f9219e004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95cc841-4e4f-4896-a073-f2e246ca62e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95cc841-4e4f-4896-a073-f2e246ca62e4.jpg?1",
             "name": "Recalibrate",
             "text": "Return target creature to its owner's hand. If you've discarded a card this turn, draw a card.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "0804eb6a-dacb-57ae-96fc-f8ec2a1f59a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e658cb2-11c5-4b59-a91c-f26ac28e82af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e658cb2-11c5-4b59-a91c-f26ac28e82af.jpg?1",
             "name": "Rise and Shine",
             "text": "Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on each artifact that became a creature this way.\nOverload {4}{U}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2011,7 +2011,7 @@
         },
         {
             "id": "edfcf1b9-88ba-5fcf-8ad4-c4afa317c385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg?1",
             "name": "Rishadan Dockhand",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\n{1}, {T}: Tap target land.",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "92879e5d-fbcb-57a5-8d74-7e8113699d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg?1",
             "name": "Said // Done",
             "text": "Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2080,7 +2080,7 @@
         },
         {
             "id": "5896af19-9c32-583f-96ae-2ec7cfca638c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg?1",
             "name": "Said // Done",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "7d7d940d-32bb-54c6-bbb8-46cdb995b92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e4ce27-aba2-4a3f-8de7-d442323d8be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e4ce27-aba2-4a3f-8de7-d442323d8be2.jpg?1",
             "name": "Scuttletide",
             "text": "{1}, Discard a card: Create a 0/3 blue Crab creature token.\nDelirium \u2014 Crabs you control get +1/+1 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "203a2502-8efb-5d2a-bd75-6ea237d1bd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191d1ab9-cd9e-4351-9acd-d7a57b963253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191d1ab9-cd9e-4351-9acd-d7a57b963253.jpg?1",
             "name": "Shattered Ego",
             "text": "Enchant creature\nEnchanted creature gets -3/-0.\n{3}{U}{U}: Put enchanted creature into its owner's library third from the top.",
             "colours": [
@@ -2178,7 +2178,7 @@
         },
         {
             "id": "95b6612f-dd2b-5651-bb6d-d66b7b1a0f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135db79f-6f07-486c-ae3a-d4244aaf6dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135db79f-6f07-486c-ae3a-d4244aaf6dc8.jpg?1",
             "name": "So Shiny",
             "text": "Enchant creature\nWhen So Shiny enters the battlefield, if you control a token, tap enchanted creature, then scry 2.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "8919813d-d600-5844-8c51-b889296610ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfaed69-bc4c-4c73-abc3-00dce5e0177e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfaed69-bc4c-4c73-abc3-00dce5e0177e.jpg?1",
             "name": "Specimen Collector",
             "text": "When Specimen Collector enters the battlefield, create a 1/1 green Squirrel creature token and a 0/3 blue Crab creature token.\nWhen Specimen Collector dies, create a token that's a copy of target token you control.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "070e236e-0c26-5819-9ca7-18b2a178b91b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7ca8b6-d7e0-4af2-a578-bf45a8731c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7ca8b6-d7e0-4af2-a578-bf45a8731c19.jpg?1",
             "name": "Steelfin Whale",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhenever an artifact enters the battlefield under your control, untap Steelfin Whale.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "31c59d84-a47a-5278-8097-152e625ccde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716534cb-aa89-4de7-9aa5-8d8aa4422a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716534cb-aa89-4de7-9aa5-8d8aa4422a6a.jpg?1",
             "name": "Step Through",
             "text": "Return two target creatures to their owners' hands.\nWizardcycling {2} ({2}, Discard this card: Search your library for a Wizard card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "584d7124-cc7f-508a-9304-16cc17dd3751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701256d5-1389-48b7-9581-d6037209bd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701256d5-1389-48b7-9581-d6037209bd06.jpg?1",
             "name": "Subtlety",
             "text": "Flash\nFlying\nWhen Subtlety enters the battlefield, choose up to one target creature spell or planeswalker spell. Its owner puts it on the top or bottom of their library.\nEvoke\u2014\nExile a blue card from your hand.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "c2c6de27-0085-5b5e-90e3-3e717f72f801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40af215c-d3f7-42f0-85cd-77a3fcd919ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40af215c-d3f7-42f0-85cd-77a3fcd919ba.jpg?1",
             "name": "Suspend",
             "text": "Exile target creature and put two time counters on it. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, they remove a time counter. When the last is removed, they play it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -2386,7 +2386,7 @@
         },
         {
             "id": "9c9ca5b3-d6a3-5d5a-b12e-0ff7a3bbf36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f9ece1-669a-47c9-96c3-1e1dbf87421c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f9ece1-669a-47c9-96c3-1e1dbf87421c.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}. (Whenever another Merfolk you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "3c31282d-7694-5c08-ab46-cefe8a25174c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22dcb4e-ac39-4bee-b8d0-1b6ed038834e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22dcb4e-ac39-4bee-b8d0-1b6ed038834e.jpg?1",
             "name": "Sweep the Skies",
             "text": "Converge \u2014 Create a 1/1 colorless Thopter artifact creature token with flying for each color of mana spent to cast this spell.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "f9b24510-d75a-5c50-a218-41f7e2832cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996c1952-8d10-4296-8960-ff8993833649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996c1952-8d10-4296-8960-ff8993833649.jpg?1",
             "name": "Thought Monitor",
             "text": "Affinity for artifacts\nFlying\nWhen Thought Monitor enters the battlefield, draw two cards.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "6541bc80-e3f0-5058-857f-2a667bd0184f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff414bc-6736-428b-bb60-9d62793a5ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff414bc-6736-428b-bb60-9d62793a5ae5.jpg?1",
             "name": "Tide Shaper",
             "text": "Kicker {1} (You may pay an additional {1} as you cast this spell.)\nWhen Tide Shaper enters the battlefield, if it was kicked, target land becomes an Island for as long as Tide Shaper remains on the battlefield.\nTide Shaper gets +1/+1 as long as an opponent controls an Island.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "e2e6a29d-744b-5484-adc3-3c1406934357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfc6a8-7880-4810-8c0a-d9ea931138f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfc6a8-7880-4810-8c0a-d9ea931138f2.jpg?1",
             "name": "Vedalken Infiltrator",
             "text": "Vedalken Infiltrator can't be blocked.\nMetalcraft \u2014 Vedalken Infiltrator gets +1/+0 as long as you control three or more artifacts.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "8791a150-567e-584e-aff9-21ab74f27b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d089f1-718e-4853-a634-64114735fba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d089f1-718e-4853-a634-64114735fba5.jpg?1",
             "name": "Archfiend of Sorrows",
             "text": "Flying\nWhen Archfiend of Sorrows enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nUnearth {3}{B}{B} ({3}{B}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2601,7 +2601,7 @@
         },
         {
             "id": "e5bf7106-c055-5ea7-9672-25294bc5dba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be9d9a4-d7ee-4854-abc2-85cabf993ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be9d9a4-d7ee-4854-abc2-85cabf993ec9.jpg?1",
             "name": "Archon of Cruelty",
             "text": "Flying\nWhenever Archon of Cruelty enters the battlefield or attacks, target opponent sacrifices a creature or planeswalker, discards a card, and loses 3 life. You draw a card and gain 3 life.",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "f617eeaa-b3ae-5894-9d71-60a77d5943e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee98955-4c47-4d45-9377-608dfa755337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee98955-4c47-4d45-9377-608dfa755337.jpg?1",
             "name": "Bone Shards",
             "text": "As an additional cost to cast this spell, sacrifice a creature or discard a card.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "c53b438f-9953-53a3-b443-0d43d3be3035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ca9568-06b6-4c57-b1f6-8a74ec2a2b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ca9568-06b6-4c57-b1f6-8a74ec2a2b91.jpg?1",
             "name": "Break the Ice",
             "text": "Destroy target land that is snow or could produce {C}.\nOverload {4}{B}{B} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2703,7 +2703,7 @@
         },
         {
             "id": "32b7e6bb-9fba-55f6-b220-e50641d4f069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b279a03f-85ab-43f2-b5ca-1bc10563e5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b279a03f-85ab-43f2-b5ca-1bc10563e5ad.jpg?1",
             "name": "Cabal Initiate",
             "text": "Discard a card: Cabal Initiate gains lifelink until end of turn.\nThreshold \u2014 Cabal Initiate gets +1/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "6ed4c05b-0c16-5503-98cf-27b74c6ff8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22dd28d-eb65-410a-af17-51b5064c6033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22dd28d-eb65-410a-af17-51b5064c6033.jpg?1",
             "name": "Clattering Augur",
             "text": "Clattering Augur can't block.\nWhen Clattering Augur enters the battlefield, you draw a card and you lose 1 life.\n{2}{B}{B}: Return Clattering Augur from your graveyard to your hand.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "c191679f-c789-5644-97bb-b1fd58139c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeae088-9ac5-4d2f-a15c-d8675a471ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeae088-9ac5-4d2f-a15c-d8675a471ac5.jpg?1",
             "name": "Damn",
             "text": "Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "5d25e879-61ee-5a0c-87bc-555e849dfa35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5db87-4a78-4b8d-b5c2-918ccd1ba4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5db87-4a78-4b8d-b5c2-918ccd1ba4e3.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf a card would be put into an opponent's graveyard from anywhere, instead exile it with a void counter on it.\n{T}, Sacrifice Dauthi Voidwalker: Choose an exiled card an opponent owns with a void counter on it. You may play it this turn without paying its mana cost.",
             "colours": [
@@ -2847,7 +2847,7 @@
         },
         {
             "id": "4ef50b2a-ec09-581a-8466-8ae71c8226af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f395828-9d6d-4ffa-be92-b681350031b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f395828-9d6d-4ffa-be92-b681350031b0.jpg?1",
             "name": "Discerning Taste",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. You gain life equal to the greatest power among creature cards put into your graveyard this way.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "234ab16d-6b70-5711-8a6c-b3586b1fa6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39eb0e67-f989-4430-b2d6-b8b647f0b7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39eb0e67-f989-4430-b2d6-b8b647f0b7ca.jpg?1",
             "name": "Echoing Return",
             "text": "Return target creature card and all other cards with the same name as that card from your graveyard to your hand.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "03140fdb-6383-5745-b645-46758e587fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f71309d-1b62-461d-b939-87f2932937a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f71309d-1b62-461d-b939-87f2932937a7.jpg?1",
             "name": "Feast of Sanity",
             "text": "Whenever you discard a card, Feast of Sanity deals 1 damage to any target and you gain 1 life.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "85809469-8bbf-596c-8534-a6de994b215f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297eaa16-890b-41dc-a470-fa8c313e6e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297eaa16-890b-41dc-a470-fa8c313e6e1b.jpg?1",
             "name": "Flay Essence",
             "text": "Exile target creature or planeswalker. You gain life equal to the number of counters on it.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "c4b8354a-ab94-5c48-a26c-d86c23782abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8cf47-cfe4-4a11-a57d-bebeb2fae437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8cf47-cfe4-4a11-a57d-bebeb2fae437.jpg?1",
             "name": "Gilt-Blade Prowler",
             "text": "{1}, {T}, Pay 1 life: Draw a card. Activate only if you've discarded a card this turn.",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "8b47aa60-e9e1-51ba-aefd-9fcf7b950d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6befbc4-1320-4f26-bd9f-b1814fedda10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6befbc4-1320-4f26-bd9f-b1814fedda10.jpg?1",
             "name": "Grief",
             "text": "Menace\nWhen Grief enters the battlefield, target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nEvoke\u2014\nExile a black card from your hand.",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "93a0c626-25f9-5fcf-aa25-bd2a228dadfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7da32a3-8e33-4603-abd2-8db144062f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7da32a3-8e33-4603-abd2-8db144062f6a.jpg?1",
             "name": "Hell Mongrel",
             "text": "Discard a card: Hell Mongrel gets +1/+1 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3082,7 +3082,7 @@
         },
         {
             "id": "60e3d9ab-b6ec-5b4c-815b-f6508e73aa2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836ae711-e62f-49ec-850e-d25f6fd2a4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836ae711-e62f-49ec-850e-d25f6fd2a4d4.jpg?1",
             "name": "Kitchen Imp",
             "text": "Flying, haste\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3118,7 +3118,7 @@
         },
         {
             "id": "a5723a00-bd54-5342-a1dc-c206e9aea193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ac1b48-dcfd-48a1-b999-ccc642596d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ac1b48-dcfd-48a1-b999-ccc642596d28.jpg?1",
             "name": "Legion Vanguard",
             "text": "{1}, Sacrifice another creature: Legion Vanguard explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "489ac6ff-8135-5db0-b435-d7d68bedd1ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a59a6f-6ef0-4acc-8358-a4e2cebdb7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a59a6f-6ef0-4acc-8358-a4e2cebdb7d5.jpg?1",
             "name": "Loathsome Curator",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nMenace\nWhen Loathsome Curator exploits a creature, destroy target creature you don't control with mana value 3 or less.",
             "colours": [
@@ -3188,7 +3188,7 @@
         },
         {
             "id": "0932efe2-a421-5d05-8912-0016a01ab3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4b7d1-16ed-4cc3-8db3-12fb8f25658c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4b7d1-16ed-4cc3-8db3-12fb8f25658c.jpg?1",
             "name": "Magus of the Bridge",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 2/2 black Zombie creature token.\nWhen a creature is put into an opponent's graveyard from the battlefield, exile Magus of the Bridge.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "216ef4eb-253e-52d7-8656-f5385923f1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f200ea9a-198b-4ba2-ad2b-ea4a133b7f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f200ea9a-198b-4ba2-ad2b-ea4a133b7f40.jpg?1",
             "name": "Necrogoyf",
             "text": "Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "0cbf105c-36fc-5cff-8daf-444c29184976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfb84f-582a-4fe2-9710-8b480a268571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfb84f-582a-4fe2-9710-8b480a268571.jpg?1",
             "name": "Necromancer's Familiar",
             "text": "Flying\nHellbent \u2014 Necromancer's Familiar has lifelink as long as you have no cards in hand.\n{B}, Discard a card: Necromancer's Familiar gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -3297,7 +3297,7 @@
         },
         {
             "id": "11376e91-39ff-5428-ba80-9cf2a590f52c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9851f290-f502-49f8-9b48-67f7966d4e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9851f290-f502-49f8-9b48-67f7966d4e34.jpg?1",
             "name": "Nested Shambler",
             "text": "When Nested Shambler dies, create X tapped 1/1 green Squirrel creature tokens, where X is Nested Shambler's power.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "1b0701b4-4ef7-5e88-b4d7-6f2d8fdb3245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f390c3-af1c-424f-9721-e26e9321e5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f390c3-af1c-424f-9721-e26e9321e5a3.jpg?1",
             "name": "Persist",
             "text": "Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "bd4e3e5a-e9ab-5a17-9609-0f4df4334ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afc6f7d-ab59-4d64-bd11-6bd0fd4bfcd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afc6f7d-ab59-4d64-bd11-6bd0fd4bfcd2.jpg?1",
             "name": "Profane Tutor",
             "text": "Suspend 2\u2014{1}{B} (Rather than cast this card from your hand, pay {1}{B} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -3403,7 +3403,7 @@
         },
         {
             "id": "d1947c1d-376e-5588-8725-6c4a41b1f9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c99e55-c605-4519-a52a-39dfdbabb44a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c99e55-c605-4519-a52a-39dfdbabb44a.jpg?1",
             "name": "Radiant Epicure",
             "text": "Converge \u2014 When Radiant Epicure enters the battlefield, each opponent loses X life and you gain X life, where X is the number of colors of mana spent to cast this spell.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "1deb3a21-57e1-51b0-adac-20d1197105b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db209732-c290-4999-a1aa-2369dfa8790c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db209732-c290-4999-a1aa-2369dfa8790c.jpg?1",
             "name": "Sinister Starfish",
             "text": "{T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "39da9411-38a6-56a0-9689-ecfc4dbe9cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cc8aeb-221d-46a1-b03f-df8499bba26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cc8aeb-221d-46a1-b03f-df8499bba26d.jpg?1",
             "name": "Sudden Edict",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget player sacrifices a creature.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "5515729d-86c2-55b0-b77b-481acc04acfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed4901c-9b1e-4e0e-ae71-81cb10779f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed4901c-9b1e-4e0e-ae71-81cb10779f07.jpg?1",
             "name": "Tizerus Charger",
             "text": "Escape\u2014{4}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nTizerus Charger escapes with your choice of a +1/+1 counter or a flying counter on it.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "9dccdb6b-43ce-5e3e-9284-dbdde8f36bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3526751-0101-4d91-a496-c53cd92326e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3526751-0101-4d91-a496-c53cd92326e0.jpg?1",
             "name": "Tourach, Dread Cantor",
             "text": "Kicker {B}{B} (You may pay an additional {B}{B} as you cast this spell.)\nProtection from white\nWhenever an opponent discards a card, put a +1/+1 counter on Tourach, Dread Cantor.\nWhen Tourach enters the battlefield, if it was kicked, target opponent discards two cards at random.",
             "colours": [
@@ -3580,7 +3580,7 @@
         },
         {
             "id": "61a8a6d8-1ede-5bff-ae9b-1c9f9173b8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d97fd7d-c29f-4db0-b909-2f6aa9c39d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d97fd7d-c29f-4db0-b909-2f6aa9c39d65.jpg?1",
             "name": "Tourach's Canticle",
             "text": "Target opponent reveals their hand. You choose a card from it. That player discards that card, then discards a card at random.",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "184173f6-96c5-5766-bf76-293763b82e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affc1d27-55f6-46e9-a67c-f15b6832813d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affc1d27-55f6-46e9-a67c-f15b6832813d.jpg?1",
             "name": "Tragic Fall",
             "text": "Target creature gets -3/-3 until end of turn.\nHellbent \u2014 That creature gets -13/-13 until end of turn instead if you have no cards in hand.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "b8ee2130-9975-5565-9664-628cf1bf790f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1a23a-084a-429b-823a-a8e7e5f26e0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1a23a-084a-429b-823a-a8e7e5f26e0d.jpg?1",
             "name": "Underworld Hermit",
             "text": "When Underworld Hermit enters the battlefield, create a number of 1/1 green Squirrel creature tokens equal to your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3681,7 +3681,7 @@
         },
         {
             "id": "cb24ae3a-882e-54be-ba49-82f43707b883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492b368b-de32-45c1-8459-238aae54f9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492b368b-de32-45c1-8459-238aae54f9fc.jpg?1",
             "name": "Unmarked Grave",
             "text": "Search your library for a nonlegendary card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "1fe41038-d72a-5315-b863-5e95184d84c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3166b10-5bc3-4db6-bb5b-81045d98e446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3166b10-5bc3-4db6-bb5b-81045d98e446.jpg?1",
             "name": "Vermin Gorger",
             "text": "{T}, Sacrifice another creature: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "2ad7d4b0-1112-5cf5-9c93-0bbe8c232a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d890ae71-da2b-44fa-8cfa-9c3016c9f696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d890ae71-da2b-44fa-8cfa-9c3016c9f696.jpg?1",
             "name": "Vile Entomber",
             "text": "Deathtouch\nWhen Vile Entomber enters the battlefield, search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "8e514156-e361-51a1-9420-3b943c052e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c1b08-3184-478f-92be-88db6cda33c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c1b08-3184-478f-92be-88db6cda33c5.jpg?1",
             "name": "World-Weary",
             "text": "Enchant creature\nEnchanted creature gets -4/-4.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3822,7 +3822,7 @@
         },
         {
             "id": "746ecc8b-4e8b-5140-abe6-81562949ba13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b5f6da-5e0f-4cce-92fe-7aa69124e265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b5f6da-5e0f-4cce-92fe-7aa69124e265.jpg?1",
             "name": "Young Necromancer",
             "text": "When Young Necromancer enters the battlefield, you may exile two cards from your graveyard. When you do, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "cd9fbb80-8140-521c-93bb-dcd6e2b7458b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcafff1a-e220-40ff-8c00-de6037219bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcafff1a-e220-40ff-8c00-de6037219bc6.jpg?1",
             "name": "Arcbound Slasher",
             "text": "Modular 4 (This creature enters the battlefield with four +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nRiot (This creature enters the battlefield with your choice of an additional +1/+1 counter or haste.)",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "e077aacd-54c8-5bbb-8e07-0debc0286aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881175c4-fee5-4c39-ad25-145ef73569ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881175c4-fee5-4c39-ad25-145ef73569ce.jpg?1",
             "name": "Arcbound Tracker",
             "text": "Menace\nModular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nWhenever you cast a spell other than your first spell each turn, put a +1/+1 counter on Arcbound Tracker.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "7a0371f0-58c7-56b9-9f12-2eb918c42852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154ed1d3-e24a-48ba-8f7b-be254c08d1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154ed1d3-e24a-48ba-8f7b-be254c08d1cc.jpg?1",
             "name": "Arcbound Whelp",
             "text": "Flying\n{R}: Arcbound Whelp gets +1/+0 until end of turn.\nModular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "83a799fe-b8d4-5dc3-88b4-aee546e69842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1e907-0e77-42ee-9eca-eae632020204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1e907-0e77-42ee-9eca-eae632020204.jpg?1",
             "name": "Battle Plan",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "4fe88e3b-f614-524a-b82b-57daa33153b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404fc9c-ef02-479c-9638-0cc163f0b48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404fc9c-ef02-479c-9638-0cc163f0b48f.jpg?1",
             "name": "Blazing Rootwalla",
             "text": "{R}: Blazing Rootwalla gets +2/+0 until end of turn. Activate only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "44db0613-6767-5cd0-b1c9-1f8045ac5973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6286fd93-bb97-4721-8a40-1c5a884c2edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6286fd93-bb97-4721-8a40-1c5a884c2edb.jpg?1",
             "name": "Bloodbraid Marauder",
             "text": "Bloodbraid Marauder can't block.\nDelirium \u2014 This spell has cascade as long as there are four or more card types among cards in your graveyard. (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "11941f28-14a0-56e2-ad46-262b536230a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b5b2e-dabf-4672-b476-4873781f636e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b5b2e-dabf-4672-b476-4873781f636e.jpg?1",
             "name": "Breya's Apprentice",
             "text": "When Breya's Apprentice enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\n{T}, Sacrifice an artifact: Choose one \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play that card.\n\u2022 Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "297daae4-aea2-52e7-8347-4d2bc2ccb14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37962700-e4d9-419e-8972-d3fd955ff40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37962700-e4d9-419e-8972-d3fd955ff40e.jpg?1",
             "name": "Calibrated Blast",
             "text": "Reveal cards from the top of your library until you reveal a nonland card. Put the revealed cards on the bottom of your library in a random order. When you reveal a nonland card this way, Calibrated Blast deals damage equal to that card's mana value to any target.\nFlashback {3}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "1ad4cc57-6629-50fd-8336-7fddee83fbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71052204-d35c-4603-9af6-a1691f438d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71052204-d35c-4603-9af6-a1691f438d48.jpg?1",
             "name": "Captain Ripley Vance",
             "text": "Whenever you cast your third spell each turn, put a +1/+1 counter on Captain Ripley Vance, then it deals damage equal to its power to any target.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "91d781ae-b01c-5996-9789-a76df55008fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936ebbd-512a-49a6-ab23-16ac34b4a3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936ebbd-512a-49a6-ab23-16ac34b4a3a9.jpg?1",
             "name": "Chef's Kiss",
             "text": "Gain control of target spell that targets only a single permanent or player. Copy it, then reselect the targets at random for the spell and the copy. The new targets can't be you or a permanent you control.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "34c7209b-75b9-5bab-a193-71a6fd7dccfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ced112a-e775-4f97-97b3-74877e9dce12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ced112a-e775-4f97-97b3-74877e9dce12.jpg?1",
             "name": "Dragon's Rage Channeler",
             "text": "Whenever you cast a noncreature spell, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Dragon's Rage Channeler gets +2/+2, has flying, and attacks each combat if able.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "6e52960a-8607-5a5f-98c5-26b1d9792e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8024ce-12c9-4139-934d-fb230103daa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8024ce-12c9-4139-934d-fb230103daa1.jpg?1",
             "name": "A-Dragon's Rage Channeler",
             "text": "",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "6d39cf23-abef-5606-a810-672cb08045a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed4077-4ed5-48fb-91c9-a9195d652978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed4077-4ed5-48fb-91c9-a9195d652978.jpg?1",
             "name": "Faithless Salvaging",
             "text": "Discard a card, then draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "ab3572c6-348a-55e4-b1a7-3213b23486d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg?1",
             "name": "Fast // Furious",
             "text": "Discard a card, then draw two cards.",
             "colours": [
@@ -4346,7 +4346,7 @@
         },
         {
             "id": "75d613c2-0d81-5e3b-8909-84f149b7ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg?1",
             "name": "Fast // Furious",
             "text": "Furious deals 3 damage to each creature without flying.",
             "colours": [
@@ -4378,7 +4378,7 @@
         },
         {
             "id": "b12be851-2866-5fcc-896a-1ed979949e98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93c6ba8-666b-4c05-8137-8ffa1d5d928b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93c6ba8-666b-4c05-8137-8ffa1d5d928b.jpg?1",
             "name": "Flame Blitz",
             "text": "At the beginning of your end step, Flame Blitz deals 5 damage to each planeswalker.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4410,7 +4410,7 @@
         },
         {
             "id": "56855e11-cd4d-5baa-82b1-4011cdc187d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ab05b5-d6f5-439c-9aed-1a58ceb282ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ab05b5-d6f5-439c-9aed-1a58ceb282ad.jpg?1",
             "name": "Flametongue Yearling",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nFlametongue Yearling enters the battlefield with a +1/+1 counter on it for each time it was kicked.\nWhen Flametongue Yearling enters the battlefield, it deals damage equal to its power to target creature.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "35b762b0-741a-544d-a178-bde5dd7712d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd281158-8180-40b9-a5b7-03cfc712d81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd281158-8180-40b9-a5b7-03cfc712d81a.jpg?1",
             "name": "Fury",
             "text": "Double strike\nWhen Fury enters the battlefield, it deals 4 damage divided as you choose among any number of target creatures and/or planeswalkers.\nEvoke\u2014\nExile a red card from your hand.",
             "colours": [
@@ -4483,7 +4483,7 @@
         },
         {
             "id": "c3d7c426-71e5-58dc-9d40-1190f5893758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06373318-e548-4664-b227-17e3b6fd0a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06373318-e548-4664-b227-17e3b6fd0a88.jpg?1",
             "name": "Galvanic Relay",
             "text": "Exile the top card of your library. During your next turn, you may play that card.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -4517,7 +4517,7 @@
         },
         {
             "id": "a580932d-339a-56ea-937d-b2fd9de5e841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b672c59-7376-455d-961e-ce94d47a5ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b672c59-7376-455d-961e-ce94d47a5ca4.jpg?1",
             "name": "Gargadon",
             "text": "Trample\nSuspend 4\u2014{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "975f39f4-20fa-59b8-898e-e3f090c3f793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee1fcbc-3573-42c5-b3e3-1f44a6400cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee1fcbc-3573-42c5-b3e3-1f44a6400cd0.jpg?1",
             "name": "Glimpse of Tomorrow",
             "text": "Suspend 3\u2014{R}{R}\nShuffle all permanents you own into your library, then reveal that many cards from the top of your library. Put all non-Aura permanent cards revealed this way onto the battlefield, then do the same for Aura cards, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "3f226ac8-07c4-5c6d-ba52-617246e09079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f0fd37-eb34-418d-b136-03d816c93034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f0fd37-eb34-418d-b136-03d816c93034.jpg?1",
             "name": "Goblin Traprunner",
             "text": "Whenever Goblin Traprunner attacks, flip three coins. For each flip you win, create a 1/1 red Goblin creature token that's tapped and attacking.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "5bf19897-929a-5bc2-8296-b3212962c7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0595a6-a9e5-4ea8-b733-382e6c365759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0595a6-a9e5-4ea8-b733-382e6c365759.jpg?1",
             "name": "Gouged Zealot",
             "text": "Reach\nDelirium \u2014 Whenever Gouged Zealot attacks, if there are four or more card types among cards in your graveyard, Gouged Zealot deals 1 damage to each creature defending player controls.",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "dbf1c895-2122-598c-b0df-c4654e2c3747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22579ac0-ad3f-4000-a65a-46a17a7f1aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22579ac0-ad3f-4000-a65a-46a17a7f1aa5.jpg?1",
             "name": "Harmonic Prodigy",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nIf an ability of a Shaman or another Wizard you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "f92b2d9c-9942-507f-9fb5-35bacb3eaef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f07603-fd79-437a-9b12-495fc5a39b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f07603-fd79-437a-9b12-495fc5a39b68.jpg?1",
             "name": "Kaleidoscorch",
             "text": "Converge \u2014 Kaleidoscorch deals X damage to any target, where X is the number of colors of mana spent to cast this spell.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "19e23990-573f-528c-86a9-b3588c407384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72fcda4-feb4-46e4-87d9-88bd95474fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72fcda4-feb4-46e4-87d9-88bd95474fe9.jpg?1",
             "name": "Lightning Spear",
             "text": "Equipped creature gets +1/+0 and has trample.\n{2}{R}, Sacrifice Lightning Spear: It deals 3 damage to any target.\nEquip {1}",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "7c289f95-f878-54fe-b049-23320d95519c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e2e8b5-660d-4469-a4fe-2367dfadb709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e2e8b5-660d-4469-a4fe-2367dfadb709.jpg?1",
             "name": "Mine Collapse",
             "text": "If it's your turn, you may sacrifice a Mountain rather than pay this spell's mana cost.\nMine Collapse deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "d09d7383-18fb-5957-a397-e1c8d7371639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a356c-b10d-42f2-bb2f-c3fd9affa4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a356c-b10d-42f2-bb2f-c3fd9affa4bd.jpg?1",
             "name": "Mount Velus Manticore",
             "text": "At the beginning of combat on your turn, you may discard a card. When you do, Mount Velus Manticore deals X damage to any target, where X is the number of card types the discarded card has.",
             "colours": [
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "4ceeba04-139b-5375-854d-0417af4a1cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6d08be-a6fc-44a5-932d-b6a8705534c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6d08be-a6fc-44a5-932d-b6a8705534c0.jpg?1",
             "name": "Obsidian Charmaw",
             "text": "This spell costs {1} less to cast for each land your opponents control that could produce {C}.\nFlying\nWhen Obsidian Charmaw enters the battlefield, destroy target nonbasic land an opponent controls.",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "03245f9c-8df0-5763-89fe-9fdfd55acfa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9738cda-adb1-47fb-9f4c-ecd930228c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9738cda-adb1-47fb-9f4c-ecd930228c4d.jpg?1",
             "name": "Ragavan, Nimble Pilferer",
             "text": "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\nDash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "ce2b0e14-d016-5755-a5ed-cdc33ffa6a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8f3008-a3ba-4f73-afa6-ad81074b3196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8f3008-a3ba-4f73-afa6-ad81074b3196.jpg?1",
             "name": "Revolutionist",
             "text": "When Revolutionist enters the battlefield, return target instant or sorcery card from your graveyard to your hand.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "c8752782-2de4-514e-bc73-f8d375ae72cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32691e3f-dea9-45ac-96fe-96b34d5116a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32691e3f-dea9-45ac-96fe-96b34d5116a9.jpg?1",
             "name": "Skophos Reaver",
             "text": "As long as it's your turn, Skophos Reaver gets +2/+0.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "18aad247-fbbe-5d81-93fc-51631927125e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a271f3-ea5f-4947-aac3-b4cffdfa87ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a271f3-ea5f-4947-aac3-b4cffdfa87ac.jpg?1",
             "name": "Slag Strider",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{1}, Sacrifice an artifact: Slag Strider deals 1 damage to any target.",
             "colours": [
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "a41fa9e7-3ac7-5df4-8ab3-7041a86c5c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c1918b-2f7a-4cab-9547-029ebc589000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c1918b-2f7a-4cab-9547-029ebc589000.jpg?1",
             "name": "Spreading Insurrection",
             "text": "Gain control of target creature you don't control until end of turn. Untap that creature. It gains haste until end of turn.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "630aa7b3-3cce-510e-93c8-e3c6cecb87c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c2814-a617-4123-acdf-1b01b2768210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c2814-a617-4123-acdf-1b01b2768210.jpg?1",
             "name": "Strike It Rich",
             "text": "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "02c756db-2e95-5811-b220-3a25adafb4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55082c8a-d792-4cd8-94b1-d80c65804463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55082c8a-d792-4cd8-94b1-d80c65804463.jpg?1",
             "name": "Tavern Scoundrel",
             "text": "Whenever you win a coin flip, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{1}, {T}, Sacrifice another permanent: Flip a coin.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "f00bdb93-10ca-5f1c-a496-bd927a5dd483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b73d294-6ab1-4051-9b0f-d8e335d37674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b73d294-6ab1-4051-9b0f-d8e335d37674.jpg?1",
             "name": "Unholy Heat",
             "text": "Unholy Heat deals 2 damage to target creature or planeswalker.\nDelirium \u2014 Unholy Heat deals 6 damage instead if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "70f7824d-a4b0-5392-855c-5a44f256a45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d5d2b5-3769-4341-b84e-03771dbb7491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d5d2b5-3769-4341-b84e-03771dbb7491.jpg?1",
             "name": "A-Unholy Heat",
             "text": "",
             "colours": [
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "f9380142-47eb-52b7-8846-0556d638939e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457e346-a5de-4624-b577-f59d4c186537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457e346-a5de-4624-b577-f59d4c186537.jpg?1",
             "name": "Viashino Lashclaw",
             "text": "{T}, Discard a card: Creatures you control gain haste until end of turn.",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "f75dbc69-1235-5f1e-8d85-87fe0e10e162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad86b17-3fed-418a-938c-c49adb409531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad86b17-3fed-418a-938c-c49adb409531.jpg?1",
             "name": "Abundant Harvest",
             "text": "Choose land or nonland. Reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "a915abd3-3577-5bee-81ae-79c30c5dec36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9b1b8-dffe-427d-be1e-2c6b8395bd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9b1b8-dffe-427d-be1e-2c6b8395bd54.jpg?1",
             "name": "Aeve, Progenitor Ooze",
             "text": "Storm (When you cast this spell, copy it for each spell cast before it this turn. Copies become tokens.)\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "70f751cc-feee-5f1d-8721-e2e865b69707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1271251b-7d79-4cb4-80bb-98574aa63249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1271251b-7d79-4cb4-80bb-98574aa63249.jpg?1",
             "name": "Bannerhide Krushok",
             "text": "Trample\nReinforce 2\u2014{1}{G} ({1}{G}, Discard this card: Put two +1/+1 counters on target creature.)\nScavenge {5}{G}{G} ({5}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "8823bb45-52f3-5e0b-b6a2-8c8242c4593c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217881d-26dc-44c0-81d8-8c78c44bc5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217881d-26dc-44c0-81d8-8c78c44bc5f0.jpg?1",
             "name": "Blessed Respite",
             "text": "Target player shuffles their graveyard into their library. Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5344,7 +5344,7 @@
         },
         {
             "id": "786db635-7c4f-51ed-80cd-fb28968549ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1785cf85-1ac0-4246-9b89-1a8221a8e1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1785cf85-1ac0-4246-9b89-1a8221a8e1b2.jpg?1",
             "name": "Chatterfang, Squirrel General",
             "text": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)\nIf one or more tokens would be created under your control, those tokens plus that many 1/1 green Squirrel creature tokens are created instead.\n{B}, Sacrifice X Squirrels: Target creature gets +X/-X until end of turn.",
             "colours": [
@@ -5385,7 +5385,7 @@
         },
         {
             "id": "16613a30-fb25-5060-a506-d57655df7724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34f0ac1-6894-4761-b62c-b85d927acf09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34f0ac1-6894-4761-b62c-b85d927acf09.jpg?1",
             "name": "Chatterstorm",
             "text": "Create a 1/1 green Squirrel creature token.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "fc29d230-0403-564e-9c78-902e66f885b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee33ff3-d3d6-4519-9d9f-72e342d8b215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee33ff3-d3d6-4519-9d9f-72e342d8b215.jpg?1",
             "name": "Chitterspitter",
             "text": "At the beginning of your upkeep, you may sacrifice a token. If you do, put an acorn counter on Chitterspitter.\nSquirrels you control get +1/+1 for each acorn counter on Chitterspitter.\n{G}, {T}: Create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -5453,7 +5453,7 @@
         },
         {
             "id": "5ba7cf2a-eecc-589e-ad0c-7099358fd62f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b77a34-9b69-4b01-9f2c-2ff8de47fc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b77a34-9b69-4b01-9f2c-2ff8de47fc12.jpg?1",
             "name": "Crack Open",
             "text": "Destroy target artifact or enchantment. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5485,7 +5485,7 @@
         },
         {
             "id": "58e2d31f-3631-5dbe-b9bc-f892761bec8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333f02f7-3b8a-41e3-9ae5-2151539e64ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333f02f7-3b8a-41e3-9ae5-2151539e64ad.jpg?1",
             "name": "Deepwood Denizen",
             "text": "Vigilance\n{5}{G}, {T}: Draw a card. This ability costs {1} less to activate for each +1/+1 counter on creatures you control.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "032ae38c-deb0-5abe-9434-e07f396d29d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af03fc3-5eb6-404e-96d9-e291a1e11ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af03fc3-5eb6-404e-96d9-e291a1e11ec3.jpg?1",
             "name": "Duskshell Crawler",
             "text": "When Duskshell Crawler enters the battlefield, put a +1/+1 counter on target creature.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5554,7 +5554,7 @@
         },
         {
             "id": "bba0bda1-9086-533a-91c2-60cfd687952b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e0404-4846-4891-acfa-bd0951ecf9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e0404-4846-4891-acfa-bd0951ecf9c6.jpg?1",
             "name": "Endurance",
             "text": "Flash\nReach\nWhen Endurance enters the battlefield, up to one target player puts all the cards from their graveyard on the bottom of their library in a random order.\nEvoke\u2014\nExile a green card from your hand.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "39f7da46-44b4-5b1f-8309-8f60b0467bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de8307a-7da3-4a4c-98dc-d6624b1f869d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de8307a-7da3-4a4c-98dc-d6624b1f869d.jpg?1",
             "name": "Fae Offering",
             "text": "At the beginning of each end step, if you've cast both a creature spell and a noncreature spell this turn, create a Clue token, a Food token, and a Treasure token.",
             "colours": [
@@ -5623,7 +5623,7 @@
         },
         {
             "id": "e8b1fe41-463f-561f-b231-b4d91f97daf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4b23a5-d997-4f02-b136-44ee7be51c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4b23a5-d997-4f02-b136-44ee7be51c7b.jpg?1",
             "name": "Flourishing Strike",
             "text": "Choose one \u2014\n\u2022 Flourishing Strike deals 5 damage to target creature with flying.\n\u2022 Target creature gets +3/+3 until end of turn.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "68a8c8e6-1696-5988-9118-52076bffb67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f08381e-34f5-4d08-b737-8c37964719e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f08381e-34f5-4d08-b737-8c37964719e0.jpg?1",
             "name": "Foundation Breaker",
             "text": "When Foundation Breaker enters the battlefield, you may destroy target artifact or enchantment.\nEvoke {1}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -5689,7 +5689,7 @@
         },
         {
             "id": "1b2989a3-2070-50a9-b8ec-c7b148b5ac93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b486c9cf-b0a6-44a4-b4c1-b3f5eed6c294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b486c9cf-b0a6-44a4-b4c1-b3f5eed6c294.jpg?1",
             "name": "Funnel-Web Recluse",
             "text": "Reach\nMorbid \u2014 When Funnel-Web Recluse enters the battlefield, if a creature died this turn, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "1bddc1db-30dc-5515-99f0-880aa56a3cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488996b2-06c8-4866-bf0d-4664640c2be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488996b2-06c8-4866-bf0d-4664640c2be1.jpg?1",
             "name": "Gaea's Will",
             "text": "Suspend 4\u2014{G}\nUntil end of turn, you may play lands and cast spells from your graveyard.\nIf a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -5758,7 +5758,7 @@
         },
         {
             "id": "d6733510-296c-52c2-83cd-f4f829b14cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03250752-bd85-485a-b19a-fa344c4ffd50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03250752-bd85-485a-b19a-fa344c4ffd50.jpg?1",
             "name": "Glimmer Bairn",
             "text": "Sacrifice a token: Glimmer Bairn gets +2/+2 until end of turn.",
             "colours": [
@@ -5794,7 +5794,7 @@
         },
         {
             "id": "dd42029e-2aa7-5ebe-bfc7-a372072a23e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad2438-0b98-4b07-bba9-dff26aa1fc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad2438-0b98-4b07-bba9-dff26aa1fc3a.jpg?1",
             "name": "Glinting Creeper",
             "text": "Converge \u2014 Glinting Creeper enters the battlefield with two +1/+1 counters on it for each color of mana spent to cast it.\nGlinting Creeper can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -5828,7 +5828,7 @@
         },
         {
             "id": "0a16f035-219d-54dd-b37a-80cbcfc56f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9cef5-c55f-47d9-9d2f-300dab8fcb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9cef5-c55f-47d9-9d2f-300dab8fcb0b.jpg?1",
             "name": "Herd Baloth",
             "text": "Whenever one or more +1/+1 counters are put on Herd Baloth, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "9fe00ec6-4efb-5672-8361-45b31217f1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba51852-af8f-49d8-8fb6-22d52a1742b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba51852-af8f-49d8-8fb6-22d52a1742b8.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {B}, {R}, or {G}.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "8be5e8e1-056a-55c9-a6d8-4b4d1b1d2c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81500be-c959-4f38-bcf2-d63519168f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81500be-c959-4f38-bcf2-d63519168f67.jpg?1",
             "name": "Jade Avenger",
             "text": "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "68aa0ff7-db4d-5ada-884c-0f5b0afb175b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8db60d-3adf-45e1-b4d0-3b5e24f5e01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8db60d-3adf-45e1-b4d0-3b5e24f5e01d.jpg?1",
             "name": "Jewel-Eyed Cobra",
             "text": "Deathtouch\nWhen Jewel-Eyed Cobra dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5973,7 +5973,7 @@
         },
         {
             "id": "b627a97f-d93a-5621-bc0d-1f9a43d9f9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386da156-59cd-4b96-9276-a7cb2ddd0421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386da156-59cd-4b96-9276-a7cb2ddd0421.jpg?1",
             "name": "Orchard Strider",
             "text": "When Orchard Strider enters the battlefield, create two Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "3d7d671d-b317-54b0-a5c4-ed7dbe1895d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dbd212-f1e8-429a-bf00-b2ea966d880e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dbd212-f1e8-429a-bf00-b2ea966d880e.jpg?1",
             "name": "Rift Sower",
             "text": "{T}: Add one mana of any color.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -6042,7 +6042,7 @@
         },
         {
             "id": "a171ca5b-21d9-5eb0-8b34-0c10baa7e85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42e22d-f60e-40c5-b069-5e1708f3bebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42e22d-f60e-40c5-b069-5e1708f3bebc.jpg?1",
             "name": "Sanctum Weaver",
             "text": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
             "colours": [
@@ -6079,7 +6079,7 @@
         },
         {
             "id": "4a592365-8d77-51d4-92ce-0d260b655c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb48c2e-ee0f-4fae-9c22-247870c10d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb48c2e-ee0f-4fae-9c22-247870c10d5b.jpg?1",
             "name": "Scurry Oak",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever one or more +1/+1 counters are put on Scurry Oak, you may create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -6113,7 +6113,7 @@
         },
         {
             "id": "6febda23-d8db-5d34-aacd-604ce7ada5b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956a2a42-6a91-45b5-99f1-87c2cf1dd608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956a2a42-6a91-45b5-99f1-87c2cf1dd608.jpg?1",
             "name": "Smell Fear",
             "text": "Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nTarget creature you control fights up to one target creature you don't control.",
             "colours": [
@@ -6145,7 +6145,7 @@
         },
         {
             "id": "bf913d4a-4ffe-5d8e-9653-25858944c371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6ab503-5e9a-4339-a0e7-a909b2908f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6ab503-5e9a-4339-a0e7-a909b2908f41.jpg?1",
             "name": "Squirrel Sanctuary",
             "text": "When Squirrel Sanctuary enters the battlefield, create a 1/1 green Squirrel creature token.\nWhenever a nontoken creature you control dies, you may pay {1}. If you do, return Squirrel Sanctuary to its owner's hand.",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "ef7206ea-4035-5f0b-9be2-9244d488557a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f739d55-30d6-4879-872a-82c6778113de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f739d55-30d6-4879-872a-82c6778113de.jpg?1",
             "name": "Squirrel Sovereign",
             "text": "Other Squirrels you control get +1/+1.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "7fa2b918-4c94-57d5-bc74-d74e032fb17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg?1",
             "name": "Sylvan Anthem",
             "text": "Green creatures you control get +1/+1.\nWhenever a green creature enters the battlefield under your control, scry 1.",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "7d0db270-7867-5eae-b17d-43faf4a87b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b08596-f6c7-4366-a4ed-21a11fbc901a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b08596-f6c7-4366-a4ed-21a11fbc901a.jpg?1",
             "name": "Terramorph",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "ec7313ae-020f-5223-b174-ba0b6dfa515d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172da14-9a87-4cf9-aff5-aca3470a67ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172da14-9a87-4cf9-aff5-aca3470a67ef.jpg?1",
             "name": "Thrasta, Tempest's Roar",
             "text": "This spell costs {3} less to cast for each other spell cast this turn.\nTrample, haste\nTrample over planeswalkers (This creature can deal excess combat damage to the controller of the planeswalker it's attacking.)\nThrasta, Tempest's Roar has hexproof as long as it entered the battlefield this turn.",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "921bad4c-b100-51b6-a988-b2e0e93c8f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22c07e2-91d2-4edb-bd2b-cca6d4cefcc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22c07e2-91d2-4edb-bd2b-cca6d4cefcc9.jpg?1",
             "name": "Timeless Witness",
             "text": "When Timeless Witness enters the battlefield, return target card from your graveyard to your hand.\nEternalize {5}{G}{G} ({5}{G}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Shaman with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -6355,7 +6355,7 @@
         },
         {
             "id": "05b1bbe5-5e39-51e6-940e-352de3185cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5be54d-660e-42ab-b5ea-5e1cf3bad0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5be54d-660e-42ab-b5ea-5e1cf3bad0bc.jpg?1",
             "name": "Tireless Provisioner",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a Food token or a Treasure token. (Food is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\" Treasure is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6390,7 +6390,7 @@
         },
         {
             "id": "d4bdc3c4-08cb-5fee-b4ac-001500fd9731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab83a39-d90d-403e-b74d-fe99c8b2aacd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab83a39-d90d-403e-b74d-fe99c8b2aacd.jpg?1",
             "name": "Urban Daggertooth",
             "text": "Vigilance\nEnrage \u2014 Whenever Urban Daggertooth is dealt damage, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "3ed1ee79-8985-525d-a7b0-a0fe80820a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83031ea8-a6c9-4318-af16-bba701dd76bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83031ea8-a6c9-4318-af16-bba701dd76bb.jpg?1",
             "name": "Verdant Command",
             "text": "Choose two \u2014\n\u2022 Target player creates two tapped 1/1 green Squirrel creature tokens.\n\u2022 Counter target loyalty ability of a planeswalker.\n\u2022 Exile target card from a graveyard.\n\u2022 Target player gains 3 life.",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "bb0d88ef-8ea4-5e9e-9449-a02d99654564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5198ac65-118c-4616-8315-d71d41b883ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5198ac65-118c-4616-8315-d71d41b883ad.jpg?1",
             "name": "Wren's Run Hydra",
             "text": "Reach\nWren's Run Hydra enters the battlefield with X +1/+1 counters on it.\nReinforce X\u2014{X}{G}{G} ({X}{G}{G}, Discard this card: Put X +1/+1 counters on target creature.)",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "b52cb624-9eb4-5c02-b583-f10a42e05591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54c510-19bf-4da4-a51b-1caadf960654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54c510-19bf-4da4-a51b-1caadf960654.jpg?1",
             "name": "Arcbound Shikari",
             "text": "First strike\nWhen Arcbound Shikari enters the battlefield, put a +1/+1 counter on each other artifact creature you control.\nModular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -6532,7 +6532,7 @@
         },
         {
             "id": "cd40b240-991a-50f7-8dbc-b900187fd96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8546eaa-1e64-4e70-b6a5-85892bab8c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8546eaa-1e64-4e70-b6a5-85892bab8c47.jpg?1",
             "name": "Arcus Acolyte",
             "text": "Reach, lifelink\nOutlast {RW} ({RW}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach other creature you control without a +1/+1 counter on it has outlast {RW}.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "901d71b1-77da-542e-bd5d-703c0c6ab5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a9a7d-d9ca-4c11-80ab-e39d5943a315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a9a7d-d9ca-4c11-80ab-e39d5943a315.jpg?1",
             "name": "Asmoranomardicadaistinaculdacar",
             "text": "As long as you've discarded a card this turn, you may pay {BR} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters the battlefield, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "59049ca3-0cbb-58f8-af19-b51f6a0cdd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4785739-821d-49b0-a298-3c2b95e16972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4785739-821d-49b0-a298-3c2b95e16972.jpg?1",
             "name": "Breathless Knight",
             "text": "Flying, lifelink\nWhenever Breathless Knight or another creature enters the battlefield under your control, if that creature entered from a graveyard or you cast it from a graveyard, put a +1/+1 counter on Breathless Knight.",
             "colours": [
@@ -6651,7 +6651,7 @@
         },
         {
             "id": "e08c8e8d-c6b1-5e07-ac95-803a45b986ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1c2a8-688b-4f63-8d58-e325efc6052a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1c2a8-688b-4f63-8d58-e325efc6052a.jpg?1",
             "name": "Captured by Lagacs",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen Captured by Lagacs enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two target creatures.)",
             "colours": [
@@ -6687,7 +6687,7 @@
         },
         {
             "id": "2256eea9-574e-5d43-beff-766e6c908143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09e9b65-ff0e-4efe-b96a-ede69c96e2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09e9b65-ff0e-4efe-b96a-ede69c96e2ea.jpg?1",
             "name": "Carth the Lion",
             "text": "Whenever Carth the Lion enters the battlefield or a planeswalker you control dies, look at the top seven cards of your library. You may reveal a planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nPlaneswalkers' loyalty abilities you activate cost an additional  to activate.",
             "colours": [
@@ -6729,7 +6729,7 @@
         },
         {
             "id": "7865399b-cae1-51b9-a659-fae243390308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d8da1-a183-470a-b4ed-2e35ac5ab9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d8da1-a183-470a-b4ed-2e35ac5ab9a9.jpg?1",
             "name": "Chrome Courier",
             "text": "Flying\nWhen Chrome Courier enters the battlefield, reveal the top two cards of your library. Put one of them into your hand and the other into your graveyard. If you put an artifact card into your hand this way, you gain 3 life.",
             "colours": [
@@ -6766,7 +6766,7 @@
         },
         {
             "id": "96cf6577-a58f-5c40-bb73-3b102049d970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d54ec2-a458-4e13-97b8-be99b7338548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d54ec2-a458-4e13-97b8-be99b7338548.jpg?1",
             "name": "Combine Chrysalis",
             "text": "Creature tokens you control have flying.\n{2}{G}{U}, {T}, Sacrifice a token: Create a 4/4 green Beast creature token. Activate only as a sorcery.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "7f38cd7c-eb22-5b85-bad6-53e75d512bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1",
             "name": "Dakkon, Shadow Slayer",
             "text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n\u22123: Exile target creature.\n\u22126: You may put an artifact card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "0339991b-f176-5833-8b0e-7da99bd7f562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091e8dc-b546-4b74-9dc9-aef55f60d13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091e8dc-b546-4b74-9dc9-aef55f60d13a.jpg?1",
             "name": "Dihada's Ploy",
             "text": "Draw two cards, then discard a card. You gain life equal to the number of cards you've discarded this turn.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "c599288b-7492-5821-ad27-bd901fa9ae7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995529d1-e2b0-4cce-bd40-56c7ef3c33da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995529d1-e2b0-4cce-bd40-56c7ef3c33da.jpg?1",
             "name": "Drey Keeper",
             "text": "When Drey Keeper enters the battlefield, create two 1/1 green Squirrel creature tokens.\n{3}{B}: Squirrels you control get +1/+0 and gain menace until end of turn.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "6cd3dbef-d86a-5e85-967c-6f3352677908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315ae21a-4d95-488e-812b-0d018219af6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315ae21a-4d95-488e-812b-0d018219af6c.jpg?1",
             "name": "Ethersworn Sphinx",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card with lesser mana value. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6955,7 +6955,7 @@
         },
         {
             "id": "b8ac34f1-8ac7-53fd-9b76-060ac0f2b49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c54b7c6-f94c-4349-8725-319c54240409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c54b7c6-f94c-4349-8725-319c54240409.jpg?1",
             "name": "Foundry Helix",
             "text": "As an additional cost to cast this spell, sacrifice a permanent.\nFoundry Helix deals 4 damage to any target. If the sacrificed permanent was an artifact, you gain 4 life.",
             "colours": [
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "38f03b7e-f44a-554b-ad1d-c9f4876db2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23774462-9f17-4b50-a2ac-b2edd706bbfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23774462-9f17-4b50-a2ac-b2edd706bbfe.jpg?1",
             "name": "Garth One-Eye",
             "text": "{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy. (You still pay its costs.)",
             "colours": [
@@ -7037,7 +7037,7 @@
         },
         {
             "id": "0347fbcf-2de8-5c4e-93bb-569c46ebb9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600dca0f-5964-45e7-86df-f16a5b4a0106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600dca0f-5964-45e7-86df-f16a5b4a0106.jpg?1",
             "name": "General Ferrous Rokiric",
             "text": "Hexproof from monocolored\nWhenever you cast a multicolored spell, create a 4/4 red and white Golem artifact creature token.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "022b3dd6-a6c7-506f-bf99-27a19430b061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d228005-91f1-451e-ab6f-1f86316708a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d228005-91f1-451e-ab6f-1f86316708a7.jpg?1",
             "name": "Geyadrone Dihada",
             "text": "Protection from permanents with corruption counters on them\n+1: Each opponent loses 2 life and you gain 2 life. Put a corruption counter on up to one other target creature or planeswalker.\n\u22123: Gain control of target creature or planeswalker until end of turn. Untap it and put a corruption counter on it. It gains haste until end of turn.\n\u22127: Gain control of each permanent with a corruption counter on it.",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "038fb204-7715-5533-b910-52bc58bf2f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a3423-501d-4b22-95a6-743233be521e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a3423-501d-4b22-95a6-743233be521e.jpg?1",
             "name": "Goblin Anarchomancer",
             "text": "Each spell you cast that's red or green costs {1} less to cast.",
             "colours": [
@@ -7160,7 +7160,7 @@
         },
         {
             "id": "d4ddd301-0455-5b3f-8b5f-f5d36838f79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d7c3c-02f2-4c42-bcfa-0b83de30f607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d7c3c-02f2-4c42-bcfa-0b83de30f607.jpg?1",
             "name": "Graceful Restoration",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to the battlefield with an additional +1/+1 counter on it.\n\u2022 Return up to two target creature cards with power 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "60b27752-6378-5bba-8b0a-936f9febede2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af2825-18c2-4463-b6ba-42eaa070ccc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af2825-18c2-4463-b6ba-42eaa070ccc1.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n+1: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n\u22122: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n\u22125: Each opponent loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "1f5b63a5-768d-56d5-b61b-f839482228d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e68f3d-ef94-4651-a256-c72017f64b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e68f3d-ef94-4651-a256-c72017f64b21.jpg?1",
             "name": "Lazotep Chancellor",
             "text": "Whenever you discard a card, you may pay {1}. If you do, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "344ebfca-3a74-5819-a151-1be263315158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd08da-6717-49ee-94ba-2562224f5baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd08da-6717-49ee-94ba-2562224f5baa.jpg?1",
             "name": "Lonis, Cryptozoologist",
             "text": "Whenever another nontoken creature enters the battlefield under your control, investigate.\n{T}, Sacrifice X Clues: Target opponent reveals the top X cards of their library. You may put a nonland permanent card with mana value X or less from among them onto the battlefield under your control. That player puts the rest on the bottom of their library in a random order.",
             "colours": [
@@ -7316,7 +7316,7 @@
         },
         {
             "id": "d87624b2-9aad-5de3-b0fd-c6fbcd9cc01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9775175-6763-4826-afc8-dc520a235c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9775175-6763-4826-afc8-dc520a235c36.jpg?1",
             "name": "Master of Death",
             "text": "When Master of Death enters the battlefield, surveil 2.\nAt the beginning of your upkeep, if Master of Death is in your graveyard, you may pay 1 life. If you do, return it to your hand.",
             "colours": [
@@ -7355,7 +7355,7 @@
         },
         {
             "id": "53a2b4a5-db12-5bd5-bce6-2582712e9136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41b3d7a-f8e1-46b8-a689-6125dcd9cb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41b3d7a-f8e1-46b8-a689-6125dcd9cb17.jpg?1",
             "name": "Moderation",
             "text": "You can't cast more than one spell each turn.\nWhenever you cast a spell, draw a card.",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "fdc3ee1f-6310-5350-9dc0-c91441d4dccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82d946-1efb-4253-84ab-93c88d2d1d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82d946-1efb-4253-84ab-93c88d2d1d84.jpg?1",
             "name": "Piru, the Volatile",
             "text": "Flying, lifelink\nAt the beginning of your upkeep, sacrifice Piru, the Volatile unless you pay {R}{W}{B}.\nWhen Piru dies, it deals 7 damage to each nonlegendary creature.",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "aee62f4e-1c56-53c0-bac8-4744fe4312e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116329d-6de7-402c-821d-e9aeba9ad2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116329d-6de7-402c-821d-e9aeba9ad2b1.jpg?1",
             "name": "Priest of Fell Rites",
             "text": "{T}, Pay 3 life, Sacrifice Priest of Fell Rites: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.\nUnearth {3}{W}{B} ({3}{W}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "42d8848b-6238-5f45-bb6f-c1ed25f92e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b92ae-eb84-4548-a5e5-a07c79b77f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b92ae-eb84-4548-a5e5-a07c79b77f7f.jpg?1",
             "name": "Prophetic Titan",
             "text": "Delirium \u2014 When Prophetic Titan enters the battlefield, choose one. If there are four or more card types among cards in your graveyard, choose both instead.\n\u2022 Prophetic Titan deals 4 damage to any target.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "468202d6-ac9b-599a-b285-d85eb43ec11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6576b-605c-4007-a2a7-0d7550520d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6576b-605c-4007-a2a7-0d7550520d6d.jpg?1",
             "name": "Rakdos Headliner",
             "text": "Haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "a8cf40cf-8cdc-510d-8ecd-cc5c91a8b023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f44a15c-1bb4-4fb8-88a0-e4d3f2dee1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f44a15c-1bb4-4fb8-88a0-e4d3f2dee1b4.jpg?1",
             "name": "Ravenous Squirrel",
             "text": "Whenever you sacrifice an artifact or creature, put a +1/+1 counter on Ravenous Squirrel.\n{1}{B}{G}, Sacrifice an artifact or creature: You gain 1 life and draw a card.",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "d0245e59-81bc-58ec-974d-49f6335d7568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg?1",
             "name": "Road // Ruin",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "32f25efe-29ab-5926-a6e8-ebe09c8c26cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg?1",
             "name": "Road // Ruin",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nRuin deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -7659,7 +7659,7 @@
         },
         {
             "id": "5c90b22c-6747-518c-9bff-2edb76df45d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d22f24-f752-4bc8-ba97-061b2c060ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d22f24-f752-4bc8-ba97-061b2c060ec8.jpg?1",
             "name": "Storm God's Oracle",
             "text": "{1}: Storm God's Oracle gets +1/-1 until end of turn.\nWhen Storm God's Oracle dies, it deals 3 damage to any target.",
             "colours": [
@@ -7697,7 +7697,7 @@
         },
         {
             "id": "c8395ba1-79c0-5c6a-88f0-bfbf55cbf023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0babfe00-9bad-48fc-b3b1-df8280242fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0babfe00-9bad-48fc-b3b1-df8280242fd2.jpg?1",
             "name": "Sythis, Harvest's Hand",
             "text": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "ccb85cb5-9903-5f25-91d4-9ddc338161d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e94ad-0e12-48bb-aae1-2c842943114a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e94ad-0e12-48bb-aae1-2c842943114a.jpg?1",
             "name": "Terminal Agony",
             "text": "Destroy target creature.\nMadness {B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -7774,7 +7774,7 @@
         },
         {
             "id": "0c7ac7ef-8309-5d9c-9948-af923774e24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2605df98-0b02-4aab-bc36-01e93c693743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2605df98-0b02-4aab-bc36-01e93c693743.jpg?1",
             "name": "Territorial Kavu",
             "text": "Domain \u2014 Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.\nWhenever Territorial Kavu attacks, choose one \u2014\n\u2022 Discard a card. If you do, draw a card.\n\u2022 Exile up to one target card from a graveyard.",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "bb679e2e-59ba-5c19-8418-2d416596f7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a269277-7f4e-40de-a2b4-53aa50cfd665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a269277-7f4e-40de-a2b4-53aa50cfd665.jpg?1",
             "name": "Wavesifter",
             "text": "Flying\nWhen Wavesifter enters the battlefield, investigate twice. (To investigate, create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nEvoke {G}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -7849,7 +7849,7 @@
         },
         {
             "id": "f0e7a4a5-3f8d-5dde-a378-b6019e7998be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfab9e33-0d07-46e6-be06-1eaffe26cbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfab9e33-0d07-46e6-be06-1eaffe26cbfd.jpg?1",
             "name": "Yusri, Fortune's Flame",
             "text": "Flying\nWhenever Yusri, Fortune's Flame attacks, choose a number between 1 and 5. Flip that many coins. For each flip you win, draw a card. For each flip you lose, Yusri deals 2 damage to you. If you won five flips this way, you may cast spells from your hand this turn without paying their mana costs.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "8a5ba1bf-3ecb-552c-9a77-49f5bc54d21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90744c2c-6dd7-4623-8cbf-b138b83ee88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90744c2c-6dd7-4623-8cbf-b138b83ee88f.jpg?1",
             "name": "Academy Manufactor",
             "text": "If you would create a Clue, Food, or Treasure token, instead create one of each.",
             "colours": [],
@@ -7923,7 +7923,7 @@
         },
         {
             "id": "520e18b6-c118-57a9-9045-9dd3873daf0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b3a98f-2b3c-438b-b78c-eef8d917f68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b3a98f-2b3c-438b-b78c-eef8d917f68e.jpg?1",
             "name": "Altar of the Goyf",
             "text": "Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of card types among cards in all graveyards.\nLhurgoyf creatures you control have trample.",
             "colours": [],
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "8e0f6bde-da2a-5a7f-99c6-2d7b039a9545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94266c32-774f-42fa-84d7-7b646c950587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94266c32-774f-42fa-84d7-7b646c950587.jpg?1",
             "name": "Batterbone",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1 and has vigilance and lifelink.\nEquip {5}",
             "colours": [],
@@ -7984,7 +7984,7 @@
         },
         {
             "id": "1d1893c3-2f98-5626-b354-1748328f838a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a36a1-b2e3-4779-b8a7-66f01c488bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a36a1-b2e3-4779-b8a7-66f01c488bf0.jpg?1",
             "name": "Bottle Golems",
             "text": "Trample\nWhen Bottle Golems dies, you gain life equal to its power.",
             "colours": [],
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "0eb43c00-9e9f-5764-aafa-8d82b0011b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9a9f6-5be5-47aa-8e2f-576d06c5abb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9a9f6-5be5-47aa-8e2f-576d06c5abb9.jpg?1",
             "name": "Brainstone",
             "text": "{2}, {T}, Sacrifice Brainstone: Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [],
@@ -8045,7 +8045,7 @@
         },
         {
             "id": "1ab21c82-3c73-5c52-bfbd-a7713daaed49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a37428-e969-4c0c-8e1c-55d1adf9c171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a37428-e969-4c0c-8e1c-55d1adf9c171.jpg?1",
             "name": "Dermotaxi",
             "text": "Imprint \u2014 As Dermotaxi enters the battlefield, exile a creature card from a graveyard.\nTap two untapped creatures you control: Until end of turn, Dermotaxi becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "c6752631-71a3-55cf-b58a-ad29bd99e064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317a8ed5-1ec2-4a5d-a606-8c6ba781c8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317a8ed5-1ec2-4a5d-a606-8c6ba781c8a3.jpg?1",
             "name": "Diamond Lion",
             "text": "{T}, Discard your hand, Sacrifice Diamond Lion: Add three mana of any one color. Activate only as an instant.",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "7680da45-392c-5b86-96df-9164599a2ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd401525-b874-4af2-99a3-c2c83e22547e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd401525-b874-4af2-99a3-c2c83e22547e.jpg?1",
             "name": "Fodder Tosser",
             "text": "{T}, Discard a card: Fodder Tosser deals 2 damage to target player or planeswalker.",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "cc1d3799-8da6-51a4-9a77-a373fe5a0d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2855-6b14-44dd-a398-7dc2bbae081f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2855-6b14-44dd-a398-7dc2bbae081f.jpg?1",
             "name": "Kaldra Compleat",
             "text": "Living weapon\nIndestructible\nEquipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"\nEquip {7}",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "67ad2b48-2b8e-583b-b5f5-f8d4d808cff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6101a-da40-4785-8ccb-4e779bbbdb55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6101a-da40-4785-8ccb-4e779bbbdb55.jpg?1",
             "name": "Liquimetal Torque",
             "text": "{T}: Add {C}.\n{T}: Target nonland permanent becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "78532063-e9e5-5761-b911-cdf4a65b4f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736aae2-5136-4f8f-9283-baf6b542a6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736aae2-5136-4f8f-9283-baf6b542a6a8.jpg?1",
             "name": "Monoskelion",
             "text": "Monoskelion enters the battlefield with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from Monoskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "1b31525f-16f0-5d0a-a7d8-cb2c2b1546c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9072a5-bd7f-4007-a34a-ebe251c95356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9072a5-bd7f-4007-a34a-ebe251c95356.jpg?1",
             "name": "Myr Scrapling",
             "text": "Sacrifice Myr Scrapling: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "76f97ff8-a66c-522b-bf47-d13bfd54e2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0bb5dc-75a6-4bd6-81f8-611197fb0fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0bb5dc-75a6-4bd6-81f8-611197fb0fba.jpg?1",
             "name": "Nettlecyst",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1 for each artifact and/or enchantment you control.\nEquip {2}",
             "colours": [],
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "04f24e88-2479-53e9-8304-c92fda486f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b0f0f-daf6-4071-82e7-39c015447ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b0f0f-daf6-4071-82e7-39c015447ce4.jpg?1",
             "name": "Ornithopter of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8332,7 +8332,7 @@
         },
         {
             "id": "69d774ad-9cd5-549b-ad03-993f39743c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdb1eb-2546-4c1a-bfab-ef61bdadd364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdb1eb-2546-4c1a-bfab-ef61bdadd364.jpg?1",
             "name": "Sanctuary Raptor",
             "text": "Flying\nWhenever Sanctuary Raptor attacks, if you control three or more tokens, Sanctuary Raptor gets +2/+0 and gains first strike until end of turn.",
             "colours": [],
@@ -8363,7 +8363,7 @@
         },
         {
             "id": "34888b02-a686-57d5-afa7-7cb95677e748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7da55c-7f05-46b2-aa3c-17f8d5df46bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7da55c-7f05-46b2-aa3c-17f8d5df46bb.jpg?1",
             "name": "Scion of Draco",
             "text": "Domain \u2014 This spell costs {2} less to cast for each basic land type among lands you control.\nFlying\nEach creature you control has vigilance if it's white, hexproof if it's blue, lifelink if it's black, first strike if it's red, and trample if it's green.",
             "colours": [],
@@ -8397,7 +8397,7 @@
         },
         {
             "id": "87404031-4ab5-5e33-85fd-e9d28fc3d84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6af084-eee7-4259-a58b-a866e0cf171b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6af084-eee7-4259-a58b-a866e0cf171b.jpg?1",
             "name": "Sojourner's Companion",
             "text": "Affinity for artifacts\nArtifact landcycling {2} ({2}, Discard this card: Search your library for an artifact land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -8428,7 +8428,7 @@
         },
         {
             "id": "f3baa6f6-e959-56ba-aa21-9ad94ee92f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb64d-cc0c-400d-971f-78c28d42043b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb64d-cc0c-400d-971f-78c28d42043b.jpg?1",
             "name": "Sol Talisman",
             "text": "Suspend 3\u2014{1} (Rather than cast this card from your hand, pay {1} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}: Add {C}{C}.",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "82ce247b-693a-50cf-9f22-983169c33a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dcff03-0ef9-4485-80db-5447e9ca4ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dcff03-0ef9-4485-80db-5447e9ca4ef9.jpg?1",
             "name": "Steel Dromedary",
             "text": "Steel Dromedary enters the battlefield tapped with two +1/+1 counters on it.\nSteel Dromedary doesn't untap during your untap step if it has a +1/+1 counter on it.\nAt the beginning of combat on your turn, you may move a +1/+1 counter from Steel Dromedary onto target creature.",
             "colours": [],
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "1ab41f4c-6b24-57d9-8556-9776d1d0e850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16fabbe-4557-4067-b882-f2e5dbd8b458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16fabbe-4557-4067-b882-f2e5dbd8b458.jpg?1",
             "name": "Sword of Hearth and Home",
             "text": "Equipped creature gets +2/+2 and has protection from green and from white.\nWhenever equipped creature deals combat damage to a player, exile up to one target creature you own, then search your library for a basic land card. Put both cards onto the battlefield under your control, then shuffle.\nEquip {2}",
             "colours": [],
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "67418a30-da25-53a2-a6d5-ca808f3a858d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05900f1d-f065-4656-a8a2-2f719d3fdea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05900f1d-f065-4656-a8a2-2f719d3fdea8.jpg?1",
             "name": "Tormod's Cryptkeeper",
             "text": "Vigilance\n{T}, Sacrifice Tormod's Cryptkeeper: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "c17b1c09-8833-55e0-b179-30c224b45280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039d62b0-3309-4424-a2ea-5a0d88d4bd72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039d62b0-3309-4424-a2ea-5a0d88d4bd72.jpg?1",
             "name": "The Underworld Cookbook",
             "text": "{T}, Discard a card: Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{4}, {T}, Sacrifice The Underworld Cookbook: Return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -8584,7 +8584,7 @@
         },
         {
             "id": "a453830c-3252-5974-ab60-cc6e1a3a73a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc098a4-24fa-492f-91f0-2e8b482c823b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc098a4-24fa-492f-91f0-2e8b482c823b.jpg?1",
             "name": "Vectis Gloves",
             "text": "Equipped creature gets +2/+0 and has artifact landwalk. (It can't be blocked as long as defending player controls an artifact land.)\nEquip {2}",
             "colours": [],
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "ff6a689c-066a-5ed3-86a6-6962d8d58482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f906219-7a6a-427b-93c4-4d958cbd171c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f906219-7a6a-427b-93c4-4d958cbd171c.jpg?1",
             "name": "Void Mirror",
             "text": "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.",
             "colours": [],
@@ -8645,7 +8645,7 @@
         },
         {
             "id": "fde4274c-143f-5781-8a2d-7a976c87f982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1cce91-7c81-45d9-bbec-b085e794791d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1cce91-7c81-45d9-bbec-b085e794791d.jpg?1",
             "name": "Zabaz, the Glimmerwasp",
             "text": "Modular 1\nIf a modular triggered ability would put one or more +1/+1 counters on a creature you control, that many plus one +1/+1 counters are put on it instead.\n{R}: Destroy target artifact you control.\n{W}: Zabaz, the Glimmerwasp gains flying until end of turn.",
             "colours": [],
@@ -8683,7 +8683,7 @@
         },
         {
             "id": "eacc9461-eb57-5cb3-80f5-53e12fe4f636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ac5405-df7b-4097-914a-022cb18e20d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ac5405-df7b-4097-914a-022cb18e20d4.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8714,7 +8714,7 @@
         },
         {
             "id": "0a214ff3-53f8-553a-b591-3582c89c54cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f0be9-b9f7-45d2-9499-c5d849d7289f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f0be9-b9f7-45d2-9499-c5d849d7289f.jpg?1",
             "name": "Darkmoss Bridge",
             "text": "Darkmoss Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "98c43a3d-fec1-55b8-9103-80045be75986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b46b8d8-723a-4752-b97d-29ef83bd294c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b46b8d8-723a-4752-b97d-29ef83bd294c.jpg?1",
             "name": "Drossforge Bridge",
             "text": "Drossforge Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "cc5dbcc1-8c94-5987-b8a7-1dcde3125f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe2a1fa-196f-497f-a15f-0b3b04da9cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe2a1fa-196f-497f-a15f-0b3b04da9cbb.jpg?1",
             "name": "Goldmire Bridge",
             "text": "Goldmire Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8810,7 +8810,7 @@
         },
         {
             "id": "c906dbd7-1cd9-537b-a77f-151bb313968a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3ba6d-eb7f-4f5b-9a3b-c6239c3baa42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3ba6d-eb7f-4f5b-9a3b-c6239c3baa42.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "b4ed5b8a-8e02-5c2b-9066-0005c097ce65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f36a6e2-3e51-4a30-a225-10cfe6650b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f36a6e2-3e51-4a30-a225-10cfe6650b9d.jpg?1",
             "name": "Mistvault Bridge",
             "text": "Mistvault Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "618347b5-eec2-599a-ba6b-d980629d76a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88231c0d-0cc8-44ec-bf95-81d1710ac141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88231c0d-0cc8-44ec-bf95-81d1710ac141.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8904,7 +8904,7 @@
         },
         {
             "id": "ae0e75fc-b4b3-5b43-b4ec-c41d2af0ff20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032eba04-0a63-4823-85e1-64861330a8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032eba04-0a63-4823-85e1-64861330a8d7.jpg?1",
             "name": "Power Depot",
             "text": "Power Depot enters the battlefield tapped.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast artifact spells or activate abilities of artifacts.\nModular 1",
             "colours": [],
@@ -8933,7 +8933,7 @@
         },
         {
             "id": "91a67d40-7eef-5698-a103-c1b3dc6d485c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea7395-430e-4036-92c9-17a850ec2371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea7395-430e-4036-92c9-17a850ec2371.jpg?1",
             "name": "Razortide Bridge",
             "text": "Razortide Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "31222abc-7d80-5b7d-a81c-9419f44ab69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2207467a-b82a-47ae-8867-15a859328fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2207467a-b82a-47ae-8867-15a859328fe9.jpg?1",
             "name": "Rustvale Bridge",
             "text": "Rustvale Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8997,7 +8997,7 @@
         },
         {
             "id": "541be1a7-4131-5604-8028-a5e98bcd42e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e491c5-8c07-449b-b2f1-ffa052e6d311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e491c5-8c07-449b-b2f1-ffa052e6d311.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -9028,7 +9028,7 @@
         },
         {
             "id": "dadf31cc-05f1-5dcf-8c03-b3df7d3681cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80dc025-c2c4-48c2-8354-7d9ddb430eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80dc025-c2c4-48c2-8354-7d9ddb430eb9.jpg?1",
             "name": "Silverbluff Bridge",
             "text": "Silverbluff Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9060,7 +9060,7 @@
         },
         {
             "id": "993312f0-e06d-5d20-b214-8e315f71000b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51b48e9-a75a-4acd-9462-5e1ac2b0d803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51b48e9-a75a-4acd-9462-5e1ac2b0d803.jpg?1",
             "name": "Slagwoods Bridge",
             "text": "Slagwoods Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "5c1ff42a-ffdc-5a01-8a1d-3517fcba1a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d2b895-8921-4615-a674-fb85eed5ea3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d2b895-8921-4615-a674-fb85eed5ea3f.jpg?1",
             "name": "Tanglepool Bridge",
             "text": "Tanglepool Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9124,7 +9124,7 @@
         },
         {
             "id": "0398f334-e03a-594d-8ae0-34a9c9f4b31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d483643-6a11-47f7-a0aa-190e0179525f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d483643-6a11-47f7-a0aa-190e0179525f.jpg?1",
             "name": "Thornglint Bridge",
             "text": "Thornglint Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9156,7 +9156,7 @@
         },
         {
             "id": "fcfeffd1-6b2b-5bc1-9ae1-17de53cca3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e0f201-42cb-46a1-901a-65bb4fc18f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e0f201-42cb-46a1-901a-65bb4fc18f6c.jpg?1",
             "name": "Urza's Saga",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Urza's Saga gains \"{T}: Add {C}.\"\nII \u2014 Urza's Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with \u2018\nThis creature gets +1/+1 for each artifact you control.'\"\nIII \u2014 Search your library for an artifact card with mana cost {0} or {1}, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -9190,7 +9190,7 @@
         },
         {
             "id": "dcbd60a9-189b-5389-b38e-a3fee3f29395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c229ea-90da-4aa0-bfda-b162fb3b5b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c229ea-90da-4aa0-bfda-b162fb3b5b8b.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -9221,7 +9221,7 @@
         },
         {
             "id": "32910797-1a99-58eb-b6a8-f02792fe8d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4b6e22-93b2-4896-bba5-0ceaa5d8ea3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4b6e22-93b2-4896-bba5-0ceaa5d8ea3c.jpg?1",
             "name": "Yavimaya, Cradle of Growth",
             "text": "Each land is a Forest in addition to its other land types.",
             "colours": [],
@@ -9254,7 +9254,7 @@
         },
         {
             "id": "bdf5a083-643a-5f6f-8bc9-0236b35d0a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332352c2-98f2-4eb8-b49a-026a39df227b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332352c2-98f2-4eb8-b49a-026a39df227b.jpg?1",
             "name": "Angelic Curator",
             "text": "Flying, protection from artifacts",
             "colours": [
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "42976d5f-cc7a-5a46-9501-139ea9059320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915b4638-b1ec-4045-80e6-f05fb1e2a87c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915b4638-b1ec-4045-80e6-f05fb1e2a87c.jpg?1",
             "name": "Karmic Guide",
             "text": "Flying, protection from black\nEcho {3}{W}{W} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Karmic Guide enters the battlefield, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "9b2ebbde-d3c1-536a-bbf7-2ec2325b252e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27885a9a-3bcd-476d-97a9-acaec0553a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27885a9a-3bcd-476d-97a9-acaec0553a60.jpg?1",
             "name": "Seal of Cleansing",
             "text": "Sacrifice Seal of Cleansing: Destroy target artifact or enchantment.",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "ce31aa05-faa4-5819-bf7d-7c9cf998f2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9031a7f-8821-443c-9c9d-552fb25b2101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9031a7f-8821-443c-9c9d-552fb25b2101.jpg?1",
             "name": "Solitary Confinement",
             "text": "At the beginning of your upkeep, sacrifice Solitary Confinement unless you discard a card.\nSkip your draw step.\nYou have shroud. (You can't be the target of spells or abilities.)\nPrevent all damage that would be dealt to you.",
             "colours": [
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "f2343a8e-4997-5c9c-9b45-3a7446164cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da64eec-d8a9-4156-9d26-56f81e1ffc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da64eec-d8a9-4156-9d26-56f81e1ffc44.jpg?1",
             "name": "Soul Snare",
             "text": "{W}, Sacrifice Soul Snare: Exile target creature that's attacking you or a planeswalker you control.",
             "colours": [
@@ -9427,7 +9427,7 @@
         },
         {
             "id": "40470d4d-f834-59ae-9af3-de01926a221a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1920dae4-fb92-4f19-ae4b-eb3276b8dac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1920dae4-fb92-4f19-ae4b-eb3276b8dac7.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -9462,7 +9462,7 @@
         },
         {
             "id": "19843d61-66b0-5839-b8d5-61513ad46fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8b69ff-22ef-451f-8322-b54eec79bacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8b69ff-22ef-451f-8322-b54eec79bacf.jpg?1",
             "name": "Sea Drake",
             "text": "Flying\nWhen Sea Drake enters the battlefield, return two target lands you control to their owner's hand.",
             "colours": [
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "de6a3d2b-91a9-57cc-84e2-2f7a4b99a8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfc7060-e374-486f-8029-d3fdfe4b61e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfc7060-e374-486f-8029-d3fdfe4b61e7.jpg?1",
             "name": "Seal of Removal",
             "text": "Sacrifice Seal of Removal: Return target creature to its owner's hand.",
             "colours": [
@@ -9530,7 +9530,7 @@
         },
         {
             "id": "33aeff18-856c-515b-8940-c0e50687e3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe74b1-c487-42bb-a1a1-4d13f3a86ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe74b1-c487-42bb-a1a1-4d13f3a86ff7.jpg?1",
             "name": "Upheaval",
             "text": "Return all permanents to their owners' hands.",
             "colours": [
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "02014519-e81b-5650-ac5d-989d044b9d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675d6729-23da-4f0b-b222-fe54fe24dd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675d6729-23da-4f0b-b222-fe54fe24dd90.jpg?1",
             "name": "Wonder",
             "text": "Flying\nAs long as Wonder is in your graveyard and you control an Island, creatures you control have flying.",
             "colours": [
@@ -9598,7 +9598,7 @@
         },
         {
             "id": "182f75f1-1221-5164-86ce-0e4d2c32678c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0b5f0-ed45-4b30-9c24-1c12011e3513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0b5f0-ed45-4b30-9c24-1c12011e3513.jpg?1",
             "name": "Bone Shredder",
             "text": "Flying\nEcho {2}{B} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Bone Shredder enters the battlefield, destroy target nonartifact, nonblack creature.",
             "colours": [
@@ -9634,7 +9634,7 @@
         },
         {
             "id": "d69000d7-f977-50a5-9e94-b949f73a43de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27691efa-052d-4afe-b9ef-159858ca660f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27691efa-052d-4afe-b9ef-159858ca660f.jpg?1",
             "name": "Braids, Cabal Minion",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact, creature, or land.",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "4bc4bb42-8b3a-5ef5-8128-0f77dd703f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f8d1f-163c-4c4f-beee-431b64ec8a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f8d1f-163c-4c4f-beee-431b64ec8a99.jpg?1",
             "name": "Greed",
             "text": "{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -9705,7 +9705,7 @@
         },
         {
             "id": "3193fdfe-8562-5339-91b4-8e1b056f28d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317686d8-b762-4598-b74a-8b1fa6b899ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317686d8-b762-4598-b74a-8b1fa6b899ba.jpg?1",
             "name": "Patriarch's Bidding",
             "text": "Each player chooses a creature type. Each player returns all creature cards of a type chosen this way from their graveyard to the battlefield.",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "e2fe9757-712a-586a-b438-5c6eeb0654fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fcf1-2ccd-47d2-9a24-f44b766a0b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fcf1-2ccd-47d2-9a24-f44b766a0b68.jpg?1",
             "name": "Skirge Familiar",
             "text": "Flying\nDiscard a card: Add {B}.",
             "colours": [
@@ -9774,7 +9774,7 @@
         },
         {
             "id": "22aed906-f3cc-548b-b24f-c8881d3d41e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a4b0c9-a35b-4b55-ab27-7246bbca0d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a4b0c9-a35b-4b55-ab27-7246bbca0d16.jpg?1",
             "name": "Chance Encounter",
             "text": "Whenever you win a coin flip, put a luck counter on Chance Encounter.\nAt the beginning of your upkeep, if Chance Encounter has ten or more luck counters on it, you win the game.",
             "colours": [
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "8583c792-2e7b-5b6b-8300-c5066e3c8296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63ed449-d249-4639-85d2-f8fe75496d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63ed449-d249-4639-85d2-f8fe75496d5c.jpg?1",
             "name": "Flame Rift",
             "text": "Flame Rift deals 4 damage to each player.",
             "colours": [
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "28d2eeff-34fb-5511-af99-66b3014f4a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f55e-9239-4a97-a19e-9b08fb34502e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f55e-9239-4a97-a19e-9b08fb34502e.jpg?1",
             "name": "Goblin Bombardment",
             "text": "Sacrifice a creature: Goblin Bombardment deals 1 damage to any target.",
             "colours": [
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "44078b38-73e6-52e6-88c9-ccb351fbde4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f8ee19-3a88-40fa-85d8-386ffe06efd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f8ee19-3a88-40fa-85d8-386ffe06efd7.jpg?1",
             "name": "Gorilla Shaman",
             "text": "{X}{X}{1}: Destroy target noncreature artifact with mana value X.",
             "colours": [
@@ -9909,7 +9909,7 @@
         },
         {
             "id": "de5b009e-2fd0-511f-8cf1-44a56f0ffedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bd329b-5707-42fc-af1c-084cc604e805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bd329b-5707-42fc-af1c-084cc604e805.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "c3edfdb3-468a-5dca-a44b-b44814171e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b93e65e-8a10-444f-8b0a-9327dd30cce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b93e65e-8a10-444f-8b0a-9327dd30cce2.jpg?1",
             "name": "Mogg Salvage",
             "text": "If an opponent controls an Island and you control a Mountain, you may cast this spell without paying its mana cost.\nDestroy target artifact.",
             "colours": [
@@ -9980,7 +9980,7 @@
         },
         {
             "id": "f8e7a25c-f8aa-5426-abb9-53eac370b831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d62bc-5f3c-4b3b-88f2-693249635349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d62bc-5f3c-4b3b-88f2-693249635349.jpg?1",
             "name": "Enchantress's Presence",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -10013,7 +10013,7 @@
         },
         {
             "id": "4e3e9c80-50c8-5faf-a061-5ff28c47a9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9eb595-e8fa-4a5e-abca-d30613c0e28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9eb595-e8fa-4a5e-abca-d30613c0e28f.jpg?1",
             "name": "Hunting Pack",
             "text": "Create a 4/4 green Beast creature token.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -10046,7 +10046,7 @@
         },
         {
             "id": "8bb275ef-7881-5f24-8679-92baa28795bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320fdf89-e158-41c5-b0bf-fee9dec36a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320fdf89-e158-41c5-b0bf-fee9dec36a75.jpg?1",
             "name": "Quirion Ranger",
             "text": "Return a Forest you control to its owner's hand: Untap target creature. Activate only once each turn.",
             "colours": [
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "99203757-aa58-5170-b998-59519df8109d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6bfc95-ec7e-46dd-88fd-b0e1ba48bfbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6bfc95-ec7e-46dd-88fd-b0e1ba48bfbc.jpg?1",
             "name": "Squirrel Mob",
             "text": "Squirrel Mob gets +1/+1 for each other Squirrel on the battlefield.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "6b5dc0ce-bd6e-510e-9718-ca48a6061dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6d49f-1577-4d17-a633-0c282769728a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6d49f-1577-4d17-a633-0c282769728a.jpg?1",
             "name": "Titania, Protector of Argoth",
             "text": "When Titania, Protector of Argoth enters the battlefield, return target land card from your graveyard to the battlefield.\nWhenever a land you control is put into a graveyard from the battlefield, create a 5/3 green Elemental creature token.",
             "colours": [
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "fe6374ad-e5db-56a0-a4ea-ce1e29551fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8511fe7-63f9-4942-8972-d40bf5d7e949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8511fe7-63f9-4942-8972-d40bf5d7e949.jpg?1",
             "name": "Yavimaya Elder",
             "text": "When Yavimaya Elder dies, you may search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle.\n{2}, Sacrifice Yavimaya Elder: Draw a card.",
             "colours": [
@@ -10193,7 +10193,7 @@
         },
         {
             "id": "e3b1f43a-dfd6-53e2-befe-cd195652f33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8089e7f-7619-43fe-8e0b-31ce5d988a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8089e7f-7619-43fe-8e0b-31ce5d988a1b.jpg?1",
             "name": "Chainer, Nightmare Adept",
             "text": "Discard a card: You may cast a creature spell from your graveyard this turn. Activate only once each turn.\nWhenever a nontoken creature enters the battlefield under your control, if you didn't cast it from your hand, it gains haste until your next turn.",
             "colours": [
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "6c0a2687-f3ca-5554-8c14-548361cb70b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg?1",
             "name": "Fire // Ice",
             "text": "Fire deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -10269,7 +10269,7 @@
         },
         {
             "id": "5dd6c679-ae1f-5bf7-8f2a-64637431fdc2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -10303,7 +10303,7 @@
         },
         {
             "id": "69a68954-0c44-5c48-9823-3c60eefacabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f8f3d-2fe6-44fa-802f-0c56e3f9998e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f8f3d-2fe6-44fa-802f-0c56e3f9998e.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "7ab7a67e-668f-5321-a049-f0558c857292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0824e77-c84b-464a-aa0c-44af5f6faa50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0824e77-c84b-464a-aa0c-44af5f6faa50.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -10382,7 +10382,7 @@
         },
         {
             "id": "13bfb7eb-7f2d-5364-8043-1db7bfd8d527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba03e105-a76c-4769-a35a-d780448890ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba03e105-a76c-4769-a35a-d780448890ec.jpg?1",
             "name": "Sterling Grove",
             "text": "Other enchantments you control have shroud. (They can't be the targets of spells or abilities.)\n{1}, Sacrifice Sterling Grove: Search your library for an enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -10417,7 +10417,7 @@
         },
         {
             "id": "2f75c0dc-603b-54c5-acf7-09cae3bf3166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683c4e13-525c-45c9-8832-bfe67965c34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683c4e13-525c-45c9-8832-bfe67965c34e.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "2ecba824-4c05-5cdf-8377-e46e4b9d757e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dde91a9-7d2d-4a7b-861a-3d1c16ec79d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dde91a9-7d2d-4a7b-861a-3d1c16ec79d9.jpg?1",
             "name": "Cursed Totem",
             "text": "Activated abilities of creatures can't be activated.",
             "colours": [],
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "185472b2-b06e-5ad9-af22-a7b4d8d22f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e53f0-cfca-4b40-9867-94ea771463cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e53f0-cfca-4b40-9867-94ea771463cd.jpg?1",
             "name": "Extruder",
             "text": "Echo {4} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nSacrifice an artifact: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "48beb241-a211-5a7d-810a-c1c6eaf49340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513ba8b6-9583-405f-84a5-9d2ca42f9597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513ba8b6-9583-405f-84a5-9d2ca42f9597.jpg?1",
             "name": "Millikin",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -10547,7 +10547,7 @@
         },
         {
             "id": "5431f747-fc17-5dd3-99a9-cd44834eeaff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9e6af4-522c-4dfa-895a-6946fe983e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9e6af4-522c-4dfa-895a-6946fe983e3c.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "da691221-b485-56be-827a-c8960bca1f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ccef-5322-4f99-9fce-3b4303347240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ccef-5322-4f99-9fce-3b4303347240.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Discard a card: Regenerate Patchwork Gnomes. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [],
@@ -10608,7 +10608,7 @@
         },
         {
             "id": "0259083e-8c96-5214-8f88-dff5771cb54b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618c8ecc-686d-41de-b9b1-1a7ee9cc7c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618c8ecc-686d-41de-b9b1-1a7ee9cc7c14.jpg?1",
             "name": "Zuran Orb",
             "text": "Sacrifice a land: You gain 2 life.",
             "colours": [],
@@ -10637,7 +10637,7 @@
         },
         {
             "id": "e629b1a5-131d-5373-9399-5efc5599bd34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efb0d3-2c72-46ff-bdc1-1069967365a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efb0d3-2c72-46ff-bdc1-1069967365a0.jpg?1",
             "name": "Cabal Coffers",
             "text": "{2}, {T}: Add {B} for each Swamp you control.",
             "colours": [],
@@ -10670,7 +10670,7 @@
         },
         {
             "id": "cf42be59-b7f1-5ce6-8007-27fee5d178c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5d6972-3f64-486c-a325-7351b910dafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5d6972-3f64-486c-a325-7351b910dafe.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -10701,7 +10701,7 @@
         },
         {
             "id": "39f3b2ae-5458-5708-ac49-7e813b3f0975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a9cb87-e572-4885-8561-1d4b158ec7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a9cb87-e572-4885-8561-1d4b158ec7e4.jpg?1",
             "name": "Riptide Laboratory",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Return target Wizard you control to its owner's hand.",
             "colours": [],
@@ -10732,7 +10732,7 @@
         },
         {
             "id": "3539872a-b5c1-5ed1-a5b2-c65ad8187d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538baaf-cb79-45f8-a06b-9f5e773920fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538baaf-cb79-45f8-a06b-9f5e773920fa.jpg?1",
             "name": "Dakkon, Shadow Slayer",
             "text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n\u22123: Exile target creature.\n\u22126: You may put an artifact card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "a5066582-b28a-5701-90a2-0f129b8a0e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ef067b-58ac-4b88-a983-83316d157fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ef067b-58ac-4b88-a983-83316d157fcb.jpg?1",
             "name": "Geyadrone Dihada",
             "text": "Protection from permanents with corruption counters on them\n+1: Each opponent loses 2 life and you gain 2 life. Put a corruption counter on up to one other target creature or planeswalker.\n\u22123: Gain control of target creature or planeswalker until end of turn. Untap it and put a corruption counter on it. It gains haste until end of turn.\n\u22127: Gain control of each permanent with a corruption counter on it.",
             "colours": [
@@ -10818,7 +10818,7 @@
         },
         {
             "id": "56dc37ff-ef60-56ce-a551-628edcb0724c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808a3770-057a-4985-ba5c-870d7b1cd527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808a3770-057a-4985-ba5c-870d7b1cd527.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n+1: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n\u22122: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n\u22125: Each opponent loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -10859,7 +10859,7 @@
         },
         {
             "id": "a9410b61-f238-5988-921c-607aa42138da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febad44a-eaf0-4122-87c5-a12d17f28392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febad44a-eaf0-4122-87c5-a12d17f28392.jpg?1",
             "name": "Solitude",
             "text": "Flash\nLifelink\nWhen Solitude enters the battlefield, exile up to one other target creature. That creature's controller gains life equal to its power.\nEvoke\u2014\nExile a white card from your hand.",
             "colours": [
@@ -10896,7 +10896,7 @@
         },
         {
             "id": "a4941073-a383-563c-82c1-11c661b40172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c358d75-01ad-4487-8104-425124b96aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c358d75-01ad-4487-8104-425124b96aae.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -10930,7 +10930,7 @@
         },
         {
             "id": "04a35c99-a392-5250-81d7-ba59632e0484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade923f-f064-4b5a-a6c0-348ca3e0dbed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade923f-f064-4b5a-a6c0-348ca3e0dbed.jpg?1",
             "name": "Subtlety",
             "text": "Flash\nFlying\nWhen Subtlety enters the battlefield, choose up to one target creature spell or planeswalker spell. Its owner puts it on the top or bottom of their library.\nEvoke\u2014\nExile a blue card from your hand.",
             "colours": [
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "f061a2bd-630c-5054-bc83-aa1888c147cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc69e6-5973-4e8e-a8d2-33657924d86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc69e6-5973-4e8e-a8d2-33657924d86a.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}.",
             "colours": [
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "04176768-b6a3-550b-8517-17b910238886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea859431-c1bf-4d07-9845-430bc217cb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea859431-c1bf-4d07-9845-430bc217cb91.jpg?1",
             "name": "Grief",
             "text": "Menace\nWhen Grief enters the battlefield, target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nEvoke\u2014\nExile a black card from your hand.",
             "colours": [
@@ -11044,7 +11044,7 @@
         },
         {
             "id": "d6e151a7-1372-5162-bb14-29089ba02fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c38dc8-574b-4e53-9b60-8fbb64a29175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c38dc8-574b-4e53-9b60-8fbb64a29175.jpg?1",
             "name": "Tourach, Dread Cantor",
             "text": "Kicker {B}{B}\nProtection from white\nWhenever an opponent discards a card, put a +1/+1 counter on Tourach, Dread Cantor.\nWhen Tourach enters the battlefield, if it was kicked, target opponent discards two cards at random.",
             "colours": [
@@ -11084,7 +11084,7 @@
         },
         {
             "id": "2297b8c1-a9c0-5bd6-806c-1a40216c50c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071daca8-ccc6-4707-843e-adac40dd1588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071daca8-ccc6-4707-843e-adac40dd1588.jpg?1",
             "name": "Fury",
             "text": "Double strike\nWhen Fury enters the battlefield, it deals 4 damage divided as you choose among any number of target creatures and/or planeswalkers.\nEvoke\u2014\nExile a red card from your hand.",
             "colours": [
@@ -11121,7 +11121,7 @@
         },
         {
             "id": "7e372f2d-5409-5916-95cc-4e1bc2137c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0dbf20-bb76-4f4b-960f-68bbb99bde33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0dbf20-bb76-4f4b-960f-68bbb99bde33.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -11158,7 +11158,7 @@
         },
         {
             "id": "86e57d21-1353-5f6f-b673-fc0ca198df03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e685f9-cc0f-4dc6-98dc-4727944de445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e685f9-cc0f-4dc6-98dc-4727944de445.jpg?1",
             "name": "Ragavan, Nimble Pilferer",
             "text": "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\nDash {1}{R}",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "ca164fb9-4ef2-5f23-8224-1c5e747e0532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819b7-c193-446d-b7cf-75a09e1d58a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819b7-c193-446d-b7cf-75a09e1d58a4.jpg?1",
             "name": "Chatterfang, Squirrel General",
             "text": "Forestwalk\nIf one or more tokens would be created under your control, those tokens plus that many 1/1 green Squirrel creature tokens are created instead.\n{B}, Sacrifice X Squirrels: Target creature gets +X/-X until end of turn.",
             "colours": [
@@ -11238,7 +11238,7 @@
         },
         {
             "id": "747a9215-6dd5-54e3-91fe-3c5a7a57e64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6d14a-1328-4032-ad9e-cd85cd365bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6d14a-1328-4032-ad9e-cd85cd365bd3.jpg?1",
             "name": "Endurance",
             "text": "Flash\nReach\nWhen Endurance enters the battlefield, up to one target player puts all the cards from their graveyard on the bottom of their library in a random order.\nEvoke\u2014\nExile a green card from your hand.",
             "colours": [
@@ -11275,7 +11275,7 @@
         },
         {
             "id": "c9516fef-1b36-536f-be16-7f1350f944b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abf3165-6260-4dcf-8f06-6e808bff0289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abf3165-6260-4dcf-8f06-6e808bff0289.jpg?1",
             "name": "Thrasta, Tempest's Roar",
             "text": "This spell costs {3} less to cast for each other spell cast this turn.\nTrample, trample over planeswalkers, haste\nThrasta, Tempest's Roar has hexproof as long as it entered the battlefield this turn.",
             "colours": [
@@ -11313,7 +11313,7 @@
         },
         {
             "id": "57f8b73b-b746-51af-9561-07e7ce1f35b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb9fd5-359e-4da2-8d91-80ef50a8e390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb9fd5-359e-4da2-8d91-80ef50a8e390.jpg?1",
             "name": "Titania, Protector of Argoth",
             "text": "When Titania, Protector of Argoth enters the battlefield, return target land card from your graveyard to the battlefield.\nWhenever a land you control is put into a graveyard from the battlefield, create a 5/3 green Elemental creature token.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "4a6b166b-7e9e-55dd-be2e-a712de9509b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157ce8f8-625c-407a-b015-3b5326da69a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157ce8f8-625c-407a-b015-3b5326da69a0.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -11388,7 +11388,7 @@
         },
         {
             "id": "66b8e70c-90b9-5cfb-b515-ab86fdd0b2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7fa4d-5190-4f2b-a8ae-933bdab3bfc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7fa4d-5190-4f2b-a8ae-933bdab3bfc5.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade",
             "colours": [
@@ -11429,7 +11429,7 @@
         },
         {
             "id": "4642c150-a748-5283-b8a3-3d56c8297885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4978ecd-3c2e-49e2-98e0-0172887e4319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4978ecd-3c2e-49e2-98e0-0172887e4319.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -11465,7 +11465,7 @@
         },
         {
             "id": "e3e7fdc1-5f7c-5dbf-86a8-bf08201fb573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec628a-4b66-4ab8-9e00-c1582da722ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec628a-4b66-4ab8-9e00-c1582da722ff.jpg?1",
             "name": "Scion of Draco",
             "text": "Domain \u2014 This spell costs {2} less to cast for each basic land type among lands you control.\nFlying\nEach creature you control has vigilance if it's white, hexproof if it's blue, lifelink if it's black, first strike if it's red, and trample if it's green.",
             "colours": [],
@@ -11499,7 +11499,7 @@
         },
         {
             "id": "512ab9da-8eaa-57dd-b2d2-ecb7d4e7678c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27d2f06-42ed-42fd-874c-8c278cdb66dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27d2f06-42ed-42fd-874c-8c278cdb66dc.jpg?1",
             "name": "Sword of Hearth and Home",
             "text": "Equipped creature gets +2/+2 and has protection from green and from white.\nWhenever equipped creature deals combat damage to a player, exile up to one target creature you own, then search your library for a basic land card. Put both cards onto the battlefield under your control, then shuffle.\nEquip {2}",
             "colours": [],
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "85f94792-2e14-5b22-b091-e13c52bd4106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd01460-901c-4d75-bc29-e97ed26afc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd01460-901c-4d75-bc29-e97ed26afc39.jpg?1",
             "name": "Cabal Coffers",
             "text": "{2}, {T}: Add {B} for each Swamp you control.",
             "colours": [],
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "bc0517a9-c7e1-5064-a637-8dd5e41bbd83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d596bc0-c972-4a36-8cf6-cd8f72169021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d596bc0-c972-4a36-8cf6-cd8f72169021.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -11594,7 +11594,7 @@
         },
         {
             "id": "db32a243-4b44-5681-903e-a5057fff4b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7667b9c-073d-456d-8c43-5e56316cef92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7667b9c-073d-456d-8c43-5e56316cef92.jpg?1",
             "name": "Blossoming Calm",
             "text": "You gain hexproof until your next turn. You gain 2 life.\nRebound",
             "colours": [
@@ -11628,7 +11628,7 @@
         },
         {
             "id": "1ca86e65-b447-549f-a1b7-1009d9da93b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676758ee-dac8-4c97-8a62-fff25bcbb6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676758ee-dac8-4c97-8a62-fff25bcbb6df.jpg?1",
             "name": "Esper Sentinel",
             "text": "Whenever an opponent casts their first noncreature spell each turn, draw a card unless that player pays {X}, where X is Esper Sentinel's power.",
             "colours": [
@@ -11666,7 +11666,7 @@
         },
         {
             "id": "e8a111ea-2ed4-5fa7-ae77-76fdfdf30dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4613fc96-a98d-4ea8-b1e2-0a776dfd4d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4613fc96-a98d-4ea8-b1e2-0a776dfd4d5a.jpg?1",
             "name": "Late to Dinner",
             "text": "Return target creature card from your graveyard to the battlefield. Create a Food token.",
             "colours": [
@@ -11700,7 +11700,7 @@
         },
         {
             "id": "e8f2fa9f-9707-5d0f-afc7-f3f8d6ec00ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d044aa-abed-47dd-b3a1-268fab03f8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d044aa-abed-47dd-b3a1-268fab03f8af.jpg?1",
             "name": "Lens Flare",
             "text": "Affinity for artifacts\nLens Flare deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -11734,7 +11734,7 @@
         },
         {
             "id": "c24a7f4a-2219-5ae2-b0e1-26583aa0778d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f6052b-b90b-4630-9cd7-26920897d976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f6052b-b90b-4630-9cd7-26920897d976.jpg?1",
             "name": "Nykthos Paragon",
             "text": "Whenever you gain life, you may put that many +1/+1 counters on each creature you control. Do this only once each turn.",
             "colours": [
@@ -11772,7 +11772,7 @@
         },
         {
             "id": "e857461d-61fe-537a-9dd6-0bbd6ecfe64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbd1cb1-799e-45aa-acd8-36ef924b0cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbd1cb1-799e-45aa-acd8-36ef924b0cdf.jpg?1",
             "name": "Search the Premises",
             "text": "Whenever a creature attacks you or a planeswalker you control, investigate.",
             "colours": [
@@ -11806,7 +11806,7 @@
         },
         {
             "id": "76bbb580-cfbf-5805-a895-8262a92bbd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de657fb-e68e-4400-9a12-60aaaa075fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de657fb-e68e-4400-9a12-60aaaa075fc4.jpg?1",
             "name": "Serra's Emissary",
             "text": "Flying\nAs Serra's Emissary enters the battlefield, choose a card type.\nYou and creatures you control have protection from the chosen card type.",
             "colours": [
@@ -11842,7 +11842,7 @@
         },
         {
             "id": "87d16fe7-6831-5246-860c-87cc84369d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dcf74-110c-421f-87db-c2133d7a8281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dcf74-110c-421f-87db-c2133d7a8281.jpg?1",
             "name": "Dress Down",
             "text": "Flash\nWhen Dress Down enters the battlefield, draw a card.\nCreatures lose all abilities.\nAt the beginning of the end step, sacrifice Dress Down.",
             "colours": [
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "f08a54bd-2b0b-5a79-baab-22671f8bdebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d6402-a941-46cc-b1d6-352d5aa5cc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d6402-a941-46cc-b1d6-352d5aa5cc3f.jpg?1",
             "name": "Floodhound",
             "text": "{3}, {T}: Investigate.",
             "colours": [
@@ -11913,7 +11913,7 @@
         },
         {
             "id": "ede806de-5743-5898-a278-f44d1bde44e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a3b565-2880-48f1-bbfe-1eeafcb76c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a3b565-2880-48f1-bbfe-1eeafcb76c2b.jpg?1",
             "name": "Fractured Sanity",
             "text": "Each opponent mills fourteen cards.\nCycling {1}{U}\nWhen you cycle Fractured Sanity, each opponent mills four cards.",
             "colours": [
@@ -11947,7 +11947,7 @@
         },
         {
             "id": "77c06662-3345-5156-b848-85f947c7664f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad586c86-6d5b-49ac-8908-098eddae26e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad586c86-6d5b-49ac-8908-098eddae26e6.jpg?1",
             "name": "Murktide Regent",
             "text": "Delve\nFlying\nMurktide Regent enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.\nWhenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on Murktide Regent.",
             "colours": [
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "187d2a1d-e528-5f59-aaed-e62dab8d88af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bec76f-243b-41b6-9e47-17a61f18ae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bec76f-243b-41b6-9e47-17a61f18ae53.jpg?1",
             "name": "Mystic Redaction",
             "text": "At the beginning of your upkeep, scry 1.\nWhenever you discard a card, each opponent mills two cards.",
             "colours": [
@@ -12017,7 +12017,7 @@
         },
         {
             "id": "1bff8e86-909c-5461-b879-ccee441e4b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2484b24-ca5e-421d-8dbf-41df7094c8a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2484b24-ca5e-421d-8dbf-41df7094c8a8.jpg?1",
             "name": "Phantasmal Dreadmaw",
             "text": "Trample\nWhen Phantasmal Dreadmaw becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -12054,7 +12054,7 @@
         },
         {
             "id": "04305f86-457c-5aee-93e1-d335e31053b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9011c3a-c9db-4e92-89d5-29f139017573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9011c3a-c9db-4e92-89d5-29f139017573.jpg?1",
             "name": "Rise and Shine",
             "text": "Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on each artifact that became a creature this way.\nOverload {4}{U}{U}",
             "colours": [
@@ -12088,7 +12088,7 @@
         },
         {
             "id": "8894a091-08ad-5af1-9145-ac936600c5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c98ef7-be05-4bcf-be4b-62a437297330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c98ef7-be05-4bcf-be4b-62a437297330.jpg?1",
             "name": "Thought Monitor",
             "text": "Affinity for artifacts\nFlying\nWhen Thought Monitor enters the battlefield, draw two cards.",
             "colours": [
@@ -12125,7 +12125,7 @@
         },
         {
             "id": "675fd3de-8b62-5414-a2de-9a3e77523da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d9873-f4e9-418f-aee8-8623b2576f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d9873-f4e9-418f-aee8-8623b2576f6c.jpg?1",
             "name": "Archon of Cruelty",
             "text": "Flying\nWhenever Archon of Cruelty enters the battlefield or attacks, target opponent sacrifices a creature or planeswalker, discards a card, and loses 3 life. You draw a card and gain 3 life.",
             "colours": [
@@ -12161,7 +12161,7 @@
         },
         {
             "id": "25cf89af-3f6a-50b4-8cb4-be66713dfa00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c7b777-c002-45c7-b2bb-d21dab591445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c7b777-c002-45c7-b2bb-d21dab591445.jpg?1",
             "name": "Kitchen Imp",
             "text": "Flying, haste\nMadness {B}",
             "colours": [
@@ -12197,7 +12197,7 @@
         },
         {
             "id": "5bcf6617-bc10-5c23-89a5-28fbe7311781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec0c309-5e11-40b2-a38f-66503b357f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec0c309-5e11-40b2-a38f-66503b357f5d.jpg?1",
             "name": "Magus of the Bridge",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 2/2 black Zombie creature token.\nWhen a creature is put into an opponent's graveyard from the battlefield, exile Magus of the Bridge.",
             "colours": [
@@ -12234,7 +12234,7 @@
         },
         {
             "id": "eeb0c12b-8bba-547d-84c1-a7274261ebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beb3062-b3a2-4af5-867c-e6389554c1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beb3062-b3a2-4af5-867c-e6389554c1f5.jpg?1",
             "name": "Persist",
             "text": "Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.",
             "colours": [
@@ -12269,7 +12269,7 @@
         },
         {
             "id": "643d712f-fa28-5a0a-8344-78b54a82baa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d1d680-9a27-4850-9175-cc71220ea33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d1d680-9a27-4850-9175-cc71220ea33d.jpg?1",
             "name": "Sudden Edict",
             "text": "Split second\nTarget player sacrifices a creature.",
             "colours": [
@@ -12303,7 +12303,7 @@
         },
         {
             "id": "4e5cbf85-5d0c-5296-9841-005471474cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735a5082-72f4-4812-adcc-d8095d8eee51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735a5082-72f4-4812-adcc-d8095d8eee51.jpg?1",
             "name": "Underworld Hermit",
             "text": "When Underworld Hermit enters the battlefield, create a number of 1/1 green Squirrel creature tokens equal to your devotion to black.",
             "colours": [
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "02d397c1-d8e1-5b21-92ce-b2fe9e58561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16d9113-d279-4a6d-9cf0-f5e104f77852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16d9113-d279-4a6d-9cf0-f5e104f77852.jpg?1",
             "name": "World-Weary",
             "text": "Enchant creature\nEnchanted creature gets -4/-4.\nBasic landcycling {1}{B}",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "35c1fe32-c344-5638-89cf-0ed34f2b7379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958aa5c-176d-4f6e-be52-ef2afbe8d452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958aa5c-176d-4f6e-be52-ef2afbe8d452.jpg?1",
             "name": "Faithless Salvaging",
             "text": "Discard a card, then draw a card.\nRebound",
             "colours": [
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "740e6a2e-84c2-549e-b8ef-4d8f1a5826d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d35091-c272-4679-aa20-7889e9cdcd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d35091-c272-4679-aa20-7889e9cdcd41.jpg?1",
             "name": "Flametongue Yearling",
             "text": "Multikicker {2}\nFlametongue Yearling enters the battlefield with a +1/+1 counter on it for each time it was kicked.\nWhen Flametongue Yearling enters the battlefield, it deals damage equal to its power to target creature.",
             "colours": [
@@ -12446,7 +12446,7 @@
         },
         {
             "id": "57bfa94e-be5d-5501-af24-223cdd4e715b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88167b74-c25f-4a9b-a4f5-33a51e01d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88167b74-c25f-4a9b-a4f5-33a51e01d498.jpg?1",
             "name": "Gargadon",
             "text": "Trample\nSuspend 4\u2014{1}{R}",
             "colours": [
@@ -12482,7 +12482,7 @@
         },
         {
             "id": "554a101d-7d7b-56d5-858e-135029dd276d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4290d31a-ce74-4a22-8266-9e44d23d506f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4290d31a-ce74-4a22-8266-9e44d23d506f.jpg?1",
             "name": "Harmonic Prodigy",
             "text": "Prowess\nIf an ability of a Shaman or another Wizard you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -12519,7 +12519,7 @@
         },
         {
             "id": "864604a6-ecc8-51fe-8c51-5a7aec922b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7a09e-a28f-4153-81b0-c8dbb1aaa0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7a09e-a28f-4153-81b0-c8dbb1aaa0e7.jpg?1",
             "name": "Obsidian Charmaw",
             "text": "This spell costs {1} less to cast for each land your opponents control that could produce {C}.\nFlying\nWhen Obsidian Charmaw enters the battlefield, destroy target nonbasic land an opponent controls.",
             "colours": [
@@ -12555,7 +12555,7 @@
         },
         {
             "id": "de35b17d-42a1-5c72-8fb4-c503a9f755d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae42f372-2a17-4905-99d1-3371ca0ed6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae42f372-2a17-4905-99d1-3371ca0ed6ae.jpg?1",
             "name": "Abundant Harvest",
             "text": "Choose land or nonland. Reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12589,7 +12589,7 @@
         },
         {
             "id": "db4d83e8-e345-58ed-9946-036e2fbd860c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3139cce8-3467-4c50-add2-5b78fb33b90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3139cce8-3467-4c50-add2-5b78fb33b90a.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "Exalted\n{T}: Add {B}, {R}, or {G}.",
             "colours": [
@@ -12629,7 +12629,7 @@
         },
         {
             "id": "3640de24-4048-50bd-9469-ebdca0ad8eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793f5aef-15ad-4ad7-b390-201b3c0c149d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793f5aef-15ad-4ad7-b390-201b3c0c149d.jpg?1",
             "name": "Jade Avenger",
             "text": "Bushido 2",
             "colours": [
@@ -12666,7 +12666,7 @@
         },
         {
             "id": "b57e763d-adaf-525c-9317-c1f02978b43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afd2ecd-c2e5-49f2-bf35-dcec2addcebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afd2ecd-c2e5-49f2-bf35-dcec2addcebb.jpg?1",
             "name": "Sylvan Anthem",
             "text": "Green creatures you control get +1/+1.\nWhenever a green creature enters the battlefield under your control, scry 1.",
             "colours": [
@@ -12700,7 +12700,7 @@
         },
         {
             "id": "f7bc6e1a-cf09-56e5-a967-3d22b9d47887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f47b0-2254-4df2-b3dc-74c1d3811d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f47b0-2254-4df2-b3dc-74c1d3811d2f.jpg?1",
             "name": "Timeless Witness",
             "text": "When Timeless Witness enters the battlefield, return target card from your graveyard to your hand.\nEternalize {5}{G}{G}",
             "colours": [
@@ -12737,7 +12737,7 @@
         },
         {
             "id": "31650fa0-1cf2-5f87-b0be-3074effb52e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a3f30-0839-4678-a37c-475ee189811e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a3f30-0839-4678-a37c-475ee189811e.jpg?1",
             "name": "Verdant Command",
             "text": "Choose two \u2014\n\u2022 Target player creates two tapped 1/1 green Squirrel creature tokens.\n\u2022 Counter target loyalty ability of a planeswalker.\n\u2022 Exile target card from a graveyard.\n\u2022 Target player gains 3 life.",
             "colours": [
@@ -12771,7 +12771,7 @@
         },
         {
             "id": "cdb942ad-6513-5c00-a4e2-2d0f80356532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896eceec-7dcc-48fb-acc2-1ca5ee28ea3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896eceec-7dcc-48fb-acc2-1ca5ee28ea3b.jpg?1",
             "name": "Arcbound Shikari",
             "text": "First strike\nWhen Arcbound Shikari enters the battlefield, put a +1/+1 counter on each other artifact creature you control.\nModular 2",
             "colours": [
@@ -12811,7 +12811,7 @@
         },
         {
             "id": "ee374622-a64a-5991-8d89-ad0f3fb507b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ee002-fbd4-4bbe-a17c-876972750646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ee002-fbd4-4bbe-a17c-876972750646.jpg?1",
             "name": "Arcus Acolyte",
             "text": "Reach, lifelink\nOutlast {RW}\nEach other creature you control without a +1/+1 counter on it has outlast {RW}.",
             "colours": [
@@ -12851,7 +12851,7 @@
         },
         {
             "id": "87193fa5-dec1-543c-b572-97c5be17bbe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac6ff5-4caa-48ee-a9a4-de7c1300e326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac6ff5-4caa-48ee-a9a4-de7c1300e326.jpg?1",
             "name": "Combine Chrysalis",
             "text": "Creature tokens you control have flying.\n{2}{G}{U}, {T}, Sacrifice a token: Create a 4/4 green Beast creature token. Activate only as a sorcery.",
             "colours": [
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "2aab330b-bdc4-5bb0-9c0f-17b99dfb4506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05467b80-0781-4f03-8027-59dbb44d8826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05467b80-0781-4f03-8027-59dbb44d8826.jpg?1",
             "name": "Dakkon, Shadow Slayer",
             "text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n\u22123: Exile target creature.\n\u22126: You may put an artifact card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -12930,7 +12930,7 @@
         },
         {
             "id": "50e275b8-6823-5f79-96a2-4658d25018d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3a54c0-98f0-47be-aae1-608479f4b9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3a54c0-98f0-47be-aae1-608479f4b9cf.jpg?1",
             "name": "Ethersworn Sphinx",
             "text": "Affinity for artifacts\nFlying\nCascade",
             "colours": [
@@ -12969,7 +12969,7 @@
         },
         {
             "id": "ed87244e-2d60-59dc-b59f-d62913cc1f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92aed86-4786-42c5-a599-7b3178eed478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92aed86-4786-42c5-a599-7b3178eed478.jpg?1",
             "name": "Garth One-Eye",
             "text": "{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy.",
             "colours": [
@@ -13017,7 +13017,7 @@
         },
         {
             "id": "b90f35ab-7e70-5e62-ab95-69aee562c7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a0636e-cf3c-4bf2-8d01-b830bed999ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a0636e-cf3c-4bf2-8d01-b830bed999ef.jpg?1",
             "name": "General Ferrous Rokiric",
             "text": "Hexproof from monocolored\nWhenever you cast a multicolored spell, create a 4/4 red and white Golem artifact creature token.",
             "colours": [
@@ -13058,7 +13058,7 @@
         },
         {
             "id": "9f4edf19-e45f-5a01-9770-aef1c2cdfdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1985f4-f3e4-4ddd-bed9-a0566e411620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1985f4-f3e4-4ddd-bed9-a0566e411620.jpg?1",
             "name": "Geyadrone Dihada",
             "text": "Protection from permanents with corruption counters on them\n+1: Each opponent loses 2 life and you gain 2 life. Put a corruption counter on up to one other target creature or planeswalker.\n\u22123: Gain control of target creature or planeswalker until end of turn. Untap it and put a corruption counter on it. It gains haste until end of turn.\n\u22127: Gain control of each permanent with a corruption counter on it.",
             "colours": [
@@ -13101,7 +13101,7 @@
         },
         {
             "id": "b83a6a83-4ad7-522f-b1fc-5b8f7a1d5efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627c68-c4a9-4579-85f1-6a1a5e6f6fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627c68-c4a9-4579-85f1-6a1a5e6f6fce.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n+1: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n\u22122: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n\u22125: Each opponent loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "06f84d80-6329-5e91-9ef8-0b04747fe381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e2d11-0f87-43f2-a961-99a47486f8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e2d11-0f87-43f2-a961-99a47486f8fa.jpg?1",
             "name": "Lazotep Chancellor",
             "text": "Whenever you discard a card, you may pay {1}. If you do, amass 2.",
             "colours": [
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "88dbf42a-03a4-5ff3-9bf1-3340f99f77e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6baff7b-bdfe-4b64-802d-f73c455dac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6baff7b-bdfe-4b64-802d-f73c455dac35.jpg?1",
             "name": "Lonis, Cryptozoologist",
             "text": "Whenever another nontoken creature enters the battlefield under your control, investigate.\n{T}, Sacrifice X Clues: Target opponent reveals the top X cards of their library. You may put a nonland permanent card with mana value X or less from among them onto the battlefield under your control. That player puts the rest on the bottom of their library in a random order.",
             "colours": [
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "b56adcb6-9695-5427-9e6d-21f6d1d0539f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcab41d9-e002-4183-bbbe-b1f955217b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcab41d9-e002-4183-bbbe-b1f955217b3c.jpg?1",
             "name": "Moderation",
             "text": "You can't cast more than one spell each turn.\nWhenever you cast a spell, draw a card.",
             "colours": [
@@ -13259,7 +13259,7 @@
         },
         {
             "id": "878d585e-2165-5f9c-b051-2dd1e03e25af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a63c64-bbf4-46cc-bffe-0992bea502cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a63c64-bbf4-46cc-bffe-0992bea502cc.jpg?1",
             "name": "Priest of Fell Rites",
             "text": "{T}, Pay 3 life, Sacrifice Priest of Fell Rites: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.\nUnearth {3}{W}{B}",
             "colours": [
@@ -13298,7 +13298,7 @@
         },
         {
             "id": "6ebf083b-1921-5751-b162-579066e40e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e8b65-16ec-4aef-ac26-8afd78d8bfe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e8b65-16ec-4aef-ac26-8afd78d8bfe5.jpg?1",
             "name": "Prophetic Titan",
             "text": "Delirium \u2014 When Prophetic Titan enters the battlefield, choose one. If there are four or more card types among cards in your graveyard, choose both instead.\n\u2022 Prophetic Titan deals 4 damage to any target.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13337,7 +13337,7 @@
         },
         {
             "id": "56519556-e0cf-57e5-8ef1-99227b9a1a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2caad15a-b567-47b5-b055-e52bfed5b889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2caad15a-b567-47b5-b055-e52bfed5b889.jpg?1",
             "name": "Rakdos Headliner",
             "text": "Haste\nEcho\u2014\nDiscard a card.",
             "colours": [
@@ -13375,7 +13375,7 @@
         },
         {
             "id": "6ddd925f-cf16-576c-984b-404f242a1270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505b77d0-8651-4b40-a2e9-6dd00ac3c575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505b77d0-8651-4b40-a2e9-6dd00ac3c575.jpg?1",
             "name": "Ravenous Squirrel",
             "text": "Whenever you sacrifice an artifact or creature, put a +1/+1 counter on Ravenous Squirrel.\n{1}{B}{G}, Sacrifice an artifact or creature: You gain 1 life and draw a card.",
             "colours": [
@@ -13413,7 +13413,7 @@
         },
         {
             "id": "dd1061df-c0f4-5059-8f04-d7c8a9f57fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg?1",
             "name": "Road // Ruin",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13448,7 +13448,7 @@
         },
         {
             "id": "28d5a9ff-b2ec-5d4b-9ae5-8ab1bff853d0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg?1",
             "name": "Road // Ruin",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nRuin deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -13483,7 +13483,7 @@
         },
         {
             "id": "8e171166-b2bd-5d2f-8405-70162a8e2be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebe313-3452-415c-a93f-52c7467531a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebe313-3452-415c-a93f-52c7467531a3.jpg?1",
             "name": "Sythis, Harvest's Hand",
             "text": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
             "colours": [
@@ -13524,7 +13524,7 @@
         },
         {
             "id": "799b7249-9b7d-5681-ace9-8e30381d4025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b32e-e9c3-4245-887c-fe30c5f3148f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b32e-e9c3-4245-887c-fe30c5f3148f.jpg?1",
             "name": "Dermotaxi",
             "text": "Imprint \u2014 As Dermotaxi enters the battlefield, exile a creature card from a graveyard.\nTap two untapped creatures you control: Until end of turn, Dermotaxi becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.",
             "colours": [],
@@ -13556,7 +13556,7 @@
         },
         {
             "id": "c308f5aa-0700-50a8-9e10-f8da2fe2c8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0ae99-d84a-4f27-bed8-889747c78529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0ae99-d84a-4f27-bed8-889747c78529.jpg?1",
             "name": "Kaldra Compleat",
             "text": "Living weapon\nIndestructible\nEquipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"\nEquip {7}",
             "colours": [],
@@ -13590,7 +13590,7 @@
         },
         {
             "id": "4aeae54e-cfaf-5ae5-8f80-3b7fbca69937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138dfbb-a4e3-49db-b908-95d0b2b7e82f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138dfbb-a4e3-49db-b908-95d0b2b7e82f.jpg?1",
             "name": "Urza's Saga",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Urza's Saga gains \"{T}: Add {C}.\"\nII \u2014 Urza's Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with \u2018\nThis creature gets +1/+1 for each artifact you control.'\"\nIII \u2014 Search your library for an artifact card with mana cost {0} or {1}, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13624,7 +13624,7 @@
         },
         {
             "id": "de7f21d1-dadd-512c-94a6-eb2e7d237306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37304f74-a925-444c-bff6-7811f7f06966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37304f74-a925-444c-bff6-7811f7f06966.jpg?1",
             "name": "Blacksmith's Skill",
             "text": "Target permanent gains hexproof and indestructible until end of turn. If it's an artifact creature, it gets +2/+2 until end of turn.",
             "colours": [
@@ -13659,7 +13659,7 @@
         },
         {
             "id": "6409d567-63b2-58ef-bcad-c10e36a6d153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9900b8-da89-433b-ada5-f17c82e60c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9900b8-da89-433b-ada5-f17c82e60c64.jpg?1",
             "name": "Marble Gargoyle",
             "text": "Flying\n{W}: Marble Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -13697,7 +13697,7 @@
         },
         {
             "id": "b2376ef7-e713-5aa5-bc51-dc6210e59aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd77468-7aad-4add-8385-e3310cd5d5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd77468-7aad-4add-8385-e3310cd5d5cd.jpg?1",
             "name": "Out of Time",
             "text": "When Out of Time enters the battlefield, untap all creatures, then phase them out until Out of Time leaves the battlefield. Put a time counter on Out of Time for each creature phased out this way.\nVanishing",
             "colours": [
@@ -13733,7 +13733,7 @@
         },
         {
             "id": "bafac74c-f4f8-5c71-8a6b-0bd02c536c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaa24a9-eece-4067-b7e2-6bc8993cea5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaa24a9-eece-4067-b7e2-6bc8993cea5a.jpg?1",
             "name": "Prismatic Ending",
             "text": "Converge \u2014 Exile target nonland permanent if its mana value is less than or equal to the number of colors of mana spent to cast this spell.",
             "colours": [
@@ -13768,7 +13768,7 @@
         },
         {
             "id": "43a6ae44-81b0-5cdf-9753-f2886623396d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e60c9e-0b9c-4daa-8a61-52111e03f49f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e60c9e-0b9c-4daa-8a61-52111e03f49f.jpg?1",
             "name": "Resurgent Belief",
             "text": "Suspend 2\u2014{1}{W}\nReturn all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -13804,7 +13804,7 @@
         },
         {
             "id": "bfb8b749-277f-55d8-90f1-34870699f525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d4ef76-4d57-40df-93f6-c67c017798ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d4ef76-4d57-40df-93f6-c67c017798ce.jpg?1",
             "name": "Sanctifier en-Vec",
             "text": "Protection from black and from red\nWhen Sanctifier en-Vec enters the battlefield, exile all cards that are black or red from all graveyards.\nIf a black or red permanent, spell, or card not on the battlefield would be put into a graveyard, exile it instead.",
             "colours": [
@@ -13843,7 +13843,7 @@
         },
         {
             "id": "ed86ebe7-178f-52fc-9b05-8a9e36e50343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e612763-6611-40e7-ab47-3161f8275b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e612763-6611-40e7-ab47-3161f8275b9d.jpg?1",
             "name": "Soul Snare",
             "text": "{W}, Sacrifice Soul Snare: Exile target creature that's attacking you or a planeswalker you control.",
             "colours": [
@@ -13878,7 +13878,7 @@
         },
         {
             "id": "18c02204-0326-563a-b971-4704ea570c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476cc60-e59d-4f34-abc9-f3eafdc2890d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476cc60-e59d-4f34-abc9-f3eafdc2890d.jpg?1",
             "name": "Timeless Dragon",
             "text": "Flying\nPlainscycling {2}\nEternalize {2}{W}{W}",
             "colours": [
@@ -13916,7 +13916,7 @@
         },
         {
             "id": "312c9d62-1bee-5027-b19e-de16923d9681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de0eb6-94f5-440f-8201-cc7dad2f0805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de0eb6-94f5-440f-8201-cc7dad2f0805.jpg?1",
             "name": "Aeromoeba",
             "text": "Flying\nDiscard a card: Switch Aeromoeba's power and toughness until end of turn.",
             "colours": [
@@ -13954,7 +13954,7 @@
         },
         {
             "id": "89f8d747-0cbb-57c6-b825-9e0bff758810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c015a6-dc4c-49f6-8d39-4c7b598e5a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c015a6-dc4c-49f6-8d39-4c7b598e5a61.jpg?1",
             "name": "Inevitable Betrayal",
             "text": "Suspend 3\u2014{1}{U}{U}\nSearch target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -13990,7 +13990,7 @@
         },
         {
             "id": "cce47761-f152-59eb-9d6c-a082b00203a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39d88fd-7762-4d02-af7c-b13e7db5b23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39d88fd-7762-4d02-af7c-b13e7db5b23e.jpg?1",
             "name": "Rishadan Dockhand",
             "text": "Islandwalk\n{1}, {T}: Tap target land.",
             "colours": [
@@ -14028,7 +14028,7 @@
         },
         {
             "id": "87fb9b01-1ed1-587f-93b8-ab8bc7f3213b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5688978-1744-4986-bda3-09629541b827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5688978-1744-4986-bda3-09629541b827.jpg?1",
             "name": "Step Through",
             "text": "Return two target creatures to their owners' hands.\nWizardcycling {2}",
             "colours": [
@@ -14063,7 +14063,7 @@
         },
         {
             "id": "cbaf543f-95c6-5524-b54e-303d78857607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7252a6-0add-4bba-a0cc-9068f8701775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7252a6-0add-4bba-a0cc-9068f8701775.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}.",
             "colours": [
@@ -14104,7 +14104,7 @@
         },
         {
             "id": "cf58208c-7c6f-570b-aeb7-a99a45fd3929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1fb951-89c2-49c9-9ee9-3c8d0d6c4c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1fb951-89c2-49c9-9ee9-3c8d0d6c4c86.jpg?1",
             "name": "Tide Shaper",
             "text": "Kicker {1}\nWhen Tide Shaper enters the battlefield, if it was kicked, target land becomes an Island for as long as Tide Shaper remains on the battlefield.\nTide Shaper gets +1/+1 as long as an opponent controls an Island.",
             "colours": [
@@ -14142,7 +14142,7 @@
         },
         {
             "id": "ba44d76c-fd07-5444-995c-cc63060a2579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15299d85-ee28-41a3-9952-f50e8e1d40eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15299d85-ee28-41a3-9952-f50e8e1d40eb.jpg?1",
             "name": "Bone Shards",
             "text": "As an additional cost to cast this spell, sacrifice a creature or discard a card.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -14177,7 +14177,7 @@
         },
         {
             "id": "9504916a-c84f-5155-bf62-8700b56fb156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95b26-0bbf-4fa1-80c1-f621f1a1b947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95b26-0bbf-4fa1-80c1-f621f1a1b947.jpg?1",
             "name": "Damn",
             "text": "Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W}",
             "colours": [
@@ -14214,7 +14214,7 @@
         },
         {
             "id": "0897ac9a-e0e2-5961-b06b-586197dce98c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d54f0dd-5d27-483b-8af9-92a1c5a785f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d54f0dd-5d27-483b-8af9-92a1c5a785f2.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "Shadow\nIf a card would be put into an opponent's graveyard from anywhere, instead exile it with a void counter on it.\n{T}, Sacrifice Dauthi Voidwalker: Choose an exiled card an opponent owns with a void counter on it. You may play it this turn without paying its mana cost.",
             "colours": [
@@ -14253,7 +14253,7 @@
         },
         {
             "id": "c278e4a7-f7ce-53ee-ac48-116cffe7a434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3af4da8-07fe-4781-ad36-375b75012939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3af4da8-07fe-4781-ad36-375b75012939.jpg?1",
             "name": "Necrogoyf",
             "text": "Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B}",
             "colours": [
@@ -14291,7 +14291,7 @@
         },
         {
             "id": "07a13bb5-82b5-5350-812c-ad1a7ced242c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8595c6-5237-4ed1-98e4-8615bb0eb8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8595c6-5237-4ed1-98e4-8615bb0eb8e1.jpg?1",
             "name": "Nested Shambler",
             "text": "When Nested Shambler dies, create X tapped 1/1 green Squirrel creature tokens, where X is Nested Shambler's power.",
             "colours": [
@@ -14328,7 +14328,7 @@
         },
         {
             "id": "6a9e6512-8aa9-5690-90f4-8f92d1d82c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a8dbf-d5b1-4337-8c3e-bc0c8308e426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a8dbf-d5b1-4337-8c3e-bc0c8308e426.jpg?1",
             "name": "Persist",
             "text": "Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.",
             "colours": [
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "63922c26-4949-5f2b-88bf-5e2682736d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f7fdb-9c38-43f8-acb9-6ea1797387a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f7fdb-9c38-43f8-acb9-6ea1797387a6.jpg?1",
             "name": "Profane Tutor",
             "text": "Suspend 2\u2014{1}{B}\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -14400,7 +14400,7 @@
         },
         {
             "id": "1de83188-2953-5aa2-ae09-ad652d8368b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7caf6c-9f5b-45c4-99ab-2968c3d574e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7caf6c-9f5b-45c4-99ab-2968c3d574e9.jpg?1",
             "name": "Tourach, Dread Cantor",
             "text": "Kicker {B}{B}\nProtection from white\nWhenever an opponent discards a card, put a +1/+1 counter on Tourach, Dread Cantor.\nWhen Tourach enters the battlefield, if it was kicked, target opponent discards two cards at random.",
             "colours": [
@@ -14441,7 +14441,7 @@
         },
         {
             "id": "197be68d-89e8-5591-b6fd-0f5c0d9b5bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36590526-2f1b-4959-ba9e-55f3ebcffd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36590526-2f1b-4959-ba9e-55f3ebcffd1e.jpg?1",
             "name": "Vile Entomber",
             "text": "Deathtouch\nWhen Vile Entomber enters the battlefield, search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -14479,7 +14479,7 @@
         },
         {
             "id": "f10b8c10-ee91-54eb-b3f1-ad47057f2599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45121709-9f0e-4f60-8dd7-ebc31acdb124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45121709-9f0e-4f60-8dd7-ebc31acdb124.jpg?1",
             "name": "Blazing Rootwalla",
             "text": "{R}: Blazing Rootwalla gets +2/+0 until end of turn. Activate only once each turn.\nMadness {0}",
             "colours": [
@@ -14516,7 +14516,7 @@
         },
         {
             "id": "a036bf8d-05fa-5146-90c9-b40a57b05a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d81763-46c0-4e5e-9292-04a8aa461682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d81763-46c0-4e5e-9292-04a8aa461682.jpg?1",
             "name": "Calibrated Blast",
             "text": "Reveal cards from the top of your library until you reveal a nonland card. Put the revealed cards on the bottom of your library in a random order. When you reveal a nonland card this way, Calibrated Blast deals damage equal to that card's mana value to any target.\nFlashback {3}{R}{R}",
             "colours": [
@@ -14552,7 +14552,7 @@
         },
         {
             "id": "5e8a6084-1031-59b9-a610-07f101803bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0a4bba-4512-4718-89b5-f02331f3aa5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0a4bba-4512-4718-89b5-f02331f3aa5f.jpg?1",
             "name": "Galvanic Relay",
             "text": "Exile the top card of your library. During your next turn, you may play that card.\nStorm",
             "colours": [
@@ -14587,7 +14587,7 @@
         },
         {
             "id": "c99614e9-5ae9-5589-9bcc-8b890ce8efbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988137f8-40a3-4308-b297-a9a4d171181d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988137f8-40a3-4308-b297-a9a4d171181d.jpg?1",
             "name": "Glimpse of Tomorrow",
             "text": "Suspend 3\u2014{R}{R}\nShuffle all permanents you own into your library, then reveal that many cards from the top of your library. Put all non-Aura permanent cards revealed this way onto the battlefield, then do the same for Aura cards, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14623,7 +14623,7 @@
         },
         {
             "id": "2dda8abc-dfbe-54d4-aeea-e26177de6b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeb96a-1e2c-47fa-9cfc-7d1ead1cfab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeb96a-1e2c-47fa-9cfc-7d1ead1cfab6.jpg?1",
             "name": "Mine Collapse",
             "text": "If it's your turn, you may sacrifice a Mountain rather than pay this spell's mana cost.\nMine Collapse deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -14658,7 +14658,7 @@
         },
         {
             "id": "521c9344-4bbc-5ac8-9f1c-53301aa63341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a03422-4106-4d06-b26a-06b1e3b0cb2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a03422-4106-4d06-b26a-06b1e3b0cb2a.jpg?1",
             "name": "Aeve, Progenitor Ooze",
             "text": "Storm\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.",
             "colours": [
@@ -14698,7 +14698,7 @@
         },
         {
             "id": "ea44c218-be76-54bf-a1ba-fee2ba24259f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ba5ac8-e8fa-4979-9ef9-c3d75ee7f982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ba5ac8-e8fa-4979-9ef9-c3d75ee7f982.jpg?1",
             "name": "Chatterfang, Squirrel General",
             "text": "Forestwalk\nIf one or more tokens would be created under your control, those tokens plus that many 1/1 green Squirrel creature tokens are created instead.\n{B}, Sacrifice X Squirrels: Target creature gets +X/-X until end of turn.",
             "colours": [
@@ -14740,7 +14740,7 @@
         },
         {
             "id": "42727da1-af1a-5edc-a4b3-cd7126af3e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1b91d8-39c4-4ab1-996b-2a5a78243fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1b91d8-39c4-4ab1-996b-2a5a78243fd4.jpg?1",
             "name": "Chatterstorm",
             "text": "Create a 1/1 green Squirrel creature token.\nStorm",
             "colours": [
@@ -14775,7 +14775,7 @@
         },
         {
             "id": "89ec351d-1484-57a9-927d-5b9aa78a7468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3283b-e74c-4991-9369-cf3415db41e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3283b-e74c-4991-9369-cf3415db41e0.jpg?1",
             "name": "Gaea's Will",
             "text": "Suspend 4\u2014{G}\nUntil end of turn, you may play lands and cast spells from your graveyard.\nIf a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -14811,7 +14811,7 @@
         },
         {
             "id": "d4200f85-a9db-5ce8-be49-b02e004402b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0691a6a-bfbd-411b-b147-bf9702e7d149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0691a6a-bfbd-411b-b147-bf9702e7d149.jpg?1",
             "name": "Glimmer Bairn",
             "text": "Sacrifice a token: Glimmer Bairn gets +2/+2 until end of turn.",
             "colours": [
@@ -14848,7 +14848,7 @@
         },
         {
             "id": "c2502044-3a73-55f5-ac09-a6265ae5cfae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417f14c-a853-42c6-a992-29139484260a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417f14c-a853-42c6-a992-29139484260a.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "Exalted\n{T}: Add {B}, {R}, or {G}.",
             "colours": [
@@ -14889,7 +14889,7 @@
         },
         {
             "id": "2807bb92-920a-526d-8f03-0d0ac52c34c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512e5b8-2394-42d9-9dbf-345137710cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512e5b8-2394-42d9-9dbf-345137710cde.jpg?1",
             "name": "Squirrel Sovereign",
             "text": "Other Squirrels you control get +1/+1.",
             "colours": [
@@ -14927,7 +14927,7 @@
         },
         {
             "id": "0b6ab7a9-6022-5e0b-baf4-3f2275ce669b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab161d9-45d7-48b7-af47-21e3dbae4d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab161d9-45d7-48b7-af47-21e3dbae4d85.jpg?1",
             "name": "Titania, Protector of Argoth",
             "text": "When Titania, Protector of Argoth enters the battlefield, return target land card from your graveyard to the battlefield.\nWhenever a land you control is put into a graveyard from the battlefield, create a 5/3 green Elemental creature token.",
             "colours": [
@@ -14967,7 +14967,7 @@
         },
         {
             "id": "35922c91-19e9-5d64-86a0-b2c7dd2099a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6fac09-34e1-495a-ba70-8110845fbefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6fac09-34e1-495a-ba70-8110845fbefb.jpg?1",
             "name": "Asmoranomardicadaistinaculdacar",
             "text": "As long as you've discarded a card this turn, you may pay {BR} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters the battlefield, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.",
             "colours": [
@@ -15010,7 +15010,7 @@
         },
         {
             "id": "44f7fb26-b981-500c-95bd-a3480de7326e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d9b79-bcf8-4c6e-8b0b-6cd71b615d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d9b79-bcf8-4c6e-8b0b-6cd71b615d39.jpg?1",
             "name": "Carth the Lion",
             "text": "Whenever Carth the Lion enters the battlefield or a planeswalker you control dies, look at the top seven cards of your library. You may reveal a planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nPlaneswalkers' loyalty abilities you activate cost an additional  to activate.",
             "colours": [
@@ -15053,7 +15053,7 @@
         },
         {
             "id": "0adb358f-5ae4-5a49-91db-b5cb5693c35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875244ac-d129-407a-bd9b-9fb59958bef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875244ac-d129-407a-bd9b-9fb59958bef9.jpg?1",
             "name": "Chainer, Nightmare Adept",
             "text": "Discard a card: You may cast a creature spell from your graveyard this turn. Activate only once each turn.\nWhenever a nontoken creature enters the battlefield under your control, if you didn't cast it from your hand, it gains haste until your next turn.",
             "colours": [
@@ -15095,7 +15095,7 @@
         },
         {
             "id": "513c2f7e-2216-5dfd-952e-0926c80b55c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662c23f8-feb3-43e3-add5-cf136cd54a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662c23f8-feb3-43e3-add5-cf136cd54a1a.jpg?1",
             "name": "Garth One-Eye",
             "text": "{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy.",
             "colours": [
@@ -15144,7 +15144,7 @@
         },
         {
             "id": "9ee80811-9f1e-5591-b335-d6da8764cff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f07a80-05b5-4108-9e68-f8da05866acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f07a80-05b5-4108-9e68-f8da05866acc.jpg?1",
             "name": "Goblin Anarchomancer",
             "text": "Each spell you cast that's red or green costs {1} less to cast.",
             "colours": [
@@ -15184,7 +15184,7 @@
         },
         {
             "id": "76a3771a-6dd1-5f8d-8aa8-e99564b1c61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53945b5e-75da-48e5-ac87-5c02f318fdf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53945b5e-75da-48e5-ac87-5c02f318fdf0.jpg?1",
             "name": "Piru, the Volatile",
             "text": "Flying, lifelink\nAt the beginning of your upkeep, sacrifice Piru, the Volatile unless you pay {R}{W}{B}.\nWhen Piru dies, it deals 7 damage to each nonlegendary creature.",
             "colours": [
@@ -15229,7 +15229,7 @@
         },
         {
             "id": "3b0e276f-177a-5db7-bf1c-9f46239ad8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27424714-b656-41b8-b19f-022e472afc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27424714-b656-41b8-b19f-022e472afc7f.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade",
             "colours": [
@@ -15271,7 +15271,7 @@
         },
         {
             "id": "ca3320b7-9d27-5e61-830b-e3f29a2b51b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddb6d98-3a3a-4332-a64e-97aec71777a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddb6d98-3a3a-4332-a64e-97aec71777a4.jpg?1",
             "name": "Terminal Agony",
             "text": "Destroy target creature.\nMadness {B}{R}",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "0302370f-fd91-5951-9004-b28200994b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b25acb5-3bd3-4835-9b6b-32a751c7ce97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b25acb5-3bd3-4835-9b6b-32a751c7ce97.jpg?1",
             "name": "Territorial Kavu",
             "text": "Domain \u2014 Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.\nWhenever Territorial Kavu attacks, choose one \u2014\n\u2022 Discard a card. If you do, draw a card.\n\u2022 Exile up to one target card from a graveyard.",
             "colours": [
@@ -15348,7 +15348,7 @@
         },
         {
             "id": "2abeb6d5-537c-537e-aeb2-ba2d04c372fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef23258-511f-43f8-b84f-bd2256b5c86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef23258-511f-43f8-b84f-bd2256b5c86b.jpg?1",
             "name": "Brainstone",
             "text": "{2}, {T}, Sacrifice Brainstone: Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [],
@@ -15379,7 +15379,7 @@
         },
         {
             "id": "c6851edc-6574-52b2-940a-394f93340efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4310ee5-a65d-4113-a57c-bb121601e963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4310ee5-a65d-4113-a57c-bb121601e963.jpg?1",
             "name": "Diamond Lion",
             "text": "{T}, Discard your hand, Sacrifice Diamond Lion: Add three mana of any one color. Activate only as an instant.",
             "colours": [],
@@ -15414,7 +15414,7 @@
         },
         {
             "id": "adfb900c-7c37-52f9-ad7b-e173d16acec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b548fdf-7130-4a94-bd7e-09591b395513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b548fdf-7130-4a94-bd7e-09591b395513.jpg?1",
             "name": "Liquimetal Torque",
             "text": "{T}: Add {C}.\n{T}: Target nonland permanent becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -15445,7 +15445,7 @@
         },
         {
             "id": "d70aaae2-a9e9-5e10-b2af-759a0f07a345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff376d1a-85b4-4d8d-8862-5de0aae6fa4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff376d1a-85b4-4d8d-8862-5de0aae6fa4e.jpg?1",
             "name": "Monoskelion",
             "text": "Monoskelion enters the battlefield with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from Monoskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -15479,7 +15479,7 @@
         },
         {
             "id": "237db7cb-3ea4-5ef7-8510-b2482e649a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ac45cf-4dc8-47b9-8ca8-e72464f745d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ac45cf-4dc8-47b9-8ca8-e72464f745d6.jpg?1",
             "name": "Ornithopter of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [],
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "d9babe0d-38ca-57c8-8154-53d99082e9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b3983d-93aa-4a33-a064-23c87ab6ed51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b3983d-93aa-4a33-a064-23c87ab6ed51.jpg?1",
             "name": "Scion of Draco",
             "text": "Domain \u2014 This spell costs {2} less to cast for each basic land type among lands you control.\nFlying\nEach creature you control has vigilance if it's white, hexproof if it's blue, lifelink if it's black, first strike if it's red, and trample if it's green.",
             "colours": [],
@@ -15548,7 +15548,7 @@
         },
         {
             "id": "fcfa85c8-d6ff-589a-af32-f2b84a4352e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f81658-4008-45a1-9a3d-a39369b6c96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f81658-4008-45a1-9a3d-a39369b6c96f.jpg?1",
             "name": "Sol Talisman",
             "text": "Suspend 3\u2014{1}\n{T}: Add {C}{C}.",
             "colours": [],
@@ -15580,7 +15580,7 @@
         },
         {
             "id": "9cdf38ce-0201-5732-835f-02afd037bb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c530cf5-601a-4e9c-b81e-5bddff0c1196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c530cf5-601a-4e9c-b81e-5bddff0c1196.jpg?1",
             "name": "Sword of Hearth and Home",
             "text": "Equipped creature gets +2/+2 and has protection from green and from white.\nWhenever equipped creature deals combat damage to a player, exile up to one target creature you own, then search your library for a basic land card. Put both cards onto the battlefield under your control, then shuffle.\nEquip {2}",
             "colours": [],
@@ -15614,7 +15614,7 @@
         },
         {
             "id": "06e10288-bb9b-5bc6-9472-9a0129c5bc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24504e-b397-4b98-b8e8-8166457f7a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24504e-b397-4b98-b8e8-8166457f7a2e.jpg?1",
             "name": "The Underworld Cookbook",
             "text": "{T}, Discard a card: Create a Food token.\n{4}, {T}, Sacrifice The Underworld Cookbook: Return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -15645,7 +15645,7 @@
         },
         {
             "id": "beb27252-4df7-519d-bbcb-fe196803e75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f982bda-3153-4ef7-9eab-a658732b5db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f982bda-3153-4ef7-9eab-a658732b5db7.jpg?1",
             "name": "Void Mirror",
             "text": "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.",
             "colours": [],
@@ -15677,7 +15677,7 @@
         },
         {
             "id": "365afb20-e706-586e-b17e-44642b4b5e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716c415e-5eb8-4644-ac64-5ba7c3f0ea65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716c415e-5eb8-4644-ac64-5ba7c3f0ea65.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15709,7 +15709,7 @@
         },
         {
             "id": "85e31db0-769e-51d8-a677-8d810653e70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19a6f20-8ca1-4a8b-8488-bcb5d86868dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19a6f20-8ca1-4a8b-8488-bcb5d86868dc.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15741,7 +15741,7 @@
         },
         {
             "id": "8fe78eb0-850f-5d0b-a6d8-eab0aa8d6b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cad746-a1dc-4739-9707-9c12c42e141a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cad746-a1dc-4739-9707-9c12c42e141a.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15773,7 +15773,7 @@
         },
         {
             "id": "a4737272-0b06-5265-a54a-6466b2327c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c6ba55-2470-4dde-a7fa-137a60716c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c6ba55-2470-4dde-a7fa-137a60716c96.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15805,7 +15805,7 @@
         },
         {
             "id": "a0e2d24e-d722-5646-bd47-875937f1afb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981b3a2e-de94-428d-8e5d-5a7ba6afe4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981b3a2e-de94-428d-8e5d-5a7ba6afe4a2.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15837,7 +15837,7 @@
         },
         {
             "id": "bb2e12ac-0186-51d0-964f-227243dacd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0063a44-6cde-4d7e-81e1-61bae08831ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0063a44-6cde-4d7e-81e1-61bae08831ee.jpg?1",
             "name": "Yavimaya, Cradle of Growth",
             "text": "Each land is a Forest in addition to its other land types.",
             "colours": [],
@@ -15871,7 +15871,7 @@
         },
         {
             "id": "cbe32e44-5077-5a06-9d20-579e4cfb63ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44fbfa3-3698-4b79-a7bd-6b6f86bea82a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44fbfa3-3698-4b79-a7bd-6b6f86bea82a.jpg?1",
             "name": "Out of Time",
             "text": "When Out of Time enters the battlefield, untap all creatures, then phase them out until Out of Time leaves the battlefield. Put a time counter on Out of Time for each creature phased out this way.\nVanishing",
             "colours": [
@@ -15906,7 +15906,7 @@
         },
         {
             "id": "5609ef81-d09a-5d1d-bd60-7e5eaa892bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2387da7-5372-4533-a632-624dd08120ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2387da7-5372-4533-a632-624dd08120ab.jpg?1",
             "name": "Resurgent Belief",
             "text": "Suspend 2\u2014{1}{W}\nReturn all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -15941,7 +15941,7 @@
         },
         {
             "id": "28e5aaed-94b7-59b7-960a-e459ed7189b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed75e0-f016-4c62-b96e-de97f7fdb6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed75e0-f016-4c62-b96e-de97f7fdb6d8.jpg?1",
             "name": "Sanctifier en-Vec",
             "text": "Protection from black and from red\nWhen Sanctifier en-Vec enters the battlefield, exile all cards that are black or red from all graveyards.\nIf a black or red permanent, spell, or card not on the battlefield would be put into a graveyard, exile it instead.",
             "colours": [
@@ -15979,7 +15979,7 @@
         },
         {
             "id": "8425b4ee-541e-5561-a273-565b728fee44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044902aa-29a1-4627-a4fc-0beccd2a10b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044902aa-29a1-4627-a4fc-0beccd2a10b3.jpg?1",
             "name": "Timeless Dragon",
             "text": "Flying\nPlainscycling {2}\nEternalize {2}{W}{W}",
             "colours": [
@@ -16016,7 +16016,7 @@
         },
         {
             "id": "cf614be5-243f-5913-abb1-6f8e9de7aacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb9a0f9-0af6-42ac-9e42-f315f4882939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb9a0f9-0af6-42ac-9e42-f315f4882939.jpg?1",
             "name": "Inevitable Betrayal",
             "text": "Suspend 3\u2014{1}{U}{U}\nSearch target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -16051,7 +16051,7 @@
         },
         {
             "id": "047deb7c-09ed-5d90-a071-9a1dcf68ee98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6f1da-ddef-44d0-af1b-e0c4024d9985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6f1da-ddef-44d0-af1b-e0c4024d9985.jpg?1",
             "name": "Rishadan Dockhand",
             "text": "Islandwalk\n{1}, {T}: Tap target land.",
             "colours": [
@@ -16088,7 +16088,7 @@
         },
         {
             "id": "6fbb8561-ea4f-5059-b2ac-1c2effe7708f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b39f1d-6d8b-4d5d-a956-094de5c26ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b39f1d-6d8b-4d5d-a956-094de5c26ba8.jpg?1",
             "name": "Suspend",
             "text": "Exile target creature and put two time counters on it. If it doesn't have suspend, it gains suspend.",
             "colours": [
@@ -16122,7 +16122,7 @@
         },
         {
             "id": "756fca49-691b-5713-8498-47743bef64b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402060d4-10d6-4cee-aa8b-cd083bf5df43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402060d4-10d6-4cee-aa8b-cd083bf5df43.jpg?1",
             "name": "Damn",
             "text": "Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W}",
             "colours": [
@@ -16158,7 +16158,7 @@
         },
         {
             "id": "6ee206c8-1453-56cb-a2f1-a7e34d5eb805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29632951-3c3d-478c-8c5a-9a34f30a5c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29632951-3c3d-478c-8c5a-9a34f30a5c28.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "Shadow\nIf a card would be put into an opponent's graveyard from anywhere, instead exile it with a void counter on it.\n{T}, Sacrifice Dauthi Voidwalker: Choose an exiled card an opponent owns with a void counter on it. You may play it this turn without paying its mana cost.",
             "colours": [
@@ -16196,7 +16196,7 @@
         },
         {
             "id": "5476f12f-7a1b-5be3-92a9-3bd920f19675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2d158-d69e-4854-b84f-9f271e36101c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2d158-d69e-4854-b84f-9f271e36101c.jpg?1",
             "name": "Necrogoyf",
             "text": "Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B}",
             "colours": [
@@ -16233,7 +16233,7 @@
         },
         {
             "id": "0a7b2595-642f-5c87-bb62-6fa47aa54a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44989011-7833-42e3-8fae-6ed0c7220e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44989011-7833-42e3-8fae-6ed0c7220e28.jpg?1",
             "name": "Profane Tutor",
             "text": "Suspend 2\u2014{1}{B}\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -16268,7 +16268,7 @@
         },
         {
             "id": "9b1fa2e0-39f3-5d49-98de-aa70d2edf4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d05400a-862f-4dcc-8ebc-edb0b5deaadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d05400a-862f-4dcc-8ebc-edb0b5deaadd.jpg?1",
             "name": "Unmarked Grave",
             "text": "Search your library for a nonlegendary card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -16302,7 +16302,7 @@
         },
         {
             "id": "cd0a0756-0977-51d9-8338-d6f7aeabf909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3af226-9f55-481a-87ec-da2861ac60e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3af226-9f55-481a-87ec-da2861ac60e0.jpg?1",
             "name": "Bloodbraid Marauder",
             "text": "Bloodbraid Marauder can't block.\nDelirium \u2014 This spell has cascade as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -16339,7 +16339,7 @@
         },
         {
             "id": "fb15b4fb-01c3-5afd-b7a7-9dc3c4950164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a7da2c-3156-403b-8722-d1fa5eb5192e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a7da2c-3156-403b-8722-d1fa5eb5192e.jpg?1",
             "name": "Breya's Apprentice",
             "text": "When Breya's Apprentice enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\n{T}, Sacrifice an artifact: Choose one \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play that card.\n\u2022 Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -16377,7 +16377,7 @@
         },
         {
             "id": "8228d372-60cb-53a6-a496-0770657997c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8284eb-a604-4e86-a140-7c703b52c806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8284eb-a604-4e86-a140-7c703b52c806.jpg?1",
             "name": "Calibrated Blast",
             "text": "Reveal cards from the top of your library until you reveal a nonland card. Put the revealed cards on the bottom of your library in a random order. When you reveal a nonland card this way, Calibrated Blast deals damage equal to that card's mana value to any target.\nFlashback {3}{R}{R}",
             "colours": [
@@ -16412,7 +16412,7 @@
         },
         {
             "id": "63fc9053-f4fe-523f-acf0-95f60fea7eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c706922d-c892-43d0-a4f5-91283999d291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c706922d-c892-43d0-a4f5-91283999d291.jpg?1",
             "name": "Chef's Kiss",
             "text": "Gain control of target spell that targets only a single permanent or player. Copy it, then reselect the targets at random for the spell and the copy. The new targets can't be you or a permanent you control.",
             "colours": [
@@ -16446,7 +16446,7 @@
         },
         {
             "id": "fb3e720e-42eb-54d1-8b00-ddebe0529e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d332ab-67bf-4db8-953a-6843efbb455c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d332ab-67bf-4db8-953a-6843efbb455c.jpg?1",
             "name": "Glimpse of Tomorrow",
             "text": "Suspend 3\u2014{R}{R}\nShuffle all permanents you own into your library, then reveal that many cards from the top of your library. Put all non-Aura permanent cards revealed this way onto the battlefield, then do the same for Aura cards, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -16481,7 +16481,7 @@
         },
         {
             "id": "d9f72619-78f0-52af-be7b-5c3ce35256ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2009ab97-1d0f-4c59-9357-3ff4952ce3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2009ab97-1d0f-4c59-9357-3ff4952ce3be.jpg?1",
             "name": "Aeve, Progenitor Ooze",
             "text": "Storm\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.",
             "colours": [
@@ -16520,7 +16520,7 @@
         },
         {
             "id": "4c9b5e15-d4cc-5cb2-b656-9101084254eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7687d1-d168-4279-b21d-fcfc7573c7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7687d1-d168-4279-b21d-fcfc7573c7b5.jpg?1",
             "name": "Chitterspitter",
             "text": "At the beginning of your upkeep, you may sacrifice a token. If you do, put an acorn counter on Chitterspitter.\nSquirrels you control get +1/+1 for each acorn counter on Chitterspitter.\n{G}, {T}: Create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -16554,7 +16554,7 @@
         },
         {
             "id": "480d0b04-c353-540a-aeb4-213fd547489b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecd084d-20c6-43cf-b5d5-8ba3d692a50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecd084d-20c6-43cf-b5d5-8ba3d692a50a.jpg?1",
             "name": "Gaea's Will",
             "text": "Suspend 4\u2014{G}\nUntil end of turn, you may play lands and cast spells from your graveyard.\nIf a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -16589,7 +16589,7 @@
         },
         {
             "id": "dfc77d68-2f73-5aab-a53b-518b590d5b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd218c-3e14-4b82-9e03-16a0fad1b530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd218c-3e14-4b82-9e03-16a0fad1b530.jpg?1",
             "name": "Sanctum Weaver",
             "text": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
             "colours": [
@@ -16626,7 +16626,7 @@
         },
         {
             "id": "982c13aa-1dd6-5a9d-a25b-38ad0c1f6141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879f780-e17f-4e68-931e-6e45f9df28e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879f780-e17f-4e68-931e-6e45f9df28e1.jpg?1",
             "name": "Asmoranomardicadaistinaculdacar",
             "text": "As long as you've discarded a card this turn, you may pay {BR} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters the battlefield, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.",
             "colours": [
@@ -16668,7 +16668,7 @@
         },
         {
             "id": "d9626b00-e739-56b5-8b4b-5095752aa275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf4ca15-10b9-4dcc-86dc-be15eeda87a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf4ca15-10b9-4dcc-86dc-be15eeda87a4.jpg?1",
             "name": "Carth the Lion",
             "text": "Whenever Carth the Lion enters the battlefield or a planeswalker you control dies, look at the top seven cards of your library. You may reveal a planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nPlaneswalkers' loyalty abilities you activate cost an additional  to activate.",
             "colours": [
@@ -16710,7 +16710,7 @@
         },
         {
             "id": "d5e65e51-73b9-5b65-a43e-a5467aa62d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c398de-b96d-4fa6-89c4-3ce8183dc27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c398de-b96d-4fa6-89c4-3ce8183dc27e.jpg?1",
             "name": "Master of Death",
             "text": "When Master of Death enters the battlefield, surveil 2.\nAt the beginning of your upkeep, if Master of Death is in your graveyard, you may pay 1 life. If you do, return it to your hand.",
             "colours": [
@@ -16749,7 +16749,7 @@
         },
         {
             "id": "9574edd1-178d-50c9-aa66-3960874ff112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064c2f03-5290-4e87-9d2f-cfbd247c9646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064c2f03-5290-4e87-9d2f-cfbd247c9646.jpg?1",
             "name": "Piru, the Volatile",
             "text": "Flying, lifelink\nAt the beginning of your upkeep, sacrifice Piru, the Volatile unless you pay {R}{W}{B}.\nWhen Piru dies, it deals 7 damage to each nonlegendary creature.",
             "colours": [
@@ -16793,7 +16793,7 @@
         },
         {
             "id": "d895b0ca-cf2f-5b67-8cef-937f5d3fbe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2474c3e8-7b52-477b-ada8-22e221037925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2474c3e8-7b52-477b-ada8-22e221037925.jpg?1",
             "name": "Territorial Kavu",
             "text": "Domain \u2014 Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.\nWhenever Territorial Kavu attacks, choose one \u2014\n\u2022 Discard a card. If you do, draw a card.\n\u2022 Exile up to one target card from a graveyard.",
             "colours": [
@@ -16832,7 +16832,7 @@
         },
         {
             "id": "241eeabf-8e5f-5987-8324-53099a514e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc06edb-d7dd-40e4-abbb-03ec2d467193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc06edb-d7dd-40e4-abbb-03ec2d467193.jpg?1",
             "name": "Yusri, Fortune's Flame",
             "text": "Flying\nWhenever Yusri, Fortune's Flame attacks, choose a number between 1 and 5. Flip that many coins. For each flip you win, draw a card. For each flip you lose, Yusri deals 2 damage to you. If you won five flips this way, you may cast spells from your hand this turn without paying their mana costs.",
             "colours": [
@@ -16873,7 +16873,7 @@
         },
         {
             "id": "37257ed9-afbe-52d8-a081-a8b9805f8ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb31a63-a4c9-4432-9029-eb5a50c769b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb31a63-a4c9-4432-9029-eb5a50c769b4.jpg?1",
             "name": "Academy Manufactor",
             "text": "If you would create a Clue, Food, or Treasure token, instead create one of each.",
             "colours": [],
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "0f5a3683-0214-569d-9916-639198285845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2116f1a3-f621-4bef-b5bd-fa4a644f76b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2116f1a3-f621-4bef-b5bd-fa4a644f76b1.jpg?1",
             "name": "Diamond Lion",
             "text": "{T}, Discard your hand, Sacrifice Diamond Lion: Add three mana of any one color. Activate only as an instant.",
             "colours": [],
@@ -16940,7 +16940,7 @@
         },
         {
             "id": "9ff2c337-a520-5571-8302-c981b3f2c96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f3852d-e99a-418e-a235-da47ed38aabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f3852d-e99a-418e-a235-da47ed38aabe.jpg?1",
             "name": "Nettlecyst",
             "text": "Living weapon\nEquipped creature gets +1/+1 for each artifact and/or enchantment you control.\nEquip {2}",
             "colours": [],
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "911050fe-18a4-546c-a37e-bb17386e1fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18052761-39c3-4342-b6e6-38dc5b7b05dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18052761-39c3-4342-b6e6-38dc5b7b05dd.jpg?1",
             "name": "Sol Talisman",
             "text": "Suspend 3\u2014{1}\n{T}: Add {C}{C}.",
             "colours": [],
@@ -17003,7 +17003,7 @@
         },
         {
             "id": "d157b20f-ae11-55c6-a887-c140907d7c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c216e5-856d-4464-96f7-17b5289d5396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c216e5-856d-4464-96f7-17b5289d5396.jpg?1",
             "name": "Void Mirror",
             "text": "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.",
             "colours": [],
@@ -17034,7 +17034,7 @@
         },
         {
             "id": "5d802e96-c38e-54c8-b634-b070cb6ee24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58a96f-939c-4b9b-a4c2-fb83d896eefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58a96f-939c-4b9b-a4c2-fb83d896eefb.jpg?1",
             "name": "Zabaz, the Glimmerwasp",
             "text": "Modular 1\nIf a modular triggered ability would put one or more +1/+1 counters on a creature you control, that many plus one +1/+1 counters are put on it instead.\n{R}: Destroy target artifact you control.\n{W}: Zabaz, the Glimmerwasp gains flying until end of turn.",
             "colours": [],
@@ -17072,7 +17072,7 @@
         },
         {
             "id": "bfd186b5-e698-583d-9a96-15530aa43df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ced5cf-b51a-4dab-97f7-50fb18e5c463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ced5cf-b51a-4dab-97f7-50fb18e5c463.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17103,7 +17103,7 @@
         },
         {
             "id": "55b43cef-e9de-5d62-8dc2-74491241811d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8397e6-d13a-4996-8fde-b8a9895de287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8397e6-d13a-4996-8fde-b8a9895de287.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17134,7 +17134,7 @@
         },
         {
             "id": "d53c0a56-2548-5ece-8bad-ed09112e1ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d8e67a-5150-4782-98d1-da2ca79607ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d8e67a-5150-4782-98d1-da2ca79607ad.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17165,7 +17165,7 @@
         },
         {
             "id": "58bbf59a-b4bd-58f0-8b8b-9747789966bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ecfc9-8d6b-4fdb-9001-64dc3e4e7a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ecfc9-8d6b-4fdb-9001-64dc3e4e7a3f.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17196,7 +17196,7 @@
         },
         {
             "id": "064b0bae-29ab-578c-b210-8a73443d93d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7057b04-e22f-4e33-9f08-b9fbd2e54bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7057b04-e22f-4e33-9f08-b9fbd2e54bf5.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17227,7 +17227,7 @@
         },
         {
             "id": "904bb8b4-f746-5f1f-8c18-082fc3d6f59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7c2820-e36e-4024-a542-02ca42bb7e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7c2820-e36e-4024-a542-02ca42bb7e2f.jpg?1",
             "name": "Yavimaya, Cradle of Growth",
             "text": "Each land is a Forest in addition to its other land types.",
             "colours": [],
@@ -17260,7 +17260,7 @@
         },
         {
             "id": "2210b34e-1821-5bbd-a039-6a4a7733a5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa2449-6b74-4319-858f-caa9282da5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa2449-6b74-4319-858f-caa9282da5c1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17297,7 +17297,7 @@
         },
         {
             "id": "eae53b01-b037-55e5-8efc-2a0ef422c887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14e6193-f60b-46c8-a7eb-02a437138568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14e6193-f60b-46c8-a7eb-02a437138568.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17334,7 +17334,7 @@
         },
         {
             "id": "f34e51c1-7c9c-517d-9753-a90e50de9bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423927e6-2419-4d88-b0c4-425e5cac1a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423927e6-2419-4d88-b0c4-425e5cac1a3f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17371,7 +17371,7 @@
         },
         {
             "id": "62b78512-f9e7-5f75-95b4-b394587023f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d781a5-2f5e-499f-b210-c4a5c50a180c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d781a5-2f5e-499f-b210-c4a5c50a180c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17408,7 +17408,7 @@
         },
         {
             "id": "95e0346e-d6df-5be8-b103-d8373325fdf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8546d1-bfea-4cf7-bfa1-48555ea81bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8546d1-bfea-4cf7-bfa1-48555ea81bd4.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17445,7 +17445,7 @@
         },
         {
             "id": "35cb261c-c1f4-52df-9363-e638725c2b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959cb185-a280-493c-b85c-69b74e042c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959cb185-a280-493c-b85c-69b74e042c15.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17482,7 +17482,7 @@
         },
         {
             "id": "8a0a06d9-8bdd-5d1f-b29f-fd20687b6487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be3032-c55b-43b5-9ae0-f4e7470f4f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be3032-c55b-43b5-9ae0-f4e7470f4f83.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17519,7 +17519,7 @@
         },
         {
             "id": "7b0ce595-0135-5e59-bb04-156fdc19b8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a0d49-71ae-42c4-a896-6828dc4f1e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a0d49-71ae-42c4-a896-6828dc4f1e85.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17556,7 +17556,7 @@
         },
         {
             "id": "3ae61fb7-3293-5880-a32a-a9c530041d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e93212-da68-48f8-9aeb-ee5eb92e9a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e93212-da68-48f8-9aeb-ee5eb92e9a54.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17593,7 +17593,7 @@
         },
         {
             "id": "1da41dd8-bf56-5fdc-952b-9f26e082d1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17393110-c57e-487b-b07e-dc21a164efa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17393110-c57e-487b-b07e-dc21a164efa7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17630,7 +17630,7 @@
         },
         {
             "id": "8f52b2f8-87c2-54c4-b133-87a2ca4fa99f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9839e4e-94dd-4087-b7a9-3089f1828397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9839e4e-94dd-4087-b7a9-3089f1828397.jpg?1",
             "name": "Sanctum Prelate",
             "text": "As Sanctum Prelate enters the battlefield, choose a number.\nNoncreature spells with mana value equal to the chosen number can't be cast.",
             "colours": [
@@ -17664,7 +17664,7 @@
         },
         {
             "id": "40ccb40a-60f4-5df4-8eff-f8c1efcea7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c332e-a5c9-40fb-a2fa-b4888aecc9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c332e-a5c9-40fb-a2fa-b4888aecc9c7.jpg?1",
             "name": "Yusri, Fortune's Flame",
             "text": "Flying\nWhenever Yusri, Fortune's Flame attacks, choose a number between 1 and 5. Flip that many coins. For each flip you win, draw a card. For each flip you lose, Yusri deals 2 damage to you. If you won five flips this way, you may cast spells from your hand this turn without paying their mana costs.",
             "colours": [
@@ -17705,7 +17705,7 @@
         },
         {
             "id": "c4b05382-12cb-5258-8d3d-d651126026ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e40dd-f435-4abc-a3e8-fd3d3a94e910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e40dd-f435-4abc-a3e8-fd3d3a94e910.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -17740,7 +17740,7 @@
         },
         {
             "id": "d22b1f7f-bd5a-5691-ba2e-6999608aab5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5.jpg?1",
             "name": "Crab",
             "text": "",
             "colours": [
@@ -17775,7 +17775,7 @@
         },
         {
             "id": "281298b5-2b46-58ad-9317-5c6432a07a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e0681-603e-4180-bc86-3dadf214e61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e0681-603e-4180-bc86-3dadf214e61a.jpg?1",
             "name": "Phyrexian Germ",
             "text": "",
             "colours": [
@@ -17811,7 +17811,7 @@
         },
         {
             "id": "66c1dec4-4e0e-50d3-852e-142972e48d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ab74f3-897a-4dd9-b460-f31a0f496bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ab74f3-897a-4dd9-b460-f31a0f496bb4.jpg?1",
             "name": "Timeless Dragon",
             "text": "",
             "colours": [
@@ -17847,7 +17847,7 @@
         },
         {
             "id": "007e7abf-e733-5bf0-8c22-37881e5bb218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e466a1b-a120-420a-884f-99c6629dcbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e466a1b-a120-420a-884f-99c6629dcbc7.jpg?1",
             "name": "Timeless Witness",
             "text": "",
             "colours": [
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "68c08e04-c7bc-5c2c-8653-80c3960b1b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3031bec1-c6dc-441f-9391-458bb1577c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3031bec1-c6dc-441f-9391-458bb1577c56.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17919,7 +17919,7 @@
         },
         {
             "id": "1381dd95-3d82-5215-887b-4c7178baa411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46d82e0-ef99-473c-a09c-8f552db759bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46d82e0-ef99-473c-a09c-8f552db759bf.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -17955,7 +17955,7 @@
         },
         {
             "id": "b053b0fa-87ef-5444-9e60-0946d493e14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41268b47-df00-41db-92d7-991c7945e4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41268b47-df00-41db-92d7-991c7945e4c6.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -17990,7 +17990,7 @@
         },
         {
             "id": "022298f4-4249-5c29-b611-1a014734e0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -18025,7 +18025,7 @@
         },
         {
             "id": "1e44ddb7-8c59-5857-90f3-62ea867a0a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cddb130-a354-4373-9dc4-60c7d57eec8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cddb130-a354-4373-9dc4-60c7d57eec8b.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -18060,7 +18060,7 @@
         },
         {
             "id": "20cf468e-53c0-55c9-81f0-7ed254feac63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ddd05-1aae-46fc-95ce-866710d1c5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ddd05-1aae-46fc-95ce-866710d1c5c6.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -18095,7 +18095,7 @@
         },
         {
             "id": "3d30fcdc-6e3d-5535-8bb3-34d175b2fb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb9e14-b299-4064-a41b-0fb6b078942e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb9e14-b299-4064-a41b-0fb6b078942e.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [
@@ -18133,7 +18133,7 @@
         },
         {
             "id": "7ad2c163-6575-5d2d-ac75-aeb04fa45a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1033-ce07-40ef-9315-beb759af9465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1033-ce07-40ef-9315-beb759af9465.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -18170,7 +18170,7 @@
         },
         {
             "id": "7d9ff3f2-78bb-56dc-b1a3-6eac61cede64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcf6efe-9f94-4a55-9994-701e596691ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcf6efe-9f94-4a55-9994-701e596691ad.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -18201,7 +18201,7 @@
         },
         {
             "id": "e7b91ed4-09bc-5999-9f8c-e60a09b645ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb129b0d-1349-4e88-a6a7-b7968b26ee7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb129b0d-1349-4e88-a6a7-b7968b26ee7e.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -18232,7 +18232,7 @@
         },
         {
             "id": "3b93e4cb-767f-55f7-b59f-05f4c78db185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7caaf39-8f16-4f1d-bee6-a45674306319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7caaf39-8f16-4f1d-bee6-a45674306319.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -18264,7 +18264,7 @@
         },
         {
             "id": "17aa22b9-8fe3-518a-89fa-5fd2def16e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fdfb0ba-d086-4e7c-97e0-70d1e8328ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fdfb0ba-d086-4e7c-97e0-70d1e8328ded.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -18295,7 +18295,7 @@
         },
         {
             "id": "af87e130-3b6a-589f-959b-301f7269a7fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e32ba6-108a-421f-9dad-3d03f7ebe239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e32ba6-108a-421f-9dad-3d03f7ebe239.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -18326,7 +18326,7 @@
         },
         {
             "id": "1f1c1d57-2f8f-5e0e-9d59-3f7dfd405b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e542094-8d95-463c-ae6c-8f2cd56434b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e542094-8d95-463c-ae6c-8f2cd56434b2.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -18358,7 +18358,7 @@
         },
         {
             "id": "68325c67-cbb6-5db7-aedd-7248ad6e408e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630c0d1c-9ddb-4e76-a82a-9cdd8a5b487b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630c0d1c-9ddb-4e76-a82a-9cdd8a5b487b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -18389,7 +18389,7 @@
         },
         {
             "id": "74d281e4-6c2a-53c2-b0ea-253ef143d22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ab4943-3943-4b83-8da3-90a1fb0988b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ab4943-3943-4b83-8da3-90a1fb0988b3.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MH3.json
+++ b/Assets/Resources/Sets/MH3.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "02791d8b-58da-5d60-939d-c78899a1db53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72449552-aa2c-4ae3-846f-df523c5e6078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72449552-aa2c-4ae3-846f-df523c5e6078.jpg?1",
             "name": "Breaker of Creation",
             "text": "When you cast this spell, you gain 1 life for each colorless permanent you control.\nHexproof from each color\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "410b91e9-36e3-590c-bfe7-10cc8c74e72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560debcd-feb4-4534-991e-a7aa1cca2409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560debcd-feb4-4534-991e-a7aa1cca2409.jpg?1",
             "name": "Devourer of Destiny",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of your first upkeep, look at the top four cards of your library. You may put one of those cards back on top of your library. Exile the rest.\nWhen you cast this spell, exile target permanent that's one or more colors.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "9aa66138-80e5-556a-9c8e-cebbe0a67692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7faf5812-2067-4386-bb83-150723d67d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7faf5812-2067-4386-bb83-150723d67d02.jpg?1",
             "name": "Drownyard Lurker",
             "text": "Vigilance\nWhen you cast or cycle Drownyard Lurker, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "bb0aab6d-0741-5f9d-bdd8-6a9d12a980f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28b9bee-d726-407b-9e5b-2231384df81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28b9bee-d726-407b-9e5b-2231384df81e.jpg?1",
             "name": "Echoes of Eternity",
             "text": "If a triggered ability of a colorless spell you control or another colorless permanent you control triggers, that ability triggers an additional time.\nWhenever you cast a colorless spell, copy it. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [],
@@ -130,7 +130,7 @@
         },
         {
             "id": "e90f91e6-0aea-5caf-b0d6-f3fd932da900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce97bb8-b0ee-4473-8c26-a3ec91abec97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce97bb8-b0ee-4473-8c26-a3ec91abec97.jpg?1",
             "name": "Eldrazi Ravager",
             "text": "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\nSacrifice two Eldrazi: Return Eldrazi Ravager from your graveyard to your hand.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -160,7 +160,7 @@
         },
         {
             "id": "0ca5ef79-ca0b-5fc6-b108-2dc6f3d970d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b914bfd9-5be3-4459-a68a-9b3ea2747bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b914bfd9-5be3-4459-a68a-9b3ea2747bbc.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -197,7 +197,7 @@
         },
         {
             "id": "9ff09957-8a19-5826-829c-967017a4c7b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c2a3c7-1486-4ff9-88ec-79ec67a437f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c2a3c7-1486-4ff9-88ec-79ec67a437f8.jpg?1",
             "name": "Glaring Fleshraker",
             "text": "Whenever you cast a colorless spell, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nWhenever another colorless creature enters the battlefield under your control, Glaring Fleshraker deals 1 damage to each opponent.",
             "colours": [],
@@ -230,7 +230,7 @@
         },
         {
             "id": "abda2134-de62-534f-b5eb-2b49f95981d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7baf9549-1869-4bd3-a52a-2f0b30ba0b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7baf9549-1869-4bd3-a52a-2f0b30ba0b16.jpg?1",
             "name": "Herigast, Erupting Nullkite",
             "text": "Emerge {6}{R}{R} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, you may exile your hand. If you do, draw three cards.\nFlying\nEach creature spell you cast has emerge. The emerge cost is equal to its mana cost.",
             "colours": [],
@@ -268,7 +268,7 @@
         },
         {
             "id": "d2b86473-616c-50f7-89ec-8f0d0c5bd11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c47679-0fac-466f-be3c-794f23576e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c47679-0fac-466f-be3c-794f23576e55.jpg?1",
             "name": "It That Heralds the End",
             "text": "Colorless spells you cast with mana value 7 or greater cost {1} less to cast.\nOther colorless creatures you control get +1/+1.",
             "colours": [],
@@ -301,7 +301,7 @@
         },
         {
             "id": "9da7f8de-25d5-5caf-8c09-0f534d0fe609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04066abb-44d2-4730-9cc3-2584bc4c7d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04066abb-44d2-4730-9cc3-2584bc4c7d8c.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -337,7 +337,7 @@
         },
         {
             "id": "ad7d9412-4564-5a17-b0ff-c85f89065f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92585587-cfdc-406a-9114-4f6dd8802c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92585587-cfdc-406a-9114-4f6dd8802c37.jpg?1",
             "name": "Kozilek's Command",
             "text": "Choose two \u2014\n\u2022 Target player creates X 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\n\u2022 Target player scries X, then draws a card.\n\u2022 Exile target creature with mana value X or less.\n\u2022 Exile up to X target cards from graveyards.",
             "colours": [],
@@ -368,7 +368,7 @@
         },
         {
             "id": "38728faa-eeb6-55b0-9f6c-f48a6c0fc88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e259868-d29a-4c03-8ec3-49e914f849fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e259868-d29a-4c03-8ec3-49e914f849fb.jpg?1",
             "name": "Null Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target multicolored spell.\n\u2022 Destroy target multicolored permanent.",
             "colours": [],
@@ -398,7 +398,7 @@
         },
         {
             "id": "6f7e51c2-dc49-5aa6-b83c-8d543d15f027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9f1bb8-c91b-40cd-a416-abbff0d65306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9f1bb8-c91b-40cd-a416-abbff0d65306.jpg?1",
             "name": "Nulldrifter",
             "text": "When you cast this spell, draw two cards.\nFlying\nAnnihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [],
@@ -433,7 +433,7 @@
         },
         {
             "id": "fef8ba31-4834-5144-8177-7fd7d16d2a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d7ae4-9c4b-4a5a-a109-7630a07aeb45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d7ae4-9c4b-4a5a-a109-7630a07aeb45.jpg?1",
             "name": "Twisted Riddlekeeper",
             "text": "Emerge {5}{C}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, tap up to two target permanents. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nFlying",
             "colours": [],
@@ -466,7 +466,7 @@
         },
         {
             "id": "8183ba2c-988a-50c5-92c4-98498ffb1730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd00d56a-86bd-41d8-82b6-975404ef8067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd00d56a-86bd-41d8-82b6-975404ef8067.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -502,7 +502,7 @@
         },
         {
             "id": "90e2259b-cd91-5547-853e-b820e2134692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5f3a1a-8514-4598-be3d-c3be719f6951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5f3a1a-8514-4598-be3d-c3be719f6951.jpg?1",
             "name": "Warped Tusker",
             "text": "Reach\nWhen you cast or cycle Warped Tusker, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -536,7 +536,7 @@
         },
         {
             "id": "3bb1c660-988c-561a-9e14-3f388c1c0f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc119b8-429c-4ab6-adba-b65b03810e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc119b8-429c-4ab6-adba-b65b03810e98.jpg?1",
             "name": "Wastescape Battlemage",
             "text": "Kicker {G} and/or {1}{U}\nWhen you cast this spell, if it was kicked with its {G} kicker, exile target artifact or enchantment an opponent controls.\nWhen you cast this spell, if it was kicked with its {1}{U} kicker, return target creature an opponent controls to its owner's hand.",
             "colours": [],
@@ -572,7 +572,7 @@
         },
         {
             "id": "2e429867-a992-5cce-9d5d-44cf934f6d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c134b-a416-467e-a158-def84c92c6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c134b-a416-467e-a158-def84c92c6af.jpg?1",
             "name": "Aerie Auxiliary",
             "text": "Flying\nWhen Aerie Auxiliary enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "8a94d048-e6b1-51c0-8c05-2267f800b3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d918133-d4e2-4674-a3cb-58edef1c6758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d918133-d4e2-4674-a3cb-58edef1c6758.jpg?1",
             "name": "Ajani Fells the Godsire",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile target creature an opponent controls with power 3 or greater.\nII \u2014 Create a 2/1 white Cat Warrior creature token, then put a vigilance counter on a creature you control.\nIII \u2014 Target creature you control gains double strike until end of turn.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "4cc01edd-4bbc-5d96-ab62-ca8907583364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ad225-1249-4e94-898c-ca21b132e62d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ad225-1249-4e94-898c-ca21b132e62d.jpg?1",
             "name": "Argent Dais",
             "text": "Argent Dais enters the battlefield with two oil counters on it.\nWhenever two or more creatures attack, put an oil counter on Argent Dais.\n{2}, {T}, Remove two oil counters from Argent Dais: Exile another target nonland permanent. Its controller draws two cards.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "01af488b-2004-5f7b-92ed-613c42acca47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5cab75-546c-4760-97b7-4591de9e6662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5cab75-546c-4760-97b7-4591de9e6662.jpg?1",
             "name": "Charitable Levy",
             "text": "Noncreature spells cost {1} more to cast.\nWhenever a player casts a noncreature spell, put a collection counter on Charitable Levy. Then if there are three or more collection counters on it, sacrifice it. If you do, draw a card, then you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "a3aeec60-595a-5847-a678-3fe0b7f2b95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ba710-eddb-40ca-b2fe-0e4e778aab9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ba710-eddb-40ca-b2fe-0e4e778aab9c.jpg?1",
             "name": "Dog Umbra",
             "text": "Flash\nEnchant creature\nAs long as another player controls enchanted creature, it can't attack or block. Otherwise, Dog Umbra has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "abf0e10d-e128-58c7-83fd-6bf8526fb880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1dfbfc-90e0-48fa-98f1-39929f823619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1dfbfc-90e0-48fa-98f1-39929f823619.jpg?1",
             "name": "Envoy of the Ancestors",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nModified creatures you control have lifelink. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "ad20260f-e1bd-59c4-a578-eaefb04bcaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65f4ae3-6b21-4827-9851-8a53628e254f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65f4ae3-6b21-4827-9851-8a53628e254f.jpg?1",
             "name": "Essence Reliquary",
             "text": "{T}: Return another target permanent you control and all Auras you control attached to it to their owner's hand. Activate only during your turn.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "843bdfed-0fb0-54d7-9936-7d0ef5319f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68baee-f503-407d-931f-2a550470a55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68baee-f503-407d-931f-2a550470a55f.jpg?1",
             "name": "Expel the Unworthy",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nChoose target creature with mana value 3 or less. If this spell was kicked, instead choose target creature. Exile the chosen creature, then its controller gains life equal to its mana value.",
             "colours": [
@@ -842,7 +842,7 @@
         },
         {
             "id": "6ea65582-7b07-5eb0-a388-0ea914785d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b41b59-0296-443b-8a62-8d5c4641ef66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b41b59-0296-443b-8a62-8d5c4641ef66.jpg?1",
             "name": "Flare of Fortitude",
             "text": "You may sacrifice a nontoken white creature rather than pay this spell's mana cost.\nUntil end of turn, your life total can't change, and permanents you control gain hexproof and indestructible.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "e0279383-d355-573f-a17e-ec621b53effe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f48c8f-b6f9-43b2-91c3-8d6e95d62db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f48c8f-b6f9-43b2-91c3-8d6e95d62db9.jpg?1",
             "name": "Glyph Elemental",
             "text": "Bestow {1}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Glyph Elemental.\nEnchanted creature gets +1/+1 for each +1/+1 counter on Glyph Elemental.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "31f79b60-43a2-5dc1-b1bc-f366b985d61c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8032c909-3170-45ab-a552-a8dc683b0a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8032c909-3170-45ab-a552-a8dc683b0a6e.jpg?1",
             "name": "Guardian of the Forgotten",
             "text": "Vigilance\nWhenever a modified creature you control dies, manifest the top card of your library. (Equipment, Auras you control, and counters are modifications. To manifest a card, put the top card of your library onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "a527d5f5-9f4d-53d2-b494-4c4e52068184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c3cad2-1e25-4abe-878d-9194de6fcc27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c3cad2-1e25-4abe-878d-9194de6fcc27.jpg?1",
             "name": "Guide of Souls",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life and get {E} (an energy counter).\nWhenever you attack, you may pay {E}{E}{E}. When you do, put two +1/+1 counters and a flying counter on target attacking creature. It becomes an Angel in addition to its other types.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "7f4e041e-0278-5b22-9765-6723755533d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a85b6d-fb2b-4359-9dd6-081d8722e580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a85b6d-fb2b-4359-9dd6-081d8722e580.jpg?1",
             "name": "Hexgold Slith",
             "text": "When Hexgold Slith enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Hexgold Slith attacks, you may pay {E}{E}. If you do, it gains first strike until end of turn.\nWhenever Hexgold Slith deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "83ad96e8-e01b-58cf-820e-d2c86a3a74d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdbef00-bc1b-4dd6-aef5-aeb5ce454344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdbef00-bc1b-4dd6-aef5-aeb5ce454344.jpg?1",
             "name": "Indebted Spirit",
             "text": "Bestow {2}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nAfterlife 1 (When this permanent is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying.)\nEnchanted creature gets +1/+1 and has afterlife 1.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "242f794d-c10c-51c9-a67f-caa4772466d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9143fc7c-f4eb-4f06-97b9-f912237a055f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9143fc7c-f4eb-4f06-97b9-f912237a055f.jpg?1",
             "name": "Inspired Inventor",
             "text": "When Inspired Inventor enters the battlefield, choose one \u2014\n\u2022 You get {E}{E}{E} (three energy counters).\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "91031d68-29c0-515f-9633-118c4d10a7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f773a79f-ad0f-45c9-bcf5-44ba5e992729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f773a79f-ad0f-45c9-bcf5-44ba5e992729.jpg?1",
             "name": "Jolted Awake",
             "text": "Choose up to one target artifact or creature card in your graveyard. You get {E}{E} (two energy counters). Then you may pay an amount of {E} equal to that card's mana value. If you do, return it from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "440234d7-451c-5214-bbbf-b7497972156c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b922f71-18e6-4a74-b792-d477d4a1deca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b922f71-18e6-4a74-b792-d477d4a1deca.jpg?1",
             "name": "Mandibular Kite",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1 and has flying.\nEquip {3}{W}",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "664b67e7-c7b3-5753-a3af-b1f708b7b29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e115a-c0dc-4901-9a1f-87754304e378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e115a-c0dc-4901-9a1f-87754304e378.jpg?1",
             "name": "Metastatic Evangel",
             "text": "Whenever another nontoken creature enters the battlefield under your control, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "044b5388-caf5-5088-9f30-0b68d24ad214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37510bb-245c-47bc-bbf3-2b202b67d383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37510bb-245c-47bc-bbf3-2b202b67d383.jpg?1",
             "name": "Muster the Departed",
             "text": "When Muster the Departed enters the battlefield, create a 1/1 white Spirit creature token with flying.\nMorbid \u2014 At the beginning of your end step, if a creature died this turn, populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "6c41fe29-0a3a-5eb8-bcf4-b4668770df5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3a9f8f-b74f-44f1-a8b5-d21a55358a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3a9f8f-b74f-44f1-a8b5-d21a55358a6c.jpg?1",
             "name": "Nyxborn Unicorn",
             "text": "Bestow {3}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nEnchanted creature gets +2/+2 and has mentor.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "e06e4b32-af41-50a1-b6df-70150c43311b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cf6f57-230f-497e-a14e-ad1e8737fd42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cf6f57-230f-497e-a14e-ad1e8737fd42.jpg?1",
             "name": "Ocelot Pride",
             "text": "First strike, lifelink\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your end step, if you gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's blessing, for each token you control that entered the battlefield this turn, create a token that's a copy of it.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "4508bde5-72d3-503b-a6e0-756bc70b21a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aef7c8-58b3-463c-91d3-2d1ff8a815ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aef7c8-58b3-463c-91d3-2d1ff8a815ee.jpg?1",
             "name": "Pearl-Ear, Imperial Advisor",
             "text": "Lifelink\nEnchantment spells you cast have affinity for Auras. (They cost {1} less to cast for each Aura you control.)\nWhenever you cast an Aura spell that targets a modified permanent you control, draw a card. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -1339,7 +1339,7 @@
         },
         {
             "id": "24488650-34e7-576c-8533-4735246dba55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55707746-da6e-46e5-a5ca-7ac843fdc38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55707746-da6e-46e5-a5ca-7ac843fdc38e.jpg?1",
             "name": "Phelia, Exuberant Shepherd",
             "text": "Flash\nWhenever Phelia, Exuberant Shepherd attacks, exile up to one other target nonland permanent. At the beginning of the next end step, return that card to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on Phelia.",
             "colours": [
@@ -1378,7 +1378,7 @@
         },
         {
             "id": "6fe5f480-a737-5d92-b6a1-29b594bf9f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0821e622-88b8-4b82-a696-954da1dde915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0821e622-88b8-4b82-a696-954da1dde915.jpg?1",
             "name": "Proud Pack-Rhino",
             "text": "When Proud Pack-Rhino enters the battlefield, choose one \u2014\n\u2022 Put a shield counter on target permanent. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1412,7 +1412,7 @@
         },
         {
             "id": "b14b9b1c-8060-5db9-8520-8f71219b8a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7df20-1ccf-459b-b81c-ab8763c77ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7df20-1ccf-459b-b81c-ab8763c77ccf.jpg?1",
             "name": "Rosecot Knight",
             "text": "Vigilance\nWhen Rosecot Knight enters the battlefield, look at the top six cards of your library. You may reveal an artifact or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, put a +1/+1 counter on Rosecot Knight.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "56291a1e-dcd9-593b-95e7-67ea58e5288f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10539e3-d4bc-4f71-a00f-8e94bb97509d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10539e3-d4bc-4f71-a00f-8e94bb97509d.jpg?1",
             "name": "Solstice Zealot",
             "text": "When Solstice Zealot enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Tap target creature.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "2bd36d2c-750f-54bc-afe6-248e7e50e423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd16222e-349c-4a2b-a7c8-8eb35a8ab332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd16222e-349c-4a2b-a7c8-8eb35a8ab332.jpg?1",
             "name": "Static Prison",
             "text": "When Static Prison enters the battlefield, exile target nonland permanent an opponent controls until Static Prison leaves the battlefield. You get {E}{E} (two energy counters).\nAt the beginning of your precombat main phase, sacrifice Static Prison unless you pay {E}.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "34583a06-d3ce-5963-a0f5-9626c1a6c7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd28a646-f38f-4cdf-948c-969cd979e5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd28a646-f38f-4cdf-948c-969cd979e5e6.jpg?1",
             "name": "Thraben Charm",
             "text": "Choose one \u2014\n\u2022 Thraben Charm deals damage equal to twice the number of creatures you control to target creature.\n\u2022 Destroy target enchantment.\n\u2022 Exile any number of target players' graveyards.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "ce4e660f-e971-53fe-a1f2-1c323f78f848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5495f34-423e-4012-808c-b267e6fabf2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5495f34-423e-4012-808c-b267e6fabf2c.jpg?1",
             "name": "Voltstorm Angel",
             "text": "Flying\nWhen Voltstorm Angel enters the battlefield, you get {E}{E}{E} (three energy counters).\nAt the beginning of combat on your turn, you may pay {E}{E}. When you do, choose one \u2014\n\u2022 Voltstorm Angel gains vigilance and lifelink until end of turn.\n\u2022 Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "71ced676-d4f3-5da5-98e2-a6be14cb5dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d885c-5b57-457f-a658-fd0b79cf98cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d885c-5b57-457f-a658-fd0b79cf98cc.jpg?1",
             "name": "White Orchid Phantom",
             "text": "Flying, first strike\nWhen White Orchid Phantom enters the battlefield, destroy up to one target nonbasic land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "4eee2d26-8ef5-5d1c-9dc4-3e443d3cbbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23abf47-22fa-4dca-bd42-fafa1c8b592f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23abf47-22fa-4dca-bd42-fafa1c8b592f.jpg?1",
             "name": "Wing It",
             "text": "Target creature gets +2/+2 until end of turn. Put a flying counter on it. Scry 1.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "444ba7ac-40cb-5f4c-b715-55569cb5c7f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef1882e-b422-4f30-8a6c-bd71c2601660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef1882e-b422-4f30-8a6c-bd71c2601660.jpg?1",
             "name": "Wrath of the Skies",
             "text": "You get X {E} (energy counters), then you may pay any amount of {E}. Destroy each artifact, creature, and enchantment with mana value less than or equal to the amount of {E} paid this way.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "4c66fd7a-707d-560f-8923-344339ce8e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f5195-10ab-4b32-a5de-a79341cd536a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f5195-10ab-4b32-a5de-a79341cd536a.jpg?1",
             "name": "Aether Spike",
             "text": "Choose target spell. You get {E}{E} (two energy counters), then you may pay any amount of {E}. Counter that spell unless its controller pays {1} for each {E} paid this way.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "e07f2836-14ee-5a83-8be3-79fde0041210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8aeca5-622a-45be-8168-07e7c00e3092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8aeca5-622a-45be-8168-07e7c00e3092.jpg?1",
             "name": "Amphibian Downpour",
             "text": "Flash\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies. Copies become tokens.)\nEnchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1.",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "0b3a0f36-8e1c-5635-ab35-3e0410367e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3feccebc-c792-420d-b96c-51494b5c41db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3feccebc-c792-420d-b96c-51494b5c41db.jpg?1",
             "name": "Bespoke Battlewagon",
             "text": "{T}: You get {E}{E} (two energy counters).\n{T}, Pay {E}{E}: Tap target creature.\n{T}, Pay {E}{E}{E}: Draw a card.\nPay {E}{E}{E}{E}: Bespoke Battlewagon becomes an artifact creature until end of turn.\nCrew 4",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "85444a87-aa7b-509a-acc9-6af666903b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed48f805-b57c-4d7f-a3c2-d16ae71bce2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed48f805-b57c-4d7f-a3c2-d16ae71bce2d.jpg?1",
             "name": "Brainsurge",
             "text": "Draw four cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "b7273086-1327-5cfc-bfe2-0bac73bd1e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95af55-d1dd-4fe6-adb0-3ad6db20d986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95af55-d1dd-4fe6-adb0-3ad6db20d986.jpg?1",
             "name": "Consign to Memory",
             "text": "Replicate {1} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nCounter target triggered ability or colorless spell.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "c8e344d4-aeb6-5f3e-9328-8b2948ec4a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea5e71-d0a3-4065-918b-9b2af98589ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea5e71-d0a3-4065-918b-9b2af98589ba.jpg?1",
             "name": "Copycrook",
             "text": "You may have Copycrook enter the battlefield as a copy of any creature on the battlefield, except it has \"Whenever this creature attacks, it connives.\" (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "758c23a7-75d9-58a1-aff2-fc0a817bc7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27534c8a-cb71-43bc-b706-80a525396222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27534c8a-cb71-43bc-b706-80a525396222.jpg?1",
             "name": "Corrupted Shapeshifter",
             "text": "Devoid (This card has no color.)\nAs Corrupted Shapeshifter enters the battlefield, it becomes your choice of a 3/3 creature with flying, a 2/5 creature with vigilance, or a 0/12 creature with defender.",
             "colours": [],
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "46f35ab1-553b-57df-bfa5-3de7baf21dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0835c7-58ca-4f16-984a-c590ce6a229a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0835c7-58ca-4f16-984a-c590ce6a229a.jpg?1",
             "name": "Deem Inferior",
             "text": "This spell costs {1} less to cast for each card you've drawn this turn.\nThe owner of target nonland permanent puts it into their library second from the top or on the bottom.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "a209562e-4b50-5534-94dc-87393218fcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37684797-7503-460d-9f74-047b1ab2fac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37684797-7503-460d-9f74-047b1ab2fac3.jpg?1",
             "name": "Depth Defiler",
             "text": "Devoid (This card has no color.)\nKicker {C} (You may pay an additional {C} as you cast this spell.)\nWhen you cast this spell, choose one. If it was kicked, choose both instead.\n\u2022 Return target creature to its owner's hand.\n\u2022 Target player draws two cards, then discards a card.",
             "colours": [],
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "0c127932-ffc2-55e5-b817-0ef7d94a48e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7dc03e-2a61-482a-b7eb-6cdb7f375fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7dc03e-2a61-482a-b7eb-6cdb7f375fd8.jpg?1",
             "name": "Dreamtide Whale",
             "text": "Vanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever a player casts their second spell each turn, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "0423c2bc-6f15-5459-9062-c21a50742a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f92dce7-45d4-4d9e-abfc-e4bfce9562c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f92dce7-45d4-4d9e-abfc-e4bfce9562c9.jpg?1",
             "name": "Electrozoa",
             "text": "Flash\nFlying\nWhen Electrozoa enters the battlefield, you get {E}{E} (two energy counters).\nAt the beginning of your precombat main phase, tap Electrozoa unless you pay {E}.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "e6e89362-eb3d-5897-b4ba-49437fddf728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f818d7-320c-47b9-a083-40007f3d91ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f818d7-320c-47b9-a083-40007f3d91ea.jpg?1",
             "name": "Emrakul's Messenger",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever you draw your second card each turn, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "31768fbb-b480-5ce7-aecf-0f1fa7ea32d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a98efb-9b0a-496b-ac21-8d70527ea544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a98efb-9b0a-496b-ac21-8d70527ea544.jpg?1",
             "name": "Flare of Denial",
             "text": "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "10d150a0-4fbd-5afc-a97a-653a2a67d723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00212714-a410-4cbc-bf1c-f90d7d77378c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00212714-a410-4cbc-bf1c-f90d7d77378c.jpg?1",
             "name": "Harbinger of the Seas",
             "text": "Nonbasic lands are Islands.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "576d2423-d76f-5cfa-968a-89c55b8c89c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26973cad-26d7-4d42-a58a-85c3dce3b9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26973cad-26d7-4d42-a58a-85c3dce3b9fd.jpg?1",
             "name": "Hope-Ender Coatl",
             "text": "Devoid (This card has no color.)\nFlash\nWhen you cast this spell, counter target spell an opponent controls unless they pay {1}.\nFlying",
             "colours": [],
@@ -2198,7 +2198,7 @@
         },
         {
             "id": "d6b52215-6c8f-520c-9d42-014e08cd036c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b44ffe-db9e-4db5-9806-098411c9ece0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b44ffe-db9e-4db5-9806-098411c9ece0.jpg?1",
             "name": "Kozilek's Unsealing",
             "text": "Devoid (This card has no color.)\nWhenever you cast a creature spell with mana value 4, 5, or 6, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\nWhenever you cast a creature spell with mana value 7 or greater, draw three cards.",
             "colours": [],
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "18b918c9-af6d-5138-8ed5-6391a978bbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f2bdfd-1cbc-456e-aba7-4e0b6485cf8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f2bdfd-1cbc-456e-aba7-4e0b6485cf8a.jpg?1",
             "name": "Petrifying Meddler",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, tap up to one target creature and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nReach",
             "colours": [],
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "08cd7471-6e11-54b0-b60e-d5592646e95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84317f9d-5a24-4f74-9c3e-0a8b5c15bb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84317f9d-5a24-4f74-9c3e-0a8b5c15bb5f.jpg?1",
             "name": "Roil Cartographer",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you get {E} (an energy counter).\n{T}, Pay six {E}: Draw three cards.",
             "colours": [
@@ -2297,7 +2297,7 @@
         },
         {
             "id": "28ba6129-362f-5cfb-8ddc-9e5310649eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f481ab3-ca6c-4a5c-aa32-d087464fc4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f481ab3-ca6c-4a5c-aa32-d087464fc4da.jpg?1",
             "name": "Sage of the Unknowable",
             "text": "{T}: Add {C}. Spend this mana only to cast a colorless spell or to activate an ability.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "96aa47a6-9a78-57b5-97b8-f99918b0a348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a587f5-5910-405e-8982-c889dbbc7f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a587f5-5910-405e-8982-c889dbbc7f98.jpg?1",
             "name": "Serum Visionary",
             "text": "When Serum Visionary enters the battlefield, draw a card, then scry 2.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "3336474a-97a4-52d5-8ad4-1378f9f4377c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da72736-574d-4d99-98ba-3a91c374cd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da72736-574d-4d99-98ba-3a91c374cd10.jpg?1",
             "name": "Shadow of the Second Sun",
             "text": "Enchant player\nAt the beginning of enchanted player's postcombat main phase, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "913df8e4-c396-5e27-b3b5-5bc7e869a5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac5ac7-b2f9-4e6f-af41-7e42ac816374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac5ac7-b2f9-4e6f-af41-7e42ac816374.jpg?1",
             "name": "Strix Serenade",
             "text": "Counter target artifact, creature, or planeswalker spell. Its controller creates a 2/2 blue Bird creature token with flying.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "34b4c375-dad5-5b75-9bd1-dcca15020b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee66a06e-a461-46af-a318-550bc35de5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee66a06e-a461-46af-a318-550bc35de5d0.jpg?1",
             "name": "Tamiyo Meets the Story Circle",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Until your next turn, whenever a creature attacks you or a planeswalker you control, it gets -2/-0 until end of turn.\nII \u2014 Discard any number of cards, then investigate twice for each card discarded this way.\nIII \u2014 Shuffle up to three target cards from your graveyard into your library.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "61c5b907-b692-5562-bce1-5d67534fcf1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a3fc3f-f5cd-45f1-a3d5-d90c9dd4f6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a3fc3f-f5cd-45f1-a3d5-d90c9dd4f6c7.jpg?1",
             "name": "Tempest Harvester",
             "text": "When Tempest Harvester enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Draw a card, then discard a card.",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "cc4f98d1-1add-56b4-9e69-752b8ad082b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e68700-c71c-46db-b6a4-beae924cf97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e68700-c71c-46db-b6a4-beae924cf97a.jpg?1",
             "name": "Triton Wavebreaker",
             "text": "Bestow {1}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nAs long as Triton Wavebreaker is a creature, it has prowess. (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nEnchanted creature gets +1/+1 and has prowess.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "3a1de3f6-3b8d-508c-a396-82e5021f30f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b13321-98f1-4e8c-802d-65498e43ec24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b13321-98f1-4e8c-802d-65498e43ec24.jpg?1",
             "name": "Tune the Narrative",
             "text": "Draw a card. You get {E}{E} (two energy counters).",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "0405fbef-3910-5997-8895-d59da67155a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13786a-f967-456b-bbc6-f4312467a827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13786a-f967-456b-bbc6-f4312467a827.jpg?1",
             "name": "Ugin's Binding",
             "text": "Devoid (This card has no color.)\nReturn target nonland permanent you don't control to its owner's hand.\nWhenever you cast a colorless spell with mana value 7 or greater, you may exile Ugin's Binding from your graveyard. When you do, return each nonland permanent you don't control to its owner's hand.",
             "colours": [],
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "710cd074-c5c1-507c-8fd9-8cab17108edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95b8eb1-4dbb-4bb9-aa31-b7a12e3b4618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95b8eb1-4dbb-4bb9-aa31-b7a12e3b4618.jpg?1",
             "name": "Unfathomable Truths",
             "text": "Devoid (This card has no color.)\nDraw three cards and create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "0d2d7b81-2d82-5c26-ab22-59b8982de648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3050ac06-4c16-4155-a97f-f6bc92709ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3050ac06-4c16-4155-a97f-f6bc92709ee4.jpg?1",
             "name": "Utter Insignificance",
             "text": "Flash\nEnchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.\n{2}{C}: Exile enchanted creature.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "5849ba01-735a-59fb-89e6-a12d6c4ef09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6e3232-8bb8-4504-9597-dfdfc6d634bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6e3232-8bb8-4504-9597-dfdfc6d634bd.jpg?1",
             "name": "Volatile Stormdrake",
             "text": "Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters the battlefield, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "44655c66-f06b-5afa-9707-3fd1cbb5ef81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da14d86-0780-4821-a799-96f64b377df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da14d86-0780-4821-a799-96f64b377df4.jpg?1",
             "name": "Accursed Marauder",
             "text": "When Accursed Marauder enters the battlefield, each player sacrifices a nontoken creature.",
             "colours": [
@@ -2747,7 +2747,7 @@
         },
         {
             "id": "a7531dc2-d9fa-5769-86ec-277a392a791a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7995b44-7932-4d28-9a4c-a32ba35c60d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7995b44-7932-4d28-9a4c-a32ba35c60d7.jpg?1",
             "name": "Arcbound Condor",
             "text": "Flying\nModular 3 (This creature enters the battlefield with three +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nWhenever another artifact enters the battlefield under your control, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "351d9157-e823-55ff-8967-3008972d3795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eac71d-54f9-46c2-aa1d-c04c37e61f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eac71d-54f9-46c2-aa1d-c04c37e61f74.jpg?1",
             "name": "Breathe Your Last",
             "text": "Destroy target creature or planeswalker. You gain 1 life for each of its colors.",
             "colours": [
@@ -2814,7 +2814,7 @@
         },
         {
             "id": "ddb45742-fab2-5989-880f-681a2834148b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5dd2c1-b6e0-4914-b5c9-7dd451c29e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5dd2c1-b6e0-4914-b5c9-7dd451c29e22.jpg?1",
             "name": "Chthonian Nightmare",
             "text": "When Chthonian Nightmare enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay X {E}, Sacrifice a creature, Return Chthonian Nightmare to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "f362acdd-02bd-5a0e-9710-9910badda67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9068b3a4-9130-42d8-a26b-52010b7daa8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9068b3a4-9130-42d8-a26b-52010b7daa8b.jpg?1",
             "name": "Consuming Corruption",
             "text": "Consuming Corruption deals X damage to target creature or planeswalker and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "91df80c1-197f-5f5d-92ac-761ce4af622e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f328d6e0-d808-4abe-b6a2-cc557b27c329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f328d6e0-d808-4abe-b6a2-cc557b27c329.jpg?1",
             "name": "Crabomination",
             "text": "Emerge from artifact {5}{B}{B} (You may cast this spell by sacrificing an artifact and paying the emerge cost reduced by that artifact's mana value.)\nWhen Crabomination enters the battlefield, target opponent exiles the top card of their library, a card at random from their graveyard, and a card at random from their hand. You may cast a spell from among cards exiled this way without paying its mana cost.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "589c89e9-d149-5d15-9640-3bf6e9a456c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d701aa-df93-4f0e-b1e3-d081487eb456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d701aa-df93-4f0e-b1e3-d081487eb456.jpg?1",
             "name": "The Creation of Avacyn",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Search your library for a card, exile it face down, then shuffle.\nII \u2014 Turn the exiled card face up. If it's a creature card, you lose life equal to its mana value.\nIII \u2014 You may put the exiled card onto the battlefield if it's a creature card. If you don't put it onto the battlefield, put it into its owner's hand.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "fd41eb3c-8592-5274-bd4a-0494e33c53b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831506ea-017a-40ff-91c1-ff2d70dc0013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831506ea-017a-40ff-91c1-ff2d70dc0013.jpg?1",
             "name": "Dreadmobile",
             "text": "Menace\n{1}, Sacrifice another artifact or creature: Put a +1/+1 counter on Dreadmobile.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "34248229-f58c-553a-adca-9395f9cc6f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961a3a53-344b-44d5-bc8e-f43437e6b558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961a3a53-344b-44d5-bc8e-f43437e6b558.jpg?1",
             "name": "Dreamdrinker Vampire",
             "text": "Lifelink\n{1}{B}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Dreamdrinker Vampire, it gains menace until end of turn.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "a9531fb0-6a9d-5d03-b535-1edceddff956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e68656-3204-4bb5-9f31-8036083fcba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e68656-3204-4bb5-9f31-8036083fcba6.jpg?1",
             "name": "Drossclaw",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, each opponent loses 1 life.\nEquip {2}",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "1905b86c-a20e-534c-870d-f3ac1f6704a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9d9075-2d1e-4848-b661-816d539e05eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9d9075-2d1e-4848-b661-816d539e05eb.jpg?1",
             "name": "Emperor of Bones",
             "text": "At the beginning of combat on your turn, exile up to one target card from a graveyard.\n{1}{B}: Adapt 2.\nWhenever one or more +1/+1 counters are put on Emperor of Bones, put a creature card exiled with Emperor of Bones onto the battlefield under your control with a finality counter on it. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "3abdb988-ee5f-568f-8582-44f86be8ec31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428e255d-bdda-4265-91cf-d02962e818e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428e255d-bdda-4265-91cf-d02962e818e4.jpg?1",
             "name": "Etched Slith",
             "text": "Menace\nWhenever Etched Slith deals combat damage to a player, put a +1/+1 counter on it. When you do, you may remove a counter from another target permanent or opponent.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "265004b8-2140-5555-98fd-c73a6a79f780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abd093b-c1d6-400e-bc26-1aa045fe47b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abd093b-c1d6-400e-bc26-1aa045fe47b8.jpg?1",
             "name": "Etherium Pteramander",
             "text": "Flying\nEtherium Pteramander can block only creatures with flying.\n{6}{B}: Adapt 4. This ability costs {1} less to activate for each other artifact you control. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "3e181565-80ae-51ca-a257-0f85253f9803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00573bd-5bbb-4531-a0bb-a40f62b92b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00573bd-5bbb-4531-a0bb-a40f62b92b88.jpg?1",
             "name": "Eviscerator's Insight",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards.\nFlashback {4}{B} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "d78d59cc-901d-559a-b508-6f8179196a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd368a9-5efe-4755-89be-a05cfa2b71c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd368a9-5efe-4755-89be-a05cfa2b71c0.jpg?1",
             "name": "Fetid Gargantua",
             "text": "{2}{B}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Fetid Gargantua, you may draw two cards. If you do, you lose 2 life.",
             "colours": [
@@ -3231,7 +3231,7 @@
         },
         {
             "id": "01c0a75b-3bf1-51e3-9960-da9e843a3858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19efb9ce-62eb-4cbf-b01e-979f3fd09ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19efb9ce-62eb-4cbf-b01e-979f3fd09ba6.jpg?1",
             "name": "Flare of Malice",
             "text": "You may sacrifice a nontoken black creature rather than pay this spell's mana cost.\nEach opponent sacrifices a creature or planeswalker with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "9d9ac668-fbfc-59f9-8a7f-cf5a832c65e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b054a9-7565-4fdd-b6a5-2786c5bb5b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b054a9-7565-4fdd-b6a5-2786c5bb5b7e.jpg?1",
             "name": "Gravedig",
             "text": "Choose one \u2014\n\u2022 Target player creates a 2/2 black Zombie creature token.\n\u2022 Return target creature card from your graveyard to your hand.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "095261f9-a35e-56de-95bb-2454c0efc90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9c275d-e8cc-40c2-8baf-7a0d154aa7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9c275d-e8cc-40c2-8baf-7a0d154aa7cf.jpg?1",
             "name": "Grim Servant",
             "text": "Menace\nWhen Grim Servant enters the battlefield, search your library for a card with mana value less than or equal to your devotion to black, reveal it, put it into your hand, then shuffle. You lose 3 life. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "69d09b89-cdfb-5fe3-8171-084b61e50d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2958c96-97f8-4961-813c-938b83e20d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2958c96-97f8-4961-813c-938b83e20d07.jpg?1",
             "name": "Kami of Jealous Thirst",
             "text": "Deathtouch\n{4}{B}: Each opponent loses 2 life and you gain 2 life. This ability costs {4}{B} less to activate if you've drawn three or more cards this turn. Activate only once each turn.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "a53b2279-d530-5f25-9587-831fe2246f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f52a0-f6fb-4ad8-8d50-c8209de95ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f52a0-f6fb-4ad8-8d50-c8209de95ab8.jpg?1",
             "name": "Lethal Throwdown",
             "text": "As an additional cost to cast this spell, sacrifice a creature or sacrifice a modified creature. (Equipment, Auras you control, and counters are modifications.)\nDestroy target creature or planeswalker. If the modified creature was sacrificed, draw a card.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "561ab67c-2a60-5ca4-a7a0-2ea8cc976a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16f8670-f038-400a-83e7-a53a7f8c47ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16f8670-f038-400a-83e7-a53a7f8c47ac.jpg?1",
             "name": "Marionette Apprentice",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, each opponent loses 1 life.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "93b18ee7-08bf-585a-80ad-6fe27fa9d438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af5b195-101a-4265-98a7-522a968cf218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af5b195-101a-4265-98a7-522a968cf218.jpg?1",
             "name": "Mindless Conscription",
             "text": "When Mindless Conscription enters the battlefield and whenever you draw your third card each turn, amass Zombies 3. (Put three +1/+1 counters on an Army you control. It's also a Zombie. If you don't control an Army, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "dd2f7f8d-0b6c-5e6a-a50a-dc8b9cdbcbd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc0109c-f939-4424-820e-d6e60cacd794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc0109c-f939-4424-820e-d6e60cacd794.jpg?1",
             "name": "Necrodominance",
             "text": "Skip your draw step.\nAt the beginning of your end step, you may pay any amount of life. If you do, draw that many cards.\nYour maximum hand size is five.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "6beb5ea1-2135-5c15-837e-ee47b92b8c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3945e-5089-4751-b7b3-5961c39d2a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3945e-5089-4751-b7b3-5961c39d2a33.jpg?1",
             "name": "Nethergoyf",
             "text": "Nethergoyf's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nEscape\u2014{2}{B}, Exile any number of other cards from your graveyard with four or more card types among them. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3542,7 +3542,7 @@
         },
         {
             "id": "5b1c1595-0ff7-5122-90cd-13b2c691aef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813020ef-9d98-4f79-a953-85e7e7e5d3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813020ef-9d98-4f79-a953-85e7e7e5d3e1.jpg?1",
             "name": "Quest for the Necropolis",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a quest counter on Quest for the Necropolis.\n{5}{B}, Sacrifice Quest for the Necropolis: Put target creature card from a graveyard onto the battlefield under your control. This ability costs {1} less to activate for each quest counter on Quest for the Necropolis. Activate only as a sorcery.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "3886296c-9119-5a91-8823-03894745ab05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b338e078-629c-4cac-bd1d-e1f0a132728d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b338e078-629c-4cac-bd1d-e1f0a132728d.jpg?1",
             "name": "Refurbished Familiar",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nWhen Refurbished Familiar enters the battlefield, each opponent discards a card. For each opponent who can't, you draw a card.",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "33a10cfc-d13d-5e15-8f6b-932ae2e633d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b83d-710b-4680-855a-02ba1f72abf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b83d-710b-4680-855a-02ba1f72abf0.jpg?1",
             "name": "Retrofitted Transmogrant",
             "text": "{3}{B}: Return Retrofitted Transmogrant from your graveyard to the battlefield tapped with two +1/+1 counters on it.",
             "colours": [
@@ -3645,7 +3645,7 @@
         },
         {
             "id": "dd1407e1-b970-5cc0-bd05-8f823dc0b191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201d1bc-e3fe-4f59-bd48-3683996ac308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201d1bc-e3fe-4f59-bd48-3683996ac308.jpg?1",
             "name": "Ripples of Undeath",
             "text": "At the beginning of your precombat main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "5cb278da-b220-5033-8cda-27ee257315bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e2805f-59fa-4a6d-97bc-266191b2aa8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e2805f-59fa-4a6d-97bc-266191b2aa8d.jpg?1",
             "name": "Scurrilous Sentry",
             "text": "Menace\nWhenever Scurrilous Sentry enters the battlefield or attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "9cf1c168-a91f-57d0-a4b0-d7ee57c0c2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6aba35-bee5-4058-a2df-d73506d225c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6aba35-bee5-4058-a2df-d73506d225c2.jpg?1",
             "name": "Shilgengar, Sire of Famine",
             "text": "Flying\nSacrifice another creature: Create a Blood token. If you sacrificed an Angel this way, create a number of Blood tokens equal to its toughness instead.\n{WB}{WB}{WB}, Sacrifice six Blood tokens: Return each creature card from your graveyard to the battlefield with a finality counter on it. Those creatures are Vampires in addition to their other types.",
             "colours": [
@@ -3756,7 +3756,7 @@
         },
         {
             "id": "786439eb-32e9-5ac9-922d-94f7605fe194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b334e4c6-d316-4141-8889-f95afcc04701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b334e4c6-d316-4141-8889-f95afcc04701.jpg?1",
             "name": "Warren Soultrader",
             "text": "Pay 1 life, Sacrifice another creature: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "2461aba8-093a-56d1-b471-fc233524d8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c2390f-71f1-4e42-83da-d603ca86a8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c2390f-71f1-4e42-83da-d603ca86a8d0.jpg?1",
             "name": "Wither and Bloom",
             "text": "Target creature gets -3/-3 until end of turn.\n{1}{B}, Exile Wither and Bloom from your graveyard: Put a +1/+1 counter on target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "93b21db2-7673-585c-abf8-254616974c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9b30e0-3934-4e4c-bdd9-5b7696b45948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9b30e0-3934-4e4c-bdd9-5b7696b45948.jpg?1",
             "name": "Wurmcoil Larva",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Larva dies, create a 1/2 black Phyrexian Wurm artifact creature token with deathtouch and a 2/1 black Phyrexian Wurm artifact creature token with lifelink.",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "3aeff659-75db-51b6-8364-902094db22ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8732e62-cdee-4d32-82a8-8a71a04be7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8732e62-cdee-4d32-82a8-8a71a04be7a1.jpg?1",
             "name": "Aether Revolt",
             "text": "Revolt \u2014 As long as a permanent you controlled left the battlefield this turn, if a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.\nWhenever you get one or more {E}, Aether Revolt deals that much damage to any target.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "ee0375ba-2584-52f6-9298-ebc4a04da059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac0e78b-0fdd-44f9-8b7b-c4f28a32782e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac0e78b-0fdd-44f9-8b7b-c4f28a32782e.jpg?1",
             "name": "Amped Raptor",
             "text": "First strike\nWhen Amped Raptor enters the battlefield, you get {E}{E} (two energy counters). Then if you cast it from your hand, exile cards from the top of your library until you exile a nonland card. You may cast that card by paying an amount of {E} equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "08af11d6-5493-5b56-9a7b-b5e4ce8d0f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40463be5-89e2-410b-9a4b-770f70d14293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40463be5-89e2-410b-9a4b-770f70d14293.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "f733d252-2706-5ca9-b205-157041808c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a01edd-dbc0-4ed4-b827-9b608290e9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a01edd-dbc0-4ed4-b827-9b608290e9a1.jpg?1",
             "name": "Detective's Phoenix",
             "text": "Bestow\u2014{R}, Collect evidence 6. (To pay this bestow cost, pay {R} and exile cards with total mana value 6 or greater from your graveyard.)\nFlying, haste\nEnchanted creature gets +2/+2 and has flying and haste.\nYou may cast Detective's Phoenix from your graveyard using its bestow ability.",
             "colours": [
@@ -4011,7 +4011,7 @@
         },
         {
             "id": "14ec75b3-3500-5ac1-afb6-c61e7ae25226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67774a1-f5f8-4b7b-871d-88a1b5e57d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67774a1-f5f8-4b7b-871d-88a1b5e57d27.jpg?1",
             "name": "Eldrazi Linebreaker",
             "text": "Devoid (This card has no color.)\nTrample\nAt the beginning of combat on your turn, target creature you control gains haste and gets +X/+0 until end of turn, where X is the number of Eldrazi you control.",
             "colours": [],
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "3de8237d-713a-519b-8946-c78cb2ce5c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfac301-55db-49a7-9a0d-918c907703da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfac301-55db-49a7-9a0d-918c907703da.jpg?1",
             "name": "Fanged Flames",
             "text": "Devoid (This card has no color.)\nFanged Flames deals 4 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [],
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "a0a41612-27ca-5b16-b3db-d1bad8d45b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497a10c6-131b-464e-95e4-e47708a24d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497a10c6-131b-464e-95e4-e47708a24d48.jpg?1",
             "name": "Flare of Duplication",
             "text": "You may sacrifice a nontoken red creature rather than pay this spell's mana cost.\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "322531f6-7b3b-5860-85fe-f72eb0380dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981fdd21-a650-4360-9ea5-550399d1da91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981fdd21-a650-4360-9ea5-550399d1da91.jpg?1",
             "name": "Frogmyr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n//PRT-Prototype_\nMech//\n{3}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "736e5898-943f-52d5-84d7-8f0dd9c5965a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d91b5-7c09-4a9c-9dc8-fdd4c049009c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d91b5-7c09-4a9c-9dc8-fdd4c049009c.jpg?1",
             "name": "Furnace Hellkite",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\n{R}: Furnace Hellkite gets +1/+0 until end of turn.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "0a0ecc26-2faf-5f5b-8121-de983a204c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aa6e33-221f-414c-9b51-850d97a7e051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aa6e33-221f-414c-9b51-850d97a7e051.jpg?1",
             "name": "Galvanic Discharge",
             "text": "Choose target creature or planeswalker. You get {E}{E}{E} (three energy counters), then you may pay any amount of {E}. Galvanic Discharge deals that much damage to that permanent.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "38abcca7-5ee7-5bd6-a49b-9220533a95a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adea3ee-138f-455b-a001-586883c44758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adea3ee-138f-455b-a001-586883c44758.jpg?1",
             "name": "Ghostfire Slice",
             "text": "Devoid (This card has no color.)\nThis spell costs {2} less to cast if an opponent controls a multicolored permanent.\nGhostfire Slice deals 4 damage to any target.",
             "colours": [],
@@ -4241,7 +4241,7 @@
         },
         {
             "id": "05dfa15e-1a10-5c75-8e62-26c55b2333bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133ad0dd-5b61-4c38-9264-0b0e75b95d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133ad0dd-5b61-4c38-9264-0b0e75b95d95.jpg?1",
             "name": "Glimpse the Impossible",
             "text": "Exile the top three cards of your library. You may play those cards this turn. At the beginning of the next end step, if any of those cards remain exiled, put them into your graveyard, then create a 0/1 colorless Eldrazi Spawn creature token for each card put into your graveyard this way. Those tokens have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "0bf9374c-6fa8-577c-84e4-e293478228dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b30243d-511b-47b8-bbed-0395d3de903d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b30243d-511b-47b8-bbed-0395d3de903d.jpg?1",
             "name": "Infernal Captor",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Infernal Captor exploits a creature, gain control of target artifact or creature until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "eae1c717-0afa-59c8-a04f-9f253c8f16eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f918c-bd02-4a63-b4c2-ca204c77b208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f918c-bd02-4a63-b4c2-ca204c77b208.jpg?1",
             "name": "Inventor's Axe",
             "text": "Flash\nWhen Inventor's Axe enters the battlefield, you get {E}{E} (two energy counters).\nWhen Inventor's Axe enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip\u2014\nPay {E}{E}.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "dbc3b11a-79b5-56ff-8786-db3ef3f2a4ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1457aa8-9f70-4586-b595-6a722879f6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1457aa8-9f70-4586-b595-6a722879f6ae.jpg?1",
             "name": "Mogg Mob",
             "text": "Sacrifice Mogg Mob: It deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "4851c79b-ebcd-5291-9181-1e26ee2b98c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5ba065-2806-4e99-a330-168cfe76250f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5ba065-2806-4e99-a330-168cfe76250f.jpg?1",
             "name": "Molten Gatekeeper",
             "text": "Whenever another creature enters the battlefield under your control, Molten Gatekeeper deals 1 damage to each opponent.\nUnearth {R} ({R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "56d32dd5-271c-5d1b-a5a7-02a6667f4f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f8bb8d-c46a-4531-9525-6981a222b468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f8bb8d-c46a-4531-9525-6981a222b468.jpg?1",
             "name": "Party Thrasher",
             "text": "Noncreature spells you cast from exile have convoke. (Each creature you tap while casting a noncreature spell from exile pays for {1} or one mana of that creature's color.)\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "00cb0247-c29c-5781-99ed-ee67097561d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d64e1a8-cb4f-4968-b3e0-c9ca7c7894a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d64e1a8-cb4f-4968-b3e0-c9ca7c7894a3.jpg?1",
             "name": "Phyrexian Ironworks",
             "text": "Whenever you attack, you get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Create a 3/3 colorless Phyrexian Golem artifact creature token. Activate only as a sorcery.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "8c8b5487-38d3-5ecc-8632-abb2d2721052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff7c0bb-1210-4aeb-b5f8-1387eb633b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff7c0bb-1210-4aeb-b5f8-1387eb633b0f.jpg?1",
             "name": "Powerbalance",
             "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, you may cast that card without paying its mana cost if the two spells have the same mana value.",
             "colours": [
@@ -4516,7 +4516,7 @@
         },
         {
             "id": "d8319975-b97a-5661-998f-2b1e118a0114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebadb7dc-69a4-43c9-a2f8-d846b231c71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebadb7dc-69a4-43c9-a2f8-d846b231c71c.jpg?1",
             "name": "Ral and the Implicit Maze",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Ral and the Implicit Maze deals 2 damage to each creature and planeswalker your opponents control.\nII \u2014 You may discard a card. If you do, exile the top two cards of your library. You may play them until the end of your next turn.\nIII \u2014 Create a Spellgorger Weird token. (It's a {2}{R} 2/2 Weird creature with \"Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.\")",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "c81a249e-e167-5820-ae3c-d2a3c9cb0312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1bb8ac-7125-4537-b2da-e23a8c28df79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1bb8ac-7125-4537-b2da-e23a8c28df79.jpg?1",
             "name": "Reckless Pyrosurfer",
             "text": "Haste\nLandfall \u2014 Whenever a land enters the battlefield under your control, Reckless Pyrosurfer gains battle cry until end of turn. (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn. Each instance of battle cry triggers separately.)",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "1c99e4a9-057e-5e5d-aeb1-a42842be8319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f57902-85d1-4c40-b79c-6cffafb4557a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f57902-85d1-4c40-b79c-6cffafb4557a.jpg?1",
             "name": "Reiterating Bolt",
             "text": "Replicate\u2014\nPay {E}{E}{E}. (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nReiterating Bolt deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "b2c4fa52-16e7-5ee0-958f-90dbac672681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099c65d5-9dd3-41d3-9102-3f6cb30c7b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099c65d5-9dd3-41d3-9102-3f6cb30c7b8e.jpg?1",
             "name": "Sarpadian Simulacrum",
             "text": "Haste\n{3}{R}, Sacrifice Sarpadian Simulacrum: It deals 4 damage to target creature.",
             "colours": [
@@ -4652,7 +4652,7 @@
         },
         {
             "id": "e1779632-c645-5376-a734-f43c5612f8a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33e3b25-76f5-4263-a309-9ea97f2d8248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33e3b25-76f5-4263-a309-9ea97f2d8248.jpg?1",
             "name": "Siege Smash",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target creature gets +3/+2 and gains trample until end of turn.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "b8590cac-2714-5dcb-aa4b-6b684d50eb07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a3b943-7b38-4316-87d9-15e0c08abea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a3b943-7b38-4316-87d9-15e0c08abea5.jpg?1",
             "name": "Skittering Precursor",
             "text": "Devoid (This card has no color.)\nMenace\nWhenever you sacrifice a nontoken permanent, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "fa697373-70aa-5eac-9019-ceef8717dec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf34b0f8-a68a-428f-9f2c-9556229367ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf34b0f8-a68a-428f-9f2c-9556229367ec.jpg?1",
             "name": "Skoa, Embermage",
             "text": "When Skoa, Embermage enters the battlefield, it deals 4 damage to any target.\nGrandeur \u2014 Discard another card named Skoa, Embermage, Sacrifice two Mountains: Skoa deals 4 damage to any target.",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "41c24fa2-edcd-5eaf-bbdf-5202b3a4bb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dad40bf-2cd0-47f5-a878-9a289d1d58d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dad40bf-2cd0-47f5-a878-9a289d1d58d0.jpg?1",
             "name": "Smelted Chargebug",
             "text": "Menace\nWhen Smelted Chargebug enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Smelted Chargebug attacks, you may pay {E}. If you do, another target attacking creature gets +1/+0 and gains menace until end of turn.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "4f0f36da-60fc-52e6-9e55-de4b638a1a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecac9885-6f4e-4413-90dc-c8b44f883357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecac9885-6f4e-4413-90dc-c8b44f883357.jpg?1",
             "name": "Spawn-Gang Commander",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, create three 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\n{1}{C}, Sacrifice an Eldrazi: Spawn-Gang Commander deals 2 damage to any target.",
             "colours": [],
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "172c14e1-bc59-572c-aa72-f3a8118d6108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465857f2-df08-4f7b-b4fe-b16831ac0eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465857f2-df08-4f7b-b4fe-b16831ac0eb1.jpg?1",
             "name": "Thriving Skyclaw",
             "text": "Flying\nWhen Thriving Skyclaw enters the battlefield, you get {E}{E}{E} (three energy counters).\nWhenever Thriving Skyclaw attacks, you may pay {E}{E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "b0265b85-7ae6-5a09-babe-27a16d3964db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9949f5-8d6c-4ea9-b203-99e8a57a6c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9949f5-8d6c-4ea9-b203-99e8a57a6c60.jpg?1",
             "name": "Unstable Amulet",
             "text": "When Unstable Amulet enters the battlefield, you get {E}{E} (two energy counters).\nWhenever you cast a spell from anywhere other than your hand, Unstable Amulet deals 1 damage to each opponent.\n{T}, Pay {E}{E}: Exile the top card of your library. You may play it until you exile another card with Unstable Amulet.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "287fdf3e-6d47-5819-bd9f-2135af961b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9b8532-4f1a-4653-9cbb-befba8169e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9b8532-4f1a-4653-9cbb-befba8169e5a.jpg?1",
             "name": "Voidpouncer",
             "text": "Devoid (This card has no color.)\nKicker {2}{C} (You may pay an additional {2}{C} as you cast this spell.)\nIf Voidpouncer was kicked, it enters the battlefield with two +1/+1 counters and a trample counter on it and with haste.",
             "colours": [],
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "33c71b11-67e2-51b1-b4e8-2c429197525d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eb9a82-91f7-4741-a029-a07a3ff6af78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eb9a82-91f7-4741-a029-a07a3ff6af78.jpg?1",
             "name": "Wheel of Potential",
             "text": "You get {E}{E}{E} (three energy counters), then you may pay X {E}.\nEach player may exile their hand and draw X cards. If X is 7 or more, you may play cards you own exiled this way until the end of your next turn.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "eed83a21-137e-56be-9ab2-4544b9060e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feba5d6-99a6-4e9b-8a7d-90d955868fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feba5d6-99a6-4e9b-8a7d-90d955868fc3.jpg?1",
             "name": "Basking Broodscale",
             "text": "Devoid (This card has no color.)\n{1}{G}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Basking Broodscale, you may create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "8d95401a-8b91-5c1b-b5eb-eb7e23fd6c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4820d223-4ea1-4850-931c-3d2ab5eb003b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4820d223-4ea1-4850-931c-3d2ab5eb003b.jpg?1",
             "name": "Birthing Ritual",
             "text": "At the beginning of your end step, if you control a creature, look at the top seven cards of your library. Then you may sacrifice a creature. If you do, you may put a creature card with mana value X or less from among those cards onto the battlefield, where X is 1 plus the sacrificed creature's mana value. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "11feee44-ebca-5f59-afac-b8d5ea926a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f260bd08-68b6-44f4-ace9-e298cb13d82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f260bd08-68b6-44f4-ace9-e298cb13d82e.jpg?1",
             "name": "Collective Resistance",
             "text": "Escalate {G} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Target creature gains hexproof and indestructible until end of turn.",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "18bf5cfc-c0f9-57a9-8592-b3949d4f545f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98164430-64c1-465f-b786-45753c965f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98164430-64c1-465f-b786-45753c965f44.jpg?1",
             "name": "Colossal Dreadmask",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +6/+6 and has trample.\nEquip {3}{G}{G}",
             "colours": [
@@ -5094,7 +5094,7 @@
         },
         {
             "id": "484f3599-cb82-519e-a078-b6569a65d6a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdabdda-bd46-4ea2-8b37-5d7f6cec6aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdabdda-bd46-4ea2-8b37-5d7f6cec6aff.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "d3d31def-d7fc-5c85-b16c-956ccddc650c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f79ba7-7b65-4387-b498-f770816ce8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f79ba7-7b65-4387-b498-f770816ce8dd.jpg?1",
             "name": "Eldrazi Repurposer",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell and when Eldrazi Repurposer dies, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "199bd3be-d81e-567a-ae41-8de1c6d35f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d89283e-9783-4006-9294-4ae0473d2ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d89283e-9783-4006-9294-4ae0473d2ce6.jpg?1",
             "name": "Evolution Witness",
             "text": "{1}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Evolution Witness, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "f326634c-927c-593d-acfc-c8a76fc33d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9fb33a-3b39-4aff-93b8-aedafe0ea694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9fb33a-3b39-4aff-93b8-aedafe0ea694.jpg?1",
             "name": "Fanatic of Rhonas",
             "text": "{T}: Add {G}.\nFerocious \u2014 {T}: Add {G}{G}{G}{G}. Activate only if you control a creature with power 4 or greater.\nEternalize {2}{G}{G} ({2}{G}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Snake Druid with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -5243,7 +5243,7 @@
         },
         {
             "id": "737c15c5-e881-52a6-828e-97cc0edc62c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae8a77b-4001-4da2-b684-d0fab370a162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae8a77b-4001-4da2-b684-d0fab370a162.jpg?1",
             "name": "Fangs of Kalonia",
             "text": "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on each creature that had a +1/+1 counter put on it this way.\nOverload {4}{G}{G} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "3b908dd3-a9ca-53d7-aae4-121760e6c2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda2fa87-81c0-41ac-8831-556ce392c058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda2fa87-81c0-41ac-8831-556ce392c058.jpg?1",
             "name": "Flare of Cultivation",
             "text": "You may sacrifice a nontoken green creature rather than pay this spell's mana cost.\nSearch your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -5310,7 +5310,7 @@
         },
         {
             "id": "5b2e2819-265b-580a-8f4f-453b9e7f5ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b6c7ab-f42f-40d2-9cb6-89291d57e27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b6c7ab-f42f-40d2-9cb6-89291d57e27f.jpg?1",
             "name": "Fowl Strike",
             "text": "Destroy target creature with flying.\nReinforce 2\u2014{2}{G} ({2}{G}, Discard this card: Put two +1/+1 counters on target creature.)",
             "colours": [
@@ -5342,7 +5342,7 @@
         },
         {
             "id": "6f9ee059-17d1-5d10-b1ce-fa984edd7202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fa0b62-d474-4dc7-9631-9d0a9d99e5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fa0b62-d474-4dc7-9631-9d0a9d99e5e2.jpg?1",
             "name": "Gift of the Viper",
             "text": "Put a +1/+1 counter, a reach counter, and a deathtouch counter on target creature. Untap it.",
             "colours": [
@@ -5374,7 +5374,7 @@
         },
         {
             "id": "ecdd8036-5da7-596c-9e0d-7668f6d3fb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa6ed13-7bba-40c0-8e0e-4ffd3cea6241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa6ed13-7bba-40c0-8e0e-4ffd3cea6241.jpg?1",
             "name": "Horrific Assault",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control. If you control an Eldrazi, you gain 3 life.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "1f760ed3-f217-56ef-b776-e90754471071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b44f01b-17e8-4d49-8f38-fd1128114b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b44f01b-17e8-4d49-8f38-fd1128114b2f.jpg?1",
             "name": "The Hunger Tide Rises",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Create a 1/1 black and green Insect creature token.\nIV \u2014 Sacrifice any number of creatures. Search your library and/or graveyard for a creature card with mana value less than or equal to the number of creatures sacrificed this way and put it onto the battlefield. If you search your library this way, shuffle.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "1cac1d46-56be-5690-ab52-a1227e2fc58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d28ae5c-eec3-445a-81d6-42bf9789afce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d28ae5c-eec3-445a-81d6-42bf9789afce.jpg?1",
             "name": "Hydra Trainer",
             "text": "You may exert Hydra Trainer as it attacks. When you do, target creature gets +X/+X until end of turn, where X is the number of counters on permanents you control. (An exerted creature won't untap during your next untap step.)\n{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "9f523b19-c1ef-5858-b948-0fed2a01c3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d58e9b-b1d9-4174-a30d-426d2e0ace07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d58e9b-b1d9-4174-a30d-426d2e0ace07.jpg?1",
             "name": "Lion Umbra",
             "text": "Enchant modified creature (Equipment, Auras its controller controls, and counters are modifications.)\nEnchanted creature gets +3/+3 and has vigilance and reach.\nUmbra armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "20f72f1a-8ca3-5efb-b395-0867e7afbc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a178cfe8-f9fa-4255-88d0-54a0bed079f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a178cfe8-f9fa-4255-88d0-54a0bed079f5.jpg?1",
             "name": "Malevolent Rumble",
             "text": "Reveal the top four cards of your library. You may put a permanent card from among them into your hand. Put the rest into your graveyard. Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "603f6ca3-4d99-5a18-9c3f-73ecbabaeaf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162fcdec-bf3c-43ba-9ada-212f7dec5fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162fcdec-bf3c-43ba-9ada-212f7dec5fbd.jpg?1",
             "name": "Monstrous Vortex",
             "text": "Whenever you cast a creature spell with power 5 or greater, discover X, where X is that spell's mana value. (Exile cards from the top of your library until you exile a nonland card with that mana value or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "4c4f9a34-774a-55c1-8cb3-b172ab524709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9252d-241f-45ea-9d80-663150963b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9252d-241f-45ea-9d80-663150963b59.jpg?1",
             "name": "Nightshade Dryad",
             "text": "Deathtouch\n{T}: Add {C}.\n{T}: Add one mana of any color.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "aa075f9d-1302-59cb-97da-d35f7501114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902a969e-9f22-4e92-93eb-9d4536ca82e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902a969e-9f22-4e92-93eb-9d4536ca82e5.jpg?1",
             "name": "Nyxborn Hydra",
             "text": "Bestow {X}{G}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nReach, trample\nNyxborn Hydra enters the battlefield with X +1/+1 counters on it.\nEnchanted creature gets +1/+1 for each +1/+1 counter on Nyxborn Hydra and has reach and trample.",
             "colours": [
@@ -5646,7 +5646,7 @@
         },
         {
             "id": "5f82e093-44ee-5fc9-9dbe-8a622e6cda9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28493c98-a11c-4bcc-bf55-412c884ffa7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28493c98-a11c-4bcc-bf55-412c884ffa7a.jpg?1",
             "name": "Path of Annihilation",
             "text": "Devoid (This card has no color.)\nWhen Path of Annihilation enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\nEldrazi you control have \"{T}: Add one mana of any color.\"\nWhenever you cast a creature spell with mana value 7 or greater, you gain 4 life.",
             "colours": [],
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "ad6a8fc8-94bf-5da1-9ad6-711642e8df5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eda3db-b47d-4f1e-a93d-e2ea747d935c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eda3db-b47d-4f1e-a93d-e2ea747d935c.jpg?1",
             "name": "Primal Prayers",
             "text": "When Primal Prayers enters the battlefield, you get {E}{E} (two energy counters).\nYou may cast creature spells with mana value 3 or less by paying {E} rather than paying their mana costs. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "ad13706b-0d65-5586-acdd-0575a5fc4549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b2d89-d641-4815-8e6c-5dba0d31419e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b2d89-d641-4815-8e6c-5dba0d31419e.jpg?1",
             "name": "Propagator Drone",
             "text": "Devoid (This card has no color.)\nCreature tokens you control have evolve. (They have \"Whenever a creature enters the battlefield under your control, if it has greater power or toughness than this token, put a +1/+1 counter on this token.\" They see this creature enter.)\n{3}{G}: Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "9f47fd7a-c051-5f02-a730-8d729739263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634e05c9-96da-467a-870d-3af68da53071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634e05c9-96da-467a-870d-3af68da53071.jpg?1",
             "name": "Signature Slam",
             "text": "Put a +1/+1 counter on target creature you control, then each modified creature you control deals damage equal to its power to target creature you don't control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5776,7 +5776,7 @@
         },
         {
             "id": "4cecf2b1-82ae-56a9-99ca-73c4c79477ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9246b68-580f-4f53-883d-7900880e4b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9246b68-580f-4f53-883d-7900880e4b0d.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace. (You may cast permanent cards from your graveyard by discarding a land card in addition to paying their other costs.)",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "fc5bda91-33bd-5d33-b97d-25a4f244c28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfadb17-76ad-4d4d-9fa7-33c4b88b4c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfadb17-76ad-4d4d-9fa7-33c4b88b4c0a.jpg?1",
             "name": "Sowing Mycospawn",
             "text": "Devoid (This card has no color.)\nKicker {1}{C} (You may pay an additional {1}{C} as you cast this spell.)\nWhen you cast this spell, search your library for a land card, put it onto the battlefield, then shuffle.\nWhen you cast this spell, if it was kicked, exile target land.",
             "colours": [],
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "232adf27-a52e-57cc-9006-35215af05a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a3ea87-005e-4985-b2a5-21711d0b71c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a3ea87-005e-4985-b2a5-21711d0b71c0.jpg?1",
             "name": "Springheart Nantuko",
             "text": "Bestow {1}{G}\nEnchanted creature gets +1/+1.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may pay {1}{G} if Springheart Nantuko is attached to a creature you control. If you do, create a token that's a copy of that creature. If you didn't create a token this way, create a 1/1 green Insect creature token.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "ff438f9c-b91e-550c-ad09-5f178b952e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6625df2e-7046-411a-ae86-c46ac0953a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6625df2e-7046-411a-ae86-c46ac0953a0b.jpg?1",
             "name": "Temperamental Oozewagg",
             "text": "{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nModified creatures you control have trample. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "93657372-7c9b-5b40-b6d4-dfb5ef15175a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c249aa6-c65c-4572-8e2e-c3899638ecce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c249aa6-c65c-4572-8e2e-c3899638ecce.jpg?1",
             "name": "Territory Culler",
             "text": "Devoid (This card has no color.)\nReach\nLandfall \u2014 Whenever a land enters the battlefield under your control, look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [],
@@ -5956,7 +5956,7 @@
         },
         {
             "id": "cf20d4e0-05df-5fff-85dd-768d3f92211a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328b02ca-d8eb-401d-9c41-93f8eb909312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328b02ca-d8eb-401d-9c41-93f8eb909312.jpg?1",
             "name": "Thief of Existence",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, exile up to one target noncreature, nonland permanent an opponent controls with mana value 4 or less. If you do, Thief of Existence gains \"When this creature leaves the battlefield, target opponent draws a card.\"",
             "colours": [],
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "0d0ef2d8-f0ea-55b3-9ffc-2fb64a4cf645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812af562-853a-48a3-b428-ad891c54be5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812af562-853a-48a3-b428-ad891c54be5c.jpg?1",
             "name": "Trickster's Elk",
             "text": "Bestow {1}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nEnchanted creature loses all abilities and is a green Elk creature with base power and toughness 3/3.",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "2d63cec1-e3ed-55e7-baf8-6d72e1cd1297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c19f67-834c-4709-9038-7916ac0921eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c19f67-834c-4709-9038-7916ac0921eb.jpg?1",
             "name": "Wumpus Aberration",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, if {C} wasn't spent to cast it, target opponent may put a creature card from their hand onto the battlefield.\nTrample",
             "colours": [],
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "7f62a152-f57e-59ff-934e-1f7d51af4e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7149359-bb3f-413c-b21d-e4cd88618e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7149359-bb3f-413c-b21d-e4cd88618e56.jpg?1",
             "name": "Abstruse Appropriation",
             "text": "Devoid (This card has no color.)\nExile target nonland permanent. You may cast that card for as long as it remains exiled, and you may spend colorless mana as though it were mana of any color to cast that spell.",
             "colours": [],
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "3a2ad1db-5528-5308-820a-766887fa9279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19266b5a-ff78-436c-b0f1-457e80bb647e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19266b5a-ff78-436c-b0f1-457e80bb647e.jpg?1",
             "name": "Arna Kenner\u00fcd, Skycaptain",
             "text": "Flying, lifelink\nWard\u2014\nDiscard a card.\nWhenever a modified creature you control attacks, double the number of each kind of counter on it. Then for each nontoken permanent attached to it, create a token that's a copy of that permanent attached to that creature.",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "a92205db-6497-5911-af3d-b6232a3899bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9ad04d-c4d4-4d06-93bb-a881be733717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9ad04d-c4d4-4d06-93bb-a881be733717.jpg?1",
             "name": "Conduit Goblin",
             "text": "When Conduit Goblin enters the battlefield, you get {E}{E} (two energy counters).\nAt the beginning of combat on your turn, you may pay {E}. If you do, another target creature you control gets +1/+0 and gains haste until end of turn.",
             "colours": [
@@ -6170,7 +6170,7 @@
         },
         {
             "id": "12069abb-426a-5e47-bb1c-2eea7ce6d2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62993aa2-4804-43cc-910a-c51e794f8508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62993aa2-4804-43cc-910a-c51e794f8508.jpg?1",
             "name": "Cranial Ram",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +X/+1, where X is the number of artifacts you control.\nEquip {2}",
             "colours": [
@@ -6206,7 +6206,7 @@
         },
         {
             "id": "572e4801-4d0d-5cab-8183-9fc8b9f05630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09a8de1-98b3-49e0-82f6-d90f1048de44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09a8de1-98b3-49e0-82f6-d90f1048de44.jpg?1",
             "name": "Cursed Wombat",
             "text": "{2}{B}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nPermanents you control have \"Whenever one or more +1/+1 counters are put on this permanent, put an additional +1/+1 counter on it. This ability triggers only once each turn.\"",
             "colours": [
@@ -6243,7 +6243,7 @@
         },
         {
             "id": "e1ca3b0e-9280-5ef7-ac23-2626c9837e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce6839-92d1-497b-9760-6fdc7388614e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce6839-92d1-497b-9760-6fdc7388614e.jpg?1",
             "name": "Cyclops Superconductor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Cyclops Superconductor enters the battlefield, you get {E}{E}{E} (three energy counters).\nWhen Cyclops Superconductor dies, you may pay {E}{E}{E}. When you do, Cyclops Superconductor deals damage equal to its power to any target.",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "53df824f-d506-5a67-8280-e97b93d3f5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663e9e3-1989-4ddb-9508-9cc055d2ebe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663e9e3-1989-4ddb-9508-9cc055d2ebe9.jpg?1",
             "name": "Emissary of Soulfire",
             "text": "When Emissary of Soulfire enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}: Put an exalted counter on target creature you control. Activate only as a sorcery. (Whenever a creature you control attacks alone, it gets +1/+1 until end of turn for each instance of exalted among permanents you control.)",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "c817bb23-307e-5aeb-b463-a8aa10fde884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdb095d-b826-4e3e-8c61-0d408e52d6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdb095d-b826-4e3e-8c61-0d408e52d6b8.jpg?1",
             "name": "Expanding Ooze",
             "text": "{B}{G}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever Expanding Ooze attacks, put a +1/+1 counter on target modified creature you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "4db7e6f9-34b4-5887-8f88-c5d9dcb63e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9afac99-a094-41a8-8323-90dec29691c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9afac99-a094-41a8-8323-90dec29691c4.jpg?1",
             "name": "Faithful Watchdog",
             "text": "Vigilance\nFaithful Watchdog enters the battlefield with three +1/+1 counters on it.",
             "colours": [
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "091dcfd4-feec-5bd8-870a-4e48382b8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbcc962-65c4-496d-8034-75c8d204dba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbcc962-65c4-496d-8034-75c8d204dba3.jpg?1",
             "name": "Genku, Future Shaper",
             "text": "Whenever another nontoken permanent you control leaves the battlefield, choose one that hasn't been chosen this turn. Create a creature token with those characteristics.\n\u2022 2/2 white Fox with vigilance.\n\u2022 1/2 blue Moonfolk with flying.\n\u2022 1/1 black Rat with lifelink.\n{3}{W}{U}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6431,7 +6431,7 @@
         },
         {
             "id": "73a2f007-3c00-57cd-8311-97550fb73d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d42bd9-0307-42ec-a4cd-b39b69b607d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d42bd9-0307-42ec-a4cd-b39b69b607d0.jpg?1",
             "name": "Golden-Tail Trainer",
             "text": "Aura and Equipment spells you cast cost {X} less to cast, where X is Golden-Tail Trainer's power.\nWhenever Golden-Tail Trainer attacks, other modified creatures you control get +X/+X until end of turn, where X is Golden-Tail Trainer's power. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "860928cf-17e9-53c9-8fc1-d71f1ca531f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b69aaf-0aae-4f6e-a27f-0129882dfe1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b69aaf-0aae-4f6e-a27f-0129882dfe1d.jpg?1",
             "name": "Horrid Shadowspinner",
             "text": "Lifelink\nWhenever Horrid Shadowspinner attacks, you may draw cards equal to its power. If you do, discard that many cards.",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "33b46870-f94a-5c52-ae96-4cfad384e5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541209fa-38b6-4d61-a72d-26bfb6ad5ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541209fa-38b6-4d61-a72d-26bfb6ad5ead.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "03015878-fb30-5020-b03f-e87c7c880c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee6a8a-c3a8-43bc-beb9-be30d03ab952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee6a8a-c3a8-43bc-beb9-be30d03ab952.jpg?1",
             "name": "Invert Polarity",
             "text": "Choose target spell, then flip a coin. If you win the flip, gain control of that spell and you may choose new targets for it. If you lose the flip, counter that spell.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "c456fc6e-1ca5-518b-8f17-9eb057ef7891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9537d-c6b9-46ef-834b-87750d79f1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9537d-c6b9-46ef-834b-87750d79f1ae.jpg?1",
             "name": "Izzet Generatorium",
             "text": "If you would get one or more {E} (energy counters), you get that many plus one {E} instead.\n{T}: Draw a card. Activate only if you've paid or lost four or more {E} this turn.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "1ecb8709-4a82-5e08-81fd-d1e358723e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585e4e02-4873-4a65-a9ad-30cf0d5b6f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585e4e02-4873-4a65-a9ad-30cf0d5b6f79.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "041e10fd-833e-5d6e-866f-6a412f1f0c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b67489-5eb0-4406-9bf3-27e50dc632eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b67489-5eb0-4406-9bf3-27e50dc632eb.jpg?1",
             "name": "Nadu, Winged Wisdom",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand. This ability triggers only twice each turn.\"",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "52f7d503-dd20-5f85-8c62-97005958ba6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcf68cf-0dac-4b29-90d5-c18c685182e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcf68cf-0dac-4b29-90d5-c18c685182e6.jpg?1",
             "name": "The Necrobloom",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 0/1 green Plant creature token. If you control seven or more lands with different names, create a 2/2 black Zombie creature token instead.\nLand cards in your graveyard have dredge 2. (You may return a land card from your graveyard to your hand and mill two cards instead of drawing a card.)",
             "colours": [
@@ -6745,7 +6745,7 @@
         },
         {
             "id": "f508210a-1ef0-549c-a9f9-4d71aeaa7a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cf39f2-7382-405d-a14b-7eb8726cd38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cf39f2-7382-405d-a14b-7eb8726cd38a.jpg?1",
             "name": "Obstinate Gargoyle",
             "text": "Obstinate Gargoyle has flying as long as it's modified. (Equipment, Auras you control, and counters are modifications.)\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6782,7 +6782,7 @@
         },
         {
             "id": "bc9614ef-1304-5986-a728-70880d4670e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg?1",
             "name": "Ondu Knotmaster // Throw a Line",
             "text": "Lifelink\nWhenever another modified creature you control dies, put two +1/+1 counters on Ondu Knotmaster.",
             "colours": [
@@ -6819,7 +6819,7 @@
         },
         {
             "id": "5a8e7f91-4790-5004-9ad5-2777874da6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg?1",
             "name": "Ondu Knotmaster // Throw a Line",
             "text": "Distribute two +1/+1 counters among one or two target creatures. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6855,7 +6855,7 @@
         },
         {
             "id": "ac065932-5493-5e8c-a9b9-dd0469692ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419cd0b-2449-4cc5-9ead-b9e45e271700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419cd0b-2449-4cc5-9ead-b9e45e271700.jpg?1",
             "name": "Phlage, Titan of Fire's Fury",
             "text": "When Phlage enters the battlefield, sacrifice it unless it escaped.\nWhenever Phlage enters the battlefield or attacks, it deals 3 damage to any target and you gain 3 life.\nEscape\u2014{R}{R}{W}{W}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "b83057ae-433e-598f-965c-5c970a668f98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc9a10b-c9f9-4129-a671-ced0917ce78b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc9a10b-c9f9-4129-a671-ced0917ce78b.jpg?1",
             "name": "Planar Genesis",
             "text": "Look at the top four cards of your library. You may put a land card from among them onto the battlefield tapped. If you don't, put a card from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6931,7 +6931,7 @@
         },
         {
             "id": "eb4cffdc-c32b-5679-9234-3943762e8cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68924203-c3d9-41ce-8ca8-c6dd491eb3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68924203-c3d9-41ce-8ca8-c6dd491eb3ca.jpg?1",
             "name": "Psychic Frog",
             "text": "Whenever Psychic Frog deals combat damage to a player or planeswalker, draw a card.\nDiscard a card: Put a +1/+1 counter on Psychic Frog.\nExile three cards from your graveyard: Psychic Frog gains flying until end of turn.",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "6bae738d-fba6-5bf9-9f81-12f7e4f51b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5968f641-48b5-4b97-8072-ddd8073cd4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5968f641-48b5-4b97-8072-ddd8073cd4d7.jpg?1",
             "name": "Pyretic Rebirth",
             "text": "Return target artifact or creature card from your graveyard to your hand. Pyretic Rebirth deals damage equal to that card's mana value to up to one target creature or planeswalker.",
             "colours": [
@@ -7004,7 +7004,7 @@
         },
         {
             "id": "0ae63b32-dbcd-5cea-9146-f3f7069e935a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e72a934-12e0-4e56-af67-566c2d5b01c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e72a934-12e0-4e56-af67-566c2d5b01c1.jpg?1",
             "name": "Riddle Gate Gargoyle",
             "text": "Flying\nWhen Riddle Gate Gargoyle enters the battlefield, you get {E}{E}{E} (three energy counters).\nWhenever you attack, you may pay {E}{E}. When you do, target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -7041,7 +7041,7 @@
         },
         {
             "id": "30c90adb-d95e-5daf-a3a4-e464eade96d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ac88b2-a92e-4a12-9ba3-5a4b8cdb58dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ac88b2-a92e-4a12-9ba3-5a4b8cdb58dc.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -7084,7 +7084,7 @@
         },
         {
             "id": "55596b28-3a7e-5f4d-aeee-73186aa23f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ce8e9-64b9-403c-bee0-66a4c47ca6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ce8e9-64b9-403c-bee0-66a4c47ca6d4.jpg?1",
             "name": "Scurry of Gremlins",
             "text": "When Scurry of Gremlins enters the battlefield, create two 1/1 red Gremlin creature tokens. Then you get an amount of {E} (energy counters) equal to the number of creatures you control.\nPay {E}{E}{E}{E}: Creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "ebf28291-11c1-5140-a218-eee767332da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185371c-2dde-48ad-ab27-08be04b3c522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185371c-2dde-48ad-ab27-08be04b3c522.jpg?1",
             "name": "Snapping Voidcraw",
             "text": "Devoid (This card has no color.)\n{T}: Add {C}{C}.\n{3}{C}, {T}: Draw a card.",
             "colours": [],
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "17faa53a-33e9-5015-992b-dd1a048ae83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3aedae-e4bb-48e3-9f8b-bea0430df306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3aedae-e4bb-48e3-9f8b-bea0430df306.jpg?1",
             "name": "Sneaky Snacker",
             "text": "Flying\nWhen you draw your third card in a turn, return Sneaky Snacker from your graveyard to the battlefield tapped.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "654d91ae-f8b5-5f0a-a609-d2d1fec2254b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ea14e-44ac-4f69-bfea-cb6bf1bfbd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ea14e-44ac-4f69-bfea-cb6bf1bfbd74.jpg?1",
             "name": "Titans' Vanguard",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell and whenever Titans' Vanguard attacks, put a +1/+1 counter on each colorless creature you control.\nTrample",
             "colours": [],
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "afe19133-5882-54da-bd94-fc39e2353965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15570c0-4210-4959-8584-987ec85f8283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15570c0-4210-4959-8584-987ec85f8283.jpg?1",
             "name": "Wight of the Reliquary",
             "text": "Vigilance\nWight of the Reliquary gets +1/+1 for each creature card in your graveyard.\n{T}, Sacrifice another creature: Search your library for a land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7267,7 +7267,7 @@
         },
         {
             "id": "614503bf-187d-59b2-9271-1fa4f5e79fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54dbeb1-51f8-40e2-912a-ec25457de5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54dbeb1-51f8-40e2-912a-ec25457de5a2.jpg?1",
             "name": "Writhing Chrysalis",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\nReach\nWhenever you sacrifice another Eldrazi, put a +1/+1 counter on Writhing Chrysalis.",
             "colours": [],
@@ -7301,7 +7301,7 @@
         },
         {
             "id": "1a246652-3682-5efb-bc97-8cf82ca0c3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad8671-4761-4014-a8a3-af45627e6e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad8671-4761-4014-a8a3-af45627e6e79.jpg?1",
             "name": "Disruptor Flute",
             "text": "Flash\nAs Disruptor Flute enters the battlefield, choose a card name.\nSpells with the chosen name cost {3} more to cast.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "04d61069-61b8-5e6e-a03c-b6377030efa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e1ff6d-190a-497f-89c3-35e0979c93b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e1ff6d-190a-497f-89c3-35e0979c93b5.jpg?1",
             "name": "Idol of False Gods",
             "text": "{1}{C}, {T}: Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nWhenever another Eldrazi you control dies, put a +1/+1 counter on Idol of False Gods.\nAs long as Idol of False Gods has eight or more +1/+1 counters on it, it's a 0/0 creature in addition to its other types and it has annihilator 2.",
             "colours": [],
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "6e9099be-3ffd-504c-bcfe-7c7296463e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87315b3-d3a3-4eef-8a20-90587b36f551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87315b3-d3a3-4eef-8a20-90587b36f551.jpg?1",
             "name": "Solar Transformer",
             "text": "Solar Transformer enters the battlefield tapped.\nWhen Solar Transformer enters the battlefield, you get {E}{E}{E} (three energy counters).\n{T}: Add {C}.\n{T}, Pay {E}: Add one mana of any color.",
             "colours": [],
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "8bdef6a5-46f7-5e5d-979f-a95c3f8f0b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f11089-658f-42e6-aeb0-09b512ad2479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f11089-658f-42e6-aeb0-09b512ad2479.jpg?1",
             "name": "Vexing Bauble",
             "text": "Whenever a player casts a spell, if no mana was spent to cast it, counter that spell.\n{1}, {T}, Sacrifice Vexing Bauble: Draw a card.",
             "colours": [],
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "aeb657d8-fc52-519c-baa6-8093f6b363ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76bc2da-8f4b-4153-8a7b-c601b19affaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76bc2da-8f4b-4153-8a7b-c601b19affaf.jpg?1",
             "name": "Winter Moon",
             "text": "Players can't untap more than one nonbasic land during their untap steps.",
             "colours": [],
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "1e4983e2-644a-5deb-9847-1e9fce802950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90f9e6-9251-4203-9599-cc4032a5e6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90f9e6-9251-4203-9599-cc4032a5e6e1.jpg?1",
             "name": "Archway of Innovation",
             "text": "Archway of Innovation enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn has improvise. (Your artifacts can help cast that spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "ec41dbde-c951-5454-8210-e9fcad225741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd148edc-9e43-41aa-bb50-f912115d3e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd148edc-9e43-41aa-bb50-f912115d3e72.jpg?1",
             "name": "Arena of Glory",
             "text": "Arena of Glory enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{R}, {T}, Exert Arena of Glory: Add {R}{R}. If that mana is spent on a creature spell, it gains haste until end of turn. (An exerted permanent won't untap during your next untap step.)",
             "colours": [],
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "c094f759-c561-513c-b307-9ca4e0bb3b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/579743fe-f71e-4cb2-8629-d6b02ed1591d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/579743fe-f71e-4cb2-8629-d6b02ed1591d.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -7546,7 +7546,7 @@
         },
         {
             "id": "c521d694-8b14-53c4-9320-6d94a5740c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b277752b-430a-4f09-8a98-b72f813dd52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b277752b-430a-4f09-8a98-b72f813dd52e.jpg?1",
             "name": "Bountiful Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Bountiful Landscape: Search your library for a basic Forest, Island, or Mountain card, put it onto the battlefield tapped, then shuffle.\nCycling {G}{U}{R} ({G}{U}{R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "cbcb9d30-f6c0-5bbf-acf3-c0fd63d3ebee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2312c49-1627-47ad-8113-78a999a97d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2312c49-1627-47ad-8113-78a999a97d8d.jpg?1",
             "name": "Contaminated Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Contaminated Landscape: Search your library for a basic Plains, Island, or Swamp card, put it onto the battlefield tapped, then shuffle.\nCycling {W}{U}{B} ({W}{U}{B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "9ceed8dd-1373-584b-a654-6d8798b2e37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae6828e-ff19-45db-8b59-61616353491f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae6828e-ff19-45db-8b59-61616353491f.jpg?1",
             "name": "Deceptive Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Deceptive Landscape: Search your library for a basic Plains, Swamp, or Forest card, put it onto the battlefield tapped, then shuffle.\nCycling {W}{B}{G} ({W}{B}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "587bebb1-e19a-56af-8c80-cfe94ee23ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f85e12c-196b-4459-b81f-0c9c854e9f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f85e12c-196b-4459-b81f-0c9c854e9f57.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "2dd99920-7cf9-5c46-8d3c-aa161ac1e844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fb0fa7-0c5c-4a75-9461-c51403c30282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fb0fa7-0c5c-4a75-9461-c51403c30282.jpg?1",
             "name": "Foreboding Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Foreboding Landscape: Search your library for a basic Swamp, Forest, or Island card, put it onto the battlefield tapped, then shuffle.\nCycling {B}{G}{U} ({B}{G}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7706,7 +7706,7 @@
         },
         {
             "id": "f8b3c5f2-5d6e-5ec1-8c64-0956a6ee7775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62907e7b-e531-4f51-9a69-7e60ae525775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62907e7b-e531-4f51-9a69-7e60ae525775.jpg?1",
             "name": "Monumental Henge",
             "text": "Monumental Henge enters the battlefield tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "ef9d4fb9-a6f6-5bbf-b654-b6986c3d1489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bd07e-cf80-4d64-af29-f4cec6632b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bd07e-cf80-4d64-af29-f4cec6632b3e.jpg?1",
             "name": "Perilous Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Perilous Landscape: Search your library for a basic Island, Mountain, or Plains card, put it onto the battlefield tapped, then shuffle.\nCycling {U}{R}{W} ({U}{R}{W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "549699dc-f041-593b-af40-90d76450c283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e288374-2b71-4ace-b1d2-a19fee6cb4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e288374-2b71-4ace-b1d2-a19fee6cb4af.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -7802,7 +7802,7 @@
         },
         {
             "id": "e790b126-ba6d-5ba2-8394-cd515429b01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661fc907-7003-45c6-820c-9616e9a71c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661fc907-7003-45c6-820c-9616e9a71c30.jpg?1",
             "name": "Seething Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Seething Landscape: Search your library for a basic Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle.\nCycling {U}{B}{R} ({U}{B}{R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "75ebcc1a-8fb3-536b-9f9d-c412826a4432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28c7-6e92-439d-a163-91682d4f11dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28c7-6e92-439d-a163-91682d4f11dc.jpg?1",
             "name": "Shattered Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Shattered Landscape: Search your library for a basic Mountain, Plains, or Swamp card, put it onto the battlefield tapped, then shuffle.\nCycling {R}{W}{B} ({R}{W}{B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "7cb34093-8dfb-595a-9fe5-ede07143b696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe070f4-8877-4280-b8fd-869f3ac34ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe070f4-8877-4280-b8fd-869f3ac34ab6.jpg?1",
             "name": "Sheltering Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Sheltering Landscape: Search your library for a basic Mountain, Forest, or Plains card, put it onto the battlefield tapped, then shuffle.\nCycling {R}{G}{W} ({R}{G}{W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "f8279d95-b679-5816-82e1-e3e32f398a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059164e1-894d-4586-9800-e60d6fbd6eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059164e1-894d-4586-9800-e60d6fbd6eb6.jpg?1",
             "name": "Shifting Woodland",
             "text": "Shifting Woodland enters the battlefield tapped unless you control a Forest.\n{T}: Add {G}.\nDelirium \u2014 {2}{G}{G}: Shifting Woodland becomes a copy of target permanent card in your graveyard until end of turn. Activate only if there are four or more card types among cards in your graveyard.",
             "colours": [],
@@ -7930,7 +7930,7 @@
         },
         {
             "id": "d4003a6b-2200-5214-b07f-0deda2011fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87870792-e429-4eba-8193-cdce5c7b6c55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87870792-e429-4eba-8193-cdce5c7b6c55.jpg?1",
             "name": "Snow-Covered Wastes",
             "text": "",
             "colours": [],
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "f7e0779d-e40f-5974-b524-409971f71514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5fbb30-abfc-4e79-8ce5-bbb04a241c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5fbb30-abfc-4e79-8ce5-bbb04a241c9f.jpg?1",
             "name": "Spymaster's Vault",
             "text": "Spymaster's Vault enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{B}, {T}: Target creature you control connives X, where X is the number of creatures that died this turn. (Draw X cards, then discard X cards. Put a +1/+1 counter on that creature for each nonland card discarded this way.)",
             "colours": [],
@@ -7996,7 +7996,7 @@
         },
         {
             "id": "e6de2375-a845-5147-821f-637bee301f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f48b9-a972-4e2c-af95-05ab078e01f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f48b9-a972-4e2c-af95-05ab078e01f2.jpg?1",
             "name": "Tranquil Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Tranquil Landscape: Search your library for a basic Forest, Plains, or Island card, put it onto the battlefield tapped, then shuffle.\nCycling {G}{W}{U} ({G}{W}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "fd23e0b2-37a4-5f79-81b8-057cd09232a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e3e7b3-7ba9-47a2-b46c-a40bffb445e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e3e7b3-7ba9-47a2-b46c-a40bffb445e2.jpg?1",
             "name": "Twisted Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Twisted Landscape: Search your library for a basic Swamp, Mountain, or Forest card, put it onto the battlefield tapped, then shuffle.\nCycling {B}{R}{G} ({B}{R}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8064,7 +8064,7 @@
         },
         {
             "id": "767fd71b-7f44-5e8a-b681-1ef52e137fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020e1348-1a35-4cc8-bad6-9fbddfa79277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020e1348-1a35-4cc8-bad6-9fbddfa79277.jpg?1",
             "name": "Ugin's Labyrinth",
             "text": "Imprint \u2014 When Ugin's Labyrinth enters the battlefield, you may exile a colorless card with mana value 7 or greater from your hand.\n{T}: Add {C}. If a card is exiled with Ugin's Labyrinth, add {C}{C} instead.\n{T}: Return the exiled card to its owner's hand.",
             "colours": [],
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "1c7aa0bd-cffb-51c4-a34e-4f6941bc15e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926916ed-2f22-4ba9-9427-194886ad6c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926916ed-2f22-4ba9-9427-194886ad6c1e.jpg?1",
             "name": "Urza's Cave",
             "text": "{T}: Add {C}.\n{3}, {T}, Sacrifice Urza's Cave: Search your library for a land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "810d9bdc-8ecb-5ae5-8131-5dbda9df6ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1d13f7-fd38-4f0b-a8e0-1eac78668117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1d13f7-fd38-4f0b-a8e0-1eac78668117.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "4b8ed103-5009-54f1-b40d-49b65edc9409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11ea8a-f895-438d-a3b7-f070238e4161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11ea8a-f895-438d-a3b7-f070238e4161.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8189,7 +8189,7 @@
         },
         {
             "id": "9191bfd4-a5f4-543c-9f72-b0ccb3fae2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "918cccd3-05d3-5fab-a130-bf2ff405a1df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -8271,7 +8271,7 @@
         },
         {
             "id": "3a98f320-5bb3-5602-9d25-3cd5d8ef88f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg?1",
             "name": "Razorgrass Ambush // Razorgrass Field",
             "text": "Razorgrass Ambush deals 3 damage to target attacking or blocking creature.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -8303,7 +8303,7 @@
         },
         {
             "id": "2c24bc35-425b-5fa8-9548-eebc4e25c52b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg?1",
             "name": "Razorgrass Ambush // Razorgrass Field",
             "text": "As Razorgrass Field enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.\n\n\nInstant\n{1}{W}",
             "colours": [],
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "a737a715-d53d-57e4-8186-21e3a56a048d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1",
             "name": "Witch Enchanter // Witch-Blessed Meadow",
             "text": "When Witch Enchanter enters the battlefield, destroy target artifact or enchantment an opponent controls.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -8368,7 +8368,7 @@
         },
         {
             "id": "734f8f5c-bd2b-5553-bce7-fcd4525d72dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1",
             "name": "Witch Enchanter // Witch-Blessed Meadow",
             "text": "As Witch-Blessed Meadow enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.\n\n\nHuman\n{3}{W}",
             "colours": [],
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "ec35f2dd-baf4-5bd2-ab08-85d14b251db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg?1",
             "name": "Hydroelectric Specimen // Hydroelectric Laboratory",
             "text": "Flash\nWhen Hydroelectric Specimen enters the battlefield, you may change the target of target instant or sorcery spell with a single target to Hydroelectric Specimen.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "829e4875-8236-5261-812d-07228edbd9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg?1",
             "name": "Hydroelectric Specimen // Hydroelectric Laboratory",
             "text": "As Hydroelectric Laboratory enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.\n\n\nWeird\n{2}{U}",
             "colours": [],
@@ -8462,7 +8462,7 @@
         },
         {
             "id": "4735928e-7ad1-542c-b43c-268ec6eddc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1",
             "name": "Sink into Stupor // Soporific Springs",
             "text": "Return target spell or nonland permanent an opponent controls to its owner's hand.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "22e9a471-886f-5f0c-b474-e4f00363a746",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1",
             "name": "Sink into Stupor // Soporific Springs",
             "text": "As Soporific Springs enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{1}{U}{U}",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "614f1d54-6bc9-5578-a9c3-d4d446b4a9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "36f3308d-943e-544c-a920-258b4a90d311",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -8606,7 +8606,7 @@
         },
         {
             "id": "f34f3fed-44f9-5ae2-9e49-f1d19e5296b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg?1",
             "name": "Boggart Trawler // Boggart Bog",
             "text": "When Boggart Trawler enters the battlefield, exile target player's graveyard.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -8640,7 +8640,7 @@
         },
         {
             "id": "0a761b9f-fa88-5ad3-b90a-fae894f4f07a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg?1",
             "name": "Boggart Trawler // Boggart Bog",
             "text": "As Boggart Bog enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.\n\n\nGoblin\n{2}{B}",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "b045ab78-84a0-568c-b71c-1992e6f57bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1",
             "name": "Fell the Profane // Fell Mire",
             "text": "Destroy target creature or planeswalker.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "36d72a5a-db59-55ce-be93-608e84b07a68",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1",
             "name": "Fell the Profane // Fell Mire",
             "text": "As Fell Mire enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.\n\n\nInstant\n{2}{B}{B}",
             "colours": [],
@@ -8732,7 +8732,7 @@
         },
         {
             "id": "27310488-922d-5d07-9b2a-b4139d26aa63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "ebc1ce75-2aeb-5771-ab19-0213c15f8160",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "c5e406cf-a4da-5d13-9557-7a372366bb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg?1",
             "name": "Pinnacle Monk // Mystic Peak",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Pinnacle Monk enters the battlefield, return target instant or sorcery card from your graveyard to your hand.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "c7642483-b8d2-5d8c-ae06-052493ac7038",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg?1",
             "name": "Pinnacle Monk // Mystic Peak",
             "text": "As Mystic Peak enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.\n\n\nMonk\n{3}{R}{R}",
             "colours": [],
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "c398deca-20aa-5b75-bed8-3739eeb2f63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "fd5c0567-a45a-590c-b2cd-d8ffb8648940",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -8961,7 +8961,7 @@
         },
         {
             "id": "94499941-afe4-533a-a698-3277da40f2b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1",
             "name": "Sundering Eruption // Volcanic Fissure",
             "text": "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle. Creatures without flying can't block this turn.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -8993,7 +8993,7 @@
         },
         {
             "id": "da6decde-3150-5434-9600-b3e3ded5c670",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1",
             "name": "Sundering Eruption // Volcanic Fissure",
             "text": "As Volcanic Fissure enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.\n\n\nSorcery\n{2}{R}",
             "colours": [],
@@ -9023,7 +9023,7 @@
         },
         {
             "id": "39bc978e-fe2d-5132-bead-0bda7020716c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1",
             "name": "Bridgeworks Battle // Tanglespan Bridgeworks",
             "text": "Target creature you control gets +2/+2 until end of turn. It fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -9055,7 +9055,7 @@
         },
         {
             "id": "2a6616d0-99a8-5c50-8213-21dea885c24b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1",
             "name": "Bridgeworks Battle // Tanglespan Bridgeworks",
             "text": "As Tanglespan Bridgeworks enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.\n\n\nSorcery\n{2}{G}",
             "colours": [],
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "d49ece9c-e674-56b4-b436-75d5ee89eb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1",
             "name": "Disciple of Freyalise // Garden of Freyalise",
             "text": "When Disciple of Freyalise enters the battlefield, you may sacrifice another creature. If you do, you gain X life and draw X cards, where X is that creature's power.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "cb2159ac-76b6-5494-a884-1018100b6d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1",
             "name": "Disciple of Freyalise // Garden of Freyalise",
             "text": "As Garden of Freyalise enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElf\n{3}{G}{G}{G}",
             "colours": [],
@@ -9150,7 +9150,7 @@
         },
         {
             "id": "7ff0f7cb-d87a-590b-82e1-a5a56f60084c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -9190,7 +9190,7 @@
         },
         {
             "id": "35154104-4cb6-574c-84ef-bf808124ef9a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -9231,7 +9231,7 @@
         },
         {
             "id": "cddd8253-4b21-573a-9b7b-4a85597c88f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg?1",
             "name": "Bloodsoaked Insight // Sanguine Morass",
             "text": "This spell costs {1} less to cast for each 1 life your opponents have lost this turn.\nTarget opponent exiles the top three cards of their library. Until the end of your next turn, you may play those cards. If you cast a spell this way, mana of any type can be spent to cast it.\n\n\nLand\n{T}: Add {B} or {R}.",
             "colours": [
@@ -9265,7 +9265,7 @@
         },
         {
             "id": "4d9c0824-80a6-54dc-9b8a-c54f052e3874",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg?1",
             "name": "Bloodsoaked Insight // Sanguine Morass",
             "text": "Sanguine Morass enters the battlefield tapped.\n{T}: Add {B} or {R}.\n\n\nSorcery\n{5}{BR}{BR}",
             "colours": [],
@@ -9296,7 +9296,7 @@
         },
         {
             "id": "bb762192-6788-53c7-b5ea-811ae295629c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1",
             "name": "Drowner of Truth // Drowned Jungle",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, if {C} was spent to cast it, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\n\n\nLand\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "e96debeb-7222-5071-8c2e-992e13914fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1",
             "name": "Drowner of Truth // Drowned Jungle",
             "text": "Drowned Jungle enters the battlefield tapped.\n{T}: Add {G} or {U}.\n\n\nEldrazi\n{5}{GW}{GW}",
             "colours": [],
@@ -9360,7 +9360,7 @@
         },
         {
             "id": "5b8e03cd-1735-53cb-ab9f-9748eefafa6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg?1",
             "name": "Glasswing Grace // Age-Graced Chapel",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying and lifelink.\n\n\nLand\n{T}: Add {W} or {B}.",
             "colours": [
@@ -9396,7 +9396,7 @@
         },
         {
             "id": "3cb0c74f-6cf1-540a-b132-77790368249a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg?1",
             "name": "Glasswing Grace // Age-Graced Chapel",
             "text": "Age-Graced Chapel enters the battlefield tapped.\n{T}: Add {W} or {B}.\n\n\nAura\n{3}{WB}{WB}",
             "colours": [],
@@ -9427,7 +9427,7 @@
         },
         {
             "id": "578e7410-549e-5ebb-9048-7a60485c91e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg?1",
             "name": "Legion Leadership // Legion Stronghold",
             "text": "Until end of turn, double target creature's power and it gains first strike.\n\n\nLand\n{T}: Add {R} or {W}.",
             "colours": [
@@ -9461,7 +9461,7 @@
         },
         {
             "id": "5613d3c9-6860-5b89-8ea6-daaef693b522",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg?1",
             "name": "Legion Leadership // Legion Stronghold",
             "text": "Legion Stronghold enters the battlefield tapped.\n{T}: Add {R} or {W}.\n\n\nInstant\n{1}{GU}",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "310d79cf-56f7-5837-a77e-9bae78afbc9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg?1",
             "name": "Revitalizing Repast // Old-Growth Grove",
             "text": "Put a +1/+1 counter on target creature. It gains indestructible until end of turn.\n\n\nLand\n{T}: Add {B} or {G}.",
             "colours": [
@@ -9526,7 +9526,7 @@
         },
         {
             "id": "5fb52d28-4da3-58d4-a246-c7e66069f856",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg?1",
             "name": "Revitalizing Repast // Old-Growth Grove",
             "text": "Old-Growth Grove enters the battlefield tapped.\n{T}: Add {B} or {G}.\n\n\nInstant\n{BG}",
             "colours": [],
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "05070f60-1fb1-5a87-97b7-7c898a7309ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg?1",
             "name": "Rush of Inspiration // Crackling Falls",
             "text": "Draw two cards. Then discard a card at random unless you pay {E}{E} (two energy counters).\n\n\nLand\n{T}: Add {U} or {R}.",
             "colours": [
@@ -9591,7 +9591,7 @@
         },
         {
             "id": "caeefefc-7359-59a7-8b12-e7abfac50c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg?1",
             "name": "Rush of Inspiration // Crackling Falls",
             "text": "Crackling Falls enters the battlefield tapped.\n{T}: Add {U} or {R}.\n\n\nInstant\n{1}{UR}{UR}",
             "colours": [],
@@ -9622,7 +9622,7 @@
         },
         {
             "id": "7ccb4f69-c1dc-57a6-b7d6-24bba2a33f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg?1",
             "name": "Strength of the Harvest // Haven of the Harvest",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each creature and/or enchantment you control.\n\n\nLand\n{T}: Add {G} or {W}.",
             "colours": [
@@ -9658,7 +9658,7 @@
         },
         {
             "id": "7c11eb6c-210b-59a8-b009-1c64638e4cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg?1",
             "name": "Strength of the Harvest // Haven of the Harvest",
             "text": "Haven of the Harvest enters the battlefield tapped.\n{T}: Add {G} or {W}.\n\n\nAura\n{2}{RW}",
             "colours": [],
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "408eea78-22e9-59c0-a714-502075b40436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg?1",
             "name": "Stump Stomp // Burnwillow Clearing",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.\n\n\nLand\n{T}: Add {R} or {G}.",
             "colours": [
@@ -9723,7 +9723,7 @@
         },
         {
             "id": "5aff678d-f25d-54f0-bda0-3896343bfc95",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg?1",
             "name": "Stump Stomp // Burnwillow Clearing",
             "text": "Burnwillow Clearing enters the battlefield tapped.\n{T}: Add {R} or {G}.\n\n\nSorcery\n{1}{RG}",
             "colours": [],
@@ -9754,7 +9754,7 @@
         },
         {
             "id": "4781e96c-6301-5160-abd4-60e11f997e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg?1",
             "name": "Suppression Ray // Orderly Plaza",
             "text": "Tap all creatures target player controls. You may pay X {E}, then choose up to X creatures tapped this way. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)\n\n\nLand\n{T}: Add {W} or {U}.",
             "colours": [
@@ -9788,7 +9788,7 @@
         },
         {
             "id": "e385bca3-0e93-59b3-9621-148992ee4d17",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg?1",
             "name": "Suppression Ray // Orderly Plaza",
             "text": "Orderly Plaza enters the battlefield tapped.\n{T}: Add {W} or {U}.\n\n\nSorcery\n{3}{WU}{WU}",
             "colours": [],
@@ -9819,7 +9819,7 @@
         },
         {
             "id": "2b2da129-2c69-5d23-a4a6-7d1998afb9ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg?1",
             "name": "Waterlogged Teachings // Inundated Archive",
             "text": "Search your library for an instant card or a card with flash, reveal it, put it into your hand, then shuffle.\n\n\nLand\n{T}: Add {U} or {B}.",
             "colours": [
@@ -9853,7 +9853,7 @@
         },
         {
             "id": "bb8edab3-b547-59ee-9ac9-88a234fd1af4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg?1",
             "name": "Waterlogged Teachings // Inundated Archive",
             "text": "Inundated Archive enters the battlefield tapped.\n{T}: Add {U} or {B}.\n\n\nInstant\n{3}{UB}",
             "colours": [],
@@ -9884,7 +9884,7 @@
         },
         {
             "id": "1c6cacb6-be04-51d4-9308-f96dd93e5da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2647b5ac-1cd1-4069-a8df-2cd291a527b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2647b5ac-1cd1-4069-a8df-2cd291a527b4.jpg?1",
             "name": "Angel of the Ruins",
             "text": "Flying\nWhen Angel of the Ruins enters the battlefield, exile up to two target artifacts and/or enchantments.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "6e4ea43a-94b8-52e5-b432-560997c2fe11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21637fbe-d9d3-4d5b-a361-0687385d4738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21637fbe-d9d3-4d5b-a361-0687385d4738.jpg?1",
             "name": "Decree of Justice",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
             "colours": [
@@ -9951,7 +9951,7 @@
         },
         {
             "id": "521f1d4b-d46f-589c-b751-e3986c0444a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed5bc3d-4056-40b0-a47a-2841692614b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed5bc3d-4056-40b0-a47a-2841692614b3.jpg?1",
             "name": "Distinguished Conjurer",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.\n{4}{W}, {T}: Exile another target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "83894c8c-77c0-5974-aada-c02649216e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee241079-1e5a-4224-b9cb-4fd3e0da687c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee241079-1e5a-4224-b9cb-4fd3e0da687c.jpg?1",
             "name": "Orim's Chant",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nTarget player can't cast spells this turn. If this spell was kicked, creatures can't attack this turn.",
             "colours": [
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "42dd85df-9c12-5389-911f-5eacec78d7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c6ba1-1abc-478f-9b7c-97e9e3c92fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c6ba1-1abc-478f-9b7c-97e9e3c92fb0.jpg?1",
             "name": "Recruiter of the Guard",
             "text": "When Recruiter of the Guard enters the battlefield, you may search your library for a creature card with toughness 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "b77387cf-6699-5577-bb61-2bae0fb88f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f055754-58cf-474a-a3a9-59490dbf9dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f055754-58cf-474a-a3a9-59490dbf9dce.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "4257b849-4e55-5b4f-bce6-6a05cdc0a86d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33818e-6f6e-47a9-ae5d-406bdd47b292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33818e-6f6e-47a9-ae5d-406bdd47b292.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "733f028f-8cc0-56d7-9f8d-342015fc7ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8920e7e4-d89e-4ff9-8922-27fdc2f8ed6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8920e7e4-d89e-4ff9-8922-27fdc2f8ed6e.jpg?1",
             "name": "Estrid's Invocation",
             "text": "You may have Estrid's Invocation enter the battlefield as a copy of an enchantment you control, except it has \"At the beginning of your upkeep, you may exile this enchantment. If you do, return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "b2612df4-4767-5ee3-b65d-f6ce68dcb93c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc2852-11c4-40da-b26f-6f236349f608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc2852-11c4-40da-b26f-6f236349f608.jpg?1",
             "name": "Kappa Cannoneer",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nWard {4}\nWhenever Kappa Cannoneer or another artifact enters the battlefield under your control, put a +1/+1 counter on Kappa Cannoneer and it can't be blocked this turn.",
             "colours": [
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "46b6ed83-6920-532d-aca1-c4384c67b00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25576181-a5a4-4baf-a2b4-fbfe13fb9df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25576181-a5a4-4baf-a2b4-fbfe13fb9df6.jpg?1",
             "name": "Reef Worm",
             "text": "When Reef Worm dies, create a 3/3 blue Fish creature token with \"When this creature dies, create a 6/6 blue Whale creature token with \u2018\nWhen this creature dies, create a 9/9 blue Kraken creature token.'\"",
             "colours": [
@@ -10225,7 +10225,7 @@
         },
         {
             "id": "2ac29122-d69f-5f89-a02d-2894cd02d4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1cc39f-898c-4e92-82a0-a17606b60574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1cc39f-898c-4e92-82a0-a17606b60574.jpg?1",
             "name": "Shrieking Drake",
             "text": "Flying\nWhen Shrieking Drake enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -10259,7 +10259,7 @@
         },
         {
             "id": "e1980ca7-9176-5156-84d1-f6c48c7d9117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76878b19-2916-4f3f-bee5-20846bc9e2db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76878b19-2916-4f3f-bee5-20846bc9e2db.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards, put them into your graveyard, then shuffle.",
             "colours": [
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "66ae25d9-4d13-5e8b-bf3b-b35ac184dca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f087b1c-97e0-4379-a94d-beac53685314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f087b1c-97e0-4379-a94d-beac53685314.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "({PB} can be paid with either {B} or 2 life.)\nLifelink\nFor each {B} in a cost, you may pay 2 life rather than pay that mana.\nWhenever you cast a black spell, put a +1/+1 counter on K'rrik, Son of Yawgmoth.",
             "colours": [
@@ -10332,7 +10332,7 @@
         },
         {
             "id": "15ba2572-774e-59a8-ac6b-50df29a391d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9926d7-91b7-4067-b590-a0430bf68d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9926d7-91b7-4067-b590-a0430bf68d16.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "9d65a815-f542-5209-855a-0c3ee0b3d84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a402cff8-be7f-4473-b880-a6a2eedfda86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a402cff8-be7f-4473-b880-a6a2eedfda86.jpg?1",
             "name": "Ophiomancer",
             "text": "At the beginning of each upkeep, if you control no Snakes, create a 1/1 black Snake creature token with deathtouch.",
             "colours": [
@@ -10402,7 +10402,7 @@
         },
         {
             "id": "492ce888-c5fe-5a99-9fac-8915ea7aa5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa02b7d-db31-4924-b75e-eb02f332ca3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa02b7d-db31-4924-b75e-eb02f332ca3a.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -10436,7 +10436,7 @@
         },
         {
             "id": "58c3ebcf-a175-5a9d-834f-2669c8a6528b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83379f7f-3766-43f5-bd5e-e11ef9070ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83379f7f-3766-43f5-bd5e-e11ef9070ddb.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "3693c99f-1206-5a98-b0c7-3d4c2b7cd917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768daa5-41b0-49e1-b71a-63f733b4dc3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768daa5-41b0-49e1-b71a-63f733b4dc3d.jpg?1",
             "name": "Cursed Mirror",
             "text": "{T}: Add {R}.\nAs Cursed Mirror enters the battlefield, you may have it become a copy of any creature on the battlefield until end of turn, except it has haste.",
             "colours": [
@@ -10502,7 +10502,7 @@
         },
         {
             "id": "962b0255-09ae-5989-a56e-ccd838b75238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9e213-992a-45f8-8c4d-3ca0250a2061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9e213-992a-45f8-8c4d-3ca0250a2061.jpg?1",
             "name": "Fledgling Dragon",
             "text": "Flying\nThreshold \u2014 As long as seven or more cards are in your graveyard, Fledgling Dragon gets +3/+3 and has \"{R}: Fledgling Dragon gets +1/+0 until end of turn.\"",
             "colours": [
@@ -10536,7 +10536,7 @@
         },
         {
             "id": "4450031a-e584-5022-a6be-97adebec35b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb2fe4-f0ef-4366-a568-c36b538f0196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb2fe4-f0ef-4366-a568-c36b538f0196.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "332b83d9-1007-5f1f-a702-4c8b8a14bb2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173369d2-dc39-4bfe-a602-b47156570365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173369d2-dc39-4bfe-a602-b47156570365.jpg?1",
             "name": "Meltdown",
             "text": "Destroy each artifact with mana value X or less.",
             "colours": [
@@ -10610,7 +10610,7 @@
         },
         {
             "id": "66689ef5-7f41-5a21-a9de-6776b5b4f0b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb34a09-d911-49ac-ac39-fad7ee1b41ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb34a09-d911-49ac-ac39-fad7ee1b41ef.jpg?1",
             "name": "Meteoric Mace",
             "text": "Equipped creature gets +4/+0 and has trample.\nEquip {4}\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -10644,7 +10644,7 @@
         },
         {
             "id": "d911421a-1b46-55df-a34d-0bad4aeb8b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa9354d-3496-47f4-81c9-aead15efb8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa9354d-3496-47f4-81c9-aead15efb8bb.jpg?1",
             "name": "Annoyed Altisaur",
             "text": "Reach, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -10678,7 +10678,7 @@
         },
         {
             "id": "c356051d-8370-5302-b258-f6b966966110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f1a736-8b12-4f58-a031-bf1733f65c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f1a736-8b12-4f58-a031-bf1733f65c51.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "969ca6ce-eb1b-50de-89ad-61b4f24c02b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb11921b-1b28-483f-a707-4de21a6daa31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb11921b-1b28-483f-a707-4de21a6daa31.jpg?1",
             "name": "Priest of Titania",
             "text": "{T}: Add {G} for each Elf on the battlefield.",
             "colours": [
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "4fd1a161-3b9c-535b-9b33-86e0e01529fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83036e21-21ea-4324-aa07-11757f80c417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83036e21-21ea-4324-aa07-11757f80c417.jpg?1",
             "name": "Sylvan Safekeeper",
             "text": "Sacrifice a land: Target creature you control gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -10782,7 +10782,7 @@
         },
         {
             "id": "9ad885a8-66c5-5027-97b6-04c225fdf99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237f5cc-2b9b-4929-9697-72078bac4c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237f5cc-2b9b-4929-9697-72078bac4c77.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "Return an Elf you control to its owner's hand: Untap target creature. Activate only once each turn.",
             "colours": [
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "6ceb0d71-e802-5513-819e-69a629809d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf3929c-957f-4ea2-a27d-7d53979844af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf3929c-957f-4ea2-a27d-7d53979844af.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -10862,7 +10862,7 @@
         },
         {
             "id": "f8ee5841-00a6-52bf-820d-a4fa29e18fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71c8c39-3fbb-4a42-9cf6-b3224f5a56fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71c8c39-3fbb-4a42-9cf6-b3224f5a56fc.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "1fac7252-fc9f-594f-b5f0-35236cbb181a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddf44fe-9e4e-42a6-a6f8-11ada3ce8a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddf44fe-9e4e-42a6-a6f8-11ada3ce8a94.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "442a8e90-e5ec-5187-8868-04fa899568b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d423365c-a32c-4060-b178-3221e3200387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d423365c-a32c-4060-b178-3221e3200387.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "14948afe-b927-50b3-8009-d6e2ad7226e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5d53cb-bf80-43b0-b839-b11a64ff4c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5d53cb-bf80-43b0-b839-b11a64ff4c1b.jpg?1",
             "name": "Junk Diver",
             "text": "Flying\nWhen Junk Diver dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -10998,7 +10998,7 @@
         },
         {
             "id": "4a726983-7b5f-56c0-a57d-5701e5e6e9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1225264f-b298-4b56-b208-c5da87bd6867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1225264f-b298-4b56-b208-c5da87bd6867.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -11028,7 +11028,7 @@
         },
         {
             "id": "52e5ee35-4b38-5538-9414-0dd23e3ef52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630febf5-58ff-4dab-a5a8-575ebc5435a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630febf5-58ff-4dab-a5a8-575ebc5435a6.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "972648aa-a151-5eb1-98c2-50f5a631d03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77850b2-6478-449e-bdb9-5b92650e3504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77850b2-6478-449e-bdb9-5b92650e3504.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -11088,7 +11088,7 @@
         },
         {
             "id": "293295e9-2eed-5aac-a289-1bbab90e5e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4589226-6072-409b-b598-ebd87f675a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4589226-6072-409b-b598-ebd87f675a6a.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -11116,7 +11116,7 @@
         },
         {
             "id": "35bfa538-a36b-54ce-8fed-5f69583ab426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace686ad-9e3f-41b3-b8eb-d1b6d45eb4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace686ad-9e3f-41b3-b8eb-d1b6d45eb4e1.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone enters the battlefield tapped.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -11144,7 +11144,7 @@
         },
         {
             "id": "b854fc5a-6cfd-55d5-8bfd-4ca0632a5b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c184406c-b22c-4b9b-9d3a-3e7b17efd8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c184406c-b22c-4b9b-9d3a-3e7b17efd8a0.jpg?1",
             "name": "Barbarian Ring",
             "text": "{T}: Add {R}. Barbarian Ring deals 1 damage to you.\nThreshold \u2014 {R}, {T}, Sacrifice Barbarian Ring: It deals 2 damage to any target. Activate only if seven or more cards are in your graveyard.",
             "colours": [],
@@ -11174,7 +11174,7 @@
         },
         {
             "id": "ca100dbd-60c0-517c-bf67-070a5bfa736d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb9c743-8793-48e6-bb3d-0d9b76fd1a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb9c743-8793-48e6-bb3d-0d9b76fd1a62.jpg?1",
             "name": "Cephalid Coliseum",
             "text": "",
             "colours": [],
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "dbd87492-aa7e-590e-a529-4449a7fb0ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd51f8f0-779b-40bb-b65c-5907f816676e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd51f8f0-779b-40bb-b65c-5907f816676e.jpg?1",
             "name": "Deserted Temple",
             "text": "",
             "colours": [],
@@ -11232,7 +11232,7 @@
         },
         {
             "id": "4bdc2dfb-1f04-5057-9396-064434f61833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1d8a22-e730-4344-bba9-7c495500f065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1d8a22-e730-4344-bba9-7c495500f065.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "836961bd-fdae-5f9b-b943-199be94b1d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47f6d2-9f65-47a4-bfc4-15619befe53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47f6d2-9f65-47a4-bfc4-15619befe53d.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "5d4eddee-41cf-5de9-a69a-1649d7c95506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecd4f-4cde-4d8f-a9b7-d7c6098be981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecd4f-4cde-4d8f-a9b7-d7c6098be981.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11335,7 +11335,7 @@
         },
         {
             "id": "05e950d6-90c3-5522-8bc8-4df81f6ef746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1ac28-ee04-4892-97ea-2cfdebbafcad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1ac28-ee04-4892-97ea-2cfdebbafcad.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "e99a9359-e3fb-5f77-8e24-527eef208f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e3909e-e00a-4855-a0be-b1c538f89cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e3909e-e00a-4855-a0be-b1c538f89cb8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11413,7 +11413,7 @@
         },
         {
             "id": "4cecd9e2-c702-5c5c-959d-ed6a2d049d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9744bb5-9ad1-4287-9929-1146377d975b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9744bb5-9ad1-4287-9929-1146377d975b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11452,7 +11452,7 @@
         },
         {
             "id": "810f3de8-149d-5870-8479-570faf86428e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4c78b4-7178-4a60-ba22-086fb18146df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4c78b4-7178-4a60-ba22-086fb18146df.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11491,7 +11491,7 @@
         },
         {
             "id": "1965c503-85a6-5012-adef-42446aca4179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21a874-525e-4d11-bd8e-bc44918bec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21a874-525e-4d11-bd8e-bc44918bec40.jpg?1",
             "name": "Snow-Covered Wastes",
             "text": "",
             "colours": [],
@@ -11525,7 +11525,7 @@
         },
         {
             "id": "6af8cf39-4f25-5269-a0bd-155230f075e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0281fba-d771-4431-931f-920db2f14c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0281fba-d771-4431-931f-920db2f14c47.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "44fcee29-f798-5cc8-b898-abf763ee1e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bd857b-87d0-4a0f-9aac-0b1b661bb3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bd857b-87d0-4a0f-9aac-0b1b661bb3bd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11603,7 +11603,7 @@
         },
         {
             "id": "af5c4112-c59e-5417-a005-d9bdca6f9bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64daf0ac-678b-4683-9351-a6daf9c9f849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64daf0ac-678b-4683-9351-a6daf9c9f849.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11642,7 +11642,7 @@
         },
         {
             "id": "20aee50c-8e86-57c0-a0a4-85ca21b5a61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54250-74a9-4f77-bf60-bf13585c1a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54250-74a9-4f77-bf60-bf13585c1a1b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11681,7 +11681,7 @@
         },
         {
             "id": "e6f5c0c1-64ca-5f4a-8a14-b5b820b34dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e672fc-673b-4476-b9cc-a395dc60b471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e672fc-673b-4476-b9cc-a395dc60b471.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11720,7 +11720,7 @@
         },
         {
             "id": "8a6f72b0-9feb-5cb0-82d8-2a4cf15d4bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537fb023-4352-406f-8435-51b37b99a6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537fb023-4352-406f-8435-51b37b99a6be.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11759,7 +11759,7 @@
         },
         {
             "id": "a8ebc342-480f-532a-8e34-0864e7067416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e36d5-3f1d-4423-a8db-f4c38898fa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e36d5-3f1d-4423-a8db-f4c38898fa30.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11798,7 +11798,7 @@
         },
         {
             "id": "661d2683-7a76-554c-9542-6e3cabd8d8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0928b-0469-4e3a-a8c8-1df26abb6707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0928b-0469-4e3a-a8c8-1df26abb6707.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11837,7 +11837,7 @@
         },
         {
             "id": "8b911a1f-44f0-5054-b249-a0aef91cf933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac34881-de32-42c7-af60-f992638e1da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac34881-de32-42c7-af60-f992638e1da2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "f9752529-9629-5dc9-bb00-bb5b37a2ae98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6527c8ce-4a63-45f2-ae8e-c651e8713716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6527c8ce-4a63-45f2-ae8e-c651e8713716.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11915,7 +11915,7 @@
         },
         {
             "id": "4c28aba1-ba5f-505c-a913-d99bc9421268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae70f03f-cf60-418b-98e3-bc868e739656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae70f03f-cf60-418b-98e3-bc868e739656.jpg?1",
             "name": "Echoes of Eternity",
             "text": "If a triggered ability of a colorless spell you control or another colorless permanent you control triggers, that ability triggers an additional time.\nWhenever you cast a colorless spell, copy it. You may choose new targets for the copy.",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "5b6d2ae2-13ac-5718-b896-6d0475e54d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9500a456-1d7a-4463-975c-da0ad5af6baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9500a456-1d7a-4463-975c-da0ad5af6baa.jpg?1",
             "name": "Flare of Fortitude",
             "text": "You may sacrifice a nontoken white creature rather than pay this spell's mana cost.\nUntil end of turn, your life total can't change, and permanents you control gain hexproof and indestructible.",
             "colours": [
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "854ea9b2-cdb1-52a5-8100-51b6450f43c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b8a75-9e31-4a44-95b8-c83b9a49646f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b8a75-9e31-4a44-95b8-c83b9a49646f.jpg?1",
             "name": "Ocelot Pride",
             "text": "First strike, lifelink\nAscend\nAt the beginning of your end step, if you gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's blessing, for each token you control that entered the battlefield this turn, create a token that's a copy of it.",
             "colours": [
@@ -12020,7 +12020,7 @@
         },
         {
             "id": "8ccdce5a-2ec9-527c-bb57-2dce839edba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2706178a-8a9a-4e40-b716-6aef4185ca39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2706178a-8a9a-4e40-b716-6aef4185ca39.jpg?1",
             "name": "Orim's Chant",
             "text": "Kicker {W}\nTarget player can't cast spells this turn. If this spell was kicked, creatures can't attack this turn.",
             "colours": [
@@ -12054,7 +12054,7 @@
         },
         {
             "id": "2d939f00-ea40-5c54-aaa9-a170bf8db1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8e1c7-031f-47cd-b854-ea2b746bd6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8e1c7-031f-47cd-b854-ea2b746bd6c3.jpg?1",
             "name": "White Orchid Phantom",
             "text": "Flying, first strike\nWhen White Orchid Phantom enters the battlefield, destroy up to one target nonbasic land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -12092,7 +12092,7 @@
         },
         {
             "id": "e11e5eac-89d4-5238-839f-bc3669f7ee31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e3a66-d59e-43f8-9ce1-054680f5d46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e3a66-d59e-43f8-9ce1-054680f5d46b.jpg?1",
             "name": "Wrath of the Skies",
             "text": "You get X {E}, then you may pay any amount of {E}. Destroy each artifact, creature, and enchantment with mana value less than or equal to the amount of {E} paid this way.",
             "colours": [
@@ -12127,7 +12127,7 @@
         },
         {
             "id": "6af881bf-d05d-5fff-a6fa-9a073912aa7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746533fe-7fe2-4985-8655-9aca4b08b419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746533fe-7fe2-4985-8655-9aca4b08b419.jpg?1",
             "name": "Flare of Denial",
             "text": "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -12162,7 +12162,7 @@
         },
         {
             "id": "8b511304-bee6-54f6-b72f-c7e0c3f0fc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eccf31d-869d-4003-a92b-71b4f4b479ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eccf31d-869d-4003-a92b-71b4f4b479ee.jpg?1",
             "name": "Strix Serenade",
             "text": "Counter target artifact, creature, or planeswalker spell. Its controller creates a 2/2 blue Bird creature token with flying.",
             "colours": [
@@ -12196,7 +12196,7 @@
         },
         {
             "id": "55bb0bea-e978-5f94-bac8-a3e862bd0f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80423f5-98b1-47be-bcc1-bd88848c2fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80423f5-98b1-47be-bcc1-bd88848c2fc7.jpg?1",
             "name": "Ugin's Binding",
             "text": "Devoid\nReturn target nonland permanent you don't control to its owner's hand.\nWhenever you cast a colorless spell with mana value 7 or greater, you may exile Ugin's Binding from your graveyard. When you do, return each nonland permanent you don't control to its owner's hand.",
             "colours": [],
@@ -12228,7 +12228,7 @@
         },
         {
             "id": "e31198cf-eea9-53f3-816e-4a7083e1c2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb819762-02e8-4d32-8245-c44b809c34bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb819762-02e8-4d32-8245-c44b809c34bb.jpg?1",
             "name": "Volatile Stormdrake",
             "text": "Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters the battlefield, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
             "colours": [
@@ -12265,7 +12265,7 @@
         },
         {
             "id": "005a3653-7584-5f6d-a1a5-c5a1c847fb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb26867-8b4d-4535-98d4-829d702197a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb26867-8b4d-4535-98d4-829d702197a4.jpg?1",
             "name": "Chthonian Nightmare",
             "text": "When Chthonian Nightmare enters the battlefield, you get {E}{E}{E}.\nPay X {E}, Sacrifice a creature, Return Chthonian Nightmare to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -12300,7 +12300,7 @@
         },
         {
             "id": "5739f3f7-97c8-5dbb-aa9e-3f16ad5722b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1822be1-9316-40c7-871d-25b0a5dea755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1822be1-9316-40c7-871d-25b0a5dea755.jpg?1",
             "name": "Flare of Malice",
             "text": "You may sacrifice a nontoken black creature rather than pay this spell's mana cost.\nEach opponent sacrifices a creature or planeswalker with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "57aebde0-6b38-52f0-a898-152ff7bc9011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18591d-a8e2-49ea-b31e-7358e4143024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18591d-a8e2-49ea-b31e-7358e4143024.jpg?1",
             "name": "Warren Soultrader",
             "text": "Pay 1 life, Sacrifice another creature: Create a Treasure token.",
             "colours": [
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "1e1e3ea0-d813-52c3-ad62-7d56a1d7aab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348dd804-315c-479a-9605-3ab9ae60aac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348dd804-315c-479a-9605-3ab9ae60aac2.jpg?1",
             "name": "Flare of Duplication",
             "text": "You may sacrifice a nontoken red creature rather than pay this spell's mana cost.\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -12409,7 +12409,7 @@
         },
         {
             "id": "318a3d96-9d64-5dbf-8aa3-7d6c2014aff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb8272-e60f-4aa1-8f98-6110715a78fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb8272-e60f-4aa1-8f98-6110715a78fa.jpg?1",
             "name": "Party Thrasher",
             "text": "Noncreature spells you cast from exile have convoke.\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -12447,7 +12447,7 @@
         },
         {
             "id": "de5a9750-6736-5548-a213-2689fc432a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a64a5c4-ebae-472b-8f90-dcdd8ab8bc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a64a5c4-ebae-472b-8f90-dcdd8ab8bc26.jpg?1",
             "name": "Powerbalance",
             "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, you may cast that card without paying its mana cost if the two spells have the same mana value.",
             "colours": [
@@ -12482,7 +12482,7 @@
         },
         {
             "id": "d0742b02-9035-5f5f-bf25-e3e19fedc497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a00e86-39c0-4c8b-8285-ab527f2a0c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a00e86-39c0-4c8b-8285-ab527f2a0c57.jpg?1",
             "name": "Wheel of Potential",
             "text": "You get {E}{E}{E}, then you may pay X {E}.\nEach player may exile their hand and draw X cards. If X is 7 or more, you may play cards you own exiled this way until the end of your next turn.",
             "colours": [
@@ -12517,7 +12517,7 @@
         },
         {
             "id": "ddd67ecb-36f0-5e1f-91bf-06d7413cad09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004bbc84-b57b-4393-889e-dff95e8f334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004bbc84-b57b-4393-889e-dff95e8f334c.jpg?1",
             "name": "Birthing Ritual",
             "text": "At the beginning of your end step, if you control a creature, look at the top seven cards of your library. Then you may sacrifice a creature. If you do, you may put a creature card with mana value X or less from among those cards onto the battlefield, where X is 1 plus the sacrificed creature's mana value. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12551,7 +12551,7 @@
         },
         {
             "id": "b71d3efd-efe2-519c-b4b2-9c2d0bbc2bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719cbb26-54a9-402f-9043-e177552fd1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719cbb26-54a9-402f-9043-e177552fd1c0.jpg?1",
             "name": "Flare of Cultivation",
             "text": "You may sacrifice a nontoken green creature rather than pay this spell's mana cost.\nSearch your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "5e078ee2-b98a-556a-af18-1d762de54b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f718cfb2-a30b-424c-8e95-0e3daa03d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f718cfb2-a30b-424c-8e95-0e3daa03d6b7.jpg?1",
             "name": "Primal Prayers",
             "text": "When Primal Prayers enters the battlefield, you get {E}{E}.\nYou may cast creature spells with mana value 3 or less by paying {E} rather than paying their mana costs. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -12621,7 +12621,7 @@
         },
         {
             "id": "c8d4681b-aed8-50c9-801e-1e2894bc4bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511bfe7-b107-4ec5-b363-f718c19d9579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511bfe7-b107-4ec5-b363-f718c19d9579.jpg?1",
             "name": "Sowing Mycospawn",
             "text": "Devoid\nKicker {1}{C}\nWhen you cast this spell, search your library for a land card, put it onto the battlefield, then shuffle.\nWhen you cast this spell, if it was kicked, exile target land.",
             "colours": [],
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "d622dfb1-5d67-521e-9640-42f76e92bd0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf723c91-e3ae-4a71-93b2-65d05bfa9b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf723c91-e3ae-4a71-93b2-65d05bfa9b60.jpg?1",
             "name": "Springheart Nantuko",
             "text": "Bestow {1}{G}\nEnchanted creature gets +1/+1.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may pay {1}{G} if Springheart Nantuko is attached to a creature you control. If you do, create a token that's a copy of that creature. If you didn't create a token this way, create a 1/1 green Insect creature token.",
             "colours": [
@@ -12694,7 +12694,7 @@
         },
         {
             "id": "fafd8310-5b76-55fd-ae37-0650c27c5d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771d4911-3dc8-4dc7-b2c9-e2158ee394bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771d4911-3dc8-4dc7-b2c9-e2158ee394bf.jpg?1",
             "name": "Abstruse Appropriation",
             "text": "Devoid\nExile target nonland permanent. You may cast that card for as long as it remains exiled, and you may spend colorless mana as though it were mana of any color to cast that spell.",
             "colours": [],
@@ -12727,7 +12727,7 @@
         },
         {
             "id": "662bffaa-0bbc-56bf-a700-3929ebcbc54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef099f25-2b0b-4028-8490-fbc859e35f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef099f25-2b0b-4028-8490-fbc859e35f6c.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -12772,7 +12772,7 @@
         },
         {
             "id": "af898970-7ac2-5550-85d9-9f951cc459cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d2cae8-9eb3-4bb2-878b-1a9032445e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d2cae8-9eb3-4bb2-878b-1a9032445e4f.jpg?1",
             "name": "Psychic Frog",
             "text": "Whenever Psychic Frog deals combat damage to a player or planeswalker, draw a card.\nDiscard a card: Put a +1/+1 counter on Psychic Frog.\nExile three cards from your graveyard: Psychic Frog gains flying until end of turn.",
             "colours": [
@@ -12811,7 +12811,7 @@
         },
         {
             "id": "a862116c-4ca7-5b5c-912f-713bcf038bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d58d50-875c-498e-bdde-ffda391ce839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d58d50-875c-498e-bdde-ffda391ce839.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12841,7 +12841,7 @@
         },
         {
             "id": "84409f95-8786-54e3-ad66-181382c0ce40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b25772-8512-4270-851b-289cd182d819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b25772-8512-4270-851b-289cd182d819.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "9bbe43eb-84a7-5ceb-9d28-db4921d544fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bce47b-ba52-4a6c-a0ed-f533489a077c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bce47b-ba52-4a6c-a0ed-f533489a077c.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12901,7 +12901,7 @@
         },
         {
             "id": "4e09bba5-c256-5eef-ba70-65e050491ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3935034b-611f-4ce7-9bba-14c3b31eb597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3935034b-611f-4ce7-9bba-14c3b31eb597.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12931,7 +12931,7 @@
         },
         {
             "id": "4b6a0726-09a4-524f-82e8-fb07a865d216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec271e4-1813-4ee7-bfd5-5a0c39d2d25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec271e4-1813-4ee7-bfd5-5a0c39d2d25d.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12961,7 +12961,7 @@
         },
         {
             "id": "48d4f921-42af-5f7e-bd21-e1bf4d6ddeaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472905ac-1eb9-4951-8180-b8c35fbab3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472905ac-1eb9-4951-8180-b8c35fbab3d7.jpg?1",
             "name": "Archway of Innovation",
             "text": "Archway of Innovation enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn has improvise.",
             "colours": [],
@@ -12993,7 +12993,7 @@
         },
         {
             "id": "25f09039-7008-58cf-bb2e-d05daed7e8a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7d07bb-b875-4a6d-8b87-4187e823af75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7d07bb-b875-4a6d-8b87-4187e823af75.jpg?1",
             "name": "Arena of Glory",
             "text": "Arena of Glory enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{R}, {T}, Exert Arena of Glory: Add {R}{R}. If that mana is spent on a creature spell, it gains haste until end of turn.",
             "colours": [],
@@ -13025,7 +13025,7 @@
         },
         {
             "id": "8e889e5b-60f3-55e1-805c-40407bae7cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f941fee-aea1-4afb-ada4-7bbab39c2f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f941fee-aea1-4afb-ada4-7bbab39c2f6c.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13057,7 +13057,7 @@
         },
         {
             "id": "901b3776-c39b-5d7e-be54-59c93bc3c7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996ab8e-5fa4-4d39-8c7b-12e4258bf8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996ab8e-5fa4-4d39-8c7b-12e4258bf8a9.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13089,7 +13089,7 @@
         },
         {
             "id": "2f9cfbee-a919-5b2c-b6c5-e55946ce281b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ae1a74-cbff-4d36-bfee-d1b6494114b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ae1a74-cbff-4d36-bfee-d1b6494114b4.jpg?1",
             "name": "Monumental Henge",
             "text": "Monumental Henge enters the battlefield tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -13121,7 +13121,7 @@
         },
         {
             "id": "01d3d6d0-8b5a-5900-9c25-2a4269bd5c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f22229-95d4-4a84-a581-e23816db2494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f22229-95d4-4a84-a581-e23816db2494.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "1c72c43a-daf6-5ede-87e6-275745b9b0eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c221d8-fbe4-4901-9f7b-1d04e08b261e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c221d8-fbe4-4901-9f7b-1d04e08b261e.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13187,7 +13187,7 @@
         },
         {
             "id": "287a186a-4e78-57bc-ab11-43ef54cd4607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e97b5-6750-4fae-8481-1244e311da7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e97b5-6750-4fae-8481-1244e311da7e.jpg?1",
             "name": "Shifting Woodland",
             "text": "Shifting Woodland enters the battlefield tapped unless you control a Forest.\n{T}: Add {G}.\nDelirium \u2014 {2}{G}{G}: Shifting Woodland becomes a copy of target permanent card in your graveyard until end of turn. Activate only if there are four or more card types among cards in your graveyard.",
             "colours": [],
@@ -13219,7 +13219,7 @@
         },
         {
             "id": "396422d1-4909-55e6-bc72-aaf81ef7df3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33535dbf-203b-44c9-be20-67fafa0927ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33535dbf-203b-44c9-be20-67fafa0927ee.jpg?1",
             "name": "Spymaster's Vault",
             "text": "Spymaster's Vault enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{B}, {T}: Target creature you control connives X, where X is the number of creatures that died this turn.",
             "colours": [],
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "bfe23197-bffa-5b86-a66b-6e7921da8c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1506f3-5121-4b83-b199-6594b41e7883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1506f3-5121-4b83-b199-6594b41e7883.jpg?1",
             "name": "Ugin's Labyrinth",
             "text": "Imprint \u2014 When Ugin's Labyrinth enters the battlefield, you may exile a colorless card with mana value 7 or greater from your hand.\n{T}: Add {C}. If a card is exiled with Ugin's Labyrinth, add {C}{C} instead.\n{T}: Return the exiled card to its owner's hand.",
             "colours": [],
@@ -13281,7 +13281,7 @@
         },
         {
             "id": "03c291b0-855f-5e21-a871-1bed3ab237d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26343f80-4d60-407a-a44a-ee6295d2e5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26343f80-4d60-407a-a44a-ee6295d2e5ec.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13313,7 +13313,7 @@
         },
         {
             "id": "e0818b53-9ea9-56ba-900e-1282ed05b80e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fa77b-d103-446f-95d0-e4b11dfac05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fa77b-d103-446f-95d0-e4b11dfac05f.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13345,7 +13345,7 @@
         },
         {
             "id": "6451c9d5-c3d4-52c9-89a1-f14aea416831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49fd832-1185-4eb5-8bd3-bccc8835dbee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49fd832-1185-4eb5-8bd3-bccc8835dbee.jpg?1",
             "name": "Herigast, Erupting Nullkite",
             "text": "Emerge {6}{R}{R}\nWhen you cast this spell, you may exile your hand. If you do, draw three cards.\nFlying\nEach creature spell you cast has emerge. The emerge cost is equal to its mana cost.",
             "colours": [],
@@ -13383,7 +13383,7 @@
         },
         {
             "id": "4acb0149-3207-5843-a701-dd53b651f3f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd6f74-a3bb-4d12-9dbe-1d0a4dde85cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd6f74-a3bb-4d12-9dbe-1d0a4dde85cb.jpg?1",
             "name": "Pearl-Ear, Imperial Advisor",
             "text": "Lifelink\nEnchantment spells you cast have affinity for Auras.\nWhenever you cast an Aura spell that targets a modified permanent you control, draw a card.",
             "colours": [
@@ -13423,7 +13423,7 @@
         },
         {
             "id": "bd9efd3b-4008-5667-beeb-830d2aefa9f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95505d46-fc4f-4e2d-8e08-380d392b74a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95505d46-fc4f-4e2d-8e08-380d392b74a4.jpg?1",
             "name": "Phelia, Exuberant Shepherd",
             "text": "Flash\nWhenever Phelia, Exuberant Shepherd attacks, exile up to one other target nonland permanent. At the beginning of the next end step, return that card to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on Phelia.",
             "colours": [
@@ -13462,7 +13462,7 @@
         },
         {
             "id": "be1aa573-db05-50b0-8352-f8493ab7ce7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a325a92-522b-4f2d-a3dd-2a9eb56d1478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a325a92-522b-4f2d-a3dd-2a9eb56d1478.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "Lifelink\nFor each {B} in a cost, you may pay 2 life rather than pay that mana.\nWhenever you cast a black spell, put a +1/+1 counter on K'rrik, Son of Yawgmoth.",
             "colours": [
@@ -13503,7 +13503,7 @@
         },
         {
             "id": "c1b80421-aa3d-544a-9971-c5dcf813e6fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68425ba0-7216-46aa-a9c3-c552e4a44203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68425ba0-7216-46aa-a9c3-c552e4a44203.jpg?1",
             "name": "Shilgengar, Sire of Famine",
             "text": "Flying\nSacrifice another creature: Create a Blood token. If you sacrificed an Angel this way, create a number of Blood tokens equal to its toughness instead.\n{WB}{WB}{WB}, Sacrifice six Blood tokens: Return each creature card from your graveyard to the battlefield with a finality counter on it. Those creatures are Vampires in addition to their other types.",
             "colours": [
@@ -13544,7 +13544,7 @@
         },
         {
             "id": "4da901a0-b94a-5985-ba9b-8adc300f93b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95089b00-b159-4c95-952d-bc29e463a1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95089b00-b159-4c95-952d-bc29e463a1e7.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -13585,7 +13585,7 @@
         },
         {
             "id": "748ea911-1a47-5f51-9967-cf489a509c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac72836-a656-4bdb-adc8-04cf20b77aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac72836-a656-4bdb-adc8-04cf20b77aba.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "cc681541-4cd7-5143-ab72-dca8aecb818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86029eaa-b5d3-40ba-8eba-6e6002ea4325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86029eaa-b5d3-40ba-8eba-6e6002ea4325.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -13666,7 +13666,7 @@
         },
         {
             "id": "bffd593c-b54a-59fa-9ce2-27a5a51534c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ea0c62-a9b3-4e8f-9ede-1f0122149737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ea0c62-a9b3-4e8f-9ede-1f0122149737.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace.",
             "colours": [
@@ -13706,7 +13706,7 @@
         },
         {
             "id": "404835ed-5804-5cdb-9e07-48ee0b0fed54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b5403e-7d57-4696-a6dc-c339c1969925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b5403e-7d57-4696-a6dc-c339c1969925.jpg?1",
             "name": "Arna Kenner\u00fcd, Skycaptain",
             "text": "Flying, lifelink\nWard\u2014\nDiscard a card.\nWhenever a modified creature you control attacks, double the number of each kind of counter on it. Then for each nontoken permanent attached to it, create a token that's a copy of that permanent attached to that creature.",
             "colours": [
@@ -13750,7 +13750,7 @@
         },
         {
             "id": "3abf92cb-d769-592f-8a6b-0a8975d88b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e5d5a-01cc-4d01-88fb-ab556e2383cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e5d5a-01cc-4d01-88fb-ab556e2383cb.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -13796,7 +13796,7 @@
         },
         {
             "id": "9d8bc666-813a-5912-8b8a-8730f7a42d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853b432-e5cc-4637-b496-5e9e4620727f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853b432-e5cc-4637-b496-5e9e4620727f.jpg?1",
             "name": "Genku, Future Shaper",
             "text": "Whenever another nontoken permanent you control leaves the battlefield, choose one that hasn't been chosen this turn. Create a creature token with those characteristics.\n\u2022 2/2 white Fox with vigilance.\n\u2022 1/2 blue Moonfolk with flying.\n\u2022 1/1 black Rat with lifelink.\n{3}{W}{U}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -13838,7 +13838,7 @@
         },
         {
             "id": "04c1697b-ff03-56d0-ac25-a417a9865132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26585ae8-5f96-4e6a-a008-752aacce433a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26585ae8-5f96-4e6a-a008-752aacce433a.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -13880,7 +13880,7 @@
         },
         {
             "id": "bd222010-1fb4-5eb1-a280-53848c31c9e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7782562f-cd13-4770-930c-95ad4263f24d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7782562f-cd13-4770-930c-95ad4263f24d.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -13925,7 +13925,7 @@
         },
         {
             "id": "7ef7a802-3e3f-5060-b151-4bf455e93dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0083d7-508a-4206-a4bd-72bb009626ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0083d7-508a-4206-a4bd-72bb009626ce.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "fb97780c-d4f7-553c-a6e6-b5e48a1766eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8281df8a-2fde-454a-813c-d9f86bb35d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8281df8a-2fde-454a-813c-d9f86bb35d36.jpg?1",
             "name": "Nadu, Winged Wisdom",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand. This ability triggers only twice each turn.\"",
             "colours": [
@@ -14009,7 +14009,7 @@
         },
         {
             "id": "63abefdb-0025-59ab-9efd-8f78bb3b9c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c5c8e0-0744-4bd3-a5a1-ca71c287569b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c5c8e0-0744-4bd3-a5a1-ca71c287569b.jpg?1",
             "name": "The Necrobloom",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 0/1 green Plant creature token. If you control seven or more lands with different names, create a 2/2 black Zombie creature token instead.\nLand cards in your graveyard have dredge 2.",
             "colours": [
@@ -14052,7 +14052,7 @@
         },
         {
             "id": "030f5963-dd91-58fb-a310-3f7b257f67cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08742bb-d980-4912-a2fd-b8edac1fe554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08742bb-d980-4912-a2fd-b8edac1fe554.jpg?1",
             "name": "Phlage, Titan of Fire's Fury",
             "text": "When Phlage enters the battlefield, sacrifice it unless it escaped.\nWhenever Phlage enters the battlefield or attacks, it deals 3 damage to any target and you gain 3 life.\nEscape\u2014{R}{R}{W}{W}, Exile five other cards from your graveyard.",
             "colours": [
@@ -14094,7 +14094,7 @@
         },
         {
             "id": "244de6c9-97c9-5b0f-a054-ee3b2f64266b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5522e2-5182-4ce3-8690-3b4f133b1e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5522e2-5182-4ce3-8690-3b4f133b1e6e.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "d34e8e6e-c9a8-5783-ad82-d4ccbf3feecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77f5c3-b027-416b-8d9c-1b96c7bd504e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77f5c3-b027-416b-8d9c-1b96c7bd504e.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -14174,7 +14174,7 @@
         },
         {
             "id": "14c848d0-7d9f-5257-a1ed-d17fe8851070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08c318-f57e-4557-a6ce-8fa23a732b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08c318-f57e-4557-a6ce-8fa23a732b05.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "",
             "colours": [],
@@ -14210,7 +14210,7 @@
         },
         {
             "id": "6a5266da-e429-5ff4-839a-83735edad4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bace1-28d2-4429-ae8d-b867c202afbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bace1-28d2-4429-ae8d-b867c202afbd.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -14246,7 +14246,7 @@
         },
         {
             "id": "eb635d64-3e6a-5bb6-9801-3956121fedce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339f83ca-4f46-4246-be23-5ca4add31d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339f83ca-4f46-4246-be23-5ca4add31d81.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -14282,7 +14282,7 @@
         },
         {
             "id": "9d0586da-121d-5a2c-89cd-dfda9f5b70bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5bc75-4d04-4a8e-9830-0f0c73f5a39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5bc75-4d04-4a8e-9830-0f0c73f5a39f.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -14319,7 +14319,7 @@
         },
         {
             "id": "21d71927-6ebe-58b4-b15d-cad94203159e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca489d-a1e3-4a39-8c83-c2836ee0a240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca489d-a1e3-4a39-8c83-c2836ee0a240.jpg?1",
             "name": "It That Heralds the End",
             "text": "Colorless spells you cast with mana value 7 or greater cost {1} less to cast.\nOther colorless creatures you control get +1/+1.",
             "colours": [],
@@ -14352,7 +14352,7 @@
         },
         {
             "id": "43f8d9c8-43bf-5dff-a1c0-e92bbb45513c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d08a8-32ed-423e-aa8a-51c70025592c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d08a8-32ed-423e-aa8a-51c70025592c.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -14388,7 +14388,7 @@
         },
         {
             "id": "f9361ae7-2454-510f-bcc1-63e1aff0af1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7114c9c8-5370-42e0-8aaf-dc05e2422a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7114c9c8-5370-42e0-8aaf-dc05e2422a76.jpg?1",
             "name": "Null Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target multicolored spell.\n\u2022 Destroy target multicolored permanent.",
             "colours": [],
@@ -14418,7 +14418,7 @@
         },
         {
             "id": "b4dea9c6-8f0b-52d1-9c7a-c480d434b044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d5409-0375-4a77-8019-ddaade86e144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d5409-0375-4a77-8019-ddaade86e144.jpg?1",
             "name": "Nulldrifter",
             "text": "When you cast this spell, draw two cards.\nFlying, annihilator 1\nEvoke {2}{U}",
             "colours": [],
@@ -14453,7 +14453,7 @@
         },
         {
             "id": "777fbf2f-1c66-5f61-9190-a0936c30c4f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d577b0a9-b680-4dd2-9df2-865bab48a318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d577b0a9-b680-4dd2-9df2-865bab48a318.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -14489,7 +14489,7 @@
         },
         {
             "id": "b5ea1e5e-6625-5404-b771-41f9a120c9cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b1bd25-bab3-408d-bdc5-7fd4d2dd2e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b1bd25-bab3-408d-bdc5-7fd4d2dd2e83.jpg?1",
             "name": "Charitable Levy",
             "text": "Noncreature spells cost {1} more to cast.\nWhenever a player casts a noncreature spell, put a collection counter on Charitable Levy. Then if there are three or more collection counters on it, sacrifice it. If you do, draw a card, then you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -14523,7 +14523,7 @@
         },
         {
             "id": "9e2640e7-aa42-57dd-a0e5-16d71d0b5cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9ba97a-9eda-465a-891d-f3be9c2abeb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9ba97a-9eda-465a-891d-f3be9c2abeb2.jpg?1",
             "name": "Flare of Fortitude",
             "text": "You may sacrifice a nontoken white creature rather than pay this spell's mana cost.\nUntil end of turn, your life total can't change, and permanents you control gain hexproof and indestructible.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "18838485-9688-5be9-8db8-4102dd2ccf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51015ef-184c-44bb-b3d2-c74a0549efac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51015ef-184c-44bb-b3d2-c74a0549efac.jpg?1",
             "name": "Jolted Awake",
             "text": "Choose up to one target artifact or creature card in your graveyard. You get {E}{E}. Then you may pay an amount of {E} equal to that card's mana value. If you do, return it from your graveyard to the battlefield.\nCycling {2}",
             "colours": [
@@ -14593,7 +14593,7 @@
         },
         {
             "id": "7a85ce1e-8a3f-5fe5-b9a1-c206016222ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7ef64-9223-4c5d-bb2f-8a9f033729ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7ef64-9223-4c5d-bb2f-8a9f033729ec.jpg?1",
             "name": "Metastatic Evangel",
             "text": "Whenever another nontoken creature enters the battlefield under your control, proliferate.",
             "colours": [
@@ -14631,7 +14631,7 @@
         },
         {
             "id": "8867cfa0-bc32-5d41-b28d-1be12c194c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2ff4-8b8c-410b-8636-7e6a539fd291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2ff4-8b8c-410b-8636-7e6a539fd291.jpg?1",
             "name": "Ocelot Pride",
             "text": "First strike, lifelink\nAscend\nAt the beginning of your end step, if you gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's blessing, for each token you control that entered the battlefield this turn, create a token that's a copy of it.",
             "colours": [
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "c8928311-e2ab-53bb-b34d-13d6219a5204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6920d07-f406-4458-9446-209202c1d9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6920d07-f406-4458-9446-209202c1d9ca.jpg?1",
             "name": "Recruiter of the Guard",
             "text": "When Recruiter of the Guard enters the battlefield, you may search your library for a creature card with toughness 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -14705,7 +14705,7 @@
         },
         {
             "id": "d57cad80-612d-594a-abb3-66f4275c2bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eca3c-8718-4890-ac1b-f267deb55836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eca3c-8718-4890-ac1b-f267deb55836.jpg?1",
             "name": "White Orchid Phantom",
             "text": "Flying, first strike\nWhen White Orchid Phantom enters the battlefield, destroy up to one target nonbasic land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "b8945f73-69a9-5f95-a75e-8109d87fc343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7325714a-bd27-4215-9826-3785089ffa23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7325714a-bd27-4215-9826-3785089ffa23.jpg?1",
             "name": "Wrath of the Skies",
             "text": "You get X {E}, then you may pay any amount of {E}. Destroy each artifact, creature, and enchantment with mana value less than or equal to the amount of {E} paid this way.",
             "colours": [
@@ -14778,7 +14778,7 @@
         },
         {
             "id": "a71140f3-cdad-5671-875c-2811b5c5630a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb10f7af-8c6d-4228-8600-5b1de3e3abcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb10f7af-8c6d-4228-8600-5b1de3e3abcb.jpg?1",
             "name": "Aether Spike",
             "text": "Choose target spell. You get {E}{E}, then you may pay any amount of {E}. Counter that spell unless its controller pays {1} for each {E} paid this way.",
             "colours": [
@@ -14812,7 +14812,7 @@
         },
         {
             "id": "066ded7e-5c33-5d9f-af26-55238955aa81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6997b-a8b1-4655-a9b0-5f9a305ca96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6997b-a8b1-4655-a9b0-5f9a305ca96e.jpg?1",
             "name": "Brainsurge",
             "text": "Draw four cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -14846,7 +14846,7 @@
         },
         {
             "id": "aa68a9dd-c104-5e66-929c-5cbd488c9b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149c119-83ea-46f5-9e22-33a674ddddb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149c119-83ea-46f5-9e22-33a674ddddb6.jpg?1",
             "name": "Flare of Denial",
             "text": "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -14881,7 +14881,7 @@
         },
         {
             "id": "cdf5e753-9dfc-527d-97b1-32f8c23e7b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974f71e8-2c42-4267-b0b5-5826930e4f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974f71e8-2c42-4267-b0b5-5826930e4f1f.jpg?1",
             "name": "Kappa Cannoneer",
             "text": "Improvise\nWard {4}\nWhenever Kappa Cannoneer or another artifact enters the battlefield under your control, put a +1/+1 counter on Kappa Cannoneer and it can't be blocked this turn.",
             "colours": [
@@ -14919,7 +14919,7 @@
         },
         {
             "id": "f8e8afeb-4cb6-5a81-9399-38cca00d1c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57b700d-2a28-40b5-a6da-1a967c90a601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57b700d-2a28-40b5-a6da-1a967c90a601.jpg?1",
             "name": "Shadow of the Second Sun",
             "text": "Enchant player\nAt the beginning of enchanted player's postcombat main phase, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "2de41d02-6d3b-54d7-8068-c44414943b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad6d5d0-2b45-4d89-8335-f238f6454201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad6d5d0-2b45-4d89-8335-f238f6454201.jpg?1",
             "name": "Tune the Narrative",
             "text": "Draw a card. You get {E}{E}.",
             "colours": [
@@ -14989,7 +14989,7 @@
         },
         {
             "id": "5791aafb-0caa-5fea-9ab8-3629568e266d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5fb32c-6348-4d39-8d74-b345452b3875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5fb32c-6348-4d39-8d74-b345452b3875.jpg?1",
             "name": "Volatile Stormdrake",
             "text": "Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters the battlefield, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
             "colours": [
@@ -15026,7 +15026,7 @@
         },
         {
             "id": "3fde5e91-38df-54c8-acbc-648414d48e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a63029-1fb2-4fdc-bca9-0a530c7b42d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a63029-1fb2-4fdc-bca9-0a530c7b42d9.jpg?1",
             "name": "Accursed Marauder",
             "text": "When Accursed Marauder enters the battlefield, each player sacrifices a nontoken creature.",
             "colours": [
@@ -15064,7 +15064,7 @@
         },
         {
             "id": "700059b6-6a24-502c-8041-a24f91ee0924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cbd637-30d1-4c3c-95ce-b6c6f9248d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cbd637-30d1-4c3c-95ce-b6c6f9248d15.jpg?1",
             "name": "Chthonian Nightmare",
             "text": "When Chthonian Nightmare enters the battlefield, you get {E}{E}{E}.\nPay X {E}, Sacrifice a creature, Return Chthonian Nightmare to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -15099,7 +15099,7 @@
         },
         {
             "id": "fed11c59-2cb4-52eb-9fdc-123b286ea2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2803b9-ad7b-4f0e-b622-2b8e84cdd591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2803b9-ad7b-4f0e-b622-2b8e84cdd591.jpg?1",
             "name": "Consuming Corruption",
             "text": "Consuming Corruption deals X damage to target creature or planeswalker and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -15133,7 +15133,7 @@
         },
         {
             "id": "7f20a86e-9697-5bd3-b399-a6da80fee109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb9479-d019-4ffe-a508-1db81a28847f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb9479-d019-4ffe-a508-1db81a28847f.jpg?1",
             "name": "Flare of Malice",
             "text": "You may sacrifice a nontoken black creature rather than pay this spell's mana cost.\nEach opponent sacrifices a creature or planeswalker with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -15168,7 +15168,7 @@
         },
         {
             "id": "9f4b26df-3d55-5816-9ded-36034736131e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77251806-c2b6-448c-a95e-a1943ca0bfd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77251806-c2b6-448c-a95e-a1943ca0bfd8.jpg?1",
             "name": "Grim Servant",
             "text": "Menace\nWhen Grim Servant enters the battlefield, search your library for a card with mana value less than or equal to your devotion to black, reveal it, put it into your hand, then shuffle. You lose 3 life.",
             "colours": [
@@ -15205,7 +15205,7 @@
         },
         {
             "id": "2e99c5d7-b531-5df1-b573-15f031dc4f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b5a3dd-0b5a-434e-afee-a83b0279fd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b5a3dd-0b5a-434e-afee-a83b0279fd15.jpg?1",
             "name": "Marionette Apprentice",
             "text": "Fabricate 1\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, each opponent loses 1 life.",
             "colours": [
@@ -15242,7 +15242,7 @@
         },
         {
             "id": "5d05e53c-3acf-5d71-8766-b59e2593518d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f810a2d7-efbe-4ea1-83d1-d594a8eaf88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f810a2d7-efbe-4ea1-83d1-d594a8eaf88b.jpg?1",
             "name": "Necrodominance",
             "text": "Skip your draw step.\nAt the beginning of your end step, you may pay any amount of life. If you do, draw that many cards.\nYour maximum hand size is five.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.",
             "colours": [
@@ -15278,7 +15278,7 @@
         },
         {
             "id": "2aa7e199-22ec-57af-92f3-8128b6adf831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab57e89-a420-4a3a-b2ba-34bb427e40d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab57e89-a420-4a3a-b2ba-34bb427e40d4.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -15312,7 +15312,7 @@
         },
         {
             "id": "eac1f1a2-1a61-5ef7-ae43-20f01de3baf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7b6b5-5cc6-4edd-8e0b-1eb59d22d958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7b6b5-5cc6-4edd-8e0b-1eb59d22d958.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "3458595b-27c9-5f48-bca0-c9fbb227c3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fd4d15-413f-41c5-b3e0-71bbb52851bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fd4d15-413f-41c5-b3e0-71bbb52851bc.jpg?1",
             "name": "Warren Soultrader",
             "text": "Pay 1 life, Sacrifice another creature: Create a Treasure token.",
             "colours": [
@@ -15385,7 +15385,7 @@
         },
         {
             "id": "0bd67721-7862-5c2b-a9bc-5df944fbe570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365e0cc-ce69-41f3-a90b-06817aa858ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365e0cc-ce69-41f3-a90b-06817aa858ac.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -15426,7 +15426,7 @@
         },
         {
             "id": "21707c84-c7b0-5dd1-90dc-58a7a21de04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170483c2-4e50-4cc8-9481-3330057d91bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170483c2-4e50-4cc8-9481-3330057d91bb.jpg?1",
             "name": "Flare of Duplication",
             "text": "You may sacrifice a nontoken red creature rather than pay this spell's mana cost.\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -15461,7 +15461,7 @@
         },
         {
             "id": "fcb4421d-9f85-57a9-9c2a-b58de89e867f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d3315d-2472-4fb5-8aba-611037043cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d3315d-2472-4fb5-8aba-611037043cbf.jpg?1",
             "name": "Galvanic Discharge",
             "text": "Choose target creature or planeswalker. You get {E}{E}{E}, then you may pay any amount of {E}. Galvanic Discharge deals that much damage to that permanent.",
             "colours": [
@@ -15495,7 +15495,7 @@
         },
         {
             "id": "5e25058b-c3ac-5751-9ee6-de2e28c31ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eedd92-8386-4ca9-ad72-afa03fa4bb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eedd92-8386-4ca9-ad72-afa03fa4bb28.jpg?1",
             "name": "Meltdown",
             "text": "Destroy each artifact with mana value X or less.",
             "colours": [
@@ -15529,7 +15529,7 @@
         },
         {
             "id": "c76a649d-78bc-5844-ab3e-43e4f2c6591d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0e5378-310b-44b6-8fc8-26c94eaceafc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0e5378-310b-44b6-8fc8-26c94eaceafc.jpg?1",
             "name": "Party Thrasher",
             "text": "Noncreature spells you cast from exile have convoke.\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "b2fd021b-e4af-5c9e-93f8-1e13b33edca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b61aa8e-bb16-4ed5-b8d3-4e2f0c6d3812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b61aa8e-bb16-4ed5-b8d3-4e2f0c6d3812.jpg?1",
             "name": "Skoa, Embermage",
             "text": "When Skoa, Embermage enters the battlefield, it deals 4 damage to any target.\nGrandeur \u2014 Discard another card named Skoa, Embermage, Sacrifice two Mountains: Skoa deals 4 damage to any target.",
             "colours": [
@@ -15606,7 +15606,7 @@
         },
         {
             "id": "e13b5e08-5af4-5685-8ae1-0d43ef045a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f01df9-c4fa-4598-84c1-217bde6b1841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f01df9-c4fa-4598-84c1-217bde6b1841.jpg?1",
             "name": "Unstable Amulet",
             "text": "When Unstable Amulet enters the battlefield, you get {E}{E}.\nWhenever you cast a spell from anywhere other than your hand, Unstable Amulet deals 1 damage to each opponent.\n{T}, Pay {E}{E}: Exile the top card of your library. You may play it until you exile another card with Unstable Amulet.",
             "colours": [
@@ -15641,7 +15641,7 @@
         },
         {
             "id": "3bf56854-5dee-5f7d-b8b4-4b5066e2f6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9baaa353-e4ab-48e3-824c-712946ba0229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9baaa353-e4ab-48e3-824c-712946ba0229.jpg?1",
             "name": "Wheel of Potential",
             "text": "You get {E}{E}{E}, then you may pay X {E}.\nEach player may exile their hand and draw X cards. If X is 7 or more, you may play cards you own exiled this way until the end of your next turn.",
             "colours": [
@@ -15676,7 +15676,7 @@
         },
         {
             "id": "d2c21dfb-b7be-5c78-9a4e-ad7479559f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e17861-e0e6-4660-8705-6c71f10d1f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e17861-e0e6-4660-8705-6c71f10d1f19.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -15717,7 +15717,7 @@
         },
         {
             "id": "ad35ab12-dda6-5141-9ec3-6a29e1c7b305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4ecfa6-5e38-4c0a-91e2-f93cb492f374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4ecfa6-5e38-4c0a-91e2-f93cb492f374.jpg?1",
             "name": "Evolution Witness",
             "text": "{1}{G}: Adapt 2.\nWhenever one or more +1/+1 counters are put on Evolution Witness, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -15755,7 +15755,7 @@
         },
         {
             "id": "b6338070-dabe-5bc3-ab97-f959ae628b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b057c3e0-9d1e-4136-be70-ff34701a2cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b057c3e0-9d1e-4136-be70-ff34701a2cb7.jpg?1",
             "name": "Flare of Cultivation",
             "text": "You may sacrifice a nontoken green creature rather than pay this spell's mana cost.\nSearch your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -15790,7 +15790,7 @@
         },
         {
             "id": "3106e380-a313-54a5-8712-c39ec6fe40ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3726c01c-e314-4ca6-a82d-17178b100b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3726c01c-e314-4ca6-a82d-17178b100b64.jpg?1",
             "name": "Lion Umbra",
             "text": "Enchant modified creature\nEnchanted creature gets +3/+3 and has vigilance and reach.\nUmbra armor",
             "colours": [
@@ -15826,7 +15826,7 @@
         },
         {
             "id": "2f95f749-1a11-567a-bd68-e3938a05fee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0970efb6-427f-4d5b-9b66-eda4b91015bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0970efb6-427f-4d5b-9b66-eda4b91015bd.jpg?1",
             "name": "Monstrous Vortex",
             "text": "Whenever you cast a creature spell with power 5 or greater, discover X, where X is that spell's mana value.",
             "colours": [
@@ -15860,7 +15860,7 @@
         },
         {
             "id": "91b583fd-6ae0-57c4-a9a1-e673ffb165ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777b6f4-38de-4cba-b050-361b0f5bc560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777b6f4-38de-4cba-b050-361b0f5bc560.jpg?1",
             "name": "Priest of Titania",
             "text": "{T}: Add {G} for each Elf on the battlefield.",
             "colours": [
@@ -15897,7 +15897,7 @@
         },
         {
             "id": "aa84dba3-4c6f-5c01-abd7-78a5bed1d120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40017c2c-7631-4db8-8fcc-596108cfc7d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40017c2c-7631-4db8-8fcc-596108cfc7d3.jpg?1",
             "name": "Primal Prayers",
             "text": "When Primal Prayers enters the battlefield, you get {E}{E}.\nYou may cast creature spells with mana value 3 or less by paying {E} rather than paying their mana costs. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -15932,7 +15932,7 @@
         },
         {
             "id": "988bdb79-c326-5c2b-9717-bc15a2e80d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ff685-8694-4939-8f92-d91bb7ae5b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ff685-8694-4939-8f92-d91bb7ae5b76.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace.",
             "colours": [
@@ -15972,7 +15972,7 @@
         },
         {
             "id": "b63e754b-6691-5f40-a8f7-bda8ca2ce120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecbe0a4-c5b7-4f21-adcc-aea0dc20700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecbe0a4-c5b7-4f21-adcc-aea0dc20700e.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -16014,7 +16014,7 @@
         },
         {
             "id": "a18fdcc9-12eb-5082-9ac8-12e7a0ad5c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d59081-ad4e-4b9a-bb25-2105a88268b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d59081-ad4e-4b9a-bb25-2105a88268b3.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -16056,7 +16056,7 @@
         },
         {
             "id": "43d67a5f-201c-5d92-a431-68d5e3ceeab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d344f-5659-400e-8b8f-ad293ccf6308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d344f-5659-400e-8b8f-ad293ccf6308.jpg?1",
             "name": "Psychic Frog",
             "text": "Whenever Psychic Frog deals combat damage to a player or planeswalker, draw a card.\nDiscard a card: Put a +1/+1 counter on Psychic Frog.\nExile three cards from your graveyard: Psychic Frog gains flying until end of turn.",
             "colours": [
@@ -16095,7 +16095,7 @@
         },
         {
             "id": "b24afd27-c9a0-5583-9dd5-01b3c5508fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407e5c6-3f1d-4716-877a-f537dd183eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407e5c6-3f1d-4716-877a-f537dd183eac.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -16138,7 +16138,7 @@
         },
         {
             "id": "9806f8ab-0171-5939-9a6e-b8c100214db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115400ae-a43b-4b3d-9ea0-be1e7224dea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115400ae-a43b-4b3d-9ea0-be1e7224dea5.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16170,7 +16170,7 @@
         },
         {
             "id": "78308344-3b26-5008-9a65-3b5e9877bc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3016d92-a5ee-44d7-aa0a-775fa04a7c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3016d92-a5ee-44d7-aa0a-775fa04a7c6a.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16202,7 +16202,7 @@
         },
         {
             "id": "1a63a81a-8ff8-5161-ba01-393d4bce3fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe15dc63-761f-4f24-8aa3-716552d45c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe15dc63-761f-4f24-8aa3-716552d45c64.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -16232,7 +16232,7 @@
         },
         {
             "id": "bfb0632c-4d5e-54a0-b8bd-f698019b32c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d79c3-93fa-4232-959f-2bbc62954dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d79c3-93fa-4232-959f-2bbc62954dfd.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16264,7 +16264,7 @@
         },
         {
             "id": "707f7ecc-f57f-5c78-8cb0-89a55c2b13d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0de06-7782-4d2b-93ba-ef42cd5f79b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0de06-7782-4d2b-93ba-ef42cd5f79b4.jpg?1",
             "name": "Snow-Covered Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -16298,7 +16298,7 @@
         },
         {
             "id": "d3900da8-302c-5eb9-851a-e51bf5e7f760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b1ba-78be-47ab-8dad-13233f4d4dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b1ba-78be-47ab-8dad-13233f4d4dfc.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16330,7 +16330,7 @@
         },
         {
             "id": "e89f9ca7-9eef-5c0d-b13e-18142077859b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3164be2f-28c9-4a33-bd70-d5089396538c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3164be2f-28c9-4a33-bd70-d5089396538c.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16362,7 +16362,7 @@
         },
         {
             "id": "9b08944d-5b7c-5f72-8dc0-e9b1c0803366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "When Ajani, Nacatl Pariah enters the battlefield, create a 2/1 white Cat Warrior creature token.\nWhenever one or more other Cats you control die, you may exile Ajani, then return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -16403,7 +16403,7 @@
         },
         {
             "id": "44d3b919-7458-531c-a563-876c50d5287b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "+2: Put a +1/+1 counter on each Cat you control.\n0: Create a 2/1 white Cat Warrior creature token. When you do, if you control a red permanent other than Ajani, Nacatl Avenger, he deals damage equal to the number of creatures you control to any target.\n\u22124: Each opponent chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest.",
             "colours": [
@@ -16444,7 +16444,7 @@
         },
         {
             "id": "d7bd8437-9999-5615-b6bc-9a64f37a5c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "Flying\nWhenever Tamiyo, Inquisitive Student attacks, investigate.\nWhen you draw your third card in a turn, exile Tamiyo, then return her to the battlefield transformed under her owner's control.",
             "colours": [
@@ -16485,7 +16485,7 @@
         },
         {
             "id": "d0c7070d-3d72-543c-98a0-1d5d7c41a4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "+2: Until your next turn, whenever a creature attacks you or a planeswalker you control, it gets -1/-0 until end of turn.\n\u22123: Return target instant or sorcery card from your graveyard to your hand. If it's a green card, add one mana of any color.\n\u22127: Draw cards equal to half the number of cards in your library, rounded up. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -16526,7 +16526,7 @@
         },
         {
             "id": "e9c637f0-03cc-5a79-92cb-e79c35d048ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "Lifelink\nExtort\nAt the beginning of your postcombat main phase, if you gained 3 or more life this turn, exile Sorin of House Markov, then return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -16567,7 +16567,7 @@
         },
         {
             "id": "4daa9ac4-55f4-5d7a-acc3-ba306f6fb6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "Extort\n+2: Create a Food token.\n\u22121: Sorin, Ravenous Neonate deals damage equal to the amount of life you gained this turn to any target.\n\u22126: Gain control of target creature. It becomes a Vampire in addition to its other types. Put a lifelink counter on it if you control a white permanent other than that creature or Sorin.",
             "colours": [
@@ -16608,7 +16608,7 @@
         },
         {
             "id": "23d299d9-3bcb-5fce-859c-f04af29cdcf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell during your turn, flip a coin. If you lose the flip, Ral, Monsoon Mage deals 1 damage to you. If you win the flip, you may exile Ral. If you do, return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -16649,7 +16649,7 @@
         },
         {
             "id": "7e576dd5-de16-5262-acf5-c8578f828191",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "Ral, Leyline Prodigy enters the battlefield with an additional loyalty counter on him for each instant and sorcery spell you've cast this turn.\n+1: Until your next turn, instant and sorcery spells you cast cost {1} less to cast.\n\u22122: Ral deals 2 damage divided as you choose among one or two targets. Draw a card if you control a blue permanent other than Ral.\n\u22128: Exile the top eight cards of your library. You may cast instant and sorcery spells from among them this turn without paying their mana costs.",
             "colours": [
@@ -16690,7 +16690,7 @@
         },
         {
             "id": "42c2b899-4538-563c-837b-c792604d216e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "Deathtouch\nWhenever Grist, Voracious Larva or another creature enters the battlefield under your control, if it entered from your graveyard or you cast it from your graveyard, you may pay {G}. If you do, exile Grist, then return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "d19f485e-7c41-51ff-ac0c-03a058df6feb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "+1: Create a 1/1 black and green Insect creature token, then mill two cards. Put a deathtouch counter on the token if a black card was milled this way.\n\u22122: Destroy target artifact or enchantment.\n\u22126: For each creature card in your graveyard, create a token that's a copy of it, except it's a 1/1 black and green Insect.",
             "colours": [
@@ -16771,7 +16771,7 @@
         },
         {
             "id": "949a5bb9-cc63-5f03-af79-da5931158845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a3155-7453-4861-8d20-89be442c0e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a3155-7453-4861-8d20-89be442c0e08.jpg?1",
             "name": "Argent Dais",
             "text": "Argent Dais enters the battlefield with two oil counters on it.\nWhenever two or more creatures attack, put an oil counter on Argent Dais.\n{2}, {T}, Remove two oil counters from Argent Dais: Exile another target nonland permanent. Its controller draws two cards.",
             "colours": [
@@ -16805,7 +16805,7 @@
         },
         {
             "id": "61fbb6e1-0f10-5d9a-9781-407ef44e7b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298de33f-cb39-47c5-9579-54d91eb34414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298de33f-cb39-47c5-9579-54d91eb34414.jpg?1",
             "name": "Guide of Souls",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life and get {E}.\nWhenever you attack, you may pay {E}{E}{E}. When you do, put two +1/+1 counters and a flying counter on target attacking creature. It becomes an Angel in addition to its other types.",
             "colours": [
@@ -16842,7 +16842,7 @@
         },
         {
             "id": "e26e4b53-c383-5a53-b80e-3b397e19b4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2d9f8-e5cb-4783-b314-df2b6f75b154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2d9f8-e5cb-4783-b314-df2b6f75b154.jpg?1",
             "name": "Amphibian Downpour",
             "text": "Flash\nStorm\nEnchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1.",
             "colours": [
@@ -16878,7 +16878,7 @@
         },
         {
             "id": "116634bb-0bd1-5086-9da5-3001ba629e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966e2066-ef45-4882-a420-247115a319b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966e2066-ef45-4882-a420-247115a319b9.jpg?1",
             "name": "Dreamtide Whale",
             "text": "Vanishing 2\nWhenever a player casts their second spell each turn, proliferate.",
             "colours": [
@@ -16914,7 +16914,7 @@
         },
         {
             "id": "221eec74-9318-5deb-8b15-9649f5166f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee81433e-a8e4-4bf1-89d8-6b9b040e8eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee81433e-a8e4-4bf1-89d8-6b9b040e8eb4.jpg?1",
             "name": "Harbinger of the Seas",
             "text": "Nonbasic lands are Islands.",
             "colours": [
@@ -16951,7 +16951,7 @@
         },
         {
             "id": "0590492f-329e-5a23-b4dd-2d4e9361b4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ac511f-6c28-45f9-968b-9ac72872641b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ac511f-6c28-45f9-968b-9ac72872641b.jpg?1",
             "name": "Crabomination",
             "text": "Emerge from artifact {5}{B}{B}\nWhen Crabomination enters the battlefield, target opponent exiles the top card of their library, a card at random from their graveyard, and a card at random from their hand. You may cast a spell from among cards exiled this way without paying its mana cost.",
             "colours": [
@@ -16988,7 +16988,7 @@
         },
         {
             "id": "0367cd48-233d-59e6-8de9-204764b4e162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfbba55-38b1-4994-ba6f-de09af4098dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfbba55-38b1-4994-ba6f-de09af4098dc.jpg?1",
             "name": "Emperor of Bones",
             "text": "At the beginning of combat on your turn, exile up to one target card from a graveyard.\n{1}{B}: Adapt 2.\nWhenever one or more +1/+1 counters are put on Emperor of Bones, put a creature card exiled with Emperor of Bones onto the battlefield under your control with a finality counter on it. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -17025,7 +17025,7 @@
         },
         {
             "id": "199aee48-81c6-57a8-b957-5a781e88b553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653589ff-8186-49cf-8ff5-baf299501daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653589ff-8186-49cf-8ff5-baf299501daa.jpg?1",
             "name": "Nethergoyf",
             "text": "Nethergoyf's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nEscape\u2014{2}{B}, Exile any number of other cards from your graveyard with four or more card types among them.",
             "colours": [
@@ -17061,7 +17061,7 @@
         },
         {
             "id": "4efb75c1-813f-5759-9513-406fdcaec0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0136a022-6b16-4b33-a817-946ded4e9dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0136a022-6b16-4b33-a817-946ded4e9dd5.jpg?1",
             "name": "Ripples of Undeath",
             "text": "At the beginning of your precombat main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.",
             "colours": [
@@ -17095,7 +17095,7 @@
         },
         {
             "id": "74804cf1-d40d-59f8-9e35-a0fe648b35ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2f7432-9216-4ef7-ab7b-c5d8e1cae395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2f7432-9216-4ef7-ab7b-c5d8e1cae395.jpg?1",
             "name": "Aether Revolt",
             "text": "Revolt \u2014 As long as a permanent you controlled left the battlefield this turn, if a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.\nWhenever you get one or more {E}, Aether Revolt deals that much damage to any target.",
             "colours": [
@@ -17129,7 +17129,7 @@
         },
         {
             "id": "7e964ff6-860c-58c5-8df0-561c15e96b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db16e02b-1b7f-4976-b9eb-41350337616c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db16e02b-1b7f-4976-b9eb-41350337616c.jpg?1",
             "name": "Detective's Phoenix",
             "text": "Bestow\u2014{R}, Collect evidence 6.\nFlying, haste\nEnchanted creature gets +2/+2 and has flying and haste.\nYou may cast Detective's Phoenix from your graveyard using its bestow ability.",
             "colours": [
@@ -17166,7 +17166,7 @@
         },
         {
             "id": "83c6f4b8-bb49-5d1b-bc09-4895cb74b9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fce56-307a-44bf-8c46-0e1328550e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fce56-307a-44bf-8c46-0e1328550e17.jpg?1",
             "name": "Fanatic of Rhonas",
             "text": "{T}: Add {G}.\nFerocious \u2014 {T}: Add {G}{G}{G}{G}. Activate only if you control a creature with power 4 or greater.\nEternalize {2}{G}{G}",
             "colours": [
@@ -17203,7 +17203,7 @@
         },
         {
             "id": "448d0b65-fd7d-5f67-bd7e-da69af563384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9458db2e-2013-492d-b086-9cf9dc230294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9458db2e-2013-492d-b086-9cf9dc230294.jpg?1",
             "name": "Invert Polarity",
             "text": "Choose target spell, then flip a coin. If you win the flip, gain control of that spell and you may choose new targets for it. If you lose the flip, counter that spell.",
             "colours": [
@@ -17239,7 +17239,7 @@
         },
         {
             "id": "9c355a30-6cd4-5872-ad0b-c374d33ec485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915715f7-5487-47aa-ada5-de1bce282164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915715f7-5487-47aa-ada5-de1bce282164.jpg?1",
             "name": "Wight of the Reliquary",
             "text": "Vigilance\nWight of the Reliquary gets +1/+1 for each creature card in your graveyard.\n{T}, Sacrifice another creature: Search your library for a land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -17278,7 +17278,7 @@
         },
         {
             "id": "55ce785d-bb72-5a38-a962-8d9f09038c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e764e3e9-653c-44d7-b96a-530d51ca5c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e764e3e9-653c-44d7-b96a-530d51ca5c2f.jpg?1",
             "name": "Disruptor Flute",
             "text": "Flash\nAs Disruptor Flute enters the battlefield, choose a card name.\nSpells with the chosen name cost {3} more to cast.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -17308,7 +17308,7 @@
         },
         {
             "id": "3e034b67-ca2e-5dbd-a18e-8dcd75f36abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea94321-7311-4543-bdc0-23938a8904c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea94321-7311-4543-bdc0-23938a8904c3.jpg?1",
             "name": "Winter Moon",
             "text": "Players can't untap more than one nonbasic land during their untap steps.",
             "colours": [],
@@ -17338,7 +17338,7 @@
         },
         {
             "id": "5c5d3ba1-4206-5922-89f9-633e72b3483e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de472d0-cca2-4bc3-ab0a-9f79fa6325ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de472d0-cca2-4bc3-ab0a-9f79fa6325ce.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17370,7 +17370,7 @@
         },
         {
             "id": "5361051d-c1d5-54b0-972b-342ef57fccb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431eca69-ba8c-47c8-a325-22a844f83e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431eca69-ba8c-47c8-a325-22a844f83e80.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17402,7 +17402,7 @@
         },
         {
             "id": "46da3208-d8bc-5403-b464-25d926d2cc70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797b30b0-bc82-43fd-a842-d5879e2441bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797b30b0-bc82-43fd-a842-d5879e2441bd.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17434,7 +17434,7 @@
         },
         {
             "id": "49225ddc-6bfe-5a55-af7b-13b215d3b91a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de8387d-a707-4c2b-9661-c586b7d0db50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de8387d-a707-4c2b-9661-c586b7d0db50.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17466,7 +17466,7 @@
         },
         {
             "id": "848f5225-2899-5df8-a3b9-f7d61f47ef2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af6676-e780-4ebf-b2d3-0bc3436e527c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af6676-e780-4ebf-b2d3-0bc3436e527c.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17498,7 +17498,7 @@
         },
         {
             "id": "3ecb147d-a567-57df-9b21-6e93fffc36e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -17538,7 +17538,7 @@
         },
         {
             "id": "577c5fb8-abb4-5c37-bf54-acb8839f0958",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -17578,7 +17578,7 @@
         },
         {
             "id": "46a667e4-ea37-53e8-88fd-7896307d1a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -17618,7 +17618,7 @@
         },
         {
             "id": "5f9c7ee5-31b9-5bf2-8736-e1fc9de778ee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -17658,7 +17658,7 @@
         },
         {
             "id": "88e228e7-100f-5739-a0cc-aa115d18076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -17698,7 +17698,7 @@
         },
         {
             "id": "9410fe70-626e-5e11-b56c-1748bf23996b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -17738,7 +17738,7 @@
         },
         {
             "id": "e27c6e4c-fa75-50a3-af50-c62485ba6e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -17778,7 +17778,7 @@
         },
         {
             "id": "c6ec4e04-a2b2-5f04-a039-4ffbb2523b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -17818,7 +17818,7 @@
         },
         {
             "id": "96da87d0-8d8d-50ae-a797-8f4b3c9c0127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -17857,7 +17857,7 @@
         },
         {
             "id": "799a7c35-eb97-510a-acd8-6dc2d5bcdcbb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -17897,7 +17897,7 @@
         },
         {
             "id": "0f0ec9f1-e34e-54c7-8c10-5d017b11aa63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e4a2ce-96d3-4a76-afe6-ef85146f5e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e4a2ce-96d3-4a76-afe6-ef85146f5e5c.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -17933,7 +17933,7 @@
         },
         {
             "id": "57c897f7-af13-50dd-9115-bc845b6698fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a86d7d-a7a4-4a26-b92a-0518af2d9646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a86d7d-a7a4-4a26-b92a-0518af2d9646.jpg?1",
             "name": "Herigast, Erupting Nullkite",
             "text": "Emerge {6}{R}{R}\nWhen you cast this spell, you may exile your hand. If you do, draw three cards.\nFlying\nEach creature spell you cast has emerge. The emerge cost is equal to its mana cost.",
             "colours": [],
@@ -17970,7 +17970,7 @@
         },
         {
             "id": "fcf84a6f-348a-5ba7-8a29-a29cad2219df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ff41a5-3ad9-4d3a-8b03-402459f502c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ff41a5-3ad9-4d3a-8b03-402459f502c1.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -18005,7 +18005,7 @@
         },
         {
             "id": "af11440c-bebb-541f-a3e3-e93ea2a8013e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73da8a4-301e-4a80-9430-1d5cae8bb7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73da8a4-301e-4a80-9430-1d5cae8bb7f9.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -18040,7 +18040,7 @@
         },
         {
             "id": "3317592d-0770-5b38-9b87-01166f186269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6752d23-e4f4-40b0-9d15-f668b46ca2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6752d23-e4f4-40b0-9d15-f668b46ca2af.jpg?1",
             "name": "Pearl-Ear, Imperial Advisor",
             "text": "Lifelink\nEnchantment spells you cast have affinity for Auras.\nWhenever you cast an Aura spell that targets a modified permanent you control, draw a card.",
             "colours": [
@@ -18079,7 +18079,7 @@
         },
         {
             "id": "5a42414c-e95e-5ec5-87d0-473fcad6fa5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644f2e7a-354f-4338-9d4f-5a06a1ad412d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644f2e7a-354f-4338-9d4f-5a06a1ad412d.jpg?1",
             "name": "Phelia, Exuberant Shepherd",
             "text": "Flash\nWhenever Phelia, Exuberant Shepherd attacks, exile up to one other target nonland permanent. At the beginning of the next end step, return that card to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on Phelia.",
             "colours": [
@@ -18117,7 +18117,7 @@
         },
         {
             "id": "723185d0-c127-5c74-bc16-2587967ba0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b27dba9-ffee-4b2c-b4d4-67c24511cffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b27dba9-ffee-4b2c-b4d4-67c24511cffb.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "Lifelink\nFor each {B} in a cost, you may pay 2 life rather than pay that mana.\nWhenever you cast a black spell, put a +1/+1 counter on K'rrik, Son of Yawgmoth.",
             "colours": [
@@ -18157,7 +18157,7 @@
         },
         {
             "id": "a8655b11-f8fd-56c0-b276-135fe97bd20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c7ff3-e483-41f3-b49f-7cdc261527c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c7ff3-e483-41f3-b49f-7cdc261527c0.jpg?1",
             "name": "Shilgengar, Sire of Famine",
             "text": "Flying\nSacrifice another creature: Create a Blood token. If you sacrificed an Angel this way, create a number of Blood tokens equal to its toughness instead.\n{WB}{WB}{WB}, Sacrifice six Blood tokens: Return each creature card from your graveyard to the battlefield with a finality counter on it. Those creatures are Vampires in addition to their other types.",
             "colours": [
@@ -18197,7 +18197,7 @@
         },
         {
             "id": "fcd72e81-ffa8-535b-8678-38bc3b44d437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8e160a-487a-44dd-9075-6cae6f3df3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8e160a-487a-44dd-9075-6cae6f3df3d8.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -18237,7 +18237,7 @@
         },
         {
             "id": "7d6bc4fa-0da4-5f0e-a260-b3134e4bcf1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616106e-b75e-4de4-860e-15369e4abf84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616106e-b75e-4de4-860e-15369e4abf84.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -18276,7 +18276,7 @@
         },
         {
             "id": "68d2e2e8-4906-5853-96d5-634b21eb613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc45370c-79f4-428b-ac65-8397e1190cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc45370c-79f4-428b-ac65-8397e1190cfd.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -18316,7 +18316,7 @@
         },
         {
             "id": "56a7354a-70af-5183-9f63-d2c4f7315b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3070e7-dce0-4121-bbef-c4357f8265ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3070e7-dce0-4121-bbef-c4357f8265ab.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace.",
             "colours": [
@@ -18355,7 +18355,7 @@
         },
         {
             "id": "2c67ff28-463a-5a79-b504-5166f846b426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b2b01e-68f7-48d5-aad6-31605765a3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b2b01e-68f7-48d5-aad6-31605765a3b1.jpg?1",
             "name": "Arna Kenner\u00fcd, Skycaptain",
             "text": "Flying, lifelink\nWard\u2014\nDiscard a card.\nWhenever a modified creature you control attacks, double the number of each kind of counter on it. Then for each nontoken permanent attached to it, create a token that's a copy of that permanent attached to that creature.",
             "colours": [
@@ -18398,7 +18398,7 @@
         },
         {
             "id": "912c752d-51f4-5844-ab94-677010600b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61061110-a8f4-41ac-a89e-93359050919d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61061110-a8f4-41ac-a89e-93359050919d.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -18443,7 +18443,7 @@
         },
         {
             "id": "9144f76c-7d8a-5d27-8d25-5a5372e3982b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3f892-fffb-46ed-90c0-ade2fb4b9d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3f892-fffb-46ed-90c0-ade2fb4b9d19.jpg?1",
             "name": "Genku, Future Shaper",
             "text": "Whenever another nontoken permanent you control leaves the battlefield, choose one that hasn't been chosen this turn. Create a creature token with those characteristics.\n\u2022 2/2 white Fox with vigilance.\n\u2022 1/2 blue Moonfolk with flying.\n\u2022 1/1 black Rat with lifelink.\n{3}{W}{U}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -18484,7 +18484,7 @@
         },
         {
             "id": "13e8d096-faff-5a0e-870c-25d1fe784bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c8f6d5-28e5-46d5-9559-d69ed39e7b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c8f6d5-28e5-46d5-9559-d69ed39e7b87.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -18525,7 +18525,7 @@
         },
         {
             "id": "19852bc3-4f46-5ba5-976b-95cd8cf95469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e42cd7b-8ce5-46a6-a44b-2b1dc8477d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e42cd7b-8ce5-46a6-a44b-2b1dc8477d86.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -18569,7 +18569,7 @@
         },
         {
             "id": "af3c3a96-e00b-58e4-918a-29db33d09c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de61cb1-3baa-4471-b7dc-1a2088a8e6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de61cb1-3baa-4471-b7dc-1a2088a8e6d7.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -18610,7 +18610,7 @@
         },
         {
             "id": "efc94284-cdb8-5099-95fb-cb317d2f58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a7d66d-c602-46b2-8ec6-7116acbe8e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a7d66d-c602-46b2-8ec6-7116acbe8e3a.jpg?1",
             "name": "Nadu, Winged Wisdom",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand. This ability triggers only twice each turn.\"",
             "colours": [
@@ -18651,7 +18651,7 @@
         },
         {
             "id": "e9259c6c-5a6e-5044-ac22-769c3a5afba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe4969b-2b18-4958-af28-88bdf92dac2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe4969b-2b18-4958-af28-88bdf92dac2c.jpg?1",
             "name": "The Necrobloom",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 0/1 green Plant creature token. If you control seven or more lands with different names, create a 2/2 black Zombie creature token instead.\nLand cards in your graveyard have dredge 2.",
             "colours": [
@@ -18693,7 +18693,7 @@
         },
         {
             "id": "2971feab-e867-5805-be80-6aff61ce167c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bacad-abb8-41bd-9a33-08b75f4a8817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bacad-abb8-41bd-9a33-08b75f4a8817.jpg?1",
             "name": "Phlage, Titan of Fire's Fury",
             "text": "When Phlage enters the battlefield, sacrifice it unless it escaped.\nWhenever Phlage enters the battlefield or attacks, it deals 3 damage to any target and you gain 3 life.\nEscape\u2014{R}{R}{W}{W}, Exile five other cards from your graveyard.",
             "colours": [
@@ -18734,7 +18734,7 @@
         },
         {
             "id": "b7b69928-d643-527b-917d-901546cb214d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb64dd7b-c1b8-4fd4-99d6-9a75f64a6296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb64dd7b-c1b8-4fd4-99d6-9a75f64a6296.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -18776,7 +18776,7 @@
         },
         {
             "id": "377020f2-f3eb-5ae2-8952-913c23198025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1714304b-7216-46e8-afba-439ac320ceb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1714304b-7216-46e8-afba-439ac320ceb7.jpg?1",
             "name": "Powerbalance",
             "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, you may cast that card without paying its mana cost if the two spells have the same mana value.",
             "colours": [
@@ -18810,7 +18810,7 @@
         },
         {
             "id": "2ded6de3-83f3-530b-af2c-54e9408e0b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a98ff2-6e78-4133-ad4e-c62c396ba1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a98ff2-6e78-4133-ad4e-c62c396ba1e0.jpg?1",
             "name": "Flusterstorm",
             "text": "Counter target instant or sorcery spell unless its controller pays {1}.\nStorm",
             "colours": [
@@ -18841,7 +18841,7 @@
         },
         {
             "id": "84800bbe-66a9-5fd6-9d0d-5cc69cfc9e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9319a-a257-472a-9ab3-676d41adf877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9319a-a257-472a-9ab3-676d41adf877.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18879,7 +18879,7 @@
         },
         {
             "id": "ef6e78b2-de0d-5842-b3dc-776234334e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c9001f-a8ee-4693-b8f7-59f10ad8f63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c9001f-a8ee-4693-b8f7-59f10ad8f63a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18917,7 +18917,7 @@
         },
         {
             "id": "a3744826-e7e1-52ec-af49-f9635ea8475f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5754638d-14ce-452d-bb45-d1d8f1151a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5754638d-14ce-452d-bb45-d1d8f1151a96.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18955,7 +18955,7 @@
         },
         {
             "id": "b5fb48f9-2600-5848-8853-fc424b7fce4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e906bdc0-3b04-46ed-a162-92a366319cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e906bdc0-3b04-46ed-a162-92a366319cbf.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18993,7 +18993,7 @@
         },
         {
             "id": "f139dcb5-ff4f-5a98-a800-d178f75c7e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a63c166-93c2-4c56-a202-1f9dc40fd557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a63c166-93c2-4c56-a202-1f9dc40fd557.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -19031,7 +19031,7 @@
         },
         {
             "id": "b0a97442-4428-5ac1-ae75-592bea27c715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e8c5ea-12a2-44b6-a0b6-6c7cea1119f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e8c5ea-12a2-44b6-a0b6-6c7cea1119f3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -19069,7 +19069,7 @@
         },
         {
             "id": "49919d42-86af-5e88-8ae9-faecde4dd352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be9bbc9-77f2-4a61-b19f-30f2e61b8e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be9bbc9-77f2-4a61-b19f-30f2e61b8e88.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -19107,7 +19107,7 @@
         },
         {
             "id": "a1894399-9835-5631-ba79-14faff2d1de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa04994a-4295-4be6-90c8-8f67fabd2e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa04994a-4295-4be6-90c8-8f67fabd2e99.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -19145,7 +19145,7 @@
         },
         {
             "id": "84e2902d-1424-55e6-807d-e27e4ca6a156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b20aa40-2b88-4cac-ad15-f730fde60643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b20aa40-2b88-4cac-ad15-f730fde60643.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -19183,7 +19183,7 @@
         },
         {
             "id": "9925eaed-421f-53fe-8dcd-e73d4d0c2beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1814fc7a-0f2a-407c-9d71-e7a7339ce82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1814fc7a-0f2a-407c-9d71-e7a7339ce82c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -19221,7 +19221,7 @@
         },
         {
             "id": "682a161e-1e43-5cf3-8eb5-3a55b19676a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb0e442-cd29-4dde-a7c5-6eed5df5cfe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb0e442-cd29-4dde-a7c5-6eed5df5cfe9.jpg?1",
             "name": "Glaring Fleshraker",
             "text": "",
             "colours": [],
@@ -19253,7 +19253,7 @@
         },
         {
             "id": "2271e8bc-8443-5a6c-afbd-50a2cc97cc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7310b5b-a0ba-4779-a7d0-aecab2608991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7310b5b-a0ba-4779-a7d0-aecab2608991.jpg?1",
             "name": "Wastescape Battlemage",
             "text": "",
             "colours": [],
@@ -19288,7 +19288,7 @@
         },
         {
             "id": "e43b7eab-4d2a-53f4-84ae-84427488321e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca4a34-016a-4bc6-b0b3-745fc99254e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca4a34-016a-4bc6-b0b3-745fc99254e3.jpg?1",
             "name": "Jolted Awake",
             "text": "",
             "colours": [
@@ -19322,7 +19322,7 @@
         },
         {
             "id": "34b98f93-bc2d-5435-9da9-344642c15f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8028519d-8f1e-43c1-9e1a-2162a91c7e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8028519d-8f1e-43c1-9e1a-2162a91c7e16.jpg?1",
             "name": "Bespoke Battlewagon",
             "text": "",
             "colours": [
@@ -19357,7 +19357,7 @@
         },
         {
             "id": "c68f9280-83e9-5a1c-8b6d-45f38b2922de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9b743b-340d-4a15-a71d-d3108adbdc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9b743b-340d-4a15-a71d-d3108adbdc45.jpg?1",
             "name": "Roil Cartographer",
             "text": "",
             "colours": [
@@ -19393,7 +19393,7 @@
         },
         {
             "id": "23689285-fbf6-5044-81f6-7682bcc97805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb0ba5-67c5-4b04-b604-27182878be1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb0ba5-67c5-4b04-b604-27182878be1a.jpg?1",
             "name": "Accursed Marauder",
             "text": "",
             "colours": [
@@ -19430,7 +19430,7 @@
         },
         {
             "id": "60c3de45-8c59-5e66-9e9e-193931c3f8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce50742-3eef-417e-8042-046969e9ea01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce50742-3eef-417e-8042-046969e9ea01.jpg?1",
             "name": "Amped Raptor",
             "text": "",
             "colours": [
@@ -19465,7 +19465,7 @@
         },
         {
             "id": "e3fb0eff-5b06-5c37-9aaa-ca1773239d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a7c05e-abe8-44fc-b64b-1d59b7629f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a7c05e-abe8-44fc-b64b-1d59b7629f51.jpg?1",
             "name": "Unstable Amulet",
             "text": "",
             "colours": [
@@ -19499,7 +19499,7 @@
         },
         {
             "id": "ea3f76f1-8ce7-5bc7-a508-4675bbcac5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a78f479-aa17-417a-a81b-e8747656ba23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a78f479-aa17-417a-a81b-e8747656ba23.jpg?1",
             "name": "Izzet Generatorium",
             "text": "",
             "colours": [
@@ -19534,7 +19534,7 @@
         },
         {
             "id": "217b60de-5c64-5def-a81a-24a556b35d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4a6113-1db4-42d0-92b8-5fdc431d96ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4a6113-1db4-42d0-92b8-5fdc431d96ea.jpg?1",
             "name": "Scurry of Gremlins",
             "text": "",
             "colours": [
@@ -19569,7 +19569,7 @@
         },
         {
             "id": "00b9ad30-63a7-591f-9612-4ae91267c6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3a5a5-9cb1-4ee5-b7b2-d870c9a56097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3a5a5-9cb1-4ee5-b7b2-d870c9a56097.jpg?1",
             "name": "Snapping Voidcraw",
             "text": "",
             "colours": [],
@@ -19604,7 +19604,7 @@
         },
         {
             "id": "5c687ab9-5ff0-57f9-9c14-d6a20b38c0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907e314e-b346-4bc0-8754-3d436cbe1360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907e314e-b346-4bc0-8754-3d436cbe1360.jpg?1",
             "name": "Titans' Vanguard",
             "text": "",
             "colours": [],
@@ -19638,7 +19638,7 @@
         },
         {
             "id": "ea7e2411-f22c-5539-b552-70182906a6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2f68d-7192-407b-a59f-efa8578d9975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2f68d-7192-407b-a59f-efa8578d9975.jpg?1",
             "name": "Solar Transformer",
             "text": "",
             "colours": [],
@@ -19667,7 +19667,7 @@
         },
         {
             "id": "518c2d6c-2fca-5d48-96ad-165823e21762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097049b-c25e-43ea-8de5-d708b058a556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097049b-c25e-43ea-8de5-d708b058a556.jpg?1",
             "name": "Tranquil Landscape",
             "text": "",
             "colours": [],
@@ -19700,7 +19700,7 @@
         },
         {
             "id": "7739c063-2628-5653-b5c9-4bb5ab62f382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d647d67-f963-43b4-ade8-6c90e91f65ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d647d67-f963-43b4-ade8-6c90e91f65ac.jpg?1",
             "name": "Twisted Landscape",
             "text": "",
             "colours": [],
@@ -19733,7 +19733,7 @@
         },
         {
             "id": "2eaa66cd-5e8a-5f41-b5f5-2a9c4fdcfc5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450bfe1d-a51b-4e45-a0f4-fc72ed94caa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450bfe1d-a51b-4e45-a0f4-fc72ed94caa4.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -19761,7 +19761,7 @@
         },
         {
             "id": "a3a80ea5-71d6-53db-bad7-cf358cf02df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0645cf05-4660-4a6e-b789-7e0f6b7660c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0645cf05-4660-4a6e-b789-7e0f6b7660c0.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -19793,7 +19793,7 @@
         },
         {
             "id": "e9d0c3ba-e49f-509b-8227-f39558f12f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe9d826-2642-4dc8-9dfd-0526394d43ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe9d826-2642-4dc8-9dfd-0526394d43ac.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -19828,7 +19828,7 @@
         },
         {
             "id": "dbe4ac1a-dff9-5388-8576-e73064037539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bacab2-a4c6-4ba5-a208-6bd09ae4cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bacab2-a4c6-4ba5-a208-6bd09ae4cf9f.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -19863,7 +19863,7 @@
         },
         {
             "id": "d9743436-0dec-5c72-bfc5-54668a38d036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c5bcf-1fdd-4d73-a92b-223292da00ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c5bcf-1fdd-4d73-a92b-223292da00ca.jpg?1",
             "name": "Cat Warrior",
             "text": "",
             "colours": [
@@ -19899,7 +19899,7 @@
         },
         {
             "id": "7c686f3c-cba1-533b-ab0f-9461135cb7c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d906e-e5c2-48ad-b7b0-f740ea4447ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d906e-e5c2-48ad-b7b0-f740ea4447ff.jpg?1",
             "name": "Fox",
             "text": "",
             "colours": [
@@ -19934,7 +19934,7 @@
         },
         {
             "id": "cb355e8f-f11b-5c4d-8e3d-8ef722795c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17648a0-f680-429d-8dda-2b0c14f3d80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17648a0-f680-429d-8dda-2b0c14f3d80a.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -19969,7 +19969,7 @@
         },
         {
             "id": "024bf013-7a87-531a-a8ad-277eea89f07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aa2f5e-9809-4e97-b9b2-9c9a322a8e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aa2f5e-9809-4e97-b9b2-9c9a322a8e21.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20004,7 +20004,7 @@
         },
         {
             "id": "fa9eac92-3a7d-5b17-8320-f046addea8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7222593-5ade-4512-bfee-6126d4d0cc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7222593-5ade-4512-bfee-6126d4d0cc19.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -20039,7 +20039,7 @@
         },
         {
             "id": "bc7e93bc-db60-52f7-aeb7-ccc93c41e1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e081becb-40f1-4151-aea3-5a9a9bd672c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e081becb-40f1-4151-aea3-5a9a9bd672c6.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -20074,7 +20074,7 @@
         },
         {
             "id": "edf11a1d-f2a7-5888-9243-6dde2db4dbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9155825a-6449-4b36-aa14-4c227075ed51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9155825a-6449-4b36-aa14-4c227075ed51.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -20109,7 +20109,7 @@
         },
         {
             "id": "6a48d751-7da2-5ec5-9e3d-0697870d6a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10136b4b-ccc1-48ce-bc8c-295660464cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10136b4b-ccc1-48ce-bc8c-295660464cf7.jpg?1",
             "name": "Moonfolk",
             "text": "",
             "colours": [
@@ -20144,7 +20144,7 @@
         },
         {
             "id": "e8749ef0-5281-5142-9c43-c89478006681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a7adb3-8e66-4e63-95f2-1a5f5827b676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a7adb3-8e66-4e63-95f2-1a5f5827b676.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [
@@ -20180,7 +20180,7 @@
         },
         {
             "id": "faebb681-5591-50ad-977a-337a4ec0686e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b8f3b4-d0f3-4f2f-8e6f-7da1e852dac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b8f3b4-d0f3-4f2f-8e6f-7da1e852dac1.jpg?1",
             "name": "Whale",
             "text": "",
             "colours": [
@@ -20215,7 +20215,7 @@
         },
         {
             "id": "001dd45c-851b-5eb3-9a53-fc9fb2c0e322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef58164-4155-4e5b-8c16-f16f2ab65baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef58164-4155-4e5b-8c16-f16f2ab65baa.jpg?1",
             "name": "Fanatic of Rhonas",
             "text": "",
             "colours": [
@@ -20252,7 +20252,7 @@
         },
         {
             "id": "be06fa30-58eb-5c66-a6a0-8ba4e57af9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec719dc-6b07-4b1d-a79c-84ebced33422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec719dc-6b07-4b1d-a79c-84ebced33422.jpg?1",
             "name": "Phyrexian Germ",
             "text": "",
             "colours": [
@@ -20288,7 +20288,7 @@
         },
         {
             "id": "ed84d86c-78c7-527a-a8ed-ba64a1429eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7800c9-6808-4f33-87ad-50ad8c79f2d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7800c9-6808-4f33-87ad-50ad8c79f2d7.jpg?1",
             "name": "Phyrexian Wurm",
             "text": "",
             "colours": [
@@ -20325,7 +20325,7 @@
         },
         {
             "id": "2a288bf4-93b7-5dee-8e23-6d58e0cfc0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482ab42-875c-46fc-aa0b-b18154488985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482ab42-875c-46fc-aa0b-b18154488985.jpg?1",
             "name": "Phyrexian Wurm",
             "text": "",
             "colours": [
@@ -20362,7 +20362,7 @@
         },
         {
             "id": "c8266738-dc3a-5b7e-8a53-2ef29c92d37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3054ecd-0f8a-439d-ab7c-129d5aa0ccb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3054ecd-0f8a-439d-ab7c-129d5aa0ccb2.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -20397,7 +20397,7 @@
         },
         {
             "id": "affc1692-059c-5ac7-952c-e53bfc9d1542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9be7c2-efe5-4d37-a43e-ddcd50a77aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9be7c2-efe5-4d37-a43e-ddcd50a77aa9.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -20432,7 +20432,7 @@
         },
         {
             "id": "03a1849a-11cc-587a-b68a-4d4ee2e68232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909387e1-dc33-446c-825f-07c915ad73ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909387e1-dc33-446c-825f-07c915ad73ee.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -20467,7 +20467,7 @@
         },
         {
             "id": "90194dcf-b927-5f58-87bc-4924425daa4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505a3bc6-deab-410e-a58e-e3b5f0f21e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505a3bc6-deab-410e-a58e-e3b5f0f21e3d.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -20503,7 +20503,7 @@
         },
         {
             "id": "2c5e04d9-23ef-503d-aa81-5678f40fc581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af08a84-4a57-4c94-a290-31d93f79db83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af08a84-4a57-4c94-a290-31d93f79db83.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -20538,7 +20538,7 @@
         },
         {
             "id": "b1ada3a2-f010-583d-85f8-6d7d496a70a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b63bd0-0b61-4a87-928f-95fc6b5a3150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b63bd0-0b61-4a87-928f-95fc6b5a3150.jpg?1",
             "name": "Spellgorger Weird",
             "text": "",
             "colours": [
@@ -20573,7 +20573,7 @@
         },
         {
             "id": "52626921-713d-5fbe-823b-c222119520aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e9d51-c7bf-41c0-a6f0-c0bbc6d3b434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e9d51-c7bf-41c0-a6f0-c0bbc6d3b434.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -20608,7 +20608,7 @@
         },
         {
             "id": "11535942-2557-5fbb-9d19-cc263ebb9d89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3a058-3e25-4bb9-895b-ad2285c50bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3a058-3e25-4bb9-895b-ad2285c50bca.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -20643,7 +20643,7 @@
         },
         {
             "id": "d43a8a70-5a2c-5c27-b20f-c0c8d0766750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bc4cb0-60d4-4c8f-a420-8bfe635154cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bc4cb0-60d4-4c8f-a420-8bfe635154cd.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -20680,7 +20680,7 @@
         },
         {
             "id": "410b9b26-6c7e-59e7-a366-695781154d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef77c8eb-aa24-46d5-8036-6651c7602383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef77c8eb-aa24-46d5-8036-6651c7602383.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20717,7 +20717,7 @@
         },
         {
             "id": "30b07a0a-3f08-54ee-be36-82e81be8faf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3364c1cf-e036-4ba2-a8ae-20e995610311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3364c1cf-e036-4ba2-a8ae-20e995610311.jpg?1",
             "name": "Blood",
             "text": "",
             "colours": [],
@@ -20748,7 +20748,7 @@
         },
         {
             "id": "27887612-3a17-5445-afde-bb96a6da5aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604b9ca-6c5a-459e-b509-955c3428530a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604b9ca-6c5a-459e-b509-955c3428530a.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -20779,7 +20779,7 @@
         },
         {
             "id": "c71c9643-4101-5306-9514-9a7004d811df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fe0b7c-2d73-4c21-98ca-ee3a7d7f20c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fe0b7c-2d73-4c21-98ca-ee3a7d7f20c8.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -20810,7 +20810,7 @@
         },
         {
             "id": "c682b365-1b9b-5833-a24c-3a069e47764f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee5119d-f76c-44c7-bf82-34aabb4d2e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee5119d-f76c-44c7-bf82-34aabb4d2e69.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -20843,7 +20843,7 @@
         },
         {
             "id": "3363ed10-f27c-5516-979e-24cb9e524dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165814-3eb8-4d94-b9c8-ecc798afe7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165814-3eb8-4d94-b9c8-ecc798afe7a0.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -20875,7 +20875,7 @@
         },
         {
             "id": "258bb001-94da-5756-8510-0e20289462ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1141c3fe-1adf-48ab-ac05-079b081788cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1141c3fe-1adf-48ab-ac05-079b081788cc.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -20906,7 +20906,7 @@
         },
         {
             "id": "85dcec74-7d88-516b-9819-ada71d71e0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88e2bea-9c95-447e-bc9d-7d7f8ea40567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88e2bea-9c95-447e-bc9d-7d7f8ea40567.jpg?1",
             "name": "Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [],
@@ -20934,7 +20934,7 @@
         },
         {
             "id": "ddc9a92f-9fc8-5a18-ba5c-73d8e1202cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c516212-ad39-4396-8e05-ae57f100309f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c516212-ad39-4396-8e05-ae57f100309f.jpg?1",
             "name": "Energy Reserve",
             "text": "",
             "colours": [],
@@ -20962,7 +20962,7 @@
         },
         {
             "id": "fdc7aa74-0ebb-5ec9-987d-82b3714dd8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a016157-6f3f-4fb2-b962-1f548d378545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a016157-6f3f-4fb2-b962-1f548d378545.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -20990,7 +20990,7 @@
         },
         {
             "id": "05897422-e2c4-5f20-93af-97fe0ba44515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32795e1-5548-43ef-8cd6-c605a19ef708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32795e1-5548-43ef-8cd6-c605a19ef708.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -21022,7 +21022,7 @@
         },
         {
             "id": "ac0893be-5124-5b96-be09-690fcd16b1d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c923eed-3d09-4b38-a884-513700aebca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c923eed-3d09-4b38-a884-513700aebca3.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -21057,7 +21057,7 @@
         },
         {
             "id": "8b7dac8b-69c6-56c3-8fd9-f25fb52ba236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b1dfdc-09cf-4b87-a6c1-a78ba51e1133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b1dfdc-09cf-4b87-a6c1-a78ba51e1133.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -21092,7 +21092,7 @@
         },
         {
             "id": "34320c28-6922-5da5-99c8-9ef5b135c14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909f85b2-0d7b-42ac-a0b7-402e20cedab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909f85b2-0d7b-42ac-a0b7-402e20cedab4.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -21127,7 +21127,7 @@
         },
         {
             "id": "77d0369d-a75c-5b97-9f61-0ed7f830f121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e85e215-29d0-4ff6-9e42-9ce84b5280cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e85e215-29d0-4ff6-9e42-9ce84b5280cf.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -21164,7 +21164,7 @@
         },
         {
             "id": "7c5cdbc2-a953-53bd-81dd-9a5c8fbedb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a7e037-9f56-4a77-a09e-caeafbb86d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a7e037-9f56-4a77-a09e-caeafbb86d7c.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MID.json
+++ b/Assets/Resources/Sets/MID.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f10c65cc-1a64-552e-b53c-f825ca89d5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18092f68-b96e-4084-9eba-b240d2195d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18092f68-b96e-4084-9eba-b240d2195d81.jpg?1",
             "name": "Adeline, Resplendent Cathar",
             "text": "Vigilance\nAdeline, Resplendent Cathar's power is equal to the number of creatures you control.\nWhenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.",
             "colours": [
@@ -43,7 +43,7 @@
         },
         {
             "id": "cf968d16-027f-5970-a3a3-cb2f49e8dca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1",
             "name": "Ambitious Farmhand // Seasoned Cathar",
             "text": "When Ambitious Farmhand enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nCoven \u2014 {1}{W}{W}: Transform Ambitious Farmhand. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "12b1f13f-af09-5197-85f7-104ec020bdd5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1",
             "name": "Ambitious Farmhand // Seasoned Cathar",
             "text": "Lifelink",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "13d054c7-4c25-5425-8b39-01fed17ebca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg?1",
             "name": "Beloved Beggar // Generous Soul",
             "text": "Disturb {4}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "0fb19178-de6a-5410-9506-4fed53ffbd36",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg?1",
             "name": "Beloved Beggar // Generous Soul",
             "text": "Flying, vigilance\nIf Generous Soul would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "295b974a-b0ee-59f3-829e-6f9912c9c9b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg?1",
             "name": "Bereaved Survivor // Dauntless Avenger",
             "text": "When another creature you control dies, transform Bereaved Survivor.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "dac4f4fa-81e7-5a11-a425-19817f894866",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg?1",
             "name": "Bereaved Survivor // Dauntless Avenger",
             "text": "Whenever Dauntless Avenger attacks, return target creature card with mana value 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "87f85d5d-834c-589d-9738-1983bba0ded8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1555cdcb-3471-4ee7-99c3-d05311bf433c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1555cdcb-3471-4ee7-99c3-d05311bf433c.jpg?1",
             "name": "Blessed Defiance",
             "text": "Target creature you control gets +2/+0 and gains lifelink until end of turn. When that creature dies this turn, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -284,7 +284,7 @@
         },
         {
             "id": "521e339e-756d-5f38-bf2b-f4070e304ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeef24b-b937-408e-a32e-1a546d3e7b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeef24b-b937-408e-a32e-1a546d3e7b0f.jpg?1",
             "name": "Borrowed Time",
             "text": "When Borrowed Time enters the battlefield, exile target nonland permanent an opponent controls until Borrowed Time leaves the battlefield.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "c1527b1d-ced8-5f09-ae7f-5401a36eb7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "When this creature enters the battlefield or transforms into Brutal Cathar, exile target creature an opponent controls until this creature leaves the battlefield.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "87690b59-8c3b-519a-a1f5-c621dece7f24",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "First strike\nWard\u2014\nPay 3 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "92e0f198-040e-57c9-9ba8-52f77a4b5e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfe6ea-cd43-4ec4-83a1-1f0f74e27f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfe6ea-cd43-4ec4-83a1-1f0f74e27f56.jpg?1",
             "name": "Candlegrove Witch",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Candlegrove Witch gains flying until end of turn.",
             "colours": [
@@ -429,7 +429,7 @@
         },
         {
             "id": "6aae96ba-4c2f-5ab9-9e63-082dbe5f83f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32869a36-f21e-4348-a787-871daa6151df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32869a36-f21e-4348-a787-871daa6151df.jpg?1",
             "name": "Candletrap",
             "text": "Enchant creature\nEnchanted creature has defender.\nPrevent all combat damage that would be dealt by enchanted creature.\nCoven \u2014 {2}{W}, Sacrifice Candletrap: Exile enchanted creature. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "32fd4594-c94a-57bb-8e46-84ea6e84047a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cbc1c2-b76e-4da3-aa43-00e10b2ce532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cbc1c2-b76e-4da3-aa43-00e10b2ce532.jpg?1",
             "name": "Cathar Commando",
             "text": "Flash\n{1}, Sacrifice Cathar Commando: Destroy target artifact or enchantment.",
             "colours": [
@@ -498,7 +498,7 @@
         },
         {
             "id": "f87cf043-7e7d-5ad9-90c4-73e41c900171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d044a9-0149-4302-86e5-90623e54e36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d044a9-0149-4302-86e5-90623e54e36b.jpg?1",
             "name": "Cathar's Call",
             "text": "Enchant creature\nEnchanted creature has vigilance and \"At the beginning of your end step, create a 1/1 white Human creature token.\"",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "d519cdc0-a79d-5cee-95d1-1c16f676f6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67547253-ab98-4d3a-bf95-3e109cf60a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67547253-ab98-4d3a-bf95-3e109cf60a85.jpg?1",
             "name": "Celestus Sanctifier",
             "text": "If it's neither day nor night, it becomes day as Celestus Sanctifier enters the battlefield.\nWhenever day becomes night or night becomes day, look at the top two cards of your library. Put one of them into your graveyard.",
             "colours": [
@@ -567,7 +567,7 @@
         },
         {
             "id": "e4c2e25a-d7f5-56dc-8237-ae4050a7949f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg?1",
             "name": "Chaplain of Alms // Chapel Shieldgeist",
             "text": "First strike\nWard {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nDisturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "928536d7-8475-5394-9952-29a1b168046f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg?1",
             "name": "Chaplain of Alms // Chapel Shieldgeist",
             "text": "Flying, first strike\nEach creature you control has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nIf Chapel Shieldgeist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -637,7 +637,7 @@
         },
         {
             "id": "93e1791d-78b8-5af2-9c58-d51bdd2e2894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8ea28-7de1-4908-8e2d-b1aeff651015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8ea28-7de1-4908-8e2d-b1aeff651015.jpg?1",
             "name": "Clarion Cathars",
             "text": "When Clarion Cathars enters the battlefield, create a 1/1 white Human creature token.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "1a655a52-ec4a-5635-aff4-0191b485936e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7819d5-12a9-4719-91b2-8dd1ba6f3800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7819d5-12a9-4719-91b2-8dd1ba6f3800.jpg?1",
             "name": "Curse of Silence",
             "text": "Enchant player\nAs Curse of Silence enters the battlefield, choose a card name.\nSpells with the chosen name enchanted player casts cost {2} more to cast.\nWhenever enchanted player casts a spell with the chosen name, you may sacrifice Curse of Silence. If you do, draw a card.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "1bf7dfc9-eef6-514d-8def-2c827da0bd60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75855c-88dc-4491-8045-080debfeb7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75855c-88dc-4491-8045-080debfeb7b5.jpg?1",
             "name": "Duelcraft Trainer",
             "text": "First strike\nCoven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "d0c91a01-91ab-54a6-844e-110e2879df19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying, double strike\nYou have hexproof.\nIf your life total would be reduced to 0 or less, instead transform Enduring Angel and your life total becomes 3. Then if Enduring Angel didn't transform this way, you lose the game.",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "ecda1506-87f2-5e5c-8c9d-d13e695a5531",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying\nYou have hexproof.\nAngelic Enforcer's power and toughness are each equal to your life total.\nWhenever Angelic Enforcer attacks, double your life total.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "4ea85441-084c-5fd5-b199-91d972a09078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca8d6f8-c6f1-437c-99e2-4281eae14a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca8d6f8-c6f1-437c-99e2-4281eae14a6f.jpg?1",
             "name": "Fateful Absence",
             "text": "Destroy target creature or planeswalker. Its controller investigates. (They create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "c4463eec-180c-5aab-8df8-61032a908aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4354c6-ea21-46c0-93c4-744dbacbfcf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4354c6-ea21-46c0-93c4-744dbacbfcf4.jpg?1",
             "name": "Flare of Faith",
             "text": "Target creature gets +2/+2 until end of turn. If it's a Human, instead it gets +3/+3 and gains indestructible until end of turn.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "3d429a43-5ba4-5c93-8b73-d2382a02a779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58891dae-1c59-4f53-82ec-5b4c47133182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58891dae-1c59-4f53-82ec-5b4c47133182.jpg?1",
             "name": "Gavony Dawnguard",
             "text": "Ward {1}\nIf it's neither day nor night, it becomes day as Gavony Dawnguard enters the battlefield.\nWhenever day becomes night or night becomes day, look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "fb6c5c0a-bb71-5c5a-88b6-2d15b004b655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c53b007-96aa-4db6-8c3e-529d1e845b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c53b007-96aa-4db6-8c3e-529d1e845b19.jpg?1",
             "name": "Gavony Silversmith",
             "text": "When Gavony Silversmith enters the battlefield, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "5eb37ea3-b3c0-5059-acd2-b8f128a5b86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1309ea-4411-4116-841f-5aef8611400c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1309ea-4411-4116-841f-5aef8611400c.jpg?1",
             "name": "Gavony Trapper",
             "text": "{2}, {T}: Tap target creature.",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "252edc2e-5c64-5f76-86e4-53a49200787a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97321072-1f7f-413b-9246-e6b3ec7a8c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97321072-1f7f-413b-9246-e6b3ec7a8c30.jpg?1",
             "name": "Hedgewitch's Mask",
             "text": "Equipped creature gets +1/+1.\nEquipped creature can't be blocked by creatures with power 4 or greater.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "f2f6f3f8-e31e-5ff2-8d74-87f365153bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a9c49f-fcd3-4572-bac7-6eb06fdc0815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a9c49f-fcd3-4572-bac7-6eb06fdc0815.jpg?1",
             "name": "Homestead Courage",
             "text": "Put a +1/+1 counter on target creature you control. It gains vigilance until end of turn.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "90af122d-e6d2-51ab-9cbf-a5e19b50fddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773199f9-c83b-4a77-8342-9f1552ecf595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773199f9-c83b-4a77-8342-9f1552ecf595.jpg?1",
             "name": "Intrepid Adversary",
             "text": "Lifelink\nWhen Intrepid Adversary enters the battlefield, you may pay {1}{W} any number of times. When you pay this cost one or more times, put that many valor counters on Intrepid Adversary.\nCreatures you control get +1/+1 for each valor counter on Intrepid Adversary.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "12fbc3ed-001e-53a3-9cd3-730812fa18cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d41ac4-3273-4722-aaa6-ceeba66cf591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d41ac4-3273-4722-aaa6-ceeba66cf591.jpg?1",
             "name": "Loyal Gryff",
             "text": "Flash\nFlying\nWhen Loyal Gryff enters the battlefield, you may return another creature you control to its owner's hand.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "32ec1f14-eabe-544f-b58e-ffaa718462db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg?1",
             "name": "Lunarch Veteran // Luminous Phantom",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.\nDisturb {1}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "1647f9b2-2f43-5b1e-badf-138b00360bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg?1",
             "name": "Lunarch Veteran // Luminous Phantom",
             "text": "Flying\nWhenever another creature you control leaves the battlefield, you gain 1 life.\nIf Luminous Phantom would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "7233d817-024f-59b6-9e08-21c796a663cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg?1",
             "name": "Mourning Patrol // Morning Apparition",
             "text": "Vigilance\nDisturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "43157e91-b4ed-581b-a195-821c90b12fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg?1",
             "name": "Mourning Patrol // Morning Apparition",
             "text": "Flying, vigilance\nIf Morning Apparition would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "97f82d30-6cc9-5a93-8a3c-1ce28ec6e18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016f837-cc19-43f1-adb9-96bdd3195407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016f837-cc19-43f1-adb9-96bdd3195407.jpg?1",
             "name": "Odric's Outrider",
             "text": "Whenever Odric's Outrider or another creature you control dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1301,7 +1301,7 @@
         },
         {
             "id": "84260dd7-a7d7-53ba-9746-438fb33524ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f077f07e-4660-4483-b6ea-16cca0956892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f077f07e-4660-4483-b6ea-16cca0956892.jpg?1",
             "name": "Ritual Guardian",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Ritual Guardian gains lifelink until end of turn.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "725848a0-6588-504e-9d9b-cee059a3b0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8293903-4604-4516-866e-27a306b6fd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8293903-4604-4516-866e-27a306b6fd7c.jpg?1",
             "name": "Ritual of Hope",
             "text": "Creatures you control get +1/+1 until end of turn.\nCoven \u2014 If you control three or more creatures with different powers, creatures you control get +2/+1 until end of turn instead.",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "c2ec7748-a817-5bd6-897d-1173cebe1d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9006c1-2e6f-4bca-a1c4-3cf2a8b6e964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9006c1-2e6f-4bca-a1c4-3cf2a8b6e964.jpg?1",
             "name": "Search Party Captain",
             "text": "This spell costs {1} less to cast for each creature you attacked with this turn.\nWhen Search Party Captain enters the battlefield, draw a card.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "fa5f6ea3-6634-591f-9df8-4aeda06db41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb22626d-84ef-40d1-a4f2-771b45198eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb22626d-84ef-40d1-a4f2-771b45198eaa.jpg?1",
             "name": "Sigarda's Splendor",
             "text": "As Sigarda's Splendor enters the battlefield, note your life total.\nAt the beginning of your upkeep, draw a card if your life total is greater than or equal to the last noted life total for Sigarda's Splendor. Then note your life total.\nWhenever you cast a white spell, you gain 1 life.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "2e371926-8d4b-5e12-a4c5-d447eec20f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a2b41a-34b0-428e-80ec-3ffd601093a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a2b41a-34b0-428e-80ec-3ffd601093a2.jpg?1",
             "name": "Sigardian Savior",
             "text": "Flying\nWhen Sigardian Savior enters the battlefield, if you cast it, return up to two target creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1473,7 +1473,7 @@
         },
         {
             "id": "72d0bacf-d8da-55c3-ad96-3d4f6b9ef2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1031bb-af9f-4446-8b36-b0bb9aa5997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1031bb-af9f-4446-8b36-b0bb9aa5997a.jpg?1",
             "name": "Soul-Guide Gryff",
             "text": "Flying\nWhen Soul-Guide Gryff enters the battlefield, exile up to one target card from a graveyard.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "9b0f4130-fd15-5620-ad8c-77c06f631505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee507688-9890-47c4-bb04-43c51eb48e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee507688-9890-47c4-bb04-43c51eb48e22.jpg?1",
             "name": "Sungold Barrage",
             "text": "Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "8cbb3552-62b4-5a6c-b394-2389863e52f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e1afd0-49d4-4657-ab75-98b0bfbfb245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e1afd0-49d4-4657-ab75-98b0bfbfb245.jpg?1",
             "name": "Sungold Sentinel",
             "text": "Whenever Sungold Sentinel enters the battlefield or attacks, exile up to one target card from a graveyard.\nCoven \u2014 {1}{W}: Choose a color. Sungold Sentinel gains hexproof from that color until end of turn and can't be blocked by creatures of that color this turn. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "b00532a8-231b-54aa-b552-f12bb3ae79d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b39ef1-29d4-4c8d-aece-a3f1ce008e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b39ef1-29d4-4c8d-aece-a3f1ce008e2d.jpg?1",
             "name": "Sunset Revelry",
             "text": "If an opponent has more life than you, you gain 4 life.\nIf an opponent controls more creatures than you, create two 1/1 white Human creature tokens.\nIf an opponent has more cards in hand than you, draw a card.",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "8fbe0122-96d0-56b9-9597-b3c5fa2491ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0700298-30d2-45a6-bd64-4fd7fa4d7d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0700298-30d2-45a6-bd64-4fd7fa4d7d30.jpg?1",
             "name": "Thraben Exorcism",
             "text": "Exile target Spirit, creature with disturb, or enchantment.",
             "colours": [
@@ -1641,7 +1641,7 @@
         },
         {
             "id": "db50a92b-842d-5029-82ce-614db9742a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f48622a-abf3-407f-921f-77c29d59ba8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f48622a-abf3-407f-921f-77c29d59ba8e.jpg?1",
             "name": "Unruly Mob",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Unruly Mob.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "d1b58df4-7ac7-5e4e-98cd-b8bbc6245bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264615c-eb99-4cb3-844a-2b4a94ba5203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264615c-eb99-4cb3-844a-2b4a94ba5203.jpg?1",
             "name": "Vanquish the Horde",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nDestroy all creatures.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "a3f7eeea-918b-50c5-82b5-3a9bc03c0329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg?1",
             "name": "Baithook Angler // Hook-Haunt Drifter",
             "text": "Disturb {1}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "f7669195-e6de-5426-bc86-a7116a20e359",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg?1",
             "name": "Baithook Angler // Hook-Haunt Drifter",
             "text": "Flying\nIf Hook-Haunt Drifter would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "985ee93c-16df-5e13-b3b2-59b1988ac0d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b74fc-1355-4668-838b-e8927794608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b74fc-1355-4668-838b-e8927794608c.jpg?1",
             "name": "Component Collector",
             "text": "If it's neither day nor night, it becomes day as Component Collector enters the battlefield.\nWhenever day becomes night or night becomes day, you may tap or untap target nonland permanent.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "f50da26d-f479-51bd-a946-7230e27cb0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a211d505-4d40-4914-a9da-220770d6ddbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a211d505-4d40-4914-a9da-220770d6ddbc.jpg?1",
             "name": "Consider",
             "text": "Look at the top card of your library. You may put that card into your graveyard.\nDraw a card.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "b65a9471-c70f-5301-9f83-b166b8de8538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg?1",
             "name": "Covetous Castaway // Ghostly Castigator",
             "text": "When Covetous Castaway dies, mill three cards. (Put the top three cards of your library into your graveyard.)\nDisturb {3}{U}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "44d7534d-add2-55e8-bab1-b124e49dbca1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg?1",
             "name": "Covetous Castaway // Ghostly Castigator",
             "text": "Flying\nWhen Ghostly Castigator enters the battlefield, you may shuffle up to three target cards from your graveyard into your library.\nIf Ghostly Castigator would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "b15a71f6-5940-5c9f-9d02-21197e8179a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a5b3b2-4f27-4c97-9d87-d7bdcc06d36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a5b3b2-4f27-4c97-9d87-d7bdcc06d36a.jpg?1",
             "name": "Curse of Surveillance",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, any number of target players other than that player each draw cards equal to the number of Curses attached to that player.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "d69f5a61-fe28-5677-8a33-5b092b332384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform Delver of Secrets.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "fc7dc7f8-31f1-58f1-aec3-5da76f43d585",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "Flying",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "29ff5371-5959-517b-b67f-2696aea94e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648281fe-89fb-4d8d-b944-3af28fb044f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648281fe-89fb-4d8d-b944-3af28fb044f6.jpg?1",
             "name": "Devious Cover-Up",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may shuffle up to four target cards from your graveyard into your library.",
             "colours": [
@@ -2053,7 +2053,7 @@
         },
         {
             "id": "553df376-6655-5792-826f-aa95cd0c4ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4689b3f2-e4b7-448e-b3d4-ab33194aafb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4689b3f2-e4b7-448e-b3d4-ab33194aafb2.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "6664281e-83d9-5443-b2b2-086739e2535d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b05d44-d987-45e1-bbd9-842dbe58c2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b05d44-d987-45e1-bbd9-842dbe58c2b5.jpg?1",
             "name": "Drownyard Amalgam",
             "text": "When Drownyard Amalgam enters the battlefield, target player mills three cards. (They put the top three cards of their library into their graveyard.)\n{2}{U}: Drownyard Amalgam can't be blocked this turn.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "a36ce463-0ec4-5006-9359-07f7ff04cd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fb1fff-12be-4bd5-8dba-c36e84d49651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fb1fff-12be-4bd5-8dba-c36e84d49651.jpg?1",
             "name": "Fading Hope",
             "text": "Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "8a2e3354-2fcd-5047-b61a-43187fab3995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0668413-859d-4ec4-a4d8-17ec7f5b1b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0668413-859d-4ec4-a4d8-17ec7f5b1b8b.jpg?1",
             "name": "Falcon Abomination",
             "text": "Flying\nWhen Falcon Abomination enters the battlefield, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "832437ff-7da1-5bc2-94ed-897d095f05fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004c1078-0dea-4885-97b5-497f3f15c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004c1078-0dea-4885-97b5-497f3f15c8c3.jpg?1",
             "name": "A-Falcon Abomination",
             "text": "",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "106e0b72-aaad-5fd0-bf3b-f6ec8178e498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db186a1-3dc5-4ed2-8cd4-1e4f13094885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db186a1-3dc5-4ed2-8cd4-1e4f13094885.jpg?1",
             "name": "Firmament Sage",
             "text": "If it's neither day nor night, it becomes day as Firmament Sage enters the battlefield.\nWhenever day becomes night or night becomes day, draw a card.",
             "colours": [
@@ -2256,7 +2256,7 @@
         },
         {
             "id": "6e141203-87ac-58bb-9379-7e3a9c9b53b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cdbe4e3-f030-46fa-ae84-edf261b61706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cdbe4e3-f030-46fa-ae84-edf261b61706.jpg?1",
             "name": "Flip the Switch",
             "text": "Counter target spell unless its controller pays {4}. Create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -2288,7 +2288,7 @@
         },
         {
             "id": "352d1c55-678f-566c-8ce0-25acd9f8b5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg?1",
             "name": "Galedrifter // Waildrifter",
             "text": "Flying\nDisturb {4}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "5d7019fb-0782-5177-9573-2e417c2919cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg?1",
             "name": "Galedrifter // Waildrifter",
             "text": "Flying\nIf Waildrifter would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "6450471f-494c-53c1-b869-7f059ab254b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3d1ac-bec2-4bba-a6cf-a823996dde2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3d1ac-bec2-4bba-a6cf-a823996dde2d.jpg?1",
             "name": "Geistwave",
             "text": "Return target nonland permanent to its owner's hand. If you controlled that permanent, draw a card.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "89d20b1a-e989-504c-b41d-90f72870e0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559846b-03d6-4a2c-97e1-c71f107e9f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559846b-03d6-4a2c-97e1-c71f107e9f24.jpg?1",
             "name": "Grafted Identity",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nEnchant creature\nYou control enchanted creature.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "a4bc221d-5e3e-5566-8e0e-be9d0dabd5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bebd764-e5ed-4164-a9f8-3c595691eb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bebd764-e5ed-4164-a9f8-3c595691eb49.jpg?1",
             "name": "Grafted Identity",
             "text": "",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "f640fa71-5a11-57c6-a3bc-c4b2b7e29c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c0dcac-f3d4-4d6e-9c6e-9295bb1cd47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c0dcac-f3d4-4d6e-9c6e-9295bb1cd47f.jpg?1",
             "name": "Larder Zombie",
             "text": "Defender\nTap three untapped creatures you control: Look at the top card of your library. You may put it into your graveyard.",
             "colours": [
@@ -2496,7 +2496,7 @@
         },
         {
             "id": "f02ee053-d0f7-5821-9120-8638487a9b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fb8900-d28d-4e33-96a7-66fcbc117adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fb8900-d28d-4e33-96a7-66fcbc117adf.jpg?1",
             "name": "Lier, Disciple of the Drowned",
             "text": "Spells can't be countered.\nEach instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "6aba2654-fc6a-5361-b718-ae0604e6deb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a6bf25-4e94-4760-b4f5-69c78ac98fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a6bf25-4e94-4760-b4f5-69c78ac98fb5.jpg?1",
             "name": "A-Lier, Disciple of the Drowned",
             "text": "",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "dc2bb006-7f3d-5885-b010-8abf46602b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68593c6d-8d1b-4c36-84a1-f1144669825e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68593c6d-8d1b-4c36-84a1-f1144669825e.jpg?1",
             "name": "Locked in the Cemetery",
             "text": "Enchant creature\nWhen Locked in the Cemetery enters the battlefield, if there are five or more cards in your graveyard, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "92b79f11-5b30-5de3-b27a-c062d6731386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "{U}, Sacrifice Malevolent Hermit: Counter target noncreature spell unless its controller pays {3}.\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "34d3d6f8-b162-5b00-80c8-a316234837af",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "234ba496-bd60-56db-acc5-0f7d851ed14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fd1b-3dd9-492a-9ed4-0b6743074730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fd1b-3dd9-492a-9ed4-0b6743074730.jpg?1",
             "name": "Memory Deluge",
             "text": "Look at the top X cards of your library, where X is the amount of mana spent to cast this spell. Put two of them into your hand and the rest on the bottom of your library in a random order.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2713,7 +2713,7 @@
         },
         {
             "id": "79525cf3-7def-59a3-915f-3bbbb7a76eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg?1",
             "name": "Mysterious Tome // Chilling Chronicle",
             "text": "{2}, {T}: Draw a card. Transform Mysterious Tome.",
             "colours": [
@@ -2745,7 +2745,7 @@
         },
         {
             "id": "d81d2f12-496a-5046-a7cd-465ba04dedb2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg?1",
             "name": "Mysterious Tome // Chilling Chronicle",
             "text": "{1}, {T}: Tap target nonland permanent. Transform Chilling Chronicle.",
             "colours": [
@@ -2777,7 +2777,7 @@
         },
         {
             "id": "6388141e-c971-507b-8ad7-d117c0dcdfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c801346-0052-4f4b-a497-1567a34679fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c801346-0052-4f4b-a497-1567a34679fb.jpg?1",
             "name": "Nebelgast Intruder",
             "text": "Flash\nFlying\nWhen Nebelgast Intruder enters the battlefield, up to one target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "d4fcdcce-861a-53ef-ae61-6c578c8d9ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf2b49a-56f9-4093-960f-9ec7af8983b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf2b49a-56f9-4093-960f-9ec7af8983b5.jpg?1",
             "name": "Ominous Roost",
             "text": "When Ominous Roost enters the battlefield or whenever you cast a spell from your graveyard, create a 1/1 blue Bird creature token with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "4e48def6-8c1d-572a-af25-24671ef6de8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9716d384-88d1-415e-882f-7fed9be1adc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9716d384-88d1-415e-882f-7fed9be1adc6.jpg?1",
             "name": "Organ Hoarder",
             "text": "When Organ Hoarder enters the battlefield, look at the top three cards of your library, then put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "eba77cde-5080-5dd2-877f-dcaa2b7b0ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebee20-869e-45ed-9ddc-843faf4032ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebee20-869e-45ed-9ddc-843faf4032ad.jpg?1",
             "name": "Otherworldly Gaze",
             "text": "Look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2909,7 +2909,7 @@
         },
         {
             "id": "dddfeab5-6c74-5ce8-8cd5-1ab3c9d3b922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg?1",
             "name": "Overwhelmed Archivist // Archive Haunt",
             "text": "When Overwhelmed Archivist enters the battlefield, draw a card, then discard a card.\nDisturb {3}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "e83597e3-e262-5c77-b746-e94837ce04ce",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg?1",
             "name": "Overwhelmed Archivist // Archive Haunt",
             "text": "Flying\nWhenever Archive Haunt attacks, draw a card, then discard a card.\nIf Archive Haunt would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "62a16a17-5e83-5311-9722-a81f64adfc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2b0c63-c929-42ec-aada-dddb2a26550c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2b0c63-c929-42ec-aada-dddb2a26550c.jpg?1",
             "name": "Patrician Geist",
             "text": "Flying\nOther Spirits you control get +1/+1.\nSpells you cast from your graveyard cost {1} less to cast.",
             "colours": [
@@ -3016,7 +3016,7 @@
         },
         {
             "id": "45d498bd-510b-5e6d-a984-0693af708f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17c4ab2-f455-4195-86d2-b8d039fb27dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17c4ab2-f455-4195-86d2-b8d039fb27dd.jpg?1",
             "name": "A-Patrician Geist",
             "text": "",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "0de7483a-3fa2-59bd-af3c-a6f99a1abf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1990ed41-3739-40f6-8797-359f88af05f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1990ed41-3739-40f6-8797-359f88af05f9.jpg?1",
             "name": "Phantom Carriage",
             "text": "Flying\nWhen Phantom Carriage enters the battlefield, you may search your library for a card with flashback or disturb, put it into your graveyard, then shuffle.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "e71dd4d0-2741-54eb-8483-3b803208a251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a920c-5bd9-4aee-863a-26b4bfd4bf08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a920c-5bd9-4aee-863a-26b4bfd4bf08.jpg?1",
             "name": "A-Phantom Carriage",
             "text": "",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "a0329187-f970-562c-bba2-bb0194634d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)\nAt the beginning of your upkeep, if you control three or more creature tokens, you may transform Poppet Stitcher.",
             "colours": [
@@ -3154,7 +3154,7 @@
         },
         {
             "id": "0fd308b7-9f33-5044-aff1-625c8408caac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Creature tokens you control lose all abilities and have base power and toughness 3/3.\nAt the beginning of your upkeep, you may transform Poppet Factory.",
             "colours": [
@@ -3188,7 +3188,7 @@
         },
         {
             "id": "aad14172-0916-5288-86ed-e0b93ff6495a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7d72-927a-40ce-8de4-04a3f21c134b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7d72-927a-40ce-8de4-04a3f21c134b.jpg?1",
             "name": "Revenge of the Drowned",
             "text": "Target creature's owner puts it on the top or bottom of their library. You create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "36232801-3227-5177-8fc2-90e1e2d0be51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b022ba8-07b6-4993-99c8-89c6dcb19e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b022ba8-07b6-4993-99c8-89c6dcb19e60.jpg?1",
             "name": "Secrets of the Key",
             "text": "Investigate. If this spell was cast from a graveyard, investigate twice instead. (To investigate, create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nFlashback {3}{U}",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "d1a801a7-bfd3-53ba-aa90-10cb48e96579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f295833-a83e-4b18-8007-c7f5d78e5624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f295833-a83e-4b18-8007-c7f5d78e5624.jpg?1",
             "name": "Shipwreck Sifters",
             "text": "When Shipwreck Sifters enters the battlefield, draw a card, then discard a card.\nWhenever you discard a Spirit card or a card with disturb, put a +1/+1 counter on Shipwreck Sifters.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "380c6ba9-9af3-50be-a0b4-fadf855a6eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59feb0fa-3d5f-4712-899c-272f3976ff0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59feb0fa-3d5f-4712-899c-272f3976ff0d.jpg?1",
             "name": "A-Shipwreck Sifters",
             "text": "",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "45b02210-a7cd-5080-926f-2530b1e3dfc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9771d9e8-97d5-44af-8612-dc5c44d65ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9771d9e8-97d5-44af-8612-dc5c44d65ceb.jpg?1",
             "name": "Skaab Wrangler",
             "text": "Tap three untapped creatures you control: Tap target creature.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "afa03201-81a4-5109-8a67-b16e2f3e0c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa9aa8-86d2-4f1e-ac65-ace7e73a853c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa9aa8-86d2-4f1e-ac65-ace7e73a853c.jpg?1",
             "name": "Sludge Monster",
             "text": "Whenever Sludge Monster enters the battlefield or attacks, put a slime counter on up to one other target creature.\nNon-Horror creatures with slime counters on them lose all abilities and have base power and toughness 2/2.",
             "colours": [
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "11931050-93b1-596e-a3f8-2056a0f8313e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67fe04-814f-4051-bd13-7c8ee40a6c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67fe04-814f-4051-bd13-7c8ee40a6c08.jpg?1",
             "name": "Spectral Adversary",
             "text": "Flash\nFlying\nWhen Spectral Adversary enters the battlefield, you may pay {1}{U} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Spectral Adversary, then up to that many other target artifacts, creatures, and/or enchantments phase out.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "ae07bc34-bff9-567b-8cfd-0b8f641a6435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f68eb3-9b40-4967-a52e-f95aec6e3fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f68eb3-9b40-4967-a52e-f95aec6e3fbf.jpg?1",
             "name": "Startle",
             "text": "Target creature gets -2/-0 until end of turn. Create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)\nDraw a card.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "56bbd7ec-2e7a-503a-8c98-f1d6128c1003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a95edb-9f5b-4e42-8b27-0b3d978dcefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a95edb-9f5b-4e42-8b27-0b3d978dcefe.jpg?1",
             "name": "Stormrider Spirit",
             "text": "Flash\nFlying",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "68907426-a42c-5c2f-a4ec-675df6271eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "Suspicious Stowaway can't be blocked.\nWhenever Suspicious Stowaway deals combat damage to a player, draw a card, then discard a card.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "ae246422-37b8-51b2-a6cd-4cecb425f3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "Seafaring Werewolf can't be blocked.\nWhenever Seafaring Werewolf deals combat damage to a player, draw a card.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "b9eedd3b-ab15-5671-88d6-7773e648e656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6750e203-1215-4203-b5b8-3f1b18940839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6750e203-1215-4203-b5b8-3f1b18940839.jpg?1",
             "name": "Triskaidekaphile",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, if you have exactly thirteen cards in your hand, you win the game.\n{3}{U}: Draw a card.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "ab5d5b44-922b-585d-bd13-6f0efa3a57ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8148063c-a509-43ac-a291-c9410c30c2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8148063c-a509-43ac-a291-c9410c30c2f2.jpg?1",
             "name": "Unblinking Observer",
             "text": "{T}: Add {U}. Spend this mana only to pay a disturb cost or cast an instant or sorcery spell.",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "12d64263-ad40-5b61-acda-0583b0e1cfdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6a06-9c36-45a3-a591-183cb5c0f800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6a06-9c36-45a3-a591-183cb5c0f800.jpg?1",
             "name": "Vivisection",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "3189d243-436a-5d3b-862e-8a1e9e4a9cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a9d45-6197-44b6-b0fc-17aeae281b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a9d45-6197-44b6-b0fc-17aeae281b2f.jpg?1",
             "name": "Arrogant Outlaw",
             "text": "When Arrogant Outlaw enters the battlefield, if an opponent lost life this turn, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "5fb25610-27a6-543a-bb03-e4011443bc94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "Whenever Baneblade Scoundrel becomes blocked, each creature blocking it gets -1/-1 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "cd28b695-3e8a-5b31-a534-3b2ccb4ac9f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "Whenever Baneclaw Marauder becomes blocked, each creature blocking it gets -1/-1 until end of turn.\nWhenever a creature blocking Baneclaw Marauder dies, that creature's controller loses 1 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "9e4a27d7-2252-52a0-814c-d71e44b62fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4412c901-0ec8-437a-9d1e-ce318bbe2b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4412c901-0ec8-437a-9d1e-ce318bbe2b03.jpg?1",
             "name": "Bat Whisperer",
             "text": "When Bat Whisperer enters the battlefield, if an opponent lost life this turn, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "1ab43c60-cb2d-5d53-91ce-f126d56eb906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d4713d-321a-447f-a318-88b552ec5d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d4713d-321a-447f-a318-88b552ec5d0c.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "cd9cd29f-0fe1-566d-8de9-c529c7368675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607b1066-1ca0-45e1-a55c-30aed77cc8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607b1066-1ca0-45e1-a55c-30aed77cc8dc.jpg?1",
             "name": "Blood Pact",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "74e7d0fe-fe3e-5e39-8b91-ae3ed8e9acf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac827f7-a587-4adf-8408-2d9ccd9c1343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac827f7-a587-4adf-8408-2d9ccd9c1343.jpg?1",
             "name": "Bloodline Culling",
             "text": "Choose one \u2014\n\u2022 Target creature gets -5/-5 until end of turn.\n\u2022 Creature tokens get -2/-2 until end of turn.",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "5f7bc06f-3935-568c-864f-095a2eb65157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d5e536-7774-4949-8127-727ae4d8fc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d5e536-7774-4949-8127-727ae4d8fc80.jpg?1",
             "name": "Bloodtithe Collector",
             "text": "Flying\nWhen Bloodtithe Collector enters the battlefield, if an opponent lost life this turn, each opponent discards a card.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "4a083762-4c6b-5489-a575-180b7633b4a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e6941-ad6e-4d2f-93c0-be79e75bdf06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e6941-ad6e-4d2f-93c0-be79e75bdf06.jpg?1",
             "name": "Champion of the Perished",
             "text": "Whenever another Zombie enters the battlefield under your control, put a +1/+1 counter on Champion of the Perished.",
             "colours": [
@@ -3985,7 +3985,7 @@
         },
         {
             "id": "9f776bf3-f2b7-5075-9fd0-aa9adbd427c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg?1",
             "name": "Covert Cutpurse // Covetous Geist",
             "text": "When Covert Cutpurse enters the battlefield, destroy target creature you don't control that was dealt damage this turn.\nDisturb {4}{B} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "cbbf6e08-a555-5014-baf5-b97157ce010d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg?1",
             "name": "Covert Cutpurse // Covetous Geist",
             "text": "Flying, deathtouch\nIf Covetous Geist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -4055,7 +4055,7 @@
         },
         {
             "id": "759d9b9e-7db7-5f12-81d0-4c4585af9b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c8942-d43e-4456-ac98-3220cb954c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c8942-d43e-4456-ac98-3220cb954c65.jpg?1",
             "name": "Crawl from the Cellar",
             "text": "Return target creature card from your graveyard to your hand. Put a +1/+1 counter on up to one target Zombie you control.\nFlashback {3}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "805adae5-5bf2-53cc-8dc1-bcce235023d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Enchant player\nAs this permanent transforms into Curse of Leeches, attach it to a player.\nAt the beginning of enchanted player's upkeep, they lose 1 life and you gain 1 life.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "c8aac324-8ba3-504a-bfb8-17611bd252aa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Lifelink\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -4161,7 +4161,7 @@
         },
         {
             "id": "34195e97-2d9d-567c-a447-011277601cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3abdcc-83a8-45c3-9bfd-23f929705018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3abdcc-83a8-45c3-9bfd-23f929705018.jpg?1",
             "name": "Defenestrate",
             "text": "Destroy target creature without flying.",
             "colours": [
@@ -4193,7 +4193,7 @@
         },
         {
             "id": "2ca5751e-8d89-5576-8685-49ebf0fd68c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153be768-ddad-44f2-bcdd-c40353c807d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153be768-ddad-44f2-bcdd-c40353c807d7.jpg?1",
             "name": "Diregraf Horde",
             "text": "When Diregraf Horde enters the battlefield, create two 2/2 black Zombie creature tokens with decayed. When you do, exile up to two target cards from graveyards. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "007d25f9-c442-54a4-8dde-673564814b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd571b-8316-4c60-a042-8bcf4816b126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd571b-8316-4c60-a042-8bcf4816b126.jpg?1",
             "name": "Dreadhound",
             "text": "When Dreadhound enters the battlefield, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhenever a creature dies or a creature card is put into a graveyard from a library, each opponent loses 1 life.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "42f83d7a-2fa1-5e90-99f3-0f650b6e36e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a72721-2a4a-4d48-a7b0-2370b90b8619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a72721-2a4a-4d48-a7b0-2370b90b8619.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "f4d6ccf8-b53d-59f7-85c5-4c53277e9457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7975a3c-570a-4bff-a60d-d274f758b93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7975a3c-570a-4bff-a60d-d274f758b93f.jpg?1",
             "name": "Eaten Alive",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nExile target creature or planeswalker.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "9b5af7fa-8358-5b79-a930-0b48fdce5760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg?1",
             "name": "Ecstatic Awakener // Awoken Demon",
             "text": "{2}{B}, Sacrifice another creature: Draw a card, then transform Ecstatic Awakener. Activate only once each turn.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "fc9e9fca-4b6f-5bec-b1d7-3b2e25ae2394",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg?1",
             "name": "Ecstatic Awakener // Awoken Demon",
             "text": "",
             "colours": [
@@ -4395,7 +4395,7 @@
         },
         {
             "id": "77405d87-9cfb-586e-9967-523d5fb6a57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e4b75c-e993-4983-8933-977be314bba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e4b75c-e993-4983-8933-977be314bba6.jpg?1",
             "name": "Foul Play",
             "text": "Destroy target creature with power 2 or less. Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -4427,7 +4427,7 @@
         },
         {
             "id": "0b560a42-38ab-5859-bf6e-7bef87f24a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bd6a6-e8e4-4626-a43c-0b77339dd28b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bd6a6-e8e4-4626-a43c-0b77339dd28b.jpg?1",
             "name": "Ghoulish Procession",
             "text": "Whenever one or more nontoken creatures die, create a 2/2 black Zombie creature token with decayed. This ability triggers only once each turn. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4459,7 +4459,7 @@
         },
         {
             "id": "e473c2e9-1146-5929-93b8-f3d3a284e9c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63461076-a13d-488d-bd82-ceac441341c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63461076-a13d-488d-bd82-ceac441341c8.jpg?1",
             "name": "Gisa, Glorious Resurrector",
             "text": "If a creature an opponent controls would die, exile it instead.\nAt the beginning of your upkeep, put all creature cards exiled with Gisa, Glorious Resurrector onto the battlefield under your control. They gain decayed. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "00b8c874-ae08-5023-aef0-65d2e3e29d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "Ward\u2014\nDiscard a card.\nWhenever Graveyard Trespasser enters the battlefield or attacks, exile up to one target card from a graveyard. If a creature card was exiled this way, each opponent loses 1 life and you gain 1 life.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -4535,7 +4535,7 @@
         },
         {
             "id": "910565f2-f015-5372-804c-0ca68c9321d6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "Ward\u2014\nDiscard a card.\nWhenever Graveyard Glutton enters the battlefield or attacks, exile up to two target cards from graveyards. For each creature card exiled this way, each opponent loses 1 life and you gain 1 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "b190de68-b285-5ee8-b079-362ecc69ae47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg?1",
             "name": "Heirloom Mirror // Inherited Fiend",
             "text": "{1}, {T}, Pay 1 life, Discard a card: Draw a card, mill a card, then put a ritual counter on Heirloom Mirror. Then if it has three or more ritual counters on it, remove them and transform it. Activate only as a sorcery.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "7ed8b27e-ff39-5b07-ad51-3819ed223864",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg?1",
             "name": "Heirloom Mirror // Inherited Fiend",
             "text": "Flying\n{2}{B}: Exile target creature card from a graveyard. Put a +1/+1 counter on Inherited Fiend.",
             "colours": [
@@ -4637,7 +4637,7 @@
         },
         {
             "id": "00819278-741b-5cbc-abfb-c5ae296605eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68284193-a38e-40d2-8d15-92d223756751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68284193-a38e-40d2-8d15-92d223756751.jpg?1",
             "name": "Hobbling Zombie",
             "text": "Deathtouch\nWhen Hobbling Zombie dies, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "3beb95f1-6e57-5a47-b59e-220694ba4c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fae7302-0439-4b96-88c8-4ecfae322e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fae7302-0439-4b96-88c8-4ecfae322e7b.jpg?1",
             "name": "A-Hobbling Zombie",
             "text": "",
             "colours": [
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "fda01cd3-db33-520f-a742-41de3fbd511e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17824929-f131-4b8d-addb-66c25323155e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17824929-f131-4b8d-addb-66c25323155e.jpg?1",
             "name": "Infernal Grasp",
             "text": "Destroy target creature. You lose 2 life.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "efed3167-f840-57be-af4b-741cb1869178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff971ba7-68b8-482a-9cb1-741f6893550c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff971ba7-68b8-482a-9cb1-741f6893550c.jpg?1",
             "name": "Jadar, Ghoulcaller of Nephalia",
             "text": "At the beginning of your end step, if you control no creatures with decayed, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "32b418d0-d22a-511f-b224-0eae9dafa776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Whenever Jerren, Corrupted Bishop enters the battlefield or another nontoken Human you control dies, you lose 1 life and create a 1/1 white Human creature token.\n{2}: Target Human you control gains lifelink until end of turn.\nAt the beginning of your end step, if you have exactly 13 life, you may pay {4}{B}{B}. If you do, transform Jerren.",
             "colours": [
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "90122fb3-563b-54fd-96da-d3589e001638",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Flying, trample, lifelink\nSacrifice another creature: Draw a card.",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "c1220317-fe4c-5f8c-8abb-bbd8e8da9ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8846c-3950-4588-97e8-3aa70bcd2403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8846c-3950-4588-97e8-3aa70bcd2403.jpg?1",
             "name": "Lord of the Forsaken",
             "text": "Flying, trample\n{B}, Sacrifice another creature: Target player mills three cards.\nPay 1 life: Add {C}. Spend this mana only to cast a spell from your graveyard.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "1973ece9-f53c-5d8d-8198-a10252045b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829786e2-260b-4bc6-935b-1868b37e2d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829786e2-260b-4bc6-935b-1868b37e2d33.jpg?1",
             "name": "Mask of Griselbrand",
             "text": "Equipped creature has flying and lifelink.\nWhenever equipped creature dies, you may pay X life, where X is its power. If you do, draw X cards.\nEquip {3}",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "c918b5d5-48c1-50b1-a924-3babf7992b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08950015-eee5-4327-888c-82dfd13bb9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08950015-eee5-4327-888c-82dfd13bb9ad.jpg?1",
             "name": "The Meathook Massacre",
             "text": "When The Meathook Massacre enters the battlefield, each creature gets -X/-X until end of turn.\nWhenever a creature you control dies, each opponent loses 1 life.\nWhenever a creature an opponent controls dies, you gain 1 life.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "3bd54180-0f46-5e4e-9904-eefe6d065865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353c37d7-1c20-43fe-b9d9-6336856c9ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353c37d7-1c20-43fe-b9d9-6336856c9ef4.jpg?1",
             "name": "A-The Meathook Massacre",
             "text": "",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "730bb5cd-b6af-508c-8467-968380e40338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a53982e-3d66-4808-bcb5-46ff40567872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a53982e-3d66-4808-bcb5-46ff40567872.jpg?1",
             "name": "Morbid Opportunist",
             "text": "Whenever one or more other creatures die, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "a0c67b6f-7b78-557e-835b-9e5dce38cb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318fe8a2-a68a-4c7e-9581-ae6800826164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318fe8a2-a68a-4c7e-9581-ae6800826164.jpg?1",
             "name": "Morkrut Behemoth",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {1}{B}.\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "ecca5622-57fd-54d5-a507-05ea0841d4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75b89f1-e032-4d8c-b2b6-1b76e8644801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75b89f1-e032-4d8c-b2b6-1b76e8644801.jpg?1",
             "name": "Necrosynthesis",
             "text": "Enchant creature\nEnchanted creature has \"Whenever another creature dies, put a +1/+1 counter on this creature.\"\nWhen enchanted creature dies, look at the top X cards of your library, where X is its power. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "a0489278-4ff9-571d-ac9c-4ad0084362a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef6a68-60a4-4a20-8b57-8b7a7c5ed0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef6a68-60a4-4a20-8b57-8b7a7c5ed0c6.jpg?1",
             "name": "No Way Out",
             "text": "Target opponent discards two cards. You create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "4bd6608b-eec4-58f5-869d-9af0ed02872c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a541ac79-a969-42b4-b989-f6e37572ec90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a541ac79-a969-42b4-b989-f6e37572ec90.jpg?1",
             "name": "Novice Occultist",
             "text": "When Novice Occultist dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "38e94e95-05b3-5f83-bc5e-944288f621e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1adede-22ad-4c1c-9501-ad731fbe1742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1adede-22ad-4c1c-9501-ad731fbe1742.jpg?1",
             "name": "Olivia's Midnight Ambush",
             "text": "Target creature gets -2/-2 until end of turn. If it's night, that creature gets -13/-13 until end of turn instead.",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "75e530b8-88bd-5b77-8932-35e2dae17429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97398ad2-675b-4a34-aab7-935dd6714f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97398ad2-675b-4a34-aab7-935dd6714f1c.jpg?1",
             "name": "Rotten Reunion",
             "text": "Exile up to one target card from a graveyard. Create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "2c5c972d-133d-5b99-9d5b-d913cbe82bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "3476f68f-ca7f-5436-88cc-046c474f7cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -5305,7 +5305,7 @@
         },
         {
             "id": "b4aa775e-e5f3-52c1-8fd4-59a59a5151a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94b5270-840b-4905-815a-057029d7352f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94b5270-840b-4905-815a-057029d7352f.jpg?1",
             "name": "Siege Zombie",
             "text": "Tap three untapped creatures you control: Each opponent loses 1 life.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "90da1a95-4425-5b46-b3e3-657fb4fb4eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb83e33c-810e-4de3-800d-2038f38a1eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb83e33c-810e-4de3-800d-2038f38a1eda.jpg?1",
             "name": "Slaughter Specialist",
             "text": "When Slaughter Specialist enters the battlefield, each opponent creates a 1/1 white Human creature token.\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Slaughter Specialist.",
             "colours": [
@@ -5376,7 +5376,7 @@
         },
         {
             "id": "e4304fa0-0576-5817-ab4b-def0974929f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa819123-bf13-44ea-9a6e-06c8ab023e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa819123-bf13-44ea-9a6e-06c8ab023e44.jpg?1",
             "name": "Stromkirk Bloodthief",
             "text": "At the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on target Vampire you control.",
             "colours": [
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "8e11c3c3-b287-522a-bed0-ece45b9b98ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b9b8fc-c30d-49e7-bb6c-219380d73a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b9b8fc-c30d-49e7-bb6c-219380d73a82.jpg?1",
             "name": "Tainted Adversary",
             "text": "Deathtouch\nWhen Tainted Adversary enters the battlefield, you may pay {2}{B} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Tainted Adversary, then create twice that many 2/2 black Zombie creature tokens with decayed. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -5447,7 +5447,7 @@
         },
         {
             "id": "c401e10c-5568-59b9-a399-3bcf052f7837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e2ea59-36f1-4e95-bfe8-7008b085194f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e2ea59-36f1-4e95-bfe8-7008b085194f.jpg?1",
             "name": "Vampire Interloper",
             "text": "Flying\nVampire Interloper can't block.",
             "colours": [
@@ -5482,7 +5482,7 @@
         },
         {
             "id": "baf76046-9d4d-558a-8ade-afa40015548f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg?1",
             "name": "Vengeful Strangler // Strangling Grasp",
             "text": "Vengeful Strangler can't block.\nWhen Vengeful Strangler dies, return it to the battlefield transformed under your control attached to target creature or planeswalker an opponent controls.",
             "colours": [
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "4ea72248-3a36-5f04-a84b-c86108fd2071",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg?1",
             "name": "Vengeful Strangler // Strangling Grasp",
             "text": "Enchant creature or planeswalker an opponent controls\nAt the beginning of your upkeep, enchanted permanent's controller sacrifices a nonland permanent and loses 1 life.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "c0b433e9-15df-5983-8eb2-3aab58034a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983da138-f0f5-46c4-90c2-d3c34cc37d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983da138-f0f5-46c4-90c2-d3c34cc37d1f.jpg?1",
             "name": "Abandon the Post",
             "text": "Up to two target creatures can't block this turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5583,7 +5583,7 @@
         },
         {
             "id": "743b896d-496d-5ddf-87d2-25bb3beee16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58592f7-1df5-428d-9dde-e6acd9a5d1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58592f7-1df5-428d-9dde-e6acd9a5d1d5.jpg?1",
             "name": "Ardent Elementalist",
             "text": "When Ardent Elementalist enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -5618,7 +5618,7 @@
         },
         {
             "id": "fbb68108-d16b-56cc-ba58-6fcac3dd43a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed557e51-32bd-476f-99f8-d7b1738495c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed557e51-32bd-476f-99f8-d7b1738495c5.jpg?1",
             "name": "Bloodthirsty Adversary",
             "text": "Haste\nWhen Bloodthirsty Adversary enters the battlefield, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Bloodthirsty Adversary, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "8c97aba3-1b9b-54af-9124-63319e6e3784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10addf9a-daca-4b84-a9d3-f98f7b955af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10addf9a-daca-4b84-a9d3-f98f7b955af9.jpg?1",
             "name": "Brimstone Vandal",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nIf it's neither day nor night, it becomes day as Brimstone Vandal enters the battlefield.\nWhenever day becomes night or night becomes day, Brimstone Vandal deals 1 damage to each opponent.",
             "colours": [
@@ -5688,7 +5688,7 @@
         },
         {
             "id": "f7cdad15-4e2c-5229-89f3-eb662b0f77b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ded7af-8086-465e-a980-3099217d324c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ded7af-8086-465e-a980-3099217d324c.jpg?1",
             "name": "Burn Down the House",
             "text": "Choose one \u2014\n\u2022 Burn Down the House deals 5 damage to each creature and each planeswalker.\n\u2022 Create three 1/1 red Devil creature tokens with \"When this creature dies, it deals 1 damage to any target.\" They gain haste until end of turn.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "79ca672f-302c-5c74-bd32-370786da475b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d4e6b-564d-46da-8e32-09ed08c8ddc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d4e6b-564d-46da-8e32-09ed08c8ddc5.jpg?1",
             "name": "Burn the Accursed",
             "text": "Burn the Accursed deals 5 damage to target creature and 2 damage to that creature's controller. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "d9269477-c24f-5388-a7f2-c7cdbde611bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b045c28a-39f9-4cd9-8f3a-a626b697f409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b045c28a-39f9-4cd9-8f3a-a626b697f409.jpg?1",
             "name": "Cathartic Pyre",
             "text": "Choose one \u2014\n\u2022 Cathartic Pyre deals 3 damage to target creature or planeswalker.\n\u2022 Discard up to two cards, then draw that many cards.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "b10ecbc4-a8da-5630-b084-f8881bfc0153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371b7795-5cfc-4e2b-b26c-2def52c61dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371b7795-5cfc-4e2b-b26c-2def52c61dbf.jpg?1",
             "name": "Curse of Shaken Faith",
             "text": "Enchant player\nWhenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, Curse of Shaken Faith deals 2 damage to them.",
             "colours": [
@@ -5823,7 +5823,7 @@
         },
         {
             "id": "38aab4f2-47fe-5e10-8908-0f924efdedf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff3289-00fb-4e91-b34f-6255e9de8e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff3289-00fb-4e91-b34f-6255e9de8e9e.jpg?1",
             "name": "Electric Revelation",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -5855,7 +5855,7 @@
         },
         {
             "id": "83831857-3269-526d-944f-d189cbcc997d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40998e0-d7d0-4d79-a40a-9a381debd2cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40998e0-d7d0-4d79-a40a-9a381debd2cb.jpg?1",
             "name": "Falkenrath Perforator",
             "text": "Whenever Falkenrath Perforator attacks, it deals 1 damage to defending player.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "934664a9-40b1-57f7-a947-dc250e51ecaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a743a3b6-3278-4644-a2d5-acf495c273ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a743a3b6-3278-4644-a2d5-acf495c273ed.jpg?1",
             "name": "Falkenrath Pit Fighter",
             "text": "{1}{R}, Discard a card, Sacrifice a Vampire: Draw two cards. Activate only if an opponent lost life this turn.",
             "colours": [
@@ -5926,7 +5926,7 @@
         },
         {
             "id": "d62a337e-8eb2-5007-ac74-8c859a24f6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe6937-ceda-4367-a101-562fd5e0e09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe6937-ceda-4367-a101-562fd5e0e09d.jpg?1",
             "name": "Famished Foragers",
             "text": "When Famished Foragers enters the battlefield, if an opponent lost life this turn, add {R}{R}{R}.\n{2}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "1a534ce0-2442-51cf-92be-6422a52e2d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "{1}{R}: Fangblade Brigand gets +1/+0 and gains first strike until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "b051b605-cb99-5739-8100-283201fff38b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "{1}{R}: Fangblade Eviscerator gets +1/+0 and gains first strike until end of turn.\n{4}{R}: Creatures you control get +2/+0 until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "a97339f0-5589-55b9-9d07-aefa5213dadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626b0477-6165-443a-8a75-dfeac26ac9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626b0477-6165-443a-8a75-dfeac26ac9f9.jpg?1",
             "name": "Festival Crasher",
             "text": "Whenever you cast an instant or sorcery spell, Festival Crasher gets +2/+0 until end of turn.",
             "colours": [
@@ -6067,7 +6067,7 @@
         },
         {
             "id": "b51bbd9a-6ac1-5a3a-afb7-37e7be6d869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg?1",
             "name": "Flame Channeler // Embodiment of Flame",
             "text": "When a spell you control deals damage, transform Flame Channeler.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "dc2a1b47-2cfa-545e-953c-68d883c89d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg?1",
             "name": "Flame Channeler // Embodiment of Flame",
             "text": "Whenever a spell you control deals damage, put a flame counter on Embodiment of Flame.\n{1}, Remove a flame counter from Embodiment of Flame: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "0ddae50e-b65b-5549-a606-60f5d3943d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b247ce7-9c58-404f-bed1-84abb37575ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b247ce7-9c58-404f-bed1-84abb37575ab.jpg?1",
             "name": "Geistflame Reservoir",
             "text": "Whenever you cast an instant or sorcery spell, put a charge counter on Geistflame Reservoir.\n{1}{R}, {T}, Remove any number of charge counters from Geistflame Reservoir: It deals that much damage to any target.\n{1}{R}, {T}: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "1f28c694-4ca8-50bf-bc9c-bb61b19f2ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "Trample\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6208,7 +6208,7 @@
         },
         {
             "id": "cdeb455a-03fe-5ab6-ac32-304b6ac13fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "Trample\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "a4f1fdc2-e84b-50c8-a6b0-ffbf84c9fd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b1148-4aa6-4d78-bedd-e31573282921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b1148-4aa6-4d78-bedd-e31573282921.jpg?1",
             "name": "Immolation",
             "text": "Enchant creature\nEnchanted creature gets +2/-2.",
             "colours": [
@@ -6278,7 +6278,7 @@
         },
         {
             "id": "b199282c-9d0d-538d-994d-b352e10fc772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a732ca-cd68-465f-8e44-783e1fe34e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a732ca-cd68-465f-8e44-783e1fe34e44.jpg?1",
             "name": "Lambholt Harrier",
             "text": "{3}{R}: Target creature can't block this turn.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "71cc680f-6c82-573e-9bea-bfe05d316027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de68154-3b82-4a94-98a6-cfc49d359e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de68154-3b82-4a94-98a6-cfc49d359e4e.jpg?1",
             "name": "Light Up the Night",
             "text": "Light Up the Night deals X damage to any target. It deals X plus 1 damage instead if that target is a creature or planeswalker.\nFlashback\u2014{3}{R}, Remove X loyalty counters from among planeswalkers you control. If you cast this spell this way, X can't be 0. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "156b05ab-16c1-5c11-90fb-091e1568017c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb18c4-1386-4ea0-97c1-4bdd1e7eb5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb18c4-1386-4ea0-97c1-4bdd1e7eb5a6.jpg?1",
             "name": "Lunar Frenzy",
             "text": "Target creature you control gets +X/+0 and gains first strike and trample until end of turn.",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "3f042954-6ce2-59d0-8431-7173b89b031f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4f266b-c41c-4047-ae6f-b2226c7459e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4f266b-c41c-4047-ae6f-b2226c7459e8.jpg?1",
             "name": "Moonrager's Slash",
             "text": "This spell costs {2} less to cast if it's night.\nMoonrager's Slash deals 3 damage to any target.",
             "colours": [
@@ -6410,7 +6410,7 @@
         },
         {
             "id": "611946ae-c2e9-581f-bccc-fa2df2c350b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc55fd-161a-4d77-82f0-27075210e7e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc55fd-161a-4d77-82f0-27075210e7e7.jpg?1",
             "name": "Moonveil Regent",
             "text": "Flying\nWhenever you cast a spell, you may discard your hand. If you do, draw a card for each of that spell's colors.\nWhen Moonveil Regent dies, it deals X damage to any target, where X is the number of colors among permanents you control.",
             "colours": [
@@ -6446,7 +6446,7 @@
         },
         {
             "id": "fa1795f1-75dc-5dd1-a1ff-7bdac4eeb42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1814fc8-011f-4cd4-825b-f00ae6ec0fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1814fc8-011f-4cd4-825b-f00ae6ec0fe0.jpg?1",
             "name": "Mounted Dreadknight",
             "text": "Trample\nMounted Dreadknight enters the battlefield with a +1/+1 counter on it if an opponent lost life this turn.",
             "colours": [
@@ -6481,7 +6481,7 @@
         },
         {
             "id": "9c8d99c3-d541-5a4a-803e-789adec9a2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee17e12-e08f-4449-9f49-05f20e0d1670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee17e12-e08f-4449-9f49-05f20e0d1670.jpg?1",
             "name": "Neonate's Rush",
             "text": "This spell costs {1} less to cast if you control a Vampire.\nNeonate's Rush deals 1 damage to target creature and 1 damage to its controller. Draw a card.",
             "colours": [
@@ -6513,7 +6513,7 @@
         },
         {
             "id": "924201aa-0db8-58c6-a952-b71f620b5de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6e0cb6-283b-448e-89c6-8b6e8e21e38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6e0cb6-283b-448e-89c6-8b6e8e21e38b.jpg?1",
             "name": "Obsessive Astronomer",
             "text": "If it's neither day nor night, it becomes day as Obsessive Astronomer enters the battlefield.\nWhenever day becomes night or night becomes day, discard up to two cards, then draw that many cards.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "fa180baf-a5c1-5d3c-8530-2d7139cb3f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebadb1e-32cd-41d6-b26e-49134973d05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebadb1e-32cd-41d6-b26e-49134973d05c.jpg?1",
             "name": "Pack's Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If you control a Wolf or Werewolf, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "2938aa79-4cd8-5498-9923-5e2c3e048418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a6c60-a8c4-44c2-b1ea-d3befbabdf43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a6c60-a8c4-44c2-b1ea-d3befbabdf43.jpg?1",
             "name": "Play with Fire",
             "text": "Play with Fire deals 2 damage to any target. If a player is dealt damage this way, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "7911b744-a386-577b-b937-724ababf6ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db384e-9555-4ccc-a305-ee448252e685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db384e-9555-4ccc-a305-ee448252e685.jpg?1",
             "name": "Purifying Dragon",
             "text": "Flying\nWhenever Purifying Dragon attacks, it deals 1 damage to target creature defending player controls. If that creature is a Zombie, Purifying Dragon deals 2 damage to it instead.",
             "colours": [
@@ -6648,7 +6648,7 @@
         },
         {
             "id": "762477e4-b10f-5074-b48b-86eee18a6ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0dd378c-5050-48c9-9a16-6d91afa62d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0dd378c-5050-48c9-9a16-6d91afa62d21.jpg?1",
             "name": "Raze the Effigy",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target attacking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "ecef4bce-b292-5c98-ba1c-3a67347613da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "At the beginning of combat on your turn, target creature you control gets +1/+0 and gains haste until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6717,7 +6717,7 @@
         },
         {
             "id": "0e7e3490-16b8-581a-9dbe-f966c531877e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 and gains trample and haste until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6753,7 +6753,7 @@
         },
         {
             "id": "535db88a-d4e3-5ad6-8d06-36a5fa0fece5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532e079f-55b7-4b92-b489-aed4d3becae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532e079f-55b7-4b92-b489-aed4d3becae7.jpg?1",
             "name": "Seize the Storm",
             "text": "Create a red Elemental creature token with trample and \"This creature's power and toughness are each equal to the number of instant and sorcery cards in your graveyard plus the number of cards with flashback you own in exile.\"\nFlashback {6}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6785,7 +6785,7 @@
         },
         {
             "id": "eac190d0-1c00-5d5b-a146-fc1cd2415e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, put a number of ember counters on Smoldering Egg equal to the amount of mana spent to cast that spell. Then if Smoldering Egg has seven or more ember counters on it, remove them and transform Smoldering Egg.",
             "colours": [
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "77bae4f3-039b-5c55-a68f-2a8eff571300",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Ashmouth Dragon deals 2 damage to any target.",
             "colours": [
@@ -6858,7 +6858,7 @@
         },
         {
             "id": "7c970d76-48a9-508f-b45e-049ef7d3e026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "Whenever you cast an instant or sorcery spell, Spellrune Painter gets +1/+1 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "2d4ece62-383d-56db-8acb-db6ecef0db56",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "Whenever you cast an instant or sorcery spell, Spellrune Howler gets +2/+2 until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "018ebada-7dbb-5503-b731-9c3d39cdcb56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50df2dd-8d14-4d92-ab4e-bf9f9f147e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50df2dd-8d14-4d92-ab4e-bf9f9f147e91.jpg?1",
             "name": "Stolen Vitality",
             "text": "Target creature gets +3/+1 until end of turn. If it's your turn, that creature gains trample until end of turn. Otherwise, it gains first strike until end of turn.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "79276ac9-62e2-5d1f-973e-8459e590313d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de6e92-e0e8-444e-baba-09c97510b1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de6e92-e0e8-444e-baba-09c97510b1ab.jpg?1",
             "name": "Sunstreak Phoenix",
             "text": "Flying\nIf it's neither day nor night, it becomes day as Sunstreak Phoenix enters the battlefield.\nWhenever day becomes night or night becomes day, you may pay {1}{R}. If you do, return Sunstreak Phoenix from your graveyard to the battlefield tapped.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "e0b70c92-7792-5e86-bb22-c8b33d44b199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "Daybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7038,7 +7038,7 @@
         },
         {
             "id": "8491c394-b6a0-5f5f-b549-636eddc53ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7074,7 +7074,7 @@
         },
         {
             "id": "af1a8225-2047-509e-90d9-190ce76b019a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c68bad-c7ee-4dbc-ad06-8c4d9446884e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c68bad-c7ee-4dbc-ad06-8c4d9446884e.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -7109,7 +7109,7 @@
         },
         {
             "id": "3eb5c969-9db9-5178-a0ed-c63a35579083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "Haste\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "92763eaf-2618-5a04-90bd-f3e7c8204ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "Wolves and Werewolves you control have haste.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7182,7 +7182,7 @@
         },
         {
             "id": "43bfa2f7-0f38-50c9-9945-b89c8e732b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceb4303-5d02-45f2-86f8-7e8deb774d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceb4303-5d02-45f2-86f8-7e8deb774d58.jpg?1",
             "name": "Voldaren Ambusher",
             "text": "When Voldaren Ambusher enters the battlefield, if an opponent lost life this turn, it deals X damage to up to one target creature or planeswalker, where X is the number of Vampires you control.",
             "colours": [
@@ -7217,7 +7217,7 @@
         },
         {
             "id": "c845251d-e81e-51aa-9140-65718988130f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27a7c78-3a64-42fc-8808-15b1f41976a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27a7c78-3a64-42fc-8808-15b1f41976a1.jpg?1",
             "name": "Voldaren Stinger",
             "text": "Voldaren Stinger has first strike as long as it's attacking.\n{2}{R}: Voldaren Stinger gets +2/+0 until end of turn.",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "e00c7329-3f4b-537f-88ec-1c8d575414ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa98767-ae27-4cf0-98ea-93e659f160f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa98767-ae27-4cf0-98ea-93e659f160f4.jpg?1",
             "name": "Augur of Autumn",
             "text": "You may look at the top card of your library any time.\nYou may play lands from the top of your library.\nCoven \u2014 As long as you control three or more creatures with different powers, you may cast creature spells from the top of your library.",
             "colours": [
@@ -7289,7 +7289,7 @@
         },
         {
             "id": "bff7597b-00a9-5994-8f30-b43dd0d0ff64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "Reach\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "8dc87470-c124-5afb-a5ef-ebafbbb805a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "Reach\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "ac65f159-b949-5847-b50a-2b9f2ed28b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e22ed6-9d39-4feb-8c64-64cdd8313816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e22ed6-9d39-4feb-8c64-64cdd8313816.jpg?1",
             "name": "Bounding Wolf",
             "text": "Flash\nReach",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "222d00de-a710-52cb-b85a-0b6b30daae71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621b58aa-c809-4baf-b2c8-3a46969598d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621b58aa-c809-4baf-b2c8-3a46969598d7.jpg?1",
             "name": "Bramble Armor",
             "text": "When Bramble Armor enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "d78efdb6-2737-5046-bb13-470342ccc3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e215a7bd-112f-4228-a99e-5a8cb4be5cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e215a7bd-112f-4228-a99e-5a8cb4be5cee.jpg?1",
             "name": "Briarbridge Tracker",
             "text": "Vigilance\nWhen Briarbridge Tracker enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nAs long as you control a token, Briarbridge Tracker gets +2/+0.",
             "colours": [
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "1734b7f3-55db-5c9b-83e4-1dcf35b157eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24e2f49-70f9-445f-af03-2ef43798004a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24e2f49-70f9-445f-af03-2ef43798004a.jpg?1",
             "name": "Brood Weaver",
             "text": "Reach\nWhen Brood Weaver dies, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -7502,7 +7502,7 @@
         },
         {
             "id": "d446b043-9525-5a30-b817-530d4be25d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "6d6607b8-ad80-5d29-ab93-e3af12458b09",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7575,7 +7575,7 @@
         },
         {
             "id": "305e85c4-aee7-56b0-8cbc-8088a03091d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3bd60-1ff6-4136-9188-d0620fd299a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3bd60-1ff6-4136-9188-d0620fd299a7.jpg?1",
             "name": "Candlelit Cavalry",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Candlelit Cavalry gains trample until end of turn.",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "fae554ca-f70c-55b7-9e09-e5d9cccda791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27476d9c-006d-4227-a5f2-49c7234b84a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27476d9c-006d-4227-a5f2-49c7234b84a1.jpg?1",
             "name": "Clear Shot",
             "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "e5fed8cb-ef33-52dd-8d84-426b06565dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540fa4b-93e8-4749-a839-9a6e816c1145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540fa4b-93e8-4749-a839-9a6e816c1145.jpg?1",
             "name": "Consuming Blob",
             "text": "Consuming Blob's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nAt the beginning of your end step, create a green Ooze creature token with \"This creature's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\"",
             "colours": [
@@ -7678,7 +7678,7 @@
         },
         {
             "id": "af49b8eb-3d7e-517b-9479-9b713c27e898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81da535-04e4-4dc8-9e12-7b417aba2f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81da535-04e4-4dc8-9e12-7b417aba2f39.jpg?1",
             "name": "Contortionist Troupe",
             "text": "Contortionist Troupe enters the battlefield with X +1/+1 counters on it.\nCoven \u2014 At the beginning of your end step, if you control three or more creatures with different powers, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "8a5d7d75-bae3-5113-ab19-2ac15b610788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a09dd-a202-4487-899f-348744143ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a09dd-a202-4487-899f-348744143ba5.jpg?1",
             "name": "Dawnhart Mentor",
             "text": "When Dawnhart Mentor enters the battlefield, create a 1/1 white Human creature token.\nCoven \u2014 {5}{G}: Target creature you control gets +3/+3 and gains trample until end of turn. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "f6690db2-16b0-5cd5-8d4e-f35cfa83e2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4b5ad9-3de6-4d53-93a0-3b8d2e484687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4b5ad9-3de6-4d53-93a0-3b8d2e484687.jpg?1",
             "name": "Dawnhart Rejuvenator",
             "text": "When Dawnhart Rejuvenator enters the battlefield, you gain 3 life.\n{T}: Add one mana of any color.",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "cf2d69ec-47c6-52d1-945b-2ec636a1fe02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg?1",
             "name": "Deathbonnet Sprout // Deathbonnet Hulk",
             "text": "At the beginning of your upkeep, mill a card. Then if there are three or more creature cards in your graveyard, transform Deathbonnet Sprout. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -7820,7 +7820,7 @@
         },
         {
             "id": "cd81875f-bbec-5088-86c4-5b904235b673",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg?1",
             "name": "Deathbonnet Sprout // Deathbonnet Hulk",
             "text": "At the beginning of your upkeep, you may exile a card from a graveyard. If a creature card was exiled this way, put a +1/+1 counter on Deathbonnet Hulk.",
             "colours": [
@@ -7855,7 +7855,7 @@
         },
         {
             "id": "e152d970-a574-5028-a470-cd886ee16abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11e4420-06f3-48e2-91d1-a9199483add2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11e4420-06f3-48e2-91d1-a9199483add2.jpg?1",
             "name": "Defend the Celestus",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures you control.",
             "colours": [
@@ -7887,7 +7887,7 @@
         },
         {
             "id": "50cd6c05-4f84-5708-81fb-e687fcbdd3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0aa3eb-0aa8-42da-b437-a3f336df585d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0aa3eb-0aa8-42da-b437-a3f336df585d.jpg?1",
             "name": "Dryad's Revival",
             "text": "Return target card from your graveyard to your hand.\nFlashback {4}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7919,7 +7919,7 @@
         },
         {
             "id": "e1d365f7-5c80-512e-b3df-eb466148ff98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0a0c8-158e-4a6f-976e-3de9f57c3463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0a0c8-158e-4a6f-976e-3de9f57c3463.jpg?1",
             "name": "Duel for Dominance",
             "text": "Coven \u2014 Choose target creature you control and target creature you don't control. If you control three or more creatures with different powers, put a +1/+1 counter on the chosen creature you control. Then the chosen creatures fight each other. (They each deal damage equal to their power to the other.)",
             "colours": [
@@ -7951,7 +7951,7 @@
         },
         {
             "id": "38879b38-8198-5e5e-8ea0-26bd0cb7055f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5339f6e-9ed7-4734-91c9-c2ed59ca1052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5339f6e-9ed7-4734-91c9-c2ed59ca1052.jpg?1",
             "name": "Eccentric Farmer",
             "text": "When Eccentric Farmer enters the battlefield, mill three cards, then you may return a land card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -7986,7 +7986,7 @@
         },
         {
             "id": "c2d3ccd6-a0af-5b34-83d3-e9a65ef398e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543cf53-8cf5-49d0-9c60-8b11e21da953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543cf53-8cf5-49d0-9c60-8b11e21da953.jpg?1",
             "name": "Harvesttide Sentry",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Harvesttide Sentry can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "f81fcd65-a396-5d42-937a-aa715d2ba86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "Trample\n{3}{G}: Put a +1/+1 counter on target creature.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8058,7 +8058,7 @@
         },
         {
             "id": "f75dc67c-ae5a-5ea7-b624-909d12c1012b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "Trample\nOther Wolves and Werewolves you control have trample.\n{3}{G}: Put a +1/+1 counter on target creature.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "b7aa17f5-776d-5842-bb7a-dc98f31a1f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a48a42e-5cc5-4f9a-8745-99936f4cae5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a48a42e-5cc5-4f9a-8745-99936f4cae5f.jpg?1",
             "name": "Howl of the Hunt",
             "text": "Flash\nEnchant creature\nWhen Howl of the Hunt enters the battlefield, if enchanted creature is a Wolf or Werewolf, untap that creature.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "f3380d77-93d7-5516-bbd0-e8907b156623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a853679-e9dd-4c05-8688-248de8f12760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a853679-e9dd-4c05-8688-248de8f12760.jpg?1",
             "name": "Might of the Old Ways",
             "text": "Target creature gets +2/+2 until end of turn.\nCoven \u2014 Then if you control three or more creatures with different powers, draw a card.",
             "colours": [
@@ -8160,7 +8160,7 @@
         },
         {
             "id": "5afe118d-3d8b-5541-a0c6-c529c0bfbfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "{1}, Sacrifice Outland Liberator: Destroy target artifact or enchantment.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "0cb004e6-6f72-53c9-8e46-f8e4df500063",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "{1}, Sacrifice Frenzied Trapbreaker: Destroy target artifact or enchantment.\nWhenever Frenzied Trapbreaker attacks, destroy target artifact or enchantment defending player controls.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8233,7 +8233,7 @@
         },
         {
             "id": "570ce268-ce71-5ca3-9614-b33433220c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f545d-bdbf-42c7-837a-a7076bbe5027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f545d-bdbf-42c7-837a-a7076bbe5027.jpg?1",
             "name": "Path to the Festival",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nFlashback {4}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "8b785007-c2a3-5697-8fb0-fef01ebed937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2686431-8d9c-4b9c-998f-38b5ae113d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2686431-8d9c-4b9c-998f-38b5ae113d4a.jpg?1",
             "name": "Pestilent Wolf",
             "text": "{2}{G}: Pestilent Wolf gains deathtouch until end of turn.",
             "colours": [
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "0b196e1a-520a-5392-b48e-675c7d5b28c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5469e696-bbf1-43e3-9c25-fe089b36caed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5469e696-bbf1-43e3-9c25-fe089b36caed.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "144995c9-b272-576b-90fd-a7c99c1de885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3ce5c5-ea31-4f6d-84dd-430f52c49c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3ce5c5-ea31-4f6d-84dd-430f52c49c4e.jpg?1",
             "name": "Primal Adversary",
             "text": "Trample\nWhen Primal Adversary enters the battlefield, you may pay {1}{G} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Primal Adversary, then up to that many target lands you control become 3/3 Wolf creatures with haste that are still lands.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "cfb4499b-b783-5c20-9b21-31be95771e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e25c252-4177-4193-914c-b6933d9c0d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e25c252-4177-4193-914c-b6933d9c0d7d.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "c7fb8c3b-26a0-5312-9ce6-bbb7fe4dd175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143fadd-0162-4e0c-89fc-89dc3501d13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143fadd-0162-4e0c-89fc-89dc3501d13c.jpg?1",
             "name": "Rise of the Ants",
             "text": "Create two 3/3 green Insect creature tokens. You gain 2 life.\nFlashback {6}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "369df800-2efc-5520-b87d-b682e5ec580e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8b3a09-75e8-428c-91f7-8fac62fadc98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8b3a09-75e8-428c-91f7-8fac62fadc98.jpg?1",
             "name": "Saryth, the Viper's Fang",
             "text": "Other tapped creatures you control have deathtouch.\nOther untapped creatures you control have hexproof.\n{1}, {T}: Untap another target creature or land you control.",
             "colours": [
@@ -8470,7 +8470,7 @@
         },
         {
             "id": "9490232f-d9be-508a-92a1-9ddd2bd2c6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12e978-4deb-4ccc-8ae6-462bc4598c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12e978-4deb-4ccc-8ae6-462bc4598c90.jpg?1",
             "name": "Shadowbeast Sighting",
             "text": "Create a 4/4 green Beast creature token.\nFlashback {6}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "65a6a7db-d3ec-5f2f-b361-8e80aa0336e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b614b21-69ed-4788-97d7-ad502b634abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b614b21-69ed-4788-97d7-ad502b634abb.jpg?1",
             "name": "Snarling Wolf",
             "text": "{1}{G}: Snarling Wolf gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -8536,7 +8536,7 @@
         },
         {
             "id": "cfaa2f30-bdaa-5982-8986-812b23d22417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f1f69c-122d-472a-b82d-fed7c253a4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f1f69c-122d-472a-b82d-fed7c253a4cd.jpg?1",
             "name": "Storm the Festival",
             "text": "Look at the top five cards of your library. You may put up to two permanent cards with mana value 5 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\nFlashback {7}{G}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "23012e9a-ae6f-520a-ad9d-815bb2b06a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba75dc52-7ab2-43ec-afac-0a9bcf24cde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba75dc52-7ab2-43ec-afac-0a9bcf24cde9.jpg?1",
             "name": "Tapping at the Window",
             "text": "Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest into your graveyard.\nFlashback {2}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8602,7 +8602,7 @@
         },
         {
             "id": "81d440aa-cb24-5ac4-b13a-3e3a7b71c799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215b6a-82e3-4ce8-b288-d7341761cad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215b6a-82e3-4ce8-b288-d7341761cad0.jpg?1",
             "name": "Timberland Guide",
             "text": "When Timberland Guide enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8637,7 +8637,7 @@
         },
         {
             "id": "e9baf11a-3238-5296-9a2b-4ca4b940af77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "Vigilance\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8674,7 +8674,7 @@
         },
         {
             "id": "1e7cafcb-3626-53bf-a1c9-23da753a6f86",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "Vigilance\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "0bf51c8d-b481-5be5-8645-7f7d27d37846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "When Tovolar's Huntmaster enters the battlefield, create two 2/2 green Wolf creature tokens.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8747,7 +8747,7 @@
         },
         {
             "id": "24229b27-335a-538e-b6c0-95705dbcbbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "Whenever Tovolar's Packleader enters the battlefield or attacks, create two 2/2 green Wolf creature tokens.\n{2}{G}{G}: Another target Wolf or Werewolf you control fights target creature you don't control.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "ec3f73e7-0da0-55b7-b1e0-370d78c48fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34076a93-9e8f-45d4-a1d7-31f40210a5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34076a93-9e8f-45d4-a1d7-31f40210a5b6.jpg?1",
             "name": "Turn the Earth",
             "text": "Choose up to three target cards in graveyards. The owners of those cards shuffle them into their libraries. You gain 2 life.\nFlashback {1}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "6a80d9d4-93c1-515a-a75a-e719cdaed501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6748a844-e185-4e3b-ac1d-8a735666d8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6748a844-e185-4e3b-ac1d-8a735666d8ae.jpg?1",
             "name": "Unnatural Growth",
             "text": "At the beginning of each combat, double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "e705572d-4baa-5f58-abbe-ec00d982dc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c40c71c-4cdc-4a28-8ea3-4636c936f8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c40c71c-4cdc-4a28-8ea3-4636c936f8aa.jpg?1",
             "name": "Willow Geist",
             "text": "Trample\nWhenever one or more cards leave your graveyard, put a +1/+1 counter on Willow Geist.\nWhen Willow Geist dies, you gain life equal to its power.",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "4fa35034-d0dc-5335-945a-1b08388e663a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7757e99-8d51-4b92-b346-6961845def24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7757e99-8d51-4b92-b346-6961845def24.jpg?1",
             "name": "Wrenn and Seven",
             "text": "+1: Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.\n0: Put any number of land cards from your hand onto the battlefield tapped.\n\u22123: Create a green Treefolk creature token with reach and \"This creature's power and toughness are each equal to the number of lands you control.\"\n\u22128: Return all permanent cards from your graveyard to your hand. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -8924,7 +8924,7 @@
         },
         {
             "id": "050334fc-2f00-5bcd-bbed-03b096e29716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4c7a2-6243-43ed-8c1c-e3edee43a583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4c7a2-6243-43ed-8c1c-e3edee43a583.jpg?1",
             "name": "Angelfire Ignition",
             "text": "Put two +1/+1 counters on target creature. It gains vigilance, trample, lifelink, indestructible, and haste until end of turn.\nFlashback {2}{R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "0105938f-dd59-5806-9037-1b5576dbda9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab520b7-ad87-4c8e-a454-5c022e378564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab520b7-ad87-4c8e-a454-5c022e378564.jpg?1",
             "name": "Arcane Infusion",
             "text": "Look at the top four cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{U}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8994,7 +8994,7 @@
         },
         {
             "id": "7450d1d0-1622-5a70-b874-a5464b530be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Daybound (If a player casts no spells during their own turn, it becomes night next turn.)\n+1: Until your next turn, you may cast creature spells as though they had flash, and each creature you control enters the battlefield with an additional +1/+1 counter on it.\n\u22123: Create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -9035,7 +9035,7 @@
         },
         {
             "id": "1956efa1-c954-5f26-854b-75d264419c54",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)\n+2: Add {R}{G}.\n0: Until end of turn, Arlinn, the Moon's Fury becomes a 5/5 Werewolf creature with trample, indestructible, and haste.",
             "colours": [
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "c3fefc24-1c3f-5509-84cb-a80bea21353f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a73f77-aab5-47e3-bfc1-97f6374f40fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a73f77-aab5-47e3-bfc1-97f6374f40fc.jpg?1",
             "name": "Bladestitched Skaab",
             "text": "Other Zombies you control get +1/+0.",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "0b85833f-5a7f-58c1-a25d-84dcb53fc5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccfebf1-add1-4f62-bffa-9023dea5b7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccfebf1-add1-4f62-bffa-9023dea5b7c4.jpg?1",
             "name": "Can't Stay Away",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains \"If this creature would die, exile it instead.\"\nFlashback {3}{W}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9149,7 +9149,7 @@
         },
         {
             "id": "7c2f5297-e6b5-5659-aec3-59dbe6f742e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe4f48d-179a-47d7-aed6-9751dd2f7d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe4f48d-179a-47d7-aed6-9751dd2f7d8c.jpg?1",
             "name": "Corpse Cobble",
             "text": "As an additional cost to cast this spell, sacrifice any number of creatures.\nCreate an X/X blue and black Zombie creature token with menace, where X is the total power of the sacrificed creatures.\nFlashback {3}{U}{B} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "34ac63a5-b7f4-52db-8c5c-eb604c691498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847b22f-6660-4654-91a9-e0adb8606bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847b22f-6660-4654-91a9-e0adb8606bab.jpg?1",
             "name": "Croaking Counterpart",
             "text": "Create a token that's a copy of target non-Frog creature, except it's a 1/1 green Frog.\nFlashback {3}{G}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9219,7 +9219,7 @@
         },
         {
             "id": "2c5f9bb6-8bb8-5522-bebc-06c0ed85803e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb2f0a7-f3a6-4487-b847-4ef26ad5ecad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb2f0a7-f3a6-4487-b847-4ef26ad5ecad.jpg?1",
             "name": "Dawnhart Wardens",
             "text": "Vigilance\nCoven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -9258,7 +9258,7 @@
         },
         {
             "id": "f1c8c16b-0a29-58e5-a782-128f8ad542b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Lifelink\nCards in graveyards can't be the targets of spells or abilities.\nDisturb {2}{W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "3ecbb2c7-3b07-557c-9088-4642dc903396",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Flying\nWhenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nIf Dennick, Pious Apparition would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "1f62e4d7-700b-5815-8bc1-aedbfc9b3f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg?1",
             "name": "Devoted Grafkeeper // Departed Soulkeeper",
             "text": "When Devoted Grafkeeper enters the battlefield, mill two cards.\nWhenever you cast a spell from your graveyard, tap target creature you don't control.\nDisturb {1}{W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -9377,7 +9377,7 @@
         },
         {
             "id": "8237df0e-a4a4-5daa-8a1f-aa600e03621f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg?1",
             "name": "Devoted Grafkeeper // Departed Soulkeeper",
             "text": "Flying\nDeparted Soulkeeper can block only creatures with flying.\nIf Departed Soulkeeper would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -9413,7 +9413,7 @@
         },
         {
             "id": "c855e474-9f8c-57be-ae96-3ca15bc288d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg?1",
             "name": "A-Devoted Grafkeeper // A-Departed Soulkeeper",
             "text": "",
             "colours": [
@@ -9449,7 +9449,7 @@
         },
         {
             "id": "8169d2bb-5aed-57d1-b5d8-d131c43bb771",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg?1",
             "name": "A-Devoted Grafkeeper // A-Departed Soulkeeper",
             "text": "",
             "colours": [
@@ -9484,7 +9484,7 @@
         },
         {
             "id": "16240e97-9066-58b5-a45b-c0fafa60dd4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4a7c01-95ca-43bf-bc53-875cfb4bffa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4a7c01-95ca-43bf-bc53-875cfb4bffa1.jpg?1",
             "name": "Dire-Strain Rampage",
             "text": "Destroy target artifact, enchantment, or land. If a land was destroyed this way, its controller may search their library for up to two basic land cards, put them onto the battlefield tapped, then shuffle. Otherwise, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.\nFlashback {3}{R}{G}",
             "colours": [
@@ -9520,7 +9520,7 @@
         },
         {
             "id": "f93af46b-3fd3-5bf5-b9aa-b0c2fb577e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51ed1ea-661e-49c6-9751-1eb7bb651bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51ed1ea-661e-49c6-9751-1eb7bb651bb1.jpg?1",
             "name": "Diregraf Rebirth",
             "text": "This spell costs {1} less to cast for each creature that died this turn.\nReturn target creature card from your graveyard to the battlefield.\nFlashback {5}{B}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "d8b0d757-7eb1-5aea-b72e-3a654ae9b19c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50752ca9-ea85-4c4b-9bf5-4f8759a7dcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50752ca9-ea85-4c4b-9bf5-4f8759a7dcec.jpg?1",
             "name": "Faithful Mending",
             "text": "You gain 2 life, draw two cards, then discard two cards.\nFlashback {1}{W}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9588,7 +9588,7 @@
         },
         {
             "id": "3d06ea9b-0eba-50b6-a72b-4813821e7178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed8c0ef-2b53-49b5-bc2f-428628cb3975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed8c0ef-2b53-49b5-bc2f-428628cb3975.jpg?1",
             "name": "Fleshtaker",
             "text": "Whenever you sacrifice another creature, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{1}, Sacrifice another creature: Fleshtaker gets +2/+2 until end of turn.",
             "colours": [
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "87fd67c9-62c8-579b-a215-c363c23da22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53289e69-74da-46d2-91c2-a11378ba76ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53289e69-74da-46d2-91c2-a11378ba76ef.jpg?1",
             "name": "Florian, Voldaren Scion",
             "text": "First strike\nAt the beginning of your postcombat main phase, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -9666,7 +9666,7 @@
         },
         {
             "id": "b0b940bc-628d-5bc1-8d8e-f2c544e04811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8ee5b-e1f5-4bc8-8ca3-d8308d71f2b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8ee5b-e1f5-4bc8-8ca3-d8308d71f2b9.jpg?1",
             "name": "Galvanic Iteration",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nFlashback {1}{U}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "ea67373e-2b7a-5c60-8b8e-dd074527d676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a507ea6-d818-4443-b468-cf65c3e7031c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a507ea6-d818-4443-b468-cf65c3e7031c.jpg?1",
             "name": "Ghoulcaller's Harvest",
             "text": "Create X 2/2 black Zombie creature tokens with decayed, where X is half the number of creature cards in your graveyard, rounded up. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)\nFlashback {3}{B}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "aeda2c8d-3685-5fa3-86f8-ae068e0640cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec421f1-4ee8-4816-ab5c-372e87aae231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec421f1-4ee8-4816-ab5c-372e87aae231.jpg?1",
             "name": "Grizzly Ghoul",
             "text": "Trample\nGrizzly Ghoul enters the battlefield with a +1/+1 counter on it for each creature that died this turn.",
             "colours": [
@@ -9775,7 +9775,7 @@
         },
         {
             "id": "770b3537-e3f5-5a75-bedf-dbb3f6949da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2877523-6321-47e6-8be4-755ec21676c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2877523-6321-47e6-8be4-755ec21676c6.jpg?1",
             "name": "Hallowed Respite",
             "text": "Exile target nonlegendary creature, then return it to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on it. Otherwise, tap it.\nFlashback {1}{W}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "1bb43027-59b4-51f3-a467-a40fc086a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce09c0df-d022-4ebf-8f7f-8a913249e75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce09c0df-d022-4ebf-8f7f-8a913249e75f.jpg?1",
             "name": "Hungry for More",
             "text": "Create a 3/1 black and red Vampire creature token with trample, lifelink, and haste. Sacrifice it at the beginning of the next end step.\nFlashback {1}{B}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9845,7 +9845,7 @@
         },
         {
             "id": "95103ddf-fd4b-5ebb-9dc8-0052ca3da3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b30a99-601b-40b9-b012-30fa4be5fd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b30a99-601b-40b9-b012-30fa4be5fd3c.jpg?1",
             "name": "Join the Dance",
             "text": "Create two 1/1 white Human creature tokens.\nFlashback {3}{G}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "94bae36e-66ea-5ae3-a449-5a556d9cf32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673cd775-d417-4652-a91d-825ad5c89e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673cd775-d417-4652-a91d-825ad5c89e8a.jpg?1",
             "name": "Katilda, Dawnhart Prime",
             "text": "Protection from Werewolves\nHuman creatures you control have \"{T}: Add one mana of any of this creature's colors.\"\n{4}{G}{W}, {T}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "ebe8980b-a6a3-5139-aaf6-8d11e37e0c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "Whenever Kessig Naturalist attacks, add {R} or {G}. Until end of turn, you don't lose this mana as steps and phases end.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9961,7 +9961,7 @@
         },
         {
             "id": "33a44fdf-9467-5415-b92d-b6d72bff24be",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "Other Wolves and Werewolves you control get +1/+1.\nWhenever Lord of the Ulvenwald attacks, add {R} or {G}. Until end of turn, you don't lose this mana as steps and phases end.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9999,7 +9999,7 @@
         },
         {
             "id": "ee7adcd4-52f5-57cd-8277-1b553a6b70b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532fca6b-f788-43f8-b29f-7273e7a48449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532fca6b-f788-43f8-b29f-7273e7a48449.jpg?1",
             "name": "Liesa, Forgotten Archangel",
             "text": "Flying, lifelink\nWhenever another nontoken creature you control dies, return that card to its owner's hand at the beginning of the next end step.\nIf a creature an opponent controls would die, exile it instead.",
             "colours": [
@@ -10039,7 +10039,7 @@
         },
         {
             "id": "05a2281d-457f-5385-869f-5eaa3711e160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "Whenever Ludevic, Necrogenius enters the battlefield or attacks, mill a card.\n{X}{U}{U}{B}{B}, Exile X creature cards from your graveyard: Transform Ludevic. X can't be 0. Activate only as a sorcery.",
             "colours": [
@@ -10080,7 +10080,7 @@
         },
         {
             "id": "40dfd18b-ad5e-5681-b7d4-3426cb898014",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "As this creature transforms into Olag, Ludevic's Hubris, it becomes a copy of a creature card exiled with it, except its name is Olag, Ludevic's Hubris, it's 4/4, and it's a legendary blue and black Zombie in addition to its other colors and types. Put a number of +1/+1 counters on Olag equal to the number of creature cards exiled with it.",
             "colours": [
@@ -10120,7 +10120,7 @@
         },
         {
             "id": "5391aca1-89c6-53ea-be08-bb78e3bd64d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b203be6f-c565-4d8f-b200-b537569a0292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b203be6f-c565-4d8f-b200-b537569a0292.jpg?1",
             "name": "Old Stickfingers",
             "text": "When you cast this spell, reveal cards from the top of your library until you reveal X creature cards. Put all creature cards revealed this way into your graveyard, then put the rest on the bottom of your library in a random order.\nOld Stickfingers's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -10160,7 +10160,7 @@
         },
         {
             "id": "f27c51ca-a19b-594a-8b9b-3c9c179bc6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31e307a-9689-4e11-8c5f-96b7a4b50bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31e307a-9689-4e11-8c5f-96b7a4b50bed.jpg?1",
             "name": "Rem Karolus, Stalwart Slayer",
             "text": "Flying, haste\nIf a spell would deal damage to you or another permanent you control, prevent that damage.\nIf a spell would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -10201,7 +10201,7 @@
         },
         {
             "id": "83f1d52e-a13e-59e5-b6de-8179577f6929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1a16f9-13d4-4188-8e1e-0f2394349c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1a16f9-13d4-4188-8e1e-0f2394349c7a.jpg?1",
             "name": "Rite of Harmony",
             "text": "Whenever a creature or enchantment enters the battlefield under your control this turn, draw a card.\nFlashback {2}{G}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10237,7 +10237,7 @@
         },
         {
             "id": "c4e8f1a9-1382-59cc-8286-67266bf2a9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f8d52-565e-4900-8357-fd29f2022dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f8d52-565e-4900-8357-fd29f2022dc1.jpg?1",
             "name": "Rite of Oblivion",
             "text": "As an additional cost to cast this spell, sacrifice a nonland permanent.\nExile target nonland permanent.\nFlashback {2}{W}{B} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -10271,7 +10271,7 @@
         },
         {
             "id": "989faa25-f8a6-58a5-b960-9f3320c13a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3743cf9c-226f-43a3-b385-375a25414792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3743cf9c-226f-43a3-b385-375a25414792.jpg?1",
             "name": "Rootcoil Creeper",
             "text": "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this mana only to cast spells from your graveyard.\n{G}{U}, {T}, Exile Rootcoil Creeper: Return target card with flashback you own from exile to your hand.",
             "colours": [
@@ -10308,7 +10308,7 @@
         },
         {
             "id": "c3dd074c-2b42-51bf-b791-f7f84be7a9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b1dcd7-6dd9-4134-bc6c-9dc7754006a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b1dcd7-6dd9-4134-bc6c-9dc7754006a2.jpg?1",
             "name": "Sacred Fire",
             "text": "Sacred Fire deals 2 damage to any target and you gain 2 life.\nFlashback {4}{R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10342,7 +10342,7 @@
         },
         {
             "id": "accfa508-c69a-5546-b200-f6bfd6c3c9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cf357-c231-4512-aa9a-ab4a60007136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cf357-c231-4512-aa9a-ab4a60007136.jpg?1",
             "name": "Sigarda, Champion of Light",
             "text": "Flying, trample\nHumans you control get +1/+1.\nCoven \u2014 Whenever Sigarda attacks, if you control three or more creatures with different powers, look at the top five cards of your library. You may reveal a Human creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10382,7 +10382,7 @@
         },
         {
             "id": "ab2df273-6324-5079-bd6a-3f4c572fae2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d329e2d4-e483-4981-8a0b-6a9a717d50cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d329e2d4-e483-4981-8a0b-6a9a717d50cd.jpg?1",
             "name": "Siphon Insight",
             "text": "Look at the top two cards of target opponent's library. Exile one of them face down and put the other on the bottom of that library. You may look at and play the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\nFlashback {1}{U}{B}",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "6b13d83e-6026-55e2-9038-cd6459ffec18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94e888b-6eeb-4ef3-ab21-5ed2bf0036a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94e888b-6eeb-4ef3-ab21-5ed2bf0036a3.jpg?1",
             "name": "Slogurk, the Overslime",
             "text": "Trample\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Slogurk, the Overslime.\nRemove three +1/+1 counters from Slogurk: Return it to its owner's hand.\nWhen Slogurk leaves the battlefield, return up to three target land cards from your graveyard to your hand.",
             "colours": [
@@ -10458,7 +10458,7 @@
         },
         {
             "id": "a558119d-ae11-5088-9a6a-0312495280f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49618f-2e9e-4674-9953-153ccc76cce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49618f-2e9e-4674-9953-153ccc76cce2.jpg?1",
             "name": "Storm Skreelix",
             "text": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, Storm Skreelix gets +2/+0 until end of turn.",
             "colours": [
@@ -10495,7 +10495,7 @@
         },
         {
             "id": "760a76c4-bc08-5780-898d-9d4da3880a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0081b1-40fd-44ad-b154-efe2f27fed6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0081b1-40fd-44ad-b154-efe2f27fed6b.jpg?1",
             "name": "Sunrise Cavalier",
             "text": "Trample, haste\nIf it's neither day nor night, it becomes day as Sunrise Cavalier enters the battlefield.\nWhenever day becomes night or night becomes day, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -10532,7 +10532,7 @@
         },
         {
             "id": "39c5ef1d-b358-539e-b3fc-41573cc30c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2e18d4-986c-4a44-8f26-1b8689339cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2e18d4-986c-4a44-8f26-1b8689339cfb.jpg?1",
             "name": "Teferi, Who Slows the Sunset",
             "text": "+1: Choose up to one target artifact, up to one target creature, and up to one target land. Untap the chosen permanents you control. Tap the chosen permanents you don't control. You gain 2 life.\n\u22122: Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\n\u22127: You get an emblem with \"Untap all permanents you control during each opponent's untap step\" and \"You draw a card during each opponent's draw step.\"",
             "colours": [
@@ -10572,7 +10572,7 @@
         },
         {
             "id": "21dd2fa3-93db-5255-9553-232ed6c9955f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "Whenever a Wolf or Werewolf you control deals combat damage to a player, draw a card.\nAt the beginning of your upkeep, if you control three or more Wolves and/or Werewolves, it becomes night. Then transform any number of Human Werewolves you control.\nDaybound",
             "colours": [
@@ -10613,7 +10613,7 @@
         },
         {
             "id": "25891f92-590d-5834-8e0e-492996255bee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "Whenever a Wolf or Werewolf you control deals combat damage to a player, draw a card.\n{X}{R}{G}: Target Wolf or Werewolf you control gets +X/+0 and gains trample until end of turn.\nNightbound",
             "colours": [
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "9ca6be69-b310-5be1-a842-24abe2ce58e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdd9df1-6a3b-4f03-8eca-00ed22c02566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdd9df1-6a3b-4f03-8eca-00ed22c02566.jpg?1",
             "name": "Unnatural Moonrise",
             "text": "It becomes night. Until end of turn, target creature gets +1/+0 and gains trample and \"Whenever this creature deals combat damage to a player, draw a card.\"\nFlashback {2}{R}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "8955b15c-162e-5f2f-a3e7-538031a3e6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454666bb-f81d-4845-84aa-d6f8f80ce86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454666bb-f81d-4845-84aa-d6f8f80ce86a.jpg?1",
             "name": "Vadrik, Astral Archmage",
             "text": "If it's neither day nor night, it becomes day as Vadrik, Astral Archmage enters the battlefield.\nInstant and sorcery spells you cast cost {X} less to cast, where X is Vadrik's power.\nWhenever day becomes night or night becomes day, put a +1/+1 counter on Vadrik.",
             "colours": [
@@ -10728,7 +10728,7 @@
         },
         {
             "id": "02337410-6162-5634-b77a-fe1a7464458d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07cbf04-2864-4407-800e-4d55c10d3426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07cbf04-2864-4407-800e-4d55c10d3426.jpg?1",
             "name": "Vampire Socialite",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Vampire Socialite enters the battlefield, if an opponent lost life this turn, put a +1/+1 counter on each other Vampire you control.\nAs long as an opponent lost life this turn, each other Vampire you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -10765,7 +10765,7 @@
         },
         {
             "id": "1280443a-97ef-554d-803a-b1eba8ec8de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f02a544-716c-4f09-8ae9-dbfe7ef136d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f02a544-716c-4f09-8ae9-dbfe7ef136d7.jpg?1",
             "name": "Wake to Slaughter",
             "text": "Choose up to two target creature cards in your graveyard. An opponent chooses one of them. Return that card to your hand. Return the other to the battlefield under your control. It gains haste. Exile it at the beginning of the next end step.\nFlashback {4}{B}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "d13957a4-3f58-5bbb-a862-780eeae0ee48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e9edd3-151d-4bf6-b491-03db9db32234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e9edd3-151d-4bf6-b491-03db9db32234.jpg?1",
             "name": "Winterthorn Blessing",
             "text": "Put a +1/+1 counter on up to one target creature you control. Tap up to one target creature you don't control, and that creature doesn't untap during its controller's next untap step.\nFlashback {1}{G}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10835,7 +10835,7 @@
         },
         {
             "id": "bc06cbe5-e4ff-54d9-b504-a5c7b3333124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39226a07-d44e-41a6-b9f1-685ef505d015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39226a07-d44e-41a6-b9f1-685ef505d015.jpg?1",
             "name": "The Celestus",
             "text": "If it's neither day nor night, it becomes day as The Celestus enters the battlefield.\n{T}: Add one mana of any color.\n{3}, {T}: If it's night, it becomes day. Otherwise, it becomes night. Activate only as a sorcery.\nWhenever day becomes night or night becomes day, you gain 1 life. You may draw a card. If you do, discard a card.",
             "colours": [],
@@ -10867,7 +10867,7 @@
         },
         {
             "id": "141d1f58-946a-5630-bdf1-9df88e80010e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad1524-9e75-47e0-b817-47110634802a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad1524-9e75-47e0-b817-47110634802a.jpg?1",
             "name": "Crossroads Candleguide",
             "text": "When Crossroads Candleguide enters the battlefield, exile up to one target card from a graveyard.\n{2}: Add one mana of any color.",
             "colours": [],
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "41faef03-46c3-5383-91af-1441066834ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b589ab-45a0-480a-a891-581c34f8a9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b589ab-45a0-480a-a891-581c34f8a9bf.jpg?1",
             "name": "Jack-o'-Lantern",
             "text": "{1}, {T}, Sacrifice Jack-o'-Lantern: Exile up to one target card from a graveyard. Draw a card.\n{1}, Exile Jack-o'-Lantern from your graveyard: Add one mana of any color.",
             "colours": [],
@@ -10926,7 +10926,7 @@
         },
         {
             "id": "b6b5758c-a97a-5b69-bc76-acc21b8aaf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87778e37-af92-402e-b037-5fbd6112b682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87778e37-af92-402e-b037-5fbd6112b682.jpg?1",
             "name": "Moonsilver Key",
             "text": "{1}, {T}, Sacrifice Moonsilver Key: Search your library for an artifact card with a mana ability or a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -10954,7 +10954,7 @@
         },
         {
             "id": "ea6f4366-b2b0-5bd8-ac96-497f5d728053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg?1",
             "name": "Mystic Skull // Mystic Monstrosity",
             "text": "{1}, {T}: Add one mana of any color.\n{5}, {T}: Transform Mystic Skull.",
             "colours": [],
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "dc22eeea-7a68-59c7-8422-a596d4189386",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg?1",
             "name": "Mystic Skull // Mystic Monstrosity",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"",
             "colours": [],
@@ -11013,7 +11013,7 @@
         },
         {
             "id": "fa514288-97e0-5ea7-8fd2-0c9272f6e19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556ec6ab-a19f-4caa-8bfa-145555402caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556ec6ab-a19f-4caa-8bfa-145555402caf.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -11043,7 +11043,7 @@
         },
         {
             "id": "757f1e1a-076f-5742-afab-5659af57dd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2c05a8-db56-4397-9b6c-5accb2d3f81f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2c05a8-db56-4397-9b6c-5accb2d3f81f.jpg?1",
             "name": "Silver Bolt",
             "text": "{3}, {T}, Sacrifice Silver Bolt: It deals 3 damage to target creature. If a Werewolf is dealt damage this way, destroy it.",
             "colours": [],
@@ -11071,7 +11071,7 @@
         },
         {
             "id": "003cf175-385c-5e76-b62a-04ff30703fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd40276-016b-475f-906f-74d31dceaf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd40276-016b-475f-906f-74d31dceaf70.jpg?1",
             "name": "Stuffed Bear",
             "text": "{2}: Stuffed Bear becomes a 4/4 green Bear artifact creature until end of turn.",
             "colours": [],
@@ -11099,7 +11099,7 @@
         },
         {
             "id": "351012c3-c774-5f06-8c0e-0f26017f011f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38367ee5-154b-44cb-8974-422038d039df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38367ee5-154b-44cb-8974-422038d039df.jpg?1",
             "name": "Deserted Beach",
             "text": "Deserted Beach enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "ba05d48d-8b06-5598-8d61-971b6fa899ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb471f90-46f2-4037-87fc-f523fc9d004f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb471f90-46f2-4037-87fc-f523fc9d004f.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11160,7 +11160,7 @@
         },
         {
             "id": "9e79b341-6d00-55e0-be68-e6a748eadcbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d510eece-4f55-4198-83fe-5291a76ffdcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d510eece-4f55-4198-83fe-5291a76ffdcc.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles.",
             "colours": [],
@@ -11188,7 +11188,7 @@
         },
         {
             "id": "a014a45e-0f72-5ec4-bfd2-5afda91512ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b200e822-be36-4e59-bd0e-9d0188a68df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b200e822-be36-4e59-bd0e-9d0188a68df8.jpg?1",
             "name": "Haunted Ridge",
             "text": "Haunted Ridge enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11221,7 +11221,7 @@
         },
         {
             "id": "f2aa39ee-e000-57d3-8e08-6db4b5114124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice a creature: Put a soul counter on Hostile Hostel. Then if there are three or more soul counters on it, remove those counters, transform it, then untap it. Activate only as a sorcery.",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "3cb1937e-97e5-53d9-b75b-93b4e74196f7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "Whenever Creeping Inn attacks, you may exile a creature card from your graveyard. If you do, each opponent loses X life and you gain X life, where X is the number of creature cards exiled with Creeping Inn.\n{4}: Creeping Inn phases out.",
             "colours": [
@@ -11291,7 +11291,7 @@
         },
         {
             "id": "2a2e75fd-9a21-5d4d-b83f-2d5c385e2a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a76e0f-49fc-4087-8859-98f4a4deacdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a76e0f-49fc-4087-8859-98f4a4deacdf.jpg?1",
             "name": "Overgrown Farmland",
             "text": "Overgrown Farmland enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "2b247b13-c724-53ee-bd2d-f832a6ae7ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaff0a1e-b65a-422f-8f9f-65fac037047d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaff0a1e-b65a-422f-8f9f-65fac037047d.jpg?1",
             "name": "Rockfall Vale",
             "text": "Rockfall Vale enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -11357,7 +11357,7 @@
         },
         {
             "id": "f335b77f-53ce-5cb9-b544-4f51d7939f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7579824a-6e46-442b-95ff-03fea4adbba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7579824a-6e46-442b-95ff-03fea4adbba6.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "Shipwreck Marsh enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11390,7 +11390,7 @@
         },
         {
             "id": "e409e1f5-59bd-51f0-be9c-4152342944c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1902d-0b09-4bbe-9059-a0779450ee05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1902d-0b09-4bbe-9059-a0779450ee05.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11427,7 +11427,7 @@
         },
         {
             "id": "bd8177b8-d7e7-5646-a284-86d746c3e5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acefadb-8b2f-4319-a5e9-1e8fd9ef3086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acefadb-8b2f-4319-a5e9-1e8fd9ef3086.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11464,7 +11464,7 @@
         },
         {
             "id": "53feba3f-3821-50eb-878f-d8a6f91ee1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3bd34-4d12-4728-a53a-b5ae434d74b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3bd34-4d12-4728-a53a-b5ae434d74b0.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11501,7 +11501,7 @@
         },
         {
             "id": "30f70fd7-525a-55d3-99a4-f5d6c9fbdf4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2cfa62-c972-4373-b405-a075697d009c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2cfa62-c972-4373-b405-a075697d009c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11538,7 +11538,7 @@
         },
         {
             "id": "fd072f4b-fa3d-55fd-8fce-9f4030d811ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ba59d8-c13c-4966-845f-c090e9f061cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ba59d8-c13c-4966-845f-c090e9f061cb.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "b2280552-f148-54a4-8217-7d136e5063f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fef662-993c-4522-8b3f-7c1d3bb1d946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fef662-993c-4522-8b3f-7c1d3bb1d946.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11612,7 +11612,7 @@
         },
         {
             "id": "44970d1e-88c1-565c-bf1b-abc6af8b365e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba24a61-e529-4490-8536-6276ea77c511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba24a61-e529-4490-8536-6276ea77c511.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11649,7 +11649,7 @@
         },
         {
             "id": "a0639963-8ec4-5013-9d71-5b8cd0b89675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c0731-555a-4bef-9d9e-b877f0339417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c0731-555a-4bef-9d9e-b877f0339417.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "ea2a2ba8-dec2-55c7-af4a-2de52d404cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8ff40e-2d40-4557-8209-d2c84eb4ccf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8ff40e-2d40-4557-8209-d2c84eb4ccf2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "0c1b7f25-d6cd-5897-bebf-003b5c97bb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122b5548-5ff5-43e4-b799-75c709b1c32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122b5548-5ff5-43e4-b799-75c709b1c32d.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11760,7 +11760,7 @@
         },
         {
             "id": "12ba2109-11e1-5562-bb15-57dbd0274276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3628a023-3f69-4b7f-a6cc-42e4293ecfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3628a023-3f69-4b7f-a6cc-42e4293ecfdd.jpg?1",
             "name": "Wrenn and Seven",
             "text": "+1: Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.\n0: Put any number of land cards from your hand onto the battlefield tapped.\n\u22123: Create a green Treefolk creature token with reach and \"This creature's power and toughness are each equal to the number of lands you control.\"\n\u22128: Return all permanent cards from your graveyard to your hand. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -11798,7 +11798,7 @@
         },
         {
             "id": "3fd7e042-f38d-527e-a7d8-4685c437f511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Daybound\n+1: Until your next turn, you may cast creature spells as though they had flash, and each creature you control enters the battlefield with an additional +1/+1 counter on it.\n\u22123: Create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -11839,7 +11839,7 @@
         },
         {
             "id": "475c8a1d-471b-5f3e-a38c-6f5d8b347728",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Nightbound\n+2: Add {R}{G}.\n0: Until end of turn, Arlinn, the Moon's Fury becomes a 5/5 Werewolf creature with trample, indestructible, and haste.",
             "colours": [
@@ -11880,7 +11880,7 @@
         },
         {
             "id": "3ab9c25b-29b0-55f1-8d4b-fa4af73edda0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94bc06c-6351-43d3-a58d-b28dc6d4705c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94bc06c-6351-43d3-a58d-b28dc6d4705c.jpg?1",
             "name": "Teferi, Who Slows the Sunset",
             "text": "+1: Choose up to one target artifact, up to one target creature, and up to one target land. Untap the chosen permanents you control. Tap the chosen permanents you don't control. You gain 2 life.\n\u22122: Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\n\u22127: You get an emblem with \"Untap all permanents you control during each opponent's untap step\" and \"You draw a card during each opponent's draw step.\"",
             "colours": [
@@ -11920,7 +11920,7 @@
         },
         {
             "id": "d99b271d-f536-5915-8f24-c8d8258d53d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c092d9c5-538f-4667-9070-bdce7f8b522a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c092d9c5-538f-4667-9070-bdce7f8b522a.jpg?1",
             "name": "Deserted Beach",
             "text": "Deserted Beach enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11953,7 +11953,7 @@
         },
         {
             "id": "86a2b881-0180-5193-a19c-fdff17758b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f67a64-b97d-473a-be9d-c8044ff86605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f67a64-b97d-473a-be9d-c8044ff86605.jpg?1",
             "name": "Haunted Ridge",
             "text": "Haunted Ridge enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11986,7 +11986,7 @@
         },
         {
             "id": "4c33d27d-81de-57cc-9221-2978181e386d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46aa097-ad92-4f9a-be52-e4e485a8fe99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46aa097-ad92-4f9a-be52-e4e485a8fe99.jpg?1",
             "name": "Overgrown Farmland",
             "text": "Overgrown Farmland enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -12019,7 +12019,7 @@
         },
         {
             "id": "d90a0378-4141-586a-b509-c7d314db4eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcc5d4-babd-4b66-95fa-c5ec6c49e93a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcc5d4-babd-4b66-95fa-c5ec6c49e93a.jpg?1",
             "name": "Rockfall Vale",
             "text": "Rockfall Vale enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -12052,7 +12052,7 @@
         },
         {
             "id": "09fbb7b1-eebd-5107-8bb8-c9bc5a9f9ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad2562-fc26-40a1-9e6c-21f4f88dc2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad2562-fc26-40a1-9e6c-21f4f88dc2d8.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "Shipwreck Marsh enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -12085,7 +12085,7 @@
         },
         {
             "id": "e56c6f8e-adde-502e-bfa0-07bc52f23149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "",
             "colours": [
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "5e2ceecd-3161-50c0-ac36-cd44c2560544",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "",
             "colours": [
@@ -12161,7 +12161,7 @@
         },
         {
             "id": "bbfbd4af-b08a-55ca-8387-2ae8f2b9c19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482c0eab-326b-41db-9be6-f98d15bbd0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482c0eab-326b-41db-9be6-f98d15bbd0af.jpg?1",
             "name": "Candlegrove Witch",
             "text": "",
             "colours": [
@@ -12198,7 +12198,7 @@
         },
         {
             "id": "b2c92d64-66d7-5dab-b542-3dfb3cc50682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da534-738e-4507-821f-f30956045646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da534-738e-4507-821f-f30956045646.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "",
             "colours": [
@@ -12237,7 +12237,7 @@
         },
         {
             "id": "c9626980-d33e-5921-9f4d-7ae8e7e47686",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783da534-738e-4507-821f-f30956045646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783da534-738e-4507-821f-f30956045646.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "",
             "colours": [
@@ -12274,7 +12274,7 @@
         },
         {
             "id": "ea873dbb-db1d-59df-a4b1-ddc23c8ee235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "",
             "colours": [
@@ -12312,7 +12312,7 @@
         },
         {
             "id": "4184eb6e-bced-5600-bf22-40c27a9c4303",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "",
             "colours": [
@@ -12348,7 +12348,7 @@
         },
         {
             "id": "0213e762-d29e-5ada-91c6-bf0ba369640e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "",
             "colours": [
@@ -12385,7 +12385,7 @@
         },
         {
             "id": "5a5913ef-4f7a-590c-a1c0-040644f1ff80",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "90f9b1ba-afee-5034-9bbc-88f173532548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "",
             "colours": [
@@ -12458,7 +12458,7 @@
         },
         {
             "id": "39aeadfe-9b78-5bb2-9053-8345a2beb281",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "",
             "colours": [
@@ -12494,7 +12494,7 @@
         },
         {
             "id": "1f7dd0fc-6046-51ad-b51e-035bacedf3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "",
             "colours": [
@@ -12531,7 +12531,7 @@
         },
         {
             "id": "02b97bcd-3058-5fa5-9e1b-21652be29823",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "",
             "colours": [
@@ -12567,7 +12567,7 @@
         },
         {
             "id": "edc204dc-f2f9-5aa5-99de-ac3d42ba2d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "",
             "colours": [
@@ -12604,7 +12604,7 @@
         },
         {
             "id": "dcade9bb-d061-5f93-8c15-e2fba766b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "",
             "colours": [
@@ -12640,7 +12640,7 @@
         },
         {
             "id": "29563237-0610-5ac1-b892-66077c5c15e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "",
             "colours": [
@@ -12677,7 +12677,7 @@
         },
         {
             "id": "2639054a-d2fa-5e5d-9ab0-14590ff5536f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "",
             "colours": [
@@ -12713,7 +12713,7 @@
         },
         {
             "id": "03df0b18-20fb-5a47-bc75-fdcbcd9bbda3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "",
             "colours": [
@@ -12751,7 +12751,7 @@
         },
         {
             "id": "8ffe8af6-6b6d-554d-be08-90cf2d25c92e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "",
             "colours": [
@@ -12787,7 +12787,7 @@
         },
         {
             "id": "5f7ad8e0-4115-5a28-acb0-7f7a2bf0c35f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "",
             "colours": [
@@ -12825,7 +12825,7 @@
         },
         {
             "id": "169bc3fe-3455-5839-abdf-2ac315cf089f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "",
             "colours": [
@@ -12861,7 +12861,7 @@
         },
         {
             "id": "ff29a4ba-5f08-58a1-bec4-b76a1bc46132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "",
             "colours": [
@@ -12898,7 +12898,7 @@
         },
         {
             "id": "4c545fd3-f58f-5804-8271-84b071d36922",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "",
             "colours": [
@@ -12934,7 +12934,7 @@
         },
         {
             "id": "3e6d1b67-1658-572a-9837-e2be8757273d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "",
             "colours": [
@@ -12972,7 +12972,7 @@
         },
         {
             "id": "9c4e07b8-cfb9-5b23-896e-df00754fa6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "",
             "colours": [
@@ -13008,7 +13008,7 @@
         },
         {
             "id": "fe2e87d2-9137-5dd2-9e75-a69e99c69b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "",
             "colours": [
@@ -13045,7 +13045,7 @@
         },
         {
             "id": "7d1e631a-8a9e-576f-8af2-3340f4e5eb38",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "",
             "colours": [
@@ -13081,7 +13081,7 @@
         },
         {
             "id": "609d9b83-1654-5b83-9ad7-fa04c1b699dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac558d9d-5c7d-4671-ae0b-94c099e1b111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac558d9d-5c7d-4671-ae0b-94c099e1b111.jpg?1",
             "name": "Dawnhart Mentor",
             "text": "",
             "colours": [
@@ -13118,7 +13118,7 @@
         },
         {
             "id": "24d91edc-d425-56e6-844d-f1e4415cc61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0e267-c361-4224-9b7a-2a3d1c5ac8b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0e267-c361-4224-9b7a-2a3d1c5ac8b4.jpg?1",
             "name": "Dawnhart Rejuvenator",
             "text": "",
             "colours": [
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "3f5db88a-c842-5b81-bb3c-bfbbeb5656e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "5038a68d-90a1-59bc-9789-9ae4ac742693",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "",
             "colours": [
@@ -13228,7 +13228,7 @@
         },
         {
             "id": "bdc48922-e194-5bb2-8d15-7ad4e3feaa7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "",
             "colours": [
@@ -13265,7 +13265,7 @@
         },
         {
             "id": "c5f47619-454a-5bd9-a4f9-356b63ee3843",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "",
             "colours": [
@@ -13301,7 +13301,7 @@
         },
         {
             "id": "eb78c8c1-6f1e-517b-acd1-a82d43afa2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a07fd28-0b65-4ff0-96c6-7e88fc89b0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a07fd28-0b65-4ff0-96c6-7e88fc89b0a5.jpg?1",
             "name": "Saryth, the Viper's Fang",
             "text": "",
             "colours": [
@@ -13340,7 +13340,7 @@
         },
         {
             "id": "df31259e-32b9-5a07-99a3-35131f7f5f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "",
             "colours": [
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "5337f113-b1fd-5068-ab12-9fd2de4f8b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "",
             "colours": [
@@ -13413,7 +13413,7 @@
         },
         {
             "id": "27ef4628-f66b-5e6e-8682-feac25f113d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "",
             "colours": [
@@ -13450,7 +13450,7 @@
         },
         {
             "id": "fbd27c73-fdae-5fe3-8202-07fd6055c354",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "",
             "colours": [
@@ -13486,7 +13486,7 @@
         },
         {
             "id": "ea2712fb-2ca0-55cb-8434-bf2ff1dccb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "",
             "colours": [
@@ -13527,7 +13527,7 @@
         },
         {
             "id": "10d29748-f5ba-5985-9571-94d9f62db638",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "",
             "colours": [
@@ -13568,7 +13568,7 @@
         },
         {
             "id": "265dde3c-967b-5c4e-9bd2-0ee83397d65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c410dc-123c-4431-9ccb-3f17e6555d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c410dc-123c-4431-9ccb-3f17e6555d68.jpg?1",
             "name": "Dawnhart Wardens",
             "text": "",
             "colours": [
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "714a97fa-fa5a-5573-89ea-4db1d65e95c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef98a2c-4b48-45e3-bbcb-9fd338f5a05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef98a2c-4b48-45e3-bbcb-9fd338f5a05a.jpg?1",
             "name": "Katilda, Dawnhart Prime",
             "text": "",
             "colours": [
@@ -13648,7 +13648,7 @@
         },
         {
             "id": "6a786f93-a683-5e01-aed5-c562792bb3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "",
             "colours": [
@@ -13687,7 +13687,7 @@
         },
         {
             "id": "6f8311df-09ae-5566-b87a-44536b4be31a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "4ccceecf-4286-5707-9647-98722cc397a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -13766,7 +13766,7 @@
         },
         {
             "id": "bf95c01c-6b7d-5455-a9b2-22015b6d9fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -13806,7 +13806,7 @@
         },
         {
             "id": "68d45fcc-98ec-54b1-beb7-b75b0a004c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f71585a-3ea8-40f8-8e02-e155477fd8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f71585a-3ea8-40f8-8e02-e155477fd8b5.jpg?1",
             "name": "Adeline, Resplendent Cathar",
             "text": "Vigilance\nAdeline, Resplendent Cathar's power is equal to the number of creatures you control.\nWhenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "c7d342ae-4e83-5638-b5d6-d6794acf446f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d67b9ec-7f53-4df6-b2cc-afd7efda6bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d67b9ec-7f53-4df6-b2cc-afd7efda6bb4.jpg?1",
             "name": "Lier, Disciple of the Drowned",
             "text": "Spells can't be countered.\nEach instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -13884,7 +13884,7 @@
         },
         {
             "id": "d0e72986-90b3-51b5-9217-3e343dafd9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473f95a-b004-41ad-9729-0242c8b2a5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473f95a-b004-41ad-9729-0242c8b2a5ee.jpg?1",
             "name": "Gisa, Glorious Resurrector",
             "text": "If a creature an opponent controls would die, exile it instead.\nAt the beginning of your upkeep, put all creature cards exiled with Gisa, Glorious Resurrector onto the battlefield under your control. They gain decayed.",
             "colours": [
@@ -13923,7 +13923,7 @@
         },
         {
             "id": "783f4f0a-6972-5600-8e3f-88f25ce86f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ec5be-501c-4a5d-8b2a-f974c6cf06c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ec5be-501c-4a5d-8b2a-f974c6cf06c6.jpg?1",
             "name": "Jadar, Ghoulcaller of Nephalia",
             "text": "At the beginning of your end step, if you control no creatures with decayed, create a 2/2 black Zombie creature token with decayed.",
             "colours": [
@@ -13962,7 +13962,7 @@
         },
         {
             "id": "d17751e2-20f5-5846-a59f-6ed2fca8ef92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Whenever Jerren, Corrupted Bishop enters the battlefield or another nontoken Human you control dies, you lose 1 life and create a 1/1 white Human creature token.\n{2}: Target Human you control gains lifelink until end of turn.\nAt the beginning of your end step, if you have exactly 13 life, you may pay {4}{B}{B}. If you do, transform Jerren.",
             "colours": [
@@ -14001,7 +14001,7 @@
         },
         {
             "id": "dce9236c-17c2-5531-be19-2754a72872f5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Flying, trample, lifelink\nSacrifice another creature: Draw a card.",
             "colours": [
@@ -14039,7 +14039,7 @@
         },
         {
             "id": "0badba9d-4b10-53f6-a79b-07f7d2579573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Lifelink\nCards in graveyards can't be the targets of spells or abilities.\nDisturb {2}{W}{U}",
             "colours": [
@@ -14080,7 +14080,7 @@
         },
         {
             "id": "5de39a9c-6fe7-5145-b6d1-8db371736aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Flying\nWhenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn.\nIf Dennick, Pious Apparition would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14121,7 +14121,7 @@
         },
         {
             "id": "01ba390c-e8d8-55b1-9b8e-7659052f0b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b100ae-5795-4583-88a1-a428b090a80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b100ae-5795-4583-88a1-a428b090a80f.jpg?1",
             "name": "Florian, Voldaren Scion",
             "text": "First strike\nAt the beginning of your postcombat main phase, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -14162,7 +14162,7 @@
         },
         {
             "id": "ea8f1dec-7ac6-5eec-9b89-5de3cc2c8c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a4ecfa-8173-4c9b-a28f-dc06e63491de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a4ecfa-8173-4c9b-a28f-dc06e63491de.jpg?1",
             "name": "Liesa, Forgotten Archangel",
             "text": "Flying, lifelink\nWhenever another nontoken creature you control dies, return that card to its owner's hand at the beginning of the next end step.\nIf a creature an opponent controls would die, exile it instead.",
             "colours": [
@@ -14202,7 +14202,7 @@
         },
         {
             "id": "39e16458-2330-5531-8aa4-6e57ad6991a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "Whenever Ludevic, Necrogenius enters the battlefield or attacks, mill a card.\n{X}{U}{U}{B}{B}, Exile X creature cards from your graveyard: Transform Ludevic. X can't be 0. Activate only as a sorcery.",
             "colours": [
@@ -14243,7 +14243,7 @@
         },
         {
             "id": "ec907727-b46e-549f-9d54-c066c89c4ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "As this creature transforms into Olag, Ludevic's Hubris, it becomes a copy of a creature card exiled with it, except its name is Olag, Ludevic's Hubris, it's 4/4, and it's a legendary blue and black Zombie in addition to its other colors and types. Put a number of +1/+1 counters on Olag equal to the number of creature cards exiled with it.",
             "colours": [
@@ -14283,7 +14283,7 @@
         },
         {
             "id": "65988925-a62b-57f2-8f0b-d49084f00210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a0dc21-c202-4cef-9e67-26b9dd24d565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a0dc21-c202-4cef-9e67-26b9dd24d565.jpg?1",
             "name": "Old Stickfingers",
             "text": "When you cast this spell, reveal cards from the top of your library until you reveal X creature cards. Put all creature cards revealed this way into your graveyard, then put the rest on the bottom of your library in a random order.\nOld Stickfingers's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -14323,7 +14323,7 @@
         },
         {
             "id": "059a66ff-914c-5c13-b72a-8f3c1abab159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54105a7-c369-40a8-8b37-610821c0fd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54105a7-c369-40a8-8b37-610821c0fd08.jpg?1",
             "name": "Rem Karolus, Stalwart Slayer",
             "text": "Flying, haste\nIf a spell would deal damage to you or another permanent you control, prevent that damage.\nIf a spell would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "6d5e744e-daa1-59cb-bf05-77f8bd086b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b66f1b-9341-461d-9f10-a808be1ac324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b66f1b-9341-461d-9f10-a808be1ac324.jpg?1",
             "name": "Sigarda, Champion of Light",
             "text": "Flying, trample\nHumans you control get +1/+1.\nCoven \u2014 Whenever Sigarda attacks, if you control three or more creatures with different powers, look at the top five cards of your library. You may reveal a Human creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14404,7 +14404,7 @@
         },
         {
             "id": "729588c9-b436-5116-93e8-f1109ae69a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a03a8-df78-43fb-a811-478be5983e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a03a8-df78-43fb-a811-478be5983e91.jpg?1",
             "name": "Slogurk, the Overslime",
             "text": "Trample\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Slogurk, the Overslime.\nRemove three +1/+1 counters from Slogurk: Return it to its owner's hand.\nWhen Slogurk leaves the battlefield, return up to three target land cards from your graveyard to your hand.",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "b8dbb572-c6e6-5ae6-beac-b0dbb0a64488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e4a483-727d-45f4-bf20-47d94d37e0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e4a483-727d-45f4-bf20-47d94d37e0d0.jpg?1",
             "name": "Vadrik, Astral Archmage",
             "text": "If it's neither day nor night, it becomes day as Vadrik, Astral Archmage enters the battlefield.\nInstant and sorcery spells you cast cost {X} less to cast, where X is Vadrik's power.\nWhenever day becomes night or night becomes day, put a +1/+1 counter on Vadrik.",
             "colours": [
@@ -14485,7 +14485,7 @@
         },
         {
             "id": "107e694d-ae13-51bc-aa5b-ace492adcf7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719030bb-59f9-4d42-b7be-7f06e9cada4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719030bb-59f9-4d42-b7be-7f06e9cada4d.jpg?1",
             "name": "Curse of Silence",
             "text": "Enchant player\nAs Curse of Silence enters the battlefield, choose a card name.\nSpells with the chosen name enchanted player casts cost {2} more to cast.\nWhenever enchanted player casts a spell with the chosen name, you may sacrifice Curse of Silence. If you do, draw a card.",
             "colours": [
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "19c789ca-ba96-572f-8cb3-767cbb681f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying, double strike\nYou have hexproof.\nIf your life total would be reduced to 0 or less, instead transform Enduring Angel and your life total becomes 3. Then if Enduring Angel didn't transform this way, you lose the game.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "279fa126-de86-52cb-a31b-f8e41661aa90",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying\nYou have hexproof.\nAngelic Enforcer's power and toughness are each equal to your life total.\nWhenever Angelic Enforcer attacks, double your life total.",
             "colours": [
@@ -14594,7 +14594,7 @@
         },
         {
             "id": "00d0df58-8fe1-5ae3-8899-f62700e0cbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf1ab2-4d6b-4e81-b537-82889aab767d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf1ab2-4d6b-4e81-b537-82889aab767d.jpg?1",
             "name": "Fateful Absence",
             "text": "Destroy target creature or planeswalker. Its controller investigates.",
             "colours": [
@@ -14628,7 +14628,7 @@
         },
         {
             "id": "64eaa9c2-c1d8-56b3-a97e-02bd7e4f4e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651d249f-6771-41ed-8ccf-c8fa85419a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651d249f-6771-41ed-8ccf-c8fa85419a75.jpg?1",
             "name": "Intrepid Adversary",
             "text": "Lifelink\nWhen Intrepid Adversary enters the battlefield, you may pay {1}{W} any number of times. When you pay this cost one or more times, put that many valor counters on Intrepid Adversary.\nCreatures you control get +1/+1 for each valor counter on Intrepid Adversary.",
             "colours": [
@@ -14665,7 +14665,7 @@
         },
         {
             "id": "1b403902-0ac7-505e-a950-cf9ee2d9a4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56271daf-f5d1-4256-852a-5b746c83e666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56271daf-f5d1-4256-852a-5b746c83e666.jpg?1",
             "name": "Sigarda's Splendor",
             "text": "As Sigarda's Splendor enters the battlefield, note your life total.\nAt the beginning of your upkeep, draw a card if your life total is greater than or equal to the last noted life total for Sigarda's Splendor. Then note your life total.\nWhenever you cast a white spell, you gain 1 life.",
             "colours": [
@@ -14699,7 +14699,7 @@
         },
         {
             "id": "7c8ae116-70ef-5fa5-8926-43e77ed3f298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1b95e-7f1a-4918-85f6-41df3f7d3cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1b95e-7f1a-4918-85f6-41df3f7d3cce.jpg?1",
             "name": "Sigardian Savior",
             "text": "Flying\nWhen Sigardian Savior enters the battlefield, if you cast it, return up to two target creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -14735,7 +14735,7 @@
         },
         {
             "id": "405b743c-6fb0-5ccb-9441-7b09e0be0276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd31f9-2bdb-42f6-8436-d6dd4b546856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd31f9-2bdb-42f6-8436-d6dd4b546856.jpg?1",
             "name": "Sungold Sentinel",
             "text": "Whenever Sungold Sentinel enters the battlefield or attacks, exile up to one target card from a graveyard.\nCoven \u2014 {1}{W}: Choose a color. Sungold Sentinel gains hexproof from that color until end of turn and can't be blocked by creatures of that color this turn. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -14772,7 +14772,7 @@
         },
         {
             "id": "baf64e45-bb54-52b1-bbef-0038fc69ff22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0153894b-ef77-4a0d-b93d-5b06fdcbd9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0153894b-ef77-4a0d-b93d-5b06fdcbd9f3.jpg?1",
             "name": "Vanquish the Horde",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nDestroy all creatures.",
             "colours": [
@@ -14806,7 +14806,7 @@
         },
         {
             "id": "f39a9faf-529b-5af2-922a-070ca1046db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f9995c-c8f4-48d8-8ee0-65c168af2005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f9995c-c8f4-48d8-8ee0-65c168af2005.jpg?1",
             "name": "Curse of Surveillance",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, any number of target players other than that player each draw cards equal to the number of Curses attached to that player.",
             "colours": [
@@ -14843,7 +14843,7 @@
         },
         {
             "id": "66510916-582d-5d44-927e-5b3889389148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5a33a7-50be-497c-bb5e-e044cf12edce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5a33a7-50be-497c-bb5e-e044cf12edce.jpg?1",
             "name": "Grafted Identity",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nEnchant creature\nYou control enchanted creature.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -14880,7 +14880,7 @@
         },
         {
             "id": "1d93b6ef-e162-5487-a36e-3517d5657a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "{U}, Sacrifice Malevolent Hermit: Counter target noncreature spell unless its controller pays {3}.\nDisturb {2}{U}",
             "colours": [
@@ -14917,7 +14917,7 @@
         },
         {
             "id": "867aa5e8-b9ee-5cbc-ae7e-8a22e26da2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14954,7 +14954,7 @@
         },
         {
             "id": "b4ed2f0d-4428-5e4b-b372-6ca838004980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2d6292-d444-48a0-9dca-207ebcdbd4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2d6292-d444-48a0-9dca-207ebcdbd4f5.jpg?1",
             "name": "Memory Deluge",
             "text": "Look at the top X cards of your library, where X is the amount of mana spent to cast this spell. Put two of them into your hand and the rest on the bottom of your library in a random order.\nFlashback {5}{U}{U}",
             "colours": [
@@ -14988,7 +14988,7 @@
         },
         {
             "id": "4d3312f5-6224-5da5-a68c-51c98902b793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0eb016-8842-4ff2-a202-f32213b06e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0eb016-8842-4ff2-a202-f32213b06e18.jpg?1",
             "name": "Patrician Geist",
             "text": "Flying\nOther Spirits you control get +1/+1.\nSpells you cast from your graveyard cost {1} less to cast.",
             "colours": [
@@ -15025,7 +15025,7 @@
         },
         {
             "id": "817807ae-1230-54c4-a0e5-56b858e8e72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 black Zombie creature token with decayed.\nAt the beginning of your upkeep, if you control three or more creature tokens, you may transform Poppet Stitcher.",
             "colours": [
@@ -15062,7 +15062,7 @@
         },
         {
             "id": "c89048fd-f699-5642-87da-6de5d4542fee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Creature tokens you control lose all abilities and have base power and toughness 3/3.\nAt the beginning of your upkeep, you may transform Poppet Factory.",
             "colours": [
@@ -15096,7 +15096,7 @@
         },
         {
             "id": "ddcee35d-1104-58ea-b538-8b5026a5d57e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b1195a-61ab-44ac-8079-355d5b862630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b1195a-61ab-44ac-8079-355d5b862630.jpg?1",
             "name": "Sludge Monster",
             "text": "Whenever Sludge Monster enters the battlefield or attacks, put a slime counter on up to one other target creature.\nNon-Horror creatures with slime counters on them lose all abilities and have base power and toughness 2/2.",
             "colours": [
@@ -15132,7 +15132,7 @@
         },
         {
             "id": "72d15706-f62a-5800-8942-6e0e1c065436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320b73c-408a-4dc5-bfc9-3d2717a21397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320b73c-408a-4dc5-bfc9-3d2717a21397.jpg?1",
             "name": "Spectral Adversary",
             "text": "Flash\nFlying\nWhen Spectral Adversary enters the battlefield, you may pay {1}{U} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Spectral Adversary, then up to that many other target artifacts, creatures, and/or enchantments phase out.",
             "colours": [
@@ -15168,7 +15168,7 @@
         },
         {
             "id": "974e8752-24d2-5d64-850c-7a7a24e176c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed68800-3fc6-4b0e-a624-8be3beeed92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed68800-3fc6-4b0e-a624-8be3beeed92f.jpg?1",
             "name": "Triskaidekaphile",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, if you have exactly thirteen cards in your hand, you win the game.\n{3}{U}: Draw a card.",
             "colours": [
@@ -15206,7 +15206,7 @@
         },
         {
             "id": "c8de3efc-05e3-5c27-9161-15c1315f1408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0069688d-6fc8-466e-8b53-11f0ada87b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0069688d-6fc8-466e-8b53-11f0ada87b21.jpg?1",
             "name": "Bloodline Culling",
             "text": "Choose one \u2014\n\u2022 Target creature gets -5/-5 until end of turn.\n\u2022 Creature tokens get -2/-2 until end of turn.",
             "colours": [
@@ -15240,7 +15240,7 @@
         },
         {
             "id": "246ad66c-5321-5c59-bb37-b41341f6c145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b384260-9bf9-40f4-8a49-cc4936531a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b384260-9bf9-40f4-8a49-cc4936531a89.jpg?1",
             "name": "Champion of the Perished",
             "text": "Whenever another Zombie enters the battlefield under your control, put a +1/+1 counter on Champion of the Perished.",
             "colours": [
@@ -15277,7 +15277,7 @@
         },
         {
             "id": "90c4f64e-5da4-5ef2-9938-e4b62f12fe13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Enchant player\nAs this permanent transforms into Curse of Leeches, attach it to a player.\nAt the beginning of enchanted player's upkeep, they lose 1 life and you gain 1 life.\nDaybound",
             "colours": [
@@ -15314,7 +15314,7 @@
         },
         {
             "id": "6f1f9d88-d36c-552b-8ca1-ba444cb21d62",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Lifelink\nNightbound",
             "colours": [
@@ -15351,7 +15351,7 @@
         },
         {
             "id": "ac35fbfd-bf43-5c90-a68f-6f50d0baabb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bfb784-03e9-408f-b7f5-18c1dab4f12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bfb784-03e9-408f-b7f5-18c1dab4f12f.jpg?1",
             "name": "Lord of the Forsaken",
             "text": "Flying, trample\n{B}, Sacrifice another creature: Target player mills three cards.\nPay 1 life: Add {C}. Spend this mana only to cast a spell from your graveyard.",
             "colours": [
@@ -15387,7 +15387,7 @@
         },
         {
             "id": "031b0df6-5f62-5156-8007-b12331e48a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1490037d-bd86-449d-baf4-cbedcdae3922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1490037d-bd86-449d-baf4-cbedcdae3922.jpg?1",
             "name": "Mask of Griselbrand",
             "text": "Equipped creature has flying and lifelink.\nWhenever equipped creature dies, you may pay X life, where X is its power. If you do, draw X cards.\nEquip {3}",
             "colours": [
@@ -15425,7 +15425,7 @@
         },
         {
             "id": "1954bd8d-28b6-51a9-a3b4-80fc72dcb0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52593d64-182f-45ff-82c6-fb7649d36736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52593d64-182f-45ff-82c6-fb7649d36736.jpg?1",
             "name": "The Meathook Massacre",
             "text": "When The Meathook Massacre enters the battlefield, each creature gets -X/-X until end of turn.\nWhenever a creature you control dies, each opponent loses 1 life.\nWhenever a creature an opponent controls dies, you gain 1 life.",
             "colours": [
@@ -15461,7 +15461,7 @@
         },
         {
             "id": "fe7c40d9-bf5f-5688-90c9-7a6dec09c9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea62ec7-46cc-4023-8ddf-709dcde0896a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea62ec7-46cc-4023-8ddf-709dcde0896a.jpg?1",
             "name": "Slaughter Specialist",
             "text": "When Slaughter Specialist enters the battlefield, each opponent creates a 1/1 white Human creature token.\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Slaughter Specialist.",
             "colours": [
@@ -15498,7 +15498,7 @@
         },
         {
             "id": "9f8c9b05-05d1-50ff-acff-b474e81ed7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e4136-6ceb-4dc2-9b4b-e6fd3fb1ac1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e4136-6ceb-4dc2-9b4b-e6fd3fb1ac1d.jpg?1",
             "name": "Tainted Adversary",
             "text": "Deathtouch\nWhen Tainted Adversary enters the battlefield, you may pay {2}{B} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Tainted Adversary, then create twice that many 2/2 black Zombie creature tokens with decayed.",
             "colours": [
@@ -15534,7 +15534,7 @@
         },
         {
             "id": "48fde43d-4bb6-5908-a138-1e3f2bd7857a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196e21ed-6523-40a5-9d53-5864c7dca2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196e21ed-6523-40a5-9d53-5864c7dca2cf.jpg?1",
             "name": "Bloodthirsty Adversary",
             "text": "Haste\nWhen Bloodthirsty Adversary enters the battlefield, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Bloodthirsty Adversary, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -15570,7 +15570,7 @@
         },
         {
             "id": "de31d8b0-808d-501b-a58c-b08a6d6ec31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2dbfa-4bd5-44d5-a487-0f88c239fbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2dbfa-4bd5-44d5-a487-0f88c239fbbc.jpg?1",
             "name": "Burn Down the House",
             "text": "Choose one \u2014\n\u2022 Burn Down the House deals 5 damage to each creature and each planeswalker.\n\u2022 Create three 1/1 red Devil creature tokens with \"When this creature dies, it deals 1 damage to any target.\" They gain haste until end of turn.",
             "colours": [
@@ -15604,7 +15604,7 @@
         },
         {
             "id": "5ae4f5b3-23ff-5b36-8339-7e67e165ac76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636f014-95aa-45cd-a0c8-635364ea3baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636f014-95aa-45cd-a0c8-635364ea3baa.jpg?1",
             "name": "Curse of Shaken Faith",
             "text": "Enchant player\nWhenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, Curse of Shaken Faith deals 2 damage to them.",
             "colours": [
@@ -15641,7 +15641,7 @@
         },
         {
             "id": "d35214b9-b8c6-585d-8b09-74d5f300acfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddde36d5-adca-4576-8f31-bf11b8e90a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddde36d5-adca-4576-8f31-bf11b8e90a15.jpg?1",
             "name": "Falkenrath Pit Fighter",
             "text": "{1}{R}, Discard a card, Sacrifice a Vampire: Draw two cards. Activate only if an opponent lost life this turn.",
             "colours": [
@@ -15678,7 +15678,7 @@
         },
         {
             "id": "f860933f-a11d-5908-a68e-99d11420112e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587e5c52-9c4b-4462-b214-47556d0906b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587e5c52-9c4b-4462-b214-47556d0906b6.jpg?1",
             "name": "Geistflame Reservoir",
             "text": "Whenever you cast an instant or sorcery spell, put a charge counter on Geistflame Reservoir.\n{1}{R}, {T}, Remove any number of charge counters from Geistflame Reservoir: It deals that much damage to any target.\n{1}{R}, {T}: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -15712,7 +15712,7 @@
         },
         {
             "id": "4cb591da-6262-5a96-9c2d-29c35aa1d728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f655087-4af9-46d3-a11e-830ac15ce08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f655087-4af9-46d3-a11e-830ac15ce08c.jpg?1",
             "name": "Light Up the Night",
             "text": "Light Up the Night deals X damage to any target. It deals X plus 1 damage instead if that target is a creature or planeswalker.\nFlashback\u2014{3}{R}, Remove X loyalty counters from among planeswalkers you control. If you cast this spell this way, X can't be 0.",
             "colours": [
@@ -15746,7 +15746,7 @@
         },
         {
             "id": "9c5c3f2d-33f9-521c-a232-36cb6fc72f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff73df-e69a-4abf-900e-85b95106a17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff73df-e69a-4abf-900e-85b95106a17e.jpg?1",
             "name": "Moonveil Regent",
             "text": "Flying\nWhenever you cast a spell, you may discard your hand. If you do, draw a card for each of that spell's colors.\nWhen Moonveil Regent dies, it deals X damage to any target, where X is the number of colors among permanents you control.",
             "colours": [
@@ -15782,7 +15782,7 @@
         },
         {
             "id": "cc177246-8a73-5705-a189-78ee873291c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, put a number of ember counters on Smoldering Egg equal to the amount of mana spent to cast that spell. Then if Smoldering Egg has seven or more ember counters on it, remove them and transform Smoldering Egg.",
             "colours": [
@@ -15819,7 +15819,7 @@
         },
         {
             "id": "8449064f-f7e0-5519-930d-60560606fe04",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Ashmouth Dragon deals 2 damage to any target.",
             "colours": [
@@ -15855,7 +15855,7 @@
         },
         {
             "id": "d37474dd-b29b-5188-9f21-5ccad1612689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d375b7f-e4c3-48f0-b967-3ce50c2728c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d375b7f-e4c3-48f0-b967-3ce50c2728c4.jpg?1",
             "name": "Sunstreak Phoenix",
             "text": "Flying\nIf it's neither day nor night, it becomes day as Sunstreak Phoenix enters the battlefield.\nWhenever day becomes night or night becomes day, you may pay {1}{R}. If you do, return Sunstreak Phoenix from your graveyard to the battlefield tapped.",
             "colours": [
@@ -15891,7 +15891,7 @@
         },
         {
             "id": "677a35e6-d4b7-54b4-a286-25f0d99ba4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dfb33e-761d-420f-8202-c1a714ff0832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dfb33e-761d-420f-8202-c1a714ff0832.jpg?1",
             "name": "Augur of Autumn",
             "text": "You may look at the top card of your library any time.\nYou may play lands from the top of your library.\nCoven \u2014 As long as you control three or more creatures with different powers, you may cast creature spells from the top of your library.",
             "colours": [
@@ -15928,7 +15928,7 @@
         },
         {
             "id": "5835c1cf-2ffe-5412-82ad-398b972158e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1db00c-c9fd-48d8-b7d5-c39f8e213232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1db00c-c9fd-48d8-b7d5-c39f8e213232.jpg?1",
             "name": "Briarbridge Tracker",
             "text": "Vigilance\nWhen Briarbridge Tracker enters the battlefield, investigate.\nAs long as you control a token, Briarbridge Tracker gets +2/+0.",
             "colours": [
@@ -15965,7 +15965,7 @@
         },
         {
             "id": "53e6d59b-8d6b-5a7c-bb09-b052ad2800c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8819ff-cd97-440c-8256-f3e3b4fc3c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8819ff-cd97-440c-8256-f3e3b4fc3c41.jpg?1",
             "name": "Consuming Blob",
             "text": "Consuming Blob's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nAt the beginning of your end step, create a green Ooze creature token with \"This creature's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\"",
             "colours": [
@@ -16001,7 +16001,7 @@
         },
         {
             "id": "5759147a-77d3-5a0d-8bc3-6b93bc4d714c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e39fdb5-a4cd-49fb-843f-30136ce54b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e39fdb5-a4cd-49fb-843f-30136ce54b34.jpg?1",
             "name": "Primal Adversary",
             "text": "Trample\nWhen Primal Adversary enters the battlefield, you may pay {1}{G} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Primal Adversary, then up to that many target lands you control become 3/3 Wolf creatures with haste that are still lands.",
             "colours": [
@@ -16037,7 +16037,7 @@
         },
         {
             "id": "05c18043-ee84-53bf-882b-45d181dd47e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28be27e6-66e6-4997-b8a0-f4d9c597e536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28be27e6-66e6-4997-b8a0-f4d9c597e536.jpg?1",
             "name": "Storm the Festival",
             "text": "Look at the top five cards of your library. You may put up to two permanent cards with mana value 5 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\nFlashback {7}{G}{G}{G}",
             "colours": [
@@ -16071,7 +16071,7 @@
         },
         {
             "id": "5bc3b947-7568-5083-894f-85aa1804e203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61baa102-9bc0-4f97-89e1-cca4dbd823bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61baa102-9bc0-4f97-89e1-cca4dbd823bd.jpg?1",
             "name": "Unnatural Growth",
             "text": "At the beginning of each combat, double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -16105,7 +16105,7 @@
         },
         {
             "id": "1eb1eae0-e908-560f-adca-14e9c4d7be9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99947ee-3a73-47aa-bd71-d29a0066314e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99947ee-3a73-47aa-bd71-d29a0066314e.jpg?1",
             "name": "Willow Geist",
             "text": "Trample\nWhenever one or more cards leave your graveyard, put a +1/+1 counter on Willow Geist.\nWhen Willow Geist dies, you gain life equal to its power.",
             "colours": [
@@ -16142,7 +16142,7 @@
         },
         {
             "id": "39c8d2c6-3056-5c99-bb89-73389b83741c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742eaaed-4162-4179-94e6-0c1a943a46b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742eaaed-4162-4179-94e6-0c1a943a46b9.jpg?1",
             "name": "Angelfire Ignition",
             "text": "Put two +1/+1 counters on target creature. It gains vigilance, trample, lifelink, indestructible, and haste until end of turn.\nFlashback {2}{R}{W}",
             "colours": [
@@ -16178,7 +16178,7 @@
         },
         {
             "id": "d7dbea2e-654f-5bf9-9164-54317867eeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d1d7a4-6276-4f7e-bc50-5e48eef8f6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d1d7a4-6276-4f7e-bc50-5e48eef8f6f8.jpg?1",
             "name": "Can't Stay Away",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains \"If this creature would die, exile it instead.\"\nFlashback {3}{W}{B}",
             "colours": [
@@ -16214,7 +16214,7 @@
         },
         {
             "id": "af9ca1ad-02ca-50f5-a5fc-ba754cc0eb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cbd312-a0ee-4dc8-9d23-9d54aa0a70b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cbd312-a0ee-4dc8-9d23-9d54aa0a70b3.jpg?1",
             "name": "Croaking Counterpart",
             "text": "Create a token that's a copy of target non-Frog creature, except it's a 1/1 green Frog.\nFlashback {3}{G}{U}",
             "colours": [
@@ -16250,7 +16250,7 @@
         },
         {
             "id": "76869cd2-7b47-5e40-adfa-7e9341a89746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fdcf0e-7102-4ac1-afb9-093f1670a878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fdcf0e-7102-4ac1-afb9-093f1670a878.jpg?1",
             "name": "Dire-Strain Rampage",
             "text": "Destroy target artifact, enchantment, or land. If a land was destroyed this way, its controller may search their library for up to two basic land cards, put them onto the battlefield tapped, then shuffle. Otherwise, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.\nFlashback {3}{R}{G}",
             "colours": [
@@ -16286,7 +16286,7 @@
         },
         {
             "id": "a32245d6-68a2-565c-84f3-95f887e4b9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20ae02-a7d5-40b2-8be2-bc8c0dc0f6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20ae02-a7d5-40b2-8be2-bc8c0dc0f6d8.jpg?1",
             "name": "Galvanic Iteration",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nFlashback {1}{U}{R}",
             "colours": [
@@ -16322,7 +16322,7 @@
         },
         {
             "id": "bf3afce1-0fcb-5660-81ae-943d5520a614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb2dc53-57aa-4327-8700-6396fd86e3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb2dc53-57aa-4327-8700-6396fd86e3d1.jpg?1",
             "name": "Ghoulcaller's Harvest",
             "text": "Create X 2/2 black Zombie creature tokens with decayed, where X is half the number of creature cards in your graveyard, rounded up.\nFlashback {3}{B}{G}",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "0b705360-f0c9-5e41-9fb4-ecaf4f1c5fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2e89f2-6101-4ada-b925-2ae6f754b39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2e89f2-6101-4ada-b925-2ae6f754b39e.jpg?1",
             "name": "Hallowed Respite",
             "text": "Exile target nonlegendary creature, then return it to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on it. Otherwise, tap it.\nFlashback {1}{W}{U}",
             "colours": [
@@ -16394,7 +16394,7 @@
         },
         {
             "id": "0fb50319-5c5f-5ca7-8253-ef2a4b60ff49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae388-c917-4917-9401-6852a384d274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae388-c917-4917-9401-6852a384d274.jpg?1",
             "name": "Rite of Harmony",
             "text": "Whenever a creature or enchantment enters the battlefield under your control this turn, draw a card.\nFlashback {2}{G}{W}",
             "colours": [
@@ -16430,7 +16430,7 @@
         },
         {
             "id": "e5820482-daf4-527d-ac26-7cc233a95243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94d7713-5c26-4e65-9f0e-3b4f46efcdc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94d7713-5c26-4e65-9f0e-3b4f46efcdc4.jpg?1",
             "name": "Siphon Insight",
             "text": "Look at the top two cards of target opponent's library. Exile one of them face down and put the other on the bottom of that library. You may look at and play the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\nFlashback {1}{U}{B}",
             "colours": [
@@ -16466,7 +16466,7 @@
         },
         {
             "id": "8b240e95-3c78-5054-9bcc-da459849d829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dc5a7d-759c-4d6d-ace2-81731f5c4c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dc5a7d-759c-4d6d-ace2-81731f5c4c35.jpg?1",
             "name": "Wake to Slaughter",
             "text": "Choose up to two target creature cards in your graveyard. An opponent chooses one of them. Return that card to your hand. Return the other to the battlefield under your control. It gains haste. Exile it at the beginning of the next end step.\nFlashback {4}{B}{R}",
             "colours": [
@@ -16502,7 +16502,7 @@
         },
         {
             "id": "a8525221-1bc6-568e-85cb-f389b6e33d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45a290-5ab8-4200-91e4-ea03d45c34b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45a290-5ab8-4200-91e4-ea03d45c34b6.jpg?1",
             "name": "The Celestus",
             "text": "If it's neither day nor night, it becomes day as The Celestus enters the battlefield.\n{T}: Add one mana of any color.\n{3}, {T}: If it's night, it becomes day. Otherwise, it becomes night. Activate only as a sorcery.\nWhenever day becomes night or night becomes day, you gain 1 life. You may draw a card. If you do, discard a card.",
             "colours": [],
@@ -16534,7 +16534,7 @@
         },
         {
             "id": "d8962e25-4c2d-5b2f-b4a4-2e0eb54b8395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241616ef-5698-491c-995d-1ff2ca0d455f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241616ef-5698-491c-995d-1ff2ca0d455f.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -16564,7 +16564,7 @@
         },
         {
             "id": "72577c64-449e-519c-905c-081bbbbb8c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice a creature: Put a soul counter on Hostile Hostel. Then if there are three or more soul counters on it, remove those counters, transform it, then untap it. Activate only as a sorcery.",
             "colours": [],
@@ -16596,7 +16596,7 @@
         },
         {
             "id": "1c3be0aa-6ba2-5b86-b022-faa54421f3db",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice a creature: Put a soul counter on Hostile Hostel. Then if there are three or more soul counters on it, remove those counters, transform it, then untap it. Activate only as a sorcery.",
             "colours": [
@@ -16634,7 +16634,7 @@
         },
         {
             "id": "c839dfb3-cbb3-5d19-8223-8b4442eae318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b94de4-099e-43d7-8f24-d5450b09f1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b94de4-099e-43d7-8f24-d5450b09f1f1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -16671,7 +16671,7 @@
         },
         {
             "id": "f759aba0-a9bd-52ee-9aed-99e499f81534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6b919-e7c0-4844-a65c-d8b83b3e5287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6b919-e7c0-4844-a65c-d8b83b3e5287.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -16708,7 +16708,7 @@
         },
         {
             "id": "e39f8634-c477-5836-9235-f302d92a7e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b9030-f04a-4f42-8dd8-2eae0ce7e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b9030-f04a-4f42-8dd8-2eae0ce7e420.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -16745,7 +16745,7 @@
         },
         {
             "id": "46e0c17f-101f-56c4-a8aa-55dfb95d84cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92e9e94-e5e9-4b2c-b9e5-35de42ca7b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92e9e94-e5e9-4b2c-b9e5-35de42ca7b8e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16782,7 +16782,7 @@
         },
         {
             "id": "a499b95b-8f0f-56e2-ba4e-077e5bc6979e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8de02c-7954-4424-8b95-a21d8e104bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8de02c-7954-4424-8b95-a21d8e104bd4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16819,7 +16819,7 @@
         },
         {
             "id": "d8a65e0b-37e8-50b3-99b5-b9460552e822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ade554-861c-423f-9aa3-e36da95b20dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ade554-861c-423f-9aa3-e36da95b20dc.jpg?1",
             "name": "Champion of the Perished",
             "text": "Whenever another Zombie enters the battlefield under your control, put a +1/+1 counter on Champion of the Perished.",
             "colours": [
@@ -16855,7 +16855,7 @@
         },
         {
             "id": "7d723124-a3ff-5e96-be73-12a3dc44b91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6db2d37-3533-4830-ab63-6724ece6fbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6db2d37-3533-4830-ab63-6724ece6fbea.jpg?1",
             "name": "Triskaidekaphile",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, if you have exactly thirteen cards in your hand, you win the game.\n{3}{U}: Draw a card.",
             "colours": [
@@ -16892,7 +16892,7 @@
         },
         {
             "id": "b15c8864-8faa-59de-9afc-1259e351ae6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0f88d0-49b8-451b-948d-46401d49020e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0f88d0-49b8-451b-948d-46401d49020e.jpg?1",
             "name": "Gavony Dawnguard",
             "text": "Ward {1}\nIf it's neither day nor night, it becomes day as Gavony Dawnguard enters the battlefield.\nWhenever day becomes night or night becomes day, look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -16929,7 +16929,7 @@
         },
         {
             "id": "d23c113b-400f-588a-835b-68a61f40fcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f40a0-5f58-4157-aed9-b1a52e922c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f40a0-5f58-4157-aed9-b1a52e922c3c.jpg?1",
             "name": "Consider",
             "text": "Look at the top card of your library. You may put that card into your graveyard.\nDraw a card.",
             "colours": [
@@ -16963,7 +16963,7 @@
         },
         {
             "id": "1a327055-585a-574e-a488-528434929a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0655bae1-d33b-4bac-856a-ca4518f192e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0655bae1-d33b-4bac-856a-ca4518f192e8.jpg?1",
             "name": "Infernal Grasp",
             "text": "Destroy target creature. You lose 2 life.",
             "colours": [
@@ -16997,7 +16997,7 @@
         },
         {
             "id": "b3f5b3f5-7377-5728-884c-49ead4c1151d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42901bec-a8d0-46a3-a710-bfb7bd87f155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42901bec-a8d0-46a3-a710-bfb7bd87f155.jpg?1",
             "name": "Play with Fire",
             "text": "Play with Fire deals 2 damage to any target. If a player is dealt damage this way, scry 1.",
             "colours": [
@@ -17031,7 +17031,7 @@
         },
         {
             "id": "4f35ff67-1be3-55fa-bc8d-1e1cbaf81172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd0f3-933d-4e73-9ac5-c743b8394e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd0f3-933d-4e73-9ac5-c743b8394e80.jpg?1",
             "name": "Join the Dance",
             "text": "Create two 1/1 white Human creature tokens.\nFlashback {3}{G}{W}",
             "colours": [
@@ -17067,7 +17067,7 @@
         },
         {
             "id": "4201fbf8-0646-5234-bce1-0bdca04be8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7667345-e11b-4cad-ac4c-84eb1c5656c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7667345-e11b-4cad-ac4c-84eb1c5656c5.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -17102,7 +17102,7 @@
         },
         {
             "id": "0c360f56-026d-582b-9a9f-afe878c099df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c865bc02-0562-408c-b18e-0e66da906fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c865bc02-0562-408c-b18e-0e66da906fc6.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17137,7 +17137,7 @@
         },
         {
             "id": "d1a28b9a-8f82-5413-a1f1-3284bd2f3f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b2f0-16d3-4db0-a737-c7b8dcb9d5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b2f0-16d3-4db0-a737-c7b8dcb9d5de.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -17172,7 +17172,7 @@
         },
         {
             "id": "1a35533c-585f-57c6-a1f0-15a30c970419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c0f400-41be-488b-be84-b07289b1ef62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c0f400-41be-488b-be84-b07289b1ef62.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -17207,7 +17207,7 @@
         },
         {
             "id": "974e8ef7-5b3c-5f02-9887-027e2578687f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb8607-1066-451d-a719-74ad32358278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb8607-1066-451d-a719-74ad32358278.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17242,7 +17242,7 @@
         },
         {
             "id": "51112885-432d-52a4-97be-107f00bbdf70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f9c505-a833-4240-83a0-fbd160bdbf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f9c505-a833-4240-83a0-fbd160bdbf0f.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -17277,7 +17277,7 @@
         },
         {
             "id": "c827d437-be61-5b73-8d1a-b3576f6629a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -17312,7 +17312,7 @@
         },
         {
             "id": "3378a201-b957-5508-931e-f85e221d6801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55c70b8-0fa5-4d08-9061-f53d6f949908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55c70b8-0fa5-4d08-9061-f53d6f949908.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -17347,7 +17347,7 @@
         },
         {
             "id": "f553735d-b495-5c5f-b28e-464065ef8859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53e20ee-b43c-45aa-9921-2c6f7ddc27fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53e20ee-b43c-45aa-9921-2c6f7ddc27fb.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -17382,7 +17382,7 @@
         },
         {
             "id": "6382a9a1-d8c1-53e6-b1f3-e2f4f082a584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa10292-f358-48c1-a516-9a1eecf62b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa10292-f358-48c1-a516-9a1eecf62b1d.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -17417,7 +17417,7 @@
         },
         {
             "id": "4e36e853-a4a6-55fa-be91-2414b16ed170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bee18a-46d6-4f60-9e19-5fc670a20a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bee18a-46d6-4f60-9e19-5fc670a20a4d.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -17452,7 +17452,7 @@
         },
         {
             "id": "f491d91a-8f4e-54a5-9513-5d89bad9f4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4345b-61b1-4026-a01c-c9f2036c5c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4345b-61b1-4026-a01c-c9f2036c5c8a.jpg?1",
             "name": "Treefolk",
             "text": "",
             "colours": [
@@ -17487,7 +17487,7 @@
         },
         {
             "id": "134c10aa-8ee5-5bcf-a813-169abcb94318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364e04d9-9a8a-49df-921c-7a9bf62dc731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364e04d9-9a8a-49df-921c-7a9bf62dc731.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -17522,7 +17522,7 @@
         },
         {
             "id": "c5487613-a4b3-5943-8405-51c497f272a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe08d-b469-4471-8a7d-cf75850ba312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe08d-b469-4471-8a7d-cf75850ba312.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -17559,7 +17559,7 @@
         },
         {
             "id": "b9f7553d-55f1-5a3d-a0bc-2c36967c544f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5fb489-6e46-4359-9c3c-ef1702526e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5fb489-6e46-4359-9c3c-ef1702526e5a.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17596,7 +17596,7 @@
         },
         {
             "id": "4109db31-6037-50fc-a8ba-07c1a21b59f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eca06-2ef2-47ef-a0ab-6766bbd3ab8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eca06-2ef2-47ef-a0ab-6766bbd3ab8b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17627,7 +17627,7 @@
         },
         {
             "id": "c24f7648-d86a-5c66-93c1-104ddd0f95d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a970bebc-08e1-4125-a4c5-8883dfd5a5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a970bebc-08e1-4125-a4c5-8883dfd5a5ca.jpg?1",
             "name": "Teferi, Who Slows the Sunset Emblem",
             "text": "",
             "colours": [],
@@ -17655,7 +17655,7 @@
         },
         {
             "id": "a0aeb1e1-284f-51b4-bc3a-44cb3d26c067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62eda69-f0c2-4977-8603-150d5d4bec49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62eda69-f0c2-4977-8603-150d5d4bec49.jpg?1",
             "name": "Wrenn and Seven Emblem",
             "text": "",
             "colours": [],
@@ -17683,7 +17683,7 @@
         },
         {
             "id": "5b43434b-ed87-5548-bbe4-3f4bc4525c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],
@@ -17710,7 +17710,7 @@
         },
         {
             "id": "90a53819-1a62-5b90-b7eb-d9bcffc2ce6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MIR.json
+++ b/Assets/Resources/Sets/MIR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5476b4a0-5ce9-5b16-9272-5d2be623c26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4644694d-52e6-4d00-8cad-748899eeea84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4644694d-52e6-4d00-8cad-748899eeea84.jpg?1",
             "name": "Afterlife",
             "text": "Bury target creature and put an Essence token into play under the control of that creature's controller. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "2f2593aa-3f74-5844-bf8f-bfdb5dfaaf6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155f2aa6-6c47-4a06-b0ef-2d9205cd133e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155f2aa6-6c47-4a06-b0ef-2d9205cd133e.jpg?1",
             "name": "Alarum",
             "text": "Untap target nonattacking creature. That creature gets +1/+3 until end of turn.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "bbec9fac-89f2-5f39-8f47-45fa4478a867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6f9ec3-6033-4cd4-a52e-31a559559a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6f9ec3-6033-4cd4-a52e-31a559559a93.jpg?1",
             "name": "Auspicious Ancestor",
             "text": "If Auspicious Ancestor is put into the graveyard from play, gain 3 life.\no1: Gain 1 life. Use this ability only when a white spell is successfully cast and only once for each such spell.",
             "colours": [
@@ -100,7 +100,7 @@
         },
         {
             "id": "9be86536-0da7-54a0-b4ad-9ab60a63f549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a243bd7-af98-4e44-af6e-3b0b71d4837b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a243bd7-af98-4e44-af6e-3b0b71d4837b.jpg?1",
             "name": "Benevolent Unicorn",
             "text": "Whenever a spell assigns damage to a creature or player, that damage is reduced by 1.",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "6cd5e890-d14a-5269-9088-629f1aca0d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2192a-78a5-4579-94ce-cccf773a809d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2192a-78a5-4579-94ce-cccf773a809d.jpg?1",
             "name": "Blinding Light",
             "text": "Tap all nonwhite creatures.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "aa523d97-5660-5a3f-af64-ace2084564d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4c4a-ccdd-4f3c-80cf-356ab7836e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4c4a-ccdd-4f3c-80cf-356ab7836e16.jpg?1",
             "name": "Celestial Dawn",
             "text": "All nonland cards you own that are not in play are white. All nonland permanents you control are white. All lands you control are plains. All colored mana symbols in all costs on all of these cards and permanents are o\nW.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "18c19c12-3fa4-51cb-83f2-9b67b8983ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9319039-db2f-47bf-9ef0-8d3a381d54fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9319039-db2f-47bf-9ef0-8d3a381d54fb.jpg?1",
             "name": "Civic Guildmage",
             "text": "o\nG, oc\nT: Target creature gets +0/+1 until end of turn.\no\nU, oc\nT: Put target creature you control on top of owner's library.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "52a26957-27b9-530a-bae7-887aa9885543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ece98-5506-4a18-b900-8d1a6cd87385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ece98-5506-4a18-b900-8d1a6cd87385.jpg?1",
             "name": "Dazzling Beauty",
             "text": "Play only when defense is chosen.\nTarget unblocked creature is considered blocked.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "a9b1eb34-43c7-5e32-bae5-aabe06ad43c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86a2ae-aaf3-4d4d-ae06-ec3d4a539550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86a2ae-aaf3-4d4d-ae06-ec3d4a539550.jpg?1",
             "name": "Disempower",
             "text": "Put target artifact or enchantment on top of owner's library.",
             "colours": [
@@ -293,7 +293,7 @@
         },
         {
             "id": "33858ef7-7ad2-5e18-84ba-6589df5b411c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e27cbc-d986-437a-9195-6f5e065a49a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e27cbc-d986-437a-9195-6f5e065a49a2.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "a748daf4-d7b7-5dda-a273-53bbf2ef7669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b84697e-d72d-4169-bf16-753144da281f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b84697e-d72d-4169-bf16-753144da281f.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. Gain an amount of life equal to that artifact's casting cost.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "f5dfd3cf-2410-55ed-ad14-e251ebe36bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75629aa3-426e-4e25-a7ab-71e03436e061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75629aa3-426e-4e25-a7ab-71e03436e061.jpg?1",
             "name": "Divine Retribution",
             "text": "For each attacking creature, Divine Retribution deals 1 damage to target attacking creature.",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "8d576f77-1cf4-5b7f-8ecc-ae69d9d88efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a32778b-e6ff-45ca-8b22-dc97a406faa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a32778b-e6ff-45ca-8b22-dc97a406faa4.jpg?1",
             "name": "Ekundu Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -419,7 +419,7 @@
         },
         {
             "id": "0102c858-3387-5864-a4b5-3a9425d617e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbac1d27-15e2-4e2f-82ab-625a16e096cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbac1d27-15e2-4e2f-82ab-625a16e096cb.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card and reveal that card to all players. Shuffle your library and put the revealed card back on top of it.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "f6d3aa0c-31f5-58c8-9256-e2278e5aa83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f2d15e-490b-4754-8197-ac91653698f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f2d15e-490b-4754-8197-ac91653698f7.jpg?1",
             "name": "Ethereal Champion",
             "text": "Pay 1 life: Prevent 1 damage to Ethereal Champion.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "d6f33310-1155-5c55-83d7-c61d39daec95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5657403-7c86-4eb6-84b0-75eedb04a5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5657403-7c86-4eb6-84b0-75eedb04a5a2.jpg?1",
             "name": "Favorable Destiny",
             "text": "As long as enchanted creature's controller controls at least one other creature, enchanted creature cannot be the target of spells or effects.\nAs long as enchanted creature is white, it gets +1/+2.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "c54d9785-b675-50dd-9a15-e08c589edf0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dedd5e-e2ee-46ec-8541-27f1548b2a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dedd5e-e2ee-46ec-8541-27f1548b2a2a.jpg?1",
             "name": "Femeref Healer",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "966010c1-bdbc-5831-9fa8-6642db470084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a2e07-b449-4d94-93e3-e756e891c542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a2e07-b449-4d94-93e3-e756e891c542.jpg?1",
             "name": "Femeref Knight",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\noo\nW Attacking does not cause Femeref Knight to tap this turn.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "ed83d5ce-1aaa-5eba-944a-198fd9bc0cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60192ded-689b-4cc5-9293-bff52924089b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60192ded-689b-4cc5-9293-bff52924089b.jpg?1",
             "name": "Femeref Scouts",
             "text": "",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "60ceaabd-1890-5146-bce2-446467de56f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c9ca9-3611-46df-8108-45ba383b4ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c9ca9-3611-46df-8108-45ba383b4ee6.jpg?1",
             "name": "Healing Salve",
             "text": "Target player gains 3 life, or prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "0dc12e86-a212-55b6-b22c-203594aa472c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28f6e5-c9ef-416e-b315-967d857e7600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28f6e5-c9ef-416e-b315-967d857e7600.jpg?1",
             "name": "Illumination",
             "text": "Counter target artifact or enchantment spell. That spell's caster gains an amount of life equal to the spell's casting cost.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "c805d06e-1707-5746-a4cd-19489b562106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c8e952-f040-4e5b-88f3-f80ad4b3f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c8e952-f040-4e5b-88f3-f80ad4b3f2f1.jpg?1",
             "name": "Iron Tusk Elephant",
             "text": "Trample",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "7efbd9d2-53fb-5342-a719-990055c81719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0706acf6-587e-4f29-944a-fdf25aeacb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0706acf6-587e-4f29-944a-fdf25aeacb6d.jpg?1",
             "name": "Ivory Charm",
             "text": "Choose one All creatures get -2/-0 until end of turn; or prevent 1 damage to any creature or player; or tap target creature.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "d5c6bec2-4b21-58c0-ade3-5653b37d201b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f764d7-4c18-40ef-8373-ef1e2a88007e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f764d7-4c18-40ef-8373-ef1e2a88007e.jpg?1",
             "name": "Jabari's Influence",
             "text": "Play only after combat.\nGain control of target nonartifact, nonblack creature that attacked you this turn and put a -1/-0 counter on it.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "0640ae40-bed2-5284-bf73-9d8142093858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0125f79-ff68-4fb9-b309-8d277259f323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0125f79-ff68-4fb9-b309-8d277259f323.jpg?1",
             "name": "Mangara's Blessing",
             "text": "Gain 5 life.\nWhen a spell or ability an opponent controls causes you to discard Mangara's Blessing, you gain 2 life and return Mangara's Blessing from your graveyard to your hand at end of turn.",
             "colours": [
@@ -806,7 +806,7 @@
         },
         {
             "id": "6f93e735-0721-51b7-aba2-02d4e2146e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796153-3f7f-4d94-8ad4-5a4b2c8e09bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796153-3f7f-4d94-8ad4-5a4b2c8e09bb.jpg?1",
             "name": "Mangara's Equity",
             "text": "When you play Mangara's Equity, choose black or red.\nDuring your upkeep, pay o1o\nW or bury Mangara's Equity.\nFor each 1 damage a creature of the chosen color deals to you or a white creature you control, Mangara's Equity deals 1 damage to that creature.",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "ddbce2d2-5bd5-5a35-9ff0-ef2b5464e780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8292b6e7-92ac-4bbb-906c-1fe47e260a24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8292b6e7-92ac-4bbb-906c-1fe47e260a24.jpg?1",
             "name": "Melesse Spirit",
             "text": "Flying, protection from black",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "6b5442bd-4d21-5406-b591-95895952cd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162dd988-0beb-48e4-9eaa-a08ddb835648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162dd988-0beb-48e4-9eaa-a08ddb835648.jpg?1",
             "name": "Mtenda Griffin",
             "text": "Flying\no\nW, oc\nT: Return Mtenda Griffin to owner's hand and return target Griffin card in your graveyard to your hand. Use this ability only during your upkeep.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "dc0679c5-bdc8-59a9-9df7-fcee5cf7f82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f30a3d-1421-4706-b17f-39a9ec7a0d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f30a3d-1421-4706-b17f-39a9ec7a0d8b.jpg?1",
             "name": "Mtenda Herder",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "9060d72b-3c76-5e15-a8d2-8028026a6fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f399cb-dddb-422a-8d36-938b82b59e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f399cb-dddb-422a-8d36-938b82b59e10.jpg?1",
             "name": "Noble Elephant",
             "text": "Banding, trample",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "4e23a427-c11a-51d0-a69c-89480f3e2bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814f8976-6612-438f-a04a-8edb63edb1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814f8976-6612-438f-a04a-8edb63edb1e7.jpg?1",
             "name": "Null Chamber",
             "text": "You and target opponent each name any card except a basic land. Those cards cannot be played.",
             "colours": [
@@ -1004,7 +1004,7 @@
         },
         {
             "id": "a91056a7-755b-57fc-bada-9c45e359f086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c891df1b-bae6-4d6d-85ee-42901c149f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c891df1b-bae6-4d6d-85ee-42901c149f98.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature cannot attack or block.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "29f4026c-9200-5070-b4e9-d515da46f836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac3411-3286-4698-b5d9-d4bb2db30770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac3411-3286-4698-b5d9-d4bb2db30770.jpg?1",
             "name": "Pearl Dragon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "9cfaaad4-67b9-5f2a-b30a-a104a044198b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e3de4-f173-4bcc-a5fb-089eee7108d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e3de4-f173-4bcc-a5fb-089eee7108d3.jpg?1",
             "name": "Prismatic Circle",
             "text": "Cumulative upkeep o1\nWhen you play Prismatic Circle, choose a color.\no1: Prevent all damage to you from a source of the chosen color. Treat further damage from that source normally.",
             "colours": [
@@ -1101,7 +1101,7 @@
         },
         {
             "id": "06bc148c-fc3e-552b-8dbe-65591dfa2e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb48053-da60-477a-b1eb-a9ab9ea682af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb48053-da60-477a-b1eb-a9ab9ea682af.jpg?1",
             "name": "Rashida Scalebane",
             "text": "oc\nT: Bury target attacking or blocking Dragon. Gain an amount of life equal to that Dragon's power.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "5bef75d1-11d4-53c1-98e0-18e9afec92b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21205189-0d00-44d5-9772-820e607dba25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21205189-0d00-44d5-9772-820e607dba25.jpg?1",
             "name": "Ritual of Steel",
             "text": "Draw a card at the beginning of the upkeep of the turn after Ritual of Steel comes into play.\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "19a0190f-81bc-569e-ae39-d36f11a9458f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6622f325-6bc3-49dc-ba8e-154e70772dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6622f325-6bc3-49dc-ba8e-154e70772dd5.jpg?1",
             "name": "Sacred Mesa",
             "text": "During your upkeep, sacrifice a Pegasus or bury Sacred Mesa.\no1oo\nW Put a Wild Pegasus token into play. Treat this token as a 1/1 white creature with flying that counts as a Pegasus.",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "799dde78-9eca-5051-9e16-c549e1fd7178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe8fa5-5ca8-43ce-863e-61802126e485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe8fa5-5ca8-43ce-863e-61802126e485.jpg?1",
             "name": "Shadowbane",
             "text": "Prevent all damage to you or a creature you control from any one source. If that source is black, gain 1 life for each 1 damage prevented in this way.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "86e6bd5e-5b30-5747-9b7a-2f9ba8d4bd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f0d06-cd14-49f3-ad3c-0d419a0c30bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f0d06-cd14-49f3-ad3c-0d419a0c30bc.jpg?1",
             "name": "Sidar Jabari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Sidar Jabari attacks, tap target creature defending player controls.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "7739870b-32c9-50fd-9e41-ba3437ed5dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f9427-ef5c-49fd-81e1-ddf130d69da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f9427-ef5c-49fd-81e1-ddf130d69da0.jpg?1",
             "name": "Soul Echo",
             "text": "When you play Soul Echo, put X echo counters on it.\nAt the beginning of your upkeep, if there are no echo counters on Soul Echo, bury it; otherwise, target opponent may choose that for each 1 damage dealt to you until your next upkeep, you instead remove 1 echo counter from Soul Echo.\nYou do not lose the game as a result of having less than 1 life.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "e31e3ecd-2a88-5550-adb1-19aba621f6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bea61-8fd2-4802-90b4-651bebbe9638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bea61-8fd2-4802-90b4-651bebbe9638.jpg?1",
             "name": "Spectral Guardian",
             "text": "As long as Spectral Guardian is untapped, noncreature artifacts cannot be the target of spells or effects.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "cd934160-f38d-5dc9-bc33-da9bf6ea7121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dc838-3022-42f1-bc92-8e8358c27ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dc838-3022-42f1-bc92-8e8358c27ea4.jpg?1",
             "name": "Sunweb",
             "text": "Flying\nSunweb cannot block creatures with power 2 or less.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "7d2781a8-3f77-5d21-aca0-16e3d5e82824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96267012-24da-43ae-97af-69ca3d7704f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96267012-24da-43ae-97af-69ca3d7704f8.jpg?1",
             "name": "Teremko Griffin",
             "text": "Banding, flying",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "6febdfd8-eedc-5c25-96e7-8295aa446d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3573-2cc5-47ca-b65f-080aab7fdddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3573-2cc5-47ca-b65f-080aab7fdddc.jpg?1",
             "name": "Unyaro Griffin",
             "text": "Flying\nSacrifice Unyaro Griffin: Counter target red spell that assigns damage to you or a creature you control. Play this ability as an interrupt.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "5e40a834-b2f3-5b99-812e-58a27be82e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02e3c10-cc21-4e06-a987-b03aee61bd50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02e3c10-cc21-4e06-a987-b03aee61bd50.jpg?1",
             "name": "Vigilant Martyr",
             "text": "Sacrifice Vigilant Martyr: Regenerate target creature.\no\nWo\nW, oc\nT, Sacrifice Vigilant Martyr: Counter target spell that targets an enchantment in play. Play this ability as an interrupt.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "2af935e1-5af3-547e-a075-969bd0c73cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd25787d-b90c-4b25-8259-1ac41d4dcd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd25787d-b90c-4b25-8259-1ac41d4dcd15.jpg?1",
             "name": "Wall of Resistance",
             "text": "Flying\nAt the end of any turn in which Wall of Resistance is dealt damage, put a +0/+1 counter on it.",
             "colours": [
@@ -1498,7 +1498,7 @@
         },
         {
             "id": "a84e8a79-238f-558e-ae6c-9b36f0c2c64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389daf-c7d8-4bd1-b4ea-5082f5d280c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389daf-c7d8-4bd1-b4ea-5082f5d280c0.jpg?1",
             "name": "Ward of Lights",
             "text": "You may choose to play Ward of Lights as an instant; if you do, bury it at end of turn.\nEnchanted creature gains protection from a color of your choice. The protection granted by Ward of Lights does not bury Ward of Lights.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "4b914cd8-14ff-5da0-97ef-cf3f81a97883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14343d-c2cd-4a67-ae54-6b6a4677ca85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14343d-c2cd-4a67-ae54-6b6a4677ca85.jpg?1",
             "name": "Yare",
             "text": "Target creature defending player controls gets +3/+0 until end of turn. That creature may be assigned to block up to three creatures this turn. All blocks must be legal.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "67f57ede-0568-5a0d-a742-c0a738569bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e63cb-6da5-4f65-a976-e79d201e9fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e63cb-6da5-4f65-a976-e79d201e9fc7.jpg?1",
             "name": "Zhalfirin Commander",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1o\nWoo\nW Target Knight gets +1/+1 until end of turn.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "6fb0ea39-61da-5f54-9ae4-4f1345355db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb65d104-bd50-481e-a70e-62aeb2f2c12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb65d104-bd50-481e-a70e-62aeb2f2c12b.jpg?1",
             "name": "Zhalfirin Knight",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no\nWoo\nW First strike until end of turn",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "87c59eb0-3d69-55d3-80c7-a40db1ab72c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b24a80-b5e1-484f-9e21-886cb6b5db48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b24a80-b5e1-484f-9e21-886cb6b5db48.jpg?1",
             "name": "Zuberi, Golden Feather",
             "text": "Flying\nZuberi, Golden Feather counts as a Griffin.\nAll other Griffins get +1/+1.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "59e77d3c-017d-59b5-8354-8f5491b4489c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d1298b-9f56-4540-8d6b-7eecfe38cf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d1298b-9f56-4540-8d6b-7eecfe38cf62.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your library. Put two of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "95d6afc2-cbc6-5496-9cb9-d9446e0dcf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ba4e0-f6f3-4b6c-b6cb-ab2b93d64601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ba4e0-f6f3-4b6c-b6cb-ab2b93d64601.jpg?1",
             "name": "Azimaet Drake",
             "text": "Flying\noo\nU +1/+0 until end of turn. You cannot spend more than o\nU in this way each turn.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "94ee710a-b1c5-5ff0-845b-05fb9d632ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45268a-b757-4ad2-bab0-869058ee9186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45268a-b757-4ad2-bab0-869058ee9186.jpg?1",
             "name": "Bay Falcon",
             "text": "Flying\nAttacking does not cause Bay Falcon to tap.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "6ee65f07-0f61-555d-823b-4abca5654c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e7a165-e135-4b85-943d-8352b6e65870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e7a165-e135-4b85-943d-8352b6e65870.jpg?1",
             "name": "Bazaar of Wonders",
             "text": "When Bazaar of Wonders comes into play, remove all cards in all graveyards from the game.\nWhenever a spell is played, counter it if a card with the same name is in play or in any graveyard.",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "a64a4985-34ea-5183-b0c2-3fc8c88509f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98413-740d-47fd-bed6-2d3d05a72b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98413-740d-47fd-bed6-2d3d05a72b31.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to owner's hand.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "7a4da54f-0802-5be6-92db-9ffccc648a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c599f95-c0dd-4dd8-a8d7-9481df0cf649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c599f95-c0dd-4dd8-a8d7-9481df0cf649.jpg?1",
             "name": "Cerulean Wyvern",
             "text": "Flying, protection from green",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "bbd009fe-3a12-5080-b063-3a538a744c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6e21e6-fb3e-49c1-b5a0-499faf66d279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6e21e6-fb3e-49c1-b5a0-499faf66d279.jpg?1",
             "name": "Cloak of Invisibility",
             "text": "Enchanted creature gains phasing and cannot be blocked except by Walls.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "9e91a149-b355-5ad9-a3b8-f4a123a0c04d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9dfa0-bdb3-4419-ae4b-cc394552af74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9dfa0-bdb3-4419-ae4b-cc394552af74.jpg?1",
             "name": "Coral Fighters",
             "text": "If Coral Fighters attacks and is not blocked, look at the top card of defending player's library. You may choose to put that card on the bottom of that player's library.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "b9695fca-ea47-557b-992c-a66a56ce7921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87b3c06-5479-4060-8d3a-d161fd5830c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87b3c06-5479-4060-8d3a-d161fd5830c1.jpg?1",
             "name": "Daring Apprentice",
             "text": "oc\nT, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "e9c340ef-5f89-5e12-ab95-d067c9e322b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9271d-6dbf-4640-9222-721a7a3ccc08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9271d-6dbf-4640-9222-721a7a3ccc08.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. Remove that spell card from the game.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "274c4f97-a565-5951-9dc3-7204ef63b660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b599422e-5f78-4d4f-bc67-684caf69458f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b599422e-5f78-4d4f-bc67-684caf69458f.jpg?1",
             "name": "Dream Cache",
             "text": "Draw three cards. Choose two cards from your hand and put both on either the top or the bottom of your library.",
             "colours": [
@@ -2022,7 +2022,7 @@
         },
         {
             "id": "d72674be-d656-5543-b795-47ab241a72b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec06bc9-553c-4e01-8b43-a4eeaa511b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec06bc9-553c-4e01-8b43-a4eeaa511b4d.jpg?1",
             "name": "Dream Fighter",
             "text": "Whenever Dream Fighter blocks or is blocked by a creature, Dream Fighter and that creature phase out.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "4d5bf919-6733-5fe7-b39f-df2504e661a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e060d7-42ed-49ab-bc5c-2f3210cbd0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e060d7-42ed-49ab-bc5c-2f3210cbd0d1.jpg?1",
             "name": "Energy Vortex",
             "text": "When you play Energy Vortex, choose target opponent.\nAt the beginning of your upkeep, remove all energy counters from Energy Vortex.\nDuring chosen opponent's upkeep, he or she pays o1 for each energy counter on Energy Vortex, or it deals 3 damage to him or her.\noo\nX Put X energy counters on Energy Vortex. Use this ability only during your upkeep.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "6a9b82dc-95d3-523c-a4b2-1213af3e9e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2cf195-01bf-4076-a0c6-ca5403d84f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2cf195-01bf-4076-a0c6-ca5403d84f7d.jpg?1",
             "name": "Ether Well",
             "text": "Put target creature on top of owner's library. If that creature is red, you may choose to put it on the bottom of owner's library instead.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "89eb396a-c21a-590f-a1c3-606539a75b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63af3c26-5b1f-46f6-9aa2-036c615bf5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63af3c26-5b1f-46f6-9aa2-036c615bf5ea.jpg?1",
             "name": "Flash",
             "text": "Choose a creature card from your hand and put that creature into play as though it were just played. Pay the creature's casting cost reduced by up to o2. If you cannot, bury the creature.",
             "colours": [
@@ -2149,7 +2149,7 @@
         },
         {
             "id": "910d60c3-2b48-573b-9af9-3495f286bca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2f594d-e608-444b-b81f-836de2452868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2f594d-e608-444b-b81f-836de2452868.jpg?1",
             "name": "Floodgate",
             "text": "If Floodgate gains flying, bury it.\nIf Floodgate leaves play, it deals to each nonblue creature without flying 1 damage for each two islands you control.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "2c0c052c-9dcd-56da-bf0b-3cdb299cfec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8192bca7-03e5-4ea1-ae77-8bc811c19417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8192bca7-03e5-4ea1-ae77-8bc811c19417.jpg?1",
             "name": "Hakim, Loreweaver",
             "text": "Flying\no\nUoo\nU Put target creature enchantment card from your graveyard on Hakim, Loreweaver. Treat that enchantment as though it were just played. Use this ability only during your upkeep and only if there are no enchantments on Hakim.\no\nUo\nU, oc\nT: Destroy all enchantments on Hakim.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "ee103e90-c409-566c-9f0b-19095cbb2eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6673d49-c3f6-41f6-84c6-1957fff71509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6673d49-c3f6-41f6-84c6-1957fff71509.jpg?1",
             "name": "Harmattan Efreet",
             "text": "Flying\no1o\nUoo\nU Target creature gains flying until end of turn.",
             "colours": [
@@ -2251,7 +2251,7 @@
         },
         {
             "id": "21660c9a-0847-5171-850b-1202de7d6df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0c085a-e17d-4003-bb58-f97555365fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0c085a-e17d-4003-bb58-f97555365fcf.jpg?1",
             "name": "Jolt",
             "text": "Tap or untap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2282,7 +2282,7 @@
         },
         {
             "id": "0c9573f2-c0fa-5f9d-9d86-7bb8c50d596c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10b5ce7-16c9-48f3-a1da-8a91092d053a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10b5ce7-16c9-48f3-a1da-8a91092d053a.jpg?1",
             "name": "Kukemssa Pirates",
             "text": "If Kukemssa Pirates attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do, gain control of target artifact that player controls.",
             "colours": [
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "707a488e-ffe4-567f-b004-59304b1ecc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099eacf-1898-493c-ae87-d5ff4a3646a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099eacf-1898-493c-ae87-d5ff4a3646a2.jpg?1",
             "name": "Kukemssa Serpent",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)\no\nU, Sacrifice an island: Target land an opponent controls is an island until end of turn.",
             "colours": [
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "72f496de-70bd-5b03-8731-e10011d1c928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0245553c-b483-47df-940b-5d7deb108642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0245553c-b483-47df-940b-5d7deb108642.jpg?1",
             "name": "Meddle",
             "text": "Target spell, which targets a single creature, targets another creature of your choice instead. The new target must be legal.",
             "colours": [
@@ -2380,7 +2380,7 @@
         },
         {
             "id": "2b351303-ce53-5178-bc50-b31811117e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63453ed9-5cf1-4cad-b173-a067f22a4405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63453ed9-5cf1-4cad-b173-a067f22a4405.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of owner's library.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "cc40bfe6-d8d1-5a8a-bd86-fe36aad43653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f34166-8946-4bcc-84af-3540c42ac7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f34166-8946-4bcc-84af-3540c42ac7f7.jpg?1",
             "name": "Merfolk Raiders",
             "text": "Phasing; islandwalk (If defending player controls any islands, this creature is unblockable.)",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "a23873f5-23b9-5c71-ab5f-3be659a3faea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63139890-e860-4791-9bb6-b79bb361ef8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63139890-e860-4791-9bb6-b79bb361ef8b.jpg?1",
             "name": "Merfolk Seer",
             "text": "o1oo\nU Draw a card. Use this ability only when Merfolk Seer is put into the graveyard from play and only once.",
             "colours": [
@@ -2479,7 +2479,7 @@
         },
         {
             "id": "35a27a60-8139-501b-b407-91694e4b8106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952eb6ae-a530-4f4f-92f0-a6602beaa7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952eb6ae-a530-4f4f-92f0-a6602beaa7b2.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word or basic land type with another. (For example, you may change \"nonred creature\" to \"nongreen creature\" or \"plainswalk\" to \"swampwalk.\")",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "a99448b1-710e-5445-9a03-1f5642a16b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf17780-801d-4ab8-91f4-a803ede51395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf17780-801d-4ab8-91f4-a803ede51395.jpg?1",
             "name": "Mind Harness",
             "text": "Play only on a red or green creature.\nCumulative upkeep o1\nGain control of enchanted creature.",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "e9bca768-7084-5366-a0fc-d85ac8164a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9b4be4-74c8-4fe5-a5e4-de57c11e8ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9b4be4-74c8-4fe5-a5e4-de57c11e8ec1.jpg?1",
             "name": "Mist Dragon",
             "text": "o0: Flying\no0: Loses flying\no3o\nUoo\nU Phases out",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "2fd2e10a-a268-5c33-aaf7-a57b7f81e866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d98101f-e32a-4a4a-a649-faa920d111ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d98101f-e32a-4a4a-a649-faa920d111ee.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant, interrupt, mana source, or sorcery card and reveal that card to all players. Shuffle your library and put the revealed card back on top of it.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "f637988d-3152-5174-9f62-fa6d884562d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e56e720-5e8b-4685-969c-e073de78b9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e56e720-5e8b-4685-969c-e073de78b9a1.jpg?1",
             "name": "Political Trickery",
             "text": "Choose target land you control and target land an opponent controls. Exchange control of those lands.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "064e4a22-f012-5b39-afb1-60f2dd6a568c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbae8702-a152-4c53-8a76-691a221f2475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbae8702-a152-4c53-8a76-691a221f2475.jpg?1",
             "name": "Polymorph",
             "text": "Bury target creature. That creature's controller reveals cards from the top of his or her library until a creature card is revealed and then puts that creature into play under his or her control as though it were just played. The player shuffles all other revealed cards into his or her library.",
             "colours": [
@@ -2669,7 +2669,7 @@
         },
         {
             "id": "d7891392-09f3-587d-a6ff-b67da33429fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49717583-e0bb-47d6-92d0-8959af13391f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49717583-e0bb-47d6-92d0-8959af13391f.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless that spell's caster pays an additional o\nX. That player draws and pays all mana from lands and mana pool until o\nX is paid; he or she may also draw and pay mana from other sources if desired.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "7578d1ee-c2b9-5200-a19a-d5af203e55e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1129585-6d59-4217-9404-747a100f1e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1129585-6d59-4217-9404-747a100f1e8c.jpg?1",
             "name": "Prismatic Lace",
             "text": "Target permanent becomes the color(s) of your choice. Costs to tap, maintain, or use an ability of that permanent remain unchanged.",
             "colours": [
@@ -2731,7 +2731,7 @@
         },
         {
             "id": "a9b5375d-7c1e-55a5-9f24-bbaa212b7908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507c474-5c4b-4292-b7bc-3ab4b48ea290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507c474-5c4b-4292-b7bc-3ab4b48ea290.jpg?1",
             "name": "Psychic Transfer",
             "text": "Compare your life total with target player's life total. If the difference is 5 or less and you have at least 1 life, exchange life totals with that player.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "9a69d5fc-412d-5af0-9a80-db43652e2f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4361c600-7a97-46bf-8cc1-f3713d3c28ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4361c600-7a97-46bf-8cc1-f3713d3c28ab.jpg?1",
             "name": "Ray of Command",
             "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature is unaffected by summoning sickness this turn. Tap the creature if you lose control of it at end of this turn.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "c1bb27c9-f1ac-506b-8fe8-80648343b232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b94eed-2a45-4a6b-a06b-a2021b174bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b94eed-2a45-4a6b-a06b-a2021b174bc5.jpg?1",
             "name": "Reality Ripple",
             "text": "Target artifact, creature, or land phases out.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "ec327bd1-5dc5-583e-9e8c-d85740a04eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bea2ea-04d3-4835-843a-ebbed0ef5831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bea2ea-04d3-4835-843a-ebbed0ef5831.jpg?1",
             "name": "Reality Ripple",
             "text": "",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "a2b59e0a-5179-5d02-9648-1253776e3e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450b79d9-5ab8-4699-8052-a278c316a5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450b79d9-5ab8-4699-8052-a278c316a5c3.jpg?1",
             "name": "Sandbar Crocodile",
             "text": "Phasing",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "007e9122-9daf-53d3-9972-15cc08cd9a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2944e5df-eef9-42be-a591-5ac15e306ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2944e5df-eef9-42be-a591-5ac15e306ad8.jpg?1",
             "name": "Sapphire Charm",
             "text": "Choose one Target player draws a card at the beginning of the next turn's upkeep; or target creature an opponent controls phases out; or target creature gains flying until end of turn.",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "a268439a-5a5c-5c87-a5f9-aae29524a9ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124308ac-1bf6-4a79-8aaa-f3be8eeb3e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124308ac-1bf6-4a79-8aaa-f3be8eeb3e78.jpg?1",
             "name": "Sea Scryer",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source. o1, oc\nT: Add o\nU to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "ec6a76c8-2bf3-53ae-8af7-135a28b2eff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9304e1-f403-404d-9fe9-169da75e0d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9304e1-f403-404d-9fe9-169da75e0d62.jpg?1",
             "name": "Shaper Guildmage",
             "text": "o\nW, oc\nT: Target creature gains first strike until end of turn.\no\nB, oc\nT: Target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "f14b09f0-fbb1-5b79-95bc-742cf2bc5c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c892daa-57fe-4712-b64a-6099d531bb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c892daa-57fe-4712-b64a-6099d531bb26.jpg?1",
             "name": "Shimmer",
             "text": "When you play Shimmer, choose a land type.\nAll lands of the chosen type gain phasing.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "d561d8cf-760e-54d4-9307-b635c17aff44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3666dd-a90e-43c2-bd78-ea9c1af08a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3666dd-a90e-43c2-bd78-ea9c1af08a0e.jpg?1",
             "name": "Soar",
             "text": "You may choose to play Soar as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +0/+1 and gains flying.",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "d5bc82aa-d34c-557c-8fa8-e703cf8d16a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a7c22e-fe96-4960-96d4-ee85abec3281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a7c22e-fe96-4960-96d4-ee85abec3281.jpg?1",
             "name": "Suq'Ata Firewalker",
             "text": "Suq'Ata Firewalker cannot be the target of red spells or effects.\noc\nT: Suq'Ata Firewalker deals 1 damage to target creature or player.",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "8b90c74f-d130-5724-8ee8-4e56a8d49743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d12315-4220-470d-9628-b9a3ea904ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d12315-4220-470d-9628-b9a3ea904ca7.jpg?1",
             "name": "Taniwha",
             "text": "Phasing, trample\nAt the beginning of your upkeep, all lands you control phase out.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "c1769e4e-fa28-5b5b-832a-459a04038ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb813ef5-8441-4024-a585-1ea24145e1bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb813ef5-8441-4024-a585-1ea24145e1bd.jpg?1",
             "name": "Teferi's Curse",
             "text": "Play only on an artifact or creature.\nEnchanted permanent gains phasing.",
             "colours": [
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "38e1cc38-9fcb-5984-9e36-e921378625ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24823df-5651-4578-a0c8-f9f52f66abe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24823df-5651-4578-a0c8-f9f52f66abe4.jpg?1",
             "name": "Teferi's Drake",
             "text": "Flying, phasing",
             "colours": [
@@ -3192,7 +3192,7 @@
         },
         {
             "id": "8944a2d4-16e5-51f5-a55e-ef3c84a5f6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048f2368-0e2f-4197-b977-353d38b38ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048f2368-0e2f-4197-b977-353d38b38ccc.jpg?1",
             "name": "Teferi's Imp",
             "text": "Flying, phasing\nWhen Teferi's Imp phases out, choose and discard a card.\nWhen Teferi's Imp phases in, draw a card.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "7b0f084b-7c24-546c-aa2b-375971f7c6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12630ac5-a6c4-4852-abd9-5a0bc71bbf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12630ac5-a6c4-4852-abd9-5a0bc71bbf83.jpg?1",
             "name": "Thirst",
             "text": "When Thirst comes into play, tap enchanted creature.\nDuring your upkeep, pay o\nU or bury Thirst.\nEnchanted creature does not untap during its controller's untap phase.",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "d3d4639b-7452-5a81-8b86-8e23e27335ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a9689b-bf1e-404e-ba08-0b04de4288fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a9689b-bf1e-404e-ba08-0b04de4288fb.jpg?1",
             "name": "Tidal Wave",
             "text": "Put a Wave token into play. Treat this token as a 5/5 blue creature that counts as a Wall. Bury the token at end of any turn.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "6d625080-fbbd-52d8-acb8-a0dde05f1dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea65e2-68d8-429f-9be7-e6e5e12a2a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea65e2-68d8-429f-9be7-e6e5e12a2a4d.jpg?1",
             "name": "Vaporous Djinn",
             "text": "Flying\nDuring your upkeep, pay o\nUo\nU or Vaporous Djinn phases out.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "b2c9255f-f875-5408-af91-adf758da5550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ee762-72cb-43e3-88a1-6f1f0b9ee66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ee762-72cb-43e3-88a1-6f1f0b9ee66e.jpg?1",
             "name": "Wave Elemental",
             "text": "o\nU, oc\nT, Sacrifice Wave Elemental: Tap up to three target creatures without flying.",
             "colours": [
@@ -3355,7 +3355,7 @@
         },
         {
             "id": "ea75b13d-b141-5f76-86db-a19c62ac6b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08798c53-46f3-4a51-9284-491730605b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08798c53-46f3-4a51-9284-491730605b2b.jpg?1",
             "name": "Abyssal Hunter",
             "text": "o\nB, oc\nT: Tap target creature. Abyssal Hunter deals to that creature an amount of damage equal to Abyssal Hunter's power.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "21b899af-6fec-584d-acaa-8d22d8e6d5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686aebd0-0d34-47e3-bbbd-ad08d2a3a864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686aebd0-0d34-47e3-bbbd-ad08d2a3a864.jpg?1",
             "name": "Ashen Powder",
             "text": "Put target creature card from an opponent's graveyard into play under your control.",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "6c502fe2-b243-51aa-befc-0032654f51f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b96810d-72d3-4dee-a29f-cdf85ea5ce6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b96810d-72d3-4dee-a29f-cdf85ea5ce6f.jpg?1",
             "name": "Barbed-Back Wurm",
             "text": "oo\nB Target green creature blocking Barbed-Back Wurm gets -1/-1 until end of turn.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "c7bdac6d-ecb2-569c-a9cc-bdb582533cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b620a9f4-358d-4436-85b8-b0c16602ff57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b620a9f4-358d-4436-85b8-b0c16602ff57.jpg?1",
             "name": "Binding Agony",
             "text": "For each 1 damage dealt to enchanted creature, Binding Agony deals 1 damage to that creature's controller.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "96bb1246-fcc0-5103-91f9-ab7cba719e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f2b33c-8d4d-406e-98de-b92d92a3012a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f2b33c-8d4d-406e-98de-b92d92a3012a.jpg?1",
             "name": "Blighted Shaman",
             "text": "oc\nT, Sacrifice a creature: Target creature gets +2/+2 until end of turn.\noc\nT, Sacrifice a swamp: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "e02961ee-0103-5cdf-b23f-e87aa2df584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfde1ca-52f9-477d-a36e-6e4f7ca2e4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfde1ca-52f9-477d-a36e-6e4f7ca2e4d8.jpg?1",
             "name": "Bone Harvest",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3552,7 +3552,7 @@
         },
         {
             "id": "0ae1127e-f367-5ec9-bdaa-efcd90e088ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9da69-5e57-4719-a712-630c9464fada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9da69-5e57-4719-a712-630c9464fada.jpg?1",
             "name": "Breathstealer",
             "text": "oo\nB +1/-1 until end of turn",
             "colours": [
@@ -3585,7 +3585,7 @@
         },
         {
             "id": "17eb7844-6d60-5f89-a474-1df18bec0222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e954b2-c8ce-4b6c-a118-4a14ffa72063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e954b2-c8ce-4b6c-a118-4a14ffa72063.jpg?1",
             "name": "Cadaverous Knight",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1o\nBoo\nB Regenerate",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "c29fc8f4-5b5a-5277-87d5-e63f51836fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6c7750-bc3b-4790-bc9d-88e2cf16881e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6c7750-bc3b-4790-bc9d-88e2cf16881e.jpg?1",
             "name": "Carrion",
             "text": "Sacrifice a creature: Put into play a number of Maggot tokens equal to the sacrificed creature's power. Treat these tokens as 0/1 black creatures.",
             "colours": [
@@ -3650,7 +3650,7 @@
         },
         {
             "id": "b0e6a24b-9eaa-5e65-9bca-036f115299c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46daebe4-199e-4580-8a52-1aebc8492d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46daebe4-199e-4580-8a52-1aebc8492d8c.jpg?1",
             "name": "Catacomb Dragon",
             "text": "Flying\nWhenever Catacomb Dragon is blocked by any nonartifact, non-Dragon creature, that creature's power is halved, rounded up, until end of turn.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "c1f6a2d8-f885-5c09-8c8c-bbfed0836623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c15fb-01a1-446e-9e88-71e8e95d9bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c15fb-01a1-446e-9e88-71e8e95d9bce.jpg?1",
             "name": "Choking Sands",
             "text": "Destroy target nonswamp land. If that land is a nonbasic land, Choking Sands deals 2 damage to the land's controller.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "f3ae4aa6-0677-5643-bd51-1c1dbeee8f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7bcd36-13e2-4ac7-a449-246cecb3fc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7bcd36-13e2-4ac7-a449-246cecb3fc0f.jpg?1",
             "name": "Crypt Cobra",
             "text": "If Crypt Cobra attacks and is not blocked, defending player gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "f2f2014a-dfa7-5215-b237-871f1c2912e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f983dcb-b077-465f-a70b-6bd0e425556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f983dcb-b077-465f-a70b-6bd0e425556c.jpg?1",
             "name": "Dark Banishing",
             "text": "Bury target nonblack creature.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "7b24a110-ded9-542b-8405-04e5969da0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5fc7ce-0618-4145-b8aa-bc871e4afa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5fc7ce-0618-4145-b8aa-bc871e4afa99.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "140c074b-f7d4-5a10-a2dd-4c9c0047019e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc3fa22-a4c4-423d-969b-98c65b23e782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc3fa22-a4c4-423d-969b-98c65b23e782.jpg?1",
             "name": "Dirtwater Wraith",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)\noo\nB +1/+0 until end of turn.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "2a01f8da-317b-583a-b754-f9dd122839f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f030a5-62c6-439d-93b6-43f2cf927a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f030a5-62c6-439d-93b6-43f2cf927a7f.jpg?1",
             "name": "Drain Life",
             "text": "For each o\nB you spend in addition to the casting cost, Drain Life deals 1 damage to target creature or player. Gain 1 life for each 1 damage dealt, but not more than the toughness of the creature or the life total of the player Drain Life damages.",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "79fa383f-c15e-5808-bbd4-f4b0c04eef4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c48e08-9a77-4ba2-8041-90998f7e3812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c48e08-9a77-4ba2-8041-90998f7e3812.jpg?1",
             "name": "Dread Specter",
             "text": "Whenever Dread Specter blocks or is blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "2295ae3d-03d2-5055-b499-3a1c607c43b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937c8016-43c8-418b-9057-b5d6715f71f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937c8016-43c8-418b-9057-b5d6715f71f7.jpg?1",
             "name": "Ebony Charm",
             "text": "Choose one Target opponent loses 1 life and you gain 1 life; or remove from the game up to three cards in any player's graveyard; or target creature cannot be blocked this turn except by artifact or black creatures.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "c6c43457-f5f2-54b6-affb-331b7f11dc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf808509-c6c2-4dcb-b35b-e61291faf5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf808509-c6c2-4dcb-b35b-e61291faf5d9.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchanted creature gets -2/-2.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "aca595c5-6dc5-520f-ac82-e61400ec4cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2d34-1aae-47c7-8b7a-e3354bbbd662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2d34-1aae-47c7-8b7a-e3354bbbd662.jpg?1",
             "name": "Feral Shadow",
             "text": "Flying",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "a065f1ab-e69b-5a2c-a85f-f214f0fc4a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be39d50-1e36-4dac-a923-81fc9f229b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be39d50-1e36-4dac-a923-81fc9f229b8d.jpg?1",
             "name": "Fetid Horror",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "d4e5d5e5-f8e8-5c86-a4d9-4e78c25474fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6168af2-e49b-4c57-91c0-2cac9290a560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6168af2-e49b-4c57-91c0-2cac9290a560.jpg?1",
             "name": "Forbidden Crypt",
             "text": "For each card you would draw, instead choose target card in your graveyard and put it into your hand. If you cannot, you lose the game.\nWhenever a card is put into your graveyard, remove that card from the game.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "99b54ed9-432c-5da0-a6d8-31c0952fe62a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbfc7c-164d-47b8-8f05-987864fca89b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbfc7c-164d-47b8-8f05-987864fca89b.jpg?1",
             "name": "Forsaken Wastes",
             "text": "Players cannot gain life.\nDuring each player's upkeep, that player loses 1 life.\nIf Forsaken Wastes is the target of a successfully cast spell, that spell's caster loses 5 life.",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "0782288d-43c8-5b3b-af03-0789b2d295f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe072da-0524-492b-af3d-7c2600e915ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe072da-0524-492b-af3d-7c2600e915ab.jpg?1",
             "name": "Grave Servitude",
             "text": "You may choose to play Grave Servitude as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +3/-1 and is black.",
             "colours": [
@@ -4134,7 +4134,7 @@
         },
         {
             "id": "0ffd105a-2b82-53ea-99d0-64023cf1734a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e16f8bc-3200-4a0a-b298-c7e7b4e8376c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e16f8bc-3200-4a0a-b298-c7e7b4e8376c.jpg?1",
             "name": "Gravebane Zombie",
             "text": "If Gravebane Zombie is put into the graveyard from play, put Gravebane Zombie on top of owner's library.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "e80b7b59-e59a-56bd-a22f-0df4456f3b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33124133-ed2c-4b86-a135-ac76f4fe4da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33124133-ed2c-4b86-a135-ac76f4fe4da5.jpg?1",
             "name": "Harbinger of Night",
             "text": "During your upkeep, put a -1/-1 counter on each creature.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "c8866d3a-bbc1-5539-beed-7bfeedc345db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62c43bd-59fe-46e3-83f8-c4b37cbc4931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62c43bd-59fe-46e3-83f8-c4b37cbc4931.jpg?1",
             "name": "Infernal Contract",
             "text": "Pay half your life, rounded up: Draw four cards.",
             "colours": [
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "b74191e1-0bf0-5b25-a0f6-3318b29a8a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097910fb-7c48-4535-8ffc-b521d08294b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097910fb-7c48-4535-8ffc-b521d08294b0.jpg?1",
             "name": "Kaervek's Hex",
             "text": "Kaervek's Hex deals 1 damage to each nonblack creature and an additional 1 damage to each green creature.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "9cd0d3dc-ebfb-58be-b364-eb197d536024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120822b8-02ae-411f-bda5-a774c21db66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120822b8-02ae-411f-bda5-a774c21db66c.jpg?1",
             "name": "Mire Shade",
             "text": "o\nB, Sacrifice a swamp: Put a +1/+1 counter on Mire Shade. Play this ability as a sorcery.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "dbbd5bb1-2c23-5979-a9dc-13f45f89201e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1",
             "name": "Nocturnal Raid",
             "text": "All black creatures get +2/+0 until end of turn.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "543c03cf-69ec-5a5b-841f-763e486a72a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79223c17-ecb1-47f1-8e24-eea464cc9b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79223c17-ecb1-47f1-8e24-eea464cc9b1e.jpg?1",
             "name": "Painful Memories",
             "text": "Look at target opponent's hand. Choose one of those cards and put it on top of his or her library.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "fe30d169-a7f3-5df5-a415-60dbaaf92d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc55d48-6d6f-429d-8281-e66a9996d574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc55d48-6d6f-429d-8281-e66a9996d574.jpg?1",
             "name": "Phyrexian Tribute",
             "text": "Sacrifice two creatures: Destroy target artifact.",
             "colours": [
@@ -4388,7 +4388,7 @@
         },
         {
             "id": "7ca32f33-50fa-542d-a10c-baba804dc66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4704bf02-c6be-4983-9bc7-a1d464d21b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4704bf02-c6be-4983-9bc7-a1d464d21b31.jpg?1",
             "name": "Purraj of Urborg",
             "text": "First strike when attacking\noo\nB Put a +1/+1 counter on Purraj of Urborg. Use this ability only when a black spell is successfully cast and only once for each such spell.",
             "colours": [
@@ -4424,7 +4424,7 @@
         },
         {
             "id": "9cc440ac-1202-5a0b-bcb3-eb54c668b1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee67033-7f0f-49b4-8472-3bc4fbb8ffe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee67033-7f0f-49b4-8472-3bc4fbb8ffe1.jpg?1",
             "name": "Ravenous Vampire",
             "text": "Flying\nDuring your upkeep, sacrifice a nonartifact creature and put a +1/+1 counter on Ravenous Vampire, or tap Ravenous Vampire.",
             "colours": [
@@ -4457,7 +4457,7 @@
         },
         {
             "id": "7d7747d8-d6f3-5337-b41f-1fd199856575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd83049-aec1-4911-bc70-39adba04b174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd83049-aec1-4911-bc70-39adba04b174.jpg?1",
             "name": "Reign of Terror",
             "text": "Bury all white creatures or bury all green creatures. Lose 2 life for each creature put into the graveyard in this way.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "d2bb93c8-aa1c-5758-8cea-017ec2ac76ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237cff4-af6f-4745-bda1-e3ed2267fa89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237cff4-af6f-4745-bda1-e3ed2267fa89.jpg?1",
             "name": "Restless Dead",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "54cf24d8-cc9b-563a-b4ea-0e220355385d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe08c3-5024-486c-ba03-19d371ceccb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe08c3-5024-486c-ba03-19d371ceccb0.jpg?1",
             "name": "Sewer Rats",
             "text": "o\nB, Pay 1 life: +1/+0 until end of turn. You cannot spend more than o\nBo\nBo\nB in this way each turn.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "5e1cb8fe-9a62-5c21-b992-bb08c560e7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3fc11e-db36-430c-920b-31195913c16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3fc11e-db36-430c-920b-31195913c16a.jpg?1",
             "name": "Shadow Guildmage",
             "text": "o\nU, oc\nT: Put target creature you control on top of owner's library.\no\nR, oc\nT: Shadow Guildmage deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "e71084b2-bbb1-511c-827f-9a9f97b94fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c782cc-c951-4c6f-a93f-774ae6c1c214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c782cc-c951-4c6f-a93f-774ae6c1c214.jpg?1",
             "name": "Shallow Grave",
             "text": "Put the top creature card from your graveyard into play as though it were just played. That creature is unaffected by summoning sickness. Remove the creature from the game at end of any turn.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "8c0617b5-0945-52f5-925f-01b53022653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d94b21-7568-4e5c-a8ec-ff5bb48a4f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d94b21-7568-4e5c-a8ec-ff5bb48a4f36.jpg?1",
             "name": "Shauku, Endbringer",
             "text": "Flying\nShauku, Endbringer cannot attack if there is another creature in play.\nDuring your upkeep, lose 3 life.\noc\nT: Remove target creature from the game and put a +1/+1 counter on Shauku.",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "4bd6e3fc-41a9-5d5c-9fe5-e907c011ee70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca7e96-0545-4f36-85c0-944d5c0b760a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca7e96-0545-4f36-85c0-944d5c0b760a.jpg?1",
             "name": "Skulking Ghost",
             "text": "Flying\nIf Skulking Ghost is the target of a spell or effect, bury Skulking Ghost.",
             "colours": [
@@ -4689,7 +4689,7 @@
         },
         {
             "id": "79bc43f9-6704-53b7-a33e-fe3bde36bc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa084e1-05c2-4691-b9fe-3e3c717e5c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa084e1-05c2-4691-b9fe-3e3c717e5c9d.jpg?1",
             "name": "Soul Rend",
             "text": "Bury target creature if it is white.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "428f5ad5-702b-5bba-9ad2-3c42f428f1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3bf717-2b88-4704-a7e9-f62dbb3d3d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3bf717-2b88-4704-a7e9-f62dbb3d3d3d.jpg?1",
             "name": "Soulshriek",
             "text": "Target creature you control gets +*/+0 until end of turn, where * is equal to the number of creature cards in your graveyard. Bury that creature at end of turn.",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "d1a6778b-e974-5669-93a8-4da65d5e1296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845c4b06-090f-4217-acb2-8900b7dab37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845c4b06-090f-4217-acb2-8900b7dab37c.jpg?1",
             "name": "Spirit of the Night",
             "text": "Flying, trample, protection from black\nFirst strike when attacking\nSpirit of the Night is unaffected by summoning sickness.",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "05467085-f6a1-5b57-b580-20c63d73bdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fed2498-20ce-48ad-a56e-2c7e297c0c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fed2498-20ce-48ad-a56e-2c7e297c0c66.jpg?1",
             "name": "Stupor",
             "text": "Target opponent discards a card at random, then chooses and discards a card.",
             "colours": [
@@ -4818,7 +4818,7 @@
         },
         {
             "id": "e54bea45-3077-5a74-9c16-ea01eaec6a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb223-784a-4540-8a8e-6007d10a9505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb223-784a-4540-8a8e-6007d10a9505.jpg?1",
             "name": "Tainted Specter",
             "text": "Flying\no1o\nBo\nB, oc\nT: Target player chooses a card from his or her hand and then chooses either to discard that card or put it on top of his or her library. If the card is discarded, Tainted Specter deals 1 damage to each creature and player. Play this ability as a sorcery.",
             "colours": [
@@ -4851,7 +4851,7 @@
         },
         {
             "id": "ffb49fa3-82ca-5a9d-92d3-7ffbdf4870bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fe2f99-7ec2-490c-8ec3-aa2fb4680826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fe2f99-7ec2-490c-8ec3-aa2fb4680826.jpg?1",
             "name": "Tombstone Stairwell",
             "text": "Cumulative upkeep o1o\nB\nDuring each upkeep, each player puts into play a Tombspawn token for each summon card in his or her graveyard. Treat these tokens as 2/2 black creatures that are unaffected by summoning sickness and count as Zombies. At end of any turn or if Tombstone Stairwell leaves play, bury all of these tokens.",
             "colours": [
@@ -4884,7 +4884,7 @@
         },
         {
             "id": "b125bd97-89a4-52db-bd5e-c2e3e34143b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc9ff0f-adec-4d39-b281-98c5862f506b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc9ff0f-adec-4d39-b281-98c5862f506b.jpg?1",
             "name": "Urborg Panther",
             "text": "o\nB, Sacrifice Urborg Panther: Destroy target creature blocking Urborg Panther.\nSacrifice Feral Shadow, Breathstealer, and Urborg Panther: Search your library for Spirit of the Night and put it into play as though it were just played. Shuffle your library afterwards.",
             "colours": [
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "f5d3124a-d680-5944-a21e-ecd8fd699a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde6d3d1-75db-445f-9f17-632ee0292211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde6d3d1-75db-445f-9f17-632ee0292211.jpg?1",
             "name": "Wall of Corpses",
             "text": "o\nB, Sacrifice Wall of Corpses: Destroy target creature blocked by Wall of Corpses.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "3228047a-1dcc-50ea-b330-33ae533a6060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6499cb-6073-4c94-8c82-47f489094df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6499cb-6073-4c94-8c82-47f489094df5.jpg?1",
             "name": "Withering Boon",
             "text": "Pay 3 life: Counter target summon spell.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "6c8c107d-5d4f-51d4-9de5-4db14c095f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab85551f-c9cc-409c-9fb5-a45de695e521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab85551f-c9cc-409c-9fb5-a45de695e521.jpg?1",
             "name": "Zombie Mob",
             "text": "Zombie Mob comes into play with one +1/+1 counter for each summon card in your graveyard. Remove all of those summon cards from the game.",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "635ec7c0-556d-50b1-ae98-55258983880d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5694cb42-7489-40c5-b21a-aeb36636015f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5694cb42-7489-40c5-b21a-aeb36636015f.jpg?1",
             "name": "Agility",
             "text": "Enchanted creature gets +1/+1 and gains flanking (whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn).",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "7ab17ab2-c15a-56e3-a63f-d964a9b139c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380af0a-8a8f-44fd-9456-14a68a2830d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380af0a-8a8f-44fd-9456-14a68a2830d3.jpg?1",
             "name": "Aleatory",
             "text": "Play only after defense is chosen.\nFlip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "19eb715e-59b4-5039-bcca-608bd51b05b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e999fdc3-9269-44d7-9015-e16f5e5b73eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e999fdc3-9269-44d7-9015-e16f5e5b73eb.jpg?1",
             "name": "Armorer Guildmage",
             "text": "o\nB, oc\nT: Target creature gets +1/+0 until end of turn.\no\nG, oc\nT: Target creature gets +0/+1 until end of turn.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "a1bbd14f-09b0-535f-b74a-678431dab570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2955e-e714-419e-9e3d-7ae3d7fae041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2955e-e714-419e-9e3d-7ae3d7fae041.jpg?1",
             "name": "Barreling Attack",
             "text": "Target creature gains trample until end of turn. That creature gets +1/+1 until end of turn for each creature that blocks it.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "98398874-ef12-525d-8719-73b9f1ca6f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff91a17-0a5f-456f-a431-8505ba29e679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff91a17-0a5f-456f-a431-8505ba29e679.jpg?1",
             "name": "Blind Fury",
             "text": "All creatures lose trample until end of turn. Double all combat damage assigned to creatures this turn.",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "b0f796e2-d75e-564c-8a0b-40bec45ec567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d000d8-24e1-4cf3-bed9-e68a89c8f569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d000d8-24e1-4cf3-bed9-e68a89c8f569.jpg?1",
             "name": "Blistering Barrier",
             "text": "",
             "colours": [
@@ -5210,7 +5210,7 @@
         },
         {
             "id": "9eaa86b4-e194-590d-a0a3-40185f88f6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb398027-5a29-4c81-aab5-b1a2b82fd655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb398027-5a29-4c81-aab5-b1a2b82fd655.jpg?1",
             "name": "Builder's Bane",
             "text": "Destroy X target artifacts. For each artifact put into the graveyard in this way, Builder's Bane deals 1 damage to that artifact's controller.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "645b7343-2f59-5ca9-a09d-09660e8a9ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a194488a-1d6f-4bc3-8f30-82e2c3c91389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a194488a-1d6f-4bc3-8f30-82e2c3c91389.jpg?1",
             "name": "Burning Palm Efreet",
             "text": "o1o\nRoo\nR Burning Palm Efreet deals 2 damage to target creature with flying and that creature loses flying until end of turn.",
             "colours": [
@@ -5274,7 +5274,7 @@
         },
         {
             "id": "df9bac2a-6b72-5adf-9e99-37857c74e99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486547cd-d2e7-4c46-9f7b-81c4267d65cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486547cd-d2e7-4c46-9f7b-81c4267d65cc.jpg?1",
             "name": "Burning Shield Askari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no\nRoo\nR First strike until end of turn",
             "colours": [
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "47cdb84d-2574-5352-bf2f-295e813341d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf8ccb8-57fb-491c-b07d-93348b33a765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf8ccb8-57fb-491c-b07d-93348b33a765.jpg?1",
             "name": "Chaos Charm",
             "text": "Choose one Target creature is unaffected by summoning sickness this turn; or Chaos Charm deals 1 damage to target creature; or destroy target Wall.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "6c4e170c-e2da-5118-83ea-8af0862669b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41cb92-578b-4fc8-b1e6-56604088fcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41cb92-578b-4fc8-b1e6-56604088fcd5.jpg?1",
             "name": "Chaosphere",
             "text": "Creatures with flying cannot block creatures without flying.\nCreatures without flying can block creatures with flying.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "7470d1b1-0d68-5079-b9ce-42d9f54fd537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f044c470-50ce-4a6c-b8ab-665357c3c11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f044c470-50ce-4a6c-b8ab-665357c3c11e.jpg?1",
             "name": "Cinder Cloud",
             "text": "Destroy target creature. If a white creature is put into the graveyard in this way, Cinder Cloud deals to that creature's controller an amount of damage equal to the creature's power.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "667b4083-19de-5885-b920-1782d60dedd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05835e35-f4f8-4513-b5a1-9e31b21168f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05835e35-f4f8-4513-b5a1-9e31b21168f0.jpg?1",
             "name": "Consuming Ferocity",
             "text": "Play only on a non-Wall creature.\nEnchanted creature gets +1/+0.\nDuring your upkeep, put a +1/+0 counter on enchanted creature. At the end of any upkeep, if that creature has three of these counters on it, bury the creature and it deals to its controller an amount of damage equal to its power.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "fc665e8e-227d-5db1-9f8c-c3ebd61b88ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f2314-67fe-4a31-8015-9762edf15187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f2314-67fe-4a31-8015-9762edf15187.jpg?1",
             "name": "Crimson Hellkite",
             "text": "Flying\no\nX, oc\nT: Crimson Hellkite deals X damage to target creature. Spend only red mana in this way.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "9b12cb4c-09b7-5b01-ac1e-c9e41b03c11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63836c-37af-49c1-84a1-8650ed072805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63836c-37af-49c1-84a1-8650ed072805.jpg?1",
             "name": "Crimson Roc",
             "text": "Flying\nIf Crimson Roc blocks any creature without flying, Crimson Roc gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "5bdc9766-acc7-505d-8d6d-e3b6d90b6339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7142196-c379-4932-9402-97642ad2ebdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7142196-c379-4932-9402-97642ad2ebdb.jpg?1",
             "name": "Dwarven Miner",
             "text": "o2o\nR, oc\nT: Destroy target nonbasic land.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "dc2093e4-8f54-5242-9173-178ac9e3236a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b09e65-5e69-48f8-be9b-a1e9706f18bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b09e65-5e69-48f8-be9b-a1e9706f18bf.jpg?1",
             "name": "Dwarven Nomad",
             "text": "oc\nT: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -5569,7 +5569,7 @@
         },
         {
             "id": "80332f73-beed-50ed-88ca-0ca669795a58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047d292-8f5c-4a6b-b74e-c8dbf3e0ab24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047d292-8f5c-4a6b-b74e-c8dbf3e0ab24.jpg?1",
             "name": "Ekundu Cyclops",
             "text": "If any creature you control attacks, Ekundu Cyclops also attacks if able.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "58a6a9f2-4e4f-5007-bb4a-a7b50a044bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8c9f5-61dd-4dcc-bd40-8f366374ea18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8c9f5-61dd-4dcc-bd40-8f366374ea18.jpg?1",
             "name": "Emberwilde Djinn",
             "text": "Flying\nDuring each player's upkeep, he or she may pay o\nRo\nR or 2 life to gain control of Emberwilde Djinn.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "7170320e-d569-58d5-98b1-d0c1e77b8f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83589c25-58a2-4172-8f60-6033a61f34c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83589c25-58a2-4172-8f60-6033a61f34c6.jpg?1",
             "name": "Final Fortune",
             "text": "Take another turn after this one. You lose the game at the end of that turn.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "e81fb050-f107-5e9c-badd-b5f11f7a4b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d39dc35-87c9-4984-8a11-443da414e629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d39dc35-87c9-4984-8a11-443da414e629.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "2eb86e1c-07ad-51c7-897d-b8db5b3ffe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e813d-b0b3-4040-b87a-4fa2be681ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e813d-b0b3-4040-b87a-4fa2be681ec5.jpg?1",
             "name": "Flame Elemental",
             "text": "o\nR, oc\nT, Sacrifice Flame Elemental: Flame Elemental deals an amount of damage equal to its power to target creature.",
             "colours": [
@@ -5732,7 +5732,7 @@
         },
         {
             "id": "551c4b17-7c88-5c15-86fd-9e835a848492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd7755f-7ca5-4948-8baf-976823906891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd7755f-7ca5-4948-8baf-976823906891.jpg?1",
             "name": "Flare",
             "text": "Flare deals 1 damage to target creature or player.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "cdbf13b7-4e49-56e6-9174-e07c469d06cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c6b8-9f87-41f1-9e81-b5995e3ed6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c6b8-9f87-41f1-9e81-b5995e3ed6b7.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "If Goblin Elite Infantry blocks or is blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "1bc21728-ddca-5ca5-8606-0549c3bfad05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b87068-aaa6-41de-9b9a-76ca4210a485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b87068-aaa6-41de-9b9a-76ca4210a485.jpg?1",
             "name": "Goblin Scouts",
             "text": "Put three Goblin Scout tokens into play. Treat these tokens as 1/1 red creatures with mountainwalk that count as Goblins (if defending player controls any mountains, these creatures are unblockable).",
             "colours": [
@@ -5828,7 +5828,7 @@
         },
         {
             "id": "8d6c5b48-d23e-549a-bfa7-dc32c06ecb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686b847c-242c-4b91-9fa9-69c9c9f187a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686b847c-242c-4b91-9fa9-69c9c9f187a7.jpg?1",
             "name": "Goblin Soothsayer",
             "text": "o\nR, oc\nT, Sacrifice a Goblin: All red creatures get +1/+1 until end of turn.",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "726c818d-25b1-5162-b4c3-df227578b6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6529852-8b3e-4a70-a4a1-029e012231c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6529852-8b3e-4a70-a4a1-029e012231c6.jpg?1",
             "name": "Goblin Tinkerer",
             "text": "o\nR, oc\nT: Destroy target artifact. That artifact deals an amount of damage equal to its casting cost to Goblin Tinkerer.",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "cd91a286-01b6-5945-b61b-24829496ee58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7285f52-5df0-4f90-9cf7-a57295d90fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7285f52-5df0-4f90-9cf7-a57295d90fd4.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "Hammer of Bogardan deals 3 damage to target creature or player.\no2o\nRo\nRoo\nR Return Hammer of Bogardan to your hand. Use this ability only during your upkeep and only if Hammer of Bogardan is in your graveyard.",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "0a5c46c4-bd5c-59c6-af40-9092e15cee7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee84e61e-d99a-489b-a3b1-cb45fc81bce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee84e61e-d99a-489b-a3b1-cb45fc81bce6.jpg?1",
             "name": "Hivis of the Scale",
             "text": "You may choose not to untap Hivis of the Scale during your untap phase.\noc\nT: Gain control of target Dragon. If Hivis becomes untapped or you lose control of Hivis, lose control of that Dragon.",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "aeb3f535-9aac-566c-8021-e6ce013393c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f633f-538c-4581-b3cc-9285ed6bc4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f633f-538c-4581-b3cc-9285ed6bc4fe.jpg?1",
             "name": "Illicit Auction",
             "text": "Choose target creature. Each player may bid life for control of that creature. You begin the bidding with a high bid of 0. Proceeding in turn order, each player may top the high bid. The auction ends when the high bid stands. The high bidder loses an amount of life equal to the high bid and gains control of the creature.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "b294fe05-1e5e-5460-bb71-6f5586ffaa54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409b2be8-5bb6-45e0-ab87-ca73b4e3a396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409b2be8-5bb6-45e0-ab87-ca73b4e3a396.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. A creature damaged by Incinerate cannot regenerate this turn.",
             "colours": [
@@ -6025,7 +6025,7 @@
         },
         {
             "id": "89889f4e-800b-5e3f-bd2c-efbc9616b258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1624ab-e50e-48a3-acf7-457069914616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1624ab-e50e-48a3-acf7-457069914616.jpg?1",
             "name": "Kaervek's Torch",
             "text": "Interrupts that target Kaervek's Torch each cost an additional o2 to play.\nKaervek's Torch deals X damage to target creature or player.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "e599e4e6-3459-5bc1-ae67-a2b5b17c1b7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271febe5-98ea-403d-87be-7865cf9f426d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271febe5-98ea-403d-87be-7865cf9f426d.jpg?1",
             "name": "Lightning Reflexes",
             "text": "You may choose to play Lightning Reflexes as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +1/+0 and gains first strike.",
             "colours": [
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "26f10de5-6a3a-5041-a552-48e9bf91b849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2dc1a7-4b70-4643-90a8-fdc7877c01ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2dc1a7-4b70-4643-90a8-fdc7877c01ca.jpg?1",
             "name": "Pyric Salamander",
             "text": "oo\nR +1/+0 until end of turn. Bury Pyric Salamander at end of turn.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "182f6ac8-fb50-5eaf-9b59-8347055c58e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a196c21b-e9f5-4ae8-8a1e-668685ef4cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a196c21b-e9f5-4ae8-8a1e-668685ef4cf0.jpg?1",
             "name": "Raging Spirit",
             "text": "o2: Raging Spirit is colorless until end of turn.",
             "colours": [
@@ -6155,7 +6155,7 @@
         },
         {
             "id": "7452429d-9736-5109-a648-777e57ec269d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e41febe-6fad-451e-afe8-20d3ca3c88a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e41febe-6fad-451e-afe8-20d3ca3c88a4.jpg?1",
             "name": "Reckless Embermage",
             "text": "o1oo\nR Reckless Embermage deals 1 damage to target creature or player and 1 damage to itself.",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "b1426643-faf9-5609-814b-c1f41371c1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9285b14a-fc8e-457a-b803-202e05be41e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9285b14a-fc8e-457a-b803-202e05be41e5.jpg?1",
             "name": "Reign of Chaos",
             "text": "Destroy target plains and target white creature, or destroy target island and target blue creature.",
             "colours": [
@@ -6220,7 +6220,7 @@
         },
         {
             "id": "5c39c972-3079-5fce-aec6-0d2f6867c29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf66916-7f6b-412f-acd6-f96ad4539a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf66916-7f6b-412f-acd6-f96ad4539a46.jpg?1",
             "name": "Searing Spear Askari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1oo\nR Searing Spear Askari cannot be blocked by only one creature this turn.",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "39094de7-ad11-5f63-94db-63220e5a963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce37492e-4f07-4171-97d4-84f28fb4e2be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce37492e-4f07-4171-97d4-84f28fb4e2be.jpg?1",
             "name": "Sirocco",
             "text": "Target player reveals his or her hand to all players. For each blue interrupt card that player holds, he or she pays 4 life or discards that card.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "9d8e8169-1d46-5b38-a18a-fe7c6de73ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b774d2-1272-4cd2-b5f8-dfe3ca6e41ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b774d2-1272-4cd2-b5f8-dfe3ca6e41ee.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to target creature an amount of damage equal to the number of mountains you control.",
             "colours": [
@@ -6316,7 +6316,7 @@
         },
         {
             "id": "3224787a-ac24-532b-8d8c-cc0229655210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64bc56f-9e0b-478e-9af4-5333ec2da1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64bc56f-9e0b-478e-9af4-5333ec2da1c3.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "7358d516-8ea4-5217-827c-f7cdefeeb4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132e8aac-9698-45fa-8d64-b460fd5deffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132e8aac-9698-45fa-8d64-b460fd5deffc.jpg?1",
             "name": "Subterranean Spirit",
             "text": "Protection from red\noc\nT: Subterranean Spirit deals 1 damage to each creature without flying.",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "60888647-3b5c-5d41-a60a-1073c7dcd15f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51657034-2c30-40a2-a215-a00277f01642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51657034-2c30-40a2-a215-a00277f01642.jpg?1",
             "name": "Talruum Minotaur",
             "text": "Talruum Minotaur is unaffected by summoning sickness.",
             "colours": [
@@ -6415,7 +6415,7 @@
         },
         {
             "id": "a2d530da-4622-593f-a780-177c24128f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cc89c8-a3ea-469e-b499-f48acec4f538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cc89c8-a3ea-469e-b499-f48acec4f538.jpg?1",
             "name": "Telim'Tor",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Telim'Tor attacks, all attacking creatures with flanking get +1/+1 until end of turn.",
             "colours": [
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "590f18b6-685d-5b4c-bd25-b5cacee82416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088a60f0-2224-4e00-a06a-1d376c8d82a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088a60f0-2224-4e00-a06a-1d376c8d82a4.jpg?1",
             "name": "Telim'Tor's Edict",
             "text": "Remove from the game target permanent you own or control.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -6482,7 +6482,7 @@
         },
         {
             "id": "28bf4334-5bab-5aff-917a-68e118fb1670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19528a24-4968-4742-a2d1-06f94e60f290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19528a24-4968-4742-a2d1-06f94e60f290.jpg?1",
             "name": "Torrent of Lava",
             "text": "Torrent of Lava deals X damage to each creature without flying.\nEach creature gains \"oc\nT: Prevent 1 damage to this creature from Torrent of Lava.\"",
             "colours": [
@@ -6513,7 +6513,7 @@
         },
         {
             "id": "8ed6762f-95ef-56bb-95d2-ce86be8bd384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4947cbf9-69dc-44e3-a22e-a6129f331f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4947cbf9-69dc-44e3-a22e-a6129f331f3c.jpg?1",
             "name": "Viashino Warrior",
             "text": "",
             "colours": [
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "a32af02c-1d2f-59d6-a41d-363569b4d349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda123a7-d121-483a-8ff0-a541ccdbc7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda123a7-d121-483a-8ff0-a541ccdbc7ca.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nVolcanic Dragon is unaffected by summoning sickness.",
             "colours": [
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "4864614c-3a53-565b-8aab-88d6ac9a7ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911787db-9023-46f8-9501-3ad26b6ca51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911787db-9023-46f8-9501-3ad26b6ca51d.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -6611,7 +6611,7 @@
         },
         {
             "id": "7708a2d6-919d-52d5-88a0-f22318beb74c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d99204c-b42d-48bc-9a93-fae5660665c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d99204c-b42d-48bc-9a93-fae5660665c7.jpg?1",
             "name": "Wildfire Emissary",
             "text": "Protection from white\no1oo\nR +1/+0 until end of turn",
             "colours": [
@@ -6644,7 +6644,7 @@
         },
         {
             "id": "fc75fbc0-4ac1-5f5b-a679-10bddb753015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a105b7f4-c93b-4b54-acf8-7212907d9cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a105b7f4-c93b-4b54-acf8-7212907d9cd6.jpg?1",
             "name": "Zirilan of the Claw",
             "text": "o1o\nRo\nR, oc\nT: Search your library for a Dragon card and put it into play as though it were just played. Shuffle your library afterwards. That creature is unaffected by summoning sickness. Remove the creature from the game at end of any turn.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "5e7d26fa-2b75-546a-b4c4-a6b3bbb472a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c495e1f3-0845-4556-83e6-de8b9d518d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c495e1f3-0845-4556-83e6-de8b9d518d1d.jpg?1",
             "name": "Afiya Grove",
             "text": "Afiya Grove comes into play with three +1/+1 counters on it.\nDuring your upkeep, put one of these counters on target creature.\nIf Afiya Grove has none of these counters on it, bury it.",
             "colours": [
@@ -6711,7 +6711,7 @@
         },
         {
             "id": "06274f11-4c80-54df-bd19-0ff5ff8d3886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdb9e7-d79e-4d24-8678-a37ab6e3a413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdb9e7-d79e-4d24-8678-a37ab6e3a413.jpg?1",
             "name": "Armor of Thorns",
             "text": "You may choose to play Armor of Thorns as an instant; if you do, bury it at end of turn.\nPlay only on a nonblack creature.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "0637f38f-fd82-584f-94e4-3d2d13360f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1220fdd1-e4b0-4175-9b8a-178f6a84b8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1220fdd1-e4b0-4175-9b8a-178f6a84b8e6.jpg?1",
             "name": "Barbed Foliage",
             "text": "Whenever a creature attacks you, it loses flanking until end of turn.\nWhenever a creature without flying attacks you, Barbed Foliage deals 1 damage to it.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "d266838d-1bb6-5c84-a6df-71f67fb7ebb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c20edc3-5ad0-42c1-a5ec-3e680fb03297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c20edc3-5ad0-42c1-a5ec-3e680fb03297.jpg?1",
             "name": "Brushwagg",
             "text": "If Brushwagg blocks or is blocked, it gets -2/+2 until end of turn.",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "977de1b3-0aad-5785-b355-05fad4fc8b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c5e4d6-b716-4994-b226-b1eb799bec25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c5e4d6-b716-4994-b226-b1eb799bec25.jpg?1",
             "name": "Canopy Dragon",
             "text": "Trample\no1oo\nG Flying and loses trample until end of turn",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "14180949-64d4-5f7c-bde1-684999418b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e0337-d9ac-4bf2-b2b5-aadc97433030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e0337-d9ac-4bf2-b2b5-aadc97433030.jpg?1",
             "name": "Crash of Rhinos",
             "text": "Trample",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "4140f4e8-686a-587d-8468-6e5a6f31bcf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b53861-97aa-4fff-9526-7d496d1717a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b53861-97aa-4fff-9526-7d496d1717a4.jpg?1",
             "name": "Cycle of Life",
             "text": "Return Cycle of Life to owner's hand: Target creature you summoned this turn is 0/1 until the beginning of your next upkeep. At the beginning of your next upkeep, put a +1/+1 counter on that creature.",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "8975e752-db69-52f6-b027-0148bbea56d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ea46a1-ea65-4802-812c-4f0e0f3088d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ea46a1-ea65-4802-812c-4f0e0f3088d2.jpg?1",
             "name": "Decomposition",
             "text": "Play only on a black creature.\nEnchanted creature gains \"Cumulative upkeep\u20141 life.\"\nIf enchanted creature is put into the graveyard, its controller loses 2 life.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "19f5d02b-5f97-5ae9-bb29-d8c8e51bcff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e18b5-baef-4fe9-807e-097b972c879f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e18b5-baef-4fe9-807e-097b972c879f.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "f0ab2a9e-f37e-5e3d-a439-63adaa88dcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482c390-69cf-484e-a06c-8d63f770c7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482c390-69cf-484e-a06c-8d63f770c7de.jpg?1",
             "name": "Fallow Earth",
             "text": "Put target land on top of owner's library.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "ff2051d3-6404-5295-a7f4-fb89530f23a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e859180f-084c-4023-848a-96f22b8f9698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e859180f-084c-4023-848a-96f22b8f9698.jpg?1",
             "name": "Femeref Archers",
             "text": "oc\nT: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "14a8ef67-fa96-5cc0-af89-96fded5be883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d822598-2f0f-45fa-9643-0368e2c0e18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d822598-2f0f-45fa-9643-0368e2c0e18b.jpg?1",
             "name": "Fog",
             "text": "Creatures deal no combat damage this turn.",
             "colours": [
@@ -7065,7 +7065,7 @@
         },
         {
             "id": "7360c7a9-92c0-5664-bf78-7fa1cc856c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e1195d-443f-4826-a748-bc6e7e24153a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e1195d-443f-4826-a748-bc6e7e24153a.jpg?1",
             "name": "Foratog",
             "text": "o\nG, Sacrifice a forest: +2/+2 until end of turn",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "c5974b3c-61a8-5c15-a045-8fff4f53701c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b56c895-37d3-4475-a542-dc6d21c46f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b56c895-37d3-4475-a542-dc6d21c46f06.jpg?1",
             "name": "Giant Mantis",
             "text": "Giant Mantis can block creatures with flying.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "8cff347b-e73f-59fb-a79a-551171c15eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a252a1f5-bba5-4525-8141-57caea9624e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a252a1f5-bba5-4525-8141-57caea9624e9.jpg?1",
             "name": "Gibbering Hyenas",
             "text": "Gibbering Hyenas cannot block black creatures.",
             "colours": [
@@ -7164,7 +7164,7 @@
         },
         {
             "id": "fb737dbc-f0bf-59b5-840c-7b658c473995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f495b27-3eed-4962-b69a-b86f9fc6a9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f495b27-3eed-4962-b69a-b86f9fc6a9a7.jpg?1",
             "name": "Granger Guildmage",
             "text": "o\nW, oc\nT: Target creature gains first strike until end of turn.\no\nR, oc\nT: Granger Guildmage deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -7200,7 +7200,7 @@
         },
         {
             "id": "936d59b9-2ebb-5df1-9c21-7d885806b782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e4551f-9f6c-4421-ad66-a270df6d3463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e4551f-9f6c-4421-ad66-a270df6d3463.jpg?1",
             "name": "Hall of Gemstone",
             "text": "During each player's upkeep, that player chooses a color.\nUntil end of turn, each mana-producing land produces mana of the chosen color instead of its normal color.",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "763b5b9d-6551-5845-a9dd-25d67ab02167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31588ea3-31d2-4118-9b9f-4ce820c16a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31588ea3-31d2-4118-9b9f-4ce820c16a15.jpg?1",
             "name": "Jolrael's Centaur",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nJolrael's Centaur cannot be the target of spells or effects.",
             "colours": [
@@ -7267,7 +7267,7 @@
         },
         {
             "id": "e388ba37-a6a4-58ad-ac2b-a72263ce7707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c343b8-bbfd-4bc5-b80a-4bc4565cdd40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c343b8-bbfd-4bc5-b80a-4bc4565cdd40.jpg?1",
             "name": "Jungle Patrol",
             "text": "o1o\nG, oc\nT: Put a Wood token into play. Treat this token as a 0/1 green creature that counts as a Wall.\nSacrifice a Wood token: Add o\nR to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "2819327b-f43b-5c3c-b997-c1fc1bc4347f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f81b9-1fa1-4062-a9b3-048179274c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f81b9-1fa1-4062-a9b3-048179274c05.jpg?1",
             "name": "Jungle Wurm",
             "text": "For each creature assigned to block it beyond the first, Jungle Wurm gets -1/-1 until end of turn.",
             "colours": [
@@ -7335,7 +7335,7 @@
         },
         {
             "id": "1a31fb94-f149-5d84-9f44-5c501bccb9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16396594-4f59-4600-8e39-d99544062265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16396594-4f59-4600-8e39-d99544062265.jpg?1",
             "name": "Karoo Meerkat",
             "text": "Protection from blue",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "65d039ab-9cc8-5cce-9a1f-0c590628975b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd269842-4c31-4398-9451-be0d941397ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd269842-4c31-4398-9451-be0d941397ac.jpg?1",
             "name": "Locust Swarm",
             "text": "Flying\noo\nG Regenerate\noo\nG Untap Locust Swarm. Use this ability only once each turn.",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "edb8c20f-d274-558c-8d58-953fd8208d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7165f1d8-7b31-4a81-aab4-c6cd4ff2e67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7165f1d8-7b31-4a81-aab4-c6cd4ff2e67d.jpg?1",
             "name": "Lure of Prey",
             "text": "Play only if an opponent successfully cast a summon spell this turn.\nPut a green summon card from your hand into play as though it were just played.",
             "colours": [
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "d9cea628-64aa-556b-ae31-3c2dfa90c01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfec2de-cff3-4015-9a43-a58be525a2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfec2de-cff3-4015-9a43-a58be525a2da.jpg?1",
             "name": "Maro",
             "text": "Maro has power and toughness each equal to the number of cards in your hand.",
             "colours": [
@@ -7465,7 +7465,7 @@
         },
         {
             "id": "5b4dc4e6-0fa6-5adc-9af0-2d57e64e765c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41066eb-be5e-4a6d-9156-64f5e56c7ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41066eb-be5e-4a6d-9156-64f5e56c7ab3.jpg?1",
             "name": "Mindbender Spores",
             "text": "Flying\nWhenever Mindbender Spores blocks any creature, put four fungus counters on that creature. During its controller's untap phase, remove a fungus counter from the creature. As long as the creature has any fungus counters on it, it does not untap during its controller's untap phase.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "0f5ac0fc-5828-5158-b948-3579925da8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05cf5b-2a0d-432a-b8e7-10335c2a18e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05cf5b-2a0d-432a-b8e7-10335c2a18e8.jpg?1",
             "name": "Mtenda Lion",
             "text": "If Mtenda Lion attacks, defending player may pay o\nU to have it deal no combat damage this turn.",
             "colours": [
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "f79c163d-0ce4-5095-9336-f1b4db658e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f7c47c-416e-4f73-89ec-024a29dfb5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f7c47c-416e-4f73-89ec-024a29dfb5e9.jpg?1",
             "name": "Natural Balance",
             "text": "Each player controlling six or more lands sacrifices enough lands to reduce his or her land total to five.\nEach player controlling four or fewer lands may search his or her library for enough basic land to bring his or her land total to five and put those lands into play. Those players shuffle their libraries afterwards.",
             "colours": [
@@ -7564,7 +7564,7 @@
         },
         {
             "id": "f9174da1-8341-533a-9193-7e694f9671d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5aa60d-91aa-4eee-9d13-55a357c8eced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5aa60d-91aa-4eee-9d13-55a357c8eced.jpg?1",
             "name": "Nettletooth Djinn",
             "text": "During your upkeep, Nettletooth Djinn deals 1 damage to you.",
             "colours": [
@@ -7597,7 +7597,7 @@
         },
         {
             "id": "9a41a0f5-8a64-5e3c-8695-632c3e86bb9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ce9668-78ef-44a5-ba9c-49fa740b8cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ce9668-78ef-44a5-ba9c-49fa740b8cb5.jpg?1",
             "name": "Preferred Selection",
             "text": "At the beginning of your draw phase, look at the top two cards of your library and choose one. Put that card on the bottom of your library, or sacrifice Preferred Selection and pay o2o\nGo\nG to draw the card.",
             "colours": [
@@ -7628,7 +7628,7 @@
         },
         {
             "id": "90460444-2189-5c1f-8a1a-36f2c2d7a49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9a64fb-1e8d-4ed8-b4c5-3d44db9c1d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9a64fb-1e8d-4ed8-b4c5-3d44db9c1d3b.jpg?1",
             "name": "Quirion Elves",
             "text": "When you play Quirion Elves, choose a color.\noc\nT: Add one mana of the chosen color to your mana pool. Play this ability as a mana source.\noc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "48204728-b341-5d20-8268-b3e36ae8e132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd8043-4099-42bb-9d54-4efc8b38fe18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd8043-4099-42bb-9d54-4efc8b38fe18.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put it into play, tapped. Shuffle your library afterwards.",
             "colours": [
@@ -7693,7 +7693,7 @@
         },
         {
             "id": "19326ed0-4337-58f2-b431-ee5f900d825f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3d7a4f-8ccc-44cf-bacc-5055c7e1edbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3d7a4f-8ccc-44cf-bacc-5055c7e1edbc.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -7726,7 +7726,7 @@
         },
         {
             "id": "b5ecfb49-2aaa-5f04-83ec-e435136efc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26724a51-87dd-4159-b012-71598e4cf5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26724a51-87dd-4159-b012-71598e4cf5eb.jpg?1",
             "name": "Roots of Life",
             "text": "When you play Roots of Life, choose islands or swamps.\nWhenever a land of the chosen type that target opponent controls becomes tapped, gain 1 life.",
             "colours": [
@@ -7757,7 +7757,7 @@
         },
         {
             "id": "462bf035-0bd4-5017-9b03-7845f87db66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ead72b-f3f5-4065-a33c-0992cf1fdb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ead72b-f3f5-4065-a33c-0992cf1fdb34.jpg?1",
             "name": "Sabertooth Cobra",
             "text": "If Sabertooth Cobra damages a player, he or she gets a poison counter. During that player's next upkeep, he or she gets another poison counter unless he or she pays o2 before then to prevent this effect. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "259ba38c-1801-52b4-ba2d-1a09ed0a1887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdce7d3c-cc17-4010-85ec-402a6f256360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdce7d3c-cc17-4010-85ec-402a6f256360.jpg?1",
             "name": "Sandstorm",
             "text": "Sandstorm deals 1 damage to each attacking creature.",
             "colours": [
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "1dd6f12a-8a69-5853-a7f1-f32600fba0a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42746e1-f422-4453-a860-3993d5796479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42746e1-f422-4453-a860-3993d5796479.jpg?1",
             "name": "Seedling Charm",
             "text": "Choose one Return target creature enchantment to owner's hand; or regenerate target green creature; or target creature gains trample until end of turn.",
             "colours": [
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "e18e5ae4-d709-5344-8aaa-5801ce82d5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c868f5-0f90-4f7e-bafb-c45d2372fe06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c868f5-0f90-4f7e-bafb-c45d2372fe06.jpg?1",
             "name": "Seeds of Innocence",
             "text": "Bury all artifacts. Each artifact's controller gains an amount of life equal to that artifact's casting cost.",
             "colours": [
@@ -7883,7 +7883,7 @@
         },
         {
             "id": "39c97901-2d81-5f5c-8380-a01a0a19e072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff19d9d-8069-4f8d-a81b-e2fcd94c13b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff19d9d-8069-4f8d-a81b-e2fcd94c13b3.jpg?1",
             "name": "Serene Heart",
             "text": "Destroy all local enchantments.",
             "colours": [
@@ -7914,7 +7914,7 @@
         },
         {
             "id": "66787a53-ebe2-5783-94f8-2bd3c8994920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12cc4e9-010a-4ff7-a026-dcb6113a36fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12cc4e9-010a-4ff7-a026-dcb6113a36fb.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger cannot be blocked by more than one creature.",
             "colours": [
@@ -7947,7 +7947,7 @@
         },
         {
             "id": "25106200-0622-5772-a85f-93a0efc5a5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d90914-ddfc-49c2-8e58-fdc3693040f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d90914-ddfc-49c2-8e58-fdc3693040f2.jpg?1",
             "name": "Superior Numbers",
             "text": "Superior Numbers deals to target creature 1 damage for each creature you control in excess of the number of creatures target opponent controls.",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "614e0813-ae57-5153-8e1a-6776048b4c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801f34a6-9f22-43c2-b1e5-194395cc7da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801f34a6-9f22-43c2-b1e5-194395cc7da1.jpg?1",
             "name": "Tranquil Domain",
             "text": "Destroy all global enchantments.",
             "colours": [
@@ -8009,7 +8009,7 @@
         },
         {
             "id": "7905102a-c7cd-54ad-97a8-aecef23f137e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f473c-e11e-4047-91f9-81b80f0a3562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f473c-e11e-4047-91f9-81b80f0a3562.jpg?1",
             "name": "Tropical Storm",
             "text": "Tropical Storm deals X damage to each creature with flying and 1 damage to each blue creature.",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "4f293dcf-b501-59f9-950a-56667096a443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cdee9f-7ea9-4397-a230-ce610be5d3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cdee9f-7ea9-4397-a230-ce610be5d3af.jpg?1",
             "name": "Uktabi Faerie",
             "text": "Flying\no3o\nG, Sacrifice Uktabi Faerie: Destroy target artifact.",
             "colours": [
@@ -8073,7 +8073,7 @@
         },
         {
             "id": "23c4b87f-1f53-5dd3-8275-a7ef94aec5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f287ff-1b1b-454a-9360-fac34c8e1f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f287ff-1b1b-454a-9360-fac34c8e1f24.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "Uktabi Wildcats has power and toughness each equal to the number of forests you control.\no\nG, Sacrifice a forest: Regenerate",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "c6fd3479-316f-5874-9ac6-2f90ed13f293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a73d-8810-42f7-b20a-a6dd53586220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a73d-8810-42f7-b20a-a6dd53586220.jpg?1",
             "name": "Unseen Walker",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)\no1o\nGoo\nG Target creature gains forestwalk until end of turn.",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "2c2efed9-b246-5409-b97d-3bb60985c65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bdd944-e86c-4e5e-b75c-9bbf4fb27ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bdd944-e86c-4e5e-b75c-9bbf4fb27ccd.jpg?1",
             "name": "Unyaro Bee Sting",
             "text": "Unyaro Bee Sting deals 2 damage to target creature or player.",
             "colours": [
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "6bd19445-c2f2-5e7d-b930-7eddbb7a1661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253a1d97-ec45-41c9-ba81-bbb6ab584b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253a1d97-ec45-41c9-ba81-bbb6ab584b2b.jpg?1",
             "name": "Village Elder",
             "text": "o\nG, oc\nT, Sacrifice a forest: Regenerate target creature.",
             "colours": [
@@ -8204,7 +8204,7 @@
         },
         {
             "id": "de47aade-4eca-5a31-bb9e-bf22d14ff21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f91ec4e-6818-46f4-94da-f3f8c4489fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f91ec4e-6818-46f4-94da-f3f8c4489fb2.jpg?1",
             "name": "Waiting in the Weeds",
             "text": "For each untapped forest he or she controls, each player puts a Cat token into play under his or her control. Treat these tokens as 1/1 green creatures.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "d31b98de-c104-5875-a6a1-a203b48432e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb151d2-c313-44d2-972e-33487f070c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb151d2-c313-44d2-972e-33487f070c23.jpg?1",
             "name": "Wall of Roots",
             "text": "Put a -0/-1 counter on Wall of Roots: Add o\nG to your mana pool. Play this ability as a mana source. Use this ability only once each turn.",
             "colours": [
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "114d7215-080d-5cf9-9699-146462374727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7809131c-747c-4c33-a3ca-13e573a92b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7809131c-747c-4c33-a3ca-13e573a92b66.jpg?1",
             "name": "Wild Elephant",
             "text": "Trample",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "5aeb81bd-bf82-56ee-9950-17cbbb1cf3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00115bc-b551-4bf5-a121-bebb37201575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00115bc-b551-4bf5-a121-bebb37201575.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card and reveal that card to all players. Shuffle your library and put the revealed card back on top of it.",
             "colours": [
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "c49cdef6-e33c-55a0-869e-76d0f6be5fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d64600-84fc-42a5-a6a6-b26f98fac0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d64600-84fc-42a5-a6a6-b26f98fac0a4.jpg?1",
             "name": "Asmira, Holy Avenger",
             "text": "Flying\nAt the end of each turn, put a +1/+1 counter on Asmira, Holy Avenger for each creature put into your graveyard from play that turn.",
             "colours": [
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "972dc843-b9d1-5fcf-a7dc-5c942ee1c341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03586-8d04-4114-a7ce-b8c8ab5ff857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03586-8d04-4114-a7ce-b8c8ab5ff857.jpg?1",
             "name": "Benthic Djinn",
             "text": "Islandwalk (If defending player controls any islands, this creature is unblockable.)\nDuring your upkeep, lose 2 life.",
             "colours": [
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "b5e9f356-02aa-5a0e-9c3a-7b7a1f2e01ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bef70b-61c7-4df5-b4df-09cd6ab2015c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bef70b-61c7-4df5-b4df-09cd6ab2015c.jpg?1",
             "name": "Cadaverous Bloom",
             "text": "Choose a card in your hand and remove it from the game: Add o\nBo\nB or o\nGo\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "ca0a846b-99b4-5381-acc6-2f065625b985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2c05-0d2f-4d02-aef3-e1078d78e5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2c05-0d2f-4d02-aef3-e1078d78e5ff.jpg?1",
             "name": "Circle of Despair",
             "text": "o1, Sacrifice a creature: Prevent all damage to any creature or player from any one source.",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "21aac4c5-5a75-5b61-8fcf-39183cbe3912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52981ea-1173-4f4b-a929-705a11c6e381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52981ea-1173-4f4b-a929-705a11c6e381.jpg?1",
             "name": "Delirium",
             "text": "Play only on target opponent's turn.\nTap target creature that player controls. That creature deals to the player an amount of damage equal to its power. The creature neither deals nor receives combat damage this turn.",
             "colours": [
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "cad7972d-2ddc-55de-87e1-eae70e5c384d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be67b950-dfe3-4159-aa53-63df25d2a926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be67b950-dfe3-4159-aa53-63df25d2a926.jpg?1",
             "name": "Discordant Spirit",
             "text": "At end of target opponent's turn, put a +1/+1 counter on Discordant Spirit for each 1 damage dealt to you this turn.\nAt end of your turn, remove all these counters from Discordant Spirit.",
             "colours": [
@@ -8540,7 +8540,7 @@
         },
         {
             "id": "6a683d79-bc22-5121-aa8d-271db94f3ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598a9b4-15bb-4645-92ed-8eedef75dc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598a9b4-15bb-4645-92ed-8eedef75dc24.jpg?1",
             "name": "Emberwilde Caliph",
             "text": "Flying, trample\nEmberwilde Caliph attacks each turn if able.\nFor each 1 damage Emberwilde Caliph successfully deals, lose 1 life.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "7590cf45-e102-5714-ae55-94ef5a5bce7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711f4cff-0256-44b2-a2fe-1cae6e9edb2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711f4cff-0256-44b2-a2fe-1cae6e9edb2b.jpg?1",
             "name": "Energy Bolt",
             "text": "Energy Bolt deals X damage to target player, or target player gains X life.",
             "colours": [
@@ -8608,7 +8608,7 @@
         },
         {
             "id": "aa51352c-d09d-5ee5-8fd2-e147a97847c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4468b-f7de-44fe-898a-4125d26d242f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4468b-f7de-44fe-898a-4125d26d242f.jpg?1",
             "name": "Frenetic Efreet",
             "text": "Flying\no0: Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, Frenetic Efreet phases out. Otherwise, bury Frenetic Efreet.",
             "colours": [
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "2d9dd4fa-c822-5223-9fcb-25a6f3ee38eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69dc4ac-7354-465e-b859-d8556f3b1498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69dc4ac-7354-465e-b859-d8556f3b1498.jpg?1",
             "name": "Grim Feast",
             "text": "At the beginning of your upkeep, Grim Feast deals 1 damage to you.\nWhenever a creature is put into target opponent's graveyard from play, gain an amount of life equal to that creature's toughness.",
             "colours": [
@@ -8676,7 +8676,7 @@
         },
         {
             "id": "6732d483-4117-53e4-b9de-e22a275816ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a2359f-6586-42a6-a855-c0049b448cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a2359f-6586-42a6-a855-c0049b448cb9.jpg?1",
             "name": "Harbor Guardian",
             "text": "Harbor Guardian can block creatures with flying.\nIf Harbor Guardian attacks, defending player may draw a card.",
             "colours": [
@@ -8711,7 +8711,7 @@
         },
         {
             "id": "cbcaab40-b4a9-5e7a-abda-ce80496976e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce9c58f-6470-4e0f-8f6b-457fbaac7451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce9c58f-6470-4e0f-8f6b-457fbaac7451.jpg?1",
             "name": "Haunting Apparition",
             "text": "Flying\nHaunting Apparition has power equal to 1 plus the number of green creature cards in target opponent's graveyard.",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "b490120a-ecdc-55b2-ae5d-47e0eea1f61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2ae5c-58b9-4690-8039-d50cca9ef6cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2ae5c-58b9-4690-8039-d50cca9ef6cf.jpg?1",
             "name": "Hazerider Drake",
             "text": "Flying, protection from red",
             "colours": [
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "0a4a07e3-2512-5f17-b947-a6bfb0ae801c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb9591-399a-4196-a52d-f2954d287a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb9591-399a-4196-a52d-f2954d287a10.jpg?1",
             "name": "Jungle Troll",
             "text": "oo\nR Regenerate\noo\nG Regenerate",
             "colours": [
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "95c1a248-78e5-5695-bcb8-2c14e6faf426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a42ef95-92ec-40fe-ab30-a476f012a525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a42ef95-92ec-40fe-ab30-a476f012a525.jpg?1",
             "name": "Kaervek's Purge",
             "text": "Destroy target creature with casting cost equal to X. If that creature is put into the graveyard in this way, Kaervek's Purge deals to the creature's controller an amount of damage equal to the creature's power.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "0956cb8d-75ae-5f31-b962-a5dfb45d391e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05d1cac-7012-4d22-82d3-0f82b168fe68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05d1cac-7012-4d22-82d3-0f82b168fe68.jpg?1",
             "name": "Leering Gargoyle",
             "text": "Flying\noc\nT: Leering Gargoyle gets -2/+2 and loses flying until end of turn.",
             "colours": [
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "a32d2450-7969-551d-a69d-0a547344bc3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760b6703-ac92-45f6-8c32-60f760eba866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760b6703-ac92-45f6-8c32-60f760eba866.jpg?1",
             "name": "Malignant Growth",
             "text": "Cumulative upkeep o1\nDuring your upkeep, put a growth counter on Malignant Growth.\nDuring target opponent's draw phase, he or she draws an additional card for each growth counter on Malignant Growth. For each card that opponent draws in this way, Malignant Growth deals 1 damage to him or her.",
             "colours": [
@@ -8917,7 +8917,7 @@
         },
         {
             "id": "f008bf58-0303-5d48-a273-8fb6ff4c7ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbc1b-4c2a-44c1-8e62-c0f94fd2ba8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbc1b-4c2a-44c1-8e62-c0f94fd2ba8e.jpg?1",
             "name": "Phyrexian Purge",
             "text": "Pay 3 life per target: Destroy any number of target creatures.",
             "colours": [
@@ -8950,7 +8950,7 @@
         },
         {
             "id": "e65518e8-f7e6-5de9-b5f1-ae638b386eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb774a9b-d29f-4f41-9fb8-a0189205e16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb774a9b-d29f-4f41-9fb8-a0189205e16f.jpg?1",
             "name": "Prismatic Boon",
             "text": "X target creatures gain protection from a single color of your choice until end of turn.",
             "colours": [
@@ -8983,7 +8983,7 @@
         },
         {
             "id": "9b52e8c2-0082-5bcd-ab81-aec804f3e70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5e58b-46f3-437c-89ac-24235a65bd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5e58b-46f3-437c-89ac-24235a65bd1f.jpg?1",
             "name": "Purgatory",
             "text": "Whenever a summon card is put into your graveyard from play, put that card face up under Purgatory.\nDuring your upkeep, you may pay o4 and 2 life to put any card under Purgatory into play as though it were just played.\nIf Purgatory leaves play, remove all cards under if from the game.",
             "colours": [
@@ -9016,7 +9016,7 @@
         },
         {
             "id": "88f310d7-0428-5ef2-a3b3-719d50279b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1853c-d5b9-4361-8a2f-36946a62847b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1853c-d5b9-4361-8a2f-36946a62847b.jpg?1",
             "name": "Radiant Essence",
             "text": "As long as target opponent controls any black permanents, Radiant Essence gets +1/+2.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "21c5fd06-731a-55b8-aae4-ef183328ac83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2bf39b-9665-426b-b618-eb731d24a1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2bf39b-9665-426b-b618-eb731d24a1ee.jpg?1",
             "name": "Reflect Damage",
             "text": "Redirect all damage dealt by any one source to that source's controller.",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "8a13df15-0c31-5b43-a7fc-30f9b8790210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9edf28-79c0-42a5-af0f-6df9c3a1f546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9edf28-79c0-42a5-af0f-6df9c3a1f546.jpg?1",
             "name": "Reparations",
             "text": "Whenever target opponent successfully casts a spell that targets you or a creature you control, you may draw a card.",
             "colours": [
@@ -9117,7 +9117,7 @@
         },
         {
             "id": "d1219e4c-9dd7-5c43-814d-ae76cfc90e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79949237-dcce-4ac1-bdc6-7c6d8b5f5fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79949237-dcce-4ac1-bdc6-7c6d8b5f5fde.jpg?1",
             "name": "Rock Basilisk",
             "text": "Whenever Rock Basilisk blocks or is blocked by a non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "75d9b42d-c01e-548f-9b14-1aac27274544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb73313b-d39a-46ab-abfc-76f94a75dfca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb73313b-d39a-46ab-abfc-76f94a75dfca.jpg?1",
             "name": "Savage Twister",
             "text": "Savage Twister deals X damage to each creature.",
             "colours": [
@@ -9185,7 +9185,7 @@
         },
         {
             "id": "9a13db33-4528-506c-9e4a-ecfaa2edded1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24e74e9-ce88-48af-a113-b4fe76f963d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24e74e9-ce88-48af-a113-b4fe76f963d4.jpg?1",
             "name": "Sawback Manticore",
             "text": "o4: Flying until end of turn\no1: Sawback Manticore deals 2 damage to target attacking or blocking creature. Use this ability only once each turn and only if Sawback Manticore is attacking or blocking.",
             "colours": [
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "2e38c646-8ae6-51a1-b71c-81c278bc4bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cf9da8-f078-4f6e-8077-bb24a7ed487f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cf9da8-f078-4f6e-8077-bb24a7ed487f.jpg?1",
             "name": "Sealed Fate",
             "text": "Look at the top X cards of target opponent's library. Remove one of those cards from the game and put the rest back on top of that player's library in any order.",
             "colours": [
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "ea0e4a40-8745-5235-bfc8-62278ccfe540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9743dc-031b-4932-80a6-1c8ec1dea069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9743dc-031b-4932-80a6-1c8ec1dea069.jpg?1",
             "name": "Shauku's Minion",
             "text": "o\nBo\nR, oc\nT: Shauku's Minion deals 2 damage to target white creature.",
             "colours": [
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "3f409fec-8622-5c6d-9c7d-e0d0ab993d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176d625f-1410-4ad6-a279-9a184fac6507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176d625f-1410-4ad6-a279-9a184fac6507.jpg?1",
             "name": "Spatial Binding",
             "text": "Pay 1 life: Target permanent cannot phase out until the beginning of your next upkeep.",
             "colours": [
@@ -9322,7 +9322,7 @@
         },
         {
             "id": "4771ffc4-bd8b-5c37-8953-71269c0fdfa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389d6c7-2a8a-48d6-a09d-aa195d830576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389d6c7-2a8a-48d6-a09d-aa195d830576.jpg?1",
             "name": "Unfulfilled Desires",
             "text": "o1, Pay 1 life: Draw a card, then choose and discard a card.",
             "colours": [
@@ -9355,7 +9355,7 @@
         },
         {
             "id": "fc2db3d8-f280-586f-b850-46ed8d6a90e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe8a5b8-1a87-46f5-920f-fbbb05bfd563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe8a5b8-1a87-46f5-920f-fbbb05bfd563.jpg?1",
             "name": "Vitalizing Cascade",
             "text": "Gain X+3 life.",
             "colours": [
@@ -9388,7 +9388,7 @@
         },
         {
             "id": "8e58ce6d-6bdd-5731-9e2c-63dfb54b4f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c41d0f-f1db-4797-b245-7de12ffa3a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c41d0f-f1db-4797-b245-7de12ffa3a0d.jpg?1",
             "name": "Warping Wurm",
             "text": "Phasing\nDuring your upkeep, pay o2o\nGo\nU or Warping Wurm phases out.\nWhen Warping Wurm phases in, put a +1/+1 counter on it.",
             "colours": [
@@ -9423,7 +9423,7 @@
         },
         {
             "id": "aa66a392-2c0e-56a3-ab0f-0da26fba1549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ba095-dd78-4999-87a9-63f7165846e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ba095-dd78-4999-87a9-63f7165846e4.jpg?1",
             "name": "Wellspring",
             "text": "When Wellspring comes into play, gain control of enchanted land.\nAt the end of each of your turns, lose control of enchanted land.\nAt the beginning of each of your turns, gain control of enchanted land.",
             "colours": [
@@ -9458,7 +9458,7 @@
         },
         {
             "id": "aba9ba30-bb9b-5c22-9ade-bf7e4a955428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65285030-0714-43bf-bb91-a79dcba1ccc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65285030-0714-43bf-bb91-a79dcba1ccc5.jpg?1",
             "name": "Windreaper Falcon",
             "text": "Flying, protection from blue",
             "colours": [
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "c3d709be-d8b1-5917-899c-d9f63362778f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a663ee9d-78f1-4c89-af9e-c788e165fa91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a663ee9d-78f1-4c89-af9e-c788e165fa91.jpg?1",
             "name": "Zebra Unicorn",
             "text": "For each 1 damage Zebra Unicorn deals, gain 1 life.",
             "colours": [
@@ -9528,7 +9528,7 @@
         },
         {
             "id": "ceba66ba-68ab-5d20-9543-baeafad93c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfdea79-2a7c-489d-8466-e6090c2a0919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfdea79-2a7c-489d-8466-e6090c2a0919.jpg?1",
             "name": "Acidic Dagger",
             "text": "o4, oc\nT: Destroy any non-Wall creature receiving combat damage from target creature this turn. If targeted creature leaves play, bury Acidic Dagger. Use this ability only before defense is chosen.",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "fa926f95-101e-5d58-86da-dd865085f59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046475e5-36d1-4b5f-af31-6df715c7a368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046475e5-36d1-4b5f-af31-6df715c7a368.jpg?1",
             "name": "Amber Prison",
             "text": "You may choose not to untap Amber Prison during your untap phase.\no4, oc\nT: Tap target artifact, creature, or land. As long as Amber Prison remains tapped, that permanent does not untap during its controller's untap phase.",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "eee5fb17-a896-5419-83f5-2afe0bac2969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbd94c8-611c-4b20-99ca-dd2d7661d644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbd94c8-611c-4b20-99ca-dd2d7661d644.jpg?1",
             "name": "Amulet of Unmaking",
             "text": "o5, oc\nT, Remove Amulet of Unmaking from the game: Remove target artifact, creature, or land from the game. Play this ability as a sorcery.",
             "colours": [],
@@ -9609,7 +9609,7 @@
         },
         {
             "id": "b509c617-e067-5bd9-95ff-c6dbf3bb849c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff538f9-10b4-4327-aea6-a86759daf488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff538f9-10b4-4327-aea6-a86759daf488.jpg?1",
             "name": "Basalt Golem",
             "text": "Basalt Golem cannot be blocked by artifact creatures.\nWhenever Basalt Golem is blocked by any creature, bury that creature at end of combat and put a Stone token into play under the control of the creature's controller. Treat this token as a 0/2 artifact creature that counts as a Wall.",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "4578bfe7-059e-53ed-ab8d-7e1aaebb8227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f46aea3-ea00-46c4-b207-522ceeeae68b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f46aea3-ea00-46c4-b207-522ceeeae68b.jpg?1",
             "name": "Bone Mask",
             "text": "o2, oc\nT: Prevent all damage to you from any one source. For each 1 damage prevented in this way, remove the top card of your library from the game.",
             "colours": [],
@@ -9666,7 +9666,7 @@
         },
         {
             "id": "d13e6b70-0e42-59f6-9513-fd64b7b9a8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a81b3f1-babc-4bd7-8b87-754c8389ae85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a81b3f1-babc-4bd7-8b87-754c8389ae85.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond comes into play tapped.\noc\nT: Add o\nB to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9695,7 +9695,7 @@
         },
         {
             "id": "8294d3b4-d1f4-5889-aa86-6ac1d47d28f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3bc470-cfcc-4835-b46f-c08d698ee1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3bc470-cfcc-4835-b46f-c08d698ee1ab.jpg?1",
             "name": "Chariot of the Sun",
             "text": "o2, oc\nT: Target creature you control gains flying and has its toughness reduced to 1 until end of turn.",
             "colours": [],
@@ -9722,7 +9722,7 @@
         },
         {
             "id": "9b280a01-013a-5d49-ae98-05f5359abcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d3280-f3e1-42ea-93e1-dbab7336fb73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d3280-f3e1-42ea-93e1-dbab7336fb73.jpg?1",
             "name": "Crystal Golem",
             "text": "At end of your turn, Crystal Golem phases out.",
             "colours": [],
@@ -9752,7 +9752,7 @@
         },
         {
             "id": "f625e4cd-6da9-5c29-8698-d0c8f75bbcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc99ee76-45b6-4f1d-b0b0-7da8775ca90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc99ee76-45b6-4f1d-b0b0-7da8775ca90c.jpg?1",
             "name": "Cursed Totem",
             "text": "Players cannot play any creature abilities requiring an activation cost.",
             "colours": [],
@@ -9779,7 +9779,7 @@
         },
         {
             "id": "7b3a0a44-c808-55e4-9798-e17dfc5eed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60450239-6055-4561-9f8c-565b4e4d9cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60450239-6055-4561-9f8c-565b4e4d9cb1.jpg?1",
             "name": "Elixir of Vitality",
             "text": "Elixir of Vitality comes into play tapped.\noc\nT, Sacrifice Elixir of Vitality: Gain 4 life.\no8, oc\nT, Sacrifice Elixir of Vitality: Gain 8 life.",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "8feeab09-671d-5795-aa97-14594b93976c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2747ab-00c8-4f59-b9a6-54ff4e99f6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2747ab-00c8-4f59-b9a6-54ff4e99f6c8.jpg?1",
             "name": "Ersatz Gnomes",
             "text": "oc\nT: Target spell is colorless. Play this ability as an interrupt.\noc\nT: Target permanent is colorless until end of turn.",
             "colours": [],
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "cea77127-6950-55ad-a97c-461764a29efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcca5bbe-df01-45ea-a6ac-4e3d1cf237c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcca5bbe-df01-45ea-a6ac-4e3d1cf237c8.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond comes into play tapped.\noc\nT: Add o\nR to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9865,7 +9865,7 @@
         },
         {
             "id": "577b32b0-9bd6-5e14-8ee2-4be20893ebf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558ddf-2bc6-4870-bd24-2467d870ffe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558ddf-2bc6-4870-bd24-2467d870ffe5.jpg?1",
             "name": "Grinning Totem",
             "text": "o2, oc\nT, Sacrifice Grinning Totem: Search target opponent's library for any card and put it face up in front of you. That player shuffles his or her library afterwards. You may play the card as though it were in your hand. If you do not play the card by the beginning of your next upkeep, put it into its owner's graveyard.",
             "colours": [],
@@ -9892,7 +9892,7 @@
         },
         {
             "id": "515d70a0-0e76-52a3-af98-fc924cc77da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf04f2cd-d9f8-4e0c-adaf-6d38bc14dd7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf04f2cd-d9f8-4e0c-adaf-6d38bc14dd7a.jpg?1",
             "name": "Horrible Hordes",
             "text": "Rampage 1 (For each creature assigned to block it beyond the first, this creature gets +1/+1 until end of turn.)",
             "colours": [],
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "a5f66604-a257-5473-8bf0-0f1007a1c859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44c5e24-98f9-4a4d-9ecc-c862363eb66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44c5e24-98f9-4a4d-9ecc-c862363eb66d.jpg?1",
             "name": "Igneous Golem",
             "text": "o2: Trample until end of turn",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "484ba4cc-1291-52c3-a396-54c415a13360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9afb9e-eab3-4969-9a44-2c01bf730e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9afb9e-eab3-4969-9a44-2c01bf730e68.jpg?1",
             "name": "Lead Golem",
             "text": "If Lead Golem attacks, it does not untap during your next untap phase.",
             "colours": [],
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "f251d62d-d267-5985-ad48-3c2f582988d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bacc32-d6ba-420c-9b49-299c08e5fb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bacc32-d6ba-420c-9b49-299c08e5fb39.jpg?1",
             "name": "Lion's Eye Diamond",
             "text": "Sacrifice Lion's Eye Diamond, Discard your hand: Add three mana of any one color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10009,7 +10009,7 @@
         },
         {
             "id": "8bec994e-ae78-5225-ae3e-d14f024b57d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81137c17-18b8-484e-8334-28f143c08177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81137c17-18b8-484e-8334-28f143c08177.jpg?1",
             "name": "Mana Prism",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source. o1, oc\nT: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10036,7 +10036,7 @@
         },
         {
             "id": "0175cfa2-29a3-52d9-8fc5-aff161dd90b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557ebacf-4a8f-4548-a142-533b7adfdac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557ebacf-4a8f-4548-a142-533b7adfdac3.jpg?1",
             "name": "Mangara's Tome",
             "text": "When Mangara's Tome comes into play, search your library and choose any five cards. Shuffle these cards and put them face down under Mangara's Tome. Shuffle your library afterwards.\nIf you lose control of Mangara's Tome, remove all cards under it from the game.\no2: Instead of drawing a card, put the top card from under Mangara's Tome into your hand.",
             "colours": [],
@@ -10063,7 +10063,7 @@
         },
         {
             "id": "473c323b-4de3-5ea0-b571-e8cde4513b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4731eb16-3088-4d4d-80a4-7e39d00c1a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4731eb16-3088-4d4d-80a4-7e39d00c1a87.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond comes into play tapped.\noc\nT: Add o\nW to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10092,7 +10092,7 @@
         },
         {
             "id": "fb6c6e85-1efb-5090-9b84-5e79a5ac4fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c00691-26b1-4e7a-bdf5-4b15f0eb45ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c00691-26b1-4e7a-bdf5-4b15f0eb45ce.jpg?1",
             "name": "Misers' Cage",
             "text": "At end of target opponent's upkeep, if that player has five or more cards in hand, Misers' Cage deals 2 damage to him or her.",
             "colours": [],
@@ -10119,7 +10119,7 @@
         },
         {
             "id": "2734c45a-65c2-5323-a82f-9ca593bb41c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cea56a-b64f-452a-8e4b-40363aabb452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cea56a-b64f-452a-8e4b-40363aabb452.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond comes into play tapped.\noc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10148,7 +10148,7 @@
         },
         {
             "id": "2d0af40c-4146-595f-a148-fdcb9e3c7feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920b7a-fd56-4fa8-96c9-fb66c2af6fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920b7a-fd56-4fa8-96c9-fb66c2af6fbf.jpg?1",
             "name": "Patagia Golem",
             "text": "o3: Flying until end of turn",
             "colours": [],
@@ -10178,7 +10178,7 @@
         },
         {
             "id": "f1c8a62f-8e44-52bf-b3b3-e3905dccafd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411c350-a940-4172-b558-f5dc44b4fb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411c350-a940-4172-b558-f5dc44b4fb33.jpg?1",
             "name": "Paupers' Cage",
             "text": "At end of target opponent's upkeep, if that player has two or fewer cards in hand, Paupers' Cage deals 2 damage to him or her.",
             "colours": [],
@@ -10205,7 +10205,7 @@
         },
         {
             "id": "7a486d99-c6e3-5e76-9463-4dc28ca9e0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8197b9-0cd1-4fa1-9668-d1b5f1759151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8197b9-0cd1-4fa1-9668-d1b5f1759151.jpg?1",
             "name": "Phyrexian Dreadnought",
             "text": "Trample\nWhen Phyrexian Dreadnought comes into play, sacrifice any number of creatures with total power of 12 or more, or bury Phyrexian Dreadnought.",
             "colours": [],
@@ -10236,7 +10236,7 @@
         },
         {
             "id": "62de14f9-dbf2-5fde-a482-e80734274d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966a4e7-bf0f-4880-a4ba-8641fb7e4519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966a4e7-bf0f-4880-a4ba-8641fb7e4519.jpg?1",
             "name": "Phyrexian Vault",
             "text": "o2, oc\nT, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -10263,7 +10263,7 @@
         },
         {
             "id": "b36edac5-ce2c-5466-b444-def51ecba05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72562860-6097-4c63-9858-ae130805f4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72562860-6097-4c63-9858-ae130805f4d6.jpg?1",
             "name": "Razor Pendulum",
             "text": "At the end of each player's turn, if that player has 5 or less life, Razor Pendulum deals 2 damage to him or her.",
             "colours": [],
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "d8518a67-189b-5cc9-b6f5-cc99579a3f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a955-ce9a-4386-b6ac-c00fd25de882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a955-ce9a-4386-b6ac-c00fd25de882.jpg?1",
             "name": "Sand Golem",
             "text": "If a spell or effect controlled by an opponent causes you to discard Sand Golem, put Sand Golem from your graveyard into play at end of turn with a +1/+1 counter on it.",
             "colours": [],
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "d96ce806-04e8-50fd-b009-865bbc6acd60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959aef9-77bb-45a3-939e-324bd59aec89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959aef9-77bb-45a3-939e-324bd59aec89.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond comes into play tapped.\noc\nT: Add o\nU to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10349,7 +10349,7 @@
         },
         {
             "id": "b0300715-0221-58a1-95c0-c5178db6e758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e8971d-baeb-4e4f-8c4d-0e8109e4505e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e8971d-baeb-4e4f-8c4d-0e8109e4505e.jpg?1",
             "name": "Teeka's Dragon",
             "text": "Flying, trample; rampage 4 (For each creature assigned to block it beyond the first, this creature gets +4/+4 until end of turn.)\nTeeka's Dragon counts as a Dragon.",
             "colours": [],
@@ -10379,7 +10379,7 @@
         },
         {
             "id": "c0a06c3d-b5d4-5a9d-9799-408a09c57671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59733b76-3b44-4543-8bb2-a160232cee27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59733b76-3b44-4543-8bb2-a160232cee27.jpg?1",
             "name": "Telim'Tor's Darts",
             "text": "o2, oc\nT: Telim'Tor's Darts deals 1 damage to target player.",
             "colours": [],
@@ -10406,7 +10406,7 @@
         },
         {
             "id": "6faa10af-e9b8-586e-976d-bd983b04fbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf946b8-8574-406a-83fd-966ed912921f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf946b8-8574-406a-83fd-966ed912921f.jpg?1",
             "name": "Unerring Sling",
             "text": "o3, oc\nT, Tap an untapped creature you control: Unerring Sling deals an amount of damage equal to that creature's power to target attacking or blocking creature with flying.",
             "colours": [],
@@ -10433,7 +10433,7 @@
         },
         {
             "id": "d81d3a17-9fd7-5bac-92c7-c1469772e169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520f4a24-fb1a-4964-887c-2f08a752fae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520f4a24-fb1a-4964-887c-2f08a752fae2.jpg?1",
             "name": "Ventifact Bottle",
             "text": "o1o\nX, oc\nT: Put X charge counters on Ventifact Bottle. Play this ability as a sorcery.\nAt the beginning of your main phase, if Ventifact Bottle has any charge counters on it, tap Ventifact Bottle and remove all charge counters from it to add to your mana pool an amount of colorless mana equal to the number of charge counters removed.",
             "colours": [],
@@ -10460,7 +10460,7 @@
         },
         {
             "id": "f6dce6fa-fc9e-5023-981b-c6b09427f714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a78abdb-d1ac-49cb-a74b-9de21c06364a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a78abdb-d1ac-49cb-a74b-9de21c06364a.jpg?1",
             "name": "Bad River",
             "text": "Bad River comes into play tapped.\noc\nT, Sacrifice Bad River: Search your library for an island or swamp card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "22695aad-3a70-5369-b9ab-7cae6065e737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afb6e29-058e-44c5-a3fa-56c462f070a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afb6e29-058e-44c5-a3fa-56c462f070a0.jpg?1",
             "name": "Crystal Vein",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Crystal Vein: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -10514,7 +10514,7 @@
         },
         {
             "id": "fc5f2ee5-3f49-5f64-93a8-ee2b1ecb75d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7610f3-f182-404e-80b9-ccd94e174db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7610f3-f182-404e-80b9-ccd94e174db0.jpg?1",
             "name": "Flood Plain",
             "text": "Flood Plain comes into play tapped.\noc\nT, Sacrifice Flood Plain: Search your library for a plains or island card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "488d36d1-f662-5359-bee9-41a44a87c0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5efac-ef98-4be2-abcc-1aa38bf66b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5efac-ef98-4be2-abcc-1aa38bf66b06.jpg?1",
             "name": "Grasslands",
             "text": "Grasslands comes into play tapped.\noc\nT, Sacrifice Grasslands: Search your library for a forest or plains card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "c0875b00-793e-58cc-abbe-73d1e66146d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4e5c2-4f03-47c1-9843-b98c239ccfea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4e5c2-4f03-47c1-9843-b98c239ccfea.jpg?1",
             "name": "Mountain Valley",
             "text": "Mountain Valley comes into play tapped.\noc\nT, Sacrifice Mountain Valley: Search your library for a mountain or forest card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10595,7 +10595,7 @@
         },
         {
             "id": "af680651-f514-59f3-bdc9-3f844fdb6c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e21c347-7aaf-42ae-abf3-f1283c5b54e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e21c347-7aaf-42ae-abf3-f1283c5b54e6.jpg?1",
             "name": "Rocky Tar Pit",
             "text": "Rocky Tar Pit comes into play tapped.\noc\nT, Sacrifice Rocky Tar Pit: Search your library for a swamp or mountain card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10622,7 +10622,7 @@
         },
         {
             "id": "48cf8376-94b5-5121-a255-976cec395e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed7ca8-fd91-46e3-9149-a3de23c7078e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed7ca8-fd91-46e3-9149-a3de23c7078e.jpg?1",
             "name": "Teferi's Isle",
             "text": "Phasing\nTeferi's Isle comes into play tapped.\noc\nT: Add o\nUo\nU to your mana pool.",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "095122c1-18f2-5258-b265-70eb3f1401b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f32ad-3bdd-4c46-b3f0-522ac9763591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f32ad-3bdd-4c46-b3f0-522ac9763591.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10690,7 +10690,7 @@
         },
         {
             "id": "0fe3ba7a-4cee-5094-931b-daf0c4d658cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b078ef66-a83b-4e12-bcba-838bc3809322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b078ef66-a83b-4e12-bcba-838bc3809322.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10727,7 +10727,7 @@
         },
         {
             "id": "b26ce97a-5a95-5c76-9d29-0e77fd6978df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15978d-41e6-4eaa-9456-0de3b912d437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15978d-41e6-4eaa-9456-0de3b912d437.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10764,7 +10764,7 @@
         },
         {
             "id": "796ea6a2-a2b0-5fbe-8b5f-927abde3497a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bbbf38-5d1a-4013-aff9-6167709897f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bbbf38-5d1a-4013-aff9-6167709897f0.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "e6ad28a9-8091-5ed4-9b0b-5b6551ee2afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df84bf1b-8698-4c3e-baa9-926f0efc6a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df84bf1b-8698-4c3e-baa9-926f0efc6a12.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "2b0a6b66-ca9e-5331-8df3-4a6bcb0801ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776912e7-fa16-4d71-b830-0a5d35f38297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776912e7-fa16-4d71-b830-0a5d35f38297.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10875,7 +10875,7 @@
         },
         {
             "id": "8b311f21-b14c-5dd6-b7f3-6f8184c449c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e571f07-167f-4a7d-8f98-0c98d7d15e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e571f07-167f-4a7d-8f98-0c98d7d15e81.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10912,7 +10912,7 @@
         },
         {
             "id": "05788e22-a768-5f5c-af18-c5836abc79ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39fc1e0-caf0-4cfa-bbf2-fea7ca32c00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39fc1e0-caf0-4cfa-bbf2-fea7ca32c00d.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10949,7 +10949,7 @@
         },
         {
             "id": "a8f19ee5-ee06-5a1a-8ef4-38b6d40bcfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28477-8be1-4caf-8185-64f47905ccb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28477-8be1-4caf-8185-64f47905ccb1.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "0fe7d94e-dedf-5e29-bb63-5780065aead9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4be2d6-d168-4e67-8d75-a04f637b56dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4be2d6-d168-4e67-8d75-a04f637b56dd.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "ce3d8396-397c-56c1-b337-00ae99478e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65181db5-3fc5-497b-ba61-385efdf740ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65181db5-3fc5-497b-ba61-385efdf740ed.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11060,7 +11060,7 @@
         },
         {
             "id": "72772625-a921-547e-a23b-85f1075bfef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5083de34-d127-45df-9252-ff09b5cf8b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5083de34-d127-45df-9252-ff09b5cf8b47.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11097,7 +11097,7 @@
         },
         {
             "id": "bbde108f-db73-564a-b802-eea50334cc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004cdc-0baf-415d-8e87-7f36667c4628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004cdc-0baf-415d-8e87-7f36667c4628.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11134,7 +11134,7 @@
         },
         {
             "id": "a9338e82-b840-5236-b38a-76b22e3315a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207a468f-79c3-486e-ac5a-4516361b7b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207a468f-79c3-486e-ac5a-4516361b7b4d.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "0ecf027e-0132-5685-9fd1-30543ac2fa92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681b9c8a-6140-4086-bc72-37f0058a8e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681b9c8a-6140-4086-bc72-37f0058a8e9f.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11208,7 +11208,7 @@
         },
         {
             "id": "0f202bf8-d277-53c6-a916-e732e91dde3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cef9230-34fa-496f-8835-5dfaac627f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cef9230-34fa-496f-8835-5dfaac627f70.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11245,7 +11245,7 @@
         },
         {
             "id": "dc947b92-322e-5277-90a6-43543763989d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae7a81-9a61-4112-af22-369c525b2eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae7a81-9a61-4112-af22-369c525b2eb1.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11282,7 +11282,7 @@
         },
         {
             "id": "762a918f-23b5-5e43-9b0e-bf2928b34bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b3f80-20bf-4693-b106-cfb31a3d7f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b3f80-20bf-4693-b106-cfb31a3d7f83.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11319,7 +11319,7 @@
         },
         {
             "id": "2174580e-abe4-54da-b611-9c7231976255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a67bf6-818b-4afe-af15-3d955dc5e884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a67bf6-818b-4afe-af15-3d955dc5e884.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11356,7 +11356,7 @@
         },
         {
             "id": "42320053-e36e-5123-86e0-a223e8ff1027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dfef30-acca-4b15-a05e-d33289055218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dfef30-acca-4b15-a05e-d33289055218.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/MKM.json
+++ b/Assets/Resources/Sets/MKM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "81495a8a-9228-5d55-816f-c1d6e4c4978c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a70f0ae-d49b-4cc8-9f76-895039c3dc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a70f0ae-d49b-4cc8-9f76-895039c3dc39.jpg?1",
             "name": "Case of the Shattered Pact",
             "text": "When this Case enters the battlefield, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nTo solve \u2014 There are five colors among permanents you control. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 At the beginning of combat on your turn, target creature you control gains flying, double strike, and vigilance until end of turn.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "6a6ef4b7-48cb-5bbf-829a-71bed2d33201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6e71a1-713e-4eca-bd65-9f0638c16794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6e71a1-713e-4eca-bd65-9f0638c16794.jpg?1",
             "name": "Absolving Lammasu",
             "text": "Flying\nWhen Absolving Lammasu enters the battlefield, all suspected creatures are no longer suspected.\nWhen Absolving Lammasu dies, you gain 3 life and suspect up to one target creature an opponent controls. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "796cc9f8-6c1b-5aab-8595-f76ca47d5c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg?1",
             "name": "Assemble the Players",
             "text": "You may look at the top card of your library any time.\nOnce each turn, you may cast a creature spell with power 2 or less from the top of your library.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "a8a47dc9-6b25-58cc-9346-f655a37b463d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg?1",
             "name": "Aurelia's Vindicator",
             "text": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "014eac08-1133-53c4-a8bf-b8b6308cfab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5180c85c-6add-4066-83c4-27fb1fd4de16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5180c85c-6add-4066-83c4-27fb1fd4de16.jpg?1",
             "name": "Auspicious Arrival",
             "text": "Target creature gets +2/+2 until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "b2c3c176-704f-5835-ad42-19441c284040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5148def-cf1a-460e-8dfd-856103940892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5148def-cf1a-460e-8dfd-856103940892.jpg?1",
             "name": "Call a Surprise Witness",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Put a flying counter on it. It's a Spirit in addition to its other types.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "b050a894-4431-5285-8d16-ed530ba87000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a52038-9d1c-4be1-8dbe-6f0ee916ba94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a52038-9d1c-4be1-8dbe-6f0ee916ba94.jpg?1",
             "name": "Case File Auditor",
             "text": "When Case File Auditor enters the battlefield and whenever you solve a Case, look at the top six cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nYou may spend mana as though it were mana of any color to cast Case spells.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "f9f02dd6-c004-5c46-916e-93746ed52de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2278d7-215e-49f9-ae2b-9df099c67b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2278d7-215e-49f9-ae2b-9df099c67b6d.jpg?1",
             "name": "Case File Auditor",
             "text": "",
             "colours": [
@@ -281,7 +281,7 @@
         },
         {
             "id": "b760b99d-88af-50da-8794-17951af4f638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0862bf07-8a76-4e80-bba2-20d22f8eee30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0862bf07-8a76-4e80-bba2-20d22f8eee30.jpg?1",
             "name": "Case of the Gateway Express",
             "text": "When this Case enters the battlefield, choose target creature you don't control. Each creature you control deals 1 damage to that creature.\nTo solve \u2014 Three or more creatures attacked this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Creatures you control get +1/+0.",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "3a4f2981-77ea-5b59-a990-31a9bdbc08a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32927bf2-63c1-4402-99dc-3a0f2f8e0f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32927bf2-63c1-4402-99dc-3a0f2f8e0f9c.jpg?1",
             "name": "Case of the Pilfered Proof",
             "text": "Whenever a Detective enters the battlefield under your control and whenever a Detective you control is turned face up, put a +1/+1 counter on it.\nTo solve \u2014 You control three or more Detectives. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 If one or more tokens would be created under your control, those tokens plus a Clue token are created instead. (It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "3c892f85-0f5e-50a8-8684-82585cd44d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63941b-3f78-4bd3-8b05-ca12aaaa006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63941b-3f78-4bd3-8b05-ca12aaaa006c.jpg?1",
             "name": "Case of the Uneaten Feast",
             "text": "Whenever a creature enters the battlefield under your control, you gain 1 life.\nTo solve \u2014 You've gained 5 or more life this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Sacrifice this Case: Creature cards in your graveyard gain \"You may cast this card from your graveyard\" until end of turn.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "7e7be949-6fb5-5a04-890b-f69b9f8aeaa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b284304-c3bf-4413-9fd3-b44eb4eb642a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b284304-c3bf-4413-9fd3-b44eb4eb642a.jpg?1",
             "name": "Defenestrated Phantom",
             "text": "Flying\nDisguise {4}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "d6f664ef-967c-5083-993d-ba7426808d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be219928-3d0e-4d00-b124-152ce8a8c13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be219928-3d0e-4d00-b124-152ce8a8c13b.jpg?1",
             "name": "Delney, Streetwise Lookout",
             "text": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
             "colours": [
@@ -457,7 +457,7 @@
         },
         {
             "id": "320ad70d-2ecc-5108-9740-f0aea1cb8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a1cd28-d2a5-4d1a-aa03-a6a5958ae432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a1cd28-d2a5-4d1a-aa03-a6a5958ae432.jpg?1",
             "name": "Doorkeeper Thrull",
             "text": "Flash\nFlying\nArtifacts and creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "c496e009-821b-554e-8f2d-635e57552c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076d9f76-a247-4727-9e0f-a0289c51059e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076d9f76-a247-4727-9e0f-a0289c51059e.jpg?1",
             "name": "Due Diligence",
             "text": "Enchant creature\nWhen Due Diligence enters the battlefield, target creature you control other than enchanted creature gets +2/+2 and gains vigilance until end of turn.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "ab329b2d-9671-5af9-ab2a-af64623404ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee2945d-bf6d-4328-a482-df24c2973b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee2945d-bf6d-4328-a482-df24c2973b56.jpg?1",
             "name": "Essence of Antiquity",
             "text": "Disguise {2}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Essence of Antiquity is turned face up, creatures you control gain hexproof until end of turn. Untap them.",
             "colours": [
@@ -562,7 +562,7 @@
         },
         {
             "id": "a5db9915-2b20-5623-8855-7888117ee600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06a243d-acc8-42cd-926c-98a4cc96ab21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06a243d-acc8-42cd-926c-98a4cc96ab21.jpg?1",
             "name": "Forum Familiar",
             "text": "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Forum Familiar is turned face up, return another target permanent you control to its owner's hand and put a +1/+1 counter on Forum Familiar.",
             "colours": [
@@ -596,7 +596,7 @@
         },
         {
             "id": "9aa2f238-9fc4-5cfe-9e17-b0f2ad56afd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f5d048-226f-49a4-a2ce-a6fa99aa9e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f5d048-226f-49a4-a2ce-a6fa99aa9e8a.jpg?1",
             "name": "Griffnaut Tracker",
             "text": "Flying\nWhen Griffnaut Tracker enters the battlefield, exile up to two target cards from a single graveyard.",
             "colours": [
@@ -631,7 +631,7 @@
         },
         {
             "id": "8247a633-efa4-56b3-967c-16ac18bc0783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277fe72-dc33-4d19-a439-63b5344c6034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277fe72-dc33-4d19-a439-63b5344c6034.jpg?1",
             "name": "Haazda Vigilante",
             "text": "Whenever Haazda Vigilante enters the battlefield or attacks, put a +1/+1 counter on target creature you control with power 2 or less.",
             "colours": [
@@ -666,7 +666,7 @@
         },
         {
             "id": "1f510559-fe57-5845-bdac-9dc342f6f6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1548d181-3f83-457a-b2d3-eb88cfb2afda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1548d181-3f83-457a-b2d3-eb88cfb2afda.jpg?1",
             "name": "Inside Source",
             "text": "When Inside Source enters the battlefield, create a 2/2 white and blue Detective creature token.\n{3}, {T}: Target Detective you control gets +2/+0 and gains vigilance until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -701,7 +701,7 @@
         },
         {
             "id": "21b42fe6-c247-5280-8214-1e33a07bc546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cfb366-ae2a-4b3d-9a80-383a32db1509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cfb366-ae2a-4b3d-9a80-383a32db1509.jpg?1",
             "name": "Karlov Watchdog",
             "text": "Vigilance\nPermanents your opponents control can't be turned face up during your turn.\nWhenever you attack with three or more creatures, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -735,7 +735,7 @@
         },
         {
             "id": "49981f47-9db0-5279-9d33-809c2a903033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f663cd86-39e6-467b-85b7-dd27536251a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f663cd86-39e6-467b-85b7-dd27536251a6.jpg?1",
             "name": "Krovod Haunch",
             "text": "Equipped creature gets +2/+0.\n{2}, {T}, Sacrifice Krovod Haunch: You gain 3 life.\nWhen Krovod Haunch is put into a graveyard from the battlefield, you may pay {1}{W}. If you do, create two 1/1 white Dog creature tokens.\nEquip {2}",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "d4d7fc15-1602-508b-87a1-e9a867712b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73475d29-2673-4614-86d3-404232426aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73475d29-2673-4614-86d3-404232426aa8.jpg?1",
             "name": "Make Your Move",
             "text": "Destroy target artifact, enchantment, or creature with power 4 or greater.",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "4f770fac-6ca2-508e-bff2-e6e29be07cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45d2e0c-d70d-40e5-8c3d-db6803393516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45d2e0c-d70d-40e5-8c3d-db6803393516.jpg?1",
             "name": "Makeshift Binding",
             "text": "When Makeshift Binding enters the battlefield, exile target creature an opponent controls until Makeshift Binding leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "d34e79f3-0595-540c-8ed1-ee32d72a431d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf6a392-3fc4-45d1-b85d-3b1381b3ab7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf6a392-3fc4-45d1-b85d-3b1381b3ab7d.jpg?1",
             "name": "Marketwatch Phantom",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, Marketwatch Phantom gains flying until end of turn.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "334ed088-b831-5940-922d-ce6b08310678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37860682-4973-4a0f-a43a-3056037bd2dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37860682-4973-4a0f-a43a-3056037bd2dc.jpg?1",
             "name": "Museum Nightwatch",
             "text": "When Museum Nightwatch dies, create a 2/2 white and blue Detective creature token.\nDisguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -906,7 +906,7 @@
         },
         {
             "id": "7b7b72d7-e625-5bed-8348-c22974c9a94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0438d482-b74c-4d5e-a2bc-7063c1ae73fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0438d482-b74c-4d5e-a2bc-7063c1ae73fa.jpg?1",
             "name": "Neighborhood Guardian",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -942,7 +942,7 @@
         },
         {
             "id": "2e57188e-f3ee-55b4-ae23-bb60ddbf4ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg?1",
             "name": "No Witnesses",
             "text": "Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "6a07841c-45cd-5eb9-87c4-9037e85d8f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700294fc-7c16-4f7d-bce0-7452d8e9c401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700294fc-7c16-4f7d-bce0-7452d8e9c401.jpg?1",
             "name": "Not on My Watch",
             "text": "Exile target attacking creature.",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "680c33fb-90c6-54b2-a796-2e4c2964c9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad38866-fc5f-4f62-89c1-afc0f50765aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad38866-fc5f-4f62-89c1-afc0f50765aa.jpg?1",
             "name": "Novice Inspector",
             "text": "When Novice Inspector enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "d5e6343d-c4eb-5ea5-b62c-6568cfc63cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b92629-4196-4943-91fd-8c8d5f3fcaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b92629-4196-4943-91fd-8c8d5f3fcaef.jpg?1",
             "name": "On the Job",
             "text": "Creatures you control get +2/+1 until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "f559ade9-0849-5d9d-9c9a-f61dd3b6c380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88d077-5082-4a67-91e4-97aafb9a5e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88d077-5082-4a67-91e4-97aafb9a5e91.jpg?1",
             "name": "Perimeter Enforcer",
             "text": "Flying, lifelink\nWhenever another Detective enters the battlefield under your control and whenever a Detective you control is turned face up, Perimeter Enforcer gets +1/+1 until end of turn.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "2fe03732-9171-5dba-bea0-94d070fcd066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a009ba2-c7b9-4cf6-bb90-9d6fd589e932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a009ba2-c7b9-4cf6-bb90-9d6fd589e932.jpg?1",
             "name": "Sanctuary Wall",
             "text": "Defender\n{2}{W}, {T}: Tap target creature. You may put a stun counter on it. If you do, put a stun counter on Sanctuary Wall. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "49ae4680-8e41-5ed4-9389-3c9853652eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ebfe5d-8819-495d-bf72-b9c28c6fd23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ebfe5d-8819-495d-bf72-b9c28c6fd23e.jpg?1",
             "name": "Seasoned Consultant",
             "text": "Whenever you attack with three or more creatures, Seasoned Consultant gets +2/+0 until end of turn.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "a444a816-47ee-5623-986a-31de6d7e7358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c65a79e-f28a-4f30-95a4-1ea55fd84564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c65a79e-f28a-4f30-95a4-1ea55fd84564.jpg?1",
             "name": "Tenth District Hero",
             "text": "{1}{W}, Collect evidence 2: Tenth District Hero becomes a Human Detective with base power and toughness 4/4 and gains vigilance.\n{2}{W}, Collect evidence 4: If Tenth District Hero is a Detective, it becomes a legendary creature named Mileva, the Stalwart, it has base power and toughness 5/5, and it gains \"Other creatures you control have indestructible.\"",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "36090590-c863-5e82-89c2-62fe288f2266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg?1",
             "name": "Unyielding Gatekeeper",
             "text": "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Unyielding Gatekeeper is turned face up, exile another target nonland permanent. If you controlled it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue Detective creature token.",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "f3398b7a-62d1-564d-ae28-8e57404ec860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg?1",
             "name": "Wojek Investigator",
             "text": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "3a45d036-c2cb-5a95-94e6-8a68573760e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bb0b1-c374-4af7-b018-fa7efaf14b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bb0b1-c374-4af7-b018-fa7efaf14b25.jpg?1",
             "name": "Wojek Investigator",
             "text": "",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "164e9959-037b-585b-b633-b8bf22aba992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cc39b-8f3b-4297-b118-86fa624308b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cc39b-8f3b-4297-b118-86fa624308b4.jpg?1",
             "name": "Wrench",
             "text": "Equipped creature gets +1/+1 and has vigilance and \"{3}, {T}: Tap target creature.\"\n{2}, Sacrifice Wrench: Draw a card.\nEquip {2}",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "a2c331ea-107f-569c-bfea-40aaa4210b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8112f133-535e-4264-8357-9cbf97957710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8112f133-535e-4264-8357-9cbf97957710.jpg?1",
             "name": "Agency Outfitter",
             "text": "Flying\nWhen Agency Outfitter enters the battlefield, you may search your graveyard, hand and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "185f4b1b-50a4-5410-833b-2f22c8f4890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e522b043-fbd8-48a4-9f20-39e2a66a35ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e522b043-fbd8-48a4-9f20-39e2a66a35ec.jpg?1",
             "name": "Behind the Mask",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nUntil end of turn, target artifact or creature becomes an artifact creature with base power and toughness 4/3. If evidence was collected, it has base power and toughness 1/1 until end of turn instead.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "b9424422-4e63-58de-8461-e1286a97a9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b6b5a-acdf-4255-a294-0964d9c62686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b6b5a-acdf-4255-a294-0964d9c62686.jpg?1",
             "name": "Benthic Criminologists",
             "text": "Whenever Benthic Criminologists enters the battlefield or attacks, you may sacrifice an artifact. If you do, draw a card.",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "bf480f09-1a55-5428-8522-b17b5a1a0563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b863ee0-d9f3-4b1e-993d-5212731d9353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b863ee0-d9f3-4b1e-993d-5212731d9353.jpg?1",
             "name": "Bubble Smuggler",
             "text": "Disguise {5}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nAs Bubble Smuggler is turned face up, put four +1/+1 counters on it.",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "38639726-2da7-52f1-a624-952676bd8862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea29c34-4b55-4170-9120-0a8dda61f2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea29c34-4b55-4170-9120-0a8dda61f2eb.jpg?1",
             "name": "Burden of Proof",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+2 as long as it's a Detective you control. Otherwise, it has base power and toughness 1/1 and can't block Detectives.",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "1f49936c-0570-5bdb-94a7-db05f9048ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeae6fb-3834-4891-924e-3d1fb3e19e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeae6fb-3834-4891-924e-3d1fb3e19e09.jpg?1",
             "name": "Candlestick",
             "text": "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, surveil 2.\" (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n{2}, Sacrifice Candlestick: Draw a card.\nEquip {2}",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "c656fccb-f542-506d-80fa-becb3dd9f998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266be5bd-71ba-4511-8b71-d0b03885a28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266be5bd-71ba-4511-8b71-d0b03885a28d.jpg?1",
             "name": "Case of the Filched Falcon",
             "text": "When this Case enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nTo solve \u2014 You control three or more artifacts. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 {2}{U}, Sacrifice this Case: Put four +1/+1 counters on target noncreature artifact. It becomes a 0/0 Bird creature with flying in addition to its other types.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "f3849490-6130-5ae6-af7c-7e37c0aad588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9a596-61de-4fcf-aae0-41836c3deca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9a596-61de-4fcf-aae0-41836c3deca5.jpg?1",
             "name": "Case of the Ransacked Lab",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nTo solve \u2014 You've cast four or more instant and sorcery spells this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Whenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "029f1c1d-a7e0-55a6-ac90-09d48c0cc414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f082111b-9b1c-4a25-8c5d-d6ef77533a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f082111b-9b1c-4a25-8c5d-d6ef77533a9b.jpg?1",
             "name": "Cold Case Cracker",
             "text": "Flying\nWhen Cold Case Cracker dies, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "def94cd4-cdfe-5093-ac1b-7111960af362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e791fc-bf9f-49b6-b5f2-a24d4b3e360e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e791fc-bf9f-49b6-b5f2-a24d4b3e360e.jpg?1",
             "name": "Conspiracy Unraveler",
             "text": "Flying\nYou may collect evidence 10 rather than pay the mana cost for spells that you cast. (To collect evidence 10, exile cards with total mana value 10 or greater from your graveyard.)",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "98b4033d-f1a5-59a2-ade1-c3e611106bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg?1",
             "name": "Coveted Falcon",
             "text": "Flying\nWhenever Coveted Falcon attacks, gain control of target permanent you own but don't control.\nDisguise {1}{U}\nWhen Coveted Falcon is turned face up, target opponent gains control of any number of target permanents you control. Draw a card for each one they gained control of this way.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "e7cb61e7-9bb0-5014-8473-8d38a680b578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4ac597-38f0-48b5-ac2d-dfb0b169f834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4ac597-38f0-48b5-ac2d-dfb0b169f834.jpg?1",
             "name": "Crimestopper Sprite",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nFlying\nWhen Crimestopper Sprite enters the battlefield, tap target creature. If evidence was collected, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "b6725d59-1cce-5d82-accf-a460ed1d205f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg?1",
             "name": "Cryptic Coat",
             "text": "When Cryptic Coat enters the battlefield, cloak the top card of your library, then attach Cryptic Coat to it. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature gets +1/+0 and can't be blocked.\n{1}{U}: Return Cryptic Coat to its owner's hand.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "4e188324-625e-597a-a48f-9d1a4b140306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3603c6-92df-45c7-b402-1f0a552ea398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3603c6-92df-45c7-b402-1f0a552ea398.jpg?1",
             "name": "Curious Inquiry",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, investigate.\" (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "7c43b9c6-bd52-570a-9373-13df10b37f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbb17af-e17e-438a-ad72-0c942e6706b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbb17af-e17e-438a-ad72-0c942e6706b6.jpg?1",
             "name": "Deduce",
             "text": "Draw a card. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "7a8957af-6a29-5e19-aa45-eef3feaaa90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca93438-a132-45ca-9fa8-364aeb519594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca93438-a132-45ca-9fa8-364aeb519594.jpg?1",
             "name": "Dramatic Accusation",
             "text": "Enchant creature\nWhen Dramatic Accusation enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{U}{U}: Shuffle enchanted creature into its owner's library.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "a72a4491-68bc-5cd8-b65e-c91c1c79270c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486f1cc2-c162-448e-91a9-577d7d796584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486f1cc2-c162-448e-91a9-577d7d796584.jpg?1",
             "name": "Eliminate the Impossible",
             "text": "Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "81536096-df4d-5fa0-9193-a3f7d1e87b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f142d-9fb1-4673-b804-add1f08dacb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f142d-9fb1-4673-b804-add1f08dacb9.jpg?1",
             "name": "Exit Specialist",
             "text": "Exit Specialist can't be blocked by creatures with power 3 or greater.\nDisguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Exit Specialist is turned face up, return another target creature to its owner's hand.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "3941c7a1-e31f-5c41-b02b-07e127feb732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9caa4eb-ed8c-4d05-8029-2a42163938a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9caa4eb-ed8c-4d05-8029-2a42163938a7.jpg?1",
             "name": "Fae Flight",
             "text": "Flash\nEnchant creature\nWhen Fae Flight enters the battlefield, enchanted creature gains hexproof until end of turn.\nEnchanted creature gets +1/+0 and has flying.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "32868293-2972-5b33-8204-480a1eb72678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg?1",
             "name": "Forensic Gadgeteer",
             "text": "Whenever you cast an artifact spell, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "2fe33fb4-e16c-5fc6-9800-9de90d81c98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1384df5d-d705-49cb-a982-1588cbf303d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1384df5d-d705-49cb-a982-1588cbf303d8.jpg?1",
             "name": "Forensic Researcher",
             "text": "{T}: Untap another target permanent you control.\n{T}, Collect evidence 3: Tap target creature you don't control. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "3327377d-7f08-52d5-a0ce-fe4192b22a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f359fc2-b9e4-4a01-9d04-442bb160b01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f359fc2-b9e4-4a01-9d04-442bb160b01e.jpg?1",
             "name": "Furtive Courier",
             "text": "Furtive Courier can't be blocked as long as you've sacrificed an artifact this turn.\nWhenever Furtive Courier attacks, draw a card, then discard a card.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "929770da-ffcb-5e0b-b8b1-a8c0598a4418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3b23b-04d6-4ac0-b698-596ea90b7781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3b23b-04d6-4ac0-b698-596ea90b7781.jpg?1",
             "name": "Hotshot Investigators",
             "text": "When Hotshot Investigators enters the battlefield, return up to one other target creature to its owner's hand. If you controlled it, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "197bb141-a564-5778-9a4e-c3260550c365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg?1",
             "name": "Intrude on the Mind",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. Create a 0/0 colorless Thopter artifact creature token with flying, then put a +1/+1 counter on it for each card put into your graveyard this way.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "a19c15ed-3e93-5f3a-b7c4-316ff0ab7b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2807dcfb-d99c-483b-835f-2606eae4bd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2807dcfb-d99c-483b-835f-2606eae4bd30.jpg?1",
             "name": "Jaded Analyst",
             "text": "Defender\nWhenever you draw your second card each turn, Jaded Analyst loses defender and gains vigilance until end of turn.",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "49fc8f61-c9ce-57b5-8dc4-38c38c661bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb11c7-7b7f-4bdb-a022-53e28ebadecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb11c7-7b7f-4bdb-a022-53e28ebadecc.jpg?1",
             "name": "Living Conundrum",
             "text": "Hexproof\nIf you would draw a card while your library has no cards in it, skip that draw instead.\nAs long as there are no cards in your library, Living Conundrum has base power and toughness 10/10 and has flying and vigilance.",
             "colours": [
@@ -2278,7 +2278,7 @@
         },
         {
             "id": "21ec39a7-6739-5815-baf2-b853ba693e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6308dc62-d945-4761-aa4c-ef8e9271e901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6308dc62-d945-4761-aa4c-ef8e9271e901.jpg?1",
             "name": "Lost in the Maze",
             "text": "Flash\nWhen Lost in the Maze enters the battlefield, tap X target creatures. Put a stun counter on each of those creatures you don't control. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nTapped creatures you control have hexproof.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "197f82d1-c722-53ae-82ae-3616eba7ff94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8578839-046f-4afd-a0e7-4737ded9e6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8578839-046f-4afd-a0e7-4737ded9e6eb.jpg?1",
             "name": "Mistway Spy",
             "text": "Flying\nDisguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Mistway Spy is turned face up, until end of turn, whenever a creature you control deals combat damage to a player, investigate.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "33a632b0-fdb1-5635-ae31-95348fceece7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabfada0-3c1b-4237-b06c-573071ccd68d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabfada0-3c1b-4237-b06c-573071ccd68d.jpg?1",
             "name": "Out Cold",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nTap up to two target creatures and put a stun counter on each of them. Investigate. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "622a2c0f-9eb8-5684-9011-e26310697c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg?1",
             "name": "Proft's Eidetic Memory",
             "text": "When Proft's Eidetic Memory enters the battlefield, draw a card.\nYou have no maximum hand size.\nAt the beginning of combat on your turn, if you've drawn more than one card this turn, put X +1/+1 counters on target creature you control, where X is the number of cards you've drawn this turn minus one.",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "8f6e3e2e-270e-5c44-8b8d-1c1e5ae38592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad378843-e2b0-48d6-90dc-b584e857473d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad378843-e2b0-48d6-90dc-b584e857473d.jpg?1",
             "name": "Projektor Inspector",
             "text": "Whenever Projektor Inspector or another Detective enters the battlefield under your control and whenever a Detective you control is turned face up, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "8cffa0cf-9f3a-59ce-97d4-a374f6e7c4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270570a3-8637-4e4e-92d9-e985474cd5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270570a3-8637-4e4e-92d9-e985474cd5d2.jpg?1",
             "name": "Reasonable Doubt",
             "text": "Counter target spell unless its controller pays {2}.\nSuspect up to one target creature. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "7e9918e7-d4b4-5e46-bcbb-d12b2627c7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg?1",
             "name": "Reenact the Crime",
             "text": "Exile target nonland card in a graveyard that was put there from anywhere this turn. Copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "d968be74-8caa-592c-ad9a-65e43cf77238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg?1",
             "name": "Steamcore Scholar",
             "text": "Flying, vigilance\nWhen Steamcore Scholar enters the battlefield, draw two cards. Then discard two cards unless you discard an instant or sorcery card or a creature card with flying.",
             "colours": [
@@ -2553,7 +2553,7 @@
         },
         {
             "id": "b82ce6de-3170-561b-af45-3a4fdb01eb4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9e5fd6-a5ea-4ae5-83f5-89ed6a658dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9e5fd6-a5ea-4ae5-83f5-89ed6a658dd3.jpg?1",
             "name": "Sudden Setback",
             "text": "The owner of target spell or nonland permanent puts it on the top or bottom of their library.",
             "colours": [
@@ -2587,7 +2587,7 @@
         },
         {
             "id": "61ab5459-8a88-5f4a-86e1-4d1d5398feef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc6af2-f6b1-429d-b3ac-06a2c392d2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc6af2-f6b1-429d-b3ac-06a2c392d2b8.jpg?1",
             "name": "Sudden Setback",
             "text": "",
             "colours": [
@@ -2621,7 +2621,7 @@
         },
         {
             "id": "9ce2101a-1439-5f46-9cae-41269fb82a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b874d-6739-4063-9891-e9c040dd9618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b874d-6739-4063-9891-e9c040dd9618.jpg?1",
             "name": "Surveillance Monitor",
             "text": "When Surveillance Monitor enters the battlefield, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)\nWhenever you collect evidence, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "4aac12c9-5346-57b3-a562-c9f98fb69ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529568-c759-4ae0-b2e4-ab5a11d421a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529568-c759-4ae0-b2e4-ab5a11d421a4.jpg?1",
             "name": "Surveillance Monitor",
             "text": "",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "25ceb03a-7166-53ae-9a5f-6b1b687024bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a458474-d721-46d7-b487-6a47dc063cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a458474-d721-46d7-b487-6a47dc063cfd.jpg?1",
             "name": "Unauthorized Exit",
             "text": "Return target nonland permanent to its owner's hand. Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "710e8210-332f-54ae-8019-d8819ee4eea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63f2c23-e877-42e3-9362-5d003a173c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63f2c23-e877-42e3-9362-5d003a173c6d.jpg?1",
             "name": "Agency Coroner",
             "text": "{2}{B}, Sacrifice another creature: Draw a card. If the sacrificed creature was suspected, draw two cards instead.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "ffe4b210-e324-5e7d-89d8-807d202e58fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf238c9-61de-4f3a-b82f-05af46e5e81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf238c9-61de-4f3a-b82f-05af46e5e81b.jpg?1",
             "name": "Alley Assailant",
             "text": "Alley Assailant enters the battlefield tapped.\nDisguise {4}{B}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Alley Assailant is turned face up, target opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "16e1a122-0fff-5ced-80e8-03a1e83054b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg?1",
             "name": "Barbed Servitor",
             "text": "Indestructible\nWhen Barbed Servitor enters the battlefield, suspect it. (It has menace and can't block.)\nWhenever Barbed Servitor deals combat damage to a player, you draw a card and you lose 1 life.\nWhenever Barbed Servitor is dealt damage, target opponent loses that much life.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "1f547d04-18de-5e9a-b9cf-3fb99cb6a6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdafea8f-283d-4f19-a74a-669bfbdfed98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdafea8f-283d-4f19-a74a-669bfbdfed98.jpg?1",
             "name": "Basilica Stalker",
             "text": "Flying\nWhenever Basilica Stalker deals combat damage to a player, you gain 1 life and surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nDisguise {4}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "f2993b5f-022f-5d81-b72b-f382e114d3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e4c07a-3205-4193-8163-b0e63e6242a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e4c07a-3205-4193-8163-b0e63e6242a4.jpg?1",
             "name": "Case of the Gorgon's Kiss",
             "text": "When this Case enters the battlefield, destroy up to one target creature that was dealt damage this turn.\nTo solve \u2014 Three or more creature cards were put into graveyards from anywhere this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 This Case is a 4/4 Gorgon creature with deathtouch and lifelink in addition to its other types.",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "89077f37-dcc0-545e-82ac-b0c4e316ffec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ead0e-477b-4b3d-b6bf-b2598ddc6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ead0e-477b-4b3d-b6bf-b2598ddc6f04.jpg?1",
             "name": "Case of the Gorgon's Kiss",
             "text": "",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "541a82fa-3604-5ba7-a968-1994ab40096f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b120cbe-f0af-46c5-863f-03ecadf0435c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b120cbe-f0af-46c5-863f-03ecadf0435c.jpg?1",
             "name": "Case of the Stashed Skeleton",
             "text": "When this Case enters the battlefield, create a 2/1 black Skeleton creature token and suspect it. (It has menace and can't block.)\nTo solve \u2014 You control no suspected Skeletons. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 {1}{B}, Sacrifice this Case: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "d60d91ef-6ef7-564b-b3ab-19bf9c444fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3c3d15-b775-44a2-91ea-4abcc3cf2dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3c3d15-b775-44a2-91ea-4abcc3cf2dba.jpg?1",
             "name": "Cerebral Confiscation",
             "text": "Choose one \u2014\n\u2022 Target opponent discards two cards.\n\u2022 Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "52f1315d-572f-5c9a-8557-cff8bb64887b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e069de0-3218-456c-b191-93e755634783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e069de0-3218-456c-b191-93e755634783.jpg?1",
             "name": "Clandestine Meddler",
             "text": "When Clandestine Meddler enters the battlefield, suspect up to one other target creature you control. (A suspected creature has menace and can't block.)\nWhenever one or more suspected creatures you control attack, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "170bd191-1e06-551f-ace2-b2fbbb5755fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b13406-3b4e-4c61-b19a-c1faf31ed676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b13406-3b4e-4c61-b19a-c1faf31ed676.jpg?1",
             "name": "Clandestine Meddler",
             "text": "",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "0031ac0c-95db-5dc6-aac1-311ea9649bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg?1",
             "name": "Deadly Cover-Up",
             "text": "As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "9a7b535f-b126-56b5-aa2b-7d8a505a4834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256c8b6e-4031-458b-8eb9-bbfe58405a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256c8b6e-4031-458b-8eb9-bbfe58405a0c.jpg?1",
             "name": "Extract a Confession",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nEach opponent sacrifices a creature. If evidence was collected, instead each opponent sacrifices a creature with the greatest power among creatures they control.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "b1829455-ff54-50ca-9389-bebbe613d7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6fa37-8351-403b-ae05-b67e9bf74bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6fa37-8351-403b-ae05-b67e9bf74bbb.jpg?1",
             "name": "Festerleech",
             "text": "Whenever Festerleech deals combat damage to a player, you mill two cards.\n{1}{B}: Festerleech gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "8d6b5c36-8c95-5bcc-ac38-7875d8b14455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg?1",
             "name": "Homicide Investigator",
             "text": "Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3221,7 +3221,7 @@
         },
         {
             "id": "5f75aa30-7159-5f5c-92fc-c5671a0a99ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg?1",
             "name": "Hunted Bonebrute",
             "text": "Menace\nWhen Hunted Bonebrute enters the battlefield, target opponent creates two 1/1 white Dog creature tokens.\nWhen Hunted Bonebrute dies, each opponent loses 3 life.\nDisguise {1}{B}",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "8b39bad3-e7c1-5b68-94e7-3487397fe617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg?1",
             "name": "Illicit Masquerade",
             "text": "Flash\nWhen Illicit Masquerade enters the battlefield, put an impostor counter on each creature you control.\nWhenever a creature you control with an impostor counter on it dies, exile it. Return up to one other target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "122e9834-22f1-51de-bb38-30d28c112ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02dbc2-ad01-47fd-b39e-f0a695029f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02dbc2-ad01-47fd-b39e-f0a695029f26.jpg?1",
             "name": "It Doesn't Add Up",
             "text": "Return target creature card from your graveyard to the battlefield. Suspect it. (It has menace and can't block.)",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "a5ec3482-2296-5d21-b930-ae2124f31147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f69249-c6e4-40c1-9870-b9c45ce24c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f69249-c6e4-40c1-9870-b9c45ce24c39.jpg?1",
             "name": "Lead Pipe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, each opponent loses 1 life.\n{2}, Sacrifice Lead Pipe: Draw a card.\nEquip {2}",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "72944f0f-3029-5179-a160-b236a20d4bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc687588-9c57-411d-b666-b9699949d48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc687588-9c57-411d-b666-b9699949d48f.jpg?1",
             "name": "Leering Onlooker",
             "text": "Flying\n{2}{B}{B}, Exile Leering Onlooker from your graveyard: Create two tapped 1/1 black Bat creature tokens with flying.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "e09b3bfe-1e8e-5a46-b158-61bbd3abe896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3896705-bbd2-4ffb-a590-ee78e0eabdc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3896705-bbd2-4ffb-a590-ee78e0eabdc5.jpg?1",
             "name": "Long Goodbye",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nDestroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "e231de8b-2385-5d90-9870-74520e0509f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb6184c-e3d0-4275-b25b-95e4a64b26f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb6184c-e3d0-4275-b25b-95e4a64b26f3.jpg?1",
             "name": "Macabre Reconstruction",
             "text": "This spell costs {2} less to cast if a creature card was put into your graveyard from anywhere this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "7880ad48-a920-500b-9409-83a5498e21e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1c8800-9d33-485c-b776-042003b9ea92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1c8800-9d33-485c-b776-042003b9ea92.jpg?1",
             "name": "Massacre Girl, Known Killer",
             "text": "Menace\nCreatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls dies, if its toughness was less than 1, draw a card.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "c5a5633c-312e-5816-90a9-eb623aeababf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea6438b-0e6c-4d65-8bcd-34a988717c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea6438b-0e6c-4d65-8bcd-34a988717c81.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "6ee842c3-d31e-5a4e-a1b6-c8fee52ba42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce043cba-aea4-4156-b1d0-545eda06c400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce043cba-aea4-4156-b1d0-545eda06c400.jpg?1",
             "name": "Nightdrinker Moroii",
             "text": "Flying\nWhen Nightdrinker Moroii enters the battlefield, you lose 3 life.\nDisguise {B}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "0eb53275-5155-502b-81fc-e2ab0a839758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg?1",
             "name": "Outrageous Robbery",
             "text": "Target opponent exiles the top X cards of their library face down. You may look at and play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any type to cast it.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "84cb8b2f-086d-5a21-b3c7-ac37e499085f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0713025-581f-451b-97a3-97d891285dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0713025-581f-451b-97a3-97d891285dcc.jpg?1",
             "name": "Persuasive Interrogators",
             "text": "When Persuasive Interrogators enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, target opponent gets two poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "62104658-309c-5e48-9beb-6c580833bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc4c6f-4a84-4d42-89fa-7405f7ad6ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc4c6f-4a84-4d42-89fa-7405f7ad6ba0.jpg?1",
             "name": "Polygraph Orb",
             "text": "When Polygraph Orb enters the battlefield, look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.\n{2}, {T}, Collect evidence 3: Each opponent loses 3 life unless they discard a card or sacrifice a creature. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "124360ed-d621-5613-9ddb-06728a67e5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd64e5c-ea0b-4ea0-aba3-88e7e96ac7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd64e5c-ea0b-4ea0-aba3-88e7e96ac7ba.jpg?1",
             "name": "Presumed Dead",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield under its owner's control and suspect it.\" (A suspected creature has menace and can't block.)",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "e6f38724-1818-53ee-9d4c-fdbc4b7caab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2ca1e7-e0de-4d29-a81b-62185ccd295f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2ca1e7-e0de-4d29-a81b-62185ccd295f.jpg?1",
             "name": "Repeat Offender",
             "text": "{2}{B}: If Repeat Offender is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "038d09bf-3d2f-557e-b172-784071285d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023b0142-663a-47e7-a9f1-0b565a172b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023b0142-663a-47e7-a9f1-0b565a172b60.jpg?1",
             "name": "Rot Farm Mortipede",
             "text": "Whenever one or more creature cards leave your graveyard, Rot Farm Mortipede gets +1/+0 and gains menace and lifelink until end of turn.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "0dfa3bc9-f635-5571-b653-c476ec88c121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317800b3-6b2d-4de6-8e44-7e54dd623055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317800b3-6b2d-4de6-8e44-7e54dd623055.jpg?1",
             "name": "Slice from the Shadows",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -3807,7 +3807,7 @@
         },
         {
             "id": "5b4de9d1-d244-54d7-ad88-ed2dfc0a3f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc803ad-f8a2-4198-a8a6-8d987b3d00fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc803ad-f8a2-4198-a8a6-8d987b3d00fb.jpg?1",
             "name": "Slimy Dualleech",
             "text": "At the beginning of combat on your turn, target creature you control with power 2 or less gets +1/+0 and gains deathtouch until end of turn.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "cd4d3323-dfa6-56ab-aa1e-636b82785502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ab3e11-8584-406f-b9ae-9e1df4396cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ab3e11-8584-406f-b9ae-9e1df4396cbc.jpg?1",
             "name": "Snarling Gorehound",
             "text": "Menace\nWhenever another creature with power 2 or less enters the battlefield under your control, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "2c90d34d-6d39-5195-80de-83c56ff95e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22ac67-06ce-47cc-a515-d216d30b9cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22ac67-06ce-47cc-a515-d216d30b9cae.jpg?1",
             "name": "Soul Enervation",
             "text": "Flash\nWhen Soul Enervation enters the battlefield, target creature gets -4/-4 until end of turn.\nWhenever one or more creature cards leave your graveyard, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3909,7 +3909,7 @@
         },
         {
             "id": "94c61119-e552-5c7a-8090-4419caf079da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg?1",
             "name": "Toxin Analysis",
             "text": "Target creature gains deathtouch and lifelink until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3941,7 +3941,7 @@
         },
         {
             "id": "499fb379-83bb-53e8-a528-14b60a547905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67a4c5e-215b-4f03-87f7-c1af4f9f0a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67a4c5e-215b-4f03-87f7-c1af4f9f0a63.jpg?1",
             "name": "Undercity Eliminator",
             "text": "When Undercity Eliminator enters the battlefield, you may sacrifice an artifact or creature. When you do, exile target creature an opponent controls.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "ccc8b64f-679c-59a0-bb7d-64f8d2c6c95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg?1",
             "name": "Unscrupulous Agent",
             "text": "When Unscrupulous Agent enters the battlefield, target opponent exiles a card from their hand.",
             "colours": [
@@ -4011,7 +4011,7 @@
         },
         {
             "id": "6819ac4f-8ced-5b23-a0f2-428ecc1fa50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg?1",
             "name": "Vein Ripper",
             "text": "Flying\nWard\u2014\nSacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4049,7 +4049,7 @@
         },
         {
             "id": "9d12b110-1b73-54a5-9279-41f609c64588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc52b53-3e4f-4d7d-851f-86c6e0ac67b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc52b53-3e4f-4d7d-851f-86c6e0ac67b2.jpg?1",
             "name": "Anzrag's Rampage",
             "text": "Destroy all artifacts you don't control, then exile the top X cards of your library, where X is the number of artifacts that were put into graveyards from the battlefield this turn. You may put a creature card exiled this way onto the battlefield. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -4083,7 +4083,7 @@
         },
         {
             "id": "80fd934b-567c-5998-b9e0-74039128ac93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87683f7-8a61-4e4a-8b8b-3bf812454096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87683f7-8a61-4e4a-8b8b-3bf812454096.jpg?1",
             "name": "Bolrac-Clan Basher",
             "text": "Double strike, trample\nDisguise {3}{R}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "bed53f1f-9d16-52d9-872a-3f3d0c6d1d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee07df-215f-45a6-9a5a-708143d73e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee07df-215f-45a6-9a5a-708143d73e45.jpg?1",
             "name": "Case of the Burning Masks",
             "text": "When this Case enters the battlefield, it deals 3 damage to target creature an opponent controls.\nTo solve \u2014 Three or more sources you controlled dealt damage this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Sacrifice this Case: Exile the top three cards of your library. Choose one of them. You may play that card this turn.",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "96337375-06a8-52ba-a0b1-98e767451d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18b1de-bc08-4522-b891-6117a8271534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18b1de-bc08-4522-b891-6117a8271534.jpg?1",
             "name": "Case of the Crimson Pulse",
             "text": "When this Case enters the battlefield, discard a card, then draw two cards.\nTo solve \u2014 You have no cards in hand. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 At the beginning of your upkeep, discard your hand, then draw two cards.",
             "colours": [
@@ -4186,7 +4186,7 @@
         },
         {
             "id": "fc8c5ed5-70f1-5374-bae5-31ffb8602a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bc5f89-2f01-40c4-9883-4c90ab89fcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bc5f89-2f01-40c4-9883-4c90ab89fcbb.jpg?1",
             "name": "Caught Red-Handed",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Suspect it. (It has menace and can't block.)",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "8663243b-81a2-57cc-8647-4b2dbf902c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d54d596-f7aa-4b05-ab13-19b246698c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d54d596-f7aa-4b05-ab13-19b246698c04.jpg?1",
             "name": "The Chase Is On",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "5ac59122-fa7e-5330-8747-4a1a76219ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e31fa6-a445-47c6-a73f-135087f6d760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e31fa6-a445-47c6-a73f-135087f6d760.jpg?1",
             "name": "Concealed Weapon",
             "text": "Equipped creature gets +3/+0.\nDisguise {2}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Concealed Weapon is turned face up, attach it to target creature you control.\nEquip {1}{R}",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "726af514-483d-5f90-86f5-5645ce97c3ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg?1",
             "name": "Connecting the Dots",
             "text": "Whenever a creature you control attacks, exile the top card of your library face down. (You can't look at it.)\n{1}{R}, Discard your hand, Sacrifice Connecting the Dots: Put all cards exiled with Connecting the Dots into their owners' hands.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "fec832b4-e5fe-526a-8263-e4379a472f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2cf2ae-9152-41c4-9dc4-a19da5812869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2cf2ae-9152-41c4-9dc4-a19da5812869.jpg?1",
             "name": "Convenient Target",
             "text": "Enchant creature\nWhen Convenient Target enters the battlefield, suspect enchanted creature. (It has menace and can't block.)\nEnchanted creature gets +1/+1.\n{2}{R}: Return Convenient Target from your graveyard to your hand.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "fd92ecac-d675-5477-83e6-c1f67d0f4cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aff1ea-1d25-49c3-a2d9-f435124a5969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aff1ea-1d25-49c3-a2d9-f435124a5969.jpg?1",
             "name": "Cornered Crook",
             "text": "When Cornered Crook enters the battlefield, you may sacrifice an artifact. When you do, Cornered Crook deals 3 damage to any target.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "d2798e4d-db07-516e-9b75-0abe3c64fd44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a5cd7c-b0b1-4ffa-a806-bb0e73baffad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a5cd7c-b0b1-4ffa-a806-bb0e73baffad.jpg?1",
             "name": "Crime Novelist",
             "text": "Whenever you sacrifice an artifact, put a +1/+1 counter on Crime Novelist and add {R}.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "75f8359d-ece3-5403-b592-4c38bd2ff528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca092fc-7c67-4a73-989e-5297bbaaea76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca092fc-7c67-4a73-989e-5297bbaaea76.jpg?1",
             "name": "Demand Answers",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or discard a card.\nDraw two cards.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "30f21c62-14ed-5568-8cd9-a1604afcdc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65209da-cf48-4d37-b045-7d181070fd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65209da-cf48-4d37-b045-7d181070fd05.jpg?1",
             "name": "Expedited Inheritance",
             "text": "Whenever a creature is dealt damage, its controller may exile that many cards from the top of their library. They may play those cards until the end of their next turn.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "bb7bc526-1d6d-553e-8dd9-41cc86a1fc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31aadd3d-5ce1-44ba-ac6d-b192a9ea491b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31aadd3d-5ce1-44ba-ac6d-b192a9ea491b.jpg?1",
             "name": "Expose the Culprit",
             "text": "Choose one or both \u2014\n\u2022 Turn target face-down creature face up.\n\u2022 Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "5f6a0214-9adb-5133-8573-32afe645624d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538d6a8-a24a-40e3-b894-45a30882c92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538d6a8-a24a-40e3-b894-45a30882c92a.jpg?1",
             "name": "Felonious Rage",
             "text": "Target creature you control gets +2/+0 and gains haste until end of turn. When that creature dies this turn, create a 2/2 white and blue Detective creature token.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "44fda5ff-8048-5702-99f9-e0c531284b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81e343-7242-44b1-9ce6-1dddd104f764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81e343-7242-44b1-9ce6-1dddd104f764.jpg?1",
             "name": "Frantic Scapegoat",
             "text": "Haste\nWhen Frantic Scapegoat enters the battlefield, suspect it. (It has menace and can't block.)\nWhenever one or more other creatures enter the battlefield under your control, if Frantic Scapegoat is suspected, you may suspect one of the other creatures. If you do, Frantic Scapegoat is no longer suspected.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "844f5a49-2688-5ed3-afee-07e18c07fdba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg?1",
             "name": "Fugitive Codebreaker",
             "text": "Prowess, haste\nDisguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Fugitive Codebreaker is turned face up, discard your hand, then draw three cards.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "6ba196f9-8ff4-51ba-ba4c-ec177b781829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ed3bfa-3294-45dd-825e-3afc2580f0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ed3bfa-3294-45dd-825e-3afc2580f0d4.jpg?1",
             "name": "Galvanize",
             "text": "Galvanize deals 3 damage to target creature. If you've drawn two or more cards this turn, Galvanize deals 5 damage to that creature instead.",
             "colours": [
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "069a00f2-e480-58a2-9a27-a467b7e4b2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6900a344-a155-4ee1-a3ac-d6c28e024270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6900a344-a155-4ee1-a3ac-d6c28e024270.jpg?1",
             "name": "Gearbane Orangutan",
             "text": "Reach\nWhen Gearbane Orangutan enters the battlefield, choose one \u2014\n\u2022 Destroy up to one target artifact.\n\u2022 Sacrifice an artifact. If you do, put two +1/+1 counters on Gearbane Orangutan.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "5a19475e-ebcd-5a8c-8fd3-6a24f42067a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6154a991-c602-4fca-91a3-3830060da60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6154a991-c602-4fca-91a3-3830060da60e.jpg?1",
             "name": "Goblin Maskmaker",
             "text": "Whenever Goblin Maskmaker attacks, face-down spells you cast this turn cost {1} less to cast.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "f0a1de8c-7c98-5e32-a1d2-28b915af94d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb25ee-3c84-40a8-ba45-7e44893deecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb25ee-3c84-40a8-ba45-7e44893deecf.jpg?1",
             "name": "Harried Dronesmith",
             "text": "At the beginning of combat on your turn, create a 1/1 colorless Thopter artifact creature token with flying. It gains haste until end of turn. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "07a1f955-15ca-5f8f-80c6-611edac7381f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6aca64-a554-45c1-9f23-4f7878abeda5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6aca64-a554-45c1-9f23-4f7878abeda5.jpg?1",
             "name": "Incinerator of the Guilty",
             "text": "Flying, trample\nWhenever Incinerator of the Guilty deals combat damage to a player, you may collect evidence X. When you do, Incinerator of the Guilty deals X damage to each creature and each planeswalker that player controls. (To collect evidence X, exile cards with total mana value X or greater from your graveyard.)",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "9ba423e8-6033-52d3-96bb-317502c1ac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085f4595-4ae5-428e-a934-e918774df6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085f4595-4ae5-428e-a934-e918774df6fd.jpg?1",
             "name": "Innocent Bystander",
             "text": "Whenever Innocent Bystander is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "70fbec67-432d-57d1-b472-403405dbda01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6883788-e1ee-4ddd-add2-24d6bc367717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6883788-e1ee-4ddd-add2-24d6bc367717.jpg?1",
             "name": "Knife",
             "text": "As long as it's your turn, equipped creature gets +1/+0 and has first strike.\n{2}, Sacrifice Knife: Draw a card.\nEquip {2}",
             "colours": [
@@ -4876,7 +4876,7 @@
         },
         {
             "id": "026a8fcb-c5db-50c9-9c9c-13db04701f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg?1",
             "name": "Krenko, Baron of Tin Street",
             "text": "Haste\n{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control.\nWhenever an artifact is put into a graveyard from the battlefield, you may pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "2ecdc2bc-c9b3-5789-8fc8-9db6a4cd6bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg?1",
             "name": "Krenko's Buzzcrusher",
             "text": "Flying, trample\nWhen Krenko's Buzzcrusher enters the battlefield, for each player, destroy up to one nonbasic land that player controls. For each land destroyed this way, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "6f5e3849-ac1a-5806-b415-5287374b46f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg?1",
             "name": "Lamplight Phoenix",
             "text": "Flying\nWhen Lamplight Phoenix dies, you may exile it and collect evidence 4. If you do, return Lamplight Phoenix to the battlefield tapped. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "5836f68b-62c3-5ba8-b3bd-6f4b4a627c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f096ff4a-85f4-46f1-9478-e8921f21309d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f096ff4a-85f4-46f1-9478-e8921f21309d.jpg?1",
             "name": "Offender at Large",
             "text": "Disguise {4}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Offender at Large enters the battlefield or is turned face up, up to one target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "9520de35-83de-5cbd-ae8c-abf340b72495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d56ebff-67c8-4bc7-a533-ddde4ce0c2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d56ebff-67c8-4bc7-a533-ddde4ce0c2af.jpg?1",
             "name": "Person of Interest",
             "text": "When Person of Interest enters the battlefield, suspect it. Create a 2/2 white and blue Detective creature token. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -5058,7 +5058,7 @@
         },
         {
             "id": "0a4aba16-619a-5f27-b122-fe007b2b261a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5671b-2651-4944-a50a-c768ec70229e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5671b-2651-4944-a50a-c768ec70229e.jpg?1",
             "name": "Pyrotechnic Performer",
             "text": "Disguise {R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhenever Pyrotechnic Performer or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "77438f5a-a166-532d-a200-b400ad772e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da1a1d-e6ba-47e5-a545-0bacd427b782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da1a1d-e6ba-47e5-a545-0bacd427b782.jpg?1",
             "name": "Reckless Detective",
             "text": "Whenever Reckless Detective attacks, you may sacrifice an artifact or discard a card. If you do, draw a card and Reckless Detective gets +2/+0 until end of turn.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "81099d80-6a55-5eae-b50e-150e300d5fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c137a44-9ab6-4e59-8324-34d9dca8f5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c137a44-9ab6-4e59-8324-34d9dca8f5a6.jpg?1",
             "name": "Red Herring",
             "text": "Haste\nRed Herring attacks each combat if able.\n{2}, Sacrifice Red Herring: Draw a card.",
             "colours": [
@@ -5166,7 +5166,7 @@
         },
         {
             "id": "1ad034a2-0165-5d09-84bb-2a69e90c5d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90f8691-210a-4bf0-9fc2-fb2efcf057fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90f8691-210a-4bf0-9fc2-fb2efcf057fb.jpg?1",
             "name": "Rubblebelt Braggart",
             "text": "Whenever Rubblebelt Braggart attacks, if it's not suspected, you may suspect it. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -5201,7 +5201,7 @@
         },
         {
             "id": "3df0a424-6fb7-5f8d-90fa-8c0461c5d59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298747bb-eb40-4b58-bb22-4ac2bc1d795c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298747bb-eb40-4b58-bb22-4ac2bc1d795c.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5233,7 +5233,7 @@
         },
         {
             "id": "09298bbb-04ae-5668-826d-39fb525f97b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e280482-ed7e-4011-899e-096ff7bd4c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e280482-ed7e-4011-899e-096ff7bd4c41.jpg?1",
             "name": "Suspicious Detonation",
             "text": "This spell costs {3} less to cast if you've sacrificed an artifact this turn.\nThis spell can't be countered. (This includes by the ward ability.)\nSuspicious Detonation deals 4 damage to target creature.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "164f49d7-d3a7-5bda-9bf4-d49758cbe473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bbf709-d8e9-4e3b-8ec8-206f1b2162b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bbf709-d8e9-4e3b-8ec8-206f1b2162b3.jpg?1",
             "name": "Torch the Witness",
             "text": "Torch the Witness deals twice X damage to target creature. If excess damage was dealt to that creature this way, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "82d9ac51-be52-59f6-86a1-43a2a72607ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcc6106-71ad-40e4-8e1f-ddbfd655612b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcc6106-71ad-40e4-8e1f-ddbfd655612b.jpg?1",
             "name": "Torch the Witness",
             "text": "",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "99096027-dd20-5280-8726-2494bc967446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a247c9a0-0c65-47bc-92fd-bebe95cd35a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a247c9a0-0c65-47bc-92fd-bebe95cd35a3.jpg?1",
             "name": "Vengeful Tracker",
             "text": "Whenever an opponent sacrifices an artifact, Vengeful Tracker deals 2 damage to them.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "b1ae47e9-983d-5254-be0d-a947b60ad406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1aa6f8-2d34-4f4b-9184-0eab2e4745f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1aa6f8-2d34-4f4b-9184-0eab2e4745f7.jpg?1",
             "name": "Aftermath Analyst",
             "text": "When Aftermath Analyst enters the battlefield, mill three cards.\n{3}{G}, Sacrifice Aftermath Analyst: Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "bbbcd5f9-6eb0-5c8b-8479-fe6dde72d048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffbbe21-0a1d-48b9-903e-81c109aa11de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffbbe21-0a1d-48b9-903e-81c109aa11de.jpg?1",
             "name": "Airtight Alibi",
             "text": "Flash\nEnchant creature\nWhen Airtight Alibi enters the battlefield, untap enchanted creature. It gains hexproof until end of turn. If it's suspected, it's no longer suspected.\nEnchanted creature gets +2/+2 and can't become suspected.",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "fe8add1e-3ac6-575b-9121-906f7ed25ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5563967f-09fd-4ccf-8892-4dd0c2544c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5563967f-09fd-4ccf-8892-4dd0c2544c98.jpg?1",
             "name": "Analyze the Pollen",
             "text": "As an additional cost to cast this spell, you may collect evidence 8. (Exile cards with total mana value 8 or greater from your graveyard.)\nSearch your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "32404393-7656-5378-b29e-5d303a9a7427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg?1",
             "name": "Archdruid's Charm",
             "text": "Choose one \u2014\n\u2022 Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n\u2022 Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control.\n\u2022 Exile target artifact or enchantment.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "52915c2b-9a9b-5be3-8b75-06a827a5ee6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg?1",
             "name": "Audience with Trostani",
             "text": "Create a 0/1 green Plant creature token, then draw cards equal to the number of differently named creature tokens you control.",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "8fd98136-4259-53d8-b644-a6769e34ca36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg?1",
             "name": "Axebane Ferox",
             "text": "Deathtouch, haste\nWard\u2014\nCollect evidence 4. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player exiles cards with total mana value 4 or greater from their graveyard.)",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "e8731553-a09c-55b9-8f00-1cf9bcf11110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bbfe93-8225-444c-835b-33ffa006ef66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bbfe93-8225-444c-835b-33ffa006ef66.jpg?1",
             "name": "Bite Down on Crime",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. This spell costs {2} less to cast if evidence was collected. (To collect evidence 6, exile cards with total mana value 6 or greater from your graveyard.)\nTarget creature you control gets +2/+0 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "ac60d13e-7e18-5e83-bd01-14502ed42a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0929a1bd-e35c-4ca5-8c8c-dd304cf4b830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0929a1bd-e35c-4ca5-8c8c-dd304cf4b830.jpg?1",
             "name": "Case of the Locked Hothouse",
             "text": "You may play an additional land on each of your turns.\nTo solve \u2014 You control seven or more lands. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 You may look at the top card of your library any time, and you may play lands and cast creature and enchantment spells from the top of your library.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "20adc6a2-f0cc-5a87-a17b-f294e1ae0ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80f5c7-ae29-473c-ac64-04bcbc629385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80f5c7-ae29-473c-ac64-04bcbc629385.jpg?1",
             "name": "Case of the Trampled Garden",
             "text": "When this Case enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.\nTo solve \u2014 Creatures you control have total power 8 or greater. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Whenever you attack, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "a652bd6b-62ed-5660-b1f1-61ee562b8f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ff56c1-4153-4e15-9ac6-06d93fa2ae50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ff56c1-4153-4e15-9ac6-06d93fa2ae50.jpg?1",
             "name": "Chalk Outline",
             "text": "Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "b9a10969-026f-5983-ab50-1a9383108508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdc58b-1e7e-402c-88f9-c789ff1dae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdc58b-1e7e-402c-88f9-c789ff1dae31.jpg?1",
             "name": "Culvert Ambusher",
             "text": "When Culvert Ambusher enters the battlefield or is turned face up, target creature blocks this turn if able.\nDisguise {4}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "a5978836-dfd0-50f1-98df-ca5525a13c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941fa74-c7b9-4468-8080-de8057d3d27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941fa74-c7b9-4468-8080-de8057d3d27b.jpg?1",
             "name": "Fanatical Strength",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -5779,7 +5779,7 @@
         },
         {
             "id": "3a0478d9-27ca-58c0-820c-60b21fe996f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb31e-9301-44f1-b138-0573fbf56a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb31e-9301-44f1-b138-0573fbf56a47.jpg?1",
             "name": "Flourishing Bloom-Kin",
             "text": "Flourishing Bloom-Kin gets +1/+1 for each Forest you control.\nDisguise {4}{G}\nWhen Flourishing Bloom-Kin is turned face up, search your library for up to two Forest cards and reveal them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "5ec75087-073d-5702-bcd1-880309ecf9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e61e0f-d0f3-492a-92f1-36f72a91583a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e61e0f-d0f3-492a-92f1-36f72a91583a.jpg?1",
             "name": "Get a Leg Up",
             "text": "Until end of turn, target creature gets +1/+1 for each creature you control and gains reach.",
             "colours": [
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "cab2bab4-5dfc-5d44-ae6e-83d5ee3fd301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eff4d0-67ad-4900-b33d-605659b59161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eff4d0-67ad-4900-b33d-605659b59161.jpg?1",
             "name": "Glint Weaver",
             "text": "Reach\nWhen Glint Weaver enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures, then you gain life equal to the greatest toughness among creatures you control.",
             "colours": [
@@ -5880,7 +5880,7 @@
         },
         {
             "id": "767c7bb2-78de-58b9-ae27-65e005d95f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e62346-cc62-4938-970c-b56beeb79fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e62346-cc62-4938-970c-b56beeb79fa6.jpg?1",
             "name": "Greenbelt Radical",
             "text": "Disguise {5}{G}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Greenbelt Radical is turned face up, put a +1/+1 counter on each creature you control. Creatures you control gain trample until end of turn.",
             "colours": [
@@ -5915,7 +5915,7 @@
         },
         {
             "id": "35372129-0942-58f5-80c9-2830c9d080e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad807c2-14a7-4464-bf57-c323fb3c0bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad807c2-14a7-4464-bf57-c323fb3c0bd0.jpg?1",
             "name": "Hard-Hitting Question",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -5947,7 +5947,7 @@
         },
         {
             "id": "fb4f6ba3-a8e4-57e7-a9a1-13a9e5997695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4627adcd-ace7-4777-a7e6-fc80ac6b9dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4627adcd-ace7-4777-a7e6-fc80ac6b9dfe.jpg?1",
             "name": "Hedge Whisperer",
             "text": "You may choose not to untap Hedge Whisperer during your untap step.\n{3}{G}, {T}, Collect evidence 4: Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as Hedge Whisperer remains tapped. It's still a land. Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "4f606ff1-eb79-5b33-aefb-6bec7c2e5db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87c1ed8-c644-4ad5-9a21-c7bd9a7e8d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87c1ed8-c644-4ad5-9a21-c7bd9a7e8d20.jpg?1",
             "name": "Hide in Plain Sight",
             "text": "Look at the top five cards of your library, cloak two of them, and put the rest on the bottom of your library in a random order. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "aa75be43-aa9d-5fc3-8cce-1b052ed483db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1392c5-91a5-4e6e-803d-ed032e4d594b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1392c5-91a5-4e6e-803d-ed032e4d594b.jpg?1",
             "name": "A Killer Among Us",
             "text": "When A Killer Among Us enters the battlefield, create a 1/1 white Human creature token, a 1/1 blue Merfolk creature token, and a 1/1 red Goblin creature token. Then secretly choose Human, Merfolk, or Goblin.\nSacrifice A Killer Among Us, Reveal the chosen creature type: If target attacking creature token is the chosen type, put three +1/+1 counters on it and it gains deathtouch until end of turn.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "bd657af5-2039-5fdd-b89e-5bd63bb7cb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848.jpg?1",
             "name": "Loxodon Eavesdropper",
             "text": "When Loxodon Eavesdropper enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you draw your second card each turn, Loxodon Eavesdropper gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "1c4be8c4-8806-5d58-b6be-197fb42ec4f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b747c7-b342-47f8-a190-16c393b20607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b747c7-b342-47f8-a190-16c393b20607.jpg?1",
             "name": "Nervous Gardener",
             "text": "Disguise {G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Nervous Gardener is turned face up, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "a45be06a-6400-519e-9a55-20558c0951b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58cfb23-4d99-4133-bf4b-d7e7c7d17cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58cfb23-4d99-4133-bf4b-d7e7c7d17cea.jpg?1",
             "name": "Pick Your Poison",
             "text": "Choose one \u2014\n\u2022 Each opponent sacrifices an artifact.\n\u2022 Each opponent sacrifices an enchantment.\n\u2022 Each opponent sacrifices a creature with flying.",
             "colours": [
@@ -6150,7 +6150,7 @@
         },
         {
             "id": "8d7a5713-129d-5033-a45f-81c9a56270e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d803b93-c1df-4a02-9dbb-d347c841d4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d803b93-c1df-4a02-9dbb-d347c841d4d7.jpg?1",
             "name": "Pompous Gadabout",
             "text": "Pompous Gadabout has hexproof as long as it's your turn.\nPompous Gadabout can't be blocked by creatures that don't have a name.",
             "colours": [
@@ -6185,7 +6185,7 @@
         },
         {
             "id": "3eed2098-8122-5df1-b6ea-5ddb38670cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg?1",
             "name": "The Pride of Hull Clade",
             "text": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "149cee39-275e-5e80-a898-1e39bd0246e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6881946c-5036-4d9f-926f-932c9a592aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6881946c-5036-4d9f-926f-932c9a592aff.jpg?1",
             "name": "Rope",
             "text": "Equipped creature gets +1/+2, has reach, and can't be blocked by more than one creature.\n{2}, Sacrifice Rope: Draw a card.\nEquip {3}",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "ca8d33da-f49f-5d78-8326-807e05fa0cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c7ff67-b9e1-4d2e-b1ae-da9b946da00b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c7ff67-b9e1-4d2e-b1ae-da9b946da00b.jpg?1",
             "name": "Rubblebelt Maverick",
             "text": "When Rubblebelt Maverick enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n{G}, Exile Rubblebelt Maverick from your graveyard: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "b0f001f5-bbd9-5631-8e19-325788064021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7480c-82cc-4ddd-b619-c1a609c29a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7480c-82cc-4ddd-b619-c1a609c29a13.jpg?1",
             "name": "Sample Collector",
             "text": "Whenever Sample Collector attacks, you may collect evidence 3. When you do, put a +1/+1 counter on target creature you control. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "11efb9e1-2031-5ea0-8b72-d09395f58465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg?1",
             "name": "Sharp-Eyed Rookie",
             "text": "Vigilance\nWhenever a creature enters the battlefield under your control, if its power is greater than Sharp-Eyed Rookie's power or its toughness is greater than Sharp-Eyed Rookie's toughness, put a +1/+1 counter on Sharp-Eyed Rookie and investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6369,7 +6369,7 @@
         },
         {
             "id": "9e749f1a-45eb-56b9-af34-dfb344e798a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb21318-d32e-4724-8908-c0d7613de2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb21318-d32e-4724-8908-c0d7613de2f4.jpg?1",
             "name": "Slime Against Humanity",
             "text": "Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.\nA deck can have any number of cards named Slime Against Humanity.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "96379585-7d14-51b2-9423-1b9e6de685c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a31d4a-34bc-46b4-b20f-a5460191b35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a31d4a-34bc-46b4-b20f-a5460191b35d.jpg?1",
             "name": "They Went This Way",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "8c3a042b-5822-5d55-9650-f4bd226c7bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d0365e-6dee-4236-a997-6761e3cde90d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d0365e-6dee-4236-a997-6761e3cde90d.jpg?1",
             "name": "Topiary Panther",
             "text": "Trample\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "ff9f4fbc-e9cd-5d7a-b43e-158cb233bc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e29b890-35b9-4e2a-9b4c-9417ca7db31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e29b890-35b9-4e2a-9b4c-9417ca7db31d.jpg?1",
             "name": "Tunnel Tipster",
             "text": "At the beginning of your end step, if a face-down creature entered the battlefield under your control this turn, put a +1/+1 counter on Tunnel Tipster.\n{T}: Add {G}.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "56a80a30-013f-5b8c-9566-81589172ce30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8a22b8-368f-41e4-8d49-432c6c2ed11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8a22b8-368f-41e4-8d49-432c6c2ed11e.jpg?1",
             "name": "Undergrowth Recon",
             "text": "At the beginning of your upkeep, return target land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "6889e6ab-59b7-5766-8952-a28483e9c42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a914416-effd-4eda-b609-2773c53a08ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a914416-effd-4eda-b609-2773c53a08ec.jpg?1",
             "name": "Vengeful Creeper",
             "text": "Disguise {5}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Vengeful Creeper is turned face up, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "b7ac033f-bf61-5bd0-b06a-a27724f71255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d15d7-2724-4a9b-b5a7-8042d4b7da7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d15d7-2724-4a9b-b5a7-8042d4b7da7b.jpg?1",
             "name": "Vitu-Ghazi Inspector",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nReach\nWhen Vitu-Ghazi Inspector enters the battlefield, if evidence was collected, put a +1/+1 counter on target creature and you gain 2 life.",
             "colours": [
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "c4fab116-558d-5dfe-a352-b9b519deb207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aeac7c-1275-49d4-9915-7604ae4bfdff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aeac7c-1275-49d4-9915-7604ae4bfdff.jpg?1",
             "name": "Agrus Kos, Spirit of Justice",
             "text": "Double strike, vigilance\nWhenever Agrus Kos, Spirit of Justice enters the battlefield or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "4eb569cb-d88e-5d76-9e88-70290c840187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41129b44-4fa7-473b-b2b7-48c6a58be03c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41129b44-4fa7-473b-b2b7-48c6a58be03c.jpg?1",
             "name": "Alquist Proft, Master Sleuth",
             "text": "Vigilance\nWhen Alquist Proft, Master Sleuth enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
             "colours": [
@@ -6691,7 +6691,7 @@
         },
         {
             "id": "97ade56c-db8d-533e-8116-390d6f69b0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e9d8b8-4b32-4414-b32f-1f47523239c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e9d8b8-4b32-4414-b32f-1f47523239c5.jpg?1",
             "name": "Anzrag, the Quake-Mole",
             "text": "Whenever Anzrag, the Quake-Mole becomes blocked, untap each creature you control. After this combat phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "25a19fd1-2582-55b2-bd17-85547fb693f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c7d29-71b4-4134-b591-5598f479d592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c7d29-71b4-4134-b591-5598f479d592.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "bbe6811b-657b-528e-9ce3-89f405559829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f80c6e7-e9f9-4ca6-87f7-a52c96079e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f80c6e7-e9f9-4ca6-87f7-a52c96079e4a.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia, the Law Above deals 3 damage to each of your opponents and you gain 3 life.",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "48b17106-dfb1-55db-b3ac-7a84c929787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b80feb8-5cc8-4e91-ac22-a733305a67de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b80feb8-5cc8-4e91-ac22-a733305a67de.jpg?1",
             "name": "Blood Spatter Analysis",
             "text": "When Blood Spatter Analysis enters the battlefield, it deals 3 damage to target creature an opponent controls.\nWhenever one or more creatures die, mill a card and put a bloodstain counter on Blood Spatter Analysis. Then sacrifice it if it has five or more bloodstain counters on it. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -6847,7 +6847,7 @@
         },
         {
             "id": "da8181e8-c003-545c-9611-7ac0f74a7301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c628476-0987-47d4-8d2a-cfc3977b2357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c628476-0987-47d4-8d2a-cfc3977b2357.jpg?1",
             "name": "Break Out",
             "text": "Look at the top six cards of your library. You may reveal a creature card from among them. If that card has mana value 2 or less, you may put it onto the battlefield and it gains haste until end of turn. If you didn't put the revealed card onto the battlefield this way, put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6883,7 +6883,7 @@
         },
         {
             "id": "7486fc59-7190-551c-9669-f5a73782caf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b50a8f-2788-41df-81ca-61194960b730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b50a8f-2788-41df-81ca-61194960b730.jpg?1",
             "name": "Break Out",
             "text": "",
             "colours": [
@@ -6919,7 +6919,7 @@
         },
         {
             "id": "64297291-457b-5b1d-8c64-51bd0694b1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e144609-e1f6-4bdc-8d14-b735ef4140d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e144609-e1f6-4bdc-8d14-b735ef4140d3.jpg?1",
             "name": "Buried in the Garden",
             "text": "Enchant land\nWhen Buried in the Garden enters the battlefield, exile target nonland permanent you don't control until Buried in the Garden leaves the battlefield.\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -6955,7 +6955,7 @@
         },
         {
             "id": "a2dd2668-6487-5f82-a010-e6912f4f796a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc9f352-5076-4b5f-9815-cf47abb63d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc9f352-5076-4b5f-9815-cf47abb63d5b.jpg?1",
             "name": "Coerced to Kill",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin in addition to its other types.",
             "colours": [
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "b145112e-b579-57cb-bb64-9e9ecef56220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0578f-4966-4ecd-81e1-83ae13126f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0578f-4966-4ecd-81e1-83ae13126f13.jpg?1",
             "name": "Crowd-Control Warden",
             "text": "As Crowd-Control Warden enters the battlefield or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.\nDisguise {3}{RW}{RW} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "efe61e6b-5bea-5222-a32f-7406468d489f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893aef8-835d-4935-b532-d8670585e489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893aef8-835d-4935-b532-d8670585e489.jpg?1",
             "name": "Curious Cadaver",
             "text": "Flying\nWhen you sacrifice a Clue, return Curious Cadaver from your graveyard to your hand.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "09d8e7fa-f876-5103-b410-5d018d21cca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c68981c-037c-42e7-9b7f-6f07edab5f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c68981c-037c-42e7-9b7f-6f07edab5f2e.jpg?1",
             "name": "Deadly Complication",
             "text": "Choose one or both \u2014\n\u2022 Destroy target creature.\n\u2022 Put a +1/+1 counter on target suspected creature you control. You may have it become no longer suspected.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "f6113556-29a1-584e-a14c-80dc90fb926e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c05bf2d-7d4f-4717-b1ea-ec4284854f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c05bf2d-7d4f-4717-b1ea-ec4284854f4f.jpg?1",
             "name": "Detective's Satchel",
             "text": "When Detective's Satchel enters the battlefield, investigate twice. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn.",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "7037c6a6-2329-5e62-a365-ddd83f37d0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e0adb7-a030-4dcc-9284-cd91c7598a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e0adb7-a030-4dcc-9284-cd91c7598a22.jpg?1",
             "name": "Dog Walker",
             "text": "Vigilance\nDisguise {GU}{GU} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Dog Walker is turned face up, create two tapped 1/1 white Dog creature tokens.",
             "colours": [
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "02c11a99-531f-509c-8878-760e2769a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2daec58-78ed-4da5-b3b0-b04f12b0acbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2daec58-78ed-4da5-b3b0-b04f12b0acbd.jpg?1",
             "name": "Doppelgang",
             "text": "For each of X target permanents, create X tokens that are copies of that permanent.",
             "colours": [
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "1040fc8c-a70c-5e2f-a81a-330668ed19a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508d7096-2be3-4d4b-a55c-d4dbd3c9019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508d7096-2be3-4d4b-a55c-d4dbd3c9019c.jpg?1",
             "name": "Drag the Canal",
             "text": "Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "c1a9c58d-e493-5a95-a054-81f228f14621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4410db5a-62af-43ac-979d-88a7c975f7bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4410db5a-62af-43ac-979d-88a7c975f7bd.jpg?1",
             "name": "Etrata, Deadly Fugitive",
             "text": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library.",
             "colours": [
@@ -7290,7 +7290,7 @@
         },
         {
             "id": "4a2ac383-205d-5cb2-a525-f044e34b9738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53a6ee7-86e1-4d2d-994c-214e0ec08dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53a6ee7-86e1-4d2d-994c-214e0ec08dad.jpg?1",
             "name": "Evidence Examiner",
             "text": "At the beginning of combat on your turn, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)\nWhenever you collect evidence, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "2ea1917d-a6b9-59c4-800a-bbcafd90b80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554d5f2-7a33-4734-8cf3-dfae2ccc3596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554d5f2-7a33-4734-8cf3-dfae2ccc3596.jpg?1",
             "name": "Ezrim, Agency Chief",
             "text": "Flying\nWhen Ezrim, Agency Chief enters the battlefield, investigate twice. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "d3a700fe-8d25-539a-9162-c66043b5f51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20267dab-8898-4b44-8ef4-8a239967662c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20267dab-8898-4b44-8ef4-8a239967662c.jpg?1",
             "name": "Faerie Snoop",
             "text": "Flying\nDisguise {1}{UB}{UB} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Faerie Snoop is turned face up, look at the top two cards of your library. Put one into your hand and the other into your graveyard.",
             "colours": [
@@ -7405,7 +7405,7 @@
         },
         {
             "id": "48a6fc46-d0f4-51de-a396-75936fa230b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b489a54-ee43-4962-be7b-16e0e28800e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b489a54-ee43-4962-be7b-16e0e28800e0.jpg?1",
             "name": "Gadget Technician",
             "text": "When Gadget Technician enters the battlefield or is turned face up, create a 1/1 colorless Thopter artifact creature token with flying.\nDisguise {UR}{UR} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -7442,7 +7442,7 @@
         },
         {
             "id": "4112040a-1d5c-5ecc-a914-da9bf3ade6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabb5875-42ff-4e3a-a32e-aab392fccff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabb5875-42ff-4e3a-a32e-aab392fccff8.jpg?1",
             "name": "Gleaming Geardrake",
             "text": "Flying\nWhen Gleaming Geardrake enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.",
             "colours": [
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "b2216055-28c2-5ef5-9f03-a7a1f45e4e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daee9d98-f8c6-4980-8f23-c6c636b69430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daee9d98-f8c6-4980-8f23-c6c636b69430.jpg?1",
             "name": "Granite Witness",
             "text": "Flying, vigilance\nDisguise {WU}{WU} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Granite Witness is turned face up, you may tap or untap target creature.",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "ac7a6c1a-56ae-51f8-b629-fc1c633e19c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5cdb01-eaa4-4a0a-b42a-332bcf4d6fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5cdb01-eaa4-4a0a-b42a-332bcf4d6fff.jpg?1",
             "name": "Ill-Timed Explosion",
             "text": "Draw two cards. Then you may discard two cards. When you do, Ill-Timed Explosion deals X damage to each creature, where X is the greatest mana value among cards discarded this way.",
             "colours": [
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "930a4418-cf45-5363-a013-f80937d782e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb91a22-2040-4a37-85f8-5f22de8c5907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb91a22-2040-4a37-85f8-5f22de8c5907.jpg?1",
             "name": "Insidious Roots",
             "text": "Creature tokens you control have \"{T}: Add one mana of any color.\"\nWhenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature token, then put a +1/+1 counter on each Plant you control.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "717dc943-8cb6-523b-a053-eb03c4f06e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea66cd-587a-4ca9-9ca8-d7d2046bfbed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea66cd-587a-4ca9-9ca8-d7d2046bfbed.jpg?1",
             "name": "Izoni, Center of the Web",
             "text": "Menace\nWhenever Izoni, Center of the Web enters the battlefield or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with menace and reach.\nSacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life.",
             "colours": [
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "fd5d80f2-adb3-51fd-8fc6-a3452a72a5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaa19ce-cace-499e-8b23-ef9e56b23700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaa19ce-cace-499e-8b23-ef9e56b23700.jpg?1",
             "name": "Judith, Carnage Connoisseur",
             "text": "Whenever you cast an instant or sorcery spell, choose one \u2014\n\u2022 That spell gains deathtouch and lifelink.\n\u2022 Create a 2/2 red Imp creature token with \"When this creature dies, it deals 2 damage to each opponent.\"",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "c6a4a427-8945-5d64-8236-d8ea1146bd77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2827593-4951-4ba7-b73e-c27de56f2606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2827593-4951-4ba7-b73e-c27de56f2606.jpg?1",
             "name": "Kaya, Spirits' Justice",
             "text": "Whenever one or more creatures you control and/or creature cards in your graveyard are put into exile, you may choose a creature card from among them. Until end of turn, target token you control becomes a copy of it, except it has flying.\n+2: Surveil 2, then exile a card from a graveyard.\n+1: Create a 1/1 white and black Spirit creature token with flying.\n\u22122: Exile target creature you control. For each other player, exile up to one target creature that player controls.",
             "colours": [
@@ -7714,7 +7714,7 @@
         },
         {
             "id": "259cdf6a-1ecc-5ad6-8f5b-8d2415f4013d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Flying, vigilance\nWhenever Kellan, Inquisitive Prodigy attacks, destroy up to one target artifact. If you controlled that permanent, draw a card.",
             "colours": [
@@ -7756,7 +7756,7 @@
         },
         {
             "id": "b51e90f9-401b-5f89-8875-7ecb3bde7ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Investigate. You may play an additional land this turn.",
             "colours": [
@@ -7794,7 +7794,7 @@
         },
         {
             "id": "2989a41b-795c-530f-85af-e29121736041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c08ed44-2c13-4029-af2e-68585a76bb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c08ed44-2c13-4029-af2e-68585a76bb03.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "Reach\nWhen Kraul Whipcracker enters the battlefield, destroy target token an opponent controls.",
             "colours": [
@@ -7835,7 +7835,7 @@
         },
         {
             "id": "985555b3-fd3a-59e4-9e8b-ff10c8ae3ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ceb4988-0a79-4757-9fcc-381ee8643d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ceb4988-0a79-4757-9fcc-381ee8643d0f.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "d7b8c510-8842-51ac-9424-765bbb0a594a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00faa272-91ad-407b-9175-8fa1d02585b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00faa272-91ad-407b-9175-8fa1d02585b8.jpg?1",
             "name": "Kylox, Visionary Inventor",
             "text": "Menace, ward {2}, haste\nWhenever Kylox, Visionary Inventor attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs.",
             "colours": [
@@ -7917,7 +7917,7 @@
         },
         {
             "id": "6c201c83-cdfd-5123-9aec-6b4abb868fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a8a1af-b1cf-47fc-ab42-7efa07a1c95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a8a1af-b1cf-47fc-ab42-7efa07a1c95b.jpg?1",
             "name": "Kylox's Voltstrider",
             "text": "Collect evidence 6: Kylox's Voltstrider becomes an artifact creature until end of turn.\nWhenever Kylox's Voltstrider attacks, you may cast an instant or sorcery spell from among cards exiled with it. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.\nCrew 2",
             "colours": [
@@ -7955,7 +7955,7 @@
         },
         {
             "id": "d077b955-0bff-5433-b0c7-4cc2246df89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc264d1d-689d-41ac-b624-3fc7bb890e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc264d1d-689d-41ac-b624-3fc7bb890e58.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
             "colours": [
@@ -7998,7 +7998,7 @@
         },
         {
             "id": "59f47b57-652a-516b-a382-c0821a54cd03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e59be-f959-4f4a-8c2d-b7c441e88135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e59be-f959-4f4a-8c2d-b7c441e88135.jpg?1",
             "name": "Leyline of the Guildpact",
             "text": "If Leyline of the Guildpact is in your opening hand, you may begin the game with it on the battlefield.\nEach nonland permanent you control is all colors.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "dcc68ad9-3362-59ba-a8f7-5be1a2464ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4101e3fe-b0e7-4f0f-b9ac-9b61a4d628b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4101e3fe-b0e7-4f0f-b9ac-9b61a4d628b3.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "bee0cf6d-36d6-5a6b-b12b-da3a136f326d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af12417c-b082-4379-a850-c72e2652c6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af12417c-b082-4379-a850-c72e2652c6fb.jpg?1",
             "name": "Meddling Youths",
             "text": "Haste\nWhenever you attack with three or more creatures, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "e28826b3-0981-593b-910e-06a0f3261a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8fda6-8614-45cd-879c-0cb7fa29647e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8fda6-8614-45cd-879c-0cb7fa29647e.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet, Guildpact deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
             "colours": [
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "f87f2154-b850-5e95-a291-0f53fb479407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0c695d-62f9-4805-9e2f-7032e8464136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0c695d-62f9-4805-9e2f-7032e8464136.jpg?1",
             "name": "No More Lies",
             "text": "Counter target spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -8200,7 +8200,7 @@
         },
         {
             "id": "215a62a0-ceb5-5f3e-9bb1-8d1ccdbfcce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a433ca4c-82d0-4e49-bc8e-98e18dd174e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a433ca4c-82d0-4e49-bc8e-98e18dd174e9.jpg?1",
             "name": "Officious Interrogation",
             "text": "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "71bab7a8-7ad1-5235-99dd-00592eb6a842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a50807-058e-45dc-847c-8ffd13b1bd48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a50807-058e-45dc-847c-8ffd13b1bd48.jpg?1",
             "name": "Private Eye",
             "text": "Other Detectives you control get +1/+1.\nWhenever you draw your second card each turn, target Detective can't be blocked this turn.",
             "colours": [
@@ -8273,7 +8273,7 @@
         },
         {
             "id": "21c4a58c-3ccf-513c-ac66-9bee91af52e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6fd2d5-8eb2-4265-a1bf-d4ae635285af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6fd2d5-8eb2-4265-a1bf-d4ae635285af.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "a5a3a8b5-42c3-5e1b-be19-e684b6e9c03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8c6b-7ef7-45db-99c9-4a6e7f177b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8c6b-7ef7-45db-99c9-4a6e7f177b94.jpg?1",
             "name": "Rakish Scoundrel",
             "text": "Deathtouch\nWhen Rakish Scoundrel enters the battlefield or is turned face up, target creature gains indestructible until end of turn.\nDisguise {4}{BG}{BG} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "39136acc-3259-553b-955a-95d7028952a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20948cd2-e40c-4648-832f-ab0f1cc21610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20948cd2-e40c-4648-832f-ab0f1cc21610.jpg?1",
             "name": "Relive the Past",
             "text": "Return up to one target artifact card, up to one target land card, and up to one target non-Aura enchantment card from your graveyard to the battlefield. They are 5/5 Elemental creatures in addition to their other types.",
             "colours": [
@@ -8389,7 +8389,7 @@
         },
         {
             "id": "f65886f3-10eb-5192-879d-588070ea82c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71701c28-f113-4d38-8fd3-a19cd9749661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71701c28-f113-4d38-8fd3-a19cd9749661.jpg?1",
             "name": "Repulsive Mutation",
             "text": "Put X +1/+1 counters on target creature you control. Then counter up to one target spell unless its controller pays mana equal to the greatest power among creatures you control.",
             "colours": [
@@ -8423,7 +8423,7 @@
         },
         {
             "id": "a4b5e0e0-fde5-502c-8006-2ca1679472b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fae9044-a859-434d-8dc6-4f9d455ca5e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fae9044-a859-434d-8dc6-4f9d455ca5e1.jpg?1",
             "name": "Riftburst Hellion",
             "text": "Reach\nDisguise {4}{RG}{RG} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "72387799-de35-5ff9-b860-a03a5bd6bd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5288cf17-9d79-4d35-85f1-bf4d0a73494b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5288cf17-9d79-4d35-85f1-bf4d0a73494b.jpg?1",
             "name": "Rune-Brand Juggler",
             "text": "When Rune-Brand Juggler enters the battlefield, suspect up to one target creature you control. (A suspected creature has menace and can't block.)\n{3}{B}{R}, Sacrifice a suspected creature: Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -8496,7 +8496,7 @@
         },
         {
             "id": "dedd43ca-50c0-5408-aee3-5d8d91548108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cba5503-ba99-43d8-8062-66d905e0d86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cba5503-ba99-43d8-8062-66d905e0d86b.jpg?1",
             "name": "Sanguine Savior",
             "text": "Flying, lifelink\nDisguise {WB}{WB} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Sanguine Savior is turned face up, another target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "ec930abd-7284-50b2-b69f-2d79011e4fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de36e63-8190-415f-b65b-bae1e595845d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de36e63-8190-415f-b65b-bae1e595845d.jpg?1",
             "name": "Shady Informant",
             "text": "When Shady Informant dies, it deals 2 damage to any target.\nDisguise {2}{BR}{BR} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "099c2ae3-7193-53d2-81b3-a8e42fad591b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f852937-381d-4445-99d3-2ecb8af6bb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f852937-381d-4445-99d3-2ecb8af6bb6a.jpg?1",
             "name": "Soul Search",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If the card's mana value is 1 or less, create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "f675558c-ee94-52e0-9069-5d16374beade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d4691-59d1-4e97-9b5d-8017788fbcb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d4691-59d1-4e97-9b5d-8017788fbcb3.jpg?1",
             "name": "Sumala Sentry",
             "text": "Reach\nWhenever a face-down permanent you control is turned face up, put a +1/+1 counter on it and a +1/+1 counter on Sumala Sentry.",
             "colours": [
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "3eeffce7-92ea-5be8-af06-33de173d486b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5a13dd-c2fd-432e-bc49-cc62d94d62a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5a13dd-c2fd-432e-bc49-cc62d94d62a0.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "Deathtouch\nAt the beginning of your end step, investigate for each opponent who lost life this turn.\nWhenever a Clue you control is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "a43fb179-8017-54d5-93c9-a4cf8c103da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4094b13f-28d4-48b6-8cce-3c44656745b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4094b13f-28d4-48b6-8cce-3c44656745b7.jpg?1",
             "name": "Tin Street Gossip",
             "text": "Vigilance\n{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn creatures face up.",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "f9d0029e-f3df-50e7-ad05-c5bd1fad56e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d22402-c41d-43d7-be1f-42be1e300726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d22402-c41d-43d7-be1f-42be1e300726.jpg?1",
             "name": "Tolsimir, Midnight's Light",
             "text": "Lifelink\nWhen Tolsimir, Midnight's Light enters the battlefield, create Voja Fenstalker, a legendary 5/5 green and white Wolf creature token with trample.\nWhenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an opponent controls blocks that Wolf this combat if able.",
             "colours": [
@@ -8762,7 +8762,7 @@
         },
         {
             "id": "098c42a4-52e9-5acc-9705-96e4acaad73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b9260b-0993-42c5-9bcf-87ab394d51db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b9260b-0993-42c5-9bcf-87ab394d51db.jpg?1",
             "name": "Treacherous Greed",
             "text": "As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.\nDraw three cards. Each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -8798,7 +8798,7 @@
         },
         {
             "id": "ba9c7a26-5a7b-5126-90c7-debe02aa687c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f3aca-6db7-41d3-95b2-c479d14b7fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f3aca-6db7-41d3-95b2-c479d14b7fa3.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "af4abf8e-b3be-5955-8a4a-8ac99d0f4772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc669c8-6f39-4d52-82d3-a4005d41c8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc669c8-6f39-4d52-82d3-a4005d41c8a5.jpg?1",
             "name": "Undercover Crocodelf",
             "text": "Whenever Undercover Crocodelf deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nDisguise {3}{GW}{GW} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "023e6218-784f-50e4-b73b-9541f07a34f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163c6f2-dca1-4d6f-8f0d-7c3c55c6f75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163c6f2-dca1-4d6f-8f0d-7c3c55c6f75e.jpg?1",
             "name": "Undercover Crocodelf",
             "text": "",
             "colours": [
@@ -8921,7 +8921,7 @@
         },
         {
             "id": "d368d63c-0939-50b9-a686-588bdfe90dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ac346a-fc46-4023-aa60-4d55170697dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ac346a-fc46-4023-aa60-4d55170697dc.jpg?1",
             "name": "Urgent Necropsy",
             "text": "As an additional cost to cast this spell, collect evidence X, where X is the total mana value of the permanents this spell targets.\nDestroy up to one target artifact, up to one target creature, up to one target enchantment, and up to one target planeswalker.",
             "colours": [
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "9dab7895-e300-59b7-b6bc-b2bb1418e47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d381eb-6cb6-4505-aebe-995c1ddc8527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d381eb-6cb6-4505-aebe-995c1ddc8527.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand. (Put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -9002,7 +9002,7 @@
         },
         {
             "id": "18016e0e-c8f5-5c0d-96f5-924aa9a0bdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e8f8bd-1c8b-4a7c-96c4-57a247ce9ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e8f8bd-1c8b-4a7c-96c4-57a247ce9ccc.jpg?1",
             "name": "Warleader's Call",
             "text": "Creatures you control get +1/+1.\nWhenever a creature enters the battlefield under your control, Warleader's Call deals 1 damage to each opponent.",
             "colours": [
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "e87f1a1d-50eb-57ad-ac66-0eb7e6f4857d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3490c05-d12c-4483-acbc-1b4ae68877f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3490c05-d12c-4483-acbc-1b4ae68877f0.jpg?1",
             "name": "Wispdrinker Vampire",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.\n{5}{W}{B}: Creatures you control with power 2 or less gain deathtouch and lifelink until end of turn.",
             "colours": [
@@ -9077,7 +9077,7 @@
         },
         {
             "id": "dd1ef6ad-d69a-5b41-9b7a-15374bff3a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3340bd-1d8c-4c21-a59d-e092fcbe02e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3340bd-1d8c-4c21-a59d-e092fcbe02e3.jpg?1",
             "name": "Worldsoul's Rage",
             "text": "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped.",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "a62100e7-0bd7-52fb-929a-d2912a0411d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326845a7-7502-4dc3-8f3e-867d6c84e931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326845a7-7502-4dc3-8f3e-867d6c84e931.jpg?1",
             "name": "Yarus, Roar of the Old Gods",
             "text": "Other creatures you control have haste.\nWhenever one or more face-down creatures you control deal combat damage to a player, draw a card.\nWhenever a face-down creature you control dies, return it to the battlefield face down under its owner's control if it's a permanent card, then turn it face up.",
             "colours": [
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "7d7724c2-f8f9-5a65-acd0-1b720c3cde62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg?1",
             "name": "Cease // Desist",
             "text": "Exile up to two target cards from a single graveyard. Target player gains 2 life and draws a card.",
             "colours": [
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "f57b8326-c2a8-529b-b253-4e0552814561",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg?1",
             "name": "Cease // Desist",
             "text": "Destroy all artifacts and enchantments.",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "3adf27ae-6050-531c-bcd7-7f813cb0b2f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg?1",
             "name": "Flotsam // Jetsam",
             "text": "Mill three cards. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "ad68d7c0-3ecc-521f-83f3-7a6922756dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg?1",
             "name": "Flotsam // Jetsam",
             "text": "Each opponent mills three cards, then you may cast a spell from each opponent's graveyard without paying its mana cost. If a spell cast this way would be put into a graveyard, exile it instead.",
             "colours": [
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "63bc1b51-86fb-5901-91b5-15e15d7b5bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg?1",
             "name": "Fuss // Bother",
             "text": "Put a +1/+1 counter on each attacking creature you control.",
             "colours": [
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "b7a0fd32-d2e2-5bac-a48f-39bbcb547c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg?1",
             "name": "Fuss // Bother",
             "text": "Create three 1/1 colorless Thopter artifact creature tokens with flying. Surveil 2.",
             "colours": [
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "e3c80952-c9fb-5777-a69a-04cf35718a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg?1",
             "name": "Hustle // Bustle",
             "text": "Target creature attacks or blocks this turn if able.",
             "colours": [
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "373178c7-7664-545f-bf35-e867e93f9544",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg?1",
             "name": "Hustle // Bustle",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn. You may turn a creature you control face up.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "7846184e-eee9-5122-bcd6-515d8c8a102f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg?1",
             "name": "Push // Pull",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "f060ec7b-3ec0-5a01-badc-b7b20587d211",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg?1",
             "name": "Push // Pull",
             "text": "Put up to two target creature cards from a single graveyard onto the battlefield under your control. They gain haste until end of turn. Sacrifice them at the beginning of the next end step.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "9982f02e-dfb9-5a60-a267-3576222a85b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a2563-6cfb-4d12-9513-b44d1a7a20ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a2563-6cfb-4d12-9513-b44d1a7a20ab.jpg?1",
             "name": "Cryptex",
             "text": "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on Cryptex. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)\nSacrifice Cryptex: Surveil 3, then draw three cards. Activate only if Cryptex has five or more unlock counters on it.",
             "colours": [],
@@ -9534,7 +9534,7 @@
         },
         {
             "id": "ec0b6cb5-684c-5b5d-a260-91d4e78062d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f952d8d-c089-432c-822a-8ef1e605ae38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f952d8d-c089-432c-822a-8ef1e605ae38.jpg?1",
             "name": "Gravestone Strider",
             "text": "{1}: Add one mana of any color. Activate only once each turn.\n{2}, Exile Gravestone Strider from your graveyard: Exile target card from a graveyard.",
             "colours": [],
@@ -9565,7 +9565,7 @@
         },
         {
             "id": "13f228a5-1bfa-5235-93b5-8837cf060110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ad039-1669-4735-9864-76f4c61fc59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ad039-1669-4735-9864-76f4c61fc59e.jpg?1",
             "name": "Lumbering Laundry",
             "text": "{2}: Until end of turn, you may look at face-down creatures you don't control any time.\nDisguise {5} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [],
@@ -9596,7 +9596,7 @@
         },
         {
             "id": "f5bcce0b-6142-50ff-89fc-0203f7644fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70476534-2fc7-4872-a009-3380dd5ce2ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70476534-2fc7-4872-a009-3380dd5ce2ab.jpg?1",
             "name": "Magnetic Snuffler",
             "text": "When Magnetic Snuffler enters the battlefield, return target Equipment card from your graveyard to the battlefield attached to Magnetic Snuffler.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Magnetic Snuffler.",
             "colours": [],
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "6dd8a4cb-309d-58a9-a540-4db1a1453de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606a71f-8fb0-486b-955f-727ebf436946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606a71f-8fb0-486b-955f-727ebf436946.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "991e0f85-385b-50eb-b1da-2b34ae45ff91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52608ba4-c47d-44e4-b624-dee2a3a42ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52608ba4-c47d-44e4-b624-dee2a3a42ae2.jpg?1",
             "name": "Sanitation Automaton",
             "text": "When Sanitation Automaton enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "a524ea2c-d122-51d1-8ac5-fcf1a65b1d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2565e1-dd7b-462b-8270-a17913277793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2565e1-dd7b-462b-8270-a17913277793.jpg?1",
             "name": "Thinking Cap",
             "text": "Equipped creature gets +1/+2.\nEquip Detective {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9718,7 +9718,7 @@
         },
         {
             "id": "f1d619df-b539-558b-b796-3616383465a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8169f-b858-47a5-9c76-2e7c50ad4ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8169f-b858-47a5-9c76-2e7c50ad4ecd.jpg?1",
             "name": "Branch of Vitu-Ghazi",
             "text": "{T}: Add {C}.\nDisguise {3} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Branch of Vitu-Ghazi is turned face up, add two mana of any one color. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -9746,7 +9746,7 @@
         },
         {
             "id": "cb7372cc-5eeb-5633-8e2d-971843ae7023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf220c06-3cce-4bdd-aa58-83940c223e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf220c06-3cce-4bdd-aa58-83940c223e9c.jpg?1",
             "name": "Commercial District",
             "text": "({T}: Add {R} or {G}.)\nCommercial District enters the battlefield tapped.\nWhen Commercial District enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "1781db93-d1ec-5062-b4c3-da1819495363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6d541-e2cb-4d6e-acac-90a8f53b7006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6d541-e2cb-4d6e-acac-90a8f53b7006.jpg?1",
             "name": "Elegant Parlor",
             "text": "({T}: Add {R} or {W}.)\nElegant Parlor enters the battlefield tapped.\nWhen Elegant Parlor enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9818,7 +9818,7 @@
         },
         {
             "id": "1d888e36-a43f-56e9-a157-8c36144d147e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg?1",
             "name": "Escape Tunnel",
             "text": "{T}, Sacrifice Escape Tunnel: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{T}, Sacrifice Escape Tunnel: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [],
@@ -9846,7 +9846,7 @@
         },
         {
             "id": "fc832b56-73ab-52f6-b7bc-863b119a64d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260f8ae-805b-4eae-badf-62de0f768867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260f8ae-805b-4eae-badf-62de0f768867.jpg?1",
             "name": "Hedge Maze",
             "text": "({T}: Add {G} or {U}.)\nHedge Maze enters the battlefield tapped.\nWhen Hedge Maze enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9882,7 +9882,7 @@
         },
         {
             "id": "d1b9e8fb-2862-54e7-9c10-eadbf54cb11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17816e8-28b1-4295-a637-efb0e5c18873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17816e8-28b1-4295-a637-efb0e5c18873.jpg?1",
             "name": "Lush Portico",
             "text": "({T}: Add {G} or {W}.)\nLush Portico enters the battlefield tapped.\nWhen Lush Portico enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9918,7 +9918,7 @@
         },
         {
             "id": "98d5a2d1-64ee-56b8-ac96-bb87c2fc0e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652236c2-84ef-45e4-b5fc-ed6170bc3d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652236c2-84ef-45e4-b5fc-ed6170bc3d6c.jpg?1",
             "name": "Meticulous Archive",
             "text": "({T}: Add {W} or {U}.)\nMeticulous Archive enters the battlefield tapped.\nWhen Meticulous Archive enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "ea9fecbb-4369-5852-802c-db70209927ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b915f-3e82-4b05-b963-01ebff7a8f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b915f-3e82-4b05-b963-01ebff7a8f7b.jpg?1",
             "name": "Public Thoroughfare",
             "text": "Public Thoroughfare enters the battlefield tapped.\nWhen Public Thoroughfare enters the battlefield, sacrifice it unless you tap an untapped artifact or land you control.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "9cac4fe7-3790-531b-87ff-3d4a73fa1c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b598c93e-dae1-4d71-a9e4-917abf76d2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b598c93e-dae1-4d71-a9e4-917abf76d2d0.jpg?1",
             "name": "Raucous Theater",
             "text": "({T}: Add {B} or {R}.)\nRaucous Theater enters the battlefield tapped.\nWhen Raucous Theater enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "8061e12c-cd7b-507d-b8c2-fadf27b7a2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de039992-631b-4feb-a522-acdb0a6d1f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de039992-631b-4feb-a522-acdb0a6d1f26.jpg?1",
             "name": "Scene of the Crime",
             "text": "Scene of the Crime enters the battlefield tapped.\n{T}: Add {C}.\n{T}, Tap an untapped creature you control: Add one mana of any color.\n{2}, Sacrifice Scene of the Crime: Draw a card.",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "bd691e08-4492-525b-b644-6d0884260041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b656-1d67-499c-bf0f-417682a86c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b656-1d67-499c-bf0f-417682a86c7d.jpg?1",
             "name": "Shadowy Backstreet",
             "text": "({T}: Add {W} or {B}.)\nShadowy Backstreet enters the battlefield tapped.\nWhen Shadowy Backstreet enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "3f88972a-3ffb-539e-b514-228c5f56185f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17260fff-b239-4af4-9306-3236ae3fa5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17260fff-b239-4af4-9306-3236ae3fa5a5.jpg?1",
             "name": "Thundering Falls",
             "text": "({T}: Add {U} or {R}.)\nThundering Falls enters the battlefield tapped.\nWhen Thundering Falls enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "be48a761-6e79-5fa3-8490-e7888f6a9032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5801fb-2026-4f25-98bc-ebb2f99684b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5801fb-2026-4f25-98bc-ebb2f99684b9.jpg?1",
             "name": "Undercity Sewers",
             "text": "({T}: Add {U} or {B}.)\nUndercity Sewers enters the battlefield tapped.\nWhen Undercity Sewers enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "fb93c13e-ee50-502f-9966-8b44914e8a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ca59cd-8779-4a84-a54b-e863b79c61f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ca59cd-8779-4a84-a54b-e863b79c61f0.jpg?1",
             "name": "Underground Mortuary",
             "text": "({T}: Add {B} or {G}.)\nUnderground Mortuary enters the battlefield tapped.\nWhen Underground Mortuary enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10193,7 +10193,7 @@
         },
         {
             "id": "626f78bc-1374-5c58-9dc7-8ee28627cd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598f857d-ee17-4478-bb39-cc3ab77ab8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598f857d-ee17-4478-bb39-cc3ab77ab8d8.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "7d77484b-1033-54a2-af4a-1f8b080a859e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5f01e9-f85f-41e8-9527-88f76e7bfc02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5f01e9-f85f-41e8-9527-88f76e7bfc02.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10267,7 +10267,7 @@
         },
         {
             "id": "8dc7629b-77da-5ed6-a12b-c01515446b39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d0a415-26b8-4ba2-9503-b4ee2b93617c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d0a415-26b8-4ba2-9503-b4ee2b93617c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10304,7 +10304,7 @@
         },
         {
             "id": "97e51c26-7a92-5f11-869e-27a0d2153b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383b66e-e559-47d2-9967-9c2d5f898653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383b66e-e559-47d2-9967-9c2d5f898653.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10341,7 +10341,7 @@
         },
         {
             "id": "af9de45c-409f-56bf-9ada-de3a3f3b748e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8126b842-ea58-4988-8b3f-0394cf766b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8126b842-ea58-4988-8b3f-0394cf766b91.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10378,7 +10378,7 @@
         },
         {
             "id": "cee7488e-5346-5a7a-a8e9-3b973d5803eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1a8a6-916b-4eef-8079-6775afcb63cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1a8a6-916b-4eef-8079-6775afcb63cf.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10415,7 +10415,7 @@
         },
         {
             "id": "682bf5a1-7151-5a1a-a5dd-0f378ea652c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec05cb6c-6e7f-4d40-ba38-a9fc06158094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec05cb6c-6e7f-4d40-ba38-a9fc06158094.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10452,7 +10452,7 @@
         },
         {
             "id": "27a8b821-4c7a-594a-a59d-ef397ea5f0fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6908b583-4a52-4819-82a3-9db9c860aeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6908b583-4a52-4819-82a3-9db9c860aeb6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10489,7 +10489,7 @@
         },
         {
             "id": "6e055635-9822-59ab-bd02-6a12c8aa2fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df18762d-9980-4344-9d4f-e9d2cd8e0456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df18762d-9980-4344-9d4f-e9d2cd8e0456.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10526,7 +10526,7 @@
         },
         {
             "id": "6011504d-1dae-5968-a113-4b4aad18f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d0ef58-c0b3-4bcd-b470-0cf41219a4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d0ef58-c0b3-4bcd-b470-0cf41219a4e6.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10563,7 +10563,7 @@
         },
         {
             "id": "c4be0dd1-abad-5b23-ba5b-a63e55bfce48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbccfc-3585-4895-94d1-c3a67205e5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbccfc-3585-4895-94d1-c3a67205e5fe.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10600,7 +10600,7 @@
         },
         {
             "id": "93a8241c-45a7-5d3c-915a-5e8a12525a52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de754d20-5371-456b-9064-8f0687d2eab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de754d20-5371-456b-9064-8f0687d2eab7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10637,7 +10637,7 @@
         },
         {
             "id": "12dbef3e-4412-5647-ac0c-9c8532227280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a0cd6-8d3b-44bd-b609-c12fb851d17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a0cd6-8d3b-44bd-b609-c12fb851d17b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10674,7 +10674,7 @@
         },
         {
             "id": "6053e63c-67ef-56b1-ad98-2b43931ba5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc485069-e081-4e83-bbad-d5faf7a5bd03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc485069-e081-4e83-bbad-d5faf7a5bd03.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10711,7 +10711,7 @@
         },
         {
             "id": "b57a1231-6966-5b92-914c-582a47626be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb8f264-cc26-476e-a3b7-53638dce7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb8f264-cc26-476e-a3b7-53638dce7395.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10748,7 +10748,7 @@
         },
         {
             "id": "a6aee678-4405-5edc-8487-b34fe009064b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88c5959-c033-46d0-94ea-df22988dc923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88c5959-c033-46d0-94ea-df22988dc923.jpg?1",
             "name": "Assemble the Players",
             "text": "You may look at the top card of your library any time.\nOnce each turn, you may cast a creature spell with power 2 or less from the top of your library.",
             "colours": [
@@ -10782,7 +10782,7 @@
         },
         {
             "id": "859784e1-61bf-54bb-aa13-4d909213b182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49598c0a-3b3c-42a2-9358-ff072de9d9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49598c0a-3b3c-42a2-9358-ff072de9d9f2.jpg?1",
             "name": "Auspicious Arrival",
             "text": "Target creature gets +2/+2 until end of turn. Investigate.",
             "colours": [
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "0fef2c11-e41a-5b14-ab1f-8315c8fba01d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e844d2-80de-4473-acd3-c39c1b11246f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e844d2-80de-4473-acd3-c39c1b11246f.jpg?1",
             "name": "Call a Surprise Witness",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Put a flying counter on it. It's a Spirit in addition to its other types.",
             "colours": [
@@ -10850,7 +10850,7 @@
         },
         {
             "id": "54131580-4a86-578b-9552-75b4e017f2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512dafb-3cba-4415-9f26-9345f1935b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512dafb-3cba-4415-9f26-9345f1935b1e.jpg?1",
             "name": "Makeshift Binding",
             "text": "When Makeshift Binding enters the battlefield, exile target creature an opponent controls until Makeshift Binding leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -10884,7 +10884,7 @@
         },
         {
             "id": "163c17a9-2545-5e95-b95f-ad977671a4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb67d2a1-4b0b-4d4a-8ae9-eaf0f831cdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb67d2a1-4b0b-4d4a-8ae9-eaf0f831cdb5.jpg?1",
             "name": "Not on My Watch",
             "text": "Exile target attacking creature.",
             "colours": [
@@ -10918,7 +10918,7 @@
         },
         {
             "id": "4c78c394-b1f4-54fe-893c-d917aaef837f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a5571e-02cb-4aa4-926d-d04f5ab04f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a5571e-02cb-4aa4-926d-d04f5ab04f29.jpg?1",
             "name": "On the Job",
             "text": "Creatures you control get +2/+1 until end of turn. Investigate.",
             "colours": [
@@ -10952,7 +10952,7 @@
         },
         {
             "id": "a991bdc7-8be1-5876-b98c-402feece2387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad92dbd-828e-425f-8cab-819a04ea9020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad92dbd-828e-425f-8cab-819a04ea9020.jpg?1",
             "name": "Deduce",
             "text": "Draw a card. Investigate.",
             "colours": [
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "959cc734-b093-5a14-8e6f-7aa03cb94b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bff30e-c25c-4d89-8fbe-1a9effe63ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bff30e-c25c-4d89-8fbe-1a9effe63ba7.jpg?1",
             "name": "Dramatic Accusation",
             "text": "Enchant creature\nWhen Dramatic Accusation enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{U}{U}: Shuffle enchanted creature into its owner's library.",
             "colours": [
@@ -11022,7 +11022,7 @@
         },
         {
             "id": "b5643c0e-d297-5f04-ba47-7c3c9b231b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51724cc6-edf7-490d-8039-b11b91ae1eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51724cc6-edf7-490d-8039-b11b91ae1eb4.jpg?1",
             "name": "Fae Flight",
             "text": "Flash\nEnchant creature\nWhen Fae Flight enters the battlefield, enchanted creature gains hexproof until end of turn.\nEnchanted creature gets +1/+0 and has flying.",
             "colours": [
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "da665ca2-ff71-566d-b690-5bf6040000eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6c5c84-2721-4aaa-9185-69351a4ab105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6c5c84-2721-4aaa-9185-69351a4ab105.jpg?1",
             "name": "Intrude on the Mind",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. Create a 0/0 colorless Thopter artifact creature token with flying, then put a +1/+1 counter on it for each card put into your graveyard this way.",
             "colours": [
@@ -11092,7 +11092,7 @@
         },
         {
             "id": "4ad282e3-b576-5568-a5d6-a5dc230e7c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580e1986-d22b-4deb-914a-2d38d6da4145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580e1986-d22b-4deb-914a-2d38d6da4145.jpg?1",
             "name": "Reenact the Crime",
             "text": "Exile target nonland card in a graveyard that was put there from anywhere this turn. Copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -11126,7 +11126,7 @@
         },
         {
             "id": "df12fa84-b72f-5355-8274-27bdb27c4356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695437c-1b7e-4163-aade-ca79b9c70e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695437c-1b7e-4163-aade-ca79b9c70e15.jpg?1",
             "name": "Unauthorized Exit",
             "text": "Return target nonland permanent to its owner's hand. Surveil 1.",
             "colours": [
@@ -11160,7 +11160,7 @@
         },
         {
             "id": "b814245c-605e-595d-9f22-41085db32fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef279e1-cbce-4766-9d56-02fa6c79d69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef279e1-cbce-4766-9d56-02fa6c79d69d.jpg?1",
             "name": "It Doesn't Add Up",
             "text": "Return target creature card from your graveyard to the battlefield. Suspect it.",
             "colours": [
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "c08afbfd-feda-5dc8-885d-0461a7668bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c98fcd3-8273-459f-857d-d0a34a1d285a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c98fcd3-8273-459f-857d-d0a34a1d285a.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -11228,7 +11228,7 @@
         },
         {
             "id": "7e5dd595-3627-5833-85bd-632b163e5f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e49c72-0fa2-4271-aabd-38a3e2b4779c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e49c72-0fa2-4271-aabd-38a3e2b4779c.jpg?1",
             "name": "Slice from the Shadows",
             "text": "This spell can't be countered.\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "088e040c-48d4-5c6f-ba03-89723fddea88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef61777-be03-40c5-be9c-d573cf025813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef61777-be03-40c5-be9c-d573cf025813.jpg?1",
             "name": "Soul Enervation",
             "text": "Flash\nWhen Soul Enervation enters the battlefield, target creature gets -4/-4 until end of turn.\nWhenever one or more creature cards leave your graveyard, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "5b8724b2-8208-5a40-b3f6-fb59b9a6328c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba0604-3d9d-4f68-9086-6c7bf85a1354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba0604-3d9d-4f68-9086-6c7bf85a1354.jpg?1",
             "name": "Anzrag's Rampage",
             "text": "Destroy all artifacts you don't control, then exile the top X cards of your library, where X is the number of artifacts that were put into graveyards from the battlefield this turn. You may put a creature card exiled this way onto the battlefield. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -11330,7 +11330,7 @@
         },
         {
             "id": "6f09d5ba-734d-53e5-bbc7-8a412c97859f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5d312-8664-4690-9823-8be4d1c06cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5d312-8664-4690-9823-8be4d1c06cd0.jpg?1",
             "name": "The Chase Is On",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. Investigate.",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "e64feb99-46d5-5cd4-9460-094b822c8a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11c0f62-80a0-4e45-9ed2-295814475a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11c0f62-80a0-4e45-9ed2-295814475a3f.jpg?1",
             "name": "Convenient Target",
             "text": "Enchant creature\nWhen Convenient Target enters the battlefield, suspect enchanted creature.\nEnchanted creature gets +1/+1.\n{2}{R}: Return Convenient Target from your graveyard to your hand.",
             "colours": [
@@ -11400,7 +11400,7 @@
         },
         {
             "id": "0c193d4d-2b29-5fdd-94ce-a2c855892400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a35d1cb-5a61-49b7-a124-e8713655e4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a35d1cb-5a61-49b7-a124-e8713655e4c3.jpg?1",
             "name": "Demand Answers",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or discard a card.\nDraw two cards.",
             "colours": [
@@ -11434,7 +11434,7 @@
         },
         {
             "id": "4cd8e690-09e5-5527-bfb0-b3c15ae87017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaae9b6-510f-4039-8cca-fe7d7c57f1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaae9b6-510f-4039-8cca-fe7d7c57f1c5.jpg?1",
             "name": "Expose the Culprit",
             "text": "Choose one or both \u2014\n\u2022 Turn target face-down creature face up.\n\u2022 Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them.",
             "colours": [
@@ -11468,7 +11468,7 @@
         },
         {
             "id": "f9a04478-ca15-5e97-a971-45f031359e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8faf9-4230-4bb5-ad2e-b520ab338c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8faf9-4230-4bb5-ad2e-b520ab338c35.jpg?1",
             "name": "Analyze the Pollen",
             "text": "As an additional cost to cast this spell, you may collect evidence 8.\nSearch your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "f1fa7428-7110-5614-9566-50b281d9f455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4b7b29-b1c1-4413-80d9-3c8585ed8eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4b7b29-b1c1-4413-80d9-3c8585ed8eb4.jpg?1",
             "name": "Audience with Trostani",
             "text": "Create a 0/1 green Plant creature token, then draw cards equal to the number of differently named creature tokens you control.",
             "colours": [
@@ -11536,7 +11536,7 @@
         },
         {
             "id": "8ac4d93e-cccf-5ebe-a181-cd4b90ba384e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee8b5b-ab55-4a26-9491-a0dc20cf54c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee8b5b-ab55-4a26-9491-a0dc20cf54c8.jpg?1",
             "name": "Fanatical Strength",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -11570,7 +11570,7 @@
         },
         {
             "id": "806e9642-5b69-58bf-8a10-f0c1d1ff7158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9c1153-93d6-4250-bc42-2d9fd3042e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9c1153-93d6-4250-bc42-2d9fd3042e55.jpg?1",
             "name": "Coerced to Kill",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin in addition to its other types.",
             "colours": [
@@ -11608,7 +11608,7 @@
         },
         {
             "id": "5f77df67-a32b-5eda-96a8-8d966c38b476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1aaebc-105a-4867-9727-24b8d7899e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1aaebc-105a-4867-9727-24b8d7899e28.jpg?1",
             "name": "Deadly Complication",
             "text": "Choose one or both \u2014\n\u2022 Destroy target creature.\n\u2022 Put a +1/+1 counter on target suspected creature you control. You may have it become no longer suspected.",
             "colours": [
@@ -11644,7 +11644,7 @@
         },
         {
             "id": "588544ab-8007-5b19-aeef-838972747d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9e0ae-38c0-4618-b664-16a9ad1661c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9e0ae-38c0-4618-b664-16a9ad1661c1.jpg?1",
             "name": "Insidious Roots",
             "text": "Creature tokens you control have \"{T}: Add one mana of any color.\"\nWhenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature token, then put a +1/+1 counter on each Plant you control.",
             "colours": [
@@ -11680,7 +11680,7 @@
         },
         {
             "id": "d3cd2ac1-e99d-5f5d-b430-f9199c9a2ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a78b4-9fe3-4f99-8678-2cf5d344bd0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a78b4-9fe3-4f99-8678-2cf5d344bd0c.jpg?1",
             "name": "Officious Interrogation",
             "text": "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.",
             "colours": [
@@ -11716,7 +11716,7 @@
         },
         {
             "id": "2cb07172-362c-5c8b-81ab-ec3bcd5551fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26cd008-0a09-4a3d-a5de-2babf79ec6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26cd008-0a09-4a3d-a5de-2babf79ec6c6.jpg?1",
             "name": "Warleader's Call",
             "text": "Creatures you control get +1/+1.\nWhenever a creature enters the battlefield under your control, Warleader's Call deals 1 damage to each opponent.",
             "colours": [
@@ -11752,7 +11752,7 @@
         },
         {
             "id": "1bde860d-31d6-5fa6-b004-b711cc3a193c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62c3c3c-1196-45b0-832a-77ba26df3b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62c3c3c-1196-45b0-832a-77ba26df3b70.jpg?1",
             "name": "Worldsoul's Rage",
             "text": "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped.",
             "colours": [
@@ -11788,7 +11788,7 @@
         },
         {
             "id": "ebd980bd-32b1-5482-8929-e32a5bb9a4b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f000f6-6a24-4daa-8552-bfc2634e6d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f000f6-6a24-4daa-8552-bfc2634e6d83.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia, the Law Above deals 3 damage to each of your opponents and you gain 3 life.",
             "colours": [
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "05c2a9fe-28b3-57b3-9192-e3dfff0341f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39c4234-3b5a-4114-871a-ae8dd5659e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39c4234-3b5a-4114-871a-ae8dd5659e86.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "",
             "colours": [
@@ -11871,7 +11871,7 @@
         },
         {
             "id": "86fb2c18-1941-51ee-8e47-25344fe564d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f43e9f-8a0e-4534-ba4d-14cde33df864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f43e9f-8a0e-4534-ba4d-14cde33df864.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate.\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
             "colours": [
@@ -11914,7 +11914,7 @@
         },
         {
             "id": "555d9d6a-fdcd-52fa-965e-1b3440da5032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a701da-47d6-4c85-a428-adeb4a20678d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a701da-47d6-4c85-a428-adeb4a20678d.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "",
             "colours": [
@@ -11956,7 +11956,7 @@
         },
         {
             "id": "bd6e217f-c50d-51d2-9312-a3d68b7c1dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd713f-a0d0-4456-9678-d0a48e4bc334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd713f-a0d0-4456-9678-d0a48e4bc334.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet, Guildpact deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
             "colours": [
@@ -12005,7 +12005,7 @@
         },
         {
             "id": "5242832d-253c-5e5a-a1ff-e6373073b29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdad75c-82e3-4feb-9bc9-29b6251439cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdad75c-82e3-4feb-9bc9-29b6251439cb.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "",
             "colours": [
@@ -12053,7 +12053,7 @@
         },
         {
             "id": "399cfb63-129a-5734-9be5-47bf669935be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea612ae-6e7e-4a42-844f-2bc97153b6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea612ae-6e7e-4a42-844f-2bc97153b6b1.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -12096,7 +12096,7 @@
         },
         {
             "id": "6601393f-14bf-5e60-8497-3912e3525f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5c2b49-ae53-48b7-877a-7f9aa7b6fc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5c2b49-ae53-48b7-877a-7f9aa7b6fc4a.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "",
             "colours": [
@@ -12138,7 +12138,7 @@
         },
         {
             "id": "c11e2034-3429-5682-8d82-8ac046cfccfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536f271e-5daa-4ffe-9dd4-0ccc48d6fb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536f271e-5daa-4ffe-9dd4-0ccc48d6fb66.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "Deathtouch\nAt the beginning of your end step, investigate for each opponent who lost life this turn.\nWhenever a Clue you control is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -12181,7 +12181,7 @@
         },
         {
             "id": "d0abc038-9a1a-5925-a581-16d333549e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4193a7bd-bba3-44f2-acf3-685847b8be27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4193a7bd-bba3-44f2-acf3-685847b8be27.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "",
             "colours": [
@@ -12223,7 +12223,7 @@
         },
         {
             "id": "19363e7f-8aa0-55fd-8d76-35c67b2b9bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a158690c-0a9a-4057-a6ee-f651bfb6664a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a158690c-0a9a-4057-a6ee-f651bfb6664a.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -12266,7 +12266,7 @@
         },
         {
             "id": "3d0286ac-5b96-5f5b-8bd5-1939b067fcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c420297-04c7-4659-b7cc-141a5c0ad1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c420297-04c7-4659-b7cc-141a5c0ad1e1.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "",
             "colours": [
@@ -12308,7 +12308,7 @@
         },
         {
             "id": "5e7411c1-4f90-5ab5-967a-6732000467e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7381c-c745-458c-bf55-457242781a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7381c-c745-458c-bf55-457242781a09.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand.\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -12353,7 +12353,7 @@
         },
         {
             "id": "03897f17-8cf5-54a1-b020-be3b812feee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fa5a00-34d3-4ca4-afb9-62ab1c7afb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fa5a00-34d3-4ca4-afb9-62ab1c7afb14.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "",
             "colours": [
@@ -12397,7 +12397,7 @@
         },
         {
             "id": "895798fd-83cd-5b9a-8523-1784c3a526c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9889ab-3527-414e-9c30-539f0608bd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9889ab-3527-414e-9c30-539f0608bd2b.jpg?1",
             "name": "Commercial District",
             "text": "Commercial District enters the battlefield tapped.\nWhen Commercial District enters the battlefield, surveil 1.",
             "colours": [],
@@ -12433,7 +12433,7 @@
         },
         {
             "id": "dcaef4cf-fc2e-55d6-a5ca-2ecd27b8cfb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0cef88-50bd-4baa-8d02-26ec4967a7be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0cef88-50bd-4baa-8d02-26ec4967a7be.jpg?1",
             "name": "Elegant Parlor",
             "text": "Elegant Parlor enters the battlefield tapped.\nWhen Elegant Parlor enters the battlefield, surveil 1.",
             "colours": [],
@@ -12469,7 +12469,7 @@
         },
         {
             "id": "20a8cb94-2afe-5cc8-aadb-3ef30a98c4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee215175-d48b-4630-a1b1-36e195db05dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee215175-d48b-4630-a1b1-36e195db05dd.jpg?1",
             "name": "Hedge Maze",
             "text": "Hedge Maze enters the battlefield tapped.\nWhen Hedge Maze enters the battlefield, surveil 1.",
             "colours": [],
@@ -12505,7 +12505,7 @@
         },
         {
             "id": "3f720e0a-e565-5ab4-bdfe-4d2cb832e0e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bd2920-9fbf-4853-ace3-66cd7015de32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bd2920-9fbf-4853-ace3-66cd7015de32.jpg?1",
             "name": "Lush Portico",
             "text": "Lush Portico enters the battlefield tapped.\nWhen Lush Portico enters the battlefield, surveil 1.",
             "colours": [],
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "82cfe850-83cd-5ec4-908f-e2d95fc271d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d4ba4b-03f3-4e64-b4e7-8c025fc70178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d4ba4b-03f3-4e64-b4e7-8c025fc70178.jpg?1",
             "name": "Meticulous Archive",
             "text": "Meticulous Archive enters the battlefield tapped.\nWhen Meticulous Archive enters the battlefield, surveil 1.",
             "colours": [],
@@ -12577,7 +12577,7 @@
         },
         {
             "id": "b84d24ab-094d-538d-8591-7d5a19a8b8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf0337-c7a3-45a0-bb14-c431526da2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf0337-c7a3-45a0-bb14-c431526da2cd.jpg?1",
             "name": "Raucous Theater",
             "text": "Raucous Theater enters the battlefield tapped.\nWhen Raucous Theater enters the battlefield, surveil 1.",
             "colours": [],
@@ -12613,7 +12613,7 @@
         },
         {
             "id": "204c60c9-ccd5-554d-b1e5-663cefe565d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eae4ce-e0b3-482b-9136-6fc17333877e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eae4ce-e0b3-482b-9136-6fc17333877e.jpg?1",
             "name": "Shadowy Backstreet",
             "text": "Shadowy Backstreet enters the battlefield tapped.\nWhen Shadowy Backstreet enters the battlefield, surveil 1.",
             "colours": [],
@@ -12649,7 +12649,7 @@
         },
         {
             "id": "dbb66a3b-8609-5de9-b949-a178a7864baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1792e4-2170-42ae-a335-fde6f5ef8932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1792e4-2170-42ae-a335-fde6f5ef8932.jpg?1",
             "name": "Thundering Falls",
             "text": "Thundering Falls enters the battlefield tapped.\nWhen Thundering Falls enters the battlefield, surveil 1.",
             "colours": [],
@@ -12685,7 +12685,7 @@
         },
         {
             "id": "300ef52d-06c0-5fc2-b41d-3ead553bacf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3239a1e5-a002-4389-b9a7-049b1d60e2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3239a1e5-a002-4389-b9a7-049b1d60e2ac.jpg?1",
             "name": "Undercity Sewers",
             "text": "Undercity Sewers enters the battlefield tapped.\nWhen Undercity Sewers enters the battlefield, surveil 1.",
             "colours": [],
@@ -12721,7 +12721,7 @@
         },
         {
             "id": "0a5b834f-4142-560c-80c2-c5b7c3d845f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8938e4-bfa5-47e1-8c71-9c6583346300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8938e4-bfa5-47e1-8c71-9c6583346300.jpg?1",
             "name": "Underground Mortuary",
             "text": "Underground Mortuary enters the battlefield tapped.\nWhen Underground Mortuary enters the battlefield, surveil 1.",
             "colours": [],
@@ -12757,7 +12757,7 @@
         },
         {
             "id": "cb1ac85a-c77c-55fd-a2a2-ed22f0c0d402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Flying, vigilance\nWhenever Kellan, Inquisitive Prodigy attacks, destroy up to one target artifact. If you controlled that permanent, draw a card.",
             "colours": [
@@ -12799,7 +12799,7 @@
         },
         {
             "id": "9962fa93-b09f-5d6f-a22e-887214c324b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Investigate. You may play an additional land this turn.",
             "colours": [
@@ -12837,7 +12837,7 @@
         },
         {
             "id": "44dc9146-abc7-5f55-a3c0-9966a7531888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9acee3-12b7-41c6-8a5c-7985d052bc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9acee3-12b7-41c6-8a5c-7985d052bc7a.jpg?1",
             "name": "Kaya, Spirits' Justice",
             "text": "Whenever one or more creatures you control and/or creature cards in your graveyard are put into exile, you may choose a creature card from among them. Until end of turn, target token you control becomes a copy of it, except it has flying.\n+2: Surveil 2, then exile a card from a graveyard.\n+1: Create a 1/1 white and black Spirit creature token with flying.\n\u22122: Exile target creature you control. For each other player, exile up to one target creature that player controls.",
             "colours": [
@@ -12877,7 +12877,7 @@
         },
         {
             "id": "23c1c826-4963-5519-a567-2395368ff089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975b5145-b30e-4ae3-b318-3b245bf12cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975b5145-b30e-4ae3-b318-3b245bf12cc3.jpg?1",
             "name": "Aurelia's Vindicator",
             "text": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -12914,7 +12914,7 @@
         },
         {
             "id": "512b27e6-dcc9-595c-8fce-86adf71d6d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6297104-b73c-439c-ac0c-b7fac01d49dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6297104-b73c-439c-ac0c-b7fac01d49dc.jpg?1",
             "name": "Delney, Streetwise Lookout",
             "text": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
             "colours": [
@@ -12954,7 +12954,7 @@
         },
         {
             "id": "392acb88-371d-5e53-9f32-c668cbfd33c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd24cf-ee30-4a05-a473-f3ec589c35dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd24cf-ee30-4a05-a473-f3ec589c35dd.jpg?1",
             "name": "Doorkeeper Thrull",
             "text": "Flash\nFlying\nArtifacts and creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "d772a586-5d4f-5716-b818-ee751d82882c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d12e748-e8d6-42d2-b501-c39cfcd6551d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d12e748-e8d6-42d2-b501-c39cfcd6551d.jpg?1",
             "name": "Neighborhood Guardian",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -13026,7 +13026,7 @@
         },
         {
             "id": "0a6bd12e-1f39-5ec3-8784-552f70a78fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481b5d9a-872d-4a2f-a52a-d4a746ee04ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481b5d9a-872d-4a2f-a52a-d4a746ee04ab.jpg?1",
             "name": "Wojek Investigator",
             "text": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you.",
             "colours": [
@@ -13065,7 +13065,7 @@
         },
         {
             "id": "5fd6dce7-4df7-5bb0-a582-6b0ec31a3271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a33f43e-e57e-4d2c-b6f3-c785ab96214e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a33f43e-e57e-4d2c-b6f3-c785ab96214e.jpg?1",
             "name": "Conspiracy Unraveler",
             "text": "Flying\nYou may collect evidence 10 rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -13103,7 +13103,7 @@
         },
         {
             "id": "c272dd32-59fb-51dc-aa0e-55baf52ffc5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab507e5-7bf2-4fa0-9ac0-a6aaec90de83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab507e5-7bf2-4fa0-9ac0-a6aaec90de83.jpg?1",
             "name": "Forensic Gadgeteer",
             "text": "Whenever you cast an artifact spell, investigate.\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -13141,7 +13141,7 @@
         },
         {
             "id": "cef5cd9a-2261-5d83-ac5b-b19cf1741018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9106abf-f589-48a2-90f8-d606a7367377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9106abf-f589-48a2-90f8-d606a7367377.jpg?1",
             "name": "Homicide Investigator",
             "text": "Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn.",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "639e8b17-6f48-59cf-a8b7-8774f8eb9153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab741b3-6230-46c3-9c43-8a0d735e9d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab741b3-6230-46c3-9c43-8a0d735e9d49.jpg?1",
             "name": "Massacre Girl, Known Killer",
             "text": "Menace\nCreatures you control have wither.\nWhenever a creature an opponent controls dies, if its toughness was less than 1, draw a card.",
             "colours": [
@@ -13218,7 +13218,7 @@
         },
         {
             "id": "a15b18bf-0d3c-55e5-b84c-e481af71944e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c134956-ba18-415e-b101-c1254415ea04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c134956-ba18-415e-b101-c1254415ea04.jpg?1",
             "name": "Persuasive Interrogators",
             "text": "When Persuasive Interrogators enters the battlefield, investigate.\nWhenever you sacrifice a Clue, target opponent gets two poison counters.",
             "colours": [
@@ -13255,7 +13255,7 @@
         },
         {
             "id": "4022642f-03a5-5f77-9e0b-9db5cacd63a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65121bff-89f0-436d-89a5-b8191dc91891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65121bff-89f0-436d-89a5-b8191dc91891.jpg?1",
             "name": "Vein Ripper",
             "text": "Flying\nWard\u2014\nSacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -13293,7 +13293,7 @@
         },
         {
             "id": "86298311-372c-58ab-9317-3d79ddb3d142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae07b33-dcee-41aa-9886-38336d2aff7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae07b33-dcee-41aa-9886-38336d2aff7a.jpg?1",
             "name": "Frantic Scapegoat",
             "text": "Haste\nWhen Frantic Scapegoat enters the battlefield, suspect it.\nWhenever one or more other creatures enter the battlefield under your control, if Frantic Scapegoat is suspected, you may suspect one of the other creatures. If you do, Frantic Scapegoat is no longer suspected.",
             "colours": [
@@ -13329,7 +13329,7 @@
         },
         {
             "id": "8ce83935-bda4-5055-9635-9b5686dad7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbb3378-291c-4de6-be98-dd09daa3b828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbb3378-291c-4de6-be98-dd09daa3b828.jpg?1",
             "name": "Fugitive Codebreaker",
             "text": "Prowess, haste\nDisguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard.\nWhen Fugitive Codebreaker is turned face up, discard your hand, then draw three cards.",
             "colours": [
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "4741baea-a6b0-5825-a2f1-79d06e8a8e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874659c8-43e2-4298-844a-510f2b21830c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874659c8-43e2-4298-844a-510f2b21830c.jpg?1",
             "name": "Incinerator of the Guilty",
             "text": "Flying, trample\nWhenever Incinerator of the Guilty deals combat damage to a player, you may collect evidence X. When you do, Incinerator of the Guilty deals X damage to each creature and each planeswalker that player controls.",
             "colours": [
@@ -13403,7 +13403,7 @@
         },
         {
             "id": "f1cd2751-bb61-5e51-8942-5ed8a40a815c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f3c6-934a-4819-8057-b8c80f2a8696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f3c6-934a-4819-8057-b8c80f2a8696.jpg?1",
             "name": "Krenko, Baron of Tin Street",
             "text": "Haste\n{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control.\nWhenever an artifact is put into a graveyard from the battlefield, you may pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn.",
             "colours": [
@@ -13441,7 +13441,7 @@
         },
         {
             "id": "02d27163-fd8f-516a-94cf-cfc735ae38f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82849769-ee1b-4f70-935c-9cb97772ade1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82849769-ee1b-4f70-935c-9cb97772ade1.jpg?1",
             "name": "Culvert Ambusher",
             "text": "When Culvert Ambusher enters the battlefield or is turned face up, target creature blocks this turn if able.\nDisguise {4}{G}",
             "colours": [
@@ -13478,7 +13478,7 @@
         },
         {
             "id": "41dc7925-75ad-5cdc-a5a4-4e323afdda96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8bdb03-02d0-4b97-b058-959f1fff9118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8bdb03-02d0-4b97-b058-959f1fff9118.jpg?1",
             "name": "The Pride of Hull Clade",
             "text": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
             "colours": [
@@ -13520,7 +13520,7 @@
         },
         {
             "id": "9083d91a-61ed-5a06-a534-dc5bf8d247d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b1b18-179d-48e1-ab8a-9374eb1ae429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b1b18-179d-48e1-ab8a-9374eb1ae429.jpg?1",
             "name": "Sharp-Eyed Rookie",
             "text": "Vigilance\nWhenever a creature enters the battlefield under your control, if its power is greater than Sharp-Eyed Rookie's power or its toughness is greater than Sharp-Eyed Rookie's toughness, put a +1/+1 counter on Sharp-Eyed Rookie and investigate.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "0face518-45ff-5254-a9aa-b7b3ca850303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2d61c-194a-482b-9c59-6800d6cc3a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2d61c-194a-482b-9c59-6800d6cc3a5b.jpg?1",
             "name": "Agrus Kos, Spirit of Justice",
             "text": "Double strike, vigilance\nWhenever Agrus Kos, Spirit of Justice enters the battlefield or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it.",
             "colours": [
@@ -13599,7 +13599,7 @@
         },
         {
             "id": "588cd5fe-e08f-5851-9878-383d946f20a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e528424e-a3b1-4902-b42d-1ba9ac412e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e528424e-a3b1-4902-b42d-1ba9ac412e73.jpg?1",
             "name": "Alquist Proft, Master Sleuth",
             "text": "Vigilance\nWhen Alquist Proft, Master Sleuth enters the battlefield, investigate.\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
             "colours": [
@@ -13641,7 +13641,7 @@
         },
         {
             "id": "c676ee72-94ab-55e1-b874-595540a305fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba703ed8-3c5e-479f-b7f1-b8070d4f83b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba703ed8-3c5e-479f-b7f1-b8070d4f83b7.jpg?1",
             "name": "Anzrag, the Quake-Mole",
             "text": "Whenever Anzrag, the Quake-Mole becomes blocked, untap each creature you control. After this combat phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
             "colours": [
@@ -13683,7 +13683,7 @@
         },
         {
             "id": "e8289052-bbba-52b6-9f96-2e56050cb357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5598d3-b66b-42a2-aa43-d2785c1bfe36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5598d3-b66b-42a2-aa43-d2785c1bfe36.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia, the Law Above deals 3 damage to each of your opponents and you gain 3 life.",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "4de85fb8-6935-5f07-8f51-4ae8ab44064e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf5e45d-0f1a-4c85-a944-770fc525dc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf5e45d-0f1a-4c85-a944-770fc525dc01.jpg?1",
             "name": "Curious Cadaver",
             "text": "Flying\nWhen you sacrifice a Clue, return Curious Cadaver from your graveyard to your hand.",
             "colours": [
@@ -13764,7 +13764,7 @@
         },
         {
             "id": "4389a678-30d0-51af-ad7b-a3848d1f6e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01cf59e-b98b-4a8d-8347-07e2c1527330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01cf59e-b98b-4a8d-8347-07e2c1527330.jpg?1",
             "name": "Etrata, Deadly Fugitive",
             "text": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library.",
             "colours": [
@@ -13806,7 +13806,7 @@
         },
         {
             "id": "d543fd1b-5d42-5c04-9a07-5cbac9d03a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f05677b-ceec-4774-b22f-ff95cc6c5943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f05677b-ceec-4774-b22f-ff95cc6c5943.jpg?1",
             "name": "Ezrim, Agency Chief",
             "text": "Flying\nWhen Ezrim, Agency Chief enters the battlefield, investigate twice.\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.",
             "colours": [
@@ -13847,7 +13847,7 @@
         },
         {
             "id": "f361b1d2-f16e-58b1-8ee5-4eabfe738ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387e53fd-58b2-45ac-a604-531b75442732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387e53fd-58b2-45ac-a604-531b75442732.jpg?1",
             "name": "Gleaming Geardrake",
             "text": "Flying\nWhen Gleaming Geardrake enters the battlefield, investigate.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.",
             "colours": [
@@ -13887,7 +13887,7 @@
         },
         {
             "id": "0fedf47e-b1c0-5d35-90c3-842de46accc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c5f282-9297-4763-a04d-4147e5349953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c5f282-9297-4763-a04d-4147e5349953.jpg?1",
             "name": "Izoni, Center of the Web",
             "text": "Menace\nWhenever Izoni, Center of the Web enters the battlefield or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with menace and reach.\nSacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life.",
             "colours": [
@@ -13928,7 +13928,7 @@
         },
         {
             "id": "7f4e33bc-bc6d-5c49-bf34-411a3db79f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc220d51-b545-4414-9f2e-d3bfe53dcbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc220d51-b545-4414-9f2e-d3bfe53dcbd8.jpg?1",
             "name": "Judith, Carnage Connoisseur",
             "text": "Whenever you cast an instant or sorcery spell, choose one \u2014\n\u2022 That spell gains deathtouch and lifelink.\n\u2022 Create a 2/2 red Imp creature token with \"When this creature dies, it deals 2 damage to each opponent.\"",
             "colours": [
@@ -13969,7 +13969,7 @@
         },
         {
             "id": "76e21be4-0699-56b5-a922-f63c90f5b343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70bb7a-ba29-4fa5-b5f7-e2c71ca7df6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70bb7a-ba29-4fa5-b5f7-e2c71ca7df6f.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "Reach\nWhen Kraul Whipcracker enters the battlefield, destroy target token an opponent controls.",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "d553b2b0-692f-556c-b186-7e15ea50ac30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2260036c-cc6f-4016-8d8c-4953ce5b22d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2260036c-cc6f-4016-8d8c-4953ce5b22d3.jpg?1",
             "name": "Kylox, Visionary Inventor",
             "text": "Menace, ward {2}, haste\nWhenever Kylox, Visionary Inventor attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs.",
             "colours": [
@@ -14051,7 +14051,7 @@
         },
         {
             "id": "fc44bfe5-43b3-51f2-bbf7-8ca83ee3fee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd1791b-f12f-4e76-8276-cb1905bd2e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd1791b-f12f-4e76-8276-cb1905bd2e33.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate.\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
             "colours": [
@@ -14094,7 +14094,7 @@
         },
         {
             "id": "a6f1af62-fa44-53d7-ae08-3329313feb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d1e216-a150-4f57-bd1c-8c8c86023c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d1e216-a150-4f57-bd1c-8c8c86023c6d.jpg?1",
             "name": "Meddling Youths",
             "text": "Haste\nWhenever you attack with three or more creatures, investigate.",
             "colours": [
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "bb05a407-c711-5b08-b6c3-647aa4579006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f2fcaf-97d6-441a-bdde-fb105ffad1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f2fcaf-97d6-441a-bdde-fb105ffad1c5.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet, Guildpact deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
             "colours": [
@@ -14182,7 +14182,7 @@
         },
         {
             "id": "30dd664c-476b-50fb-9e0a-74eb916f7abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5f435-144e-4466-be0f-781664cfddb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5f435-144e-4466-be0f-781664cfddb7.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -14225,7 +14225,7 @@
         },
         {
             "id": "c45c1acd-e0c0-56e3-846d-bb08b98bb009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0870d4-b5b8-4fd7-a21b-417f832e0d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0870d4-b5b8-4fd7-a21b-417f832e0d7e.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "Deathtouch\nAt the beginning of your end step, investigate for each opponent who lost life this turn.\nWhenever a Clue you control is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -14268,7 +14268,7 @@
         },
         {
             "id": "f86fe1a2-029e-57aa-bfdd-ea3d82fd0208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acaae58-93b5-4544-84cc-98e134edb738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acaae58-93b5-4544-84cc-98e134edb738.jpg?1",
             "name": "Tolsimir, Midnight's Light",
             "text": "Lifelink\nWhen Tolsimir, Midnight's Light enters the battlefield, create Voja Fenstalker, a legendary 5/5 green and white Wolf creature token with trample.\nWhenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an opponent controls blocks that Wolf this combat if able.",
             "colours": [
@@ -14309,7 +14309,7 @@
         },
         {
             "id": "e8a62ad7-1a63-5ecf-8bfd-cb002c0d92aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839ff656-1886-4b31-8d72-dde696258a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839ff656-1886-4b31-8d72-dde696258a97.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -14352,7 +14352,7 @@
         },
         {
             "id": "17e08a2c-ca21-5c38-bbed-ded812de9974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0df81e-1700-41f0-bede-f3eb594351b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0df81e-1700-41f0-bede-f3eb594351b6.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand.\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "bc71f91a-8de0-5c7f-b240-11d3760d029c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74463d05-3928-4d55-84d4-21d65623a3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74463d05-3928-4d55-84d4-21d65623a3e6.jpg?1",
             "name": "Wispdrinker Vampire",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.\n{5}{W}{B}: Creatures you control with power 2 or less gain deathtouch and lifelink until end of turn.",
             "colours": [
@@ -14436,7 +14436,7 @@
         },
         {
             "id": "917e86d5-ad51-54ee-b451-f902da977528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2230bda5-42a9-40fa-bda4-1eabab5675f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2230bda5-42a9-40fa-bda4-1eabab5675f4.jpg?1",
             "name": "Yarus, Roar of the Old Gods",
             "text": "Other creatures you control have haste.\nWhenever one or more face-down creatures you control deal combat damage to a player, draw a card.\nWhenever a face-down creature you control dies, return it to the battlefield face down under its owner's control if it's a permanent card, then turn it face up.",
             "colours": [
@@ -14477,7 +14477,7 @@
         },
         {
             "id": "d05632f5-7d3b-5a9d-aba3-cc76eccd0679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9a827-b41d-4628-95e1-6546a8140c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9a827-b41d-4628-95e1-6546a8140c61.jpg?1",
             "name": "Magnetic Snuffler",
             "text": "When Magnetic Snuffler enters the battlefield, return target Equipment card from your graveyard to the battlefield attached to Magnetic Snuffler.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Magnetic Snuffler.",
             "colours": [],
@@ -14510,7 +14510,7 @@
         },
         {
             "id": "18945240-3690-5a88-b29a-1a751b73a492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd20526-024a-4a08-8f86-f5d7c2d7e8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd20526-024a-4a08-8f86-f5d7c2d7e8e7.jpg?1",
             "name": "Aurelia's Vindicator",
             "text": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -14546,7 +14546,7 @@
         },
         {
             "id": "6ca947fe-9e66-58b1-8f19-7094899acdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063654b-6e4e-4958-a63c-24cf933e4a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063654b-6e4e-4958-a63c-24cf933e4a40.jpg?1",
             "name": "Delney, Streetwise Lookout",
             "text": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
             "colours": [
@@ -14585,7 +14585,7 @@
         },
         {
             "id": "1c1c6134-5640-5605-af50-55ca8d09e88d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8002174-8cff-4566-ba4d-d6caec14d69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8002174-8cff-4566-ba4d-d6caec14d69c.jpg?1",
             "name": "Conspiracy Unraveler",
             "text": "Flying\nYou may collect evidence 10 rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -14622,7 +14622,7 @@
         },
         {
             "id": "1f3563fa-905a-5499-8742-23cd860ebcb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae24a4c2-6a19-4e26-902a-cdf73d9f3608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae24a4c2-6a19-4e26-902a-cdf73d9f3608.jpg?1",
             "name": "Massacre Girl, Known Killer",
             "text": "",
             "colours": [
@@ -14661,7 +14661,7 @@
         },
         {
             "id": "21c51c89-fbab-55c3-8f99-6e46b29d5726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321fe5e9-50c4-4b96-883a-2d9b10f2172f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321fe5e9-50c4-4b96-883a-2d9b10f2172f.jpg?1",
             "name": "Incinerator of the Guilty",
             "text": "Flying, trample\nWhenever Incinerator of the Guilty deals combat damage to a player, you may collect evidence X. When you do, Incinerator of the Guilty deals X damage to each creature and each planeswalker that player controls.",
             "colours": [
@@ -14697,7 +14697,7 @@
         },
         {
             "id": "d49acd18-d7b7-513f-aaad-24b5a95424e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99027565-f009-48d6-a7d0-fec1afff0611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99027565-f009-48d6-a7d0-fec1afff0611.jpg?1",
             "name": "The Pride of Hull Clade",
             "text": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
             "colours": [
@@ -14738,7 +14738,7 @@
         },
         {
             "id": "9011ef5c-a7ae-5896-bbd7-6a7a1ed434ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fc7b85-a321-4259-9fe6-a107d6d79819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fc7b85-a321-4259-9fe6-a107d6d79819.jpg?1",
             "name": "Agrus Kos, Spirit of Justice",
             "text": "Double strike, vigilance\nWhenever Agrus Kos, Spirit of Justice enters the battlefield or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it.",
             "colours": [
@@ -14779,7 +14779,7 @@
         },
         {
             "id": "389f6c13-4d1e-5eb8-a04a-748ccb1ec012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c4f8d2-1e9c-41e1-9991-8125cd7151a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c4f8d2-1e9c-41e1-9991-8125cd7151a5.jpg?1",
             "name": "Alquist Proft, Master Sleuth",
             "text": "Vigilance\nWhen Alquist Proft, Master Sleuth enters the battlefield, investigate.\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
             "colours": [
@@ -14820,7 +14820,7 @@
         },
         {
             "id": "3380cfac-b949-5f5a-a974-f66f6a835e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c7933b-a65a-4032-a652-1a29b26de2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c7933b-a65a-4032-a652-1a29b26de2c8.jpg?1",
             "name": "Anzrag, the Quake-Mole",
             "text": "Whenever Anzrag, the Quake-Mole becomes blocked, untap each creature you control. After this combat phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
             "colours": [
@@ -14861,7 +14861,7 @@
         },
         {
             "id": "272ea0d9-3881-5ea8-8f9b-4cacbe7717d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b70f7a-8e77-4a99-8d13-7465a190630e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b70f7a-8e77-4a99-8d13-7465a190630e.jpg?1",
             "name": "Etrata, Deadly Fugitive",
             "text": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library.",
             "colours": [
@@ -14902,7 +14902,7 @@
         },
         {
             "id": "bbb93d2d-657c-5a4b-bcb0-5ff9eddb988a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8ed51-897f-4587-a234-dd3e051fab3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8ed51-897f-4587-a234-dd3e051fab3f.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -14944,7 +14944,7 @@
         },
         {
             "id": "e118125c-23c4-57d8-96da-d7a414262664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe1969-e30c-4f07-90b0-3d9699a09f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe1969-e30c-4f07-90b0-3d9699a09f1b.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -14986,7 +14986,7 @@
         },
         {
             "id": "9f3e53e7-4236-5901-b8c2-bf0dcb290714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1b9d5f-fb88-49ea-ab56-ea6e78ea2077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1b9d5f-fb88-49ea-ab56-ea6e78ea2077.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand.\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -15030,7 +15030,7 @@
         },
         {
             "id": "1dbeb71c-d9fd-5bf1-a6d3-1def6660859e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d327d7d-1c01-4af1-8a6f-ce6cded4119d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d327d7d-1c01-4af1-8a6f-ce6cded4119d.jpg?1",
             "name": "No Witnesses",
             "text": "Each player who controls the most creatures investigates. Then destroy all creatures.",
             "colours": [
@@ -15064,7 +15064,7 @@
         },
         {
             "id": "91947789-1ea5-5b27-babe-bcd073eb20a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2adffd5-ddc1-41ef-9442-2fbc17153f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2adffd5-ddc1-41ef-9442-2fbc17153f3d.jpg?1",
             "name": "Tenth District Hero",
             "text": "{1}{W}, Collect evidence 2: Tenth District Hero becomes a Human Detective with base power and toughness 4/4 and gains vigilance.\n{2}{W}, Collect evidence 4: If Tenth District Hero is a Detective, it becomes a legendary creature named Mileva, the Stalwart, it has base power and toughness 5/5, and it gains \"Other creatures you control have indestructible.\"",
             "colours": [
@@ -15100,7 +15100,7 @@
         },
         {
             "id": "3b380219-8526-520b-b035-08e5989064ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349bcef-4ec5-4160-96ef-302d825f3888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349bcef-4ec5-4160-96ef-302d825f3888.jpg?1",
             "name": "Unyielding Gatekeeper",
             "text": "Disguise {1}{W}\nWhen Unyielding Gatekeeper is turned face up, exile another target nonland permanent. If you controlled it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue Detective creature token.",
             "colours": [
@@ -15137,7 +15137,7 @@
         },
         {
             "id": "e936ceb6-0fab-570a-9ab1-e79de43697cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e5b027-7cd5-4343-b029-f4d197e1f1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e5b027-7cd5-4343-b029-f4d197e1f1da.jpg?1",
             "name": "Coveted Falcon",
             "text": "Flying\nWhenever Coveted Falcon attacks, gain control of target permanent you own but don\u2018t control.\nDisguise {1}{U}\nWhen Coveted Falcon is turned face up, target opponent gains control of any number of target permanents you control. Draw a card for each one they gained control of this way.",
             "colours": [
@@ -15174,7 +15174,7 @@
         },
         {
             "id": "4b3af3c7-1043-5ad5-8e51-8c488223a032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3faa376-7391-4084-8b57-15d71ab07cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3faa376-7391-4084-8b57-15d71ab07cbd.jpg?1",
             "name": "Cryptic Coat",
             "text": "When Cryptic Coat enters the battlefield, cloak the top card of your library, then attach Cryptic Coat to it.\nEquipped creature gets +1/+0 and can't be blocked.\n{1}{U}: Return Cryptic Coat to its owner's hand.",
             "colours": [
@@ -15210,7 +15210,7 @@
         },
         {
             "id": "d91f6dbc-9a1a-5c29-82a3-d0a32743f865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5a56a-3017-4f08-802d-e6f9d246c754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5a56a-3017-4f08-802d-e6f9d246c754.jpg?1",
             "name": "Lost in the Maze",
             "text": "Flash\nWhen Lost in the Maze enters the battlefield, tap X target creatures. Put a stun counter on each of those creatures you don't control.\nTapped creatures you control have hexproof.",
             "colours": [
@@ -15244,7 +15244,7 @@
         },
         {
             "id": "ae89a0da-5dc2-5e27-8c36-dd5456a61fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3472756-0305-4567-b425-f7dbf9b3cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3472756-0305-4567-b425-f7dbf9b3cc7f.jpg?1",
             "name": "Proft's Eidetic Memory",
             "text": "When Proft's Eidetic Memory enters the battlefield, draw a card.\nYou have no maximum hand size.\nAt the beginning of combat on your turn, if you've drawn more than one card this turn, put X +1/+1 counters on target creature you control, where X is the number of cards you've drawn this turn minus one.",
             "colours": [
@@ -15280,7 +15280,7 @@
         },
         {
             "id": "29bed373-b1ce-5dfc-abba-92db55431d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f0ac41-3f03-4480-aea8-41ec0a024671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f0ac41-3f03-4480-aea8-41ec0a024671.jpg?1",
             "name": "Steamcore Scholar",
             "text": "Flying, vigilance\nWhen Steamcore Scholar enters the battlefield, draw two cards. Then discard two cards unless you discard an instant or sorcery card or a creature card with flying.",
             "colours": [
@@ -15317,7 +15317,7 @@
         },
         {
             "id": "b77e225b-12af-5999-aa1e-18d401171a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7330586a-9614-4373-b455-ee5fb09ed262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7330586a-9614-4373-b455-ee5fb09ed262.jpg?1",
             "name": "Barbed Servitor",
             "text": "Indestructible\nWhen Barbed Servitor enters the battlefield, suspect it.\nWhenever Barbed Servitor deals combat damage to a player, you draw a card and you lose 1 life.\nWhenever Barbed Servitor is dealt damage, target opponent loses that much life.",
             "colours": [
@@ -15354,7 +15354,7 @@
         },
         {
             "id": "0bff19db-6c74-5290-af82-2067e737a075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f667e6-c27d-4055-8ddb-ea6cbcde6e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f667e6-c27d-4055-8ddb-ea6cbcde6e4e.jpg?1",
             "name": "Deadly Cover-Up",
             "text": "As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -15388,7 +15388,7 @@
         },
         {
             "id": "d866142c-a604-52c2-bbae-4b4875191f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edff2c6-a259-4442-9e21-07572d0d1665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edff2c6-a259-4442-9e21-07572d0d1665.jpg?1",
             "name": "Hunted Bonebrute",
             "text": "Menace\nWhen Hunted Bonebrute enters the battlefield, target opponent creates two 1/1 white Dog creature tokens.\nWhen Hunted Bonebrute dies, each opponent loses 3 life.\nDisguise {1}{B}",
             "colours": [
@@ -15425,7 +15425,7 @@
         },
         {
             "id": "c3f39291-299e-564b-a96a-91eaf8b72f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436f52c-b780-4d16-a62f-e1b339356a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436f52c-b780-4d16-a62f-e1b339356a39.jpg?1",
             "name": "Illicit Masquerade",
             "text": "Flash\nWhen Illicit Masquerade enters the battlefield, put an impostor counter on each creature you control.\nWhenever a creature you control with an impostor counter on it dies, exile it. Return up to one other target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -15459,7 +15459,7 @@
         },
         {
             "id": "4e580ab1-04ad-54ed-8f98-fac4e54e4fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d8304d-59e3-4478-911d-54d77abfe69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d8304d-59e3-4478-911d-54d77abfe69c.jpg?1",
             "name": "Outrageous Robbery",
             "text": "Target opponent exiles the top X cards of their library face down. You may look at and play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any type to cast it.",
             "colours": [
@@ -15493,7 +15493,7 @@
         },
         {
             "id": "46806453-9d9c-533c-9019-861e6f11b782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597b8c60-d06b-425b-9fca-f2e3dfb45623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597b8c60-d06b-425b-9fca-f2e3dfb45623.jpg?1",
             "name": "Connecting the Dots",
             "text": "Whenever a creature you control attacks, exile the top card of your library face down. (You can't look at it.)\n{1}{R}, Discard your hand, Sacrifice Connecting the Dots: Put all cards exiled with Connecting the Dots into their owners' hands.",
             "colours": [
@@ -15527,7 +15527,7 @@
         },
         {
             "id": "75c0892d-9c6a-558e-b6c7-a4c6f7947588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538c112a-203e-4b3e-ae1d-6eb7824fe68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538c112a-203e-4b3e-ae1d-6eb7824fe68a.jpg?1",
             "name": "Expedited Inheritance",
             "text": "Whenever a creature is dealt damage, its controller may exile that many cards from the top of their library. They may play those cards until the end of their next turn.",
             "colours": [
@@ -15561,7 +15561,7 @@
         },
         {
             "id": "cad1b7b1-0f9a-5df7-ab83-9debe71cbcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebec98c-a935-48c3-ba2f-80c70079929d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebec98c-a935-48c3-ba2f-80c70079929d.jpg?1",
             "name": "Krenko's Buzzcrusher",
             "text": "Flying, trample\nWhen Krenko's Buzzcrusher enters the battlefield, for each player, destroy up to one nonbasic land that player controls. For each land destroyed this way, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -15599,7 +15599,7 @@
         },
         {
             "id": "5764c446-1f0e-53d0-8d7a-a7617d94eca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9549ad7-5eb3-4672-a0f5-cad96db011c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9549ad7-5eb3-4672-a0f5-cad96db011c3.jpg?1",
             "name": "Lamplight Phoenix",
             "text": "Flying\nWhen Lamplight Phoenix dies, you may exile it and collect evidence 4. If you do, return Lamplight Phoenix to the battlefield tapped.",
             "colours": [
@@ -15635,7 +15635,7 @@
         },
         {
             "id": "136501dc-d51b-5509-8c6b-5933c53af7a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348027a1-1fb4-4473-b77e-b961e00a22b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348027a1-1fb4-4473-b77e-b961e00a22b7.jpg?1",
             "name": "Pyrotechnic Performer",
             "text": "Disguise {R}\nWhenever Pyrotechnic Performer or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.",
             "colours": [
@@ -15672,7 +15672,7 @@
         },
         {
             "id": "be902e97-71ef-5f94-89c4-83fcc3c652c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c2c17b-889b-416b-af58-c4039efec2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c2c17b-889b-416b-af58-c4039efec2bb.jpg?1",
             "name": "Archdruid's Charm",
             "text": "Choose one \u2014\n\u2022 Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n\u2022 Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control.\n\u2022 Exile target artifact or enchantment.",
             "colours": [
@@ -15706,7 +15706,7 @@
         },
         {
             "id": "86bec418-7629-5d69-85c7-ac4db035d5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a057ac-c9f9-4cf6-896f-e18976bdfb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a057ac-c9f9-4cf6-896f-e18976bdfb38.jpg?1",
             "name": "Axebane Ferox",
             "text": "Deathtouch, haste\nWard\u2014\nCollect evidence 4.",
             "colours": [
@@ -15743,7 +15743,7 @@
         },
         {
             "id": "e1666bfc-6467-5948-b1a8-595b90d4698d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c69f3-3c83-41e9-b389-21235a2dc5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c69f3-3c83-41e9-b389-21235a2dc5cd.jpg?1",
             "name": "Hide in Plain Sight",
             "text": "Look at the top five cards of your library, cloak two of them, and put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -15777,7 +15777,7 @@
         },
         {
             "id": "d7dec1eb-d192-5430-89b8-1c1c700b601d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c0e63c-ca4e-4991-89f1-dc4c22189372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c0e63c-ca4e-4991-89f1-dc4c22189372.jpg?1",
             "name": "Undergrowth Recon",
             "text": "At the beginning of your upkeep, return target land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -15811,7 +15811,7 @@
         },
         {
             "id": "debc72bf-435d-54f0-bdc6-98353707acb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6644d62-3d2a-4db1-a387-736fcad9a851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6644d62-3d2a-4db1-a387-736fcad9a851.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -15847,7 +15847,7 @@
         },
         {
             "id": "f7f7d0a9-9df0-5aef-9322-f1750083087b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a68f5-62ef-40c9-8a40-e7b79619f719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a68f5-62ef-40c9-8a40-e7b79619f719.jpg?1",
             "name": "Blood Spatter Analysis",
             "text": "When Blood Spatter Analysis enters the battlefield, it deals 3 damage to target creature an opponent controls.\nWhenever one or more creatures die, mill a card and put a bloodstain counter on Blood Spatter Analysis. Then sacrifice it if it has five or more bloodstain counters on it. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15883,7 +15883,7 @@
         },
         {
             "id": "98d64cf1-add1-5071-ae34-46956ededdc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db9df42-042d-48a0-ac28-228b72a0b19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db9df42-042d-48a0-ac28-228b72a0b19a.jpg?1",
             "name": "Doppelgang",
             "text": "For each of X target permanents, create X tokens that are copies of that permanent.",
             "colours": [
@@ -15919,7 +15919,7 @@
         },
         {
             "id": "6813fe90-725c-5a7f-994b-98fcbef71dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066fed99-5aa5-42db-9472-240cfc2f4f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066fed99-5aa5-42db-9472-240cfc2f4f42.jpg?1",
             "name": "Drag the Canal",
             "text": "Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate.",
             "colours": [
@@ -15955,7 +15955,7 @@
         },
         {
             "id": "4f9a0747-fdb0-59fe-a991-ac628ffe2e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cddd86f-2eaa-41ad-8f97-bd18bfa2f766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cddd86f-2eaa-41ad-8f97-bd18bfa2f766.jpg?1",
             "name": "Ill-Timed Explosion",
             "text": "Draw two cards. Then you may discard two cards. When you do, Ill-Timed Explosion deals X damage to each creature, where X is the greatest mana value among cards discarded this way.",
             "colours": [
@@ -15991,7 +15991,7 @@
         },
         {
             "id": "2312b0aa-2821-527c-9e52-0495ba1a1ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b524c71-c2ac-4a08-8ab7-27b1c232a359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b524c71-c2ac-4a08-8ab7-27b1c232a359.jpg?1",
             "name": "Kylox's Voltstrider",
             "text": "Collect evidence 6: Kylox's Voltstrider becomes an artifact creature until end of turn.\nWhenever Kylox's Voltstrider attacks, you may cast an instant or sorcery spell from among cards exiled with it. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.\nCrew 2",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "3134c790-1fca-5d5f-9527-b6c106c05678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549370b-f32d-48f0-877c-05e6fd1daf7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549370b-f32d-48f0-877c-05e6fd1daf7b.jpg?1",
             "name": "Leyline of the Guildpact",
             "text": "If Leyline of the Guildpact is in your opening hand, you may begin the game with it on the battlefield.\nEach nonland permanent you control is all colors.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -16071,7 +16071,7 @@
         },
         {
             "id": "a7e3957c-9fed-55a8-be4e-a03d9e4caeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffadebd-a7ef-4a75-918a-284d509b11c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffadebd-a7ef-4a75-918a-284d509b11c5.jpg?1",
             "name": "Relive the Past",
             "text": "Return up to one target artifact card, up to one target land card, and up to one target non-Aura enchantment card from your graveyard to the battlefield. They are 5/5 Elemental creatures in addition to their other types.",
             "colours": [
@@ -16107,7 +16107,7 @@
         },
         {
             "id": "7a2ad7e6-56f3-581c-9e18-1e3b722a1c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0ee59f-439a-47ab-b543-e0e013419f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0ee59f-439a-47ab-b543-e0e013419f12.jpg?1",
             "name": "Treacherous Greed",
             "text": "As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.\nDraw three cards. Each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "cee6d1e1-0024-5be8-98af-842cf1dd7426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe89b207-04a4-4cdc-95a2-07c7761b885e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe89b207-04a4-4cdc-95a2-07c7761b885e.jpg?1",
             "name": "Urgent Necropsy",
             "text": "As an additional cost to cast this spell, collect evidence X, where X is the total mana value of the permanents this spell targets.\nDestroy up to one target artifact, up to one target creature, up to one target enchantment, and up to one target planeswalker.",
             "colours": [
@@ -16179,7 +16179,7 @@
         },
         {
             "id": "73fdc534-bcdb-58a1-bde3-d95c04af9939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17938b40-a4a3-4150-a94c-ecddbed3ccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17938b40-a4a3-4150-a94c-ecddbed3ccfc.jpg?1",
             "name": "Cryptex",
             "text": "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on Cryptex.\nSacrifice Cryptex: Surveil 3, then draw three cards. Activate only if Cryptex has five or more unlock counters on it.",
             "colours": [],
@@ -16209,7 +16209,7 @@
         },
         {
             "id": "fff4430a-b314-5dab-9de0-fb5e7535b2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a8889-1323-4268-b34c-146c4136fd53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a8889-1323-4268-b34c-146c4136fd53.jpg?1",
             "name": "Long Goodbye",
             "text": "This spell can't be countered.\nDestroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -16243,7 +16243,7 @@
         },
         {
             "id": "8d62bb7b-1bfe-53df-9187-d83361a118fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b6cd91-8178-4c5c-9cb1-f3d970fe3b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b6cd91-8178-4c5c-9cb1-f3d970fe3b03.jpg?1",
             "name": "Gleaming Geardrake",
             "text": "Flying\nWhen Gleaming Geardrake enters the battlefield, investigate.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.",
             "colours": [
@@ -16283,7 +16283,7 @@
         },
         {
             "id": "7b006931-ae30-5462-bb66-7bb3edcbe5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd02c8-7b28-4128-b2fc-d961e565a147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd02c8-7b28-4128-b2fc-d961e565a147.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "Reach\nWhen Kraul Whipcracker enters the battlefield, destroy target token an opponent controls.",
             "colours": [
@@ -16324,7 +16324,7 @@
         },
         {
             "id": "318d0ab3-2514-5852-bc78-de893fa69137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e478972-27a6-4a89-a8d7-cb1abdd9f0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e478972-27a6-4a89-a8d7-cb1abdd9f0d9.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -16360,7 +16360,7 @@
         },
         {
             "id": "669be5ab-16b2-50cd-890a-f0ba2634eafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c882d46-c26c-47f1-96ce-b0676f345b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c882d46-c26c-47f1-96ce-b0676f345b89.jpg?1",
             "name": "No More Lies",
             "text": "Counter target spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -16396,7 +16396,7 @@
         },
         {
             "id": "3d459fbd-76c6-5dc0-8f38-b0f115053a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd5e33-5a58-4321-8742-236d6cc6f4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd5e33-5a58-4321-8742-236d6cc6f4f4.jpg?1",
             "name": "Axebane Ferox",
             "text": "Deathtouch, haste\nWard\u2014\nCollect evidence 4. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player exiles cards with total mana value 4 or greater from their graveyard.)",
             "colours": [
@@ -16432,7 +16432,7 @@
         },
         {
             "id": "c592c285-f1ee-5740-b4cd-e888e298c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eccc85-bdfe-48f4-a79e-76d9ef122815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eccc85-bdfe-48f4-a79e-76d9ef122815.jpg?1",
             "name": "Wojek Investigator",
             "text": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you.",
             "colours": [
@@ -16470,7 +16470,7 @@
         },
         {
             "id": "7c8de30e-0bae-56f2-bf2c-fc1bc1bf7cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5ede0-a098-4f21-8b7e-795a83e75aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5ede0-a098-4f21-8b7e-795a83e75aae.jpg?1",
             "name": "Melek, Reforged Researcher",
             "text": "Melek, Reforged Researcher's power and toughness are each equal to twice the number of instant and sorcery cards in your graveyard.\nThe first instant or sorcery spell you cast each turn costs {3} less to cast.",
             "colours": [
@@ -16508,7 +16508,7 @@
         },
         {
             "id": "a4cd2e06-df57-5bf5-9e53-5a36272b53a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7550-fe1a-4797-9583-70ab56cfac0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7550-fe1a-4797-9583-70ab56cfac0d.jpg?1",
             "name": "Tomik, Wielder of Law",
             "text": "Affinity for planeswalkers (This spell costs {1} less to cast for each planeswalker you control.)\nFlying, vigilance\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, that opponent loses 3 life and you draw a card.",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "2b58868e-0dab-5a3e-9218-d94cbfbc4f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1bd2f-25bd-4fbd-877b-cef00ab7f92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1bd2f-25bd-4fbd-877b-cef00ab7f92f.jpg?1",
             "name": "Voja, Jaws of the Conclave",
             "text": "Vigilance, trample, ward {3}\nWhenever Voja, Jaws of the Conclave attacks, put X +1/+1 counters on each creature you control, where X is the number of Elves you control. Draw a card for each Wolf you control.",
             "colours": [
@@ -16585,7 +16585,7 @@
         },
         {
             "id": "172269e3-9b8b-5e05-91e0-894fe07d4f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7be0f36-9acd-457b-bdfa-77be787be5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7be0f36-9acd-457b-bdfa-77be787be5c3.jpg?1",
             "name": "Vein Ripper",
             "text": "Flying\nWard\u2014\nSacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -16622,7 +16622,7 @@
         },
         {
             "id": "6f222117-73e0-5b15-8f8d-529bfa2cdbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf03be-294a-4539-954c-79853f4351a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf03be-294a-4539-954c-79853f4351a9.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "f4991ff1-b597-5f15-9a8e-9724ae5ee3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd1de1-9657-4262-be11-8279b3408e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd1de1-9657-4262-be11-8279b3408e54.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -16692,7 +16692,7 @@
         },
         {
             "id": "ea2f86f5-bc5a-58d4-8ae6-116f9a5981c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ce61b-480a-4da6-80f6-63e096902ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ce61b-480a-4da6-80f6-63e096902ae6.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -16727,7 +16727,7 @@
         },
         {
             "id": "40d0e746-6be8-592b-921b-67f31f9c68ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677bd8b5-d751-4d17-9e6f-55eb2c30c3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677bd8b5-d751-4d17-9e6f-55eb2c30c3ed.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "a3a8ccfa-230d-5c26-8b80-d0993fd4ba97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02404852-5788-4adb-b2dc-98bf705d8d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02404852-5788-4adb-b2dc-98bf705d8d96.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -16797,7 +16797,7 @@
         },
         {
             "id": "9ac7e305-d4ff-57c5-8aa0-d0b1272b7212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cd0d3-7973-49e6-9c1c-6f516a5d5fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cd0d3-7973-49e6-9c1c-6f516a5d5fe5.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16832,7 +16832,7 @@
         },
         {
             "id": "a52750b3-3a65-5300-96f3-0222857b9d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1385b-2be2-49a8-8400-186cd5525dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1385b-2be2-49a8-8400-186cd5525dad.jpg?1",
             "name": "Imp",
             "text": "",
             "colours": [
@@ -16867,7 +16867,7 @@
         },
         {
             "id": "f8dacdc5-2e85-5385-8f67-e1fcc92a738d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b37032-9660-4dfb-9629-c4e8eddc43b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b37032-9660-4dfb-9629-c4e8eddc43b0.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -16902,7 +16902,7 @@
         },
         {
             "id": "eb7bf20b-ea05-5471-8ba9-e9c3b3bb77b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92091012-856c-4b42-9e22-405112c39edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92091012-856c-4b42-9e22-405112c39edd.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -16937,7 +16937,7 @@
         },
         {
             "id": "4c84fc07-0117-5360-9426-02f030e51f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a109aa-99d4-4cfe-a9b1-1b40db5b7885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a109aa-99d4-4cfe-a9b1-1b40db5b7885.jpg?1",
             "name": "Detective",
             "text": "",
             "colours": [
@@ -16974,7 +16974,7 @@
         },
         {
             "id": "806b3bc5-ffdc-511c-a96f-92be64ad12d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -17011,7 +17011,7 @@
         },
         {
             "id": "e00e04e7-7717-50ba-9862-5b446921ecae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17048,7 +17048,7 @@
         },
         {
             "id": "c166de59-5e3f-5bab-a3dd-abbb9f2bdd0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2175200f-3ed4-4b39-ac76-a7d25967aa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2175200f-3ed4-4b39-ac76-a7d25967aa8a.jpg?1",
             "name": "Voja Fenstalker",
             "text": "",
             "colours": [
@@ -17087,7 +17087,7 @@
         },
         {
             "id": "97bab7f2-472c-50d6-9686-180c947cc457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee022200-f589-4f06-8de8-d313e29f7be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee022200-f589-4f06-8de8-d313e29f7be8.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17118,7 +17118,7 @@
         },
         {
             "id": "9bf154c7-6242-5c33-9ff7-54eecc0771bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8c41b5-beec-4fd1-bbfa-20fbc7f44307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8c41b5-beec-4fd1-bbfa-20fbc7f44307.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17149,7 +17149,7 @@
         },
         {
             "id": "d2d3de02-7f08-5e0f-a3c4-8117096fa45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233d3d41-1559-464a-a41e-096eb3b8a968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233d3d41-1559-464a-a41e-096eb3b8a968.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17180,7 +17180,7 @@
         },
         {
             "id": "3ceaed1b-4c1a-50ef-b42a-fc1259368500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576b691a-9cb1-4c2e-93cf-42f52f587bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576b691a-9cb1-4c2e-93cf-42f52f587bff.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17211,7 +17211,7 @@
         },
         {
             "id": "9a9827e0-4bbe-56ff-8e04-064bd0c5cfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef607895-d6d2-44ab-a6b4-84af55fce593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef607895-d6d2-44ab-a6b4-84af55fce593.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17242,7 +17242,7 @@
         },
         {
             "id": "41e3bd0b-1a07-571a-997d-db549c64497f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ad97f4-cc41-493c-9848-c06f3cf778c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ad97f4-cc41-493c-9848-c06f3cf778c7.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -17274,7 +17274,7 @@
         },
         {
             "id": "2bd4585e-48e5-58a6-a684-9f1672cb99a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80c5f0a-5573-4dc2-8791-35e35bdf4c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80c5f0a-5573-4dc2-8791-35e35bdf4c78.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -17306,7 +17306,7 @@
         },
         {
             "id": "f5b1634e-a14b-51d6-a679-356f7f0ac60f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241b3b6d-a25f-4a43-b5d6-1d1079e7e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241b3b6d-a25f-4a43-b5d6-1d1079e7e498.jpg?1",
             "name": "A Mysterious Creature",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MM2.json
+++ b/Assets/Resources/Sets/MM2.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3469ae47-c0d4-5252-89e4-154448a2efb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c9f6dd-308e-4c91-8bcc-975d273a0a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c9f6dd-308e-4c91-8bcc-975d273a0a33.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all colored permanents he or she controls.",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "b6e66ba1-5aa3-5a3e-a987-e7cd40e10be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79dedcf-ecba-49a1-81dc-7e3bdb7abefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79dedcf-ecba-49a1-81dc-7e3bdb7abefd.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast Artisan of Kozilek, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "c7cc7830-911b-5a51-b5ab-3bd00447d432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3197aa08-9fb1-47d2-b873-432700cb790e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3197aa08-9fb1-47d2-b873-432700cb790e.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "Emrakul, the Aeons Torn can't be countered.\nWhen you cast Emrakul, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "03cbf8b6-6be5-5ae1-a40a-b5d17772d422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1deda0-c99d-4570-a5dd-f51eb5d12570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1deda0-c99d-4570-a5dd-f51eb5d12570.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from his or her hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -129,7 +129,7 @@
         },
         {
             "id": "30ccc583-cdf1-5cbc-8c1d-d32a5904cea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc70f3b-844e-428c-a8cd-d6c6a55b925a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc70f3b-844e-428c-a8cd-d6c6a55b925a.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast Kozilek, Butcher of Truth, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -161,7 +161,7 @@
         },
         {
             "id": "b418cb0d-e389-546f-80a1-4d333373db5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a056241d-513a-4de7-a604-bf8248c31225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a056241d-513a-4de7-a604-bf8248c31225.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast Ulamog, the Infinite Gyre, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -193,7 +193,7 @@
         },
         {
             "id": "dc8ddaf0-9007-50cc-8afe-fdd372718068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54baced-fabe-4ed6-9203-5bb5fbb64007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54baced-fabe-4ed6-9203-5bb5fbb64007.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each turn if able.",
             "colours": [],
@@ -223,7 +223,7 @@
         },
         {
             "id": "cd70ded6-4a05-5621-8c16-6e721c3f3452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfbc07e-d726-4d42-9394-6aa0f5fc3a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfbc07e-d726-4d42-9394-6aa0f5fc3a3a.jpg?1",
             "name": "Apostle's Blessing",
             "text": "({PW} can be paid with either {W} or 2 life.)\nTarget artifact or creature you control gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -255,7 +255,7 @@
         },
         {
             "id": "6d147a1a-a243-535b-9d17-8c533a0d0fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0be19-e041-4347-a51c-7e93a3d9e712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0be19-e041-4347-a51c-7e93a3d9e712.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "c476c37c-9de6-5d26-a4f2-c23656258102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf72b23-a951-4e88-a52b-b3abe8f16bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf72b23-a951-4e88-a52b-b3abe8f16bf4.jpg?1",
             "name": "Battlegrace Angel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains lifelink until end of turn.",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "44a94851-8526-52a2-847c-18af3f803fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd38afd4-d7a4-493d-bdea-72be9a1d9a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd38afd4-d7a4-493d-bdea-72be9a1d9a07.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "630ff113-a71a-5691-ad88-b9159927af19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04435b25-1a44-493f-810e-23d260f363a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04435b25-1a44-493f-810e-23d260f363a6.jpg?1",
             "name": "Conclave Phalanx",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Conclave Phalanx enters the battlefield, you gain 1 life for each creature you control.",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "ea0c162b-7cb4-5c52-b817-8abb0af008a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61aded-0007-48fb-b1d6-1c69a8703400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61aded-0007-48fb-b1d6-1c69a8703400.jpg?1",
             "name": "Court Homunculus",
             "text": "Court Homunculus gets +1/+1 as long as you control another artifact.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "eda16b19-de1d-5584-bda2-ec24df6ab8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6f35e-26b4-465d-9026-ffaa869c7722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6f35e-26b4-465d-9026-ffaa869c7722.jpg?1",
             "name": "Daybreak Coronet",
             "text": "Enchant creature with another Aura attached to it\nEnchanted creature gets +3/+3 and has first strike, vigilance, and lifelink.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "fb8e306c-50ce-5892-b213-9c85c31cda80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242aeb96-0163-4d3d-9cc1-43c37a9278f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242aeb96-0163-4d3d-9cc1-43c37a9278f5.jpg?1",
             "name": "Dispatch",
             "text": "Tap target creature.\nMetalcraft \u2014 If you control three or more artifacts, exile that creature.",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "c2d2179d-50a0-53e9-ae54-f17bb537ebde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ecbe1d-2ad7-4cbb-8392-f41f107356db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ecbe1d-2ad7-4cbb-8392-f41f107356db.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "Vigilance\nOther creatures you control get +2/+2.\nCreatures your opponents control get -2/-2.",
             "colours": [
@@ -528,7 +528,7 @@
         },
         {
             "id": "2483540d-79e0-5712-b251-09fb78781e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fa2bb8-005f-4a34-820e-9bfee7268691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fa2bb8-005f-4a34-820e-9bfee7268691.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -560,7 +560,7 @@
         },
         {
             "id": "f09cf60e-125f-5af9-b8d4-53bb87c0c5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3e29ea-c907-4185-986c-f0dabd3b3855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3e29ea-c907-4185-986c-f0dabd3b3855.jpg?1",
             "name": "Hikari, Twilight Guardian",
             "text": "Flying\nWhenever you cast a Spirit or Arcane spell, you may exile Hikari, Twilight Guardian. If you do, return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -596,7 +596,7 @@
         },
         {
             "id": "97220d5d-c043-59c2-a8af-c3e269688df8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94810748-7c70-4491-a355-c7c56cc03df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94810748-7c70-4491-a355-c7c56cc03df0.jpg?1",
             "name": "Indomitable Archangel",
             "text": "Flying\nMetalcraft \u2014 Artifacts you control have shroud as long as you control three or more artifacts. (An artifact with shroud can't be the target of spells or abilities.)",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "ae68949e-9557-53d0-b194-fbf99e395251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197b59e-1652-496c-a038-e2eb88ecf017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197b59e-1652-496c-a038-e2eb88ecf017.jpg?1",
             "name": "Iona, Shield of Emeria",
             "text": "Flying\nAs Iona, Shield of Emeria enters the battlefield, choose a color.\nYour opponents can't cast spells of the chosen color.",
             "colours": [
@@ -666,7 +666,7 @@
         },
         {
             "id": "fbfdd248-a110-502e-b70e-198c13d3cee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c92c0b-232b-4786-8cd6-6eb207eed8d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c92c0b-232b-4786-8cd6-6eb207eed8d5.jpg?1",
             "name": "Kami of Ancient Law",
             "text": "Sacrifice Kami of Ancient Law: Destroy target enchantment.",
             "colours": [
@@ -700,7 +700,7 @@
         },
         {
             "id": "efcba597-0170-5fab-81fe-9e7080102179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd85ac-e826-4b16-b9ab-864ae2cabed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd85ac-e826-4b16-b9ab-864ae2cabed1.jpg?1",
             "name": "Kor Duelist",
             "text": "As long as Kor Duelist is equipped, it has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -735,7 +735,7 @@
         },
         {
             "id": "c81a8a5b-7ab4-523c-841e-ed475a44c518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3346cb1-c593-4221-b27a-fa5d0caf620f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3346cb1-c593-4221-b27a-fa5d0caf620f.jpg?1",
             "name": "Leyline of Sanctity",
             "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -767,7 +767,7 @@
         },
         {
             "id": "d0fc28c6-24c5-5b47-9ea9-fd5130193c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78494f6-ef4e-4f31-b8e3-feab4bbcb279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78494f6-ef4e-4f31-b8e3-feab4bbcb279.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "ccc439b2-9969-5c0c-8450-9a8331fa7cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c34f5d-0430-4036-a633-1a68a0d2fc65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c34f5d-0430-4036-a633-1a68a0d2fc65.jpg?1",
             "name": "Mirran Crusader",
             "text": "Double strike, protection from black and from green",
             "colours": [
@@ -834,7 +834,7 @@
         },
         {
             "id": "7d6e3f00-1a93-53c8-a4f3-d0c6512af1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9819bc-5da2-4b0c-b5d4-c99b2914bb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9819bc-5da2-4b0c-b5d4-c99b2914bb6f.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type at all times.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
             "colours": [
@@ -868,7 +868,7 @@
         },
         {
             "id": "6915b93d-9f06-5e7f-b37e-34cc345da370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fe00af-1634-45bd-bf1b-42997c4c3359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fe00af-1634-45bd-bf1b-42997c4c3359.jpg?1",
             "name": "Moonlit Strider",
             "text": "Sacrifice Moonlit Strider: Target creature you control gains protection from the color of your choice until end of turn.\nSoulshift 3 (When this creature dies, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "395a36ab-7a59-5465-b684-be9db9f6532a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff45f775-9d77-4a55-917e-2de57ce2cf31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff45f775-9d77-4a55-917e-2de57ce2cf31.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [
@@ -937,7 +937,7 @@
         },
         {
             "id": "9e7ab993-7bf2-51a8-9bf8-8c50d497ac05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff31eba-8ab3-403e-8d82-37a18b279bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff31eba-8ab3-403e-8d82-37a18b279bec.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -969,7 +969,7 @@
         },
         {
             "id": "07b4f113-cd02-5d84-a45f-caf8ca4c414d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd220e4-2e2a-437e-aa4e-1007247c8e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd220e4-2e2a-437e-aa4e-1007247c8e4d.jpg?1",
             "name": "Otherworldly Journey",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -1003,7 +1003,7 @@
         },
         {
             "id": "cfdfd8c7-e2bd-57f4-8dbc-140dc41fe73e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b083211a-aa01-4944-ae6c-e7fcdec67bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b083211a-aa01-4944-ae6c-e7fcdec67bbf.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -1035,7 +1035,7 @@
         },
         {
             "id": "6cf5d509-0c16-5b6c-845d-0dbdc1f779fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbf772f-ebdf-4c04-996f-0dbf1826049b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbf772f-ebdf-4c04-996f-0dbf1826049b.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "29fdbe20-f78c-50c3-b0bd-8e588f1b50bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964629e-d79e-46e4-b3fd-e7d1759cbc60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964629e-d79e-46e4-b3fd-e7d1759cbc60.jpg?1",
             "name": "Spectral Procession",
             "text": "({2\nW} can be paid with any two mana or with {W}. This card's converted mana cost is 6.)\nPut three 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "5f53a33f-6796-50c2-9e09-7a540974142b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0f671-8597-4c40-b9ca-7c6bfe2983c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0f671-8597-4c40-b9ca-7c6bfe2983c1.jpg?1",
             "name": "Sunlance",
             "text": "Sunlance deals 3 damage to target nonwhite creature.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "3f679705-53bc-57b4-89ce-f4155a1e21c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7d4b63-0221-4bfe-b0a3-66a5e3054627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7d4b63-0221-4bfe-b0a3-66a5e3054627.jpg?1",
             "name": "Sunspear Shikari",
             "text": "As long as Sunspear Shikari is equipped, it has first strike and lifelink.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "d540afd1-2e9a-5d89-ae1e-96ffb8024268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73949ba2-81d8-40f0-bd50-0a610c89e2fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73949ba2-81d8-40f0-bd50-0a610c89e2fa.jpg?1",
             "name": "Taj-Nar Swordsmith",
             "text": "When Taj-Nar Swordsmith enters the battlefield, you may pay {X}. If you do, search your library for an Equipment card with converted mana cost X or less and put that card onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -1204,7 +1204,7 @@
         },
         {
             "id": "11838f25-8c8b-584e-92f5-0a349169807a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0d818-b463-4ef7-93b4-1ae341b52e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0d818-b463-4ef7-93b4-1ae341b52e2c.jpg?1",
             "name": "Terashi's Grasp",
             "text": "Destroy target artifact or enchantment. You gain life equal to its converted mana cost.",
             "colours": [
@@ -1238,7 +1238,7 @@
         },
         {
             "id": "0310277c-b6f1-5634-b43b-532497d41b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c47e0-c87b-4304-b412-00496c2c289f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c47e0-c87b-4304-b412-00496c2c289f.jpg?1",
             "name": "Waxmane Baku",
             "text": "Whenever you cast a Spirit or Arcane spell, you may put a ki counter on Waxmane Baku.\n{1}, Remove X ki counters from Waxmane Baku: Tap X target creatures.",
             "colours": [
@@ -1272,7 +1272,7 @@
         },
         {
             "id": "07198d73-16e9-5d88-8bde-a067fa50ddc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8691ca3-8772-40f6-a7dd-68fe8efd7cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8691ca3-8772-40f6-a7dd-68fe8efd7cf4.jpg?1",
             "name": "Aethersnipe",
             "text": "When \u00c6thersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1306,7 +1306,7 @@
         },
         {
             "id": "76c7717a-0167-50ba-8e9d-b8b55bbf1079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896fc879-1ead-4eeb-b764-7e3f7f98bcfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896fc879-1ead-4eeb-b764-7e3f7f98bcfb.jpg?1",
             "name": "Air Servant",
             "text": "Flying\n{2}{U}: Tap target creature with flying.",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "f3d64884-6795-5b64-ade9-25fc461975ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d03f11-7448-47de-9fb4-3ceaf08dc1d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d03f11-7448-47de-9fb4-3ceaf08dc1d4.jpg?1",
             "name": "Argent Sphinx",
             "text": "Flying\nMetalcraft \u2014 {U}: Exile Argent Sphinx. Return it to the battlefield under your control at the beginning of the next end step. Activate this ability only if you control three or more artifacts.",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "eeb4f4a2-45d4-5607-8cb3-7ccc684c748e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3639ad50-6e39-48bd-9055-c32369d2f676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3639ad50-6e39-48bd-9055-c32369d2f676.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "6da157ab-7b7e-5cfe-8a5b-896f33700b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe76b0-86eb-4f5b-8877-657cb8a37fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe76b0-86eb-4f5b-8877-657cb8a37fc3.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Counter target spell.\n\u2022 Return target permanent to its owner's hand.\n\u2022 Tap all creatures your opponents control.\n\u2022 Draw a card.",
             "colours": [
@@ -1440,7 +1440,7 @@
         },
         {
             "id": "8d205fa4-a9d4-5d09-86a9-357a503ff186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6693346f-3891-441f-a628-4dea4dd181b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6693346f-3891-441f-a628-4dea4dd181b0.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist enters the battlefield, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1476,7 +1476,7 @@
         },
         {
             "id": "100ff2c0-a886-5817-bfe7-7aae2f5a778d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97aaed2-5e10-4080-b373-31f67fbac1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97aaed2-5e10-4080-b373-31f67fbac1a9.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "cb5ac40c-f1cc-5912-bd5b-1ec9a3de5348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9021f91-0b92-44ff-9ccb-bcf1e81232c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9021f91-0b92-44ff-9ccb-bcf1e81232c2.jpg?1",
             "name": "Guile",
             "text": "Guile can't be blocked except by three or more creatures.\nIf a spell or ability you control would counter a spell, instead exile that spell and you may play that card without paying its mana cost.\nWhen Guile is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "ca2cfecc-052a-530b-98bf-5c9d0541f484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a9a786-8d15-4186-8030-4151bddcc0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a9a786-8d15-4186-8030-4151bddcc0f7.jpg?1",
             "name": "Helium Squirter",
             "text": "Graft 3 (This creature enters the battlefield with three +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{1}: Target creature with a +1/+1 counter on it gains flying until end of turn.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "500788a0-0cf8-5b5c-be19-83c7a0be3c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73edeaaa-6a87-4cf1-b013-bab9a7bb94d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73edeaaa-6a87-4cf1-b013-bab9a7bb94d9.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "Return all artifacts target player owns to his or her hand.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "123256fa-709e-5c87-a463-b5cbe5a1eff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40441345-23ca-47e4-b349-bd13d986e41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40441345-23ca-47e4-b349-bd13d986e41e.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "62560e10-8068-5424-86b2-65266a8d8ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea345b5d-3b4b-4b59-876b-bc56fbe8578a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea345b5d-3b4b-4b59-876b-bc56fbe8578a.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "279a1d2d-1087-521b-8a13-1b045f47d64a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e282a2-d258-4c23-852c-6b0f10ae1962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e282a2-d258-4c23-852c-6b0f10ae1962.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "246f3339-5b8b-5aa2-a311-01ccc4aa47cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42910ab0-902f-43e9-ba21-6a35f9334e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42910ab0-902f-43e9-ba21-6a35f9334e59.jpg?1",
             "name": "Narcolepsy",
             "text": "Enchant creature\nAt the beginning of each upkeep, if enchanted creature is untapped, tap it.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "c716513c-731b-5b94-877c-70afb663b198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f75658e-43de-4091-acf6-5d6d571f9e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f75658e-43de-4091-acf6-5d6d571f9e99.jpg?1",
             "name": "Novijen Sages",
             "text": "Graft 4 (This creature enters the battlefield with four +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{1}, Remove two +1/+1 counters from among creatures you control: Draw a card.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "57cc0d6f-87cd-5f16-a6f0-3d06d89f999b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357aa2a1-4f72-4890-aa46-d212292ab837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357aa2a1-4f72-4890-aa46-d212292ab837.jpg?1",
             "name": "Qumulox",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "6a12b45f-cde1-5c58-870d-0681b1bbfc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc595c63-af05-4c05-80e8-e1a90df26b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc595c63-af05-4c05-80e8-e1a90df26b0f.jpg?1",
             "name": "Remand",
             "text": "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "612b7964-91c5-5a24-aac7-051f45c40544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d67a29-a9b2-4234-ad28-35d143fe1e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d67a29-a9b2-4234-ad28-35d143fe1e21.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "c843990b-6460-5381-88e9-4edb183f2b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfe45f-0b1f-489b-a0a6-679668589726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfe45f-0b1f-489b-a0a6-679668589726.jpg?1",
             "name": "Somber Hoverguard",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "e6c2a165-ea56-5371-ab48-36182729c0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71106361-b5b9-403c-b3b1-afe3337e9e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71106361-b5b9-403c-b3b1-afe3337e9e3d.jpg?1",
             "name": "Steady Progress",
             "text": "Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)\nDraw a card.",
             "colours": [
@@ -1942,7 +1942,7 @@
         },
         {
             "id": "52a70528-5acc-5174-a4a7-296e244cc9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f8146e-ca33-4fa2-8f39-5a44b0db4bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f8146e-ca33-4fa2-8f39-5a44b0db4bd6.jpg?1",
             "name": "Stoic Rebuttal",
             "text": "Metalcraft \u2014 Stoic Rebuttal costs {1} less to cast if you control three or more artifacts.\nCounter target spell.",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "92b4ce3c-0567-506e-8c58-5dbd3516f102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c26b28-b542-41d4-bfe0-222400653ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c26b28-b542-41d4-bfe0-222400653ae9.jpg?1",
             "name": "Surrakar Spellblade",
             "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Surrakar Spellblade.\nWhenever Surrakar Spellblade deals combat damage to a player, you may draw X cards, where X is the number of charge counters on it.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "8d27dea1-7d45-50fa-af35-2ede16fa5388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af206bea-f441-4a5a-ba5a-d2d2fd5cb226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af206bea-f441-4a5a-ba5a-d2d2fd5cb226.jpg?1",
             "name": "Telling Time",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "1b6bda46-0153-5653-9b4d-ec993841c86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339735-eb1a-46f0-8c3e-eae06f278eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339735-eb1a-46f0-8c3e-eae06f278eca.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "+1: Untap up to two target artifacts.\n\u2212X: Search your library for an artifact card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.\n\u22125: Artifacts you control become artifact creatures with base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "86d6c097-e7a6-5c04-8e8b-d459a1ef26c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f09f8e-f212-4b79-98fd-d1c6277a48c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f09f8e-f212-4b79-98fd-d1c6277a48c2.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "({PU} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "cdf48a44-b0dd-5f51-a94f-382471207474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895485a4-06b6-449d-8cf1-db08e52790e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895485a4-06b6-449d-8cf1-db08e52790e4.jpg?1",
             "name": "Thoughtcast",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nDraw two cards.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "6ba1fb13-ecae-5208-958b-6660432a1a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df368f26-e9e7-476c-be59-a141392e3932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df368f26-e9e7-476c-be59-a141392e3932.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "14abc049-ca19-562b-8d5e-a215b8b97363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f26d0a-e9f3-442f-b5c6-8016cf736432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f26d0a-e9f3-442f-b5c6-8016cf736432.jpg?1",
             "name": "Vapor Snag",
             "text": "Return target creature to its owner's hand. Its controller loses 1 life.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "70083909-8e28-51b1-8239-ff84fddb0c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01978fe5-00a9-4add-ae2a-b4c2572ffb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01978fe5-00a9-4add-ae2a-b4c2572ffb9a.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "9d8a217a-40be-5df8-93f1-3b7322bea834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa0a951-0018-41bb-8e82-c3844983a753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa0a951-0018-41bb-8e82-c3844983a753.jpg?1",
             "name": "Vigean Graftmage",
             "text": "Graft 2 (This creature enters the battlefield with two +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{1}{U}: Untap target creature with a +1/+1 counter on it.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "a0536412-8de3-5619-88c5-3ab5682dcc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba4e555-7528-46fd-9cf8-aa1a70e2cc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba4e555-7528-46fd-9cf8-aa1a70e2cc6a.jpg?1",
             "name": "Water Servant",
             "text": "{U}: Water Servant gets +1/-1 until end of turn.\n{U}: Water Servant gets -1/+1 until end of turn.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "674357a0-1598-572e-a44c-c09586ef3193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5f287b-beaa-4b51-8db7-91982e2c0bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5f287b-beaa-4b51-8db7-91982e2c0bb0.jpg?1",
             "name": "Wings of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nUntil end of turn, target creature has base power and toughness 4/4, gains all creature types, and gains flying.",
             "colours": [
@@ -2350,7 +2350,7 @@
         },
         {
             "id": "abb78da0-c21c-5c3d-b234-808fda020e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349f13c9-9a4e-4460-873e-fec58798646c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349f13c9-9a4e-4460-873e-fec58798646c.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and put a 1/1 black Faerie Rogue creature token with flying onto the battlefield.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "e399ad69-6b33-5de4-9eb2-4049597d4ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d87d15f-e944-4ca3-a729-b7ecee4cf118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d87d15f-e944-4ca3-a729-b7ecee4cf118.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "23e28dd5-556e-54b8-afc7-e7237d3fa173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9847c5a-056e-45fb-9871-ca1dcaddb61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9847c5a-056e-45fb-9871-ca1dcaddb61d.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "c63523d1-50e4-519e-8d0b-663869263a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afa8918-86b7-4244-813f-ef7b51d77809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afa8918-86b7-4244-813f-ef7b51d77809.jpg?1",
             "name": "Daggerclaw Imp",
             "text": "Flying\nDaggerclaw Imp can't block.",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "41f497ca-1cd1-5c70-994f-880efadc5b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cf51d8-9f91-42ff-99e9-4397f2251c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cf51d8-9f91-42ff-99e9-4397f2251c20.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "ad9eafee-206c-59ce-b9b3-b761a4b4a7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc323d-f30e-4463-bcf7-5d4d0df1fe98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc323d-f30e-4463-bcf7-5d4d0df1fe98.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "d0753a27-0cc2-5795-9a11-11c7b38772f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ef45f-c82c-4490-b353-b0b5b572f403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ef45f-c82c-4490-b353-b0b5b572f403.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "db1dc158-137f-5771-a024-7ade39604085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f9b26-e1b0-4818-8d70-40a000f274eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f9b26-e1b0-4818-8d70-40a000f274eb.jpg?1",
             "name": "Devouring Greed",
             "text": "As an additional cost to cast Devouring Greed, you may sacrifice any number of Spirits.\nTarget player loses 2 life plus 2 life for each Spirit sacrificed this way. You gain that much life.",
             "colours": [
@@ -2620,7 +2620,7 @@
         },
         {
             "id": "05cba0ca-60c1-5914-ad19-aec6f18f3d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d286cf6-3e16-4941-9326-1818b1e06d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d286cf6-3e16-4941-9326-1818b1e06d69.jpg?1",
             "name": "Dismember",
             "text": "({PB} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "4d3c9f53-3157-535e-b9bc-452f6e67af22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3894e7-5740-4455-8093-57579b1549a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3894e7-5740-4455-8093-57579b1549a7.jpg?1",
             "name": "Dread Drone",
             "text": "When Dread Drone enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "e612722c-48ec-56aa-a941-b173ef26bb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723d783-e2c5-4c01-8adc-fade22e4936e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723d783-e2c5-4c01-8adc-fade22e4936e.jpg?1",
             "name": "Duskhunter Bat",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFlying",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "88b7525c-7dd0-5c76-9769-30e896db9cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97b9d0e-e150-46d5-b6fd-59793e82dae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97b9d0e-e150-46d5-b6fd-59793e82dae4.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you cast a creature spell, put X 1/1 black Thrull creature tokens onto the battlefield, where X is that spell's converted mana cost.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "1cc8dfb3-83a3-556d-bc55-7732d9508381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9f1fda-8a94-48fe-9682-5b2fdbc31bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9f1fda-8a94-48fe-9682-5b2fdbc31bad.jpg?1",
             "name": "Ghostly Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{B}: Ghostly Changeling gets +1/+1 until end of turn.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "bd3f9873-8159-5f67-8000-4bda62175e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8145805-daa8-43c0-9f22-e6829f6ed390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8145805-daa8-43c0-9f22-e6829f6ed390.jpg?1",
             "name": "Grim Affliction",
             "text": "Put a -1/-1 counter on target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "47588661-c6f2-56d2-9a01-80429c57ef28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a14b58-e0d9-4203-a9da-ad8e997a7936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a14b58-e0d9-4203-a9da-ad8e997a7936.jpg?1",
             "name": "Instill Infection",
             "text": "Put a -1/-1 counter on target creature.\nDraw a card.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "43434c0a-1dfe-50f7-91b2-a378c1f31bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7da8f15-ea21-46fd-b24f-f8af4d5d5f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7da8f15-ea21-46fd-b24f-f8af4d5d5f1d.jpg?1",
             "name": "Midnight Banshee",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nAt the beginning of your upkeep, put a -1/-1 counter on each nonblack creature.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "3220df56-7753-58a3-8e7f-ee0f43936010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6f58-267a-4ae9-bf72-e0ae0be3b884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6f58-267a-4ae9-bf72-e0ae0be3b884.jpg?1",
             "name": "Nameless Inversion",
             "text": "Changeling (This card is every creature type at all times.)\nTarget creature gets +3/-3 and loses all creature types until end of turn.",
             "colours": [
@@ -2925,7 +2925,7 @@
         },
         {
             "id": "0219b4c7-2d9c-510f-93d4-d59380bd58b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d1e8a-b80e-4963-aeff-4b364a02a246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d1e8a-b80e-4963-aeff-4b364a02a246.jpg?1",
             "name": "Necroskitter",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls with a -1/-1 counter on it dies, you may return that card to the battlefield under your control.",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "d43e2a16-2d30-5b07-847c-f64dae5ab8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85343bc7-d670-439e-9a84-3c75eb171b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85343bc7-d670-439e-9a84-3c75eb171b12.jpg?1",
             "name": "Plagued Rusalka",
             "text": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "22ac70be-b20c-506b-8837-9707fa825bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a770a18f-c333-431b-b15a-69bb025601c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a770a18f-c333-431b-b15a-69bb025601c2.jpg?1",
             "name": "Profane Command",
             "text": "Choose two \u2014\n\u2022 Target player loses X life.\n\u2022 Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n\u2022 Target creature gets -X/-X until end of turn.\n\u2022 Up to X target creatures gain fear until end of turn.",
             "colours": [
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "5f5bb4c5-76f6-5e69-a07a-6047915fd567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440b7874-b71c-4cd8-987a-d2915b8a9974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440b7874-b71c-4cd8-987a-d2915b8a9974.jpg?1",
             "name": "Puppeteer Clique",
             "text": "Flying\nWhen Puppeteer Clique enters the battlefield, put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. At the beginning of your next end step, exile it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "f961cefc-3a70-59ee-b7b7-de0208ddb7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528c4e3a-fdeb-4080-b2b7-82faa07a3383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528c4e3a-fdeb-4080-b2b7-82faa07a3383.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "b758c5e7-2b04-5875-925f-9553569ee754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5249a7-de7f-445f-a24f-9c429f45c779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5249a7-de7f-445f-a24f-9c429f45c779.jpg?1",
             "name": "Scavenger Drake",
             "text": "Flying\nWhenever another creature dies, you may put a +1/+1 counter on Scavenger Drake.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "4cc68f76-dabd-5581-8cba-1aab1fb638e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f68a90c-1afb-43d3-aed2-4704f4599e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f68a90c-1afb-43d3-aed2-4704f4599e75.jpg?1",
             "name": "Scuttling Death",
             "text": "Sacrifice Scuttling Death: Target creature gets -1/-1 until end of turn.\nSoulshift 4 (When this creature dies, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "a8f5615a-5cfc-5bc4-8a78-0d3a90ce3063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5460a0-1aae-45bf-a2aa-5b95fd29d06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5460a0-1aae-45bf-a2aa-5b95fd29d06f.jpg?1",
             "name": "Shrivel",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "2d453aa3-af71-55e2-951d-d0d2563bc1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831462c0-476b-4106-8381-e4177626b570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831462c0-476b-4106-8381-e4177626b570.jpg?1",
             "name": "Sickle Ripper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "eed08515-dfc7-524a-8c91-0d0a83a2e0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f94c5a-684e-4a48-8280-f0e3db712d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f94c5a-684e-4a48-8280-f0e3db712d75.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "70783945-2c15-58ed-8560-965aa55778b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003bc8f1-f282-491c-984d-1ce7ac027053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003bc8f1-f282-491c-984d-1ce7ac027053.jpg?1",
             "name": "Spread the Sickness",
             "text": "Destroy target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -3294,7 +3294,7 @@
         },
         {
             "id": "b6566e51-204f-555f-b7a9-691f2aba35a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e438caf-9373-4de8-b4ac-212f5036e677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e438caf-9373-4de8-b4ac-212f5036e677.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "f947bb42-d72d-5a4b-9c4e-8973ca39d27b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48304e24-9c74-4726-95ae-3b1a356f5998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48304e24-9c74-4726-95ae-3b1a356f5998.jpg?1",
             "name": "Thief of Hope",
             "text": "Whenever you cast a Spirit or Arcane spell, target opponent loses 1 life and you gain 1 life.\nSoulshift 2 (When this creature dies, you may return target Spirit card with converted mana cost 2 or less from your graveyard to your hand.)",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "71c42c27-51c8-564c-a610-8dd73e561048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4403436b-2605-495b-ab08-9a2001cc7f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4403436b-2605-495b-ab08-9a2001cc7f8b.jpg?1",
             "name": "Vampire Lacerator",
             "text": "At the beginning of your upkeep, you lose 1 life unless an opponent has 10 or less life.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "8ae6b3ce-d169-5e95-a3b3-eef62fe760d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c1d966-b3c5-4480-be58-054a88141e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c1d966-b3c5-4480-be58-054a88141e44.jpg?1",
             "name": "Vampire Outcasts",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nLifelink",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "94133ac5-b27c-55a6-a476-2108bec1ac43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc87c53-0612-42a7-9c32-f7d1adf246af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc87c53-0612-42a7-9c32-f7d1adf246af.jpg?1",
             "name": "Waking Nightmare",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "a6309475-ed56-5bb6-81e0-09e61f1bd89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d418362-aa0c-4e42-b473-f266ec3d0a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d418362-aa0c-4e42-b473-f266ec3d0a25.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "24a75fd6-beb2-56c9-8935-18745806bc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b17fb1-4a33-454f-9222-c6d5671c7e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b17fb1-4a33-454f-9222-c6d5671c7e2f.jpg?1",
             "name": "Blades of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nUp to two target creatures each get +2/+0 and gain all creature types until end of turn.",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "3d6c4b53-d1e5-52ac-9e97-ae1a53be40ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0dec-e4bc-413f-a081-db3421742986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0dec-e4bc-413f-a081-db3421742986.jpg?1",
             "name": "Blood Ogre",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFirst strike",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "ba3f85f4-3ac7-5c60-ace7-9fbfe1aa87c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb21ef9-fab4-427e-bcbf-5cbcbdacd059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb21ef9-fab4-427e-bcbf-5cbcbdacd059.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "3535cac0-3465-539a-a8da-8db170e60620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa32b2a-ce3c-441a-88d4-1ee853a7c265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa32b2a-ce3c-441a-88d4-1ee853a7c265.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "9028de2c-af25-5f9d-bcb4-f850bae7dc62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e6428f-5c78-45f7-9bf9-eb4de63325d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e6428f-5c78-45f7-9bf9-eb4de63325d5.jpg?1",
             "name": "Burst Lightning",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to target creature or player. If Burst Lightning was kicked, it deals 4 damage to that creature or player instead.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "47e10acb-5039-5a93-8cfd-be26bc1845e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acedb1-874c-48ea-820d-f1b1f8cb2553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acedb1-874c-48ea-820d-f1b1f8cb2553.jpg?1",
             "name": "Combust",
             "text": "Combust can't be countered by spells or abilities.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "193785c7-f08e-5f8a-8dba-c9a0d95f39cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccfe45e-c00c-48ec-b520-ccbb63cfbecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccfe45e-c00c-48ec-b520-ccbb63cfbecc.jpg?1",
             "name": "Comet Storm",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature or player, then choose another target creature or player for each time Comet Storm was kicked. Comet Storm deals X damage to each of them.",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "330bffc6-3204-585d-9838-a4f50cb7398c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef2daf4-45ff-4604-b572-31dfaf1e70fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef2daf4-45ff-4604-b572-31dfaf1e70fe.jpg?1",
             "name": "Dragonsoul Knight",
             "text": "First strike\n{W}{U}{B}{R}{G}: Until end of turn, Dragonsoul Knight becomes a Dragon, gets +5/+3, and gains flying and trample.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "b9990c2c-c130-5ebf-8042-ceb9f3c21a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22014836-8a81-4385-bdb0-b9a080fa57af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22014836-8a81-4385-bdb0-b9a080fa57af.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "14992450-3a2a-5d7a-a071-956878088d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c043b7-1eec-4d11-986c-8fb3823fc3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c043b7-1eec-4d11-986c-8fb3823fc3b1.jpg?1",
             "name": "Goblin Fireslinger",
             "text": "{T}: Goblin Fireslinger deals 1 damage to target player.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "ed211520-bc05-5630-a103-47a9fb4cf096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aedc52-8fc9-4a5d-af42-f9db684c3003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aedc52-8fc9-4a5d-af42-f9db684c3003.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "484acd08-e23c-5ac4-adab-65dad6b50177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda652b4-3ae5-4a5b-be82-c0e47a886907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda652b4-3ae5-4a5b-be82-c0e47a886907.jpg?1",
             "name": "Gorehorn Minotaurs",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "d31b71f8-5e6b-55b3-a191-4ad0f95ae271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461987da-8860-4a04-8f93-d182523ca311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461987da-8860-4a04-8f93-d182523ca311.jpg?1",
             "name": "Gut Shot",
             "text": "({PR} can be paid with either {R} or 2 life.)\nGut Shot deals 1 damage to target creature or player.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "4a0d4039-7c77-57b2-aea9-86a9b99cbcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a7453-3c5d-4933-8fea-7696ac329f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a7453-3c5d-4933-8fea-7696ac329f71.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "3aa9d29a-d909-569f-b4c0-52e17cc8293c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024e80e3-a36f-4c07-99d3-5dd8a2d8998f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024e80e3-a36f-4c07-99d3-5dd8a2d8998f.jpg?1",
             "name": "Incandescent Soulstoke",
             "text": "Other Elemental creatures you control get +1/+1.\n{1}{R}, {T}: You may put an Elemental creature card from your hand onto the battlefield. That creature gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "22478557-2cf4-574a-ad5f-86fa81fd851c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107b3dbc-fc02-4548-90cf-844da42db13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107b3dbc-fc02-4548-90cf-844da42db13f.jpg?1",
             "name": "Inner-Flame Igniter",
             "text": "{2}{R}: Creatures you control get +1/+0 until end of turn. If this is the third time this ability has resolved this turn, creatures you control gain first strike until end of turn.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "113656ea-6be0-5717-8c4a-9910fcb8d053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa701469-a15c-4e45-8455-089bd4040cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa701469-a15c-4e45-8455-089bd4040cf1.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Put a token that's a copy of target nonlegendary creature you control onto the battlefield. That token has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "90382a47-3cdf-511d-8965-342d00e37672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da834-7f4a-4f60-9151-de7ddcf29622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da834-7f4a-4f60-9151-de7ddcf29622.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "808dc5d0-6258-5218-8f84-691584449b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4400ba-7e77-41d0-8177-ae3d366fb9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4400ba-7e77-41d0-8177-ae3d366fb9bd.jpg?1",
             "name": "Skarrgan Firebird",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature enters the battlefield with three +1/+1 counters on it.)\nFlying\n{R}{R}{R}: Return Skarrgan Firebird from your graveyard to your hand. Activate this ability only if an opponent was dealt damage this turn.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "ce31bcd5-5b46-5f95-8751-57ea0e952e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e1c601-5a3d-4819-ab54-2c9acc357d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e1c601-5a3d-4819-ab54-2c9acc357d69.jpg?1",
             "name": "Smash to Smithereens",
             "text": "Destroy target artifact. Smash to Smithereens deals 3 damage to that artifact's controller.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "e60540b7-8445-53d1-bbec-1e60339e9967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6090f5-dfee-4c3f-8257-7707fb6abf2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6090f5-dfee-4c3f-8257-7707fb6abf2c.jpg?1",
             "name": "Smokebraider",
             "text": "{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast Elemental spells or activate abilities of Elementals.",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "57aec187-da7d-5ae3-9c2e-90c05a76ae06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d622758-b182-4a2d-9746-9b03611c1212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d622758-b182-4a2d-9746-9b03611c1212.jpg?1",
             "name": "Soulbright Flamekin",
             "text": "{2}: Target creature gains trample until end of turn. If this is the third time this ability has resolved this turn, you may add {R}{R}{R}{R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -4244,7 +4244,7 @@
         },
         {
             "id": "4c54ec0c-e9c5-5425-a827-5262128675dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c14e44-20ff-4128-b07d-4b751fc82d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c14e44-20ff-4128-b07d-4b751fc82d4e.jpg?1",
             "name": "Spikeshot Elder",
             "text": "{1}{R}{R}: Spikeshot Elder deals damage equal to its power to target creature or player.",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "2a06ffb5-2126-5ad4-84a7-a64167c4ddfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7390a8-78c7-4bb2-9615-18c0f2ffd9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7390a8-78c7-4bb2-9615-18c0f2ffd9eb.jpg?1",
             "name": "Spitebellows",
             "text": "When Spitebellows leaves the battlefield, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "6a99851f-6e0d-5720-af9f-252117baf0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580fbbf8-ba7e-4889-a5ea-d066f3ea8cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580fbbf8-ba7e-4889-a5ea-d066f3ea8cea.jpg?1",
             "name": "Splinter Twin",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put a token that's a copy of this creature onto the battlefield. That token has haste. Exile it at the beginning of the next end step.\"",
             "colours": [
@@ -4347,7 +4347,7 @@
         },
         {
             "id": "ccf20fa9-7f5e-5210-ac86-44c3951100b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf24b25-e98c-4c32-91a2-9c5e10679472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf24b25-e98c-4c32-91a2-9c5e10679472.jpg?1",
             "name": "Stormblood Berserker",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nStormblood Berserker can't be blocked except by two or more creatures.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "d9609e12-1471-5881-aa1f-a6295d58deba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ec37d-c4ed-4af6-8c30-bcec13c108fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ec37d-c4ed-4af6-8c30-bcec13c108fd.jpg?1",
             "name": "Thunderblust",
             "text": "Haste\nThunderblust has trample as long as it has a -1/-1 counter on it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "5779ff89-4dde-5266-971a-98799a566f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22418cd-4c49-4754-aa75-17f6eaf1639a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22418cd-4c49-4754-aa75-17f6eaf1639a.jpg?1",
             "name": "Tribal Flames",
             "text": "Domain \u2014 Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -4448,7 +4448,7 @@
         },
         {
             "id": "f8d4f913-fd5d-5354-bcc3-352413f94071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a441fae0-a9c7-4d91-a69e-8ea1f8fa6947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a441fae0-a9c7-4d91-a69e-8ea1f8fa6947.jpg?1",
             "name": "Viashino Slaughtermaster",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\n{B}{G}: Viashino Slaughtermaster gets +1/+1 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "56b02820-5632-5afc-83fe-055e5e31e700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5924430-1904-47b9-bcf0-3379babd395c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5924430-1904-47b9-bcf0-3379babd395c.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands. Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -4517,7 +4517,7 @@
         },
         {
             "id": "99f0633f-cd62-52e8-9e97-0fef09582a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927081a-4eea-48dd-a81a-2e751552751d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927081a-4eea-48dd-a81a-2e751552751d.jpg?1",
             "name": "Worldheart Phoenix",
             "text": "Flying\nYou may cast Worldheart Phoenix from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost. If you do, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "d2e9a9b5-9dea-597b-94ca-1ee5dcbee2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e1dcb2-9471-48d9-98c8-12194e3a88ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e1dcb2-9471-48d9-98c8-12194e3a88ac.jpg?1",
             "name": "Wrap in Flames",
             "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "331bae39-d45b-54b6-936c-57e9c460abc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d30720-5baa-4779-a435-14fab778bad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d30720-5baa-4779-a435-14fab778bad6.jpg?1",
             "name": "Algae Gharial",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nWhenever another creature dies, you may put a +1/+1 counter on Algae Gharial.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "3413f257-8c38-5234-a578-d0f07d094046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15629398-bb20-4ff3-ab0e-061dcea916d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15629398-bb20-4ff3-ab0e-061dcea916d5.jpg?1",
             "name": "All Suns' Dawn",
             "text": "For each color, return up to one target card of that color from your graveyard to your hand. Exile All Suns' Dawn.",
             "colours": [
@@ -4653,7 +4653,7 @@
         },
         {
             "id": "fa83d223-63b5-556d-ae55-67f4db3c104e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cc16c-9ead-45b9-b56c-7512cd54cf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cc16c-9ead-45b9-b56c-7512cd54cf7c.jpg?1",
             "name": "Ant Queen",
             "text": "{1}{G}: Put a 1/1 green Insect creature token onto the battlefield.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "45ff2217-ab82-537d-b43b-234419061b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9dd8d6-013a-4018-9186-988f5e8d0ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9dd8d6-013a-4018-9186-988f5e8d0ab9.jpg?1",
             "name": "Aquastrand Spider",
             "text": "Graft 2 (This creature enters the battlefield with two +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "c5bdea54-2d0e-5df8-b43c-6d306aa76303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c16134-692d-4fd1-bffa-f9342113cbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c16134-692d-4fd1-bffa-f9342113cbd8.jpg?1",
             "name": "Bestial Menace",
             "text": "Put a 1/1 green Snake creature token, a 2/2 green Wolf creature token, and a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "aa8e5c4e-1238-5461-a274-7688aff9b0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59eafb3-3ce6-4056-a7f7-8d0a8fc12294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59eafb3-3ce6-4056-a7f7-8d0a8fc12294.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "a5297ea7-bf97-53c6-a1fd-9457ff74e8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e149b2-6bac-4749-ab06-edde21dc408e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e149b2-6bac-4749-ab06-edde21dc408e.jpg?1",
             "name": "Cytoplast Root-Kin",
             "text": "Graft 4 (This creature enters the battlefield with four +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\nWhen Cytoplast Root-Kin enters the battlefield, put a +1/+1 counter on each other creature you control with a +1/+1 counter on it.\n{2}: Move a +1/+1 counter from target creature you control onto Cytoplast Root-Kin.",
             "colours": [
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "a8b50099-f208-5970-a985-ea095f81a648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2716f3a-97ce-419c-9a0f-930cbb660308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2716f3a-97ce-419c-9a0f-930cbb660308.jpg?1",
             "name": "Gnarlid Pack",
             "text": "Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nGnarlid Pack enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "34fc4e5e-bde6-55cd-918c-4b682992437c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eef91c5-3861-40de-9bb7-67f44431428a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eef91c5-3861-40de-9bb7-67f44431428a.jpg?1",
             "name": "Karplusan Strider",
             "text": "Karplusan Strider can't be the target of blue or black spells.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "f4377244-f413-5f7d-9414-608aec39f668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1644535-cea4-4dda-aa09-225f8b30dddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1644535-cea4-4dda-aa09-225f8b30dddd.jpg?1",
             "name": "Kavu Primarch",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf Kavu Primarch was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -4923,7 +4923,7 @@
         },
         {
             "id": "21cb8dfa-062c-575d-ae6d-c3db52ae7a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03226d4-837a-4d95-a70b-082ce726765f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03226d4-837a-4d95-a70b-082ce726765f.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "d10e2701-fdcf-5c74-9807-2be8f205be7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eac937f-9d61-4da2-8946-187839e13590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eac937f-9d61-4da2-8946-187839e13590.jpg?1",
             "name": "Matca Rioters",
             "text": "Domain \u2014 Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "059dfb34-8cee-567c-bc6a-32c8f648ed29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0861a2-1858-47af-8154-20a977c2b298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0861a2-1858-47af-8154-20a977c2b298.jpg?1",
             "name": "Mutagenic Growth",
             "text": "({PG} can be paid with either {G} or 2 life.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "86ca93c4-3253-5af6-b604-645c81e4a7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55135987-719d-4b7d-a721-b100334a3c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55135987-719d-4b7d-a721-b100334a3c68.jpg?1",
             "name": "Nest Invader",
             "text": "When Nest Invader enters the battlefield, put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "43c3d222-1816-5516-8ff9-fe322170b451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b5322-bfd9-4e37-90b8-3d507ab687de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b5322-bfd9-4e37-90b8-3d507ab687de.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "21875dfe-76a0-5eff-b54f-c48048b55610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d7d3ca-8e0d-43ce-9cdb-310d017873ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d7d3ca-8e0d-43ce-9cdb-310d017873ca.jpg?1",
             "name": "Overwhelm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "827d012f-ff7b-54ed-92e5-0ac1f774392d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4035157c-92ba-41b6-89c4-85a52578730b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4035157c-92ba-41b6-89c4-85a52578730b.jpg?1",
             "name": "Overwhelming Stampede",
             "text": "Until end of turn, creatures you control gain trample and get +X/+X, where X is the greatest power among creatures you control.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "957799d0-70af-5e68-a538-5dbc94073942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f37ffb3-96d7-4c91-8dd7-eb9061b6cf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f37ffb3-96d7-4c91-8dd7-eb9061b6cf7f.jpg?1",
             "name": "Pelakka Wurm",
             "text": "Trample\nWhen Pelakka Wurm enters the battlefield, you gain 7 life.\nWhen Pelakka Wurm dies, draw a card.",
             "colours": [
@@ -5195,7 +5195,7 @@
         },
         {
             "id": "6d4f0092-8099-5ce9-a6ae-951628c14477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c24ae7-ae33-4324-8880-84f71262ffd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c24ae7-ae33-4324-8880-84f71262ffd9.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -5227,7 +5227,7 @@
         },
         {
             "id": "31589d7b-e410-5c6a-abd2-ca40b491fd5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea2bf31-4320-4605-ab5b-6b32472b82fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea2bf31-4320-4605-ab5b-6b32472b82fa.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "e35f807e-1a16-51d5-9529-b02de54c1f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07954800-e3b8-4d73-a763-56a64726c384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07954800-e3b8-4d73-a763-56a64726c384.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "8e1d71bf-b345-5b06-9e54-6b4ceddd51a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840c324-4dd4-41fe-9af2-593314ab685e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840c324-4dd4-41fe-9af2-593314ab685e.jpg?1",
             "name": "Root-Kin Ally",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTap two untapped creatures you control: Root-Kin Ally gets +2/+2 until end of turn.",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "ad9ec3f2-f923-57af-83f6-c186ef110dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28c2a8-ee7d-4eea-8046-a47e81ddd28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28c2a8-ee7d-4eea-8046-a47e81ddd28d.jpg?1",
             "name": "Scatter the Seeds",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut three 1/1 green Saproling creature tokens onto the battlefield.",
             "colours": [
@@ -5360,7 +5360,7 @@
         },
         {
             "id": "263fecae-3c4a-51d9-843d-7c7d655a0619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8860f5-64ad-4e2d-bab9-b7d416e4ddb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8860f5-64ad-4e2d-bab9-b7d416e4ddb9.jpg?1",
             "name": "Scion of the Wild",
             "text": "Scion of the Wild's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "6a5be7b5-e934-56b6-ab07-1180723be36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fca009-8424-41b0-9807-7af979dde785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fca009-8424-41b0-9807-7af979dde785.jpg?1",
             "name": "Scute Mob",
             "text": "At the beginning of your upkeep, if you control five or more lands, put four +1/+1 counters on Scute Mob.",
             "colours": [
@@ -5428,7 +5428,7 @@
         },
         {
             "id": "f94e8013-617b-5c2d-9519-64872138ccaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68896747-bab9-4c29-9fd0-764bebde96c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68896747-bab9-4c29-9fd0-764bebde96c4.jpg?1",
             "name": "Simic Initiate",
             "text": "Graft 1 (This creature enters the battlefield with a +1/+1 counter on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)",
             "colours": [
@@ -5463,7 +5463,7 @@
         },
         {
             "id": "fb395431-616b-51b9-ba71-41bde01d2e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491b58f-3c54-41ea-b93b-c32fdc1e5917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491b58f-3c54-41ea-b93b-c32fdc1e5917.jpg?1",
             "name": "Sundering Vitae",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "d3859c19-1bed-52f9-8f3b-0d3c1df5e9c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d9dfe0-a793-4903-a83d-dc9041a87f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d9dfe0-a793-4903-a83d-dc9041a87f83.jpg?1",
             "name": "Sylvan Bounty",
             "text": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -5527,7 +5527,7 @@
         },
         {
             "id": "bd35b85f-0417-5fe7-a96d-213201988380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfdd410-391b-4b71-8139-f5a30653097a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfdd410-391b-4b71-8139-f5a30653097a.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "7da0f887-1e95-53cd-97e4-5fa438631a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88e954-7041-4063-8625-fa98d9be9394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88e954-7041-4063-8625-fa98d9be9394.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -5593,7 +5593,7 @@
         },
         {
             "id": "ee9efb33-56fe-53f7-b8a9-0410519498ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e76688-bba3-4498-8c01-75cfa03c9ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e76688-bba3-4498-8c01-75cfa03c9ad8.jpg?1",
             "name": "Tukatongue Thallid",
             "text": "When Tukatongue Thallid dies, put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5627,7 +5627,7 @@
         },
         {
             "id": "394e8181-41ee-5978-bef6-532ecf96930d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203e3d4-8998-41d6-9f7e-b68af0f1f8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203e3d4-8998-41d6-9f7e-b68af0f1f8b5.jpg?1",
             "name": "Vines of Vastwood",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nTarget creature can't be the target of spells or abilities your opponents control this turn. If Vines of Vastwood was kicked, that creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "c09055ab-723e-5193-9df3-9d23a6345404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb10f5be-a82f-4f4f-8653-2d6927ac0ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb10f5be-a82f-4f4f-8653-2d6927ac0ca8.jpg?1",
             "name": "Wolfbriar Elemental",
             "text": "Multikicker {G} (You may pay an additional {G} any number of times as you cast this spell.)\nWhen Wolfbriar Elemental enters the battlefield, put a 2/2 green Wolf creature token onto the battlefield for each time it was kicked.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "d37425cd-19e5-5a32-b1bd-72f23f559315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325fa8a5-3464-4217-971d-cd4aa8e2e865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325fa8a5-3464-4217-971d-cd4aa8e2e865.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "d1b515db-6b1a-5d6c-ab9c-71d6e2109aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc9b519-f558-4aec-9d75-e2a8a3f48b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc9b519-f558-4aec-9d75-e2a8a3f48b8c.jpg?1",
             "name": "Apocalypse Hydra",
             "text": "Apocalypse Hydra enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.\n{1}{R}, Remove a +1/+1 counter from Apocalypse Hydra: Apocalypse Hydra deals 1 damage to target creature or player.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "80407c4b-f83f-57ff-bfa1-eb24edce3ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6135a9f2-e86d-4a34-857e-adea3c722fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6135a9f2-e86d-4a34-857e-adea3c722fea.jpg?1",
             "name": "Boros Swiftblade",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "a27d5f46-612f-55a7-bda9-dbf081143a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbafd6c-15cc-492f-b1e4-c5baa61e4a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbafd6c-15cc-492f-b1e4-c5baa61e4a0b.jpg?1",
             "name": "Drooling Groodion",
             "text": "{2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "db4514d3-f5ba-52ef-962a-0403e7ea972b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d916a-5c87-4e16-b8e0-6d65b6d2ef53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d916a-5c87-4e16-b8e0-6d65b6d2ef53.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "4316406e-ba39-58b8-9939-fe011bb55cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125126e1-1e48-42ed-ac94-02f62ab13d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125126e1-1e48-42ed-ac94-02f62ab13d05.jpg?1",
             "name": "Ethercaste Knight",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "c94b673d-0737-5ec6-8c7a-a112cf47d8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b551074-a9b4-45f0-a007-f07d7b2e12a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b551074-a9b4-45f0-a007-f07d7b2e12a8.jpg?1",
             "name": "Ghost Council of Orzhova",
             "text": "When Ghost Council of Orzhova enters the battlefield, target opponent loses 1 life and you gain 1 life.\n{1}, Sacrifice a creature: Exile Ghost Council of Orzhova. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -5946,7 +5946,7 @@
         },
         {
             "id": "f83035fc-d60a-59ec-83f4-ab555b2a7716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bbbfda-2909-45e3-bdbb-9e8964e608d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bbbfda-2909-45e3-bdbb-9e8964e608d1.jpg?1",
             "name": "Glassdust Hulk",
             "text": "Whenever another artifact enters the battlefield under your control, Glassdust Hulk gets +1/+1 until end of turn and can't be blocked this turn.\nCycling {WU} ({WU}, Discard this card: Draw a card.)",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "fa018623-103d-50c4-b2c3-2b1baedc1b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5137c28-632f-40f4-bf9d-877f5f070987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5137c28-632f-40f4-bf9d-877f5f070987.jpg?1",
             "name": "Horde of Notions",
             "text": "Vigilance, trample, haste\n{W}{U}{B}{R}{G}: You may play target Elemental card from your graveyard without paying its mana cost.",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "6cb209ae-1934-5d61-87d3-c019097f221e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a752d05-cd6f-4754-85fd-16f1308ac1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a752d05-cd6f-4754-85fd-16f1308ac1ea.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, you may put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "76a20841-426a-5c4a-abae-15c0b6feded6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38810fe4-dc72-439e-adf7-362af772b8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38810fe4-dc72-439e-adf7-362af772b8f8.jpg?1",
             "name": "Mystic Snake",
             "text": "Flash\nWhen Mystic Snake enters the battlefield, counter target spell.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "c1a6e091-1736-59bb-9dc0-f6d4f91106ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee31b6-874f-47fc-9e94-0f4e6413ef54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee31b6-874f-47fc-9e94-0f4e6413ef54.jpg?1",
             "name": "Necrogenesis",
             "text": "{2}: Exile target creature card from a graveyard. Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "1a1fa698-2bff-54f2-824e-8d58bbf424b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fd56e6-5d54-426e-9e44-ec2ad8a63724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fd56e6-5d54-426e-9e44-ec2ad8a63724.jpg?1",
             "name": "Niv-Mizzet, the Firemind",
             "text": "Flying\nWhenever you draw a card, Niv-Mizzet, the Firemind deals 1 damage to target creature or player.\n{T}: Draw a card.",
             "colours": [
@@ -6172,7 +6172,7 @@
         },
         {
             "id": "01311c55-7816-5d61-b2ba-1d87421225e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d01b08e-9cd6-4166-afcc-c58ea323e29f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d01b08e-9cd6-4166-afcc-c58ea323e29f.jpg?1",
             "name": "Pillory of the Sleepless",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"At the beginning of your upkeep, you lose 1 life.\"",
             "colours": [
@@ -6208,7 +6208,7 @@
         },
         {
             "id": "765a427b-81b8-5be0-b5c4-f140fbc0d88f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173d28f9-b356-457d-b356-22993460429c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173d28f9-b356-457d-b356-22993460429c.jpg?1",
             "name": "Plaxcaster Frogling",
             "text": "Graft 3 (This creature enters the battlefield with three +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{2}: Target creature with a +1/+1 counter on it gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "5128268b-50b2-5756-8f4e-ea2247c32f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667b7583-23e0-4721-b2f9-4f06167532af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667b7583-23e0-4721-b2f9-4f06167532af.jpg?1",
             "name": "Savage Twister",
             "text": "Savage Twister deals X damage to each creature.",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "a5e88598-ceed-5ad0-8b97-ee3980eedb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39aea233-992a-4aea-86c1-f9c07c74efbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39aea233-992a-4aea-86c1-f9c07c74efbc.jpg?1",
             "name": "Shadowmage Infiltrator",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever Shadowmage Infiltrator deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -6316,7 +6316,7 @@
         },
         {
             "id": "979aa9e5-5a51-5a23-955b-b227f0e2f2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b5a580-c267-43f7-be77-fbc2928ff0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b5a580-c267-43f7-be77-fbc2928ff0ab.jpg?1",
             "name": "Sigil Blessing",
             "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "0916d4b2-1503-5e3a-a5ed-9f978fa15356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a2f52-56b9-4eb5-b2ae-8dbee42a490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a2f52-56b9-4eb5-b2ae-8dbee42a490c.jpg?1",
             "name": "Vengeful Rebirth",
             "text": "Return target card from your graveyard to your hand. If you return a nonland card to your hand this way, Vengeful Rebirth deals damage equal to that card's converted mana cost to target creature or player.\nExile Vengeful Rebirth.",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "6c790f87-7523-5548-8a3e-aeef935e417a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d933dfd2-6def-4d07-92c2-93a771996fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d933dfd2-6def-4d07-92c2-93a771996fe6.jpg?1",
             "name": "Wrecking Ball",
             "text": "Destroy target creature or land.",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "d83e8cad-3e14-5fff-a0f9-0b0ad3336b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad79a3-050a-43f0-81ea-7f8c2ae00abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad79a3-050a-43f0-81ea-7f8c2ae00abf.jpg?1",
             "name": "Ashenmoor Gouger",
             "text": "Ashenmoor Gouger can't block.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "8f129a5c-3b99-5b20-8b96-e79c88fe82c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc8f83-07a5-4ced-a0f4-78c75c287903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc8f83-07a5-4ced-a0f4-78c75c287903.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may put a 1/1 black and green Worm creature token onto the battlefield.",
             "colours": [
@@ -6491,7 +6491,7 @@
         },
         {
             "id": "fe299dcf-a9cb-5606-a882-63a8bad859a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d19fbe-0f6d-4e22-b56d-a63fd17a48ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d19fbe-0f6d-4e22-b56d-a63fd17a48ef.jpg?1",
             "name": "Dimir Guildmage",
             "text": "{3}{U}: Target player draws a card. Activate this ability only any time you could cast a sorcery.\n{3}{B}: Target player discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "d9dfa079-9428-5138-af1e-837f1dd77f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b128089-ed05-4a94-b83e-a5f783b8cec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b128089-ed05-4a94-b83e-a5f783b8cec8.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -6565,7 +6565,7 @@
         },
         {
             "id": "69f2bb1a-4059-5274-9991-136ab758b990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee5eda-41a9-4cae-bb2a-b63fd450d02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee5eda-41a9-4cae-bb2a-b63fd450d02d.jpg?1",
             "name": "Hearthfire Hobgoblin",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "cf04505f-9122-5e42-8b4e-f89947b6dd54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f002636-1971-468d-b171-7b8147829972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f002636-1971-468d-b171-7b8147829972.jpg?1",
             "name": "Nobilis of War",
             "text": "Flying\nAttacking creatures you control get +2/+0.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "c77d29c1-7056-5246-8103-0e9155a4304e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aea782-f054-41bc-8681-7e2246e6f3fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aea782-f054-41bc-8681-7e2246e6f3fd.jpg?1",
             "name": "Restless Apparition",
             "text": "{WB}{WB}{WB}: Restless Apparition gets +3/+3 until end of turn.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "33c42eee-52ab-56fc-a010-b5cf5832331a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ed69a0-8793-45c0-8971-98a062b8b1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ed69a0-8793-45c0-8971-98a062b8b1fb.jpg?1",
             "name": "Selesnya Guildmage",
             "text": "{3}{G}: Put a 1/1 green Saproling creature token onto the battlefield.\n{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "de4d7ab9-bbe8-5985-a1eb-783516a5f953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4e3f7-bef1-419b-963e-9fee4ee23b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4e3f7-bef1-419b-963e-9fee4ee23b0e.jpg?1",
             "name": "Shrewd Hatchling",
             "text": "Shrewd Hatchling enters the battlefield with four -1/-1 counters on it.\n{UR}: Target creature can't block Shrewd Hatchling this turn.\nWhenever you cast a blue spell, remove a -1/-1 counter from Shrewd Hatchling.\nWhenever you cast a red spell, remove a -1/-1 counter from Shrewd Hatchling.",
             "colours": [
@@ -6748,7 +6748,7 @@
         },
         {
             "id": "57933a16-5019-5e79-8c74-a278082feba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8903e1d-e255-4eda-bb8e-c6229a88c8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8903e1d-e255-4eda-bb8e-c6229a88c8a7.jpg?1",
             "name": "Swans of Bryn Argoll",
             "text": "Flying\nIf a source would deal damage to Swans of Bryn Argoll, prevent that damage. The source's controller draws cards equal to the damage prevented this way.",
             "colours": [
@@ -6785,7 +6785,7 @@
         },
         {
             "id": "8dbc018a-892d-561b-a5de-0b89f551347d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0bcfad-cb7e-4b12-b308-a4a1245bd835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0bcfad-cb7e-4b12-b308-a4a1245bd835.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "c8801149-3f76-5c62-acb9-a0bd4d229af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a82ecd-ce0c-456e-bb79-b3b8d6602e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a82ecd-ce0c-456e-bb79-b3b8d6602e1b.jpg?1",
             "name": "Alloy Myr",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6853,7 +6853,7 @@
         },
         {
             "id": "f842237a-3f2d-5314-8967-b7a8e83283ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0dfbd3-4b19-4f56-b6c2-7107a3cba4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0dfbd3-4b19-4f56-b6c2-7107a3cba4ec.jpg?1",
             "name": "Blinding Souleater",
             "text": "{PW}, {T}: Tap target creature. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [],
@@ -6887,7 +6887,7 @@
         },
         {
             "id": "c77f1971-edf5-5ebe-a84d-f8fa0d83ac11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3dbd79-c0a3-44ec-bf52-611515c865c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3dbd79-c0a3-44ec-bf52-611515c865c4.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion dies, add {3} to your mana pool.",
             "colours": [],
@@ -6918,7 +6918,7 @@
         },
         {
             "id": "2515fcf6-fe2e-5457-ab8d-bff8f2a668c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef3dea8-b3e5-432e-a65d-442fe06ca976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef3dea8-b3e5-432e-a65d-442fe06ca976.jpg?1",
             "name": "Chimeric Mass",
             "text": "Chimeric Mass enters the battlefield with X charge counters on it.\n{1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"",
             "colours": [],
@@ -6946,7 +6946,7 @@
         },
         {
             "id": "14baa456-522e-5d71-ac9f-9150c049372d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eb220b-3ff1-4396-87e3-7aaaa1098691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eb220b-3ff1-4396-87e3-7aaaa1098691.jpg?1",
             "name": "Copper Carapace",
             "text": "Equipped creature gets +2/+2 and can't block.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6976,7 +6976,7 @@
         },
         {
             "id": "6581220c-9d1a-5db9-94de-b0311db49d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9478c80-621a-4b5c-8ba9-fa790f0619d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9478c80-621a-4b5c-8ba9-fa790f0619d8.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "b0db95b7-e990-53f5-be8e-9498d9b65fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5aaf42f-aee0-4874-9408-3e9e5480a0ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5aaf42f-aee0-4874-9408-3e9e5480a0ff.jpg?1",
             "name": "Culling Dais",
             "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
             "colours": [],
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "70640661-c46c-5c6d-ba1c-739e0acd3719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60beab79-8992-4f87-89b4-9eab03509f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60beab79-8992-4f87-89b4-9eab03509f38.jpg?1",
             "name": "Darksteel Axe",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.)\nEquipped creature gets +2/+0.\nEquip {2}",
             "colours": [],
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "e9478ff2-04a1-516f-b230-e84a0e28b4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe653b-956a-4e0e-981b-37e1a6b08c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe653b-956a-4e0e-981b-37e1a6b08c2c.jpg?1",
             "name": "Etched Champion",
             "text": "Metalcraft \u2014 Etched Champion has protection from all colors as long as you control three or more artifacts.",
             "colours": [],
@@ -7097,7 +7097,7 @@
         },
         {
             "id": "4f75f06d-4c2c-5165-b30d-fac714d3e74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6be7947-b929-408d-ad67-3b07b93dd36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6be7947-b929-408d-ad67-3b07b93dd36e.jpg?1",
             "name": "Etched Monstrosity",
             "text": "Etched Monstrosity enters the battlefield with five -1/-1 counters on it.\n{W}{U}{B}{R}{G}, Remove five -1/-1 counters from Etched Monstrosity: Target player draws three cards.",
             "colours": [],
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "2b5ce2a9-dbde-5aeb-9e4d-a99baca77a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874c6926-1368-45fb-8ce6-2d1c3e231bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874c6926-1368-45fb-8ce6-2d1c3e231bf0.jpg?1",
             "name": "Etched Oracle",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\n{1}, Remove four +1/+1 counters from Etched Oracle: Target player draws three cards.",
             "colours": [],
@@ -7166,7 +7166,7 @@
         },
         {
             "id": "f010c67b-6a24-575f-8e28-e4d5347d554f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4477e730-6dff-44f1-97a5-8176be1b7f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4477e730-6dff-44f1-97a5-8176be1b7f67.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {1} to your mana pool for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "5beee4c5-3ad7-58f5-a1d5-eaff3c63c256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c708dbd5-1d7b-4ed3-b5a7-93a02d8355ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c708dbd5-1d7b-4ed3-b5a7-93a02d8355ee.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "c37305a1-8c82-50f4-a8de-e8d0d20b0d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a51797a-8a37-4364-86a0-de087348bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a51797a-8a37-4364-86a0-de087348bc82.jpg?1",
             "name": "Flayer Husk",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +1/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "7369197c-c2bf-5b20-b6c5-54124db482c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2991802-e313-40de-b167-0ede5efff101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2991802-e313-40de-b167-0ede5efff101.jpg?1",
             "name": "Frogmite",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7283,7 +7283,7 @@
         },
         {
             "id": "baa8d556-1007-543e-96a7-7bbabd838c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c64d2e-1fbf-4858-8fa7-82bf2e41fe1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c64d2e-1fbf-4858-8fa7-82bf2e41fe1f.jpg?1",
             "name": "Glint Hawk Idol",
             "text": "Whenever another artifact enters the battlefield under your control, you may have Glint Hawk Idol become a 2/2 Bird artifact creature with flying until end of turn.\n{W}: Glint Hawk Idol becomes a 2/2 Bird artifact creature with flying until end of turn.",
             "colours": [],
@@ -7313,7 +7313,7 @@
         },
         {
             "id": "e9aca47f-5435-53f9-ad3c-dfee55e77f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddac7b40-f98e-497b-8075-4695ed3ee490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddac7b40-f98e-497b-8075-4695ed3ee490.jpg?1",
             "name": "Gust-Skimmer",
             "text": "{U}: Gust-Skimmer gains flying until end of turn.",
             "colours": [],
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "11ce0800-ea53-5a98-8fee-28fd9ae2d983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf0479c-4d90-4b81-8170-a42100f91d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf0479c-4d90-4b81-8170-a42100f91d89.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7376,7 +7376,7 @@
         },
         {
             "id": "025fbf5d-fede-58ea-939c-497768b28a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683a5707-cddb-494d-9b41-51b4584ded69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683a5707-cddb-494d-9b41-51b4584ded69.jpg?1",
             "name": "Lodestone Golem",
             "text": "Nonartifact spells cost {1} more to cast.",
             "colours": [],
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "68a15e39-f148-5799-bb3f-328d42adadc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617ddf01-3678-470d-b009-003d6a561dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617ddf01-3678-470d-b009-003d6a561dbf.jpg?1",
             "name": "Lodestone Myr",
             "text": "Trample\nTap an untapped artifact you control: Lodestone Myr gets +1/+1 until end of turn.",
             "colours": [],
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "f3b1319b-c9e5-5b30-bd80-15d8d5fd701d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced123-3eb4-405e-b26d-30644f35a5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced123-3eb4-405e-b26d-30644f35a5b0.jpg?1",
             "name": "Long-Forgotten Gohei",
             "text": "Arcane spells you cast cost {1} less to cast.\nSpirit creatures you control get +1/+1.",
             "colours": [],
@@ -7466,7 +7466,7 @@
         },
         {
             "id": "12700cfb-815d-5e1d-9c2c-3c31a92a8fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e6b292-41e7-40f9-b9fe-34f27d4526af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e6b292-41e7-40f9-b9fe-34f27d4526af.jpg?1",
             "name": "Mortarpod",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +0/+1 and has \"Sacrifice this creature: This creature deals 1 damage to target creature or player.\"\nEquip {2}",
             "colours": [],
@@ -7496,7 +7496,7 @@
         },
         {
             "id": "38428eaf-113e-5a41-b79f-5f738c9599ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3a20ac-1860-4513-bb73-35d23b088b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3a20ac-1860-4513-bb73-35d23b088b04.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color to your mana pool. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -7526,7 +7526,7 @@
         },
         {
             "id": "5621fae1-b71a-57d4-916b-68e2037a02db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff51ae7-4b68-4770-915b-fb6bcf9ca1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff51ae7-4b68-4770-915b-fb6bcf9ca1ed.jpg?1",
             "name": "Myr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "541f26de-592d-5efc-b5d5-af5606b94879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc90d632-fc78-4ae6-83c6-314ee5744de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc90d632-fc78-4ae6-83c6-314ee5744de5.jpg?1",
             "name": "Precursor Golem",
             "text": "When Precursor Golem enters the battlefield, put two 3/3 colorless Golem artifact creature tokens onto the battlefield.\nWhenever a player casts an instant or sorcery spell that targets only a single Golem, that player copies that spell for each other Golem that spell could target. Each copy targets a different one of those Golems.",
             "colours": [],
@@ -7588,7 +7588,7 @@
         },
         {
             "id": "3215ca23-5730-5145-bbfa-956cee7b78a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbb0a4-b788-4fe7-8663-36adbe2036ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbb0a4-b788-4fe7-8663-36adbe2036ed.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "76c91584-220e-5a17-aeaf-430056622eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797a4456-1677-49d5-bb4f-4fb062522f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797a4456-1677-49d5-bb4f-4fb062522f1e.jpg?1",
             "name": "Rusted Relic",
             "text": "Metalcraft \u2014 Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.",
             "colours": [],
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "47e44e78-b6d3-514f-a7be-836590c1df0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a9736-c84d-42a6-831c-3b1a8bad50b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a9736-c84d-42a6-831c-3b1a8bad50b7.jpg?1",
             "name": "Sickleslicer",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+2.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "7b0acf05-5414-5ede-98fd-aa071ecf3696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df1e8a0-6a54-4be9-bd0c-ac70f0ae9aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df1e8a0-6a54-4be9-bd0c-ac70f0ae9aa6.jpg?1",
             "name": "Skyreach Manta",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\nFlying",
             "colours": [],
@@ -7708,7 +7708,7 @@
         },
         {
             "id": "9a9e432b-2911-55bc-8572-e9f59e356a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e0daf-aafe-4696-a977-ac5b822134e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e0daf-aafe-4696-a977-ac5b822134e2.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "d50ab590-465f-56b5-ae1d-74fffe98c4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f7dd0-290f-4ba4-aa2d-29ff148e7778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f7dd0-290f-4ba4-aa2d-29ff148e7778.jpg?1",
             "name": "Sphere of the Suns",
             "text": "Sphere of the Suns enters the battlefield tapped and with three charge counters on it.\n{T}, Remove a charge counter from Sphere of the Suns: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "9456061d-9907-5669-9d67-d1239f2d6aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6e159-f229-44a8-b542-78e3c3d6ec79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6e159-f229-44a8-b542-78e3c3d6ec79.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -7803,7 +7803,7 @@
         },
         {
             "id": "f18abb27-6da8-5ce3-b07c-2004c0bd3818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c158f888-1870-4be7-9afd-39e859f261a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c158f888-1870-4be7-9afd-39e859f261a6.jpg?1",
             "name": "Tumble Magnet",
             "text": "Tumble Magnet enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Tumble Magnet: Tap target artifact or creature.",
             "colours": [],
@@ -7831,7 +7831,7 @@
         },
         {
             "id": "cf584269-cbb1-5b4e-9f86-e86cda6ede0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1272beac-71ac-4a88-bd49-a5a907c182ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1272beac-71ac-4a88-bd49-a5a907c182ac.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "52c4be91-b07d-50b0-a8f2-262c736a87fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481a83e6-0e6c-4953-92d4-814000d19456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481a83e6-0e6c-4953-92d4-814000d19456.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "d00e838f-9d91-5d64-b6fe-ce778ef30660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0e338-fe48-4108-b1a4-0bc9bf4ed708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0e338-fe48-4108-b1a4-0bc9bf4ed708.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -7918,7 +7918,7 @@
         },
         {
             "id": "72f4ed14-bdd3-5685-8bc6-2c1432014986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750975a0-112b-439f-ae4e-40480aa64823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750975a0-112b-439f-ae4e-40480aa64823.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "c40d6468-339d-57a0-87ca-b995cb4c630a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371077bd-9b4b-4c75-9494-c6a3cb1b304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371077bd-9b4b-4c75-9494-c6a3cb1b304d.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this land.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "3496ded9-3a71-57f3-b1ed-5cc0bf97b2ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b68dd-9a83-4e6e-9e34-53eb80311425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b68dd-9a83-4e6e-9e34-53eb80311425.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -8009,7 +8009,7 @@
         },
         {
             "id": "d1b618a1-4255-559e-bb96-6da1b4c14f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab30d54-6043-4361-b221-268813f06a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab30d54-6043-4361-b221-268813f06a72.jpg?1",
             "name": "Eldrazi Temple",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {2} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
             "colours": [],
@@ -8037,7 +8037,7 @@
         },
         {
             "id": "e070deb8-c601-552c-878d-783885aca2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd49258-f7cd-4902-a17f-9a195958fc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd49258-f7cd-4902-a17f-9a195958fc13.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8065,7 +8065,7 @@
         },
         {
             "id": "688e5b80-1eb3-587c-8c83-8c6df5c9ec8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5124b-4d73-4aa9-9331-88e03779ffad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5124b-4d73-4aa9-9331-88e03779ffad.jpg?1",
             "name": "Eye of Ugin",
             "text": "Colorless Eldrazi spells you cast cost {2} less to cast.\n{7}, {T}: Search your library for a colorless creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "49011692-04ae-5526-a27f-17ff702cead0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580063b8-9b0d-4ce0-bf2b-63299e15219e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580063b8-9b0d-4ce0-bf2b-63299e15219e.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -8126,7 +8126,7 @@
         },
         {
             "id": "3439ff7e-d227-5bc5-9093-d2ce119a1340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1325d187-4012-4875-9a0c-8520cbf386ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1325d187-4012-4875-9a0c-8520cbf386ac.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "ae4832e2-8003-5b5a-b4b1-fbbef89a6b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2759-a3d8-45f8-b31e-d8789bde0f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2759-a3d8-45f8-b31e-d8789bde0f4f.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -8188,7 +8188,7 @@
         },
         {
             "id": "9df98f4e-6524-5eee-bce7-9b3f876c9eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6b961-303d-4585-801a-82690e3c66d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6b961-303d-4585-801a-82690e3c66d9.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -8219,7 +8219,7 @@
         },
         {
             "id": "e32f09a0-09f9-596e-b372-86a9bdd33c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7e0892-7f4f-4dea-8eba-088250512071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7e0892-7f4f-4dea-8eba-088250512071.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "7d46291d-56ef-595f-8b56-c869eba2646d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbde99df-95bb-4941-981c-127c19f90488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbde99df-95bb-4941-981c-127c19f90488.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "1578cced-d0b0-53dc-b4a8-116e4ad38b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4c9c55-456f-4cc5-b727-4091708b0df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4c9c55-456f-4cc5-b727-4091708b0df1.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -8312,7 +8312,7 @@
         },
         {
             "id": "bab776c5-7084-5285-90e2-89d8a1413dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1ef4fc-9b03-4750-90c9-aaa0017579dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1ef4fc-9b03-4750-90c9-aaa0017579dc.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8343,7 +8343,7 @@
         },
         {
             "id": "5aac07aa-bf49-5b6b-98c1-a66f5cf75f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94559ea-b4c8-42e5-81b5-df45b2d711fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94559ea-b4c8-42e5-81b5-df45b2d711fd.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8374,7 +8374,7 @@
         },
         {
             "id": "d461a50f-61bc-58fa-84e5-28fd6f6c9fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaae110-ef18-44fa-b8a8-c68bd439581e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaae110-ef18-44fa-b8a8-c68bd439581e.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "21fb09ef-4b2e-508e-bfe0-6031a66fa198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d480a351-cb9d-4bcc-b5c4-cd197ae98d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d480a351-cb9d-4bcc-b5c4-cd197ae98d43.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "3b3ea474-8c13-5cf0-80de-328b45661723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8473,7 +8473,7 @@
         },
         {
             "id": "2af42eb8-cf37-5bcc-acaf-fc2c33288ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b53311-d007-42e8-94c0-c18052b6ef09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b53311-d007-42e8-94c0-c18052b6ef09.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "89b1fd11-e64b-50f0-86f0-b6f945a19c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414f9fa-dfda-4714-9f87-cb5e8914b07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414f9fa-dfda-4714-9f87-cb5e8914b07a.jpg?1",
             "name": "Germ",
             "text": "",
             "colours": [
@@ -8542,7 +8542,7 @@
         },
         {
             "id": "b6afe76a-9a45-5137-bf59-206e7ae7cbf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9f471a-1822-4981-95a9-8923d83ddcbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9f471a-1822-4981-95a9-8923d83ddcbf.jpg?1",
             "name": "Thrull",
             "text": "",
             "colours": [
@@ -8576,7 +8576,7 @@
         },
         {
             "id": "3d55fbc5-53e0-5290-925d-85d38bc10fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbccfc7-427b-41e6-b770-92d73994bf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbccfc7-427b-41e6-b770-92d73994bf3b.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "c7dbe124-4f58-5649-828f-e3368d4ed796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599b5074-86a5-4666-8cf4-3deb83c09ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599b5074-86a5-4666-8cf4-3deb83c09ba0.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "52c46d94-2f16-5836-99d0-da960c87f1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa39099-1ce8-4d59-bc2e-6bb99d10e97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa39099-1ce8-4d59-bc2e-6bb99d10e97c.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8678,7 +8678,7 @@
         },
         {
             "id": "b55c7874-9928-5560-9363-817a95c560ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a452235-cebd-4e8f-b217-9b55fc1c3830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a452235-cebd-4e8f-b217-9b55fc1c3830.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "61601928-3f3b-5630-a518-f339dc673ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb3368-fee3-4795-a23f-c97555ee7475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb3368-fee3-4795-a23f-c97555ee7475.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "90745830-76bc-59b4-a11b-1100fbe50fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd82205-5d3e-4a8d-a31b-020efc6303d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd82205-5d3e-4a8d-a31b-020efc6303d0.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -8782,7 +8782,7 @@
         },
         {
             "id": "94a1b77a-1e22-551f-ba1f-0838a6549d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae65394e-0c97-4cde-8591-13d081192e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae65394e-0c97-4cde-8591-13d081192e26.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -8813,7 +8813,7 @@
         },
         {
             "id": "ad927c4e-b2bb-5385-8ce6-d7316cc51623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a8c1a6-a88a-4b23-bd80-95769ea4917c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a8c1a6-a88a-4b23-bd80-95769ea4917c.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MM3.json
+++ b/Assets/Resources/Sets/MM3.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "15844e0d-9a41-505e-8f09-59bcaf3f9650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac22a3b-4536-4372-a854-bc7f0919830b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac22a3b-4536-4372-a854-bc7f0919830b.jpg?1",
             "name": "Attended Knight",
             "text": "First strike\nWhen Attended Knight enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "2f86fa48-502d-5bc6-959a-ee10ec41a57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eea01e5-d3ea-4d05-8d17-cae7b982d882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eea01e5-d3ea-4d05-8d17-cae7b982d882.jpg?1",
             "name": "Banishing Stroke",
             "text": "Put target artifact, creature, or enchantment on the bottom of its owner's library.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "d9cec7c7-5d1b-5c0e-9a01-96bd34d28b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d53b9ef-fedc-4471-ac90-018d7033a9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d53b9ef-fedc-4471-ac90-018d7033a9fc.jpg?1",
             "name": "Blade Splicer",
             "text": "When Blade Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control have first strike.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "92eeff2b-e0bc-525f-8cd8-bcee557f9742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916becd7-3be9-4525-83cf-3dd133816f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916becd7-3be9-4525-83cf-3dd133816f69.jpg?1",
             "name": "Entreat the Angels",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "2864e0cd-f5cd-574f-8d71-018c1bfaa0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a1d9ad-a434-43de-bcb3-143d07dbd775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a1d9ad-a434-43de-bcb3-143d07dbd775.jpg?1",
             "name": "Eyes in the Skies",
             "text": "Create a 1/1 white Bird creature token with flying, then populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "b448d4cf-c2e8-5511-a067-ddbcc0b85ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcfcf9a7-bad6-4240-8e43-a6a81fc4fbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcfcf9a7-bad6-4240-8e43-a6a81fc4fbd0.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "601385d5-2441-5035-b9e7-4a26bb31d059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df30f49a-32a2-4e9f-8f2a-1b9fab98dc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df30f49a-32a2-4e9f-8f2a-1b9fab98dc3f.jpg?1",
             "name": "Gideon's Lawkeeper",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "a4085eb4-95ef-5e46-9076-4a6afc8af638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad31171-ad46-4654-91f0-8027e00dedfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad31171-ad46-4654-91f0-8027e00dedfc.jpg?1",
             "name": "Graceful Reprieve",
             "text": "When target creature dies this turn, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "b6f11a93-f77d-5123-baee-83ee31b97557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa549-5eab-42df-b6a8-dd042d598191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa549-5eab-42df-b6a8-dd042d598191.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "2d2bf67f-de2d-549c-8c6c-56d90be67472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c77d014-8ea2-4203-88b4-53be3819bf3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c77d014-8ea2-4203-88b4-53be3819bf3c.jpg?1",
             "name": "Kor Hookmaster",
             "text": "When Kor Hookmaster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "e23db86a-46e9-5b73-8c88-15dd24c5ed17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7501662-1216-4e08-bd2b-e0a459057942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7501662-1216-4e08-bd2b-e0a459057942.jpg?1",
             "name": "Kor Skyfisher",
             "text": "Flying\nWhen Kor Skyfisher enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "1bc7525f-2954-5402-9d90-031229a60162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf1288a-8e2c-4a69-afcf-af293f66d007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf1288a-8e2c-4a69-afcf-af293f66d007.jpg?1",
             "name": "Lingering Souls",
             "text": "Create two 1/1 white Spirit creature tokens with flying.\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -407,7 +407,7 @@
         },
         {
             "id": "8012aebe-9845-51fb-a6be-6072bfc76c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb2588-60f7-4e3b-b625-3b3ada7bcc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb2588-60f7-4e3b-b625-3b3ada7bcc28.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "Flying\nActivated abilities of creatures your opponents control can't be activated.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "c8286107-f1f6-5084-9cde-e7cd86ebaf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31d5b6-0973-43d2-aae0-a3f3e7a61800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31d5b6-0973-43d2-aae0-a3f3e7a61800.jpg?1",
             "name": "Lone Missionary",
             "text": "When Lone Missionary enters the battlefield, you gain 4 life.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "4220910a-df68-54f4-8c53-97dfa455bbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c44c1e-60b8-49f7-af9a-d23dcd8a3771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c44c1e-60b8-49f7-af9a-d23dcd8a3771.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control get +1/+1.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "e1f7fcbe-6ece-5ec3-a243-185adbd4f54e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4206d5f8-edeb-4e0b-8e98-736f6ccdcf99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4206d5f8-edeb-4e0b-8e98-736f6ccdcf99.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "4df6983c-041f-58b0-9cdf-863354f53f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df0a2-1967-4ddd-84e3-3ecf3af98f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df0a2-1967-4ddd-84e3-3ecf3af98f6b.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "32ca9f44-1e73-5ac5-91a0-3d99bafe2e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a4596-552a-45dc-88a6-41810d078d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a4596-552a-45dc-88a6-41810d078d66.jpg?1",
             "name": "Pitfall Trap",
             "text": "If exactly one creature is attacking, you may pay {W} rather than pay Pitfall Trap's mana cost.\nDestroy target attacking creature without flying.",
             "colours": [
@@ -613,7 +613,7 @@
         },
         {
             "id": "d4a9c43a-5439-56af-ac34-fa86d03b3855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3ba78b-c66a-4a93-abc6-18b63779eda3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3ba78b-c66a-4a93-abc6-18b63779eda3.jpg?1",
             "name": "Ranger of Eos",
             "text": "When Ranger of Eos enters the battlefield, you may search your library for up to two creature cards with converted mana cost 1 or less, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "ca02530d-db71-5096-a23b-af87dc85cea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958bcdd-d0ea-4ae0-9dd0-e6de5cf74128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958bcdd-d0ea-4ae0-9dd0-e6de5cf74128.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "908d81d6-a9e1-53fb-b523-560181cfc20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a945-1e7f-4598-a17b-5af0e7921ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a945-1e7f-4598-a17b-5af0e7921ca8.jpg?1",
             "name": "Rootborn Defenses",
             "text": "Populate. Creatures you control gain indestructible until end of turn. (To populate, create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "dc59d2d9-6937-5b69-bdad-7fbce211b307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e376bdf-076c-471a-9408-b36fc5b8405b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e376bdf-076c-471a-9408-b36fc5b8405b.jpg?1",
             "name": "S\u00e9ance",
             "text": "At the beginning of each upkeep, you may exile target creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a Spirit in addition to its other types. Exile it at the beginning of the next end step.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "2aa9dee2-f81d-5d09-9967-cc78d1862c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369340f-d170-4566-b8e8-e4dc918f7f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369340f-d170-4566-b8e8-e4dc918f7f85.jpg?1",
             "name": "Sensor Splicer",
             "text": "When Sensor Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control have vigilance.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "c5041bf0-7449-5042-8323-a03e68c45e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96266b3-a7cb-40ce-a328-ac13719fe5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96266b3-a7cb-40ce-a328-ac13719fe5f0.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature enters the battlefield, you gain 1 life.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "3c5996de-3d24-5355-b519-0653ad2a8256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7faede-f794-4bda-9d64-21390ba19266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7faede-f794-4bda-9d64-21390ba19266.jpg?1",
             "name": "Stony Silence",
             "text": "Activated abilities of artifacts can't be activated.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "1e28cf88-7b46-5bd8-8950-5c2d04d6224b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e564a2c-e8f0-4ef2-bb1f-1d607dcb0b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e564a2c-e8f0-4ef2-bb1f-1d607dcb0b63.jpg?1",
             "name": "Terminus",
             "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "2f04cfc5-f0ad-591d-86e6-e2d002973550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ddc04b-49ce-41ca-aadc-e0e9234ac762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ddc04b-49ce-41ca-aadc-e0e9234ac762.jpg?1",
             "name": "Urbis Protector",
             "text": "When Urbis Protector enters the battlefield, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "9d56a27f-4b14-5829-96a4-047258af0535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fad4c2-7db2-4ed2-8b86-e386311512e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fad4c2-7db2-4ed2-8b86-e386311512e7.jpg?1",
             "name": "Wake the Reflections",
             "text": "Populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "d7afb942-c88e-53a3-858f-e2c03df56869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443e222b-4988-4d0f-9a7c-3e859b0211da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443e222b-4988-4d0f-9a7c-3e859b0211da.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "7d08edc7-cd9f-5ec4-89f5-aac423f9f400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7eca7a-5f42-4e58-a6c0-8d07517bda8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7eca7a-5f42-4e58-a6c0-8d07517bda8a.jpg?1",
             "name": "Augur of Bolas",
             "text": "When Augur of Bolas enters the battlefield, look at the top three cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "f1fdfef9-21d8-54e4-85e6-68d9a634bbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a7ed36-a552-4d46-929a-48f34ae9279a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a7ed36-a552-4d46-929a-48f34ae9279a.jpg?1",
             "name": "Azure Mage",
             "text": "{3}{U}: Draw a card.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "25b4ddc4-5c68-5eee-a1d3-b0ecd65256a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ad8a5a-9814-4fb5-90b1-95c0769be456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ad8a5a-9814-4fb5-90b1-95c0769be456.jpg?1",
             "name": "Cackling Counterpart",
             "text": "Create a token that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "051934ee-90e9-5f23-b133-63770d910299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5987001-abe9-4418-956e-3a360483cab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5987001-abe9-4418-956e-3a360483cab7.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless he or she discards a land card.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "6c42dda0-3dff-5a5d-bf43-b6a481906576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f73e5f-6228-494f-b74e-aca3520dc2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f73e5f-6228-494f-b74e-aca3520dc2b2.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "9580af62-c91a-5e30-9a41-0f2600535b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f6afc-bf16-4ca7-a986-945a95d3bffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f6afc-bf16-4ca7-a986-945a95d3bffc.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "b3d82a89-3345-5bb6-8f46-b6e1083f6674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a79b9-9f09-476e-b914-cade929dd852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a79b9-9f09-476e-b914-cade929dd852.jpg?1",
             "name": "Deadeye Navigator",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Deadeye Navigator is paired with another creature, each of those creatures has \"{1}{U}: Exile this creature, then return it to the battlefield under your control.\"",
             "colours": [
@@ -1215,7 +1215,7 @@
         },
         {
             "id": "63d228ad-2fb1-5418-b35c-afa438df5904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179d2a5-4694-4dcc-9261-9f5201c53a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179d2a5-4694-4dcc-9261-9f5201c53a67.jpg?1",
             "name": "Familiar's Ruse",
             "text": "As an additional cost to cast Familiar's Ruse, return a creature you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "29171849-893b-506b-9a9b-6bc0f3c7a1f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44335ed-44ba-4c33-b3ed-d7529be23b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44335ed-44ba-4c33-b3ed-d7529be23b4e.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1280,7 +1280,7 @@
         },
         {
             "id": "93f8fd7f-1683-583f-b52f-5f8eebaf5b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccd7eda-5c10-4aa7-a70c-b52f685972e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccd7eda-5c10-4aa7-a70c-b52f685972e4.jpg?1",
             "name": "Ghostly Flicker",
             "text": "Exile two target artifacts, creatures, and/or lands you control, then return those cards to the battlefield under your control.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "600b31a4-0a9f-5c04-bfcf-f9c03d5421d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11f693-716e-41de-a0ea-2a5178a284dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11f693-716e-41de-a0ea-2a5178a284dc.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "b96adaf5-394a-530c-820a-b9515b65873d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f4b833-0352-4dba-a3e7-6570cbeaad4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f4b833-0352-4dba-a3e7-6570cbeaad4f.jpg?1",
             "name": "Grasp of Phantoms",
             "text": "Put target creature on top of its owner's library.\nFlashback {7}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "f9b1084b-b5ad-5895-981c-b2dbb6aa4127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461dee11-e89c-4f2e-8f62-6327df19c295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461dee11-e89c-4f2e-8f62-6327df19c295.jpg?1",
             "name": "Kraken Hatchling",
             "text": "",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "ef7120eb-db84-5edb-bd00-8b43efe714e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8543f-5c5d-4b1a-ad96-f154f1914608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8543f-5c5d-4b1a-ad96-f154f1914608.jpg?1",
             "name": "Mist Raven",
             "text": "Flying\nWhen Mist Raven enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "b74773e8-2e59-5210-87f1-65003509fbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3a4e2-b3d2-4803-bcaf-5d63bff0feb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3a4e2-b3d2-4803-bcaf-5d63bff0feb5.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, and put it into your hand. Then shuffle your library.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "e30eba44-b93d-5d5d-b556-ea4348842422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485c71e7-8c2d-41bf-bfa3-b200c43751c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485c71e7-8c2d-41bf-bfa3-b200c43751c3.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "8ce8bdc2-7f08-576d-b21e-5500a88acb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7472958-dd1b-48a7-a960-ec2ef3b69ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7472958-dd1b-48a7-a960-ec2ef3b69ded.jpg?1",
             "name": "Phantasmal Image",
             "text": "You may have Phantasmal Image enter the battlefield as a copy of any creature on the battlefield, except it's an Illusion in addition to its other types and it gains \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "0f8b24e6-b8f7-5ff0-a7b3-5fff15bcf1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bf287-488c-4fdf-b9ff-fc2065697123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bf287-488c-4fdf-b9ff-fc2065697123.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "6d42f19d-7c2f-5b06-a026-d60b5c9932c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b075e2-6669-4074-a8df-91287970ecfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b075e2-6669-4074-a8df-91287970ecfc.jpg?1",
             "name": "Sea Gate Oracle",
             "text": "When Sea Gate Oracle enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "cec79f6f-39b6-593c-9a7b-8699decaaf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20296a5b-4e15-4f07-8bce-9a37abb35729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20296a5b-4e15-4f07-8bce-9a37abb35729.jpg?1",
             "name": "Serum Visions",
             "text": "Draw a card. Scry 2.",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "3a6672fc-7257-522e-b984-af7b4c531ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbdacc1-7a1b-4633-85f5-eb50c2bf406d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbdacc1-7a1b-4633-85f5-eb50c2bf406d.jpg?1",
             "name": "Snapcaster Mage",
             "text": "Flash\nWhen Snapcaster Mage enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "ae0f552f-f158-501f-be88-9d0181ad71a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d4fd57-74b6-42c7-88b1-110e5a8dfc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d4fd57-74b6-42c7-88b1-110e5a8dfc3c.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "827d2b86-145a-5e5f-8672-338096a820f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30ed6e1-d713-40ae-81f6-d2d66914bbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30ed6e1-d713-40ae-81f6-d2d66914bbb9.jpg?1",
             "name": "Spire Monitor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "b713d875-0a40-54a7-95b4-bb41dc823f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e44b411-ccb8-44c8-a021-2372c945f0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e44b411-ccb8-44c8-a021-2372c945f0d3.jpg?1",
             "name": "Tandem Lookout",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Tandem Lookout is paired with another creature, each of those creatures has \"Whenever this creature deals damage to an opponent, draw a card.\"",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "fa5b6d69-1115-55fe-a39e-3706cb0080d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729cdea3-59ca-4b32-9a8a-9b0cdb4b3aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729cdea3-59ca-4b32-9a8a-9b0cdb4b3aaf.jpg?1",
             "name": "Temporal Mastery",
             "text": "Take an extra turn after this one. Exile Temporal Mastery.\nMiracle {1}{U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -1811,7 +1811,7 @@
         },
         {
             "id": "775b884c-b9f3-5482-819c-8fbc663b72a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a0243a-4661-4c7c-8dd2-9237bf9238de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a0243a-4661-4c7c-8dd2-9237bf9238de.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "bb49f5d8-6b06-5a6a-951d-534ab1bd8868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ab28ee-f70d-441b-bb4e-8e781f26e2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ab28ee-f70d-441b-bb4e-8e781f26e2bc.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "c757e073-9ba0-5587-9456-3eb207d67ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694873a-0b0c-4e9e-b9fc-249e80a09cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694873a-0b0c-4e9e-b9fc-249e80a09cca.jpg?1",
             "name": "Wing Splicer",
             "text": "When Wing Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control have flying.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "44159b52-21a7-58fe-a3e7-08fda4185c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79a71b-568f-4700-9b1d-e7965159da0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79a71b-568f-4700-9b1d-e7965159da0a.jpg?1",
             "name": "Wingcrafter",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Wingcrafter is paired with another creature, both creatures have flying.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "414c434b-eee3-53ca-907e-7fb526e565e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a41bec-7fb0-4060-918a-38cbbb329543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a41bec-7fb0-4060-918a-38cbbb329543.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter deals damage to a player, that player discards a card.",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "69abe39c-5ec9-5d33-b8f4-b63da63180ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c39f3-fcfb-4a73-a3f2-f17eb8bb9bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c39f3-fcfb-4a73-a3f2-f17eb8bb9bc4.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "87f1aed0-455f-5fcc-8c35-af03f7890ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef04b-5434-480e-82a1-118ed1ff551f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef04b-5434-480e-82a1-118ed1ff551f.jpg?1",
             "name": "Corpse Connoisseur",
             "text": "When Corpse Connoisseur enters the battlefield, you may search your library for a creature card and put that card into your graveyard. If you do, shuffle your library.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "0d68355d-5f7f-5cda-8001-64edce92c2a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3cc81-2c08-4281-aa16-4c22f141f31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3cc81-2c08-4281-aa16-4c22f141f31d.jpg?1",
             "name": "Cower in Fear",
             "text": "Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "72a19549-e1e1-5435-b102-ae5faa40ac9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795fdd00-5833-4732-bc73-0ebcd84aa330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795fdd00-5833-4732-bc73-0ebcd84aa330.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "a8fe7829-a820-5606-ad30-f1358b52e9dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddf501c-af11-4e97-81f7-32c9ee384a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddf501c-af11-4e97-81f7-32c9ee384a27.jpg?1",
             "name": "Death's Shadow",
             "text": "Death's Shadow gets -X/-X, where X is your life total.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "2f93aa80-c076-5688-a410-a7bd32bc5126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0d9e7-4a0f-4f07-99ae-31c3c9f0037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0d9e7-4a0f-4f07-99ae-31c3c9f0037a.jpg?1",
             "name": "Delirium Skeins",
             "text": "Each player discards three cards.",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "e46c9d1a-6cc3-5d2a-8e1a-7f70ca3341a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89936685-8647-4a65-b764-62fc4b49293a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89936685-8647-4a65-b764-62fc4b49293a.jpg?1",
             "name": "Desecration Demon",
             "text": "Flying\nAt the beginning of each combat, any opponent may sacrifice a creature. If a player does, tap Desecration Demon and put a +1/+1 counter on it.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "37d28ed4-9562-56bd-bdc8-3b51db7b24e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db87a2be-4490-45af-89d7-540549d1d6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db87a2be-4490-45af-89d7-540549d1d6af.jpg?1",
             "name": "Dregscape Zombie",
             "text": "Unearth {B} ({B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "8a89d9be-3e40-5b7d-afa9-57185ec9b6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c81d8-804b-4fe6-80df-8a4246fbf695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c81d8-804b-4fe6-80df-8a4246fbf695.jpg?1",
             "name": "Entomber Exarch",
             "text": "When Entomber Exarch enters the battlefield, choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target opponent reveals his or her hand. You choose a noncreature card from it. That player discards that card.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "31752da4-e7c8-5709-8401-d9f272ead242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb42b47-0ae4-4ca4-9e24-d398dca7bbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb42b47-0ae4-4ca4-9e24-d398dca7bbd1.jpg?1",
             "name": "Extractor Demon",
             "text": "Flying\nWhenever another creature leaves the battlefield, you may have target player put the top two cards of his or her library into his or her graveyard.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "dd86273c-fb26-5367-9328-78cb81b1a365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6e33d-9258-4bad-8f39-31afff272415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6e33d-9258-4bad-8f39-31afff272415.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "94ee91af-09ea-5ea9-a2e8-5103ae1a25ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bdd28d-7467-494b-a52f-a84932da25f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bdd28d-7467-494b-a52f-a84932da25f3.jpg?1",
             "name": "Gnawing Zombie",
             "text": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "ddf11d54-e83d-5d5a-953d-db23a91460ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a5c2e-7fe1-45eb-b01c-891ab961186f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a5c2e-7fe1-45eb-b01c-891ab961186f.jpg?1",
             "name": "Griselbrand",
             "text": "Flying, lifelink\nPay 7 life: Draw seven cards.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "507d76ad-ca7c-566b-b328-ae7c679dde1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61df7bd-6a9b-42e9-9d27-12777afc39c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61df7bd-6a9b-42e9-9d27-12777afc39c5.jpg?1",
             "name": "Grisly Spectacle",
             "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "5b459f13-99a4-5685-9d7b-154565cd512e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1fef26-7a5d-4e8d-95df-aac67dd25fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1fef26-7a5d-4e8d-95df-aac67dd25fd5.jpg?1",
             "name": "Grixis Slavedriver",
             "text": "When Grixis Slavedriver leaves the battlefield, create a 2/2 black Zombie creature token.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "18edf1ec-2fd3-5fe4-8164-f868dd05d3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7dd9fad-d8e3-4e46-b4d7-792d029736de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7dd9fad-d8e3-4e46-b4d7-792d029736de.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals his or her hand. You choose a nonland card from it with converted mana cost 3 or less. That player discards that card.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "cfa37e73-24fe-5c69-b8d6-91a87bbd6833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7125336c-4c2d-47a0-8caf-b755f4954176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7125336c-4c2d-47a0-8caf-b755f4954176.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of his or her choice.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "842afe2d-9d72-551b-93a7-63cac2cb0280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c44782-a12f-4ecc-a6e8-d569e2942a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c44782-a12f-4ecc-a6e8-d569e2942a9a.jpg?1",
             "name": "Mind Shatter",
             "text": "Target player discards X cards at random.",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "5d405c27-bb4e-553f-832c-26554ef5c729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f2a31-1c89-43cb-92f2-195026c9311a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f2a31-1c89-43cb-92f2-195026c9311a.jpg?1",
             "name": "Mortician Beetle",
             "text": "Whenever a player sacrifices a creature, you may put a +1/+1 counter on Mortician Beetle.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "532a482b-47f8-5b5f-bfde-e9cc3fbcd4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b41fe67-daf0-47ed-8f0e-db216f8394d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b41fe67-daf0-47ed-8f0e-db216f8394d1.jpg?1",
             "name": "Night Terrors",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. Exile that card.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "3ffb44b8-52d2-5297-9cf5-8e6fd52d7d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55a961-9eb7-4b9b-9be3-d4a0a5b76efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55a961-9eb7-4b9b-9be3-d4a0a5b76efb.jpg?1",
             "name": "Ogre Jailbreaker",
             "text": "Defender\nOgre Jailbreaker can attack as though it didn't have defender as long as you control a Gate.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "0df1aed1-d5d1-517e-9691-c991e9f97ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dc02f8-43aa-4b66-8dfe-08ab9b110e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dc02f8-43aa-4b66-8dfe-08ab9b110e0c.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper enters the battlefield, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "054e8720-bff1-5987-a882-d86ac7e01be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba44d21e-b1f4-4691-9895-6dda5015ad34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba44d21e-b1f4-4691-9895-6dda5015ad34.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "2a969b45-b5bf-5a39-8452-3d935af09fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3647ef4a-fbf3-4f64-8376-72c9247bbc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3647ef4a-fbf3-4f64-8376-72c9247bbc22.jpg?1",
             "name": "Seal of Doom",
             "text": "Sacrifice Seal of Doom: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "06a31bbc-95da-5586-a3ad-2e4a0447cce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9628c3bb-2fce-4321-bb6a-b0a3377649d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9628c3bb-2fce-4321-bb6a-b0a3377649d6.jpg?1",
             "name": "Sever the Bloodline",
             "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "1fcc7c15-0075-59c0-8db2-51a3c0650245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f3dce1-4e78-4a5f-bc35-0c008669308a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f3dce1-4e78-4a5f-bc35-0c008669308a.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "4c9335cd-8848-58e1-a5bd-416306b85464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a6d22-2e87-410c-b42a-6b54d83a7d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a6d22-2e87-410c-b42a-6b54d83a7d30.jpg?1",
             "name": "Vampire Aristocrat",
             "text": "Sacrifice a creature: Vampire Aristocrat gets +2/+2 until end of turn.",
             "colours": [
@@ -2894,7 +2894,7 @@
         },
         {
             "id": "087d1b96-fc16-5eb2-9a33-7f6274c5cc31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6572c70-7162-440d-a315-9fb31cc4849d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6572c70-7162-440d-a315-9fb31cc4849d.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying, deathtouch, lifelink",
             "colours": [
@@ -2929,7 +2929,7 @@
         },
         {
             "id": "a066c50f-437a-5ddf-a1fa-71072c96a6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7313d3-e6fb-4e82-b558-5fcfd5b71177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7313d3-e6fb-4e82-b558-5fcfd5b71177.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "f04c0bb0-638a-5e10-a35e-525132f463d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d50bce-785d-48a2-8270-7e7373de9c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d50bce-785d-48a2-8270-7e7373de9c51.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -2997,7 +2997,7 @@
         },
         {
             "id": "8ebd1f82-2c18-5871-ae9f-705fc430fdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d045477-7593-46f9-8b40-1356aff1132f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d045477-7593-46f9-8b40-1356aff1132f.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -3029,7 +3029,7 @@
         },
         {
             "id": "f3c0cd49-eda2-553f-a402-3b6148e93029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4f47a9-1c23-4d63-bb89-83c889615e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4f47a9-1c23-4d63-bb89-83c889615e50.jpg?1",
             "name": "Bonfire of the Damned",
             "text": "Bonfire of the Damned deals X damage to target player and each creature he or she controls.\nMiracle {X}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "d2bb3dfc-7f12-59b7-925a-a12214f9b421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c6a1a0-c79e-4770-bf6a-f672b6215f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c6a1a0-c79e-4770-bf6a-f672b6215f7a.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "22715fe9-677a-5fe6-bf40-b086a06e5d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90e1524-d94a-4aba-ab2a-ba2b006cadbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90e1524-d94a-4aba-ab2a-ba2b006cadbe.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -3125,7 +3125,7 @@
         },
         {
             "id": "c5aa412f-275a-5ab9-a235-d0b63b68e13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e530cc-21b9-43c2-a6a9-f1d96e06c2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e530cc-21b9-43c2-a6a9-f1d96e06c2cd.jpg?1",
             "name": "Dynacharge",
             "text": "Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "9e3f27a5-4984-5ac8-9855-c7a480ca7ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473fb06e-5c71-4370-a5d7-7753d84d0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473fb06e-5c71-4370-a5d7-7753d84d0fd6.jpg?1",
             "name": "Goblin Assault",
             "text": "At the beginning of your upkeep, create a 1/1 red Goblin creature token with haste.\nGoblin creatures attack each turn if able.",
             "colours": [
@@ -3189,7 +3189,7 @@
         },
         {
             "id": "75266ede-1151-52cf-8dbe-a3c3989108ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552b7314-5dd9-4722-841b-2e9d5647f854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552b7314-5dd9-4722-841b-2e9d5647f854.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of his or her library. If it's a land card, that player puts it into his or her hand.",
             "colours": [
@@ -3224,7 +3224,7 @@
         },
         {
             "id": "861e634b-61e9-5543-b98f-8990dffcb401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db88c0d5-9df8-4cb7-8951-9d41187b7fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db88c0d5-9df8-4cb7-8951-9d41187b7fb1.jpg?1",
             "name": "Hanweir Lancer",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Hanweir Lancer is paired with another creature, both creatures have first strike.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "798c1e39-8989-5c40-8ae7-28dd5bf61fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ee5320-a19b-4798-b1fb-125b738bd3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ee5320-a19b-4798-b1fb-125b738bd3b9.jpg?1",
             "name": "Hellrider",
             "text": "Haste\nWhenever a creature you control attacks, Hellrider deals 1 damage to defending player.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "2f5c42c8-9b08-5ac1-962e-12b9dafcb6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77b1ff-e73d-4181-9564-d71df348b2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77b1ff-e73d-4181-9564-d71df348b2fe.jpg?1",
             "name": "Madcap Skills",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and has menace.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "a2320faf-552d-5600-8719-8aa2761a3858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1c5b0-973d-467e-a797-51ca75c183c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1c5b0-973d-467e-a797-51ca75c183c1.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "48e4b542-c47e-5455-8245-e9983e5adf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708557e2-c1b4-4e45-b568-17763b7a9924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708557e2-c1b4-4e45-b568-17763b7a9924.jpg?1",
             "name": "Mizzium Mortars",
             "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "46db1669-1614-55bd-bbb6-e8a1d3ce1416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc21927-efbf-4e3b-8df1-d901962c4b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc21927-efbf-4e3b-8df1-d901962c4b71.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies can't attack or block alone.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "cbe55e13-a31e-5255-8e7f-0018a37f1629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdd414b-3d9d-4347-acce-289209d09fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdd414b-3d9d-4347-acce-289209d09fc4.jpg?1",
             "name": "Molten Rain",
             "text": "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "983dba8f-5e46-5956-91dd-7691e6ba50af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c19ccf-999b-4c7d-ae5b-f93555d08a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c19ccf-999b-4c7d-ae5b-f93555d08a7a.jpg?1",
             "name": "Mudbutton Torchrunner",
             "text": "When Mudbutton Torchrunner dies, it deals 3 damage to target creature or player.",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "f7b9cb94-8c0d-530d-b3f1-2478221fefbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7472f4-37b0-439f-b4ac-80706d40d191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7472f4-37b0-439f-b4ac-80706d40d191.jpg?1",
             "name": "Past in Flames",
             "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "1039353a-3516-5adc-a4f0-8e8c3b08fcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561e7a13-6b85-456f-b074-4dc037bc14f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561e7a13-6b85-456f-b074-4dc037bc14f9.jpg?1",
             "name": "Pyrewild Shaman",
             "text": "Bloodrush \u2014 {1}{R}, Discard Pyrewild Shaman: Target attacking creature gets +3/+1 until end of turn.\nWhenever one or more creatures you control deal combat damage to a player, if Pyrewild Shaman is in your graveyard, you may pay {3}. If you do, return Pyrewild Shaman to your hand.",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "51b1cbf5-a57c-5232-b859-4296d90cfc13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac89aef-a0f5-494b-a085-5b3b016d7f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac89aef-a0f5-494b-a085-5b3b016d7f17.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "603d14f9-1fae-57c0-a517-8784e1fe96d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9cea68-4390-4d73-a374-d6299cbc9271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9cea68-4390-4d73-a374-d6299cbc9271.jpg?1",
             "name": "Pyromancer Ascension",
             "text": "Whenever you cast an instant or sorcery spell that has the same name as a card in your graveyard, you may put a quest counter on Pyromancer Ascension.\nWhenever you cast an instant or sorcery spell while Pyromancer Ascension has two or more quest counters on it, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "e1b037eb-bed6-50b8-9991-a7f150a4b479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef60e595-c1fc-4d03-a4f0-e3ae24dd6556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef60e595-c1fc-4d03-a4f0-e3ae24dd6556.jpg?1",
             "name": "Rubblebelt Maaka",
             "text": "Bloodrush \u2014 {R}, Discard Rubblebelt Maaka: Target attacking creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "9130a3fe-f809-59aa-b4cc-cc0d221f3e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b9dd6d-e286-41e8-bd9d-0b42daa5c062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b9dd6d-e286-41e8-bd9d-0b42daa5c062.jpg?1",
             "name": "Scorched Rusalka",
             "text": "{R}, Sacrifice a creature: Scorched Rusalka deals 1 damage to target player.",
             "colours": [
@@ -3691,7 +3691,7 @@
         },
         {
             "id": "6bdffe5c-2841-5ec1-b5e2-a8e80e97f87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565033d2-7cb9-4ee2-b952-45745b9a2ecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565033d2-7cb9-4ee2-b952-45745b9a2ecc.jpg?1",
             "name": "Scourge Devil",
             "text": "When Scourge Devil enters the battlefield, creatures you control get +1/+0 until end of turn.\nUnearth {2}{R} ({2}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "a089ded0-4fab-5af5-a891-32f54436779c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8634068-0ada-4913-8246-c9ac7e9dbde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8634068-0ada-4913-8246-c9ac7e9dbde3.jpg?1",
             "name": "Skirsdag Cultist",
             "text": "{R}, {T}, Sacrifice a creature: Skirsdag Cultist deals 2 damage to target creature or player.",
             "colours": [
@@ -3760,7 +3760,7 @@
         },
         {
             "id": "1d7e724c-6d58-5027-8f7e-2a6d1961cd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804458a2-5376-462d-a2cd-fa596750c0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804458a2-5376-462d-a2cd-fa596750c0aa.jpg?1",
             "name": "Thunderous Wrath",
             "text": "Thunderous Wrath deals 5 damage to target creature or player.\nMiracle {R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "fe9c489c-5d15-54a9-964b-0f288b8003e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42347e7d-6f65-4904-b3c1-a272e4cd2509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42347e7d-6f65-4904-b3c1-a272e4cd2509.jpg?1",
             "name": "Traitorous Instinct",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
             "colours": [
@@ -3824,7 +3824,7 @@
         },
         {
             "id": "8927dcb0-c140-59fe-a507-76401ac30aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbca500a-f349-4873-a2d5-f8dfbd957a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbca500a-f349-4873-a2d5-f8dfbd957a3d.jpg?1",
             "name": "Vithian Stinger",
             "text": "{T}: Vithian Stinger deals 1 damage to target creature or player.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "2854d82c-4a8b-523b-bbaf-7102d93fc5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3784d4-80cd-4f78-afb3-d61f3bab5b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3784d4-80cd-4f78-afb3-d61f3bab5b2c.jpg?1",
             "name": "Zealous Conscripts",
             "text": "Haste\nWhen Zealous Conscripts enters the battlefield, gain control of target permanent until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "83a8fca6-bb61-560a-9f6f-10dbefc31ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1476a3-2915-413c-9226-2d7dc8f0b8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1476a3-2915-413c-9226-2d7dc8f0b8fa.jpg?1",
             "name": "Arachnus Spinner",
             "text": "Reach\nTap an untapped Spider you control: Search your graveyard and/or library for a card named Arachnus Web and put it onto the battlefield attached to target creature. If you search your library this way, shuffle it.",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "33faface-8252-5f08-92c5-56aa2bddaa3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26278000-4b73-478f-8ee5-6dd8692e53d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26278000-4b73-478f-8ee5-6dd8692e53d6.jpg?1",
             "name": "Arachnus Web",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the end step, if enchanted creature's power is 4 or greater, destroy Arachnus Web.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "a8b01ee7-c989-569a-81b3-4d1af9be1544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9600bdc-6a1b-4f7a-aa7d-538fb89df937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9600bdc-6a1b-4f7a-aa7d-538fb89df937.jpg?1",
             "name": "Avacyn's Pilgrim",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [
@@ -3998,7 +3998,7 @@
         },
         {
             "id": "08e80ebb-ee38-5c89-b2c4-4d424c4dda3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c0792-1ff6-4c8c-b3d5-ff32644c366b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c0792-1ff6-4c8c-b3d5-ff32644c366b.jpg?1",
             "name": "Baloth Cage Trap",
             "text": "If an opponent had an artifact enter the battlefield under his or her control this turn, you may pay {1}{G} rather than pay Baloth Cage Trap's mana cost.\nCreate a 4/4 green Beast creature token.",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "55ff525f-f0ea-59ae-9379-e2684770cd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b496a2-11f4-4655-b9e5-0c8c37b2bb9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b496a2-11f4-4655-b9e5-0c8c37b2bb9e.jpg?1",
             "name": "Call of the Herd",
             "text": "Create a 3/3 green Elephant creature token.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "a5aeb31a-f303-53f6-ada2-ab0a6820b9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d66f5-e782-425c-9260-e8989a9cf50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d66f5-e782-425c-9260-e8989a9cf50b.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -4098,7 +4098,7 @@
         },
         {
             "id": "c7d46a72-20b0-5c91-9ebe-9fb3294bef4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556f696-5914-497e-8c84-8888cdf18b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556f696-5914-497e-8c84-8888cdf18b8f.jpg?1",
             "name": "Death-Hood Cobra",
             "text": "{1}{G}: Death-Hood Cobra gains reach until end of turn.\n{1}{G}: Death-Hood Cobra gains deathtouch until end of turn.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "fdf041e6-c9a9-5afc-bf94-c589a14a4ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f00a70e-b3a0-4279-a4d6-37f2d1a1880e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f00a70e-b3a0-4279-a4d6-37f2d1a1880e.jpg?1",
             "name": "Druid's Deliverance",
             "text": "Prevent all combat damage that would be dealt to you this turn. Populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "bf5dc7d2-e8c2-50fd-b1e1-b51b0fae19f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6899e09-0ec3-44d0-afd9-2a4e28635f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6899e09-0ec3-44d0-afd9-2a4e28635f20.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -4197,7 +4197,7 @@
         },
         {
             "id": "d94cdac3-30fc-5704-9bdc-4e7bf65e5e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d114268-7768-4a7c-a6fb-78fec7d4495a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d114268-7768-4a7c-a6fb-78fec7d4495a.jpg?1",
             "name": "Fists of Ironwood",
             "text": "Enchant creature\nWhen Fists of Ironwood enters the battlefield, create two 1/1 green Saproling creature tokens.\nEnchanted creature has trample.",
             "colours": [
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "7751f5bc-7a47-5afb-8122-295c478b11f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9796273-e50f-4d83-bebf-0e29af7312cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9796273-e50f-4d83-bebf-0e29af7312cd.jpg?1",
             "name": "Gaea's Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "c060765a-dffe-5155-8b69-63bdb91ae003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ceb1655-f487-47c3-8687-cde6e577ef12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ceb1655-f487-47c3-8687-cde6e577ef12.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "f8ba7677-fe60-566a-9fe4-7b02c1c08bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95da249-49db-4dae-9277-5d481ec480a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95da249-49db-4dae-9277-5d481ec480a9.jpg?1",
             "name": "Hungry Spriggan",
             "text": "Trample\nWhenever Hungry Spriggan attacks, it gets +3/+3 until end of turn.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "c519368c-e9cd-541a-832a-fe28211e8bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142600e0-9646-4327-aaa4-bc3294cf9b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142600e0-9646-4327-aaa4-bc3294cf9b99.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "279a0f9f-be2c-581f-9fe3-e9cf18750f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665498f9-bb0a-4305-85dd-4c72767e108d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665498f9-bb0a-4305-85dd-4c72767e108d.jpg?1",
             "name": "Penumbra Spider",
             "text": "Reach\nWhen Penumbra Spider dies, create a 2/4 black Spider creature token with reach.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "d1be3f24-157c-5c95-bf52-77f83b950ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92144021-7425-44e1-a32b-13252f1b7036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92144021-7425-44e1-a32b-13252f1b7036.jpg?1",
             "name": "Primal Command",
             "text": "Choose two \u2014\n\u2022 Target player gains 7 life.\n\u2022 Put target noncreature permanent on top of its owner's library.\n\u2022 Target player shuffles his or her graveyard into his or her library.\n\u2022 Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4428,7 +4428,7 @@
         },
         {
             "id": "dc51a142-6e47-5797-a4b6-6850a7ad74e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b365778-1678-4c1f-ae32-7671a1429a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b365778-1678-4c1f-ae32-7671a1429a3e.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "3049eab3-cfb0-5eca-aa98-81bc5b0c092d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614d466e-f830-4a2f-8740-b416a15c67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614d466e-f830-4a2f-8740-b416a15c67dd.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "c440f5d9-834d-5087-a9e2-b1c659fd0f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98b47b-c35f-47ef-b686-07b3904f2854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98b47b-c35f-47ef-b686-07b3904f2854.jpg?1",
             "name": "Seal of Primordium",
             "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "63babd63-2019-56f8-bcc0-3c063575f81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4010a419-8291-4c8b-8cda-38c35fbd7b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4010a419-8291-4c8b-8cda-38c35fbd7b88.jpg?1",
             "name": "Slaughterhorn",
             "text": "Bloodrush \u2014 {G}, Discard Slaughterhorn: Target attacking creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "982d80ff-9f47-5547-90cd-1916d994c55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daf6a74-57f7-4c44-9413-a28002f3de4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daf6a74-57f7-4c44-9413-a28002f3de4c.jpg?1",
             "name": "Slime Molding",
             "text": "Create an X/X green Ooze creature token.",
             "colours": [
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "b9a15d3b-682d-5707-a86e-d81dbd03e9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5c1fde-298b-463c-b2e9-abd241e23062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5c1fde-298b-463c-b2e9-abd241e23062.jpg?1",
             "name": "Strength in Numbers",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
             "colours": [
@@ -4624,7 +4624,7 @@
         },
         {
             "id": "98aee8a2-61df-55a8-9be6-02ff2653830b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b71fb4-27ea-4846-87e4-efd2190faf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b71fb4-27ea-4846-87e4-efd2190faf36.jpg?1",
             "name": "Summoning Trap",
             "text": "If a creature spell you cast this turn was countered by a spell or ability an opponent controlled, you may pay {0} rather than pay Summoning Trap's mana cost.\nLook at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "49a7a564-68df-5edd-a77c-c8700999ef65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101ef33-90fa-4c31-994b-478f7def4e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101ef33-90fa-4c31-994b-478f7def4e1b.jpg?1",
             "name": "Sylvan Ranger",
             "text": "When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "25358750-c060-5a66-b14d-05e3630bf3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b49dfb7-dbe7-4a2b-b9de-c620a0db2e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b49dfb7-dbe7-4a2b-b9de-c620a0db2e47.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "66e83a72-22f2-531b-9bcb-d6a2a0a5d2ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d286f930-28ca-4c59-8a53-99686ac6030e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d286f930-28ca-4c59-8a53-99686ac6030e.jpg?1",
             "name": "Thornscape Battlemage",
             "text": "Kicker {R} and/or {W} (You may pay an additional {R} and/or {W} as you cast this spell.)\nWhen Thornscape Battlemage enters the battlefield, if it was kicked with its {R} kicker, it deals 2 damage to target creature or player.\nWhen Thornscape Battlemage enters the battlefield, if it was kicked with its {W} kicker, destroy target artifact.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "1fcc8682-d5c6-5bd5-9673-2542325c18d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62f09c4-4ed2-429b-b8cc-a40c83fc60ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62f09c4-4ed2-429b-b8cc-a40c83fc60ff.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "faa2ce54-8f4e-5030-be62-c220336ad702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da9e7d8-5f01-4d55-a0a8-afe5e7d5f8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da9e7d8-5f01-4d55-a0a8-afe5e7d5f8e4.jpg?1",
             "name": "Ulvenwald Tracker",
             "text": "{1}{G}, {T}: Target creature you control fights another target creature.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "d1df5bff-7142-5327-8e9a-af59bcd1ca97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cf68c-b54c-46e1-a720-af57aac9e570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cf68c-b54c-46e1-a720-af57aac9e570.jpg?1",
             "name": "Vital Splicer",
             "text": "When Vital Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{1}: Regenerate target Golem you control.",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "b11a2ad4-06b7-508a-925e-37507ba371c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e328c6-3a84-49cf-a1a3-1d1e5373d274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e328c6-3a84-49cf-a1a3-1d1e5373d274.jpg?1",
             "name": "Abrupt Decay",
             "text": "Abrupt Decay can't be countered by spells or abilities.\nDestroy target nonland permanent with converted mana cost 3 or less.",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "7901d6e7-667e-5d8c-8a3e-c13ab32fb5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3b5e35-5448-4115-a9c5-6ac14013c904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3b5e35-5448-4115-a9c5-6ac14013c904.jpg?1",
             "name": "Advent of the Wurm",
             "text": "Create a 5/5 green Wurm creature token with trample.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "5f1ef279-2973-55dc-9239-e1d8b0bc0232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d32427-da4d-4906-8c61-13054c87b349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d32427-da4d-4906-8c61-13054c87b349.jpg?1",
             "name": "Aethermage's Touch",
             "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "89b918f0-31d0-5983-8f59-6cd7a9ce2c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6ace1f-c056-494d-a41f-75efa54312a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6ace1f-c056-494d-a41f-75efa54312a5.jpg?1",
             "name": "Agent of Masks",
             "text": "At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "271d4e29-affa-5b9d-817c-686917accb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc51eb-4ed8-433f-aee5-4aee31f6ad50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc51eb-4ed8-433f-aee5-4aee31f6ad50.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "2660753f-0d6b-5003-a7a7-9e0601b0e7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8f26e6-ce0d-4886-98dd-166ca49f1f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8f26e6-ce0d-4886-98dd-166ca49f1f4b.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -5077,7 +5077,7 @@
         },
         {
             "id": "fab1aa4d-0cb5-5168-b361-acb63e93bef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94079dd-023a-41b2-9004-95bbb0e41267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94079dd-023a-41b2-9004-95bbb0e41267.jpg?1",
             "name": "Bronzebeak Moa",
             "text": "Whenever another creature enters the battlefield under your control, Bronzebeak Moa gets +3/+3 until end of turn.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "3622653c-1eba-52fe-b70a-81ae26bf130e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45e678-1ab0-451d-b412-be7c167e812a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45e678-1ab0-451d-b412-be7c167e812a.jpg?1",
             "name": "Broodmate Dragon",
             "text": "Flying\nWhen Broodmate Dragon enters the battlefield, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "f0a47800-addf-5033-a004-d0b17bf7b801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45a453b-bc76-4768-88ea-a5117e29a49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45a453b-bc76-4768-88ea-a5117e29a49e.jpg?1",
             "name": "Call of the Conclave",
             "text": "Create a 3/3 green Centaur creature token.",
             "colours": [
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "f37d2478-70f5-5084-9a1d-9f29f9d9a4a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb4d0dd-3363-45f0-9081-7b9c8c39d63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb4d0dd-3363-45f0-9081-7b9c8c39d63f.jpg?1",
             "name": "Carnage Gladiator",
             "text": "Whenever a creature blocks, that creature's controller loses 1 life.\n{1}{B}{R}: Regenerate Carnage Gladiator.",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "4ce1ad94-a5e7-57f2-87ea-b599bd19fc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0743cd-26e3-4de5-b98b-3e16b6aff2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0743cd-26e3-4de5-b98b-3e16b6aff2ac.jpg?1",
             "name": "Centaur Healer",
             "text": "When Centaur Healer enters the battlefield, you gain 3 life.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "172a594b-7aa6-5bb4-ab4d-e5325b64c914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19719b9b-a384-4ebe-9a5a-7f51132f3c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19719b9b-a384-4ebe-9a5a-7f51132f3c44.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "db2e35b1-9927-5db6-a0fd-e311a4305336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45b55df-2de8-4327-9b2d-cff1e5d37a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45b55df-2de8-4327-9b2d-cff1e5d37a79.jpg?1",
             "name": "Cruel Ultimatum",
             "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "53149e59-98d8-56b8-ad2e-122280a727e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e7dff8-faae-46b8-8dd9-58830e1df61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e7dff8-faae-46b8-8dd9-58830e1df61e.jpg?1",
             "name": "Deputy of Acquittals",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Deputy of Acquittals enters the battlefield, you may return another target creature you control to its owner's hand.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "9040f1eb-9d04-5642-a7bc-2d2c0f5f258c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644e3ff9-94be-49f1-82f1-b844e025645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644e3ff9-94be-49f1-82f1-b844e025645a.jpg?1",
             "name": "Dinrova Horror",
             "text": "When Dinrova Horror enters the battlefield, return target permanent to its owner's hand, then that player discards a card.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "8dae9d9d-f2bd-5dc9-ac78-a4a764ac50b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d57a9dc-424e-4088-9df8-c9b9c8c688a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d57a9dc-424e-4088-9df8-c9b9c8c688a3.jpg?1",
             "name": "Domri Rade",
             "text": "+1: Look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand.\n\u22122: Target creature you control fights another target creature.\n\u22127: You get an emblem with \"Creatures you control have double strike, trample, hexproof, and haste.\"",
             "colours": [
@@ -5444,7 +5444,7 @@
         },
         {
             "id": "d1963e10-3944-5e1d-a507-da771bd9c516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4270d1d-97ae-412a-bf2e-b6b7dad3d6d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4270d1d-97ae-412a-bf2e-b6b7dad3d6d0.jpg?1",
             "name": "Evil Twin",
             "text": "You may have Evil Twin enter the battlefield as a copy of any creature on the battlefield, except it gains \"{U}{B}, {T}: Destroy target creature with the same name as this creature.\"",
             "colours": [
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "51b752e6-65cc-54c9-a969-408439e35449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53399f12-0d62-40bf-a532-1d02b6c2f19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53399f12-0d62-40bf-a532-1d02b6c2f19e.jpg?1",
             "name": "Falkenrath Aristocrat",
             "text": "Flying, haste\nSacrifice a creature: Falkenrath Aristocrat gains indestructible until end of turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.",
             "colours": [
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "09a3e9c9-e3f1-5bae-bcae-cb3bbfda676c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844a8a51-45fb-4957-b1fe-0d86dfff3fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844a8a51-45fb-4957-b1fe-0d86dfff3fb5.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
             "colours": [
@@ -5553,7 +5553,7 @@
         },
         {
             "id": "0cbc43ab-a77c-5187-983a-9278333a5197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ec0aa-1da9-4464-ac0e-c45079908070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ec0aa-1da9-4464-ac0e-c45079908070.jpg?1",
             "name": "Ghor-Clan Rampager",
             "text": "Trample\nBloodrush \u2014 {R}{G}, Discard Ghor-Clan Rampager: Target attacking creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5589,7 +5589,7 @@
         },
         {
             "id": "f8934d3a-7ca6-57ef-8d72-436e6b1388ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f17a1fc-b6cc-4f62-96df-3cde940a3bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f17a1fc-b6cc-4f62-96df-3cde940a3bea.jpg?1",
             "name": "Goblin Electromancer",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5626,7 +5626,7 @@
         },
         {
             "id": "e2b83d61-3bf6-5715-9d86-5dd8d118c048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d03f6eb-a146-45e8-a8e0-a46ec0c20c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d03f6eb-a146-45e8-a8e0-a46ec0c20c1d.jpg?1",
             "name": "Golgari Germination",
             "text": "Whenever a nontoken creature you control dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "e1e7876b-ea44-56f7-b327-f6060be0ccc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482d3d5-d4ad-4e0e-ab92-3246cf684d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482d3d5-d4ad-4e0e-ab92-3246cf684d14.jpg?1",
             "name": "Golgari Rotwurm",
             "text": "{B}, Sacrifice a creature: Target player loses 1 life.",
             "colours": [
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "412f6161-9f67-5617-b179-4b305129ab94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5d3a87-89f6-4051-918c-736b0a4b8ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5d3a87-89f6-4051-918c-736b0a4b8ec2.jpg?1",
             "name": "Ground Assault",
             "text": "Ground Assault deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5731,7 +5731,7 @@
         },
         {
             "id": "a03cfecd-5061-5789-9711-dd6248d60e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003fb65-26ee-481f-a38d-7d3fe55878f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003fb65-26ee-481f-a38d-7d3fe55878f3.jpg?1",
             "name": "Gruul War Chant",
             "text": "Attacking creatures you control get +1/+0 and have menace.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "95743a63-a09a-5735-b823-74dba6aa24fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04eae11-6bc4-41d2-98cc-285621d5724b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04eae11-6bc4-41d2-98cc-285621d5724b.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Izzet Charm deals 2 damage to target creature.\n\u2022 Draw two cards, then discard two cards.",
             "colours": [
@@ -5799,7 +5799,7 @@
         },
         {
             "id": "40f2e7e1-e29f-5ad5-a72d-7b22d9dfd98a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafece7-c3a0-465b-84c2-e095890a7a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafece7-c3a0-465b-84c2-e095890a7a8b.jpg?1",
             "name": "Kathari Bomber",
             "text": "Flying\nWhen Kathari Bomber deals combat damage to a player, create two 1/1 red Goblin creature tokens and sacrifice Kathari Bomber.\nUnearth {3}{B}{R} ({3}{B}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "564a80c1-e497-53af-8454-e8426d3b8580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ac1c79-4dff-4518-8a9e-8d381a046605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ac1c79-4dff-4518-8a9e-8d381a046605.jpg?1",
             "name": "Moroii",
             "text": "Flying\nAt the beginning of your upkeep, you lose 1 life.",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "2ead4f9f-6010-5667-ac46-700768410d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b93af3-f7b9-4b66-8a66-366134ebb896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b93af3-f7b9-4b66-8a66-366134ebb896.jpg?1",
             "name": "Mystic Genesis",
             "text": "Counter target spell. Create an X/X green Ooze creature token, where X is that spell's converted mana cost.",
             "colours": [
@@ -5906,7 +5906,7 @@
         },
         {
             "id": "845c2c52-27b3-5162-99e0-12a300842d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e949d80-d2c5-4ed1-9e53-c98a3b2749ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e949d80-d2c5-4ed1-9e53-c98a3b2749ff.jpg?1",
             "name": "Niv-Mizzet, Dracogenius",
             "text": "Flying\nWhenever Niv-Mizzet, Dracogenius deals damage to a player, you may draw a card.\n{U}{R}: Niv-Mizzet, Dracogenius deals 1 damage to target creature or player.",
             "colours": [
@@ -5945,7 +5945,7 @@
         },
         {
             "id": "7aec5519-f36b-5f08-97c7-43c03e78578c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4029c3a0-a999-453a-a838-7adb81e481ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4029c3a0-a999-453a-a838-7adb81e481ee.jpg?1",
             "name": "Obzedat, Ghost Council",
             "text": "When Obzedat, Ghost Council enters the battlefield, target opponent loses 2 life and you gain 2 life.\nAt the beginning of your end step, you may exile Obzedat. If you do, return it to the battlefield under its owner's control at the beginning of your next upkeep. It gains haste.",
             "colours": [
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "ca760cc7-93ea-55d4-a8e1-5727de915e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6411d49-b108-423c-825f-67fe8dbe1f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6411d49-b108-423c-825f-67fe8dbe1f58.jpg?1",
             "name": "Olivia Voldaren",
             "text": "Flying\n{1}{R}: Olivia Voldaren deals 1 damage to another target creature. That creature becomes a Vampire in addition to its other types. Put a +1/+1 counter on Olivia Voldaren.\n{3}{B}{B}: Gain control of target Vampire for as long as you control Olivia Voldaren.",
             "colours": [
@@ -6022,7 +6022,7 @@
         },
         {
             "id": "ccfb24af-803c-58ab-9a22-7577c3de856c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4628454-65f0-4cf7-82b5-3c33e0b3a705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4628454-65f0-4cf7-82b5-3c33e0b3a705.jpg?1",
             "name": "Pilfered Plans",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard. Draw two cards.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "986809aa-110a-547c-9ab4-4e6f1bda453e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed2acec-bdae-4462-91b7-c24a60e6f9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed2acec-bdae-4462-91b7-c24a60e6f9c1.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "ba38fb1e-5124-5a0b-a29a-d6aeba701243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd24e81d-d3a8-4550-bad9-b818f48cc700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd24e81d-d3a8-4550-bad9-b818f48cc700.jpg?1",
             "name": "Rhox War Monk",
             "text": "Lifelink",
             "colours": [
@@ -6129,7 +6129,7 @@
         },
         {
             "id": "b43934e4-a39c-563c-af02-911a6057eec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c82373-9290-408a-859f-c17354441e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c82373-9290-408a-859f-c17354441e1c.jpg?1",
             "name": "Sedraxis Specter",
             "text": "Flying\nWhenever Sedraxis Specter deals combat damage to a player, that player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "0614e4e1-c557-5b2f-87ea-78772ebaf20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93288c87-84ad-40c8-a998-a3e36075adfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93288c87-84ad-40c8-a998-a3e36075adfd.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "f8371693-6b34-5c9c-837f-3e005db82427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cad9de8-91fc-435f-9b56-66210813aebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cad9de8-91fc-435f-9b56-66210813aebd.jpg?1",
             "name": "Sin Collector",
             "text": "When Sin Collector enters the battlefield, target opponent reveals his or her hand. You choose an instant or sorcery card from it and exile that card.",
             "colours": [
@@ -6240,7 +6240,7 @@
         },
         {
             "id": "5e7d21e0-87e2-5210-bc78-364fae63160a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062404ff-f856-4e97-82e8-fee9083f4c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062404ff-f856-4e97-82e8-fee9083f4c42.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -6277,7 +6277,7 @@
         },
         {
             "id": "eff90a45-9735-51bd-8ab6-0480aed6464c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6998e90-89a9-43d7-8e89-cc20bc608545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6998e90-89a9-43d7-8e89-cc20bc608545.jpg?1",
             "name": "Soul Manipulation",
             "text": "Choose one or both \u2014\n\u2022 Counter target creature spell.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -6311,7 +6311,7 @@
         },
         {
             "id": "6ee7630a-44a5-53db-864e-99e195bd6f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f187c27-a2ad-4560-ba74-1012046303cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f187c27-a2ad-4560-ba74-1012046303cc.jpg?1",
             "name": "Soul Ransom",
             "text": "Enchant creature\nYou control enchanted creature.\nDiscard two cards: Soul Ransom's controller sacrifices it, then draws two cards. Only any opponent may activate this ability.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "82aa1867-5d10-5274-bdd3-6255be24eb44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ea4d-d0a6-44a4-bee6-24c03313d2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ea4d-d0a6-44a4-bee6-24c03313d2bc.jpg?1",
             "name": "Sphinx's Revelation",
             "text": "You gain X life and draw X cards.",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "a68feb20-7147-52eb-bc2b-8b9f693079a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82ff29-2b2c-4e4f-a6ac-e307e2921da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82ff29-2b2c-4e4f-a6ac-e307e2921da0.jpg?1",
             "name": "Spike Jester",
             "text": "Haste",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "e26bbb1b-60b0-56ed-9e3d-d18538712dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a034412f-5d91-45ab-866e-c28ae6c17f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a034412f-5d91-45ab-866e-c28ae6c17f57.jpg?1",
             "name": "Sprouting Thrinax",
             "text": "When Sprouting Thrinax dies, create three 1/1 green Saproling creature tokens.",
             "colours": [
@@ -6456,7 +6456,7 @@
         },
         {
             "id": "37c1fca6-5be8-5ff2-a791-9d426c3034cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fd303a-0a51-4931-9735-704ce8179a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fd303a-0a51-4931-9735-704ce8179a98.jpg?1",
             "name": "Stoic Angel",
             "text": "Flying, vigilance\nPlayers can't untap more than one creature during their untap steps.",
             "colours": [
@@ -6494,7 +6494,7 @@
         },
         {
             "id": "e13942c8-ad70-59fc-93cd-69377c3387b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5ee3d-3db2-45fc-adc0-9903231f16db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5ee3d-3db2-45fc-adc0-9903231f16db.jpg?1",
             "name": "Sunhome Guildmage",
             "text": "{1}{R}{W}: Creatures you control get +1/+0 until end of turn.\n{2}{R}{W}: Create a 1/1 red and white Soldier creature token with haste.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "b7a051c9-09ec-5740-a34c-f80f0d4f613f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec07bce-abf0-4387-bb9f-a9ba5492c754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec07bce-abf0-4387-bb9f-a9ba5492c754.jpg?1",
             "name": "Talon Trooper",
             "text": "Flying",
             "colours": [
@@ -6568,7 +6568,7 @@
         },
         {
             "id": "58d300cc-5bc3-5569-9220-d00aab9f16c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322a64-f1a0-49c6-ad59-2b803598f7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322a64-f1a0-49c6-ad59-2b803598f7d1.jpg?1",
             "name": "Teleportal",
             "text": "Target creature you control gets +1/+0 until end of turn and can't be blocked this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "93c0686d-b653-51a6-9deb-3ef76e12cea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2d815-d8b2-42ff-9889-acbe77a42583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2d815-d8b2-42ff-9889-acbe77a42583.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "edb64cc6-a124-5236-8338-83f96378be84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98e91c-9518-4dcf-90a1-610d2d977e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98e91c-9518-4dcf-90a1-610d2d977e0c.jpg?1",
             "name": "Thundersong Trumpeter",
             "text": "{T}: Target creature can't attack or block this turn.",
             "colours": [
@@ -6673,7 +6673,7 @@
         },
         {
             "id": "2575c12c-ef53-504e-9d82-a75fad48c567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2562ab8-6491-4f13-bd20-4e4eacf840cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2562ab8-6491-4f13-bd20-4e4eacf840cb.jpg?1",
             "name": "Tower Gargoyle",
             "text": "Flying",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "ec08d035-c570-5e36-9e57-46e9299a0f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2846c5-9098-4983-84aa-d364f72135f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2846c5-9098-4983-84aa-d364f72135f3.jpg?1",
             "name": "Unflinching Courage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample and lifelink.",
             "colours": [
@@ -6748,7 +6748,7 @@
         },
         {
             "id": "42997767-c851-580e-9f01-477603bf8e05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a005974-ba57-42cf-a54f-4aba41cad144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a005974-ba57-42cf-a54f-4aba41cad144.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -6782,7 +6782,7 @@
         },
         {
             "id": "c0dfdfd1-09ef-5a65-a0db-b28a2f6c11ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdd22d7-b3b0-4cb5-846d-aa3d96a29c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdd22d7-b3b0-4cb5-846d-aa3d96a29c97.jpg?1",
             "name": "Vanish into Memory",
             "text": "Exile target creature. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to the battlefield under its owner's control. If you do, discard cards equal to that creature's toughness.",
             "colours": [
@@ -6816,7 +6816,7 @@
         },
         {
             "id": "494d58ed-02d6-57af-b55a-eca734e67b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993e42f4-fc60-4e37-8f69-7b82bb9e5d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993e42f4-fc60-4e37-8f69-7b82bb9e5d60.jpg?1",
             "name": "Voice of Resurgence",
             "text": "Whenever an opponent casts a spell during your turn or when Voice of Resurgence dies, create a green and white Elemental creature token with \"This creature's power and toughness are each equal to the number of creatures you control.\"",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "88527cec-ca18-5f71-8718-03ea167a67c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd95bba-0c3d-4f2c-94ea-bbd3f396292c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd95bba-0c3d-4f2c-94ea-bbd3f396292c.jpg?1",
             "name": "Wall of Denial",
             "text": "Defender, flying\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "8fcdfb46-c0e9-51b6-b01c-24d8f1a6f338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191c4d56-9cee-4a7a-a2d4-e417952fef00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191c4d56-9cee-4a7a-a2d4-e417952fef00.jpg?1",
             "name": "Wayfaring Temple",
             "text": "Wayfaring Temple's power and toughness are each equal to the number of creatures you control.\nWhenever Wayfaring Temple deals combat damage to a player, populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "56cc8ce3-c20c-5fe3-89f4-3aca07e5dc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7188d8-d37f-49ec-ab52-8ea080725ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7188d8-d37f-49ec-ab52-8ea080725ca7.jpg?1",
             "name": "Woolly Thoctar",
             "text": "",
             "colours": [
@@ -6962,7 +6962,7 @@
         },
         {
             "id": "aa4d829e-bc94-5710-9a97-75d254ff322b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253e19db-28a1-4909-b235-e02631a38c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253e19db-28a1-4909-b235-e02631a38c35.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with converted mana cost 3 or less and put it onto the battlefield. If you do, shuffle your library.",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "c3c967bb-7c91-51b7-bfc5-19af47b859ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b34ecd-6dd4-49b0-ab49-3c11f70e0c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b34ecd-6dd4-49b0-ab49-3c11f70e0c4a.jpg?1",
             "name": "Aethertow",
             "text": "Put target attacking or blocking creature on top of its owner's library.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -7037,7 +7037,7 @@
         },
         {
             "id": "51285174-a0f1-530c-9fb0-fe9f50c63b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc5666c-6f27-4ae9-8f0e-17e2a44bc646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc5666c-6f27-4ae9-8f0e-17e2a44bc646.jpg?1",
             "name": "Boros Reckoner",
             "text": "Whenever Boros Reckoner is dealt damage, it deals that much damage to target creature or player.\n{GU}: Boros Reckoner gains first strike until end of turn.",
             "colours": [
@@ -7074,7 +7074,7 @@
         },
         {
             "id": "47eca8df-3b9b-5366-bc84-5475c1fe1d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48335a70-151d-4d92-8365-e2ad9ac153ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48335a70-151d-4d92-8365-e2ad9ac153ac.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G} to your mana pool.",
             "colours": [
@@ -7111,7 +7111,7 @@
         },
         {
             "id": "f8323f96-6b03-5317-83e3-0536590e0516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509d27ed-f9cf-4130-8807-38a4ae857323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509d27ed-f9cf-4130-8807-38a4ae857323.jpg?1",
             "name": "Giantbaiting",
             "text": "Create a 4/4 red and green Giant Warrior creature token with haste. Exile it at the beginning of the next end step.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
             "colours": [
@@ -7145,7 +7145,7 @@
         },
         {
             "id": "728d82f2-79c3-5472-87c8-e154ca48a48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da824204-a7ed-46f1-b890-f21fcc39ce7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da824204-a7ed-46f1-b890-f21fcc39ce7e.jpg?1",
             "name": "Gift of Orzhova",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying and lifelink.",
             "colours": [
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "58264794-b1f2-5af7-ad5d-341a6d5b7943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edb89a4-e749-4043-913c-34ed20d10b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edb89a4-e749-4043-913c-34ed20d10b02.jpg?1",
             "name": "Mistmeadow Witch",
             "text": "{2}{W}{U}: Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "b5e92e16-1157-52be-9ae5-200c353578ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d2e144-04a3-41dd-810b-e9e0a04e8b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d2e144-04a3-41dd-810b-e9e0a04e8b39.jpg?1",
             "name": "Sundering Growth",
             "text": "Destroy target artifact or enchantment, then populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "c5c4c4d1-df18-51dd-ab9e-53d083527234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9916a-2806-4c3d-a152-5543071cc311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9916a-2806-4c3d-a152-5543071cc311.jpg?1",
             "name": "Tattermunge Witch",
             "text": "{R}{G}: Each blocked creature gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -7289,7 +7289,7 @@
         },
         {
             "id": "4ded582d-03ef-58aa-853f-c4245d2cbddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60c97a2-52db-4e4b-a075-0120a3ebca75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60c97a2-52db-4e4b-a075-0120a3ebca75.jpg?1",
             "name": "Torrent of Souls",
             "text": "Return up to one target creature card from your graveyard to the battlefield if {B} was spent to cast Torrent of Souls. Creatures target player controls get +2/+0 and gain haste until end of turn if {R} was spent to cast Torrent of Souls. (Do both if {B}{R} was spent.)",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "f1d0d14f-9f1d-5191-b261-7735092da552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9103a97c-ffb6-4584-b7fc-58835ba942c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9103a97c-ffb6-4584-b7fc-58835ba942c2.jpg?1",
             "name": "Wort, the Raidmother",
             "text": "When Wort, the Raidmother enters the battlefield, create two 1/1 red and green Goblin Warrior creature tokens.\nEach red or green instant or sorcery spell you cast has conspire. (As you cast the spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose new targets for the copy.)",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "23a63ce8-af72-55e4-b5e7-40be5a5c70d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff1d33-e35a-4c7c-b2ba-207cf72ae5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff1d33-e35a-4c7c-b2ba-207cf72ae5d4.jpg?1",
             "name": "Azorius Signet",
             "text": "{1}, {T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -7393,7 +7393,7 @@
         },
         {
             "id": "1a2c4e14-2a91-5142-99b1-63e0795c42fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeab4ce-0828-40f1-a058-0d6695646f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeab4ce-0828-40f1-a058-0d6695646f4e.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -7423,7 +7423,7 @@
         },
         {
             "id": "58637223-0551-56c2-adcd-2767b1e5f5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09b060-575a-4cc3-9e27-b3c133b80235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09b060-575a-4cc3-9e27-b3c133b80235.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -7454,7 +7454,7 @@
         },
         {
             "id": "d7e39103-1972-5655-af10-708696850ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c89492-ef45-460e-9c78-83c8c8c80fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c89492-ef45-460e-9c78-83c8c8c80fe2.jpg?1",
             "name": "Damping Matrix",
             "text": "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "2c0772f0-5705-54fb-870d-94b963534422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501d0d13-b6a4-415c-916e-fdb0809a67d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501d0d13-b6a4-415c-916e-fdb0809a67d8.jpg?1",
             "name": "Dimir Signet",
             "text": "{1}, {T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "b281a86f-bd93-5b13-a322-641ce1b90f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca34c6fa-8019-4bdf-b748-4188ac79abf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca34c6fa-8019-4bdf-b748-4188ac79abf4.jpg?1",
             "name": "Golgari Signet",
             "text": "{1}, {T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "8834faab-1fbc-56dc-89b3-d77f030622b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d03f2e5-c778-4a85-a104-7cf367e5a5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d03f2e5-c778-4a85-a104-7cf367e5a5ea.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "Creature cards can't enter the battlefield from graveyards or libraries.\nPlayers can't cast cards in graveyards or libraries.",
             "colours": [],
@@ -7572,7 +7572,7 @@
         },
         {
             "id": "901b40ff-9b9c-5cd6-9d68-7243582a4e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c688f52-60ba-4acb-ba0e-40691c5b736c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c688f52-60ba-4acb-ba0e-40691c5b736c.jpg?1",
             "name": "Gruul Signet",
             "text": "{1}, {T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "c506f605-73ef-5a77-aebe-a5bb259145ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a005a2-3eb8-4d8f-8608-2cbf5cf7887e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a005a2-3eb8-4d8f-8608-2cbf5cf7887e.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "9c0564df-44bd-5722-9f45-a3048fc57cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b842616-c0cc-43d4-a52d-0159caebadd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b842616-c0cc-43d4-a52d-0159caebadd2.jpg?1",
             "name": "Orzhov Signet",
             "text": "{1}, {T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "ed779dfa-bb3f-5821-8280-2d33131c3a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7feea129-3e71-45fc-9769-e6ec80e9f3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7feea129-3e71-45fc-9769-e6ec80e9f3e5.jpg?1",
             "name": "Rakdos Signet",
             "text": "{1}, {T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "82f15659-6285-599f-a178-7b9b58323246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c5c5b-ffab-4a78-9f3a-0b80860b8c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c5c5b-ffab-4a78-9f3a-0b80860b8c53.jpg?1",
             "name": "Selesnya Signet",
             "text": "{1}, {T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "49cc7f31-2494-5f74-b4a8-a179eb36c170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11488771-3d02-476e-bf6d-ad40ec691fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11488771-3d02-476e-bf6d-ad40ec691fd5.jpg?1",
             "name": "Simic Signet",
             "text": "{1}, {T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -7758,7 +7758,7 @@
         },
         {
             "id": "70d63a45-a4ae-595e-82b5-874a43f7aade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a929bfef-7e6d-483d-9605-f4ba7d104656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a929bfef-7e6d-483d-9605-f4ba7d104656.jpg?1",
             "name": "Arcane Sanctum",
             "text": "Arcane Sanctum enters the battlefield tapped.\n{T}: Add {W}, {U}, or {B} to your mana pool.",
             "colours": [],
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "a12b410a-ae23-54a7-9610-733280012f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a8cc61-7e36-4df7-9c89-c32fce129c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a8cc61-7e36-4df7-9c89-c32fce129c5a.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "8687707c-6f80-5972-b34b-cd0d089c026d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27addb51-f447-458a-8b3d-89de0a4c542a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27addb51-f447-458a-8b3d-89de0a4c542a.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "b1ebac58-b548-5380-ab7b-dc7b4e280016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78293-93f1-47a4-81b6-057857611d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78293-93f1-47a4-81b6-057857611d78.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -7884,7 +7884,7 @@
         },
         {
             "id": "c63763bc-cbd2-51de-bdfd-3c467797cad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1045bdc7-6fbb-4b63-9798-a2a993f95bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1045bdc7-6fbb-4b63-9798-a2a993f95bc2.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -7912,7 +7912,7 @@
         },
         {
             "id": "f02984f6-468b-5102-882e-48e6d1b35618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f4726f-8b5a-4433-ad9b-af7e4c397987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f4726f-8b5a-4433-ad9b-af7e4c397987.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "Crumbling Necropolis enters the battlefield tapped.\n{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "6d8ebe42-604d-5478-ad32-4780e6cd4765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a31b8f9-5e12-4aa2-ab2c-84ad30315e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a31b8f9-5e12-4aa2-ab2c-84ad30315e8b.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7977,7 +7977,7 @@
         },
         {
             "id": "7b82a2be-62b6-5ec2-ba3b-8d3532ea94cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc31774-e185-4c0e-9779-046c4db3306d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc31774-e185-4c0e-9779-046c4db3306d.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8010,7 +8010,7 @@
         },
         {
             "id": "e46aba73-e372-5455-8cfd-df6648694619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5a55b9-1b28-4592-a2be-dfa393f7f12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5a55b9-1b28-4592-a2be-dfa393f7f12c.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8043,7 +8043,7 @@
         },
         {
             "id": "ad37dd71-b8f4-5065-9b6b-350af218913e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e2167-defb-46cc-a165-02ce6157137d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e2167-defb-46cc-a165-02ce6157137d.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "72815c8c-1a2b-5845-8f0c-8e0b39572b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db3c84b-eb9e-4a90-88e4-444cca5fcf3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db3c84b-eb9e-4a90-88e4-444cca5fcf3c.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine enters the battlefield tapped.\n{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "90ecf3e9-13f0-5611-b055-2e5b1185b65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659039ed-c269-4c2d-bce6-91d143f0618e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659039ed-c269-4c2d-bce6-91d143f0618e.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8136,7 +8136,7 @@
         },
         {
             "id": "681e29cd-87cc-568c-8949-501ed77d8a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cd0d88-53b5-4560-bce0-910b3b7be946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cd0d88-53b5-4560-bce0-910b3b7be946.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "50318f25-f68b-5342-a87a-370712722dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb4f13-77b0-4bd6-9bdd-c65dd08399a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb4f13-77b0-4bd6-9bdd-c65dd08399a6.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "6df1dd2d-247a-5ec6-895e-ea11b416f476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c2b2fd-9cd9-49a9-8158-1c0506198393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c2b2fd-9cd9-49a9-8158-1c0506198393.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "42c9d83f-b1f5-53e4-a8a0-7519f543ef0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a5525-d49c-4669-95ee-d410f3350281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a5525-d49c-4669-95ee-d410f3350281.jpg?1",
             "name": "Savage Lands",
             "text": "Savage Lands enters the battlefield tapped.\n{T}: Add {B}, {R}, or {G} to your mana pool.",
             "colours": [],
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "e1811dc1-d10d-5ac1-a1a8-7e2a1c803821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2661d4a-450a-433a-b893-b1ee15982494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2661d4a-450a-433a-b893-b1ee15982494.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "b462eb42-4738-58d4-936f-6c3a2f47deee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e5e16d-fc2f-4763-9e2b-2cce022e7a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e5e16d-fc2f-4763-9e2b-2cce022e7a11.jpg?1",
             "name": "Seaside Citadel",
             "text": "Seaside Citadel enters the battlefield tapped.\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [],
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "d3b3d7f6-1d49-51ed-892e-bfc4453a1ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f7fe6-faca-4911-b7bf-72f081dd5fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f7fe6-faca-4911-b7bf-72f081dd5fea.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "370ce649-70a8-5802-bfaa-f6edc11ab551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d6756-8839-4753-a178-ef42da96dbb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d6756-8839-4753-a178-ef42da96dbb5.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "9f726bf8-596e-5a01-8262-caec7a867fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e32265-09f6-448f-9413-31327d11eea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e32265-09f6-448f-9413-31327d11eea5.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "35ebcf47-2062-5a74-90ed-2dd39e126387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15faa763-b897-4e86-b094-73f3236291a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15faa763-b897-4e86-b094-73f3236291a9.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "604ee7d8-32fa-595f-9c29-1baacd62a613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6277af10-b10b-450b-9d42-54c978337931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6277af10-b10b-450b-9d42-54c978337931.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "0305d004-4443-505c-98b3-8e147951fe73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd5abfa-ec18-49a4-9531-826d47c6301b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd5abfa-ec18-49a4-9531-826d47c6301b.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8512,7 +8512,7 @@
         },
         {
             "id": "1c3b5f9b-1b95-5bbd-be00-19c2b0806d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2c0e6f-44a9-410f-a501-b95c1def9d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2c0e6f-44a9-410f-a501-b95c1def9d88.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "2fce7c78-01a9-5ee8-999d-5917b9a09d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933a376-399c-4071-b44b-95605edd8fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933a376-399c-4071-b44b-95605edd8fdb.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "de8e7c49-276b-58ca-8c38-5188fbd6a952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd8800-affa-4e64-825f-2a3b4516ed0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd8800-affa-4e64-825f-2a3b4516ed0f.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "f378381d-6f5c-57f2-9abb-cb4fab793b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22110a53-493d-4af5-aea5-f6a8b4958a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22110a53-493d-4af5-aea5-f6a8b4958a84.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8648,7 +8648,7 @@
         },
         {
             "id": "d01a56cc-e672-511b-9b09-16003a1e6d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0413b3da-fec3-4221-bcec-2b964b45dd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0413b3da-fec3-4221-bcec-2b964b45dd00.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "3b426fd6-6cdc-5529-a531-fb1df8aa6711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbf199b-2c3f-441d-950e-c4a3d3086e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbf199b-2c3f-441d-950e-c4a3d3086e4b.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8716,7 +8716,7 @@
         },
         {
             "id": "a37cf97e-f9ae-5c96-b3bf-f49a43cc6eb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4333372-80ea-42df-bf8a-d1f12bcb348e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4333372-80ea-42df-bf8a-d1f12bcb348e.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "6bee9d2a-319e-5b67-a899-29258d2f8cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff64dab-233b-42b0-88bb-d3e4f7eb4e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff64dab-233b-42b0-88bb-d3e4f7eb4e93.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "9308254b-38ac-54a1-87b5-e0325d8063ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83648ae-b9a5-40c1-825d-287b2d4ec838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83648ae-b9a5-40c1-825d-287b2d4ec838.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "df8502df-5d33-55e9-a756-f8fa94ef5b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ea880-0158-4faa-8018-f6626f25dd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ea880-0158-4faa-8018-f6626f25dd02.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "1545ee29-d9c1-57ff-acae-431cfd6d60cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9cea73-9421-4f91-b8f9-1a8081b3811a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9cea73-9421-4f91-b8f9-1a8081b3811a.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "78ec3c68-cfdb-5d1d-966a-466357082666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e78d072-183d-4272-9d9f-6801dced729d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e78d072-183d-4272-9d9f-6801dced729d.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "04980b0b-701b-5763-aefa-a81de18dc93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "e8a3b735-b487-54f5-a6a1-cb589433671f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b980ff-02ad-447e-8815-16cd0112ce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b980ff-02ad-447e-8815-16cd0112ce60.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8990,7 +8990,7 @@
         },
         {
             "id": "801b4da1-9973-5d92-b53e-3ca496f67f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06eea30-810b-4623-9862-ec71c4bed11a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06eea30-810b-4623-9862-ec71c4bed11a.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -9027,7 +9027,7 @@
         },
         {
             "id": "7d6177c0-df09-58f5-a5b6-8b83d2c0e91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f827ad1-4931-404d-a0ff-bff8b98eae42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f827ad1-4931-404d-a0ff-bff8b98eae42.jpg?1",
             "name": "Goblin Warrior",
             "text": "",
             "colours": [
@@ -9064,7 +9064,7 @@
         },
         {
             "id": "87158278-d23f-5c6d-aba0-35859a8e1252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d49a56f-2a5e-4d42-b75c-f3f3735829d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d49a56f-2a5e-4d42-b75c-f3f3735829d3.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9100,7 +9100,7 @@
         },
         {
             "id": "7fd86b65-c9ff-54a6-9442-953c3750e345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "115d8a6c-40ed-5c40-b256-e66d7b653e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf98006-cc53-4a6c-b372-97b0970ffe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf98006-cc53-4a6c-b372-97b0970ffe4d.jpg?1",
             "name": "Domri Rade Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MMA.json
+++ b/Assets/Resources/Sets/MMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "eb17f73c-21e5-54c8-bfac-1da5b59f55c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d6999d-63d7-4719-9e1a-851e040593f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d6999d-63d7-4719-9e1a-851e040593f5.jpg?1",
             "name": "Adarkar Valkyrie",
             "text": "Flying, vigilance\n{T}: When target creature other than Adarkar Valkyrie dies this turn, return that card to the battlefield under your control.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "4ce23e56-7fe7-5a14-9347-c31e1062367a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ada83d-c499-45c2-bf8b-788a439fd1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ada83d-c499-45c2-bf8b-788a439fd1c3.jpg?1",
             "name": "Amrou Scout",
             "text": "{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "01011f44-5656-5aa0-bfff-1dbade305c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0191a7-9928-4b6e-ae4f-0db2d41ca71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0191a7-9928-4b6e-ae4f-0db2d41ca71a.jpg?1",
             "name": "Amrou Seekers",
             "text": "Amrou Seekers can't be blocked except by artifact creatures and/or white creatures.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "32bc582a-ad16-5574-8a5b-fcdf5b78c1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310deafe-124b-4813-a383-bc9a9d028cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310deafe-124b-4813-a383-bc9a9d028cfc.jpg?1",
             "name": "Angel's Grace",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "fafcdce8-4f45-5e94-8ddd-b521b51b2ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bc3347-6d07-4609-ae7b-4f4596a065b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bc3347-6d07-4609-ae7b-4f4596a065b7.jpg?1",
             "name": "Auriok Salvagers",
             "text": "{1}{W}: Return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "b839d665-58aa-59ca-9e51-3c0a755dd820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe4fba9-5ff4-4e4b-be28-2849fa3c7003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe4fba9-5ff4-4e4b-be28-2849fa3c7003.jpg?1",
             "name": "Avian Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nFlying",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "47a94eb8-2c86-5161-a63d-c9a0cfbef0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b15737-1026-407f-b2a8-4f7932b2bb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b15737-1026-407f-b2a8-4f7932b2bb18.jpg?1",
             "name": "Blinding Beam",
             "text": "Choose one \u2014 Tap two target creatures; or creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "13a2f1b3-181a-5c9d-82e6-2c8483f517d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c809f77a-2c9a-4134-9c29-0709ee4f4957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c809f77a-2c9a-4134-9c29-0709ee4f4957.jpg?1",
             "name": "Bound in Silence",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "45ace07e-775c-5d44-958d-20442acf4065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bcc0fd-1eea-4eb0-8099-e0e94ffe00b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bcc0fd-1eea-4eb0-8099-e0e94ffe00b6.jpg?1",
             "name": "Cenn's Enlistment",
             "text": "Put two 1/1 white Kithkin Soldier creature tokens onto the battlefield.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "f931b623-5385-5e95-95af-dc8b403fb66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c55419c-f4d3-46b4-9a46-8cf84612819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c55419c-f4d3-46b4-9a46-8cf84612819b.jpg?1",
             "name": "Cloudgoat Ranger",
             "text": "When Cloudgoat Ranger enters the battlefield, put three 1/1 white Kithkin Soldier creature tokens onto the battlefield.\nTap three untapped Kithkin you control: Cloudgoat Ranger gets +2/+0 and gains flying until end of turn.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "a4c54462-d0c2-5137-8bbd-3250d30e725f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0025826-efe4-4be2-9e1d-76505251060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0025826-efe4-4be2-9e1d-76505251060d.jpg?1",
             "name": "Court Homunculus",
             "text": "Court Homunculus gets +1/+1 as long as you control another artifact.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "834dedd1-59ab-54af-88c1-b0e23f75a83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407b9797-fd17-4f40-8107-33512f6e8ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407b9797-fd17-4f40-8107-33512f6e8ab5.jpg?1",
             "name": "Dispeller's Capsule",
             "text": "{2}{W}, {T}, Sacrifice Dispeller's Capsule: Destroy target artifact or enchantment.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "75dbbd57-df8e-52ca-a9cc-948bbc0b2ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746d56ef-7ac5-403b-bca3-1cd267de97df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746d56ef-7ac5-403b-bca3-1cd267de97df.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "+1: Put a 1/1 white Soldier creature token onto the battlefield.\n+1: Target creature gets +3/+3 and gains flying until end of turn.\n-8: You get an emblem with \"Artifacts, creatures, enchantments, and lands you control are indestructible.\"",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "b1c54eb5-9e0e-59f0-89c3-75e3ccfcc159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992efc14-29d0-4a33-976e-28bb0a5f6b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992efc14-29d0-4a33-976e-28bb0a5f6b52.jpg?1",
             "name": "Ethersworn Canonist",
             "text": "Each player who has cast a nonartifact spell this turn can't cast additional nonartifact spells.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "6e2ec13d-634f-5d86-b211-25d0f9b977ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2993319-5b3d-48ca-b78d-563a8b66d76d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2993319-5b3d-48ca-b78d-563a8b66d76d.jpg?1",
             "name": "Feudkiller's Verdict",
             "text": "You gain 10 life. Then if you have more life than an opponent, put a 5/5 white Giant Warrior creature token onto the battlefield.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "cc0c33ae-9e4b-5105-82eb-022b555121be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d332f494-386c-4aaa-9854-d78e75a91e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d332f494-386c-4aaa-9854-d78e75a91e81.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -556,7 +556,7 @@
         },
         {
             "id": "a6961568-6987-5224-a054-28eaa7f91980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157091f0-4416-4129-b417-cb6de7a970f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157091f0-4416-4129-b417-cb6de7a970f7.jpg?1",
             "name": "Gleam of Resistance",
             "text": "Creatures you control get +1/+2 until end of turn. Untap those creatures.\nBasic landcycling {1}{W} ({1}{W}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -588,7 +588,7 @@
         },
         {
             "id": "073a7490-0626-5809-bb03-3edde6a681f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d48857-2fb6-4163-8785-12436db1b37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d48857-2fb6-4163-8785-12436db1b37c.jpg?1",
             "name": "Hillcomber Giant",
             "text": "Mountainwalk",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "222edb9c-4a0b-5941-a16e-0df7110ad65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ad17b9-6604-4a60-8f22-62775f1086ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ad17b9-6604-4a60-8f22-62775f1086ce.jpg?1",
             "name": "Ivory Giant",
             "text": "When Ivory Giant enters the battlefield, tap all nonwhite creatures.\nSuspend 5\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -657,7 +657,7 @@
         },
         {
             "id": "4319155a-6f45-5470-8041-b0af5739b381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d84ac44-01d8-415e-af69-7c608ac8ae20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d84ac44-01d8-415e-af69-7c608ac8ae20.jpg?1",
             "name": "Kataki, War's Wage",
             "text": "All artifacts have \"At the beginning of your upkeep, sacrifice this artifact unless you pay {1}.\"",
             "colours": [
@@ -693,7 +693,7 @@
         },
         {
             "id": "8e3204ea-9c3c-527d-9748-80a347bedba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d091f-7718-434f-894d-2fe40e0e67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d091f-7718-434f-894d-2fe40e0e67dd.jpg?1",
             "name": "Kithkin Greatheart",
             "text": "As long as you control a Giant, Kithkin Greatheart gets +1/+1 and has first strike.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "0dd188f4-ff36-5bfa-b56f-9c32ab6bc006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dc0113-f03c-47c2-9424-4c546793d25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dc0113-f03c-47c2-9424-4c546793d25d.jpg?1",
             "name": "Meadowboon",
             "text": "When Meadowboon leaves the battlefield, put a +1/+1 counter on each creature target player controls.\nEvoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "4f40d51a-70d5-5066-a561-623128e49e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3974cd-7054-4381-b327-4aba1c693382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3974cd-7054-4381-b327-4aba1c693382.jpg?1",
             "name": "Otherworldly Journey",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "4c60314c-e1e7-5778-8b1a-79caac1dbadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12788a7-5309-4a23-930d-009dc3305cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12788a7-5309-4a23-930d-009dc3305cef.jpg?1",
             "name": "Pallid Mycoderm",
             "text": "At the beginning of your upkeep, put a spore counter on Pallid Mycoderm.\nRemove three spore counters from Pallid Mycoderm: Put a 1/1 green Saproling creature token onto the battlefield.\nSacrifice a Saproling: Each creature you control that's a Fungus or a Saproling gets +1/+1 until end of turn.",
             "colours": [
@@ -830,7 +830,7 @@
         },
         {
             "id": "f851a8c9-4d07-5df7-82e2-d996ed2ad113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde60409-6b44-43ce-9441-af6020fe6355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde60409-6b44-43ce-9441-af6020fe6355.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -862,7 +862,7 @@
         },
         {
             "id": "4e709547-d634-547b-aafd-b25b776d90d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a4d2e0-1410-41f4-8070-2b0144c71e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a4d2e0-1410-41f4-8070-2b0144c71e1d.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "5d7ed4d5-b30f-53b2-b238-65949b08de32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a8a34-5f4c-43c3-9010-5c43453916f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a8a34-5f4c-43c3-9010-5c43453916f5.jpg?1",
             "name": "Saltfield Recluse",
             "text": "{T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "c9f19214-5c4e-536d-a9b5-1da7d4c9abb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e6cabf-0116-432a-99ae-fcbfec33e873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e6cabf-0116-432a-99ae-fcbfec33e873.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle enters the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "b382dc10-55bc-5652-8f35-ea59b533034b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae0b42a-ae61-4aa8-95c6-49b7fe455603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae0b42a-ae61-4aa8-95c6-49b7fe455603.jpg?1",
             "name": "Sandsower",
             "text": "Tap three untapped creatures you control: Tap target creature.",
             "colours": [
@@ -1001,7 +1001,7 @@
         },
         {
             "id": "a05d7804-b057-5d6c-a91f-de4f46e5ef8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e01c926-bd9a-4d2f-b9fc-452584d056d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e01c926-bd9a-4d2f-b9fc-452584d056d9.jpg?1",
             "name": "Stir the Pride",
             "text": "Choose one \u2014 Creatures you control get +2/+2 until end of turn; or until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "b0505bec-a01f-510e-984a-dd79401a6ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93cdf08-d503-4084-8c09-c4080ea05c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93cdf08-d503-4084-8c09-c4080ea05c3a.jpg?1",
             "name": "Stonehewer Giant",
             "text": "Vigilance\n{1}{W}, {T}: Search your library for an Equipment card and put it onto the battlefield. Attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "4aa06d88-94ea-5c6c-ab53-df466223c254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab387bfd-2651-4883-b1a7-7bf197018bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab387bfd-2651-4883-b1a7-7bf197018bbe.jpg?1",
             "name": "Terashi's Grasp",
             "text": "Destroy target artifact or enchantment. You gain life equal to its converted mana cost.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "57287897-373a-55c3-8fde-fd19da35c99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ba07ca-7be4-400e-a104-f7bbd527b6b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ba07ca-7be4-400e-a104-f7bbd527b6b4.jpg?1",
             "name": "Test of Faith",
             "text": "Prevent the next 3 damage that would be dealt to target creature this turn, and put a +1/+1 counter on that creature for each 1 damage prevented this way.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "09e526e4-5ae2-5102-b9bd-aef7ff7514fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026aaea6-ed4f-4505-9779-7c28ff6c2284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026aaea6-ed4f-4505-9779-7c28ff6c2284.jpg?1",
             "name": "Veteran Armorer",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "770207bc-1d65-5963-ae86-eee5a6a0eed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376485a9-7cf5-43e0-919d-4de06b6aec61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376485a9-7cf5-43e0-919d-4de06b6aec61.jpg?1",
             "name": "Yosei, the Morning Star",
             "text": "Flying\nWhen Yosei, the Morning Star dies, target player skips his or her next untap step. Tap up to five target permanents that player controls.",
             "colours": [
@@ -1206,7 +1206,7 @@
         },
         {
             "id": "a122ff55-e315-53b6-a03e-227c78d92acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fee19e-6175-4701-90ae-08a1dcd93f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fee19e-6175-4701-90ae-08a1dcd93f00.jpg?1",
             "name": "Aethersnipe",
             "text": "When \u00c6thersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1240,7 +1240,7 @@
         },
         {
             "id": "d1b51619-cec6-506d-a039-d029befa34b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d61bfb-cc58-41a8-8532-e575e789eae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d61bfb-cc58-41a8-8532-e575e789eae3.jpg?1",
             "name": "Careful Consideration",
             "text": "Target player draws four cards, then discards three cards. If you cast this spell during your main phase, instead that player draws four cards, then discards two cards.",
             "colours": [
@@ -1272,7 +1272,7 @@
         },
         {
             "id": "76d2c903-0833-5bd5-b09d-f83394439fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0183c540-9b05-4e65-b2a5-b062754020da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0183c540-9b05-4e65-b2a5-b062754020da.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two \u2014 Counter target spell; or return target permanent to its owner's hand; or tap all creatures your opponents control; or draw a card.",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "28f09f85-1aa1-56c8-868e-85e0d753f6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c8590d-21f8-4bbf-8b71-1588428e2467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c8590d-21f8-4bbf-8b71-1588428e2467.jpg?1",
             "name": "Dampen Thought",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard.\nSplice onto Arcane {1}{U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1338,7 +1338,7 @@
         },
         {
             "id": "11090008-9822-5dca-ab03-21970583f5b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c426c11-0c9c-476f-9547-fd61eecab4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c426c11-0c9c-476f-9547-fd61eecab4db.jpg?1",
             "name": "Echoing Truth",
             "text": "Return target nonland permanent and all other permanents with the same name as that permanent to their owners' hands.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "df87a6e8-779b-5625-8e1a-db419b0bf507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d62dbee-9b25-41fb-ade0-fef4ba1cf8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d62dbee-9b25-41fb-ade0-fef4ba1cf8bb.jpg?1",
             "name": "Errant Ephemeron",
             "text": "Flying\nSuspend 4\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "45f09ab6-9200-5c1d-954c-02d02914f103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef14d4e-4727-4bc7-bc15-b0d31e19df8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef14d4e-4727-4bc7-bc15-b0d31e19df8c.jpg?1",
             "name": "Erratic Mutation",
             "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "76bc1bf4-444e-5036-b9f6-b3baa78d0031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0de335a-d31e-41e1-ab0d-7dbdd768ac82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0de335a-d31e-41e1-ab0d-7dbdd768ac82.jpg?1",
             "name": "Esperzoa",
             "text": "Flying\nAt the beginning of your upkeep, return an artifact you control to its owner's hand.",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "8f559bb4-367f-5691-aa5a-f99e7c2f05a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808d20da-b76c-4ebf-8477-4cab922a7aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808d20da-b76c-4ebf-8477-4cab922a7aab.jpg?1",
             "name": "Etherium Sculptor",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "bee5b3a6-be63-5f90-84a1-ee8924c203b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3029ea36-78f5-4d98-bd28-1e5292c85e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3029ea36-78f5-4d98-bd28-1e5292c85e8e.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist enters the battlefield, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "b53385c6-f8af-5c39-8205-79275928a5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7dbbd-7947-4d1d-aaf8-a74e1ffdae97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7dbbd-7947-4d1d-aaf8-a74e1ffdae97.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "87c48713-a9f5-5e32-9317-7fb0f3d9b8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e00cea-5dc0-43f6-bd95-d2776bdb19c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e00cea-5dc0-43f6-bd95-d2776bdb19c2.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "Flying\n{U}, Sacrifice Glen Elendra Archmage: Counter target noncreature spell.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "7d9e0682-cd6e-5249-a6a4-e71d3b5280f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993cdb5-132a-466e-aa2c-e8ab402aef2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993cdb5-132a-466e-aa2c-e8ab402aef2d.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star dies, gain control of target creature.",
             "colours": [
@@ -1647,7 +1647,7 @@
         },
         {
             "id": "8b65a938-8165-5c0a-a92b-22ab1255d78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9ba246-0f2c-4865-a6a5-f9fd4b813ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9ba246-0f2c-4865-a6a5-f9fd4b813ef1.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.\"",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "49fbabcb-be56-5a4f-9e0a-cbed39243805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd63974-2a37-49bc-9eaf-a128c5ee3109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd63974-2a37-49bc-9eaf-a128c5ee3109.jpg?1",
             "name": "Latchkey Faerie",
             "text": "Flying\nProwl {2}{U} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Faerie or Rogue.)\nWhen Latchkey Faerie enters the battlefield, if its prowl cost was paid, draw a card.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "32bce47d-7a55-58a6-bcda-95c0ef072b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e39726-6229-4956-b3f9-7eb1d91227ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e39726-6229-4956-b3f9-7eb1d91227ef.jpg?1",
             "name": "Logic Knot",
             "text": "Delve (You may exile any number of cards from your graveyard as you cast this spell. It costs {1} less to cast for each card exiled this way.)\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "aed22900-3e24-5545-b18b-fab7ebba3313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19601ac-48a7-40c2-9159-af15af8520ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19601ac-48a7-40c2-9159-af15af8520ca.jpg?1",
             "name": "Meloku the Clouded Mirror",
             "text": "Flying\n{1}, Return a land you control to its owner's hand: Put a 1/1 blue Illusion creature token with flying onto the battlefield.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "8f797c15-2a9e-518f-9bc9-196a9ec3eb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acffb1-c1e8-4729-a350-64823b2f9d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acffb1-c1e8-4729-a350-64823b2f9d29.jpg?1",
             "name": "Mothdust Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nTap an untapped creature you control: Mothdust Changeling gains flying until end of turn.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "662e50ed-faf2-5ca2-9bca-c0a6f96538ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18233ee-3d90-4a28-8d93-918983bc9d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18233ee-3d90-4a28-8d93-918983bc9d11.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "df656d28-2840-586e-bdc6-04dacc114fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de38943-8f61-4be9-839b-370830c555cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de38943-8f61-4be9-839b-370830c555cf.jpg?1",
             "name": "Narcomoeba",
             "text": "Flying\nWhen Narcomoeba is put into your graveyard from your library, you may put it onto the battlefield.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "78aa1aaf-1c98-5a0a-9442-dbad610f8580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0e1481-a2a3-43d0-a33f-6f450c176e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0e1481-a2a3-43d0-a33f-6f450c176e43.jpg?1",
             "name": "Pact of Negation",
             "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "86915d58-7dc4-5b9c-9c3a-8d6f89d27cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3cc8b1-19af-426e-8b8b-d94b3280c728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3cc8b1-19af-426e-8b8b-d94b3280c728.jpg?1",
             "name": "Peer Through Depths",
             "text": "Look at the top five cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "88ccd563-fb4c-5787-8142-e81450209179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f425b017-8c4d-457f-919a-f2686d71bcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f425b017-8c4d-457f-919a-f2686d71bcac.jpg?1",
             "name": "Perilous Research",
             "text": "Draw two cards, then sacrifice a permanent.",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "09576448-6c81-5ace-a671-a35c85a0096e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58a6a63-c7d8-4f2f-acaf-b0a871eb5a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58a6a63-c7d8-4f2f-acaf-b0a871eb5a7c.jpg?1",
             "name": "Pestermite",
             "text": "Flash\nFlying\nWhen Pestermite enters the battlefield, you may tap or untap target permanent.",
             "colours": [
@@ -2022,7 +2022,7 @@
         },
         {
             "id": "1619fed2-35c4-58b0-a400-e25c7c2a5179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134c8764-028e-4f7f-988d-ffd4d3827eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134c8764-028e-4f7f-988d-ffd4d3827eb6.jpg?1",
             "name": "Petals of Insight",
             "text": "Look at the top three cards of your library. You may put those cards on the bottom of your library in any order. If you do, return Petals of Insight to its owner's hand. Otherwise, draw three cards.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "ad859108-f820-5676-8e16-8dee55bbdb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273db8a7-9c29-47c7-a00d-cc462e107d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273db8a7-9c29-47c7-a00d-cc462e107d02.jpg?1",
             "name": "Reach Through Mists",
             "text": "Draw a card.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "f12aed20-d52d-54c1-85cd-6692a6d7bea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc160761-60b4-4911-b75f-df445ea399aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc160761-60b4-4911-b75f-df445ea399aa.jpg?1",
             "name": "Riftwing Cloudskate",
             "text": "Flying\nWhen Riftwing Cloudskate enters the battlefield, return target permanent to its owner's hand.\nSuspend 3\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "0a28f300-f5aa-5146-a49e-24c9e0915bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29f95fe-2efa-4788-84d8-2bd88d8650b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29f95fe-2efa-4788-84d8-2bd88d8650b4.jpg?1",
             "name": "Scion of Oona",
             "text": "Flash\nFlying\nOther Faerie creatures you control get +1/+1.\nOther Faeries you control have shroud.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "31b060aa-b63d-5afd-94df-02f45f5dd328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79418c88-5335-4a02-bcad-c1a611be25b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79418c88-5335-4a02-bcad-c1a611be25b7.jpg?1",
             "name": "Spell Snare",
             "text": "Counter target spell with converted mana cost 2.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "f68f3d1c-9e2b-5a9a-94da-a4dc5f1f2951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3899605d-2203-4ab6-9ff5-69490382eea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3899605d-2203-4ab6-9ff5-69490382eea4.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "Flash\nFlying\nWhen Spellstutter Sprite enters the battlefield, counter target spell with converted mana cost X or less, where X is the number of Faeries you control.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "c08deceb-e515-538e-b694-a2a1578e40b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8632ab0-9b6d-4d32-8af9-c61e9206497f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8632ab0-9b6d-4d32-8af9-c61e9206497f.jpg?1",
             "name": "Take Possession",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nEnchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "7fafe986-dba7-5ea8-a0dd-ab7dbc652e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85756379-cdcb-4139-939d-36b22d39c001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85756379-cdcb-4139-939d-36b22d39c001.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -2292,7 +2292,7 @@
         },
         {
             "id": "aa821b91-35e7-5371-8edf-8bc66075a5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f29ba-ec1a-4362-b041-fe07214670f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f29ba-ec1a-4362-b041-fe07214670f8.jpg?1",
             "name": "Traumatic Visions",
             "text": "Counter target spell.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "73e12c4d-e03d-57f9-811d-48629be5b78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe73a5-dba9-422b-86c1-c957d9cb0622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe73a5-dba9-422b-86c1-c957d9cb0622.jpg?1",
             "name": "Vedalken Dismisser",
             "text": "When Vedalken Dismisser enters the battlefield, put target creature on top of its owner's library.",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "3f778c62-f4c3-5888-9eec-9c60fbebf497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141d5bb-6437-4353-bec9-63d59f5d8207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141d5bb-6437-4353-bec9-63d59f5d8207.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "f58b6851-c70d-55ec-a42e-9b60fa209cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894a8bc4-4ee0-45c6-86e9-aa91ddb505da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894a8bc4-4ee0-45c6-86e9-aa91ddb505da.jpg?1",
             "name": "Absorb Vis",
             "text": "Target player loses 4 life and you gain 4 life.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "a7f991a9-b995-57b2-9192-8a072bac3209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae897d-bbf9-47fe-a4d1-788cdf5c5de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae897d-bbf9-47fe-a4d1-788cdf5c5de3.jpg?1",
             "name": "Auntie's Snitch",
             "text": "Auntie's Snitch can't block.\nProwl {1}{B} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhenever a Goblin or Rogue you control deals combat damage to a player, if Auntie's Snitch is in your graveyard, you may return Auntie's Snitch to your hand.",
             "colours": [
@@ -2463,7 +2463,7 @@
         },
         {
             "id": "7374cf13-98b0-5532-a033-73f657b21e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af270e2-3bf2-4a53-9160-4ccdab34f3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af270e2-3bf2-4a53-9160-4ccdab34f3b3.jpg?1",
             "name": "Blightspeaker",
             "text": "{T}: Target player loses 1 life.\n{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "9fb01731-8d11-5861-9ce2-dfb32095fc4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ce657c-2092-419a-b35f-7b9786adc621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ce657c-2092-419a-b35f-7b9786adc621.jpg?1",
             "name": "Bridge from Below",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, if Bridge from Below is in your graveyard, put a 2/2 black Zombie creature token onto the battlefield.\nWhen a creature is put into an opponent's graveyard from the battlefield, if Bridge from Below is in your graveyard, exile Bridge from Below.",
             "colours": [
@@ -2531,7 +2531,7 @@
         },
         {
             "id": "1db67744-4595-53cd-b508-7dcb9a603190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c008ad2-ad33-46ee-a3f1-af85368c8734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c008ad2-ad33-46ee-a3f1-af85368c8734.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2566,7 +2566,7 @@
         },
         {
             "id": "667d5cc0-e262-5ed2-bc2b-223fe58701d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0870b88-2794-4646-9f51-f3af03bc8bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0870b88-2794-4646-9f51-f3af03bc8bc8.jpg?1",
             "name": "Death Cloud",
             "text": "Each player loses X life, discards X cards, sacrifices X creatures, then sacrifices X lands.",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "cbba1a0a-2dd9-55dc-b9bc-8006f9086933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179fc63a-cfa3-44be-9da5-d1bf33209207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179fc63a-cfa3-44be-9da5-d1bf33209207.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "e4926009-0db5-55f4-a194-86c4da65d3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a287887a-fc19-41e3-8914-8f984c1e4f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a287887a-fc19-41e3-8914-8f984c1e4f59.jpg?1",
             "name": "Death Rattle",
             "text": "Delve (You may exile any number of cards from your graveyard as you cast this spell. It costs {1} less to cast for each card exiled this way.)\nDestroy target nongreen creature. It can't be regenerated.",
             "colours": [
@@ -2664,7 +2664,7 @@
         },
         {
             "id": "b4ca7cc7-0378-57f2-a554-d7c633fa7eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78541e3-4e8f-41f8-b709-05b1b8e751d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78541e3-4e8f-41f8-b709-05b1b8e751d9.jpg?1",
             "name": "Deepcavern Imp",
             "text": "Flying, haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -2699,7 +2699,7 @@
         },
         {
             "id": "61c7a278-59b9-5937-8042-dbf7367e709b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2f3899-2e2e-418f-b3e7-74426d6255f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2f3899-2e2e-418f-b3e7-74426d6255f4.jpg?1",
             "name": "Drag Down",
             "text": "Domain \u2014 Target creature gets -1/-1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2731,7 +2731,7 @@
         },
         {
             "id": "e8eca786-0d83-5574-ad44-0ed1f404fa27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893376-f82b-49b5-b641-85d2458ae261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893376-f82b-49b5-b641-85d2458ae261.jpg?1",
             "name": "Dreamspoiler Witches",
             "text": "Flying\nWhenever you cast a spell during an opponent's turn, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "7b07c101-98fb-50f7-b5b8-e800ba73cfbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12759ab-97c7-406a-bf57-eec74839f8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12759ab-97c7-406a-bf57-eec74839f8f6.jpg?1",
             "name": "Earwig Squad",
             "text": "Prowl {2}{B} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhen Earwig Squad enters the battlefield, if its prowl cost was paid, search target opponent's library for three cards and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "d44314e2-3f90-5317-980d-cfc7c6def138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60afc2-d383-4a52-8a0e-0d9dc68fed03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60afc2-d383-4a52-8a0e-0d9dc68fed03.jpg?1",
             "name": "Executioner's Capsule",
             "text": "{1}{B}, {T}, Sacrifice Executioner's Capsule: Destroy target nonblack creature.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "87388ac2-cc09-546f-84f8-29f7f909d8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c9390-1b44-40c5-b370-1d9966cbfeae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c9390-1b44-40c5-b370-1d9966cbfeae.jpg?1",
             "name": "Extirpate",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "3fc0b19d-a63f-513c-a48c-f937852e46e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a25f62-0ef5-4941-b9af-1ce1a63fb5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a25f62-0ef5-4941-b9af-1ce1a63fb5e8.jpg?1",
             "name": "Facevaulter",
             "text": "{B}, Sacrifice a Goblin: Facevaulter gets +2/+2 until end of turn.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "2bd57741-2467-5c60-9298-bd02e7f2f42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352f7903-c2ab-4b08-b602-ee008eeb19cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352f7903-c2ab-4b08-b602-ee008eeb19cd.jpg?1",
             "name": "Faerie Macabre",
             "text": "Flying\nDiscard Faerie Macabre: Exile up to two target cards from graveyards.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "ff9fdef1-17cb-571a-818b-21d702943367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978a9e84-2cce-41ec-b311-745a8ea6c238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978a9e84-2cce-41ec-b311-745a8ea6c238.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin dies, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "58ea9635-a9dd-583a-aa96-6a7b9c4d89af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e029c-cf98-4c98-b394-923247579ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e029c-cf98-4c98-b394-923247579ee5.jpg?1",
             "name": "Horobi's Whisper",
             "text": "If you control a Swamp, destroy target nonblack creature.\nSplice onto Arcane\u2014\nExile four cards from your graveyard. (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "059e3a43-f0cf-5b74-8fe0-f20df29a6157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80365-1613-4d26-abe3-8cec0d40146b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80365-1613-4d26-abe3-8cec0d40146b.jpg?1",
             "name": "Kokusho, the Evening Star",
             "text": "Flying\nWhen Kokusho, the Evening Star dies, each opponent loses 5 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "4c54a41b-7461-5144-b7b2-4a54e6e1ccc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1",
             "name": "Mad Auntie",
             "text": "Other Goblin creatures you control get +1/+1.\n{T}: Regenerate another target Goblin.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "4713dcda-3349-511e-9887-350d88e714d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1833f-a682-4795-a39a-8b03ead50b10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1833f-a682-4795-a39a-8b03ead50b10.jpg?1",
             "name": "Marsh Flitter",
             "text": "Flying\nWhen Marsh Flitter enters the battlefield, put two 1/1 black Goblin Rogue creature tokens onto the battlefield.\nSacrifice a Goblin: Marsh Flitter becomes 3/3 until end of turn.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "004b3b84-db1d-5191-91d9-0b5844b8cf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f45251-e71e-4601-9b51-dbc08ab036c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f45251-e71e-4601-9b51-dbc08ab036c2.jpg?1",
             "name": "Peppersmoke",
             "text": "Target creature gets -1/-1 until end of turn. If you control a Faerie, draw a card.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "b89be611-c214-5ab5-9928-3b673de32928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb65f5ff-1f0a-469c-831f-618254727111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb65f5ff-1f0a-469c-831f-618254727111.jpg?1",
             "name": "Phthisis",
             "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5\u2014{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "031421f7-65ac-54a2-b0ec-0dfc18cdc141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7449f03-fed0-4f8d-89ca-28182b6598f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7449f03-fed0-4f8d-89ca-28182b6598f6.jpg?1",
             "name": "Rathi Trapper",
             "text": "{B}, {T}: Tap target creature.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "0a33f2e8-e9b3-5360-a3f9-2be629b52a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271436b-897a-4b24-a5d2-d29dbea8c1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271436b-897a-4b24-a5d2-d29dbea8c1bf.jpg?1",
             "name": "Raven's Crime",
             "text": "Target player discards a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "7ead80a0-36cc-5282-99a6-57ab852f5a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07c59-23d3-44fe-9393-4ebb5450b644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07c59-23d3-44fe-9393-4ebb5450b644.jpg?1",
             "name": "Skeletal Vampire",
             "text": "Flying\nWhen Skeletal Vampire enters the battlefield, put two 1/1 black Bat creature tokens with flying onto the battlefield.\n{3}{B}{B}, Sacrifice a Bat: Put two 1/1 black Bat creature tokens with flying onto the battlefield.\nSacrifice a Bat: Regenerate Skeletal Vampire.",
             "colours": [
@@ -3281,7 +3281,7 @@
         },
         {
             "id": "2049040a-5d82-54c6-977b-8a8f407cbcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd740d1d-ad70-47de-aef1-aec5ab2135d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd740d1d-ad70-47de-aef1-aec5ab2135d2.jpg?1",
             "name": "Slaughter Pact",
             "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "fc123fef-083a-5957-bd6d-63f0974f70b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c40d4c-426d-4697-a173-e0a348308857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c40d4c-426d-4697-a173-e0a348308857.jpg?1",
             "name": "Stinkweed Imp",
             "text": "Flying\nWhenever Stinkweed Imp deals combat damage to a creature, destroy that creature.\nDredge 5 (If you would draw a card, instead you may put exactly five cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "257361a5-6efe-5690-9739-85a29ef608a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edbaa-68c8-4a1c-ab5f-d096e74c0d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edbaa-68c8-4a1c-ab5f-d096e74c0d01.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "912300df-9050-5746-990d-390a51172b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0547b01-aabc-4114-b71c-ae44cb2bb871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0547b01-aabc-4114-b71c-ae44cb2bb871.jpg?1",
             "name": "Syphon Life",
             "text": "Target player loses 2 life and you gain 2 life.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "38a33600-5ddc-5322-9cfc-bf094c5a0da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244d864d-fc74-4147-aca6-d0498691b1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244d864d-fc74-4147-aca6-d0498691b1a9.jpg?1",
             "name": "Thieving Sprite",
             "text": "Flying\nWhen Thieving Sprite enters the battlefield, target player reveals X cards from his or her hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "785c1577-c08a-567a-a4b4-74f472a44411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d4615-fe42-41b1-be74-4ad8355eb114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d4615-fe42-41b1-be74-4ad8355eb114.jpg?1",
             "name": "Tombstalker",
             "text": "Flying\nDelve (You may exile any number of cards from your graveyard as you cast this spell. It costs {1} less to cast for each card exiled this way.)",
             "colours": [
@@ -3482,7 +3482,7 @@
         },
         {
             "id": "a1537f03-9ba3-5929-a7c8-93094ec3d6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac647ea-e81e-46d4-9a65-613d6643362b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac647ea-e81e-46d4-9a65-613d6643362b.jpg?1",
             "name": "Warren Pilferers",
             "text": "When Warren Pilferers enters the battlefield, return target creature card from your graveyard to your hand. If that card is a Goblin card, Warren Pilferers gains haste until end of turn.",
             "colours": [
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "0b768caf-a6c5-5bfc-adac-c019f666110c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524aa84d-7838-4664-b30c-3c242b46fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524aa84d-7838-4664-b30c-3c242b46fc6b.jpg?1",
             "name": "Warren Weirding",
             "text": "Target player sacrifices a creature. If a Goblin is sacrificed this way, that player puts two 1/1 black Goblin Rogue creature tokens onto the battlefield, and those tokens gain haste until end of turn.",
             "colours": [
@@ -3552,7 +3552,7 @@
         },
         {
             "id": "d06290e5-4769-5e5b-a1e1-51b7a6ffcc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d76ed9-7a2c-466f-be39-1f7880744c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d76ed9-7a2c-466f-be39-1f7880744c33.jpg?1",
             "name": "Blind-Spot Giant",
             "text": "Blind-Spot Giant can't attack or block unless you control another Giant.",
             "colours": [
@@ -3587,7 +3587,7 @@
         },
         {
             "id": "184de455-c0d9-5134-9075-9a09c65fe483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310647b0-54a4-4c0a-acdd-5e8e91972a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310647b0-54a4-4c0a-acdd-5e8e91972a87.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "839763b8-7185-5493-a24d-b95d02a06850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8283d5c-9dc3-409b-b897-9bc61a6c9d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8283d5c-9dc3-409b-b897-9bc61a6c9d57.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "80c2d6d9-ca17-5bb1-ac66-9c608527e00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54582b89-a152-4686-8172-82db740dfea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54582b89-a152-4686-8172-82db740dfea2.jpg?1",
             "name": "Countryside Crusher",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a land card, put it into your graveyard and repeat this process.\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Countryside Crusher.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "049f4442-fba3-5e4e-bf48-8e7f20068181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756025a8-1096-4e7c-bbfe-6237e4a76216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756025a8-1096-4e7c-bbfe-6237e4a76216.jpg?1",
             "name": "Crush Underfoot",
             "text": "Choose a Giant creature you control. It deals damage equal to its power to target creature.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "4117174d-c04d-5d5f-b9b9-7890e884c11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827c728-5526-4abe-ad21-311594a0bc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827c728-5526-4abe-ad21-311594a0bc13.jpg?1",
             "name": "Desperate Ritual",
             "text": "Add {R}{R}{R} to your mana pool.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3755,7 +3755,7 @@
         },
         {
             "id": "46cfc4cf-ff22-50a3-ab70-e3babb31c9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230cd568-f7ed-4571-a609-36522add91d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230cd568-f7ed-4571-a609-36522add91d0.jpg?1",
             "name": "Dragonstorm",
             "text": "Search your library for a Dragon permanent card and put it onto the battlefield. Then shuffle your library.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -3787,7 +3787,7 @@
         },
         {
             "id": "f6edb6b4-e23a-53e3-bf65-8a8552f7be51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7488515d-d90f-44c4-b2a9-8f76e46bbbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7488515d-d90f-44c4-b2a9-8f76e46bbbbe.jpg?1",
             "name": "Empty the Warrens",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "f90d39c1-d3a9-50aa-aed4-503a00360c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc517738-d731-4960-bc1e-5e86ca341ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc517738-d731-4960-bc1e-5e86ca341ba9.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "000a83dc-9ee4-528d-866d-2ca2063e718c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2a382b-f63a-4520-ab6e-a5428a5e61db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2a382b-f63a-4520-ab6e-a5428a5e61db.jpg?1",
             "name": "Fury Charm",
             "text": "Choose one \u2014 Destroy target artifact; or target creature gets +1/+1 and gains trample until end of turn; or remove two time counters from target permanent or suspended card.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "59edb354-18f7-536e-b189-3b4709038c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa3b25c-a1e1-4eb0-9b65-3c4c6b2a8903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa3b25c-a1e1-4eb0-9b65-3c4c6b2a8903.jpg?1",
             "name": "Glacial Ray",
             "text": "Glacial Ray deals 2 damage to target creature or player.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "d8f8c47c-6bdf-51ff-9ace-f62c9dd7bdef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd49f85-7dbd-4cb6-b916-2adee29bb745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd49f85-7dbd-4cb6-b916-2adee29bb745.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to target creature or player.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "5a9277bb-651e-5871-8042-da4bdaa8b9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b922fc5-602b-4f92-9588-00a77a9d803c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b922fc5-602b-4f92-9588-00a77a9d803c.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate this ability only if Greater Gargadon is suspended.",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "b1f81661-995d-5768-b0e2-2e0a6c1ce443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908980bf-0631-4c10-b0ae-39e5b50b9068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908980bf-0631-4c10-b0ae-39e5b50b9068.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {2}{R} to your mana pool. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4017,7 +4017,7 @@
         },
         {
             "id": "aa923abe-e78c-528e-a35b-6bbbe9876b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd39a59-688f-4465-8f00-540326c41128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd39a59-688f-4465-8f00-540326c41128.jpg?1",
             "name": "Hammerheim Deadeye",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Hammerheim Deadeye enters the battlefield, destroy target creature with flying.",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "e0dbd8fc-ccc0-531b-afd3-0af32c27f64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7445467-1222-4d9e-8a2f-879719c97b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7445467-1222-4d9e-8a2f-879719c97b29.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Put a token that's a copy of target nonlegendary creature you control onto the battlefield. That token has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "0a5c0300-7ba3-58b7-87fb-14d02fb57196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbec4-202d-47ee-9472-b41d41f75372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbec4-202d-47ee-9472-b41d41f75372.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "7fde22d1-63d9-50dd-ae6a-fc848c31dacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45b117-8ba1-4349-ac06-f690cde48c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45b117-8ba1-4349-ac06-f690cde48c17.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, put a 1/1 red Goblin creature token onto the battlefield.",
             "colours": [
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "7585cd24-0661-5698-8c03-5462b53124d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed531da-4e57-4694-bd6c-8669dcc3d119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed531da-4e57-4694-bd6c-8669dcc3d119.jpg?1",
             "name": "Molten Disaster",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf Molten Disaster was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "535daefb-20e2-5df3-b9d7-3eea0ccdf314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd618eb1-0013-461c-873e-a66377fa284a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd618eb1-0013-461c-873e-a66377fa284a.jpg?1",
             "name": "Pardic Dragon",
             "text": "Flying\n{R}: Pardic Dragon gets +1/+0 until end of turn.\nSuspend 2\u2014{R}{R}\nWhenever an opponent casts a spell, if Pardic Dragon is suspended, that player may put a time counter on Pardic Dragon.",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "893f164f-b791-5e18-81cd-3c36901c0516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ee7137-dbc4-4fe5-802a-42dada4445db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ee7137-dbc4-4fe5-802a-42dada4445db.jpg?1",
             "name": "Pyromancer's Swath",
             "text": "If an instant or sorcery source you control would deal damage to a creature or player, it deals that much damage plus 2 to that creature or player instead.\nAt the beginning of each end step, discard your hand.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "88732e50-69b3-57a9-b4a5-1cbc948574fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c5fcbf-00f5-41ee-9673-ad39fd2327c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c5fcbf-00f5-41ee-9673-ad39fd2327c6.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to target creature or player.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "a2b8e1ac-ad12-5c98-918e-5e17c003c050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9015b8a-7070-40de-8baa-4b4002429e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9015b8a-7070-40de-8baa-4b4002429e79.jpg?1",
             "name": "Rift Elemental",
             "text": "{1}{R}, Remove a time counter from a permanent you control or suspended card you own: Rift Elemental gets +2/+0 until end of turn.",
             "colours": [
@@ -4322,7 +4322,7 @@
         },
         {
             "id": "fb65e460-438a-50a4-ba75-38392849944e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784393a8-e231-4613-8849-576e6b61b354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784393a8-e231-4613-8849-576e6b61b354.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "84c45e5a-5263-5135-92f5-761c9624df1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fdf1-99cf-402b-a70e-de0e77933d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fdf1-99cf-402b-a70e-de0e77933d81.jpg?1",
             "name": "Shrapnel Blast",
             "text": "As an additional cost to cast Shrapnel Blast, sacrifice an artifact.\nShrapnel Blast deals 5 damage to target creature or player.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "8a200fe3-b555-5677-a988-ad10dac7907f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a309d0-5da2-4976-b1ad-1b363c8dca42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a309d0-5da2-4976-b1ad-1b363c8dca42.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -4427,7 +4427,7 @@
         },
         {
             "id": "3ad8b61f-93b4-5611-85a8-8f3a049ed43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102b0df-04c0-418c-a316-c8ea8660e9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102b0df-04c0-418c-a316-c8ea8660e9f7.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -4462,7 +4462,7 @@
         },
         {
             "id": "a3b8cf4b-4e12-5cbd-9ba1-ae15f76ae231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1527b360-2aa5-4680-89f0-4c9095afa3ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1527b360-2aa5-4680-89f0-4c9095afa3ef.jpg?1",
             "name": "Stinkdrinker Daredevil",
             "text": "Giant spells you cast cost {2} less to cast.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "eb9464c3-8963-5aae-a3e3-69709b845c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b6f51-d444-48f7-a7f0-743f2b8d0595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b6f51-d444-48f7-a7f0-743f2b8d0595.jpg?1",
             "name": "Sudden Shock",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "5775de32-5115-52b2-813b-7563992e2694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc997628-22f3-4e6f-998f-e049fac8192c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc997628-22f3-4e6f-998f-e049fac8192c.jpg?1",
             "name": "Tar Pitcher",
             "text": "{T}, Sacrifice a Goblin: Tar Pitcher deals 2 damage to target creature or player.",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "a60e2b14-3ca5-5c0d-bfa4-ee3a93bd953c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d964912d-50cb-42d7-a72c-9c9066087a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d964912d-50cb-42d7-a72c-9c9066087a96.jpg?1",
             "name": "Thundercloud Shaman",
             "text": "When Thundercloud Shaman enters the battlefield, it deals damage equal to the number of Giants you control to each non-Giant creature.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "eeb27f4c-8fb5-5806-ba7a-d07a37778336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b76021-77de-4155-98b2-24daab1a850e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b76021-77de-4155-98b2-24daab1a850e.jpg?1",
             "name": "Thundering Giant",
             "text": "Haste",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "db01d6ed-0d5c-5aab-936b-6f4938614691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d00132-6c25-42d3-bfe5-5f893b63a292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d00132-6c25-42d3-bfe5-5f893b63a292.jpg?1",
             "name": "Torrent of Stone",
             "text": "Torrent of Stone deals 4 damage to target creature.\nSplice onto Arcane\u2014\nSacrifice two Mountains. (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "2731230b-3bc5-57f8-b41e-fb2c7f8236dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fafa53-1e22-43f5-abf3-bbab8130f84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fafa53-1e22-43f5-abf3-bbab8130f84d.jpg?1",
             "name": "Tribal Flames",
             "text": "Domain \u2014 Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "76cc6bab-2221-582d-bc09-e43398675f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523500d3-5614-4be8-95c7-d63ca279c1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523500d3-5614-4be8-95c7-d63ca279c1b1.jpg?1",
             "name": "War-Spike Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{R}: War-Spike Changeling gains first strike until end of turn.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "f8822e3b-4d08-515c-9996-fcf7fdcb28f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cd5c0-f56f-4419-b9d2-478d8455f2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cd5c0-f56f-4419-b9d2-478d8455f2b8.jpg?1",
             "name": "Citanul Woodreaders",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nWhen Citanul Woodreaders enters the battlefield, if it was kicked, draw two cards.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "ce2b37c5-5aa8-5974-93c1-9f212f8da736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f296a5a-9e6c-4432-bf9b-fafbcccb6e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f296a5a-9e6c-4432-bf9b-fafbcccb6e62.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would put one or more tokens onto the battlefield under your control, it puts twice that many of those tokens onto the battlefield instead.\nIf an effect would place one or more counters on a permanent you control, it places twice that many of those counters on that permanent instead.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "1ba3f49c-ce11-56e0-9209-f285f5c059b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7c7dea-c73d-47ee-9119-5c8a4357d79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7c7dea-c73d-47ee-9119-5c8a4357d79e.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "d9db8c69-c632-5f20-ab73-f1152e669962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b14c3cf-fb7b-4397-bb30-1efaf142959f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b14c3cf-fb7b-4397-bb30-1efaf142959f.jpg?1",
             "name": "Echoing Courage",
             "text": "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "d5a79241-2063-5fa3-9bd9-c06862938432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02902fcc-eefc-4e81-aafd-59fa203a71d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02902fcc-eefc-4e81-aafd-59fa203a71d7.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "384466f5-db22-54ac-aaea-c3aecab37384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2033c-3be6-413f-93b9-a375af9b5cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2033c-3be6-413f-93b9-a375af9b5cf1.jpg?1",
             "name": "Giant Dustwasp",
             "text": "Flying\nSuspend 4\u2014{1}{G} (Rather than cast this card from your hand, you may pay {1}{G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "71168119-be35-52d0-a10d-119887c1d6bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98318dc-8ba5-4a33-b4a6-c36add8aa80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98318dc-8ba5-4a33-b4a6-c36add8aa80e.jpg?1",
             "name": "Greater Mossdog",
             "text": "Dredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "d1585cf4-3805-56c3-b2dc-2093f498238a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afa824d-ad9b-44c1-9509-f9ecd34bde08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afa824d-ad9b-44c1-9509-f9ecd34bde08.jpg?1",
             "name": "Hana Kami",
             "text": "{1}{G}, Sacrifice Hana Kami: Return target Arcane card from your graveyard to your hand.",
             "colours": [
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "3afdfe8f-d280-52f4-9263-095b7a36ca77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d0f09b-cab8-42d8-ac93-1fd7c1244560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d0f09b-cab8-42d8-ac93-1fd7c1244560.jpg?1",
             "name": "Imperiosaur",
             "text": "Spend only mana produced by basic lands to cast Imperiosaur.",
             "colours": [
@@ -5038,7 +5038,7 @@
         },
         {
             "id": "1a7b26c5-697f-5e2b-b08b-25a0e37d3218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3528ed-e1a1-4020-acba-c079484de0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3528ed-e1a1-4020-acba-c079484de0ba.jpg?1",
             "name": "Incremental Growth",
             "text": "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "3540485b-d706-54fd-9d4d-5948c10aa6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d044c-b6ff-4434-a059-081832130212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d044c-b6ff-4434-a059-081832130212.jpg?1",
             "name": "Jugan, the Rising Star",
             "text": "Flying\nWhen Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "d63db819-1d7d-5e20-a56e-23e731e28ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd600b0a-c7dd-4a5d-bd35-14ef4215c520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd600b0a-c7dd-4a5d-bd35-14ef4215c520.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "889c2d3f-27dc-5139-9194-8fd63e8d3036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8338bb-bf0d-4fc2-b247-4b2a183f27cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8338bb-bf0d-4fc2-b247-4b2a183f27cf.jpg?1",
             "name": "Krosan Grip",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "805ae955-3184-5ae0-83a8-fcc6863a50ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57d97cf-2252-47f3-9eff-6003626bc900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57d97cf-2252-47f3-9eff-6003626bc900.jpg?1",
             "name": "Life from the Loam",
             "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "e5d2af6c-02aa-59e8-8415-0db675abc02f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ec6fc8-f778-4cca-8b67-66d6ff0efd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ec6fc8-f778-4cca-8b67-66d6ff0efd45.jpg?1",
             "name": "Masked Admirers",
             "text": "When Masked Admirers enters the battlefield, draw a card.\nWhenever you cast a creature spell, you may pay {G}{G}. If you do, return Masked Admirers from your graveyard to your hand.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "11b7ede1-e828-5f7f-aa0f-df0dabde8953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771cf62-b454-4c7f-918e-68335e695702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771cf62-b454-4c7f-918e-68335e695702.jpg?1",
             "name": "Moldervine Cloak",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5274,7 +5274,7 @@
         },
         {
             "id": "a712db83-4e81-5080-a2c8-4e0cc538e328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501e4cb0-121e-450e-b522-eed90a2e34cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501e4cb0-121e-450e-b522-eed90a2e34cb.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman enters the battlefield, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than cast this card from your hand, you may pay {2}{G}{G} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "d3f615f8-07a7-53ed-87f5-dc3415274e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6415bf5-ead8-45a6-8d9c-d160c44cb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6415bf5-ead8-45a6-8d9c-d160c44cb775.jpg?1",
             "name": "Penumbra Spider",
             "text": "Reach\nWhen Penumbra Spider dies, put a 2/4 black Spider creature token with reach onto the battlefield.",
             "colours": [
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "42177c55-1e63-59f2-865d-e66a6d557215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034215f1-62f5-49ce-a818-44577138b508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034215f1-62f5-49ce-a818-44577138b508.jpg?1",
             "name": "Reach of Branches",
             "text": "Put a 2/5 green Treefolk Shaman creature token onto the battlefield.\nWhenever a Forest enters the battlefield under your control, you may return Reach of Branches from your graveyard to your hand.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "218040b4-a4aa-5ae8-8f11-910f41a84c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785d5a98-97b2-4a9e-83ee-2a74479add7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785d5a98-97b2-4a9e-83ee-2a74479add7b.jpg?1",
             "name": "Riftsweeper",
             "text": "When Riftsweeper enters the battlefield, choose target face-up exiled card. Its owner shuffles it into his or her library.",
             "colours": [
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "e6397612-820c-5364-ad97-ca855640bd07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5dfc70-5e39-41bd-a78b-f7dfc7f53bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5dfc70-5e39-41bd-a78b-f7dfc7f53bf4.jpg?1",
             "name": "Rude Awakening",
             "text": "Choose one \u2014 Untap all lands you control; or until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -5445,7 +5445,7 @@
         },
         {
             "id": "0b9bdc89-568e-5e66-bcd6-1919105bd47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0383f8d-8b8a-4a6b-8756-b27d8351a856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0383f8d-8b8a-4a6b-8756-b27d8351a856.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card and put it onto the battlefield. Then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -5477,7 +5477,7 @@
         },
         {
             "id": "2c889c8f-8e40-53e4-98a9-3c7411d5847b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7facb43f-275f-4f7f-a1b2-9c0e4b15addc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7facb43f-275f-4f7f-a1b2-9c0e4b15addc.jpg?1",
             "name": "Sporesower Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on each Fungus you control.\nRemove three spore counters from Sporesower Thallid: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "a3aed9ed-11f3-5727-bb2d-0729de974409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f0e2f5-6680-4abb-8724-32e0aa306dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f0e2f5-6680-4abb-8724-32e0aa306dd3.jpg?1",
             "name": "Sporoloth Ancient",
             "text": "At the beginning of your upkeep, put a spore counter on Sporoloth Ancient.\nCreatures you control have \"Remove two spore counters from this creature: Put a 1/1 green Saproling creature token onto the battlefield.\"",
             "colours": [
@@ -5545,7 +5545,7 @@
         },
         {
             "id": "d5a107fd-9ad7-5224-9022-06ee090d50dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8948f92-9bd5-4950-b901-6cf1528b5c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8948f92-9bd5-4950-b901-6cf1528b5c3f.jpg?1",
             "name": "Summoner's Pact",
             "text": "Search your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "00fc4df9-94bd-5c1f-ab5e-dbd04188e9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fed99a1-4cd6-40fc-8796-a92edc79bc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fed99a1-4cd6-40fc-8796-a92edc79bc76.jpg?1",
             "name": "Sylvan Bounty",
             "text": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "ba7ef1e5-642c-55e4-8391-983f4ef98bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea82414-3f16-4c8c-8668-1f1ee7566c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea82414-3f16-4c8c-8668-1f1ee7566c7b.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -5643,7 +5643,7 @@
         },
         {
             "id": "5f04253d-ffbe-5c48-b4ce-ebe4e7e9744a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d20d28-76e9-4e6e-95c3-f88c51dfabfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d20d28-76e9-4e6e-95c3-f88c51dfabfd.jpg?1",
             "name": "Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid.\nRemove three spore counters from Thallid: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "94f7870f-3be1-5876-99c1-2208697dfd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbb06b1-c2ca-4a69-835e-a47b576b7079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbb06b1-c2ca-4a69-835e-a47b576b7079.jpg?1",
             "name": "Thallid Germinator",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid Germinator.\nRemove three spore counters from Thallid Germinator: Put a 1/1 green Saproling creature token onto the battlefield.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "a7ec1219-0350-57a8-8e5f-b3c3cb47baa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4363851-ecd6-41de-9bad-1fa02fb0b06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4363851-ecd6-41de-9bad-1fa02fb0b06e.jpg?1",
             "name": "Thallid Shell-Dweller",
             "text": "Defender\nAt the beginning of your upkeep, put a spore counter on Thallid Shell-Dweller.\nRemove three spore counters from Thallid Shell-Dweller: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "3364ab1f-6b88-558a-8bc2-30d1b1401ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f6e97-eb7a-470a-8673-4997256e79f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f6e97-eb7a-470a-8673-4997256e79f0.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle your library; or put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -5777,7 +5777,7 @@
         },
         {
             "id": "0f168065-1569-584f-8371-42ec60d54d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3815bd2-bc3c-46b8-b9e1-8eea25156440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3815bd2-bc3c-46b8-b9e1-8eea25156440.jpg?1",
             "name": "Tromp the Domains",
             "text": "Domain \u2014 Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "8073a0c6-42b4-5f75-8517-6f87ce7c90cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c2fce4-32b4-40cd-b467-a3ba3bf1fa10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c2fce4-32b4-40cd-b467-a3ba3bf1fa10.jpg?1",
             "name": "Verdeloth the Ancient",
             "text": "Kicker {X} (You may pay an additional {X} as you cast this spell.)\nSaproling creatures and other Treefolk creatures get +1/+1.\nWhen Verdeloth the Ancient enters the battlefield, if it was kicked, put X 1/1 green Saproling creature tokens onto the battlefield.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "0a605817-1495-5fbd-a882-c18d96469893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b014c3d9-0c24-42c3-8b70-eaf1064901ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b014c3d9-0c24-42c3-8b70-eaf1064901ce.jpg?1",
             "name": "Walker of the Grove",
             "text": "When Walker of the Grove leaves the battlefield, put a 4/4 green Elemental creature token onto the battlefield.\nEvoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "467b717e-0207-577f-bf1b-d44e8fc98da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb81647-e8ff-492e-a862-1b1ca142efe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb81647-e8ff-492e-a862-1b1ca142efe6.jpg?1",
             "name": "Woodfall Primus",
             "text": "Trample\nWhen Woodfall Primus enters the battlefield, destroy target noncreature permanent.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "68b3935f-96db-5717-ad94-0fe2b6b499dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d415c502-208f-4615-b5d9-57db7f966ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d415c502-208f-4615-b5d9-57db7f966ac1.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -5948,7 +5948,7 @@
         },
         {
             "id": "1ea5f7e0-1d0c-51d7-b6c9-beee97777282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337fd1aa-1c85-4aee-923b-c457e43cda72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337fd1aa-1c85-4aee-923b-c457e43cda72.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "271a80df-d4c1-599e-a6ac-6a4a3d61e054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64553587-e707-41d2-a2f4-768dfa47e893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64553587-e707-41d2-a2f4-768dfa47e893.jpg?1",
             "name": "Jhoira of the Ghitu",
             "text": "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend. (At the beginning of your upkeep, remove a time counter from that card. When the last is removed, cast it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -6026,7 +6026,7 @@
         },
         {
             "id": "977fa373-00a4-5f87-98bb-9987cda039be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde4a6-128d-447f-9659-ceb3b345ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde4a6-128d-447f-9659-ceb3b345ed33.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "c3140c5d-3b07-5f53-b75d-70a24393647e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3eaaed-9af5-4220-a3d1-744de8147c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3eaaed-9af5-4220-a3d1-744de8147c52.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "51c22baa-7c3e-589a-b879-ab6e178cdc27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58beea98-bafd-46bf-8aec-d98893019374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58beea98-bafd-46bf-8aec-d98893019374.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "bec3cb35-cc69-5077-b071-2eb3063d023c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd667f-c330-474e-842b-49dfd3906375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd667f-c330-474e-842b-49dfd3906375.jpg?1",
             "name": "Mind Funeral",
             "text": "Target opponent reveals cards from the top of his or her library until four land cards are revealed. That player puts all cards revealed this way into his or her graveyard.",
             "colours": [
@@ -6165,7 +6165,7 @@
         },
         {
             "id": "6fb068b9-e7fc-5c78-a610-c217d177fc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5d0ba-bcb1-41db-80dd-ad22b8408105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5d0ba-bcb1-41db-80dd-ad22b8408105.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "89759631-3cfe-50d4-8c07-20e36b49f1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181e20e9-94a2-40b6-abc4-797f588866bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181e20e9-94a2-40b6-abc4-797f588866bf.jpg?1",
             "name": "Sarkhan Vol",
             "text": "+1: Creatures you control get +1/+1 and gain haste until end of turn.\n-2: Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n-6: Put five 4/4 red Dragon creature tokens with flying onto the battlefield.",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "c718f22f-5c40-5485-bf1e-5c5a30b07629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09521f23-52d6-482d-9f3b-c4d12fcc08cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09521f23-52d6-482d-9f3b-c4d12fcc08cc.jpg?1",
             "name": "Tidehollow Sculler",
             "text": "When Tidehollow Sculler enters the battlefield, target opponent reveals his or her hand and you choose a nonland card from it. Exile that card.\nWhen Tidehollow Sculler leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "8c921bc3-9ed0-5057-9ab3-7c95d979ac04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b14a8b3-1a85-400b-b17c-a28ed145d720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b14a8b3-1a85-400b-b17c-a28ed145d720.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -6321,7 +6321,7 @@
         },
         {
             "id": "ef2b1908-680e-5cfe-a354-cfa260f74e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700508bd-d425-40bc-abbf-7da2c97e0a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700508bd-d425-40bc-abbf-7da2c97e0a74.jpg?1",
             "name": "Cold-Eyed Selkie",
             "text": "Islandwalk\nWhenever Cold-Eyed Selkie deals combat damage to a player, you may draw that many cards.",
             "colours": [
@@ -6358,7 +6358,7 @@
         },
         {
             "id": "9a241193-9dd9-5c15-813d-83f212077a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a62b9ea-18ea-4fbc-8e4d-0bacb4e4c47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a62b9ea-18ea-4fbc-8e4d-0bacb4e4c47e.jpg?1",
             "name": "Demigod of Revenge",
             "text": "Flying, haste\nWhen you cast Demigod of Revenge, return all cards named Demigod of Revenge from your graveyard to the battlefield.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "1d7a805b-cc70-5c7c-81dd-7a84caa72ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccd00e2-5aaf-45be-9360-70da3c573a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccd00e2-5aaf-45be-9360-70da3c573a28.jpg?1",
             "name": "Divinity of Pride",
             "text": "Flying, lifelink\nDivinity of Pride gets +4/+4 as long as you have 25 or more life.",
             "colours": [
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "a67cdc39-b259-54e8-be0f-ba7ac0033898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a4dd-a2cb-47a0-a1d5-da40d42013f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a4dd-a2cb-47a0-a1d5-da40d42013f3.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a 2/2 Kithkin Spirit.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a 4/4 Kithkin Spirit Warrior.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike.",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "4fa21274-628f-5d50-9dd1-ebe46e6c3606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df8bd5-cc06-4a95-a089-938fb7e4b650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df8bd5-cc06-4a95-a089-938fb7e4b650.jpg?1",
             "name": "Kitchen Finks",
             "text": "When Kitchen Finks enters the battlefield, you gain 2 life.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "326f27d7-ae9f-5e04-a791-f7da1a0ef6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079df56-60f9-46e5-8f2e-032e62b6a5f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079df56-60f9-46e5-8f2e-032e62b6a5f1.jpg?1",
             "name": "Manamorphose",
             "text": "Add two mana in any combination of colors to your mana pool.\nDraw a card.",
             "colours": [
@@ -6538,7 +6538,7 @@
         },
         {
             "id": "e08d3099-4023-561a-b670-af628f28234e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7ad50f-19e9-4dcd-97c2-49ab308b6030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7ad50f-19e9-4dcd-97c2-49ab308b6030.jpg?1",
             "name": "Murderous Redcap",
             "text": "When Murderous Redcap enters the battlefield, it deals damage equal to its power to target creature or player.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "9c517825-19f5-5962-92b6-5b1213415022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab4b6f-480c-40ac-a8cc-335a22b5acb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab4b6f-480c-40ac-a8cc-335a22b5acb9.jpg?1",
             "name": "Oona, Queen of the Fae",
             "text": "Flying\n{X}{UB}: Choose a color. Target opponent exiles the top X cards of his or her library. For each card of the chosen color exiled this way, put a 1/1 blue and black Faerie Rogue creature token with flying onto the battlefield.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "7f9bce74-3c9b-57a3-8563-c1fc9f86b6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accad809-77f5-4a0f-9ec6-a368c9f27d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accad809-77f5-4a0f-9ec6-a368c9f27d69.jpg?1",
             "name": "Plumeveil",
             "text": "Flash\nDefender, flying",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "66b8d585-717c-5947-8943-a5c5005d50ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b5512-2520-4fd5-87a3-f8a5c56769ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b5512-2520-4fd5-87a3-f8a5c56769ad.jpg?1",
             "name": "Worm Harvest",
             "text": "Put a 1/1 black and green Worm creature token onto the battlefield for each land card in your graveyard.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "4e9211e8-1b47-56b9-a12b-f06b690ef481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ef7938-7c68-4aeb-9403-4ab1af944a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ef7938-7c68-4aeb-9403-4ab1af944a81.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice \u00c6ther Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice \u00c6ther Spellbomb: Draw a card.",
             "colours": [],
@@ -6714,7 +6714,7 @@
         },
         {
             "id": "9eb3f203-aebf-5196-b6a7-03d335d64b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6774c646-76d4-4991-a7f3-b753ef200ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6774c646-76d4-4991-a7f3-b753ef200ce5.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on \u00c6ther Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on \u00c6ther Vial from your hand onto the battlefield.",
             "colours": [],
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "1eb85ade-b31d-52ba-825a-37b2eaa50c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c33a92-5621-40b4-a3a2-b67893edbc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c33a92-5621-40b4-a3a2-b67893edbc01.jpg?1",
             "name": "Arcbound Ravager",
             "text": "Sacrifice an artifact: Put a +1/+1 counter on Arcbound Ravager.\nModular 1 (This enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6773,7 +6773,7 @@
         },
         {
             "id": "98255b51-d87e-5f6c-a0f7-d5802f851eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db438720-5bfb-4cd9-b565-434839045f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db438720-5bfb-4cd9-b565-434839045f60.jpg?1",
             "name": "Arcbound Stinger",
             "text": "Flying\nModular 1 (This enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "768cf879-4e63-5237-9e68-ce479a67747b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb48b77-9d25-47b0-8d3b-bf52b8db23e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb48b77-9d25-47b0-8d3b-bf52b8db23e8.jpg?1",
             "name": "Arcbound Wanderer",
             "text": "Modular\u2014\nSunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "815ac2d3-5afd-5b0c-bbdc-a5244e9cf6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc2453-5a2b-4104-bf82-84f935de7b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc2453-5a2b-4104-bf82-84f935de7b99.jpg?1",
             "name": "Arcbound Worker",
             "text": "Modular 1 (This enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6866,7 +6866,7 @@
         },
         {
             "id": "d3e5e836-f896-548f-bfa5-38656ae0692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09dad6d-ec9a-40b4-b136-7a8b58a42a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09dad6d-ec9a-40b4-b136-7a8b58a42a3b.jpg?1",
             "name": "Bonesplitter",
             "text": "Equipped creature gets +2/+0.\nEquip {1}",
             "colours": [],
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "4af95686-b777-5bf3-bec3-9c3e2e7be572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e472d9d-4e00-4f01-9daa-559e630403cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e472d9d-4e00-4f01-9daa-559e630403cc.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "4f26781c-cbed-527b-832a-5b5d29a563ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822a3a49-48dc-462f-8eb1-613429b7dc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822a3a49-48dc-462f-8eb1-613429b7dc1b.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "88fff6a8-e92e-5a99-8014-502f542e4654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec35cbe-dd07-45c3-8fd4-802a20e6802b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec35cbe-dd07-45c3-8fd4-802a20e6802b.jpg?1",
             "name": "Epochrasite",
             "text": "Epochrasite enters the battlefield with three +1/+1 counters on it if you didn't cast it from your hand.\nWhen Epochrasite dies, exile it with three time counters on it and it gains suspend. (At the beginning of your upkeep, remove a time counter. When the last is removed, cast this card without paying its mana cost. It has haste.)",
             "colours": [],
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "d310e9a1-9f4a-5d25-a3a3-7a769b5ae71d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835b057-6652-48b0-82d4-8d932d716e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835b057-6652-48b0-82d4-8d932d716e4b.jpg?1",
             "name": "Etched Oracle",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\n{1}, Remove four +1/+1 counters from Etched Oracle: Target player draws three cards.",
             "colours": [],
@@ -7014,7 +7014,7 @@
         },
         {
             "id": "4ff6f3d2-5f6f-525d-a729-7f8865b83f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d89d6b-9218-439a-a976-25ea02848d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d89d6b-9218-439a-a976-25ea02848d7f.jpg?1",
             "name": "Frogmite",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "12f0a42a-f86f-506c-9bc0-5208e27b8c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035c3112-222d-4362-9109-c8b872a59a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035c3112-222d-4362-9109-c8b872a59a2b.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -7073,7 +7073,7 @@
         },
         {
             "id": "224d6ae8-8e75-5c0e-9bee-7d2773849c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563350ab-1a32-4304-921f-1fd80cb3a630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563350ab-1a32-4304-921f-1fd80cb3a630.jpg?1",
             "name": "Myr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "3da99f8f-1d5a-5aae-b864-246ef733593f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8972a7c-ff64-4158-8277-2bd90e8db48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8972a7c-ff64-4158-8277-2bd90e8db48d.jpg?1",
             "name": "Myr Retriever",
             "text": "When Myr Retriever dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "166b42e0-92e5-5e48-b0d5-37980fb65307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cd6bcc-ca47-47cc-9fe4-c29e9c176485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cd6bcc-ca47-47cc-9fe4-c29e9c176485.jpg?1",
             "name": "Paradise Mantle",
             "text": "Equipped creature has \"{T}: Add one mana of any color to your mana pool.\"\nEquip {1}",
             "colours": [],
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "efa0f967-6bf6-5a44-b84a-b390a1be4a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a10d1-ca71-4cf3-9072-ee3a69c4885c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a10d1-ca71-4cf3-9072-ee3a69c4885c.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "{R}, Sacrifice Pyrite Spellbomb: Pyrite Spellbomb deals 2 damage to target creature or player.\n{1}, Sacrifice Pyrite Spellbomb: Draw a card.",
             "colours": [],
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "4e2836f0-c029-5788-9f34-5e9fc5b4065d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c285b3a0-a27c-4416-a1b5-90219a5c7800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c285b3a0-a27c-4416-a1b5-90219a5c7800.jpg?1",
             "name": "Relic of Progenitus",
             "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
             "colours": [],
@@ -7223,7 +7223,7 @@
         },
         {
             "id": "f6fc557a-0ba2-5b39-b9cb-cb1838d0b4a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54f50fe-d4c0-49ba-9063-853c76ae3e19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54f50fe-d4c0-49ba-9063-853c76ae3e19.jpg?1",
             "name": "Runed Stalactite",
             "text": "Equipped creature gets +1/+1 and is every creature type.\nEquip {2}",
             "colours": [],
@@ -7253,7 +7253,7 @@
         },
         {
             "id": "d6a81240-9513-5710-8698-acc491770bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61229b83-2a77-43c7-bc02-5b7a54ba4a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61229b83-2a77-43c7-bc02-5b7a54ba4a87.jpg?1",
             "name": "Skyreach Manta",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\nFlying",
             "colours": [],
@@ -7284,7 +7284,7 @@
         },
         {
             "id": "d1a7852b-37b9-5251-8eb2-9054d4395023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddc025-4396-4d88-8d72-6c06ea7125f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddc025-4396-4d88-8d72-6c06ea7125f1.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to target creature or player and you draw a card.\nEquip {2}",
             "colours": [],
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "c99f51a6-26ff-5225-9d4f-19e3bf7d8c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b662709a-d0b3-4c85-b849-6aedebb550eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b662709a-d0b3-4c85-b849-6aedebb550eb.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "b20fe602-b271-51fc-9095-b4647ecc9f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3257833-b237-49ef-856a-3c1d1c752cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3257833-b237-49ef-856a-3c1d1c752cf8.jpg?1",
             "name": "Vedalken Shackles",
             "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as Vedalken Shackles remains tapped.",
             "colours": [],
@@ -7372,7 +7372,7 @@
         },
         {
             "id": "1a6659e9-3070-508a-a16f-c7c4bda5f9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2c9306-b065-4813-8817-ae46a7725b5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2c9306-b065-4813-8817-ae46a7725b5e.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}, {T}: Put target artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "638b73bb-c037-5328-9d42-888d70567d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e0482-d1e6-420f-9a8a-a675345fc09b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e0482-d1e6-420f-9a8a-a675345fc09b.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "165dbc21-3b94-551c-9c67-404d8609dc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459042ef-0d5b-480f-9b8a-520e13ae9217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459042ef-0d5b-480f-9b8a-520e13ae9217.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7460,7 +7460,7 @@
         },
         {
             "id": "d3d1a17d-a243-56cd-a850-504c797a27a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29307e6-f323-4b86-b9ce-4c2d6f995743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29307e6-f323-4b86-b9ce-4c2d6f995743.jpg?1",
             "name": "Dakmor Salvage",
             "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [],
@@ -7490,7 +7490,7 @@
         },
         {
             "id": "d2a10e04-22b6-5771-8280-95040a26c948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8ea9d-3252-4f6b-9b01-edb2a49e98b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8ea9d-3252-4f6b-9b01-edb2a49e98b9.jpg?1",
             "name": "Glimmervoid",
             "text": "At the beginning of the end step, if you control no artifacts, sacrifice Glimmervoid.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7518,7 +7518,7 @@
         },
         {
             "id": "8bdad128-00f1-52cc-a275-a429c523fb72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0af384a-6421-43f6-a6ed-166022912a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0af384a-6421-43f6-a6ed-166022912a36.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7546,7 +7546,7 @@
         },
         {
             "id": "92b08b42-8335-5c35-93a1-7e50aa4b73b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208067af-9dd2-4509-96cb-f3ae216e3551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208067af-9dd2-4509-96cb-f3ae216e3551.jpg?1",
             "name": "Vivid Crag",
             "text": "Vivid Crag enters the battlefield tapped with two charge counters on it.\n{T}: Add {R} to your mana pool.\n{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7576,7 +7576,7 @@
         },
         {
             "id": "ec60d494-a0da-5c3b-ab2e-937f7a69b5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5a9520-484f-4f6c-a302-af6764d6d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5a9520-484f-4f6c-a302-af6764d6d842.jpg?1",
             "name": "Vivid Creek",
             "text": "Vivid Creek enters the battlefield tapped with two charge counters on it.\n{T}: Add {U} to your mana pool.\n{T}, Remove a charge counter from Vivid Creek: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7606,7 +7606,7 @@
         },
         {
             "id": "ff1baa42-6024-5702-ac99-f3ffdea8269c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbb669a-5bcb-4189-b0ad-73ff900e102f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbb669a-5bcb-4189-b0ad-73ff900e102f.jpg?1",
             "name": "Vivid Grove",
             "text": "Vivid Grove enters the battlefield tapped with two charge counters on it.\n{T}: Add {G} to your mana pool.\n{T}, Remove a charge counter from Vivid Grove: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "719caa1a-cfb2-5e12-8a97-3996d522197f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8d99b-ce80-4cf2-a55c-1257d6b1d799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8d99b-ce80-4cf2-a55c-1257d6b1d799.jpg?1",
             "name": "Vivid Marsh",
             "text": "Vivid Marsh enters the battlefield tapped with two charge counters on it.\n{T}: Add {B} to your mana pool.\n{T}, Remove a charge counter from Vivid Marsh: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "e3ebbc63-f7ad-53a0-b129-2425f5cef8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f0d54-07b9-4668-8eed-4062b3b942da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f0d54-07b9-4668-8eed-4062b3b942da.jpg?1",
             "name": "Vivid Meadow",
             "text": "Vivid Meadow enters the battlefield tapped with two charge counters on it.\n{T}: Add {W} to your mana pool.\n{T}, Remove a charge counter from Vivid Meadow: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "424eae52-6b3b-59f9-8a03-9a682fe7d85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a41d0d-aaf5-4cb4-a9db-07992c57e436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a41d0d-aaf5-4cb4-a9db-07992c57e436.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -7731,7 +7731,7 @@
         },
         {
             "id": "c1353bba-95b5-5c2d-a138-6f9175747736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28adced8-4f86-4dc7-bd21-e20ba403219c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28adced8-4f86-4dc7-bd21-e20ba403219c.jpg?1",
             "name": "Kithkin Soldier",
             "text": "",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "e773321d-42e1-5116-8379-148e26427153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3317ef0-5104-41de-9e7a-2629ad658ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3317ef0-5104-41de-9e7a-2629ad658ae7.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "1a4acb2d-e5ef-57b0-9653-9c48f5458b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24ae780-d226-4deb-9a4a-91262763d0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24ae780-d226-4deb-9a4a-91262763d0cd.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "f1a551ec-bdba-5acc-a5ac-60b5b5f283e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ed94-564b-415c-b590-d89c972384a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ed94-564b-415c-b590-d89c972384a1.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -7868,7 +7868,7 @@
         },
         {
             "id": "377beef1-7cf9-5725-80e4-13f5a3502631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bd708d-dc84-44d3-a563-536ade028bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bd708d-dc84-44d3-a563-536ade028bd0.jpg?1",
             "name": "Goblin Rogue",
             "text": "",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "2b7c9afc-3e4e-5ae4-b148-4e5e9dbd471b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d833298-a270-4b89-987c-5b6432bbc311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d833298-a270-4b89-987c-5b6432bbc311.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -7937,7 +7937,7 @@
         },
         {
             "id": "60575e5a-881b-5fe6-aa4a-0ae0d8ccbd02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738dce42-9852-4ced-8e9e-4639fad8b79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738dce42-9852-4ced-8e9e-4639fad8b79f.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7971,7 +7971,7 @@
         },
         {
             "id": "ea0db304-776f-556c-a0a5-eedcf6c6ad5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529930fe-a1af-42fb-85a4-4999e787b25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529930fe-a1af-42fb-85a4-4999e787b25b.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "32aa33fc-99b2-54ad-9990-fa9b874f2fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ac66f-4b21-4acf-b51b-41c9d241d971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ac66f-4b21-4acf-b51b-41c9d241d971.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8039,7 +8039,7 @@
         },
         {
             "id": "25b6cf61-2957-59fc-b0bf-e268799eb338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9c63b7-ec72-443f-9216-5cb7bd07e940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9c63b7-ec72-443f-9216-5cb7bd07e940.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8073,7 +8073,7 @@
         },
         {
             "id": "68d70380-b934-5999-9ba5-acd59aadf216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15854c49-14fd-4947-8444-c5ab614cb416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15854c49-14fd-4947-8444-c5ab614cb416.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "5cf2b39f-2017-5f35-84c8-5ec778289e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75c1ada-2a49-49e8-800d-f11d08263dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75c1ada-2a49-49e8-800d-f11d08263dde.jpg?1",
             "name": "Treefolk Shaman",
             "text": "",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "6b5a3b83-2057-5f85-9676-8bb0633405e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb3b8a-f9d3-4ce1-b171-ba7b0c3f4830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb3b8a-f9d3-4ce1-b171-ba7b0c3f4830.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "92a66c18-cf1c-5a7f-b0cb-5b6f049e653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b9eb1-ccdc-4540-9d53-7853539af189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b9eb1-ccdc-4540-9d53-7853539af189.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -8215,7 +8215,7 @@
         },
         {
             "id": "2815b341-9e87-5933-b5f0-d8a2f238d311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014c0557-11b8-49da-8486-0dd14b919338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014c0557-11b8-49da-8486-0dd14b919338.jpg?1",
             "name": "Elspeth, Knight-Errant Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MMQ.json
+++ b/Assets/Resources/Sets/MMQ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f1c68663-178b-5cd5-910c-21f95eb3f87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa2ecf9-b53c-4f1d-9028-ca3820d043cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa2ecf9-b53c-4f1d-9028-ca3820d043cb.jpg?1",
             "name": "Afterlife",
             "text": "Destroy target creature. It can't be regenerated. Its controller puts a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "a0d3faf1-0b41-5799-a658-73aea6ed5a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf393a3-831e-4d3a-8404-ee83f60970aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf393a3-831e-4d3a-8404-ee83f60970aa.jpg?1",
             "name": "Alabaster Wall",
             "text": "(Walls can't attack.)\noc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "ad09c304-d8f2-5f2e-a635-f232f83edf48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4402a-f263-4f82-b4c0-cf0aa58dc946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4402a-f263-4f82-b4c0-cf0aa58dc946.jpg?1",
             "name": "Armistice",
             "text": "o3o\nWoo\nW You draw a card and target opponent gains 3 life.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "a9a5fa0f-6fba-5821-a626-e1cf68a49f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b083fd8-6422-4cd3-a27d-41b6d88598c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b083fd8-6422-4cd3-a27d-41b6d88598c2.jpg?1",
             "name": "Arrest",
             "text": "Enchanted creature can't attack or block, and its activated abilities can't be played.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "b23bd8f5-11f8-5a21-893f-bd062a540e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d51d84-23d2-41ff-ab68-a633beddba06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d51d84-23d2-41ff-ab68-a633beddba06.jpg?1",
             "name": "Ballista Squad",
             "text": "o\nXo\nW, oc\nT: Ballista Squad deals X damage to target attacking or blocking creature.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "1b54738f-d419-5735-9729-24c9fb95afb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082e6ee3-cc1f-46c7-9d82-56751478b3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082e6ee3-cc1f-46c7-9d82-56751478b3cf.jpg?1",
             "name": "Charm Peddler",
             "text": "o\nW, oc\nT, Discard a card from your hand: The next time a source of your choice would deal damage to target creature this turn, prevent that damage.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "f28518c2-aca8-57e5-a9c5-0c9e68f4e2d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d36960-3c78-4032-9325-8002b2a48503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d36960-3c78-4032-9325-8002b2a48503.jpg?1",
             "name": "Charmed Griffin",
             "text": "Flying\nWhen Charmed Griffin comes into play, each other player may put an artifact or enchantment card into play from his or her hand.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "6cedfe89-0c02-5350-9d5a-731bcc18d661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c9d49d-61eb-4f33-b06b-03bdd990efd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c9d49d-61eb-4f33-b06b-03bdd990efd0.jpg?1",
             "name": "Cho-Arrim Alchemist",
             "text": "o1o\nWo\nW, oc\nT, Discard a card from your hand: The next time a source of your choice would deal damage to you this turn, prevent that damage and gain that much life.",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "051d56e9-d7d3-53fd-95ac-d93cfd24c10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg?1",
             "name": "Cho-Arrim Bruiser",
             "text": "Whenever Cho-Arrim Bruiser attacks, you may tap up to two target creatures.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "798fdcfa-a539-55ed-adb1-f661c8a68e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427a3a1-24e1-4697-b5eb-1c0a24f89e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427a3a1-24e1-4697-b5eb-1c0a24f89e75.jpg?1",
             "name": "Cho-Arrim Legate",
             "text": "Protection from black\nIf an opponent controls a swamp and you control a plains, you may play Cho-Arrim Legate without paying its mana cost.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "e35ff5d9-96da-5cc2-b16f-fcada63d68c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc51393-de63-4ce3-ab02-c695e4448018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc51393-de63-4ce3-ab02-c695e4448018.jpg?1",
             "name": "Cho-Manno, Revolutionary",
             "text": "Prevent all damage that would be dealt to Cho-Manno, Revolutionary.",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "c82b4e9d-b42b-5cd9-bc07-856b1be0d7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9f33c6-5294-4584-854d-c8c0f847aba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9f33c6-5294-4584-854d-c8c0f847aba8.jpg?1",
             "name": "Cho-Manno's Blessing",
             "text": "You may play Cho-Manno's Blessing any time you could play an instant.\nAs Cho-Manno's Blessing comes into play, choose a color.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Cho-Manno's Blessing.",
             "colours": [
@@ -416,7 +416,7 @@
         },
         {
             "id": "c0440638-8d8e-5a9f-bb6b-26e4bb8577d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae4c25f-2005-4ac0-a5f0-2fc250520995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae4c25f-2005-4ac0-a5f0-2fc250520995.jpg?1",
             "name": "Common Cause",
             "text": "Nonartifact creatures get +2/+2 as long as they all share a color.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "e3c7077f-6f6e-58be-96d2-c29e04ade09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4f3c1d-d25e-4263-ab2b-19534c852678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4f3c1d-d25e-4263-ab2b-19534c852678.jpg?1",
             "name": "Cornered Market",
             "text": "Players can't play spells or nonbasic lands with the same name as a card in play.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "91fef90f-0e95-5a57-a1c7-55c52f52dbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7009fd8-1d80-41bb-a1b0-fea9c909c63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7009fd8-1d80-41bb-a1b0-fea9c909c63d.jpg?1",
             "name": "Crackdown",
             "text": "Nonwhite creatures with power 3 or greater don't untap during their controllers' untap steps.",
             "colours": [
@@ -512,7 +512,7 @@
         },
         {
             "id": "d79b0ad8-85cd-562d-834a-0f8d40d99531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744c2177-3140-48a1-95a4-2f0a27ca5b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744c2177-3140-48a1-95a4-2f0a27ca5b2f.jpg?1",
             "name": "Crossbow Infantry",
             "text": "oc\nT: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "f17a0ae5-41dc-56e6-97c3-e2608287b539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca7aeb-09db-4409-9ba2-c5c5500ad72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca7aeb-09db-4409-9ba2-c5c5500ad72f.jpg?1",
             "name": "Devout Witness",
             "text": "o1o\nW, oc\nT, Discard a card from your hand: Destroy target artifact or enchantment.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "57d16e20-f99e-5648-8a06-62044b60ff10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366407d8-3ed9-4809-b9bb-388ebb9ea815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366407d8-3ed9-4809-b9bb-388ebb9ea815.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "80d15177-2df1-5e8c-862f-830a71f81dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690daa19-1842-4605-9bda-bf67e4ede3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690daa19-1842-4605-9bda-bf67e4ede3c4.jpg?1",
             "name": "Fountain Watch",
             "text": "Artifacts and enchantments you control can't be the target of spells or abilities.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "b4bb4b8d-da00-59f5-b71a-451434816b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070ea4a-c417-405f-b788-78fb7ca2eaa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070ea4a-c417-405f-b788-78fb7ca2eaa5.jpg?1",
             "name": "Fresh Volunteers",
             "text": "",
             "colours": [
@@ -685,7 +685,7 @@
         },
         {
             "id": "fb12f047-246b-5910-b47b-d471a87aef52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70147617-10e0-413d-be0a-a888b9cb6b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70147617-10e0-413d-be0a-a888b9cb6b97.jpg?1",
             "name": "Honor the Fallen",
             "text": "Remove all creature cards in all graveyards from the game. You gain 1 life for each card removed this way.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "af0536fd-aa89-58df-890b-8b48f27bbe79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676a2506-17f8-4b8e-be0c-eacc0fe972f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676a2506-17f8-4b8e-be0c-eacc0fe972f6.jpg?1",
             "name": "Ignoble Soldier",
             "text": "Whenever Ignoble Soldier becomes blocked, prevent all combat damage that would be dealt by it this turn.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "59300584-dcaf-5d60-b292-4e02a3692269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ece8504-389a-43e3-b178-7067722c4b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ece8504-389a-43e3-b178-7067722c4b75.jpg?1",
             "name": "Inviolability",
             "text": "Prevent all damage that would be dealt to enchanted creature.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "5aadd930-34ee-5c44-a7b5-30e913cd27e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ea3762-a419-412c-b2bd-0a40902d8d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ea3762-a419-412c-b2bd-0a40902d8d51.jpg?1",
             "name": "Ivory Mask",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "d44987a0-9a72-58f8-8235-57be5c203844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg?1",
             "name": "Jhovall Queen",
             "text": "Attacking doesn't cause Jhovall Queen to tap.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "f96a6789-9ce6-5012-be0f-9593b2f5ad74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1f7c51-0011-4ea5-b123-3c26293f5dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1f7c51-0011-4ea5-b123-3c26293f5dab.jpg?1",
             "name": "Jhovall Rider",
             "text": "Trample",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "a2dacd18-7aae-5d08-86be-d6139908d342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b540da2-f8c6-48d6-af6d-db78958f0a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b540da2-f8c6-48d6-af6d-db78958f0a17.jpg?1",
             "name": "Last Breath",
             "text": "Remove target creature with power 2 or less from the game. Its controller gains 4 life.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "7ccd961a-bd38-55c0-8cfa-9485c3983dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50b5f5-8dac-4785-b1af-a0bd64ce7a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50b5f5-8dac-4785-b1af-a0bd64ce7a92.jpg?1",
             "name": "Moment of Silence",
             "text": "Target player skips his or her combat phase this turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "f23bda86-82ee-5d8b-b412-7eb79b6dc390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eba9595-6789-4d7a-9e46-8d1f75993b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eba9595-6789-4d7a-9e46-8d1f75993b21.jpg?1",
             "name": "Moonlit Wake",
             "text": "Whenever a creature is put into a graveyard from play, you gain 1 life.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "e7702c38-b0fd-55f9-a510-fe63397e2a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3048ec-bcbf-4a69-b56f-83bbe82b68e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3048ec-bcbf-4a69-b56f-83bbe82b68e5.jpg?1",
             "name": "Muzzle",
             "text": "Prevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "756c3036-044f-5cdb-bda7-6a2d529111ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0968401d-522f-4def-92a1-d504471ac54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0968401d-522f-4def-92a1-d504471ac54e.jpg?1",
             "name": "Nightwind Glider",
             "text": "Flying, protection from black",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "860f70b6-8faf-5d01-8cb9-2fea2e465d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ff149-8516-456e-af8a-3dea78715acb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ff149-8516-456e-af8a-3dea78715acb.jpg?1",
             "name": "Noble Purpose",
             "text": "Whenever a creature you control deals combat damage, you gain that much life.",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "9cc1e02e-d8d3-5b16-90a4-05da8641e043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754ae359-363b-456a-bbca-52fbfbaa86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754ae359-363b-456a-bbca-52fbfbaa86b8.jpg?1",
             "name": "Orim's Cure",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying the mana cost of Orim's Cure.\nPrevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "ec803ebf-1403-5a13-9581-5dae806a340b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc20c1f0-9883-484c-88d8-1cab08d0b210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc20c1f0-9883-484c-88d8-1cab08d0b210.jpg?1",
             "name": "Pious Warrior",
             "text": "Whenever Pious Warrior is dealt combat damage, you gain that much life.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "f964f5f5-8100-5398-bd4a-eb153ab0d893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d2e2a-c608-4787-bbd9-e1871f681b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d2e2a-c608-4787-bbd9-e1871f681b58.jpg?1",
             "name": "Ramosian Captain",
             "text": "First strike\no5, oc\nT: Search your library for a Rebel card with converted mana cost 4 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "d60c0466-d164-5a36-88ef-f052e7e609b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867f5d82-71c2-455f-ab16-5a32bba46986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867f5d82-71c2-455f-ab16-5a32bba46986.jpg?1",
             "name": "Ramosian Commander",
             "text": "o6, oc\nT: Search your library for a Rebel card with converted mana cost 5 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "cde1cc99-8115-5868-867d-387a8bc86c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debe840a-ebc9-43c4-9bf7-7eb292b65bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debe840a-ebc9-43c4-9bf7-7eb292b65bf9.jpg?1",
             "name": "Ramosian Lieutenant",
             "text": "o4, oc\nT: Search your library for a Rebel card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "7ee925dd-d36b-50be-b7fa-f4e683c26e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc0ff04-43e7-4a0d-b7e2-8bab72cc6cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc0ff04-43e7-4a0d-b7e2-8bab72cc6cc0.jpg?1",
             "name": "Ramosian Rally",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying Ramosian Rally's mana cost.\nCreatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "a5f4f18a-7f24-5dd0-a558-2fee6d0ab76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2b036d-5721-4a6e-bf43-69148b90da10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2b036d-5721-4a6e-bf43-69148b90da10.jpg?1",
             "name": "Ramosian Sergeant",
             "text": "o3, oc\nT: Search your library for a Rebel card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "cf240ae5-4410-5bd5-a13d-f98fbb17e015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg?1",
             "name": "Ramosian Sky Marshal",
             "text": "Flying\no7, oc\nT: Search your library for a Rebel card with converted mana cost 6 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1360,7 +1360,7 @@
         },
         {
             "id": "53ef4efa-ed8d-5009-aee7-fab32310eb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113b8366-e6d0-423e-af4b-52c1e08ed446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113b8366-e6d0-423e-af4b-52c1e08ed446.jpg?1",
             "name": "Rappelling Scouts",
             "text": "Flying\no2oo\nW Rappelling Scouts gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "f4198239-6754-5db7-9229-4cc9e264151e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2bfb9-cc4a-4d33-99f9-17db4d9fc718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2bfb9-cc4a-4d33-99f9-17db4d9fc718.jpg?1",
             "name": "Renounce",
             "text": "Sacrifice any number of permanents. You gain 2 life for each one sacrificed this way.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "9141fc5f-48b8-523e-a027-fe7dd91b23fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0793175-e56b-4ff8-9e22-3a96a698068c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0793175-e56b-4ff8-9e22-3a96a698068c.jpg?1",
             "name": "Revered Elder",
             "text": "o1: Prevent the next 1 damage that would be dealt to Revered Elder this turn.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "430f9307-cd5e-5567-a118-35c4ae74a0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48364e19-a3ea-4980-925f-7918e57315f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48364e19-a3ea-4980-925f-7918e57315f1.jpg?1",
             "name": "Reverent Mantra",
             "text": "You may remove a white card in your hand from the game instead of paying Reverent Mantra's mana cost.\nAll creatures gain protection from the color of your choice until end of turn.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "c93b2785-10c8-54a8-8729-0e903269b0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d3bcb4-6cbd-4144-a95d-f61e68c10296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d3bcb4-6cbd-4144-a95d-f61e68c10296.jpg?1",
             "name": "Righteous Aura",
             "text": "o\nW, Pay 2 life: The next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "41cfe630-38f0-56c6-b2ce-b1344d0cf5e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb6335-cfd8-438c-b936-09b850d61b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb6335-cfd8-438c-b936-09b850d61b28.jpg?1",
             "name": "Righteous Indignation",
             "text": "Whenever a creature blocks a black or red creature, the blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "0433f382-d5dc-52de-aad0-f00cfff71e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b89d34b-1a67-4f5c-a731-54b56c5233ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b89d34b-1a67-4f5c-a731-54b56c5233ff.jpg?1",
             "name": "Security Detail",
             "text": "o\nWoo\nW Put a 1/1 white Soldier creature token into play. Play this ability only if you control no creatures and only once each turn.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "6fd6d724-4647-52a6-a12d-9fb0f0a59281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b8f4be-9f4d-4373-8141-a03518ecd38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b8f4be-9f4d-4373-8141-a03518ecd38a.jpg?1",
             "name": "Soothing Balm",
             "text": "Target player gains 5 life.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "c90a4659-c536-5bbf-9036-29ff65556180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8521ae08-eb46-45ff-8fc4-62d8b07cfac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8521ae08-eb46-45ff-8fc4-62d8b07cfac2.jpg?1",
             "name": "Spiritual Focus",
             "text": "Whenever a spell or ability an opponent controls causes you to discard a card, you gain 2 life and you may draw a card.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "d3e6c48a-861a-5282-8a7f-efe8d89c824b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6381774b-fb91-46cc-9bf6-6eeb4d67a165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6381774b-fb91-46cc-9bf6-6eeb4d67a165.jpg?1",
             "name": "Steadfast Guard",
             "text": "Attacking doesn't cause Steadfast Guard to tap.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "0ca19244-8541-5832-8f16-c9b7bca32624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675378bb-7dc1-4bc8-b026-27e6e8e72e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675378bb-7dc1-4bc8-b026-27e6e8e72e18.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\noo\nW The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "1a36b8c1-01e9-5913-953f-ac0316853c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a58c5b-28c2-4261-992c-2ecadb721880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a58c5b-28c2-4261-992c-2ecadb721880.jpg?1",
             "name": "Task Force",
             "text": "Whenever Task Force becomes the target of a spell or ability, it gets +0/+3 until end of turn.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "fd6d2580-e843-549d-966f-a9c9b5cfd371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd909c26-930d-4af0-b19a-c899847338b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd909c26-930d-4af0-b19a-c899847338b4.jpg?1",
             "name": "Thermal Glider",
             "text": "Flying, protection from red",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "00c6f15f-f4ae-5b10-82d2-611b94f29cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bbd9d-3549-4352-9635-d772aab28503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bbd9d-3549-4352-9635-d772aab28503.jpg?1",
             "name": "Tonic Peddler",
             "text": "o\nW, oc\nT, Discard a card from your hand: Target player gains 3 life.",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "22378f33-4956-528e-8fdc-2b065f72a292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba97681-1d1f-4ab6-a21b-fbbbe63a1c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba97681-1d1f-4ab6-a21b-fbbbe63a1c74.jpg?1",
             "name": "Trap Runner",
             "text": "oc\nT: Target attacking unblocked creature becomes blocked. (This ability works on unblockable creatures.)",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "c3246af7-7c59-57d5-8f13-17995c4e72ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b101b5e-d478-4686-b3cf-bdc545f089e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b101b5e-d478-4686-b3cf-bdc545f089e5.jpg?1",
             "name": "Wave of Reckoning",
             "text": "Each creature deals to itself damage equal to its power.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "48a3d89e-65d9-50ef-a28c-89a063090145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0d8834-109e-4235-a145-75edc43da0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0d8834-109e-4235-a145-75edc43da0ec.jpg?1",
             "name": "Wishmonger",
             "text": "o2: Target creature gains protection from the color of its controller's choice until end of turn. Any player may play this ability.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "679720fe-21ad-5cdc-a30e-3c1594c04b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg?1",
             "name": "Aerial Caravan",
             "text": "Flying\no1o\nUo\nU: Remove the top card of your library from the game. Until end of turn, you may play that card as though it were in your hand. (Reveal the card as you remove it from the game.)",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "6d2bc0d8-6553-5fd3-96cd-d0935bb3ab87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34963e6-850e-4ce4-b04f-5e623ce5b73f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34963e6-850e-4ce4-b04f-5e623ce5b73f.jpg?1",
             "name": "Balloon Peddler",
             "text": "o\nU, oc\nT, Discard a card from your hand: Target creature gains flying until end of turn.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "b08249d9-f947-5733-8b42-e7ecbe6d57be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e483df-b58a-401e-85bc-0afda4bf7cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e483df-b58a-401e-85bc-0afda4bf7cac.jpg?1",
             "name": "Blockade Runner",
             "text": "oo\nU Blockade Runner is unblockable this turn.",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "2666c1d9-caa9-57b5-8d8d-86dc7d09bff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff71d13-c4b7-4125-ab10-db4abbb7a074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff71d13-c4b7-4125-ab10-db4abbb7a074.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -2065,7 +2065,7 @@
         },
         {
             "id": "f65753cb-0578-5a4d-a230-ce4390a939d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc0ea8a-62f6-49e8-8eec-9748870bc596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc0ea8a-62f6-49e8-8eec-9748870bc596.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card into play under your control. That player then shuffles his or her library.",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "e9e7711b-f5a2-5da3-aa47-fe0d534bd112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b208dad2-a412-45fd-b19a-d370426ef5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b208dad2-a412-45fd-b19a-d370426ef5b8.jpg?1",
             "name": "Buoyancy",
             "text": "You may play Buoyancy any time you could play an instant.\nEnchanted creature has flying.",
             "colours": [
@@ -2131,7 +2131,7 @@
         },
         {
             "id": "c311ffd9-892d-5922-98a8-3200a621e37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860c613d-d031-4c2a-922b-39f4eec04e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860c613d-d031-4c2a-922b-39f4eec04e18.jpg?1",
             "name": "Chambered Nautilus",
             "text": "Whenever Chambered Nautilus becomes blocked, you may draw a card.",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "25d40aee-d74e-53e6-b8ff-166e46f76363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05972ea2-b0bc-40fd-bce4-07eebdb150d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05972ea2-b0bc-40fd-bce4-07eebdb150d5.jpg?1",
             "name": "Chameleon Spirit",
             "text": "As Chameleon Spirit comes into play, choose a color.\nChameleon Spirit's power and toughness are each equal to the number of permanents of the chosen color your opponents control.",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "c835ff99-7928-573a-b929-431c09a4dd36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63565b03-28e9-4534-b085-d5803e2623bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63565b03-28e9-4534-b085-d5803e2623bb.jpg?1",
             "name": "Charisma",
             "text": "Whenever enchanted creature deals damage to a creature, you control that creature as long as Charisma remains in play.",
             "colours": [
@@ -2235,7 +2235,7 @@
         },
         {
             "id": "d3c5da8f-496f-5031-8631-181716955f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14352c-ac8c-45b5-b930-63822408ba3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14352c-ac8c-45b5-b930-63822408ba3d.jpg?1",
             "name": "Cloud Sprite",
             "text": "Flying\nCloud Sprite may block only creatures with flying.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "d7849d12-af96-5f42-b550-ad02f63aa511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179d1f76-6f4c-4a77-815a-aae7a933c9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179d1f76-6f4c-4a77-815a-aae7a933c9ad.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "760c431b-d372-5165-8b41-f320286e0afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd03c80-7812-4704-9e07-9cf73b49c01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd03c80-7812-4704-9e07-9cf73b49c01f.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "65839450-3fb4-530a-90ca-5dda4d95b66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e46d3d-7c7f-487f-8cc6-078b17c113a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e46d3d-7c7f-487f-8cc6-078b17c113a0.jpg?1",
             "name": "Cowardice",
             "text": "Whenever a creature becomes the target of a spell or ability, return that creature to its owner's hand.",
             "colours": [
@@ -2365,7 +2365,7 @@
         },
         {
             "id": "6580d97a-15f6-501a-9541-d4821dac7c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067d8c46-c334-4b00-af06-2e28b6086c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067d8c46-c334-4b00-af06-2e28b6086c58.jpg?1",
             "name": "Customs Depot",
             "text": "Whenever you play a creature spell, you may pay o1. If you do, draw a card, then discard a card from your hand.",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "739d3f3c-c779-556c-849b-e8df9415ad11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438e15f7-59bb-4047-af1f-ef92cc1866b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438e15f7-59bb-4047-af1f-ef92cc1866b8.jpg?1",
             "name": "Darting Merfolk",
             "text": "oo\nU Return Darting Merfolk to its owner's hand.",
             "colours": [
@@ -2431,7 +2431,7 @@
         },
         {
             "id": "f0407b45-2b72-5ba1-aee3-4ebfa7fd994a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9e4043-e7a6-4c68-aa03-ef2f88e46451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9e4043-e7a6-4c68-aa03-ef2f88e46451.jpg?1",
             "name": "Dehydration",
             "text": "Enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2465,7 +2465,7 @@
         },
         {
             "id": "a47dee60-889d-59fc-bb0b-4d4c8b2b799b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9356bdbb-d647-4f51-a7a3-18ecea898a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9356bdbb-d647-4f51-a7a3-18ecea898a7f.jpg?1",
             "name": "Diplomatic Escort",
             "text": "o\nU, oc\nT, Discard a card from your hand: Counter target spell or ability that targets a creature.",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "ca9491dc-1a42-5c70-971d-e1ec2031f85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1e610e-a4a2-460b-8e4c-13674badbce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1e610e-a4a2-460b-8e4c-13674badbce3.jpg?1",
             "name": "Diplomatic Immunity",
             "text": "Enchanted creature can't be the target of spells or abilities.\nDiplomatic Immunity can't be the target of spells or abilities.",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "3fa2d2f6-ec79-52a5-a376-20cbdd9d0b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee32f9-6120-4f15-a692-89a4cd8167c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee32f9-6120-4f15-a692-89a4cd8167c6.jpg?1",
             "name": "Drake Hatchling",
             "text": "Flying\noo\nU Drake Hatchling gets +1/+0 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "7d8cc2d8-437b-58c7-a731-dfc6228bd20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fca3c65-f20e-4978-bfbb-ee7f9e1d829f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fca3c65-f20e-4978-bfbb-ee7f9e1d829f.jpg?1",
             "name": "Embargo",
             "text": "Nonland permanents don't untap during their controllers' untap steps.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "9543ac13-9270-52d3-b201-fa9b320f7e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b22a0-d5cc-4dbb-aec3-763b8efaee7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b22a0-d5cc-4dbb-aec3-763b8efaee7e.jpg?1",
             "name": "Energy Flux",
             "text": "All artifacts gain \"At the beginning of your upkeep, sacrifice this artifact unless you pay o2.\"",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "16a5227e-419e-587f-a017-847db186ab24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99243564-9dbd-420c-922d-c17854c99d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99243564-9dbd-420c-922d-c17854c99d2a.jpg?1",
             "name": "Extravagant Spirit",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Extravagant Spirit unless you pay o1 for each card in your hand.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "722749fe-3809-5009-8769-c66b9ba003cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48872422-895f-45f0-ba2a-7cd307285c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48872422-895f-45f0-ba2a-7cd307285c7d.jpg?1",
             "name": "False Demise",
             "text": "When enchanted creature is put into a graveyard, return that creature to play under your control.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "60b29eb7-8868-5546-8f5c-fc53241a4256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708593e6-787b-4f76-a86c-1d52857493ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708593e6-787b-4f76-a86c-1d52857493ea.jpg?1",
             "name": "Glowing Anemone",
             "text": "When Glowing Anemone comes into play, you may return target land to its owner's hand.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "2abd9f6e-0219-59e9-8fb6-737a88083650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e755bbef-bf34-49c0-ae72-d70e3599de52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e755bbef-bf34-49c0-ae72-d70e3599de52.jpg?1",
             "name": "Gush",
             "text": "You may return two islands you control to their owner's hand instead of paying Gush's mana cost.\nDraw two cards.",
             "colours": [
@@ -2767,7 +2767,7 @@
         },
         {
             "id": "31da8e0e-396c-5378-842a-c09c252587c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12eb6a6-14cc-4ad6-9684-ff33a39ba09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12eb6a6-14cc-4ad6-9684-ff33a39ba09f.jpg?1",
             "name": "High Seas",
             "text": "Red creature spells and green creature spells cost o1 more to play.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "34677c59-6422-5f46-ae3a-86fd6cfa4066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d505fbb-ec85-475b-a0e1-6670627ec017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d505fbb-ec85-475b-a0e1-6670627ec017.jpg?1",
             "name": "Hoodwink",
             "text": "Return target artifact, enchantment, or land to its owner's hand.",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "ad3a80d0-aad5-5c91-89e3-8f9451cd4e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae62ce7-852b-42c6-9cbe-4807d8bf5740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae62ce7-852b-42c6-9cbe-4807d8bf5740.jpg?1",
             "name": "Indentured Djinn",
             "text": "Flying\nWhen Indentured Djinn comes into play, each other player may draw up to three cards.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "303d6775-5155-5c13-bd48-060342c91d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07845861-f974-43b7-829c-79a4a41ac3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07845861-f974-43b7-829c-79a4a41ac3e3.jpg?1",
             "name": "Karn's Touch",
             "text": "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost until end of turn. (It retains its abilities.)",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "2f62f355-5f33-5eb2-8322-3d3efa800568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ad59c-29e9-4498-a6fd-33bf21e8e7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ad59c-29e9-4498-a6fd-33bf21e8e7c4.jpg?1",
             "name": "Misdirection",
             "text": "You may remove a blue card in your hand from the game instead of paying Misdirection's mana cost.\nTarget spell with a single target targets another target instead.",
             "colours": [
@@ -2929,7 +2929,7 @@
         },
         {
             "id": "c9660153-4777-587a-8f71-27b6c432048f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e23f5a1-bf3e-41e0-875f-fc2f8508e69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e23f5a1-bf3e-41e0-875f-fc2f8508e69f.jpg?1",
             "name": "Misstep",
             "text": "Creatures target player controls don't untap during that player's next untap step.",
             "colours": [
@@ -2961,7 +2961,7 @@
         },
         {
             "id": "9e33f708-f246-543b-950f-6704a0a25d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145903cb-9eaa-4f3c-a376-88dcd474ffda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145903cb-9eaa-4f3c-a376-88dcd474ffda.jpg?1",
             "name": "Overtaker",
             "text": "o3o\nU, oc\nT, Discard a card from your hand: Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "93fc4af6-0c43-5ea6-b859-d5705b106cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25d969-68d9-4580-bb29-f72bd5646a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25d969-68d9-4580-bb29-f72bd5646a3d.jpg?1",
             "name": "Port Inspector",
             "text": "Whenever Port Inspector becomes blocked, you may look at defending player's hand.",
             "colours": [
@@ -3030,7 +3030,7 @@
         },
         {
             "id": "985af666-e535-5251-834d-73e5de8a3922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8e596b-f5ef-405a-8910-c5d0b5c8c0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8e596b-f5ef-405a-8910-c5d0b5c8c0fc.jpg?1",
             "name": "Rishadan Airship",
             "text": "Flying\nRishadan Airship may block only creatures with flying.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "dedbd6c4-1cd4-526b-8a42-0a6e441c1e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6efb653-97d8-4bc7-af8f-0b09fda655ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6efb653-97d8-4bc7-af8f-0b09fda655ff.jpg?1",
             "name": "Rishadan Brigand",
             "text": "Flying\nWhen Rishadan Brigand comes into play, each opponent sacrifices a permanent unless he or she pays o3.\nRishadan Brigand may block only creatures with flying.",
             "colours": [
@@ -3100,7 +3100,7 @@
         },
         {
             "id": "2f765215-8a97-53f2-ae46-38dd64438078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947fc270-11e3-46cd-9086-e880a5845c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947fc270-11e3-46cd-9086-e880a5845c79.jpg?1",
             "name": "Rishadan Cutpurse",
             "text": "When Rishadan Cutpurse comes into play, each opponent sacrifices a permanent unless he or she pays o1.",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "adbef0c3-52cc-5b1e-8953-9fb64cbfd4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee964-1a44-46a1-8606-90e215805483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee964-1a44-46a1-8606-90e215805483.jpg?1",
             "name": "Rishadan Footpad",
             "text": "When Rishadan Footpad comes into play, each opponent sacrifices a permanent unless he or she pays o2.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "b4b88054-ea10-5dad-94ad-3c01d3dc9297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142479d8-8956-44a2-8c54-9dd6dc1774c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142479d8-8956-44a2-8c54-9dd6dc1774c0.jpg?1",
             "name": "Sailmonger",
             "text": "o2: Target creature gains flying until end of turn. Any player may play this ability.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "47165f3e-6087-5bcd-bc50-9adf5c0f8f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd7ce9-b920-409d-a4d2-a07fff280712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd7ce9-b920-409d-a4d2-a07fff280712.jpg?1",
             "name": "Sand Squid",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)\nYou may choose not to untap Sand Squid during your untap step.\noc\nT: Tap target creature. That creature does not untap during its controller's untap step as long as Sand Squid remains tapped.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "de2fdc6d-96dd-56a4-9f54-b83fec0da12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f50964-1b57-426a-ac46-c90c045c7e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f50964-1b57-426a-ac46-c90c045c7e40.jpg?1",
             "name": "Saprazzan Bailiff",
             "text": "When Saprazzan Bailiff comes into play, remove all artifact and enchantment cards in all graveyards from the game.\nWhen Saprazzan Bailiff leaves play, return all artifact and enchantment cards from all graveyards to their owners' hands.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "86f01e79-9f6d-51f8-bf91-753f9e2ef16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de7bf0f-5ad5-467b-ad80-28517951bbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de7bf0f-5ad5-467b-ad80-28517951bbe1.jpg?1",
             "name": "Saprazzan Breaker",
             "text": "oo\nU Put the top card of your library into your graveyard. If that card is a land card, Saprazzan Breaker is unblockable this turn.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "344d824d-d6f3-5437-a447-c31f24ed07c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg?1",
             "name": "Saprazzan Heir",
             "text": "Whenever Saprazzan Heir becomes blocked, you may draw three cards.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "cf8372f0-d928-57d8-994f-f6dcb5f56696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9adf84-ee7e-472b-bd96-9abf853afa83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9adf84-ee7e-472b-bd96-9abf853afa83.jpg?1",
             "name": "Saprazzan Legate",
             "text": "Flying\nIf an opponent controls a mountain and you control an island, you may play Saprazzan Legate without paying its mana cost.",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "d7622724-e9e8-5e5e-b074-7f40c4c49ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28048f1-4cf5-4389-9e69-9b5e1bc95396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28048f1-4cf5-4389-9e69-9b5e1bc95396.jpg?1",
             "name": "Saprazzan Outrigger",
             "text": "When Saprazzan Outrigger attacks or blocks, put it on top of its owner's library at end of combat.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "de062eaf-db22-5d86-b8fb-87871c14a449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62493f34-cea8-4d9f-8781-005947b69c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62493f34-cea8-4d9f-8781-005947b69c9d.jpg?1",
             "name": "Saprazzan Raider",
             "text": "When Saprazzan Raider becomes blocked, return it to its owner's hand.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "1ef27a43-79ab-569f-8902-cef99787d974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4787-9b29-4f57-b105-1f9eb4bb8861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4787-9b29-4f57-b105-1f9eb4bb8861.jpg?1",
             "name": "Shoving Match",
             "text": "Until end of turn, all creatures gain \"oc\nT: Tap target creature.\"",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "0890f001-c5eb-5730-bf6c-3d956f026a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def384ff-1b6f-4c4f-8151-3c72c29b63ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def384ff-1b6f-4c4f-8151-3c72c29b63ce.jpg?1",
             "name": "Soothsaying",
             "text": "o3o\nUoo\nU Shuffle your library.\noo\nX Look at the top X cards of your library and put them back in any order.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "90b04539-38d2-5094-859d-fbbdfce300bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg?1",
             "name": "Squeeze",
             "text": "Sorcery spells cost o3 more to play.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "27726ce1-88c2-5a8c-a5a7-2eeb59e08bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dcd19e-8daf-4d53-946b-c07d5eca3cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dcd19e-8daf-4d53-946b-c07d5eca3cc9.jpg?1",
             "name": "Statecraft",
             "text": "Prevent all combat damage that would be dealt to and dealt by creatures you control.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "29c7ce28-96a6-56c6-b90a-12cf72b3efbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f7cd5-4e91-474a-9f60-a66f3f462b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f7cd5-4e91-474a-9f60-a66f3f462b1c.jpg?1",
             "name": "Stinging Barrier",
             "text": "(Walls can't attack.)\no\nU, oc\nT: Stinging Barrier deals 1 damage to target creature or player.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "64cc2814-da4b-5fc4-aa46-9429b3215d29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12a0717-e9ea-4be3-a29f-179671ed4489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12a0717-e9ea-4be3-a29f-179671ed4489.jpg?1",
             "name": "Thwart",
             "text": "You may return three islands you control to their owner's hand instead of paying Thwart's mana cost.\nCounter target spell.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "4979d48e-69e5-5767-80fa-22c84b5c9f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68fd547-59fb-41e6-be55-1ec17fe2840b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68fd547-59fb-41e6-be55-1ec17fe2840b.jpg?1",
             "name": "Tidal Bore",
             "text": "You may return an island you control to its owner's hand instead of paying Tidal Bore's mana cost.\nTap or untap target creature.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "a3e7af11-07f1-5143-ba01-9da4ec11f2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356a9dcd-1a4b-4371-8f1d-aa7cb65e97e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356a9dcd-1a4b-4371-8f1d-aa7cb65e97e8.jpg?1",
             "name": "Tidal Kraken",
             "text": "Tidal Kraken is unblockable.",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "b66734fa-8d6b-545e-aa5b-927bf89256bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9212f685-d7af-4279-b17e-7201d8f63813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9212f685-d7af-4279-b17e-7201d8f63813.jpg?1",
             "name": "Timid Drake",
             "text": "Flying\nWhenever another creature comes into play, return Timid Drake to its owner's hand.",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "d8655418-ab9c-5a77-a4ea-a8f23f8e0155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaba189-b215-4d1c-9135-a86ce5ec955d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaba189-b215-4d1c-9135-a86ce5ec955d.jpg?1",
             "name": "Trade Routes",
             "text": "o1: Return target land you control to its owner's hand.\no1, Discard a land card from your hand: Draw a card.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "86fc6206-2118-5250-b6ca-b5ccf5d55e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c15159-8466-43e5-9dc5-a8cc94619931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c15159-8466-43e5-9dc5-a8cc94619931.jpg?1",
             "name": "War Tax",
             "text": "o\nXoo\nU Creatures can't attack this turn unless their controller pays o\nX for each attacking creature.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "ad3828cb-8f37-5a18-be9b-fcef8a965e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdce9e-94fa-4ed5-9b97-d2026cffe7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdce9e-94fa-4ed5-9b97-d2026cffe7cb.jpg?1",
             "name": "Waterfront Bouncer",
             "text": "o\nU, oc\nT, Discard a card from your hand: Return target creature to its owner's hand.",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "0d0529d1-8ea3-5ec8-8a11-2abcd684ac91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb648e3-f5ad-4b33-afa3-d4cda0d369a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb648e3-f5ad-4b33-afa3-d4cda0d369a1.jpg?1",
             "name": "Alley Grifters",
             "text": "Whenever Alley Grifters becomes blocked, defending player discards a card from his or her hand.",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "5b4cf6bd-5be9-52e4-a842-d4d0be272a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05976e5c-b46c-431e-9dbd-1dc5fad3536c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05976e5c-b46c-431e-9dbd-1dc5fad3536c.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature is put into a graveyard from play, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add o\nB to your mana pool for each charge counter on Black Market.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "ef21a8d8-8c9e-54af-898c-8b870611fa80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2103a44-87e5-40cd-a0de-cd19456a8366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2103a44-87e5-40cd-a0de-cd19456a8366.jpg?1",
             "name": "Bog Smugglers",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "8f246b02-ca26-5fee-a483-af875baf0aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a926f9e-ee63-4b6e-8e5b-0650b74344a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a926f9e-ee63-4b6e-8e5b-0650b74344a5.jpg?1",
             "name": "Bog Witch",
             "text": "o\nB, oc\nT, Discard a card from your hand: Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "b0b04b78-8dd3-58ea-9e5c-08278373698b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec755ee-b4c0-47fd-9e61-9a3161766de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec755ee-b4c0-47fd-9e61-9a3161766de6.jpg?1",
             "name": "Cackling Witch",
             "text": "o\nXo\nB, oc\nT, Discard a card from your hand: Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "87ce062f-cc9b-5ef9-a382-53e380b8501f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6ce76-0ed0-4994-ae2c-d8e51ae09920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6ce76-0ed0-4994-ae2c-d8e51ae09920.jpg?1",
             "name": "Cateran Brute",
             "text": "o2, oc\nT: Search your library for a Mercenary card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "2e599de4-794f-5f1f-a94f-68c0998b28cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9b6da8-39da-4fce-89cf-ea972f981331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9b6da8-39da-4fce-89cf-ea972f981331.jpg?1",
             "name": "Cateran Enforcer",
             "text": "Cateran Enforcer can't be blocked except by artifact creatures and black creatures.\no4, oc\nT: Search your library for a Mercenary card with converted mana cost 4 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4080,7 +4080,7 @@
         },
         {
             "id": "2781fe11-19fe-58ce-bce3-531029d91d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768bdc1-4055-423a-a1cc-69b4c620e3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768bdc1-4055-423a-a1cc-69b4c620e3e6.jpg?1",
             "name": "Cateran Kidnappers",
             "text": "o3, oc\nT: Search your library for a Mercenary card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4115,7 +4115,7 @@
         },
         {
             "id": "01a38117-53b8-5ac8-9b28-03953eab8b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg?1",
             "name": "Cateran Overlord",
             "text": "Sacrifice a creature: Regenerate Cateran Overlord.\no6, oc\nT: Search your library for a Mercenary card with converted mana cost 6 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "a7478f4c-1014-5438-9543-ffa3ddec81bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98bdbf1-32a6-4d9b-8e57-5d3aca6b05bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98bdbf1-32a6-4d9b-8e57-5d3aca6b05bc.jpg?1",
             "name": "Cateran Persuader",
             "text": "o1, oc\nT: Search your library for a Mercenary card with converted mana cost 1 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4185,7 +4185,7 @@
         },
         {
             "id": "ff5a7b50-6444-534b-84b9-108bf72dd583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg?1",
             "name": "Cateran Slaver",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)\no5, oc\nT: Search your library for a Mercenary card with converted mana cost 5 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4220,7 +4220,7 @@
         },
         {
             "id": "ed755125-190b-5361-a71b-e41da019eb16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3de1f9-9038-4352-b4bf-2e9c5c27495a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3de1f9-9038-4352-b4bf-2e9c5c27495a.jpg?1",
             "name": "Cateran Summons",
             "text": "Search your library for a Mercenary card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "3faf62d8-64b8-5fcd-8175-30c5dff72e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411c9f22-2df0-4a63-b2be-fa02612a6ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411c9f22-2df0-4a63-b2be-fa02612a6ef8.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy comes into play, choose a creature type.\nCreatures you control and creature cards in your graveyard, hand, and library are of the chosen type.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "5cfc4edf-737e-5465-b101-3d265bb783de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb652fc-5a21-4e02-a776-a38fb41ad18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb652fc-5a21-4e02-a776-a38fb41ad18c.jpg?1",
             "name": "Corrupt Official",
             "text": "o2oo\nB Regenerate Corrupt Official.\nWhenever Corrupt Official becomes blocked, defending player discards a card at random from his or her hand.",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "f737e62b-5a49-5b21-90be-09205f5231e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6aacc3e-fe37-4a08-83e6-7ee8c0c0af74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6aacc3e-fe37-4a08-83e6-7ee8c0c0af74.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "57c328a3-7313-5c7b-87b2-82101fb3b76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fff328-704e-462d-9613-82d05371f544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fff328-704e-462d-9613-82d05371f544.jpg?1",
             "name": "Deathgazer",
             "text": "Whenever Deathgazer blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "6e070061-0d93-515d-bf83-7b90b667ebaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd6685-37ca-47c7-8f64-1fb86e9610ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd6685-37ca-47c7-8f64-1fb86e9610ca.jpg?1",
             "name": "Deepwood Ghoul",
             "text": "Pay 2 life: Regenerate Deepwood Ghoul.",
             "colours": [
@@ -4419,7 +4419,7 @@
         },
         {
             "id": "00c4a226-ae9f-5d18-85cb-8690873508be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f01925-7fd0-472d-91a4-3309e615f22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f01925-7fd0-472d-91a4-3309e615f22f.jpg?1",
             "name": "Deepwood Legate",
             "text": "If an opponent controls a forest and you control a swamp, you may play Deepwood Legate without paying its mana cost.\noo\nB Deepwood Legate gets +1/+1 until end of turn.",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "322a6b45-298c-5f1f-a5b4-add14afb5d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da64094f-df6e-4c43-b4ae-03aab6b92816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da64094f-df6e-4c43-b4ae-03aab6b92816.jpg?1",
             "name": "Delraich",
             "text": "Trample\nYou may sacrifice three black creatures instead of paying Delraich's mana cost.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "ac13da9b-2ce6-527a-a9ba-d7efa5ebb90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffca723-360d-48de-a0a8-32288627f3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffca723-360d-48de-a0a8-32288627f3df.jpg?1",
             "name": "Enslaved Horror",
             "text": "When Enslaved Horror comes into play, each other player may return a creature card from his or her graveyard to play.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "c6c31dcd-b647-5e17-b80c-a25c3017180e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66742db-4750-49ce-ad05-b825af7222c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66742db-4750-49ce-ad05-b825af7222c4.jpg?1",
             "name": "Extortion",
             "text": "Look at target player's hand and choose up to two cards from it. That player discards those cards.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "bad03c8a-5ffe-5dd0-b90c-9943ec794610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg?1",
             "name": "Forced March",
             "text": "Destroy all creatures with converted mana cost X or less.",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "2daab5ad-d713-5932-9da0-d6cc667b488f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0054c1-6510-41dd-8695-9bf50296b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0054c1-6510-41dd-8695-9bf50296b615.jpg?1",
             "name": "Ghoul's Feast",
             "text": "Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "c27dfed6-6eeb-53bc-9b54-43ead6058322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c065cae-1ed5-445e-ace3-e81cf4c773de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c065cae-1ed5-445e-ace3-e81cf4c773de.jpg?1",
             "name": "Haunted Crossroads",
             "text": "oo\nB Put target creature card from your graveyard on top of your library.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "d9a5ca51-5800-5a93-b276-2b32929c23c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc826c88-fe3c-4004-8283-27910c550fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc826c88-fe3c-4004-8283-27910c550fae.jpg?1",
             "name": "Highway Robber",
             "text": "When Highway Robber comes into play, you gain 2 life and target opponent loses 2 life.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "61f4343a-fc09-549d-9e38-e0c7607037d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f57af-17d4-4a4c-ae46-fe37f97466fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f57af-17d4-4a4c-ae46-fe37f97466fa.jpg?1",
             "name": "Instigator",
             "text": "o1o\nBo\nB, oc\nT, Discard a card from your hand: Creatures target player controls attack this turn if able.",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "bb23960c-30aa-54f1-94a2-e4516bf1912e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2544c9d-adc2-4d67-8850-9af38e73ea1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2544c9d-adc2-4d67-8850-9af38e73ea1e.jpg?1",
             "name": "Insubordination",
             "text": "At the end of the turn of enchanted creature's controller, Insubordination deals 2 damage to that player unless enchanted creature attacked this turn.",
             "colours": [
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "62ccd550-33c7-58b0-8443-30efa3109c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e1724-91cf-422e-909b-ddb69a6f9f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e1724-91cf-422e-909b-ddb69a6f9f76.jpg?1",
             "name": "Intimidation",
             "text": "Creatures you control can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "2a3c83c6-1bdd-58ec-84e0-020dfff94ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a863da2-0639-4eed-8da9-2e9a38c04a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a863da2-0639-4eed-8da9-2e9a38c04a23.jpg?1",
             "name": "Larceny",
             "text": "Whenever a creature you control deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "69976122-4fa6-5075-a4d4-ae9da4f70a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b07c66d-5f37-4098-b7e6-03e6c684806b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b07c66d-5f37-4098-b7e6-03e6c684806b.jpg?1",
             "name": "Liability",
             "text": "Whenever a card is put into a player's graveyard from play, that player loses 1 life.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "1dfe8a4b-210c-587d-94eb-3b92dcde075c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab963aa-2304-4ee6-a8c7-c485c5133b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab963aa-2304-4ee6-a8c7-c485c5133b40.jpg?1",
             "name": "Maggot Therapy",
             "text": "You may play Maggot Therapy any time you could play an instant.\nEnchanted creature gets +2/-2.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "4484512f-e3eb-59d6-b6d9-fe6d4c6b6d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e98c4f7-b0f4-48c6-b502-3dc5802d827f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e98c4f7-b0f4-48c6-b502-3dc5802d827f.jpg?1",
             "name": "Midnight Ritual",
             "text": "Remove X target creature cards in your graveyard from the game. For each creature card removed this way, put a black 2/2 Zombie creature token into play.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "44f8d84e-3d80-50f1-8f8f-52d68ce2fc45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43cf59e-7583-4651-968a-2a7201c69b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43cf59e-7583-4651-968a-2a7201c69b6b.jpg?1",
             "name": "Misshapen Fiend",
             "text": "Flying",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "2e6f6e95-e7ee-5463-b34c-29e4f24920f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfe33fb-71d5-4552-bcd3-f07e4e3847e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfe33fb-71d5-4552-bcd3-f07e4e3847e1.jpg?1",
             "name": "Molting Harpy",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Molting Harpy unless you pay o2.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "9243a691-4abd-5800-bd35-c8fb96582445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220217c5-408c-40df-8133-da16b13d4f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220217c5-408c-40df-8133-da16b13d4f21.jpg?1",
             "name": "Nether Spirit",
             "text": "At the beginning of your upkeep, if Nether Spirit is the only creature card in your graveyard, you may return Nether Spirit to play.",
             "colours": [
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "72309364-4efa-51dc-934e-e0204cb08bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg?1",
             "name": "Notorious Assassin",
             "text": "o2o\nB, oc\nT, Discard a card from your hand: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "ba2e6a3a-f1e6-5abc-8770-666ef9ba57ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc29dab-9211-46bc-a98c-a5dbd5b0980a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc29dab-9211-46bc-a98c-a5dbd5b0980a.jpg?1",
             "name": "Pretender's Claim",
             "text": "Whenever enchanted creature becomes blocked, tap all lands defending player controls.",
             "colours": [
@@ -5089,7 +5089,7 @@
         },
         {
             "id": "86b560de-c038-5196-974f-a9c3d45e097c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6ed1fb-2f7d-4a21-bbf3-660cad631975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6ed1fb-2f7d-4a21-bbf3-660cad631975.jpg?1",
             "name": "Primeval Shambler",
             "text": "oo\nB Primeval Shambler gets +1/+1 until end of turn.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "3999433b-12c1-59c5-81c5-322469107871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65104b23-58a6-41c0-b887-90a3fb959289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65104b23-58a6-41c0-b887-90a3fb959289.jpg?1",
             "name": "Putrefaction",
             "text": "Whenever a player plays a white spell or green spell, that player discards a card from his or her hand.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "e8f69916-a34f-52e9-9009-0d6f329ef4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c91c44e-6bfc-4595-9cdb-17d73f912c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c91c44e-6bfc-4595-9cdb-17d73f912c09.jpg?1",
             "name": "Quagmire Lamprey",
             "text": "Whenever Quagmire Lamprey becomes blocked by a creature, put a -1/-1 counter on that creature.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "a73fd9dd-f197-54a9-92ce-5efe648d1e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bffa7f-919c-4c9b-9fdc-dde8204c61c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bffa7f-919c-4c9b-9fdc-dde8204c61c2.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy target land.",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "5d336df5-3421-5f46-93d5-b489ad100d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b60f86f-c78a-4dfb-bb18-e9bcf21b26c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b60f86f-c78a-4dfb-bb18-e9bcf21b26c4.jpg?1",
             "name": "Rampart Crawler",
             "text": "Rampart Crawler can't be blocked by Walls.",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "675b6d28-075b-5464-a341-23050f9a00d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad01a8e2-5dc5-49a3-ad1c-7d5bf006b774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad01a8e2-5dc5-49a3-ad1c-7d5bf006b774.jpg?1",
             "name": "Rouse",
             "text": "If you control a swamp, you may pay 2 life instead of paying Rouse's mana cost.\nTarget creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "95d05fe7-91ee-547f-9469-296c92b04a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c97baa-9bc0-4894-867c-ad1f56c469fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c97baa-9bc0-4894-867c-ad1f56c469fd.jpg?1",
             "name": "Scandalmonger",
             "text": "o2: Target player discards a card from his or her hand. Any player may play this ability but only if he or she could play a sorcery.",
             "colours": [
@@ -5324,7 +5324,7 @@
         },
         {
             "id": "8f9979bb-c94c-589c-8fd3-559e1fad8a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d84fec-18f1-4231-a293-0dc1ff868a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d84fec-18f1-4231-a293-0dc1ff868a40.jpg?1",
             "name": "Sever Soul",
             "text": "Destroy target nonblack creature. It can't be regenerated. You gain life equal to its toughness.",
             "colours": [
@@ -5356,7 +5356,7 @@
         },
         {
             "id": "b622a8f5-bc65-5f34-a404-375597d5ec48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba34034a-1150-41c8-a340-543f529ae07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba34034a-1150-41c8-a340-543f529ae07f.jpg?1",
             "name": "Silent Assassin",
             "text": "o3o\nB: Destroy target blocking creature at end of combat.",
             "colours": [
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "d2781aea-7da9-5495-a28f-8cbb7fef94cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175ed19c-9635-45ee-bb2c-32b96270a246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175ed19c-9635-45ee-bb2c-32b96270a246.jpg?1",
             "name": "Skulking Fugitive",
             "text": "When Skulking Fugitive becomes the target of a spell or ability, sacrifice Skulking Fugitive.",
             "colours": [
@@ -5427,7 +5427,7 @@
         },
         {
             "id": "764063c5-cc64-5174-9c8e-719ac46de9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a3cca1-e50e-49b6-9e1a-f86640e3b177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a3cca1-e50e-49b6-9e1a-f86640e3b177.jpg?1",
             "name": "Snuff Out",
             "text": "If you control a swamp, you may pay 4 life instead of paying Snuff Out's mana cost.\nDestroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5459,7 +5459,7 @@
         },
         {
             "id": "4d3d7a36-5153-5a61-905f-394b605e6640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cd09ef-1655-4a62-b6c5-6eda33d2607a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cd09ef-1655-4a62-b6c5-6eda33d2607a.jpg?1",
             "name": "Soul Channeling",
             "text": "Pay 2 life: Regenerate enchanted creature.",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "42772e50-5923-545e-aeee-8eaa49be0563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1637b62-e364-4250-aad5-841c6a47a11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1637b62-e364-4250-aad5-841c6a47a11e.jpg?1",
             "name": "Specter's Wail",
             "text": "Target player discards a card at random from his or her hand.",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "67d8c6c0-19f5-523f-a9f7-d4b1949da999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aa9108-470c-484d-908a-c31cf6935765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aa9108-470c-484d-908a-c31cf6935765.jpg?1",
             "name": "Strongarm Thug",
             "text": "When Strongarm Thug comes into play, you may return a Mercenary card from your graveyard to your hand.",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "43b41ca4-bd9d-5bc6-854f-a28b64de5095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg?1",
             "name": "Thrashing Wumpus",
             "text": "oo\nB Thrashing Wumpus deals 1 damage to each creature and each player.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "7c80a2c0-5062-5062-af37-86e602cd97f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615f531-e8af-4f7b-a4ea-fb962149093f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615f531-e8af-4f7b-a4ea-fb962149093f.jpg?1",
             "name": "Undertaker",
             "text": "o\nB, oc\nT, Discard a card from your hand: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "1614f689-9077-5673-b722-a230dd049576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db7a0e6-eea5-4fa6-ac14-401411b106cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db7a0e6-eea5-4fa6-ac14-401411b106cc.jpg?1",
             "name": "Unmask",
             "text": "You may remove a black card in your hand from the game instead of paying Unmask's mana cost.\nLook at target player's hand and choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "dcbd58db-4ebb-5348-ab47-c29a93956c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985f240-4289-4d48-978c-bb2ce2b54c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985f240-4289-4d48-978c-bb2ce2b54c36.jpg?1",
             "name": "Unnatural Hunger",
             "text": "At the beginning of the upkeep of enchanted creature's controller, Unnatural Hunger deals to that player damage equal to enchanted creature's power unless he or she sacrifices another creature.",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "14ef995f-14fe-5dba-b401-805a1eefd941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced38e-0f33-4bda-8e18-09f6ac03a3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced38e-0f33-4bda-8e18-09f6ac03a3d7.jpg?1",
             "name": "Vendetta",
             "text": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "60e865be-7b26-54f7-8aa7-0f7edc57131a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b2d07a-9ea1-430d-b432-ae507f4fe73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b2d07a-9ea1-430d-b432-ae507f4fe73b.jpg?1",
             "name": "Wall of Distortion",
             "text": "(Walls can't attack.)\no2o\nB, oc\nT: Target player discards a card from his or her hand. Play this ability only if you could play a sorcery.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "ea97f39e-daec-5dcf-b324-833c8dd024a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafea45d-be00-428d-a127-70e6a14efe3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafea45d-be00-428d-a127-70e6a14efe3f.jpg?1",
             "name": "Arms Dealer",
             "text": "o1o\nR, Sacrifice a Goblin: Arms Dealer deals 4 damage to target creature.",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "b3537580-34b2-5fa0-980f-24a41b9d179d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27f6658-0f00-4934-8d12-cd0dda3958c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27f6658-0f00-4934-8d12-cd0dda3958c9.jpg?1",
             "name": "Battle Rampart",
             "text": "(Walls can't attack.)\noc\nT: Target creature gains haste until end of turn. (That creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "e3ef1a41-318e-5e2f-9062-cdcb096dd68f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg?1",
             "name": "Battle Squadron",
             "text": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "96de848f-f68d-5984-acd6-f09fbb091f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b0fd1-bbb2-47c0-a4c3-4129a67473b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b0fd1-bbb2-47c0-a4c3-4129a67473b9.jpg?1",
             "name": "Blaster Mage",
             "text": "o\nR, oc\nT, Discard a card from your hand: Destroy target Wall.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "842ffd5c-1df2-58d8-a5de-56e83ee5c3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa1e796-809c-49af-a84e-ec088f7f48f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa1e796-809c-49af-a84e-ec088f7f48f8.jpg?1",
             "name": "Blood Hound",
             "text": "Whenever you're dealt damage, you may put that many +1/+1 counters on Blood Hound.\nAt the end of your turn, remove all +1/+1 counters from Blood Hound.",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "2f85c9d2-1721-5070-8cff-ba782453ea22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1556a12-ff45-4a12-988a-63615b3799a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1556a12-ff45-4a12-988a-63615b3799a9.jpg?1",
             "name": "Blood Oath",
             "text": "Choose a card type. Target opponent reveals his or her hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -5965,7 +5965,7 @@
         },
         {
             "id": "2aaaef87-72e0-586b-9245-3f70fccedd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4e783c-0717-4127-bd7b-885ca617ca29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4e783c-0717-4127-bd7b-885ca617ca29.jpg?1",
             "name": "Brawl",
             "text": "Until end of turn, all creatures gain \"oc\nT: This creature deals damage equal to its power to target creature.\"",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "aed071b1-5078-512c-8524-7725f27a1353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d718421-c742-489c-a243-3adb19f6716a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d718421-c742-489c-a243-3adb19f6716a.jpg?1",
             "name": "Cave Sense",
             "text": "Enchanted creature gets +1/+1 and has mountainwalk. (It's unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "93e657e5-4c4c-5aa1-addf-fafc09d646e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d9d26-f304-467d-af79-914cc65f082e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d9d26-f304-467d-af79-914cc65f082e.jpg?1",
             "name": "Cave-In",
             "text": "You may remove a red card in your hand from the game instead of paying Cave-In's mana cost.\nCave-In deals 2 damage to each creature and each player.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "f4eb2aa0-1d1e-5f70-977c-f249661884ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a8af9-2e86-4639-a6c9-209f115e95f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a8af9-2e86-4639-a6c9-209f115e95f8.jpg?1",
             "name": "Cavern Crawler",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)\noo\nR Cavern Crawler gets +1/-1 until end of turn.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "90737596-1f65-5666-a118-51cb611e29b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c69d1-5295-419f-bb8f-af826bf92cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c69d1-5295-419f-bb8f-af826bf92cb3.jpg?1",
             "name": "Ceremonial Guard",
             "text": "When Ceremonial Guard attacks or blocks, destroy it at end of combat.",
             "colours": [
@@ -6132,7 +6132,7 @@
         },
         {
             "id": "82cbb80b-862e-5394-ad0c-c54e09ce8810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg?1",
             "name": "Cinder Elemental",
             "text": "o\nXo\nR, oc\nT, Sacrifice Cinder Elemental: Cinder Elemental deals X damage to target creature or player.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "eff21e5d-75c5-5ac9-9c44-ef7cbc617be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9131c7-4e46-4c01-80b3-a6b055439346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9131c7-4e46-4c01-80b3-a6b055439346.jpg?1",
             "name": "Close Quarters",
             "text": "Whenever a creature you control becomes blocked, Close Quarters deals 1 damage to target creature or player.",
             "colours": [
@@ -6198,7 +6198,7 @@
         },
         {
             "id": "6db6621d-abf0-57b1-89ae-3b0baaf8dfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0907a5-938e-4ef4-aa85-e7c1ae4317a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0907a5-938e-4ef4-aa85-e7c1ae4317a6.jpg?1",
             "name": "Crag Saurian",
             "text": "Whenever Crag Saurian is dealt damage, the controller of that damage's source gains control of Crag Saurian.",
             "colours": [
@@ -6232,7 +6232,7 @@
         },
         {
             "id": "0224c6e4-2e80-5764-82d3-c3e0cae6defd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a26bde3-8392-4476-b347-f223d52554a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a26bde3-8392-4476-b347-f223d52554a6.jpg?1",
             "name": "Crash",
             "text": "You may sacrifice a mountain instead of paying Crash's mana cost.\nDestroy target artifact.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "2645d487-3741-54ab-8afa-8d82aa70fd50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eee8c2e-bda7-4bf9-80fe-87d96024ca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eee8c2e-bda7-4bf9-80fe-87d96024ca8b.jpg?1",
             "name": "Flailing Manticore",
             "text": "Flying, first strike\no1: Flailing Manticore gets +1/+1 until end of turn. Any player may play this ability.\no1: Flailing Manticore gets -1/-1 until end of turn. Any player may play this ability.",
             "colours": [
@@ -6298,7 +6298,7 @@
         },
         {
             "id": "0b5aed27-3cb5-530a-adef-fec7d81018ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e520-b2b8-4c13-a4ea-f8810c927bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e520-b2b8-4c13-a4ea-f8810c927bf7.jpg?1",
             "name": "Flailing Ogre",
             "text": "o1: Flailing Ogre gets +1/+1 until end of turn. Any player may play this ability.\no1: Flailing Ogre gets -1/-1 until end of turn. Any player may play this ability.",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "a27f8a1e-cb17-543c-a769-73288eb0287e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb44b0f6-0608-40d6-9eaa-48e5a834701f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb44b0f6-0608-40d6-9eaa-48e5a834701f.jpg?1",
             "name": "Flailing Soldier",
             "text": "o1: Flailing Soldier gets +1/+1 until end of turn. Any player may play this ability.\no1: Flailing Soldier gets -1/-1 until end of turn. Any player may play this ability.",
             "colours": [
@@ -6367,7 +6367,7 @@
         },
         {
             "id": "005b1161-73b7-5175-96f1-0cd580d10a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ecd9ff-8c30-4e17-8cff-dd40d653c4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ecd9ff-8c30-4e17-8cff-dd40d653c4af.jpg?1",
             "name": "Flaming Sword",
             "text": "You may play Flaming Sword any time you could play an instant.\nTarget creature gets +1/+0 and has first strike.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "82839c70-473f-59c2-9c14-233dfc18dbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a07fae-0f34-45e7-b22d-97eea9031022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a07fae-0f34-45e7-b22d-97eea9031022.jpg?1",
             "name": "Furious Assault",
             "text": "Whenever you play a creature spell, Furious Assault deals 1 damage to target player.",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "4c2f8959-64ab-55aa-81d0-67fa656e9d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a88f507-3d78-4f7f-a91f-8489ad9250f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a88f507-3d78-4f7f-a91f-8489ad9250f2.jpg?1",
             "name": "Gerrard's Irregulars",
             "text": "Trample; haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "737f3dff-b4ab-51c2-89f9-4574fc363655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b959d7ad-a78e-439f-9225-4dbb89f490d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b959d7ad-a78e-439f-9225-4dbb89f490d7.jpg?1",
             "name": "Hammer Mage",
             "text": "o\nXo\nR, oc\nT, Discard a card from your hand: Destroy all artifacts with converted mana cost X or less.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "db2bed1d-ec67-5070-80b4-866b9ac8f768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc33920a-f05c-46fa-b94b-278af0022b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc33920a-f05c-46fa-b94b-278af0022b78.jpg?1",
             "name": "Hired Giant",
             "text": "When Hired Giant comes into play, each other player may search his or her library for a land card, put that card into play, then shuffle that library.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "1273f802-49a6-520d-ab6a-7c686a83174d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4389fbcd-182a-4cac-b14f-aa971948cf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4389fbcd-182a-4cac-b14f-aa971948cf8e.jpg?1",
             "name": "Kris Mage",
             "text": "o\nR, oc\nT, Discard a card from your hand: Kris Mage deals 1 damage to target creature or player.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "3df8ff78-b4bc-5288-9c27-774f36939e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc55e01-342e-4856-937e-14561b8d165b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc55e01-342e-4856-937e-14561b8d165b.jpg?1",
             "name": "Kyren Glider",
             "text": "Flying\nKyren Glider can't block.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "79821431-efca-54c8-885e-30cb57845a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0e9806-be8c-4b88-a4be-0111d1be81d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0e9806-be8c-4b88-a4be-0111d1be81d9.jpg?1",
             "name": "Kyren Legate",
             "text": "If an opponent controls a plains and you control a mountain, you may play Kyren Legate without paying its mana cost.\nHaste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "5fcafc4d-c4f2-5702-af2c-096e23612c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c263a17-bbc2-433e-93f8-72e57b818322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c263a17-bbc2-433e-93f8-72e57b818322.jpg?1",
             "name": "Kyren Negotiations",
             "text": "Tap an untapped creature you control: Kyren Negotiations deals 1 damage to target player.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "50f1a066-c694-5a14-8bfc-f769ffa3dd5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df99e19-0b1e-48ec-a146-38cf147eab61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df99e19-0b1e-48ec-a146-38cf147eab61.jpg?1",
             "name": "Kyren Sniper",
             "text": "At the beginning of your upkeep, you may have Kyren Sniper deal 1 damage to target player.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "756d620f-461c-5e44-8fbb-bb1b9cbb1f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d0fbe6-6ce1-4b95-afb7-a7386b5033cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d0fbe6-6ce1-4b95-afb7-a7386b5033cf.jpg?1",
             "name": "Lava Runner",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhenever Lava Runner becomes the target of a spell or ability, that spell or ability's controller sacrifices a land.",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "b1729cf2-9858-5dfa-86f0-659f88908d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c82a1d-5db1-4090-b446-cc5bc6dc811d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c82a1d-5db1-4090-b446-cc5bc6dc811d.jpg?1",
             "name": "Lightning Hounds",
             "text": "First strike",
             "colours": [
@@ -6774,7 +6774,7 @@
         },
         {
             "id": "fd51cac8-96b3-58a1-bceb-314c94869b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee0f17-de64-4abb-afad-4005275f1a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee0f17-de64-4abb-afad-4005275f1a3c.jpg?1",
             "name": "Lithophage",
             "text": "At the beginning of your upkeep, sacrifice Lithophage unless you sacrifice a mountain.",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "e1b656ad-a6c2-5907-bbd7-dcbee83f1591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e43349-429c-43f7-b808-c4bf37370a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e43349-429c-43f7-b808-c4bf37370a9f.jpg?1",
             "name": "Lunge",
             "text": "Lunge deals 2 damage to target creature and 2 damage to target player.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "1fcf704e-d9f7-5fff-bb09-a59b4b9ee9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f83d39e-bf49-4968-829e-c0e9abf2fb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f83d39e-bf49-4968-829e-c0e9abf2fb86.jpg?1",
             "name": "Magistrate's Veto",
             "text": "White creatures and blue creatures can't block.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "cfd17e89-e40a-5268-9276-f158163253f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14507fe6-80a9-4ed4-bf3e-4656f3d377c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14507fe6-80a9-4ed4-bf3e-4656f3d377c0.jpg?1",
             "name": "Mercadia's Downfall",
             "text": "Attacking creatures get +X/+0 until end of turn, where X is the number of nonbasic lands defending player controls.",
             "colours": [
@@ -6904,7 +6904,7 @@
         },
         {
             "id": "6ee67c75-4024-5735-9524-839d178baf02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d6c28-6468-4bde-9738-eb51594fa7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d6c28-6468-4bde-9738-eb51594fa7c1.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "e942dae0-9355-5bd5-aea6-c226f2d5c44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbc44d-60fb-45fc-a588-14aab0340134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbc44d-60fb-45fc-a588-14aab0340134.jpg?1",
             "name": "Pulverize",
             "text": "You may sacrifice two mountains instead of paying Pulverize's mana cost.\nDestroy all artifacts.",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "70215b2a-8dc5-5ea8-8057-7f9dd6f2b1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052b743a-456d-49c3-881e-4f30c7645fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052b743a-456d-49c3-881e-4f30c7645fa5.jpg?1",
             "name": "Puppet's Verdict",
             "text": "Flip a coin. If you win the flip, destroy all creatures with power 2 or less. If you lose the flip, destroy all creatures with power 3 or greater.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "03baff19-c451-5287-8b6f-ad9a1f02d91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5cf073-2ba0-463e-bcd4-979ad18e28fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5cf073-2ba0-463e-bcd4-979ad18e28fc.jpg?1",
             "name": "Robber Fly",
             "text": "Flying\nWhenever Robber Fly becomes blocked, defending player discards his or her hand, then draws that many cards.",
             "colours": [
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "415b8716-dee1-5647-9b54-5bbb64af4e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff05df8-76f5-48c6-ac96-7b4e6a7050f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff05df8-76f5-48c6-ac96-7b4e6a7050f6.jpg?1",
             "name": "Rock Badger",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -7071,7 +7071,7 @@
         },
         {
             "id": "0eb838f3-390f-5bb1-a2b9-cfb7dd2d25bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg?1",
             "name": "Seismic Mage",
             "text": "o2o\nR, oc\nT, Discard a card from your hand: Destroy target land.",
             "colours": [
@@ -7106,7 +7106,7 @@
         },
         {
             "id": "6082ec5f-c682-52cf-ba84-daeac2e227b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a918ca-3e60-46de-9f29-56bdc6430a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a918ca-3e60-46de-9f29-56bdc6430a77.jpg?1",
             "name": "Shock Troops",
             "text": "Sacrifice Shock Troops: Shock Troops deals 2 damage to target creature or player.",
             "colours": [
@@ -7141,7 +7141,7 @@
         },
         {
             "id": "344ead1c-4052-5b6a-9cab-a3b40b8b0a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca1eee-d97d-48c6-84f1-7d1f972c3ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca1eee-d97d-48c6-84f1-7d1f972c3ca9.jpg?1",
             "name": "Sizzle",
             "text": "Sizzle deals 3 damage to each opponent.",
             "colours": [
@@ -7173,7 +7173,7 @@
         },
         {
             "id": "9c1b266a-0485-570b-be1e-9b961ed5f225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8325a-1203-4125-9111-94d9e2b1f14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8325a-1203-4125-9111-94d9e2b1f14b.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, if Squee, Goblin Nabob is in your graveyard, you may return Squee to your hand.",
             "colours": [
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "4c567124-63d1-51eb-91f4-52e8b00548c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7ded-9249-42c8-bb17-4c6b8cd2a9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7ded-9249-42c8-bb17-4c6b8cd2a9cc.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "d2355933-e5e1-51d7-82d9-78c9cbdc2abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0ee5d-10f6-4152-8416-1f2b749b439d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0ee5d-10f6-4152-8416-1f2b749b439d.jpg?1",
             "name": "Tectonic Break",
             "text": "Each player sacrifices X lands.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "45ae73db-6930-55a0-a56d-c4a0c11cf741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa8a13a-f09f-4b10-8fab-3ea4fdc643d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa8a13a-f09f-4b10-8fab-3ea4fdc643d1.jpg?1",
             "name": "Territorial Dispute",
             "text": "Players can't play lands.\nAt the beginning of your upkeep, sacrifice Territorial Dispute unless you sacrifice a land.",
             "colours": [
@@ -7305,7 +7305,7 @@
         },
         {
             "id": "19f96e81-4af0-5b3a-88b2-3f9dee2d9378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5708c87-108d-4ba1-a1e9-e83cb9b16b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5708c87-108d-4ba1-a1e9-e83cb9b16b6c.jpg?1",
             "name": "Thieves' Auction",
             "text": "Set aside all permanents. You choose one of those cards and put it into play tapped under your control. Then your opponent chooses one and puts it into play tapped under his or her control. Repeat this process until all cards set aside this way have been chosen. (Local enchantments with no permanent to enchant remain removed from the game.)",
             "colours": [
@@ -7337,7 +7337,7 @@
         },
         {
             "id": "2b09dee3-dfd4-5ad8-912d-857722db4b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f8c5ee-2179-4c05-adc9-0b66d02b59ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f8c5ee-2179-4c05-adc9-0b66d02b59ad.jpg?1",
             "name": "Thunderclap",
             "text": "You may sacrifice a mountain instead of paying Thunderclap's mana cost.\nThunderclap deals 3 damage to target creature.",
             "colours": [
@@ -7369,7 +7369,7 @@
         },
         {
             "id": "47111681-dba4-57dc-86b4-5a3b5cbf0553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8531efb1-d77d-451a-8621-424fc278ccf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8531efb1-d77d-451a-8621-424fc278ccf9.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "c679a52d-ab94-554c-9b2b-125ba3c414bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fed2c7-c922-41c3-b86b-a8ed41a1308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fed2c7-c922-41c3-b86b-a8ed41a1308d.jpg?1",
             "name": "Two-Headed Dragon",
             "text": "Flying\no1oo\nR Two-Headed Dragon gets +2/+0 until end of turn.\nTwo-Headed Dragon can't be blocked except by two or more creatures. It may block one additional creature. (All blocks must be legal.)",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "6f830d61-7a67-51a9-b1cc-3a37e89a2a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa3455-3ba0-41ad-aefd-40f183aed2a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa3455-3ba0-41ad-aefd-40f183aed2a6.jpg?1",
             "name": "Uphill Battle",
             "text": "Creatures your opponents play come into play tapped.",
             "colours": [
@@ -7467,7 +7467,7 @@
         },
         {
             "id": "cfdc365f-aa18-5955-a15a-7d9557e81c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c69dd00-46ce-42b2-a2ed-43b4cf04a975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c69dd00-46ce-42b2-a2ed-43b4cf04a975.jpg?1",
             "name": "Volcanic Wind",
             "text": "Volcanic Wind deals X damage divided as you choose among any number of target creatures, where X is the number of creatures in play.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "040b26e4-944a-5818-ad03-326ddb446328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e030d2eb-70c5-4ff7-8f03-ad5495cf9c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e030d2eb-70c5-4ff7-8f03-ad5495cf9c69.jpg?1",
             "name": "War Cadence",
             "text": "o\nXoo\nR Creatures can't block this turn unless their controller pays o\nX for each blocking creature.",
             "colours": [
@@ -7531,7 +7531,7 @@
         },
         {
             "id": "dbb1cd0f-4c3b-5749-aad7-d318f6df6fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577ac30-ee84-4d3c-b407-82578779dc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577ac30-ee84-4d3c-b407-82578779dc90.jpg?1",
             "name": "Warmonger",
             "text": "o2: Warmonger deals 1 damage to each creature without flying and each player. Any player may play this ability.",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "06267158-a59b-5fad-a8a5-fecf53bd7205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e031c819-1237-4911-8a1d-87d6095a5faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e031c819-1237-4911-8a1d-87d6095a5faa.jpg?1",
             "name": "Warpath",
             "text": "Warpath deals 3 damage to each blocking creature and each blocked creature.",
             "colours": [
@@ -7598,7 +7598,7 @@
         },
         {
             "id": "7759f516-b520-5c29-93b6-c1905a329ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bcc06a-de86-4387-882d-ead33e9c9e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bcc06a-de86-4387-882d-ead33e9c9e01.jpg?1",
             "name": "Wild Jhovall",
             "text": "",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "20de66b0-569a-5b04-b7f6-161200ecd124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5362ead-9162-4160-bfa9-432f7d0e222d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5362ead-9162-4160-bfa9-432f7d0e222d.jpg?1",
             "name": "Word of Blasting",
             "text": "Destroy target Wall. It can't be regenerated. Word of Blasting deals damage equal to that Wall's converted mana cost to the Wall's controller.",
             "colours": [
@@ -7664,7 +7664,7 @@
         },
         {
             "id": "236a4bd1-807c-5287-964d-07767ac86705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203f98a-fb6e-4f16-88e3-553eba177450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203f98a-fb6e-4f16-88e3-553eba177450.jpg?1",
             "name": "Ancestral Mask",
             "text": "Enchanted creature gets +2/+2 for each other enchantment in play.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "b094f051-ef64-521e-b220-b6c2ea7304d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedb483e-b2c6-46c6-b02b-a49599d33521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedb483e-b2c6-46c6-b02b-a49599d33521.jpg?1",
             "name": "Bifurcate",
             "text": "Search your library for a copy of target creature card in play and put that card into play. Then shuffle your library.",
             "colours": [
@@ -7730,7 +7730,7 @@
         },
         {
             "id": "c01152ee-acc6-53f9-b313-534554d9ae41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7369cbf-6986-4a39-b07c-a283b40aee40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7369cbf-6986-4a39-b07c-a283b40aee40.jpg?1",
             "name": "Boa Constrictor",
             "text": "oc\nT: Boa Constrictor gets +3/+3 until end of turn.",
             "colours": [
@@ -7764,7 +7764,7 @@
         },
         {
             "id": "1b0d97c8-06bb-5433-ae30-d9f9c9b9619b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5913fc6-eeb0-411b-9264-1e75bea8489b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5913fc6-eeb0-411b-9264-1e75bea8489b.jpg?1",
             "name": "Briar Patch",
             "text": "Whenever a creature attacks you, it gets -1/-0 until end of turn.",
             "colours": [
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "ab8134fb-ff51-5a19-a69a-05c955a72117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e8e1cf-0a47-4ce4-889a-091229d0e466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e8e1cf-0a47-4ce4-889a-091229d0e466.jpg?1",
             "name": "Caller of the Hunt",
             "text": "As you play Caller of the Hunt, choose a creature type.\nCaller of the Hunt's power and toughness are each equal to the number of creatures in play of the chosen type.",
             "colours": [
@@ -7830,7 +7830,7 @@
         },
         {
             "id": "c182a03b-2f3f-5a4c-a9cb-833167d9ce9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a46e20-2910-4287-a5e0-bccac8cbabcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a46e20-2910-4287-a5e0-bccac8cbabcd.jpg?1",
             "name": "Caustic Wasps",
             "text": "Flying\nWhenever Caustic Wasps deals combat damage to a player, you may destroy target artifact that player controls.",
             "colours": [
@@ -7864,7 +7864,7 @@
         },
         {
             "id": "93c28d1c-eb7f-555a-be37-956e8070518a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87f3579-f314-4207-a02c-14e9cb269b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87f3579-f314-4207-a02c-14e9cb269b47.jpg?1",
             "name": "Clear the Land",
             "text": "Each player reveals the top five cards of his or her library, puts into play tapped all land cards revealed this way, and removes the rest from the game.",
             "colours": [
@@ -7896,7 +7896,7 @@
         },
         {
             "id": "39cdcd8b-88f8-54dc-a73d-0a94f5b13e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7d6a8-9190-403f-bbdd-ab71d9c89e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7d6a8-9190-403f-bbdd-ab71d9c89e4d.jpg?1",
             "name": "Collective Unconscious",
             "text": "Draw a card for each creature you control.",
             "colours": [
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "4ca0743d-ea66-52e4-aa24-a79a53ef759d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg?1",
             "name": "Dawnstrider",
             "text": "o\nG, oc\nT, Discard a card from your hand: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "9f5e9479-3a19-5042-bbe2-0ab5d7f06b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46be78e6-13bb-4500-87db-5ed5cae0145e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46be78e6-13bb-4500-87db-5ed5cae0145e.jpg?1",
             "name": "Deadly Insect",
             "text": "Deadly Insect can't be the target of spells or abilities.",
             "colours": [
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "97b57a74-2e93-5315-9d32-a497aa210fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbed0f5-2ac0-48d8-b5ab-b4cd7176fde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbed0f5-2ac0-48d8-b5ab-b4cd7176fde2.jpg?1",
             "name": "Deepwood Drummer",
             "text": "o\nG, oc\nT, Discard a card from your hand: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8032,7 +8032,7 @@
         },
         {
             "id": "b95a320b-67dd-582c-815a-ee2b94cbb163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a1ed74-027e-4c8e-ac7e-e58c5fccff14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a1ed74-027e-4c8e-ac7e-e58c5fccff14.jpg?1",
             "name": "Deepwood Elder",
             "text": "o\nXo\nGo\nG, oc\nT, Discard a card from your hand: X target lands become forests until end of turn.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "167c438b-989d-53a5-8cb7-5dbc3f2bc9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa2028e-4e73-4ff2-a9e2-9ac347d67893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa2028e-4e73-4ff2-a9e2-9ac347d67893.jpg?1",
             "name": "Deepwood Tantiv",
             "text": "Whenever Deepwood Tantiv becomes blocked, you gain 2 life.",
             "colours": [
@@ -8101,7 +8101,7 @@
         },
         {
             "id": "29af5e08-2618-5df7-8f9c-69a2f755520f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a9a76-741a-4ba3-bd4b-0eb87d678253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a9a76-741a-4ba3-bd4b-0eb87d678253.jpg?1",
             "name": "Deepwood Wolverine",
             "text": "Whenever Deepwood Wolverine becomes blocked, it gets +2/+0 until end of turn.",
             "colours": [
@@ -8135,7 +8135,7 @@
         },
         {
             "id": "d8d0d686-bf4f-5ea4-bf5b-8617f0756d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2437f2-1966-4e83-9f7e-6aaf76e21d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2437f2-1966-4e83-9f7e-6aaf76e21d11.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy target permanent.",
             "colours": [
@@ -8167,7 +8167,7 @@
         },
         {
             "id": "29944b27-6b92-543e-9e43-5de8cb1b516a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ea4e2-2102-4b99-bea5-6fc4203f2b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ea4e2-2102-4b99-bea5-6fc4203f2b26.jpg?1",
             "name": "Erithizon",
             "text": "Whenever Erithizon attacks, put a +1/+1 counter on target creature of defending player's choice.",
             "colours": [
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "8bc550b8-08e8-53ad-91c8-22a02a8ff09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afda489-8397-4ad4-89dc-e8bad92db133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afda489-8397-4ad4-89dc-e8bad92db133.jpg?1",
             "name": "Ferocity",
             "text": "Whenever enchanted creature blocks or becomes blocked, you may put a +1/+1 counter on it.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "30648153-eaa7-584e-960b-cac289fbf6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1bb9e-006c-495e-8f99-d451183d2669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1bb9e-006c-495e-8f99-d451183d2669.jpg?1",
             "name": "Food Chain",
             "text": "Remove a creature you control from the game: Add X mana of any color to your mana pool, where X is the removed creature's converted mana cost plus one. This mana may be spent only to play creature spells.",
             "colours": [
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "d372719e-e01d-54f2-ba92-d8d7e3947d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be54e1d7-1388-4184-ad0d-dde4b0a3d02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be54e1d7-1388-4184-ad0d-dde4b0a3d02d.jpg?1",
             "name": "Foster",
             "text": "Whenever a creature you control is put into a graveyard, you may pay o1. If you do, reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest into your graveyard.",
             "colours": [
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "6ab3e02a-019b-5232-ae2b-dc23e758a4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb62356-72bb-4dc1-a2f9-45a3aca62e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb62356-72bb-4dc1-a2f9-45a3aca62e41.jpg?1",
             "name": "Game Preserve",
             "text": "At the beginning of your upkeep, each player reveals the top card of his or her library. If all cards revealed this way are creature cards, put those cards into play under their owners' control. (Otherwise, put them back face-down on top of their owners' libraries.)",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "7a1941a1-aa54-5efe-87f8-ca9cc9150ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc5eb8a-4531-4408-90fe-9b352d71a052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc5eb8a-4531-4408-90fe-9b352d71a052.jpg?1",
             "name": "Giant Caterpillar",
             "text": "o\nG, Sacrifice Giant Caterpillar: Put a 1/1 green Butterfly creature token with flying into play at end of turn.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "c93b8543-0015-5f25-9e5c-1f72dc78c5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d9fe16-562a-4a86-84ed-15cd90b8afc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d9fe16-562a-4a86-84ed-15cd90b8afc0.jpg?1",
             "name": "Groundskeeper",
             "text": "o1oo\nG Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -8400,7 +8400,7 @@
         },
         {
             "id": "1eaf699f-a040-518f-80dc-c0b90daa5114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a6d10-054e-4d6f-aeb7-4204f02490c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a6d10-054e-4d6f-aeb7-4204f02490c7.jpg?1",
             "name": "Horned Troll",
             "text": "oo\nG Regenerate Horned Troll.",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "0a743eaa-0317-50d6-ab52-d87aeed934a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c68a-5a6a-4d51-8dc7-5c62da81ec77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c68a-5a6a-4d51-8dc7-5c62da81ec77.jpg?1",
             "name": "Howling Wolf",
             "text": "When Howling Wolf comes into play, you may search your library for up to three Howling Wolf cards, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "50e1914f-4ebc-55e1-8a8c-32475bea9f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21c8b2d-ef0f-4839-acfc-20fd248c62cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21c8b2d-ef0f-4839-acfc-20fd248c62cf.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play under his or her control.",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "2a0b1415-c3c9-538f-8294-14cf13e3674b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406b343c-90b5-4a4d-91c3-2fddcc9a0e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406b343c-90b5-4a4d-91c3-2fddcc9a0e05.jpg?1",
             "name": "Invigorate",
             "text": "If you control a forest, you may have an opponent gain 3 life instead of paying Invigorate's mana cost.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -8534,7 +8534,7 @@
         },
         {
             "id": "25faec42-eb6b-521a-8674-c5712f71228a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6862005-32d1-473e-a28b-5dfc4b7782cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6862005-32d1-473e-a28b-5dfc4b7782cd.jpg?1",
             "name": "Land Grant",
             "text": "If you have no land cards in hand, you may reveal your hand instead of paying Land Grant's mana cost.\nSearch your library for a forest card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -8566,7 +8566,7 @@
         },
         {
             "id": "5e7c6040-9957-592e-92e3-b1c3986147b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8990efd-708a-4019-bce0-2d6409ecc004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8990efd-708a-4019-bce0-2d6409ecc004.jpg?1",
             "name": "Ley Line",
             "text": "At the beginning of each player's upkeep, that player may put a +1/+1 counter on target creature.",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "60e65200-6cc9-5bad-884f-20c4d3678a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d897088-0667-4864-91c3-5f0ac7f9b220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d897088-0667-4864-91c3-5f0ac7f9b220.jpg?1",
             "name": "Lumbering Satyr",
             "text": "All creatures gain forestwalk. (They're unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -8633,7 +8633,7 @@
         },
         {
             "id": "421b9960-a327-5686-8dcc-3aa0e4d8127d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e0015e-9b16-4787-8b4f-02d8bddb1b80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e0015e-9b16-4787-8b4f-02d8bddb1b80.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so if able.",
             "colours": [
@@ -8667,7 +8667,7 @@
         },
         {
             "id": "097ce26d-c05e-5490-9aa3-5983c5232db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a1e43-a173-45d6-ac55-363664bf6e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a1e43-a173-45d6-ac55-363664bf6e1b.jpg?1",
             "name": "Megatherium",
             "text": "Trample\nWhen Megatherium comes into play, sacrifice it unless you pay o1 for each card in your hand.",
             "colours": [
@@ -8701,7 +8701,7 @@
         },
         {
             "id": "c990b50a-091a-54c1-ba87-ac5daefac128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c6f647-f71b-4f61-9b16-774884ed52e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c6f647-f71b-4f61-9b16-774884ed52e2.jpg?1",
             "name": "Natural Affinity",
             "text": "All lands become 2/2 creatures until end of turn. They still count as lands.",
             "colours": [
@@ -8733,7 +8733,7 @@
         },
         {
             "id": "8d2e5d77-648d-52fb-82e3-15b31b4a8514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0335d282-cd1a-4be3-8eb2-82aaee91401a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0335d282-cd1a-4be3-8eb2-82aaee91401a.jpg?1",
             "name": "Pangosaur",
             "text": "Whenever a player plays a land, return Pangosaur to its owner's hand.",
             "colours": [
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "34a52b56-a83c-58d2-a1d2-bf6515cdff50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b19b453-8393-424d-9578-3ab568c92882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b19b453-8393-424d-9578-3ab568c92882.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "91d854bc-d4cb-54c4-a14f-82b9951186fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55367a94-b343-4a04-bfa9-47722e32cc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55367a94-b343-4a04-bfa9-47722e32cc45.jpg?1",
             "name": "Rushwood Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -8833,7 +8833,7 @@
         },
         {
             "id": "aa52ce2a-1ce0-59c9-be0c-d080c177b128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg?1",
             "name": "Rushwood Elemental",
             "text": "Trample\nAt the beginning of your upkeep, you may put a +1/+1 counter on Rushwood Elemental.",
             "colours": [
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "999bf15c-20d2-54ff-afd3-92269b28ec9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afde98f-a429-4eff-9d06-8582267ac74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afde98f-a429-4eff-9d06-8582267ac74b.jpg?1",
             "name": "Rushwood Herbalist",
             "text": "o\nG, oc\nT, Discard a card from your hand: Regenerate target creature.",
             "colours": [
@@ -8902,7 +8902,7 @@
         },
         {
             "id": "6f3eeb42-592e-5c92-a4e0-93af82accb1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b9c99-87d7-493c-9dc3-0c6aa4a61b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b9c99-87d7-493c-9dc3-0c6aa4a61b49.jpg?1",
             "name": "Rushwood Legate",
             "text": "If an opponent controls an island and you control a forest, you may play Rushwood Legate without paying its mana cost.",
             "colours": [
@@ -8936,7 +8936,7 @@
         },
         {
             "id": "7df73f74-0595-5404-a0e0-69671dcaa6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9269f52-1002-475d-a0f3-d652630591ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9269f52-1002-475d-a0f3-d652630591ca.jpg?1",
             "name": "Saber Ants",
             "text": "Whenever Saber Ants is dealt damage, you may put that many 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -8970,7 +8970,7 @@
         },
         {
             "id": "1530fcde-fcff-5010-a24a-82a2defecf3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e965d32c-3151-48e8-b256-0b7fa8a8a211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e965d32c-3151-48e8-b256-0b7fa8a8a211.jpg?1",
             "name": "Sacred Prey",
             "text": "When Sacred Prey becomes blocked, you gain 1 life.",
             "colours": [
@@ -9004,7 +9004,7 @@
         },
         {
             "id": "9b585ffc-b6fc-554e-ba3e-f0097ca789df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f222fe90-ac92-4ba9-b060-9b64075bf139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f222fe90-ac92-4ba9-b060-9b64075bf139.jpg?1",
             "name": "Silverglade Elemental",
             "text": "When Silverglade Elemental comes into play, you may search your library for a forest card and put that card into play. If you do, shuffle your library.",
             "colours": [
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "0c442d83-4204-5035-a6a5-2db8640bf840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc99b33-ce06-4a44-8b23-300b41b2b2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc99b33-ce06-4a44-8b23-300b41b2b2fe.jpg?1",
             "name": "Silverglade Pathfinder",
             "text": "o1o\nG, oc\nT, Discard a card from your hand: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -9073,7 +9073,7 @@
         },
         {
             "id": "5b97eeac-ef6c-535d-a2cc-f60aaf0dcc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059a70a5-d4fb-445e-af98-e81821df2c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059a70a5-d4fb-445e-af98-e81821df2c59.jpg?1",
             "name": "Snake Pit",
             "text": "Whenever an opponent plays a blue or black spell, you may put a 1/1 green Snake creature token into play.",
             "colours": [
@@ -9105,7 +9105,7 @@
         },
         {
             "id": "f353a038-93ab-5084-aa79-484fac3de6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e568503e-a886-4c8b-9d46-8520c2cdda48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e568503e-a886-4c8b-9d46-8520c2cdda48.jpg?1",
             "name": "Snorting Gahr",
             "text": "Whenever Snorting Gahr becomes blocked, it gets +2/+2 until end of turn.",
             "colours": [
@@ -9140,7 +9140,7 @@
         },
         {
             "id": "0852573b-33e0-53f6-99ea-a86a75042032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb7694f-af4c-4152-b868-528257d05154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb7694f-af4c-4152-b868-528257d05154.jpg?1",
             "name": "Spidersilk Armor",
             "text": "Creatures you control get +0/+1 and may block as though they had flying.",
             "colours": [
@@ -9172,7 +9172,7 @@
         },
         {
             "id": "1649a602-2b0a-5059-8e20-78126e5d495f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5765cb-00cd-4920-9fe8-68791048ec4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5765cb-00cd-4920-9fe8-68791048ec4a.jpg?1",
             "name": "Spontaneous Generation",
             "text": "Put a 1/1 green Saproling creature token into play for each card in your hand.",
             "colours": [
@@ -9204,7 +9204,7 @@
         },
         {
             "id": "57d40993-10fd-5d0f-9522-8f13890add59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5409b54-66ed-4add-bf43-cfeb074b1c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5409b54-66ed-4add-bf43-cfeb074b1c50.jpg?1",
             "name": "Squall",
             "text": "Squall deals 2 damage to each creature with flying.",
             "colours": [
@@ -9236,7 +9236,7 @@
         },
         {
             "id": "13cec50d-71b1-547a-884e-d213e62be04d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c845e1b8-6a39-456c-aa67-d180ae63e200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c845e1b8-6a39-456c-aa67-d180ae63e200.jpg?1",
             "name": "Squallmonger",
             "text": "o2: Squallmonger deals 1 damage to each creature with flying and each player. Any player may play this ability.",
             "colours": [
@@ -9270,7 +9270,7 @@
         },
         {
             "id": "b3a58689-1483-555e-85e4-daddcc8f0b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8abca3-6e31-49cd-b9bf-86ad68e1cc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8abca3-6e31-49cd-b9bf-86ad68e1cc83.jpg?1",
             "name": "Stamina",
             "text": "Attacking doesn't cause enchanted creature to tap.\nSacrifice Stamina: Regenerate enchanted creature.",
             "colours": [
@@ -9304,7 +9304,7 @@
         },
         {
             "id": "9c94d192-b8be-5ffc-94da-513c4b067cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61db44-80dc-4058-9c9d-65cd18e63fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61db44-80dc-4058-9c9d-65cd18e63fd4.jpg?1",
             "name": "Sustenance",
             "text": "o1, Sacrifice a land: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -9336,7 +9336,7 @@
         },
         {
             "id": "1d46afb0-3dfe-5fc7-8554-b52e03977b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0146a689-4817-4849-a90d-4cc64566960d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0146a689-4817-4849-a90d-4cc64566960d.jpg?1",
             "name": "Tiger Claws",
             "text": "You may play Tiger Claws any time you could play an instant.\nEnchanted creature gets +1/+1 and has trample.",
             "colours": [
@@ -9370,7 +9370,7 @@
         },
         {
             "id": "daa0bdb1-e59a-5374-8b23-4e74e14a1dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843e801e-1ceb-4e3f-82e6-3c092051ba8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843e801e-1ceb-4e3f-82e6-3c092051ba8c.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "5fafe883-8d82-5ec8-9602-d6cfdc50eb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4797556c-df74-4e13-b8fb-8b0b58c92b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4797556c-df74-4e13-b8fb-8b0b58c92b4c.jpg?1",
             "name": "Venomous Breath",
             "text": "At end of combat, destroy all creatures that blocked or were blocked by target creature this turn.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "fb46813f-66b6-5ebe-b810-6644ebdea45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479fc902-ce94-4a6b-af87-4645387a46c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479fc902-ce94-4a6b-af87-4645387a46c6.jpg?1",
             "name": "Venomous Dragonfly",
             "text": "Flying\nWhenever Venomous Dragonfly blocks or becomes blocked by a creature, destroy that creature at end of combat.",
             "colours": [
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "dc44433b-d18f-51b5-94d0-43ad3783cbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed69d2-f5fb-4173-b939-5abdb48b82b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed69d2-f5fb-4173-b939-5abdb48b82b4.jpg?1",
             "name": "Vernal Equinox",
             "text": "Any player may play creature and enchantment spells any time he or she could play an instant.",
             "colours": [
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "6af00dfd-76ea-55ef-a018-d9e05cac7d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c9158-faed-42ae-9f6b-71dee49ff79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c9158-faed-42ae-9f6b-71dee49ff79f.jpg?1",
             "name": "Vine Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)\nYou may play Vine Dryad any time you could play an instant.\nYou may remove a green card in your hand from the game instead of paying Vine Dryad's mana cost.",
             "colours": [
@@ -9534,7 +9534,7 @@
         },
         {
             "id": "b2cc959a-ded1-54a0-a53a-8e756d083256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e660241f-0976-4206-8149-7dac8466a2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e660241f-0976-4206-8149-7dac8466a2a3.jpg?1",
             "name": "Vine Trellis",
             "text": "(Walls can't attack.)\noc\nT: Add one green mana to your mana pool.",
             "colours": [
@@ -9569,7 +9569,7 @@
         },
         {
             "id": "8a7f7fca-dcf9-594c-b98e-0e98be8e0bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676ccbb-91d2-4f26-b3a5-ccb1a21bdebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676ccbb-91d2-4f26-b3a5-ccb1a21bdebf.jpg?1",
             "name": "Assembly Hall",
             "text": "o4, oc\nT: Reveal a creature card in your hand, search your library for a copy of that card, and put the card into your hand. Then shuffle your library.",
             "colours": [],
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "e9e4e693-6417-5c2b-ba86-c3b0cc444b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e2e59-1527-4c61-9cc9-dcaf1181bd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e2e59-1527-4c61-9cc9-dcaf1181bd43.jpg?1",
             "name": "Barbed Wire",
             "text": "At the beginning of each player's upkeep, Barbed Wire deals 1 damage to that player.\no2: Prevent the next 1 damage that would be dealt by Barbed Wire this turn.",
             "colours": [],
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "9115773d-8455-53d0-a66b-9bf3941c555d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da9395-42e9-4408-832d-74ea4b01256b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da9395-42e9-4408-832d-74ea4b01256b.jpg?1",
             "name": "Bargaining Table",
             "text": "o\nX, oc\nT: Draw a card. X is the number of cards in an opponent's hand.",
             "colours": [],
@@ -9653,7 +9653,7 @@
         },
         {
             "id": "a1a74fb8-5eef-5aa3-be00-aa9789256544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab65242-17ad-4c22-9c70-aac8076d1b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab65242-17ad-4c22-9c70-aac8076d1b4c.jpg?1",
             "name": "Credit Voucher",
             "text": "o2, oc\nT, Sacrifice Credit Voucher: Shuffle any number of cards from your hand into your library, then draw that many cards.",
             "colours": [],
@@ -9681,7 +9681,7 @@
         },
         {
             "id": "f1e4acc1-1bb7-57ea-9d61-edb3e803ab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85ad08d-1120-411a-8bbe-ac93a56476bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85ad08d-1120-411a-8bbe-ac93a56476bd.jpg?1",
             "name": "Crenellated Wall",
             "text": "(Walls can't attack.)\noc\nT: Target creature gets +0/+4 until end of turn.",
             "colours": [],
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "b3c9ceac-183f-510e-bd8d-aaca18645740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7084ba-cca6-4fb9-b21b-b79e7d74c5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7084ba-cca6-4fb9-b21b-b79e7d74c5c0.jpg?1",
             "name": "Crooked Scales",
             "text": "o4, oc\nT: Choose target creature you control and target creature an opponent controls. Flip a coin. If you win the flip, destroy the creature the opponent controls. If you lose the flip, destroy the creature you control unless you pay o3 and reflip the coin.",
             "colours": [],
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "f06f1beb-865e-5cc5-b2d5-5192fde6b6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa6d6c-c1cd-46f3-8430-94f67be55bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa6d6c-c1cd-46f3-8430-94f67be55bf7.jpg?1",
             "name": "Crumbling Sanctuary",
             "text": "For each 1 damage that would be dealt to a player, that player removes the top card of his or her library from the game instead.",
             "colours": [],
@@ -9768,7 +9768,7 @@
         },
         {
             "id": "00c03a00-014f-5858-9a84-dbd8a3bfceb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab196d8d-5d1c-4f0e-a924-37774db02821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab196d8d-5d1c-4f0e-a924-37774db02821.jpg?1",
             "name": "Distorting Lens",
             "text": "oc\nT: Target permanent becomes the color of your choice until end of turn.",
             "colours": [],
@@ -9796,7 +9796,7 @@
         },
         {
             "id": "77bf111e-4e00-5fd2-82a4-e72b579c836a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d22400-39f6-444d-b508-783a7df7e945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d22400-39f6-444d-b508-783a7df7e945.jpg?1",
             "name": "Eye of Ramos",
             "text": "oc\nT: Add one blue mana to your mana pool.\nSacrifice Eye of Ramos: Add one blue mana to your mana pool.",
             "colours": [],
@@ -9826,7 +9826,7 @@
         },
         {
             "id": "1858f8ca-4c2f-5fa2-a17f-e9c8e2a9913d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb99d982-8ab1-4d6a-ba24-58ac23a9b9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb99d982-8ab1-4d6a-ba24-58ac23a9b9e7.jpg?1",
             "name": "General's Regalia",
             "text": "o3: The next time a source of your choice would deal damage to you this turn, that damage is dealt to target creature you control instead.",
             "colours": [],
@@ -9854,7 +9854,7 @@
         },
         {
             "id": "2f46d828-c3a5-5cb2-a822-ad4752f5a7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0046226-7563-4345-aa4b-a2c732c2780a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0046226-7563-4345-aa4b-a2c732c2780a.jpg?1",
             "name": "Heart of Ramos",
             "text": "oc\nT: Add one red mana to your mana pool.\nSacrifice Heart of Ramos: Add one red mana to your mana pool.",
             "colours": [],
@@ -9884,7 +9884,7 @@
         },
         {
             "id": "ae08d275-a72c-561b-94f4-a646656b2765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028e5e18-b639-4461-87e4-5306371440b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028e5e18-b639-4461-87e4-5306371440b5.jpg?1",
             "name": "Henge Guardian",
             "text": "o2: Henge Guardian gains trample until end of turn.",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "1f43bdff-8e10-5f4e-850a-e22741bc2847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e04462-1d10-47df-b456-211dd0a87891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e04462-1d10-47df-b456-211dd0a87891.jpg?1",
             "name": "Horn of Plenty",
             "text": "Whenever a player plays a spell, he or she may pay o1. If that player does, he or she draws a card at end of turn.",
             "colours": [],
@@ -9944,7 +9944,7 @@
         },
         {
             "id": "4e74c3c3-1f51-5eaf-979c-ddd0d345522a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f541-8e9d-43b0-b688-e3f2e7fa55c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f541-8e9d-43b0-b688-e3f2e7fa55c8.jpg?1",
             "name": "Horn of Ramos",
             "text": "oc\nT: Add one green mana to your mana pool.\nSacrifice Horn of Ramos: Add one green mana to your mana pool.",
             "colours": [],
@@ -9974,7 +9974,7 @@
         },
         {
             "id": "471a2ba6-ac9a-501c-8a5a-7896d04fffe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d212-faf2-4a6f-a338-d9e5014b56d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d212-faf2-4a6f-a338-d9e5014b56d5.jpg?1",
             "name": "Iron Lance",
             "text": "o3, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [],
@@ -10002,7 +10002,7 @@
         },
         {
             "id": "62593a3b-b313-57da-9a7f-fd0425db1a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab076bc-e4c3-42a1-b701-9bc49bcc3cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab076bc-e4c3-42a1-b701-9bc49bcc3cdd.jpg?1",
             "name": "Jeweled Torque",
             "text": "As Jeweled Torque comes into play, choose a color.\nWhenever a player plays a spell of the chosen color, you may pay o2. If you do, you gain 2 life.",
             "colours": [],
@@ -10030,7 +10030,7 @@
         },
         {
             "id": "0cdbc754-a88a-5b87-944f-ff6e0485d9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e65a06a-e7af-422a-9481-446731009935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e65a06a-e7af-422a-9481-446731009935.jpg?1",
             "name": "Kyren Archive",
             "text": "At the beginning of your upkeep, you may remove the top card of your library from the game face down.\no5, Discard your hand, Sacrifice Kyren Archive: Put all cards removed from the game with Kyren Archive into their owner's hand.",
             "colours": [],
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "13943c74-8688-5cb5-866b-4d7017fcc459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8318bb-bc3c-45e9-bd57-60ae72b6f8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8318bb-bc3c-45e9-bd57-60ae72b6f8b0.jpg?1",
             "name": "Kyren Toy",
             "text": "o1, oc\nT: Put a charge counter on Kyren Toy.\noc\nT, Remove X charge counters from Kyren Toy: Add X plus one colorless mana to your mana pool.",
             "colours": [],
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "3198d04a-fdfb-58ab-9e7c-9ce9fa321ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4785ed7-c948-4ad2-b24d-2f45806d9fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4785ed7-c948-4ad2-b24d-2f45806d9fcc.jpg?1",
             "name": "Magistrate's Scepter",
             "text": "o4, oc\nT: Put a charge counter on Magistrate's Scepter.\noc\nT, Remove three charge counters from Magistrate's Scepter: Take another turn after this one.",
             "colours": [],
@@ -10114,7 +10114,7 @@
         },
         {
             "id": "69a28d00-0c9b-5d4e-8f31-52c66cee9948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ad3531-399c-4897-b0ee-ad2a26445a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ad3531-399c-4897-b0ee-ad2a26445a17.jpg?1",
             "name": "Mercadian Atlas",
             "text": "At the end of your turn, if you didn't play a land this turn, you may draw a card.",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "f2455441-5453-54b9-94cb-d5555f39014b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395a1a8a-785f-442b-8e95-8b4ca44af2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395a1a8a-785f-442b-8e95-8b4ca44af2a3.jpg?1",
             "name": "Mercadian Lift",
             "text": "o1, oc\nT: Put a winch counter on Mercadian Lift.\noc\nT, Remove X winch counters from Mercadian Lift: Put a creature card with converted mana cost X from your hand into play.",
             "colours": [],
@@ -10170,7 +10170,7 @@
         },
         {
             "id": "6fe07575-9bff-5fc9-a8b6-252121be4def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f6be53-7a20-4e6b-a6ce-11cba06af8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f6be53-7a20-4e6b-a6ce-11cba06af8cb.jpg?1",
             "name": "Monkey Cage",
             "text": "When a creature comes into play, sacrifice Monkey Cage and put into play a number of 2/2 green Ape creature tokens equal to that creature's converted mana cost.",
             "colours": [],
@@ -10198,7 +10198,7 @@
         },
         {
             "id": "4fd135ce-cdec-5b28-9eb9-e0944f45719e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89414770-2a19-4baf-9b18-76104b7b0b9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89414770-2a19-4baf-9b18-76104b7b0b9a.jpg?1",
             "name": "Panacea",
             "text": "o\nXo\nX, oc\nT: Prevent the next X damage that would be dealt to target creature or player this turn.",
             "colours": [],
@@ -10226,7 +10226,7 @@
         },
         {
             "id": "23454f96-f19c-550c-b316-28d89d34b419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a578599c-7d90-4881-b59a-9cf64b90d917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a578599c-7d90-4881-b59a-9cf64b90d917.jpg?1",
             "name": "Power Matrix",
             "text": "oc\nT: Target creature gets +1/+1 and gains flying, first strike, and trample until end of turn.",
             "colours": [],
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "7d1c7345-b7ed-51c0-8da0-276ee3039254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83093cdf-0b12-419c-a748-21acf166e195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83093cdf-0b12-419c-a748-21acf166e195.jpg?1",
             "name": "Puffer Extract",
             "text": "o\nX, oc\nT: Target creature you control gets +X/+X until end of turn. Destroy it at end of turn.",
             "colours": [],
@@ -10282,7 +10282,7 @@
         },
         {
             "id": "a2969c6f-6d31-5233-b521-67b6b499f249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fc9fc-a0f9-4f56-8368-2d7e1fec5ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fc9fc-a0f9-4f56-8368-2d7e1fec5ba0.jpg?1",
             "name": "Rishadan Pawnshop",
             "text": "o2, oc\nT: Shuffle target card in play you control into its owner's library.",
             "colours": [],
@@ -10310,7 +10310,7 @@
         },
         {
             "id": "5a1ec2fa-47d4-5619-9d60-f989609e9683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f071957c-9bea-4d00-9ffd-30f98d57b8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f071957c-9bea-4d00-9ffd-30f98d57b8d2.jpg?1",
             "name": "Skull of Ramos",
             "text": "oc\nT: Add one black mana to your mana pool.\nSacrifice Skull of Ramos: Add one black mana to your mana pool.",
             "colours": [],
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "b45aed8a-1df5-5322-bd96-4a4a8bfe999a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3b999d-8e63-4647-a921-15e169022096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3b999d-8e63-4647-a921-15e169022096.jpg?1",
             "name": "Tooth of Ramos",
             "text": "oc\nT: Add one white mana to your mana pool.\nSacrifice Tooth of Ramos: Add one white mana to your mana pool.",
             "colours": [],
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "4328ab7b-be98-5a8d-b92f-c8e04e1f6a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3992a-553c-4032-b144-55aad2f909f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3992a-553c-4032-b144-55aad2f909f1.jpg?1",
             "name": "Toymaker",
             "text": "o1, oc\nT, Discard a card from your hand: Target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost until end of turn. (It retains its abilities.)",
             "colours": [],
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "0ab05aef-dcd1-531d-8481-b0dc5342a517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400edfe9-9efa-43f9-b713-13ad4eae2fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400edfe9-9efa-43f9-b713-13ad4eae2fa4.jpg?1",
             "name": "Worry Beads",
             "text": "At the beginning of each player's upkeep, that player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -10429,7 +10429,7 @@
         },
         {
             "id": "c5a11a39-85cf-5914-a5b8-8ec6e27332ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b03c30-c2b8-4207-b675-26c59c40a7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b03c30-c2b8-4207-b675-26c59c40a7e5.jpg?1",
             "name": "Dust Bowl",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no3, oc\nT, Sacrifice a land: Destroy target nonbasic land.",
             "colours": [],
@@ -10457,7 +10457,7 @@
         },
         {
             "id": "2d077383-597c-595e-b660-3dd14a407fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f352c3-4b63-4174-b2b4-6c19fb8c06ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f352c3-4b63-4174-b2b4-6c19fb8c06ff.jpg?1",
             "name": "Fountain of Cho",
             "text": "Fountain of Cho comes into play tapped.\noc\nT: Put a storage counter on Fountain of Cho.\noc\nT, Remove any number of storage counters from Fountain of Cho: Add one white mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "05a58920-2e74-53aa-aef2-2c97eb96a871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0582b42f-5ae5-4be2-ba2d-ed62b3cb20c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0582b42f-5ae5-4be2-ba2d-ed62b3cb20c5.jpg?1",
             "name": "Henge of Ramos",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "137ab8c3-92ca-51a7-a473-5946996ee8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7aafb7-6870-4d09-a191-70786766c459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7aafb7-6870-4d09-a191-70786766c459.jpg?1",
             "name": "Hickory Woodlot",
             "text": "Hickory Woodlot comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Hickory Woodlot: Add two green mana to your mana pool. If there are no depletion counters on Hickory Woodlot, sacrifice it.",
             "colours": [],
@@ -10545,7 +10545,7 @@
         },
         {
             "id": "07563a4b-638a-5a4d-93bd-18c8d22d7898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c58683-65a6-4df9-8952-458e397b1374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c58683-65a6-4df9-8952-458e397b1374.jpg?1",
             "name": "High Market",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice a creature: You gain 1 life.",
             "colours": [],
@@ -10573,7 +10573,7 @@
         },
         {
             "id": "bb583cde-94fe-5f98-891e-53632e97357b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f787cb6-78cb-4baa-a9cf-cee8b7d8d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f787cb6-78cb-4baa-a9cf-cee8b7d8d6b1.jpg?1",
             "name": "Mercadian Bazaar",
             "text": "Mercadian Bazaar comes into play tapped.\noc\nT: Put a storage counter on Mercadian Bazaar.\noc\nT, Remove any number of storage counters from Mercadian Bazaar: Add one red mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "109559a0-b9a6-5224-8936-47f492378a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc9d1e0-c8f4-4bac-90d4-8167f7a1515a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc9d1e0-c8f4-4bac-90d4-8167f7a1515a.jpg?1",
             "name": "Peat Bog",
             "text": "Peat Bog comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Peat Bog: Add two black mana to your mana pool. If there are no depletion counters on Peat Bog, sacrifice it.",
             "colours": [],
@@ -10633,7 +10633,7 @@
         },
         {
             "id": "bd3043d9-d3d3-582d-9ebc-970936a83279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115cab84-60d7-4bf2-9beb-b4ed7b5ceaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115cab84-60d7-4bf2-9beb-b4ed7b5ceaf4.jpg?1",
             "name": "Remote Farm",
             "text": "Remote Farm comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Remote Farm: Add two white mana to your mana pool. If there are no depletion counters on Remote Farm, sacrifice it.",
             "colours": [],
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "5a243366-749e-506b-b91e-f7e835e5f63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477a1f53-5cdf-4b45-b584-2e36b31a3fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477a1f53-5cdf-4b45-b584-2e36b31a3fdb.jpg?1",
             "name": "Rishadan Port",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Tap target land.",
             "colours": [],
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "cf4d1432-726d-54fd-9525-9d772fa0f5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c315c72c-3e2f-4aff-b7d7-2f709ccec332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c315c72c-3e2f-4aff-b7d7-2f709ccec332.jpg?1",
             "name": "Rushwood Grove",
             "text": "Rushwood Grove comes into play tapped.\noc\nT: Put a storage counter on Rushwood Grove.\noc\nT, Remove any number of storage counters from Rushwood Grove: Add one green mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10721,7 +10721,7 @@
         },
         {
             "id": "381d605b-6d1c-52fd-94df-48b6fd943ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bc7c6b-2e3d-42d1-b2bb-b37b6f34d33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bc7c6b-2e3d-42d1-b2bb-b37b6f34d33b.jpg?1",
             "name": "Sandstone Needle",
             "text": "Sandstone Needle comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Sandstone Needle: Add two red mana to your mana pool. If there are no depletion counters on Sandstone Needle, sacrifice it.",
             "colours": [],
@@ -10751,7 +10751,7 @@
         },
         {
             "id": "b7a85418-b075-5000-a64c-0f8fb0213afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a69122-19c0-47ec-8bea-478511ba88e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a69122-19c0-47ec-8bea-478511ba88e6.jpg?1",
             "name": "Saprazzan Cove",
             "text": "Saprazzan Cove comes into play tapped.\noc\nT: Put a storage counter on Saprazzan Cove.\noc\nT, Remove any number of storage counters from Saprazzan Cove: Add one blue mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10781,7 +10781,7 @@
         },
         {
             "id": "cd100140-bae3-58f2-8232-5f31bb5e35e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006871fd-2641-42cb-a2ac-a33d05fc5a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006871fd-2641-42cb-a2ac-a33d05fc5a35.jpg?1",
             "name": "Saprazzan Skerry",
             "text": "Saprazzan Skerry comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Saprazzan Skerry: Add two blue mana to your mana pool. If there are no depletion counters on Saprazzan Skerry, sacrifice it.",
             "colours": [],
@@ -10811,7 +10811,7 @@
         },
         {
             "id": "ab421e7e-7e06-57cd-9138-27163b98a0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc199d1-970b-489f-b713-8285151f16ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc199d1-970b-489f-b713-8285151f16ae.jpg?1",
             "name": "Subterranean Hangar",
             "text": "Subterranean Hangar comes into play tapped.\noc\nT: Put a storage counter on Subterranean Hangar.\noc\nT, Remove any number of storage counters from Subterranean Hangar: Add one black mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "90bc35fb-4324-58d4-b935-3f8e84eb13a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0481db-15ae-46b4-89a3-01c95a9626c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0481db-15ae-46b4-89a3-01c95a9626c7.jpg?1",
             "name": "Tower of the Magistrate",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Target creature gains protection from artifacts until end of turn.",
             "colours": [],
@@ -10869,7 +10869,7 @@
         },
         {
             "id": "3c75e5ee-810f-54ae-968d-3e42d270a023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edf5042-d185-424e-922d-c0bd4ce3e8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edf5042-d185-424e-922d-c0bd4ce3e8b0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "de345860-f1ed-5fe4-806e-ffda52466c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44214f36-8bb3-4a32-8046-3ecdfff8407b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44214f36-8bb3-4a32-8046-3ecdfff8407b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10945,7 +10945,7 @@
         },
         {
             "id": "1ff3b87f-6358-5690-b3c9-a3d8aa6e0e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e536cc-e724-43d4-9fe3-dfb4952613cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e536cc-e724-43d4-9fe3-dfb4952613cb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10983,7 +10983,7 @@
         },
         {
             "id": "046ca9b7-5b11-5f77-9dda-8f329c9e24b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8fd867-8be1-4ee7-bb67-32c3f22db59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8fd867-8be1-4ee7-bb67-32c3f22db59e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11021,7 +11021,7 @@
         },
         {
             "id": "21ff94c9-782c-5f66-b85b-db1228c188c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae77e8-1230-4a6e-8c75-c99d2741a509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae77e8-1230-4a6e-8c75-c99d2741a509.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11059,7 +11059,7 @@
         },
         {
             "id": "c1f855e1-40b6-5437-85ef-2d04a3b1d58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a38509a-2b74-42a0-af91-ed453e463b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a38509a-2b74-42a0-af91-ed453e463b95.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11097,7 +11097,7 @@
         },
         {
             "id": "1eabfcbf-ae04-5290-b5d3-f23785430fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d83856-2201-4c30-bfcf-9cab62545201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d83856-2201-4c30-bfcf-9cab62545201.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11135,7 +11135,7 @@
         },
         {
             "id": "0619e868-e046-54ad-8188-331e386b3912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fedd66-e547-492c-ad0d-9c7b527bdd17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fedd66-e547-492c-ad0d-9c7b527bdd17.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11173,7 +11173,7 @@
         },
         {
             "id": "94a2fb92-ebb8-5f9f-8683-38e9518e7331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72020810-bfa3-42d5-ad0d-6d02a6fe1b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72020810-bfa3-42d5-ad0d-6d02a6fe1b31.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11211,7 +11211,7 @@
         },
         {
             "id": "e341f86f-6b40-5e23-91a0-01f80597e73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2436ceb-05c0-40e6-b370-a6f02f4adbe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2436ceb-05c0-40e6-b370-a6f02f4adbe4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11249,7 +11249,7 @@
         },
         {
             "id": "1ca6a99e-0980-5a34-b0f6-79cf08ba2f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1017347b-6b1a-4a2f-9147-98acad779616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1017347b-6b1a-4a2f-9147-98acad779616.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11287,7 +11287,7 @@
         },
         {
             "id": "24635263-dfc2-5e04-9f58-808fb97ae799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0243d2-5fde-489f-8113-4ece0511cb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0243d2-5fde-489f-8113-4ece0511cb5c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11325,7 +11325,7 @@
         },
         {
             "id": "d103e41a-10e4-5d13-9366-0321a4412d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5fff1-7a60-4e50-893a-8177cd62bf82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5fff1-7a60-4e50-893a-8177cd62bf82.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11363,7 +11363,7 @@
         },
         {
             "id": "3a5253fc-53dd-544e-8782-7a7ea09e838c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd12ed-e512-43d8-919d-478b18674deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd12ed-e512-43d8-919d-478b18674deb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11401,7 +11401,7 @@
         },
         {
             "id": "49508501-518b-5ebd-a756-c5033194fffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921ce16-8ed8-41d7-a2b4-9e62f44ac8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921ce16-8ed8-41d7-a2b4-9e62f44ac8d6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11439,7 +11439,7 @@
         },
         {
             "id": "ec26167c-d263-578c-b42b-e0cd6ac35a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f4311-9feb-4c63-8b4c-32ddd38382e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f4311-9feb-4c63-8b4c-32ddd38382e0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11477,7 +11477,7 @@
         },
         {
             "id": "d0ce4b65-ae5c-5393-9714-d5ae0eac2ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695de19e-801f-4f08-b44c-b0726e4aced0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695de19e-801f-4f08-b44c-b0726e4aced0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11515,7 +11515,7 @@
         },
         {
             "id": "233c7c1a-bec5-54e9-95f2-2c69f210111f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38e4ee7-6965-4e12-95d4-c9de1dbb014c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38e4ee7-6965-4e12-95d4-c9de1dbb014c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "e2ebdd87-99ae-55f4-89fa-6c2903e1d996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1973049-2d42-4091-9703-189ba374254d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1973049-2d42-4091-9703-189ba374254d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11591,7 +11591,7 @@
         },
         {
             "id": "da0abe46-d341-5aa2-9be1-3ea5ec0e8147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c4806b-a31a-4026-9876-eab4d0d1694b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c4806b-a31a-4026-9876-eab4d0d1694b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/MOM.json
+++ b/Assets/Resources/Sets/MOM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "dff87229-6257-5fe4-907e-694ad4f8974e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg?1",
             "name": "Invasion of Ravnica // Guildpact Paragon",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ravnica enters the battlefield, exile target nonland permanent an opponent controls that isn't exactly two colors.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "3e1b355c-0a6c-579a-a0d3-96010048ad39",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg?1",
             "name": "Invasion of Ravnica // Guildpact Paragon",
             "text": "Whenever you cast a spell that's exactly two colors, look at the top six cards of your library. You may reveal a card that's exactly two colors from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "eeacede0-193a-53ec-b9c6-ec616b960c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7017afb-4c7c-4c8d-9c9d-3f056a55561e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7017afb-4c7c-4c8d-9c9d-3f056a55561e.jpg?1",
             "name": "Aerial Boost",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "79bc98eb-7179-58d4-b472-4bbdc438ffa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165357cc-ec74-490f-aec3-7048bb43c8f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165357cc-ec74-490f-aec3-7048bb43c8f9.jpg?1",
             "name": "Alabaster Host Intercessor",
             "text": "When Alabaster Host Intercessor enters the battlefield, exile target creature an opponent controls until Alabaster Host Intercessor leaves the battlefield.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -132,7 +132,7 @@
         },
         {
             "id": "b1334ce9-0115-51bc-bc46-c1303be41f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbd934a-39c4-4ce7-af2a-34ca226d7f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbd934a-39c4-4ce7-af2a-34ca226d7f23.jpg?1",
             "name": "Alabaster Host Sanctifier",
             "text": "Lifelink",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "3769fbfe-178d-5ac1-ac29-ba0f3d97bf60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fb5876-5b47-4a05-be57-7ad3890c8953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fb5876-5b47-4a05-be57-7ad3890c8953.jpg?1",
             "name": "Angelic Intervention",
             "text": "Target creature or planeswalker you control gains protection from colorless or from the color of your choice until end of turn. If it's a creature, put a +1/+1 counter on it. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything with that quality.)",
             "colours": [
@@ -199,7 +199,7 @@
         },
         {
             "id": "6b4e232f-3750-5754-8397-0549d3f50e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed6263-bdd7-4013-ac8c-9b652d71a0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed6263-bdd7-4013-ac8c-9b652d71a0db.jpg?1",
             "name": "Archangel Elspeth",
             "text": "+1: Create a 1/1 white Soldier creature token with lifelink.\n\u22122: Put two +1/+1 counters on target creature. It becomes an Angel in addition to its other types and gains flying.\n\u22126: Return all nonland permanent cards with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "b1ef0362-a7c1-5b34-b855-9a7a6ac679c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d89bd5-95cc-41fc-aea2-2dde52231919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d89bd5-95cc-41fc-aea2-2dde52231919.jpg?1",
             "name": "Attentive Skywarden",
             "text": "Flying\nWhenever Attentive Skywarden deals combat damage to a player or battle, transform up to one target Incubator token you control.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "8f2bc04a-f900-5858-a34c-caaa9ce43239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896043a7-c7a2-4542-8739-7b4f09c6e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896043a7-c7a2-4542-8739-7b4f09c6e1f1.jpg?1",
             "name": "Bola Slinger",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nWhenever this creature attacks, tap target artifact or creature an opponent controls.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "e56f58d4-9bbb-5cea-8163-c00ed7d321b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e1cc7d-e645-4b0e-b117-63f93528ed12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e1cc7d-e645-4b0e-b117-63f93528ed12.jpg?1",
             "name": "Boon-Bringer Valkyrie",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following abilities until end of turn.)\nFlying, first strike, lifelink",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "ef54fb63-ae5a-5fb5-ae5d-a0776e4170c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a45d4d-d16a-43c6-843c-916d4629aae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a45d4d-d16a-43c6-843c-916d4629aae1.jpg?1",
             "name": "Cut Short",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target planeswalker that was activated this turn or tapped creature.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "4c96883b-2428-59be-8d75-27d9ecdf1fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305a8d3-5403-4483-92af-863dc91c6084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305a8d3-5403-4483-92af-863dc91c6084.jpg?1",
             "name": "Dusk Legion Duelist",
             "text": "Vigilance\nWhenever one or more +1/+1 counters are put on Dusk Legion Duelist, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -413,7 +413,7 @@
         },
         {
             "id": "cd624224-94be-5a95-8e48-704e79f20a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "Vigilance\nWhenever a source an opponent controls deals damage to you or a permanent you control, that source's controller loses 2 life unless they pay {1}.\n{2}{W}, Sacrifice three other creatures: Exile Elesh Norn, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "029993c5-80e2-5996-9c45-0db28f177b29",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Incubate 2 five times, then transform all Incubator tokens you control.\nII \u2014 Creatures you control get +1/+1 and gain double strike until end of turn.\nIII \u2014 Destroy all other permanents except for artifacts, lands, and Phyrexians. Exile The Argent Etchings, then return it to the battlefield (front face up).",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "ecfc1058-5e8d-50da-af6b-e51d21576d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03a480f-de67-4611-9db7-c0c3d020f597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03a480f-de67-4611-9db7-c0c3d020f597.jpg?1",
             "name": "Elspeth's Smite",
             "text": "Elspeth's Smite deals 3 damage to target attacking or blocking creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "02954227-4a8f-5827-80ff-94da80092b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0680eb-ceca-44d9-9654-78ea2ccfce17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0680eb-ceca-44d9-9654-78ea2ccfce17.jpg?1",
             "name": "Enduring Bondwarden",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nWhen this creature dies, put its counters on target creature you control.",
             "colours": [
@@ -557,7 +557,7 @@
         },
         {
             "id": "38a27611-d385-5aed-b0a4-adc36b0bdb6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2f3c52-8d6a-411a-aa62-cbb08a144351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2f3c52-8d6a-411a-aa62-cbb08a144351.jpg?1",
             "name": "Golden-Scale Aeronaut",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nFlying",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "cd727ebf-260c-5a67-8eb1-9720c8a19ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9503a1e6-f0bf-44d0-a28b-56fbfcff1ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9503a1e6-f0bf-44d0-a28b-56fbfcff1ff2.jpg?1",
             "name": "Guardian of Ghirapur",
             "text": "Flying\nWhen Guardian of Ghirapur enters the battlefield, exile up to one other target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -628,7 +628,7 @@
         },
         {
             "id": "53a210da-e9bb-5c71-815a-c36fc7500333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "When Heliod, the Radiant Dawn enters the battlefield, return target enchantment card that isn't a God from your graveyard to your hand.\n{3}{PU}: Transform Heliod, the Radiant Dawn. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "a7a0ce43-9590-5d59-b64c-c1d94a442fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "You may cast spells as though they had flash.\nSpells you cast cost {1} less to cast for each card your opponents have drawn this turn.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "7764ceac-28bc-5465-ae2d-0afe9292071f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2777f8b5-2f8e-4cb8-9206-8a4978488657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2777f8b5-2f8e-4cb8-9206-8a4978488657.jpg?1",
             "name": "Infected Defector",
             "text": "When Infected Defector dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "b8a56698-abaa-57c9-9d50-068770d81041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17e624-219a-4e76-bfe0-f49c9ddd4a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17e624-219a-4e76-bfe0-f49c9ddd4a6d.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "3ce43aa0-a3e8-5872-a8a6-68d9031e1221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg?1",
             "name": "Invasion of Belenon // Belenon War Anthem",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Belenon enters the battlefield, create a 2/2 white and blue Knight creature token with vigilance.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "2dad5bd1-5c96-5f61-8635-7412cb471338",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg?1",
             "name": "Invasion of Belenon // Belenon War Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "2e436661-f64b-5541-b292-12b1644223a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg?1",
             "name": "Invasion of Dominaria // Serra Faithkeeper",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Dominaria enters the battlefield, you gain 4 life and draw a card.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "5965458e-584a-56fb-be09-3f70ebe73a32",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg?1",
             "name": "Invasion of Dominaria // Serra Faithkeeper",
             "text": "Flying, vigilance",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "df0b4721-e8a6-510a-9edb-5d57333b6a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg?1",
             "name": "Invasion of Gobakhan // Lightshield Array",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Gobakhan enters the battlefield, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A spell cast this way costs {2} more to cast.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "7c593a6e-750f-5c06-80df-c34807edee6f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg?1",
             "name": "Invasion of Gobakhan // Lightshield Array",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature that attacked this turn.\nSacrifice Lightshield Array: Creatures you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "d4b67c58-ae61-580e-8ced-c43619cfddad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg?1",
             "name": "Invasion of Theros // Ephara, Ever-Sheltering",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Theros enters the battlefield, search your library for an Aura, God, or Demigod card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1012,7 +1012,7 @@
         },
         {
             "id": "8dc7be16-fed7-53d9-9b98-7134ceb60053",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg?1",
             "name": "Invasion of Theros // Ephara, Ever-Sheltering",
             "text": "Ephara, Ever-Sheltering has lifelink and indestructible as long as you control at least three other enchantments.\nWhenever another enchantment enters the battlefield under your control, draw a card.",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "e8af9899-ac9c-5ff7-9878-55622a285ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535b69f-247d-49c9-97e1-d988700578ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535b69f-247d-49c9-97e1-d988700578ab.jpg?1",
             "name": "Kithkin Billyrider",
             "text": "Double strike",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "65baf74e-2939-5b3b-9053-d5a7f267ac1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a3108b-c33d-47c5-984b-01fa257fbd79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a3108b-c33d-47c5-984b-01fa257fbd79.jpg?1",
             "name": "Knight of the New Coalition",
             "text": "Vigilance\nWhen Knight of the New Coalition enters the battlefield, create a 2/2 white and blue Knight creature token with vigilance.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "0712e12f-dc48-5b5c-ac2c-eb8f0cf2654f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2ad652-2406-491a-9f22-23e974f943d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2ad652-2406-491a-9f22-23e974f943d7.jpg?1",
             "name": "Knight-Errant of Eos",
             "text": "Convoke\nWhen Knight-Errant of Eos enters the battlefield, look at the top six cards of your library. You may reveal up to two creature cards with mana value X or less from among them, where X is the number of creatures that convoked Knight-Errant of Eos. Put the revealed cards into your hand, then shuffle.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "a1c727fd-d8f3-59b5-9e88-b596fa679eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4705327-ada6-4575-82fc-351e183d060e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4705327-ada6-4575-82fc-351e183d060e.jpg?1",
             "name": "Kor Halberd",
             "text": "Equipped creature gets +1/+1 and has vigilance.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "b4b99f38-8045-5d35-b12c-40c33e22398b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75665c2f-a100-4e3f-be8e-b5cc3c9a090b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75665c2f-a100-4e3f-be8e-b5cc3c9a090b.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "3dcce702-d858-5130-827e-3f63c095fc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d387b608-ba4e-49c8-bd81-37594290a352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d387b608-ba4e-49c8-bd81-37594290a352.jpg?1",
             "name": "Norn's Inquisitor",
             "text": "When Norn's Inquisitor enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a permanent you control transforms into a Phyrexian, put a +1/+1 counter on it.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "359ca627-9ce4-5a52-bf23-c2dca18b383c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9ed068-b6bb-4c9e-a8c9-56aa9b62037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9ed068-b6bb-4c9e-a8c9-56aa9b62037a.jpg?1",
             "name": "Phyrexian Awakening",
             "text": "When Phyrexian Awakening enters the battlefield, incubate 4. (Create an Incubator token with four +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have vigilance.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "ddd1fd9d-3ec3-5af1-adae-35b61941bdad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150e17b1-b9fd-4ec4-b305-19596fed14d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150e17b1-b9fd-4ec4-b305-19596fed14d1.jpg?1",
             "name": "Phyrexian Censor",
             "text": "Each player can't cast more than one non-Phyrexian spell each turn.\nNon-Phyrexian creatures enter the battlefield tapped.",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "b44e9229-6462-5b47-831e-daef839767d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f7d03-ce71-498d-9dc5-2bd853ac0eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f7d03-ce71-498d-9dc5-2bd853ac0eae.jpg?1",
             "name": "Progenitor Exarch",
             "text": "When Progenitor Exarch enters the battlefield, incubate 3 X times. (To incubate 3, create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n{T}: Transform target Incubator token you control.",
             "colours": [
@@ -1371,7 +1371,7 @@
         },
         {
             "id": "8775e1c4-d96b-5bca-8cc9-364e4aa488a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a41675-47dd-40ca-a30c-0fd0faa32b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a41675-47dd-40ca-a30c-0fd0faa32b76.jpg?1",
             "name": "Realmbreaker's Grasp",
             "text": "Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "e9cb003e-7de4-5372-bc97-f6cd8dc3f530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc278d1-2ea4-4fbc-95cd-a9cd48c3c630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc278d1-2ea4-4fbc-95cd-a9cd48c3c630.jpg?1",
             "name": "Scrollshift",
             "text": "Exile up to one target artifact, creature, or enchantment you control, then return it to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "414521ac-f25b-58d3-ba5d-82790106f43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccc29cc-025d-402e-9fe3-75998eb290c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccc29cc-025d-402e-9fe3-75998eb290c9.jpg?1",
             "name": "Seal from Existence",
             "text": "Ward {3} (Whenever this enchantment becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nWhen Seal from Existence enters the battlefield, exile target nonland permanent an opponent controls until Seal from Existence leaves the battlefield.",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "4f4fe6e0-e113-52d4-873c-65e65d7aaa70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg?1",
             "name": "Seraph of New Capenna // Seraph of New Phyrexia",
             "text": "Flying\n{4}{PB}: Transform Seraph of New Capenna. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "3df0348a-a010-5942-b904-7dd413b965b3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg?1",
             "name": "Seraph of New Capenna // Seraph of New Phyrexia",
             "text": "Flying\nWhenever Seraph of New Phyrexia attacks, you may sacrifice another creature or artifact. If you do, Seraph of New Phyrexia gets +2/+1 until end of turn.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "795ae882-8aec-5edb-b730-f7a0b0f692ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65b178-51d6-4dcb-a1cc-4b4dcb2237cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65b178-51d6-4dcb-a1cc-4b4dcb2237cd.jpg?1",
             "name": "Sigiled Sentinel",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nVigilance",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "ea6aa768-26f2-551f-8de6-b6d890b6ddeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg?1",
             "name": "Sun-Blessed Guardian // Furnace-Blessed Conqueror",
             "text": "{5}{PR}: Transform Sun-Blessed Guardian. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "fd832534-e3fb-59c5-94a7-f2f5e8550dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg?1",
             "name": "Sun-Blessed Guardian // Furnace-Blessed Conqueror",
             "text": "Whenever Furnace-Blessed Conqueror attacks, create a tapped and attacking token that's a copy of it. Put a +1/+1 counter on that token for each +1/+1 counter on Furnace-Blessed Conqueror. Sacrifice that token at the beginning of the next end step.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "1bdd1570-7bbf-5ccd-852f-d039e915f36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ad785-21bb-4ce6-8776-31c67259fb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ad785-21bb-4ce6-8776-31c67259fb99.jpg?1",
             "name": "Sunder the Gateway",
             "text": "Choose one \u2014\n\u2022 Destroy target nontoken artifact or enchantment an opponent controls. Incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n\u2022 Incubate 2, then transform an Incubator token you control.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "548dad81-f2d5-5ea8-9f87-c4c5180531f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e29c7d-ed4b-4eff-b3c2-d99e5b63ef8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e29c7d-ed4b-4eff-b3c2-d99e5b63ef8d.jpg?1",
             "name": "Sunfall",
             "text": "Exile all creatures. Incubate X, where X is the number of creatures exiled this way. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "8f0d8947-f6e0-5c14-9f2e-33a2207789db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d25ee5-0348-4206-bb6a-ccb0a599ac87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d25ee5-0348-4206-bb6a-ccb0a599ac87.jpg?1",
             "name": "Surge of Salvation",
             "text": "You and permanents you control gain hexproof until end of turn. Prevent all damage that black and/or red sources would deal to creatures you control this turn.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "527289ca-ea89-5689-97a9-ae4a123af455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0461fc-4298-45b9-90a0-939093cf2544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0461fc-4298-45b9-90a0-939093cf2544.jpg?1",
             "name": "Swordsworn Cavalier",
             "text": "Swordsworn Cavalier has first strike as long as another Knight entered the battlefield under your control this turn.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "1cebb976-4b7f-5a14-9516-e39a1448982e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg?1",
             "name": "Tarkir Duneshaper // Burnished Dunestomper",
             "text": "{4}{PG}: Transform Tarkir Duneshaper. Activate only as a sorcery. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "99ef5197-f618-5e8b-b1dd-53d0bd4a3f91",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg?1",
             "name": "Tarkir Duneshaper // Burnished Dunestomper",
             "text": "Trample",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "7891b026-a621-528d-8f5c-88275c01a42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e206f2-1647-4456-8f2f-b67d053413e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e206f2-1647-4456-8f2f-b67d053413e2.jpg?1",
             "name": "Tiller of Flesh",
             "text": "Whenever you cast a spell that targets one or more permanents, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "e072239c-cdd4-5c50-81aa-e0e9f6dd90e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e5b49-c53f-4bf7-aac0-950d8708b957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e5b49-c53f-4bf7-aac0-950d8708b957.jpg?1",
             "name": "Zhalfirin Lancer",
             "text": "Whenever another Knight enters the battlefield under your control, Zhalfirin Lancer gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "9c0d4dd4-9e6a-52df-9fae-1ebaae2cef64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd05f97-ef8b-4cbe-a44b-6501aa5895b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd05f97-ef8b-4cbe-a44b-6501aa5895b0.jpg?1",
             "name": "Artistic Refusal",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one or both \u2014\n\u2022 Counter target spell.\n\u2022 Draw two cards, then discard a card.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "84c0a7a0-fb6f-5f65-b507-1949a6fd0ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee12ba-0e6c-485a-a1ff-61726ed72fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee12ba-0e6c-485a-a1ff-61726ed72fea.jpg?1",
             "name": "Assimilate Essence",
             "text": "Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "86f660a5-fced-5666-9897-ab5934298dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2ef728-a2c7-45ee-8594-372ed135b482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2ef728-a2c7-45ee-8594-372ed135b482.jpg?1",
             "name": "Astral Wingspan",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEnchant creature\nWhen Astral Wingspan enters the battlefield, draw a card.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "83a150cd-77d8-5da7-8bd2-8473c18df7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg?1",
             "name": "Captive Weird // Compleated Conjurer",
             "text": "Defender\n{3}{PR}: Transform Captive Weird. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "cf9d64bd-02a1-5daa-9252-76858b5582b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg?1",
             "name": "Captive Weird // Compleated Conjurer",
             "text": "When this creature transforms into Compleated Conjurer, exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "0f61067d-d21c-5372-8054-d1e435158cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98db9ed-b43f-4bc1-b7a9-ce03a534d992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98db9ed-b43f-4bc1-b7a9-ce03a534d992.jpg?1",
             "name": "Change the Equation",
             "text": "Choose one \u2014\n\u2022 Counter target spell with mana value 2 or less.\n\u2022 Counter target red or green spell with mana value 6 or less.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "b239cf87-e26c-5275-a650-1c3c3376281a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febaaeae-5c0d-45fa-8169-b27b4996f18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febaaeae-5c0d-45fa-8169-b27b4996f18e.jpg?1",
             "name": "Chrome Host Seedshark",
             "text": "Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "5f3302d4-f77b-56f3-b18e-1ad3d185777e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5de96-9418-48f1-a18e-01a0108c4f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5de96-9418-48f1-a18e-01a0108c4f97.jpg?1",
             "name": "Complete the Circuit",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nYou may cast sorcery spells this turn as though they had flash.\nWhen you next cast an instant or sorcery spell this turn, copy that spell twice. You may choose new targets for the copies.",
             "colours": [
@@ -2200,7 +2200,7 @@
         },
         {
             "id": "4c1e5421-f0ee-5abd-ad68-da29b8591b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e896a87-2a93-488c-a0c9-0bed8404da44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e896a87-2a93-488c-a0c9-0bed8404da44.jpg?1",
             "name": "Corruption of Towashi",
             "text": "When Corruption of Towashi enters the battlefield, incubate 4. (Create an Incubator token with four +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a permanent you control transforms or a permanent enters the battlefield under your control transformed, you may draw a card. Do this only once each turn.",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "aee89355-5f7a-5530-9012-ad9ab95794f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a63d530-27c3-4cd7-ac37-c62b5a1afbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a63d530-27c3-4cd7-ac37-c62b5a1afbc1.jpg?1",
             "name": "Disturbing Conversion",
             "text": "Flash\nEnchant creature\nWhen Disturbing Conversion enters the battlefield, each player mills two cards.\nEnchanted creature gets -X/-0, where X is the number of cards in its controller's graveyard.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "c6edefa8-2e82-5760-b6ee-445150680c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bcc71f-72ec-4a76-9393-ed3ea61eeeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bcc71f-72ec-4a76-9393-ed3ea61eeeb6.jpg?1",
             "name": "Ephara's Dispersal",
             "text": "This spell costs {2} less to cast if it targets an attacking creature.\nReturn target creature to its owner's hand. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "84493439-d81e-5c50-a524-e170afd22783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e14dfd2-5805-46ef-bd19-dab7ac23fbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e14dfd2-5805-46ef-bd19-dab7ac23fbce.jpg?1",
             "name": "Expedition Lookout",
             "text": "Defender\nAs long as an opponent has eight or more cards in their graveyard, Expedition Lookout can attack as though it didn't have defender and it can't be blocked.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "765f0bb5-c883-58b2-9e65-212834b9f124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4303347-3fbd-4bbd-ab3f-e7ddbe0e0a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4303347-3fbd-4bbd-ab3f-e7ddbe0e0a9d.jpg?1",
             "name": "Eyes of Gitaxias",
             "text": "Incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nDraw a card.",
             "colours": [
@@ -2365,7 +2365,7 @@
         },
         {
             "id": "35c573b6-b4d8-59f2-923f-7223c868cf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3005f-a1c7-4ef5-911f-ccc0752f4181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3005f-a1c7-4ef5-911f-ccc0752f4181.jpg?1",
             "name": "Faerie Mastermind",
             "text": "Flash\nFlying\nWhenever an opponent draws their second card each turn, you draw a card.\n{3}{U}: Each player draws a card.",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "d29e2736-9775-5925-8cd0-063b9c2f8377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c55aff-baed-4fb5-a490-abd59b8df5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c55aff-baed-4fb5-a490-abd59b8df5e7.jpg?1",
             "name": "Furtive Analyst",
             "text": "Vigilance\n{2}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "da0e250a-8c63-5cdd-9ac4-549af96fb39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6bdac3-6762-41a4-821f-ab7034a823d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6bdac3-6762-41a4-821f-ab7034a823d9.jpg?1",
             "name": "Halo-Charged Skaab",
             "text": "When Halo-Charged Skaab enters the battlefield, each player mills two cards. Then you may put an instant, sorcery, or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "40c6e7c7-e2c5-5236-afc6-70c301dbe951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg?1",
             "name": "Invasion of Arcavios // Invocation of the Founders",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Arcavios enters the battlefield, search your library, graveyard, and/or outside the game for an instant or sorcery card you own, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "1b2ed823-6eb1-5e0d-9fab-8e7178f35b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg?1",
             "name": "Invasion of Arcavios // Invocation of the Founders",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "e339a3a4-dcfa-5779-947b-7aa1481b9416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg?1",
             "name": "Invasion of Kamigawa // Rooftop Saboteurs",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kamigawa enters the battlefield, tap target artifact or creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "f5384e38-600f-587f-8fae-a8fdad027948",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg?1",
             "name": "Invasion of Kamigawa // Rooftop Saboteurs",
             "text": "Flying\nWhenever Rooftop Saboteurs deals combat damage to a player or battle, draw a card.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "cbc5d711-26a7-5768-bdd9-068b2bcae46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1",
             "name": "Invasion of Segovia // Caetus, Sea Tyrant of Segovia",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Segovia enters the battlefield, create two 1/1 blue Kraken creature tokens with trample.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "ef32858d-de8a-551e-bb10-d6192d08575a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1",
             "name": "Invasion of Segovia // Caetus, Sea Tyrant of Segovia",
             "text": "Noncreature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a noncreature spell pays for {1} or one mana of that creature's color.)\nAt the beginning of your end step, untap up to four target creatures.",
             "colours": [
@@ -2676,7 +2676,7 @@
         },
         {
             "id": "fc751992-539f-5695-8aa2-8e975ffa4257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg?1",
             "name": "Invasion of Vryn // Overloaded Mage-Ring",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Vryn enters the battlefield, draw three cards, then discard a card.",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "24b7b0b2-0d94-56ea-850f-daf1e45316b3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg?1",
             "name": "Invasion of Vryn // Overloaded Mage-Ring",
             "text": "{1}, {T}, Sacrifice Overloaded Mage-Ring: Copy target spell you control. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "22cadebf-e1f3-5dd2-81e9-1d03df5ba19c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "Ward {2}\nWhenever you cast a noncreature spell with mana value 3 or greater, draw a card.\n{3}{U}: Exile Jin-Gitaxias, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you have seven or more cards in hand.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "0e47ebf9-0f24-5bee-bb02-659dc1091f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Draw cards equal to the number of cards in your hand. You have no maximum hand size for as long as you control The Great Synthesis.\nII \u2014 Return all non-Phyrexian creatures to their owners' hands.\nIII \u2014 You may cast any number of spells from your hand without paying their mana costs. Exile The Great Synthesis, then return it to the battlefield (front face up).",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "483f55d5-9d00-5331-ab50-a399e68e25e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b8650-c283-4e54-abdc-32ec2fb1ee34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b8650-c283-4e54-abdc-32ec2fb1ee34.jpg?1",
             "name": "Meeting of Minds",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDraw two cards.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "b60a0ef7-8c55-55bc-ba53-8fd4e237308d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e758594-a48c-4508-b400-9028aec07f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e758594-a48c-4508-b400-9028aec07f63.jpg?1",
             "name": "Moment of Truth",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one into your graveyard, and one on the bottom of your library.",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "581753a4-5c7f-5725-a4bf-dbd34b53f671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81752db1-374e-4723-b695-a2f4a634dfc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81752db1-374e-4723-b695-a2f4a634dfc6.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "b73fffa7-51b1-5fae-82bb-89875bb67803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b35399-79af-49fa-989e-867a85320cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b35399-79af-49fa-989e-867a85320cc2.jpg?1",
             "name": "Oculus Whelp",
             "text": "Flying\nAs long as you control a transformed permanent, Oculus Whelp has \"When Oculus Whelp dies, draw a card.\"",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "517c80f0-cce0-567d-8afe-be3ad2e4378d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0749c3c-e3f7-4c96-8c5b-4fd2401544c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0749c3c-e3f7-4c96-8c5b-4fd2401544c4.jpg?1",
             "name": "Omen Hawker",
             "text": "{T}: Add {C}{U}. Spend this mana only to activate abilities.",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "7052a910-3f61-591c-975d-ede410366cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2aa39-b876-4136-8e16-5272a8083235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2aa39-b876-4136-8e16-5272a8083235.jpg?1",
             "name": "Oracle of Tragedy",
             "text": "When Oracle of Tragedy enters the battlefield or dies, choose one \u2014\n\u2022 Draw a card, then discard a card.\n\u2022 Shuffle up to four target cards with mana value 3 or greater from your graveyard into your library.",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "f509a4a7-371d-5cdf-a1f1-9d9f14d843a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg?1",
             "name": "Order of the Mirror // Order of the Alabaster Host",
             "text": "{3}{PW}: Transform Order of the Mirror. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "81b01436-3c4a-51ec-b1f0-934e86998490",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg?1",
             "name": "Order of the Mirror // Order of the Alabaster Host",
             "text": "Whenever Order of the Alabaster Host becomes blocked by a creature, that creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "64a870eb-541a-58a5-8cb7-fd559e887104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44178ece-af31-4a94-88bc-c9ce43bb4573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44178ece-af31-4a94-88bc-c9ce43bb4573.jpg?1",
             "name": "Preening Champion",
             "text": "Flying\nWhen Preening Champion enters the battlefield, create a 1/1 blue and red Elemental creature token.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "c6f3f40a-42aa-5cad-a6bf-9f7c360df93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6cb380-0b4d-4870-abef-928eb63e1702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6cb380-0b4d-4870-abef-928eb63e1702.jpg?1",
             "name": "Protocol Knight",
             "text": "When Protocol Knight enters the battlefield, tap target creature an opponent controls. Put a stun counter on that creature if you control another Knight. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "1a77ddbe-cad0-5218-aaa4-aef1fffd80f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Whenever you cast a legendary spell, untap Rona, Herald of Invasion.\n{T}: Draw a card, then discard a card.\n{5}{PB}: Transform Rona. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "b5774468-1349-515d-8c5c-3dc68af274b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Rona, Tolarian Obliterator, that source's controller exiles a card from their hand at random. If it's a land card, you may put it onto the battlefield under your control. Otherwise, you may cast it without paying its mana cost.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "bfc8c7a6-0555-5f96-b205-fd538a85e78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3934d535-740d-471a-bbf1-c3b26b1cd596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3934d535-740d-471a-bbf1-c3b26b1cd596.jpg?1",
             "name": "Saiba Cryptomancer",
             "text": "Flash\nBackup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nHexproof",
             "colours": [
@@ -3279,7 +3279,7 @@
         },
         {
             "id": "57c9d0e8-2a3f-5228-bcd7-a1601b8dd51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41634103-7b58-4feb-84b7-90a07a7b474f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41634103-7b58-4feb-84b7-90a07a7b474f.jpg?1",
             "name": "See Double",
             "text": "This spell can't be copied.\nChoose one. If an opponent has eight or more cards in their graveyard, you may choose both.\n\u2022 Copy target spell. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)\n\u2022 Create a token that's a copy of target creature.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "ead58232-6381-547e-a0f9-6469dfa2c0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg?1",
             "name": "Skyclave Aerialist // Skyclave Invader",
             "text": "Flying\n{4}{PG}: Transform Skyclave Aerialist. Activate only as a sorcery. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "cef44c52-0795-527c-a36b-b2fc261b12c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg?1",
             "name": "Skyclave Aerialist // Skyclave Invader",
             "text": "Flying\nWhen this creature transforms into Skyclave Invader, look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -3387,7 +3387,7 @@
         },
         {
             "id": "f4a9a10d-9a82-5eb0-9aa8-af99f3cb81e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38211d78-ebac-4150-ac11-7613a0e9e1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38211d78-ebac-4150-ac11-7613a0e9e1bc.jpg?1",
             "name": "Stasis Field",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/2, has defender, and loses all other abilities.",
             "colours": [
@@ -3421,7 +3421,7 @@
         },
         {
             "id": "6d806afd-7420-53d9-a2fd-ca8addde747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e67031a-8216-4c66-b6fb-6628bd02d279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e67031a-8216-4c66-b6fb-6628bd02d279.jpg?1",
             "name": "Temporal Cleansing",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nThe owner of target nonland permanent puts it into their library second from the top or on the bottom.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "ad033535-2012-500a-889e-30c04412eb60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eaa0946-591f-4136-9d8a-e56934151383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eaa0946-591f-4136-9d8a-e56934151383.jpg?1",
             "name": "Thunderhead Squadron",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying",
             "colours": [
@@ -3488,7 +3488,7 @@
         },
         {
             "id": "13e438e3-6cd6-53e5-af6c-7ef09f3328d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e943948-2326-4446-9a16-64d6040b8856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e943948-2326-4446-9a16-64d6040b8856.jpg?1",
             "name": "Tidal Terror",
             "text": "Whenever Tidal Terror attacks, you may tap two other untapped creatures you control. If you do, Tidal Terror can't be blocked this turn.\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "c2b13953-70a5-56a2-89dc-9adf21b1b847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261c7e6-45be-44d1-8855-026359ba0ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261c7e6-45be-44d1-8855-026359ba0ae7.jpg?1",
             "name": "Transcendent Message",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDraw X cards.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "7e5b0fce-5ae0-5236-b91c-acabfbdb2303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140cd8bd-b74d-4cb1-b78f-8de3cbd878ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140cd8bd-b74d-4cb1-b78f-8de3cbd878ff.jpg?1",
             "name": "Wicked Slumber",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTap up to two target creatures. Put a stun counter on either of them. Then put a stun counter on either of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "ae8d627b-b79f-5d94-8a63-62e388fc397a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38a32bc-133d-43d1-a6e3-80d39fe53d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38a32bc-133d-43d1-a6e3-80d39fe53d32.jpg?1",
             "name": "Xerex Strobe-Knight",
             "text": "Flying, vigilance\n{T}: Create a 2/2 white and blue Knight creature token with vigilance. Activate only if you've cast two or more spells this turn.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "bf85254c-6f84-5361-bad5-9046e741ae35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678966b-65f1-405c-b8db-5f2d4f434933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678966b-65f1-405c-b8db-5f2d4f434933.jpg?1",
             "name": "Zephyr Singer",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying, vigilance\nWhen Zephyr Singer enters the battlefield, put a flying counter on each creature that convoked it.",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "0c677ddd-6fb1-5796-96fd-80610f7dc420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e446a380-0316-46f7-8ac9-22bce773b35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e446a380-0316-46f7-8ac9-22bce773b35f.jpg?1",
             "name": "Zhalfirin Shapecraft",
             "text": "Target creature has base power and toughness 4/3 until end of turn.\nDraw a card.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "d612a3cf-a485-522b-969b-b50936b74689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg?1",
             "name": "Aetherblade Agent // Gitaxian Mindstinger",
             "text": "Deathtouch\n{4}{PU}: Transform Aetherblade Agent. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "05c89823-6d2e-5e16-8777-1b77d3b91f07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg?1",
             "name": "Aetherblade Agent // Gitaxian Mindstinger",
             "text": "Deathtouch\nWhenever Gitaxian Mindstinger deals combat damage to a player or battle, draw a card.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "09cd09c6-ac3d-52dc-a45e-6d05da8946c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5931746-a55c-4528-9e4a-ee15edab3489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5931746-a55c-4528-9e4a-ee15edab3489.jpg?1",
             "name": "Archpriest of Shadows",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following abilities until end of turn.)\nDeathtouch\nWhenever this creature deals combat damage to a player or battle, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "2a3b4d0a-e5cf-5393-89e0-1ba98f03a416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "{T}, Sacrifice another creature or artifact: Ayara, Widow of the Realm deals X damage to target opponent or battle and you gain X life, where X is the sacrificed permanent's mana value.\n{5}{PR}: Transform Ayara. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "e3b6a0b8-2443-5d5b-bc0c-82d30ea98fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "At the beginning of combat on your turn, return up to one target artifact or creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "878df494-8ec3-5ce0-a767-dd7ff9887f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28f5de4-2af6-44ff-9bb8-d874f8ae7dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28f5de4-2af6-44ff-9bb8-d874f8ae7dd1.jpg?1",
             "name": "Bladed Battle-Fan",
             "text": "Flash\nWhen Bladed Battle-Fan enters the battlefield, attach it to target creature you control. That creature gains indestructible until end of turn.\nEquipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "4bbc42a7-93f9-5bf6-ae70-9ed837ead736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg?1",
             "name": "Blightreaper Thallid // Blightsower Thallid",
             "text": "{3}{PG}: Transform Blightreaper Thallid. Activate only as a sorcery. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -3953,7 +3953,7 @@
         },
         {
             "id": "fbed7b16-3eee-50d6-af2b-9aba65b01c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg?1",
             "name": "Blightreaper Thallid // Blightsower Thallid",
             "text": "When this creature transforms into Blightsower Thallid or dies, create a 1/1 green Phyrexian Saproling creature token.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "cbf09c2e-4b98-5515-bed2-acc88b271c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ddcca8-5720-4341-acce-c6694ddc97f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ddcca8-5720-4341-acce-c6694ddc97f8.jpg?1",
             "name": "Bloated Processor",
             "text": "Sacrifice another Phyrexian: Put a +1/+1 counter on Bloated Processor.\nWhen Bloated Processor dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4026,7 +4026,7 @@
         },
         {
             "id": "4a780c9f-3977-586b-920c-13da1c8190b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf51a76-7a57-4462-ae18-a19e817e49e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf51a76-7a57-4462-ae18-a19e817e49e5.jpg?1",
             "name": "Breach the Multiverse",
             "text": "Each player mills ten cards. For each player, choose a creature or planeswalker card in that player's graveyard. Put those cards onto the battlefield under your control. Then each creature you control becomes a Phyrexian in addition to its other types.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "b6042cec-eb85-5a31-b729-a15a673f9c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05864d3a-d8bb-4ddf-b721-883632050cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05864d3a-d8bb-4ddf-b721-883632050cb1.jpg?1",
             "name": "Collective Nightmare",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "148007dd-8693-50fa-ae28-4e8e637e57b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc23af5-18dd-45f9-8d82-76b48aaf6d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc23af5-18dd-45f9-8d82-76b48aaf6d4d.jpg?1",
             "name": "Compleated Huntmaster",
             "text": "{1}, {T}, Sacrifice another creature or artifact: Incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "b196febd-040f-55aa-822c-5afa8f2f3467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7311ade8-eb75-40f8-b018-668762aa3b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7311ade8-eb75-40f8-b018-668762aa3b77.jpg?1",
             "name": "Consuming Aetherborn",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nLifelink",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "e8fc0534-d9f4-5af9-9f53-b2489537693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg?1",
             "name": "Corrupted Conviction",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -4195,7 +4195,7 @@
         },
         {
             "id": "846e8d52-88bf-54d0-970f-683200563df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a02f-128c-44aa-b708-6fcda34b40c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a02f-128c-44aa-b708-6fcda34b40c0.jpg?1",
             "name": "Deadly Derision",
             "text": "Destroy target creature or planeswalker. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "8335547d-394e-516d-b59d-fc2d7bc62b34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef82b33-82ba-4521-846b-e651764ef46d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef82b33-82ba-4521-846b-e651764ef46d.jpg?1",
             "name": "Dreg Recycler",
             "text": "{T}, Sacrifice an artifact or creature: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "5bf30b58-4e66-518a-910a-a6743fe3270f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616a548-269b-4530-97e8-c690ccc138f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616a548-269b-4530-97e8-c690ccc138f3.jpg?1",
             "name": "Etched Familiar",
             "text": "When Etched Familiar dies, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "5d2c1a88-6d9d-5200-a449-889f784047eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f1afa2-ca71-49cf-953b-d5dfc60c178f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f1afa2-ca71-49cf-953b-d5dfc60c178f.jpg?1",
             "name": "Etched Host Doombringer",
             "text": "When Etched Host Doombringer enters the battlefield, choose one \u2014\n\u2022 Target opponent loses 2 life and you gain 2 life.\n\u2022 Choose target battle. If an opponent protects it, remove three defense counters from it. Otherwise, put three defense counters on it.",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "e3375bac-5213-5713-a179-2fdc54ab1211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c18b7-5321-4793-b54a-e48e39548b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c18b7-5321-4793-b54a-e48e39548b9c.jpg?1",
             "name": "Failed Conversion",
             "text": "Enchant creature\nEnchanted creature gets -4/-4.\nWhen enchanted creature dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -4367,7 +4367,7 @@
         },
         {
             "id": "d4ded43a-bc1b-5515-a7fe-8175c49af3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4dcdb-6939-4d9f-8921-549e0ddc9f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4dcdb-6939-4d9f-8921-549e0ddc9f63.jpg?1",
             "name": "Final Flourish",
             "text": "Kicker\u2014\nSacrifice an artifact or creature. (You may sacrifice an artifact or creature in addition to any other costs as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -6/-6 until end of turn instead.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "bd071b93-b495-5b56-9ebd-428d1acd9688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9184bc57-0a16-4abf-a13a-6a03a175c28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9184bc57-0a16-4abf-a13a-6a03a175c28a.jpg?1",
             "name": "Flitting Guerrilla",
             "text": "Flying\nWhen Flitting Guerrilla dies, each player mills two cards. Then you may exile Flitting Guerrilla. When you do, put target creature or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "711db069-e298-51d4-8727-b6ae3a519647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e08244-bbdb-402a-8dde-93e17d989467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e08244-bbdb-402a-8dde-93e17d989467.jpg?1",
             "name": "Gift of Compleation",
             "text": "When Gift of Compleation enters the battlefield, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a Phyrexian you control dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "0ec53856-8bfd-55a3-89b7-9046b9298633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ca46ac-0698-4651-940d-3fd20c266b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ca46ac-0698-4651-940d-3fd20c266b74.jpg?1",
             "name": "Glistening Deluge",
             "text": "All creatures get -1/-1 until end of turn. Creatures that are green and/or white get an additional -2/-2 until end of turn.",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "c72ac6cf-c8c3-5d60-ab9e-727c9d99700d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a5338-133f-486d-9f73-0896226685c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a5338-133f-486d-9f73-0896226685c0.jpg?1",
             "name": "Gloomfang Mauler",
             "text": "Swampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)\nBackup 2 (When this creature enters the battlefield, put two +1/+1 counters on target creature. If that's another creature, it gains the following ability until end of turn.)\nMenace",
             "colours": [
@@ -4532,7 +4532,7 @@
         },
         {
             "id": "1808ef40-f81c-5bab-aebc-1a93006dc2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22f11a1-0cbd-4b36-8dbd-37ba29ad4608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22f11a1-0cbd-4b36-8dbd-37ba29ad4608.jpg?1",
             "name": "Grafted Butcher",
             "text": "When Grafted Butcher enters the battlefield, Phyrexians you control gain menace until end of turn.\nOther Phyrexians you control get +1/+1.\n{3}{B}, Sacrifice an artifact or creature: Return Grafted Butcher from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "5c3009e4-70bf-5056-ab83-6d4d9d02faa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ce3c9-869d-461c-a3de-c8add3786f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ce3c9-869d-461c-a3de-c8add3786f73.jpg?1",
             "name": "Hoarding Broodlord",
             "text": "Convoke\nFlying\nWhen Hoarding Broodlord enters the battlefield, search your library for a card, exile it face down, then shuffle. For as long as that card remains exiled, you may play it.\nSpells you cast from exile have convoke.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "31077d0e-7d23-55d1-96c2-ee2dbc5b3d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fd7350-cc97-4c35-a072-2c826984293c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fd7350-cc97-4c35-a072-2c826984293c.jpg?1",
             "name": "Ichor Drinker",
             "text": "Lifelink\n{B}, Exile Ichor Drinker from your graveyard: Incubate 2. Activate only as a sorcery. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "1f287881-df53-54b7-99d6-e9df29aeeb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd86fbf-eac2-456b-b4bb-437ff9be9b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd86fbf-eac2-456b-b4bb-437ff9be9b58.jpg?1",
             "name": "Ichor Shade",
             "text": "At the beginning of your end step, if an artifact or creature was put into a graveyard from the battlefield this turn, put a +1/+1 counter on Ichor Shade.",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "4ecd4a4b-3934-5b33-b0cd-8f5c61331745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg?1",
             "name": "Invasion of Eldraine // Prickle Faeries",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Eldraine enters the battlefield, target opponent discards two cards.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "528c8dd2-e305-5493-996a-6cd03f11c757",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg?1",
             "name": "Invasion of Eldraine // Prickle Faeries",
             "text": "Flying\nAt the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Prickle Faeries deals 2 damage to them.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "b97d18bf-f859-5188-98ea-bfdb84d91964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg?1",
             "name": "Invasion of Fiora // Marchesa, Resolute Monarch",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Fiora enters the battlefield, choose one or both \u2014\n\u2022 Destroy all legendary creatures.\n\u2022 Destroy all nonlegendary creatures.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "2eeb81d4-1282-5f31-9dff-76d8ebe172fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg?1",
             "name": "Invasion of Fiora // Marchesa, Resolute Monarch",
             "text": "Menace, deathtouch\nWhenever Marchesa, Resolute Monarch attacks, remove all counters from up to one target permanent.\nAt the beginning of your upkeep, if you haven't been dealt combat damage since your last turn, you draw a card and you lose 1 life.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "adf06d13-4f72-51fe-8b96-df213a3941b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg?1",
             "name": "Invasion of Innistrad // Deluge of the Dead",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nFlash\nWhen Invasion of Innistrad enters the battlefield, target creature an opponent controls gets -13/-13 until end of turn.",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "4a1dac0f-7fc1-5e78-91c1-5af53d133fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg?1",
             "name": "Invasion of Innistrad // Deluge of the Dead",
             "text": "When Deluge of the Dead enters the battlefield, create two 2/2 black Zombie creature tokens.\n{2}{B}: Exile target card from a graveyard. If it was a creature card, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "37d884b9-a129-58ec-a9ec-3b61b61adcc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg?1",
             "name": "Invasion of Ulgrotha // Grandmother Ravi Sengir",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ulgrotha enters the battlefield, it deals 3 damage to any other target and you gain 3 life.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "8d6f011b-0bd6-599e-a9dc-07a16dc43efd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg?1",
             "name": "Invasion of Ulgrotha // Grandmother Ravi Sengir",
             "text": "Flying\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Grandmother Ravi Sengir and you gain 1 life.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "03574893-04b3-586b-963e-595c72b7ac26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edec35-1770-47f0-9ad2-32e597ee0327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edec35-1770-47f0-9ad2-32e597ee0327.jpg?1",
             "name": "Merciless Repurposing",
             "text": "Exile target creature. Incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "7617a5c3-3301-5c60-b514-eb1a762343ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750b2090-7fd4-4048-a148-9a5fc7b6f265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750b2090-7fd4-4048-a148-9a5fc7b6f265.jpg?1",
             "name": "Mirrodin Avenged",
             "text": "Destroy target creature that was dealt damage this turn.\nDraw a card.",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "fe3bcbc2-40c4-5b15-bcbf-b3e15b654303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg?1",
             "name": "Nezumi Freewheeler // Hideous Fleshwheeler",
             "text": "Menace\nWhen Nezumi Freewheeler enters the battlefield, each player mills three cards. (To mill three cards, a player puts the top three cards of their library into their graveyard.)\n{5}{PW}: Transform Nezumi Freewheeler. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "55077e0d-30dd-5a2b-be8d-1dffc1513f47",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg?1",
             "name": "Nezumi Freewheeler // Hideous Fleshwheeler",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature transforms into Hideous Fleshwheeler, put target permanent card with mana value 2 or less from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -5088,7 +5088,7 @@
         },
         {
             "id": "f6bc7bfc-139a-5296-bf60-ac7d7316a3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36fbff8-471e-4cf8-8946-e1e5cdf598af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36fbff8-471e-4cf8-8946-e1e5cdf598af.jpg?1",
             "name": "Nezumi Informant",
             "text": "When Nezumi Informant enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -5123,7 +5123,7 @@
         },
         {
             "id": "3e847461-bae5-5c9e-a3b5-7bd4d4db18ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be7576-bea6-4c20-b594-a058115f7acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be7576-bea6-4c20-b594-a058115f7acf.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "69c9d713-f7ce-55af-970e-16680c9eaa05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492e9369-0ca3-4c31-b747-75d615daf6e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492e9369-0ca3-4c31-b747-75d615daf6e4.jpg?1",
             "name": "Pile On",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature or planeswalker. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -5192,7 +5192,7 @@
         },
         {
             "id": "78652a5e-d320-544b-8aba-8c47ce17b0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b66ef5-9b93-4042-a618-c1ade83d0004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b66ef5-9b93-4042-a618-c1ade83d0004.jpg?1",
             "name": "Render Inert",
             "text": "Remove up to five counters from target permanent.\nDraw a card.",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "45c68d58-8ce4-52c1-b749-16706a1a5878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e7386-4c2d-4fa9-b499-fa3681f2a50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e7386-4c2d-4fa9-b499-fa3681f2a50e.jpg?1",
             "name": "Scorn-Blade Berserker",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\n{1}, Sacrifice this creature: Draw a card.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "a08e899a-7d8a-5ee1-932d-e880bcf8ee51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "Menace\nWhen Sheoldred enters the battlefield, each opponent sacrifices a nontoken creature or planeswalker.\n{4}{B}: Exile Sheoldred, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if an opponent has eight or more cards in their graveyard.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "1ac03fbd-8157-528f-a87f-352a9a484b23",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 For each opponent, destroy up to one target creature or planeswalker that player controls.\nII \u2014 Each opponent discards three cards, then mills three cards.\nIII \u2014 Put all creature cards from all graveyards onto the battlefield under your control. Exile The True Scriptures, then return it to the battlefield (front face up).",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "aeec7051-9526-5a9c-aea4-7035abb819f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65721bc1-87fa-45b9-8b45-ee77c1aab6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65721bc1-87fa-45b9-8b45-ee77c1aab6ac.jpg?1",
             "name": "Tenured Oilcaster",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nTenured Oilcaster gets +3/+0 as long as an opponent has eight or more cards in their graveyard.\nWhenever Tenured Oilcaster attacks or blocks, each player mills a card.",
             "colours": [
@@ -5371,7 +5371,7 @@
         },
         {
             "id": "496356ac-34f4-5c6c-ad5d-79820cf2d8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40511-c9ff-466c-8eb9-cc7afc5c2eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40511-c9ff-466c-8eb9-cc7afc5c2eab.jpg?1",
             "name": "Traumatic Revelation",
             "text": "Target opponent reveals their hand. You may choose a creature or battle card from it. If you do, that player discards that card. If you don't, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "c36f983d-50ff-5909-8c9f-7947bbb9184a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9825ac-c186-4a10-b9e3-e73b10f75ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9825ac-c186-4a10-b9e3-e73b10f75ed9.jpg?1",
             "name": "Unseal the Necropolis",
             "text": "Each player mills three cards. Then you return up to two creature cards from your graveyard to your hand. (To mill three cards, a player puts the top three cards of their library into their graveyard.)",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "4949a1fa-b375-597d-bc84-b968a2e7ce2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935cb9a2-11ba-45d9-ab38-dea23cecf521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935cb9a2-11ba-45d9-ab38-dea23cecf521.jpg?1",
             "name": "Vanquish the Weak",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "63f7dde0-328f-56f1-b8e4-51b06d85369c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e02737-0193-46e4-a506-cec86a44dc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e02737-0193-46e4-a506-cec86a44dc99.jpg?1",
             "name": "Akki Scrapchomper",
             "text": "{1}{R}, {T}, Sacrifice an artifact or land: Draw a card.",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "fa579150-cda8-5381-9803-494b8e43836a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443cb94-b27e-4a96-93cb-ac7880149bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443cb94-b27e-4a96-93cb-ac7880149bcc.jpg?1",
             "name": "Beamtown Beatstick",
             "text": "Equipped creature gets +1/+0 and has menace. (It can't be blocked except by two or more creatures.)\nWhenever equipped creature deals combat damage to a player or battle, create a Treasure token.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5536,7 +5536,7 @@
         },
         {
             "id": "ab4c3a79-4131-5e0d-8a5d-2ab2b6374a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed97bf6f-726c-40aa-bc1c-14fa801da96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed97bf6f-726c-40aa-bc1c-14fa801da96a.jpg?1",
             "name": "Bloodfeather Phoenix",
             "text": "Flying\nBloodfeather Phoenix can't block.\nWhenever an instant or sorcery spell you control deals damage to an opponent or battle, you may pay {R}. If you do, return Bloodfeather Phoenix from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "41134eee-5b03-5838-a24a-32dc2950b346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2731e181-f59c-446c-bb86-8f93bfbb10e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2731e181-f59c-446c-bb86-8f93bfbb10e9.jpg?1",
             "name": "Burning Sun's Fury",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nUp to two target creatures each get +2/+0 and gain haste until end of turn.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "d461f6df-e724-514e-adf2-620f1db0a694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146ea07-ec1c-448d-b67a-dd9f9e27c2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146ea07-ec1c-448d-b67a-dd9f9e27c2e0.jpg?1",
             "name": "Chandra, Hope's Beacon",
             "text": "Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy. This ability triggers only once each turn.\n+2: Add two mana in any combination of colors.\n+1: Exile the top five cards of your library. Until the end of your next turn, you may cast an instant or sorcery spell from among those exiled cards.\n\u2212X: Chandra, Hope's Beacon deals X damage to each of up to two targets.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "69abc720-8184-5efb-bc12-97be81a628d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f455cc1-a822-44ef-ba7c-bfcff69bd45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f455cc1-a822-44ef-ba7c-bfcff69bd45e.jpg?1",
             "name": "City on Fire",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf a source you control would deal damage to a permanent or player, it deals triple that damage instead.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "d75d30f3-a8e5-562e-a291-8a942d99aeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6eb966-67af-4b18-8899-4a99a5179aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6eb966-67af-4b18-8899-4a99a5179aa3.jpg?1",
             "name": "Coming In Hot",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "1bc06916-8692-57f2-a049-5363d143baa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample\nWhen Etali, Primal Conqueror enters the battlefield, each player exiles cards from the top of their library until they exile a nonland card. You may cast any number of spells from among the nonland cards exiled this way without paying their mana costs.\n{9}{PG}: Transform Etali. Activate only as a sorcery.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "725d2df6-2ca9-569f-80b7-6c712d1252a8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample, indestructible\nWhenever Etali, Primal Sickness deals combat damage to a player, they get that many poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "6b853553-2cfe-524e-957d-ef2b9caefe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e317d1d-3f20-4f0d-8b1e-31df351e8f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e317d1d-3f20-4f0d-8b1e-31df351e8f83.jpg?1",
             "name": "Fearless Skald",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nDouble strike",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "de0a0345-c529-5f44-8e54-fb8018f07fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445b3315-6587-4d57-ab7e-faab1eec0241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445b3315-6587-4d57-ab7e-faab1eec0241.jpg?1",
             "name": "Furnace Gremlin",
             "text": "{1}{R}: Furnace Gremlin gets +1/+0 until end of turn.\nWhen Furnace Gremlin dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "ccf715cf-070a-5307-a393-9d7d0dfa6cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d142ded-a2df-41b0-9c02-056b5f34abab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d142ded-a2df-41b0-9c02-056b5f34abab.jpg?1",
             "name": "Furnace Host Charger",
             "text": "Haste\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "b180f6a6-fc1e-51fe-9dba-8cc306ef3b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91bfea6-0e80-4239-bede-7cb971e64c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91bfea6-0e80-4239-bede-7cb971e64c1a.jpg?1",
             "name": "Furnace Reins",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and \"Whenever this creature deals combat damage to a player or battle, create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "03c6c7c8-907d-55b0-820c-770c50278eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2551b01-4d88-47f3-b54d-96ec03e093f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2551b01-4d88-47f3-b54d-96ec03e093f8.jpg?1",
             "name": "Hangar Scrounger",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nWhenever this creature becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "eb3c64c2-668f-56e4-9c57-2a0f6ae768a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg?1",
             "name": "Harried Artisan // Phyrexian Skyflayer",
             "text": "Haste\n{3}{PW}: Transform Harried Artisan. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "721b95f0-3f0d-5b80-956f-d65b10fe6d65",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg?1",
             "name": "Harried Artisan // Phyrexian Skyflayer",
             "text": "Flying, haste",
             "colours": [
@@ -6035,7 +6035,7 @@
         },
         {
             "id": "396a6fd6-95a9-56cf-9d40-ace4e35efb8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f649bb-b163-44ae-801f-8884143c407f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f649bb-b163-44ae-801f-8884143c407f.jpg?1",
             "name": "Into the Fire",
             "text": "Choose one \u2014\n\u2022 Into the Fire deals 2 damage to each creature, planeswalker, and battle.\n\u2022 Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "f887ddca-842c-53f4-a217-23929168a6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg?1",
             "name": "Invasion of Kaldheim // Pyre of the World Tree",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kaldheim enters the battlefield, exile all cards from your hand, then draw that many cards. Until the end of your next turn, you may play cards exiled this way.",
             "colours": [
@@ -6103,7 +6103,7 @@
         },
         {
             "id": "fe0bf4bd-e649-5c01-9002-2c150cddfaab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg?1",
             "name": "Invasion of Kaldheim // Pyre of the World Tree",
             "text": "Discard a land card: Pyre of the World Tree deals 2 damage to any target.\nWhenever you discard a land card, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6135,7 +6135,7 @@
         },
         {
             "id": "dca11ba5-ee8a-52bc-b12b-a07eecc2a6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg?1",
             "name": "Invasion of Karsus // Refraction Elemental",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Karsus enters the battlefield, it deals 3 damage to each creature and each planeswalker.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "33309313-7420-515b-93f4-00541b4a3748",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg?1",
             "name": "Invasion of Karsus // Refraction Elemental",
             "text": "Ward\u2014\nPay 2 life.\nWhenever you cast a spell, Refraction Elemental deals 2 damage to each opponent.",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "ed1304f7-e0a9-59ab-82e0-73dcb536144f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg?1",
             "name": "Invasion of Mercadia // Kyren Flamewright",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Mercadia enters the battlefield, you may discard a card. If you do, draw two cards.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "5670eab1-caaf-5eb2-a00f-10be900365ff",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg?1",
             "name": "Invasion of Mercadia // Kyren Flamewright",
             "text": "{2}{R}, {T}, Discard a card: Create two 1/1 blue and red Elemental creature tokens. Creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "164bfd10-f6f0-517a-8c97-7a95e09be464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg?1",
             "name": "Invasion of Regatha // Disciples of the Inferno",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Regatha enters the battlefield, it deals 4 damage to another target battle or opponent and 1 damage to up to one target creature.",
             "colours": [
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "0510e909-f1bc-5eae-8bf8-05e0abeaa01a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg?1",
             "name": "Invasion of Regatha // Disciples of the Inferno",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nIf a noncreature source you control would deal damage to a creature, battle, or opponent, it deals that much damage plus 2 instead.",
             "colours": [
@@ -6341,7 +6341,7 @@
         },
         {
             "id": "bb42b46d-365b-58ab-940d-b804f3392633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg?1",
             "name": "Invasion of Tarkir // Defiant Thundermaw",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Tarkir enters the battlefield, reveal any number of Dragon cards from your hand. When you do, Invasion of Tarkir deals X plus 2 damage to any other target, where X is the number of cards revealed this way. (X can be 0.)",
             "colours": [
@@ -6375,7 +6375,7 @@
         },
         {
             "id": "1a45e310-8c99-5f04-a6a2-28c23cc02a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg?1",
             "name": "Invasion of Tarkir // Defiant Thundermaw",
             "text": "Flying, trample\nWhenever a Dragon you control attacks, it deals 2 damage to any target.",
             "colours": [
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "1caa011e-3b37-56a8-be67-a98323dc568e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac76be5-3a2c-499e-830a-bd02eec517ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac76be5-3a2c-499e-830a-bd02eec517ce.jpg?1",
             "name": "Karsus Depthguard",
             "text": "Defender\nAs long as Karsus Depthguard's power is 5 or greater, it can attack as though it didn't have defender.",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "d76f9500-071d-5566-ba40-451fdc84e22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg?1",
             "name": "Khenra Spellspear // Gitaxian Spellstalker",
             "text": "Trample\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{3}{PU}: Transform Khenra Spellspear. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -6480,7 +6480,7 @@
         },
         {
             "id": "746a6706-038b-5f21-a8c2-4c5d8cd390ef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg?1",
             "name": "Khenra Spellspear // Gitaxian Spellstalker",
             "text": "Trample, ward {2}, prowess, prowess (Each instance of prowess triggers separately.)",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "14925070-798b-57b2-ad2e-1d3e817a392d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45a5f4a-2174-4885-aa5a-c4c24cc732f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45a5f4a-2174-4885-aa5a-c4c24cc732f0.jpg?1",
             "name": "Lithomantic Barrage",
             "text": "This spell can't be countered.\nLithomantic Barrage deals 1 damage to target creature or planeswalker. It deals 5 damage instead if that target is white and/or blue.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "a115dd07-7223-508d-bc8f-2ce057023266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625d6a-3844-4d23-ab35-ee3c3508db8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625d6a-3844-4d23-ab35-ee3c3508db8d.jpg?1",
             "name": "Marauding Dreadship",
             "text": "Haste\nWhen Marauding Dreadship enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "c43f5199-5712-5eaf-b563-4d5d75158d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d00b8-1373-47b2-9be5-2199e0b12540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d00b8-1373-47b2-9be5-2199e0b12540.jpg?1",
             "name": "Mirran Banesplitter",
             "text": "Flash\nWhen Mirran Banesplitter enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "4fa4326b-3407-5095-84e8-8e9785bc2cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0453fea-3c88-4eb1-818a-9efa01986852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0453fea-3c88-4eb1-818a-9efa01986852.jpg?1",
             "name": "Nahiri's Warcrafting",
             "text": "Nahiri's Warcrafting deals 5 damage to target creature, planeswalker, or battle. Look at the top X cards of your library, where X is the excess damage dealt this way. You may exile one of those cards. Put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -6651,7 +6651,7 @@
         },
         {
             "id": "4f94f436-80a5-509e-80f7-b94f14ac6f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5446057-7330-40b9-a5d9-bad4876337cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5446057-7330-40b9-a5d9-bad4876337cd.jpg?1",
             "name": "Onakke Javelineer",
             "text": "Reach\n{T}: Onakke Javelineer deals 2 damage to target player or battle.",
             "colours": [
@@ -6686,7 +6686,7 @@
         },
         {
             "id": "a7d602db-4417-5f4e-a949-38777439a42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg?1",
             "name": "Pyretic Prankster // Glistening Goremonger",
             "text": "{3}{PB}: Transform Pyretic Prankster. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "218c4856-dfaf-55b4-9e9c-c8e55a96fe7e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg?1",
             "name": "Pyretic Prankster // Glistening Goremonger",
             "text": "When Glistening Goremonger dies, each opponent sacrifices an artifact or creature.",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "f97cf180-f553-500e-8855-b8e5c0fe7a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0bb76-075c-49d7-9afb-e5bcf5b654f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0bb76-075c-49d7-9afb-e5bcf5b654f7.jpg?1",
             "name": "Ral's Reinforcements",
             "text": "Create two 1/1 blue and red Elemental creature tokens.",
             "colours": [
@@ -6790,7 +6790,7 @@
         },
         {
             "id": "a207f344-541a-5dc1-a822-efd277c9f2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd6f04e-e83d-4580-ae3f-583ada848868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd6f04e-e83d-4580-ae3f-583ada848868.jpg?1",
             "name": "Ramosian Greatsword",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEquipped creature gets +3/+1 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6824,7 +6824,7 @@
         },
         {
             "id": "0e5132b6-0c80-531f-9658-d296e3973e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b80ddb-ce55-4ebc-b587-77843abc8bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b80ddb-ce55-4ebc-b587-77843abc8bad.jpg?1",
             "name": "Rampaging Raptor",
             "text": "Trample, haste\n{2}{R}: Rampaging Raptor gets +2/+0 until end of turn.\nWhenever Rampaging Raptor deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls or battle that player protects.",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "da35ec76-de68-5707-99f4-f4bbc39b3ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ca435-aa84-4d35-80db-d1c74b878b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ca435-aa84-4d35-80db-d1c74b878b12.jpg?1",
             "name": "Redcap Heelslasher",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nFirst strike",
             "colours": [
@@ -6895,7 +6895,7 @@
         },
         {
             "id": "9b09aa6d-2bf8-5f6e-ab4c-f4a69e733adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6c877a-25f7-4ee7-8cf0-33728ef085fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6c877a-25f7-4ee7-8cf0-33728ef085fc.jpg?1",
             "name": "Scrappy Bruiser",
             "text": "Whenever Scrappy Bruiser attacks, up to one target attacking creature gets +2/+0 and gains trample until end of turn. Return that creature to its owner's hand at end of combat. (Return it only if it's on the battlefield.)",
             "colours": [
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "c1979ee2-33dd-594d-924f-6103265fae36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f156b6-68c2-4787-b3f0-6d1079bb576f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f156b6-68c2-4787-b3f0-6d1079bb576f.jpg?1",
             "name": "Searing Barb",
             "text": "Searing Barb deals 2 damage to any target. If it's a creature, it can't block this turn. Incubate 1. (Create an Incubator token with a +1/+1 counter on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "4eb7630c-5067-5628-b351-e05e2a800134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032720a1-410b-4638-9294-35fd8e27375f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032720a1-410b-4638-9294-35fd8e27375f.jpg?1",
             "name": "Shatter the Source",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one \u2014\n\u2022 Shatter the Source deals 6 damage to target creature, planeswalker, or battle.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "6205b35f-10c1-5a10-8c62-eba899e19b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585631c-bd41-4b48-aac4-4b6f5636ecd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585631c-bd41-4b48-aac4-4b6f5636ecd5.jpg?1",
             "name": "Shivan Branch-Burner",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying, haste",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "3bb70b19-c736-5fb3-a551-95693a9bf65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04113b3c-cc8f-4b15-9091-f82ea3df2e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04113b3c-cc8f-4b15-9091-f82ea3df2e7c.jpg?1",
             "name": "Stoke the Flames",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nStoke the Flames deals 4 damage to any target.",
             "colours": [
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "d1376554-d4c4-5e0b-bc41-aa8afd8862cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fd9ccb-2cb0-4fe1-9eb0-ba929bb527be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fd9ccb-2cb0-4fe1-9eb0-ba929bb527be.jpg?1",
             "name": "Thrashing Frontliner",
             "text": "Trample\nWhenever Thrashing Frontliner attacks a battle, it gets +1/+1 until end of turn.",
             "colours": [
@@ -7097,7 +7097,7 @@
         },
         {
             "id": "95583254-0f19-52cf-9346-de0db4609b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53088da-25b5-4c7e-9a11-456fbc814dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53088da-25b5-4c7e-9a11-456fbc814dfc.jpg?1",
             "name": "Trailblazing Historian",
             "text": "Haste\n{T}: Another target creature gains haste until end of turn.",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "a660e82b-e1fa-52f1-8139-0832830ceb9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "First strike\nWhenever you cast an instant or sorcery spell, Urabrask deals 1 damage to target opponent. Add {R}.\n{R}: Exile Urabrask, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you've cast three or more instant and/or sorcery spells this turn.",
             "colours": [
@@ -7172,7 +7172,7 @@
         },
         {
             "id": "5790e3d9-3748-5267-a643-24a046f64221",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 The Great Work deals 3 damage to target opponent and each creature they control.\nII \u2014 Create three Treasure tokens.\nIII \u2014 Until end of turn, you may cast instant and sorcery spells from any graveyard. If a spell cast this way would be put into a graveyard, exile it instead. Exile The Great Work, then return it to the battlefield (front face up).",
             "colours": [
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "22235f1a-f155-5a62-bd61-7c4612b8f134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69490262-afc2-4692-8fac-b771a972c8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69490262-afc2-4692-8fac-b771a972c8f8.jpg?1",
             "name": "Volcanic Spite",
             "text": "Volcanic Spite deals 3 damage to target creature, planeswalker, or battle. You may put a card from your hand on the bottom of your library. If you do, draw a card.",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "8d56aff8-24cd-52df-9b00-c8f445ba7d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbcd466-fb99-4388-a118-4534b85544f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbcd466-fb99-4388-a118-4534b85544f0.jpg?1",
             "name": "Voldaren Thrillseeker",
             "text": "Backup 2 (When this creature enters the battlefield, put two +1/+1 counters on target creature. If that's another creature, it gains the following ability until end of turn.)\n{1}, Sacrifice this creature: It deals damage equal to its power to any target.",
             "colours": [
@@ -7278,7 +7278,7 @@
         },
         {
             "id": "fde50677-361b-5e11-bb17-8cc4833ecbe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a87c5d-5efc-4ceb-b165-27f807117f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a87c5d-5efc-4ceb-b165-27f807117f71.jpg?1",
             "name": "War-Trained Slasher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever War-Trained Slasher attacks a battle, double its power until end of turn.",
             "colours": [
@@ -7313,7 +7313,7 @@
         },
         {
             "id": "86705079-980e-5271-9ec1-b07b2902b9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47999c-12d5-4e1a-a9c1-40a1757007f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47999c-12d5-4e1a-a9c1-40a1757007f1.jpg?1",
             "name": "Wrenn's Resolve",
             "text": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "7232d6fd-c8be-56cd-a583-70ffe2b5c1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687d3261-dfbf-4c49-986f-20117b7ab5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687d3261-dfbf-4c49-986f-20117b7ab5e7.jpg?1",
             "name": "Ancient Imperiosaur",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample, ward {2}\nAncient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.",
             "colours": [
@@ -7381,7 +7381,7 @@
         },
         {
             "id": "64578c5e-b25f-5d84-8ad9-286917bad659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8278069a-bd92-40ee-b7d5-e740dddb00fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8278069a-bd92-40ee-b7d5-e740dddb00fa.jpg?1",
             "name": "Arachnoid Adaptation",
             "text": "Target creature gets +2/+2 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "163c7b7b-41a8-54f5-9f84-8855d010df5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08ed414-77bf-402a-82a8-9d4e1bd627a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08ed414-77bf-402a-82a8-9d4e1bd627a1.jpg?1",
             "name": "Atraxa's Fall",
             "text": "Destroy target artifact, battle, enchantment, or creature with flying.",
             "colours": [
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "6db66913-4386-5360-b5ea-bdcfa3bf7f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007324b3-b8a9-4a32-a5a1-ad78f3a07bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007324b3-b8a9-4a32-a5a1-ad78f3a07bc3.jpg?1",
             "name": "Blighted Burgeoning",
             "text": "Enchant land\nWhen Blighted Burgeoning enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -7479,7 +7479,7 @@
         },
         {
             "id": "fd0a4215-096b-503c-be1c-bf200bf83b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg?1",
             "name": "Bonded Herdbeast // Plated Kilnbeast",
             "text": "{4}{PR}: Transform Bonded Herdbeast. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "71b92adb-fc6e-5078-b47e-c580f4977a05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg?1",
             "name": "Bonded Herdbeast // Plated Kilnbeast",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "cbbc3b8e-2f5f-5d2b-9d4f-831df34c5c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c249d9-37c0-451d-866b-e834c4c57214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c249d9-37c0-451d-866b-e834c4c57214.jpg?1",
             "name": "Chomping Kavu",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nThis creature can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "7d369fb5-4b98-59da-8373-60a0cd03486f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd3ecb-8c11-4a4c-a503-bc29f79a9dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd3ecb-8c11-4a4c-a503-bc29f79a9dcb.jpg?1",
             "name": "Converter Beast",
             "text": "When Converter Beast enters the battlefield, incubate 5. (Create an Incubator token with five +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -7620,7 +7620,7 @@
         },
         {
             "id": "44b98c9b-dffd-51cb-aa88-5d6c645373d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af527344-9d88-4641-8f6d-0263a6797df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af527344-9d88-4641-8f6d-0263a6797df3.jpg?1",
             "name": "Copper Host Crusher",
             "text": "Trample\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "5f6e9fcc-595a-5e82-8fb8-3763af34eea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eef541-6851-4312-ad2b-74f45c7ede6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eef541-6851-4312-ad2b-74f45c7ede6c.jpg?1",
             "name": "Cosmic Hunger",
             "text": "Target creature you control deals damage equal to its power to another target creature, planeswalker, or battle.",
             "colours": [
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "9f709e7c-0304-5a56-b329-1fde6a24ec70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1888c61-dc2d-4a33-9ba4-439d97f490be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1888c61-dc2d-4a33-9ba4-439d97f490be.jpg?1",
             "name": "Crystal Carapace",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has ward {2}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "1a293440-02ed-5170-b8ed-009c4dfe7659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4066d41-0eb5-4dfd-93ec-2f242c3a27a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4066d41-0eb5-4dfd-93ec-2f242c3a27a4.jpg?1",
             "name": "Deeproot Wayfinder",
             "text": "Whenever Deeproot Wayfinder deals combat damage to a player or battle, surveil 1, then you may return a land card from your graveyard to the battlefield tapped. (To surveil 1, look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -7759,7 +7759,7 @@
         },
         {
             "id": "04f50ac8-456a-56f4-b928-9929e2c759b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1db4e3-e98c-49af-8682-3b7aa20bc31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1db4e3-e98c-49af-8682-3b7aa20bc31e.jpg?1",
             "name": "Doomskar Warrior",
             "text": "Backup 1\nTrample\nWhenever this creature deals combat damage to a player or battle, look at that many cards from the top of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "6ed0ead3-3856-5d56-9318-c2164917a78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bbfb58-8b22-4e8d-991c-855c29964d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bbfb58-8b22-4e8d-991c-855c29964d94.jpg?1",
             "name": "Fertilid's Favor",
             "text": "Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles. Put two +1/+1 counters on up to one target artifact or creature.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "ffae4b2f-c109-58e7-a75a-bb19e59c0a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5443f4f6-a549-4912-a919-69e3570a9933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5443f4f6-a549-4912-a919-69e3570a9933.jpg?1",
             "name": "Glistening Dawn",
             "text": "Incubate X twice, where X is the number of lands you control. (To incubate X, create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -7862,7 +7862,7 @@
         },
         {
             "id": "cf3c3827-be59-5984-b67d-c58aa4aa65e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg?1",
             "name": "Gnottvold Hermit // Chrome Host Hulk",
             "text": "{5}{PU}: Transform Gnottvold Hermit. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "7309a0c9-bca0-50bf-bbda-5da5b519d0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg?1",
             "name": "Gnottvold Hermit // Chrome Host Hulk",
             "text": "Whenever Chrome Host Hulk attacks, up to one other target creature has base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -7934,7 +7934,7 @@
         },
         {
             "id": "5933955b-4871-5abd-a7ff-febc0a0997dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg?1",
             "name": "Herbology Instructor // Malady Invoker",
             "text": "When Herbology Instructor enters the battlefield, you gain 3 life.\n{6}{PB}: Transform Herbology Instructor. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -7970,7 +7970,7 @@
         },
         {
             "id": "45bd5089-4189-5e79-b9fe-deda18f0206b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg?1",
             "name": "Herbology Instructor // Malady Invoker",
             "text": "When this creature transforms into Malady Invoker, target creature an opponent controls gets -0/-X until end of turn, where X is Malady Invoker's power.",
             "colours": [
@@ -8007,7 +8007,7 @@
         },
         {
             "id": "73bc51de-a0ad-5cde-a229-3ed3893c4764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg?1",
             "name": "Invasion of Ikoria // Zilortha, Apex of Ikoria",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ikoria enters the battlefield, search your library and/or graveyard for a non-Human creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle.",
             "colours": [
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "1f8a8202-28ff-5337-ba0c-c06acec25162",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg?1",
             "name": "Invasion of Ikoria // Zilortha, Apex of Ikoria",
             "text": "Reach\nFor each non-Human creature you control, you may have that creature assign its combat damage as though it weren't blocked.",
             "colours": [
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "97a63d3c-5572-5795-8a30-cf1b6b11e50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg?1",
             "name": "Invasion of Ixalan // Belligerent Regisaur",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ixalan enters the battlefield, look at the top five cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "ef7a0e27-b71e-5159-b030-cf9107f1508c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg?1",
             "name": "Invasion of Ixalan // Belligerent Regisaur",
             "text": "Trample\nWhenever you cast a spell, Belligerent Regisaur gains indestructible until end of turn.",
             "colours": [
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "41ef2441-1e98-5da7-948d-bc5e8bbd9a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg?1",
             "name": "Invasion of Muraganda // Primordial Plasm",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Muraganda enters the battlefield, put a +1/+1 counter on target creature you control. Then that creature fights up to one target creature you don't control.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "65aa2c3c-4d3e-5c4c-aacd-f2bcb0f03077",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg?1",
             "name": "Invasion of Muraganda // Primordial Plasm",
             "text": "At the beginning of combat on your turn, another target creature gets +2/+2 and loses all abilities until end of turn.",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "0f8f82e4-f662-59ad-9cfb-fdf2c97c6519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg?1",
             "name": "Invasion of Shandalar // Leyline Surge",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Shandalar enters the battlefield, return up to three target permanent cards from your graveyard to your hand.",
             "colours": [
@@ -8247,7 +8247,7 @@
         },
         {
             "id": "06b6e4cc-e2f1-5147-bd20-d3305bf41e23",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg?1",
             "name": "Invasion of Shandalar // Leyline Surge",
             "text": "At the beginning of your upkeep, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -8279,7 +8279,7 @@
         },
         {
             "id": "f75922b9-2a6f-5a5c-b559-47ea7540601b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg?1",
             "name": "Invasion of Zendikar // Awakened Skyclave",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Zendikar enters the battlefield, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "d9333b7e-78ab-5b78-bc14-8bf10f90645d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg?1",
             "name": "Invasion of Zendikar // Awakened Skyclave",
             "text": "Vigilance, haste\nAs long as Awakened Skyclave is on the battlefield, it's a land in addition to its other types.\n{T}: Add one mana of any color.",
             "colours": [
@@ -8347,7 +8347,7 @@
         },
         {
             "id": "d25063db-c584-5dc9-a74a-9197a27964c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fee189f-539f-48fa-b217-4b2599375364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fee189f-539f-48fa-b217-4b2599375364.jpg?1",
             "name": "Iridescent Blademaster",
             "text": "{3}{G}: Iridescent Blademaster gets +2/+2 until end of turn.",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "f2549ebd-b2ce-5786-9100-ab138485d918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c644650-3861-4a78-9e39-a413b073ddac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c644650-3861-4a78-9e39-a413b073ddac.jpg?1",
             "name": "Kami of Whispered Hopes",
             "text": "If one or more +1/+1 counters would be put on a permanent you control, that many plus one +1/+1 counters are put on that permanent instead.\n{T}: Add X mana of any one color, where X is Kami of Whispered Hopes's power.",
             "colours": [
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "8ec5536e-c434-5e84-9254-faa20f89395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e04eed-9a6c-491b-8f1f-1c76ac40452d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e04eed-9a6c-491b-8f1f-1c76ac40452d.jpg?1",
             "name": "Overgrown Pest",
             "text": "When Overgrown Pest enters the battlefield, look at the top five cards of your library. You may reveal a land or double-faced card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "6355315b-6fa3-58fa-99d2-82e0c3766444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9eee658-29e8-4ab5-8a0e-31f2f28a9a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9eee658-29e8-4ab5-8a0e-31f2f28a9a92.jpg?1",
             "name": "Ozolith, the Shattered Spire",
             "text": "If one or more +1/+1 counters would be put on an artifact or creature you control, that many plus one +1/+1 counters are put on it instead.\n{1}{G}, {T}: Put a +1/+1 counter on target artifact or creature you control. Activate only as a sorcery.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -8488,7 +8488,7 @@
         },
         {
             "id": "065979d3-a601-53b0-bed3-b641a4578fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a87c5d2-3ebc-442b-8618-963cfc63855f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a87c5d2-3ebc-442b-8618-963cfc63855f.jpg?1",
             "name": "Placid Rottentail",
             "text": "Vigilance\n{2}{G}, Exile Placid Rottentail from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
             "colours": [
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "b30f5f2b-979b-529e-9491-ebf7901a8f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach\n{6}{PW}: Transform Polukranos Reborn. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -8562,7 +8562,7 @@
         },
         {
             "id": "a5e6fc8e-1736-53cc-99d8-6f13aeb02207",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach, lifelink\nWhenever Polukranos, Engine of Ruin or another nontoken Hydra you control dies, create a 3/3 green and white Phyrexian Hydra creature token with reach and a 3/3 green and white Phyrexian Hydra creature token with lifelink.",
             "colours": [
@@ -8603,7 +8603,7 @@
         },
         {
             "id": "b70f34ca-edcf-5dd0-b476-5b5ff48a55f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6104d4-d0af-40da-8227-14243d778e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6104d4-d0af-40da-8227-14243d778e96.jpg?1",
             "name": "Portent Tracker",
             "text": "{T}: Untap target land.\n{T}: Choose target battle. If an opponent protects it, remove a defense counter from it. Otherwise, put a defense counter on it. Activate only as a sorcery.",
             "colours": [
@@ -8638,7 +8638,7 @@
         },
         {
             "id": "db9add44-2c3d-5ad8-9451-9de9efcccf51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a225cb30-9f3e-4cfa-bdd6-a7c73c95ea2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a225cb30-9f3e-4cfa-bdd6-a7c73c95ea2b.jpg?1",
             "name": "Ravenous Sailback",
             "text": "When Ravenous Sailback enters the battlefield, choose one \u2014\n\u2022 Ravenous Sailback gains haste until end of turn.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "ca9510e8-80ef-532d-9981-1f81b7bd07e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17b083-413b-4a09-a935-ac27594e3bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17b083-413b-4a09-a935-ac27594e3bd6.jpg?1",
             "name": "Sandstalker Moloch",
             "text": "Flash\nWhen Sandstalker Moloch enters the battlefield, if an opponent cast a blue and/or black spell this turn, look at the top four cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8706,7 +8706,7 @@
         },
         {
             "id": "2577e6a8-fe84-52fe-8a87-393ac850b70c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084a8b94-0c5d-41e0-88e4-fe91ab92c09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084a8b94-0c5d-41e0-88e4-fe91ab92c09d.jpg?1",
             "name": "Seed of Hope",
             "text": "Mill two cards. You may put a permanent card from among the milled cards into your hand. You gain 2 life. (To mill two cards, put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "43cfb7a4-6ff3-53f3-967b-33ff90b9b854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fabc49f-b665-4c56-b06e-03220f7918bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fabc49f-b665-4c56-b06e-03220f7918bb.jpg?1",
             "name": "Serpent-Blade Assailant",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nDeathtouch",
             "colours": [
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "9388256e-aec2-5c7c-84cc-6b8f17a43d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf989a4d-3209-4071-b6e9-d2b99372ec10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf989a4d-3209-4071-b6e9-d2b99372ec10.jpg?1",
             "name": "Storm the Seedcore",
             "text": "Distribute four +1/+1 counters among up to four target creatures you control. Creatures you control gain vigilance and trample until end of turn.",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "a05db8bf-aab9-5c75-bcbc-2a31620a613a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f9565-4c04-449d-b337-0eff3fd0c295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f9565-4c04-449d-b337-0eff3fd0c295.jpg?1",
             "name": "Streetwise Negotiator",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nThis creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "ef292507-fbe1-5e94-9c29-fd0e3db6dd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb51be0-6a2e-464a-86d1-aa36179c8c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb51be0-6a2e-464a-86d1-aa36179c8c18.jpg?1",
             "name": "Tandem Takedown",
             "text": "Up to two target creatures you control each get +1/+0 until end of turn. They each deal damage equal to their power to another target creature, planeswalker, or battle.",
             "colours": [
@@ -8872,7 +8872,7 @@
         },
         {
             "id": "6c01b60d-9dbe-5bfb-8222-729179484003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e0ef1-a8e0-4c0a-a996-3eee89e37fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e0ef1-a8e0-4c0a-a996-3eee89e37fee.jpg?1",
             "name": "Tangled Skyline",
             "text": "When Tangled Skyline enters the battlefield, you gain 5 life and incubate 5. (Create an Incubator token with five +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have reach.",
             "colours": [
@@ -8904,7 +8904,7 @@
         },
         {
             "id": "78f5a1bd-f235-5043-93e1-38e5a67e85e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73cd60-cd89-4c7a-85a6-e0ae34ca101b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73cd60-cd89-4c7a-85a6-e0ae34ca101b.jpg?1",
             "name": "Timberland Ancient",
             "text": "Reach, trample\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -8938,7 +8938,7 @@
         },
         {
             "id": "57d30a16-afbb-53e4-95de-51c16de0c9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cdeaba-fc21-44e6-bf99-aa1ff379401b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cdeaba-fc21-44e6-bf99-aa1ff379401b.jpg?1",
             "name": "Tribute to the World Tree",
             "text": "Whenever a creature enters the battlefield under your control, draw a card if its power is 3 or greater. Otherwise, put two +1/+1 counters on it.",
             "colours": [
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "dd70e577-5c14-534e-9eb6-538f726184c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e20076-5d24-4c59-b707-6d20e121032f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e20076-5d24-4c59-b707-6d20e121032f.jpg?1",
             "name": "Vengeant Earth",
             "text": "Target creature or land you control becomes a 4/4 Elemental creature with haste in addition to its other types until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -9004,7 +9004,7 @@
         },
         {
             "id": "7bd0a200-ca22-525a-9ffb-8f23a28efca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "Trample, reach\nWhen Vorinclex enters the battlefield, search your library for up to two Forest cards, reveal them, put them into your hand, then shuffle.\n{6}{G}{G}: Exile Vorinclex, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "5fa1e219-b6b0-56f2-8985-570df6b5859c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill ten cards. Put up to two creature cards from among the milled cards onto the battlefield.\nII \u2014 Distribute seven +1/+1 counters among any number of target creatures you control.\nIII \u2014 Until end of turn, creatures you control gain \"{1}: This creature fights target creature you don't control.\" Exile The Grand Evolution, then return it to the battlefield (front face up).",
             "colours": [
@@ -9081,7 +9081,7 @@
         },
         {
             "id": "751681dd-268d-5f09-963d-c029240b6e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1",
             "name": "War Historian",
             "text": "Reach\nWar Historian has indestructible as long as it attacked a battle this turn.",
             "colours": [
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "d0c19a31-3c02-5d49-aab0-762e9ec34b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b29bf-0b64-410f-9a92-c88e5615c27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b29bf-0b64-410f-9a92-c88e5615c27f.jpg?1",
             "name": "Wary Thespian",
             "text": "When Wary Thespian enters the battlefield or dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "a924b6af-95bf-58de-8749-b9b65c1ef0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c6fc26-df6e-44de-96e6-a6e34086edc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c6fc26-df6e-44de-96e6-a6e34086edc2.jpg?1",
             "name": "Wildwood Escort",
             "text": "When Wildwood Escort enters the battlefield, return target creature or battle card from your graveyard to your hand.\nIf Wildwood Escort would die, exile it instead.",
             "colours": [
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "c7c4e1f7-fb55-55f9-9604-27fbb5207e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f807d91-b157-44e8-a431-49782184f876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f807d91-b157-44e8-a431-49782184f876.jpg?1",
             "name": "Wrenn and Realmbreaker",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n+1: Up to one target land you control becomes a 3/3 Elemental creature with vigilance, hexproof, and haste until your next turn. It's still a land.\n\u22122: Mill three cards. You may put a permanent card from among the milled cards into your hand.\n\u22127: You get an emblem with \"You may play lands and cast permanent spells from your graveyard.\"",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "bb6bd117-b187-5639-ac7b-9e0a1dd0e7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc43a788-ab06-4d28-b45a-aa47801d6ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc43a788-ab06-4d28-b45a-aa47801d6ace.jpg?1",
             "name": "Baral and Kari Zev",
             "text": "First strike, menace\nWhenever you cast your first instant or sorcery spell each turn, you may cast a spell with lesser mana value that shares a card type with it from your hand without paying its mana cost. If you don't, create First Mate Ragavan, a legendary 2/1 red Monkey Pirate creature token. It gains haste until end of turn.",
             "colours": [
@@ -9264,7 +9264,7 @@
         },
         {
             "id": "4ecf9f14-5822-5de8-a2dd-5da5402e547b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bbf1c1-2868-4c9e-b5c4-1aae86faed6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bbf1c1-2868-4c9e-b5c4-1aae86faed6c.jpg?1",
             "name": "Borborygmos and Fblthp",
             "text": "Whenever Borborygmos and Fblthp enters the battlefield or attacks, draw a card, then you may discard any number of land cards. When you discard one or more cards this way, Borborygmos and Fblthp deals twice that much damage to target creature.\n{1}{U}: Put Borborygmos and Fblthp into its owner's library third from the top.",
             "colours": [
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "e70776dd-0124-5827-a12d-87ad71b27d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977c15c9-2aad-4d1d-86a6-1f9d78ad7af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977c15c9-2aad-4d1d-86a6-1f9d78ad7af6.jpg?1",
             "name": "Botanical Brawler",
             "text": "Trample\nBotanical Brawler enters the battlefield with two +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another permanent you control, if it's the first time +1/+1 counters have been put on that permanent this turn, put a +1/+1 counter on Botanical Brawler.",
             "colours": [
@@ -9346,7 +9346,7 @@
         },
         {
             "id": "500fe84b-f90d-5866-8f58-6548bfc23e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db1ae7b-ed48-409f-8d50-07c7e8c6c128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db1ae7b-ed48-409f-8d50-07c7e8c6c128.jpg?1",
             "name": "Djeru and Hazoret",
             "text": "As long as you have one or fewer cards in hand, Djeru and Hazoret has vigilance and haste.\nWhenever Djeru and Hazoret attacks, look at the top six cards of your library. You may exile a legendary creature card from among them. Put the rest on the bottom of your library in a random order. Until end of turn, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "ec98507f-48c7-53e0-ad56-3402563ea371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda000f-3cf7-48b6-96ff-c23a3a64eab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda000f-3cf7-48b6-96ff-c23a3a64eab5.jpg?1",
             "name": "Drana and Linvala",
             "text": "Flying, vigilance\nActivated abilities of creatures your opponents control can't be activated.\nDrana and Linvala has all activated abilities of all creatures your opponents control. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -9428,7 +9428,7 @@
         },
         {
             "id": "5a286ada-73b5-5856-9c9c-27a042626a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3227c07-9ef2-46a6-9b4f-bbd6ef12f4a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3227c07-9ef2-46a6-9b4f-bbd6ef12f4a5.jpg?1",
             "name": "Elvish Vatkeeper",
             "text": "When Elvish Vatkeeper enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n{5}: Transform target Incubator token you control. Double the number of +1/+1 counters on it.",
             "colours": [
@@ -9465,7 +9465,7 @@
         },
         {
             "id": "ece93143-6cae-5066-ae97-56ec212fcbf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa2d03-7713-44d4-8fca-45c6f77b174b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa2d03-7713-44d4-8fca-45c6f77b174b.jpg?1",
             "name": "Errant and Giada",
             "text": "Flash\nFlying\nYou may look at the top card of your library any time.\nYou may cast spells with flash or flying from the top of your library.",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "454df7bf-2a50-5d57-9c8a-edefb554ce55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ec900f-1e31-4440-a75a-20b256734d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ec900f-1e31-4440-a75a-20b256734d5b.jpg?1",
             "name": "Ghalta and Mavren",
             "text": "Trample\nWhenever you attack, choose one \u2014\n\u2022 Create a tapped and attacking X/X green Dinosaur creature token with trample, where X is the greatest power among other attacking creatures.\n\u2022 Create X 1/1 white Vampire creature tokens with lifelink, where X is the number of other attacking creatures.",
             "colours": [
@@ -9548,7 +9548,7 @@
         },
         {
             "id": "0afd0974-f8bd-5cbe-af35-86e4f4558a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c299066-dfdd-47a3-85e6-225508ba95fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c299066-dfdd-47a3-85e6-225508ba95fe.jpg?1",
             "name": "Glissa, Herald of Predation",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Incubate 2 twice. (To incubate 2, create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n\u2022 Transform all Incubator tokens you control.\n\u2022 Phyrexians you control gain first strike and deathtouch until end of turn.",
             "colours": [
@@ -9590,7 +9590,7 @@
         },
         {
             "id": "49918a1c-eab4-5b05-b651-e06992738166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb5f0cc-c826-4e7b-882c-63f6e51fa932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb5f0cc-c826-4e7b-882c-63f6e51fa932.jpg?1",
             "name": "Halo Forager",
             "text": "Flying\nWhen Halo Forager enters the battlefield, you may pay {X}. When you do, you may cast target instant or sorcery card with mana value X from a graveyard without paying its mana cost. If that spell would be put into a graveyard, exile it instead.",
             "colours": [
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "41f6ad11-2d47-523a-a78d-5bdabfaed957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81039daf-0d54-4474-a833-fa287ec10cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81039daf-0d54-4474-a833-fa287ec10cf9.jpg?1",
             "name": "Hidetsugu and Kairi",
             "text": "Flying\nWhen Hidetsugu and Kairi enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.\nWhen Hidetsugu and Kairi dies, exile the top card of your library. Target opponent loses life equal to its mana value. If it's an instant or sorcery card, you may cast it without paying its mana cost.",
             "colours": [
@@ -9671,7 +9671,7 @@
         },
         {
             "id": "a325d9e9-2b5f-5ada-837a-414caf84e043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa97506-b943-4443-96b1-1b49f57d80aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa97506-b943-4443-96b1-1b49f57d80aa.jpg?1",
             "name": "Inga and Esika",
             "text": "Creatures you control have vigilance and \"{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\"\nWhenever you cast a creature spell, if three or more mana from creatures was spent to cast it, draw a card.",
             "colours": [
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "60f7db0d-743f-59a4-b62f-16cef07ef47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg?1",
             "name": "Invasion of Alara // Awaken the Maelstrom",
             "text": "When Invasion of Alara enters the battlefield, exile cards from the top of your library until you exile two nonland cards with mana value 4 or less. You may cast one of those two cards without paying its mana cost. Put one of them into your hand. Then put the other cards exiled this way on the bottom of your library in a random order.",
             "colours": [
@@ -9754,7 +9754,7 @@
         },
         {
             "id": "99550742-8719-53e7-b929-7ee18bef6eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg?1",
             "name": "Invasion of Alara // Awaken the Maelstrom",
             "text": "Awaken the Maelstrom is all colors.\nTarget player draws two cards. You may put an artifact card from your hand onto the battlefield. Create a token that's a copy of a permanent you control. Distribute three +1/+1 counters among one, two, or three creatures you control. Destroy target permanent an opponent controls.",
             "colours": [
@@ -9794,7 +9794,7 @@
         },
         {
             "id": "f25152f1-f5fd-599e-834c-aff8a94df8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg?1",
             "name": "Invasion of Amonkhet // Lazotep Convert",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Amonkhet enters the battlefield, each player mills three cards, then each opponent discards a card and you draw a card. (To mill three cards, a player puts the top three cards of their library into their graveyard.)",
             "colours": [
@@ -9830,7 +9830,7 @@
         },
         {
             "id": "7a132681-9f0b-51ec-b747-c53dab4ea9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg?1",
             "name": "Invasion of Amonkhet // Lazotep Convert",
             "text": "You may have Lazotep Convert enter the battlefield as a copy of any creature card in a graveyard, except it's a 4/4 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -9866,7 +9866,7 @@
         },
         {
             "id": "617af43d-0e84-5a50-b980-b92a4e45e159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg?1",
             "name": "Invasion of Azgol // Ashen Reaper",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Azgol enters the battlefield, target player sacrifices a creature or planeswalker and loses 1 life.",
             "colours": [
@@ -9902,7 +9902,7 @@
         },
         {
             "id": "d6283d24-3a58-5381-8ff6-1254bd4474ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg?1",
             "name": "Invasion of Azgol // Ashen Reaper",
             "text": "Menace\nAt the beginning of your end step, put a +1/+1 counter on Ashen Reaper if a permanent was put into a graveyard from the battlefield this turn.",
             "colours": [
@@ -9939,7 +9939,7 @@
         },
         {
             "id": "dc9b6914-986c-5dc5-8095-24a47c030db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg?1",
             "name": "Invasion of Ergamon // Truga Cliffcharger",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ergamon enters the battlefield, create a Treasure token. Then you may discard a card. If you do, draw a card.",
             "colours": [
@@ -9975,7 +9975,7 @@
         },
         {
             "id": "0fa42ca1-2fc6-57f1-8423-cfd0073387f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg?1",
             "name": "Invasion of Ergamon // Truga Cliffcharger",
             "text": "Trample\nWhen Truga Cliffcharger enters the battlefield, you may discard a card. If you do, search your library for a land or battle card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "a73ff0d3-fd1e-54d2-8684-b836331a9130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg?1",
             "name": "Invasion of Kaladesh // Aetherwing, Golden-Scale Flagship",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kaladesh enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "9c5743e3-6ccd-5049-bba3-56445bf06363",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg?1",
             "name": "Invasion of Kaladesh // Aetherwing, Golden-Scale Flagship",
             "text": "Flying\nAetherwing, Golden-Scale Flagship's power is equal to the number of artifacts you control.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "8ce4e9f6-62a8-58f3-98e9-48937bd0aefc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg?1",
             "name": "Invasion of Kylem // Valor's Reach Tag Team",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kylem enters the battlefield, up to two target creatures each get +2/+0 and gain vigilance and haste until end of turn.",
             "colours": [
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "9d26a474-3b3e-587b-ba8d-377bf5f95d68",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg?1",
             "name": "Invasion of Kylem // Valor's Reach Tag Team",
             "text": "Create two 3/2 red and white Warrior creature tokens with \"Whenever this creature and at least one other creature token attack, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -10155,7 +10155,7 @@
         },
         {
             "id": "2073ab80-b648-533b-8e0d-e8971f4642c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg?1",
             "name": "Invasion of Lorwyn // Winnowing Forces",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Lorwyn enters the battlefield, destroy target non-Elf creature an opponent controls with power X or less, where X is the number of lands you control.",
             "colours": [
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "dfa36ea4-066b-55e6-be1d-6b90b55d140c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg?1",
             "name": "Invasion of Lorwyn // Winnowing Forces",
             "text": "Winnowing Forces's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -10228,7 +10228,7 @@
         },
         {
             "id": "6b84c19a-052e-50f0-aa21-b4eb7eed4505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg?1",
             "name": "Invasion of Moag // Bloomwielder Dryads",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Moag enters the battlefield, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10264,7 +10264,7 @@
         },
         {
             "id": "f711e6fd-636d-5e86-96bc-92b415b65b58",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg?1",
             "name": "Invasion of Moag // Bloomwielder Dryads",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your end step, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -10300,7 +10300,7 @@
         },
         {
             "id": "870a6cde-d063-5193-b61e-6e9552ad6078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg?1",
             "name": "Invasion of New Capenna // Holy Frazzle-Cannon",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of New Capenna enters the battlefield, you may sacrifice an artifact or creature. When you do, exile target artifact or creature an opponent controls.",
             "colours": [
@@ -10336,7 +10336,7 @@
         },
         {
             "id": "6217cf93-4374-5136-8342-cdc0121000e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg?1",
             "name": "Invasion of New Capenna // Holy Frazzle-Cannon",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on that creature and each other creature you control that shares a creature type with it.\nEquip {1}",
             "colours": [
@@ -10372,7 +10372,7 @@
         },
         {
             "id": "7bcacdcd-ec54-5be9-95b8-8afb7fb2156e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg?1",
             "name": "Invasion of New Phyrexia // Teferi Akosa of Zhalfir",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of New Phyrexia enters the battlefield, create X 2/2 white and blue Knight creature tokens with vigilance.",
             "colours": [
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "4c21b872-6111-5f66-804f-8e15ffb4075e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg?1",
             "name": "Invasion of New Phyrexia // Teferi Akosa of Zhalfir",
             "text": "+1: Draw two cards. Then discard two cards unless you discard a creature card.\n\u22122: You get an emblem with \"Knights you control get +1/+0 and have ward {1}.\"\n\u22123: Tap X untapped creatures you control. When you do, shuffle target nonland permanent an opponent controls with mana value X or less into its owner's library.",
             "colours": [
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "a9b6c94a-d9ce-5704-93bf-2a62af205b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg?1",
             "name": "Invasion of Pyrulea // Gargantuan Slabhorn",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Pyrulea enters the battlefield, scry 3, then reveal the top card of your library. If it's a land or double-faced card, draw a card.",
             "colours": [
@@ -10482,7 +10482,7 @@
         },
         {
             "id": "b133ffd1-43d3-5a9b-b89a-d48fe479bfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg?1",
             "name": "Invasion of Pyrulea // Gargantuan Slabhorn",
             "text": "Trample, ward {2}\nOther transformed permanents you control have trample and ward {2}.",
             "colours": [
@@ -10518,7 +10518,7 @@
         },
         {
             "id": "ceb61e24-6e58-5ec0-aee0-61a52f8d87dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1",
             "name": "Invasion of Tolvada // The Broken Sky",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Tolvada enters the battlefield, return target nonbattle permanent card from your graveyard to the battlefield.",
             "colours": [
@@ -10554,7 +10554,7 @@
         },
         {
             "id": "9749345a-22e8-59a8-b16a-b26abc83d202",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1",
             "name": "Invasion of Tolvada // The Broken Sky",
             "text": "Creature tokens you control get +1/+0 and have lifelink.\nAt the beginning of your end step, create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -10588,7 +10588,7 @@
         },
         {
             "id": "18d50241-c3a3-57fd-9fb1-156c25cd52ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg?1",
             "name": "Invasion of Xerex // Vertex Paladin",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Xerex enters the battlefield, return up to one target creature to its owner's hand.",
             "colours": [
@@ -10624,7 +10624,7 @@
         },
         {
             "id": "582b4d0b-1e5c-5d34-917e-eb4f4626989d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg?1",
             "name": "Invasion of Xerex // Vertex Paladin",
             "text": "Flying\nVertex Paladin's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "c3a9ad8f-4fa4-593b-89f9-e787bf3acb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dabe69-a88f-4e61-a5fb-c4b9ef1c7569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dabe69-a88f-4e61-a5fb-c4b9ef1c7569.jpg?1",
             "name": "Joyful Stormsculptor",
             "text": "When Joyful Stormsculptor enters the battlefield, create two 1/1 blue and red Elemental creature tokens.\nWhenever you cast a spell that has convoke, Joyful Stormsculptor deals 1 damage to each opponent and each battle they protect.",
             "colours": [
@@ -10698,7 +10698,7 @@
         },
         {
             "id": "e1785f10-6812-5f68-99d2-ce60ae10286c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760ebdf-bea6-4c43-a187-4a02ebf95ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760ebdf-bea6-4c43-a187-4a02ebf95ebf.jpg?1",
             "name": "Kogla and Yidaro",
             "text": "When Kogla and Yidaro enters the battlefield, choose one \u2014\n\u2022 It gains trample and haste until end of turn.\n\u2022 It fights target creature you don't control.\n{2}{R}{G}, Discard Kogla and Yidaro: Destroy up to one target artifact or enchantment. Shuffle Kogla and Yidaro into your library from your graveyard, then draw a card.",
             "colours": [
@@ -10740,7 +10740,7 @@
         },
         {
             "id": "b4857586-a288-541e-bd82-29cfea585fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e4a233-e40b-4e6a-9863-4d0fc052484c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e4a233-e40b-4e6a-9863-4d0fc052484c.jpg?1",
             "name": "Kroxa and Kunoros",
             "text": "Vigilance, menace, lifelink\nWhenever Kroxa and Kunoros enters the battlefield or attacks, you may exile five cards from your graveyard. When you do, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "e43e9d60-d7cc-56e2-a846-b7272054b022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2418f5c-a85f-4249-8a53-c94b011b9714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2418f5c-a85f-4249-8a53-c94b011b9714.jpg?1",
             "name": "Marshal of Zhalfir",
             "text": "Other Knights you control get +1/+1.\n{W}{U}, {T}: Tap another target creature.",
             "colours": [
@@ -10821,7 +10821,7 @@
         },
         {
             "id": "29af7ddc-4a31-5100-99c4-fca29778612a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a5e7de-43cc-488b-99a4-7d173b42d5dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a5e7de-43cc-488b-99a4-7d173b42d5dc.jpg?1",
             "name": "Mirror-Shield Hoplite",
             "text": "Vigilance\nWhenever a creature you control becomes the target of a backup ability, copy that ability. You may choose new targets for the copy. This ability triggers only once each turn.",
             "colours": [
@@ -10858,7 +10858,7 @@
         },
         {
             "id": "52ae2f25-23fb-5275-9722-f5f7e07ddfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a84b6d7-3944-4223-ac16-aa5e59ac84cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a84b6d7-3944-4223-ac16-aa5e59ac84cb.jpg?1",
             "name": "Mutagen Connoisseur",
             "text": "Flying, vigilance\nMutagen Connoisseur gets +1/+0 for each transformed permanent you control.",
             "colours": [
@@ -10895,7 +10895,7 @@
         },
         {
             "id": "77ff02da-e3e9-5df5-a342-994ac785cfad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d94ecf-758b-4f68-a7be-6bf3ff1047f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d94ecf-758b-4f68-a7be-6bf3ff1047f4.jpg?1",
             "name": "Omnath, Locus of All",
             "text": "If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",
             "colours": [
@@ -10943,7 +10943,7 @@
         },
         {
             "id": "49a2714f-4c62-5c60-a99a-f245f9efb453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b152c-8376-42f9-9daf-e139dc29c9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b152c-8376-42f9-9daf-e139dc29c9ca.jpg?1",
             "name": "Quintorius, Loremaster",
             "text": "Vigilance\nAt the beginning of your end step, exile target noncreature, nonland card from your graveyard. Create a 3/2 red and white Spirit creature token.\n{1}{R}{W}, {T}, Sacrifice a Spirit: Choose target card exiled with Quintorius. You may cast that card this turn without paying its mana cost. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.",
             "colours": [
@@ -10984,7 +10984,7 @@
         },
         {
             "id": "2ffb215a-710a-5833-8548-708d61a30084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a973e70f-9e3e-47a3-94b9-7bb8a198a438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a973e70f-9e3e-47a3-94b9-7bb8a198a438.jpg?1",
             "name": "Rampaging Geoderm",
             "text": "Trample, haste\nWhenever you attack, target attacking creature gets +1/+1 until end of turn. If it's attacking a battle, put a +1/+1 counter on it instead.",
             "colours": [
@@ -11021,7 +11021,7 @@
         },
         {
             "id": "cbf79129-a0ca-5613-bedd-19c28e6e2c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92c191e-329c-41f5-ae4f-1bb91fc001a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92c191e-329c-41f5-ae4f-1bb91fc001a0.jpg?1",
             "name": "Rankle and Torbran",
             "text": "Flying, first strike, haste\nWhenever Rankle and Torbran deals combat damage to a player or battle, choose any number \u2014\n\u2022 Each player creates a Treasure token.\n\u2022 Each player sacrifices a creature.\n\u2022 If a source would deal damage to a player or battle this turn, it deals that much damage plus 2 instead.",
             "colours": [
@@ -11062,7 +11062,7 @@
         },
         {
             "id": "02ad0267-a020-5abd-9ac6-5353e6bca43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594aefa2-7a5b-4ec1-841b-a6ef4f5aa2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594aefa2-7a5b-4ec1-841b-a6ef4f5aa2b1.jpg?1",
             "name": "Sculpted Perfection",
             "text": "When Sculpted Perfection enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control get +1/+1.",
             "colours": [
@@ -11096,7 +11096,7 @@
         },
         {
             "id": "05e51f1c-622b-51db-a176-e7def724aaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b00c6e1-dfda-4c47-b1d8-4c114a921477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b00c6e1-dfda-4c47-b1d8-4c114a921477.jpg?1",
             "name": "Stormclaw Rager",
             "text": "{1}, Sacrifice another creature or artifact: Put a +1/+1 counter on Stormclaw Rager and draw a card. Activate only as a sorcery.",
             "colours": [
@@ -11133,7 +11133,7 @@
         },
         {
             "id": "4f94928f-8d22-576e-b3f4-3acb832625f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7ff937-de92-445f-976c-726fef5c91cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7ff937-de92-445f-976c-726fef5c91cc.jpg?1",
             "name": "Thalia and The Gitrog Monster",
             "text": "First strike, deathtouch\nYou may play an additional land on each of your turns.\nCreatures and nonbasic lands your opponents control enter the battlefield tapped.\nWhenever Thalia and The Gitrog Monster attacks, sacrifice a creature or land, then draw a card.",
             "colours": [
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "0e09aa03-a6fd-5580-a847-6c0888678c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c15e244-14cc-46a5-abd4-66a58d1c0dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c15e244-14cc-46a5-abd4-66a58d1c0dd0.jpg?1",
             "name": "Yargle and Multani",
             "text": "",
             "colours": [
@@ -11219,7 +11219,7 @@
         },
         {
             "id": "6c7a5c13-35aa-50dc-8632-cd94f35715b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2af874-1052-4cad-90ed-d80e49d4c68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2af874-1052-4cad-90ed-d80e49d4c68c.jpg?1",
             "name": "Zimone and Dina",
             "text": "Whenever you draw your second card each turn, target opponent loses 2 life and you gain 2 life.\n{T}, Sacrifice another creature: Draw a card. You may put a land card from your hand onto the battlefield tapped. If you control eight or more lands, repeat this process once.",
             "colours": [
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "beaca6ee-7b13-5ada-8cf1-b11413c4cb14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacbcd82-36e6-424c-bd4e-ec3a584836c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacbcd82-36e6-424c-bd4e-ec3a584836c5.jpg?1",
             "name": "Zurgo and Ojutai",
             "text": "Flying, haste\nZurgo and Ojutai has hexproof as long as it entered the battlefield this turn.\nWhenever one or more Dragons you control deal combat damage to a player or battle, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. You may return one of those Dragons to its owner's hand.",
             "colours": [
@@ -11305,7 +11305,7 @@
         },
         {
             "id": "5f16c80c-62f5-513e-8fa5-cb6b708c7c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694485d-a753-4e55-929c-d8e4a53c7d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694485d-a753-4e55-929c-d8e4a53c7d08.jpg?1",
             "name": "Flywheel Racer",
             "text": "Vigilance\n{T}: Add one mana of any color. Activate only if Flywheel Racer is a creature.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -11335,7 +11335,7 @@
         },
         {
             "id": "b03def35-15f3-5775-98a4-f54ab566629a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07baeb1-c873-42c2-8f1e-757f13572079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07baeb1-c873-42c2-8f1e-757f13572079.jpg?1",
             "name": "Halo Hopper",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
             "colours": [],
@@ -11366,7 +11366,7 @@
         },
         {
             "id": "528b28b7-178d-5a41-8faa-6a26df45c9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc3bf6e-e011-4334-a142-c09941c6f213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc3bf6e-e011-4334-a142-c09941c6f213.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11396,7 +11396,7 @@
         },
         {
             "id": "080dee5b-3e28-5117-8515-95d388a65d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93960b5e-b13c-4f7d-a826-8aad6bd210b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93960b5e-b13c-4f7d-a826-8aad6bd210b4.jpg?1",
             "name": "Phyrexian Archivist",
             "text": "Reach\n{2}, {T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -11428,7 +11428,7 @@
         },
         {
             "id": "8053f752-0eed-5456-93f1-3fe0cf72d6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608134-cfc3-48bf-92d8-35d732fcde54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608134-cfc3-48bf-92d8-35d732fcde54.jpg?1",
             "name": "Realmbreaker, the Invasion Tree",
             "text": "{2}, {T}: Target opponent mills three cards. Put a land card from their graveyard onto the battlefield tapped under your control. It gains \"If this land would leave the battlefield, exile it instead of putting it anywhere else.\"\n{1}0, {T}, Sacrifice Realmbreaker, the Invasion Tree: Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.",
             "colours": [],
@@ -11460,7 +11460,7 @@
         },
         {
             "id": "1de338ee-e241-52da-bfec-7465ad2b5016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae9f1d-e96d-444c-a0fd-5608243ee6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae9f1d-e96d-444c-a0fd-5608243ee6c8.jpg?1",
             "name": "Skittering Surveyor",
             "text": "When Skittering Surveyor enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -11491,7 +11491,7 @@
         },
         {
             "id": "3a3ca3b4-c565-5e8e-befa-e8e40e58ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670393d-86f0-46fb-b577-f73a1da2a3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670393d-86f0-46fb-b577-f73a1da2a3ed.jpg?1",
             "name": "Sword of Once and Future",
             "text": "Equipped creature gets +2/+2 and has protection from blue and from black.\nWhenever equipped creature deals combat damage to a player, surveil 2. Then you may cast an instant or sorcery spell with mana value 2 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.\nEquip {2}",
             "colours": [],
@@ -11523,7 +11523,7 @@
         },
         {
             "id": "de2a1835-fcbe-5dbb-aa3c-df0ac34d7eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f302e-d884-4995-ba3c-8c22f9045318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f302e-d884-4995-ba3c-8c22f9045318.jpg?1",
             "name": "Urn of Godfire",
             "text": "{2}: Add one mana of any color.\n{6}, {T}, Sacrifice Urn of Godfire: Destroy target creature or enchantment.",
             "colours": [],
@@ -11551,7 +11551,7 @@
         },
         {
             "id": "657c6a43-f1cd-5672-90af-8cb4095f62bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85930f68-6f53-4921-9556-2887ac3abfd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85930f68-6f53-4921-9556-2887ac3abfd2.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11582,7 +11582,7 @@
         },
         {
             "id": "c43970b7-1134-5d74-a65f-29a1ecab2d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34684d6-2935-4776-9a86-b603ad8cf624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34684d6-2935-4776-9a86-b603ad8cf624.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11613,7 +11613,7 @@
         },
         {
             "id": "4493239a-9e3e-5e1d-b2f0-158064a095af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cd4f63-3484-4cee-8603-1f89cabee6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cd4f63-3484-4cee-8603-1f89cabee6c3.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11644,7 +11644,7 @@
         },
         {
             "id": "837ae536-6529-56be-a838-1f069ed20e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed20a4-bc8a-44b1-b9b7-c82518c287b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed20a4-bc8a-44b1-b9b7-c82518c287b8.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11675,7 +11675,7 @@
         },
         {
             "id": "974d37f5-5e9d-50c7-8543-542c8bd264b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aeef1b1-a351-47ce-a686-a0eb0a35a894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aeef1b1-a351-47ce-a686-a0eb0a35a894.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -11706,7 +11706,7 @@
         },
         {
             "id": "451ce7a3-7461-5973-a97f-0c715391f6b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aefbfc-3f67-443d-8ec4-cc9beafb64ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aefbfc-3f67-443d-8ec4-cc9beafb64ee.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -11737,7 +11737,7 @@
         },
         {
             "id": "1967ceae-7733-5eea-bd4b-a479deee287b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957efc4e-c2a9-46a2-b9e3-20dc419ffd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957efc4e-c2a9-46a2-b9e3-20dc419ffd05.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -11768,7 +11768,7 @@
         },
         {
             "id": "63bf2704-728d-555c-b57c-284cec3b3b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b753e2-6e53-4ed1-9be4-66f8eb005a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b753e2-6e53-4ed1-9be4-66f8eb005a11.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -11799,7 +11799,7 @@
         },
         {
             "id": "a200199f-262d-5b9c-972d-cfda8d9f423b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3799dcb2-7cd7-4d28-b9af-249e3ebe3d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3799dcb2-7cd7-4d28-b9af-249e3ebe3d3b.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "ea47a507-0df0-5212-810c-e6b2a2e29814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2642cd-e3cc-4aab-8c00-4987284509b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2642cd-e3cc-4aab-8c00-4987284509b3.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11861,7 +11861,7 @@
         },
         {
             "id": "47a9e945-efa5-5ec7-8f35-b35d15f7acaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf269d-aca3-494c-8777-de90ae903af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf269d-aca3-494c-8777-de90ae903af2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11898,7 +11898,7 @@
         },
         {
             "id": "d2dba459-36dc-59d5-a520-199390521b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988bfa94-0c83-4057-a0c7-0ad885b8919c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988bfa94-0c83-4057-a0c7-0ad885b8919c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "8a72c48e-d746-54d9-8389-ee50c35bace7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888cdb76-d365-41df-8b6a-378ac58ca8b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888cdb76-d365-41df-8b6a-378ac58ca8b2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11972,7 +11972,7 @@
         },
         {
             "id": "60eab57f-fced-54de-ba77-d5ba92a22705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21041ed6-8f13-4909-a2c3-fa4894a2d1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21041ed6-8f13-4909-a2c3-fa4894a2d1e3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12009,7 +12009,7 @@
         },
         {
             "id": "01b9cc89-6e90-5dbc-8daf-530d9bb23be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80716ed1-8d0e-44e6-8b18-606e80d22181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80716ed1-8d0e-44e6-8b18-606e80d22181.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12046,7 +12046,7 @@
         },
         {
             "id": "1647a4e3-119f-54fa-9c34-4e47f6b46be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7f525c-d777-4adf-8920-8adfc73bbc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7f525c-d777-4adf-8920-8adfc73bbc55.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12083,7 +12083,7 @@
         },
         {
             "id": "89a88a78-8ab7-5be6-971c-0140c49247d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a790328-70b3-477d-bf02-8718870367ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a790328-70b3-477d-bf02-8718870367ae.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12120,7 +12120,7 @@
         },
         {
             "id": "ca2932ea-1ad9-5845-834a-3378fd14ef1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2039d727-3bb6-4a76-89ca-159ecf10cad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2039d727-3bb6-4a76-89ca-159ecf10cad8.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12157,7 +12157,7 @@
         },
         {
             "id": "031e3c5a-bf28-5f69-9568-ac2b09622764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c7de9-0046-4a76-a41a-fa1c3ef92f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c7de9-0046-4a76-a41a-fa1c3ef92f04.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12194,7 +12194,7 @@
         },
         {
             "id": "f785ae17-b374-5d9c-b076-102264d35747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19e24a8-5a4f-4a2d-b8dd-eb92aac7be78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19e24a8-5a4f-4a2d-b8dd-eb92aac7be78.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12231,7 +12231,7 @@
         },
         {
             "id": "6709cfdf-61a9-5fdd-ade6-0fc8feb33ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013612b4-fed9-4112-8018-9267ae608fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013612b4-fed9-4112-8018-9267ae608fd7.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12268,7 +12268,7 @@
         },
         {
             "id": "9287082a-e3a6-5918-a210-1ac5833d5347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a57c6a-3603-466c-8a81-a9eb8de92aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a57c6a-3603-466c-8a81-a9eb8de92aec.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12305,7 +12305,7 @@
         },
         {
             "id": "7cc4c0fd-f07d-5e1c-85e9-5ef58304e9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e19c7e1-1b4b-4c7e-b011-eff8ed7de0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e19c7e1-1b4b-4c7e-b011-eff8ed7de0fd.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12342,7 +12342,7 @@
         },
         {
             "id": "d45b8087-d2b3-55b7-8020-ea827c4b297c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6151d4-5129-4631-84a1-5cffc551c1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6151d4-5129-4631-84a1-5cffc551c1e9.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12379,7 +12379,7 @@
         },
         {
             "id": "910e2046-3ab0-5239-ba69-5b2a9ea16925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ce5575-2d62-43c9-9c4b-fca4aff6ae4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ce5575-2d62-43c9-9c4b-fca4aff6ae4d.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12416,7 +12416,7 @@
         },
         {
             "id": "678a79aa-21ee-517f-8be5-da9349c85662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "Vigilance\nWhenever a source an opponent controls deals damage to you or a permanent you control, that source's controller loses 2 life unless they pay {1}.\n{2}{W}, Sacrifice three other creatures: Exile Elesh Norn, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "53bdd792-627f-5a6d-ab8d-4031b747e2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Incubate 2 five times, then transform all Incubator tokens you control.\nII \u2014 Creatures you control get +1/+1 and gain double strike until end of turn.\nIII \u2014 Destroy all other permanents except for artifacts, lands, and Phyrexians. Exile The Argent Etchings, then return it to the battlefield (front face up).",
             "colours": [
@@ -12493,7 +12493,7 @@
         },
         {
             "id": "04cf9a35-9727-57d4-a939-d251a403fd23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "When Heliod, the Radiant Dawn enters the battlefield, return target enchantment card that isn't a God from your graveyard to your hand.\n{3}{PU}: Transform Heliod, the Radiant Dawn. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -12533,7 +12533,7 @@
         },
         {
             "id": "fd432d12-0702-579a-85df-eadce25ac30b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "You may cast spells as though they had flash.\nSpells you cast cost {1} less to cast for each card your opponents have drawn this turn.",
             "colours": [
@@ -12575,7 +12575,7 @@
         },
         {
             "id": "4e2c63e1-fab4-5797-b59b-5bf3ecb64534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "Ward {2}\nWhenever you cast a noncreature spell with mana value 3 or greater, draw a card.\n{3}{U}: Exile Jin-Gitaxias, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you have seven or more cards in hand.",
             "colours": [
@@ -12615,7 +12615,7 @@
         },
         {
             "id": "a8a6d87c-e029-5992-a992-befac91dd90b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Draw cards equal to the number of cards in your hand. You have no maximum hand size for as long as you control The Great Synthesis.\nII \u2014 Return all non-Phyrexian creatures to their owners' hands.\nIII \u2014 You may cast any number of spells from your hand without paying their mana costs. Exile The Great Synthesis, then return it to the battlefield (front face up).",
             "colours": [
@@ -12652,7 +12652,7 @@
         },
         {
             "id": "4fb6598a-4d81-5db1-b35a-53c2265192e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Whenever you cast a legendary spell, untap Rona, Herald of Invasion.\n{T}: Draw a card, then discard a card.\n{5}{PB}: Transform Rona. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -12692,7 +12692,7 @@
         },
         {
             "id": "bdd68e5d-bb57-5ce4-a696-329fd9b2831f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Rona, Tolarian Obliterator, that source's controller exiles a card from their hand at random. If it's a land card, you may put it onto the battlefield under your control. Otherwise, you may cast it without paying its mana cost.",
             "colours": [
@@ -12733,7 +12733,7 @@
         },
         {
             "id": "108368e1-8808-5ca7-8c89-e09c4c33bb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "{T}, Sacrifice another creature or artifact: Ayara, Widow of the Realm deals X damage to target opponent or battle and you gain X life, where X is the sacrificed permanent's mana value.\n{5}{PR}: Transform Ayara. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -12773,7 +12773,7 @@
         },
         {
             "id": "e198aa16-fe29-50e7-8ac5-46f00df159d3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "At the beginning of combat on your turn, return up to one target artifact or creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -12815,7 +12815,7 @@
         },
         {
             "id": "552ea12c-68a4-5bc6-abcc-7c1356bccca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "Menace\nWhen Sheoldred enters the battlefield, each opponent sacrifices a nontoken creature or planeswalker.\n{4}{B}: Exile Sheoldred, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if an opponent has eight or more cards in their graveyard.",
             "colours": [
@@ -12855,7 +12855,7 @@
         },
         {
             "id": "ab60b806-a5d5-546a-9c2a-7fd4b3f76a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 For each opponent, destroy up to one target creature or planeswalker that player controls.\nII \u2014 Each opponent discards three cards, then mills three cards.\nIII \u2014 Put all creature cards from all graveyards onto the battlefield under your control. Exile The True Scriptures, then return it to the battlefield (front face up).",
             "colours": [
@@ -12892,7 +12892,7 @@
         },
         {
             "id": "4c10387e-abef-5de0-990f-053af3a67ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample\nWhen Etali, Primal Conqueror enters the battlefield, each player exiles cards from the top of their library until they exile a nonland card. You may cast any number of spells from among the nonland cards exiled this way without paying their mana costs.\n{9}{PG}: Transform Etali. Activate only as a sorcery.",
             "colours": [
@@ -12932,7 +12932,7 @@
         },
         {
             "id": "576435f3-d934-53e9-84e4-315b389e1fee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample, indestructible\nWhenever Etali, Primal Sickness deals combat damage to a player, they get that many poison counters.",
             "colours": [
@@ -12974,7 +12974,7 @@
         },
         {
             "id": "dece52c4-d17c-5764-82a7-3f0fe7e9ecce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "First strike\nWhenever you cast an instant or sorcery spell, Urabrask deals 1 damage to target opponent. Add {R}.\n{R}: Exile Urabrask, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you've cast three or more instant and/or sorcery spells this turn.",
             "colours": [
@@ -13014,7 +13014,7 @@
         },
         {
             "id": "b8503e2d-58b8-552d-a501-6c1178c7d64e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 The Great Work deals 3 damage to target opponent and each creature they control.\nII \u2014 Create three Treasure tokens.\nIII \u2014 Until end of turn, you may cast instant and sorcery spells from any graveyard. If a spell cast this way would be put into a graveyard, exile it instead. Exile The Great Work, then return it to the battlefield (front face up).",
             "colours": [
@@ -13051,7 +13051,7 @@
         },
         {
             "id": "90652088-73bb-5eeb-9c57-b8628090f93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach\n{6}{PW}: Transform Polukranos Reborn. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -13090,7 +13090,7 @@
         },
         {
             "id": "234f5390-12d5-5de3-8bdc-179f19ad229d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach, lifelink\nWhenever Polukranos, Engine of Ruin or another nontoken Hydra you control dies, create a 3/3 green and white Phyrexian Hydra creature token with reach and a 3/3 green and white Phyrexian Hydra creature token with lifelink.",
             "colours": [
@@ -13131,7 +13131,7 @@
         },
         {
             "id": "5b4134b4-2c87-55ff-b827-34b10d3a78af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "Trample, reach\nWhen Vorinclex enters the battlefield, search your library for up to two Forest cards, reveal them, put them into your hand, then shuffle.\n{6}{G}{G}: Exile Vorinclex, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -13171,7 +13171,7 @@
         },
         {
             "id": "e3fc4c9b-4ff8-548f-98aa-c017b6798c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill ten cards. Put up to two creature cards from among the milled cards onto the battlefield.\nII \u2014 Distribute seven +1/+1 counters among any number of target creatures you control.\nIII \u2014 Until end of turn, creatures you control gain \"{1}: This creature fights target creature you don't control.\" Exile The Grand Evolution, then return it to the battlefield (front face up).",
             "colours": [
@@ -13208,7 +13208,7 @@
         },
         {
             "id": "b2329698-c1e0-5682-9fab-8d4fd3cc7e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612a164-d73e-47b3-a06a-fd5429b51fa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612a164-d73e-47b3-a06a-fd5429b51fa9.jpg?1",
             "name": "Baral and Kari Zev",
             "text": "First strike, menace\nWhenever you cast your first instant or sorcery spell each turn, you may cast a spell with lesser mana value that shares a card type with it from your hand without paying its mana cost. If you don't, create First Mate Ragavan, a legendary 2/1 red Monkey Pirate creature token. It gains haste until end of turn.",
             "colours": [
@@ -13248,7 +13248,7 @@
         },
         {
             "id": "30e08ec5-ce0d-5222-b5c1-9be9dd856394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df48f1c0-b336-4c68-8d11-41bceb36c83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df48f1c0-b336-4c68-8d11-41bceb36c83c.jpg?1",
             "name": "Borborygmos and Fblthp",
             "text": "Whenever Borborygmos and Fblthp enters the battlefield or attacks, draw a card, then you may discard any number of land cards. When you discard one or more cards this way, Borborygmos and Fblthp deals twice that much damage to target creature.\n{1}{U}: Put Borborygmos and Fblthp into its owner's library third from the top.",
             "colours": [
@@ -13291,7 +13291,7 @@
         },
         {
             "id": "873e9c29-295d-5877-a3a7-a6dbc9be7829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf166b-5383-443a-9ecc-027f72e0dfa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf166b-5383-443a-9ecc-027f72e0dfa5.jpg?1",
             "name": "Djeru and Hazoret",
             "text": "As long as you have one or fewer cards in hand, Djeru and Hazoret has vigilance and haste.\nWhenever Djeru and Hazoret attacks, look at the top six cards of your library. You may exile a legendary creature card from among them. Put the rest on the bottom of your library in a random order. Until end of turn, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -13332,7 +13332,7 @@
         },
         {
             "id": "48aa19dc-2718-59b1-b1a4-73ba302244d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a5fe67-beaa-4ee3-b22c-0b8aed6f6f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a5fe67-beaa-4ee3-b22c-0b8aed6f6f4d.jpg?1",
             "name": "Drana and Linvala",
             "text": "Flying, vigilance\nActivated abilities of creatures your opponents control can't be activated.\nDrana and Linvala has all activated abilities of all creatures your opponents control. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -13373,7 +13373,7 @@
         },
         {
             "id": "b5f25cec-f9b4-5996-b4a3-9cc88708306d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d8b20a-9288-4470-90d2-5b72fb4a9e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d8b20a-9288-4470-90d2-5b72fb4a9e68.jpg?1",
             "name": "Errant and Giada",
             "text": "Flash\nFlying\nYou may look at the top card of your library any time.\nYou may cast spells with flash or flying from the top of your library.",
             "colours": [
@@ -13414,7 +13414,7 @@
         },
         {
             "id": "94b0692f-c79a-55df-b95c-5f16c6d3d4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adea9871-807e-471d-9a9f-ad6efcf07e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adea9871-807e-471d-9a9f-ad6efcf07e80.jpg?1",
             "name": "Ghalta and Mavren",
             "text": "Trample\nWhenever you attack, choose one \u2014\n\u2022 Create a tapped and attacking X/X green Dinosaur creature token with trample, where X is the greatest power among other attacking creatures.\n\u2022 Create X 1/1 white Vampire creature tokens with lifelink, where X is the number of other attacking creatures.",
             "colours": [
@@ -13456,7 +13456,7 @@
         },
         {
             "id": "1dd8c7d5-6eff-53b9-bfde-a9308ad0a9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e12422-c46b-41b2-8b5d-c965d5694bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e12422-c46b-41b2-8b5d-c965d5694bd2.jpg?1",
             "name": "Glissa, Herald of Predation",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Incubate 2 twice.\n\u2022 Transform all Incubator tokens you control.\n\u2022 Phyrexians you control gain first strike and deathtouch until end of turn.",
             "colours": [
@@ -13498,7 +13498,7 @@
         },
         {
             "id": "58d2ecf9-7456-588e-9707-0ab035f31dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd881d-6e12-4c90-a198-1d7ec61924b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd881d-6e12-4c90-a198-1d7ec61924b6.jpg?1",
             "name": "Hidetsugu and Kairi",
             "text": "Flying\nWhen Hidetsugu and Kairi enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.\nWhen Hidetsugu and Kairi dies, exile the top card of your library. Target opponent loses life equal to its mana value. If it's an instant or sorcery card, you may cast it without paying its mana cost.",
             "colours": [
@@ -13540,7 +13540,7 @@
         },
         {
             "id": "f52ab886-42e9-5497-a03a-fb493f18ca08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced80468-2853-4fbd-928a-98381ca1d06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced80468-2853-4fbd-928a-98381ca1d06e.jpg?1",
             "name": "Inga and Esika",
             "text": "Creatures you control have vigilance and \"{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\"\nWhenever you cast a creature spell, if three or more mana from creatures was spent to cast it, draw a card.",
             "colours": [
@@ -13581,7 +13581,7 @@
         },
         {
             "id": "86061e55-e91a-5734-ada8-08e0a9fc205b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32dbdc6-3321-4d77-8d2f-acbcb1a29090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32dbdc6-3321-4d77-8d2f-acbcb1a29090.jpg?1",
             "name": "Kogla and Yidaro",
             "text": "When Kogla and Yidaro enters the battlefield, choose one \u2014\n\u2022 It gains trample and haste until end of turn.\n\u2022 It fights target creature you don't control.\n{2}{R}{G}, Discard Kogla and Yidaro: Destroy up to one target artifact or enchantment. Shuffle Kogla and Yidaro into your library from your graveyard, then draw a card.",
             "colours": [
@@ -13623,7 +13623,7 @@
         },
         {
             "id": "c49fa048-ac10-5a94-96ab-65902850ca40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1c9e3a-cd3f-412c-af59-c024081782cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1c9e3a-cd3f-412c-af59-c024081782cf.jpg?1",
             "name": "Kroxa and Kunoros",
             "text": "Vigilance, menace, lifelink\nWhenever Kroxa and Kunoros enters the battlefield or attacks, you may exile five cards from your graveyard. When you do, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -13667,7 +13667,7 @@
         },
         {
             "id": "1abd8fd9-bdfb-5d2e-ad65-e925c11b1979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b998493-d2c5-48dd-8d0c-b63b6795acf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b998493-d2c5-48dd-8d0c-b63b6795acf6.jpg?1",
             "name": "Omnath, Locus of All",
             "text": "If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",
             "colours": [
@@ -13715,7 +13715,7 @@
         },
         {
             "id": "74aae536-67cb-5578-b2d5-62488d60a2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac290f-69fb-4e18-a36c-356f04193ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac290f-69fb-4e18-a36c-356f04193ab3.jpg?1",
             "name": "Quintorius, Loremaster",
             "text": "Vigilance\nAt the beginning of your end step, exile target noncreature, nonland card from your graveyard. Create a 3/2 red and white Spirit creature token.\n{1}{R}{W}, {T}, Sacrifice a Spirit: Choose target card exiled with Quintorius. You may cast that card this turn without paying its mana cost. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.",
             "colours": [
@@ -13756,7 +13756,7 @@
         },
         {
             "id": "2ee7b341-f00f-5091-bcec-e2b427c55b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e314fa27-8d87-425a-ae94-28bfd9005505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e314fa27-8d87-425a-ae94-28bfd9005505.jpg?1",
             "name": "Rankle and Torbran",
             "text": "Flying, first strike, haste\nWhenever Rankle and Torbran deals combat damage to a player or battle, choose any number \u2014\n\u2022 Each player creates a Treasure token.\n\u2022 Each player sacrifices a creature.\n\u2022 If a source would deal damage to a player or battle this turn, it deals that much damage plus 2 instead.",
             "colours": [
@@ -13797,7 +13797,7 @@
         },
         {
             "id": "82e724d5-4212-5982-beb7-7096361267a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c4eb73-7e50-4c22-8fa6-c770152ebdaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c4eb73-7e50-4c22-8fa6-c770152ebdaf.jpg?1",
             "name": "Thalia and The Gitrog Monster",
             "text": "First strike, deathtouch\nYou may play an additional land on each of your turns.\nCreatures and nonbasic lands your opponents control enter the battlefield tapped.\nWhenever Thalia and The Gitrog Monster attacks, sacrifice a creature or land, then draw a card.",
             "colours": [
@@ -13841,7 +13841,7 @@
         },
         {
             "id": "b0c6ab80-f899-503f-af34-6dc71c5f8c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46df4f25-3705-4d63-aadb-eb89c3476cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46df4f25-3705-4d63-aadb-eb89c3476cf4.jpg?1",
             "name": "Yargle and Multani",
             "text": "",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "1fe975ad-c35f-5e0d-9490-f3d8f7141fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9769de5-43d0-4a59-a219-1740c65281c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9769de5-43d0-4a59-a219-1740c65281c4.jpg?1",
             "name": "Zimone and Dina",
             "text": "Whenever you draw your second card each turn, target opponent loses 2 life and you gain 2 life.\n{T}, Sacrifice another creature: Draw a card. You may put a land card from your hand onto the battlefield tapped. If you control eight or more lands, repeat this process once.",
             "colours": [
@@ -13926,7 +13926,7 @@
         },
         {
             "id": "a9a4f79c-5370-5249-a85c-2c25c3491df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26911a0-447a-41d6-96e5-c93353778a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26911a0-447a-41d6-96e5-c93353778a2c.jpg?1",
             "name": "Zurgo and Ojutai",
             "text": "Flying, haste\nZurgo and Ojutai has hexproof as long as it entered the battlefield this turn.\nWhenever one or more Dragons you control deal combat damage to a player or battle, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. You may return one of those Dragons to its owner's hand.",
             "colours": [
@@ -13969,7 +13969,7 @@
         },
         {
             "id": "8302bccd-9646-540f-a478-5ef007f125cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99e67-901f-4c8d-8a09-e443b7eb928f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99e67-901f-4c8d-8a09-e443b7eb928f.jpg?1",
             "name": "Archangel Elspeth",
             "text": "+1: Create a 1/1 white Soldier creature token with lifelink.\n\u22122: Put two +1/+1 counters on target creature. It becomes an Angel in addition to its other types and gains flying.\n\u22126: Return all nonland permanent cards with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -14007,7 +14007,7 @@
         },
         {
             "id": "36cff21d-84e3-5f9e-9557-ae8b7084c9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62707510-96ae-492f-8b14-a34d0c9fb859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62707510-96ae-492f-8b14-a34d0c9fb859.jpg?1",
             "name": "Chandra, Hope's Beacon",
             "text": "Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy. This ability triggers only once each turn.\n+2: Add two mana in any combination of colors.\n+1: Exile the top five cards of your library. Until the end of your next turn, you may cast an instant or sorcery spell from among those exiled cards.\n\u2212X: Chandra, Hope's Beacon deals X damage to each of up to two targets.",
             "colours": [
@@ -14045,7 +14045,7 @@
         },
         {
             "id": "faaa623c-d2d4-547f-973c-d0b64081ea45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17269aae-10bc-49ef-b6a7-94e0dd6cf677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17269aae-10bc-49ef-b6a7-94e0dd6cf677.jpg?1",
             "name": "Wrenn and Realmbreaker",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n+1: Up to one target land you control becomes a 3/3 Elemental creature with vigilance, hexproof, and haste until your next turn. It's still a land.\n\u22122: Mill three cards. You may put a permanent card from among the milled cards into your hand.\n\u22127: You get an emblem with \"You may play lands and cast permanent spells from your graveyard.\"",
             "colours": [
@@ -14083,7 +14083,7 @@
         },
         {
             "id": "aa74a4bc-a063-5950-8238-2a4b0653dff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604233dc-0520-47d0-8d3d-816f45c9f087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604233dc-0520-47d0-8d3d-816f45c9f087.jpg?1",
             "name": "Essence of Orthodoxy",
             "text": "Flying\nWhenever Essence of Orthodoxy or another Phyrexian enters the battlefield under your control, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -14119,7 +14119,7 @@
         },
         {
             "id": "684f8097-df18-58b5-a4fe-15d093f5d12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1200a1-8671-464f-ab3b-bfc1fb0d6ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1200a1-8671-464f-ab3b-bfc1fb0d6ed8.jpg?1",
             "name": "Phyrexian Pegasus",
             "text": "Flying\nWhenever Phyrexian Pegasus attacks, another target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -14154,7 +14154,7 @@
         },
         {
             "id": "1d2a2313-8f71-506c-a1ce-42cd1d89fd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861bda4-d014-4908-aed5-3f3bf78704cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861bda4-d014-4908-aed5-3f3bf78704cf.jpg?1",
             "name": "Seedpod Caretaker",
             "text": "When Seedpod Caretaker enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on target artifact or creature you control.\n\u2022 Transform target Incubator token you control.",
             "colours": [
@@ -14189,7 +14189,7 @@
         },
         {
             "id": "88cb3b48-5772-514e-bedc-e0c7d5fdd96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg?1",
             "name": "Interdisciplinary Mascot",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWard {3}\nWhen Interdisciplinary Mascot enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14226,7 +14226,7 @@
         },
         {
             "id": "d1cff22c-8033-5df4-a673-74f6a01178fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434515bf-de57-4c00-b0b4-c9579cc1b84c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434515bf-de57-4c00-b0b4-c9579cc1b84c.jpg?1",
             "name": "Referee Squad",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nVigilance\nWhen Referee Squad enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -14260,7 +14260,7 @@
         },
         {
             "id": "baca352d-c614-50ff-a223-98d4e1b63cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14456a8e-016c-4407-8410-c490db3f5ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14456a8e-016c-4407-8410-c490db3f5ea9.jpg?1",
             "name": "Zephyr Winder",
             "text": "Flying\nWhenever Zephyr Winder deals combat damage to a player, untap up to one target creature.",
             "colours": [
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "8b34c0c2-bdf3-574b-aa0d-261e2e92aa31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974ddcab-bbe0-4bae-9c99-1fd5a5554d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974ddcab-bbe0-4bae-9c99-1fd5a5554d2e.jpg?1",
             "name": "Injector Crocodile",
             "text": "When Injector Crocodile dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -14329,7 +14329,7 @@
         },
         {
             "id": "0857bdf2-803a-57ff-9d07-db87859b6b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0b3232-44ee-481d-81d9-46432f853a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0b3232-44ee-481d-81d9-46432f853a7d.jpg?1",
             "name": "Seer of Stolen Sight",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever one or more artifacts and/or creatures you control are put into a graveyard from the battlefield, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "7bd3cede-cb6c-51ad-8f09-fbb2249c3299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a759d44-5496-437e-a714-acc398988b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a759d44-5496-437e-a714-acc398988b84.jpg?1",
             "name": "Terror of Towashi",
             "text": "Deathtouch\nWhenever Terror of Towashi attacks, you may pay {3}{B}. When you do, return target creature card from your graveyard to the battlefield. It's a Phyrexian in addition to its other types.",
             "colours": [
@@ -14401,7 +14401,7 @@
         },
         {
             "id": "5e8cfca1-704a-5bb6-ab92-83a84ae5e7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af130b37-d3e0-4839-8193-5c62a91f0218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af130b37-d3e0-4839-8193-5c62a91f0218.jpg?1",
             "name": "Axgard Artisan",
             "text": "Whenever one or more +1/+1 counters are put on Axgard Artisan for the first time each turn, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -14436,7 +14436,7 @@
         },
         {
             "id": "555071ca-fd3e-5e2d-b6e3-970aa0cea149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7a4ccb-c0c9-491f-9475-e78895fa9d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7a4ccb-c0c9-491f-9475-e78895fa9d03.jpg?1",
             "name": "Cragsmasher Yeti",
             "text": "Mountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)\nBackup 2 (When this creature enters the battlefield, put two +1/+1 counters on target creature. If that's another creature, it gains the following ability until end of turn.)\nTrample",
             "colours": [
@@ -14470,7 +14470,7 @@
         },
         {
             "id": "99116a05-b192-5d55-8658-27563600e1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dadbb3-7b8a-4656-973f-65a3284afe07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dadbb3-7b8a-4656-973f-65a3284afe07.jpg?1",
             "name": "Orthion, Hero of Lavabrink",
             "text": "{1}{R}, {T}: Create a token that's a copy of another target creature you control. It gains haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\n{6}{R}{R}{R}, {T}: Create five tokens that are copies of another target creature you control. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -14509,7 +14509,7 @@
         },
         {
             "id": "816c2e7f-e097-544d-bbdc-980fd56aa465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c6408b-9e24-4bf5-b0d0-a4cda3069b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c6408b-9e24-4bf5-b0d0-a4cda3069b1c.jpg?1",
             "name": "Fairgrounds Trumpeter",
             "text": "At the beginning of each end step, if a +1/+1 counter was put on a permanent under your control this turn, put a +1/+1 counter on Fairgrounds Trumpeter.",
             "colours": [
@@ -14543,7 +14543,7 @@
         },
         {
             "id": "24014a9e-9a71-5614-9fa2-41a707580cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c0fdf5-2f56-4480-9ccb-84471b3e5331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c0fdf5-2f56-4480-9ccb-84471b3e5331.jpg?1",
             "name": "Ruins Recluse",
             "text": "Reach, deathtouch\n{3}{G}: Put a +1/+1 counter on Ruins Recluse.",
             "colours": [
@@ -14577,7 +14577,7 @@
         },
         {
             "id": "fd194602-2332-50e9-83d2-ad3babab115d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10934d-9016-43c4-a7ab-56cc7d8f671f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10934d-9016-43c4-a7ab-56cc7d8f671f.jpg?1",
             "name": "Surrak and Goreclaw",
             "text": "Trample\nOther creatures you control have trample.\nWhenever another nontoken creature enters the battlefield under your control, put a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -14616,7 +14616,7 @@
         },
         {
             "id": "4e8747e2-642b-56e8-9ecb-71afb5b7af49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "",
             "colours": [
@@ -14655,7 +14655,7 @@
         },
         {
             "id": "89cb157e-16dc-55d4-afd3-74efe0d3f70b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "",
             "colours": [
@@ -14691,7 +14691,7 @@
         },
         {
             "id": "f35925e8-e074-5448-ac33-fe54f1f9e158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "",
             "colours": [
@@ -14730,7 +14730,7 @@
         },
         {
             "id": "2297d0bf-14c5-5c2a-9f09-1747ac17d152",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "",
             "colours": [
@@ -14766,7 +14766,7 @@
         },
         {
             "id": "5fb4cbe9-b370-5205-bb89-101c677eab7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "",
             "colours": [
@@ -14805,7 +14805,7 @@
         },
         {
             "id": "c153f8a5-0537-5e54-bddd-ef806fbd0af9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "",
             "colours": [
@@ -14841,7 +14841,7 @@
         },
         {
             "id": "7c8e0d52-0094-52c1-b92d-08342bf099bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "",
             "colours": [
@@ -14880,7 +14880,7 @@
         },
         {
             "id": "c6e5732c-f8f4-58c6-a67f-9021f2d0a7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "",
             "colours": [
@@ -14916,7 +14916,7 @@
         },
         {
             "id": "2db0afd1-ba8a-54e0-8f13-16a90fc1110c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "8a6a3698-cfca-5387-9120-06cf7fa2af89",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "",
             "colours": [
@@ -14991,7 +14991,7 @@
         },
         {
             "id": "7136fee1-7a3a-5247-8212-dff9e416bfcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cc901-ae12-45e0-a9cf-e505c3a21dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cc901-ae12-45e0-a9cf-e505c3a21dd1.jpg?1",
             "name": "Boon-Bringer Valkyrie",
             "text": "Backup 1\nFlying, first strike, lifelink",
             "colours": [
@@ -15028,7 +15028,7 @@
         },
         {
             "id": "dcaa1173-3b3d-5668-95ee-4ea5a797644f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d1c7e-9c5c-434b-b974-504674852c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d1c7e-9c5c-434b-b974-504674852c3c.jpg?1",
             "name": "Dusk Legion Duelist",
             "text": "Vigilance\nWhenever one or more +1/+1 counters are put on Dusk Legion Duelist, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -15065,7 +15065,7 @@
         },
         {
             "id": "adb9cd9c-1f9d-5a37-8da1-e7bc4a8d7bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90058f83-6af9-4776-aeaf-35dec519af88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90058f83-6af9-4776-aeaf-35dec519af88.jpg?1",
             "name": "Guardian of Ghirapur",
             "text": "Flying\nWhen Guardian of Ghirapur enters the battlefield, exile up to one other target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "8d26cdc5-ed9b-58f5-9f4e-1144113392f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10463a-d63c-43c3-97af-1d7ca672d782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10463a-d63c-43c3-97af-1d7ca672d782.jpg?1",
             "name": "Knight-Errant of Eos",
             "text": "Convoke\nWhen Knight-Errant of Eos enters the battlefield, look at the top six cards of your library. You may reveal up to two creature cards with mana value X or less from among them, where X is the number of creatures that convoked Knight-Errant of Eos. Put the revealed cards into your hand, then shuffle.",
             "colours": [
@@ -15138,7 +15138,7 @@
         },
         {
             "id": "bd73274d-cb3c-5819-9c65-44050694b830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12381b-822f-4e45-bb53-fade9e51f10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12381b-822f-4e45-bb53-fade9e51f10e.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -15175,7 +15175,7 @@
         },
         {
             "id": "cf04fad1-8c7c-5e6d-8d7c-254bad8befc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecf78c-1a96-465e-a877-8a3051b8a9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecf78c-1a96-465e-a877-8a3051b8a9af.jpg?1",
             "name": "Progenitor Exarch",
             "text": "When Progenitor Exarch enters the battlefield, incubate 3 X times.\n{T}: Transform target Incubator token you control.",
             "colours": [
@@ -15213,7 +15213,7 @@
         },
         {
             "id": "e0359b42-2e80-5cf5-8b66-d04dce350792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b961b23d-a16f-4126-9293-2906dc2aba79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b961b23d-a16f-4126-9293-2906dc2aba79.jpg?1",
             "name": "Sunfall",
             "text": "Exile all creatures. Incubate X, where X is the number of creatures exiled this way.",
             "colours": [
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "de34cd1f-6b6a-5c1d-9e35-f6ed3c75000d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c77833-8cd7-446f-bb67-454f85a972a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c77833-8cd7-446f-bb67-454f85a972a4.jpg?1",
             "name": "Chrome Host Seedshark",
             "text": "Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value.",
             "colours": [
@@ -15284,7 +15284,7 @@
         },
         {
             "id": "27a7b478-832d-5b90-86ed-486bced2873b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68813ee-bb24-4066-9c32-ca3ca2db3d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68813ee-bb24-4066-9c32-ca3ca2db3d4f.jpg?1",
             "name": "Complete the Circuit",
             "text": "Convoke\nYou may cast sorcery spells this turn as though they had flash.\nWhen you next cast an instant or sorcery spell this turn, copy that spell twice. You may choose new targets for the copies.",
             "colours": [
@@ -15318,7 +15318,7 @@
         },
         {
             "id": "aa26d966-64dc-5571-b4a6-1b4edd3dbab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb3321c-6b3f-4e7e-8557-b90855ff48cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb3321c-6b3f-4e7e-8557-b90855ff48cd.jpg?1",
             "name": "Faerie Mastermind",
             "text": "Flash\nFlying\nWhenever an opponent draws their second card each turn, you draw a card.\n{3}{U}: Each player draws a card.",
             "colours": [
@@ -15355,7 +15355,7 @@
         },
         {
             "id": "6f71b78b-939c-580c-983b-01efb42d2cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa9084e-3a93-4fba-8c67-2b3065d6fd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa9084e-3a93-4fba-8c67-2b3065d6fd5c.jpg?1",
             "name": "See Double",
             "text": "This spell can't be copied.\nChoose one. If an opponent has eight or more cards in their graveyard, you may choose both.\n\u2022 Copy target spell. You may choose new targets for the copy.\n\u2022 Create a token that's a copy of target creature.",
             "colours": [
@@ -15389,7 +15389,7 @@
         },
         {
             "id": "4cb697b7-69e4-58cd-b7b8-4ddf366b0e0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc45791-af1f-4647-a567-29c64e1855df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc45791-af1f-4647-a567-29c64e1855df.jpg?1",
             "name": "Transcendent Message",
             "text": "Convoke\nDraw X cards.",
             "colours": [
@@ -15423,7 +15423,7 @@
         },
         {
             "id": "9eb2fc70-5a06-5d06-b2b3-5a2788a81f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41046d8a-a39b-42e4-9ed4-6cbdf60371b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41046d8a-a39b-42e4-9ed4-6cbdf60371b5.jpg?1",
             "name": "Zephyr Singer",
             "text": "Convoke\nFlying, vigilance\nWhen Zephyr Singer enters the battlefield, put a flying counter on each creature that convoked it.",
             "colours": [
@@ -15460,7 +15460,7 @@
         },
         {
             "id": "ea1c00eb-c7cc-56a7-8c4a-5f2da76d5c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4332d36c-0db6-43fc-823b-6b6876e64b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4332d36c-0db6-43fc-823b-6b6876e64b54.jpg?1",
             "name": "Archpriest of Shadows",
             "text": "Backup 1\nDeathtouch\nWhenever this creature deals combat damage to a player or battle, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "c752aeeb-a59e-53a6-862e-5e56981a616c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd459d06-2c0d-4999-bedd-8455371799fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd459d06-2c0d-4999-bedd-8455371799fe.jpg?1",
             "name": "Bloated Processor",
             "text": "Sacrifice another Phyrexian: Put a +1/+1 counter on Bloated Processor.\nWhen Bloated Processor dies, incubate X, where X is its power.",
             "colours": [
@@ -15533,7 +15533,7 @@
         },
         {
             "id": "dd0c8bf7-c04c-5cdb-b49b-3b13846cb69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee99acde-796c-423b-81ed-13d33e210925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee99acde-796c-423b-81ed-13d33e210925.jpg?1",
             "name": "Breach the Multiverse",
             "text": "Each player mills ten cards. For each player, choose a creature or planeswalker card in that player's graveyard. Put those cards onto the battlefield under your control. Then each creature you control becomes a Phyrexian in addition to its other types.",
             "colours": [
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "1e9257ed-d8cc-5ec2-937b-5b12506843f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21321e17-79fd-43f1-93ae-4b87f0d0951a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21321e17-79fd-43f1-93ae-4b87f0d0951a.jpg?1",
             "name": "Grafted Butcher",
             "text": "When Grafted Butcher enters the battlefield, Phyrexians you control gain menace until end of turn.\nOther Phyrexians you control get +1/+1.\n{3}{B}, Sacrifice an artifact or creature: Return Grafted Butcher from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -15604,7 +15604,7 @@
         },
         {
             "id": "191e912b-67e6-5e9b-9324-6bc7a7eb1c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbfb78e-cbab-4511-a887-60dad1a6cb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbfb78e-cbab-4511-a887-60dad1a6cb6b.jpg?1",
             "name": "Hoarding Broodlord",
             "text": "Convoke\nFlying\nWhen Hoarding Broodlord enters the battlefield, search your library for a card, exile it face down, then shuffle. For as long as that card remains exiled, you may play it.\nSpells you cast from exile have convoke.",
             "colours": [
@@ -15640,7 +15640,7 @@
         },
         {
             "id": "e38d4813-9119-5cc2-838c-9e6d0237ff6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f8aab2-995b-4e55-8c23-6915eac6278c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f8aab2-995b-4e55-8c23-6915eac6278c.jpg?1",
             "name": "Pile On",
             "text": "Convoke\nDestroy target creature or planeswalker. Surveil 2.",
             "colours": [
@@ -15674,7 +15674,7 @@
         },
         {
             "id": "bc21b817-627d-5db5-963e-71186fe0ad51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56ccab-6a43-48b4-ad65-b618e07c001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56ccab-6a43-48b4-ad65-b618e07c001f.jpg?1",
             "name": "Bloodfeather Phoenix",
             "text": "Flying\nBloodfeather Phoenix can't block.\nWhenever an instant or sorcery spell you control deals damage to an opponent or battle, you may pay {R}. If you do, return Bloodfeather Phoenix from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -15710,7 +15710,7 @@
         },
         {
             "id": "47b5bb14-f141-5e79-b18a-49cb543fbb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b86e4-c36a-42d1-8322-93ffa379ca3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b86e4-c36a-42d1-8322-93ffa379ca3e.jpg?1",
             "name": "City on Fire",
             "text": "Convoke\nIf a source you control would deal damage to a permanent or player, it deals triple that damage instead.",
             "colours": [
@@ -15744,7 +15744,7 @@
         },
         {
             "id": "2c8f7d10-2721-58b5-a36a-f0121257f414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33ee0-fdfa-417d-b4d6-77d4d25233d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33ee0-fdfa-417d-b4d6-77d4d25233d3.jpg?1",
             "name": "Into the Fire",
             "text": "Choose one \u2014\n\u2022 Into the Fire deals 2 damage to each creature, planeswalker, and battle.\n\u2022 Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.",
             "colours": [
@@ -15778,7 +15778,7 @@
         },
         {
             "id": "45cfcb73-95ff-59e9-8a3d-8fc44d179015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c92c29-ed97-41ea-936f-0db39d86b17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c92c29-ed97-41ea-936f-0db39d86b17e.jpg?1",
             "name": "Nahiri's Warcrafting",
             "text": "Nahiri's Warcrafting deals 5 damage to target creature, planeswalker, or battle. Look at the top X cards of your library, where X is the excess damage dealt this way. You may exile one of those cards. Put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -15812,7 +15812,7 @@
         },
         {
             "id": "18c0a2e6-f7c1-52dd-9cb2-30c57acfe46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81513aff-337b-45f3-8e3d-895cee6eb492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81513aff-337b-45f3-8e3d-895cee6eb492.jpg?1",
             "name": "Rampaging Raptor",
             "text": "Trample, haste\n{2}{R}: Rampaging Raptor gets +2/+0 until end of turn.\nWhenever Rampaging Raptor deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls or battle that player protects.",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "e44a669d-28a4-5285-be7a-a142b984459a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8fc4f0-06d4-4504-86fb-df385e2c818e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8fc4f0-06d4-4504-86fb-df385e2c818e.jpg?1",
             "name": "Voldaren Thrillseeker",
             "text": "Backup 2\n{1}, Sacrifice this creature: It deals damage equal to its power to any target.",
             "colours": [
@@ -15885,7 +15885,7 @@
         },
         {
             "id": "14cf6ea2-c33f-5fe3-bc5e-0eda9bb6a10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13a3a77-c877-4822-b2e9-5abafa4aae9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13a3a77-c877-4822-b2e9-5abafa4aae9a.jpg?1",
             "name": "Ancient Imperiosaur",
             "text": "Convoke\nTrample, ward {2}\nAncient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.",
             "colours": [
@@ -15921,7 +15921,7 @@
         },
         {
             "id": "5a85690a-f52e-511e-a5fb-3cfbb0b9f365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5cc6f-c8b8-42fa-8cb0-8899b594f094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5cc6f-c8b8-42fa-8cb0-8899b594f094.jpg?1",
             "name": "Deeproot Wayfinder",
             "text": "Whenever Deeproot Wayfinder deals combat damage to a player or battle, surveil 1, then you may return a land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -15958,7 +15958,7 @@
         },
         {
             "id": "541f867b-6c7e-5d8d-bb68-81653d50289a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47961516-abf7-45d3-aad6-bce3dbd1327f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47961516-abf7-45d3-aad6-bce3dbd1327f.jpg?1",
             "name": "Doomskar Warrior",
             "text": "Backup 1\nTrample\nWhenever this creature deals combat damage to a player or battle, look at that many cards from the top of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "7b03832e-0287-5ea6-81b7-9a24b9774a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4cc2dc-9ae8-4da1-8d9d-b2999f37625e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4cc2dc-9ae8-4da1-8d9d-b2999f37625e.jpg?1",
             "name": "Glistening Dawn",
             "text": "Incubate X twice, where X is the number of lands you control.",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "617e2253-af02-51f6-897a-d38653d057c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27455b98-d2a1-41f9-b827-cce21c4c1d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27455b98-d2a1-41f9-b827-cce21c4c1d84.jpg?1",
             "name": "Ozolith, the Shattered Spire",
             "text": "If one or more +1/+1 counters would be put on an artifact or creature you control, that many plus one +1/+1 counters are put on it instead.\n{1}{G}, {T}: Put a +1/+1 counter on target artifact or creature you control. Activate only as a sorcery.\nCycling {2}",
             "colours": [
@@ -16065,7 +16065,7 @@
         },
         {
             "id": "76ea3e11-9e58-541e-a832-323f52943285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cde7d3-e4b9-4c2e-a541-c7644e527551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cde7d3-e4b9-4c2e-a541-c7644e527551.jpg?1",
             "name": "Tribute to the World Tree",
             "text": "Whenever a creature enters the battlefield under your control, draw a card if its power is 3 or greater. Otherwise, put two +1/+1 counters on it.",
             "colours": [
@@ -16099,7 +16099,7 @@
         },
         {
             "id": "11682441-2fe4-5a62-920f-e343c0ed2ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182520ae-d98f-4ef0-ad32-252f932f5d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182520ae-d98f-4ef0-ad32-252f932f5d51.jpg?1",
             "name": "Realmbreaker, the Invasion Tree",
             "text": "{2}, {T}: Target opponent mills three cards. Put a land card from their graveyard onto the battlefield tapped under your control. It gains \"If this land would leave the battlefield, exile it instead of putting it anywhere else.\"\n{1}0, {T}, Sacrifice Realmbreaker, the Invasion Tree: Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.",
             "colours": [],
@@ -16131,7 +16131,7 @@
         },
         {
             "id": "13179baf-9c3e-5632-a350-19c7ecd14704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255e402f-5083-4ce4-a807-ba17b949e384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255e402f-5083-4ce4-a807-ba17b949e384.jpg?1",
             "name": "Sword of Once and Future",
             "text": "Equipped creature gets +2/+2 and has protection from blue and from black.\nWhenever equipped creature deals combat damage to a player, surveil 2. Then you may cast an instant or sorcery spell with mana value 2 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.\nEquip {2}",
             "colours": [],
@@ -16163,7 +16163,7 @@
         },
         {
             "id": "b26166e1-bd5d-5c74-9043-b459987a81a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a21edf-c63c-47c1-8670-1f8bcf879fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a21edf-c63c-47c1-8670-1f8bcf879fcf.jpg?1",
             "name": "Essence of Orthodoxy",
             "text": "Flying\nWhenever Essence of Orthodoxy or another Phyrexian enters the battlefield under your control, incubate 2.",
             "colours": [
@@ -16198,7 +16198,7 @@
         },
         {
             "id": "a585d1ca-d620-5409-b206-5583a60c47d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd6e040-2394-43c4-8aa5-2b7bde8b3862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd6e040-2394-43c4-8aa5-2b7bde8b3862.jpg?1",
             "name": "Interdisciplinary Mascot",
             "text": "Convoke\nWard {3}\nWhen Interdisciplinary Mascot enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -16234,7 +16234,7 @@
         },
         {
             "id": "867a78b1-24d5-5341-8997-2d9ad4c4adbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465c7c4-5e13-4273-9ea5-d8f6e2db1265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465c7c4-5e13-4273-9ea5-d8f6e2db1265.jpg?1",
             "name": "Terror of Towashi",
             "text": "Deathtouch\nWhenever Terror of Towashi attacks, you may pay {3}{B}. When you do, return target creature card from your graveyard to the battlefield. It's a Phyrexian in addition to its other types.",
             "colours": [
@@ -16270,7 +16270,7 @@
         },
         {
             "id": "a0f49c42-e116-5425-a64b-45ff72dd5170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ad2b1a-668e-4c7d-8158-b25897be22c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ad2b1a-668e-4c7d-8158-b25897be22c8.jpg?1",
             "name": "Orthion, Hero of Lavabrink",
             "text": "{1}{R}, {T}: Create a token that's a copy of another target creature you control. It gains haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\n{6}{R}{R}{R}, {T}: Create five tokens that are copies of another target creature you control. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -16308,7 +16308,7 @@
         },
         {
             "id": "0ac5b7bf-085b-5dff-b2cc-6b9d89f4c783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d017cf-32b0-4770-a647-b29cfd1ac2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d017cf-32b0-4770-a647-b29cfd1ac2d1.jpg?1",
             "name": "Surrak and Goreclaw",
             "text": "Trample\nOther creatures you control have trample.\nWhenever another nontoken creature enters the battlefield under your control, put a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -16346,7 +16346,7 @@
         },
         {
             "id": "776ee23d-9d5d-5ab3-ba23-0e7445532237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf90c1a-fcad-45b7-8666-79d55edd71b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf90c1a-fcad-45b7-8666-79d55edd71b1.jpg?1",
             "name": "Norn's Inquisitor",
             "text": "When Norn's Inquisitor enters the battlefield, incubate 2.\nWhenever a permanent you control transforms into a Phyrexian, put a +1/+1 counter on it.",
             "colours": [
@@ -16383,7 +16383,7 @@
         },
         {
             "id": "741cae61-1474-5b17-af15-e56fb8da6000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469ff89d-95d5-41b7-a0e6-912fa1e892f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469ff89d-95d5-41b7-a0e6-912fa1e892f0.jpg?1",
             "name": "Scrappy Bruiser",
             "text": "Whenever Scrappy Bruiser attacks, up to one target attacking creature gets +2/+0 and gains trample until end of turn. Return that creature to its owner's hand at end of combat. (Return it only if it's on the battlefield.)",
             "colours": [
@@ -16420,7 +16420,7 @@
         },
         {
             "id": "589f612a-2b1d-5bf2-a1d0-044ff0739623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97ba4c-7785-4245-b091-692c8fdb68e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97ba4c-7785-4245-b091-692c8fdb68e9.jpg?1",
             "name": "Kami of Whispered Hopes",
             "text": "If one or more +1/+1 counters would be put on a permanent you control, that many plus one +1/+1 counters are put on that permanent instead.\n{T}: Add X mana of any one color, where X is Kami of Whispered Hopes's power.",
             "colours": [
@@ -16456,7 +16456,7 @@
         },
         {
             "id": "9f25ae3b-4282-5c44-8032-939cde31ec46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dcbfc4-9791-496e-b17a-7ff1b3978e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dcbfc4-9791-496e-b17a-7ff1b3978e0c.jpg?1",
             "name": "Botanical Brawler",
             "text": "Trample\nBotanical Brawler enters the battlefield with two +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another permanent you control, if it's the first time +1/+1 counters have been put on that permanent this turn, put a +1/+1 counter on Botanical Brawler.",
             "colours": [
@@ -16495,7 +16495,7 @@
         },
         {
             "id": "93ec638a-e667-547a-9e68-449640860c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca2b471-9418-4881-b7dc-92209942698b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca2b471-9418-4881-b7dc-92209942698b.jpg?1",
             "name": "Halo Forager",
             "text": "Flying\nWhen Halo Forager enters the battlefield, you may pay {X}. When you do, you may cast target instant or sorcery card with mana value X from a graveyard without paying its mana cost. If that spell would be put into a graveyard, exile it instead.",
             "colours": [
@@ -16534,7 +16534,7 @@
         },
         {
             "id": "c9f3a2e0-0e85-5fd0-92a2-9d7f273cb871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccb21e9-5169-4934-83c3-78ac00e5ffc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccb21e9-5169-4934-83c3-78ac00e5ffc7.jpg?1",
             "name": "Ghalta and Mavren",
             "text": "Trample\nWhenever you attack, choose one \u2014\n\u2022 Create a tapped and attacking X/X green Dinosaur creature token with trample, where X is the greatest power among other attacking creatures.\n\u2022 Create X 1/1 white Vampire creature tokens with lifelink, where X is the number of other attacking creatures.",
             "colours": [
@@ -16575,7 +16575,7 @@
         },
         {
             "id": "300015bd-7cf4-50d1-84ef-06a5c83e4e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0acfa-1a8d-4a94-8972-c9bb235e4897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0acfa-1a8d-4a94-8972-c9bb235e4897.jpg?1",
             "name": "Omnath, Locus of All",
             "text": "If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",
             "colours": [
@@ -16622,7 +16622,7 @@
         },
         {
             "id": "b73ea419-17f3-538f-a806-124a03513cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27b3b91-8bef-4d3c-84ef-5015ca9e472c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27b3b91-8bef-4d3c-84ef-5015ca9e472c.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "53b344e6-83a3-5eb3-a468-efe9b0e6ea29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774c68a-3d76-4fe1-b741-e6acf6b9214c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774c68a-3d76-4fe1-b741-e6acf6b9214c.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16692,7 +16692,7 @@
         },
         {
             "id": "c9b9d4d4-fced-558c-92ef-81c86be7e966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a2f3c3-fbcb-4b21-8f86-232c0db80c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a2f3c3-fbcb-4b21-8f86-232c0db80c1f.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -16727,7 +16727,7 @@
         },
         {
             "id": "fe3dc071-a8eb-558f-8f1a-2cf95935cc5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb727dec-dd82-4072-b2ec-a4e31b58752f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb727dec-dd82-4072-b2ec-a4e31b58752f.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "2ca6847c-e3f2-5003-8034-7b4c956afc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b2c61-b903-4669-b9a3-110418a35593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b2c61-b903-4669-b9a3-110418a35593.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -16797,7 +16797,7 @@
         },
         {
             "id": "430515a3-9c84-5aaf-8fe6-63cda4fa6731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69504a4-8caf-40c7-b998-1558a00444fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69504a4-8caf-40c7-b998-1558a00444fc.jpg?1",
             "name": "First Mate Ragavan",
             "text": "",
             "colours": [
@@ -16835,7 +16835,7 @@
         },
         {
             "id": "618893aa-cc4f-5940-8887-ad6f9a38a3a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6ea55-c976-40e7-aa09-5ba77688bfe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6ea55-c976-40e7-aa09-5ba77688bfe9.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -16870,7 +16870,7 @@
         },
         {
             "id": "e167b906-df66-5cce-962b-1086f473e884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10358f5-d653-49a0-9d81-a5d4e6dafe25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10358f5-d653-49a0-9d81-a5d4e6dafe25.jpg?1",
             "name": "Phyrexian Saproling",
             "text": "",
             "colours": [
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "bbab9684-dcc4-5a3a-af74-b040cc9d3a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16943,7 +16943,7 @@
         },
         {
             "id": "74a6afcf-21ee-526d-876d-15aabe19fffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439bfc-8942-473b-9e4f-863017788476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439bfc-8942-473b-9e4f-863017788476.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16980,7 +16980,7 @@
         },
         {
             "id": "5e46e483-0a40-57e9-9aea-59830b06d88f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff78d9-7c4c-4b3b-a485-5328e985315b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff78d9-7c4c-4b3b-a485-5328e985315b.jpg?1",
             "name": "Phyrexian Hydra",
             "text": "",
             "colours": [
@@ -17018,7 +17018,7 @@
         },
         {
             "id": "3a9a5194-7a70-54b0-b3f1-ff840ecbc811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bb0ec0-729e-4dcb-bab4-9f31c1056ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bb0ec0-729e-4dcb-bab4-9f31c1056ab3.jpg?1",
             "name": "Phyrexian Hydra",
             "text": "",
             "colours": [
@@ -17056,7 +17056,7 @@
         },
         {
             "id": "7658c38d-f21f-5b0a-8b1a-7f1048012f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7dada-ba7f-4233-ba21-f6f32698997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7dada-ba7f-4233-ba21-f6f32698997a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17093,7 +17093,7 @@
         },
         {
             "id": "bf20a56d-0799-512a-aa35-fa2df7e4deca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d02a57e-6c76-491c-85f8-8f4d825be2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d02a57e-6c76-491c-85f8-8f4d825be2c2.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17130,7 +17130,7 @@
         },
         {
             "id": "70b5f89e-ef3b-5912-bcec-80db98a589fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2661ea2-7ff6-4188-9d40-f18bb625ed52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2661ea2-7ff6-4188-9d40-f18bb625ed52.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -17167,7 +17167,7 @@
         },
         {
             "id": "a2f6e1f2-4191-594a-abe9-568e8c2e0e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17198,7 +17198,7 @@
         },
         {
             "id": "58bfc65d-9684-592a-94f7-b02435e46de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17230,7 +17230,7 @@
         },
         {
             "id": "7e5474f9-a09d-5e2a-8cc4-51a674771cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17261,7 +17261,7 @@
         },
         {
             "id": "55391123-7e23-5afa-9183-4b721a922977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17293,7 +17293,7 @@
         },
         {
             "id": "f4fd5aae-f65c-5d73-88ce-2a052c7616f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17324,7 +17324,7 @@
         },
         {
             "id": "4db065f6-6ce4-5ce5-a19a-02dfc694ba5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17356,7 +17356,7 @@
         },
         {
             "id": "d976794c-c6a4-56c8-8f29-7a3668f30b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0041d8-cacd-4057-8f99-37810edb4b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0041d8-cacd-4057-8f99-37810edb4b7e.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -17388,7 +17388,7 @@
         },
         {
             "id": "7f3fe0f9-49b9-562c-947b-74661b9bdaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e82686-0574-4fb3-8c3b-c6dbe3b24c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e82686-0574-4fb3-8c3b-c6dbe3b24c8d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17419,7 +17419,7 @@
         },
         {
             "id": "4873fe20-675e-5db5-b9ba-8d996c2806ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728ad2d-c8a6-49e4-85bb-29934fa26208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728ad2d-c8a6-49e4-85bb-29934fa26208.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17450,7 +17450,7 @@
         },
         {
             "id": "220ed608-fe2e-58e2-bfb7-4b68c0aca779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33aefd66-d1d2-44fd-a2cc-8661291c407e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33aefd66-d1d2-44fd-a2cc-8661291c407e.jpg?1",
             "name": "Teferi Akosa of Zhalfir Emblem",
             "text": "",
             "colours": [],
@@ -17478,7 +17478,7 @@
         },
         {
             "id": "afada065-4cf0-5ee1-b63a-ba76493499be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8ebb6-26dc-41eb-ae40-47c8e7b040a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8ebb6-26dc-41eb-ae40-47c8e7b040a6.jpg?1",
             "name": "Wrenn and Realmbreaker Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/MOR.json
+++ b/Assets/Resources/Sets/MOR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e02a08dd-aaf9-5cd0-aa3c-9db8616c1e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a029814e-d84d-43e5-b483-e918871b3333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a029814e-d84d-43e5-b483-e918871b3333.jpg?1",
             "name": "Ballyrush Banneret",
             "text": "Kithkin spells and Soldier spells you play cost {1} less to play.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "cd9faa11-55aa-572a-a589-13e2a23a628d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5357e0-ff69-4bb9-9a02-b0372e0ea5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5357e0-ff69-4bb9-9a02-b0372e0ea5e5.jpg?1",
             "name": "Battletide Alchemist",
             "text": "If a source would deal damage to a player, you may prevent X of that damage, where X is the number of Clerics you control.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "693dcc5a-7664-53a4-8b9b-d7d403bb0d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb44500-0c07-4fb6-9525-ab41621be1b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb44500-0c07-4fb6-9525-ab41621be1b0.jpg?1",
             "name": "Burrenton Bombardier",
             "text": "Flying\nReinforce 2\u2014{2}{W} ({2}{W}, Discard this card: Put two +1/+1 counters on target creature.)",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "08312da7-f275-54fc-93eb-132976e4b85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afc1033-0004-43c1-9341-c5ed0b0048f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afc1033-0004-43c1-9341-c5ed0b0048f2.jpg?1",
             "name": "Burrenton Shield-Bearers",
             "text": "Whenever Burrenton Shield-Bearers attacks, target creature gets +0/+3 until end of turn.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "87eb702a-67c4-57fe-8ed4-ef5ac8cc9090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998c949-4791-477f-ab8d-e625199623ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998c949-4791-477f-ab8d-e625199623ad.jpg?1",
             "name": "Cenn's Tactician",
             "text": "{W}, {T}: Put a +1/+1 counter on target Soldier creature.\nEach creature you control with a +1/+1 counter on it can block an additional creature.",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "e6943899-811b-5d11-80dd-dd447922fba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7e0c9f-000d-494d-86f6-95e8d2b59ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7e0c9f-000d-494d-86f6-95e8d2b59ac7.jpg?1",
             "name": "Changeling Sentinel",
             "text": "Changeling (This card is every creature type at all times.)\nVigilance",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "095212d1-d307-5484-88b5-1031e4b30da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0b26b0-cc31-458b-8a92-aa3392d0ca0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0b26b0-cc31-458b-8a92-aa3392d0ca0f.jpg?1",
             "name": "Coordinated Barrage",
             "text": "Choose a creature type. Coordinated Barrage deals damage to target attacking or blocking creature equal to the number of permanents you control of the chosen type.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "1d34c63c-7148-53a7-b303-1bce88d66f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d83dae-747b-4acf-adfd-7822dd64cfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d83dae-747b-4acf-adfd-7822dd64cfcc.jpg?1",
             "name": "Daily Regimen",
             "text": "Enchant creature\n{1}{W}: Put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "87fd49d7-1291-5803-b2aa-f5f9e7851be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1fff8e-0379-4d56-b726-f5cc56e63d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1fff8e-0379-4d56-b726-f5cc56e63d48.jpg?1",
             "name": "Feudkiller's Verdict",
             "text": "You gain 10 life. Then if you have more life than an opponent, put a 5/5 white Giant Warrior creature token into play.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "b684510a-44ad-561d-a90e-23ba0fa924c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e333-60f2-4e19-ad0f-5259d4feab37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e333-60f2-4e19-ad0f-5259d4feab37.jpg?1",
             "name": "Forfend",
             "text": "Prevent all damage that would be dealt to creatures this turn.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "4a38da33-bca8-501b-a2ba-2a35679c7245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38748fbe-0d3e-4697-b9c4-d93a4ac59f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38748fbe-0d3e-4697-b9c4-d93a4ac59f9a.jpg?1",
             "name": "Graceful Reprieve",
             "text": "When target creature is put into a graveyard this turn, return that card to play under its owner's control.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "076cee76-9e81-546e-8883-fd2de61be1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e7a59-7322-46eb-9903-00131234b310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e7a59-7322-46eb-9903-00131234b310.jpg?1",
             "name": "Idyllic Tutor",
             "text": "Search your library for an enchantment card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "5e37f45f-0dd7-5490-8d58-3ce1545e740e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf33cb6-d159-4af3-8403-d0ac10af9894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf33cb6-d159-4af3-8403-d0ac10af9894.jpg?1",
             "name": "Indomitable Ancients",
             "text": "",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "5dfeadcd-d8e7-5e36-bd22-11701b19acf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e219-9e84-4f54-88e2-3925e48c4827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e219-9e84-4f54-88e2-3925e48c4827.jpg?1",
             "name": "Kinsbaile Borderguard",
             "text": "Kinsbaile Borderguard comes into play with a +1/+1 counter on it for each other Kithkin you control.\nWhen Kinsbaile Borderguard is put into a graveyard from play, put a 1/1 white Kithkin Soldier creature token into play for each counter on it.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "f51efbaf-1503-5344-a0d9-19818d037c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3d840-95af-4664-ace0-625f89f06a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3d840-95af-4664-ace0-625f89f06a41.jpg?1",
             "name": "Kinsbaile Cavalier",
             "text": "Knight creatures you control have double strike.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "dda6fbc8-4f3d-50a4-a4ee-fa4182617f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8671abe8-4333-4b23-a87e-58bcc65deef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8671abe8-4333-4b23-a87e-58bcc65deef2.jpg?1",
             "name": "Kithkin Zephyrnaut",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Kithkin Zephyrnaut, you may reveal it. If you do, Kithkin Zephyrnaut gets +2/+2 and gains flying and vigilance until end of turn.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "f612b7c8-ecc4-5b82-bf7a-ad2384880f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7a4e9-08c3-4600-9eb5-03ed01ea0738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7a4e9-08c3-4600-9eb5-03ed01ea0738.jpg?1",
             "name": "Meadowboon",
             "text": "When Meadowboon leaves play, put a +1/+1 counter on each creature target player controls.\nEvoke {3}{W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "e4596d33-8311-5ea7-a611-5ce6eb929f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5bca35-5098-4100-815b-de141c82eb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5bca35-5098-4100-815b-de141c82eb6a.jpg?1",
             "name": "Mosquito Guard",
             "text": "First strike\nReinforce 1\u2014{1}{W} ({1}{W}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -619,7 +619,7 @@
         },
         {
             "id": "131bdbf0-7636-5d48-96ad-469a81001c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c2f16-5661-4c17-8265-f4b88ff1e833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c2f16-5661-4c17-8265-f4b88ff1e833.jpg?1",
             "name": "Order of the Golden Cricket",
             "text": "Whenever Order of the Golden Cricket attacks, you may pay {W}. If you do, it gains flying until end of turn.",
             "colours": [
@@ -654,7 +654,7 @@
         },
         {
             "id": "71f9ac67-3499-516b-8b9c-60ddb388a736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41659773-8b26-41bf-afcc-805f373c0074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41659773-8b26-41bf-afcc-805f373c0074.jpg?1",
             "name": "Preeminent Captain",
             "text": "First strike\nWhenever Preeminent Captain attacks, you may put a Soldier creature card from your hand into play tapped and attacking.",
             "colours": [
@@ -689,7 +689,7 @@
         },
         {
             "id": "abbedd3e-a2cb-5d8f-bf45-319e4a89416c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0f1aa1-b5be-43f0-822d-c4fcf33270d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0f1aa1-b5be-43f0-822d-c4fcf33270d9.jpg?1",
             "name": "Redeem the Lost",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Clash with an opponent. If you win, return Redeem the Lost to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "6b215c2d-c537-5609-9aee-8714777b76b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5629edd4-b5d3-43f8-8c7c-f9d916e35158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5629edd4-b5d3-43f8-8c7c-f9d916e35158.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves play, return up to two target creature cards with power 2 or less from your graveyard to play.\nEvoke {5}{W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "c3992bdd-645f-55f1-bcb5-71cc2d1d58c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dbd4a4-2a6f-477a-a267-27859ad73369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dbd4a4-2a6f-477a-a267-27859ad73369.jpg?1",
             "name": "Shinewend",
             "text": "Flying\nShinewend comes into play with a +1/+1 counter on it.\n{1}{W}, Remove a +1/+1 counter from Shinewend: Destroy target enchantment.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "d043700c-c9ff-5a8d-9b4f-927b9367292b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363c51c5-b0fc-4c84-b3d6-8cc17c2387a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363c51c5-b0fc-4c84-b3d6-8cc17c2387a4.jpg?1",
             "name": "Stonehewer Giant",
             "text": "Vigilance\n{1}{W}, {T}: Search your library for an Equipment card and put it into play. Attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "4c756906-cc0c-5c95-a08b-2e0d89e0e586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fa2293-f398-4ad8-895e-c739ddea56d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fa2293-f398-4ad8-895e-c739ddea56d0.jpg?1",
             "name": "Stonybrook Schoolmaster",
             "text": "Whenever Stonybrook Schoolmaster becomes tapped, you may put a 1/1 blue Merfolk Wizard creature token into play.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "4756f7e3-d3c5-5422-97ff-5db2b2dcdea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162bba28-667d-4acd-97ed-3421d12e0453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162bba28-667d-4acd-97ed-3421d12e0453.jpg?1",
             "name": "Swell of Courage",
             "text": "Creatures you control get +2/+2 until end of turn.\nReinforce X\u2014{X}{W}{W} ({X}{W}{W}, Discard this card: Put X +1/+1 counters on target creature.)",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "de139dc6-5d5c-540b-a3dd-810df3742c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5c82f9-4bc5-4326-92c0-d2aa4b4838a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5c82f9-4bc5-4326-92c0-d2aa4b4838a5.jpg?1",
             "name": "Wandering Graybeard",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Wandering Graybeard, you may reveal it. If you do, you gain 4 life.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "0111ac5f-a597-5c1f-b2a0-2be7b745d1ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396c8c41-70b4-4189-9160-8b7367a817a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396c8c41-70b4-4189-9160-8b7367a817a2.jpg?1",
             "name": "Weight of Conscience",
             "text": "Enchant creature\nEnchanted creature can't attack.\nTap two untapped creatures you control that share a creature type: Remove enchanted creature from the game.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "b04f7bb0-9634-5d56-8b0f-380e5375e8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e67d62f-9629-463b-a445-4181f6fafd0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e67d62f-9629-463b-a445-4181f6fafd0f.jpg?1",
             "name": "Declaration of Naught",
             "text": "As Declaration of Naught comes into play, name a card.\n{U}: Counter target spell with that name.",
             "colours": [
@@ -992,7 +992,7 @@
         },
         {
             "id": "ae5b947d-43ff-5801-871f-567b0b52a38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b14ad2-0ac7-4ae1-8a9e-eb49c8c5cc40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b14ad2-0ac7-4ae1-8a9e-eb49c8c5cc40.jpg?1",
             "name": "Dewdrop Spy",
             "text": "Flash\nFlying\nWhen Dewdrop Spy comes into play, look at the top card of target player's library.",
             "colours": [
@@ -1027,7 +1027,7 @@
         },
         {
             "id": "48f67fe0-94a7-5231-94e1-a12853b8d498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "3fb7af23-7b1b-5b97-8277-662f6824be1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a28e4f9-3b68-40bb-bf77-850b08c6b096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a28e4f9-3b68-40bb-bf77-850b08c6b096.jpg?1",
             "name": "Distant Melody",
             "text": "Choose a creature type. Draw a card for each permanent you control of that type.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "71ac33ae-70c7-55b1-ba94-7617c3d91f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c0929f-bee6-416d-8571-6540ae4f6e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c0929f-bee6-416d-8571-6540ae4f6e4f.jpg?1",
             "name": "Fencer Clique",
             "text": "Flying\n{U}: Put Fencer Clique on top of its owner's library.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "06cf5425-91ee-5887-9231-3cb709d8813f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71265bb0-bf51-4d9d-b94c-c90adf65c55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71265bb0-bf51-4d9d-b94c-c90adf65c55b.jpg?1",
             "name": "Floodchaser",
             "text": "Floodchaser comes into play with six +1/+1 counters on it.\nFloodchaser can't attack unless defending player controls an Island.\n{U}, Remove a +1/+1 counter from Floodchaser: Target land becomes an Island until end of turn.",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "a9b3fcb9-dd4e-5818-88d0-86e851b0572a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c4dceb-6889-4a79-87c2-98952f3478bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c4dceb-6889-4a79-87c2-98952f3478bb.jpg?1",
             "name": "Grimoire Thief",
             "text": "Whenever Grimoire Thief becomes tapped, remove the top three cards of target opponent's library from the game face down.\nYou may look at cards removed from the game with Grimoire Thief.\n{U}, Sacrifice Grimoire Thief: Turn all cards removed from the game with Grimoire Thief face up. Counter all spells with those names.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "30258a82-da21-52f5-87e5-e1748a7a824e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1bf0ad-f718-4118-9e9b-19041cfbb5cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1bf0ad-f718-4118-9e9b-19041cfbb5cf.jpg?1",
             "name": "Ink Dissolver",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Ink Dissolver, you may reveal it. If you do, each opponent puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1230,7 +1230,7 @@
         },
         {
             "id": "faf67ae3-8991-5cf8-9ba4-ab7d4d215052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0960dc0a-907b-4e02-a0b5-dd2613be8e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0960dc0a-907b-4e02-a0b5-dd2613be8e65.jpg?1",
             "name": "Inspired Sprite",
             "text": "Flash\nFlying\nWhenever you play a Wizard spell, you may untap Inspired Sprite.\n{T}: Draw a card, then discard a card.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "43945f6f-2816-5171-a887-5f4726c7c677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d283c49-2e81-4b2e-956a-69152cc4704e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d283c49-2e81-4b2e-956a-69152cc4704e.jpg?1",
             "name": "Knowledge Exploitation",
             "text": "Prowl {3}{U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nSearch target opponent's library for an instant or sorcery card. You may play that card without paying its mana cost. Then that player shuffles his or her library.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "f99f9733-1158-5b07-a20f-12f4a014dffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32d51e-1ec0-46aa-b240-e28a1fb64d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32d51e-1ec0-46aa-b240-e28a1fb64d73.jpg?1",
             "name": "Latchkey Faerie",
             "text": "Flying\nProwl {2}{U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Faerie or Rogue.)\nWhen Latchkey Faerie comes into play, if its prowl cost was paid, draw a card.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "e2956c48-b49d-51d1-aa47-2bd941a52457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b4e77f-012f-47f4-8b44-930148250b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b4e77f-012f-47f4-8b44-930148250b1d.jpg?1",
             "name": "Merrow Witsniper",
             "text": "When Merrow Witsniper comes into play, target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "756fd41d-64fa-5c33-9ff2-05485ae1a548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7cd9b6-1ea8-423d-8aa0-8699fffbcf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7cd9b6-1ea8-423d-8aa0-8699fffbcf50.jpg?1",
             "name": "Mind Spring",
             "text": "Draw X cards.",
             "colours": [
@@ -1402,7 +1402,7 @@
         },
         {
             "id": "4d38b559-c441-5770-87a8-acb309bb825c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da9bc9-6ac5-432d-ac12-04088cc6c74d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da9bc9-6ac5-432d-ac12-04088cc6c74d.jpg?1",
             "name": "Mothdust Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nTap an untapped creature you control: Mothdust Changeling gains flying until end of turn.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "4f46c0e4-67a0-5d76-9a4e-489fa5bf4b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a501252-e722-4ebf-bcf7-f53a42745fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a501252-e722-4ebf-bcf7-f53a42745fa7.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "a682d9e6-a14a-56fe-8c07-8148e525e9bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fa77d1-cd61-4ef8-a71f-7c92b1f3b074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fa77d1-cd61-4ef8-a71f-7c92b1f3b074.jpg?1",
             "name": "Nevermaker",
             "text": "Flying\nWhen Nevermaker leaves play, put target nonland permanent on top of its owner's library.\nEvoke {3}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "13dc663a-9648-582d-b97d-2cc7fd26ac7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4b5890-21d3-4eb9-a959-645dd389dde6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4b5890-21d3-4eb9-a959-645dd389dde6.jpg?1",
             "name": "Notorious Throng",
             "text": "Prowl {5}{U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nPut X 1/1 black Faerie Rogue creature tokens with flying into play, where X is the damage dealt to your opponents this turn. If Notorious Throng's prowl cost was paid, take an extra turn after this one.",
             "colours": [
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "e76eef53-f0b4-5a45-8bec-670577b35e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927bab71-a208-4ff2-b6c9-51b63468db38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927bab71-a208-4ff2-b6c9-51b63468db38.jpg?1",
             "name": "Research the Deep",
             "text": "Draw a card. Clash with an opponent. If you win, return Research the Deep to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "189dfaad-f667-56c3-94e7-4f67f982112f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b3e46e-7a65-4c2a-989b-b626b20e1b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b3e46e-7a65-4c2a-989b-b626b20e1b14.jpg?1",
             "name": "Sage of Fables",
             "text": "Each other Wizard creature you control comes into play with an additional +1/+1 counter on it.\n{2}, Remove a +1/+1 counter from a creature you control: Draw a card.",
             "colours": [
@@ -1604,7 +1604,7 @@
         },
         {
             "id": "d7d4649b-ebe6-53f8-80d0-61c778d5a668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ccd5f6-b363-433f-9e98-f65e10b10bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ccd5f6-b363-433f-9e98-f65e10b10bc9.jpg?1",
             "name": "Sage's Dousing",
             "text": "Counter target spell unless its controller pays {3}. If you control a Wizard, draw a card.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "a540dbdc-a0ae-5808-b99f-ae2a531b4e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9341e6-b899-418d-916f-550775af419f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9341e6-b899-418d-916f-550775af419f.jpg?1",
             "name": "Sigil Tracer",
             "text": "{1}{U}, Tap two untapped Wizards you control: Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "e5110866-2adb-5587-a37b-329f8d21612e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9df4e-2ee7-4c77-91b0-ad6e624340cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9df4e-2ee7-4c77-91b0-ad6e624340cd.jpg?1",
             "name": "Slithermuse",
             "text": "When Slithermuse leaves play, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.\nEvoke {3}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "146b7bab-0363-5ce1-a7d7-19c4ea49ca3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3e9c6c-e11a-4771-ae1a-3c13cc97e92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3e9c6c-e11a-4771-ae1a-3c13cc97e92e.jpg?1",
             "name": "Stonybrook Banneret",
             "text": "Islandwalk\nMerfolk spells and Wizard spells you play cost {1} less to play.",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "97f9b50d-7b2c-587a-88b3-93b1c3eab0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ba05db-6b09-4b6a-b7fe-13c1e1058e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ba05db-6b09-4b6a-b7fe-13c1e1058e25.jpg?1",
             "name": "Stream of Unconsciousness",
             "text": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "2accbeb6-dc14-5ea2-85b0-d405aad195fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea92ba-d6e3-4fba-be81-86b10852a9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea92ba-d6e3-4fba-be81-86b10852a9d1.jpg?1",
             "name": "Supreme Exemplar",
             "text": "Flying\nChampion an Elemental (When this comes into play, sacrifice it unless you remove another Elemental you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "6a0b021e-30fd-5991-a655-36192a7c4021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8175ec81-f4e2-45d2-a9d8-e8855e17ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8175ec81-f4e2-45d2-a9d8-e8855e17ff4a.jpg?1",
             "name": "Thieves' Fortune",
             "text": "Prowl {U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nLook at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1847,7 +1847,7 @@
         },
         {
             "id": "29be6065-fe26-575c-8ac6-24cbf3aa751a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53d8540-fb6d-4d4c-b467-ebfbfa53c880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53d8540-fb6d-4d4c-b467-ebfbfa53c880.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique comes into play, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "35d2419c-39c9-55a2-8fce-3f3f66d22906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5c04f-fd5e-4e4c-9146-f9e6ef20a159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5c04f-fd5e-4e4c-9146-f9e6ef20a159.jpg?1",
             "name": "Waterspout Weavers",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Waterspout Weavers, you may reveal it. If you do, each creature you control gains flying until end of turn.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "9b9d969f-109c-5a0a-9f65-bcd3761c224e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5caf12-9358-490b-aafa-fc4d2b8b9b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5caf12-9358-490b-aafa-fc4d2b8b9b22.jpg?1",
             "name": "Auntie's Snitch",
             "text": "Auntie's Snitch can't block.\nProwl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhenever a Goblin or Rogue you control deals combat damage to a player, if Auntie's Snitch is in your graveyard, you may return Auntie's Snitch to your hand.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "133f3ccf-4693-5a23-ac98-b61e6cc1157b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8145fed6-6b51-420a-84cf-4ea5e0aa1883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8145fed6-6b51-420a-84cf-4ea5e0aa1883.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and put a 1/1 black Faerie Rogue creature token with flying into play.",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "49a9461d-1570-5a47-9f33-e17728a79b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6355f5b-c136-466c-bcfd-f2bf561217cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6355f5b-c136-466c-bcfd-f2bf561217cf.jpg?1",
             "name": "Blightsoil Druid",
             "text": "{T}, Pay 1 life: Add {G} to your mana pool.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "ade172bb-ccf4-5013-8f74-05d4728fa89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0116416b-ed95-4fa2-abc5-446de5c3106b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0116416b-ed95-4fa2-abc5-446de5c3106b.jpg?1",
             "name": "Earwig Squad",
             "text": "Prowl {2}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhen Earwig Squad comes into play, if its prowl cost was paid, search target opponent's library for three cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "152dbb93-11be-54d6-95ea-481a1cb9783d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fb2b62-eea7-469f-b237-fdce20b8bdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fb2b62-eea7-469f-b237-fdce20b8bdcf.jpg?1",
             "name": "Fendeep Summoner",
             "text": "{T}: Up to two target Swamps each become 3/5 Treefolk Warrior creatures in addition to their other types until end of turn.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "6de17214-1ea0-5bdd-a845-9ddfd1bf5bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614a9456-0ebf-4fba-b085-225f8c7e4a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614a9456-0ebf-4fba-b085-225f8c7e4a98.jpg?1",
             "name": "Festercreep",
             "text": "Festercreep comes into play with a +1/+1 counter on it.\n{1}{B}, Remove a +1/+1 counter from Festercreep: All other creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "46dd4fa8-828e-5bdd-9494-a064a5e4732c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb237de0-bf73-445f-a42b-c3da4cd35973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb237de0-bf73-445f-a42b-c3da4cd35973.jpg?1",
             "name": "Final-Sting Faerie",
             "text": "Flying\nWhen Final-Sting Faerie comes into play, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "9efb01c8-2732-54ef-aeb0-5645a80a509a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78543dac-7367-429f-88a5-83cb803193ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78543dac-7367-429f-88a5-83cb803193ef.jpg?1",
             "name": "Frogtosser Banneret",
             "text": "Haste\nGoblin spells and Rogue spells you play cost {1} less to play.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "9a4dffea-beb7-56e1-a7dc-c24e5ddcadfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba98d363-194b-4bc0-b9fe-987c498ab6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba98d363-194b-4bc0-b9fe-987c498ab6fa.jpg?1",
             "name": "Maralen of the Mornsong",
             "text": "Players can't draw cards.\nAt the beginning of each player's draw step, that player loses 3 life, searches his or her library for a card, puts it into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "e6ecba3d-3375-5a0a-a728-766683ea4e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6b2715-4d19-4980-8f5c-3ae20af6af72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6b2715-4d19-4980-8f5c-3ae20af6af72.jpg?1",
             "name": "Mind Shatter",
             "text": "Target player discards X cards at random.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "890fcea5-929c-5b86-9323-dc2a66435c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955348b-70e9-49c3-9343-9becf977abe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955348b-70e9-49c3-9343-9becf977abe8.jpg?1",
             "name": "Moonglove Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{B}: Moonglove Changeling gains deathtouch until end of turn. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "e784222b-f93b-5c11-ad7e-b12633a4219f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac48152-81c0-4cdc-8e3c-bfbe7b068b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac48152-81c0-4cdc-8e3c-bfbe7b068b28.jpg?1",
             "name": "Morsel Theft",
             "text": "Prowl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nTarget player loses 3 life and you gain 3 life. If Morsel Theft's prowl cost was paid, draw a card.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "7e892934-14dc-5631-a9f6-b2a62fc66ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a61cd-3a26-4142-83ce-9c41cdb16eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a61cd-3a26-4142-83ce-9c41cdb16eb4.jpg?1",
             "name": "Nightshade Schemers",
             "text": "Flying\nKinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Nightshade Schemers, you may reveal it. If you do, each opponent loses 2 life.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "38934412-f61e-57a8-8b74-f6da63eaf358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932649ab-ed5e-405f-986f-855d8a7c8eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932649ab-ed5e-405f-986f-855d8a7c8eb2.jpg?1",
             "name": "Noggin Whack",
             "text": "Prowl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nTarget player reveals three cards from his or her hand. You choose two of them. That player discards those cards.",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "3cf78189-5cc5-5d9c-9dd6-26a441b16338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632dcea3-53ad-4317-b8bc-457b1887e7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632dcea3-53ad-4317-b8bc-457b1887e7b5.jpg?1",
             "name": "Offalsnout",
             "text": "Flash\nWhen Offalsnout leaves play, remove target card in a graveyard from the game.\nEvoke {B} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "3fee5cfe-7cc9-52df-90b1-77c6cd64eee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180abc09-b098-4a51-bf4f-c1ad7c5e1c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180abc09-b098-4a51-bf4f-c1ad7c5e1c30.jpg?1",
             "name": "Oona's Blackguard",
             "text": "Flying\nEach other Rogue creature you control comes into play with an additional +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it deals combat damage to a player, that player discards a card.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "3117ceda-34a3-5ac2-a8be-cee2c50085ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79713cf7-2715-44cc-9f15-4c809b82efb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79713cf7-2715-44cc-9f15-4c809b82efb6.jpg?1",
             "name": "Pack's Disdain",
             "text": "Choose a creature type. Target creature gets -1/-1 until end of turn for each permanent of the chosen type you control.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "b77c808a-a760-5e5f-ac7a-79f80158a505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55121b63-22a6-4923-82e9-c55f66742980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55121b63-22a6-4923-82e9-c55f66742980.jpg?1",
             "name": "Prickly Boggart",
             "text": "Fear",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "b57dd121-36f1-519b-8dcd-5f1e0489079b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdce79d-c8a6-4172-8211-7cf2dcb8bf2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdce79d-c8a6-4172-8211-7cf2dcb8bf2d.jpg?1",
             "name": "Pulling Teeth",
             "text": "Clash with an opponent. If you win, target player discards two cards. Otherwise, that player discards a card. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "c528ad02-04ec-5075-8059-5a023c1dc55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0aa3c8-9e11-4917-956b-35b77a100761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0aa3c8-9e11-4917-956b-35b77a100761.jpg?1",
             "name": "Revive the Fallen",
             "text": "Return target creature card in a graveyard to its owner's hand. Clash with an opponent. If you win, return Revive the Fallen to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "3dbc8925-5291-55ef-827f-dc78f25da1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5c2b6-fcb2-4865-a0e5-9af59d94ae5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5c2b6-fcb2-4865-a0e5-9af59d94ae5a.jpg?1",
             "name": "Scarblade Elite",
             "text": "{T}, Remove an Assassin card in your graveyard from the game: Destroy target creature.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "6f54a402-9437-5268-a02e-d0cf21407fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81290ae9-9217-482a-ae1a-be1a0ef47b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81290ae9-9217-482a-ae1a-be1a0ef47b5d.jpg?1",
             "name": "Squeaking Pie Grubfellows",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Squeaking Pie Grubfellows, you may reveal it. If you do, each opponent discards a card.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "21f94ec1-402a-5431-a355-248f36c0811d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c376fd5f-596a-4208-b173-0b2e5165f2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c376fd5f-596a-4208-b173-0b2e5165f2e9.jpg?1",
             "name": "Stenchskipper",
             "text": "Flying\nAt end of turn, if you control no Goblins, sacrifice Stenchskipper.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "93a2eb43-4b14-5209-9cc6-f43f47f8befc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9818ad-db8d-41e2-945f-a8b487c2df76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9818ad-db8d-41e2-945f-a8b487c2df76.jpg?1",
             "name": "Stinkdrinker Bandit",
             "text": "Prowl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhenever a Rogue you control attacks and isn't blocked, it gets +2/+1 until end of turn.",
             "colours": [
@@ -2746,7 +2746,7 @@
         },
         {
             "id": "bd882e34-1f35-5c9c-8fd4-952597e6fe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd0fa3-37d2-403e-99fe-8c9e57515e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd0fa3-37d2-403e-99fe-8c9e57515e9d.jpg?1",
             "name": "Violet Pall",
             "text": "Destroy target nonblack creature. Put a 1/1 black Faerie Rogue creature token with flying into play.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "18d77294-17b9-5e75-9b04-ec70877e979e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c1288b-5515-497f-b15d-520a29322f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c1288b-5515-497f-b15d-520a29322f5b.jpg?1",
             "name": "Warren Weirding",
             "text": "Target player sacrifices a creature. If a Goblin is sacrificed this way, that player puts two 1/1 black Goblin Rogue creature tokens into play, and those tokens gain haste until end of turn.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "43286367-366e-57b9-b3fe-b93b06a5bbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44d2eb4-e5a3-4401-86cb-311374a2de04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44d2eb4-e5a3-4401-86cb-311374a2de04.jpg?1",
             "name": "Weed-Pruner Poplar",
             "text": "At the beginning of your upkeep, target creature other than Weed-Pruner Poplar gets -1/-1 until end of turn.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "d7eb0e5e-8a92-5025-8c96-e48d64ea0419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1d40cc-2871-4a33-bc58-5250fd3d4f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1d40cc-2871-4a33-bc58-5250fd3d4f0e.jpg?1",
             "name": "Weirding Shaman",
             "text": "{3}{B}, Sacrifice a Goblin: Put two 1/1 black Goblin Rogue creature tokens into play.",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "6e42f17f-f918-5a3c-9f71-2d6ef9e71bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d90bc4-7f70-4203-b554-800c70c775ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d90bc4-7f70-4203-b554-800c70c775ef.jpg?1",
             "name": "Boldwyr Heavyweights",
             "text": "Trample\nWhen Boldwyr Heavyweights comes into play, each opponent may search his or her library for a creature card and put it into play. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "801a8d9e-7172-574a-bbfa-cdf8ebd49d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e9f546-7d34-4ec5-a017-913d7ebb7223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e9f546-7d34-4ec5-a017-913d7ebb7223.jpg?1",
             "name": "Boldwyr Intimidator",
             "text": "Cowards can't block Warriors.\n{R}: Target creature becomes a Coward until end of turn.\n{2}{R}: Target creature becomes a Warrior until end of turn.",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "db0e1b67-86cd-56bb-b74f-2f1c5c3df2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ccfc78-b2d6-4eb7-b8bf-ba8bd876d2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ccfc78-b2d6-4eb7-b8bf-ba8bd876d2b8.jpg?1",
             "name": "Borderland Behemoth",
             "text": "Trample\nBorderland Behemoth gets +4/+4 for each other Giant you control.",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "9711561b-b585-57dd-9817-ca015bafee6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb44df5b-6c89-46ae-b068-5056b8c4c189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb44df5b-6c89-46ae-b068-5056b8c4c189.jpg?1",
             "name": "Brighthearth Banneret",
             "text": "Elemental spells and Warrior spells you play cost {1} less to play.\nReinforce 1\u2014{1}{R} ({1}{R}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "344fe1d1-a8b4-5683-a72a-072c59d7d88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3f7a3-05e7-44c0-9e09-3f28378677c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3f7a3-05e7-44c0-9e09-3f28378677c1.jpg?1",
             "name": "Countryside Crusher",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a land card, put it into your graveyard and repeat this process.\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Countryside Crusher.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "2fd08585-c8dd-5bff-9444-418e5524af08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04d5eef-da88-496b-a902-b87b0b386f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04d5eef-da88-496b-a902-b87b0b386f96.jpg?1",
             "name": "Fire Juggler",
             "text": "Whenever Fire Juggler becomes blocked, clash with an opponent. If you win, Fire Juggler deals 4 damage to each creature blocking it. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "9679c6e0-2472-5285-ab4e-4167eab73e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e172b353-7a16-4831-b735-206230b22e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e172b353-7a16-4831-b735-206230b22e59.jpg?1",
             "name": "Hostile Realm",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature can't block this turn.\"",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "c4893b37-7fff-58e2-b7dd-ca8318f8fe9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993956c9-30d8-41ee-84c2-c06d0512aea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993956c9-30d8-41ee-84c2-c06d0512aea4.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "c64283ca-e43e-5463-a144-0c3e233a72b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68f5ac9-0345-4052-9f93-d9f7afc66932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68f5ac9-0345-4052-9f93-d9f7afc66932.jpg?1",
             "name": "Lightning Crafter",
             "text": "Champion a Goblin or Shaman (When this comes into play, sacrifice it unless you remove another Goblin or Shaman you control from the game. When this leaves play, that card returns to play.)\n{T}: Lightning Crafter deals 3 damage to target creature or player.",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "606d01f1-90b6-53cc-9dc9-ffc88214fc2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f459acfa-a9db-43c6-b0e9-ed66d772a335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f459acfa-a9db-43c6-b0e9-ed66d772a335.jpg?1",
             "name": "Lunk Errant",
             "text": "Whenever Lunk Errant attacks alone, it gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -3232,7 +3232,7 @@
         },
         {
             "id": "d95ee617-3d1a-55b6-85b7-1da7ffa5c778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5e2771-ae35-4aff-a92d-7fc7f3ca915f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5e2771-ae35-4aff-a92d-7fc7f3ca915f.jpg?1",
             "name": "Mudbutton Clanger",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Mudbutton Clanger, you may reveal it. If you do, Mudbutton Clanger gets +1/+1 until end of turn.",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "c66dd10c-db78-5a8f-8849-87a448b11384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a1c7c8-1acd-4219-a272-69e855517a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a1c7c8-1acd-4219-a272-69e855517a74.jpg?1",
             "name": "Pyroclast Consul",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Pyroclast Consul, you may reveal it. If you do, Pyroclast Consul deals 2 damage to each creature.",
             "colours": [
@@ -3302,7 +3302,7 @@
         },
         {
             "id": "2df9436e-3388-52f4-88b0-5dd58e1516cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe140361-93b2-4382-b85e-8c263d2f446e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe140361-93b2-4382-b85e-8c263d2f446e.jpg?1",
             "name": "Rage Forger",
             "text": "When Rage Forger comes into play, put a +1/+1 counter on each other Shaman creature you control.\nWhenever a creature you control with a +1/+1 counter on it attacks, you may have that creature deal 1 damage to target player.",
             "colours": [
@@ -3337,7 +3337,7 @@
         },
         {
             "id": "f203002d-492a-5d11-bfbe-ff1840a80810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6f1afb-2451-4611-ac3e-3513a4651719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6f1afb-2451-4611-ac3e-3513a4651719.jpg?1",
             "name": "Release the Ants",
             "text": "Release the Ants deals 1 damage to target creature or player. Clash with an opponent. If you win, return Release the Ants to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "76cbec0c-b033-5891-9521-46f5c304b400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2eee8b-cc55-4a65-983f-0a91d7e4494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2eee8b-cc55-4a65-983f-0a91d7e4494a.jpg?1",
             "name": "Rivals' Duel",
             "text": "Choose two target creatures that share no creature types. Each of those creatures deals damage equal to its power to the other.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "63d40784-bdb7-58fc-a519-611f83a7acf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b0e072-c51a-4e97-a089-8e5b540355aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b0e072-c51a-4e97-a089-8e5b540355aa.jpg?1",
             "name": "Roar of the Crowd",
             "text": "Choose a creature type. Roar of the Crowd deals damage to target creature or player equal to the number of permanents you control of the chosen type.",
             "colours": [
@@ -3433,7 +3433,7 @@
         },
         {
             "id": "4d769e12-e240-5cea-939d-ab0d87b48f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4971a447-29c8-47b6-863c-f13a69b4148b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4971a447-29c8-47b6-863c-f13a69b4148b.jpg?1",
             "name": "Seething Pathblazer",
             "text": "Sacrifice an Elemental: Seething Pathblazer gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3468,7 +3468,7 @@
         },
         {
             "id": "fa1655ee-cf1e-5fbb-b397-e570a21cfa58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5eb69-dcd9-4784-bf4c-20b674f4c035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5eb69-dcd9-4784-bf4c-20b674f4c035.jpg?1",
             "name": "Sensation Gorger",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Sensation Gorger, you may reveal it. If you do, each player discards his or her hand and draws four cards.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "7efb8402-403d-5907-a3a3-292416498099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43db4810-078e-487a-afef-57cbc1db0cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43db4810-078e-487a-afef-57cbc1db0cc7.jpg?1",
             "name": "Shard Volley",
             "text": "As an additional cost to play Shard Volley, sacrifice a land.\nShard Volley deals 3 damage to target creature or player.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "cafadf7d-76e1-5857-a83d-a4803bd92e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe332c46-90f0-4cc0-8bf1-35a3934ff8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe332c46-90f0-4cc0-8bf1-35a3934ff8a0.jpg?1",
             "name": "Shared Animosity",
             "text": "Whenever a creature you control attacks, it gets +1/+0 until end of turn for each other attacking creature that shares a creature type with it.",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "c40a933c-cb0f-56d8-82e6-b49a066d7ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f2104d-aeff-493f-8227-cb95bf3e2eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f2104d-aeff-493f-8227-cb95bf3e2eab.jpg?1",
             "name": "Spitebellows",
             "text": "When Spitebellows leaves play, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -3601,7 +3601,7 @@
         },
         {
             "id": "a58dcd67-497c-5de4-9fc4-1030dc627a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0fdb4-187a-4178-a702-884bef9e029d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0fdb4-187a-4178-a702-884bef9e029d.jpg?1",
             "name": "Stingmoggie",
             "text": "Stingmoggie comes into play with two +1/+1 counters on it.\n{3}{R}, Remove a +1/+1 counter from Stingmoggie: Destroy target artifact or land.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "09cbf6df-68e9-58b8-8dda-71e7d1e7ef3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820f1acf-7f0c-4ee5-9f18-b5627aac7c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820f1acf-7f0c-4ee5-9f18-b5627aac7c81.jpg?1",
             "name": "Stomping Slabs",
             "text": "Reveal the top seven cards of your library, then put those cards on the bottom of your library in any order. If a card named Stomping Slabs was revealed this way, Stomping Slabs deals 7 damage to target creature or player.",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "07b59dd9-303d-553d-a776-192f2404c6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db24aa7-4922-4b39-9964-f76df09cba12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db24aa7-4922-4b39-9964-f76df09cba12.jpg?1",
             "name": "Sunflare Shaman",
             "text": "{1}{R}, {T}: Sunflare Shaman deals X damage to target creature or player and X damage to itself, where X is the number of Elemental cards in your graveyard.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "55fe035a-c30a-5568-9bf4-69b8551334ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50b5df1-b658-4df0-900e-79c44599b93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50b5df1-b658-4df0-900e-79c44599b93e.jpg?1",
             "name": "Taurean Mauler",
             "text": "Changeling (This card is every creature type at all times.)\nWhenever an opponent plays a spell, you may put a +1/+1 counter on Taurean Mauler.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "010b14c3-d0c4-505b-b8f2-c0f7055b57d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b0f9ca-b752-4dd6-982b-06bb3a27ddbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b0f9ca-b752-4dd6-982b-06bb3a27ddbc.jpg?1",
             "name": "Titan's Revenge",
             "text": "Titan's Revenge deals X damage to target creature or player. Clash with an opponent. If you win, return Titan's Revenge to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "8cb61f54-e1e3-5ec1-9160-0e755391b82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5db7e33-188f-4d66-a58b-7b5c5760a773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5db7e33-188f-4d66-a58b-7b5c5760a773.jpg?1",
             "name": "Vengeful Firebrand",
             "text": "Vengeful Firebrand has haste as long as a Warrior card is in your graveyard.\n{R}: Vengeful Firebrand gets +1/+0 until end of turn.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "f53603f3-e100-546f-b8a7-e0f58070e1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917081e0-8a5f-4edc-b5e9-9a7302bb5c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917081e0-8a5f-4edc-b5e9-9a7302bb5c06.jpg?1",
             "name": "War-Spike Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{R}: War-Spike Changeling gains first strike until end of turn.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "69a73eea-8ba3-54e1-915b-400a83e03215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904d3416-70bf-4043-8078-f5f033ecfb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904d3416-70bf-4043-8078-f5f033ecfb31.jpg?1",
             "name": "Ambassador Oak",
             "text": "When Ambassador Oak comes into play, put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "3ab69ca8-bd94-55ad-bfe8-6bee194612e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203f41a7-ecf5-4757-9162-01ffd2a42ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203f41a7-ecf5-4757-9162-01ffd2a42ee9.jpg?1",
             "name": "Bosk Banneret",
             "text": "Treefolk spells and Shaman spells you play cost {1} less to play.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "f5e932c7-44fa-5c84-a4bf-3025ed336f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3910f5b2-17da-41e4-bf40-1c40b513fa12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3910f5b2-17da-41e4-bf40-1c40b513fa12.jpg?1",
             "name": "Bramblewood Paragon",
             "text": "Each other Warrior creature you control comes into play with an additional +1/+1 counter on it.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -3942,7 +3942,7 @@
         },
         {
             "id": "602edcd7-8a29-5152-b8f5-92b604334bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5459f1e6-7019-427d-9e2d-e494b3cd52d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5459f1e6-7019-427d-9e2d-e494b3cd52d2.jpg?1",
             "name": "Chameleon Colossus",
             "text": "Changeling (This card is every creature type at all times.)\nProtection from black\n{2}{G}{G}: Chameleon Colossus gets +X/+X until end of turn, where X is its power.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "edc6e1eb-550f-51d2-9465-4c6442e80469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030b0a9d-d0cf-4f3a-97b3-3e1d59226ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030b0a9d-d0cf-4f3a-97b3-3e1d59226ee6.jpg?1",
             "name": "Cream of the Crop",
             "text": "Whenever a creature comes into play under your control, you may look at the top X cards of your library, where X is that creature's power. If you do, put one of those cards on top of your library and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "b5734943-e22b-514d-b641-e27b94e7b699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b43aa-58f0-42fc-9ef0-a7925727d58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b43aa-58f0-42fc-9ef0-a7925727d58f.jpg?1",
             "name": "Deglamer",
             "text": "Choose target artifact or enchantment. Its owner shuffles it into his or her library.",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "2de19504-d19e-5650-a491-bf912be6e650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478208df-9776-4354-b8a9-8da16ae1f50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478208df-9776-4354-b8a9-8da16ae1f50a.jpg?1",
             "name": "Earthbrawn",
             "text": "Target creature gets +3/+3 until end of turn.\nReinforce 1\u2014{1}{G} ({1}{G}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "75e63236-10bd-59c3-a6bb-7a96e8c47b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2154a16-1fb8-45bb-9b9b-e995e701c330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2154a16-1fb8-45bb-9b9b-e995e701c330.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "61b1b191-3d7a-51fe-82b5-cb28654888ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ae521-a176-4d93-92b1-89ba674f86e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ae521-a176-4d93-92b1-89ba674f86e4.jpg?1",
             "name": "Everbark Shaman",
             "text": "{T}, Remove a Treefolk card in your graveyard from the game: Search your library for two Forest cards and put them into play tapped. Then shuffle your library.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "de79ffe9-420b-5ab8-ad76-fa4bfec81155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8055f1-cf3a-4db4-844e-b10bbbb25255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8055f1-cf3a-4db4-844e-b10bbbb25255.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid comes into play with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches his or her library for a basic land card and puts it into play tapped. Then that player shuffles his or her library.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "def4a4db-d80d-58e9-a43e-246b49c70f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc76a7f-516f-4d0b-b024-39d5c8096a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc76a7f-516f-4d0b-b024-39d5c8096a9f.jpg?1",
             "name": "Game-Trail Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nTrample",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "e59113fd-c6fe-5f09-a728-7095609812b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913f9b3-abbd-424b-8dea-061e15364fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913f9b3-abbd-424b-8dea-061e15364fb0.jpg?1",
             "name": "Gilt-Leaf Archdruid",
             "text": "Whenever you play a Druid spell, you may draw a card.\nTap seven untapped Druids you control: Gain control of all lands target player controls.",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "a351eb29-0728-5938-8159-5f7a5a03aaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f64e8a-2775-4f64-8728-36e7d613f54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f64e8a-2775-4f64-8728-36e7d613f54c.jpg?1",
             "name": "Greatbow Doyen",
             "text": "Other Archer creatures you control get +1/+1.\nWhenever an Archer you control deals damage to a creature, that Archer deals that much damage to that creature's controller.",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "29dddc60-20f2-57f0-ae13-a32b3854ac30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726acbd-724e-46c5-a4cf-4aee7c2abb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726acbd-724e-46c5-a4cf-4aee7c2abb16.jpg?1",
             "name": "Heritage Druid",
             "text": "Tap three untapped Elves you control: Add {G}{G}{G} to your mana pool.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "22807b67-5993-5a75-9389-be824b01f32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093f039a-47af-4284-a7ab-67971c2bc5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093f039a-47af-4284-a7ab-67971c2bc5b2.jpg?1",
             "name": "Hunting Triad",
             "text": "Put three 1/1 green Elf Warrior creature tokens into play.\nReinforce 3\u2014{3}{G} ({3}{G}, Discard this card: Put three +1/+1 counters on target creature.)",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "6bc5a893-ea54-5463-a9e7-7763828cbe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c666dc97-8780-4982-b9e7-7d4a358f922c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c666dc97-8780-4982-b9e7-7d4a358f922c.jpg?1",
             "name": "Leaf-Crowned Elder",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Leaf-Crowned Elder, you may reveal it. If you do, you may play that card without paying its mana cost.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "e26616e2-2add-5e35-8186-83cd6ad269df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9903cc-350c-44cf-9c0b-5df7922ed766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9903cc-350c-44cf-9c0b-5df7922ed766.jpg?1",
             "name": "Luminescent Rain",
             "text": "Choose a creature type. You gain 2 life for each permanent you control of that type.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "a3ab23a8-5077-548a-9b15-6ca99aaabf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac845bd-becd-4c58-9561-7cdf2adca058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac845bd-becd-4c58-9561-7cdf2adca058.jpg?1",
             "name": "Lys Alana Bowmaster",
             "text": "Reach (This can block creatures with flying.)\nWhenever you play an Elf spell, you may have Lys Alana Bowmaster deal 2 damage to target creature with flying.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "11793fd4-afb1-54e7-881d-f169d25d389b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e2c5c-26ad-4b13-934b-e545038b6729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e2c5c-26ad-4b13-934b-e545038b6729.jpg?1",
             "name": "Orchard Warden",
             "text": "Whenever another Treefolk creature comes into play under your control, you may gain life equal to that creature's toughness.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "bf47a0f6-3b32-5d02-a23d-6f67808aa3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2215c-fdc0-4135-83ef-ddf4151318ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2215c-fdc0-4135-83ef-ddf4151318ba.jpg?1",
             "name": "Reach of Branches",
             "text": "Put a 2/5 green Treefolk Shaman creature token into play.\nWhenever a Forest comes into play under your control, you may return Reach of Branches from your graveyard to your hand.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "cbae8e41-9054-57f2-b727-cf884f7b78f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfe1d8e-ae3c-4144-a44b-e13ab33da95c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfe1d8e-ae3c-4144-a44b-e13ab33da95c.jpg?1",
             "name": "Recross the Paths",
             "text": "Reveal cards from the top of your library until you reveal a land card. Put that card into play and the rest on the bottom of your library in any order. Clash with an opponent. If you win, return Recross the Paths to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "345d9eb0-3991-5ff9-91ca-cec3bbbd9acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a0ef5-a63e-4013-b3d9-b42f2c42c7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a0ef5-a63e-4013-b3d9-b42f2c42c7a4.jpg?1",
             "name": "Reins of the Vinesteed",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nWhen enchanted creature is put into a graveyard, you may return Reins of the Vinesteed from your graveyard to play attached to a creature that shares a creature type with that creature.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "49522c29-5ee5-54df-9a2b-037cc9004ea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26da029-9c95-4e9b-9a1b-62048c16acaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26da029-9c95-4e9b-9a1b-62048c16acaf.jpg?1",
             "name": "Rhys the Exiled",
             "text": "Whenever Rhys the Exiled attacks, you gain 1 life for each Elf you control.\n{B}, Sacrifice an Elf: Regenerate Rhys the Exiled.",
             "colours": [
@@ -4626,7 +4626,7 @@
         },
         {
             "id": "0de4b8c9-17e0-5057-b118-722a8a82364f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84829605-50eb-455d-a236-ebfa11e883c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84829605-50eb-455d-a236-ebfa11e883c5.jpg?1",
             "name": "Scapeshift",
             "text": "Sacrifice any number of lands. Search your library for that many land cards, put them into play tapped, then shuffle your library.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "f4447a07-087f-58d9-9346-7340910d98bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9de6380-6203-41ae-b134-8633eb5df076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9de6380-6203-41ae-b134-8633eb5df076.jpg?1",
             "name": "Unstoppable Ash",
             "text": "Trample\nChampion a Treefolk or Warrior (When this comes into play, sacrifice it unless you remove another Treefolk or Warrior you control from the game. When this leaves play, that card returns to play.)\nWhenever a creature you control becomes blocked, it gets +0/+5 until end of turn.",
             "colours": [
@@ -4693,7 +4693,7 @@
         },
         {
             "id": "da5abe84-6b81-5a7d-8509-f4c5ccf30182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2675b8b-a321-4982-b1d9-5c55d27b9bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2675b8b-a321-4982-b1d9-5c55d27b9bfd.jpg?1",
             "name": "Walker of the Grove",
             "text": "When Walker of the Grove leaves play, put a 4/4 green Elemental creature token into play.\nEvoke {4}{G} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "29b64465-ccff-5507-9a39-4b7b0eac93ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bed84-5a4a-4f16-af6c-789c542ce3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bed84-5a4a-4f16-af6c-789c542ce3a7.jpg?1",
             "name": "Winnower Patrol",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Winnower Patrol, you may reveal it. If you do, put a +1/+1 counter on Winnower Patrol.",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "2a1cd41d-f839-589c-8e2f-54f9024b883d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804ef999-0d44-420e-ad0c-a6dcf8e9c392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804ef999-0d44-420e-ad0c-a6dcf8e9c392.jpg?1",
             "name": "Wolf-Skull Shaman",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Wolf-Skull Shaman, you may reveal it. If you do, put a 2/2 green Wolf creature token into play.",
             "colours": [
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "f860f14f-9b41-5767-ba1b-426b1e32596c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bb3e3c-1a7d-4bc4-b69d-6a8e9f1b3fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bb3e3c-1a7d-4bc4-b69d-6a8e9f1b3fe7.jpg?1",
             "name": "Cloak and Dagger",
             "text": "Equipped creature gets +2/+0 and has shroud. (It can't be the target of spells or abilities.)\nWhenever a Rogue creature comes into play, you may attach Cloak and Dagger to it.\nEquip {3}",
             "colours": [],
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "7e2e20e2-2077-5cfb-84b4-e512a6181031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277eed87-6b78-456d-91fb-774c72b3ae8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277eed87-6b78-456d-91fb-774c72b3ae8c.jpg?1",
             "name": "Diviner's Wand",
             "text": "Equipped creature has \"Whenever you draw a card, this creature gets +1/+1 and gains flying until end of turn\" and \"{4}: Draw a card.\"\nWhenever a Wizard creature comes into play, you may attach Diviner's Wand to it.\nEquip {3}",
             "colours": [],
@@ -4861,7 +4861,7 @@
         },
         {
             "id": "0b050d4c-d831-50da-8fbd-10f3f2ec751c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4800be-5f77-42f5-914c-2a8e647e3af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4800be-5f77-42f5-914c-2a8e647e3af5.jpg?1",
             "name": "Door of Destinies",
             "text": "As Door of Destinies comes into play, choose a creature type.\nWhenever you play a spell of that type, put a charge counter on Door of Destinies.\nCreatures you control of that type get +1/+1 for each charge counter on Door of Destinies.",
             "colours": [],
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "110efd2b-f97a-5d7c-bdc9-5cb4a087de81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7978371-9ea8-4264-9a2f-38226ea25018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7978371-9ea8-4264-9a2f-38226ea25018.jpg?1",
             "name": "Obsidian Battle-Axe",
             "text": "Equipped creature gets +2/+1 and has haste.\nWhenever a Warrior creature comes into play, you may attach Obsidian Battle-Axe to it.\nEquip {3}",
             "colours": [],
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "8b83fe22-0ab9-5fc4-9336-5a65fef6cbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab3225-64a9-411e-b22b-1869e958b8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab3225-64a9-411e-b22b-1869e958b8e5.jpg?1",
             "name": "Thornbite Staff",
             "text": "Equipped creature has \"{2}, {T}: This creature deals 1 damage to target creature or player\" and \"Whenever a creature is put into a graveyard from play, untap this creature.\"\nWhenever a Shaman creature comes into play, you may attach Thornbite Staff to it.\nEquip {4}",
             "colours": [],
@@ -4953,7 +4953,7 @@
         },
         {
             "id": "c47bbca3-d316-560f-b530-5bd29c79e993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d0beb9-3381-423f-b54e-5490b892630a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d0beb9-3381-423f-b54e-5490b892630a.jpg?1",
             "name": "Veteran's Armaments",
             "text": "Equipped creature has \"Whenever this creature attacks or blocks, it gets +1/+1 until end of turn for each attacking creature.\"\nWhenever a Soldier creature comes into play, you may attach Veteran's Armaments to it.\nEquip {2}",
             "colours": [],
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "49f7e6a3-f229-5559-8b47-2a545b2c4ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4f8cc7-3d02-4cf2-920f-2cc32b58f397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4f8cc7-3d02-4cf2-920f-2cc32b58f397.jpg?1",
             "name": "Murmuring Bosk",
             "text": "({T}: Add {G} to your mana pool.)\nAs Murmuring Bosk comes into play, you may reveal a Treefolk card from your hand. If you don't, Murmuring Bosk comes into play tapped.\n{T}: Add {W} or {B} to your mana pool. Murmuring Bosk deals 1 damage to you.",
             "colours": [],
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "19712d57-2060-5100-b454-677e19d4b832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3c48b-f104-4292-9a4e-2ce87a65893c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3c48b-f104-4292-9a4e-2ce87a65893c.jpg?1",
             "name": "Mutavault",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "10dedaf2-27a4-5278-b1d3-03ca1301cec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c28c1d-0ebf-4e95-8d0a-56be10cc0ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c28c1d-0ebf-4e95-8d0a-56be10cc0ef2.jpg?1",
             "name": "Primal Beyond",
             "text": "As Primal Beyond comes into play, you may reveal an Elemental card from your hand. If you don't, Primal Beyond comes into play tapped.\n{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to play Elemental spells or activated abilities of Elementals.",
             "colours": [],
@@ -5075,7 +5075,7 @@
         },
         {
             "id": "6ad0fbd5-67ae-543e-bc47-4353a38bbbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bc170c-4a84-4c07-b481-b50b82f62f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bc170c-4a84-4c07-b481-b50b82f62f44.jpg?1",
             "name": "Rustic Clachan",
             "text": "As Rustic Clachan comes into play, you may reveal a Kithkin card from your hand. If you don't, Rustic Clachan comes into play tapped.\n{T}: Add {W} to your mana pool.\nReinforce 1\u2014{1}{W} ({1}{W}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [],
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "2693e39f-f3c5-571a-91f0-1c619794439d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0661166a-7d6c-4cba-8190-8d3eedf7f58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0661166a-7d6c-4cba-8190-8d3eedf7f58c.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "71f2319e-6832-577e-801e-2e21d28505b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1666cae8-8750-4091-8e45-259e76268db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1666cae8-8750-4091-8e45-259e76268db9.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -5175,7 +5175,7 @@
         },
         {
             "id": "c708411b-0c07-54f8-a11f-3e686a91fe34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c82ec9-692e-48eb-9337-c350fe815a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c82ec9-692e-48eb-9337-c350fe815a3e.jpg?1",
             "name": "Treefolk Shaman",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/MRD.json
+++ b/Assets/Resources/Sets/MRD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ca851196-6344-5b10-82a0-ef1cba6a921a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd037f62-7cef-4737-b575-942c5959f1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd037f62-7cef-4737-b575-942c5959f1ea.jpg?1",
             "name": "Altar's Light",
             "text": "Remove target artifact or enchantment from the game.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "ce8578ff-7446-5af1-81fd-162b8e02e01d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ca260d-4ed8-4a99-b00a-0be15ba0df9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ca260d-4ed8-4a99-b00a-0be15ba0df9f.jpg?1",
             "name": "Arrest",
             "text": "Enchanted creature can't attack or block, and its activated abilities can't be played.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "abd0d2bb-01f6-5a8a-b491-7f52250b85c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51605471-1198-4296-a9b5-3bee14ac2091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51605471-1198-4296-a9b5-3bee14ac2091.jpg?1",
             "name": "Auriok Bladewarden",
             "text": "{T}: Target creature gets +X/+X until end of turn, where X is Auriok Bladewarden's power.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "f2b80e4f-4f3f-5fe8-bf7d-7c014a301b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd09c01-5a77-4992-96ae-c395a5966a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd09c01-5a77-4992-96ae-c395a5966a92.jpg?1",
             "name": "Auriok Steelshaper",
             "text": "Equip costs you pay cost {1} less.\nAs long as Auriok Steelshaper is equipped, Soldiers and Knights you control get +1/+1.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "083d2026-6a66-5b86-9738-1557873b5c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5c3f22-f228-4503-9d35-ee1b36a46ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5c3f22-f228-4503-9d35-ee1b36a46ef0.jpg?1",
             "name": "Auriok Transfixer",
             "text": "{W}, {T}: Tap target artifact.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "a3bb66d9-2327-59cd-adfa-4b14e8da1255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cd231b-7891-42b5-b5de-5112d1230c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cd231b-7891-42b5-b5de-5112d1230c37.jpg?1",
             "name": "Awe Strike",
             "text": "The next time target creature would deal damage this turn, prevent that damage. You gain life equal to the damage prevented this way.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "a5b02fbc-0908-5d82-a4db-c97e3b13c0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73f6e4c-9da7-45ec-b786-1b2f59d6b73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73f6e4c-9da7-45ec-b786-1b2f59d6b73b.jpg?1",
             "name": "Blinding Beam",
             "text": "Choose one Tap two target creatures; or creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "cbdd916f-11ef-5ce1-ac75-c149934a3525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5474bcc-4ffd-4b6d-98d0-891b766d5961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5474bcc-4ffd-4b6d-98d0-891b766d5961.jpg?1",
             "name": "Leonin Abunas",
             "text": "Artifacts you control can't be the targets of spells or abilities your opponents control.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "6d5e91b0-da0a-5ef1-b269-6057dc339486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f30b7a-75bb-44e6-b1a2-726df1b5b1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f30b7a-75bb-44e6-b1a2-726df1b5b1f3.jpg?1",
             "name": "Leonin Den-Guard",
             "text": "As long as Leonin Den-Guard is equipped, it gets +1/+1 and attacking doesn't cause it to tap.",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "d53968f1-4971-5d35-88d7-1477e9cd90ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b766e7-fe4a-47fb-949b-e046b5a38d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b766e7-fe4a-47fb-949b-e046b5a38d91.jpg?1",
             "name": "Leonin Elder",
             "text": "Whenever an artifact comes into play, you may gain 1 life.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "4e3dec9d-c032-5a83-a0fd-85789a0f45bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275a47e1-816c-44f9-bd05-b8b56410436f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275a47e1-816c-44f9-bd05-b8b56410436f.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "5c4e569e-75ab-5c2c-b42d-6b24bf2f595e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg?1",
             "name": "Loxodon Mender",
             "text": "{W}, {T}: Regenerate target artifact.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "1a87ceaa-f28a-5bf6-9d7f-baa64a8c5c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9e7029-bea3-4a33-bd05-774e802616d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9e7029-bea3-4a33-bd05-774e802616d4.jpg?1",
             "name": "Loxodon Peacekeeper",
             "text": "At the beginning of your upkeep, the player with the lowest life total gains control of Loxodon Peacekeeper. If two or more players are tied for lowest life total, you choose one of them, and that player gains control of Loxodon Peacekeeper.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "67628edb-2fef-5b6b-8e8f-619991a5b671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg?1",
             "name": "Loxodon Punisher",
             "text": "Loxodon Punisher gets +2/+2 for each Equipment attached to it.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "b3744e7e-3f9f-5f55-b3d7-62f81efebb74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4f880d-6262-429f-91b7-def417aa13bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4f880d-6262-429f-91b7-def417aa13bd.jpg?1",
             "name": "Luminous Angel",
             "text": "Flying\nAt the beginning of your upkeep, you may put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "f3766d63-daf4-5841-9438-c124142c2784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be510c8-fc01-4374-ac04-7968d24480fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be510c8-fc01-4374-ac04-7968d24480fe.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "c99da938-e268-52fb-a300-7fc76ca14ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6743fab2-75b4-4eb8-b416-b5f052473393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6743fab2-75b4-4eb8-b416-b5f052473393.jpg?1",
             "name": "Razor Barrier",
             "text": "Target permanent you control gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "f50077fa-e8bf-5543-b742-748bf3fd04bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc697a4c-f219-46fd-90f2-63c638cd5ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc697a4c-f219-46fd-90f2-63c638cd5ef7.jpg?1",
             "name": "Roar of the Kha",
             "text": "Choose one Creatures you control get +1/+1 until end of turn; or untap all creatures you control.\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "d6968813-2b39-5e6c-9e2b-9065c7e16e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg?1",
             "name": "Rule of Law",
             "text": "Each player can't play more than one spell each turn.",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "11c2e5a1-cfe9-549f-a32a-b2d60491ce72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg?1",
             "name": "Second Sunrise",
             "text": "Each player returns to play all artifact, creature, enchantment, and land cards that were put into his or her graveyard from play this turn.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "cb5b7c69-f62a-50ed-886e-da8c01dbd940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd46bfba-0685-4dcb-9b63-f90da8fb0ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd46bfba-0685-4dcb-9b63-f90da8fb0ce7.jpg?1",
             "name": "Skyhunter Cub",
             "text": "As long as Skyhunter Cub is equipped, it gets +1/+1 and has flying.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "f0a15fa2-b077-5f78-940d-2e1e54af3daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c162594c-31f4-4d07-87ee-2d6ee7704980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c162594c-31f4-4d07-87ee-2d6ee7704980.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "Flying, first strike",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "a5e31eb7-42b9-5e38-804b-c1237262d750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0286b42a-295b-467c-a1d8-0b31774b7ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0286b42a-295b-467c-a1d8-0b31774b7ac5.jpg?1",
             "name": "Slith Ascendant",
             "text": "Flying\nWhenever Slith Ascendant deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "97e6c970-4b67-568f-a62c-01914b286cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg?1",
             "name": "Solar Tide",
             "text": "Choose one Destroy all creatures with power 2 or less; or destroy all creatures with power 3 or greater.\nEntwine\u2014\nSacrifice two lands. (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "17547075-f07e-5cff-a8f4-2adcedf8fe5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862682d-cbf3-4c35-83d0-76883b0ac105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862682d-cbf3-4c35-83d0-76883b0ac105.jpg?1",
             "name": "Soul Nova",
             "text": "Remove target attacking creature and all Equipment attached to it from the game.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "42533543-d748-59f4-93e4-f33481770c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392944d5-bff1-4125-86db-68d05682a430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392944d5-bff1-4125-86db-68d05682a430.jpg?1",
             "name": "Sphere of Purity",
             "text": "If an artifact would deal damage to you, prevent 1 of that damage.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "32727caf-24e4-584b-9bef-e80a68149369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c24cb4-4d7d-41df-b5c2-bd967a6a5d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c24cb4-4d7d-41df-b5c2-bd967a6a5d7e.jpg?1",
             "name": "Taj-Nar Swordsmith",
             "text": "When Taj-Nar Swordsmith comes into play, you may pay {X}. If you do, search your library for an Equipment card with converted mana cost X or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "83204ed4-53da-5880-bbab-a2b16f54a102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd05d7-eb2d-489d-ad1c-5527d3336a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd05d7-eb2d-489d-ad1c-5527d3336a6d.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "8592440a-ee14-5312-9353-7d7419e7c036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba18ec8-e82f-41be-9ed8-b1a4ae9b7426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba18ec8-e82f-41be-9ed8-b1a4ae9b7426.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "8bac1c12-e490-53da-950f-56f18575ef67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc339ed7-e1d4-4fe9-a4c4-b030d3e74c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc339ed7-e1d4-4fe9-a4c4-b030d3e74c00.jpg?1",
             "name": "Assert Authority",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nCounter target spell. If it's countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "5cb0855e-38d4-5dbf-af8d-19da6294311e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a194cb-53c9-4690-ba63-79beecaebe0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a194cb-53c9-4690-ba63-79beecaebe0e.jpg?1",
             "name": "Broodstar",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying\nBroodstar's power and toughness are each equal to the number of artifacts you control.",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "e0f49a68-4681-519d-bdaa-c4f1a9ee510c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c6350-af52-45f1-8024-5f31aa62a0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c6350-af52-45f1-8024-5f31aa62a0d0.jpg?1",
             "name": "Disarm",
             "text": "Unattach all Equipment from target creature.",
             "colours": [
@@ -1075,7 +1075,7 @@
         },
         {
             "id": "d3a3bb98-5f4c-51ea-87e3-f9f56b09448a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0010b89-afc4-4dee-bda3-2f34e552cba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0010b89-afc4-4dee-bda3-2f34e552cba5.jpg?1",
             "name": "Domineer",
             "text": "You control enchanted artifact creature.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "23a68ba3-d4f2-5987-9c9e-befc463249a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaa6a2-7c86-45b4-8892-b837e05f11a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaa6a2-7c86-45b4-8892-b837e05f11a6.jpg?1",
             "name": "Dream's Grip",
             "text": "Choose one Tap target permanent; or untap target permanent.\nEntwine {1} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1141,7 +1141,7 @@
         },
         {
             "id": "35fc5261-176b-5c13-acb4-fdc4601aef6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742e23c-1991-4dce-b670-dea92a1cf4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742e23c-1991-4dce-b670-dea92a1cf4ec.jpg?1",
             "name": "Fabricate",
             "text": "Search your library for an artifact card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1173,7 +1173,7 @@
         },
         {
             "id": "cb378311-e382-5d29-8a80-6703de57f55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg?1",
             "name": "Fatespinner",
             "text": "At the beginning of each opponent's upkeep, that player chooses draw step, main phase, or combat phase. The player skips each instance of the chosen step or phase this turn.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "6b932420-9870-5fb0-85a2-61918f8ae8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b2d227-68b3-40e8-bef7-45ea43e17318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b2d227-68b3-40e8-bef7-45ea43e17318.jpg?1",
             "name": "Inertia Bubble",
             "text": "Enchanted artifact doesn't untap during its controller's untap step.",
             "colours": [
@@ -1242,7 +1242,7 @@
         },
         {
             "id": "c54a6018-7d37-5e99-a255-da0cdef50f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29de2f4c-81a6-42c7-94d1-f9109c3331ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29de2f4c-81a6-42c7-94d1-f9109c3331ff.jpg?1",
             "name": "Looming Hoverguard",
             "text": "Flying\nWhen Looming Hoverguard comes into play, put target artifact on top of its owner's library.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "11c64f80-0df1-59c3-8869-7a90da4d0c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg?1",
             "name": "Lumengrid Augur",
             "text": "{1}, {T}: Target player draws a card, then discards a card from his or her hand. If that player discards an artifact card this way, untap Lumengrid Augur.",
             "colours": [
@@ -1311,7 +1311,7 @@
         },
         {
             "id": "18e95a19-f035-5f84-8f33-b742bb831d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48068b80-9a98-45d0-8224-ee298cbf708f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48068b80-9a98-45d0-8224-ee298cbf708f.jpg?1",
             "name": "Lumengrid Sentinel",
             "text": "Flying\nWhenever an artifact comes into play under your control, you may tap target permanent.",
             "colours": [
@@ -1346,7 +1346,7 @@
         },
         {
             "id": "26bde397-a503-5bab-82f2-b781a024f05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aadd54-6e83-4bcf-9760-16479d919a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aadd54-6e83-4bcf-9760-16479d919a56.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -1381,7 +1381,7 @@
         },
         {
             "id": "720bfb82-f437-5307-b18e-a920ac4f3ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdcc966-7837-463f-ae26-1096f34ac8c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdcc966-7837-463f-ae26-1096f34ac8c0.jpg?1",
             "name": "March of the Machines",
             "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "6af72e5f-d7b7-5c42-a56e-4c136b56bc69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd15b0-4ada-41c7-81e0-4f8956798685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd15b0-4ada-41c7-81e0-4f8956798685.jpg?1",
             "name": "Neurok Familiar",
             "text": "Flying\nWhen Neurok Familiar comes into play, reveal the top card of your library. If it's an artifact card, put it into your hand. Otherwise, put it into your graveyard.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "3df70f69-5f34-5ddc-a0a0-61b57c819b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b86a02-d40a-4615-8402-bd5700cb5101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b86a02-d40a-4615-8402-bd5700cb5101.jpg?1",
             "name": "Neurok Spy",
             "text": "Neurok Spy is unblockable as long as defending player controls an artifact.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "d5dfbacd-ddc0-5aa9-b331-c188f0d46a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35964fa6-800d-41d6-9f82-fb9c87deee56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35964fa6-800d-41d6-9f82-fb9c87deee56.jpg?1",
             "name": "Override",
             "text": "Counter target spell unless its controller pays {1} for each artifact you control.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "d665dad2-b054-5cf1-90d5-b0ddfaf56e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5a69-05b6-4fc4-8186-503a2e204330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5a69-05b6-4fc4-8186-503a2e204330.jpg?1",
             "name": "Psychic Membrane",
             "text": "(Walls can't attack.)\nWhenever Psychic Membrane blocks, you may draw a card.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "8a2698ef-19c3-5997-92c6-ba8506f36876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg?1",
             "name": "Quicksilver Elemental",
             "text": "{U}: Quicksilver Elemental gains all activated abilities of target creature until end of turn. (If any of the abilities use that creature's name, use this creature's name instead.)\nYou may spend blue mana as though it were mana of any color to pay the activation costs of Quicksilver Elemental's abilities.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "15131557-224d-5fd2-905f-159d26981198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869775f-72fa-463f-a46a-7c3e955f8590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869775f-72fa-463f-a46a-7c3e955f8590.jpg?1",
             "name": "Regress",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "881f48d0-870a-5c40-af38-aac6b3e5faa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d5b02-ef38-4dab-8ac6-78814ef27b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d5b02-ef38-4dab-8ac6-78814ef27b55.jpg?1",
             "name": "Shared Fate",
             "text": "If a player would draw a card, that player removes the top card of an opponent's library from the game face down instead.\nEach player may look at and play cards he or she removed from the game with Shared Fate as though they were in his or her hand.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "5a2712fb-264c-588f-aae3-93fea68252de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85866351-a721-4b3c-9b6f-4d291daab657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85866351-a721-4b3c-9b6f-4d291daab657.jpg?1",
             "name": "Slith Strider",
             "text": "Whenever Slith Strider becomes blocked, draw a card.\nWhenever Slith Strider deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "cce0a90a-9cea-5ba1-8529-dead44ee59dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a46ac2-d96d-4d5a-94fc-a9fc83a9ea1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a46ac2-d96d-4d5a-94fc-a9fc83a9ea1d.jpg?1",
             "name": "Somber Hoverguard",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "7c225686-3cb3-5798-b0d5-b282d123ea30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg?1",
             "name": "Temporal Cascade",
             "text": "Choose one Each player shuffles his or her hand and graveyard into his or her library; or each player draws seven cards.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "e4e0fb33-fd90-5b1d-9072-e06d98e2a9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff1f608-203e-4413-8753-37fc49731c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff1f608-203e-4413-8753-37fc49731c87.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards from your hand unless you discard an artifact card from your hand.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "0a2506d5-0ef8-5eb8-be55-6c98e8ad0364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb965a7-877a-4302-b507-25b0a9e32d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb965a7-877a-4302-b507-25b0a9e32d9b.jpg?1",
             "name": "Thoughtcast",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nDraw two cards.",
             "colours": [
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "0f911e87-c597-5d22-8f74-612d3fac1824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38da97-5141-4de6-bd7f-3fcbf46cfd96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38da97-5141-4de6-bd7f-3fcbf46cfd96.jpg?1",
             "name": "Vedalken Archmage",
             "text": "Whenever you play an artifact spell, draw a card.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "779ffcd6-d98b-5637-b015-02ffa9104831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac6290-1401-41c5-90a1-99acb344719e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac6290-1401-41c5-90a1-99acb344719e.jpg?1",
             "name": "Wanderguard Sentry",
             "text": "When Wanderguard Sentry comes into play, look at target opponent's hand.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "bf4577fc-a174-5f47-af4c-e9d895a04d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg?1",
             "name": "Barter in Blood",
             "text": "Each player sacrifices two creatures.",
             "colours": [
@@ -1911,7 +1911,7 @@
         },
         {
             "id": "dca63274-7322-5350-8dd9-f464373f02b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2e107-0277-4e5c-81a7-258bb2998f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2e107-0277-4e5c-81a7-258bb2998f3e.jpg?1",
             "name": "Betrayal of Flesh",
             "text": "Choose one Destroy target creature; or return target creature card from your graveyard to play.\nEntwine\u2014\nSacrifice three lands. (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "ff68ec8d-13b7-5387-882b-ff3f8822e21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a426922-5e96-48f3-b696-f5dc99258943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a426922-5e96-48f3-b696-f5dc99258943.jpg?1",
             "name": "Chimney Imp",
             "text": "Flying\nWhen Chimney Imp is put into a graveyard from play, target opponent puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "7102f022-452a-5e4e-865d-60ab7432c873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f375a49c-806a-4d8b-9513-6b4afc19497b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f375a49c-806a-4d8b-9513-6b4afc19497b.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player. You gain X life.",
             "colours": [
@@ -2009,7 +2009,7 @@
         },
         {
             "id": "13a5c287-f991-50b1-9a3f-fd3e086998af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a64356-3064-47a2-80be-5e2f56c85556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a64356-3064-47a2-80be-5e2f56c85556.jpg?1",
             "name": "Contaminated Bond",
             "text": "Whenever enchanted creature attacks or blocks, its controller loses 3 life.",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "92f2e2b2-894f-5e64-841b-c982455b2448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644359dc-3c4c-4291-876d-7390dc466877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644359dc-3c4c-4291-876d-7390dc466877.jpg?1",
             "name": "Disciple of the Vault",
             "text": "Whenever an artifact is put into a graveyard from play, you may have target opponent lose 1 life.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "ee45440a-2ba9-5e50-9553-73b7e59bc9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b088832c-6119-4460-98b7-ae25cf70b2c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b088832c-6119-4460-98b7-ae25cf70b2c5.jpg?1",
             "name": "Dross Harvester",
             "text": "Protection from white\nAt the end of your turn, you lose 4 life.\nWhenever a creature is put into a graveyard from play, you gain 2 life.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "967d38f8-e73f-56fc-bd1d-48d5b2dd4180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fff470a-3574-42be-8f0b-ac5e7a70f61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fff470a-3574-42be-8f0b-ac5e7a70f61a.jpg?1",
             "name": "Dross Prowler",
             "text": "Fear",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "5c539309-690a-5181-8d9e-0327cd7abc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2381b3-ebf8-4c65-8e89-e089c2e57145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2381b3-ebf8-4c65-8e89-e089c2e57145.jpg?1",
             "name": "Flayed Nim",
             "text": "Whenever Flayed Nim deals combat damage to a creature, that creature's controller loses that much life.\n{2}{B}: Regenerate Flayed Nim.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "736e764a-074c-540e-8630-f1f3ea2288e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35baa726-8c2f-4a0b-93d1-d7ecfae69fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35baa726-8c2f-4a0b-93d1-d7ecfae69fe4.jpg?1",
             "name": "Grim Reminder",
             "text": "Search your library for a nonland card and reveal it. Each opponent who played a card this turn with the same name as that card loses 6 life. Then shuffle the revealed card back into your library.\n{B}{B}: Return Grim Reminder from your graveyard to your hand. Play this ability only during your upkeep.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "eecc43a9-88e2-587e-a37f-ec8b7268eab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0460cf-ff87-4cf8-89b5-a8b9fb7322e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0460cf-ff87-4cf8-89b5-a8b9fb7322e0.jpg?1",
             "name": "Irradiate",
             "text": "Target creature gets -1/-1 until end of turn for each artifact you control.",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "cfe562f2-09b7-5ff9-b209-3099c338371e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27426b-3679-44e4-9249-f57b92baa3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27426b-3679-44e4-9249-f57b92baa3f3.jpg?1",
             "name": "Moriok Scavenger",
             "text": "When Moriok Scavenger comes into play, you may return target artifact creature card from your graveyard to your hand.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "11c9e1ee-6f83-537d-8d36-5d01980b2b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18291514-9ffb-4032-9c77-cec0200bf1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18291514-9ffb-4032-9c77-cec0200bf1b6.jpg?1",
             "name": "Necrogen Mists",
             "text": "At the beginning of each player's upkeep, that player discards a card from his or her hand.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "93e14b44-10fb-5d30-94f7-1294f65bf04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg?1",
             "name": "Nim Devourer",
             "text": "Nim Devourer gets +1/+0 for each artifact you control.\n{B}{B}: Return Nim Devourer from your graveyard to play, then sacrifice a creature. Play this ability only during your upkeep.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "f8cd3e57-5c63-5571-846b-c5e5eec97381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b66c698-02bd-48ef-a866-5251bdc02c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b66c698-02bd-48ef-a866-5251bdc02c16.jpg?1",
             "name": "Nim Lasher",
             "text": "Nim Lasher gets +1/+0 for each artifact you control.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "fb89a5f5-ef81-547c-842a-53477a54469f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c09a0-a374-46c1-978f-ec7478dc7ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c09a0-a374-46c1-978f-ec7478dc7ab7.jpg?1",
             "name": "Nim Shambler",
             "text": "Nim Shambler gets +1/+0 for each artifact you control.\nSacrifice a creature: Regenerate Nim Shambler.",
             "colours": [
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "3ea6d665-0a7b-516f-9e32-0fc76a86e75b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a2c39b-b302-4cc3-b507-e4fe00614036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a2c39b-b302-4cc3-b507-e4fe00614036.jpg?1",
             "name": "Nim Shrieker",
             "text": "Flying\nNim Shrieker gets +1/+0 for each artifact you control.",
             "colours": [
@@ -2447,7 +2447,7 @@
         },
         {
             "id": "7ccfaf6d-50b1-51b7-886c-af38569f8829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96c3947-0eec-48a1-ba69-59734b4ac9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96c3947-0eec-48a1-ba69-59734b4ac9da.jpg?1",
             "name": "Promise of Power",
             "text": "Choose one You draw five cards and you lose 5 life; or put a black Demon creature token with flying into play with power and toughness each equal to the number of cards in your hand as the token comes into play.\nEntwine {4} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2479,7 +2479,7 @@
         },
         {
             "id": "5c59a293-4022-5b9e-90c7-04de82cae2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d109abda-982f-4907-8b64-ec63e138bc42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d109abda-982f-4907-8b64-ec63e138bc42.jpg?1",
             "name": "Reiver Demon",
             "text": "Flying\nWhen Reiver Demon comes into play, if you played it from your hand, destroy all nonartifact, nonblack creatures. They can't be regenerated.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "5e6b214f-ab14-548e-a220-da0309681130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbafa51-693b-485c-807d-64020540f16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbafa51-693b-485c-807d-64020540f16a.jpg?1",
             "name": "Relic Bane",
             "text": "Enchanted artifact has \"At the beginning of your upkeep, you lose 2 life.\"",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "81ec8466-d1d7-5a95-a519-6c5e567a062e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a04ccb-cb57-4548-81db-e1b77b09f5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a04ccb-cb57-4548-81db-e1b77b09f5da.jpg?1",
             "name": "Slith Bloodletter",
             "text": "Whenever Slith Bloodletter deals combat damage to a player, put a +1/+1 counter on it.\n{1}{B}: Regenerate Slith Bloodletter.",
             "colours": [
@@ -2581,7 +2581,7 @@
         },
         {
             "id": "f17b171c-4c8c-5a95-9639-7c904d08adab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d100d-d20b-4018-8518-609113ec36d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d100d-d20b-4018-8518-609113ec36d7.jpg?1",
             "name": "Spoils of the Vault",
             "text": "Name a card. Reveal cards from the top of your library until you reveal the named card, then put that card into your hand. Remove all other cards revealed this way from the game, and you lose 1 life for each of the removed cards.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "bee16d9c-a26f-5358-9829-21b03dd49eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41651db-619a-4ab4-86cf-a0d32297dbdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41651db-619a-4ab4-86cf-a0d32297dbdf.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "7dc00114-d2c5-5373-9ad0-c5c34ffea4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b68e084-0760-4817-a656-32dc4b094370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b68e084-0760-4817-a656-32dc4b094370.jpg?1",
             "name": "Vermiculos",
             "text": "Whenever an artifact comes into play, Vermiculos gets +4/+4 until end of turn.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "4fd5b63b-fbfb-5592-96db-944835562bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c32faa-c6d1-418a-aed6-ccc5849daa1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c32faa-c6d1-418a-aed6-ccc5849daa1f.jpg?1",
             "name": "Wail of the Nim",
             "text": "Choose one Regenerate each creature you control; or Wail of the Nim deals 1 damage to each creature and each player.\nEntwine {B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "1cdc7f00-062f-5b5b-a77e-1c5067aac2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17320043-f81c-4e14-b9ba-c1309972c22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17320043-f81c-4e14-b9ba-c1309972c22b.jpg?1",
             "name": "Wall of Blood",
             "text": "(Walls can't attack.)\nPay 1 life: Wall of Blood gets +1/+1 until end of turn.",
             "colours": [
@@ -2745,7 +2745,7 @@
         },
         {
             "id": "fea2a4a3-7aff-53b2-96c2-e362b41d61ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg?1",
             "name": "Woebearer",
             "text": "Fear\nWhenever Woebearer deals combat damage to a player, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2779,7 +2779,7 @@
         },
         {
             "id": "452464b5-0fe5-5164-a547-bc65ab9818e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce975b-c3df-4472-a6c1-2546df11b74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce975b-c3df-4472-a6c1-2546df11b74e.jpg?1",
             "name": "Wrench Mind",
             "text": "Target player discards two cards from his or her hand unless he or she discards an artifact card from his or her hand.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "dbf99b19-1209-57bd-9b16-3c9805b447a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg?1",
             "name": "Arc-Slogger",
             "text": "{R}, Remove the top ten cards of your library from the game: Arc-Slogger deals 2 damage to target creature or player.",
             "colours": [
@@ -2845,7 +2845,7 @@
         },
         {
             "id": "3dfe1802-c210-53ee-a342-a96f6daf9a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15397bc-c400-4f8d-b206-08a4d65e76ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15397bc-c400-4f8d-b206-08a4d65e76ff.jpg?1",
             "name": "Atog",
             "text": "Sacrifice an artifact: Atog gets +2/+2 until end of turn.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "c31098a0-2d77-50cd-89f1-2e242b48f2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d46aca2-4714-4d2c-9466-5f1c043b8726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d46aca2-4714-4d2c-9466-5f1c043b8726.jpg?1",
             "name": "Confusion in the Ranks",
             "text": "Whenever an artifact, creature, or enchantment comes into play, its controller chooses target permanent another player controls that shares a type with it. Exchange control of those permanents.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "e944b4e6-835f-5d23-b988-42b94b089047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237eedf5-8a8f-4668-a911-e2bf66f8221e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237eedf5-8a8f-4668-a911-e2bf66f8221e.jpg?1",
             "name": "Detonate",
             "text": "Destroy target artifact with converted mana cost X. It can't be regenerated. Detonate deals X damage to that artifact's controller.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "70ddb182-17b1-53ba-84ac-5a8229d22967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455c8d4-6f20-4dcb-8e82-c2bb70d6bc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455c8d4-6f20-4dcb-8e82-c2bb70d6bc3e.jpg?1",
             "name": "Electrostatic Bolt",
             "text": "Electrostatic Bolt deals 2 damage to target creature. If it's an artifact creature, Electrostatic Bolt deals 4 damage to it instead.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "e251a438-1100-519f-857a-d41fde44bdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91376ed-5868-4887-8389-5ef5b9471786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91376ed-5868-4887-8389-5ef5b9471786.jpg?1",
             "name": "Fiery Gambit",
             "text": "Flip a coin until you lose a flip or choose to stop flipping. If you lose a flip, Fiery Gambit has no effect. If you win one or more flips, Fiery Gambit deals 3 damage to target creature. If you win two or more flips, Fiery Gambit deals 6 damage to each opponent. If you win three or more flips, draw nine cards and untap all lands you control.",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "49bf94a1-f7aa-5893-9c9a-cbfc28569549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb94bc02-b348-43c2-9e78-e2e3fd541d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb94bc02-b348-43c2-9e78-e2e3fd541d6a.jpg?1",
             "name": "Fists of the Anvil",
             "text": "Target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "716dd69a-dffa-50f5-a8ab-17cc9cc45154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2873b6d5-af76-498c-bc2d-a26c36be3cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2873b6d5-af76-498c-bc2d-a26c36be3cbd.jpg?1",
             "name": "Forge Armor",
             "text": "As an additional cost to play Forge Armor, sacrifice an artifact.\nPut X +1/+1 counters on target creature, where X is the sacrificed artifact's converted mana cost.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "db541004-d404-5ce2-8de1-3063ffe5d9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7ce5d5-e51a-4dbc-82f2-b79c88769a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7ce5d5-e51a-4dbc-82f2-b79c88769a7b.jpg?1",
             "name": "Fractured Loyalty",
             "text": "Whenever enchanted creature becomes the target of a spell or ability, that spell or ability's controller gains control of enchanted creature. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "0421be4a-ebf3-5a3c-828b-e9fdea4cc053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7654d8a-7013-4311-b29e-b55aaa1bf502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7654d8a-7013-4311-b29e-b55aaa1bf502.jpg?1",
             "name": "Goblin Striker",
             "text": "First strike, haste",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "1686a5d1-ab63-53dc-a76a-1881e04df7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570fa211-e937-4ad7-bc72-60f8adc3203d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570fa211-e937-4ad7-bc72-60f8adc3203d.jpg?1",
             "name": "Grab the Reins",
             "text": "Choose one Until end of turn, you gain control of target creature and it gains haste; or sacrifice a creature, then Grab the Reins deals damage equal to that creature's power to target creature or player.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "43f364aa-7c2c-5600-8b5e-a60243e9b6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30527c-0eb1-4b66-9028-1607a960019a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30527c-0eb1-4b66-9028-1607a960019a.jpg?1",
             "name": "Incite War",
             "text": "Choose one Creatures target player controls attack this turn if able; or creatures you control gain first strike until end of turn.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "e2fec47e-46a4-5357-93c9-a3b7e268f343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd9e422-206e-4c25-9964-ed6592c16e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd9e422-206e-4c25-9964-ed6592c16e12.jpg?1",
             "name": "Krark-Clan Grunt",
             "text": "Sacrifice an artifact: Krark-Clan Grunt gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "cd9aa095-f999-5a2c-91e5-4acd94d45416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f9ea8-af2c-456f-acd0-ffa9ea0d98c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f9ea8-af2c-456f-acd0-ffa9ea0d98c1.jpg?1",
             "name": "Krark-Clan Shaman",
             "text": "Sacrifice an artifact: Krark-Clan Shaman deals 1 damage to each creature without flying.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "8fbcf505-3189-5011-8918-b94d259762ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431354a-fcfa-4f67-a822-6dcc4d13ac3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431354a-fcfa-4f67-a822-6dcc4d13ac3f.jpg?1",
             "name": "Mass Hysteria",
             "text": "All creatures have haste.",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "20f60883-8f56-56e9-b2e2-2f60ee5fd792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9734b1-c5fb-4b2b-bada-c45c3a725e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9734b1-c5fb-4b2b-bada-c45c3a725e01.jpg?1",
             "name": "Megatog",
             "text": "Sacrifice an artifact: Megatog gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "0c97e000-1408-5558-ae4e-fbea0d4600c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888b4d4-31f9-4322-8225-4d7e7a9f4dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888b4d4-31f9-4322-8225-4d7e7a9f4dd5.jpg?1",
             "name": "Molten Rain",
             "text": "Destroy target land. If that land is nonbasic, Molten Rain deals 2 damage to the land's controller.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "254f04c7-eccf-5336-b648-5aa7420319a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c77744-3a86-46cf-9e0f-5a217a1c08b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c77744-3a86-46cf-9e0f-5a217a1c08b9.jpg?1",
             "name": "Ogre Leadfoot",
             "text": "Whenever Ogre Leadfoot becomes blocked by an artifact creature, destroy that creature.",
             "colours": [
@@ -3406,7 +3406,7 @@
         },
         {
             "id": "da003b46-f9b7-5c6f-a5ec-5b90b1303467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8bd0c9-6b3a-489e-bf4d-b2062d530b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8bd0c9-6b3a-489e-bf4d-b2062d530b55.jpg?1",
             "name": "Rustmouth Ogre",
             "text": "Whenever Rustmouth Ogre deals combat damage to a player, you may destroy target artifact that player controls.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "6ad62466-e9c5-522f-9ced-23bcd15861d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9213d580-7953-455f-abbe-99d3db2705cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9213d580-7953-455f-abbe-99d3db2705cf.jpg?1",
             "name": "Seething Song",
             "text": "Add {R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "eb0bee60-dfc8-570f-a665-551ef9395e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b3d7e6-df52-4cd1-92e7-5dfe8b0a9d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b3d7e6-df52-4cd1-92e7-5dfe8b0a9d9e.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "b77211e4-683c-5806-a9df-0faf6827e069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056affab-4e2a-4b68-b864-d879becd3c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056affab-4e2a-4b68-b864-d879becd3c45.jpg?1",
             "name": "Shrapnel Blast",
             "text": "As an additional cost to play Shrapnel Blast, sacrifice an artifact.\nShrapnel Blast deals 5 damage to target creature or player.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "6f59dba2-c864-5547-986e-beb8bbfbf3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff7383-71da-46ae-849f-349c40815a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff7383-71da-46ae-849f-349c40815a29.jpg?1",
             "name": "Slith Firewalker",
             "text": "Haste\nWhenever Slith Firewalker deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -3570,7 +3570,7 @@
         },
         {
             "id": "af3f8a3b-e17f-5e4f-9795-07ff0991c87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147c826a-b664-4afa-ae7f-284ddce80861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147c826a-b664-4afa-ae7f-284ddce80861.jpg?1",
             "name": "Spikeshot Goblin",
             "text": "{R}, {T}: Spikeshot Goblin deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3605,7 +3605,7 @@
         },
         {
             "id": "89782ed9-606d-5f35-9e76-63d1c69a81f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec59ed99-ce40-489a-b776-8874bec60393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec59ed99-ce40-489a-b776-8874bec60393.jpg?1",
             "name": "Trash for Treasure",
             "text": "As an additional cost to play Trash for Treasure, sacrifice an artifact.\nReturn target artifact card from your graveyard to play.",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "2e9b8691-372b-51dc-9b14-1c99b1da232d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg?1",
             "name": "Vulshok Battlemaster",
             "text": "Haste\nWhen Vulshok Battlemaster comes into play, attach all Equipment in play to it. (Control of the Equipment doesn't change.)",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "d9b7221d-40f0-58a6-8f20-0655330f7496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23510414-974e-4510-9742-884ecd572ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23510414-974e-4510-9742-884ecd572ad8.jpg?1",
             "name": "Vulshok Berserker",
             "text": "Haste",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "02f6328b-9c67-5815-b58a-d83a97f155f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg?1",
             "name": "War Elemental",
             "text": "When War Elemental comes into play, sacrifice it unless an opponent was dealt damage this turn.\nWhenever damage is dealt to an opponent, put that many +1/+1 counters on War Elemental.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "b903c792-99ab-5320-913c-a937a82efb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b34e76b-86b3-464e-93e7-c3f2074028fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b34e76b-86b3-464e-93e7-c3f2074028fb.jpg?1",
             "name": "Battlegrowth",
             "text": "Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "c4ac67ed-8ab3-5f6d-b5c0-ac7cb4b51e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca1eb7b-e964-4c36-8fc5-e1d2a98e841f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca1eb7b-e964-4c36-8fc5-e1d2a98e841f.jpg?1",
             "name": "Bloodscent",
             "text": "All creatures able to block target creature this turn do so.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "a9cb4f21-7f54-50ab-9009-f77623821463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8779ec-0ebd-45a1-96c9-4b1146871ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8779ec-0ebd-45a1-96c9-4b1146871ab7.jpg?1",
             "name": "Brown Ouphe",
             "text": "{1}{G}, {T}: Counter target activated ability from an artifact source. (Mana abilities can't be countered.)",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "54fc5081-f17b-5d7f-a486-bb47c1ad1830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg?1",
             "name": "Copperhoof Vorrac",
             "text": "Copperhoof Vorrac gets +1/+1 for each untapped permanent your opponents control.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "45d89b40-00c5-5efe-a744-b8bbd6c08b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b50bda-f19f-4991-977b-de794f11103d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b50bda-f19f-4991-977b-de794f11103d.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "d73caaf3-659d-5ff0-87b2-d34ef320c377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53face79-d2bf-43dd-aa4e-d724c2b68c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53face79-d2bf-43dd-aa4e-d724c2b68c49.jpg?1",
             "name": "Deconstruct",
             "text": "Destroy target artifact. Then add {G}{G}{G} to your mana pool.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "56f5b809-f07c-5e81-bc89-41eca38123ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc8eef-f032-490a-b487-da1af71b7ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc8eef-f032-490a-b487-da1af71b7ff2.jpg?1",
             "name": "Fangren Hunter",
             "text": "Trample",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "a8051892-19a3-5101-9eeb-0fa83140b75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg?1",
             "name": "Glissa Sunseeker",
             "text": "First strike\n{T}: Destroy target artifact if its converted mana cost is equal to the amount of mana in your mana pool.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "07eb3db9-2a06-5de0-afce-59f2deae70cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e84098-c15c-40f4-9d8a-3fa5da26a268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e84098-c15c-40f4-9d8a-3fa5da26a268.jpg?1",
             "name": "Groffskithur",
             "text": "Whenever Groffskithur becomes blocked, you may return target card named Groffskithur from your graveyard to your hand.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "21588cba-df2c-5bf3-b4fa-41c67a929733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg?1",
             "name": "Hum of the Radix",
             "text": "Each artifact spell costs {1} more to play for each artifact its controller controls.",
             "colours": [
@@ -4075,7 +4075,7 @@
         },
         {
             "id": "6fb939cc-6091-5399-9106-fa863d212cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f4356f-8cfb-43ed-bdf9-6191bb563388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f4356f-8cfb-43ed-bdf9-6191bb563388.jpg?1",
             "name": "Journey of Discovery",
             "text": "Choose one Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library; or you may play up to two additional lands this turn.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "61feb004-c24d-59d5-81b5-44c9cc87c198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407dad3c-d721-412a-8b29-bc15be56d2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407dad3c-d721-412a-8b29-bc15be56d2fe.jpg?1",
             "name": "Living Hive",
             "text": "Trample\nWhenever Living Hive deals combat damage to a player, put that many 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "7f6adf2e-dae6-55ba-bb4e-f0c8b36bf5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee355d1b-5d64-4328-94d6-7a58889b99bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee355d1b-5d64-4328-94d6-7a58889b99bc.jpg?1",
             "name": "Molder Slug",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "8d949caf-fe03-5016-9c45-54d4531b93b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3216148-f64e-434b-80b8-772f6eb831ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3216148-f64e-434b-80b8-772f6eb831ca.jpg?1",
             "name": "One Dozen Eyes",
             "text": "Choose one Put a 5/5 green Beast creature token into play; or put five 1/1 green Insect creature tokens into play.\nEntwine {G}{G}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "e7c1ebf0-31ee-5dde-bb7b-a093f63ac3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fc3c5e-025d-4b21-af86-9c861658d32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fc3c5e-025d-4b21-af86-9c861658d32e.jpg?1",
             "name": "Plated Slagwurm",
             "text": "Plated Slagwurm can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "55bad9f7-2c22-545e-8299-bd65f5bbe094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e5bcc2-9203-4526-a9a9-fac6fd02a854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e5bcc2-9203-4526-a9a9-fac6fd02a854.jpg?1",
             "name": "Predator's Strike",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "7f8554e6-b78f-5303-b6a4-72808ec67523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bae45c-eaa8-4c6d-8042-df5cf26e294f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bae45c-eaa8-4c6d-8042-df5cf26e294f.jpg?1",
             "name": "Slith Predator",
             "text": "Trample\nWhenever Slith Predator deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "33ea24df-f7c3-5b94-bd80-7f262be850fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff07b6-be9f-498f-9f36-cbd64f1b10cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff07b6-be9f-498f-9f36-cbd64f1b10cc.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "f9a12bf9-06eb-5863-9790-1eb6d19858e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1fde33-e86a-4146-9c90-4616a5fc0868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1fde33-e86a-4146-9c90-4616a5fc0868.jpg?1",
             "name": "Tel-Jilad Archers",
             "text": "Protection from artifacts\nTel-Jilad Archers may block as though it had flying.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "a8bf2066-2f9c-5497-ab06-7394d14d5af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefea84f-d657-491d-b60d-63e6a61e9eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefea84f-d657-491d-b60d-63e6a61e9eb2.jpg?1",
             "name": "Tel-Jilad Chosen",
             "text": "Protection from artifacts",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "03b66c98-4f51-5229-95e7-84501d20112c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3529277-8409-45fe-9f29-64354597e918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3529277-8409-45fe-9f29-64354597e918.jpg?1",
             "name": "Tel-Jilad Exile",
             "text": "{1}{G}: Regenerate Tel-Jilad Exile.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "52a30ada-50cc-5e8e-9632-a3bdf88c37d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0067c-2d38-46bd-b52e-070c2ce424f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0067c-2d38-46bd-b52e-070c2ce424f0.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle your library; or put up to two creature cards from your hand into play.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "ae6ac0d4-54c0-51dc-a009-9664c4334d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01233c2-6df0-4f0e-8668-3855868731ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01233c2-6df0-4f0e-8668-3855868731ea.jpg?1",
             "name": "Troll Ascetic",
             "text": "Troll Ascetic can't be the target of spells or abilities your opponents control.\n{1}{G}: Regenerate Troll Ascetic.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "94192555-f332-5d0f-8696-ca3a1fece3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6535f2ad-6cda-4be9-8e4f-6f062b63be31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6535f2ad-6cda-4be9-8e4f-6f062b63be31.jpg?1",
             "name": "Trolls of Tel-Jilad",
             "text": "{1}{G}: Regenerate target green creature.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "4140ad49-0d3d-5aa4-b125-83d808a2385e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfcb643-bbd1-419a-b1a8-daae1062c8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfcb643-bbd1-419a-b1a8-daae1062c8bc.jpg?1",
             "name": "Turn to Dust",
             "text": "Destroy target Equipment. Then add {G} to your mana pool.",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "76ab6fb0-0446-59a0-b146-fea48dc167ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50679df-bf82-4bb2-9fe3-8ebd7a9decde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50679df-bf82-4bb2-9fe3-8ebd7a9decde.jpg?1",
             "name": "Viridian Joiner",
             "text": "{T}: Add an amount of {G} to your mana pool equal to Viridian Joiner's power.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "ef201401-a2b2-5e84-af64-e9b293d83ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932bf583-efd3-42e9-8a7b-7b3fe07fbcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932bf583-efd3-42e9-8a7b-7b3fe07fbcf0.jpg?1",
             "name": "Viridian Shaman",
             "text": "When Viridian Shaman comes into play, destroy target artifact.",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "a7880a99-cb3a-5079-80b2-71cb56c93f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f303e-371b-47dd-bbb8-7f3e44ef9af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f303e-371b-47dd-bbb8-7f3e44ef9af0.jpg?1",
             "name": "Wurmskin Forger",
             "text": "When Wurmskin Forger comes into play, distribute three +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "44829535-d2be-519b-9484-3e1008ee49f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3792e8b-4ad7-4e2d-994c-c4eaac0fa55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3792e8b-4ad7-4e2d-994c-c4eaac0fa55f.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice \u00c6ther Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice \u00c6ther Spellbomb: Draw a card.",
             "colours": [],
@@ -4715,7 +4715,7 @@
         },
         {
             "id": "0662f0e3-23b5-5eee-a7e0-d78fc0b6ec79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f792d7-75be-429e-8f62-0b563b103642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f792d7-75be-429e-8f62-0b563b103642.jpg?1",
             "name": "Alpha Myr",
             "text": "",
             "colours": [],
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "b0c62122-52b3-5038-aff9-6b45f3e019bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc3824c-11ee-4fec-9397-823783b682d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc3824c-11ee-4fec-9397-823783b682d9.jpg?1",
             "name": "Altar of Shadows",
             "text": "At the beginning of your precombat main phase, add {B} to your mana pool for each charge counter on Altar of Shadows.\n{7}, {T}: Destroy target creature. Then put a charge counter on Altar of Shadows.",
             "colours": [],
@@ -4776,7 +4776,7 @@
         },
         {
             "id": "0addcced-63f4-570e-844a-2589e65ea266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77baad4-2bd6-492a-86ca-8e0088b751d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77baad4-2bd6-492a-86ca-8e0088b751d2.jpg?1",
             "name": "Banshee's Blade",
             "text": "Equipped creature gets +1/+1 for each charge counter on Banshee's Blade.\nWhenever equipped creature deals combat damage, put a charge counter on this card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "5127618b-f2cf-5a05-b69a-b2c843b0d415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff34d0b-a278-4990-beaf-5a64885460db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff34d0b-a278-4990-beaf-5a64885460db.jpg?1",
             "name": "Blinkmoth Urn",
             "text": "At the beginning of each player's precombat main phase, if Blinkmoth Urn is untapped, that player adds {1} to his or her mana pool for each artifact he or she controls.",
             "colours": [],
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "32c3fe49-1e7c-50a9-ba75-826d46e41b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465a7990-c9f9-4716-a833-fd41458b9cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465a7990-c9f9-4716-a833-fd41458b9cee.jpg?1",
             "name": "Bonesplitter",
             "text": "Equipped creature gets +2/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4864,7 +4864,7 @@
         },
         {
             "id": "a0d692d6-7a9d-5b3d-86d9-600b23567da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe325c-8d3d-4543-9fcd-214525d4ab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe325c-8d3d-4543-9fcd-214525d4ab2a.jpg?1",
             "name": "Bosh, Iron Golem",
             "text": "Trample\n{3}{R}, Sacrifice an artifact: Bosh, Iron Golem deals damage equal to the sacrificed artifact's converted mana cost to target creature or player.",
             "colours": [],
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "67a337b4-9d24-5f9c-893c-e7dfa8658fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018dcb37-221a-4552-9e72-2b9492883eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018dcb37-221a-4552-9e72-2b9492883eae.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: You gain 3 life.",
             "colours": [],
@@ -4930,7 +4930,7 @@
         },
         {
             "id": "884a487d-4469-58ef-b392-93f890463d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e223e822-a7a0-48d1-9bb7-88ee3d939c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e223e822-a7a0-48d1-9bb7-88ee3d939c6f.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion is put into a graveyard from play, add {3} to your mana pool.",
             "colours": [],
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "e750531f-d22b-53c6-b6a7-467682079c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02ca71-5e39-4a5f-aaba-a1e3e10a6a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02ca71-5e39-4a5f-aaba-a1e3e10a6a3e.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void comes into play with X charge counters on it.\nWhenever a player plays a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "7524befc-0a52-595e-b48a-1697d32e8aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31a6dfd-93d2-49c8-a357-9a707b9c42bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31a6dfd-93d2-49c8-a357-9a707b9c42bd.jpg?1",
             "name": "Chromatic Sphere",
             "text": "{1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color to your mana pool. Draw a card.",
             "colours": [],
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "3b84c096-d20b-54a2-b09e-959bb5ff5e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058e68-70af-4a64-859c-c881e5578368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058e68-70af-4a64-859c-c881e5578368.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint When Chrome Mox comes into play, you may remove a nonartifact, nonland card in your hand from the game. (The removed card is imprinted on this artifact.)\n{T}: Add one mana of any of the imprinted card's colors to your mana pool.",
             "colours": [],
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "08a992e2-ccd6-54b1-a33f-f05f3ee4259e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c8db7-cf58-4571-b4ad-2b68d73495b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c8db7-cf58-4571-b4ad-2b68d73495b2.jpg?1",
             "name": "Clockwork Beetle",
             "text": "Clockwork Beetle comes into play with two +1/+1 counters on it.\nWhenever Clockwork Beetle attacks or blocks, remove a +1/+1 counter from it at end of combat.",
             "colours": [],
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "610cde51-3a05-5dbb-a674-1fe8bbffff5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a7e1a6-347e-47bc-8a14-e584a45941e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a7e1a6-347e-47bc-8a14-e584a45941e1.jpg?1",
             "name": "Clockwork Condor",
             "text": "Flying\nClockwork Condor comes into play with three +1/+1 counters on it.\nWhenever Clockwork Condor attacks or blocks, remove a +1/+1 counter from it at end of combat.",
             "colours": [],
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "7079cdfc-9e0c-5819-8d95-9c0cb92e9c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6448da-b513-4bea-95f4-47bdfa0df078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6448da-b513-4bea-95f4-47bdfa0df078.jpg?1",
             "name": "Clockwork Dragon",
             "text": "Flying\nClockwork Dragon comes into play with six +1/+1 counters on it.\nWhenever Clockwork Dragon attacks or blocks, remove a +1/+1 counter from it at end of combat.\n{3}: Put a +1/+1 counter on Clockwork Dragon.",
             "colours": [],
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "7c70911f-51db-508f-9e0d-2a10232ea3d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e876938-1b8e-44cf-ade2-a42f8acdf24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e876938-1b8e-44cf-ade2-a42f8acdf24c.jpg?1",
             "name": "Clockwork Vorrac",
             "text": "Trample\nClockwork Vorrac comes into play with four +1/+1 counters on it.\nWhenever Clockwork Vorrac attacks or blocks, remove a +1/+1 counter from it at end of combat.\n{T}: Put a +1/+1 counter on Clockwork Vorrac.",
             "colours": [],
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "0e2d748e-016a-5067-aee1-3caab8e69c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e72f6-f573-4e37-9daa-abe6561ab086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e72f6-f573-4e37-9daa-abe6561ab086.jpg?1",
             "name": "Cobalt Golem",
             "text": "{1}{U}: Cobalt Golem gains flying until end of turn.",
             "colours": [],
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "18368775-5612-598b-bbb8-a67aa623b80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b2dc4-4fb3-4ddf-bdb6-c63e8c8efc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b2dc4-4fb3-4ddf-bdb6-c63e8c8efc09.jpg?1",
             "name": "Copper Myr",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "cb5d6b42-f7b8-5d6e-b771-a5c24c340079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c1d05b-92be-40d7-859f-75293a531a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c1d05b-92be-40d7-859f-75293a531a84.jpg?1",
             "name": "Crystal Shard",
             "text": "{3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}.",
             "colours": [],
@@ -5266,7 +5266,7 @@
         },
         {
             "id": "18625edd-db2b-5feb-adb2-1f74586d8671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a57d6-bba6-463d-ad12-6f93c035d16b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a57d6-bba6-463d-ad12-6f93c035d16b.jpg?1",
             "name": "Culling Scales",
             "text": "At the beginning of your upkeep, destroy target nonland permanent with the lowest converted mana cost among nonland permanents in play. (If two or more permanents are tied for lowest cost, target any one of them.)",
             "colours": [],
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "c0a937a4-2c1f-5412-bd06-e0c80623f473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2214e75-e469-41ae-8412-df725c097d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2214e75-e469-41ae-8412-df725c097d08.jpg?1",
             "name": "Damping Matrix",
             "text": "Activated abilities of artifacts and creatures can't be played unless they're mana abilities.",
             "colours": [],
@@ -5322,7 +5322,7 @@
         },
         {
             "id": "71e3eee1-0ecd-5485-894c-cdac080b400a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc312c0-14da-4b23-8293-6fa41bdd3167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc312c0-14da-4b23-8293-6fa41bdd3167.jpg?1",
             "name": "Dead-Iron Sledge",
             "text": "Whenever equipped creature blocks or becomes blocked by a creature, destroy that creature and equipped creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "80f47aad-b99f-5fc1-a483-ba9fe40f8f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc372-c5f9-4f98-9a15-0ea4a33017b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc372-c5f9-4f98-9a15-0ea4a33017b1.jpg?1",
             "name": "Dragon Blood",
             "text": "{3}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "23241051-54fc-54aa-b4ff-89d48c1c7eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg?1",
             "name": "Dross Scorpion",
             "text": "Whenever Dross Scorpion or another artifact creature is put into a graveyard from play, you may untap target artifact.",
             "colours": [],
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "5f46e5f4-30f5-5158-9bfa-010a7cec0e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48a96f2-738f-433f-bfae-fbf378832a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48a96f2-738f-433f-bfae-fbf378832a3b.jpg?1",
             "name": "Duplicant",
             "text": "Imprint When Duplicant comes into play, you may remove target nontoken creature from the game. (The removed card is imprinted on this artifact.)\nAs long as a creature card is imprinted on Duplicant, Duplicant has that card's power, toughness, and creature types. It's still a Shapeshifter.",
             "colours": [],
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "6fde934b-be53-5358-9f82-9293f9ec565f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d18dd3b-980b-4833-93fd-79dc3a260da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d18dd3b-980b-4833-93fd-79dc3a260da4.jpg?1",
             "name": "Duskworker",
             "text": "Whenever Duskworker becomes blocked, regenerate it.\n{3}: Duskworker gets +1/+0 until end of turn.",
             "colours": [],
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "145426c9-3e4c-5edc-b015-690b72deb964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92cce55-22ee-40a7-bb94-4889093f142c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92cce55-22ee-40a7-bb94-4889093f142c.jpg?1",
             "name": "Elf Replica",
             "text": "{1}{G}, Sacrifice Elf Replica: Destroy target enchantment.",
             "colours": [],
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "47ad7c72-e712-5d7f-b366-62506592f74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1735bbb-402e-4657-8ad0-df2c56d5ee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1735bbb-402e-4657-8ad0-df2c56d5ee01.jpg?1",
             "name": "Empyrial Plate",
             "text": "Equipped creature gets +1/+1 for each card in your hand.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5536,7 +5536,7 @@
         },
         {
             "id": "1308e781-9fc1-572d-a99a-84e1b694eed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622a6523-3b12-4657-a656-00a57a3ae59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622a6523-3b12-4657-a656-00a57a3ae59c.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint When Extraplanar Lens comes into play, you may remove target land you control from the game. (The removed card is imprinted on this artifact.)\nWhenever a land with the same name as the imprinted card is tapped for mana, its controller adds one mana to his or her mana pool of any type that land produced.",
             "colours": [],
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "17426b58-1608-57fc-8350-a93ac13268b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98312bc3-9d2a-480c-bcf0-db8d70d632b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98312bc3-9d2a-480c-bcf0-db8d70d632b9.jpg?1",
             "name": "Farsight Mask",
             "text": "Whenever a source an opponent controls deals damage to you, if Farsight Mask is untapped, you may draw a card.",
             "colours": [],
@@ -5592,7 +5592,7 @@
         },
         {
             "id": "c8199596-de89-5ba9-a712-52ab3f057c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da0fcc6-6209-4b8e-997d-ad3cc4ff0856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da0fcc6-6209-4b8e-997d-ad3cc4ff0856.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "e90b88c9-b69b-5627-892f-e79d01735f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff504dcb-2eb8-4b3c-a8b9-29697739b649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff504dcb-2eb8-4b3c-a8b9-29697739b649.jpg?1",
             "name": "Frogmite",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)",
             "colours": [],
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "c9f5c36c-ec4e-5ebe-8fe2-ef777aee6981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934936d1-f470-47fa-ac28-344020c9fc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934936d1-f470-47fa-ac28-344020c9fc76.jpg?1",
             "name": "Galvanic Key",
             "text": "You may play Galvanic Key any time you could play an instant.\n{3}, {T}: Untap target artifact.",
             "colours": [],
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "c5bb36a9-9b93-5c11-8f0b-fa7ecffc82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fd840-e633-46d3-991a-b9fea95a2f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fd840-e633-46d3-991a-b9fea95a2f28.jpg?1",
             "name": "Gate to the Aether",
             "text": "At the beginning of each player's upkeep, that player reveals the top card of his or her library. If it's an artifact, creature, enchantment, or land card, the player may put it into play.",
             "colours": [],
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "d35ed259-c7ee-5ee4-872c-76875c85afed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d5e4c8-dfd0-45bc-8000-ebfaccfefec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d5e4c8-dfd0-45bc-8000-ebfaccfefec3.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -5737,7 +5737,7 @@
         },
         {
             "id": "4aa6dae9-0664-5051-9000-edb6cd5fde0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c37fc1-4842-4bc5-93ed-83fff9e420f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c37fc1-4842-4bc5-93ed-83fff9e420f2.jpg?1",
             "name": "Goblin Charbelcher",
             "text": "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. Goblin Charbelcher deals damage equal to the number of nonland cards revealed this way to target creature or player. If the revealed land card was a Mountain, Goblin Charbelcher deals double that damage instead. Put the revealed cards on the bottom of your library in any order.",
             "colours": [],
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "1e1e1eec-ba16-5b8b-8b80-bd26e5e3b2aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ed2990-e5bf-4567-9a41-1846108a8aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ed2990-e5bf-4567-9a41-1846108a8aeb.jpg?1",
             "name": "Goblin Dirigible",
             "text": "Flying\nGoblin Dirigible doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Goblin Dirigible.",
             "colours": [],
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "e9b6fbce-67d0-5d52-998a-504f3a34dcb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63282976-e08d-4b8c-bbfc-f6739fdaeaf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63282976-e08d-4b8c-bbfc-f6739fdaeaf9.jpg?1",
             "name": "Goblin Replica",
             "text": "{3}{R}, Sacrifice Goblin Replica: Destroy target artifact.",
             "colours": [],
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "b346418d-e819-5c12-9131-6582a489e240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229e8124-54ed-4c29-8c44-4962bd60f145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229e8124-54ed-4c29-8c44-4962bd60f145.jpg?1",
             "name": "Goblin War Wagon",
             "text": "Goblin War Wagon doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {2}. If you do, untap Goblin War Wagon.",
             "colours": [],
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "f8234e3b-ed3b-50ee-84d2-17aaff3500a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9b4040-ab49-476b-b101-5ef2b1824e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9b4040-ab49-476b-b101-5ef2b1824e10.jpg?1",
             "name": "Gold Myr",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "c5d3a332-7a2b-5438-892a-1f5f0b1e09bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9519f2a-e98d-4f84-885c-24a9849a996d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9519f2a-e98d-4f84-885c-24a9849a996d.jpg?1",
             "name": "Golem-Skin Gauntlets",
             "text": "Equipped creature gets +1/+0 for each Equipment attached to it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5923,7 +5923,7 @@
         },
         {
             "id": "aca7f6b4-f573-59d9-9e14-2ff257f89c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197af6a-24ac-4f3b-ab3c-736f4057748b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197af6a-24ac-4f3b-ab3c-736f4057748b.jpg?1",
             "name": "Granite Shard",
             "text": "{3}, {T} or {R}, {T}: Granite Shard deals 1 damage to target creature or player.",
             "colours": [],
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "f2d40670-fa05-5050-bbe2-c5767c84b349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg?1",
             "name": "Grid Monitor",
             "text": "You can't play creature spells.",
             "colours": [],
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "51ebff86-42fa-518b-a178-db2f7af9296d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13328a9-fc03-4c1b-b1b7-61cd41766300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13328a9-fc03-4c1b-b1b7-61cd41766300.jpg?1",
             "name": "Heartwood Shard",
             "text": "{3}, {T} or {G}, {T}: Target creature gains trample until end of turn.",
             "colours": [],
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "3116f693-b007-5e71-a2d9-9db85686a515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8d47d-6ecb-424a-a908-a6501f308c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8d47d-6ecb-424a-a908-a6501f308c8e.jpg?1",
             "name": "Hematite Golem",
             "text": "{1}{R}: Hematite Golem gets +2/+0 until end of turn.",
             "colours": [],
@@ -6047,7 +6047,7 @@
         },
         {
             "id": "c245d9c0-8838-53aa-bd52-ae57b31017c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1bdbe2-4163-469b-aa8c-00fd8208ec27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1bdbe2-4163-469b-aa8c-00fd8208ec27.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "acd896a7-edf9-5575-b5c2-f2fd5eeae669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e17883-0767-40b5-ac44-a52a1ea54993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e17883-0767-40b5-ac44-a52a1ea54993.jpg?1",
             "name": "Iron Myr",
             "text": "{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "a3585853-9506-5b1c-b035-1e26e5aa0c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878b0159-6917-45d3-b9ea-562ac49f0b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878b0159-6917-45d3-b9ea-562ac49f0b8f.jpg?1",
             "name": "Isochron Scepter",
             "text": "Imprint When Isochron Scepter comes into play, you may remove an instant card with converted mana cost 2 or less in your hand from the game. (The removed card is imprinted on this artifact.)\n{2}, {T}: You may copy the imprinted instant card and play the copy without paying its mana cost.",
             "colours": [],
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "0facf220-1c21-5be3-8acf-76d10f74d123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987910b0-0419-45ff-bda6-c6683fd00e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987910b0-0419-45ff-bda6-c6683fd00e49.jpg?1",
             "name": "Jinxed Choker",
             "text": "At the end of your turn, target opponent gains control of Jinxed Choker and puts a charge counter on it.\nAt the beginning of your upkeep, Jinxed Choker deals damage to you equal to the number of charge counters on it.\n{3}: Put a charge counter on Jinxed Choker or remove one from it.",
             "colours": [],
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "47bf8c6d-3d74-578a-a873-03e76ea2dcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a5d49a-747e-4ec8-a20a-ca917c315774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a5d49a-747e-4ec8-a20a-ca917c315774.jpg?1",
             "name": "Krark's Thumb",
             "text": "If you would flip a coin, instead flip two coins and ignore one.",
             "colours": [],
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "ebce3430-1e96-576c-bcdd-5a017b653f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555efe5f-848f-44da-92b5-69c8e852f179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555efe5f-848f-44da-92b5-69c8e852f179.jpg?1",
             "name": "Leaden Myr",
             "text": "{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "270b6d4b-7a2b-536d-849d-d4e30a5783a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780199bc-dce4-4ed0-88fb-7d288f304e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780199bc-dce4-4ed0-88fb-7d288f304e69.jpg?1",
             "name": "Leonin Bladetrap",
             "text": "You may play Leonin Bladetrap any time you could play an instant.\n{2}, Sacrifice Leonin Bladetrap: Leonin Bladetrap deals 2 damage to each attacking creature without flying.",
             "colours": [],
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "d326b076-522d-572e-85b2-0dee953d9510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abf4bbe-5b1c-4f6f-be32-5f61c66e1830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abf4bbe-5b1c-4f6f-be32-5f61c66e1830.jpg?1",
             "name": "Leonin Scimitar",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "cb0df8c9-b497-5526-8e9e-a805d0bc53c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395f719d-1f55-4f1a-a9fb-a178cd589f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395f719d-1f55-4f1a-a9fb-a178cd589f70.jpg?1",
             "name": "Leonin Sun Standard",
             "text": "{1}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [],
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "8988dfbc-8e24-5758-8f5b-79af5a0815a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ffa3c3-dd29-47eb-abf2-7951fadb5c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ffa3c3-dd29-47eb-abf2-7951fadb5c37.jpg?1",
             "name": "Leveler",
             "text": "When Leveler comes into play, remove your library from the game.",
             "colours": [],
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "80d4204a-17d2-5f67-92f1-f0e94d501fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66372597-c182-4850-a630-231737b1482b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66372597-c182-4850-a630-231737b1482b.jpg?1",
             "name": "Liar's Pendulum",
             "text": "{2}, {T}: Name a card. Target opponent guesses whether a card with that name is in your hand. You may reveal your hand. If you do and your opponent guessed wrong, draw a card.",
             "colours": [],
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "53b1883f-4c6f-5342-9bf3-8e36f3ca57ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adde668-67af-4a08-a36a-2a49893ab20d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adde668-67af-4a08-a36a-2a49893ab20d.jpg?1",
             "name": "Lifespark Spellbomb",
             "text": "{G}, Sacrifice Lifespark Spellbomb: Until end of turn, target land becomes a 3/3 creature that's still a land.\n{1}, Sacrifice Lifespark Spellbomb: Draw a card.",
             "colours": [],
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "1250647d-4890-5043-a6a6-f4786006ea6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a800f326-3416-4917-a1cf-0f90255777d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a800f326-3416-4917-a1cf-0f90255777d3.jpg?1",
             "name": "Lightning Coils",
             "text": "Whenever a nontoken creature you control is put into a graveyard from play, put a charge counter on Lightning Coils.\nAt the beginning of your upkeep, if Lightning Coils has five or more charge counters on it, remove all of them from it and put that many 3/1 red Elemental creature tokens with haste into play. Remove them from the game at end of turn.",
             "colours": [],
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "25429a6d-fd7a-5235-a230-f4748b04589d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a28870-cf78-4323-9d82-cee764067764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a28870-cf78-4323-9d82-cee764067764.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and can't be the target of spells or abilities.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "817c05bf-b9af-5093-9fa0-a64e7e526ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faab1d25-dee5-4315-ba63-f8e14087a9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faab1d25-dee5-4315-ba63-f8e14087a9c0.jpg?1",
             "name": "Lodestone Myr",
             "text": "Trample\nTap an untapped artifact you control: Lodestone Myr gets +1/+1 until end of turn.",
             "colours": [],
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "2d4a07f8-ad17-5b90-8e09-3d8519fca861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6e375-5c47-4447-9453-adf0038693e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6e375-5c47-4447-9453-adf0038693e3.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0, has trample, and has \"Whenever this creature deals damage, you gain that much life.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6523,7 +6523,7 @@
         },
         {
             "id": "778a262f-8759-5dfc-89ff-a514ecec8acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1193164-5ee5-40ff-b244-f80d426bbf89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1193164-5ee5-40ff-b244-f80d426bbf89.jpg?1",
             "name": "Malachite Golem",
             "text": "{1}{G}: Malachite Golem gains trample until end of turn.",
             "colours": [],
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "1c42d2bd-058a-5d29-94f8-3731c10c9b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f8021-aaf3-4b1c-b08c-fe667ce2d8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f8021-aaf3-4b1c-b08c-fe667ce2d8e1.jpg?1",
             "name": "Mask of Memory",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw two cards. If you do, discard a card from your hand.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6586,7 +6586,7 @@
         },
         {
             "id": "c879425a-6b46-555b-abac-5f56b7790280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d11b14-43a9-4d1c-ba2c-3025d51d841e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d11b14-43a9-4d1c-ba2c-3025d51d841e.jpg?1",
             "name": "Mesmeric Orb",
             "text": "Whenever a permanent becomes untapped, that permanent's controller puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "8f6813a7-cfbd-59b1-beac-373b18a025d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0899f753-c229-4cdf-a60c-4978a6506def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0899f753-c229-4cdf-a60c-4978a6506def.jpg?1",
             "name": "Mind's Eye",
             "text": "Whenever an opponent draws a card, you may pay {1}. If you do, draw a card.",
             "colours": [],
@@ -6642,7 +6642,7 @@
         },
         {
             "id": "6b60ae25-d5a3-57aa-8102-ba5262ec796c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb1eaa-2871-491a-a4f5-3e358778ba40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb1eaa-2871-491a-a4f5-3e358778ba40.jpg?1",
             "name": "Mindslaver",
             "text": "{4}, {T}, Sacrifice Mindslaver: You control target player's next turn. (You see all cards that player could see and make all decisions for the player. He or she doesn't lose life because of mana burn.)",
             "colours": [],
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "97708c05-2689-5840-8713-8888e878c0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c1442-036b-43e7-9f86-b81a54d6bc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c1442-036b-43e7-9f86-b81a54d6bc41.jpg?1",
             "name": "Mindstorm Crown",
             "text": "At the beginning of your upkeep, draw a card if you had no cards in hand at the beginning of this turn. If you had a card in hand, Mindstorm Crown deals 1 damage to you.",
             "colours": [],
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "69d416fb-f290-58c9-a9a9-32275d36d265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9467839-b2a2-4cfe-a60e-12766e2ba983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9467839-b2a2-4cfe-a60e-12766e2ba983.jpg?1",
             "name": "Mirror Golem",
             "text": "Imprint When Mirror Golem comes into play, you may remove target card in a graveyard from the game. (The removed card is imprinted on this artifact.)\nMirror Golem has protection from each of the imprinted card's card types. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [],
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "d60a0ae3-b61b-5b5b-aec5-a9e16cb3c0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fe67f-59f7-46f0-bfa4-fa4a65c9c33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fe67f-59f7-46f0-bfa4-fa4a65c9c33c.jpg?1",
             "name": "Mourner's Shield",
             "text": "Imprint When Mourner's Shield comes into play, you may remove target card in a graveyard from the game. (The removed card is imprinted on this artifact.)\n{2}, {T}: Prevent all damage that would be dealt this turn by a source of your choice that shares a color with the imprinted card.",
             "colours": [],
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "bed0e680-9691-5266-91cf-8756bfbfec2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6ddde9-4427-4a0f-b05c-9cfd886aad2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6ddde9-4427-4a0f-b05c-9cfd886aad2d.jpg?1",
             "name": "Myr Adapter",
             "text": "Myr Adapter gets +1/+1 for each Equipment attached to it.",
             "colours": [],
@@ -6790,7 +6790,7 @@
         },
         {
             "id": "92e5b9a2-fb68-5eae-aba6-338bcb17b24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg?1",
             "name": "Myr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)",
             "colours": [],
@@ -6821,7 +6821,7 @@
         },
         {
             "id": "18dc0e7f-1f1f-5530-ab3e-5ffc7b82d0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0f9ef-7404-4e05-b759-aaf1ebcfcb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0f9ef-7404-4e05-b759-aaf1ebcfcb31.jpg?1",
             "name": "Myr Incubator",
             "text": "{6}, {T}, Sacrifice Myr Incubator: Search your library for any number of artifact cards, remove them from the game, then put that many 1/1 Myr artifact creature tokens into play. Then shuffle your library.",
             "colours": [],
@@ -6849,7 +6849,7 @@
         },
         {
             "id": "fa3e26b7-096d-5845-ac22-a90be7a41d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce711-8f68-4487-b67b-be35796ffcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce711-8f68-4487-b67b-be35796ffcff.jpg?1",
             "name": "Myr Mindservant",
             "text": "{2}, {T}: Shuffle your library.",
             "colours": [],
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "0e0be462-2b51-5ce2-ae7a-9f64e0ea7343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929b28-c184-4e77-a40b-ee43b8a37d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929b28-c184-4e77-a40b-ee43b8a37d79.jpg?1",
             "name": "Myr Prototype",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on Myr Prototype.\nMyr Prototype can't attack or block unless you pay {1} for each +1/+1 counter on it. (This cost is paid as attackers or blockers are declared.)",
             "colours": [],
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "6a03e3ca-8041-56c0-b908-3c2027c77813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee766f7b-4e9c-442d-bf53-31c204646449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee766f7b-4e9c-442d-bf53-31c204646449.jpg?1",
             "name": "Myr Retriever",
             "text": "When Myr Retriever is put into a graveyard from play, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "840919e2-7c75-5ce5-84e1-dd9bffcffc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0950bfe7-2600-4e01-8f54-f03a5c023520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0950bfe7-2600-4e01-8f54-f03a5c023520.jpg?1",
             "name": "Necrogen Spellbomb",
             "text": "{B}, Sacrifice Necrogen Spellbomb: Target player discards a card from his or her hand.\n{1}, Sacrifice Necrogen Spellbomb: Draw a card.",
             "colours": [],
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "4d1a3bd1-2d9c-59ce-b7a1-28756d977a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fbd8a-1e2a-450e-98f2-26bbc9e9ac79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fbd8a-1e2a-450e-98f2-26bbc9e9ac79.jpg?1",
             "name": "Needlebug",
             "text": "Protection from artifacts\nYou may play Needlebug any time you could play an instant.",
             "colours": [],
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "de2fc517-fcbc-557b-a0e3-2242e4212f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5790b-5388-4bf9-9caa-44d8cbb64708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5790b-5388-4bf9-9caa-44d8cbb64708.jpg?1",
             "name": "Neurok Hoversail",
             "text": "Equipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -7033,7 +7033,7 @@
         },
         {
             "id": "9d9cfc11-23f2-549e-bb77-12946b49952b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8e3fa6-494c-412f-90cc-36d45cd2b175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8e3fa6-494c-412f-90cc-36d45cd2b175.jpg?1",
             "name": "Nightmare Lash",
             "text": "Equipped creature gets +1/+1 for each Swamp you control.\nEquip\u2014\nPay 3 life. (Pay 3 life: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "cf6c78bd-2497-5b65-bb2c-89fd9fde1484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11a56e7-30a4-44da-a58b-336f4c0c4882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11a56e7-30a4-44da-a58b-336f4c0c4882.jpg?1",
             "name": "Nim Replica",
             "text": "{2}{B}, Sacrifice Nim Replica: Target creature gets -1/-1 until end of turn.",
             "colours": [],
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "efff191a-c928-5104-a8b4-f7be30494e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266df8c3-5872-4d83-90bc-8f6f854ac838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266df8c3-5872-4d83-90bc-8f6f854ac838.jpg?1",
             "name": "Nuisance Engine",
             "text": "{2}, {T}: Put a 0/1 Pest artifact creature token into play.",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "bbe06c84-7e26-5db8-b76b-91946c4d9c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddba1566-2778-4636-b4d3-9095fb2d83c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddba1566-2778-4636-b4d3-9095fb2d83c8.jpg?1",
             "name": "Oblivion Stone",
             "text": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice Oblivion Stone: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
             "colours": [],
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "4c88c7e1-4e4d-54fd-a2f1-d54e6d7d14fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa5c60-054f-4397-a110-21df58264caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa5c60-054f-4397-a110-21df58264caf.jpg?1",
             "name": "Omega Myr",
             "text": "",
             "colours": [],
@@ -7183,7 +7183,7 @@
         },
         {
             "id": "dc0ae0b0-0184-5012-be34-6bbba1408b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969ebd20-de69-44ba-a0c2-9e2a89480370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969ebd20-de69-44ba-a0c2-9e2a89480370.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -7214,7 +7214,7 @@
         },
         {
             "id": "de4f0614-5752-52ef-9e50-f1559a1db4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde295d-af41-4b9c-af48-3067befe9383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde295d-af41-4b9c-af48-3067befe9383.jpg?1",
             "name": "Pearl Shard",
             "text": "{3}, {T} or {W}, {T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [],
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "bf99443f-28c0-57fb-bb96-006e8dea9f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a11f0a-7547-4fda-a8ed-caf76ce98f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a11f0a-7547-4fda-a8ed-caf76ce98f10.jpg?1",
             "name": "Pentavus",
             "text": "Pentavus comes into play with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from Pentavus: Put a 1/1 Pentavite artifact creature token with flying into play.\n{1}, Sacrifice a Pentavite: Put a +1/+1 counter on Pentavus.",
             "colours": [],
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "50811d69-2ac8-51e0-a0ba-d5d8bbf34c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa6682-bf11-4959-9d07-423a55f35199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa6682-bf11-4959-9d07-423a55f35199.jpg?1",
             "name": "Pewter Golem",
             "text": "{1}{B}: Regenerate Pewter Golem.",
             "colours": [],
@@ -7308,7 +7308,7 @@
         },
         {
             "id": "91945553-a222-52ea-9950-0a8621105bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bb5aee-b334-4c24-875b-56751d4add02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bb5aee-b334-4c24-875b-56751d4add02.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -7339,7 +7339,7 @@
         },
         {
             "id": "322daeea-5abe-59ba-87dd-0285dd8f20ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f5c84f-1924-4a4a-84c1-00dcb756e9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f5c84f-1924-4a4a-84c1-00dcb756e9c9.jpg?1",
             "name": "Power Conduit",
             "text": "{T}, Remove a counter from a permanent you control: Choose one Put a charge counter on target artifact; or put a +1/+1 counter on target creature.",
             "colours": [],
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "3c79fb75-2aa5-5233-aa8c-96a594d474e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e5c69c-43d0-4f5b-8720-40074eb122bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e5c69c-43d0-4f5b-8720-40074eb122bb.jpg?1",
             "name": "Proteus Staff",
             "text": "{2}{U}, {T}: Put target creature on the bottom of its owner's library. That creature's controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card into play and the rest on the bottom of his or her library in any order. Play this ability only any time you could play a sorcery.",
             "colours": [],
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "45fcc44f-59f3-525c-bc72-a1d887101b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83d1ed5-3a49-4cfa-bad2-e342ef28649e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83d1ed5-3a49-4cfa-bad2-e342ef28649e.jpg?1",
             "name": "Psychogenic Probe",
             "text": "Whenever a spell or ability causes a player to shuffle his or her library, Psychogenic Probe deals 2 damage to him or her.",
             "colours": [],
@@ -7425,7 +7425,7 @@
         },
         {
             "id": "c77e1c3d-6f63-5942-828c-fe65cbafc039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b9bab9-12ee-4da5-9d53-d0b82d9279cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b9bab9-12ee-4da5-9d53-d0b82d9279cd.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "{R}, Sacrifice Pyrite Spellbomb: Pyrite Spellbomb deals 2 damage to target creature or player.\n{1}, Sacrifice Pyrite Spellbomb: Draw a card.",
             "colours": [],
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "f6c1643d-5e74-5cf0-a404-4d1545052be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f2bf63-e3cf-4a58-86b7-f3bab3b90712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f2bf63-e3cf-4a58-86b7-f3bab3b90712.jpg?1",
             "name": "Quicksilver Fountain",
             "text": "At the beginning of each player's upkeep, that player puts a flood counter on target non-Island land he or she controls. That land is an Island as long as it has a flood counter on it.\nAt end of turn, if all lands in play are Islands, remove all flood counters from them.",
             "colours": [],
@@ -7483,7 +7483,7 @@
         },
         {
             "id": "37d303d7-af1f-5cbc-a57a-aadcd255d41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a08cd-72b3-4b3f-9f23-15697704acb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a08cd-72b3-4b3f-9f23-15697704acb3.jpg?1",
             "name": "Rust Elemental",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice an artifact other than Rust Elemental. If you can't, tap Rust Elemental and you lose 4 life.",
             "colours": [],
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "d1719b64-8f30-5c97-8746-96c8178d811d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d23449c-4439-4425-ad53-84168a94b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d23449c-4439-4425-ad53-84168a94b1ce.jpg?1",
             "name": "Rustspore Ram",
             "text": "When Rustspore Ram comes into play, destroy target Equipment.",
             "colours": [],
@@ -7545,7 +7545,7 @@
         },
         {
             "id": "bf1af69e-8e86-5acf-80fe-c5013a4c47b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133b367c-b1a1-46f7-a539-a33ee655affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133b367c-b1a1-46f7-a539-a33ee655affb.jpg?1",
             "name": "Scale of Chiss-Goria",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nYou may play Scale of Chiss-Goria any time you could play an instant.\n{T}: Target creature gets +0/+1 until end of turn.",
             "colours": [],
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "53ba04f7-47a3-51e6-baa5-ee3d6fcd96df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg?1",
             "name": "Scrabbling Claws",
             "text": "{T}: Target player removes a card in his or her graveyard from the game.\n{1}, Sacrifice Scrabbling Claws: Remove target card in a graveyard from the game. Draw a card.",
             "colours": [],
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "52ad0c9d-ea18-5244-b305-e1b254d9767d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aac5f6f-97c1-4546-94ed-016292e98c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aac5f6f-97c1-4546-94ed-016292e98c9d.jpg?1",
             "name": "Sculpting Steel",
             "text": "As Sculpting Steel comes into play, you may choose an artifact in play. If you do, Sculpting Steel comes into play as a copy of that artifact.",
             "colours": [],
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "12587e5a-3b4f-56d5-b843-2a821faeee91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e7a81-fb3d-4bad-854a-b24138ca7415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e7a81-fb3d-4bad-854a-b24138ca7415.jpg?1",
             "name": "Scythe of the Wretched",
             "text": "Equipped creature gets +2/+2.\nWhenever a creature dealt damage by equipped creature this turn is put into a graveyard, return that card to play under your control. Attach Scythe of the Wretched to that creature.\nEquip {4}",
             "colours": [],
@@ -7659,7 +7659,7 @@
         },
         {
             "id": "084f78e9-5e62-55a3-9d05-266c5b7f19a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ec055-1a7d-426b-a87f-c85c60aa7fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ec055-1a7d-426b-a87f-c85c60aa7fc3.jpg?1",
             "name": "Serum Tank",
             "text": "Whenever Serum Tank or another artifact comes into play, put a charge counter on Serum Tank.\n{3}, {T}, Remove a charge counter from Serum Tank: Draw a card.",
             "colours": [],
@@ -7687,7 +7687,7 @@
         },
         {
             "id": "038e6785-57cf-52fb-88b1-c58d77f79451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a73a2-fedb-40bd-8e29-82a7abd6f211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a73a2-fedb-40bd-8e29-82a7abd6f211.jpg?1",
             "name": "Silver Myr",
             "text": "{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -7720,7 +7720,7 @@
         },
         {
             "id": "164ca139-fabd-5a35-a19a-dfa932fac67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeffcd61-ea1f-4ccd-b3d3-79efa9d4a0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeffcd61-ea1f-4ccd-b3d3-79efa9d4a0cf.jpg?1",
             "name": "Skeleton Shard",
             "text": "{3}, {T} or {B}, {T}: Return target artifact creature card from your graveyard to your hand.",
             "colours": [],
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "2c5c62a1-1190-5489-bb8d-a56372790faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a6e3f-909a-4ca0-a6aa-7354b9476df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a6e3f-909a-4ca0-a6aa-7354b9476df2.jpg?1",
             "name": "Slagwurm Armor",
             "text": "Equipped creature gets +0/+6.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "7f1e3001-49f6-50d6-b058-fce4f87cc7ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31761a8-1146-4003-9653-881233787ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31761a8-1146-4003-9653-881233787ac4.jpg?1",
             "name": "Soldier Replica",
             "text": "{1}{W}, Sacrifice Soldier Replica: Soldier Replica deals 3 damage to target attacking or blocking creature.",
             "colours": [],
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "cbdf57dd-db66-52fd-8e44-ee3dffc3a540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f9955f-a522-47bf-b064-92dd21a76b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f9955f-a522-47bf-b064-92dd21a76b18.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum comes into play, you may search your library for a basic land card and put that card into play tapped. If you do, shuffle your library.\nWhen Solemn Simulacrum is put into a graveyard from play, you may draw a card.",
             "colours": [],
@@ -7844,7 +7844,7 @@
         },
         {
             "id": "e2429895-beca-5a8f-bc99-2df107558ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b4983a-2a95-4322-a315-27b4bd430d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b4983a-2a95-4322-a315-27b4bd430d39.jpg?1",
             "name": "Soul Foundry",
             "text": "Imprint When Soul Foundry comes into play, you may remove a creature card in your hand from the game. (The removed card is imprinted on this artifact.)\n{X}, {T}: Put a creature token into play that's a copy of the imprinted creature card. X is the converted mana cost of that card.",
             "colours": [],
@@ -7872,7 +7872,7 @@
         },
         {
             "id": "0cfde1f1-7795-515f-b52f-92e37e1def29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d44b4-1c3b-4109-aaad-8351bf8a7624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d44b4-1c3b-4109-aaad-8351bf8a7624.jpg?1",
             "name": "Spellweaver Helix",
             "text": "Imprint When Spellweaver Helix comes into play, you may remove two target sorcery cards in a single graveyard from the game. (The removed cards are imprinted on this artifact.)\nWhenever a card is played, if it has the same name as one of the imprinted sorcery cards, you may copy the other and play the copy without paying its mana cost.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "ed0116b1-6bc7-58a1-956d-0f868817f3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d641aaf-e2ff-4ccb-9e4e-27bbfc31ba8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d641aaf-e2ff-4ccb-9e4e-27bbfc31ba8c.jpg?1",
             "name": "Steel Wall",
             "text": "(Walls can't attack.)",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "4dd3cda3-ee64-5eb2-b508-4846f2648add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdd01de-2ac6-4393-ad53-d52df137bc08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdd01de-2ac6-4393-ad53-d52df137bc08.jpg?1",
             "name": "Sun Droplet",
             "text": "Whenever you're dealt damage, put that many charge counters on Sun Droplet.\nAt the beginning of each player's upkeep, you may remove a charge counter from Sun Droplet. If you do, you gain 1 life.",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "97a835d8-f52d-5d08-bacd-2e5740d81965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ffdb7-9f8e-4376-9431-cf1c1814f2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ffdb7-9f8e-4376-9431-cf1c1814f2c4.jpg?1",
             "name": "Sunbeam Spellbomb",
             "text": "{W}, Sacrifice Sunbeam Spellbomb: You gain 5 life.\n{1}, Sacrifice Sunbeam Spellbomb: Draw a card.",
             "colours": [],
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "9fc4c275-4670-5099-af68-6e7702d94988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a665bff-b57a-450c-9310-932b0686a03e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a665bff-b57a-450c-9310-932b0686a03e.jpg?1",
             "name": "Sword of Kaldra",
             "text": "Equipped creature gets +5/+5.\nWhenever equipped creature deals damage to a creature, remove that creature from the game.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "fb3ae02b-8802-52d6-8f6b-57cf3e3b6088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2ab6e-019e-4e72-be06-9c8cd97d54d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2ab6e-019e-4e72-be06-9c8cd97d54d4.jpg?1",
             "name": "Synod Sanctum",
             "text": "{2}, {T}: Remove target permanent you control from the game.\n{2}, Sacrifice Synod Sanctum: Return to play under your control all cards removed from the game with Synod Sanctum.",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "f879f3ab-f95a-5d46-9765-624e44808366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991037a2-fea2-49f5-8ace-ebbf9f678cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991037a2-fea2-49f5-8ace-ebbf9f678cff.jpg?1",
             "name": "Talisman of Dominance",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Talisman of Dominance deals 1 damage to you.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "dfb9a097-19dc-509e-ad8f-cef6388e9b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00b65f7-70d0-4bbd-ac13-be24cc3374ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00b65f7-70d0-4bbd-ac13-be24cc3374ee.jpg?1",
             "name": "Talisman of Impulse",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Talisman of Impulse deals 1 damage to you.",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "51aea172-b039-538b-9b75-2ebcf16b598e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14011b3-56ce-4b93-833f-d8403809159c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14011b3-56ce-4b93-833f-d8403809159c.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Talisman of Indulgence deals 1 damage to you.",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "26aec3cf-6430-506d-b066-40573ab5d8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ff849e-2439-4690-8aa4-769039b6da4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ff849e-2439-4690-8aa4-769039b6da4c.jpg?1",
             "name": "Talisman of Progress",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Talisman of Progress deals 1 damage to you.",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "23d05da0-a519-5e3e-b7e9-8cd7e3875b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cc8a5a-b98b-4758-a168-bf2ef738fb05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cc8a5a-b98b-4758-a168-bf2ef738fb05.jpg?1",
             "name": "Talisman of Unity",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Talisman of Unity deals 1 damage to you.",
             "colours": [],
@@ -8204,7 +8204,7 @@
         },
         {
             "id": "4e6cd2b7-06e6-5c40-898c-fa1c6aaaab18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361a524c-17aa-43a0-8aea-1d26a9a1044c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361a524c-17aa-43a0-8aea-1d26a9a1044c.jpg?1",
             "name": "Tanglebloom",
             "text": "{1}, {T}: You gain 1 life.",
             "colours": [],
@@ -8232,7 +8232,7 @@
         },
         {
             "id": "04919084-641d-519d-813f-0a0e6cbbda86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ff2c28-770b-49cb-be10-35429233e048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ff2c28-770b-49cb-be10-35429233e048.jpg?1",
             "name": "Tangleroot",
             "text": "Whenever a player plays a creature spell, that player adds {G} to his or her mana pool.",
             "colours": [],
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "456b5d44-92a6-5d2b-ae1c-d2945ff47c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522570eb-e654-4f8a-828c-3e456a0ad8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522570eb-e654-4f8a-828c-3e456a0ad8e6.jpg?1",
             "name": "Tel-Jilad Stylus",
             "text": "{T}: Put target permanent you own on the bottom of your library.",
             "colours": [],
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "09c84d88-0429-554b-aa62-c00725bae836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409087ef-8232-489c-8b98-b601bb0a47a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409087ef-8232-489c-8b98-b601bb0a47a4.jpg?1",
             "name": "Thought Prison",
             "text": "Imprint When Thought Prison comes into play, you may have target player reveal his or her hand. If you do, choose a nonland card from it and remove that card from the game. (The removed card is imprinted on this artifact.)\nWhenever a player plays a spell that shares a color or converted mana cost with the imprinted card, Thought Prison deals 2 damage to that player.",
             "colours": [],
@@ -8318,7 +8318,7 @@
         },
         {
             "id": "db9deb44-c440-57e6-bda6-f40703792553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cab0e-8874-4534-bf79-0c1488a9f0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cab0e-8874-4534-bf79-0c1488a9f0a5.jpg?1",
             "name": "Timesifter",
             "text": "At the beginning of each player's upkeep, each player removes the top card of his or her library from the game. The player who removed the card with the highest converted mana cost takes an extra turn after this one. If two or more players' cards are tied for highest cost, the tied players repeat this process until the tie is broken.",
             "colours": [],
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "115b87d0-044c-5306-9c07-ab8635ac7130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8defd53c-3792-4ed3-aee9-cffda2b8a8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8defd53c-3792-4ed3-aee9-cffda2b8a8b6.jpg?1",
             "name": "Titanium Golem",
             "text": "{1}{W}: Titanium Golem gains first strike until end of turn.",
             "colours": [],
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "5084a2a8-2170-5e1d-a2fc-ca457b32afa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5a91db-1b86-4471-badc-884142c355ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5a91db-1b86-4471-badc-884142c355ca.jpg?1",
             "name": "Tooth of Chiss-Goria",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nYou may play Tooth of Chiss-Goria any time you could play an instant.\n{T}: Target creature gets +1/+0 until end of turn.",
             "colours": [],
@@ -8407,7 +8407,7 @@
         },
         {
             "id": "36a2e003-2cb2-51c9-a2fe-308ceac58967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5280aef-dfd2-4d52-bc87-4a6d1f2bd173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5280aef-dfd2-4d52-bc87-4a6d1f2bd173.jpg?1",
             "name": "Tower of Champions",
             "text": "{8}, {T}: Target creature gets +6/+6 until end of turn.",
             "colours": [],
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "69ee29de-5b36-580c-8c54-2d806f964eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb67150-53e4-4164-bea5-dd3659469b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb67150-53e4-4164-bea5-dd3659469b8e.jpg?1",
             "name": "Tower of Eons",
             "text": "{8}, {T}: You gain 10 life.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "dc84e7a3-0758-5378-8a43-eb71e1c52488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433bab44-b644-4e77-a187-bd924d21e91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433bab44-b644-4e77-a187-bd924d21e91f.jpg?1",
             "name": "Tower of Fortunes",
             "text": "{8}, {T}: Draw four cards.",
             "colours": [],
@@ -8491,7 +8491,7 @@
         },
         {
             "id": "aeaf9131-042f-5620-9874-aa68700dd415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76be1ca8-b68e-436d-86b6-2a2a07da1be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76be1ca8-b68e-436d-86b6-2a2a07da1be9.jpg?1",
             "name": "Tower of Murmurs",
             "text": "{8}, {T}: Target player puts the top eight cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -8519,7 +8519,7 @@
         },
         {
             "id": "5f49458c-b134-5a27-a93e-8a8da1e22099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b997abd-8eae-4e87-97fc-36dde95ef8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b997abd-8eae-4e87-97fc-36dde95ef8c7.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion comes into play with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: Triskelion deals 1 damage to target creature or player.",
             "colours": [],
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "3523ad3b-3dab-51e4-a836-9a3cfd2cd2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be892d73-d1f4-4c36-b674-01ae21ff1484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be892d73-d1f4-4c36-b674-01ae21ff1484.jpg?1",
             "name": "Viridian Longbow",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target creature or player.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "142cd1bb-d2bd-5460-944b-22ccda065dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b19949-90c9-46f1-85d4-d6eda0b7977e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b19949-90c9-46f1-85d4-d6eda0b7977e.jpg?1",
             "name": "Vorrac Battlehorns",
             "text": "Equipped creature has trample and can't be blocked by more than one creature.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "2bda989c-55a4-52dd-8bf9-50a647151369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e731de-32e9-4dae-804f-9b962b457cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e731de-32e9-4dae-804f-9b962b457cf3.jpg?1",
             "name": "Vulshok Battlegear",
             "text": "Equipped creature gets +3/+3.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8640,7 +8640,7 @@
         },
         {
             "id": "5f5495c9-6740-55e4-8cdc-ef2f7c9b8bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a04bbd-1d07-4b11-aa54-01790b9dd3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a04bbd-1d07-4b11-aa54-01790b9dd3a0.jpg?1",
             "name": "Vulshok Gauntlets",
             "text": "Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "1775236c-3a6f-5eef-83b0-51b762407250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b7b73b-4800-4fc7-9a5c-93e00ea88498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b7b73b-4800-4fc7-9a5c-93e00ea88498.jpg?1",
             "name": "Welding Jar",
             "text": "Sacrifice Welding Jar: Regenerate target artifact.",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "ddd2cf1d-b32a-50b6-b961-daf930626d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ab68b3-864e-4fe3-a5c5-faa33b45da0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ab68b3-864e-4fe3-a5c5-faa33b45da0f.jpg?1",
             "name": "Wizard Replica",
             "text": "Flying\n{U}, Sacrifice Wizard Replica: Counter target spell unless its controller pays {2}.",
             "colours": [],
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "03b8970f-fec8-5ffb-87b7-068ccb29db3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb1b869-3e2d-4447-a12d-e790883feeee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb1b869-3e2d-4447-a12d-e790883feeee.jpg?1",
             "name": "Worldslayer",
             "text": "Whenever equipped creature deals combat damage to a player, destroy all permanents other than Worldslayer.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "055333ec-a8cf-572b-8cbf-0f876016d9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936af0be-6e7b-49f0-ba84-d8bc1b60994d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936af0be-6e7b-49f0-ba84-d8bc1b60994d.jpg?1",
             "name": "Yotian Soldier",
             "text": "Attacking doesn't cause Yotian Soldier to tap.",
             "colours": [],
@@ -8792,7 +8792,7 @@
         },
         {
             "id": "ddb39aed-2186-5a21-ba04-03343d362a58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857fbd-8e0f-4bff-8f14-561c9925c484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857fbd-8e0f-4bff-8f14-561c9925c484.jpg?1",
             "name": "Ancient Den",
             "text": "(Ancient Den isn't a spell.)\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -8823,7 +8823,7 @@
         },
         {
             "id": "417d2f23-189c-570b-9045-b2d436da736f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c79155-b6d8-46df-891f-487b24c4e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c79155-b6d8-46df-891f-487b24c4e0d5.jpg?1",
             "name": "Blinkmoth Well",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Tap target noncreature artifact.",
             "colours": [],
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "50fdbbf5-d4f1-5fe8-920a-c9b663a6dd19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f28ecdc-a4f0-4327-a78c-340be41555ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f28ecdc-a4f0-4327-a78c-340be41555ee.jpg?1",
             "name": "Cloudpost",
             "text": "Cloudpost comes into play tapped.\n{T}: Add {1} to your mana pool for each Locus in play.",
             "colours": [],
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "b0fde0a0-c51e-51b3-8a80-86d15872e9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ab98a1-664c-4775-a3dd-22a15e2f836b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ab98a1-664c-4775-a3dd-22a15e2f836b.jpg?1",
             "name": "Glimmervoid",
             "text": "At end of turn, if you control no artifacts, sacrifice Glimmervoid.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "a2431ece-7fe5-53ae-9e3a-591546241d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2877281d-c85d-4f32-b40d-828b93c4ee8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2877281d-c85d-4f32-b40d-828b93c4ee8e.jpg?1",
             "name": "Great Furnace",
             "text": "(Great Furnace isn't a spell.)\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "35255e8a-029e-53a2-82b0-0180711c0644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da5587d-6b6c-4645-8cc9-2866d1e6911b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da5587d-6b6c-4645-8cc9-2866d1e6911b.jpg?1",
             "name": "Seat of the Synod",
             "text": "(Seat of the Synod isn't a spell.)\n{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -8971,7 +8971,7 @@
         },
         {
             "id": "f202a313-7c77-53db-a919-08aa6285875a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96d7230-c7ca-4613-ae7e-88a0e6270b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96d7230-c7ca-4613-ae7e-88a0e6270b98.jpg?1",
             "name": "Stalking Stones",
             "text": "{T}: Add {1} to your mana pool.\n{6}: Stalking Stones becomes a 3/3 artifact creature that's still a land. (This effect doesn't end at end of turn.)",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "c22745b0-4f52-508a-923b-25aacf91fcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db07aa-43d3-41b5-924e-60f1756b9c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db07aa-43d3-41b5-924e-60f1756b9c69.jpg?1",
             "name": "Tree of Tales",
             "text": "(Tree of Tales isn't a spell.)\n{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -9030,7 +9030,7 @@
         },
         {
             "id": "1f08d5e7-8e2f-517a-be40-190cb2403680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73866487-33f4-4f64-b100-2c4ddadcd74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73866487-33f4-4f64-b100-2c4ddadcd74e.jpg?1",
             "name": "Vault of Whispers",
             "text": "(Vault of Whispers isn't a spell.)\n{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -9061,7 +9061,7 @@
         },
         {
             "id": "5fa6d528-88b1-5a67-9828-cf7cd8153bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac2d0d-43db-41f7-99dd-9ff55a4f2b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac2d0d-43db-41f7-99dd-9ff55a4f2b3b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "1e2abaf2-e188-50a3-8bc6-9abf9592ef48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c160b1e7-8fad-4592-899c-995d09bc8b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c160b1e7-8fad-4592-899c-995d09bc8b52.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9137,7 +9137,7 @@
         },
         {
             "id": "d37c4d07-5bd9-5c03-b180-9fd86d4b44dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac11282-82d6-40db-8c28-5ed02268d2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac11282-82d6-40db-8c28-5ed02268d2c6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "aed1ac6c-e250-5d15-9611-1e8a31ebd19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546507c7-8fa8-44e3-aeb7-56fabf419d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546507c7-8fa8-44e3-aeb7-56fabf419d82.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "3cbb9b81-021e-5891-81e4-a7af7551a507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5235cd-5d25-498d-8e36-7a7c0791f212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5235cd-5d25-498d-8e36-7a7c0791f212.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9251,7 +9251,7 @@
         },
         {
             "id": "05d31f1f-f143-5e7c-a063-0c96c121b7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd90bb-b5d1-47a3-b566-3407db04dd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd90bb-b5d1-47a3-b566-3407db04dd55.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "abd6856d-ff3b-5e0f-93d7-e513de22b445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3309e-2893-4a39-876f-fd68ea057e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3309e-2893-4a39-876f-fd68ea057e22.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "7b3f8b9d-58ae-5b32-9c42-3b674292685b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de46f610-fab8-4819-b86a-d1defed319a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de46f610-fab8-4819-b86a-d1defed319a1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9365,7 +9365,7 @@
         },
         {
             "id": "df6693a0-d5c5-507b-a20a-0065cc1a255a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bae27d4-9de5-4f95-8c56-79afc6cbeb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bae27d4-9de5-4f95-8c56-79afc6cbeb0c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9403,7 +9403,7 @@
         },
         {
             "id": "e0a867a4-b61a-5ca4-bea0-abefbedfce6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45927890-52ef-448c-b302-4192afa27a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45927890-52ef-448c-b302-4192afa27a04.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9441,7 +9441,7 @@
         },
         {
             "id": "7060d213-98cb-5e2e-bc89-e73bb57b0cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b5147e-99b0-47fd-bec2-3baaf7e8ac4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b5147e-99b0-47fd-bec2-3baaf7e8ac4a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "de41ec0f-94cc-5421-9ef9-ad63cb6d1ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d48cef-cfaf-4223-9efb-d76762a896d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d48cef-cfaf-4223-9efb-d76762a896d6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "a61807d9-f69e-5897-a8dc-6371e4bbf479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b082f22f-6c01-4e8c-80ad-6fdae5c3f22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b082f22f-6c01-4e8c-80ad-6fdae5c3f22f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "3e2ad6d5-3b20-531a-8dc6-38a3ba249d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4399a832-4406-4a12-a5e5-81744d02ceec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4399a832-4406-4a12-a5e5-81744d02ceec.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9593,7 +9593,7 @@
         },
         {
             "id": "35d5c337-4eca-5382-b38e-9b5bdf656e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba50901e-a030-4f52-8369-f4c9ca6b9c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba50901e-a030-4f52-8369-f4c9ca6b9c7a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9631,7 +9631,7 @@
         },
         {
             "id": "e8cf2834-e498-5ccf-9897-0a0853f0f1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22965406-d8d7-46ad-992e-7fc0e994698d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22965406-d8d7-46ad-992e-7fc0e994698d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9669,7 +9669,7 @@
         },
         {
             "id": "06ebc501-cc95-542c-bd8a-4fc76465612f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aec0b2-30f2-4f35-a9a3-24d87795d177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aec0b2-30f2-4f35-a9a3-24d87795d177.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "52d6b5fe-6d66-5843-abe6-e0b402b3fbba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174cb9a0-afa3-4f45-b317-238fa9d4f55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174cb9a0-afa3-4f45-b317-238fa9d4f55f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9745,7 +9745,7 @@
         },
         {
             "id": "e8367098-edb8-533f-859a-7b5897e0a0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f8d695-a3e4-4707-9db9-886849ce4c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f8d695-a3e4-4707-9db9-886849ce4c42.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9783,7 +9783,7 @@
         },
         {
             "id": "70f4c47f-bde7-5db9-bd89-a2fe00342b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4bfc1c-20d5-40f4-8863-c69a89872159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4bfc1c-20d5-40f4-8863-c69a89872159.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/NEM.json
+++ b/Assets/Resources/Sets/NEM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "23704f34-3b23-5f9b-b2ef-5cd0647886fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871ad2f3-1dd2-45ea-881d-529aad3b76ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871ad2f3-1dd2-45ea-881d-529aad3b76ec.jpg?1",
             "name": "Angelic Favor",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying Angelic Favor's mana cost.\nPlay Angelic Favor only during combat.\nPut a 4/4 white Angel creature token with flying into play. Remove it from the game at end of turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "80a631b5-a4e3-5f4d-92b9-c3b451d05275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf6f711-c0bc-4e12-b9d0-41581924e13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf6f711-c0bc-4e12-b9d0-41581924e13c.jpg?1",
             "name": "Avenger en-Dal",
             "text": "o2o\nW, oc\nT, Discard a card from your hand: Remove target attacking creature from the game. Its controller gains life equal to its toughness.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "725207e4-8744-5f47-bba6-7fcc36e98070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c25553-6554-4e31-9012-c50da1f0a171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c25553-6554-4e31-9012-c50da1f0a171.jpg?1",
             "name": "Blinding Angel",
             "text": "Flying\nWhenever Blinding Angel deals combat damage to a player, that player skips his or her next combat phase.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "b9f2d4e0-265f-5ef6-a27a-f1b3321944fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1f49bc-d144-466f-8795-c0dae7afdc10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1f49bc-d144-466f-8795-c0dae7afdc10.jpg?1",
             "name": "Chieftain en-Dal",
             "text": "Whenever Chieftain en-Dal attacks, attacking creatures gain first strike until end of turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "c5dda98f-e980-51b9-9abb-53199cfb0a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b224b7-d5f7-4515-beca-523f305ee3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b224b7-d5f7-4515-beca-523f305ee3b8.jpg?1",
             "name": "Defender en-Vec",
             "text": "Fading 4 (This creature comes into play with four fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRemove a fade counter from Defender en-Vec: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "46a08e0a-48f3-57fa-963c-ab61e6bb5137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80032b-daeb-4661-9a66-61abe9d12ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80032b-daeb-4661-9a66-61abe9d12ddd.jpg?1",
             "name": "Defiant Falcon",
             "text": "Flying\no4, oc\nT: Search your library for a Rebel card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "0787e30c-ac7b-51f6-bd21-436fbe62522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0bd267-59ec-41df-b0b7-37f6e6d6b073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0bd267-59ec-41df-b0b7-37f6e6d6b073.jpg?1",
             "name": "Defiant Vanguard",
             "text": "When Defiant Vanguard blocks, at end of combat, destroy it and all creatures it blocked this turn.\no5, oc\nT: Search your library for a Rebel card with converted mana cost 4 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "94de62d7-ec60-5a86-b01c-6f8d6326fcd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0ed1fb-d380-4e3e-a43f-c39660a996e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0ed1fb-d380-4e3e-a43f-c39660a996e9.jpg?1",
             "name": "Fanatical Devotion",
             "text": "Sacrifice a creature: Regenerate target creature.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "2c452b38-f610-5e5a-901a-7e2f21a08b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7451cc-4126-4518-a103-2558fa81323f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7451cc-4126-4518-a103-2558fa81323f.jpg?1",
             "name": "Lashknife",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying Lashknife's mana cost.\nEnchanted creature has first strike.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "d110e66e-0448-5fe4-9b42-1fb49a290318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d76b7e3-6890-4120-8575-732909c8bdff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d76b7e3-6890-4120-8575-732909c8bdff.jpg?1",
             "name": "Lawbringer",
             "text": "oc\nT, Sacrifice Lawbringer: Remove target red creature from the game.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "a8bfd02e-895e-599e-8194-4ee8da28a691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19451993-7a53-4a50-bfca-ddc9cdfbe168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19451993-7a53-4a50-bfca-ddc9cdfbe168.jpg?1",
             "name": "Lightbringer",
             "text": "oc\nT, Sacrifice Lightbringer: Remove target black creature from the game.",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "7479ec2e-9147-5558-b706-551df36aa13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e574e522-2632-4cd4-8545-c582ac3b641f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e574e522-2632-4cd4-8545-c582ac3b641f.jpg?1",
             "name": "Lin Sivvi, Defiant Hero",
             "text": "o\nX, oc\nT: Search your library for a Rebel card with converted mana cost X or less and put that card into play. Then shuffle your library.\no3: Put target Rebel card from your graveyard on the bottom of your library.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "9914f5a4-2bc1-5045-890c-5585475ac795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2190649d-f898-4693-8ccf-80e6709d8496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2190649d-f898-4693-8ccf-80e6709d8496.jpg?1",
             "name": "Netter en-Dal",
             "text": "o\nW, oc\nT, Discard a card from your hand: Target creature can't attack this turn.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "62d606f3-6c3e-56d0-acf8-fecf960b3994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f53ab12-7c16-43b1-b9f9-a5e523cf431b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f53ab12-7c16-43b1-b9f9-a5e523cf431b.jpg?1",
             "name": "Noble Stand",
             "text": "Whenever a creature you control blocks, you gain 2 life.",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "bd1cc7c5-94c5-5fa4-a769-2828e8e86887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adafe5c4-8de0-4d38-919f-de96bc70c21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adafe5c4-8de0-4d38-919f-de96bc70c21b.jpg?1",
             "name": "Off Balance",
             "text": "Target creature can't attack or block this turn.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "97894068-daf3-5c2c-8e6a-382bb08da3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e0ea3e-9826-408d-835b-18dfecaac8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e0ea3e-9826-408d-835b-18dfecaac8af.jpg?1",
             "name": "Oracle's Attendants",
             "text": "oc\nT: All damage that would be dealt to target creature this turn by a source of your choice is dealt to Oracle's Attendants instead.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "743a7bc8-8668-5110-b92e-4fa89799e189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef789e8-e4cc-4f61-bc15-debc2487777f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef789e8-e4cc-4f61-bc15-debc2487777f.jpg?1",
             "name": "Parallax Wave",
             "text": "Fading 5\nRemove a fade counter from Parallax Wave: Remove target creature from the game.\nWhen Parallax Wave leaves play, each player returns to play all cards he or she owns removed from the game with Parallax Wave.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "f7bde977-6308-5ee1-9c8d-249f0caf2795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c921e-1b82-412c-9979-adfdf83440f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c921e-1b82-412c-9979-adfdf83440f7.jpg?1",
             "name": "Seal of Cleansing",
             "text": "Sacrifice Seal of Cleansing: Destroy target artifact or enchantment.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "d53b1477-7158-599a-85ae-492ccd0c602d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3480efc4-1078-4c63-a94c-d00a7507f6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3480efc4-1078-4c63-a94c-d00a7507f6b1.jpg?1",
             "name": "Silkenfist Fighter",
             "text": "Whenever Silkenfist Fighter becomes blocked, untap it.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "8fd0d5a4-0233-5c2a-bd11-448aab0667f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93741517-90ed-46fe-a505-fe6299f188bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93741517-90ed-46fe-a505-fe6299f188bf.jpg?1",
             "name": "Silkenfist Order",
             "text": "Whenever Silkenfist Order becomes blocked, untap it.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "ff6c52a8-d4c8-598c-98b3-1a3ce918acf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132112a0-0fb0-4a80-927d-39d34cf10159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132112a0-0fb0-4a80-927d-39d34cf10159.jpg?1",
             "name": "Sivvi's Ruse",
             "text": "If an opponent controls a mountain and you control a plains, you may play Sivvi's Ruse without paying its mana cost.\nPrevent all damage that would be dealt this turn to creatures you control.",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "b9a38bf6-c596-58e3-94f5-3268ad748e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d15f7b5-5070-4742-a05c-623822d874fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d15f7b5-5070-4742-a05c-623822d874fb.jpg?1",
             "name": "Sivvi's Valor",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying the mana cost of Sivvi's Valor.\nAll damage that would be dealt to target creature this turn is dealt to you instead.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "29677cb9-af46-5b88-b9bc-72d90105f03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5eea354-2d92-4b57-aec7-25260ab7a70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5eea354-2d92-4b57-aec7-25260ab7a70f.jpg?1",
             "name": "Spiritual Asylum",
             "text": "Creatures and lands you control can't be the target of spells or abilities.\nWhen a creature you control attacks, sacrifice Spiritual Asylum.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "bdf28773-fc7d-5c7e-b3e3-c095320e47fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c25c67-4214-4318-a718-7d351e713f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c25c67-4214-4318-a718-7d351e713f80.jpg?1",
             "name": "Topple",
             "text": "Remove target creature with the greatest power from the game. (If two or more creatures are tied for greatest power, target only one of them.)",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "83144a3c-6405-5323-8e07-7164d6962d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40377e3d-77d9-4d86-ac8c-4e27803e48d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40377e3d-77d9-4d86-ac8c-4e27803e48d8.jpg?1",
             "name": "Voice of Truth",
             "text": "Flying, protection from white",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "1ba175b0-328c-5f92-8dfd-0ad81686649c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab061406-38f4-40e7-a9ea-e3cbcaabc127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab061406-38f4-40e7-a9ea-e3cbcaabc127.jpg?1",
             "name": "Accumulated Knowledge",
             "text": "Draw a card, then draw cards equal to the number of Accumulated Knowledge cards in all graveyards.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "eed24d06-bd8d-5395-a801-624e0a55fed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36298f9f-12cc-43bd-adda-ccabd67a9568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36298f9f-12cc-43bd-adda-ccabd67a9568.jpg?1",
             "name": "Aether Barrier",
             "text": "Whenever a player plays a creature spell, that player sacrifices a permanent unless he or she pays o1.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "01d39ab4-ec57-5437-b8fa-e81f0b597d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7363c6f-53a3-4f41-b451-8120bc24f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7363c6f-53a3-4f41-b451-8120bc24f1ee.jpg?1",
             "name": "Air Bladder",
             "text": "Enchanted creature has flying.\nEnchanted creature can block only creatures with flying.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "7c077ac0-6399-5a11-8830-f906f1597aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f97e50-3aeb-4c79-81b1-505a2f32d8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f97e50-3aeb-4c79-81b1-505a2f32d8ac.jpg?1",
             "name": "Cloudskate",
             "text": "Flying\nFading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "8026d95d-4dc9-5c4f-a5fb-988fcd5f0169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03bff25-0d5e-4dcf-8d75-6df846afea3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03bff25-0d5e-4dcf-8d75-6df846afea3b.jpg?1",
             "name": "Daze",
             "text": "You may return an island you control to its owner's hand instead of paying Daze's mana cost.\nCounter target spell unless its controller pays o1.",
             "colours": [
@@ -1012,7 +1012,7 @@
         },
         {
             "id": "9864a7df-53e6-57cc-a1b3-424ba3bace10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b2dcb1-8c3e-434c-865a-196d4d799706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b2dcb1-8c3e-434c-865a-196d4d799706.jpg?1",
             "name": "Dominate",
             "text": "Gain control of target creature with converted mana cost X or less. (This spell's effect doesn't end at end of turn.)",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "cae7cdcd-b1bf-5e89-9a43-620ca06e15cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055b344a-4eb1-4579-ac50-973b18e12fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055b344a-4eb1-4579-ac50-973b18e12fad.jpg?1",
             "name": "Ensnare",
             "text": "You may return two islands you control to their owner's hand instead of paying Ensnare's mana cost.\nTap all creatures.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "47e28523-014f-57b9-9c81-49ad3dfc5b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c549b817-8ad6-44d0-9761-5e4ff9e62c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c549b817-8ad6-44d0-9761-5e4ff9e62c71.jpg?1",
             "name": "Infiltrate",
             "text": "Target creature is unblockable this turn.",
             "colours": [
@@ -1108,7 +1108,7 @@
         },
         {
             "id": "b9fd30af-041c-546a-b2bc-6453158e3bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4d1c74-8b73-445c-b226-349c57a972f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4d1c74-8b73-445c-b226-349c57a972f6.jpg?1",
             "name": "Jolting Merfolk",
             "text": "Fading 4 (This creature comes into play with four fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRemove a fade counter from Jolting Merfolk: Tap target creature.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "01a4d8c8-02cf-5afb-b75c-28519519c160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05609a-f32d-4454-af24-a24452997dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05609a-f32d-4454-af24-a24452997dcb.jpg?1",
             "name": "Oraxid",
             "text": "Protection from red",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "d8ed0dbb-c1e4-52eb-b1c6-fe7efcbe9284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb282bb-d0b8-4822-8197-ff0523549309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb282bb-d0b8-4822-8197-ff0523549309.jpg?1",
             "name": "Pale Moon",
             "text": "Until end of turn, if a player taps a nonbasic land for mana, it produces colorless mana instead of its normal type.",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "17080c20-87cc-552c-91d0-ad9762e04666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe593eb-df3c-43e5-97a6-418f91e87cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe593eb-df3c-43e5-97a6-418f91e87cb3.jpg?1",
             "name": "Parallax Tide",
             "text": "Fading 5\nRemove a fade counter from Parallax Tide: Remove target land from the game.\nWhen Parallax Tide leaves play, each player returns to play all cards he or she owns removed from the game with Parallax Tide.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "4c99b31f-ca81-57e7-a6d8-29a95b7da261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9c84db-cf45-43e1-b38f-8bbf53cf088b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9c84db-cf45-43e1-b38f-8bbf53cf088b.jpg?1",
             "name": "Rising Waters",
             "text": "Lands don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player untaps a land he or she controls.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "c827a8c0-8034-50f1-9ad9-3c4694b402c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86f36d-584d-49b2-8c66-19c262408950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86f36d-584d-49b2-8c66-19c262408950.jpg?1",
             "name": "Rootwater Commando",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "69f255c6-48b5-5eac-a5aa-c700cdc394d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38addef3-1dd7-41a1-9706-3be5c86a58c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38addef3-1dd7-41a1-9706-3be5c86a58c9.jpg?1",
             "name": "Rootwater Thief",
             "text": "oo\nU Rootwater Thief gains flying until end of turn.\nWhenever Rootwater Thief deals combat damage to a player, you may pay o2. If you do, search that player's library for a card and remove that card from the game, then the player shuffles his or her library.",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "9596dfe2-bcf6-5159-bad5-0f7b3460d5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375f65a-6d88-4d3c-a7a7-8c7a5cc5807f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375f65a-6d88-4d3c-a7a7-8c7a5cc5807f.jpg?1",
             "name": "Seahunter",
             "text": "o3, oc\nT: Search your library for a Merfolk card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1377,7 +1377,7 @@
         },
         {
             "id": "2e4e4961-70e8-5187-b784-a4afbcc96f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487becfe-a9b1-4029-a487-2a32561570cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487becfe-a9b1-4029-a487-2a32561570cb.jpg?1",
             "name": "Seal of Removal",
             "text": "Sacrifice Seal of Removal: Return target creature to its owner's hand.",
             "colours": [
@@ -1409,7 +1409,7 @@
         },
         {
             "id": "5886769c-4230-5469-94b0-d623c7d5e33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8647649-5669-46c4-8840-9ff967fabd99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8647649-5669-46c4-8840-9ff967fabd99.jpg?1",
             "name": "Sliptide Serpent",
             "text": "o3oo\nU Return Sliptide Serpent to its owner's hand.",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "44d16998-8c7c-550f-86b5-9d3187067649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b2dadb-4ce3-4f7e-9ca7-79757543f04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b2dadb-4ce3-4f7e-9ca7-79757543f04d.jpg?1",
             "name": "Sneaky Homunculus",
             "text": "Sneaky Homunculus can't block or be blocked by creatures with power 2 or greater.",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "82b128f2-1e62-5fd8-b26c-69acbee43b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6215a5d9-d6d2-4f9f-8a0c-a65d1afd956a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6215a5d9-d6d2-4f9f-8a0c-a65d1afd956a.jpg?1",
             "name": "Stronghold Biologist",
             "text": "o\nUo\nU, oc\nT, Discard a card from your hand: Counter target creature spell.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "0dc24359-ba71-5300-9661-8b4207a34f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3567b4e-6e31-40b0-83ea-4a2a58bd637c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3567b4e-6e31-40b0-83ea-4a2a58bd637c.jpg?1",
             "name": "Stronghold Machinist",
             "text": "o\nUo\nU, oc\nT, Discard a card from your hand: Counter target noncreature spell.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "16419149-50cc-5e25-a935-4d25ee60bc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d672110d-b7c4-4233-9c46-73323be7204d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d672110d-b7c4-4233-9c46-73323be7204d.jpg?1",
             "name": "Stronghold Zeppelin",
             "text": "Flying\nStronghold Zeppelin can block only creatures with flying.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "d5ed69eb-0646-5de6-9bc0-28576c1be75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2741fe4-37fe-427f-ae85-5107991d4eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2741fe4-37fe-427f-ae85-5107991d4eee.jpg?1",
             "name": "Submerge",
             "text": "If an opponent controls a forest and you control an island, you may play Submerge without paying its mana cost.\nPut target creature on top of its owner's library.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "2b678ea3-56d6-57c8-a4ce-613662b32587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e24-1a70-48bd-8946-ff29e12c6f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e24-1a70-48bd-8946-ff29e12c6f3d.jpg?1",
             "name": "Trickster Mage",
             "text": "o\nU, oc\nT, Discard a card from your hand: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "897c2bb7-835b-5f6b-983f-d7d6685bf049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2869efd2-060f-4af3-b0dc-b7dc5e1143b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2869efd2-060f-4af3-b0dc-b7dc5e1143b8.jpg?1",
             "name": "Wandering Eye",
             "text": "Flying\nAll players play with their hands revealed.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "3df91f21-0530-5b79-88e8-b720cacc3b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c87c93-8cf4-4d1a-9bb8-349600da55bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c87c93-8cf4-4d1a-9bb8-349600da55bc.jpg?1",
             "name": "Ascendant Evincar",
             "text": "Flying\nOther black creatures get +1/+1.\nNonblack creatures get -1/-1.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "fd329364-bb24-5c1a-ba5a-7fb80dedeb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebf021-02a1-4a47-b581-c85a7a76cdec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebf021-02a1-4a47-b581-c85a7a76cdec.jpg?1",
             "name": "Battlefield Percher",
             "text": "Flying\nBattlefield Percher can block only creatures with flying.\no1oo\nB Battlefield Percher gets +1/+1 until end of turn.",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "8e3897ca-c61a-5678-b6c8-934f35507dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95dcb2e-8945-47dd-ad40-b5bdcc3ea742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95dcb2e-8945-47dd-ad40-b5bdcc3ea742.jpg?1",
             "name": "Belbe's Percher",
             "text": "Flying\nBelbe's Percher can block only creatures with flying.",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "3fe3d4ad-5a17-5f90-a524-1050c354742c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6fa78-3422-4ace-88ab-e985c558cba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6fa78-3422-4ace-88ab-e985c558cba7.jpg?1",
             "name": "Carrion Wall",
             "text": "(Walls can't attack.)\no1oo\nB Regenerate Carrion Wall.",
             "colours": [
@@ -1823,7 +1823,7 @@
         },
         {
             "id": "72ce993e-edd1-5b9b-9416-704b67f15ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794657cd-b292-41d7-a4a6-3f3dd20dc07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794657cd-b292-41d7-a4a6-3f3dd20dc07a.jpg?1",
             "name": "Dark Triumph",
             "text": "If you control a swamp, you may sacrifice a creature instead of paying Dark Triumph's mana cost.\nCreatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "a6eee561-c910-54c4-997a-0a107fe3ca71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223e583-8ef6-4d93-8ed0-3ccf4488f166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223e583-8ef6-4d93-8ed0-3ccf4488f166.jpg?1",
             "name": "Death Pit Offering",
             "text": "As Death Pit Offering comes into play, sacrifice all creatures you control.\nCreatures you control get +2/+2.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "8498c32f-d005-55b3-b97f-0efe8c580c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be981eef-9dd2-4233-82c9-03f9f2e82c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be981eef-9dd2-4233-82c9-03f9f2e82c59.jpg?1",
             "name": "Divining Witch",
             "text": "o1o\nB, oc\nT, Discard a card from your hand: Name a card. Remove the top six cards of your library from the game. Reveal cards from the top of your library until you reveal the named card, then put that card into your hand. Remove all other cards revealed this way from the game.",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "81d8bc41-0433-55bf-a345-2dc8a07e802d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05f5d93-50d1-4aa6-af05-383a6808345b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05f5d93-50d1-4aa6-af05-383a6808345b.jpg?1",
             "name": "Massacre",
             "text": "If an opponent controls a plains and you control a swamp, you may play Massacre without paying its mana cost.\nAll creatures get -2/-2 until end of turn.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "8461f912-4ada-55f4-9cab-3089cfb5fbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bece38b-e09e-4666-95b6-5e5b05867cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bece38b-e09e-4666-95b6-5e5b05867cd5.jpg?1",
             "name": "Mind Slash",
             "text": "o\nB, Sacrifice a creature: Look at target opponent's hand and choose a card from it. That player discards that card. Play this ability only if you could play a sorcery.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "7e759523-23c7-56fe-88d6-98a3be7faa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d91df-008b-48f2-a84f-550702fbcdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d91df-008b-48f2-a84f-550702fbcdb3.jpg?1",
             "name": "Mind Swords",
             "text": "If you control a swamp, you may sacrifice a creature instead of paying Mind Swords's mana cost.\nEach player removes two cards in his or her hand from the game.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "645c4cf6-5bf8-52aa-8d33-bb244747a1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13a3ed0-aa57-4082-b6b0-b1078c93c0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13a3ed0-aa57-4082-b6b0-b1078c93c0b2.jpg?1",
             "name": "Murderous Betrayal",
             "text": "o\nBo\nB, Pay half your life rounded up: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "dc8b1c59-a77f-5a41-b2e7-0b3a7bb073d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154789ac-bbea-467b-9655-76f378a53f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154789ac-bbea-467b-9655-76f378a53f40.jpg?1",
             "name": "Parallax Dementia",
             "text": "Fading 1 (This enchantment comes into play with one fade counter on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nEnchanted creature gets +3/+2.\nWhen Parallax Dementia leaves play, destroy enchanted creature. That creature can't be regenerated.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "5c0773b3-19df-5468-8770-688459373c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862c50c7-0840-46e0-a653-5b660fdfd4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862c50c7-0840-46e0-a653-5b660fdfd4bd.jpg?1",
             "name": "Parallax Nexus",
             "text": "Fading 5\nRemove a fade counter from Parallax Nexus: Target opponent removes a card in his or her hand from the game. Play this ability only if you could play a sorcery.\nWhen Parallax Nexus leaves play, each player returns to his or her hand all cards he or she owns removed from the game with Parallax Nexus.",
             "colours": [
@@ -2116,7 +2116,7 @@
         },
         {
             "id": "5764200e-7d6c-5bc3-b93b-8a95be21f6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeef7f3-5b87-440d-a851-95ae2bdb840d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeef7f3-5b87-440d-a851-95ae2bdb840d.jpg?1",
             "name": "Phyrexian Driver",
             "text": "When Phyrexian Driver comes into play, all other Mercenaries get +1/+1 until end of turn.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "714bd855-78c5-5fbf-ad6e-13fc520261d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26f79b5-780a-4cbb-b49d-01673a411d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26f79b5-780a-4cbb-b49d-01673a411d1f.jpg?1",
             "name": "Phyrexian Prowler",
             "text": "Fading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRemove a fade counter from Phyrexian Prowler: Phyrexian Prowler gets +1/+1 until end of turn.",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "c71ec478-330c-5982-840d-53a9388448ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3614c2-39b4-4f67-adab-373dcb9e4553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3614c2-39b4-4f67-adab-373dcb9e4553.jpg?1",
             "name": "Plague Witch",
             "text": "o\nB, oc\nT, Discard a card from your hand: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "b3f55762-f258-5983-8482-31c09df7ea72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3597c3-3053-49f8-ab7e-a774e2fb082f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3597c3-3053-49f8-ab7e-a774e2fb082f.jpg?1",
             "name": "Rathi Assassin",
             "text": "o1o\nBo\nB, oc\nT: Destroy target tapped nonblack creature.\no3, oc\nT: Search your library for a Mercenary card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "3040688f-300f-5edb-a54c-467f74732bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca1184-ade0-4d6d-87f9-ad17f37679b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca1184-ade0-4d6d-87f9-ad17f37679b3.jpg?1",
             "name": "Rathi Fiend",
             "text": "When Rathi Fiend comes into play, each player loses 3 life.\no3, oc\nT: Search your library for a Mercenary card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "11055170-4ad5-53f1-91d7-c5b1e077c18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc59fa5-144f-49e6-b6bd-2ba6d3f2eff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc59fa5-144f-49e6-b6bd-2ba6d3f2eff2.jpg?1",
             "name": "Rathi Intimidator",
             "text": "Rathi Intimidator can't be blocked except by artifact creatures and black creatures.\no2, oc\nT: Search your library for a Mercenary card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "814c11c7-b051-5f84-80ee-2bc54c59af3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396d9f58-a4ca-4197-94be-0f115427224e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396d9f58-a4ca-4197-94be-0f115427224e.jpg?1",
             "name": "Seal of Doom",
             "text": "Sacrifice Seal of Doom: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "fe0a1aea-3ef9-5f47-9ad7-0c4a0309af96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9bb47-3855-425d-924c-09dbde74735b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9bb47-3855-425d-924c-09dbde74735b.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "d2983259-5872-5415-b079-0c633c3e53aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5535d14a-7126-4a94-96a0-e17ad5c72070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5535d14a-7126-4a94-96a0-e17ad5c72070.jpg?1",
             "name": "Spiteful Bully",
             "text": "At the beginning of your upkeep, Spiteful Bully deals 3 damage to target creature you control.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "173587cb-0d00-561a-a4f2-f2df6605c550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa5472-5341-47cd-884e-fe2fcca12c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa5472-5341-47cd-884e-fe2fcca12c0d.jpg?1",
             "name": "Stronghold Discipline",
             "text": "Each player loses 1 life for each creature he or she controls.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "caa3c5e4-680c-52a9-9b60-22d71e1a9d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaff6a0-7831-45db-a50f-881c6cb7ce49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaff6a0-7831-45db-a50f-881c6cb7ce49.jpg?1",
             "name": "Vicious Hunger",
             "text": "Vicious Hunger deals 2 damage to target creature. You gain 2 life.",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "698f5b94-4a21-5b1a-9b9f-9f96c60049d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdd66e-9ca1-456e-a61c-7c96cf6f7c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdd66e-9ca1-456e-a61c-7c96cf6f7c56.jpg?1",
             "name": "Volrath the Fallen",
             "text": "o1o\nB, Discard a creature card from your hand: Volrath the Fallen gets +X/+X until end of turn, where X is the discarded card's converted mana cost.",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "0cd5be94-3bcf-560a-982c-c911323e0557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de57c84-38b9-4606-b934-0ab270496582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de57c84-38b9-4606-b934-0ab270496582.jpg?1",
             "name": "Ancient Hydra",
             "text": "Fading 5 (This creature comes into play with five fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\no1, Remove a fade counter from Ancient Hydra: Ancient Hydra deals 1 damage to target creature or player.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "d37e9370-ab98-5772-9381-7e28f0318038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982dab-4c27-45b3-9740-38fec3df7226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982dab-4c27-45b3-9740-38fec3df7226.jpg?1",
             "name": "Arc Mage",
             "text": "o2o\nR, oc\nT, Discard a card from your hand: Arc Mage deals 2 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "fb2ac461-6aa5-5504-b6a1-819e98c73595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6e1de6-e7e0-4037-896a-f80c54b8ef5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6e1de6-e7e0-4037-896a-f80c54b8ef5c.jpg?1",
             "name": "Bola Warrior",
             "text": "o\nR, oc\nT, Discard a card from your hand: Target creature can't block this turn.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "9de780a3-afde-548f-9c19-ed40d1777456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebfc91c-d764-4e63-a428-82704f8bf1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebfc91c-d764-4e63-a428-82704f8bf1fd.jpg?1",
             "name": "Downhill Charge",
             "text": "You may sacrifice a mountain instead of paying Downhill Charge's mana cost.\nTarget creature gets +X/+0 until end of turn, where X is the number of mountains you control.",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "f0430846-3af3-5f81-916b-f329bc29d789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7717eeb9-c457-4a65-93a0-e91c7f6a1970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7717eeb9-c457-4a65-93a0-e91c7f6a1970.jpg?1",
             "name": "Flame Rift",
             "text": "Flame Rift deals 4 damage to each player.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "670114b1-b24d-5cd8-8159-988204a6706b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93f0066-1ff0-4e52-9959-9eb0def60957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93f0066-1ff0-4e52-9959-9eb0def60957.jpg?1",
             "name": "Flowstone Crusher",
             "text": "oo\nR Flowstone Crusher gets +1/-1 until end of turn.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "0ac417aa-a705-55b9-933c-741af737706d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644ab8-3cc3-413d-a918-44fc636087ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644ab8-3cc3-413d-a918-44fc636087ae.jpg?1",
             "name": "Flowstone Overseer",
             "text": "o\nRoo\nR Target creature gets +1/-1 until end of turn.",
             "colours": [
@@ -2774,7 +2774,7 @@
         },
         {
             "id": "6ad44289-0ed0-50e5-9854-e7b6f60027f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b02e1-0a20-4247-ae2a-056c5356f168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b02e1-0a20-4247-ae2a-056c5356f168.jpg?1",
             "name": "Flowstone Slide",
             "text": "All creatures get +X/-X until end of turn.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "ff631882-6133-59e9-b87e-3e013110c472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1203053-0829-4f46-a361-62cb9cd17280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1203053-0829-4f46-a361-62cb9cd17280.jpg?1",
             "name": "Flowstone Strike",
             "text": "Target creature gets +1/-1 and gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "83760a97-6ef6-5d31-adb7-151ba5e4399b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc450922-0bbf-46c4-9955-79f4d41ee488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc450922-0bbf-46c4-9955-79f4d41ee488.jpg?1",
             "name": "Flowstone Surge",
             "text": "Creatures you control get +1/-1.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "a6da3092-79a9-5a07-9477-bc786253e8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89844c2f-f0a4-41c6-ad8c-d559fcaec85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89844c2f-f0a4-41c6-ad8c-d559fcaec85c.jpg?1",
             "name": "Flowstone Wall",
             "text": "(Walls can't attack.)\noo\nR Flowstone Wall gets +1/-1 until end of turn.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "5d9db8dd-bafb-5bb3-96d5-623340e5ac36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27fd65a-5631-491f-b158-45012832ccf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27fd65a-5631-491f-b158-45012832ccf1.jpg?1",
             "name": "Laccolith Grunt",
             "text": "Whenever Laccolith Grunt becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Grunt deals no combat damage this turn.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "fc3dfbf6-a346-548a-8f5e-07b17ff0f796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb92039-03fd-4aee-be74-96997be629d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb92039-03fd-4aee-be74-96997be629d6.jpg?1",
             "name": "Laccolith Rig",
             "text": "Whenever enchanted creature becomes blocked, you may have it deal damage equal to its power to target creature. If you do, enchanted creature deals no combat damage this turn.",
             "colours": [
@@ -2972,7 +2972,7 @@
         },
         {
             "id": "8216f307-a7cb-57c7-a7d3-74fbd41cee0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36bc466-0f74-46fd-add2-c1cf3b3fe46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36bc466-0f74-46fd-add2-c1cf3b3fe46b.jpg?1",
             "name": "Laccolith Titan",
             "text": "Whenever Laccolith Titan becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Titan deals no combat damage this turn.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "f57c6709-e940-5ff5-a801-6dc176b89e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b103f-482b-47d5-84a2-3621ba23bd20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b103f-482b-47d5-84a2-3621ba23bd20.jpg?1",
             "name": "Laccolith Warrior",
             "text": "Whenever Laccolith Warrior becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Warrior deals no combat damage this turn.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "65016745-2376-5229-af91-042290ee396c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb5b9e-320f-40de-8668-ee0c08f63ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb5b9e-320f-40de-8668-ee0c08f63ec1.jpg?1",
             "name": "Laccolith Whelp",
             "text": "Whenever Laccolith Whelp becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Whelp deals no combat damage this turn.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "5c15cebc-1d46-5793-ab06-209394977636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a33b3-7833-48e5-88c3-849a5771ef6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a33b3-7833-48e5-88c3-849a5771ef6e.jpg?1",
             "name": "Mana Cache",
             "text": "At the end of each player's turn, put a charge counter on Mana Cache for each untapped land that player controls.\nRemove a charge counter from Mana Cache: Add one colorless mana to your mana pool. Any player may play this ability but only during his or her turn before the end phase.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "4bc9158f-95a4-5f4e-bb45-868d892a2279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f246e128-0a43-478a-a232-51020fab76d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f246e128-0a43-478a-a232-51020fab76d5.jpg?1",
             "name": "Mogg Alarm",
             "text": "You may sacrifice two mountains instead of paying Mogg Alarm's mana cost.\nPut two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "91c9b4f8-8b06-5402-a08a-790a65a6281d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403aa48c-b684-4c54-8863-460958055a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403aa48c-b684-4c54-8863-460958055a1f.jpg?1",
             "name": "Mogg Salvage",
             "text": "If an opponent controls an island and you control a mountain, you may play Mogg Salvage without paying its mana cost.\nDestroy target artifact.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "4ba12d75-018b-53ad-bdbf-f5270fda19b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8edaf6-d46e-4efb-8bc0-ec11e06eb499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8edaf6-d46e-4efb-8bc0-ec11e06eb499.jpg?1",
             "name": "Mogg Toady",
             "text": "Mogg Toady can't attack unless you control more creatures than defending player.\nMogg Toady can't block unless you control more creatures than attacking player.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "5769b6ca-dabf-5148-b693-7f47fba222da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba582d7-1dce-4664-8bd9-6b419596788c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba582d7-1dce-4664-8bd9-6b419596788c.jpg?1",
             "name": "Moggcatcher",
             "text": "o3, oc\nT: Search your library for a Goblin card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "a59ca6cf-e07f-5018-b5b4-533707f51784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db53c1fb-3641-44a3-b0b4-b7b2ba993646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db53c1fb-3641-44a3-b0b4-b7b2ba993646.jpg?1",
             "name": "Rupture",
             "text": "Sacrifice a creature. Rupture deals damage equal to that creature's power to each creature without flying and each player.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "dde7dd23-1843-5f26-bfdf-52eaf70a88e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eaf1f6-4bdc-4669-9a15-50b65e016ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eaf1f6-4bdc-4669-9a15-50b65e016ccf.jpg?1",
             "name": "Seal of Fire",
             "text": "Sacrifice Seal of Fire: Seal of Fire deals 2 damage to target creature or player.",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "4fa85078-1bae-50b7-9000-a3363857fb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce46919-d312-490c-8942-39fbb2d375bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce46919-d312-490c-8942-39fbb2d375bf.jpg?1",
             "name": "Shrieking Mogg",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhen Shrieking Mogg comes into play, tap all other creatures.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "7af43200-c591-59a6-82f8-76bd92347a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18050e-9aad-471e-a6ae-66e5fa2bbb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18050e-9aad-471e-a6ae-66e5fa2bbb6f.jpg?1",
             "name": "Stronghold Gambit",
             "text": "Each player chooses a card in his or her hand. Then each player reveals his or her chosen card. The owner of the creature card revealed this way with the lowest converted mana cost puts that card into play. If two or more creature cards are tied for lowest cost, those cards are put into play.",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "e3577379-9337-5c2e-9252-fdff704de0c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff4e7d-fa50-48d2-8ab6-6b86e3a05e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff4e7d-fa50-48d2-8ab6-6b86e3a05e86.jpg?1",
             "name": "Animate Land",
             "text": "Until end of turn, target land is a 3/3 creature that's still a land.",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "275734d9-9b06-5108-af6a-70b995cfe2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db5d6c2-b11f-442a-b172-c0c99c9bec07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db5d6c2-b11f-442a-b172-c0c99c9bec07.jpg?1",
             "name": "Blastoderm",
             "text": "Fading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nBlastoderm can't be the target of spells or abilities.",
             "colours": [
@@ -3436,7 +3436,7 @@
         },
         {
             "id": "3fc91c27-ea86-5eee-a040-e790d5438239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341a70be-2dbf-4365-9c7a-e52cb62a74fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341a70be-2dbf-4365-9c7a-e52cb62a74fa.jpg?1",
             "name": "Coiling Woodworm",
             "text": "Coiling Woodworm's power is equal to the number of forests in play.",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "fdfe3488-ad1f-5069-8408-317742d25d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133f9e4f-2b1b-4a24-ad19-285a2c5845b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133f9e4f-2b1b-4a24-ad19-285a2c5845b5.jpg?1",
             "name": "Fog Patch",
             "text": "Play Fog Patch only during the declare blockers step.\nAttacking creatures become blocked. (This spell works on unblockable creatures.)",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "1db2c436-6f3c-51d9-a4f6-12546462def0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b29329-b9a3-4d59-b0f8-2abc67337760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b29329-b9a3-4d59-b0f8-2abc67337760.jpg?1",
             "name": "Harvest Mage",
             "text": "o\nG, oc\nT, Discard a card from your hand: Until end of turn, if you tap a land for mana, it produces one mana of any color instead of its normal type and amount.",
             "colours": [
@@ -3538,7 +3538,7 @@
         },
         {
             "id": "4b794aaf-515a-51e4-8420-030d0a447669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe0201-3df3-4d0c-8aa4-8f35f12c322c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe0201-3df3-4d0c-8aa4-8f35f12c322c.jpg?1",
             "name": "Mossdog",
             "text": "Whenever Mossdog becomes the target of a spell or ability an opponent controls, put a +1/+1 counter on Mossdog.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "f65c24fc-87fe-5edc-b7e9-fa52ffe68081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da697da-7026-4dea-b494-8314d789160f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da697da-7026-4dea-b494-8314d789160f.jpg?1",
             "name": "Nesting Wurm",
             "text": "Trample\nWhen Nesting Wurm comes into play, you may search your library for up to three Nesting Wurm cards, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "198e1e3b-a435-55c3-8708-eacefbd1058c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230c7926-9a4b-4ead-b4c8-889f84210545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230c7926-9a4b-4ead-b4c8-889f84210545.jpg?1",
             "name": "Overlaid Terrain",
             "text": "As Overlaid Terrain comes into play, sacrifice all lands you control.\nLands you control have \"oc\nT: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "9c9c6258-e08d-547c-aa9e-7f886072f960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c46caa8-efc0-4b72-b122-61e5d86a5b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c46caa8-efc0-4b72-b122-61e5d86a5b86.jpg?1",
             "name": "Pack Hunt",
             "text": "Search your library for up to three copies of target creature, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "523cd7f8-71bb-51fc-b953-0fb5658d83f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e24850-bd9b-40ab-878f-b8a554da1956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e24850-bd9b-40ab-878f-b8a554da1956.jpg?1",
             "name": "Refreshing Rain",
             "text": "If an opponent controls a swamp and you control a forest, you may play Refreshing Rain without paying its mana cost.\nTarget player gains 6 life.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "a3bbfada-e787-5e2c-9521-db69cc52b38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82d3432-2167-4a65-8221-cb7b338e60d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82d3432-2167-4a65-8221-cb7b338e60d0.jpg?1",
             "name": "Reverent Silence",
             "text": "If you control a forest, you may have each other player gain 6 life instead of paying Reverent Silence's mana cost.\nDestroy all enchantments.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "eba08829-de4a-5fe0-9dc6-649d60a2cb9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58388a29-b2a6-4d16-b872-f198563721d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58388a29-b2a6-4d16-b872-f198563721d9.jpg?1",
             "name": "Rhox",
             "text": "You may have Rhox deal combat damage to defending player as though it weren't blocked.\no2oo\nG Regenerate Rhox.",
             "colours": [
@@ -3770,7 +3770,7 @@
         },
         {
             "id": "89c4037f-6c13-51c6-9af4-4a59d5e7c677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3a293d-08d8-49e4-b0fa-91afa0a5591d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3a293d-08d8-49e4-b0fa-91afa0a5591d.jpg?1",
             "name": "Saproling Burst",
             "text": "Fading 7\nRemove a fade counter from Saproling Burst: Put a green Saproling creature token into play. It has \"This creature's power and toughness are each equal to the number of fade counters on Saproling Burst.\"\nWhen Saproling Burst leaves play, destroy all tokens put into play with Saproling Burst. They can't be regenerated.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "9f4df2c5-1b90-5ef1-81d8-bd8d81faf4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f50072b-aedd-4074-b1f7-f9ce477c26c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f50072b-aedd-4074-b1f7-f9ce477c26c2.jpg?1",
             "name": "Saproling Cluster",
             "text": "o1, Discard a card from your hand: Put a 1/1 green Saproling creature token into play. Any player may play this ability.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "6ec2c69b-9973-51c1-977b-8440e25b9d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57650f78-3bf0-485a-bba8-7e7e14e47508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57650f78-3bf0-485a-bba8-7e7e14e47508.jpg?1",
             "name": "Seal of Strength",
             "text": "Sacrifice Seal of Strength: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "348eba42-8e28-548a-b927-fbe79fd438b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c01d17e-45a2-4b6f-aaa5-2af9c8f26181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c01d17e-45a2-4b6f-aaa5-2af9c8f26181.jpg?1",
             "name": "Skyshroud Behemoth",
             "text": "Fading 2 (This creature comes into play with two fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nSkyshroud Behemoth comes into play tapped.",
             "colours": [
@@ -3900,7 +3900,7 @@
         },
         {
             "id": "49f7971f-d24c-5990-93a9-fa6dbaadf218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3e09ff-c917-4c0c-8ddb-e152b4b0b82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3e09ff-c917-4c0c-8ddb-e152b4b0b82c.jpg?1",
             "name": "Skyshroud Claim",
             "text": "Search your library for up to two forest cards and put them into play. Then shuffle your library.",
             "colours": [
@@ -3932,7 +3932,7 @@
         },
         {
             "id": "039835cd-d9c2-5055-8f05-a2e67c71df5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558c4f5-a716-4e46-9234-5f84f1bd57aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558c4f5-a716-4e46-9234-5f84f1bd57aa.jpg?1",
             "name": "Skyshroud Cutter",
             "text": "If you control a forest, you may have each other player gain 5 life instead of paying Skyshroud Cutter's mana cost.",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "5a3cc916-859d-5e59-9e46-12ca4a94bc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4e44e-656e-4294-a53b-1f7aa96fab31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4e44e-656e-4294-a53b-1f7aa96fab31.jpg?1",
             "name": "Skyshroud Poacher",
             "text": "o3, oc\nT: Search your library for an Elf card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "05dabfa2-2b17-5a27-8438-9d2660c3d355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410896ab-d3dc-478c-bfd1-c0cad5b1180a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410896ab-d3dc-478c-bfd1-c0cad5b1180a.jpg?1",
             "name": "Skyshroud Ridgeback",
             "text": "Fading 2 (This creature comes into play with two fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "d50135e5-8043-5b34-b7dd-a2fb9bc62616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ab55f-f677-45c8-bd32-56788a776b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ab55f-f677-45c8-bd32-56788a776b33.jpg?1",
             "name": "Skyshroud Sentinel",
             "text": "When Skyshroud Sentinel comes into play, you may search your library for up to three Skyshroud Sentinel cards, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "246a4001-264b-5275-af52-d3a37e488aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a295758a-ee46-4ed0-8539-67501a37010d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a295758a-ee46-4ed0-8539-67501a37010d.jpg?1",
             "name": "Stampede Driver",
             "text": "o1o\nG, oc\nT, Discard a card from your hand: Creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "19758357-86e1-5526-b683-d05a34615bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d85032-26e9-44af-ab52-56d9c24e337d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d85032-26e9-44af-ab52-56d9c24e337d.jpg?1",
             "name": "Treetop Bracers",
             "text": "Enchanted creature gets +1/+1 and can be blocked only by creatures with flying.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "7195e93c-ebb1-5d53-a9e4-fe13695acf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d927fdb-11c0-42b6-95d4-7af051e45213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d927fdb-11c0-42b6-95d4-7af051e45213.jpg?1",
             "name": "Wild Mammoth",
             "text": "At the beginning of your upkeep, if a player controls more creatures than any other, that player gains control of Wild Mammoth.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "8a3b9667-805e-5bf8-a87a-906c85089dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5126b782-d74c-40ca-a9b2-a6c78f94d138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5126b782-d74c-40ca-a9b2-a6c78f94d138.jpg?1",
             "name": "Woodripper",
             "text": "Fading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\no1, Remove a fade counter from Woodripper: Destroy target artifact.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "8e5bda55-b2d8-52a9-bb13-92c40225eade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0052158b-58d1-4416-a7ce-7c6a7595263c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0052158b-58d1-4416-a7ce-7c6a7595263c.jpg?1",
             "name": "Belbe's Armor",
             "text": "o\nX, oc\nT: Target creature gets -X/+X until end of turn.",
             "colours": [],
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "4a4a6d47-cdd9-548a-8c1d-c48e33799778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4eeea1-693e-475c-a209-8a0464df8081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4eeea1-693e-475c-a209-8a0464df8081.jpg?1",
             "name": "Belbe's Portal",
             "text": "As Belbe's Portal comes into play, choose a creature type.\no3, oc\nT: Put a creature card of the chosen type from your hand into play.",
             "colours": [],
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "e5c12057-dac7-5f1d-b8f2-5c437a561414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb3c7af-74e1-4072-953b-b3e9ccd8aa03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb3c7af-74e1-4072-953b-b3e9ccd8aa03.jpg?1",
             "name": "Complex Automaton",
             "text": "At the beginning of your upkeep, if you control seven or more permanents, return Complex Automaton to its owner's hand.",
             "colours": [],
@@ -4293,7 +4293,7 @@
         },
         {
             "id": "3aab0863-c8cd-5a9b-ae36-85e0576e094c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c258aa1-cd9f-45e9-b478-d689b78850cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c258aa1-cd9f-45e9-b478-d689b78850cd.jpg?1",
             "name": "Eye of Yawgmoth",
             "text": "o3, oc\nT, Sacrifice a creature: Reveal cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and remove the rest from the game.",
             "colours": [],
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "aac8774b-c1d8-5257-9f58-7cc946837345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e62aa7e-d9f9-42d4-9eed-5f51f88047c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e62aa7e-d9f9-42d4-9eed-5f51f88047c6.jpg?1",
             "name": "Flint Golem",
             "text": "Whenever Flint Golem becomes blocked, defending player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -4352,7 +4352,7 @@
         },
         {
             "id": "52f9692d-7ad8-54a4-8711-482b0d3bf9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1160e476-8a2b-4b90-b4db-f386a80ab067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1160e476-8a2b-4b90-b4db-f386a80ab067.jpg?1",
             "name": "Flowstone Armor",
             "text": "You may choose not to untap Flowstone Armor during your untap step.\no3, oc\nT: Target creature gets +1/-1 as long as Flowstone Armor remains tapped.",
             "colours": [],
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "5432d274-95df-551c-b05b-c2b51c3bcff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf016ec-2654-4c3e-8e2e-6c70c4604d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf016ec-2654-4c3e-8e2e-6c70c4604d28.jpg?1",
             "name": "Flowstone Thopter",
             "text": "o1: Flowstone Thopter gets +1/-1 and gains flying until end of turn.",
             "colours": [],
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "c08b13d9-ef28-5fb7-9d43-dbb7c9fe0aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94cfd63-7f2b-4c0a-8dcb-f22cf83e1e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94cfd63-7f2b-4c0a-8dcb-f22cf83e1e27.jpg?1",
             "name": "Kill Switch",
             "text": "o2, oc\nT: Tap all other artifacts. They don't untap during their controllers' untap steps as long as Kill Switch remains tapped.",
             "colours": [],
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "c8f4aaa6-b47c-52de-a34b-79dc90344e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758617c-f0e4-43d5-8fb4-e33eb2c5b99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758617c-f0e4-43d5-8fb4-e33eb2c5b99f.jpg?1",
             "name": "Parallax Inhibitor",
             "text": "o1, oc\nT, Sacrifice Parallax Inhibitor: Put a fade counter on each permanent with fading you control.",
             "colours": [],
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "be2366dc-b407-5cc4-8a0d-7c729a9fdc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28927927-3974-48c3-81c2-518089a10003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28927927-3974-48c3-81c2-518089a10003.jpg?1",
             "name": "Predator, Flagship",
             "text": "o2: Target creature gains flying until end of turn.\no5, oc\nT: Destroy target creature with flying.",
             "colours": [],
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "e8f2f520-ca11-5548-a222-40be0ec07f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f82f2e-a6db-491b-b253-82c34cd6c940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f82f2e-a6db-491b-b253-82c34cd6c940.jpg?1",
             "name": "Rackling",
             "text": "At the beginning of each opponent's upkeep, Rackling deals X damage to that player, where X is the number of cards in his or her hand fewer than three.",
             "colours": [],
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "a960ebe2-624b-55f6-8a02-ca3e8d90fc7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97f86ce-4758-4ae3-af29-b08a4d771652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97f86ce-4758-4ae3-af29-b08a4d771652.jpg?1",
             "name": "Rejuvenation Chamber",
             "text": "Fading 2 (This artifact comes into play with two fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\noc\nT: You gain 2 life.",
             "colours": [],
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "609ed521-2f76-52dc-9762-183502a7fc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2605448-8e0d-492b-a635-468923c64625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2605448-8e0d-492b-a635-468923c64625.jpg?1",
             "name": "Rusting Golem",
             "text": "Fading 5 (This creature comes into play with five fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRusting Golem's power and toughness are each equal to the number of fade counters on it.",
             "colours": [],
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "70fa0a47-3e0d-5a41-85df-04599f6c9c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad62f313-8a8a-4ffa-ada2-b12b76288729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad62f313-8a8a-4ffa-ada2-b12b76288729.jpg?1",
             "name": "Tangle Wire",
             "text": "Fading 4 (This artifact comes into play with four fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nAt the beginning of each player's upkeep, that player taps an untapped artifact, creature, or land he or she controls for each fade counter on Tangle Wire.",
             "colours": [],
@@ -4616,7 +4616,7 @@
         },
         {
             "id": "b70624a4-29e4-5265-8cb8-635f7d2ed07a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eb86c5-d6fe-4dde-ad07-c3109b3a1611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eb86c5-d6fe-4dde-ad07-c3109b3a1611.jpg?1",
             "name": "Viseling",
             "text": "At the beginning of each opponent's upkeep, Viseling deals X damage to that player, where X is the number of cards in his or her hand minus four.",
             "colours": [],
@@ -4648,7 +4648,7 @@
         },
         {
             "id": "4a4794e0-9c60-5bf5-be66-e4f582bd8b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5529ca-5c20-4dfd-8595-96d6dfa6debe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5529ca-5c20-4dfd-8595-96d6dfa6debe.jpg?1",
             "name": "Kor Haven",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1o\nW, oc\nT: Prevent all combat damage that would be dealt by target attacking creature this turn.",
             "colours": [],
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "86ff84df-069b-5092-8b16-da75cb36b64c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42681dce-5c63-4e56-955e-39f085ea6ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42681dce-5c63-4e56-955e-39f085ea6ae9.jpg?1",
             "name": "Rath's Edge",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no4, oc\nT, Sacrifice a land: Rath's Edge deals 1 damage to target creature or player.",
             "colours": [],
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "632f69d7-fab6-5163-b186-060b97bfac1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe66a2-8e70-414f-bedb-8f1f85f1d2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe66a2-8e70-414f-bedb-8f1f85f1d2d9.jpg?1",
             "name": "Terrain Generator",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Put a basic land card from your hand into play tapped.",
             "colours": [],

--- a/Assets/Resources/Sets/NEO.json
+++ b/Assets/Resources/Sets/NEO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8791a7d2-1849-540f-8061-202341471d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1ed43-ee6c-43a2-ba94-5bf71c63e070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1ed43-ee6c-43a2-ba94-5bf71c63e070.jpg?1",
             "name": "Ancestral Katana",
             "text": "Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+1.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "df076713-0b94-56fd-91cf-4e588ce5641c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2c4063-7322-4041-a870-b95598a03e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2c4063-7322-4041-a870-b95598a03e29.jpg?1",
             "name": "Ao, the Dawn Sky",
             "text": "Flying, vigilance\nWhen Ao, the Dawn Sky dies, choose one \u2014\n\u2022 Look at the top seven cards of your library. Put any number of nonland permanent cards with total mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\n\u2022 Put two +1/+1 counters on each permanent you control that's a creature or Vehicle.",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "c203c94d-110b-597c-85f7-88c514b38c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b8946b-6604-49ca-98db-18a540b1b4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b8946b-6604-49ca-98db-18a540b1b4e5.jpg?1",
             "name": "Banishing Slash",
             "text": "Destroy up to one target artifact, enchantment, or tapped creature. Then if you control an artifact and an enchantment, create a 2/2 white Samurai creature token with vigilance.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "c0341c9b-5572-5143-86e2-1034cc8cc1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg?1",
             "name": "Befriending the Moths // Imperial Moth",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Target creature you control gets +1/+1 and gains flying until end of turn.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "e370560e-3cf4-5dd2-a653-04547f1e91e3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg?1",
             "name": "Befriending the Moths // Imperial Moth",
             "text": "Flying",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "637a1f88-8896-56da-95d8-0bc1725a253e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8419d27-8c6e-4f38-98b4-60dd9a910c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8419d27-8c6e-4f38-98b4-60dd9a910c43.jpg?1",
             "name": "Blade-Blizzard Kitsune",
             "text": "Ninjutsu {3}{W} ({3}{W}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nDouble strike",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "a6f17516-a7f3-5a0c-bcab-326cb01aa4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdfad1f-d316-4023-9c79-8c24f1cd31d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdfad1f-d316-4023-9c79-8c24f1cd31d0.jpg?1",
             "name": "Born to Drive",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +1/+1 for each creature and/or Vehicle you control.\nChannel \u2014 {2}{W}, Discard Born to Drive: Create two 1/1 colorless Pilot creature tokens with \"This creature crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "a938cd74-da65-5c56-a552-fbd66f4e48e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f7a506-0aa1-4c2d-b322-e0e9179d05fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f7a506-0aa1-4c2d-b322-e0e9179d05fb.jpg?1",
             "name": "Brilliant Restoration",
             "text": "Return all artifact and enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "1eae8cac-f52e-56ee-970f-85b9a10be3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13ddda7-da6e-415e-8886-295514f862d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13ddda7-da6e-415e-8886-295514f862d4.jpg?1",
             "name": "Cloudsteel Kirin",
             "text": "Flying\nEquipped creature has flying and \"You can't lose the game and your opponents can't win the game.\"\nReconfigure {5} ({5}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "200c76ad-46ba-529f-9d52-5e06ae5cd8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4900862f-90f4-450b-a775-219da4ce67ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4900862f-90f4-450b-a775-219da4ce67ef.jpg?1",
             "name": "Dragonfly Suit",
             "text": "Flying\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "841a3ec3-6182-5cde-baf9-043d06ef73d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b0a9cc0-bb6d-47f7-b0d5-3956c46a1b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b0a9cc0-bb6d-47f7-b0d5-3956c46a1b3a.jpg?1",
             "name": "Eiganjo Exemplar",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "4e6dae10-127f-54e0-a176-d67be5fa5e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg?1",
             "name": "Era of Enlightenment // Hand of Enlightenment",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Scry 2.\nII \u2014 You gain 2 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "43e5e998-cc08-574a-a33c-8dd3ac64b9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg?1",
             "name": "Era of Enlightenment // Hand of Enlightenment",
             "text": "First strike",
             "colours": [
@@ -466,7 +466,7 @@
         },
         {
             "id": "f840f1b5-e8ff-5cab-895a-80eda3d5f478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg?1",
             "name": "The Fall of Lord Konda // Fragment of Konda",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile target creature an opponent controls with mana value 4 or greater.\nII \u2014 Each player gains control of all permanents they own.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -500,7 +500,7 @@
         },
         {
             "id": "d8e2771c-b870-5c80-803e-fffce0f2dddb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg?1",
             "name": "The Fall of Lord Konda // Fragment of Konda",
             "text": "Defender\nWhen Fragment of Konda dies, draw a card.",
             "colours": [
@@ -536,7 +536,7 @@
         },
         {
             "id": "c68d4d14-fd1a-5b7c-b1f6-dd408cdf797a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1068723-d1ef-4007-97d9-b10dccdbade4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1068723-d1ef-4007-97d9-b10dccdbade4.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "5d8c9ea3-edb1-5341-8879-bd6a011bf41a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab91962-ebad-46f6-9f90-7477c224d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab91962-ebad-46f6-9f90-7477c224d93d.jpg?1",
             "name": "Go-Shintai of Shared Purpose",
             "text": "Vigilance\nAt the beginning of your end step, you may pay {1}. If you do, create a 1/1 colorless Spirit creature token for each Shrine you control.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "d6d8e065-4ac1-5e2b-a22f-162a8b4621f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631e7da-bd71-424a-a349-9bce0fd16b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631e7da-bd71-424a-a349-9bce0fd16b1f.jpg?1",
             "name": "Golden-Tail Disciple",
             "text": "Lifelink",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "8b2ba96b-a9e1-5d12-9d1c-f198fd56eadd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a70e8fa-b71d-441e-b049-dacb09a9a7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a70e8fa-b71d-441e-b049-dacb09a9a7af.jpg?1",
             "name": "Hotshot Mechanic",
             "text": "Hotshot Mechanic crews Vehicles as though its power were 2 greater.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "7bd11a78-eaae-5fde-8ad2-81aa009a4d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6750dd-2303-493b-885d-1bfb5787b16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6750dd-2303-493b-885d-1bfb5787b16c.jpg?1",
             "name": "Imperial Oath",
             "text": "Create three 2/2 white Samurai creature tokens with vigilance. Scry 3.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "b052f767-68de-584c-a092-83ebdc424259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2c7b-c93b-4b97-999e-86faed8a26ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2c7b-c93b-4b97-999e-86faed8a26ee.jpg?1",
             "name": "Imperial Recovery Unit",
             "text": "Whenever Imperial Recovery Unit attacks, return target creature or Vehicle card with mana value 2 or less from your graveyard to your hand.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "cc15edae-a6c0-55af-9ea0-321c0f3d807e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13246172-7554-4edc-b6db-23dc91e4290a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13246172-7554-4edc-b6db-23dc91e4290a.jpg?1",
             "name": "Imperial Subduer",
             "text": "Whenever a Samurai or Warrior you control attacks alone, tap target creature you don't control.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "d08a1773-d298-53da-be7c-8bf44cd77341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f2148-bb5d-4236-8d12-150deed0577e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f2148-bb5d-4236-8d12-150deed0577e.jpg?1",
             "name": "Intercessor's Arrest",
             "text": "Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "b71f19d8-10bd-59dd-988b-25841c4bdf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a598ab6-3254-49fe-b69f-e7c759129599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a598ab6-3254-49fe-b69f-e7c759129599.jpg?1",
             "name": "Invoke Justice",
             "text": "Return target permanent card from your graveyard to the battlefield, then distribute four +1/+1 counters among any number of creatures and/or Vehicles target player controls.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "f72b855c-53f7-5cf3-872a-91a61e887f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d446a-8607-45b8-a01f-dad17bab76e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d446a-8607-45b8-a01f-dad17bab76e7.jpg?1",
             "name": "Kitsune Ace",
             "text": "Whenever a Vehicle you control attacks, choose one \u2014\n\u2022 That Vehicle gains first strike until end of turn.\n\u2022 Untap Kitsune Ace.",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "8d5cb4ba-2b5e-555a-a03f-34a807ae9505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfd21e-96f1-4e5b-8546-73bb5a887b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfd21e-96f1-4e5b-8546-73bb5a887b98.jpg?1",
             "name": "Kyodai, Soul of Kamigawa",
             "text": "Flash\nFlying\nWhen Kyodai, Soul of Kamigawa enters the battlefield, another target permanent gains indestructible for as long as you control Kyodai.\n{W}{U}{B}{R}{G}: Kyodai gets +5/+5 until end of turn.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "9cc9fbd6-869a-5d6c-bd05-4ea0bd0ae59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd960-c4ec-4dfa-a61d-f8577b9d3519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd960-c4ec-4dfa-a61d-f8577b9d3519.jpg?1",
             "name": "Light the Way",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on target creature or Vehicle. Untap it.\n\u2022 Return target permanent you control to its owner's hand.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "14594ecb-045f-5e99-b22d-e0747a611ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39555a72-a57b-45ee-9222-ce3b9e8de126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39555a72-a57b-45ee-9222-ce3b9e8de126.jpg?1",
             "name": "Light-Paws, Emperor's Voice",
             "text": "Whenever an Aura enters the battlefield under your control, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, Emperor's Voice, then shuffle.",
             "colours": [
@@ -1004,7 +1004,7 @@
         },
         {
             "id": "33be0ee4-1ca4-5827-960f-637e9e64bb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1766e9-2fa7-4446-a255-7beea1467ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1766e9-2fa7-4446-a255-7beea1467ece.jpg?1",
             "name": "Lion Sash",
             "text": "{W}: Exile target card from a graveyard. If it was a permanent card, put a +1/+1 counter on Lion Sash.\nEquipped creature gets +1/+1 for each +1/+1 counter on Lion Sash.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "a1107b1a-1196-5ba1-91c5-5c5c7878d83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bbdeb0-9165-4874-a853-d19c20c250ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bbdeb0-9165-4874-a853-d19c20c250ef.jpg?1",
             "name": "Lucky Offering",
             "text": "Destroy target artifact with mana value 3 or less. You gain 3 life.",
             "colours": [
@@ -1075,7 +1075,7 @@
         },
         {
             "id": "a7d1e5e0-a8a4-5ca0-8bb4-77017b2fab70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553fb946-2706-475b-89f9-e4355ec9ea2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553fb946-2706-475b-89f9-e4355ec9ea2b.jpg?1",
             "name": "March of Otherworldly Light",
             "text": "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "f27869d4-52b5-5002-afe9-2425834c2b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg?1",
             "name": "Michiko's Reign of Truth // Portrait of Michiko",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Target creature gets +1/+1 until end of turn for each artifact and/or enchantment you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -1144,7 +1144,7 @@
         },
         {
             "id": "f60b13fb-9d34-5328-84e8-d83647f72ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg?1",
             "name": "Michiko's Reign of Truth // Portrait of Michiko",
             "text": "Portrait of Michiko gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "50a05c3c-0f91-50ce-bb13-cdf4230e56ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f657f2dc-adc8-4a66-b081-a71b3a127389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f657f2dc-adc8-4a66-b081-a71b3a127389.jpg?1",
             "name": "Mothrider Patrol",
             "text": "Flying\n{3}{W}, {T}: Tap target creature.",
             "colours": [
@@ -1215,7 +1215,7 @@
         },
         {
             "id": "b1cb3669-7393-57de-936b-efec2b3d4abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cb553c-58c1-4cfd-b441-297b5f09b263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cb553c-58c1-4cfd-b441-297b5f09b263.jpg?1",
             "name": "Norika Yamazaki, the Poet",
             "text": "Vigilance\nWhenever a Samurai or Warrior you control attacks alone, you may cast target enchantment card from your graveyard this turn.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "e26ffa70-a351-596c-96fc-34d057ddf886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79243e97-fe45-4988-b299-f59a7c53ad31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79243e97-fe45-4988-b299-f59a7c53ad31.jpg?1",
             "name": "Regent's Authority",
             "text": "Target creature gets +2/+2 until end of turn. If it's an enchantment creature or legendary creature, instead put a +1/+1 counter on it and it gets +1/+1 until end of turn.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "6ee930e3-369d-5024-8404-db2b53f782bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a37d5b4-af3a-48b0-895f-91b652108ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a37d5b4-af3a-48b0-895f-91b652108ef6.jpg?1",
             "name": "Repel the Vile",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power 4 or greater.\n\u2022 Exile target enchantment.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "28d0d299-8d59-55d4-8c5b-125097fd3d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nII \u2014 You may discard a card. When you do, return target permanent card with mana value 2 or less from your graveyard to the battlefield tapped.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "5a513108-8b70-58d9-b8d4-77f14d25e398",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "Vigilance\nWhenever Architect of Restoration attacks or blocks, create a 1/1 colorless Spirit creature token.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "c29d1457-9927-5af2-bbdf-81aa7a7383a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c27ec5-5a9b-4080-9a53-00630335a915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c27ec5-5a9b-4080-9a53-00630335a915.jpg?1",
             "name": "Selfless Samurai",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gains lifelink until end of turn.\nSacrifice Selfless Samurai: Another target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "12f88423-1150-5c73-b9fa-6e79f4023a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d77d1e6-c804-46f7-ba00-6df6bca2ae08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d77d1e6-c804-46f7-ba00-6df6bca2ae08.jpg?1",
             "name": "Seven-Tail Mentor",
             "text": "When Seven-Tail Mentor enters the battlefield or dies, put a +1/+1 counter on target creature or Vehicle you control.",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "e5aa55a7-e84b-56b9-81af-e27c2692668d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c7ba6f-c58e-4347-92e4-51ae8f2d5a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c7ba6f-c58e-4347-92e4-51ae8f2d5a88.jpg?1",
             "name": "Sky-Blessed Samurai",
             "text": "This spell costs {1} less to cast for each enchantment you control.\nFlying",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "42ec02a1-5588-5d70-a40e-628d7a24699b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa91a9e-2fe2-43bc-aa9c-cfb8a71829ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa91a9e-2fe2-43bc-aa9c-cfb8a71829ff.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "f36f9d31-4fa6-55bb-96bf-ff07382ca5cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c577bb-5e21-4a3e-b0a7-713a4ff7dce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c577bb-5e21-4a3e-b0a7-713a4ff7dce6.jpg?1",
             "name": "Sunblade Samurai",
             "text": "Vigilance\nChannel \u2014 {2}, Discard Sunblade Samurai: Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
             "colours": [
@@ -1581,7 +1581,7 @@
         },
         {
             "id": "bac741ad-bf92-514e-b051-5f3af2cd7312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16ab44e-4257-4c0c-b705-8ac1e9c1d835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16ab44e-4257-4c0c-b705-8ac1e9c1d835.jpg?1",
             "name": "Touch the Spirit Realm",
             "text": "When Touch the Spirit Realm enters the battlefield, exile up to one target artifact or creature until Touch the Spirit Realm leaves the battlefield.\nChannel \u2014 {1}{W}, Discard Touch the Spirit Realm: Exile target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "bfca10a4-6141-5f8a-95de-d4c5a758f019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43708ec9-a85a-4244-86b4-67b30b41d854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43708ec9-a85a-4244-86b4-67b30b41d854.jpg?1",
             "name": "Wanderer's Intervention",
             "text": "Wanderer's Intervention deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "ba3bc840-d81c-5f26-afb7-c81460a512ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2d8a9-ab4c-4225-a570-22636293c17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2d8a9-ab4c-4225-a570-22636293c17d.jpg?1",
             "name": "The Wandering Emperor",
             "text": "Flash\nAs long as The Wandering Emperor entered the battlefield this turn, you may activate her loyalty abilities any time you could cast an instant.\n+1: Put a +1/+1 counter on up to one target creature. It gains first strike until end of turn.\n\u22121: Create a 2/2 white Samurai creature token with vigilance.\n\u22122: Exile target tapped creature. You gain 2 life.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "2010a8e7-8fab-56dc-a8be-d40157617035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db14cb8-9ff8-41ee-a733-4f1130e73b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db14cb8-9ff8-41ee-a733-4f1130e73b29.jpg?1",
             "name": "When We Were Young",
             "text": "Up to two target creatures each get +2/+2 until end of turn. If you control an artifact and an enchantment, those creatures also gain lifelink until end of turn.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "dc5ef955-2a52-55c4-a296-c214c51fb885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e971a72-31db-4b7e-b9b9-9f45e8c3f87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e971a72-31db-4b7e-b9b9-9f45e8c3f87e.jpg?1",
             "name": "Acquisition Octopus",
             "text": "Whenever Acquisition Octopus or equipped creature deals combat damage to a player, draw a card.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "5264ba34-4d48-5a9b-bed0-736439e02dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58141ad0-32ea-4e07-a133-ff7812d58c0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58141ad0-32ea-4e07-a133-ff7812d58c0e.jpg?1",
             "name": "Anchor to Reality",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nSearch your library for an Equipment or Vehicle card, put that card onto the battlefield, then shuffle. If it has mana value less than the sacrificed permanent's mana value, scry 2.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "50317638-1b9b-54e1-abcc-2ce9fc6fd243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7497f147-146d-4a76-b670-bd84e07352b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7497f147-146d-4a76-b670-bd84e07352b3.jpg?1",
             "name": "Armguard Familiar",
             "text": "Ward {2} (Whenever this permanent becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nEquipped creature gets +2/+1 and has ward {2}.\nReconfigure {4} ({4}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "97eee1b7-ad6a-5e51-be18-dde48a8a103a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51378e10-2f17-445b-97e9-5c373234ba52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51378e10-2f17-445b-97e9-5c373234ba52.jpg?1",
             "name": "Awakened Awareness",
             "text": "Enchant artifact or creature\nWhen Awakened Awareness enters the battlefield, put X +1/+1 counters on enchanted permanent.\nAs long as enchanted permanent is a creature, it has base power and toughness 1/1.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "73392c5e-7eae-5eac-92ce-5809b04d65f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg?1",
             "name": "Behold the Unspeakable // Vision of the Unspeakable",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Creatures you don't control get -2/-0 until your next turn.\nII \u2014 If you have one or fewer cards in hand, draw four cards. Otherwise, scry 2, then draw two cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "e05c46ba-242c-5f04-9aef-6bde02141539",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg?1",
             "name": "Behold the Unspeakable // Vision of the Unspeakable",
             "text": "Flying, trample\nVision of the Unspeakable gets +1/+1 for each card in your hand.",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "042ff4f3-466b-5535-9e61-fb2ac8bfb8e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae9991-43a2-4afb-a882-fff6b0d89d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae9991-43a2-4afb-a882-fff6b0d89d12.jpg?1",
             "name": "Covert Technician",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "6f3a0256-7742-580b-97b7-77070571f24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c201117-9850-4e92-9ecc-e4d71a70a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c201117-9850-4e92-9ecc-e4d71a70a959.jpg?1",
             "name": "Discover the Impossible",
             "text": "Look at the top five cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost if it's an instant spell with mana value 2 or less. If you don't, put that card into your hand.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "43f2229b-1f5a-5976-85ca-934fe3ae9d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053ab598-06a4-43ae-b9fd-c291bd05642c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053ab598-06a4-43ae-b9fd-c291bd05642c.jpg?1",
             "name": "Disruption Protocol",
             "text": "As an additional cost to cast this spell, tap an untapped artifact you control or pay {1}.\nCounter target spell.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "d77d838d-ff29-518c-9fe6-2c11b11220e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39bf1fa-b530-4353-a683-843466227109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39bf1fa-b530-4353-a683-843466227109.jpg?1",
             "name": "Essence Capture",
             "text": "Counter target creature spell. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "219592e7-469f-5036-8a4f-a2d8c25d4cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5858176-9f85-403c-8338-48eb55db5c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5858176-9f85-403c-8338-48eb55db5c3d.jpg?1",
             "name": "Futurist Operative",
             "text": "As long as Futurist Operative is tapped, it's a Human Citizen with base power and toughness 1/1 and can't be blocked.\n{2}{U}: Untap Futurist Operative.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "e3ab4b2c-6630-5eb7-9bc1-41e1a4e2699d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672f626-3e46-447b-841f-6a04cd380653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672f626-3e46-447b-841f-6a04cd380653.jpg?1",
             "name": "Futurist Sentinel",
             "text": "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "36263be5-4d4a-5e25-a1c6-a09c0cb0cf30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec1192c-25b8-4975-ae6c-86be28ac1840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec1192c-25b8-4975-ae6c-86be28ac1840.jpg?1",
             "name": "Go-Shintai of Lost Wisdom",
             "text": "Flying\nAt the beginning of your end step, you may pay {1}. When you do, target player mills X cards, where X is the number of Shrines you control. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "ced99533-689c-5dfb-89f8-44802b07df66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c44d4e-742f-4e4f-9bf4-921075bc427c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c44d4e-742f-4e4f-9bf4-921075bc427c.jpg?1",
             "name": "Guardians of Oboro",
             "text": "Defender\nModified creatures you control can attack as though they didn't have defender. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "9a60937c-36d1-5a60-8251-f74b6a445e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Return up to one target creature or planeswalker to its owner's hand.\nII \u2014 Return an artifact card from your graveyard to your hand. If you can't, draw a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "4916bf0d-3728-5b7d-9dc5-11d8e1ba9533",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "Flying\nWhenever you cast a spell, your opponents can't cast spells with the same mana value as that spell until your next turn.",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "3598306c-5b23-5910-a2e9-113947c163a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7b423a-bfd1-47aa-bd2c-64a169b96924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7b423a-bfd1-47aa-bd2c-64a169b96924.jpg?1",
             "name": "Invoke the Winds",
             "text": "Gain control of target artifact or creature. Untap it.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "a301bd29-045c-5fd9-afe4-c7e312f8aa36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b4876-5387-4f73-b8e2-8e7bdca8b0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b4876-5387-4f73-b8e2-8e7bdca8b0bc.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn. (A copy of a permanent spell becomes a token.)\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -2355,7 +2355,7 @@
         },
         {
             "id": "8870d116-ed98-53a1-803f-c3e003c9609b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7979d8-21f3-40ba-8a2e-7ebad210e48b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7979d8-21f3-40ba-8a2e-7ebad210e48b.jpg?1",
             "name": "Kairi, the Swirling Sky",
             "text": "Flying, ward {3}\nWhen Kairi, the Swirling Sky dies, choose one \u2014\n\u2022 Return any number of target nonland permanents with total mana value 6 or less to their owners' hands.\n\u2022 Mill six cards, then return up to two instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "b723ebb2-a59f-54d5-8c64-f34c852d92b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100171d8-7436-44c8-b4cb-0101ffa05c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100171d8-7436-44c8-b4cb-0101ffa05c25.jpg?1",
             "name": "March of Swirling Mist",
             "text": "As an additional cost to cast this spell, you may exile any number of blue cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nUp to X target creatures phase out. (While they're phased out, they're treated as though they don't exist. Each one phases in before its controller untaps during their next untap step.)",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "6adf63fd-0d34-5743-a805-873f63a3241f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28273a5b-57b3-4b7a-b017-5886c171c9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28273a5b-57b3-4b7a-b017-5886c171c9c9.jpg?1",
             "name": "Mindlink Mech",
             "text": "Flying\nWhenever Mindlink Mech becomes crewed for the first time each turn, until end of turn, Mindlink Mech becomes a copy of target nonlegendary creature that crewed it this turn, except it's 4/3, it's a Vehicle artifact in addition to its other types, and it has flying.\nCrew 1",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "1068214a-68c5-5948-b484-4ff16704fe03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0394c8df-2e8a-4477-93b7-569934d7b936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0394c8df-2e8a-4477-93b7-569934d7b936.jpg?1",
             "name": "Mirrorshell Crab",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nChannel \u2014 {2}{U}, Discard Mirrorshell Crab: Counter target spell or ability unless its controller pays {3}.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "e68a2447-a201-5376-ab10-721a0531a47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a15d8d9-0575-4add-ae8d-4576e8ed2cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a15d8d9-0575-4add-ae8d-4576e8ed2cbe.jpg?1",
             "name": "Mnemonic Sphere",
             "text": "{1}{U}, Sacrifice Mnemonic Sphere: Draw two cards.\nChannel \u2014 {U}, Discard Mnemonic Sphere: Draw a card.",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "748a0f72-e052-5159-8f32-7d4a95f22559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4bb9de-ba7c-4916-b8ed-e2e644c06b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4bb9de-ba7c-4916-b8ed-e2e644c06b58.jpg?1",
             "name": "Mobilizer Mech",
             "text": "Flying\nWhenever Mobilizer Mech becomes crewed, up to one other target Vehicle you control becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "ebadf36b-1cb6-5ac0-9162-de0a615ef665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg?1",
             "name": "The Modern Age // Vector Glider",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Draw a card, then discard a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "2b8e212e-c7b1-55da-8691-3d79f2cf88b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg?1",
             "name": "The Modern Age // Vector Glider",
             "text": "Flying",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "1e577b48-b7f3-592f-9518-610d8dc3f27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e466d1-943d-41e6-a47d-c9d951ca4262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e466d1-943d-41e6-a47d-c9d951ca4262.jpg?1",
             "name": "Moon-Circuit Hacker",
             "text": "Ninjutsu {U} ({U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Moon-Circuit Hacker deals combat damage to a player, you may draw a card. If you do, discard a card unless Moon-Circuit Hacker entered the battlefield this turn.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "cfa82014-0d58-52dc-a010-0b0921561bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fa6d4c-78dc-4b40-9ce8-a0e593d4001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fa6d4c-78dc-4b40-9ce8-a0e593d4001f.jpg?1",
             "name": "Moonfolk Puzzlemaker",
             "text": "Flying\nWhenever Moonfolk Puzzlemaker becomes tapped, scry 1.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "5bd75001-600a-51f6-9574-d7cd14da8838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8bc0e9-a536-4bca-92a6-8dca85e1e984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8bc0e9-a536-4bca-92a6-8dca85e1e984.jpg?1",
             "name": "Moonsnare Prototype",
             "text": "{T}, Tap an untapped artifact or creature you control: Add {C}.\nChannel \u2014 {4}{U}, Discard Moonsnare Prototype: The owner of target nonland permanent puts it on the top or bottom of their library.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "a6144caf-43a5-558b-a35b-dc66c8bb305d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8b209f-f577-45cc-9d18-03c1d67d391e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8b209f-f577-45cc-9d18-03c1d67d391e.jpg?1",
             "name": "Moonsnare Specialist",
             "text": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen Moonsnare Specialist enters the battlefield, return up to one target creature to its owner's hand.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "1d29625e-1460-5342-83c4-362891d7594f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a37719a-2a87-4870-8f25-12544ca2f2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a37719a-2a87-4870-8f25-12544ca2f2cf.jpg?1",
             "name": "Network Disruptor",
             "text": "Flying\nWhen Network Disruptor enters the battlefield, tap target permanent.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "8843a444-2fa1-5ca5-9247-8076059f23bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9163cb04-ee28-4127-b53a-89c546996d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9163cb04-ee28-4127-b53a-89c546996d7d.jpg?1",
             "name": "Planar Incision",
             "text": "Exile target artifact or creature, then return it to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "c05700a5-8627-5df9-bc06-8486b63c59aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f683e-5a28-4ae7-b53b-851b957123ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f683e-5a28-4ae7-b53b-851b957123ba.jpg?1",
             "name": "Prosperous Thief",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever one or more Ninja or Rogue creatures you control deal combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "af19f7d1-3948-57bf-9c3c-0538ee5f17cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d859de3a-0be1-4e66-b438-1c3d4ee756cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d859de3a-0be1-4e66-b438-1c3d4ee756cd.jpg?1",
             "name": "The Reality Chip",
             "text": "You may look at the top card of your library any time.\nAs long as The Reality Chip is attached to a creature, you may play lands and cast spells from the top of your library.\nReconfigure {2}{U} ({2}{U}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "8c039d47-b2d0-5c4e-8d32-36d96a84d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc954d7-322a-45b8-9e25-6e9a97fbde61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc954d7-322a-45b8-9e25-6e9a97fbde61.jpg?1",
             "name": "Reality Heist",
             "text": "This spell costs {1} less to cast for each artifact you control.\nLook at the top seven cards of your library. You may reveal up to two artifact cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "1b7ab75f-6648-5331-ba83-bac991b5b23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bb3b5-b648-460c-b0ea-89ecfe0ff226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bb3b5-b648-460c-b0ea-89ecfe0ff226.jpg?1",
             "name": "Replication Specialist",
             "text": "Flying\nWhenever a nontoken artifact enters the battlefield under your control, you may pay {1}{U}. If you do, create a token that's a copy of that artifact.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "c895297f-04b5-5d87-8833-ce4a71a02ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dd7f1a-5d43-4218-a9d8-7cc4f6a18ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dd7f1a-5d43-4218-a9d8-7cc4f6a18ecd.jpg?1",
             "name": "Saiba Trespassers",
             "text": "Channel \u2014 {3}{U}, Discard Saiba Trespassers: Tap up to two target creatures you don't control. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -3029,7 +3029,7 @@
         },
         {
             "id": "2ef73e00-881b-5100-b090-935773268f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0fb5-e994-41b1-a73d-4e68f7afdf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0fb5-e994-41b1-a73d-4e68f7afdf34.jpg?1",
             "name": "Short Circuit",
             "text": "Flash\nEnchant artifact or creature\nAs long as enchanted permanent is a creature, it gets -3/-0 and loses flying.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "f985e590-c531-5601-b7da-1bae66669292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50259b-8ca8-4fbe-8ae3-6b0312d70980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50259b-8ca8-4fbe-8ae3-6b0312d70980.jpg?1",
             "name": "Skyswimmer Koi",
             "text": "Flying\nWhenever an artifact enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "73523ca1-8d92-5450-a834-8a02b40913ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb42273-935b-4bda-849e-c163606cf89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb42273-935b-4bda-849e-c163606cf89e.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "9009dacd-36f7-5e52-9cb1-0bf52d07fcd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50870bfd-7779-4a1c-b18f-57fac7e193b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50870bfd-7779-4a1c-b18f-57fac7e193b1.jpg?1",
             "name": "Suit Up",
             "text": "Until end of turn, target creature or Vehicle becomes an artifact creature with base power and toughness 4/5.\nDraw a card.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "e003f340-9c0e-5312-8dac-2b49a82c6e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26594b52-3e9c-4cde-88df-1f4e9e16676e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26594b52-3e9c-4cde-88df-1f4e9e16676e.jpg?1",
             "name": "Tameshi, Reality Architect",
             "text": "Whenever one or more noncreature permanents are returned to hand, draw a card. This ability triggers only once each turn.\n{X}{W}, Return a land you control to its owner's hand: Return target artifact or enchantment card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "0e2ca9c8-8b26-50fd-8fdc-4cbf8d9f52b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee62e43-6a82-4749-972b-e21802642abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee62e43-6a82-4749-972b-e21802642abf.jpg?1",
             "name": "Tamiyo's Compleation",
             "text": "Flash\nEnchant artifact, creature, or planeswalker\nWhen Tamiyo's Compleation enters the battlefield, tap enchanted permanent. If it's an Equipment, unattach it.\nEnchanted permanent loses all abilities and doesn't untap during its controller's untap step.",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "beddaaaf-a88d-5d44-acef-1a1d052da23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2174d16e-4a78-4d27-b220-1086c40db83e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2174d16e-4a78-4d27-b220-1086c40db83e.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "The first activated ability of an artifact you activate each turn costs {2} less to activate.\n+1: Draw two cards. Then discard two cards unless you discard an artifact card.\n\u22122: Target artifact becomes an artifact creature. If it isn't a Vehicle, it has base power and toughness 4/4.\n\u22126: You get an emblem with \"Whenever an artifact you control becomes tapped, draw a card.\"",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "69e1483d-5c32-5bcd-a270-46121a7542fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b927837-8252-4ea7-b2d0-ab624de65bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b927837-8252-4ea7-b2d0-ab624de65bd7.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "4c4ebd0c-b904-5e97-9d5e-93155ff77d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a698a5-f4ac-4b04-96dc-32e1eeef6ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a698a5-f4ac-4b04-96dc-32e1eeef6ac7.jpg?1",
             "name": "Thousand-Faced Shadow",
             "text": "Ninjutsu {2}{U}{U} ({2}{U}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "bdd250dd-e01d-520d-bab5-ec67403580fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a926c10-029d-4e24-8c3f-1808025e30aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a926c10-029d-4e24-8c3f-1808025e30aa.jpg?1",
             "name": "Assassin's Ink",
             "text": "This spell costs {1} less to cast if you control an artifact and {1} less to cast if you control an enchantment.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "c1b1e927-8e33-5f6a-89d5-9986818eba82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017df51-67ae-4c3d-8210-086f83bc2040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017df51-67ae-4c3d-8210-086f83bc2040.jpg?1",
             "name": "Biting-Palm Ninja",
             "text": "Ninjutsu {2}{B}\nBiting-Palm Ninja enters the battlefield with a menace counter on it.\nWhenever Biting-Palm Ninja deals combat damage to a player, you may remove a menace counter from it. When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "841679dc-4fad-59e6-a1f6-f736a3be4b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bc3f71-b4ce-4c05-be3c-7a0faad476c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bc3f71-b4ce-4c05-be3c-7a0faad476c3.jpg?1",
             "name": "Blade of the Oni",
             "text": "Menace\nEquipped creature has base power and toughness 5/5, has menace, and is a black Demon in addition to its other colors and types.\nReconfigure {2}{B}{B} ({2}{B}{B}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "a3f5c445-d600-583e-a7c1-7f36b22aa9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8efe0-2f7b-4ada-a1b9-9c5f9e6a114d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8efe0-2f7b-4ada-a1b9-9c5f9e6a114d.jpg?1",
             "name": "Chainflail Centipede",
             "text": "Whenever Chainflail Centipede or equipped creature attacks, it gets +2/+0 until end of turn.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "449fd881-d75e-5370-a66e-b60b3fbdf8fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621fce96-5933-4e2b-98ec-2589940e24cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621fce96-5933-4e2b-98ec-2589940e24cb.jpg?1",
             "name": "Clawing Torment",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets -1/-1 and can't block.\nEnchanted permanent has \"At the beginning of your upkeep, you lose 1 life.\"",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "b2f1e203-47bb-5a24-9f69-45f9005b8ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a7e728-ba01-4e3d-b269-9e2dd85a1d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a7e728-ba01-4e3d-b269-9e2dd85a1d1b.jpg?1",
             "name": "Debt to the Kami",
             "text": "Choose one \u2014\n\u2022 Target opponent exiles a creature they control.\n\u2022 Target opponent exiles an enchantment they control.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "1bac13ef-9154-5189-a97b-bc27ac59c1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80100c3-c81e-4084-8dfe-f8610637fd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80100c3-c81e-4084-8dfe-f8610637fd91.jpg?1",
             "name": "Dockside Chef",
             "text": "{1}{B}, Sacrifice an artifact or creature: Draw a card.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "68d4f98f-a81f-5e1d-b48f-e72f48e08d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81496a81-c986-4749-a28c-45341764e28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81496a81-c986-4749-a28c-45341764e28f.jpg?1",
             "name": "Dokuchi Shadow-Walker",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "36431125-3b8c-58bb-82cf-498da586c66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24d5664-e214-466d-bb53-4e8f6f75a009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24d5664-e214-466d-bb53-4e8f6f75a009.jpg?1",
             "name": "Dokuchi Silencer",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Dokuchi Silencer deals combat damage to a player, you may discard a creature card. When you do, destroy target creature or planeswalker that player controls.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "9551daa9-e3ac-543d-8035-7beb7f1a6aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991370bd-a96a-4ed0-bdf9-f03b98191abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991370bd-a96a-4ed0-bdf9-f03b98191abf.jpg?1",
             "name": "Enormous Energy Blade",
             "text": "Equipped creature gets +4/+0.\nWhenever Enormous Energy Blade becomes attached to a creature, tap that creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "bf72caf7-8724-598e-a1f3-a463ea64d64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e1ff1e-916b-4455-84cb-4125a79d76de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e1ff1e-916b-4455-84cb-4125a79d76de.jpg?1",
             "name": "Go-Shintai of Hidden Cruelty",
             "text": "Deathtouch\nAt the beginning of your end step, you may pay {1}. When you do, destroy target creature with toughness X or less, where X is the number of Shrines you control.",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "2c52acaf-dd4e-5b4f-a23b-4ca77b07db5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c5b14-75cf-4e4c-9b80-2d56a86e2844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c5b14-75cf-4e4c-9b80-2d56a86e2844.jpg?1",
             "name": "Gravelighter",
             "text": "Flying\nWhen Gravelighter enters the battlefield, draw a card if a creature died this turn. Otherwise, each player sacrifices a creature.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "d2d89a9d-ae88-52af-84f1-c0441a9cca03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4142d3-f7ca-4613-a6e5-528cf1f22383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4142d3-f7ca-4613-a6e5-528cf1f22383.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "{B}, Sacrifice a creature: Scry 2.\n{2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.",
             "colours": [
@@ -3818,7 +3818,7 @@
         },
         {
             "id": "b05d8e44-2dec-5b5f-b332-0b2668ae9043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6e447-5f40-4039-8a17-257b4a55382c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6e447-5f40-4039-8a17-257b4a55382c.jpg?1",
             "name": "Inkrise Infiltrator",
             "text": "Flying\n{3}{B}: Inkrise Infiltrator gets +2/+2 until end of turn.",
             "colours": [
@@ -3855,7 +3855,7 @@
         },
         {
             "id": "c9f820b9-5b00-527f-8f9f-2bf9ad89a8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -3891,7 +3891,7 @@
         },
         {
             "id": "a07096eb-3e0e-5602-823d-d85882721f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9033cf27-d9e6-49b8-8ee1-c1f38c9680b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9033cf27-d9e6-49b8-8ee1-c1f38c9680b9.jpg?1",
             "name": "Junji, the Midnight Sky",
             "text": "Flying, menace\nWhen Junji, the Midnight Sky dies, choose one \u2014\n\u2022 Each opponent discards two cards and loses 2 life.\n\u2022 Put target non-Dragon creature card from a graveyard onto the battlefield under your control. You lose 2 life.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "8b079003-717d-5942-8903-26aacc16282a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd73fa5a-be0f-49a4-a921-afefbc8fa9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd73fa5a-be0f-49a4-a921-afefbc8fa9c5.jpg?1",
             "name": "Kaito's Pursuit",
             "text": "Target player discards two cards. Ninjas and Rogues you control gain menace until end of turn. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "feca572f-e49a-5852-a31e-e32c4dbd9a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3be4a-ab4f-46ef-837c-0f7559a701fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3be4a-ab4f-46ef-837c-0f7559a701fe.jpg?1",
             "name": "Kami of Restless Shadows",
             "text": "When Kami of Restless Shadows enters the battlefield, choose one \u2014\n\u2022 Return up to one target Ninja or Rogue creature card from your graveyard to your hand.\n\u2022 Put target creature card from your graveyard on top of your library.",
             "colours": [
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "f4fe0808-32d2-5666-8fca-e26192f367af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f15af6-eaf5-41b8-b93d-5a90ca219478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f15af6-eaf5-41b8-b93d-5a90ca219478.jpg?1",
             "name": "Kami of Terrible Secrets",
             "text": "When Kami of Terrible Secrets enters the battlefield, if you control an artifact and an enchantment, you draw a card and you gain 1 life.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "f34e3c90-23e2-5585-8201-d930aa50d69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97986b67-5ae4-492f-a9e0-81f57a829d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97986b67-5ae4-492f-a9e0-81f57a829d86.jpg?1",
             "name": "Leech Gauntlet",
             "text": "Lifelink\nEquipped creature has lifelink.\nReconfigure {4} ({4}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "0f1c9878-1ae5-509d-8f05-63d7d86d9f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8edf8f-c2bd-4fd1-8abf-d3162e068b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8edf8f-c2bd-4fd1-8abf-d3162e068b17.jpg?1",
             "name": "Lethal Exploit",
             "text": "Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn for each modified creature you controlled as you cast this spell. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "f8aee9ed-0d99-5f25-8dca-5be056591a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg?1",
             "name": "Life of Toshiro Umezawa // Memory of Toshiro",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Choose one \u2014\n\u2022 Target creature gets +2/+2 until end of turn.\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 You gain 2 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "f3158902-81ec-505b-8be4-5b4ad5e3a462",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg?1",
             "name": "Life of Toshiro Umezawa // Memory of Toshiro",
             "text": "{T}, Pay 1 life: Add {B}. Spend this mana only to cast an instant or sorcery spell.",
             "colours": [
@@ -4169,7 +4169,7 @@
         },
         {
             "id": "7c96ff8d-1af2-577a-b251-0400cf0c7efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg?1",
             "name": "The Long Reach of Night // Animus of Night's Reach",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent sacrifices a creature unless they discard a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4203,7 +4203,7 @@
         },
         {
             "id": "4b3891a5-d7e9-5111-a7ce-e9f1e40a51a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg?1",
             "name": "The Long Reach of Night // Animus of Night's Reach",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Animus of Night's Reach attacks, it gets +X/+0 until end of turn, where X is the number of creature cards in defending player's graveyard.",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "684b6d29-31ce-5f86-b4ed-a465a48d90c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e7415f-f014-4ece-81db-d8271444d9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e7415f-f014-4ece-81db-d8271444d9e9.jpg?1",
             "name": "Malicious Malfunction",
             "text": "All creatures get -2/-2 until end of turn. If a creature would die this turn, exile it instead.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "0ac19ec3-ca53-59ac-bc02-0f8904863bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a604e-6146-4e2e-88a5-863ecb3dfa1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a604e-6146-4e2e-88a5-863ecb3dfa1f.jpg?1",
             "name": "March of Wretched Sorrow",
             "text": "As an additional cost to cast this spell, you may exile any number of black cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nMarch of Wretched Sorrow deals X damage to target creature or planeswalker and you gain X life.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "69c33d92-a202-5405-a557-1b5b722cefb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3293-c1e0-447c-8231-26fa9476a262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3293-c1e0-447c-8231-26fa9476a262.jpg?1",
             "name": "Mukotai Ambusher",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nLifelink",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "92d75749-1102-582f-9a34-d941ac855fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166775be-c3b7-4a17-9376-aa4229b147f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166775be-c3b7-4a17-9376-aa4229b147f9.jpg?1",
             "name": "Mukotai Soulripper",
             "text": "Whenever Mukotai Soulripper attacks, you may sacrifice another artifact or creature. If you do, put a +1/+1 counter on Mukotai Soulripper and it gains menace until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "cd7b242e-2d8d-5d2f-b46a-0a58cb312992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893b070-a610-4273-beb2-7609a2da0499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893b070-a610-4273-beb2-7609a2da0499.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "69096d29-b8c8-5499-a267-e099d6ef94e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a03d3f5-b32b-4814-b485-25f24e51609c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a03d3f5-b32b-4814-b485-25f24e51609c.jpg?1",
             "name": "Nezumi Bladeblesser",
             "text": "Nezumi Bladeblesser has deathtouch as long as you control an artifact.\nNezumi Bladeblesser has menace as long as you control an enchantment. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "d686b66a-a754-5468-aaaa-7f26d93453f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca911e9a-bd04-4531-a81e-3485e9cbe89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca911e9a-bd04-4531-a81e-3485e9cbe89e.jpg?1",
             "name": "Nezumi Prowler",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen Nezumi Prowler enters the battlefield, target creature you control gains deathtouch and lifelink until end of turn.",
             "colours": [
@@ -4496,7 +4496,7 @@
         },
         {
             "id": "fcaab0ce-fae1-5118-a674-b9fd7fe6b15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg?1",
             "name": "Okiba Reckoner Raid // Nezumi Road Captain",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent loses 1 life and you gain 1 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "1f58a3fb-5c60-54b1-ae77-5c7dcb6491fe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg?1",
             "name": "Okiba Reckoner Raid // Nezumi Road Captain",
             "text": "Menace\nVehicles you control have menace. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "f9f29963-21e2-5595-b049-41ff0273165a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e4485d-c208-46b4-9b5d-48e55e2ee182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e4485d-c208-46b4-9b5d-48e55e2ee182.jpg?1",
             "name": "Okiba Salvage",
             "text": "Return target creature or Vehicle card from your graveyard to the battlefield. Then put two +1/+1 counters on that permanent if you control an artifact and an enchantment.",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "c3297f3e-b8e3-5459-9504-2ce51343dd3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf57666f-366b-43bf-95c7-39c1f7f061e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf57666f-366b-43bf-95c7-39c1f7f061e2.jpg?1",
             "name": "Reckoner Shakedown",
             "text": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card. If you don't, put two +1/+1 counters on a creature or Vehicle you control.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "2f6c16c3-2579-53f5-9f2e-62f3908d275a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6338942d-d650-4571-8ec6-4d658792c53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6338942d-d650-4571-8ec6-4d658792c53e.jpg?1",
             "name": "Reckoner's Bargain",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nYou gain life equal to the sacrificed permanent's mana value. Draw two cards.",
             "colours": [
@@ -4662,7 +4662,7 @@
         },
         {
             "id": "3109ea0a-5943-5dbf-8e1d-c8051b3d1c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342ec072-e581-490c-b5ae-a625bd35a153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342ec072-e581-490c-b5ae-a625bd35a153.jpg?1",
             "name": "Return to Action",
             "text": "Until end of turn, target creature gets +1/+0 and gains lifelink and \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "56d76a8f-a3bd-5c40-b9f9-e46bcff816fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5aba90-c8c7-4f06-b7b3-1b4758d2791a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5aba90-c8c7-4f06-b7b3-1b4758d2791a.jpg?1",
             "name": "Soul Transfer",
             "text": "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both.\n\u2022 Exile target creature or planeswalker.\n\u2022 Return target creature or planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -4729,7 +4729,7 @@
         },
         {
             "id": "884889c3-2fb4-593e-8642-21af6834952f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf42833-43d0-4b05-b499-d13b2c577ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf42833-43d0-4b05-b499-d13b2c577ee8.jpg?1",
             "name": "Tatsunari, Toad Rider",
             "text": "Whenever you cast an enchantment spell, if you don't control a creature named Keimi, create Keimi, a legendary 3/3 black and green Frog creature token with \"Whenever you cast an enchantment spell, each opponent loses 1 life and you gain 1 life.\"\n{1}{GW}: Tatsunari, Toad Rider and target Frog you control can't be blocked this turn except by creatures with flying or reach.",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "11100b42-d6bb-543d-8d14-5a475b14cd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent creates a 1/1 black Rat Rogue creature token.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4808,7 +4808,7 @@
         },
         {
             "id": "a6c4f572-c1e1-5d39-805f-4bb17c931298",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "Flying, haste\nWhen Echo of Death's Wail enters the battlefield, gain control of all Rat tokens.\nWhenever Echo of Death's Wail attacks, you may sacrifice another creature. If you do, draw a card.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "8b9554a9-b12a-57ed-882a-a250a178d0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7919a-de62-46df-a937-593647473ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7919a-de62-46df-a937-593647473ef5.jpg?1",
             "name": "Twisted Embrace",
             "text": "Enchant artifact or creature you control\nWhen Twisted Embrace enters the battlefield, destroy target creature or planeswalker an opponent controls.\nAs long as enchanted permanent is a creature, it gets +1/+1.",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "665acf79-d6ef-5a56-961f-40b59756211d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6319b84b-8a3d-4bc8-af48-8b500f124be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6319b84b-8a3d-4bc8-af48-8b500f124be1.jpg?1",
             "name": "Undercity Scrounger",
             "text": "{T}: Create a Treasure token. Activate only if a creature died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "f33c2238-b3c3-52a9-a333-f5da2b157191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb20c08-a84a-4773-a90c-fb007b94644b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb20c08-a84a-4773-a90c-fb007b94644b.jpg?1",
             "name": "Unforgiving One",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Unforgiving One attacks, return target creature card with mana value X or less from your graveyard to the battlefield, where X is the number of modified creatures you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "213cbf96-9270-5906-9ace-b65561d5a100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488ee202-0d28-4cc0-8a7d-644d9878e952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488ee202-0d28-4cc0-8a7d-644d9878e952.jpg?1",
             "name": "Virus Beetle",
             "text": "When Virus Beetle enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "8bba91fa-c6ea-590f-ab22-56a93e8aafad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768727ce-4f84-4527-8d69-3c9b7877b748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768727ce-4f84-4527-8d69-3c9b7877b748.jpg?1",
             "name": "You Are Already Dead",
             "text": "Destroy target creature that was dealt damage this turn.\nDraw a card.",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "fd858b35-7fcd-5856-825a-7024033b9e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d83e837-fcd1-4833-9117-e6f1bb53caad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d83e837-fcd1-4833-9117-e6f1bb53caad.jpg?1",
             "name": "Akki Ember-Keeper",
             "text": "Whenever a nontoken modified creature you control dies, create a 1/1 colorless Spirit creature token. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5053,7 +5053,7 @@
         },
         {
             "id": "93ed7aae-6f64-5624-83e7-3a2b545770ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f15754-1ca6-45b0-a7de-2fe507df2a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f15754-1ca6-45b0-a7de-2fe507df2a1a.jpg?1",
             "name": "Akki Ronin",
             "text": "Whenever a Samurai or Warrior you control attacks alone, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "3e831aaf-2264-5fcc-b7d6-32a5f00f2e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110698e-a343-4eff-ba23-ed7ac5a3f87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110698e-a343-4eff-ba23-ed7ac5a3f87b.jpg?1",
             "name": "Akki War Paint",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +2/+1.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "01cfe1cc-ac52-5c76-9c79-4e60e0256247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d618d-abad-475b-b938-e111282ea1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d618d-abad-475b-b938-e111282ea1c3.jpg?1",
             "name": "Ambitious Assault",
             "text": "Creatures you control get +2/+0 until end of turn. If you control a modified creature, draw a card. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "f60ae2f8-5614-5f98-bdac-68cf532dfce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b64c17-8a52-4d9d-a28b-7e0e945be059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b64c17-8a52-4d9d-a28b-7e0e945be059.jpg?1",
             "name": "Atsushi, the Blazing Sky",
             "text": "Flying, trample\nWhen Atsushi, the Blazing Sky dies, choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Create three Treasure tokens.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "0f2638a4-a353-531a-aa4e-5bee99896986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8f5da8-13a8-4b39-8ddc-7661892924af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8f5da8-13a8-4b39-8ddc-7661892924af.jpg?1",
             "name": "Bronzeplate Boar",
             "text": "Trample\nEquipped creature gets +3/+2 and has trample.\nReconfigure {5} ({5}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "d5018e9d-cc32-59c4-8302-2b87a8b02891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f77f987-ebb7-4105-a67c-0987f50fc676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f77f987-ebb7-4105-a67c-0987f50fc676.jpg?1",
             "name": "Crackling Emergence",
             "text": "Enchant land you control\nEnchanted land is a 3/3 red Spirit creature with haste. It's still a land.\nIf enchanted land would be destroyed, instead sacrifice Crackling Emergence and that land gains indestructible until end of turn.",
             "colours": [
@@ -5266,7 +5266,7 @@
         },
         {
             "id": "8432928f-1b52-5107-a63b-36095e559028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf531dd-0a93-43e3-880b-f705fa5f533d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf531dd-0a93-43e3-880b-f705fa5f533d.jpg?1",
             "name": "Dragonspark Reactor",
             "text": "Whenever Dragonspark Reactor or another artifact enters the battlefield under your control, put a charge counter on Dragonspark Reactor.\n{4}, Sacrifice Dragonspark Reactor: It deals damage equal to the number of charge counters on it to target player and that much damage to up to one target creature.",
             "colours": [
@@ -5298,7 +5298,7 @@
         },
         {
             "id": "c82a4e4b-5abf-55fd-a540-3e19faff8a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47931c9-685d-4b83-8299-bc347224b4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47931c9-685d-4b83-8299-bc347224b4e8.jpg?1",
             "name": "Experimental Synthesizer",
             "text": "When Experimental Synthesizer enters or leaves the battlefield, exile the top card of your library. Until end of turn, you may play that card.\n{2}{R}, Sacrifice Experimental Synthesizer: Create a 2/2 white Samurai creature token with vigilance. Activate only as a sorcery.",
             "colours": [
@@ -5330,7 +5330,7 @@
         },
         {
             "id": "2203b6be-86bf-511c-8459-91329449df73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba639ff-fe82-4ac3-9fb4-eac168bef053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba639ff-fe82-4ac3-9fb4-eac168bef053.jpg?1",
             "name": "Explosive Entry",
             "text": "Destroy up to one target artifact. Put a +1/+1 counter on up to one target creature.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "b0036ff4-5ca7-5132-9cdb-be7a2eef677f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdd822-44a1-4d58-9de4-69fc56eae255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdd822-44a1-4d58-9de4-69fc56eae255.jpg?1",
             "name": "Explosive Singularity",
             "text": "As an additional cost to cast this spell, you may tap any number of untapped creatures you control. This spell costs {1} less to cast for each creature tapped this way.\nExplosive Singularity deals 10 damage to any target.",
             "colours": [
@@ -5398,7 +5398,7 @@
         },
         {
             "id": "e54871ca-b187-5a71-b8eb-9e9c5322f4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 2/2 red Goblin Shaman creature token with \"Whenever this creature attacks, create a Treasure token.\"\nII \u2014 You may discard up to two cards. If you do, draw that many cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "ff6bdac8-48f6-51e1-a8bc-9db0a5b2dee7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "b2bc4fe0-0b1e-5fe5-acd5-af1ca5f57305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b44534f-d10c-4754-8585-5fe9db5fd4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b44534f-d10c-4754-8585-5fe9db5fd4ea.jpg?1",
             "name": "Flame Discharge",
             "text": "Flame Discharge deals X damage to target creature or planeswalker. If you controlled a modified creature as you cast this spell, it deals X plus 2 damage instead. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "37ec2f9b-4a90-5234-8ed3-9f97ee61a4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c33f6d9-be29-4698-96f9-d393a2c8ad68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c33f6d9-be29-4698-96f9-d393a2c8ad68.jpg?1",
             "name": "Gift of Wrath",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +2/+2 and has menace. (It can't be blocked except by two or more creatures.)\nWhen Gift of Wrath leaves the battlefield, create a 2/2 red Spirit creature token with menace.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "925f449b-5578-5809-81ab-84fbba952354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b915e8d-b972-4ae1-a1c3-74d6623963c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b915e8d-b972-4ae1-a1c3-74d6623963c8.jpg?1",
             "name": "Go-Shintai of Ancient Wars",
             "text": "First strike\nAt the beginning of your end step, you may pay {1}. When you do, Go-Shintai of Ancient Wars deals X damage to target player or planeswalker, where X is the number of Shrines you control.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "2ed62ee3-84b6-568b-a09a-1d39904fade0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca736c7-35a9-48c7-b5a9-69b2a6e33ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca736c7-35a9-48c7-b5a9-69b2a6e33ad0.jpg?1",
             "name": "Goro-Goro, Disciple of Ryusei",
             "text": "{R}: Creatures you control gain haste until end of turn.\n{3}{R}{R}: Create a 5/5 red Dragon Spirit creature token with flying. Activate only if you control an attacking modified creature. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "24785665-d324-5c98-a56a-7e905ad13a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5e61c-d903-410b-9acf-96a917ce05cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5e61c-d903-410b-9acf-96a917ce05cc.jpg?1",
             "name": "Heiko Yamazaki, the General",
             "text": "Trample\nWhenever a Samurai or Warrior you control attacks alone, you may cast target artifact card from your graveyard this turn.",
             "colours": [
@@ -5656,7 +5656,7 @@
         },
         {
             "id": "6a1a700f-be63-5887-8b58-49f2a48b58f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe666c86-6734-4c47-9244-bcd26b54068d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe666c86-6734-4c47-9244-bcd26b54068d.jpg?1",
             "name": "Invoke Calamity",
             "text": "You may cast up to two instant and/or sorcery spells with total mana value 6 or less from your graveyard and/or hand without paying their mana costs. If those spells would be put into your graveyard, exile them instead. Exile Invoke Calamity.",
             "colours": [
@@ -5691,7 +5691,7 @@
         },
         {
             "id": "43b2c280-be17-5b6a-a8b1-ec5ac1bc1198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abe574-6fb8-4809-9c18-0cf989f986f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abe574-6fb8-4809-9c18-0cf989f986f5.jpg?1",
             "name": "Ironhoof Boar",
             "text": "Trample, haste\nChannel \u2014 {1}{R}, Discard Ironhoof Boar: Target creature gets +3/+1 and gains trample until end of turn.",
             "colours": [
@@ -5726,7 +5726,7 @@
         },
         {
             "id": "38c1235e-e3ce-566d-a550-25a667f1624e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d00e61-3007-43da-960b-823e9ead2acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d00e61-3007-43da-960b-823e9ead2acf.jpg?1",
             "name": "Kami of Industry",
             "text": "When Kami of Industry enters the battlefield, return target artifact card with mana value 3 or less from your graveyard to the battlefield. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "e02774a4-9c5c-513d-a789-9dfefa6fd795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef5d58e-b490-4682-9a44-12cd61a94c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef5d58e-b490-4682-9a44-12cd61a94c0f.jpg?1",
             "name": "Kami's Flare",
             "text": "Kami's Flare deals 3 damage to target creature or planeswalker. Kami's Flare also deals 2 damage to that permanent's controller if you control a modified creature. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "3a9e95d8-dd5a-5bcd-934f-03b6773659be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8bdce-73a3-4266-b3d6-61dbf4534ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8bdce-73a3-4266-b3d6-61dbf4534ea3.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "0a262ce7-7635-51b2-a6e7-8feaccc178ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1",
             "name": "Kumano Faces Kakkazan // Etching of Kumano",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Kumano Faces Kakkazan deals 1 damage to each opponent and each planeswalker they control.\nII \u2014 When you cast your next creature spell this turn, that creature enters the battlefield with an additional +1/+1 counter on it.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "2d410dfb-e1f7-5b32-b013-953eb4ed86ab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1",
             "name": "Kumano Faces Kakkazan // Etching of Kumano",
             "text": "Haste\nIf a creature dealt damage this turn by a source you controlled would die, exile it instead.",
             "colours": [
@@ -5894,7 +5894,7 @@
         },
         {
             "id": "abc87425-bef9-5f5e-948a-15d7c9c3dc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a747e6cf-c687-4c4f-8e07-d51165d6cb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a747e6cf-c687-4c4f-8e07-d51165d6cb62.jpg?1",
             "name": "Lizard Blades",
             "text": "Double strike\nEquipped creature has double strike.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "3be796c8-ae44-537f-ad34-1ceba5ed6fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e1bf1-e392-40f2-9e84-764dedc5fcd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e1bf1-e392-40f2-9e84-764dedc5fcd4.jpg?1",
             "name": "March of Reckless Joy",
             "text": "As an additional cost to cast this spell, you may exile any number of red cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile the top X cards of your library. You may play up to two of those cards until the end of your next turn.",
             "colours": [
@@ -5968,7 +5968,7 @@
         },
         {
             "id": "9d787ee9-e9ad-5538-a4fd-49af08264eb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0d5f7d-4e8a-42ad-8875-610004bd9796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0d5f7d-4e8a-42ad-8875-610004bd9796.jpg?1",
             "name": "Ogre-Head Helm",
             "text": "Equipped creature gets +2/+2.\nWhenever Ogre-Head Helm or equipped creature deals combat damage to a player, you may sacrifice it. If you do, discard your hand, then draw three cards.\nReconfigure {3} ({3}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "82c30936-724c-5cd5-a95d-f5a0734e3da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b2176d-8925-4474-9d3e-1c97192715fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b2176d-8925-4474-9d3e-1c97192715fb.jpg?1",
             "name": "Peerless Samurai",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever a Samurai or Warrior you control attacks alone, the next spell you cast this turn costs {1} less to cast.",
             "colours": [
@@ -6044,7 +6044,7 @@
         },
         {
             "id": "0898bec2-807d-54a9-9127-dcda63f86d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d33a5b7-797b-4079-8d62-edd124c0fb5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d33a5b7-797b-4079-8d62-edd124c0fb5a.jpg?1",
             "name": "Rabbit Battery",
             "text": "Haste\nEquipped creature gets +1/+1 and has haste.\nReconfigure {R} ({R}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -6080,7 +6080,7 @@
         },
         {
             "id": "e5abe64e-f408-5af3-a391-4a16b698eb7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a18961-8f0b-4e98-9de4-aba97e91ad9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a18961-8f0b-4e98-9de4-aba97e91ad9a.jpg?1",
             "name": "Reinforced Ronin",
             "text": "Haste\nAt the beginning of your end step, return Reinforced Ronin to its owner's hand.\nChannel \u2014 {1}{R}, Discard Reinforced Ronin: Draw a card.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "ebba66c7-9626-5b0e-b538-8850d84763aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14057067-2325-4229-8580-d9a6397ae343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14057067-2325-4229-8580-d9a6397ae343.jpg?1",
             "name": "Scrap Welder",
             "text": "{T}, Sacrifice an artifact with mana value X: Return target artifact card with mana value less than X from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "28e233b6-d42c-546b-9f7c-f81e4766ec55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5776e576-5562-45ea-a29b-185410317e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5776e576-5562-45ea-a29b-185410317e17.jpg?1",
             "name": "Scrapyard Steelbreaker",
             "text": "{1}, Sacrifice another artifact: Scrapyard Steelbreaker gets +2/+1 until end of turn.",
             "colours": [
@@ -6192,7 +6192,7 @@
         },
         {
             "id": "0ce6e912-7b0b-5dea-b0c2-1f40e9f69678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b8ffb-c2e4-4676-9051-ff6c686cad0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b8ffb-c2e4-4676-9051-ff6c686cad0b.jpg?1",
             "name": "Seismic Wave",
             "text": "Seismic Wave deals 2 damage to any target and 1 damage to each nonartifact creature target opponent controls.",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "66a7c459-985c-55d5-aa84-b74720400cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg?1",
             "name": "The Shattered States Era // Nameless Conqueror",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Gain control of target creature until end of turn. Untap it. It gains haste until end of turn.\nII \u2014 Creatures you control get +1/+0 until end of turn.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -6258,7 +6258,7 @@
         },
         {
             "id": "6ae71f2e-d666-52c8-8749-f2f30452ce3d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg?1",
             "name": "The Shattered States Era // Nameless Conqueror",
             "text": "Trample, haste",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "fd31077b-409a-5295-8644-e9f472697bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a00f95-d563-4d51-a5f2-af139261921a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a00f95-d563-4d51-a5f2-af139261921a.jpg?1",
             "name": "Simian Sling",
             "text": "Equipped creature gets +1/+1.\nWhenever Simian Sling or equipped creature becomes blocked, it deals 1 damage to defending player.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -6330,7 +6330,7 @@
         },
         {
             "id": "213c2ff0-9d35-5912-a7d7-6000f36a5448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758724f9-93c9-4178-ae40-3fefc75a010e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758724f9-93c9-4178-ae40-3fefc75a010e.jpg?1",
             "name": "Sokenzan Smelter",
             "text": "At the beginning of combat on your turn, you may pay {1} and sacrifice an artifact. If you do, create a 3/1 red Construct artifact creature token with haste.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "e24e2e15-6faf-5a68-a4c9-53c755f5e479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd0693-6dba-4c0d-8c42-859d7bf38c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd0693-6dba-4c0d-8c42-859d7bf38c40.jpg?1",
             "name": "Tempered in Solitude",
             "text": "Whenever a creature you control attacks alone, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6397,7 +6397,7 @@
         },
         {
             "id": "b2c633bb-c486-5dd2-95f0-608fec8fc5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1a2920-6d39-4276-921c-65cc16a45f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1a2920-6d39-4276-921c-65cc16a45f17.jpg?1",
             "name": "Thundering Raiju",
             "text": "Haste\nWhenever Thundering Raiju attacks, put a +1/+1 counter on target creature you control. Then Thundering Raiju deals X damage to each opponent, where X is the number of modified creatures you control other than Thundering Raiju. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6434,7 +6434,7 @@
         },
         {
             "id": "cbd992a3-becd-5764-9c22-c47ae1f32ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ff9be1-765f-4001-a0ac-39c8099924eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ff9be1-765f-4001-a0ac-39c8099924eb.jpg?1",
             "name": "Towashi Songshaper",
             "text": "Whenever another artifact enters the battlefield under your control, Towashi Songshaper gets +1/+0 until end of turn.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "b4c7770f-f788-5217-87d4-dd9d95755838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a86009-4637-4b6c-9d36-367151583668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a86009-4637-4b6c-9d36-367151583668.jpg?1",
             "name": "Twinshot Sniper",
             "text": "Reach\nWhen Twinshot Sniper enters the battlefield, it deals 2 damage to any target.\nChannel \u2014 {1}{R}, Discard Twinshot Sniper: It deals 2 damage to any target.",
             "colours": [
@@ -6506,7 +6506,7 @@
         },
         {
             "id": "93bfb5b2-0f55-5c2c-abe9-3fa3e0272b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719f20d9-2baa-49b3-8c6a-89f21a07d538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719f20d9-2baa-49b3-8c6a-89f21a07d538.jpg?1",
             "name": "Unstoppable Ogre",
             "text": "When Unstoppable Ogre enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -6542,7 +6542,7 @@
         },
         {
             "id": "9e5bda11-4164-56b8-b6c7-d60fd2c2c2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d878c2-a340-4751-adaa-e50b0bb85423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d878c2-a340-4751-adaa-e50b0bb85423.jpg?1",
             "name": "Upriser Renegade",
             "text": "Upriser Renegade gets +2/+0 for each other modified creature you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6579,7 +6579,7 @@
         },
         {
             "id": "13882ddf-4134-5d8e-9f8e-571f0d2d8b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b7141-45b9-4629-a4e4-b50f93929717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b7141-45b9-4629-a4e4-b50f93929717.jpg?1",
             "name": "Voltage Surge",
             "text": "As an additional cost to cast this spell, you may sacrifice an artifact.\nVoltage Surge deals 2 damage to target creature or planeswalker. If this spell's additional cost was paid, Voltage Surge deals 4 damage instead.",
             "colours": [
@@ -6611,7 +6611,7 @@
         },
         {
             "id": "34fd3ebf-ae2c-5ad3-abc2-ece387b2d3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg?1",
             "name": "Azusa's Many Journeys // Likeness of the Seeker",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 You may play an additional land this turn.\nII \u2014 You gain 3 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -6645,7 +6645,7 @@
         },
         {
             "id": "2649d2cb-b59e-533b-afe5-334e8f310b62",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg?1",
             "name": "Azusa's Many Journeys // Likeness of the Seeker",
             "text": "Whenever Likeness of the Seeker becomes blocked, untap up to three lands you control.",
             "colours": [
@@ -6681,7 +6681,7 @@
         },
         {
             "id": "0551a67e-049f-582b-af96-cb2bd4d20ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b43bb9f-1b84-41cc-a4f9-5875ae6d207c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b43bb9f-1b84-41cc-a4f9-5875ae6d207c.jpg?1",
             "name": "Bamboo Grove Archer",
             "text": "Defender, reach\nChannel \u2014 {4}{G}, Discard Bamboo Grove Archer: Destroy target creature with flying.",
             "colours": [
@@ -6717,7 +6717,7 @@
         },
         {
             "id": "3cd4e31a-4336-5362-99d0-34838f4568ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540ba70a-bea8-4512-83ba-92dab6d25b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540ba70a-bea8-4512-83ba-92dab6d25b52.jpg?1",
             "name": "Bearer of Memory",
             "text": "{5}{G}: Put a +1/+1 counter on target enchantment creature. It gains trample until end of turn.",
             "colours": [
@@ -6753,7 +6753,7 @@
         },
         {
             "id": "e7d98862-6983-50fa-bf8d-f0d49326dbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26abdf2-efd7-40e5-bfc6-d75fcadd26f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26abdf2-efd7-40e5-bfc6-d75fcadd26f8.jpg?1",
             "name": "Blossom Prancer",
             "text": "Reach\nWhen Blossom Prancer enters the battlefield, look at the top five cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, you gain 4 life.",
             "colours": [
@@ -6787,7 +6787,7 @@
         },
         {
             "id": "a2cae6ad-d9df-5e02-aef3-4e349fe42ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06771591-0480-4232-bc67-216b2e0fe738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06771591-0480-4232-bc67-216b2e0fe738.jpg?1",
             "name": "Boon of Boseiju",
             "text": "Target creature gets +X/+X until end of turn, where X is the greatest mana value among permanents you control. Untap it.",
             "colours": [
@@ -6819,7 +6819,7 @@
         },
         {
             "id": "b0d99b95-a0e2-5afd-abcd-4fd24793ca42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg?1",
             "name": "Boseiju Reaches Skyward // Branch of Boseiju",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Search your library for up to two basic Forest cards, reveal them, put them into your hand, then shuffle.\nII \u2014 Put up to one target land card from your graveyard on top of your library.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -6853,7 +6853,7 @@
         },
         {
             "id": "47355285-ab9e-5748-858f-ae3f62af3579",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg?1",
             "name": "Boseiju Reaches Skyward // Branch of Boseiju",
             "text": "Reach\nBranch of Boseiju gets +1/+1 for each land you control.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "1aaf1c02-71c9-5530-841d-cf7ed6b64d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2ebad5-0a56-4166-80af-7ebd20ae565a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2ebad5-0a56-4166-80af-7ebd20ae565a.jpg?1",
             "name": "Careful Cultivation",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +1/+3 and has reach and \"{T}: Add {G}{G}.\"\nChannel \u2014 {1}{G}, Discard Careful Cultivation: Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"",
             "colours": [
@@ -6922,7 +6922,7 @@
         },
         {
             "id": "550680a6-a484-5949-9381-19f75a03afbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eba24f6-8a9c-4398-b2ab-3924b107c7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eba24f6-8a9c-4398-b2ab-3924b107c7b7.jpg?1",
             "name": "Coiling Stalker",
             "text": "Ninjutsu {1}{G} ({1}{G}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Coiling Stalker deals combat damage to a player, put a +1/+1 counter on target creature you control that doesn't have a +1/+1 counter on it.",
             "colours": [
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "9d2bd07e-4b55-56ff-a7cf-3a3d2d23eb23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ff4dd-bad3-4496-82b3-8253f48af06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ff4dd-bad3-4496-82b3-8253f48af06d.jpg?1",
             "name": "Commune with Spirits",
             "text": "Look at the top four cards of your library. You may reveal an enchantment or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "1285a01c-6b69-58c9-82e0-bec092465844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 You gain 2 life. Look at the top three cards of your library. Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "81f21804-bf2f-5b0a-bee4-36d1e63cffe9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "Whenever Dragon-Kami's Egg or a Dragon you control dies, you may cast a creature spell from among cards you own in exile with hatching counters on them without paying its mana cost.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "b6e328f0-5d1b-57d6-8cbb-989c50b08c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55174ab7-9f2e-42e5-a61b-57458cfd33f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55174ab7-9f2e-42e5-a61b-57458cfd33f3.jpg?1",
             "name": "Fade into Antiquity",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "0ebf0136-1096-50a9-b65b-035935445fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd0fef1-209f-4de5-a736-8f9bca2faa0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd0fef1-209f-4de5-a736-8f9bca2faa0a.jpg?1",
             "name": "Fang of Shigeki",
             "text": "Deathtouch",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "0c6593d9-2f70-5731-bf0e-252e52526ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013266a-81f4-4441-8dcf-2764d14afceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013266a-81f4-4441-8dcf-2764d14afceb.jpg?1",
             "name": "Favor of Jukai",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +3/+3 and has reach.\nChannel \u2014 {1}{G}, Discard Favor of Jukai: Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -7170,7 +7170,7 @@
         },
         {
             "id": "a9c36462-d45d-5a0c-b76c-c1d1ec87674e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1066ccd-a932-4d05-98da-11ae4675364e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1066ccd-a932-4d05-98da-11ae4675364e.jpg?1",
             "name": "Generous Visitor",
             "text": "Whenever you cast an enchantment spell, put a +1/+1 counter on target creature.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "21116e40-cad1-5365-898d-caa3c2f06039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d7162-39fc-4d99-8c5f-b40a765b883a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d7162-39fc-4d99-8c5f-b40a765b883a.jpg?1",
             "name": "Geothermal Kami",
             "text": "When Geothermal Kami enters the battlefield, you may return an enchantment you control to its owner's hand. If you do, you gain 3 life.",
             "colours": [
@@ -7238,7 +7238,7 @@
         },
         {
             "id": "49957446-7c02-5c2e-ba1a-11b7be2b98af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691016a1-8630-423c-9a57-061593d170fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691016a1-8630-423c-9a57-061593d170fd.jpg?1",
             "name": "Go-Shintai of Boundless Vigor",
             "text": "Trample\nAt the beginning of your end step, you may pay {1}. When you do, put a +1/+1 counter on target Shrine for each Shrine you control.",
             "colours": [
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "0dab9121-ce6e-5d18-a1e5-9c5fafc6bb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a15010-1b70-4b4f-8b5d-cb2d764a1799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a15010-1b70-4b4f-8b5d-cb2d764a1799.jpg?1",
             "name": "Grafted Growth",
             "text": "Enchant land\nWhen Grafted Growth enters the battlefield, put a +1/+1 counter on target creature or Vehicle you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "b8c064d3-14ef-5068-ab8e-8d4455197a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fbaee3-a10f-4b2d-b07e-d041a96a7e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fbaee3-a10f-4b2d-b07e-d041a96a7e27.jpg?1",
             "name": "Greater Tanuki",
             "text": "Trample\nChannel \u2014 {2}{G}, Discard Greater Tanuki: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "20c06679-1915-5559-9b8e-bfcd43b8b134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ff968-b436-4313-8375-8a3bb41f9892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ff968-b436-4313-8375-8a3bb41f9892.jpg?1",
             "name": "Harmonious Emergence",
             "text": "Enchant land you control\nEnchanted land is a 4/5 green Spirit creature with vigilance and haste. It's still a land.\nIf enchanted land would be destroyed, instead sacrifice Harmonious Emergence and that land gains indestructible until end of turn.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "f72f4a23-a50e-5b9f-91c1-694668416db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45daa56-6ad8-4df7-9d81-3193fd32e574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45daa56-6ad8-4df7-9d81-3193fd32e574.jpg?1",
             "name": "Heir of the Ancient Fang",
             "text": "Heir of the Ancient Fang enters the battlefield with a +1/+1 counter on it if you control a modified creature. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "4be47f4f-75b2-55c7-8a10-acfe234c25aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941f91bb-f5a3-4cca-85b5-b610502460bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941f91bb-f5a3-4cca-85b5-b610502460bb.jpg?1",
             "name": "Historian's Wisdom",
             "text": "Enchant artifact or creature\nWhen Historian's Wisdom enters the battlefield, if enchanted permanent is a creature with the greatest power among creatures on the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it gets +2/+1.",
             "colours": [
@@ -7449,7 +7449,7 @@
         },
         {
             "id": "863ec27b-bbd8-5cfd-a571-bc17a39c08c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c02102-3be7-462f-ab9c-ff404255002d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c02102-3be7-462f-ab9c-ff404255002d.jpg?1",
             "name": "Invoke the Ancients",
             "text": "Create two 4/5 green Spirit creature tokens. For each of them, put your choice of a vigilance counter, a reach counter, or a trample counter on it.",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "60e2af6f-d9b9-5338-b02c-cc0a3846c6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"\nII \u2014 Put a +1/+1 counter on each of up to two target creatures.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "ce05e474-1979-5f32-b08e-72a832cb4db4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on that creature.\nAs long as you control five or more modified creatures, Remnant of the Rising Star gets +5/+5 and has trample. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -7560,7 +7560,7 @@
         },
         {
             "id": "5ed3eef1-f470-52b3-90d8-a4d56738707e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66120a5-95a3-4d15-873c-cfba221a2299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66120a5-95a3-4d15-873c-cfba221a2299.jpg?1",
             "name": "Jukai Preserver",
             "text": "When Jukai Preserver enters the battlefield, put a +1/+1 counter on target creature you control.\nChannel \u2014 {2}{G}, Discard Jukai Preserver: Put a +1/+1 counter on each of up to two target creatures you control.",
             "colours": [
@@ -7596,7 +7596,7 @@
         },
         {
             "id": "35085fce-178f-5ca7-9f2e-e0a7f098b3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be526cd-1480-4661-a05b-e004d7b4656c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be526cd-1480-4661-a05b-e004d7b4656c.jpg?1",
             "name": "Jukai Trainee",
             "text": "Whenever Jukai Trainee blocks or becomes blocked, it gets +1/+1 until end of turn.",
             "colours": [
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "8ceb44a4-1427-5d26-9ee4-f982d3af8b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d038a59-e589-45f4-b5ef-6d2f9875d560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d038a59-e589-45f4-b5ef-6d2f9875d560.jpg?1",
             "name": "Kami of Transience",
             "text": "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on Kami of Transience.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return Kami of Transience from your graveyard to your hand.",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "3323c0b0-b345-5136-89e3-8d268b93685c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a7bc69-4500-4e7e-94e4-67b85597bd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a7bc69-4500-4e7e-94e4-67b85597bd82.jpg?1",
             "name": "Kappa Tech-Wrecker",
             "text": "Ninjutsu {1}{G}\nKappa Tech-Wrecker enters the battlefield with a deathtouch counter on it.\nWhenever Kappa Tech-Wrecker deals combat damage to a player, you may remove a deathtouch counter from it. When you do, exile target artifact or enchantment that player controls.",
             "colours": [
@@ -7707,7 +7707,7 @@
         },
         {
             "id": "c0bf15e5-3e01-5c3b-85fb-f4712afe0e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e1dff-b559-441d-8df3-b6a418066aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e1dff-b559-441d-8df3-b6a418066aca.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "Reach\nModified creatures you control have trample. (Equipment, Auras you control, and counters are modifications.)\nWhenever a modified creature you control deals combat damage to a player, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7747,7 +7747,7 @@
         },
         {
             "id": "b76f513b-00c3-57e9-99ad-889643c994c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b25752-26be-4189-bc8b-828db6f0e612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b25752-26be-4189-bc8b-828db6f0e612.jpg?1",
             "name": "Kura, the Boundless Sky",
             "text": "Flying, deathtouch\nWhen Kura, the Boundless Sky dies, choose one \u2014\n\u2022 Search your library for up to three land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Create an X/X green Spirit creature token, where X is the number of lands you control.",
             "colours": [
@@ -7787,7 +7787,7 @@
         },
         {
             "id": "749a36c5-2621-59a1-ab94-b6adb63e5588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e223d99-408a-413d-abb1-cb2f11ae521d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e223d99-408a-413d-abb1-cb2f11ae521d.jpg?1",
             "name": "March of Burgeoning Life",
             "text": "As an additional cost to cast this spell, you may exile any number of green cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nChoose target creature with mana value less than X. Search your library for a creature card with the same name as that creature, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "41644b59-168e-54c4-aad8-dbd751a57bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42ca7c-5b36-45a9-b235-4f90e66f4377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42ca7c-5b36-45a9-b235-4f90e66f4377.jpg?1",
             "name": "Master's Rebuke",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "1b70aeea-46af-5704-bbde-8d6308ae33d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736c3278-6ee2-47f9-aab0-1457e90137b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736c3278-6ee2-47f9-aab0-1457e90137b1.jpg?1",
             "name": "Orochi Merge-Keeper",
             "text": "{T}: Add {G}.\nAs long as Orochi Merge-Keeper is modified, it has \"{T}: Add {G}{G}.\" (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -7889,7 +7889,7 @@
         },
         {
             "id": "72f182d1-cbd0-5e34-9d3d-3bf604d0c50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbdd88e-c532-4fc0-a1fe-8aa0c26d1092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbdd88e-c532-4fc0-a1fe-8aa0c26d1092.jpg?1",
             "name": "Roaring Earth",
             "text": "Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature or Vehicle you control.\nChannel \u2014 {X}{G}{G}, Discard Roaring Earth: Put X +1/+1 counters on target land you control. It becomes a 0/0 green Spirit creature with haste. It's still a land.",
             "colours": [
@@ -7921,7 +7921,7 @@
         },
         {
             "id": "9082406e-8a03-591d-8e6d-32abb28e5534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841f0ec2-94c7-4cec-94bb-b365084ca45f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841f0ec2-94c7-4cec-94bb-b365084ca45f.jpg?1",
             "name": "Season of Renewal",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -7953,7 +7953,7 @@
         },
         {
             "id": "feb59d6e-ee2d-5f4f-9f13-1a5e644551ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a16623-7e6d-405b-95db-bf18aeea3f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a16623-7e6d-405b-95db-bf18aeea3f49.jpg?1",
             "name": "Shigeki, Jukai Visionary",
             "text": "{1}{G}, {T}, Return Shigeki, Jukai Visionary to its owner's hand: Reveal the top four cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest into your graveyard.\nChannel \u2014 {X}{X}{G}{G}, Discard Shigeki: Return X target nonlegendary cards from your graveyard to your hand.",
             "colours": [
@@ -7994,7 +7994,7 @@
         },
         {
             "id": "2b9f3c2a-555e-5229-b672-e3defc3e08e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f36ddd7-82c1-45ef-a966-ae2a34c540e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f36ddd7-82c1-45ef-a966-ae2a34c540e1.jpg?1",
             "name": "Spinning Wheel Kick",
             "text": "Target creature you control deals damage equal to its power to each of X target creatures and/or planeswalkers.",
             "colours": [
@@ -8026,7 +8026,7 @@
         },
         {
             "id": "e8340bce-194d-5bf4-a10c-bc5f15bf1c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1ba9c-ee62-461f-8422-f791274e2f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1ba9c-ee62-461f-8422-f791274e2f1c.jpg?1",
             "name": "Spring-Leaf Avenger",
             "text": "Ninjutsu {3}{G} ({3}{G}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Spring-Leaf Avenger deals combat damage to a player, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -8064,7 +8064,7 @@
         },
         {
             "id": "f930708f-e4b2-5263-8301-13609541952a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a77eed-aa03-43b7-b3c8-6aee4c96c648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a77eed-aa03-43b7-b3c8-6aee4c96c648.jpg?1",
             "name": "Storyweave",
             "text": "Choose one \u2014\n\u2022 Put two +1/+1 counters on target creature you control.\n\u2022 Put two lore counters on target Saga you control. The next time one or more enchantment creatures enter the battlefield under your control this turn, each enters with two additional +1/+1 counters on it.",
             "colours": [
@@ -8096,7 +8096,7 @@
         },
         {
             "id": "57b9ab73-4bee-5e41-8b23-4e34fe7d157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg?1",
             "name": "Tales of Master Seshiro // Seshiro's Living Legacy",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Put a +1/+1 counter on target creature or Vehicle you control. It gains vigilance until end of turn.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8130,7 +8130,7 @@
         },
         {
             "id": "a8630b25-30f9-54a8-8c52-b21093d723a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg?1",
             "name": "Tales of Master Seshiro // Seshiro's Living Legacy",
             "text": "Vigilance, haste",
             "colours": [
@@ -8166,7 +8166,7 @@
         },
         {
             "id": "0650fc5d-0edb-50cb-a547-3f177ac3d24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4b7ee2-de65-4288-872d-486065a4f226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4b7ee2-de65-4288-872d-486065a4f226.jpg?1",
             "name": "Tamiyo's Safekeeping",
             "text": "Target permanent you control gains hexproof and indestructible until end of turn. You gain 2 life.(A permanent with hexproof and indestructible can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "586dc7fe-bcbc-59ba-b234-085ff74f503a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill three cards. Create a 1/1 colorless Spirit creature token.\nII \u2014 Put a +1/+1 counter on target creature you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "b09459b8-a39f-5c42-b1ea-c83b5b91724e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "Whenever Kirin-Touched Orochi attacks, choose one \u2014\n\u2022 Exile target creature card from a graveyard. When you do, create a 1/1 colorless Spirit creature token.\n\u2022 Exile target noncreature card from a graveyard. When you do, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8274,7 +8274,7 @@
         },
         {
             "id": "c772def6-a5a7-5549-8f72-d47cdb76961b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1682673-e947-44e2-b9c9-cbcb9a16892b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1682673-e947-44e2-b9c9-cbcb9a16892b.jpg?1",
             "name": "Weaver of Harmony",
             "text": "Other enchantment creatures you control get +1/+1.\n{G}, {T}: Copy target activated or triggered ability you control from an enchantment source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
             "colours": [
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "1894d9f2-e0ae-5dc0-adc6-a63fb24fd3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73cc6a7-0a18-488c-b52a-787da95a2e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73cc6a7-0a18-488c-b52a-787da95a2e6b.jpg?1",
             "name": "Webspinner Cuff",
             "text": "Reach\nEquipped creature gets +1/+4 and has reach.\nReconfigure {4} ({4}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -8349,7 +8349,7 @@
         },
         {
             "id": "589fa1d7-d898-50de-9c37-b23aaf1f5e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b4e6a-1812-4399-8fe4-bb1686ba49ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b4e6a-1812-4399-8fe4-bb1686ba49ef.jpg?1",
             "name": "Asari Captain",
             "text": "Haste\nWhenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.",
             "colours": [
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "6bd4eeb4-81e7-5393-b579-34a9dfd923ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40bd797-4d12-4098-a1a8-d7e5b7b82ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40bd797-4d12-4098-a1a8-d7e5b7b82ac9.jpg?1",
             "name": "Colossal Skyturtle",
             "text": "Flying, ward {2}\nChannel \u2014 {2}{G}, Discard Colossal Skyturtle: Return target card from your graveyard to your hand.\nChannel \u2014 {1}{U}, Discard Colossal Skyturtle: Return target creature to its owner's hand.",
             "colours": [
@@ -8425,7 +8425,7 @@
         },
         {
             "id": "39ff65f2-0121-5657-bbfc-a1e4c8df04f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35203138-5237-49aa-a335-7a32829548a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35203138-5237-49aa-a335-7a32829548a1.jpg?1",
             "name": "Eiganjo Uprising",
             "text": "Create X 2/2 white Samurai creature tokens with vigilance. They gain menace and haste until end of turn.\nEach opponent creates X minus one 2/2 white Samurai creature tokens with vigilance.",
             "colours": [
@@ -8462,7 +8462,7 @@
         },
         {
             "id": "68b7d0f3-5389-53a6-8578-3815d100ec9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00521f-1b7d-478d-afe8-6761ea512d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00521f-1b7d-478d-afe8-6761ea512d8d.jpg?1",
             "name": "Enthusiastic Mechanaut",
             "text": "Flying\nArtifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "557d0e90-e2d2-5349-b886-e64aba07cbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b50751-7f65-4321-86da-eef735bf8b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b50751-7f65-4321-86da-eef735bf8b67.jpg?1",
             "name": "Gloomshrieker",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Gloomshrieker enters the battlefield, return target permanent card from your graveyard to your hand.\nIf Gloomshrieker would die, exile it instead.",
             "colours": [
@@ -8540,7 +8540,7 @@
         },
         {
             "id": "5cff0b8e-ae7e-5489-887a-5f58af8a2c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a0d43b-4d38-40a7-be6c-8324ab3bf773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a0d43b-4d38-40a7-be6c-8324ab3bf773.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "At the beginning of combat on your turn, return target Vehicle card from your graveyard to the battlefield. It gains haste. Return it to its owner's hand at the beginning of your next end step.",
             "colours": [
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "fde7c235-495e-5277-93db-b22522cdcd5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Destroy each nonland permanent with mana value 1 or less.\nII \u2014 Exile all graveyards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8621,7 +8621,7 @@
         },
         {
             "id": "5dccaf2a-e203-5d82-b91c-eb2fdb559eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "Trample\nWhenever Vessel of the All-Consuming deals damage, put a +1/+1 counter on it.\nWhenever Vessel of the All-Consuming deals damage to a player, if it has dealt 10 or more damage to that player this turn, they lose the game.",
             "colours": [
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "855600e3-71d8-5dc2-89bb-7785dce3c47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25aff90-56fd-4f70-bb3b-cabf2900c391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25aff90-56fd-4f70-bb3b-cabf2900c391.jpg?1",
             "name": "Hinata, Dawn-Crowned",
             "text": "Flying, trample\nSpells you cast cost {1} less to cast for each target.\nSpells your opponents cast cost {1} more to cast for each target.",
             "colours": [
@@ -8706,7 +8706,7 @@
         },
         {
             "id": "0073008c-2bf2-52a3-9093-6a39d3e01f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a118d1-30b8-42c0-ac42-6fba0778200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a118d1-30b8-42c0-ac42-6fba0778200a.jpg?1",
             "name": "Invigorating Hot Spring",
             "text": "Invigorating Hot Spring enters the battlefield with four +1/+1 counters on it.\nModified creatures you control have haste. (Equipment, Auras you control, and counters are modifications.)\nRemove a +1/+1 counter from Invigorating Hot Spring: Put a +1/+1 counter on target creature you control. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -8740,7 +8740,7 @@
         },
         {
             "id": "6223bd64-f295-50f2-97db-1e17f6ba99b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062a004-984e-4b62-960c-af7288f7a3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062a004-984e-4b62-960c-af7288f7a3e9.jpg?1",
             "name": "Isshin, Two Heavens as One",
             "text": "If a creature attacking causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "54471ea2-f563-5892-b211-e4f6b912f4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5366900b-2abf-4e5c-8507-f51aca9c7ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5366900b-2abf-4e5c-8507-f51aca9c7ce8.jpg?1",
             "name": "Jukai Naturalist",
             "text": "Lifelink\nEnchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -8824,7 +8824,7 @@
         },
         {
             "id": "2afa6690-ec57-5501-8659-4b11ce8b35e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d35a710-3008-4e27-8afd-6e83329f9917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d35a710-3008-4e27-8afd-6e83329f9917.jpg?1",
             "name": "Kaito Shizuki",
             "text": "At the beginning of your end step, if Kaito Shizuki entered the battlefield this turn, he phases out.\n+1: Draw a card. Then discard a card unless you attacked this turn.\n\u22122: Create a 1/1 blue Ninja creature token with \"This creature can't be blocked.\"\n\u22127: You get an emblem with \"Whenever a creature you control deals combat damage to a player, search your library for a blue or black creature card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -8866,7 +8866,7 @@
         },
         {
             "id": "5760a74f-8685-58df-9ec5-74a28e17b372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile target nonland permanent an opponent controls.\nII \u2014 Return up to one other target nonland permanent to its owner's hand. Then each opponent discards a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "edcb8ea4-c961-52d4-a188-82abc60481f7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "O-Kagachi Made Manifest is all colors.\nFlying, trample\nWhenever O-Kagachi Made Manifest attacks, defending player chooses a nonland card in your graveyard. Return that card to your hand. O-Kagachi Made Manifest gets +X/+0 until end of turn, where X is the mana value of that card.",
             "colours": [
@@ -8958,7 +8958,7 @@
         },
         {
             "id": "1451bc53-9193-580d-b163-0e2b5a59d08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e97b5-cd43-4f5e-acdd-a107208e061c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e97b5-cd43-4f5e-acdd-a107208e061c.jpg?1",
             "name": "Kotose, the Silent Spider",
             "text": "When Kotose, the Silent Spider enters the battlefield, exile target card other than a basic land card from an opponent's graveyard. Search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles. For as long as you control Kotose, you may play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -9000,7 +9000,7 @@
         },
         {
             "id": "c6146703-5caa-58d3-a181-64d3e657dfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4400fd66-1a24-47fb-bc94-37e0aae0e610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4400fd66-1a24-47fb-bc94-37e0aae0e610.jpg?1",
             "name": "Naomi, Pillar of Order",
             "text": "Whenever Naomi, Pillar of Order enters the battlefield or attacks, if you control an artifact and an enchantment, create a 2/2 white Samurai creature token with vigilance.",
             "colours": [
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "8b72d531-3261-52dc-843c-e529be89c696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84db1e2-855c-4169-a9cc-a54c73c14e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84db1e2-855c-4169-a9cc-a54c73c14e0c.jpg?1",
             "name": "Oni-Cult Anvil",
             "text": "Whenever one or more artifacts you control leave the battlefield during your turn, create a 1/1 colorless Construct artifact creature token. This ability triggers only once each turn.\n{T}, Sacrifice an artifact: Oni-Cult Anvil deals 1 damage to each opponent. You gain 1 life.",
             "colours": [
@@ -9073,7 +9073,7 @@
         },
         {
             "id": "bae38a34-14ae-52a3-bc39-6b238cbcaf65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be046e0a-6509-450b-b34f-29d5a5e3472e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be046e0a-6509-450b-b34f-29d5a5e3472e.jpg?1",
             "name": "Prodigy's Prototype",
             "text": "Whenever one or more Vehicles you control attack, create a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "7749b2bd-fe9d-54d3-8686-407635b8eba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37748b74-0eda-4b20-a08f-faa418adb9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37748b74-0eda-4b20-a08f-faa418adb9ff.jpg?1",
             "name": "Raiyuu, Storm's Edge",
             "text": "First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "colours": [
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "a78817be-d624-5a64-a119-934d751042af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8f1fa-ca92-4e2e-91e8-195bdad82def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8f1fa-ca92-4e2e-91e8-195bdad82def.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "Haste\nWhenever Risona, Asari Commander deals combat damage to a player, if it doesn't have an indestructible counter on it, put an indestructible counter on it.\nWhenever combat damage is dealt to you, remove an indestructible counter from Risona.",
             "colours": [
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "a9a1963b-b751-5de7-98b6-47de633f79f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8887f26d-b097-4fbc-9c48-bdc656409a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8887f26d-b097-4fbc-9c48-bdc656409a32.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -9238,7 +9238,7 @@
         },
         {
             "id": "04e88882-2e45-5a21-b836-1d1ff79a1a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0152575b-31b0-4142-9cc2-b87a81bd51a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0152575b-31b0-4142-9cc2-b87a81bd51a8.jpg?1",
             "name": "Satsuki, the Living Lore",
             "text": "{T}: Put a lore counter on each Saga you control. Activate only as a sorcery.\nWhen Satsuki, the Living Lore dies, choose up to one \u2014\n\u2022 Return target Saga or enchantment creature you control to its owner's hand.\n\u2022 Return target Saga card from your graveyard to your hand.",
             "colours": [
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "e472aa7d-bf2c-50ea-bc04-7c44ff7b6c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacc36d9-4c4b-43b2-a8b4-d265deb1e6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacc36d9-4c4b-43b2-a8b4-d265deb1e6b2.jpg?1",
             "name": "Silver-Fur Master",
             "text": "Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.",
             "colours": [
@@ -9320,7 +9320,7 @@
         },
         {
             "id": "d5e3f668-af8f-5974-a5a6-ac067de534db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f094735f-5843-4f75-bc90-3e248a061a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f094735f-5843-4f75-bc90-3e248a061a43.jpg?1",
             "name": "Spirit-Sister's Call",
             "text": "At the beginning of your end step, choose target permanent card in your graveyard. You may sacrifice a permanent that shares a card type with the chosen card. If you do, return the chosen card from your graveyard to the battlefield and it gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\"",
             "colours": [
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "59c7f473-c87a-5758-90e9-425b454075c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222a736e-d819-452d-aeda-eb848c4b2302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222a736e-d819-452d-aeda-eb848c4b2302.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "Compleated ({Variable} can be paid with {G}, {U}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Tap up to one target artifact or creature. It doesn't untap during its controller's next untap step.\n\u2212X: Exile target nonland permanent card with mana value X from your graveyard. Create a token that's a copy of that card.\n\u22127: Create Tamiyo's Notebook, a legendary colorless artifact token with \"Spells you cast cost {2} less to cast\" and \"{T}: Draw a card.\"",
             "colours": [
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "0244d788-e8f9-5630-9715-5886fd6745bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c30ffb-b4f5-40b0-87b8-800a42bded2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c30ffb-b4f5-40b0-87b8-800a42bded2b.jpg?1",
             "name": "Automated Artificer",
             "text": "{T}: Add {C}. Spend this mana only to activate an ability or cast an artifact spell.",
             "colours": [],
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "6325be0f-7169-5ca6-a777-0eddbac9d5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fa226c-cc31-4c22-a167-40985706557b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fa226c-cc31-4c22-a167-40985706557b.jpg?1",
             "name": "Bronze Cudgels",
             "text": "{2}: Until end of turn, equipped creature gets +X/+0, where X is the number of times this ability has resolved this turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9460,7 +9460,7 @@
         },
         {
             "id": "a0c910c9-9d64-5381-afcf-5fdb5a7ea452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cb43a-e358-4380-a42f-9b095ca522c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cb43a-e358-4380-a42f-9b095ca522c6.jpg?1",
             "name": "Brute Suit",
             "text": "Vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9490,7 +9490,7 @@
         },
         {
             "id": "f5b7605d-ef20-50ca-8511-cace967423cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg?1",
             "name": "Circuit Mender",
             "text": "When Circuit Mender enters the battlefield, you gain 2 life.\nWhen Circuit Mender leaves the battlefield, draw a card.",
             "colours": [],
@@ -9521,7 +9521,7 @@
         },
         {
             "id": "48b77764-6400-5d92-8cc0-11ca0aa758fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520e5505-429b-4da0-b25e-14b8d4e81ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520e5505-429b-4da0-b25e-14b8d4e81ce3.jpg?1",
             "name": "Containment Construct",
             "text": "Whenever you discard a card, you may exile that card from your graveyard. If you do, you may play that card this turn.",
             "colours": [],
@@ -9552,7 +9552,7 @@
         },
         {
             "id": "5d5aff94-224a-593d-8ddc-fc79a9f36195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b490e065-b54a-4015-9768-d0e62f0e2e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b490e065-b54a-4015-9768-d0e62f0e2e84.jpg?1",
             "name": "Dramatist's Puppet",
             "text": "When Dramatist's Puppet enters the battlefield, for each kind of counter on target permanent, put another counter of that kind on it or remove one from it.",
             "colours": [],
@@ -9583,7 +9583,7 @@
         },
         {
             "id": "ce32b5eb-7028-569e-bb05-0e1f4a9eb054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d92077-d7b2-4996-848f-fd4917e2fb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d92077-d7b2-4996-848f-fd4917e2fb42.jpg?1",
             "name": "Eater of Virtue",
             "text": "Whenever equipped creature dies, exile it.\nEquipped creature gets +2/+0.\nAs long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.\nEquip {1}",
             "colours": [],
@@ -9618,7 +9618,7 @@
         },
         {
             "id": "b35452ee-5e44-5ba2-8a24-bb49f9914462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d981026-b2df-4d8d-a9b4-296b011d9925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d981026-b2df-4d8d-a9b4-296b011d9925.jpg?1",
             "name": "Ecologist's Terrarium",
             "text": "When Ecologist's Terrarium enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{2}, {T}, Sacrifice Ecologist's Terrarium: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [],
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "28af4320-3185-5893-a9b8-e2872012c5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c619116-1eae-439d-9b1f-639643458a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c619116-1eae-439d-9b1f-639643458a23.jpg?1",
             "name": "High-Speed Hoverbike",
             "text": "Flash\nFlying\nWhen High-Speed Hoverbike enters the battlefield, tap up to one target creature.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9676,7 +9676,7 @@
         },
         {
             "id": "f6b2d2b8-649a-5692-8bbd-66979aab78c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6d9fc-509b-42db-8ac1-85066eb6e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6d9fc-509b-42db-8ac1-85066eb6e9c4.jpg?1",
             "name": "Iron Apprentice",
             "text": "Iron Apprentice enters the battlefield with a +1/+1 counter on it.\nWhen Iron Apprentice dies, if it had counters on it, put those counters on target creature you control.",
             "colours": [],
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "6284e544-335d-5c6d-bd65-3b6585e4f19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca286ba9-01a7-4dce-b388-177f5dcb95b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca286ba9-01a7-4dce-b388-177f5dcb95b1.jpg?1",
             "name": "Mechtitan Core",
             "text": "{5}, Exile Mechtitan Core and four other artifact creatures and/or Vehicles you control: Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors. When that token leaves the battlefield, return all cards exiled with Mechtitan Core except Mechtitan Core to the battlefield tapped under their owners' control.\nCrew 2",
             "colours": [],
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "ee311e6d-2cce-543c-835d-cedcdc86442a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d507daa3-3f16-4ab1-81ea-794e5bb488fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d507daa3-3f16-4ab1-81ea-794e5bb488fc.jpg?1",
             "name": "Mirror Box",
             "text": "The \"legend rule\" doesn't apply to permanents you control.\nEach legendary creature you control gets +1/+1.\nEach nontoken creature you control gets +1/+1 for each other creature you control with the same name as that creature.",
             "colours": [],
@@ -9771,7 +9771,7 @@
         },
         {
             "id": "fff966b5-e4fa-5ddb-ab33-501ab3701a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61e596f-97ef-4eb3-af42-ddfe50d07667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61e596f-97ef-4eb3-af42-ddfe50d07667.jpg?1",
             "name": "Network Terminal",
             "text": "{T}: Add one mana of any color.\n{1}, {T}, Tap another untapped artifact you control: Draw a card, then discard a card.",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "b918c3d0-4e46-5500-93d1-4a7985a39d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6ae567-c77a-416a-b609-4df3d0dd2e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6ae567-c77a-416a-b609-4df3d0dd2e18.jpg?1",
             "name": "Ninja's Kunai",
             "text": "Equipped creature has \"{1}, {T}, Sacrifice Ninja's Kunai: Ninja's Kunai deals 3 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9829,7 +9829,7 @@
         },
         {
             "id": "4789bf41-10d8-5c91-bd78-28acd11589d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3453084c-42cc-4241-b244-c79e704f96c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3453084c-42cc-4241-b244-c79e704f96c8.jpg?1",
             "name": "Papercraft Decoy",
             "text": "When Papercraft Decoy leaves the battlefield, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -9860,7 +9860,7 @@
         },
         {
             "id": "8c29e511-490a-5d27-89ab-4fc3759d2d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e1580-dd26-4f4b-ac98-3e6fa7b879d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e1580-dd26-4f4b-ac98-3e6fa7b879d5.jpg?1",
             "name": "Patchwork Automaton",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhenever you cast an artifact spell, put a +1/+1 counter on Patchwork Automaton.",
             "colours": [],
@@ -9891,7 +9891,7 @@
         },
         {
             "id": "55b5864a-8d81-55b5-bfd6-c927e0c380d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279acd17-6c17-427b-a69d-fc02442ff4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279acd17-6c17-427b-a69d-fc02442ff4a3.jpg?1",
             "name": "Reckoner Bankbuster",
             "text": "Reckoner Bankbuster enters the battlefield with three charge counters on it.\n{2}, {T}, Remove a charge counter from Reckoner Bankbuster: Draw a card. Then if there are no charge counters on Reckoner Bankbuster, create a Treasure token and a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 3",
             "colours": [],
@@ -9924,7 +9924,7 @@
         },
         {
             "id": "33eb8f7b-c2ed-5803-a748-90cbe2007c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0218923a-b685-4492-8fdd-2d2d22ef532e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0218923a-b685-4492-8fdd-2d2d22ef532e.jpg?1",
             "name": "Reito Sentinel",
             "text": "Defender\nWhen Reito Sentinel enters the battlefield, target player mills three cards. (They put the top three cards of their library into their graveyard.)\n{3}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "fd04376c-52ff-50bd-a9bf-1814e4a74580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eebf6a6-f1fd-40a1-ac27-367deafa6f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eebf6a6-f1fd-40a1-ac27-367deafa6f2a.jpg?1",
             "name": "Runaway Trash-Bot",
             "text": "Trample\nRunaway Trash-Bot gets +1/+0 for each artifact and/or enchantment card in your graveyard.",
             "colours": [],
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "e0d61bc4-1eaf-501c-9729-f580ad9c5865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79b30e-e7aa-490e-b130-de7533e6e13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79b30e-e7aa-490e-b130-de7533e6e13b.jpg?1",
             "name": "Searchlight Companion",
             "text": "Flying\nWhen Searchlight Companion enters the battlefield, create a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -10017,7 +10017,7 @@
         },
         {
             "id": "2e4d2a3d-ae3c-59cd-adc5-f61199df48dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e8d71c-3a0b-4042-a0f7-e99e92a79dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e8d71c-3a0b-4042-a0f7-e99e92a79dc2.jpg?1",
             "name": "Shrine Steward",
             "text": "When Shrine Steward enters the battlefield, you may search your library for an Aura or Shrine card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "20311449-033b-559f-8c30-e2effa40edc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4bf679-01cc-4786-a3bd-89c8ae70fdfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4bf679-01cc-4786-a3bd-89c8ae70fdfa.jpg?1",
             "name": "Surgehacker Mech",
             "text": "Menace\nWhen Surgehacker Mech enters the battlefield, it deals damage equal to twice the number of Vehicles you control to target creature or planeswalker an opponent controls.\nCrew 4",
             "colours": [],
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "8afb204e-c442-54b9-a950-1bfa3d481814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d49f9c-2dd3-4aed-9b78-e1bcad354a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d49f9c-2dd3-4aed-9b78-e1bcad354a35.jpg?1",
             "name": "Thundersteel Colossus",
             "text": "Trample, haste\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -10111,7 +10111,7 @@
         },
         {
             "id": "e4cf0817-f1a1-57ca-9e3c-ccfb05d029ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ccf70-b661-46ea-bea9-4466a3a35562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ccf70-b661-46ea-bea9-4466a3a35562.jpg?1",
             "name": "Towashi Guide-Bot",
             "text": "When Towashi Guide-Bot enters the battlefield, put a +1/+1 counter on target creature you control.\n{4}, {T}: Draw a card. This ability costs {1} less to activate for each modified creature you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "734519a1-6376-5e53-af5e-74a74fa3c835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958af4ba-f29e-47ef-995e-3985982c75ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958af4ba-f29e-47ef-995e-3985982c75ad.jpg?1",
             "name": "Walking Skyscraper",
             "text": "This spell costs {1} less to cast for each modified creature you control. (Equipment, Auras you control, and counters are modifications.)\nTrample\nWalking Skyscraper has hexproof as long as it's untapped. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [],
@@ -10173,7 +10173,7 @@
         },
         {
             "id": "5765ecef-a549-5979-bb23-fa08ac10da49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba06fcda-7ab8-48d4-8656-2a911e73dc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba06fcda-7ab8-48d4-8656-2a911e73dc44.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -10204,7 +10204,7 @@
         },
         {
             "id": "562b232a-13a5-562f-b04c-624eab33adc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290ec6b-15a6-49e8-abd2-b8c4d0f556eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290ec6b-15a6-49e8-abd2-b8c4d0f556eb.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "8f6e5033-fdb3-502c-85fc-ee71d77cbbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2135ac5a-187b-4dc9-8f82-34e8d1603416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2135ac5a-187b-4dc9-8f82-34e8d1603416.jpg?1",
             "name": "Boseiju, Who Endures",
             "text": "{T}: Add {G}.\nChannel \u2014 {1}{G}, Discard Boseiju, Who Endures: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "c6c88f02-ee95-57de-bbb6-62fdfc855cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab0660b-81f8-40ca-8098-5f8d51219a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab0660b-81f8-40ca-8098-5f8d51219a40.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -10301,7 +10301,7 @@
         },
         {
             "id": "a3c9ce9d-c5e6-567e-a475-19240c6bff28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375a022-5b57-496d-a802-e4ea8376e9e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375a022-5b57-496d-a802-e4ea8376e9e4.jpg?1",
             "name": "Eiganjo, Seat of the Empire",
             "text": "{T}: Add {W}.\nChannel \u2014 {2}{W}, Discard Eiganjo, Seat of the Empire: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10336,7 +10336,7 @@
         },
         {
             "id": "6aa5e279-721e-5d86-9c46-9304119e2701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadca61-0be9-4eeb-ba12-bc73a49bae74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadca61-0be9-4eeb-ba12-bc73a49bae74.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "2205f8d9-50bc-5dc5-bf0f-ca433862aabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c093984d-38cd-4b49-b179-1e289ab442d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c093984d-38cd-4b49-b179-1e289ab442d1.jpg?1",
             "name": "Mech Hangar",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Pilot or Vehicle spell.\n{3}, {T}: Target Vehicle becomes an artifact creature until end of turn.",
             "colours": [],
@@ -10395,7 +10395,7 @@
         },
         {
             "id": "f25d25fe-48bf-51c9-9b29-bedd6975f4e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486d7edc-d983-41f0-8b78-c99aecd72996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486d7edc-d983-41f0-8b78-c99aecd72996.jpg?1",
             "name": "Otawara, Soaring City",
             "text": "{T}: Add {U}.\nChannel \u2014 {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10430,7 +10430,7 @@
         },
         {
             "id": "a626eb95-5182-5111-8005-6b22aa5819e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8002de90-93fb-48ea-a849-40fdad0aef5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8002de90-93fb-48ea-a849-40fdad0aef5a.jpg?1",
             "name": "Roadside Reliquary",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Roadside Reliquary: Draw a card if you control an artifact. Draw a card if you control an enchantment.",
             "colours": [],
@@ -10458,7 +10458,7 @@
         },
         {
             "id": "e7ff6285-f9f2-559b-b0a7-727cea209b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d511be-60e0-4755-abec-18eebb530605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d511be-60e0-4755-abec-18eebb530605.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -10489,7 +10489,7 @@
         },
         {
             "id": "297590d9-2601-5722-93b5-e2e579e2170b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00538414-90f3-41da-b67e-d81cfa643de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00538414-90f3-41da-b67e-d81cfa643de3.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10520,7 +10520,7 @@
         },
         {
             "id": "0a6cef69-ab9a-5545-b810-afb8ec9a973b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As Secluded Courtyard enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature or creature card of the chosen type.",
             "colours": [],
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "c4e84811-f488-55b2-9b01-5ae741f9e040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa548dcd-c1dd-492d-a69f-c65dfeef0633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa548dcd-c1dd-492d-a69f-c65dfeef0633.jpg?1",
             "name": "Sokenzan, Crucible of Defiance",
             "text": "{T}: Add {R}.\nChannel \u2014 {3}{R}, Discard Sokenzan, Crucible of Defiance: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10585,7 +10585,7 @@
         },
         {
             "id": "afbc6770-154e-5f40-8a1b-de219d1211e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6c2670-e6fd-40d6-afe0-7d3c4db96a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6c2670-e6fd-40d6-afe0-7d3c4db96a4d.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10616,7 +10616,7 @@
         },
         {
             "id": "62c39db2-afee-518e-ad3c-c2ffb7abba5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499037cc-a577-41cb-8ca2-5e117945634f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499037cc-a577-41cb-8ca2-5e117945634f.jpg?1",
             "name": "Takenuma, Abandoned Mire",
             "text": "{T}: Add {B}.\nChannel \u2014 {3}{B}, Discard Takenuma, Abandoned Mire: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "d897313e-25e5-5e3d-8708-30d4c7257a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5af3569-3e66-4a50-aca0-c17c799dca28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5af3569-3e66-4a50-aca0-c17c799dca28.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10682,7 +10682,7 @@
         },
         {
             "id": "cbf34a82-8d75-51fe-85f7-53ade371bf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f822b7-efc5-42c8-93ea-7dd17b4c3e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f822b7-efc5-42c8-93ea-7dd17b4c3e7a.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "2707b022-d12f-5e19-87e7-b5c6227e0bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4ad89a-3a00-4bf4-a357-4a8a089d4a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4ad89a-3a00-4bf4-a357-4a8a089d4a82.jpg?1",
             "name": "Uncharted Haven",
             "text": "Uncharted Haven enters the battlefield tapped.\nAs Uncharted Haven enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -10741,7 +10741,7 @@
         },
         {
             "id": "7fa83775-f18c-5349-a396-da973b307805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b1d47-11ef-4f06-94b2-94b6727de3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b1d47-11ef-4f06-94b2-94b6727de3bd.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "a8902146-7c93-5751-82fa-c6b173148645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc26aa1-58b9-41b5-95b4-7e9bf2309b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc26aa1-58b9-41b5-95b4-7e9bf2309b54.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10810,7 +10810,7 @@
         },
         {
             "id": "684d2321-ac91-5441-a82a-7f5e7a99fcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db21784-e56b-46bd-97a4-3770f2ef5caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db21784-e56b-46bd-97a4-3770f2ef5caf.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10848,7 +10848,7 @@
         },
         {
             "id": "e067f68b-0df4-5e4b-ba4e-7f4da4832a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66d573-5da4-4b3c-ab06-bb330cff2c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66d573-5da4-4b3c-ab06-bb330cff2c9a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10886,7 +10886,7 @@
         },
         {
             "id": "f79d5937-5ee7-5d23-add6-ac6ed3ea27c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae091d-8bd3-44d0-a083-6b4078303bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae091d-8bd3-44d0-a083-6b4078303bc3.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10924,7 +10924,7 @@
         },
         {
             "id": "a9f90e47-e47c-542e-b018-608beb4174f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f7492c-67f2-4ba3-848b-7a6a8df7e88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f7492c-67f2-4ba3-848b-7a6a8df7e88b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10962,7 +10962,7 @@
         },
         {
             "id": "20ec4bcf-47d1-5cea-b18e-7449b7f090df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfebc79-5d84-4ce5-8bff-d09fe333f4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfebc79-5d84-4ce5-8bff-d09fe333f4a3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11000,7 +11000,7 @@
         },
         {
             "id": "d3bf1756-9dec-521f-88db-f06fca315045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe601b0-0398-47f0-9e4f-9f841ad79b9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe601b0-0398-47f0-9e4f-9f841ad79b9b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11038,7 +11038,7 @@
         },
         {
             "id": "182c88fe-257b-57e0-9cfc-e6210569b3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8489c0-b01c-466e-b33b-239406d7ea69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8489c0-b01c-466e-b33b-239406d7ea69.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11076,7 +11076,7 @@
         },
         {
             "id": "8edbcf7d-2715-57e3-b34e-1e64b3fca0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea5c36b-c107-4daf-bedb-507b4cd64724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea5c36b-c107-4daf-bedb-507b4cd64724.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11114,7 +11114,7 @@
         },
         {
             "id": "ce189568-fdd4-5fcc-8c72-9ef3072ed2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17db23-a8ca-416e-b978-1eae852c6690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17db23-a8ca-416e-b978-1eae852c6690.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11152,7 +11152,7 @@
         },
         {
             "id": "822705d0-4c39-5701-919a-bd0f74d59f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8fb179-7e81-4b20-8b81-ea1aa97afe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8fb179-7e81-4b20-8b81-ea1aa97afe58.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11190,7 +11190,7 @@
         },
         {
             "id": "fa297a82-aff5-51af-b12f-617697a59dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a76d8ee-28fc-49ac-951c-a4d29822f91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a76d8ee-28fc-49ac-951c-a4d29822f91e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11228,7 +11228,7 @@
         },
         {
             "id": "cf74a84a-1f1c-5aac-a49d-530cb05224db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0578f26-1396-4e1d-9986-8fc6c55aeb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0578f26-1396-4e1d-9986-8fc6c55aeb66.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11266,7 +11266,7 @@
         },
         {
             "id": "19a31a18-1d66-585b-b145-e638345ffad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132999f-6e2d-4689-8131-7b12076a348d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132999f-6e2d-4689-8131-7b12076a348d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11304,7 +11304,7 @@
         },
         {
             "id": "1679f14d-7893-50dd-be2e-898cd7cc617d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50b3d79-2361-4858-98b0-64d83c4f7f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50b3d79-2361-4858-98b0-64d83c4f7f70.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11342,7 +11342,7 @@
         },
         {
             "id": "3010da25-e2f9-57c5-af01-e92b2b41313d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ef531e-2a8f-4d40-b509-92e3a86b2257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ef531e-2a8f-4d40-b509-92e3a86b2257.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "bf38abc3-a3c0-5ecc-b05a-6752124777ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd5953-37fc-4a8a-89f8-0b5dd8412dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd5953-37fc-4a8a-89f8-0b5dd8412dc9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11418,7 +11418,7 @@
         },
         {
             "id": "1e079185-018b-52de-912d-60ac49412cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d75969d-c932-4b4e-8135-61968228bc32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d75969d-c932-4b4e-8135-61968228bc32.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11456,7 +11456,7 @@
         },
         {
             "id": "477f3189-5c2e-5a77-985d-538a62b2e616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc778ae-a2d0-493f-963d-e946bd7cacd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc778ae-a2d0-493f-963d-e946bd7cacd9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11494,7 +11494,7 @@
         },
         {
             "id": "d24e9cf2-c35c-5ad5-b9a1-5ccf9e278205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8179106-e5d7-457a-9250-70df980b38ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8179106-e5d7-457a-9250-70df980b38ce.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "14c66c62-1dae-52f5-9bbf-925bf67249dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71327818-2784-4fde-8e19-ef8677694a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71327818-2784-4fde-8e19-ef8677694a5f.jpg?1",
             "name": "The Wandering Emperor",
             "text": "Flash\nAs long as The Wandering Emperor entered the battlefield this turn, you may activate her loyalty abilities any time you could cast an instant.\n+1: Put a +1/+1 counter on up to one target creature. It gains first strike until end of turn.\n\u22121: Create a 2/2 white Samurai creature token with vigilance.\n\u22122: Exile target tapped creature. You gain 2 life.",
             "colours": [
@@ -11570,7 +11570,7 @@
         },
         {
             "id": "2385db1a-fc37-564b-a4e6-9889da682a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc079b5-291d-466e-9f1b-baaf1079637b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc079b5-291d-466e-9f1b-baaf1079637b.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "The first activated ability of an artifact you activate each turn costs {2} less to activate.\n+1: Draw two cards. Then discard two cards unless you discard an artifact card.\n\u22122: Target artifact becomes an artifact creature. If it isn't a Vehicle, it has base power and toughness 4/4.\n\u22126: You get an emblem with \"Whenever an artifact you control becomes tapped, draw a card.\"",
             "colours": [
@@ -11610,7 +11610,7 @@
         },
         {
             "id": "4dd59a99-6088-510a-a841-14987a235670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106e4cc-f3fc-41bf-ab1c-4ae7c1a0521c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106e4cc-f3fc-41bf-ab1c-4ae7c1a0521c.jpg?1",
             "name": "Kaito Shizuki",
             "text": "At the beginning of your end step, if Kaito Shizuki entered the battlefield this turn, he phases out.\n+1: Draw a card. Then discard a card unless you attacked this turn.\n\u22122: Create a 1/1 blue Ninja creature token with \"This creature can't be blocked.\"\n\u22127: You get an emblem with \"Whenever a creature you control deals combat damage to a player, search your library for a blue or black creature card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "e8e365fb-f5f3-5cc6-9b5e-8fae6cc95fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5898a9c4-c983-4807-af06-18111702ab59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5898a9c4-c983-4807-af06-18111702ab59.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "Compleated ({Variable} can be paid with {G}, {U}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Tap up to one target artifact or creature. It doesn't untap during its controller's next untap step.\n\u2212X: Exile target nonland permanent card with mana value X from your graveyard. Create a token that's a copy of that card.\n\u22127: Create Tamiyo's Notebook, a legendary colorless artifact token with \"Spells you cast cost {2} less to cast\" and \"{T}: Draw a card.\"",
             "colours": [
@@ -11694,7 +11694,7 @@
         },
         {
             "id": "be84b7d9-3a07-5680-90b6-c36c262a093c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855ca31-842e-4962-a5f0-163a3f833784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855ca31-842e-4962-a5f0-163a3f833784.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn. (A copy of a permanent spell becomes a token.)\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -11738,7 +11738,7 @@
         },
         {
             "id": "8f71630d-0a76-5925-9ea2-916d3178cba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16028f-25d0-4817-b20e-8b390b80ef35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16028f-25d0-4817-b20e-8b390b80ef35.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "Compleated ({Variable} can be paid with {G}, {U}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Tap up to one target artifact or creature. It doesn't untap during its controller's next untap step.\n\u2212X: Exile target nonland permanent card with mana value X from your graveyard. Create a token that's a copy of that card.\n\u22127: Create Tamiyo's Notebook, a legendary colorless artifact token with \"Spells you cast cost {2} less to cast\" and \"{T}: Draw a card.\"",
             "colours": [
@@ -11780,7 +11780,7 @@
         },
         {
             "id": "11682101-db7b-508d-8153-16b0d94051ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85917c-60ea-44d3-8483-fa639564e881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85917c-60ea-44d3-8483-fa639564e881.jpg?1",
             "name": "Eiganjo Exemplar",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.",
             "colours": [
@@ -11818,7 +11818,7 @@
         },
         {
             "id": "a3eb3065-37fc-5d7c-ac7b-60326ff77ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e7420e-55d0-4f4b-84bb-e5b86616cbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e7420e-55d0-4f4b-84bb-e5b86616cbb3.jpg?1",
             "name": "Imperial Subduer",
             "text": "Whenever a Samurai or Warrior you control attacks alone, tap target creature you don't control.",
             "colours": [
@@ -11855,7 +11855,7 @@
         },
         {
             "id": "85eaf070-e4c9-5e28-bf1f-f9e405737920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344df5c2-a963-42e3-b61b-1712f15e1eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344df5c2-a963-42e3-b61b-1712f15e1eb9.jpg?1",
             "name": "Norika Yamazaki, the Poet",
             "text": "Vigilance\nWhenever a Samurai or Warrior you control attacks alone, you may cast target enchantment card from your graveyard this turn.",
             "colours": [
@@ -11894,7 +11894,7 @@
         },
         {
             "id": "4f445e55-50ab-553c-aa14-4e3e0ed1b464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1ade5-06ff-41ab-9a68-bf901959b01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1ade5-06ff-41ab-9a68-bf901959b01f.jpg?1",
             "name": "Selfless Samurai",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gains lifelink until end of turn.\nSacrifice Selfless Samurai: Another target creature you control gains indestructible until end of turn.",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "c055b489-9651-5b76-86c6-14d16247b2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267efff1-cbe6-40b0-959e-72b81cbda1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267efff1-cbe6-40b0-959e-72b81cbda1d0.jpg?1",
             "name": "Seven-Tail Mentor",
             "text": "When Seven-Tail Mentor enters the battlefield or dies, put a +1/+1 counter on target creature or Vehicle you control.",
             "colours": [
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "e6fa1ffc-1bb1-5855-accf-46352ae9da7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d6a843-a1b7-4862-a2bf-8f8f66788126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d6a843-a1b7-4862-a2bf-8f8f66788126.jpg?1",
             "name": "Sky-Blessed Samurai",
             "text": "This spell costs {1} less to cast for each enchantment you control.\nFlying",
             "colours": [
@@ -12006,7 +12006,7 @@
         },
         {
             "id": "43356485-e1a1-5fcd-9cd5-b0082e5db9fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32e2ad3-c5fb-4072-aabf-6cb9538db3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32e2ad3-c5fb-4072-aabf-6cb9538db3ca.jpg?1",
             "name": "Sunblade Samurai",
             "text": "Vigilance\nChannel \u2014 {2}, Discard Sunblade Samurai: Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
             "colours": [
@@ -12044,7 +12044,7 @@
         },
         {
             "id": "038b47e7-ea13-54fc-b0e0-b8472d292c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92aafa5-9a21-4564-8b33-dab414cd5dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92aafa5-9a21-4564-8b33-dab414cd5dca.jpg?1",
             "name": "The Wandering Emperor",
             "text": "Flash\nAs long as The Wandering Emperor entered the battlefield this turn, you may activate her loyalty abilities any time you could cast an instant.\n+1: Put a +1/+1 counter on up to one target creature. It gains first strike until end of turn.\n\u22121: Create a 2/2 white Samurai creature token with vigilance.\n\u22122: Exile target tapped creature. You gain 2 life.",
             "colours": [
@@ -12082,7 +12082,7 @@
         },
         {
             "id": "83ca6f4c-44e5-5fb4-ab1b-75b83ee02fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dbd59e-a2f0-4031-b6c6-1b59fb7cb067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dbd59e-a2f0-4031-b6c6-1b59fb7cb067.jpg?1",
             "name": "Guardians of Oboro",
             "text": "Defender\nModified creatures you control can attack as though they didn't have defender.",
             "colours": [
@@ -12119,7 +12119,7 @@
         },
         {
             "id": "b326f163-12ba-5fb8-93b8-7aaa833d0251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bdf0d-df7d-4ca2-8131-060ba7cf2602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bdf0d-df7d-4ca2-8131-060ba7cf2602.jpg?1",
             "name": "Nezumi Bladeblesser",
             "text": "Nezumi Bladeblesser has deathtouch as long as you control an artifact.\nNezumi Bladeblesser has menace as long as you control an enchantment.",
             "colours": [
@@ -12156,7 +12156,7 @@
         },
         {
             "id": "31cf0c98-c833-5897-b695-2a8b470b030b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ee8e-d33a-40e9-9956-e345f0511819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ee8e-d33a-40e9-9956-e345f0511819.jpg?1",
             "name": "Akki Ronin",
             "text": "Whenever a Samurai or Warrior you control attacks alone, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -12193,7 +12193,7 @@
         },
         {
             "id": "c4ffe8c7-a4d1-50cf-af16-a7088f8a1f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862e9b05-209d-47d6-8692-ec0cb5f19e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862e9b05-209d-47d6-8692-ec0cb5f19e25.jpg?1",
             "name": "Goro-Goro, Disciple of Ryusei",
             "text": "{R}: Creatures you control gain haste until end of turn.\n{3}{R}{R}: Create a 5/5 red Dragon Spirit creature token with flying. Activate only if you control an attacking modified creature.",
             "colours": [
@@ -12233,7 +12233,7 @@
         },
         {
             "id": "051d5105-dd2a-54c7-b2e5-38055ea89396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91040c0-f025-4843-8c0e-3ac1b76c8582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91040c0-f025-4843-8c0e-3ac1b76c8582.jpg?1",
             "name": "Heiko Yamazaki, the General",
             "text": "Trample\nWhenever a Samurai or Warrior you control attacks alone, you may cast target artifact card from your graveyard this turn.",
             "colours": [
@@ -12272,7 +12272,7 @@
         },
         {
             "id": "6aafe7f1-ca84-56bd-ab14-123fe8416de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247c362c-bf21-4bca-89d4-54eb60806f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247c362c-bf21-4bca-89d4-54eb60806f10.jpg?1",
             "name": "Peerless Samurai",
             "text": "Menace\nWhenever a Samurai or Warrior you control attacks alone, the next spell you cast this turn costs {1} less to cast.",
             "colours": [
@@ -12309,7 +12309,7 @@
         },
         {
             "id": "fa1d971f-ce13-51cf-bbf4-a800d327948a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69eec2f-eec0-491f-944c-ca944d9d320b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69eec2f-eec0-491f-944c-ca944d9d320b.jpg?1",
             "name": "Reinforced Ronin",
             "text": "Haste\nAt the beginning of your end step, return Reinforced Ronin to its owner's hand.\nChannel \u2014 {1}{R}, Discard Reinforced Ronin: Draw a card.",
             "colours": [
@@ -12347,7 +12347,7 @@
         },
         {
             "id": "db4feb75-7c7d-55ff-97fd-17227533476f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52af0f2d-de2e-4554-ae32-c88bc7ba7c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52af0f2d-de2e-4554-ae32-c88bc7ba7c71.jpg?1",
             "name": "Upriser Renegade",
             "text": "Upriser Renegade gets +2/+0 for each other modified creature you control.",
             "colours": [
@@ -12384,7 +12384,7 @@
         },
         {
             "id": "c13652c1-4a35-5bbe-9fcc-20de94ff59bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54509524-92b9-41a3-8aba-a8955a7dfa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54509524-92b9-41a3-8aba-a8955a7dfa1a.jpg?1",
             "name": "Heir of the Ancient Fang",
             "text": "Heir of the Ancient Fang enters the battlefield with a +1/+1 counter on it if you control a modified creature.",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "766448bc-4367-56b1-a1f7-509610e730db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164e663f-6a67-4a10-a737-33ea533a9316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164e663f-6a67-4a10-a737-33ea533a9316.jpg?1",
             "name": "Jukai Trainee",
             "text": "Whenever Jukai Trainee blocks or becomes blocked, it gets +1/+1 until end of turn.",
             "colours": [
@@ -12458,7 +12458,7 @@
         },
         {
             "id": "e48285ef-223f-5c3b-8434-f7ef41548fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94158fdf-c794-4ce9-a04e-cb6922604d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94158fdf-c794-4ce9-a04e-cb6922604d19.jpg?1",
             "name": "Asari Captain",
             "text": "Haste\nWhenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.",
             "colours": [
@@ -12497,7 +12497,7 @@
         },
         {
             "id": "47c9d122-6fb1-56af-8a16-107b0e422f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf8b008-3a7c-4b6d-8c18-263a576f0d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf8b008-3a7c-4b6d-8c18-263a576f0d64.jpg?1",
             "name": "Isshin, Two Heavens as One",
             "text": "If a creature attacking would cause a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "ada3d938-2061-5d62-8e11-2a79279640fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1026485e-3df5-4ac7-baa1-06bff537a506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1026485e-3df5-4ac7-baa1-06bff537a506.jpg?1",
             "name": "Raiyuu, Storm's Edge",
             "text": "First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "colours": [
@@ -12583,7 +12583,7 @@
         },
         {
             "id": "b8fc2dea-4c58-5658-93d6-ecd2d9a539da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd32b69-5e1e-4990-88ec-85b21056ceae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd32b69-5e1e-4990-88ec-85b21056ceae.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "Haste\nWhenever Risona, Asari Commander deals combat damage to a player, if it doesn't have an indestructible counter on it, put an indestructible counter on it.\nWhenever combat damage is dealt to you, remove an indestructible counter from Risona.",
             "colours": [
@@ -12626,7 +12626,7 @@
         },
         {
             "id": "0dc81de1-dad5-5e29-ae95-5a0f2c1484c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d244d4-c2c4-4032-b249-794556d79429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d244d4-c2c4-4032-b249-794556d79429.jpg?1",
             "name": "Blade-Blizzard Kitsune",
             "text": "Ninjutsu {3}{W}\nDouble strike",
             "colours": [
@@ -12663,7 +12663,7 @@
         },
         {
             "id": "79896d82-8e2a-5b75-aad2-5f5da70b6d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f268152-304a-4db8-a3f9-dd9d0f3319a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f268152-304a-4db8-a3f9-dd9d0f3319a1.jpg?1",
             "name": "Covert Technician",
             "text": "Ninjutsu {1}{U}\nWhenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.",
             "colours": [
@@ -12701,7 +12701,7 @@
         },
         {
             "id": "9ebcbf7a-89a2-5fc4-9a80-c943aa6d1ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bad5c1-5804-4fba-91d9-3a49951f6e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bad5c1-5804-4fba-91d9-3a49951f6e06.jpg?1",
             "name": "Futurist Operative",
             "text": "As long as Futurist Operative is tapped, it's a Human Citizen with base power and toughness 1/1 and can't be blocked.\n{2}{U}: Untap Futurist Operative.",
             "colours": [
@@ -12738,7 +12738,7 @@
         },
         {
             "id": "fafc2bd0-bb19-5717-88da-1edafb366660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c43923-7280-4ccb-810b-e8c38dd8a26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c43923-7280-4ccb-810b-e8c38dd8a26f.jpg?1",
             "name": "Moon-Circuit Hacker",
             "text": "Ninjutsu {U}\nWhenever Moon-Circuit Hacker deals combat damage to a player, you may draw a card. If you do, discard a card unless Moon-Circuit Hacker entered the battlefield this turn.",
             "colours": [
@@ -12776,7 +12776,7 @@
         },
         {
             "id": "0b637440-bc16-50b2-a007-037810f7a68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2fdd4-b953-4e9a-b511-52199a34214e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2fdd4-b953-4e9a-b511-52199a34214e.jpg?1",
             "name": "Moonsnare Specialist",
             "text": "Ninjutsu {2}{U}\nWhen Moonsnare Specialist enters the battlefield, return up to one target creature to its owner's hand.",
             "colours": [
@@ -12813,7 +12813,7 @@
         },
         {
             "id": "191d8139-dfc3-52f1-a4de-c9cdfaa9a9a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e666d9-d2ba-49a6-a2c7-cd2639bf4663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e666d9-d2ba-49a6-a2c7-cd2639bf4663.jpg?1",
             "name": "Prosperous Thief",
             "text": "Ninjutsu {1}{U}\nWhenever one or more Ninja or Rogue creatures you control deal combat damage to a player, create a Treasure token.",
             "colours": [
@@ -12850,7 +12850,7 @@
         },
         {
             "id": "ae4f4699-e4b5-5ad6-908b-12c19be594be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c2751-fd12-42f2-b8c1-eaf78c5e29eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c2751-fd12-42f2-b8c1-eaf78c5e29eb.jpg?1",
             "name": "Thousand-Faced Shadow",
             "text": "Ninjutsu {2}{U}{U}\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.",
             "colours": [
@@ -12888,7 +12888,7 @@
         },
         {
             "id": "2f015f09-43e3-5dc3-9ae7-bd47fb796815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f92eb2-84ef-4343-9a31-41479c61a26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f92eb2-84ef-4343-9a31-41479c61a26d.jpg?1",
             "name": "Biting-Palm Ninja",
             "text": "Ninjutsu {2}{B}\nBiting-Palm Ninja enters the battlefield with a menace counter on it.\nWhenever Biting-Palm Ninja deals combat damage to a player, you may remove a menace counter from it. When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
             "colours": [
@@ -12926,7 +12926,7 @@
         },
         {
             "id": "d7a61d9e-7c77-584f-9a95-f772393a6a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d35bcc7-2280-4061-9a6c-e67038cfb114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d35bcc7-2280-4061-9a6c-e67038cfb114.jpg?1",
             "name": "Dokuchi Shadow-Walker",
             "text": "Ninjutsu {3}{B}",
             "colours": [
@@ -12963,7 +12963,7 @@
         },
         {
             "id": "4cd3ec66-6841-5cfe-b3b6-ba215b0cb937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5103a49-806f-48de-ba44-e252bb6dd035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5103a49-806f-48de-ba44-e252bb6dd035.jpg?1",
             "name": "Dokuchi Silencer",
             "text": "Ninjutsu {1}{B}\nWhenever Dokuchi Silencer deals combat damage to a player, you may discard a creature card. When you do, destroy target creature or planeswalker that player controls.",
             "colours": [
@@ -13000,7 +13000,7 @@
         },
         {
             "id": "e9a4ab51-b3fb-5b6a-b1bb-721fd8476c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66aaba3-4a28-4fcf-926a-34bbbf0dbeb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66aaba3-4a28-4fcf-926a-34bbbf0dbeb4.jpg?1",
             "name": "Inkrise Infiltrator",
             "text": "Flying\n{3}{B}: Inkrise Infiltrator gets +2/+2 until end of turn.",
             "colours": [
@@ -13037,7 +13037,7 @@
         },
         {
             "id": "1b65680b-c4c2-5bc6-9ceb-3fe5578eeb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357594c7-a9a6-468d-b262-e5f7d5e35f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357594c7-a9a6-468d-b262-e5f7d5e35f54.jpg?1",
             "name": "Mukotai Ambusher",
             "text": "Ninjutsu {1}{B}\nLifelink",
             "colours": [
@@ -13075,7 +13075,7 @@
         },
         {
             "id": "bc10c82e-599d-5ce4-ac6a-39d3dd39e131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e4f390-c420-44ec-a703-9a9d3ca6ab2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e4f390-c420-44ec-a703-9a9d3ca6ab2e.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "Ninjutsu {3}{B}\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -13116,7 +13116,7 @@
         },
         {
             "id": "3278b0cd-f402-5f81-96f9-3dbb19d44396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a64789a-748a-4630-949c-e1b045edd225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a64789a-748a-4630-949c-e1b045edd225.jpg?1",
             "name": "Nezumi Prowler",
             "text": "Ninjutsu {1}{B}\nWhen Nezumi Prowler enters the battlefield, target creature you control gains deathtouch and lifelink until end of turn.",
             "colours": [
@@ -13154,7 +13154,7 @@
         },
         {
             "id": "0ef70622-ce54-5799-80f7-35f04670db68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b3345-d09c-46ec-b450-f52fbcac5233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b3345-d09c-46ec-b450-f52fbcac5233.jpg?1",
             "name": "Tatsunari, Toad Rider",
             "text": "Whenever you cast an enchantment spell, if you don't control a creature named Keimi, create Keimi, a legendary 3/3 black and green Frog creature token with \"Whenever you cast an enchantment spell, each opponent loses 1 life and you gain 1 life.\"\n{1}{GW}: Tatsunari, Toad Rider and target Frog you control can't be blocked this turn except by creatures with flying or reach.",
             "colours": [
@@ -13196,7 +13196,7 @@
         },
         {
             "id": "21afaa23-868b-5429-96a6-162388a6744e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297592c-3036-434a-9dbb-5f0af804dd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297592c-3036-434a-9dbb-5f0af804dd13.jpg?1",
             "name": "Coiling Stalker",
             "text": "Ninjutsu {1}{G}\nWhenever Coiling Stalker deals combat damage to a player, put a +1/+1 counter on target creature you control that doesn't have a +1/+1 counter on it.",
             "colours": [
@@ -13233,7 +13233,7 @@
         },
         {
             "id": "69bea426-7e12-5f1a-8126-a8c00399dd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c8e2d5-2706-4137-bfdc-d65f1cd33bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c8e2d5-2706-4137-bfdc-d65f1cd33bda.jpg?1",
             "name": "Fang of Shigeki",
             "text": "Deathtouch",
             "colours": [
@@ -13271,7 +13271,7 @@
         },
         {
             "id": "83c9daca-0e58-59e1-8fc5-e3ca039f70ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9017ff4-d63f-4dd2-9157-c93fe4866bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9017ff4-d63f-4dd2-9157-c93fe4866bef.jpg?1",
             "name": "Kappa Tech-Wrecker",
             "text": "Ninjutsu {1}{G}\nKappa Tech-Wrecker enters the battlefield with a deathtouch counter on it.\nWhenever Kappa Tech-Wrecker deals combat damage to a player, you may remove a deathtouch counter from it. When you do, exile target artifact or enchantment that player controls.",
             "colours": [
@@ -13308,7 +13308,7 @@
         },
         {
             "id": "c9acfa54-bbd0-5187-b112-a9be0efdad4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a144bb-df52-4d55-aecc-8c2ba644a942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a144bb-df52-4d55-aecc-8c2ba644a942.jpg?1",
             "name": "Spring-Leaf Avenger",
             "text": "Ninjutsu {3}{G}\nWhenever Spring-Leaf Avenger deals combat damage to a player, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -13346,7 +13346,7 @@
         },
         {
             "id": "857aa231-2514-52f2-964a-31b8c957c686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6d5319-1cbb-41fb-83ed-97c9344e3073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6d5319-1cbb-41fb-83ed-97c9344e3073.jpg?1",
             "name": "Kaito Shizuki",
             "text": "At the beginning of your end step, if Kaito Shizuki entered the battlefield this turn, he phases out.\n+1: Draw a card. Then discard a card unless you attacked this turn.\n\u22122: Create a 1/1 blue Ninja creature token with \"This creature can't be blocked.\"\n\u22127: You get an emblem with \"Whenever a creature you control deals combat damage to a player, search your library for a blue or black creature card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -13388,7 +13388,7 @@
         },
         {
             "id": "169d3186-2b47-5e03-b0b0-4522dfe0045f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf89ee78-bcc9-419a-a400-e612b5a90f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf89ee78-bcc9-419a-a400-e612b5a90f07.jpg?1",
             "name": "Kotose, the Silent Spider",
             "text": "When Kotose, the Silent Spider enters the battlefield, exile target card other than a basic land card from an opponent's graveyard. Search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles. For as long as you control Kotose, you may play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -13430,7 +13430,7 @@
         },
         {
             "id": "969b07fb-145f-5190-9e4a-344ea3bb7457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c415762a-5b24-4dbb-9066-6e9be48874a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c415762a-5b24-4dbb-9066-6e9be48874a6.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -13474,7 +13474,7 @@
         },
         {
             "id": "c954711e-cdf1-56f5-b28f-6bb302d9ba66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9a0771-072c-4b0c-afcb-15a6406473c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9a0771-072c-4b0c-afcb-15a6406473c6.jpg?1",
             "name": "Silver-Fur Master",
             "text": "Ninjutsu {U}{B}\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.",
             "colours": [
@@ -13514,7 +13514,7 @@
         },
         {
             "id": "c6779dcb-e7bd-525b-bea2-77587f0b01d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nII \u2014 You may discard a card. When you do, return target permanent card with mana value 2 or less from your graveyard to the battlefield tapped.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13551,7 +13551,7 @@
         },
         {
             "id": "a2af8a6a-e40e-5ecb-bc93-fd5e5b1c20b1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "Vigilance\nWhenever Architect of Restoration attacks or blocks, create a 1/1 colorless Spirit creature token.",
             "colours": [
@@ -13590,7 +13590,7 @@
         },
         {
             "id": "28ed206d-6c6a-54c4-8c62-206805e8b7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Return up to one target creature or planeswalker to its owner's hand.\nII \u2014 Return an artifact card from your graveyard to your hand. If you can't, draw a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13627,7 +13627,7 @@
         },
         {
             "id": "0a62b979-3110-5fcd-86b0-c6ad8d34ca24",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "Flying\nWhenever you cast a spell, your opponents can't cast spells with the same mana value as that spell until your next turn.",
             "colours": [
@@ -13665,7 +13665,7 @@
         },
         {
             "id": "acfda7f4-9b1e-5cdf-ab35-88f5a6b96fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent creates a 1/1 black Rat Rogue creature token.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13702,7 +13702,7 @@
         },
         {
             "id": "46271276-669b-5353-997b-0ae0a8a32072",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "Flying, haste\nWhen Echo of Death's Wail enters the battlefield, gain control of all Rat tokens.\nWhenever Echo of Death's Wail attacks, you may sacrifice another creature. If you do, draw a card.",
             "colours": [
@@ -13740,7 +13740,7 @@
         },
         {
             "id": "48c2413e-30a2-5fa9-85aa-9f8305d7f4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 2/2 red Goblin Shaman creature token with \"Whenever this creature attacks, create a Treasure token.\"\nII \u2014 You may discard up to two cards. If you do, draw that many cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13777,7 +13777,7 @@
         },
         {
             "id": "b384f442-c485-587e-954e-f3bc0962daa1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -13816,7 +13816,7 @@
         },
         {
             "id": "131e6619-3b54-5c9d-abc1-7e392dec9d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 You gain 2 life. Look at the top three cards of your library. Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13853,7 +13853,7 @@
         },
         {
             "id": "ad7a3465-26b8-5a44-9532-834e19b83ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "Whenever Dragon-Kami's Egg or a Dragon you control dies, you may cast a creature spell from among cards you own in exile with hatching counters on them without paying its mana cost.",
             "colours": [
@@ -13891,7 +13891,7 @@
         },
         {
             "id": "a937305c-719b-52a5-b600-902d252b91e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"\nII \u2014 Put a +1/+1 counter on each of up to two target creatures.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13928,7 +13928,7 @@
         },
         {
             "id": "64d23141-1b89-5fd2-b7ad-1c7e389ce56b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on that creature.\nAs long as you control five or more modified creatures, Remnant of the Rising Star gets +5/+5 and has trample.",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "71a468ee-2c87-5cea-8009-94a9c663c2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill three cards. Create a 1/1 colorless Spirit creature token.\nII \u2014 Put a +1/+1 counter on target creature you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -14004,7 +14004,7 @@
         },
         {
             "id": "941c7d9c-57fb-5575-bea6-a8e733769dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "Whenever Kirin-Touched Orochi attacks, choose one \u2014\n\u2022 Exile target creature card from a graveyard. When you do, create a 1/1 colorless Spirit creature token.\n\u2022 Exile target noncreature card from a graveyard. When you do, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -14043,7 +14043,7 @@
         },
         {
             "id": "abf2cbbc-a757-5f91-8cef-2b30c472ecbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Destroy each nonland permanent with mana value 1 or less.\nII \u2014 Exile all graveyards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -14082,7 +14082,7 @@
         },
         {
             "id": "02291ae9-e366-506e-8130-6f94f76c1915",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "Trample\nWhenever Vessel of the All-Consuming deals damage, put a +1/+1 counter on it.\nWhenever Vessel of the All-Consuming deals damage to a player, if it has dealt 10 or more damage to that player this turn, they lose the game.",
             "colours": [
@@ -14123,7 +14123,7 @@
         },
         {
             "id": "76c7301f-b7d3-52be-aa5d-d027e4274390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile target nonland permanent an opponent controls.\nII \u2014 Return up to one other target nonland permanent to its owner's hand. Then each opponent discards a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -14168,7 +14168,7 @@
         },
         {
             "id": "031190c2-7a56-583c-b37b-1ce907f0a9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "O-Kagachi Made Manifest is all colors.\nFlying, trample\nWhenever O-Kagachi Made Manifest attacks, defending player chooses a nonland card in your graveyard. Return that card to your hand. O-Kagachi Made Manifest gets +X/+0 until end of turn, where X is the mana value of that card.",
             "colours": [
@@ -14215,7 +14215,7 @@
         },
         {
             "id": "1edeb946-a0dd-5659-b2ee-f90113def0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820390d7-fabb-4556-8d30-99f0a58b2da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820390d7-fabb-4556-8d30-99f0a58b2da5.jpg?1",
             "name": "Brilliant Restoration",
             "text": "Return all artifact and enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -14250,7 +14250,7 @@
         },
         {
             "id": "e048edc1-629b-5b28-aa07-3b3a40fa6698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ace38c6-2cc8-4f72-8276-eb02aa6773e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ace38c6-2cc8-4f72-8276-eb02aa6773e0.jpg?1",
             "name": "Cloudsteel Kirin",
             "text": "Flying\nEquipped creature has flying and \"You can't lose the game and your opponents can't win the game.\"\nReconfigure {5}",
             "colours": [
@@ -14289,7 +14289,7 @@
         },
         {
             "id": "794297f4-e9c1-5cd9-9195-e17c1249f2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c664bc-9585-47a7-9514-b3e30a4e1b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c664bc-9585-47a7-9514-b3e30a4e1b59.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -14325,7 +14325,7 @@
         },
         {
             "id": "3c0b225a-09b9-57e3-ac67-223245ecdf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c1acbf-5ef0-4677-b097-30db77d87310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c1acbf-5ef0-4677-b097-30db77d87310.jpg?1",
             "name": "Invoke Justice",
             "text": "Return target permanent card from your graveyard to the battlefield, then distribute four +1/+1 counters among any number of creatures and/or Vehicles target player controls.",
             "colours": [
@@ -14360,7 +14360,7 @@
         },
         {
             "id": "e9d3ba82-9f8a-539f-87e0-1ec0bc41f773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614523-e51a-44ff-83ad-5be9e322697a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614523-e51a-44ff-83ad-5be9e322697a.jpg?1",
             "name": "Light-Paws, Emperor's Voice",
             "text": "Whenever an Aura enters the battlefield under your control, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, Emperor's Voice, then shuffle.",
             "colours": [
@@ -14400,7 +14400,7 @@
         },
         {
             "id": "c34c94b6-547f-59ff-8835-d52a1af412d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c8834-e06e-452a-b82e-cb2b8fe0c304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c8834-e06e-452a-b82e-cb2b8fe0c304.jpg?1",
             "name": "Lion Sash",
             "text": "{W}: Exile target card from a graveyard. If it was a permanent card, put a +1/+1 counter on Lion Sash.\nEquipped creature gets +1/+1 for each +1/+1 counter on Lion Sash.\nReconfigure {2}",
             "colours": [
@@ -14439,7 +14439,7 @@
         },
         {
             "id": "63b796f3-17d2-57ec-87c1-71273e3c3839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a400cd7d-b004-4310-9787-bbec0fe36fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a400cd7d-b004-4310-9787-bbec0fe36fd8.jpg?1",
             "name": "March of Otherworldly Light",
             "text": "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
             "colours": [
@@ -14474,7 +14474,7 @@
         },
         {
             "id": "b23db4e8-ad62-5af8-873b-9e8ee615b4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307380fe-7484-4513-8180-f10411ea7726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307380fe-7484-4513-8180-f10411ea7726.jpg?1",
             "name": "Invoke the Winds",
             "text": "Gain control of target artifact or creature. Untap it.",
             "colours": [
@@ -14509,7 +14509,7 @@
         },
         {
             "id": "4dc289a9-6c82-5420-9152-59992c696d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01985566-275b-4bf0-8667-c81eb95ad70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01985566-275b-4bf0-8667-c81eb95ad70c.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn.\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -14553,7 +14553,7 @@
         },
         {
             "id": "d4fce68e-1740-5681-92ca-3651d0a97e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a8eac-82c7-4e02-bff5-1e1095b781ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a8eac-82c7-4e02-bff5-1e1095b781ef.jpg?1",
             "name": "March of Swirling Mist",
             "text": "As an additional cost to cast this spell, you may exile any number of blue cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nUp to X target creatures phase out.",
             "colours": [
@@ -14588,7 +14588,7 @@
         },
         {
             "id": "f886b418-f06b-5c47-a0cb-c37c5e69fe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37163f66-393f-4cb7-9f55-307d3d4b5975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37163f66-393f-4cb7-9f55-307d3d4b5975.jpg?1",
             "name": "Mindlink Mech",
             "text": "Flying\nWhenever Mindlink Mech becomes crewed for the first time each turn, until end of turn, Mindlink Mech becomes a copy of target nonlegendary creature that crewed it this turn, except it's 4/3, it's a Vehicle artifact in addition to its other types, and it has flying.\nCrew 1",
             "colours": [
@@ -14625,7 +14625,7 @@
         },
         {
             "id": "029be1ea-eaeb-50bb-b050-cca86d056f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fb5ee3-97af-40c1-a8de-a2a62afd418d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fb5ee3-97af-40c1-a8de-a2a62afd418d.jpg?1",
             "name": "The Reality Chip",
             "text": "You may look at the top card of your library any time.\nAs long as The Reality Chip is attached to a creature, you may play lands and cast spells from the top of your library.\nReconfigure {2}{U}",
             "colours": [
@@ -14666,7 +14666,7 @@
         },
         {
             "id": "a8b4dcff-5ef2-592f-8c98-da55a1ee6d29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0467d-bc7b-4233-8ac1-adb9d88344fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0467d-bc7b-4233-8ac1-adb9d88344fb.jpg?1",
             "name": "Tameshi, Reality Architect",
             "text": "Whenever one or more noncreature permanents are returned to hand, draw a card. This ability triggers only once each turn.\n{X}{W}, Return a land you control to its owner's hand: Return target artifact or enchantment card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -14707,7 +14707,7 @@
         },
         {
             "id": "ce2b63c9-fa96-5b07-8863-990c72de3e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b71dd5-0bed-4c02-9f92-c52984e2bb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b71dd5-0bed-4c02-9f92-c52984e2bb78.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "The first activated ability of an artifact you activate each turn costs {2} less to activate.\n+1: Draw two cards. Then discard two cards unless you discard an artifact card.\n\u22122: Target artifact becomes an artifact creature. If it isn't a Vehicle, it has base power and toughness 4/4.\n\u22126: You get an emblem with \"Whenever an artifact you control becomes tapped, draw a card.\"",
             "colours": [
@@ -14747,7 +14747,7 @@
         },
         {
             "id": "a319e2b9-8155-5eb2-9f29-c4c6356a9581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f5c2f4-1690-4392-80d6-d99148bc8b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f5c2f4-1690-4392-80d6-d99148bc8b13.jpg?1",
             "name": "Blade of the Oni",
             "text": "Menace\nEquipped creature has base power and toughness 5/5, has menace, and is a black Demon in addition to its other colors and types.\nReconfigure {2}{B}{B}",
             "colours": [
@@ -14787,7 +14787,7 @@
         },
         {
             "id": "114e3066-b29c-5fad-bb4f-d50fdd4c469f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3981fc94-efb5-4256-8adb-4538515a085c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3981fc94-efb5-4256-8adb-4538515a085c.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "{B}, Sacrifice a creature: Scry 2.\n{2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.",
             "colours": [
@@ -14832,7 +14832,7 @@
         },
         {
             "id": "ad48e205-1bc2-56aa-afb1-a2ee72665c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e4edbd-4a7c-435b-b7c0-f9cfdd3dff68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e4edbd-4a7c-435b-b7c0-f9cfdd3dff68.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -14868,7 +14868,7 @@
         },
         {
             "id": "9bc14b09-90ad-5ab0-890a-76ce80db6938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4703bba7-3248-410f-99a8-dffd629bab4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4703bba7-3248-410f-99a8-dffd629bab4c.jpg?1",
             "name": "March of Wretched Sorrow",
             "text": "As an additional cost to cast this spell, you may exile any number of black cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nMarch of Wretched Sorrow deals X damage to target creature or planeswalker and you gain X life.",
             "colours": [
@@ -14903,7 +14903,7 @@
         },
         {
             "id": "d01ed3d6-bddc-5e93-89c1-da239f10dac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d7df77-dc10-4c88-a51e-43d6b86ef10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d7df77-dc10-4c88-a51e-43d6b86ef10e.jpg?1",
             "name": "Mukotai Soulripper",
             "text": "Whenever Mukotai Soulripper attacks, you may sacrifice another artifact or creature. If you do, put a +1/+1 counter on Mukotai Soulripper and it gains menace until end of turn.\nCrew 2",
             "colours": [
@@ -14940,7 +14940,7 @@
         },
         {
             "id": "b1a4261e-13d5-50f4-9177-d9ffd3f650c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12642d-85b5-4b40-b1c0-2c08feae2f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12642d-85b5-4b40-b1c0-2c08feae2f0a.jpg?1",
             "name": "Soul Transfer",
             "text": "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both.\n\u2022 Exile target creature or planeswalker.\n\u2022 Return target creature or planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -14975,7 +14975,7 @@
         },
         {
             "id": "192b1640-1a8b-58a5-856b-ad674be71401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d47e98-daae-42f7-9581-1269d57bd16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d47e98-daae-42f7-9581-1269d57bd16e.jpg?1",
             "name": "Explosive Singularity",
             "text": "As an additional cost to cast this spell, you may tap any number of untapped creatures you control. This spell costs {1} less to cast for each creature tapped this way.\nExplosive Singularity deals 10 damage to any target.",
             "colours": [
@@ -15011,7 +15011,7 @@
         },
         {
             "id": "ae2307a1-e245-56f5-b8c3-c759cc13f8d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12af2504-ff1c-4361-a428-be9d1d35899f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12af2504-ff1c-4361-a428-be9d1d35899f.jpg?1",
             "name": "Invoke Calamity",
             "text": "You may cast up to two instant and/or sorcery spells with total mana value 6 or less from your graveyard and/or hand without paying their mana costs. If those spells would be put into your graveyard, exile them instead. Exile Invoke Calamity.",
             "colours": [
@@ -15046,7 +15046,7 @@
         },
         {
             "id": "9e91e4fd-e09b-5e0e-a12b-92df66a2f2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cadc1b-3434-4c38-b414-0f5ab4ca52a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cadc1b-3434-4c38-b414-0f5ab4ca52a0.jpg?1",
             "name": "Lizard Blades",
             "text": "Double strike\nEquipped creature has double strike.\nReconfigure {2}",
             "colours": [
@@ -15085,7 +15085,7 @@
         },
         {
             "id": "fe3168f3-7143-5d35-861c-ee1536b12c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbd3545-f98e-404e-a283-0ce2d83e64bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbd3545-f98e-404e-a283-0ce2d83e64bc.jpg?1",
             "name": "March of Reckless Joy",
             "text": "As an additional cost to cast this spell, you may exile any number of red cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile the top X cards of your library. You may play up to two of those cards until the end of your next turn.",
             "colours": [
@@ -15120,7 +15120,7 @@
         },
         {
             "id": "a95e2935-3527-598f-aa21-9905c5931b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f143d-986a-474e-be48-819d1f9f078c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f143d-986a-474e-be48-819d1f9f078c.jpg?1",
             "name": "Ogre-Head Helm",
             "text": "Equipped creature gets +2/+2.\nWhenever Ogre-Head Helm or equipped creature deals combat damage to a player, you may sacrifice it. If you do, discard your hand, then draw three cards.\nReconfigure {3}",
             "colours": [
@@ -15159,7 +15159,7 @@
         },
         {
             "id": "4eefadca-eb9d-566d-b056-cb09c0c2db3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793c45e2-d0ce-4899-9f7f-5629bd6e01a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793c45e2-d0ce-4899-9f7f-5629bd6e01a1.jpg?1",
             "name": "Scrap Welder",
             "text": "{T}, Sacrifice an artifact with mana value X: Return target artifact card with mana value less than X from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -15197,7 +15197,7 @@
         },
         {
             "id": "90f032f7-1c3b-5ce3-b6cb-399bba3ad15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6a9bef-6910-4293-87b8-52abcef41566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6a9bef-6910-4293-87b8-52abcef41566.jpg?1",
             "name": "Thundering Raiju",
             "text": "Haste\nWhenever Thundering Raiju attacks, put a +1/+1 counter on target creature you control. Then Thundering Raiju deals X damage to each opponent, where X is the number of modified creatures you control other than Thundering Raiju.",
             "colours": [
@@ -15234,7 +15234,7 @@
         },
         {
             "id": "27ad4eae-e68c-522c-955a-b2f533508ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f89fc5-fe77-490b-ba05-34ec0b362801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f89fc5-fe77-490b-ba05-34ec0b362801.jpg?1",
             "name": "Invoke the Ancients",
             "text": "Create two 4/5 green Spirit creature tokens. For each of them, put your choice of a vigilance counter, a reach counter, or a trample counter on it.",
             "colours": [
@@ -15269,7 +15269,7 @@
         },
         {
             "id": "bacee13b-e91d-5d91-a70a-4726cf604c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f10049-8fd2-48f4-9319-d747546cf22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f10049-8fd2-48f4-9319-d747546cf22d.jpg?1",
             "name": "Kami of Transience",
             "text": "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on Kami of Transience.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return Kami of Transience from your graveyard to your hand.",
             "colours": [
@@ -15306,7 +15306,7 @@
         },
         {
             "id": "471e5871-2860-5f35-a954-0db6b54cfc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a4aeaa-aff7-4299-8030-36eefd5acaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a4aeaa-aff7-4299-8030-36eefd5acaf3.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "Reach\nModified creatures you control have trample.\nWhenever a modified creature you control deals combat damage to a player, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "22c957c8-ad24-5025-bbe2-34febb807c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed33009e-5686-4de9-9270-d1540ddceb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed33009e-5686-4de9-9270-d1540ddceb8a.jpg?1",
             "name": "March of Burgeoning Life",
             "text": "As an additional cost to cast this spell, you may exile any number of green cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nChoose target creature with mana value less than X. Search your library for a creature card with the same name as that creature, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -15381,7 +15381,7 @@
         },
         {
             "id": "a66fb16b-1c79-5ca3-b021-a617f68734b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c303e5-a0af-4e42-afcc-1d3a81c78e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c303e5-a0af-4e42-afcc-1d3a81c78e8e.jpg?1",
             "name": "Shigeki, Jukai Visionary",
             "text": "{1}{G}, {T}, Return Shigeki, Jukai Visionary to its owner's hand: Reveal the top four cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest into your graveyard.\nChannel \u2014 {X}{X}{G}{G}, Discard Shigeki: Return X target nonlegendary cards from your graveyard to your hand.",
             "colours": [
@@ -15422,7 +15422,7 @@
         },
         {
             "id": "317710f4-1c6c-582c-97e3-33eadd33da8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c4b17-a804-4340-bb7e-5cd3183ecbef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c4b17-a804-4340-bb7e-5cd3183ecbef.jpg?1",
             "name": "Weaver of Harmony",
             "text": "Other enchantment creatures you control get +1/+1.\n{G}, {T}: Copy target activated or triggered ability you control from an enchantment source. You may choose new targets for the copy.",
             "colours": [
@@ -15461,7 +15461,7 @@
         },
         {
             "id": "7f2f0143-9f62-53ab-90cc-eb3299672484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a560ff4-446e-4dd0-87a6-145a27bdcdb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a560ff4-446e-4dd0-87a6-145a27bdcdb9.jpg?1",
             "name": "Eiganjo Uprising",
             "text": "Create X 2/2 white Samurai creature tokens with vigilance. They gain menace and haste until end of turn.\nEach opponent creates X minus one 2/2 white Samurai creature tokens with vigilance.",
             "colours": [
@@ -15498,7 +15498,7 @@
         },
         {
             "id": "bcf9d63a-854e-51e5-8aff-0de49b04a7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9455cb27-89d3-4bb1-8af8-08c7712c2915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9455cb27-89d3-4bb1-8af8-08c7712c2915.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "At the beginning of combat on your turn, return target Vehicle card from your graveyard to the battlefield. It gains haste. Return it to its owner's hand at the beginning of your next end step.",
             "colours": [
@@ -15540,7 +15540,7 @@
         },
         {
             "id": "1fae3320-0a21-5103-9199-b637bab95e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737d299-09ce-4012-b3e9-c93a09035d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737d299-09ce-4012-b3e9-c93a09035d65.jpg?1",
             "name": "Hinata, Dawn-Crowned",
             "text": "Flying, trample\nSpells you cast cost {1} less to cast for each target.\nSpells your opponents cast cost {1} more to cast for each target.",
             "colours": [
@@ -15584,7 +15584,7 @@
         },
         {
             "id": "8280a696-5e91-53c2-97a7-09a86a676d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dd5813-8c6e-4fa3-b11d-e13f14ce8c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dd5813-8c6e-4fa3-b11d-e13f14ce8c4e.jpg?1",
             "name": "Satsuki, the Living Lore",
             "text": "{T}: Put a lore counter on each Saga you control. Activate only as a sorcery.\nWhen Satsuki, the Living Lore dies, choose up to one \u2014\n\u2022 Return target Saga or enchantment creature you control to its owner's hand.\n\u2022 Return target Saga card from your graveyard to your hand.",
             "colours": [
@@ -15626,7 +15626,7 @@
         },
         {
             "id": "081132fd-7d1c-525e-af32-2d64ae38f7f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaefe4b-9750-460a-9993-60a138df80a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaefe4b-9750-460a-9993-60a138df80a6.jpg?1",
             "name": "Spirit-Sister's Call",
             "text": "At the beginning of your end step, choose target permanent card in your graveyard. You may sacrifice a permanent that shares a card type with the chosen card. If you do, return the chosen card from your graveyard to the battlefield and it gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\"",
             "colours": [
@@ -15663,7 +15663,7 @@
         },
         {
             "id": "e76fba99-2f57-5dad-a646-2dd91164a9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f103cb00-29f7-41ad-8368-ed2cf1a408ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f103cb00-29f7-41ad-8368-ed2cf1a408ea.jpg?1",
             "name": "Eater of Virtue",
             "text": "Whenever equipped creature dies, exile it.\nEquipped creature gets +2/+0.\nAs long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.\nEquip {1}",
             "colours": [],
@@ -15698,7 +15698,7 @@
         },
         {
             "id": "4de32c0d-eb72-51f6-b477-cc0d1ece6cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b7411-09e5-4990-88ca-649321dd62b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b7411-09e5-4990-88ca-649321dd62b5.jpg?1",
             "name": "Mechtitan Core",
             "text": "{5}, Exile Mechtitan Core and four other artifact creatures and/or Vehicles you control: Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors. When that token leaves the battlefield, return all cards exiled with Mechtitan Core except Mechtitan Core to the battlefield tapped under their owners' control.\nCrew 2",
             "colours": [],
@@ -15731,7 +15731,7 @@
         },
         {
             "id": "58ec70dd-4482-589f-a95b-732df0d164d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf676a6-8ccb-4908-9e49-ccb4a319d588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf676a6-8ccb-4908-9e49-ccb4a319d588.jpg?1",
             "name": "Mirror Box",
             "text": "The \"legend rule\" doesn't apply to permanents you control.\nEach legendary creature you control gets +1/+1.\nEach nontoken creature you control gets +1/+1 for each other creature you control with the same name as that creature.",
             "colours": [],
@@ -15762,7 +15762,7 @@
         },
         {
             "id": "4258601e-7151-5b84-93d1-b6ab16671d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bf5955-67fe-4bbf-acd5-164bf087e7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bf5955-67fe-4bbf-acd5-164bf087e7a2.jpg?1",
             "name": "Reckoner Bankbuster",
             "text": "Reckoner Bankbuster enters the battlefield with three charge counters on it.\n{2}, {T}, Remove a charge counter from Reckoner Bankbuster: Draw a card. Then if there are no charge counters on Reckoner Bankbuster, create a Treasure token and a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 3",
             "colours": [],
@@ -15795,7 +15795,7 @@
         },
         {
             "id": "09579f26-be0a-5263-b5ec-0a25f295d5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0332502-bcba-42c0-9dfc-9ab873b1719a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0332502-bcba-42c0-9dfc-9ab873b1719a.jpg?1",
             "name": "Surgehacker Mech",
             "text": "Menace\nWhen Surgehacker Mech enters the battlefield, it deals damage equal to twice the number of Vehicles you control to target creature or planeswalker an opponent controls.\nCrew 4",
             "colours": [],
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "6ecde099-bc5d-5537-8846-8b5a15a4ebf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d1c2d-d3be-4647-a260-15ce85e69eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d1c2d-d3be-4647-a260-15ce85e69eea.jpg?1",
             "name": "Ao, the Dawn Sky",
             "text": "Flying, vigilance\nWhen Ao, the Dawn Sky dies, choose one \u2014\n\u2022 Look at the top seven cards of your library. Put any number of nonland permanent cards with total mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\n\u2022 Put two +1/+1 counters on each permanent you control that's a creature or Vehicle.",
             "colours": [
@@ -15868,7 +15868,7 @@
         },
         {
             "id": "1b946e7c-8838-5444-8e99-dc0f392a1649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e500c22f-b16a-431b-8562-1508df7db27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e500c22f-b16a-431b-8562-1508df7db27e.jpg?1",
             "name": "Kyodai, Soul of Kamigawa",
             "text": "Flash\nFlying\nWhen Kyodai, Soul of Kamigawa enters the battlefield, another target permanent gains indestructible for as long as you control Kyodai.\n{W}{U}{B}{R}{G}: Kyodai gets +5/+5 until end of turn.",
             "colours": [
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "92063907-3b81-5741-a96d-753c5f6b282a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516dc285-f0f9-4a5c-a7b7-395c1821b42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516dc285-f0f9-4a5c-a7b7-395c1821b42c.jpg?1",
             "name": "Kairi, the Swirling Sky",
             "text": "Flying, ward {3}\nWhen Kairi, the Swirling Sky dies, choose one \u2014\n\u2022 Return any number of target nonland permanents with total mana value 6 or less to their owners' hands.\n\u2022 Mill six cards, then return up to two instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -15952,7 +15952,7 @@
         },
         {
             "id": "b294b576-4d72-57d3-adf3-57665cbfdb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c61476-2105-48f3-8f57-3d0322bdc92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c61476-2105-48f3-8f57-3d0322bdc92e.jpg?1",
             "name": "Junji, the Midnight Sky",
             "text": "Flying, menace\nWhen Junji, the Midnight Sky dies, choose one \u2014\n\u2022 Each opponent discards two cards and loses 2 life.\n\u2022 Put target non-Dragon creature card from a graveyard onto the battlefield under your control. You lose 2 life.",
             "colours": [
@@ -15992,7 +15992,7 @@
         },
         {
             "id": "1d8dfd46-1ce3-5c2c-bdd4-2c5f59e3506f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed997183-24b2-466f-b740-c414ef485a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed997183-24b2-466f-b740-c414ef485a96.jpg?1",
             "name": "Atsushi, the Blazing Sky",
             "text": "Flying, trample\nWhen Atsushi, the Blazing Sky dies, choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Create three Treasure tokens.",
             "colours": [
@@ -16032,7 +16032,7 @@
         },
         {
             "id": "dd5b8849-af08-523a-afe8-644103903cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0986e1a1-749d-4f34-9cdf-b347f2041c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0986e1a1-749d-4f34-9cdf-b347f2041c5c.jpg?1",
             "name": "Kura, the Boundless Sky",
             "text": "Flying, deathtouch\nWhen Kura, the Boundless Sky dies, choose one \u2014\n\u2022 Search your library for up to three land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Create an X/X green Spirit creature token, where X is the number of lands you control.",
             "colours": [
@@ -16072,7 +16072,7 @@
         },
         {
             "id": "9b4a13c9-99d2-5e55-82ec-6c55b375b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055ea30-20fb-4324-a632-8fed87628f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055ea30-20fb-4324-a632-8fed87628f05.jpg?1",
             "name": "Boseiju, Who Endures",
             "text": "{T}: Add {G}.\nChannel \u2014 {1}{G}, Discard Boseiju, Who Endures: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16107,7 +16107,7 @@
         },
         {
             "id": "b71f6f8d-c3c1-524b-8afa-3884445f6982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c31c48f-6275-4430-8dc9-05d70c332b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c31c48f-6275-4430-8dc9-05d70c332b7a.jpg?1",
             "name": "Eiganjo, Seat of the Empire",
             "text": "{T}: Add {W}.\nChannel \u2014 {2}{W}, Discard Eiganjo, Seat of the Empire: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16142,7 +16142,7 @@
         },
         {
             "id": "3dc881d0-b0e0-5e00-afbe-219f098b2624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e99599e-c594-42c6-b9e3-4dbb8e982f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e99599e-c594-42c6-b9e3-4dbb8e982f88.jpg?1",
             "name": "Otawara, Soaring City",
             "text": "{T}: Add {U}.\nChannel \u2014 {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16177,7 +16177,7 @@
         },
         {
             "id": "a87f4980-b2ec-5ee2-a268-f7df5247f351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327333cc-2cc9-44ba-a0e6-d01329c416a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327333cc-2cc9-44ba-a0e6-d01329c416a3.jpg?1",
             "name": "Sokenzan, Crucible of Defiance",
             "text": "{T}: Add {R}.\nChannel \u2014 {3}{R}, Discard Sokenzan, Crucible of Defiance: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16212,7 +16212,7 @@
         },
         {
             "id": "60469103-5301-5a82-b5b2-72886f64cba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc98705-77c2-47b6-b41c-3e41578700e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc98705-77c2-47b6-b41c-3e41578700e8.jpg?1",
             "name": "Takenuma, Abandoned Mire",
             "text": "{T}: Add {B}.\nChannel \u2014 {3}{B}, Discard Takenuma, Abandoned Mire: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16247,7 +16247,7 @@
         },
         {
             "id": "a117fe2d-3817-5429-b5e1-b99af81d8cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956b833-0b74-4890-bc67-4aed7df33af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956b833-0b74-4890-bc67-4aed7df33af4.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -16282,7 +16282,7 @@
         },
         {
             "id": "38faf8e0-756f-500d-bf1d-6c41701fd7b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22edc832-993b-432a-8435-8d8a72799122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22edc832-993b-432a-8435-8d8a72799122.jpg?1",
             "name": "The Wandering Emperor",
             "text": "",
             "colours": [
@@ -16319,7 +16319,7 @@
         },
         {
             "id": "f9e5bf08-bbcd-56db-86bd-db496e3c7067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd7793-5a6d-4b5c-8924-b0aee73e31eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd7793-5a6d-4b5c-8924-b0aee73e31eb.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "e885d0d4-7a5c-5f81-8621-64115ec6b475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029be79-88d8-4d15-a7d7-f5b8d469ad54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029be79-88d8-4d15-a7d7-f5b8d469ad54.jpg?1",
             "name": "Blade of the Oni",
             "text": "",
             "colours": [
@@ -16397,7 +16397,7 @@
         },
         {
             "id": "bf30b070-13f8-5c35-8dd7-9b8abd52aceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3564486e-e19b-4a11-a587-ad3e040cd914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3564486e-e19b-4a11-a587-ad3e040cd914.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "",
             "colours": [
@@ -16437,7 +16437,7 @@
         },
         {
             "id": "750634d9-3eb8-5bf3-a9cb-9a700d18f52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae9af1-58ea-49ad-8e57-8dcc53d2a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae9af1-58ea-49ad-8e57-8dcc53d2a959.jpg?1",
             "name": "Explosive Singularity",
             "text": "",
             "colours": [
@@ -16472,7 +16472,7 @@
         },
         {
             "id": "83eeaeb4-eb1e-5fdb-8d74-816fb741679f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f7bfb-8f0a-435a-b23c-c2f3bea46ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f7bfb-8f0a-435a-b23c-c2f3bea46ed2.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "",
             "colours": [
@@ -16511,7 +16511,7 @@
         },
         {
             "id": "186c8408-50d9-5f5f-8534-0bedb157fec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b189f965-d66d-4b35-b42f-933bdea62562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b189f965-d66d-4b35-b42f-933bdea62562.jpg?1",
             "name": "Kaito Shizuki",
             "text": "",
             "colours": [
@@ -16552,7 +16552,7 @@
         },
         {
             "id": "3bc5eae6-eb01-56b2-9a20-048a3239e143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a3d9fd-4023-4f64-b31c-8dab1eec8566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a3d9fd-4023-4f64-b31c-8dab1eec8566.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "",
             "colours": [
@@ -16594,7 +16594,7 @@
         },
         {
             "id": "1b1a6fa4-fdcc-55ce-ae62-a1ec5cb2cf0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c178c8d-ef57-4a69-a72d-c6c6f1eda617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c178c8d-ef57-4a69-a72d-c6c6f1eda617.jpg?1",
             "name": "Satoru Umezawa",
             "text": "",
             "colours": [
@@ -16637,7 +16637,7 @@
         },
         {
             "id": "89142f06-23ee-54d7-b0ed-505e335be5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa7cbf8-64b2-428e-8991-d8454d724f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa7cbf8-64b2-428e-8991-d8454d724f9f.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "",
             "colours": [
@@ -16680,7 +16680,7 @@
         },
         {
             "id": "6c89aef7-b810-5773-85a2-bec1c98783bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816eacac-a8b2-4d77-af3c-75f620ce3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816eacac-a8b2-4d77-af3c-75f620ce3148.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "",
             "colours": [
@@ -16721,7 +16721,7 @@
         },
         {
             "id": "c8e496a3-684c-5c37-a5bb-0475c7fa699c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4826991d-c3c3-45ff-9dfc-4246a84b40e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4826991d-c3c3-45ff-9dfc-4246a84b40e0.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16765,7 +16765,7 @@
         },
         {
             "id": "d274e1a6-af18-5ab6-ad23-1b6f070fdd41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046b0b3-05f0-4468-817f-355e87552faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046b0b3-05f0-4468-817f-355e87552faf.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16809,7 +16809,7 @@
         },
         {
             "id": "3dac3f82-0eeb-591b-82f1-08d2fff5ac67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92da2c98-afe0-4e7a-9510-5a74cc2cdde4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92da2c98-afe0-4e7a-9510-5a74cc2cdde4.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16853,7 +16853,7 @@
         },
         {
             "id": "ca6df049-edea-5e26-ba38-6c0cb4c1807c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c0b64b-cade-414d-b893-ac1b633c66d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c0b64b-cade-414d-b893-ac1b633c66d0.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16897,7 +16897,7 @@
         },
         {
             "id": "5c185426-0557-53dd-bb04-3e1535ef2e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d726f3f-2920-4de4-b531-5c42006e85af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d726f3f-2920-4de4-b531-5c42006e85af.jpg?1",
             "name": "Ao, the Dawn Sky",
             "text": "Flying, vigilance\nWhen Ao, the Dawn Sky dies, choose one \u2014\n\u2022 Look at the top seven cards of your library. Put any number of nonland permanent cards with total mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\n\u2022 Put two +1/+1 counters on each permanent you control that's a creature or Vehicle.",
             "colours": [
@@ -16937,7 +16937,7 @@
         },
         {
             "id": "34351cf0-60d1-506a-b980-7aded950f2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d801eea3-d549-458a-b099-730969bfcba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d801eea3-d549-458a-b099-730969bfcba7.jpg?1",
             "name": "Brilliant Restoration",
             "text": "Return all artifact and enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "3ec852bd-04bf-57a9-97ab-5f0fc40abaa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea33e1d-fa3b-4179-9f94-74bc35cdf088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea33e1d-fa3b-4179-9f94-74bc35cdf088.jpg?1",
             "name": "Cloudsteel Kirin",
             "text": "Flying\nEquipped creature has flying and \"You can't lose the game and your opponents can't win the game.\"\nReconfigure {5}",
             "colours": [
@@ -17011,7 +17011,7 @@
         },
         {
             "id": "81cd1f23-4d0c-5e71-96ac-69ff0c695ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050b693-7bad-4c0c-baca-0186d153ce2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050b693-7bad-4c0c-baca-0186d153ce2e.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -17047,7 +17047,7 @@
         },
         {
             "id": "95fe1570-ddc0-5a10-bdf2-58f27bf7aa41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a2079f-2a87-428f-aefc-f7c075a35598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a2079f-2a87-428f-aefc-f7c075a35598.jpg?1",
             "name": "Invoke Justice",
             "text": "Return target permanent card from your graveyard to the battlefield, then distribute four +1/+1 counters among any number of creatures and/or Vehicles target player controls.",
             "colours": [
@@ -17082,7 +17082,7 @@
         },
         {
             "id": "d21d8047-8ebe-5b8b-8150-f065be924cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c446e-986a-4345-aeec-28f4cd8c801b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c446e-986a-4345-aeec-28f4cd8c801b.jpg?1",
             "name": "Kyodai, Soul of Kamigawa",
             "text": "Flash\nFlying\nWhen Kyodai, Soul of Kamigawa enters the battlefield, another target permanent gains indestructible for as long as you control Kyodai.\n{W}{U}{B}{R}{G}: Kyodai gets +5/+5 until end of turn.",
             "colours": [
@@ -17126,7 +17126,7 @@
         },
         {
             "id": "12cd1e92-46d6-5518-bd5a-29c4be14be78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008fe9b-1913-4358-a411-5d3c175c60ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008fe9b-1913-4358-a411-5d3c175c60ba.jpg?1",
             "name": "Light-Paws, Emperor's Voice",
             "text": "Whenever an Aura enters the battlefield under your control, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, Emperor's Voice, then shuffle.",
             "colours": [
@@ -17166,7 +17166,7 @@
         },
         {
             "id": "5f5b9dc3-7bd1-5ab8-9b10-91dbbdd4ce30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f8ce4c-c6fc-408c-a216-33374bbfb08d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f8ce4c-c6fc-408c-a216-33374bbfb08d.jpg?1",
             "name": "Lion Sash",
             "text": "{W}: Exile target card from a graveyard. If it was a permanent card, put a +1/+1 counter on Lion Sash.\nEquipped creature gets +1/+1 for each +1/+1 counter on Lion Sash.\nReconfigure {2}",
             "colours": [
@@ -17205,7 +17205,7 @@
         },
         {
             "id": "62e61598-aa38-5da4-820d-fd22da7ed924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbf453c-bded-4d39-bebf-fd240ec44287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbf453c-bded-4d39-bebf-fd240ec44287.jpg?1",
             "name": "March of Otherworldly Light",
             "text": "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
             "colours": [
@@ -17240,7 +17240,7 @@
         },
         {
             "id": "c7fedf9d-a3d2-571c-8446-56e49f42c78b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "I \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nII \u2014 You may discard a card. When you do, return target permanent card with mana value 2 or less from your graveyard to the battlefield tapped.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -17277,7 +17277,7 @@
         },
         {
             "id": "faf8f293-b7b8-5d4c-977a-1018952752f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "Vigilance\nWhenever Architect of Restoration attacks or blocks, create a 1/1 colorless Spirit creature token.",
             "colours": [
@@ -17316,7 +17316,7 @@
         },
         {
             "id": "783e4236-19fe-5927-b644-3f15385cbc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "I \u2014 Return up to one target creature or planeswalker to its owner's hand.\nII \u2014 Return an artifact card from your graveyard to your hand. If you can't, draw a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -17353,7 +17353,7 @@
         },
         {
             "id": "12c20efb-f785-5ddc-9366-c0354b7ceb22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "Flying\nWhenever you cast a spell, your opponents can't cast spells with the same mana value as that spell until your next turn.",
             "colours": [
@@ -17391,7 +17391,7 @@
         },
         {
             "id": "01dcf3f8-3106-53ea-b94c-c12a1d42120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8832ae-0f84-48f0-a8f2-0bf37c3a6551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8832ae-0f84-48f0-a8f2-0bf37c3a6551.jpg?1",
             "name": "Invoke the Winds",
             "text": "Gain control of target artifact or creature. Untap it.",
             "colours": [
@@ -17426,7 +17426,7 @@
         },
         {
             "id": "291c02f3-dc12-5ba1-89bc-53a44f9f5c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729a8bdc-3246-482b-a0b7-1d071247d218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729a8bdc-3246-482b-a0b7-1d071247d218.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn. (A copy of a permanent spell becomes a token.)\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -17470,7 +17470,7 @@
         },
         {
             "id": "d146ff34-49e5-5227-9fce-9a90bf2c5493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e356fa-eeeb-44a0-a3ba-90f90a855d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e356fa-eeeb-44a0-a3ba-90f90a855d40.jpg?1",
             "name": "Kairi, the Swirling Sky",
             "text": "Flying, ward {3}\nWhen Kairi, the Swirling Sky dies, choose one \u2014\n\u2022 Return any number of target nonland permanents with total mana value 6 or less to their owners' hands.\n\u2022 Mill six cards, then return up to two instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -17510,7 +17510,7 @@
         },
         {
             "id": "b02c0659-c22d-5406-aa13-fcc24f6e73bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e72c2-e229-43c9-9e5a-df4754732d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e72c2-e229-43c9-9e5a-df4754732d19.jpg?1",
             "name": "March of Swirling Mist",
             "text": "As an additional cost to cast this spell, you may exile any number of blue cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nUp to X target creatures phase out.",
             "colours": [
@@ -17545,7 +17545,7 @@
         },
         {
             "id": "13c324ec-7069-5a2d-8d06-c73cea57ba8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1e4d50-8ca7-4dc0-8181-aa51beafb218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1e4d50-8ca7-4dc0-8181-aa51beafb218.jpg?1",
             "name": "Mindlink Mech",
             "text": "Flying\nWhenever Mindlink Mech becomes crewed for the first time each turn, until end of turn, Mindlink Mech becomes a copy of target nonlegendary creature that crewed it this turn, except it's 4/3, it's a Vehicle artifact in addition to its other types, and it has flying.\nCrew 1",
             "colours": [
@@ -17582,7 +17582,7 @@
         },
         {
             "id": "a8f80842-2893-57b4-b7d2-3cc8acb41d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797bb82-24f6-4dd5-8f5d-b3ea45bb65b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797bb82-24f6-4dd5-8f5d-b3ea45bb65b8.jpg?1",
             "name": "The Reality Chip",
             "text": "You may look at the top card of your library any time.\nAs long as The Reality Chip is attached to a creature, you may play lands and cast spells from the top of your library.\nReconfigure {2}{U}",
             "colours": [
@@ -17623,7 +17623,7 @@
         },
         {
             "id": "5135924b-5736-5bac-9155-efa3d7d4f06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28d4c2-279e-4f73-a134-a47b7cc2fa9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28d4c2-279e-4f73-a134-a47b7cc2fa9b.jpg?1",
             "name": "Tameshi, Reality Architect",
             "text": "Whenever one or more noncreature permanents are returned to hand, draw a card. This ability triggers only once each turn.\n{X}{W}, Return a land you control to its owner's hand: Return target artifact or enchantment card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -17664,7 +17664,7 @@
         },
         {
             "id": "8d1dc7e8-bb0d-50e1-9f67-e0dd115936d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00632c03-be00-4722-85b3-2ce31bba5cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00632c03-be00-4722-85b3-2ce31bba5cc6.jpg?1",
             "name": "Thousand-Faced Shadow",
             "text": "Ninjutsu {2}{U}{U}\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.",
             "colours": [
@@ -17702,7 +17702,7 @@
         },
         {
             "id": "ee450cbd-fac3-5177-8d21-5bcbefa2b47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b1cd2e-cea3-41c6-9fd2-1b473d5f61a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b1cd2e-cea3-41c6-9fd2-1b473d5f61a7.jpg?1",
             "name": "Biting-Palm Ninja",
             "text": "Ninjutsu {2}{B}\nBiting-Palm Ninja enters the battlefield with a menace counter on it.\nWhenever Biting-Palm Ninja deals combat damage to a player, you may remove a menace counter from it. When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
             "colours": [
@@ -17740,7 +17740,7 @@
         },
         {
             "id": "520d89cd-8811-5c80-9dbd-d56a0dc0e4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9896df-0d5c-4b02-b584-345f4c7cd127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9896df-0d5c-4b02-b584-345f4c7cd127.jpg?1",
             "name": "Blade of the Oni",
             "text": "Menace\nEquipped creature has base power and toughness 5/5, has menace, and is a black Demon in addition to its other colors and types.\nReconfigure {2}{B}{B}",
             "colours": [
@@ -17780,7 +17780,7 @@
         },
         {
             "id": "07320e66-550d-5e2c-989f-49361a8de0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9655d9c-d4fb-4ced-b841-543eb4d88d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9655d9c-d4fb-4ced-b841-543eb4d88d2f.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "{B}, Sacrifice a creature: Scry 2.\n{2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.",
             "colours": [
@@ -17825,7 +17825,7 @@
         },
         {
             "id": "6bfcba59-d856-5bba-8f20-19ae096df1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359445e8-2f4a-4e73-9201-2c7a11d26666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359445e8-2f4a-4e73-9201-2c7a11d26666.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -17861,7 +17861,7 @@
         },
         {
             "id": "f5a4c003-496c-531b-8695-76c7471723b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f0f499-35d7-4e04-a2fc-d6735f6087d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f0f499-35d7-4e04-a2fc-d6735f6087d4.jpg?1",
             "name": "Junji, the Midnight Sky",
             "text": "Flying, menace\nWhen Junji, the Midnight Sky dies, choose one \u2014\n\u2022 Each opponent discards two cards and loses 2 life.\n\u2022 Put target non-Dragon creature card from a graveyard onto the battlefield under your control. You lose 2 life.",
             "colours": [
@@ -17901,7 +17901,7 @@
         },
         {
             "id": "30f59f31-f0c7-5152-b18b-69f5dd043dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70647c5f-e2ce-43e0-8715-0648e206caf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70647c5f-e2ce-43e0-8715-0648e206caf8.jpg?1",
             "name": "March of Wretched Sorrow",
             "text": "As an additional cost to cast this spell, you may exile any number of black cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nMarch of Wretched Sorrow deals X damage to target creature or planeswalker and you gain X life.",
             "colours": [
@@ -17936,7 +17936,7 @@
         },
         {
             "id": "9c0ce6d4-c635-5bce-9035-e676ecb66092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d99c1-a6ad-4ab8-abb9-4845f7945f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d99c1-a6ad-4ab8-abb9-4845f7945f08.jpg?1",
             "name": "Mukotai Soulripper",
             "text": "Whenever Mukotai Soulripper attacks, you may sacrifice another artifact or creature. If you do, put a +1/+1 counter on Mukotai Soulripper and it gains menace until end of turn.\nCrew 2",
             "colours": [
@@ -17973,7 +17973,7 @@
         },
         {
             "id": "430951bf-56bb-5da3-9f9e-d6090058369e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a509120-d075-43cc-9422-35b2bf8183aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a509120-d075-43cc-9422-35b2bf8183aa.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "Ninjutsu {3}{B}\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -18014,7 +18014,7 @@
         },
         {
             "id": "e4aa0fbc-bdca-5974-99ce-647020a9e654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35ce3d2-8e7b-412a-abde-9885ca4e7a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35ce3d2-8e7b-412a-abde-9885ca4e7a64.jpg?1",
             "name": "Soul Transfer",
             "text": "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both.\n\u2022 Exile target creature or planeswalker.\n\u2022 Return target creature or planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -18049,7 +18049,7 @@
         },
         {
             "id": "04a0628c-3b33-528f-a8f5-44ae525804c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b9c95e-6691-4736-bfbd-0932458f03c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b9c95e-6691-4736-bfbd-0932458f03c6.jpg?1",
             "name": "Tatsunari, Toad Rider",
             "text": "Whenever you cast an enchantment spell, if you don't control a creature named Keimi, create Keimi, a legendary 3/3 black and green Frog creature token with \"Whenever you cast an enchantment spell, each opponent loses 1 life and you gain 1 life.\"\n{1}{GW}: Tatsunari, Toad Rider and target Frog you control can't be blocked this turn except by creatures with flying or reach.",
             "colours": [
@@ -18091,7 +18091,7 @@
         },
         {
             "id": "a6b414cf-44d5-5be3-b343-e0a0ae32317f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "I, II \u2014 Each opponent creates a 1/1 black Rat Rogue creature token.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18128,7 +18128,7 @@
         },
         {
             "id": "8a3ad2e6-6b77-5e71-afe0-fbe27a4fe331",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "Flying, haste\nWhen Echo of Death's Wail enters the battlefield, gain control of all Rat tokens.\nWhenever Echo of Death's Wail attacks, you may sacrifice another creature. If you do, draw a card.",
             "colours": [
@@ -18166,7 +18166,7 @@
         },
         {
             "id": "2aba0181-6727-59dc-96c3-e9958b7c1e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756ccc1d-e43a-44d6-a722-3e209a164dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756ccc1d-e43a-44d6-a722-3e209a164dc5.jpg?1",
             "name": "Atsushi, the Blazing Sky",
             "text": "Flying, trample\nWhen Atsushi, the Blazing Sky dies, choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Create three Treasure tokens.",
             "colours": [
@@ -18206,7 +18206,7 @@
         },
         {
             "id": "3ad22d7a-f9b0-57e1-bb8e-5a4a7e88cf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74a2f31-01e6-480b-a722-7a9c972e2a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74a2f31-01e6-480b-a722-7a9c972e2a51.jpg?1",
             "name": "Explosive Singularity",
             "text": "As an additional cost to cast this spell, you may tap any number of untapped creatures you control. This spell costs {1} less to cast for each creature tapped this way.\nExplosive Singularity deals 10 damage to any target.",
             "colours": [
@@ -18242,7 +18242,7 @@
         },
         {
             "id": "1e03fdfd-e583-5b65-bec9-091dde849bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "I \u2014 Create a 2/2 red Goblin Shaman creature token with \"Whenever this creature attacks, create a Treasure token.\"\nII \u2014 You may discard up to two cards. If you do, draw that many cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18279,7 +18279,7 @@
         },
         {
             "id": "f71fe9b3-8915-5c5d-b736-633995e0c5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -18318,7 +18318,7 @@
         },
         {
             "id": "7981ddcc-b58c-575e-8bd5-e1dc3afed8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d398246a-dc65-4096-b4b7-46ddff38372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d398246a-dc65-4096-b4b7-46ddff38372e.jpg?1",
             "name": "Goro-Goro, Disciple of Ryusei",
             "text": "{R}: Creatures you control gain haste until end of turn.\n{3}{R}{R}: Create a 5/5 red Dragon Spirit creature token with flying. Activate only if you control an attacking modified creature.",
             "colours": [
@@ -18358,7 +18358,7 @@
         },
         {
             "id": "78fae0ce-75e9-5771-8a29-436d0a52c62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff8eec-5510-4c57-91c1-ec380fdd7f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff8eec-5510-4c57-91c1-ec380fdd7f8e.jpg?1",
             "name": "Invoke Calamity",
             "text": "You may cast up to two instant and/or sorcery spells with total mana value 6 or less from your graveyard and/or hand without paying their mana costs. If those spells would be put into your graveyard, exile them instead. Exile Invoke Calamity.",
             "colours": [
@@ -18393,7 +18393,7 @@
         },
         {
             "id": "9059563d-4fc7-589b-9d12-3dce7689387a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20833a-ebdf-4daa-8220-ea95758d41b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20833a-ebdf-4daa-8220-ea95758d41b5.jpg?1",
             "name": "Lizard Blades",
             "text": "Double strike\nEquipped creature has double strike.\nReconfigure {2}",
             "colours": [
@@ -18432,7 +18432,7 @@
         },
         {
             "id": "f2d3c476-2e18-52a0-be8a-e686a9bddc89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec97d1-3b8c-4441-b6bc-836be5f8a015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec97d1-3b8c-4441-b6bc-836be5f8a015.jpg?1",
             "name": "March of Reckless Joy",
             "text": "As an additional cost to cast this spell, you may exile any number of red cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile the top X cards of your library. You may play up to two of those cards until the end of your next turn.",
             "colours": [
@@ -18467,7 +18467,7 @@
         },
         {
             "id": "d3d8b587-b21a-51d2-bf39-ee0639103b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eecab66-d600-49d5-8b5a-f70872375d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eecab66-d600-49d5-8b5a-f70872375d8b.jpg?1",
             "name": "Ogre-Head Helm",
             "text": "Equipped creature gets +2/+2.\nWhenever Ogre-Head Helm or equipped creature deals combat damage to a player, you may sacrifice it. If you do, discard your hand, then draw three cards.\nReconfigure {3}",
             "colours": [
@@ -18506,7 +18506,7 @@
         },
         {
             "id": "78750ad3-270c-5d5a-ab25-f1a75ca00176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76866cc1-06a4-4d1d-bbec-724109fa6c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76866cc1-06a4-4d1d-bbec-724109fa6c93.jpg?1",
             "name": "Scrap Welder",
             "text": "{T}, Sacrifice an artifact with mana value X: Return target artifact card with mana value less than X from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -18544,7 +18544,7 @@
         },
         {
             "id": "27d000ad-d60e-5324-8afa-8dbe0e58abc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49d17cf-242b-4f44-8ea0-125d9d18139c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49d17cf-242b-4f44-8ea0-125d9d18139c.jpg?1",
             "name": "Thundering Raiju",
             "text": "Haste\nWhenever Thundering Raiju attacks, put a +1/+1 counter on target creature you control. Then Thundering Raiju deals X damage to each opponent, where X is the number of modified creatures you control other than Thundering Raiju.",
             "colours": [
@@ -18581,7 +18581,7 @@
         },
         {
             "id": "2fab85d9-1aa3-59c6-81c8-1f6bbc3a3656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "I, II \u2014 You gain 2 life. Look at the top three cards of your library. Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18618,7 +18618,7 @@
         },
         {
             "id": "95ef007a-5073-5ae2-abcf-b9e007bc0afb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "Whenever Dragon-Kami's Egg or a Dragon you control dies, you may cast a creature spell from among cards you own in exile with hatching counters on them without paying its mana cost.",
             "colours": [
@@ -18656,7 +18656,7 @@
         },
         {
             "id": "931723bf-0fba-557b-91ef-1e6b7b1f66fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5564dc16-22f1-428a-8c49-ecc7de13d4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5564dc16-22f1-428a-8c49-ecc7de13d4a6.jpg?1",
             "name": "Invoke the Ancients",
             "text": "Create two 4/5 green Spirit creature tokens. For each of them, put your choice of a vigilance counter, a reach counter, or a trample counter on it.",
             "colours": [
@@ -18691,7 +18691,7 @@
         },
         {
             "id": "8a819086-cd2c-5843-aaf8-70b73ce63384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "I \u2014 Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"\nII \u2014 Put a +1/+1 counter on each of up to two target creatures.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18728,7 +18728,7 @@
         },
         {
             "id": "ca75c486-f313-5770-a870-a7954e899030",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on that creature.\nAs long as you control five or more modified creatures, Remnant of the Rising Star gets +5/+5 and has trample.",
             "colours": [
@@ -18767,7 +18767,7 @@
         },
         {
             "id": "b209b0f8-a31a-5029-b6f9-06d4e5d90b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bfeaf-ed02-4bf3-a36a-58feda05d992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bfeaf-ed02-4bf3-a36a-58feda05d992.jpg?1",
             "name": "Kami of Transience",
             "text": "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on Kami of Transience.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return Kami of Transience from your graveyard to your hand.",
             "colours": [
@@ -18804,7 +18804,7 @@
         },
         {
             "id": "b1c118e3-1e7a-5087-b2af-13d0e6c7277f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e17d9-fb24-45ef-aba6-292009834dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e17d9-fb24-45ef-aba6-292009834dc2.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "Reach\nModified creatures you control have trample.\nWhenever a modified creature you control deals combat damage to a player, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -18844,7 +18844,7 @@
         },
         {
             "id": "bf2f0930-8096-5766-a3a5-c761cfed2e49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765ad05-069b-4224-80ed-2f9bdced2dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765ad05-069b-4224-80ed-2f9bdced2dae.jpg?1",
             "name": "Kura, the Boundless Sky",
             "text": "Flying, deathtouch\nWhen Kura, the Boundless Sky dies, choose one \u2014\n\u2022 Search your library for up to three land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Create an X/X green Spirit creature token, where X is the number of lands you control.",
             "colours": [
@@ -18884,7 +18884,7 @@
         },
         {
             "id": "f980b6ea-df2c-5b41-a5b2-b8a5eff03af6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36efdf01-9e6f-4963-887a-9018df56ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36efdf01-9e6f-4963-887a-9018df56ced4.jpg?1",
             "name": "March of Burgeoning Life",
             "text": "As an additional cost to cast this spell, you may exile any number of green cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nChoose target creature with mana value less than X. Search your library for a creature card with the same name as that creature, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -18919,7 +18919,7 @@
         },
         {
             "id": "5cf1a289-cc35-5614-a251-cff8e3359bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd634f0-2373-4747-8b16-92dbf279e1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd634f0-2373-4747-8b16-92dbf279e1ff.jpg?1",
             "name": "Shigeki, Jukai Visionary",
             "text": "{1}{G}, {T}, Return Shigeki, Jukai Visionary to its owner's hand: Reveal the top four cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest into your graveyard.\nChannel \u2014 {X}{X}{G}{G}, Discard Shigeki: Return X target nonlegendary cards from your graveyard to your hand.",
             "colours": [
@@ -18960,7 +18960,7 @@
         },
         {
             "id": "261abec2-2c77-5ff2-a1ed-03bd62ae8e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209115ac-06ef-4d3f-9550-5e9eda081079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209115ac-06ef-4d3f-9550-5e9eda081079.jpg?1",
             "name": "Spring-Leaf Avenger",
             "text": "Ninjutsu {3}{G}\nWhenever Spring-Leaf Avenger deals combat damage to a player, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -18998,7 +18998,7 @@
         },
         {
             "id": "9ab92083-1da7-5cde-b367-897630072278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "I \u2014 Mill three cards. Create a 1/1 colorless Spirit creature token.\nII \u2014 Put a +1/+1 counter on target creature you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -19035,7 +19035,7 @@
         },
         {
             "id": "748bee3d-89d7-5f11-be37-9d34b590ed64",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "Whenever Kirin-Touched Orochi attacks, choose one \u2014\n\u2022 Exile target creature card from a graveyard. When you do, create a 1/1 colorless Spirit creature token.\n\u2022 Exile target noncreature card from a graveyard. When you do, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -19074,7 +19074,7 @@
         },
         {
             "id": "602b47dd-4f4f-56c2-9828-f7ea08a48bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009fad8-40cb-4421-9fa8-fd525c5f7189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009fad8-40cb-4421-9fa8-fd525c5f7189.jpg?1",
             "name": "Weaver of Harmony",
             "text": "Other enchantment creatures you control get +1/+1.\n{G}, {T}: Copy target activated or triggered ability you control from an enchantment source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
             "colours": [
@@ -19113,7 +19113,7 @@
         },
         {
             "id": "dcff09f9-74f5-5c45-8d88-6428b1fb3e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d6851-f110-46aa-a4ed-f657d2d2eceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d6851-f110-46aa-a4ed-f657d2d2eceb.jpg?1",
             "name": "Eiganjo Uprising",
             "text": "Create X 2/2 white Samurai creature tokens with vigilance. They gain menace and haste until end of turn.\nEach opponent creates X minus one 2/2 white Samurai creature tokens with vigilance.",
             "colours": [
@@ -19150,7 +19150,7 @@
         },
         {
             "id": "09423682-808a-5779-8f5c-5343416f8076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020a4094-e5d8-477b-930f-f7ab98dc9fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020a4094-e5d8-477b-930f-f7ab98dc9fb1.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "At the beginning of combat on your turn, return target Vehicle card from your graveyard to the battlefield. It gains haste. Return it to its owner's hand at the beginning of your next end step.",
             "colours": [
@@ -19192,7 +19192,7 @@
         },
         {
             "id": "88416c94-7ae8-5c4a-8ddf-277f2b9227bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "I \u2014 Destroy each nonland permanent with mana value 1 or less.\nII \u2014 Exile all graveyards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -19231,7 +19231,7 @@
         },
         {
             "id": "609e9c73-8507-5e26-9964-74506ad9cee4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "Trample\nWhenever Vessel of the All-Consuming deals damage, put a +1/+1 counter on it.\nWhenever Vessel of the All-Consuming deals damage to a player, if it has dealt 10 or more damage to that player this turn, they lose the game.",
             "colours": [
@@ -19272,7 +19272,7 @@
         },
         {
             "id": "edb016ac-f74f-5f4b-8904-fdc3eaea47e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/466f98c4-c5a7-4fad-b183-a3fbd28cb66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/466f98c4-c5a7-4fad-b183-a3fbd28cb66b.jpg?1",
             "name": "Hinata, Dawn-Crowned",
             "text": "Flying, trample\nSpells you cast cost {1} less to cast for each target.\nSpells your opponents cast cost {1} more to cast for each target.",
             "colours": [
@@ -19316,7 +19316,7 @@
         },
         {
             "id": "87cb62e8-6027-57a6-ae48-93e565f53414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26eeb39-77ab-4e60-8b10-1420e755c372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26eeb39-77ab-4e60-8b10-1420e755c372.jpg?1",
             "name": "Isshin, Two Heavens as One",
             "text": "If a creature attacking would cause a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -19360,7 +19360,7 @@
         },
         {
             "id": "136c4e09-8eeb-5878-a0aa-b67f5a267d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "I \u2014 Exile target nonland permanent an opponent controls.\nII \u2014 Return up to one other target nonland permanent to its owner's hand. Then each opponent discards a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -19405,7 +19405,7 @@
         },
         {
             "id": "13903bf8-0ee7-5f97-a12a-bcb42e5830fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "O-Kagachi Made Manifest is all colors.\nFlying, trample\nWhenever O-Kagachi Made Manifest attacks, defending player chooses a nonland card in your graveyard. Return that card to your hand. O-Kagachi Made Manifest gets +X/+0 until end of turn, where X is the mana value of that card.",
             "colours": [
@@ -19452,7 +19452,7 @@
         },
         {
             "id": "5e11809b-9426-53a2-a75c-31195475acdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabc4c53-365e-412e-8ce4-a9e67d12c33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabc4c53-365e-412e-8ce4-a9e67d12c33f.jpg?1",
             "name": "Kotose, the Silent Spider",
             "text": "When Kotose, the Silent Spider enters the battlefield, exile target card other than a basic land card from an opponent's graveyard. Search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles. For as long as you control Kotose, you may play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -19494,7 +19494,7 @@
         },
         {
             "id": "c2b571a3-2f03-5b0e-a5ce-4dc48ae8af85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89f16b7-fcfb-44a9-b05f-a77a157a9865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89f16b7-fcfb-44a9-b05f-a77a157a9865.jpg?1",
             "name": "Raiyuu, Storm's Edge",
             "text": "First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "colours": [
@@ -19536,7 +19536,7 @@
         },
         {
             "id": "99297d05-6772-5552-83e8-6443add89dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5db6d6-c8b4-4c38-8b94-f455f148cf3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5db6d6-c8b4-4c38-8b94-f455f148cf3f.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "Haste\nWhenever Risona, Asari Commander deals combat damage to a player, if it doesn't have an indestructible counter on it, put an indestructible counter on it.\nWhenever combat damage is dealt to you, remove an indestructible counter from Risona.",
             "colours": [
@@ -19579,7 +19579,7 @@
         },
         {
             "id": "b391ae18-e4fb-5660-8d1d-4ddf65f0f78b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb4d0a-f979-42ed-a4aa-15c180e4f0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb4d0a-f979-42ed-a4aa-15c180e4f0be.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -19623,7 +19623,7 @@
         },
         {
             "id": "ec9c47d6-697c-54de-b110-7eecc071ca1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80aa5a9e-5152-4dc0-9a98-089a3d4d7dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80aa5a9e-5152-4dc0-9a98-089a3d4d7dda.jpg?1",
             "name": "Satsuki, the Living Lore",
             "text": "{T}: Put a lore counter on each Saga you control. Activate only as a sorcery.\nWhen Satsuki, the Living Lore dies, choose up to one \u2014\n\u2022 Return target Saga or enchantment creature you control to its owner's hand.\n\u2022 Return target Saga card from your graveyard to your hand.",
             "colours": [
@@ -19665,7 +19665,7 @@
         },
         {
             "id": "7a12c7d5-0224-5df9-aeaf-e255f4040458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e7b4ab-bc2c-4dd0-9433-6266c86c1c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e7b4ab-bc2c-4dd0-9433-6266c86c1c84.jpg?1",
             "name": "Spirit-Sister's Call",
             "text": "At the beginning of your end step, choose target permanent card in your graveyard. You may sacrifice a permanent that shares a card type with the chosen card. If you do, return the chosen card from your graveyard to the battlefield and it gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\"",
             "colours": [
@@ -19702,7 +19702,7 @@
         },
         {
             "id": "1fc634ea-576a-57cf-92f9-c270a70befc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a86f45-ba70-48b4-a2e9-8269ec22b991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a86f45-ba70-48b4-a2e9-8269ec22b991.jpg?1",
             "name": "Eater of Virtue",
             "text": "Whenever equipped creature dies, exile it.\nEquipped creature gets +2/+0.\nAs long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.\nEquip {1}",
             "colours": [],
@@ -19737,7 +19737,7 @@
         },
         {
             "id": "aacbd487-4cf9-5e6a-9994-d622138b5431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9430b849-cee9-4fda-84c1-0777db82fe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9430b849-cee9-4fda-84c1-0777db82fe58.jpg?1",
             "name": "Mechtitan Core",
             "text": "{5}, Exile Mechtitan Core and four other artifact creatures and/or Vehicles you control: Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors. When that token leaves the battlefield, return all cards exiled with Mechtitan Core except Mechtitan Core to the battlefield tapped under their owners' control.\nCrew 2",
             "colours": [],
@@ -19770,7 +19770,7 @@
         },
         {
             "id": "bccc949c-99a1-5c1e-9281-1eeab0d711be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8354b07-8dac-44bb-871f-3c8f60a20d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8354b07-8dac-44bb-871f-3c8f60a20d1c.jpg?1",
             "name": "Mirror Box",
             "text": "The \"legend rule\" doesn't apply to permanents you control.\nEach legendary creature you control gets +1/+1.\nEach nontoken creature you control gets +1/+1 for each other creature you control with the same name as that creature.",
             "colours": [],
@@ -19801,7 +19801,7 @@
         },
         {
             "id": "d5cc74ab-7262-530e-b626-1023305f91c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5d9a22-0111-40ba-8d9e-a36bd84a39c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5d9a22-0111-40ba-8d9e-a36bd84a39c3.jpg?1",
             "name": "Reckoner Bankbuster",
             "text": "Reckoner Bankbuster enters the battlefield with three charge counters on it.\n{2}, {T}, Remove a charge counter from Reckoner Bankbuster: Draw a card. Then if there are no charge counters on Reckoner Bankbuster, create a Treasure token and a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 3",
             "colours": [],
@@ -19834,7 +19834,7 @@
         },
         {
             "id": "2cbaf6d5-9ae0-5470-8de9-cb6d07697bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ce02c6-0918-41a7-9286-7a0bdc0f166e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ce02c6-0918-41a7-9286-7a0bdc0f166e.jpg?1",
             "name": "Surgehacker Mech",
             "text": "Menace\nWhen Surgehacker Mech enters the battlefield, it deals damage equal to twice the number of Vehicles you control to target creature or planeswalker an opponent controls.\nCrew 4",
             "colours": [],
@@ -19867,7 +19867,7 @@
         },
         {
             "id": "488ed991-4cc1-53d5-89b1-c3bb99fa1d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2488a80b-6882-4b59-8232-f02f800204a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2488a80b-6882-4b59-8232-f02f800204a9.jpg?1",
             "name": "Boseiju, Who Endures",
             "text": "{T}: Add {G}.\nChannel \u2014 {1}{G}, Discard Boseiju, Who Endures: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -19902,7 +19902,7 @@
         },
         {
             "id": "ec3589f5-def0-5b85-91dc-77eeb1ad152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb53f59-d89b-481c-af98-75c11c30ee17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb53f59-d89b-481c-af98-75c11c30ee17.jpg?1",
             "name": "Eiganjo, Seat of the Empire",
             "text": "{T}: Add {W}.\nChannel \u2014 {2}{W}, Discard Eiganjo, Seat of the Empire: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -19937,7 +19937,7 @@
         },
         {
             "id": "38c008cf-1cc7-5e8c-8855-c84570dc0b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdbf15-7578-465e-afa2-f65c01fb4802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdbf15-7578-465e-afa2-f65c01fb4802.jpg?1",
             "name": "Otawara, Soaring City",
             "text": "{T}: Add {U}.\nChannel \u2014 {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -19972,7 +19972,7 @@
         },
         {
             "id": "6d7093e3-3133-5148-ac5f-8e161e0dd1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca9f8ae-838f-4a9c-9341-38e39da68926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca9f8ae-838f-4a9c-9341-38e39da68926.jpg?1",
             "name": "Sokenzan, Crucible of Defiance",
             "text": "{T}: Add {R}.\nChannel \u2014 {3}{R}, Discard Sokenzan, Crucible of Defiance: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -20007,7 +20007,7 @@
         },
         {
             "id": "375e116f-e257-5bf9-92c8-2b69aee150e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13410bd5-acee-4cc9-90e3-dbcf8415bcaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13410bd5-acee-4cc9-90e3-dbcf8415bcaf.jpg?1",
             "name": "Takenuma, Abandoned Mire",
             "text": "{T}: Add {B}.\nChannel \u2014 {3}{B}, Discard Takenuma, Abandoned Mire: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -20042,7 +20042,7 @@
         },
         {
             "id": "8c3a2f60-6cd3-557f-9c29-7694b7b526d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe6d3be-67b9-45be-a5c8-4edf753a7fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe6d3be-67b9-45be-a5c8-4edf753a7fd0.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -20078,7 +20078,7 @@
         },
         {
             "id": "8d93fe3c-e3d1-52e0-8cc5-1dd3c8b01c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7112729-908e-430d-8e0e-eb71a9043309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7112729-908e-430d-8e0e-eb71a9043309.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -20121,7 +20121,7 @@
         },
         {
             "id": "55f218e3-c32b-59f9-9d56-56267c635fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae5aecd-f1e3-4a1a-92a7-69235437102d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae5aecd-f1e3-4a1a-92a7-69235437102d.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -20158,7 +20158,7 @@
         },
         {
             "id": "6f07d674-4a76-5968-b321-18dd1aabcf67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a43b94-4425-47ab-9e9f-9287aa9a807e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a43b94-4425-47ab-9e9f-9287aa9a807e.jpg?1",
             "name": "Enthusiastic Mechanaut",
             "text": "Flying\nArtifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -20198,7 +20198,7 @@
         },
         {
             "id": "c8c41aed-78ba-5861-a8d2-a6e7b638a2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa567185-e0f2-4fe1-82a8-57b7fb277ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa567185-e0f2-4fe1-82a8-57b7fb277ab9.jpg?1",
             "name": "Jukai Naturalist",
             "text": "Lifelink\nEnchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -20238,7 +20238,7 @@
         },
         {
             "id": "181c8b04-2aea-5b87-b8da-916036993cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1eef728-8f2f-4b18-ae40-f14074ab6791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1eef728-8f2f-4b18-ae40-f14074ab6791.jpg?1",
             "name": "Silver-Fur Master",
             "text": "Ninjutsu {U}{B}\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.",
             "colours": [
@@ -20278,7 +20278,7 @@
         },
         {
             "id": "56f456ca-cf4a-5e0d-a216-80de38e4e956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb026a80-72ae-4969-b2e7-ed88ecc542a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb026a80-72ae-4969-b2e7-ed88ecc542a1.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As Secluded Courtyard enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature or creature card of the chosen type.",
             "colours": [],
@@ -20308,7 +20308,7 @@
         },
         {
             "id": "46a97d70-e73b-5117-80e7-3c1ca286ca51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c395a69-b60d-4510-b04b-86b59ed2b158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c395a69-b60d-4510-b04b-86b59ed2b158.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "",
             "colours": [
@@ -20352,7 +20352,7 @@
         },
         {
             "id": "10ea1fa3-6c35-57af-862d-9693bca5e728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5ffb0d-1fc3-40da-ac1f-19465aa8412b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5ffb0d-1fc3-40da-ac1f-19465aa8412b.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "",
             "colours": [
@@ -20395,7 +20395,7 @@
         },
         {
             "id": "6c112277-fd0b-5566-a5f5-0f59216e0444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be84f259-2809-48c9-9c70-861437f08c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be84f259-2809-48c9-9c70-861437f08c23.jpg?1",
             "name": "Pilot",
             "text": "",
             "colours": [],
@@ -20425,7 +20425,7 @@
         },
         {
             "id": "af3f43ba-5ccd-5df8-bb7b-5b26307c67b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -20455,7 +20455,7 @@
         },
         {
             "id": "0979b2d0-05a6-5616-b7be-75c1777f6cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg?1",
             "name": "Samurai",
             "text": "",
             "colours": [
@@ -20489,7 +20489,7 @@
         },
         {
             "id": "e279e34e-2bb6-5fc5-9f24-e2d8441c8b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14eb629e-f09f-4deb-b434-7615a3010a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14eb629e-f09f-4deb-b434-7615a3010a4d.jpg?1",
             "name": "Ninja",
             "text": "",
             "colours": [
@@ -20523,7 +20523,7 @@
         },
         {
             "id": "9179b14e-8e42-594c-bb1a-b2ef2b4cadbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f72ea-13e6-40ab-afc7-55657701c82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f72ea-13e6-40ab-afc7-55657701c82d.jpg?1",
             "name": "Rat Rogue",
             "text": "",
             "colours": [
@@ -20558,7 +20558,7 @@
         },
         {
             "id": "ff7baed0-4359-5fe5-bd9b-abb6234677ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbafdfc0-380a-482b-b5f8-a7a00ecf8da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbafdfc0-380a-482b-b5f8-a7a00ecf8da6.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [
@@ -20593,7 +20593,7 @@
         },
         {
             "id": "90c08b72-09bc-50dd-82c2-00c0d6906d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c06e08-2026-471d-a6d0-bbb0f040420a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c06e08-2026-471d-a6d0-bbb0f040420a.jpg?1",
             "name": "Dragon Spirit",
             "text": "",
             "colours": [
@@ -20628,7 +20628,7 @@
         },
         {
             "id": "54edcc8d-dc97-5a6e-b42b-00d63b81e738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9461c3-f545-4efb-926e-759961db0495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9461c3-f545-4efb-926e-759961db0495.jpg?1",
             "name": "Goblin Shaman",
             "text": "",
             "colours": [
@@ -20663,7 +20663,7 @@
         },
         {
             "id": "3678f749-eef6-5616-a8f0-b019b350f8a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20e427c-efa5-476c-aa33-e3149648d207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20e427c-efa5-476c-aa33-e3149648d207.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20697,7 +20697,7 @@
         },
         {
             "id": "64544fb1-96f2-59f1-a427-0a8ec477a8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dd086e-c757-4a6a-8838-51860f2095f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dd086e-c757-4a6a-8838-51860f2095f8.jpg?1",
             "name": "Human Monk",
             "text": "",
             "colours": [
@@ -20732,7 +20732,7 @@
         },
         {
             "id": "8d87d9c3-08f4-516a-b53d-0c28162ae064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f48aaab-dd6e-4bcc-a8fb-d31dd4a098ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f48aaab-dd6e-4bcc-a8fb-d31dd4a098ba.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20766,7 +20766,7 @@
         },
         {
             "id": "c06ee636-394e-505c-8844-ac3c012e5a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237377d-b79b-4f27-a142-e2c1756e0d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237377d-b79b-4f27-a142-e2c1756e0d94.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20800,7 +20800,7 @@
         },
         {
             "id": "385c70a5-88a4-5ba7-8a01-51688d3af742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb5b3f9-0012-4deb-b795-c377cdfe546b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb5b3f9-0012-4deb-b795-c377cdfe546b.jpg?1",
             "name": "Keimi",
             "text": "",
             "colours": [
@@ -20838,7 +20838,7 @@
         },
         {
             "id": "023515e1-6755-56be-a01a-6f75b668a182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0281825d-9d38-4b56-b522-a8d3cf8c77c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0281825d-9d38-4b56-b522-a8d3cf8c77c9.jpg?1",
             "name": "Mechtitan",
             "text": "",
             "colours": [
@@ -20883,7 +20883,7 @@
         },
         {
             "id": "68fddd02-839b-556e-abc3-c1ec59dcf867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2770f887-7e96-44d1-864a-8c0504a39785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2770f887-7e96-44d1-864a-8c0504a39785.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -20914,7 +20914,7 @@
         },
         {
             "id": "e1afd0a4-f8bf-53eb-8c21-034d1240c3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992cb1e0-e846-4710-b49e-a748e4ebffa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992cb1e0-e846-4710-b49e-a748e4ebffa5.jpg?1",
             "name": "Tamiyo's Notebook",
             "text": "",
             "colours": [],
@@ -20944,7 +20944,7 @@
         },
         {
             "id": "fe4dffe8-dc27-5c0d-aaa3-589a15e78f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911181d-573b-41eb-96a4-799c96e008fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911181d-573b-41eb-96a4-799c96e008fc.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -20974,7 +20974,7 @@
         },
         {
             "id": "274930fe-6153-55a8-8c05-c8e88b7fac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df296190-e51b-44a7-ae83-279fee3151a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df296190-e51b-44a7-ae83-279fee3151a5.jpg?1",
             "name": "Kaito Shizuki Emblem",
             "text": "",
             "colours": [],
@@ -21001,7 +21001,7 @@
         },
         {
             "id": "7ee89398-0e02-5dc6-837e-c5105a01e4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb4fa32-18dd-4530-a529-5477e45413dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb4fa32-18dd-4530-a529-5477e45413dd.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/NPH.json
+++ b/Assets/Resources/Sets/NPH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8130be98-f21c-5977-be37-823d59751a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9287151-95df-4f5a-b32a-4b0aea825452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9287151-95df-4f5a-b32a-4b0aea825452.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from his or her hand.\n-3: Exile target permanent.\n-14: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "dde65be5-56df-5126-b0b4-29894c7accda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7c3571-925d-486e-80dd-bac47aa48283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7c3571-925d-486e-80dd-bac47aa48283.jpg?1",
             "name": "Apostle's Blessing",
             "text": "({PW} can be paid with either {W} or 2 life.)\nTarget artifact or creature you control gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "6d2fd5b4-5a83-58e7-8a0a-80c93aeb4035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deffb601-6a53-4d88-a6af-686ce97eb4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deffb601-6a53-4d88-a6af-686ce97eb4f0.jpg?1",
             "name": "Auriok Survivors",
             "text": "When Auriok Survivors enters the battlefield, you may return target Equipment card from your graveyard to the battlefield. If you do, you may attach it to Auriok Survivors.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "fd9c8e7a-c050-551a-8e5a-a3e1ee821f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e56a28-713b-4a13-a601-1128cf117539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e56a28-713b-4a13-a601-1128cf117539.jpg?1",
             "name": "Blade Splicer",
             "text": "When Blade Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control have first strike.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "6fb3c0bb-1174-55e8-8cb2-a49fa606a5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07592731-68be-4218-bb2c-c2523c5a27f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07592731-68be-4218-bb2c-c2523c5a27f1.jpg?1",
             "name": "Cathedral Membrane",
             "text": "({PW} can be paid with either {W} or 2 life.)\nDefender\nWhen Cathedral Membrane is put into a graveyard from the battlefield during combat, it deals 6 damage to each creature it blocked this combat.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "8c98e08d-8ffb-5958-a59a-bbb30b70af8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1b482a-badb-4b9a-ab63-2e7944826aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1b482a-badb-4b9a-ab63-2e7944826aa0.jpg?1",
             "name": "Chancellor of the Annex",
             "text": "You may reveal this card from your opening hand. If you do, when each opponent casts his or her first spell of the game, counter that spell unless that player pays {1}.\nFlying\nWhenever an opponent casts a spell, counter it unless that player pays {1}.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "986531ec-1fe2-584f-a220-ef73ddd73c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496634f9-1271-4be7-bad5-364bb87a6962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496634f9-1271-4be7-bad5-364bb87a6962.jpg?1",
             "name": "Dispatch",
             "text": "Tap target creature.\nMetalcraft \u2014 If you control three or more artifacts, exile that creature.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "8064c4c6-6b58-5c9b-8849-64cd42481ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7159850-964b-4f12-957f-614eb0570544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7159850-964b-4f12-957f-614eb0570544.jpg?1",
             "name": "Due Respect",
             "text": "Permanents enter the battlefield tapped this turn.\nDraw a card.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "eb466fee-cd94-5313-9cd3-4cd2423a6ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66390d6-1649-4bfa-92d3-77664650d552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66390d6-1649-4bfa-92d3-77664650d552.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "Vigilance\nOther creatures you control get +2/+2.\nCreatures your opponents control get -2/-2.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "e5299b7a-bedf-5208-9223-68d7794357fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3b826a-7349-45ae-89bf-675fea7ce8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3b826a-7349-45ae-89bf-675fea7ce8e3.jpg?1",
             "name": "Exclusion Ritual",
             "text": "Imprint \u2014 When Exclusion Ritual enters the battlefield, exile target nonland permanent.\nPlayers can't cast spells with the same name as the exiled card.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "038f4ef3-8f50-51a5-84e7-66dd05c03f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e050701d-4609-470d-85ff-4b7638893c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e050701d-4609-470d-85ff-4b7638893c6a.jpg?1",
             "name": "Forced Worship",
             "text": "Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "57159a07-07a6-5719-b54a-f8a511182c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e241a0-a027-494b-8187-6ecb006d1d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e241a0-a027-494b-8187-6ecb006d1d33.jpg?1",
             "name": "Inquisitor Exarch",
             "text": "When Inquisitor Exarch enters the battlefield, choose one \u2014 You gain 2 life; or target opponent loses 2 life.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "48a42da3-e6c0-5a3a-b121-d5a98c315eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8209fa5d-2c0e-4827-813b-fff123533f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8209fa5d-2c0e-4827-813b-fff123533f16.jpg?1",
             "name": "Lost Leonin",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "521a6122-7410-5a6a-bad2-854d29ca579e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c050c3-4f50-4bb6-8477-6737887ca10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c050c3-4f50-4bb6-8477-6737887ca10d.jpg?1",
             "name": "Loxodon Convert",
             "text": "",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "2ce98b48-c7c3-53b3-bbae-9ffe85db4689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ca60ee-e54b-4a28-b6a6-7bf3503c35b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ca60ee-e54b-4a28-b6a6-7bf3503c35b4.jpg?1",
             "name": "Marrow Shards",
             "text": "({PW} can be paid with either {W} or 2 life.)\nMarrow Shards deals 1 damage to each attacking creature.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "82981058-1a50-501d-9cc6-f47a051930e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2b91-63af-4700-8ca5-b1756aa6639b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2b91-63af-4700-8ca5-b1756aa6639b.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control get +1/+1.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "11f21d9a-4899-5529-8304-48ebdaa0b803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64073f2-99f5-4dc7-9403-e7cb94ce0e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64073f2-99f5-4dc7-9403-e7cb94ce0e60.jpg?1",
             "name": "Norn's Annex",
             "text": "({PW} can be paid with either {W} or 2 life.)\nCreatures can't attack you or a planeswalker you control unless their controller pays {PW} for each of those creatures.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "5f9c3025-5531-5050-aae0-199fff681c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a1e16a-39f0-47ab-aba8-73e82ba9ab18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a1e16a-39f0-47ab-aba8-73e82ba9ab18.jpg?1",
             "name": "Phyrexian Unlife",
             "text": "You don't lose the game for having 0 or less life.\nAs long as you have 0 or less life, all damage is dealt to you as though its source had infect. (Damage is dealt to you in the form of poison counters.)",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "57761de5-5958-5c03-aea8-19dc038977f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616aa0e-8413-4e63-877c-bffd5263f552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616aa0e-8413-4e63-877c-bffd5263f552.jpg?1",
             "name": "Porcelain Legionnaire",
             "text": "({PW} can be paid with either {W} or 2 life.)\nFirst strike",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "1b103515-a22d-50a5-a651-c013a2114362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca100248-fcd6-41ed-8d75-bcb473845edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca100248-fcd6-41ed-8d75-bcb473845edd.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "5a934f4d-e3d0-59d9-970c-794b420cdad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9b8325-2a28-4312-b778-40087f8ea778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9b8325-2a28-4312-b778-40087f8ea778.jpg?1",
             "name": "Remember the Fallen",
             "text": "Choose one or both \u2014 Return target creature card from your graveyard to your hand; and/or return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "d825ab4b-8123-582c-8f0b-44848c0ec925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79076264-d71c-4b30-aac9-702a4d229933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79076264-d71c-4b30-aac9-702a4d229933.jpg?1",
             "name": "Sensor Splicer",
             "text": "When Sensor Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control have vigilance.",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "c1e3c300-295b-5ca6-97b2-432084c40b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f94e9-91cd-48da-873f-2da2b03a4965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f94e9-91cd-48da-873f-2da2b03a4965.jpg?1",
             "name": "Shattered Angel",
             "text": "Flying\nWhenever a land enters the battlefield under an opponent's control, you may gain 3 life.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "3cfc4510-8ec3-583c-90e6-e89ca819e114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73071a3b-9329-418e-9285-fa4765463d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73071a3b-9329-418e-9285-fa4765463d1f.jpg?1",
             "name": "Shriek Raptor",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "9fe2de06-25b4-5729-ac3d-e5f879cccc35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31432e98-86cd-42ea-ad37-eb4383dc6a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31432e98-86cd-42ea-ad37-eb4383dc6a81.jpg?1",
             "name": "Suture Priest",
             "text": "Whenever another creature enters the battlefield under your control, you may gain 1 life.\nWhenever a creature enters the battlefield under an opponent's control, you may have that player lose 1 life.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "fbe84364-567a-59db-9c95-bfdbbaeef97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d837262-cd5d-4fc9-96dd-39ed04166883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d837262-cd5d-4fc9-96dd-39ed04166883.jpg?1",
             "name": "War Report",
             "text": "You gain life equal to the number of creatures on the battlefield plus the number of artifacts on the battlefield.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "2a673723-f6cb-5c3f-b70f-918d9ca85a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507fa5fd-2aa5-4721-a059-2c8c3056a4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507fa5fd-2aa5-4721-a059-2c8c3056a4ca.jpg?1",
             "name": "Argent Mutation",
             "text": "Target permanent becomes an artifact in addition to its other types until end of turn.\nDraw a card.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "6a3a2439-6c13-592d-9d11-8272947563bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0878b20-315d-49fa-a4d7-232ba1ed6b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0878b20-315d-49fa-a4d7-232ba1ed6b0d.jpg?1",
             "name": "Arm with Aether",
             "text": "Until end of turn, creatures you control gain \"Whenever this creature deals damage to an opponent, you may return target creature that player controls to its owner's hand.\"",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "8d615557-102a-5b2a-b701-85227e417574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddaebde-a060-4510-8c97-68432d931987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddaebde-a060-4510-8c97-68432d931987.jpg?1",
             "name": "Blighted Agent",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nBlighted Agent is unblockable.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "3081b169-78b6-5072-ab6f-d6175a69685b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7bb447-c2b0-429e-bf82-02d6a966fe73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7bb447-c2b0-429e-bf82-02d6a966fe73.jpg?1",
             "name": "Chained Throatseeker",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nChained Throatseeker can't attack unless defending player is poisoned.",
             "colours": [
@@ -1026,7 +1026,7 @@
         },
         {
             "id": "ed8003ff-8cc7-511b-a2d0-ab8284833d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e06e16-96fa-4611-b4a9-512eeeeddd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e06e16-96fa-4611-b4a9-512eeeeddd3c.jpg?1",
             "name": "Chancellor of the Spires",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, each opponent puts the top seven cards of his or her library into his or her graveyard.\nFlying\nWhen Chancellor of the Spires enters the battlefield, you may cast target instant or sorcery card from an opponent's graveyard without paying its mana cost.",
             "colours": [
@@ -1061,7 +1061,7 @@
         },
         {
             "id": "92a0d797-2615-51cc-83e5-75cdbc9cd347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28432161-023b-4a98-b92a-55dc6d936cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28432161-023b-4a98-b92a-55dc6d936cd1.jpg?1",
             "name": "Corrupted Resolve",
             "text": "Counter target spell if its controller is poisoned.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "b9f1c267-f3ff-5cb4-86d5-c757e7f1f3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f123ad6-fe84-4fed-9c0f-6b41921e9c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f123ad6-fe84-4fed-9c0f-6b41921e9c26.jpg?1",
             "name": "Deceiver Exarch",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Deceiver Exarch enters the battlefield, choose one \u2014 Untap target permanent you control; or tap target permanent an opponent controls.",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "fcb14a82-2e05-55ee-8188-1d64891f2878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0670653-d4fe-4fac-b769-d19ca4698c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0670653-d4fe-4fac-b769-d19ca4698c97.jpg?1",
             "name": "Defensive Stance",
             "text": "Enchant creature\nEnchanted creature gets -1/+1.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "46575881-efb3-5df5-93aa-2ed44b7852da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995486ce-58bb-4753-a812-0ca73ef1a235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995486ce-58bb-4753-a812-0ca73ef1a235.jpg?1",
             "name": "Gitaxian Probe",
             "text": "({PU} can be paid with either {U} or 2 life.)\nLook at target player's hand.\nDraw a card.",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "4a3540e4-a836-5b02-9058-13d49080ffb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e1f8b5-4792-457d-b3de-1d4874ddf72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e1f8b5-4792-457d-b3de-1d4874ddf72e.jpg?1",
             "name": "Impaler Shrike",
             "text": "Flying\nWhen Impaler Shrike deals combat damage to a player, you may sacrifice it. If you do, draw three cards.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "7e3e1df1-49dc-5586-9de4-74032da6e280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd46fc9f-5b92-44d7-8940-2f39b0962b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd46fc9f-5b92-44d7-8940-2f39b0962b8f.jpg?1",
             "name": "Jin-Gitaxias, Core Augur",
             "text": "Flash\nAt the beginning of your end step, draw seven cards.\nEach opponent's maximum hand size is reduced by seven.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "0f0c9ca6-9687-5454-8d54-2c91c5d49a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e9c6df-1c84-4eab-9076-a4feb6347c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e9c6df-1c84-4eab-9076-a4feb6347c10.jpg?1",
             "name": "Mental Misstep",
             "text": "({PU} can be paid with either {U} or 2 life.)\nCounter target spell with converted mana cost 1.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "56d7dfca-775b-50b1-8633-616f914fee82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faf4372-6fb5-48aa-9b94-b0e77c867116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faf4372-6fb5-48aa-9b94-b0e77c867116.jpg?1",
             "name": "Mindculling",
             "text": "You draw two cards and target opponent discards two cards.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "de3729ed-f58b-541d-a600-02fcb571b88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f28a0f4-43e1-46df-8b6a-d588c5cceb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f28a0f4-43e1-46df-8b6a-d588c5cceb88.jpg?1",
             "name": "Numbing Dose",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step.\nAt the beginning of the upkeep of enchanted permanent's controller, that player loses 1 life.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "8027cc50-ee1e-5559-88b5-2b6a8fce175f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376e9829-23eb-4b43-9ec7-246cb3156e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376e9829-23eb-4b43-9ec7-246cb3156e95.jpg?1",
             "name": "Phyrexian Ingester",
             "text": "Imprint \u2014 When Phyrexian Ingester enters the battlefield, you may exile target nontoken creature.\nPhyrexian Ingester gets +X/+Y, where X is the exiled creature card's power and Y is its toughness.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "95b2120c-e0a6-523a-8600-001f86cc6ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e27911-87cb-49a0-a34f-6afe4bddd592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e27911-87cb-49a0-a34f-6afe4bddd592.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "({PU} can be paid with either {U} or 2 life.)\nYou may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "7ad337c2-7f17-5229-966b-f425b84345d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cba7d67-5c6c-4738-8907-7cce503e3180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cba7d67-5c6c-4738-8907-7cce503e3180.jpg?1",
             "name": "Psychic Barrier",
             "text": "Counter target creature spell. Its controller loses 1 life.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "f8759670-a9d4-5950-bce7-92384c76eb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea9a6d-d6ca-48cb-adac-958ad0e7440c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea9a6d-d6ca-48cb-adac-958ad0e7440c.jpg?1",
             "name": "Psychic Surgery",
             "text": "Whenever an opponent shuffles his or her library, you may look at the top two cards of that library. You may exile one of those cards. Then put the rest on top of that library in any order.",
             "colours": [
@@ -1499,7 +1499,7 @@
         },
         {
             "id": "29f3138b-9427-5ad9-a897-81e57570892c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd27f71a-cd22-4b5e-9536-3e160111875a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd27f71a-cd22-4b5e-9536-3e160111875a.jpg?1",
             "name": "Spined Thopter",
             "text": "({PU} can be paid with either {U} or 2 life.)\nFlying",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "62474302-a468-574e-9408-707b883594c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f83aa-264b-4d09-b45f-099597a789d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f83aa-264b-4d09-b45f-099597a789d4.jpg?1",
             "name": "Spire Monitor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "f4df5428-2ac5-5255-8e0f-bfb9ab7eb7cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff5a09e-9276-44b8-b374-4b84aebd47cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff5a09e-9276-44b8-b374-4b84aebd47cc.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "({PU} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "a603a196-d4b8-545d-98d9-61cda056075d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70305148-23bd-41dd-9de5-13cf5ae591ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70305148-23bd-41dd-9de5-13cf5ae591ae.jpg?1",
             "name": "Vapor Snag",
             "text": "Return target creature to its owner's hand. Its controller loses 1 life.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "5148a787-8ed6-5e85-a608-9e3aa74e16f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89b312b-cc90-4f08-ae2e-043a79e51156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89b312b-cc90-4f08-ae2e-043a79e51156.jpg?1",
             "name": "Viral Drake",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{3}{U}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1669,7 +1669,7 @@
         },
         {
             "id": "0e864a45-4590-5948-aed0-ce39de43a359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dbfb1b-092c-44a3-932d-a8b27be0a72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dbfb1b-092c-44a3-932d-a8b27be0a72b.jpg?1",
             "name": "Wing Splicer",
             "text": "When Wing Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control have flying.",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "6d4ead99-3d4d-572f-bbee-afdc559fd8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52f08e1-b234-42e4-8f1f-485a4f6edb3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52f08e1-b234-42e4-8f1f-485a4f6edb3b.jpg?1",
             "name": "Xenograft",
             "text": "As Xenograft enters the battlefield, choose a creature type.\nEach creature you control is the chosen type in addition to its other types.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "a7bf233a-d92d-59f6-a7ab-4fbd1fdda5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd04df1-5131-455d-b497-fcce4f9af552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd04df1-5131-455d-b497-fcce4f9af552.jpg?1",
             "name": "Blind Zealot",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever Blind Zealot deals combat damage to a player, you may sacrifice it. If you do, destroy target creature that player controls.",
             "colours": [
@@ -1773,7 +1773,7 @@
         },
         {
             "id": "719c7c0e-8f58-523e-86dc-5fbac4e57593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef987ad-a3dc-4ef5-90ec-9a8cfa95965b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef987ad-a3dc-4ef5-90ec-9a8cfa95965b.jpg?1",
             "name": "Caress of Phyrexia",
             "text": "Target player draws three cards, loses 3 life, and gets three poison counters.",
             "colours": [
@@ -1805,7 +1805,7 @@
         },
         {
             "id": "5eb2777f-1c7a-515e-b760-962c715f0119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec6d85e-6263-44b4-a91f-d51585c561c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec6d85e-6263-44b4-a91f-d51585c561c2.jpg?1",
             "name": "Chancellor of the Dross",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, each opponent loses 3 life, then you gain life equal to the life lost this way.\nFlying, lifelink",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "4adf4345-fe12-557f-b167-08f61089e9f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ae22c3-2dea-463e-894a-188657849909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ae22c3-2dea-463e-894a-188657849909.jpg?1",
             "name": "Dementia Bat",
             "text": "Flying\n{4}{B}, Sacrifice Dementia Bat: Target player discards two cards.",
             "colours": [
@@ -1875,7 +1875,7 @@
         },
         {
             "id": "28004313-defc-5f8b-afaa-48ec622e65d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bfcd3-9f2b-41f5-93b4-8c1ee6ba4d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bfcd3-9f2b-41f5-93b4-8c1ee6ba4d88.jpg?1",
             "name": "Despise",
             "text": "Target opponent reveals his or her hand. You choose a creature or planeswalker card from it. That player discards that card.",
             "colours": [
@@ -1907,7 +1907,7 @@
         },
         {
             "id": "26db94e4-32a5-5f8d-8347-179ac7348575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dfdeb-485f-473e-9fa0-8fdb7638cdc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dfdeb-485f-473e-9fa0-8fdb7638cdc6.jpg?1",
             "name": "Dismember",
             "text": "({PB} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -1939,7 +1939,7 @@
         },
         {
             "id": "7df7ea69-59a0-574c-a6a5-e91ed2857fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2f5f0-1f37-4f51-9c10-c02e2ef7d4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2f5f0-1f37-4f51-9c10-c02e2ef7d4ee.jpg?1",
             "name": "Enslave",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, enchanted creature deals 1 damage to its owner.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "cf7782a4-1932-5985-9fbe-7b9d6de0864e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f58020e-6d4d-474d-8d4b-cfb7d5a5e9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f58020e-6d4d-474d-8d4b-cfb7d5a5e9a8.jpg?1",
             "name": "Entomber Exarch",
             "text": "When Entomber Exarch enters the battlefield, choose one \u2014 Return target creature card from your graveyard to your hand; or target opponent reveals his or her hand, you choose a noncreature card from it, then that player discards that card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "9846b817-95b7-5df4-aeef-a4f1e74d4bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd00bc5-234c-4ded-b0b7-1181bc16cb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd00bc5-234c-4ded-b0b7-1181bc16cb28.jpg?1",
             "name": "Evil Presence",
             "text": "Enchant land\nEnchanted land is a Swamp.",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "efa6cc79-a88f-5478-9db4-12ee9e82f091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20b5a2-8613-49ed-b5cc-7cae9d0e0850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20b5a2-8613-49ed-b5cc-7cae9d0e0850.jpg?1",
             "name": "Geth's Verdict",
             "text": "Target player sacrifices a creature and loses 1 life.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "1c183bcf-951c-578b-98b5-e76b1aad9110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e99fd-7e48-400d-9817-451089089e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e99fd-7e48-400d-9817-451089089e0c.jpg?1",
             "name": "Glistening Oil",
             "text": "Enchant creature\nEnchanted creature has infect.\nAt the beginning of your upkeep, put a -1/-1 counter on enchanted creature.\nWhen Glistening Oil is put into a graveyard from the battlefield, return Glistening Oil to its owner's hand.",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "b95418c2-7948-5f84-888e-f8e502e82e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5c8ba8-d9f4-440c-8e0b-93699df6343e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5c8ba8-d9f4-440c-8e0b-93699df6343e.jpg?1",
             "name": "Grim Affliction",
             "text": "Put a -1/-1 counter on target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "46bd4566-da66-55ae-ab1b-3e9c0336e292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b207e2f-4604-43c5-bb35-a877e35ddd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b207e2f-4604-43c5-bb35-a877e35ddd81.jpg?1",
             "name": "Ichor Explosion",
             "text": "As an additional cost to cast Ichor Explosion, sacrifice a creature.\nAll creatures get -X/-X until end of turn, where X is the sacrificed creature's power.",
             "colours": [
@@ -2172,7 +2172,7 @@
         },
         {
             "id": "60ec56c2-4740-5da8-8cc6-530db8268895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd3fbd2-87c7-4f08-baaa-91d61c1114da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd3fbd2-87c7-4f08-baaa-91d61c1114da.jpg?1",
             "name": "Life's Finale",
             "text": "Destroy all creatures, then search target opponent's library for up to three creature cards and put them into his or her graveyard. Then that player shuffles his or her library.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "f863a2d2-46eb-540d-87ec-efbd07395a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cae1f40-0e43-41d8-bc5c-aa9873f7d7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cae1f40-0e43-41d8-bc5c-aa9873f7d7d5.jpg?1",
             "name": "Mortis Dogs",
             "text": "Whenever Mortis Dogs attacks, it gets +2/+0 until end of turn.\nWhen Mortis Dogs is put into a graveyard from the battlefield, target player loses life equal to its power.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "626419a8-6d57-5918-983c-1755d72798eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f1bf3-9f3a-47f0-9761-8b2356328a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f1bf3-9f3a-47f0-9761-8b2356328a39.jpg?1",
             "name": "Parasitic Implant",
             "text": "Enchant creature\nAt the beginning of your upkeep, enchanted creature's controller sacrifices it and you put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "8cd926fa-b06e-568c-8768-b8ae6e7ff020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c4476d-58f9-420d-9545-f5d580c589de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c4476d-58f9-420d-9545-f5d580c589de.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "372ace98-509f-54e6-a038-bfe2ad1ce730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e960c6-6da0-4679-87eb-55bac890e0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e960c6-6da0-4679-87eb-55bac890e0c6.jpg?1",
             "name": "Pith Driller",
             "text": "({PB} can be paid with either {B} or 2 life.)\nWhen Pith Driller enters the battlefield, put a -1/-1 counter on target creature.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "b12eada7-5a1f-5503-8cac-afcf5d900ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f8b46e-1ad3-4c6e-aa63-376f2d222d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f8b46e-1ad3-4c6e-aa63-376f2d222d46.jpg?1",
             "name": "Postmortem Lunge",
             "text": "({PB} can be paid with either {B} or 2 life.)\nReturn target creature card with converted mana cost X from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "3261649b-2982-5180-b3cd-19bd0f9ee651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9588be49-d9b5-4491-a5a0-10bcadc9f8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9588be49-d9b5-4491-a5a0-10bcadc9f8b3.jpg?1",
             "name": "Praetor's Grasp",
             "text": "Search target opponent's library for a card and exile it face down. Then that player shuffles his or her library. You may look at and play that card for as long as it remains exiled.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "58e9da95-98e9-5da6-8422-acec4b6b3a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300a645-aec6-4cda-8c11-1e8a6af056ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300a645-aec6-4cda-8c11-1e8a6af056ff.jpg?1",
             "name": "Reaper of Sheoldred",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever a source deals damage to Reaper of Sheoldred, that source's controller gets a poison counter.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "7d18309e-04d9-5ea4-aeac-81b30a94c950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8347b-8663-40b8-bdfb-411236d2efc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8347b-8663-40b8-bdfb-411236d2efc8.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "Swampwalk\nAt the beginning of your upkeep, return target creature card from your graveyard to the battlefield.\nAt the beginning of each opponent's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -2480,7 +2480,7 @@
         },
         {
             "id": "faa41ad0-fe62-5866-8b36-6d1d264f54fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca7e072-edb5-4f7e-bdec-a3a393053c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca7e072-edb5-4f7e-bdec-a3a393053c80.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "96f05ffd-2a1d-56c9-9faf-74a17741c748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5823990c-8d40-4352-8d34-74332934adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5823990c-8d40-4352-8d34-74332934adb2.jpg?1",
             "name": "Toxic Nim",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{B}: Regenerate Toxic Nim.",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "d76cd63b-bf56-55e4-a520-edd52cfc268f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f254239c-c07a-4c41-98f7-8f4de539c73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f254239c-c07a-4c41-98f7-8f4de539c73e.jpg?1",
             "name": "Vault Skirge",
             "text": "({PB} can be paid with either {B} or 2 life.)\nFlying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2583,7 +2583,7 @@
         },
         {
             "id": "7cd86351-f2bd-556d-a4fe-3d198a3ed634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb1b486-e336-4e88-b635-b6ff18cb4841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb1b486-e336-4e88-b635-b6ff18cb4841.jpg?1",
             "name": "Whispering Specter",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Whispering Specter deals combat damage to a player, you may sacrifice it. If you do, that player discards a card for each poison counter he or she has.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "7069ef31-1382-58b4-af23-8da8d0b5a79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a9f30b-d154-49a4-ad6b-f05601992de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a9f30b-d154-49a4-ad6b-f05601992de3.jpg?1",
             "name": "Act of Aggression",
             "text": "({PR} can be paid with either {R} or 2 life.)\nGain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "5ef6dec9-f676-55df-ba8a-37dd28a2cab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034522ae-f531-44d9-b186-ada046ce0abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034522ae-f531-44d9-b186-ada046ce0abc.jpg?1",
             "name": "Artillerize",
             "text": "As an additional cost to cast Artillerize, sacrifice an artifact or creature.\nArtillerize deals 5 damage to target creature or player.",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "78dd8369-982c-571c-9fca-72fc62a2b532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30fa96d-64d1-423e-a62e-d43453ea838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30fa96d-64d1-423e-a62e-d43453ea838d.jpg?1",
             "name": "Bludgeon Brawl",
             "text": "Each noncreature, non-Equipment artifact is an Equipment with equip {X} and \"Equipped creature gets +X/+0,\" where X is that artifact's converted mana cost.",
             "colours": [
@@ -2714,7 +2714,7 @@
         },
         {
             "id": "800ced71-dd44-58e2-81b3-e682ec735694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3520a7-a55f-4c00-b4f1-c1c154adfc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3520a7-a55f-4c00-b4f1-c1c154adfc8f.jpg?1",
             "name": "Chancellor of the Forge",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, put a 1/1 red Goblin creature token with haste onto the battlefield.\nWhen Chancellor of the Forge enters the battlefield, put X 1/1 red Goblin creature tokens with haste onto the battlefield, where X is the number of creatures you control.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "cbd06e67-2941-50b0-a2e2-6d37eb80f8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b200986-f553-4156-8f5e-37678db09687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b200986-f553-4156-8f5e-37678db09687.jpg?1",
             "name": "Fallen Ferromancer",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{1}{R}, {T}: Fallen Ferromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "e58baef3-e2d8-5c15-b022-1536377639ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9601ea62-a609-4bc5-a2f0-f7615b4dd5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9601ea62-a609-4bc5-a2f0-f7615b4dd5fa.jpg?1",
             "name": "Flameborn Viron",
             "text": "",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "944b7867-2b11-5c62-a479-5dc600eaa030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97538294-058c-47d4-b7a8-4db3753a6628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97538294-058c-47d4-b7a8-4db3753a6628.jpg?1",
             "name": "Furnace Scamp",
             "text": "Whenever Furnace Scamp deals combat damage to a player, you may sacrifice it. If you do, Furnace Scamp deals 3 damage to that player.",
             "colours": [
@@ -2855,7 +2855,7 @@
         },
         {
             "id": "eaac4455-ac6f-5ffa-a5d2-e5204953d00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b7aa3-bb05-4691-978e-51486435bf05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b7aa3-bb05-4691-978e-51486435bf05.jpg?1",
             "name": "Geosurge",
             "text": "Add {R}{R}{R}{R}{R}{R}{R} to your mana pool. Spend this mana only to cast artifact or creature spells.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "2332fc69-5248-510f-a319-1da3c2928790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a2a30-b96a-49c7-9151-1f4b0d4a4413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a2a30-b96a-49c7-9151-1f4b0d4a4413.jpg?1",
             "name": "Gut Shot",
             "text": "({PR} can be paid with either {R} or 2 life.)\nGut Shot deals 1 damage to target creature or player.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "6b39846e-236c-5246-8068-e6bad81853d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a8c53f-2cb0-41ea-8391-c32667f17c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a8c53f-2cb0-41ea-8391-c32667f17c30.jpg?1",
             "name": "Invader Parasite",
             "text": "Imprint \u2014 When Invader Parasite enters the battlefield, exile target land.\nWhenever a land with the same name as the exiled card enters the battlefield under an opponent's control, Invader Parasite deals 2 damage to that player.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "0e89e63f-b481-5b7d-a21e-5ac17b5cc6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b78018-bfbe-43fa-809f-9b52a155e11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b78018-bfbe-43fa-809f-9b52a155e11c.jpg?1",
             "name": "Moltensteel Dragon",
             "text": "({PR} can be paid with either {R} or 2 life.)\nFlying\n{PR}: Moltensteel Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "3540b031-73ea-5e25-947d-04ec8e17b73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6271c5c1-5f39-4908-b838-0f34c74e912e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6271c5c1-5f39-4908-b838-0f34c74e912e.jpg?1",
             "name": "Ogre Menial",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{R}: Ogre Menial gets +1/+0 until end of turn.",
             "colours": [
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "f04fde7e-c69b-5f25-8889-87bec3a8823b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9f49c-f15c-4b2d-b6a5-8efc3c430d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9f49c-f15c-4b2d-b6a5-8efc3c430d87.jpg?1",
             "name": "Priest of Urabrask",
             "text": "When Priest of Urabrask enters the battlefield, add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "f46b2c83-6924-5f35-83e0-060bdd159bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8cebc2c-a46b-4459-b62b-7fce1a744b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8cebc2c-a46b-4459-b62b-7fce1a744b11.jpg?1",
             "name": "Rage Extractor",
             "text": "({PR} can be paid with either {R} or 2 life.)\nWhenever you cast a spell with p in its mana cost, Rage Extractor deals damage equal to that spell's converted mana cost to target creature or player.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "41ce6f8d-509a-56b0-a4b5-eb8c8c34e8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb022a3-5f9e-491e-8340-087e33f927d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb022a3-5f9e-491e-8340-087e33f927d6.jpg?1",
             "name": "Razor Swine",
             "text": "First strike\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "9c3a2574-3084-53e2-9cd4-016418437345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2bbff9-af57-4858-9351-d148b8c4bc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2bbff9-af57-4858-9351-d148b8c4bc3a.jpg?1",
             "name": "Ruthless Invasion",
             "text": "({PR} can be paid with either {R} or 2 life.)\nNonartifact creatures can't block this turn.",
             "colours": [
@@ -3160,7 +3160,7 @@
         },
         {
             "id": "7cd8e402-e7a5-533b-900d-670a926664cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4874eb-635b-47f0-bbee-6bd8b26e2f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4874eb-635b-47f0-bbee-6bd8b26e2f10.jpg?1",
             "name": "Scrapyard Salvo",
             "text": "Scrapyard Salvo deals damage to target player equal to the number of artifact cards in your graveyard.",
             "colours": [
@@ -3192,7 +3192,7 @@
         },
         {
             "id": "1316ef86-28fa-5dac-976c-0fe1e14018e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d1ee33-e247-4ada-bb01-518611cd7d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d1ee33-e247-4ada-bb01-518611cd7d00.jpg?1",
             "name": "Slag Fiend",
             "text": "Slag Fiend's power and toughness are each equal to the number of artifact cards in all graveyards.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "cdf6cf26-22e7-5d05-ba66-4981b64309ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f510946-34de-4c12-8998-f61887d1a0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f510946-34de-4c12-8998-f61887d1a0e1.jpg?1",
             "name": "Slash Panther",
             "text": "({PR} can be paid with either {R} or 2 life.)\nHaste",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "e126f893-3c79-59cf-950b-df79ea215dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4886eb6a-0f6a-4ea7-8e85-4a27d1a6f03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4886eb6a-0f6a-4ea7-8e85-4a27d1a6f03b.jpg?1",
             "name": "Tormentor Exarch",
             "text": "When Tormentor Exarch enters the battlefield, choose one \u2014 Target creature gets +2/+0 until end of turn; or target creature gets -0/-2 until end of turn.",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "c25e702c-6200-56bc-901f-f5ba2774a121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06fcab2-891e-4fa3-8583-068ba56c2e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06fcab2-891e-4fa3-8583-068ba56c2e27.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "Creatures you control have haste.\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "5701e585-dcab-52fa-9fe8-b99305d51ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b81cb30-e9f8-41f3-a10b-26e0ba2503aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b81cb30-e9f8-41f3-a10b-26e0ba2503aa.jpg?1",
             "name": "Victorious Destruction",
             "text": "Destroy target artifact or land. Its controller loses 1 life.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "6cfc3054-bc79-552d-912f-e3d9d2886d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88011c-a19d-4faa-8da6-86b9980cd571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88011c-a19d-4faa-8da6-86b9980cd571.jpg?1",
             "name": "Volt Charge",
             "text": "Volt Charge deals 3 damage to target creature or player. Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -3399,7 +3399,7 @@
         },
         {
             "id": "d4379a55-b449-5249-ae36-fb4db1a0cc6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1615ec-21b3-4575-8b02-fd2bccb930ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1615ec-21b3-4575-8b02-fd2bccb930ba.jpg?1",
             "name": "Vulshok Refugee",
             "text": "Protection from red",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "e1bc452d-28f2-57a2-b07e-14390dc37220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e6c10-d066-4967-932f-5b6c8d74568b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e6c10-d066-4967-932f-5b6c8d74568b.jpg?1",
             "name": "Whipflare",
             "text": "Whipflare deals 2 damage to each nonartifact creature.",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "a59e8188-768b-5857-9648-a356808cab68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5b6d19-22e3-4f57-8f4d-a17e982286c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5b6d19-22e3-4f57-8f4d-a17e982286c7.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller puts a 3/3 green Beast creature token onto the battlefield.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "d0bcc0c4-1735-58d6-8645-900bc9ae3a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b768efa2-e56b-4a7e-ace8-d673f10e0714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b768efa2-e56b-4a7e-ace8-d673f10e0714.jpg?1",
             "name": "Birthing Pod",
             "text": "({PG} can be paid with either {G} or 2 life.)\n{1}{PG}, {T}, Sacrifice a creature: Search your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "48b02786-7ffd-5bbf-b779-4082b05f6667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfa4ed-70fb-4e25-875d-df0f973f7294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfa4ed-70fb-4e25-875d-df0f973f7294.jpg?1",
             "name": "Brutalizer Exarch",
             "text": "When Brutalizer Exarch enters the battlefield, choose one \u2014 Search your library for a creature card, reveal it, then shuffle your library and put that card on top of it; or put target noncreature permanent on the bottom of its owner's library.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "88050ada-9e44-5484-bb7a-ab3abb77bab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129aa8-b637-451e-8123-5221e08cc2cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129aa8-b637-451e-8123-5221e08cc2cc.jpg?1",
             "name": "Chancellor of the Tangle",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of your first main phase, add {G} to your mana pool.\nVigilance, reach",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "63e30831-50f8-58e2-882d-d795ec2cc334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a13825-ab9b-4ffd-9b59-6198181891b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a13825-ab9b-4ffd-9b59-6198181891b9.jpg?1",
             "name": "Corrosive Gale",
             "text": "({PG} can be paid with either {G} or 2 life.)\nCorrosive Gale deals X damage to each creature with flying.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "5635a434-e3bd-59b4-90dd-2e4fb1b9e87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279ac25-8175-44ad-ab7b-dfa17e359a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279ac25-8175-44ad-ab7b-dfa17e359a10.jpg?1",
             "name": "Death-Hood Cobra",
             "text": "{1}{G}: Death-Hood Cobra gains reach until end of turn. (It can block creatures with flying.)\n{1}{G}: Death-Hood Cobra gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "1e12dc9f-54ca-5127-80ef-3f43eae6df05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1",
             "name": "Fresh Meat",
             "text": "Put a 3/3 green Beast creature token onto the battlefield for each creature put into your graveyard from the battlefield this turn.",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "566524be-4c3d-5bf2-bd65-01ad1f6bbae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11187c1-de35-4e85-87c3-656f978b2d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11187c1-de35-4e85-87c3-656f978b2d7e.jpg?1",
             "name": "Glissa's Scorn",
             "text": "Destroy target artifact. Its controller loses 1 life.",
             "colours": [
@@ -3731,7 +3731,7 @@
         },
         {
             "id": "010e4573-7fdc-5559-82f8-797179e1bfaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94f4c6-b518-43b3-be52-e889d1f3ea38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94f4c6-b518-43b3-be52-e889d1f3ea38.jpg?1",
             "name": "Glistener Elf",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "80532ed1-47bd-5d98-b4bf-0a22a805a0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370f8ef5-c809-43cc-903a-077fad33cd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370f8ef5-c809-43cc-903a-077fad33cd30.jpg?1",
             "name": "Greenhilt Trainee",
             "text": "{T}: Target creature gets +4/+4 until end of turn. Activate this ability only if Greenhilt Trainee's power is 4 or greater.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "b9ba3811-474a-598a-81da-0f725cf8a4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3bdbeb-c376-42bd-af2a-251cd7ac704c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3bdbeb-c376-42bd-af2a-251cd7ac704c.jpg?1",
             "name": "Leeching Bite",
             "text": "Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "33f2bd92-346a-5fd4-a80f-9199a6abd02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c6a6d-5b59-47d7-b290-df3640d9555f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c6a6d-5b59-47d7-b290-df3640d9555f.jpg?1",
             "name": "Maul Splicer",
             "text": "When Maul Splicer enters the battlefield, put two 3/3 colorless Golem artifact creature tokens onto the battlefield.\nGolem creatures you control have trample.",
             "colours": [
@@ -3870,7 +3870,7 @@
         },
         {
             "id": "4c141f3c-4e6c-5c49-8913-a7cdce8d88b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83851a1-e4e8-49ec-af5c-4efe86fa51ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83851a1-e4e8-49ec-af5c-4efe86fa51ad.jpg?1",
             "name": "Melira, Sylvok Outcast",
             "text": "You can't get poison counters.\nCreatures you control can't have -1/-1 counters placed on them.\nCreatures your opponents control lose infect.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "6e1a0bc2-eb2b-57b1-9ba8-1b021cd51166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d23da-70a1-49ba-91bf-c110cc4bbedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d23da-70a1-49ba-91bf-c110cc4bbedc.jpg?1",
             "name": "Mutagenic Growth",
             "text": "({PG} can be paid with either {G} or 2 life.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "b8cffb54-3bf7-524c-a65b-0d4820ff5c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcd1b8e-9f1f-48a3-b7a1-43a32cc03bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcd1b8e-9f1f-48a3-b7a1-43a32cc03bb1.jpg?1",
             "name": "Mycosynth Fiend",
             "text": "Mycosynth Fiend gets +1/+1 for each poison counter your opponents have.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "5efc2769-b535-5437-90f6-01c0b854dc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd1243-1d14-496a-9b7a-0c5b34461361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd1243-1d14-496a-9b7a-0c5b34461361.jpg?1",
             "name": "Noxious Revival",
             "text": "({PG} can be paid with either {G} or 2 life.)\nPut target card from a graveyard on top of its owner's library.",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "65c3b16a-adcd-52ab-8f2c-0166c277908c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a91dea7-9792-4714-82b0-ba2c06cef304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a91dea7-9792-4714-82b0-ba2c06cef304.jpg?1",
             "name": "Phyrexian Swarmlord",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nAt the beginning of your upkeep, put a 1/1 green Insect creature token with infect onto the battlefield for each poison counter your opponents have.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "c27926b6-8c3c-5f8c-beb7-cdd478870dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcae97d-468a-4e16-bfed-d2946f64784c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcae97d-468a-4e16-bfed-d2946f64784c.jpg?1",
             "name": "Rotted Hystrix",
             "text": "",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "17432b9c-90e3-537f-9cb7-d9d45e2958bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc79ac6-ffc6-4506-9dea-e20176f960ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc79ac6-ffc6-4506-9dea-e20176f960ea.jpg?1",
             "name": "Spinebiter",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nYou may have Spinebiter assign its combat damage as though it weren't blocked.",
             "colours": [
@@ -4112,7 +4112,7 @@
         },
         {
             "id": "e88e4c4a-2acf-5dde-84c6-930b4d4fdf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fab443-0f4b-45ea-8a6d-435b93803409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fab443-0f4b-45ea-8a6d-435b93803409.jpg?1",
             "name": "Thundering Tanadon",
             "text": "({PG} can be paid with either {G} or 2 life.)\nTrample",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "f9a07681-0ac3-54f5-aaf7-819301f7714c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16b90ff-d256-4ac6-b687-3430b8c80dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16b90ff-d256-4ac6-b687-3430b8c80dd7.jpg?1",
             "name": "Triumph of the Hordes",
             "text": "Until end of turn, creatures you control get +1/+1 and gain trample and infect. (Creatures with infect deal damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "71f38180-09bf-53ad-a74f-de6e32bf3084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ea52f-4b24-45ff-99e1-4d0e1bd42875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ea52f-4b24-45ff-99e1-4d0e1bd42875.jpg?1",
             "name": "Viridian Betrayers",
             "text": "Viridian Betrayers has infect as long as an opponent is poisoned. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "5c800b02-c433-50d9-9b61-1a38aa06b380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666eb9a5-b105-45c1-be3e-7ac5cc650338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666eb9a5-b105-45c1-be3e-7ac5cc650338.jpg?1",
             "name": "Viridian Harvest",
             "text": "Enchant artifact\nWhen enchanted artifact is put into a graveyard, you gain 6 life.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "dce3de3e-dc43-5e6b-b788-7c4857e635c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b982d-bca2-4418-8618-c711d28fc901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b982d-bca2-4418-8618-c711d28fc901.jpg?1",
             "name": "Vital Splicer",
             "text": "When Vital Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\n{1}: Regenerate target Golem you control.",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "0eca3b0c-40f7-5fea-913e-25d17b54d391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0806adab-6a08-411b-b249-e1c58ade354b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0806adab-6a08-411b-b249-e1c58ade354b.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "Trample\nWhenever you tap a land for mana, add one mana to your mana pool of any type that land produced.\nWhenever an opponent taps a land for mana, that land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "590bc71c-f8fc-5895-804a-47e400c4993b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd8d7de-a2e1-4f83-85f9-7057eebf0c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd8d7de-a2e1-4f83-85f9-7057eebf0c37.jpg?1",
             "name": "Jor Kadeen, the Prevailer",
             "text": "First strike\nMetalcraft \u2014 Creatures you control get +3/+0 as long as you control three or more artifacts.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "2e31da60-fc58-513c-bb69-e23e2f95654c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd3350b-89fb-40b4-a942-28e0c8c274aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd3350b-89fb-40b4-a942-28e0c8c274aa.jpg?1",
             "name": "Alloy Myr",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "d0d5adad-202a-5214-abe6-205b04e841b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd114ec3-d286-4c70-a122-3043bc53cc88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd114ec3-d286-4c70-a122-3043bc53cc88.jpg?1",
             "name": "Batterskull",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return Batterskull to its owner's hand.\nEquip {5}",
             "colours": [],
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "2687074b-7975-5efd-b2d5-cabe0f1669de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220e9dd-f1d8-4a69-9df9-1322e4a5cdc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220e9dd-f1d8-4a69-9df9-1322e4a5cdc7.jpg?1",
             "name": "Blinding Souleater",
             "text": "{PW}, {T}: Tap target creature. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [],
@@ -4457,7 +4457,7 @@
         },
         {
             "id": "cfa07c23-a9bc-5e28-b662-c535fab5067e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506597cc-48f9-4098-a229-2b3b3c0de944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506597cc-48f9-4098-a229-2b3b3c0de944.jpg?1",
             "name": "Caged Sun",
             "text": "As Caged Sun enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+1.\nWhenever a land's ability adds one or more mana of the chosen color to your mana pool, add one additional mana of that color to your mana pool.",
             "colours": [],
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "76fd29fb-68ba-5e8e-982d-6d6653130d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5a8f3-05b6-4bb7-bbe1-e753e22cbb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5a8f3-05b6-4bb7-bbe1-e753e22cbb50.jpg?1",
             "name": "Conversion Chamber",
             "text": "{2}, {T}: Exile target artifact card from a graveyard. Put a charge counter on Conversion Chamber.\n{2}, {T}, Remove a charge counter from Conversion Chamber: Put a 3/3 colorless Golem artifact creature token onto the battlefield.",
             "colours": [],
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "1d82327b-7bdf-5390-b256-ed635fe102d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd8c918-62d9-41be-a3e1-32ddac71b7e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd8c918-62d9-41be-a3e1-32ddac71b7e7.jpg?1",
             "name": "Darksteel Relic",
             "text": "Darksteel Relic is indestructible. (Effects that say \"destroy\" don't destroy it.)",
             "colours": [],
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "e1fe033f-383b-5078-b042-741ae4ea2655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9c4451-dd17-4859-a31d-62ed2430c63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9c4451-dd17-4859-a31d-62ed2430c63c.jpg?1",
             "name": "Etched Monstrosity",
             "text": "Etched Monstrosity enters the battlefield with five -1/-1 counters on it.\n{W}{U}{B}{R}{G}, Remove five -1/-1 counters from Etched Monstrosity: Target player draws three cards.",
             "colours": [],
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "d913d2c5-5e58-5dfd-8467-f3481e358eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccde7ebb-90de-4174-a1c5-75fc9384deaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccde7ebb-90de-4174-a1c5-75fc9384deaa.jpg?1",
             "name": "Gremlin Mine",
             "text": "{1}, {T}, Sacrifice Gremlin Mine: Gremlin Mine deals 4 damage to target artifact creature.\n{1}, {T}, Sacrifice Gremlin Mine: Remove up to four charge counters from target noncreature artifact.",
             "colours": [],
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "b9a02b83-781e-5c55-9411-d53331052466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43502078-5349-4e29-8e7d-277654a9a71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43502078-5349-4e29-8e7d-277654a9a71e.jpg?1",
             "name": "Hex Parasite",
             "text": "{X}{PB}: Remove up to X counters from target permanent. For each counter removed this way, Hex Parasite gets +1/+0 until end of turn. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [],
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "cce3302e-4097-5860-8d82-63e0f019e7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4e445-8333-4cb4-b4fb-80957fae0b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4e445-8333-4cb4-b4fb-80957fae0b97.jpg?1",
             "name": "Hovermyr",
             "text": "Flying, vigilance",
             "colours": [],
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "7306c676-ec7e-5cf0-9146-06eda148c55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbaf916-067d-4834-a55c-b400fe0d8c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbaf916-067d-4834-a55c-b400fe0d8c1f.jpg?1",
             "name": "Immolating Souleater",
             "text": "{PR}: Immolating Souleater gets +1/+0 until end of turn. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [],
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "cc429993-8d7a-5406-b1a4-5f17ceb1c637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171d5213-5bb4-4f5b-9ddd-e2a7ac092ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171d5213-5bb4-4f5b-9ddd-e2a7ac092ec6.jpg?1",
             "name": "Insatiable Souleater",
             "text": "{PG}: Insatiable Souleater gains trample until end of turn. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [],
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "0de228e6-769e-53cb-b171-2cd0dcd91eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e72c64-cb0e-4a04-97d0-3537bb0420cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e72c64-cb0e-4a04-97d0-3537bb0420cd.jpg?1",
             "name": "Isolation Cell",
             "text": "Whenever an opponent casts a creature spell, that player loses 2 life unless he or she pays {2}.",
             "colours": [],
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "30731f96-2262-5cd4-9d5b-4c51fa6f9852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91678632-ebe6-41b6-9250-cd3ffd63663b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91678632-ebe6-41b6-9250-cd3ffd63663b.jpg?1",
             "name": "Kiln Walker",
             "text": "Whenever Kiln Walker attacks, it gets +3/+0 until end of turn.",
             "colours": [],
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "578180d2-5e1f-5ca0-ae10-75a7ad530855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c418159-b5d1-48e9-9a31-707f49d6733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c418159-b5d1-48e9-9a31-707f49d6733b.jpg?1",
             "name": "Lashwrithe",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +1/+1 for each Swamp you control.\nEquip {PB}{PB} ({PB} can be paid with either {B} or 2 life.)",
             "colours": [],
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "e4e5ed0b-51e0-547a-bb73-3f3f128f2492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a5ae0-d76a-4430-98c1-47a19e615e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a5ae0-d76a-4430-98c1-47a19e615e2c.jpg?1",
             "name": "Mindcrank",
             "text": "Whenever an opponent loses life, that player puts that many cards from the top of his or her library into his or her graveyard. (Damage dealt by sources without infect causes loss of life.)",
             "colours": [],
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "bc088047-dc01-5d4c-bca9-ae2fdd4f100b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097f7ab8-01fa-4699-943a-32075aecebc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097f7ab8-01fa-4699-943a-32075aecebc2.jpg?1",
             "name": "Mycosynth Wellspring",
             "text": "When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "8d568569-d77c-58d4-b7b5-f67f9d1f6bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290c6036-02a3-43fa-b0d4-af3818794c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290c6036-02a3-43fa-b0d4-af3818794c3c.jpg?1",
             "name": "Myr Superion",
             "text": "Spend only mana produced by creatures to cast Myr Superion.",
             "colours": [],
@@ -4919,7 +4919,7 @@
         },
         {
             "id": "40d24c20-d83c-59a1-81d4-690c013d1580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed51dbc-bbec-4c78-a71e-26322a8d2439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed51dbc-bbec-4c78-a71e-26322a8d2439.jpg?1",
             "name": "Necropouncer",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +3/+1 and has haste.\nEquip {2}",
             "colours": [],
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "d002fb98-c3ae-5d87-910b-b3664a882b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4e35f-2a82-4d3c-86c5-ae05a5abc4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4e35f-2a82-4d3c-86c5-ae05a5abc4d7.jpg?1",
             "name": "Omen Machine",
             "text": "Players can't draw cards.\nAt the beginning of each player's draw step, that player exiles the top card of his or her library. If it's a land card, the player puts it onto the battlefield. Otherwise, the player casts it without paying its mana cost if able.",
             "colours": [],
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "d6615067-214e-5f38-a3f2-b6bd700dfe84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a069cc07-55eb-4ddb-a548-cbf463d078d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a069cc07-55eb-4ddb-a548-cbf463d078d3.jpg?1",
             "name": "Pestilent Souleater",
             "text": "{PB}: Pestilent Souleater gains infect until end of turn. ({PB} can be paid with either {B} or 2 life. A creature with infect deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -5011,7 +5011,7 @@
         },
         {
             "id": "2370d712-cf23-5f29-b889-1470af911081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687b5a7-7013-409a-ba8d-9cd8b5bb08f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687b5a7-7013-409a-ba8d-9cd8b5bb08f3.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "85533b0a-2b86-5469-8ada-690a3dd0c525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31d96cf-7276-46c4-ad17-d6a5c85f1315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31d96cf-7276-46c4-ad17-d6a5c85f1315.jpg?1",
             "name": "Pristine Talisman",
             "text": "{T}: Add {1} to your mana pool. You gain 1 life.",
             "colours": [],
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "7e0097fe-e0df-5c24-837e-d4b219d72d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ec7b95-667f-43ed-b310-b657befd55a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ec7b95-667f-43ed-b310-b657befd55a2.jpg?1",
             "name": "Shrine of Boundless Growth",
             "text": "At the beginning of your upkeep or whenever you cast a green spell, put a charge counter on Shrine of Boundless Growth.\n{T}, Sacrifice Shrine of Boundless Growth: Add {1} to your mana pool for each charge counter on Shrine of Boundless Growth.",
             "colours": [],
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "fad7a770-0a63-5675-be11-62f94b9f1a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a8afef-fa50-4aeb-94de-a4d90b1e5631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a8afef-fa50-4aeb-94de-a4d90b1e5631.jpg?1",
             "name": "Shrine of Burning Rage",
             "text": "At the beginning of your upkeep or whenever you cast a red spell, put a charge counter on Shrine of Burning Rage.\n{3}, {T}, Sacrifice Shrine of Burning Rage: Shrine of Burning Rage deals damage equal to the number of charge counters on it to target creature or player.",
             "colours": [],
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "23d96f27-c1f0-5095-8e11-7c87f6bf58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61873223-f378-4478-9cf3-f1326eb76834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61873223-f378-4478-9cf3-f1326eb76834.jpg?1",
             "name": "Shrine of Limitless Power",
             "text": "At the beginning of your upkeep or whenever you cast a black spell, put a charge counter on Shrine of Limitless Power.\n{4}, {T}, Sacrifice Shrine of Limitless Power: Target player discards a card for each charge counter on Shrine of Limitless Power.",
             "colours": [],
@@ -5155,7 +5155,7 @@
         },
         {
             "id": "c9f29a6f-bafd-5f6a-afb4-6840e5869ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13563c7-abe0-4760-9b4c-841de47dbc46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13563c7-abe0-4760-9b4c-841de47dbc46.jpg?1",
             "name": "Shrine of Loyal Legions",
             "text": "At the beginning of your upkeep or whenever you cast a white spell, put a charge counter on Shrine of Loyal Legions.\n{3}, {T}, Sacrifice Shrine of Loyal Legions: Put a 1/1 colorless Myr artifact creature token onto the battlefield for each charge counter on Shrine of Loyal Legions.",
             "colours": [],
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "a7ab5e65-bac4-5d3a-989a-8e90b1c10e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b150924-f83c-410e-aaab-ff2d06c9d356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b150924-f83c-410e-aaab-ff2d06c9d356.jpg?1",
             "name": "Shrine of Piercing Vision",
             "text": "At the beginning of your upkeep or whenever you cast a blue spell, put a charge counter on Shrine of Piercing Vision.\n{T}, Sacrifice Shrine of Piercing Vision: Look at the top X cards of your library, where X is the number of charge counters on Shrine of Piercing Vision. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [],
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "5e5232a0-16f2-55a2-97ba-36828805f97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44746d5-3d34-4480-b4cd-c66de72f0622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44746d5-3d34-4480-b4cd-c66de72f0622.jpg?1",
             "name": "Sickleslicer",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+2.\nEquip {4}",
             "colours": [],
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "18adf78f-b8de-51c4-9c0f-3aa7676c04e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7e4989-cba7-4e0c-bb9d-140af6c006c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7e4989-cba7-4e0c-bb9d-140af6c006c3.jpg?1",
             "name": "Soul Conduit",
             "text": "{6}, {T}: Two target players exchange life totals.",
             "colours": [],
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "94c6ba0a-4357-5783-b78a-a90fe697ea37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a84bada-ed6a-4e97-8a0c-05b7cb32d66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a84bada-ed6a-4e97-8a0c-05b7cb32d66f.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "ef432622-2c22-582f-bf93-65b344da8e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12414fc0-bb24-4244-baf4-adad0125376e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12414fc0-bb24-4244-baf4-adad0125376e.jpg?1",
             "name": "Surge Node",
             "text": "Surge Node enters the battlefield with six charge counters on it.\n{1}, {T}, Remove a charge counter from Surge Node: Put a charge counter on target artifact.",
             "colours": [],
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "1e6c58f8-0510-5553-90f1-33497f1a91ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5bc6c-8943-4078-866a-5d02f9be0eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5bc6c-8943-4078-866a-5d02f9be0eef.jpg?1",
             "name": "Sword of War and Peace",
             "text": "Equipped creature gets +2/+2 and has protection from red and from white.\nWhenever equipped creature deals combat damage to a player, Sword of War and Peace deals damage to that player equal to the number of cards in his or her hand and you gain 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "0c18cee4-144f-56e6-b54d-390354dc79f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953610f6-ea96-4e71-969f-50ecac09c091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953610f6-ea96-4e71-969f-50ecac09c091.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -5389,7 +5389,7 @@
         },
         {
             "id": "9d700286-e587-5985-a62b-c32b22892b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5263269-9f64-43de-9e82-408644dbc628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5263269-9f64-43de-9e82-408644dbc628.jpg?1",
             "name": "Trespassing Souleater",
             "text": "{PU}: Trespassing Souleater is unblockable this turn. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -5423,7 +5423,7 @@
         },
         {
             "id": "a2008e00-77bf-5414-8305-5e59cd4e22f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d520b-7560-4ecb-ae62-143eeec5682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d520b-7560-4ecb-ae62-143eeec5682f.jpg?1",
             "name": "Unwinding Clock",
             "text": "Untap all artifacts you control during each other player's untap step.",
             "colours": [],
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "041203ff-7e3d-514e-8078-1a196c2e8b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db36c8e7-0c13-4f0d-9947-68cb0e9ea239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db36c8e7-0c13-4f0d-9947-68cb0e9ea239.jpg?1",
             "name": "Phyrexia's Core",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice an artifact: You gain 1 life.",
             "colours": [],
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "a61134b2-4ee9-5c6e-8871-230eef5cba00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0c6f01-42be-40a1-becb-085f54750830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0c6f01-42be-40a1-becb-085f54750830.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5515,7 +5515,7 @@
         },
         {
             "id": "5fb5547e-8a9c-5d2f-b1bb-f8a607f16405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9129628e-ee2b-450b-a3d6-fc94e9bf477d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9129628e-ee2b-450b-a3d6-fc94e9bf477d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "960fd8bc-b431-50ac-8ace-f889cf387d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25790-29ac-4fc6-afd8-9c4063f4284d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25790-29ac-4fc6-afd8-9c4063f4284d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "f39b232b-83a5-5dce-a321-cf421076f624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aba057e-11db-432b-a39c-a2845868bccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aba057e-11db-432b-a39c-a2845868bccd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5623,7 +5623,7 @@
         },
         {
             "id": "ccdd25fd-573f-5814-bf75-5debd6eff5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267d4321-4411-499c-a476-70c805abf02a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267d4321-4411-499c-a476-70c805abf02a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "8d7af453-7748-565b-801c-8c4dd032e618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f11dc9-cedd-4691-9615-0ed65b5398ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f11dc9-cedd-4691-9615-0ed65b5398ba.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "af017ab5-c317-5012-8bab-1cf372862da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af1a73f-e2ab-4832-b9a0-5bd9643f4fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af1a73f-e2ab-4832-b9a0-5bd9643f4fd3.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5731,7 +5731,7 @@
         },
         {
             "id": "bffbba18-626b-5035-b3d2-bc00d319148d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d68279-a6fd-4cf3-afb3-1ba4e26a78a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d68279-a6fd-4cf3-afb3-1ba4e26a78a3.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "59aa53d0-0b9f-5947-bac6-8e4ea9754094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a8d9ff-291a-4862-b2e8-3db520cc9ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a8d9ff-291a-4862-b2e8-3db520cc9ae4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5803,7 +5803,7 @@
         },
         {
             "id": "da5a70f4-00fc-52fb-8c26-c2a92cd2645c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebd9027-5b48-42c0-9533-afe50bb101e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebd9027-5b48-42c0-9533-afe50bb101e6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5839,7 +5839,7 @@
         },
         {
             "id": "5e492088-8c67-5abf-a3f2-13d0a5871f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b226475-c85c-4b78-9d6a-70cc9545bc31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b226475-c85c-4b78-9d6a-70cc9545bc31.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "37995e58-2bf6-5ce8-be92-1c0e16bead9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeae905-e456-4598-b3de-b339397983bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeae905-e456-4598-b3de-b339397983bf.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "72154cc7-4afa-5a35-942d-1b4c3b52eaf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "d300dc0e-fe5c-534c-ac74-aaa150bdd12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "f1bf3ee3-1f9f-54f0-b789-efd6d7ce4560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470618f6-f67f-44c6-a086-285632508915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470618f6-f67f-44c6-a086-285632508915.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ODY.json
+++ b/Assets/Resources/Sets/ODY.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b115ceba-324e-5b1f-bebc-b7b0b5e21507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561ffdb-f4dd-4b62-a2c2-933498e3a061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561ffdb-f4dd-4b62-a2c2-933498e3a061.jpg?1",
             "name": "Aegis of Honor",
             "text": "o1: The next time an instant or sorcery spell would deal damage to you this turn, that spell deals that damage to its controller instead.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "2bef54d5-8860-5b95-bcdf-547ec73ce469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f28b2af-7891-49eb-a07f-5552b5fe3d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f28b2af-7891-49eb-a07f-5552b5fe3d15.jpg?1",
             "name": "Ancestral Tribute",
             "text": "You gain 2 life for each card in your graveyard.\nFlashback o9o\nWo\nWo\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "10ad8196-c72e-560a-aa25-9f3e05e14fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7c9675-e663-4ad1-9271-38d5c050a7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7c9675-e663-4ad1-9271-38d5c050a7c7.jpg?1",
             "name": "Angelic Wall",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "3773af8f-2a85-5dd1-9fa4-451f52149b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3379317-be18-4252-84ad-b7ebb6e557ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3379317-be18-4252-84ad-b7ebb6e557ff.jpg?1",
             "name": "Animal Boneyard",
             "text": "Enchanted land has \"oc\nT, Sacrifice a creature: You gain life equal to that creature's toughness.\"",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "343672a9-33ce-5b9f-a800-7a3dda392b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090dd4cf-5087-4ed8-a944-f3794e5862d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090dd4cf-5087-4ed8-a944-f3794e5862d5.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer comes into play, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "f8c9359c-7d2a-5c1c-ad49-805ba4269943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d174892-c192-4667-94fb-9f8dbcc6c5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d174892-c192-4667-94fb-9f8dbcc6c5eb.jpg?1",
             "name": "Aven Archer",
             "text": "Flying\no2o\nW, oc\nT: Aven Archer deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "3500d96d-4b86-5035-83f2-26b53e797fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08afe190-368e-4259-9959-00beaccee7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08afe190-368e-4259-9959-00beaccee7ba.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "6fedc331-a462-58af-b12c-51538b944132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29866d0b-f9be-4284-9d21-03598ef6ae4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29866d0b-f9be-4284-9d21-03598ef6ae4f.jpg?1",
             "name": "Aven Flock",
             "text": "Flying\no\nW: Aven Flock gets +0/+1 until end of turn.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "061ca2cf-b6f0-5ddd-b9a4-5b095a5c322a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9890be7f-35af-43b7-b255-25be4ff20dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9890be7f-35af-43b7-b255-25be4ff20dc0.jpg?1",
             "name": "Aven Shrine",
             "text": "Whenever a player plays a spell, that player gains X life, where X is the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "0c12a466-3775-5fc0-b843-fc374bfc54a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6cb368-43f7-4d06-9cd5-492df5766567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6cb368-43f7-4d06-9cd5-492df5766567.jpg?1",
             "name": "Balancing Act",
             "text": "Each player chooses a number of permanents he or she controls equal to the number of permanents controlled by the player who controls the fewest, then sacrifices the rest. Each player discards cards from his or her hand the same way.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "ee55cc08-a8c3-5e68-8ebf-eb91a12cdb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decec62b-7ac4-4097-9215-5db18db2dec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decec62b-7ac4-4097-9215-5db18db2dec6.jpg?1",
             "name": "Beloved Chaplain",
             "text": "Protection from creatures",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "aac72b72-583f-50fe-aee5-48c684c1c621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5654575e-0849-4e7f-98f2-0074ac8e0faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5654575e-0849-4e7f-98f2-0074ac8e0faa.jpg?1",
             "name": "Blessed Orator",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "8cc0dd3e-d975-5166-94eb-70f98dce32f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5243fc3-176b-44a3-9f1a-ab069a08757a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5243fc3-176b-44a3-9f1a-ab069a08757a.jpg?1",
             "name": "Cantivore",
             "text": "Attacking doesn't cause Cantivore to tap.\nCantivore's power and toughness are each equal to the number of enchantment cards in all graveyards.",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "2077c234-4a88-58f3-b241-1b80ef347383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646c998-aee5-497f-bd75-24ced1dabef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646c998-aee5-497f-bd75-24ced1dabef9.jpg?1",
             "name": "Cease-Fire",
             "text": "Target player can't play creature spells this turn.\nDraw a card.",
             "colours": [
@@ -477,7 +477,7 @@
         },
         {
             "id": "1279963f-83a0-5fe9-9e19-94f83a8ea215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c0bdb-e9e2-435e-aa68-2dbad52c3dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c0bdb-e9e2-435e-aa68-2dbad52c3dbd.jpg?1",
             "name": "Confessor",
             "text": "Whenever a player discards a card from his or her hand, you may gain 1 life.",
             "colours": [
@@ -512,7 +512,7 @@
         },
         {
             "id": "daee1fd6-5954-5ae4-8dea-06193d0f28a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f95b64-858b-4344-84a2-3afa5c7b9ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f95b64-858b-4344-84a2-3afa5c7b9ee9.jpg?1",
             "name": "Dedicated Martyr",
             "text": "o\nW, Sacrifice Dedicated Martyr: You gain 3 life.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "716e708c-4c27-52d1-9626-5e5df617f90b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8195a-d0e4-4b11-b413-765ed1cae834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8195a-d0e4-4b11-b413-765ed1cae834.jpg?1",
             "name": "Delaying Shield",
             "text": "If you would be dealt damage, put that many delay counters on Delaying Shield instead.\nAt the beginning of your upkeep, remove all delay counters from Delaying Shield. For each delay counter removed this way, you lose 1 life unless you pay o1o\nW.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "f91f8c59-0d32-5c4d-98a3-b7a387d33b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d400b63-de3e-4805-a51d-c4c0dfbb7033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d400b63-de3e-4805-a51d-c4c0dfbb7033.jpg?1",
             "name": "Devoted Caretaker",
             "text": "o\nW, oc\nT: Target permanent you control gains protection from instant spells and from sorcery spells until end of turn.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "f764d740-1ef6-5fad-b193-a274068d29df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69ecef5-4f1a-4463-8908-7c0ef955b02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69ecef5-4f1a-4463-8908-7c0ef955b02d.jpg?1",
             "name": "Divine Sacrament",
             "text": "White creatures get +1/+1.\nThreshold White creatures get an additional +1/+1. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "ac41b326-f87d-5832-a205-677ea3bb1614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d4337-9b71-429b-b6bc-2d70299a6e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d4337-9b71-429b-b6bc-2d70299a6e76.jpg?1",
             "name": "Dogged Hunter",
             "text": "oc\nT: Destroy target creature token.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "90a85158-1568-5d5d-8a3c-2253af9b6b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66392169-5c6f-46bf-b0df-5670e40aecd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66392169-5c6f-46bf-b0df-5670e40aecd9.jpg?1",
             "name": "Earnest Fellowship",
             "text": "Each creature has protection from its colors.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "14848184-54a0-5162-886c-2bd8484c526b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36848fb0-4070-40cf-b24a-2e8f47c5ebc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36848fb0-4070-40cf-b24a-2e8f47c5ebc3.jpg?1",
             "name": "Embolden",
             "text": "Prevent the next 4 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.\nFlashback o1o\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "7377d2f9-f09b-5942-9ecf-d7422ee3351e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7992f83-93ad-4132-b8f2-a9f93bc96b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7992f83-93ad-4132-b8f2-a9f93bc96b4e.jpg?1",
             "name": "Gallantry",
             "text": "Target blocking creature gets +4/+4 until end of turn.\nDraw a card.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "bf3c0238-23c4-5118-9ecd-fcc05f2067f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f0d9d-4e05-48b4-8652-1f8f41d35563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f0d9d-4e05-48b4-8652-1f8f41d35563.jpg?1",
             "name": "Graceful Antelope",
             "text": "Plainswalk\nWhenever Graceful Antelope deals combat damage to a player, you may have target land become a plains until Graceful Antelope leaves play.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "c692ab84-5894-56e9-b45c-c3065c900db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254d5bf0-f985-4919-a142-d4578ae9a38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254d5bf0-f985-4919-a142-d4578ae9a38e.jpg?1",
             "name": "Hallowed Healer",
             "text": "oc\nT: Prevent the next 2 damage that would be dealt to target creature or player this turn.\nThreshold oc\nT: Prevent the next 4 damage that would be dealt to target creature or player this turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "af5f22cb-db2c-55ac-8404-78a26a15c311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ffb8e7-7ae3-4846-b3da-ca6b4598eb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ffb8e7-7ae3-4846-b3da-ca6b4598eb7c.jpg?1",
             "name": "Karmic Justice",
             "text": "Whenever a spell or ability an opponent controls destroys a noncreature permanent you control, you may destroy target permanent that opponent controls.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "1d286a26-feb1-545f-8beb-1533984ba59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e36fe-ecbe-46aa-9ee8-2ba4daba7d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e36fe-ecbe-46aa-9ee8-2ba4daba7d31.jpg?1",
             "name": "Kirtar's Desire",
             "text": "Enchanted creature can't attack.\nThreshold Enchanted creature can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "079bffa1-700e-5452-b2f0-bb59cb9d75f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a0c4e6-d50e-42e8-b062-8f6ef5950ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a0c4e6-d50e-42e8-b062-8f6ef5950ab7.jpg?1",
             "name": "Kirtar's Wrath",
             "text": "Destroy all creatures. They can't be regenerated.\nThreshold Instead destroy all creatures, then put two 1/1 white Spirit creature tokens with flying into play. Creatures destroyed this way can't be regenerated. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "dc5f6f12-9b44-59f6-8fc6-3e3becd0c30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e518750f-492d-4575-b4ee-c80c1f8e0a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e518750f-492d-4575-b4ee-c80c1f8e0a58.jpg?1",
             "name": "Lieutenant Kirtar",
             "text": "Flying\no1o\nW, Sacrifice Lieutenant Kirtar: Remove target attacking creature from the game.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "18460453-2820-55af-9cc3-15b29903f999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8eee50-efd2-45fd-b815-051167ef4541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8eee50-efd2-45fd-b815-051167ef4541.jpg?1",
             "name": "Life Burst",
             "text": "Target player gains 4 life, then gains 4 life for each Life Burst card in each graveyard.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "5dcc7297-1da2-51b5-90da-3e5f75e649db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5becc51-4df8-4f67-a029-42a3da598a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5becc51-4df8-4f67-a029-42a3da598a26.jpg?1",
             "name": "Luminous Guardian",
             "text": "o\nW: Luminous Guardian gets +0/+1 until end of turn.\no2: Luminous Guardian may block an additional creature this turn.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "b9a0bb6d-8f4e-5fde-852e-95718e87a4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff6624-ed0e-43d0-9519-112979b165f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff6624-ed0e-43d0-9519-112979b165f5.jpg?1",
             "name": "Master Apothecary",
             "text": "Tap an untapped Cleric you control: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "a714a140-2f97-5805-b1c8-e49ffae0cd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce1baf-8a89-4884-b0f7-19311bfc8c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce1baf-8a89-4884-b0f7-19311bfc8c4c.jpg?1",
             "name": "Mystic Crusader",
             "text": "Protection from black and from red\nThreshold Mystic Crusader gets +1/+1 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "e0397687-d3c5-5c22-a3c2-2cdf8366630a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37f08b-019e-4e6b-8b15-b2971a3b5ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37f08b-019e-4e6b-8b15-b2971a3b5ebb.jpg?1",
             "name": "Mystic Penitent",
             "text": "Attacking doesn't cause Mystic Penitent to tap.\nThreshold Mystic Penitent gets +1/+1 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "4ecbfe6a-7ee8-531f-b3b6-b8ba88f2b28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ed1b3d-0f7e-46ff-ada7-ebbd416ecf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ed1b3d-0f7e-46ff-ada7-ebbd416ecf5b.jpg?1",
             "name": "Mystic Visionary",
             "text": "Threshold Mystic Visionary has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "d0eafb42-228f-5aff-8e9b-060db88e6963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba21062-5d13-47b9-bea1-ded8530a9aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba21062-5d13-47b9-bea1-ded8530a9aeb.jpg?1",
             "name": "Mystic Zealot",
             "text": "Threshold Mystic Zealot gets +1/+1 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "b9c96296-d5af-51a7-9fbe-2135e0fd3bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffef7c6-e05b-4bef-84aa-8df10be110af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffef7c6-e05b-4bef-84aa-8df10be110af.jpg?1",
             "name": "Nomad Decoy",
             "text": "o\nW, oc\nT: Tap target creature.\nThreshold o\nWo\nW, oc\nT: Tap two target creatures. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "9ab506c6-bfe5-531b-9aaa-44d4678b2fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216a539-152b-4a83-98ef-1996182a5714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216a539-152b-4a83-98ef-1996182a5714.jpg?1",
             "name": "Patrol Hound",
             "text": "Discard a card from your hand: Patrol Hound gains first strike until end of turn.",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "f86d25aa-bc5a-536f-88f5-d58956a6dfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812edfa-3a53-48e8-ba35-6922a1f3aa90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812edfa-3a53-48e8-ba35-6922a1f3aa90.jpg?1",
             "name": "Pianna, Nomad Captain",
             "text": "Whenever Pianna, Nomad Captain attacks, attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "c7e7f75a-d305-57e5-b409-859904917d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6103a3a7-78ce-4a66-bd82-434e0bd9dea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6103a3a7-78ce-4a66-bd82-434e0bd9dea4.jpg?1",
             "name": "Pilgrim of Justice",
             "text": "Protection from red\no\nW, Sacrifice Pilgrim of Justice: The next time a red source of your choice would deal damage this turn, prevent that damage.",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "7c646e8c-89fb-59ee-b7e6-bb767df635b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be58f0dd-3856-4960-83de-06eed78ed703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be58f0dd-3856-4960-83de-06eed78ed703.jpg?1",
             "name": "Pilgrim of Virtue",
             "text": "Protection from black\no\nW, Sacrifice Pilgrim of Virtue: The next time a black source of your choice would deal damage this turn, prevent that damage.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "3498f9f0-522b-5f9e-bf81-cabb55aee68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9940f593-021f-44cd-9725-0779a2808b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9940f593-021f-44cd-9725-0779a2808b6c.jpg?1",
             "name": "Ray of Distortion",
             "text": "Destroy target artifact or enchantment.\nFlashback o4o\nWo\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "bd691240-464b-5f72-a460-d698336e3dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a61de-ee4e-4097-b342-b5f2c976e16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a61de-ee4e-4097-b342-b5f2c976e16e.jpg?1",
             "name": "Resilient Wanderer",
             "text": "First strike\nDiscard a card from your hand: Resilient Wanderer gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "8336a969-5e2c-5a92-93bf-287928e48863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7f1dd0-ee1b-484a-949d-dde4c3340a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7f1dd0-ee1b-484a-949d-dde4c3340a09.jpg?1",
             "name": "Sacred Rites",
             "text": "Discard any number of cards from your hand. Creatures you control get +0/+1 until end of turn for each card discarded this way.",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "718be822-fd0a-5f48-b199-ca1cf7874468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09586de-4853-4e51-a4ac-70eabb37eef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09586de-4853-4e51-a4ac-70eabb37eef4.jpg?1",
             "name": "Second Thoughts",
             "text": "Remove target attacking creature from the game.\nDraw a card.",
             "colours": [
@@ -1534,7 +1534,7 @@
         },
         {
             "id": "9517992a-e143-53c5-a034-ba593b2b3570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c726ab3-1692-4e14-ab21-664a1679bc53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c726ab3-1692-4e14-ab21-664a1679bc53.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -1566,7 +1566,7 @@
         },
         {
             "id": "2679c275-acdc-5845-9513-80873c9f965f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d24d2f-699b-46d8-9353-45e6a67f99d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d24d2f-699b-46d8-9353-45e6a67f99d2.jpg?1",
             "name": "Soulcatcher",
             "text": "Flying\nWhenever a creature with flying is put into a graveyard from play, put a +1/+1 counter on Soulcatcher.",
             "colours": [
@@ -1601,7 +1601,7 @@
         },
         {
             "id": "25ffe3e0-fa75-540d-ae35-2c6b97f6e4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdcd0de-6466-488c-a882-bad80c86504d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdcd0de-6466-488c-a882-bad80c86504d.jpg?1",
             "name": "Sphere of Duty",
             "text": "If a green source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1633,7 +1633,7 @@
         },
         {
             "id": "1f7756cf-4df0-5f1d-8021-02067b3d0f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b49d82-6d11-4294-a367-0b5b45c05e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b49d82-6d11-4294-a367-0b5b45c05e44.jpg?1",
             "name": "Sphere of Grace",
             "text": "If a black source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "f3cd9491-f0dd-54e4-a8c1-557fc4e8e488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3451ddf-efec-474b-884c-64288e5552d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3451ddf-efec-474b-884c-64288e5552d2.jpg?1",
             "name": "Sphere of Law",
             "text": "If a red source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "87009baf-f63d-520a-a5fc-f5c60dda4a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ef2016-b3c8-4615-a056-3000bcccb68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ef2016-b3c8-4615-a056-3000bcccb68e.jpg?1",
             "name": "Sphere of Reason",
             "text": "If a blue source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "a5732dba-6f53-5197-87bf-0a3c60c92408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3de9f5-a05c-4341-a2c2-a1a475d400fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3de9f5-a05c-4341-a2c2-a1a475d400fd.jpg?1",
             "name": "Sphere of Truth",
             "text": "If a white source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "f270f1f6-6f2b-5a91-bda7-eac465d993eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6780ded-86df-419d-b63b-6b67d2960b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6780ded-86df-419d-b63b-6b67d2960b28.jpg?1",
             "name": "Spiritualize",
             "text": "Until end of turn, whenever target creature deals damage, you gain that much life.\nDraw a card.",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "afe9d5a1-86d1-5adf-a20b-26ca633c4289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920480-9b39-47dd-988a-c040067da7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920480-9b39-47dd-988a-c040067da7fb.jpg?1",
             "name": "Tattoo Ward",
             "text": "Enchanted creature gets +1/+1 and has protection from enchantments. This effect doesn't remove Tattoo Ward.\nSacrifice Tattoo Ward: Destroy target enchantment.",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "978faa25-618b-54d6-bb7e-4cbda17d5ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f399b371-fed0-42b8-8f95-5d76fdbe193d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f399b371-fed0-42b8-8f95-5d76fdbe193d.jpg?1",
             "name": "Testament of Faith",
             "text": "o\nX: Testament of Faith becomes an X/X Wall creature until end of turn. It's still an enchantment. (Walls can't attack.)",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "27dc91f9-d635-5b14-915f-b593e0cbf8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d23e47a-21d5-4d7e-8aa0-3b3064da5967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d23e47a-21d5-4d7e-8aa0-3b3064da5967.jpg?1",
             "name": "Tireless Tribe",
             "text": "Discard a card from your hand: Tireless Tribe gets +0/+4 until end of turn.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "4a620892-ecb5-58d2-87f4-267707171a5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb726e8-162d-4143-9778-32476c0e1ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb726e8-162d-4143-9778-32476c0e1ab1.jpg?1",
             "name": "Wayward Angel",
             "text": "Flying\nAttacking doesn't cause Wayward Angel to tap.\nThreshold Wayward Angel gets +3/+3, is black, has trample, and has \"At the beginning of your upkeep, sacrifice a creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "5ee5073e-f73d-5841-864d-a1af3d7688ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db4a41-03e8-4f0c-946c-a98fc5c9f7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db4a41-03e8-4f0c-946c-a98fc5c9f7c8.jpg?1",
             "name": "Aboshan, Cephalid Emperor",
             "text": "Tap an untapped Cephalid you control: Tap target permanent.\no\nUo\nUo\nU: Tap all creatures without flying.",
             "colours": [
@@ -1966,7 +1966,7 @@
         },
         {
             "id": "4f2edfee-374a-5a68-9472-b70b32d3e6ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137b701e-6140-463e-84b5-58d8a728df40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137b701e-6140-463e-84b5-58d8a728df40.jpg?1",
             "name": "Aboshan's Desire",
             "text": "Enchanted creature has flying.\nThreshold Enchanted creature can't be the target of spells or abilities. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "f6727bbd-ffc5-51a0-8e42-e033edcf3f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09ea4a-0d3a-40b8-be0f-a31693099c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09ea4a-0d3a-40b8-be0f-a31693099c4f.jpg?1",
             "name": "Aether Burst",
             "text": "Return up to X target creatures to their owners' hands, where X is one plus the number of \u00c6ther Burst cards in all graveyards as you play \u00c6ther Burst.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "3b316639-a2fd-5549-aec2-6c4b4265ad6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d73d1e7-79be-4b28-a480-b65b4f34f755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d73d1e7-79be-4b28-a480-b65b4f34f755.jpg?1",
             "name": "Amugaba",
             "text": "Flying\no2o\nU, Discard a card from your hand: Return Amugaba to its owner's hand.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "b671c573-467f-5cbb-9a70-b2d67bc5ef74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7553877-7df2-42f7-98a3-1a07f66a4905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7553877-7df2-42f7-98a3-1a07f66a4905.jpg?1",
             "name": "Aura Graft",
             "text": "Move target enchantment that's enchanting a permanent to another permanent it can enchant. Gain control of that enchantment. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2098,7 +2098,7 @@
         },
         {
             "id": "c8d6108c-1ce4-504b-b64b-6abe5d70c34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b27130d-2296-4076-9829-15ab63081896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b27130d-2296-4076-9829-15ab63081896.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "124d7533-25fb-5c2f-afe2-5aa2ec04dbf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f5d024-f137-4ea8-be02-7de46dee95fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f5d024-f137-4ea8-be02-7de46dee95fd.jpg?1",
             "name": "Aven Smokeweaver",
             "text": "Flying, protection from red",
             "colours": [
@@ -2168,7 +2168,7 @@
         },
         {
             "id": "f432dab2-c070-5f77-a741-bcf415c541c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd2f2cb-a0f1-4844-a692-bcaf1899d41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd2f2cb-a0f1-4844-a692-bcaf1899d41c.jpg?1",
             "name": "Aven Windreader",
             "text": "Flying\no1o\nU: Target player reveals the top card of his or her library.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "7dd8293e-d88b-540c-abbb-4534fdbd0b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d977da2-4024-4c7b-b557-e89564f8d465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d977da2-4024-4c7b-b557-e89564f8d465.jpg?1",
             "name": "Balshan Beguiler",
             "text": "Whenever Balshan Beguiler deals combat damage to a player, that player reveals the top two cards of his or her library. You choose one of those cards and put it into his or her graveyard.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "de0c2eb9-8d5c-517a-b1d9-614d89b81006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c5440-e31f-40be-9e66-699d17049fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c5440-e31f-40be-9e66-699d17049fb4.jpg?1",
             "name": "Balshan Griffin",
             "text": "Flying\no1o\nU, Discard a card from your hand: Return Balshan Griffin to its owner's hand.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "183ff917-55a7-5589-94a2-84a8b26e031a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012bb8-17b7-4b50-a796-662ef09bfc29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012bb8-17b7-4b50-a796-662ef09bfc29.jpg?1",
             "name": "Bamboozle",
             "text": "Target player reveals the top four cards of his or her library. You choose two of those cards and put them into his or her graveyard. Put the rest on top of his or her library in any order.",
             "colours": [
@@ -2305,7 +2305,7 @@
         },
         {
             "id": "e54b5360-a13d-5a52-8928-b887d60f4532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f3c75b-0fe0-48e0-b468-bb928565e9dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f3c75b-0fe0-48e0-b468-bb928565e9dd.jpg?1",
             "name": "Battle of Wits",
             "text": "At the beginning of your upkeep, if you have 200 or more cards in your library, you win the game.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "eceafb2a-499f-5cd5-82ce-59a2b9af5fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea15b53-2940-40e7-8d48-8ec11341da83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea15b53-2940-40e7-8d48-8ec11341da83.jpg?1",
             "name": "Careful Study",
             "text": "Draw two cards, then discard two cards from your hand.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "7b05548d-81d0-5ab5-b641-7b661b6a5cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d2cfe5-b905-4d8a-89e4-474619e2796c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d2cfe5-b905-4d8a-89e4-474619e2796c.jpg?1",
             "name": "Cephalid Broker",
             "text": "oc\nT: Target player draws two cards, then discards two cards from his or her hand.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "709374d4-6c5a-5a2d-aa41-f1bf75a5c41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f1c4e-4fbc-4474-8dd2-5846d417b6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f1c4e-4fbc-4474-8dd2-5846d417b6ab.jpg?1",
             "name": "Cephalid Looter",
             "text": "oc\nT: Target player draws a card, then discards a card from his or her hand.",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "e8dd1a47-1c37-5a94-95ee-ca33354c2b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae87f9d-d6eb-4178-a99d-76a9dffacf28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae87f9d-d6eb-4178-a99d-76a9dffacf28.jpg?1",
             "name": "Cephalid Looter",
             "text": "",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "b10c2f6f-349d-5988-bcc9-f64e54a705ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78480527-cfd6-4065-b702-82de4694f9bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78480527-cfd6-4065-b702-82de4694f9bb.jpg?1",
             "name": "Cephalid Retainer",
             "text": "o\nUo\nU: Tap target creature without flying.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "396d380c-159d-5e6e-bb76-545db2ef34e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efdf190-970d-4751-b214-cd962f7f2ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efdf190-970d-4751-b214-cd962f7f2ca8.jpg?1",
             "name": "Cephalid Scout",
             "text": "Flying\no2o\nU, Sacrifice a land: Draw a card.",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "c275a73a-4599-5bdc-9566-144a902076c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137e0ac1-3bf2-4583-b44f-c9fe8d7e8882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137e0ac1-3bf2-4583-b44f-c9fe8d7e8882.jpg?1",
             "name": "Cephalid Shrine",
             "text": "Whenever a player plays a spell, counter that spell unless that player pays o\nX, where X is the number of cards in all graveyards with the same name as the spell.",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "386cbb19-647c-50ac-9766-155c20c46a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50496069-0f55-4dfe-8b1e-7fc4f649f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50496069-0f55-4dfe-8b1e-7fc4f649f2f1.jpg?1",
             "name": "Chamber of Manipulation",
             "text": "Enchanted land has \"oc\nT, Discard a card from your hand: Gain control of target creature until end of turn.\"",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "7d0f2ddb-d347-5ca3-a224-3a899744c47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de76ff6-d065-4db1-b28d-4a4ccb1cc0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de76ff6-d065-4db1-b28d-4a4ccb1cc0fa.jpg?1",
             "name": "Cognivore",
             "text": "Flying\nCognivore's power and toughness are each equal to the number of instant cards in all graveyards.",
             "colours": [
@@ -2647,7 +2647,7 @@
         },
         {
             "id": "9f3ba421-c6ce-5347-86a9-8a154d656742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2878e-1c1c-4dd3-9687-7bb216d557c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2878e-1c1c-4dd3-9687-7bb216d557c7.jpg?1",
             "name": "Concentrate",
             "text": "Draw three cards.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "5f62e157-3127-562f-9cfc-69c997a3e8a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f38d07-829c-4311-a61b-2785cf2266ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f38d07-829c-4311-a61b-2785cf2266ef.jpg?1",
             "name": "Cultural Exchange",
             "text": "Choose any number of creatures target player controls. Choose the same number of creatures another target player controls. Those players exchange control of those creatures. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "d0a5d989-087f-51b4-a1b6-8c1aa0199cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e64f32-0436-4f07-b2b5-a622e3f59d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e64f32-0436-4f07-b2b5-a622e3f59d65.jpg?1",
             "name": "Deluge",
             "text": "Tap all creatures without flying.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "7c164472-830e-52e5-8c77-1c3767978c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04217c17-7c29-4b02-b9b6-bfa1df50d4bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04217c17-7c29-4b02-b9b6-bfa1df50d4bc.jpg?1",
             "name": "Dematerialize",
             "text": "Return target permanent to its owner's hand.\nFlashback o5o\nUo\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "63bc1141-5498-5dcb-8926-eb34c560438a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6e9f8-a508-451e-8a72-5f9834ba5352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6e9f8-a508-451e-8a72-5f9834ba5352.jpg?1",
             "name": "Divert",
             "text": "Change the target of target spell with a single target unless that spell's controller pays o2.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "10ac94e8-461a-5e39-88d3-9b8b386c8ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae3a000-478c-4185-a8c0-82f29942497b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae3a000-478c-4185-a8c0-82f29942497b.jpg?1",
             "name": "Dreamwinder",
             "text": "Dreamwinder can't attack unless defending player controls an island.\no\nU, Sacrifice an island: Target land becomes an island until end of turn.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "01a665bb-a08e-5445-ab2d-a11513d07bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5d0e3f-b8f1-472a-857b-5464174d243b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5d0e3f-b8f1-472a-857b-5464174d243b.jpg?1",
             "name": "Escape Artist",
             "text": "Escape Artist is unblockable.\no\nU, Discard a card from your hand: Return Escape Artist to its owner's hand.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "7f2ccf67-234e-5e45-85b2-94361566ef8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f99a3d-d811-4666-aac8-5957068157dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f99a3d-d811-4666-aac8-5957068157dc.jpg?1",
             "name": "Extract",
             "text": "Search target player's library for a card and remove that card from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "284dbad0-cc2b-5b5b-994a-43e2dc5b57b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed13fdb4-f28a-43c9-a69f-bab227806c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed13fdb4-f28a-43c9-a69f-bab227806c39.jpg?1",
             "name": "Fervent Denial",
             "text": "Counter target spell.\nFlashback o5o\nUo\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "11706f30-f25b-5b9f-9d4f-cfdde57d3015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6e2d96-dd9e-45f6-b412-78562f2ada40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6e2d96-dd9e-45f6-b412-78562f2ada40.jpg?1",
             "name": "Immobilizing Ink",
             "text": "Enchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"o1, Discard a card from your hand: Untap this creature.\"",
             "colours": [
@@ -2974,7 +2974,7 @@
         },
         {
             "id": "7a2aa93b-1a01-5f23-9db9-59f15368e07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd48c28-bfa3-4eca-8e1a-f72d785b2ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd48c28-bfa3-4eca-8e1a-f72d785b2ab9.jpg?1",
             "name": "Laquatus's Creativity",
             "text": "Target player draws cards equal to the number of cards in his or her hand, then discards that many cards.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "cea8da24-a339-50c5-883a-ee6d4c7147aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b863b8-7780-4bbe-a7f8-46bfdcb34a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b863b8-7780-4bbe-a7f8-46bfdcb34a2b.jpg?1",
             "name": "Patron Wizard",
             "text": "Tap an untapped Wizard you control: Counter target spell unless its controller pays o1.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "78dfe7ec-8cd1-5632-9b10-34a705d14a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67445332-0b56-4fec-8dcd-bb9a87194db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67445332-0b56-4fec-8dcd-bb9a87194db5.jpg?1",
             "name": "Pedantic Learning",
             "text": "Whenever a land card is put into your graveyard from your library, you may pay o1. If you do, draw a card.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "56032103-4eef-5fa9-a733-05196b9ec717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50843cc-20ac-4746-816e-f2630aa31594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50843cc-20ac-4746-816e-f2630aa31594.jpg?1",
             "name": "Peek",
             "text": "Look at target player's hand.\nDraw a card.",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "428620c9-c943-5ab9-a4df-5a084e758461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5d930-23b4-4726-8f5c-3c690b36f4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5d930-23b4-4726-8f5c-3c690b36f4a4.jpg?1",
             "name": "Persuasion",
             "text": "You control enchanted creature.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "51f5447a-168f-5f12-b7a1-88639597058b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9216e73b-56ef-48b9-a6a1-b370fb0d97c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9216e73b-56ef-48b9-a6a1-b370fb0d97c1.jpg?1",
             "name": "Phantom Whelp",
             "text": "When Phantom Whelp attacks or blocks, return it to its owner's hand at end of combat.",
             "colours": [
@@ -3174,7 +3174,7 @@
         },
         {
             "id": "cdac857b-036d-50d2-96ca-8b818182425e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dc842c-3250-44ed-906c-38f14bf1f0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dc842c-3250-44ed-906c-38f14bf1f0e2.jpg?1",
             "name": "Predict",
             "text": "Name a card, then put the top card of target player's library into his or her graveyard. If that card is the named card, you draw two cards. Otherwise, you draw a card.",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "cdf07699-558c-507c-910b-9dc75b50e42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fc18f-90d2-430d-aff2-47c1483dee9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fc18f-90d2-430d-aff2-47c1483dee9d.jpg?1",
             "name": "Psionic Gift",
             "text": "Enchanted creature has \"oc\nT: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "5a4b30cd-4b8a-566c-9a24-9d7b09aa9d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3297f28-a15d-43dd-a96e-09701d5f9aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3297f28-a15d-43dd-a96e-09701d5f9aed.jpg?1",
             "name": "Pulsating Illusion",
             "text": "Flying\nDiscard a card from your hand: Pulsating Illusion gets +4/+4 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "2946de09-dff3-592f-b29d-2cf90ef5a4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d5bd2-02bf-4a22-a656-764425711c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d5bd2-02bf-4a22-a656-764425711c29.jpg?1",
             "name": "Puppeteer",
             "text": "o\nU, oc\nT: Tap or untap target creature.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "5eec6283-86ab-53f9-8a2b-25baafa12446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ea14a6-539a-47eb-9147-a310be7b63fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ea14a6-539a-47eb-9147-a310be7b63fe.jpg?1",
             "name": "Repel",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "eb84e010-5516-55c7-b884-7b54b6670102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa88f595-1b6f-4af0-bc50-bd07c8be431f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa88f595-1b6f-4af0-bc50-bd07c8be431f.jpg?1",
             "name": "Rites of Refusal",
             "text": "Discard any number of cards from your hand. Counter target spell unless its controller pays o3 for each card discarded this way.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "bb8d0a37-5dc4-5e0b-b655-1c792d436c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f16fb-0829-45f9-a12e-aeb2371dd533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f16fb-0829-45f9-a12e-aeb2371dd533.jpg?1",
             "name": "Scrivener",
             "text": "When Scrivener comes into play, you may return target instant card from your graveyard to your hand.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "5efbdab7-2ec0-50b6-a04d-4e1ad5ef7d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538ffe1e-c312-4797-99dd-9bf5f896bdc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538ffe1e-c312-4797-99dd-9bf5f896bdc3.jpg?1",
             "name": "Shifty Doppelganger",
             "text": "o3o\nU, Remove Shifty Doppelganger from the game: Put a creature card from your hand into play. That creature gains haste until end of turn. At end of turn, sacrifice that creature. If you do, return Shifty Doppelganger to play.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "074d1271-6f47-52b3-b1f0-7b22e230a79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede3f6f-e642-4fe4-aa37-0f01cdf4d149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede3f6f-e642-4fe4-aa37-0f01cdf4d149.jpg?1",
             "name": "Standstill",
             "text": "When a player plays a spell, sacrifice Standstill. If you do, each of that player's opponents draws three cards.",
             "colours": [
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "fc7da356-b141-58cd-a0df-130443327e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7850794-4c85-4844-a461-650cd4eaec93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7850794-4c85-4844-a461-650cd4eaec93.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays o\nX. If that spell is countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "32f6940d-d732-517d-b186-ffa311dda473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c9d34-ea4c-4e89-a7ed-06c4469c1aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c9d34-ea4c-4e89-a7ed-06c4469c1aca.jpg?1",
             "name": "Think Tank",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -3538,7 +3538,7 @@
         },
         {
             "id": "a4ceeea9-0fea-551b-927a-d2454f645f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7a96ee-e2d1-4d76-a09e-d6868ddd9282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7a96ee-e2d1-4d76-a09e-d6868ddd9282.jpg?1",
             "name": "Thought Devourer",
             "text": "Flying\nYour maximum hand size is reduced by four.",
             "colours": [
@@ -3572,7 +3572,7 @@
         },
         {
             "id": "8eb420e1-9ac6-57eb-ae56-9e93206d0554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e05f63c-f93d-44b9-98e9-c5e3e3aad6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e05f63c-f93d-44b9-98e9-c5e3e3aad6b9.jpg?1",
             "name": "Thought Eater",
             "text": "Flying\nYour maximum hand size is reduced by three.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "5eb5e069-005a-5e38-a0c3-e359394206ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7284a7fd-cda8-43ac-b119-ad47b33c2ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7284a7fd-cda8-43ac-b119-ad47b33c2ec4.jpg?1",
             "name": "Thought Nibbler",
             "text": "Flying\nYour maximum hand size is reduced by two.",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "8f8322dd-b342-5494-a50d-5f1647f05db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c3d626-880c-422a-ac09-a79a52847477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c3d626-880c-422a-ac09-a79a52847477.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "2249a0e4-05cc-5b16-b622-0b1316ef5ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0c915-92a9-4eb0-a02a-c1571b00761b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0c915-92a9-4eb0-a02a-c1571b00761b.jpg?1",
             "name": "Touch of Invisibility",
             "text": "Target creature is unblockable this turn.\nDraw a card.",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "8c7c316c-bddf-5494-bf16-b534ada6bdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cad8762-ff91-4971-84be-f643c7795679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cad8762-ff91-4971-84be-f643c7795679.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "50aafbce-e387-5573-963e-29483bb717c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b4e02-f81a-490c-8d2e-cfea7917d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b4e02-f81a-490c-8d2e-cfea7917d6b7.jpg?1",
             "name": "Treetop Sentinel",
             "text": "Flying, protection from green",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "435c2005-9396-5f8f-82f0-9a9ed8a54392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa4bf82-65e7-4b0c-9f96-dd84a67dcfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa4bf82-65e7-4b0c-9f96-dd84a67dcfb2.jpg?1",
             "name": "Unifying Theory",
             "text": "Whenever a player plays a spell, that player may pay o2. If the player does, he or she draws a card.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "41cd1b42-7209-520f-84d0-ef0d11bd87ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e201229-34a6-48c8-a07c-d8aefcf5f8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e201229-34a6-48c8-a07c-d8aefcf5f8a7.jpg?1",
             "name": "Upheaval",
             "text": "Return all permanents to their owners' hands.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "e4e1100b-3193-5fd1-bc9a-5a740b99350d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0199cfb-5e44-40f0-b9cf-71473155eb94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0199cfb-5e44-40f0-b9cf-71473155eb94.jpg?1",
             "name": "Words of Wisdom",
             "text": "You draw two cards, then each other player draws a card.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "a61ff5ab-413e-5253-b742-3822f9f21570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1",
             "name": "Afflict",
             "text": "Target creature gets -1/-1 until end of turn.\nDraw a card.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "ae826956-60e6-52e9-ba00-aeb79c40527e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1452ff-cec6-4df3-8bdc-bfb7869553a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1452ff-cec6-4df3-8bdc-bfb7869553a1.jpg?1",
             "name": "Bloodcurdler",
             "text": "Flying\nAt the beginning of your upkeep, put the top card of your library into your graveyard.\nThreshold Bloodcurdler gets +1/+1 and has \"At the end of your turn, remove two cards in your graveyard from the game.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "ea92b680-e0e4-5848-ad34-0ed9e31d7db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcdcad5-e4fb-480e-984f-1ac5cdc986b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcdcad5-e4fb-480e-984f-1ac5cdc986b9.jpg?1",
             "name": "Braids, Cabal Minion",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact, creature, or land.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "2a36ed0e-e599-5bbd-9931-b9ebd8c2f772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db3697e-a31b-45a5-b742-fdfb00ce3929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db3697e-a31b-45a5-b742-fdfb00ce3929.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards and put them into your graveyard. Then shuffle your library.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "1f8f8880-114b-5bf0-a97e-ec6e2d1556a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0530e09-5206-460e-abd2-e928eca294a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0530e09-5206-460e-abd2-e928eca294a5.jpg?1",
             "name": "Cabal Inquisitor",
             "text": "Threshold o1o\nB, oc\nT, Remove two cards in your graveyard from the game: Target player discards a card from his or her hand. Play this ability only any time you could play a sorcery. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "4d3f0198-0d59-5247-b719-cb67f4b3e133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2f0da3-a13e-4a45-98dc-6227cf952a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2f0da3-a13e-4a45-98dc-6227cf952a5e.jpg?1",
             "name": "Cabal Patriarch",
             "text": "o2o\nB, Sacrifice a creature: Target creature gets -2/-2 until end of turn.\no2o\nB, Remove a creature card in your graveyard from the game: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -4074,7 +4074,7 @@
         },
         {
             "id": "b012919c-46d1-530d-b0ff-8416203fa4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd376a52-5dfd-49f3-a520-537cd4527439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd376a52-5dfd-49f3-a520-537cd4527439.jpg?1",
             "name": "Cabal Shrine",
             "text": "Whenever a player plays a spell, that player discards X cards from his or her hand, where X is the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "2970231f-3f90-57a1-aefd-850bae883fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a61f-76fe-42e6-be93-0ba319b7b543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a61f-76fe-42e6-be93-0ba319b7b543.jpg?1",
             "name": "Caustic Tar",
             "text": "Enchanted land has \"oc\nT: Target player loses 3 life.\"",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "c7f99a44-e825-521d-b423-d47ae7141017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c180ea-2d1e-458e-b5d4-e87975eba968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c180ea-2d1e-458e-b5d4-e87975eba968.jpg?1",
             "name": "Childhood Horror",
             "text": "Flying\nThreshold Childhood Horror gets +2/+2 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "15bba7b9-7505-5d77-9e1a-956df21f25dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e06cb-5616-40b4-9d36-89471a795ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e06cb-5616-40b4-9d36-89471a795ac8.jpg?1",
             "name": "Coffin Purge",
             "text": "Remove target card in a graveyard from the game.\nFlashback o\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "b846501f-6872-5058-a813-fe5795cac4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7363dc-fc0d-4fe0-a90c-6ce1782be3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7363dc-fc0d-4fe0-a90c-6ce1782be3ae.jpg?1",
             "name": "Crypt Creeper",
             "text": "Sacrifice Crypt Creeper: Remove target card in a graveyard from the game.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "809df54e-bf75-5511-9103-4c0743e1a53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de97585-3d24-4e8d-8bf9-edd75ee88443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de97585-3d24-4e8d-8bf9-edd75ee88443.jpg?1",
             "name": "Cursed Monstrosity",
             "text": "Flying\nWhenever Cursed Monstrosity becomes the target of a spell or ability, sacrifice it unless you discard a land card from your hand.",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "4dd19d9f-cc17-546b-bb1b-289678106664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bea0ec-52e0-4f45-a445-8805dc6ed596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bea0ec-52e0-4f45-a445-8805dc6ed596.jpg?1",
             "name": "Decaying Soil",
             "text": "At the beginning of your upkeep, remove a card in your graveyard from the game.\nThreshold Whenever a nontoken creature is put into your graveyard from play, you may pay o1. If you do, return that card to your hand. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "2939b646-2a7d-5c20-9efc-6838001548ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916fb8a8-f402-4ef6-8a6b-8fc591e04367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916fb8a8-f402-4ef6-8a6b-8fc591e04367.jpg?1",
             "name": "Decompose",
             "text": "Remove up to three target cards in a single graveyard from the game.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "3226c5e8-9128-5eca-9a3c-56251cde2aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cf7e1b-00ea-46f8-a20a-76c307167854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cf7e1b-00ea-46f8-a20a-76c307167854.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "364a78e3-e1e2-509c-b213-69847618824d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d15534-310f-4f9d-be0d-59b0ed8a5f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d15534-310f-4f9d-be0d-59b0ed8a5f53.jpg?1",
             "name": "Dirty Wererat",
             "text": "o\nB, Discard a card from your hand: Regenerate Dirty Wererat.\nThreshold Dirty Wererat gets +2/+2 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4406,7 +4406,7 @@
         },
         {
             "id": "d22b288c-2652-51ff-86eb-4d29ac188a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67943c0-304a-4d04-8e26-f45b3ab27a45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67943c0-304a-4d04-8e26-f45b3ab27a45.jpg?1",
             "name": "Dusk Imp",
             "text": "Flying",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "75434c84-1e0a-5dcd-92a4-4f83c259112b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60a2091-fb97-4f04-911b-fce9b6351044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60a2091-fb97-4f04-911b-fce9b6351044.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card and put that card into your graveyard. Then shuffle your library.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "161b3b0a-91da-503b-a583-6748e7c64fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333123bc-fb66-4b5a-bf55-045d2906c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333123bc-fb66-4b5a-bf55-045d2906c8c3.jpg?1",
             "name": "Execute",
             "text": "Destroy target white creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -4504,7 +4504,7 @@
         },
         {
             "id": "77552a05-3493-563e-91d1-5049ac9176b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17542219-1165-4483-9cef-7abecaebb6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17542219-1165-4483-9cef-7abecaebb6a2.jpg?1",
             "name": "Face of Fear",
             "text": "o2o\nB, Discard a card from your hand: Face of Fear can't be blocked this turn except by artifact creatures and/or black creatures.",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "d7d8b352-98e6-57bc-8208-d58570217657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e413b65a-700d-44eb-a880-5a0118d2ebac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e413b65a-700d-44eb-a880-5a0118d2ebac.jpg?1",
             "name": "Famished Ghoul",
             "text": "o1o\nB, Sacrifice Famished Ghoul: Remove up to two target cards in a single graveyard from the game.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "0cb66385-2406-5aef-a9e9-9d8f9c234da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634b2b46-b213-4eb0-81d8-0e9dd161b85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634b2b46-b213-4eb0-81d8-0e9dd161b85f.jpg?1",
             "name": "Filthy Cur",
             "text": "Whenever Filthy Cur is dealt damage, you lose that much life.",
             "colours": [
@@ -4606,7 +4606,7 @@
         },
         {
             "id": "49b38bb3-d102-5612-bfa8-01d9dbe7d984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11770ee-dcf0-4dd4-ab43-b98f1133cec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11770ee-dcf0-4dd4-ab43-b98f1133cec7.jpg?1",
             "name": "Fledgling Imp",
             "text": "o\nB, Discard a card from your hand: Fledgling Imp gains flying until end of turn.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "533641e9-8ccb-53b2-977b-677aa4019e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79129e7-6cc4-4060-8b76-3afbd2e0d456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79129e7-6cc4-4060-8b76-3afbd2e0d456.jpg?1",
             "name": "Frightcrawler",
             "text": "Frightcrawler can't be blocked except by artifact creatures and/or black creatures.\nThreshold Frightcrawler gets +2/+2 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "a4b4db82-6417-5e3b-94b1-e518e9a925f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2bfa3-0499-43ea-a76d-b12fddbc104e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2bfa3-0499-43ea-a76d-b12fddbc104e.jpg?1",
             "name": "Ghastly Demise",
             "text": "Destroy target nonblack creature if its toughness is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "cf652576-7db1-5dec-8c82-8b1228c2a622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92e67ef-d1e9-427f-827b-d07e06126821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92e67ef-d1e9-427f-827b-d07e06126821.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "333968d2-e053-53bd-adc5-10ad6dc833a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e273b71-85ca-49d2-ba96-70cc0ae8d718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e273b71-85ca-49d2-ba96-70cc0ae8d718.jpg?1",
             "name": "Gravestorm",
             "text": "At the beginning of your upkeep, target opponent may remove a card in his or her graveyard from the game. If that player doesn't, you may draw a card.",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "bf9da854-10a7-5258-995f-99e3ce85afb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca4c571-48b8-4150-93f8-4cb5c8e797c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca4c571-48b8-4150-93f8-4cb5c8e797c4.jpg?1",
             "name": "Haunting Echoes",
             "text": "Remove all cards in target player's graveyard other than basic land cards from the game. Search that player's library for all cards with the same name as cards removed this way and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -4804,7 +4804,7 @@
         },
         {
             "id": "43cc8983-aab5-5f4a-b6a7-3621bcfc215b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6abaca0-7ce1-4024-adf6-ef6cc0fbcb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6abaca0-7ce1-4024-adf6-ef6cc0fbcb75.jpg?1",
             "name": "Hint of Insanity",
             "text": "Target player reveals his or her hand. That player discards from it all nonland cards with the same name as another card in his or her hand.",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "5c92763c-0c1e-5623-91c9-f614e399f44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00615487-3526-4b4c-bb06-8f2af1f101d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00615487-3526-4b4c-bb06-8f2af1f101d0.jpg?1",
             "name": "Infected Vermin",
             "text": "o2o\nB: Infected Vermin deals 1 damage to each creature and each player.\nThreshold o3o\nB: Infected Vermin deals 3 damage to each creature and each player. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "47f4de42-e097-5703-8708-2b81ea975ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26af8f6-df64-4027-880c-f2fae2d8103f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26af8f6-df64-4027-880c-f2fae2d8103f.jpg?1",
             "name": "Innocent Blood",
             "text": "Each player sacrifices a creature.",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "e4ad7330-eab8-5ae6-acb6-5931fa036261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b140a36-6686-4781-a432-cb2ef58afa81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b140a36-6686-4781-a432-cb2ef58afa81.jpg?1",
             "name": "Last Rites",
             "text": "Discard any number of cards from your hand. Target player reveals his or her hand, then you choose a nonland card from it for each card discarded this way. That player discards those cards.",
             "colours": [
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "4f548729-fa5e-5bff-9ff2-a32379bdb89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d94052-aae3-4ced-9309-fc4a0d1f159d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d94052-aae3-4ced-9309-fc4a0d1f159d.jpg?1",
             "name": "Malevolent Awakening",
             "text": "o1o\nBo\nB, Sacrifice a creature: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4966,7 +4966,7 @@
         },
         {
             "id": "2fd7bbaf-9eff-5ac3-b6f9-76880f38e7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07889a1-1582-4f14-8925-fa21a1a5fd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07889a1-1582-4f14-8925-fa21a1a5fd65.jpg?1",
             "name": "Mind Burst",
             "text": "Target player discards X cards from his or her hand, where X is one plus the number of Mind Burst cards in all graveyards.",
             "colours": [
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "1b3b11f2-f787-5f2d-8993-ffc085c9671e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895b1c9b-b1a1-457b-92cd-3469a38b69a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895b1c9b-b1a1-457b-92cd-3469a38b69a3.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer is put into a graveyard from play, each player discards his or her hand.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "71a6d6cb-5597-5346-9095-3333623bcf6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a4e7d0-ff09-4e19-8456-f4845f56dc8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a4e7d0-ff09-4e19-8456-f4845f56dc8b.jpg?1",
             "name": "Morbid Hunger",
             "text": "Morbid Hunger deals 3 damage to target creature or player. You gain 3 life.\nFlashback o7o\nBo\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5064,7 +5064,7 @@
         },
         {
             "id": "798edf13-56ff-5929-99b1-bd11500fbd11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937465ca-4cf7-4412-86eb-264efb0fdddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937465ca-4cf7-4412-86eb-264efb0fdddd.jpg?1",
             "name": "Morgue Theft",
             "text": "Return target creature card from your graveyard to your hand.\nFlashback o4o\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "f63da01b-42a7-5504-aeb5-ede2ca34e9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc0d499-4a22-4f33-83c7-4e8cdbc3ebe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc0d499-4a22-4f33-83c7-4e8cdbc3ebe6.jpg?1",
             "name": "Mortivore",
             "text": "Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\no\nB: Regenerate Mortivore.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "120ab790-fdd5-538c-8504-8150be62702c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90f5a4e-8c3a-4803-bb59-d3d7c23761db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90f5a4e-8c3a-4803-bb59-d3d7c23761db.jpg?1",
             "name": "Nefarious Lich",
             "text": "If you would be dealt damage, remove that many cards in your graveyard from the game instead. If you can't, you lose the game.\nIf you would gain life, draw that many cards instead.\nWhen Nefarious Lich leaves play, you lose the game.",
             "colours": [
@@ -5162,7 +5162,7 @@
         },
         {
             "id": "481e6be2-fc07-52ca-b23b-a03cf983e22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b886292-5937-44ee-bc2a-f316791c91ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b886292-5937-44ee-bc2a-f316791c91ae.jpg?1",
             "name": "Overeager Apprentice",
             "text": "Discard a card from your hand, Sacrifice Overeager Apprentice: Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -5197,7 +5197,7 @@
         },
         {
             "id": "32d68fa0-539f-5853-9083-7cfde93d43d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f993815-af2f-4fa0-8848-979fc8c72d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f993815-af2f-4fa0-8848-979fc8c72d9a.jpg?1",
             "name": "Painbringer",
             "text": "oc\nT, Remove any number of cards in your graveyard from the game: Target creature gets -X/-X until end of turn, where X is the number of cards removed this way.",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "8ba53fd3-b200-549e-be4b-85080b1651e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309bc2e7-bece-493d-b7ab-0e08a9f40909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309bc2e7-bece-493d-b7ab-0e08a9f40909.jpg?1",
             "name": "Patriarch's Desire",
             "text": "Enchanted creature gets +2/-2.\nThreshold Enchanted creature gets an additional +2/-2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -5266,7 +5266,7 @@
         },
         {
             "id": "15503ac8-d34f-5a56-bd9f-61bf66a21a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbad4-1105-4426-8d4d-a30f6fa95ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbad4-1105-4426-8d4d-a30f6fa95ce8.jpg?1",
             "name": "Repentant Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Repentant Vampire this turn is put into a graveyard, put a +1/+1 counter on Repentant Vampire.\nThreshold Repentant Vampire is white and has \"oc\nT: Destroy target black creature.\"",
             "colours": [
@@ -5300,7 +5300,7 @@
         },
         {
             "id": "999a111d-88e0-5433-967d-ed46d027aba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2db4b2-6209-4a49-b868-e5d229ffcbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2db4b2-6209-4a49-b868-e5d229ffcbc1.jpg?1",
             "name": "Rotting Giant",
             "text": "Whenever Rotting Giant attacks or blocks, sacrifice it unless you remove a card in your graveyard from the game.",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "c0345c75-c652-5ebf-8d8f-2ff345401b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a6fba0-e5fc-4fa8-9895-8e4b8272bebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a6fba0-e5fc-4fa8-9895-8e4b8272bebe.jpg?1",
             "name": "Sadistic Hypnotist",
             "text": "Sacrifice a creature: Target player discards two cards from his or her hand. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "f632d64b-f88a-5a6e-b53b-ab21e8ba56dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cc53cf-13eb-4028-944d-a670ad30dbca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cc53cf-13eb-4028-944d-a670ad30dbca.jpg?1",
             "name": "Screams of the Damned",
             "text": "o1o\nB, Remove a card in your graveyard from the game: Screams of the Damned deals 1 damage to each creature and each player.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "d0814f61-a4d1-5a18-b654-aeb53a90b742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee49bae4-b53f-4d62-9ba6-6105b0087bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee49bae4-b53f-4d62-9ba6-6105b0087bcf.jpg?1",
             "name": "Skeletal Scrying",
             "text": "As an additional cost to play Skeletal Scrying, remove X cards in your graveyard from the game.\nYou draw X cards and you lose X life.",
             "colours": [
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "75220e2c-4aac-5e03-9d07-5b422b88e2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e3c013-319f-4a77-a55e-11323468b8ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e3c013-319f-4a77-a55e-11323468b8ea.jpg?1",
             "name": "Skull Fracture",
             "text": "Target player discards a card from his or her hand.\nFlashback o3o\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "5a6174a7-51b8-5f3a-8b8a-ec570d9d7cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16705695-1ba8-4169-974f-d8c683ab2652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16705695-1ba8-4169-974f-d8c683ab2652.jpg?1",
             "name": "Stalking Bloodsucker",
             "text": "Flying\no1o\nB, Discard a card from your hand: Stalking Bloodsucker gets +2/+2 until end of turn.",
             "colours": [
@@ -5500,7 +5500,7 @@
         },
         {
             "id": "11aa2a64-049f-553a-8b19-08e2557f94ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c513f51b-a0db-4c08-8acc-1e91060b93b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c513f51b-a0db-4c08-8acc-1e91060b93b7.jpg?1",
             "name": "Tainted Pact",
             "text": "Remove the top card of your library from the game. You may put that card into your hand unless it has the same name as another card removed this way. Repeat this process until you put a card into your hand or you remove two cards with the same name, whichever comes first.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "22908fa2-d733-562e-9415-7907d7405f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb08a4a7-941b-4b54-a89b-a4145a6fc14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb08a4a7-941b-4b54-a89b-a4145a6fc14e.jpg?1",
             "name": "Tombfire",
             "text": "Target player removes all cards with flashback in his or her graveyard from the game.",
             "colours": [
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "c7f55e06-9ef0-54e7-b07f-0396c0aafbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b6413d-68d3-4097-9bb3-873df4900e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b6413d-68d3-4097-9bb3-873df4900e4c.jpg?1",
             "name": "Traveling Plague",
             "text": "At the beginning of each player's upkeep, put a plague counter on Traveling Plague.\nEnchanted creature gets -1/-1 for each plague counter on Traveling Plague.\nWhen enchanted creature leaves play, that creature's controller returns Traveling Plague from its owner's graveyard to play.",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "b84fbfb1-3b4c-569f-9fcb-4411f1ab48d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbfdc2a-7bf3-4461-bef7-fa499d29d1b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbfdc2a-7bf3-4461-bef7-fa499d29d1b8.jpg?1",
             "name": "Whispering Shade",
             "text": "Swampwalk\no\nB: Whispering Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "457223f6-3d8c-594d-8979-1b8aec32c53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4649311-1300-42fb-ac10-90490756c7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4649311-1300-42fb-ac10-90490756c7aa.jpg?1",
             "name": "Zombie Assassin",
             "text": "oc\nT, Remove two cards in your graveyard and Zombie Assassin from the game: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "9c430939-d16a-553c-9cb1-2eee2ef77349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe73ea4-caa2-41de-a065-272a4d850362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe73ea4-caa2-41de-a065-272a4d850362.jpg?1",
             "name": "Zombie Cannibal",
             "text": "Whenever Zombie Cannibal deals combat damage to a player, you may remove target card in that player's graveyard from the game.",
             "colours": [
@@ -5701,7 +5701,7 @@
         },
         {
             "id": "752665ed-e4ac-5f9f-9392-65dd15628a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd5f98a-7ab5-44b3-850c-b50963dace66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd5f98a-7ab5-44b3-850c-b50963dace66.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards from your hand: Put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "e0e5b3e9-49ef-5980-8ca8-def78fb028cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a2a6f-9ae6-42cb-b75f-6b45fc35f36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a2a6f-9ae6-42cb-b75f-6b45fc35f36e.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "9ce08581-c475-5806-9060-d674620fb244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9082bfb8-0ab0-4378-976d-a2c9d3c35a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9082bfb8-0ab0-4378-976d-a2c9d3c35a5e.jpg?1",
             "name": "Acceptable Losses",
             "text": "As an additional cost to play Acceptable Losses, discard a card at random from your hand.\nAcceptable Losses deals 5 damage to target creature.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "141f9a3b-cf0b-5566-a0d5-7329c5520ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5514627a-b24c-48c9-9a5a-5a375adcdf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5514627a-b24c-48c9-9a5a-5a375adcdf62.jpg?1",
             "name": "Anarchist",
             "text": "When Anarchist comes into play, you may return target sorcery card from your graveyard to your hand.",
             "colours": [
@@ -5832,7 +5832,7 @@
         },
         {
             "id": "47407006-536e-5aaa-8b1c-ac9a6c4d242f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaef0bd-8288-49ba-a889-d897a4aae64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaef0bd-8288-49ba-a889-d897a4aae64c.jpg?1",
             "name": "Ashen Firebeast",
             "text": "o1o\nR: Ashen Firebeast deals 1 damage to each creature without flying.",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "7f347609-84f8-598a-9aa1-373a329817a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c899f9b-ebce-4424-9cd9-861a50a5f7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c899f9b-ebce-4424-9cd9-861a50a5f7d2.jpg?1",
             "name": "Barbarian Lunatic",
             "text": "o2o\nR, Sacrifice Barbarian Lunatic: Barbarian Lunatic deals 2 damage to target creature.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "196da1b6-79d9-56a2-94b0-d626fa9627c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694b24de-d7f8-49c6-8ab3-d5fab13b6a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694b24de-d7f8-49c6-8ab3-d5fab13b6a8f.jpg?1",
             "name": "Bash to Bits",
             "text": "Destroy target artifact.\nFlashback o4o\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5934,7 +5934,7 @@
         },
         {
             "id": "da16eb40-c814-5949-95e8-54be3e575d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1be893-1287-40a3-81d6-271df3154b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1be893-1287-40a3-81d6-271df3154b45.jpg?1",
             "name": "Battle Strain",
             "text": "Whenever a creature blocks, Battle Strain deals 1 damage to that creature's controller.",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "536505a4-5713-55a7-94f1-f92eb81e1c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d192ef-a174-4df5-b67f-22918c32cf71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d192ef-a174-4df5-b67f-22918c32cf71.jpg?1",
             "name": "Blazing Salvo",
             "text": "Blazing Salvo deals 3 damage to target creature unless that creature's controller has Blazing Salvo deal 5 damage to him or her.",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "2d235403-9978-5873-a21c-cda45772d8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9535a5-29ea-4085-a36b-4905d85e97ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9535a5-29ea-4085-a36b-4905d85e97ac.jpg?1",
             "name": "Bomb Squad",
             "text": "oc\nT: Put a fuse counter on target creature.\nAt the beginning of your upkeep, put a fuse counter on each creature with a fuse counter on it.\nWhenever a creature has four or more fuse counters on it, remove all fuse counters from it and destroy it. That creature deals 4 damage to its controller.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "3fa9a2f4-5114-500c-bf73-c698a6a7d919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5d5eef-6e3c-4907-a277-a13de2916e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5d5eef-6e3c-4907-a277-a13de2916e2b.jpg?1",
             "name": "Burning Sands",
             "text": "Whenever a creature is put into a graveyard from play, that creature's controller sacrifices a land.",
             "colours": [
@@ -6064,7 +6064,7 @@
         },
         {
             "id": "8cfa2aae-aa8f-5c0d-b736-85bcd5081500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a5bba-a10f-41f6-88cd-cef1dfe4bfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a5bba-a10f-41f6-88cd-cef1dfe4bfa9.jpg?1",
             "name": "Chainflinger",
             "text": "o1o\nR, oc\nT: Chainflinger deals 1 damage to target creature or player.\nThreshold o2o\nR, oc\nT: Chainflinger deals 2 damage to target creature or player. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -6098,7 +6098,7 @@
         },
         {
             "id": "312c95a8-7c86-54f0-9910-aa675d60efd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57817159-de10-4a68-83e1-971fa9cfee2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57817159-de10-4a68-83e1-971fa9cfee2c.jpg?1",
             "name": "Chance Encounter",
             "text": "Whenever you win a coin flip, put a luck counter on Chance Encounter.\nAt the beginning of your upkeep, if Chance Encounter has ten or more luck counters on it, you win the game.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "5dc9f5e5-cc2e-5045-a5eb-5a91dd5a3bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9162a4df-ca6d-4f07-ae48-d333f1cb74b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9162a4df-ca6d-4f07-ae48-d333f1cb74b9.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "5f91bf83-3dfe-5258-b749-f781f2f8c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2f16f9-4980-45e9-99bf-0e00e3008b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2f16f9-4980-45e9-99bf-0e00e3008b1d.jpg?1",
             "name": "Demoralize",
             "text": "Each creature can't be blocked this turn except by two or more creatures.\nThreshold Creatures can't block this turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "6bf08151-4a70-5337-b827-4cb8ee5dc908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f00d726-4289-48ff-8c14-6a5080a00fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f00d726-4289-48ff-8c14-6a5080a00fda.jpg?1",
             "name": "Dwarven Grunt",
             "text": "Mountainwalk",
             "colours": [
@@ -6228,7 +6228,7 @@
         },
         {
             "id": "4f73102c-d004-5cba-8472-b1404f4435d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a15d274-85b4-4f3c-b502-f6dfe7db4d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a15d274-85b4-4f3c-b502-f6dfe7db4d37.jpg?1",
             "name": "Dwarven Recruiter",
             "text": "When Dwarven Recruiter comes into play, search your library for any number of Dwarf cards and reveal those cards. Shuffle your library, then put them on top of it in any order.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "d8cee50f-304a-5ecc-a61d-f37e54022ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85197997-5e1a-46ce-8f0d-6da5ce297baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85197997-5e1a-46ce-8f0d-6da5ce297baf.jpg?1",
             "name": "Dwarven Shrine",
             "text": "Whenever a player plays a spell, Dwarven Shrine deals X damage to that player, where X is twice the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "916c723a-ee2e-51f8-b19e-c598c70f5414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bc3d85-5ba1-4f2e-a676-be989bdb04f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bc3d85-5ba1-4f2e-a676-be989bdb04f7.jpg?1",
             "name": "Dwarven Strike Force",
             "text": "Discard a card at random from your hand: Dwarven Strike Force gains first strike and haste until end of turn.",
             "colours": [
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "65235541-9fe5-51a1-8b31-237926ca9e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e10742-77c9-4f91-81b2-37b2ac910f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e10742-77c9-4f91-81b2-37b2ac910f09.jpg?1",
             "name": "Earth Rift",
             "text": "Destroy target land.\nFlashback o5o\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -6361,7 +6361,7 @@
         },
         {
             "id": "d4817371-883b-5be2-a455-6f839ae6fe64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25080720-612f-40c0-8894-cda8e3e8afb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25080720-612f-40c0-8894-cda8e3e8afb8.jpg?1",
             "name": "Ember Beast",
             "text": "Ember Beast can't attack or block alone.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "99a44c94-6c46-562f-b91f-e79dedc8b653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a92ac-0788-4238-a2ed-1ebd3dd0dd88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a92ac-0788-4238-a2ed-1ebd3dd0dd88.jpg?1",
             "name": "Engulfing Flames",
             "text": "Engulfing Flames deals 1 damage to target creature. It can't be regenerated this turn.\nFlashback o3o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "2725213e-5436-5204-96b0-0472cf5327b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9232ae-9f32-4bbc-a020-554b3f9cbbd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9232ae-9f32-4bbc-a020-554b3f9cbbd3.jpg?1",
             "name": "Epicenter",
             "text": "Target player sacrifices a land.\nThreshold All players sacrifice all lands instead. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -6459,7 +6459,7 @@
         },
         {
             "id": "4c157fa0-47c6-5025-bccb-b0c43b1ffa9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e45005-dd81-4d80-b043-02f719aca929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e45005-dd81-4d80-b043-02f719aca929.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to target creature or player.\nFlashback o4o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -6491,7 +6491,7 @@
         },
         {
             "id": "f42cc081-85bd-5be6-b531-605c9c57b1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bbd438-7df2-4d7b-88ad-4531ebaf3931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bbd438-7df2-4d7b-88ad-4531ebaf3931.jpg?1",
             "name": "Flame Burst",
             "text": "Flame Burst deals X damage to target creature or player, where X is 2 plus the number of Flame Burst cards in all graveyards.",
             "colours": [
@@ -6523,7 +6523,7 @@
         },
         {
             "id": "af2b1baf-34fb-53c0-a9c0-89e7a8688366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc939cc-826a-4208-ba5b-a11e1cd47aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc939cc-826a-4208-ba5b-a11e1cd47aa2.jpg?1",
             "name": "Frenetic Ogre",
             "text": "o\nR, Discard a card at random from your hand: Frenetic Ogre gets +3/+0 until end of turn.",
             "colours": [
@@ -6557,7 +6557,7 @@
         },
         {
             "id": "2a630cd5-7f6e-5c4c-a26e-71e7708d496e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69dfc05-51ba-4798-ac00-1e9b8bbbf280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69dfc05-51ba-4798-ac00-1e9b8bbbf280.jpg?1",
             "name": "Halberdier",
             "text": "First strike",
             "colours": [
@@ -6592,7 +6592,7 @@
         },
         {
             "id": "8ded884f-5a1b-5d4a-9332-228514777263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b404c0-9ce1-4491-82fd-6dba7e6895cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b404c0-9ce1-4491-82fd-6dba7e6895cd.jpg?1",
             "name": "Impulsive Maneuvers",
             "text": "Whenever a creature attacks, flip a coin. If you win the flip, the next time that creature would deal combat damage this turn, it deals double that damage instead. If you lose the flip, the next time that creature would deal combat damage this turn, prevent that damage.",
             "colours": [
@@ -6624,7 +6624,7 @@
         },
         {
             "id": "f091278e-f518-50e3-a739-cf3cad23a04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee88c776-85f1-4beb-a814-f706f5c4f341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee88c776-85f1-4beb-a814-f706f5c4f341.jpg?1",
             "name": "Kamahl, Pit Fighter",
             "text": "Haste\noc\nT: Kamahl, Pit Fighter deals 3 damage to target creature or player.",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "6e3d1127-cf89-5b58-b576-a34e14992675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99e1ded-7440-40a6-846b-7450a9b7d2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99e1ded-7440-40a6-846b-7450a9b7d2a8.jpg?1",
             "name": "Kamahl's Desire",
             "text": "Enchanted creature has first strike.\nThreshold Enchanted creature gets +3/+0. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "14ffaaa5-7b92-57f3-9a89-1da8fbe62ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e53-2710-4c2a-a8e4-48f25375ebc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e53-2710-4c2a-a8e4-48f25375ebc7.jpg?1",
             "name": "Lava Blister",
             "text": "Destroy target nonbasic land unless its controller has Lava Blister deal 6 damage to him or her.",
             "colours": [
@@ -6727,7 +6727,7 @@
         },
         {
             "id": "c0d2e4d6-ae30-5a3a-9646-1058e0369e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b836d4c-38f3-4661-9dc7-0c9baaa595a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b836d4c-38f3-4661-9dc7-0c9baaa595a5.jpg?1",
             "name": "Liquid Fire",
             "text": "Liquid Fire deals 5 damage divided as you choose between target creature and that creature's controller.",
             "colours": [
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "b1c3bb94-6c09-534f-b688-c95a1eb2de13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be2da24-a0cd-4e90-bc29-4da649fa56bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be2da24-a0cd-4e90-bc29-4da649fa56bf.jpg?1",
             "name": "Mad Dog",
             "text": "At the end of your turn, if Mad Dog didn't attack or come under your control this turn, sacrifice it.",
             "colours": [
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "364ce09c-83fa-5c19-a54d-3b826a46a1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ed2b52-2862-423c-8ce3-6c8232d9d92c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ed2b52-2862-423c-8ce3-6c8232d9d92c.jpg?1",
             "name": "Magma Vein",
             "text": "o\nR, Sacrifice a land: Magma Vein deals 1 damage to each creature without flying.",
             "colours": [
@@ -6825,7 +6825,7 @@
         },
         {
             "id": "0b84d151-a550-5fec-a0bd-0e98c4c5177a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200fa50d-5a54-47eb-a123-29c4fb55ebee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200fa50d-5a54-47eb-a123-29c4fb55ebee.jpg?1",
             "name": "Magnivore",
             "text": "Haste\nMagnivore's power and toughness are each equal to the number of sorcery cards in all graveyards.",
             "colours": [
@@ -6859,7 +6859,7 @@
         },
         {
             "id": "66c421cf-6636-5685-a3a4-7c444791a450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497efda1-5013-45d2-b717-b0296218c42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497efda1-5013-45d2-b717-b0296218c42b.jpg?1",
             "name": "Mine Layer",
             "text": "o1o\nR, oc\nT: Put a mine counter on target land.\nWhenever a land with a mine counter on it becomes tapped, destroy it.\nWhen Mine Layer leaves play, remove all mine counters from all lands.",
             "colours": [
@@ -6893,7 +6893,7 @@
         },
         {
             "id": "a22fb48e-492f-5d97-b35a-a45af078c55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55725e38-d60a-41a2-93b0-2eefe6d2cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55725e38-d60a-41a2-93b0-2eefe6d2cc59.jpg?1",
             "name": "Minotaur Explorer",
             "text": "When Minotaur Explorer comes into play, sacrifice it unless you discard a card at random from your hand.",
             "colours": [
@@ -6928,7 +6928,7 @@
         },
         {
             "id": "a18ef66f-2fe8-50d1-af48-7a9187ca2072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2b326b-d177-4a03-a0a3-fe2c2d4af272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2b326b-d177-4a03-a0a3-fe2c2d4af272.jpg?1",
             "name": "Molten Influence",
             "text": "Counter target instant or sorcery spell unless its controller has Molten Influence deal 4 damage to him or her.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "b6dfae53-7f60-5ccb-8728-7ec75d7cede0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d31bc-7355-4dfc-ac4e-ababaa0dc529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d31bc-7355-4dfc-ac4e-ababaa0dc529.jpg?1",
             "name": "Mudhole",
             "text": "Target player removes all land cards in his or her graveyard from the game.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "f63823fc-166f-5607-8c31-e01101526336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407b02f-66b3-4cfa-a3c4-105f314fd037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407b02f-66b3-4cfa-a3c4-105f314fd037.jpg?1",
             "name": "Need for Speed",
             "text": "Sacrifice a land: Target creature gains haste until end of turn.",
             "colours": [
@@ -7024,7 +7024,7 @@
         },
         {
             "id": "6f7beea2-5e1a-5b20-be3d-8329fd084fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88468a76-1f64-4189-bbb8-7c333181d57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88468a76-1f64-4189-bbb8-7c333181d57c.jpg?1",
             "name": "Obstinate Familiar",
             "text": "If you would draw a card, you may skip that draw instead.",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "468247f2-12aa-56fb-9144-9a6127ab9120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16858395-c742-4657-88c2-5af20c92718d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16858395-c742-4657-88c2-5af20c92718d.jpg?1",
             "name": "Pardic Firecat",
             "text": "Haste\nIf Pardic Firecat is in a graveyard, Flame Burst's effect counts it as a Flame Burst.",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "4112ce7a-0f5a-5fa2-8022-e462b3a6fbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a734abe-7bfd-4153-be2d-1c289fb60996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a734abe-7bfd-4153-be2d-1c289fb60996.jpg?1",
             "name": "Pardic Miner",
             "text": "Sacrifice Pardic Miner: Target player can't play lands this turn.",
             "colours": [
@@ -7127,7 +7127,7 @@
         },
         {
             "id": "f3f99503-9970-5485-ac53-2561d2b06841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ac622c-db04-41bf-817e-4698843e6346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ac622c-db04-41bf-817e-4698843e6346.jpg?1",
             "name": "Pardic Swordsmith",
             "text": "o\nR, Discard a card at random from your hand: Pardic Swordsmith gets +2/+0 until end of turn.",
             "colours": [
@@ -7161,7 +7161,7 @@
         },
         {
             "id": "7cd3718e-aa6d-5b05-bfb0-5daa32a760c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785ccfe1-04f1-4d2e-9e30-2ae3efe7213a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785ccfe1-04f1-4d2e-9e30-2ae3efe7213a.jpg?1",
             "name": "Price of Glory",
             "text": "Whenever a player taps a land for mana during another player's turn, destroy that land.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "76942ada-7d7c-5f7d-aa3c-6cfe1e7396cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0938e686-345e-4411-b564-cf9324ec6b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0938e686-345e-4411-b564-cf9324ec6b9d.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback o2o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7225,7 +7225,7 @@
         },
         {
             "id": "97d7ef86-8e2d-521b-acef-5f51032eadcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431145f8-64e9-4e7d-998a-21fe55f49e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431145f8-64e9-4e7d-998a-21fe55f49e01.jpg?1",
             "name": "Recoup",
             "text": "Target sorcery card in your graveyard gains flashback until end of turn. Its flashback cost is equal to its mana cost. (Mana cost includes color.)\nFlashback o3o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "922b680c-bc26-534e-84ed-0d190255c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2fc246-2e95-456f-aa4e-97768c4f4bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2fc246-2e95-456f-aa4e-97768c4f4bb4.jpg?1",
             "name": "Rites of Initiation",
             "text": "Discard any number of cards at random from your hand. Creatures you control get +1/+0 until end of turn for each card discarded this way.",
             "colours": [
@@ -7289,7 +7289,7 @@
         },
         {
             "id": "48fcb400-0290-5532-9368-bce0aefcf790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e14dbe-4d33-405c-ab84-2fc6b1e000b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e14dbe-4d33-405c-ab84-2fc6b1e000b8.jpg?1",
             "name": "Savage Firecat",
             "text": "Trample\nSavage Firecat comes into play with seven +1/+1 counters on it.\nWhenever you tap a land for mana, remove a +1/+1 counter from Savage Firecat.",
             "colours": [
@@ -7324,7 +7324,7 @@
         },
         {
             "id": "ec623ebf-5716-56b4-839e-654949f55167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0672960b-4cb5-4ed6-ba3c-6b97290e0330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0672960b-4cb5-4ed6-ba3c-6b97290e0330.jpg?1",
             "name": "Scorching Missile",
             "text": "Scorching Missile deals 4 damage to target player.\nFlashback o9o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7356,7 +7356,7 @@
         },
         {
             "id": "dedee1af-77b4-5bb8-b74d-cc5b1daeef08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d03ec3-2279-4266-a3bd-4cebdcb04d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d03ec3-2279-4266-a3bd-4cebdcb04d70.jpg?1",
             "name": "Seize the Day",
             "text": "Untap target creature. After this phase, there is an additional combat phase followed by an additional main phase.\nFlashback o2o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "632a974f-991d-530a-9aae-893632f48dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e623a8-145e-4649-b2cc-d3bb8a93f0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e623a8-145e-4649-b2cc-d3bb8a93f0f3.jpg?1",
             "name": "Shower of Coals",
             "text": "Shower of Coals deals 2 damage to each of up to three target creatures and/or players.\nThreshold Shower of Coals deals 4 damage to each of those creatures and/or players instead. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "b2ee872c-eb4c-56f3-b212-463797ba7012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5902e-2ca1-43bb-b636-c860b3d0b3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5902e-2ca1-43bb-b636-c860b3d0b3f2.jpg?1",
             "name": "Spark Mage",
             "text": "Whenever Spark Mage deals combat damage to a player, you may have Spark Mage deal 1 damage to target creature that player controls.",
             "colours": [
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "47a4d337-2aa8-54f3-90ce-86909393c4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3936053-b2ed-49b8-ab69-fe47a972cfe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3936053-b2ed-49b8-ab69-fe47a972cfe4.jpg?1",
             "name": "Steam Vines",
             "text": "When enchanted land becomes tapped, destroy it and Steam Vines deals 1 damage to that land's controller. That player moves Steam Vines to a land of his or her choice.",
             "colours": [
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "cd6327ff-a1a7-5c21-a71d-7703431abb18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623cc141-0f75-4e67-b852-6c144d98e619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623cc141-0f75-4e67-b852-6c144d98e619.jpg?1",
             "name": "Thermal Blast",
             "text": "Thermal Blast deals 3 damage to target creature.\nThreshold Thermal Blast deals 5 damage to that creature instead. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "4a4fae1a-4cd6-5129-98fa-96b0e5758910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1dc36f-3fdd-42cf-9d3a-695f4bf60c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1dc36f-3fdd-42cf-9d3a-695f4bf60c68.jpg?1",
             "name": "Tremble",
             "text": "Each player sacrifices a land.",
             "colours": [
@@ -7553,7 +7553,7 @@
         },
         {
             "id": "2a8647c7-b5fa-5bb4-b9cf-fa42dbad137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97daab4b-d934-4a3f-a043-f7c9c1dd32bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97daab4b-d934-4a3f-a043-f7c9c1dd32bf.jpg?1",
             "name": "Volcanic Spray",
             "text": "Volcanic Spray deals 1 damage to each creature without flying and each player.\nFlashback o1o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "b0414922-1dd7-5884-9094-432be5515c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f663979-a778-4fb2-97c4-67ab82926f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f663979-a778-4fb2-97c4-67ab82926f13.jpg?1",
             "name": "Volley of Boulders",
             "text": "Volley of Boulders deals 6 damage divided as you choose among any number of target creatures and/or players.\nFlashback o\nRo\nRo\nRo\nRo\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7617,7 +7617,7 @@
         },
         {
             "id": "80c54a92-8a68-5520-bb74-13969e509224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d86db25-3ec1-42f3-8b02-2729d50dd201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d86db25-3ec1-42f3-8b02-2729d50dd201.jpg?1",
             "name": "Whipkeeper",
             "text": "oc\nT: Whipkeeper deals damage to target creature equal to the damage already dealt to it this turn.",
             "colours": [
@@ -7651,7 +7651,7 @@
         },
         {
             "id": "ca2428e9-eb3c-5b57-88e0-b1d80c0264bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3284b61a-bd95-4846-ad3f-903cd1158867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3284b61a-bd95-4846-ad3f-903cd1158867.jpg?1",
             "name": "Bearscape",
             "text": "o1o\nG, Remove two cards in your graveyard from the game: Put a 2/2 green Bear creature token into play.",
             "colours": [
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "99b8f924-4cdc-5b63-83f8-98d736187b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5ebe27-2083-400e-8943-b506be470e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5ebe27-2083-400e-8943-b506be470e3f.jpg?1",
             "name": "Beast Attack",
             "text": "Put a 4/4 green Beast creature token into play.\nFlashback o2o\nGo\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "55a8844a-e8d4-5e0e-be6c-109900735660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429a88cc-53db-4c5e-a061-f0f49a38c675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429a88cc-53db-4c5e-a061-f0f49a38c675.jpg?1",
             "name": "Call of the Herd",
             "text": "Put a 3/3 green Elephant creature token into play.\nFlashback o3o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7747,7 +7747,7 @@
         },
         {
             "id": "ba0ab9e6-f36c-5d35-aa1d-14b4dddb132c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8241680d-6453-44ac-ab0f-3e7ebdd31e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8241680d-6453-44ac-ab0f-3e7ebdd31e89.jpg?1",
             "name": "Cartographer",
             "text": "When Cartographer comes into play, you may return target land card from your graveyard to your hand.",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "571bbd3a-2e8b-5216-81b0-efa4dfd1a7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84273844-7fab-4ff7-afb3-c82153132daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84273844-7fab-4ff7-afb3-c82153132daf.jpg?1",
             "name": "Chatter of the Squirrel",
             "text": "Put a 1/1 green Squirrel creature token into play.\nFlashback o1o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "9869abbe-a26c-547e-a0d4-7a0786d98657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd0ea3-4134-4f7d-a0c8-01c49bacfcfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd0ea3-4134-4f7d-a0c8-01c49bacfcfc.jpg?1",
             "name": "Chlorophant",
             "text": "At the beginning of your upkeep, you may put a +1/+1 counter on Chlorophant.\nThreshold At the beginning of your upkeep, you may put another +1/+1 counter on Chlorophant. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "ce5ff27d-af4d-5369-a326-e29f297f962c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3a32a-bfd2-4c31-a349-3e62a84c20e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3a32a-bfd2-4c31-a349-3e62a84c20e1.jpg?1",
             "name": "Crashing Centaur",
             "text": "o\nG, Discard a card from your hand: Crashing Centaur gains trample until end of turn.\nThreshold Crashing Centaur gets +2/+2 and can't be the target of spells or abilities. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "a11ef53b-86bb-539b-afef-924979ebbc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148ce683-3911-4b77-9e07-3985766a3777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148ce683-3911-4b77-9e07-3985766a3777.jpg?1",
             "name": "Deep Reconnaissance",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.\nFlashback o4o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "31f3a2ce-b440-56ac-bbc0-aae315886026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb40e09-6855-46d5-9bc9-bc6b2b0d7653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb40e09-6855-46d5-9bc9-bc6b2b0d7653.jpg?1",
             "name": "Diligent Farmhand",
             "text": "o1o\nG, Sacrifice Diligent Farmhand: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.\nIf Diligent Farmhand is in a graveyard, Muscle Burst's effect counts it as a Muscle Burst.",
             "colours": [
@@ -7948,7 +7948,7 @@
         },
         {
             "id": "08fb7c3d-f9a1-56b9-811d-beb2093ab700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9923532-bc4f-44de-b963-d6914321c49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9923532-bc4f-44de-b963-d6914321c49a.jpg?1",
             "name": "Druid Lyrist",
             "text": "o\nG, oc\nT, Sacrifice Druid Lyrist: Destroy target enchantment.",
             "colours": [
@@ -7983,7 +7983,7 @@
         },
         {
             "id": "f31c402a-3197-56f2-af2c-a47e2b2697ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22318a5-80c8-4fa3-ad05-8d3035caf336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22318a5-80c8-4fa3-ad05-8d3035caf336.jpg?1",
             "name": "Druid's Call",
             "text": "Whenever enchanted creature is dealt damage, its controller puts that many 1/1 green Squirrel creature tokens into play.",
             "colours": [
@@ -8017,7 +8017,7 @@
         },
         {
             "id": "055ed5b2-e0b5-5427-bea5-e10a7c07351c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4abdf1c-a0a9-4e1d-b448-58742830f767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4abdf1c-a0a9-4e1d-b448-58742830f767.jpg?1",
             "name": "Elephant Ambush",
             "text": "Put a 3/3 green Elephant creature token into play.\nFlashback o6o\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "b799efe7-c454-5709-86e2-af4ade2f90cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435d9562-8f2b-43fe-ba21-8f5896378280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435d9562-8f2b-43fe-ba21-8f5896378280.jpg?1",
             "name": "Gorilla Titan",
             "text": "Trample\nGorilla Titan gets +4/+4 as long as there are no cards in your graveyard.",
             "colours": [
@@ -8083,7 +8083,7 @@
         },
         {
             "id": "289032ec-6347-5598-856b-841ea6e99a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977383a8-9a31-4aad-ace2-6ed4d0dd1cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977383a8-9a31-4aad-ace2-6ed4d0dd1cbe.jpg?1",
             "name": "Ground Seal",
             "text": "When Ground Seal comes into play, draw a card.\nCards in graveyards can't be the targets of spells or abilities.",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "2f8fc613-7a04-5779-ad94-242fec7364ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2134a564-b089-4049-bd9c-a3f10e072263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2134a564-b089-4049-bd9c-a3f10e072263.jpg?1",
             "name": "Holistic Wisdom",
             "text": "o2, Remove a card in your hand from the game: Return target card from your graveyard to your hand if it shares a type with the card removed this way. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -8147,7 +8147,7 @@
         },
         {
             "id": "f0a739c9-335c-55e5-897c-fd242a39696e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9917cf32-0236-4463-9b1d-e8193754ff97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9917cf32-0236-4463-9b1d-e8193754ff97.jpg?1",
             "name": "Howling Gale",
             "text": "Howling Gale deals 1 damage to each creature with flying and each player.\nFlashback o1o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "6bc84134-5c93-5100-baf8-cdb0108a65be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc441d3a-e917-4dd6-b5f9-f99075ec398f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc441d3a-e917-4dd6-b5f9-f99075ec398f.jpg?1",
             "name": "Ivy Elemental",
             "text": "Ivy Elemental comes into play with X +1/+1 counters on it.",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "a3e69a1f-82ec-5401-81cc-c53cc496534b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188562f-8219-4fb0-ac2c-5618cfb00bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188562f-8219-4fb0-ac2c-5618cfb00bca.jpg?1",
             "name": "Krosan Archer",
             "text": "Krosan Archer may block as though it had flying.\no\nG, Discard a card from your hand: Krosan Archer gets +0/+2 until end of turn.",
             "colours": [
@@ -8248,7 +8248,7 @@
         },
         {
             "id": "ca92b122-217d-5fcb-8519-7940dfbd68e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afd6911-32b5-410a-afb0-fd3d2996fe59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afd6911-32b5-410a-afb0-fd3d2996fe59.jpg?1",
             "name": "Krosan Avenger",
             "text": "Trample\nThreshold o1o\nG: Regenerate Krosan Avenger. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "c6d72557-d06a-52b9-acee-3710eea67d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af822507-fd4c-454b-ab07-106c81c535bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af822507-fd4c-454b-ab07-106c81c535bf.jpg?1",
             "name": "Krosan Beast",
             "text": "Threshold Krosan Beast gets +7/+7. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8318,7 +8318,7 @@
         },
         {
             "id": "ea88b5fe-af45-5445-99ab-d24be839fe7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebab65c-7d5f-4086-8eb1-7dc445e801e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebab65c-7d5f-4086-8eb1-7dc445e801e9.jpg?1",
             "name": "Leaf Dancer",
             "text": "Forestwalk",
             "colours": [
@@ -8352,7 +8352,7 @@
         },
         {
             "id": "d74c5ae7-38f0-5218-8c58-3f8a831dedc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e020a-ed73-465a-b7eb-a4eeccd096cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e020a-ed73-465a-b7eb-a4eeccd096cc.jpg?1",
             "name": "Metamorphic Wurm",
             "text": "Threshold Metamorphic Wurm gets +4/+4. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "c94cb550-35ec-5021-a341-cd6e4379cae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ebe935-ccf9-435e-8fe8-53bcbf3526e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ebe935-ccf9-435e-8fe8-53bcbf3526e7.jpg?1",
             "name": "Moment's Peace",
             "text": "Prevent all combat damage that would be dealt this turn.\nFlashback o2o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "2a3e4267-9bc9-5f55-a7a7-18fe68e09581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dada5-7ffc-488b-8062-34c034906ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dada5-7ffc-488b-8062-34c034906ea9.jpg?1",
             "name": "Muscle Burst",
             "text": "Target creature gets +X/+X until end of turn, where X is 3 plus the number of Muscle Burst cards in all graveyards.",
             "colours": [
@@ -8451,7 +8451,7 @@
         },
         {
             "id": "5d1edc02-e92d-57d1-a700-9ff2277424ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5db5e0-bd95-4c82-a12d-7288dbbbe3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5db5e0-bd95-4c82-a12d-7288dbbbe3ba.jpg?1",
             "name": "Nantuko Disciple",
             "text": "o\nG, oc\nT: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "88decf22-3cd0-52d4-acf3-92628b48e56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0a4e6e-cc4e-43d5-aece-f009e117366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0a4e6e-cc4e-43d5-aece-f009e117366a.jpg?1",
             "name": "Nantuko Elder",
             "text": "oc\nT: Add o1o\nG to your mana pool.",
             "colours": [
@@ -8521,7 +8521,7 @@
         },
         {
             "id": "4245e4e3-60d4-574a-a8ac-6b0633ead32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb5283-d384-490e-a0a5-2d10c1acc8cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb5283-d384-490e-a0a5-2d10c1acc8cc.jpg?1",
             "name": "Nantuko Mentor",
             "text": "o2o\nG, oc\nT: Target creature gets +X/+X until end of turn, where X is that creature's power.",
             "colours": [
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "76c0da19-d841-5821-9ff7-367188241f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66bab3-ee6f-4f74-bbc1-8099c9c4904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66bab3-ee6f-4f74-bbc1-8099c9c4904b.jpg?1",
             "name": "Nantuko Shrine",
             "text": "Whenever a player plays a spell, that player puts X 1/1 green Squirrel creature tokens into play, where X is the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "562c33ed-7b3a-579e-b57b-405ed85fbe1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1f6cfa-9576-4bb8-83db-33c2b147206d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1f6cfa-9576-4bb8-83db-33c2b147206d.jpg?1",
             "name": "New Frontiers",
             "text": "Each player may search his or her library for up to X basic land cards and put them into play tapped. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -8620,7 +8620,7 @@
         },
         {
             "id": "90540949-3c8f-5853-b0c2-279bf9f3227a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e5ecf5-a662-4df0-a6ba-9177c62b6503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e5ecf5-a662-4df0-a6ba-9177c62b6503.jpg?1",
             "name": "Nimble Mongoose",
             "text": "Nimble Mongoose can't be the target of spells or abilities.\nThreshold Nimble Mongoose gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "1055e72a-a1b9-5ec9-bd8c-74c89671c135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4eec210-5df0-4fb8-8eb1-e616d9995acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4eec210-5df0-4fb8-8eb1-e616d9995acc.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may put a 1/1 green Squirrel creature token into play.\nThreshold All Squirrels get +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8689,7 +8689,7 @@
         },
         {
             "id": "0c523e70-5067-57a1-969b-8d505cbd6fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9df13-3bd8-415d-b949-9b39f97fdde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9df13-3bd8-415d-b949-9b39f97fdde7.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "65819b0e-b90b-5b4e-86a4-3d35b9c8d65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642ea1f9-49f0-4e0d-8122-c3a305c149e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642ea1f9-49f0-4e0d-8122-c3a305c149e9.jpg?1",
             "name": "Piper's Melody",
             "text": "Shuffle any number of target creature cards from your graveyard into your library.",
             "colours": [
@@ -8753,7 +8753,7 @@
         },
         {
             "id": "6533632e-c475-5c09-a871-e516752d4b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2d822-09d0-42e5-ad91-67c66e947b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2d822-09d0-42e5-ad91-67c66e947b3d.jpg?1",
             "name": "Primal Frenzy",
             "text": "Enchanted creature has trample.",
             "colours": [
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "07c366c8-dfa1-58f0-b631-fb6c90ef9bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe394a38-ee44-4342-adcf-8c65d14f4978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe394a38-ee44-4342-adcf-8c65d14f4978.jpg?1",
             "name": "Rabid Elephant",
             "text": "Whenever Rabid Elephant becomes blocked, it gets +2/+2 until end of turn for each creature blocking it.",
             "colours": [
@@ -8821,7 +8821,7 @@
         },
         {
             "id": "247f60e4-a060-5ebf-945b-a5c0330a3003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0084ba4e-98eb-4eb4-b23e-c5ab4d7d95cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0084ba4e-98eb-4eb4-b23e-c5ab4d7d95cb.jpg?1",
             "name": "Refresh",
             "text": "Regenerate target creature.\nDraw a card.",
             "colours": [
@@ -8853,7 +8853,7 @@
         },
         {
             "id": "c888da26-7b07-5bd8-9b16-7a8dcb1b1414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bddb0ef-fdda-491b-a0cf-48cbdd761918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bddb0ef-fdda-491b-a0cf-48cbdd761918.jpg?1",
             "name": "Rites of Spring",
             "text": "Discard any number of cards from your hand. Search your library for that many basic land cards, reveal those cards, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -8885,7 +8885,7 @@
         },
         {
             "id": "8b5b5f0a-1dd9-5103-b8d8-63fc9f05d5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf54317-4c08-4a66-9fd2-9983384e2374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf54317-4c08-4a66-9fd2-9983384e2374.jpg?1",
             "name": "Roar of the Wurm",
             "text": "Put a 6/6 green Wurm creature token into play.\nFlashback o3o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8917,7 +8917,7 @@
         },
         {
             "id": "7ba5bac3-2929-5e7a-8535-6539646d3f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641a3bae-9146-4e70-862a-86a56f7c3816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641a3bae-9146-4e70-862a-86a56f7c3816.jpg?1",
             "name": "Seton, Krosan Protector",
             "text": "Tap an untapped Druid you control: Add o\nG to your mana pool.",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "5691768a-929e-54ba-95e7-aea047f45ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d05b6a-5c7e-4e08-88d3-98f2b5b054bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d05b6a-5c7e-4e08-88d3-98f2b5b054bc.jpg?1",
             "name": "Seton's Desire",
             "text": "Enchanted creature gets +2/+2.\nThreshold All creatures able to block enchanted creature do so. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "6673e904-b3b1-5618-8ac7-74181d34e1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a43fd3e-1e08-400c-b22b-e22da82bcdee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a43fd3e-1e08-400c-b22b-e22da82bcdee.jpg?1",
             "name": "Simplify",
             "text": "Each player sacrifices an enchantment.",
             "colours": [
@@ -9020,7 +9020,7 @@
         },
         {
             "id": "50188273-d9e7-55aa-a1a0-8bbe27ed878f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56f195e-a80c-4447-8d3f-cc1259035d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56f195e-a80c-4447-8d3f-cc1259035d1b.jpg?1",
             "name": "Skyshooter",
             "text": "Skyshooter may block as though it had flying.\noc\nT, Sacrifice Skyshooter: Destroy target attacking or blocking creature with flying.",
             "colours": [
@@ -9055,7 +9055,7 @@
         },
         {
             "id": "b038c139-e60f-5e4c-99fd-ce0c579ad5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72194a6e-481d-4b07-922b-53f919bfa316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72194a6e-481d-4b07-922b-53f919bfa316.jpg?1",
             "name": "Spellbane Centaur",
             "text": "Creatures you control can't be the targets of blue spells or abilities from blue sources.",
             "colours": [
@@ -9089,7 +9089,7 @@
         },
         {
             "id": "012f4333-6134-54b0-b761-abecb4ec0842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04462629-fb03-40e8-84e6-4a66e4d5392b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04462629-fb03-40e8-84e6-4a66e4d5392b.jpg?1",
             "name": "Springing Tiger",
             "text": "Threshold Springing Tiger gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9123,7 +9123,7 @@
         },
         {
             "id": "f0179755-517a-5efc-9542-d1ac320f953b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181254ce-259a-4b31-8937-728564f2baf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181254ce-259a-4b31-8937-728564f2baf3.jpg?1",
             "name": "Squirrel Mob",
             "text": "Squirrel Mob gets +1/+1 for each other Squirrel in play.",
             "colours": [
@@ -9157,7 +9157,7 @@
         },
         {
             "id": "e20fbce9-da38-50cf-8bbb-0e36188bb723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eccb27-1723-4c5a-96b8-85e6e5739c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eccb27-1723-4c5a-96b8-85e6e5739c30.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchanted land has \"oc\nT: Put a 1/1 green Squirrel creature token into play.\"",
             "colours": [
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "76d989f7-0487-5304-8195-23b670002ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12be33d7-f25e-4dbf-9706-74403103b127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12be33d7-f25e-4dbf-9706-74403103b127.jpg?1",
             "name": "Still Life",
             "text": "o\nGo\nG: Still Life becomes a 4/3 Centaur creature until end of turn. It's still an enchantment.",
             "colours": [
@@ -9223,7 +9223,7 @@
         },
         {
             "id": "2a382909-9789-586d-9495-160f78d66e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d5157-154c-4300-82d4-0e23d934d436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d5157-154c-4300-82d4-0e23d934d436.jpg?1",
             "name": "Stone-Tongue Basilisk",
             "text": "Whenever Stone-Tongue Basilisk deals combat damage to a creature, destroy that creature at end of combat.\nThreshold All creatures able to block Stone-Tongue Basilisk do so. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9257,7 +9257,7 @@
         },
         {
             "id": "38a45bcb-ee74-5edd-8739-0ff510eeb510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e3ccd-40a3-4ea9-8e76-5e70b2ef9123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e3ccd-40a3-4ea9-8e76-5e70b2ef9123.jpg?1",
             "name": "Sylvan Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nFlashback o2o\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "9f3291a5-8115-5144-b662-41e4e4199441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39c412b-2f21-483a-b744-5d55bc007c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39c412b-2f21-483a-b744-5d55bc007c0d.jpg?1",
             "name": "Terravore",
             "text": "Trample\nTerravore's power and toughness are each equal to the number of land cards in all graveyards.",
             "colours": [
@@ -9323,7 +9323,7 @@
         },
         {
             "id": "535195f7-02cc-5f36-9ab6-6106845f0636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b8ba27-c3bb-48cf-b831-518f5d255c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b8ba27-c3bb-48cf-b831-518f5d255c2e.jpg?1",
             "name": "Twigwalker",
             "text": "o1o\nG, Sacrifice Twigwalker: Two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "5e4cb7d2-e4cf-527b-8fa4-17c7f1f685b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3c78de-0c2a-441e-8912-ff920fc563ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3c78de-0c2a-441e-8912-ff920fc563ef.jpg?1",
             "name": "Verdant Succession",
             "text": "Whenever a green nontoken creature is put into a graveyard from play, that creature's controller may search his or her library for a card with the same name as that creature and put it into play. If that player does, he or she then shuffles his or her library.",
             "colours": [
@@ -9389,7 +9389,7 @@
         },
         {
             "id": "54ec622d-07a2-5d97-ab08-61b86f7d60d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b5e7ed-a0ab-48f6-8f69-56a8bd115007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b5e7ed-a0ab-48f6-8f69-56a8bd115007.jpg?1",
             "name": "Vivify",
             "text": "Target land becomes a 3/3 creature until end of turn. It's still a land.\nDraw a card.",
             "colours": [
@@ -9421,7 +9421,7 @@
         },
         {
             "id": "533fea94-9804-5445-8500-ee62e1e06111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964cf7e3-932d-432f-8ad4-9bd651aada96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964cf7e3-932d-432f-8ad4-9bd651aada96.jpg?1",
             "name": "Werebear",
             "text": "oc\nT: Add o\nG to your mana pool.\nThreshold Werebear gets +3/+3. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "5fbb4293-b8a9-54eb-a168-74f4f5b47c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb8dd5c-a79a-4afc-80b2-64645bb17a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb8dd5c-a79a-4afc-80b2-64645bb17a34.jpg?1",
             "name": "Wild Mongrel",
             "text": "Discard a card from your hand: Wild Mongrel gets +1/+1 and becomes the color of your choice until end of turn.",
             "colours": [
@@ -9491,7 +9491,7 @@
         },
         {
             "id": "cfb43ded-c561-52cd-a332-96bed8b4fdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e501e6-38da-44ad-abe2-53ea7f0eb4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e501e6-38da-44ad-abe2-53ea7f0eb4ae.jpg?1",
             "name": "Woodland Druid",
             "text": "",
             "colours": [
@@ -9526,7 +9526,7 @@
         },
         {
             "id": "4ff061a2-43d7-5e52-bf38-1f7ef2a1286f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be645675-d263-42c4-9e71-f98cf4c2aab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be645675-d263-42c4-9e71-f98cf4c2aab5.jpg?1",
             "name": "Zoologist",
             "text": "o3o\nG, oc\nT: Reveal the top card of your library. If it's a creature card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -9561,7 +9561,7 @@
         },
         {
             "id": "7173fffd-c862-527a-83c3-85a104902b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3e6eb5-6d0f-4f82-86f9-bbce8d27afbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3e6eb5-6d0f-4f82-86f9-bbce8d27afbb.jpg?1",
             "name": "Atogatog",
             "text": "Sacrifice an Atog: Atogatog gets +X/+X until end of turn, where X is the sacrificed Atog's power.",
             "colours": [
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "c7c09497-42b5-52fe-b633-a244feff325c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912c398a-e49a-4399-ac41-7b1d4328a59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912c398a-e49a-4399-ac41-7b1d4328a59d.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "dc22c77e-935d-542b-8bbe-7af8662c13b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bce4f8-3a3f-4ec2-9b37-10bb12713afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bce4f8-3a3f-4ec2-9b37-10bb12713afc.jpg?1",
             "name": "Iridescent Angel",
             "text": "Flying, protection from all colors",
             "colours": [
@@ -9675,7 +9675,7 @@
         },
         {
             "id": "4ec7b667-62dd-5c0f-a312-4e24b4d5afe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69742a8-cc6d-457b-8d99-81d05ab1bf0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69742a8-cc6d-457b-8d99-81d05ab1bf0b.jpg?1",
             "name": "Lithatog",
             "text": "Sacrifice an artifact: Lithatog gets +1/+1 until end of turn.\nSacrifice a land: Lithatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9711,7 +9711,7 @@
         },
         {
             "id": "98f746f8-3be5-52b0-be7d-7afa9fdbfc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb68983d-fd8c-4844-8ceb-afd3cae7e4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb68983d-fd8c-4844-8ceb-afd3cae7e4df.jpg?1",
             "name": "Mystic Enforcer",
             "text": "Protection from black\nThreshold Mystic Enforcer gets +3/+3 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9749,7 +9749,7 @@
         },
         {
             "id": "24b7f7ee-c7dc-50e6-b07a-632b44da11b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967608d-141d-426f-a129-6f1a6a58273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967608d-141d-426f-a129-6f1a6a58273c.jpg?1",
             "name": "Phantatog",
             "text": "Sacrifice an enchantment: Phantatog gets +1/+1 until end of turn.\nDiscard a card from your hand: Phantatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9785,7 +9785,7 @@
         },
         {
             "id": "5e4d0c59-adee-546b-abed-6a3e42787daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6757bf0e-489f-4be2-9e41-463b59f00dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6757bf0e-489f-4be2-9e41-463b59f00dd1.jpg?1",
             "name": "Psychatog",
             "text": "Discard a card from your hand: Psychatog gets +1/+1 until end of turn.\nRemove two cards in your graveyard from the game: Psychatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "9c9c00da-1f14-56bf-b45b-a88f7d17821d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a329c-e815-49d3-8df1-d052ce19b0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a329c-e815-49d3-8df1-d052ce19b0c6.jpg?1",
             "name": "Sarcatog",
             "text": "Remove two cards in your graveyard from the game: Sarcatog gets +1/+1 until end of turn.\nSacrifice an artifact: Sarcatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9857,7 +9857,7 @@
         },
         {
             "id": "0b25ba97-22ab-59e8-b357-6df465ff634a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932ce702-565f-4d8c-b9fc-2d7c939ef7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932ce702-565f-4d8c-b9fc-2d7c939ef7d7.jpg?1",
             "name": "Shadowmage Infiltrator",
             "text": "Shadowmage Infiltrator can't be blocked except by artifact creatures and/or black creatures.\nWhenever Shadowmage Infiltrator deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -9894,7 +9894,7 @@
         },
         {
             "id": "971e0be0-faf7-5111-b019-4bddd95bc7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa559342-9587-4fe3-9059-3b3a08d6637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa559342-9587-4fe3-9059-3b3a08d6637a.jpg?1",
             "name": "Thaumatog",
             "text": "Sacrifice a land: Thaumatog gets +1/+1 until end of turn.\nSacrifice an enchantment: Thaumatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9930,7 +9930,7 @@
         },
         {
             "id": "7aa2061f-669e-5a7d-b482-4159ef910c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f21d595-c248-4aae-9fd7-4e5787ab8781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f21d595-c248-4aae-9fd7-4e5787ab8781.jpg?1",
             "name": "Vampiric Dragon",
             "text": "Flying\nWhenever a creature dealt damage by Vampiric Dragon this turn is put into a graveyard, put a +1/+1 counter on Vampiric Dragon.\no1o\nR: Vampiric Dragon deals 1 damage to target creature.",
             "colours": [
@@ -9967,7 +9967,7 @@
         },
         {
             "id": "01517c3a-ddc8-561a-9439-6ea0fdd17c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca85d4-b4c2-4adc-a0f9-26339bacfd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca85d4-b4c2-4adc-a0f9-26339bacfd92.jpg?1",
             "name": "Catalyst Stone",
             "text": "Flashback costs you pay cost up to o2 less.\nFlashback costs your opponents pay cost o2 more.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "c67ec222-5601-51b2-a709-a586118fa827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701942dd-7777-436f-8076-194584be8285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701942dd-7777-436f-8076-194584be8285.jpg?1",
             "name": "Charmed Pendant",
             "text": "oc\nT, Put the top card of your library into your graveyard: For each colored mana symbol in that card's mana cost, add one mana of that color to your mana pool. Play this ability only any time you could play an instant. (For example, if the card's mana cost is o3o\nUo\nUo\nB, you add o\nUo\nUo\nB to your mana pool.)",
             "colours": [],
@@ -10023,7 +10023,7 @@
         },
         {
             "id": "098ea01f-87b0-529c-8e95-36f90872175f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb988572-1e1d-4b1d-8dc7-78bda966554e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb988572-1e1d-4b1d-8dc7-78bda966554e.jpg?1",
             "name": "Darkwater Egg",
             "text": "o2, oc\nT, Sacrifice Darkwater Egg: Add o\nUo\nB to your mana pool. Draw a card.",
             "colours": [],
@@ -10054,7 +10054,7 @@
         },
         {
             "id": "da2eb80f-db47-5a52-8fba-8da6ea2732b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9410da0-5693-456f-afa8-cb92ac176847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9410da0-5693-456f-afa8-cb92ac176847.jpg?1",
             "name": "Junk Golem",
             "text": "Junk Golem comes into play with three +1/+1 counters on it.\nAt the beginning of your upkeep, sacrifice Junk Golem unless you remove a +1/+1 counter from it.\no1, Discard a card from your hand: Put a +1/+1 counter on Junk Golem.",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "612d05ca-d77c-56f7-87df-3a6df23d6d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522518c-1846-4e95-b77d-2aadac78684d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522518c-1846-4e95-b77d-2aadac78684d.jpg?1",
             "name": "Limestone Golem",
             "text": "o2, Sacrifice Limestone Golem: Target player draws a card.",
             "colours": [],
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "e7e2408d-6d8a-59d3-808c-0ce1e16c6b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550133b-22cf-4ecd-b89a-8c2f0beeaa22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550133b-22cf-4ecd-b89a-8c2f0beeaa22.jpg?1",
             "name": "Millikin",
             "text": "oc\nT, Put the top card of your library into your graveyard: Add one colorless mana to your mana pool.",
             "colours": [],
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "ea9c0761-fe9b-5336-a584-efeff32e14c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbaad4f-fb66-4e56-b383-32f55552c8b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbaad4f-fb66-4e56-b383-32f55552c8b2.jpg?1",
             "name": "Mirari",
             "text": "Whenever you play an instant or sorcery spell, you may pay o3. If you do, put a copy of that spell onto the stack. You may choose new targets for that copy.",
             "colours": [],
@@ -10177,7 +10177,7 @@
         },
         {
             "id": "33f05ce8-a101-59d5-b441-c7bdba441e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd66433-b0e9-453d-9a27-ea0efb158dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd66433-b0e9-453d-9a27-ea0efb158dac.jpg?1",
             "name": "Mossfire Egg",
             "text": "o2, oc\nT, Sacrifice Mossfire Egg: Add o\nRo\nG to your mana pool. Draw a card.",
             "colours": [],
@@ -10208,7 +10208,7 @@
         },
         {
             "id": "4c06e03a-9302-587d-9534-cc73a023bd10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752420dc-d69a-4c9d-b563-f8928a4a0920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752420dc-d69a-4c9d-b563-f8928a4a0920.jpg?1",
             "name": "Otarian Juggernaut",
             "text": "Otarian Juggernaut can't be blocked by Walls.\nThreshold Otarian Juggernaut gets +3/+0 and attacks each turn if able. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10239,7 +10239,7 @@
         },
         {
             "id": "c8ed8e0a-7a27-571e-9eb6-86220b5abd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8958d5-e4a9-42ee-ae82-d184c4b92c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8958d5-e4a9-42ee-ae82-d184c4b92c9d.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Discard a card from your hand: Regenerate Patchwork Gnomes.",
             "colours": [],
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "4626ef6a-bf7d-5604-9384-1f69648c21a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ebc17-b8ae-4ca4-8413-f53501d86244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ebc17-b8ae-4ca4-8413-f53501d86244.jpg?1",
             "name": "Sandstone Deadfall",
             "text": "oc\nT, Sacrifice two lands and Sandstone Deadfall: Destroy target attacking creature.",
             "colours": [],
@@ -10298,7 +10298,7 @@
         },
         {
             "id": "38e803f9-b925-5125-92b1-719ced16760c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044bbf15-e71d-4f47-bac3-bba8021118bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044bbf15-e71d-4f47-bac3-bba8021118bd.jpg?1",
             "name": "Shadowblood Egg",
             "text": "o2, oc\nT, Sacrifice Shadowblood Egg: Add o\nBo\nR to your mana pool. Draw a card.",
             "colours": [],
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "aedf172b-273d-5342-b09d-000aaff0625e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e588cc41-4b86-4e93-94e8-dd765b27ab63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e588cc41-4b86-4e93-94e8-dd765b27ab63.jpg?1",
             "name": "Skycloud Egg",
             "text": "o2, oc\nT, Sacrifice Skycloud Egg: Add o\nWo\nU to your mana pool. Draw a card.",
             "colours": [],
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "dfbd6a51-7ce1-5cf6-8c0e-db58726422ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f84a9bf-ce64-4301-8f2c-20f1b4acd3ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f84a9bf-ce64-4301-8f2c-20f1b4acd3ef.jpg?1",
             "name": "Steamclaw",
             "text": "o3, oc\nT: Remove target card in a graveyard from the game.\no1, Sacrifice Steamclaw: Remove target card in a graveyard from the game.",
             "colours": [],
@@ -10388,7 +10388,7 @@
         },
         {
             "id": "18d6f03c-6510-59ae-b9c8-f2b97c89bffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e888f9-c583-478a-9ef0-2e89db8a8dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e888f9-c583-478a-9ef0-2e89db8a8dbb.jpg?1",
             "name": "Sungrass Egg",
             "text": "o2, oc\nT, Sacrifice Sungrass Egg: Add o\nGo\nW to your mana pool. Draw a card.",
             "colours": [],
@@ -10419,7 +10419,7 @@
         },
         {
             "id": "e30b3771-fba9-5093-a088-b9b849bf47a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4945031e-1158-474c-9e50-1ec817acc767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4945031e-1158-474c-9e50-1ec817acc767.jpg?1",
             "name": "Abandoned Outpost",
             "text": "Abandoned Outpost comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Abandoned Outpost: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10449,7 +10449,7 @@
         },
         {
             "id": "554f90f6-71f7-53df-87fc-6133cbaece7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1809361e-ae1a-4c47-8464-e6496e94d962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1809361e-ae1a-4c47-8464-e6496e94d962.jpg?1",
             "name": "Barbarian Ring",
             "text": "oc\nT: Add o\nR to your mana pool. Barbarian Ring deals 1 damage to you.\nThreshold o\nR, oc\nT, Sacrifice Barbarian Ring: Barbarian Ring deals 2 damage to target creature or player. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10479,7 +10479,7 @@
         },
         {
             "id": "46a96f08-ddb3-5e4f-8d56-ab7e0c324019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189b4925-b34b-43bd-869e-1b1db99450e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189b4925-b34b-43bd-869e-1b1db99450e6.jpg?1",
             "name": "Bog Wreckage",
             "text": "Bog Wreckage comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Bog Wreckage: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10509,7 +10509,7 @@
         },
         {
             "id": "fe6ef7f8-875a-5486-9775-eba61fa75fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848d686a-e2f7-488d-947f-a555099b74b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848d686a-e2f7-488d-947f-a555099b74b1.jpg?1",
             "name": "Cabal Pit",
             "text": "oc\nT: Add o\nB to your mana pool. Cabal Pit deals 1 damage to you.\nThreshold o\nB, oc\nT, Sacrifice Cabal Pit: Target creature gets -2/-2 until end of turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "21dc7e05-5365-58f3-8cdd-6071e9dd2aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca041d5e-c65f-4e7e-ae4f-9c748a069aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca041d5e-c65f-4e7e-ae4f-9c748a069aa3.jpg?1",
             "name": "Centaur Garden",
             "text": "oc\nT: Add o\nG to your mana pool. Centaur Garden deals 1 damage to you.\nThreshold o\nG, oc\nT, Sacrifice Centaur Garden: Target creature gets +3/+3 until end of turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10569,7 +10569,7 @@
         },
         {
             "id": "99f58f00-acb6-5778-bf39-8837d5ea5c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d74112-7244-4c3f-a5eb-b6be671aefe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d74112-7244-4c3f-a5eb-b6be671aefe8.jpg?1",
             "name": "Cephalid Coliseum",
             "text": "oc\nT: Add o\nU to your mana pool. Cephalid Coliseum deals 1 damage to you.\nThreshold o\nU, oc\nT, Sacrifice Cephalid Coliseum: Target player draws three cards, then discards three cards from his or her hand. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10599,7 +10599,7 @@
         },
         {
             "id": "094f7ca6-af94-5d2d-9953-50abe8970a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1012124a-5401-4bd1-a163-4633d934938f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1012124a-5401-4bd1-a163-4633d934938f.jpg?1",
             "name": "Crystal Quarry",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no5, oc\nT: Add o\nWo\nUo\nBo\nRo\nG to your mana pool.",
             "colours": [],
@@ -10633,7 +10633,7 @@
         },
         {
             "id": "0e6ea663-0840-5553-84de-d94c70c451d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2583b941-6156-4c4b-a068-0d0ac75a3dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2583b941-6156-4c4b-a068-0d0ac75a3dd3.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "o1, oc\nT: Add o\nUo\nB to your mana pool.",
             "colours": [],
@@ -10664,7 +10664,7 @@
         },
         {
             "id": "16fd0db1-c8f0-5208-a489-d84a96215c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fa74b2-f9bd-4617-8b65-878781f3a2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fa74b2-f9bd-4617-8b65-878781f3a2fd.jpg?1",
             "name": "Deserted Temple",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Untap target land.",
             "colours": [],
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "4abf77f3-009c-5f7a-8047-83d43e8e4670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6c08ce-d01d-4ae6-81d3-149679e27e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6c08ce-d01d-4ae6-81d3-149679e27e6a.jpg?1",
             "name": "Mossfire Valley",
             "text": "o1, oc\nT: Add o\nRo\nG to your mana pool.",
             "colours": [],
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "333d5d2a-6631-506d-9a5c-72792f4b81ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64300b71-050f-47a3-83be-f24480bdc01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64300b71-050f-47a3-83be-f24480bdc01d.jpg?1",
             "name": "Nomad Stadium",
             "text": "oc\nT: Add o\nW to your mana pool. Nomad Stadium deals 1 damage to you.\nThreshold o\nW, oc\nT, Sacrifice Nomad Stadium: You gain 4 life. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10753,7 +10753,7 @@
         },
         {
             "id": "058a5384-b67f-5016-8a2c-c32925f1e9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeaf9f2-d196-4607-a704-06f2315d8cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeaf9f2-d196-4607-a704-06f2315d8cc5.jpg?1",
             "name": "Petrified Field",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Petrified Field: Return target land card from your graveyard to your hand.",
             "colours": [],
@@ -10781,7 +10781,7 @@
         },
         {
             "id": "f36b7d82-5534-5c27-83fd-5906cc42999c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb60ffc9-4919-40f2-bdd6-07eee6abf37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb60ffc9-4919-40f2-bdd6-07eee6abf37c.jpg?1",
             "name": "Ravaged Highlands",
             "text": "Ravaged Highlands comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Ravaged Highlands: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10811,7 +10811,7 @@
         },
         {
             "id": "eb4d8ed3-5240-525d-a393-46a83fb16a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e492399-d514-485a-8cdd-a3797a05e47a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e492399-d514-485a-8cdd-a3797a05e47a.jpg?1",
             "name": "Seafloor Debris",
             "text": "Seafloor Debris comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Seafloor Debris: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10843,7 +10843,7 @@
         },
         {
             "id": "adfc7385-b0ae-501f-84ed-467aef5e9cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb5977c-5009-4d97-82c8-c150a0d41bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb5977c-5009-4d97-82c8-c150a0d41bc3.jpg?1",
             "name": "Seafloor Debris",
             "text": "",
             "colours": [],
@@ -10874,7 +10874,7 @@
         },
         {
             "id": "56e30965-7a9d-50e9-ad4e-1ee9ef840166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a5f84a-9e9b-42b6-a973-864409d6e564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a5f84a-9e9b-42b6-a973-864409d6e564.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "o1, oc\nT: Add o\nBo\nR to your mana pool.",
             "colours": [],
@@ -10905,7 +10905,7 @@
         },
         {
             "id": "64291673-fd96-5f3b-8af7-c177ac9acb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c0da61-59c5-4206-83d9-c4676e169f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c0da61-59c5-4206-83d9-c4676e169f01.jpg?1",
             "name": "Skycloud Expanse",
             "text": "o1, oc\nT: Add o\nWo\nU to your mana pool.",
             "colours": [],
@@ -10936,7 +10936,7 @@
         },
         {
             "id": "681f7234-2403-5019-9b68-e7449cb25018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfa27ee-553e-4c6e-a79c-9757bd74c057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfa27ee-553e-4c6e-a79c-9757bd74c057.jpg?1",
             "name": "Sungrass Prairie",
             "text": "o1, oc\nT: Add o\nGo\nW to your mana pool.",
             "colours": [],
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "123d82bb-28a4-5a13-a029-441b38ce4797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30375d24-ccfe-47a2-babd-1bda0a6298fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30375d24-ccfe-47a2-babd-1bda0a6298fe.jpg?1",
             "name": "Tarnished Citadel",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add one mana of any color to your mana pool. Tarnished Citadel deals 3 damage to you.",
             "colours": [],
@@ -10995,7 +10995,7 @@
         },
         {
             "id": "3370b874-17ed-5cec-be38-2f34ece17152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e8770-c72b-439c-8f79-3aa24646cdd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e8770-c72b-439c-8f79-3aa24646cdd5.jpg?1",
             "name": "Timberland Ruins",
             "text": "Timberland Ruins comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Timberland Ruins: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -11025,7 +11025,7 @@
         },
         {
             "id": "fd317690-4a6c-5f37-97c5-fb09f179c633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecfb420-ace3-4627-a2e0-62a701d025c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecfb420-ace3-4627-a2e0-62a701d025c9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11063,7 +11063,7 @@
         },
         {
             "id": "6a8967bf-84be-5b14-ad31-6a5dc0efb375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014efd6a-5b0c-41d1-b7de-78eab5b62917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014efd6a-5b0c-41d1-b7de-78eab5b62917.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11101,7 +11101,7 @@
         },
         {
             "id": "65b210e3-b8b7-54a4-b7cd-715641e42d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b0dd0f-8ad8-4292-9df6-7b28ab4605e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b0dd0f-8ad8-4292-9df6-7b28ab4605e3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11139,7 +11139,7 @@
         },
         {
             "id": "aa8730c2-7377-5ed3-9853-05fd4c96cbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee52bef-0586-46b8-a405-f4e0741f0059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee52bef-0586-46b8-a405-f4e0741f0059.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "d1558fc2-b254-5cbb-a408-7dd5c97acf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527f36a0-80b8-4492-b1c3-20a34953ceb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527f36a0-80b8-4492-b1c3-20a34953ceb7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11215,7 +11215,7 @@
         },
         {
             "id": "fe2f4ad4-65b3-5084-8f53-162d88c8433c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef57bbe1-8507-4284-8d08-6b10b7894f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef57bbe1-8507-4284-8d08-6b10b7894f96.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "b8ee0208-27dd-54d3-b25f-3d6d351a6d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30bfc3-5aec-480d-a80a-fe71b098b14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30bfc3-5aec-480d-a80a-fe71b098b14b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11291,7 +11291,7 @@
         },
         {
             "id": "4705c2be-4aac-500a-9a40-83bc96b987a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf964c1b-941f-4a02-895b-0608bddc1ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf964c1b-941f-4a02-895b-0608bddc1ce7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11329,7 +11329,7 @@
         },
         {
             "id": "80cfa786-570f-5474-b7df-e36c03e17016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b18fb-66cb-4dc0-9c67-60cee1502c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b18fb-66cb-4dc0-9c67-60cee1502c7f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11367,7 +11367,7 @@
         },
         {
             "id": "57d2884c-53b0-55fd-8368-f84f02ec50fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907ff242-885f-4948-b95c-61cf033d0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907ff242-885f-4948-b95c-61cf033d0969.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11405,7 +11405,7 @@
         },
         {
             "id": "8d2bbb73-4606-5c32-8382-3a7c2876adc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a9736-da37-4327-b9ee-e9a38fbe8a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a9736-da37-4327-b9ee-e9a38fbe8a19.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11443,7 +11443,7 @@
         },
         {
             "id": "6b8970fa-2bb9-58f7-ba13-ffc177a914c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f74cd0-cd73-4b08-8544-5f56b6d96f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f74cd0-cd73-4b08-8544-5f56b6d96f78.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11481,7 +11481,7 @@
         },
         {
             "id": "a261ddfd-a8c5-549e-b6de-01e6b369afc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c22765e-a131-4be6-ba48-64b84564ea51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c22765e-a131-4be6-ba48-64b84564ea51.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11519,7 +11519,7 @@
         },
         {
             "id": "9077748b-110a-591e-8eae-39e13611124f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e88b41-7ae5-40fc-8947-5f5aa03388be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e88b41-7ae5-40fc-8947-5f5aa03388be.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11557,7 +11557,7 @@
         },
         {
             "id": "8cc27cb6-5b69-5f8b-83c5-a7251417e67c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025e57e4-d088-4ad9-b872-cba327f63e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025e57e4-d088-4ad9-b872-cba327f63e9c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11595,7 +11595,7 @@
         },
         {
             "id": "af13132c-589d-5b1d-a9d9-ed862d925efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b396f90-92b1-4cc0-9be8-2f724b39fbc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b396f90-92b1-4cc0-9be8-2f724b39fbc6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "9161b799-9fa2-5501-b856-cf0e20dc6c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73029d4b-f073-4df0-a6cc-8014284a1ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73029d4b-f073-4df0-a6cc-8014284a1ced.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11671,7 +11671,7 @@
         },
         {
             "id": "eb08181a-9298-5851-999f-2b36795705a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9397010b-6116-4612-993a-11ec2a5d3115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9397010b-6116-4612-993a-11ec2a5d3115.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "b8656f2e-3dff-57a0-87a6-8e4d2eefe7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b15ea-80b9-48df-b010-aa1aabcf51ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b15ea-80b9-48df-b010-aa1aabcf51ea.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11747,7 +11747,7 @@
         },
         {
             "id": "c0597e8c-3015-52de-8d3b-af6f4bd41595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e8080f-9e4a-4fad-9ea3-09d5e0e1c816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e8080f-9e4a-4fad-9ea3-09d5e0e1c816.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/OGW.json
+++ b/Assets/Resources/Sets/OGW.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1b85404d-d965-5418-92cd-627280d66ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a416d54b-ac84-48ac-92f8-eeb348f26016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a416d54b-ac84-48ac-92f8-eeb348f26016.jpg?1",
             "name": "Deceiver of Form",
             "text": "({C} represents colorless mana.)\nAt the beginning of combat on your turn, reveal the top card of your library. If a creature card is revealed this way, you may have creatures you control other than Deceiver of Form become copies of that card until end of turn. You may put that card on the bottom of your library.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "476df97e-3333-5c64-9ac7-137001914598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a05b1-042d-47e7-9fd7-6e8abe8fc578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a05b1-042d-47e7-9fd7-6e8abe8fc578.jpg?1",
             "name": "Eldrazi Mimic",
             "text": "Whenever another colorless creature enters the battlefield under your control, you may change Eldrazi Mimic's base power and toughness to that creature's power and toughness until end of turn.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "41f5a87f-713a-52e1-8ac3-66e8020fc35c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bba7509-db77-414f-926f-1f28a4117831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bba7509-db77-414f-926f-1f28a4117831.jpg?1",
             "name": "Endbringer",
             "text": "Untap Endbringer during each other player's untap step.\n{T}: Endbringer deals 1 damage to target creature or player.\n{C}, {T}: Target creature can't attack or block this turn.\n{C}{C}, {T}: Draw a card.",
             "colours": [],
@@ -94,7 +94,7 @@
         },
         {
             "id": "bbe86a57-53bf-5430-b7f4-d018d48984ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06fc6e0-b22c-40d3-bb53-d5ec400d921c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06fc6e0-b22c-40d3-bb53-d5ec400d921c.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast Kozilek, the Great Distortion, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with converted mana cost X: Counter target spell with converted mana cost X.",
             "colours": [],
@@ -126,7 +126,7 @@
         },
         {
             "id": "89c962b0-8156-5bba-96b5-707a9a6150f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75585bd-fdd8-44d1-8c7c-b96df5fc473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75585bd-fdd8-44d1-8c7c-b96df5fc473e.jpg?1",
             "name": "Kozilek's Pathfinder",
             "text": "{C}: Target creature can't block Kozilek's Pathfinder this turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -156,7 +156,7 @@
         },
         {
             "id": "ed297c15-c849-51c8-8fb8-2ec4780e0a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906b61a-3865-4dfd-ae06-a7d2a608851a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906b61a-3865-4dfd-ae06-a7d2a608851a.jpg?1",
             "name": "Matter Reshaper",
             "text": "({C} represents colorless mana.)\nWhen Matter Reshaper dies, reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with converted mana cost 3 or less. Otherwise, put that card into your hand.",
             "colours": [],
@@ -186,7 +186,7 @@
         },
         {
             "id": "43ffa08b-254d-5616-a75e-6836f5f69517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d4b652-a830-4fd4-94bb-c17c227f2928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d4b652-a830-4fd4-94bb-c17c227f2928.jpg?1",
             "name": "Reality Smasher",
             "text": "({C} represents colorless mana.)\nTrample, haste\nWhenever Reality Smasher becomes the target of a spell an opponent controls, counter that spell unless its controller discards a card.",
             "colours": [],
@@ -216,7 +216,7 @@
         },
         {
             "id": "a173dd20-23f2-5732-ba93-f8f97e757b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2acf70-7625-4b77-83c1-0e08436da31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2acf70-7625-4b77-83c1-0e08436da31f.jpg?1",
             "name": "Spatial Contortion",
             "text": "({C} represents colorless mana.)\nTarget creature gets +3/-3 until end of turn.",
             "colours": [],
@@ -244,7 +244,7 @@
         },
         {
             "id": "8c19de75-def2-5330-954a-5e58877ec842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg?1",
             "name": "Thought-Knot Seer",
             "text": "({C} represents colorless mana.)\nWhen Thought-Knot Seer enters the battlefield, target opponent reveals his or her hand. You choose a nonland card from it and exile that card.\nWhen Thought-Knot Seer leaves the battlefield, target opponent draws a card.",
             "colours": [],
@@ -274,7 +274,7 @@
         },
         {
             "id": "46ec5404-767e-5d68-ba27-f038c0eee90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f635ac-ad6d-4a13-a08e-64c8e2b9779c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f635ac-ad6d-4a13-a08e-64c8e2b9779c.jpg?1",
             "name": "Walker of the Wastes",
             "text": "({C} represents colorless mana.)\nTrample\nWalker of the Wastes gets +1/+1 for each land you control named Wastes.",
             "colours": [],
@@ -304,7 +304,7 @@
         },
         {
             "id": "fdca781d-a310-5b58-a486-58127c534c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f517b9-ac10-4710-8ef1-ced1253d5ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f517b9-ac10-4710-8ef1-ced1253d5ecf.jpg?1",
             "name": "Warden of Geometries",
             "text": "Vigilance\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)",
             "colours": [],
@@ -335,7 +335,7 @@
         },
         {
             "id": "5530f939-0952-5c42-afcd-e5d319e6ebe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ef4db8-b51c-4f52-84f1-6fee31c4a14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ef4db8-b51c-4f52-84f1-6fee31c4a14c.jpg?1",
             "name": "Warping Wail",
             "text": "({C} represents colorless mana.)\nChoose one \u2014\n\u2022 Exile target creature with power or toughness 1 or less.\n\u2022 Counter target sorcery spell.\n\u2022 Put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\"",
             "colours": [],
@@ -363,7 +363,7 @@
         },
         {
             "id": "34e86fb7-c504-5a5f-946b-145b6799bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb1a5c-0f59-4951-827f-fe9df968232d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb1a5c-0f59-4951-827f-fe9df968232d.jpg?1",
             "name": "Eldrazi Displacer",
             "text": "Devoid (This card has no color.)\n{2}{C}: Exile another target creature, then return it to the battlefield tapped under its owner's control. ({C} represents colorless mana.)",
             "colours": [],
@@ -395,7 +395,7 @@
         },
         {
             "id": "3f560736-ae97-569d-8166-16bb7fa74ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e54ac79-fbaa-4385-869b-aaf31e33a11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e54ac79-fbaa-4385-869b-aaf31e33a11f.jpg?1",
             "name": "Affa Protector",
             "text": "Vigilance",
             "colours": [
@@ -431,7 +431,7 @@
         },
         {
             "id": "60574abb-95b8-5032-8018-34c02d665212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7d7c93-5622-45ca-9359-110685d9162c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7d7c93-5622-45ca-9359-110685d9162c.jpg?1",
             "name": "Allied Reinforcements",
             "text": "Put two 2/2 white Knight Ally creature tokens onto the battlefield.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "b8fb5227-1d45-5a78-912b-f64a6d38e125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4719ac60-2cff-4abb-b9cc-b677d3ac945c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4719ac60-2cff-4abb-b9cc-b677d3ac945c.jpg?1",
             "name": "Call the Gatewatch",
             "text": "Search your library for a planeswalker card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "93ee2eea-cc93-549d-89cb-eeff59b4a1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77977e8-25d8-4531-a6fc-8c46e6904670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77977e8-25d8-4531-a6fc-8c46e6904670.jpg?1",
             "name": "Dazzling Reflection",
             "text": "You gain life equal to target creature's power. The next time that creature would deal damage this turn, prevent that damage.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "70b5b4f5-33fd-5566-a96a-bb51a8328a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d11eb-960b-4116-ba09-f03bff88b4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d11eb-960b-4116-ba09-f03bff88b4e7.jpg?1",
             "name": "Expedition Raptor",
             "text": "Flying\nWhen Expedition Raptor enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "1d60cd12-194c-5001-a7fe-4003954bdd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e9aa86-1a31-4c0f-928d-923f066286b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e9aa86-1a31-4c0f-928d-923f066286b6.jpg?1",
             "name": "General Tazri",
             "text": "When General Tazri enters the battlefield, you may search your library for an Ally creature card, reveal it, put it into your hand, then shuffle your library.\n{W}{U}{B}{R}{G}: Ally creatures you control get +X/+X until end of turn, where X is the number of colors among those creatures.",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "3b3ec5fc-1d59-5376-918b-749148cd8910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f468338-bb66-4db0-a883-69095566092b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f468338-bb66-4db0-a883-69095566092b.jpg?1",
             "name": "Immolating Glare",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "d626b04b-8cd6-53ae-bcb3-42357ae8f169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30f26f7-5181-4bf1-9084-5563b4996a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30f26f7-5181-4bf1-9084-5563b4996a3c.jpg?1",
             "name": "Iona's Blessing",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has vigilance, and can block an additional creature.",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "0636d2f5-dc98-528d-a9e3-9ffdc5b2912c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca698e3-1249-4a08-be04-bae3bd944e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca698e3-1249-4a08-be04-bae3bd944e99.jpg?1",
             "name": "Isolation Zone",
             "text": "When Isolation Zone enters the battlefield, exile target creature or enchantment an opponent controls until Isolation Zone leaves the battlefield. (That permanent returns under its owner's control.)",
             "colours": [
@@ -700,7 +700,7 @@
         },
         {
             "id": "80292929-1645-5795-a592-5dc2665c4ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce587ba-f23a-4548-a5b8-fca54984d4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce587ba-f23a-4548-a5b8-fca54984d4b4.jpg?1",
             "name": "Kor Scythemaster",
             "text": "Kor Scythemaster has first strike as long as it's attacking.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "7d7b6d11-e3de-53a9-94ff-3db7cb0fe509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54938334-ebad-4dde-82e6-8c854aef4a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54938334-ebad-4dde-82e6-8c854aef4a91.jpg?1",
             "name": "Kor Sky Climber",
             "text": "{1}{W}: Kor Sky Climber gains flying until end of turn.",
             "colours": [
@@ -772,7 +772,7 @@
         },
         {
             "id": "435ca3a4-9c60-51d9-8948-35fdbb7e6a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0dbb08-d124-46da-bfb1-af7ef4a18179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0dbb08-d124-46da-bfb1-af7ef4a18179.jpg?1",
             "name": "Linvala, the Preserver",
             "text": "Flying\nWhen Linvala, the Preserver enters the battlefield, if an opponent has more life than you, you gain 5 life.\nWhen Linvala enters the battlefield, if an opponent controls more creatures than you, put a 3/3 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "bdc6165b-5910-5c0f-8276-b289c5653fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cace63-91ca-493c-b67f-740fbbf06370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cace63-91ca-493c-b67f-740fbbf06370.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "52aa1e1b-7cfd-50a5-8681-4b7aae600d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d3113-6cb7-4b74-94a3-8160d9ac1b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d3113-6cb7-4b74-94a3-8160d9ac1b89.jpg?1",
             "name": "Makindi Aeronaut",
             "text": "Flying",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "eba9c90d-be65-51ff-abc7-7ce7c8e4c33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e25089b-5a5f-4cb5-9261-be6cb6b45b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e25089b-5a5f-4cb5-9261-be6cb6b45b22.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "018633d9-9c74-5943-a8b2-52f90e27b926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfb21b1-95a5-446d-afc6-aede81ee5a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfb21b1-95a5-446d-afc6-aede81ee5a0d.jpg?1",
             "name": "Munda's Vanguard",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "4b287b30-6123-58fd-907c-c8a68b86e640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97976ade-c6ec-4068-be6b-953255b86a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97976ade-c6ec-4068-be6b-953255b86a79.jpg?1",
             "name": "Oath of Gideon",
             "text": "When Oath of Gideon enters the battlefield, put two 1/1 white Kor Ally creature tokens onto the battlefield.\nEach planeswalker you control enters the battlefield with an additional loyalty counter on it.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "91b2a7a2-230b-58a3-b2ae-02561aadefe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b255d34-04fa-4d3b-9fc1-8f980ef1f054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b255d34-04fa-4d3b-9fc1-8f980ef1f054.jpg?1",
             "name": "Ondu War Cleric",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: You gain 2 life.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "07a61ba8-6ecc-5a2e-888d-e08bcea8f209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecacff4-87b9-4cc1-bfbe-019cfda82d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecacff4-87b9-4cc1-bfbe-019cfda82d17.jpg?1",
             "name": "Relief Captain",
             "text": "When Relief Captain enters the battlefield, support 3. (Put a +1/+1 counter on each of up to three other target creatures.)",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "68c0d239-b28d-5182-9fb0-40796d2ebaa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dadfd8-8492-4c55-827c-cd4e6a40ae97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dadfd8-8492-4c55-827c-cd4e6a40ae97.jpg?1",
             "name": "Searing Light",
             "text": "Destroy target attacking or blocking creature with power 2 or less.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "b0393926-caac-5226-8b86-b240a110ec4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d11865-a1ea-4f2e-b7da-31630c6d0272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d11865-a1ea-4f2e-b7da-31630c6d0272.jpg?1",
             "name": "Shoulder to Shoulder",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nDraw a card.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "88763199-e109-5253-ac65-2e032826bc80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677bd49-69eb-41dc-8e64-2df3b7f5c45f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677bd49-69eb-41dc-8e64-2df3b7f5c45f.jpg?1",
             "name": "Spawnbinder Mage",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Tap target creature.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "4e66160b-98a3-5764-9739-4dcf3d1f5093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539dbdfe-3e32-409d-8e1e-aeb0c56656a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539dbdfe-3e32-409d-8e1e-aeb0c56656a7.jpg?1",
             "name": "Steppe Glider",
             "text": "Flying, vigilance\n{1}{W}: Target creature with a +1/+1 counter on it gains flying and vigilance until end of turn.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "bf6d9619-32ed-594e-830a-2e4ec639ba33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b98e63-f23d-432a-86ae-f88bdad2f648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b98e63-f23d-432a-86ae-f88bdad2f648.jpg?1",
             "name": "Stone Haven Outfitter",
             "text": "Equipped creatures you control get +1/+1.\nWhenever an equipped creature you control dies, draw a card.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "5284cca3-86da-57f7-9ca0-adec794260ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ec11-48c3-49d8-9dcd-1da5ffaf9184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ec11-48c3-49d8-9dcd-1da5ffaf9184.jpg?1",
             "name": "Stoneforge Acolyte",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Look at the top four cards of your library. You may reveal an Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "02354ce8-221a-5ecd-ba04-738488373d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f0dc1-c8cf-4733-a874-5ae57b38258e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f0dc1-c8cf-4733-a874-5ae57b38258e.jpg?1",
             "name": "Wall of Resurgence",
             "text": "Defender\nWhen Wall of Resurgence enters the battlefield, you may put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "3f4a026f-0704-51ea-ac9f-c1a3f9596c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249a7be3-311e-4ce6-97dc-97242463ae23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249a7be3-311e-4ce6-97dc-97242463ae23.jpg?1",
             "name": "Abstruse Interference",
             "text": "Devoid (This card has no color.)\nCounter target spell unless its controller pays {1}. You put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "8e76a8e5-faec-5b61-891d-bbee668ecb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb60957-0811-40c3-a92b-cce3e6a94745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb60957-0811-40c3-a92b-cce3e6a94745.jpg?1",
             "name": "Blinding Drone",
             "text": "Devoid (This card has no color.)\n{C}, {T}: Tap target creature. ({C} represents colorless mana.)",
             "colours": [],
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "7a435393-2564-5e99-8f61-9866ef543344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe4bb6f-bec6-49d2-99d7-e3750a0ea03f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe4bb6f-bec6-49d2-99d7-e3750a0ea03f.jpg?1",
             "name": "Cultivator Drone",
             "text": "Devoid (This card has no color.)\n{T}: Add {C} to your mana pool. Spend this mana only to cast a colorless spell, activate an ability of a colorless permanent, or pay a cost that contains {C}. ({C} represents colorless mana.)",
             "colours": [],
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "1c7e3597-a6bb-5d6b-9112-3f529adce853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a22cc-36dd-4d4d-b887-8c4733a29870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a22cc-36dd-4d4d-b887-8c4733a29870.jpg?1",
             "name": "Deepfathom Skulker",
             "text": "Devoid (This card has no color.)\nWhenever a creature you control deals combat damage to a player, you may draw a card.\n{3}{C}: Target creature can't be blocked this turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "f34cfa5d-c0b9-51a1-84b9-cc051b08a945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea28dd5-57b0-4255-a3d9-1c190c446f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea28dd5-57b0-4255-a3d9-1c190c446f20.jpg?1",
             "name": "Dimensional Infiltrator",
             "text": "Devoid (This card has no color.)\nFlash\nFlying\n{1}{C}: Target opponent exiles the top card of his or her library. If it's a land card, you may return Dimensional Infiltrator to its owner's hand. ({C} represents colorless mana.)",
             "colours": [],
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "19f2ab80-c7d5-5b6f-8a42-b21969e29692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9b63e-6ecc-4d85-9724-87b8176ae6a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9b63e-6ecc-4d85-9724-87b8176ae6a6.jpg?1",
             "name": "Gravity Negator",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever Gravity Negator attacks, you may pay {C}. If you do, another target creature gains flying until end of turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "c8bc3da4-89c8-526e-87fd-ea8e3c005f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ee2d7e-50ee-4f5a-b787-cf9669a892f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ee2d7e-50ee-4f5a-b787-cf9669a892f3.jpg?1",
             "name": "Prophet of Distortion",
             "text": "Devoid (This card has no color.)\n{3}{C}: Draw a card. ({C} represents colorless mana.)",
             "colours": [],
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "61b31748-9472-5998-a781-8103dbc5289d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dee6dca-9c7e-4347-bea7-7fecc69e5827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dee6dca-9c7e-4347-bea7-7fecc69e5827.jpg?1",
             "name": "Slip Through Space",
             "text": "Devoid (This card has no color.)\nTarget creature can't be blocked this turn.\nDraw a card.",
             "colours": [],
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "1fb6b965-6d0e-536c-8593-63140f3c6e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f9eeb2-22f6-4bdb-bbf8-f53774cc6226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f9eeb2-22f6-4bdb-bbf8-f53774cc6226.jpg?1",
             "name": "Thought Harvester",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever you cast a colorless spell, target opponent exiles the top card of his or her library.",
             "colours": [],
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "14abd99b-f452-56e8-8f6d-7247052fd443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf13c5e-3968-48ad-ba08-99ba58873223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf13c5e-3968-48ad-ba08-99ba58873223.jpg?1",
             "name": "Void Shatter",
             "text": "Devoid (This card has no color.)\nCounter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [],
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "3d0be5c2-4535-5189-b2e6-0ba6395d99c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783794e3-fe0c-4014-ae5a-6c249af23ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783794e3-fe0c-4014-ae5a-6c249af23ddc.jpg?1",
             "name": "Ancient Crab",
             "text": "",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "738dcc95-7c3f-57ce-8987-f2139ebab35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd83129b-7e8c-4cc5-a7b3-e0ae221d7ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd83129b-7e8c-4cc5-a7b3-e0ae221d7ad4.jpg?1",
             "name": "Comparative Analysis",
             "text": "Surge {2}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nTarget player draws two cards.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "f36936ed-927e-500f-9aef-a107634e5b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd3963-a4d7-4992-b6f8-753996390bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd3963-a4d7-4992-b6f8-753996390bbf.jpg?1",
             "name": "Containment Membrane",
             "text": "Surge {U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nEnchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "c96eea20-9fb4-5bb5-b22f-87a2798db3b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1434e1-a0d6-4028-918b-1e2d17d3a227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1434e1-a0d6-4028-918b-1e2d17d3a227.jpg?1",
             "name": "Crush of Tentacles",
             "text": "Surge {3}{U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nReturn all nonland permanents to their owners' hands. If Crush of Tentacles's surge cost was paid, put an 8/8 blue Octopus creature token onto the battlefield.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "1f42e397-1ca3-5ddf-a29a-e39d170daceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff62270-57ed-4706-bedf-11f60ae2da43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff62270-57ed-4706-bedf-11f60ae2da43.jpg?1",
             "name": "Cyclone Sire",
             "text": "Flying\nWhen Cyclone Sire dies, you may put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.",
             "colours": [
@@ -1775,7 +1775,7 @@
         },
         {
             "id": "5d6c2ddc-bb40-5946-9d4c-9e25b7ee63e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3821122c-c495-42b0-b8f6-3f469967f16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3821122c-c495-42b0-b8f6-3f469967f16d.jpg?1",
             "name": "Gift of Tusks",
             "text": "Until end of turn, target creature loses all abilities and becomes a green Elephant with base power and toughness 3/3.",
             "colours": [
@@ -1807,7 +1807,7 @@
         },
         {
             "id": "facd991f-9a0d-5f23-9161-09c3cbf3e81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf33069-013f-43ab-9a31-e67bb6dc996d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf33069-013f-43ab-9a31-e67bb6dc996d.jpg?1",
             "name": "Grip of the Roil",
             "text": "Surge {1}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "c4e1202d-ab50-5ab0-9619-9df1c8e48dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ec511-1b78-46e9-8ec2-fc09abd1b434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ec511-1b78-46e9-8ec2-fc09abd1b434.jpg?1",
             "name": "Hedron Alignment",
             "text": "Hexproof\nAt the beginning of your upkeep, you may reveal your hand. If you do, you win the game if you own a card named Hedron Alignment in exile, in your hand, in your graveyard, and on the battlefield.\n{1}{U}: Scry 1.",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "38ae7bbc-73d6-5cd2-b2a9-5b13b67709ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b059f-2fa3-474f-9c74-6d4021703add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b059f-2fa3-474f-9c74-6d4021703add.jpg?1",
             "name": "Jwar Isle Avenger",
             "text": "Surge {2}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFlying",
             "colours": [
@@ -1905,7 +1905,7 @@
         },
         {
             "id": "a0922c23-9456-5550-a002-6e367073e91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026c499d-3d5b-4f65-a824-f78f146b82ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026c499d-3d5b-4f65-a824-f78f146b82ef.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "7dd85c72-ffaa-569d-a572-4f1dbe702c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7b007-a14b-40b2-9de7-38545c50a073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7b007-a14b-40b2-9de7-38545c50a073.jpg?1",
             "name": "Oath of Jace",
             "text": "When Oath of Jace enters the battlefield, draw three cards, then discard two cards.\nAt the beginning of your upkeep, scry X, where X is the number of planeswalkers you control.",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "ee63c4e2-67b5-5e7d-880f-2f09839ab162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff1000-1a4e-43f6-aa02-1dbe9fac6901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff1000-1a4e-43f6-aa02-1dbe9fac6901.jpg?1",
             "name": "Overwhelming Denial",
             "text": "Surge {U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nOverwhelming Denial can't be countered by spells or abilities.\nCounter target spell.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "9b203bad-6ea1-51b4-a76e-b3335ff15ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d878c10-de5e-4224-98ce-d49902b5ab8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d878c10-de5e-4224-98ce-d49902b5ab8b.jpg?1",
             "name": "Roiling Waters",
             "text": "Return up to two target creatures your opponents control to their owners' hands. Target player draws two cards.",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "dc16bd4e-4cff-5de2-81a2-2db11185814c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg?1",
             "name": "Sphinx of the Final Word",
             "text": "Sphinx of the Final Word can't be countered.\nFlying, hexproof\nInstant and sorcery spells you control can't be countered by spells or abilities.",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "c5b808b7-f4b7-5a3e-969f-dc3ed5326ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75234f6d-a2da-42dd-a668-8db8f341e7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75234f6d-a2da-42dd-a668-8db8f341e7f0.jpg?1",
             "name": "Sweep Away",
             "text": "Return target creature to its owner's hand. If that creature is attacking, you may put it on top of its owner's library instead.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "44e7e272-cd4d-5a75-abe8-fa5ceb79e080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4ddc45-cd67-4b2c-84d0-4604783fd8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4ddc45-cd67-4b2c-84d0-4604783fd8e7.jpg?1",
             "name": "Umara Entangler",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "d94cca2b-aeb8-5f90-8312-5895d693bc0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f87292c-0140-44d7-881e-2e8c9ff737a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f87292c-0140-44d7-881e-2e8c9ff737a1.jpg?1",
             "name": "Unity of Purpose",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nUntap each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "01cb51c7-44d2-5667-aa18-95b998418031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50460cce-ee1c-4384-bb0c-d90616e0d2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50460cce-ee1c-4384-bb0c-d90616e0d2e9.jpg?1",
             "name": "Bearer of Silence",
             "text": "Devoid (This card has no color.)\nWhen you cast Bearer of Silence, you may pay {1}{C}. If you do, target opponent sacrifices a creature. ({C} represents colorless mana.)\nFlying\nBearer of Silence can't block.",
             "colours": [],
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "fc6d19ea-7078-5ac7-9e02-88a96cbdbe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b26769-4705-4b09-94b4-1063e67041d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b26769-4705-4b09-94b4-1063e67041d1.jpg?1",
             "name": "Dread Defiler",
             "text": "Devoid (This card has no color.)\n{3}{C}, Exile a creature card from your graveyard: Target opponent loses life equal to the exiled card's power. ({C} represents colorless mana.)",
             "colours": [],
@@ -2233,7 +2233,7 @@
         },
         {
             "id": "479ab91c-f98d-51b7-850d-e5dcce4a37d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996da623-1c34-4545-a800-648238ea91ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996da623-1c34-4545-a800-648238ea91ae.jpg?1",
             "name": "Essence Depleter",
             "text": "Devoid (This card has no color.)\n{1}{C}: Target opponent loses 1 life and you gain 1 life. ({C} represents colorless mana.)",
             "colours": [],
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "da2658fc-f04d-5f72-bd36-6f25c2ae472a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77899cb2-4d87-4c2d-99ae-1ae75bc5dc86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77899cb2-4d87-4c2d-99ae-1ae75bc5dc86.jpg?1",
             "name": "Flaying Tendrils",
             "text": "Devoid (This card has no color.)\nAll creatures get -2/-2 until end of turn. If a creature would die this turn, exile it instead.",
             "colours": [],
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "4fa571b5-fb97-56eb-b242-9462862f87f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8585871-24a2-41d7-ae12-29aabfbc9ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8585871-24a2-41d7-ae12-29aabfbc9ccc.jpg?1",
             "name": "Havoc Sower",
             "text": "Devoid (This card has no color.)\n{1}{C}: Havoc Sower gets +2/+1 until end of turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -2329,7 +2329,7 @@
         },
         {
             "id": "6336cde2-1a6f-5bfc-84d6-e8a2cff61dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c9d8c5-333b-4281-b923-b4a060927bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c9d8c5-333b-4281-b923-b4a060927bbc.jpg?1",
             "name": "Inverter of Truth",
             "text": "Devoid (This card has no color.)\nFlying\nWhen Inverter of Truth enters the battlefield, exile all cards from your library face down, then shuffle all cards from your graveyard into your library.",
             "colours": [],
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "513ce397-8737-5c97-b108-3176574c2335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a384cd5b-2c6c-4969-bb62-a017e2fc9794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a384cd5b-2c6c-4969-bb62-a017e2fc9794.jpg?1",
             "name": "Kozilek's Shrieker",
             "text": "Devoid (This card has no color.)\n{C}: Kozilek's Shrieker gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures. {C} represents colorless mana.)",
             "colours": [],
@@ -2394,7 +2394,7 @@
         },
         {
             "id": "1990ea10-2979-5d6a-a0a6-fa8171396f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80665ae-fcb2-48fd-95be-8768293bcef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80665ae-fcb2-48fd-95be-8768293bcef7.jpg?1",
             "name": "Kozilek's Translator",
             "text": "Devoid (This card has no color.)\nPay 1 life: Add {C} to your mana pool. Activate this ability only once each turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "0ce07a6d-f70b-540b-bcdb-5556103a95bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e30acf-b30f-4bb3-b80e-dc7e9559da51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e30acf-b30f-4bb3-b80e-dc7e9559da51.jpg?1",
             "name": "Oblivion Strike",
             "text": "Devoid (This card has no color.)\nExile target creature.",
             "colours": [],
@@ -2457,7 +2457,7 @@
         },
         {
             "id": "e912a670-5ba5-5633-82eb-011137324722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162f3fb8-75b7-4cd7-9d6c-27dd76197aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162f3fb8-75b7-4cd7-9d6c-27dd76197aa5.jpg?1",
             "name": "Reaver Drone",
             "text": "Devoid (This card has no color.)\nAt the beginning of your upkeep, you lose 1 life unless you control another colorless creature.",
             "colours": [],
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "f918e90c-ef38-5dcd-9eba-54e94b477b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be57a5aa-44f1-483f-9274-aa68f5a2bf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be57a5aa-44f1-483f-9274-aa68f5a2bf1f.jpg?1",
             "name": "Sifter of Skulls",
             "text": "Devoid (This card has no color.)\nWhenever another nontoken creature you control dies, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "d6df5383-46eb-50b1-b1e0-359776812d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00fa72-bcda-4081-9048-e13752da8d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00fa72-bcda-4081-9048-e13752da8d46.jpg?1",
             "name": "Sky Scourer",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever you cast a colorless spell, Sky Scourer gets +1/+0 until end of turn.",
             "colours": [],
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "e844291e-2942-5dac-879c-c54f27c83219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b1185-49aa-45ae-8e2d-12aa469a7d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b1185-49aa-45ae-8e2d-12aa469a7d77.jpg?1",
             "name": "Slaughter Drone",
             "text": "Devoid (This card has no color.)\n{C}: Slaughter Drone gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it. {C} represents colorless mana.)",
             "colours": [],
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "e9d3f69e-622b-532b-9bdc-ef1bc9977acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac497133-a44a-4acc-ba7e-8fc1fae7e226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac497133-a44a-4acc-ba7e-8fc1fae7e226.jpg?1",
             "name": "Unnatural Endurance",
             "text": "Devoid (This card has no color.)\nTarget creature gets +2/+0 until end of turn. Regenerate it.",
             "colours": [],
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "9587e7ab-5c86-559f-af9b-a69bec33296f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ed374-54ad-4b81-b071-0b4668feb282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ed374-54ad-4b81-b071-0b4668feb282.jpg?1",
             "name": "Visions of Brutality",
             "text": "Devoid (This card has no color.)\nEnchant creature\nEnchanted creature can't block.\nWhenever enchanted creature deals damage, its controller loses that much life.",
             "colours": [],
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "708117b0-f116-5975-a198-24422cc153af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c06d8ec-55ab-4be9-a470-77c79d643d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c06d8ec-55ab-4be9-a470-77c79d643d1f.jpg?1",
             "name": "Witness the End",
             "text": "Devoid (This card has no color.)\nTarget opponent exiles two cards from his or her hand and loses 2 life.",
             "colours": [],
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "a954c595-d003-5b42-af45-f4b997805817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7e6054-c6b8-4b29-83c5-a2e4e295bdf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7e6054-c6b8-4b29-83c5-a2e4e295bdf3.jpg?1",
             "name": "Corpse Churn",
             "text": "Put the top three cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "f853f063-cb65-526f-aff1-cb1e099a10f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189abe2f-5899-438b-9f54-3c98e50f037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189abe2f-5899-438b-9f54-3c98e50f037a.jpg?1",
             "name": "Drana's Chosen",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -2748,7 +2748,7 @@
         },
         {
             "id": "3f731932-6904-54b4-b08a-3ad13a96790a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d692236-92e5-460f-a8fc-8f6c73eba30c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d692236-92e5-460f-a8fc-8f6c73eba30c.jpg?1",
             "name": "Grasp of Darkness",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "968d91e6-eae1-5dd3-8fda-8d57d9c0d6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a278d0-f601-4d57-bc3d-2972f8602a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a278d0-f601-4d57-bc3d-2972f8602a69.jpg?1",
             "name": "Kalitas, Traitor of Ghet",
             "text": "Lifelink\nIf a nontoken creature an opponent controls would die, instead exile that card and put a 2/2 black Zombie creature token onto the battlefield.\n{2}{B}, Sacrifice another Vampire or Zombie: Put two +1/+1 counters on Kalitas, Traitor of Ghet.",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "c87cd087-cd08-5a4d-a752-02ed5635087e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cb3c2c-5d5a-4c9b-a381-ab4dd477d84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cb3c2c-5d5a-4c9b-a381-ab4dd477d84d.jpg?1",
             "name": "Malakir Soothsayer",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: You draw a card and you lose 1 life.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "8577dc94-3acc-5e01-b9f7-6ce9d399ecfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe773b-2987-4001-a0fd-9dca414a9129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe773b-2987-4001-a0fd-9dca414a9129.jpg?1",
             "name": "Null Caller",
             "text": "{3}{B}, Exile a creature card from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -2888,7 +2888,7 @@
         },
         {
             "id": "1614c3a5-c661-5b71-a983-e9d3f4884269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde9379-b335-400f-9748-a7ca3e293ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde9379-b335-400f-9748-a7ca3e293ee0.jpg?1",
             "name": "Remorseless Punishment",
             "text": "Target opponent loses 5 life unless that player discards two cards or sacrifices a creature or planeswalker. Repeat this process once.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "533028ae-7a0c-5afd-b360-9dcec70c3bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee017c-25ae-4668-8cfe-ae3b55e851aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee017c-25ae-4668-8cfe-ae3b55e851aa.jpg?1",
             "name": "Tar Snare",
             "text": "Target creature gets -3/-2 until end of turn.",
             "colours": [
@@ -2952,7 +2952,7 @@
         },
         {
             "id": "a6b606e6-4b37-5909-8550-234b26ef3128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595deb86-b6cf-4e4f-a6cf-f5ff128b720d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595deb86-b6cf-4e4f-a6cf-f5ff128b720d.jpg?1",
             "name": "Untamed Hunger",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "e9eb9fba-8330-55ba-b404-c46e633cba9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba8e7aa-9a87-410e-b846-5f5c910585cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba8e7aa-9a87-410e-b846-5f5c910585cf.jpg?1",
             "name": "Vampire Envoy",
             "text": "Flying\nWhenever Vampire Envoy becomes tapped, you gain 1 life.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "86d5c9f9-cdfa-5d0c-b1ca-d2113ed11f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92461f3c-21dc-48a8-b532-9c4e2e1e80b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92461f3c-21dc-48a8-b532-9c4e2e1e80b5.jpg?1",
             "name": "Zulaport Chainmage",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Target opponent loses 2 life.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "71aa6c57-9c99-5c3d-8140-ececbc1b28cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a42b28-3d1b-4432-b8c9-2d42e4d0e1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a42b28-3d1b-4432-b8c9-2d42e4d0e1c5.jpg?1",
             "name": "Consuming Sinkhole",
             "text": "Devoid (This card has no color.)\nChoose one \u2014\n\u2022 Exile target land creature.\n\u2022 Consuming Sinkhole deals 4 damage to target player.",
             "colours": [],
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "d2280846-0d70-5a82-a5bd-9866c6ab502f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f3ec85-552d-4e28-939e-ab2c39e3e9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f3ec85-552d-4e28-939e-ab2c39e3e9c5.jpg?1",
             "name": "Eldrazi Aggressor",
             "text": "Devoid (This card has no color.)\nEldrazi Aggressor has haste as long as you control another colorless creature.",
             "colours": [],
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "8a49fac3-7e0c-5532-b03f-428a63251a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaa8b16-7c12-44e2-8ddb-17608d491c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaa8b16-7c12-44e2-8ddb-17608d491c41.jpg?1",
             "name": "Eldrazi Obligator",
             "text": "Devoid (This card has no color.)\nWhen you cast Eldrazi Obligator, you may pay {1}{C}. If you do, gain control of target creature until end of turn, untap that creature, and it gains haste until end of turn. ({C} represents colorless mana.)\nHaste",
             "colours": [],
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "a79ccb68-b43e-58e5-b804-87c724e58680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9c92d-8b1b-4adc-8015-d50e673b6321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9c92d-8b1b-4adc-8015-d50e673b6321.jpg?1",
             "name": "Immobilizer Eldrazi",
             "text": "Devoid (This card has no color.)\n{2}{C}: Each creature with toughness greater than its power can't block this turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "cf8a28d7-afc4-5969-99c8-830fbb854bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72765559-0a78-4aa3-827e-cb4612720991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72765559-0a78-4aa3-827e-cb4612720991.jpg?1",
             "name": "Kozilek's Return",
             "text": "Devoid (This card has no color.)\nKozilek's Return deals 2 damage to each creature.\nWhenever you cast an Eldrazi creature spell with converted mana cost 7 or greater, you may exile Kozilek's Return from your graveyard. If you do, Kozilek's Return deals 5 damage to each creature.",
             "colours": [],
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "2653d424-4ba3-5845-8c0d-6d83c8f08a99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48669993-ad68-499e-8f2e-bc5c651b4b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48669993-ad68-499e-8f2e-bc5c651b4b28.jpg?1",
             "name": "Maw of Kozilek",
             "text": "Devoid (This card has no color.)\n{C}: Maw of Kozilek gets +2/-2 until end of turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -3249,7 +3249,7 @@
         },
         {
             "id": "10e36b0e-88a9-5bdd-be4d-3727ffc967de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c044168d-cb08-493d-98c1-b66b6149fe5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c044168d-cb08-493d-98c1-b66b6149fe5a.jpg?1",
             "name": "Reality Hemorrhage",
             "text": "Devoid (This card has no color.)\nReality Hemorrhage deals 2 damage to target creature or player.",
             "colours": [],
@@ -3279,7 +3279,7 @@
         },
         {
             "id": "2b03bd87-1f75-5897-8885-dcbd821a90fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4e1e2-7961-47d2-bb55-9168ea201214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4e1e2-7961-47d2-bb55-9168ea201214.jpg?1",
             "name": "Akoum Flameseeker",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Discard a card. If you do, draw a card.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "461cf41a-585c-5b6b-a54f-0b3144f32e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e269989-bb22-4da4-a374-434a572e8e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e269989-bb22-4da4-a374-434a572e8e8f.jpg?1",
             "name": "Boulder Salvo",
             "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nBoulder Salvo deals 4 damage to target creature.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "5edf7a0c-b1e1-5959-afa4-5457e72d323a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec60192a-19b3-447c-b732-bbcb2d275df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec60192a-19b3-447c-b732-bbcb2d275df6.jpg?1",
             "name": "Brute Strength",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.",
             "colours": [
@@ -3379,7 +3379,7 @@
         },
         {
             "id": "d460ffe2-635f-5dc3-b9ba-ccd535bce435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fdd0d3-7140-4c12-a41c-37eedd986d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fdd0d3-7140-4c12-a41c-37eedd986d9e.jpg?1",
             "name": "Chandra, Flamecaller",
             "text": "+1: Put two 3/1 red Elemental creature tokens with haste onto the battlefield. Exile them at the beginning of the next end step.\n0: Discard all the cards in your hand, then draw that many cards plus one.\n\u2212X: Chandra, Flamecaller deals X damage to each creature.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "ba520565-3e5d-590c-ad46-b781bbd31cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a069118-42e4-40e3-a2ba-593ac89b9064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a069118-42e4-40e3-a2ba-593ac89b9064.jpg?1",
             "name": "Cinder Hellion",
             "text": "Trample\nWhen Cinder Hellion enters the battlefield, it deals 2 damage to target opponent.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "f0261d8c-8a00-5dd6-a679-1e36f4c1e999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432dd78b-9520-4c28-8699-d7ff9c477070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432dd78b-9520-4c28-8699-d7ff9c477070.jpg?1",
             "name": "Devour in Flames",
             "text": "As an additional cost to cast Devour in Flames, return a land you control to its owner's hand.\nDevour in Flames deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "c93120e6-206c-5f20-81c6-5588d7ea1496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f385d1-a6c5-40b7-bc90-6f71b6f815e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f385d1-a6c5-40b7-bc90-6f71b6f815e7.jpg?1",
             "name": "Embodiment of Fury",
             "text": "Trample\nLand creatures you control have trample.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target land you control become a 3/3 Elemental creature with haste until end of turn. It's still a land.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "d6203006-0886-5b89-b300-87117c113659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c65eb7-4353-45ce-9c2e-1791c2804ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c65eb7-4353-45ce-9c2e-1791c2804ccf.jpg?1",
             "name": "Expedite",
             "text": "Target creature gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "692b35f6-29f2-50bc-966b-e3a0e09888c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21da73-0dad-4b2b-8cc6-61861bed9410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21da73-0dad-4b2b-8cc6-61861bed9410.jpg?1",
             "name": "Fall of the Titans",
             "text": "Surge {X}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFall of the Titans deals X damage to each of up to two target creatures and/or players.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "3a83e403-7e44-5ccb-b188-a788c20065da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf91a4e-97f7-4189-823d-b619bb3b3d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf91a4e-97f7-4189-823d-b619bb3b3d55.jpg?1",
             "name": "Goblin Dark-Dwellers",
             "text": "Menace\nWhen Goblin Dark-Dwellers enters the battlefield, you may cast target instant or sorcery card with converted mana cost 3 or less from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "2215358d-8af0-5d32-804b-f3c3ed90843e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5082e0a1-5c3e-4b8c-ba88-290151564133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5082e0a1-5c3e-4b8c-ba88-290151564133.jpg?1",
             "name": "Goblin Freerunner",
             "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "aec84040-a619-5194-995f-786ecffd58fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6824f48d-6808-4458-a2fd-1ffd0a10d72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6824f48d-6808-4458-a2fd-1ffd0a10d72a.jpg?1",
             "name": "Kazuul's Toll Collector",
             "text": "{0}: Attach target Equipment you control to Kazuul's Toll Collector. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "b50438e0-e180-5dcf-aa3c-58e9549cd74b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f570b0cb-2f38-422d-89d6-22c85e085328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f570b0cb-2f38-422d-89d6-22c85e085328.jpg?1",
             "name": "Oath of Chandra",
             "text": "When Oath of Chandra enters the battlefield, it deals 3 damage to target creature an opponent controls.\nAt the beginning of each end step, if a planeswalker entered the battlefield under your control this turn, Oath of Chandra deals 2 damage to each opponent.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "c3b1302a-20b3-548e-948b-591e76f9d3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b9eb4b-3ab8-4506-baa4-3a818e7677a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b9eb4b-3ab8-4506-baa4-3a818e7677a3.jpg?1",
             "name": "Press into Service",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "148bf771-be00-5247-abdb-ccab50650579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c8dad1-278c-4ced-8124-5593b140d361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c8dad1-278c-4ced-8124-5593b140d361.jpg?1",
             "name": "Pyromancer's Assault",
             "text": "Whenever you cast your second spell each turn, Pyromancer's Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -3782,7 +3782,7 @@
         },
         {
             "id": "fef5a7dc-3415-52fc-81a3-e9cd1927c1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0405b1b9-976a-4aaf-bec6-fa006decea74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0405b1b9-976a-4aaf-bec6-fa006decea74.jpg?1",
             "name": "Reckless Bushwhacker",
             "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nHaste\nWhen Reckless Bushwhacker enters the battlefield, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -3818,7 +3818,7 @@
         },
         {
             "id": "5d7a09bd-52fc-5e31-a204-fad82cf9547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736ad6c8-e275-4644-9d1e-d2d380149839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736ad6c8-e275-4644-9d1e-d2d380149839.jpg?1",
             "name": "Sparkmage's Gambit",
             "text": "Sparkmage's Gambit deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "f22ceac8-501a-5a5b-96c0-997a16ab4195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db858823-ae8b-4da1-be6f-aee541e008ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db858823-ae8b-4da1-be6f-aee541e008ae.jpg?1",
             "name": "Tears of Valakut",
             "text": "Tears of Valakut can't be countered by spells or abilities.\nTears of Valakut deals 5 damage to target creature with flying.",
             "colours": [
@@ -3882,7 +3882,7 @@
         },
         {
             "id": "4284b1e1-99fd-5756-affe-df411cb086d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388be9e-332e-4199-9f30-862d631fa26b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388be9e-332e-4199-9f30-862d631fa26b.jpg?1",
             "name": "Tyrant of Valakut",
             "text": "Surge {3}{R}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFlying\nWhen Tyrant of Valakut enters the battlefield, if its surge cost was paid, it deals 3 damage to target creature or player.",
             "colours": [
@@ -3916,7 +3916,7 @@
         },
         {
             "id": "076eb3de-0172-5ce5-8c1a-7a7ec58d8351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ad826d-c7e6-4dfd-991f-15d75b87d504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ad826d-c7e6-4dfd-991f-15d75b87d504.jpg?1",
             "name": "Zada's Commando",
             "text": "First strike\nCohort \u2014 {T}, Tap an untapped Ally you control: Zada's Commando deals 1 damage to target opponent.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "3e87b480-2b47-5e22-92e9-a6c7d533c599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a644e0-96e5-4b73-873f-1132948cb21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a644e0-96e5-4b73-873f-1132948cb21f.jpg?1",
             "name": "Birthing Hulk",
             "text": "Devoid (This card has no color.)\nWhen Birthing Hulk enters the battlefield, put two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)\n{1}{C}: Regenerate Birthing Hulk.",
             "colours": [],
@@ -3985,7 +3985,7 @@
         },
         {
             "id": "aed4c413-eda0-5148-b5f7-b2d9175be57e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0ff591-e4d9-4b62-ac9c-7962fd815226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0ff591-e4d9-4b62-ac9c-7962fd815226.jpg?1",
             "name": "Ruin in Their Wake",
             "text": "Devoid (This card has no color.)\nSearch your library for a basic land card and reveal it. You may put that card onto the battlefield tapped if you control a land named Wastes. Otherwise, put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "b78b63e6-7b7b-573f-81fb-ff0eb1727b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a882e-c4bd-4132-b797-9e1aa2d0bce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a882e-c4bd-4132-b797-9e1aa2d0bce4.jpg?1",
             "name": "Scion Summoner",
             "text": "Devoid (This card has no color.)\nWhen Scion Summoner enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -4048,7 +4048,7 @@
         },
         {
             "id": "ba3b0819-a6f3-5283-bd4a-935e1026278f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bc5b4c-a809-43f0-8848-38812ce865c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bc5b4c-a809-43f0-8848-38812ce865c2.jpg?1",
             "name": "Stalking Drone",
             "text": "Devoid (This card has no color.)\n{C}: Stalking Drone gets +1/+2 until end of turn. Activate this ability only once each turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -4081,7 +4081,7 @@
         },
         {
             "id": "e9721010-a8da-5ce3-96d9-15350b07c85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b0613-127a-4338-aea4-ad0b8aa96d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b0613-127a-4338-aea4-ad0b8aa96d77.jpg?1",
             "name": "Vile Redeemer",
             "text": "Devoid (This card has no color.)\nFlash\nWhen you cast Vile Redeemer, you may pay {C}. If you do, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield for each nontoken creature that died under your control this turn. Those tokens have \"Sacrifice this creature: Add {C} to your mana pool.\"",
             "colours": [],
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "aebb4023-332e-5daf-bbfe-2e629d1433aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1",
             "name": "World Breaker",
             "text": "Devoid (This card has no color.)\nWhen you cast World Breaker, exile target artifact, enchantment, or land.\nReach\n{2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand. ({C} represents colorless mana.)",
             "colours": [],
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "7a5d0f97-be5c-5646-b5fd-481d0895bf00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c87f4-4fa5-4c97-9654-c4acd250f850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c87f4-4fa5-4c97-9654-c4acd250f850.jpg?1",
             "name": "Baloth Pup",
             "text": "Baloth Pup has trample as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "e65f7045-6ea6-5bb3-90b1-acb88f2ac09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff50de00-115f-41ed-892b-aac9bd13b9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff50de00-115f-41ed-892b-aac9bd13b9b9.jpg?1",
             "name": "Bonds of Mortality",
             "text": "When Bonds of Mortality enters the battlefield, draw a card.\n{G}: Creatures your opponents control lose hexproof and indestructible until end of turn.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "e22a403e-0286-5ee7-95d0-398141744fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc8957d-769c-4630-9544-56cea8c847c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc8957d-769c-4630-9544-56cea8c847c2.jpg?1",
             "name": "Canopy Gorger",
             "text": "",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "5e2ee7df-bebe-5da3-9468-fec024242f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e194b283-a7d2-4c0a-9ee2-8689a8e911b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e194b283-a7d2-4c0a-9ee2-8689a8e911b9.jpg?1",
             "name": "Elemental Uprising",
             "text": "Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. It must be blocked this turn if able.",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "26ffa7a4-9e09-5dff-899e-efde248d369f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b034a95d-4f51-4f04-94c2-dad073ea0f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b034a95d-4f51-4f04-94c2-dad073ea0f35.jpg?1",
             "name": "Embodiment of Insight",
             "text": "Vigilance\nLand creatures you control have vigilance.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target land you control become a 3/3 Elemental creature with haste until end of turn. It's still a land.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "c1cd2e46-4854-5bec-b120-d2a244c2a77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ffd3f4-a034-4cb2-9270-bdb5197f1bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ffd3f4-a034-4cb2-9270-bdb5197f1bef.jpg?1",
             "name": "Gladehart Cavalry",
             "text": "When Gladehart Cavalry enters the battlefield, support 6. (Put a +1/+1 counter on each of up to six other target creatures.)\nWhenever a creature you control with a +1/+1 counter on it dies, you gain 2 life.",
             "colours": [
@@ -4346,7 +4346,7 @@
         },
         {
             "id": "d2e53ba2-2533-5013-b183-dfa26727b5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf92744-0acc-4c7e-819c-51b0696facad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf92744-0acc-4c7e-819c-51b0696facad.jpg?1",
             "name": "Harvester Troll",
             "text": "When Harvester Troll enters the battlefield, you may sacrifice a creature or land. If you do, put two +1/+1 counters on Harvester Troll.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "18e42ebd-8011-532f-a543-90e5aa838741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cdcb985-b0bb-4921-a7e4-3ee6e8f8992b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cdcb985-b0bb-4921-a7e4-3ee6e8f8992b.jpg?1",
             "name": "Lead by Example",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "5cbd65d8-0e1a-56fc-8c82-d81fb1e0c4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affa9314-0021-445e-9496-349254b16bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affa9314-0021-445e-9496-349254b16bf8.jpg?1",
             "name": "Loam Larva",
             "text": "When Loam Larva enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "49c56c51-88b8-5794-a1be-c800221bb2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd4bdd5-1673-4f22-b593-41df8ce95a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd4bdd5-1673-4f22-b593-41df8ce95a97.jpg?1",
             "name": "Natural State",
             "text": "Destroy target artifact or enchantment with converted mana cost 3 or less.",
             "colours": [
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "ea3ef362-09de-5323-8502-1f652540d759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456de8f8-f5dc-44fb-81b1-ca653c32be8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456de8f8-f5dc-44fb-81b1-ca653c32be8e.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "ba07abeb-ec3d-5cb4-af04-fc3c35426fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a600b97b-1851-4b1b-a2af-f80e0307c02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a600b97b-1851-4b1b-a2af-f80e0307c02c.jpg?1",
             "name": "Nissa, Voice of Zendikar",
             "text": "+1: Put a 0/1 green Plant creature token onto the battlefield.\n\u22122: Put a +1/+1 counter on each creature you control.\n\u22127: You gain X life and draw X cards, where X is the number of lands you control.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "9a833312-edfc-5c56-a113-064c89c6914d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b263fb-00b5-4050-85e1-cfc4018bb75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b263fb-00b5-4050-85e1-cfc4018bb75d.jpg?1",
             "name": "Nissa's Judgment",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nChoose up to one target creature an opponent controls. Each creature you control with a +1/+1 counter on it deals damage equal to its power to that creature.",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "2beb9411-5d69-59b1-bd71-ba806a0d6a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613513ea-55dd-4ae8-93b2-247e468112a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613513ea-55dd-4ae8-93b2-247e468112a6.jpg?1",
             "name": "Oath of Nissa",
             "text": "When Oath of Nissa enters the battlefield, look at the top three cards of your library. You may reveal a creature, land, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nYou may spend mana as though it were mana of any color to cast planeswalker spells.",
             "colours": [
@@ -4614,7 +4614,7 @@
         },
         {
             "id": "ebb0e013-49e1-55f5-ab3c-434604171f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c8057f-b45b-4f67-90cd-c808b5e9cbfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c8057f-b45b-4f67-90cd-c808b5e9cbfa.jpg?1",
             "name": "Pulse of Murasa",
             "text": "Return target creature or land card from a graveyard to its owner's hand. You gain 6 life.",
             "colours": [
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "cd5bffba-e3e9-568d-bb42-e644a94760e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df4803-b32d-43ae-ac68-b72e45e10b0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df4803-b32d-43ae-ac68-b72e45e10b0c.jpg?1",
             "name": "Saddleback Lagac",
             "text": "When Saddleback Lagac enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "e2090566-f510-5758-8ca3-19f6e03ab1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4736b3-d6ce-4a16-bcb7-67780caeb78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4736b3-d6ce-4a16-bcb7-67780caeb78c.jpg?1",
             "name": "Seed Guardian",
             "text": "Reach\nWhen Seed Guardian dies, put an X/X green Elemental creature token onto the battlefield, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "69d725fd-6e09-587b-b6bd-bcdb425df73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1ff9b-306d-47c3-9334-371e4482370b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1ff9b-306d-47c3-9334-371e4482370b.jpg?1",
             "name": "Sylvan Advocate",
             "text": "Vigilance\nAs long as you control six or more lands, Sylvan Advocate and land creatures you control get +2/+2.",
             "colours": [
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "601e3ea8-641e-53fe-b2eb-97a039a3572e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073e75b-b432-41a5-a71e-d169fecf774f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073e75b-b432-41a5-a71e-d169fecf774f.jpg?1",
             "name": "Tajuru Pathwarden",
             "text": "Vigilance, trample",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "8061e89b-f6e1-5691-9b54-ed5d7be8d490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a1fc4b-ec68-4fd1-af0f-6ccc8c6dee89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a1fc4b-ec68-4fd1-af0f-6ccc8c6dee89.jpg?1",
             "name": "Vines of the Recluse",
             "text": "Target creature gets +1/+2 and gains reach until end of turn. Untap it. (A creature with reach can block creatures with flying.)",
             "colours": [
@@ -4818,7 +4818,7 @@
         },
         {
             "id": "fe343165-b53d-54b0-a97e-4a7ceedd5609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f02bc3-b565-4a38-8313-eb47ff31db8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f02bc3-b565-4a38-8313-eb47ff31db8d.jpg?1",
             "name": "Zendikar Resurgent",
             "text": "Whenever you tap a land for mana, add one mana to your mana pool of any type that land produced. (The types of mana are white, blue, black, red, green, and colorless.)\nWhenever you cast a creature spell, draw a card.",
             "colours": [
@@ -4850,7 +4850,7 @@
         },
         {
             "id": "9c212646-876b-5b14-b23e-04d5983d0e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3931db42-3773-4aae-b6eb-2209e7312f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3931db42-3773-4aae-b6eb-2209e7312f8c.jpg?1",
             "name": "Flayer Drone",
             "text": "Devoid (This card has no color.)\nFirst strike\nWhenever another colorless creature enters the battlefield under your control, target opponent loses 1 life.",
             "colours": [],
@@ -4884,7 +4884,7 @@
         },
         {
             "id": "0812faca-0d90-57c9-bb5f-53223e207038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5bf575-6d09-4cb0-8fe0-8e49d2c39fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5bf575-6d09-4cb0-8fe0-8e49d2c39fd5.jpg?1",
             "name": "Mindmelter",
             "text": "Devoid (This card has no color.)\nMindmelter can't be blocked.\n{3}{C}: Target opponent exiles a card from his or her hand. Activate this ability only any time you could cast a sorcery. ({C} represents colorless mana.)",
             "colours": [],
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "6861bcef-3e68-5cd8-a612-94da5cc99379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e37e2-a4bd-4f90-9191-3125784a3369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e37e2-a4bd-4f90-9191-3125784a3369.jpg?1",
             "name": "Void Grafter",
             "text": "Devoid (This card has no color.)\nFlash (You may cast this spell any time you could cast an instant.)\nWhen Void Grafter enters the battlefield, another target creature you control gains hexproof until end of turn.",
             "colours": [],
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "77a37e8a-1035-5d19-9fd1-a453f82b734f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b5893d-6df6-4cae-ae70-d02d443d1740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b5893d-6df6-4cae-ae70-d02d443d1740.jpg?1",
             "name": "Ayli, Eternal Pilgrim",
             "text": "Deathtouch\n{1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.\n{1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate this ability only if you have at least 10 life more than your starting life total.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "268d267a-9cd2-5b8b-92bc-cb0e35b868a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8811d210-23e2-4318-9730-7ee3b2021c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8811d210-23e2-4318-9730-7ee3b2021c68.jpg?1",
             "name": "Baloth Null",
             "text": "When Baloth Null enters the battlefield, return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "77981902-4770-5656-8fdf-582c237dfe74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544247d-1f8f-443f-a4c4-d8461db28a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544247d-1f8f-443f-a4c4-d8461db28a79.jpg?1",
             "name": "Cliffhaven Vampire",
             "text": "Flying\nWhenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "e45d56d0-f2bc-5f47-98ff-ef9cdd407830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d920b4-81ab-45be-b763-b6114b879357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d920b4-81ab-45be-b763-b6114b879357.jpg?1",
             "name": "Joraga Auxiliary",
             "text": "{4}{G}{W}: Support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "98a3a425-9181-5b4e-b854-c8eda0c9c79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900d3af7-a03f-4173-8a8a-bd146dec9c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900d3af7-a03f-4173-8a8a-bd146dec9c0f.jpg?1",
             "name": "Jori En, Ruin Diver",
             "text": "Whenever you cast your second spell each turn, draw a card.",
             "colours": [
@@ -5143,7 +5143,7 @@
         },
         {
             "id": "1c8c07db-4ce5-5831-b9a6-934b1916bc6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27ff523-0ff3-480d-ae95-ff5e04483e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27ff523-0ff3-480d-ae95-ff5e04483e40.jpg?1",
             "name": "Mina and Denn, Wildborn",
             "text": "You may play an additional land on each of your turns.\n{R}{G}, Return a land you control to its owner's hand: Target creature gains trample until end of turn.",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "7971f30c-a3c4-54a3-9834-9fc5274253b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473fe01-83f6-4432-ab01-f7953d2ca904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473fe01-83f6-4432-ab01-f7953d2ca904.jpg?1",
             "name": "Reflector Mage",
             "text": "When Reflector Mage enters the battlefield, return target creature an opponent controls to its owner's hand. That creature's owner can't cast spells with the same name as that creature until your next turn.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "0d752b8a-98a5-5be1-acee-086712880731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a52252-46b6-42e5-8cb5-c4f823cd0bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a52252-46b6-42e5-8cb5-c4f823cd0bf5.jpg?1",
             "name": "Relentless Hunter",
             "text": "{1}{R}{G}: Relentless Hunter gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -5256,7 +5256,7 @@
         },
         {
             "id": "9a3d9f28-9497-5cf4-879d-c74b070f0ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba1b45-d8ae-42fd-b30f-c904640ab173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba1b45-d8ae-42fd-b30f-c904640ab173.jpg?1",
             "name": "Stormchaser Mage",
             "text": "Flying, haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "e3bbdb4f-719d-5740-81f7-40e0607e6056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47bcb1-b028-4be8-9710-7c390cb984ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47bcb1-b028-4be8-9710-7c390cb984ce.jpg?1",
             "name": "Weapons Trainer",
             "text": "Other creatures you control get +1/+0 as long as you control an Equipment.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "df7f1a01-8d94-52ef-b028-17744fd980fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3d19ff-b618-4b07-99a8-ea6e7ee72459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3d19ff-b618-4b07-99a8-ea6e7ee72459.jpg?1",
             "name": "Bone Saw",
             "text": "Equipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "b3442430-cf71-5c56-b072-6ee3045e192c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521ee576-5a51-4353-af38-c461f05d66ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521ee576-5a51-4353-af38-c461f05d66ce.jpg?1",
             "name": "Captain's Claws",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature attacks, put a 1/1 white Kor Ally creature token onto the battlefield tapped and attacking.\nEquip {1}",
             "colours": [],
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "55b003c0-6916-5323-8b6c-ac15e4b8bccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acbc14b-89e6-44ef-ae12-e2049adc06b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acbc14b-89e6-44ef-ae12-e2049adc06b1.jpg?1",
             "name": "Captain's Claws",
             "text": "",
             "colours": [],
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "4766fd45-18f2-5b60-8243-e33b38e76b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e54603-af67-497f-afe0-88cfa4d00095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e54603-af67-497f-afe0-88cfa4d00095.jpg?1",
             "name": "Chitinous Cloak",
             "text": "Equipped creature gets +2/+2 and has menace. (It can't be blocked except by two or more creatures.)\nEquip {3}",
             "colours": [],
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "8623a0ae-1901-5191-a3e7-4c2b22a91ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f827f92-1df6-4fd0-aa61-ec2e53476f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f827f92-1df6-4fd0-aa61-ec2e53476f9c.jpg?1",
             "name": "Hedron Crawler",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)",
             "colours": [],
@@ -5485,7 +5485,7 @@
         },
         {
             "id": "e8082b2b-2708-5251-bf63-3fb41c33afe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6618a854-7d9c-4e57-b959-4c0259cb4d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6618a854-7d9c-4e57-b959-4c0259cb4d97.jpg?1",
             "name": "Seer's Lantern",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{2}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "799a21a6-139f-5373-b91a-55d3a8e0e8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5b78f5-6a49-4433-a42b-5abf5ea60919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5b78f5-6a49-4433-a42b-5abf5ea60919.jpg?1",
             "name": "Stoneforge Masterwork",
             "text": "Equipped creature gets +1/+1 for each other creature you control that shares a creature type with it.\nEquip {2}",
             "colours": [],
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "d9a6d0b2-14c4-5afd-8b59-224cee962374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c90f49-d1eb-420e-bfb6-b834a496860d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c90f49-d1eb-420e-bfb6-b834a496860d.jpg?1",
             "name": "Strider Harness",
             "text": "Equipped creature gets +1/+1 and has haste.\nEquip {1}",
             "colours": [],
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "7abe3511-24fa-5dd2-b1f9-ddef75132d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949f41a0-9082-4682-88b8-a29fbcb48d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949f41a0-9082-4682-88b8-a29fbcb48d5d.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "6a1fa2aa-d923-5183-aa8a-a74f7252986c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7043e193-8051-4f1b-9633-9c1f250d3607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7043e193-8051-4f1b-9633-9c1f250d3607.jpg?1",
             "name": "Corrupted Crossroads",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}, Pay 1 life: Add one mana of any color to your mana pool. Spend this mana only to cast a spell with devoid.",
             "colours": [],
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "6a4c5895-45b8-57eb-af4a-a00aac5d47ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d491c13c-43e3-4ca3-b888-4edd34dfe14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d491c13c-43e3-4ca3-b888-4edd34dfe14a.jpg?1",
             "name": "Crumbling Vestige",
             "text": "Crumbling Vestige enters the battlefield tapped.\nWhen Crumbling Vestige enters the battlefield, add one mana of any color to your mana pool.\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)",
             "colours": [],
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "925a248d-8407-589d-b56b-8ca45e039f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef11b54-205a-48e9-92d0-5d416be869ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef11b54-205a-48e9-92d0-5d416be869ef.jpg?1",
             "name": "Hissing Quagmire",
             "text": "Hissing Quagmire enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.\n{1}{B}{G}: Hissing Quagmire becomes a 2/2 black and green Elemental creature with deathtouch until end of turn. It's still a land.",
             "colours": [],
@@ -5691,7 +5691,7 @@
         },
         {
             "id": "711dc524-f104-5a0c-ac6b-de5dc4ca8e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08c317-6f2d-47e3-ab5b-8af73fd3e404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08c317-6f2d-47e3-ab5b-8af73fd3e404.jpg?1",
             "name": "Holdout Settlement",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5719,7 +5719,7 @@
         },
         {
             "id": "bb39ca73-b1a8-5e0b-9472-bd221a33ede4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5bedf1-92b6-465c-afc2-ce8e150a5e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5bedf1-92b6-465c-afc2-ce8e150a5e57.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "1b26b32d-fc88-5bdd-9914-b14f90fdfac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbea2b5-eed3-464b-9d5c-9591f309f298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbea2b5-eed3-464b-9d5c-9591f309f298.jpg?1",
             "name": "Mirrorpool",
             "text": "Mirrorpool enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}{C}, {T}, Sacrifice Mirrorpool: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}{C}, {T}, Sacrifice Mirrorpool: Put a token onto the battlefield that's a copy of target creature you control.",
             "colours": [],
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "cde10a13-c29d-5064-8950-9c755bffacf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73700c-fa62-42be-aaca-5f8a50af20db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73700c-fa62-42be-aaca-5f8a50af20db.jpg?1",
             "name": "Needle Spires",
             "text": "Needle Spires enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.\n{2}{R}{W}: Needle Spires becomes a 2/1 red and white Elemental creature with double strike until end of turn. It's still a land.",
             "colours": [],
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "efa59d83-f63e-504e-92ab-8d6bc8c9cbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed86e5-5631-401b-8820-9685f8296134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed86e5-5631-401b-8820-9685f8296134.jpg?1",
             "name": "Ruins of Oran-Rief",
             "text": "Ruins of Oran-Rief enters the battlefield tapped.\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}: Put a +1/+1 counter on target colorless creature that entered the battlefield this turn.",
             "colours": [],
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "5b34a47a-af85-5ebb-9f9a-e253ef389863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd42576b-9de5-4d77-9d30-1ef5b5a4fd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd42576b-9de5-4d77-9d30-1ef5b5a4fd73.jpg?1",
             "name": "Sea Gate Wreckage",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{2}{C}, {T}: Draw a card. Activate this ability only if you have no cards in hand.",
             "colours": [],
@@ -5865,7 +5865,7 @@
         },
         {
             "id": "ce3c4606-269d-5b55-8fa2-bb7eadebe7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479a246-21ac-490a-aefb-6ed72aabdb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479a246-21ac-490a-aefb-6ed72aabdb88.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "82557838-9203-5d7b-9b16-989746c677a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d05ff7-f071-4eb3-b10a-203741abdf10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d05ff7-f071-4eb3-b10a-203741abdf10.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "3f509c0c-13a5-5f74-8c0e-c0edd94008c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42787d2b-3f9d-4c29-9ece-e65544eb1340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42787d2b-3f9d-4c29-9ece-e65544eb1340.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5958,7 +5958,7 @@
         },
         {
             "id": "43a79012-3276-58d6-8556-a43e5845d54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87db92c1-ac17-4e32-840e-7ccbcef31bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87db92c1-ac17-4e32-840e-7ccbcef31bc6.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "8342b862-3a09-5c07-8697-3b4e235566e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0ee251-6c79-499b-8366-c281c989b061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0ee251-6c79-499b-8366-c281c989b061.jpg?1",
             "name": "Wandering Fumarole",
             "text": "Wandering Fumarole enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.\n{2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with \"{0}: Switch this creature's power and toughness until end of turn.\" It's still a land.",
             "colours": [],
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "b14af286-9338-5c24-9715-c4c9479e8d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7019912c-bd9b-4b96-9388-400794909aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7019912c-bd9b-4b96-9388-400794909aa1.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "8da5d0bf-9f7c-5d8b-89a3-2fa3055cf7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc070d3-4b83-4684-9caf-063e5c473a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc070d3-4b83-4684-9caf-063e5c473a77.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "7015e402-ad21-5e10-9681-afc52e43a0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b215fe-0d97-4ca1-9490-174220fd454b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b215fe-0d97-4ca1-9490-174220fd454b.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "d2c827be-6188-558c-ae9d-317a50436ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60682c00-c661-4a9d-8326-f3f014a04e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60682c00-c661-4a9d-8326-f3f014a04e3e.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "5475891d-3ff7-5af1-9f29-318cd6231bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03edf14-3495-4f61-ad73-f16e9456472c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03edf14-3495-4f61-ad73-f16e9456472c.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "a6be99bf-0852-56eb-a8bf-9064c3303bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88da33f-a944-4cc4-978e-3858c2e17e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88da33f-a944-4cc4-978e-3858c2e17e3a.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6213,7 +6213,7 @@
         },
         {
             "id": "e1fee3c2-87e9-5c7b-bd2e-c038c4a28165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e69ee5-ea72-4f0b-91fe-152b1459e318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e69ee5-ea72-4f0b-91fe-152b1459e318.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "47209d9f-c753-5476-afe1-e7451b5fdf9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2f495f-3b50-4b59-a2aa-d33c1767cf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2f495f-3b50-4b59-a2aa-d33c1767cf7c.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "eeab57a1-7941-5786-b834-0b974f173877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e91066-63ee-40f7-aa69-0603b61ea49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e91066-63ee-40f7-aa69-0603b61ea49e.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "5e22c8ed-9cfc-5244-aaa7-d49109b2b414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b7443e-7eb2-4fcb-8114-23bad3b3bf51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b7443e-7eb2-4fcb-8114-23bad3b3bf51.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "bd954ba2-c399-5d83-9c8b-c0503991e723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f407ef-2b08-45e9-a45e-128cf0a63839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f407ef-2b08-45e9-a45e-128cf0a63839.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "4f38d11a-7a5e-54fd-b4ca-04ff6873b36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bde78b-98d1-4864-899b-fc2f945ce06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bde78b-98d1-4864-899b-fc2f945ce06b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "0bfa7d0c-9a5d-58a2-aa93-ffe0f6aa1f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f27f7-0248-4c04-8022-41073966e4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f27f7-0248-4c04-8022-41073966e4d8.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "9cd481a2-eed9-5d16-a789-6228b9fbc5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db67bc06-b6c9-49a0-beef-4d35842497cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db67bc06-b6c9-49a0-beef-4d35842497cb.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "5d511409-a4ae-50f9-8cc7-c7fd0ec6fda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8501a910-e181-4f85-ad34-d2a099257148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8501a910-e181-4f85-ad34-d2a099257148.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/ONE.json
+++ b/Assets/Resources/Sets/ONE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7966a171-4458-5fb1-aa99-b8486938798a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd8dd4e-6892-49d7-8fae-97d04f9f6c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd8dd4e-6892-49d7-8fae-97d04f9f6c84.jpg?1",
             "name": "Against All Odds",
             "text": "Choose one or both \u2014\n\u2022 Exile target artifact or creature you control, then return it to the battlefield under its owner's control.\n\u2022 Return target artifact or creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "ec921ff1-d254-5831-bd17-d09f2ca025dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04baad61-1b51-4602-9e33-0de4a9f34793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04baad61-1b51-4602-9e33-0de4a9f34793.jpg?1",
             "name": "Annex Sentry",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Annex Sentry enters the battlefield, exile target artifact or creature an opponent controls with mana value 3 or less until Annex Sentry leaves the battlefield.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "95c002c0-293c-57de-8a07-b96b20ee146e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a973487-5def-4771-bb77-5748cbd2f469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a973487-5def-4771-bb77-5748cbd2f469.jpg?1",
             "name": "Apostle of Invasion",
             "text": "Flying\nCorrupted \u2014 As long as an opponent has three or more poison counters, Apostle of Invasion has double strike.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "4c7e3e56-53ff-5ae8-812c-e685dc7a5a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ef3cfa-63e6-4450-af65-da7f05d13cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ef3cfa-63e6-4450-af65-da7f05d13cf3.jpg?1",
             "name": "Basilica Shepherd",
             "text": "Flying\nWhen Basilica Shepherd enters the battlefield, create two 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by them also get a poison counter.)",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "c6ab8992-3cd8-5aea-a843-bccd39ce53c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd8d2b8-4caf-4349-9538-0dfbebf0ce1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd8d2b8-4caf-4349-9538-0dfbebf0ce1b.jpg?1",
             "name": "Bladed Ambassador",
             "text": "Bladed Ambassador enters the battlefield with an oil counter on it.\n{1}, Remove an oil counter from Bladed Ambassador: Bladed Ambassador gains indestructible until end of turn.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "2ebe9fe7-32ff-5750-9051-e2e884836399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42060b9d-de58-485e-817a-1e64839943aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42060b9d-de58-485e-817a-1e64839943aa.jpg?1",
             "name": "Charge of the Mites",
             "text": "Choose one \u2014\n\u2022 Charge of the Mites deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Create two 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by them also get a poison counter.)",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "98301b7b-e585-515d-9d05-19b618ee103b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb29a69-3e42-4268-8026-f01072d7b56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb29a69-3e42-4268-8026-f01072d7b56c.jpg?1",
             "name": "Compleat Devotion",
             "text": "Target creature you control gets +2/+2 until end of turn. If that creature has toxic, draw a card.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "64471693-5444-5652-951b-7373c253f66a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aace4c44-7250-414b-aac4-df042a1e2e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aace4c44-7250-414b-aac4-df042a1e2e1d.jpg?1",
             "name": "Crawling Chorus",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Crawling Chorus dies, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "194fcbca-3f8a-512c-9ebc-6c5fe57a8736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444440-a9e6-4583-a289-9f0571a98093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444440-a9e6-4583-a289-9f0571a98093.jpg?1",
             "name": "Duelist of Deep Faith",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nAs long as it's your turn, Duelist of Deep Faith has first strike.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "0da82b07-e6e4-5679-a50b-fe268459bd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dcab01-1d13-4dfc-ae2f-fbaa3dd35087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dcab01-1d13-4dfc-ae2f-fbaa3dd35087.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "a4b710c3-6a4e-596e-8c92-bcffae689084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905f0dd4-0197-45f8-8e7f-396d6dcef600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905f0dd4-0197-45f8-8e7f-396d6dcef600.jpg?1",
             "name": "The Eternal Wanderer",
             "text": "No more than one creature can attack The Eternal Wanderer each combat.\n+1: Exile up to one target artifact or creature. Return that card to the battlefield under its owner's control at the beginning of that player's next end step.\n0: Create a 2/2 white Samurai creature token with double strike.\n\u22124: For each player, choose a creature that player controls. Each player sacrifices all creatures they control not chosen this way.",
             "colours": [
@@ -398,7 +398,7 @@
         },
         {
             "id": "76088f0c-f5d2-560e-a129-0d1b47b8dce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134aecf0-dc48-4fb3-8c8b-4e5272077856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134aecf0-dc48-4fb3-8c8b-4e5272077856.jpg?1",
             "name": "Flensing Raptor",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Flensing Raptor enters the battlefield, another target creature you control with toxic gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -433,7 +433,7 @@
         },
         {
             "id": "048f38ad-7d42-50ce-b6d5-e43f677f4299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4057210-ef07-4496-94c8-95c3b807c23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4057210-ef07-4496-94c8-95c3b807c23c.jpg?1",
             "name": "Goldwarden's Helm",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +0/+1.\nEquip {1}{W} ({1}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -467,7 +467,7 @@
         },
         {
             "id": "cbbc084c-b6a2-5e55-b5de-78de7ebac743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c498dbf9-c68c-400c-9349-c3c3fc8efcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c498dbf9-c68c-400c-9349-c3c3fc8efcae.jpg?1",
             "name": "Hexgold Hoverwings",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature has flying.\nCreatures you control that are equipped get +1/+0.\nEquip {2}{W}",
             "colours": [
@@ -501,7 +501,7 @@
         },
         {
             "id": "c7bbfb6a-0674-5ba7-b732-004452611005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3cf4c4f-bda6-454c-991d-429c0dca0e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3cf4c4f-bda6-454c-991d-429c0dca0e85.jpg?1",
             "name": "Incisor Glider",
             "text": "Flying\nCorrupted \u2014 Whenever Incisor Glider attacks, if an opponent has three or more poison counters, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -537,7 +537,7 @@
         },
         {
             "id": "4755c4b0-fa5a-5910-b893-4de8428705e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d051bfc7-b402-444d-896e-c3a9562cdb0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d051bfc7-b402-444d-896e-c3a9562cdb0d.jpg?1",
             "name": "Indoctrination Attendant",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Indoctrination Attendant enters the battlefield, you may return another permanent you control to its owner's hand. If you do, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "7205a8ce-5119-5095-84aa-46853b1bd9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f03d6bf-cbba-4ad7-8cec-065a47f03dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f03d6bf-cbba-4ad7-8cec-065a47f03dbe.jpg?1",
             "name": "Infested Fleshcutter",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by it also get a poison counter.)\nEquip {2}{W}",
             "colours": [
@@ -606,7 +606,7 @@
         },
         {
             "id": "f1c443b6-a0cd-551f-9e31-cd9d1c1efccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00ea7bb-705b-4669-bb2a-560bed04b14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00ea7bb-705b-4669-bb2a-560bed04b14a.jpg?1",
             "name": "Jawbone Duelist",
             "text": "Double strike\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "2b4c0cce-eda8-5db9-9677-20914c4701b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945d283d-4592-485f-808a-6e5a721f3cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945d283d-4592-485f-808a-6e5a721f3cf7.jpg?1",
             "name": "Kemba, Kha Enduring",
             "text": "Whenever Kemba, Kha Enduring or another Cat enters the battlefield under your control, attach up to one target Equipment you control to that creature.\nEquipped creatures you control get +1/+1.\n{3}{W}{W}: Create a 2/2 white Cat creature token.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "7164f4af-364f-508f-b066-4a52e4095173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ae13df-670e-49a0-99b0-baf908ac9eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ae13df-670e-49a0-99b0-baf908ac9eb4.jpg?1",
             "name": "Leonin Lightbringer",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAs long as Leonin Lightbringer is equipped, it gets +1/+1.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "ce067242-e0c0-5d99-bc04-044883a6fcec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a707d-4090-4a74-91aa-60fbd8a4ae96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a707d-4090-4a74-91aa-60fbd8a4ae96.jpg?1",
             "name": "Mandible Justiciar",
             "text": "Lifelink\nWhenever another artifact enters the battlefield under your control, Mandible Justiciar gets +1/+1 until end of turn.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "59e8cbcd-d0cf-5950-bd16-54b89aada7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3006ea5a-5391-41eb-b0c8-092741dca2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3006ea5a-5391-41eb-b0c8-092741dca2eb.jpg?1",
             "name": "Mirran Bardiche",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +2/+1 and has vigilance.\nEquip {3}{W} ({3}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "9082dc4a-b3d5-599d-80e5-0fd052d19e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296a455-21d5-498e-9029-2bdf0da855a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296a455-21d5-498e-9029-2bdf0da855a8.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n{1}{PW}{PW}, Sacrifice two other artifacts and/or creatures: Put an indestructible counter on Mondrak, Glory Dominus. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -827,7 +827,7 @@
         },
         {
             "id": "7d6c732b-3b16-52d4-b2c1-9ab7d00d6e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeebc0ab-89fb-47d5-a20f-8f1fe5e3c149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeebc0ab-89fb-47d5-a20f-8f1fe5e3c149.jpg?1",
             "name": "Norn's Wellspring",
             "text": "Whenever a creature you control dies, scry 1 and put an oil counter on Norn's Wellspring.\n{1}, {T}, Remove two oil counters from Norn's Wellspring: Draw a card.",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "5c525b35-f1fb-5c4a-be30-bb27cb85a7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c938a0f-531c-4293-a89c-c7440d5acc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c938a0f-531c-4293-a89c-c7440d5acc5d.jpg?1",
             "name": "Orthodoxy Enforcer",
             "text": "Vigilance\nOrthodoxy Enforcer gets +2/+0 as long as you control two or more artifacts.",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "d2712fe8-6850-52ad-b318-6f72140e766f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da03224-c1af-438f-96c2-b0e41e1070b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da03224-c1af-438f-96c2-b0e41e1070b7.jpg?1",
             "name": "Ossification",
             "text": "Enchant basic land you control\nWhen Ossification enters the battlefield, exile target creature or planeswalker an opponent controls until Ossification leaves the battlefield.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "ec217e50-10f3-507d-b2ae-7ef2315b6937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18780ce-add4-4346-8028-4bc3b4099d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18780ce-add4-4346-8028-4bc3b4099d71.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "Flying\nIf damage would be dealt to Phyrexian Vindicator, prevent that damage. When damage is prevented this way, Phyrexian Vindicator deals that much damage to any other target.",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "a38930e1-f11d-5674-8c61-91a2fc1c09eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee69a1f-aeed-4eb4-8987-fa720fc99715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee69a1f-aeed-4eb4-8987-fa720fc99715.jpg?1",
             "name": "Planar Disruption",
             "text": "Enchant artifact, creature, or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1005,7 +1005,7 @@
         },
         {
             "id": "610c9cb6-2b51-5307-8e81-718d4c723d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472a635a-a581-4c00-89d6-464f30887944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472a635a-a581-4c00-89d6-464f30887944.jpg?1",
             "name": "Plated Onslaught",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nCreatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "e36f72ed-cf67-54c0-a81f-ab9a9a557d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409bacf-b728-473d-bf9b-41fdf364e783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409bacf-b728-473d-bf9b-41fdf364e783.jpg?1",
             "name": "Porcelain Zealot",
             "text": "At the beginning of combat on your turn, target creature you control gets +1/+1 until end of turn. If that creature has toxic, instead it gets +2/+2 until end of turn.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "a49edb48-2529-551b-9402-a7ce753b3f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc4b5ca-557e-4465-9725-9e7a15590258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc4b5ca-557e-4465-9725-9e7a15590258.jpg?1",
             "name": "Resistance Reunited",
             "text": "Target creature gets +2/+2 until end of turn.\nEquipped creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -1104,7 +1104,7 @@
         },
         {
             "id": "9d8c43ef-8e60-5c20-8cc4-9407f5995f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebad4fcc-4f78-48dc-b236-c78c22edc1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebad4fcc-4f78-48dc-b236-c78c22edc1e9.jpg?1",
             "name": "Sinew Dancer",
             "text": "{3}{W}, {T}: Tap target creature.\nCorrupted \u2014 {W}, {T}: Tap target creature. Activate only if an opponent has three or more poison counters.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "aed49ca5-02ad-54b0-8c4a-0b20f104e7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b565da-a49b-479c-b0c4-8ff3dd20cc0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b565da-a49b-479c-b0c4-8ff3dd20cc0b.jpg?1",
             "name": "Skrelv, Defector Mite",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nSkrelv, Defector Mite can't block.\n{PW}, {T}: Choose a color. Another target creature you control gains toxic 1 and hexproof from that color until end of turn. It can't be blocked by creatures of that color this turn. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "930b0d2e-10dc-5fd7-a510-feaaeeaa7ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd77ec-fc81-41d5-934f-c3dd844cb053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd77ec-fc81-41d5-934f-c3dd844cb053.jpg?1",
             "name": "Skrelv's Hive",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"\nCorrupted \u2014 As long as an opponent has three or more poison counters, creatures you control with toxic have lifelink.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "465e5154-c390-5e1d-b1ce-34027792b5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c740d-260d-4dfa-b6b3-9a1527538f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c740d-260d-4dfa-b6b3-9a1527538f89.jpg?1",
             "name": "Swooping Lookout",
             "text": "Flying, vigilance",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "fdbc75d9-2c3b-5839-a231-8952c8867a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0b3308-9c0b-4461-9094-38deec20e1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0b3308-9c0b-4461-9094-38deec20e1bc.jpg?1",
             "name": "Vanish into Eternity",
             "text": "This spell costs {3} more to cast if it targets a creature.\nExile target nonland permanent.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "00c63beb-6c64-5947-88a6-066e09a11a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d8d87-e32f-4ad9-8d72-d1b88cd14510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d8d87-e32f-4ad9-8d72-d1b88cd14510.jpg?1",
             "name": "Veil of Assimilation",
             "text": "Whenever Veil of Assimilation or another artifact enters the battlefield under your control, target creature you control gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -1317,7 +1317,7 @@
         },
         {
             "id": "4426392e-513e-5289-9d7f-174fc159c0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff13d77-8133-4328-b91e-efce229bc331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff13d77-8133-4328-b91e-efce229bc331.jpg?1",
             "name": "White Sun's Twilight",
             "text": "You gain X life. Create X 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" If X is 5 or more, destroy all other creatures. (Players dealt combat damage by a creature with toxic 1 also get a poison counter.)",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "8d1034ad-59ec-574c-99dd-c1acbd7ad483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a419ba1-7bd3-48e3-8f88-d9f833b25d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a419ba1-7bd3-48e3-8f88-d9f833b25d6d.jpg?1",
             "name": "Zealot's Conviction",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nCorrupted \u2014 As long as an opponent has three or more poison counters, enchanted creature gets an additional +1/+0 and has first strike.",
             "colours": [
@@ -1385,7 +1385,7 @@
         },
         {
             "id": "bade33e1-a75b-59ff-86ff-46d937e242f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57551332-e2a4-4e6a-9bd8-e3a9baafcd17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57551332-e2a4-4e6a-9bd8-e3a9baafcd17.jpg?1",
             "name": "Aspirant's Ascent",
             "text": "Until end of turn, target creature gets +1/+3 and gains flying and toxic 1. (Players dealt combat damage by that creature also get a poison counter.)",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "018bcf55-3b74-5331-8167-028b41f9e228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66988ca-29d5-45ea-8d68-c8e0e4c3ffb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66988ca-29d5-45ea-8d68-c8e0e4c3ffb1.jpg?1",
             "name": "Atmosphere Surgeon",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Atmosphere Surgeon.\nRemove an oil counter from Atmosphere Surgeon: Target creature gains flying until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "0523e6fd-35f5-511a-b124-0706f83321f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277aeb73-4c7c-4132-b9f9-55181d57e75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277aeb73-4c7c-4132-b9f9-55181d57e75d.jpg?1",
             "name": "Blade of Shared Souls",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nWhenever Blade of Shared Souls becomes attached to a creature, for as long as Blade of Shared Souls remains attached to it, you may have that creature become a copy of another target creature you control.\nEquip {2}",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "790a4b44-02cc-51a4-b763-a17d83a516cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a836e6b-6854-4f6f-bc78-2da1fd4dd224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a836e6b-6854-4f6f-bc78-2da1fd4dd224.jpg?1",
             "name": "Blue Sun's Twilight",
             "text": "Gain control of target creature with mana value X or less. If X is 5 or more, create a token that's a copy of that creature.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "f3293a7f-1700-568a-b2c8-73f450f93758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d9d26-0c76-4a09-aa25-b32854e70c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d9d26-0c76-4a09-aa25-b32854e70c0b.jpg?1",
             "name": "Bring the Ending",
             "text": "Counter target spell unless its controller pays {2}.\nCorrupted \u2014 Counter that spell instead if its controller has three or more poison counters.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "688e19c3-7a61-57dd-999f-e44e38efb17a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94378a2-cbde-4adf-b889-43e90fc6ba28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94378a2-cbde-4adf-b889-43e90fc6ba28.jpg?1",
             "name": "Chrome Prowler",
             "text": "Flash\nWhen Chrome Prowler enters the battlefield, tap target creature an opponent controls.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "86b8af57-606b-53c7-94cb-a035ec9117f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f932ddd3-beb4-4dc8-8c15-e1c9c2276986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f932ddd3-beb4-4dc8-8c15-e1c9c2276986.jpg?1",
             "name": "Distorted Curiosity",
             "text": "Corrupted \u2014 This spell costs {2} less to cast if an opponent has three or more poison counters.\nDraw two cards.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "71d990cd-9777-5b87-9eb4-4fab7d2af9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a2fcc9-2317-48a1-a5eb-234fb3300364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a2fcc9-2317-48a1-a5eb-234fb3300364.jpg?1",
             "name": "Encroaching Mycosynth",
             "text": "Nonland permanents you control are artifacts in addition to their other types. The same is true for permanent spells you control and nonland permanent cards you own that aren't on the battlefield.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "0b382265-73df-5d46-b2b1-b802d97075f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611497d2-83df-4c69-bbeb-6a807c686bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611497d2-83df-4c69-bbeb-6a807c686bc4.jpg?1",
             "name": "Escaped Experiment",
             "text": "Whenever Escaped Experiment attacks, target creature an opponent controls gets -X/-0 until end of turn, where X is the number of artifacts you control.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "7470cbb7-3734-58d2-a2b5-fdaf47c7a604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e508ae5d-ffb5-4480-be90-a4394954b559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e508ae5d-ffb5-4480-be90-a4394954b559.jpg?1",
             "name": "Experimental Augury",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "2baf2518-4295-5ef4-a2ec-c952548f68ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4246b-ff59-44b2-acff-c0bb6e4cd6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4246b-ff59-44b2-acff-c0bb6e4cd6ac.jpg?1",
             "name": "Eye of Malcator",
             "text": "When Eye of Malcator enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\nWhenever another artifact enters the battlefield under your control, Eye of Malcator becomes a 4/4 Phyrexian Eye artifact creature until end of turn.",
             "colours": [
@@ -1758,7 +1758,7 @@
         },
         {
             "id": "cd298f35-d14b-52ba-90da-af4d97c3b2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272c9888-ef13-4d47-a4bc-f5239b357a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272c9888-ef13-4d47-a4bc-f5239b357a1b.jpg?1",
             "name": "Font of Progress",
             "text": "Font of Progress enters the battlefield with two oil counters on it.\n{3}, {T}: Target player mills X cards, where X is the number of oil counters on Font of Progress.",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "0ac734f5-d42e-55ad-b38b-9cae1a9d00da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63517062-77da-4b60-aa24-f91553a81bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63517062-77da-4b60-aa24-f91553a81bed.jpg?1",
             "name": "Gitaxian Anatomist",
             "text": "When Gitaxian Anatomist enters the battlefield, you may tap it. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "c5c9e029-f09a-5152-b858-d7eedb2f486d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5e95f8-c04d-405f-bba4-e83a8f6bf463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5e95f8-c04d-405f-bba4-e83a8f6bf463.jpg?1",
             "name": "Gitaxian Raptor",
             "text": "Flying\nGitaxian Raptor enters the battlefield with three oil counters on it.\nRemove an oil counter from Gitaxian Raptor: Gitaxian Raptor gets +1/-1 until end of turn.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "28d82030-1f59-5b11-b377-f2f220845abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22aaaec-bad5-43e9-8e92-9c4bde95fcfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22aaaec-bad5-43e9-8e92-9c4bde95fcfd.jpg?1",
             "name": "Glistener Seer",
             "text": "Glistener Seer enters the battlefield with three oil counters on it.\n{T}, Remove an oil counter from Glistener Seer: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "8959a8a8-7e7f-528b-9bfa-bb4fb81a0237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f516ee6-8f7b-40b2-82e5-9c4ea3e0a355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f516ee6-8f7b-40b2-82e5-9c4ea3e0a355.jpg?1",
             "name": "Ichor Synthesizer",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Ichor Synthesizer.\nAs long as Ichor Synthesizer has four or more oil counters on it, it gets +2/+0 and can't be blocked.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "42f5939f-4a62-5927-8b8b-c55f762b2fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c093ce0-2561-4847-ab58-f6f1650d743e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c093ce0-2561-4847-ab58-f6f1650d743e.jpg?1",
             "name": "Ichormoon Gauntlet",
             "text": "Planeswalkers you control have \"0: Proliferate\" and \"\u201312: Take an extra turn after this one.\"\nWhenever you cast a noncreature spell, choose a counter on target permanent. Put an additional counter of that kind on that permanent.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "7db75465-cffb-5742-a5b0-075766b2584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e6a8d1-ae75-45bd-af62-9a622620cb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e6a8d1-ae75-45bd-af62-9a622620cb5c.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "Compleated ({PU} can be paid with {U} or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Until your next turn, up to one target creature gets -3/-0.\n\u22122: Target player mills three cards. Then if a graveyard has twenty or more cards in it, you draw three cards. Otherwise, you draw a card.\n\u2212X: Target player mills three times X cards.",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "e6edc6de-0e72-5810-81e2-2e823ff06e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a7e5ff-ba81-4b45-933e-0ac747525ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a7e5ff-ba81-4b45-933e-0ac747525ab8.jpg?1",
             "name": "Malcator's Watcher",
             "text": "Flying, vigilance\nWhen Malcator's Watcher dies, draw a card.",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "9f2d52b0-51b8-5e1f-ba60-58c5b6238109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d392b2-1dac-432d-930c-66b238f7512b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d392b2-1dac-432d-930c-66b238f7512b.jpg?1",
             "name": "Meldweb Curator",
             "text": "When Meldweb Curator enters the battlefield, put up to one target instant or sorcery card from your graveyard on top of your library.",
             "colours": [
@@ -2077,7 +2077,7 @@
         },
         {
             "id": "4bac64f0-c950-5182-b398-94afaea8e192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efd9b5-05e5-440f-b28c-658e461cf644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efd9b5-05e5-440f-b28c-658e461cf644.jpg?1",
             "name": "Meldweb Strider",
             "text": "Vigilance\nMeldweb Strider enters the battlefield with an oil counter on it.\nRemove an oil counter from Meldweb Strider: It becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2111,7 +2111,7 @@
         },
         {
             "id": "031bcda4-05fc-5ceb-bd2f-11a110455f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf28c75d-1fb3-44cc-b651-5b2830e22add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf28c75d-1fb3-44cc-b651-5b2830e22add.jpg?1",
             "name": "Mercurial Spelldancer",
             "text": "Mercurial Spelldancer can't be blocked.\nWhenever you cast a noncreature spell, put an oil counter on Mercurial Spelldancer.\nWhenever Mercurial Spelldancer deals combat damage to a player, you may remove two oil counters from it. If you do, when you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "7556c708-8c3a-5965-8e82-9f62dede5c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28e27-78aa-48b1-96fa-edca1fbcfb77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28e27-78aa-48b1-96fa-edca1fbcfb77.jpg?1",
             "name": "Mesmerizing Dose",
             "text": "Enchant creature\nWhen Mesmerizing Dose enters the battlefield, tap enchanted creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "ebe7cdaa-e84e-5a91-9720-d81942ddec11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4ad1cb-4bbb-4485-b322-0b003f06d034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4ad1cb-4bbb-4485-b322-0b003f06d034.jpg?1",
             "name": "Mindsplice Apparatus",
             "text": "Flash\nAt the beginning of your upkeep, put an oil counter on Mindsplice Apparatus.\nInstant and sorcery spells you cast cost {1} less to cast for each oil counter on Mindsplice Apparatus.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "a4134fde-a36b-535d-8072-69e9e58b392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360ca37b-5bbd-4923-a493-7674786a36af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360ca37b-5bbd-4923-a493-7674786a36af.jpg?1",
             "name": "Minor Misstep",
             "text": "Counter target spell with mana value 1 or less.",
             "colours": [
@@ -2248,7 +2248,7 @@
         },
         {
             "id": "867970b6-629d-576b-ad79-2e012ebee781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac625f30-ed91-4b21-ada8-aaa5b2ad79b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac625f30-ed91-4b21-ada8-aaa5b2ad79b8.jpg?1",
             "name": "Prologue to Phyresis",
             "text": "Each opponent gets a poison counter.\nDraw a card.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "0b198323-715c-5062-a9ac-4d996ee5472f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad0e96a-b4cc-4439-aab9-731a1036145d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad0e96a-b4cc-4439-aab9-731a1036145d.jpg?1",
             "name": "Quicksilver Fisher",
             "text": "Flying\nWhen Quicksilver Fisher enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -2318,7 +2318,7 @@
         },
         {
             "id": "b584cd9e-b373-576e-8ede-b8a79a58df7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ce5296-f28f-4105-9c79-b9c63ea720e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ce5296-f28f-4105-9c79-b9c63ea720e7.jpg?1",
             "name": "Reject Imperfection",
             "text": "Counter target spell. If that spell's mana value was 3 or less, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2350,7 +2350,7 @@
         },
         {
             "id": "97d2d04b-7491-5a02-8389-9a0712958e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326bff1-5370-4817-8370-6da87a061058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326bff1-5370-4817-8370-6da87a061058.jpg?1",
             "name": "Serum Snare",
             "text": "Return target nonland permanent to its owner's hand. If that permanent had mana value 3 or less, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "c25610de-84ad-538a-a0e0-80529aa1616f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa20112-2955-439d-8802-3a228ba0832e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa20112-2955-439d-8802-3a228ba0832e.jpg?1",
             "name": "Tamiyo's Immobilizer",
             "text": "Tamiyo's Immobilizer enters the battlefield with four oil counters on it.\n{T}, Remove an oil counter from Tamiyo's Immobilizer: Tap target artifact or creature.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "8ae50d88-6d45-5a2d-bb90-790089ccb4b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb2d01-9a94-410c-8ab7-ca1b404ab5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb2d01-9a94-410c-8ab7-ca1b404ab5f0.jpg?1",
             "name": "Tamiyo's Logbook",
             "text": "{5}{U}, {T}: Draw a card. This ability costs {1} less to activate for each other artifact you control.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "35b1c00c-1e44-518d-bf58-0b1b20e12050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4b157-2c77-4355-8c65-78dec9d44c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4b157-2c77-4355-8c65-78dec9d44c85.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "Flying\nIf you would proliferate, proliferate twice instead.\n{1}{PU}{PU}, Remove three counters from among other artifacts, creatures, and planeswalkers you control: Put an indestructible counter on Tekuthal, Inquiry Dominus. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -2487,7 +2487,7 @@
         },
         {
             "id": "f0064a60-e027-5ed9-9a08-7534f3541505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f0a63e-0866-423e-b917-fc7c71063021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f0a63e-0866-423e-b917-fc7c71063021.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "9b4095c2-24f7-5477-907d-dbd517777c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f912c4ec-08e9-4524-a2ba-98f6dfabdc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f912c4ec-08e9-4524-a2ba-98f6dfabdc18.jpg?1",
             "name": "Transplant Theorist",
             "text": "Whenever Transplant Theorist or another artifact enters the battlefield under your control, you may draw a card. If you do, discard a card.\n{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "35990d2c-954d-5c2a-9b8a-13eef00dc3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442442d-2e5d-4913-82d8-bab2f31541f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442442d-2e5d-4913-82d8-bab2f31541f8.jpg?1",
             "name": "Trawler Drake",
             "text": "Flying\nTrawler Drake enters the battlefield with an oil counter on it.\nTrawler Drake gets +1/+1 for each oil counter on it.\nWhenever you cast a noncreature spell, put an oil counter on Trawler Drake.",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "2f64a1d6-d332-5154-99e7-881115850df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164b07e6-48ba-4789-bd8f-7cada1fec8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164b07e6-48ba-4789-bd8f-7cada1fec8a9.jpg?1",
             "name": "Unctus, Grand Metatect",
             "text": "Other blue creatures you control have \"Whenever this creature becomes tapped, draw a card, then discard a card.\"\nOther artifact creatures you control get +1/+1.\n{PU}: Until end of turn, target creature you control becomes a blue artifact in addition to its other colors and types. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "44ae9f8a-2ae0-5c11-8379-8a866a650a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30225e40-4bde-4e2e-b0f0-48ed16aebafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30225e40-4bde-4e2e-b0f0-48ed16aebafd.jpg?1",
             "name": "Unctus's Retrofitter",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Unctus's Retrofitter enters the battlefield, up to one target artifact you control becomes an artifact creature with base power and toughness 4/4 for as long as Unctus's Retrofitter remains on the battlefield.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "13d10813-b5c1-5091-9eaa-22889c148c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd244359-781e-4e1d-946d-243664f40c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd244359-781e-4e1d-946d-243664f40c7c.jpg?1",
             "name": "Vivisurgeon's Insight",
             "text": "Draw three cards. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "bda63558-1fd6-5dd2-8a1c-befd4822f8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a895f63f-3c59-4249-9346-55ef489944fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a895f63f-3c59-4249-9346-55ef489944fc.jpg?1",
             "name": "Watchful Blisterzoa",
             "text": "Flying\nWatchful Blisterzoa enters the battlefield with an oil counter on it.\nWhen Watchful Blisterzoa dies, draw cards equal to the number of oil counters on it.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "d340266c-7582-587f-a8c0-73e3e2dee903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c9005c-0574-4b75-8dbf-0a6641c3ae33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c9005c-0574-4b75-8dbf-0a6641c3ae33.jpg?1",
             "name": "Ambulatory Edifice",
             "text": "When Ambulatory Edifice enters the battlefield, you may pay 2 life. When you do, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "caef4ff0-c3fb-58d3-afa6-82248ce2a711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5d0b95-ec12-4e8e-99a0-7aca457f9107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5d0b95-ec12-4e8e-99a0-7aca457f9107.jpg?1",
             "name": "Annihilating Glare",
             "text": "As an additional cost to cast this spell, pay {4} or sacrifice an artifact or creature.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -2808,7 +2808,7 @@
         },
         {
             "id": "1810f7c4-6971-5024-9368-f10a24825192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc55a8-290f-4666-90ce-aa632e87c5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc55a8-290f-4666-90ce-aa632e87c5e7.jpg?1",
             "name": "Anoint with Affliction",
             "text": "Exile target creature if it has mana value 3 or less.\nCorrupted \u2014 Exile that creature instead if its controller has three or more poison counters.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "8dc4c406-8045-5655-a6ed-b803113b02c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b0edaf-8cfd-4508-9554-6f0fddc2dfc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b0edaf-8cfd-4508-9554-6f0fddc2dfc4.jpg?1",
             "name": "Archfiend of the Dross",
             "text": "Flying\nArchfiend of the Dross enters the battlefield with four oil counters on it.\nAt the beginning of your upkeep, remove an oil counter from Archfiend of the Dross. Then if it has no oil counters on it, you lose the game.\nWhenever a creature an opponent controls dies, its controller loses 2 life.",
             "colours": [
@@ -2878,7 +2878,7 @@
         },
         {
             "id": "3106a5eb-b92c-5e02-b2ec-6d7eee84dd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb81cb1-ac56-4803-a962-359854a447df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb81cb1-ac56-4803-a962-359854a447df.jpg?1",
             "name": "Bilious Skulldweller",
             "text": "Deathtouch\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -2913,7 +2913,7 @@
         },
         {
             "id": "0da0d3d2-613d-5dbb-a003-6657481114c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb4def-c67c-44c2-b3b2-8c53a077432d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb4def-c67c-44c2-b3b2-8c53a077432d.jpg?1",
             "name": "Black Sun's Twilight",
             "text": "Up to one target creature gets -X/-X until end of turn. If X is 5 or more, return a creature card with mana value X or less from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2947,7 +2947,7 @@
         },
         {
             "id": "bb866dca-ee14-51bd-9137-26d650fe6a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9255cd01-a611-4fec-b9ec-b271687740ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9255cd01-a611-4fec-b9ec-b271687740ba.jpg?1",
             "name": "Blightbelly Rat",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Blightbelly Rat dies, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "08be0746-efaf-5db6-bb8c-9bd18be62f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f4e41-a5f5-4929-9816-06dc1c228474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f4e41-a5f5-4929-9816-06dc1c228474.jpg?1",
             "name": "Bonepicker Skirge",
             "text": "Flying\nCorrupted \u2014 As long as an opponent has three or more poison counters, Bonepicker Skirge has deathtouch and lifelink.",
             "colours": [
@@ -3023,7 +3023,7 @@
         },
         {
             "id": "05a4e403-5d85-5c99-8156-2a90984d3963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0328d43-ae9b-462a-a1e5-8ed408eea1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0328d43-ae9b-462a-a1e5-8ed408eea1a7.jpg?1",
             "name": "Chittering Skitterling",
             "text": "Corrupted \u2014 Sacrifice an artifact or creature: Draw a card. Activate only if an opponent has three or more poison counters and only once each turn.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "e1dbc387-af3c-5064-9599-f8f0b1c61fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f571b5-ce50-4856-a151-fe6610d27bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f571b5-ce50-4856-a151-fe6610d27bca.jpg?1",
             "name": "Cruel Grimnarch",
             "text": "Deathtouch\nWhen Cruel Grimnarch enters the battlefield, each opponent discards a card. For each opponent who can't, you gain 4 life.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "ef25e595-eaeb-5ddb-a29b-56c2b5e8af1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3890961-d636-4ccc-9c42-2088a8531c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3890961-d636-4ccc-9c42-2088a8531c9b.jpg?1",
             "name": "Cutthroat Centurion",
             "text": "Sacrifice another artifact or creature: Cutthroat Centurion gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "6ccea8a0-86e3-5c3d-9d52-a5008f718720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc26bca-c4d8-4e8b-a96a-9529fc2daed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc26bca-c4d8-4e8b-a96a-9529fc2daed7.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n{PB}{PB}, Exile three creature cards from your graveyard: Put an indestructible counter on Drivnod, Carnage Dominus. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "e09166c0-8245-5423-a707-d1a860e56fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf148ef4-0ed7-4fbe-8ab6-01dd3981c8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf148ef4-0ed7-4fbe-8ab6-01dd3981c8d3.jpg?1",
             "name": "Drown in Ichor",
             "text": "Target creature gets -4/-4 until end of turn. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "2e6ced1f-fce7-583b-9c37-41776c679fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557e601-9b71-4ce9-9047-1a8baa72e574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557e601-9b71-4ce9-9047-1a8baa72e574.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "87aca805-afde-5be3-8ae3-bc44d8d32122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f013a1a-d4b9-4380-9802-c299ee6c4492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f013a1a-d4b9-4380-9802-c299ee6c4492.jpg?1",
             "name": "Feed the Infection",
             "text": "You draw three cards and you lose 3 life.\nCorrupted \u2014 Each opponent who has three or more poison counters loses 3 life.",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "9d1eb74a-badb-5996-9748-f4a5dbe73878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2a32c9-f0ae-4ae4-a5c5-72bea05018fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2a32c9-f0ae-4ae4-a5c5-72bea05018fb.jpg?1",
             "name": "Fleshless Gladiator",
             "text": "Corrupted \u2014 {2}{B}: Return Fleshless Gladiator from your graveyard to the battlefield tapped. You lose 1 life. Activate only if an opponent has three or more poison counters.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "004caf6d-019f-5213-9300-f2029a5c86e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26e18be-81a1-4645-866a-fae5c2fdf7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26e18be-81a1-4645-866a-fae5c2fdf7c9.jpg?1",
             "name": "Geth, Thane of Contracts",
             "text": "Other creatures you control get -1/-1.\n{1}{B}{B}, {T}: Return target creature card from your graveyard to the battlefield. It gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else.\" Activate only as a sorcery.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "3b0604f2-d0dc-55a1-ac09-24e92080d357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f48394-c6aa-4453-954a-68195d9bd6ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f48394-c6aa-4453-954a-68195d9bd6ea.jpg?1",
             "name": "Gulping Scraptrap",
             "text": "When Gulping Scraptrap enters the battlefield or dies, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "d1e388ff-87dc-5dbf-a716-b6b12d96b7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a10f284-b043-4307-bdc7-6dad47cc9221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a10f284-b043-4307-bdc7-6dad47cc9221.jpg?1",
             "name": "Infectious Inquiry",
             "text": "You draw two cards and you lose 2 life. Each opponent gets a poison counter.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "d5a9a880-dd05-5b87-b4c9-8845b9b91fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e282d-8941-46c7-a974-c05b6f73c964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e282d-8941-46c7-a974-c05b6f73c964.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nOther Rats you control have toxic 1.\nWhen Karumonix enters the battlefield, look at the top five cards of your library. You may reveal any number of Rat cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "b877f126-c183-50cb-8df8-9e012eb4d140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8cd7c-992f-4953-b5bf-42e5a9ff09ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8cd7c-992f-4953-b5bf-42e5a9ff09ad.jpg?1",
             "name": "Necrogen Communion",
             "text": "Enchant creature you control\nEnchanted creature has toxic 2. (Players dealt combat damage by it also get two poison counters.)\nWhen enchanted creature dies, return that card to the battlefield under your control.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "ab9973ee-3e5d-5941-89cc-6e8269e4b066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72af72d2-5995-4cad-82f1-e2d0c465d6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72af72d2-5995-4cad-82f1-e2d0c465d6f1.jpg?1",
             "name": "Necrosquito",
             "text": "Flying\nNecrosquito enters the battlefield with two oil counters on it.\nNecrosquito gets +1/+1 for each oil counter on it.\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Necrosquito.",
             "colours": [
@@ -3518,7 +3518,7 @@
         },
         {
             "id": "89962ac1-e504-5a20-9267-061799bd2a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99fe9a8-d9e7-4286-81a1-adfb753e4741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99fe9a8-d9e7-4286-81a1-adfb753e4741.jpg?1",
             "name": "Nimraiser Paladin",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhen Nimraiser Paladin enters the battlefield, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "bdda9781-0417-55d3-9d6a-6a0cbaba1e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aac10a-6d47-4a6c-8a10-2b7c06f3ff32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aac10a-6d47-4a6c-8a10-2b7c06f3ff32.jpg?1",
             "name": "Offer Immortality",
             "text": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3585,7 +3585,7 @@
         },
         {
             "id": "d9c91082-8138-5bd3-8770-4b0eca317de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a1e44-3485-4e24-a34d-6c318584743c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a1e44-3485-4e24-a34d-6c318584743c.jpg?1",
             "name": "Pestilent Syphoner",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "b3f15302-6345-526a-bacd-cb6b2f294ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f69d43-de01-46a8-b102-b47e23e0e947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f69d43-de01-46a8-b102-b47e23e0e947.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -3655,7 +3655,7 @@
         },
         {
             "id": "f81713fe-a075-5a46-8b1b-0a04146c47b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a9c38b-6b3a-4056-a87c-fc48446f854f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a9c38b-6b3a-4056-a87c-fc48446f854f.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -3694,7 +3694,7 @@
         },
         {
             "id": "58a52f97-c78e-5d6b-a511-e28371c68813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7e1e9b-ad7f-4f4c-bdb5-2ccb6f147037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7e1e9b-ad7f-4f4c-bdb5-2ccb6f147037.jpg?1",
             "name": "Ravenous Necrotitan",
             "text": "Corrupted \u2014 When Ravenous Necrotitan enters the battlefield, sacrifice a creature unless an opponent has three or more poison counters.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "7b5e31ea-482c-5681-be21-03b64fa4c9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de80f71-82b5-499c-afc0-6bbae6b896ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de80f71-82b5-499c-afc0-6bbae6b896ad.jpg?1",
             "name": "Scheming Aspirant",
             "text": "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "5cb1ec7d-5109-542a-8d54-d26792cce328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9225cc3-90f0-448f-a8d9-7c6c2796d077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9225cc3-90f0-448f-a8d9-7c6c2796d077.jpg?1",
             "name": "Sheoldred's Edict",
             "text": "Choose one \u2014\n\u2022 Each opponent sacrifices a nontoken creature.\n\u2022 Each opponent sacrifices a creature token.\n\u2022 Each opponent sacrifices a planeswalker.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "1d11ac95-a4a1-5460-95f2-28cc9661a076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b818f-6912-4ea1-a35a-c8cd7ee9aead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b818f-6912-4ea1-a35a-c8cd7ee9aead.jpg?1",
             "name": "Sheoldred's Headcleaver",
             "text": "Menace\nToxic 2 (Players dealt combat damage by this creature also get two poison counters.)",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "9c0498ff-1248-5e8c-92a5-6a1f62886ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbbcbe1-5317-455e-8d71-a4e2ad0addfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbbcbe1-5317-455e-8d71-a4e2ad0addfc.jpg?1",
             "name": "Stinging Hivemaster",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Stinging Hivemaster dies, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "5603460d-c840-5957-b04c-475c9d794085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5424859-628a-4c19-acd0-0c63c21c8338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5424859-628a-4c19-acd0-0c63c21c8338.jpg?1",
             "name": "Testament Bearer",
             "text": "When Testament Bearer dies, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "036b4a98-f494-5be5-afc1-87463f4472c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2aeaeb-7853-4588-8a5e-cfd997ba8515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2aeaeb-7853-4588-8a5e-cfd997ba8515.jpg?1",
             "name": "Vat Emergence",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "cbe0ade1-dbf8-57a6-ae68-fab988d75ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a961ea-0639-4f5d-8cf4-f909c59a4ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a961ea-0639-4f5d-8cf4-f909c59a4ae1.jpg?1",
             "name": "Vat of Rebirth",
             "text": "Whenever another artifact or creature you control is put into a graveyard from the battlefield, put an oil counter on Vat of Rebirth.\n{2}{B}, {T}, Remove four oil counters from Vat of Rebirth: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "3e3cdcaa-0187-5836-bb38-2f1f0662b3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4a3119-c70a-46ff-8ede-6356f2b7bc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4a3119-c70a-46ff-8ede-6356f2b7bc13.jpg?1",
             "name": "Vraan, Executioner Thane",
             "text": "Whenever one or more other creatures you control die, each opponent loses 2 life and you gain 2 life. This ability triggers only once each turn.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "cd5308fd-6729-5f7d-9d04-e81270d04480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59f2b07-47ad-4efd-ae8c-1c04b9265024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59f2b07-47ad-4efd-ae8c-1c04b9265024.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "Compleated ({PB} can be paid with {B} or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n0: You draw a card and you lose 1 life. Proliferate.\n\u22122: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\u22129: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.",
             "colours": [
@@ -4049,7 +4049,7 @@
         },
         {
             "id": "002a5e44-81f2-596e-9b3d-bf8a4981df78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0173b7b4-2832-4943-ba45-8ba498d7a056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0173b7b4-2832-4943-ba45-8ba498d7a056.jpg?1",
             "name": "Vraska's Fall",
             "text": "Each opponent sacrifices a creature or planeswalker and gets a poison counter.",
             "colours": [
@@ -4081,7 +4081,7 @@
         },
         {
             "id": "df50b486-2722-509c-8d15-ee52bae7f4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d287e8-5297-415a-97d5-02002470c52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d287e8-5297-415a-97d5-02002470c52b.jpg?1",
             "name": "Whisper of the Dross",
             "text": "Target creature gets -1/-1 until end of turn. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "5523af1e-1d88-53a3-a5ac-8ee78dfc8d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d75e1f4-bd63-428e-8e6e-131594b3ba44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d75e1f4-bd63-428e-8e6e-131594b3ba44.jpg?1",
             "name": "All Will Be One",
             "text": "Whenever you put one or more counters on a permanent or player, All Will Be One deals that much damage to target opponent, creature an opponent controls, or planeswalker an opponent controls.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "d1f2038f-085f-5098-b079-82365ffb1462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92f866-2522-4f2a-a5ca-7d01ad79b927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92f866-2522-4f2a-a5ca-7d01ad79b927.jpg?1",
             "name": "Awaken the Sleeper",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If it's equipped, you may destroy all Equipment attached to that creature.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "53a1d83b-8d47-5ffe-8fc8-135e6902b966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b3b785-396e-4240-bfa3-58ab53497686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b3b785-396e-4240-bfa3-58ab53497686.jpg?1",
             "name": "Axiom Engraver",
             "text": "Axiom Engraver enters the battlefield with two oil counters on it.\n{T}, Remove an oil counter from Axiom Engraver, Discard a card: Draw a card.",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "540ca546-2050-5ca8-b2e9-78dc9c266d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1d02d1-91dc-47d6-bdbe-87602428abfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1d02d1-91dc-47d6-bdbe-87602428abfb.jpg?1",
             "name": "Barbed Batterfist",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +1/-1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "f98569a0-f016-51dc-93bd-2fa30a24baea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6cf933-73fe-4e79-8d0b-29dc0f18b25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6cf933-73fe-4e79-8d0b-29dc0f18b25d.jpg?1",
             "name": "Bladegraft Aspirant",
             "text": "Menace\nEquipment spells you cast cost {1} less to cast.\nActivated abilities of Equipment you control that target Bladegraft Aspirant cost {1} less to activate.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "f06d5006-947f-506e-aa49-6c6d7bae2aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfc16a-2871-40a4-b279-636b80491a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfc16a-2871-40a4-b279-636b80491a06.jpg?1",
             "name": "Blazing Crescendo",
             "text": "Target creature gets +3/+1 until end of turn.\nExile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "ef359b96-9ff2-5ed8-9c32-d4c14e034234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553dcef-7b99-49d5-b071-06b894696952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553dcef-7b99-49d5-b071-06b894696952.jpg?1",
             "name": "Cacophony Scamp",
             "text": "Whenever Cacophony Scamp deals combat damage to a player, you may sacrifice it. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nWhen Cacophony Scamp dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "f5024d59-ee03-5943-a71e-89ae8d6bbc99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23afca1a-62a8-497f-994f-ceb479d020ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23afca1a-62a8-497f-994f-ceb479d020ba.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "This spell costs {3} less to cast if you have nine or more cards in your graveyard.\nFlying\nWhen Capricious Hellraiser enters the battlefield, exile three cards at random from your graveyard. Choose a noncreature, nonland card from among them and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "909a29bd-773a-5bf9-acc3-7b9d687d60eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5668699d-8df8-426b-a04a-99cfe55e570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5668699d-8df8-426b-a04a-99cfe55e570b.jpg?1",
             "name": "Chimney Rabble",
             "text": "Haste\nWhen Chimney Rabble enters the battlefield, create a 1/1 red Phyrexian Goblin creature token.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "e084dfdf-f7a2-5231-b108-5b283dd97263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c117239-8e40-4e7e-ab1b-82f2ddf55cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c117239-8e40-4e7e-ab1b-82f2ddf55cf4.jpg?1",
             "name": "Churning Reservoir",
             "text": "At the beginning of your upkeep, put an oil counter on another target nontoken artifact or creature you control.\n{2}, {T}: Create a 1/1 red Phyrexian Goblin creature token. Activate only if an oil counter was removed from a permanent you controlled this turn or a permanent with an oil counter on it was put into a graveyard this turn.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "d7f7057a-61b4-5153-bd24-7b77218e0c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5456b036-231e-4a64-b060-0709f5254664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5456b036-231e-4a64-b060-0709f5254664.jpg?1",
             "name": "Dragonwing Glider",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +2/+2 and has flying and haste.\nEquip {3}{R}{R}",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "a42734b2-aeb4-52ff-97ca-f2320d2392cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8d7b9-ff5e-48ae-9e38-d2b6a45b119b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8d7b9-ff5e-48ae-9e38-d2b6a45b119b.jpg?1",
             "name": "Exuberant Fuseling",
             "text": "Trample\nExuberant Fuseling gets +1/+0 for each oil counter on it.\nWhen Exuberant Fuseling enters the battlefield and whenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Exuberant Fuseling.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "8d9fd16a-d102-5679-9985-5c3df3fc1682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c2c914-e9a7-450b-88d9-8885fe0f6643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c2c914-e9a7-450b-88d9-8885fe0f6643.jpg?1",
             "name": "Forgehammer Centurion",
             "text": "Whenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Forgehammer Centurion.\nWhenever Forgehammer Centurion attacks, you may remove two oil counters from it. When you do, target creature can't block this turn.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "3cfaf622-32e0-5414-8f0c-0fa99c5c5b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c83600d-ea4d-4219-8dbb-34c4215a2005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c83600d-ea4d-4219-8dbb-34c4215a2005.jpg?1",
             "name": "Free from Flesh",
             "text": "Target creature gets +2/+2 until end of turn. Put two oil counters on it.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "29a0bcfa-6fb2-564b-8867-4aa9ece4fcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e5fc08-7a04-4bba-81ba-990889cae96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e5fc08-7a04-4bba-81ba-990889cae96a.jpg?1",
             "name": "Furnace Punisher",
             "text": "Menace\nAt the beginning of each player's upkeep, Furnace Punisher deals 2 damage to that player unless they control two or more basic lands.",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "6979b6a6-1377-5358-9c10-359cd276f2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa625ab0-1e79-4497-a5da-98fe1abfd024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa625ab0-1e79-4497-a5da-98fe1abfd024.jpg?1",
             "name": "Furnace Strider",
             "text": "Furnace Strider enters the battlefield with two oil counters on it.\nRemove an oil counter from Furnace Strider: Target creature you control gains haste until end of turn.",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "430c50d3-1247-58d1-ab72-16b64af4aa7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e4efa6-5783-4a51-99c6-116d1a8f01cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e4efa6-5783-4a51-99c6-116d1a8f01cf.jpg?1",
             "name": "Gleeful Demolition",
             "text": "Destroy target artifact. If you controlled that artifact, create three 1/1 red Phyrexian Goblin creature tokens.",
             "colours": [
@@ -4702,7 +4702,7 @@
         },
         {
             "id": "9db7fc73-b602-5ec6-83b9-a8a616404352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380a4c9-a5d3-465f-8584-e546b54f91e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380a4c9-a5d3-465f-8584-e546b54f91e0.jpg?1",
             "name": "Hazardous Blast",
             "text": "Hazardous Blast deals 1 damage to each creature your opponents control. Creatures your opponents control can't block this turn.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "ac68cb3a-ea48-5304-b7f6-4c48c6a18a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22108ec-28f0-44d3-ba6b-3075f5f6bc65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22108ec-28f0-44d3-ba6b-3075f5f6bc65.jpg?1",
             "name": "Hexgold Halberd",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nAs long as it's your turn, equipped creature has first strike and trample.\nEquip {2}{R}",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "db100f3f-f7f0-5074-8a9c-8fc6ba0e35b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec44465-68d4-4dca-a313-7f2ab0ce2e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec44465-68d4-4dca-a313-7f2ab0ce2e63.jpg?1",
             "name": "Hexgold Slash",
             "text": "Hexgold Slash deals 2 damage to target creature. If that creature has toxic, Hexgold Slash deals 4 damage to that creature instead.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "4f4f323d-eff6-54f1-9bd9-ea32ec592052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6528e012-4091-4722-b706-c51772676167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6528e012-4091-4722-b706-c51772676167.jpg?1",
             "name": "Koth, Fire of Resistance",
             "text": "+2: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n\u22123: Koth, Fire of Resistance deals damage to target creature equal to the number of Mountains you control.\n\u22127: You get an emblem with \"Whenever a Mountain enters the battlefield under your control, this emblem deals 4 damage to any target.\"",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "67613efc-963c-54ed-8a41-49ca92f34112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7155c42-a824-4bbe-9f7a-fa01e7625fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7155c42-a824-4bbe-9f7a-fa01e7625fd6.jpg?1",
             "name": "Kuldotha Cackler",
             "text": "Trample\nWhenever Kuldotha Cackler attacks, it gets +X/+0 until end of turn, where X is the number of permanents you control with oil counters on them.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "1958f038-8af7-51a5-b7dc-1b4c8023e6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6af42f-35ec-432f-9879-2a0fb938a9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6af42f-35ec-432f-9879-2a0fb938a9f6.jpg?1",
             "name": "Magmatic Sprinter",
             "text": "Haste\nWhen Magmatic Sprinter enters the battlefield, put two oil counters on target artifact or creature you control.\nAt the beginning of your end step, return Magmatic Sprinter to its owner's hand unless you remove two oil counters from it.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "7dc26f6c-bd5e-55f1-91e7-b9e883f3045e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3291b-de5c-4a10-9915-2cd2d84a815c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3291b-de5c-4a10-9915-2cd2d84a815c.jpg?1",
             "name": "Molten Rebuke",
             "text": "Choose one or both \u2014\n\u2022 Molten Rebuke deals 5 damage to target creature or planeswalker.\n\u2022 Destroy target Equipment.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "e517109b-449d-514a-8f14-d7c7885d4ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98395039-1353-4fa8-b51d-c4e1cadf9263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98395039-1353-4fa8-b51d-c4e1cadf9263.jpg?1",
             "name": "Nahiri's Sacrifice",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature with mana value X.\nNahiri's Sacrifice deals X damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "50cd4e78-859c-5d27-bc23-1e4aeaebf5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7177431e-5cc4-4ecd-8848-f51903289072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7177431e-5cc4-4ecd-8848-f51903289072.jpg?1",
             "name": "Oxidda Finisher",
             "text": "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nTrample",
             "colours": [
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "430b8664-73a5-5268-8b27-4d236f63c857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd37d1b1-70ce-466e-890d-36be82433035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd37d1b1-70ce-466e-890d-36be82433035.jpg?1",
             "name": "Rebel Salvo",
             "text": "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nRebel Salvo deals 5 damage to target creature or planeswalker. That permanent loses indestructible until end of turn.",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "cd866547-0c2e-5695-b59e-4de4893184e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cac1827-69af-469d-b88c-fb9f2f33866a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cac1827-69af-469d-b88c-fb9f2f33866a.jpg?1",
             "name": "Red Sun's Twilight",
             "text": "Destroy up to X target artifacts. If X is 5 or more, for each artifact destroyed this way, create a token that's a copy of it. Those tokens gain haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "7ab9c136-cc86-55ad-bd19-bd3956981931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6249aabe-8f21-4257-9e04-ceffd44d42a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6249aabe-8f21-4257-9e04-ceffd44d42a5.jpg?1",
             "name": "Resistance Skywarden",
             "text": "Menace, reach",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "8f92c873-1835-5701-9ee2-fbbf6fb7b9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c2e5-9100-439a-9aa4-28d388518e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c2e5-9100-439a-9aa4-28d388518e4a.jpg?1",
             "name": "Sawblade Scamp",
             "text": "Haste\nWhenever you cast a noncreature spell, put an oil counter on Sawblade Scamp.\n{T}, Remove an oil counter from Sawblade Scamp: It deals 1 damage to each opponent.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "e71e6f05-5688-568c-82a9-58aee00c9112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6147bdc-4e02-48be-9ab9-c212f70d9194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6147bdc-4e02-48be-9ab9-c212f70d9194.jpg?1",
             "name": "Shrapnel Slinger",
             "text": "When Shrapnel Slinger enters the battlefield, you may sacrifice a creature. When you do, destroy target artifact an opponent controls.",
             "colours": [
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "a4e03a81-6b89-5555-b5a9-c660b99253a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7dadf0-7323-403e-b353-33c121bdb0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7dadf0-7323-403e-b353-33c121bdb0db.jpg?1",
             "name": "Slobad, Iron Goblin",
             "text": "{T}, Sacrifice an artifact: Add an amount of {R} equal to the sacrificed artifact's mana value. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "59bfd687-78f5-55fb-b26c-95c65e5a7f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0c7f3-7fb9-43de-a9af-96532c31e5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0c7f3-7fb9-43de-a9af-96532c31e5ed.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "If a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals double that damage to that player or permanent instead.\n{1}{PR}{PR}, Discard two cards: Put an indestructible counter on Solphim, Mayhem Dominus. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "7f423ee1-9bfd-5635-ba7a-e122fff93282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efd4ae5-0076-46a0-a113-58cfff53144f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efd4ae5-0076-46a0-a113-58cfff53144f.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "fc0bc28b-560b-5400-ac4d-076a5123da9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ef034f-37e5-4baa-a7a9-5fd0de792535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ef034f-37e5-4baa-a7a9-5fd0de792535.jpg?1",
             "name": "Urabrask's Anointer",
             "text": "When Urabrask's Anointer enters the battlefield, it deals X damage to any target, where X is the number of permanents you control with oil counters on them.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "784e981f-97f8-5417-893c-41b6c3b730b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f9f9d8-9ea0-4608-a79c-a09a87918186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f9f9d8-9ea0-4608-a79c-a09a87918186.jpg?1",
             "name": "Urabrask's Forge",
             "text": "At the beginning of combat on your turn, put an oil counter on Urabrask's Forge, then create an X/1 red Phyrexian Horror creature token with trample and haste, where X is the number of oil counters on Urabrask's Forge. Sacrifice that token at the beginning of the next end step.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "053d5396-62ae-581f-9478-0f016a1703a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7a16-ff30-4fb9-9fcb-6561eec50caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7a16-ff30-4fb9-9fcb-6561eec50caf.jpg?1",
             "name": "Vindictive Flamestoker",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Vindictive Flamestoker.\n{6}{R}, Sacrifice Vindictive Flamestoker: Discard your hand, then draw four cards. This ability costs {1} less to activate for each oil counter on Vindictive Flamestoker.",
             "colours": [
@@ -5407,7 +5407,7 @@
         },
         {
             "id": "d52bb3ca-49a0-5945-829b-3cdaae67b0f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d74045-cc9b-4b01-bc5f-0f2eb4b01580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d74045-cc9b-4b01-bc5f-0f2eb4b01580.jpg?1",
             "name": "Volt Charge",
             "text": "Volt Charge deals 3 damage to any target. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "a7ec285f-f436-5100-ae25-d44bdef52402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05078dd-b928-4b3f-9636-f299ebac180b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05078dd-b928-4b3f-9636-f299ebac180b.jpg?1",
             "name": "Vulshok Splitter",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +2/+0.\nEquip {2}{R} ({2}{R}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "b8473eeb-c4f2-5163-9cfe-28b335afdf9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6d202-9c6f-4485-9224-173b23de7054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6d202-9c6f-4485-9224-173b23de7054.jpg?1",
             "name": "Adaptive Sporesinger",
             "text": "Vigilance\nWhen Adaptive Sporesinger enters the battlefield, choose one \u2014\n\u2022 Target creature gets +2/+2 and gains vigilance until end of turn.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "2d1a89e3-dbc7-5370-8333-4cbafd26dcda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e220d0-38c9-4584-940b-8a9e983ecfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e220d0-38c9-4584-940b-8a9e983ecfe7.jpg?1",
             "name": "Armored Scrapgorger",
             "text": "Armored Scrapgorger gets +3/+0 as long as it has three or more oil counters on it.\n{T}: Add one mana of any color.\nWhenever Armored Scrapgorger becomes tapped, exile target card from a graveyard and put an oil counter on Armored Scrapgorger.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "03b60dc5-9023-5a0c-b2ae-fed7b0a84a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411bda96-6c65-475d-9850-0a9b3eefa553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411bda96-6c65-475d-9850-0a9b3eefa553.jpg?1",
             "name": "Bloated Contaminator",
             "text": "Trample\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhenever Bloated Contaminator deals combat damage to a player, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5580,7 +5580,7 @@
         },
         {
             "id": "0c518ca2-8608-57b6-809d-dd71074712c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5290a4c-1f98-4e97-a407-f951e386b8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5290a4c-1f98-4e97-a407-f951e386b8b0.jpg?1",
             "name": "Branchblight Stalker",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "b57e19e2-5e80-501a-8923-bd37f540cea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b39293-6f57-4294-85fc-c718bdbb4d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b39293-6f57-4294-85fc-c718bdbb4d40.jpg?1",
             "name": "Cankerbloom",
             "text": "{1}, Sacrifice Cankerbloom: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "bc9ad3b9-1082-577c-8c25-9ba96c907a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ba43-f7ae-4e00-b797-2360c3ccd839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ba43-f7ae-4e00-b797-2360c3ccd839.jpg?1",
             "name": "Carnivorous Canopy",
             "text": "Destroy target artifact, enchantment, or creature with flying. If that permanent's mana value was 3 or less, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "7910545e-c599-5998-9663-386e261a328d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635146da-d415-4107-a7f9-2c46189e5c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635146da-d415-4107-a7f9-2c46189e5c52.jpg?1",
             "name": "Conduit of Worlds",
             "text": "You may play lands from your graveyard.\n{T}: Choose target nonland permanent card in your graveyard. If you haven't cast a spell this turn, you may cast that card. If you do, you can't cast additional spells this turn. Activate only as a sorcery.",
             "colours": [
@@ -5720,7 +5720,7 @@
         },
         {
             "id": "6d89f777-3976-5029-8fcf-7668b9ab0631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af2c85-e58f-4043-99d3-e90121348aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af2c85-e58f-4043-99d3-e90121348aca.jpg?1",
             "name": "Contagious Vorrac",
             "text": "When Contagious Vorrac enters the battlefield, look at the top four cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "d29fa315-0d68-5e2b-93a0-3eac7664a5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8855fbf-4f1e-4c44-9653-bbbfc3f2fafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8855fbf-4f1e-4c44-9653-bbbfc3f2fafd.jpg?1",
             "name": "Copper Longlegs",
             "text": "Reach\n{1}{G}, Sacrifice Copper Longlegs: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "d7dbba15-4e28-5a6c-8d77-f683cdce9638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4bcb42-f5cf-410d-8f20-1006b0f92abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4bcb42-f5cf-410d-8f20-1006b0f92abe.jpg?1",
             "name": "Evolved Spinoderm",
             "text": "Evolved Spinoderm enters the battlefield with four oil counters on it.\nEvolved Spinoderm has trample as long as it has two or fewer oil counters on it. Otherwise, it has hexproof.\nAt the beginning of your upkeep, remove an oil counter from Evolved Spinoderm. Then if it has no oil counters on it, sacrifice it.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "3223c974-e7de-5fb9-a357-9465b2032b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13366c60-1200-4ad2-bbf4-77596121fcd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13366c60-1200-4ad2-bbf4-77596121fcd2.jpg?1",
             "name": "Evolving Adaptive",
             "text": "Evolving Adaptive enters the battlefield with an oil counter on it.\nEvolving Adaptive gets +1/+1 for each oil counter on it.\nWhenever another creature enters the battlefield under your control, if that creature has greater power or toughness than Evolving Adaptive, put an oil counter on Evolving Adaptive.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "4893f5a8-ce90-55f7-8c06-8be2a3a0ae24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572e174e-99f7-4b5e-8506-1833adddbf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572e174e-99f7-4b5e-8506-1833adddbf07.jpg?1",
             "name": "Expand the Sphere",
             "text": "Look at the top six cards of your library. Put up to two land cards from among them onto the battlefield tapped and the rest on the bottom of your library in a random order. If you put fewer than two lands onto the battlefield this way, proliferate a number of times equal to the difference. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "07e45dea-714c-5a56-bf2c-0ea4034aa4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c985d-cb70-41a7-9f66-3506708b7e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c985d-cb70-41a7-9f66-3506708b7e26.jpg?1",
             "name": "Green Sun's Twilight",
             "text": "Reveal the top X plus one cards of your library. Choose a creature card and/or a land card from among them. Put those cards into your hand and the rest on the bottom of your library in a random order. If X is 5 or more, instead put the chosen cards onto the battlefield or into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5931,7 +5931,7 @@
         },
         {
             "id": "60020c37-97c0-57d5-a500-28261916e8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0955b64f-6721-4fa6-b161-cae404cb5b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0955b64f-6721-4fa6-b161-cae404cb5b9f.jpg?1",
             "name": "Ichorspit Basilisk",
             "text": "Deathtouch\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "a1161542-f856-55c8-8bb6-22ca4982c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b36e23-a414-400c-a3a5-e23883e866d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b36e23-a414-400c-a3a5-e23883e866d3.jpg?1",
             "name": "Incubation Sac",
             "text": "Incubation Sac enters the battlefield with three oil counters on it.\n{4}, {T}, Remove an oil counter from Incubation Sac: Create a 3/3 colorless Phyrexian Golem artifact creature token. Activate only as a sorcery.",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "c6897d5b-fad9-5202-a8dc-fc4ab2dbb61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83dfb2a5-cd5c-46c6-9bb8-7c5d00f3e003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83dfb2a5-cd5c-46c6-9bb8-7c5d00f3e003.jpg?1",
             "name": "Infectious Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. Each opponent gets a poison counter.",
             "colours": [
@@ -6030,7 +6030,7 @@
         },
         {
             "id": "fb3d29f5-a392-5c19-b5f6-b80211709979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7427def-c4b2-475a-8dc9-7e89409d9abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7427def-c4b2-475a-8dc9-7e89409d9abb.jpg?1",
             "name": "Lattice-Blade Mantis",
             "text": "Lattice-Blade Mantis enters the battlefield with two oil counters on it.\nWhenever Lattice-Blade Mantis attacks, you may remove an oil counter from it. If you do, untap it and it gets +1/+1 until end of turn.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "1f054389-514a-565b-a30a-b7c5dc9ea657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc79106b-9aa2-4add-b9ca-e3c7aafd9821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc79106b-9aa2-4add-b9ca-e3c7aafd9821.jpg?1",
             "name": "Maze's Mantle",
             "text": "Flash\nEnchant creature\nWhen Maze's Mantle enters the battlefield, if enchanted creature has toxic, that creature gains hexproof until end of turn.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "a1023295-7922-5b7d-afd2-eabd05c16b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd64b1d-bcef-476c-bf0b-3ac7df7cbed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd64b1d-bcef-476c-bf0b-3ac7df7cbed3.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "Compleated ({PG} can be paid with {G} or 2 life. For each {PG} paid with life, this planeswalker enters with two fewer loyalty counters.)\n+1: Create an X/X green Phyrexian Horror creature token, where X is Nissa, Ascended Animist's loyalty.\n\u22121: Destroy target artifact or enchantment.\n\u22127: Until end of turn, creatures you control get +1/+1 for each Forest you control and gain trample.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "e1cc3bd9-7514-5c32-89d4-67d7dae2030b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9649de6c-a9f7-4f0a-8bf7-cacaea60ed54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9649de6c-a9f7-4f0a-8bf7-cacaea60ed54.jpg?1",
             "name": "Noxious Assault",
             "text": "Creatures you control get +2/+2 until end of turn. Whenever a creature blocks this turn, its controller gets a poison counter.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "62d18d80-f5a3-580a-bc0c-db18a697b9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78493579-1fad-4664-96d7-195bf59ceef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78493579-1fad-4664-96d7-195bf59ceef2.jpg?1",
             "name": "Oil-Gorger Troll",
             "text": "When Oil-Gorger Troll enters the battlefield, you gain 3 life. Then if you control a permanent with an oil counter on it, draw a card.",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "ec588a7f-6aad-576d-901c-a17640adb15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758dbe61-6dc7-4b08-bdd6-7262257955fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758dbe61-6dc7-4b08-bdd6-7262257955fc.jpg?1",
             "name": "Paladin of Predation",
             "text": "Toxic 6 (Players dealt combat damage by this creature also get six poison counters.)\nPaladin of Predation can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "79af8678-6ab6-586c-9607-8e3dcb0c9d80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7eef9e-68ae-4743-ad89-64f6fafbe365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7eef9e-68ae-4743-ad89-64f6fafbe365.jpg?1",
             "name": "Plague Nurse",
             "text": "Toxic 2\n{2}{G}: Each other creature you control with toxic gains toxic 1 until end of turn. Activate only once each turn. (A player dealt combat damage by a creature with toxic also gets poison counters equal to that creature's total toxic value.)",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "2d9e2dca-3fb6-57b7-b3fb-98afcc38390e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fab07-f921-4eff-91e2-1974ae121077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fab07-f921-4eff-91e2-1974ae121077.jpg?1",
             "name": "Predation Steward",
             "text": "Predation Steward enters the battlefield with two oil counters on it.\n{2}{G}, {T}, Remove an oil counter from Predation Steward: Target creature gets +2/+2 until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "c16e5c6b-9952-589a-a3b3-f1a91998c48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b71fd8f-e688-4210-bc5b-a3f19b5b3497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b71fd8f-e688-4210-bc5b-a3f19b5b3497.jpg?1",
             "name": "Rustvine Cultivator",
             "text": "{T}: Put an oil counter on Rustvine Cultivator.\n{T}, Remove an oil counter from Rustvine Cultivator: Untap target land.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "154d5c62-91e6-5cd4-9345-84d883468b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123f0c76-1fde-439e-a76d-eccf96f8d941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123f0c76-1fde-439e-a76d-eccf96f8d941.jpg?1",
             "name": "Ruthless Predation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "1fe6144a-8d1c-5e6c-b043-4e8f98d087d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7898399-3c52-402c-9cd7-baad2cb7f00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7898399-3c52-402c-9cd7-baad2cb7f00e.jpg?1",
             "name": "Skyscythe Engulfer",
             "text": "Reach, trample\nSkyscythe Engulfer can't be blocked by creatures with flying.",
             "colours": [
@@ -6421,7 +6421,7 @@
         },
         {
             "id": "20a7a394-ed82-5305-9376-fa037f688773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c1a1d0-5616-42f8-a59c-42c1ccd48d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c1a1d0-5616-42f8-a59c-42c1ccd48d26.jpg?1",
             "name": "Sylvok Battle-Chair",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has trample.\nEquip {5}{G}{G}",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "0a07b890-8ef8-576b-8d41-93b7a6f3c46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4a340-453b-471a-82ba-48ebf20b271a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4a340-453b-471a-82ba-48ebf20b271a.jpg?1",
             "name": "Thirsting Roots",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6487,7 +6487,7 @@
         },
         {
             "id": "78f2b9c7-c869-554a-8457-f488cffd041e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9f51dd-0393-4b3c-bea5-8f74634ab0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9f51dd-0393-4b3c-bea5-8f74634ab0e5.jpg?1",
             "name": "Thrun, Breaker of Silence",
             "text": "This spell can't be countered.\nTrample\nThrun, Breaker of Silence can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.\nAs long as it's your turn, Thrun has indestructible.",
             "colours": [
@@ -6527,7 +6527,7 @@
         },
         {
             "id": "5a3bd3b1-9f07-5d1c-ad86-595a73ccea49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3583ea03-525f-4c70-9d7e-ccc6002ee9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3583ea03-525f-4c70-9d7e-ccc6002ee9e1.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6559,7 +6559,7 @@
         },
         {
             "id": "fc186b98-10f1-55e1-8c1c-16f559415bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157cf43c-f7f2-4362-bfc8-11682e94b747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157cf43c-f7f2-4362-bfc8-11682e94b747.jpg?1",
             "name": "Tyrranax Atrocity",
             "text": "Haste\nToxic 3 (Players dealt combat damage by this creature also get three poison counters.)",
             "colours": [
@@ -6594,7 +6594,7 @@
         },
         {
             "id": "0f465d50-ec6b-569d-8d8a-ce65b4baa33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg?1",
             "name": "Tyrranax Rex",
             "text": "This spell can't be countered.\nTrample, ward {4}, haste\nToxic 4 (Players dealt combat damage by this creature also get four poison counters.)",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "8bd34a5d-d614-535b-a7a3-94c5408daddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b362a5-382a-4016-b4f2-aa7b683354c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b362a5-382a-4016-b4f2-aa7b683354c4.jpg?1",
             "name": "Tyvar's Stand",
             "text": "Target creature you control gets +X/+X and gains hexproof and indestructible until end of turn. (A creature with hexproof and indestructible can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -6665,7 +6665,7 @@
         },
         {
             "id": "1561e67e-a9dd-502a-b498-566003ad0d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e6a91-59cc-4f7f-af25-16acabdafb1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e6a91-59cc-4f7f-af25-16acabdafb1a.jpg?1",
             "name": "Unnatural Restoration",
             "text": "Return target permanent card from your graveyard to your hand. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6697,7 +6697,7 @@
         },
         {
             "id": "409bff6c-b7e2-5836-842a-4e8f8b84468b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b032e3-14e3-48ba-ab8a-d2b4f8d31a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b032e3-14e3-48ba-ab8a-d2b4f8d31a7d.jpg?1",
             "name": "Venerated Rotpriest",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhenever a creature you control becomes the target of a spell, target opponent gets a poison counter.",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "5bcd4e6d-a9d9-5be4-8183-63be1ba304a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9df44a-a0ab-435f-914c-aa11cd88f4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9df44a-a0ab-435f-914c-aa11cd88f4ec.jpg?1",
             "name": "Venomous Brutalizer",
             "text": "Toxic 3 (Players dealt combat damage by this creature also get three poison counters.)\nWhen Venomous Brutalizer enters the battlefield, you may pay {1}{G}. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "91befce7-5b8a-55a0-ae2f-3468afdee6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad30a1-3ecc-42ca-afe8-85df5bad9196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad30a1-3ecc-42ca-afe8-85df5bad9196.jpg?1",
             "name": "Viral Spawning",
             "text": "Create a 3/3 green Phyrexian Beast creature token with toxic 1. (Players dealt combat damage by it also get a poison counter.)\nCorrupted \u2014 As long as an opponent has three or more poison counters and Viral Spawning is in your graveyard, it has flashback {2}{G}. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "f73401c0-2d8e-5113-8226-736006970735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb419d9d-e06f-48c8-a4f8-a57f9be39e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb419d9d-e06f-48c8-a4f8-a57f9be39e50.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "Reach\nAt the beginning of each combat, double the power and toughness of each creature you control until end of turn.\n{PG}{PG}, Sacrifice two other creatures: Put an indestructible counter on Zopandrel, Hunger Dominus. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -6842,7 +6842,7 @@
         },
         {
             "id": "00110d45-bc2b-58af-936c-7eb69899ec7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1f905f-1d55-4d02-9d24-e58070793d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1f905f-1d55-4d02-9d24-e58070793d3f.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "Flying, vigilance, deathtouch, lifelink\nWhen Atraxa, Grand Unifier enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order. (Artifact, battle, creature, enchantment, instant, land, planeswalker, and sorcery are card types.)",
             "colours": [
@@ -6889,7 +6889,7 @@
         },
         {
             "id": "b116f091-5597-5d99-8e53-e897e4254a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e9ba5-e0ec-4fb3-8301-689aa145cc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e9ba5-e0ec-4fb3-8301-689aa145cc19.jpg?1",
             "name": "Bladehold War-Whip",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquip abilities you activate of other Equipment cost {1} less to activate.\nEquipped creature has double strike.\nEquip {3}{R}{W}",
             "colours": [
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "97ab7286-8822-5a73-a214-4df1cc0531a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c22eb9-5056-4c0b-a5d8-41e09161eb40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c22eb9-5056-4c0b-a5d8-41e09161eb40.jpg?1",
             "name": "Cephalopod Sentry",
             "text": "Flying\nCephalopod Sentry's power is equal to the number of artifacts you control.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "ab9472f1-fa45-5992-9d4a-e83b0bafbb56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45db6b46-c4b4-4684-8a49-53a64ffc82f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45db6b46-c4b4-4684-8a49-53a64ffc82f2.jpg?1",
             "name": "Charforger",
             "text": "When Charforger enters the battlefield, create a 1/1 red Phyrexian Goblin creature token.\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Charforger.\nRemove three oil counters from Charforger: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "58274e59-5ff0-551d-b6a7-241d6535188b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee24300-fff8-4405-9629-9f62b4a839ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee24300-fff8-4405-9629-9f62b4a839ef.jpg?1",
             "name": "Cinderslash Ravager",
             "text": "This spell costs {1} less to cast for each permanent you control with oil counters on it.\nVigilance\nWhen Cinderslash Ravager enters the battlefield, it deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "b5d0a4cd-aa06-5e4a-9960-a0fea2ec2ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38961ce-0257-412f-acec-c5c9886061f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38961ce-0257-412f-acec-c5c9886061f8.jpg?1",
             "name": "Ezuri, Stalker of Spheres",
             "text": "When Ezuri, Stalker of Spheres enters the battlefield, you may pay {3}. If you do, proliferate twice.\nWhenever you proliferate, draw a card.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "91040ff4-32d2-5207-8941-158734ba7991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bf633e-0470-4b87-99ed-5ad1683b0954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bf633e-0470-4b87-99ed-5ad1683b0954.jpg?1",
             "name": "Glissa Sunslayer",
             "text": "First strike, deathtouch\nWhenever Glissa Sunslayer deals combat damage to a player, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Destroy target enchantment.\n\u2022 Remove up to three counters from target permanent.",
             "colours": [
@@ -7125,7 +7125,7 @@
         },
         {
             "id": "9a26a488-ea97-561b-a6f9-29f3d5165a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4d8f7-874d-4b2a-ad23-afab479784ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4d8f7-874d-4b2a-ad23-afab479784ea.jpg?1",
             "name": "Jor Kadeen, First Goldwarden",
             "text": "Trample\nWhenever Jor Kadeen, First Goldwarden attacks, it gets +X/+X until end of turn, where X is the number of equipped creatures you control. Then if Jor Kadeen's power is 4 or greater, draw a card.",
             "colours": [
@@ -7167,7 +7167,7 @@
         },
         {
             "id": "7e3db830-928a-59e9-a587-84e2f733ed79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d97f59a-07b8-47ef-aa88-d94f8c3feae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d97f59a-07b8-47ef-aa88-d94f8c3feae4.jpg?1",
             "name": "Kaito, Dancing Shadow",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may return one of them to its owner's hand. If you do, you may activate loyalty abilities of Kaito twice this turn rather than only once.\n+1: Up to one target creature can't attack or block until your next turn.\n0: Draw a card.\n\u22122: Create a 2/2 colorless Drone artifact creature token with deathtouch and \"When this creature leaves the battlefield, each opponent loses 2 life and you gain 2 life.\"",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "35fc764b-a80b-59e6-a8ff-ac3793a8c6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6865b8c7-b260-48e8-a905-64cbf06b7e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6865b8c7-b260-48e8-a905-64cbf06b7e57.jpg?1",
             "name": "Kaya, Intangible Slayer",
             "text": "Hexproof\n+2: Each opponent loses 3 life and you gain 3 life.\n0: You draw two cards. Then each opponent may scry 1.\n\u22123: Exile target creature or enchantment. If it wasn't an Aura, create a token that's a copy of it, except it's a 1/1 white Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -7249,7 +7249,7 @@
         },
         {
             "id": "1484ffdc-bdf6-53b6-8852-81947ed34ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152a5a8-e5a1-46b0-8f75-b9ac341da474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152a5a8-e5a1-46b0-8f75-b9ac341da474.jpg?1",
             "name": "Kethek, Crucible Goliath",
             "text": "At the beginning of your end step, you may sacrifice another creature. If you do, reveal cards from the top of your library until you reveal a nonlegendary creature card with lesser mana value, put it onto the battlefield, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "52b13bc8-697f-5742-ab91-e68796e17493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df77017-c4a7-4b79-a16b-26463bd6a96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df77017-c4a7-4b79-a16b-26463bd6a96a.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "Compleated ({Red Green Mana for Phyrexian} can be paid with {R}, {G}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.\n\u22121: Create a 3/3 green Phyrexian Beast creature token with toxic 1.\n\u22124: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers, where X is the greatest power among creatures you controlled as you activated this ability.",
             "colours": [
@@ -7335,7 +7335,7 @@
         },
         {
             "id": "c497e727-e54c-5522-aa0d-eff604a510cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bda977-e5d1-4813-a5f5-265023965142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bda977-e5d1-4813-a5f5-265023965142.jpg?1",
             "name": "Malcator, Purity Overseer",
             "text": "When Malcator, Purity Overseer enters the battlefield, create a 3/3 colorless Phyrexian Golem artifact creature token.\nAt the beginning of your end step, if three or more artifacts entered the battlefield under your control this turn, create a 3/3 colorless Phyrexian Golem artifact creature token.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "1e5e358e-534d-5e18-9e5b-b37df31133ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1329ad9-5989-4920-b17b-943b9b4a0cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1329ad9-5989-4920-b17b-943b9b4a0cd9.jpg?1",
             "name": "Melira, the Living Cure",
             "text": "If you would get one or more poison counters, instead you get one poison counter and you can't get additional poison counters this turn.\nExile Melira, the Living Cure: Choose another target creature or artifact. When it's put into a graveyard this turn, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "b72c847f-81f7-508f-bdd8-8580cdd589af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1171899-07d8-4e60-a79b-f162f59dc3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1171899-07d8-4e60-a79b-f162f59dc3ce.jpg?1",
             "name": "Migloz, Maze Crusher",
             "text": "Migloz, Maze Crusher enters the battlefield with five oil counters on it.\n{1}, Remove an oil counter from Migloz: It gains vigilance and menace until end of turn.\n{2}, Remove two oil counters from Migloz: It gets +2/+2 until end of turn.\n{3}, Remove three oil counters from Migloz: Destroy target artifact or enchantment.",
             "colours": [
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "1faa0a14-481c-53d0-9dd5-ccf714d4d0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578e35b9-7252-4767-a1f3-aecd71256515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578e35b9-7252-4767-a1f3-aecd71256515.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "Compleated ({Red White Mana for Phyrexian} can be paid with {R}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Until your next turn, up to one target creature attacks a player each combat if able.\n+1: Discard a card, then draw a card.\n0: Exile target creature or Equipment card with mana value less than Nahiri's loyalty from your graveyard. Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -7506,7 +7506,7 @@
         },
         {
             "id": "bdacc19b-1ba6-54e1-a072-efa0bb4a7857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87519b36-1d95-4020-a61d-6afb75555e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87519b36-1d95-4020-a61d-6afb75555e3e.jpg?1",
             "name": "Necrogen Rotpriest",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "e7d0e9e1-1a1e-58fe-a989-2a20982ff527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298cf34-7aa5-4f97-a86c-7f28d2113b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298cf34-7aa5-4f97-a86c-7f28d2113b87.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "Flying\nWard\u2014{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "6f8151d0-1016-5d0c-9ef1-c7ed0d327c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7531ed3-235f-4368-98a8-e4e1947c53fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7531ed3-235f-4368-98a8-e4e1947c53fb.jpg?1",
             "name": "Ria Ivor, Bane of Bladehold",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nAt the beginning of combat on your turn, the next time target creature would deal combat damage to one or more players this combat, prevent that damage. If damage is prevented this way, create that many 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "0164f94a-5768-5f1b-b623-f5699c3cf9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31147651-9a5e-4329-923b-e464f67135e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31147651-9a5e-4329-923b-e464f67135e9.jpg?1",
             "name": "Serum-Core Chimera",
             "text": "Flying\nWhenever you cast a noncreature spell, put an oil counter on Serum-Core Chimera.\nRemove three oil counters from Serum-Core Chimera: Draw a card. Then you may discard a nonland card. When you discard a card this way, Serum-Core Chimera deals 3 damage to target creature or planeswalker. Activate only as a sorcery.",
             "colours": [
@@ -7668,7 +7668,7 @@
         },
         {
             "id": "962f89e1-2bdf-5c33-8f08-21a5f2d196fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a37aa46-bcf3-48a5-9f74-05e4878ad96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a37aa46-bcf3-48a5-9f74-05e4878ad96f.jpg?1",
             "name": "Slaughter Singer",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever another creature you control with toxic attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -7707,7 +7707,7 @@
         },
         {
             "id": "c34584b0-15b9-5f99-abd6-756b9200890a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cba67a-b714-49b0-9797-24aca283f162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cba67a-b714-49b0-9797-24aca283f162.jpg?1",
             "name": "Tainted Observer",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhenever another creature enters the battlefield under your control, you may pay {2}. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -7744,7 +7744,7 @@
         },
         {
             "id": "b37b5d29-bdeb-5b5a-9017-05abb45f8ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605fe1-9a20-4c95-b53e-1249cedb978b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605fe1-9a20-4c95-b53e-1249cedb978b.jpg?1",
             "name": "Tyvar, Jubilant Brawler",
             "text": "You may activate abilities of creatures you control as though those creatures had haste.\n+1: Untap up to one target creature.\n\u22122: Mill three cards, then you may return a creature card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -7785,7 +7785,7 @@
         },
         {
             "id": "6453e540-883a-5efb-82f3-da93fd7ae064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5b94b8-0420-40f2-b989-39cb43cff916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5b94b8-0420-40f2-b989-39cb43cff916.jpg?1",
             "name": "Venser, Corpse Puppet",
             "text": "Lifelink, toxic 1\nWhenever you proliferate, choose one \u2014\n\u2022 If you don't control a creature named The Hollow Sentinel, create The Hollow Sentinel, a legendary 3/3 colorless Phyrexian Golem artifact creature token.\n\u2022 Target artifact creature you control gains flying and lifelink until end of turn.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "c49a8ac8-e978-5f45-b79b-f02d859ad844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c46a3-72b8-4e04-adf2-c9c7aaf94f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c46a3-72b8-4e04-adf2-c9c7aaf94f04.jpg?1",
             "name": "Vivisection Evangelist",
             "text": "Vigilance\nCorrupted \u2014 When Vivisection Evangelist enters the battlefield, if an opponent has three or more poison counters, destroy target creature or planeswalker an opponent controls.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "17841d45-2c10-54f5-952e-6f9649989031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a48705f-bd8a-43f1-b1fe-14a5c9a83ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a48705f-bd8a-43f1-b1fe-14a5c9a83ccd.jpg?1",
             "name": "Voidwing Hybrid",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen you proliferate, return Voidwing Hybrid from your graveyard to your hand.",
             "colours": [
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "dbde4eab-eb45-54be-a42f-e95995d370ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746e3ab-c0a6-46c1-a418-275b419962e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746e3ab-c0a6-46c1-a418-275b419962e4.jpg?1",
             "name": "Argentum Masticore",
             "text": "First strike, protection from multicolored\nAt the beginning of your upkeep, sacrifice Argentum Masticore unless you discard a card. When you discard a card this way, destroy target nonland permanent an opponent controls with mana value less than or equal to the mana value of the discarded card.",
             "colours": [],
@@ -7936,7 +7936,7 @@
         },
         {
             "id": "d97bbf63-2a4f-57a9-aed3-2fcd9e7074ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdedebad-f71e-4434-871e-5bbbd3c07a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdedebad-f71e-4434-871e-5bbbd3c07a12.jpg?1",
             "name": "Atraxa's Skitterfang",
             "text": "Atraxa's Skitterfang enters the battlefield with three oil counters on it.\nAt the beginning of combat on your turn, you may remove an oil counter from Atraxa's Skitterfang. When you do, target creature you control gains your choice of flying, vigilance, deathtouch, or lifelink until end of turn.",
             "colours": [],
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "9d521f23-2078-5df0-b2e5-0e88d238280a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f0ae2-db68-4338-93f9-9d9268cec41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f0ae2-db68-4338-93f9-9d9268cec41e.jpg?1",
             "name": "Basilica Skullbomb",
             "text": "{1}, Sacrifice Basilica Skullbomb: Draw a card.\n{2}{W}, Sacrifice Basilica Skullbomb: Target creature you control gets +2/+2 and gains flying until end of turn. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -7998,7 +7998,7 @@
         },
         {
             "id": "ed03fd2c-0bf7-5237-b9ce-42ed6287cddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66270dd2-9139-4329-9621-852962836688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66270dd2-9139-4329-9621-852962836688.jpg?1",
             "name": "Dross Skullbomb",
             "text": "{1}, Sacrifice Dross Skullbomb: Draw a card.\n{2}{B}, Sacrifice Dross Skullbomb: Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "8504a0b8-dc1a-512e-929d-5cd519039314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d2c689-af37-433a-a012-e8d384702811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d2c689-af37-433a-a012-e8d384702811.jpg?1",
             "name": "Dune Mover",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Dune Mover enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -8060,7 +8060,7 @@
         },
         {
             "id": "a293647c-5273-5d38-9987-e929af697213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0958a1-1bac-48be-888d-f7573f409a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0958a1-1bac-48be-888d-f7573f409a9b.jpg?1",
             "name": "The Filigree Sylex",
             "text": "{T}: Put an oil counter on The Filigree Sylex.\n{T}, Sacrifice The Filigree Sylex: Destroy each nonland permanent with mana value equal to the number of oil counters on The Filigree Sylex.\n{T}, Remove ten oil counters from among permanents you control and sacrifice The Filigree Sylex: It deals 10 damage to any target.",
             "colours": [],
@@ -8092,7 +8092,7 @@
         },
         {
             "id": "89a813e2-8b74-5674-a12b-3ea8509b70d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb530f9d-cf35-48a7-8711-f74b3d9a35a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb530f9d-cf35-48a7-8711-f74b3d9a35a7.jpg?1",
             "name": "Furnace Skullbomb",
             "text": "{1}, Sacrifice Furnace Skullbomb: Draw a card.\n{1}{R}, Sacrifice Furnace Skullbomb: Put two oil counters on target artifact or creature you control. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8122,7 +8122,7 @@
         },
         {
             "id": "1281a038-9a04-56db-92c4-6b00c066826f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e73b63-17cc-4dca-abd6-728b74bc37a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e73b63-17cc-4dca-abd6-728b74bc37a8.jpg?1",
             "name": "Graaz, Unstoppable Juggernaut",
             "text": "Juggernauts you control attack each combat if able.\nJuggernauts you control can't be blocked by Walls.\nOther creatures you control have base power and toughness 5/3 and are Juggernauts in addition to their other creature types.",
             "colours": [],
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "3d5f3101-7947-572e-9883-2a05b66ddb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e555abb1-ffd4-4143-9be8-ec8a758f5c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e555abb1-ffd4-4143-9be8-ec8a758f5c2a.jpg?1",
             "name": "Ichorplate Golem",
             "text": "Whenever a creature enters the battlefield under your control, if it has one or more oil counters on it, put an oil counter on it.\nCreatures you control with oil counters on them get +1/+1.",
             "colours": [],
@@ -8190,7 +8190,7 @@
         },
         {
             "id": "cf713e79-43f5-5d0d-a005-abde8c0102ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1073aee2-aea6-473d-97c6-248778d79d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1073aee2-aea6-473d-97c6-248778d79d80.jpg?1",
             "name": "Maze Skullbomb",
             "text": "{1}, Sacrifice Maze Skullbomb: Draw a card.\n{2}{G}, Sacrifice Maze Skullbomb: Target creature you control gets +3/+3 and gains trample until end of turn. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "df89add1-9ab4-5fac-999f-67e1f789d206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76fe2f2-ce2c-49e4-9f00-89c82f2fae8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76fe2f2-ce2c-49e4-9f00-89c82f2fae8d.jpg?1",
             "name": "Mirran Safehouse",
             "text": "As long as Mirran Safehouse is on the battlefield, it has all activated abilities of all land cards in all graveyards.",
             "colours": [],
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "e2a85358-af52-53c1-a4b7-9933a921617c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab892e7b-6797-4ede-ab5d-d9d0fa488c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab892e7b-6797-4ede-ab5d-d9d0fa488c80.jpg?1",
             "name": "Monument to Perfection",
             "text": "{3}, {T}: Search your library for a basic, Sphere, or Locus land card, reveal it, put it into your hand, then shuffle.\n{3}: Monument to Perfection becomes a 9/9 Phyrexian Construct artifact creature, loses all abilities, and gains indestructible and toxic 9. Activate only if there are nine or more lands with different names among the basic, Sphere, and Locus lands you control.",
             "colours": [],
@@ -8280,7 +8280,7 @@
         },
         {
             "id": "2df501c8-8536-58be-aa10-3209c42faa9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg?1",
             "name": "Myr Convert",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\n{T}, Pay 2 life: Add one mana of any color.",
             "colours": [],
@@ -8315,7 +8315,7 @@
         },
         {
             "id": "a68a6509-353f-55a0-b478-a5d2b173ccbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bfdd21-4d46-4ec2-ba25-f16b6993f1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bfdd21-4d46-4ec2-ba25-f16b6993f1a8.jpg?1",
             "name": "Myr Custodian",
             "text": "When Myr Custodian enters the battlefield, scry 2. Then each opponent may scry 1. (To scry X, that player looks at the top X cards of their library, then put any number of them on the bottom and the rest on top in any order.)",
             "colours": [],
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "6914752a-c557-58b5-a9c5-d002997c6856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6046e50a-f4c9-4029-a589-62a19371b734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6046e50a-f4c9-4029-a589-62a19371b734.jpg?1",
             "name": "Myr Kinsmith",
             "text": "When Myr Kinsmith enters the battlefield, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -8377,7 +8377,7 @@
         },
         {
             "id": "cdc59af9-db9e-5cb4-b0be-3d812f6b2d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5adb509-6ad3-4838-925d-1cafa926b83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5adb509-6ad3-4838-925d-1cafa926b83a.jpg?1",
             "name": "Phyrexian Atlas",
             "text": "{T}: Add one mana of any color.\nCorrupted \u2014 Whenever Phyrexian Atlas becomes tapped, each opponent who has three or more poison counters loses 1 life.",
             "colours": [],
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "ff8208f0-ce25-5034-9acd-4baa1d692c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3056ac38-7630-4301-88bb-a012a5b186ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3056ac38-7630-4301-88bb-a012a5b186ed.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8433,7 +8433,7 @@
         },
         {
             "id": "cc4be521-bef6-53df-b9d8-af4cf506e3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a1beec-bafe-4243-b91e-040a88fb0e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a1beec-bafe-4243-b91e-040a88fb0e95.jpg?1",
             "name": "Prosthetic Injector",
             "text": "Equipped creature gets +0/+2 and has toxic 1. (Players dealt combat damage by equipped creature also get a poison counter.)\nEquip {1}",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "c1254c43-4574-5a8a-ad6a-9014e76b6227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec8f984-5ed4-4b34-8b2a-a113cbba001d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec8f984-5ed4-4b34-8b2a-a113cbba001d.jpg?1",
             "name": "Ribskiff",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhen Ribskiff enters the battlefield, draw a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8493,7 +8493,7 @@
         },
         {
             "id": "b3d3b304-e427-5502-9075-9bb02fddbe7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9991fd-ea6a-4ed7-b5f1-46a95f8d0634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9991fd-ea6a-4ed7-b5f1-46a95f8d0634.jpg?1",
             "name": "Soulless Jailer",
             "text": "Permanent cards in graveyards can't enter the battlefield.\nPlayers can't cast noncreature spells from graveyards or exile.",
             "colours": [],
@@ -8527,7 +8527,7 @@
         },
         {
             "id": "ec257bb0-a4ac-5d8d-9071-7a50ee6a25cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2934af5-aa4f-4c88-adbd-dcd847ef43a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2934af5-aa4f-4c88-adbd-dcd847ef43a2.jpg?1",
             "name": "Staff of Compleation",
             "text": "{T}, Pay 1 life: Destroy target permanent you own.\n{T}, Pay 2 life: Add one mana of any color.\n{T}, Pay 3 life: Proliferate.\n{T}, Pay 4 life: Draw a card.\n{5}: Untap Staff of Compleation.",
             "colours": [],
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "5ff878e7-33c8-5c9a-8f02-1f2bec9add19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg?1",
             "name": "Surgical Skullbomb",
             "text": "{1}, Sacrifice Surgical Skullbomb: Draw a card.\n{2}{U}, Sacrifice Surgical Skullbomb: Return target creature to its owner's hand. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8587,7 +8587,7 @@
         },
         {
             "id": "41fc2554-ffdb-5897-a0b5-d023a1ce60c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa3621-8a2c-4b4b-87ac-f981192a0567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa3621-8a2c-4b4b-87ac-f981192a0567.jpg?1",
             "name": "Sword of Forge and Frontier",
             "text": "Equipped creature gets +2/+2 and has protection from red and from green.\nWhenever equipped creature deals combat damage to a player, exile the top two cards of your library. You may play those cards this turn. You may play an additional land this turn.\nEquip {2}",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "ac12fd65-4caa-5089-a4e5-70486b0df317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9747e4b0-fcf9-4f1d-b990-2a3e461adfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9747e4b0-fcf9-4f1d-b990-2a3e461adfee.jpg?1",
             "name": "Tablet of Compleation",
             "text": "{T}: Put an oil counter on Tablet of Compleation.\n{T}: Add {C}. Activate only if Tablet of Compleation has two or more oil counters on it.\n{1}, {T}: Draw a card. Activate only if Tablet of Compleation has five or more oil counters on it.",
             "colours": [],
@@ -8649,7 +8649,7 @@
         },
         {
             "id": "c81a1ccc-ea6f-5cd0-b37e-6769d51afed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431fe83-7dc7-4c40-8d66-6525560e4323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431fe83-7dc7-4c40-8d66-6525560e4323.jpg?1",
             "name": "Zenith Chronicler",
             "text": "Whenever a player casts their first multicolored spell each turn, each other player draws a card.",
             "colours": [],
@@ -8683,7 +8683,7 @@
         },
         {
             "id": "a32683d9-7e4b-5dde-8b67-290f2995b2f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16f96f5-a2a6-4ac4-bdae-326cee92bf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16f96f5-a2a6-4ac4-bdae-326cee92bf2e.jpg?1",
             "name": "The Autonomous Furnace",
             "text": "The Autonomous Furnace enters the battlefield tapped.\n{T}: Add {R}.\n{1}{R}, {T}, Sacrifice The Autonomous Furnace: Draw a card.",
             "colours": [],
@@ -8715,7 +8715,7 @@
         },
         {
             "id": "140bad0a-64b8-5f64-a73d-1e9d9095b667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1441fba4-fe06-4b5f-a103-aa6cf59a3859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1441fba4-fe06-4b5f-a103-aa6cf59a3859.jpg?1",
             "name": "Blackcleave Cliffs",
             "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8748,7 +8748,7 @@
         },
         {
             "id": "76dca8d1-34e6-5e31-b571-5c6cb9e4bd4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0f36b-7d8c-4e77-adc2-a4dad93a81d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0f36b-7d8c-4e77-adc2-a4dad93a81d5.jpg?1",
             "name": "Copperline Gorge",
             "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "c6092d44-6658-5556-858b-4c7afc31e48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbda15b-e49a-4445-a0e1-f221aa82c1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbda15b-e49a-4445-a0e1-f221aa82c1e8.jpg?1",
             "name": "Darkslick Shores",
             "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "78d187c6-3baa-5ae8-add9-18e18734216f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d469f1-2219-4466-9f8a-769ee43e28db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d469f1-2219-4466-9f8a-769ee43e28db.jpg?1",
             "name": "The Dross Pits",
             "text": "The Dross Pits enters the battlefield tapped.\n{T}: Add {B}.\n{1}{B}, {T}, Sacrifice The Dross Pits: Draw a card.",
             "colours": [],
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "2caf45dc-59c5-571a-a35a-f1d380cc70b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d6ba55-7bc0-41c6-84be-8cd528e46a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d6ba55-7bc0-41c6-84be-8cd528e46a05.jpg?1",
             "name": "The Fair Basilica",
             "text": "The Fair Basilica enters the battlefield tapped.\n{T}: Add {W}.\n{1}{W}, {T}, Sacrifice The Fair Basilica: Draw a card.",
             "colours": [],
@@ -8878,7 +8878,7 @@
         },
         {
             "id": "bfdbb395-bf75-54cf-9cd1-3d2af2955617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6389c242-2139-4f12-af30-2b080a1c5e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6389c242-2139-4f12-af30-2b080a1c5e83.jpg?1",
             "name": "The Hunter Maze",
             "text": "The Hunter Maze enters the battlefield tapped.\n{T}: Add {G}.\n{1}{G}, {T}, Sacrifice The Hunter Maze: Draw a card.",
             "colours": [],
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "f9ea76b0-2a1e-5277-a24b-b57b9b51053c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a702cd-ca49-4570-b47e-8b090452a3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a702cd-ca49-4570-b47e-8b090452a3c3.jpg?1",
             "name": "Mirrex",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Activate only if Mirrex entered the battlefield this turn.\n{3}, {T}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by it also get a poison counter.)",
             "colours": [],
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "883d83eb-055b-53ae-9318-0f9e1583dbb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6785057-0d06-4f91-b45f-c05f7c4e2b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6785057-0d06-4f91-b45f-c05f7c4e2b19.jpg?1",
             "name": "The Monumental Facade",
             "text": "The Monumental Facade enters the battlefield with two oil counters on it.\n{T}: Add {C}.\n{T}, Remove an oil counter from The Monumental Facade: Put an oil counter on target artifact or creature you control. Activate only as a sorcery.",
             "colours": [],
@@ -8974,7 +8974,7 @@
         },
         {
             "id": "7e44d41f-161b-5b6b-a913-aebb3e292a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a931463-25f6-4e31-95b4-bb4a9388009b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a931463-25f6-4e31-95b4-bb4a9388009b.jpg?1",
             "name": "The Mycosynth Gardens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{X}, {T}: The Mycosynth Gardens becomes a copy of target nontoken artifact you control with mana value X.",
             "colours": [],
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "4a778101-c1d6-5413-a27d-9d0927434d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b26f68-3a25-4c4e-bc76-a199ab479a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b26f68-3a25-4c4e-bc76-a199ab479a50.jpg?1",
             "name": "Razorverge Thicket",
             "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "7d614044-85d6-59db-b32f-0c6faf34f916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed7441f-f624-49c8-8611-d9bba0e441ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed7441f-f624-49c8-8611-d9bba0e441ac.jpg?1",
             "name": "Seachrome Coast",
             "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9072,7 +9072,7 @@
         },
         {
             "id": "0ce4cdcb-5d49-581c-9ab6-0eb57e95249d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c91aad-bf33-448e-b122-65940fb2e33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c91aad-bf33-448e-b122-65940fb2e33b.jpg?1",
             "name": "The Seedcore",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast Phyrexian creature spells.\nCorrupted \u2014 {T}: Target 1/1 creature gets +2/+1 until end of turn. Activate only if an opponent has three or more poison counters.",
             "colours": [],
@@ -9104,7 +9104,7 @@
         },
         {
             "id": "583277bf-d414-52cc-84de-e20080b3eea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49ec35-2c4f-4144-85fe-226f7cb67266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49ec35-2c4f-4144-85fe-226f7cb67266.jpg?1",
             "name": "The Surgical Bay",
             "text": "The Surgical Bay enters the battlefield tapped.\n{T}: Add {U}.\n{1}{U}, {T}, Sacrifice The Surgical Bay: Draw a card.",
             "colours": [],
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "79bdf24d-3306-528d-a4c5-39920c6f5954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adceb34-78c7-40dd-af31-6fb282d577ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adceb34-78c7-40dd-af31-6fb282d577ca.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9164,7 +9164,7 @@
         },
         {
             "id": "033b1a64-bdc0-59ec-8c1d-7fdbabd65956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50958c6e-9555-42ad-9bb3-2da9faa5cb52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50958c6e-9555-42ad-9bb3-2da9faa5cb52.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9202,7 +9202,7 @@
         },
         {
             "id": "2a6ab51e-424f-5487-85ec-943339e2dc2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6322d4-52bf-471a-a5b2-8329ef4be39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6322d4-52bf-471a-a5b2-8329ef4be39a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9240,7 +9240,7 @@
         },
         {
             "id": "7194b0ea-d862-564d-b459-7c48500cf781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736a0484-e091-4178-92c5-c517b0e92f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736a0484-e091-4178-92c5-c517b0e92f3d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "fee13d2f-7a4c-5b3b-bb4f-2860155c20ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9e44c1-7b51-47cb-b564-608deb46cc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9e44c1-7b51-47cb-b564-608deb46cc44.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9316,7 +9316,7 @@
         },
         {
             "id": "2fc57869-a899-5d3c-8270-50e7cc317ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fce7045-4572-4e9e-8853-2a5dcfc989ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fce7045-4572-4e9e-8853-2a5dcfc989ac.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9354,7 +9354,7 @@
         },
         {
             "id": "e823b2cd-efe1-55dc-b04f-bcb81dbdaea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ccde39-98bd-4a67-bfcf-a66d9fbd9417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ccde39-98bd-4a67-bfcf-a66d9fbd9417.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "ed09057a-b976-56a7-a80b-b6fac64c0f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97baa8-5e57-45b6-9c64-cb9ce4806294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97baa8-5e57-45b6-9c64-cb9ce4806294.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "e475bd17-a94e-52d0-921f-e298e4649800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e9fa1-6a50-4697-8645-fea4524e8dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e9fa1-6a50-4697-8645-fea4524e8dde.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "6d4ef65f-47de-5e7e-b268-e28362c6d0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c61b29-797f-4fda-acf1-039a807954c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c61b29-797f-4fda-acf1-039a807954c9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "001b516c-09a3-5776-92d3-944fee7c18e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ec4ded-7c8d-416a-9a12-3e5d6c91ac93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ec4ded-7c8d-416a-9a12-3e5d6c91ac93.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "5aeb8a6b-f2dd-5201-a315-fa37f04c3b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db14da86-6721-4e22-9b61-4a5680d4e5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db14da86-6721-4e22-9b61-4a5680d4e5a3.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "479243a5-f674-5b21-ba5e-00ebf23c9cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa641d46-d002-4903-af72-e96971f558bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa641d46-d002-4903-af72-e96971f558bc.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "570f0826-2dea-5ad3-82fd-a03517fca7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485c620-f1fb-4715-b7c5-d2d56588308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485c620-f1fb-4715-b7c5-d2d56588308d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9658,7 +9658,7 @@
         },
         {
             "id": "66de1103-e901-5910-a332-e91877915390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd95f833-27ce-447c-b505-02137daaba4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd95f833-27ce-447c-b505-02137daaba4c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9696,7 +9696,7 @@
         },
         {
             "id": "c952ea2f-c71f-5071-b07e-ad840d56bb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e911e-7e12-4d99-806c-5cfba19ea8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e911e-7e12-4d99-806c-5cfba19ea8f3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9734,7 +9734,7 @@
         },
         {
             "id": "835fcbd6-c719-5c01-b569-81d71d9094bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1374a1-2795-4477-b800-e8a777391ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1374a1-2795-4477-b800-e8a777391ef6.jpg?1",
             "name": "Ossification",
             "text": "Enchant basic land you control\nWhen Ossification enters the battlefield, exile target creature or planeswalker an opponent controls until Ossification leaves the battlefield.",
             "colours": [
@@ -9770,7 +9770,7 @@
         },
         {
             "id": "cf6b4bab-4dfe-5617-81e5-d7a36f247d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d056ff-ee47-4718-8587-6f172cdf8b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d056ff-ee47-4718-8587-6f172cdf8b2c.jpg?1",
             "name": "Experimental Augury",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. Proliferate.",
             "colours": [
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "118e682b-fe9e-5502-9103-bf43650d19f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d6e50e-d339-49b5-ab97-4b38bba7c187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d6e50e-d339-49b5-ab97-4b38bba7c187.jpg?1",
             "name": "Sheoldred's Edict",
             "text": "Choose one \u2014\n\u2022 Each opponent sacrifices a nontoken creature.\n\u2022 Each opponent sacrifices a creature token.\n\u2022 Each opponent sacrifices a planeswalker.",
             "colours": [
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "86691d07-203e-5cf9-82e5-29ed5f92bc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fd082c-3209-4268-8bf8-01dbbda15f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fd082c-3209-4268-8bf8-01dbbda15f1d.jpg?1",
             "name": "Bladehold War-Whip",
             "text": "For Mirrodin\nEquip abilities you activate of other Equipment cost {1} less to activate.\nEquipped creature has double strike.\nEquip {3}{R}{W}",
             "colours": [
@@ -9876,7 +9876,7 @@
         },
         {
             "id": "114cc2b1-66b9-5b72-9839-62f23889703b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a802def-efe2-4f65-9dff-a1c0d800b146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a802def-efe2-4f65-9dff-a1c0d800b146.jpg?1",
             "name": "Slaughter Singer",
             "text": "Toxic 2\nWhenever another creature you control with toxic attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -9915,7 +9915,7 @@
         },
         {
             "id": "93749cb0-2d01-5b80-b630-ff97d25e5ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c2d370-982d-4b1b-b9b3-371b08121b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c2d370-982d-4b1b-b9b3-371b08121b1f.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nOther Rats you control have toxic 1.\nWhen Karumonix enters the battlefield, look at the top five cards of your library. You may reveal any number of Rat cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "dab29a67-28a9-5847-a77e-1f0771b55be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b18d219-efde-4cc0-b955-cb71ead88023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b18d219-efde-4cc0-b955-cb71ead88023.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -9989,7 +9989,7 @@
         },
         {
             "id": "ed7712f8-8771-5828-9c5a-2faa0e49d6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c79dbc-0b75-4ffb-bc17-42cfe3cbd7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c79dbc-0b75-4ffb-bc17-42cfe3cbd7e4.jpg?1",
             "name": "Green Sun's Twilight",
             "text": "Reveal the top X plus one cards of your library. Choose a creature card and/or a land card from among them. Put those cards into your hand and the rest on the bottom of your library in a random order. If X is 5 or more, instead put the chosen cards onto the battlefield or into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10023,7 +10023,7 @@
         },
         {
             "id": "349d7608-d871-539d-b768-bfd6523b2697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85465be2-7327-4e1f-8a4b-d24dca4f3ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85465be2-7327-4e1f-8a4b-d24dca4f3ada.jpg?1",
             "name": "Bladed Ambassador",
             "text": "Bladed Ambassador enters the battlefield with an oil counter on it.\n{1}, Remove an oil counter from Bladed Ambassador: Bladed Ambassador gains indestructible until end of turn.",
             "colours": [
@@ -10061,7 +10061,7 @@
         },
         {
             "id": "918ef7db-4500-5365-a46d-e254bc9837be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7836bd5e-9df3-4f24-adce-ca7028fea78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7836bd5e-9df3-4f24-adce-ca7028fea78f.jpg?1",
             "name": "Sinew Dancer",
             "text": "{3}{W}, {T}: Tap target creature.\nCorrupted \u2014 {W}, {T}: Tap target creature. Activate only if an opponent has three or more poison counters.",
             "colours": [
@@ -10099,7 +10099,7 @@
         },
         {
             "id": "41aa8a9b-b8e7-5b2d-b9d3-7bf627c7c400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b394cdd1-a632-4b57-8356-4e2d9c9620f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b394cdd1-a632-4b57-8356-4e2d9c9620f7.jpg?1",
             "name": "Quicksilver Fisher",
             "text": "Flying\nWhen Quicksilver Fisher enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -10137,7 +10137,7 @@
         },
         {
             "id": "ec5bbe93-5a39-5d12-b9d5-2a310fee0d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9dd552-1020-4e82-ba51-f54b3938b920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9dd552-1020-4e82-ba51-f54b3938b920.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate.",
             "colours": [
@@ -10176,7 +10176,7 @@
         },
         {
             "id": "e33edf3e-e3e4-5adb-906f-71d259a1807e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20364e49-0948-411a-b58f-b0d12fedce43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20364e49-0948-411a-b58f-b0d12fedce43.jpg?1",
             "name": "Blightbelly Rat",
             "text": "Toxic 1\nWhen Blightbelly Rat dies, proliferate.",
             "colours": [
@@ -10214,7 +10214,7 @@
         },
         {
             "id": "374b0827-86e2-5bf0-8e3f-a278e646fe48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e1de30-1899-49ef-88ae-6defc69f19b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e1de30-1899-49ef-88ae-6defc69f19b3.jpg?1",
             "name": "Bonepicker Skirge",
             "text": "Flying\nCorrupted \u2014 As long as an opponent has three or more poison counters, Bonepicker Skirge has deathtouch and lifelink.",
             "colours": [
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "77b74dda-4f80-575a-ad5c-fe808e2fc33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66c086-bb19-45d1-8387-17348f2c5c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66c086-bb19-45d1-8387-17348f2c5c78.jpg?1",
             "name": "Furnace Punisher",
             "text": "Menace\nAt the beginning of each player's upkeep, Furnace Punisher deals 2 damage to that player unless they control two or more basic lands.",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "b3add4bb-63b8-52ff-85ab-5849c1d80605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3df8b6-3f31-4d1c-a165-40cb3f2e2233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3df8b6-3f31-4d1c-a165-40cb3f2e2233.jpg?1",
             "name": "Sawblade Scamp",
             "text": "Haste\nWhenever you cast a noncreature spell, put an oil counter on Sawblade Scamp.\n{T}, Remove an oil counter from Sawblade Scamp: It deals 1 damage to each opponent.",
             "colours": [
@@ -10328,7 +10328,7 @@
         },
         {
             "id": "5d13fb08-96f0-5517-8a9f-bcc768635444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d419a3d0-c1ee-4c7a-a88c-a6a8b1f7ab6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d419a3d0-c1ee-4c7a-a88c-a6a8b1f7ab6e.jpg?1",
             "name": "Urabrask's Anointer",
             "text": "When Urabrask's Anointer enters the battlefield, it deals X damage to any target, where X is the number of permanents you control with oil counters on them.",
             "colours": [
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "08fd4e5a-83ab-5688-aaee-3585a8ea05b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02272f89-dd8e-4a07-8bd4-b33ad4e12888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02272f89-dd8e-4a07-8bd4-b33ad4e12888.jpg?1",
             "name": "Cankerbloom",
             "text": "{1}, Sacrifice Cankerbloom: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Proliferate.",
             "colours": [
@@ -10405,7 +10405,7 @@
         },
         {
             "id": "5f94a228-3093-5cba-8613-ece1bcbe40f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8ef6fc-a81b-4354-aa65-c88590522d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8ef6fc-a81b-4354-aa65-c88590522d30.jpg?1",
             "name": "Rustvine Cultivator",
             "text": "{T}: Put an oil counter on Rustvine Cultivator.\n{T}, Remove an oil counter from Rustvine Cultivator: Untap target land.",
             "colours": [
@@ -10444,7 +10444,7 @@
         },
         {
             "id": "e5d92ef1-e112-57ea-b695-bb8e50a3de2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b4fe48-f9e6-4606-9901-76dd85fd7038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b4fe48-f9e6-4606-9901-76dd85fd7038.jpg?1",
             "name": "Necrogen Rotpriest",
             "text": "Toxic 2\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.",
             "colours": [
@@ -10485,7 +10485,7 @@
         },
         {
             "id": "8f90f581-52ab-551f-a745-38dce55111b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb7150-5157-4471-8874-4f9258c5d396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb7150-5157-4471-8874-4f9258c5d396.jpg?1",
             "name": "Myr Convert",
             "text": "Toxic 1\n{T}, Pay 2 life: Add one mana of any color.",
             "colours": [],
@@ -10520,7 +10520,7 @@
         },
         {
             "id": "e1e6c672-8060-5a49-b4c1-16d9aa3a38ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db44dd2-6bb4-4f0b-8bab-c0d89ba7f2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db44dd2-6bb4-4f0b-8bab-c0d89ba7f2ca.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -10567,7 +10567,7 @@
         },
         {
             "id": "81f3f988-934e-5aa0-8938-9aa7393b52c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c633ffe8-2198-4d62-969c-9a44a7ca132d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c633ffe8-2198-4d62-969c-9a44a7ca132d.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n{1}{PW}{PW}, Sacrifice two other artifacts and/or creatures: Put an indestructible counter on Mondrak, Glory Dominus.",
             "colours": [
@@ -10608,7 +10608,7 @@
         },
         {
             "id": "17a5bd77-30c4-5b0c-a421-b052f68db75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1b0b81-6f78-4c4b-9d0d-28acf0a15940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1b0b81-6f78-4c4b-9d0d-28acf0a15940.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "Flying\nIf damage would be dealt to Phyrexian Vindicator, prevent that damage. When damage is prevented this way, Phyrexian Vindicator deals that much damage to any other target.",
             "colours": [
@@ -10647,7 +10647,7 @@
         },
         {
             "id": "a1b4e9c3-be1c-5403-b371-6e86a5c42cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4862ed-7be8-4fd0-9150-a20e56d1e858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4862ed-7be8-4fd0-9150-a20e56d1e858.jpg?1",
             "name": "Skrelv, Defector Mite",
             "text": "Toxic 1\nSkrelv, Defector Mite can't block.\n{PW}, {T}: Choose a color. Another target creature you control gains toxic 1 and hexproof from that color until end of turn. It can't be blocked by creatures of that color this turn.",
             "colours": [
@@ -10688,7 +10688,7 @@
         },
         {
             "id": "0cfe8b12-6a8d-5c40-926b-93af05f007fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c17f88-440b-443a-bca7-6f4e8587cffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c17f88-440b-443a-bca7-6f4e8587cffb.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "Flying\nIf you would proliferate, proliferate twice instead.\n{1}{PU}{PU}, Remove three counters from among other artifacts, creatures, and planeswalkers you control: Put an indestructible counter on Tekuthal, Inquiry Dominus.",
             "colours": [
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "29456adc-b67a-520a-a76c-de5229c30445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc001d-b20b-4d6e-b744-f4f19339f0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc001d-b20b-4d6e-b744-f4f19339f0cb.jpg?1",
             "name": "Unctus, Grand Metatect",
             "text": "Other blue creatures you control have \"Whenever this creature becomes tapped, draw a card, then discard a card.\"\nOther artifact creatures you control get +1/+1.\n{PU}: Until end of turn, target creature you control becomes a blue artifact in addition to its other colors and types. Activate only as a sorcery.",
             "colours": [
@@ -10770,7 +10770,7 @@
         },
         {
             "id": "94ce7a4c-73e7-5b56-a831-37e606a28252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4aad94-5b0e-4644-b331-39dae2a7e937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4aad94-5b0e-4644-b331-39dae2a7e937.jpg?1",
             "name": "Archfiend of the Dross",
             "text": "Flying\nArchfiend of the Dross enters the battlefield with four oil counters on it.\nAt the beginning of your upkeep, remove an oil counter from Archfiend of the Dross. Then if it has no oil counters on it, you lose the game.\nWhenever a creature an opponent controls dies, its controller loses 2 life.",
             "colours": [
@@ -10808,7 +10808,7 @@
         },
         {
             "id": "d649fb73-5f39-5f68-a893-58290efbf50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676cf76-027d-423b-a84c-19179cee9d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676cf76-027d-423b-a84c-19179cee9d08.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n{PB}{PB}, Exile three creature cards from your graveyard: Put an indestructible counter on Drivnod, Carnage Dominus.",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "0f2c845c-d0d8-52d8-b6ef-a9482018f571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0957749-7539-4aa4-b89c-61c0e8ad0c55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0957749-7539-4aa4-b89c-61c0e8ad0c55.jpg?1",
             "name": "Geth, Thane of Contracts",
             "text": "Other creatures you control get -1/-1.\n{1}{B}{B}, {T}: Return target creature card from your graveyard to the battlefield. It gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else.\" Activate only as a sorcery.",
             "colours": [
@@ -10889,7 +10889,7 @@
         },
         {
             "id": "87d43a8a-c8a5-5ae7-a459-2b6a3c1d7646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55e3-71c5-4444-a307-76c8ccc0a02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55e3-71c5-4444-a307-76c8ccc0a02b.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "Toxic 1\nOther Rats you control have toxic 1.\nWhen Karumonix enters the battlefield, look at the top five cards of your library. You may reveal any number of Rat cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10930,7 +10930,7 @@
         },
         {
             "id": "872a5f71-a168-54b7-ae1e-9d97df26eb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216360c-ce9a-443a-b5c1-0ecd08aed37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216360c-ce9a-443a-b5c1-0ecd08aed37f.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "72654f92-fde1-5c58-b7f8-02d614811372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d279e-8350-4baf-9aa8-3c6f7b7ae444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d279e-8350-4baf-9aa8-3c6f7b7ae444.jpg?1",
             "name": "Vraan, Executioner Thane",
             "text": "Whenever one or more other creatures you control die, each opponent loses 2 life and you gain 2 life. This ability triggers only once each turn.",
             "colours": [
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "5609cdbc-a206-5d70-b9b8-a7bc51a6afa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fcddc7-126a-4e2c-898d-dcf488618cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fcddc7-126a-4e2c-898d-dcf488618cf0.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "This spell costs {3} less to cast if you have nine or more cards in your graveyard.\nFlying\nWhen Capricious Hellraiser enters the battlefield, exile three cards at random from your graveyard. Choose a noncreature, nonland card from among them and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -11048,7 +11048,7 @@
         },
         {
             "id": "365ab43f-ff90-5e26-ae3a-f789dda0482c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0c255c-d42e-413c-8afd-c8f373600cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0c255c-d42e-413c-8afd-c8f373600cbf.jpg?1",
             "name": "Slobad, Iron Goblin",
             "text": "{T}, Sacrifice an artifact: Add an amount of {R} equal to the sacrificed artifact's mana value. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -11089,7 +11089,7 @@
         },
         {
             "id": "2e54c269-1181-597c-af15-c8091e653de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91271b80-cc8c-436f-983e-3f168febeb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91271b80-cc8c-436f-983e-3f168febeb99.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "If a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals double that damage to that player or permanent instead.\n{1}{PR}{PR}, Discard two cards: Put an indestructible counter on Solphim, Mayhem Dominus.",
             "colours": [
@@ -11130,7 +11130,7 @@
         },
         {
             "id": "89b350fb-95db-5ae4-933a-e0019449924c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dd555e-cd27-4b9e-9ee6-b785242637d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dd555e-cd27-4b9e-9ee6-b785242637d6.jpg?1",
             "name": "Evolved Spinoderm",
             "text": "Evolved Spinoderm enters the battlefield with four oil counters on it.\nEvolved Spinoderm has trample as long as it has two or fewer oil counters on it. Otherwise, it has hexproof.\nAt the beginning of your upkeep, remove an oil counter from Evolved Spinoderm. Then if it has no oil counters on it, sacrifice it.",
             "colours": [
@@ -11168,7 +11168,7 @@
         },
         {
             "id": "c1d9701f-2738-521a-b7df-b863daf15057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3697cb-416c-49ca-a80a-c681e15230ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3697cb-416c-49ca-a80a-c681e15230ce.jpg?1",
             "name": "Tyrranax Rex",
             "text": "This spell can't be countered.\nTrample, toxic 4, ward {4}, haste",
             "colours": [
@@ -11207,7 +11207,7 @@
         },
         {
             "id": "fdaeea0f-2407-5b18-8630-42c53071aaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49782a6f-1a14-47c1-a6e6-e5650092684f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49782a6f-1a14-47c1-a6e6-e5650092684f.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "Reach\nAt the beginning of each combat, double the power and toughness of each creature you control until end of turn.\n{PG}{PG}, Sacrifice two other creatures: Put an indestructible counter on Zopandrel, Hunger Dominus.",
             "colours": [
@@ -11248,7 +11248,7 @@
         },
         {
             "id": "73907208-58f7-5afa-bac8-c44e4684120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e5d02-d3d0-45e5-a589-1fe25ff5082b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e5d02-d3d0-45e5-a589-1fe25ff5082b.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "Flying, vigilance, deathtouch, lifelink\nWhen Atraxa, Grand Unifier enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11295,7 +11295,7 @@
         },
         {
             "id": "cdddeb2b-ffb6-5930-b890-fcfb68360236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3be4338-2c79-470a-a11f-8f7370d98e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3be4338-2c79-470a-a11f-8f7370d98e85.jpg?1",
             "name": "Ezuri, Stalker of Spheres",
             "text": "When Ezuri, Stalker of Spheres enters the battlefield, you may pay {3}. If you do, proliferate twice.\nWhenever you proliferate, draw a card.",
             "colours": [
@@ -11338,7 +11338,7 @@
         },
         {
             "id": "86fe28e3-19d6-5506-8d2f-2a475b38197b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cecd38-6729-4870-8fad-4dfa4f9fcc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cecd38-6729-4870-8fad-4dfa4f9fcc3a.jpg?1",
             "name": "Glissa Sunslayer",
             "text": "First strike, deathtouch\nWhenever Glissa Sunslayer deals combat damage to a player, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Destroy target enchantment.\n\u2022 Remove up to three counters from target permanent.",
             "colours": [
@@ -11381,7 +11381,7 @@
         },
         {
             "id": "32f35b50-83cf-5400-ae06-c832ed1478f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34e3ef-8d6d-4304-bb19-803f8c049205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34e3ef-8d6d-4304-bb19-803f8c049205.jpg?1",
             "name": "Kethek, Crucible Goliath",
             "text": "At the beginning of your end step, you may sacrifice another creature. If you do, reveal cards from the top of your library until you reveal a nonlegendary creature card with lesser mana value, put it onto the battlefield, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "1cb0779f-91cb-5310-a9ac-221685cce123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2960de-b1ee-4ac3-bf34-835e7edb6582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2960de-b1ee-4ac3-bf34-835e7edb6582.jpg?1",
             "name": "Malcator, Purity Overseer",
             "text": "When Malcator, Purity Overseer enters the battlefield, create a 3/3 colorless Phyrexian Golem artifact creature token.\nAt the beginning of your end step, if three or more artifacts entered the battlefield under your control this turn, create a 3/3 colorless Phyrexian Golem artifact creature token.",
             "colours": [
@@ -11466,7 +11466,7 @@
         },
         {
             "id": "86e9a9b5-a5eb-57d6-b8ed-4072b09c2332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f24481-fd89-4d0e-bb64-1f6afe4f17df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f24481-fd89-4d0e-bb64-1f6afe4f17df.jpg?1",
             "name": "Migloz, Maze Crusher",
             "text": "Migloz, Maze Crusher enters the battlefield with five oil counters on it.\n{1}, Remove an oil counter from Migloz: It gains vigilance and menace until end of turn.\n{2}, Remove two oil counters from Migloz: It gets +2/+2 until end of turn.\n{3}, Remove three oil counters from Migloz: Destroy target artifact or enchantment.",
             "colours": [
@@ -11508,7 +11508,7 @@
         },
         {
             "id": "46d3009b-572b-5c35-b220-6e466423e500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52321500-b025-4195-819a-4b895315d0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52321500-b025-4195-819a-4b895315d0ee.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "Flying\nWard\u2014{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
             "colours": [
@@ -11550,7 +11550,7 @@
         },
         {
             "id": "fcc1acdf-59b3-5b6f-b435-12bd4b7ad170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e4160e-bc91-416e-8ab0-49742fd8ed63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e4160e-bc91-416e-8ab0-49742fd8ed63.jpg?1",
             "name": "Ria Ivor, Bane of Bladehold",
             "text": "Battle cry\nAt the beginning of combat on your turn, the next time target creature would deal combat damage to one or more players this combat, prevent that damage. If damage is prevented this way, create that many 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -11592,7 +11592,7 @@
         },
         {
             "id": "8b2bfea9-701a-5b76-bbe8-6c9f813f0f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7089903f-25cb-4eda-9ebb-ddad36fc8610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7089903f-25cb-4eda-9ebb-ddad36fc8610.jpg?1",
             "name": "Venser, Corpse Puppet",
             "text": "Lifelink, toxic 1\nWhenever you proliferate, choose one \u2014\n\u2022 If you don't control a creature named The Hollow Sentinel, create The Hollow Sentinel, a legendary 3/3 colorless Phyrexian Golem artifact creature token.\n\u2022 Target artifact creature you control gains flying and lifelink until end of turn.",
             "colours": [
@@ -11635,7 +11635,7 @@
         },
         {
             "id": "b7531f1f-fd7e-5c99-9525-d8b530f11c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b1acf9-9d25-4d80-a364-34eecaa474b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b1acf9-9d25-4d80-a364-34eecaa474b0.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "Compleated\n+1: Until your next turn, up to one target creature gets -3/-0.\n\u22122: Target player mills three cards. Then if a graveyard has twenty or more cards in it, you draw three cards. Otherwise, you draw a card.\n\u2212X: Target player mills three times X cards.",
             "colours": [
@@ -11677,7 +11677,7 @@
         },
         {
             "id": "e6261f1b-248b-5aa4-8bdb-8d9f9a171c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdbadc3-f93d-4ec8-aa56-3fe235b9a85e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdbadc3-f93d-4ec8-aa56-3fe235b9a85e.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "Compleated\n0: You draw a card and you lose 1 life. Proliferate.\n\u22122: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\u22129: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.",
             "colours": [
@@ -11719,7 +11719,7 @@
         },
         {
             "id": "b64afc3d-a8e6-58ca-939e-15b35f95600c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a0ced-c1c9-4a35-b1ce-476506afc030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a0ced-c1c9-4a35-b1ce-476506afc030.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "Compleated\n+1: Create an X/X green Phyrexian Horror creature token, where X is Nissa, Ascended Animist's loyalty.\n\u22121: Destroy target artifact or enchantment.\n\u22127: Until end of turn, creatures you control get +1/+1 for each Forest you control and gain trample.",
             "colours": [
@@ -11761,7 +11761,7 @@
         },
         {
             "id": "39a68207-0be5-5248-aca9-831155f20a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b70560-5c87-4aa7-9e92-5c80e4cc1115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b70560-5c87-4aa7-9e92-5c80e4cc1115.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "Compleated\n+1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.\n\u22121: Create a 3/3 green Phyrexian Beast creature token with toxic 1.\n\u22124: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers, where X is the greatest power among creatures you controlled as you activated this ability.",
             "colours": [
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "b1889829-459a-50f7-bf4a-36cde8037059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad016ccb-bb4d-427a-a6c2-9fd65924e542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad016ccb-bb4d-427a-a6c2-9fd65924e542.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "Compleated\n+1: Until your next turn, up to one target creature attacks a player each combat if able.\n+1: Discard a card, then draw a card.\n0: Exile target creature or Equipment card with mana value less than Nahiri's loyalty from your graveyard. Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -11849,7 +11849,7 @@
         },
         {
             "id": "3318293c-c846-58a6-b104-f029befc1ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192ccc7f-ffb1-4f78-8cf0-a220df612be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192ccc7f-ffb1-4f78-8cf0-a220df612be7.jpg?1",
             "name": "Kemba, Kha Enduring",
             "text": "Whenever Kemba, Kha Enduring or another Cat enters the battlefield under your control, attach up to one target Equipment you control to that creature.\nEquipped creatures you control get +1/+1.\n{3}{W}{W}: Create a 2/2 white Cat creature token.",
             "colours": [
@@ -11889,7 +11889,7 @@
         },
         {
             "id": "45bcac82-2327-5dec-8d7f-558e4d09b1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374b5642-8fd2-414b-b634-9a9cba801846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374b5642-8fd2-414b-b634-9a9cba801846.jpg?1",
             "name": "Thrun, Breaker of Silence",
             "text": "This spell can't be countered.\nTrample\nThrun, Breaker of Silence can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.\nAs long as it's your turn, Thrun has indestructible.",
             "colours": [
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "19ae57ae-94fe-55f0-bafe-1f64c2e55f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01502e03-4cd6-40ef-b8fe-93e76e7ed54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01502e03-4cd6-40ef-b8fe-93e76e7ed54b.jpg?1",
             "name": "Jor Kadeen, First Goldwarden",
             "text": "Trample\nWhenever Jor Kadeen, First Goldwarden attacks, it gets +X/+X until end of turn, where X is the number of equipped creatures you control. Then if Jor Kadeen's power is 4 or greater, draw a card.",
             "colours": [
@@ -11971,7 +11971,7 @@
         },
         {
             "id": "c9450738-87c8-512e-900c-c375cb7d66c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54455a6a-5a59-4a2f-b7e9-732a11d49f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54455a6a-5a59-4a2f-b7e9-732a11d49f6d.jpg?1",
             "name": "Melira, the Living Cure",
             "text": "If you would get one or more poison counters, instead you get one poison counter and you can't get additional poison counters this turn.\nExile Melira, the Living Cure: Choose another target creature or artifact. When it's put into a graveyard this turn, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "cb83ef19-aa6c-554b-9a53-c43839defcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e29a758-d930-4a99-b524-fc72bd125485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e29a758-d930-4a99-b524-fc72bd125485.jpg?1",
             "name": "Graaz, Unstoppable Juggernaut",
             "text": "Juggernauts you control attack each combat if able.\nJuggernauts you control can't be blocked by Walls.\nOther creatures you control have base power and toughness 5/3 and are Juggernauts in addition to their other creature types.",
             "colours": [],
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "a7070278-1396-55fa-ba70-5cd38a7d14af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af4c00-014c-448c-ac48-53a4698cf8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af4c00-014c-448c-ac48-53a4698cf8d8.jpg?1",
             "name": "The Eternal Wanderer",
             "text": "No more than one creature can attack The Eternal Wanderer each combat.\n+1: Exile up to one target artifact or creature. Return that card to the battlefield under its owner's control at the beginning of that player's next end step.\n0: Create a 2/2 white Samurai creature token with double strike.\n\u22124: For each player, choose a creature that player controls. Each player sacrifices all creatures they control not chosen this way.",
             "colours": [
@@ -12086,7 +12086,7 @@
         },
         {
             "id": "757f6de6-d8cd-58d8-ad8a-5f074283cfcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b48007-37d7-49b9-ad47-1fe0db14c3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b48007-37d7-49b9-ad47-1fe0db14c3c4.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "Compleated\n+1: Until your next turn, up to one target creature gets -3/-0.\n\u22122: Target player mills three cards. Then if a graveyard has twenty or more cards in it, you draw three cards. Otherwise, you draw a card.\n\u2212X: Target player mills three times X cards.",
             "colours": [
@@ -12128,7 +12128,7 @@
         },
         {
             "id": "20d4c1da-25f5-5685-abb8-871cb25be961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa015843-2aff-4184-9432-a548e379b1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa015843-2aff-4184-9432-a548e379b1f4.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "Compleated\n0: You draw a card and you lose 1 life. Proliferate.\n\u22122: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\u22129: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.",
             "colours": [
@@ -12170,7 +12170,7 @@
         },
         {
             "id": "1c62caf6-826f-5b9d-85ab-c21284db73df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fc1c96-849e-43a8-9e7f-3c3af6861155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fc1c96-849e-43a8-9e7f-3c3af6861155.jpg?1",
             "name": "Koth, Fire of Resistance",
             "text": "+2: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n\u22123: Koth, Fire of Resistance deals damage to target creature equal to the number of Mountains you control.\n\u22127: You get an emblem with \"Whenever a Mountain enters the battlefield under your control, this emblem deals 4 damage to any target.\"",
             "colours": [
@@ -12209,7 +12209,7 @@
         },
         {
             "id": "37d2bc9d-f0cb-5b96-bcd8-b6e3058e3a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d6d5a-acd4-444d-a670-2fc87e4d53b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d6d5a-acd4-444d-a670-2fc87e4d53b0.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "Compleated\n+1: Create an X/X green Phyrexian Horror creature token, where X is Nissa, Ascended Animist's loyalty.\n\u22121: Destroy target artifact or enchantment.\n\u22127: Until end of turn, creatures you control get +1/+1 for each Forest you control and gain trample.",
             "colours": [
@@ -12251,7 +12251,7 @@
         },
         {
             "id": "84e11d08-2917-5507-81d0-2c98a39b0e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f04ee2-dd29-4ce8-98a6-d8b669c71308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f04ee2-dd29-4ce8-98a6-d8b669c71308.jpg?1",
             "name": "Kaito, Dancing Shadow",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may return one of them to its owner's hand. If you do, you may activate loyalty abilities of Kaito twice this turn rather than only once.\n+1: Up to one target creature can't attack or block until your next turn.\n0: Draw a card.\n\u22122: Create a 2/2 colorless Drone artifact creature token with deathtouch and \"When this creature leaves the battlefield, each opponent loses 2 life and you gain 2 life.\"",
             "colours": [
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "11acd014-5c18-50d7-8ab5-a3ac0364b942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35830b2-b622-4b95-b36f-37c3de83c694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35830b2-b622-4b95-b36f-37c3de83c694.jpg?1",
             "name": "Kaya, Intangible Slayer",
             "text": "Hexproof\n+2: Each opponent loses 3 life and you gain 3 life.\n0: You draw two cards. Then each opponent may scry 1.\n\u22123: Exile target creature or enchantment. If it wasn't an Aura, create a token that's a copy of it, except it's a 1/1 white Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -12333,7 +12333,7 @@
         },
         {
             "id": "92d8bd84-3de6-576b-a7a7-670087354f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5e2da-3e4f-4f48-8510-619ff3cc5952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5e2da-3e4f-4f48-8510-619ff3cc5952.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "Compleated\n+1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.\n\u22121: Create a 3/3 green Phyrexian Beast creature token with toxic 1.\n\u22124: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers, where X is the greatest power among creatures you controlled as you activated this ability.",
             "colours": [
@@ -12377,7 +12377,7 @@
         },
         {
             "id": "42286bd8-c3b2-503a-a1ef-2557e678a41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d97fd-b5d7-4c9d-b1ed-d84e2ba820fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d97fd-b5d7-4c9d-b1ed-d84e2ba820fa.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "Compleated\n+1: Until your next turn, up to one target creature attacks a player each combat if able.\n+1: Discard a card, then draw a card.\n0: Exile target creature or Equipment card with mana value less than Nahiri's loyalty from your graveyard. Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "55da91da-7ce4-5851-8b00-9d822a945e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bddf1b3-e23f-4f05-977d-257881b8babe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bddf1b3-e23f-4f05-977d-257881b8babe.jpg?1",
             "name": "Tyvar, Jubilant Brawler",
             "text": "You may activate abilities of creatures you control as though those creatures had haste.\n+1: Untap up to one target creature.\n\u22122: Mill three cards, then you may return a creature card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -12462,7 +12462,7 @@
         },
         {
             "id": "7d437eb9-e2c7-5850-9e5e-c82026f6b4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ceaf6-b22d-4a4f-aa04-41202d72b379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ceaf6-b22d-4a4f-aa04-41202d72b379.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -12508,7 +12508,7 @@
         },
         {
             "id": "a4cadcaf-f018-52ea-8436-27e36d13ed24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef1b6a8-0151-4e41-a909-3d519dc19f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef1b6a8-0151-4e41-a909-3d519dc19f14.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "",
             "colours": [
@@ -12548,7 +12548,7 @@
         },
         {
             "id": "08d560a9-98e5-5025-aed8-2129bdb7d38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8bb65-07b7-462a-9bbb-0f48cb872b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8bb65-07b7-462a-9bbb-0f48cb872b43.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "18ee7d02-5440-5f52-bfb0-ae75662e1348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac5bc52-dd0d-473e-ad8a-a0f5b546d1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac5bc52-dd0d-473e-ad8a-a0f5b546d1ee.jpg?1",
             "name": "Ichormoon Gauntlet",
             "text": "",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "16ac6bdf-4fe4-53e9-8b52-1c186ba0e41e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9b1f69-baf8-4e36-8612-d4fc486a5568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9b1f69-baf8-4e36-8612-d4fc486a5568.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "",
             "colours": [
@@ -12659,7 +12659,7 @@
         },
         {
             "id": "58ad6b04-c057-519a-a3aa-cf6a6b74d92e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682cdf8e-6248-49bc-816d-35e75de64a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682cdf8e-6248-49bc-816d-35e75de64a1f.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "",
             "colours": [
@@ -12699,7 +12699,7 @@
         },
         {
             "id": "28f5ed5f-21b1-55fb-9901-e08f3c16f491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c44e5-dd14-4569-8e2d-466f72eaf287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c44e5-dd14-4569-8e2d-466f72eaf287.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "",
             "colours": [
@@ -12737,7 +12737,7 @@
         },
         {
             "id": "73765b7d-f169-57d1-9810-c9a5c46a5eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff67241-4c6a-436d-893b-ef7760825e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff67241-4c6a-436d-893b-ef7760825e68.jpg?1",
             "name": "All Will Be One",
             "text": "",
             "colours": [
@@ -12770,7 +12770,7 @@
         },
         {
             "id": "59b0ffc0-8b0d-5db6-9780-6cfc1d882c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7bdd7a-6d85-4d9c-ae21-c0701160b348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7bdd7a-6d85-4d9c-ae21-c0701160b348.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "",
             "colours": [
@@ -12808,7 +12808,7 @@
         },
         {
             "id": "b0c52e89-e2cb-595b-800b-4532d2a61f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8273b43-6702-412e-b0c1-4c715fa24ed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8273b43-6702-412e-b0c1-4c715fa24ed6.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "",
             "colours": [
@@ -12848,7 +12848,7 @@
         },
         {
             "id": "6986b9f3-74bb-5db2-b4f4-8a5f3c3b3fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9989f-6314-4bae-9404-430582af2bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9989f-6314-4bae-9404-430582af2bf5.jpg?1",
             "name": "Tyrranax Rex",
             "text": "",
             "colours": [
@@ -12886,7 +12886,7 @@
         },
         {
             "id": "4e017e79-d6d9-5bc3-9640-d2ae8f72adde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4e681-91f2-47ad-942e-b1c1950ff81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4e681-91f2-47ad-942e-b1c1950ff81d.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "",
             "colours": [
@@ -12926,7 +12926,7 @@
         },
         {
             "id": "253a7431-e232-59b4-955f-ce4e87b68a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b484a071-1e65-4bb3-893b-d34d7d101af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b484a071-1e65-4bb3-893b-d34d7d101af8.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "",
             "colours": [
@@ -12972,7 +12972,7 @@
         },
         {
             "id": "a2e75550-8378-50d0-80e7-a791c80133ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315490d2-4d1f-4065-9d18-4682f1d7d066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315490d2-4d1f-4065-9d18-4682f1d7d066.jpg?1",
             "name": "Staff of Compleation",
             "text": "",
             "colours": [],
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "a0c48f39-a25d-5fef-bee8-c42cdd5343c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d98f3d-046c-4acc-8cd3-51876844613c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d98f3d-046c-4acc-8cd3-51876844613c.jpg?1",
             "name": "Sword of Forge and Frontier",
             "text": "",
             "colours": [],
@@ -13032,7 +13032,7 @@
         },
         {
             "id": "38b4bca4-0dab-549d-b409-d4c86b590efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d00f39-cdc0-4e26-b2c7-0aae50f76e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d00f39-cdc0-4e26-b2c7-0aae50f76e85.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "",
             "colours": [
@@ -13073,7 +13073,7 @@
         },
         {
             "id": "fb262505-2f6f-56f3-9593-69387fdeb47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4d205-8721-46c4-81b9-017c9a5adcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4d205-8721-46c4-81b9-017c9a5adcae.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "",
             "colours": [
@@ -13114,7 +13114,7 @@
         },
         {
             "id": "5d43ef27-f5a5-52e4-ac22-c4df1bc8173a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e4d34-65c1-4d5f-8689-600c68c01931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e4d34-65c1-4d5f-8689-600c68c01931.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "",
             "colours": [
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "a74d2d5c-b75b-5a48-8287-fb6e23f381a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c1d8c-ddb8-4617-8d59-5427cbde7972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c1d8c-ddb8-4617-8d59-5427cbde7972.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "",
             "colours": [
@@ -13198,7 +13198,7 @@
         },
         {
             "id": "4d548085-e5e4-56a4-94d6-763616773fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7a6dbb-9dee-4e2b-8372-e74f49fe83d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7a6dbb-9dee-4e2b-8372-e74f49fe83d1.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "",
             "colours": [
@@ -13241,7 +13241,7 @@
         },
         {
             "id": "8a41f21f-6cea-5957-8ecc-0a10389141d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82b57f-a886-4423-a921-9932055feb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82b57f-a886-4423-a921-9932055feb68.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -13278,7 +13278,7 @@
         },
         {
             "id": "1ada23b6-f837-5c93-8be4-256481515379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6f4848-85b9-4770-9820-516e2a295284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6f4848-85b9-4770-9820-516e2a295284.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13315,7 +13315,7 @@
         },
         {
             "id": "7dcc04ce-1788-5229-abea-56596487a2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af92ec23-a252-4ae2-98d7-0dce19d18e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af92ec23-a252-4ae2-98d7-0dce19d18e35.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13352,7 +13352,7 @@
         },
         {
             "id": "92ae7986-05f3-5df2-99f0-f39f491848fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b4fb7-dbfe-4d9d-b520-4a307c31c876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b4fb7-dbfe-4d9d-b520-4a307c31c876.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -13389,7 +13389,7 @@
         },
         {
             "id": "d184a3d0-65b1-5f03-84cc-a4a3eaf7d9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d94fa1c-48d1-48bc-b725-5c11a158507b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d94fa1c-48d1-48bc-b725-5c11a158507b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "069f26dc-ea0f-5f69-83db-3122da6f1cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359ab776-e30c-4ccf-8fb8-8597812f131d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359ab776-e30c-4ccf-8fb8-8597812f131d.jpg?1",
             "name": "Blackcleave Cliffs",
             "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -13459,7 +13459,7 @@
         },
         {
             "id": "feefae0a-d8a7-5d1c-a67f-f885abe35192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d316dca-05e6-471e-99ad-dfd9eecedf39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d316dca-05e6-471e-99ad-dfd9eecedf39.jpg?1",
             "name": "Copperline Gorge",
             "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -13492,7 +13492,7 @@
         },
         {
             "id": "8ef8239b-d954-504d-93cf-c5f5be8731fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b95c400-8fa0-489d-b401-5e2ec4241942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b95c400-8fa0-489d-b401-5e2ec4241942.jpg?1",
             "name": "Darkslick Shores",
             "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -13525,7 +13525,7 @@
         },
         {
             "id": "e34148ce-2ce6-5e31-a548-28210a9a674d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedadf47-0e1e-4569-9da6-fac097f32497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedadf47-0e1e-4569-9da6-fac097f32497.jpg?1",
             "name": "Razorverge Thicket",
             "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -13558,7 +13558,7 @@
         },
         {
             "id": "8500abb8-7a5b-5688-bde0-920ba7d759de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f4e8-aa29-4c68-ab89-7a529bae73e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f4e8-aa29-4c68-ab89-7a529bae73e9.jpg?1",
             "name": "Seachrome Coast",
             "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -13591,7 +13591,7 @@
         },
         {
             "id": "14a735e6-55d5-50f7-9083-dd130a2da580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf5e4f-c907-4ab4-877d-90fe7623cb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf5e4f-c907-4ab4-877d-90fe7623cb81.jpg?1",
             "name": "Norn's Wellspring",
             "text": "Whenever a creature you control dies, scry 1 and put an oil counter on Norn's Wellspring.\n{1}, {T}, Remove two oil counters from Norn's Wellspring: Draw a card.",
             "colours": [
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "58a0fea6-7953-529b-ae7d-2643221774f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029caf7-da57-4894-ab27-4718977817c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029caf7-da57-4894-ab27-4718977817c5.jpg?1",
             "name": "Skrelv's Hive",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"\nCorrupted \u2014 As long as an opponent has three or more poison counters, creatures you control with toxic have lifelink.",
             "colours": [
@@ -13659,7 +13659,7 @@
         },
         {
             "id": "dc7de853-76a7-5121-ab56-36919a1a724b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8d13-45e5-4ead-8617-0b3939bb9123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8d13-45e5-4ead-8617-0b3939bb9123.jpg?1",
             "name": "White Sun's Twilight",
             "text": "You gain X life. Create X 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -13693,7 +13693,7 @@
         },
         {
             "id": "9e81fc5b-53bc-5ffe-b7d3-514ea3800dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e3aa37-80dc-4c5a-b118-788298ee3fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e3aa37-80dc-4c5a-b118-788298ee3fd5.jpg?1",
             "name": "Blade of Shared Souls",
             "text": "For Mirrodin\nWhenever Blade of Shared Souls becomes attached to a creature, for as long as Blade of Shared Souls remains attached to it, you may have that creature become a copy of another target creature you control.\nEquip {2}",
             "colours": [
@@ -13729,7 +13729,7 @@
         },
         {
             "id": "ee92fd87-40e6-5131-80a4-3d55beb25783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7a6f3e-4e9f-4e50-ab60-17dc1b494fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7a6f3e-4e9f-4e50-ab60-17dc1b494fa5.jpg?1",
             "name": "Blue Sun's Twilight",
             "text": "Gain control of target creature with mana value X or less. If X is 5 or more, create a token that's a copy of that creature.",
             "colours": [
@@ -13763,7 +13763,7 @@
         },
         {
             "id": "b6eaac7f-6503-5be4-b9b1-a77a94c730d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764475dd-00ee-4e5b-bf17-06b5c534ffe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764475dd-00ee-4e5b-bf17-06b5c534ffe0.jpg?1",
             "name": "Encroaching Mycosynth",
             "text": "Nonland permanents you control are artifacts in addition to their other types. The same is true for permanent spells you control and nonland permanent cards you own that aren't on the battlefield.",
             "colours": [
@@ -13797,7 +13797,7 @@
         },
         {
             "id": "b27bc2ad-c557-5de6-925c-8979c1af3d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b820e40-178d-4dac-b5f9-e4192e6d9161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b820e40-178d-4dac-b5f9-e4192e6d9161.jpg?1",
             "name": "Mercurial Spelldancer",
             "text": "Mercurial Spelldancer can't be blocked.\nWhenever you cast a noncreature spell, put an oil counter on Mercurial Spelldancer.\nWhenever Mercurial Spelldancer deals combat damage to a player, you may remove two oil counters from it. If you do, when you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -13834,7 +13834,7 @@
         },
         {
             "id": "c7a169b0-2ad3-5293-9652-a32671c91782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e92da4c-85ed-4afa-8755-dc9627491b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e92da4c-85ed-4afa-8755-dc9627491b07.jpg?1",
             "name": "Mindsplice Apparatus",
             "text": "Flash\nAt the beginning of your upkeep, put an oil counter on Mindsplice Apparatus.\nInstant and sorcery spells you cast cost {1} less to cast for each oil counter on Mindsplice Apparatus.",
             "colours": [
@@ -13868,7 +13868,7 @@
         },
         {
             "id": "668b9602-035e-542d-a98e-0e0980d02b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646144b6-f644-4a3f-af46-63feb16bd0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646144b6-f644-4a3f-af46-63feb16bd0f9.jpg?1",
             "name": "Black Sun's Twilight",
             "text": "Up to one target creature gets -X/-X until end of turn. If X is 5 or more, return a creature card with mana value X or less from your graveyard to the battlefield tapped.",
             "colours": [
@@ -13902,7 +13902,7 @@
         },
         {
             "id": "8cb3b628-c30b-5bff-bb12-14966c7f0b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0ecf3a-ac0e-45a6-98ae-8c043c636252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0ecf3a-ac0e-45a6-98ae-8c043c636252.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -13937,7 +13937,7 @@
         },
         {
             "id": "1926cccd-2ea8-56f9-b950-892b09c0ca5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eccd1f0-8e03-48c7-b457-c616c0bd79ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eccd1f0-8e03-48c7-b457-c616c0bd79ae.jpg?1",
             "name": "Dragonwing Glider",
             "text": "For Mirrodin\nEquipped creature gets +2/+2 and has flying and haste.\nEquip {3}{R}{R}",
             "colours": [
@@ -13973,7 +13973,7 @@
         },
         {
             "id": "fc74836a-1902-59d0-87e1-4c3cea64ceef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf27ba9-7d6a-41d1-acec-a55c25e39997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf27ba9-7d6a-41d1-acec-a55c25e39997.jpg?1",
             "name": "Red Sun's Twilight",
             "text": "Destroy up to X target artifacts. If X is 5 or more, for each artifact destroyed this way, create a token that's a copy of it. Those tokens gain haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -14007,7 +14007,7 @@
         },
         {
             "id": "a0ce5988-857e-56c7-a922-d4b9358a9185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd0ae70-db67-43d8-beab-e70c97794d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd0ae70-db67-43d8-beab-e70c97794d7b.jpg?1",
             "name": "Urabrask's Forge",
             "text": "At the beginning of combat on your turn, put an oil counter on Urabrask's Forge, then create an X/1 red Phyrexian Horror creature token with trample and haste, where X is the number of oil counters on Urabrask's Forge. Sacrifice that token at the beginning of the next end step.",
             "colours": [
@@ -14041,7 +14041,7 @@
         },
         {
             "id": "9e9d87cb-6276-5158-8fba-827e043a9fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c266012-6374-4870-917a-532fadf917ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c266012-6374-4870-917a-532fadf917ad.jpg?1",
             "name": "Vindictive Flamestoker",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Vindictive Flamestoker.\n{6}{R}, Sacrifice Vindictive Flamestoker: Discard your hand, then draw four cards. This ability costs {1} less to activate for each oil counter on Vindictive Flamestoker.",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "cc8a2a3f-ee66-5775-a33b-8c84eb207cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53285ae-3345-4ebf-836f-8eb8ae43c21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53285ae-3345-4ebf-836f-8eb8ae43c21f.jpg?1",
             "name": "Bloated Contaminator",
             "text": "Trample, toxic 1\nWhenever Bloated Contaminator deals combat damage to a player, proliferate.",
             "colours": [
@@ -14115,7 +14115,7 @@
         },
         {
             "id": "bc0c6360-89f9-5404-9120-0224573ce3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc653708-e7de-48fb-ba4f-6e52163160e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc653708-e7de-48fb-ba4f-6e52163160e2.jpg?1",
             "name": "Conduit of Worlds",
             "text": "You may play lands from your graveyard.\n{T}: Choose target nonland permanent card in your graveyard. If you haven't cast a spell this turn, you may cast that card. If you do, you can't cast additional spells this turn. Activate only as a sorcery.",
             "colours": [
@@ -14149,7 +14149,7 @@
         },
         {
             "id": "e86979f7-39b7-57e2-8dd2-b895bdb78611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8f1ec-a5d6-4ad5-af27-2604f1fb211a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8f1ec-a5d6-4ad5-af27-2604f1fb211a.jpg?1",
             "name": "Green Sun's Twilight",
             "text": "Reveal the top X plus one cards of your library. Choose a creature card and/or a land card from among them. Put those cards into your hand and the rest on the bottom of your library in a random order. If X is 5 or more, instead put the chosen cards onto the battlefield or into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14184,7 +14184,7 @@
         },
         {
             "id": "0b2f7c20-9905-5cee-b393-0bce147521fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ea9176-16cf-4064-8c69-071a520a110b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ea9176-16cf-4064-8c69-071a520a110b.jpg?1",
             "name": "Venerated Rotpriest",
             "text": "Toxic 1\nWhenever a creature you control becomes the target of a spell, target opponent gets a poison counter.",
             "colours": [
@@ -14221,7 +14221,7 @@
         },
         {
             "id": "43ba161c-89d5-56d4-a94d-f3e9c0477c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149425d1-e0d3-4b97-b893-b8a5055e0e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149425d1-e0d3-4b97-b893-b8a5055e0e7d.jpg?1",
             "name": "Argentum Masticore",
             "text": "First strike, protection from multicolored\nAt the beginning of your upkeep, sacrifice Argentum Masticore unless you discard a card. When you discard a card this way, destroy target nonland permanent an opponent controls with mana value less than or equal to the mana value of the discarded card.",
             "colours": [],
@@ -14255,7 +14255,7 @@
         },
         {
             "id": "93a13057-2799-5031-9804-20b4aeabae8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2638457b-276c-4738-acff-a75e9c4ac7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2638457b-276c-4738-acff-a75e9c4ac7c7.jpg?1",
             "name": "The Filigree Sylex",
             "text": "{T}: Put an oil counter on The Filigree Sylex.\n{T}, Sacrifice The Filigree Sylex: Destroy each nonland permanent with mana value equal to the number of oil counters on The Filigree Sylex.\n{T}, Remove ten oil counters from among permanents you control and sacrifice The Filigree Sylex: It deals 10 damage to any target.",
             "colours": [],
@@ -14287,7 +14287,7 @@
         },
         {
             "id": "7e22c845-3356-5733-a2be-10a6ea3f0078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d109ca-5ffa-4854-a18f-b7485fe307cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d109ca-5ffa-4854-a18f-b7485fe307cc.jpg?1",
             "name": "Mirran Safehouse",
             "text": "As long as Mirran Safehouse is on the battlefield, it has all activated abilities of all land cards in all graveyards.",
             "colours": [],
@@ -14317,7 +14317,7 @@
         },
         {
             "id": "d391ab6d-c672-5338-9b2f-8ea973c12138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ccd6b-dab6-4657-97ed-58caead1287f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ccd6b-dab6-4657-97ed-58caead1287f.jpg?1",
             "name": "Monument to Perfection",
             "text": "{3}, {T}: Search your library for a basic, Sphere, or Locus land card, reveal it, put it into your hand, then shuffle.\n{3}: Monument to Perfection becomes a 9/9 Phyrexian Construct artifact creature, loses all abilities, and gains indestructible and toxic 9. Activate only if there are nine or more lands with different names among the basic, Sphere, and Locus lands you control.",
             "colours": [],
@@ -14347,7 +14347,7 @@
         },
         {
             "id": "debe7410-a35d-5d68-8b57-58371ee1231c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45354872-4426-445e-8ef0-2df65afdbc53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45354872-4426-445e-8ef0-2df65afdbc53.jpg?1",
             "name": "Soulless Jailer",
             "text": "Permanent cards in graveyards can't enter the battlefield.\nPlayers can't cast noncreature spells from graveyards or exile.",
             "colours": [],
@@ -14381,7 +14381,7 @@
         },
         {
             "id": "eb18a0d8-b17a-5956-9881-12474d0c8069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91a075f-b8c2-499e-a7e5-4063f0dbafc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91a075f-b8c2-499e-a7e5-4063f0dbafc8.jpg?1",
             "name": "Tablet of Compleation",
             "text": "{T}: Put an oil counter on Tablet of Compleation.\n{T}: Add {C}. Activate only if Tablet of Compleation has two or more oil counters on it.\n{1}, {T}: Draw a card. Activate only if Tablet of Compleation has five or more oil counters on it.",
             "colours": [],
@@ -14411,7 +14411,7 @@
         },
         {
             "id": "5ced9739-b0e9-58e0-94e8-3b7b0705cb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca1010-95ab-48a0-ae69-7948e7dc73df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca1010-95ab-48a0-ae69-7948e7dc73df.jpg?1",
             "name": "Zenith Chronicler",
             "text": "Whenever a player casts their first multicolored spell each turn, each other player draws a card.",
             "colours": [],
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "4b0f00aa-ce14-57f1-8391-edac87bbdf47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7a760f-c9fb-454c-bedd-46a675daf02e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7a760f-c9fb-454c-bedd-46a675daf02e.jpg?1",
             "name": "Mirrex",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Activate only if Mirrex entered the battlefield this turn.\n{3}, {T}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [],
@@ -14477,7 +14477,7 @@
         },
         {
             "id": "88bc7236-7987-5988-ae90-70ee0ab4036b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1469fe76-f7e9-48a2-85de-d4d02856cd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1469fe76-f7e9-48a2-85de-d4d02856cd00.jpg?1",
             "name": "The Monumental Facade",
             "text": "The Monumental Facade enters the battlefield with two oil counters on it.\n{T}: Add {C}.\n{T}, Remove an oil counter from The Monumental Facade: Put an oil counter on target artifact or creature you control. Activate only as a sorcery.",
             "colours": [],
@@ -14509,7 +14509,7 @@
         },
         {
             "id": "277e7f2a-b0e4-5b4a-b683-4b35b76f8467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afcac49-ac80-4561-ba2c-ce9487e9d8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afcac49-ac80-4561-ba2c-ce9487e9d8fe.jpg?1",
             "name": "The Mycosynth Gardens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{X}, {T}: The Mycosynth Gardens becomes a copy of target nontoken artifact you control with mana value X.",
             "colours": [],
@@ -14541,7 +14541,7 @@
         },
         {
             "id": "06c5784e-cc95-5868-a36b-9442768fd031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3e28ca-bd1a-46bf-8ce0-56807cbb41c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3e28ca-bd1a-46bf-8ce0-56807cbb41c6.jpg?1",
             "name": "The Seedcore",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast Phyrexian creature spells.\nCorrupted \u2014 {T}: Target 1/1 creature gets +2/+1 until end of turn. Activate only if an opponent has three or more poison counters.",
             "colours": [],
@@ -14573,7 +14573,7 @@
         },
         {
             "id": "86cd1f91-6ffc-530c-8339-eb1365ee2df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55a5edb-edf3-4f6c-90b8-1780b1e73997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55a5edb-edf3-4f6c-90b8-1780b1e73997.jpg?1",
             "name": "Mite Overseer",
             "text": "First strike\nAs long as it's your turn, creature tokens you control get +1/+0 and have first strike.\n{3}{PW}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by it also get a poison counter. {PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -14610,7 +14610,7 @@
         },
         {
             "id": "e845f297-eeaa-5894-9258-089cafd160c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d562aa-8b49-40a3-a5c1-3af8afa98edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d562aa-8b49-40a3-a5c1-3af8afa98edc.jpg?1",
             "name": "Serum Sovereign",
             "text": "Flying\nWhenever you cast a noncreature spell, put an oil counter on Serum Sovereign.\n{U}, Remove an oil counter from Serum Sovereign: Draw a card, then scry 2.",
             "colours": [
@@ -14647,7 +14647,7 @@
         },
         {
             "id": "b1d76fc1-3fe7-5c52-9922-2d8afe783e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28934cf3-c1e0-49c9-93ce-fd60b1881884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28934cf3-c1e0-49c9-93ce-fd60b1881884.jpg?1",
             "name": "Kinzu of the Bleak Coven",
             "text": "Flying\nWhenever another nontoken creature you control dies, you may pay 2 life and exile it. If you do, create a token that's a copy of that creature, except it's 1/1 and has toxic 1. (Players dealt combat damage by it also get a poison counter.)",
             "colours": [
@@ -14686,7 +14686,7 @@
         },
         {
             "id": "6b8f9233-8f78-5016-88f0-334a08100653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c25806-1da6-4789-a17e-d2440184ec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c25806-1da6-4789-a17e-d2440184ec40.jpg?1",
             "name": "Rhuk, Hexgold Nabber",
             "text": "Trample, haste\nWhenever an equipped creature you control other than Rhuk, Hexgold Nabber attacks or dies, you may attach all Equipment attached to that creature to Rhuk.",
             "colours": [
@@ -14725,7 +14725,7 @@
         },
         {
             "id": "43a4ecbe-4561-5ac3-aa69-75cafc750e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1141ca-78c0-46e5-99f8-28069d69f23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1141ca-78c0-46e5-99f8-28069d69f23a.jpg?1",
             "name": "Goliath Hatchery",
             "text": "When Goliath Hatchery enters the battlefield, create two 3/3 green Phyrexian Beast creature tokens with toxic 1. (Players dealt combat damage by them also get a poison counter.)\nCorrupted \u2014 At the beginning of your upkeep, if an opponent has three or more poison counters, choose a creature you control, then draw cards equal to its total toxic value.",
             "colours": [
@@ -14759,7 +14759,7 @@
         },
         {
             "id": "cee3911f-5491-5c14-9e1e-1ad3518372d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83a0027-e82d-46ec-b40b-8bf16eb1f379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83a0027-e82d-46ec-b40b-8bf16eb1f379.jpg?1",
             "name": "Mite Overseer",
             "text": "First strike\nAs long as it's your turn, creature tokens you control get +1/+0 and have first strike.\n{3}{PW}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "e9f9dc33-bf53-517f-b866-c286c4068dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ed286-e5ac-4224-8892-363885eb1350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ed286-e5ac-4224-8892-363885eb1350.jpg?1",
             "name": "Serum Sovereign",
             "text": "Flying\nWhenever you cast a noncreature spell, put an oil counter on Serum Sovereign.\n{U}, Remove an oil counter from Serum Sovereign: Draw a card, then scry 2.",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "f38cb3db-51bd-543d-8929-ff9876787094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0359c24-6a70-476f-b26b-cd992d9acecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0359c24-6a70-476f-b26b-cd992d9acecf.jpg?1",
             "name": "Kinzu of the Bleak Coven",
             "text": "Flying\nWhenever another nontoken creature you control dies, you may pay 2 life and exile it. If you do, create a token that's a copy of that creature, except it's 1/1 and has toxic 1.",
             "colours": [
@@ -14872,7 +14872,7 @@
         },
         {
             "id": "fa17bdb4-8b3a-51cc-9bd9-b5545e510773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94655928-1f1c-4993-8139-c705be369134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94655928-1f1c-4993-8139-c705be369134.jpg?1",
             "name": "Rhuk, Hexgold Nabber",
             "text": "Trample, haste\nWhenever an equipped creature you control other than Rhuk, Hexgold Nabber attacks or dies, you may attach all Equipment attached to that creature to Rhuk.",
             "colours": [
@@ -14911,7 +14911,7 @@
         },
         {
             "id": "d4347a5a-06aa-596e-abf2-1854a2fc64fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d55c882-bf32-4d52-8af2-6a59c00bde5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d55c882-bf32-4d52-8af2-6a59c00bde5c.jpg?1",
             "name": "Goliath Hatchery",
             "text": "When Goliath Hatchery enters the battlefield, create two 3/3 green Phyrexian Beast creature tokens with toxic 1.\nCorrupted \u2014 At the beginning of your upkeep, if an opponent has three or more poison counters, choose a creature you control, then draw cards equal to its total toxic value.",
             "colours": [
@@ -14945,7 +14945,7 @@
         },
         {
             "id": "1330d7f5-2ef2-5233-af4d-d59e12e693e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09705595-47c6-4f7c-9351-4004bfa39218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09705595-47c6-4f7c-9351-4004bfa39218.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -14992,7 +14992,7 @@
         },
         {
             "id": "2342718f-3d15-5243-8fd0-4c86b116330d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673ccb2-e960-44a9-917b-c53c91e61a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673ccb2-e960-44a9-917b-c53c91e61a94.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -15039,7 +15039,7 @@
         },
         {
             "id": "2f49292a-f476-5c70-86ac-4fa00d5f7900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649be99a-fa52-469e-85df-11ecc576ea39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649be99a-fa52-469e-85df-11ecc576ea39.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15086,7 +15086,7 @@
         },
         {
             "id": "0cc400ed-2270-5d14-a507-6d725ce175b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71546201-a8a9-4d9d-93b7-46e90fb7b8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71546201-a8a9-4d9d-93b7-46e90fb7b8ae.jpg?1",
             "name": "Bladed Ambassador",
             "text": "",
             "colours": [
@@ -15123,7 +15123,7 @@
         },
         {
             "id": "3824b0d2-7444-5f20-b24b-10dc0190a47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e5db-dad1-4544-a9c5-8a4a29327265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e5db-dad1-4544-a9c5-8a4a29327265.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15169,7 +15169,7 @@
         },
         {
             "id": "e71df342-78a6-5a1c-b430-48738185a820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eca4d1-07e3-4142-85ce-3dca122f7f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eca4d1-07e3-4142-85ce-3dca122f7f2c.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15215,7 +15215,7 @@
         },
         {
             "id": "99925849-2d19-5c18-9a87-00f56b3bdf1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0835e3b2-7836-47b2-905d-5660a718387c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0835e3b2-7836-47b2-905d-5660a718387c.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15261,7 +15261,7 @@
         },
         {
             "id": "0e7ac64a-c882-5ccf-928c-d8344fb8229f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835ba56b-6a8f-4ca7-be05-baedfa3451c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835ba56b-6a8f-4ca7-be05-baedfa3451c0.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15307,7 +15307,7 @@
         },
         {
             "id": "6b9c19bd-2690-506d-957a-b97f4e1992fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73088dcd-56e0-4421-834b-bfb8edfe8b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73088dcd-56e0-4421-834b-bfb8edfe8b68.jpg?1",
             "name": "The Eternal Wanderer",
             "text": "",
             "colours": [
@@ -15343,7 +15343,7 @@
         },
         {
             "id": "9b64598b-b6e1-58ea-8fdd-39825fc47353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1ae568-c353-4da5-a6bb-3e09f3c403d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1ae568-c353-4da5-a6bb-3e09f3c403d7.jpg?1",
             "name": "Kemba, Kha Enduring",
             "text": "",
             "colours": [
@@ -15382,7 +15382,7 @@
         },
         {
             "id": "42b8427a-d8c2-5faa-b45c-fdc0f66527f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e733259b-ef96-4a60-ab1a-b70dd3ef7681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e733259b-ef96-4a60-ab1a-b70dd3ef7681.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "",
             "colours": [
@@ -15422,7 +15422,7 @@
         },
         {
             "id": "c03af55a-d35b-5dfc-b4be-94baf9045af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad244f-2f1d-4c95-9cd4-519f325b56f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad244f-2f1d-4c95-9cd4-519f325b56f3.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "",
             "colours": [
@@ -15460,7 +15460,7 @@
         },
         {
             "id": "90681e2c-87ea-5924-83f9-90056bac81ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca49f9-4c0a-4279-86cd-f02c2117b04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca49f9-4c0a-4279-86cd-f02c2117b04d.jpg?1",
             "name": "Sinew Dancer",
             "text": "",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "0654adb3-c64d-58ce-ac41-ba4c66b133a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55ca48-0fe0-44bd-9453-02cda0b7f5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55ca48-0fe0-44bd-9453-02cda0b7f5da.jpg?1",
             "name": "Skrelv, Defector Mite",
             "text": "",
             "colours": [
@@ -15537,7 +15537,7 @@
         },
         {
             "id": "3e5b29b9-650f-5216-ae2c-0bac9cfb4a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f45a6a-6425-45ce-8661-9b511c71bb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f45a6a-6425-45ce-8661-9b511c71bb5f.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "",
             "colours": [
@@ -15578,7 +15578,7 @@
         },
         {
             "id": "91289491-b300-5859-bfdb-dd0c52cf4d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9f5a2e-1f1e-4ecf-8d5c-dbd952574f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9f5a2e-1f1e-4ecf-8d5c-dbd952574f7e.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "",
             "colours": [
@@ -15619,7 +15619,7 @@
         },
         {
             "id": "10c078ea-fce8-5167-9ba2-04f915442dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ae222b-5fe0-4110-8a45-f47a6bff63f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ae222b-5fe0-4110-8a45-f47a6bff63f7.jpg?1",
             "name": "Quicksilver Fisher",
             "text": "",
             "colours": [
@@ -15656,7 +15656,7 @@
         },
         {
             "id": "1de4aca1-15e5-5e2f-951b-d8ce1156a9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6915aa9f-f8c7-415d-b265-6d40fa7cd0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6915aa9f-f8c7-415d-b265-6d40fa7cd0fe.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "",
             "colours": [
@@ -15696,7 +15696,7 @@
         },
         {
             "id": "d54d0c03-a5ba-531d-97ae-4c065a3bbf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fff05f-84f3-43ec-9752-86b156ec0c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fff05f-84f3-43ec-9752-86b156ec0c5b.jpg?1",
             "name": "Thrummingbird",
             "text": "",
             "colours": [
@@ -15734,7 +15734,7 @@
         },
         {
             "id": "db952d8e-d61b-5a22-bc87-6f0fcb9b2d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3992c4c-d241-4dc5-bb68-6db5fb93a356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3992c4c-d241-4dc5-bb68-6db5fb93a356.jpg?1",
             "name": "Unctus, Grand Metatect",
             "text": "",
             "colours": [
@@ -15774,7 +15774,7 @@
         },
         {
             "id": "35b91bbb-79eb-5f14-b0f6-ee980a70909c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d02c56-bf38-4bd8-9e0b-c1e2cc2e5dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d02c56-bf38-4bd8-9e0b-c1e2cc2e5dfe.jpg?1",
             "name": "Archfiend of the Dross",
             "text": "",
             "colours": [
@@ -15811,7 +15811,7 @@
         },
         {
             "id": "770cf186-7dcf-548c-9af0-cc66d7a4de9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bf86e8-df70-4ec0-8fe6-f15191774e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bf86e8-df70-4ec0-8fe6-f15191774e50.jpg?1",
             "name": "Blightbelly Rat",
             "text": "",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "9a0fed4b-798c-5918-b405-13dae01656ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c1b7bb-79ca-44c2-9152-d302ca00eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c1b7bb-79ca-44c2-9152-d302ca00eb3e.jpg?1",
             "name": "Bonepicker Skirge",
             "text": "",
             "colours": [
@@ -15885,7 +15885,7 @@
         },
         {
             "id": "6602bae5-7943-5315-85df-33b50fa92c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4b6d7-945f-4bce-9591-ec80cab18055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4b6d7-945f-4bce-9591-ec80cab18055.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "31b19a7e-351b-5287-9a09-89552cdd9791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5230995-da48-4eea-a2fd-3b303d3df963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5230995-da48-4eea-a2fd-3b303d3df963.jpg?1",
             "name": "Geth, Thane of Contracts",
             "text": "",
             "colours": [
@@ -15964,7 +15964,7 @@
         },
         {
             "id": "1885a4ec-f428-5fad-ac54-7a47e3fd74f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b3202b-fdfb-422b-8abd-5a319cb34341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b3202b-fdfb-422b-8abd-5a319cb34341.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "",
             "colours": [
@@ -16004,7 +16004,7 @@
         },
         {
             "id": "19e47847-e39c-54ec-9aee-2d285090f076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f21774-ea98-41ae-b4fa-4402f1876cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f21774-ea98-41ae-b4fa-4402f1876cda.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "",
             "colours": [
@@ -16042,7 +16042,7 @@
         },
         {
             "id": "0c77eb2a-4a68-56c1-8ae1-31cf03f59cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b41d4e-913c-49fd-a263-b0144fdd8667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b41d4e-913c-49fd-a263-b0144fdd8667.jpg?1",
             "name": "Vraan, Executioner Thane",
             "text": "",
             "colours": [
@@ -16081,7 +16081,7 @@
         },
         {
             "id": "1b7f5de3-e64a-5d5d-97e6-651c77880b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae2dfd8-a10a-4a13-97c0-a0ac7df0aabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae2dfd8-a10a-4a13-97c0-a0ac7df0aabb.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "",
             "colours": [
@@ -16122,7 +16122,7 @@
         },
         {
             "id": "954bf834-771f-5ea5-9829-b2acae18ceac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af5aaae-c343-4a9e-94a3-6225100e2e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af5aaae-c343-4a9e-94a3-6225100e2e25.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "",
             "colours": [
@@ -16163,7 +16163,7 @@
         },
         {
             "id": "d7178899-625d-5cfb-8932-51efd7490cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43706591-f0ac-4a03-b745-126fa1d4cfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43706591-f0ac-4a03-b745-126fa1d4cfe6.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "",
             "colours": [
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "4c50740d-f7bf-563c-987b-300a3f82940d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16994ad-6288-4e3a-a02f-0dfce71bf013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16994ad-6288-4e3a-a02f-0dfce71bf013.jpg?1",
             "name": "Furnace Punisher",
             "text": "",
             "colours": [
@@ -16238,7 +16238,7 @@
         },
         {
             "id": "db1b6c7d-8c25-5246-8aa7-9b09e9951209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8570-0f6d-4a49-b166-38a5d788a3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8570-0f6d-4a49-b166-38a5d788a3f0.jpg?1",
             "name": "Koth, Fire of Resistance",
             "text": "",
             "colours": [
@@ -16276,7 +16276,7 @@
         },
         {
             "id": "8a2b986a-0ecc-5ed6-a0ed-aecfa8c3106f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e5be1-b129-4384-8b51-d076b1459302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e5be1-b129-4384-8b51-d076b1459302.jpg?1",
             "name": "Sawblade Scamp",
             "text": "",
             "colours": [
@@ -16313,7 +16313,7 @@
         },
         {
             "id": "50ac2ec9-4ccb-5aa6-afb8-7149b2ace513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb7a29-7bca-4402-b47c-e73eaa5e6fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb7a29-7bca-4402-b47c-e73eaa5e6fef.jpg?1",
             "name": "Slobad, Iron Goblin",
             "text": "",
             "colours": [
@@ -16353,7 +16353,7 @@
         },
         {
             "id": "d1c5df6a-b1b8-5d63-83b6-6a2171e8ad82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ac6a1-d792-473a-a189-5282ae7559a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ac6a1-d792-473a-a189-5282ae7559a7.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "",
             "colours": [
@@ -16393,7 +16393,7 @@
         },
         {
             "id": "b7fbac61-95f5-58b6-8004-2109cbfe9238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c2c971-aaed-48af-80ae-f5df2b1f17ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c2c971-aaed-48af-80ae-f5df2b1f17ac.jpg?1",
             "name": "Urabrask's Anointer",
             "text": "",
             "colours": [
@@ -16431,7 +16431,7 @@
         },
         {
             "id": "c1506ac2-f92b-51b0-a9f2-38ad8a8c9af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbfb112b-a148-4c28-9ba6-af535ec2d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbfb112b-a148-4c28-9ba6-af535ec2d4fd.jpg?1",
             "name": "Cankerbloom",
             "text": "",
             "colours": [
@@ -16468,7 +16468,7 @@
         },
         {
             "id": "8d338ee2-e09d-5705-848c-eac384ac769e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99546cde-3a05-45d0-b77d-e007243a68e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99546cde-3a05-45d0-b77d-e007243a68e4.jpg?1",
             "name": "Evolved Spinoderm",
             "text": "",
             "colours": [
@@ -16505,7 +16505,7 @@
         },
         {
             "id": "716df6e5-5c72-56f0-bf79-b2874d86b4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff957d-257b-4cfa-94f5-15fd5f0091ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff957d-257b-4cfa-94f5-15fd5f0091ff.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "6f24bb46-5af8-56c9-9d90-93fd20cfc598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570136da-4178-48db-a725-16cd240c9e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570136da-4178-48db-a725-16cd240c9e8a.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "",
             "colours": [
@@ -16587,7 +16587,7 @@
         },
         {
             "id": "d57684a4-c772-5ed6-b684-a86d67b1c5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c97359-8355-436d-8d48-833d18793de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c97359-8355-436d-8d48-833d18793de0.jpg?1",
             "name": "Rustvine Cultivator",
             "text": "",
             "colours": [
@@ -16625,7 +16625,7 @@
         },
         {
             "id": "0f9dac93-3081-54c9-9fbc-174067bf195c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e39ca9-0267-47cb-a378-892fbad324e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e39ca9-0267-47cb-a378-892fbad324e4.jpg?1",
             "name": "Thrun, Breaker of Silence",
             "text": "",
             "colours": [
@@ -16664,7 +16664,7 @@
         },
         {
             "id": "e1899d57-5090-59e3-9992-cb76890ff36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc1978e-ba4f-48ed-90e2-9252603f99fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc1978e-ba4f-48ed-90e2-9252603f99fe.jpg?1",
             "name": "Tyrranax Rex",
             "text": "",
             "colours": [
@@ -16702,7 +16702,7 @@
         },
         {
             "id": "4c0d9f52-a677-570d-86c0-88d3d397403e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b31ca5-087a-4359-a570-134eedc7cb3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b31ca5-087a-4359-a570-134eedc7cb3a.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "",
             "colours": [
@@ -16742,7 +16742,7 @@
         },
         {
             "id": "d7011b9d-66a8-5a16-bd31-78297e02508d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d5df16-3f65-4616-9d41-b8a9afb1e6bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d5df16-3f65-4616-9d41-b8a9afb1e6bb.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "",
             "colours": [
@@ -16788,7 +16788,7 @@
         },
         {
             "id": "71ebb842-13cd-5cac-9b9a-c3040dc23495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc873b9-1e0e-4787-9447-893a7e16346f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc873b9-1e0e-4787-9447-893a7e16346f.jpg?1",
             "name": "Ezuri, Stalker of Spheres",
             "text": "",
             "colours": [
@@ -16830,7 +16830,7 @@
         },
         {
             "id": "fee78fa4-55ae-579b-b573-31d0e3ce0aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d347959-a8c8-4a5d-af1f-257dadf42064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d347959-a8c8-4a5d-af1f-257dadf42064.jpg?1",
             "name": "Glissa Sunslayer",
             "text": "",
             "colours": [
@@ -16872,7 +16872,7 @@
         },
         {
             "id": "58c7d4a8-1d5b-5516-8063-d56f6dc4347d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85071fe7-ce69-40e7-95ad-ccf0d5ef5ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85071fe7-ce69-40e7-95ad-ccf0d5ef5ee0.jpg?1",
             "name": "Jor Kadeen, First Goldwarden",
             "text": "",
             "colours": [
@@ -16913,7 +16913,7 @@
         },
         {
             "id": "369e7ee0-7d32-5ae3-976a-2f2b21d3e448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66d6e92-006e-4eb3-91e4-93c2c40f700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66d6e92-006e-4eb3-91e4-93c2c40f700e.jpg?1",
             "name": "Kaito, Dancing Shadow",
             "text": "",
             "colours": [
@@ -16953,7 +16953,7 @@
         },
         {
             "id": "bf27b565-29f7-5a36-9dcf-3ad65fec9747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93770494-21c5-491e-bf4f-3dc7888a93a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93770494-21c5-491e-bf4f-3dc7888a93a5.jpg?1",
             "name": "Kaya, Intangible Slayer",
             "text": "",
             "colours": [
@@ -16993,7 +16993,7 @@
         },
         {
             "id": "3b233f36-933c-5333-9beb-7b52d49d8129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c29f1eb-5e1d-452e-892d-a9e8393af477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c29f1eb-5e1d-452e-892d-a9e8393af477.jpg?1",
             "name": "Kethek, Crucible Goliath",
             "text": "",
             "colours": [
@@ -17034,7 +17034,7 @@
         },
         {
             "id": "7d8e7523-133b-588d-94de-83cee7c70fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508eb4f9-56a1-4e7c-99d5-d5e751c61b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508eb4f9-56a1-4e7c-99d5-d5e751c61b91.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "",
             "colours": [
@@ -17077,7 +17077,7 @@
         },
         {
             "id": "ccdf2293-496a-5371-b310-8d231397766d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738ed22-fb88-4f19-a67f-b39a33a0c7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738ed22-fb88-4f19-a67f-b39a33a0c7a7.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "",
             "colours": [
@@ -17120,7 +17120,7 @@
         },
         {
             "id": "32f1b81a-ae5c-5005-92ee-c5c90b855861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70919ad2-8045-4354-b3a0-793fa6910d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70919ad2-8045-4354-b3a0-793fa6910d10.jpg?1",
             "name": "Malcator, Purity Overseer",
             "text": "",
             "colours": [
@@ -17162,7 +17162,7 @@
         },
         {
             "id": "cfb7f453-0958-51bd-896a-b9d57505b336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538fcecf-0e1d-4995-960b-c461b92d2f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538fcecf-0e1d-4995-960b-c461b92d2f72.jpg?1",
             "name": "Melira, the Living Cure",
             "text": "",
             "colours": [
@@ -17203,7 +17203,7 @@
         },
         {
             "id": "c62ab924-b3f2-5ea1-83a1-92bc2fc21b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7066cfb-f2a5-4dc0-973c-3ff73c74ba65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7066cfb-f2a5-4dc0-973c-3ff73c74ba65.jpg?1",
             "name": "Migloz, Maze Crusher",
             "text": "",
             "colours": [
@@ -17244,7 +17244,7 @@
         },
         {
             "id": "92240a5c-54d4-5af6-8470-f8b863a92969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ad9ed5-5cbb-4329-936c-32fefd623eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ad9ed5-5cbb-4329-936c-32fefd623eb7.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "",
             "colours": [
@@ -17287,7 +17287,7 @@
         },
         {
             "id": "f41a870b-1262-5f9b-a313-c4314e9e4833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ba17d4-19e0-4d11-a565-52aeb08d954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ba17d4-19e0-4d11-a565-52aeb08d954e.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "",
             "colours": [
@@ -17330,7 +17330,7 @@
         },
         {
             "id": "476ce0b1-9d60-5ad0-81b0-c6d819c551bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ffea1-e103-4f06-b652-7b9f37de8754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ffea1-e103-4f06-b652-7b9f37de8754.jpg?1",
             "name": "Necrogen Rotpriest",
             "text": "",
             "colours": [
@@ -17370,7 +17370,7 @@
         },
         {
             "id": "c53e2d25-f179-55fd-8a73-df7e0e2eee15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f4293-ea6e-4f10-b9e1-1b06c94af32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f4293-ea6e-4f10-b9e1-1b06c94af32b.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "",
             "colours": [
@@ -17411,7 +17411,7 @@
         },
         {
             "id": "6c15d9a7-69e1-5242-b607-9e3e6c322bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3809f4-5ee6-40cb-b5eb-b29dda1c038f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3809f4-5ee6-40cb-b5eb-b29dda1c038f.jpg?1",
             "name": "Ria Ivor, Bane of Bladehold",
             "text": "",
             "colours": [
@@ -17452,7 +17452,7 @@
         },
         {
             "id": "94dbb941-79a9-5586-9372-6a69a01a1a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bc261c-fb79-4397-9a47-b9f601a1341b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bc261c-fb79-4397-9a47-b9f601a1341b.jpg?1",
             "name": "Tyvar, Jubilant Brawler",
             "text": "",
             "colours": [
@@ -17492,7 +17492,7 @@
         },
         {
             "id": "d08f67f7-a052-55ef-942c-d72b1a98daac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc9003-7290-48b0-ba7b-4dc5c98cf2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc9003-7290-48b0-ba7b-4dc5c98cf2c4.jpg?1",
             "name": "Venser, Corpse Puppet",
             "text": "",
             "colours": [
@@ -17534,7 +17534,7 @@
         },
         {
             "id": "d8fd2200-9354-53fb-9bab-8217d15c566e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7c66b-5453-4237-8dd5-bf6ee69bcab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7c66b-5453-4237-8dd5-bf6ee69bcab8.jpg?1",
             "name": "Graaz, Unstoppable Juggernaut",
             "text": "",
             "colours": [],
@@ -17569,7 +17569,7 @@
         },
         {
             "id": "82fe9ae0-eddb-542a-b06b-e78c1d1c804a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c7d89a-2b02-4faa-83cf-7dcf7faf6c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c7d89a-2b02-4faa-83cf-7dcf7faf6c4a.jpg?1",
             "name": "Myr Convert",
             "text": "",
             "colours": [],
@@ -17603,7 +17603,7 @@
         },
         {
             "id": "21098256-4763-5eaf-ae0e-9eed26ef6b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11011596-4aa1-48a7-90d8-36cb7b27c711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11011596-4aa1-48a7-90d8-36cb7b27c711.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -17638,7 +17638,7 @@
         },
         {
             "id": "f61410ad-88a7-5e6b-b4db-fcd243ae3ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70750c90-3856-4d6d-923b-2ab91b1d7049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70750c90-3856-4d6d-923b-2ab91b1d7049.jpg?1",
             "name": "Samurai",
             "text": "",
             "colours": [
@@ -17673,7 +17673,7 @@
         },
         {
             "id": "3a49ec7d-50c8-5459-861f-07185c1142e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg?1",
             "name": "Phyrexian Goblin",
             "text": "",
             "colours": [
@@ -17709,7 +17709,7 @@
         },
         {
             "id": "56b09793-68bf-56de-ab32-7ee18e9aa1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da13c90f-9ed2-4262-88e2-17daa294537b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da13c90f-9ed2-4262-88e2-17daa294537b.jpg?1",
             "name": "Phyrexian Horror",
             "text": "",
             "colours": [
@@ -17745,7 +17745,7 @@
         },
         {
             "id": "f78af17a-6b08-5984-b36b-a15b4f1dccd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41eb9df-d8b4-4697-a759-886faf16754d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41eb9df-d8b4-4697-a759-886faf16754d.jpg?1",
             "name": "Rebel",
             "text": "",
             "colours": [
@@ -17780,7 +17780,7 @@
         },
         {
             "id": "1e507a36-d0d4-5fd0-9076-0ebdcc7b3432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919381b0-2d23-4794-b4ff-923c23e18196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919381b0-2d23-4794-b4ff-923c23e18196.jpg?1",
             "name": "Phyrexian Beast",
             "text": "",
             "colours": [
@@ -17816,7 +17816,7 @@
         },
         {
             "id": "22dbcfbd-79aa-5d9e-b5ee-ab3ef77529db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5fc2cb-a172-418a-a0f3-1a63a5f1aa2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5fc2cb-a172-418a-a0f3-1a63a5f1aa2c.jpg?1",
             "name": "Phyrexian Horror",
             "text": "",
             "colours": [
@@ -17852,7 +17852,7 @@
         },
         {
             "id": "d9327567-d717-52db-aa40-71cc2a6b962b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacac5f-7685-4792-9e4c-166d4b421240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacac5f-7685-4792-9e4c-166d4b421240.jpg?1",
             "name": "Drone",
             "text": "",
             "colours": [],
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "4de6bb51-46aa-59d7-b603-291babb01771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0cbfa-a7f9-49a6-9bca-4a08f5b8da93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0cbfa-a7f9-49a6-9bca-4a08f5b8da93.jpg?1",
             "name": "The Hollow Sentinel",
             "text": "",
             "colours": [],
@@ -17919,7 +17919,7 @@
         },
         {
             "id": "ca6d8b20-0901-5c81-9dbc-7615c2f21b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ace2fa-8cfb-4641-a05c-d12830378e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ace2fa-8cfb-4641-a05c-d12830378e03.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -17952,7 +17952,7 @@
         },
         {
             "id": "d4928ecf-ba43-5759-b91c-d230325c6331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ec91a9-659a-455f-98e0-cd30b6c6c2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ec91a9-659a-455f-98e0-cd30b6c6c2a4.jpg?1",
             "name": "Phyrexian Mite",
             "text": "",
             "colours": [],
@@ -17985,7 +17985,7 @@
         },
         {
             "id": "3ebcf5ed-caad-558d-8ab0-90afa791c054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b4b9cc-b0a4-4383-881b-e843e5d8a8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b4b9cc-b0a4-4383-881b-e843e5d8a8c1.jpg?1",
             "name": "Phyrexian Mite",
             "text": "",
             "colours": [],
@@ -18018,7 +18018,7 @@
         },
         {
             "id": "5fb6fd07-bae2-5d67-92a2-5e1000e4fa12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4746f904-67f3-450d-93f6-172b3fd50057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4746f904-67f3-450d-93f6-172b3fd50057.jpg?1",
             "name": "Koth, Fire of Resistance Emblem",
             "text": "",
             "colours": [],
@@ -18046,7 +18046,7 @@
         },
         {
             "id": "be1f1afc-0d4e-5ce8-9bab-8e65a120ecbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40255bfa-0004-45f1-a31b-17d385f09a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40255bfa-0004-45f1-a31b-17d385f09a95.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ONS.json
+++ b/Assets/Resources/Sets/ONS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b5be618e-ef00-5081-9a3c-1acead38807f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3710c68-3f71-4d76-8bd2-001f0e8036f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3710c68-3f71-4d76-8bd2-001f0e8036f5.jpg?1",
             "name": "Akroma's Blessing",
             "text": "Creatures you control gain protection from the color of your choice until end of turn.\nCycling o\nW (o\nW, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "e32e9f23-d6b1-584d-88af-62fb06405357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33aaf7-7490-4b64-a966-82fbf7ca8686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33aaf7-7490-4b64-a966-82fbf7ca8686.jpg?1",
             "name": "Akroma's Vengeance",
             "text": "Destroy all artifacts, creatures, and enchantments.\nCycling o3 (o3, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "9c250be9-8f16-5fdc-b4d1-af188d1c6420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdee956e-76b1-4ba7-a387-2fbfb853507d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdee956e-76b1-4ba7-a387-2fbfb853507d.jpg?1",
             "name": "Ancestor's Prophet",
             "text": "Tap five untapped Clerics you control: You gain 10 life.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "8481fb36-5a9a-5d12-831b-06b40e508d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14993b6-ed8d-4b9b-b54c-2837b343a61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14993b6-ed8d-4b9b-b54c-2837b343a61e.jpg?1",
             "name": "Astral Slide",
             "text": "Whenever a player cycles a card, you may remove target creature from the game. If you do, return that creature to play under its owner's control at end of turn.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "b8067d0b-7434-581b-86d3-67b186bef6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d16883-5e98-4dd2-92dd-0ba92f1099cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d16883-5e98-4dd2-92dd-0ba92f1099cb.jpg?1",
             "name": "Aura Extraction",
             "text": "Put target enchantment on top of its owner's library.\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "5f4893b8-904c-5e85-9d02-8621efde5189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d9e9ea-9f88-4206-8960-b5ebe839ee16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d9e9ea-9f88-4206-8960-b5ebe839ee16.jpg?1",
             "name": "Aurification",
             "text": "Whenever a creature deals damage to you, put a gold counter on it.\nEach creature with a gold counter on it is a Wall in addition to its other creature types. (Walls can't attack.)\nWhen Aurification leaves play, remove all gold counters from all creatures.",
             "colours": [
@@ -199,7 +199,7 @@
         },
         {
             "id": "48b053a0-8bea-55c0-bb90-269ae72af258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da24ef56-8d54-4146-97e9-4abded807545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da24ef56-8d54-4146-97e9-4abded807545.jpg?1",
             "name": "Aven Brigadier",
             "text": "Flying\nAll other Birds get +1/+1.\nAll other Soldiers get +1/+1.",
             "colours": [
@@ -234,7 +234,7 @@
         },
         {
             "id": "a6d17844-cb98-51fa-8222-162c3c68bfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5189f152-f075-4090-97dd-b7686d813865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5189f152-f075-4090-97dd-b7686d813865.jpg?1",
             "name": "Aven Soulgazer",
             "text": "Flying\no2o\nW: Look at target face-down creature.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "c67ebba0-4eef-5542-b5c9-1c60cf7adad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c444503-42a8-4952-819b-bbca89b06abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c444503-42a8-4952-819b-bbca89b06abc.jpg?1",
             "name": "Battlefield Medic",
             "text": "oc\nT: Prevent the next X damage that would be dealt to target creature this turn, where X is the number of Clerics in play.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "dea9ded2-5212-507e-a878-d1a93f6d6672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d7aa2-c6ff-432d-b671-cef58c6736c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d7aa2-c6ff-432d-b671-cef58c6736c6.jpg?1",
             "name": "Catapult Master",
             "text": "Tap five untapped Soldiers you control: Remove target creature from the game.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "ae88f0f7-1887-5cd2-9e58-cd6b27564291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a71d29-29eb-43c4-b0f3-457435e8f629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a71d29-29eb-43c4-b0f3-457435e8f629.jpg?1",
             "name": "Catapult Squad",
             "text": "Tap two untapped Soldiers you control: Catapult Squad deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "1c82505d-85ca-5055-9f86-8d007bc226a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a60ac8e-11eb-433f-86f9-8e593b38c617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a60ac8e-11eb-433f-86f9-8e593b38c617.jpg?1",
             "name": "Chain of Silence",
             "text": "Prevent all damage target creature would deal this turn. That creature's controller may sacrifice a land. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "7c0a451f-0a07-5074-964d-345bc617f8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f567dc-8a60-40e1-b947-199872d8df08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f567dc-8a60-40e1-b947-199872d8df08.jpg?1",
             "name": "Circle of Solace",
             "text": "As Circle of Solace comes into play, choose a creature type.\no1o\nW: The next time a creature of the chosen type would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "22122b0e-3a18-5ad6-aa01-35416dff20cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f3ad80-d000-496a-b704-d09e07981b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f3ad80-d000-496a-b704-d09e07981b6e.jpg?1",
             "name": "Convalescent Care",
             "text": "At the beginning of your upkeep, if you have 5 life or less, you gain 3 life and draw a card.",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "f76d6a6c-08a0-5570-b6d6-c08ddcc70923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1038436d-aea5-4508-8b37-c2cfa32c2771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1038436d-aea5-4508-8b37-c2cfa32c2771.jpg?1",
             "name": "Crowd Favorites",
             "text": "o3o\nW: Tap target creature.\no3o\nW: Crowd Favorites gets +0/+5 until end of turn.",
             "colours": [
@@ -505,7 +505,7 @@
         },
         {
             "id": "22d32cd8-60c2-5341-83d2-d00f4a8b0148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaea4bc-dcea-4340-a039-ebc97b944673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaea4bc-dcea-4340-a039-ebc97b944673.jpg?1",
             "name": "Crown of Awe",
             "text": "Enchanted creature has protection from black and from red.\nSacrifice Crown of Awe: Enchanted creature and other creatures that share a creature type with it gain protection from black and from red until end of turn.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "ece559dc-fce0-5e6b-a360-da9989096fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d1be2-d6ae-4820-aa01-62f261b0f110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d1be2-d6ae-4820-aa01-62f261b0f110.jpg?1",
             "name": "Crude Rampart",
             "text": "(Walls can't attack.)\nMorph o4o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "30b5804c-b019-5ef7-8f09-22fda8da6089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2e9b7e-434e-477f-b3e8-e85ceb913650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2e9b7e-434e-477f-b3e8-e85ceb913650.jpg?1",
             "name": "Daru Cavalier",
             "text": "First strike\nWhen Daru Cavalier comes into play, you may search your library for a card named Daru Cavalier, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -608,7 +608,7 @@
         },
         {
             "id": "fee1b7a6-27b0-5b04-adce-b7f6078ee5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f3eff-ac99-41e2-9003-9630cdb3ae23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f3eff-ac99-41e2-9003-9630cdb3ae23.jpg?1",
             "name": "Daru Healer",
             "text": "oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\nMorph o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "1175aa79-3587-5941-818c-d31ebf1ccd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd888ca8-0ebe-46f0-9317-3b193ccc43fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd888ca8-0ebe-46f0-9317-3b193ccc43fb.jpg?1",
             "name": "Daru Lancer",
             "text": "First strike\nMorph o2o\nWo\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "79930b4a-5796-5975-9c5a-0e09f5994fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38737f38-26bd-417c-b6b4-53f26e4e8044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38737f38-26bd-417c-b6b4-53f26e4e8044.jpg?1",
             "name": "Daunting Defender",
             "text": "If a source would deal damage to a Cleric you control, prevent 1 of that damage.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "13fa5c2b-b046-5740-a4ff-24888f7ded6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb25b0-e4c3-4a4e-b722-ea30e695f917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb25b0-e4c3-4a4e-b722-ea30e695f917.jpg?1",
             "name": "Dawning Purist",
             "text": "Whenever Dawning Purist deals combat damage to a player, you may destroy target enchantment that player controls.\nMorph o1o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "f27f78c5-e8e4-562c-91f6-49357f6027cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f9eb25-4140-4ecf-bcaa-1b193d884007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f9eb25-4140-4ecf-bcaa-1b193d884007.jpg?1",
             "name": "Defensive Maneuvers",
             "text": "Creatures of the type of your choice get +0/+4 until end of turn.",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "07ec1be1-a12d-50b0-8d8c-875ffd6ae96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0df839f-dc4c-44b0-82c7-cb2037172ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0df839f-dc4c-44b0-82c7-cb2037172ac5.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "15f85638-89bd-53fa-b7d0-1600fda3b3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1790cb-34e4-4f23-8a13-1906fd9a956f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1790cb-34e4-4f23-8a13-1906fd9a956f.jpg?1",
             "name": "Disciple of Grace",
             "text": "Protection from black\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "ef9d5f9e-5ec5-572a-beff-626393716a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65162b24-8a3b-4b92-a831-6f23f809c76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65162b24-8a3b-4b92-a831-6f23f809c76f.jpg?1",
             "name": "Dive Bomber",
             "text": "Flying\noc\nT, Sacrifice Dive Bomber: Dive Bomber deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "c6a9a0de-0a49-5dcc-85bc-bb1970e50986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dedef8a-5527-40dc-9ad9-bcee4cf30a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dedef8a-5527-40dc-9ad9-bcee4cf30a76.jpg?1",
             "name": "Doubtless One",
             "text": "Doubtless One's power and toughness are each equal to the number of Clerics in play.\nWhenever Doubtless One deals damage, you gain that much life.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "d12e0d50-d5f3-5f84-9d3f-a44676420197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2213eac-cea4-4dfd-90c4-c1f466967e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2213eac-cea4-4dfd-90c4-c1f466967e2e.jpg?1",
             "name": "Exalted Angel",
             "text": "Flying\nWhenever Exalted Angel deals damage, you gain that much life.\nMorph o2o\nWo\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "8435581e-18f1-548c-a7de-2778c3641547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409adb7b-6dcb-4e7f-a5dd-c0adf12140a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409adb7b-6dcb-4e7f-a5dd-c0adf12140a4.jpg?1",
             "name": "Foothill Guide",
             "text": "Protection from Goblins\nMorph o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "1f43f10a-35f0-5104-a59a-cfc9e31f8f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e505e8e-51aa-4415-81e6-cf022279edb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e505e8e-51aa-4415-81e6-cf022279edb0.jpg?1",
             "name": "Glarecaster",
             "text": "Flying\no5o\nW: The next time damage would be dealt to Glarecaster or you this turn, that damage is dealt to target creature or player instead.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "2e6f3bb4-946e-5e3c-9a02-da9009b6a9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047075e-9fca-484d-bb79-32c0d6821281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047075e-9fca-484d-bb79-32c0d6821281.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "548a1e75-3af9-5bef-8cd6-2191627c83bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c129f361-8769-4f9a-9745-eb5d0c085b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c129f361-8769-4f9a-9745-eb5d0c085b88.jpg?1",
             "name": "Grassland Crusader",
             "text": "oc\nT: Target Elf or Soldier gets +2/+2 until end of turn.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "63fc0809-3bc7-533b-805e-5556e96cc7f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87551307-6b5f-4f12-aa1f-4beebefad3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87551307-6b5f-4f12-aa1f-4beebefad3b3.jpg?1",
             "name": "Gravel Slinger",
             "text": "oc\nT: Gravel Slinger deals 1 damage to target attacking or blocking creature.\nMorph o1o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1127,7 +1127,7 @@
         },
         {
             "id": "ea949bc9-7d74-55e2-a8d5-c2689c3cc21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ff5c7d-7823-4d1e-8abb-77e2d8126996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ff5c7d-7823-4d1e-8abb-77e2d8126996.jpg?1",
             "name": "Gustcloak Harrier",
             "text": "Flying\nWhenever Gustcloak Harrier becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "ce7e8595-6cf3-56a2-a93c-092ab09eb730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227f65-9189-41ed-94a0-2aa21cad26f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227f65-9189-41ed-94a0-2aa21cad26f5.jpg?1",
             "name": "Gustcloak Runner",
             "text": "Whenever Gustcloak Runner becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "7eb4cc44-9281-5289-810a-d9fedf7bee39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d6e81-1869-4ab7-8a4e-477d5c4aed6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d6e81-1869-4ab7-8a4e-477d5c4aed6b.jpg?1",
             "name": "Gustcloak Savior",
             "text": "Flying\nWhenever a creature you control becomes blocked, you may untap that creature and remove it from combat.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "a767f0dc-da7d-53cb-ae7f-9b7cb14cccbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90da5c3-fd8f-445d-809f-e129870d7449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90da5c3-fd8f-445d-809f-e129870d7449.jpg?1",
             "name": "Gustcloak Sentinel",
             "text": "Whenever Gustcloak Sentinel becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "5f65fb59-ea71-568c-b699-d82828040d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbff06c-5f92-4320-8b70-df3c8344f600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbff06c-5f92-4320-8b70-df3c8344f600.jpg?1",
             "name": "Gustcloak Skirmisher",
             "text": "Flying\nWhenever Gustcloak Skirmisher becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "2c204bfe-4159-5bdd-a7f5-c0fe3f4dd3eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6473b4d-1f59-4216-ace9-f3e5306266fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6473b4d-1f59-4216-ace9-f3e5306266fb.jpg?1",
             "name": "Harsh Mercy",
             "text": "Each player chooses a creature type. Destroy all creatures that aren't of a type chosen this way. They can't be regenerated.",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "fcfceb0c-7f1b-5257-ba5e-8e35afa940f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7d5d79-73d8-4f1a-9dda-4de5f41539d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7d5d79-73d8-4f1a-9dda-4de5f41539d9.jpg?1",
             "name": "Improvised Armor",
             "text": "Enchanted creature gets +2/+5.\nCycling o3 (o3, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "3e8e91ce-9b2d-592c-b6de-c7e53fd4ef19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0e300-db79-4328-ba1d-9c3910e47f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0e300-db79-4328-ba1d-9c3910e47f52.jpg?1",
             "name": "Inspirit",
             "text": "Untap target creature. It gets +2/+4 until end of turn.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "16b4cba1-ba18-55a7-8015-ff52dfc3bb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7284e32-de54-4c83-a7de-7b249c47319a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7284e32-de54-4c83-a7de-7b249c47319a.jpg?1",
             "name": "Ironfist Crusher",
             "text": "Ironfist Crusher may block any number of creatures.\nMorph o3o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "6c6136b0-a451-581f-819c-33e6add94c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd1364-ff36-4cb9-ad93-e6fcbcb942cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd1364-ff36-4cb9-ad93-e6fcbcb942cf.jpg?1",
             "name": "Jareth, Leonine Titan",
             "text": "Whenever Jareth, Leonine Titan blocks, it gets +7/+7 until end of turn.\no\nW: Jareth gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "af7e5b52-14cc-57a2-8523-84e46ba50f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653cc07b-0f53-4b5b-9c5f-885b8b4a6e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653cc07b-0f53-4b5b-9c5f-885b8b4a6e5f.jpg?1",
             "name": "Mobilization",
             "text": "Attacking doesn't cause Soldiers to tap.\no2o\nW: Put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "a71c081e-0d8d-58ef-ab0d-883ed1fa566d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2048d84-b5e6-405c-9091-1997a0c4e1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2048d84-b5e6-405c-9091-1997a0c4e1a5.jpg?1",
             "name": "Nova Cleric",
             "text": "o2o\nW, oc\nT, Sacrifice Nova Cleric: Destroy all enchantments.",
             "colours": [
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "eff02303-d9fd-5c66-a719-053f73bbdf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58561356-4a97-467b-88e5-412e633715fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58561356-4a97-467b-88e5-412e633715fb.jpg?1",
             "name": "Oblation",
             "text": "The owner of target nonland permanent shuffles it into his or her library, then draws two cards.",
             "colours": [
@@ -1571,7 +1571,7 @@
         },
         {
             "id": "30273590-e307-5296-8470-c3423c451203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee262fde-8df1-431f-9e5c-0cafe9212b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee262fde-8df1-431f-9e5c-0cafe9212b49.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "cf6ad2eb-d0de-59c6-939e-a59f14dbf2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea7219-6ab6-471a-afe7-d7da1df434c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea7219-6ab6-471a-afe7-d7da1df434c7.jpg?1",
             "name": "Pearlspear Courier",
             "text": "You may choose not to untap Pearlspear Courier during your untap step.\no2o\nW, oc\nT: As long as Pearlspear Courier remains tapped, target Soldier gets +2/+2 and has \"Attacking doesn't cause this creature to tap.\"",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "f727ec40-5cb8-52bb-81ba-8f9e13a5980f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2da43-c0e1-4fbf-b309-a75e105c29c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2da43-c0e1-4fbf-b309-a75e105c29c1.jpg?1",
             "name": "Piety Charm",
             "text": "Choose one Destroy target enchant creature; or target Soldier gets +2/+2 until end of turn; or attacking doesn't cause creatures you control to tap this turn.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "01990ecd-f83e-5609-8556-06a56b4bf754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea572b5-ff68-45aa-8200-78ee7f64a0ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea572b5-ff68-45aa-8200-78ee7f64a0ce.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling o1o\nW (o1o\nW, Discard this card from your hand: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "47c83dd2-6ff0-5f97-a80d-fe35e70801cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83c6245-4b37-430d-af10-2581804fff08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83c6245-4b37-430d-af10-2581804fff08.jpg?1",
             "name": "Righteous Cause",
             "text": "Whenever a creature attacks, you gain 1 life.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "6d4c8b3e-a45f-56e3-b1c2-390ba91cc5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b59844-c9d4-4bc1-86e6-4cc596d9165d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b59844-c9d4-4bc1-86e6-4cc596d9165d.jpg?1",
             "name": "Sandskin",
             "text": "Prevent all combat damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -1770,7 +1770,7 @@
         },
         {
             "id": "27aad62c-55f0-59aa-83ef-1238d7364d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ebe6-76cf-4345-b59b-9954496c44d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ebe6-76cf-4345-b59b-9954496c44d0.jpg?1",
             "name": "Shared Triumph",
             "text": "As Shared Triumph comes into play, choose a creature type.\nCreatures of the chosen type get +1/+1.",
             "colours": [
@@ -1802,7 +1802,7 @@
         },
         {
             "id": "b4fb4fd4-1ba9-5dd6-af51-1960dc7a7f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2d660-7c93-4087-a6e5-49c2ad21eb5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2d660-7c93-4087-a6e5-49c2ad21eb5a.jpg?1",
             "name": "Shieldmage Elder",
             "text": "Tap two untapped Clerics you control: Prevent all damage target creature would deal this turn.\nTap two untapped Wizards you control: Prevent all damage target spell would deal this turn.",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "ca28357d-c2db-5a3a-be83-2ab712565211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1babca-b285-4b00-8b46-ed946c9a027f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1babca-b285-4b00-8b46-ed946c9a027f.jpg?1",
             "name": "Sigil of the New Dawn",
             "text": "Whenever a creature is put into your graveyard from play, you may pay o1o\nW. If you do, return that card to your hand.",
             "colours": [
@@ -1870,7 +1870,7 @@
         },
         {
             "id": "93bc409f-e57b-5b5a-8953-27a237a2642e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d563ebb-ecd1-406c-9d69-c101acdeced7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d563ebb-ecd1-406c-9d69-c101acdeced7.jpg?1",
             "name": "Sunfire Balm",
             "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.\nCycling o1o\nW (o1o\nW, Discard this card from your hand: Draw a card.)\nWhen you cycle Sunfire Balm, you may prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1902,7 +1902,7 @@
         },
         {
             "id": "ed8233b5-72f4-50c2-a5a6-68601fc47901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4289bdcb-6eea-458f-a4eb-89e26264673a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4289bdcb-6eea-458f-a4eb-89e26264673a.jpg?1",
             "name": "True Believer",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "c244658f-5f79-5dc0-a320-4c9126e73e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29906eca-0823-4cd6-890f-e5b93cc50a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29906eca-0823-4cd6-890f-e5b93cc50a11.jpg?1",
             "name": "Unified Strike",
             "text": "Remove target attacking creature from the game if its power is less than or equal to the number of Soldiers in play.",
             "colours": [
@@ -1969,7 +1969,7 @@
         },
         {
             "id": "7c39156a-1908-5c43-830a-cedebb78794a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601ab1-3862-4aff-82be-be15493fe4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601ab1-3862-4aff-82be-be15493fe4b0.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "o\nW, oc\nT: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library. Play this ability only if an opponent controls more lands than you.",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "0a58b648-0b77-520c-bee0-eed8e2cd4603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf6987e-a6e4-4a88-af0b-cf3b2d2b80c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf6987e-a6e4-4a88-af0b-cf3b2d2b80c7.jpg?1",
             "name": "Whipcorder",
             "text": "o\nW, oc\nT: Tap target creature.\nMorph o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "b9375010-6acd-5001-a68f-81ba233fe3ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea5c6e0-8361-4214-997b-32a66b19fae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea5c6e0-8361-4214-997b-32a66b19fae9.jpg?1",
             "name": "Words of Worship",
             "text": "o1: The next time you would draw a card this turn, you gain 5 life instead.",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "7a0cce7b-5e97-5c6c-a832-b25d2163b460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa43b0-601f-4b99-a328-541b04d5696d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa43b0-601f-4b99-a328-541b04d5696d.jpg?1",
             "name": "Airborne Aid",
             "text": "Draw a card for each Bird in play.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "2ee98c33-b75b-57b4-8c1a-e549ae95b2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95d5cb7-3121-430b-80c3-84c75e5f869e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95d5cb7-3121-430b-80c3-84c75e5f869e.jpg?1",
             "name": "Annex",
             "text": "You control enchanted land.",
             "colours": [
@@ -2139,7 +2139,7 @@
         },
         {
             "id": "9306d242-8a71-53fa-8de6-9e4340f126c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd2628f-63c4-4e19-83ea-26041650faab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd2628f-63c4-4e19-83ea-26041650faab.jpg?1",
             "name": "Aphetto Alchemist",
             "text": "oc\nT: Untap target artifact or creature.\nMorph o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "dd8418ad-47c6-5f2e-bb6a-57af366fd6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a7bf3-1b0c-415d-9c57-73ac55b1f915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a7bf3-1b0c-415d-9c57-73ac55b1f915.jpg?1",
             "name": "Aphetto Grifter",
             "text": "Tap two untapped Wizards you control: Tap target permanent.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "ae53d7f5-9e4b-5f94-af1c-214dcb3c1b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90865f52-c062-4505-a204-b4d7d4b3fc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90865f52-c062-4505-a204-b4d7d4b3fc4c.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "oc\nT: Draw three cards.\no2o\nUo\nU: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "5c048d5f-d1bf-5fea-a3cf-56743193b2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46894d1-2503-43fa-938e-7bbf19101d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46894d1-2503-43fa-938e-7bbf19101d13.jpg?1",
             "name": "Artificial Evolution",
             "text": "Change the text of target spell or permanent by replacing all instances of one creature type with another. The new creature type can't be Legend or Wall. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "0d6f904b-6cc3-502e-bfff-e27b106df9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b17df-615c-4cc1-af1a-2fc35a985af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b17df-615c-4cc1-af1a-2fc35a985af9.jpg?1",
             "name": "Ascending Aven",
             "text": "Flying\nAscending Aven may block only creatures with flying.\nMorph o2o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "666e8cf7-fc62-5af9-b617-1122a4a599ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4b41c4-0d14-4b9c-8e0c-a626ba6b104d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4b41c4-0d14-4b9c-8e0c-a626ba6b104d.jpg?1",
             "name": "Aven Fateshaper",
             "text": "Flying\nWhen Aven Fateshaper comes into play, look at the top four cards of your library, then put them back in any order.\no4o\nU: Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "d99fd63e-ebb8-5bc8-ad3b-af6c180c5354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c40269-80a5-454f-83dd-dae1c11500c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c40269-80a5-454f-83dd-dae1c11500c0.jpg?1",
             "name": "Backslide",
             "text": "Turn target creature with morph face down.\nCycling o\nU (o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "b9d5d150-c6a1-542a-a267-d477fc0b48f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8284476c-a7c8-4a6c-8021-ee997e9270ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8284476c-a7c8-4a6c-8021-ee997e9270ce.jpg?1",
             "name": "Blatant Thievery",
             "text": "For each opponent, gain control of target permanent that player controls. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "7e1e3177-46c7-5365-b7a4-7f244a371acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd3ce7-e0e3-4412-9983-ff933584f59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd3ce7-e0e3-4412-9983-ff933584f59b.jpg?1",
             "name": "Callous Oppressor",
             "text": "You may choose not to untap Callous Oppressor during your untap step.\nAs Callous Oppressor comes into play, an opponent chooses a creature type.\noc\nT: Gain control of target creature that isn't of the chosen type as long as Callous Oppressor remains tapped.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "3bc37ffb-0aa3-578d-9e37-4a37b5108373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6b4a2-5780-46e9-b239-459d2cf37743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6b4a2-5780-46e9-b239-459d2cf37743.jpg?1",
             "name": "Chain of Vapor",
             "text": "Return target nonland permanent to its owner's hand. Then that permanent's controller may sacrifice a land. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "f543e64d-72ad-5203-aa54-baca67d1df61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4de14d1-441f-4d65-bd12-df0506530015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4de14d1-441f-4d65-bd12-df0506530015.jpg?1",
             "name": "Choking Tethers",
             "text": "Tap up to four target creatures.\nCycling o1o\nU (o1o\nU, Discard this card from your hand: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
             "colours": [
@@ -2509,7 +2509,7 @@
         },
         {
             "id": "81691298-49ff-51d6-aacc-4ab98eb10771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d513dde-7c5f-46f1-b871-5290595bdbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d513dde-7c5f-46f1-b871-5290595bdbbe.jpg?1",
             "name": "Clone",
             "text": "As Clone comes into play, you may choose a creature in play. If you do, Clone comes into play as a copy of that creature.",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "7f6737c6-b3d5-53b7-884c-23ed3c16ce36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f69670-e494-42b8-9148-fe105ec61aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f69670-e494-42b8-9148-fe105ec61aa0.jpg?1",
             "name": "Complicate",
             "text": "Counter target spell unless its controller pays o3.\nCycling o2o\nU (o2o\nU, Discard this card from your hand: Draw a card.)\nWhen you cycle Complicate, you may counter target spell unless its controller pays o1.",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "15d28ef5-50c2-5a40-8a3f-a929803089e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d91378-f831-40ef-a79b-b044af1470e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d91378-f831-40ef-a79b-b044af1470e0.jpg?1",
             "name": "Crafty Pathmage",
             "text": "oc\nT: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "5d824a36-bc77-5e5a-be9c-488db21f74c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe86733-7851-4c2a-8d94-dba6f071b94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe86733-7851-4c2a-8d94-dba6f071b94d.jpg?1",
             "name": "Crown of Ascension",
             "text": "Enchanted creature has flying.\nSacrifice Crown of Ascension: Enchanted creature and other creatures that share a creature type with it gain flying until end of turn.",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "4ff58604-467a-57dd-8cae-1d66a09e9835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef584c5-6e2d-419b-9c11-a1b6c9c9ab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef584c5-6e2d-419b-9c11-a1b6c9c9ab2a.jpg?1",
             "name": "Discombobulate",
             "text": "Counter target spell. Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2676,7 +2676,7 @@
         },
         {
             "id": "c8585246-8e7a-5be4-82b4-2fc9756242fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69db0298-f6d5-450f-add3-a28c0a43f33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69db0298-f6d5-450f-add3-a28c0a43f33f.jpg?1",
             "name": "Dispersing Orb",
             "text": "o3o\nU, Sacrifice a permanent: Return target permanent to its owner's hand.",
             "colours": [
@@ -2708,7 +2708,7 @@
         },
         {
             "id": "35b13727-7bd7-5e8e-9e52-4ae980ccb85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d9c2f-356c-4f27-8560-8ffceadac31c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d9c2f-356c-4f27-8560-8ffceadac31c.jpg?1",
             "name": "Disruptive Pitmage",
             "text": "oc\nT: Counter target spell unless its controller pays o1.\nMorph o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "5e92dc52-bcd3-59d5-a834-bad741d0d91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0b6c7a-0891-492d-8e07-6a198bf2ccc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0b6c7a-0891-492d-8e07-6a198bf2ccc4.jpg?1",
             "name": "Essence Fracture",
             "text": "Return two target creatures to their owners' hands.\nCycling o2o\nU (o2o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "ae49538e-acff-5c1e-9034-0ab6afcaedf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a2758-0096-43b9-8193-d6ae5b41b6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a2758-0096-43b9-8193-d6ae5b41b6e6.jpg?1",
             "name": "Fleeting Aven",
             "text": "Flying\nWhenever a player cycles a card, return Fleeting Aven to its owner's hand.",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "99a9f5cc-cd06-56b8-ad9b-54bb7eba38fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd665-4948-4961-aec5-f17782257f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd665-4948-4961-aec5-f17782257f9b.jpg?1",
             "name": "Future Sight",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library as though it were in your hand.",
             "colours": [
@@ -2842,7 +2842,7 @@
         },
         {
             "id": "4275595d-3e30-5a77-9e81-3271aea91c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cc30a-9ed4-4f36-95cb-6f0a2b8dce02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cc30a-9ed4-4f36-95cb-6f0a2b8dce02.jpg?1",
             "name": "Ghosthelm Courier",
             "text": "You may choose not to untap Ghosthelm Courier during your untap step.\no2o\nU, oc\nT: As long as Ghosthelm Courier remains tapped, target Wizard gets +2/+2 and can't be the target of spells or abilities.",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "3d384fad-647a-5b03-987a-1acdd3416c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c16e565-0b7f-46b1-a091-64c47c923a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c16e565-0b7f-46b1-a091-64c47c923a9f.jpg?1",
             "name": "Graxiplon",
             "text": "Graxiplon is unblockable unless defending player controls three or more creatures that share a creature type.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "3812f9f5-b4c9-57ee-8ba7-6d832f6a5e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6441-8a45-43e4-8d12-a886dcaadbd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6441-8a45-43e4-8d12-a886dcaadbd3.jpg?1",
             "name": "Imagecrafter",
             "text": "oc\nT: Choose a creature type other than Legend or Wall. Target creature's type becomes that type until end of turn.",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "2f1eaa32-fbc5-5bdf-ad92-eee1d82b9760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ac59c-654d-44de-b266-532d44b34137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ac59c-654d-44de-b266-532d44b34137.jpg?1",
             "name": "Information Dealer",
             "text": "oc\nT: Look at the top X cards of your library, where X is the number of Wizards in play, then put them back in any order.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "321aefb8-4f6c-51dd-98b7-4846adb1ad52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d5e89-55f7-42b4-af19-d4d0f499a265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d5e89-55f7-42b4-af19-d4d0f499a265.jpg?1",
             "name": "Ixidor, Reality Sculptor",
             "text": "Face-down creatures get +1/+1.\no2o\nU: Turn target face-down creature face up.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "5852aef0-d60b-5fb3-a444-d4c714f62ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b713448-853a-41ee-a302-963e9c1c1c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b713448-853a-41ee-a302-963e9c1c1c65.jpg?1",
             "name": "Ixidor's Will",
             "text": "Counter target spell unless its controller pays o2 for each Wizard in play.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "10ec581d-456f-5172-90e5-fb42c4642b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301cb538-a931-4916-927b-4986046b1158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301cb538-a931-4916-927b-4986046b1158.jpg?1",
             "name": "Mage's Guile",
             "text": "Target creature can't be the target of spells or abilities this turn.\nCycling o\nU (o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3082,7 +3082,7 @@
         },
         {
             "id": "b6a40151-876f-5418-8b5c-585137c9ef30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685edfe8-9770-47c6-95fb-0816f3126f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685edfe8-9770-47c6-95fb-0816f3126f04.jpg?1",
             "name": "Meddle",
             "text": "If target spell has only one target and that target is a creature, change that spell's target to another creature.",
             "colours": [
@@ -3114,7 +3114,7 @@
         },
         {
             "id": "a33ec260-6d6b-59b1-99a3-2c415712c237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff34e303-c94a-4f5f-b9f6-8d48e6aac383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff34e303-c94a-4f5f-b9f6-8d48e6aac383.jpg?1",
             "name": "Mistform Dreamer",
             "text": "Flying\no1: Mistform Dreamer's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "a9f1f476-f217-565b-8abf-f67065806eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbb075-5795-425f-9e33-70cb922eea16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbb075-5795-425f-9e33-70cb922eea16.jpg?1",
             "name": "Mistform Mask",
             "text": "o1: Enchanted creature's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "95ea7de6-1d57-5c63-9cfe-26f1e10fcf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25b2697-5d7f-490a-8474-c775096e681e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25b2697-5d7f-490a-8474-c775096e681e.jpg?1",
             "name": "Mistform Mutant",
             "text": "o1o\nU: Choose a creature type other than Legend or Wall. Target creature's type becomes that type until end of turn.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "662bba54-af59-5c1b-88b1-80f600316b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1082eea2-5e83-48d4-b02b-a22e7cbe2054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1082eea2-5e83-48d4-b02b-a22e7cbe2054.jpg?1",
             "name": "Mistform Shrieker",
             "text": "Flying\no1: Mistform Shrieker's type becomes the creature type of your choice until end of turn.\nMorph o3o\nUo\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "762de601-3f11-5d45-a70c-57a5708004aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e394e096-ea70-4813-9039-e4bd065d0a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e394e096-ea70-4813-9039-e4bd065d0a17.jpg?1",
             "name": "Mistform Skyreaver",
             "text": "Flying\no1: Mistform Skyreaver's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "132ebcc0-0ab0-5c8a-9b46-d650b35458cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80d109-b73f-4b5d-b9e4-534e8d69633f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80d109-b73f-4b5d-b9e4-534e8d69633f.jpg?1",
             "name": "Mistform Stalker",
             "text": "o1: Mistform Stalker's type becomes the creature type of your choice until end of turn.\no2o\nUo\nU: Mistform Stalker gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "672e0ce5-ab1d-5b4d-bd6b-e74268130d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaa7a26-8516-4d71-a524-77b2d3f030d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaa7a26-8516-4d71-a524-77b2d3f030d5.jpg?1",
             "name": "Mistform Wall",
             "text": "(Walls can't attack.)\no1: Mistform Wall's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "9e01e03e-4148-50bc-9df7-aabefa7b2424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cf3535-3f80-4b76-aad3-dd851e6885a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cf3535-3f80-4b76-aad3-dd851e6885a6.jpg?1",
             "name": "Nameless One",
             "text": "Nameless One's power and toughness are each equal to the number of Wizards in play.\nMorph o2o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "217ec249-b205-5372-8a2f-17f87af2fc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0110ba-49e4-4729-8a84-4d408b20df53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0110ba-49e4-4729-8a84-4d408b20df53.jpg?1",
             "name": "Peer Pressure",
             "text": "Choose a creature type. If you control more creatures of that type than any other player, you gain control of all creatures of that type. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -3421,7 +3421,7 @@
         },
         {
             "id": "c0ebfc62-9188-57ed-8493-3181879b240e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e55695-16cc-4373-8078-959f1ded4c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e55695-16cc-4373-8078-959f1ded4c6d.jpg?1",
             "name": "Psychic Trance",
             "text": "Until end of turn, Wizards you control gain \"oc\nT: Counter target spell.\"",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "5e15baf5-3e63-5be4-a990-0ffd9900a886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93577bd-2711-443c-aa88-a235345d7800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93577bd-2711-443c-aa88-a235345d7800.jpg?1",
             "name": "Quicksilver Dragon",
             "text": "Flying\no\nU: If target spell has only one target and that target is Quicksilver Dragon, change that spell's target to another creature.\nMorph o4o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "f09f7132-2845-54d5-ae59-726fd43daaea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc148c21-cbe6-4cea-899b-e62501b59a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc148c21-cbe6-4cea-899b-e62501b59a00.jpg?1",
             "name": "Read the Runes",
             "text": "Draw X cards. For each card drawn this way, discard a card from your hand unless you sacrifice a permanent.",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "ab12fa71-3947-508e-96a3-0bdfe72e67ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f246e3-2193-4820-9c59-07b480300fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f246e3-2193-4820-9c59-07b480300fbe.jpg?1",
             "name": "Reminisce",
             "text": "Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -3551,7 +3551,7 @@
         },
         {
             "id": "6ad26f2d-ab6f-5425-b306-5df798a6d828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d399b71-c365-492c-976e-2c79d97d08bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d399b71-c365-492c-976e-2c79d97d08bc.jpg?1",
             "name": "Riptide Biologist",
             "text": "Protection from Beasts\nMorph o2o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "fc249eb0-2778-55c6-8e75-299ba71c38a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3767f568-36b1-4064-835e-4dd7576b7b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3767f568-36b1-4064-835e-4dd7576b7b8b.jpg?1",
             "name": "Riptide Chronologist",
             "text": "o\nU, Sacrifice Riptide Chronologist: Untap all creatures of the type of your choice.",
             "colours": [
@@ -3621,7 +3621,7 @@
         },
         {
             "id": "189bf95e-7dbc-5240-996a-0693d05eac4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd9abc9-f289-4294-bc0f-4addc8b92a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd9abc9-f289-4294-bc0f-4addc8b92a4e.jpg?1",
             "name": "Riptide Entrancer",
             "text": "Whenever Riptide Entrancer deals combat damage to a player, you may sacrifice it. If you do, gain control of target creature that player controls. (This effect doesn't end at end of turn.)\nMorph o\nUo\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3656,7 +3656,7 @@
         },
         {
             "id": "7c051edf-ad88-5093-893f-cf3021d05bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85be34ac-7bc2-4da2-8d9c-2412b9946073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85be34ac-7bc2-4da2-8d9c-2412b9946073.jpg?1",
             "name": "Riptide Shapeshifter",
             "text": "o2o\nUo\nU, Sacrifice Riptide Shapeshifter: Choose a creature type. Reveal cards from the top of your library until you reveal a creature card of that type. Put that card into play and shuffle the rest into your library.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "9a25de58-bf33-5155-b5c5-d42d8f6e2e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad96e158-bf2b-4f3e-9692-0f79efdd94f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad96e158-bf2b-4f3e-9692-0f79efdd94f5.jpg?1",
             "name": "Rummaging Wizard",
             "text": "o2o\nU: Look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "d2cf6aac-e13a-5c12-8df6-12d20b2b47c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c03afc5-7ca3-4ac6-a06e-091e2cce13a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c03afc5-7ca3-4ac6-a06e-091e2cce13a0.jpg?1",
             "name": "Sage Aven",
             "text": "Flying\nWhen Sage Aven comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -3760,7 +3760,7 @@
         },
         {
             "id": "38c505ff-2a4b-5df6-b526-05d05c3fe63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5856ac-e710-44ee-8516-6070f4f31ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5856ac-e710-44ee-8516-6070f4f31ce5.jpg?1",
             "name": "Screaming Seahawk",
             "text": "Flying\nWhen Screaming Seahawk comes into play, you may search your library for a card named Screaming Seahawk, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "cf5909f0-a4bd-542c-ad38-9dd2f179db34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb652a5c-464e-4ba4-a4ab-1181be70cf7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb652a5c-464e-4ba4-a4ab-1181be70cf7a.jpg?1",
             "name": "Sea's Claim",
             "text": "Enchanted land is an island.",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "140ec755-b635-5d61-8392-2bfcc8addd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d06a1f-00b7-440d-849d-efc466d73f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d06a1f-00b7-440d-849d-efc466d73f29.jpg?1",
             "name": "Slipstream Eel",
             "text": "Slipstream Eel can't attack unless defending player controls an island.\nCycling o1o\nU (o1o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "b730df06-b7bc-55dd-b477-a43c978dd11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4bed3f-845c-4822-b8af-8b511dce6fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4bed3f-845c-4822-b8af-8b511dce6fe2.jpg?1",
             "name": "Spy Network",
             "text": "Look at target player's hand, the top card of that player's library, and any face-down creatures he or she controls. Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -3895,7 +3895,7 @@
         },
         {
             "id": "ea8c90f9-e421-549f-b519-3cd42d70cc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c79e64-91bf-4e87-a4fd-3136ea67c5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c79e64-91bf-4e87-a4fd-3136ea67c5bb.jpg?1",
             "name": "Standardize",
             "text": "Choose a creature type other than Legend or Wall. Each creature's type becomes that type until end of turn.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "0cbc6ab8-629a-5669-96aa-7bdff36c7bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867de3d2-2178-4931-823e-ff439e1a45ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867de3d2-2178-4931-823e-ff439e1a45ea.jpg?1",
             "name": "Supreme Inquisitor",
             "text": "Tap five untapped Wizards you control: Search target player's library for up to five cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "f6ba8b97-6dc0-5883-9239-e927a876ac75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92e197e-ef7e-46bb-9533-5f9819d545b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92e197e-ef7e-46bb-9533-5f9819d545b2.jpg?1",
             "name": "Trade Secrets",
             "text": "Target opponent draws two cards, then you draw up to four cards. That opponent may repeat this process as many times as he or she chooses.",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "ca174f0e-24fc-5cca-96d4-5ef4765f08e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a2ee45-7f1d-40a8-82b4-ab3b705417ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a2ee45-7f1d-40a8-82b4-ab3b705417ea.jpg?1",
             "name": "Trickery Charm",
             "text": "Choose one Target creature gains flying until end of turn; or target creature's type becomes the creature type of your choice until end of turn; or look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -4026,7 +4026,7 @@
         },
         {
             "id": "8e14be91-4a8d-5822-8903-199dc2e2d19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7441e7f9-a326-4f61-b7b1-e0dbed06046f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7441e7f9-a326-4f61-b7b1-e0dbed06046f.jpg?1",
             "name": "Voidmage Prodigy",
             "text": "o\nUo\nU, Sacrifice a Wizard: Counter target spell.\nMorph o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "1628559b-3ec3-5f5e-b5b4-97b2d8c7fa47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f50a1a-f3d0-4fcf-bd32-0e173b0d3247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f50a1a-f3d0-4fcf-bd32-0e173b0d3247.jpg?1",
             "name": "Wheel and Deal",
             "text": "Any number of target opponents each discards his or her hand and draws seven cards.\nDraw a card.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "454f5658-5f95-5ef7-80a3-05e0be13c7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5595a57a-a76c-467b-afaf-5affffc24f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5595a57a-a76c-467b-afaf-5affffc24f35.jpg?1",
             "name": "Words of Wind",
             "text": "o1: The next time you would draw a card this turn, each player returns a permanent he or she controls to its owner's hand instead.",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "c2e2bd85-74e3-5b60-9768-684c0bbf046a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894556d8-6d5c-431b-a45d-26cd37c5f456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894556d8-6d5c-431b-a45d-26cd37c5f456.jpg?1",
             "name": "Accursed Centaur",
             "text": "When Accursed Centaur comes into play, sacrifice a creature.",
             "colours": [
@@ -4160,7 +4160,7 @@
         },
         {
             "id": "98602e96-acee-5632-a429-882eae5511b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e43d62c-488a-4c8d-b193-bacbf8037761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e43d62c-488a-4c8d-b193-bacbf8037761.jpg?1",
             "name": "Anurid Murkdiver",
             "text": "Swampwalk",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "10065749-efa1-5d46-ac68-e9c4b036c7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e7fadf-40f1-45ff-97ef-5830381accc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e7fadf-40f1-45ff-97ef-5830381accc9.jpg?1",
             "name": "Aphetto Dredging",
             "text": "Return up to three target creature cards of the creature type of your choice from your graveyard to your hand.",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "239a6a04-31c3-529c-90b9-dce5271cd53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492b9-03a8-4d53-a0cf-4814ffbec409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492b9-03a8-4d53-a0cf-4814ffbec409.jpg?1",
             "name": "Aphetto Vulture",
             "text": "Flying\nWhen Aphetto Vulture is put into a graveyard from play, you may put target Zombie card from your graveyard on top of your library.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "bf3b4737-8948-50aa-80e6-f2bc5c311b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b40f6eb-e2a4-46d2-8822-b0f3dc508b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b40f6eb-e2a4-46d2-8822-b0f3dc508b73.jpg?1",
             "name": "Blackmail",
             "text": "Target player reveals three cards from his or her hand and you choose one of them. That player discards that card.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "6acebbcd-2d45-5e03-b539-b93a291d27fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d58030-a95a-4221-93bc-30a59344e30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d58030-a95a-4221-93bc-30a59344e30b.jpg?1",
             "name": "Boneknitter",
             "text": "o1o\nB: Regenerate target Zombie.\nMorph o2o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "f4963900-a6d8-5baf-85a9-e6de4359ec2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdf6e2a-1bf5-4d63-a58b-883cfb1ea0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdf6e2a-1bf5-4d63-a58b-883cfb1ea0fa.jpg?1",
             "name": "Cabal Archon",
             "text": "o\nB, Sacrifice a Cleric: Target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "a813d5a4-94c6-5ed0-bd73-c8751a74626e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7727a7-0cdf-4fd5-82b4-e6587c10ca80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7727a7-0cdf-4fd5-82b4-e6587c10ca80.jpg?1",
             "name": "Cabal Executioner",
             "text": "Whenever Cabal Executioner deals combat damage to a player, that player sacrifices a creature.\nMorph o3o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4400,7 +4400,7 @@
         },
         {
             "id": "aa410d84-5c6a-5963-b16a-1d7d6320df1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c04fd3-021a-4011-be9b-0d268557aa06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c04fd3-021a-4011-be9b-0d268557aa06.jpg?1",
             "name": "Cabal Slaver",
             "text": "Whenever a Goblin deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "beada537-108a-5d82-be87-422ebf562aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfe64f9-8b03-41f6-a47b-fade397ad9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfe64f9-8b03-41f6-a47b-fade397ad9d1.jpg?1",
             "name": "Chain of Smog",
             "text": "Target player discards two cards from his or her hand. That player may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "e6d8e894-b461-5f65-9a65-96d574ab9155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6d7d88-d82b-40f4-bf57-ec5d7c480689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6d7d88-d82b-40f4-bf57-ec5d7c480689.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness comes into play, choose a creature type.\nCreatures of the chosen type have fear. (They can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "2654df6a-5ce0-5f97-8468-b2c2bd9ea364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8953e11b-cc3a-4c8d-9d7e-04bf90c77027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8953e11b-cc3a-4c8d-9d7e-04bf90c77027.jpg?1",
             "name": "Crown of Suspicion",
             "text": "Enchanted creature gets +2/-1.\nSacrifice Crown of Suspicion: Enchanted creature and other creatures that share a creature type with it get +2/-1 until end of turn.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "0ebbd262-917e-5c1e-aa1e-fe48d770e1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245aba23-2abb-4084-b4cb-d06e46de2108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245aba23-2abb-4084-b4cb-d06e46de2108.jpg?1",
             "name": "Cruel Revival",
             "text": "Destroy target non-Zombie creature. It can't be regenerated. Return up to one target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "603231f0-6184-58d9-970f-a03e7b1181e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9057-267a-4c78-b72a-4f8018b627a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9057-267a-4c78-b72a-4f8018b627a8.jpg?1",
             "name": "Death Match",
             "text": "Whenever a creature comes into play, that creature's controller may have target creature of his or her choice get -3/-3 until end of turn.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "6584f9e0-a7be-5db0-80ee-4d74735fab41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fd470-e535-47ea-98a0-6187e429dfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fd470-e535-47ea-98a0-6187e429dfe1.jpg?1",
             "name": "Death Pulse",
             "text": "Target creature gets -4/-4 until end of turn.\nCycling o1o\nBo\nB (o1o\nBo\nB, Discard this card from your hand: Draw a card.)\nWhen you cycle Death Pulse, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "420a60d7-03af-5786-82da-58c46e6c38d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8496e9c2-4c13-4307-bda7-b88512a21a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8496e9c2-4c13-4307-bda7-b88512a21a6a.jpg?1",
             "name": "Dirge of Dread",
             "text": "All creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)\nCycling o1o\nB (o1o\nB, Discard this card from your hand: Draw a card.)\nWhen you cycle Dirge of Dread, you may have target creature gain fear until end of turn.",
             "colours": [
@@ -4661,7 +4661,7 @@
         },
         {
             "id": "89743b98-7ec9-51cc-a77a-dc46619a56a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cc7ab0-a5db-4ae9-af9a-89fd5aaaab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cc7ab0-a5db-4ae9-af9a-89fd5aaaab57.jpg?1",
             "name": "Disciple of Malice",
             "text": "Protection from white\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "092f93ad-628f-5c55-bb8d-2b9274e23289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca3e348-47cc-41d6-999a-60d1206aaf06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca3e348-47cc-41d6-999a-60d1206aaf06.jpg?1",
             "name": "Doomed Necromancer",
             "text": "o\nB, oc\nT, Sacrifice Doomed Necromancer: Return target creature card from your graveyard to play.",
             "colours": [
@@ -4732,7 +4732,7 @@
         },
         {
             "id": "8ee5569f-b0dc-59c2-982c-6afe7d5c137f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebef2c-8bb2-4816-a628-0062f95e512e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebef2c-8bb2-4816-a628-0062f95e512e.jpg?1",
             "name": "Ebonblade Reaper",
             "text": "Whenever Ebonblade Reaper attacks, you lose half your life, rounded up.\nWhenever Ebonblade Reaper deals combat damage to a player, that player loses half his or her life, rounded up.\nMorph o3o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "2f3b284e-5fc4-59bc-a143-aac6a6bc9b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15326971-a53b-45f2-8f1d-1b82935286e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15326971-a53b-45f2-8f1d-1b82935286e1.jpg?1",
             "name": "Endemic Plague",
             "text": "As an additional cost to play Endemic Plague, sacrifice a creature.\nDestroy all creatures that share a creature type with the sacrificed creature. They can't be regenerated.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "b527d563-7482-549d-902a-d23c9c50eef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab92-3e1f-49dc-afd0-8c84d0d952c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab92-3e1f-49dc-afd0-8c84d0d952c2.jpg?1",
             "name": "Entrails Feaster",
             "text": "At the beginning of your upkeep, you may remove a creature card in a graveyard from the game. If you do, put a +1/+1 counter on Entrails Feaster. If you don't, tap Entrails Feaster.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "628fffbd-8558-5703-8660-b96e36a7de4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34afa-0183-49aa-aa5f-03e070020136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34afa-0183-49aa-aa5f-03e070020136.jpg?1",
             "name": "Fade from Memory",
             "text": "Remove target card in a graveyard from the game.\nCycling o\nB (o\nB, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "97d7e4de-2eed-5d86-95bb-d2728ce88275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7652dc61-9170-4895-a0bf-c32a1ee0350e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7652dc61-9170-4895-a0bf-c32a1ee0350e.jpg?1",
             "name": "Fallen Cleric",
             "text": "Protection from Clerics\nMorph o4o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "9f62d05b-2cd1-5f58-8dfd-698c070ebf36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef397db1-2d99-4cb0-a6e9-6f72d615ebad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef397db1-2d99-4cb0-a6e9-6f72d615ebad.jpg?1",
             "name": "False Cure",
             "text": "Until end of turn, whenever a player gains life, that player loses 2 life for each 1 life he or she gained.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "3eb16b6f-29e0-5467-a096-bf2b94150f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d74c30-ebca-4684-ad84-3ca19193ad88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d74c30-ebca-4684-ad84-3ca19193ad88.jpg?1",
             "name": "Feeding Frenzy",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of Zombies in play.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "66143d4c-030e-5c1c-b241-50260c941dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7209cc8-b519-4f27-87d8-b12e239a121f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7209cc8-b519-4f27-87d8-b12e239a121f.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "3ed447f2-b6b2-5541-a6ee-0d097b8d88e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0fa75a-a82b-44cd-965f-07e0fe7a111a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0fa75a-a82b-44cd-965f-07e0fe7a111a.jpg?1",
             "name": "Frightshroud Courier",
             "text": "You may choose not to untap Frightshroud Courier during your untap step.\no2o\nB, oc\nT: As long as Frightshroud Courier remains tapped, target Zombie gets +2/+2 and has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -5034,7 +5034,7 @@
         },
         {
             "id": "73c931d0-d2e4-5c94-a47b-0d64cb5827d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b58b6b-24cd-4440-b99c-d88d44b3c41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b58b6b-24cd-4440-b99c-d88d44b3c41c.jpg?1",
             "name": "Gangrenous Goliath",
             "text": "Tap three untapped Clerics you control: Return Gangrenous Goliath from your graveyard to your hand.",
             "colours": [
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "2e7724c5-bcc3-5368-828c-560a74754777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db909e95-7979-41f0-b17a-874c4137fcc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db909e95-7979-41f0-b17a-874c4137fcc1.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -5103,7 +5103,7 @@
         },
         {
             "id": "c43a2f6d-3e31-5832-b7b1-24dfc30a08b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18dc249-a343-4198-bef9-e8092a2bac15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18dc249-a343-4198-bef9-e8092a2bac15.jpg?1",
             "name": "Gravespawn Sovereign",
             "text": "Tap five untapped Zombies you control: Put target creature card from a graveyard into play under your control.",
             "colours": [
@@ -5137,7 +5137,7 @@
         },
         {
             "id": "e3a2dfbb-848a-529c-9ff4-68364ddfba91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de2f66-0b86-4c21-b4c8-c2d97e3fd095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de2f66-0b86-4c21-b4c8-c2d97e3fd095.jpg?1",
             "name": "Grinning Demon",
             "text": "At the beginning of your upkeep, you lose 2 life.\nMorph o2o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "c4659c15-a416-5a7c-b4fe-7de6c64dd1aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a164420c-3619-4f5e-81cf-2aa5a4553bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a164420c-3619-4f5e-81cf-2aa5a4553bc3.jpg?1",
             "name": "Haunted Cadaver",
             "text": "Whenever Haunted Cadaver deals combat damage to a player, you may sacrifice it. If you do, that player discards three cards from his or her hand.\nMorph o1o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "80a3b164-5676-5b46-8bbe-2b86a5df2f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecc098-aa2b-4bae-80d5-4d02128ef837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecc098-aa2b-4bae-80d5-4d02128ef837.jpg?1",
             "name": "Head Games",
             "text": "Target opponent puts the cards from his or her hand on top of his or her library. Search that player's library for that many cards. The player puts those cards into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -5237,7 +5237,7 @@
         },
         {
             "id": "ffcc5119-2fa1-592b-aa4e-39ee3e91b290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbd82d5-d64f-4833-b1a9-9652fcfa1578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbd82d5-d64f-4833-b1a9-9652fcfa1578.jpg?1",
             "name": "Headhunter",
             "text": "Whenever Headhunter deals combat damage to a player, that player discards a card from his or her hand.\nMorph o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "8224f491-8020-5e05-aea3-91f6ce920903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7890ba2-aa42-4c8d-bbc1-94fb1d4150fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7890ba2-aa42-4c8d-bbc1-94fb1d4150fc.jpg?1",
             "name": "Infest",
             "text": "All creatures get -2/-2 until end of turn.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "0989d38c-46b1-59aa-b0dd-c873185a5085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be66eaf-222b-4c40-a9fa-aad56b9218e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be66eaf-222b-4c40-a9fa-aad56b9218e0.jpg?1",
             "name": "Misery Charm",
             "text": "Choose one Destroy target Cleric; or return target Cleric card from your graveyard to your hand; or target player loses 2 life.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "7f77133e-da57-556e-944d-cc06fcb36cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff31ece-f132-4107-9415-fcf30e251167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff31ece-f132-4107-9415-fcf30e251167.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -5371,7 +5371,7 @@
         },
         {
             "id": "321f3080-f740-5df9-a0d5-db99d355b56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbfd715-0772-4516-8cd8-89495dbccf4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbfd715-0772-4516-8cd8-89495dbccf4a.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "005cae9d-52f2-5f53-b212-4b7d1dad344b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2deba175-8c02-492d-b404-5d842910c095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2deba175-8c02-492d-b404-5d842910c095.jpg?1",
             "name": "Patriarch's Bidding",
             "text": "Each player chooses a creature type. Each player returns all creature cards of a type chosen this way from his or her graveyard to play.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "659b48c4-da4a-538f-a1d6-f6e4ffdf0669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8320ef-af97-4cf6-9aaf-17818174d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8320ef-af97-4cf6-9aaf-17818174d842.jpg?1",
             "name": "Profane Prayers",
             "text": "Profane Prayers deals X damage to target creature or player and you gain X life, where X is the number of Clerics in play.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "599bea52-f75c-58ad-8c04-c724b7b3aa42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f037e99-75fb-4a2a-b4c6-448ef21b16a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f037e99-75fb-4a2a-b4c6-448ef21b16a3.jpg?1",
             "name": "Prowling Pangolin",
             "text": "When Prowling Pangolin comes into play, any player may sacrifice two creatures. If a player does, sacrifice Prowling Pangolin.",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "00426069-829e-5bdd-a94b-82b98dc59ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b29d1e-9c06-4ad1-8178-b3eaa212f6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b29d1e-9c06-4ad1-8178-b3eaa212f6f1.jpg?1",
             "name": "Rotlung Reanimator",
             "text": "Whenever Rotlung Reanimator or another Cleric is put into a graveyard from play, put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "fa5b1951-551a-5f00-a058-988f83f05a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4b887a-d928-4f6c-aa37-a0b09e87b91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4b887a-d928-4f6c-aa37-a0b09e87b91e.jpg?1",
             "name": "Screeching Buzzard",
             "text": "Flying\nWhen Screeching Buzzard is put into a graveyard from play, each opponent discards a card from his or her hand.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "ee3b2c53-b9db-5552-8a0b-461e76fde688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe12afd-da41-436e-af84-fa3b36a58030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe12afd-da41-436e-af84-fa3b36a58030.jpg?1",
             "name": "Severed Legion",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -5605,7 +5605,7 @@
         },
         {
             "id": "1753a371-fc73-5e85-bba4-b1431d8a4dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37be9a8-ef69-4c62-8455-e129e62fe69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37be9a8-ef69-4c62-8455-e129e62fe69a.jpg?1",
             "name": "Shade's Breath",
             "text": "Until end of turn, each creature you control becomes black, its creature type becomes Shade, and it gains \"o\nB: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "2698ec69-6a3b-557f-9e54-e621d76c7432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952c021f-74c9-455f-9cd9-f0d354e8bea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952c021f-74c9-455f-9cd9-f0d354e8bea8.jpg?1",
             "name": "Shepherd of Rot",
             "text": "oc\nT: Each player loses 1 life for each Zombie in play.",
             "colours": [
@@ -5672,7 +5672,7 @@
         },
         {
             "id": "a0e22422-af02-525d-b1e2-6a87a2e2feb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd891ba-cf6a-4b83-a421-3a7c346ada31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd891ba-cf6a-4b83-a421-3a7c346ada31.jpg?1",
             "name": "Silent Specter",
             "text": "Flying\nWhenever Silent Specter deals combat damage to a player, that player discards two cards from his or her hand.\nMorph o3o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5706,7 +5706,7 @@
         },
         {
             "id": "f82e9a9b-f041-5ab0-8adf-e4217859a522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8321af-d667-44e7-8c03-3957286604b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8321af-d667-44e7-8c03-3957286604b9.jpg?1",
             "name": "Smother",
             "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "5c917f2d-3b95-58d7-8ade-905f9cdbfa99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c826d786-0d96-4f77-94ae-6907fbce51e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c826d786-0d96-4f77-94ae-6907fbce51e0.jpg?1",
             "name": "Soulless One",
             "text": "Soulless One's power and toughness are each equal to the number of Zombies in play plus the number of Zombie cards in all graveyards.",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "c5d92066-cc07-5214-b3ac-8f2da4d496d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0d666a-8e31-466c-937f-54df910f664e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0d666a-8e31-466c-937f-54df910f664e.jpg?1",
             "name": "Spined Basher",
             "text": "Morph o2o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5808,7 +5808,7 @@
         },
         {
             "id": "ed3d8434-cf8f-5d44-b0be-e221a565a240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcf434-5c67-440a-8b67-2df7307e92bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcf434-5c67-440a-8b67-2df7307e92bd.jpg?1",
             "name": "Strongarm Tactics",
             "text": "Each player discards a card from his or her hand. Then each player who didn't discard a creature card this way loses 4 life.",
             "colours": [
@@ -5840,7 +5840,7 @@
         },
         {
             "id": "66484280-edfc-5325-82a7-f845dcee90eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a260-6c50-401d-a0ff-bf49a973e1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a260-6c50-401d-a0ff-bf49a973e1a1.jpg?1",
             "name": "Swat",
             "text": "Destroy target creature with power 2 or less.\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "bd8b0004-435c-5bd6-b03c-1942cd7a98a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg?1",
             "name": "Syphon Mind",
             "text": "Each other player discards a card from his or her hand. You draw a card for each card discarded this way.",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "9c015664-e6e8-53a4-ad48-276138b18098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaef0f-9965-463b-902d-72ec24b2db7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaef0f-9965-463b-902d-72ec24b2db7b.jpg?1",
             "name": "Syphon Soul",
             "text": "Syphon Soul deals 2 damage to each other player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "516d81b8-62c0-5116-a129-becdb64df549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da84de0e-a4cd-4dff-8ee3-87c9debf0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da84de0e-a4cd-4dff-8ee3-87c9debf0969.jpg?1",
             "name": "Thrashing Mudspawn",
             "text": "Whenever Thrashing Mudspawn is dealt damage, you lose that much life.\nMorph o1o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "8590e97b-2039-5feb-9ee2-0f67f36ecb1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc779d9-3200-4369-9289-1a8e90e243b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc779d9-3200-4369-9289-1a8e90e243b9.jpg?1",
             "name": "Undead Gladiator",
             "text": "o1o\nB, Discard a card from your hand: Return Undead Gladiator from your graveyard to your hand. Play this ability only during your upkeep.\nCycling o1o\nB (o1o\nB, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -6005,7 +6005,7 @@
         },
         {
             "id": "7353d5a5-8b3d-59d5-a6ed-c04c8ad33911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6adcfe-b0f7-4a96-bab2-f76c84ef5ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6adcfe-b0f7-4a96-bab2-f76c84ef5ca6.jpg?1",
             "name": "Visara the Dreadful",
             "text": "Flying\noc\nT: Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "ae1b5ab3-6fa6-5b5a-b58f-8c8e79a1e9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f3e91-571a-4990-b1e8-db2a5bac34af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f3e91-571a-4990-b1e8-db2a5bac34af.jpg?1",
             "name": "Walking Desecration",
             "text": "o\nB, oc\nT: Creatures of the type of your choice attack this turn if able.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "c2c42dbb-c402-5581-97c5-7b03aa227cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce4be1e-97dd-45ec-89e5-2fb56145c098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce4be1e-97dd-45ec-89e5-2fb56145c098.jpg?1",
             "name": "Withering Hex",
             "text": "Whenever a player cycles a card, put a plague counter on Withering Hex.\nEnchanted creature gets -1/-1 for each plague counter on Withering Hex.",
             "colours": [
@@ -6109,7 +6109,7 @@
         },
         {
             "id": "3ab4cf8b-1490-591a-a513-b4ec037bfda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2dcb8ed-23e7-4cee-9f43-042232c6035a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2dcb8ed-23e7-4cee-9f43-042232c6035a.jpg?1",
             "name": "Words of Waste",
             "text": "o1: The next time you would draw a card this turn, each opponent discards a card from his or her hand instead.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "1ce513d8-9219-5753-96cf-19a9e499521c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab525ad-1f62-4d9c-9b74-c7b0048da452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab525ad-1f62-4d9c-9b74-c7b0048da452.jpg?1",
             "name": "Wretched Anurid",
             "text": "Whenever another creature comes into play, you lose 1 life.",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "a76cc031-816c-5673-aa49-5ffe61cdb5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df2792-4971-49e8-a8f2-17700e247500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df2792-4971-49e8-a8f2-17700e247500.jpg?1",
             "name": "Aether Charge",
             "text": "Whenever a Beast comes into play under your control, you may have it deal 4 damage to target opponent.",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "dd550ac2-ca82-5011-abf8-6d6af9c3ee25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c5707-d5f2-4675-bfca-e801e6b0f627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c5707-d5f2-4675-bfca-e801e6b0f627.jpg?1",
             "name": "Aggravated Assault",
             "text": "o3o\nRo\nR: Untap all creatures you control. After this phase, there is an additional combat phase followed by an additional main phase. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -6241,7 +6241,7 @@
         },
         {
             "id": "b1e13027-a000-5dcd-a87f-f56e67a0d29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9796ac-11e2-4295-bf00-f684d0111970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9796ac-11e2-4295-bf00-f684d0111970.jpg?1",
             "name": "Airdrop Condor",
             "text": "Flying\no1o\nR, Sacrifice a Goblin: Airdrop Condor deals damage equal to the sacrificed Goblin's power to target creature or player.",
             "colours": [
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "6d5b7a0f-4740-5e89-b23a-5e7a10e22aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76705f-ec95-48b0-9e26-84ce40c9514b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76705f-ec95-48b0-9e26-84ce40c9514b.jpg?1",
             "name": "Avarax",
             "text": "Haste\nWhen Avarax comes into play, you may search your library for a card named Avarax, reveal it, and put it into your hand. If you do, shuffle your library.\no1o\nR: Avarax gets +1/+0 until end of turn.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "99eb75bb-f759-5dfd-b7cd-b071eb8a2428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef71f42-87e5-4b1d-aac1-3752b81cee7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef71f42-87e5-4b1d-aac1-3752b81cee7c.jpg?1",
             "name": "Battering Craghorn",
             "text": "First strike\nMorph o1o\nRo\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6344,7 +6344,7 @@
         },
         {
             "id": "274eaea1-f129-598f-bba3-640f029ac6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ddcf4a-1943-49dd-a02c-75804ce4bc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ddcf4a-1943-49dd-a02c-75804ce4bc3e.jpg?1",
             "name": "Blistering Firecat",
             "text": "Trample, haste\nAt end of turn, sacrifice Blistering Firecat.\nMorph o\nRo\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "54e189ba-3c6d-5968-bf39-8b664ac9ca4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ae8050-b644-41db-b1e9-d9bad2173485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ae8050-b644-41db-b1e9-d9bad2173485.jpg?1",
             "name": "Break Open",
             "text": "Turn target face-down creature an opponent controls face up.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "b96981ad-1bd1-585b-97cc-254b40343852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b08b0a6-c94e-4407-8a24-c8202497b5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b08b0a6-c94e-4407-8a24-c8202497b5f2.jpg?1",
             "name": "Brightstone Ritual",
             "text": "Add o\nR to your mana pool for each Goblin in play.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "b4fe6e2c-b0a1-59ba-8757-14d998b4ce22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a29cf-4b2e-44c0-af73-512d6fed0dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a29cf-4b2e-44c0-af73-512d6fed0dae.jpg?1",
             "name": "Butcher Orgg",
             "text": "You may divide Butcher Orgg's combat damage as you choose among defending player and/or any number of creatures he or she controls.",
             "colours": [
@@ -6477,7 +6477,7 @@
         },
         {
             "id": "04178205-0b20-5641-95a2-1c0a6800d122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94aa774-9036-4016-8880-4bde2710cb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94aa774-9036-4016-8880-4bde2710cb90.jpg?1",
             "name": "Chain of Plasma",
             "text": "Chain of Plasma deals 3 damage to target creature or player. Then that player or that creature's controller may discard a card from his or her hand. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "02885f14-3b09-5b29-a40d-ce75008505e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cfff37-655f-4107-abf3-e6f63d0e4de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cfff37-655f-4107-abf3-e6f63d0e4de2.jpg?1",
             "name": "Charging Slateback",
             "text": "Charging Slateback can't block.\nMorph o4o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "4f51d410-6c77-526c-9114-705c9c956a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb237330-ac2e-411d-836c-6628f96f3262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb237330-ac2e-411d-836c-6628f96f3262.jpg?1",
             "name": "Commando Raid",
             "text": "Until end of turn, target creature you control gains \"When this creature deals combat damage to a player, you may have it deal damage equal to its power to target creature that player controls.\"",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "7175746b-3173-5581-9a93-f2fb4fa5c364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caae974-f531-469d-8c6a-2077c4f3294a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caae974-f531-469d-8c6a-2077c4f3294a.jpg?1",
             "name": "Crown of Fury",
             "text": "Enchanted creature gets +1/+0 and has first strike.\nSacrifice Crown of Fury: Enchanted creature and other creatures that share a creature type with it get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -6609,7 +6609,7 @@
         },
         {
             "id": "3282eaf9-847c-5d0c-b6a2-448e884b3379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72257f5-0cf9-45ca-8dc7-a1a93bd7dd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72257f5-0cf9-45ca-8dc7-a1a93bd7dd1e.jpg?1",
             "name": "Custody Battle",
             "text": "Enchanted creature has \"At the beginning of your upkeep, target opponent gains control of this creature unless you sacrifice a land.\"",
             "colours": [
@@ -6643,7 +6643,7 @@
         },
         {
             "id": "ab5cbeb2-4210-55e1-ab43-e1a33e274320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4f28b-c7a7-4450-b477-73e4559f0276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4f28b-c7a7-4450-b477-73e4559f0276.jpg?1",
             "name": "Dragon Roost",
             "text": "o5o\nRo\nR: Put a 5/5 red Dragon creature token with flying into play.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "71f768fe-021f-5248-8bc9-e9400f65e4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970831a-738b-476f-9d46-39f10a1f91e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970831a-738b-476f-9d46-39f10a1f91e7.jpg?1",
             "name": "Dwarven Blastminer",
             "text": "o2o\nR, oc\nT: Destroy target nonbasic land.\nMorph o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6709,7 +6709,7 @@
         },
         {
             "id": "bc61e812-95e5-56ef-8676-2dda68131844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50f60a8-e99a-4891-b474-a21abee38970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50f60a8-e99a-4891-b474-a21abee38970.jpg?1",
             "name": "Embermage Goblin",
             "text": "When Embermage Goblin comes into play, you may search your library for a card named Embermage Goblin, reveal it, and put it into your hand. If you do, shuffle your library.\noc\nT: Embermage Goblin deals 1 damage to target creature or player.",
             "colours": [
@@ -6745,7 +6745,7 @@
         },
         {
             "id": "27d7a71e-07d6-52bb-9664-4e2e3db2ffd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee5aa80-32cc-486e-bbb2-5386eadaf4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee5aa80-32cc-486e-bbb2-5386eadaf4ca.jpg?1",
             "name": "Embermage Goblin",
             "text": "",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "c3c8ac79-758e-5063-a5ce-94e1c1e99f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f608a7e-5555-4554-a6e7-fe00e0bbe753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f608a7e-5555-4554-a6e7-fe00e0bbe753.jpg?1",
             "name": "Erratic Explosion",
             "text": "Choose target creature or player. Reveal cards from the top of your library until you reveal a nonland card. Erratic Explosion deals damage equal to that card's converted mana cost to that creature or player. Put the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "dc4da6d3-88ae-5b59-8760-2114518b4f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d1980-f460-4be2-9379-c3f74c8318f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d1980-f460-4be2-9379-c3f74c8318f3.jpg?1",
             "name": "Fever Charm",
             "text": "Choose one Target creature gains haste until end of turn; or target creature gets +2/+0 until end of turn; or Fever Charm deals 3 damage to target Wizard.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "2ba5e8ff-bb3f-5ce1-94a8-26422a4ecbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e822161d-0434-4578-aecd-c9ef0b84bd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e822161d-0434-4578-aecd-c9ef0b84bd4e.jpg?1",
             "name": "Flamestick Courier",
             "text": "You may choose not to untap Flamestick Courier during your untap step.\no2o\nR, oc\nT: As long as Flamestick Courier remains tapped, target Goblin gets +2/+2 and has haste.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "a06fcfc2-7c39-53a6-ab67-3ccad21289e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5874e312-1010-43f2-b330-82bc9fcc9f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5874e312-1010-43f2-b330-82bc9fcc9f53.jpg?1",
             "name": "Goblin Machinist",
             "text": "o2o\nR: Reveal cards from the top of your library until you reveal a nonland card. Goblin Machinist gets +X/+0 until end of turn, where X is that card's converted mana cost. Put the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "d838b33a-07fe-56ef-a46e-e9dfd51dea7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c4df1f-f148-42ec-8e22-e7114216927d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c4df1f-f148-42ec-8e22-e7114216927d.jpg?1",
             "name": "Goblin Piledriver",
             "text": "Protection from blue\nWhenever Goblin Piledriver attacks, it gets +2/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "a479bf53-8e01-5ad8-851a-a43fe15bba0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4815b7-fc20-44a4-ad1c-66d92993557f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4815b7-fc20-44a4-ad1c-66d92993557f.jpg?1",
             "name": "Goblin Pyromancer",
             "text": "When Goblin Pyromancer comes into play, all Goblins get +3/+0 until end of turn.\nAt end of turn, destroy all Goblins.",
             "colours": [
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "4d78e400-9ffe-5e8b-b1ad-0aeeaced1517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e689df7-b85d-4346-bee8-5e978b5cbbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e689df7-b85d-4346-bee8-5e978b5cbbbc.jpg?1",
             "name": "Goblin Sharpshooter",
             "text": "Goblin Sharpshooter doesn't untap during your untap step.\nWhenever a creature is put into a graveyard from play, untap Goblin Sharpshooter.\noc\nT: Goblin Sharpshooter deals 1 damage to target creature or player.",
             "colours": [
@@ -7017,7 +7017,7 @@
         },
         {
             "id": "6547649c-ac39-5e32-abe9-e7ef339decf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738cbf9b-e3d3-4568-93ce-7915b248e5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738cbf9b-e3d3-4568-93ce-7915b248e5b3.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "Flying",
             "colours": [
@@ -7052,7 +7052,7 @@
         },
         {
             "id": "a659d3af-ca3e-57d7-8218-2f5af2d01e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9a1ecf-29f6-474e-bbcf-3455d388aa94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9a1ecf-29f6-474e-bbcf-3455d388aa94.jpg?1",
             "name": "Goblin Sledder",
             "text": "Sacrifice a Goblin: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7086,7 +7086,7 @@
         },
         {
             "id": "7ea52a0c-f150-554c-b77e-be254bcd0f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feff65ca-aedf-4434-b701-590d600d1a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feff65ca-aedf-4434-b701-590d600d1a0b.jpg?1",
             "name": "Goblin Taskmaster",
             "text": "o1o\nR: Target Goblin gets +1/+0 until end of turn.\nMorph o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "2b4ab389-545e-526c-b16d-4c21271db96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0d3142-4224-4b51-885d-33c8938418c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0d3142-4224-4b51-885d-33c8938418c1.jpg?1",
             "name": "Grand Melee",
             "text": "All creatures attack each turn if able.\nAll creatures block each turn if able.",
             "colours": [
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "558acb5c-9ea3-5e58-a20e-86c9b2aa64cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c5d14-4fab-4034-a2d3-0d851ef67cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c5d14-4fab-4034-a2d3-0d851ef67cbd.jpg?1",
             "name": "Gratuitous Violence",
             "text": "If a creature you control would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "f4312ca1-722b-5c2a-83f7-b4e639606cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998bad32-1927-4e12-9527-efa55b86cae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998bad32-1927-4e12-9527-efa55b86cae0.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "ec6e4530-3356-52a9-8ab4-0b033f149dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e81e5fc-0e18-4dd8-a505-aa7dba8521a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e81e5fc-0e18-4dd8-a505-aa7dba8521a8.jpg?1",
             "name": "Kaboom!",
             "text": "Choose any number of target players. For each of those players, reveal cards from the top of your library until you reveal a nonland card. Kaboom deals damage equal to that card's converted mana cost to that player, then you put the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "121371bc-da15-5ea5-83d2-c4756ba1827c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4dd156-a2c1-4fab-b9f4-3302a4e8835a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4dd156-a2c1-4fab-b9f4-3302a4e8835a.jpg?1",
             "name": "Lavamancer's Skill",
             "text": "Enchanted creature has \"oc\nT: This creature deals 1 damage to target creature.\"\nIf enchanted creature is a Wizard, it has \"oc\nT: This creature deals 2 damage to target creature.\"",
             "colours": [
@@ -7282,7 +7282,7 @@
         },
         {
             "id": "e0d82e91-0d55-5d22-bd6a-0736dd05fc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22061b5e-81d3-4c7f-ab39-7ee719c13cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22061b5e-81d3-4c7f-ab39-7ee719c13cef.jpg?1",
             "name": "Lay Waste",
             "text": "Destroy target land.\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "29468782-66b3-5c57-a556-bcd4dfad17a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d775d729-0ad9-4b14-9d44-6282f6936e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d775d729-0ad9-4b14-9d44-6282f6936e07.jpg?1",
             "name": "Lightning Rift",
             "text": "Whenever a player cycles a card, you may pay o1. If you do, Lightning Rift deals 2 damage to target creature or player.",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "28ee6bb1-072a-556b-bc48-97f2ec8b4534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b15d04c-62cb-4704-8cc7-9842cef27a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b15d04c-62cb-4704-8cc7-9842cef27a1b.jpg?1",
             "name": "Mana Echoes",
             "text": "Whenever a creature comes into play, you may add o1 to your mana pool for each creature you control that shares a creature type with it.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "e6bf2e99-20db-59e2-9e7c-bc37b3084aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360a871-6932-45b2-bc94-1bd414e38906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360a871-6932-45b2-bc94-1bd414e38906.jpg?1",
             "name": "Menacing Ogre",
             "text": "Trample, haste\nWhen Menacing Ogre comes into play, each player secretly chooses a number. Then those numbers are revealed. Each player with the highest number loses that much life. If you are one of those players, put two +1/+1 counters on Menacing Ogre.",
             "colours": [
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "a7ce8c1f-039e-51f4-aebc-0a00c26e5d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea023e-e66d-4049-b7bc-5e660804f088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea023e-e66d-4049-b7bc-5e660804f088.jpg?1",
             "name": "Nosy Goblin",
             "text": "oc\nT, Sacrifice Nosy Goblin: Destroy target face-down creature.",
             "colours": [
@@ -7446,7 +7446,7 @@
         },
         {
             "id": "5ed77a43-dd16-53d5-ab80-38ec0f1c7cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cf8876-4c7d-4779-9363-d0a58bb7d851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cf8876-4c7d-4779-9363-d0a58bb7d851.jpg?1",
             "name": "Pinpoint Avalanche",
             "text": "Pinpoint Avalanche deals 4 damage to target creature. The damage can't be prevented.",
             "colours": [
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "d4e68eb6-24ba-5b3f-a797-92dcfe354b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37775f40-10de-4f5d-abb2-c49e682039de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37775f40-10de-4f5d-abb2-c49e682039de.jpg?1",
             "name": "Reckless One",
             "text": "Haste\nReckless One's power and toughness are each equal to the number of Goblins in play.",
             "colours": [
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "d45ae925-a2f4-5286-b6e3-64de9d32f341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09315c-d6ff-4fdb-8774-c6402b45e959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09315c-d6ff-4fdb-8774-c6402b45e959.jpg?1",
             "name": "Risky Move",
             "text": "At the beginning of each player's upkeep, that player gains control of Risky Move.\nWhen you gain control of Risky Move from another player, choose a creature you control and an opponent. Flip a coin. If you lose the flip, that opponent gains control of that creature.",
             "colours": [
@@ -7545,7 +7545,7 @@
         },
         {
             "id": "0f6282f2-80e8-5b74-96e6-d4bd3af696a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2caba5-9f30-4b5e-833e-68c85a47ef7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2caba5-9f30-4b5e-833e-68c85a47ef7c.jpg?1",
             "name": "Rorix Bladewing",
             "text": "Flying, haste",
             "colours": [
@@ -7581,7 +7581,7 @@
         },
         {
             "id": "9162dc72-5f7f-55a2-ab8e-18c83d75d05d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83db110-42e7-4823-a686-b83205faf503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83db110-42e7-4823-a686-b83205faf503.jpg?1",
             "name": "Searing Flesh",
             "text": "Searing Flesh deals 7 damage to target opponent.",
             "colours": [
@@ -7613,7 +7613,7 @@
         },
         {
             "id": "ea581b74-c2b7-5cc7-9caa-27f5f8e5c669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2de8a4-0d84-4f7c-bbe4-3a31172186ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2de8a4-0d84-4f7c-bbe4-3a31172186ab.jpg?1",
             "name": "Shaleskin Bruiser",
             "text": "Trample\nWhenever Shaleskin Bruiser attacks, it gets +3/+0 until end of turn for each other attacking Beast.",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "cd5a1479-2969-5f5a-bbb8-093b31fee07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c92b5d-103c-4719-a850-690a7010291a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c92b5d-103c-4719-a850-690a7010291a.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -7679,7 +7679,7 @@
         },
         {
             "id": "4f1fbfa9-edf3-530f-a141-4502ada32ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c870a66-4cd5-4a8d-9948-feffa7d4ff11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c870a66-4cd5-4a8d-9948-feffa7d4ff11.jpg?1",
             "name": "Skirk Commando",
             "text": "Whenever Skirk Commando deals combat damage to a player, you may have it deal 2 damage to target creature that player controls.\nMorph o2o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "12aeaf71-2c0f-586d-909f-b4b58eea2f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71117d0-5cf7-4041-b568-00bd8a975dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71117d0-5cf7-4041-b568-00bd8a975dd8.jpg?1",
             "name": "Skirk Fire Marshal",
             "text": "Protection from red\nTap five untapped Goblins you control: Skirk Fire Marshal deals 10 damage to each creature and each player.",
             "colours": [
@@ -7747,7 +7747,7 @@
         },
         {
             "id": "2b2213df-2e26-505d-9862-de7dc5a550f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb545dcd-3a7a-46a7-9c35-d28faebc6d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb545dcd-3a7a-46a7-9c35-d28faebc6d17.jpg?1",
             "name": "Skirk Prospector",
             "text": "Sacrifice a Goblin: Add o\nR to your mana pool.",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "2fbfee7f-cc68-5187-8764-e9bf2c9216c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc8a6e6-ed62-4784-ba9a-b1f703fc6119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc8a6e6-ed62-4784-ba9a-b1f703fc6119.jpg?1",
             "name": "Skittish Valesk",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, turn Skittish Valesk face down.\nMorph o5o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7815,7 +7815,7 @@
         },
         {
             "id": "f3a08fd9-1c7c-589f-8752-78f9eac6d547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59262684-86e3-4485-9e35-202771c3eaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59262684-86e3-4485-9e35-202771c3eaa6.jpg?1",
             "name": "Slice and Dice",
             "text": "Slice and Dice deals 4 damage to each creature.\nCycling o2o\nR (o2o\nR, Discard this card from your hand: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
             "colours": [
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "0ec33b70-19b6-5fe0-b424-96a62f5b7371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a47d41-b893-46b9-90c9-ccd8f9f78855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a47d41-b893-46b9-90c9-ccd8f9f78855.jpg?1",
             "name": "Snapping Thragg",
             "text": "Whenever Snapping Thragg deals combat damage to a player, you may have it deal 3 damage to target creature that player controls.\nMorph o4o\nRo\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "a661cc07-1000-53b0-8a6c-ffe01f9d8292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fc40c-6a68-4192-91d9-2031c7d32e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fc40c-6a68-4192-91d9-2031c7d32e05.jpg?1",
             "name": "Solar Blast",
             "text": "Solar Blast deals 3 damage to target creature or player.\nCycling o1o\nRo\nR (o1o\nRo\nR, Discard this card from your hand: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "6389ef66-09ea-5781-adc4-32c6331c9b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a4460d-3fe8-4b1f-9990-0a19c3345367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a4460d-3fe8-4b1f-9990-0a19c3345367.jpg?1",
             "name": "Sparksmith",
             "text": "oc\nT: Sparksmith deals X damage to target creature and X damage to you, where X is the number of Goblins in play.",
             "colours": [
@@ -7947,7 +7947,7 @@
         },
         {
             "id": "42e82155-92ec-5ac7-86ab-683c350ad32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe72820-952f-4c53-9ee7-ea7ea54fc848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe72820-952f-4c53-9ee7-ea7ea54fc848.jpg?1",
             "name": "Spitfire Handler",
             "text": "Spitfire Handler can't block creatures with power greater than Spitfire Handler's power.\no\nR: Spitfire Handler gets +1/+0 until end of turn.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "b9f97286-a560-5db3-8c5e-08597337cf30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d7aaea-226b-4820-8db2-89dcdcbcc557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d7aaea-226b-4820-8db2-89dcdcbcc557.jpg?1",
             "name": "Spurred Wolverine",
             "text": "Tap two untapped Beasts you control: Target creature gains first strike until end of turn.",
             "colours": [
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "465e8c53-4843-57d3-88ff-dcb959e43aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54d72ba-05ce-4299-a7c3-a9e9f126fffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54d72ba-05ce-4299-a7c3-a9e9f126fffb.jpg?1",
             "name": "Starstorm",
             "text": "Starstorm deals X damage to each creature.\nCycling o3 (o3, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "fa26da38-0ccc-58f4-87ce-4902304b569f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b65eba-140b-4c1d-b796-8134b7c1ede8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b65eba-140b-4c1d-b796-8134b7c1ede8.jpg?1",
             "name": "Tephraderm",
             "text": "Whenever a creature deals damage to Tephraderm, Tephraderm deals that much damage to that creature.\nWhenever a spell deals damage to Tephraderm, Tephraderm deals that much damage to that spell's controller.",
             "colours": [
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "e08562d2-b593-526a-844f-40ce3ac0a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89156b5-8bdb-41d1-a7aa-63f770a9b070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89156b5-8bdb-41d1-a7aa-63f770a9b070.jpg?1",
             "name": "Thoughtbound Primoc",
             "text": "Flying\nAt the beginning of your upkeep, if a player controls more Wizards than any other player, he or she gains control of Thoughtbound Primoc.",
             "colours": [
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "8a511385-9a2f-5c28-baaa-694c85ae3d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9676b6-6812-44e5-ad70-f498fbad0e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9676b6-6812-44e5-ad70-f498fbad0e18.jpg?1",
             "name": "Threaten",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "40282069-ee68-586e-b1cb-40f2d3a37488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4f796a-6831-4d83-824d-88fd2148b4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4f796a-6831-4d83-824d-88fd2148b4c1.jpg?1",
             "name": "Thunder of Hooves",
             "text": "Thunder of Hooves deals X damage to each creature without flying and each player, where X is the number of Beasts in play.",
             "colours": [
@@ -8181,7 +8181,7 @@
         },
         {
             "id": "ad83b32e-c777-5ed3-8f68-dba107280577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c88b942-06d5-45d8-a4d8-6ca864f65516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c88b942-06d5-45d8-a4d8-6ca864f65516.jpg?1",
             "name": "Wave of Indifference",
             "text": "X target creatures can't block this turn.",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "c692d1d4-498c-57c2-ba86-614122b3eed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2593a6a6-dc21-4742-acb8-f7092931b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2593a6a6-dc21-4742-acb8-f7092931b1ce.jpg?1",
             "name": "Words of War",
             "text": "o1: The next time you would draw a card this turn, Words of War deals 2 damage to target creature or player instead.",
             "colours": [
@@ -8245,7 +8245,7 @@
         },
         {
             "id": "c2e9eb4d-ad07-577f-a11d-d679fd370674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33db646-b30d-4a15-9f8a-63bda74e2d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33db646-b30d-4a15-9f8a-63bda74e2d81.jpg?1",
             "name": "Animal Magnetism",
             "text": "Reveal the top five cards of your library. An opponent chooses a creature card from among them. Put that card into play and the rest into your graveyard.",
             "colours": [
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "6ebb301b-635a-577d-a223-b36e7cd21f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9196ce7-3ff4-4dda-a628-559ada11c9ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9196ce7-3ff4-4dda-a628-559ada11c9ba.jpg?1",
             "name": "Barkhide Mauler",
             "text": "Cycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -8311,7 +8311,7 @@
         },
         {
             "id": "50542c89-2839-5638-bacf-ddb22212aa22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02d6d5-27be-4301-a467-5b49491d0d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02d6d5-27be-4301-a467-5b49491d0d4f.jpg?1",
             "name": "Biorhythm",
             "text": "Each player's life total becomes the number of creatures he or she controls.",
             "colours": [
@@ -8343,7 +8343,7 @@
         },
         {
             "id": "3df4f458-06b1-5950-b8f4-fec55e5aa1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce3a3a1-3569-4909-a604-f78d4888781e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce3a3a1-3569-4909-a604-f78d4888781e.jpg?1",
             "name": "Birchlore Rangers",
             "text": "Tap two untapped Elves you control: Add one mana of any color to your mana pool.\nMorph o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "8d9ad366-f16c-5452-93be-b7c686ecfdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc473-8477-4c04-a4e7-ecac1b0a5716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc473-8477-4c04-a4e7-ecac1b0a5716.jpg?1",
             "name": "Bloodline Shaman",
             "text": "oc\nT: Choose a creature type. Reveal the top card of your library. If that card is a creature card of the chosen type, put it into your hand. Otherwise, put it into your graveyard.",
             "colours": [
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "5c73b821-075a-5afc-b8d8-8919732c80f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38315ba3-57a0-4aa0-b1bc-4b1fcdd763d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38315ba3-57a0-4aa0-b1bc-4b1fcdd763d4.jpg?1",
             "name": "Broodhatch Nantuko",
             "text": "Whenever Broodhatch Nantuko is dealt damage, you may put that many 1/1 green Insect creature tokens into play.\nMorph o2o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "23f0e917-5807-5c17-8b91-09ea9feb5ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c75f9c8-9640-4f64-b32a-916436e461fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c75f9c8-9640-4f64-b32a-916436e461fc.jpg?1",
             "name": "Centaur Glade",
             "text": "o2o\nGo\nG: Put a 3/3 green Centaur creature token into play.",
             "colours": [
@@ -8482,7 +8482,7 @@
         },
         {
             "id": "5ac026bf-e12f-50d5-a316-89e5a0c1adb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d47ddca-a363-4ab7-b7f2-d0e0043c9916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d47ddca-a363-4ab7-b7f2-d0e0043c9916.jpg?1",
             "name": "Chain of Acid",
             "text": "Destroy target noncreature permanent. Then that permanent's controller may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "896ccc3d-f606-59a1-a47a-5478ef7dc6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e320a6-88e2-4be1-97e2-30e0f3c2e450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e320a6-88e2-4be1-97e2-30e0f3c2e450.jpg?1",
             "name": "Crown of Vigor",
             "text": "Enchanted creature gets +1/+1.\nSacrifice Crown of Vigor: Enchanted creature and other creatures that share a creature type with it get +1/+1 until end of turn.",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "144dac9c-fef6-560b-b316-a9c28a5aad26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c1aa30-0271-48d9-b9d0-3b1da26d98bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c1aa30-0271-48d9-b9d0-3b1da26d98bf.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders can't be blocked except by creatures with flying and/or Walls.",
             "colours": [
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "c8c0be55-537d-5e62-8bbc-e08999445b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698c46b-2628-4482-88f9-e37a01ade274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698c46b-2628-4482-88f9-e37a01ade274.jpg?1",
             "name": "Elvish Guidance",
             "text": "Whenever enchanted land is tapped for mana, its controller adds o\nG to his or her mana pool for each Elf in play.",
             "colours": [
@@ -8616,7 +8616,7 @@
         },
         {
             "id": "4dc4eba7-8209-5d0b-b25b-c5c466dba863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d810b8-1a15-46cc-9d9d-871ac43b7036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d810b8-1a15-46cc-9d9d-871ac43b7036.jpg?1",
             "name": "Elvish Pathcutter",
             "text": "o2o\nG: Target Elf gains forestwalk until end of turn.",
             "colours": [
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "323ff0fc-be66-5018-9146-a1ae9bca33ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e71fc2d-643b-4fad-89a8-624d330895d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e71fc2d-643b-4fad-89a8-624d330895d6.jpg?1",
             "name": "Elvish Pioneer",
             "text": "When Elvish Pioneer comes into play, you may put a basic land card from your hand into play tapped.",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "0a70ba58-5539-5694-99c6-0ce5e746163d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae85fafb-114b-4fd8-ac4c-5ada57054705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae85fafb-114b-4fd8-ac4c-5ada57054705.jpg?1",
             "name": "Elvish Scrapper",
             "text": "o\nG, oc\nT, Sacrifice Elvish Scrapper: Destroy target artifact.",
             "colours": [
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "195f810f-2bbd-5676-9559-1c5a31589db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455c6923-8d0e-4a7f-a5c0-add8db519ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455c6923-8d0e-4a7f-a5c0-add8db519ee3.jpg?1",
             "name": "Elvish Vanguard",
             "text": "Whenever another Elf comes into play, put a +1/+1 counter on Elvish Vanguard.",
             "colours": [
@@ -8755,7 +8755,7 @@
         },
         {
             "id": "20d5a703-3a71-5abd-ae95-56c76994a08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6b767b-49e5-4845-9b3f-29540e5fa330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6b767b-49e5-4845-9b3f-29540e5fa330.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -8790,7 +8790,7 @@
         },
         {
             "id": "82f4b549-0c22-5bc9-a517-bd73765ee350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75def198-99d6-4b0a-8878-5151f44bc0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75def198-99d6-4b0a-8878-5151f44bc0a4.jpg?1",
             "name": "Enchantress's Presence",
             "text": "Whenever you play an enchantment spell, draw a card.",
             "colours": [
@@ -8822,7 +8822,7 @@
         },
         {
             "id": "a9b95b0c-b89d-5dfe-b85a-c16c0f3716ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bf5786-e41a-4839-b8a0-5c7a413b23d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bf5786-e41a-4839-b8a0-5c7a413b23d0.jpg?1",
             "name": "Everglove Courier",
             "text": "You may choose not to untap Everglove Courier during your untap step.\no2o\nG, oc\nT: As long as Everglove Courier remains tapped, target Elf gets +2/+2 and has trample.",
             "colours": [
@@ -8856,7 +8856,7 @@
         },
         {
             "id": "0905d6cc-9009-55ea-86f9-5e8b5b01c376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6efd31-ab5e-46ff-80d2-9382438e302c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6efd31-ab5e-46ff-80d2-9382438e302c.jpg?1",
             "name": "Explosive Vegetation",
             "text": "Search your library for up to two basic land cards and put them into play tapped. Then shuffle your library.",
             "colours": [
@@ -8888,7 +8888,7 @@
         },
         {
             "id": "0d0bf7bc-d458-5fff-ae1d-188eaa708fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a96a608-9237-41c1-824c-89d5fad939ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a96a608-9237-41c1-824c-89d5fad939ad.jpg?1",
             "name": "Gigapede",
             "text": "Gigapede can't be the target of spells or abilities.\nAt the beginning of your upkeep, if Gigapede is in your graveyard, you may discard a card from your hand. If you do, return Gigapede to your hand.",
             "colours": [
@@ -8922,7 +8922,7 @@
         },
         {
             "id": "fe7a040d-d053-5e2e-838a-d1166c5d5fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea338499-26a0-44e5-8999-f264644184d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea338499-26a0-44e5-8999-f264644184d1.jpg?1",
             "name": "Heedless One",
             "text": "Trample\nHeedless One's power and toughness are each equal to the number of Elves in play.",
             "colours": [
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "6ed31a8d-a89c-5f5a-809d-0b98eaac4d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c964473-7c54-4c2d-a3eb-dba01c842103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c964473-7c54-4c2d-a3eb-dba01c842103.jpg?1",
             "name": "Hystrodon",
             "text": "Trample\nWhenever Hystrodon deals combat damage to a player, you may draw a card.\nMorph o1o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -8991,7 +8991,7 @@
         },
         {
             "id": "571bc0e9-428c-5fd4-85fa-494df9aeabb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f324b-63c6-4fb5-a80a-e9da51c3eb77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f324b-63c6-4fb5-a80a-e9da51c3eb77.jpg?1",
             "name": "Invigorating Boon",
             "text": "Whenever a player cycles a card, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -9023,7 +9023,7 @@
         },
         {
             "id": "a8316609-0500-573e-9b83-08f0c8806f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150d5229-b1a5-42cf-bf6a-04d246f1124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150d5229-b1a5-42cf-bf6a-04d246f1124f.jpg?1",
             "name": "Kamahl, Fist of Krosa",
             "text": "o\nG: Target land becomes a 1/1 creature until end of turn. It's still a land.\no2o\nGo\nGo\nG: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -9060,7 +9060,7 @@
         },
         {
             "id": "f5175ec9-9e14-5b58-8e99-cecf793b9974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edc37c6-b6a8-424f-95dd-928d03c28542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edc37c6-b6a8-424f-95dd-928d03c28542.jpg?1",
             "name": "Kamahl's Summons",
             "text": "Each player may reveal any number of creature cards from his or her hand. Then each player puts a 2/2 green Bear creature token into play for each card he or she revealed this way.",
             "colours": [
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "d3516447-7d75-5c0a-ab1f-37b8b3087afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804f3c0-5ebf-43ca-b200-09f7c1bbe902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804f3c0-5ebf-43ca-b200-09f7c1bbe902.jpg?1",
             "name": "Krosan Colossus",
             "text": "Morph o6o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9126,7 +9126,7 @@
         },
         {
             "id": "9402f02f-11dc-55ec-8287-b01b0282079d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82105090-5f71-4690-9ade-187354311ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82105090-5f71-4690-9ade-187354311ae3.jpg?1",
             "name": "Krosan Groundshaker",
             "text": "o\nG: Target Beast gains trample until end of turn.",
             "colours": [
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "70720d48-6adb-5628-b7f3-632e3f733c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b872f85-60c5-44c4-956d-a8aa8132908b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b872f85-60c5-44c4-956d-a8aa8132908b.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling o2o\nG (o2o\nG, Discard this card from your hand: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -9195,7 +9195,7 @@
         },
         {
             "id": "fe484e83-cd9e-54e5-82bd-ee8569d57999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56125660-2307-4270-a947-f1f4ad63841c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56125660-2307-4270-a947-f1f4ad63841c.jpg?1",
             "name": "Leery Fogbeast",
             "text": "Whenever Leery Fogbeast becomes blocked, prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "ea510d6e-494c-5af9-8c74-96f9b6c523ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829069cf-7e63-4443-b679-65ad15d6ca5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829069cf-7e63-4443-b679-65ad15d6ca5e.jpg?1",
             "name": "Mythic Proportions",
             "text": "Enchanted creature gets +8/+8 and has trample.",
             "colours": [
@@ -9263,7 +9263,7 @@
         },
         {
             "id": "11320490-55cf-52a4-8a85-746492907f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0acc41f-b55b-47cb-8803-d39d72788799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0acc41f-b55b-47cb-8803-d39d72788799.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -9295,7 +9295,7 @@
         },
         {
             "id": "0bd48913-1497-5673-90c4-a5abce224ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9e3793-7ddc-45c5-b25d-acd5cb96026f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9e3793-7ddc-45c5-b25d-acd5cb96026f.jpg?1",
             "name": "Overwhelming Instinct",
             "text": "Whenever you attack with three or more creatures, draw a card.",
             "colours": [
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "c799edb4-3a32-5976-be07-db94bc285cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b91a5a-9328-4fc6-a2f6-a7879281e145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b91a5a-9328-4fc6-a2f6-a7879281e145.jpg?1",
             "name": "Primal Boost",
             "text": "Target creature gets +4/+4 until end of turn.\nCycling o2o\nG (o2o\nG, Discard this card from your hand: Draw a card.)\nWhen you cycle Primal Boost, you may have target creature get +1/+1 until end of turn.",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "88e23599-0578-54b3-81ec-358d2c051406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98182d6-5b25-4493-9286-f29633e1bec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98182d6-5b25-4493-9286-f29633e1bec4.jpg?1",
             "name": "Ravenous Baloth",
             "text": "Sacrifice a Beast: You gain 4 life.",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "37013baa-7288-5639-9052-5d2dd29fdaac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a7354-162c-489d-955d-4df17b930e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a7354-162c-489d-955d-4df17b930e1c.jpg?1",
             "name": "Run Wild",
             "text": "Until end of turn, target creature gains trample and \"o\nG: Regenerate this creature.\"",
             "colours": [
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "80459a80-f908-5b58-a3b2-c79ff4081031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052a5af-20b2-4817-8c94-78d488ee220f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052a5af-20b2-4817-8c94-78d488ee220f.jpg?1",
             "name": "Serpentine Basilisk",
             "text": "Whenever Serpentine Basilisk deals combat damage to a creature, destroy that creature at end of combat.\nMorph o1o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "38b423ba-f34d-532c-82f0-03e49ad38c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41680e2-6689-4263-a5a3-9fb2e4280d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41680e2-6689-4263-a5a3-9fb2e4280d52.jpg?1",
             "name": "Silklash Spider",
             "text": "Silklash Spider may block as though it had flying.\no\nXo\nGo\nG: Silklash Spider deals X damage to each creature with flying.",
             "colours": [
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "5ac2d3ad-dfda-57a4-a0bb-e43c1cbe867d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e48715c-6ff7-4b0c-aa7e-a2c901215426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e48715c-6ff7-4b0c-aa7e-a2c901215426.jpg?1",
             "name": "Silvos, Rogue Elemental",
             "text": "Trample\no\nG: Regenerate Silvos, Rogue Elemental.",
             "colours": [
@@ -9529,7 +9529,7 @@
         },
         {
             "id": "ae5b80b6-ee61-530a-bc5f-a252a2d3316a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05788d63-6210-44f2-9ae4-e55e9507a3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05788d63-6210-44f2-9ae4-e55e9507a3a9.jpg?1",
             "name": "Snarling Undorak",
             "text": "o2o\nG: Target Beast gets +1/+1 until end of turn.\nMorph o1o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "87f40376-161b-50ca-9ed1-fa51b4f5531a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746b98bf-5398-4a00-b4fe-a990ea9cfd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746b98bf-5398-4a00-b4fe-a990ea9cfd77.jpg?1",
             "name": "Spitting Gourna",
             "text": "Spitting Gourna may block as though it had flying.\nMorph o4o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "ee5ed1e1-359d-57e6-beb7-7e20dca181e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc64b9-f5b9-42d3-9921-564c4c9f2c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc64b9-f5b9-42d3-9921-564c4c9f2c77.jpg?1",
             "name": "Stag Beetle",
             "text": "Stag Beetle comes into play with X +1/+1 counters on it, where X is the number of other creatures in play.",
             "colours": [
@@ -9631,7 +9631,7 @@
         },
         {
             "id": "faa04b17-9bde-5c58-a9d2-823c5b6a07c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88c530a-abc3-4cc4-8a48-5b76e1504a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88c530a-abc3-4cc4-8a48-5b76e1504a3c.jpg?1",
             "name": "Steely Resolve",
             "text": "As Steely Resolve comes into play, choose a creature type.\nCreatures of the chosen type can't be the targets of spells or abilities.",
             "colours": [
@@ -9663,7 +9663,7 @@
         },
         {
             "id": "935cf33f-5709-532d-ab91-c7fe52d2a986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb61443d-e47a-4fe1-b777-67a3670a5a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb61443d-e47a-4fe1-b777-67a3670a5a56.jpg?1",
             "name": "Symbiotic Beast",
             "text": "When Symbiotic Beast is put into a graveyard from play, put four 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -9698,7 +9698,7 @@
         },
         {
             "id": "5a9c1a91-c911-5e94-b8ca-d5f7fd1bec62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af35c6-7802-4366-ad20-1e330b4957ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af35c6-7802-4366-ad20-1e330b4957ef.jpg?1",
             "name": "Symbiotic Elf",
             "text": "When Symbiotic Elf is put into a graveyard from play, put two 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "515dca0e-a44a-536b-bd53-10f7b25a2fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60313ca-10cc-4c33-a557-1401c5721e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60313ca-10cc-4c33-a557-1401c5721e3b.jpg?1",
             "name": "Symbiotic Wurm",
             "text": "When Symbiotic Wurm is put into a graveyard from play, put seven 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "82103017-0b8d-5d45-8eac-413c62c4424d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b24af94-9632-47da-9bf3-e81bb743cd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b24af94-9632-47da-9bf3-e81bb743cd43.jpg?1",
             "name": "Taunting Elf",
             "text": "All creatures able to block Taunting Elf do so.",
             "colours": [
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "7527d37f-2fa6-5460-b1d9-f412ca366d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857c2b6c-cfdf-4c88-a334-2937cb7db603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857c2b6c-cfdf-4c88-a334-2937cb7db603.jpg?1",
             "name": "Tempting Wurm",
             "text": "When Tempting Wurm comes into play, each opponent may put any number of artifact, creature, enchantment, and/or land cards from his or her hand into play.",
             "colours": [
@@ -9834,7 +9834,7 @@
         },
         {
             "id": "7aedd758-9204-53d8-b328-f5a341fd0de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8cc948-28ff-4bbe-b8c9-71de37478023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8cc948-28ff-4bbe-b8c9-71de37478023.jpg?1",
             "name": "Towering Baloth",
             "text": "Morph o6o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9868,7 +9868,7 @@
         },
         {
             "id": "20305cf5-f09b-58c3-9ca5-c4ac66fbc895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d7ce-37d3-4989-beb4-173447cb5294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d7ce-37d3-4989-beb4-173447cb5294.jpg?1",
             "name": "Treespring Lorian",
             "text": "Morph o5o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9902,7 +9902,7 @@
         },
         {
             "id": "55e6b67f-85cf-530d-95ff-43aa7363ba31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7b5ddf-d5a6-42bf-a196-7e834dbdb3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7b5ddf-d5a6-42bf-a196-7e834dbdb3dc.jpg?1",
             "name": "Tribal Unity",
             "text": "Creatures of the type of your choice get +X/+X until end of turn.",
             "colours": [
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "f11d67ec-dcea-5180-82ad-bc6e8b7e4d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774771c-5373-4636-9174-d06e7d635183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774771c-5373-4636-9174-d06e7d635183.jpg?1",
             "name": "Venomspout Brackus",
             "text": "o1o\nG, oc\nT: Venomspout Brackus deals 5 damage to target attacking or blocking creature with flying.\nMorph o3o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9968,7 +9968,7 @@
         },
         {
             "id": "3e29868d-9ca1-5129-9969-0bbde2df3cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1abae21-ed8f-4e21-b227-f721b840c11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1abae21-ed8f-4e21-b227-f721b840c11f.jpg?1",
             "name": "Vitality Charm",
             "text": "Choose one Put a 1/1 green Insect creature token into play; or target creature gets +1/+1 and gains trample until end of turn; or regenerate target Beast.",
             "colours": [
@@ -10000,7 +10000,7 @@
         },
         {
             "id": "1d5af82a-8b16-5b11-860d-00c399a3b0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb4668-eebf-4b7e-ae29-75fff5963868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb4668-eebf-4b7e-ae29-75fff5963868.jpg?1",
             "name": "Voice of the Woods",
             "text": "Tap five untapped Elves you control: Put a 7/7 green Elemental creature token with trample into play.",
             "colours": [
@@ -10034,7 +10034,7 @@
         },
         {
             "id": "24c2c1ca-fdb8-5a3a-aafb-6a4d6751bfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b4448-50f0-4996-94a1-db9ce356d925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b4448-50f0-4996-94a1-db9ce356d925.jpg?1",
             "name": "Wall of Mulch",
             "text": "(Walls can't attack.)\no\nG, Sacrifice a Wall: Draw a card.",
             "colours": [
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "e30c7730-7419-59e0-845b-3335bfa61021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdfa8b3-393b-4bb6-9265-faa4ab7126d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdfa8b3-393b-4bb6-9265-faa4ab7126d2.jpg?1",
             "name": "Weird Harvest",
             "text": "Each player may search his or her library for up to X creature cards, reveal those cards, and put them into his or her hand. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -10100,7 +10100,7 @@
         },
         {
             "id": "87a1378d-5c76-5b16-90e2-696630503bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95ab7c-0e77-4293-aa48-ee54902a363f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95ab7c-0e77-4293-aa48-ee54902a363f.jpg?1",
             "name": "Wellwisher",
             "text": "oc\nT: You gain 1 life for each Elf in play.",
             "colours": [
@@ -10134,7 +10134,7 @@
         },
         {
             "id": "b952da86-cd26-5c04-8815-83ee646f595c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a34e31-97f1-40e8-9d91-a8139af7f096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a34e31-97f1-40e8-9d91-a8139af7f096.jpg?1",
             "name": "Wirewood Elf",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [
@@ -10169,7 +10169,7 @@
         },
         {
             "id": "5a187388-1980-5641-b5ca-30ba6b591445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35724e9f-efa6-47e7-ab4d-7defe38ba576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35724e9f-efa6-47e7-ab4d-7defe38ba576.jpg?1",
             "name": "Wirewood Herald",
             "text": "When Wirewood Herald is put into a graveyard from play, you may search your library for an Elf card. If you do, reveal that card and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -10203,7 +10203,7 @@
         },
         {
             "id": "3695eedb-481f-5700-8888-299422cb4dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559e844-06c9-4953-bc2c-a58e4170fe47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559e844-06c9-4953-bc2c-a58e4170fe47.jpg?1",
             "name": "Wirewood Pride",
             "text": "Target creature gets +X/+X until end of turn, where X is the number of Elves in play.",
             "colours": [
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "4cf6e561-76f4-5689-87a7-ce2657397cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99982622-98bc-45ae-8642-41cd543f32a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99982622-98bc-45ae-8642-41cd543f32a8.jpg?1",
             "name": "Wirewood Savage",
             "text": "Whenever a Beast comes into play, you may draw a card.",
             "colours": [
@@ -10269,7 +10269,7 @@
         },
         {
             "id": "f014aecb-b501-5e7b-8e48-4bea9f4aeb8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb9565f-5b09-4127-b169-3146079dab84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb9565f-5b09-4127-b169-3146079dab84.jpg?1",
             "name": "Words of Wilding",
             "text": "o1: The next time you would draw a card this turn, put a 2/2 green Bear creature token into play instead.",
             "colours": [
@@ -10301,7 +10301,7 @@
         },
         {
             "id": "c531e709-b300-5fe4-8ac1-2b343a5fd3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f379966-6a0a-434c-8682-1cf528a9a4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f379966-6a0a-434c-8682-1cf528a9a4a1.jpg?1",
             "name": "Cryptic Gateway",
             "text": "Tap two untapped creatures you control: You may put a creature card from your hand into play that shares a creature type with each creature tapped this way.",
             "colours": [],
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "7da23043-7120-5fa5-bf44-147fa24b19b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abde0d7-266b-41bd-ade1-c4d93507eb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abde0d7-266b-41bd-ade1-c4d93507eb16.jpg?1",
             "name": "Doom Cannon",
             "text": "As Doom Cannon comes into play, choose a creature type.\no3, oc\nT, Sacrifice a creature of the chosen type: Doom Cannon deals 3 damage to target creature or player.",
             "colours": [],
@@ -10357,7 +10357,7 @@
         },
         {
             "id": "0ef73265-2e2b-565c-b736-b9d1e65c7af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89610e9-f1d3-4332-901a-2598bf01d61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89610e9-f1d3-4332-901a-2598bf01d61d.jpg?1",
             "name": "Dream Chisel",
             "text": "Face-down creature spells you play cost o1 less to play.",
             "colours": [],
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "79cac9bb-9660-56ac-8e66-26fb012e1082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bb314f-237a-43fc-95c8-b26188dc4476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bb314f-237a-43fc-95c8-b26188dc4476.jpg?1",
             "name": "Riptide Replicator",
             "text": "As Riptide Replicator comes into play, choose a color and a creature type.\nRiptide Replicator comes into play with X charge counters on it.\no4, oc\nT: Put an X/X creature token of the chosen color and type into play, where X is the number of charge counters on Riptide Replicator.",
             "colours": [],
@@ -10413,7 +10413,7 @@
         },
         {
             "id": "ade07f4f-1bba-5ef6-9b1c-972563448569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae596e8c-04f5-48b0-b5e2-683c74912e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae596e8c-04f5-48b0-b5e2-683c74912e85.jpg?1",
             "name": "Slate of Ancestry",
             "text": "o4, oc\nT, Discard your hand: Draw a card for each creature you control.",
             "colours": [],
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "2898ad79-f7ed-5187-a2eb-040c12b5b73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e208be1-8b24-4048-90b2-6389f08043d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e208be1-8b24-4048-90b2-6389f08043d1.jpg?1",
             "name": "Tribal Golem",
             "text": "Tribal Golem has trample as long as you control a Beast, haste as long as you control a Goblin, first strike as long as you control a Soldier, flying as long as you control a Wizard, and \"o\nB: Regenerate Tribal Golem\" as long as you control a Zombie.",
             "colours": [],
@@ -10474,7 +10474,7 @@
         },
         {
             "id": "022b44a7-227e-5e5f-affa-c39582562f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45be3811-a223-4c45-9b24-0317f2d53c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45be3811-a223-4c45-9b24-0317f2d53c60.jpg?1",
             "name": "Barren Moor",
             "text": "Barren Moor comes into play tapped.\noc\nT: Add o\nB to your mana pool.\nCycling o\nB (o\nB, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10504,7 +10504,7 @@
         },
         {
             "id": "9f120b75-5834-57a7-80e2-dfff9bacc0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c72226-6f52-4322-8b14-18737293dfa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c72226-6f52-4322-8b14-18737293dfa0.jpg?1",
             "name": "Bloodstained Mire",
             "text": "oc\nT, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a swamp or mountain card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10532,7 +10532,7 @@
         },
         {
             "id": "72d26b04-31d4-52f1-b2ce-67568dd29284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6363ea-3814-4014-ad9e-1066c72d907c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6363ea-3814-4014-ad9e-1066c72d907c.jpg?1",
             "name": "Contested Cliffs",
             "text": "oc\nT: Add o1 to your mana pool.\no\nRo\nG, oc\nT: Choose target Beast you control and target creature an opponent controls. Each creature deals damage equal to its power to the other.",
             "colours": [],
@@ -10563,7 +10563,7 @@
         },
         {
             "id": "888d88b5-0e3c-57d0-94f3-405c340bb659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5869f08-fac8-44b6-8142-7d7ecccab414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5869f08-fac8-44b6-8142-7d7ecccab414.jpg?1",
             "name": "Daru Encampment",
             "text": "oc\nT: Add o1 to your mana pool.\no\nW, oc\nT: Target Soldier gets +1/+1 until end of turn.",
             "colours": [],
@@ -10593,7 +10593,7 @@
         },
         {
             "id": "78851d72-de34-5893-a18a-859150b8c636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e3d844-d3b4-41d8-921d-c1cb3af343f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e3d844-d3b4-41d8-921d-c1cb3af343f8.jpg?1",
             "name": "Flooded Strand",
             "text": "oc\nT, Pay 1 life, Sacrifice Flooded Strand: Search your library for a plains or island card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "a19f2077-61f8-5962-bbd1-55dd70624f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5202668-a32c-4473-b272-e86264992576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5202668-a32c-4473-b272-e86264992576.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave comes into play tapped.\noc\nT: Add o\nR to your mana pool.\nCycling o\nR (o\nR, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "9d2565de-7c68-5dbc-8f0c-cf67fba9619a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5064cd2-8762-4e08-8c3c-be6f31e9ab61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5064cd2-8762-4e08-8c3c-be6f31e9ab61.jpg?1",
             "name": "Goblin Burrows",
             "text": "oc\nT: Add o1 to your mana pool.\no1o\nR, oc\nT: Target Goblin gets +2/+0 until end of turn.",
             "colours": [],
@@ -10681,7 +10681,7 @@
         },
         {
             "id": "7f1cc940-cb96-531d-993f-e9b75c024990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dc8061-a855-4a81-9eb7-350b355a9b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dc8061-a855-4a81-9eb7-350b355a9b3f.jpg?1",
             "name": "Grand Coliseum",
             "text": "Grand Coliseum comes into play tapped.\noc\nT: Add o1 to your mana pool.\noc\nT: Add one mana of any color to your mana pool. Grand Coliseum deals 1 damage to you.",
             "colours": [],
@@ -10709,7 +10709,7 @@
         },
         {
             "id": "06ab039c-0d3a-5852-b6b5-e31e65d87d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddab06-aff7-4c40-bcaa-10cbfe899dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddab06-aff7-4c40-bcaa-10cbfe899dd9.jpg?1",
             "name": "Lonely Sandbar",
             "text": "Lonely Sandbar comes into play tapped.\noc\nT: Add o\nU to your mana pool.\nCycling o\nU (o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10739,7 +10739,7 @@
         },
         {
             "id": "204f6277-6785-58e8-a35c-28ed4963ddb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7585c8-9e21-4eef-afc1-2852de23db2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7585c8-9e21-4eef-afc1-2852de23db2f.jpg?1",
             "name": "Polluted Delta",
             "text": "oc\nT, Pay 1 life, Sacrifice Polluted Delta: Search your library for an island or swamp card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "fca0ba14-93b6-5961-824c-922dc94ef4c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d993c973-2eb6-423c-8ee9-10749a751524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d993c973-2eb6-423c-8ee9-10749a751524.jpg?1",
             "name": "Riptide Laboratory",
             "text": "oc\nT: Add o1 to your mana pool.\no1o\nU, oc\nT: Return target Wizard you control to its owner's hand.",
             "colours": [],
@@ -10797,7 +10797,7 @@
         },
         {
             "id": "8c1a21f0-cac3-5bc9-bf78-efcb6459aded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c940a6b-3c5e-4ce2-92b6-63e2cb575c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c940a6b-3c5e-4ce2-92b6-63e2cb575c15.jpg?1",
             "name": "Seaside Haven",
             "text": "oc\nT: Add o1 to your mana pool.\no\nWo\nU, oc\nT, Sacrifice a Bird: Draw a card.",
             "colours": [],
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "a73a2671-b8be-53eb-95a1-0aa4320588a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea454280-f7f4-4315-bb46-b56050c02c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea454280-f7f4-4315-bb46-b56050c02c97.jpg?1",
             "name": "Secluded Steppe",
             "text": "Secluded Steppe comes into play tapped.\noc\nT: Add o\nW to your mana pool.\nCycling o\nW (o\nW, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10858,7 +10858,7 @@
         },
         {
             "id": "a1a54582-e511-5a81-bf0d-1bd358fab7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace5e601-2583-4d9c-8bdf-aa33666c717c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace5e601-2583-4d9c-8bdf-aa33666c717c.jpg?1",
             "name": "Starlit Sanctum",
             "text": "oc\nT: Add o1 to your mana pool.\no\nW, oc\nT, Sacrifice a Cleric: You gain life equal to that Cleric's toughness.\no\nB, oc\nT, Sacrifice a Cleric: Target player loses life equal to that Cleric's power.",
             "colours": [],
@@ -10889,7 +10889,7 @@
         },
         {
             "id": "7ec55299-c645-5a0a-9908-025e0baa7c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7cef-8aeb-4c84-88e9-6df17768e292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7cef-8aeb-4c84-88e9-6df17768e292.jpg?1",
             "name": "Tranquil Thicket",
             "text": "Tranquil Thicket comes into play tapped.\noc\nT: Add o\nG to your mana pool.\nCycling o\nG (o\nG, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10919,7 +10919,7 @@
         },
         {
             "id": "cdc4e0ff-325c-5026-bae2-dfd88306e825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f464a9-586c-4cf3-894b-b407c9f4dcb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f464a9-586c-4cf3-894b-b407c9f4dcb8.jpg?1",
             "name": "Unholy Grotto",
             "text": "oc\nT: Add o1 to your mana pool.\no\nB, oc\nT: Put target Zombie card from your graveyard on top of your library.",
             "colours": [],
@@ -10949,7 +10949,7 @@
         },
         {
             "id": "057ab958-8e75-5640-89b0-48fdd53e2240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c5941-9c8a-4a40-9efb-a84f05c58e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c5941-9c8a-4a40-9efb-a84f05c58e53.jpg?1",
             "name": "Windswept Heath",
             "text": "oc\nT, Pay 1 life, Sacrifice Windswept Heath: Search your library for a forest or plains card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10977,7 +10977,7 @@
         },
         {
             "id": "f735c763-eb7a-5823-91fd-5e0d198ae68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d251490-41bb-4ad3-bfd0-a5e66ee42598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d251490-41bb-4ad3-bfd0-a5e66ee42598.jpg?1",
             "name": "Wirewood Lodge",
             "text": "oc\nT: Add o1 to your mana pool.\no\nG, oc\nT: Untap target Elf.",
             "colours": [],
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "1e2d949e-4371-5e11-a189-bac74f753780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad38f7-9dfa-4f1b-9fac-41ab2b253f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad38f7-9dfa-4f1b-9fac-41ab2b253f53.jpg?1",
             "name": "Wooded Foothills",
             "text": "oc\nT, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a mountain or forest card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "afa23e8b-4cfa-599e-80b3-9865c2df3a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf7d68a-dbd0-45f3-acbb-59ee38e6057e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf7d68a-dbd0-45f3-acbb-59ee38e6057e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11073,7 +11073,7 @@
         },
         {
             "id": "1a7a501c-3882-5f4a-b021-a70b593f0f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52ed647-bd30-40a5-b648-0b98d1a3fd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52ed647-bd30-40a5-b648-0b98d1a3fd4a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11111,7 +11111,7 @@
         },
         {
             "id": "18e3eb70-964c-56c7-b6b8-12c9816ab701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854a255e-fd89-4c5d-b97b-416a9ac70960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854a255e-fd89-4c5d-b97b-416a9ac70960.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11149,7 +11149,7 @@
         },
         {
             "id": "93bd04bd-75b9-5841-9f97-e49fdaddb697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7babbe-f8c1-4e7c-8de2-2224dd357de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7babbe-f8c1-4e7c-8de2-2224dd357de4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11187,7 +11187,7 @@
         },
         {
             "id": "e7aeaeaa-59ab-588c-b2ff-63ddd86e5273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e062ec-df51-40c0-ad8a-2ee1cb8f8f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e062ec-df51-40c0-ad8a-2ee1cb8f8f17.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11225,7 +11225,7 @@
         },
         {
             "id": "46549032-d4c1-58fe-ac05-d54722cf1715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8c0e52-8482-4c33-bc5d-26eaad922e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8c0e52-8482-4c33-bc5d-26eaad922e72.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11263,7 +11263,7 @@
         },
         {
             "id": "9a755292-6fe4-5a68-b28b-a379be207eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dac3bfe-884b-4875-bc7d-df564eb014cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dac3bfe-884b-4875-bc7d-df564eb014cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11301,7 +11301,7 @@
         },
         {
             "id": "009dbba5-ccab-5e07-aae2-5fc32185b21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a09b8-46d2-4ef6-b7cc-9e510d1ea0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a09b8-46d2-4ef6-b7cc-9e510d1ea0b8.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11339,7 +11339,7 @@
         },
         {
             "id": "3aa44df6-87f7-5bed-b01d-93a73ad26b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0356ae45-e5ca-46b9-8ebc-42bf4776e89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0356ae45-e5ca-46b9-8ebc-42bf4776e89c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11377,7 +11377,7 @@
         },
         {
             "id": "2bf47f3c-5a4b-5ef1-8531-5a8d997fae51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6285f63-a5d8-4b8b-a6dd-51ce7968fbaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6285f63-a5d8-4b8b-a6dd-51ce7968fbaf.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11415,7 +11415,7 @@
         },
         {
             "id": "5a2f8f98-c87f-52aa-b617-551be38b4567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa97b25-1ea0-4351-ab9f-f06c8bb4d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa97b25-1ea0-4351-ab9f-f06c8bb4d044.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11453,7 +11453,7 @@
         },
         {
             "id": "5626d132-7176-58eb-9f9b-075e101a4e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e10b125-eaa6-4630-a6fe-6b1805921f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e10b125-eaa6-4630-a6fe-6b1805921f07.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11491,7 +11491,7 @@
         },
         {
             "id": "43b1455f-0f45-5de9-80f6-746b893b53a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f9bdca-0d54-46c7-b803-9083dfc9ee24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f9bdca-0d54-46c7-b803-9083dfc9ee24.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11529,7 +11529,7 @@
         },
         {
             "id": "f40895cd-ca24-5dd9-af7f-1c34d091cd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d39f35-c7b2-43b2-aee3-4ff2cd3e37e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d39f35-c7b2-43b2-aee3-4ff2cd3e37e7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11567,7 +11567,7 @@
         },
         {
             "id": "5f3e7e6a-0848-5715-9694-62681f450744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8aade2d-5cf5-44f6-9095-aa3756b1c1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8aade2d-5cf5-44f6-9095-aa3756b1c1dd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11605,7 +11605,7 @@
         },
         {
             "id": "c601a84e-2a40-551a-ad9d-efe94dc04708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd194fb1-0d3a-4eff-a446-240d18dad43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd194fb1-0d3a-4eff-a446-240d18dad43c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11643,7 +11643,7 @@
         },
         {
             "id": "6de6537b-81c7-56e8-9496-8ad2b1831781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b361b42d-401f-440a-bae9-35338b5dde0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b361b42d-401f-440a-bae9-35338b5dde0e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11681,7 +11681,7 @@
         },
         {
             "id": "ec5b9c11-ce3f-5c66-8f7b-3a72c09549d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8edfee-7837-450a-bcf3-a7bb25670056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8edfee-7837-450a-bcf3-a7bb25670056.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11719,7 +11719,7 @@
         },
         {
             "id": "5cd274e0-746b-5aa6-af83-248db158a903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0af992-80e0-4ac6-a828-5eaac47eaff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0af992-80e0-4ac6-a828-5eaac47eaff6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "49013084-8d20-5a77-bcc7-af4cd1dc052c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835a4eed-a308-428d-ac85-e385b5d47d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835a4eed-a308-428d-ac85-e385b5d47d8e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/ORI.json
+++ b/Assets/Resources/Sets/ORI.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d4066ede-a0fc-5f22-94d8-d1daec6723b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg?1",
             "name": "Akroan Jailer",
             "text": "{2}{W}, {T}: Tap target creature.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "8db77bc6-b969-5fbe-85e0-74b8855066c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg?1",
             "name": "Ampryn Tactician",
             "text": "When Ampryn Tactician enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "82345c0b-3dce-5a4d-8e82-5128303c367d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg?1",
             "name": "Anointer of Champions",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "c0da2f7b-dd82-562d-b3f5-0da81cf86c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af50bf1-c51e-4592-86bf-4197ec85a45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af50bf1-c51e-4592-86bf-4197ec85a45d.jpg?1",
             "name": "Archangel of Tithes",
             "text": "Flying\nAs long as Archangel of Tithes is untapped, creatures can't attack you or a planeswalker you control unless their controller pays {1} for each of those creatures.\nAs long as Archangel of Tithes is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "a19b5d8d-e7cb-52ac-8ff5-b59beb2fafa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598ebb91-57d6-4800-8931-4d0016e9fec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598ebb91-57d6-4800-8931-4d0016e9fec1.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "52446988-15f5-57a4-b62a-6d5c39bab309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg?1",
             "name": "Aven Battle Priest",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aven Battle Priest enters the battlefield, you gain 3 life.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "8147c810-3f73-508c-ba59-511e58648029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150dd602-5f61-4f1e-a422-e64c079de141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150dd602-5f61-4f1e-a422-e64c079de141.jpg?1",
             "name": "Blessed Spirits",
             "text": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on Blessed Spirits.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "d6431884-e599-5e96-96d1-b4044c764c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bb3b06-b33b-4897-882e-75b75790ea02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bb3b06-b33b-4897-882e-75b75790ea02.jpg?1",
             "name": "Celestial Flare",
             "text": "Target player sacrifices an attacking or blocking creature.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "3a1f2a0a-f146-5815-97d9-4d86a7b6ecb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86bd259-bc2f-402c-9e7a-030f9a3781e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86bd259-bc2f-402c-9e7a-030f9a3781e2.jpg?1",
             "name": "Charging Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Charging Griffin attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "bf729219-262a-5e2a-9128-aa859241a63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcea783-e9f0-4d44-ac74-5aee9a07aa69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcea783-e9f0-4d44-ac74-5aee9a07aa69.jpg?1",
             "name": "Cleric of the Forward Order",
             "text": "When Cleric of the Forward Order enters the battlefield, you gain 2 life for each creature you control named Cleric of the Forward Order.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "d85a2e44-dd4f-5a1d-a199-9a440bcbc63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a1b68-2890-4702-a90e-bad8d309c40d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a1b68-2890-4702-a90e-bad8d309c40d.jpg?1",
             "name": "Consul's Lieutenant",
             "text": "First strike\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhenever Consul's Lieutenant attacks, if it's renowned, other attacking creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "03e67300-5fff-52c0-afca-414a7f5b1d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg?1",
             "name": "Enlightened Ascetic",
             "text": "When Enlightened Ascetic enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "f46ef550-f5b5-56cc-9cfa-79832439e8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059bd3e-451c-445a-b299-544c82fc0eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059bd3e-451c-445a-b299-544c82fc0eb9.jpg?1",
             "name": "Enshrouding Mist",
             "text": "Target creature gets +1/+1 until end of turn. Prevent all damage that would be dealt to it this turn. If it's renowned, untap it.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "3caf9ad0-e24f-587a-93fa-221dfd1f14a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30142729-de9a-4a0b-b060-8f68e1ef234d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30142729-de9a-4a0b-b060-8f68e1ef234d.jpg?1",
             "name": "Gideon's Phalanx",
             "text": "Put four 2/2 white Knight creature tokens with vigilance onto the battlefield.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "cbb7d6f8-80c4-5c22-b1d5-2a03d2c02121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8740d2-7fcf-4bdf-afea-0c28c025370c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8740d2-7fcf-4bdf-afea-0c28c025370c.jpg?1",
             "name": "Grasp of the Hieromancer",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature attacks, tap target creature defending player controls.\"",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "e7f84d27-e3c4-51aa-be69-d3e069cb8f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fd0c0f-4a6a-47cf-9f50-df0bbf19aae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fd0c0f-4a6a-47cf-9f50-df0bbf19aae4.jpg?1",
             "name": "Hallowed Moonlight",
             "text": "Until end of turn, if a creature would enter the battlefield and it wasn't cast, exile it instead.\nDraw a card.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "38640ca7-d113-5363-8810-92451a23e090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26559c-0ac5-42a7-b6ac-b39938c31026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26559c-0ac5-42a7-b6ac-b39938c31026.jpg?1",
             "name": "Healing Hands",
             "text": "Target player gains 4 life.\nDraw a card.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "fb29b33f-ee5c-5f12-9c30-6529d05d2dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg?1",
             "name": "Heavy Infantry",
             "text": "When Heavy Infantry enters the battlefield, tap target creature an opponent controls.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "6f67ad7c-b19d-5169-9302-d9de89e5e0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c21a35-4b70-4de4-93ff-c0ccabdc39e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c21a35-4b70-4de4-93ff-c0ccabdc39e0.jpg?1",
             "name": "Hixus, Prison Warden",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever a creature deals combat damage to you, if Hixus, Prison Warden entered the battlefield this turn, exile that creature until Hixus leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "4866b8c8-0765-593f-a968-4b74603830d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg?1",
             "name": "Knight of the Pilgrim's Road",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "f7b53ad2-0328-52b6-9d0e-56409f24f63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a601d-de5c-412c-87a2-69500c08809a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a601d-de5c-412c-87a2-69500c08809a.jpg?1",
             "name": "Knight of the White Orchid",
             "text": "First strike\nWhen Knight of the White Orchid enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "5128c866-cf5c-5d4d-ae6b-c82c82eb7804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20930fab-eb4f-4179-94a7-84dc7055710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20930fab-eb4f-4179-94a7-84dc7055710a.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, put a 2/2 white Knight creature token with vigilance onto the battlefield. (Attacking doesn't cause it to tap.)\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -756,7 +756,7 @@
         },
         {
             "id": "afb65926-e03d-53dc-ba00-2370bfe260a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg?1",
             "name": "Kytheon, Hero of Akros // Gideon, Battle-Forged",
             "text": "At end of combat, if Kytheon, Hero of Akros and at least two other creatures attacked this combat, exile Kytheon, then return him to the battlefield transformed under his owner's control.{2}{W}: Kytheon gains indestructible until end of turn.",
             "colours": [
@@ -793,7 +793,7 @@
         },
         {
             "id": "e0152afe-6828-586e-a1cc-a0b75079708c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg?1",
             "name": "Kytheon, Hero of Akros // Gideon, Battle-Forged",
             "text": "+2: Up to one target creature an opponent controls attacks Gideon, Battle-Forged during its controller's next turn if able.+1: Until your next turn, target creature gains indestructible. Untap that creature.0: Until end of turn, Gideon, Battle-Forged becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -829,7 +829,7 @@
         },
         {
             "id": "e9fba55e-0ec8-5e8c-ae1c-3270295bbf41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg?1",
             "name": "Kytheon's Irregulars",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.){W}{W}: Tap target creature.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "859ca126-274b-50b7-8838-bd103a9a45ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0521669-206e-4909-be6f-a74603203a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0521669-206e-4909-be6f-a74603203a70.jpg?1",
             "name": "Kytheon's Tactics",
             "text": "Creatures you control get +2/+1 until end of turn.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, those creatures also gain vigilance until end of turn. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "4da36866-b693-57cd-b0d7-6ae7dd1e62b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dad608-5f8d-49a8-a1f1-c80aae207945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dad608-5f8d-49a8-a1f1-c80aae207945.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -928,7 +928,7 @@
         },
         {
             "id": "78bd5118-032e-5585-976c-4ce21750b284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8d6f7-ed22-4e01-9aeb-c6bc0065c89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8d6f7-ed22-4e01-9aeb-c6bc0065c89c.jpg?1",
             "name": "Murder Investigation",
             "text": "Enchant creature you control\nWhen enchanted creature dies, put X 1/1 white Soldier creature tokens onto the battlefield, where X is its power.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "ec315a32-8848-54b9-b71d-4411abda8558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5c0526-ac1f-40ca-a597-bf004f2e2377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5c0526-ac1f-40ca-a597-bf004f2e2377.jpg?1",
             "name": "Patron of the Valiant",
             "text": "Flying\nWhen Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "969f5f14-96a3-5b0f-9856-c7ef4b4ad2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a4b00c-5bd5-4931-be05-121f09a3fae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a4b00c-5bd5-4931-be05-121f09a3fae4.jpg?1",
             "name": "Relic Seeker",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhen Relic Seeker becomes renowned, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "ed2b5923-b6f4-55fc-8dd1-145db14978bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7b01ce-2729-4b70-ae0a-b9a1007be78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7b01ce-2729-4b70-ae0a-b9a1007be78f.jpg?1",
             "name": "Sentinel of the Eternal Watch",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nAt the beginning of combat on each opponent's turn, tap target creature that player controls.",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "362e7b63-b083-57ff-aebb-ca9debd2458c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386f050c-0233-490f-94ab-92a7b5dc65cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386f050c-0233-490f-94ab-92a7b5dc65cf.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, put a 4/4 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "ffe1bd4c-4008-5d04-b3c2-2f71cb0f8c60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg?1",
             "name": "Stalwart Aven",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1133,7 +1133,7 @@
         },
         {
             "id": "31260b56-aa6d-5715-84d0-6a1e5b095f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861dc1a5-4e84-47bc-83a2-f289804086d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861dc1a5-4e84-47bc-83a2-f289804086d8.jpg?1",
             "name": "Starfield of Nyx",
             "text": "At the beginning of your upkeep, you may return target enchantment card from your graveyard to the battlefield.\nAs long as you control five or more enchantments, each other non-Aura enchantment you control is a creature in addition to its other types and has base power and base toughness each equal to its converted mana cost.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "2da90fb6-e808-5c2b-b780-28f9835a5944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34c717b-224b-4289-826d-f5b1f7c3dbfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34c717b-224b-4289-826d-f5b1f7c3dbfb.jpg?1",
             "name": "Suppression Bonds",
             "text": "Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "edeb9610-6438-5ff7-b1f3-3944b5b68c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904cb2f5-eb62-4416-8236-d2fbeadf1dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904cb2f5-eb62-4416-8236-d2fbeadf1dc4.jpg?1",
             "name": "Swift Reckoning",
             "text": "Spell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may cast Swift Reckoning as though it had flash. (You may cast it any time you could cast an instant.)\nDestroy target tapped creature.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "830afd2b-e08f-5274-a516-567757271c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg?1",
             "name": "Topan Freeblade",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "02f40065-9163-51a5-8026-a83475cc580a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589346d3-b32b-40f2-8513-741ceb88bf7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589346d3-b32b-40f2-8513-741ceb88bf7b.jpg?1",
             "name": "Totem-Guide Hartebeest",
             "text": "When Totem-Guide Hartebeest enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "fa751be7-80bd-57ad-b38d-2f60b6981cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16acf619-0f45-4985-a8ec-074a4ec33fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16acf619-0f45-4985-a8ec-074a4ec33fa7.jpg?1",
             "name": "Tragic Arrogance",
             "text": "For each player, you choose from among the permanents that player controls an artifact, a creature, an enchantment, and a planeswalker. Then each player sacrifices all other nonland permanents he or she controls.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "dcfa530a-722a-5304-af41-0596a4403269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fa0acd-84c3-492e-adf7-e7438db47e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fa0acd-84c3-492e-adf7-e7438db47e0a.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "0c96b7da-967a-581e-8ed3-5833a338a93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg?1",
             "name": "Vryn Wingmare",
             "text": "Flying\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "d707e356-2db1-58bd-95f5-eab5a86dc327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg?1",
             "name": "War Oracle",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "f0a63ac4-cd33-5aa6-9b89-6f2efba41b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431069f2-3eba-42f3-b42d-05a7d066b665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431069f2-3eba-42f3-b42d-05a7d066b665.jpg?1",
             "name": "Yoked Ox",
             "text": "",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "4dee4663-2ccd-5e6c-8d09-74b726528901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4200b101-19d3-4442-bddd-3eb77d5f99a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4200b101-19d3-4442-bddd-3eb77d5f99a9.jpg?1",
             "name": "Alhammarret, High Arbiter",
             "text": "Flying\nAs Alhammarret, High Arbiter enters the battlefield, each opponent reveals his or her hand. You choose the name of a nonland card revealed this way.\nYour opponents can't cast spells with the chosen name (as long as this creature is on the battlefield).",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "775f431b-c477-56c3-9b01-43ffc476cbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15058f91-d266-4804-96af-fc050b6c8436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15058f91-d266-4804-96af-fc050b6c8436.jpg?1",
             "name": "Anchor to the Aether",
             "text": "Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "19dff3aa-7a25-5153-8459-8739b6a106f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c847774-c76d-44bd-acf6-bc1bc865ac77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c847774-c76d-44bd-acf6-bc1bc865ac77.jpg?1",
             "name": "Artificer's Epiphany",
             "text": "Draw two cards. If you control no artifacts, discard a card.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "dccca95d-a8f3-53d1-917d-16ac57c44520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae6c87f-003b-44b7-96fd-ab8fca9af6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae6c87f-003b-44b7-96fd-ab8fca9af6f1.jpg?1",
             "name": "Aspiring Aeronaut",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aspiring Aeronaut enters the battlefield, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield.",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "20d17316-2b25-5c2c-98f0-c36c878aebc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7a29e0-02a8-4d04-8b80-831a7bed58f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7a29e0-02a8-4d04-8b80-831a7bed58f7.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "696723b9-a62d-5020-a08a-c774095472b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c42ab35-6050-42b2-9c3c-3252f2e69442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c42ab35-6050-42b2-9c3c-3252f2e69442.jpg?1",
             "name": "Calculated Dismissal",
             "text": "Counter target spell unless its controller pays {3}.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1666,7 +1666,7 @@
         },
         {
             "id": "b49c6bea-8706-5968-a1fd-c1c2b42fc978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665ee42f-8d76-4f8b-9dd3-7455a90f0da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665ee42f-8d76-4f8b-9dd3-7455a90f0da7.jpg?1",
             "name": "Clash of Wills",
             "text": "Counter target spell unless its controller pays {X}.",
             "colours": [
@@ -1698,7 +1698,7 @@
         },
         {
             "id": "8a939c7a-f99b-5589-b2b2-002436540e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d249de3-4a84-4e98-9557-06e23e78de15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d249de3-4a84-4e98-9557-06e23e78de15.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "8433e8d8-b7b9-568e-902e-e5fe34bb068f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a11287a-8002-4679-9f69-a7360e7f4d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a11287a-8002-4679-9f69-a7360e7f4d3c.jpg?1",
             "name": "Day's Undoing",
             "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities on the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -1764,7 +1764,7 @@
         },
         {
             "id": "1a09fb8c-c370-5890-810f-609c38f76ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007b526c-5387-4ed4-a320-b826d507e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007b526c-5387-4ed4-a320-b826d507e014.jpg?1",
             "name": "Deep-Sea Terror",
             "text": "Deep-Sea Terror can't attack unless there are seven or more cards in your graveyard.",
             "colours": [
@@ -1798,7 +1798,7 @@
         },
         {
             "id": "1029dc8c-1d8f-50ed-b355-b685b8fb718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d344f86-a02d-4de3-82c1-2586dd9ddbfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d344f86-a02d-4de3-82c1-2586dd9ddbfe.jpg?1",
             "name": "Disciple of the Ring",
             "text": "{1}, Exile an instant or sorcery card from your graveyard: Choose one \u2014\u2022 Counter target noncreature spell unless its controller pays {2}.\u2022 Disciple of the Ring gets +1/+1 until end of turn.\u2022 Tap target creature.\u2022 Untap target creature.",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "b6ae0b93-b1a9-5029-93cc-f6b2e6cee1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f790b0b5-ed67-40f8-b23b-10cf0a71f285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f790b0b5-ed67-40f8-b23b-10cf0a71f285.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "e29fbc87-b6ae-5ef2-8527-0caec7a31fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6fef1f-6cc9-4e24-a1be-fc313774f28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6fef1f-6cc9-4e24-a1be-fc313774f28d.jpg?1",
             "name": "Displacement Wave",
             "text": "Return all nonland permanents with converted mana cost X or less to their owners' hands.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "68f7c59a-d0bd-5e8a-a3fb-09252202d818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1434a-4832-4008-a091-e0703dedd0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1434a-4832-4008-a091-e0703dedd0a2.jpg?1",
             "name": "Dreadwaters",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of lands you control.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "e870df24-a875-51b0-b307-35d87917f135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c487f1a-a51d-449c-827d-c7b9381acb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c487f1a-a51d-449c-827d-c7b9381acb34.jpg?1",
             "name": "Faerie Miscreant",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Faerie Miscreant enters the battlefield, if you control another creature named Faerie Miscreant, draw a card.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "0576b965-72c0-500a-bd54-ee08d200bc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca53de-cffb-4740-b318-a4ebfb3a31af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca53de-cffb-4740-b318-a4ebfb3a31af.jpg?1",
             "name": "Harbinger of the Tides",
             "text": "You may cast Harbinger of the Tides as though it had flash if you pay {2} more to cast it. (You may cast it any time you could cast an instant.)\nWhen Harbinger of the Tides enters the battlefield, you may return target tapped creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "406bbed4-aafa-5cbe-b2be-f505666d38de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaaa583-bdd3-448a-921e-527df5f7f548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaaa583-bdd3-448a-921e-527df5f7f548.jpg?1",
             "name": "Hydrolash",
             "text": "Attacking creatures get -2/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "d3c62c41-549f-50f1-bc7c-7613df49367c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg?1",
             "name": "Jace, Vryn's Prodigy // Jace, Telepath Unbound",
             "text": "{T}: Draw a card, then discard a card. If there are five or more cards in your graveyard, exile Jace, Vryn's Prodigy, then return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "683653a5-c730-5764-ab7e-8d9ee1dbed51",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg?1",
             "name": "Jace, Vryn's Prodigy // Jace, Telepath Unbound",
             "text": "+1: Up to one target creature gets -2/-0 until your next turn.\u22123: You may cast target instant or sorcery card from your graveyard this turn. If that card would be put into a graveyard this turn, exile it instead.\u22129: You get an emblem with \"Whenever you cast a spell, target opponent puts the top five cards of his or her library into his or her graveyard.\"",
             "colours": [
@@ -2104,7 +2104,7 @@
         },
         {
             "id": "a20dcbbe-28bc-5983-bb71-10b7407b39bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3fe038-a982-4cbf-a158-c45fdc3d727e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3fe038-a982-4cbf-a158-c45fdc3d727e.jpg?1",
             "name": "Jace's Sanctum",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "cfcc9aa1-5923-5176-be95-919954812d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg?1",
             "name": "Jhessian Thief",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jhessian Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "44aa02eb-c5ae-5a2b-9a1e-c72bde2feafc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008ff1b-7fb0-4570-b23e-9fda14b97640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008ff1b-7fb0-4570-b23e-9fda14b97640.jpg?1",
             "name": "Maritime Guard",
             "text": "",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "3457416f-7f85-5be5-ab70-36196d48f0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d568d-a2d6-449b-85c2-a92755efe4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d568d-a2d6-449b-85c2-a92755efe4c3.jpg?1",
             "name": "Mizzium Meddler",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Mizzium Meddler enters the battlefield, you may change a target of target spell or ability to Mizzium Meddler.",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "0ce14e2a-5d9c-59be-a9e1-604d1c44ceb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e848b632-e08a-4341-a99c-d8207f9ffe48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e848b632-e08a-4341-a99c-d8207f9ffe48.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "74b0066f-59a0-505c-85c0-c2763beee3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg?1",
             "name": "Nivix Barrier",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nDefender (This creature can't attack.)\nWhen Nivix Barrier enters the battlefield, target attacking creature gets -4/-0 until end of turn.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "c0d269c7-b9de-5c40-ae5f-7f7951d6492e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a105f8-0c01-4c09-a3bf-8c912b6dc741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a105f8-0c01-4c09-a3bf-8c912b6dc741.jpg?1",
             "name": "Psychic Rebuttal",
             "text": "Counter target instant or sorcery spell that targets you.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may copy the spell countered this way. You may choose new targets for the copy.",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "14eb1b5b-6b72-54ca-aabb-64bdd4c02f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg?1",
             "name": "Ringwarden Owl",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "67ad89d2-39dd-5bfe-a97b-8427bf2bda92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a1b7fc-6b0e-4228-b320-b1274e5ed14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a1b7fc-6b0e-4228-b320-b1274e5ed14b.jpg?1",
             "name": "Scrapskin Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)Scrapskin Drake can block only creatures with flying.",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "9cd2ed38-0232-5a4a-8e32-987079323eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f65037-d382-4a95-8cde-15f5d9f41297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f65037-d382-4a95-8cde-15f5d9f41297.jpg?1",
             "name": "Screeching Skaab",
             "text": "When Screeching Skaab enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "05823bca-9013-5808-811b-be2499548504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa34d648-da0a-4615-8dd8-d2c8b1a1a574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa34d648-da0a-4615-8dd8-d2c8b1a1a574.jpg?1",
             "name": "Send to Sleep",
             "text": "Tap up to two target creatures.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, those creatures don't untap during their controllers' next untap steps.",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "7d2bf4f6-f57a-541f-9796-f86ca3720a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg?1",
             "name": "Separatist Voidmage",
             "text": "When Separatist Voidmage enters the battlefield, you may return target creature to its owner's hand.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "f6d8ebfc-40af-53c2-91cb-2bba23913e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5849fa3-6296-4ca9-b2ac-519cf90f6b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5849fa3-6296-4ca9-b2ac-519cf90f6b62.jpg?1",
             "name": "Sigiled Starfish",
             "text": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "2b6411d4-c0f1-5221-a5d3-6836e0d49e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3682b3d3-cb3d-4c2c-a419-f08e3a370cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3682b3d3-cb3d-4c2c-a419-f08e3a370cd1.jpg?1",
             "name": "Skaab Goliath",
             "text": "As an additional cost to cast Skaab Goliath, exile two creature cards from your graveyard.\nTrample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "e77f3310-3fdc-55cc-9203-511c089b58d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg?1",
             "name": "Soulblade Djinn",
             "text": "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "0b79069b-4e12-5e7a-8b06-0dbe83880d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d90c3b0-f958-4a15-94a1-9bf1b0a9ac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d90c3b0-f958-4a15-94a1-9bf1b0a9ac2a.jpg?1",
             "name": "Sphinx's Tutelage",
             "text": "Whenever you draw a card, target opponent puts the top two cards of his or her library into his or her graveyard. If they're both nonland cards that share a color, repeat this process.{5}{U}: Draw a card, then discard a card.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "18825764-5b07-5c04-98ef-8dffda264975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947bb8f3-51f5-4fbe-9098-7e48f9fe1452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947bb8f3-51f5-4fbe-9098-7e48f9fe1452.jpg?1",
             "name": "Stratus Walk",
             "text": "Enchant creature\nWhen Stratus Walk enters the battlefield, draw a card.\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\nEnchanted creature can block only creatures with flying.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "1f14f879-0c93-5705-b44c-5a03fe7841e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da13a1-8be2-4312-a660-f3e102c552b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da13a1-8be2-4312-a660-f3e102c552b6.jpg?1",
             "name": "Talent of the Telepath",
             "text": "Target opponent reveals the top seven cards of his or her library. You may cast an instant or sorcery card from among them without paying its mana cost. Then that player puts the rest into his or her graveyard.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two revealed instant and/or sorcery cards instead of one.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "a8068e23-31c1-57be-b276-6bd82b5571b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516d86e-539a-4ba8-8d25-1a3b27b1267a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516d86e-539a-4ba8-8d25-1a3b27b1267a.jpg?1",
             "name": "Thopter Spy Network",
             "text": "At the beginning of your upkeep, if you control an artifact, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield.\nWhenever one or more artifact creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "c7ea63b0-0b7c-5c46-af23-82b88dcc72d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62815ee-d1d6-4c96-8ab0-4c0a8250ae86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62815ee-d1d6-4c96-8ab0-4c0a8250ae86.jpg?1",
             "name": "Tower Geist",
             "text": "Flying\nWhen Tower Geist enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2777,7 +2777,7 @@
         },
         {
             "id": "3053fe6a-f3d3-57e2-ae1c-4b0afb302e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13c604f-b2a7-4370-b7e4-698d8e8647bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13c604f-b2a7-4370-b7e4-698d8e8647bb.jpg?1",
             "name": "Turn to Frog",
             "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "a184400d-772d-51ae-b1d8-4dbf8359913f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b12e87-ccd6-4c84-80b2-9ac7d099be89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b12e87-ccd6-4c84-80b2-9ac7d099be89.jpg?1",
             "name": "Watercourser",
             "text": "{U}: Watercourser gets +1/-1 until end of turn.",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "fb67d0cd-b37d-5d4f-9f6a-7b085b99ed2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feb66d2-c50f-4296-af2f-b374c57443b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feb66d2-c50f-4296-af2f-b374c57443b0.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, put two 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "d0057667-7c5d-53bb-8c5f-f6f5708cec94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2465eafc-453c-4e4f-b369-0951b8a4b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2465eafc-453c-4e4f-b369-0951b8a4b7bf.jpg?1",
             "name": "Willbreaker",
             "text": "Whenever a creature an opponent controls becomes the target of a spell or ability you control, gain control of that creature for as long as you control Willbreaker.",
             "colours": [
@@ -2914,7 +2914,7 @@
         },
         {
             "id": "1c895172-51a5-5cc5-8dac-126168cb5917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8986163-6362-4c70-8ece-22ae22da5031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8986163-6362-4c70-8ece-22ae22da5031.jpg?1",
             "name": "Blightcaster",
             "text": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn.",
             "colours": [
@@ -2949,7 +2949,7 @@
         },
         {
             "id": "82081030-a86d-5b33-8876-40a4daa3da06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30d6df7-6199-4b06-9d45-785ee1e2ed3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30d6df7-6199-4b06-9d45-785ee1e2ed3b.jpg?1",
             "name": "Catacomb Slug",
             "text": "",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "e5837076-7f89-5213-883e-9b2a1779d001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d896df9-f897-4786-b1a1-d2375e81c9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d896df9-f897-4786-b1a1-d2375e81c9ef.jpg?1",
             "name": "Consecrated by Blood",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying and \"Sacrifice two other creatures: Regenerate this creature.\" (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "6cbdf8d9-6bef-5387-a6a4-e4fd171fc3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a863ae27-a99a-4a60-ab07-25c1bacec64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a863ae27-a99a-4a60-ab07-25c1bacec64d.jpg?1",
             "name": "Cruel Revival",
             "text": "Destroy target non-Zombie creature. It can't be regenerated. Return up to one target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "9a64b9a0-9585-5370-a88e-151c603a0c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5a047-2315-41a5-a78d-6a690622c457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5a047-2315-41a5-a78d-6a690622c457.jpg?1",
             "name": "Dark Dabbling",
             "text": "Regenerate target creature. Draw a card. (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, also regenerate each other creature you control.",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "dd4ea09a-2531-567c-b7ad-bd8b346d23ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9df9c5e-7087-42b2-9001-c89d40a66c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9df9c5e-7087-42b2-9001-c89d40a66c68.jpg?1",
             "name": "Dark Petition",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, add {B}{B}{B} to your mana pool.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "94b72494-9e50-5d4f-a5ba-8d1528374511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b62a4c2-e66d-4fc3-8703-a90b84f567bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b62a4c2-e66d-4fc3-8703-a90b84f567bf.jpg?1",
             "name": "Deadbridge Shaman",
             "text": "When Deadbridge Shaman dies, target opponent discards a card.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "d3566abe-1d30-5703-9941-66a56ef87501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c04014-91f9-4197-b4b4-f62c4739a5c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c04014-91f9-4197-b4b4-f62c4739a5c2.jpg?1",
             "name": "Demonic Pact",
             "text": "At the beginning of your upkeep, choose one that hasn't been chosen \u2014\u2022 Demonic Pact deals 4 damage to target creature or player and you gain 4 life.\u2022 Target opponent discards two cards.\u2022 Draw two cards.\u2022 You lose the game.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "f67a9f47-604f-5950-92e4-cbd47754c15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a09fe4-d7a0-4065-968d-0837c3eafda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a09fe4-d7a0-4065-968d-0837c3eafda0.jpg?1",
             "name": "Despoiler of Souls",
             "text": "Despoiler of Souls can't block.{B}{B}, Exile two other creature cards from your graveyard: Return Despoiler of Souls from your graveyard to the battlefield.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "11122e7e-51e3-594e-ae3b-9f541fe3c993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5972911-2d41-4a0c-8a8f-b3d35a6594d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5972911-2d41-4a0c-8a8f-b3d35a6594d8.jpg?1",
             "name": "Erebos's Titan",
             "text": "As long as your opponents control no creatures, Erebos's Titan has indestructible. (Damage and effects that say \"destroy\" don't destroy it.)\nWhenever a creature card leaves an opponent's graveyard, you may discard a card. If you do, return Erebos's Titan from your graveyard to your hand.",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "5f535a11-56c7-56ff-ae40-eaf16405b0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8aaaf1-6b21-465d-8450-0718beb9106b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8aaaf1-6b21-465d-8450-0718beb9106b.jpg?1",
             "name": "Eyeblight Assassin",
             "text": "When Eyeblight Assassin enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "67928909-bfeb-5243-a80b-466a8f6b2835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73484db-5fd0-4a01-83fd-54748cc21a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73484db-5fd0-4a01-83fd-54748cc21a0f.jpg?1",
             "name": "Eyeblight Massacre",
             "text": "Non-Elf creatures get -2/-2 until end of turn.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "50fac2bf-fc6f-51e2-ba56-a984a07afc38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891718e9-bef3-470a-80c5-514f7f43abe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891718e9-bef3-470a-80c5-514f7f43abe8.jpg?1",
             "name": "Fetid Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.){B}: Fetid Imp gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "9dc1d836-a343-586c-aab9-5e324c325d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb8ea7b-dfac-47bf-b608-efd54e4fe0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb8ea7b-dfac-47bf-b608-efd54e4fe0f1.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "7e7c901c-8560-5c56-bdd0-b5d9eb8f346c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9667cae-6801-434b-9d91-ea1f2bd2449e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9667cae-6801-434b-9d91-ea1f2bd2449e.jpg?1",
             "name": "Gilt-Leaf Winnower",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Gilt-Leaf Winnower enters the battlefield, you may destroy target non-Elf creature whose power and toughness aren't equal.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "bc78b5b7-10c4-55dd-8c46-fd9ea4ccb312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05572ba-3a26-41f5-96c1-960ec9367178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05572ba-3a26-41f5-96c1-960ec9367178.jpg?1",
             "name": "Gnarlroot Trapper",
             "text": "{T}, Pay 1 life: Add {G} to your mana pool. Spend this mana only to cast an Elf creature spell.{T}: Target attacking Elf you control gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3455,7 +3455,7 @@
         },
         {
             "id": "eedead06-f982-5fe6-a4cd-558cf9304b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85880be1-65b2-432f-8788-79716e4c8066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85880be1-65b2-432f-8788-79716e4c8066.jpg?1",
             "name": "Graveblade Marauder",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -3490,7 +3490,7 @@
         },
         {
             "id": "65faf7a6-78c6-5450-990c-65224a23afad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead8cc-5b7d-4a6d-a56f-95da91a958d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead8cc-5b7d-4a6d-a56f-95da91a958d2.jpg?1",
             "name": "Infernal Scarring",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "8612efa5-dfbe-5179-8308-f788cb47414e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f6a0-3670-4b72-8c8e-668f47252fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f6a0-3670-4b72-8c8e-668f47252fa0.jpg?1",
             "name": "Infinite Obliteration",
             "text": "Name a creature card. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "b91b94e5-ca87-5137-8e50-b40782695b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036e696a-b2aa-40ba-9ed6-3a859c4288a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036e696a-b2aa-40ba-9ed6-3a859c4288a0.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "Flying\nWhenever a permanent owned by another player is put into a graveyard from the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "94c9a868-a47d-5db4-adb8-9d68bda2db90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3593efa-0a05-4061-9f6e-edd0a5ca9a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3593efa-0a05-4061-9f6e-edd0a5ca9a1f.jpg?1",
             "name": "Languish",
             "text": "All creatures get -4/-4 until end of turn.",
             "colours": [
@@ -3624,7 +3624,7 @@
         },
         {
             "id": "63ea84ce-bca0-5eb0-861d-b82e2aaf92de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg?1",
             "name": "Liliana, Heretical Healer // Liliana, Defiant Necromancer",
             "text": "Lifelink\nWhenever another nontoken creature you control dies, exile Liliana, Heretical Healer, then return her to the battlefield transformed under her owner's control. If you do, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "2bd840b5-e790-56fe-9f21-32ff880c49c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg?1",
             "name": "Liliana, Heretical Healer // Liliana, Defiant Necromancer",
             "text": "+2: Each player discards a card.\u2212X: Return target nonlegendary creature card with converted mana cost X from your graveyard to the battlefield.\u22128: You get an emblem with \"Whenever a creature dies, return it to the battlefield under your control at the beginning of the next end step.\"",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "2bf75b07-7e2d-5358-9d6c-c83b19a8f306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958e5da-ca77-4f22-972f-5d6e2777509a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958e5da-ca77-4f22-972f-5d6e2777509a.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "1a2ccd99-b19b-5b50-857a-49dabbe7158b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70861692-1eb2-4cb1-8d7f-b881386c37d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70861692-1eb2-4cb1-8d7f-b881386c37d1.jpg?1",
             "name": "Malakir Cullblade",
             "text": "Whenever a creature an opponent controls dies, put a +1/+1 counter on Malakir Cullblade.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "c664695f-a1d7-5a34-aa9a-3943aed0e2a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3915c0be-7e9c-45bc-9c83-80beba469a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3915c0be-7e9c-45bc-9c83-80beba469a81.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "15fdfdf8-7a9d-53c0-9384-b0057db425cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe7891-09d5-470e-aa41-71d89249875b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe7891-09d5-470e-aa41-71d89249875b.jpg?1",
             "name": "Necromantic Summons",
             "text": "Put target creature card from a graveyard onto the battlefield under your control.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, that creature enters the battlefield with two additional +1/+1 counters on it.",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "9bb5e196-5c58-5465-8e6d-421778bebf4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391a1023-69e7-425c-ac54-987ba366f8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391a1023-69e7-425c-ac54-987ba366f8f4.jpg?1",
             "name": "Nightsnare",
             "text": "Target opponent reveals his or her hand. You may choose a nonland card from it. If you do, that player discards that card. If you don't, that player discards two cards.",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "9eb900ed-abe3-5c5f-9f0c-9c99fc05263e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118ba6f2-a2f0-4554-ad87-a932c951cdd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118ba6f2-a2f0-4554-ad87-a932c951cdd4.jpg?1",
             "name": "Priest of the Blood Rite",
             "text": "When Priest of the Blood Rite enters the battlefield, put a 5/5 black Demon creature token with flying onto the battlefield.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "fc32bdd3-1cf4-5dbf-a022-7e0fd508b1d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335da62-3b59-4c73-a19e-b1733393ed88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335da62-3b59-4c73-a19e-b1733393ed88.jpg?1",
             "name": "Rabid Bloodsucker",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Rabid Bloodsucker enters the battlefield, each player loses 2 life.",
             "colours": [
@@ -3932,7 +3932,7 @@
         },
         {
             "id": "4fc3ff3c-094f-5fa6-a650-272589db59c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc51b90-7f1e-4e20-bc36-e3a198bc71bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc51b90-7f1e-4e20-bc36-e3a198bc71bf.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3964,7 +3964,7 @@
         },
         {
             "id": "f5a732c1-fe19-59f6-bb07-85806690a67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3d5e9d-07e8-43e1-aaf0-1f9e4ed2834a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3d5e9d-07e8-43e1-aaf0-1f9e4ed2834a.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "b3fc4548-d9c1-58f5-9825-8796993985b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103b369c-da58-40e7-98aa-5a5471434bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103b369c-da58-40e7-98aa-5a5471434bca.jpg?1",
             "name": "Returned Centaur",
             "text": "When Returned Centaur enters the battlefield, target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "2c13f197-22a3-52bf-a03f-0225f5ec301b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c6dbe5-3375-42c2-88f5-8ead0dc2b094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c6dbe5-3375-42c2-88f5-8ead0dc2b094.jpg?1",
             "name": "Revenant",
             "text": "FlyingRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -4065,7 +4065,7 @@
         },
         {
             "id": "ae1a8f2b-d99c-5d56-9ef9-81558ce658e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02962013-fc5a-46be-9021-8fd40ab3027c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02962013-fc5a-46be-9021-8fd40ab3027c.jpg?1",
             "name": "Shadows of the Past",
             "text": "Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.){4}{B}: Each opponent loses 2 life and you gain 2 life. Activate this ability only if there are four or more creature cards in your graveyard.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "66c5dd14-2b40-5be6-b1fb-efdcb3383d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8061d2-84ce-4e4a-9911-ffc9833749da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8061d2-84ce-4e4a-9911-ffc9833749da.jpg?1",
             "name": "Shambling Ghoul",
             "text": "Shambling Ghoul enters the battlefield tapped.",
             "colours": [
@@ -4131,7 +4131,7 @@
         },
         {
             "id": "a132ad5d-7cd8-52d3-84ba-e75841874802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb8edd0-4573-4b52-a3ea-83ed19dbf58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb8edd0-4573-4b52-a3ea-83ed19dbf58d.jpg?1",
             "name": "Tainted Remedy",
             "text": "If an opponent would gain life, that player loses that much life instead.",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "02d98836-6aa3-56af-a75e-71f213f3ad2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290c60a-f9a0-464d-a15e-8473a6d50d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290c60a-f9a0-464d-a15e-8473a6d50d96.jpg?1",
             "name": "Thornbow Archer",
             "text": "Whenever Thornbow Archer attacks, each opponent who doesn't control an Elf loses 1 life.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "8155547f-1b96-5090-9f66-4f747772345d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be2be08-5bad-4813-b6f3-45b564e10b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be2be08-5bad-4813-b6f3-45b564e10b2f.jpg?1",
             "name": "Tormented Thoughts",
             "text": "As an additional cost to cast Tormented Thoughts, sacrifice a creature.\nTarget player discards a number of cards equal to the sacrificed creature's power.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "b6662ba3-4559-5b17-8cf9-0f6925b14e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf659f2f-983c-4a62-a969-4176e5fbe193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf659f2f-983c-4a62-a969-4176e5fbe193.jpg?1",
             "name": "Touch of Moonglove",
             "text": "Target creature you control gets +1/+0 and gains deathtouch until end of turn. Whenever a creature dealt damage by that creature dies this turn, its controller loses 2 life. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "5340f2c6-e5d4-5610-b7b7-cfb77f6008cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36afdfd4-8db7-45b6-9b6d-b9293fe6c26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36afdfd4-8db7-45b6-9b6d-b9293fe6c26d.jpg?1",
             "name": "Undead Servant",
             "text": "When Undead Servant enters the battlefield, put a 2/2 black Zombie creature token onto the battlefield for each card named Undead Servant in your graveyard.",
             "colours": [
@@ -4296,7 +4296,7 @@
         },
         {
             "id": "264ee6f2-ac8b-5c17-90c1-57db8a8256fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994b7b0-3bca-480b-b265-ed269f15c17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994b7b0-3bca-480b-b265-ed269f15c17e.jpg?1",
             "name": "Unholy Hunger",
             "text": "Destroy target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you gain 2 life.",
             "colours": [
@@ -4328,7 +4328,7 @@
         },
         {
             "id": "7ffd744f-d841-5382-b811-043d78809fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f31943-e26c-4bd2-bdbd-d980836f99b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f31943-e26c-4bd2-bdbd-d980836f99b9.jpg?1",
             "name": "Weight of the Underworld",
             "text": "Enchant creature\nEnchanted creature gets -3/-2.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "df0e1ede-b627-5b95-8eed-0ce7d08a897b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg?1",
             "name": "Abbot of Keral Keep",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Abbot of Keral Keep enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "a25b5d66-c9c4-56da-9b80-5aa2d3cf8231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186581c7-81a6-4c27-b8a9-ff7f7a4b1d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186581c7-81a6-4c27-b8a9-ff7f7a4b1d40.jpg?1",
             "name": "Acolyte of the Inferno",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhenever Acolyte of the Inferno becomes blocked by a creature, it deals 2 damage to that creature.",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "993e910a-f713-5c28-8018-1ba232d0831f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a71ba3-e5f0-4f36-bafa-db96611681dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a71ba3-e5f0-4f36-bafa-db96611681dd.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4464,7 +4464,7 @@
         },
         {
             "id": "322f699a-4fa1-5574-bb20-643e19cc6059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg?1",
             "name": "Akroan Sergeant",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "1418e1a4-1729-575c-a283-281be85ae219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354255d7-dc29-403b-aa90-9044cde669d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354255d7-dc29-403b-aa90-9044cde669d0.jpg?1",
             "name": "Avaricious Dragon",
             "text": "Flying\nAt the beginning of your draw step, draw an additional card.\nAt the beginning of your end step, discard your hand.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "d84ef24d-9306-5a60-9503-bb93adeccfe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d2e99-13f1-4ce8-9a54-139de193c1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d2e99-13f1-4ce8-9a54-139de193c1b3.jpg?1",
             "name": "Bellows Lizard",
             "text": "{1}{R}: Bellows Lizard gets +1/+0 until end of turn.",
             "colours": [
@@ -4567,7 +4567,7 @@
         },
         {
             "id": "28974db4-fe40-5262-91ad-cf98981100b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d735ebf-61a4-4507-9399-6d32c8903ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d735ebf-61a4-4507-9399-6d32c8903ded.jpg?1",
             "name": "Boggart Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "54c1c056-d92f-5550-afa6-c99f01d9f647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369d837a-a19b-457c-8146-cc1766a63ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369d837a-a19b-457c-8146-cc1766a63ec1.jpg?1",
             "name": "Call of the Full Moon",
             "text": "Enchant creature\nEnchanted creature gets +3/+2 and has trample. (It can deal excess combat damage to defending player or planeswalker while attacking.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, sacrifice Call of the Full Moon.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "86f3ab5a-ab07-57c5-9388-f04eabdfdaf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg?1",
             "name": "Chandra, Fire of Kaladesh // Chandra, Roaring Flame",
             "text": "Whenever you cast a red spell, untap Chandra, Fire of Kaladesh.{T}: Chandra, Fire of Kaladesh deals 1 damage to target player. If Chandra has dealt 3 or more damage this turn, exile her, then return her to the battlefield transformed under her owner's control.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "eb02a93c-ff6e-5746-a9d1-e597c5716b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg?1",
             "name": "Chandra, Fire of Kaladesh // Chandra, Roaring Flame",
             "text": "+1: Chandra, Roaring Flame deals 2 damage to target player.\u22122: Chandra, Roaring Flame deals 2 damage to target creature.\u22127: Chandra, Roaring Flame deals 6 damage to each opponent. Each player dealt damage this way gets an emblem with \"At the beginning of your upkeep, this emblem deals 3 damage to you.\"",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "f72b3360-d2e2-5563-b5b7-8f386637922e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b85237-98a8-4b52-9cc6-6fd14849b069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b85237-98a8-4b52-9cc6-6fd14849b069.jpg?1",
             "name": "Chandra's Fury",
             "text": "Chandra's Fury deals 4 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -4741,7 +4741,7 @@
         },
         {
             "id": "23cc35ec-57ec-5b67-a7ac-bc08761ca56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4c90de-49aa-43ed-a18a-f7f96268e5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4c90de-49aa-43ed-a18a-f7f96268e5eb.jpg?1",
             "name": "Chandra's Ignition",
             "text": "Target creature you control deals damage equal to its power to each other creature and each opponent.",
             "colours": [
@@ -4773,7 +4773,7 @@
         },
         {
             "id": "630e0ecc-7cc8-553f-827e-aa39c52d40f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa87a70-c9fb-4ab3-ac16-367888aa775b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa87a70-c9fb-4ab3-ac16-367888aa775b.jpg?1",
             "name": "Cobblebrute",
             "text": "",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "fceaa313-26e4-50a7-9aba-c0dad3b7f146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c95da-458d-4914-9e7c-2c5fc1aa626b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c95da-458d-4914-9e7c-2c5fc1aa626b.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "88c6b2e7-5033-5e27-835e-4d1e237b5bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19fc806-f1b7-4f82-be0e-b960699f9a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19fc806-f1b7-4f82-be0e-b960699f9a36.jpg?1",
             "name": "Dragon Fodder",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "ebde715b-13f8-5101-ad6c-660328cfec6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664f60a8-e80a-4fe0-b76c-2d76c728329e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664f60a8-e80a-4fe0-b76c-2d76c728329e.jpg?1",
             "name": "Embermaw Hellion",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nIf another red source you control would deal damage to a permanent or player, it deals that much damage plus 1 to that permanent or player instead.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "24065f2e-2436-51d4-a273-580c75ce96f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607d63b-82ab-44f0-aef5-d9063e17c76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607d63b-82ab-44f0-aef5-d9063e17c76f.jpg?1",
             "name": "Enthralling Victor",
             "text": "When Enthralling Victor enters the battlefield, gain control of target creature an opponent controls with power 2 or less until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "839e567a-ee93-5cec-9c34-a4354b09f3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eca98e-a164-4f70-a0b0-7a604863f30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eca98e-a164-4f70-a0b0-7a604863f30b.jpg?1",
             "name": "Exquisite Firecraft",
             "text": "Exquisite Firecraft deals 4 damage to target creature or player.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Exquisite Firecraft can't be countered by spells or abilities.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "8bc2c5f7-e279-58af-b77a-6e27fccb59d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104365ec-7452-4542-b409-b7eb5d314735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104365ec-7452-4542-b409-b7eb5d314735.jpg?1",
             "name": "Fiery Conclusion",
             "text": "As an additional cost to cast Fiery Conclusion, sacrifice a creature.Fiery Conclusion deals 5 damage to target creature.",
             "colours": [
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "89ceffe7-c65f-5e5d-80ea-4754dd8984da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b81a589-44bf-4441-9079-1ae66d067519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b81a589-44bf-4441-9079-1ae66d067519.jpg?1",
             "name": "Fiery Impulse",
             "text": "Fiery Impulse deals 2 damage to target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Fiery Impulse deals 3 damage to that creature instead.",
             "colours": [
@@ -5036,7 +5036,7 @@
         },
         {
             "id": "f30c907e-eba9-5337-8e98-dfbcdaa1037b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg?1",
             "name": "Firefiend Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "179de610-1b31-5fd4-8023-99b0a5f1f293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b473ee0c-b037-4968-9dda-82c2288e54f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b473ee0c-b037-4968-9dda-82c2288e54f7.jpg?1",
             "name": "Flameshadow Conjuring",
             "text": "Whenever a nontoken creature enters the battlefield under your control, you may pay {R}. If you do, put a token onto the battlefield that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -5102,7 +5102,7 @@
         },
         {
             "id": "2782664f-5eca-5358-ae37-cce8fa1cfcca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg?1",
             "name": "Ghirapur Aether Grid",
             "text": "Tap two untapped artifacts you control: Ghirapur \u00c6ther Grid deals 1 damage to target creature or player.",
             "colours": [
@@ -5134,7 +5134,7 @@
         },
         {
             "id": "bd3c622a-56ea-5bab-9ee0-2b8ddb19d7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05cafb6-8812-42bb-ad14-3dde4bcb7034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05cafb6-8812-42bb-ad14-3dde4bcb7034.jpg?1",
             "name": "Ghirapur Gearcrafter",
             "text": "When Ghirapur Gearcrafter enters the battlefield, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield. (A creature with flying can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "6dafe209-ef79-51e7-880b-3b97a1fa32d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2779415-9e0e-4c61-b590-e15ac089cf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2779415-9e0e-4c61-b590-e15ac089cf30.jpg?1",
             "name": "Goblin Glory Chaser",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nAs long as Goblin Glory Chaser is renowned, it has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5204,7 +5204,7 @@
         },
         {
             "id": "bd486c89-e9eb-542a-bad4-774246baffa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b332e3d-dcf4-4f62-8130-124ec5d23b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b332e3d-dcf4-4f62-8130-124ec5d23b90.jpg?1",
             "name": "Goblin Piledriver",
             "text": "Protection from blue (This creature can't be blocked, targeted, dealt damage, or enchanted by anything blue.)\nWhenever Goblin Piledriver attacks, it gets +2/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "0c5151a9-2f0f-5fa9-8480-fb6f64e44015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44df88-45a4-46ef-a8bd-f7fb7b9542b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44df88-45a4-46ef-a8bd-f7fb7b9542b8.jpg?1",
             "name": "Infectious Bloodlust",
             "text": "Enchant creature\nEnchanted creature gets +2/+1, has haste, and attacks each turn if able.\nWhen enchanted creature dies, you may search your library for a card named Infectious Bloodlust, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "c714c03e-f357-5c52-b1c7-b69531d103ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg?1",
             "name": "Lightning Javelin",
             "text": "Lightning Javelin deals 3 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5305,7 +5305,7 @@
         },
         {
             "id": "8bfd95bc-217a-544b-a847-e22342d33fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a129f22-dd7e-4b2c-a514-a2ac55bb5661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a129f22-dd7e-4b2c-a514-a2ac55bb5661.jpg?1",
             "name": "Mage-Ring Bully",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)Mage-Ring Bully attacks each turn if able.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "0ae855e3-af98-535e-9e03-80525ca97950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg?1",
             "name": "Magmatic Insight",
             "text": "As an additional cost to cast Magmatic Insight, discard a land card.\nDraw two cards.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "2e32afe8-ecfa-56a4-80e0-d3df604a50c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg?1",
             "name": "Molten Vortex",
             "text": "{R}, Discard a land card: Molten Vortex deals 2 damage to target creature or player.",
             "colours": [
@@ -5404,7 +5404,7 @@
         },
         {
             "id": "ce7d685b-f94e-5b45-901d-d8597e9813d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcafa9e-3637-42ca-bdb2-45a2b5da7294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcafa9e-3637-42ca-bdb2-45a2b5da7294.jpg?1",
             "name": "Pia and Kiran Nalaar",
             "text": "When Pia and Kiran Nalaar enters the battlefield, put two 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.{2}{R}, Sacrifice an artifact: Pia and Kiran Nalaar deals 2 damage to target creature or player.",
             "colours": [
@@ -5441,7 +5441,7 @@
         },
         {
             "id": "bacfb7d9-b212-540f-b419-9922436b72b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191a8fd-2c54-4e47-9d5a-692bb38c811f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191a8fd-2c54-4e47-9d5a-692bb38c811f.jpg?1",
             "name": "Prickleboar",
             "text": "As long as it's your turn, Prickleboar gets +2/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "4b9fe7c2-f4de-5bad-9f79-4ff1723fe4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9404b2-f0ea-4a31-bc7b-6748574c57d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9404b2-f0ea-4a31-bc7b-6748574c57d3.jpg?1",
             "name": "Ravaging Blaze",
             "text": "Ravaging Blaze deals X damage to target creature. Spell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Ravaging Blaze also deals X damage to that creature's controller.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "9fc238d6-157e-5997-b841-e45868b823e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d600b0-8649-424a-acad-879f3067b55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d600b0-8649-424a-acad-879f3067b55e.jpg?1",
             "name": "Scab-Clan Berserker",
             "text": "Haste\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhenever an opponent casts a noncreature spell, if Scab-Clan Berserker is renowned, Scab-Clan Berserker deals 2 damage to that player.",
             "colours": [
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "71f7f447-a10d-5eed-8e91-4d927114d3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60d957b-f71a-403e-82fe-30ea87d1e142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60d957b-f71a-403e-82fe-30ea87d1e142.jpg?1",
             "name": "Seismic Elemental",
             "text": "When Seismic Elemental enters the battlefield, creatures without flying can't block this turn.",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "62a0daf8-10e8-544c-a074-8d0e3da273c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f0d87a-8f37-4598-9106-c3545dadf6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f0d87a-8f37-4598-9106-c3545dadf6fd.jpg?1",
             "name": "Skyraker Giant",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "23cfd2e6-5c47-506b-9004-82d7ad5bf712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c489f-bffb-45a4-8e7c-2d1a35220197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c489f-bffb-45a4-8e7c-2d1a35220197.jpg?1",
             "name": "Smash to Smithereens",
             "text": "Destroy target artifact. Smash to Smithereens deals 3 damage to that artifact's controller.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "37661921-d370-5b70-997e-a326180d2766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9289dd-f1a3-4be5-8ed1-4b4dd4e97743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9289dd-f1a3-4be5-8ed1-4b4dd4e97743.jpg?1",
             "name": "Subterranean Scout",
             "text": "When Subterranean Scout enters the battlefield, target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "45e2632b-55ad-5455-8b6c-358735ce1b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6c48a-29d0-40ae-aac6-df7319873f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6c48a-29d0-40ae-aac6-df7319873f50.jpg?1",
             "name": "Thopter Engineer",
             "text": "When Thopter Engineer enters the battlefield, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield.\nArtifact creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "42edb9dd-fca5-5dfc-9dd2-c879d3799e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e48f309-8e56-4741-a9ff-e899dafb333a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e48f309-8e56-4741-a9ff-e899dafb333a.jpg?1",
             "name": "Titan's Strength",
             "text": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "d7b2ff04-82e1-5517-b5b6-d12b7e1257aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg?1",
             "name": "Volcanic Rambler",
             "text": "{2}{R}: Volcanic Rambler deals 1 damage to target player.",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "e0b38df4-8796-5c29-9307-5bfe425ff622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg?1",
             "name": "Aerial Volley",
             "text": "Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.",
             "colours": [
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "d38aba85-9e64-5b8e-bcdb-f840c825dfc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b62616-c1a3-45f7-a329-f1305c462eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b62616-c1a3-45f7-a329-f1305c462eaf.jpg?1",
             "name": "Animist's Awakening",
             "text": "Reveal the top X cards of your library. Put all land cards from among them onto the battlefield tapped and the rest on the bottom of your library in a random order.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, untap those lands.",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "e5ba2934-4802-56e1-b3e7-60f86decde93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d4e0d-bddd-4835-91b8-11c2f15e54c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d4e0d-bddd-4835-91b8-11c2f15e54c3.jpg?1",
             "name": "Caustic Caterpillar",
             "text": "{1}{G}, Sacrifice Caustic Caterpillar: Destroy target artifact or enchantment.",
             "colours": [
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "352a94a3-2fe7-5bd9-a670-37c7dd30caf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg?1",
             "name": "Conclave Naturalists",
             "text": "When Conclave Naturalists enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -5910,7 +5910,7 @@
         },
         {
             "id": "13dcfb8b-ff31-5b4a-b395-2653b3fc2637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c143a9-c642-425a-a469-a9d158e43c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c143a9-c642-425a-a469-a9d158e43c21.jpg?1",
             "name": "Dwynen, Gilt-Leaf Daen",
             "text": "Reach\nOther Elf creatures you control get +1/+1.\nWhenever Dwynen, Gilt-Leaf Daen attacks, you gain 1 life for each attacking Elf you control.",
             "colours": [
@@ -5947,7 +5947,7 @@
         },
         {
             "id": "abf48426-be1d-5729-8dbd-9485851c08fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c203722b-3f16-4b6c-9b2e-18169d3f80c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c203722b-3f16-4b6c-9b2e-18169d3f80c9.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When Dwynen's Elite enters the battlefield, if you control another Elf, put a 1/1 green Elf Warrior creature token onto the battlefield.",
             "colours": [
@@ -5982,7 +5982,7 @@
         },
         {
             "id": "d4590b70-6141-5bc2-a419-1d44e64ee51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg?1",
             "name": "Elemental Bond",
             "text": "Whenever a creature with power 3 or greater enters the battlefield under your control, draw a card.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "0bd63037-e339-5907-9d7c-09e6a8986352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ef35a-528b-407c-8b8d-679109662bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ef35a-528b-407c-8b8d-679109662bae.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "256616af-eb43-563a-97ab-92ce8dab624d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27f3193-3083-409e-99d8-10f5b1afe9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27f3193-3083-409e-99d8-10f5b1afe9f1.jpg?1",
             "name": "Evolutionary Leap",
             "text": "{G}, Sacrifice a creature: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "f10c1aa8-24cc-5983-a644-718f2a60a108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fad73f-c6eb-46d7-8971-9be4d7d7b75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fad73f-c6eb-46d7-8971-9be4d7d7b75f.jpg?1",
             "name": "Gaea's Revenge",
             "text": "Gaea's Revenge can't be countered.\nHasteGaea's Revenge can't be the target of nongreen spells or abilities from nongreen sources.",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "ad3819fe-8afe-5c83-abfe-d946419a6010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f5b00-ac50-485f-a38a-b9f409307d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f5b00-ac50-485f-a38a-b9f409307d5c.jpg?1",
             "name": "Gather the Pack",
             "text": "Reveal the top five cards of your library. You may put a creature card from among them into your hand. Put the rest into your graveyard.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, put up to two creature cards from among the revealed cards into your hand instead of one.",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "0c0b2eff-ed06-5cd3-b1d5-f73d455059bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0eb3b-00b9-42ca-9f7d-5543bffc3480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0eb3b-00b9-42ca-9f7d-5543bffc3480.jpg?1",
             "name": "The Great Aurora",
             "text": "Each player shuffles all cards from his or her hand and all permanents he or she owns into his or her library, then draws that many cards. Each player may put any number of land cards from his or her hand onto the battlefield. Exile The Great Aurora.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "713ce581-49ad-5cc7-a315-6681746d5ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg?1",
             "name": "Herald of the Pantheon",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "2e8ea325-74c1-52b6-a681-53bcd3a1ee9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf335eac-e57b-44ec-afe2-8aed567469e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf335eac-e57b-44ec-afe2-8aed567469e7.jpg?1",
             "name": "Hitchclaw Recluse",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "78261d23-f74e-58e9-b39b-96d7260545f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769d0447-2c8f-41ef-a950-3a3022161c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769d0447-2c8f-41ef-a950-3a3022161c7f.jpg?1",
             "name": "Honored Hierarch",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nAs long as Honored Hierarch is renowned, it has vigilance and \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "c5b226fb-7eb6-5691-9cd8-381466977b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c89431-0881-4aa6-ac15-d4c13b075273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c89431-0881-4aa6-ac15-d4c13b075273.jpg?1",
             "name": "Joraga Invocation",
             "text": "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "ce42e124-8713-5edc-bac7-ab1fd4ddf1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f0c9b4-9b79-4e61-8386-a36b26d9963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f0c9b4-9b79-4e61-8386-a36b26d9963c.jpg?1",
             "name": "Leaf Gilder",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "898b4190-97b9-5299-8a32-e5c9c3dca4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bdc8e-7c12-4838-9017-0d5abfc94463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bdc8e-7c12-4838-9017-0d5abfc94463.jpg?1",
             "name": "Llanowar Empath",
             "text": "When Llanowar Empath enters the battlefield, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -6385,7 +6385,7 @@
         },
         {
             "id": "14c12033-7fb3-5871-b5a6-09c747dbfe12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg?1",
             "name": "Managorger Hydra",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nWhenever a player casts a spell, put a +1/+1 counter on Managorger Hydra.",
             "colours": [
@@ -6419,7 +6419,7 @@
         },
         {
             "id": "d81bf509-417c-5983-bf92-0bb3ff929c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg?1",
             "name": "Mantle of Webs",
             "text": "Enchant creature\nEnchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)",
             "colours": [
@@ -6453,7 +6453,7 @@
         },
         {
             "id": "619f3e80-acc9-5783-ab2f-f879be0d3bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b53cc0-ef96-40da-b9b8-d93fdae40cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b53cc0-ef96-40da-b9b8-d93fdae40cb8.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -6485,7 +6485,7 @@
         },
         {
             "id": "cc3b7e29-d14d-59dc-92ea-33f825d407cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg?1",
             "name": "Nissa, Vastwood Seer // Nissa, Sage Animist",
             "text": "When Nissa, Vastwood Seer enters the battlefield, you may search your library for a basic Forest card, reveal it, put it into your hand, then shuffle your library.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, exile Nissa, then return her to the battlefield transformed under her owner's control.",
             "colours": [
@@ -6522,7 +6522,7 @@
         },
         {
             "id": "a25b5d47-1b78-50de-9c1a-11cf6453a203",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg?1",
             "name": "Nissa, Vastwood Seer // Nissa, Sage Animist",
             "text": "+1: Reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand.\u22122: Put a legendary 4/4 green Elemental creature token named Ashaya, the Awoken World onto the battlefield.\u22127: Untap up to six target lands. They become 6/6 Elemental creatures. They're still lands.",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "62af22e8-fbd2-5954-b2f7-7d6a4a3b04f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800cef89-e90c-4f84-a7a0-3cd203532169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800cef89-e90c-4f84-a7a0-3cd203532169.jpg?1",
             "name": "Nissa's Pilgrimage",
             "text": "Search your library for up to two basic Forest cards, reveal those cards, and put one onto the battlefield tapped and the rest into your hand. Then shuffle your library.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, search your library for up to three basic Forest cards instead of two.",
             "colours": [
@@ -6590,7 +6590,7 @@
         },
         {
             "id": "f16762d2-1075-5928-959f-622ed690b3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71143665-012f-4723-a58b-d5cfdbe82e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71143665-012f-4723-a58b-d5cfdbe82e8f.jpg?1",
             "name": "Nissa's Revelation",
             "text": "Scry 5, then reveal the top card of your library. If it's a creature card, you draw cards equal to its power and you gain life equal to its toughness.",
             "colours": [
@@ -6622,7 +6622,7 @@
         },
         {
             "id": "cf8ceabd-0e29-5180-a28e-5d7a2e06b311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3077a-0446-4cf4-9a32-366b4c4085a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3077a-0446-4cf4-9a32-366b4c4085a3.jpg?1",
             "name": "Orchard Spirit",
             "text": "Orchard Spirit can't be blocked except by creatures with flying or reach.",
             "colours": [
@@ -6656,7 +6656,7 @@
         },
         {
             "id": "54b15d50-e746-5989-af56-177905b96cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg?1",
             "name": "Outland Colossus",
             "text": "Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)Outland Colossus can't be blocked by more than one creature.",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "0e53d342-06c8-5672-9479-a12629e9436b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg?1",
             "name": "Pharika's Disciple",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "18993483-3076-5ac2-8e57-daacadd77c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f3c600-66f1-4a5e-ba4f-61e9f7f7a1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f3c600-66f1-4a5e-ba4f-61e9f7f7a1d9.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -6757,7 +6757,7 @@
         },
         {
             "id": "dafaef84-dfa8-5e41-bfe6-c943bcc87302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg?1",
             "name": "Rhox Maulers",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
             "colours": [
@@ -6792,7 +6792,7 @@
         },
         {
             "id": "7d1e404d-79c0-527d-9ba7-a36faf6cb7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg?1",
             "name": "Skysnare Spider",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "6c7ad929-2b1f-5248-ae00-e30d30209401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg?1",
             "name": "Somberwald Alpha",
             "text": "Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.{1}{G}: Target creature you control gains trample until end of turn. (It can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "dd5320b4-d08d-5299-81b8-0df03f0bc61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e0550c-d3ad-4bd4-a259-d597991079b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e0550c-d3ad-4bd4-a259-d597991079b1.jpg?1",
             "name": "Sylvan Messenger",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nWhen Sylvan Messenger enters the battlefield, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "52cd3e9e-c8ae-5e86-a3b3-d26d2ff7d7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b12b-cf16-4a71-b4b6-4842c1402726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b12b-cf16-4a71-b4b6-4842c1402726.jpg?1",
             "name": "Timberpack Wolf",
             "text": "Timberpack Wolf gets +1/+1 for each other creature you control named Timberpack Wolf.",
             "colours": [
@@ -6928,7 +6928,7 @@
         },
         {
             "id": "89b27e18-dada-5a17-80c7-5ff58249c468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f80ad0-2420-4de4-886c-1168166c7dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f80ad0-2420-4de4-886c-1168166c7dae.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "e50f8529-cdae-5c2c-bd0b-1bf68a6d704e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg?1",
             "name": "Undercity Troll",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.){2}{G}: Regenerate Undercity Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6994,7 +6994,7 @@
         },
         {
             "id": "7d8c5867-5448-59ef-b49f-41c069630edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693a7e7-d95e-4cd8-9524-ca5fc517189a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693a7e7-d95e-4cd8-9524-ca5fc517189a.jpg?1",
             "name": "Valeron Wardens",
             "text": "Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)\nWhenever a creature you control becomes renowned, draw a card.",
             "colours": [
@@ -7029,7 +7029,7 @@
         },
         {
             "id": "960ac0ea-6169-595b-8790-5cb7bfbfcaf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f53dc9-5397-49e1-97d4-3b0b6858f2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f53dc9-5397-49e1-97d4-3b0b6858f2b2.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "af5f06e2-d19f-5dc9-a3be-40ac909914f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg?1",
             "name": "Vine Snare",
             "text": "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "5dbbb497-0185-58ef-a298-adb21d8ebec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fafd9d-777f-4d88-ad93-63af6d7ef274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fafd9d-777f-4d88-ad93-63af6d7ef274.jpg?1",
             "name": "Wild Instincts",
             "text": "Target creature you control gets +2/+2 until end of turn. It fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7127,7 +7127,7 @@
         },
         {
             "id": "e495cb36-cab8-511a-b3b5-4337f04e4ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706d4bb-0b44-4e43-b340-7de799c086b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706d4bb-0b44-4e43-b340-7de799c086b8.jpg?1",
             "name": "Woodland Bellower",
             "text": "When Woodland Bellower enters the battlefield, you may search your library for a nonlegendary green creature card with converted mana cost 3 or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -7161,7 +7161,7 @@
         },
         {
             "id": "e229c8a7-f4b0-5313-a047-40dfa2636273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1.jpg?1",
             "name": "Yeva's Forcemage",
             "text": "When Yeva's Forcemage enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -7196,7 +7196,7 @@
         },
         {
             "id": "b885b319-453b-555d-a2c5-219043b42c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c0783-936d-4fa2-bdcb-01dae7a67fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c0783-936d-4fa2-bdcb-01dae7a67fdb.jpg?1",
             "name": "Zendikar's Roil",
             "text": "Whenever a land enters the battlefield under your control, put a 2/2 green Elemental creature token onto the battlefield.",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "37e232d2-fd81-5093-9a52-afbd4e2bfef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg?1",
             "name": "Blazing Hellhound",
             "text": "{1}, Sacrifice another creature: Blazing Hellhound deals 1 damage to target creature or player.",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "cd757d20-a928-528c-bbf0-100d89bfbe4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg?1",
             "name": "Blood-Cursed Knight",
             "text": "As long as you control an enchantment, Blood-Cursed Knight gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "f3522835-c4a9-55c6-aa2d-490f5ff3d300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660befe5-9c98-4aa3-9ca7-e643eaf91490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660befe5-9c98-4aa3-9ca7-e643eaf91490.jpg?1",
             "name": "Bounding Krasis",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Bounding Krasis enters the battlefield, you may tap or untap target creature.",
             "colours": [
@@ -7339,7 +7339,7 @@
         },
         {
             "id": "3c71396f-2f0a-5b93-864a-58986a00b52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg?1",
             "name": "Citadel Castellan",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
             "colours": [
@@ -7376,7 +7376,7 @@
         },
         {
             "id": "9b8c01cf-b82d-5b35-8fd8-baa7b234a299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg?1",
             "name": "Iroas's Champion",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "8bea1385-44f4-585a-b417-c3c0b60ac07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc94e5-a595-43ab-929b-426009190669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc94e5-a595-43ab-929b-426009190669.jpg?1",
             "name": "Possessed Skaab",
             "text": "When Possessed Skaab enters the battlefield, return target instant, sorcery, or creature card from your graveyard to your hand.\nIf Possessed Skaab would die, exile it instead.",
             "colours": [
@@ -7449,7 +7449,7 @@
         },
         {
             "id": "516cc289-6351-5313-8197-070a449a4de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5299a549-06cf-47e8-b6cd-7e44d9f1efb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5299a549-06cf-47e8-b6cd-7e44d9f1efb8.jpg?1",
             "name": "Reclusive Artificer",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Reclusive Artificer enters the battlefield, you may have it deal damage to target creature equal to the number of artifacts you control.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "c65de806-30e3-528a-9ce9-dd81506baab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304687b1-2294-4144-b2bd-7e36f9aaac34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304687b1-2294-4144-b2bd-7e36f9aaac34.jpg?1",
             "name": "Shaman of the Pack",
             "text": "When Shaman of the Pack enters the battlefield, target opponent loses life equal to the number of Elves you control.",
             "colours": [
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "585716d5-a233-5292-8369-7b46c940d6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg?1",
             "name": "Thunderclap Wyvern",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "7ffea63a-ee80-543b-af23-b7db4433f83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg?1",
             "name": "Zendikar Incarnate",
             "text": "Zendikar Incarnate's power is equal to the number of lands you control.",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "622a597d-f15c-57cc-8d32-ffaef1a84ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg?1",
             "name": "Alchemist's Vial",
             "text": "When Alchemist's Vial enters the battlefield, draw a card.{1}, {T}, Sacrifice Alchemist's Vial: Target creature can't attack or block this turn.",
             "colours": [],
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "d8232fe3-7881-5dd2-be24-d35b38d7ec76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afb856-6697-411b-b1aa-e9290a0bfd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afb856-6697-411b-b1aa-e9290a0bfd68.jpg?1",
             "name": "Alhammarret's Archive",
             "text": "If you would gain life, you gain twice that much life instead.\nIf you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.",
             "colours": [],
@@ -7653,7 +7653,7 @@
         },
         {
             "id": "b5e65756-b39b-5f5b-a332-7267015d7042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffaa737-ce46-4f35-aa8c-bd9bb77ed9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffaa737-ce46-4f35-aa8c-bd9bb77ed9f6.jpg?1",
             "name": "Angel's Tomb",
             "text": "Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.",
             "colours": [],
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "aff4bf14-1bd5-56b0-a7bc-68b9248a8dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43361897-f853-4cab-a132-5af48dad3b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43361897-f853-4cab-a132-5af48dad3b54.jpg?1",
             "name": "Bonded Construct",
             "text": "Bonded Construct can't attack alone.",
             "colours": [],
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "5ed64a00-95e8-50f1-b005-4caf5c2a7977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0a017e-eb8e-4f92-91f7-7d980461e284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0a017e-eb8e-4f92-91f7-7d980461e284.jpg?1",
             "name": "Brawler's Plate",
             "text": "Equipped creature gets +2/+2 and has trample. (It can deal excess combat damage to defending player or planeswalker while attacking.)\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "8e9894a8-9ad4-5e76-a3ee-c16cb2c80794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c65947-bc1d-4f47-b60b-2f76ab5ebde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c65947-bc1d-4f47-b60b-2f76ab5ebde9.jpg?1",
             "name": "Chief of the Foundry",
             "text": "Other artifact creatures you control get +1/+1.",
             "colours": [],
@@ -7773,7 +7773,7 @@
         },
         {
             "id": "f3cde50b-c13d-513e-b327-faed7cf5cc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdf08b-b812-4ad9-a4ca-3a9b7000b749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdf08b-b812-4ad9-a4ca-3a9b7000b749.jpg?1",
             "name": "Gold-Forged Sentinel",
             "text": "Flying",
             "colours": [],
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "0036ecd2-b835-5d1d-959e-22d84187c3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg?1",
             "name": "Guardian Automaton",
             "text": "When Guardian Automaton dies, you gain 3 life.",
             "colours": [],
@@ -7835,7 +7835,7 @@
         },
         {
             "id": "dbd0ffa5-da1b-5435-88cc-694a7719c452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff39de2-d071-4568-baac-25b505a2da56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff39de2-d071-4568-baac-25b505a2da56.jpg?1",
             "name": "Guardians of Meletis",
             "text": "Defender (This creature can't attack.)",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "19c0c367-7b80-5a9b-824a-ef0033c2bfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c21fb-fc78-4106-9a42-abc73f41ab8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c21fb-fc78-4106-9a42-abc73f41ab8b.jpg?1",
             "name": "Hangarback Walker",
             "text": "Hangarback Walker enters the battlefield with X +1/+1 counters on it.\nWhen Hangarback Walker dies, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield for each +1/+1 counter on Hangarback Walker.{1}, {T}: Put a +1/+1 counter on Hangarback Walker.",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "a07e27bb-cacf-5e9b-b0d3-248eac66e035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba006c8-0ffc-4e68-9a55-c7b842d3add9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba006c8-0ffc-4e68-9a55-c7b842d3add9.jpg?1",
             "name": "Helm of the Gods",
             "text": "Equipped creature gets +1/+1 for each enchantment you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "6d78d1ba-03fe-5bb0-be76-516b9300ab6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518af905-f518-4269-89b4-781085be8dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518af905-f518-4269-89b4-781085be8dd2.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -7955,7 +7955,7 @@
         },
         {
             "id": "0d94ffc2-490a-5e34-a121-f715537afecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c60473d-5065-4e63-bfc2-a041a8ca48ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c60473d-5065-4e63-bfc2-a041a8ca48ed.jpg?1",
             "name": "Mage-Ring Responder",
             "text": "Mage-Ring Responder doesn't untap during your untap step.{7}: Untap Mage-Ring Responder.\nWhenever Mage-Ring Responder attacks, it deals 7 damage to target creature defending player controls.",
             "colours": [],
@@ -7986,7 +7986,7 @@
         },
         {
             "id": "841f8cdd-af8d-5713-94d7-df029f4fed89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a8969f-d7a6-479a-9277-1270ee533c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a8969f-d7a6-479a-9277-1270ee533c4a.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to target creature or player.{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8014,7 +8014,7 @@
         },
         {
             "id": "81553bbd-7ba9-5a23-9708-91c2f17ebe5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33ba4e5-217f-47e3-a6ce-f935a70c7566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33ba4e5-217f-47e3-a6ce-f935a70c7566.jpg?1",
             "name": "Orbs of Warding",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\nIf a creature would deal damage to you, prevent 1 of that damage.",
             "colours": [],
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "f6e01231-03ba-5059-b8e4-6e4d0ebea7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f99de-493a-4f0f-81e4-fcd29d6e9340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f99de-493a-4f0f-81e4-fcd29d6e9340.jpg?1",
             "name": "Prism Ring",
             "text": "As Prism Ring enters the battlefield, choose a color.\nWhenever you cast a spell of the chosen color, you gain 1 life.",
             "colours": [],
@@ -8070,7 +8070,7 @@
         },
         {
             "id": "8657e487-4850-5d8b-8f25-c348ad658063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163ce9f-cf22-422e-a4b5-0240b88e2816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163ce9f-cf22-422e-a4b5-0240b88e2816.jpg?1",
             "name": "Pyromancer's Goggles",
             "text": "{T}: Add {R} to your mana pool. When that mana is spent to cast a red instant or sorcery spell, copy that spell and you may choose new targets for the copy.",
             "colours": [],
@@ -8102,7 +8102,7 @@
         },
         {
             "id": "cbfc0e81-66ee-561d-a06c-a7ae378bcc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7ba4d-26bb-4631-a135-f27d94f376d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7ba4d-26bb-4631-a135-f27d94f376d1.jpg?1",
             "name": "Ramroller",
             "text": "Ramroller attacks each turn if able.Ramroller gets +2/+0 as long as you control another artifact.",
             "colours": [],
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "31902de1-7988-5279-981d-5984e198f4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0616483f-3169-41ac-b7a8-6a543d483b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0616483f-3169-41ac-b7a8-6a543d483b87.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "c142f1c1-4319-59d0-b44e-295fe583ff1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f134f242-cbb5-4a3d-bfd4-46e8b8669b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f134f242-cbb5-4a3d-bfd4-46e8b8669b4b.jpg?1",
             "name": "Sigil of Valor",
             "text": "Whenever equipped creature attacks alone, it gets +1/+1 until end of turn for each other creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "2a05eb2c-1a17-5c35-bbf9-477d6d32169f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3687c36-c0ae-4dba-9379-b420236bf529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3687c36-c0ae-4dba-9379-b420236bf529.jpg?1",
             "name": "Sword of the Animist",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\nEquip {2}",
             "colours": [],
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "b409fd7f-663b-52ce-ab5e-b732118f8c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfce9be-67a2-4e8a-a71f-e88f64067691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfce9be-67a2-4e8a-a71f-e88f64067691.jpg?1",
             "name": "Throwing Knife",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, you may sacrifice Throwing Knife. If you do, Throwing Knife deals 2 damage to target creature or player.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8256,7 +8256,7 @@
         },
         {
             "id": "3fb2ba78-9b83-55f8-ae1e-ff328145bd5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg?1",
             "name": "Veteran's Sidearm",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8286,7 +8286,7 @@
         },
         {
             "id": "24605c70-624f-534f-ba0d-b3ff4964e7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg?1",
             "name": "War Horn",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [],
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "75b25e10-cbb1-5e5c-9e69-8c6e57d8f1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034c5944-aad3-4bf2-b79d-8da61ab1bd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034c5944-aad3-4bf2-b79d-8da61ab1bd52.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "a50ccbe9-137f-53bb-b64a-32f31ced77bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca145c1c-537a-459e-9241-0b95368aaf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca145c1c-537a-459e-9241-0b95368aaf3a.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "bc477f1c-abe0-5962-a3b7-278f607164e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a3dd4-27bd-4825-a525-2d6cc2201046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a3dd4-27bd-4825-a525-2d6cc2201046.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8404,7 +8404,7 @@
         },
         {
             "id": "cbf38d8c-024c-59c0-8cd0-a23f8c0d4a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f29e03-0a71-46cd-992e-7baa61f16ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f29e03-0a71-46cd-992e-7baa61f16ac5.jpg?1",
             "name": "Foundry of the Consuls",
             "text": "{T}: Add {1} to your mana pool.{5}, {T}, Sacrifice Foundry of the Consuls: Put two 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.",
             "colours": [],
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "be2cc16d-579f-534e-b919-48da91b7ff28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924d4025-a6f7-4ab0-8f0d-f4ba9ed0a232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924d4025-a6f7-4ab0-8f0d-f4ba9ed0a232.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "53371bce-f282-505b-9c2d-20a42fe22f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988180b-a374-43fd-b299-fb61c781df2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988180b-a374-43fd-b299-fb61c781df2e.jpg?1",
             "name": "Mage-Ring Network",
             "text": "{T}: Add {1} to your mana pool.{1}, {T}: Put a storage counter on Mage-Ring Network.{T}, Remove X storage counters from Mage-Ring Network: Add {X} to your mana pool.",
             "colours": [],
@@ -8491,7 +8491,7 @@
         },
         {
             "id": "67ef7866-693a-5913-9b44-aeae3a2791c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9851abd-ec17-4b97-9e5f-c335985a5f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9851abd-ec17-4b97-9e5f-c335985a5f29.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {1} to your mana pool.{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -8519,7 +8519,7 @@
         },
         {
             "id": "f9eb4a44-74c8-5d35-a618-e6ca763779da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d33afd-6f2a-43c8-ae5d-17a0674fcdd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d33afd-6f2a-43c8-ae5d-17a0674fcdd3.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "4568e2dc-a15c-5f7c-a766-bcab34ae70ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae3d45b-a40c-4003-960a-2d1d0847e750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae3d45b-a40c-4003-960a-2d1d0847e750.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "0b6d0c20-bb81-528d-a19c-9fe2672cc249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f96591-4f22-451e-bfb5-32561cc4640d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f96591-4f22-451e-bfb5-32561cc4640d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "e0278a30-75a6-589c-bb78-d54cb52f043c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763c1eaa-fe29-4b24-8e41-96b94e5a75a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763c1eaa-fe29-4b24-8e41-96b94e5a75a4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8657,7 +8657,7 @@
         },
         {
             "id": "d98ead89-230a-5058-aea8-9175e1d76f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e683531-4a59-4461-b589-5ebcbc51a600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e683531-4a59-4461-b589-5ebcbc51a600.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "9dee799d-6c82-59ab-b6f8-5e35a39fb602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f7329-9c72-4369-8b66-2a89423e957d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f7329-9c72-4369-8b66-2a89423e957d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8733,7 +8733,7 @@
         },
         {
             "id": "cefe7d87-cc29-5b59-8420-f0e6af1c551c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a9df3b-b542-4915-96ac-0c9027f6870a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a9df3b-b542-4915-96ac-0c9027f6870a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "19fb6263-1d04-583e-9472-8e11f26bf10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d88f06-276b-41d4-a4c3-d904f93ea403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d88f06-276b-41d4-a4c3-d904f93ea403.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8809,7 +8809,7 @@
         },
         {
             "id": "3358b305-f87f-518f-ae94-4ec54d8244b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880b12e-948b-4f3a-bb0b-604e3dd66f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880b12e-948b-4f3a-bb0b-604e3dd66f78.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8847,7 +8847,7 @@
         },
         {
             "id": "b67c5fba-a11b-5865-9939-2b7803ad0f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f845b1-3b8a-4387-aae3-fd497acf193c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f845b1-3b8a-4387-aae3-fd497acf193c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8885,7 +8885,7 @@
         },
         {
             "id": "68d5c991-4820-536e-8522-a5b5839d8e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae0b13-c9f6-4659-ba85-a87a81f6e730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae0b13-c9f6-4659-ba85-a87a81f6e730.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8923,7 +8923,7 @@
         },
         {
             "id": "4943314f-2154-5656-b8b1-acdf7c012374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d4e89-93aa-4b1e-84f6-8addef529a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d4e89-93aa-4b1e-84f6-8addef529a3f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8961,7 +8961,7 @@
         },
         {
             "id": "85b6f29e-5a24-599d-af67-32cd17c6b962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63b7238-ebdc-4dd8-b799-1ca33c14163b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63b7238-ebdc-4dd8-b799-1ca33c14163b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "1dcd2b80-bab1-5ae4-b5cf-5b56995d193f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c617c618-8320-4f76-80a6-83581470dc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c617c618-8320-4f76-80a6-83581470dc13.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9037,7 +9037,7 @@
         },
         {
             "id": "76f3c87f-bdf1-52ac-bf29-3cb0cbf0d060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b95522-a9de-4ec1-8158-c66813919e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b95522-a9de-4ec1-8158-c66813919e62.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9075,7 +9075,7 @@
         },
         {
             "id": "a7329794-9209-539d-9d40-40e213cd0e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a0ca9e-c72b-4c99-8e6b-b6dbebf894e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a0ca9e-c72b-4c99-8e6b-b6dbebf894e9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "19069324-7937-5996-9f92-d66b4a26525a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7fe3c3-9cf7-4b73-b2bd-301667a2cd4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7fe3c3-9cf7-4b73-b2bd-301667a2cd4d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "00c38ae0-a771-5f13-9bbb-6cb6e2dbeaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ddd6e0-dbdc-4ce0-bc26-f94c951f90ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ddd6e0-dbdc-4ce0-bc26-f94c951f90ad.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "c847d5c3-927e-58d7-811d-4d2b622984f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ee8330-f1bf-460b-9345-00d08665e9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ee8330-f1bf-460b-9345-00d08665e9cf.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9227,7 +9227,7 @@
         },
         {
             "id": "748ef682-9f98-57dd-8571-8ab37b691d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcdbcd-2c5e-4733-a4c4-c5a345e9206a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcdbcd-2c5e-4733-a4c4-c5a345e9206a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9265,7 +9265,7 @@
         },
         {
             "id": "ea30cff7-8542-59e4-a2a3-37ae6f3f45ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b101184-71b2-4400-a5dc-4113df5a4f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b101184-71b2-4400-a5dc-4113df5a4f12.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9303,7 +9303,7 @@
         },
         {
             "id": "69c7d3e1-5aaa-5d28-9953-c392887d1c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1afc-eb3d-46ba-a645-ab2f33264f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1afc-eb3d-46ba-a645-ab2f33264f36.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "278ab11d-bcfe-518c-a961-5d386300ca74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29edd82c-8d47-4417-85fb-c38a02d7e0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29edd82c-8d47-4417-85fb-c38a02d7e0fa.jpg?1",
             "name": "Aegis Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aegis Angel enters the battlefield, another target permanent gains indestructible for as long as you control Aegis Angel. (Effects that say \"destroy\" don't destroy it. A creature with indestructible can't be destroyed by damage.)",
             "colours": [
@@ -9374,7 +9374,7 @@
         },
         {
             "id": "3592be14-8f09-5092-a4ff-b74ee801f681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1a7b-149d-42ba-aaea-345ccae7227c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1a7b-149d-42ba-aaea-345ccae7227c.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "4edca554-d51e-5936-9834-ba2a9c9aaec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af7956d-f811-49d3-bef7-07f294dcea3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af7956d-f811-49d3-bef7-07f294dcea3c.jpg?1",
             "name": "Eagle of the Watch",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "e9bcbdb3-02f0-571c-a20e-b8394cd972b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740a59f-0a46-4ad2-90a7-ac8c4d753a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740a59f-0a46-4ad2-90a7-ac8c4d753a38.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9471,7 +9471,7 @@
         },
         {
             "id": "1b1a27a4-6b83-5de7-884d-599c3dd22267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236fbb72-3aea-4737-bf90-bd4d4e80b527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236fbb72-3aea-4737-bf90-bd4d4e80b527.jpg?1",
             "name": "Into the Void",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -9502,7 +9502,7 @@
         },
         {
             "id": "87757498-7852-50a9-97a6-1ba26f86c474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1035c7d3-2a5b-4404-93cf-e46abd716a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1035c7d3-2a5b-4404-93cf-e46abd716a10.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "65784727-82d7-5651-a0f5-a638acb71e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e57fc1-1633-447f-ae32-ad7da25a4177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e57fc1-1633-447f-ae32-ad7da25a4177.jpg?1",
             "name": "Weave Fate",
             "text": "Draw two cards.",
             "colours": [
@@ -9566,7 +9566,7 @@
         },
         {
             "id": "b260478c-cfcf-5c06-9147-1cdf79e3418c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4b0f6-fc67-48aa-9f17-21a79bd0c3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4b0f6-fc67-48aa-9f17-21a79bd0c3d3.jpg?1",
             "name": "Flesh to Dust",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "0e7ac756-5951-5209-ac1a-f7fe79f09765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df7f95a-0629-4568-9f0a-9074daa0d743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df7f95a-0629-4568-9f0a-9074daa0d743.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -9628,7 +9628,7 @@
         },
         {
             "id": "0a99f6a8-8915-53e4-9f8b-1050aee8991b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bb40a-3ecd-41eb-acee-819f3138875a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bb40a-3ecd-41eb-acee-819f3138875a.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "a0449452-91d6-5913-bac2-3554044c84d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8926224e-aeae-4e5d-b33f-5bfd5d3766c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8926224e-aeae-4e5d-b33f-5bfd5d3766c1.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -9695,7 +9695,7 @@
         },
         {
             "id": "67952215-a454-533b-a48c-5f9d0466da70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980efa5-bd21-4980-91a7-5e66528b1011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980efa5-bd21-4980-91a7-5e66528b1011.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "f9d28c81-8229-5bf0-8c15-290ec427dfb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fd9b74-8e5b-4c57-bb4f-4a7222183c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fd9b74-8e5b-4c57-bb4f-4a7222183c44.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -9762,7 +9762,7 @@
         },
         {
             "id": "f484fa29-3ab9-5989-b28c-db65fb44bf8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8bee44-410b-46a9-be40-03f000cad9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8bee44-410b-46a9-be40-03f000cad9a9.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -9793,7 +9793,7 @@
         },
         {
             "id": "c07737ba-96b0-5723-89d5-549a3982162b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500c1ede-8f4a-4009-8057-c65411550487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500c1ede-8f4a-4009-8057-c65411550487.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -9826,7 +9826,7 @@
         },
         {
             "id": "515aa243-9a30-5afb-a253-ce3cc6fb7149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652db782-cf79-4626-9eb2-ad214cb39c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652db782-cf79-4626-9eb2-ad214cb39c86.jpg?1",
             "name": "Terra Stomper",
             "text": "Terra Stomper can't be countered.\nTrample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "95e2556c-0b31-5ef9-9640-686913315dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcc7b5-c911-44c9-be5a-087298ddb492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcc7b5-c911-44c9-be5a-087298ddb492.jpg?1",
             "name": "Magic Origins Checklist",
             "text": "",
             "colours": [],
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "a6c0c426-17b4-5e19-b8a1-b5267a1cb3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ce74d5-ec65-44e8-b6c2-3f70b9fc3dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ce74d5-ec65-44e8-b6c2-3f70b9fc3dbb.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9920,7 +9920,7 @@
         },
         {
             "id": "686ad1d7-d846-5ef3-89f4-c46dc7279e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2969b-2176-4471-b316-9c80443866dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2969b-2176-4471-b316-9c80443866dd.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "d9c6c80e-a415-5150-8b2d-a8c4fbc513ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33426f5-59bf-456c-8fff-0ca27eacdef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33426f5-59bf-456c-8fff-0ca27eacdef9.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "3f69c9c3-3b9e-5beb-b792-4edb428294d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14259948-5427-401f-b510-f5b705445e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14259948-5427-401f-b510-f5b705445e50.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "3b49dcde-f310-5692-a8b0-530e880f9769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ccae95-95c2-4d11-aa68-5c80ecf90fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ccae95-95c2-4d11-aa68-5c80ecf90fd2.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -10056,7 +10056,7 @@
         },
         {
             "id": "bbd9e6d6-1bdd-590a-8d07-e373496fd030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21498f5-9098-4e50-b1d3-bd64cba1372a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21498f5-9098-4e50-b1d3-bd64cba1372a.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -10090,7 +10090,7 @@
         },
         {
             "id": "525e7f62-6d27-5a6c-bc83-389625308040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affd414-f774-48d1-af9e-bff74e58e1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affd414-f774-48d1-af9e-bff74e58e1ca.jpg?1",
             "name": "Ashaya, the Awoken World",
             "text": "",
             "colours": [
@@ -10126,7 +10126,7 @@
         },
         {
             "id": "b7d2f111-d79c-5faf-9aa4-99e4ecd723f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7047838-ac9f-4ca1-9827-73d87098124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7047838-ac9f-4ca1-9827-73d87098124f.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10160,7 +10160,7 @@
         },
         {
             "id": "777d0755-3363-520a-91c2-831baaa42bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb75376-3b3c-4957-bf87-952f8cfc1da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb75376-3b3c-4957-bf87-952f8cfc1da7.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -10195,7 +10195,7 @@
         },
         {
             "id": "f2b2fd0e-d051-5d7f-b806-31df0bd1d0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa5fab-1076-443b-ba27-46d10770883d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa5fab-1076-443b-ba27-46d10770883d.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -10226,7 +10226,7 @@
         },
         {
             "id": "53316f3a-2854-52da-826e-8e37dcb53d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa49655-6ce7-404b-ad12-33ec1cd7c0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa49655-6ce7-404b-ad12-33ec1cd7c0d3.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -10257,7 +10257,7 @@
         },
         {
             "id": "2e1d3bd1-27c1-54c5-b479-d914b4693c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458e37b1-a849-41ae-b63c-3e09ffd814e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458e37b1-a849-41ae-b63c-3e09ffd814e4.jpg?1",
             "name": "Jace, Telepath Unbound Emblem",
             "text": "",
             "colours": [],
@@ -10286,7 +10286,7 @@
         },
         {
             "id": "b6b767d0-52a6-598c-997b-6876a92a5a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f984f-2e11-4f52-b3b0-dd9d94a2dd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f984f-2e11-4f52-b3b0-dd9d94a2dd74.jpg?1",
             "name": "Liliana, Defiant Necromancer Emblem",
             "text": "",
             "colours": [],
@@ -10315,7 +10315,7 @@
         },
         {
             "id": "741922f7-81d6-5ee9-b850-6d83d447552e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8123a6-7e7b-49fb-9ebc-19d8150852e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8123a6-7e7b-49fb-9ebc-19d8150852e8.jpg?1",
             "name": "Chandra, Roaring Flame Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/OTJ.json
+++ b/Assets/Resources/Sets/OTJ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c37140a4-32c2-569c-91ca-34fb56a1b6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg?1",
             "name": "Another Round",
             "text": "Exile any number of creatures you control, then return them to the battlefield under their owner's control. Then repeat this process X more times.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "a2ad35c4-afd8-5849-98ba-5b080743f4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853d04c-864b-491c-8c6f-72d2d4874d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853d04c-864b-491c-8c6f-72d2d4874d2f.jpg?1",
             "name": "Archangel of Tithes",
             "text": "Flying\nAs long as Archangel of Tithes is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.\nAs long as Archangel of Tithes is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "6a1018f9-ca3b-5c28-a357-de3e8c3d07da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263232df-69b8-4205-93ad-c724fe57ec11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263232df-69b8-4205-93ad-c724fe57ec11.jpg?1",
             "name": "Armored Armadillo",
             "text": "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n{3}{W}: Armored Armadillo gets +X/+0 until end of turn, where X is its toughness.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "c522e3b4-1d64-5570-9d86-4acb9a9c0866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg?1",
             "name": "Aven Interrupter",
             "text": "Flash\nFlying\nWhen Aven Interrupter enters the battlefield, exile target spell. It becomes plotted. (Its owner may cast it as a sorcery on a later turn without paying its mana cost.)\nSpells your opponents cast from graveyards or from exile cost {2} more to cast.",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "1497f3ae-0a46-5f74-b9e0-f491d103c086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8925279f-c16a-43b4-b791-ce450157275b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8925279f-c16a-43b4-b791-ce450157275b.jpg?1",
             "name": "Bounding Felidar",
             "text": "Whenever Bounding Felidar attacks while saddled, put a +1/+1 counter on each other creature you control. You gain 1 life for each of those creatures.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "aa2b8e61-71ee-546b-945f-47ea47b27ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c36742-456f-4618-99bc-793ef20b31b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c36742-456f-4618-99bc-793ef20b31b0.jpg?1",
             "name": "Bovine Intervention",
             "text": "Destroy target artifact or creature. Its controller creates a 2/2 white Ox creature token.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "343c765c-ea51-57d3-ba6b-76e8ac386f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7bf089-fa9b-4ffc-bf84-45cd51c76463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7bf089-fa9b-4ffc-bf84-45cd51c76463.jpg?1",
             "name": "Bridled Bighorn",
             "text": "Vigilance\nWhenever Bridled Bighorn attacks while saddled, create a 1/1 white Sheep creature token.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "e8fcc9db-12df-5e88-9e2f-806e11f888fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654ade6b-0369-4b90-a744-2f57a45b04f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654ade6b-0369-4b90-a744-2f57a45b04f4.jpg?1",
             "name": "Claim Jumper",
             "text": "Vigilance\nWhen Claim Jumper enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls more lands than you, repeat this process once. If you search your library this way, shuffle.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "b693aa86-708c-5c1a-9b40-1b01e58a8178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70719e7b-6f02-4c1a-9f11-79b2b0d9846a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70719e7b-6f02-4c1a-9f11-79b2b0d9846a.jpg?1",
             "name": "Dust Animus",
             "text": "Flying\nIf you control five or more untapped lands, Dust Animus enters the battlefield with two +1/+1 counters and a lifelink counter on it.\nPlot {1}{W} (You may pay {1}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "96ece353-a301-52f8-a264-4da37b591579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c18b6-40e2-4f7f-a3bb-49bc695b68ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c18b6-40e2-4f7f-a3bb-49bc695b68ec.jpg?1",
             "name": "Eriette's Lullaby",
             "text": "Destroy target tapped creature. You gain 2 life.",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "0810f0e6-58d5-5640-a689-8f2f546cb571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg?1",
             "name": "Final Showdown",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 All creatures lose all abilities until end of turn.\n+ {1} \u2014 Choose a creature you control. It gains indestructible until end of turn.\n+ {3}{W}{W} \u2014 Destroy all creatures.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "d462cafd-04a2-5c14-aeb5-544af545425e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg?1",
             "name": "Fortune, Loyal Steed",
             "text": "When Fortune, Loyal Steed enters the battlefield, scry 2.\nWhenever Fortune attacks while saddled, at end of combat, exile it and up to one creature that saddled it this turn, then return those cards to the battlefield under their owner's control.\nSaddle 1",
             "colours": [
@@ -426,7 +426,7 @@
         },
         {
             "id": "ce9cc7ab-70f6-570a-a7cf-744641a6f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9368cc76-bee5-4b46-a309-981106c3addf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9368cc76-bee5-4b46-a309-981106c3addf.jpg?1",
             "name": "Frontier Seeker",
             "text": "When Frontier Seeker enters the battlefield, look at the top five cards of your library. You may reveal a Mount creature card or a Plains card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "77d1f4b3-c0e2-545a-a17a-0ff90a17c7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69689049-a704-4f16-84ee-4d5d915028ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69689049-a704-4f16-84ee-4d5d915028ec.jpg?1",
             "name": "Getaway Glamer",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\n+ {2} \u2014 Destroy target creature if no other creature has greater power.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "70a4df7f-b92d-54a2-807e-e16cc956cedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9995e0e6-7c9c-4fef-8fd2-8fb1622e6ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9995e0e6-7c9c-4fef-8fd2-8fb1622e6ec8.jpg?1",
             "name": "High Noon",
             "text": "Each player can't cast more than one spell each turn.\n{4}{R}, Sacrifice High Noon: It deals 5 damage to any target.",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "ed997377-d359-5d9e-95f4-56909e4ca8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg?1",
             "name": "Holy Cow",
             "text": "Flash\nFlying\nWhen Holy Cow enters the battlefield, you gain 2 life and scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -565,7 +565,7 @@
         },
         {
             "id": "884f5b9d-b40b-5efa-b14e-d63492096294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b36bb3-dacc-44f6-adcd-2c2d65513d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b36bb3-dacc-44f6-adcd-2c2d65513d8c.jpg?1",
             "name": "Inventive Wingsmith",
             "text": "At the beginning of your end step, if you haven't cast a spell from your hand this turn and Inventive Wingsmith doesn't have a flying counter on it, put a flying counter on it.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "177d4611-57b1-533c-970b-bec08f510d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea96eeac-c316-4247-a81f-0ddf52675ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea96eeac-c316-4247-a81f-0ddf52675ebf.jpg?1",
             "name": "Lassoed by the Law",
             "text": "When Lassoed by the Law enters the battlefield, exile target nonland permanent an opponent controls until Lassoed by the Law leaves the battlefield.\nWhen Lassoed by the Law enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "7c056732-d0e6-5a79-aa19-260a60090352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18344498-952e-489c-8b03-bd1bef4c26ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18344498-952e-489c-8b03-bd1bef4c26ca.jpg?1",
             "name": "Mystical Tether",
             "text": "You may cast Mystical Tether as though it had flash if you pay {2} more to cast it.\nWhen Mystical Tether enters the battlefield, exile target artifact or creature an opponent controls until Mystical Tether leaves the battlefield.",
             "colours": [
@@ -664,7 +664,7 @@
         },
         {
             "id": "41e9d6c6-0f9f-570d-a222-81c567e97ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe155f6-888b-41a0-a9a0-be7bea998718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe155f6-888b-41a0-a9a0-be7bea998718.jpg?1",
             "name": "Nurturing Pixie",
             "text": "Flying\nWhen Nurturing Pixie enters the battlefield, return up to one target non-Faerie, nonland permanent you control to its owner's hand. If a permanent was returned this way, put a +1/+1 counter on Nurturing Pixie.",
             "colours": [
@@ -699,7 +699,7 @@
         },
         {
             "id": "712e70bc-a5ce-52e5-99b5-f0e53c6cf62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecd8b6f-b9aa-466a-909c-3209beef8244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecd8b6f-b9aa-466a-909c-3209beef8244.jpg?1",
             "name": "Omenport Vigilante",
             "text": "Omenport Vigilante has double strike as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "a51a4ab1-4656-58e1-ad6c-15b2380788af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg?1",
             "name": "One Last Job",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Return target creature card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Mount or Vehicle card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Aura or Equipment card from your graveyard to the battlefield attached to a creature you control.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "69494ef0-0b2b-5b5b-b790-cf553e917a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feaa51e-47fb-4849-b420-ee7278f3489a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feaa51e-47fb-4849-b420-ee7278f3489a.jpg?1",
             "name": "Outlaw Medic",
             "text": "Lifelink\nWhen Outlaw Medic dies, draw a card.",
             "colours": [
@@ -803,7 +803,7 @@
         },
         {
             "id": "a7b2612b-16d8-5953-9648-88b7d8594b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37302b5d-e528-4baa-947a-c859e4ddcff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37302b5d-e528-4baa-947a-c859e4ddcff9.jpg?1",
             "name": "Prairie Dog",
             "text": "Lifelink\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, put a +1/+1 counter on Prairie Dog.\n{4}{W}: Until end of turn, if you would put one or more +1/+1 counters on a creature you control, put that many plus one +1/+1 counters on it instead.",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "67338a36-2500-5d2a-a7e6-0a4c2d494aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87824f3-aa9f-4d3d-99f7-0fbca43d8a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87824f3-aa9f-4d3d-99f7-0fbca43d8a51.jpg?1",
             "name": "Prosperity Tycoon",
             "text": "When Prosperity Tycoon enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{2}, Sacrifice a token: Prosperity Tycoon gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -872,7 +872,7 @@
         },
         {
             "id": "20badb60-8b2c-5bf3-8d86-673e2e952bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154e9ba9-0d0e-4b0e-acf2-f66a993cf3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154e9ba9-0d0e-4b0e-acf2-f66a993cf3a2.jpg?1",
             "name": "Requisition Raid",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Destroy target artifact.\n+ {1} \u2014 Destroy target enchantment.\n+ {1} \u2014 Put a +1/+1 counter on each creature target player controls.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "a43cb582-b10c-5181-9176-995ea2b924eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ed7ca3-894b-45f4-a15f-51b6bcd3f474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ed7ca3-894b-45f4-a15f-51b6bcd3f474.jpg?1",
             "name": "Rustler Rampage",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Untap all creatures target player controls.\n+ {1} \u2014 Target creature gains double strike until end of turn.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "1e0fb01e-8d9c-5fdb-828c-2bd9f3a46c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg?1",
             "name": "Shepherd of the Clouds",
             "text": "Flying, vigilance\nWhen Shepherd of the Clouds enters the battlefield, return target permanent card with mana value 3 or less from your graveyard to your hand. Return that card to the battlefield instead if you control a Mount.",
             "colours": [
@@ -970,7 +970,7 @@
         },
         {
             "id": "d92cc6c8-1bee-5dc7-8cef-599643a15827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38a845d-f25d-45ab-9154-3fa5291b0ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38a845d-f25d-45ab-9154-3fa5291b0ba0.jpg?1",
             "name": "Sheriff of Safe Passage",
             "text": "Sheriff of Safe Passage enters the battlefield with a +1/+1 counter on it plus an additional +1/+1 counter on it for each other creature you control.\nPlot {1}{W} (You may pay {1}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1005,7 +1005,7 @@
         },
         {
             "id": "0f8534c3-19d7-59b6-9d73-3751b88663b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21301998-b3e6-4f3d-89f4-5e17aeb79a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21301998-b3e6-4f3d-89f4-5e17aeb79a1e.jpg?1",
             "name": "Stagecoach Security",
             "text": "When Stagecoach Security enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.\nPlot {3}{W} (You may pay {3}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1040,7 +1040,7 @@
         },
         {
             "id": "684ed2ab-db17-5552-a511-d97f6c85aaee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523a4d6e-122b-49b4-bf3d-17d29c0007fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523a4d6e-122b-49b4-bf3d-17d29c0007fb.jpg?1",
             "name": "Steer Clear",
             "text": "Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage to that creature instead if you controlled a Mount as you cast this spell.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "ec54a1af-e697-5576-82af-7e04eb05dfaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019d539f-04c2-43f1-8677-6d6fbb0e94f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019d539f-04c2-43f1-8677-6d6fbb0e94f7.jpg?1",
             "name": "Sterling Keykeeper",
             "text": "{2}, {T}: Tap target non-Mount creature.",
             "colours": [
@@ -1107,7 +1107,7 @@
         },
         {
             "id": "f3d4abb5-dfbe-5ec4-826a-9361ccd8a89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6000be7-67db-440e-87ba-276df20b803e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6000be7-67db-440e-87ba-276df20b803e.jpg?1",
             "name": "Sterling Supplier",
             "text": "Flying\nWhen Sterling Supplier enters the battlefield, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "b237017b-86a9-5768-835c-4881316f4811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a31968-ba6d-4c01-838f-4cb8c64e73fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a31968-ba6d-4c01-838f-4cb8c64e73fb.jpg?1",
             "name": "Take Up the Shield",
             "text": "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "ef992121-be11-5db4-b6e5-106435f9b04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dff5fc-2adf-447a-b35f-e7883e0fd821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dff5fc-2adf-447a-b35f-e7883e0fd821.jpg?1",
             "name": "Thunder Lasso",
             "text": "When Thunder Lasso enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, tap target creature defending player controls.\nEquip {2}",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "c2cf8d16-6fd8-5ddd-b08e-d3d17edca972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32a5f8-f69d-47dc-a800-4f0ddf4eada5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32a5f8-f69d-47dc-a800-4f0ddf4eada5.jpg?1",
             "name": "Trained Arynx",
             "text": "Whenever Trained Arynx attacks while saddled, it gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -1244,7 +1244,7 @@
         },
         {
             "id": "92e61160-4ee0-5e8b-9b83-68f3c2adde3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df404af-571a-4867-83f5-bb4163b433ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df404af-571a-4867-83f5-bb4163b433ff.jpg?1",
             "name": "Vengeful Townsfolk",
             "text": "Whenever one or more other creatures you control die, put a +1/+1 counter on Vengeful Townsfolk.",
             "colours": [
@@ -1279,7 +1279,7 @@
         },
         {
             "id": "739d4ca3-a391-5869-bc0a-4702a4fe358f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624a176b-fe24-4441-8877-464cf172ccff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624a176b-fe24-4441-8877-464cf172ccff.jpg?1",
             "name": "Wanted Griffin",
             "text": "Flying\nWhen Wanted Griffin dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "11aae4e1-7d47-5aca-b22f-932cec3adf44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a440bbd6-8e51-4db1-90d9-7fa9fc327ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a440bbd6-8e51-4db1-90d9-7fa9fc327ad5.jpg?1",
             "name": "Archmage's Newt",
             "text": "Whenever Archmage's Newt deals combat damage to a player, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. That card gains flashback {0} until end of turn instead if Archmage's Newt is saddled. (You may cast that card from your graveyard for its flashback cost. Then exile it.)\nSaddle 3",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "19d12f17-0efa-5c41-bc7b-2c1c7257b086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg?1",
             "name": "Canyon Crab",
             "text": "{1}{U}: Canyon Crab gets +2/-2 until end of turn.\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card, then discard a card.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "59d841f7-75b9-5978-979e-1712e3f778ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a2bf7-248c-4f8b-92ec-3010d276cb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a2bf7-248c-4f8b-92ec-3010d276cb59.jpg?1",
             "name": "Daring Thunder-Thief",
             "text": "Flash\nDaring Thunder-Thief enters the battlefield tapped.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "0e540a3e-e26c-5370-a8ce-108ca1f91d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ee726-7465-40f8-a954-19b19e636c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ee726-7465-40f8-a954-19b19e636c12.jpg?1",
             "name": "Deepmuck Desperado",
             "text": "Whenever you commit a crime, each opponent mills three cards. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "b3ed033c-9928-5a73-8da0-ff232311af60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc6af-c651-485e-a1cc-f9d00aeaf812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc6af-c651-485e-a1cc-f9d00aeaf812.jpg?1",
             "name": "Djinn of Fool's Fall",
             "text": "Flying\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "7c2f8f1d-085e-5cb9-8bc6-018d3ca8c5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg?1",
             "name": "Double Down",
             "text": "Whenever you cast an outlaw spell, copy that spell. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. Copies of permanent spells become tokens.)",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "9496592b-8f9d-523b-b919-a007857fe0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg?1",
             "name": "Duelist of the Mind",
             "text": "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "9812317a-6d92-5a4d-86cc-8dadf4c8c317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623053a8-7abe-45ec-9f26-97e1c037120b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623053a8-7abe-45ec-9f26-97e1c037120b.jpg?1",
             "name": "Emergent Haunting",
             "text": "At the beginning of your end step, if you haven't cast a spell from your hand this turn and Emergent Haunting isn't a creature, it becomes a 3/3 Spirit creature with flying in addition to its other types.\n{2}{U}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "d97b7a59-0a74-57ea-906a-58d6c390f60f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg?1",
             "name": "Failed Fording",
             "text": "Return target nonland permanent to its owner's hand. If you control a Desert, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "75c7b05a-b151-576a-93a9-58af72d42fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg?1",
             "name": "Fblthp, Lost on the Range",
             "text": "Ward {2}\nYou may look at the top card of your library any time.\nThe top card of your library has plot. The plot cost is equal to its mana cost.\nYou may plot nonland cards from the top of your library.",
             "colours": [
@@ -1661,7 +1661,7 @@
         },
         {
             "id": "ff356e23-8293-5f6c-9ebd-82d20539e907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8c931e-219f-4032-b55b-b5975fbea1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8c931e-219f-4032-b55b-b5975fbea1e7.jpg?1",
             "name": "Fleeting Reflection",
             "text": "Target creature you control gains hexproof until end of turn. Untap that creature. Until end of turn, it becomes a copy of up to one other target creature.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "53a66eef-e857-53da-b23c-93a9926f8a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg?1",
             "name": "Geralf, the Fleshwright",
             "text": "Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2 blue and black Zombie Rogue creature token.\nWhenever a Zombie enters the battlefield under your control, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your control this turn.",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "2ddc7d43-db65-5610-a537-2240aea77c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b270377b-33eb-4e5e-9d14-0da2876da74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b270377b-33eb-4e5e-9d14-0da2876da74f.jpg?1",
             "name": "Geyser Drake",
             "text": "Flying\nAs long as it's not your turn, spells you cast cost {1} less to cast.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "5fa1d449-c345-5af9-8749-2e28a7d442e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ca61a9-8938-41bf-bd14-5759f4de6521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ca61a9-8938-41bf-bd14-5759f4de6521.jpg?1",
             "name": "Harrier Strix",
             "text": "Flying\nWhen Harrier Strix enters the battlefield, tap target permanent.\n{2}{U}: Draw a card, then discard a card.",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "d3f0212b-2016-5058-a8cd-35242ab5a24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be8e47-9006-4770-8d99-68a684064a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be8e47-9006-4770-8d99-68a684064a43.jpg?1",
             "name": "Jailbreak Scheme",
             "text": "Spree (Choose one or more additional costs.)\n+ {3} \u2014 Put a +1/+1 counter on target creature. It can't be blocked this turn.\n+ {2} \u2014 Target artifact or creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "72538605-4fd1-5cbf-9899-b4477bb6fbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg?1",
             "name": "The Key to the Vault",
             "text": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "6ca92037-a70d-5450-9ee9-3e418158aa0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f12760-ff07-4c9f-a7a9-1e64bd3a9adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f12760-ff07-4c9f-a7a9-1e64bd3a9adf.jpg?1",
             "name": "Loan Shark",
             "text": "When Loan Shark enters the battlefield, if you've cast two or more spells this turn, draw a card.\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "076c1160-ecd7-545a-a891-d26259f06c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34071884-c5b6-42c0-9eb3-9f32910c29d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34071884-c5b6-42c0-9eb3-9f32910c29d8.jpg?1",
             "name": "Marauding Sphinx",
             "text": "Flying, vigilance, ward {2}\nWhenever you commit a crime, surveil 2. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "3d1ed782-01d7-5395-8e5e-ab08064a111a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd38d922-cfc1-43a8-82d8-5de441c71076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd38d922-cfc1-43a8-82d8-5de441c71076.jpg?1",
             "name": "Metamorphic Blast",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.\n+ {3} \u2014 Target player draws two cards.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "7924ac83-5dff-5071-adac-41b3aea9d0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c74d48-362d-4c3b-9ff7-39bdd19657a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c74d48-362d-4c3b-9ff7-39bdd19657a6.jpg?1",
             "name": "Nimble Brigand",
             "text": "Nimble Brigand can't be blocked if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nWhenever Nimble Brigand deals combat damage to a player, draw a card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "81bfed24-7596-57f1-838d-bd46e239b2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9584f0-55b8-448d-99a7-041934053f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9584f0-55b8-448d-99a7-041934053f42.jpg?1",
             "name": "Outlaw Stitcher",
             "text": "When Outlaw Stitcher enters the battlefield, create a 2/2 blue and black Zombie Rogue creature token, then put two +1/+1 counters on that token for each spell you've cast this turn other than the first.\nPlot {4}{U} (You may pay {4}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "2d4bf343-b85c-5199-9f10-d0df2b9bbd67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae044509-2f31-4506-a124-0e445b7181a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae044509-2f31-4506-a124-0e445b7181a2.jpg?1",
             "name": "Peerless Ropemaster",
             "text": "When Peerless Ropemaster enters the battlefield, return up to one target tapped creature to its owner's hand.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "69fbc8aa-dfed-5977-bc6f-63d79201fdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf4dd1-5468-4594-9c7b-0737610f19d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf4dd1-5468-4594-9c7b-0737610f19d4.jpg?1",
             "name": "Phantom Interference",
             "text": "Spree (Choose one or more additional costs.)\n+ {3} \u2014 Create a 2/2 white Spirit creature token with flying.\n+ {1} \u2014 Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "8dc553c4-5d72-58dc-8d38-9eb0163769fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8c3a0e-d61c-457f-ac85-577d0bb94b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8c3a0e-d61c-457f-ac85-577d0bb94b96.jpg?1",
             "name": "Plan the Heist",
             "text": "Surveil 3 if you have no cards in hand. Then draw three cards. (To surveil 3, look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "9a706878-cb5c-5293-9833-12c50cdfe27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d08008-9272-405e-82ef-566e6d42bb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d08008-9272-405e-82ef-566e6d42bb17.jpg?1",
             "name": "Razzle-Dazzler",
             "text": "Whenever you cast your second spell each turn, put a +1/+1 counter on Razzle-Dazzler. It can't be blocked this turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "f9d66b75-5107-5540-939c-a7d493bf973f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdbdfa8-aa28-4b3d-95e7-3d0e7e37f982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdbdfa8-aa28-4b3d-95e7-3d0e7e37f982.jpg?1",
             "name": "Seize the Secrets",
             "text": "This spell costs {1} less to cast if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nDraw two cards.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "536e7995-ca2b-5808-bffa-6334793c5848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe383-e483-47e7-99d1-991a06b089bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe383-e483-47e7-99d1-991a06b089bc.jpg?1",
             "name": "Shackle Slinger",
             "text": "Whenever you cast your second spell each turn, choose target creature an opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "01fd50d7-744c-5eea-a475-eacd1c2bcdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b8313b-a680-4dca-959a-1a7fa5cb4b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b8313b-a680-4dca-959a-1a7fa5cb4b1b.jpg?1",
             "name": "Shifting Grift",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Exchange control of two target creatures.\n+ {1} \u2014 Exchange control of two target artifacts.\n+ {1} \u2014 Exchange control of two target enchantments.",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "924de6ba-0114-59b0-adb8-0378398b1ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a9464-ce30-4747-874e-3bbf75913081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a9464-ce30-4747-874e-3bbf75913081.jpg?1",
             "name": "Slickshot Lockpicker",
             "text": "When Slickshot Lockpicker enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)\nPlot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "9bfa736a-e982-54d6-99b6-27fbe4f2dd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592ccc36-3d10-4a12-8743-9b300b80cb4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592ccc36-3d10-4a12-8743-9b300b80cb4d.jpg?1",
             "name": "Slickshot Vault-Buster",
             "text": "Vigilance\nSlickshot Vault-Buster gets +2/+0 as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -2346,7 +2346,7 @@
         },
         {
             "id": "964a9642-5928-5e13-8ddf-c1652fb50b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6822d12-1a25-42e7-94cc-71bd29daed93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6822d12-1a25-42e7-94cc-71bd29daed93.jpg?1",
             "name": "Spring Splasher",
             "text": "Whenever Spring Splasher attacks, target creature defending player controls gets -3/-0 until end of turn.",
             "colours": [
@@ -2381,7 +2381,7 @@
         },
         {
             "id": "b1544a73-705c-535d-b6e1-bddb2491bfd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea2054-3d22-42ce-ab50-501ef09c2128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea2054-3d22-42ce-ab50-501ef09c2128.jpg?1",
             "name": "Step Between Worlds",
             "text": "Each player may shuffle their hand and graveyard into their library. Each player who does draws seven cards. Exile Step Between Worlds.\nPlot {4}{U}{U} (You may pay {4}{U}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "fb0d2b4f-9ce4-5967-9ebf-f7b5348c9adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg?1",
             "name": "Stoic Sphinx",
             "text": "Flash\nFlying\nStoic Sphinx has hexproof as long as you haven't cast a spell this turn.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "299c403c-703c-5b8c-93e3-61f17be36427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9c158-0080-427c-8cf9-0289011ea63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9c158-0080-427c-8cf9-0289011ea63e.jpg?1",
             "name": "Stop Cold",
             "text": "Flash\nEnchant artifact or creature\nWhen Stop Cold enters the battlefield, tap enchanted permanent.\nEnchanted permanent loses all abilities and doesn't untap during its controller's untap step.",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "8bf8eb09-86b0-5454-b86d-1898d587565a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fea80c4-923c-40a1-9363-bfa4c267a024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fea80c4-923c-40a1-9363-bfa4c267a024.jpg?1",
             "name": "Take the Fall",
             "text": "Target creature gets -1/-0 until end of turn. It gets -4/-0 until end of turn instead if you control an outlaw. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nDraw a card.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "aae9ae3c-e1a3-5d1e-8b2e-53127ec8c0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg?1",
             "name": "This Town Ain't Big Enough",
             "text": "This spell costs {3} less to cast if it targets a permanent you control.\nReturn up to two target nonland permanents to their owners' hands.",
             "colours": [
@@ -2549,7 +2549,7 @@
         },
         {
             "id": "820ea9bb-3e1d-5ca4-82b4-9f1460c9ad21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg?1",
             "name": "Three Steps Ahead",
             "text": "Spree (Choose one or more additional costs.)\n+ {1}{U} \u2014 Counter target spell.\n+ {3} \u2014 Create a token that's a copy of target artifact or creature you control.\n+ {2} \u2014 Draw two cards, then discard a card.",
             "colours": [
@@ -2583,7 +2583,7 @@
         },
         {
             "id": "ef412910-e80c-5f33-bfb7-27e5301cf510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ec4c6-3332-498f-8b56-d7ad8fc5230c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ec4c6-3332-498f-8b56-d7ad8fc5230c.jpg?1",
             "name": "Visage Bandit",
             "text": "You may have Visage Bandit enter the battlefield as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.\nPlot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "c36d8ad8-c8fa-5f35-a857-e0da039575b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b17d09-974a-4e33-b14d-5fe4230ab241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b17d09-974a-4e33-b14d-5fe4230ab241.jpg?1",
             "name": "Ambush Gigapede",
             "text": "Flash\nWhen Ambush Gigapede enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "28044daa-0445-5f47-99df-d4407f07b09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c26b9-981f-47cf-b0f4-769e788d9537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c26b9-981f-47cf-b0f4-769e788d9537.jpg?1",
             "name": "Binding Negotiation",
             "text": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, they discard it. Otherwise, you may put a face-up exiled card they own into their graveyard.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "cd21e7cd-d035-56b7-8355-61f564cafdb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef10b2ad-9b9b-4c5d-a2c7-3ce742224b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef10b2ad-9b9b-4c5d-a2c7-3ce742224b50.jpg?1",
             "name": "Blacksnag Buzzard",
             "text": "Flying\nBlacksnag Buzzard enters the battlefield with a +1/+1 counter on it if a creature died this turn.\nPlot {1}{B} (You may pay {1}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "458072f4-af39-5ac9-a6a2-36be801e3593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016a750-2a18-4443-a600-957eb4026d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016a750-2a18-4443-a600-957eb4026d3a.jpg?1",
             "name": "Blood Hustler",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Blood Hustler. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n{3}{B}: Target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "cf47982e-0cac-5e9f-97d4-f82d34dd7f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43981b1-60c8-4896-8885-b07e73b99b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43981b1-60c8-4896-8885-b07e73b99b30.jpg?1",
             "name": "Boneyard Desecrator",
             "text": "Menace\n{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Boneyard Desecrator. If an outlaw was sacrificed this way, create a Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "f4409d13-2bcf-5d83-80e0-abdb796c070f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a268ba-c442-4fe4-90b4-2810c8474f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a268ba-c442-4fe4-90b4-2810c8474f4e.jpg?1",
             "name": "Caustic Bronco",
             "text": "Whenever Caustic Bronco attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if Caustic Bronco isn't saddled. Otherwise, each opponent loses that much life.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "602d5db0-db76-5c56-9f36-1eff1c00ad66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f96be9-60fc-4e2f-9172-4cc53c9a095a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f96be9-60fc-4e2f-9172-4cc53c9a095a.jpg?1",
             "name": "Consuming Ashes",
             "text": "Exile target creature. If it had mana value 3 or less, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "6b66e36d-3f74-596a-807e-0c9a4b95cb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8046f892-3317-4ef7-9cf7-97b9060540c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8046f892-3317-4ef7-9cf7-97b9060540c8.jpg?1",
             "name": "Corrupted Conviction",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "58942fdd-7fa7-56a9-9a14-202bea768fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e899e4-e2de-44cf-b6f4-cace8d3770cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e899e4-e2de-44cf-b6f4-cace8d3770cb.jpg?1",
             "name": "Desert's Due",
             "text": "Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn for each Desert you control.",
             "colours": [
@@ -2922,7 +2922,7 @@
         },
         {
             "id": "3201e863-3773-54fd-a132-0f4bcfa2793a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59da027-b5dd-4920-b3a1-9da05fcb1977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59da027-b5dd-4920-b3a1-9da05fcb1977.jpg?1",
             "name": "Desperate Bloodseeker",
             "text": "Lifelink\nWhen Desperate Bloodseeker enters the battlefield, target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "9903673d-aed5-5497-9099-2e233efed4b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a17ab9-13c9-41d4-a143-82d8caacfd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a17ab9-13c9-41d4-a143-82d8caacfd8b.jpg?1",
             "name": "Fake Your Own Death",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control and you create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "14db4347-7490-512e-acd9-c1799fb8338a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1679f74d-00f8-436c-9f8c-aa3f843a546c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1679f74d-00f8-436c-9f8c-aa3f843a546c.jpg?1",
             "name": "Forsaken Miner",
             "text": "Forsaken Miner can't block.\nWhenever you commit a crime, you may pay {B}. If you do, return Forsaken Miner from your graveyard to the battlefield. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3023,7 +3023,7 @@
         },
         {
             "id": "da46f56f-f4a8-58de-8a30-f6bd1de92add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg?1",
             "name": "Gisa, the Hellraiser",
             "text": "Ward\u2014{2}, Pay 2 life.\nSkeletons and Zombies you control get +1/+1 and have menace.\nWhenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3062,7 +3062,7 @@
         },
         {
             "id": "eafef7bc-5a53-5844-92db-a6135d745217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2913d5-57c7-4f9b-bc96-8a46beef2563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2913d5-57c7-4f9b-bc96-8a46beef2563.jpg?1",
             "name": "Hollow Marauder",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nFlying\nWhen Hollow Marauder enters the battlefield, any number of target opponents each discard a card. For each of those opponents who didn't discard a card with mana value 4 or greater, draw a card.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "19a0e48f-977e-5d00-9ff1-248205c82d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a108b0e4-1b43-4659-9e91-facb0bd57ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a108b0e4-1b43-4659-9e91-facb0bd57ebb.jpg?1",
             "name": "Insatiable Avarice",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Search your library for a card, then shuffle and put that card on top.\n+ {B}{B} \u2014 Target player draws three cards and loses 3 life.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "dd1288f4-e995-5448-b1c2-6ce723204fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3affc1-be42-48c7-89ff-b59550ff278c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3affc1-be42-48c7-89ff-b59550ff278c.jpg?1",
             "name": "Kaervek, the Punisher",
             "text": "Whenever you commit a crime, exile up to one target black card from your graveyard and copy it. You may cast the copy. If you do, you lose 2 life. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime. Copies of permanent spells become tokens.)",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "0c0b4521-119f-53e4-a771-25da52d0d891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35a0d3-12f7-46f3-a6b3-02a490d45ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35a0d3-12f7-46f3-a6b3-02a490d45ca0.jpg?1",
             "name": "Lively Dirge",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Search your library for a card, put it into your graveyard, then shuffle.\n+ {2} \u2014 Return up to two creature cards with total mana value 4 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "b5f09746-5bdb-5c26-b0e2-f8e3777a9d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg?1",
             "name": "Mourner's Surprise",
             "text": "Return up to one target creature card from your graveyard to your hand. Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "74ae85d2-2a95-5285-a5e9-26900c8a890f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f1a481-598e-4e05-8471-eedb12a39022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f1a481-598e-4e05-8471-eedb12a39022.jpg?1",
             "name": "Neutralize the Guards",
             "text": "Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "20b47c0b-56ca-5d0e-8da6-cea2cdbb3c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0095b-6136-4368-94cb-4c82621aaf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0095b-6136-4368-94cb-4c82621aaf37.jpg?1",
             "name": "Nezumi Linkbreaker",
             "text": "When Nezumi Linkbreaker dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "79215d9e-0266-5105-8492-a1f19d0158a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce57d977-e9c5-4ed1-915f-cdc90a54f8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce57d977-e9c5-4ed1-915f-cdc90a54f8f8.jpg?1",
             "name": "Overzealous Muscle",
             "text": "Whenever you commit a crime during your turn, Overzealous Muscle gains indestructible until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime. Damage and effects that say \"destroy\" don't destroy a creature with indestructible.)",
             "colours": [
@@ -3336,7 +3336,7 @@
         },
         {
             "id": "d5cf3da4-2a91-51be-a065-6b22934b5240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa76fc45-a106-4dc9-9d44-a005eaa2784d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa76fc45-a106-4dc9-9d44-a005eaa2784d.jpg?1",
             "name": "Pitiless Carnage",
             "text": "Sacrifice any number of permanents you control, then draw that many cards.\nPlot {1}{B}{B} (You may pay {1}{B}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "b12f0d60-c321-5524-b4db-d0ba82d663b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f64358-58db-40ab-90e8-6137c3bd0a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f64358-58db-40ab-90e8-6137c3bd0a29.jpg?1",
             "name": "Rakish Crew",
             "text": "When Rakish Crew enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nWhenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "19f4e294-f519-5be6-8e60-5ef70c9a7dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a88e233-f09c-49e7-b1e3-386fba851fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a88e233-f09c-49e7-b1e3-386fba851fdf.jpg?1",
             "name": "Rattleback Apothecary",
             "text": "Deathtouch\nWhenever you commit a crime, target creature you control gains your choice of menace or lifelink until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "22fa3f91-71da-579b-801b-d028f1ce2df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2df3cb4-1658-450a-912a-df336706acdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2df3cb4-1658-450a-912a-df336706acdc.jpg?1",
             "name": "Raven of Fell Omens",
             "text": "Flying\nWhenever you commit a crime, each opponent loses 1 life and you gain 1 life. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "2ca6b276-df48-572a-8f6e-cfae9c3dc73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252def94-2d89-48f7-8ff7-9c8682ca3ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252def94-2d89-48f7-8ff7-9c8682ca3ec6.jpg?1",
             "name": "Rictus Robber",
             "text": "When Rictus Robber enters the battlefield, if a creature died this turn, create a 2/2 blue and black Zombie Rogue creature token.\nPlot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "904eda09-24b3-56e2-85cb-fca8b48f491f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg?1",
             "name": "Rooftop Assassin",
             "text": "Flash\nFlying, lifelink\nWhen Rooftop Assassin enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "959a2a52-24b5-5a91-8858-82a58184ef7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg?1",
             "name": "Rush of Dread",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Target opponent sacrifices half the creatures they control, rounded up.\n+ {2} \u2014 Target opponent discards half the cards in their hand, rounded up.\n+ {2} \u2014 Target opponent loses half their life, rounded up.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "c11a289f-a96f-55e6-bf26-fb622328b963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c98650-b195-4071-8e02-4df35fddddc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c98650-b195-4071-8e02-4df35fddddc7.jpg?1",
             "name": "Servant of the Stinger",
             "text": "Deathtouch\nWhenever Servant of the Stinger deals combat damage to a player, if you've committed a crime this turn, you may sacrifice Servant of the Stinger. If you do, search your library for a card, put it into your hand, then shuffle. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "a958174b-65c3-58f1-9f57-74f56db630de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d6528-c524-4bb8-8a72-b3775cd2c177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d6528-c524-4bb8-8a72-b3775cd2c177.jpg?1",
             "name": "Shoot the Sheriff",
             "text": "Destroy target non-outlaw creature. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. Everyone else is fair game.)",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "fa250655-a455-527e-903a-9e2616ed8b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03709166-164a-4075-ad0d-ea3b516ab771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03709166-164a-4075-ad0d-ea3b516ab771.jpg?1",
             "name": "Skulduggery",
             "text": "Until end of turn, target creature you control gets +1/+1 and target creature an opponent controls gets -1/-1.",
             "colours": [
@@ -3674,7 +3674,7 @@
         },
         {
             "id": "243d9946-dd04-5abc-bc6f-8b3bcc1d173e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5724a15f-0ba0-421a-9cd4-a2b701e6141f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5724a15f-0ba0-421a-9cd4-a2b701e6141f.jpg?1",
             "name": "Tinybones Joins Up",
             "text": "When Tinybones Joins Up enters the battlefield, any number of target players each discard a card.\nWhenever a legendary creature enters the battlefield under your control, any number of target players each mill a card and lose 1 life.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "d9ddb794-3cb2-5a53-97d2-20375d1c607d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg?1",
             "name": "Tinybones, the Pickpocket",
             "text": "Deathtouch\nWhenever Tinybones, the Pickpocket deals combat damage to a player, you may cast target nonland permanent card from that player's graveyard, and mana of any type can be spent to cast that spell.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "2c99a4f4-38f5-5cd2-8ca2-d37e3d156987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88df498-147c-4609-8a94-d8d10a87e37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88df498-147c-4609-8a94-d8d10a87e37c.jpg?1",
             "name": "Treasure Dredger",
             "text": "{1}, {T}, Pay 1 life: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3784,7 +3784,7 @@
         },
         {
             "id": "4226ccf9-eba2-5f5f-a3e9-43ed1dc31903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5a25d9-926e-4004-8830-2b2bf7bc0775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5a25d9-926e-4004-8830-2b2bf7bc0775.jpg?1",
             "name": "Unfortunate Accident",
             "text": "Spree (Choose one or more additional costs.)\n+ {2}{B} \u2014 Destroy target creature.\n+ {1} \u2014 Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "e6b1f987-c445-5b6b-a3a6-d1875c277e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e56a8df-db04-4a88-a5ab-6954d3449976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e56a8df-db04-4a88-a5ab-6954d3449976.jpg?1",
             "name": "Unscrupulous Contractor",
             "text": "When Unscrupulous Contractor enters the battlefield, you may sacrifice a creature. When you do, target player draws two cards and loses 2 life.\nPlot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "a992f77b-6dbf-5d0d-a328-87491eb2318b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg?1",
             "name": "Vadmir, New Blood",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Vadmir, New Blood. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nAs long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "7ee68dd0-6334-53a8-81e6-7c606df64c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6bf35c-8763-47cc-ab2d-5dbabeb28072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6bf35c-8763-47cc-ab2d-5dbabeb28072.jpg?1",
             "name": "Vault Plunderer",
             "text": "When Vault Plunderer enters the battlefield, target player draws a card and loses 1 life.",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "8b244098-b156-5bd8-ae32-a19541db894f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd13011e-a4fc-4107-988f-60cfc851ecd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd13011e-a4fc-4107-988f-60cfc851ecd3.jpg?1",
             "name": "Brimstone Roundup",
             "text": "Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "b0975e45-5440-59ea-bb91-0e655e67b973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a70f5a-2056-4c26-b6ea-9f751b5d0d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a70f5a-2056-4c26-b6ea-9f751b5d0d8c.jpg?1",
             "name": "Calamity, Galloping Inferno",
             "text": "Haste\nWhenever Calamity, Galloping Inferno attacks while saddled, choose a nonlegendary creature that saddled it this turn and create a tapped and attacking token that's a copy of it. Sacrifice that token at the beginning of the next end step. Repeat this process once.\nSaddle 1",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "94c21e52-cec6-59ba-a2be-a8554161bcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd0c4-509e-49c2-ad57-f772efcbc207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd0c4-509e-49c2-ad57-f772efcbc207.jpg?1",
             "name": "Caught in the Crossfire",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Caught in the Crossfire deals 2 damage to each outlaw creature. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\n+ {1} \u2014 Caught in the Crossfire deals 2 damage to each non-outlaw creature.",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "9d88191c-9797-57e0-bfbc-bdb4f46618c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ac6ea-c67b-4f90-be4f-aa25882f5794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ac6ea-c67b-4f90-be4f-aa25882f5794.jpg?1",
             "name": "Cunning Coyote",
             "text": "Haste\nWhen Cunning Coyote enters the battlefield, another target creature you control gets +1/+1 and gains haste until end of turn.\nPlot {1}{R} (You may pay {1}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4062,7 +4062,7 @@
         },
         {
             "id": "bf4c3a0a-8921-5efc-911d-fde99e6e07c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a50b7a-8741-4520-8d45-8e6b128c2628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a50b7a-8741-4520-8d45-8e6b128c2628.jpg?1",
             "name": "Deadeye Duelist",
             "text": "Reach\n{1}, {T}: Deadeye Duelist deals 1 damage to target opponent.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "e96e8787-776d-55d9-9ee1-9422a02656eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b491d11-d00a-4541-8389-2785a455eeee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b491d11-d00a-4541-8389-2785a455eeee.jpg?1",
             "name": "Demonic Ruckus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has menace and trample.\nWhen Demonic Ruckus is put into a graveyard from the battlefield, draw a card.\nPlot {R} (You may pay {R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4131,7 +4131,7 @@
         },
         {
             "id": "be96c593-34aa-5712-a02a-a05508f0efa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b359bf-afd8-439d-a4d2-985db1ad368c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b359bf-afd8-439d-a4d2-985db1ad368c.jpg?1",
             "name": "Discerning Peddler",
             "text": "When Discerning Peddler enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "0fb87202-3591-59e3-951b-41d1ab9e0359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3df9c-0a86-4e6f-a3c7-84a883328a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3df9c-0a86-4e6f-a3c7-84a883328a3d.jpg?1",
             "name": "Explosive Derailment",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Explosive Derailment deals 4 damage to target creature.\n+ {2} \u2014 Destroy target artifact.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "89a27db3-ed47-5fb9-839e-ffa800155ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db4260-6fc8-4500-afd7-2c845ac0d53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db4260-6fc8-4500-afd7-2c845ac0d53b.jpg?1",
             "name": "Ferocification",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Target creature you control gets +2/+0 until end of turn.\n\u2022 Target creature you control gains menace and haste until end of turn.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "d2680cfd-aa73-5141-b542-d83a1a8af9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f568803d-65c0-48d7-916f-671267a9e00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f568803d-65c0-48d7-916f-671267a9e00e.jpg?1",
             "name": "Gila Courser",
             "text": "Whenever Gila Courser attacks while saddled, exile the top card of your library. Until the end of your next turn, you may play that card.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "42bd71ea-2aeb-507c-ad1e-6f910a8a9214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg?1",
             "name": "Great Train Heist",
             "text": "Spree (Choose one or more additional costs.)\n+ {2}{R} \u2014 Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.\n+ {2} \u2014 Creatures you control get +1/+0 and gain first strike until end of turn.\n+ {R} \u2014 Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
             "colours": [
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "0cb24618-20b3-58f2-a371-5f64181efdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ad8ed7-1429-432e-8217-a4db3b97675c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ad8ed7-1429-432e-8217-a4db3b97675c.jpg?1",
             "name": "Hell to Pay",
             "text": "Hell to Pay deals X damage to target creature. Create a number of tapped Treasure tokens equal to the amount of excess damage dealt to that creature this way.",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "d55389b5-2b38-5ae8-8759-751020b80d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg?1",
             "name": "Hellspur Brute",
             "text": "Affinity for outlaws (This spell costs {1} less to cast for each Assassin, Mercenary, Pirate, Rogue, and/or Warlock you control.)\nTrample",
             "colours": [
@@ -4368,7 +4368,7 @@
         },
         {
             "id": "4d1bf2c3-2c2d-51ee-a554-296ace176e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg?1",
             "name": "Hellspur Posse Boss",
             "text": "Other outlaws you control have haste. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhen Hellspur Posse Boss enters the battlefield, create two 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "dee70ef4-0b0c-5955-a9fd-22449c872654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a88429-9204-4a23-a7a8-babbd6bab79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a88429-9204-4a23-a7a8-babbd6bab79f.jpg?1",
             "name": "Highway Robbery",
             "text": "You may discard a card or sacrifice a land. If you do, draw two cards.\nPlot {1}{R} (You may pay {1}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "0d0a0017-bc07-5bc7-9680-4a27d92fc786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c0af5-7cdf-4c71-84cc-6349f10e0d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c0af5-7cdf-4c71-84cc-6349f10e0d66.jpg?1",
             "name": "Irascible Wolverine",
             "text": "When Irascible Wolverine enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "d2c8c94a-bdf6-55fc-bb78-c02fe11489b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg?1",
             "name": "Iron-Fist Pulverizer",
             "text": "Reach\nWhenever you cast your second spell each turn, Iron-Fist Pulverizer deals 2 damage to target opponent. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "388232c7-9abc-5883-8461-0a2a48480345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398d9a16-d72c-42e2-a0ea-d9da642ee046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398d9a16-d72c-42e2-a0ea-d9da642ee046.jpg?1",
             "name": "Longhorn Sharpshooter",
             "text": "Reach\nWhen Longhorn Sharpshooter becomes plotted, it deals 2 damage to any target.\nPlot {3}{R} (You may pay {3}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "62c7bde6-8890-5a3d-ba91-71a3376b6a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg?1",
             "name": "Magda, the Hoardmaster",
             "text": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
             "colours": [
@@ -4581,7 +4581,7 @@
         },
         {
             "id": "256c420d-bdc5-5545-a080-fcc028457570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e12566-375f-4f31-aa91-1b13a96d9ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e12566-375f-4f31-aa91-1b13a96d9ece.jpg?1",
             "name": "Magebane Lizard",
             "text": "Whenever a player casts a noncreature spell, Magebane Lizard deals damage to that player equal to the number of noncreature spells they've cast this turn.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "5c86e367-0ceb-510c-ba3a-0e9ff384ca1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cfacff-e884-4954-aa6b-ed56ca942bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cfacff-e884-4954-aa6b-ed56ca942bf2.jpg?1",
             "name": "Mine Raider",
             "text": "Trample\nWhen Mine Raider enters the battlefield, if you control another outlaw, create a Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. A Treasure token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "c30baed6-3dfe-5973-bcdf-571d5d9eefdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7502b9c-b759-499a-8e94-22f87f5eb142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7502b9c-b759-499a-8e94-22f87f5eb142.jpg?1",
             "name": "Outlaws' Fury",
             "text": "Creatures you control get +2/+0 until end of turn. If you control an outlaw, exile the top card of your library. Until the end of your next turn, you may play that card. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "150a939e-c2f4-52f8-9836-35c3cea52a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70f2278-8857-46e4-aa2b-fff5589b750f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70f2278-8857-46e4-aa2b-fff5589b750f.jpg?1",
             "name": "Prickly Pair",
             "text": "When Prickly Pair enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "fb2a8220-32ba-51f2-8252-6b01d57e8866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56399cd0-1214-42b6-be38-f2cbd770915f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56399cd0-1214-42b6-be38-f2cbd770915f.jpg?1",
             "name": "Quick Draw",
             "text": "Target creature you control gets +1/+1 and gains first strike until end of turn. Creatures target opponent controls lose first strike and double strike until end of turn.",
             "colours": [
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "e4f1971d-444e-5f6f-a265-30f4642f28f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e326c4-39f1-41ee-9e47-ebe468c51718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e326c4-39f1-41ee-9e47-ebe468c51718.jpg?1",
             "name": "Quilled Charger",
             "text": "Whenever Quilled Charger attacks while saddled, it gets +1/+2 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4784,7 +4784,7 @@
         },
         {
             "id": "ad518202-cd35-53ab-863d-a86bbe76cac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912fcd14-5e81-418c-997b-771f2f38f63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912fcd14-5e81-418c-997b-771f2f38f63d.jpg?1",
             "name": "Reckless Lackey",
             "text": "First strike, haste\n{2}{R}, Sacrifice Reckless Lackey: Draw a card and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4819,7 +4819,7 @@
         },
         {
             "id": "48150d54-e1f8-5d55-9400-15da6c1c3b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07d3ee9-d3c4-4f07-839e-ec81c2587ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07d3ee9-d3c4-4f07-839e-ec81c2587ae0.jpg?1",
             "name": "Resilient Roadrunner",
             "text": "Haste, protection from Coyotes\n{3}: Resilient Roadrunner can't be blocked this turn except by creatures with haste.",
             "colours": [
@@ -4853,7 +4853,7 @@
         },
         {
             "id": "3c810e8f-418b-5a55-87d1-2a870db401d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc02d1-799d-42aa-9bc2-4c05452b63b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc02d1-799d-42aa-9bc2-4c05452b63b4.jpg?1",
             "name": "Return the Favor",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Copy target instant spell, sorcery spell, activated ability, or triggered ability. You may choose new targets for the copy.\n+ {1} \u2014 Change the target of target spell or ability with a single target.",
             "colours": [
@@ -4885,7 +4885,7 @@
         },
         {
             "id": "7c25120e-86aa-50bb-bb5c-eef189e2b96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df877a29-06e1-474d-8600-410bbec674ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df877a29-06e1-474d-8600-410bbec674ae.jpg?1",
             "name": "Rodeo Pyromancers",
             "text": "Whenever you cast your first spell each turn, add {R}{R}.",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "df6315ca-23a5-5738-aa05-c37c21a08c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d603c00f-048a-4a05-9df9-52844819d523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d603c00f-048a-4a05-9df9-52844819d523.jpg?1",
             "name": "Scalestorm Summoner",
             "text": "Whenever Scalestorm Summoner attacks, create a 3/1 red Dinosaur creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "f759dba3-5b11-5765-bce1-36996cd4e1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d8357-83bd-4157-a389-68e4aa4985c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d8357-83bd-4157-a389-68e4aa4985c8.jpg?1",
             "name": "Scorching Shot",
             "text": "Scorching Shot deals 5 damage to target creature.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "4e5c20d3-bcfd-5b04-95c5-d3f203dd1261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054012b-4f9d-44a0-aaf9-7fd3bddc7b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054012b-4f9d-44a0-aaf9-7fd3bddc7b2d.jpg?1",
             "name": "Slickshot Show-Off",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, Slickshot Show-Off gets +2/+0 until end of turn.\nPlot {1}{R} (You may pay {1}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "8fe466c5-73cf-5801-8025-beee6a65370b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg?1",
             "name": "Stingerback Terror",
             "text": "Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "f66d7854-f546-5640-beb3-d6b86bcc5afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e2ff9c-0e98-46f9-a33c-739388c5f3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e2ff9c-0e98-46f9-a33c-739388c5f3d0.jpg?1",
             "name": "Take for a Ride",
             "text": "Take for a Ride has flash as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "1b5a18af-6f45-5e20-8e22-90f48d389774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ff94a-4db4-44a6-8593-89c32905b3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ff94a-4db4-44a6-8593-89c32905b3fc.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -5131,7 +5131,7 @@
         },
         {
             "id": "579da7ae-33cb-53f9-af34-fef8cb82a9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bf0ea9-0929-4d33-815a-6df29c399e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bf0ea9-0929-4d33-815a-6df29c399e7e.jpg?1",
             "name": "Thunder Salvo",
             "text": "Thunder Salvo deals X damage to target creature, where X is 2 plus the number of other spells you've cast this turn.",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "0577fa46-115e-5605-8710-4d5da5ea2ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3c2d02-67ca-4858-9b7a-3cfe8a08356c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3c2d02-67ca-4858-9b7a-3cfe8a08356c.jpg?1",
             "name": "Trick Shot",
             "text": "Trick Shot deals 6 damage to target creature and 2 damage to up to one other target creature token.",
             "colours": [
@@ -5195,7 +5195,7 @@
         },
         {
             "id": "5f9dbd63-183e-5ebe-9cfb-dcd09825be23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f2f632-b6cc-4092-acd5-a6b152e90488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f2f632-b6cc-4092-acd5-a6b152e90488.jpg?1",
             "name": "Aloe Alchemist",
             "text": "Trample\nWhen Aloe Alchemist becomes plotted, target creature gets +3/+2 and gains trample until end of turn.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "506621c5-5e9c-576f-8868-b9b0dea3cacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424972d6-3b2c-449b-b786-749a77020fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424972d6-3b2c-449b-b786-749a77020fa1.jpg?1",
             "name": "Ankle Biter",
             "text": "Deathtouch",
             "colours": [
@@ -5264,7 +5264,7 @@
         },
         {
             "id": "8869ee04-278a-5126-aea3-56ebdfa535c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073b9ae8-8ac3-4824-aec4-84a80531aa23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073b9ae8-8ac3-4824-aec4-84a80531aa23.jpg?1",
             "name": "Beastbond Outcaster",
             "text": "When Beastbond Outcaster enters the battlefield, if you control a creature with power 4 or greater, draw a card.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "44a33d09-096e-5c53-993c-b67b71f29679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c494820f-607d-4ed2-8a86-a916ae390272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c494820f-607d-4ed2-8a86-a916ae390272.jpg?1",
             "name": "Betrayal at the Vault",
             "text": "Target creature you control deals damage equal to its power to each of two other target creatures.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "8a6aaa2d-cd1a-5fee-9d16-2b58fae1ce51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aea6702-16a8-4073-9c83-fbea20a5fd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aea6702-16a8-4073-9c83-fbea20a5fd32.jpg?1",
             "name": "Bristlepack Sentry",
             "text": "Defender\nAs long as you control a creature with power 4 or greater, Bristlepack Sentry can attack as though it didn't have defender.",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "07c179ee-cccc-5809-a585-ec77cfced29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg?1",
             "name": "Bristly Bill, Spine Sower",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature.\n{3}{G}{G}: Double the number of +1/+1 counters on each creature you control.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "49f804f2-54ad-5a1a-890c-9279be7b7fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0e27f9-dc2c-4366-b810-3e8d0bdff8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0e27f9-dc2c-4366-b810-3e8d0bdff8c3.jpg?1",
             "name": "Cactarantula",
             "text": "This spell costs {1} less to cast if you control a Desert.\nReach\nWhenever Cactarantula becomes the target of a spell or ability an opponent controls, you may draw a card.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "36b94fee-df97-5220-8c47-fc457e47fa1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a104d3-e4ac-44a0-9c6a-39965b1b9751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a104d3-e4ac-44a0-9c6a-39965b1b9751.jpg?1",
             "name": "Colossal Rattlewurm",
             "text": "Colossal Rattlewurm has flash as long as you control a Desert.\nTrample\n{1}{G}, Exile Colossal Rattlewurm from your graveyard: Search your library for a Desert card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "e4d8a4d3-7563-5edb-af70-7ced3411d419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf0e715-befb-4904-82e6-d3f8c7fbd454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf0e715-befb-4904-82e6-d3f8c7fbd454.jpg?1",
             "name": "Dance of the Tumbleweeds",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.\n+ {3} \u2014 Create an X/X green Elemental creature token, where X is the number of lands you control.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "8b988ca8-0f5b-56c9-b025-3048141e798c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg?1",
             "name": "Drover Grizzly",
             "text": "Whenever Drover Grizzly attacks while saddled, creatures you control gain trample until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "dea1e717-4486-5f00-a209-393b50a2ef63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92762169-095e-46e2-82f6-5b2ff2232240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92762169-095e-46e2-82f6-5b2ff2232240.jpg?1",
             "name": "Freestrider Commando",
             "text": "Freestrider Commando enters the battlefield with two +1/+1 counters on it if it wasn't cast or no mana was spent to cast it.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "a5b0270e-8e2c-5772-a16b-4edf0791ee9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32370f05-52a2-405f-b2bb-1b8a9b0b69f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32370f05-52a2-405f-b2bb-1b8a9b0b69f8.jpg?1",
             "name": "Freestrider Lookout",
             "text": "Reach\nWhenever you commit a crime, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -5615,7 +5615,7 @@
         },
         {
             "id": "6265f979-8f66-5fb0-8b36-3e86e0321f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084748d8-7169-4e86-a69c-631c6d7d3a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084748d8-7169-4e86-a69c-631c6d7d3a1e.jpg?1",
             "name": "Full Steam Ahead",
             "text": "Until end of turn, each creature you control gets +2/+2 and gains trample and \"This creature can't be blocked by more than one creature.\"",
             "colours": [
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "5da250e3-57fe-52e7-a3a5-ff2c4fb3c7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg?1",
             "name": "Giant Beaver",
             "text": "Vigilance\nWhenever Giant Beaver attacks while saddled, put a +1/+1 counter on target creature that saddled it this turn.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "940ca68c-b30a-52e3-a12f-af9e2e7e4407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15845be1-919d-4450-9de6-3552c52e8623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15845be1-919d-4450-9de6-3552c52e8623.jpg?1",
             "name": "Gold Rush",
             "text": "Create a Treasure token. Until end of turn, up to one target creature gets +2/+2 for each Treasure you control.",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "9afba958-eb26-5d06-af49-0cd814519c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0e01e4-e143-47fd-8565-7b48219bb546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0e01e4-e143-47fd-8565-7b48219bb546.jpg?1",
             "name": "Goldvein Hydra",
             "text": "Vigilance, trample, haste\nGoldvein Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Goldvein Hydra dies, create a number of tapped Treasure tokens equal to its power.",
             "colours": [
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "2ccd127c-f8c0-5772-8c5e-3be57163de3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe544fb-93b7-4640-b886-cb0b3e437357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe544fb-93b7-4640-b886-cb0b3e437357.jpg?1",
             "name": "Hardbristle Bandit",
             "text": "{T}: Add one mana of any color.\nWhenever you commit a crime, untap Hardbristle Bandit. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "cde225f0-bb16-535c-8362-2c8e1b38bbe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cdf2a-026a-41ba-87d9-8fcd8a67f06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cdf2a-026a-41ba-87d9-8fcd8a67f06e.jpg?1",
             "name": "Intrepid Stablemaster",
             "text": "Reach\n{T}: Add {G}.\n{T}: Add two mana of any one color. Spend this mana only to cast Mount or Vehicle spells.",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "11b0c798-f40b-57bf-97be-40b191741428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165f4428-e1a1-477d-bd90-138189e88163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165f4428-e1a1-477d-bd90-138189e88163.jpg?1",
             "name": "Map the Frontier",
             "text": "Search your library for up to two basic land cards and/or Desert cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "7e8cc9df-0abe-5bc7-b4c4-ef443f842aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020c31b-002a-4121-bc61-2c2c16e9afc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020c31b-002a-4121-bc61-2c2c16e9afc8.jpg?1",
             "name": "Ornery Tumblewagg",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature.\nWhenever Ornery Tumblewagg attacks while saddled, double the number of +1/+1 counters on target creature.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "155b13f5-3924-5b18-876f-32d8aadcc27b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9458f0f-5593-4ac9-934c-e215ef8093a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9458f0f-5593-4ac9-934c-e215ef8093a7.jpg?1",
             "name": "Outcaster Greenblade",
             "text": "When Outcaster Greenblade enters the battlefield, search your library for a basic land card or a Desert card, reveal it, put it into your hand, then shuffle.\nOutcaster Greenblade gets +1/+1 for each Desert you control.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "e2312b37-e75b-5d7e-8176-c469f3b69381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b9cd6c-d75c-4905-aa38-ff03a9c4b398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b9cd6c-d75c-4905-aa38-ff03a9c4b398.jpg?1",
             "name": "Outcaster Trailblazer",
             "text": "When Outcaster Trailblazer enters the battlefield, add one mana of any color.\nWhenever another creature with power 4 or greater enters the battlefield under your control, draw a card.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5961,7 +5961,7 @@
         },
         {
             "id": "7f11140c-02fd-5819-8c37-0e60be9b0dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd17cea-9e8c-4dba-b6ab-a6b9de87a306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd17cea-9e8c-4dba-b6ab-a6b9de87a306.jpg?1",
             "name": "Patient Naturalist",
             "text": "When Patient Naturalist enters the battlefield, mill three cards. Put a land card from among the milled cards into your hand. If you can't, create a Treasure token. (To mill three cards, put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -5996,7 +5996,7 @@
         },
         {
             "id": "15ad0296-af37-5345-b1fe-98eb73c0bd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec1f76f-f21d-4f06-8c02-be6745183348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec1f76f-f21d-4f06-8c02-be6745183348.jpg?1",
             "name": "Railway Brawler",
             "text": "Reach, trample\nWhenever another creature enters the battlefield under your control, put X +1/+1 counters on it, where X is its power.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "f7aab77f-5824-5f00-a0b1-5f267c753446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1e75f-0fee-4e07-9420-df771b696e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1e75f-0fee-4e07-9420-df771b696e85.jpg?1",
             "name": "Rambling Possum",
             "text": "Whenever Rambling Possum attacks while saddled, it gets +1/+2 until end of turn. Then you may return any number of creatures that saddled it this turn to their owner's hand.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6068,7 +6068,7 @@
         },
         {
             "id": "2aed3065-a688-557e-a5c3-64bd7097c392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3cbfe-410f-40e3-8021-647a2efb50bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3cbfe-410f-40e3-8021-647a2efb50bf.jpg?1",
             "name": "Raucous Entertainer",
             "text": "{1}, {T}: Put a +1/+1 counter on each creature you control that entered the battlefield this turn.",
             "colours": [
@@ -6103,7 +6103,7 @@
         },
         {
             "id": "249524a9-8b7b-5556-b425-9b6f11206f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb871985-a11b-4dfe-b0e3-898888c86277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb871985-a11b-4dfe-b0e3-898888c86277.jpg?1",
             "name": "Reach for the Sky",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +3/+2 and has reach.\nWhen Reach for the Sky is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "b5cd0a40-fa2d-565e-8698-78bc40d1c6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e879d8-a058-48e8-9733-f58b1e0da4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e879d8-a058-48e8-9733-f58b1e0da4b9.jpg?1",
             "name": "Rise of the Varmints",
             "text": "Create X 2/1 green Varmint creature tokens, where X is the number of creature cards in your graveyard.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "039dba5d-26b1-509c-bd08-01ad3d64db58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg?1",
             "name": "Smuggler's Surprise",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Mill four cards. You may put up to two creature and/or land cards from among the milled cards into your hand.\n+ {4}{G} \u2014 You may put up to two creature cards from your hand onto the battlefield.\n+ {1} \u2014 Creatures you control with power 4 or greater gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "b6ce5910-fae4-5e8d-b7e6-c0ab6277a4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133fbdec-0d00-433f-9015-5eb091126e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133fbdec-0d00-433f-9015-5eb091126e3a.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "8ca7c170-b5f2-5967-a408-bc63df024500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d63e7-a8c6-4750-91c9-c575a4d0561b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d63e7-a8c6-4750-91c9-c575a4d0561b.jpg?1",
             "name": "Spinewoods Armadillo",
             "text": "Reach\nWard {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\n{1}{G}, Discard Spinewoods Armadillo: Search your library for a basic land card or a Desert card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -6269,7 +6269,7 @@
         },
         {
             "id": "473e698b-c2df-5d69-beda-7c26e32d1ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b432d-9e73-4ab2-a098-546d406df6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b432d-9e73-4ab2-a098-546d406df6c0.jpg?1",
             "name": "Spinewoods Paladin",
             "text": "Trample\nWhen Spinewoods Paladin enters the battlefield, you gain 3 life.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6304,7 +6304,7 @@
         },
         {
             "id": "25e0b514-dbb5-5857-87fd-752498323ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963eb4-d20b-4d3f-bf5d-c75f7bcb9670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963eb4-d20b-4d3f-bf5d-c75f7bcb9670.jpg?1",
             "name": "Stubborn Burrowfiend",
             "text": "Whenever Stubborn Burrowfiend becomes saddled for the first time each turn, mill two cards, then Stubborn Burrowfiend gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "9fbf48da-0efd-57ae-980f-abbcf1fa42e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775874cc-4b78-4904-9c97-431c2e400c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775874cc-4b78-4904-9c97-431c2e400c64.jpg?1",
             "name": "Throw from the Saddle",
             "text": "Target creature you control gets +1/+1 until end of turn. Put a +1/+1 counter on it instead if it's a Mount. Then it deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "72335408-bae7-572b-b9f0-a6cc2629e8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda59f99-1d6d-4051-ac89-b7cbfa19262e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda59f99-1d6d-4051-ac89-b7cbfa19262e.jpg?1",
             "name": "Trash the Town",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Put two +1/+1 counters on target creature.\n+ {1} \u2014 Target creature gains trample until end of turn.\n+ {1} \u2014 Until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, draw two cards.\"",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "9eba0ad1-70e0-5785-a1e9-bd51e880af5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d2d2a-ef85-48c9-919d-bc62cdad8a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d2d2a-ef85-48c9-919d-bc62cdad8a10.jpg?1",
             "name": "Tumbleweed Rising",
             "text": "Create an X/X green Elemental creature token, where X is the greatest power among creatures you control.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6436,7 +6436,7 @@
         },
         {
             "id": "67a0624b-7ec6-5e0f-9f67-5a439d5cd0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b74fa3-c1d7-4780-977d-f2d6663a529a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b74fa3-c1d7-4780-977d-f2d6663a529a.jpg?1",
             "name": "Voracious Varmint",
             "text": "Vigilance\n{1}, Sacrifice Voracious Varmint: Destroy target artifact or enchantment.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "2a1e3689-8b05-5fda-8d3a-64e5c51f7267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fd8548-50db-4243-9154-377f32408d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fd8548-50db-4243-9154-377f32408d58.jpg?1",
             "name": "Akul the Unrepentant",
             "text": "Flying, trample\nSacrifice three other creatures: You may put a creature card from your hand onto the battlefield. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "63c69341-9c62-550f-994e-8ec0ab0c0c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4af7c3-a70d-4f71-b27d-b268c4a0f81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4af7c3-a70d-4f71-b27d-b268c4a0f81e.jpg?1",
             "name": "Annie Flash, the Veteran",
             "text": "Flash\nWhen Annie Flash, the Veteran enters the battlefield, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\nWhenever Annie Flash becomes tapped, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -6555,7 +6555,7 @@
         },
         {
             "id": "9aef13e5-8840-53e9-aafa-c5e5e6c76d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1624a5f4-f5bc-47c9-85de-c5520ee234ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1624a5f4-f5bc-47c9-85de-c5520ee234ce.jpg?1",
             "name": "Annie Joins Up",
             "text": "When Annie Joins Up enters the battlefield, it deals 5 damage to target creature or planeswalker an opponent controls.\nIf a triggered ability of a legendary creature you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -6595,7 +6595,7 @@
         },
         {
             "id": "ecc33a9b-f28e-55d3-85f5-02db00939ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bf3c6-e46f-48f8-902f-82deeba260b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bf3c6-e46f-48f8-902f-82deeba260b2.jpg?1",
             "name": "Assimilation Aegis",
             "text": "When Assimilation Aegis enters the battlefield, exile up to one target creature until Assimilation Aegis leaves the battlefield.\nWhenever Assimilation Aegis becomes attached to a creature, for as long as Assimilation Aegis remains attached to it, that creature becomes a copy of a creature card exiled with Assimilation Aegis.\nEquip {2}",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "47f2095a-8fe2-5cda-84a2-8ed93b497f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897d594d-b5b0-43dc-b877-b483942416ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897d594d-b5b0-43dc-b877-b483942416ce.jpg?1",
             "name": "At Knifepoint",
             "text": "As long as it's your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you commit a crime, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\" This ability triggers only once each turn.",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "d7db4361-843d-5179-b214-a1dc8d4edfaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ef971-cdd4-410c-97c3-df98e4f02ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ef971-cdd4-410c-97c3-df98e4f02ab2.jpg?1",
             "name": "Badlands Revival",
             "text": "Return up to one target creature card from your graveyard to the battlefield. Return up to one target permanent card from your graveyard to your hand.",
             "colours": [
@@ -6701,7 +6701,7 @@
         },
         {
             "id": "bc227a25-bed3-574d-b50f-862b0a396830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9da18b4-1efc-44b7-8001-a2cfd44c69bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9da18b4-1efc-44b7-8001-a2cfd44c69bf.jpg?1",
             "name": "Baron Bertram Graywater",
             "text": "Whenever one or more tokens enter the battlefield under your control, create a 1/1 black Vampire Rogue creature token with lifelink. This ability triggers only once each turn.\n{1}{B}, Sacrifice another creature or artifact: Draw a card.",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "414229fc-4402-5f91-b6aa-4bbc2d43cf68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383ae7c-58ea-4354-93e4-677ad185c3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383ae7c-58ea-4354-93e4-677ad185c3bb.jpg?1",
             "name": "Bonny Pall, Clearcutter",
             "text": "Reach\nWhen Bonny Pall, Clearcutter enters the battlefield, create Beau, a legendary blue Ox creature token with \"This creature's power and toughness are each equal to the number of lands you control.\"\nWhenever you attack, draw a card, then you may put a land card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "3b568273-ccce-57b3-b080-4966a1884063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3bda9e-42af-4f99-a504-c96c25c2794b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3bda9e-42af-4f99-a504-c96c25c2794b.jpg?1",
             "name": "Breeches, the Blastmaker",
             "text": "Menace\nWhenever you cast your second spell each turn, you may sacrifice an artifact. If you do, flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy. When you lose the flip, Breeches, the Blastmaker deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "42586fcf-de1a-5e18-aeea-f04c5c83f8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286c55c2-dcc1-4e87-a83f-9981d28ab62d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286c55c2-dcc1-4e87-a83f-9981d28ab62d.jpg?1",
             "name": "Bruse Tarl, Roving Rancher",
             "text": "Oxen you control have double strike.\nWhenever Bruse Tarl, Roving Rancher enters the battlefield or attacks, exile the top card of your library. If it's a land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the end of your next turn.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "d599451d-baeb-558e-ae28-e9c028853235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b8c5d-9fb0-488f-9b32-c2e29d1f1dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b8c5d-9fb0-488f-9b32-c2e29d1f1dbb.jpg?1",
             "name": "Cactusfolk Sureshot",
             "text": "Reach\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of combat on your turn, other creatures you control with power 4 or greater gain trample and haste until end of turn.",
             "colours": [
@@ -6900,7 +6900,7 @@
         },
         {
             "id": "a2affdb1-5cff-545c-a0c8-130f650eb7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef4907a-2fc1-42c5-bffc-3b3f93601fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef4907a-2fc1-42c5-bffc-3b3f93601fb9.jpg?1",
             "name": "Congregation Gryff",
             "text": "Flying, lifelink\nWhenever Congregation Gryff attacks while saddled, it gets +X/+X until end of turn, where X is the number of Mounts you control.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6937,7 +6937,7 @@
         },
         {
             "id": "1a832995-af20-54e2-a5a6-232da74b1fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc27b30-8c8e-434c-a72c-e1d409efc1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc27b30-8c8e-434c-a72c-e1d409efc1ae.jpg?1",
             "name": "Doc Aurlock, Grizzled Genius",
             "text": "Spells you cast from your graveyard or from exile cost {2} less to cast.\nPlotting cards from your hand costs {2} less.",
             "colours": [
@@ -6976,7 +6976,7 @@
         },
         {
             "id": "e65d431e-8163-5977-852a-fb22ed6e59d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46c133a-7ae4-431b-88f2-ec606a7baf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46c133a-7ae4-431b-88f2-ec606a7baf69.jpg?1",
             "name": "Eriette, the Beguiler",
             "text": "Lifelink\nWhenever an Aura you control becomes attached to a nonland permanent an opponent controls with mana value less than or equal to that Aura's mana value, gain control of that permanent for as long as that Aura is attached to it.",
             "colours": [
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "c10612eb-65e3-5e31-aa3d-ab9353787d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e81be6-6447-4f1e-be00-6fcdb2ab35af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e81be6-6447-4f1e-be00-6fcdb2ab35af.jpg?1",
             "name": "Ertha Jo, Frontier Mentor",
             "text": "When Ertha Jo, Frontier Mentor enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nWhenever you activate an ability that targets a creature or player, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "cf0f74ea-455c-5472-a87a-588cd8456f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee1387-c24e-4a66-8ad6-9afa9c0abcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee1387-c24e-4a66-8ad6-9afa9c0abcbb.jpg?1",
             "name": "Form a Posse",
             "text": "Create X 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "7801e062-e505-5840-bf11-84555d5d8879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e3d71-4fb8-4ab1-8c8f-b65ae3ad4cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e3d71-4fb8-4ab1-8c8f-b65ae3ad4cc4.jpg?1",
             "name": "Ghired, Mirror of the Wilds",
             "text": "Haste\nNontoken creatures you control have \"{T}: Create a token that's a copy of target token you control that entered the battlefield this turn.\"",
             "colours": [
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "77b1a414-68da-5ff7-a7ec-fe26d2ffd979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82512813-8618-483b-a7f0-e6a611d9d487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82512813-8618-483b-a7f0-e6a611d9d487.jpg?1",
             "name": "The Gitrog, Ravenous Ride",
             "text": "Trample, haste\nWhenever The Gitrog, Ravenous Ride deals combat damage to a player, you may sacrifice a creature that saddled it this turn. If you do, draw X cards, then put up to X land cards from your hand onto the battlefield tapped, where X is the sacrificed creature's power.\nSaddle 1",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "505b089d-cd9c-5392-a4eb-cc7c3b8a3202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ddf66-76af-4857-83c3-c812327a6e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ddf66-76af-4857-83c3-c812327a6e23.jpg?1",
             "name": "Honest Rutstein",
             "text": "When Honest Rutstein enters the battlefield, return target creature card from your graveyard to your hand.\nCreature spells you cast cost {1} less to cast.",
             "colours": [
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "53a0b44a-ffeb-5d17-bebc-170630b2e387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596fb7a2-bb79-44b7-ad84-414c8139ec13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596fb7a2-bb79-44b7-ad84-414c8139ec13.jpg?1",
             "name": "Intimidation Campaign",
             "text": "When Intimidation Campaign enters the battlefield, each opponent loses 1 life, you gain 1 life, and you draw a card.\nWhenever you commit a crime, you may return Intimidation Campaign to its owner's hand. (It returns only from the battlefield. Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "03a6d69c-0a5c-5421-9458-8e03348e0b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe6dc-662a-4abc-ad60-a1959b2be006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe6dc-662a-4abc-ad60-a1959b2be006.jpg?1",
             "name": "Jem Lightfoote, Sky Explorer",
             "text": "Flying, vigilance\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "161475f1-44d1-5321-aeea-fcd7fce6dceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe30b5c8-4889-4350-bb1d-3e2a67d9dfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe30b5c8-4889-4350-bb1d-3e2a67d9dfb2.jpg?1",
             "name": "Jolene, Plundering Pugilist",
             "text": "Whenever you attack with one or more creatures with power 4 or greater, create a Treasure token.\n{1}{R}, Sacrifice a Treasure: Jolene, Plundering Pugilist deals 1 damage to any target.",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "b3b8a077-0d38-59e7-a1ca-b3d1fa9256a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a775d-5898-41a8-b404-9b7d4721c6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a775d-5898-41a8-b404-9b7d4721c6ba.jpg?1",
             "name": "Kambal, Profiteering Mayor",
             "text": "Whenever one or more tokens enter the battlefield under your opponents' control, for each of them, create a tapped token that's a copy of it. This ability triggers only once each turn.\nWhenever one or more tokens enter the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7371,7 +7371,7 @@
         },
         {
             "id": "6117548b-f0fa-5563-ae6f-24927818fcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f95d5-b279-4469-9c89-1e02630d61e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f95d5-b279-4469-9c89-1e02630d61e6.jpg?1",
             "name": "Kellan Joins Up",
             "text": "When Kellan Joins Up enters the battlefield, you may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted. (You may cast it as a sorcery on a later turn without paying its mana cost.)\nWhenever a legendary creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -7411,7 +7411,7 @@
         },
         {
             "id": "83d76712-309f-532d-bbd6-d92a3b0870d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfbc4c-ab21-45db-bbd9-b9d245d60015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfbc4c-ab21-45db-bbd9-b9d245d60015.jpg?1",
             "name": "Kellan, the Kid",
             "text": "Flying, lifelink\nWhenever you cast a spell from anywhere other than your hand, you may cast a permanent spell with equal or lesser mana value from your hand without paying its mana cost. If you don't, you may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "c47f19d2-13ed-52ec-8140-ca3db5ce6c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a3e6b-7e20-40ea-8b2c-7c728934b5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a3e6b-7e20-40ea-8b2c-7c728934b5e5.jpg?1",
             "name": "Kraum, Violent Cacophony",
             "text": "Flying\nWhenever you cast your second spell each turn, put a +1/+1 counter on Kraum, Violent Cacophony and draw a card.",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "7d3a9a2d-ce43-5846-a922-4fc69d2a5c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0b3a41-ba99-41e8-bcfb-5796500c17c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0b3a41-ba99-41e8-bcfb-5796500c17c7.jpg?1",
             "name": "Laughing Jasper Flint",
             "text": "Creatures you control but don't own are Mercenaries in addition to their other types.\nAt the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "53743464-3b9a-5286-9c1b-d9e5a93cd875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00293326-3eb2-492c-b565-7abafa037d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00293326-3eb2-492c-b565-7abafa037d8c.jpg?1",
             "name": "Lazav, Familiar Stranger",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Lazav, Familiar Stranger. Then you may exile a card from a graveyard. If a creature card was exiled this way, you may have Lazav become a copy of that card until end of turn. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "4516f6eb-d3da-597e-bb9c-948406e53c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f90ea-5934-4757-8515-38ef116afac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f90ea-5934-4757-8515-38ef116afac1.jpg?1",
             "name": "Lilah, Undefeated Slickshot",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a multicolored instant or sorcery spell from your hand, exile that spell instead of putting it into your graveyard as it resolves. If you do, it becomes plotted. (You may cast it as a sorcery on a later turn without paying its mana cost.)",
             "colours": [
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "81fdbf09-082d-51a0-881f-ced09710aecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0557b0a3-2b48-408f-a508-9f4da2ab1cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0557b0a3-2b48-408f-a508-9f4da2ab1cd1.jpg?1",
             "name": "Make Your Own Luck",
             "text": "Look at the top three cards of your library. You may exile a nonland card from among them. If you do, it becomes plotted. Put the rest into your hand. (You may cast it as a sorcery on a later turn without paying its mana cost.)",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "d6788c4f-63fa-5749-aace-bd5cb8f4a60e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521dffaa-813b-41e4-b7c2-a8c407167875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521dffaa-813b-41e4-b7c2-a8c407167875.jpg?1",
             "name": "Malcolm, the Eyes",
             "text": "Flying, haste\nWhenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7691,7 +7691,7 @@
         },
         {
             "id": "d3dadd18-1576-5f7f-8b1e-d263e56b1f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29b59c-d57c-4a03-bae7-e9dfa57d6bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29b59c-d57c-4a03-bae7-e9dfa57d6bb1.jpg?1",
             "name": "Marchesa, Dealer of Death",
             "text": "Whenever you commit a crime, you may pay {1}. If you do, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -7734,7 +7734,7 @@
         },
         {
             "id": "55cf8d51-fc20-5731-adfb-05cf55748e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa7750a-7c32-4413-b762-62e24d992c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa7750a-7c32-4413-b762-62e24d992c6b.jpg?1",
             "name": "Miriam, Herd Whisperer",
             "text": "As long as it's your turn, Mounts and Vehicles you control have hexproof.\nWhenever a Mount or Vehicle you control attacks, put a +1/+1 counter on it.",
             "colours": [
@@ -7773,7 +7773,7 @@
         },
         {
             "id": "e98d734c-0e80-5486-b91f-fea9b0c0e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03415c42-086e-4a2e-9be8-5cdcde83f134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03415c42-086e-4a2e-9be8-5cdcde83f134.jpg?1",
             "name": "Obeka, Splitter of Seconds",
             "text": "Menace\nWhenever Obeka, Splitter of Seconds deals combat damage to a player, you get that many additional upkeep steps after this phase.",
             "colours": [
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "43bde815-4d50-5aa0-b03f-537f637ed158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396df8d6-e85d-4486-8116-68841b7e1e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396df8d6-e85d-4486-8116-68841b7e1e2e.jpg?1",
             "name": "Oko, the Ringleader",
             "text": "At the beginning of combat on your turn, Oko, the Ringleader becomes a copy of up to one target creature you control until end of turn, except he has hexproof.\n+1: Draw two cards. If you've committed a crime this turn, discard a card. Otherwise, discard two cards.\n\u22121: Create a 3/3 green Elk creature token.\n\u22125: For each other nonland permanent you control, create a token that's a copy of that permanent.",
             "colours": [
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "52fb4bff-218d-57ea-b6d8-f1487edd55ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b415f-7901-4ab4-84fe-60b90d40ac90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b415f-7901-4ab4-84fe-60b90d40ac90.jpg?1",
             "name": "Pillage the Bog",
             "text": "Look at the top X cards of your library, where X is twice the number of lands you control. Put one of them into your hand and the rest on the bottom of your library in a random order.\nPlot {1}{B}{G} (You may pay {1}{B}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -7893,7 +7893,7 @@
         },
         {
             "id": "1f112cdf-6eb5-5092-85bd-154c855e9eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7154dca-7e10-4c34-aa56-9f200c6277d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7154dca-7e10-4c34-aa56-9f200c6277d1.jpg?1",
             "name": "Rakdos Joins Up",
             "text": "When Rakdos Joins Up enters the battlefield, return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it.\nWhenever a legendary creature you control dies, Rakdos Joins Up deals damage equal to that creature's power to target opponent.",
             "colours": [
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "2d69fb61-7549-5cde-8cce-c2b3e05d70d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb34babd-1b85-4a7d-a066-a8337805056e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb34babd-1b85-4a7d-a066-a8337805056e.jpg?1",
             "name": "Rakdos, the Muscle",
             "text": "Flying, trample\nWhenever you sacrifice another creature, exile cards equal to its mana value from the top of target player's library. Until your next end step, you may play those cards, and mana of any type can be spent to cast those spells.\nSacrifice another creature: Rakdos, the Muscle gains indestructible until end of turn. Tap it. Activate only once each turn.",
             "colours": [
@@ -7972,7 +7972,7 @@
         },
         {
             "id": "901775e5-e3cf-524c-93d8-0ec0550876fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b63544-4c31-4f38-9907-0407719a60b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b63544-4c31-4f38-9907-0407719a60b1.jpg?1",
             "name": "Riku of Many Paths",
             "text": "Whenever you cast a modal spell, choose up to X, where X is the number of times you chose a mode for that spell \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play it.\n\u2022 Put a +1/+1 counter on Riku of Many Paths. It gains trample until end of turn.\n\u2022 Create a 1/1 blue Bird creature token with flying.",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "44052fb9-2122-547b-bab9-dfe6c33ed965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbe52f-febd-49fc-8391-28d3efe9c3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbe52f-febd-49fc-8391-28d3efe9c3eb.jpg?1",
             "name": "Roxanne, Starfall Savant",
             "text": "Whenever Roxanne, Starfall Savant enters the battlefield or attacks, create a tapped colorless artifact token named Meteorite with \"When Meteorite enters the battlefield, it deals 2 damage to any target\" and \"{T}: Add one mana of any color.\"\nWhenever you tap an artifact token for mana, add one mana of any type that artifact token produced.",
             "colours": [
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "17d238bd-d4cd-53fd-a907-70248c201c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927b5498-23f1-47c0-b441-7daaeb54f9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927b5498-23f1-47c0-b441-7daaeb54f9b8.jpg?1",
             "name": "Ruthless Lawbringer",
             "text": "When Ruthless Lawbringer enters the battlefield, you may sacrifice another creature. When you do, destroy target nonland permanent.",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "f4b24a37-9628-5c04-9bad-94862992ef90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9a5cc-2b3c-4c2f-8176-4a2d86265cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9a5cc-2b3c-4c2f-8176-4a2d86265cc5.jpg?1",
             "name": "Satoru, the Infiltrator",
             "text": "Menace\nWhenever Satoru, the Infiltrator and/or one or more other nontoken creatures enter the battlefield under your control, if none of them were cast or no mana was spent to cast them, draw a card.",
             "colours": [
@@ -8137,7 +8137,7 @@
         },
         {
             "id": "f193c0f0-b9d8-5ab1-bd1a-953085e099dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2e167f-7cb2-4f15-a1db-7ee56b7ba523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2e167f-7cb2-4f15-a1db-7ee56b7ba523.jpg?1",
             "name": "Selvala, Eager Trailblazer",
             "text": "Vigilance\nWhenever you cast a creature spell, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{T}: Choose a color. Add one mana of that color for each different power among creatures you control.",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "8198d164-d5b1-57c3-8bc3-b296196384e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ada7ab4-0dee-4ff3-9817-1e61ca3f2ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ada7ab4-0dee-4ff3-9817-1e61ca3f2ccf.jpg?1",
             "name": "Seraphic Steed",
             "text": "First strike, lifelink\nWhenever Seraphic Steed attacks while saddled, create a 3/3 white Angel creature token with flying.\nSaddle 4 (Tap any number of other creatures you control with total power 4 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -8217,7 +8217,7 @@
         },
         {
             "id": "cf710bb7-5f65-5e52-9560-955bd96c36a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb1c974-0d35-4e9f-a310-44eb2af64494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb1c974-0d35-4e9f-a310-44eb2af64494.jpg?1",
             "name": "Slick Sequence",
             "text": "Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card.",
             "colours": [
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "5581b583-952c-5d2f-b68f-e58bbd279980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1643af0b-fcbf-4636-8c50-77ec77eaa34d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1643af0b-fcbf-4636-8c50-77ec77eaa34d.jpg?1",
             "name": "Taii Wakeen, Perfect Shot",
             "text": "Whenever a source you control deals noncombat damage to a creature equal to that creature's toughness, draw a card.\n{X}, {T}: If a source you control would deal noncombat damage to a permanent or player this turn, it deals that much damage plus X instead.",
             "colours": [
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "ac80a80a-0f02-5e49-9c23-644f5a87f5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afce4e6-ac59-4fba-b63a-8fed96bbdc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afce4e6-ac59-4fba-b63a-8fed96bbdc4a.jpg?1",
             "name": "Vial Smasher, Gleeful Grenadier",
             "text": "Whenever another outlaw enters the battlefield under your control, Vial Smasher, Gleeful Grenadier deals 1 damage to target opponent. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "617d238b-be5a-5ab3-8e30-fa121d56a988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e546c2-737e-4b17-bf60-3069b1ccdf31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e546c2-737e-4b17-bf60-3069b1ccdf31.jpg?1",
             "name": "Vraska Joins Up",
             "text": "When Vraska Joins Up enters the battlefield, put a deathtouch counter on each creature you control.\nWhenever a legendary creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -8369,7 +8369,7 @@
         },
         {
             "id": "9f774fd5-aef8-5f4b-b9cb-f4bb280864ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b042abf2-c40b-4235-a4fa-2e4901c375c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b042abf2-c40b-4235-a4fa-2e4901c375c3.jpg?1",
             "name": "Vraska, the Silencer",
             "text": "Deathtouch\nWhenever a nontoken creature an opponent controls dies, you may pay {1}. If you do, return that card to the battlefield tapped under your control. It's a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other card types.",
             "colours": [
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "cf4cec8f-c124-5255-bf66-799d6fd3fe93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d163dd-67dc-4aab-afb9-d043352d109c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d163dd-67dc-4aab-afb9-d043352d109c.jpg?1",
             "name": "Wrangler of the Damned",
             "text": "Flash\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, create a 2/2 white Spirit creature token with flying.",
             "colours": [
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "698e6144-a907-577d-babc-9511c405e2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc97ffcf-4f51-44cd-8daa-a7dae4592ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc97ffcf-4f51-44cd-8daa-a7dae4592ee5.jpg?1",
             "name": "Wylie Duke, Atiin Hero",
             "text": "Vigilance\nWhenever Wylie Duke, Atiin Hero becomes tapped, you gain 1 life and draw a card.",
             "colours": [
@@ -8488,7 +8488,7 @@
         },
         {
             "id": "ed6a1c96-5c4e-5cb7-9473-b5b3b49a43e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b2e74b-933b-4285-963b-dda3a986a914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b2e74b-933b-4285-963b-dda3a986a914.jpg?1",
             "name": "Bandit's Haul",
             "text": "Whenever you commit a crime, put a loot counter on Bandit's Haul. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n{T}: Add one mana of any color.\n{2}, {T}, Remove two loot counters from Bandit's Haul: Draw a card.",
             "colours": [],
@@ -8516,7 +8516,7 @@
         },
         {
             "id": "37c0e4d8-6d8c-51b9-8b16-776cb599bc97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61d964-6d73-422e-9e08-360ac66f237a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61d964-6d73-422e-9e08-360ac66f237a.jpg?1",
             "name": "Boom Box",
             "text": "{6}, {T}, Sacrifice Boom Box: Destroy up to one target artifact, up to one target creature, and up to one target land.",
             "colours": [],
@@ -8544,7 +8544,7 @@
         },
         {
             "id": "e370b834-21ca-5fdf-9a01-0bef8a706765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098aae-3d9b-453b-a37e-e102f81a8311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098aae-3d9b-453b-a37e-e102f81a8311.jpg?1",
             "name": "Gold Pan",
             "text": "When Gold Pan enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "c80f2a52-32ca-5203-a3c3-7fcc6856c2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50709de-e6ef-4dbc-af1e-290fed279f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50709de-e6ef-4dbc-af1e-290fed279f34.jpg?1",
             "name": "Lavaspur Boots",
             "text": "Equipped creature gets +1/+0 and has haste and ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nEquip {1}",
             "colours": [],
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "9d7785d3-9b33-5a02-8645-1a3ab485f2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc598338-eeba-4815-a0a6-ff2dc09790d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc598338-eeba-4815-a0a6-ff2dc09790d2.jpg?1",
             "name": "Luxurious Locomotive",
             "text": "Whenever Luxurious Locomotive attacks, create a Treasure token for each creature that crewed it this turn. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nCrew 1. Activate only once each turn. (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8634,7 +8634,7 @@
         },
         {
             "id": "49e5eaf9-9a3f-5561-9982-58db55a14f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg?1",
             "name": "Mobile Homestead",
             "text": "Mobile Homestead has haste as long as you control a Mount.\nWhenever Mobile Homestead attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "4db39578-34df-5b4d-9c70-df997b68a764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg?1",
             "name": "Oasis Gardener",
             "text": "When Oasis Gardener enters the battlefield, you gain 2 life.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "e87829ae-9eeb-5e8c-9069-8d70b1c267f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb98381-8418-4dfd-b7d1-4353570e611b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb98381-8418-4dfd-b7d1-4353570e611b.jpg?1",
             "name": "Redrock Sentinel",
             "text": "Defender\n{2}, {T}, Sacrifice a land: Draw a card and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -8726,7 +8726,7 @@
         },
         {
             "id": "1bf65224-db5d-591f-8e11-9db9436853ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d2c11d-1eb8-4768-bc61-fa8f20a69462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d2c11d-1eb8-4768-bc61-fa8f20a69462.jpg?1",
             "name": "Silver Deputy",
             "text": "When Silver Deputy enters the battlefield, you may search your library for a basic land card or a Desert card, reveal it, then shuffle and put it on top.\n{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -8757,7 +8757,7 @@
         },
         {
             "id": "31c9f2f8-06d3-5ea1-a3c5-524bb730e6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5bfcf5-6e5c-47fe-af6c-6b18938261c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5bfcf5-6e5c-47fe-af6c-6b18938261c6.jpg?1",
             "name": "Sterling Hound",
             "text": "When Sterling Hound enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "e3ba7f66-f444-50fe-bc99-3d4bafaf2587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e61cb8-219a-4fe6-a2e6-307665ffa38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e61cb8-219a-4fe6-a2e6-307665ffa38f.jpg?1",
             "name": "Tomb Trawler",
             "text": "{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -8819,7 +8819,7 @@
         },
         {
             "id": "f5d34872-c33b-578d-b82f-3667c0838cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e96521-b4ce-4a36-a887-200e05ccc804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e96521-b4ce-4a36-a887-200e05ccc804.jpg?1",
             "name": "Abraded Bluffs",
             "text": "Abraded Bluffs enters the battlefield tapped.\nWhen Abraded Bluffs enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "78e6b942-1709-5c08-a8df-9e460fd8bb16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c8fa2-12ab-4f6a-9f7a-2bc69e9ba024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c8fa2-12ab-4f6a-9f7a-2bc69e9ba024.jpg?1",
             "name": "Arid Archway",
             "text": "Arid Archway enters the battlefield tapped.\nWhen Arid Archway enters the battlefield, return a land you control to its owner's hand. If another Desert was returned this way, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}{C}.",
             "colours": [],
@@ -8882,7 +8882,7 @@
         },
         {
             "id": "43c64c60-0fe2-5f1d-b767-d3685e0fd005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61dfeb7-7f6b-4601-8396-2cbb98165489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61dfeb7-7f6b-4601-8396-2cbb98165489.jpg?1",
             "name": "Bristling Backwoods",
             "text": "Bristling Backwoods enters the battlefield tapped.\nWhen Bristling Backwoods enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8915,7 +8915,7 @@
         },
         {
             "id": "dc6f3ed2-209a-5dbc-8935-6938e6778aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffa48cc-b991-4d47-b7ec-cf678915c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffa48cc-b991-4d47-b7ec-cf678915c758.jpg?1",
             "name": "Conduit Pylons",
             "text": "When Conduit Pylons enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "e8c6f29c-ed4e-574b-ba61-c6564ad84b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5523dac-7aa0-4486-89c8-3b22a1411f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5523dac-7aa0-4486-89c8-3b22a1411f26.jpg?1",
             "name": "Creosote Heath",
             "text": "Creosote Heath enters the battlefield tapped.\nWhen Creosote Heath enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "4a3d1de1-f596-5a7e-986e-84ff4c3069f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9d080f-28d7-41d6-a4e0-5b3e3a5ed770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9d080f-28d7-41d6-a4e0-5b3e3a5ed770.jpg?1",
             "name": "Eroded Canyon",
             "text": "Eroded Canyon enters the battlefield tapped.\nWhen Eroded Canyon enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "43490fe7-f568-5327-bde7-da9b70ccb16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad841eb-da0d-43d4-8b60-efe30922990b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad841eb-da0d-43d4-8b60-efe30922990b.jpg?1",
             "name": "Festering Gulch",
             "text": "Festering Gulch enters the battlefield tapped.\nWhen Festering Gulch enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "d454d997-68f3-52f2-aeae-e8050b0877fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963c100e-4e12-438f-b5ae-14391406dff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963c100e-4e12-438f-b5ae-14391406dff6.jpg?1",
             "name": "Forlorn Flats",
             "text": "Forlorn Flats enters the battlefield tapped.\nWhen Forlorn Flats enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9077,7 +9077,7 @@
         },
         {
             "id": "e2a0d6ad-b3c9-5bac-83d4-581d3e2cbc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d809f5b-d965-4cb1-a9f8-2048f8534373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d809f5b-d965-4cb1-a9f8-2048f8534373.jpg?1",
             "name": "Jagged Barrens",
             "text": "Jagged Barrens enters the battlefield tapped.\nWhen Jagged Barrens enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9110,7 +9110,7 @@
         },
         {
             "id": "90b9c858-bdb1-5d7e-845d-d9073a8336e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b778b63-e5fc-4d63-a93b-4372f32cade2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b778b63-e5fc-4d63-a93b-4372f32cade2.jpg?1",
             "name": "Lonely Arroyo",
             "text": "Lonely Arroyo enters the battlefield tapped.\nWhen Lonely Arroyo enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9143,7 +9143,7 @@
         },
         {
             "id": "42a842eb-6203-58db-8cb3-d42d6f1dfb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988e44c5-4632-4ebb-b6ae-c3886e49d637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988e44c5-4632-4ebb-b6ae-c3886e49d637.jpg?1",
             "name": "Lush Oasis",
             "text": "Lush Oasis enters the battlefield tapped.\nWhen Lush Oasis enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9176,7 +9176,7 @@
         },
         {
             "id": "6fdcd268-61ab-54e5-a651-c8ee8ddccd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e816-c06d-4c5d-98fe-c350d8cfab27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e816-c06d-4c5d-98fe-c350d8cfab27.jpg?1",
             "name": "Mirage Mesa",
             "text": "Mirage Mesa enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9206,7 +9206,7 @@
         },
         {
             "id": "d83846f8-5065-54e1-aa0c-1b9cf69fa84a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab4e0a4-2faf-456b-99e3-ee06c008538c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab4e0a4-2faf-456b-99e3-ee06c008538c.jpg?1",
             "name": "Sandstorm Verge",
             "text": "{T}: Add {C}.\n{3}, {T}: Target creature can't block this turn. Activate only as a sorcery.",
             "colours": [],
@@ -9236,7 +9236,7 @@
         },
         {
             "id": "0e5f7df0-c992-5920-9cd5-7f3cd314f935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67daa31c-d9c4-4c22-b29c-1b8a17d577e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67daa31c-d9c4-4c22-b29c-1b8a17d577e5.jpg?1",
             "name": "Soured Springs",
             "text": "Soured Springs enters the battlefield tapped.\nWhen Soured Springs enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9269,7 +9269,7 @@
         },
         {
             "id": "cba28f49-69fd-51f3-bc68-13ea8670f1f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4f6b81-53d0-49fb-b404-c2ad67de7493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4f6b81-53d0-49fb-b404-c2ad67de7493.jpg?1",
             "name": "Bucolic Ranch",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Mount spell.\n{3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it and put it into your hand. If you don't put it into your hand, you may put it on the bottom of your library.",
             "colours": [],
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "aa874e11-05b4-52b7-b0f4-b0d32198f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861caabb-0573-4e94-8b03-342f90465064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861caabb-0573-4e94-8b03-342f90465064.jpg?1",
             "name": "Blooming Marsh",
             "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9332,7 +9332,7 @@
         },
         {
             "id": "b658c176-f603-520e-9dab-e9e9291a307d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18d5f4-a56a-4f7d-9f56-ccc92cbfb7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18d5f4-a56a-4f7d-9f56-ccc92cbfb7f7.jpg?1",
             "name": "Botanical Sanctum",
             "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9365,7 +9365,7 @@
         },
         {
             "id": "96347282-5292-5103-933e-656c01504222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75df1f0-0513-40e4-a449-454f75de6434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75df1f0-0513-40e4-a449-454f75de6434.jpg?1",
             "name": "Concealed Courtyard",
             "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9398,7 +9398,7 @@
         },
         {
             "id": "f533b932-307a-5f00-af97-2ed21e0fde89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85df6b6a-2dcf-4828-a4a8-e07d52e1fddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85df6b6a-2dcf-4828-a4a8-e07d52e1fddd.jpg?1",
             "name": "Inspiring Vantage",
             "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "4320d7b6-7541-5a1f-a85c-7d7da40a992c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a04e16-a767-4112-ab01-6ca1b09c286c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a04e16-a767-4112-ab01-6ca1b09c286c.jpg?1",
             "name": "Spirebluff Canal",
             "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "53f194d8-9b63-5614-a869-b3a7c59f05dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg?1",
             "name": "Jace Reawakened",
             "text": "You can't cast this spell during your first, second, or third turns of the game.\n+1: Draw a card, then discard a card.\n+1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\n\u22126: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -9502,7 +9502,7 @@
         },
         {
             "id": "2439cad8-5b11-52c9-96f1-fbf451ca082a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe51d97-66f6-4ac3-b926-01ab7e4c5686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe51d97-66f6-4ac3-b926-01ab7e4c5686.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "95b06628-80db-5dc8-8b24-8b689994c1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624d656-207d-4e73-b615-59e7cf64ad64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624d656-207d-4e73-b615-59e7cf64ad64.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9576,7 +9576,7 @@
         },
         {
             "id": "4a1a324d-b930-5afb-845c-2410c98d4b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b383b16-8128-4d9e-a0d0-9b8ccc9ad6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b383b16-8128-4d9e-a0d0-9b8ccc9ad6df.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "053ded5c-2cea-5a75-a55e-daf37e2ea91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dbfd2-cda7-4fc9-9677-e442fb5f5f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dbfd2-cda7-4fc9-9677-e442fb5f5f6f.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "452d4eaf-d736-5dbf-9fc2-cb35022ee7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf8a774-65f3-431e-b084-328ff1000895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf8a774-65f3-431e-b084-328ff1000895.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9687,7 +9687,7 @@
         },
         {
             "id": "de196252-02f1-54ab-97ac-fa59d75c7eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f501773-1b39-4a4c-9b45-a950385c9e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f501773-1b39-4a4c-9b45-a950385c9e82.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9724,7 +9724,7 @@
         },
         {
             "id": "6932a15f-4028-5ffb-8a25-9cf7a3a78df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe60da77-084c-49e8-9948-9ac4b6a6382f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe60da77-084c-49e8-9948-9ac4b6a6382f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9761,7 +9761,7 @@
         },
         {
             "id": "3d2e9367-5afd-560b-869a-c7c612d0db53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd6be3f-745c-41ad-95c9-1db66ba56be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd6be3f-745c-41ad-95c9-1db66ba56be2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9798,7 +9798,7 @@
         },
         {
             "id": "f40527c4-8a3b-5cc8-99c3-f81fd94757bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be4db0-7cb3-4202-939b-cb7a26e90019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be4db0-7cb3-4202-939b-cb7a26e90019.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9835,7 +9835,7 @@
         },
         {
             "id": "d625c38f-3b9c-59b7-85eb-e4bdfda3a8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7dc259-9949-4673-a8f1-874396948392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7dc259-9949-4673-a8f1-874396948392.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9872,7 +9872,7 @@
         },
         {
             "id": "75cf6103-13f2-530b-b598-3c92163d7445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c9dc0-7f3a-4f3a-ba08-5c2f87e252bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c9dc0-7f3a-4f3a-ba08-5c2f87e252bc.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9909,7 +9909,7 @@
         },
         {
             "id": "b7a2c32e-944c-5d49-9223-d8d515d44ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9137b4aa-2289-4a4d-b1f5-ae75a0928278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9137b4aa-2289-4a4d-b1f5-ae75a0928278.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9946,7 +9946,7 @@
         },
         {
             "id": "12bf8065-8c2b-541e-a55d-7aeb19cd578b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2237ee9b-fff6-472c-903c-11faf9bb116d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2237ee9b-fff6-472c-903c-11faf9bb116d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "a7fda38b-455a-50b3-8408-eeddeaeb19f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20a07e-5f92-49c2-9c97-d5eda536d3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20a07e-5f92-49c2-9c97-d5eda536d3f6.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "b24333e9-249c-5f4b-9503-a77069beaf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9ac507-7c8f-431f-8d1a-220ceeacf871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9ac507-7c8f-431f-8d1a-220ceeacf871.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "ca826bbc-9dc5-5c7d-babb-41e5f441b845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef3f55e-b8e6-4ef1-85e4-2aef5afc15ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef3f55e-b8e6-4ef1-85e4-2aef5afc15ab.jpg?1",
             "name": "Geralf, the Fleshwright",
             "text": "Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2 blue and black Zombie Rogue creature token.\nWhenever a Zombie enters the battlefield under your control, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your control this turn.",
             "colours": [
@@ -10096,7 +10096,7 @@
         },
         {
             "id": "bba1619d-f59f-58a1-a4f4-171116f784af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c1ad56-cf6e-4717-a56e-feeb7339b8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c1ad56-cf6e-4717-a56e-feeb7339b8c3.jpg?1",
             "name": "Gisa, the Hellraiser",
             "text": "Ward\u2014{2}, Pay 2 life.\nSkeletons and Zombies you control get +1/+1 and have menace.\nWhenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens. This ability triggers only once each turn.",
             "colours": [
@@ -10135,7 +10135,7 @@
         },
         {
             "id": "6e4d9a40-74e3-519f-84f9-3e1cfa7cc4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e759e4-bda5-4d01-a9a8-3986df1d4428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e759e4-bda5-4d01-a9a8-3986df1d4428.jpg?1",
             "name": "Kaervek, the Punisher",
             "text": "Whenever you commit a crime, exile up to one target black card from your graveyard and copy it. You may cast the copy. If you do, you lose 2 life.",
             "colours": [
@@ -10174,7 +10174,7 @@
         },
         {
             "id": "56e1af38-efd3-5cba-ab1c-a88990627786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2a3962-315d-48df-9af5-7cb4dd2040de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2a3962-315d-48df-9af5-7cb4dd2040de.jpg?1",
             "name": "Tinybones, the Pickpocket",
             "text": "Deathtouch\nWhenever Tinybones, the Pickpocket deals combat damage to a player, you may cast target nonland permanent card from that player's graveyard, and mana of any type can be spent to cast that spell.",
             "colours": [
@@ -10213,7 +10213,7 @@
         },
         {
             "id": "1fefbd25-61cd-5d47-9a22-08155896b3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8d21f-a003-4711-ad5c-0bde87e1edc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8d21f-a003-4711-ad5c-0bde87e1edc6.jpg?1",
             "name": "Annie Flash, the Veteran",
             "text": "Flash\nWhen Annie Flash, the Veteran enters the battlefield, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\nWhenever Annie Flash becomes tapped, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -10256,7 +10256,7 @@
         },
         {
             "id": "235f9028-a23b-530c-a210-e1b9ef8d4280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcde5cd5-4ce6-4b94-8d97-534a647dbfc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcde5cd5-4ce6-4b94-8d97-534a647dbfc1.jpg?1",
             "name": "Breeches, the Blastmaker",
             "text": "Menace\nWhenever you cast your second spell each turn, you may sacrifice an artifact. If you do, flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy. When you lose the flip, Breeches, the Blastmaker deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -10297,7 +10297,7 @@
         },
         {
             "id": "1ef727a5-1d56-54a5-abd6-2d1c961b80a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b5791-a405-4578-acba-959cc181e9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b5791-a405-4578-acba-959cc181e9ad.jpg?1",
             "name": "Eriette, the Beguiler",
             "text": "Lifelink\nWhenever an Aura you control becomes attached to a nonland permanent an opponent controls with mana value less than or equal to that Aura's mana value, gain control of that permanent for as long as that Aura is attached to it.",
             "colours": [
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "851ed524-2f77-5ef9-b3f4-1c1613a1e427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789659f6-af39-4357-985f-a006f192893c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789659f6-af39-4357-985f-a006f192893c.jpg?1",
             "name": "Kellan, the Kid",
             "text": "Flying, lifelink\nWhenever you cast a spell from anywhere other than your hand, you may cast a permanent spell with equal or lesser mana value from your hand without paying its mana cost. If you don't, you may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -10384,7 +10384,7 @@
         },
         {
             "id": "3e263f5f-2a2b-591f-9d2b-334b27c2e57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480de469-3fac-4a2b-8dec-7899ce00551e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480de469-3fac-4a2b-8dec-7899ce00551e.jpg?1",
             "name": "Malcolm, the Eyes",
             "text": "Flying, haste\nWhenever you cast your second spell each turn, investigate.",
             "colours": [
@@ -10425,7 +10425,7 @@
         },
         {
             "id": "ef245052-cde1-5a43-89cb-e05ab1a7ff6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c025072-0d0a-4ca7-a386-f1ed7c97638b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c025072-0d0a-4ca7-a386-f1ed7c97638b.jpg?1",
             "name": "Oko, the Ringleader",
             "text": "At the beginning of combat on your turn, Oko, the Ringleader becomes a copy of up to one target creature you control until end of turn, except he has hexproof.\n+1: Draw two cards. If you've committed a crime this turn, discard a card. Otherwise, discard two cards.\n\u22121: Create a 3/3 green Elk creature token.\n\u22125: For each other nonland permanent you control, create a token that's a copy of that permanent.",
             "colours": [
@@ -10466,7 +10466,7 @@
         },
         {
             "id": "606b7abc-9013-586d-bc0f-12b0b279cac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85635e0-fb5b-42ea-8a30-d67922cbca95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85635e0-fb5b-42ea-8a30-d67922cbca95.jpg?1",
             "name": "Rakdos, the Muscle",
             "text": "Flying, trample\nWhenever you sacrifice another creature, exile cards equal to its mana value from the top of target player's library. Until your next end step, you may play those cards, and mana of any type can be spent to cast those spells.\nSacrifice another creature: Rakdos, the Muscle gains indestructible until end of turn. Tap it. Activate only once each turn.",
             "colours": [
@@ -10507,7 +10507,7 @@
         },
         {
             "id": "8f6a0bde-9ab4-56e0-b768-d07fc6bea691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a76f0-b697-4c1d-9b60-c66f7fc4316e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a76f0-b697-4c1d-9b60-c66f7fc4316e.jpg?1",
             "name": "Satoru, the Infiltrator",
             "text": "Menace\nWhenever Satoru, the Infiltrator and/or one or more other nontoken creatures enter the battlefield under your control, if none of them were cast or no mana was spent to cast them, draw a card.",
             "colours": [
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "46a3eef0-a80d-54d5-b2d7-27e75fe86534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6cc9ab-a1d8-47de-8ac5-112e5fee00f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6cc9ab-a1d8-47de-8ac5-112e5fee00f9.jpg?1",
             "name": "Vraska, the Silencer",
             "text": "Deathtouch\nWhenever a nontoken creature an opponent controls dies, you may pay {1}. If you do, return that card to the battlefield tapped under your control. It's a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other card types.",
             "colours": [
@@ -10590,7 +10590,7 @@
         },
         {
             "id": "e021b9da-4728-5c75-8961-a3ac87380862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb4a80-3319-41ad-9d97-a9a53c9f84fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb4a80-3319-41ad-9d97-a9a53c9f84fb.jpg?1",
             "name": "Blooming Marsh",
             "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10623,7 +10623,7 @@
         },
         {
             "id": "ded56fea-2d14-5b81-9226-68a30706b171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82670072-9851-48c7-a8f5-7842bff6c252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82670072-9851-48c7-a8f5-7842bff6c252.jpg?1",
             "name": "Botanical Sanctum",
             "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10656,7 +10656,7 @@
         },
         {
             "id": "c55a9e81-67a9-563c-a718-8382be4a353a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e85ace-7e2c-46f6-adb9-07f33f8e1750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e85ace-7e2c-46f6-adb9-07f33f8e1750.jpg?1",
             "name": "Concealed Courtyard",
             "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "4c31cf96-5daf-58d4-8d4f-f630b28278ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551e216d-a82f-49a1-a3fd-8165715a05c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551e216d-a82f-49a1-a3fd-8165715a05c4.jpg?1",
             "name": "Inspiring Vantage",
             "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10722,7 +10722,7 @@
         },
         {
             "id": "4355eee5-dc0e-5890-a8a9-a2a029b15b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83bdb3-1f04-4b99-a36b-312da0cbed50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83bdb3-1f04-4b99-a36b-312da0cbed50.jpg?1",
             "name": "Spirebluff Canal",
             "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10755,7 +10755,7 @@
         },
         {
             "id": "aebc46ed-7fb4-57dc-8073-59552fff2ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfbb249-f2cc-4295-b6e3-4fd7e1eac183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfbb249-f2cc-4295-b6e3-4fd7e1eac183.jpg?1",
             "name": "Oko, the Ringleader",
             "text": "At the beginning of combat on your turn, Oko, the Ringleader becomes a copy of up to one target creature you control until end of turn, except he has hexproof.\n+1: Draw two cards. If you've committed a crime this turn, discard a card. Otherwise, discard two cards.\n\u22121: Create a 3/3 green Elk creature token.\n\u22125: For each other nonland permanent you control, create a token that's a copy of that permanent.",
             "colours": [
@@ -10796,7 +10796,7 @@
         },
         {
             "id": "399a16ee-1ee2-5d91-a75f-8e438d383b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73bdf79-6c18-46bc-a8bb-97e07dd23aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73bdf79-6c18-46bc-a8bb-97e07dd23aff.jpg?1",
             "name": "Jace Reawakened",
             "text": "You can't cast this spell during your first, second, or third turns of the game.\n+1: Draw a card, then discard a card.\n+1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\n\u22126: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -10834,7 +10834,7 @@
         },
         {
             "id": "79c76c90-f2f9-5ff5-9108-ea583f09ac5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddec615b-537a-4fef-a2a7-9bdf74c0192a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddec615b-537a-4fef-a2a7-9bdf74c0192a.jpg?1",
             "name": "Another Round",
             "text": "Exile any number of creatures you control, then return them to the battlefield under their owner's control. Then repeat this process X more times.",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "b9735a22-0932-56c2-8372-b0e5e19a3eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34f043c-d01e-4462-b381-39748d7fa31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34f043c-d01e-4462-b381-39748d7fa31b.jpg?1",
             "name": "Archangel of Tithes",
             "text": "Flying\nAs long as Archangel of Tithes is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.\nAs long as Archangel of Tithes is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "bf501161-ea5a-54bc-b740-650533c7e227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75143fdb-5651-4289-86df-76c9655a0599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75143fdb-5651-4289-86df-76c9655a0599.jpg?1",
             "name": "Aven Interrupter",
             "text": "Flash\nFlying\nWhen Aven Interrupter enters the battlefield, exile target spell. It becomes plotted.\nSpells your opponents cast from graveyards or from exile cost {2} more to cast.",
             "colours": [
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "c5ad4928-ad44-587f-a017-ca38211eecf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfad3c84-4264-4757-8e83-25dbbed67070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfad3c84-4264-4757-8e83-25dbbed67070.jpg?1",
             "name": "Claim Jumper",
             "text": "Vigilance\nWhen Claim Jumper enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls more lands than you, repeat this process once. If you search your library this way, shuffle.",
             "colours": [
@@ -10978,7 +10978,7 @@
         },
         {
             "id": "9a02af6c-4cc3-5950-a3ef-4748256ba020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d9d4f0-48ec-43e6-bb93-a9589790417b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d9d4f0-48ec-43e6-bb93-a9589790417b.jpg?1",
             "name": "Dust Animus",
             "text": "Flying\nIf you control five or more untapped lands, Dust Animus enters the battlefield with two +1/+1 counters and a lifelink counter on it.\nPlot {1}{W}",
             "colours": [
@@ -11014,7 +11014,7 @@
         },
         {
             "id": "a93030f1-74bb-5a9a-ae05-fe7eae585965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94397320-b814-487f-aca2-537517ff9eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94397320-b814-487f-aca2-537517ff9eff.jpg?1",
             "name": "Final Showdown",
             "text": "Spree\n+ {1} \u2014 All creatures lose all abilities until end of turn.\n+ {1} \u2014 Choose a creature you control. It gains indestructible until end of turn.\n+ {3}{W}{W} \u2014 Destroy all creatures.",
             "colours": [
@@ -11048,7 +11048,7 @@
         },
         {
             "id": "d1574781-f743-578d-b680-31f5d4647875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ffb299-a327-43c1-868e-1c5225204956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ffb299-a327-43c1-868e-1c5225204956.jpg?1",
             "name": "Fortune, Loyal Steed",
             "text": "When Fortune, Loyal Steed enters the battlefield, scry 2.\nWhenever Fortune attacks while saddled, at end of combat, exile it and up to one creature that saddled it this turn, then return those cards to the battlefield under their owner's control.\nSaddle 1",
             "colours": [
@@ -11087,7 +11087,7 @@
         },
         {
             "id": "49d17971-00b4-5cb4-a972-d3b15ac39bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d69fce2-3307-4518-a196-e0b8155dca73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d69fce2-3307-4518-a196-e0b8155dca73.jpg?1",
             "name": "High Noon",
             "text": "Each player can't cast more than one spell each turn.\n{4}{R}, Sacrifice High Noon: It deals 5 damage to any target.",
             "colours": [
@@ -11122,7 +11122,7 @@
         },
         {
             "id": "4f1059d2-79df-5dc9-a996-1de60f5229d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6db7ba-3150-4ae8-84e3-11661bf1d1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6db7ba-3150-4ae8-84e3-11661bf1d1c4.jpg?1",
             "name": "One Last Job",
             "text": "Spree\n+ {2} \u2014 Return target creature card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Mount or Vehicle card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Aura or Equipment card from your graveyard to the battlefield attached to a creature you control.",
             "colours": [
@@ -11156,7 +11156,7 @@
         },
         {
             "id": "2f914156-00c1-5b57-85bb-cd3493c114ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25563be1-71f1-4f70-8527-02c5855a0b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25563be1-71f1-4f70-8527-02c5855a0b9d.jpg?1",
             "name": "Archmage's Newt",
             "text": "Whenever Archmage's Newt deals combat damage to a player, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. That card gains flashback {0} until end of turn instead if Archmage's Newt is saddled.\nSaddle 3",
             "colours": [
@@ -11193,7 +11193,7 @@
         },
         {
             "id": "ec12499e-4675-5cc7-aa18-c98f143542dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f24b8b-f9ed-4c77-8cb0-2a94848ee69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f24b8b-f9ed-4c77-8cb0-2a94848ee69b.jpg?1",
             "name": "Double Down",
             "text": "Whenever you cast an outlaw spell, copy that spell.",
             "colours": [
@@ -11227,7 +11227,7 @@
         },
         {
             "id": "7f32d840-982c-566d-853b-a20e00450c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126ae45-00b3-419c-8f07-d1286ac6b121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126ae45-00b3-419c-8f07-d1286ac6b121.jpg?1",
             "name": "Duelist of the Mind",
             "text": "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
             "colours": [
@@ -11264,7 +11264,7 @@
         },
         {
             "id": "118fb102-9475-519f-8278-5ed3a9d97951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bbf861-448b-455b-8922-38515ba65c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bbf861-448b-455b-8922-38515ba65c40.jpg?1",
             "name": "Fblthp, Lost on the Range",
             "text": "Ward {2}\nYou may look at the top card of your library any time.\nThe top card of your library has plot. The plot cost is equal to its mana cost.\nYou may plot nonland cards from the top of your library.",
             "colours": [
@@ -11302,7 +11302,7 @@
         },
         {
             "id": "2908d282-832f-5e99-86b6-a50cbc4db9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70388ee-2f97-4282-ba74-af95462ac0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70388ee-2f97-4282-ba74-af95462ac0aa.jpg?1",
             "name": "The Key to the Vault",
             "text": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
             "colours": [
@@ -11341,7 +11341,7 @@
         },
         {
             "id": "d35efa44-6de2-5f4c-a43e-1b6330a3d04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e532e5b-6d84-4669-8788-f471b1498c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e532e5b-6d84-4669-8788-f471b1498c7b.jpg?1",
             "name": "Step Between Worlds",
             "text": "Each player may shuffle their hand and graveyard into their library. Each player who does draws seven cards. Exile Step Between Worlds.\nPlot {4}{U}{U}",
             "colours": [
@@ -11375,7 +11375,7 @@
         },
         {
             "id": "7cb9c4fa-8c04-5f3a-9edf-d0d9db4f018d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e346fab1-48db-4cd2-836d-dad5e8437308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e346fab1-48db-4cd2-836d-dad5e8437308.jpg?1",
             "name": "Stoic Sphinx",
             "text": "Flash\nFlying\nStoic Sphinx has hexproof as long as you haven't cast a spell this turn.",
             "colours": [
@@ -11411,7 +11411,7 @@
         },
         {
             "id": "0d3cb81d-a43d-5488-8894-8075d5ff80c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be980c3b-b4ab-4ed7-9f61-d8db54c226d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be980c3b-b4ab-4ed7-9f61-d8db54c226d9.jpg?1",
             "name": "Three Steps Ahead",
             "text": "Spree\n+ {1}{U} \u2014 Counter target spell.\n+ {3} \u2014 Create a token that's a copy of target artifact or creature you control.\n+ {2} \u2014 Draw two cards, then discard a card.",
             "colours": [
@@ -11445,7 +11445,7 @@
         },
         {
             "id": "974bef44-a58c-59ee-80fc-d3c79cfd2c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517505a0-0d05-4e81-8582-999b88040f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517505a0-0d05-4e81-8582-999b88040f48.jpg?1",
             "name": "Caustic Bronco",
             "text": "Whenever Caustic Bronco attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if Caustic Bronco isn't saddled. Otherwise, each opponent loses that much life.\nSaddle 3",
             "colours": [
@@ -11483,7 +11483,7 @@
         },
         {
             "id": "9ac142d3-2ca1-582b-b6c2-9ed5c34cb317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae03d91-8269-4124-ba50-a6c65f47718b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae03d91-8269-4124-ba50-a6c65f47718b.jpg?1",
             "name": "Insatiable Avarice",
             "text": "Spree\n+ {2} \u2014 Search your library for a card, then shuffle and put that card on top.\n+ {B}{B} \u2014 Target player draws three cards and loses 3 life.",
             "colours": [
@@ -11517,7 +11517,7 @@
         },
         {
             "id": "6c5792dd-4e47-5abe-be3d-82a5511ad21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea6391-e70d-4f36-86b7-fd08440b4976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea6391-e70d-4f36-86b7-fd08440b4976.jpg?1",
             "name": "Pitiless Carnage",
             "text": "Sacrifice any number of permanents you control, then draw that many cards.\nPlot {1}{B}{B}",
             "colours": [
@@ -11551,7 +11551,7 @@
         },
         {
             "id": "827d17bd-c634-5a1e-ae65-3a2b569eb028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ca7ac5-5552-487f-9ac9-1092fe6cd165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ca7ac5-5552-487f-9ac9-1092fe6cd165.jpg?1",
             "name": "Rush of Dread",
             "text": "Spree\n+ {1} \u2014 Target opponent sacrifices half the creatures they control, rounded up.\n+ {2} \u2014 Target opponent discards half the cards in their hand, rounded up.\n+ {2} \u2014 Target opponent loses half their life, rounded up.",
             "colours": [
@@ -11585,7 +11585,7 @@
         },
         {
             "id": "76306f73-8a1b-538c-945b-739f1e47e7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3afc0c2-95e7-4b9f-94c5-144cce17c7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3afc0c2-95e7-4b9f-94c5-144cce17c7ed.jpg?1",
             "name": "Tinybones Joins Up",
             "text": "When Tinybones Joins Up enters the battlefield, any number of target players each discard a card.\nWhenever a legendary creature enters the battlefield under your control, any number of target players each mill a card and lose 1 life.",
             "colours": [
@@ -11621,7 +11621,7 @@
         },
         {
             "id": "d86fc688-fca9-5537-9ec5-942fda698dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d876a888-e119-494d-857a-e780a277c817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d876a888-e119-494d-857a-e780a277c817.jpg?1",
             "name": "Vadmir, New Blood",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Vadmir, New Blood. This ability triggers only once each turn.\nAs long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink.",
             "colours": [
@@ -11660,7 +11660,7 @@
         },
         {
             "id": "61bfa14c-8bbe-591a-b4fc-61a7275f1d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295e63c2-b533-4dbf-8c8a-c6493de31457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295e63c2-b533-4dbf-8c8a-c6493de31457.jpg?1",
             "name": "Calamity, Galloping Inferno",
             "text": "Haste\nWhenever Calamity, Galloping Inferno attacks while saddled, choose a nonlegendary creature that saddled it this turn and create a tapped and attacking token that's a copy of it. Sacrifice that token at the beginning of the next end step. Repeat this process once.\nSaddle 1",
             "colours": [
@@ -11699,7 +11699,7 @@
         },
         {
             "id": "1c9a18ed-acac-5a7c-b4bb-2e8904189ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b570d9c5-3348-482f-a211-ed8c9777a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b570d9c5-3348-482f-a211-ed8c9777a9fa.jpg?1",
             "name": "Great Train Heist",
             "text": "Spree\n+ {2}{R} \u2014 Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.\n+ {2} \u2014 Creatures you control get +1/+0 and gain first strike until end of turn.\n+ {R} \u2014 Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
             "colours": [
@@ -11733,7 +11733,7 @@
         },
         {
             "id": "d581a156-4e5a-5533-b94e-3b7da9a9f6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c522c232-0f86-49ad-969f-a2b086432a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c522c232-0f86-49ad-969f-a2b086432a97.jpg?1",
             "name": "Hell to Pay",
             "text": "Hell to Pay deals X damage to target creature. Create a number of tapped Treasure tokens equal to the amount of excess damage dealt to that creature this way.",
             "colours": [
@@ -11767,7 +11767,7 @@
         },
         {
             "id": "2909adc6-4c24-53b5-93a6-a599e5e18aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259262b9-f74b-4e71-9c4e-cf18ba2dc3c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259262b9-f74b-4e71-9c4e-cf18ba2dc3c2.jpg?1",
             "name": "Hellspur Posse Boss",
             "text": "Other outlaws you control have haste.\nWhen Hellspur Posse Boss enters the battlefield, create two 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -11804,7 +11804,7 @@
         },
         {
             "id": "65ee59c5-5b60-5ae2-b944-f762e5281ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf42a57-02f0-4a3f-8677-d68ffe3090c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf42a57-02f0-4a3f-8677-d68ffe3090c0.jpg?1",
             "name": "Magda, the Hoardmaster",
             "text": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn.\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
             "colours": [
@@ -11844,7 +11844,7 @@
         },
         {
             "id": "3c45d8e4-28e3-50b9-90c8-260486b19194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304523e7-f332-4c1d-9590-ff9a70daff26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304523e7-f332-4c1d-9590-ff9a70daff26.jpg?1",
             "name": "Slickshot Show-Off",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, Slickshot Show-Off gets +2/+0 until end of turn.\nPlot {1}{R}",
             "colours": [
@@ -11881,7 +11881,7 @@
         },
         {
             "id": "4956ba04-da57-581c-a99a-849033335c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa00b-bc34-4be8-a21f-11ae695f166d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa00b-bc34-4be8-a21f-11ae695f166d.jpg?1",
             "name": "Stingerback Terror",
             "text": "Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R}",
             "colours": [
@@ -11918,7 +11918,7 @@
         },
         {
             "id": "a9aa0f6a-b20a-563b-bcc7-51e00a14ef5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd20aae9-9de0-498b-8325-f8e8290d56e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd20aae9-9de0-498b-8325-f8e8290d56e3.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -11954,7 +11954,7 @@
         },
         {
             "id": "052da6e7-e1e8-525a-9dd4-768ab121e9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f921e711-168d-4836-bca2-f9bb43992708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f921e711-168d-4836-bca2-f9bb43992708.jpg?1",
             "name": "Bristly Bill, Spine Sower",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature.\n{3}{G}{G}: Double the number of +1/+1 counters on each creature you control.",
             "colours": [
@@ -11993,7 +11993,7 @@
         },
         {
             "id": "78b82d7d-06fc-5796-8f8d-b2afb5a847d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fbb0c7-29ac-4394-87e1-6e8227602aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fbb0c7-29ac-4394-87e1-6e8227602aac.jpg?1",
             "name": "Colossal Rattlewurm",
             "text": "Colossal Rattlewurm has flash as long as you control a Desert.\nTrample\n{1}{G}, Exile Colossal Rattlewurm from your graveyard: Search your library for a Desert card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -12029,7 +12029,7 @@
         },
         {
             "id": "c8cb0431-3e84-53ba-a791-0a2e70574f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81289833-ebdb-4fe7-ad17-6e39eb399e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81289833-ebdb-4fe7-ad17-6e39eb399e69.jpg?1",
             "name": "Freestrider Lookout",
             "text": "Reach\nWhenever you commit a crime, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
             "colours": [
@@ -12066,7 +12066,7 @@
         },
         {
             "id": "3388a871-eb2b-5496-a56f-7aff2f53dc67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700b3a6-327b-4dc0-aa8d-434ca971a7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700b3a6-327b-4dc0-aa8d-434ca971a7b9.jpg?1",
             "name": "Goldvein Hydra",
             "text": "Vigilance, trample, haste\nGoldvein Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Goldvein Hydra dies, create a number of tapped Treasure tokens equal to its power.",
             "colours": [
@@ -12102,7 +12102,7 @@
         },
         {
             "id": "b3457978-935d-5a42-9462-4eabf84f577e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1729d3-8e27-4db0-a7c6-e629a8faf946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1729d3-8e27-4db0-a7c6-e629a8faf946.jpg?1",
             "name": "Ornery Tumblewagg",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature.\nWhenever Ornery Tumblewagg attacks while saddled, double the number of +1/+1 counters on target creature.\nSaddle 2",
             "colours": [
@@ -12139,7 +12139,7 @@
         },
         {
             "id": "da1cabbe-023a-5cf2-9c87-a63bab5b24b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf1fe32-eac2-4d50-b403-25c3666f6d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf1fe32-eac2-4d50-b403-25c3666f6d80.jpg?1",
             "name": "Outcaster Trailblazer",
             "text": "When Outcaster Trailblazer enters the battlefield, add one mana of any color.\nWhenever another creature with power 4 or greater enters the battlefield under your control, draw a card.\nPlot {2}{G}",
             "colours": [
@@ -12176,7 +12176,7 @@
         },
         {
             "id": "89862c93-72fd-5aa8-97b1-1f3d57365a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db8c96-e6b8-4d4a-9935-29f12385a151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db8c96-e6b8-4d4a-9935-29f12385a151.jpg?1",
             "name": "Railway Brawler",
             "text": "Reach, trample\nWhenever another creature enters the battlefield under your control, put X +1/+1 counters on it, where X is its power.\nPlot {3}{G}",
             "colours": [
@@ -12213,7 +12213,7 @@
         },
         {
             "id": "72a6cf79-fe73-5017-a06c-077439871f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b76d0d-da55-44ec-add8-61696ee40d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b76d0d-da55-44ec-add8-61696ee40d21.jpg?1",
             "name": "Smuggler's Surprise",
             "text": "Spree\n+ {2} \u2014 Mill four cards. You may put up to two creature and/or land cards from among the milled cards into your hand.\n+ {4}{G} \u2014 You may put up to two creature cards from your hand onto the battlefield.\n+ {1} \u2014 Creatures you control with power 4 or greater gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -12247,7 +12247,7 @@
         },
         {
             "id": "383449f6-c81e-5316-9754-9749e424953d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6534bdb1-9436-4919-8a8b-5401bc070fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6534bdb1-9436-4919-8a8b-5401bc070fc2.jpg?1",
             "name": "Akul the Unrepentant",
             "text": "Flying, trample\nSacrifice three other creatures: You may put a creature card from your hand onto the battlefield. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -12289,7 +12289,7 @@
         },
         {
             "id": "280ad7c3-321b-5970-a7dc-cced454a992e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce19341-e652-448f-8f14-0439bd8fa385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce19341-e652-448f-8f14-0439bd8fa385.jpg?1",
             "name": "Annie Joins Up",
             "text": "When Annie Joins Up enters the battlefield, it deals 5 damage to target creature or planeswalker an opponent controls.\nIf a triggered ability of a legendary creature you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -12329,7 +12329,7 @@
         },
         {
             "id": "4cb47089-5249-547f-8d3b-ec9b5468e7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8e4f7b-bdf6-44d3-9b2b-4420bab84864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8e4f7b-bdf6-44d3-9b2b-4420bab84864.jpg?1",
             "name": "Assimilation Aegis",
             "text": "When Assimilation Aegis enters the battlefield, exile up to one target creature until Assimilation Aegis leaves the battlefield.\nWhenever Assimilation Aegis becomes attached to a creature, for as long as Assimilation Aegis remains attached to it, that creature becomes a copy of a creature card exiled with Assimilation Aegis.\nEquip {2}",
             "colours": [
@@ -12367,7 +12367,7 @@
         },
         {
             "id": "e62cef32-7cce-5ae4-b3aa-138f6cc24f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29f20b-27cd-433a-8874-41f500720109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29f20b-27cd-433a-8874-41f500720109.jpg?1",
             "name": "Bonny Pall, Clearcutter",
             "text": "Reach\nWhen Bonny Pall, Clearcutter enters the battlefield, create Beau, a legendary blue Ox creature token with \"This creature's power and toughness are each equal to the number of lands you control.\"\nWhenever you attack, draw a card, then you may put a land card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -12408,7 +12408,7 @@
         },
         {
             "id": "e845ce1d-3428-5497-b596-cc0f1697d098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026257bf-f4e7-45f8-9c93-7248f201c583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026257bf-f4e7-45f8-9c93-7248f201c583.jpg?1",
             "name": "Bruse Tarl, Roving Rancher",
             "text": "Oxen you control have double strike.\nWhenever Bruse Tarl, Roving Rancher enters the battlefield or attacks, exile the top card of your library. If it's a land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the end of your next turn.",
             "colours": [
@@ -12449,7 +12449,7 @@
         },
         {
             "id": "d2ab9ab0-c7e4-5627-ac00-6f4b1ae234e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203c84a3-5f1a-440f-93e7-bb65d1e07886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203c84a3-5f1a-440f-93e7-bb65d1e07886.jpg?1",
             "name": "Ghired, Mirror of the Wilds",
             "text": "Haste\nNontoken creatures you control have \"{T}: Create a token that's a copy of target token you control that entered the battlefield this turn.\"",
             "colours": [
@@ -12492,7 +12492,7 @@
         },
         {
             "id": "34856c65-0267-5cb7-89ec-52cab29bce95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a634b934-710b-4c83-b769-d8a034e297b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a634b934-710b-4c83-b769-d8a034e297b8.jpg?1",
             "name": "The Gitrog, Ravenous Ride",
             "text": "Trample, haste\nWhenever The Gitrog, Ravenous Ride deals combat damage to a player, you may sacrifice a creature that saddled it this turn. If you do, draw X cards, then put up to X land cards from your hand onto the battlefield tapped, where X is the sacrificed creature's power.\nSaddle 1",
             "colours": [
@@ -12534,7 +12534,7 @@
         },
         {
             "id": "efe1837f-7933-5064-b3e7-ece8c4536ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd5a0f-8859-4272-a08f-13b788422f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd5a0f-8859-4272-a08f-13b788422f4c.jpg?1",
             "name": "Kambal, Profiteering Mayor",
             "text": "Whenever one or more tokens enter the battlefield under your opponents' control, for each of them, create a tapped token that's a copy of it. This ability triggers only once each turn.\nWhenever one or more tokens enter the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -12575,7 +12575,7 @@
         },
         {
             "id": "86de96a2-fae2-5bf9-a028-7e2b808a47aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d927dc7-77b7-473d-b50b-e81c52d66b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d927dc7-77b7-473d-b50b-e81c52d66b55.jpg?1",
             "name": "Kellan Joins Up",
             "text": "When Kellan Joins Up enters the battlefield, you may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\nWhenever a legendary creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -12615,7 +12615,7 @@
         },
         {
             "id": "1d0ccfc7-d9b7-5e4a-9121-0749a29e1501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7fadd-33ea-4bf4-9122-362821ef96dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7fadd-33ea-4bf4-9122-362821ef96dc.jpg?1",
             "name": "Laughing Jasper Flint",
             "text": "Creatures you control but don't own are Mercenaries in addition to their other types.\nAt the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells.",
             "colours": [
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "a2ed0519-24e7-5b4e-b3a7-241f8a9e28c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95efd401-579e-448b-9655-31311c0ae41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95efd401-579e-448b-9655-31311c0ae41e.jpg?1",
             "name": "Lilah, Undefeated Slickshot",
             "text": "Prowess\nWhenever you cast a multicolored instant or sorcery spell from your hand, exile that spell instead of putting it into your graveyard as it resolves. If you do, it becomes plotted.",
             "colours": [
@@ -12697,7 +12697,7 @@
         },
         {
             "id": "6453614a-d397-52d4-8f15-c62c7d7cb4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724309cd-fb05-4632-a7be-33a9ba024e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724309cd-fb05-4632-a7be-33a9ba024e4a.jpg?1",
             "name": "Marchesa, Dealer of Death",
             "text": "Whenever you commit a crime, you may pay {1}. If you do, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -12740,7 +12740,7 @@
         },
         {
             "id": "91a2ed57-2e9b-55f8-88a0-8ee34f9d1c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183b8c06-62ab-41e8-82c1-f23066d832ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183b8c06-62ab-41e8-82c1-f23066d832ee.jpg?1",
             "name": "Obeka, Splitter of Seconds",
             "text": "Menace\nWhenever Obeka, Splitter of Seconds deals combat damage to a player, you get that many additional upkeep steps after this phase.",
             "colours": [
@@ -12783,7 +12783,7 @@
         },
         {
             "id": "9d18996b-ad03-5239-aa32-bcbe2ff69c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05939b7-1877-4464-98fe-d3b9ae754fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05939b7-1877-4464-98fe-d3b9ae754fb9.jpg?1",
             "name": "Pillage the Bog",
             "text": "Look at the top X cards of your library, where X is twice the number of lands you control. Put one of them into your hand and the rest on the bottom of your library in a random order.\nPlot {1}{B}{G}",
             "colours": [
@@ -12819,7 +12819,7 @@
         },
         {
             "id": "3feb0232-b85f-5f27-aa68-71159cad4dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a743a-6358-4e08-a6b7-6eaaf7ab9ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a743a-6358-4e08-a6b7-6eaaf7ab9ddc.jpg?1",
             "name": "Rakdos Joins Up",
             "text": "When Rakdos Joins Up enters the battlefield, return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it.\nWhenever a legendary creature you control dies, Rakdos Joins Up deals damage equal to that creature's power to target opponent.",
             "colours": [
@@ -12857,7 +12857,7 @@
         },
         {
             "id": "661e5cfc-5c70-546d-ac47-1dcde9de2e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215b4632-adce-4357-bfcf-b6014ed2a24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215b4632-adce-4357-bfcf-b6014ed2a24b.jpg?1",
             "name": "Riku of Many Paths",
             "text": "Whenever you cast a modal spell, choose up to X, where X is the number of times you chose a mode for that spell \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play it.\n\u2022 Put a +1/+1 counter on Riku of Many Paths. It gains trample until end of turn.\n\u2022 Create a 1/1 blue Bird creature token with flying.",
             "colours": [
@@ -12900,7 +12900,7 @@
         },
         {
             "id": "a21a90ad-0c4f-5479-81f7-b17abcb512b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8aea8d-452a-4b23-bc78-8c7db54610d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8aea8d-452a-4b23-bc78-8c7db54610d3.jpg?1",
             "name": "Roxanne, Starfall Savant",
             "text": "Whenever Roxanne, Starfall Savant enters the battlefield or attacks, create a tapped colorless artifact token named Meteorite with \"When Meteorite enters the battlefield, it deals 2 damage to any target\" and \"{T}: Add one mana of any color.\"\nWhenever you tap an artifact token for mana, add one mana of any type that artifact token produced.",
             "colours": [
@@ -12941,7 +12941,7 @@
         },
         {
             "id": "b1545762-3a9d-54ee-b630-0e46d97cab41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e523de28-b2d5-4be9-be78-883cef2499e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e523de28-b2d5-4be9-be78-883cef2499e9.jpg?1",
             "name": "Selvala, Eager Trailblazer",
             "text": "Vigilance\nWhenever you cast a creature spell, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{T}: Choose a color. Add one mana of that color for each different power among creatures you control.",
             "colours": [
@@ -12982,7 +12982,7 @@
         },
         {
             "id": "ef08d011-52d2-5edd-87b2-a342d4bdd8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9df2d7-6738-496c-8164-8bdf7d011df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9df2d7-6738-496c-8164-8bdf7d011df3.jpg?1",
             "name": "Seraphic Steed",
             "text": "First strike, lifelink\nWhenever Seraphic Steed attacks while saddled, create a 3/3 white Angel creature token with flying.\nSaddle 4",
             "colours": [
@@ -13021,7 +13021,7 @@
         },
         {
             "id": "80808eb9-68bc-5932-9df7-25bc6852a15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c558349-87bc-4e0f-96c2-b075f7da97d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c558349-87bc-4e0f-96c2-b075f7da97d5.jpg?1",
             "name": "Taii Wakeen, Perfect Shot",
             "text": "Whenever a source you control deals noncombat damage to a creature equal to that creature's toughness, draw a card.\n{X}, {T}: If a source you control would deal noncombat damage to a permanent or player this turn, it deals that much damage plus X instead.",
             "colours": [
@@ -13062,7 +13062,7 @@
         },
         {
             "id": "994a8029-791f-558b-8906-6e219012e24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43579701-c89a-4455-8f6a-0589af0c6bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43579701-c89a-4455-8f6a-0589af0c6bd3.jpg?1",
             "name": "Vraska Joins Up",
             "text": "When Vraska Joins Up enters the battlefield, put a deathtouch counter on each creature you control.\nWhenever a legendary creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "4f150a06-c180-5cc2-84dc-ea350846becf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17955d83-89ea-4151-950c-d72acf1a852a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17955d83-89ea-4151-950c-d72acf1a852a.jpg?1",
             "name": "Wylie Duke, Atiin Hero",
             "text": "Vigilance\nWhenever Wylie Duke, Atiin Hero becomes tapped, you gain 1 life and draw a card.",
             "colours": [
@@ -13141,7 +13141,7 @@
         },
         {
             "id": "512e2281-b1fa-5682-a850-4dd65e7645de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd49911-9ddb-4bef-8cd0-89f558ccd5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd49911-9ddb-4bef-8cd0-89f558ccd5cc.jpg?1",
             "name": "Frontier Seeker",
             "text": "When Frontier Seeker enters the battlefield, look at the top five cards of your library. You may reveal a Mount creature card or a Plains card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "a6b95033-5491-5e88-9b9c-09aaa117b91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188694af-b856-4439-8ce0-8306b38caacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188694af-b856-4439-8ce0-8306b38caacb.jpg?1",
             "name": "Scorching Shot",
             "text": "Scorching Shot deals 5 damage to target creature.",
             "colours": [
@@ -13211,7 +13211,7 @@
         },
         {
             "id": "44cf63d1-cfff-5726-92d0-53d5e50f057f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8df8b87-3ea1-44eb-9218-9e7e06dfd0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8df8b87-3ea1-44eb-9218-9e7e06dfd0db.jpg?1",
             "name": "Honest Rutstein",
             "text": "When Honest Rutstein enters the battlefield, return target creature card from your graveyard to your hand.\nCreature spells you cast cost {1} less to cast.",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "88f01215-1e3e-557f-9fa6-8d838b5e8a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9073963-5866-4132-a059-a46f96cd2a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9073963-5866-4132-a059-a46f96cd2a8d.jpg?1",
             "name": "Make Your Own Luck",
             "text": "Look at the top three cards of your library. You may exile a nonland card from among them. If you do, it becomes plotted. Put the rest into your hand.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "bcb3cea4-a348-5546-a82a-6991a2822d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19e6995-4926-4513-b8c1-f35a22aafbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19e6995-4926-4513-b8c1-f35a22aafbe5.jpg?1",
             "name": "Ruthless Lawbringer",
             "text": "When Ruthless Lawbringer enters the battlefield, you may sacrifice another creature. When you do, destroy target nonland permanent.",
             "colours": [
@@ -13325,7 +13325,7 @@
         },
         {
             "id": "6facc0db-c630-5624-bf58-b03350b84a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695db51-f9d5-4eef-84d9-62f7602792b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695db51-f9d5-4eef-84d9-62f7602792b4.jpg?1",
             "name": "The Key to the Vault",
             "text": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
             "colours": [
@@ -13363,7 +13363,7 @@
         },
         {
             "id": "b5b5322f-0ea1-5652-99a4-cf3a14fcfb2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834e84e-e932-4052-9dad-2e1c8e76fbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834e84e-e932-4052-9dad-2e1c8e76fbbc.jpg?1",
             "name": "Magda, the Hoardmaster",
             "text": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn.\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
             "colours": [
@@ -13402,7 +13402,7 @@
         },
         {
             "id": "4d2ba458-569a-5a74-b079-cd2b89ec3f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f57c5-923a-4824-969e-53feddd78c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f57c5-923a-4824-969e-53feddd78c3b.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -13430,7 +13430,7 @@
         },
         {
             "id": "125181f9-7b89-595f-9fa7-fb0b325b664b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d8c502-e053-425f-ba40-27a627ca12a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d8c502-e053-425f-ba40-27a627ca12a0.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -13465,7 +13465,7 @@
         },
         {
             "id": "0c6204e4-e3fc-51cd-9496-4b2da24e3783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -13500,7 +13500,7 @@
         },
         {
             "id": "644d3865-e392-5252-afa5-16f1574c96d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccb30d0-b491-43be-8aa0-2ee7da86343e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccb30d0-b491-43be-8aa0-2ee7da86343e.jpg?1",
             "name": "Sheep",
             "text": "",
             "colours": [
@@ -13535,7 +13535,7 @@
         },
         {
             "id": "2aeeec8f-4a21-58bf-a104-6ef6ea36077b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c15b18b-1ab1-44e9-b96f-c36d52f11ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c15b18b-1ab1-44e9-b96f-c36d52f11ea0.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -13570,7 +13570,7 @@
         },
         {
             "id": "d9de4442-bfad-519b-8851-a5957e5de797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1751016-9461-4250-ac07-afe4f5b41095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1751016-9461-4250-ac07-afe4f5b41095.jpg?1",
             "name": "Beau",
             "text": "",
             "colours": [
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "4121ca98-6b4d-582a-915e-7e7bb7b4ba15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d9280-a79a-4f9f-822c-7aaecbff3337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d9280-a79a-4f9f-822c-7aaecbff3337.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -13642,7 +13642,7 @@
         },
         {
             "id": "f0ef8d6a-4b64-5c73-8233-800aee022a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a35e07-9d80-4f2b-a000-5638b72a9808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a35e07-9d80-4f2b-a000-5638b72a9808.jpg?1",
             "name": "Vampire Rogue",
             "text": "",
             "colours": [
@@ -13678,7 +13678,7 @@
         },
         {
             "id": "13ae534a-28a8-5a1d-9e3c-d3cc3cb539f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c01ea-427d-4401-b5b0-166e87c4585e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c01ea-427d-4401-b5b0-166e87c4585e.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -13713,7 +13713,7 @@
         },
         {
             "id": "0b3c8513-324d-5347-af39-b6da4161a67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1",
             "name": "Mercenary",
             "text": "",
             "colours": [
@@ -13748,7 +13748,7 @@
         },
         {
             "id": "693ffc98-ec95-55c5-8d26-0cadc4663721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg?1",
             "name": "Scorpion Dragon",
             "text": "",
             "colours": [
@@ -13784,7 +13784,7 @@
         },
         {
             "id": "d07787f4-9cc9-532c-8917-b4afb42e49b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -13819,7 +13819,7 @@
         },
         {
             "id": "550650bd-3ac5-55ee-b739-173af89ff794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1632f3fa-4615-46ee-9768-22bbd9d142d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1632f3fa-4615-46ee-9768-22bbd9d142d6.jpg?1",
             "name": "Elk",
             "text": "",
             "colours": [
@@ -13854,7 +13854,7 @@
         },
         {
             "id": "a48209c0-04de-5b70-a252-d5c3462dc3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcefb329-b93d-41a1-88d3-8058afebeca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcefb329-b93d-41a1-88d3-8058afebeca8.jpg?1",
             "name": "Varmint",
             "text": "",
             "colours": [
@@ -13889,7 +13889,7 @@
         },
         {
             "id": "9c4d4329-1a29-544f-b569-59312b54fd19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1",
             "name": "Zombie Rogue",
             "text": "",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "fc4a3b47-a7a6-5fa9-8eb5-e99527c79be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a906c-8b27-4ffa-bdc3-7825c6919d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a906c-8b27-4ffa-bdc3-7825c6919d3e.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -13958,7 +13958,7 @@
         },
         {
             "id": "f605e1eb-231e-5e9f-89dd-93523bee6512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b41ca9-0bf0-41fc-af65-854e602ee007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b41ca9-0bf0-41fc-af65-854e602ee007.jpg?1",
             "name": "Meteorite",
             "text": "",
             "colours": [],
@@ -13987,7 +13987,7 @@
         },
         {
             "id": "3a2e0ac9-54bb-5b35-a4c9-6bad348f7144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec6f053-96f7-4e57-b2eb-4e7699a40a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec6f053-96f7-4e57-b2eb-4e7699a40a4f.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -14018,7 +14018,7 @@
         },
         {
             "id": "d0056891-3072-5040-b870-2c88c9110497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07677af-88a4-4ff5-b591-e1e3ac05235d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07677af-88a4-4ff5-b591-e1e3ac05235d.jpg?1",
             "name": "Plot",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/P02.json
+++ b/Assets/Resources/Sets/P02.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4b3884d1-6b49-5c17-b07b-a9a06e2d8eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e865658-67c8-43b2-8d3a-909fb1c17e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e865658-67c8-43b2-8d3a-909fb1c17e8a.jpg?1",
             "name": "Alaborn Cavalier",
             "text": "If Alaborn Cavalier attacks, you may choose to tap any one creature. (Tapped creatures can't block.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "05063d02-db75-5a6f-b09b-361a7a70b6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153b7197-57a7-4e38-bd4a-4550b9d22dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153b7197-57a7-4e38-bd4a-4550b9d22dd8.jpg?1",
             "name": "Alaborn Grenadier",
             "text": "Attacking doesn't cause Alaborn Grenadier to tap.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "20adc065-0a79-5b52-ba02-315b613047d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4776a9ed-dbc6-44d2-9761-b2d09ff34008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4776a9ed-dbc6-44d2-9761-b2d09ff34008.jpg?1",
             "name": "Alaborn Musketeer",
             "text": "Alaborn Musketeer can block creatures with flying.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "fd1cdc87-8e3d-506a-849b-4103294ae429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg?1",
             "name": "Alaborn Trooper",
             "text": "",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "171ef4d1-e523-5b21-8133-520521182c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg?1",
             "name": "Alaborn Veteran",
             "text": "On your turn, before you attack, you may tap Alaborn Veteran to give any one creature +2/+2 until the end of the turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "0ab9317a-6ff8-5e7f-a7f7-c505884104ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5eba273-0b83-42a7-b8b0-9e0cd6a7aa6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5eba273-0b83-42a7-b8b0-9e0cd6a7aa6f.jpg?1",
             "name": "Alaborn Zealot",
             "text": "If Alaborn Zealot blocks, destroy both Alaborn Zealot and the creature it blocks. (Destroy both creatures before you deal damage.)",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "d579766b-8d09-5c6f-9866-da6f4847e7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2461bf0b-53e4-4103-8485-88a940ad66fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2461bf0b-53e4-4103-8485-88a940ad66fd.jpg?1",
             "name": "Angel of Fury",
             "text": "Flying\nIf Angel of Fury is put into your graveyard from play, you may choose to shuffle Angel of Fury into your library.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "3af0b117-d8af-50b4-9c78-7afd04196daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac5c913-4eb5-4cfb-9c24-223f14f07064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac5c913-4eb5-4cfb-9c24-223f14f07064.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy comes into play from your hand, you gain 3 life.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "0483ce25-fc41-508d-9f20-30eb61015f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d409ef-9635-4ebe-944f-03e371bc40f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d409ef-9635-4ebe-944f-03e371bc40f0.jpg?1",
             "name": "Angelic Blessing",
             "text": "Any one creature gets +3/+3 and gains flying until the end of the turn.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "7ddca86a-2e7f-523f-89e4-0c3c1e136b4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bb39fb-29fc-4e69-9918-47277b8af0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bb39fb-29fc-4e69-9918-47277b8af0d3.jpg?1",
             "name": "Angelic Wall",
             "text": "Flying\nWalls can't attack.",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "e1d2266c-766d-5674-9f97-3d792e12bf1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73364e-d833-410f-b460-c36fe14c52ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73364e-d833-410f-b460-c36fe14c52ca.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking doesn't cause Archangel to tap.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "91c17e31-bed6-5572-8d96-d5a0d2c22b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f2ab-e09c-48d5-9c87-d27368e60750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f2ab-e09c-48d5-9c87-d27368e60750.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands. (This includes your lands.)",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "b9680460-9d43-5cf0-8f0a-0ae3629b6964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54866603-c80c-4dc8-9655-eaf54ed2c5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54866603-c80c-4dc8-9655-eaf54ed2c5ab.jpg?1",
             "name": "Armored Griffin",
             "text": "Flying\nAttacking doesn't cause Armored Griffin to tap.",
             "colours": [
@@ -435,7 +435,7 @@
         },
         {
             "id": "acb236ef-c2bc-5ef8-9820-19755172f21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7f3064-a378-4ca4-99f5-b46518ddc43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7f3064-a378-4ca4-99f5-b46518ddc43d.jpg?1",
             "name": "Bargain",
             "text": "Your opponent draws a card.\nYou gain 7 life.",
             "colours": [
@@ -466,7 +466,7 @@
         },
         {
             "id": "dd85a42c-fc6b-5ae6-920d-21b4de59b019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10f24f7-f82e-413e-824f-384607c7d858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10f24f7-f82e-413e-824f-384607c7d858.jpg?1",
             "name": "Breath of Life",
             "text": "Take any one creature card from your graveyard and put that creature into play. Treat it as though you just played it from your hand.",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "e59a2c2e-afea-56cd-aecf-f813ddafd80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bd783b-d4cd-4a53-8fec-a5ead7c14738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bd783b-d4cd-4a53-8fec-a5ead7c14738.jpg?1",
             "name": "Festival of Trokin",
             "text": "For each creature you have in play, you gain 2 life.",
             "colours": [
@@ -528,7 +528,7 @@
         },
         {
             "id": "46a26109-7a27-56e8-818b-83dc6524cdb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg?1",
             "name": "Just Fate",
             "text": "Play Just Fate only after you're attacked, before you declare blockers.\nDestroy any one attacking creature.",
             "colours": [
@@ -559,7 +559,7 @@
         },
         {
             "id": "62ecf410-4a0c-5c81-8daa-84cfc2efe9c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb14d3f4-09f3-4113-bdc3-0fd753137f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb14d3f4-09f3-4113-bdc3-0fd753137f7c.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy any one creature. That creature's owner gains 4 life.",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "0800ceaa-23e1-50da-a073-d12b176e59d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d92577-c3e2-4129-8974-89eb896cdc2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d92577-c3e2-4129-8974-89eb896cdc2d.jpg?1",
             "name": "Rally the Troops",
             "text": "Play Rally the Troops only after you're attacked, before you declare blockers.\nUntap all your creatures.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "84d32c03-2f69-57e4-a4ca-4bb26f52e45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7bd958-20c7-4394-8beb-06b32db90d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7bd958-20c7-4394-8beb-06b32db90d32.jpg?1",
             "name": "Righteous Charge",
             "text": "All your creatures get +2/+2 until the end of the turn.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "a753d196-28bb-5e29-a888-b56191ddf1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c408f43e-9092-440d-a15f-bef4ad58bcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c408f43e-9092-440d-a15f-bef4ad58bcc6.jpg?1",
             "name": "Righteous Fury",
             "text": "Destroy all tapped creatures. For each creature destroyed this way, you gain 2 life. (This includes your creatures.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "465ba5c5-ce53-57bf-a5d0-af89c2eb50d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbf23ff-e095-4c5c-afe6-76badfc422c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbf23ff-e095-4c5c-afe6-76badfc422c5.jpg?1",
             "name": "Steam Catapult",
             "text": "On your turn, before you attack, you may tap Steam Catapult to destroy any one tapped creature.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "724dfe39-01f7-5db8-a143-dbe14b697ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be7cba2-5673-4bef-aa3d-cbfad8932610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be7cba2-5673-4bef-aa3d-cbfad8932610.jpg?1",
             "name": "Temple Acolyte",
             "text": "When Temple Acolyte comes into play from your hand, you gain 3 life.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "f95be15a-ab0a-540f-ad0d-f09395d35f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4d4b14-d774-430c-a483-be04a238718d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4d4b14-d774-430c-a483-be04a238718d.jpg?1",
             "name": "Temple Elder",
             "text": "On your turn, before you attack, you may tap Temple Elder to gain 1 life.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "72962fc6-224e-5bf8-a4bc-95160869cf74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e9db36-0592-4e59-951a-d9d6c1522b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e9db36-0592-4e59-951a-d9d6c1522b99.jpg?1",
             "name": "Town Sentry",
             "text": "If Town Sentry blocks, it gets +0/+2 until the end of the turn.",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "13b39a81-9d65-5fbc-9b4f-578a0eb7be78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2b9302-fca6-43ca-a01c-03aec51acd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2b9302-fca6-43ca-a01c-03aec51acd0d.jpg?1",
             "name": "Trokin High Guard",
             "text": "",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "350f6e61-59d9-530f-8d78-e789f66abb7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3209ee48-4485-44fc-b71d-cd6241674e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3209ee48-4485-44fc-b71d-cd6241674e64.jpg?1",
             "name": "Vengeance",
             "text": "Destroy any one tapped creature.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "110013f9-92fe-514c-93b7-b35688d16310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg?1",
             "name": "Volunteer Militia",
             "text": "",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "74313962-3c55-5849-950a-82df41d58fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a24f00c-7e2e-4609-b956-ca3d5fb365b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a24f00c-7e2e-4609-b956-ca3d5fb365b2.jpg?1",
             "name": "Warrior's Stand",
             "text": "Play Warrior's Stand only after you're attacked, before you declare blockers.\nAll your creatures get +2/+2 until the end of the turn.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "ff37c3b6-fcb9-5376-9a68-504edefff8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b6541a-cda3-4c8a-a5b0-1845169b9b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b6541a-cda3-4c8a-a5b0-1845169b9b71.jpg?1",
             "name": "Wild Griffin",
             "text": "Flying",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "1507acc3-d4d3-5f7b-a86b-9a23adfbb6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd01ed7d-45d5-420c-836c-aec52250f161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd01ed7d-45d5-420c-836c-aec52250f161.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "8cdea777-148b-57de-990d-afce048a556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd317-5500-40e8-ad79-323832815f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd317-5500-40e8-ad79-323832815f81.jpg?1",
             "name": "Apprentice Sorcerer",
             "text": "On your turn, before you attack, you may tap Apprentice Sorcerer to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "e1e71ca9-c264-50d2-9c7b-b33762fb694f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b2978-2da5-41cf-85d4-128e9dae75c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b2978-2da5-41cf-85d4-128e9dae75c0.jpg?1",
             "name": "Armored Galleon",
             "text": "Armored Galleon can't attack unless the defending player has an island in play.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "8d7f7c47-ef31-5368-9375-3cb9700bf922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8c7377-1404-44a4-9689-1fc6cdc286c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8c7377-1404-44a4-9689-1fc6cdc286c8.jpg?1",
             "name": "Coastal Wizard",
             "text": "On your turn, before you attack, you may tap Coastal Wizard to return it and any one other creature to their owners' hands.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "8c5dc4a4-26d4-50c6-a244-6dc4315b5e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620478b8-47b7-48c5-ac22-1ba4d234c794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620478b8-47b7-48c5-ac22-1ba4d234c794.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep comes into play from your hand, return all your other creatures from play to your hand.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "19fdf0c3-9b8e-5402-a15a-c540801ebce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade6a71a-e8ec-4d41-8a39-3eacf0097c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade6a71a-e8ec-4d41-8a39-3eacf0097c8b.jpg?1",
             "name": "D\u00e9j\u00e0 Vu",
             "text": "Return any one sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "316eb72b-74b5-53ec-a434-132481adcd5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc103a6-7888-4e35-b35b-a796a48caf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc103a6-7888-4e35-b35b-a796a48caf70.jpg?1",
             "name": "Exhaustion",
             "text": "At the beginning of your opponent's next turn, he or she skips untapping creatures and lands.",
             "colours": [
@@ -1212,7 +1212,7 @@
         },
         {
             "id": "8893a4c8-eb91-5a67-b93a-9c619f392a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641f4e66-b46b-4da3-a053-f3763400d4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641f4e66-b46b-4da3-a053-f3763400d4f5.jpg?1",
             "name": "Extinguish",
             "text": "Play Extinguish only in response to another player playing a sorcery. That sorcery has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1243,7 +1243,7 @@
         },
         {
             "id": "a43e6feb-1a79-5829-a53e-7243d7fdb42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee109b81-96ef-494a-9d6d-0ea4a49b76a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee109b81-96ef-494a-9d6d-0ea4a49b76a0.jpg?1",
             "name": "Eye Spy",
             "text": "Look at the top card of any player's library. You may choose to put that card back on top of that library or into that player's graveyard.",
             "colours": [
@@ -1274,7 +1274,7 @@
         },
         {
             "id": "0043f4a7-aa18-59f1-b105-33d0c481665a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7d30a8-bc7a-42bc-8d1b-600cbf78ab98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7d30a8-bc7a-42bc-8d1b-600cbf78ab98.jpg?1",
             "name": "False Summoning",
             "text": "Play False Summoning only in response to another player playing a creature. That creature card has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "8aa736aa-0632-50f5-8f65-0cbee1894fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bb424f-f3d6-4616-a368-df12af3ad024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bb424f-f3d6-4616-a368-df12af3ad024.jpg?1",
             "name": "Mystic Denial",
             "text": "Play Mystic Denial only in response to another player playing a creature or a sorcery. That card has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "9db14610-4ab3-53d9-9c0b-27cd78790739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daeab88f-2bfc-4f40-8eed-ee44a9e90bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daeab88f-2bfc-4f40-8eed-ee44a9e90bd7.jpg?1",
             "name": "Piracy",
             "text": "This turn, you may tap your opponent's lands to help pay for your spells.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "04759a7b-46dc-512e-8b66-09a3d706aea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb08549-8ff8-410f-b817-0255abaf8b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb08549-8ff8-410f-b817-0255abaf8b1e.jpg?1",
             "name": "Remove",
             "text": "Play Remove only after you're attacked, before you declare blockers.\nReturn any one attacking creature to its owner's hand.",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "ded7a8ef-0d84-59b1-9472-0ef2e695c9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c16faac-b093-425b-b1e9-f71602d2f6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c16faac-b093-425b-b1e9-f71602d2f6dd.jpg?1",
             "name": "Screeching Drake",
             "text": "Flying\nWhen Screeching Drake comes into play from your hand, draw a card, then choose and discard a card from your hand.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "63dde068-db76-5981-9523-57975ca1c666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87a40cb-b30d-41ce-8e11-5fe3136fdadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87a40cb-b30d-41ce-8e11-5fe3136fdadd.jpg?1",
             "name": "Sea Drake",
             "text": "Flying\nWhen Sea Drake comes into play from your hand, return any two of your lands from play to your hand.",
             "colours": [
@@ -1464,7 +1464,7 @@
         },
         {
             "id": "cf9edb85-1751-5ba5-adef-bad2ef7f6986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405184-dcda-4bb6-ade6-c2a87bc3296d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405184-dcda-4bb6-ade6-c2a87bc3296d.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "8aa2dbd3-e900-51e3-879e-5ec275208b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3193cb-2c00-4ef8-bf2e-d3b1e3b875a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3193cb-2c00-4ef8-bf2e-d3b1e3b875a3.jpg?1",
             "name": "Steam Frigate",
             "text": "Steam Frigate can't attack unless the defending player has an island in play.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "70bd28c6-a9c5-572e-b6b0-1b8d7fc0fa99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bc3159-f585-45cd-8578-f3bf2fa9b2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bc3159-f585-45cd-8578-f3bf2fa9b2d1.jpg?1",
             "name": "Talas Air Ship",
             "text": "Flying",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "f76df1e2-be5f-5592-a574-5001bea3a05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f184c9-a716-4ba8-8efa-495358660de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f184c9-a716-4ba8-8efa-495358660de5.jpg?1",
             "name": "Talas Explorer",
             "text": "Flying\nWhen Talas Explorer comes into play from your hand, look at your opponent's hand.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "0eb7db17-9d5e-5d7c-ba08-4159877ba814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f779d7e-6e37-49bc-b76d-3bb490ff142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f779d7e-6e37-49bc-b76d-3bb490ff142b.jpg?1",
             "name": "Talas Merchant",
             "text": "",
             "colours": [
@@ -1632,7 +1632,7 @@
         },
         {
             "id": "0ce6d425-2333-5622-9087-48616ba9b8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg?1",
             "name": "Talas Researcher",
             "text": "On your turn, before you attack, you may tap Talas Researcher to draw a card.",
             "colours": [
@@ -1667,7 +1667,7 @@
         },
         {
             "id": "81fd67e1-cf2d-54a5-b551-93d4d1bc1b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e12f17-855e-47e0-b7e3-df5c388b01bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e12f17-855e-47e0-b7e3-df5c388b01bb.jpg?1",
             "name": "Talas Scout",
             "text": "Flying",
             "colours": [
@@ -1702,7 +1702,7 @@
         },
         {
             "id": "974226c9-6859-5de9-80f8-eb106296a8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg?1",
             "name": "Talas Warrior",
             "text": "Talas Warrior can't be blocked.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "f081f76c-3aa0-5889-a5a7-f63aea5ca57e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3964160-79d6-4cdd-8b43-7a8f5dde9da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3964160-79d6-4cdd-8b43-7a8f5dde9da7.jpg?1",
             "name": "Temporal Manipulation",
             "text": "You take another turn after this one.",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "1f6b87d2-3663-532e-b011-6b95f8ddc236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a826f84c-24c4-41f9-88a9-a18dc860b9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a826f84c-24c4-41f9-88a9-a18dc860b9a1.jpg?1",
             "name": "Theft of Dreams",
             "text": "For each tapped creature your opponent has in play, you draw a card.",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "b7a2a843-26e0-5948-b66e-3212e30ddf01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9ecba0-3d9d-4383-a45c-103300442799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9ecba0-3d9d-4383-a45c-103300442799.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap any one, two, or three creatures without flying. (Tapped creatures can't block.)",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "491786cf-991c-5c20-a11b-958972e016bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea285582-2279-4393-885d-e471d00681e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea285582-2279-4393-885d-e471d00681e9.jpg?1",
             "name": "Time Ebb",
             "text": "Return any one creature from play to the top of its owner's library.",
             "colours": [
@@ -1861,7 +1861,7 @@
         },
         {
             "id": "70a2c64e-f671-5d40-9d2e-9bdd40f3e766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277d38ee-09e5-4266-a077-d737f6c8b8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277d38ee-09e5-4266-a077-d737f6c8b8d3.jpg?1",
             "name": "Touch of Brilliance",
             "text": "Draw two cards.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "8050fe2a-9f5a-5300-beac-15250be4edf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca55da2-33e1-44b5-88b2-ac159d842b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca55da2-33e1-44b5-88b2-ac159d842b1f.jpg?1",
             "name": "Undo",
             "text": "Return any two creatures from play to their owner's hand. (You can't play Undo unless you can choose two creatures to return.)",
             "colours": [
@@ -1923,7 +1923,7 @@
         },
         {
             "id": "4c7a7830-5f7f-5be4-ba41-0b52cea64699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ef39fd-96d0-4a02-97d5-580d121b92a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ef39fd-96d0-4a02-97d5-580d121b92a3.jpg?1",
             "name": "Wind Sail",
             "text": "Any one or two creatures gain flying until the end of the turn.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "dac8f009-9bc3-5bdf-8d2e-edabee93f412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b688039-7441-490b-ad06-8a72086c4023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b688039-7441-490b-ad06-8a72086c4023.jpg?1",
             "name": "Abyssal Nightstalker",
             "text": "If Abyssal Nightstalker attacks and isn't blocked, your opponent chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "516fa67d-a565-5342-95bb-531186f068b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee59a7-0f41-4d5d-b049-71ca1ba335b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee59a7-0f41-4d5d-b049-71ca1ba335b1.jpg?1",
             "name": "Ancient Craving",
             "text": "Draw 3 cards. You lose 3 life.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "575c60ba-1c3f-5bf1-93f0-6f7a1fd96e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb0ec62-6d6f-4d10-bc2d-37f25495f884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb0ec62-6d6f-4d10-bc2d-37f25495f884.jpg?1",
             "name": "Bloodcurdling Scream",
             "text": "Any one creature gets +X/+0 until the end of the turn.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "0612e7c2-a81e-5402-8381-57526adb3543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b471102b-a66e-4cdc-b20f-7ae1f9bd0e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b471102b-a66e-4cdc-b20f-7ae1f9bd0e8a.jpg?1",
             "name": "Brutal Nightstalker",
             "text": "When Brutal Nightstalker comes into play from your hand, you may force your opponent to choose and discard a card from his or her hand.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "2b9a4d6e-3d64-5ba9-af7c-09a2ecbd61d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0289ddb3-b35c-4edf-92bb-06f84a3475d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0289ddb3-b35c-4edf-92bb-06f84a3475d9.jpg?1",
             "name": "Chorus of Woe",
             "text": "All your creatures get +1/+0 until the end of the turn.",
             "colours": [
@@ -2113,7 +2113,7 @@
         },
         {
             "id": "ff67662b-8b9c-5b8f-8dbe-7c04305ad2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ff6af-22f4-46fb-97d3-6f8f20f8b16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ff6af-22f4-46fb-97d3-6f8f20f8b16c.jpg?1",
             "name": "Coercion",
             "text": "Look at your opponent's hand and choose a card. Your opponent discards that card.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "b4699ee1-f9e7-5fa0-8573-2386057450ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018d90-cfcc-4fb1-8ecd-4e0f1c71550d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018d90-cfcc-4fb1-8ecd-4e0f1c71550d.jpg?1",
             "name": "Cruel Edict",
             "text": "Your opponent chooses one of his or her creatures. Destroy that creature.",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "ca4821fb-c959-5896-92ee-00f4097de468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45994db-776d-420e-9241-99bf3b71fa59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45994db-776d-420e-9241-99bf3b71fa59.jpg?1",
             "name": "Dakmor Bat",
             "text": "Flying",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "93b020c6-073e-5833-b0ab-f4559a0a9f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b38ef1-5839-4292-91d6-e45698c69a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b38ef1-5839-4292-91d6-e45698c69a75.jpg?1",
             "name": "Dakmor Plague",
             "text": "Dakmor Plague deals 3 damage to each creature and player. (This includes your creatures and you.)",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "5c3c5884-bda4-517e-99b7-d46842c1dad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d860dee-93a9-48e5-ba7a-80ad8cdc84e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d860dee-93a9-48e5-ba7a-80ad8cdc84e4.jpg?1",
             "name": "Dakmor Scorpion",
             "text": "",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "4aa4a590-1596-5ee0-9d58-f229d47b8e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985ef9ad-b842-40b7-8d56-98143ecef0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985ef9ad-b842-40b7-8d56-98143ecef0dc.jpg?1",
             "name": "Dakmor Sorceress",
             "text": "Dakmor Sorceress has power equal to the number of swamp cards you have in play. (This includes both tapped and untapped swamp cards.)",
             "colours": [
@@ -2306,7 +2306,7 @@
         },
         {
             "id": "a0e742fa-fe52-5041-a6cc-2e3aebc18022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0cef9-6de4-4a71-b76a-eb0198387294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0cef9-6de4-4a71-b76a-eb0198387294.jpg?1",
             "name": "Dark Offering",
             "text": "Destroy any one creature that isn't black. You gain 3 life.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "0c077160-e0a7-5de4-a27b-e7ff0a4c98ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b63e5f-b2cf-42c2-8111-1ebb9ed5ca33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b63e5f-b2cf-42c2-8111-1ebb9ed5ca33.jpg?1",
             "name": "Foul Spirit",
             "text": "Flying\nWhen Foul Spirit comes into play from your hand, destroy one of your lands.",
             "colours": [
@@ -2370,7 +2370,7 @@
         },
         {
             "id": "8de745fa-581d-5a3b-9c32-ca0ff9f87d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9761136-9e1c-4d86-98ce-7abe1d8e6a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9761136-9e1c-4d86-98ce-7abe1d8e6a8d.jpg?1",
             "name": "Hand of Death",
             "text": "Destroy any one creature that isn't black.",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "f4b65e49-910a-5dfc-a808-9bb2424190d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64243f71-0941-47d5-816b-4548986726b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64243f71-0941-47d5-816b-4548986726b4.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play from your hand, choose and discard a creature card from your hand or destroy Hidden Horror.",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "94e668ca-1b53-5028-b559-fff08f43356a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6832c1-a0a9-49ec-a787-879e510aee08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6832c1-a0a9-49ec-a787-879e510aee08.jpg?1",
             "name": "Kiss of Death",
             "text": "Kiss of Death deals 4 damage to your opponent. You gain 4 life.",
             "colours": [
@@ -2465,7 +2465,7 @@
         },
         {
             "id": "4dcb0f98-0a83-5365-9a1e-937e5f109401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1",
             "name": "Lurking Nightstalker",
             "text": "If Lurking Nightstalker attacks, it gets +2/+0 until the end of the turn.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "8112531e-c241-5fcb-92d1-2c3c0f709204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7553a2bf-2038-42f7-a311-bdc889dd773d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7553a2bf-2038-42f7-a311-bdc889dd773d.jpg?1",
             "name": "Mind Rot",
             "text": "Your opponent chooses and discards two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "62b1755a-e270-5b46-8cbf-4049c6c6e196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd99210-5201-4ecc-b86a-aee9dafe2657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd99210-5201-4ecc-b86a-aee9dafe2657.jpg?1",
             "name": "Moaning Spirit",
             "text": "Flying",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "37831dcf-45b7-5f5f-9213-4fc8c7af251d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded268ef-f1a3-4d53-82f6-9562fe51c3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded268ef-f1a3-4d53-82f6-9562fe51c3e4.jpg?1",
             "name": "Muck Rats",
             "text": "",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "0e102aad-8772-5e22-a5fb-a3318a7792bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg?1",
             "name": "Nightstalker Engine",
             "text": "Nightstalker Engine has power equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "e7f5da17-ad50-50e4-b248-e8b8e824c104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4c782-bd7f-495e-8a4d-ea7c9ac1f58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4c782-bd7f-495e-8a4d-ea7c9ac1f58b.jpg?1",
             "name": "Predatory Nightstalker",
             "text": "When Predatory Nightstalker comes into play from your hand, you may force your opponent to destroy any one of his or her creatures. (Your opponent chooses the creature.)",
             "colours": [
@@ -2661,7 +2661,7 @@
         },
         {
             "id": "9195d9bb-5103-5e27-ae00-822e3e57e59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749e3992-693b-4b4f-b410-b5f2faac0040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749e3992-693b-4b4f-b410-b5f2faac0040.jpg?1",
             "name": "Prowling Nightstalker",
             "text": "Prowling Nightstalker can't be blocked except by other black creatures.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "2b570781-3bc3-5d77-bc6b-5a00a87058ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df2887c-e70b-4ff3-a437-450c0037fb07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df2887c-e70b-4ff3-a437-450c0037fb07.jpg?1",
             "name": "Raiding Nightstalker",
             "text": "Swampwalk (If defending player has any swamps in play, Raiding Nightstalker can't be blocked.)",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "64c5f63d-5196-5a37-be41-c85f7f94bba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb09a5bb-9730-43cd-8dea-3842634c9983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb09a5bb-9730-43cd-8dea-3842634c9983.jpg?1",
             "name": "Rain of Daggers",
             "text": "Destroy all your opponent's creatures. For each creature destroyed this way, you lose 2 life.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "a4d5a511-dc6d-58d2-b0e6-5b04bd4ac77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4a57-003e-40fd-9998-ed10b38eeed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4a57-003e-40fd-9998-ed10b38eeed7.jpg?1",
             "name": "Raise Dead",
             "text": "Return any one creature from your graveyard to your hand.",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "dbfbdbde-31df-55a9-a33c-2c8b81c244bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8899244b-737a-43a9-9241-15a650b47bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8899244b-737a-43a9-9241-15a650b47bed.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play from your hand, your opponent chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "6cd4312c-0bc2-5b2d-9227-dba980357c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85d85c2-9f34-4375-adcd-a1c5b487cacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85d85c2-9f34-4375-adcd-a1c5b487cacc.jpg?1",
             "name": "Return of the Nightstalkers",
             "text": "Return all the Nightstalker cards from your graveyard to play. Then destroy all your swamps. (Treat these Nightstalkers as though they just came into play from your hand.)",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "fd337cda-1afa-5f52-80e4-42910a7afb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f154e89e-bb64-4579-9ff5-f3fc1c480105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f154e89e-bb64-4579-9ff5-f3fc1c480105.jpg?1",
             "name": "Swarm of Rats",
             "text": "Swarm of Rats has power equal to the number of Rat cards you have in play. (This includes both tapped and untapped Rat cards.)",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "fe2d6487-6a2e-5608-bb2a-ae3682cee148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f636e46a-9d35-47b8-8df0-6dcb18105d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f636e46a-9d35-47b8-8df0-6dcb18105d30.jpg?1",
             "name": "Vampiric Spirit",
             "text": "Flying\nWhen Vampiric Spirit comes into play from your hand, you lose 4 life. (The person who plays Vampiric Spirit loses the life.)",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "6519b9e0-bd98-56d1-b6b2-29965aea4952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3940d0ca-0ca2-4446-9330-a554c3e89824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3940d0ca-0ca2-4446-9330-a554c3e89824.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "5afa368e-cb51-50bd-beda-d846a6d33c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c72f51-2e8c-4a2f-9b61-80f36f8af521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c72f51-2e8c-4a2f-9b61-80f36f8af521.jpg?1",
             "name": "Brimstone Dragon",
             "text": "Flying\nBrimstone Dragon is unaffected by summoning sickness.",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "82530037-d893-59cd-abee-99027f67dc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa284a7-3aac-4e88-becb-548a28c77401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa284a7-3aac-4e88-becb-548a28c77401.jpg?1",
             "name": "Cunning Giant",
             "text": "If Cunning Giant attacks and isn't blocked, you may choose to have it deal its damage to any one of your opponent's creatures instead of to him or her.",
             "colours": [
@@ -3016,7 +3016,7 @@
         },
         {
             "id": "92f67327-2f22-561b-a7b5-f5238dbc9d04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05126438-e806-43e6-bd81-233b629b4a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05126438-e806-43e6-bd81-233b629b4a1b.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each player and each creature without flying. (This includes you and your creatures without flying.)",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "8ee0c16d-e5b0-5720-a00b-60615a2b314e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg?1",
             "name": "Goblin Cavaliers",
             "text": "",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "277baec0-d7a7-509c-9eed-b84cf8b5588a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ee21ef-26c0-4def-9046-5d6fcfa3bfeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ee21ef-26c0-4def-9046-5d6fcfa3bfeb.jpg?1",
             "name": "Goblin Firestarter",
             "text": "On your turn, before you attack, you may destroy Goblin Firestarter to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "759d1485-38de-5afa-abf1-13a5d20e7d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg?1",
             "name": "Goblin General",
             "text": "When Goblin General attacks, all your Goblins get +1/+1 until the end of the turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "c111fa97-2ee7-5e19-bd82-6ccb3a7d75e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29491b-dec1-429d-9950-062582f8164f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29491b-dec1-429d-9950-062582f8164f.jpg?1",
             "name": "Goblin Glider",
             "text": "Flying\nGoblin Glider can't block.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "d8f69b28-e416-595c-bfee-c53b0705fce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26f34db-732c-43d4-a6ef-e170538c0235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26f34db-732c-43d4-a6ef-e170538c0235.jpg?1",
             "name": "Goblin Lore",
             "text": "Draw four cards and put them into your hand. Then discard three cards at random from your hand.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "ae5ed59e-eeb9-566b-b34e-eaac16ebdf96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc21c-8600-49bf-b0a3-c981f7ec7ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc21c-8600-49bf-b0a3-c981f7ec7ac3.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron comes into play from your hand, search your library for a Goblin card and put that card into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "74f91826-a15a-5308-9eef-688acee31858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f841fe25-237f-4303-b75e-392b82767eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f841fe25-237f-4303-b75e-392b82767eea.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "Mountainwalk (If defending player has any mountains in play, Goblin Mountaineer can't be blocked.)",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "ca6a9cc9-e6fd-5144-87ad-eba35e119df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2786834d-dbda-40ce-82a4-e518cd554312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2786834d-dbda-40ce-82a4-e518cd554312.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -3312,7 +3312,7 @@
         },
         {
             "id": "2a71900e-1705-5213-860a-f6a402fc96db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fe9691-d788-42cb-8d13-005724939b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fe9691-d788-42cb-8d13-005724939b62.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "c1c90f29-a704-5eb2-9cae-cd28cc160595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3822880c-a559-409c-8390-6d57eacc3a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3822880c-a559-409c-8390-6d57eacc3a7c.jpg?1",
             "name": "Goblin War Cry",
             "text": "Your opponent chooses one of his or her creatures. Only that creature can block this turn.",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "f618fa47-ebc9-5c44-b7f7-7742d7392228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738fecfd-1119-4dcb-acd6-ec9715d9c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738fecfd-1119-4dcb-acd6-ec9715d9c074.jpg?1",
             "name": "Goblin War Strike",
             "text": "Goblin War Strike deals to your opponent damage equal to the number of Goblin cards you have in play. (This includes both tapped and untapped Goblin cards.)",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "77982381-6622-56be-9afd-ae45ed09a60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148e6704-9cf0-45cf-9bab-db318c016593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148e6704-9cf0-45cf-9bab-db318c016593.jpg?1",
             "name": "Jagged Lightning",
             "text": "Choose any two creatures. Jagged Lightning deals 3 damage to each of them. (You can't play Jagged Lightning unless you can choose two creatures to damage.)",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "12fc06d7-c686-536c-869e-69d87b31be0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6cff90-ecec-4610-82ea-0f2a109959cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6cff90-ecec-4610-82ea-0f2a109959cf.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to your opponent.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "41cf5fdb-78ba-5279-94e3-8b9089402777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bec2e0-a016-42bd-85d9-fbb262998110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bec2e0-a016-42bd-85d9-fbb262998110.jpg?1",
             "name": "Magma Giant",
             "text": "When Magma Giant comes into play from your hand, it deals 2 damage to each creature and player. (This includes you and your creatures, including Magma Giant.)",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "222bb560-d849-5fb8-96bf-70298bbee34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg?1",
             "name": "Obsidian Giant",
             "text": "",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "c4a44fc9-3f2d-5557-9cec-723391aebc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e28b2-9d25-4873-8db2-1f0853ab0c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e28b2-9d25-4873-8db2-1f0853ab0c47.jpg?1",
             "name": "Ogre Arsonist",
             "text": "When Ogre Arsonist comes into play from your hand, destroy any one land. (If you're the only one with lands, destroy one of them.)",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "d8e88429-350d-5355-a097-0693652b0913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6969d4d-c311-4663-bcd6-77a4d6458335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6969d4d-c311-4663-bcd6-77a4d6458335.jpg?1",
             "name": "Ogre Berserker",
             "text": "Ogre Berserker is unaffected by summoning sickness.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "ba13cfbd-9459-5d04-9ae6-078284b463ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d674a92e-b268-48f7-b082-f8ca2e63d43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d674a92e-b268-48f7-b082-f8ca2e63d43b.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "53e688a6-9ee1-557b-9b2f-7d2a8b1eae8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e72970-df1f-4ded-a686-036008555a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e72970-df1f-4ded-a686-036008555a76.jpg?1",
             "name": "Ogre Warrior",
             "text": "",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "3410676e-e924-5c61-87e4-10942865af61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6df5a36-7bd4-4456-a462-54f65089826c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6df5a36-7bd4-4456-a462-54f65089826c.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness.",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "e1e44532-0531-52b8-868e-82ddcbe41908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c641c3d6-0364-4209-b908-1717e5e612ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c641c3d6-0364-4209-b908-1717e5e612ad.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all your creatures that attacked this turn. You may declare an additional attack this turn.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "eb25e792-fbdc-5ebf-885f-a5da2b26ae0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f868b8b0-2be2-4833-8e9a-43a08c6d9c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f868b8b0-2be2-4833-8e9a-43a08c6d9c96.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to any one creature damage equal to the number of mountains you have in play. (This includes both tapped and untapped mountains.)",
             "colours": [
@@ -3766,7 +3766,7 @@
         },
         {
             "id": "818e2d5c-52ca-5ce4-ad3f-fa5486afbed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0b04bc-54ba-48a8-9181-233e08774a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0b04bc-54ba-48a8-9181-233e08774a8b.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy any one land.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "cc01cb0e-d765-5cc6-9089-8596ad8b3022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2509285-a88e-4f5c-86c1-c0386da0f0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2509285-a88e-4f5c-86c1-c0386da0f0c5.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying. (This includes your creatures without flying.)",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "00287b3c-8c5b-530c-9b98-75ea54409c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c0489d-b073-4ad4-b044-447fcc865b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c0489d-b073-4ad4-b044-447fcc865b6c.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to any one creature or player.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "1d1fb2d8-002f-598e-b4f0-0af5dc66c996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cfcb0-db68-4494-a3e1-7c2ca279fcf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cfcb0-db68-4494-a3e1-7c2ca279fcf5.jpg?1",
             "name": "Wildfire",
             "text": "You destroy four of your lands and your opponent destroys four of his or her lands. Then Wildfire deals 4 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "c6f49ef1-b130-54d8-8e3b-2fc40595e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d66645-a5e5-4d29-9dc0-a058f7a3f24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d66645-a5e5-4d29-9dc0-a058f7a3f24b.jpg?1",
             "name": "Alluring Scent",
             "text": "Choose any one creature. This turn, all creatures able to block it do so.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "b4526a4d-ca64-555d-a0f6-93f3d8068c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f627db9-c63e-4353-94f4-3e28db7b222a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f627db9-c63e-4353-94f4-3e28db7b222a.jpg?1",
             "name": "Barbtooth Wurm",
             "text": "",
             "colours": [
@@ -3954,7 +3954,7 @@
         },
         {
             "id": "f7817572-0f68-597f-9246-b5de379c61b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71abb70-bee5-4823-83dc-db0707023b37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71abb70-bee5-4823-83dc-db0707023b37.jpg?1",
             "name": "Bear Cub",
             "text": "",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "7fa6bd82-88cf-5a02-9e08-2f0cbe18f23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dc1f90-8227-47ad-8551-a4e7e565738d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dc1f90-8227-47ad-8551-a4e7e565738d.jpg?1",
             "name": "Bee Sting",
             "text": "Bee Sting deals 2 damage to any one creature or player.",
             "colours": [
@@ -4018,7 +4018,7 @@
         },
         {
             "id": "639b2933-80ef-538d-a9fc-3cfe844a92f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17e3b5-d609-4289-9b74-5ac96ab4ccfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17e3b5-d609-4289-9b74-5ac96ab4ccfa.jpg?1",
             "name": "Deathcoil Wurm",
             "text": "If Deathcoil Wurm attacks and is blocked, you may choose to have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -4051,7 +4051,7 @@
         },
         {
             "id": "d029cb1a-bdc6-5702-bd54-a529becdd990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04db1-bf4a-4824-9dc9-f5c510ba62bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04db1-bf4a-4824-9dc9-f5c510ba62bc.jpg?1",
             "name": "Deep Wood",
             "text": "Play Deep Wood only after you're attacked, before you declare blockers.\nThis turn, all damage dealt to you by attacking creatures is reduced to 0.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "83afde0d-048d-5eef-a7de-97e1f8a80e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dfc789-7ea0-4eb8-8c3b-2c50fd52cbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dfc789-7ea0-4eb8-8c3b-2c50fd52cbab.jpg?1",
             "name": "Golden Bear",
             "text": "",
             "colours": [
@@ -4115,7 +4115,7 @@
         },
         {
             "id": "bff1dee7-1680-5081-9898-3e0380335416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fa08d9-d41b-4696-b81a-42c8eebdeb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fa08d9-d41b-4696-b81a-42c8eebdeb49.jpg?1",
             "name": "Harmony of Nature",
             "text": "Tap any number of your creatures. You gain 4 life for each creature tapped this way. (Tapped creatures can't block.)",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "653f4e16-c6e6-5de1-97fb-d2394ea09eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4dd722-4729-444a-9d81-e2e93317fbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4dd722-4729-444a-9d81-e2e93317fbd5.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each player and each creature with flying. (This includes you and your creatures with flying.)",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "9c531396-f661-5654-a8e0-d828ba3e0c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2528c2-6405-4db9-9137-623946a4de2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2528c2-6405-4db9-9137-623946a4de2f.jpg?1",
             "name": "Ironhoof Ox",
             "text": "Ironhoof Ox can't be blocked by more than one creature.",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "ff21dc4c-e3c5-5c9d-9899-2071b63c48fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4d831-7388-4321-a636-79cf7bde25bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4d831-7388-4321-a636-79cf7bde25bb.jpg?1",
             "name": "Lone Wolf",
             "text": "If Lone Wolf attacks and is blocked, you may choose to have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "0a7ed31c-316e-5b29-b58b-3081e52bb8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8648e1-bc40-4eff-ad7b-ab0b62a47570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8648e1-bc40-4eff-ad7b-ab0b62a47570.jpg?1",
             "name": "Lynx",
             "text": "Forestwalk (If defending player has any forests in play, Lynx can't be blocked.)",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "9de6e3c6-aacf-5978-8c31-1c44a334f65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3816da20-4434-4bf7-a9dd-3eb3bb735f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3816da20-4434-4bf7-a9dd-3eb3bb735f08.jpg?1",
             "name": "Monstrous Growth",
             "text": "Any one creature gets +4/+4 until the end of the turn.",
             "colours": [
@@ -4307,7 +4307,7 @@
         },
         {
             "id": "1910bd38-a3a9-5c7a-a9b7-56ff7b4b46fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d73903-182d-4fc8-a1e4-8a1738e7a67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d73903-182d-4fc8-a1e4-8a1738e7a67b.jpg?1",
             "name": "Natural Spring",
             "text": "You gain 8 life.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "0e7336bf-c1f7-5876-b9a5-3946315e94d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fb749-5672-4a5c-ac89-e443195b95bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fb749-5672-4a5c-ac89-e443195b95bc.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a forest card and put that forest into play. Shuffle your library afterwards.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "49b360ce-bd7a-56a5-a8a2-bd414fd162a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c545fa63-d0dd-422b-8d3b-88b444f13fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c545fa63-d0dd-422b-8d3b-88b444f13fce.jpg?1",
             "name": "Norwood Archers",
             "text": "Norwood Archers can block creatures with flying.",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "493d9f3b-9e70-58e9-abe7-4dd5f92c68bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afd472f-1ede-4e78-b44c-3298ee4c8694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afd472f-1ede-4e78-b44c-3298ee4c8694.jpg?1",
             "name": "Norwood Priestess",
             "text": "On your turn, before you attack, you may tap Norwood Priestess to put any green creature from your hand into play without paying for it.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "3abd68ff-b3bf-5961-b63f-e3de124b38b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557c0c2-eb0f-4a9d-9192-577a684b3426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557c0c2-eb0f-4a9d-9192-577a684b3426.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "4b94e6b5-c3b6-54d9-9cc5-bb7c006e0c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ba8db-853e-4f51-acfe-83e472524380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ba8db-853e-4f51-acfe-83e472524380.jpg?1",
             "name": "Norwood Riders",
             "text": "Norwood Riders can't be blocked by more than one creature.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "43cc936c-0de2-58b0-b570-caa56986feca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7ddf0a-1081-4ae0-ab91-b052153bab4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7ddf0a-1081-4ae0-ab91-b052153bab4c.jpg?1",
             "name": "Norwood Warrior",
             "text": "If Norwood Warrior attacks and is blocked, it gets +1/+1 until the end of the turn.",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "492fc440-2749-51f1-963f-f360b8761908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51f8724-8f26-4a9d-b586-4223354ae7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51f8724-8f26-4a9d-b586-4223354ae7fc.jpg?1",
             "name": "Plated Wurm",
             "text": "",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "4cd6af72-e7de-5e24-85b8-0c7c061c884a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg?1",
             "name": "Razorclaw Bear",
             "text": "If Razorclaw Bear attacks and is blocked, it gets +2/+2 until the end of the turn.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "8885ca05-257b-5dc6-b9ea-7a9c43955882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ec869-f933-4b27-9f0b-b583e71a1110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ec869-f933-4b27-9f0b-b583e71a1110.jpg?1",
             "name": "Renewing Touch",
             "text": "Choose any number of creature cards in your graveyard and shuffle them into your library.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "429b2a8e-b345-51cd-b21c-824386a1ed6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8508e3b-a934-4795-a2df-07e792f2685f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8508e3b-a934-4795-a2df-07e792f2685f.jpg?1",
             "name": "River Bear",
             "text": "Islandwalk (If defending player has any islands in play, River Bear can't be blocked.)",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "dcf7f3c0-9049-528b-bc94-5e6dffcfbcad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3012e10-566b-447c-bb0a-dfc38c8e0fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3012e10-566b-447c-bb0a-dfc38c8e0fdf.jpg?1",
             "name": "Salvage",
             "text": "Take any one card from your graveyard and put that card on the top of your library.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "18cb7887-1a98-5e29-8438-ba0ccbce449d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09886-a733-4797-a489-46150cecfc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09886-a733-4797-a489-46150cecfc13.jpg?1",
             "name": "Sylvan Basilisk",
             "text": "If Sylvan Basilisk attacks and is blocked, destroy all creatures blocking it. (Destroy the creatures before they deal damage. The Basilisk doesn't damage your opponent.)",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "9101ccc5-ed7a-535d-9f72-c6de22480e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8686e2-1e14-4b4a-b45b-cab4d5c57fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8686e2-1e14-4b4a-b45b-cab4d5c57fce.jpg?1",
             "name": "Sylvan Yeti",
             "text": "Sylvan Yeti has power equal to the number of cards you have in your hand.",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "b90050b3-17f9-58b0-8361-a6267516e349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60bbbf7-a005-4b4b-b8e4-e95bbb67f529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60bbbf7-a005-4b4b-b8e4-e95bbb67f529.jpg?1",
             "name": "Tree Monkey",
             "text": "Tree Monkey can block creatures with flying.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "ad5222c8-3147-5a2f-8444-82c2f2111a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6890024-246c-42ba-8ccc-ffabb5867530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6890024-246c-42ba-8ccc-ffabb5867530.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a plains, island, swamp, mountain, or forest card and put that land into play. Shuffle your library afterwards.",
             "colours": [
@@ -4830,7 +4830,7 @@
         },
         {
             "id": "7aea16f9-0a0a-50f8-bd05-77fda49b799b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7890-86dc-4fb8-a47b-99331bbe7c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7890-86dc-4fb8-a47b-99331bbe7c29.jpg?1",
             "name": "Wild Ox",
             "text": "Swampwalk (If defending player has any swamps in play, Wild Ox can't be blocked.)",
             "colours": [
@@ -4863,7 +4863,7 @@
         },
         {
             "id": "0d6b107e-68c6-5e28-97ce-6d1932eb4595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ecf285-c48f-4ac3-9b75-0ee0ff052767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ecf285-c48f-4ac3-9b75-0ee0ff052767.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "5d46745e-85e1-5ae9-a4b1-960b9c1db9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a136975-e513-4c50-9d4a-855d03630470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a136975-e513-4c50-9d4a-855d03630470.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "ff7fb962-8fb2-5aec-8998-710212d0d154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67f2ecd-d5fb-406b-b14d-34eb087eb08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67f2ecd-d5fb-406b-b14d-34eb087eb08b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "5cb3137c-a011-58a3-8a8e-ca1dcc8a267c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a83b1a-a734-4726-9d14-c75ef04798d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a83b1a-a734-4726-9d14-c75ef04798d1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "709de056-1e70-5816-b2a8-dde675948a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b165ada0-7f52-4047-8596-c54247d13704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b165ada0-7f52-4047-8596-c54247d13704.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "a78566cd-eff9-5a23-b09b-891d43799bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8ecec-8925-470b-994d-79694d056834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8ecec-8925-470b-994d-79694d056834.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "14a0f5d1-1100-55e8-9f6f-15c4806d053b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c0bd18-fdee-4cb2-8a7e-dd86bb8a6bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c0bd18-fdee-4cb2-8a7e-dd86bb8a6bbe.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "279ae081-dc2f-5357-8966-e428caddf916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb62dd9-266b-4de9-8a11-3228b5f1e03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb62dd9-266b-4de9-8a11-3228b5f1e03a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "fb4ad4a5-93e1-5c98-ab65-96ebf4d46047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103ed69-b73b-4789-a28d-1fd071bc9029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103ed69-b73b-4789-a28d-1fd071bc9029.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "d8246b61-33b9-5592-b8ea-4a96e0d7cd81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfbb15a-d7f4-470a-9d36-78c710a6d397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfbb15a-d7f4-470a-9d36-78c710a6d397.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "30e49f46-dbd1-5ed3-a7ce-394c539444e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4453a5c0-76f2-422d-8cbc-4b21c17cdf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4453a5c0-76f2-422d-8cbc-4b21c17cdf1e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "3e4002a2-b656-51d7-b566-26542676d5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9006aa97-884f-404a-9ead-af8437ea9596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9006aa97-884f-404a-9ead-af8437ea9596.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "5e6307c8-c4a6-5a27-9a77-b7ffac92271e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f4fcbb-86a8-475f-a547-d59014bb7a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f4fcbb-86a8-475f-a547-d59014bb7a98.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "c46f8daa-1bdb-5821-8a13-d5808d2c5030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa863815-1dcc-43d8-8076-a35037688b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa863815-1dcc-43d8-8076-a35037688b20.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "cdc41ceb-9350-52b8-bd36-3d54bdf5d1d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abebee47-5205-4855-ae72-475b58a02240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abebee47-5205-4855-ae72-475b58a02240.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/PCY.json
+++ b/Assets/Resources/Sets/PCY.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "01b64921-dba7-5ddc-aa4a-4dd9e670345d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c81ae90-5abd-4c79-b14a-d5f3a1daff38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c81ae90-5abd-4c79-b14a-d5f3a1daff38.jpg?1",
             "name": "Abolish",
             "text": "You may discard a plains from your hand instead of paying Abolish's mana cost.\nDestroy target artifact or enchantment.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "db67c6ad-9b6c-5387-ae08-f36a06ca744e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8d3e36-977f-4169-8f2a-a4057b912ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8d3e36-977f-4169-8f2a-a4057b912ccb.jpg?1",
             "name": "Aura Fracture",
             "text": "Sacrifice a land: Destroy target enchantment.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "b9c59577-adfb-56f9-ac68-97d21dce08d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eec03a2-c62b-4e55-ae9d-edc30a9ad5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eec03a2-c62b-4e55-ae9d-edc30a9ad5f4.jpg?1",
             "name": "Avatar of Hope",
             "text": "Flying\nIf you have 3 life or less, Avatar of Hope costs o6 less to play.\nAvatar of Hope may block any number of creatures.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "7da10cc2-cbb2-5fb1-bd2e-c391185c191f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb624d6-9aec-498c-8df9-6fd025c74487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb624d6-9aec-498c-8df9-6fd025c74487.jpg?1",
             "name": "Blessed Wind",
             "text": "Target player's life total becomes 20.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "cf02dd64-8c1e-5c3b-b0e3-fa33b76fcc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e5c9ca-b453-488b-8702-fc74907a8335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e5c9ca-b453-488b-8702-fc74907a8335.jpg?1",
             "name": "Celestial Convergence",
             "text": "Celestial Convergence comes into play with seven omen counters on it.\nAt the beginning of your upkeep, remove an omen counter from Celestial Convergence. If there are no omen counters on Celestial Convergence, the player with the highest life total wins the game. If two or more players are tied for highest life total, the game is a draw.",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "14246ce5-a4a8-50be-b6ea-525de2e61e98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f72b2-e3d0-4b24-9a73-b95d54695fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f72b2-e3d0-4b24-9a73-b95d54695fa4.jpg?1",
             "name": "Diving Griffin",
             "text": "Flying\nAttacking doesn't cause Diving Griffin to tap.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "000db0e0-047e-59e2-b7aa-265e656ea91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc20785-4512-4ef6-8f62-928482cb585f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc20785-4512-4ef6-8f62-928482cb585f.jpg?1",
             "name": "Entangler",
             "text": "Enchanted creature may block any number of creatures.",
             "colours": [
@@ -234,7 +234,7 @@
         },
         {
             "id": "3b68af8d-b4d7-5723-8a72-f918b9e37d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f97dd-434b-4156-8e9d-253a943784e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f97dd-434b-4156-8e9d-253a943784e3.jpg?1",
             "name": "Excise",
             "text": "Remove target attacking creature from the game unless its controller pays o\nX.",
             "colours": [
@@ -266,7 +266,7 @@
         },
         {
             "id": "b7c5493e-6e08-5c04-8776-71ed4cf41eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c241fd76-f52d-48fc-864c-57caffa700f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c241fd76-f52d-48fc-864c-57caffa700f6.jpg?1",
             "name": "Flowering Field",
             "text": "Enchanted land has \"oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\"",
             "colours": [
@@ -300,7 +300,7 @@
         },
         {
             "id": "ff9f390a-05dc-5652-b8c2-e89d5c6ad37f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4be296-33a6-46b1-9748-5b0d335f40ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4be296-33a6-46b1-9748-5b0d335f40ee.jpg?1",
             "name": "Glittering Lion",
             "text": "Prevent all damage that would be dealt to Glittering Lion.\no3: Until end of turn, Glittering Lion loses \"Prevent all damage that would be dealt to Glittering Lion.\" Any player may play this ability.",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "fb7bd218-c8fe-5781-bc5a-551dcbbf4b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f26c7e-c525-4191-a542-b81343ae95bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f26c7e-c525-4191-a542-b81343ae95bb.jpg?1",
             "name": "Glittering Lynx",
             "text": "Prevent all damage that would be dealt to Glittering Lynx.\no2: Until end of turn, Glittering Lynx loses \"Prevent all damage that would be dealt to Glittering Lynx.\" Any player may play this ability.",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "8bfb3644-ff48-5077-8616-b880821d64e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3e681-bd4b-41e9-8db4-083172f3caad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3e681-bd4b-41e9-8db4-083172f3caad.jpg?1",
             "name": "Jeweled Spirit",
             "text": "Flying\nSacrifice two lands: Jeweled Spirit gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "198d9a4f-8256-5ac1-ba05-49b4e115d85c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5861dffc-5afa-44a3-a3fa-9fd440093377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5861dffc-5afa-44a3-a3fa-9fd440093377.jpg?1",
             "name": "Mageta the Lion",
             "text": "o2o\nWo\nW, oc\nT, Discard two cards from your hand: Destroy all creatures except for Mageta the Lion. Those creatures can't be regenerated.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "8106611f-4f4a-534c-a003-1c9048e04c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22db8a3b-413d-4f4d-b103-f50fc0415e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22db8a3b-413d-4f4d-b103-f50fc0415e9b.jpg?1",
             "name": "Mageta's Boon",
             "text": "You may play Mageta's Boon any time you could play an instant.\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "942a2876-52ec-5342-bd33-129bd6102c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee3f50-09d7-4960-8214-680a7299fa20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee3f50-09d7-4960-8214-680a7299fa20.jpg?1",
             "name": "Mercenary Informer",
             "text": "Mercenary Informer can't be the target of black spells or abilities.\no2oo\nW Put target Mercenary card on the bottom of its owner's library.",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "9e5658ee-4b68-5d39-8264-a1ff8462fef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8151510-2445-4244-b851-ab332b908170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8151510-2445-4244-b851-ab332b908170.jpg?1",
             "name": "Mine Bearer",
             "text": "oc\nT, Sacrifice Mine Bearer: Destroy target attacking creature.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "6b5a5ead-c8f7-5792-981b-df501506f1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148fbe36-b22d-44e6-9341-7f707baca49d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148fbe36-b22d-44e6-9341-7f707baca49d.jpg?1",
             "name": "Mirror Strike",
             "text": "Target unblocked creature deals combat damage to its controller instead of to you this turn.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "c67c6e5f-ca35-58cb-83c2-71965ecfedf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6385bb-18f9-461b-b541-3c2a5e59189b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6385bb-18f9-461b-b541-3c2a5e59189b.jpg?1",
             "name": "Reveille Squad",
             "text": "Whenever you're attacked, if Reveille Squad is untapped, you may untap all creatures you control.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "7d723ae4-f0a4-5043-8c75-a7c6777211e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76711e-b508-4bb7-a87c-911a11905af3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76711e-b508-4bb7-a87c-911a11905af3.jpg?1",
             "name": "Rhystic Circle",
             "text": "o1: Any player may pay o1. If no one does, the next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "da170a78-1238-5866-9c0a-5084c6038b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49af7b3f-f56a-4102-b398-5c215dd4fa11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49af7b3f-f56a-4102-b398-5c215dd4fa11.jpg?1",
             "name": "Rhystic Shield",
             "text": "Creatures you control get +0/+1 until end of turn. They get an additional +0/+2 until end of turn unless any player pays o2.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "a8db841a-76a3-5983-8a89-ae941b0ef5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ebeba-b61a-497a-a698-e75b130c468c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ebeba-b61a-497a-a698-e75b130c468c.jpg?1",
             "name": "Samite Sanctuary",
             "text": "o2: Prevent the next 1 damage that would be dealt to target creature this turn. Any player may play this ability.",
             "colours": [
@@ -707,7 +707,7 @@
         },
         {
             "id": "46996945-20da-5fb6-a3d6-db460af3d2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30803e6-7f0e-4832-b121-b18480c6465c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30803e6-7f0e-4832-b121-b18480c6465c.jpg?1",
             "name": "Sheltering Prayers",
             "text": "Basic lands each player controls can't be the targets of spells or abilities as long as that player controls three or fewer lands.",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "5407aafa-c8c2-5121-843e-ff2c4564fbb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d885360-1ce1-4b80-8928-29437731993f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d885360-1ce1-4b80-8928-29437731993f.jpg?1",
             "name": "Shield Dancer",
             "text": "o2oo\nW The next time target attacking creature would deal combat damage to Shield Dancer this turn, that creature deals that damage to itself instead.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "5a6ede04-3a2b-511e-b4b3-4b73735a7c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1656bd2a-e7ce-48b1-8fa1-5f470fe6058e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1656bd2a-e7ce-48b1-8fa1-5f470fe6058e.jpg?1",
             "name": "Soul Charmer",
             "text": "Whenever Soul Charmer deals combat damage to a creature, you gain 2 life unless that creature's controller pays o2.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "a2acb991-93c2-526f-9551-cc6e908873a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06f00e8-3e58-4ba7-9542-ce6b17fd4005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06f00e8-3e58-4ba7-9542-ce6b17fd4005.jpg?1",
             "name": "Sword Dancer",
             "text": "o\nWoo\nW Target attacking creature gets -1/-0 until end of turn.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "9c0b8eed-51ec-5654-b6e1-f767b799837c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a359837-2e41-4ddc-9299-89a783d62014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a359837-2e41-4ddc-9299-89a783d62014.jpg?1",
             "name": "Trenching Steed",
             "text": "Sacrifice a land: Trenching Steed gets +0/+3 until end of turn.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "1756a098-dc54-5ca9-8e10-9591c236a0e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54407ba7-6671-42a9-acbe-8a1104c7166c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54407ba7-6671-42a9-acbe-8a1104c7166c.jpg?1",
             "name": "Troubled Healer",
             "text": "Sacrifice a land: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -914,7 +914,7 @@
         },
         {
             "id": "21be870a-edd1-52c3-ae9d-00073341244e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8fc0b0-4a23-47ed-b61b-a4505fcfc5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8fc0b0-4a23-47ed-b61b-a4505fcfc5d2.jpg?1",
             "name": "Alexi, Zephyr Mage",
             "text": "o\nXo\nU, oc\nT, Discard two cards from your hand: Return X target creatures to their owners' hands.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "ef453da7-2bb3-55ab-97cb-9b91b452a386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457a5613-d1d4-4112-8484-f40120079b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457a5613-d1d4-4112-8484-f40120079b7b.jpg?1",
             "name": "Alexi's Cloak",
             "text": "You may play Alexi's Cloak any time you could play an instant.\nEnchanted creature can't be the target of spells or abilities.",
             "colours": [
@@ -985,7 +985,7 @@
         },
         {
             "id": "4930bede-d5d5-5341-8feb-315edc9a7208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf65efc7-6ab5-4116-b003-1f028af80939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf65efc7-6ab5-4116-b003-1f028af80939.jpg?1",
             "name": "Avatar of Will",
             "text": "Flying\nIf an opponent has no cards in hand, Avatar of Will costs o6 less to play.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "00fb62e4-8a9f-54b6-ba2d-af4993b25649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b91ddc-8630-4214-8dce-215f28ccc685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b91ddc-8630-4214-8dce-215f28ccc685.jpg?1",
             "name": "Coastal Hornclaw",
             "text": "Sacrifice a land: Coastal Hornclaw gains flying until end of turn.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "021935a7-af9b-589a-bffe-62ea07bcc056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f236ce-41ad-4a49-a6f9-7853a2395a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f236ce-41ad-4a49-a6f9-7853a2395a84.jpg?1",
             "name": "Denying Wind",
             "text": "Search target player's library for up to seven cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "193e7d92-e738-5a30-bde5-38981213f6cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b87ff-42a9-4ea0-a79e-1208ca35ffb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b87ff-42a9-4ea0-a79e-1208ca35ffb2.jpg?1",
             "name": "Excavation",
             "text": "o1, Sacrifice a land: Draw a card. Any player may play this ability.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "c3af2dfb-f6d5-582f-8c74-a33d83637f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870fb793-3107-4cb2-ba78-34fbf5c9da2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870fb793-3107-4cb2-ba78-34fbf5c9da2f.jpg?1",
             "name": "Foil",
             "text": "You may discard an island and another card from your hand instead of paying Foil's mana cost.\nCounter target spell.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "8b6d009c-af82-580b-84b0-76bcef43daa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf424982-a0ab-4db9-8889-f3cef10966c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf424982-a0ab-4db9-8889-f3cef10966c6.jpg?1",
             "name": "Gulf Squid",
             "text": "When Gulf Squid comes into play, tap all lands target player controls.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "43f9b3db-d2c6-562b-a6cd-9ffc6502ca18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87489f2-82b7-4be6-80ae-3d5955d5ed92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87489f2-82b7-4be6-80ae-3d5955d5ed92.jpg?1",
             "name": "Hazy Homunculus",
             "text": "Hazy Homunculus is unblockable as long as defending player controls an untapped land.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "d5094309-95ac-54ca-ac6f-69d3638e7ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2765be4f-23bf-49c1-9546-11a7916156be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2765be4f-23bf-49c1-9546-11a7916156be.jpg?1",
             "name": "Heightened Awareness",
             "text": "As Heightened Awareness comes into play, discard your hand.\nAt the beginning of your draw step, draw a card.",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "d3e45edd-5d5e-5b0a-9af0-3947fd1e81c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6dfe49-9fd6-4fa0-b73e-e6470d8e7ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6dfe49-9fd6-4fa0-b73e-e6470d8e7ca7.jpg?1",
             "name": "Mana Vapors",
             "text": "Lands target player controls don't untap during his or her next untap step.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "f9856dba-03e4-5ceb-965f-024e6f96bd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6cf6b6-b4c1-4742-9be4-b3b15fbb0202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6cf6b6-b4c1-4742-9be4-b3b15fbb0202.jpg?1",
             "name": "Overburden",
             "text": "Whenever a player puts a creature card into play, that player returns a land he or she controls to its owner's hand.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "5eb63154-11b8-5ccf-b0b1-19598b9b4bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f86c92-c19e-4f2c-96d3-d3b05623cb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f86c92-c19e-4f2c-96d3-d3b05623cb00.jpg?1",
             "name": "Psychic Theft",
             "text": "Look at target player's hand, choose an instant or sorcery card from it, and remove that card from the game. You may play the card as though it were in your hand as long as the card remains removed from the game. At end of turn, if you haven't played the card, return it to its owner's hand.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "9131c8d6-2b39-500a-b703-c989c996b42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a680aeaf-8c6e-45b5-8814-7fd04e963220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a680aeaf-8c6e-45b5-8814-7fd04e963220.jpg?1",
             "name": "Quicksilver Wall",
             "text": "(Walls can't attack.)\no4: Return Quicksilver Wall to its owner's hand. Any player may play this ability.",
             "colours": [
@@ -1381,7 +1381,7 @@
         },
         {
             "id": "e460f26f-4e88-5654-9b1a-f92ae9fc790a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ae03f-22f3-4ecc-a875-5226d8dec384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ae03f-22f3-4ecc-a875-5226d8dec384.jpg?1",
             "name": "Rethink",
             "text": "Counter target spell unless its controller pays o\nX, where X is its converted mana cost.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "14e02779-f514-510b-a8b8-b8004e031cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dd540-7f54-46fe-b1e8-7b07f57e71d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dd540-7f54-46fe-b1e8-7b07f57e71d0.jpg?1",
             "name": "Rhystic Deluge",
             "text": "oo\nU Tap target creature unless its controller pays o1.",
             "colours": [
@@ -1445,7 +1445,7 @@
         },
         {
             "id": "5e884ebb-a7c6-5665-9ae3-64a020bbcd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a59737-f06f-49b7-a490-3dc1115b47b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a59737-f06f-49b7-a490-3dc1115b47b7.jpg?1",
             "name": "Rhystic Scrying",
             "text": "Draw three cards. Then, if any player pays o2, discard three cards from your hand.",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "7691887a-48cf-523b-bd19-c94a756392a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394cefd-a3c6-4917-8f46-234e441ecfb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394cefd-a3c6-4917-8f46-234e441ecfb6.jpg?1",
             "name": "Rhystic Study",
             "text": "Whenever an opponent plays a spell, you may draw a card unless that player pays o1.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "17f9a9bc-fee1-5110-8677-04f4a1fdc20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5135dc-4fc1-48a1-8405-44b2f93a3c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5135dc-4fc1-48a1-8405-44b2f93a3c21.jpg?1",
             "name": "Ribbon Snake",
             "text": "Flying\no2: Ribbon Snake loses flying until end of turn. Any player may play this ability.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "bab87fe0-2d7a-5b26-b7ea-f7d230203756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d9035b-b6ec-479f-b697-3e5c3110ef10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d9035b-b6ec-479f-b697-3e5c3110ef10.jpg?1",
             "name": "Shrouded Serpent",
             "text": "Whenever Shrouded Serpent attacks, defending player may pay o4. If he or she doesn't, Shrouded Serpent is unblockable this turn.",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "1d3bf258-4f4f-5e89-b165-5c19b11bff33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db398ca-6b0b-4225-baaa-c4b1c243b2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db398ca-6b0b-4225-baaa-c4b1c243b2bd.jpg?1",
             "name": "Spiketail Drake",
             "text": "Flying\nSacrifice Spiketail Drake: Counter target spell unless its controller pays o3.",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "2dd559a6-ca10-58ff-9b36-6d0efb239bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9988f0fe-a7d4-44f9-b37c-fa30014ea215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9988f0fe-a7d4-44f9-b37c-fa30014ea215.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "Flying\nSacrifice Spiketail Hatchling: Counter target spell unless its controller pays o1.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "88160909-d8ac-56e0-8bed-cbff6ceaa863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c3bb62-63b4-4b53-9e4d-edfc7487494b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c3bb62-63b4-4b53-9e4d-edfc7487494b.jpg?1",
             "name": "Stormwatch Eagle",
             "text": "Flying\nSacrifice a land: Return Stormwatch Eagle to its owner's hand.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "33292320-b027-5907-83e8-287e70ac9c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211ee02-e854-4414-92b1-65a7af29f0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211ee02-e854-4414-92b1-65a7af29f0b9.jpg?1",
             "name": "Sunken Field",
             "text": "Enchanted land has \"oc\nT: Counter target spell unless its controller pays o1.\"",
             "colours": [
@@ -1713,7 +1713,7 @@
         },
         {
             "id": "b714fcac-0100-5bcb-9bd5-0221a3b6f796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d7e856-6852-4b97-ae0e-a4becdfc8166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d7e856-6852-4b97-ae0e-a4becdfc8166.jpg?1",
             "name": "Troublesome Spirit",
             "text": "Flying\nAt the end of your turn, tap all lands you control.",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "40606d6b-f239-567f-96b5-5b4ae7c94f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb70925a-4bef-4067-a1d7-79114aff5847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb70925a-4bef-4067-a1d7-79114aff5847.jpg?1",
             "name": "Windscouter",
             "text": "Flying\nWhenever Windscouter attacks or blocks, return it to its owner's hand at end of combat.",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "01f91513-95a1-5a33-a1fc-4eed13e8e4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a3a52f-0ccd-4935-b3ca-9c69cba283cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a3a52f-0ccd-4935-b3ca-9c69cba283cc.jpg?1",
             "name": "Withdraw",
             "text": "Return target creature to its owner's hand. Then return another target creature to its owner's hand unless its controller pays o1.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "9d5fad89-1025-52ea-b355-b3c425f6eb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8316804-6f8b-423e-a2c3-fa476c095544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8316804-6f8b-423e-a2c3-fa476c095544.jpg?1",
             "name": "Agent of Shauku",
             "text": "o1o\nB, Sacrifice a land: Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -1849,7 +1849,7 @@
         },
         {
             "id": "5b80c2cc-14fa-57ca-b974-86423192db90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f695405-7238-48fb-9ea2-1b1613a0afda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f695405-7238-48fb-9ea2-1b1613a0afda.jpg?1",
             "name": "Avatar of Woe",
             "text": "If there are ten or more creature cards total in all graveyards, Avatar of Woe costs o6 less to play.\nAvatar of Woe can't be blocked except by artifact creatures and/or black creatures.\noc\nT: Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -1883,7 +1883,7 @@
         },
         {
             "id": "966a4f56-3c47-5c09-b673-cbb87b60e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75191915-352e-4de7-b216-63f0ff588ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75191915-352e-4de7-b216-63f0ff588ba5.jpg?1",
             "name": "Bog Elemental",
             "text": "Protection from white\nAt the beginning of your upkeep, sacrifice Bog Elemental unless you sacrifice a land.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "6d18d1f5-bde4-5324-8a70-eb82a589384a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086a5620-704b-47a9-9a5d-73e28631d6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086a5620-704b-47a9-9a5d-73e28631d6f8.jpg?1",
             "name": "Bog Glider",
             "text": "Flying\noc\nT, Sacrifice a land: Search your library for a Mercenary card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "e8d30ba9-254c-5491-978b-902cf38dac37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20edb71-aa1d-437b-bcfb-953efbe45150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20edb71-aa1d-437b-bcfb-953efbe45150.jpg?1",
             "name": "Chilling Apparition",
             "text": "oo\nB Regenerate Chilling Apparition.\nWhenever Chilling Apparition deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "766ba887-5246-57d2-b376-657c528113b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcda8e4-d3dc-44f8-b277-b61fa261666b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcda8e4-d3dc-44f8-b277-b61fa261666b.jpg?1",
             "name": "Coffin Puppets",
             "text": "Sacrifice two lands: Return Coffin Puppets to play. Play this ability only during your upkeep, only if Coffin Puppets is in your graveyard, and only if you control a swamp.",
             "colours": [
@@ -2022,7 +2022,7 @@
         },
         {
             "id": "63d02cb3-f375-5052-bb68-06d5f261dfba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34019cb-5d87-4451-a102-b751ea3a97f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34019cb-5d87-4451-a102-b751ea3a97f8.jpg?1",
             "name": "Coffin Puppets",
             "text": "",
             "colours": [
@@ -2058,7 +2058,7 @@
         },
         {
             "id": "f13379de-5ab4-501e-9bc4-4d5688554e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58a303a-9f7a-43e7-bcba-c58b378a53ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58a303a-9f7a-43e7-bcba-c58b378a53ce.jpg?1",
             "name": "Death Charmer",
             "text": "Whenever Death Charmer deals combat damage to a creature, that creature's controller loses 2 life unless he or she pays o2.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "9f498048-1a99-575b-a46d-ae59b37336a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb6ff7-2cd6-430e-a618-0b83d9c1d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb6ff7-2cd6-430e-a618-0b83d9c1d044.jpg?1",
             "name": "Despoil",
             "text": "Destroy target land. Its controller loses 2 life.",
             "colours": [
@@ -2125,7 +2125,7 @@
         },
         {
             "id": "483bcee9-e9a1-5370-949c-0964aca85b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76843b0-0e71-473b-8c9b-6a8bc30255da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76843b0-0e71-473b-8c9b-6a8bc30255da.jpg?1",
             "name": "Endbringer's Revel",
             "text": "o4: Return target creature card from a graveyard to its owner's hand. Any player may play this ability but only any time he or she could play a sorcery.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "bac1b5e5-1aa5-52cb-8379-0defda5c8455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7d1125-7eb0-4065-bc2c-764689380fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7d1125-7eb0-4065-bc2c-764689380fa8.jpg?1",
             "name": "Fen Stalker",
             "text": "Fen Stalker can't be blocked except by artifact creatures and/or black creatures as long as you control no untapped lands.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "cd49daa6-fd33-566b-b2b5-24d884d5818c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fe155f-bfb2-49d8-83f0-ab1047a961d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fe155f-bfb2-49d8-83f0-ab1047a961d1.jpg?1",
             "name": "Flay",
             "text": "Target player discards a card at random from his or her hand. Then that player discards another card at random from his or her hand unless he or she pays o1.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "6c3be56e-71ca-53d2-abe9-d06e82422642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d1f317-efd1-4595-92e2-44815a2b8147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d1f317-efd1-4595-92e2-44815a2b8147.jpg?1",
             "name": "Greel, Mind Raker",
             "text": "o\nXo\nB, oc\nT, Discard two cards from your hand: Target player discards X cards at random from his or her hand.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "db0255d3-4b50-5a3f-a087-c9bc05089282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b25ce3f-fab3-40f8-8a16-fe580f3d97a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b25ce3f-fab3-40f8-8a16-fe580f3d97a5.jpg?1",
             "name": "Greel's Caress",
             "text": "You may play Greel's Caress any time you could play an instant.\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "a841e224-0f93-53e4-a0a0-06996eaae392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a63d16e-319d-46f4-a28c-895b36605ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a63d16e-319d-46f4-a28c-895b36605ee6.jpg?1",
             "name": "Infernal Genesis",
             "text": "At the beginning of each player's upkeep, that player puts the top card of his or her library into his or her graveyard. He or she then puts X 1/1 black Minion creature tokens into play, where X is that card's converted mana cost.",
             "colours": [
@@ -2326,7 +2326,7 @@
         },
         {
             "id": "9804f78e-ed0b-526f-8bf2-0ac48daffa93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefd9315-9b7c-4c6b-8a15-a6af873dab6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefd9315-9b7c-4c6b-8a15-a6af873dab6f.jpg?1",
             "name": "Nakaya Shade",
             "text": "oo\nB Nakaya Shade gets +1/+1 until end of turn unless any player pays o2.",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "b29c452c-c4d3-5713-a553-fea330b93ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c84d09-555c-472b-b445-5dd5a44cd555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c84d09-555c-472b-b445-5dd5a44cd555.jpg?1",
             "name": "Noxious Field",
             "text": "Enchanted land has \"oc\nT: This land deals 1 damage to each creature and each player.\"",
             "colours": [
@@ -2394,7 +2394,7 @@
         },
         {
             "id": "a6602618-6346-5af3-bd57-fea292279f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43c30d9-23a5-4872-925d-3427f5f57995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43c30d9-23a5-4872-925d-3427f5f57995.jpg?1",
             "name": "Outbreak",
             "text": "You may discard a swamp from your hand instead of paying Outbreak's mana cost.\nChoose a creature type. All creatures of that type get -1/-1 until end of turn.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "a35b2dfd-8825-56c9-9e6b-c1d7a0437a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37cd150-1064-43b7-919b-8922d8a18f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37cd150-1064-43b7-919b-8922d8a18f21.jpg?1",
             "name": "Pit Raptor",
             "text": "Flying, first strike\nAt the beginning of your upkeep, sacrifice Pit Raptor unless you pay o2o\nBo\nB.",
             "colours": [
@@ -2461,7 +2461,7 @@
         },
         {
             "id": "ce246379-e5f2-5f7b-92f3-c9cf1de55abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f077f5-c0b0-4e94-8599-e2122bc87238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f077f5-c0b0-4e94-8599-e2122bc87238.jpg?1",
             "name": "Plague Fiend",
             "text": "Whenever Plague Fiend deals combat damage to a creature, destroy that creature unless its controller pays o2.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "4eb5a9a9-f6e9-5e1a-b768-e594e760d51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4bd20-7422-45ed-aa76-3ef055c556e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4bd20-7422-45ed-aa76-3ef055c556e7.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "a9aba568-91c3-5031-bbb5-fe66f7428011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98a71a8-291f-4d94-ada0-5f50f354cca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98a71a8-291f-4d94-ada0-5f50f354cca7.jpg?1",
             "name": "Rebel Informer",
             "text": "Rebel Informer can't be the target of white spells or abilities.\no3: Put target Rebel card on the bottom of its owner's library.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "8ec47a3d-f588-5166-9c13-566e9abd6cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c5df2-e299-4bf3-8018-725893702314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c5df2-e299-4bf3-8018-725893702314.jpg?1",
             "name": "Rhystic Syphon",
             "text": "Unless target player pays o3, he or she loses 5 life and you gain 5 life.",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "b82da2d5-3271-5658-aa97-b05e8f8a1132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c1609-9cac-460f-8504-a84e28c340c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c1609-9cac-460f-8504-a84e28c340c1.jpg?1",
             "name": "Rhystic Tutor",
             "text": "Unless any player pays o2, search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "74093bc9-e08d-5aba-9d8f-ceb4ad8cfea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f9d1b-a89a-439f-8aa9-b96a1bf892eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f9d1b-a89a-439f-8aa9-b96a1bf892eb.jpg?1",
             "name": "Soul Strings",
             "text": "Return two target creature cards from your graveyard to your hand unless any player pays o\nX.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "d1363d84-b47a-5029-9579-f0a998230aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470b3bb-5061-4beb-9f44-b56c3b2fd816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470b3bb-5061-4beb-9f44-b56c3b2fd816.jpg?1",
             "name": "Steal Strength",
             "text": "Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "6c115226-b2b0-517f-be60-c8228e5b507c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1",
             "name": "Wall of Vipers",
             "text": "(Walls can't attack.)\no3: Destroy Wall of Vipers and target creature it's blocking. Any player may play this ability.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "72534716-6fb6-5609-a75d-00af189294e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd00b0b-2ac1-4926-a735-215f402ba1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd00b0b-2ac1-4926-a735-215f402ba1c4.jpg?1",
             "name": "Whipstitched Zombie",
             "text": "At the beginning of your upkeep, sacrifice Whipstitched Zombie unless you pay o\nB.",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "b24bd8c5-88d2-54da-8499-91befc6009d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528293b4-ce3b-4623-8ced-496701d7265b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528293b4-ce3b-4623-8ced-496701d7265b.jpg?1",
             "name": "Avatar of Fury",
             "text": "Flying\nIf an opponent controls seven or more lands, Avatar of Fury costs o6 less to play.\noo\nR Avatar of Fury gets +1/+0 until end of turn.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "b894bbbe-d874-5b1d-a7a4-e593ec16b4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c76db48-6f05-49c3-a49c-587c0a8a3613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c76db48-6f05-49c3-a49c-587c0a8a3613.jpg?1",
             "name": "Barbed Field",
             "text": "Enchanted land has \"oc\nT: This land deals 1 damage to target creature or player.\"",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "5abdb7bb-fa0d-51e1-830f-2bb794c6e260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a48065-fbf1-4f2a-993e-7061057a4c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a48065-fbf1-4f2a-993e-7061057a4c45.jpg?1",
             "name": "Branded Brawlers",
             "text": "Branded Brawlers can't attack if defending player controls an untapped land.\nBranded Brawlers can't block if you control an untapped land.",
             "colours": [
@@ -2863,7 +2863,7 @@
         },
         {
             "id": "0fabbddd-75c0-5e62-9ef9-5ea35dc782a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b3725b-924d-4137-9078-1a28f06c84fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b3725b-924d-4137-9078-1a28f06c84fa.jpg?1",
             "name": "Brutal Suppression",
             "text": "Activated abilities on Rebel cards cost an additional \"Sacrifice a land\" to play.",
             "colours": [
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "ab5c2852-b0df-5a6b-afee-ad395837a9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66585109-77cb-42f1-9c14-3dac1d493b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66585109-77cb-42f1-9c14-3dac1d493b71.jpg?1",
             "name": "Citadel of Pain",
             "text": "At the end of each player's turn, Citadel of Pain deals X damage to that player, where X is the number of untapped lands he or she controls.",
             "colours": [
@@ -2927,7 +2927,7 @@
         },
         {
             "id": "380eff64-9dc7-5eb3-ac0f-f9f6a7c43f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7c990-a34b-475e-a612-447c22f998d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7c990-a34b-475e-a612-447c22f998d3.jpg?1",
             "name": "Devastate",
             "text": "Destroy target land. Devastate deals 1 damage to each creature and each player.",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "25af13e3-873c-5ac8-aa7f-1fc63d03f7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d3579-3fc1-434e-8f26-d5dbd6344429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d3579-3fc1-434e-8f26-d5dbd6344429.jpg?1",
             "name": "Fault Riders",
             "text": "Sacrifice a land: Fault Riders gets +2/+0 and gains first strike until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "874b7259-e3cf-59d3-b2a5-55abb9096e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6d047a-f3dc-4c34-9679-fb76037e4044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6d047a-f3dc-4c34-9679-fb76037e4044.jpg?1",
             "name": "Fickle Efreet",
             "text": "Whenever Fickle Efreet attacks or blocks, flip a coin at end of combat. If you lose the flip, an opponent gains control of Fickle Efreet.",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "7b7797e9-7763-5d1f-b4b7-75da2281f230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7b61a8-a1ff-4e2a-bc24-8990c61a5e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7b61a8-a1ff-4e2a-bc24-8990c61a5e5b.jpg?1",
             "name": "Flameshot",
             "text": "You may discard a mountain from your hand instead of paying Flameshot's mana cost.\nFlameshot deals 3 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "4619f7ad-5321-5817-9885-3ad20a8c3ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7bc4c0-9bfd-444b-b22c-f1b7e1426807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7bc4c0-9bfd-444b-b22c-f1b7e1426807.jpg?1",
             "name": "Inflame",
             "text": "Inflame deals 2 damage to each creature dealt damage this turn.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "3190c4fd-bb85-540e-ba12-53d06c19e4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f58b1-d8d7-4544-8363-e2b96e9d2623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f58b1-d8d7-4544-8363-e2b96e9d2623.jpg?1",
             "name": "Keldon Arsonist",
             "text": "o1, Sacrifice two lands: Destroy target land.",
             "colours": [
@@ -3127,7 +3127,7 @@
         },
         {
             "id": "066b7401-0bec-5bc3-a989-3400668fae0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa3f9c0-66ff-4b94-b0c3-e1c65d2040b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa3f9c0-66ff-4b94-b0c3-e1c65d2040b9.jpg?1",
             "name": "Keldon Berserker",
             "text": "Whenever Keldon Berserker attacks, if you control no untapped lands, it gets +3/+0 until end of turn.",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "d3e4e1f4-1b1f-50d7-9e0f-a6ea881d5a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc78b5-c259-4c67-810c-99655e72c2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc78b5-c259-4c67-810c-99655e72c2da.jpg?1",
             "name": "Keldon Firebombers",
             "text": "When Keldon Firebombers comes into play, each player sacrifices all lands he or she controls except for three.",
             "colours": [
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "9ea1e7a0-cafa-5c93-b0be-c9d26c9b8f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3c7b0c-98bd-4c63-bbb0-80484a5ab26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3c7b0c-98bd-4c63-bbb0-80484a5ab26f.jpg?1",
             "name": "Latulla, Keldon Overseer",
             "text": "o\nXo\nR, oc\nT, Discard two cards from your hand: Latulla, Keldon Overseer deals X damage to target creature or player.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "9bf560bb-0cde-5a16-bb0a-179f7682a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56cd728-5c3c-4fd6-bb01-0bf0875508c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56cd728-5c3c-4fd6-bb01-0bf0875508c7.jpg?1",
             "name": "Latulla's Orders",
             "text": "You may play Latulla's Orders any time you could play an instant.\nWhenever enchanted creature deals combat damage to defending player, you may have it destroy target artifact that player controls.",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "642e7c6d-40d7-59ed-b3ba-deb8a9d48d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ed7aec-a513-418e-9cef-e0c51203055b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ed7aec-a513-418e-9cef-e0c51203055b.jpg?1",
             "name": "Lesser Gargadon",
             "text": "Whenever Lesser Gargadon attacks or blocks, sacrifice a land.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "4a132604-de61-5b78-bfa6-6d7dfb42eef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ec751c-08b5-4afb-bc08-8b2735b24f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ec751c-08b5-4afb-bc08-8b2735b24f59.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "ef55a20e-8aab-55a3-882c-5854f387328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ce365e-3002-42e9-aeb5-1b845408271e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ce365e-3002-42e9-aeb5-1b845408271e.jpg?1",
             "name": "Rhystic Lightning",
             "text": "Rhystic Lightning deals 4 damage to target creature or player unless that creature's controller or that player pays o2. If he or she does, Rhystic Lightning deals 2 damage to the creature or player.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "2e10f471-3546-52a1-9dae-61faaa1fe2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f663a4a-592a-4a3b-bbaf-e9c5c3049021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f663a4a-592a-4a3b-bbaf-e9c5c3049021.jpg?1",
             "name": "Ridgeline Rager",
             "text": "oo\nR Ridgeline Rager gets +1/+0 until end of turn.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "cd515f39-2f0e-5806-ba0e-a96660a58151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274f791-c9f1-49a1-9002-10e94caee96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274f791-c9f1-49a1-9002-10e94caee96e.jpg?1",
             "name": "Scoria Cat",
             "text": "Scoria Cat gets +3/+3 as long as you control no untapped lands.",
             "colours": [
@@ -3435,7 +3435,7 @@
         },
         {
             "id": "222cc5e0-afa0-5d35-9ba2-99f05bc63e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f19a1b5-48ba-44a9-b91f-2f628b223ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f19a1b5-48ba-44a9-b91f-2f628b223ffb.jpg?1",
             "name": "Search for Survivors",
             "text": "Shuffle your graveyard. An opponent chooses a card from it at random. If that card is a creature card, put it into play. Otherwise, remove it from the game.",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "0547a36a-2d26-5859-8107-af56f251d010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b761f97-3690-497a-b6ab-c71f61b8e841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b761f97-3690-497a-b6ab-c71f61b8e841.jpg?1",
             "name": "Searing Wind",
             "text": "Searing Wind deals 10 damage to target creature or player.",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "530fe78d-b7bb-52f0-8732-42d6e815caa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf91a7-4d04-437c-a290-6adb52f25312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf91a7-4d04-437c-a290-6adb52f25312.jpg?1",
             "name": "Spur Grappler",
             "text": "Spur Grappler gets +2/+1 as long as you control no untapped lands.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "f1e4a400-20d5-55f2-a2e4-01fd1274862e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258a9cdd-c626-404e-b82d-01091f11f107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258a9cdd-c626-404e-b82d-01091f11f107.jpg?1",
             "name": "Task Mage Assembly",
             "text": "When there are no creatures in play, sacrifice Task Mage Assembly.\no2: Task Mage Assembly deals 1 damage to target creature. Any player may play this ability but only any time he or she could play a sorcery.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "93910065-2c74-573b-8289-6d1a6e3bc2d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d3acb-68be-409d-beb7-92a7cbc0402f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d3acb-68be-409d-beb7-92a7cbc0402f.jpg?1",
             "name": "Veteran Brawlers",
             "text": "Veteran Brawlers can't attack if defending player controls an untapped land.\nVeteran Brawlers can't block if you control an untapped land.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "735d7e25-8fc7-54d7-b0c2-cd6c83ae4976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6b3f38-87c9-4cea-b9e5-b8fb42e64794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6b3f38-87c9-4cea-b9e5-b8fb42e64794.jpg?1",
             "name": "Whip Sergeant",
             "text": "oo\nR Target creature gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "f861a59a-d0ff-5712-a38b-02cc88827df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a8e1ce-e394-48d6-938a-aa76c0273abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a8e1ce-e394-48d6-938a-aa76c0273abe.jpg?1",
             "name": "Zerapa Minotaur",
             "text": "First strike\no2: Zerapa Minotaur loses first strike until end of turn. Any player may play this ability.",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "d0e58dba-d889-5eeb-b45c-b5b1121d6519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97614db-167e-4ede-96bd-77ed90b57d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97614db-167e-4ede-96bd-77ed90b57d4e.jpg?1",
             "name": "Avatar of Might",
             "text": "Trample\nIf an opponent controls at least four more creatures than you, Avatar of Might costs o6 less to play.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "ef584f9b-d6fb-5b43-9c0e-a1e2c9fb1f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec38c856-dc21-450d-9aa6-da16c91a489a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec38c856-dc21-450d-9aa6-da16c91a489a.jpg?1",
             "name": "Calming Verse",
             "text": "Destroy all enchantments you don't control. Then, if you control an untapped land, destroy all enchantments you control.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "023df0f7-38d8-5ee2-a54e-6f7ea2633a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82636dc-4b3e-44a8-bc72-dab1275dfb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82636dc-4b3e-44a8-bc72-dab1275dfb6d.jpg?1",
             "name": "Darba",
             "text": "At the beginning of your upkeep, sacrifice Darba unless you pay o\nGo\nG.",
             "colours": [
@@ -3770,7 +3770,7 @@
         },
         {
             "id": "2c0a26ff-6a0d-5078-a145-ad4c39309224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890e414-d7e1-4320-924c-083e65a2ae72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890e414-d7e1-4320-924c-083e65a2ae72.jpg?1",
             "name": "Dual Nature",
             "text": "Whenever a creature card comes into play, its controller puts a creature token into play that's a copy of that creature.\nWhenever a creature card leaves play, remove all tokens with the same name as that creature from the game.\nWhen Dual Nature leaves play, remove all tokens created with it from the game.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "8847947d-eefb-51ef-9ae9-644978188e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22147f72-7ff8-40c4-9bdd-df41dce17dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22147f72-7ff8-40c4-9bdd-df41dce17dad.jpg?1",
             "name": "Elephant Resurgence",
             "text": "Each player puts a green Elephant creature token into play. Those creatures have \"This creature's power and toughness are each equal to the number of creature cards in its controller's graveyard.\"",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "24179bb5-1e61-5479-b95f-2e6ac80badd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fefbace-03cb-43db-a221-0be2b8784357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fefbace-03cb-43db-a221-0be2b8784357.jpg?1",
             "name": "Forgotten Harvest",
             "text": "At the beginning of your upkeep, you may remove a land card in your graveyard from the game. If you do, put a +1/+1 counter on target creature.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "cc06a866-a99b-5fed-a721-6bb24b8be7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ea1c3-e920-467b-a3c8-a6b1097c3e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ea1c3-e920-467b-a3c8-a6b1097c3e8d.jpg?1",
             "name": "Jolrael, Empress of Beasts",
             "text": "o2o\nG, oc\nT, Discard two cards from your hand: Until end of turn, all lands target player controls are 3/3 creatures that are still lands.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "afca6947-a88d-5e82-9a37-e203bffe550b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8275ecd7-f119-4cca-bef1-626a3272dd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8275ecd7-f119-4cca-bef1-626a3272dd2c.jpg?1",
             "name": "Jolrael's Favor",
             "text": "You may play Jolrael's Favor any time you could play an instant.\no1oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "2b6c23d0-d3b0-5e4f-9696-8f375839530e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64558128-7990-470c-88c9-d47d622e44db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64558128-7990-470c-88c9-d47d622e44db.jpg?1",
             "name": "Living Terrain",
             "text": "Enchanted land is a 5/6 green Treefolk creature that's still a land.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "a85fbd67-5ad5-5c98-ac68-c87a19ffa461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c99bb6-a483-4beb-b98c-eb641fe3d50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c99bb6-a483-4beb-b98c-eb641fe3d50a.jpg?1",
             "name": "Marsh Boa",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "aeac099c-2b12-5379-bb8a-fb59c4f1592b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addc915-2997-4b81-a026-97d4421cf17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addc915-2997-4b81-a026-97d4421cf17d.jpg?1",
             "name": "Mungha Wurm",
             "text": "You can't untap more than one land during your untap step.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "196eee60-8e8f-58a9-b9b6-491d49e4dd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad9744f-797a-4dd3-8617-192773be995c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad9744f-797a-4dd3-8617-192773be995c.jpg?1",
             "name": "Pygmy Razorback",
             "text": "Trample",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "96b33813-f4d9-5bed-83d9-08aff0ebd162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71bebea-1634-4d9a-b3ad-2e01ecacad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71bebea-1634-4d9a-b3ad-2e01ecacad7e.jpg?1",
             "name": "Rib Cage Spider",
             "text": "Rib Cage Spider may block as though it had flying.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "19bfb21e-1c0c-5fff-a771-ccd7569e7ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db109497-7674-4067-a12b-dfb5c317a358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db109497-7674-4067-a12b-dfb5c317a358.jpg?1",
             "name": "Root Cage",
             "text": "Mercenaries don't untap during their controllers' untap steps.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "80fbefb6-97b7-5073-980a-77afb7ef80f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f334e864-4e62-4bc3-9470-661be3d879e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f334e864-4e62-4bc3-9470-661be3d879e2.jpg?1",
             "name": "Silt Crawler",
             "text": "When Silt Crawler comes into play, tap all lands you control.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "f3137977-e091-5474-96b6-65070a0331a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7401df8b-23e7-4485-9ed4-70118a66feed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7401df8b-23e7-4485-9ed4-70118a66feed.jpg?1",
             "name": "Snag",
             "text": "You may discard a forest from your hand instead of paying Snag's mana cost.\nPrevent all combat damage that would be dealt by unblocked creatures this turn.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "ef2d38ba-d250-553e-8432-ee8bda483ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220fada-5cbb-4266-bca3-a44d51773d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220fada-5cbb-4266-bca3-a44d51773d63.jpg?1",
             "name": "Spitting Spider",
             "text": "Spitting Spider may block as though it had flying.\nSacrifice a land: Spitting Spider deals 1 damage to each creature with flying.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "b2ff5fa4-a337-57d8-809f-c4cc90bc3344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f752339-003d-4ded-b2bf-e4200fc8d5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f752339-003d-4ded-b2bf-e4200fc8d5d6.jpg?1",
             "name": "Spore Frog",
             "text": "Sacrifice Spore Frog: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "b47a56dd-a307-5ffa-883b-1b15e349528f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7094be2a-454e-4e4d-a540-c5c80e37468a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7094be2a-454e-4e4d-a540-c5c80e37468a.jpg?1",
             "name": "Squirrel Wrangler",
             "text": "o1o\nG, Sacrifice a land: Put two 1/1 green Squirrel creature tokens into play.\no1o\nG, Sacrifice a land: All Squirrels get +1/+1 until end of turn.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "302b107e-278e-5769-8a59-b52664fdb376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57996732-c9e4-4271-9d5f-2a8c77f8d177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57996732-c9e4-4271-9d5f-2a8c77f8d177.jpg?1",
             "name": "Thresher Beast",
             "text": "Whenever Thresher Beast becomes blocked, defending player sacrifices a land.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "2a4965ba-beff-55b8-9968-5ec13b9bd666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb20099-fc53-4fdf-86f4-d7d8155c2af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb20099-fc53-4fdf-86f4-d7d8155c2af1.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "ebd8516b-0262-5d23-b7fe-d964bcd74182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d123da53-9fd3-492b-beb7-76d1c0f5e4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d123da53-9fd3-492b-beb7-76d1c0f5e4f6.jpg?1",
             "name": "Verdant Field",
             "text": "Enchanted land has \"oc\nT: Target creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "1e9177ce-0395-5a6b-85b1-a39a61aed2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f7aef-7398-4e10-9f4e-68e7c294c101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f7aef-7398-4e10-9f4e-68e7c294c101.jpg?1",
             "name": "Vintara Elephant",
             "text": "Trample\no3: Vintara Elephant loses trample until end of turn. Any player may play this ability.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "f89332a5-66c6-50c6-9bef-3c100843d483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897edf01-fc6f-4835-b025-c137d921ce09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897edf01-fc6f-4835-b025-c137d921ce09.jpg?1",
             "name": "Vintara Snapper",
             "text": "Vintara Snapper can't be the target of spells or abilities as long as you control no untapped lands.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "9e8cff26-3462-54ea-b80c-87e9a6dfb927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbd7c20-d527-4d97-9630-896d5e7bf1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbd7c20-d527-4d97-9630-896d5e7bf1de.jpg?1",
             "name": "Vitalizing Wind",
             "text": "Creatures you control get +7/+7 until end of turn.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "3ce6999a-df4b-5673-b4a4-f15f809e1974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8c0be2-ba90-4e7a-b1a6-c68be550e33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8c0be2-ba90-4e7a-b1a6-c68be550e33d.jpg?1",
             "name": "Wild Might",
             "text": "Target creature gets +1/+1 until end of turn. That creature gets an additional +4/+4 until end of turn unless any player pays o2.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "76a5511d-1370-5f0e-91b0-20c17e35e1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e66be1-f18a-433f-8504-aa1e85e22023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e66be1-f18a-433f-8504-aa1e85e22023.jpg?1",
             "name": "Wing Storm",
             "text": "Wing Storm deals X damage to each player, where X is twice the number of creatures with flying that player controls.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "ae0be565-65fb-5d6e-93f5-485bcbea35ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0fb30e-e4d0-4271-a712-db40fa7650c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0fb30e-e4d0-4271-a712-db40fa7650c3.jpg?1",
             "name": "Chimeric Idol",
             "text": "o0: Tap all lands you control. Chimeric Idol becomes a 3/3 artifact creature until end of turn.",
             "colours": [],
@@ -4600,7 +4600,7 @@
         },
         {
             "id": "2d6262b3-ee74-5d56-a202-3f51e7daf795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be413dd-d6e0-4bd3-8c14-4dbe44e8ee41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be413dd-d6e0-4bd3-8c14-4dbe44e8ee41.jpg?1",
             "name": "Copper-Leaf Angel",
             "text": "Flying\noc\nT, Sacrifice X lands: Put X +1/+1 counters on Copper-Leaf Angel.",
             "colours": [],
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "812fb027-a52e-526e-a72e-4ab1848ba9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163add05-9ee9-4a8f-8838-3c4143ddc2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163add05-9ee9-4a8f-8838-3c4143ddc2f5.jpg?1",
             "name": "Hollow Warrior",
             "text": "Hollow Warrior can't attack or block unless you tap an untapped creature you control. (This cost is paid as attackers or blockers are declared.)",
             "colours": [],
@@ -4663,7 +4663,7 @@
         },
         {
             "id": "c5e504ed-1b7f-54c7-841a-4d7c3c6358c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c810aa1-e367-4102-a5bd-6dc02d3023e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c810aa1-e367-4102-a5bd-6dc02d3023e8.jpg?1",
             "name": "Keldon Battlewagon",
             "text": "Trample\nKeldon Battlewagon can't block.\nWhen Keldon Battlewagon attacks, sacrifice it at end of combat.\nTap an untapped creature you control: Keldon Battlewagon gets +X/+0 until end of turn, where X is the tapped creature's power.",
             "colours": [],
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "91f9f641-40f1-518c-a3ae-1e3369ae1dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82331a8a-c0f1-4d89-87f8-1b1d0fccabb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82331a8a-c0f1-4d89-87f8-1b1d0fccabb8.jpg?1",
             "name": "Well of Discovery",
             "text": "At the end of your turn, if you control no untapped lands, draw a card.",
             "colours": [],
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "8c84dabb-7715-5932-b54f-e7534049c23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3f4fc3-3819-470d-92d9-98cb390f89b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3f4fc3-3819-470d-92d9-98cb390f89b9.jpg?1",
             "name": "Well of Life",
             "text": "At the end of your turn, if you control no untapped lands, you gain 2 life.",
             "colours": [],
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "f2f8f712-be4f-50a5-9ac3-c6ea44b5340b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae74463-4426-4ad4-b7a2-324694854245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae74463-4426-4ad4-b7a2-324694854245.jpg?1",
             "name": "Rhystic Cave",
             "text": "oc\nT: Add one mana of any color to your mana pool unless any player pays o1.",
             "colours": [],
@@ -4778,7 +4778,7 @@
         },
         {
             "id": "fcc0baca-e632-58db-a68e-ed432fa8db43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07144a6-6e47-4315-8353-f8958f014f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07144a6-6e47-4315-8353-f8958f014f41.jpg?1",
             "name": "Wintermoon Mesa",
             "text": "Wintermoon Mesa comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\no2, oc\nT, Sacrifice Wintermoon Mesa: Tap two target lands.",
             "colours": [],

--- a/Assets/Resources/Sets/PIP.json
+++ b/Assets/Resources/Sets/PIP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "759ca3de-1758-59a2-bad8-d65070984712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a7176-98bc-4f54-aa61-38747420f178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a7176-98bc-4f54-aa61-38747420f178.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "Whenever you attack, you may sacrifice another creature. When you do, choose two \u2014\n\u2022 Create two 1/1 red and white Soldier creature tokens with haste that are tapped and attacking.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Caesar, Legion's Emperor deals damage equal to the number of creature tokens you control to target opponent.",
             "colours": [
@@ -49,7 +49,7 @@
         },
         {
             "id": "0ec1782b-4274-5d6e-9b22-4fb3fb53d6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b45e3e-8460-4678-87d1-d74479936c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b45e3e-8460-4678-87d1-d74479936c83.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "When Dogmeat enters the battlefield, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\nWhenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -93,7 +93,7 @@
         },
         {
             "id": "d7bf6ff2-0a77-5640-a8ce-c649c8a2b8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95af426d-a8af-4314-9ad0-ac61935e8e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95af426d-a8af-4314-9ad0-ac61935e8e8e.jpg?1",
             "name": "Dr. Madison Li",
             "text": "Whenever you cast an artifact spell, you get {E} (an energy counter).\n{T}, Pay {E}: Target creature gets +1/+0 and gains trample and haste until end of turn.\n{T}, Pay {E}{E}{E}: Draw a card.\n{T}, Pay {E}{E}{E}{E}{E}: Return target artifact card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "c9e712fb-2e1c-572e-be7a-815bf9582581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d6944-a364-41c2-b824-7a1bf6ad0d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d6944-a364-41c2-b824-7a1bf6ad0d1e.jpg?1",
             "name": "The Wise Mothman",
             "text": "Flying\nWhenever The Wise Mothman enters the battlefield or attacks, each player gets a rad counter.\nWhenever one or more nonland cards are milled, put a +1/+1 counter on each of up to X target creatures, where X is the number of nonland cards milled this way.",
             "colours": [
@@ -183,7 +183,7 @@
         },
         {
             "id": "250b2f63-66cb-5a13-b9e4-8bc7535e3c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da11337-ceb2-4744-9696-c06fec2f2daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da11337-ceb2-4744-9696-c06fec2f2daa.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "Vigilance, trample, haste\nWhenever Liberty Prime, Recharged attacks or blocks, sacrifice it unless you pay {E}{E} (two energy counters).\n{2}, {T}, Sacrifice an artifact: You get {E}{E} and draw a card.",
             "colours": [
@@ -227,7 +227,7 @@
         },
         {
             "id": "166ea6d0-1dd0-585b-a95a-40a0ac796302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0497da-670a-405c-a39c-97cae7942836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0497da-670a-405c-a39c-97cae7942836.jpg?1",
             "name": "The Master, Transcendent",
             "text": "When The Master, Transcendent enters the battlefield, target player gets two rad counters.\n{T}: Put target creature card in a graveyard that was milled this turn onto the battlefield under your control. It's a green Mutant with base power and toughness 3/3. (It loses its other colors and creature types.)",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "2a214374-0a31-5564-80f8-b30249201277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb3cf7-c90d-4bfa-b125-4fbcb5614468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb3cf7-c90d-4bfa-b125-4fbcb5614468.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "Whenever you roll a 4 or higher, create a 3/3 colorless Robot artifact creature token. If you rolled 6 or higher, instead create that token and a Treasure token.\n{4}, {T}: Roll a six-sided die plus an additional six-sided die for each mana from Treasures spent to activate this ability.",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "ba075f2f-9db0-52e1-bc3f-e62533ca58e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b60168-1e7b-4c80-bb93-6841c1e961bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b60168-1e7b-4c80-bb93-6841c1e961bb.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "At the beginning of combat on your turn, create a green Aura enchantment token named Settlement attached to up to one target land you control. It has enchant land and \"Enchanted land has \u2018{T}: Add one mana of any color.'\"\nWhenever Preston Garvey, Minuteman attacks, untap each enchanted permanent you control.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "9745cf29-661a-597d-be64-0a969e0f91ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701dae4-348e-40f6-9db4-d6f0039be831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701dae4-348e-40f6-9db4-d6f0039be831.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhenever a creature you control attacks, if it enlisted a creature this combat, the creature that attacked gains double strike until end of turn. If that creature's power is 4 or greater, draw a card.",
             "colours": [
@@ -400,7 +400,7 @@
         },
         {
             "id": "0b4b626a-1455-540e-921e-3be2c3215a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e2a76-1324-4b8e-b23c-10c04aca1870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e2a76-1324-4b8e-b23c-10c04aca1870.jpg?1",
             "name": "Automated Assembly Line",
             "text": "Whenever one or more artifact creatures you control deal combat damage to a player, you get {E} (an energy counter).\nPay {E}{E}{E}: Create a tapped 3/3 colorless Robot artifact creature token.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "75184ad8-1878-5f6b-ac7b-9de1db7ebc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c0f13a-4e83-4e0b-a790-1f78b5ee6a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c0f13a-4e83-4e0b-a790-1f78b5ee6a64.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "As Battle of Hoover Dam enters the battlefield, choose NCR or Legion.\n\u2022 NCR \u2014 At the beginning of your end step, return target creature card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.\n\u2022 Legion \u2014 Whenever a creature you control dies, put two +1/+1 counters on target creature you control.",
             "colours": [
@@ -472,7 +472,7 @@
         },
         {
             "id": "95af5175-75ff-5dc6-a708-e1824f2e6a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e96e656-7146-420d-aaae-3aedd773eea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e96e656-7146-420d-aaae-3aedd773eea2.jpg?1",
             "name": "Brotherhood Outcast",
             "text": "When Brotherhood Outcast enters the battlefield, choose one \u2014\n\u2022 Return target Aura or Equipment card with mana value 3 or less from your graveyard to the battlefield.\n\u2022 Put a shield counter on target creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "c7e3d2fd-2479-5e3c-8b4c-c56a727ab5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751250e-ebf2-42b1-9a45-779b39974ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751250e-ebf2-42b1-9a45-779b39974ba7.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "Metalcraft \u2014 {T}: You get {E} (an energy counter). Activate only if you control three or more artifacts.\nWhenever you get one or more {E} during your turn, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "78b0724d-9bf5-5b1c-a5a0-3dd362c54775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdfbd21-61b1-4ebd-8d37-bce2a391a7e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdfbd21-61b1-4ebd-8d37-bce2a391a7e9.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "Commanders you control have ward {2}.\n{T}: Add {W}{W}. Spend this mana only to cast Aura and/or Equipment spells.\n{T}: Attach target Aura or Equipment you control to target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "70ddf5ea-2ddc-503b-ba47-72130e232129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712697a4-69b4-4237-9340-96f0e5a32229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712697a4-69b4-4237-9340-96f0e5a32229.jpg?1",
             "name": "Commander Sofia Daguerre",
             "text": "Flash\nCrash Landing \u2014 When Commander Sofia Daguerre enters the battlefield, destroy up to one target legendary permanent. That permanent's controller creates a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -628,7 +628,7 @@
         },
         {
             "id": "5a8786c8-b970-5efb-9192-bbdf02d64bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45346ac-54a9-4fda-bde7-92ff75ac34f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45346ac-54a9-4fda-bde7-92ff75ac34f7.jpg?1",
             "name": "Gary Clone",
             "text": "Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhenever Gary Clone attacks, each creature you control named Gary Clone gets +1/+0 until end of turn.",
             "colours": [
@@ -665,7 +665,7 @@
         },
         {
             "id": "fda4d637-0640-5dea-8642-c930ea2768a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687133cb-3754-475c-9e21-b6a33aa58bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687133cb-3754-475c-9e21-b6a33aa58bb0.jpg?1",
             "name": "Idolized",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks alone, it gets +X/+X until end of turn, where X is the number of nonland permanents you control.\"",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "512264bb-3cf4-5fb8-9b27-9b6be0442222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47058eaa-348d-4bbb-8df5-b931eba067f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47058eaa-348d-4bbb-8df5-b931eba067f3.jpg?1",
             "name": "Overencumbered",
             "text": "Enchant opponent\nWhen Overencumbered enters the battlefield, enchanted opponent creates a Clue token, a Food token, and a Junk token.\nAt the beginning of combat on enchanted opponent's turn, that player may pay {1} for each artifact they control. If they don't, creatures can't attack this combat.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "57c28f22-e294-5996-b0a7-8d2d507a092e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35848917-d658-4c3b-b675-4f0185f76dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35848917-d658-4c3b-b675-4f0185f76dc4.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "First Contact \u2014 Whenever Overseer of Vault 76 or another creature with power 3 or less enters the battlefield under your control, put a quest counter on Overseer of Vault 76.\nAt the beginning of combat on your turn, you may remove three quest counters from among permanents you control. When you do, put a +1/+1 counter on each creature you control and they gain vigilance until end of turn.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "6b49e9d0-f0f8-55b8-8dce-4945fcdb39b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7ee3a-18f1-4771-86d6-db1e0b2aa542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7ee3a-18f1-4771-86d6-db1e0b2aa542.jpg?1",
             "name": "Paladin Danse, Steel Maverick",
             "text": "Vigilance, lifelink\nExile Paladin Danse, Steel Maverick: Each creature you control that's an artifact or Human gains indestructible until end of turn.",
             "colours": [
@@ -822,7 +822,7 @@
         },
         {
             "id": "074945d6-064c-5112-ada8-84c5d85375d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19018f23-b63b-45af-8419-8959f41472d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19018f23-b63b-45af-8419-8959f41472d4.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "When Pre-War Formalwear enters the battlefield, return target creature card with mana value 3 or less from your graveyard to the battlefield and attach Pre-War Formalwear to it.\nEquipped creature gets +2/+2 and has vigilance.\nEquip {3}",
             "colours": [
@@ -860,7 +860,7 @@
         },
         {
             "id": "70399eac-df1f-5d73-91e5-8ca37a107bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a8eda-bfeb-4fd9-9e41-12fce02883d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a8eda-bfeb-4fd9-9e41-12fce02883d8.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "Flying\nWhenever another nontoken artifact enters the battlefield under your control, create a 2/2 white Human Knight creature token with \"This creature gets +2/+2 as long as an artifact entered the battlefield under your control this turn.\"\nCrew 2",
             "colours": [
@@ -900,7 +900,7 @@
         },
         {
             "id": "75b965e8-1404-5728-99ae-2ffa5254a1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b689a206-aec3-4a31-95cf-3d4b840db04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b689a206-aec3-4a31-95cf-3d4b840db04c.jpg?1",
             "name": "Securitron Squadron",
             "text": "Squad {3} (As an additional cost to cast this spell, you may pay {3} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nVigilance\nWhenever a creature token enters the battlefield under your control, put a +1/+1 counter on it.",
             "colours": [
@@ -939,7 +939,7 @@
         },
         {
             "id": "01308706-8daf-50c1-ab0d-308c139e1c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b0143-3511-4f79-bdb1-1ff7af55f051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b0143-3511-4f79-bdb1-1ff7af55f051.jpg?1",
             "name": "Sentry Bot",
             "text": "Flash\nThis spell costs {1} less to cast for each creature attacking you.\nWhen Sentry Bot enters the battlefield, you get {E} for each creature attacking you.\nAt the beginning of combat on your turn, you may pay {E}{E}{E}. If you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "207a0ca1-2604-5796-800b-6688c51cd1bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641dd97c-6577-4cab-8672-56f870477961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641dd97c-6577-4cab-8672-56f870477961.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "The Nuka-Cola Challenge \u2014 Whenever one or more creatures you control deal combat damage to a player, put a quest counter on Sierra, Nuka's Biggest Fan and create a Food token.\nWhenever you sacrifice a Food, target creature you control gets +X/+X until end of turn, where X is the number of quest counters on Sierra.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "33834b89-6229-54bc-b722-4f29112d65cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22ad436-215a-4da1-b12e-1faac474f948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22ad436-215a-4da1-b12e-1faac474f948.jpg?1",
             "name": "Vault 13: Dweller's Journey",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 For each player, exile up to one other target enchantment or creature that player controls until Vault 13 leaves the battlefield.\nII \u2014 You gain 2 life and scry 2.\nIII \u2014 Return two cards exiled with Vault 13 to the battlefield under their owners' control and put the rest on the bottom of their owners' libraries.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "1b516a9e-5944-51c3-81a3-91d50097530a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992e262-0491-4379-b74b-13cc8b63065e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992e262-0491-4379-b74b-13cc8b63065e.jpg?1",
             "name": "Vault 75: Middle School",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile all creatures with power 4 or greater.\nII, III \u2014 Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "ba74e6ea-b228-593a-bed9-a6d0dfbe5700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc513659-ea88-4d04-82bd-5bb2e740d957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc513659-ea88-4d04-82bd-5bb2e740d957.jpg?1",
             "name": "Vault 101: Birthday Party",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human Soldier creature token and a Food token. (A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nII, III \u2014 You may put an Aura or Equipment card from your hand or graveyard onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control.",
             "colours": [
@@ -1127,7 +1127,7 @@
         },
         {
             "id": "67b5139c-47d1-521e-b6ed-50253202a790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fac8c-a574-4414-ac68-632fc822ddbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fac8c-a574-4414-ac68-632fc822ddbb.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "{T}: Target opponent gains control of Yes Man, Personal Securitron. When they do, you draw two cards and put a quest counter on Yes Man. Activate only during your turn.\nWild Card \u2014 When Yes Man leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "e9990c25-0f2f-5943-b722-a5805d9a4f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54870f19-96f3-4cde-ae44-a9c5bbb0dbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54870f19-96f3-4cde-ae44-a9c5bbb0dbc1.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.\n{1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has \"Whenever this creature deals combat damage to a player, draw cards equal to its base power.\"",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "a3a240da-ef0d-5ce3-8ef8-08da21b7e172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "{T}: Add {C}{C}. Spend this mana only to activate abilities.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "c121c742-fbbf-5a66-bc7b-288b04e07fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "Investigate X times. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "6e0c58c1-b068-5a63-ae3f-aa769e0d834f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48313997-fd94-486a-bf30-e9143a155814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48313997-fd94-486a-bf30-e9143a155814.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "Whenever a Zombie or Mutant you control dies, if its power was different from its base power, draw a card.\nCome Fly With Me \u2014 {2}, Sacrifice a creature: Put a +1/+1 counter on target creature you control. It gains flying until end of turn.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "2a3ed239-3aa4-570a-afff-fededdf5c95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d1843-9e05-4cdd-ad4e-15d7913d87f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d1843-9e05-4cdd-ad4e-15d7913d87f7.jpg?1",
             "name": "Mirelurk Queen",
             "text": "Vigilance\nWhen Mirelurk Queen enters the battlefield, target player gets two rad counters.\nWhenever one or more nonland cards are milled, draw a card, then put a +1/+1 counter on Mirelurk Queen. This ability triggers only once each turn.",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "04c97542-3476-5e8c-8516-6f581a72a12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9857669-5fad-458a-8eda-c1790298add7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9857669-5fad-458a-8eda-c1790298add7.jpg?1",
             "name": "Nerd Rage",
             "text": "Enchant creature\nWhen Nerd Rage enters the battlefield, draw two cards.\nEnchanted creature has \"You have no maximum hand size\" and \"Whenever this creature attacks, if you have ten or more cards in hand, it gets +10/+10 until end of turn.\"",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "522f18ed-58fe-5c0d-ba2f-15b1d612069d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9553-d4a8-4d51-8e8a-8a0ffbdf1715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9553-d4a8-4d51-8e8a-8a0ffbdf1715.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "Nick Valentine, Private Eye can't be blocked except by artifact creatures.\nWhenever Nick Valentine or another artifact creature you control dies, you may investigate. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "79df93fd-5d37-5252-8d40-fd82cc3adb8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916bf331-455a-4694-93d3-15dcf6971072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916bf331-455a-4694-93d3-15dcf6971072.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "Whenever Piper Wright deals combat damage to a player, investigate that many times. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "45c2434b-7cd6-521c-b242-c7ec8cd8ba94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d778cdec-8fc7-4174-bae1-4c8e8ccdfab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d778cdec-8fc7-4174-bae1-4c8e8ccdfab3.jpg?1",
             "name": "Radstorm",
             "text": "Storm (When you cast this spell, copy it for each spell cast before it this turn.)\nProliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "3edd8ce2-f9f5-5089-adce-4cbff6ca05dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c0791d-f0c5-4673-a0c5-40540c1e6d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c0791d-f0c5-4673-a0c5-40540c1e6d8c.jpg?1",
             "name": "Robobrain War Mind",
             "text": "Robobrain War Mind's power is equal to the number of cards in your hand.\nWhen Robobrain War Mind enters the battlefield, you get an amount of {E} (energy counters) equal to the number of artifact creatures you control.\nWhenever Robobrain War Mind attacks, you may pay {E}{E}{E}. If you do, draw a card.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "4a15b789-cdba-53b0-b986-849ceda2a8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c60155-9337-4ea2-b9a2-5b72d96743ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c60155-9337-4ea2-b9a2-5b72d96743ff.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "As Struggle for Project Purity enters the battlefield, choose Brotherhood or Enclave.\n\u2022 Brotherhood \u2014 At the beginning of your upkeep, each opponent draws a card. You draw a card for each card drawn this way.\n\u2022 Enclave \u2014 Whenever a player attacks you with one or more creatures, that player gets twice that many rad counters.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "f899e0bb-8e38-57b4-ad29-294da20a2c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe16bc4-8457-4c5f-902a-0746112e80a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe16bc4-8457-4c5f-902a-0746112e80a4.jpg?1",
             "name": "Synth Infiltrator",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nYou may have Synth Infiltrator enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.",
             "colours": [
@@ -1636,7 +1636,7 @@
         },
         {
             "id": "12f4fa4f-d70c-5473-a823-0f3cd33ae69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91580910-fe0e-4cd9-9e73-821af23abfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91580910-fe0e-4cd9-9e73-821af23abfe7.jpg?1",
             "name": "Vexing Radgull",
             "text": "Flying\nWhenever Vexing Radgull deals combat damage to a player, that player gets two rad counters if they don't have any rad counters. Otherwise, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "9d0e3637-de45-55b0-8189-19c702ae734d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d90b839-0808-435d-bcf3-aa7af414c44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d90b839-0808-435d-bcf3-aa7af414c44b.jpg?1",
             "name": "Bloatfly Swarm",
             "text": "Flying\nBloatfly Swarm enters the battlefield with five +1/+1 counters on it.\nIf damage would be dealt to Bloatfly Swarm while it has a +1/+1 counter on it, prevent that damage, remove that many +1/+1 counters from it, then give each player a rad counter for each +1/+1 counter removed this way.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "452d0964-24b2-5f30-bdaf-a5bcd76ab925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed508c-ff2c-444c-8149-34b29e2fbebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed508c-ff2c-444c-8149-34b29e2fbebe.jpg?1",
             "name": "Butch DeLoria, Tunnel Snake",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nTunnel Snakes Rule \u2014 Whenever Butch DeLoria, Tunnel Snake attacks, it gets +1/+1 until end of turn for each other Rogue and/or Snake you control.\n{1}{B}: Put a menace counter on another target creature. It becomes a Rogue in addition to its other types.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "573a6625-4cd4-5745-b573-444ae4380356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdef99d-6ce9-495d-a55b-e6ba799d3da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdef99d-6ce9-495d-a55b-e6ba799d3da7.jpg?1",
             "name": "Feral Ghoul",
             "text": "Menace\nWhenever another creature you control dies, put a +1/+1 counter on Feral Ghoul.\nWhen Feral Ghoul dies, each opponent gets a number of rad counters equal to its power.",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "3134aec0-d496-55b4-bbed-06ef8835f294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bda1b4-3f02-4cbc-9573-f5b6e6c991d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bda1b4-3f02-4cbc-9573-f5b6e6c991d5.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "Each other creature you control that's a Zombie or Mutant gets +X/+X, where X is the number of counters on Hancock, Ghoulish Mayor.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "1c27aa6e-5a31-53f4-8493-65d234d8f9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b51b691-e226-44c9-b7cb-26f19c060597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b51b691-e226-44c9-b7cb-26f19c060597.jpg?1",
             "name": "Infesting Radroach",
             "text": "Flying\nInfesting Radroach can't block.\nWhenever Infesting Radroach deals combat damage to a player, they get that many rad counters.\nWhenever an opponent mills a nonland card, if Infesting Radroach is in your graveyard, you may return it to your hand.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "2a390efe-a256-551d-8d55-8125b2fa79c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e717e4b0-a8c1-4411-b18a-1d17e7225503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e717e4b0-a8c1-4411-b18a-1d17e7225503.jpg?1",
             "name": "Nuclear Fallout",
             "text": "Each creature gets twice -X/-X until end of turn. Each player gets X rad counters.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "551ef638-dc57-55c2-92ba-3ca46d681503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4542e34-2905-41ce-9182-a432c8f2c451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4542e34-2905-41ce-9182-a432c8f2c451.jpg?1",
             "name": "Ruthless Radrat",
             "text": "Squad\u2014\nExile four cards from your graveyard. (As an additional cost to cast this spell, you may pay its squad cost any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -1940,7 +1940,7 @@
         },
         {
             "id": "636e4e5b-60f2-55f0-86d6-554ca6aa3d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967dbb24-3073-4c33-bfdf-b3eb9e8fe443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967dbb24-3073-4c33-bfdf-b3eb9e8fe443.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "Flying, menace\nWhenever Screeching Scorchbeast attacks, each player gets two rad counters.\nWhenever one or more nonland cards are milled, you may create that many 2/2 black Zombie Mutant creature tokens. Do this only once each turn.",
             "colours": [
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "56e3801a-1098-5d32-9595-805652907f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512df222-0db0-4b24-9372-d0c01b181b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512df222-0db0-4b24-9372-d0c01b181b91.jpg?1",
             "name": "V.A.T.S.",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose any number of target creatures with equal toughness. Destroy the chosen creatures.",
             "colours": [
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "6849290f-b5fc-5310-a972-987fcc5ac52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cd9eb-9b15-40ce-8a48-919e72dbaa67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cd9eb-9b15-40ce-8a48-919e72dbaa67.jpg?1",
             "name": "Vault 12: The Necropolis",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player gets three rad counters.\nII \u2014 Create X 2/2 black Zombie Mutant creature tokens, where X is the total number of rad counters among players.\nIII \u2014 Put two +1/+1 counters on each creature you control that's a Zombie or Mutant.",
             "colours": [
@@ -2051,7 +2051,7 @@
         },
         {
             "id": "2c8f762c-3b55-5f9c-8170-dbae9d6eb019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae2596-013a-4e9b-982b-e0fc8d1e78bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae2596-013a-4e9b-982b-e0fc8d1e78bf.jpg?1",
             "name": "Wasteland Raider",
             "text": "Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhen Wasteland Raider enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "75802892-0df5-5eb0-ab50-104f8b4633cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19586946-a6a6-4154-a544-15a052483f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19586946-a6a6-4154-a544-15a052483f96.jpg?1",
             "name": "Acquired Mutation",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, defending player gets two rad counters.",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "f13310f9-d26b-511d-9e4e-40daa725b4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112fadb-da03-441a-beeb-1dc90425e3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112fadb-da03-441a-beeb-1dc90425e3f3.jpg?1",
             "name": "Assaultron Dominator",
             "text": "When Assaultron Dominator enters the battlefield, you get {E}{E} (two energy counters).\nWhenever an artifact creature you control attacks, you may pay {E}. If you do, put your choice of a +1/+1, first strike, or trample counter on that creature.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "a1012542-96cf-5485-ab9e-573b05f16bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdceec0-0950-4d52-86fc-d0f04e8487ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdceec0-0950-4d52-86fc-d0f04e8487ce.jpg?1",
             "name": "Bottle-Cap Blast",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nBottle-Cap Blast deals 5 damage to any target. If excess damage was dealt to a permanent this way, create that many tapped Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "421bd8e3-82cc-5abc-b4cb-a13b37648935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc522b-6297-455e-8bb5-6187061496d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc522b-6297-455e-8bb5-6187061496d0.jpg?1",
             "name": "Crimson Caravaneer",
             "text": "Double strike, trample\nWhenever Crimson Caravaneer deals combat damage to a player, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "a01791c9-2cde-55ed-9ff6-b07e44a3c54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0a17f-787b-41ac-8375-d9532dce1f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0a17f-787b-41ac-8375-d9532dce1f4f.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "Hunters for Hire \u2014 Whenever a creature you control deals combat damage to a player, put a quest counter on it.\n{1}, Remove a quest counter from a permanent you control: Create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "048a829d-e16a-5575-a04f-4aa8f853a8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e76286-9e06-42de-b322-eb8aa2cdca3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e76286-9e06-42de-b322-eb8aa2cdca3a.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "Morbid \u2014 This spell costs {3} less to cast if a creature died this turn.\nEnchant creature\nWhen Grim Reaper's Sprint enters the battlefield, untap each creature you control. If it's your main phase, there is an additional combat phase after this phase.\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "2eccbe20-3abb-5038-bbb1-06acb4827beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd46b6a-eb20-4ffa-94e0-47d1d2d46087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd46b6a-eb20-4ffa-94e0-47d1d2d46087.jpg?1",
             "name": "Ian the Reckless",
             "text": "Whenever Ian the Reckless attacks, if it's modified, you may have it deal damage equal to its power to you and any target. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "a6a8ba26-0bf2-5ba1-97ba-3c73548ba4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2397c9b8-3974-48b8-94bd-f05f2e20750c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2397c9b8-3974-48b8-94bd-f05f2e20750c.jpg?1",
             "name": "Junk Jet",
             "text": "When Junk Jet enters the battlefield, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\n{3}, Sacrifice another artifact: Double equipped creature's power until end of turn.\nEquip {1}",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "55ed5682-c877-5903-9b89-df14b6e2da45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8492127-888d-4da0-b49f-fba6a356b0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8492127-888d-4da0-b49f-fba6a356b0a9.jpg?1",
             "name": "Megaton's Fate",
             "text": "Choose one \u2014\n\u2022 Disarm \u2014 Destroy target artifact. Create four Treasure tokens.\n\u2022 Detonate \u2014 Megaton's Fate deals 8 damage to each creature. Each player gets four rad counters.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "89b4b639-3401-5a97-beea-6680efcf1123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9df394-522c-4458-bc36-cf24ad763718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9df394-522c-4458-bc36-cf24ad763718.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "When The Motherlode, Excavator enters the battlefield, choose target opponent. You get an amount of {E} (energy counters) equal to the number of nonbasic lands that player controls.\nWhenever The Motherlode attacks, you may pay {E}{E}{E}{E}. When you do, destroy target nonbasic land defending player controls, and creatures that player controls without flying can't block this turn.",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "6d698c1d-aa47-50a8-af6c-a95c12d93a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063ca0fa-1947-48da-86f9-76dd00dfb550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063ca0fa-1947-48da-86f9-76dd00dfb550.jpg?1",
             "name": "Mysterious Stranger",
             "text": "Flash\nWhen Mysterious Stranger enters the battlefield, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "87dfcd2c-c94c-5d91-8a3a-1ab7dd1d32c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1654256-25ea-4467-812d-25f32fe65cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1654256-25ea-4467-812d-25f32fe65cdd.jpg?1",
             "name": "Plasma Caster",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you get {E}{E} (two energy counters).\nPay {E}{E}: Choose target creature that's blocking equipped creature. Flip a coin. If you win the flip, exile the chosen creature. Otherwise, Plasma Caster deals 1 damage to it.\nEquip {2}",
             "colours": [
@@ -2546,7 +2546,7 @@
         },
         {
             "id": "e3268dbd-2f46-5b4b-8f87-661a5e65ae76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb57c73-a454-450d-9db9-67501bf4559d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb57c73-a454-450d-9db9-67501bf4559d.jpg?1",
             "name": "Powder Ganger",
             "text": "Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhen Powder Ganger enters the battlefield, destroy up to one target artifact.",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "537a1667-b282-5182-aac2-bddaa8d753cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803a510-99fe-467a-be3b-9301497ec7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803a510-99fe-467a-be3b-9301497ec7ec.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "First strike\nRaid \u2014 At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\nWhenever you sacrifice a Junk, add {R}.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "3b6c15fd-ec44-57ed-9fc9-33ce68add3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc7b54-26e5-4b0d-b2bb-be8f977f752b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc7b54-26e5-4b0d-b2bb-be8f977f752b.jpg?1",
             "name": "Synth Eradicator",
             "text": "Haste\nWhenever Synth Eradicator attacks, exile the top card of your library. You may get {E}{E} (two energy counters). If you don't, you may play that card this turn.\n{T}, Pay {E}{E}{E}: Synth Eradicator deals 3 damage to any target.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "ce4a0f22-38e3-542d-b12f-0213a826b147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5628e781-9f12-49ed-a575-6b467d39510b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5628e781-9f12-49ed-a575-6b467d39510b.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "Squad\u2014{1}, Discard a card. (As an additional cost to cast this spell, you may pay its squad cost any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhen Thrill-Kill Disciple dies, create a Junk token.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "d0869ab7-aca0-5353-8a75-27f02095b0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40972644-a284-4c7c-a451-d70eff7488ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40972644-a284-4c7c-a451-d70eff7488ab.jpg?1",
             "name": "Vault 21: House Gambit",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Discard a card, then draw a card.\nIII \u2014 Reveal up to five nonland cards from your hand. For each of those cards that has the same mana value as another card revealed this way, create a Treasure token.",
             "colours": [
@@ -2741,7 +2741,7 @@
         },
         {
             "id": "aa1b01e6-c52a-521d-9bc1-04fb3dbce329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2325aa29-7050-42a5-a0b4-c162db2192c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2325aa29-7050-42a5-a0b4-c162db2192c9.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "Menace\nWhenever Veronica, Dissident Scribe attacks, you may discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards for the first time each turn, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2783,7 +2783,7 @@
         },
         {
             "id": "8289800b-851f-5f5b-8011-1526deb8dbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1024d6-c5f1-48f5-9081-fb90d0c46fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1024d6-c5f1-48f5-9081-fb90d0c46fdb.jpg?1",
             "name": "Wild Wasteland",
             "text": "Skip your draw step.\nAt the beginning of your upkeep, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "d57b8147-6657-57d7-b6c5-5d3c4f9cbb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af31a045-0387-44ff-b735-54e19b04d925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af31a045-0387-44ff-b735-54e19b04d925.jpg?1",
             "name": "Animal Friend",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 1/1 green Squirrel creature token. Put a +1/+1 counter on that token for each Aura and Equipment attached to this creature other than Animal Friend.\"",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "bf53d960-529c-51c6-814f-24a853d0a83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861361bc-b357-4ff8-931b-a48d08817191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861361bc-b357-4ff8-931b-a48d08817191.jpg?1",
             "name": "Bighorner Rancher",
             "text": "Vigilance\n{T}: Add an amount of {G} equal to the greatest power among creatures you control.\nSacrifice Bighorner Rancher: You gain life equal to the greatest toughness among other creatures you control.",
             "colours": [
@@ -2894,7 +2894,7 @@
         },
         {
             "id": "e96d1d4c-684c-59fa-b9e8-a78bd8953345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389f9d7-b8ae-4c51-90f9-b6385517914a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389f9d7-b8ae-4c51-90f9-b6385517914a.jpg?1",
             "name": "Break Down",
             "text": "Destroy target artifact or enchantment. Create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "6357859e-205f-5de3-841e-5853575d7f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84118221-20a3-46a9-9e6e-a928b46a8633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84118221-20a3-46a9-9e6e-a928b46a8633.jpg?1",
             "name": "Cathedral Acolyte",
             "text": "Each creature you control with a counter on it has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n{T}: Put a +1/+1 counter on target creature that entered the battlefield this turn.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "9c9ff706-e9a9-53cb-8cb6-565a3c1a392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e36b92-aa88-4536-aebc-7e84a10d73fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e36b92-aa88-4536-aebc-7e84a10d73fe.jpg?1",
             "name": "Glowing One",
             "text": "Deathtouch\nWhenever Glowing One deals combat damage to a player, they get four rad counters.\nWhenever a player mills a nonland card, you gain 1 life.",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "95f876c4-73ef-54a6-9f5e-6bdacbd2a5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6d444f-9ffb-4dc2-b668-738d45aec2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6d444f-9ffb-4dc2-b668-738d45aec2c3.jpg?1",
             "name": "Gunner Conscript",
             "text": "Trample\nGunner Conscript gets +1/+1 for each Aura and Equipment attached to it.\nWhen Gunner Conscript dies, if it was enchanted, create a Junk token.\nWhen Gunner Conscript dies, if it was equipped, create a Junk token.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "30ac44df-ca1d-5dbd-8110-b9a34105e479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730ac69-20ec-4ef3-85ee-a5fd24e5f277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730ac69-20ec-4ef3-85ee-a5fd24e5f277.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "Vigilance, reach\nWhen Harold and Bob, First Numens dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add three mana of any one color. You get two rad counters.'\" Harold and Bob loses all other abilities.",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "22fdfb42-6454-5e17-b3ce-0922074d9976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052dc548-d356-43fe-9484-665db7e1f505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052dc548-d356-43fe-9484-665db7e1f505.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "Vigilance\nLily Bowen, Raging Grandma enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Lily Bowen if its power is 16 or less. Otherwise, remove all but one +1/+1 counter from it, then you gain 1 life for each +1/+1 counter removed this way.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "5c1cc132-eec1-5705-a900-d48f3bdc81ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b92e8a-fadf-4568-8b30-2df68e6ff7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b92e8a-fadf-4568-8b30-2df68e6ff7cf.jpg?1",
             "name": "Lumbering Megasloth",
             "text": "This spell costs {1} less to cast for each counter among players and permanents.\nTrample\nLumbering Megasloth enters the battlefield tapped.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "a00fea9e-353c-5200-94fb-ae249d967d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8f7fbc-bf2a-43c1-a88d-807c1e7dab69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8f7fbc-bf2a-43c1-a88d-807c1e7dab69.jpg?1",
             "name": "Power Fist",
             "text": "Equipped creature has trample and \"Whenever this creature deals combat damage to a player, put that many +1/+1 counters on it.\"\nEquip {2}",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "e8f48213-2b88-524d-b167-34ee95e67ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63619236-a27a-4fdd-add6-7a295901f906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63619236-a27a-4fdd-add6-7a295901f906.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "Vigilance, trample\nRampaging Yao Guai enters the battlefield with X +1/+1 counters on it.\nWhen Rampaging Yao Guai enters the battlefield, destroy any number of target artifacts and/or enchantments with total mana value X or less.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "9a933adc-e43e-5d20-aac0-fba48f347351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65afa5-e4f7-49c2-97f9-47ad5dbcacfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65afa5-e4f7-49c2-97f9-47ad5dbcacfa.jpg?1",
             "name": "Strong Back",
             "text": "Enchant creature\nEquip abilities you activate that target enchanted creature cost {3} less to activate.\nAura spells you cast that target enchanted creature cost {3} less to cast.\nEnchanted creature gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "01a9dfa4-d955-58fd-8910-ffad27b336aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc79ed6-057b-439f-b2cd-58d5bcd8b551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc79ed6-057b-439f-b2cd-58d5bcd8b551.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "Ward {2}\nEnrage \u2014 Whenever Strong is dealt damage, you get three rad counters and put three +1/+1 counters on Strong.\nYou gain life rather than lose life from radiation.",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "199a9498-e8dc-5183-a841-1356c41c34be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f48a99-eaf7-42ec-bab3-9ebbc735a82a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f48a99-eaf7-42ec-bab3-9ebbc735a82a.jpg?1",
             "name": "Super Mutant Scavenger",
             "text": "Trample\nWhen Super Mutant Scavenger enters the battlefield or dies, return up to one target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "25e7ab7b-3df7-5d4a-8054-ea4f264c415e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bade4-7232-4808-af5c-2dbed4d5bf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bade4-7232-4808-af5c-2dbed4d5bf07.jpg?1",
             "name": "Tato Farmer",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may get two rad counters.\n{T}: Put target land card in a graveyard that was milled this turn onto the battlefield under your control tapped.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "ed193d68-1433-585a-bcf4-b23bfee83858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4151d4-4d35-48d2-9e72-c87014f79137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4151d4-4d35-48d2-9e72-c87014f79137.jpg?1",
             "name": "Watchful Radstag",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever Watchful Radstag evolves, create a token that's a copy of it.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "42df1d90-0ba4-5c51-9359-cdf5a3e0c56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed640359-01e2-4a96-a4ab-aca053a2498d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed640359-01e2-4a96-a4ab-aca053a2498d.jpg?1",
             "name": "Well Rested",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature becomes untapped, put two +1/+1 counters on it, then you gain 2 life and draw a card. This ability triggers only once each turn.\"",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "ecfef169-295a-5ab3-8691-f54ed70af086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91193a0b-9087-404f-b397-815e29d0fe12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91193a0b-9087-404f-b397-815e29d0fe12.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "Trample\nAgent Frank Horrigan has indestructible as long as it attacked this turn.\nWhenever Agent Frank Horrigan enters the battlefield or attacks, proliferate twice. (To proliferate, choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "d2bcdb2c-b165-5f9c-982b-6f6e6e71d1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a9bff-969f-49c1-be02-40cb45858f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a9bff-969f-49c1-be02-40cb45858f19.jpg?1",
             "name": "Almost Perfect",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 9/10 and has indestructible.",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "3bcdc99e-6e89-55dc-862e-f9efe4d71fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4c8b04-66af-4cb3-8003-9088d8344b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4c8b04-66af-4cb3-8003-9088d8344b20.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "Menace, trample\nWhen Alpha Deathclaw enters the battlefield or becomes monstrous, destroy target permanent.\n{5}{B}{G}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "82bdaa14-8585-5719-a41f-8589e2632799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36356522-15fc-41e2-bf14-a745e5a96a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36356522-15fc-41e2-bf14-a745e5a96a50.jpg?1",
             "name": "Arcade Gannon",
             "text": "{T}: Draw a card, then discard a card. Put a quest counter on Arcade Gannon.\nFor Auld Lang Syne \u2014 Once during each of your turns, you may cast an artifact or Human spell from your graveyard with mana value less than or equal to the number of quest counters on Arcade Gannon.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "1c75def1-6b9a-58b7-99b5-ffae5da40a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ffa95-5c5f-449b-820a-7d5bc1688d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ffa95-5c5f-449b-820a-7d5bc1688d29.jpg?1",
             "name": "Armory Paladin",
             "text": "Trample\nWhenever you cast an Aura or Equipment spell, exile the top card of your library. You may play that card until the end of your next turn.",
             "colours": [
@@ -3674,7 +3674,7 @@
         },
         {
             "id": "4810de94-0351-509d-afd6-c8b070aed883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592cbafc-ab4e-461f-b64f-0bf9d83aaff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592cbafc-ab4e-461f-b64f-0bf9d83aaff3.jpg?1",
             "name": "Atomize",
             "text": "Destroy target nonland permanent. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3712,7 +3712,7 @@
         },
         {
             "id": "9b1e9596-2f2b-5c19-9014-e610dab58aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d0316-9b94-4ccb-9103-509e6a0963a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d0316-9b94-4ccb-9103-509e6a0963a1.jpg?1",
             "name": "Boomer Scrapper",
             "text": "Whenever Boomer Scrapper enters the battlefield or attacks, you lose 1 life and create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\nWhenever a token you control leaves the battlefield, put a +1/+1 counter on Boomer Scrapper.",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "098d34ae-bbb3-57b8-bf50-578b7035f5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca61d02-2819-483f-9d30-862f0650ab0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca61d02-2819-483f-9d30-862f0650ab0a.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "As long as it's your turn, Cait, Cage Brawler has indestructible.\nWhenever Cait attacks, you and defending player each draw a card, then discard a card. Put two +1/+1 counters on Cait if you discarded the card with the highest mana value among those cards or tied for highest.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "099ddf6b-01cd-5490-91b3-02cad5feb72a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6d7fa6-4de6-4bc8-b250-2ed6eb559618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6d7fa6-4de6-4bc8-b250-2ed6eb559618.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "Vigilance\nWhenever Cass or another creature you control dies, if it was enchanted or equipped, return any number of Aura cards that were attached to it from your graveyard to the battlefield attached to target creature, then attach any number of Equipment  that were attached to it to that creature.",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "d81d105a-9ef9-52cc-9ecd-d4b45b25a977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c3e5a-64f3-40b5-8080-1c53be45aa40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c3e5a-64f3-40b5-8080-1c53be45aa40.jpg?1",
             "name": "Colonel Autumn",
             "text": "Lifelink\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nOther legendary creatures you control have exploit.\nWhenever a creature you control exploits a creature, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -3882,7 +3882,7 @@
         },
         {
             "id": "93250333-e4fa-5bbc-ae34-05e09e8926fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde9eb15-544a-462a-8ab8-86067840c083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde9eb15-544a-462a-8ab8-86067840c083.jpg?1",
             "name": "Contaminated Drink",
             "text": "Draw X cards, then you get half X rad counters, rounded up.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "c44308cb-3703-5d7b-ad36-08fdaf92f3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d83dad-21c3-4777-84b0-3c775585b5fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d83dad-21c3-4777-84b0-3c775585b5fd.jpg?1",
             "name": "Craig Boone, Novac Guard",
             "text": "Reach, lifelink\nOne for My Baby \u2014 Whenever you attack with two or more creatures, put two quest counters on Craig Boone, Novac Guard. When you do, Craig Boone deals damage equal to the number of quest counters on it to up to one target creature unless that creature's controller has Craig Boone deal that much damage to them.",
             "colours": [
@@ -3959,7 +3959,7 @@
         },
         {
             "id": "2eebb8d0-85ea-5544-a634-4eb9b5858005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38d445-1752-4921-bb83-5afcdf655015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38d445-1752-4921-bb83-5afcdf655015.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "Vigilance\nWhenever Desdemona, Freedom's Edge attacks, target creature card in your graveyard that's an artifact or that has mana value 3 or less gains escape until end of turn. The escape cost is equal to its mana cost plus exile two other cards from your graveyard. (You may cast it from your graveyard for its escape cost this turn.)",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "13b11a52-aace-58bf-8d41-2d90a912aece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049771b0-69ad-4f2d-8567-47e8a87b4496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049771b0-69ad-4f2d-8567-47e8a87b4496.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "Creature tokens you control have training. (Whenever a creature token you control attacks with another creature with greater power, put a +1/+1 counter on that token.)\nBlind Betrayal \u2014 Sacrifice another creature: Elder Arthur Maxson gains indestructible until end of turn.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "a8daf465-ed63-5a7d-a940-2b113fe4896e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d923c845-59e0-403e-b57b-955fec528f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d923c845-59e0-403e-b57b-955fec528f1e.jpg?1",
             "name": "Elder Owyn Lyons",
             "text": "Artifacts you control have ward {1}. (Whenever an artifact you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nWhen Elder Owyn Lyons enters the battlefield or dies, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "f3fc3b8b-4de6-5b6d-b106-0aa72a4874d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8377fce8-edc8-4926-bf75-57162ff6df9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8377fce8-edc8-4926-bf75-57162ff6df9f.jpg?1",
             "name": "Electrosiphon",
             "text": "Counter target spell. You get an amount of {E} (energy counters) equal to its mana value.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "ae749cb8-48d9-51b7-b383-422e84cb4bd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1acb59-a679-4c6d-8458-8fe5556b9d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1acb59-a679-4c6d-8458-8fe5556b9d4d.jpg?1",
             "name": "Inventory Management",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nFor each Aura and Equipment you control, you may attach it to a creature you control.",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "311715ff-3b70-5c40-9ded-d861e3384ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b22b32-be24-48e3-aa81-9256190df02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b22b32-be24-48e3-aa81-9256190df02c.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "First strike, haste\nWhenever Kellogg, Dangerous Mind attacks, create a Treasure token.\nSacrifice five Treasures: Gain control of target creature for as long as you control Kellogg. Activate only as a sorcery.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "c934c9a1-71b8-555b-9ba4-5f2422d5f48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14eb369-b8e3-4abf-9e77-79d1fe5b426f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14eb369-b8e3-4abf-9e77-79d1fe5b426f.jpg?1",
             "name": "Legate Lanius, Caesar's Ace",
             "text": "Decimate \u2014 When Legate Lanius enters the battlefield, each opponent sacrifices a tenth of the creatures they control, rounded up.\nWhenever an opponent sacrifices a creature, put a +1/+1 counter on Legate Lanius.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "ef83c492-995b-5e62-9616-2924afa5556b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2251ce-2d5b-4d0d-8dc9-44f6b40aa7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2251ce-2d5b-4d0d-8dc9-44f6b40aa7cf.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "Whenever a creature you control with power 2 or less attacks, it gains skulk until end of turn. (It can't be blocked by creatures with greater power.)\nWhenever a creature with power 4 or greater attacks you, its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "c4326539-9a13-5816-89e9-0241995a17de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15db5769-af10-4369-ab4c-db25adb22223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15db5769-af10-4369-ab4c-db25adb22223.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "Vigilance, trample\nWhenever a creature you control deals combat damage to a player, draw a card if that creature has a +1/+1 counter on it. If it doesn't, put a +1/+1 counter on it.",
             "colours": [
@@ -4332,7 +4332,7 @@
         },
         {
             "id": "84a17e53-29ce-5219-b87e-365daea13a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418ce6f6-b483-4695-aaf5-e4f7eeb9eb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418ce6f6-b483-4695-aaf5-e4f7eeb9eb16.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "When Moira Brown, Guide Author enters the battlefield, create a colorless Equipment artifact token named Wasteland Survival Guide with \"Equipped creature gets +1/+1 for each quest counter among permanents you control\" and equip {1}.\nWhenever you attack, put a quest counter on target nonland permanent you control.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "c5120471-694d-5cf1-af64-9e59a606d1c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff92f1-9dc7-48e6-9e7c-9ef4a88518cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff92f1-9dc7-48e6-9e7c-9ef4a88518cb.jpg?1",
             "name": "Mutational Advantage",
             "text": "Permanents you control with counters on them gain hexproof and indestructible until end of turn. Prevent all damage that would be dealt to those permanents this turn. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -4413,7 +4413,7 @@
         },
         {
             "id": "9f0e210e-f6af-5e6a-8e8b-2b2e0ff15138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7cfcb2-83fb-41ad-ae31-9c32c942506c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7cfcb2-83fb-41ad-ae31-9c32c942506c.jpg?1",
             "name": "Nightkin Ambusher",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Nightkin Ambusher enters the battlefield, target player gets four rad counters.\nNightkin Ambusher can't be blocked as long as defending player has a rad counter.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "a33ffb15-ab07-58b7-9a82-2e5ecedee0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0abd847-1c9d-45cd-a6d1-3a0cda3687cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0abd847-1c9d-45cd-a6d1-3a0cda3687cb.jpg?1",
             "name": "The Nipton Lottery",
             "text": "Choose a creature at random. You gain control of that creature until end of turn. Untap it. It gains haste until end of turn. Then destroy all other creatures.",
             "colours": [
@@ -4490,7 +4490,7 @@
         },
         {
             "id": "502b42ab-7796-5b6c-a929-52bf8aa51a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24fd14b-cfd1-43db-b155-3187a1063d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24fd14b-cfd1-43db-b155-3187a1063d92.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "Battalion \u2014 Whenever Paladin Elizabeth Taggerdy and at least two other creatures attack, draw a card, then you may put a creature card with mana value X or less from your hand onto the battlefield tapped and attacking, where X is Paladin Elizabeth Taggerdy's power.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "08bd0415-c9e9-5a1f-9eb7-a7095c35d9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73a314-b197-4954-a242-7d9096a406c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73a314-b197-4954-a242-7d9096a406c1.jpg?1",
             "name": "Raul, Trouble Shooter",
             "text": "Once during each of your turns, you may cast a spell from among cards in your graveyard that were milled this turn.\n{T}: Each player mills a card. (They each put the top card of their library into their graveyard.)",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "ac551d1f-cfdd-51a3-af42-ec0c85ba07b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf616fa-b9a0-4f7a-b7ee-32ce3a08d466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf616fa-b9a0-4f7a-b7ee-32ce3a08d466.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "Alluring Eyes \u2014 {T}: Goad target creature an opponent controls. That player draws a card. You add {R}. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "bc21b656-3031-505b-8e4d-96c179e5eabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae95822-d4a9-4698-bd11-c504414fc160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae95822-d4a9-4698-bd11-c504414fc160.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "Whenever Rex, Cyber-Hound deals combat damage to a player, they mill two cards and you get {E}{E} (two energy counters).\nPay {E}{E}: Choose target creature card in a graveyard. Exile it with a brain counter on it. Activate only as a sorcery.\nRex has all activated abilities of all cards in exile with brain counters on them.",
             "colours": [
@@ -4662,7 +4662,7 @@
         },
         {
             "id": "0a6bbaf0-ce9b-5346-9556-c4c06880306c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b76965-528c-48f9-9ee6-332b09cae664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b76965-528c-48f9-9ee6-332b09cae664.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "Haste\nAs long as an artifact entered the battlefield under your control this turn, creatures you control get +2/+2.\nBattalion \u2014 Whenever Sentinel Sarah Lyons and at least two other creatures attack, Sentinel Sarah Lyons deals damage equal to the number of artifacts you control to target player.",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "f1accae0-74fd-5e3e-9c66-aaf64d13ea49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68af449f-3c30-43ea-be60-d85061d7adbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68af449f-3c30-43ea-be60-d85061d7adbd.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "Whenever you attack, you may create a tapped and attacking token that's a copy of target attacking legendary creature you control other than Shaun, except it's not legendary and it's a Synth artifact creature in addition to its other types.\nWhen Shaun leaves the battlefield, exile all Synth tokens you control.",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "02a2319c-6224-51e8-bb37-fb1075ac116a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab34e869-be7a-4632-95b3-5f200b4edcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab34e869-be7a-4632-95b3-5f200b4edcca.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "Whenever you attack, you may pay {2} and sacrifice an Aura attached to Three Dog, Galaxy News DJ. When you sacrifice an Aura this way, for each other attacking creature you control, create a token that's a copy of that Aura attached to that creature.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "3d4d90ea-94c8-5fb7-a298-be815229fa0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafcd4e-5693-4c23-be79-75653fcd214c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafcd4e-5693-4c23-be79-75653fcd214c.jpg?1",
             "name": "Vault 11: Voter's Dilemma",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 For each opponent, you create a 1/1 white Human Soldier creature token.\nII, III \u2014 Each player secretly votes for up to one creature, then those votes are revealed. If no creature got votes, each player draws a card. Otherwise, destroy each creature with the most votes or tied for most votes.",
             "colours": [
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "aa281683-cfb6-5a2d-ae47-46f0e0c004ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf267b-f41c-447a-aa35-0c01aad8a489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf267b-f41c-447a-aa35-0c01aad8a489.jpg?1",
             "name": "Vault 87: Forced Evolution",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Gain control of target non-Mutant creature for as long as you control Vault 87.\nII \u2014 Put a +1/+1 counter on target creature you control. It becomes a Mutant in addition to its other types.\nIII \u2014 Draw cards equal to the greatest power among Mutants you control.",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "2098e00d-bcc1-580b-b1bb-f4645b815785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0acee2-f6dc-4e92-937b-01e2c07adc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0acee2-f6dc-4e92-937b-01e2c07adc55.jpg?1",
             "name": "Vault 112: Sadistic Simulation",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Tap up to one target creature and put a stun counter on it. You get {E}{E} (two energy counters).\nIII \u2014 Pay any amount of {E}. If you paid one or more {E} this way, shuffle your library, then exile that many cards from the top. You may play one of those cards without paying its mana cost.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "57644998-c287-5684-8ac4-1c73b7b155c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bf1f6c-4653-4734-9bd7-af689a1b679d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bf1f6c-4653-4734-9bd7-af689a1b679d.jpg?1",
             "name": "White Glove Gourmand",
             "text": "When White Glove Gourmand enters the battlefield, create two 1/1 white Human Soldier creature tokens.\nAt the beginning of your end step, if another Human died under your control this turn, create a Food token.",
             "colours": [
@@ -4944,7 +4944,7 @@
         },
         {
             "id": "67d377d9-ec5f-5938-9d7e-e6bd500c904f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d5e6bd-de46-4bc2-854b-cc6cae713f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d5e6bd-de46-4bc2-854b-cc6cae713f98.jpg?1",
             "name": "Young Deathclaws",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nEach creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "a3d06ee3-3ec3-58b7-8688-258d89a8df68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8b0c5-5457-432a-8c27-f193c9922aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8b0c5-5457-432a-8c27-f193c9922aec.jpg?1",
             "name": "Agility Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Up to X target creatures you control each gain haste until end of turn and can't be blocked this turn except by creatures with haste, where X is the number of Bobbleheads you control as you activate this ability.",
             "colours": [],
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "01906695-e676-50ea-afc5-947b1a6198bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d6e5b-a94e-460c-ab2f-21fd842c3d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d6e5b-a94e-460c-ab2f-21fd842c3d9a.jpg?1",
             "name": "Behemoth of Vault 0",
             "text": "Trample\nWhen Behemoth of Vault 0 enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nWhen Behemoth of Vault 0 dies, you may pay an amount of {E} equal to target nonland permanent's mana value. When you do, destroy that permanent.",
             "colours": [],
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "88f1992a-7e9f-576b-984d-7b2f0e86a0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c207c76d-5f10-4fd9-9826-cf0611bfa2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c207c76d-5f10-4fd9-9826-cf0611bfa2d0.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "Flying\nBrotherhood Vertibird's power is equal to the number of artifacts you control.\nCrew 2 (Tap any number of creatures you control with total power 2 or greater: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "e55af085-668d-51b5-a578-e542508a949f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034d4543-2c53-4cda-acfd-7f26b8dd17fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034d4543-2c53-4cda-acfd-7f26b8dd17fb.jpg?1",
             "name": "C.A.M.P.",
             "text": "Whenever fortified land is tapped for mana, put a +1/+1 counter on target creature you control. If that creature shares a color with the mana that land produced, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\nFortify {3} ({3}: Attach to target land you control. Fortify only as a sorcery.)",
             "colours": [],
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "9c9b3e86-0475-5345-b59d-1b095ad8cb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f61330-869f-448c-8374-1cbac7c23454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f61330-869f-448c-8374-1cbac7c23454.jpg?1",
             "name": "Charisma Bobblehead",
             "text": "{T}: Add one mana of any color.\n{4}, {T}: Create X 1/1 white Soldier creature tokens, where X is the number of Bobbleheads you control. Activate only as a sorcery.",
             "colours": [],
@@ -5148,7 +5148,7 @@
         },
         {
             "id": "149e881d-6a23-5da4-82cd-49e4f3f3c89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b319f0e1-6f18-4fea-9f72-a21da5513aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b319f0e1-6f18-4fea-9f72-a21da5513aa4.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "Flying\nED-E My Love \u2014 Whenever you attack, if the number of attacking creatures is greater than the number of quest counters on ED-E, Lonesome Eyebot, put a quest counter on it.\n{2}, Sacrifice ED-E: Draw a card, then draw an additional card for each quest counter on ED-E.",
             "colours": [],
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "dfb34474-6e41-5c58-9c8a-014aaf87d8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8768789b-c414-4e35-bff3-d06a69dccff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8768789b-c414-4e35-bff3-d06a69dccff6.jpg?1",
             "name": "Endurance Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Up to X target creatures you control get +1/+0 and gain indestructible until end of turn, where X is the number of Bobbleheads you control as you activate this ability. Activate only as a sorcery.",
             "colours": [],
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "4532fd68-c34b-5ebf-b393-ca8ae30c41fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f4bdc-8b6a-4e87-92fd-8368537a6ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f4bdc-8b6a-4e87-92fd-8368537a6ced.jpg?1",
             "name": "Expert-Level Safe",
             "text": "When Expert-Level Safe enters the battlefield, exile the top two cards of your library face down.\n{1}, {T}: You and target opponent each secretly choose 1, 2, or 3. Then those choices are revealed. If they match, sacrifice Expert-Level Safe and put all cards exiled with it into their owners' hands. Otherwise, exile the top card of your library face down.",
             "colours": [],
@@ -5248,7 +5248,7 @@
         },
         {
             "id": "0f0bfc52-8c8c-58d8-ac74-41951bdda3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6546c0d-6be2-4ced-9d7c-4269df8dea76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6546c0d-6be2-4ced-9d7c-4269df8dea76.jpg?1",
             "name": "Intelligence Bobblehead",
             "text": "{T}: Add one mana of any color.\n{5}, {T}: Draw X cards, where X is the number of Bobbleheads you control.",
             "colours": [],
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "54ac4de7-11eb-5225-b3c5-9d7ad43544cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13281945-47ff-464d-96ef-9b26ef6783fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13281945-47ff-464d-96ef-9b26ef6783fa.jpg?1",
             "name": "Luck Bobblehead",
             "text": "{T}: Add one mana of any color.\n{1}, {T}: Roll X six-sided dice, where X is the number of Bobbleheads you control. Create a tapped Treasure token for each even result. If you rolled 6 exactly seven times, you win the game.",
             "colours": [],
@@ -5314,7 +5314,7 @@
         },
         {
             "id": "a680d38e-1dec-5615-9140-a01904859d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09166a-78de-4136-8a3c-034e1ef73ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09166a-78de-4136-8a3c-034e1ef73ede.jpg?1",
             "name": "Mister Gutsy",
             "text": "Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on Mister Gutsy.\nWhen Mister Gutsy dies, create X Junk tokens, where X is the number of +1/+1 counters on it. (They're artifacts with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [],
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "d49dfa6a-1461-5060-a841-3c2ae5da0fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405df7c7-0e37-499e-9826-6bf9f5db7a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405df7c7-0e37-499e-9826-6bf9f5db7a40.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "{1}, {T}: Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever you sacrifice a Food, create a tapped Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -5382,7 +5382,7 @@
         },
         {
             "id": "276cb8d0-6d9c-557c-a94d-b4d05b7d0139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d5835b-c206-4884-bdcf-38c7cdc703f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d5835b-c206-4884-bdcf-38c7cdc703f4.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "Equipped creature gets +3/+0 and has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever equipped creature attacks, until the end of defending player's next turn, that player gets two rad counters whenever they cast a spell.\nEquip {3}",
             "colours": [],
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "0056d472-f526-5728-8104-67e1c6915666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a8c89c-2cd1-4f68-9758-449177be2880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a8c89c-2cd1-4f68-9758-449177be2880.jpg?1",
             "name": "Perception Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Look at the top X cards of your library, where X is the number of Bobbleheads you control. You may cast a spell with mana value 3 or less from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -5449,7 +5449,7 @@
         },
         {
             "id": "8b025a00-b58b-5a43-84f9-d12a627a3a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2248694-aab0-47a8-ae8b-8d5283075e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2248694-aab0-47a8-ae8b-8d5283075e10.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Sort Inventory \u2014 Draw a card, then discard a card.\n\u2022 Pick a Perk \u2014 Put a +1/+1 counter on that creature.\n\u2022 Check Map \u2014 Untap up to two target lands.\nEquip {2}",
             "colours": [],
@@ -5483,7 +5483,7 @@
         },
         {
             "id": "e0dbf03a-d60f-528f-86d8-2304766764b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21aa59d3-e786-4ba0-9802-01b57597cda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21aa59d3-e786-4ba0-9802-01b57597cda2.jpg?1",
             "name": "Recon Craft Theta",
             "text": "Flying\nWhen Recon Craft Theta enters the battlefield, create a 0/0 blue Alien creature token. Put a +1/+1 counter on it.\nWhenever Recon Craft Theta attacks, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nCrew 2",
             "colours": [],
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "fa5948ec-3228-5e08-99ce-c4950fbf93d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21fba59-330b-4daf-bf77-6dd817327a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21fba59-330b-4daf-bf77-6dd817327a64.jpg?1",
             "name": "Silver Shroud Costume",
             "text": "Flash\nWhen Silver Shroud Costume enters the battlefield, attach it to target creature you control. That creature gains shroud until end of turn. (It can't be the target of spells or abilities.)\nEquipped creature can't be blocked.\nEquip {3}",
             "colours": [],
@@ -5549,7 +5549,7 @@
         },
         {
             "id": "8247e2b0-a9d8-5caf-924a-f08ed9df570d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af73ad-625a-4260-8917-6a837f9fdf88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af73ad-625a-4260-8917-6a837f9fdf88.jpg?1",
             "name": "Strength Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Put X +1/+1 counters on target creature, where X is the number of Bobbleheads you control. Activate only as a sorcery.",
             "colours": [],
@@ -5582,7 +5582,7 @@
         },
         {
             "id": "73c868fe-dd85-5e8e-bf02-fda7c91ab0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f30a39-aad3-45da-8f03-50b1d1806b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f30a39-aad3-45da-8f03-50b1d1806b00.jpg?1",
             "name": "Survivor's Med Kit",
             "text": "{1}, {T}: Choose one that hasn't been chosen \u2014\n\u2022 Stimpak \u2014 Draw a card.\n\u2022 Fancy Lads Snack Cakes \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n\u2022 Rad\nAway \u2014 Target player loses all rad counters. Sacrifice Survivor's Med Kit.",
             "colours": [],
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "21f14793-5663-5d04-9fb4-e13a46704162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203b1cb3-5eae-469a-8a5a-2e56dc859f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203b1cb3-5eae-469a-8a5a-2e56dc859f78.jpg?1",
             "name": "T-45 Power Armor",
             "text": "When T-45 Power Armor enters the battlefield, you get {E}{E} (two energy counters).\nEquipped creature gets +3/+3 and doesn't untap during its controller's untap step.\nAt the beginning of your upkeep, you may pay {E}. If you do, untap equipped creature, then put your choice of a menace, trample, or lifelink counter on it.\nEquip {3}",
             "colours": [],
@@ -5646,7 +5646,7 @@
         },
         {
             "id": "9946ca93-e695-5a20-869e-587cb8bd9b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f38637-8cdc-42bb-b164-85596b6b14b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f38637-8cdc-42bb-b164-85596b6b14b9.jpg?1",
             "name": "Desolate Mire",
             "text": "{1}, {T}: Add {W}{B}.",
             "colours": [],
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "5da92361-3d00-5aac-958b-d5214e7fc940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9bd49a-e9f1-4543-b04a-777a9e5a55ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9bd49a-e9f1-4543-b04a-777a9e5a55ec.jpg?1",
             "name": "Diamond City",
             "text": "Diamond City enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\n{T}: Add {C}.\n{T}: Move a shield counter from Diamond City onto target creature. Activate only if two or more creatures entered the battlefield under your control this turn.",
             "colours": [],
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "1f0a69f8-d3c8-5fad-bdd7-c8b5fa34a79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0406ff96-419b-44bc-b836-a39eaa55ae78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0406ff96-419b-44bc-b836-a39eaa55ae78.jpg?1",
             "name": "Ferrous Lake",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "2a8c6c22-82fd-5c55-80f1-840cb0975184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4102d28e-437b-440b-bf9b-8b4f6fb85a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4102d28e-437b-440b-bf9b-8b4f6fb85a6c.jpg?1",
             "name": "HELIOS One",
             "text": "{T}: Add {C}.\n{1}, {T}: You get {E} (an energy counter).\n{3}, {T}, Pay X {E}, Sacrifice HELIOS One: Destroy target nonland permanent with mana value X. Activate only as a sorcery.",
             "colours": [],
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "9a4ee213-29f4-5334-a600-0f227d802d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e24c687-f070-469d-a09d-acf4ac6ed374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e24c687-f070-469d-a09d-acf4ac6ed374.jpg?1",
             "name": "Junktown",
             "text": "{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Junktown: Create three Junk tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [],
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "3b9d9edd-004f-5a41-ba3d-9afa0a8a19f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7be9d4-f9fa-44a3-9902-7e9e226ccf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7be9d4-f9fa-44a3-9902-7e9e226ccf56.jpg?1",
             "name": "Mariposa Military Base",
             "text": "You may have Mariposa Military Base enter the battlefield tapped. If you do, you get two rad counters.\n{T}: Add {C}.\n{5}, {T}: Draw a card. This ability costs {1} less to activate for each rad counter you have.",
             "colours": [],
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "63988af9-caec-5870-9fce-9990b59efcfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75372ba1-85fb-4923-a62f-4050761c1471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75372ba1-85fb-4923-a62f-4050761c1471.jpg?1",
             "name": "Overflowing Basin",
             "text": "{1}, {T}: Add {G}{U}.",
             "colours": [],
@@ -5881,7 +5881,7 @@
         },
         {
             "id": "a94808e3-ebb6-5d53-ad74-08a2f823beaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84a8f54-9ede-40ee-a783-e58a7e4f2e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84a8f54-9ede-40ee-a783-e58a7e4f2e94.jpg?1",
             "name": "Sunscorched Divide",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -5916,7 +5916,7 @@
         },
         {
             "id": "2eccf9fa-dc4a-5e96-9e4c-e27ca74d0f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4ce16b-39bb-4580-9c38-a7c6b9a33609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4ce16b-39bb-4580-9c38-a7c6b9a33609.jpg?1",
             "name": "Viridescent Bog",
             "text": "{1}, {T}: Add {B}{G}.",
             "colours": [],
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "2ede928a-b2c7-5589-8c9e-0c92fa36b339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d9fb74-9f2d-40f1-88b8-514a460a4f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d9fb74-9f2d-40f1-88b8-514a460a4f86.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "9c889b86-969b-5d57-8710-6c5f17c9cf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5215c18d-90cd-45df-ac14-99909c97c69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5215c18d-90cd-45df-ac14-99909c97c69e.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with mana value 3 or less.\n\u2022 Destroy all creatures with mana value 4 or greater.",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "b5aca8e6-c176-537a-9e9c-0d89fb200d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936e77d4-ab74-4123-9225-879493e5ad79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936e77d4-ab74-4123-9225-879493e5ad79.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -6062,7 +6062,7 @@
         },
         {
             "id": "e081dd73-10bf-5d9d-9814-200823aa6ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0941279-8695-4b71-b27a-5477a1858525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0941279-8695-4b71-b27a-5477a1858525.jpg?1",
             "name": "Crush Contraband",
             "text": "Choose one or both \u2014\n\u2022 Exile target artifact.\n\u2022 Exile target enchantment.",
             "colours": [
@@ -6096,7 +6096,7 @@
         },
         {
             "id": "aeb65042-e28f-5e11-ae1c-a02bcafef03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfcc2a8-ab59-47b5-88a9-0692e6091334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfcc2a8-ab59-47b5-88a9-0692e6091334.jpg?1",
             "name": "Dispatch",
             "text": "Tap target creature.\nMetalcraft \u2014 If you control three or more artifacts, exile that creature.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "7aad5b77-4d0a-5b88-951c-2b97d2436dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2707cc0c-20ea-4241-b0b0-7000a713fb63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2707cc0c-20ea-4241-b0b0-7000a713fb63.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "Target player sacrifices an attacking creature. You create X 1/1 white Soldier creature tokens, where X is that creature's toughness.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "f644bc79-bce4-563c-8d8e-9d9ed67e6b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca614808-4e09-4839-ae80-7c3ea6cf61fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca614808-4e09-4839-ae80-7c3ea6cf61fd.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "fdf70f4e-ab95-5bf0-999d-7497d6b1d539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574c3028-c942-4257-a825-c25318915593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574c3028-c942-4257-a825-c25318915593.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "97d414b7-9035-5427-9763-ed73a1fab258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805c99f1-ab4d-4072-a8b7-7e2818adbc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805c99f1-ab4d-4072-a8b7-7e2818adbc97.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -6273,7 +6273,7 @@
         },
         {
             "id": "8dbc7f3a-50ba-5210-96ea-3825c74339b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dad7f-774a-47c2-892b-b3952dbed683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dad7f-774a-47c2-892b-b3952dbed683.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "61917242-1f0a-50b9-9e8b-2bee6c631883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ec4350-05fa-4452-ade3-3cf2c319eb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ec4350-05fa-4452-ade3-3cf2c319eb0b.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "Enchant creature you control\nWhen Mantle of the Ancients enters the battlefield, return any number of target Aura and/or Equipment cards that could be attached to enchanted creature from your graveyard to the battlefield attached to enchanted creature.\nEnchanted creature gets +1/+1 for each Aura and Equipment attached to it.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "3601a92b-e344-59ef-85b0-c702d89466e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cea75f-f2b0-47f3-a40b-ee43a6132ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cea75f-f2b0-47f3-a40b-ee43a6132ead.jpg?1",
             "name": "Marshal's Anthem",
             "text": "Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nCreatures you control get +1/+1.\nWhen Marshal's Anthem enters the battlefield, return up to X target creature cards from your graveyard to the battlefield, where X is the number of times Marshal's Anthem was kicked.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "55ad74c4-bd39-540e-8da7-3b36b5f2e75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f7f71-625a-46ec-bce8-6bd934f2a275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f7f71-625a-46ec-bce8-6bd934f2a275.jpg?1",
             "name": "Martial Coup",
             "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "4f530702-97d7-5aa6-85d2-9f4a53f8cba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd2e9d0-3691-40a4-a0e8-42ca29bfcc10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd2e9d0-3691-40a4-a0e8-42ca29bfcc10.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control. (Auras with nothing to enchant remain in graveyards.)",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "69c7acfd-ca45-54de-9c6e-be8d70e00115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437e42e1-a8b5-49db-885b-e7e1a06db59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437e42e1-a8b5-49db-885b-e7e1a06db59d.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "6f5091a7-7af6-5b6b-9be1-094df5d0bc2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e496f4-ec53-4e3c-a27d-5c1b5a54a642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e496f4-ec53-4e3c-a27d-5c1b5a54a642.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "0d195986-166c-51db-a270-710bb96d0f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97649f03-262c-485d-8cb4-75cc4f65ec53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97649f03-262c-485d-8cb4-75cc4f65ec53.jpg?1",
             "name": "Secure the Wastes",
             "text": "Create X 1/1 white Warrior creature tokens.",
             "colours": [
@@ -6567,7 +6567,7 @@
         },
         {
             "id": "be88ed98-8da5-5210-8ac3-dd3cc263b936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea2469c-f719-40e6-bec1-0457fa93c541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea2469c-f719-40e6-bec1-0457fa93c541.jpg?1",
             "name": "Single Combat",
             "text": "Each player chooses a creature or planeswalker they control, then sacrifices the rest. Players can't cast creature or planeswalker spells until the end of your next turn.",
             "colours": [
@@ -6603,7 +6603,7 @@
         },
         {
             "id": "e6120841-e4f8-5321-aeb0-44eba948637e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed55827d-1d72-4884-8a4f-fe7acbedab2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed55827d-1d72-4884-8a4f-fe7acbedab2c.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "579b5bf8-f670-5b90-b66b-d43fce85a561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11545710-6917-4e44-856f-4c9063a1313c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11545710-6917-4e44-856f-4c9063a1313c.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "4d430395-c83d-5f69-830d-2ec71f55dfc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dbffda-f7cf-454f-b449-0fa7c6895add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dbffda-f7cf-454f-b449-0fa7c6895add.jpg?1",
             "name": "Fraying Sanity",
             "text": "Enchant player\nAt the beginning of each end step, enchanted player mills X cards, where X is the number of cards put into their graveyard from anywhere this turn.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "4540a85b-3baf-5f70-a719-a0b78cf0ad05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d84305-2143-470a-bf1f-12fb6d4d63b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d84305-2143-470a-bf1f-12fb6d4d63b9.jpg?1",
             "name": "Glimmer of Genius",
             "text": "Scry 2, then draw two cards. You get {E}{E} (two energy counters).",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "cc5536da-8292-5a5c-9386-ce01978681cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e857a2-389d-43f4-96aa-721e4ad1f3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e857a2-389d-43f4-96aa-721e4ad1f3f1.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "54d94b5e-09b5-5830-a9b7-3110888d96c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dca7cb-4724-48d6-a0e0-2cbb5a7fa4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dca7cb-4724-48d6-a0e0-2cbb5a7fa4f7.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "9a6c2d74-2c82-5e16-9fb5-b4218c64e442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f555efc-4314-4111-8c61-9548c5bae2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f555efc-4314-4111-8c61-9548c5bae2e0.jpg?1",
             "name": "One with the Machine",
             "text": "Draw cards equal to the highest mana value among artifacts you control.",
             "colours": [
@@ -6854,7 +6854,7 @@
         },
         {
             "id": "c0b793df-b1fa-515a-8f8a-94132f7e7fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d4cc8d6-b366-4da8-a2d2-ff3be9092789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d4cc8d6-b366-4da8-a2d2-ff3be9092789.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "f15ad3f8-10df-5ec5-abeb-1159078f5bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91323e0e-5384-4571-a7c0-0e2c2ed45f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91323e0e-5384-4571-a7c0-0e2c2ed45f02.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -6926,7 +6926,7 @@
         },
         {
             "id": "78751e32-1426-5ccb-8b28-fcefea0067b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e2c839-4f55-482c-baaa-aa8f7c8e9b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e2c839-4f55-482c-baaa-aa8f7c8e9b7d.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "When Bastion of Remembrance enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "a95602bb-61a5-51d9-839b-77fcbf1406a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b4c56-e17e-49ec-8946-0e95a4bfa1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b4c56-e17e-49ec-8946-0e95a4bfa1ae.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "aaef1995-9056-5b33-937f-3f455219a81b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ee1e37-bde7-4208-8851-718f2ae1c540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ee1e37-bde7-4208-8851-718f2ae1c540.jpg?1",
             "name": "Deadly Dispute",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "a8277d91-1fb4-5147-84e5-06a38a8acba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2c44f7-7b54-4cdf-8f53-ab78c515795b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2c44f7-7b54-4cdf-8f53-ab78c515795b.jpg?1",
             "name": "Lethal Scheme",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature or planeswalker. Each creature that convoked Lethal Scheme connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "85e19e16-e228-5928-a068-294f636a4f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7357386d-7ede-449f-bd30-b19a08921d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7357386d-7ede-449f-bd30-b19a08921d86.jpg?1",
             "name": "Morbid Opportunist",
             "text": "Whenever one or more other creatures die, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -7103,7 +7103,7 @@
         },
         {
             "id": "45964035-1c64-5501-928e-9c68a259bb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47255b76-2c77-4e94-938d-b9d3497798ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47255b76-2c77-4e94-938d-b9d3497798ec.jpg?1",
             "name": "Pitiless Plunderer",
             "text": "Whenever another creature you control dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "f0efa478-70c9-5769-abfc-9dad5d5aacab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c16b7-63c2-4071-9117-184cb1a04f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c16b7-63c2-4071-9117-184cb1a04f14.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "ff2c563d-2356-5eab-bea8-411ae760b3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4d0e40-d771-458e-b705-1d2bef8c200e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4d0e40-d771-458e-b705-1d2bef8c200e.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "30cff0e7-7ea0-578c-901e-7e2215e7b5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cd0e82-d2aa-4614-93a2-b84828866742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cd0e82-d2aa-4614-93a2-b84828866742.jpg?1",
             "name": "Loyal Apprentice",
             "text": "Haste\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.",
             "colours": [
@@ -7249,7 +7249,7 @@
         },
         {
             "id": "4e40e2dd-92af-5dbc-b2eb-90b89a4417d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f748393d-5845-45d7-96e9-bbdbb701151f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f748393d-5845-45d7-96e9-bbdbb701151f.jpg?1",
             "name": "Sticky Fingers",
             "text": "Enchant creature\nEnchanted creature has menace and \"Whenever this creature deals combat damage to a player, create a Treasure token.\" (It can't be blocked except by two or more creatures. The token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhen enchanted creature dies, draw a card.",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "167e9f77-213e-5156-92e4-a530e65f048f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0adad-207a-4504-9636-75f7ccb5b60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0adad-207a-4504-9636-75f7ccb5b60c.jpg?1",
             "name": "Stolen Strategy",
             "text": "At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -7321,7 +7321,7 @@
         },
         {
             "id": "7aa4a157-669d-5cb3-8a7e-58e1a14b3113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5261d46-bf8c-4c29-8683-9a4fe4b23b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5261d46-bf8c-4c29-8683-9a4fe4b23b8d.jpg?1",
             "name": "Unexpected Windfall",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7355,7 +7355,7 @@
         },
         {
             "id": "963c63c9-1e8b-57e9-bf89-cef9e9c31f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120b71f5-3c4d-4e00-9a3d-6872416a4373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120b71f5-3c4d-4e00-9a3d-6872416a4373.jpg?1",
             "name": "Abundant Growth",
             "text": "Enchant land\nWhen Abundant Growth enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "5c403025-b600-5994-9330-c08d3cd03b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b2c132-0e57-4273-aa30-e78870647dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b2c132-0e57-4273-aa30-e78870647dc7.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -7427,7 +7427,7 @@
         },
         {
             "id": "11bb4068-4ced-5698-934d-fd5502451cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b149d9f6-c337-43cd-8f9e-1f864d039d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b149d9f6-c337-43cd-8f9e-1f864d039d9c.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -7461,7 +7461,7 @@
         },
         {
             "id": "83ace907-6006-545f-8760-8e86a3d71172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd4d32-8cb8-4699-8e96-22746cf5ea57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd4d32-8cb8-4699-8e96-22746cf5ea57.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7495,7 +7495,7 @@
         },
         {
             "id": "9849fe97-73f3-5610-87df-570b1b6db864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d3b2bb-2be0-4de9-9de0-1a07da693e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d3b2bb-2be0-4de9-9de0-1a07da693e4f.jpg?1",
             "name": "Fertile Ground",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -7531,7 +7531,7 @@
         },
         {
             "id": "e6924a58-de70-5f6e-b57a-93044760f15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1b0ed2-dc94-471d-9ea4-1a17f3cbb81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1b0ed2-dc94-471d-9ea4-1a17f3cbb81a.jpg?1",
             "name": "Guardian Project",
             "text": "Whenever a nontoken creature enters the battlefield under your control, if it doesn't have the same name as another creature you control or a creature card in your graveyard, draw a card.",
             "colours": [
@@ -7567,7 +7567,7 @@
         },
         {
             "id": "a89c6e5f-0970-57c0-9a46-f436934b1a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecefd95-4eff-4403-83c1-c0c29a2f2a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecefd95-4eff-4403-83c1-c0c29a2f2a76.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "3f3b80d2-39a2-5aec-b31f-f2b755cdc0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd260f0-2bce-469a-9c40-7978db5776e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd260f0-2bce-469a-9c40-7978db5776e9.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -7637,7 +7637,7 @@
         },
         {
             "id": "23d094b5-9bbc-5b5b-ad86-8e7a5c38ffcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdaecd3-fc71-4c86-a65e-27681e1ba41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdaecd3-fc71-4c86-a65e-27681e1ba41f.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -7673,7 +7673,7 @@
         },
         {
             "id": "4b9789d5-2f17-5ac4-a331-aa4deef1ce1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7760a-16d9-4fe2-98f3-212cc2cf6d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7760a-16d9-4fe2-98f3-212cc2cf6d83.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn.",
             "colours": [
@@ -7707,7 +7707,7 @@
         },
         {
             "id": "59c037dc-0cb2-59e4-aff8-aa7dd78137f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fad7e1-b57f-4652-879e-d97466948829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fad7e1-b57f-4652-879e-d97466948829.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "56019e8e-2f72-561b-8980-fcfab3a92863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073ecc9-5d3a-452f-b708-0572fa27a6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073ecc9-5d3a-452f-b708-0572fa27a6f0.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "b9b5dbf7-aab4-5fa2-b436-27803155f2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52b4496-b60d-4c72-bf86-0f0e54515821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52b4496-b60d-4c72-bf86-0f0e54515821.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "e71c774d-0aac-53a9-afd2-c2dd5775a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b1bc46-e8be-4437-a50a-96b6f1ec4a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b1bc46-e8be-4437-a50a-96b6f1ec4a08.jpg?1",
             "name": "Tireless Tracker",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.",
             "colours": [
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "909b3356-4cb1-5b90-a619-1b90ead0212f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fdfa77-424a-4f83-bb48-1c43b6c84b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fdfa77-424a-4f83-bb48-1c43b6c84b17.jpg?1",
             "name": "Wild Growth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.",
             "colours": [
@@ -7888,7 +7888,7 @@
         },
         {
             "id": "b0b79137-9e71-5f94-9428-ef1744f18393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e0f42-a881-4ee2-94a5-2c740863aa74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e0f42-a881-4ee2-94a5-2c740863aa74.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "499779f0-ba34-5a14-86fc-c181fca6f813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c04498-91cf-42d2-a349-44df4d022746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c04498-91cf-42d2-a349-44df4d022746.jpg?1",
             "name": "Assemble the Legion",
             "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then create a 1/1 red and white Soldier creature token with haste for each muster counter on Assemble the Legion.",
             "colours": [
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "60eb1656-534c-56d4-9235-bf17e93b03b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053d366-fc35-443b-a8dd-4ab0c3362c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053d366-fc35-443b-a8dd-4ab0c3362c81.jpg?1",
             "name": "Behemoth Sledge",
             "text": "Equipped creature gets +2/+2 and has trample and lifelink.\nEquip {3}",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "7f6d5a31-f57c-5b3c-a49e-4d2521e2ebfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3f731a-03d7-4dc9-a922-cc2250cee6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3f731a-03d7-4dc9-a922-cc2250cee6ef.jpg?1",
             "name": "Biomass Mutation",
             "text": "Creatures you control have base power and toughness X/X until end of turn.",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "08316c03-c35d-52df-a681-3089c1da0f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea2451e-ad6e-4f76-ac76-0b8f4fabd0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea2451e-ad6e-4f76-ac76-0b8f4fabd0a9.jpg?1",
             "name": "Casualties of War",
             "text": "Choose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature.\n\u2022 Destroy target enchantment.\n\u2022 Destroy target land.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -8078,7 +8078,7 @@
         },
         {
             "id": "014016de-9f65-59b6-a864-82ff2f834c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb08ac43-f138-47b6-9bff-6248c315b0ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb08ac43-f138-47b6-9bff-6248c315b0ca.jpg?1",
             "name": "Corpsejack Menace",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on it instead.",
             "colours": [
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "928f12bb-9a5e-5ecf-9723-ec2d316f3a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2a0286-a16d-4e48-a295-da8232ddc9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2a0286-a16d-4e48-a295-da8232ddc9c7.jpg?1",
             "name": "Fervent Charge",
             "text": "Whenever a creature you control attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -8156,7 +8156,7 @@
         },
         {
             "id": "768c10e3-d10f-50cc-8247-27568d4d7495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg?1",
             "name": "Find // Finality",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "fe6bb1fc-9c37-5efa-9e0d-c4f6eb3ab3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg?1",
             "name": "Find // Finality",
             "text": "You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.",
             "colours": [
@@ -8228,7 +8228,7 @@
         },
         {
             "id": "0cc50a05-572f-59f9-bc1a-bc1293ec3847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682373ca-d358-4a21-8cbe-4a41d8636b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682373ca-d358-4a21-8cbe-4a41d8636b42.jpg?1",
             "name": "General's Enforcer",
             "text": "Legendary Humans you control have indestructible.\n{2}{W}{B}: Exile target card from a graveyard. If it was a creature card, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "72ed92dc-8f69-55d3-913e-c40230c0ad58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a87f7-208d-4312-ba37-7a844b9c89ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a87f7-208d-4312-ba37-7a844b9c89ab.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste.",
             "colours": [
@@ -8303,7 +8303,7 @@
         },
         {
             "id": "7e46ad05-06c6-50f7-af1a-358b5978a9a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf308540-dd6d-4437-abe7-373a2c129455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf308540-dd6d-4437-abe7-373a2c129455.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -8339,7 +8339,7 @@
         },
         {
             "id": "f65b03fc-90b0-5c3a-a28b-f65d839fb3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3d5d4-7fa3-47ba-9963-23814bce063d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3d5d4-7fa3-47ba-9963-23814bce063d.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "Destroy all nonland permanents your opponents control.",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "9673da82-ef59-555d-9a2e-c4a60a4a3561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4548087a-9e65-4d57-988c-2b42c2801197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4548087a-9e65-4d57-988c-2b42c2801197.jpg?1",
             "name": "Wake the Past",
             "text": "Return all artifact cards from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "48ca770f-b3e7-59f8-a24f-9988f429838b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target artifact.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "a8d95e2f-e850-5c39-a371-b4130bb69a89",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target enchantment.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "ee5514cd-7b03-5a54-9522-a72f06ad134e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238c728e-5e5d-4fb2-9e97-59b5b0e721c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238c728e-5e5d-4fb2-9e97-59b5b0e721c8.jpg?1",
             "name": "Winding Constrictor",
             "text": "If one or more counters would be put on an artifact or creature you control, that many plus one of each of those kinds of counters are put on that permanent instead.\nIf you would get one or more counters, you get that many plus one of each of those kinds of counters instead.",
             "colours": [
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "1d0364df-9152-59b0-9c28-1e6402b5192a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafeaa8-5e77-4303-b30a-23fd137b7c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafeaa8-5e77-4303-b30a-23fd137b7c35.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "f493f2eb-7e34-5113-b99d-010141e0a7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b8ca7-81cb-40d8-904e-88872bd3797e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b8ca7-81cb-40d8-904e-88872bd3797e.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "eae52b98-9aab-5bbc-b882-197a1e118cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78289e0-3675-4587-8a33-54640e58a1f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78289e0-3675-4587-8a33-54640e58a1f7.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -8625,7 +8625,7 @@
         },
         {
             "id": "7ac3bbc4-47f6-5813-92c3-5562a790279c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3fcf94-c206-46ac-9356-7561cc0cd711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3fcf94-c206-46ac-9356-7561cc0cd711.jpg?1",
             "name": "Brass Knuckles",
             "text": "When you cast this spell, copy it. (The copy becomes a token.)\nEquipped creature has double strike as long as two or more Equipment are attached to it.\nEquip {1}",
             "colours": [],
@@ -8657,7 +8657,7 @@
         },
         {
             "id": "573dfce1-8919-50f7-8ab4-b748bd805c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f5d866-4ee9-4054-8d48-82da0a2d1170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f5d866-4ee9-4054-8d48-82da0a2d1170.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof. (It can't be the target of spells or abilities your opponents control.)\nEquip {1}",
             "colours": [],
@@ -8691,7 +8691,7 @@
         },
         {
             "id": "04415470-32ba-5286-b0b7-fd7e64647b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5bd288-0488-4354-a201-717bdaa10d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5bd288-0488-4354-a201-717bdaa10d44.jpg?1",
             "name": "Contagion Clasp",
             "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "4ea16af8-76da-5973-8ea1-993156f8e19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6be33e-1a5b-482c-a444-3e8ab98d591d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6be33e-1a5b-482c-a444-3e8ab98d591d.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -8751,7 +8751,7 @@
         },
         {
             "id": "836b422f-2910-50b4-bdb5-ce2b7cab01fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66cbdcb-c42c-4f30-871f-f1bc11f475df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66cbdcb-c42c-4f30-871f-f1bc11f475df.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "03e4764c-ba40-5e7d-a47d-a74f667ff8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cda06f-b935-4a40-aae5-9fcf7966e68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cda06f-b935-4a40-aae5-9fcf7966e68c.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike.\nEquip {2}",
             "colours": [],
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "bb368b09-4e3a-5c18-a38c-fb106a632da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec824ef-fd09-4f7e-a350-ac80005c261f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec824ef-fd09-4f7e-a350-ac80005c261f.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -8847,7 +8847,7 @@
         },
         {
             "id": "a106e261-ff76-5f80-b131-51093b6b2fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea75905-326f-48a9-9144-3ac147b9c2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea75905-326f-48a9-9144-3ac147b9c2bf.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "You may have Masterwork of Ingenuity enter the battlefield as a copy of any Equipment on the battlefield.",
             "colours": [],
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "7f23cbac-ae7c-5e57-b711-582b9a4757ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88baf29-a556-4e89-8471-9ba9bc8efe2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88baf29-a556-4e89-8471-9ba9bc8efe2c.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "8f2a6d23-bc98-5416-928f-e00b6d47abed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a6275-331e-4696-85ea-6f7a0a0f865e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a6275-331e-4696-85ea-6f7a0a0f865e.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast artifact spells and colorless spells from the top of your library.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "deff04bf-e86a-5d5d-9044-dd59530db3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d92b7dd-1f63-4f34-87ca-01a0eaa7b3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d92b7dd-1f63-4f34-87ca-01a0eaa7b3a1.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "32d9eb4a-a622-5a8f-ba5c-5ad2290f75af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160f5f0-8ab8-4ec1-a84c-cfe49cb43b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160f5f0-8ab8-4ec1-a84c-cfe49cb43b8d.jpg?1",
             "name": "Skullclamp",
             "text": "Equipped creature gets +1/-1.\nWhenever equipped creature dies, draw two cards.\nEquip {1}",
             "colours": [],
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "7bc6511d-3529-55d0-ac3e-de29767f49fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e675f7e2-5c9f-4912-8fdd-daaeda284a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e675f7e2-5c9f-4912-8fdd-daaeda284a3d.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "16d4381e-c306-51de-acf8-dcd48ddd4e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc91d8b8-ed18-45bf-a9e0-2f6afe6dd23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc91d8b8-ed18-45bf-a9e0-2f6afe6dd23c.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "3a8245db-206a-5e5a-a47c-6d13e0751047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca078f45-b4eb-4b5b-87cb-80b6c0ba5f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca078f45-b4eb-4b5b-87cb-80b6c0ba5f31.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "0266e48a-0618-5713-ba14-22e12e1fb15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d405a1-f951-4043-97bf-887e4fa388ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d405a1-f951-4043-97bf-887e4fa388ad.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control.)\nEquip {1}",
             "colours": [],
@@ -9141,7 +9141,7 @@
         },
         {
             "id": "9ee90e8c-9cd2-57be-800a-69561432b601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec517e7-bc4d-4986-ba3c-89866a29991d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec517e7-bc4d-4986-ba3c-89866a29991d.jpg?1",
             "name": "Talisman of Conviction",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Talisman of Conviction deals 1 damage to you.",
             "colours": [],
@@ -9174,7 +9174,7 @@
         },
         {
             "id": "66514c40-d49c-5708-bd18-255ad25b1d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d318b7-5c82-40a7-a63e-d8e72938624f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d318b7-5c82-40a7-a63e-d8e72938624f.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -9207,7 +9207,7 @@
         },
         {
             "id": "5e601cdf-3503-5b83-b27f-d47ec08ba29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9544d0d1-f9bb-43a5-9c39-db187a6efe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9544d0d1-f9bb-43a5-9c39-db187a6efe3b.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Talisman of Curiosity deals 1 damage to you.",
             "colours": [],
@@ -9240,7 +9240,7 @@
         },
         {
             "id": "32019809-c6aa-5dc6-a036-377c7fde2f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f294565-2bbc-49c6-9777-42160c0afe3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f294565-2bbc-49c6-9777-42160c0afe3e.jpg?1",
             "name": "Talisman of Dominance",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Talisman of Dominance deals 1 damage to you.",
             "colours": [],
@@ -9273,7 +9273,7 @@
         },
         {
             "id": "7718e3e9-f68a-5543-b370-73e6a9a6d4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b55b6cb-820c-4782-9f63-e04fe46e02d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b55b6cb-820c-4782-9f63-e04fe46e02d2.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Talisman of Hierarchy deals 1 damage to you.",
             "colours": [],
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "0840cdfc-1686-55da-943a-6169c78e0ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113410ff-d25e-4f25-a6c2-236bcf4c8486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113410ff-d25e-4f25-a6c2-236bcf4c8486.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Talisman of Indulgence deals 1 damage to you.",
             "colours": [],
@@ -9339,7 +9339,7 @@
         },
         {
             "id": "052d810d-ddba-5aa0-90bc-99a58df23530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290b095-7f4f-452d-b54d-b4290d182c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290b095-7f4f-452d-b54d-b4290d182c8d.jpg?1",
             "name": "Talisman of Progress",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Talisman of Progress deals 1 damage to you.",
             "colours": [],
@@ -9372,7 +9372,7 @@
         },
         {
             "id": "ace8bd8f-21fd-5593-bb15-321aa2d10d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf1082-624c-4b9d-a57f-672ccbef4987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf1082-624c-4b9d-a57f-672ccbef4987.jpg?1",
             "name": "Talisman of Resilience",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Talisman of Resilience deals 1 damage to you.",
             "colours": [],
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "5946dc25-5e73-5f9c-9932-1fae30dbfc37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68c8703-3029-443b-95f5-5310e8b48a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68c8703-3029-443b-95f5-5310e8b48a2b.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -9435,7 +9435,7 @@
         },
         {
             "id": "9acaa63d-f7b1-5fc9-b5ec-252a703cb3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7503-d05b-4eac-bb6f-ef3bf696437d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7503-d05b-4eac-bb6f-ef3bf696437d.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9465,7 +9465,7 @@
         },
         {
             "id": "96a097bf-d036-5f5b-9626-75b113a863f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a90148-5ed9-42db-a64f-4735676d82e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a90148-5ed9-42db-a64f-4735676d82e3.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -9495,7 +9495,7 @@
         },
         {
             "id": "18ff8254-369f-5d0e-af17-b1e0b3f3d97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3ebfce-47cd-4ebe-bfeb-2cb22a1bd9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3ebfce-47cd-4ebe-bfeb-2cb22a1bd9ec.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -9525,7 +9525,7 @@
         },
         {
             "id": "63a8016f-af83-5059-8ed8-fa2890a77a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3076b36b-292a-4b14-8284-28e623c20e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3076b36b-292a-4b14-8284-28e623c20e30.jpg?1",
             "name": "Canopy Vista",
             "text": "({T}: Add {G} or {W}.)\nCanopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "bda2a641-4fd0-5f58-a5ea-1de4124c521f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c66f9-64af-48aa-b24b-3ef76596378a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c66f9-64af-48aa-b24b-3ef76596378a.jpg?1",
             "name": "Canyon Slough",
             "text": "({T}: Add {B} or {R}.)\nCanyon Slough enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "96bbec60-278b-5d64-bdb1-f1f48b76132b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4959e5-bdc8-4f60-a1d2-77dc17a493a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4959e5-bdc8-4f60-a1d2-77dc17a493a0.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G}.)\nCinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "96bca4ca-a3d4-5100-8412-13b61df8da2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6454d4c-5820-4cb8-b625-3d9a09778513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6454d4c-5820-4cb8-b625-3d9a09778513.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "620533da-9b3d-5344-a2f3-dc83ac8095f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb8cb-633c-468f-8ef5-54ff91ddfb22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb8cb-633c-468f-8ef5-54ff91ddfb22.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "1559d073-1a23-532b-8a51-e9bda20de922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3d4b7-972f-447f-a512-f40ceeba5d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3d4b7-972f-447f-a512-f40ceeba5d9c.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -9741,7 +9741,7 @@
         },
         {
             "id": "3a86e38b-3f78-5f79-9b39-2523d422f5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed078f-74b4-4ae8-9b2f-6b7b629fff1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed078f-74b4-4ae8-9b2f-6b7b629fff1f.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "4a7fe09a-a28f-5b73-8781-03f154efe348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e033971a-3460-43a1-abf6-6dab433a9c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e033971a-3460-43a1-abf6-6dab433a9c3f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "adeda323-57d7-53d1-91e8-0b9b7435bcb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912837ca-054a-49a8-a5c5-5e65631b0575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912837ca-054a-49a8-a5c5-5e65631b0575.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "5d80394a-e7b5-5573-9419-3a8e4e613d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f07a84-2788-4f5b-bd76-701bab10f01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f07a84-2788-4f5b-bd76-701bab10f01b.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "70aa6ce1-145e-563b-9fa2-d5981d65962b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae00e88-0dfc-477a-a982-0187efe753f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae00e88-0dfc-477a-a982-0187efe753f2.jpg?1",
             "name": "Fetid Pools",
             "text": "({T}: Add {U} or {B}.)\nFetid Pools enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "91b74b41-6264-5d0d-81b3-ee4c1eaf52ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f303a30-e3d9-4b31-aa67-608a627fc6ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f303a30-e3d9-4b31-aa67-608a627fc6ff.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9946,7 +9946,7 @@
         },
         {
             "id": "5714a283-c512-52c5-b529-9c4599d8941c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fdcf1-09b4-4eba-a5f1-242d68ba1aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fdcf1-09b4-4eba-a5f1-242d68ba1aea.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9981,7 +9981,7 @@
         },
         {
             "id": "23627813-bab5-5a2b-aa04-f1bdd62635e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd325f-2762-4ef0-a0f1-b56bb63da0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd325f-2762-4ef0-a0f1-b56bb63da0d1.jpg?1",
             "name": "Irrigated Farmland",
             "text": "({T}: Add {W} or {U}.)\nIrrigated Farmland enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "ff11c164-1643-51ae-80f1-6d6f6e733419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377487dd-d72a-4169-bfe1-29e36c3e3d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377487dd-d72a-4169-bfe1-29e36c3e3d1f.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10054,7 +10054,7 @@
         },
         {
             "id": "3afaa3fd-0f52-5e06-8599-7870f392c407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374c9b90-9179-4866-b479-ffd303767f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374c9b90-9179-4866-b479-ffd303767f97.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine enters the battlefield tapped.\n{T}: Add {R}, {G}, or {W}.",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "77303229-fabd-5e4b-a095-67fcf2e305b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3cc476-3d5b-42d3-afe2-54c639770181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3cc476-3d5b-42d3-afe2-54c639770181.jpg?1",
             "name": "Memorial to Glory",
             "text": "Memorial to Glory enters the battlefield tapped.\n{T}: Add {W}.\n{3}{W}, {T}, Sacrifice Memorial to Glory: Create two 1/1 white Soldier creature tokens.",
             "colours": [],
@@ -10120,7 +10120,7 @@
         },
         {
             "id": "608e52e8-4a74-592e-832e-eae6111181ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b7472f-48f5-4ab5-8896-3eee29d13d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b7472f-48f5-4ab5-8896-3eee29d13d59.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.\n{T}: Add {B}.",
             "colours": [],
@@ -10152,7 +10152,7 @@
         },
         {
             "id": "9183284c-e428-5622-bb67-81a33c2a357a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b31a08a-8fb5-48ef-b923-a1c6378a95f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b31a08a-8fb5-48ef-b923-a1c6378a95f4.jpg?1",
             "name": "Mossfire Valley",
             "text": "{1}, {T}: Add {R}{G}.",
             "colours": [],
@@ -10187,7 +10187,7 @@
         },
         {
             "id": "442b5c03-5495-594c-81e4-f9098df68afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe6542-9f4b-4afa-8568-272916125b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe6542-9f4b-4afa-8568-272916125b4a.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10217,7 +10217,7 @@
         },
         {
             "id": "8ae05575-4543-5827-a363-922fa33016a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91902a-a524-4207-8864-4d7085a0e09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91902a-a524-4207-8864-4d7085a0e09f.jpg?1",
             "name": "Mystic Monastery",
             "text": "Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W}.",
             "colours": [],
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "9919da04-44e0-5ee2-86f9-2a12be18371a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1cf348-7434-4b43-907a-87a86eac735f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1cf348-7434-4b43-907a-87a86eac735f.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -10283,7 +10283,7 @@
         },
         {
             "id": "c5fca2ae-95ca-5ca3-b233-2048b7bd3efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17aa04-dbd8-4d49-898c-bf0a64cdb827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17aa04-dbd8-4d49-898c-bf0a64cdb827.jpg?1",
             "name": "Nomad Outpost",
             "text": "Nomad Outpost enters the battlefield tapped.\n{T}: Add {R}, {W}, or {B}.",
             "colours": [],
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "6a074ffc-32cf-5e54-acdf-2b80e03573a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba66391-8ff8-423a-893f-72cc022f4714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba66391-8ff8-423a-893f-72cc022f4714.jpg?1",
             "name": "Opulent Palace",
             "text": "Opulent Palace enters the battlefield tapped.\n{T}: Add {B}, {G}, or {U}.",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "3707cc3e-7890-5987-b576-067561ec616a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6415d9-14fb-4a58-aa86-bf2063037684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6415d9-14fb-4a58-aa86-bf2063037684.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "acf13b01-8fdc-5723-bc0a-42d5cbfb46d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69dd983-757e-4de8-9824-a5123b906c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69dd983-757e-4de8-9824-a5123b906c62.jpg?1",
             "name": "Prairie Stream",
             "text": "({T}: Add {W} or {U}.)\nPrairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -10419,7 +10419,7 @@
         },
         {
             "id": "8852f6a2-ec0f-5fbd-9e78-245f2a60f54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697d872f-111f-4810-baf2-d4c6f2f48dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697d872f-111f-4810-baf2-d4c6f2f48dd5.jpg?1",
             "name": "Razortide Bridge",
             "text": "Razortide Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -10453,7 +10453,7 @@
         },
         {
             "id": "07248361-25e2-5a56-9a4a-947fda603fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deca57c8-ac90-4fce-83b5-74adf45622e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deca57c8-ac90-4fce-83b5-74adf45622e5.jpg?1",
             "name": "Roadside Reliquary",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Roadside Reliquary: Draw a card if you control an artifact. Draw a card if you control an enchantment.",
             "colours": [],
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "405f56a8-ab54-5133-9581-1ae1e030ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0d5ed6-baa9-42b7-87e2-372e4513b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0d5ed6-baa9-42b7-87e2-372e4513b771.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -10513,7 +10513,7 @@
         },
         {
             "id": "c714b86c-82e6-5dc9-a18a-af5fd72c8026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8ba5e7-5867-47dc-88f5-412b490306a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8ba5e7-5867-47dc-88f5-412b490306a6.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -10548,7 +10548,7 @@
         },
         {
             "id": "5f104bfd-63a9-594d-8af4-0f5cd7799937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dd5b22-c7f8-4c00-a27b-437da0136177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dd5b22-c7f8-4c00-a27b-437da0136177.jpg?1",
             "name": "Rustvale Bridge",
             "text": "Rustvale Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10582,7 +10582,7 @@
         },
         {
             "id": "ad172cff-9de1-598b-a463-05b25d563912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc924137-6f0d-41bd-bb94-b7a6e1a13be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc924137-6f0d-41bd-bb94-b7a6e1a13be1.jpg?1",
             "name": "Scattered Groves",
             "text": "({T}: Add {G} or {W}.)\nScattered Groves enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10620,7 +10620,7 @@
         },
         {
             "id": "4c722df7-2695-5267-beef-352d614636a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8fa97c-f796-4fb7-bd4d-f55b5f66c36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8fa97c-f796-4fb7-bd4d-f55b5f66c36e.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all graveyards.",
             "colours": [],
@@ -10654,7 +10654,7 @@
         },
         {
             "id": "7fb6e6e5-7891-5f97-b0b7-8449124b4a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02d5d2-2f71-4b93-a0c5-5964ec08524f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02d5d2-2f71-4b93-a0c5-5964ec08524f.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "{1}, {T}: Add {B}{R}.",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "e89c8a0f-b25f-5814-a358-7c6469a670b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923d2489-54c6-47df-8bce-285f42c33c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923d2489-54c6-47df-8bce-285f42c33c20.jpg?1",
             "name": "Sheltered Thicket",
             "text": "({T}: Add {R} or {G}.)\nSheltered Thicket enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10727,7 +10727,7 @@
         },
         {
             "id": "62d0b809-819c-5d10-8bbc-3792a244394c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820485ab-0a31-4278-9316-ec5b909f4d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820485ab-0a31-4278-9316-ec5b909f4d11.jpg?1",
             "name": "Silverbluff Bridge",
             "text": "Silverbluff Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10761,7 +10761,7 @@
         },
         {
             "id": "ddd40ba6-5dbe-50c3-88ce-799eab6260d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b8f769-57c8-45e7-b451-7b4fe7e80bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b8f769-57c8-45e7-b451-7b4fe7e80bf8.jpg?1",
             "name": "Skycloud Expanse",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -10796,7 +10796,7 @@
         },
         {
             "id": "8575d4d5-b61a-5482-b193-3eb132ba0d31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567e219b-2961-4f02-9be0-7776210b62b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567e219b-2961-4f02-9be0-7776210b62b0.jpg?1",
             "name": "Smoldering Marsh",
             "text": "({T}: Add {B} or {R}.)\nSmoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -10834,7 +10834,7 @@
         },
         {
             "id": "409cfbfa-45af-584c-8de5-82313e9a179c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdda2ce8-23d1-4814-8e81-d6cf40f75a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdda2ce8-23d1-4814-8e81-d6cf40f75a13.jpg?1",
             "name": "Spire of Industry",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Activate only if you control an artifact.",
             "colours": [],
@@ -10866,7 +10866,7 @@
         },
         {
             "id": "2d25c939-ad14-575b-9684-7613d8434859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6821409-3793-4a7c-962b-7d501fa50fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6821409-3793-4a7c-962b-7d501fa50fe5.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10901,7 +10901,7 @@
         },
         {
             "id": "8fdd9e24-b056-5206-9863-d850b7e886ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61db976-f33e-4904-829c-b9ec11a7eeb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61db976-f33e-4904-829c-b9ec11a7eeb0.jpg?1",
             "name": "Sungrass Prairie",
             "text": "{1}, {T}: Add {G}{W}.",
             "colours": [],
@@ -10936,7 +10936,7 @@
         },
         {
             "id": "93c0e170-7c43-5f81-9063-7e4defc33166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4d725-cb54-4617-bbfd-45e2f2d3dec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4d725-cb54-4617-bbfd-45e2f2d3dec8.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B}.)\nSunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -10974,7 +10974,7 @@
         },
         {
             "id": "1a2bac4e-d7b6-5de7-9357-0f2c948c345f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bd068-32f4-4055-930d-afd2015fb41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bd068-32f4-4055-930d-afd2015fb41a.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "f13c0409-3838-5306-9f52-f1be2cdb697d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46db1a-7066-47bd-a033-cc55f9b4004e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46db1a-7066-47bd-a033-cc55f9b4004e.jpg?1",
             "name": "Tainted Field",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "4eb0a1e0-0e30-588b-8cb7-b84bb5a6b649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc20d1-c3be-4630-b860-49b9fdb6f6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc20d1-c3be-4630-b860-49b9fdb6f6c4.jpg?1",
             "name": "Tainted Isle",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11075,7 +11075,7 @@
         },
         {
             "id": "cea3fabc-6718-5fd0-8930-1bbbff0689f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1374839-bdef-4e55-a7bc-906340439605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1374839-bdef-4e55-a7bc-906340439605.jpg?1",
             "name": "Tainted Peak",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11108,7 +11108,7 @@
         },
         {
             "id": "a7331689-74cc-50a5-b072-8014887b94d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aed044e-d9c8-429f-b618-62446fa688cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aed044e-d9c8-429f-b618-62446fa688cc.jpg?1",
             "name": "Tainted Wood",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11141,7 +11141,7 @@
         },
         {
             "id": "d42e8f54-d1b0-5dcc-b9be-57ebc8de011f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83e083-bdaf-4f11-9be2-7d148428f479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83e083-bdaf-4f11-9be2-7d148428f479.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -11176,7 +11176,7 @@
         },
         {
             "id": "ad72cdec-d999-59cc-b087-e834b4257a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5460711e-dd15-476c-922f-3f1cd582d3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5460711e-dd15-476c-922f-3f1cd582d3f6.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11211,7 +11211,7 @@
         },
         {
             "id": "2859ccf2-a659-5f6c-a52e-3882619ad43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658fec13-a62d-4701-ad8b-9cb08d960253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658fec13-a62d-4701-ad8b-9cb08d960253.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11246,7 +11246,7 @@
         },
         {
             "id": "c5f03cac-a280-5069-bc94-16045ba4d56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d6842-0ba6-494d-b10c-9ac47f78c757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d6842-0ba6-494d-b10c-9ac47f78c757.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -11281,7 +11281,7 @@
         },
         {
             "id": "d3d131ce-8df7-5daa-a5f1-22b38c217935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a280c4-9cc6-4b48-9124-0ddb7fd05626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a280c4-9cc6-4b48-9124-0ddb7fd05626.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11316,7 +11316,7 @@
         },
         {
             "id": "05572ac0-79d6-54c5-9389-f907e5396abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ccf18ae-ca47-46b0-85c2-235e75d5b42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ccf18ae-ca47-46b0-85c2-235e75d5b42b.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11351,7 +11351,7 @@
         },
         {
             "id": "c6ec319d-3d5c-5c5f-8237-4dd3b2502dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ba1f6-a35b-4b24-9d33-6a9658441ec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ba1f6-a35b-4b24-9d33-6a9658441ec7.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "7f6055a4-a152-503c-a9fa-d6ae79f92328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694d6658-4126-4aea-a2ab-0cffa168e101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694d6658-4126-4aea-a2ab-0cffa168e101.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11421,7 +11421,7 @@
         },
         {
             "id": "6022a5ac-65ec-57f9-bfed-3817f991822f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e014eb8-e325-40f7-9ac8-d53508c88925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e014eb8-e325-40f7-9ac8-d53508c88925.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -11456,7 +11456,7 @@
         },
         {
             "id": "5b8aabf9-a1ad-5f3a-a03d-3c5797c0f08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22223010-1864-483d-b0af-50ca40bc3d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22223010-1864-483d-b0af-50ca40bc3d0d.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {C}{C}. Activate only if you control five or more lands.",
             "colours": [],
@@ -11486,7 +11486,7 @@
         },
         {
             "id": "74a91da7-f70e-5a8c-ba84-9c22597a3fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76721cda-494e-4c77-8b0f-43238a35c040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76721cda-494e-4c77-8b0f-43238a35c040.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11521,7 +11521,7 @@
         },
         {
             "id": "fb84280e-2322-5101-bd37-0af0a7627a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548805de-3e2e-4f1f-aafc-d89fddf8288a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548805de-3e2e-4f1f-aafc-d89fddf8288a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11551,7 +11551,7 @@
         },
         {
             "id": "59442308-9107-58a2-afc6-659e41624992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8a9a88-d4b5-4c2a-86fa-22475ce919ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8a9a88-d4b5-4c2a-86fa-22475ce919ca.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -11584,7 +11584,7 @@
         },
         {
             "id": "7c418531-58b4-5354-9518-e216bda2e1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b7b9f1-8428-4c04-a918-7c0e1d3906ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b7b9f1-8428-4c04-a918-7c0e1d3906ed.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWindbrisk Heights enters the battlefield tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -11618,7 +11618,7 @@
         },
         {
             "id": "b73984c8-eaea-56c8-b3b1-0a17a6a429d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98edea5-a974-4475-b518-e79a91fe4371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98edea5-a974-4475-b518-e79a91fe4371.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11653,7 +11653,7 @@
         },
         {
             "id": "02e7cd22-5653-570e-84ff-adfc76b7b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f33598-1344-4365-9067-17a7379de894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f33598-1344-4365-9067-17a7379de894.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11691,7 +11691,7 @@
         },
         {
             "id": "2a1490f1-06d6-586f-9ae1-e7d7e92df415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6be912-4d77-45d2-b653-7fbbee6a881a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6be912-4d77-45d2-b653-7fbbee6a881a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "353c1c91-0d66-5d8c-9893-b2acff066b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0a88d-7049-4206-8085-4a68ab0bfd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0a88d-7049-4206-8085-4a68ab0bfd81.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11767,7 +11767,7 @@
         },
         {
             "id": "9961b60c-b41d-536a-8d8a-1cb45fa6f2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040ed422-663a-4b6c-bdcd-09092f1c9004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040ed422-663a-4b6c-bdcd-09092f1c9004.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "f1198b81-4fb5-57d4-9d98-e864853a8446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237204ad-ab8a-496f-a093-48d00417350b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237204ad-ab8a-496f-a093-48d00417350b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11843,7 +11843,7 @@
         },
         {
             "id": "f6ccbaf0-aab4-552a-8186-e239bb5fac6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09af769d-a051-40d4-b203-7ec818c367ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09af769d-a051-40d4-b203-7ec818c367ca.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11881,7 +11881,7 @@
         },
         {
             "id": "b06486ee-21b3-559e-ba56-6e5201f55ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f5bbab-7bf0-48d4-8138-d64f84f4d769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f5bbab-7bf0-48d4-8138-d64f84f4d769.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11919,7 +11919,7 @@
         },
         {
             "id": "674e682b-a3a0-510c-a0b2-b8210df24a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5691d3-751a-41dd-b2a3-c766c8973bfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5691d3-751a-41dd-b2a3-c766c8973bfe.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11957,7 +11957,7 @@
         },
         {
             "id": "433a3ec6-229b-530d-a183-b0caa7cb1ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13351c-ca20-410c-8959-bbaa59816002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13351c-ca20-410c-8959-bbaa59816002.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11995,7 +11995,7 @@
         },
         {
             "id": "1cd560bc-0ce6-5d84-8f06-55007f734f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1e5ef3-790d-4f45-a264-157448bab2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1e5ef3-790d-4f45-a264-157448bab2e8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12033,7 +12033,7 @@
         },
         {
             "id": "4757d023-5938-5453-95b3-30f172f4192f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9eebec-e93d-4b23-b28a-534d00ae0765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9eebec-e93d-4b23-b28a-534d00ae0765.jpg?1",
             "name": "Idolized",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks alone, it gets +X/+X until end of turn, where X is the number of nonland permanents you control.\"",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "047c28a2-9b28-5163-8535-84329debada7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f361e79-91eb-42d6-a967-cc01c7528595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f361e79-91eb-42d6-a967-cc01c7528595.jpg?1",
             "name": "Securitron Squadron",
             "text": "Squad {3}\nVigilance\nWhenever a creature token enters the battlefield under your control, put a +1/+1 counter on it.",
             "colours": [
@@ -12110,7 +12110,7 @@
         },
         {
             "id": "9b28cbea-f8c9-57f8-807a-597672b1142a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed00d6f-dfcd-4a60-bb8f-8e95944548fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed00d6f-dfcd-4a60-bb8f-8e95944548fa.jpg?1",
             "name": "Radstorm",
             "text": "Storm\nProliferate.",
             "colours": [
@@ -12146,7 +12146,7 @@
         },
         {
             "id": "fd4bdc2f-2d8b-5589-a7e1-1fdc309c3002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ef27-1467-489d-b451-5d0c18b871c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ef27-1467-489d-b451-5d0c18b871c6.jpg?1",
             "name": "Synth Infiltrator",
             "text": "Improvise\nYou may have Synth Infiltrator enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.",
             "colours": [
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "3d192edd-8e49-550d-be86-a7b3dfc0dbb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1039a7de-bd49-4412-8d51-01041a463ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1039a7de-bd49-4412-8d51-01041a463ab4.jpg?1",
             "name": "Nuclear Fallout",
             "text": "Each creature gets twice -X/-X until end of turn. Each player gets X rad counters.",
             "colours": [
@@ -12221,7 +12221,7 @@
         },
         {
             "id": "4563732c-a538-5b62-9d30-ed1ad578dcfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd2d88-3354-4e8d-8db9-86cfd46b8444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd2d88-3354-4e8d-8db9-86cfd46b8444.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "Flying, menace\nWhenever Screeching Scorchbeast attacks, each player gets two rad counters.\nWhenever one or more nonland cards are milled, you may create that many 2/2 black Zombie Mutant creature tokens. Do this only once each turn.",
             "colours": [
@@ -12260,7 +12260,7 @@
         },
         {
             "id": "b38e5af3-6f41-59e6-b1c5-b66f280a4bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35303f4b-4114-443e-ab9c-74813becdf63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35303f4b-4114-443e-ab9c-74813becdf63.jpg?1",
             "name": "V.A.T.S.",
             "text": "Split second\nChoose any number of target creatures with equal toughness. Destroy the chosen creatures.",
             "colours": [
@@ -12296,7 +12296,7 @@
         },
         {
             "id": "f16d72c7-bf4d-5f28-bdf7-3bfc2daa4985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82d22c8-e3a0-4aa3-b721-e19f80db592f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82d22c8-e3a0-4aa3-b721-e19f80db592f.jpg?1",
             "name": "Mysterious Stranger",
             "text": "Flash\nWhen Mysterious Stranger enters the battlefield, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "fa868e33-9bc8-572f-8c80-1f60b28b16d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1033bdf3-eca0-4767-a4e9-a9c812a32145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1033bdf3-eca0-4767-a4e9-a9c812a32145.jpg?1",
             "name": "Watchful Radstag",
             "text": "Evolve\nWhenever Watchful Radstag evolves, create a token that's a copy of it.",
             "colours": [
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "aa3fcc52-3433-5bff-91ad-6848748a4b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2dc5b0-ac26-4829-9716-f213eda5df30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2dc5b0-ac26-4829-9716-f213eda5df30.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "Menace, trample\nWhen Alpha Deathclaw enters the battlefield or becomes monstrous, destroy target permanent.\n{5}{B}{G}: Monstrosity 4.",
             "colours": [
@@ -12415,7 +12415,7 @@
         },
         {
             "id": "5647d913-6e76-57d2-9c04-31b421801d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb785d-2294-481b-a82d-e7da357767ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb785d-2294-481b-a82d-e7da357767ed.jpg?1",
             "name": "Armory Paladin",
             "text": "Trample\nWhenever you cast an Aura or Equipment spell, exile the top card of your library. You may play that card until the end of your next turn.",
             "colours": [
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "cbecfed8-a419-54d4-ace7-beecc0d37398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb065c-6edd-4ef4-a5ee-cd65e5c65573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb065c-6edd-4ef4-a5ee-cd65e5c65573.jpg?1",
             "name": "Atomize",
             "text": "Destroy target nonland permanent. Proliferate.",
             "colours": [
@@ -12494,7 +12494,7 @@
         },
         {
             "id": "b98b1781-8806-5c13-a60b-12ae5c72fb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db77f53a-3960-4015-a809-b387a906be35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db77f53a-3960-4015-a809-b387a906be35.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "Whenever you attack, you may sacrifice another creature. When you do, choose two \u2014\n\u2022 Create two 1/1 red and white Soldier creature tokens with haste that are tapped and attacking.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Caesar, Legion's Emperor deals damage equal to the number of creature tokens you control to target opponent.",
             "colours": [
@@ -12540,7 +12540,7 @@
         },
         {
             "id": "c42515bc-42e8-573c-a751-869ee3e69750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda442d-cee3-4c92-b84b-bc6851d2c046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda442d-cee3-4c92-b84b-bc6851d2c046.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "When Dogmeat enters the battlefield, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\nWhenever a creature you control that's enchanted or equipped attacks, create a Junk token.",
             "colours": [
@@ -12585,7 +12585,7 @@
         },
         {
             "id": "8e18ea23-64ff-5858-9729-8aada6e08ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e356527-66a6-4d71-bc59-0c3bdde3d14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e356527-66a6-4d71-bc59-0c3bdde3d14c.jpg?1",
             "name": "Dr. Madison Li",
             "text": "Whenever you cast an artifact spell, you get {E}.\n{T}, Pay {E}: Target creature gets +1/+0 and gains trample and haste until end of turn.\n{T}, Pay {E}{E}{E}: Draw a card.\n{T}, Pay {E}{E}{E}{E}{E}: Return target artifact card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "96600cfa-2dce-5adb-b9c4-2f362c7b5cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db40c0c-773a-4b8f-9ed7-bfe24317c5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db40c0c-773a-4b8f-9ed7-bfe24317c5fe.jpg?1",
             "name": "Inventory Management",
             "text": "Split second\nFor each Aura and Equipment you control, you may attach it to a creature you control.",
             "colours": [
@@ -12669,7 +12669,7 @@
         },
         {
             "id": "da614a4f-12c9-5130-a2b1-79ac4a68abd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44f6097-a513-44a5-aaa4-92ac2fa800c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44f6097-a513-44a5-aaa4-92ac2fa800c0.jpg?1",
             "name": "The Wise Mothman",
             "text": "Flying\nWhenever The Wise Mothman enters the battlefield or attacks, each player gets a rad counter.\nWhenever one or more nonland cards are milled, put a +1/+1 counter on each of up to X target creatures, where X is the number of nonland cards milled this way.",
             "colours": [
@@ -12715,7 +12715,7 @@
         },
         {
             "id": "5f3a079c-4a97-52a1-bd9b-7d7b16cfd574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c19303a-89eb-4d05-bc0a-13a7e283d408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c19303a-89eb-4d05-bc0a-13a7e283d408.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -12752,7 +12752,7 @@
         },
         {
             "id": "1b58d897-5f1c-5c8c-bb89-8d188ee3cccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7774935-41f4-438a-a1a8-790f9b85efc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7774935-41f4-438a-a1a8-790f9b85efc0.jpg?1",
             "name": "Lord of the Undead",
             "text": "Other Zombie creatures get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -12788,7 +12788,7 @@
         },
         {
             "id": "8b1dce57-e096-5ea8-ada7-0ce0707ce84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942178d-6e44-4801-8692-8a4007b4d060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942178d-6e44-4801-8692-8a4007b4d060.jpg?1",
             "name": "Grave Titan",
             "text": "Deathtouch\nWhenever West Tek Tyrant enters the battlefield or attacks, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -12824,7 +12824,7 @@
         },
         {
             "id": "9d9688bc-1774-59bf-a09f-118203b05734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1b41d-f0bf-403c-a12d-1a1f5fc6bfb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1b41d-f0bf-403c-a12d-1a1f5fc6bfb9.jpg?1",
             "name": "Vigor",
             "text": "Trample\nIf damage would be dealt to another creature you control, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way.\nWhen Fog Crawler is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -12861,7 +12861,7 @@
         },
         {
             "id": "66b5e0cd-87dd-5403-a865-2a47c8c548b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af1ee9-525f-4db8-a07b-8a097a321afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af1ee9-525f-4db8-a07b-8a097a321afb.jpg?1",
             "name": "Ayula, Queen Among Bears",
             "text": "Whenever another Bear enters the battlefield under your control, choose one \u2014\n\u2022 Put two +1/+1 counters on target Bear.\n\u2022 Target Bear you control fights target creature you don't control.",
             "colours": [
@@ -12899,7 +12899,7 @@
         },
         {
             "id": "7517728a-d03a-5aef-ab36-3e4c6d43142e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d514db4-cf57-4442-a7c9-7373a2a42c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d514db4-cf57-4442-a7c9-7373a2a42c0d.jpg?1",
             "name": "Tarmogoyf",
             "text": "Scrounging Deathclaw's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -12935,7 +12935,7 @@
         },
         {
             "id": "b473055a-bbc2-56bc-8000-a6eec3d2bbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64e9259-3d47-4bfd-b781-504eaf7adc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64e9259-3d47-4bfd-b781-504eaf7adc66.jpg?1",
             "name": "Hornet Queen",
             "text": "Flying\nDeathtouch\nWhen Specimen 73 enters the battlefield, create four 1/1 green Insect creature tokens with flying and deathtouch.",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "758eeebe-4376-5a65-9e3c-4c188ee722d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89a613-2a48-4953-8e45-9afaebdf84bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89a613-2a48-4953-8e45-9afaebdf84bc.jpg?1",
             "name": "Gemrazer",
             "text": "Mutate {1}{G}{G}\nReach, trample\nWhenever this creature mutates, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -13007,7 +13007,7 @@
         },
         {
             "id": "b717cefd-3ff8-5f60-a490-4bac5c44f3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e66e6b-2501-4e87-bbc0-c823d39121f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e66e6b-2501-4e87-bbc0-c823d39121f8.jpg?1",
             "name": "Walking Ballista",
             "text": "Assaultron Invader enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Assaultron Invader.\nRemove a +1/+1 counter from Assaultron Invader: It deals 1 damage to any target.",
             "colours": [],
@@ -13040,7 +13040,7 @@
         },
         {
             "id": "bf71c349-d0d0-55d3-8883-196a1f3d948e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd945-e362-4aea-ba29-326b1b6a2004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd945-e362-4aea-ba29-326b1b6a2004.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -13074,7 +13074,7 @@
         },
         {
             "id": "b0813ca1-798b-54d6-a16a-3e8ef30e20b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341292df-b9bd-4796-a12d-10fb67c91040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341292df-b9bd-4796-a12d-10fb67c91040.jpg?1",
             "name": "Ravages of War",
             "text": "Destroy all lands.",
             "colours": [
@@ -13108,7 +13108,7 @@
         },
         {
             "id": "255f0f9a-ad84-58a4-b2cb-a471342c3580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3ed08-7a10-4f49-b5d5-d3ae75b0caa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3ed08-7a10-4f49-b5d5-d3ae75b0caa9.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R}",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "5915d66c-3274-5874-bd20-a2e2e3c25263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a30b502-569b-49fc-9a9e-96fdeaab6ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a30b502-569b-49fc-9a9e-96fdeaab6ad6.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13174,7 +13174,7 @@
         },
         {
             "id": "6f718953-05e8-55e1-bef4-af8118e40026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f314ca8-19fa-4cc9-9d23-c280de3b79bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f314ca8-19fa-4cc9-9d23-c280de3b79bc.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -13204,7 +13204,7 @@
         },
         {
             "id": "3fedcb5d-34d7-59e6-bc5b-bb3217eedd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794663d5-b397-4775-9921-30184bc36aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794663d5-b397-4775-9921-30184bc36aa9.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "{1}, {T}: Create a Food token.\nWhenever you sacrifice a Food, create a tapped Treasure token.",
             "colours": [],
@@ -13236,7 +13236,7 @@
         },
         {
             "id": "ce3fd22d-f477-568d-907a-49d470f9f331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af88e4e8-b694-4ec0-8885-701ea30bf84c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af88e4e8-b694-4ec0-8885-701ea30bf84c.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -13268,7 +13268,7 @@
         },
         {
             "id": "ee62cb16-20a1-578a-83de-235e169d24ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f460bca4-dfe0-4645-8feb-0b715ed3bd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f460bca4-dfe0-4645-8feb-0b715ed3bd0e.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13300,7 +13300,7 @@
         },
         {
             "id": "97b5234f-a550-5cda-b06d-0ceb8c0a711f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d51c18-4b7d-4948-96bc-12c8ab3d0bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d51c18-4b7d-4948-96bc-12c8ab3d0bd0.jpg?1",
             "name": "Wasteland",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Wasteland: Destroy target nonbasic land.",
             "colours": [],
@@ -13330,7 +13330,7 @@
         },
         {
             "id": "b9b0a4c7-8633-5011-8a99-08490e81475e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76832a0-8690-4843-8be4-1eba89ada995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76832a0-8690-4843-8be4-1eba89ada995.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "Enlist\nWhenever a creature you control attacks, if it enlisted a creature this combat, the creature that attacked gains double strike until end of turn. If that creature's power is 4 or greater, draw a card.",
             "colours": [
@@ -13371,7 +13371,7 @@
         },
         {
             "id": "034759e6-4822-5de3-ba10-c297729c5395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ac69e-c2a0-4106-951a-3ca3a33c30ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ac69e-c2a0-4106-951a-3ca3a33c30ed.jpg?1",
             "name": "Automated Assembly Line",
             "text": "Whenever one or more artifact creatures you control deal combat damage to a player, you get {E}.\nPay {E}{E}{E}: Create a tapped 3/3 colorless Robot artifact creature token.",
             "colours": [
@@ -13407,7 +13407,7 @@
         },
         {
             "id": "29682f33-25cc-587f-8414-0240c3e1b5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad4f5e-ac74-4549-bfc7-bbfdb1eb185e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad4f5e-ac74-4549-bfc7-bbfdb1eb185e.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "As Battle of Hoover Dam enters the battlefield, choose NCR or Legion.\n\u2022 NCR \u2014 At the beginning of your end step, return target creature card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.\n\u2022 Legion \u2014 Whenever a creature you control dies, put two +1/+1 counters on target creature you control.",
             "colours": [
@@ -13443,7 +13443,7 @@
         },
         {
             "id": "0f3293c6-3052-5b7b-83b5-83e5e3d29d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d9b1a8-36c1-48c6-bcfb-d2cc161da584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d9b1a8-36c1-48c6-bcfb-d2cc161da584.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "Metalcraft \u2014 {T}: You get {E}. Activate only if you control three or more artifacts.\nWhenever you get one or more {E} during your turn, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -13482,7 +13482,7 @@
         },
         {
             "id": "64351f3c-4b02-5cd8-89b3-f902c8694658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e8f8c9-7e59-43a3-b8e7-c8515fd4b3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e8f8c9-7e59-43a3-b8e7-c8515fd4b3eb.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "Commanders you control have ward {2}.\n{T}: Add {W}{W}. Spend this mana only to cast Aura and/or Equipment spells.\n{T}: Attach target Aura or Equipment you control to target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -13523,7 +13523,7 @@
         },
         {
             "id": "6257b292-d614-51dd-b9a5-978e84331f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ab676-2437-4927-8f30-dd234298f190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ab676-2437-4927-8f30-dd234298f190.jpg?1",
             "name": "Overencumbered",
             "text": "Enchant opponent\nWhen Overencumbered enters the battlefield, enchanted opponent creates a Clue token, a Food token, and a Junk token.\nAt the beginning of combat on enchanted opponent's turn, that player may pay {1} for each artifact they control. If they don't, creatures can't attack this combat.",
             "colours": [
@@ -13561,7 +13561,7 @@
         },
         {
             "id": "fa797126-7421-5a1b-ac11-fcf75e9d083b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515c4b3-a0af-4c60-aad1-627216f0bdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515c4b3-a0af-4c60-aad1-627216f0bdf7.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "First Contact \u2014 Whenever Overseer of Vault 76 or another creature with power 3 or less enters the battlefield under your control, put a quest counter on Overseer of Vault 76.\nAt the beginning of combat on your turn, you may remove three quest counters from among permanents you control. When you do, put a +1/+1 counter on each creature you control and they gain vigilance until end of turn.",
             "colours": [
@@ -13602,7 +13602,7 @@
         },
         {
             "id": "3b312c13-5373-590c-b30b-f3072a1d30f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f58eb-3cd7-44fa-abf7-6110d3e12407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f58eb-3cd7-44fa-abf7-6110d3e12407.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "When Pre-War Formalwear enters the battlefield, return target creature card with mana value 3 or less from your graveyard to the battlefield and attach Pre-War Formalwear to it.\nEquipped creature gets +2/+2 and has vigilance.\nEquip {3}",
             "colours": [
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "b7e30236-e5e0-5c3f-9785-7b5d06817844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd7f68-4dab-49b3-a151-dec47f5c30b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd7f68-4dab-49b3-a151-dec47f5c30b1.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "Flying\nWhenever another nontoken artifact enters the battlefield under your control, create a 2/2 white Human Knight creature token with \"This creature gets +2/+2 as long as an artifact entered the battlefield under your control this turn.\"\nCrew 2",
             "colours": [
@@ -13680,7 +13680,7 @@
         },
         {
             "id": "8ec4f571-3261-5ce7-9a36-5266fae90ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f5b4d8-1beb-4b74-8279-6bf0eddb6857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f5b4d8-1beb-4b74-8279-6bf0eddb6857.jpg?1",
             "name": "Sentry Bot",
             "text": "Flash\nThis spell costs {1} less to cast for each creature attacking you.\nWhen Sentry Bot enters the battlefield, you get {E} for each creature attacking you.\nAt the beginning of combat on your turn, you may pay {E}{E}{E}. If you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -13719,7 +13719,7 @@
         },
         {
             "id": "7737f69b-3552-5fe7-b856-ddbc98f5e44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9163197-bbe9-44d7-a942-04b88f7c9120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9163197-bbe9-44d7-a942-04b88f7c9120.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "The Nuka-Cola Challenge \u2014 Whenever one or more creatures you control deal combat damage to a player, put a quest counter on Sierra, Nuka's Biggest Fan and create a Food token.\nWhenever you sacrifice a Food, target creature you control gets +X/+X until end of turn, where X is the number of quest counters on Sierra.",
             "colours": [
@@ -13760,7 +13760,7 @@
         },
         {
             "id": "006f095e-96c1-58fb-b745-7990694cadfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac476507-f947-4faf-839e-fe01109c2c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac476507-f947-4faf-839e-fe01109c2c6c.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "{T}: Target opponent gains control of Yes Man, Personal Securitron. When they do, you draw two cards and put a quest counter on Yes Man. Activate only during your turn.\nWild Card \u2014 When Yes Man leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.",
             "colours": [
@@ -13801,7 +13801,7 @@
         },
         {
             "id": "7eff1d33-0c8e-525e-bbfd-ae147d9286bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126e9146-440b-442b-8981-1fcffeef441d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126e9146-440b-442b-8981-1fcffeef441d.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.\n{1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has \"Whenever this creature deals combat damage to a player, draw cards equal to its base power.\"",
             "colours": [
@@ -13842,7 +13842,7 @@
         },
         {
             "id": "a69f917c-cfab-5a30-9982-f8282288efa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "{T}: Add {C}{C}. Spend this mana only to activate abilities.",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "c46cd4f9-0972-538f-afa5-b002115cf9dd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "Investigate X times.",
             "colours": [
@@ -13921,7 +13921,7 @@
         },
         {
             "id": "e7fb51e1-4480-5d60-b79f-680af643e063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4089a153-fdf8-481a-b13d-02aaf6ca1815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4089a153-fdf8-481a-b13d-02aaf6ca1815.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "Whenever a Zombie or Mutant you control dies, if its power was different from its base power, draw a card.\nCome Fly With Me \u2014 {2}, Sacrifice a creature: Put a +1/+1 counter on target creature you control. It gains flying until end of turn.",
             "colours": [
@@ -13963,7 +13963,7 @@
         },
         {
             "id": "e2256950-d91d-5ed6-92fe-dda94abcaa88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54b0f74-f0f5-4753-9f2f-a376b1b0da2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54b0f74-f0f5-4753-9f2f-a376b1b0da2f.jpg?1",
             "name": "Mirelurk Queen",
             "text": "Vigilance\nWhen Mirelurk Queen enters the battlefield, target player gets two rad counters.\nWhenever one or more nonland cards are milled, draw a card, then put a +1/+1 counter on Mirelurk Queen. This ability triggers only once each turn.",
             "colours": [
@@ -14002,7 +14002,7 @@
         },
         {
             "id": "b9aac35f-f907-50a4-99f1-99fa5702e7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd230a2-cbbc-49e1-a57d-7f189ef8d10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd230a2-cbbc-49e1-a57d-7f189ef8d10f.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "Nick Valentine, Private Eye can't be blocked except by artifact creatures.\nWhenever Nick Valentine or another artifact creature you control dies, you may investigate.",
             "colours": [
@@ -14044,7 +14044,7 @@
         },
         {
             "id": "3ca47f48-76a8-5f49-9e7c-d09584f5837f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f00cff-9999-4d81-ac3d-2a74f4ae19e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f00cff-9999-4d81-ac3d-2a74f4ae19e1.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "Whenever Piper Wright deals combat damage to a player, investigate that many times.\nWhenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -14085,7 +14085,7 @@
         },
         {
             "id": "ad69a3d5-cd42-5ebc-b94a-d71c66c23299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae6487-3f00-4dbb-b6ec-4b6b2d090c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae6487-3f00-4dbb-b6ec-4b6b2d090c35.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "As Struggle for Project Purity enters the battlefield, choose Brotherhood or Enclave.\n\u2022 Brotherhood \u2014 At the beginning of your upkeep, each opponent draws a card. You draw a card for each card drawn this way.\n\u2022 Enclave \u2014 Whenever a player attacks you with one or more creatures, that player gets twice that many rad counters.",
             "colours": [
@@ -14121,7 +14121,7 @@
         },
         {
             "id": "46534c1e-6d20-55a9-9bf6-4a4fe7162296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3431ac9-006d-4f19-b933-fcd1dc375ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3431ac9-006d-4f19-b933-fcd1dc375ede.jpg?1",
             "name": "Feral Ghoul",
             "text": "Menace\nWhenever another creature you control dies, put a +1/+1 counter on Feral Ghoul.\nWhen Feral Ghoul dies, each opponent gets a number of rad counters equal to its power.",
             "colours": [
@@ -14160,7 +14160,7 @@
         },
         {
             "id": "6e3db293-aa49-5a4c-acdf-f26302a66a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24419ecc-c740-4972-8510-8fd15a65dd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24419ecc-c740-4972-8510-8fd15a65dd4e.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "Each other creature you control that's a Zombie or Mutant gets +X/+X, where X is the number of counters on Hancock, Ghoulish Mayor.\nUndying",
             "colours": [
@@ -14202,7 +14202,7 @@
         },
         {
             "id": "39bf31d6-f14b-5a98-a4e4-52d5826bb8ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498b0c25-5de1-493d-a328-ccfa4cb1b32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498b0c25-5de1-493d-a328-ccfa4cb1b32f.jpg?1",
             "name": "Wasteland Raider",
             "text": "Squad {2}\nWhen Wasteland Raider enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -14241,7 +14241,7 @@
         },
         {
             "id": "344bc53c-0d8d-5a3e-8f5d-33e1bdf8f2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4ba2a5-102c-49b9-8c1d-e078a7c0d4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4ba2a5-102c-49b9-8c1d-e078a7c0d4c0.jpg?1",
             "name": "Assaultron Dominator",
             "text": "When Assaultron Dominator enters the battlefield, you get {E}{E}.\nWhenever an artifact creature you control attacks, you may pay {E}. If you do, put your choice of a +1/+1, first strike, or trample counter on that creature.",
             "colours": [
@@ -14280,7 +14280,7 @@
         },
         {
             "id": "4aaf3830-dc67-51a1-92bf-71d4f9c2f896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845ee858-bcb9-4a46-aa1a-18e99081a48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845ee858-bcb9-4a46-aa1a-18e99081a48d.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "Hunters for Hire \u2014 Whenever a creature you control deals combat damage to a player, put a quest counter on it.\n{1}, Remove a quest counter from a permanent you control: Create a Junk token.",
             "colours": [
@@ -14321,7 +14321,7 @@
         },
         {
             "id": "d728fbf1-9b29-5726-af44-eb0352c5e558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c775f4f-90a5-413a-9838-c7328f5752dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c775f4f-90a5-413a-9838-c7328f5752dd.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "Morbid \u2014 This spell costs {3} less to cast if a creature died this turn.\nEnchant creature\nWhen Grim Reaper's Sprint enters the battlefield, untap each creature you control. If it's your main phase, there is an additional combat phase after this phase.\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -14359,7 +14359,7 @@
         },
         {
             "id": "e4e7caea-c2c6-57a5-a86a-bbc8af05bbc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e74c30-fcd8-4ee2-87b1-e8b7f3a846d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e74c30-fcd8-4ee2-87b1-e8b7f3a846d0.jpg?1",
             "name": "Junk Jet",
             "text": "When Junk Jet enters the battlefield, create a Junk token.\n{3}, Sacrifice another artifact: Double equipped creature's power until end of turn.\nEquip {1}",
             "colours": [
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "f19802df-eab5-5738-bdff-4ac5e0b9cc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c93a1-3553-4de7-8441-396aa50b26bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c93a1-3553-4de7-8441-396aa50b26bb.jpg?1",
             "name": "Megaton's Fate",
             "text": "Choose one \u2014\n\u2022 Disarm \u2014 Destroy target artifact. Create four Treasure tokens.\n\u2022 Detonate \u2014 Megaton's Fate deals 8 damage to each creature. Each player gets four rad counters.",
             "colours": [
@@ -14433,7 +14433,7 @@
         },
         {
             "id": "22177724-f146-5371-bed0-28fa6fa7cfae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a82f32-24aa-4575-8cae-0301f649d87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a82f32-24aa-4575-8cae-0301f649d87f.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "When The Motherlode, Excavator enters the battlefield, choose target opponent. You get an amount of {E} equal to the number of nonbasic lands that player controls.\nWhenever The Motherlode attacks, you may pay {E}{E}{E}{E}. When you do, destroy target nonbasic land defending player controls, and creatures that player controls without flying can't block this turn.",
             "colours": [
@@ -14474,7 +14474,7 @@
         },
         {
             "id": "679baef9-22d3-5710-b4d1-f5bf1ba89a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b74f6f-be1f-47ef-ae3f-1c7b0138b6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b74f6f-be1f-47ef-ae3f-1c7b0138b6c0.jpg?1",
             "name": "Plasma Caster",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you get {E}{E}.\nPay {E}{E}: Choose target creature that's blocking equipped creature. Flip a coin. If you win the flip, exile the chosen creature. Otherwise, Plasma Caster deals 1 damage to it.\nEquip {2}",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "ccaa04d0-0d3d-5e48-82eb-87c671ee45e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdf49f1-4a49-4ab7-b0fe-d16a846e0a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdf49f1-4a49-4ab7-b0fe-d16a846e0a59.jpg?1",
             "name": "Powder Ganger",
             "text": "Squad {2}\nWhen Powder Ganger enters the battlefield, destroy up to one target artifact.",
             "colours": [
@@ -14551,7 +14551,7 @@
         },
         {
             "id": "d1532472-e81f-572e-9470-fefedc657bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c7391a-77ad-48db-adf1-59d91c0bacac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c7391a-77ad-48db-adf1-59d91c0bacac.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "First strike\nRaid \u2014 At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked.\nWhenever you sacrifice a Junk, add {R}.",
             "colours": [
@@ -14592,7 +14592,7 @@
         },
         {
             "id": "2b585fad-e201-50ef-824b-0d7655e0ed38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ca870a-ebb5-41cb-bd90-39268d6a401f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ca870a-ebb5-41cb-bd90-39268d6a401f.jpg?1",
             "name": "Synth Eradicator",
             "text": "Haste\nWhenever Synth Eradicator attacks, exile the top card of your library. You may get {E}{E}. If you don't, you may play that card this turn.\n{T}, Pay {E}{E}{E}: Synth Eradicator deals 3 damage to any target.",
             "colours": [
@@ -14632,7 +14632,7 @@
         },
         {
             "id": "8e77af0b-e429-5a48-8589-193ad4c26c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8e6169-b36d-44c0-8491-69affc360d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8e6169-b36d-44c0-8491-69affc360d9a.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "Squad\u2014{1}, Discard a card.\nWhen Thrill-Kill Disciple dies, create a Junk token.",
             "colours": [
@@ -14671,7 +14671,7 @@
         },
         {
             "id": "eb99fa97-f622-5933-9874-dfd929820022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21edcd68-dd1e-4705-badb-16ae76945ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21edcd68-dd1e-4705-badb-16ae76945ac9.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "Menace\nWhenever Veronica, Dissident Scribe attacks, you may discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards for the first time each turn, create a Junk token.",
             "colours": [
@@ -14713,7 +14713,7 @@
         },
         {
             "id": "a6782cff-3649-572e-bb8b-1d315a2fff72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f04427-e286-4196-b471-dd368f40d14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f04427-e286-4196-b471-dd368f40d14b.jpg?1",
             "name": "Wild Wasteland",
             "text": "Skip your draw step.\nAt the beginning of your upkeep, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -14749,7 +14749,7 @@
         },
         {
             "id": "ac8ccb70-bd16-54d6-b682-998314cde14e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66faa677-14d5-4a4e-8587-c777f5b55869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66faa677-14d5-4a4e-8587-c777f5b55869.jpg?1",
             "name": "Animal Friend",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 1/1 green Squirrel creature token. Put a +1/+1 counter on that token for each Aura and Equipment attached to this creature other than Animal Friend.\"",
             "colours": [
@@ -14787,7 +14787,7 @@
         },
         {
             "id": "84c769eb-f31b-5e5a-9dea-80d54ff92f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7dc266-d38e-479c-a978-0c4bfd6e7370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7dc266-d38e-479c-a978-0c4bfd6e7370.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "Vigilance, reach\nWhen Harold and Bob, First Numens dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add three mana of any one color. You get two rad counters.'\" Harold and Bob loses all other abilities.",
             "colours": [
@@ -14828,7 +14828,7 @@
         },
         {
             "id": "26a348cb-2206-5351-9ec3-eeb06a3f2ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27fe33-8675-4a36-8c24-873eb5d8bbf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27fe33-8675-4a36-8c24-873eb5d8bbf7.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "Vigilance\nLily Bowen, Raging Grandma enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Lily Bowen if its power is 16 or less. Otherwise, remove all but one +1/+1 counter from it, then you gain 1 life for each +1/+1 counter removed this way.",
             "colours": [
@@ -14869,7 +14869,7 @@
         },
         {
             "id": "8db42aac-fe7f-5bc1-b1d4-abc7d6abab11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05c5af9-67ad-4c20-9d5f-91bda19d5809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05c5af9-67ad-4c20-9d5f-91bda19d5809.jpg?1",
             "name": "Power Fist",
             "text": "Equipped creature has trample and \"Whenever this creature deals combat damage to a player, put that many +1/+1 counters on it.\"\nEquip {2}",
             "colours": [
@@ -14907,7 +14907,7 @@
         },
         {
             "id": "2baf1218-0cc1-53aa-bf8f-98a3ea73248b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f7072a-5627-44e1-99b7-8a7aa228a029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f7072a-5627-44e1-99b7-8a7aa228a029.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "Vigilance, trample\nRampaging Yao Guai enters the battlefield with X +1/+1 counters on it.\nWhen Rampaging Yao Guai enters the battlefield, destroy any number of target artifacts and/or enchantments with total mana value X or less.",
             "colours": [
@@ -14946,7 +14946,7 @@
         },
         {
             "id": "2385a71c-0e94-5ef1-926b-d42576d85a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06833c3e-8447-4900-9196-8a953dab3827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06833c3e-8447-4900-9196-8a953dab3827.jpg?1",
             "name": "Strong Back",
             "text": "Enchant creature\nEquip abilities you activate that target enchanted creature cost {3} less to activate.\nAura spells you cast that target enchanted creature cost {3} less to cast.\nEnchanted creature gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -14984,7 +14984,7 @@
         },
         {
             "id": "f3e1cff3-8f8b-55ef-9e3f-092b547db112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba8a965-7f74-4d78-97a4-1781ebbcb52d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba8a965-7f74-4d78-97a4-1781ebbcb52d.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "Ward {2}\nEnrage \u2014 Whenever Strong is dealt damage, you get three rad counters and put three +1/+1 counters on Strong.\nYou gain life rather than lose life from radiation.",
             "colours": [
@@ -15025,7 +15025,7 @@
         },
         {
             "id": "c8de614e-3146-5f6c-89d4-f254568d1085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aef208-dcd2-4b66-bab2-882e38752ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aef208-dcd2-4b66-bab2-882e38752ab5.jpg?1",
             "name": "Tato Farmer",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may get two rad counters.\n{T}: Put target land card in a graveyard that was milled this turn onto the battlefield under your control tapped.",
             "colours": [
@@ -15065,7 +15065,7 @@
         },
         {
             "id": "8bb9a85c-22c0-50e4-b9e6-81522bb0c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1e4b1-5ebf-47b6-a60b-252f245877a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1e4b1-5ebf-47b6-a60b-252f245877a6.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "Trample\nAgent Frank Horrigan has indestructible as long as it attacked this turn.\nWhenever Agent Frank Horrigan enters the battlefield or attacks, proliferate twice.",
             "colours": [
@@ -15108,7 +15108,7 @@
         },
         {
             "id": "bb145d1f-7e49-5955-bf55-2adbcbe50fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a21ea5c-2e3a-42db-b688-f02f20ff2e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a21ea5c-2e3a-42db-b688-f02f20ff2e02.jpg?1",
             "name": "Almost Perfect",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 9/10 and has indestructible.",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "b2cbde15-8aec-59af-9f99-f10959f96114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987fd451-7276-4cde-a820-a6e55a59b010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987fd451-7276-4cde-a820-a6e55a59b010.jpg?1",
             "name": "Arcade Gannon",
             "text": "{T}: Draw a card, then discard a card. Put a quest counter on Arcade Gannon.\nFor Auld Lang Syne \u2014 Once during each of your turns, you may cast an artifact or Human spell from your graveyard with mana value less than or equal to the number of quest counters on Arcade Gannon.",
             "colours": [
@@ -15191,7 +15191,7 @@
         },
         {
             "id": "3df38d08-c951-5b77-a101-88c8813e1d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e84784-3baf-47da-adcd-4f00b379b278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e84784-3baf-47da-adcd-4f00b379b278.jpg?1",
             "name": "Boomer Scrapper",
             "text": "Whenever Boomer Scrapper enters the battlefield or attacks, you lose 1 life and create a Junk token.\nWhenever a token you control leaves the battlefield, put a +1/+1 counter on Boomer Scrapper.",
             "colours": [
@@ -15232,7 +15232,7 @@
         },
         {
             "id": "9bbd9398-b20b-5ba9-97a3-22a70e807c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a55e3-d231-4c2b-9035-d7835a62e649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a55e3-d231-4c2b-9035-d7835a62e649.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "As long as it's your turn, Cait, Cage Brawler has indestructible.\nWhenever Cait attacks, you and defending player each draw a card, then discard a card. Put two +1/+1 counters on Cait if you discarded the card with the highest mana value among those cards or tied for highest.",
             "colours": [
@@ -15275,7 +15275,7 @@
         },
         {
             "id": "e7f25b52-6dc6-5c30-8b27-7ebe3118a040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6143ede-4613-4f87-b792-e9aa6c19a274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6143ede-4613-4f87-b792-e9aa6c19a274.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "Vigilance\nWhenever Cass or another creature you control dies, if it was enchanted or equipped, return any number of Aura cards that were attached to it from your graveyard to the battlefield attached to target creature, then attach any number of Equipment  that were attached to it to that creature.",
             "colours": [
@@ -15318,7 +15318,7 @@
         },
         {
             "id": "7103f6fd-4712-535a-a60c-218b10b2781f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8333aa-d516-4b5a-bc74-ba81b2826dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8333aa-d516-4b5a-bc74-ba81b2826dfc.jpg?1",
             "name": "Colonel Autumn",
             "text": "Lifelink, exploit\nOther legendary creatures you control have exploit.\nWhenever a creature you control exploits a creature, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -15361,7 +15361,7 @@
         },
         {
             "id": "08be50fc-2649-5b78-ae04-b9db9e4a068c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae8bcf-4c03-477b-aa6c-f94d99676627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae8bcf-4c03-477b-aa6c-f94d99676627.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "Vigilance\nWhenever Desdemona, Freedom's Edge attacks, target creature card in your graveyard that's an artifact or that has mana value 3 or less gains escape until end of turn. The escape cost is equal to its mana cost plus exile two other cards from your graveyard.",
             "colours": [
@@ -15404,7 +15404,7 @@
         },
         {
             "id": "d68370ad-883a-52a3-b3e0-cc6133e87d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0534b7-ed5c-4bed-947e-9ec5ac7e37a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0534b7-ed5c-4bed-947e-9ec5ac7e37a9.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "Creature tokens you control have training.\nBlind Betrayal \u2014 Sacrifice another creature: Elder Arthur Maxson gains indestructible until end of turn.",
             "colours": [
@@ -15447,7 +15447,7 @@
         },
         {
             "id": "22868179-c565-5299-92b4-b6ba62bd0a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af3801-d036-4395-8c39-1f46e7de9b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af3801-d036-4395-8c39-1f46e7de9b7a.jpg?1",
             "name": "Electrosiphon",
             "text": "Counter target spell. You get an amount of {E} equal to its mana value.",
             "colours": [
@@ -15485,7 +15485,7 @@
         },
         {
             "id": "a1ac9e34-68aa-5c25-9267-25ed28236ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8912d8ca-bd08-47e0-aa21-bc9e16c954bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8912d8ca-bd08-47e0-aa21-bc9e16c954bb.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "First strike, haste\nWhenever Kellogg, Dangerous Mind attacks, create a Treasure token.\nSacrifice five Treasures: Gain control of target creature for as long as you control Kellogg. Activate only as a sorcery.",
             "colours": [
@@ -15528,7 +15528,7 @@
         },
         {
             "id": "9f12a3fd-171a-5bd6-89ff-d4b66ba7fe0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ddb442-7006-4e50-a4f5-88e2b8ec2285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ddb442-7006-4e50-a4f5-88e2b8ec2285.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "Vigilance, trample, haste\nWhenever Liberty Prime, Recharged attacks or blocks, sacrifice it unless you pay {E}{E}.\n{2}, {T}, Sacrifice an artifact: You get {E}{E} and draw a card.",
             "colours": [
@@ -15573,7 +15573,7 @@
         },
         {
             "id": "61d404be-7441-5340-ae46-2c90de9aa5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d4a3f9-c73f-4f1e-a9e2-ef4eb7cb1e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d4a3f9-c73f-4f1e-a9e2-ef4eb7cb1e1e.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "Whenever a creature you control with power 2 or less attacks, it gains skulk until end of turn.\nWhenever a creature with power 4 or greater attacks you, its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -15616,7 +15616,7 @@
         },
         {
             "id": "fef718ee-07aa-5e48-8726-beb0539998b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122cbe69-1ea2-4448-94d9-db5119339563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122cbe69-1ea2-4448-94d9-db5119339563.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "Vigilance, trample\nWhenever a creature you control deals combat damage to a player, draw a card if that creature has a +1/+1 counter on it. If it doesn't, put a +1/+1 counter on it.",
             "colours": [
@@ -15659,7 +15659,7 @@
         },
         {
             "id": "9b67a938-eaa5-5886-b301-544fbe12f0ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811876c4-ca77-4fc0-9c05-690da35949ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811876c4-ca77-4fc0-9c05-690da35949ac.jpg?1",
             "name": "The Master, Transcendent",
             "text": "When The Master, Transcendent enters the battlefield, target player gets two rad counters.\n{T}: Put target creature card in a graveyard that was milled this turn onto the battlefield under your control. It's a green Mutant with base power and toughness 3/3.",
             "colours": [
@@ -15704,7 +15704,7 @@
         },
         {
             "id": "68b7fec4-e622-5923-af70-324d0a756ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb999a58-8380-470f-8e0f-2575d089c979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb999a58-8380-470f-8e0f-2575d089c979.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "When Moira Brown, Guide Author enters the battlefield, create a colorless Equipment artifact token named Wasteland Survival Guide with \"Equipped creature gets +1/+1 for each quest counter among permanents you control\" and equip {1}.\nWhenever you attack, put a quest counter on target nonland permanent you control.",
             "colours": [
@@ -15747,7 +15747,7 @@
         },
         {
             "id": "ce321129-9215-54ff-a632-b48dae3d8291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac318a61-40c5-4772-b8a6-6843dfb62ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac318a61-40c5-4772-b8a6-6843dfb62ef4.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "Whenever you roll a 4 or higher, create a 3/3 colorless Robot artifact creature token. If you rolled 6 or higher, instead create that token and a Treasure token.\n{4}, {T}: Roll a six-sided die plus an additional six-sided die for each mana from Treasures spent to activate this ability.",
             "colours": [
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "603bdf15-0fd9-52db-9896-30f8d1528bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c2e0-4881-4651-8550-339a15e7566e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c2e0-4881-4651-8550-339a15e7566e.jpg?1",
             "name": "Mutational Advantage",
             "text": "Permanents you control with counters on them gain hexproof and indestructible until end of turn. Prevent all damage that would be dealt to those permanents this turn. Proliferate.",
             "colours": [
@@ -15830,7 +15830,7 @@
         },
         {
             "id": "de717fb4-3c53-52fe-8e8e-a448c8b59787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5db3b38-9ea2-416f-9d15-47a2b0adf9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5db3b38-9ea2-416f-9d15-47a2b0adf9c3.jpg?1",
             "name": "The Nipton Lottery",
             "text": "Choose a creature at random. You gain control of that creature until end of turn. Untap it. It gains haste until end of turn. Then destroy all other creatures.",
             "colours": [
@@ -15868,7 +15868,7 @@
         },
         {
             "id": "db84ff4b-234e-5b70-95c8-f7d78289e0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7532db9-d064-4406-9e15-40e4f06bafc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7532db9-d064-4406-9e15-40e4f06bafc3.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "Battalion \u2014 Whenever Paladin Elizabeth Taggerdy and at least two other creatures attack, draw a card, then you may put a creature card with mana value X or less from your hand onto the battlefield tapped and attacking, where X is Paladin Elizabeth Taggerdy's power.",
             "colours": [
@@ -15911,7 +15911,7 @@
         },
         {
             "id": "665b02e8-2f82-5d14-a749-43efe8b10faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc4f47f-5847-4edb-8348-cce0b0e00f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc4f47f-5847-4edb-8348-cce0b0e00f09.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "At the beginning of combat on your turn, create a green Aura enchantment token named Settlement attached to up to one target land you control. It has enchant land and \"Enchanted land has \u2018{T}: Add one mana of any color.'\"\nWhenever Preston Garvey, Minuteman attacks, untap each enchanted permanent you control.",
             "colours": [
@@ -15956,7 +15956,7 @@
         },
         {
             "id": "eefaace5-3f12-5742-9775-c1461a71084b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f555f5b-da14-4e81-9afc-60c1ed337062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f555f5b-da14-4e81-9afc-60c1ed337062.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "Alluring Eyes \u2014 {T}: Goad target creature an opponent controls. That player draws a card. You add {R}.",
             "colours": [
@@ -15999,7 +15999,7 @@
         },
         {
             "id": "9a43e74a-5735-5a87-88ae-efd7e4e3655a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4068c6-b95e-4959-9f3c-d43a7f048f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4068c6-b95e-4959-9f3c-d43a7f048f85.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "Whenever Rex, Cyber-Hound deals combat damage to a player, they mill two cards and you get {E}{E}.\nPay {E}{E}: Choose target creature card in a graveyard. Exile it with a brain counter on it. Activate only as a sorcery.\nRex has all activated abilities of all cards in exile with brain counters on them.",
             "colours": [
@@ -16043,7 +16043,7 @@
         },
         {
             "id": "fa67cc91-58c4-59f4-aa65-dc9439eeb448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a54f0-caad-4c9f-8cfa-84702a326017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a54f0-caad-4c9f-8cfa-84702a326017.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "Haste\nAs long as an artifact entered the battlefield under your control this turn, creatures you control get +2/+2.\nBattalion \u2014 Whenever Sentinel Sarah Lyons and at least two other creatures attack, Sentinel Sarah Lyons deals damage equal to the number of artifacts you control to target player.",
             "colours": [
@@ -16086,7 +16086,7 @@
         },
         {
             "id": "1220e39f-aacc-59ce-9132-007a8e095d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a23ad1-e1ce-4aaa-b670-118b351dd970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a23ad1-e1ce-4aaa-b670-118b351dd970.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "Whenever you attack, you may create a tapped and attacking token that's a copy of target attacking legendary creature you control other than Shaun, except it's not legendary and it's a Synth artifact creature in addition to its other types.\nWhen Shaun leaves the battlefield, exile all Synth tokens you control.",
             "colours": [
@@ -16129,7 +16129,7 @@
         },
         {
             "id": "1db58b05-75ee-536e-921d-3b114c6ca610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5a41f-0139-4c9b-94ea-c9d0d5fd6079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5a41f-0139-4c9b-94ea-c9d0d5fd6079.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "Whenever you attack, you may pay {2} and sacrifice an Aura attached to Three Dog, Galaxy News DJ. When you sacrifice an Aura this way, for each other attacking creature you control, create a token that's a copy of that Aura attached to that creature.",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "a2384dbf-d3a6-531d-883d-6df7396a3803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900da9ff-01d5-429e-b11a-48e0dca5df69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900da9ff-01d5-429e-b11a-48e0dca5df69.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "Flying\nBrotherhood Vertibird's power is equal to the number of artifacts you control.\nCrew 2",
             "colours": [],
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "5cf9cbd1-35b7-51d1-805c-7dc487f13b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b643d9-056b-42c2-a9aa-62f584d2e414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b643d9-056b-42c2-a9aa-62f584d2e414.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "Flying\nED-E My Love \u2014 Whenever you attack, if the number of attacking creatures is greater than the number of quest counters on ED-E, Lonesome Eyebot, put a quest counter on it.\n{2}, Sacrifice ED-E: Draw a card, then draw an additional card for each quest counter on ED-E.",
             "colours": [],
@@ -16243,7 +16243,7 @@
         },
         {
             "id": "ef3493d0-9d9b-5747-8252-d1b61e630651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e1ad95-4587-49b0-ac26-ba788b55a847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e1ad95-4587-49b0-ac26-ba788b55a847.jpg?1",
             "name": "Mister Gutsy",
             "text": "Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on Mister Gutsy.\nWhen Mister Gutsy dies, create X Junk tokens, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -16279,7 +16279,7 @@
         },
         {
             "id": "0baa2f21-8c33-5cf7-8f25-df9aa66c7c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d699efaa-4984-4712-8704-c7970cf157af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d699efaa-4984-4712-8704-c7970cf157af.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "Equipped creature gets +3/+0 and has intimidate.\nWhenever equipped creature attacks, until the end of defending player's next turn, that player gets two rad counters whenever they cast a spell.\nEquip {3}",
             "colours": [],
@@ -16313,7 +16313,7 @@
         },
         {
             "id": "87b81481-d965-5462-88ec-3e1532f93f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c1d9b-cb3b-40d7-ba6c-e05ff9762e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c1d9b-cb3b-40d7-ba6c-e05ff9762e2d.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Sort Inventory \u2014 Draw a card, then discard a card.\n\u2022 Pick a Perk \u2014 Put a +1/+1 counter on that creature.\n\u2022 Check Map \u2014 Untap up to two target lands.\nEquip {2}",
             "colours": [],
@@ -16347,7 +16347,7 @@
         },
         {
             "id": "a3ec0eb1-6750-5571-b98f-a32eafed2d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a553d-400b-44c2-bc28-a690765e32c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a553d-400b-44c2-bc28-a690765e32c6.jpg?1",
             "name": "Recon Craft Theta",
             "text": "Flying\nWhen Recon Craft Theta enters the battlefield, create a 0/0 blue Alien creature token. Put a +1/+1 counter on it.\nWhenever Recon Craft Theta attacks, proliferate.\nCrew 2",
             "colours": [],
@@ -16381,7 +16381,7 @@
         },
         {
             "id": "b384d4f4-f1ae-521d-98a3-0fb2cade33fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa426a5-0621-44aa-b053-800c2a33ec19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa426a5-0621-44aa-b053-800c2a33ec19.jpg?1",
             "name": "T-45 Power Armor",
             "text": "When T-45 Power Armor enters the battlefield, you get {E}{E}.\nEquipped creature gets +3/+3 and doesn't untap during its controller's untap step.\nAt the beginning of your upkeep, you may pay {E}. If you do, untap equipped creature, then put your choice of a menace, trample, or lifelink counter on it.\nEquip {3}",
             "colours": [],
@@ -16415,7 +16415,7 @@
         },
         {
             "id": "17936985-4af6-505b-9be9-6875acf3a43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174fb330-e13b-46c1-b9b2-d1cbbe979526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174fb330-e13b-46c1-b9b2-d1cbbe979526.jpg?1",
             "name": "Desolate Mire",
             "text": "{1}, {T}: Add {W}{B}.",
             "colours": [],
@@ -16450,7 +16450,7 @@
         },
         {
             "id": "681db0c5-8d51-5935-9d57-9b9587297c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b04a178-f8bf-4804-a676-8b8f7c569ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b04a178-f8bf-4804-a676-8b8f7c569ab6.jpg?1",
             "name": "Diamond City",
             "text": "Diamond City enters the battlefield with a shield counter on it.\n{T}: Add {C}.\n{T}: Move a shield counter from Diamond City onto target creature. Activate only if two or more creatures entered the battlefield under your control this turn.",
             "colours": [],
@@ -16482,7 +16482,7 @@
         },
         {
             "id": "4a5d19dc-a211-5bf7-b433-4e0aa2582350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac13eb-cff7-4461-b648-4e7ded990994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac13eb-cff7-4461-b648-4e7ded990994.jpg?1",
             "name": "Ferrous Lake",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -16517,7 +16517,7 @@
         },
         {
             "id": "1a4e1a4e-84e1-5972-9a56-7c32d3a6c0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b31d55a-44f3-4745-bc40-1399532d558e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b31d55a-44f3-4745-bc40-1399532d558e.jpg?1",
             "name": "HELIOS One",
             "text": "{T}: Add {C}.\n{1}, {T}: You get {E}.\n{3}, {T}, Pay X {E}, Sacrifice HELIOS One: Destroy target nonland permanent with mana value X. Activate only as a sorcery.",
             "colours": [],
@@ -16549,7 +16549,7 @@
         },
         {
             "id": "0e62c492-4715-582e-b88e-2ff23dc7a184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecd671f-da9e-4f96-8c6f-42382d949dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecd671f-da9e-4f96-8c6f-42382d949dcb.jpg?1",
             "name": "Junktown",
             "text": "{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Junktown: Create three Junk tokens.",
             "colours": [],
@@ -16583,7 +16583,7 @@
         },
         {
             "id": "650ae422-bfa2-5ece-a020-d932d4857c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d50288e-4e68-4d0a-ba5f-efaa48f6e42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d50288e-4e68-4d0a-ba5f-efaa48f6e42c.jpg?1",
             "name": "Mariposa Military Base",
             "text": "You may have Mariposa Military Base enter the battlefield tapped. If you do, you get two rad counters.\n{T}: Add {C}.\n{5}, {T}: Draw a card. This ability costs {1} less to activate for each rad counter you have.",
             "colours": [],
@@ -16615,7 +16615,7 @@
         },
         {
             "id": "3cdb6261-5bf7-594f-921b-707c975fedb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec743e0-f2b6-4f38-a00b-3e6fa01e37ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec743e0-f2b6-4f38-a00b-3e6fa01e37ea.jpg?1",
             "name": "Overflowing Basin",
             "text": "{1}, {T}: Add {G}{U}.",
             "colours": [],
@@ -16650,7 +16650,7 @@
         },
         {
             "id": "31b84978-da52-537c-86da-b379a415ab37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4e4af7-ce45-4f69-9269-e5dac980f0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4e4af7-ce45-4f69-9269-e5dac980f0de.jpg?1",
             "name": "Sunscorched Divide",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -16685,7 +16685,7 @@
         },
         {
             "id": "d97cd595-5c76-5051-9d6d-67c285572381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119f64d-1944-449d-a523-75f083f81940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119f64d-1944-449d-a523-75f083f81940.jpg?1",
             "name": "Viridescent Bog",
             "text": "{1}, {T}: Add {B}{G}.",
             "colours": [],
@@ -16720,7 +16720,7 @@
         },
         {
             "id": "f9d83c02-8bb2-5030-a80d-566b138f419d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df8b22f-f408-49cd-87f8-9614a6ddaaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df8b22f-f408-49cd-87f8-9614a6ddaaa6.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with mana value 3 or less.\n\u2022 Destroy all creatures with mana value 4 or greater.",
             "colours": [
@@ -16756,7 +16756,7 @@
         },
         {
             "id": "e6768a4f-1c51-5e7e-9825-41aa95c0f58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c224e24c-1eb7-4ebc-b2aa-7ae491acc4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c224e24c-1eb7-4ebc-b2aa-7ae491acc4ef.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -16795,7 +16795,7 @@
         },
         {
             "id": "2f5b1403-fc79-5bf2-881b-9a52d2a01f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bde02c-bb78-492e-be37-90a69f054dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bde02c-bb78-492e-be37-90a69f054dcb.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "Target player sacrifices an attacking creature. You create X 1/1 white Soldier creature tokens, where X is that creature's toughness.",
             "colours": [
@@ -16831,7 +16831,7 @@
         },
         {
             "id": "d3f1fcd9-d9f0-5132-b280-5a896a94a05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7647150-24a7-4497-9870-7f0ee6435213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7647150-24a7-4497-9870-7f0ee6435213.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke\nDestroy all nontoken creatures.",
             "colours": [
@@ -16867,7 +16867,7 @@
         },
         {
             "id": "4ba93982-f2d7-5c34-9600-54667b5688ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abfdea-b367-4e96-a435-4a03f6c98c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abfdea-b367-4e96-a435-4a03f6c98c9f.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "30eacdad-03ba-5279-a2c5-1facbfd303ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba58d6cf-ed9c-4a6c-a6f2-4ddeec1ccd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba58d6cf-ed9c-4a6c-a6f2-4ddeec1ccd1a.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "Enchant creature you control\nWhen Mantle of the Ancients enters the battlefield, return any number of target Aura and/or Equipment cards that could be attached to enchanted creature from your graveyard to the battlefield attached to enchanted creature.\nEnchanted creature gets +1/+1 for each Aura and Equipment attached to it.",
             "colours": [
@@ -16944,7 +16944,7 @@
         },
         {
             "id": "5d4ab65d-de45-59b2-b2f9-82a488ea1f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1452097-e584-44d6-bafd-a95265bdbc1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1452097-e584-44d6-bafd-a95265bdbc1a.jpg?1",
             "name": "Marshal's Anthem",
             "text": "Multikicker {1}{W}\nCreatures you control get +1/+1.\nWhen Marshal's Anthem enters the battlefield, return up to X target creature cards from your graveyard to the battlefield, where X is the number of times Marshal's Anthem was kicked.",
             "colours": [
@@ -16980,7 +16980,7 @@
         },
         {
             "id": "12fce191-0c6a-57e4-a497-704c33ce8897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2eb4f30-bb11-487c-95b0-24077569fc37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2eb4f30-bb11-487c-95b0-24077569fc37.jpg?1",
             "name": "Martial Coup",
             "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -17016,7 +17016,7 @@
         },
         {
             "id": "4499b2f8-5024-5cb8-ada2-c5d60b7529b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dc9868-af65-44f3-872f-4157cded5ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dc9868-af65-44f3-872f-4157cded5ac9.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control.",
             "colours": [
@@ -17052,7 +17052,7 @@
         },
         {
             "id": "75a43812-893a-5da7-8c67-fbe7bd6e2bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b5529-b70f-4d61-b98f-e7936683d3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b5529-b70f-4d61-b98f-e7936683d3ad.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -17091,7 +17091,7 @@
         },
         {
             "id": "6c25c33a-65d2-58d2-9b6f-64771e5fd5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fb73c4-be61-4e9b-995f-05e02d6c69d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fb73c4-be61-4e9b-995f-05e02d6c69d0.jpg?1",
             "name": "Secure the Wastes",
             "text": "Create X 1/1 white Warrior creature tokens.",
             "colours": [
@@ -17127,7 +17127,7 @@
         },
         {
             "id": "682b8071-9c75-5dd6-b408-914a2155e4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bd5046-39ed-46df-851f-622e07302c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bd5046-39ed-46df-851f-622e07302c5c.jpg?1",
             "name": "Single Combat",
             "text": "Each player chooses a creature or planeswalker they control, then sacrifices the rest. Players can't cast creature or planeswalker spells until the end of your next turn.",
             "colours": [
@@ -17163,7 +17163,7 @@
         },
         {
             "id": "3c0ca2a8-26e8-5e8d-ab29-06efb72382e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0756c6-7db8-4333-b828-4df4c0298b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0756c6-7db8-4333-b828-4df4c0298b5c.jpg?1",
             "name": "Fraying Sanity",
             "text": "Enchant player\nAt the beginning of each end step, enchanted player mills X cards, where X is the number of cards put into their graveyard from anywhere this turn.",
             "colours": [
@@ -17202,7 +17202,7 @@
         },
         {
             "id": "76906a87-58b9-501e-9491-7bcd48ae9b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0436cf2-a48d-46e1-bf60-537c199be370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0436cf2-a48d-46e1-bf60-537c199be370.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate.",
             "colours": [
@@ -17238,7 +17238,7 @@
         },
         {
             "id": "adecb634-3b60-5eba-a5c2-a0604538a410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c37cc19-11f0-4deb-91b4-c61d95f85ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c37cc19-11f0-4deb-91b4-c61d95f85ed8.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -17276,7 +17276,7 @@
         },
         {
             "id": "1efd0991-6e8f-50d6-999f-63d10b1e2d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd47a-a2f8-4618-a326-bee7f8260343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd47a-a2f8-4618-a326-bee7f8260343.jpg?1",
             "name": "One with the Machine",
             "text": "Draw cards equal to the highest mana value among artifacts you control.",
             "colours": [
@@ -17312,7 +17312,7 @@
         },
         {
             "id": "45044e06-bd47-51cb-94c7-26dea9b08e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec25793-fb7e-4f94-a5fb-08f683602c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec25793-fb7e-4f94-a5fb-08f683602c0b.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -17348,7 +17348,7 @@
         },
         {
             "id": "90c5d827-8064-5a77-b243-85893696ff1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7c7321-9d14-4940-8d59-4ffc7abdab07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7c7321-9d14-4940-8d59-4ffc7abdab07.jpg?1",
             "name": "Lethal Scheme",
             "text": "Convoke\nDestroy target creature or planeswalker. Each creature that convoked Lethal Scheme connives.",
             "colours": [
@@ -17384,7 +17384,7 @@
         },
         {
             "id": "cf23e202-df82-58eb-9ce5-731e92c2b614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dab546-6392-40cd-bcdd-14952b458e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dab546-6392-40cd-bcdd-14952b458e5e.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -17420,7 +17420,7 @@
         },
         {
             "id": "98f53db1-2ece-5ddf-b4c0-716d9c13cc40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ea9180-2a4a-4c69-848e-002cf2ccf921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ea9180-2a4a-4c69-848e-002cf2ccf921.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -17456,7 +17456,7 @@
         },
         {
             "id": "ac509f3a-0f18-5534-9634-19d3ae614bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3676db-0f8f-41ee-b178-058930c962bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3676db-0f8f-41ee-b178-058930c962bf.jpg?1",
             "name": "Stolen Strategy",
             "text": "At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -17492,7 +17492,7 @@
         },
         {
             "id": "6cc26ae5-f658-5e53-beec-5381ae773a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3544398-02fc-4fc1-ba72-65a00f14aeb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3544398-02fc-4fc1-ba72-65a00f14aeb9.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -17528,7 +17528,7 @@
         },
         {
             "id": "3b9f03f0-23e8-5a85-b52d-125cf32264ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaed17fa-09ed-47d9-a310-94c4a894b992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaed17fa-09ed-47d9-a310-94c4a894b992.jpg?1",
             "name": "Guardian Project",
             "text": "Whenever a nontoken creature enters the battlefield under your control, if it doesn't have the same name as another creature you control or a creature card in your graveyard, draw a card.",
             "colours": [
@@ -17564,7 +17564,7 @@
         },
         {
             "id": "5b0f010f-0bd3-5f91-a932-fc21c7da4373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ae7868-0cb3-427c-93c4-16bf35ac0a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ae7868-0cb3-427c-93c4-16bf35ac0a6f.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -17600,7 +17600,7 @@
         },
         {
             "id": "3472f668-307f-5de7-bfd7-c41c6db01b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f9fb7-e881-4f54-bcb0-833fd11bcae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f9fb7-e881-4f54-bcb0-833fd11bcae2.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -17636,7 +17636,7 @@
         },
         {
             "id": "c03ef367-eeba-55bf-b3c4-f48098beead8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ba9f4-4aca-46a6-89f7-9b7d8299c68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ba9f4-4aca-46a6-89f7-9b7d8299c68e.jpg?1",
             "name": "Tireless Tracker",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, investigate.\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.",
             "colours": [
@@ -17675,7 +17675,7 @@
         },
         {
             "id": "e224ece2-35ad-5ed7-bdfb-078912fd472e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0ac04a-54c6-48cd-b449-38c1f0d752f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0ac04a-54c6-48cd-b449-38c1f0d752f0.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -17713,7 +17713,7 @@
         },
         {
             "id": "f7a8a822-1c90-567f-9c76-c11e64bd25b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea53937-7fe9-46bd-8956-5238788bbbe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea53937-7fe9-46bd-8956-5238788bbbe9.jpg?1",
             "name": "Assemble the Legion",
             "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then create a 1/1 red and white Soldier creature token with haste for each muster counter on Assemble the Legion.",
             "colours": [
@@ -17751,7 +17751,7 @@
         },
         {
             "id": "e6c5b0bf-3766-5a95-aa4a-7e89f6e16a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697ec02-5056-41ce-b35e-36e3ce2caa06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697ec02-5056-41ce-b35e-36e3ce2caa06.jpg?1",
             "name": "Biomass Mutation",
             "text": "Creatures you control have base power and toughness X/X until end of turn.",
             "colours": [
@@ -17789,7 +17789,7 @@
         },
         {
             "id": "667c3b7f-2e4d-5968-93bb-c3bc339133ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d5d867-8c79-4226-bf97-2b185b3b056e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d5d867-8c79-4226-bf97-2b185b3b056e.jpg?1",
             "name": "Casualties of War",
             "text": "Choose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature.\n\u2022 Destroy target enchantment.\n\u2022 Destroy target land.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -17827,7 +17827,7 @@
         },
         {
             "id": "0c6a56e5-427f-5bbf-8320-ff62c3e994e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64cd0a6-401b-4281-a7e0-ed7059e5596c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64cd0a6-401b-4281-a7e0-ed7059e5596c.jpg?1",
             "name": "Fervent Charge",
             "text": "Whenever a creature you control attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -17867,7 +17867,7 @@
         },
         {
             "id": "ad3afc55-5d5d-5622-9731-f74608e1d424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3dbc470-4580-4672-910b-9ef96910d7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3dbc470-4580-4672-910b-9ef96910d7ae.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "Destroy all nonland permanents your opponents control.",
             "colours": [
@@ -17907,7 +17907,7 @@
         },
         {
             "id": "b6136e0f-1aa5-5e21-bc35-487848d70678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72281f40-7f62-496d-b4b7-3ba1bcbe820e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72281f40-7f62-496d-b4b7-3ba1bcbe820e.jpg?1",
             "name": "Wake the Past",
             "text": "Return all artifact cards from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -17945,7 +17945,7 @@
         },
         {
             "id": "04bb2238-8722-58f9-a8ae-b31d609c2807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e2248-a9cf-4d8e-bfb9-04b6fc067387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e2248-a9cf-4d8e-bfb9-04b6fc067387.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -17979,7 +17979,7 @@
         },
         {
             "id": "63c51a7a-2ddb-573e-80d7-db1165c74b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75efaf-34d9-4ea1-979d-afa95f4cdcb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75efaf-34d9-4ea1-979d-afa95f4cdcb8.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -18013,7 +18013,7 @@
         },
         {
             "id": "4469d38b-6edd-51bf-b014-a080ca435038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509384-6db1-4dca-8ddf-b2a03a56c310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509384-6db1-4dca-8ddf-b2a03a56c310.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -18047,7 +18047,7 @@
         },
         {
             "id": "02260682-48d6-5d3b-aad8-ee42633eeb1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176fc61-cb23-41c4-8f9b-84ff10b9b4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176fc61-cb23-41c4-8f9b-84ff10b9b4e0.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "You may have Masterwork of Ingenuity enter the battlefield as a copy of any Equipment on the battlefield.",
             "colours": [],
@@ -18081,7 +18081,7 @@
         },
         {
             "id": "dfa72bf8-0bb2-5ae2-ac2f-53a42106dcf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f596ee-b551-411f-a460-bfffa89e358e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f596ee-b551-411f-a460-bfffa89e358e.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast artifact spells and colorless spells from the top of your library.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -18113,7 +18113,7 @@
         },
         {
             "id": "ea5ad61e-cdfb-55f2-9ed1-6d0408a4fa4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8eff48e-6a3d-4c30-ba14-c6ccbc765ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8eff48e-6a3d-4c30-ba14-c6ccbc765ce0.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -18145,7 +18145,7 @@
         },
         {
             "id": "4c42eb7d-940d-5d29-909e-55f713a6371d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1c2df-05dd-4a25-9126-1aa952864fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1c2df-05dd-4a25-9126-1aa952864fb9.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -18180,7 +18180,7 @@
         },
         {
             "id": "4b365d30-f0d6-5817-ab2e-06f082bbe107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cace8d-3618-4c10-b59e-dbb51fb46ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cace8d-3618-4c10-b59e-dbb51fb46ad5.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -18215,7 +18215,7 @@
         },
         {
             "id": "150a00e4-01a0-5c1a-b083-ce4db3a65611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8510d85-e078-471e-a3dc-2720eb4f3bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8510d85-e078-471e-a3dc-2720eb4f3bab.jpg?1",
             "name": "Canopy Vista",
             "text": "Canopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -18253,7 +18253,7 @@
         },
         {
             "id": "c6f8ab6e-d516-5611-8f5c-ac9a4e376883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a42f03-b1da-459a-9444-cf6935276841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a42f03-b1da-459a-9444-cf6935276841.jpg?1",
             "name": "Canyon Slough",
             "text": "Canyon Slough enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18291,7 +18291,7 @@
         },
         {
             "id": "ba97b1cd-b596-5dfe-9446-e378b74e8660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d03315-1eaf-41fe-beaf-3269167a89ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d03315-1eaf-41fe-beaf-3269167a89ad.jpg?1",
             "name": "Cinder Glade",
             "text": "Cinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -18329,7 +18329,7 @@
         },
         {
             "id": "f688546e-70a5-5ff5-a776-1c6e43d76204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90316ec8-9e36-4abd-bf89-47227e58953a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90316ec8-9e36-4abd-bf89-47227e58953a.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -18364,7 +18364,7 @@
         },
         {
             "id": "b98cd7f2-dd9d-565d-82b9-475e1cfc16da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c4a65-9fe1-4f08-89a8-942c55da4929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c4a65-9fe1-4f08-89a8-942c55da4929.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -18399,7 +18399,7 @@
         },
         {
             "id": "c8743336-a507-500a-957f-6a3fc747b7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119b5bb5-6de4-4a66-ba22-14e19d02942f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119b5bb5-6de4-4a66-ba22-14e19d02942f.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -18434,7 +18434,7 @@
         },
         {
             "id": "0819a244-6a88-56cb-b1d7-9d34a1a068e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301ab57-e06e-4965-8182-a048fc98a01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301ab57-e06e-4965-8182-a048fc98a01e.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -18469,7 +18469,7 @@
         },
         {
             "id": "c3fd4b9a-7d7d-5153-8d73-71f7ad8df4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536e502-30c1-4107-aaec-1690cfa78ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536e502-30c1-4107-aaec-1690cfa78ce8.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -18501,7 +18501,7 @@
         },
         {
             "id": "45dedc3c-538d-518f-833f-47984bc0d46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d5841a-52b4-4a29-a929-2b0e7a1395c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d5841a-52b4-4a29-a929-2b0e7a1395c0.jpg?1",
             "name": "Fetid Pools",
             "text": "Fetid Pools enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18539,7 +18539,7 @@
         },
         {
             "id": "e19f7de1-b523-55dd-bef9-649bd9b32ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73ef22-e219-4b4c-8ff3-c0cfce8e6fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73ef22-e219-4b4c-8ff3-c0cfce8e6fd9.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -18574,7 +18574,7 @@
         },
         {
             "id": "17814f1e-0368-59fc-90ca-e63662ea8573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99085218-b635-47b3-9f0d-211feb70faa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99085218-b635-47b3-9f0d-211feb70faa1.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -18609,7 +18609,7 @@
         },
         {
             "id": "f9caea59-7e29-5c17-ba3b-ffa5612e3c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff76774-678f-41ac-9601-d5d8c4096234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff76774-678f-41ac-9601-d5d8c4096234.jpg?1",
             "name": "Irrigated Farmland",
             "text": "Irrigated Farmland enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18647,7 +18647,7 @@
         },
         {
             "id": "94362b63-0150-5ca6-9602-46670a90d82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f947e35-b994-4eb3-886e-f767f9542298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f947e35-b994-4eb3-886e-f767f9542298.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -18682,7 +18682,7 @@
         },
         {
             "id": "51649504-bdfc-507e-b8c1-adbc9f7d50ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090cecfe-bf79-4547-965b-3567783e7d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090cecfe-bf79-4547-965b-3567783e7d11.jpg?1",
             "name": "Mossfire Valley",
             "text": "{1}, {T}: Add {R}{G}.",
             "colours": [],
@@ -18717,7 +18717,7 @@
         },
         {
             "id": "98062036-5a92-5e07-9c0c-5476d7f41734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39f4c02-0879-4793-b1cf-95165d2f73bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39f4c02-0879-4793-b1cf-95165d2f73bf.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -18749,7 +18749,7 @@
         },
         {
             "id": "ad520adc-83b3-53e3-b059-6d2f75a0628d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a75617-f7d6-44fd-a294-74efd9e0d219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a75617-f7d6-44fd-a294-74efd9e0d219.jpg?1",
             "name": "Prairie Stream",
             "text": "Prairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -18787,7 +18787,7 @@
         },
         {
             "id": "8b900a81-907e-5651-8874-f41fa1d3be02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e3078-eb36-4125-9511-1f542a2af740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e3078-eb36-4125-9511-1f542a2af740.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -18822,7 +18822,7 @@
         },
         {
             "id": "9d03c347-9910-5f87-8760-ef4088e20556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab57258f-60c3-46f8-af50-64a7165974e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab57258f-60c3-46f8-af50-64a7165974e6.jpg?1",
             "name": "Scattered Groves",
             "text": "Scattered Groves enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18860,7 +18860,7 @@
         },
         {
             "id": "bb12bfeb-b85f-58d8-8f16-07ad07a2db22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4759d1a6-2cb3-4bab-b001-6798be2c589b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4759d1a6-2cb3-4bab-b001-6798be2c589b.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all graveyards.",
             "colours": [],
@@ -18894,7 +18894,7 @@
         },
         {
             "id": "3d80ea1a-133b-5e46-9a1f-bf3b8313fd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533d161c-a0a1-460f-b658-87bc268a713a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533d161c-a0a1-460f-b658-87bc268a713a.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "{1}, {T}: Add {B}{R}.",
             "colours": [],
@@ -18929,7 +18929,7 @@
         },
         {
             "id": "4d2d35eb-a1d8-519b-9893-c95be7c72fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684058fa-ceef-41e7-abb5-23571ea07cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684058fa-ceef-41e7-abb5-23571ea07cc7.jpg?1",
             "name": "Sheltered Thicket",
             "text": "Sheltered Thicket enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18967,7 +18967,7 @@
         },
         {
             "id": "f2e90245-8815-57e1-883c-ee7bee16a1c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261c9330-1d31-450b-b4c0-16e2581b8c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261c9330-1d31-450b-b4c0-16e2581b8c9b.jpg?1",
             "name": "Skycloud Expanse",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -19002,7 +19002,7 @@
         },
         {
             "id": "fda711a3-0e4a-59b6-9451-e655fb612799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b6f3d8-59c6-45dd-bc50-9ae4982e1ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b6f3d8-59c6-45dd-bc50-9ae4982e1ef9.jpg?1",
             "name": "Smoldering Marsh",
             "text": "Smoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -19040,7 +19040,7 @@
         },
         {
             "id": "89fc7bc3-c6f4-5fab-a5de-02137553cac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e62a9d-67db-4ffa-ab08-3305e52f9362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e62a9d-67db-4ffa-ab08-3305e52f9362.jpg?1",
             "name": "Spire of Industry",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Activate only if you control an artifact.",
             "colours": [],
@@ -19072,7 +19072,7 @@
         },
         {
             "id": "dce22fd6-50c1-55a7-8529-ff5d25d933a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe65f24-3621-4139-b1cd-3343ae2d0119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe65f24-3621-4139-b1cd-3343ae2d0119.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -19107,7 +19107,7 @@
         },
         {
             "id": "9f4911bb-2986-507b-947f-cb6b09be3f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3e41ad-c901-412c-9e05-1b43d062ed66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3e41ad-c901-412c-9e05-1b43d062ed66.jpg?1",
             "name": "Sungrass Prairie",
             "text": "{1}, {T}: Add {G}{W}.",
             "colours": [],
@@ -19142,7 +19142,7 @@
         },
         {
             "id": "4385211a-99fe-50cf-82cb-df6381c4a563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c64bef5-67c2-4f8c-bc6d-0528650c5b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c64bef5-67c2-4f8c-bc6d-0528650c5b3a.jpg?1",
             "name": "Sunken Hollow",
             "text": "Sunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -19180,7 +19180,7 @@
         },
         {
             "id": "6baa1f01-7d47-5d5b-b65e-d372f20c1779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8065c0-5286-4448-8fd5-07f2719c5218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8065c0-5286-4448-8fd5-07f2719c5218.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -19215,7 +19215,7 @@
         },
         {
             "id": "ea77531f-dd52-56d0-b7bf-243008186064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef9db60-85d6-4008-9224-37caa5efb63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef9db60-85d6-4008-9224-37caa5efb63d.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -19250,7 +19250,7 @@
         },
         {
             "id": "a1d11de4-46b1-583d-b3f4-3b570fe2ebc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69598022-4ff6-42bc-a9b5-530803c841cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69598022-4ff6-42bc-a9b5-530803c841cc.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -19285,7 +19285,7 @@
         },
         {
             "id": "16233a61-35be-53c7-83ba-007f4abf5eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931f17f4-3fd4-45c4-b6e1-c9dee7e8f4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931f17f4-3fd4-45c4-b6e1-c9dee7e8f4b1.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -19320,7 +19320,7 @@
         },
         {
             "id": "cf857115-9181-5631-bb9a-5f7224486a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b523ff-386a-42a9-a8b5-f18e5f4cca53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b523ff-386a-42a9-a8b5-f18e5f4cca53.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -19355,7 +19355,7 @@
         },
         {
             "id": "28ea9906-fad0-5539-9fd2-51fb1207edfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e0586-d48e-4d0a-ac3b-870d605b8934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e0586-d48e-4d0a-ac3b-870d605b8934.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -19390,7 +19390,7 @@
         },
         {
             "id": "7ef12029-84f1-54d0-a368-b0b21b9180de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d8a4eb-794c-49d1-bdd8-efc23932c6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d8a4eb-794c-49d1-bdd8-efc23932c6fa.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -19425,7 +19425,7 @@
         },
         {
             "id": "9a7e5c29-2852-5a17-a4c9-431312fa67bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c038eb3-5b72-4120-a60a-5c43020934ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c038eb3-5b72-4120-a60a-5c43020934ac.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -19460,7 +19460,7 @@
         },
         {
             "id": "806141ed-3625-5b49-997b-e5c388c87408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd2f0f6-9e7b-4401-a760-0285b999365c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd2f0f6-9e7b-4401-a760-0285b999365c.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -19495,7 +19495,7 @@
         },
         {
             "id": "99e5f23b-0259-5d0a-bec7-35d72b59c157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e505c0cc-eab3-4ee8-a659-73d6ccf075e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e505c0cc-eab3-4ee8-a659-73d6ccf075e7.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -19530,7 +19530,7 @@
         },
         {
             "id": "ddc497c1-4bb8-5cec-87ae-afa4fee97e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36d0f53-faee-40ba-8f91-8e96549af4ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36d0f53-faee-40ba-8f91-8e96549af4ad.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -19565,7 +19565,7 @@
         },
         {
             "id": "b36998fd-a9cb-5322-9b13-0301b6141074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb08369-1e4d-4182-9978-808cc9b79a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb08369-1e4d-4182-9978-808cc9b79a40.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -19598,7 +19598,7 @@
         },
         {
             "id": "586e6593-5662-5d38-b8f4-349a1592f07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b46df-c3ff-432f-9960-30451d5f60fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b46df-c3ff-432f-9960-30451d5f60fa.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway 4\nWindbrisk Heights enters the battlefield tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -19632,7 +19632,7 @@
         },
         {
             "id": "20dd0b5d-07e2-5661-a9bb-6d978afe42ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e193aa3b-5db3-4c71-bc38-8834e62f5a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e193aa3b-5db3-4c71-bc38-8834e62f5a05.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -19667,7 +19667,7 @@
         },
         {
             "id": "c0513aec-ae17-5bca-825a-816ba32ed2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca55a2-2824-41b7-8ce7-596ae028a5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca55a2-2824-41b7-8ce7-596ae028a5b2.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "",
             "colours": [
@@ -19712,7 +19712,7 @@
         },
         {
             "id": "6f585a57-fc5a-567e-8a5e-5f1b35ff4188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dae1fc-804c-499f-b3cd-1a5f3f25c1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dae1fc-804c-499f-b3cd-1a5f3f25c1ce.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "",
             "colours": [
@@ -19756,7 +19756,7 @@
         },
         {
             "id": "06ffa86a-1497-5f85-981c-a59bd0fd4ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b582ba-5216-48d7-9306-5c717e81c9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b582ba-5216-48d7-9306-5c717e81c9b8.jpg?1",
             "name": "Dr. Madison Li",
             "text": "",
             "colours": [
@@ -19801,7 +19801,7 @@
         },
         {
             "id": "185aef00-a64d-52e8-b9a2-6798f7e778e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a1d611-6f5f-40af-8ca3-b9dc619111eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a1d611-6f5f-40af-8ca3-b9dc619111eb.jpg?1",
             "name": "The Wise Mothman",
             "text": "",
             "colours": [
@@ -19846,7 +19846,7 @@
         },
         {
             "id": "ae250338-ea02-5492-b23a-2a6f8fefd994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7f0363-bf56-48fb-9cf9-68b7e8888ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7f0363-bf56-48fb-9cf9-68b7e8888ce3.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "",
             "colours": [
@@ -19890,7 +19890,7 @@
         },
         {
             "id": "230153d7-f9bb-5b3e-8fde-3858e4d6244c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21707502-8edf-4c0c-9df3-55f843d45256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21707502-8edf-4c0c-9df3-55f843d45256.jpg?1",
             "name": "The Master, Transcendent",
             "text": "",
             "colours": [
@@ -19934,7 +19934,7 @@
         },
         {
             "id": "d26b27c4-3706-59d0-a1ca-ae8a2b9a26d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000f379-bfd6-4d6c-bd8c-82bc0e13caa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000f379-bfd6-4d6c-bd8c-82bc0e13caa6.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "",
             "colours": [
@@ -19978,7 +19978,7 @@
         },
         {
             "id": "0a637d38-417c-5e0d-868e-1b15966b1c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc78029-39a6-489d-9571-5ae8d90893e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc78029-39a6-489d-9571-5ae8d90893e3.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "",
             "colours": [
@@ -20022,7 +20022,7 @@
         },
         {
             "id": "05c27681-ad35-5d5c-9509-365a296b70be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c569396f-99cf-44c5-bb64-f59a4891efd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c569396f-99cf-44c5-bb64-f59a4891efd1.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "",
             "colours": [
@@ -20062,7 +20062,7 @@
         },
         {
             "id": "00fc9193-af3c-523d-95de-85dd8d94094e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f9180-9cb5-4b0c-8e51-b7080c4d1184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f9180-9cb5-4b0c-8e51-b7080c4d1184.jpg?1",
             "name": "Automated Assembly Line",
             "text": "",
             "colours": [
@@ -20097,7 +20097,7 @@
         },
         {
             "id": "e7004cda-fb4b-5296-bf6e-92ef9af7d4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883efc5f-be03-4cca-8a26-8223d22f33f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883efc5f-be03-4cca-8a26-8223d22f33f3.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "",
             "colours": [
@@ -20132,7 +20132,7 @@
         },
         {
             "id": "8af35dcd-1e67-54b0-853b-f88d26f400ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0949fcab-5aa2-4277-bf4d-f5855a863cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0949fcab-5aa2-4277-bf4d-f5855a863cb6.jpg?1",
             "name": "Brotherhood Outcast",
             "text": "",
             "colours": [
@@ -20168,7 +20168,7 @@
         },
         {
             "id": "5f03b20a-89d1-5842-a934-354a39d6bc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147ba707-c8ef-45ef-ba9e-dff954f6fe98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147ba707-c8ef-45ef-ba9e-dff954f6fe98.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "",
             "colours": [
@@ -20206,7 +20206,7 @@
         },
         {
             "id": "23a6937b-18b8-5e71-8a2a-0ed9849e3b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a56b5c-1aea-4f05-80eb-891249bec62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a56b5c-1aea-4f05-80eb-891249bec62a.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "",
             "colours": [
@@ -20246,7 +20246,7 @@
         },
         {
             "id": "a1571cf5-e1d4-5def-ab03-910f66ff9f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63259e39-7267-465e-8600-9104c34bfcba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63259e39-7267-465e-8600-9104c34bfcba.jpg?1",
             "name": "Commander Sofia Daguerre",
             "text": "",
             "colours": [
@@ -20284,7 +20284,7 @@
         },
         {
             "id": "4f63bc96-a9fa-5eb1-a48d-b23ccc8af850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d130be-bda5-4ceb-b434-73d1aae9dcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d130be-bda5-4ceb-b434-73d1aae9dcb0.jpg?1",
             "name": "Gary Clone",
             "text": "",
             "colours": [
@@ -20320,7 +20320,7 @@
         },
         {
             "id": "90f232a5-4ae1-5d17-9849-73394574c958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427cdbb-887c-492f-8bab-6002351d1e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427cdbb-887c-492f-8bab-6002351d1e68.jpg?1",
             "name": "Idolized",
             "text": "",
             "colours": [
@@ -20357,7 +20357,7 @@
         },
         {
             "id": "3e43ab20-60bb-52f1-9029-4faed266eb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a36e45-3da1-4330-a0a2-b68be3a42478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a36e45-3da1-4330-a0a2-b68be3a42478.jpg?1",
             "name": "Overencumbered",
             "text": "",
             "colours": [
@@ -20394,7 +20394,7 @@
         },
         {
             "id": "bca6ecf7-f608-5239-9aeb-0a6dee8347d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf809b-b6e2-4513-9865-228679b9de43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf809b-b6e2-4513-9865-228679b9de43.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "",
             "colours": [
@@ -20434,7 +20434,7 @@
         },
         {
             "id": "0de78894-e014-55ed-a9bc-448ede4d0964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05d535-e457-40f1-8496-9a38e7023ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05d535-e457-40f1-8496-9a38e7023ce4.jpg?1",
             "name": "Paladin Danse, Steel Maverick",
             "text": "",
             "colours": [
@@ -20473,7 +20473,7 @@
         },
         {
             "id": "4bd14744-9a19-53f3-8236-8ece2dcb436e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461e2ddb-1d1f-4ac3-ae06-dc2f613e8564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461e2ddb-1d1f-4ac3-ae06-dc2f613e8564.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "",
             "colours": [
@@ -20510,7 +20510,7 @@
         },
         {
             "id": "70c71b7e-9cf0-56d0-80b1-18aab47f82db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a4d4fb-d55f-4a75-94bc-e5e27cc443a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a4d4fb-d55f-4a75-94bc-e5e27cc443a6.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "",
             "colours": [
@@ -20549,7 +20549,7 @@
         },
         {
             "id": "3a10d1b5-50cc-53ac-b43f-00edf28d6c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eee88d-9866-4fc3-8d7e-5f9f364af482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eee88d-9866-4fc3-8d7e-5f9f364af482.jpg?1",
             "name": "Securitron Squadron",
             "text": "",
             "colours": [
@@ -20587,7 +20587,7 @@
         },
         {
             "id": "205872d4-fe96-5530-82ec-5683180910af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2cac9-e3b7-4cdf-9d61-3970bef64a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2cac9-e3b7-4cdf-9d61-3970bef64a08.jpg?1",
             "name": "Sentry Bot",
             "text": "",
             "colours": [
@@ -20625,7 +20625,7 @@
         },
         {
             "id": "73a256e7-c75e-55e8-b095-31233f5126b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b28085-0274-457b-955f-a853f8c6ccba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b28085-0274-457b-955f-a853f8c6ccba.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "",
             "colours": [
@@ -20665,7 +20665,7 @@
         },
         {
             "id": "404128a3-313d-5d26-a7f9-0e21f6fb9a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e537f1ab-8c76-436a-8928-8acccf8d00e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e537f1ab-8c76-436a-8928-8acccf8d00e6.jpg?1",
             "name": "Vault 13: Dweller's Journey",
             "text": "",
             "colours": [
@@ -20700,7 +20700,7 @@
         },
         {
             "id": "0dc16263-717d-5fa4-9d03-446c2e46024d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77cb40e-1feb-49e5-ac56-d0f9df321480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77cb40e-1feb-49e5-ac56-d0f9df321480.jpg?1",
             "name": "Vault 75: Middle School",
             "text": "",
             "colours": [
@@ -20735,7 +20735,7 @@
         },
         {
             "id": "c34e9ccc-3ff3-536e-8323-85efdc5cf924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741caee0-03c7-4b72-8f71-234e66eb6609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741caee0-03c7-4b72-8f71-234e66eb6609.jpg?1",
             "name": "Vault 101: Birthday Party",
             "text": "",
             "colours": [
@@ -20770,7 +20770,7 @@
         },
         {
             "id": "b410135e-43bc-5da2-9adf-04e7184e5940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882551c2-c891-4a66-aac7-08612c9fc416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882551c2-c891-4a66-aac7-08612c9fc416.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "",
             "colours": [
@@ -20810,7 +20810,7 @@
         },
         {
             "id": "b6e87977-fd7e-5de0-a29d-c596f967ffaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7fce3a-1432-4b96-8bf0-34cbe3cea39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7fce3a-1432-4b96-8bf0-34cbe3cea39b.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "",
             "colours": [
@@ -20850,7 +20850,7 @@
         },
         {
             "id": "17fef03f-7628-5eb1-bc23-d8f3a7a9423a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -20890,7 +20890,7 @@
         },
         {
             "id": "1843601c-b046-522a-8e32-b971c0a1ccc6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -20927,7 +20927,7 @@
         },
         {
             "id": "4112d4eb-9a15-5339-82ba-8b44fcdbdf47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b8573d-1e31-4af8-846f-ea895f039a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b8573d-1e31-4af8-846f-ea895f039a42.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "",
             "colours": [
@@ -20968,7 +20968,7 @@
         },
         {
             "id": "d6bc4368-40c3-54b1-81ba-7a950efa2834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46aadeb3-25cb-434f-826c-5b3ea406a7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46aadeb3-25cb-434f-826c-5b3ea406a7cf.jpg?1",
             "name": "Mirelurk Queen",
             "text": "",
             "colours": [
@@ -21006,7 +21006,7 @@
         },
         {
             "id": "c22fb7e9-771f-5e36-8544-7de640d37878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea947462-b8d0-4279-99d9-8a1fa1b31269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea947462-b8d0-4279-99d9-8a1fa1b31269.jpg?1",
             "name": "Nerd Rage",
             "text": "",
             "colours": [
@@ -21041,7 +21041,7 @@
         },
         {
             "id": "44c1c780-6cd1-5dd1-ac1d-69cde0c28714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930e5715-d704-4489-b3dc-a2e44c9beeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930e5715-d704-4489-b3dc-a2e44c9beeb1.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "",
             "colours": [
@@ -21082,7 +21082,7 @@
         },
         {
             "id": "e8ae80e6-efad-54d5-ad10-646fbffd956d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c836d5df-9a1a-43ce-90db-067b32e1f4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c836d5df-9a1a-43ce-90db-067b32e1f4d4.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "",
             "colours": [
@@ -21122,7 +21122,7 @@
         },
         {
             "id": "66636f10-dbea-52d6-ac81-cbac92131d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796f354-5836-438c-a6c3-b688028e5016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796f354-5836-438c-a6c3-b688028e5016.jpg?1",
             "name": "Radstorm",
             "text": "",
             "colours": [
@@ -21157,7 +21157,7 @@
         },
         {
             "id": "6d8085ea-661c-557c-937e-99951972e945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69865b14-d016-47a7-a0c9-f61319ae92d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69865b14-d016-47a7-a0c9-f61319ae92d2.jpg?1",
             "name": "Robobrain War Mind",
             "text": "",
             "colours": [
@@ -21193,7 +21193,7 @@
         },
         {
             "id": "21db2675-7c24-5969-abc4-a71a22db8ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2af4139-6990-413d-b9fe-cb4ad33579d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2af4139-6990-413d-b9fe-cb4ad33579d3.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "",
             "colours": [
@@ -21228,7 +21228,7 @@
         },
         {
             "id": "afb74439-ff23-5341-88b9-2821f8e79381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ab62f4-fc9c-4f81-b363-45fc41227d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ab62f4-fc9c-4f81-b363-45fc41227d20.jpg?1",
             "name": "Synth Infiltrator",
             "text": "",
             "colours": [
@@ -21266,7 +21266,7 @@
         },
         {
             "id": "3edf2563-e630-5eb5-a335-25b6eec18922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7cad10-1e0e-4b01-9fa7-94f048034a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7cad10-1e0e-4b01-9fa7-94f048034a10.jpg?1",
             "name": "Vexing Radgull",
             "text": "",
             "colours": [
@@ -21302,7 +21302,7 @@
         },
         {
             "id": "0976ffad-ee2b-572f-b900-8f09ea905a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89cd297-f44c-4d17-b714-327b7e382dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89cd297-f44c-4d17-b714-327b7e382dd3.jpg?1",
             "name": "Bloatfly Swarm",
             "text": "",
             "colours": [
@@ -21338,7 +21338,7 @@
         },
         {
             "id": "f16368f9-4f2b-5280-b941-2bcf8d7b99c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edf6c39-6519-4b3e-afed-5e9ab6c4c572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edf6c39-6519-4b3e-afed-5e9ab6c4c572.jpg?1",
             "name": "Butch DeLoria, Tunnel Snake",
             "text": "",
             "colours": [
@@ -21376,7 +21376,7 @@
         },
         {
             "id": "adc1ed42-a83a-5970-b90d-d2be9b0818c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2addaa0e-6476-405b-b4be-9040b47f246b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2addaa0e-6476-405b-b4be-9040b47f246b.jpg?1",
             "name": "Feral Ghoul",
             "text": "",
             "colours": [
@@ -21414,7 +21414,7 @@
         },
         {
             "id": "9b8d93eb-820a-5180-a5d2-ff48286ed933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72fd70-211c-4350-8bd1-33929079383c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72fd70-211c-4350-8bd1-33929079383c.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "",
             "colours": [
@@ -21455,7 +21455,7 @@
         },
         {
             "id": "82f421d2-0acc-569e-a64a-e11e3362b3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a4355-5645-4af3-a16a-7fe49d0d5aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a4355-5645-4af3-a16a-7fe49d0d5aab.jpg?1",
             "name": "Infesting Radroach",
             "text": "",
             "colours": [
@@ -21491,7 +21491,7 @@
         },
         {
             "id": "3c0a73a1-1181-5919-9faa-cb04011d550e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528897b3-4a26-447a-896c-5cf4041f299c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528897b3-4a26-447a-896c-5cf4041f299c.jpg?1",
             "name": "Nuclear Fallout",
             "text": "",
             "colours": [
@@ -21526,7 +21526,7 @@
         },
         {
             "id": "05602db4-a8fb-5f4d-ad78-563051e95f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d866e7-fc21-4c96-9c3f-0cef8e7b09ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d866e7-fc21-4c96-9c3f-0cef8e7b09ed.jpg?1",
             "name": "Ruthless Radrat",
             "text": "",
             "colours": [
@@ -21562,7 +21562,7 @@
         },
         {
             "id": "4ff22f75-2c2b-5ab9-9cb7-2af68348b155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e5e6b-ebde-4133-9379-a4c882304651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e5e6b-ebde-4133-9379-a4c882304651.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "",
             "colours": [
@@ -21600,7 +21600,7 @@
         },
         {
             "id": "5a5a3bc2-49c7-5f2a-bba7-c2f171c4f7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89d6cd-0f61-4aee-b4a5-5ff6cfac037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89d6cd-0f61-4aee-b4a5-5ff6cfac037a.jpg?1",
             "name": "V.A.T.S.",
             "text": "",
             "colours": [
@@ -21635,7 +21635,7 @@
         },
         {
             "id": "e1d2ccbe-f011-57c6-8948-407bbb1b649f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961d090c-9548-42e1-abd2-34ba225a46c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961d090c-9548-42e1-abd2-34ba225a46c2.jpg?1",
             "name": "Vault 12: The Necropolis",
             "text": "",
             "colours": [
@@ -21670,7 +21670,7 @@
         },
         {
             "id": "3375865c-72cf-5a60-bb46-d868557cfc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cb1ec-de98-4a82-b872-9e62ee0198d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cb1ec-de98-4a82-b872-9e62ee0198d7.jpg?1",
             "name": "Wasteland Raider",
             "text": "",
             "colours": [
@@ -21708,7 +21708,7 @@
         },
         {
             "id": "86ec37d2-4ee6-5143-87ca-5b743626263b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd34f1bc-1386-45a5-a229-a948bbe373c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd34f1bc-1386-45a5-a229-a948bbe373c5.jpg?1",
             "name": "Acquired Mutation",
             "text": "",
             "colours": [
@@ -21743,7 +21743,7 @@
         },
         {
             "id": "335c4795-c8a9-5249-9d4d-dd947e76730c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d663f6-c76c-42ee-b5aa-db8aa1aaf4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d663f6-c76c-42ee-b5aa-db8aa1aaf4c4.jpg?1",
             "name": "Assaultron Dominator",
             "text": "",
             "colours": [
@@ -21781,7 +21781,7 @@
         },
         {
             "id": "2efcdf4c-350e-56a0-b877-764cac04a7b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d8bfb-aaf0-41f3-a000-1df6363fb25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d8bfb-aaf0-41f3-a000-1df6363fb25c.jpg?1",
             "name": "Bottle-Cap Blast",
             "text": "",
             "colours": [
@@ -21814,7 +21814,7 @@
         },
         {
             "id": "81b29916-bf01-5941-8917-8ceec90382ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f12abc-34e9-486a-a160-1a99e3632403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f12abc-34e9-486a-a160-1a99e3632403.jpg?1",
             "name": "Crimson Caravaneer",
             "text": "",
             "colours": [
@@ -21850,7 +21850,7 @@
         },
         {
             "id": "3729b4e9-372a-5eb6-bc9f-b760d4fb4fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ee8d5a-8f8d-44fe-a129-5208d14d1212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ee8d5a-8f8d-44fe-a129-5208d14d1212.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "",
             "colours": [
@@ -21890,7 +21890,7 @@
         },
         {
             "id": "2a3b2818-590b-524c-8c32-114a8cf3df77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93d5766-5cd6-45a8-8fa0-03391e274908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93d5766-5cd6-45a8-8fa0-03391e274908.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "",
             "colours": [
@@ -21927,7 +21927,7 @@
         },
         {
             "id": "1efe7a99-e68e-5317-b5bb-0a6079da7a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be12244-5e1f-4e5e-bd4b-ac0bcd74724b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be12244-5e1f-4e5e-bd4b-ac0bcd74724b.jpg?1",
             "name": "Ian the Reckless",
             "text": "",
             "colours": [
@@ -21965,7 +21965,7 @@
         },
         {
             "id": "221bcdac-8d58-5380-bf3c-52818b3cbd01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b718ad-4b42-414f-ad9a-5dffad959469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b718ad-4b42-414f-ad9a-5dffad959469.jpg?1",
             "name": "Junk Jet",
             "text": "",
             "colours": [
@@ -22002,7 +22002,7 @@
         },
         {
             "id": "e9e746f1-fef3-5c50-afc6-38a0faae0640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c90a103-e42f-4d12-848b-cf00f94ba83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c90a103-e42f-4d12-848b-cf00f94ba83c.jpg?1",
             "name": "Megaton's Fate",
             "text": "",
             "colours": [
@@ -22037,7 +22037,7 @@
         },
         {
             "id": "ffc452a6-182e-543c-a188-9ff947a7f725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ce5d9-8aaa-4982-85d7-36242d4805d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ce5d9-8aaa-4982-85d7-36242d4805d2.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "",
             "colours": [
@@ -22077,7 +22077,7 @@
         },
         {
             "id": "e66ec9d6-01bc-5f5b-899b-1b65f9487fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798c9e70-c30c-4c69-99e5-f8e90e787e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798c9e70-c30c-4c69-99e5-f8e90e787e6a.jpg?1",
             "name": "Mysterious Stranger",
             "text": "",
             "colours": [
@@ -22115,7 +22115,7 @@
         },
         {
             "id": "64a794df-15d5-5c37-96f5-b7a6e84a9a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12194b-b9c4-47ba-853f-60a1bcf2c279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12194b-b9c4-47ba-853f-60a1bcf2c279.jpg?1",
             "name": "Plasma Caster",
             "text": "",
             "colours": [
@@ -22152,7 +22152,7 @@
         },
         {
             "id": "03f01a80-e070-53dc-a815-9039ed85d49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ff636a-f681-4164-acb5-61aa91014645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ff636a-f681-4164-acb5-61aa91014645.jpg?1",
             "name": "Powder Ganger",
             "text": "",
             "colours": [
@@ -22190,7 +22190,7 @@
         },
         {
             "id": "7d824125-2e22-59ff-9b14-8af85767da79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5163087f-163d-4e5e-ae6b-aca192b4358b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5163087f-163d-4e5e-ae6b-aca192b4358b.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "",
             "colours": [
@@ -22230,7 +22230,7 @@
         },
         {
             "id": "38dc2f8a-9e3f-5edb-a1b7-e652ba637096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d641b-7740-471f-bf93-671858ea720f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d641b-7740-471f-bf93-671858ea720f.jpg?1",
             "name": "Synth Eradicator",
             "text": "",
             "colours": [
@@ -22269,7 +22269,7 @@
         },
         {
             "id": "d3143d7d-9a81-512e-9fde-3deaa76159f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747df6bf-9605-47fa-b2a0-9457d0e4db19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747df6bf-9605-47fa-b2a0-9457d0e4db19.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "",
             "colours": [
@@ -22307,7 +22307,7 @@
         },
         {
             "id": "4e41c958-349c-5bca-a320-46a99f464392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e60ea-4192-4388-8ad0-e5b3339eb872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e60ea-4192-4388-8ad0-e5b3339eb872.jpg?1",
             "name": "Vault 21: House Gambit",
             "text": "",
             "colours": [
@@ -22342,7 +22342,7 @@
         },
         {
             "id": "9638ac7c-c3b5-5738-b240-0b6c5b158a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951f76d2-2ad2-4b9a-b47a-0cdc7567092c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951f76d2-2ad2-4b9a-b47a-0cdc7567092c.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "",
             "colours": [
@@ -22383,7 +22383,7 @@
         },
         {
             "id": "d545eae2-04f3-54ab-abba-54c848335e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b15caa8-4d33-4f1e-bf4e-8cc749c3cb19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b15caa8-4d33-4f1e-bf4e-8cc749c3cb19.jpg?1",
             "name": "Wild Wasteland",
             "text": "",
             "colours": [
@@ -22418,7 +22418,7 @@
         },
         {
             "id": "90bc37a9-aff5-50b9-abb5-d44e7df68143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a34ff7-4e2e-4773-a0c4-10526e7369eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a34ff7-4e2e-4773-a0c4-10526e7369eb.jpg?1",
             "name": "Animal Friend",
             "text": "",
             "colours": [
@@ -22455,7 +22455,7 @@
         },
         {
             "id": "9bbf2662-77a1-54a6-a158-ed8af13383e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e27f186-4ae0-4ee2-9a3c-7fb62072c56b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e27f186-4ae0-4ee2-9a3c-7fb62072c56b.jpg?1",
             "name": "Bighorner Rancher",
             "text": "",
             "colours": [
@@ -22491,7 +22491,7 @@
         },
         {
             "id": "10c6cc8b-6df3-5adb-9e69-555c134a9654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2245de3-4438-433d-8a61-b16acc4e25ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2245de3-4438-433d-8a61-b16acc4e25ac.jpg?1",
             "name": "Break Down",
             "text": "",
             "colours": [
@@ -22524,7 +22524,7 @@
         },
         {
             "id": "ed466699-4b8f-5b68-ad35-f92b88d1ebac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4879129a-33db-479f-a24a-bfe92b3541a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4879129a-33db-479f-a24a-bfe92b3541a0.jpg?1",
             "name": "Cathedral Acolyte",
             "text": "",
             "colours": [
@@ -22560,7 +22560,7 @@
         },
         {
             "id": "00d72f75-c46a-5301-82ce-2e48900c8317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b3537a-e44a-47ff-9687-c2172738aeed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b3537a-e44a-47ff-9687-c2172738aeed.jpg?1",
             "name": "Glowing One",
             "text": "",
             "colours": [
@@ -22596,7 +22596,7 @@
         },
         {
             "id": "acc6b906-7149-552e-8ce9-6103e1c055de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c5337-31b2-4f1e-8b33-448c879367fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c5337-31b2-4f1e-8b33-448c879367fd.jpg?1",
             "name": "Gunner Conscript",
             "text": "",
             "colours": [
@@ -22632,7 +22632,7 @@
         },
         {
             "id": "c05bee58-c7ff-51ff-890f-d573db8d0f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5f93d2-2edc-4a97-9a51-b276d1706e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5f93d2-2edc-4a97-9a51-b276d1706e7d.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "",
             "colours": [
@@ -22672,7 +22672,7 @@
         },
         {
             "id": "bf71f629-905c-5df9-b751-c02e323bf4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438066d-32df-42bb-91e7-f7be9ad3b86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438066d-32df-42bb-91e7-f7be9ad3b86a.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "",
             "colours": [
@@ -22712,7 +22712,7 @@
         },
         {
             "id": "4c8d0825-0c59-50fb-8822-37ecb365668f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cad35-c10a-4b7e-bfd4-0295c6032736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cad35-c10a-4b7e-bfd4-0295c6032736.jpg?1",
             "name": "Lumbering Megasloth",
             "text": "",
             "colours": [
@@ -22748,7 +22748,7 @@
         },
         {
             "id": "8d57c5ec-d3e5-565f-ac96-ff9d6d30b2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171b2a6-0052-4329-9c9f-5c4d7f2c2eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171b2a6-0052-4329-9c9f-5c4d7f2c2eba.jpg?1",
             "name": "Power Fist",
             "text": "",
             "colours": [
@@ -22785,7 +22785,7 @@
         },
         {
             "id": "367f9568-a7a2-52d7-9676-f196f2cbe20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ab3da0-96b5-4b8a-bcc1-69824945d043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ab3da0-96b5-4b8a-bcc1-69824945d043.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "",
             "colours": [
@@ -22823,7 +22823,7 @@
         },
         {
             "id": "c3a9ecc9-91df-5c0d-8684-410237e73a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad5795c-a7be-4267-a196-f57d5537081c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad5795c-a7be-4267-a196-f57d5537081c.jpg?1",
             "name": "Strong Back",
             "text": "",
             "colours": [
@@ -22860,7 +22860,7 @@
         },
         {
             "id": "73066f99-c0bc-5f71-b56e-46f011f2229d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3623d4a1-7364-4177-b431-2a4dc70dec3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3623d4a1-7364-4177-b431-2a4dc70dec3d.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "",
             "colours": [
@@ -22900,7 +22900,7 @@
         },
         {
             "id": "07d52daa-cfe5-5eab-925b-68db1382e0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d05043f-9cbb-40e2-86b8-ad28247879e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d05043f-9cbb-40e2-86b8-ad28247879e2.jpg?1",
             "name": "Super Mutant Scavenger",
             "text": "",
             "colours": [
@@ -22936,7 +22936,7 @@
         },
         {
             "id": "5bf1dbcb-81c6-5ac0-9a6c-b62e93ce91b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86a7a14-6e24-4b98-a757-d0ea05055946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86a7a14-6e24-4b98-a757-d0ea05055946.jpg?1",
             "name": "Tato Farmer",
             "text": "",
             "colours": [
@@ -22975,7 +22975,7 @@
         },
         {
             "id": "8050524e-cb22-5a61-b68b-0b63cafe222d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04f9dde-d9ea-4a6e-9fe5-8f019437db01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04f9dde-d9ea-4a6e-9fe5-8f019437db01.jpg?1",
             "name": "Watchful Radstag",
             "text": "",
             "colours": [
@@ -23013,7 +23013,7 @@
         },
         {
             "id": "311f5775-7656-585a-ae4a-69354b9fcc96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831a905-55c2-4d88-b7ec-463df05e4d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831a905-55c2-4d88-b7ec-463df05e4d7a.jpg?1",
             "name": "Well Rested",
             "text": "",
             "colours": [
@@ -23048,7 +23048,7 @@
         },
         {
             "id": "2575382d-7c27-59f9-ba69-a7eb1f487433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2f624e-3d61-4582-9582-6c6cf558936e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2f624e-3d61-4582-9582-6c6cf558936e.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "",
             "colours": [
@@ -23090,7 +23090,7 @@
         },
         {
             "id": "9594226b-497b-5ff5-80cf-a3ecb08aa51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b645f84-4213-41ba-8860-332971606f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b645f84-4213-41ba-8860-332971606f26.jpg?1",
             "name": "Almost Perfect",
             "text": "",
             "colours": [
@@ -23129,7 +23129,7 @@
         },
         {
             "id": "af1e5f49-d6b4-5ac3-ad04-06c0ad43b363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00650b7-eaeb-4da1-948a-48cc97e58a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00650b7-eaeb-4da1-948a-48cc97e58a31.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "",
             "colours": [
@@ -23169,7 +23169,7 @@
         },
         {
             "id": "94c7967a-5305-5493-901e-ea356b8c0157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f49b-87ca-4ee3-a957-89cfe9716e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f49b-87ca-4ee3-a957-89cfe9716e31.jpg?1",
             "name": "Arcade Gannon",
             "text": "",
             "colours": [
@@ -23211,7 +23211,7 @@
         },
         {
             "id": "6166b610-4448-529d-ab32-807bb13a0abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67a3942-25ad-4008-8913-682704f7c501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67a3942-25ad-4008-8913-682704f7c501.jpg?1",
             "name": "Armory Paladin",
             "text": "",
             "colours": [
@@ -23251,7 +23251,7 @@
         },
         {
             "id": "f35a6ce4-99f2-5be1-a4af-7fb5cfd9b369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238b4e8-72a6-4424-9165-d9e7275b9778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238b4e8-72a6-4424-9165-d9e7275b9778.jpg?1",
             "name": "Atomize",
             "text": "",
             "colours": [
@@ -23288,7 +23288,7 @@
         },
         {
             "id": "a4bfda31-f71b-554b-a066-96a2bdf94ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c37047-bf08-4ac1-92e7-609ab8ff6f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c37047-bf08-4ac1-92e7-609ab8ff6f43.jpg?1",
             "name": "Boomer Scrapper",
             "text": "",
             "colours": [
@@ -23328,7 +23328,7 @@
         },
         {
             "id": "44e45b95-9f58-580b-b5df-388602a4831b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcabc69-fe20-40ee-987e-afe1d42d78cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcabc69-fe20-40ee-987e-afe1d42d78cb.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "",
             "colours": [
@@ -23370,7 +23370,7 @@
         },
         {
             "id": "ea2ee85f-4c6a-5e4a-afec-306508476aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacd28e-4b44-4b5e-a58c-9cccae7a04c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacd28e-4b44-4b5e-a58c-9cccae7a04c1.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "",
             "colours": [
@@ -23412,7 +23412,7 @@
         },
         {
             "id": "6550d1d1-455f-5867-95a8-72f796bf2962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a100e650-8a34-43af-b4a0-6595cfcd4a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a100e650-8a34-43af-b4a0-6595cfcd4a1b.jpg?1",
             "name": "Colonel Autumn",
             "text": "",
             "colours": [
@@ -23454,7 +23454,7 @@
         },
         {
             "id": "5c54017f-7f92-5596-9727-ec25a384e83a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd30bb4-790a-4c02-b7cb-fec60467dd89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd30bb4-790a-4c02-b7cb-fec60467dd89.jpg?1",
             "name": "Contaminated Drink",
             "text": "",
             "colours": [
@@ -23489,7 +23489,7 @@
         },
         {
             "id": "475d7a52-2359-5f7e-abaf-71d94e9fa26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc98779-5ee4-4169-8a98-02e0f63a599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc98779-5ee4-4169-8a98-02e0f63a599a.jpg?1",
             "name": "Craig Boone, Novac Guard",
             "text": "",
             "colours": [
@@ -23529,7 +23529,7 @@
         },
         {
             "id": "abd3f7ce-1d91-55f5-b647-11116abaa82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23145616-8f99-4269-8875-9bb7e24ace04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23145616-8f99-4269-8875-9bb7e24ace04.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "",
             "colours": [
@@ -23571,7 +23571,7 @@
         },
         {
             "id": "e2cdb646-f4f8-5a49-a12c-d1a34db442dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850d0a27-e6e4-4e11-bcd9-9c8253444624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850d0a27-e6e4-4e11-bcd9-9c8253444624.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "",
             "colours": [
@@ -23613,7 +23613,7 @@
         },
         {
             "id": "c3c700eb-89a2-5bca-a7a7-aae9399061b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc8fe5-736c-4baf-bd0f-a0c95721225e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc8fe5-736c-4baf-bd0f-a0c95721225e.jpg?1",
             "name": "Elder Owyn Lyons",
             "text": "",
             "colours": [
@@ -23653,7 +23653,7 @@
         },
         {
             "id": "32623bf9-3f08-59a0-938a-80b3b994efb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17762d3-b7d2-43c9-9983-046b9ec1d5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17762d3-b7d2-43c9-9983-046b9ec1d5df.jpg?1",
             "name": "Electrosiphon",
             "text": "",
             "colours": [
@@ -23690,7 +23690,7 @@
         },
         {
             "id": "44d69e1b-0290-5f6d-ae37-654dd2a66419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a392364-6045-4d1f-8ca9-61bbf5a277a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a392364-6045-4d1f-8ca9-61bbf5a277a3.jpg?1",
             "name": "Inventory Management",
             "text": "",
             "colours": [
@@ -23727,7 +23727,7 @@
         },
         {
             "id": "ddbcc9de-6bc2-5db7-939f-097e00f63db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d13d78-6094-40af-8c47-a4baacd5185f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d13d78-6094-40af-8c47-a4baacd5185f.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "",
             "colours": [
@@ -23769,7 +23769,7 @@
         },
         {
             "id": "8d4db5e1-00d7-5ccd-972f-b8b56f6a36fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522f45b-060b-4a77-9910-3c40e3b2de78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522f45b-060b-4a77-9910-3c40e3b2de78.jpg?1",
             "name": "Legate Lanius, Caesar's Ace",
             "text": "",
             "colours": [
@@ -23809,7 +23809,7 @@
         },
         {
             "id": "581dd7ef-4e43-5b4d-8610-feb67ba39838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeccc970-6762-404f-a4d9-31c1aef80d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeccc970-6762-404f-a4d9-31c1aef80d22.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "",
             "colours": [
@@ -23851,7 +23851,7 @@
         },
         {
             "id": "dd4cc344-4196-5408-b8f3-a1cff0ae6d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79d6167-fdf3-4d3c-b90e-f1511ad75113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79d6167-fdf3-4d3c-b90e-f1511ad75113.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "",
             "colours": [
@@ -23893,7 +23893,7 @@
         },
         {
             "id": "434e5d6b-7c25-5185-98d7-1724af2f9c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55baad5-d0cb-44bc-aa8d-5dcd22a0605f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55baad5-d0cb-44bc-aa8d-5dcd22a0605f.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "",
             "colours": [
@@ -23935,7 +23935,7 @@
         },
         {
             "id": "4803cdf4-806c-5829-9bdc-5e49d0bd4876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e14f3b-e3fd-4975-94b7-654f14150d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e14f3b-e3fd-4975-94b7-654f14150d96.jpg?1",
             "name": "Mutational Advantage",
             "text": "",
             "colours": [
@@ -23972,7 +23972,7 @@
         },
         {
             "id": "abc6c0c1-7033-5495-bf6a-533d3443795d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323747a-1d2e-4f08-a788-afa4dda56c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323747a-1d2e-4f08-a788-afa4dda56c13.jpg?1",
             "name": "Nightkin Ambusher",
             "text": "",
             "colours": [
@@ -24010,7 +24010,7 @@
         },
         {
             "id": "4b14d963-98f6-5ed3-9789-cfa605eaf00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c59808-ae7a-40c4-b4b5-970264fdd32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c59808-ae7a-40c4-b4b5-970264fdd32d.jpg?1",
             "name": "The Nipton Lottery",
             "text": "",
             "colours": [
@@ -24047,7 +24047,7 @@
         },
         {
             "id": "d1918f44-b018-540e-b3fd-15040f3f7d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f1540f-293c-401a-a8cc-d147334176de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f1540f-293c-401a-a8cc-d147334176de.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "",
             "colours": [
@@ -24089,7 +24089,7 @@
         },
         {
             "id": "371927a6-d8bf-52b0-b576-d6f013b0a599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e240f7-b8e5-48c4-83fe-0efd559c9c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e240f7-b8e5-48c4-83fe-0efd559c9c9f.jpg?1",
             "name": "Raul, Trouble Shooter",
             "text": "",
             "colours": [
@@ -24130,7 +24130,7 @@
         },
         {
             "id": "746a7333-c274-5b53-894b-7a1fe09f1d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9956f3c2-992d-43c8-9c5a-ccb491bd0b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9956f3c2-992d-43c8-9c5a-ccb491bd0b5d.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "",
             "colours": [
@@ -24172,7 +24172,7 @@
         },
         {
             "id": "5aea6ade-18ed-5f04-833f-dae73ce5015f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e56e5a9-e1de-4879-9287-37d1c16d46dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e56e5a9-e1de-4879-9287-37d1c16d46dd.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "",
             "colours": [
@@ -24215,7 +24215,7 @@
         },
         {
             "id": "eb19655b-4867-58d5-a967-61348711c490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b296fe9-73ad-41b1-b8dc-5a34c7de9065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b296fe9-73ad-41b1-b8dc-5a34c7de9065.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "",
             "colours": [
@@ -24257,7 +24257,7 @@
         },
         {
             "id": "6ebe213f-fc61-5eef-b916-957ad4955fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1414e2-a43b-46b9-ba77-de9a9c50b0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1414e2-a43b-46b9-ba77-de9a9c50b0cf.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "",
             "colours": [
@@ -24299,7 +24299,7 @@
         },
         {
             "id": "1824e348-7e52-500b-9878-dffe18d61fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075f346e-4e2a-4424-b974-fdcf83b3ebfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075f346e-4e2a-4424-b974-fdcf83b3ebfc.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "",
             "colours": [
@@ -24341,7 +24341,7 @@
         },
         {
             "id": "e8ddac42-ef7f-5d1d-ae19-87c2ae48e89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375a3fb0-386d-40ba-97c0-534a6c289078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375a3fb0-386d-40ba-97c0-534a6c289078.jpg?1",
             "name": "Vault 11: Voter's Dilemma",
             "text": "",
             "colours": [
@@ -24378,7 +24378,7 @@
         },
         {
             "id": "4ccbeffa-2451-5736-a0d9-9a2ac4190175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383eb67-0b54-4c3d-b830-9340b457d5ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383eb67-0b54-4c3d-b830-9340b457d5ae.jpg?1",
             "name": "Vault 87: Forced Evolution",
             "text": "",
             "colours": [
@@ -24415,7 +24415,7 @@
         },
         {
             "id": "1ce3c99e-ae12-5421-81a6-a64fb26b8909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93922262-f4db-4cdb-b6e5-bd05a1f9172c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93922262-f4db-4cdb-b6e5-bd05a1f9172c.jpg?1",
             "name": "Vault 112: Sadistic Simulation",
             "text": "",
             "colours": [
@@ -24452,7 +24452,7 @@
         },
         {
             "id": "d3f72c3e-c4da-5803-9716-ba7c40c04595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a015ab6-4eb3-42e3-bb19-a0668e9f7ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a015ab6-4eb3-42e3-bb19-a0668e9f7ff0.jpg?1",
             "name": "White Glove Gourmand",
             "text": "",
             "colours": [
@@ -24490,7 +24490,7 @@
         },
         {
             "id": "4ad006cc-05f2-5982-b215-c0d5bd6bb69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d94ede9-5125-48d9-a707-d7cf2f1b51af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d94ede9-5125-48d9-a707-d7cf2f1b51af.jpg?1",
             "name": "Young Deathclaws",
             "text": "",
             "colours": [
@@ -24528,7 +24528,7 @@
         },
         {
             "id": "0876bb17-c589-5cab-a151-547ce573a868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371ff49d-a382-4ff0-8849-aac6bc674248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371ff49d-a382-4ff0-8849-aac6bc674248.jpg?1",
             "name": "Agility Bobblehead",
             "text": "",
             "colours": [],
@@ -24560,7 +24560,7 @@
         },
         {
             "id": "0d7d6c1a-5e45-50f9-a8fc-10c8d5454f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ed63-2328-4a0f-8c36-3cdef967dc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ed63-2328-4a0f-8c36-3cdef967dc81.jpg?1",
             "name": "Behemoth of Vault 0",
             "text": "",
             "colours": [],
@@ -24592,7 +24592,7 @@
         },
         {
             "id": "3481116c-bf96-5441-8ddf-c94c0082c5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f19f53-dabd-4bbb-ba85-ba19d3ada1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f19f53-dabd-4bbb-ba85-ba19d3ada1e8.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "",
             "colours": [],
@@ -24625,7 +24625,7 @@
         },
         {
             "id": "79db72e4-2417-56ad-b509-b8605cc1ea53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6f12b-284d-4e81-8c8a-f481268422c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6f12b-284d-4e81-8c8a-f481268422c2.jpg?1",
             "name": "C.A.M.P.",
             "text": "",
             "colours": [],
@@ -24656,7 +24656,7 @@
         },
         {
             "id": "c3c66a19-7f86-59a9-82a7-c76ef2640f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def088be-c2fe-46e4-8e3d-cccdabb4b8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def088be-c2fe-46e4-8e3d-cccdabb4b8e6.jpg?1",
             "name": "Charisma Bobblehead",
             "text": "",
             "colours": [],
@@ -24688,7 +24688,7 @@
         },
         {
             "id": "725f1130-6c13-5d5f-a584-beba240aaba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726c514-1a82-4281-82bc-e543233e084d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726c514-1a82-4281-82bc-e543233e084d.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "",
             "colours": [],
@@ -24724,7 +24724,7 @@
         },
         {
             "id": "a2ac0f16-11a8-5835-9c4f-a27c171a8d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5dad34-a8c5-42de-b5b5-7537a681f126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5dad34-a8c5-42de-b5b5-7537a681f126.jpg?1",
             "name": "Endurance Bobblehead",
             "text": "",
             "colours": [],
@@ -24756,7 +24756,7 @@
         },
         {
             "id": "7ccf1cce-1835-57bc-bc5f-61abaf43c0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3000197-dfe4-48d6-be21-0f408fee143a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3000197-dfe4-48d6-be21-0f408fee143a.jpg?1",
             "name": "Expert-Level Safe",
             "text": "",
             "colours": [],
@@ -24785,7 +24785,7 @@
         },
         {
             "id": "a0ea4fe7-80b3-5990-ba4d-5c7991ddd2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dd4d0-f6c8-4a04-919a-2c9b6842b361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dd4d0-f6c8-4a04-919a-2c9b6842b361.jpg?1",
             "name": "Intelligence Bobblehead",
             "text": "",
             "colours": [],
@@ -24817,7 +24817,7 @@
         },
         {
             "id": "45027947-4338-54a1-aeb8-2003068734c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c0520-8008-412d-83f5-6608cfb7372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c0520-8008-412d-83f5-6608cfb7372c.jpg?1",
             "name": "Luck Bobblehead",
             "text": "",
             "colours": [],
@@ -24849,7 +24849,7 @@
         },
         {
             "id": "28952fbe-2413-5c61-91b5-92c482c59835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb3bec7-40bb-4b5a-9a7b-cdecf974e044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb3bec7-40bb-4b5a-9a7b-cdecf974e044.jpg?1",
             "name": "Mister Gutsy",
             "text": "",
             "colours": [],
@@ -24884,7 +24884,7 @@
         },
         {
             "id": "eaf6197c-a038-5b59-8aa3-3510e0e379b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda4cbd3-e030-4349-9643-9f7bdebf80c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda4cbd3-e030-4349-9643-9f7bdebf80c1.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "",
             "colours": [],
@@ -24915,7 +24915,7 @@
         },
         {
             "id": "67523770-d318-5adf-9a6d-16c27613162b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be9d675-c284-4da6-81b5-0ceed836f9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be9d675-c284-4da6-81b5-0ceed836f9cc.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "",
             "colours": [],
@@ -24948,7 +24948,7 @@
         },
         {
             "id": "731beb74-b489-532a-98ee-4870820d58b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc935e71-8be8-4420-ba4f-3720f7eba941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc935e71-8be8-4420-ba4f-3720f7eba941.jpg?1",
             "name": "Perception Bobblehead",
             "text": "",
             "colours": [],
@@ -24980,7 +24980,7 @@
         },
         {
             "id": "1f3022f2-5b33-50d1-acbb-945079c9be62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6f71d-aea0-4711-9177-06a8c3917d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6f71d-aea0-4711-9177-06a8c3917d6d.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "",
             "colours": [],
@@ -25013,7 +25013,7 @@
         },
         {
             "id": "ab5d9df6-2199-5a11-bda4-c1e63289fb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906c5c0-135d-4372-bcdb-a366341d1f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906c5c0-135d-4372-bcdb-a366341d1f65.jpg?1",
             "name": "Recon Craft Theta",
             "text": "",
             "colours": [],
@@ -25046,7 +25046,7 @@
         },
         {
             "id": "94fd4d29-3a77-5c60-80da-e2d57d826a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04fc3fa-119f-4dbf-a1b3-6f92812cd07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04fc3fa-119f-4dbf-a1b3-6f92812cd07d.jpg?1",
             "name": "Silver Shroud Costume",
             "text": "",
             "colours": [],
@@ -25077,7 +25077,7 @@
         },
         {
             "id": "9cb47c03-9462-50b6-a863-01019c04e8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271424ac-1f2b-4419-baca-bc9f0a862221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271424ac-1f2b-4419-baca-bc9f0a862221.jpg?1",
             "name": "Strength Bobblehead",
             "text": "",
             "colours": [],
@@ -25109,7 +25109,7 @@
         },
         {
             "id": "83dae9de-94c1-57db-8327-fa16b94ad602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda5e513-775c-4c5e-b9dc-cb836ca8cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda5e513-775c-4c5e-b9dc-cb836ca8cb8c.jpg?1",
             "name": "Survivor's Med Kit",
             "text": "",
             "colours": [],
@@ -25138,7 +25138,7 @@
         },
         {
             "id": "410e8735-9e31-5e79-9bae-87e96b211ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34a21a-3026-44d1-96d9-92112b0df7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34a21a-3026-44d1-96d9-92112b0df7f6.jpg?1",
             "name": "T-45 Power Armor",
             "text": "",
             "colours": [],
@@ -25171,7 +25171,7 @@
         },
         {
             "id": "b12cc1ff-756c-52fb-959a-f90fb26ddc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc62e13-19c0-421b-b5b1-8bff5a6db6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc62e13-19c0-421b-b5b1-8bff5a6db6cb.jpg?1",
             "name": "Desolate Mire",
             "text": "",
             "colours": [],
@@ -25205,7 +25205,7 @@
         },
         {
             "id": "23827f37-05fe-5e6b-a292-e40cc2e5f90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259e77f-0a15-43e2-bb94-41e8c585d927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259e77f-0a15-43e2-bb94-41e8c585d927.jpg?1",
             "name": "Diamond City",
             "text": "",
             "colours": [],
@@ -25236,7 +25236,7 @@
         },
         {
             "id": "b46e5fd0-2446-56d1-baaf-e76270e1ebc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277ced12-77eb-426f-a661-bb5edd2d48e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277ced12-77eb-426f-a661-bb5edd2d48e7.jpg?1",
             "name": "Ferrous Lake",
             "text": "",
             "colours": [],
@@ -25270,7 +25270,7 @@
         },
         {
             "id": "96b03fbe-3d39-51c2-9057-c2ac250350de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83173a2-3d81-4617-a41d-51fc803cd774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83173a2-3d81-4617-a41d-51fc803cd774.jpg?1",
             "name": "HELIOS One",
             "text": "",
             "colours": [],
@@ -25301,7 +25301,7 @@
         },
         {
             "id": "7eac7f6d-f43d-51cd-ba25-d679f1fae2ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d23ba-2e8f-46ef-805e-b00405417760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d23ba-2e8f-46ef-805e-b00405417760.jpg?1",
             "name": "Junktown",
             "text": "",
             "colours": [],
@@ -25334,7 +25334,7 @@
         },
         {
             "id": "a533a3b4-c9cf-59e7-9ebf-55adb7bf9e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b43792-6a34-4f36-b82a-793b846d5cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b43792-6a34-4f36-b82a-793b846d5cf5.jpg?1",
             "name": "Mariposa Military Base",
             "text": "",
             "colours": [],
@@ -25365,7 +25365,7 @@
         },
         {
             "id": "f235b8cc-35f2-5e28-bea3-7af6f877aac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04c2f3c-7114-4e8d-9c2f-e6611b4b3917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04c2f3c-7114-4e8d-9c2f-e6611b4b3917.jpg?1",
             "name": "Overflowing Basin",
             "text": "",
             "colours": [],
@@ -25399,7 +25399,7 @@
         },
         {
             "id": "8ecf985e-c805-50bd-9ae6-d0007bf496d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a916758c-9db2-48ff-b3b7-177e8d28284e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a916758c-9db2-48ff-b3b7-177e8d28284e.jpg?1",
             "name": "Sunscorched Divide",
             "text": "",
             "colours": [],
@@ -25433,7 +25433,7 @@
         },
         {
             "id": "3a7c0451-f750-5589-9ac8-c1d6960ae21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c555b4c5-08cc-4cd0-9b08-be29ce821fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c555b4c5-08cc-4cd0-9b08-be29ce821fce.jpg?1",
             "name": "Viridescent Bog",
             "text": "",
             "colours": [],
@@ -25467,7 +25467,7 @@
         },
         {
             "id": "1f1c4733-c01b-5484-bd42-7b9eb1ed256e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56300ae6-d374-412e-b7f7-23e057666596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56300ae6-d374-412e-b7f7-23e057666596.jpg?1",
             "name": "All That Glitters",
             "text": "",
             "colours": [
@@ -25502,7 +25502,7 @@
         },
         {
             "id": "21d94162-a81a-55e0-be51-c5714d25420a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b675653-2689-4d02-b64e-8ac2204fe816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b675653-2689-4d02-b64e-8ac2204fe816.jpg?1",
             "name": "Austere Command",
             "text": "",
             "colours": [
@@ -25537,7 +25537,7 @@
         },
         {
             "id": "d93485fa-2f99-50f0-ad0d-16319260ada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72641763-ac1d-42af-896b-985fd8980413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72641763-ac1d-42af-896b-985fd8980413.jpg?1",
             "name": "Captain of the Watch",
             "text": "",
             "colours": [
@@ -25575,7 +25575,7 @@
         },
         {
             "id": "df0b5eac-22dd-565b-856d-7424122e086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec886ab3-0cc2-4b17-879d-73ae10247a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec886ab3-0cc2-4b17-879d-73ae10247a8b.jpg?1",
             "name": "Crush Contraband",
             "text": "",
             "colours": [
@@ -25608,7 +25608,7 @@
         },
         {
             "id": "ba69db05-6153-5bb8-90d8-294341244e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da39a64-e8d9-4dc3-85f1-ac633b33330c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da39a64-e8d9-4dc3-85f1-ac633b33330c.jpg?1",
             "name": "Dispatch",
             "text": "",
             "colours": [
@@ -25641,7 +25641,7 @@
         },
         {
             "id": "28c6aea6-9475-5a04-acf4-3c5b4a615e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7c22b-f1f8-4d71-b5af-aae97fd6ebf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7c22b-f1f8-4d71-b5af-aae97fd6ebf0.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "",
             "colours": [
@@ -25676,7 +25676,7 @@
         },
         {
             "id": "7a842192-2cec-5f2b-a20e-92fd66689c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b73c1cb-0e96-41d7-91c1-912aedd263a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b73c1cb-0e96-41d7-91c1-912aedd263a7.jpg?1",
             "name": "Hour of Reckoning",
             "text": "",
             "colours": [
@@ -25711,7 +25711,7 @@
         },
         {
             "id": "4a2c761d-1791-5e42-981a-87ba2accce02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8cf32-3283-46f8-bde1-5f02b71ed553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8cf32-3283-46f8-bde1-5f02b71ed553.jpg?1",
             "name": "Impassioned Orator",
             "text": "",
             "colours": [
@@ -25747,7 +25747,7 @@
         },
         {
             "id": "b3bcbf89-859f-5407-b386-adc6eedf2bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9394fad6-af1b-4006-93f4-d154eb3435dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9394fad6-af1b-4006-93f4-d154eb3435dd.jpg?1",
             "name": "Intangible Virtue",
             "text": "",
             "colours": [
@@ -25780,7 +25780,7 @@
         },
         {
             "id": "d26b7e9e-0fee-5517-84d3-e2d97f68d7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee310ee-850f-44f0-82af-58bf766ea737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee310ee-850f-44f0-82af-58bf766ea737.jpg?1",
             "name": "Keeper of the Accord",
             "text": "",
             "colours": [
@@ -25818,7 +25818,7 @@
         },
         {
             "id": "4d081266-37c2-5b1f-a280-0a2eb6a7a494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb587e8-b83a-491e-9b8c-736c115d4146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb587e8-b83a-491e-9b8c-736c115d4146.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "",
             "colours": [
@@ -25855,7 +25855,7 @@
         },
         {
             "id": "7ab7a83f-2620-5e0e-b6d7-c131421ad208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f893f1-47f6-4e1d-8cc5-4ee66c855d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f893f1-47f6-4e1d-8cc5-4ee66c855d77.jpg?1",
             "name": "Marshal's Anthem",
             "text": "",
             "colours": [
@@ -25890,7 +25890,7 @@
         },
         {
             "id": "ca6ddaec-eed9-549e-9194-97ba07d63b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a14e82-31fc-4c56-a8cc-acc3f7ef91a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a14e82-31fc-4c56-a8cc-acc3f7ef91a3.jpg?1",
             "name": "Martial Coup",
             "text": "",
             "colours": [
@@ -25925,7 +25925,7 @@
         },
         {
             "id": "172aa2cc-58fb-5542-9d6e-bf88d74ef345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e54f2-38cf-41dc-b8b3-0c123db66b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e54f2-38cf-41dc-b8b3-0c123db66b3c.jpg?1",
             "name": "Open the Vaults",
             "text": "",
             "colours": [
@@ -25960,7 +25960,7 @@
         },
         {
             "id": "b8b5d93c-92cd-57fa-bbc1-aa80d0a0a536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4919c263-a9d9-4ff2-979b-2ca8ff138200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4919c263-a9d9-4ff2-979b-2ca8ff138200.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -25993,7 +25993,7 @@
         },
         {
             "id": "8dbf3112-f2b4-50e8-8636-a924da13cf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9196b9-24b9-4398-b712-3fc0ee34717e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9196b9-24b9-4398-b712-3fc0ee34717e.jpg?1",
             "name": "Puresteel Paladin",
             "text": "",
             "colours": [
@@ -26031,7 +26031,7 @@
         },
         {
             "id": "410141b5-a666-55d8-b7ca-78443d064733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4ca60c-259e-4dfd-8b70-294bc551030f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4ca60c-259e-4dfd-8b70-294bc551030f.jpg?1",
             "name": "Secure the Wastes",
             "text": "",
             "colours": [
@@ -26066,7 +26066,7 @@
         },
         {
             "id": "e7354d78-02d6-5a50-a26b-ecd5044c232f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a92d8-18b6-4b60-8650-6f0c915211a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a92d8-18b6-4b60-8650-6f0c915211a6.jpg?1",
             "name": "Single Combat",
             "text": "",
             "colours": [
@@ -26101,7 +26101,7 @@
         },
         {
             "id": "c3cf378c-7bf6-5c87-b446-01e8db41737a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809cc7e4-215b-4b39-a5f3-e60240f1723f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809cc7e4-215b-4b39-a5f3-e60240f1723f.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -26134,7 +26134,7 @@
         },
         {
             "id": "8547c27b-9754-5eac-a2ec-b444675218ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bc488a-957a-43d5-bff5-587ced5dadb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bc488a-957a-43d5-bff5-587ced5dadb3.jpg?1",
             "name": "Valorous Stance",
             "text": "",
             "colours": [
@@ -26167,7 +26167,7 @@
         },
         {
             "id": "cdc16b28-06b7-50f1-9885-d5f6cf5bf57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e2ab1-71dc-4151-ab5e-7e1e26e193b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e2ab1-71dc-4151-ab5e-7e1e26e193b5.jpg?1",
             "name": "Fraying Sanity",
             "text": "",
             "colours": [
@@ -26205,7 +26205,7 @@
         },
         {
             "id": "6fe2e34f-4b65-5c44-a56f-bbf82884e1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0d649-8a4d-43e0-a923-bc5af1ca796b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0d649-8a4d-43e0-a923-bc5af1ca796b.jpg?1",
             "name": "Glimmer of Genius",
             "text": "",
             "colours": [
@@ -26238,7 +26238,7 @@
         },
         {
             "id": "ae2c299e-adae-56aa-862a-73b2b1cadc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b898e8c-43bd-4be2-9f7b-3937cd3549ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b898e8c-43bd-4be2-9f7b-3937cd3549ea.jpg?1",
             "name": "Inexorable Tide",
             "text": "",
             "colours": [
@@ -26273,7 +26273,7 @@
         },
         {
             "id": "00904105-1037-59c5-8207-eed4daab6815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e5d9eb-a9e8-4d9e-946f-8549f4f9c616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e5d9eb-a9e8-4d9e-946f-8549f4f9c616.jpg?1",
             "name": "Mechanized Production",
             "text": "",
             "colours": [
@@ -26310,7 +26310,7 @@
         },
         {
             "id": "0dbc40a5-ce84-5d8f-b882-b1971a0c3f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4145ffe0-8824-4a30-8b99-6d52184985b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4145ffe0-8824-4a30-8b99-6d52184985b4.jpg?1",
             "name": "One with the Machine",
             "text": "",
             "colours": [
@@ -26345,7 +26345,7 @@
         },
         {
             "id": "f15905f2-6a41-5084-8b28-40089ff94c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c89abbe-6391-438e-8ff9-e91484aa8139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c89abbe-6391-438e-8ff9-e91484aa8139.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "",
             "colours": [
@@ -26378,7 +26378,7 @@
         },
         {
             "id": "3afd1436-bea6-5a73-bb71-07ee5d0ee858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd71d34-3fd5-4029-b29f-b23e63ec2031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd71d34-3fd5-4029-b29f-b23e63ec2031.jpg?1",
             "name": "Whirler Rogue",
             "text": "",
             "colours": [
@@ -26415,7 +26415,7 @@
         },
         {
             "id": "df70ac3c-fe1b-59fd-bed6-886a2e8fce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d257c-3255-46f2-876f-9ecdcccfd133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d257c-3255-46f2-876f-9ecdcccfd133.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "",
             "colours": [
@@ -26448,7 +26448,7 @@
         },
         {
             "id": "6dca74fb-3abd-515e-8c6b-885745d1f403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e572d0-f2d0-4b92-ade3-d3ffafb75aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e572d0-f2d0-4b92-ade3-d3ffafb75aa0.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -26483,7 +26483,7 @@
         },
         {
             "id": "092ed834-553e-5162-afba-fb5f76c2090b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088d768f-5523-48ed-a038-6ef70961f674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088d768f-5523-48ed-a038-6ef70961f674.jpg?1",
             "name": "Deadly Dispute",
             "text": "",
             "colours": [
@@ -26516,7 +26516,7 @@
         },
         {
             "id": "b35ca6da-e32a-5deb-83a0-766948a87d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e765f41c-54b7-447e-853a-8453b44747b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e765f41c-54b7-447e-853a-8453b44747b2.jpg?1",
             "name": "Lethal Scheme",
             "text": "",
             "colours": [
@@ -26551,7 +26551,7 @@
         },
         {
             "id": "5a3e78e6-ef83-5ba6-ae4b-e867752ad9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9fa939-2891-41da-a50c-cd1c5ff5e15f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9fa939-2891-41da-a50c-cd1c5ff5e15f.jpg?1",
             "name": "Morbid Opportunist",
             "text": "",
             "colours": [
@@ -26587,7 +26587,7 @@
         },
         {
             "id": "5d23ec4c-6109-5e8d-9711-4f84b22c6553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4869d-fadd-41ec-862e-eb391996145f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4869d-fadd-41ec-862e-eb391996145f.jpg?1",
             "name": "Pitiless Plunderer",
             "text": "",
             "colours": [
@@ -26623,7 +26623,7 @@
         },
         {
             "id": "9c9630fb-019d-5cd8-863e-958fe3ac90e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e821a9f-6e5a-4314-82e7-8009d9aef1be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e821a9f-6e5a-4314-82e7-8009d9aef1be.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -26658,7 +26658,7 @@
         },
         {
             "id": "d16181d1-3a41-5ba4-8f1e-a5ec665d2ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c613d707-6f76-42f9-81f0-80954a7e77fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c613d707-6f76-42f9-81f0-80954a7e77fd.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -26693,7 +26693,7 @@
         },
         {
             "id": "1df09454-56f3-5477-b75f-0a40c646b50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bcd6c2-3112-42e3-80c6-2408622c3955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bcd6c2-3112-42e3-80c6-2408622c3955.jpg?1",
             "name": "Loyal Apprentice",
             "text": "",
             "colours": [
@@ -26729,7 +26729,7 @@
         },
         {
             "id": "52a52f52-3652-5fa5-b69c-fae4d8b7cffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46d567-495d-4b55-877f-87a1cef5d01a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46d567-495d-4b55-877f-87a1cef5d01a.jpg?1",
             "name": "Sticky Fingers",
             "text": "",
             "colours": [
@@ -26764,7 +26764,7 @@
         },
         {
             "id": "aa8a5f47-94b7-5196-b088-dbcf5b7e44bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dbfed-4134-466f-8591-9fe70078f97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dbfed-4134-466f-8591-9fe70078f97a.jpg?1",
             "name": "Stolen Strategy",
             "text": "",
             "colours": [
@@ -26799,7 +26799,7 @@
         },
         {
             "id": "b463f1da-a5ec-5ad5-8ab3-98f5a023a6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae31c29-280f-4459-9a11-6706cfa1fe2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae31c29-280f-4459-9a11-6706cfa1fe2c.jpg?1",
             "name": "Unexpected Windfall",
             "text": "",
             "colours": [
@@ -26832,7 +26832,7 @@
         },
         {
             "id": "e5e74cf1-1517-596b-b2d4-467fb6ebfcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ae59fe-6764-4374-84cd-86fa27818f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ae59fe-6764-4374-84cd-86fa27818f54.jpg?1",
             "name": "Abundant Growth",
             "text": "",
             "colours": [
@@ -26867,7 +26867,7 @@
         },
         {
             "id": "97430ca0-527f-5940-b748-ba164a65b725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3e8e9-58a3-4e88-a46d-498974ea6284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3e8e9-58a3-4e88-a46d-498974ea6284.jpg?1",
             "name": "Branching Evolution",
             "text": "",
             "colours": [
@@ -26902,7 +26902,7 @@
         },
         {
             "id": "01f3ebc7-6057-5b49-82e4-432d1dee9b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c97fe96-f30a-41ef-9d80-dd83207d14a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c97fe96-f30a-41ef-9d80-dd83207d14a4.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -26935,7 +26935,7 @@
         },
         {
             "id": "0047a173-7db7-53cd-b12f-39c66ef9dc3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114862d6-96b4-444e-95c0-67c6e1d8b9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114862d6-96b4-444e-95c0-67c6e1d8b9c7.jpg?1",
             "name": "Farseek",
             "text": "",
             "colours": [
@@ -26968,7 +26968,7 @@
         },
         {
             "id": "2dc40b62-f812-5d48-a4bf-8c4d7e8177a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd7e29-db55-472b-878e-02cbb46afe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd7e29-db55-472b-878e-02cbb46afe9e.jpg?1",
             "name": "Fertile Ground",
             "text": "",
             "colours": [
@@ -27003,7 +27003,7 @@
         },
         {
             "id": "25215a03-05ba-5e97-8e53-939748d09be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82cd903c-48de-46d0-a511-663f0f4f63fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82cd903c-48de-46d0-a511-663f0f4f63fe.jpg?1",
             "name": "Guardian Project",
             "text": "",
             "colours": [
@@ -27038,7 +27038,7 @@
         },
         {
             "id": "80f55a4d-8af1-594e-838c-8f2ae4d8ad8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a8288-05b2-4ec9-9712-17aa7f35332a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a8288-05b2-4ec9-9712-17aa7f35332a.jpg?1",
             "name": "Hardened Scales",
             "text": "",
             "colours": [
@@ -27073,7 +27073,7 @@
         },
         {
             "id": "571ccf95-c84e-514e-9d7d-be19c65c7709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3211a14-207a-4f95-ab2e-d64329a75bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3211a14-207a-4f95-ab2e-d64329a75bc5.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -27106,7 +27106,7 @@
         },
         {
             "id": "0d734746-9e47-5ab2-bbe5-3db52ece8052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94545a-407c-4e5f-950a-e052fd6bda46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94545a-407c-4e5f-950a-e052fd6bda46.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -27141,7 +27141,7 @@
         },
         {
             "id": "cebcb129-1b65-5ea3-bc9b-145442a6caac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c701031a-11d1-4aeb-993b-37775ade51d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c701031a-11d1-4aeb-993b-37775ade51d6.jpg?1",
             "name": "Inspiring Call",
             "text": "",
             "colours": [
@@ -27174,7 +27174,7 @@
         },
         {
             "id": "d0903ef6-340c-51d0-9e1c-dab2e10d2917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b134dc-b58f-43ca-9d7b-f5bead3a4e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b134dc-b58f-43ca-9d7b-f5bead3a4e2c.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -27207,7 +27207,7 @@
         },
         {
             "id": "5525aec6-1511-5af0-b0e7-c2b56c3e036b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d86ea97-0d7a-42ee-9d46-1c0dd10474c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d86ea97-0d7a-42ee-9d46-1c0dd10474c7.jpg?1",
             "name": "Rancor",
             "text": "",
             "colours": [
@@ -27242,7 +27242,7 @@
         },
         {
             "id": "9cbf050d-e6e8-57b1-b48c-c3ee4e5eab44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc59e1a-f0f5-4054-bedf-1908fc8646ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc59e1a-f0f5-4054-bedf-1908fc8646ec.jpg?1",
             "name": "Squirrel Nest",
             "text": "",
             "colours": [
@@ -27277,7 +27277,7 @@
         },
         {
             "id": "c1c82c6a-cd8b-5601-b5dc-ee0e5797d615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856cfb5a-6e85-4ac2-9964-19b6dc68e149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856cfb5a-6e85-4ac2-9964-19b6dc68e149.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -27315,7 +27315,7 @@
         },
         {
             "id": "3ef11719-4b4d-58ed-9a1f-b22f450ba5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6714a-a83f-417c-87a2-54b5d0c3cabc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6714a-a83f-417c-87a2-54b5d0c3cabc.jpg?1",
             "name": "Wild Growth",
             "text": "",
             "colours": [
@@ -27350,7 +27350,7 @@
         },
         {
             "id": "3fa5c3d6-7034-5717-b6be-22601b646cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b230483-dcdd-4731-b98c-cbb8c221de6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b230483-dcdd-4731-b98c-cbb8c221de6b.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -27387,7 +27387,7 @@
         },
         {
             "id": "d5c9658f-1fc1-5e85-888e-90c26db720de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515422b-5bdd-413b-a414-ad3510dd62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515422b-5bdd-413b-a414-ad3510dd62cc.jpg?1",
             "name": "Assemble the Legion",
             "text": "",
             "colours": [
@@ -27424,7 +27424,7 @@
         },
         {
             "id": "b8951125-7fe9-5bd4-8c9e-d906b4f0a4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d1950-2405-442a-841d-fced89280036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d1950-2405-442a-841d-fced89280036.jpg?1",
             "name": "Behemoth Sledge",
             "text": "",
             "colours": [
@@ -27461,7 +27461,7 @@
         },
         {
             "id": "534ef5f2-cbd0-5ce5-bb60-f90c08d1cb4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79bf08b-973a-45bc-ae96-43e93092f0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79bf08b-973a-45bc-ae96-43e93092f0c0.jpg?1",
             "name": "Biomass Mutation",
             "text": "",
             "colours": [
@@ -27498,7 +27498,7 @@
         },
         {
             "id": "2205b11d-c961-51ee-bbac-63722370a392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f8961-ddf0-4057-b434-b220d88b3e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f8961-ddf0-4057-b434-b220d88b3e2d.jpg?1",
             "name": "Casualties of War",
             "text": "",
             "colours": [
@@ -27535,7 +27535,7 @@
         },
         {
             "id": "d97a29ba-27e5-5ba7-b430-cffeea28e143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a7300-b2ce-4889-94a2-0b6ea823b575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a7300-b2ce-4889-94a2-0b6ea823b575.jpg?1",
             "name": "Corpsejack Menace",
             "text": "",
             "colours": [
@@ -27572,7 +27572,7 @@
         },
         {
             "id": "2c7c556d-31b4-5203-a6f0-fa6fb347a6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b2b8a4-3174-4188-959c-f456f9fcd563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b2b8a4-3174-4188-959c-f456f9fcd563.jpg?1",
             "name": "Fervent Charge",
             "text": "",
             "colours": [
@@ -27611,7 +27611,7 @@
         },
         {
             "id": "cb901e2c-8e64-5c78-9216-3867285eecc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg?1",
             "name": "Find // Finality",
             "text": "",
             "colours": [
@@ -27646,7 +27646,7 @@
         },
         {
             "id": "cc7fa634-6481-5ddb-bfd0-a98daa51ff07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg?1",
             "name": "Find // Finality",
             "text": "",
             "colours": [
@@ -27681,7 +27681,7 @@
         },
         {
             "id": "419f4dea-3312-5888-a8a7-b4c9a594a776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc140950-d7d0-46d3-98a0-8d1453f4b0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc140950-d7d0-46d3-98a0-8d1453f4b0cf.jpg?1",
             "name": "General's Enforcer",
             "text": "",
             "colours": [
@@ -27719,7 +27719,7 @@
         },
         {
             "id": "56ba5c0c-ca3a-5b05-a9d9-f369a30b4a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7092139a-f0ad-42fd-83f2-058650c01553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7092139a-f0ad-42fd-83f2-058650c01553.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "",
             "colours": [
@@ -27754,7 +27754,7 @@
         },
         {
             "id": "29a86617-6ddb-51c6-87c1-bd99dd7a5387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2e8b73-f4bc-4cd9-b442-eb1832399958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2e8b73-f4bc-4cd9-b442-eb1832399958.jpg?1",
             "name": "Putrefy",
             "text": "",
             "colours": [
@@ -27789,7 +27789,7 @@
         },
         {
             "id": "377f7221-1716-56d6-8dd9-639ef17983f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726cc21b-953e-41d3-b073-d2c6afdb0fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726cc21b-953e-41d3-b073-d2c6afdb0fbd.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "",
             "colours": [
@@ -27828,7 +27828,7 @@
         },
         {
             "id": "5fb996b5-f447-5719-9b20-ac7b6ef72038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc783338-4792-43a7-ab40-7151ba0e06a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc783338-4792-43a7-ab40-7151ba0e06a3.jpg?1",
             "name": "Wake the Past",
             "text": "",
             "colours": [
@@ -27865,7 +27865,7 @@
         },
         {
             "id": "9d67c08b-d2a3-5c70-bc93-b8c76f45333b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg?1",
             "name": "Wear // Tear",
             "text": "",
             "colours": [
@@ -27899,7 +27899,7 @@
         },
         {
             "id": "663ad389-c435-5d45-9ff0-a6acb6ff3705",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg?1",
             "name": "Wear // Tear",
             "text": "",
             "colours": [
@@ -27933,7 +27933,7 @@
         },
         {
             "id": "d417f0f7-b139-5fce-8ce1-1257b25880b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da1507-9ec6-40a9-a848-5110583bebfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da1507-9ec6-40a9-a848-5110583bebfe.jpg?1",
             "name": "Winding Constrictor",
             "text": "",
             "colours": [
@@ -27970,7 +27970,7 @@
         },
         {
             "id": "7cd0d6af-a365-5a59-8839-1f2e11e9f1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6e91b-5ea2-4e0e-8dcf-1f99ecaa7bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6e91b-5ea2-4e0e-8dcf-1f99ecaa7bc6.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -28001,7 +28001,7 @@
         },
         {
             "id": "de0e04a1-be48-5552-83db-20ecbea772e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab107ee4-5775-4376-9992-d380360f546c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab107ee4-5775-4376-9992-d380360f546c.jpg?1",
             "name": "Basilisk Collar",
             "text": "",
             "colours": [],
@@ -28034,7 +28034,7 @@
         },
         {
             "id": "0702f949-35bb-5eed-81e5-b1d29ca8a58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabd38d7-0170-4c78-940f-7dba9ffe1c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabd38d7-0170-4c78-940f-7dba9ffe1c46.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "",
             "colours": [],
@@ -28067,7 +28067,7 @@
         },
         {
             "id": "594fdd48-027f-5ed1-a25e-3bda1ba02ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6010f966-c931-4032-a59b-feeb428e0c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6010f966-c931-4032-a59b-feeb428e0c16.jpg?1",
             "name": "Brass Knuckles",
             "text": "",
             "colours": [],
@@ -28098,7 +28098,7 @@
         },
         {
             "id": "ae5c948c-815e-5fb6-8148-3a19a7c28787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aa98c5-0f8a-45b2-904d-29afeeb491bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aa98c5-0f8a-45b2-904d-29afeeb491bc.jpg?1",
             "name": "Champion's Helm",
             "text": "",
             "colours": [],
@@ -28131,7 +28131,7 @@
         },
         {
             "id": "69968591-eb37-5eb4-b114-9a34a665209f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6f54ff-507d-4f78-9293-7c5eac04bbcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6f54ff-507d-4f78-9293-7c5eac04bbcf.jpg?1",
             "name": "Contagion Clasp",
             "text": "",
             "colours": [],
@@ -28160,7 +28160,7 @@
         },
         {
             "id": "3f5852a8-ea6e-5eef-9eea-83153a25ec26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f1ca9-453c-49b6-a913-20e461b9ea1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f1ca9-453c-49b6-a913-20e461b9ea1b.jpg?1",
             "name": "Everflowing Chalice",
             "text": "",
             "colours": [],
@@ -28189,7 +28189,7 @@
         },
         {
             "id": "a015d57a-fa99-5979-932e-57e86f6fb4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68412b0-dd83-4346-9ed0-3cb8a4a0856f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68412b0-dd83-4346-9ed0-3cb8a4a0856f.jpg?1",
             "name": "Explorer's Scope",
             "text": "",
             "colours": [],
@@ -28220,7 +28220,7 @@
         },
         {
             "id": "0bbb3654-7a93-5c06-90c6-46ced32cfee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12fc244-ca30-4da6-8350-340975a79708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12fc244-ca30-4da6-8350-340975a79708.jpg?1",
             "name": "Fireshrieker",
             "text": "",
             "colours": [],
@@ -28251,7 +28251,7 @@
         },
         {
             "id": "f4b963da-aa5a-5ae6-a871-1a1bd7178553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db25753d-59e6-4866-92fe-2b38b0f72967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db25753d-59e6-4866-92fe-2b38b0f72967.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -28282,7 +28282,7 @@
         },
         {
             "id": "db589310-1951-5110-a453-ea99ffc1d943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b132024-7835-46ef-ac08-e2f88b5c6a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b132024-7835-46ef-ac08-e2f88b5c6a33.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "",
             "colours": [],
@@ -28315,7 +28315,7 @@
         },
         {
             "id": "48fc81a6-6fa9-5674-89ec-1c53926a0f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad9914-4a18-4679-8d41-1e338fc23fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad9914-4a18-4679-8d41-1e338fc23fe5.jpg?1",
             "name": "Mind Stone",
             "text": "",
             "colours": [],
@@ -28344,7 +28344,7 @@
         },
         {
             "id": "4ac6e15f-8e09-5326-97c6-99ba94975b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26614a2-b6ce-4161-89ee-d9596a97a146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26614a2-b6ce-4161-89ee-d9596a97a146.jpg?1",
             "name": "Mystic Forge",
             "text": "",
             "colours": [],
@@ -28375,7 +28375,7 @@
         },
         {
             "id": "357b02df-8d0b-5184-af4c-99a67821aabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7721abe9-79a1-4831-87f4-95184e9223c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7721abe9-79a1-4831-87f4-95184e9223c8.jpg?1",
             "name": "Panharmonicon",
             "text": "",
             "colours": [],
@@ -28406,7 +28406,7 @@
         },
         {
             "id": "6f1524d5-5ffe-5b0d-992e-dd5a47b34d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb146d9a-f66a-460d-a230-942d04a9658e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb146d9a-f66a-460d-a230-942d04a9658e.jpg?1",
             "name": "Skullclamp",
             "text": "",
             "colours": [],
@@ -28437,7 +28437,7 @@
         },
         {
             "id": "890fe5f5-9851-583e-9331-f31d9c85ec35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8260eef-5ff2-4058-8aa5-469b402eaf65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8260eef-5ff2-4058-8aa5-469b402eaf65.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -28468,7 +28468,7 @@
         },
         {
             "id": "7b872052-35a7-5691-a6a9-b5f52c40ff6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd833ea2-6bef-4abc-8111-d7903ae4130a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd833ea2-6bef-4abc-8111-d7903ae4130a.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -28502,7 +28502,7 @@
         },
         {
             "id": "d4a11d8f-b0b9-5ec4-bbd5-8e58a44be74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f194b1-463b-4e82-961a-61be31fae8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f194b1-463b-4e82-961a-61be31fae8ab.jpg?1",
             "name": "Steel Overseer",
             "text": "",
             "colours": [],
@@ -28536,7 +28536,7 @@
         },
         {
             "id": "1182227f-82a4-5cfd-822f-8d662294ad25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae6364-fd70-403a-8ffd-9a584e992e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae6364-fd70-403a-8ffd-9a584e992e4a.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "",
             "colours": [],
@@ -28567,7 +28567,7 @@
         },
         {
             "id": "b2358196-f6b1-560a-a285-22f73e5ce409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b6a71d-83f3-4aaa-8bbc-d1dabaaade08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b6a71d-83f3-4aaa-8bbc-d1dabaaade08.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -28599,7 +28599,7 @@
         },
         {
             "id": "28e30e81-3b22-5b1d-81e8-46bfb001b454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bf263b-a568-4901-a9c7-205aabf2b631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bf263b-a568-4901-a9c7-205aabf2b631.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -28631,7 +28631,7 @@
         },
         {
             "id": "fc2c7103-02ff-58b2-9047-c87b351cea51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c74a36-5d0f-49fe-b1ec-330f40c9abca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c74a36-5d0f-49fe-b1ec-330f40c9abca.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -28663,7 +28663,7 @@
         },
         {
             "id": "9f2f875f-3d77-5fc0-931b-117f38e34132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd2d-89cb-464d-bba5-e7da37776454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd2d-89cb-464d-bba5-e7da37776454.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -28695,7 +28695,7 @@
         },
         {
             "id": "74a48df5-e214-56a9-8520-1437e93e0d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e890d8-6542-4d8e-9782-94fb5a74e244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e890d8-6542-4d8e-9782-94fb5a74e244.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "",
             "colours": [],
@@ -28727,7 +28727,7 @@
         },
         {
             "id": "3013ea62-de93-56b6-a1e8-d4c4f096f980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8190e77f-05ff-4b24-9b09-60bc8d6a6577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8190e77f-05ff-4b24-9b09-60bc8d6a6577.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -28759,7 +28759,7 @@
         },
         {
             "id": "8251f745-be05-5292-88f0-91c5b8b5be7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132b71a-032e-488d-ac63-ffbc4b18a745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132b71a-032e-488d-ac63-ffbc4b18a745.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -28791,7 +28791,7 @@
         },
         {
             "id": "73a54f11-b110-5010-b405-5c5fa52bfeca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b403f3-8570-4a60-9e03-49cd85f66f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b403f3-8570-4a60-9e03-49cd85f66f69.jpg?1",
             "name": "Talisman of Resilience",
             "text": "",
             "colours": [],
@@ -28823,7 +28823,7 @@
         },
         {
             "id": "03e1fc42-be68-522d-a4cb-1629ebdf7085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f626574-9eb2-4d17-be70-24216f1a7cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f626574-9eb2-4d17-be70-24216f1a7cb9.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -28852,7 +28852,7 @@
         },
         {
             "id": "6f27be9c-0d1d-56d3-9bee-40e7364e2d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a633b4-2c18-46f0-a902-4699a4021c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a633b4-2c18-46f0-a902-4699a4021c4d.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "",
             "colours": [],
@@ -28881,7 +28881,7 @@
         },
         {
             "id": "896fc7b5-fae4-5765-8efe-d2ee8f34e5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f448c0c-c9d2-4e3c-91b1-d8cf6b9072e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f448c0c-c9d2-4e3c-91b1-d8cf6b9072e1.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -28910,7 +28910,7 @@
         },
         {
             "id": "dd28c478-40a1-598a-ae5b-33987f67709f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67a003-7a1e-410b-9758-d8f005e84028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67a003-7a1e-410b-9758-d8f005e84028.jpg?1",
             "name": "Buried Ruin",
             "text": "",
             "colours": [],
@@ -28939,7 +28939,7 @@
         },
         {
             "id": "3e6b845e-8004-50a3-8047-7f3f73ce1497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b0a2f-53ef-43d4-99a8-9967db05e39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b0a2f-53ef-43d4-99a8-9967db05e39e.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -28976,7 +28976,7 @@
         },
         {
             "id": "e2890903-09ef-5575-9338-c7d67d7994f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad503ae-45f1-406b-b1c6-06fcb9d2f2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad503ae-45f1-406b-b1c6-06fcb9d2f2b1.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -29013,7 +29013,7 @@
         },
         {
             "id": "a143ef65-6d82-5387-8fd1-84b410ed814f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7bab64-177f-411c-bdf5-6a41dd4bb89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7bab64-177f-411c-bdf5-6a41dd4bb89a.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -29050,7 +29050,7 @@
         },
         {
             "id": "96839880-fbf4-532e-82f5-87008a06fe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20c3bf2-15f6-4692-b0d8-69a80adc55c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20c3bf2-15f6-4692-b0d8-69a80adc55c4.jpg?1",
             "name": "Clifftop Retreat",
             "text": "",
             "colours": [],
@@ -29084,7 +29084,7 @@
         },
         {
             "id": "34447e9f-3b26-5c28-b78e-dbe6c817e611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1bb7b31-9da7-4146-be80-0d5d1245ca48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1bb7b31-9da7-4146-be80-0d5d1245ca48.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -29115,7 +29115,7 @@
         },
         {
             "id": "4cac4ae6-ffde-5612-a711-a6b511eb3f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c3285-a1d8-4f7e-8fe7-1ba0d96dca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c3285-a1d8-4f7e-8fe7-1ba0d96dca51.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -29149,7 +29149,7 @@
         },
         {
             "id": "40d4ef21-57d3-55b2-b622-92bafb06aad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83f390-66cd-46a7-8b4c-752a3782fc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83f390-66cd-46a7-8b4c-752a3782fc7c.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -29183,7 +29183,7 @@
         },
         {
             "id": "8ec130d8-3046-5049-b191-a7408549660d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e37b17-de7c-4acf-b16a-404036525c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e37b17-de7c-4acf-b16a-404036525c2f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -29217,7 +29217,7 @@
         },
         {
             "id": "36fde2ae-bf1c-5544-bf0d-52bc1b131b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a3a97-f17a-4626-b6a5-94bc2be62f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a3a97-f17a-4626-b6a5-94bc2be62f03.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -29246,7 +29246,7 @@
         },
         {
             "id": "6a57d0fe-63aa-5173-802f-003cc31fde27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c052fe03-d300-41e2-89ff-054d32c4280b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c052fe03-d300-41e2-89ff-054d32c4280b.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -29277,7 +29277,7 @@
         },
         {
             "id": "d39c6ceb-adbb-5b90-b048-6a7b6aae87b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8abd26-fdba-4c08-9fa3-cab805e1908c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8abd26-fdba-4c08-9fa3-cab805e1908c.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -29314,7 +29314,7 @@
         },
         {
             "id": "dc078767-6fe1-5f58-a330-bd5e9b8e401c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ed4714-ed3d-45b6-a427-f0dcbf7e48c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ed4714-ed3d-45b6-a427-f0dcbf7e48c9.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -29348,7 +29348,7 @@
         },
         {
             "id": "77fe7d72-8996-5b3d-9dbc-d1adabda5b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7558a926-9b97-4981-89ac-6a2890cf6d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7558a926-9b97-4981-89ac-6a2890cf6d21.jpg?1",
             "name": "Hinterland Harbor",
             "text": "",
             "colours": [],
@@ -29382,7 +29382,7 @@
         },
         {
             "id": "a94a492b-2faa-555f-89de-6408062490b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddf5f7-cc9c-433a-b2db-fb8dbe3b7248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddf5f7-cc9c-433a-b2db-fb8dbe3b7248.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -29419,7 +29419,7 @@
         },
         {
             "id": "1f5116ab-9327-522e-bd2f-1dfddb7935dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe452473-c99f-4ca2-a9a4-b69fe93e521f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe452473-c99f-4ca2-a9a4-b69fe93e521f.jpg?1",
             "name": "Isolated Chapel",
             "text": "",
             "colours": [],
@@ -29453,7 +29453,7 @@
         },
         {
             "id": "6173d627-a923-5f68-842f-a125db1c1336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8f174c-c16b-4b60-aa02-3d1f3a3f7989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8f174c-c16b-4b60-aa02-3d1f3a3f7989.jpg?1",
             "name": "Jungle Shrine",
             "text": "",
             "colours": [],
@@ -29486,7 +29486,7 @@
         },
         {
             "id": "e4b6baeb-478a-5f3b-b366-9c5af792fc97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd62678-4c82-4bb1-b1c7-9dc701cde473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd62678-4c82-4bb1-b1c7-9dc701cde473.jpg?1",
             "name": "Memorial to Glory",
             "text": "",
             "colours": [],
@@ -29517,7 +29517,7 @@
         },
         {
             "id": "c4ab4644-2e42-52eb-897c-fae32cf40e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872b085d-f633-4bb4-91ab-956e0f8f3dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872b085d-f633-4bb4-91ab-956e0f8f3dc8.jpg?1",
             "name": "Mortuary Mire",
             "text": "",
             "colours": [],
@@ -29548,7 +29548,7 @@
         },
         {
             "id": "62ecde0f-cff2-5873-b618-5db197ef2bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80804054-1d2d-4f41-8399-3931e80a1e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80804054-1d2d-4f41-8399-3931e80a1e92.jpg?1",
             "name": "Mossfire Valley",
             "text": "",
             "colours": [],
@@ -29582,7 +29582,7 @@
         },
         {
             "id": "c2a7b3c2-d885-55de-b1a4-61bce82b1de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369fe1f-35b5-4b0f-be65-e6761c6852cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369fe1f-35b5-4b0f-be65-e6761c6852cf.jpg?1",
             "name": "Myriad Landscape",
             "text": "",
             "colours": [],
@@ -29611,7 +29611,7 @@
         },
         {
             "id": "6b368877-4d77-5bd4-ba0f-3a333545894f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0a61d8-9a11-413b-b836-a7d57f3de1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0a61d8-9a11-413b-b836-a7d57f3de1d9.jpg?1",
             "name": "Mystic Monastery",
             "text": "",
             "colours": [],
@@ -29644,7 +29644,7 @@
         },
         {
             "id": "d3255f48-b214-5c77-a6cd-ea0020e227e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb45f3c2-6c64-429a-abb2-0ba9424b58bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb45f3c2-6c64-429a-abb2-0ba9424b58bb.jpg?1",
             "name": "Nesting Grounds",
             "text": "",
             "colours": [],
@@ -29675,7 +29675,7 @@
         },
         {
             "id": "be338c31-dedd-5c6c-a167-4cc115195208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a172fb-883d-4499-97e5-4de0d10e3e19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a172fb-883d-4499-97e5-4de0d10e3e19.jpg?1",
             "name": "Nomad Outpost",
             "text": "",
             "colours": [],
@@ -29708,7 +29708,7 @@
         },
         {
             "id": "04b665a9-7413-587d-acc2-08dfb8a92d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3647db5-e95b-46e5-b2a2-969cf1f2a492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3647db5-e95b-46e5-b2a2-969cf1f2a492.jpg?1",
             "name": "Opulent Palace",
             "text": "",
             "colours": [],
@@ -29741,7 +29741,7 @@
         },
         {
             "id": "b68e5a76-61fd-5dd4-b9a8-cdf3940a96da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da838121-732e-4cf2-9456-487306129a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da838121-732e-4cf2-9456-487306129a73.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -29770,7 +29770,7 @@
         },
         {
             "id": "bac55529-5719-5a9d-b4d9-f2263651d785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ac603e-d8c9-4917-855a-23cece560068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ac603e-d8c9-4917-855a-23cece560068.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -29807,7 +29807,7 @@
         },
         {
             "id": "43cc3994-c9be-5822-b342-515874a6da5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4d3468-ee25-4b02-bcb9-8860c5b5ce4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4d3468-ee25-4b02-bcb9-8860c5b5ce4b.jpg?1",
             "name": "Razortide Bridge",
             "text": "",
             "colours": [],
@@ -29840,7 +29840,7 @@
         },
         {
             "id": "9e6fe040-e0d3-52ae-8e8d-64dacf57a9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6624d46-4a49-4125-b536-9300527975b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6624d46-4a49-4125-b536-9300527975b9.jpg?1",
             "name": "Roadside Reliquary",
             "text": "",
             "colours": [],
@@ -29869,7 +29869,7 @@
         },
         {
             "id": "2c33c0a6-1255-5ce5-b9b3-1211fb0321db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dae074c-d52c-482e-851a-48c89ee50802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dae074c-d52c-482e-851a-48c89ee50802.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -29898,7 +29898,7 @@
         },
         {
             "id": "3729cba0-1ac9-5290-83fe-a7bcf85f3c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7b74-97b8-4a2b-a317-de0bb7aed6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7b74-97b8-4a2b-a317-de0bb7aed6f9.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -29932,7 +29932,7 @@
         },
         {
             "id": "7d25d125-dd35-5aef-a9ee-fe05cf6c23b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fac8e5-d471-4a30-84e9-72b3dce529c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fac8e5-d471-4a30-84e9-72b3dce529c3.jpg?1",
             "name": "Rustvale Bridge",
             "text": "",
             "colours": [],
@@ -29965,7 +29965,7 @@
         },
         {
             "id": "0e6f3256-067e-5bd6-809b-c2a2669a0600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82dc7d0-e2da-4d59-9c24-b631048c9ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82dc7d0-e2da-4d59-9c24-b631048c9ebe.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -30002,7 +30002,7 @@
         },
         {
             "id": "578d17ad-365b-50b7-8fdd-62ab32aca34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125bebe-71f9-429f-a50d-3b7eb11fe5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125bebe-71f9-429f-a50d-3b7eb11fe5ac.jpg?1",
             "name": "Scavenger Grounds",
             "text": "",
             "colours": [],
@@ -30035,7 +30035,7 @@
         },
         {
             "id": "23235e99-9d68-5e24-a45a-ace3c397c8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad2ea22-64ca-443c-9530-1f36fa58a0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad2ea22-64ca-443c-9530-1f36fa58a0d8.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -30069,7 +30069,7 @@
         },
         {
             "id": "7c731eca-32f6-5c02-86b0-1a69475bd65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bff6bd-7a60-4824-9b2b-70b9a48610ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bff6bd-7a60-4824-9b2b-70b9a48610ba.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -30106,7 +30106,7 @@
         },
         {
             "id": "97d8c6d9-3254-599c-95e7-796a9215442a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b943a5c6-01c9-4ff1-9e52-37899ee885ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b943a5c6-01c9-4ff1-9e52-37899ee885ea.jpg?1",
             "name": "Silverbluff Bridge",
             "text": "",
             "colours": [],
@@ -30139,7 +30139,7 @@
         },
         {
             "id": "555e45a9-90a6-5d8a-bb40-84d800d2a851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1a1c2-1b00-4eb3-a537-33402a471308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1a1c2-1b00-4eb3-a537-33402a471308.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -30173,7 +30173,7 @@
         },
         {
             "id": "1d34e956-287b-5c1e-8bf7-46be79093a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77861dbb-86d6-4c3e-9680-e1155015b936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77861dbb-86d6-4c3e-9680-e1155015b936.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -30210,7 +30210,7 @@
         },
         {
             "id": "d825dd73-e740-58ac-aa7d-270ceda921d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e60a0b4-357b-4221-baff-afcda079422c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e60a0b4-357b-4221-baff-afcda079422c.jpg?1",
             "name": "Spire of Industry",
             "text": "",
             "colours": [],
@@ -30241,7 +30241,7 @@
         },
         {
             "id": "a9a10f92-a0ee-59ad-b96d-20001a1139e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceed6d6f-bec8-46c8-a59c-5fc3f1f4d8c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceed6d6f-bec8-46c8-a59c-5fc3f1f4d8c0.jpg?1",
             "name": "Sulfur Falls",
             "text": "",
             "colours": [],
@@ -30275,7 +30275,7 @@
         },
         {
             "id": "4f3858e9-0e59-5de3-b8a8-24070b4255d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a992ab-dbf6-4585-bdaf-f44de250d9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a992ab-dbf6-4585-bdaf-f44de250d9a7.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -30309,7 +30309,7 @@
         },
         {
             "id": "c5f90716-80d4-5b9a-951b-ae96bc5b077c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719122c5-eeca-4424-8be7-c66baf5083ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719122c5-eeca-4424-8be7-c66baf5083ab.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -30346,7 +30346,7 @@
         },
         {
             "id": "1b7be27a-43f8-5ba2-adf0-dec0df30886d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984ac231-5488-4312-bdc7-b425d2e7061f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984ac231-5488-4312-bdc7-b425d2e7061f.jpg?1",
             "name": "Sunpetal Grove",
             "text": "",
             "colours": [],
@@ -30380,7 +30380,7 @@
         },
         {
             "id": "6b57df2a-d8f5-5f6d-9426-99253f43bad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5d15cd-e6d9-4146-8bdc-b0c65b469dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5d15cd-e6d9-4146-8bdc-b0c65b469dbe.jpg?1",
             "name": "Tainted Field",
             "text": "",
             "colours": [],
@@ -30412,7 +30412,7 @@
         },
         {
             "id": "ba1bae6b-377e-56af-bb81-3b05773fc072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94ddd6-e957-4eb2-96e3-56db87aba066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94ddd6-e957-4eb2-96e3-56db87aba066.jpg?1",
             "name": "Tainted Isle",
             "text": "",
             "colours": [],
@@ -30444,7 +30444,7 @@
         },
         {
             "id": "44ef23f2-256f-5d96-93a0-e08d470ed06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887b00e-cf23-4b01-80de-20ff037aaea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887b00e-cf23-4b01-80de-20ff037aaea9.jpg?1",
             "name": "Tainted Peak",
             "text": "",
             "colours": [],
@@ -30476,7 +30476,7 @@
         },
         {
             "id": "02743741-8882-5d9c-9941-4ef24e69f041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efd18dc-ccb4-46a0-b080-50fdec45d745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efd18dc-ccb4-46a0-b080-50fdec45d745.jpg?1",
             "name": "Tainted Wood",
             "text": "",
             "colours": [],
@@ -30508,7 +30508,7 @@
         },
         {
             "id": "611992a2-a0d8-5e93-9897-3545e709c7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e4b28-8800-48cf-ace8-1669cfd5f67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e4b28-8800-48cf-ace8-1669cfd5f67c.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -30542,7 +30542,7 @@
         },
         {
             "id": "240dffd9-fb53-55dc-8de6-9cd03d5cb17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d322d8-cbce-4be3-9b7d-d4876031f92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d322d8-cbce-4be3-9b7d-d4876031f92f.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -30576,7 +30576,7 @@
         },
         {
             "id": "7ae0c7a5-bda7-588f-b2aa-ad5943531102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be15d793-4706-4c68-9938-a1f8bfeb5674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be15d793-4706-4c68-9938-a1f8bfeb5674.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -30610,7 +30610,7 @@
         },
         {
             "id": "6f58825c-5879-5e99-bc00-1a657fe33d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b49d5-25cb-451c-a68a-e5b7de8e1f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b49d5-25cb-451c-a68a-e5b7de8e1f00.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -30644,7 +30644,7 @@
         },
         {
             "id": "1224e929-416d-5f23-b787-4dd0f0642156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2689b828-85de-4493-bd5e-81858513fa3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2689b828-85de-4493-bd5e-81858513fa3c.jpg?1",
             "name": "Temple of Malady",
             "text": "",
             "colours": [],
@@ -30678,7 +30678,7 @@
         },
         {
             "id": "52e4dc8f-642c-534e-8f76-43d6c5ad7960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3c5245-f328-4fdf-9193-75dfb6de03ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3c5245-f328-4fdf-9193-75dfb6de03ad.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -30712,7 +30712,7 @@
         },
         {
             "id": "973390aa-348f-5992-ae2c-bfaa0e784178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9120c4-1a4d-4bd8-a03b-9070781677a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9120c4-1a4d-4bd8-a03b-9070781677a5.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -30746,7 +30746,7 @@
         },
         {
             "id": "61efae05-eecc-5cb8-b69b-5546078554c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a67571c-f89b-4cb2-8c62-9bfc35acab1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a67571c-f89b-4cb2-8c62-9bfc35acab1d.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -30780,7 +30780,7 @@
         },
         {
             "id": "73a1dc27-3e35-553d-93bd-9a4d1d2d6510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e0c9e5-9432-47ae-891f-dadf2558736b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e0c9e5-9432-47ae-891f-dadf2558736b.jpg?1",
             "name": "Temple of Silence",
             "text": "",
             "colours": [],
@@ -30814,7 +30814,7 @@
         },
         {
             "id": "9669c7a4-f547-51ca-9e70-93724095cc65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0778f4-2717-4e77-84cf-d01d359004ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0778f4-2717-4e77-84cf-d01d359004ed.jpg?1",
             "name": "Temple of the False God",
             "text": "",
             "colours": [],
@@ -30843,7 +30843,7 @@
         },
         {
             "id": "4c835bf1-a3af-5c83-b142-cb5acb363b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ec3ada-496e-4bee-ab87-55ae3734cc03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ec3ada-496e-4bee-ab87-55ae3734cc03.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -30877,7 +30877,7 @@
         },
         {
             "id": "b0bd46af-53ea-5369-8032-2247391912a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b79a1a-b627-42ec-8ddb-c43d9765cf85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b79a1a-b627-42ec-8ddb-c43d9765cf85.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -30906,7 +30906,7 @@
         },
         {
             "id": "901cc318-7821-5185-a8e8-6e144c2a3939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb659e8d-c7e9-4035-82b1-d2427da081a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb659e8d-c7e9-4035-82b1-d2427da081a6.jpg?1",
             "name": "Treasure Vault",
             "text": "",
             "colours": [],
@@ -30938,7 +30938,7 @@
         },
         {
             "id": "18394ad1-50a1-5755-a341-faedb1a857bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a2ef6-4316-4dbf-9725-7da20f38218d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a2ef6-4316-4dbf-9725-7da20f38218d.jpg?1",
             "name": "Windbrisk Heights",
             "text": "",
             "colours": [],
@@ -30971,7 +30971,7 @@
         },
         {
             "id": "f60d7f3e-6bc0-52d0-9ace-c6692af6e01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613e0e75-9b61-4c16-bb83-53546dc9f502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613e0e75-9b61-4c16-bb83-53546dc9f502.jpg?1",
             "name": "Woodland Cemetery",
             "text": "",
             "colours": [],
@@ -31005,7 +31005,7 @@
         },
         {
             "id": "36f2217c-e576-502c-9f53-66659ed7fc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c15c48-8425-48f5-80f7-c8f74ad773e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c15c48-8425-48f5-80f7-c8f74ad773e1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -31042,7 +31042,7 @@
         },
         {
             "id": "56c03c7d-74c6-5fef-98b7-5e230d49e534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783eeb62-ab10-437d-a6cd-c3f99401b818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783eeb62-ab10-437d-a6cd-c3f99401b818.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -31079,7 +31079,7 @@
         },
         {
             "id": "8c79a832-3809-52c0-9f9c-69e5a0e9f955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6317711a-83fc-4f6e-87d2-a147b34275ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6317711a-83fc-4f6e-87d2-a147b34275ec.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -31116,7 +31116,7 @@
         },
         {
             "id": "53815ef0-7bdf-5582-9eb1-66ec07ee6407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0480b669-e72b-4b21-b0f3-09d78abe421c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0480b669-e72b-4b21-b0f3-09d78abe421c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -31153,7 +31153,7 @@
         },
         {
             "id": "801ceeaa-a2e5-5fc0-8506-ca2548959873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37f8bb9-1d63-4f28-b15d-06f423785599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37f8bb9-1d63-4f28-b15d-06f423785599.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -31190,7 +31190,7 @@
         },
         {
             "id": "0fe24ba3-3454-5c17-9bbf-d4c7e4a7dc96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c16759-117f-4f17-baea-88b18d391c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c16759-117f-4f17-baea-88b18d391c38.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -31227,7 +31227,7 @@
         },
         {
             "id": "792c949a-cd53-5b66-8a2d-997ea2514bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0e93c3-48e3-4ae5-a33f-4ef83f67ee37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0e93c3-48e3-4ae5-a33f-4ef83f67ee37.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -31264,7 +31264,7 @@
         },
         {
             "id": "9c056223-0361-52b9-9f43-4e07641c2f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84298c7a-8bae-4e62-bd0a-bcce2156fdf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84298c7a-8bae-4e62-bd0a-bcce2156fdf1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -31301,7 +31301,7 @@
         },
         {
             "id": "1806d26c-f48b-542a-be8a-9e4de194fa9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35801ab-e484-44cb-b9ec-80723cb25bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35801ab-e484-44cb-b9ec-80723cb25bc7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -31338,7 +31338,7 @@
         },
         {
             "id": "52bc880b-c907-52d6-8eb6-931fe4e2d356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9305b9c-63af-49a3-97c2-0b3597555cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9305b9c-63af-49a3-97c2-0b3597555cc2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -31375,7 +31375,7 @@
         },
         {
             "id": "a077cbb1-43ac-5ba5-b5bb-deabf3d78574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682f0d75-0c08-4a4f-990c-2cc14761b616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682f0d75-0c08-4a4f-990c-2cc14761b616.jpg?1",
             "name": "Idolized",
             "text": "",
             "colours": [
@@ -31412,7 +31412,7 @@
         },
         {
             "id": "e5dc9bf6-0d04-5d65-94d8-9625c53034d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7951636-0969-4157-a9a5-96f86f61524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7951636-0969-4157-a9a5-96f86f61524c.jpg?1",
             "name": "Securitron Squadron",
             "text": "",
             "colours": [
@@ -31450,7 +31450,7 @@
         },
         {
             "id": "9915c1df-c151-5e79-9936-f4ecad7b17b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0ba541-930a-404f-bd38-f1aa8bd52ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0ba541-930a-404f-bd38-f1aa8bd52ed5.jpg?1",
             "name": "Radstorm",
             "text": "",
             "colours": [
@@ -31485,7 +31485,7 @@
         },
         {
             "id": "8936e594-33f8-54e0-822a-c379bf8c1373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ebaef-f153-4e5f-86d4-03750c80416a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ebaef-f153-4e5f-86d4-03750c80416a.jpg?1",
             "name": "Synth Infiltrator",
             "text": "",
             "colours": [
@@ -31523,7 +31523,7 @@
         },
         {
             "id": "c7d6f045-fdf4-5ce2-a716-ee98e7ea313e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf96a60-ab61-410e-9faf-1aba5fb81bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf96a60-ab61-410e-9faf-1aba5fb81bfb.jpg?1",
             "name": "Nuclear Fallout",
             "text": "",
             "colours": [
@@ -31558,7 +31558,7 @@
         },
         {
             "id": "6f0d9e88-d1e9-5135-8843-10b2a35aad6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bcd152-b1ba-4c49-8ad9-c71f31218ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bcd152-b1ba-4c49-8ad9-c71f31218ba8.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "",
             "colours": [
@@ -31596,7 +31596,7 @@
         },
         {
             "id": "84bb2aeb-52f6-5c38-84d7-02513c174ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa9106-9ea8-4497-98a8-a005f5437a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa9106-9ea8-4497-98a8-a005f5437a30.jpg?1",
             "name": "V.A.T.S.",
             "text": "",
             "colours": [
@@ -31631,7 +31631,7 @@
         },
         {
             "id": "5b057419-8c77-5417-bf15-9c69c3c65db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad3fb9e-ec2e-4ac5-ba77-7052ebc3a2ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad3fb9e-ec2e-4ac5-ba77-7052ebc3a2ab.jpg?1",
             "name": "Mysterious Stranger",
             "text": "",
             "colours": [
@@ -31669,7 +31669,7 @@
         },
         {
             "id": "d8e2c85a-bc7e-53a3-9231-96c49a0a4f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29442821-cb24-4e55-b65a-88742cd793ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29442821-cb24-4e55-b65a-88742cd793ef.jpg?1",
             "name": "Watchful Radstag",
             "text": "",
             "colours": [
@@ -31707,7 +31707,7 @@
         },
         {
             "id": "bec120ae-6e85-53d5-986a-9ab2f363275d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a85ee1e-554e-42cf-88da-2de42a43c293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a85ee1e-554e-42cf-88da-2de42a43c293.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "",
             "colours": [
@@ -31747,7 +31747,7 @@
         },
         {
             "id": "fcb5130d-0974-5b56-ab32-0d51a34cf19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a1c494-b569-4cf4-9af2-d462c38f1792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a1c494-b569-4cf4-9af2-d462c38f1792.jpg?1",
             "name": "Armory Paladin",
             "text": "",
             "colours": [
@@ -31787,7 +31787,7 @@
         },
         {
             "id": "6693e602-b3a1-533c-881e-ea0e816455f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da41054-7f89-4c74-8c58-092f9d6ed144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da41054-7f89-4c74-8c58-092f9d6ed144.jpg?1",
             "name": "Atomize",
             "text": "",
             "colours": [
@@ -31824,7 +31824,7 @@
         },
         {
             "id": "e962df5e-6e2c-535d-9a75-98ba63d9cb72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87eec46e-dc81-45aa-9026-c010663e0756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87eec46e-dc81-45aa-9026-c010663e0756.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "",
             "colours": [
@@ -31869,7 +31869,7 @@
         },
         {
             "id": "4ef39d13-b1e3-580a-9903-c5251abcdfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985d780d-e049-4638-8f5a-9611efcfe09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985d780d-e049-4638-8f5a-9611efcfe09f.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "",
             "colours": [
@@ -31913,7 +31913,7 @@
         },
         {
             "id": "cd434f3b-4abe-53cb-9079-fe781d655544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b35ceb-1927-4a87-a489-7b2bc9b9ceaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b35ceb-1927-4a87-a489-7b2bc9b9ceaa.jpg?1",
             "name": "Dr. Madison Li",
             "text": "",
             "colours": [
@@ -31958,7 +31958,7 @@
         },
         {
             "id": "03729953-cf82-5e40-b048-5908d9d35663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b81d84-cc20-4123-9aab-56abdadb3516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b81d84-cc20-4123-9aab-56abdadb3516.jpg?1",
             "name": "Inventory Management",
             "text": "",
             "colours": [
@@ -31995,7 +31995,7 @@
         },
         {
             "id": "fff584d9-2778-52d3-9cb0-a561f284970d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a769dd6-3018-412f-b8ea-2434c5074945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a769dd6-3018-412f-b8ea-2434c5074945.jpg?1",
             "name": "The Wise Mothman",
             "text": "",
             "colours": [
@@ -32040,7 +32040,7 @@
         },
         {
             "id": "f89dec07-fa46-54e5-bc88-e9dc440b1cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82e6a6-2ed6-4e97-a637-586d65af7aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82e6a6-2ed6-4e97-a637-586d65af7aaf.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "",
             "colours": [
@@ -32076,7 +32076,7 @@
         },
         {
             "id": "2c3e8298-1b05-5fd1-ae2b-0b055d0f65f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342240d-cbcc-41a0-9b7d-514ca2273b80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342240d-cbcc-41a0-9b7d-514ca2273b80.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -32111,7 +32111,7 @@
         },
         {
             "id": "38ecdfce-08c8-5ede-9762-38939023407a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664c7357-93c3-4148-baf4-d7c88aa69ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664c7357-93c3-4148-baf4-d7c88aa69ac9.jpg?1",
             "name": "Grave Titan",
             "text": "",
             "colours": [
@@ -32146,7 +32146,7 @@
         },
         {
             "id": "dd53937f-0766-55b2-b44f-41f9838f1b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d78449-9e80-42e5-b525-068a3985e069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d78449-9e80-42e5-b525-068a3985e069.jpg?1",
             "name": "Vigor",
             "text": "",
             "colours": [
@@ -32182,7 +32182,7 @@
         },
         {
             "id": "19b6f43a-e99e-58a0-b8cd-b461be39cdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b20cbf0-0cfe-4adb-bbf5-31ff98cd8382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b20cbf0-0cfe-4adb-bbf5-31ff98cd8382.jpg?1",
             "name": "Ayula, Queen Among Bears",
             "text": "",
             "colours": [
@@ -32219,7 +32219,7 @@
         },
         {
             "id": "16261784-995c-567c-80a0-a617974a9d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb6278-9b1d-4bac-bebd-e084e713d54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb6278-9b1d-4bac-bebd-e084e713d54a.jpg?1",
             "name": "Tarmogoyf",
             "text": "",
             "colours": [
@@ -32254,7 +32254,7 @@
         },
         {
             "id": "615fac4e-e777-56d1-a081-5d76072e8b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35408cdb-5123-455b-9944-a871d5303510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35408cdb-5123-455b-9944-a871d5303510.jpg?1",
             "name": "Hornet Queen",
             "text": "",
             "colours": [
@@ -32289,7 +32289,7 @@
         },
         {
             "id": "f9e27f19-d758-5785-a36c-69e70a3ffd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e524a4b-ce4d-43cc-a04f-4f4432746ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e524a4b-ce4d-43cc-a04f-4f4432746ede.jpg?1",
             "name": "Gemrazer",
             "text": "",
             "colours": [
@@ -32324,7 +32324,7 @@
         },
         {
             "id": "d8d7fd94-eea3-5a82-a31a-bea222538380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81111fb0-93fe-4cac-9ce2-bdf2466d7341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81111fb0-93fe-4cac-9ce2-bdf2466d7341.jpg?1",
             "name": "Walking Ballista",
             "text": "",
             "colours": [],
@@ -32356,7 +32356,7 @@
         },
         {
             "id": "ede7bd8e-ab87-563a-b8ab-e95a529eca8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a66c7bb-ef8a-4cb2-aebf-36a31883f1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a66c7bb-ef8a-4cb2-aebf-36a31883f1bf.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -32389,7 +32389,7 @@
         },
         {
             "id": "e2332d16-ff5e-5d7c-a090-7be0bf78c46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe116d16-8c6e-47c2-a2bd-01529caae440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe116d16-8c6e-47c2-a2bd-01529caae440.jpg?1",
             "name": "Ravages of War",
             "text": "",
             "colours": [
@@ -32422,7 +32422,7 @@
         },
         {
             "id": "e7e8f5d7-bbe8-5162-8180-69d3818ac6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d96f945-cf40-456d-b53b-95ef1524777c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d96f945-cf40-456d-b53b-95ef1524777c.jpg?1",
             "name": "Vandalblast",
             "text": "",
             "colours": [
@@ -32455,7 +32455,7 @@
         },
         {
             "id": "f274ef5f-0964-5cf5-9ee8-976035f18b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847c19ee-c4f9-49e7-842f-a07033bc604b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847c19ee-c4f9-49e7-842f-a07033bc604b.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -32486,7 +32486,7 @@
         },
         {
             "id": "9e5bb90c-6c22-5c3a-b973-2f84e94a516c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef970bfc-462d-4998-9366-eed160ab57da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef970bfc-462d-4998-9366-eed160ab57da.jpg?1",
             "name": "Crucible of Worlds",
             "text": "",
             "colours": [],
@@ -32515,7 +32515,7 @@
         },
         {
             "id": "8f96bf72-71b4-5dca-8df6-25810e8b3159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237fd51-5a49-4ada-8bea-236be78412ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237fd51-5a49-4ada-8bea-236be78412ac.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "",
             "colours": [],
@@ -32546,7 +32546,7 @@
         },
         {
             "id": "34c18918-d03e-52a3-985e-b7af3c6ea2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cd916c-7464-4391-814b-09eac0d8d204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cd916c-7464-4391-814b-09eac0d8d204.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -32577,7 +32577,7 @@
         },
         {
             "id": "7d9df13d-45ba-5f72-8111-9b4e33fbde3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186ca552-40bd-4ca0-9c2a-e899c443643b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186ca552-40bd-4ca0-9c2a-e899c443643b.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32608,7 +32608,7 @@
         },
         {
             "id": "3f114aed-300f-5b3a-a209-d0116a4e4fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfc63d-fc27-40dd-8e03-f1e24df6b911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfc63d-fc27-40dd-8e03-f1e24df6b911.jpg?1",
             "name": "Wasteland",
             "text": "",
             "colours": [],
@@ -32637,7 +32637,7 @@
         },
         {
             "id": "29e58061-8da7-51c9-9e97-00111d8a13c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382f11f-c32f-46cb-a578-d82e545691c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382f11f-c32f-46cb-a578-d82e545691c3.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "",
             "colours": [
@@ -32677,7 +32677,7 @@
         },
         {
             "id": "eb79e497-fffc-579b-8c40-a245fe90d0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf60b162-3e56-4ae6-a27f-7fa09491f839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf60b162-3e56-4ae6-a27f-7fa09491f839.jpg?1",
             "name": "Automated Assembly Line",
             "text": "",
             "colours": [
@@ -32712,7 +32712,7 @@
         },
         {
             "id": "8f73d8bb-9d96-5906-99ef-e17bcb42ef2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58508e3-144b-4876-9e25-c9b78eba0b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58508e3-144b-4876-9e25-c9b78eba0b0a.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "",
             "colours": [
@@ -32747,7 +32747,7 @@
         },
         {
             "id": "348af9fa-91f0-53cc-b63a-813f5e99fd89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8853734f-5538-43b5-a634-e210f80b5546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8853734f-5538-43b5-a634-e210f80b5546.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "",
             "colours": [
@@ -32785,7 +32785,7 @@
         },
         {
             "id": "586be17f-1ff4-5785-bd70-b8884935fb68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6327f10-a2d3-4e2f-8d43-5a9d3f667e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6327f10-a2d3-4e2f-8d43-5a9d3f667e89.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "",
             "colours": [
@@ -32825,7 +32825,7 @@
         },
         {
             "id": "487fa8a7-e51f-54db-9797-ddd9b0044da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ce2c9-b2aa-47c9-ae6e-480c9733e5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ce2c9-b2aa-47c9-ae6e-480c9733e5bb.jpg?1",
             "name": "Overencumbered",
             "text": "",
             "colours": [
@@ -32862,7 +32862,7 @@
         },
         {
             "id": "d9a3756c-d0a3-52fb-ac54-0ef3f98ff976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9db6bb-a6c8-4118-aa63-e29fd999cf3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9db6bb-a6c8-4118-aa63-e29fd999cf3f.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "",
             "colours": [
@@ -32902,7 +32902,7 @@
         },
         {
             "id": "0c5f7aca-8696-50ed-8f87-9c264546d67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295ef96f-512a-4277-89f0-8131a30faa59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295ef96f-512a-4277-89f0-8131a30faa59.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "",
             "colours": [
@@ -32939,7 +32939,7 @@
         },
         {
             "id": "ce5cd244-ac2f-53ea-bed3-d6513ba7d84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18c8974-61d6-4076-a612-9f5df80ac076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18c8974-61d6-4076-a612-9f5df80ac076.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "",
             "colours": [
@@ -32978,7 +32978,7 @@
         },
         {
             "id": "82f57cda-72e4-5655-ab13-13af02617efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12bd82f-a201-4faa-818a-ef335c72d7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12bd82f-a201-4faa-818a-ef335c72d7bf.jpg?1",
             "name": "Sentry Bot",
             "text": "",
             "colours": [
@@ -33016,7 +33016,7 @@
         },
         {
             "id": "a3688476-03bc-5e8c-991a-2fb0e6b9f73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd827857-3971-48ec-9aec-fe7d4c49882a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd827857-3971-48ec-9aec-fe7d4c49882a.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "",
             "colours": [
@@ -33056,7 +33056,7 @@
         },
         {
             "id": "3f6a2a10-cc81-54e2-94a5-218801e9f144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f266eb4-1de6-41c2-9b8c-eb62e9093980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f266eb4-1de6-41c2-9b8c-eb62e9093980.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "",
             "colours": [
@@ -33096,7 +33096,7 @@
         },
         {
             "id": "685619ea-c8f1-5f41-97db-60ba542c84b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522b0987-9a79-40dd-9205-38274ac2bb1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522b0987-9a79-40dd-9205-38274ac2bb1d.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "",
             "colours": [
@@ -33136,7 +33136,7 @@
         },
         {
             "id": "384b0fdb-0213-5799-ac92-4ad6e478844f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -33176,7 +33176,7 @@
         },
         {
             "id": "ae5da402-f07b-5787-95cd-dc8b1f5d9849",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -33213,7 +33213,7 @@
         },
         {
             "id": "5ef45cc5-f930-53db-ba68-1387e54fcd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492f15f9-8026-4ef7-82b3-389894906297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492f15f9-8026-4ef7-82b3-389894906297.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "",
             "colours": [
@@ -33254,7 +33254,7 @@
         },
         {
             "id": "5445c145-c6d3-53f6-aea0-5bd8f1bb3433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07b1d4-9823-4797-acd6-22f1a0e31735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07b1d4-9823-4797-acd6-22f1a0e31735.jpg?1",
             "name": "Mirelurk Queen",
             "text": "",
             "colours": [
@@ -33292,7 +33292,7 @@
         },
         {
             "id": "fc1983d9-c1d4-52bc-8966-c89a79c22ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9aba4b8-e830-4a75-8b1f-b0059773dd78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9aba4b8-e830-4a75-8b1f-b0059773dd78.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "",
             "colours": [
@@ -33333,7 +33333,7 @@
         },
         {
             "id": "2a04f7fd-c320-5153-b3f6-93f93034b923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f313db51-fa28-4a66-b96f-f7f2bb4eae9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f313db51-fa28-4a66-b96f-f7f2bb4eae9f.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "",
             "colours": [
@@ -33373,7 +33373,7 @@
         },
         {
             "id": "94e1f88a-545a-5004-a6a8-17629bc703f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c04bb6-108f-40d5-bc0f-b33ad749cf26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c04bb6-108f-40d5-bc0f-b33ad749cf26.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "",
             "colours": [
@@ -33408,7 +33408,7 @@
         },
         {
             "id": "32edc037-b226-5a42-9447-bbe128a3b780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d9eb00-5d34-4a2f-963c-017e3229dd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d9eb00-5d34-4a2f-963c-017e3229dd5a.jpg?1",
             "name": "Feral Ghoul",
             "text": "",
             "colours": [
@@ -33446,7 +33446,7 @@
         },
         {
             "id": "fdfaf1df-92cb-5ab0-b838-d2e66c2739fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a594b6-6fda-49f8-a2d5-95bccec830dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a594b6-6fda-49f8-a2d5-95bccec830dd.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "",
             "colours": [
@@ -33487,7 +33487,7 @@
         },
         {
             "id": "39ab9da7-8ada-5a77-abb6-b263d413adc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75af4c9-7d5b-4846-a20c-3f1c40d1a5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75af4c9-7d5b-4846-a20c-3f1c40d1a5c3.jpg?1",
             "name": "Wasteland Raider",
             "text": "",
             "colours": [
@@ -33525,7 +33525,7 @@
         },
         {
             "id": "e3cf2aa3-1a7b-59a8-8833-c6bc0636e0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd3a6bb-5578-449f-864c-9923ba10c4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd3a6bb-5578-449f-864c-9923ba10c4e8.jpg?1",
             "name": "Assaultron Dominator",
             "text": "",
             "colours": [
@@ -33563,7 +33563,7 @@
         },
         {
             "id": "e676c81e-73ff-5262-a681-2c6885ef6074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c339fe-47cf-4a93-93b8-2fa00b6dfacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c339fe-47cf-4a93-93b8-2fa00b6dfacc.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "",
             "colours": [
@@ -33603,7 +33603,7 @@
         },
         {
             "id": "02711ffa-0148-5c89-a7a4-78aaf81ce34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6100a41b-ecc2-4489-9109-de9bd1cac6aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6100a41b-ecc2-4489-9109-de9bd1cac6aa.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "",
             "colours": [
@@ -33640,7 +33640,7 @@
         },
         {
             "id": "52a03151-ee94-5a7e-ace3-34cb4cbcb2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92550d-7cc9-43f4-80b4-4a49bd8806b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92550d-7cc9-43f4-80b4-4a49bd8806b1.jpg?1",
             "name": "Junk Jet",
             "text": "",
             "colours": [
@@ -33677,7 +33677,7 @@
         },
         {
             "id": "5db0c852-e0b6-5935-a130-73bcd3734480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89241e80-3637-4ea0-afb4-14e5a22aa393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89241e80-3637-4ea0-afb4-14e5a22aa393.jpg?1",
             "name": "Megaton's Fate",
             "text": "",
             "colours": [
@@ -33712,7 +33712,7 @@
         },
         {
             "id": "73c13388-ce92-5266-836f-f929383b6712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f643e-985b-4965-862d-8ba8a2733514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f643e-985b-4965-862d-8ba8a2733514.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "",
             "colours": [
@@ -33752,7 +33752,7 @@
         },
         {
             "id": "ac3299a4-0269-53aa-bd33-56d393e0fd54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934217-04c4-4047-b5e2-183431123825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934217-04c4-4047-b5e2-183431123825.jpg?1",
             "name": "Plasma Caster",
             "text": "",
             "colours": [
@@ -33789,7 +33789,7 @@
         },
         {
             "id": "c21298fd-308f-5d25-8cb3-040d04c06f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa2906-f364-4681-8cf8-1510c7ba749e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa2906-f364-4681-8cf8-1510c7ba749e.jpg?1",
             "name": "Powder Ganger",
             "text": "",
             "colours": [
@@ -33827,7 +33827,7 @@
         },
         {
             "id": "19f48b0e-07c8-52e7-951c-db41a560deb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caae2dad-2e81-46b3-8e2d-cf1980aeba3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caae2dad-2e81-46b3-8e2d-cf1980aeba3c.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "",
             "colours": [
@@ -33867,7 +33867,7 @@
         },
         {
             "id": "b0700bed-1e1f-57e5-b335-2dcea053e2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d4ad5e-0201-4d8c-be94-ba7052e5c019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d4ad5e-0201-4d8c-be94-ba7052e5c019.jpg?1",
             "name": "Synth Eradicator",
             "text": "",
             "colours": [
@@ -33906,7 +33906,7 @@
         },
         {
             "id": "01354dad-ba34-5e7e-89db-7870eefc7ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf633e4-8d57-4357-b1c6-e4cf91ebecb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf633e4-8d57-4357-b1c6-e4cf91ebecb3.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "",
             "colours": [
@@ -33944,7 +33944,7 @@
         },
         {
             "id": "1c1f96dd-dba6-59c9-b835-a76db49f78e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299640b7-1924-4788-a425-bb30f6d619a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299640b7-1924-4788-a425-bb30f6d619a1.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "",
             "colours": [
@@ -33985,7 +33985,7 @@
         },
         {
             "id": "73b9e8ae-42ce-559d-aa99-3e0cacd8b6e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2140ef84-a738-4b85-b67e-ea2d4c03b5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2140ef84-a738-4b85-b67e-ea2d4c03b5e8.jpg?1",
             "name": "Wild Wasteland",
             "text": "",
             "colours": [
@@ -34020,7 +34020,7 @@
         },
         {
             "id": "b15ee0c6-1a75-5c76-a8a1-5cd74f9618f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d965b1cf-44f4-40d4-b06e-deca3c132dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d965b1cf-44f4-40d4-b06e-deca3c132dbc.jpg?1",
             "name": "Animal Friend",
             "text": "",
             "colours": [
@@ -34057,7 +34057,7 @@
         },
         {
             "id": "557cba90-e267-5246-83bc-14910a130f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e0d4d40-9fd6-4550-a7c8-45aaf5a7e17f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e0d4d40-9fd6-4550-a7c8-45aaf5a7e17f.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "",
             "colours": [
@@ -34097,7 +34097,7 @@
         },
         {
             "id": "eb84f19e-1a25-5691-9cfc-3ecc38208ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f5a89-1b83-40d3-81b2-0b54e80ee9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f5a89-1b83-40d3-81b2-0b54e80ee9f9.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "",
             "colours": [
@@ -34137,7 +34137,7 @@
         },
         {
             "id": "fedc107c-cc3a-533c-ada3-5a914b92b509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee6b263-c15a-47a3-9546-fc36dbda74b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee6b263-c15a-47a3-9546-fc36dbda74b6.jpg?1",
             "name": "Power Fist",
             "text": "",
             "colours": [
@@ -34174,7 +34174,7 @@
         },
         {
             "id": "4b125f9b-a9ce-556b-bda5-6edaf78d8901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a02723-3f78-48bf-baa2-ebed73403688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a02723-3f78-48bf-baa2-ebed73403688.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "",
             "colours": [
@@ -34212,7 +34212,7 @@
         },
         {
             "id": "f14dbd07-658c-58c2-9554-242e0a1486b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0374c25-1de7-451b-9b9f-e81429f3ea30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0374c25-1de7-451b-9b9f-e81429f3ea30.jpg?1",
             "name": "Strong Back",
             "text": "",
             "colours": [
@@ -34249,7 +34249,7 @@
         },
         {
             "id": "17f33f3e-c2e8-5501-9bf1-930a77231986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe374-7594-437c-aaab-37a4ce5c7751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe374-7594-437c-aaab-37a4ce5c7751.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "",
             "colours": [
@@ -34289,7 +34289,7 @@
         },
         {
             "id": "db18cb32-a9c9-5a10-ac81-8f120af0fe8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ce341f-1e23-44dc-8577-f5ad77962f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ce341f-1e23-44dc-8577-f5ad77962f1b.jpg?1",
             "name": "Tato Farmer",
             "text": "",
             "colours": [
@@ -34328,7 +34328,7 @@
         },
         {
             "id": "998e06da-f0fa-5be6-8c4d-1f26735422ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68fb1eb-6dc1-4feb-b5ad-44805ecc6da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68fb1eb-6dc1-4feb-b5ad-44805ecc6da6.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "",
             "colours": [
@@ -34370,7 +34370,7 @@
         },
         {
             "id": "84ca4d27-1c25-5513-82e5-7866a746975e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717522d7-09b4-4659-b88f-58aaacd1aa8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717522d7-09b4-4659-b88f-58aaacd1aa8d.jpg?1",
             "name": "Almost Perfect",
             "text": "",
             "colours": [
@@ -34409,7 +34409,7 @@
         },
         {
             "id": "f669c7e6-67a0-5fdd-9b48-6142bdd6fbb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61569b1a-2942-4426-a9d5-3130f725f3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61569b1a-2942-4426-a9d5-3130f725f3d6.jpg?1",
             "name": "Arcade Gannon",
             "text": "",
             "colours": [
@@ -34451,7 +34451,7 @@
         },
         {
             "id": "25aa037d-d8c6-5fcc-b53e-059320398627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf59a3b-f837-42b5-a680-a519d64d2aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf59a3b-f837-42b5-a680-a519d64d2aa9.jpg?1",
             "name": "Boomer Scrapper",
             "text": "",
             "colours": [
@@ -34491,7 +34491,7 @@
         },
         {
             "id": "d8ce2145-872c-55d7-8f41-765211737c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e492470-dff3-4005-b0ee-0810b73601de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e492470-dff3-4005-b0ee-0810b73601de.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "",
             "colours": [
@@ -34533,7 +34533,7 @@
         },
         {
             "id": "668a2d1b-a14d-5cd9-8e13-9dad0315731b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c1d18d-a575-4d8d-a16e-fae0bdc43380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c1d18d-a575-4d8d-a16e-fae0bdc43380.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "",
             "colours": [
@@ -34575,7 +34575,7 @@
         },
         {
             "id": "e72d0f8b-d9f4-5a91-89f9-d6794125e2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cc1769-e09f-43c0-9c03-979cb0a764a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cc1769-e09f-43c0-9c03-979cb0a764a2.jpg?1",
             "name": "Colonel Autumn",
             "text": "",
             "colours": [
@@ -34617,7 +34617,7 @@
         },
         {
             "id": "c6398647-8f92-52c5-b24c-531359b44bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f84c2-0a96-4f50-9b68-f2968044c202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f84c2-0a96-4f50-9b68-f2968044c202.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "",
             "colours": [
@@ -34659,7 +34659,7 @@
         },
         {
             "id": "0a8f5080-6dc9-5729-b15f-ffc21c1be39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51434898-d4ac-4448-8223-f570204a6cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51434898-d4ac-4448-8223-f570204a6cba.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "",
             "colours": [
@@ -34701,7 +34701,7 @@
         },
         {
             "id": "4d66877a-f392-5da9-9bd0-4c78c079a082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f388077-d7a5-41a2-a9e9-4c3a5f7c6b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f388077-d7a5-41a2-a9e9-4c3a5f7c6b48.jpg?1",
             "name": "Electrosiphon",
             "text": "",
             "colours": [
@@ -34738,7 +34738,7 @@
         },
         {
             "id": "e45746c9-c3c7-5a37-acde-28869d3d0a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff1f97-01e8-4825-aff9-3c6bab10aaab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff1f97-01e8-4825-aff9-3c6bab10aaab.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "",
             "colours": [
@@ -34780,7 +34780,7 @@
         },
         {
             "id": "294dea5f-9d15-56a3-838e-e0bf8ced6c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7aa89-f7c0-471b-ab16-c0664f535942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7aa89-f7c0-471b-ab16-c0664f535942.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "",
             "colours": [
@@ -34824,7 +34824,7 @@
         },
         {
             "id": "17757faf-eb2a-5d91-ab64-559fd7a5937d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bb617b-34e9-4126-9d45-7561640896db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bb617b-34e9-4126-9d45-7561640896db.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "",
             "colours": [
@@ -34866,7 +34866,7 @@
         },
         {
             "id": "ac7a386c-c28c-5238-9610-91d8f3cbb72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724cbef5-7f32-4341-9455-f2b8027ff715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724cbef5-7f32-4341-9455-f2b8027ff715.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "",
             "colours": [
@@ -34908,7 +34908,7 @@
         },
         {
             "id": "a3a1d39a-58b2-5bf9-9a2b-a77f8962dc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d4b2e0-1e57-461d-9c5e-fea4b9ebe897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d4b2e0-1e57-461d-9c5e-fea4b9ebe897.jpg?1",
             "name": "The Master, Transcendent",
             "text": "",
             "colours": [
@@ -34952,7 +34952,7 @@
         },
         {
             "id": "a38c3016-f3be-543d-beb8-5f5ef1a3a0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1062b4a3-c6f0-413a-b6f0-182c0d69b114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1062b4a3-c6f0-413a-b6f0-182c0d69b114.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "",
             "colours": [
@@ -34994,7 +34994,7 @@
         },
         {
             "id": "94cc7a27-33e5-50cd-a697-8a5d7af74401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fa1d0-ec56-4be8-973b-384ae0e66b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fa1d0-ec56-4be8-973b-384ae0e66b6c.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "",
             "colours": [
@@ -35038,7 +35038,7 @@
         },
         {
             "id": "6888f602-6092-5f9a-995e-362f79f18b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa8edfc-6a80-4982-a009-70d3d4259fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa8edfc-6a80-4982-a009-70d3d4259fd1.jpg?1",
             "name": "Mutational Advantage",
             "text": "",
             "colours": [
@@ -35075,7 +35075,7 @@
         },
         {
             "id": "88fea92a-4f1d-5833-9bda-7ba6b5613b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099d5706-6595-4129-83d7-ca4ae1c8e363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099d5706-6595-4129-83d7-ca4ae1c8e363.jpg?1",
             "name": "The Nipton Lottery",
             "text": "",
             "colours": [
@@ -35112,7 +35112,7 @@
         },
         {
             "id": "11023831-7b90-569d-898f-a45f1bd4dd44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9972f7e4-a5d1-48ca-95a4-4b7f3f49563e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9972f7e4-a5d1-48ca-95a4-4b7f3f49563e.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "",
             "colours": [
@@ -35154,7 +35154,7 @@
         },
         {
             "id": "adc4acf0-7075-5749-96a9-a8a5166f472c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834c8bf-1278-4cdb-a8e1-30fb2e2c66eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834c8bf-1278-4cdb-a8e1-30fb2e2c66eb.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "",
             "colours": [
@@ -35198,7 +35198,7 @@
         },
         {
             "id": "31aae57e-4b75-5ac5-b481-c40a4876646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2172a39d-7481-4a4a-861b-b4a1204d28ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2172a39d-7481-4a4a-861b-b4a1204d28ef.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "",
             "colours": [
@@ -35240,7 +35240,7 @@
         },
         {
             "id": "8953c852-d796-570e-a136-74af300d3d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539a969b-18ae-4958-b4bc-32b2ac3d4295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539a969b-18ae-4958-b4bc-32b2ac3d4295.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "",
             "colours": [
@@ -35283,7 +35283,7 @@
         },
         {
             "id": "95aecdd9-5b47-5d27-b65a-ab0c614d9474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a321f651-1016-4fce-bc9e-be11d90cea30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a321f651-1016-4fce-bc9e-be11d90cea30.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "",
             "colours": [
@@ -35325,7 +35325,7 @@
         },
         {
             "id": "3fc8e574-2841-58c4-9347-5f019dde460a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead06c9-4175-42a3-be4c-0b685c6cf8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead06c9-4175-42a3-be4c-0b685c6cf8b7.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "",
             "colours": [
@@ -35367,7 +35367,7 @@
         },
         {
             "id": "e647c25a-aaa0-5e2a-82c3-897663001e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ef2bb3-ecb7-43c6-b4ed-982983c3060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ef2bb3-ecb7-43c6-b4ed-982983c3060d.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "",
             "colours": [
@@ -35409,7 +35409,7 @@
         },
         {
             "id": "5be3efdf-efc1-5457-b0be-1808619a7a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49c217d-b476-421c-9b17-aba9f3bb5454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49c217d-b476-421c-9b17-aba9f3bb5454.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "",
             "colours": [],
@@ -35442,7 +35442,7 @@
         },
         {
             "id": "ad11c0a3-5d5b-53e2-ba34-b3bcd9f3a3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc1e676-2e9e-406a-b01d-b3b4893ffbae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc1e676-2e9e-406a-b01d-b3b4893ffbae.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "",
             "colours": [],
@@ -35478,7 +35478,7 @@
         },
         {
             "id": "b3cf5a0c-6140-5c70-9185-24ee0689b473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b0b820-338d-4045-bbc6-bf605785c7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b0b820-338d-4045-bbc6-bf605785c7d5.jpg?1",
             "name": "Mister Gutsy",
             "text": "",
             "colours": [],
@@ -35513,7 +35513,7 @@
         },
         {
             "id": "34f93cb5-7a08-5ec9-91b9-5eff56658c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8176a675-cf7f-44cf-af3f-c77371a3165f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8176a675-cf7f-44cf-af3f-c77371a3165f.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "",
             "colours": [],
@@ -35546,7 +35546,7 @@
         },
         {
             "id": "2e2cedca-3c26-5287-ae94-d7d37ebd49e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf7bd2-be3f-4cae-82a1-3232b2dc2815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf7bd2-be3f-4cae-82a1-3232b2dc2815.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "",
             "colours": [],
@@ -35579,7 +35579,7 @@
         },
         {
             "id": "3c53d6af-ea0b-53a0-828b-db16c3bdc88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15442abc-8a9a-4eeb-9166-8c0f502b11aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15442abc-8a9a-4eeb-9166-8c0f502b11aa.jpg?1",
             "name": "Recon Craft Theta",
             "text": "",
             "colours": [],
@@ -35612,7 +35612,7 @@
         },
         {
             "id": "ce55e074-3044-5c54-8281-ea8a2a04b426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5079fc-6381-4705-b3bd-9b29dbe62bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5079fc-6381-4705-b3bd-9b29dbe62bfa.jpg?1",
             "name": "T-45 Power Armor",
             "text": "",
             "colours": [],
@@ -35645,7 +35645,7 @@
         },
         {
             "id": "b4e3aa06-310e-5c43-9fbc-3687dd028785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e282d9-33fb-4107-8a8c-add7bebcedd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e282d9-33fb-4107-8a8c-add7bebcedd1.jpg?1",
             "name": "Desolate Mire",
             "text": "",
             "colours": [],
@@ -35679,7 +35679,7 @@
         },
         {
             "id": "2669a7bf-1121-5098-a7c8-59be43c175b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eddac3-aa5c-4163-b223-b57da25ee4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eddac3-aa5c-4163-b223-b57da25ee4a2.jpg?1",
             "name": "Diamond City",
             "text": "",
             "colours": [],
@@ -35710,7 +35710,7 @@
         },
         {
             "id": "d6ecd15b-de9c-528b-b7d2-9b72a6ca65f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a752279-4973-4824-bb79-8dac890c548e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a752279-4973-4824-bb79-8dac890c548e.jpg?1",
             "name": "Ferrous Lake",
             "text": "",
             "colours": [],
@@ -35744,7 +35744,7 @@
         },
         {
             "id": "61f76d39-3ce7-5554-916b-a5c643401190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcdab6a-2656-4515-baaa-47373253b6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcdab6a-2656-4515-baaa-47373253b6c8.jpg?1",
             "name": "HELIOS One",
             "text": "",
             "colours": [],
@@ -35775,7 +35775,7 @@
         },
         {
             "id": "4e597f57-69e0-572d-b93d-8a0aeb4894f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe44c048-7b6b-442f-a389-f633d752d08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe44c048-7b6b-442f-a389-f633d752d08e.jpg?1",
             "name": "Junktown",
             "text": "",
             "colours": [],
@@ -35808,7 +35808,7 @@
         },
         {
             "id": "1ab0dad8-e215-576c-99cd-14c58b49269f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2724c630-5638-4b6a-8f1e-0f764b11c8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2724c630-5638-4b6a-8f1e-0f764b11c8d8.jpg?1",
             "name": "Mariposa Military Base",
             "text": "",
             "colours": [],
@@ -35839,7 +35839,7 @@
         },
         {
             "id": "92860f56-b821-5e00-9d9d-9e6d60f6da9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068dc34e-976e-428f-8b83-e31466589310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068dc34e-976e-428f-8b83-e31466589310.jpg?1",
             "name": "Overflowing Basin",
             "text": "",
             "colours": [],
@@ -35873,7 +35873,7 @@
         },
         {
             "id": "e1ef2f28-f63b-5525-9f7b-05e3246d1c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2595012-a6ce-49d1-a1b6-27d06ae1fc64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2595012-a6ce-49d1-a1b6-27d06ae1fc64.jpg?1",
             "name": "Sunscorched Divide",
             "text": "",
             "colours": [],
@@ -35907,7 +35907,7 @@
         },
         {
             "id": "95bc038d-4207-5c48-9a59-56ed1814047f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d192615-0aaa-488f-b535-93b6a5a2d8bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d192615-0aaa-488f-b535-93b6a5a2d8bd.jpg?1",
             "name": "Viridescent Bog",
             "text": "",
             "colours": [],
@@ -35941,7 +35941,7 @@
         },
         {
             "id": "dadcbbf2-33d4-54fa-bc4e-8615a1008bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed103241-84e9-4a62-a76c-0cdf9a0c51b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed103241-84e9-4a62-a76c-0cdf9a0c51b4.jpg?1",
             "name": "Austere Command",
             "text": "",
             "colours": [
@@ -35976,7 +35976,7 @@
         },
         {
             "id": "4152fb5b-3eda-50f7-86ed-52bca3e2d547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ce501c-ae18-468e-922a-078c4eb130bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ce501c-ae18-468e-922a-078c4eb130bd.jpg?1",
             "name": "Captain of the Watch",
             "text": "",
             "colours": [
@@ -36014,7 +36014,7 @@
         },
         {
             "id": "2cd088af-d493-5ee7-a3cb-78483f138050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32abf12c-edda-479b-b844-aaa0b3061c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32abf12c-edda-479b-b844-aaa0b3061c0a.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "",
             "colours": [
@@ -36049,7 +36049,7 @@
         },
         {
             "id": "9b63c585-6f30-51b2-b028-6364a10b8044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b324eff-e709-4dc2-b5fb-0922d90ec848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b324eff-e709-4dc2-b5fb-0922d90ec848.jpg?1",
             "name": "Hour of Reckoning",
             "text": "",
             "colours": [
@@ -36084,7 +36084,7 @@
         },
         {
             "id": "df278d61-9348-56db-a847-8ff9004ce66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4575fce3-872a-4a97-a291-822988cb2745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4575fce3-872a-4a97-a291-822988cb2745.jpg?1",
             "name": "Keeper of the Accord",
             "text": "",
             "colours": [
@@ -36122,7 +36122,7 @@
         },
         {
             "id": "66c9e5c8-09f6-5f47-97b6-6750b5150a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b32d84-2d56-4ffe-a433-3d033f16045c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b32d84-2d56-4ffe-a433-3d033f16045c.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "",
             "colours": [
@@ -36159,7 +36159,7 @@
         },
         {
             "id": "f3b4d7a7-639c-54d8-8119-347d0280b4a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55620d51-6e27-4f38-a141-c39bf3d6d5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55620d51-6e27-4f38-a141-c39bf3d6d5d6.jpg?1",
             "name": "Marshal's Anthem",
             "text": "",
             "colours": [
@@ -36194,7 +36194,7 @@
         },
         {
             "id": "cb8b16a7-e8e8-54b5-8b39-d894ce0942a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30206bee-c895-4ab7-9535-68a6afb2c686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30206bee-c895-4ab7-9535-68a6afb2c686.jpg?1",
             "name": "Martial Coup",
             "text": "",
             "colours": [
@@ -36229,7 +36229,7 @@
         },
         {
             "id": "79abf21d-21bb-5023-8e75-cca0519cfb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1727b15d-2918-489f-a5b8-8ac3ca86d670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1727b15d-2918-489f-a5b8-8ac3ca86d670.jpg?1",
             "name": "Open the Vaults",
             "text": "",
             "colours": [
@@ -36264,7 +36264,7 @@
         },
         {
             "id": "2a874f95-d584-5dc3-8a02-242f6575d016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69d118-fc58-40b7-bb38-f1c3da04d950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69d118-fc58-40b7-bb38-f1c3da04d950.jpg?1",
             "name": "Puresteel Paladin",
             "text": "",
             "colours": [
@@ -36302,7 +36302,7 @@
         },
         {
             "id": "82aa3d79-2491-5f32-8081-8a079ef669d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ddf912-5bd5-430c-bb42-4a76e609466c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ddf912-5bd5-430c-bb42-4a76e609466c.jpg?1",
             "name": "Secure the Wastes",
             "text": "",
             "colours": [
@@ -36337,7 +36337,7 @@
         },
         {
             "id": "4d16e7a8-f4b2-5ad9-86ac-fdfebcda6051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b88918-d819-4dc9-ac6c-48c3b1f67092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b88918-d819-4dc9-ac6c-48c3b1f67092.jpg?1",
             "name": "Single Combat",
             "text": "",
             "colours": [
@@ -36372,7 +36372,7 @@
         },
         {
             "id": "fb7ddd8c-fd2b-5c2e-ab3c-58b2d0261995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a3d786-2ac1-48c8-aafe-64b72ecde383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a3d786-2ac1-48c8-aafe-64b72ecde383.jpg?1",
             "name": "Fraying Sanity",
             "text": "",
             "colours": [
@@ -36410,7 +36410,7 @@
         },
         {
             "id": "64ca1a63-184c-5a20-91d3-152fb50befd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd7775-da74-4312-9b2d-c4721ee179cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd7775-da74-4312-9b2d-c4721ee179cb.jpg?1",
             "name": "Inexorable Tide",
             "text": "",
             "colours": [
@@ -36445,7 +36445,7 @@
         },
         {
             "id": "4ee6d56e-69ef-503d-ad2f-ec4d9f5f9b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47199-65d9-472b-ae8e-0c6580420b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47199-65d9-472b-ae8e-0c6580420b8f.jpg?1",
             "name": "Mechanized Production",
             "text": "",
             "colours": [
@@ -36482,7 +36482,7 @@
         },
         {
             "id": "371b1887-6ab1-5717-8ea5-87016fa86492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f5512b-e7c4-43cd-9bfd-e95681a5b050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f5512b-e7c4-43cd-9bfd-e95681a5b050.jpg?1",
             "name": "One with the Machine",
             "text": "",
             "colours": [
@@ -36517,7 +36517,7 @@
         },
         {
             "id": "f7a0451b-7bb2-5ba7-b70e-2f26dc75165f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957651eb-9adb-4105-aece-d55991dc1e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957651eb-9adb-4105-aece-d55991dc1e02.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -36552,7 +36552,7 @@
         },
         {
             "id": "b94f1a6f-c85e-52ca-896e-c5a307dc1768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31e4679-e594-4907-8bef-acff38b856a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31e4679-e594-4907-8bef-acff38b856a3.jpg?1",
             "name": "Lethal Scheme",
             "text": "",
             "colours": [
@@ -36587,7 +36587,7 @@
         },
         {
             "id": "2074e840-3109-5722-a126-2fd277505abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889a828d-8915-4c2b-8650-f368172890e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889a828d-8915-4c2b-8650-f368172890e8.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -36622,7 +36622,7 @@
         },
         {
             "id": "c4cf89e6-749a-5f08-9c65-43f268e9ac1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5bc9c-490b-4873-8be1-bd39ab10ed86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5bc9c-490b-4873-8be1-bd39ab10ed86.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -36657,7 +36657,7 @@
         },
         {
             "id": "88d484cc-c74e-5c78-ad68-450d94e032f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5bdc07-7221-4681-a84c-f4fe3e85d120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5bdc07-7221-4681-a84c-f4fe3e85d120.jpg?1",
             "name": "Stolen Strategy",
             "text": "",
             "colours": [
@@ -36692,7 +36692,7 @@
         },
         {
             "id": "a4567c0e-ce51-54d6-9463-fa3dfc35c14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aee54b7-698a-4f19-8682-70b5f36a7e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aee54b7-698a-4f19-8682-70b5f36a7e30.jpg?1",
             "name": "Branching Evolution",
             "text": "",
             "colours": [
@@ -36727,7 +36727,7 @@
         },
         {
             "id": "6ace7c0b-39a8-559c-9bc8-913bf0bda100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e3d320-c63e-49b4-b6dc-441298db1329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e3d320-c63e-49b4-b6dc-441298db1329.jpg?1",
             "name": "Guardian Project",
             "text": "",
             "colours": [
@@ -36762,7 +36762,7 @@
         },
         {
             "id": "82f33430-8070-52c6-9cf7-76f8a37f8d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e897027e-b8fc-44a7-ba82-19e765f757c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e897027e-b8fc-44a7-ba82-19e765f757c4.jpg?1",
             "name": "Hardened Scales",
             "text": "",
             "colours": [
@@ -36797,7 +36797,7 @@
         },
         {
             "id": "82b41324-dd1c-5e2e-9127-2f69e2e40c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad0069-25a4-4e1d-8ef5-a5223e57d699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad0069-25a4-4e1d-8ef5-a5223e57d699.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -36832,7 +36832,7 @@
         },
         {
             "id": "e4ed896a-1ed7-5035-8cf8-9fb83953dea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b262574e-6eb0-46d5-b05c-ac66ac8f7f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b262574e-6eb0-46d5-b05c-ac66ac8f7f07.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -36870,7 +36870,7 @@
         },
         {
             "id": "473cce5e-0b2a-5a23-979d-dbfb6023ecc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275c0f2c-6454-45b8-8e4d-bcf3e66ed1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275c0f2c-6454-45b8-8e4d-bcf3e66ed1b7.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -36907,7 +36907,7 @@
         },
         {
             "id": "f16cbf1d-612a-591f-a240-76eb2d26974a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca637814-9afb-46a1-ad90-4403f7ff62d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca637814-9afb-46a1-ad90-4403f7ff62d3.jpg?1",
             "name": "Assemble the Legion",
             "text": "",
             "colours": [
@@ -36944,7 +36944,7 @@
         },
         {
             "id": "1907ce87-c733-5f72-ac0e-77bc1b777cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c1692c-d95e-480f-9f6c-da9ce099b75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c1692c-d95e-480f-9f6c-da9ce099b75d.jpg?1",
             "name": "Biomass Mutation",
             "text": "",
             "colours": [
@@ -36981,7 +36981,7 @@
         },
         {
             "id": "81aeafb2-9f9f-578b-acdc-abd8b6e156f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6918ab-ef4f-4cd4-92d9-2da6622a4cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6918ab-ef4f-4cd4-92d9-2da6622a4cb7.jpg?1",
             "name": "Casualties of War",
             "text": "",
             "colours": [
@@ -37018,7 +37018,7 @@
         },
         {
             "id": "27c355cf-c7f5-5838-af91-8cea129a99f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca785ef8-f893-4c48-83c1-6886b0dc43c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca785ef8-f893-4c48-83c1-6886b0dc43c4.jpg?1",
             "name": "Fervent Charge",
             "text": "",
             "colours": [
@@ -37057,7 +37057,7 @@
         },
         {
             "id": "24b6eac7-dc1e-5a19-887a-63a37365d8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39e94a-07b0-4a87-bd03-0cc369790c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39e94a-07b0-4a87-bd03-0cc369790c01.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "",
             "colours": [
@@ -37096,7 +37096,7 @@
         },
         {
             "id": "fd73fff4-da2d-5897-9ac2-f544a720c4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45691343-4ae4-4cdb-845a-52006b1d2566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45691343-4ae4-4cdb-845a-52006b1d2566.jpg?1",
             "name": "Wake the Past",
             "text": "",
             "colours": [
@@ -37133,7 +37133,7 @@
         },
         {
             "id": "a5f23b8e-3a38-546b-a7fd-5574f9ddcd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6e34fb-d3d0-409a-a3ad-612177b98baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6e34fb-d3d0-409a-a3ad-612177b98baa.jpg?1",
             "name": "Basilisk Collar",
             "text": "",
             "colours": [],
@@ -37166,7 +37166,7 @@
         },
         {
             "id": "e1ced1a6-b370-5fb4-942e-410ad616d1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decf8d08-a4e4-4a5d-91d7-102596b30cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decf8d08-a4e4-4a5d-91d7-102596b30cb5.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "",
             "colours": [],
@@ -37199,7 +37199,7 @@
         },
         {
             "id": "46081fca-ad8c-5711-bebe-a792f691028e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062fe8d7-c0d4-4460-9613-27c6c0555a14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062fe8d7-c0d4-4460-9613-27c6c0555a14.jpg?1",
             "name": "Champion's Helm",
             "text": "",
             "colours": [],
@@ -37232,7 +37232,7 @@
         },
         {
             "id": "5fc42952-768f-592b-a21d-36ed54166a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f10fe0-4810-4894-9805-4280175a7fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f10fe0-4810-4894-9805-4280175a7fa6.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "",
             "colours": [],
@@ -37265,7 +37265,7 @@
         },
         {
             "id": "e365f6d8-a121-5dc9-980a-96deb0c8e20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fd1f7f-4946-4f28-a759-3f73c0473536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fd1f7f-4946-4f28-a759-3f73c0473536.jpg?1",
             "name": "Mystic Forge",
             "text": "",
             "colours": [],
@@ -37296,7 +37296,7 @@
         },
         {
             "id": "065cc1b6-9af7-54c1-adc7-e7dd05539162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ea3ea-4ede-436d-a899-3e4a52dd56cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ea3ea-4ede-436d-a899-3e4a52dd56cd.jpg?1",
             "name": "Panharmonicon",
             "text": "",
             "colours": [],
@@ -37327,7 +37327,7 @@
         },
         {
             "id": "6cec8771-9570-587e-8816-d241b9d8af76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f14e3f-7de4-4c1a-a1e2-a3e21afee14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f14e3f-7de4-4c1a-a1e2-a3e21afee14f.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -37361,7 +37361,7 @@
         },
         {
             "id": "b11a3841-8e30-5d14-b60b-e18a82c210e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1752cc62-abf9-406b-a5ac-f4c8b12a92ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1752cc62-abf9-406b-a5ac-f4c8b12a92ef.jpg?1",
             "name": "Steel Overseer",
             "text": "",
             "colours": [],
@@ -37395,7 +37395,7 @@
         },
         {
             "id": "c54eb32e-bbbc-52d6-bfb0-3a4aa5cc3a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b861c7b1-976d-4d0b-8f53-59bac360432c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b861c7b1-976d-4d0b-8f53-59bac360432c.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -37432,7 +37432,7 @@
         },
         {
             "id": "2ee8d12b-9cf2-5b57-8e7c-43210dc854df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062526c8-29c1-4e0d-86ae-fb3aac9b0d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062526c8-29c1-4e0d-86ae-fb3aac9b0d95.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -37469,7 +37469,7 @@
         },
         {
             "id": "b93344ff-e660-545b-b177-d77ac7c5cd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7547eaf7-ddc1-4881-9045-b6be302354de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7547eaf7-ddc1-4881-9045-b6be302354de.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -37506,7 +37506,7 @@
         },
         {
             "id": "38e47c61-cdda-5e63-bb57-2b3cff251feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3246847-83f0-46c3-8e7f-867734448a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3246847-83f0-46c3-8e7f-867734448a62.jpg?1",
             "name": "Clifftop Retreat",
             "text": "",
             "colours": [],
@@ -37540,7 +37540,7 @@
         },
         {
             "id": "9b912ad7-9e82-57e4-bf4b-4d1ade940596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceac46f-e4e6-4a76-87c9-d8c7c6b47256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceac46f-e4e6-4a76-87c9-d8c7c6b47256.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -37574,7 +37574,7 @@
         },
         {
             "id": "da6fc880-0ff5-5e56-96f0-2db4a41e3fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76dbcd3-e280-4c71-b8bd-715001340697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76dbcd3-e280-4c71-b8bd-715001340697.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -37608,7 +37608,7 @@
         },
         {
             "id": "c792bb08-1ff1-586a-af43-7476fd13b61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a47f879-962b-44a0-9448-7217e35ea4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a47f879-962b-44a0-9448-7217e35ea4d0.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -37642,7 +37642,7 @@
         },
         {
             "id": "0a90c233-32bf-594b-9667-530c13a423e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0651aa-b804-4517-af87-41fe1d5e1699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0651aa-b804-4517-af87-41fe1d5e1699.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -37673,7 +37673,7 @@
         },
         {
             "id": "946a67b3-8700-5227-bee1-7af044efe36a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f799-be3a-4d9c-9050-85cb0b0774d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f799-be3a-4d9c-9050-85cb0b0774d7.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -37710,7 +37710,7 @@
         },
         {
             "id": "8b7ab9a4-9478-5f75-8a60-6bf93a4182c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205cd322-db6c-455a-b2ab-f196a64e08c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205cd322-db6c-455a-b2ab-f196a64e08c9.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -37744,7 +37744,7 @@
         },
         {
             "id": "57f0fc89-6ec9-508f-b3bc-c71c408b56e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd36ff-2228-4bfd-bb98-76243defbb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd36ff-2228-4bfd-bb98-76243defbb78.jpg?1",
             "name": "Hinterland Harbor",
             "text": "",
             "colours": [],
@@ -37778,7 +37778,7 @@
         },
         {
             "id": "f6149376-1c3b-511d-9ab2-de19bd036a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb11d4ab-0095-4021-8ec6-79d5d3e6bbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb11d4ab-0095-4021-8ec6-79d5d3e6bbd0.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -37815,7 +37815,7 @@
         },
         {
             "id": "1e9d77da-2d4e-50b2-92e5-7157c02d8b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d96ac45-2484-4d14-b1f5-b46f2a6ac5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d96ac45-2484-4d14-b1f5-b46f2a6ac5ee.jpg?1",
             "name": "Isolated Chapel",
             "text": "",
             "colours": [],
@@ -37849,7 +37849,7 @@
         },
         {
             "id": "43b8a834-e221-5505-9f58-0522ebd02039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896c4424-a5b9-4e2a-80a5-cda8a7612f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896c4424-a5b9-4e2a-80a5-cda8a7612f51.jpg?1",
             "name": "Mossfire Valley",
             "text": "",
             "colours": [],
@@ -37883,7 +37883,7 @@
         },
         {
             "id": "c94bf7b7-b03c-5bee-96cd-bebd6aa3db62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c7e99-7b74-46a5-8622-fca661b3f889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c7e99-7b74-46a5-8622-fca661b3f889.jpg?1",
             "name": "Nesting Grounds",
             "text": "",
             "colours": [],
@@ -37914,7 +37914,7 @@
         },
         {
             "id": "d9855421-7655-5392-a4d3-73c7c42b8470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9479bc09-7db2-46b3-8c1e-dbee5508e26a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9479bc09-7db2-46b3-8c1e-dbee5508e26a.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -37951,7 +37951,7 @@
         },
         {
             "id": "3d97e8d6-73b0-5c2c-9b3a-4ea247a52d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941113c4-9a14-4f92-8a5b-e351dcd210a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941113c4-9a14-4f92-8a5b-e351dcd210a4.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -37985,7 +37985,7 @@
         },
         {
             "id": "e2de0f53-e055-543e-9473-88452bbcf009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab3e653-e27f-4c64-8339-59849cdd9939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab3e653-e27f-4c64-8339-59849cdd9939.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -38022,7 +38022,7 @@
         },
         {
             "id": "f1c78c59-6bcf-5aa1-8c67-c058cf803fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c2062-b105-4e87-8cbc-be6e274f393a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c2062-b105-4e87-8cbc-be6e274f393a.jpg?1",
             "name": "Scavenger Grounds",
             "text": "",
             "colours": [],
@@ -38055,7 +38055,7 @@
         },
         {
             "id": "5db0d890-6dbb-583c-afad-ecbfb2af3054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87115cd5-542e-4964-9e0b-d911c8fdc335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87115cd5-542e-4964-9e0b-d911c8fdc335.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -38089,7 +38089,7 @@
         },
         {
             "id": "3c66b258-36e7-579f-8b4c-4d15dfa10c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec1158-3699-44be-8cd7-a15a1dd26311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec1158-3699-44be-8cd7-a15a1dd26311.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -38126,7 +38126,7 @@
         },
         {
             "id": "edd367c0-2f49-5f9f-bc41-3266e2b089a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216ce04-a93d-430f-ba24-fcc797076cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216ce04-a93d-430f-ba24-fcc797076cd1.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -38160,7 +38160,7 @@
         },
         {
             "id": "53c8b0c7-d3f8-5432-9f73-7935347334ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc6ca28-2df7-4cbd-b847-62c1f4576f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc6ca28-2df7-4cbd-b847-62c1f4576f3b.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -38197,7 +38197,7 @@
         },
         {
             "id": "8ec2e2a1-452d-5413-b571-7ef5736cdc19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cab6984-8d22-4bed-a42e-0f4604798787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cab6984-8d22-4bed-a42e-0f4604798787.jpg?1",
             "name": "Spire of Industry",
             "text": "",
             "colours": [],
@@ -38228,7 +38228,7 @@
         },
         {
             "id": "03b7999e-09f9-5081-9379-0a1d2bd4b935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e172658-3ba7-4d50-9c9d-bb26368f381f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e172658-3ba7-4d50-9c9d-bb26368f381f.jpg?1",
             "name": "Sulfur Falls",
             "text": "",
             "colours": [],
@@ -38262,7 +38262,7 @@
         },
         {
             "id": "72497c0b-ecfa-593f-9648-fe91e66d35b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a56626-fc86-4c3e-bc9b-75b89e0d9e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a56626-fc86-4c3e-bc9b-75b89e0d9e88.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -38296,7 +38296,7 @@
         },
         {
             "id": "96dc9565-7a0d-5fc8-94ab-218ee69d2a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fba5c8e-a364-458c-95fb-3a3999704b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fba5c8e-a364-458c-95fb-3a3999704b43.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -38333,7 +38333,7 @@
         },
         {
             "id": "a177874b-3416-52d8-80a7-6d11321b9f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80afdcb5-8ef1-442a-9f8b-233443efdc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80afdcb5-8ef1-442a-9f8b-233443efdc41.jpg?1",
             "name": "Sunpetal Grove",
             "text": "",
             "colours": [],
@@ -38367,7 +38367,7 @@
         },
         {
             "id": "032602d3-4941-5547-aa37-bcd1d7679162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e073d623-551c-489c-8f66-082c3c2a84fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e073d623-551c-489c-8f66-082c3c2a84fa.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -38401,7 +38401,7 @@
         },
         {
             "id": "fb7c3b97-fe3d-51bf-8723-8da5e5065cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2caf68-7d2e-4896-bf3a-bbbc0583f09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2caf68-7d2e-4896-bf3a-bbbc0583f09f.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -38435,7 +38435,7 @@
         },
         {
             "id": "00e41fe2-e0ac-5310-934a-ebc35c7ecf81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30da3c97-e9ef-4344-b814-adf7471a3d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30da3c97-e9ef-4344-b814-adf7471a3d78.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -38469,7 +38469,7 @@
         },
         {
             "id": "66300644-9cfe-5e77-b5f0-26cee09f403a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad07467-d467-40cf-8706-3a4b0c59ac42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad07467-d467-40cf-8706-3a4b0c59ac42.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -38503,7 +38503,7 @@
         },
         {
             "id": "92019dd3-98c0-56d5-937d-c1e92d5de438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2673417-67fa-4c32-ab9f-155d8a18d304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2673417-67fa-4c32-ab9f-155d8a18d304.jpg?1",
             "name": "Temple of Malady",
             "text": "",
             "colours": [],
@@ -38537,7 +38537,7 @@
         },
         {
             "id": "45a08e84-bc90-543d-9005-86f35b34a708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b15ef1-d79c-4164-af18-900c8aab8f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b15ef1-d79c-4164-af18-900c8aab8f1f.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -38571,7 +38571,7 @@
         },
         {
             "id": "177072f6-3188-5c18-8404-dddc0311332a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1c98e1-0181-40b3-8276-81ba79ac6741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1c98e1-0181-40b3-8276-81ba79ac6741.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -38605,7 +38605,7 @@
         },
         {
             "id": "354bca26-49ac-5894-998c-99bcd07f8d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b7a74-aa53-47f0-86ee-edad1b188200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b7a74-aa53-47f0-86ee-edad1b188200.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -38639,7 +38639,7 @@
         },
         {
             "id": "3d87e6f7-c5fd-59ef-8b49-f6093795dac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163c033-1a95-4bfb-a3c0-692a12e99e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163c033-1a95-4bfb-a3c0-692a12e99e1d.jpg?1",
             "name": "Temple of Silence",
             "text": "",
             "colours": [],
@@ -38673,7 +38673,7 @@
         },
         {
             "id": "59624696-2df6-57ca-a36a-569a39caa7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d60c97-cc03-4a3f-b521-8b9eb40af06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d60c97-cc03-4a3f-b521-8b9eb40af06d.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -38707,7 +38707,7 @@
         },
         {
             "id": "77a8b4dd-15ae-5125-83e4-e56256fa7bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbba0d-8884-4e24-a180-749a408b27d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbba0d-8884-4e24-a180-749a408b27d2.jpg?1",
             "name": "Treasure Vault",
             "text": "",
             "colours": [],
@@ -38739,7 +38739,7 @@
         },
         {
             "id": "fd674479-710a-5a5e-a840-769679d994f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70d498-1fe2-4136-94bc-18fc163cbc7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70d498-1fe2-4136-94bc-18fc163cbc7b.jpg?1",
             "name": "Windbrisk Heights",
             "text": "",
             "colours": [],
@@ -38772,7 +38772,7 @@
         },
         {
             "id": "207a231d-d836-58ee-b3fc-c1e626f805e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dfbf7-317e-45d6-9cca-29d14125e025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dfbf7-317e-45d6-9cca-29d14125e025.jpg?1",
             "name": "Woodland Cemetery",
             "text": "",
             "colours": [],
@@ -38806,7 +38806,7 @@
         },
         {
             "id": "4affd004-d432-5788-84eb-f5f3e57ac811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697418b-9823-4b9c-b8d4-b38ce818a2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697418b-9823-4b9c-b8d4-b38ce818a2a0.jpg?1",
             "name": "Strength Bobblehead",
             "text": "",
             "colours": [],
@@ -38838,7 +38838,7 @@
         },
         {
             "id": "2f800ed0-ac69-5e69-ad7d-466517a8c3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2925410a-7c44-4bf4-83cd-3e75dbe82b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2925410a-7c44-4bf4-83cd-3e75dbe82b23.jpg?1",
             "name": "Perception Bobblehead",
             "text": "",
             "colours": [],
@@ -38870,7 +38870,7 @@
         },
         {
             "id": "a8444e02-5a49-5022-a319-204a8cfc0eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb36a80-ddef-4be9-a6b3-ebe8143bc1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb36a80-ddef-4be9-a6b3-ebe8143bc1ca.jpg?1",
             "name": "Endurance Bobblehead",
             "text": "",
             "colours": [],
@@ -38902,7 +38902,7 @@
         },
         {
             "id": "061e783e-e245-5047-bf08-0a105924849e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1630054-b9f8-474c-8383-3d6058c0e555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1630054-b9f8-474c-8383-3d6058c0e555.jpg?1",
             "name": "Charisma Bobblehead",
             "text": "",
             "colours": [],
@@ -38934,7 +38934,7 @@
         },
         {
             "id": "98a1922f-a650-58d9-852f-0f87beb3f397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114600bd-4bf5-4eeb-bb9d-25bfb8a54adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114600bd-4bf5-4eeb-bb9d-25bfb8a54adc.jpg?1",
             "name": "Intelligence Bobblehead",
             "text": "",
             "colours": [],
@@ -38966,7 +38966,7 @@
         },
         {
             "id": "551a9909-3a46-586f-8e7f-60c260a357f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16414b32-2e70-4da6-9556-fcac07528e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16414b32-2e70-4da6-9556-fcac07528e5f.jpg?1",
             "name": "Agility Bobblehead",
             "text": "",
             "colours": [],
@@ -38998,7 +38998,7 @@
         },
         {
             "id": "0f1b5809-8d95-5ee3-a61b-2f04dfc8c639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e26cce-e872-47f4-90b2-0739fa98e97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e26cce-e872-47f4-90b2-0739fa98e97c.jpg?1",
             "name": "Luck Bobblehead",
             "text": "",
             "colours": [],
@@ -39030,7 +39030,7 @@
         },
         {
             "id": "4dc9b590-6b41-54a0-bab4-a7b8d06b6a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faac5cd1-ce93-4b98-97ad-8bdce2862b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faac5cd1-ce93-4b98-97ad-8bdce2862b3b.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "",
             "colours": [
@@ -39075,7 +39075,7 @@
         },
         {
             "id": "a622f7ec-a10d-593c-80a8-023d03dde43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12956bf2-cea1-40b9-8229-2746fc952755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12956bf2-cea1-40b9-8229-2746fc952755.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "",
             "colours": [
@@ -39119,7 +39119,7 @@
         },
         {
             "id": "460c8d72-6265-57dc-a82d-2522a19f302e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833fe154-fe11-4bef-8194-812cccacd4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833fe154-fe11-4bef-8194-812cccacd4fb.jpg?1",
             "name": "Dr. Madison Li",
             "text": "",
             "colours": [
@@ -39164,7 +39164,7 @@
         },
         {
             "id": "8386643b-e09f-5b9c-a06e-6ff60db6a0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28686dda-64b0-4ffe-b71a-58e7f901c4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28686dda-64b0-4ffe-b71a-58e7f901c4eb.jpg?1",
             "name": "The Wise Mothman",
             "text": "",
             "colours": [
@@ -39209,7 +39209,7 @@
         },
         {
             "id": "b99511ee-2aaf-5277-9715-18959b0636d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6535fc5-fc35-425a-a8da-2e443b4ac8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6535fc5-fc35-425a-a8da-2e443b4ac8d2.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -39237,7 +39237,7 @@
         },
         {
             "id": "79c46733-682f-5be1-b347-386901478499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c43047-87f6-4382-874e-02e9628647bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c43047-87f6-4382-874e-02e9628647bd.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -39265,7 +39265,7 @@
         },
         {
             "id": "5a89935e-2167-5ee7-8e6c-b0ed7c340979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546bda77-e3a8-4f2a-ba9c-94fb0b9ff183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546bda77-e3a8-4f2a-ba9c-94fb0b9ff183.jpg?1",
             "name": "Human Knight",
             "text": "",
             "colours": [
@@ -39301,7 +39301,7 @@
         },
         {
             "id": "930d0b44-6e57-5fc8-a310-01c9380940b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737741e7-b2b2-4c41-ab7c-4eeaf9f37b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737741e7-b2b2-4c41-ab7c-4eeaf9f37b71.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -39337,7 +39337,7 @@
         },
         {
             "id": "d69959d9-f0f9-51cd-8b0d-c560cff6e53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af191656-5e62-440f-b63a-705cfed314e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af191656-5e62-440f-b63a-705cfed314e7.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -39372,7 +39372,7 @@
         },
         {
             "id": "4db45815-c663-5c72-94dd-32f109c9d522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263a442-8ca6-4c69-a841-4a590ff2e729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263a442-8ca6-4c69-a841-4a590ff2e729.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -39407,7 +39407,7 @@
         },
         {
             "id": "110f3dd8-f598-57bd-a219-d29e29bcb414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66f10d-6fc4-4510-818c-96d29b425052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66f10d-6fc4-4510-818c-96d29b425052.jpg?1",
             "name": "Alien",
             "text": "",
             "colours": [
@@ -39442,7 +39442,7 @@
         },
         {
             "id": "e4ed1737-026f-59c0-9d76-b7bfd9649659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba45bc9c-8257-43f8-9ba1-116b9fea90f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba45bc9c-8257-43f8-9ba1-116b9fea90f4.jpg?1",
             "name": "Zombie Mutant",
             "text": "",
             "colours": [
@@ -39478,7 +39478,7 @@
         },
         {
             "id": "f265a084-6b20-50a4-8e99-d8b412da85d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02789d01-f939-4515-a6e4-db6aff36f893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02789d01-f939-4515-a6e4-db6aff36f893.jpg?1",
             "name": "Settlement",
             "text": "",
             "colours": [
@@ -39513,7 +39513,7 @@
         },
         {
             "id": "15d70ab7-e396-5476-85cc-840a9f4885c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90bb066-79fd-48cd-ab5a-eaed71139b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90bb066-79fd-48cd-ab5a-eaed71139b4e.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -39548,7 +39548,7 @@
         },
         {
             "id": "a4fa2d1c-1462-501e-b492-d6926a131c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae7bdfe-fe14-4a18-b2b0-16e9175a0441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae7bdfe-fe14-4a18-b2b0-16e9175a0441.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -39585,7 +39585,7 @@
         },
         {
             "id": "e4dce79e-c9ce-520b-9401-d635e4e4c654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff5544-bdf8-43a3-a74d-4a2b7d79245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff5544-bdf8-43a3-a74d-4a2b7d79245a.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -39616,7 +39616,7 @@
         },
         {
             "id": "53fff3d8-02af-5b55-ac8f-6166b29f1ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2a0ab-7f64-4f82-b6db-d84194b5d417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2a0ab-7f64-4f82-b6db-d84194b5d417.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -39647,7 +39647,7 @@
         },
         {
             "id": "fae89cdd-11c5-504e-9299-67377131033d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a004f0-b216-41cc-904f-91eea562d485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a004f0-b216-41cc-904f-91eea562d485.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -39678,7 +39678,7 @@
         },
         {
             "id": "89ecc35b-cd4a-5edf-a5e6-b41fbcb9bee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d0801a-9565-419f-bb0b-23547c9dd59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d0801a-9565-419f-bb0b-23547c9dd59d.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -39709,7 +39709,7 @@
         },
         {
             "id": "de557c08-4418-5956-8a9c-1a485cde1194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c4a6f6-6425-4c0c-b35a-880fcab42aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c4a6f6-6425-4c0c-b35a-880fcab42aad.jpg?1",
             "name": "Junk",
             "text": "",
             "colours": [],
@@ -39740,7 +39740,7 @@
         },
         {
             "id": "ddc8ad4e-de72-556a-926b-994d7831d498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde21f-2f01-4560-972b-7ecd6740d6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde21f-2f01-4560-972b-7ecd6740d6de.jpg?1",
             "name": "Robot",
             "text": "",
             "colours": [],
@@ -39772,7 +39772,7 @@
         },
         {
             "id": "88e4b3a4-d00d-5bf8-8360-35069add6912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaadec8-5bf7-4b53-b83e-33d17dc0ed74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaadec8-5bf7-4b53-b83e-33d17dc0ed74.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -39804,7 +39804,7 @@
         },
         {
             "id": "168d1610-a4cc-54e6-bd3b-cc3fa6b11b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0d0741-028f-481b-8982-55f36304c343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0d0741-028f-481b-8982-55f36304c343.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -39835,7 +39835,7 @@
         },
         {
             "id": "04632524-9fd9-5f3d-89ba-1b31400561f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d74d012-66ca-4a0c-9e90-e31e96730d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d74d012-66ca-4a0c-9e90-e31e96730d4d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -39866,7 +39866,7 @@
         },
         {
             "id": "20e22465-c63e-5637-abbf-0bdd2c14eee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad073c87-42f2-45f0-9613-2cdbd0abf719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad073c87-42f2-45f0-9613-2cdbd0abf719.jpg?1",
             "name": "Wasteland Survival Guide",
             "text": "",
             "colours": [],
@@ -39897,7 +39897,7 @@
         },
         {
             "id": "ab6d8380-aba9-5462-a2dc-e47698f6298b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a794202-875f-4397-a8de-9722c8d78448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a794202-875f-4397-a8de-9722c8d78448.jpg?1",
             "name": "Energy Reserve",
             "text": "",
             "colours": [],
@@ -39925,7 +39925,7 @@
         },
         {
             "id": "4ce0f951-01fd-5279-ac2c-8219768baf53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0886657d-afb0-4f1f-9af7-960724793077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0886657d-afb0-4f1f-9af7-960724793077.jpg?1",
             "name": "Radiation",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/PLC.json
+++ b/Assets/Resources/Sets/PLC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "54a02219-51cc-5401-b7b6-d4b255a1bb8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4394a-9ce2-4876-8a04-38e3775123af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4394a-9ce2-4876-8a04-38e3775123af.jpg?1",
             "name": "Aven Riftwatcher",
             "text": "Flying\nVanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher comes into play or leaves play, you gain 2 life.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "6c0086e2-8542-5619-b549-76d0b606a1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814da0-3bc8-423d-9b22-3fea123048fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814da0-3bc8-423d-9b22-3fea123048fa.jpg?1",
             "name": "Benalish Commander",
             "text": "Benalish Commander's power and toughness are each equal to the number of Soldiers you control.\nSuspend X\u2014{X}{W}{W}. X can't be 0.\nWhenever a time counter is removed from Benalish Commander while it's removed from the game, put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "41a31003-0e13-5e34-a8db-7ffec3b2fe6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63049fe4-de25-4606-a271-4ccb1b8298f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63049fe4-de25-4606-a271-4ccb1b8298f1.jpg?1",
             "name": "Crovax, Ascendant Hero",
             "text": "Other white creatures get +1/+1.\nNonwhite creatures get -1/-1.\nPay 2 life: Return Crovax, Ascendant Hero to its owner's hand.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "953e1605-049a-59cd-a6f1-db21ecfc3c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9667b-1d94-42eb-ae8e-1ae4755e200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9667b-1d94-42eb-ae8e-1ae4755e200a.jpg?1",
             "name": "Dawn Charm",
             "text": "Choose one Prevent all combat damage that would be dealt this turn; or regenerate target creature; or counter target spell that targets you.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "2b0a1071-2e17-5d6d-97f6-bfc577122c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144e9391-f417-464b-8c04-c952193997c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144e9391-f417-464b-8c04-c952193997c7.jpg?1",
             "name": "Dust Elemental",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying, fear\nWhen Dust Elemental comes into play, return three creatures you control to their owner's hand.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "da405808-346d-5236-948f-72244c886833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ab366c-085b-4b13-b5ad-918965c34d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ab366c-085b-4b13-b5ad-918965c34d22.jpg?1",
             "name": "Ghost Tactician",
             "text": "{W}, {T}, Discard a card: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "8028b34c-f720-5551-bf7b-15b2cafa13c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9902b260-82cf-4b10-a353-321231824a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9902b260-82cf-4b10-a353-321231824a3b.jpg?1",
             "name": "Heroes Remembered",
             "text": "You gain 20 life.\nSuspend 10\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with ten time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "b850f2ec-afa5-5ecf-9fbe-5fd5a4382011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd520f8c-93fb-4cf3-8dd5-d05abbd86c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd520f8c-93fb-4cf3-8dd5-d05abbd86c74.jpg?1",
             "name": "Magus of the Tabernacle",
             "text": "All creatures have \"At the beginning of your upkeep, sacrifice this creature unless you pay {1}.\"",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "70e7b2fc-5880-56cd-bc67-06b35a2384be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef5d122-cf18-42c3-be24-cfd92bd18be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef5d122-cf18-42c3-be24-cfd92bd18be9.jpg?1",
             "name": "Mantle of Leadership",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nWhenever a creature comes into play, enchanted creature gets +2/+2 until end of turn.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "f68a2a90-a01e-5e23-a49e-1fe02ed92b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a11b639-a5a3-424d-80c6-42d7252472a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a11b639-a5a3-424d-80c6-42d7252472a1.jpg?1",
             "name": "Pallid Mycoderm",
             "text": "At the beginning of your upkeep, put a spore counter on Pallid Mycoderm.\nRemove three spore counters from Pallid Mycoderm: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Each Fungus and each Saproling you control gets +1/+1 until end of turn.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "a2b9f53b-4f60-5928-86ce-1adad0e18429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3441ae0-4c20-487b-99b8-d6934dfb66ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3441ae0-4c20-487b-99b8-d6934dfb66ff.jpg?1",
             "name": "Poultice Sliver",
             "text": "All Slivers have \"{2}, {T}: Regenerate target Sliver.\"",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "4c5c3b41-6e7d-58e5-a366-2b56fa2bbf48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47fcce-d4c4-40a2-8853-6d7569d50926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47fcce-d4c4-40a2-8853-6d7569d50926.jpg?1",
             "name": "Rebuff the Wicked",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "4a0268eb-b606-5eba-bd92-4ba1ace04d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faa005e-c753-4484-bf64-349350d59094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faa005e-c753-4484-bf64-349350d59094.jpg?1",
             "name": "Retether",
             "text": "Return each Aura card from your graveyard to play. Only creatures can be enchanted this way. (Aura cards that can't enchant a creature in play remain in your graveyard.)",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "52b602b6-95ae-5955-8fe0-af7094783c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d503b565-a3c8-4b57-9e30-fb97d2a49afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d503b565-a3c8-4b57-9e30-fb97d2a49afa.jpg?1",
             "name": "Riftmarked Knight",
             "text": "Flanking, protection from black\nSuspend 3\u2014{1}{W}{W}\nWhen the last time counter is removed from Riftmarked Knight while it's removed from the game, put a 2/2 black Knight creature token with flanking, protection from white, and haste into play.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "112152b2-3b36-58ef-b7d7-2a1e1b6cf959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd1833d-64b0-4c9b-8f6b-1cf15c29d473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd1833d-64b0-4c9b-8f6b-1cf15c29d473.jpg?1",
             "name": "Saltblast",
             "text": "Destroy target nonwhite permanent.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "b1fef00a-466b-5b0c-9ff7-a5284a2837cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffed4e4-0f54-4ab1-8563-ac4be7ae8309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffed4e4-0f54-4ab1-8563-ac4be7ae8309.jpg?1",
             "name": "Saltfield Recluse",
             "text": "{T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "ccfd9880-c820-57d2-8801-75b5cd198b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b869a77-dd1c-46bb-9360-5a0c69a193c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b869a77-dd1c-46bb-9360-5a0c69a193c0.jpg?1",
             "name": "Serra's Boon",
             "text": "Enchant creature\nEnchanted creature gets +1/+2 as long as it's white. Otherwise, it gets -2/-1.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "77312ff8-1a87-5fa7-b7ff-113ebdf1e7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90d62c-5b3e-4830-bdc9-c3e342fc8389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90d62c-5b3e-4830-bdc9-c3e342fc8389.jpg?1",
             "name": "Shade of Trokair",
             "text": "{W}: Shade of Trokair gets +1/+1 until end of turn.\nSuspend 3\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "629fa7da-e90e-5cf5-8685-bff93ceff1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b11cec-de85-4289-a7b4-e8bfdf655130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b11cec-de85-4289-a7b4-e8bfdf655130.jpg?1",
             "name": "Stonecloaker",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Stonecloaker comes into play, return a creature you control to its owner's hand.\nWhen Stonecloaker comes into play, remove target card in a graveyard from the game.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "f317027b-a99e-535f-9938-322b9895df64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5e892e-d321-436f-81a6-73975e65b45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5e892e-d321-436f-81a6-73975e65b45c.jpg?1",
             "name": "Stormfront Riders",
             "text": "Flying\nWhen Stormfront Riders comes into play, return two creatures you control to their owner's hand.\nWhenever Stormfront Riders or another creature is returned to your hand from play, put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "be6e66ae-2b03-549b-b4a2-4e3032f8df6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583741a1-0faf-4fb3-8536-b9b1cc8a3b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583741a1-0faf-4fb3-8536-b9b1cc8a3b6f.jpg?1",
             "name": "Voidstone Gargoyle",
             "text": "Flying\nAs Voidstone Gargoyle comes into play, name a nonland card.\nThe named card can't be played.\nActivated abilities of permanents with that name can't be played.\nActivated abilities of cards with that name that aren't in play can't be played.",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "b433d58b-6cbc-57b3-9fef-c711093e5622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1214ff-e959-43ca-8415-79a98d398490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1214ff-e959-43ca-8415-79a98d398490.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Whitemane Lion comes into play, return a creature you control to its owner's hand.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "fc3fb615-5623-56a1-8aa9-d8175f4b3efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0159719-ccf4-4798-a394-b01f5e422a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0159719-ccf4-4798-a394-b01f5e422a27.jpg?1",
             "name": "Calciderm",
             "text": "Vanishing 4 (This permanent comes into play with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nCalciderm can't be the target of spells or abilities.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "51ef8916-29ba-524d-b142-524e7b4edd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5df373-5dad-4e33-9e2b-351f1f4bdde4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5df373-5dad-4e33-9e2b-351f1f4bdde4.jpg?1",
             "name": "Malach of the Dawn",
             "text": "Flying\n{W}{W}{W}: Regenerate Malach of the Dawn.",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "a88e9aa7-ae80-5b8c-b909-62b418054399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d48d622-f397-4f31-b1a5-0c23f60aa71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d48d622-f397-4f31-b1a5-0c23f60aa71c.jpg?1",
             "name": "Mana Tithe",
             "text": "Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "b6569548-b506-5510-bb4c-c6bc5c31b16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037d6de-f30b-483c-83a8-9a4e2978f7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037d6de-f30b-483c-83a8-9a4e2978f7fc.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -890,7 +890,7 @@
         },
         {
             "id": "79f2f68b-c6eb-596e-a2cd-9c6ae67d105f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d8e9fa-e241-4a11-99b8-ffced81eb38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d8e9fa-e241-4a11-99b8-ffced81eb38b.jpg?1",
             "name": "Mycologist",
             "text": "At the beginning of your upkeep, put a spore counter on Mycologist.\nRemove three spore counters from Mycologist: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: You gain 2 life.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "7c60a790-cd17-593f-a025-d3d20722a7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8f0e5-8fec-45b2-a6a0-59d7b493a259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8f0e5-8fec-45b2-a6a0-59d7b493a259.jpg?1",
             "name": "Porphyry Nodes",
             "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures in play, sacrifice Porphyry Nodes.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "8e5fa3bb-d3b2-5017-aa3f-108c84875566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a78d5c-27f8-4061-be89-0246fb69e752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a78d5c-27f8-4061-be89-0246fb69e752.jpg?1",
             "name": "Revered Dead",
             "text": "{W}: Regenerate Revered Dead.",
             "colours": [
@@ -992,7 +992,7 @@
         },
         {
             "id": "fc4efdf9-68e0-5e5d-af7d-6522aec8a570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd2ed50-cd9a-45d9-a59a-6279be1ab308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd2ed50-cd9a-45d9-a59a-6279be1ab308.jpg?1",
             "name": "Sinew Sliver",
             "text": "All Slivers get +1/+1.",
             "colours": [
@@ -1026,7 +1026,7 @@
         },
         {
             "id": "3229bd6d-1607-532b-99e9-eb10ed26e94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46144ca5-aa81-4314-a1e5-1716f8565d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46144ca5-aa81-4314-a1e5-1716f8565d70.jpg?1",
             "name": "Sunlance",
             "text": "Sunlance deals 3 damage to target nonwhite creature.",
             "colours": [
@@ -1058,7 +1058,7 @@
         },
         {
             "id": "fecd5269-360a-5fd0-ad3d-f3c6e22f100f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbc2dd2-976b-4239-bef9-ea0f06be79ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbc2dd2-976b-4239-bef9-ea0f06be79ba.jpg?1",
             "name": "Aeon Chronicler",
             "text": "Aeon Chronicler's power and toughness are each equal to the number of cards in your hand.\nSuspend X\u2014{X}{3}{U}. X can't be 0.\nWhenever a time counter is removed from Aeon Chronicler while it's removed from the game, draw a card.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "4bc38d45-5fda-5761-836c-b622925b04d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9781ab73-5c79-41f3-b319-c9299b03353a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9781ab73-5c79-41f3-b319-c9299b03353a.jpg?1",
             "name": "Aquamorph Entity",
             "text": "As Aquamorph Entity comes into play or is turned face up, it becomes your choice of 5/1 or 1/5.\nMorph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "89f7cb2b-024f-5f90-bc62-a235e308cbab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c787368d-d208-4aac-936d-b0c189d1cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c787368d-d208-4aac-936d-b0c189d1cd90.jpg?1",
             "name": "Auramancer's Guise",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 for each Aura attached to it and has vigilance.",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "edfa383f-723b-5dc9-a85b-5927fdfa3246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66895b2-07f9-46b1-80e6-2d573e532fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66895b2-07f9-46b1-80e6-2d573e532fc5.jpg?1",
             "name": "Body Double",
             "text": "As Body Double comes into play, you may choose a creature card in a graveyard. If you do, Body Double comes into play as a copy of that card.",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "8653afbb-6348-519f-bac2-b7a9d6660b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f16252d-0692-43f6-b980-ed9a6d937637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f16252d-0692-43f6-b980-ed9a6d937637.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from his or her hand into play.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "4daba2a1-8b47-59c7-896e-6eb900490d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77c1ac0-5548-42b0-aa46-d532b3518632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77c1ac0-5548-42b0-aa46-d532b3518632.jpg?1",
             "name": "Chronozoa",
             "text": "Flying\nVanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Chronozoa is put into a graveyard from play, if it had no time counters on it, put two tokens into play that are copies of it.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "558d00a3-c02d-5bbd-a24f-e1d5fb984c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61583ead-bccc-44d9-bd1d-2a13511990b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61583ead-bccc-44d9-bd1d-2a13511990b5.jpg?1",
             "name": "Dichotomancy",
             "text": "For each tapped nonland permanent target opponent controls, search that player's library for a card with the same name as that permanent and put it into play under your control. Then that player shuffles his or her library.\nSuspend 3\u2014{1}{U}{U}",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "83ecdb65-c6c8-57ba-b535-38d3c53a2911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35786a7a-faa6-457d-9b92-da560b93a43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35786a7a-faa6-457d-9b92-da560b93a43a.jpg?1",
             "name": "Dismal Failure",
             "text": "Counter target spell. Its controller discards a card.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "419dd637-19db-51ac-8430-2daea900012a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479d22f-1a97-4bc8-a1e1-c3de87429c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479d22f-1a97-4bc8-a1e1-c3de87429c22.jpg?1",
             "name": "Dreamscape Artist",
             "text": "{2}{U}, {T}, Discard a card, Sacrifice a land: Search your library for up to two basic land cards and put them into play. Then shuffle your library.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "10dcb6c5-2bd1-57a5-b9ec-e2795d641a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d3fb1-abfa-4724-a4e7-f65de88521f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d3fb1-abfa-4724-a4e7-f65de88521f8.jpg?1",
             "name": "Erratic Mutation",
             "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "976e61e5-245f-5426-8a30-de4eab1b7e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c92ae75-a209-4cc4-8817-06ff18f3ac02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c92ae75-a209-4cc4-8817-06ff18f3ac02.jpg?1",
             "name": "Jodah's Avenger",
             "text": "{0}: Until end of turn, Jodah's Avenger gets -1/-1 and gains your choice of double strike, protection from red, vigilance, or shadow. (A creature with shadow can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "903ec183-9622-52cc-8f21-6ea0b1cf57a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89762f8-70e0-414b-a788-532710129733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89762f8-70e0-414b-a788-532710129733.jpg?1",
             "name": "Magus of the Bazaar",
             "text": "{T}: Draw two cards, then discard three cards.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "760402ad-b067-5756-b80b-1eca315e8ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce74a84-4441-4f2e-89d8-df0b096790ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce74a84-4441-4f2e-89d8-df0b096790ed.jpg?1",
             "name": "Pongify",
             "text": "Destroy target creature. It can't be regenerated. That creature's controller puts a 3/3 green Ape creature token into play.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "b172df9d-997c-527f-89ba-8fae23581de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6ad9c3-b5dd-46a9-8494-8b395e21aedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6ad9c3-b5dd-46a9-8494-8b395e21aedf.jpg?1",
             "name": "Reality Acid",
             "text": "Enchant permanent\nVanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves play, enchanted permanent's controller sacrifices it.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "70911afd-9723-578c-bf08-598a50472d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88afc02-522b-4c51-9509-aff54bbb41c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88afc02-522b-4c51-9509-aff54bbb41c8.jpg?1",
             "name": "Shaper Parasite",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Shaper Parasite is turned face up, target creature gets +2/-2 or -2/+2 until end of turn.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "86275a73-0af6-5a1e-8692-37692eb21a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c897a6-5835-42ac-8cc7-e8d9fc1e7c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c897a6-5835-42ac-8cc7-e8d9fc1e7c77.jpg?1",
             "name": "Spellshift",
             "text": "Counter target instant or sorcery spell. Its controller reveals cards from the top of his or her library until he or she reveals an instant or sorcery card. That player may play that card without paying its mana cost. Then he or she shuffles his or her library.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "7b6b098f-ad04-53fd-8b25-7c834a498ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02fa57b-4b7f-46e1-b2b5-6b1a9e9d1643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02fa57b-4b7f-46e1-b2b5-6b1a9e9d1643.jpg?1",
             "name": "Synchronous Sliver",
             "text": "All Slivers have vigilance.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "2c1b4254-3648-522f-b1dc-e76504c6c23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464c2aa-8f12-4654-89c5-3323d7e7ab73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464c2aa-8f12-4654-89c5-3323d7e7ab73.jpg?1",
             "name": "Tidewalker",
             "text": "Tidewalker comes into play with a time counter on it for each Island you control.\nVanishing (At the beginning of your upkeep, remove a time counter from this permanent. When the last is removed, sacrifice it.)\nTidewalker's power and toughness are each equal to the number of time counters on it.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "947e57dd-5620-5a77-8abd-45c6bd4bc775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fdf8bd-a069-41ca-9cbb-deb7f53cbcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fdf8bd-a069-41ca-9cbb-deb7f53cbcbe.jpg?1",
             "name": "Timebender",
             "text": "Morph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Timebender is turned face up, choose one Remove two time counters from target permanent or suspended card; or put two time counters on target permanent with a time counter on it or suspended card.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "2a272847-4e9d-5b41-b764-d3119a2cf0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7fd5f3-e5af-4591-9db8-5d85dfe0170f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7fd5f3-e5af-4591-9db8-5d85dfe0170f.jpg?1",
             "name": "Veiling Oddity",
             "text": "Suspend 4\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)\nWhen the last time counter is removed from Veiling Oddity while it's removed from the game, creatures are unblockable this turn.",
             "colours": [
@@ -1734,7 +1734,7 @@
         },
         {
             "id": "af592cc0-baac-5e5a-a703-3542c554db67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfab012-f57a-4018-bfe3-8eac073f6ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfab012-f57a-4018-bfe3-8eac073f6ee8.jpg?1",
             "name": "Venarian Glimmer",
             "text": "Target player reveals his or her hand. Choose a nonland card with converted mana cost X or less from it. That player discards that card.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "9fd159cd-0731-51da-8d37-6f83ac319175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5031831-49ee-4c54-9200-448b8953f915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5031831-49ee-4c54-9200-448b8953f915.jpg?1",
             "name": "Wistful Thinking",
             "text": "Target player draws two cards, then discards four cards.",
             "colours": [
@@ -1798,7 +1798,7 @@
         },
         {
             "id": "e5fb32bc-9d38-5a75-9fac-31e49c8c5b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e727bb9e-3510-4c8e-ac49-6d7217667a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e727bb9e-3510-4c8e-ac49-6d7217667a18.jpg?1",
             "name": "Frozen Aether",
             "text": "Artifacts, creatures, and lands your opponents control come into play tapped.",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "1913882b-1a2c-5981-b85d-f9366e75170f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d53c7-ef63-464f-b5f0-90220ee2b575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d53c7-ef63-464f-b5f0-90220ee2b575.jpg?1",
             "name": "Gossamer Phantasm",
             "text": "Flying\nWhen Gossamer Phantasm becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "05481b64-3de4-518b-8f19-83cc31e6561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa3d335-f39f-4291-85e0-7430561e953b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa3d335-f39f-4291-85e0-7430561e953b.jpg?1",
             "name": "Merfolk Thaumaturgist",
             "text": "{T}: Switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -1899,7 +1899,7 @@
         },
         {
             "id": "c6a82611-58c6-5096-97c2-1c966c22711c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a985cfb0-6bae-4b1c-902e-d9d7a1aeec61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a985cfb0-6bae-4b1c-902e-d9d7a1aeec61.jpg?1",
             "name": "Ovinize",
             "text": "Target creature loses all abilities and becomes 0/1 until end of turn.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "9246ce26-4f33-5a54-834c-954bb69d9812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586a1d9f-59ae-41a7-8de7-d6c4553ea79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586a1d9f-59ae-41a7-8de7-d6c4553ea79e.jpg?1",
             "name": "Piracy Charm",
             "text": "Choose one Target creature gains islandwalk until end of turn; or target creature gets +2/-1 until end of turn; or target player discards a card.",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "4b96f2b7-6175-5c04-b06a-3522ec53ad4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbdd96b-e740-43d0-a1b6-7b9b92cc7993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbdd96b-e740-43d0-a1b6-7b9b92cc7993.jpg?1",
             "name": "Primal Plasma",
             "text": "As Primal Plasma comes into play, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.",
             "colours": [
@@ -1998,7 +1998,7 @@
         },
         {
             "id": "5802f345-6b28-579f-a901-bb26913fb6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcc3c1a-edb5-4534-aafa-5e078d503e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcc3c1a-edb5-4534-aafa-5e078d503e64.jpg?1",
             "name": "Riptide Pilferer",
             "text": "Whenever Riptide Pilferer deals combat damage to a player, that player discards a card.\nMorph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "ea86febe-7934-5f5e-9556-6bfe99a6581a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfd6aa-2fc9-4628-aa17-3ff0c30dc804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfd6aa-2fc9-4628-aa17-3ff0c30dc804.jpg?1",
             "name": "Serendib Sorcerer",
             "text": "{T}: Target creature other than Serendib Sorcerer becomes 0/2 until end of turn.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "a23731ce-bffc-5f36-b13d-e31db73dc99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a4d7ac-082b-4f66-9b7f-4d1d0fda78c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a4d7ac-082b-4f66-9b7f-4d1d0fda78c7.jpg?1",
             "name": "Serra Sphinx",
             "text": "Flying, vigilance",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "48fbd948-cd44-5be1-8aa1-b3ff22d26359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61f38a9-6f15-4186-a602-78cdb00f2d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61f38a9-6f15-4186-a602-78cdb00f2d75.jpg?1",
             "name": "Big Game Hunter",
             "text": "When Big Game Hunter comes into play, destroy target creature with power 4 or greater. It can't be regenerated.\nMadness {B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "17ea8a5b-1045-5f7b-81b4-c75aeb2cd868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae24bc0-1217-4db9-a745-8860f23b6d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae24bc0-1217-4db9-a745-8860f23b6d57.jpg?1",
             "name": "Blightspeaker",
             "text": "{T}: Target player loses 1 life.\n{4}, {T}: Search your library for a Rebel card with converted mana cost 3 or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "84be87e8-594e-5717-8699-2bc0c84e063e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02161f4-505c-4c01-ae33-5c61598c71d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02161f4-505c-4c01-ae33-5c61598c71d7.jpg?1",
             "name": "Brain Gorgers",
             "text": "When you play Brain Gorgers, any player may sacrifice a creature. If a player does, counter Brain Gorgers.\nMadness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "8be11234-57b0-54f9-a7cf-4adc4ec89124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f059cd0-7924-495e-bac4-021f0e46bb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f059cd0-7924-495e-bac4-021f0e46bb87.jpg?1",
             "name": "Circle of Affliction",
             "text": "As Circle of Affliction comes into play, choose a color.\nWhenever a source of the chosen color deals damage to you, you may pay {1}. If you do, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "734b7f46-3d3e-5cc1-b7a7-1d8a6502a395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec275cf-bb4e-4de0-9184-4d53dd87dad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec275cf-bb4e-4de0-9184-4d53dd87dad3.jpg?1",
             "name": "Cradle to Grave",
             "text": "Destroy target nonblack creature that came into play this turn.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "e18986be-47ce-5650-9763-32cbe01ffd81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814bcfc0-7539-4ed9-8b51-27e6a3ab9d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814bcfc0-7539-4ed9-8b51-27e6a3ab9d9a.jpg?1",
             "name": "Dash Hopes",
             "text": "When you play Dash Hopes, any player may pay 5 life. If a player does, counter Dash Hopes.\nCounter target spell.",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "78a4ab0e-2ae7-5578-b95a-037a8fd9fb29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde915a3-9c85-4365-bab9-87d446f85794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde915a3-9c85-4365-bab9-87d446f85794.jpg?1",
             "name": "Deadly Grub",
             "text": "Vanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadly Grub is put into a graveyard from play, if it had no time counters on it, put a 6/1 green Insect creature token into play with \"This creature can't be the target of spells or abilities.\"",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "f7734b94-bcc2-51f5-8a4f-ca034eff85a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6283e1-e4f1-4ff6-be01-b66ab623e0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6283e1-e4f1-4ff6-be01-b66ab623e0ac.jpg?1",
             "name": "Enslave",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, enchanted creature deals 1 damage to its owner.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "31641497-b074-56cb-bb88-03404fce839c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2608b5fc-3b58-4b02-aef1-35d885b16b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2608b5fc-3b58-4b02-aef1-35d885b16b01.jpg?1",
             "name": "Extirpate",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land. Search its owner's graveyard, hand, and library for all cards with the same name as that card and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "9b7f511e-f115-5e4d-9e78-340e0b2cb280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ec70a6-40b7-41da-a6c0-c140cadf5509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ec70a6-40b7-41da-a6c0-c140cadf5509.jpg?1",
             "name": "Imp's Mischief",
             "text": "Change the target of target spell with a single target. You lose life equal to that spell's converted mana cost.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "54ac3b12-1e17-5ff8-90ef-965a98f6e471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6b93ea-8ada-404c-9920-7976690c3e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6b93ea-8ada-404c-9920-7976690c3e8c.jpg?1",
             "name": "Magus of the Coffers",
             "text": "{2}, {T}: Add {B} to your mana pool for each Swamp you control.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "032623a5-2f61-5855-b142-ab52318082ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f51f18-41af-4a2c-a353-48bebd697599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f51f18-41af-4a2c-a353-48bebd697599.jpg?1",
             "name": "Midnight Charm",
             "text": "Choose one Midnight Charm deals 1 damage to target creature and you gain 1 life; or target creature gains first strike until end of turn; or tap target creature.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "438016fc-733d-5692-b94b-f62483f786e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09233-952f-4784-995e-0d85d8b56637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09233-952f-4784-995e-0d85d8b56637.jpg?1",
             "name": "Mirri the Cursed",
             "text": "Flying, first strike, haste\nWhenever Mirri the Cursed deals combat damage to a creature, put a +1/+1 counter on Mirri the Cursed.",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "6b99aa60-5df8-59db-b4ba-261ad45750bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bda3fc-89e8-44c2-bcfb-d17064bbc391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bda3fc-89e8-44c2-bcfb-d17064bbc391.jpg?1",
             "name": "Muck Drubb",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Muck Drubb comes into play, change the target of target spell that targets only a single creature to Muck Drubb.\nMadness {2}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "bf995934-db27-57ab-8a15-49766260d4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bcd780-70a6-4c25-8611-8b750a50aa3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bcd780-70a6-4c25-8611-8b750a50aa3d.jpg?1",
             "name": "Phantasmagorian",
             "text": "When you play Phantasmagorian, any player may discard three cards. If a player does, counter Phantasmagorian.\nDiscard three cards: Return Phantasmagorian from your graveyard to your hand.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "78ff8a83-7c99-5c0d-95c6-6e35178a25e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b27919-6b36-49f2-a6df-d63e5db6de0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b27919-6b36-49f2-a6df-d63e5db6de0b.jpg?1",
             "name": "Ridged Kusite",
             "text": "{1}{B}, {T}, Discard a card: Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -2643,7 +2643,7 @@
         },
         {
             "id": "71bf23ea-9a1f-545b-9a42-5f8b30767261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83006a5-c42b-4083-a246-f46b25412150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83006a5-c42b-4083-a246-f46b25412150.jpg?1",
             "name": "Roiling Horror",
             "text": "Roiling Horror's power and toughness are each equal to your life total minus the life total of an opponent with the most life.\nSuspend X\u2014{X}{B}{B}{B}. X can't be 0.\nWhenever a time counter is removed from Roiling Horror while it's removed from the game, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "efe09eae-321c-5f02-a37f-e31f4a754bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd07649e-c7fc-44f7-ab23-0fb935aff8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd07649e-c7fc-44f7-ab23-0fb935aff8c7.jpg?1",
             "name": "Spitting Sliver",
             "text": "All Slivers have first strike.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "2cc8aa2a-af00-59bf-93bc-2f196b461d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a1afb-423d-4f12-93e1-75cc336553b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a1afb-423d-4f12-93e1-75cc336553b8.jpg?1",
             "name": "Temporal Extortion",
             "text": "When you play Temporal Extortion, any player may pay half his or her life, rounded up. If a player does, counter Temporal Extortion.\nTake an extra turn after this one.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "2861447e-8fc1-5b19-b092-a6df19430446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22563bcd-1f29-4544-ba43-173ead61e62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22563bcd-1f29-4544-ba43-173ead61e62a.jpg?1",
             "name": "Treacherous Urge",
             "text": "Target opponent reveals his or her hand. You may put a creature card from it into play under your control. That creature has haste. Sacrifice it at end of turn.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "9c87b39f-158a-5989-8052-f202cda8cc16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20b0048-f93a-4349-b5d1-201ab0a38d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20b0048-f93a-4349-b5d1-201ab0a38d1b.jpg?1",
             "name": "Waning Wurm",
             "text": "Vanishing 2 (This permanent comes into play with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "0ad6a629-61b1-5361-b31e-fcdff2e34bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958de76-a5ec-4e14-a025-4fe0e84c8b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958de76-a5ec-4e14-a025-4fe0e84c8b4b.jpg?1",
             "name": "Bog Serpent",
             "text": "Bog Serpent can't attack unless defending player controls a Swamp.\nWhen you control no Swamps, sacrifice Bog Serpent.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "280111ea-c53a-552f-9078-41148322ee96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c68473-70ca-40ba-b5c6-71ec30f88a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c68473-70ca-40ba-b5c6-71ec30f88a2c.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "46a9336f-bda4-53f8-86a3-4b426cd55960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965d9f9-0a7b-48bc-a6ab-d8b73c4550a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965d9f9-0a7b-48bc-a6ab-d8b73c4550a8.jpg?1",
             "name": "Dunerider Outlaw",
             "text": "Protection from green\nAt end of turn, if Dunerider Outlaw dealt damage to an opponent this turn, put a +1/+1 counter on it.",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "41b99c3d-34aa-53a4-b9c8-e91e60479fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e1ec29-508f-4e5e-b601-79e27743bcea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e1ec29-508f-4e5e-b601-79e27743bcea.jpg?1",
             "name": "Kor Dirge",
             "text": "All damage that would be dealt this turn to target creature you control by a source of your choice is dealt to another target creature instead.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "409f464e-7dd6-52fa-9714-4334b19aa316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa6fe9a-27ba-480f-84ce-b8d3306f0339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa6fe9a-27ba-480f-84ce-b8d3306f0339.jpg?1",
             "name": "Melancholy",
             "text": "Enchant creature\nWhen Melancholy comes into play, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nAt the beginning of your upkeep, sacrifice Melancholy unless you pay {B}.",
             "colours": [
@@ -2978,7 +2978,7 @@
         },
         {
             "id": "8184e466-8426-50cc-a234-27aca4fab4a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c996792c-0846-4b78-bce5-1c6ad29640f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c996792c-0846-4b78-bce5-1c6ad29640f6.jpg?1",
             "name": "Null Profusion",
             "text": "Skip your draw step.\nWhenever you play a card, draw a card.\nYour maximum hand size is two.",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "fe14902d-0080-546f-8353-ff7cbcb03bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2968e01-2d04-4591-98de-24688bb087df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2968e01-2d04-4591-98de-24688bb087df.jpg?1",
             "name": "Rathi Trapper",
             "text": "{B}, {T}: Tap target creature.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "d6e129c5-2188-5c55-9a54-fa3e5659bc4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf956-90eb-4221-a8e0-c8414d819072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf956-90eb-4221-a8e0-c8414d819072.jpg?1",
             "name": "Shrouded Lore",
             "text": "Target opponent chooses a card in your graveyard. You may pay {B}. If you do, repeat this process except that opponent can't choose a card already chosen for Shrouded Lore. Then put the last chosen card into your hand.",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "816b1e25-5a79-5cc2-8529-d3b3f4c19542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9be1058-0668-4938-8801-e9a98464651c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9be1058-0668-4938-8801-e9a98464651c.jpg?1",
             "name": "Vampiric Link",
             "text": "Enchant creature\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "bc4284b8-715d-5046-a3dd-15a94d29e1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7767264f-926f-48eb-a5a1-c56b027e645f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7767264f-926f-48eb-a5a1-c56b027e645f.jpg?1",
             "name": "Aether Membrane",
             "text": "Defender\n\u00c6ther Membrane can block as though it had flying.\nWhenever \u00c6ther Membrane blocks a creature, return that creature to its owner's hand at end of combat.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "2d01ef6f-8d80-5aa4-86a2-a99fa7ad8cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815de82-5ba9-4fb6-9259-d5e50e046890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815de82-5ba9-4fb6-9259-d5e50e046890.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "Akroma, Angel of Fury can't be countered.\nFlying, trample, protection from white, protection from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "1abb31d2-2375-5bf2-9e0b-ba6fb7c4fab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc86d6-aa3e-46c6-9405-86f1e1ee7844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc86d6-aa3e-46c6-9405-86f1e1ee7844.jpg?1",
             "name": "Battering Sliver",
             "text": "All Slivers have trample.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "06dc97fe-4999-5c45-8d36-80725da9daf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec01f4b-b3df-4e2b-ae93-2f2d0cc279bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec01f4b-b3df-4e2b-ae93-2f2d0cc279bd.jpg?1",
             "name": "Detritivore",
             "text": "Detritivore's power and toughness are each equal to the number of nonbasic land cards in your opponents' graveyards.\nSuspend X\u2014{X}{3}{R}. X can't be 0.\nWhenever a time counter is removed from Detritivore while it's removed from the game, destroy target nonbasic land.",
             "colours": [
@@ -3250,7 +3250,7 @@
         },
         {
             "id": "5d8a4bef-4ddd-5e5c-bed2-bf1ce753648f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb554768-d908-474d-832d-d4e36d293712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb554768-d908-474d-832d-d4e36d293712.jpg?1",
             "name": "Dust Corona",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and can't be blocked by creatures with flying.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "1d0da11c-7de3-58b0-9ae3-3b25633139dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe87d-e886-4e30-8ff2-3886199f0461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe87d-e886-4e30-8ff2-3886199f0461.jpg?1",
             "name": "Fatal Frenzy",
             "text": "Until end of turn, target creature you control gains trample and gets +X/+0, where X is its power. Sacrifice it at end of turn.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "c557148c-f271-5c99-817d-b7a9c7573793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e1f374-d5fc-4f39-ad2a-2c9dad74efd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e1f374-d5fc-4f39-ad2a-2c9dad74efd3.jpg?1",
             "name": "Firefright Mage",
             "text": "{1}{R}, {T}, Discard a card: Target creature can't be blocked this turn except by artifact creatures and/or red creatures.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "942d9b2b-a263-5325-b696-d81482b023cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e891f1-79fa-43dc-817b-c7838cd03d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e891f1-79fa-43dc-817b-c7838cd03d5f.jpg?1",
             "name": "Fury Charm",
             "text": "Choose one Destroy target artifact; or target creature gets +1/+1 and gains trample until end of turn; or remove two time counters from target permanent or suspended card.",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "7fcb3a85-5f2e-5a05-8dbf-b716a0bbe64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791cb45a-66f0-4609-8da8-56112e31cef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791cb45a-66f0-4609-8da8-56112e31cef0.jpg?1",
             "name": "Hammerheim Deadeye",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Hammerheim Deadeye comes into play, destroy target creature with flying.",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "c88735ce-0fa0-523e-927a-2a6313c89590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c28db-34d2-4325-99d1-9b689753802f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c28db-34d2-4325-99d1-9b689753802f.jpg?1",
             "name": "Keldon Marauders",
             "text": "Vanishing 2 (This permanent comes into play with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Keldon Marauders comes into play or leaves play, it deals 1 damage to target player.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "4d549d62-2427-594d-95f5-28d3fa6b8799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2f4de-fc41-4e68-8655-577616b10c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2f4de-fc41-4e68-8655-577616b10c7e.jpg?1",
             "name": "Lavacore Elemental",
             "text": "Vanishing 1 (This permanent comes into play with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever a creature you control deals combat damage to a player, put a time counter on Lavacore Elemental.",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "32b9ffc5-77e8-5cde-9477-51e483ab191b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28af8d4-98e8-48aa-9697-49c94dfabedb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28af8d4-98e8-48aa-9697-49c94dfabedb.jpg?1",
             "name": "Magus of the Arena",
             "text": "{3}, {T}: Tap target creature you control and target creature of an opponent's choice he or she controls. Each of those creatures deals damage equal to its power to the other.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "faddbd86-a153-56c4-8cd0-86d2d22cbc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4307e3-3138-4ccb-8aa3-2ffcfeb2948f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4307e3-3138-4ccb-8aa3-2ffcfeb2948f.jpg?1",
             "name": "Needlepeak Spider",
             "text": "Needlepeak Spider can block as though it had flying.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "0dd37042-6143-5ba2-ad7a-0d0623f4be3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108599c3-f641-48f1-af68-8e9a66c6afbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108599c3-f641-48f1-af68-8e9a66c6afbc.jpg?1",
             "name": "Shivan Meteor",
             "text": "Shivan Meteor deals 13 damage to target creature.\nSuspend 2\u2014{1}{R}{R} (Rather than play this card from your hand, you may pay {1}{R}{R} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "9ca17080-c65c-5287-a55f-80e216911793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b10d6b3-2cd9-4628-a079-6ac803b6f3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b10d6b3-2cd9-4628-a079-6ac803b6f3c3.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger comes into play, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "8e234f28-934b-597a-832f-67ff6040291d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cba6fd-2474-400d-8568-33fe447abc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cba6fd-2474-400d-8568-33fe447abc7c.jpg?1",
             "name": "Sulfur Elemental",
             "text": "Flash (You may play this spell any time you could play an instant.)\nSplit second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nWhite creatures get +1/-1.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "5010385d-b09c-5424-979a-44ee607a9843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6da5ef-7e5b-4536-ad28-6fe66f3e0438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6da5ef-7e5b-4536-ad28-6fe66f3e0438.jpg?1",
             "name": "Timecrafting",
             "text": "Choose one Remove X time counters from target permanent or suspended card; or put X time counters on target permanent with a time counter on it or suspended card.",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "01677f47-0e71-5e1e-9cec-7870988ee149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9bee9f-701b-433e-b0c3-9bf00f598aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9bee9f-701b-433e-b0c3-9bf00f598aa9.jpg?1",
             "name": "Torchling",
             "text": "{R}: Untap Torchling.\n{R}: Target creature blocks Torchling this turn if able.\n{R}: Change the target of target spell that targets only Torchling.\n{1}: Torchling gets +1/-1 until end of turn.\n{1}: Torchling gets -1/+1 until end of turn.",
             "colours": [
@@ -3723,7 +3723,7 @@
         },
         {
             "id": "ba614973-7b60-526a-928d-bb1b6735187d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026b1a54-ab62-431d-a23e-5890d3932c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026b1a54-ab62-431d-a23e-5890d3932c7e.jpg?1",
             "name": "Volcano Hellion",
             "text": "Volcano Hellion has echo {X}, where X is your life total.\nWhen Volcano Hellion comes into play, it deals an amount of damage of your choice to you and target creature. The damage can't be prevented.",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "7104f01e-0ca6-53e6-873f-ee246015174a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy target land you control and target land you don't control.",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "94a1683f-deed-5731-bc0a-894075b3fdb2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy all lands.",
             "colours": [
@@ -3821,7 +3821,7 @@
         },
         {
             "id": "bea0e066-b932-546f-ae6d-7c311e395bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg?1",
             "name": "Dead // Gone",
             "text": "Dead deals 2 damage to target creature.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "38face9b-00dc-555b-b88b-f62d19f5eab9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg?1",
             "name": "Dead // Gone",
             "text": "Return target creature you don't control to its owner's hand.",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "f62813a2-f422-5f6f-b07e-97a9a47efaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg?1",
             "name": "Rough // Tumble",
             "text": "Rough deals 2 damage to each creature without flying.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "0e6a7d39-5a2b-5ced-892a-3517592f5919",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg?1",
             "name": "Rough // Tumble",
             "text": "Tumble deals 6 damage to each creature with flying.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "a8eff59b-676c-5edb-827d-c57c2050b763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2133c0-8561-4264-8802-1b2933abf186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2133c0-8561-4264-8802-1b2933abf186.jpg?1",
             "name": "Blood Knight",
             "text": "First strike, protection from white",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "92713de9-9da7-5294-aa55-2b0b540b9dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d43220-1e4e-4b61-9844-51c8bb5dde35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d43220-1e4e-4b61-9844-51c8bb5dde35.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "d41f7374-5c3a-5eb4-b2c8-fb3e8ef44183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddda66c-2df4-452e-8eca-7e100213fd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddda66c-2df4-452e-8eca-7e100213fd98.jpg?1",
             "name": "Molten Firebird",
             "text": "Flying\nWhen Molten Firebird is put into a graveyard from play, return it to play under its owner's control at end of turn and you skip your next draw step.\n{4}{R}: Remove Molten Firebird from the game.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "b2515423-4abe-5be3-bb54-e04040b32225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97787109-408e-42d3-acc5-300f5f5bf2ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97787109-408e-42d3-acc5-300f5f5bf2ff.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "8189ad5f-0cc3-5b8e-9349-a6a3dcfa76b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b778d44-60a9-4230-8090-73c38e7c9697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b778d44-60a9-4230-8090-73c38e7c9697.jpg?1",
             "name": "Pyrohemia",
             "text": "At end of turn, if no creatures are in play, sacrifice Pyrohemia.\n{R}: Pyrohemia deals 1 damage to each creature and each player.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "8f7c49f9-9426-5ec4-b436-5bca1eaec959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d4fd92-33d1-4f14-a4f4-7c7feaa18f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d4fd92-33d1-4f14-a4f4-7c7feaa18f93.jpg?1",
             "name": "Reckless Wurm",
             "text": "Trample\nMadness {2}{R} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "9b8abaf9-f0f9-5f5f-b8b6-e3194c2076e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7958a1e5-b671-4ecb-95de-240ffaf5021e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7958a1e5-b671-4ecb-95de-240ffaf5021e.jpg?1",
             "name": "Shivan Wumpus",
             "text": "Trample\nWhen Shivan Wumpus comes into play, any player may sacrifice a land. If a player does, put Shivan Wumpus on top of its owner's library.",
             "colours": [
@@ -4185,7 +4185,7 @@
         },
         {
             "id": "00845562-0b07-5c79-b903-9d2febceddd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7f701c-dcdc-4067-8d00-b4b7aadee9ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7f701c-dcdc-4067-8d00-b4b7aadee9ba.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "Remove Simian Spirit Guide in your hand from the game: Add {R} to your mana pool.",
             "colours": [
@@ -4220,7 +4220,7 @@
         },
         {
             "id": "b8a82844-b4bd-5332-a11c-55cacb0a7c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47307d3f-14e8-42bd-acf4-1383e5790e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47307d3f-14e8-42bd-acf4-1383e5790e6f.jpg?1",
             "name": "Skirk Shaman",
             "text": "Skirk Shaman can't be blocked except by artifact creatures and/or red creatures.",
             "colours": [
@@ -4255,7 +4255,7 @@
         },
         {
             "id": "cea7ac50-171a-5791-9c4c-b33340563c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafbeae0-17e3-4a29-bd02-9f45b549b990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafbeae0-17e3-4a29-bd02-9f45b549b990.jpg?1",
             "name": "Ana Battlemage",
             "text": "Kicker {2}{U} and/or {1}{B}\nWhen Ana Battlemage comes into play, if the {2}{U} kicker cost was paid, target player discards three cards.\nWhen Ana Battlemage comes into play, if the {1}{B} kicker cost was paid, tap target untapped creature and that creature deals damage equal to its power to its controller.",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "bfde935e-48c9-597b-a0ee-a8852dde251b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14556a-1bf4-4024-ba5b-2a4753fc236b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14556a-1bf4-4024-ba5b-2a4753fc236b.jpg?1",
             "name": "Citanul Woodreaders",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you play this spell.)\nWhen Citanul Woodreaders comes into play, if the kicker cost was paid, draw two cards.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "e3eca687-756d-534a-ae19-c4f275052c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e69c12-41f3-489c-ba30-2836b978f9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e69c12-41f3-489c-ba30-2836b978f9dc.jpg?1",
             "name": "Deadwood Treefolk",
             "text": "Vanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk comes into play or leaves play, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "7351c2f4-ee2f-5892-be9e-ecfea31f34ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4546059-71fe-43c1-9272-3b054e668e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4546059-71fe-43c1-9272-3b054e668e3c.jpg?1",
             "name": "Evolution Charm",
             "text": "Choose one Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library; or return target creature card from your graveyard to your hand; or target creature gains flying until end of turn.",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "5311a316-9409-534d-995c-1ff672c4bae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c1910b-9475-4551-b9a0-4b24511a6f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c1910b-9475-4551-b9a0-4b24511a6f98.jpg?1",
             "name": "Fungal Behemoth",
             "text": "Fungal Behemoth's power and toughness are each equal to the number of +1/+1 counters on creatures you control.\nSuspend X\u2014{X}{G}{G}. X can't be 0.\nWhenever a time counter is removed from Fungal Behemoth while it's removed from the game, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -4427,7 +4427,7 @@
         },
         {
             "id": "d226cec2-b83d-544e-968e-bd3a1d52f7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6938b-89e6-4cf2-8372-17f1682124ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6938b-89e6-4cf2-8372-17f1682124ec.jpg?1",
             "name": "Giant Dustwasp",
             "text": "Flying\nSuspend 4\u2014{1}{G} (Rather than play this card from your hand, you may pay {1}{G} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "83bd0c82-d369-54d4-98c6-81c2ba136ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112e0d7-5451-4e3b-8c73-2d2024f45cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112e0d7-5451-4e3b-8c73-2d2024f45cd8.jpg?1",
             "name": "Hunting Wilds",
             "text": "Kicker {3}{G} (You may pay an additional {3}{G} as you play this spell.)\nSearch your library for up to two Forest cards and put them into play tapped. Then shuffle your library.\nIf the kicker cost was paid, untap all Forests put into play this way. They become 3/3 green creatures with haste that are still lands.",
             "colours": [
@@ -4493,7 +4493,7 @@
         },
         {
             "id": "54dc14c7-ddfd-5b9c-a1bf-97e7e06302e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1685676c-19be-4220-993f-494c53f60499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1685676c-19be-4220-993f-494c53f60499.jpg?1",
             "name": "Jedit Ojanen of Efrava",
             "text": "Forestwalk\nWhenever Jedit Ojanen of Efrava attacks or blocks, put a 2/2 green Cat Warrior creature token with forestwalk into play.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "043563fd-5411-5a0d-a93a-7f23a3f1484e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965048e6-a693-4858-a244-3b9ee10bfb56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965048e6-a693-4858-a244-3b9ee10bfb56.jpg?1",
             "name": "Kavu Predator",
             "text": "Trample\nWhenever an opponent gains life, put that many +1/+1 counters on Kavu Predator.",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "3b6fe62d-8ae7-538a-af7e-fe4b2c9a69a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe9e8e-7fb3-4a6d-be3d-7965d2ffb0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe9e8e-7fb3-4a6d-be3d-7965d2ffb0a3.jpg?1",
             "name": "Life and Limb",
             "text": "All Forests and all Saprolings are 1/1 green Saproling creatures and Forest lands in addition to their other types.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "da8326dc-41d5-587b-8c73-142d4cdd0b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899db99b-df27-4848-a23d-5c645deae450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899db99b-df27-4848-a23d-5c645deae450.jpg?1",
             "name": "Magus of the Library",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Draw a card. Play this ability only if you have exactly seven cards in hand.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "c72a782f-a12f-5f42-bb90-4554b2bb6201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190dffdc-9d85-430d-9aea-b75084104840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190dffdc-9d85-430d-9aea-b75084104840.jpg?1",
             "name": "Mire Boa",
             "text": "Swampwalk\n{G}: Regenerate Mire Boa.",
             "colours": [
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "d90f9000-5662-506e-8460-41b457d7a6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e48a2f3-9c30-4187-868e-33dbf5e279fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e48a2f3-9c30-4187-868e-33dbf5e279fc.jpg?1",
             "name": "Pouncing Wurm",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you play this spell.)\nIf the kicker cost was paid, Pouncing Wurm comes into play with three +1/+1 counters on it and with haste.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "87814e7f-7008-52b4-9d6c-27c9f55131b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2803fdc-2ae1-438c-b5b1-559817e85fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2803fdc-2ae1-438c-b5b1-559817e85fdb.jpg?1",
             "name": "Psychotrope Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Psychotrope Thallid.\nRemove three spore counters from Psychotrope Thallid: Put a 1/1 green Saproling creature token into play.\n{1}, Sacrifice a Saproling: Draw a card.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "1abff1a5-d66e-5968-bbcd-634d3db7664e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017d37d-f47d-405e-95d8-78a8eec8addc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017d37d-f47d-405e-95d8-78a8eec8addc.jpg?1",
             "name": "Reflex Sliver",
             "text": "All Slivers have haste.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "3d054a4f-08e8-5d11-b1ec-b60f2815e1c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582cefca-6c11-4df3-8b54-46309dafff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582cefca-6c11-4df3-8b54-46309dafff4a.jpg?1",
             "name": "Sophic Centaur",
             "text": "{2}{G}{G}, {T}, Discard a card: You gain 2 life for each card in your hand.",
             "colours": [
@@ -4802,7 +4802,7 @@
         },
         {
             "id": "9cd81cb2-d722-52c9-879e-35280ebcad56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d604bac-58b7-4479-8ab8-2e0680746e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d604bac-58b7-4479-8ab8-2e0680746e0e.jpg?1",
             "name": "Timbermare",
             "text": "Haste\nEcho {5}{G} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Timbermare comes into play, tap all other creatures.",
             "colours": [
@@ -4837,7 +4837,7 @@
         },
         {
             "id": "bd67655c-009b-5b6c-a5c1-27da0d1646cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3fcd5-0e84-4332-ac84-19b75265ab52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3fcd5-0e84-4332-ac84-19b75265ab52.jpg?1",
             "name": "Uktabi Drake",
             "text": "Flying, haste\nEcho {1}{G}{G} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "1ab2b951-ca1a-5c87-a856-393ab601360f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f2ddb-3111-45a2-8334-a526bc885415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f2ddb-3111-45a2-8334-a526bc885415.jpg?1",
             "name": "Utopia Vow",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "34f0e239-1d65-5373-b9de-f8ed8975cad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad14bc9-b90e-48e0-9e72-173874dab6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad14bc9-b90e-48e0-9e72-173874dab6bc.jpg?1",
             "name": "Vitaspore Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Vitaspore Thallid.\nRemove three spore counters from Vitaspore Thallid: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Target creature gains haste until end of turn.",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "4882c72a-15b8-5abf-9eea-1a08f07ace36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38385d7a-fff2-4fe4-90ae-b9c58ad3b1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38385d7a-fff2-4fe4-90ae-b9c58ad3b1f5.jpg?1",
             "name": "Wild Pair",
             "text": "Whenever a creature comes into play, if you played it from your hand, you may search your library for a creature card with the same total power and toughness and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "5951324c-cfcf-57f8-b55e-578d5e474104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a65d6-0887-4fe8-a6e6-909208fddd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a65d6-0887-4fe8-a6e6-909208fddd90.jpg?1",
             "name": "Essence Warden",
             "text": "Whenever another creature comes into play, you gain 1 life.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "881e874a-c0cb-5930-9334-40e206183d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9985e8-535d-4815-8a58-a98c3edb68d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9985e8-535d-4815-8a58-a98c3edb68d4.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "f921b9e6-d10e-5890-af62-2eea6b4e6c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9e0de1-2299-4ff9-b49a-88535a96bda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9e0de1-2299-4ff9-b49a-88535a96bda0.jpg?1",
             "name": "Gaea's Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "7c33bda6-7eb0-5cf7-8054-0c7d00d25b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f467cdea-6166-4289-918b-18f5038c94ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f467cdea-6166-4289-918b-18f5038c94ed.jpg?1",
             "name": "Groundbreaker",
             "text": "Trample, haste\nAt end of turn, sacrifice Groundbreaker.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "f869a2c8-d738-5935-b11f-205ae9bbff7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b90dbd0-4672-4c0b-92eb-262ddd11cd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b90dbd0-4672-4c0b-92eb-262ddd11cd32.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "56c95a2f-0aba-595d-84c4-98379d0c9400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f58258-a1bd-4364-954e-c39938f7dab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f58258-a1bd-4364-954e-c39938f7dab2.jpg?1",
             "name": "Healing Leaves",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "1f9d53c3-d0ec-50e8-8105-10430fa64ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2e6027-598d-4ba0-93ae-f76d031de8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2e6027-598d-4ba0-93ae-f76d031de8af.jpg?1",
             "name": "Hedge Troll",
             "text": "Hedge Troll gets +1/+1 as long as you control a Plains.\n{W}: Regenerate Hedge Troll.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "2ebc922c-0b8b-536f-a7ef-8fc42033a885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4197d992-f868-44dd-85f7-598b22e208f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4197d992-f868-44dd-85f7-598b22e208f3.jpg?1",
             "name": "Keen Sense",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "cff9b6b5-3347-58ef-be89-6c57900dd42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba91ee-1f8e-47db-bb2d-bbb62039db17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba91ee-1f8e-47db-bb2d-bbb62039db17.jpg?1",
             "name": "Seal of Primordium",
             "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "7903d26f-43ae-508e-9029-5ff202719029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91da31d4-6616-4d61-82b7-52954162fe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91da31d4-6616-4d61-82b7-52954162fe4d.jpg?1",
             "name": "Cautery Sliver",
             "text": "All Slivers have \"{1}, Sacrifice this creature: This creature deals 1 damage to target creature or player.\"\nAll Slivers have \"{1}, Sacrifice this creature: Prevent the next 1 damage that would be dealt to target Sliver or player this turn.\"",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "3934308c-936d-5afd-8201-881c4ab94319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541ff31-0043-49a9-abac-77369f95b942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541ff31-0043-49a9-abac-77369f95b942.jpg?1",
             "name": "Darkheart Sliver",
             "text": "All Slivers have \"Sacrifice this creature: You gain 3 life.\"",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "234dee1a-6e68-5298-9dc8-1019c5c979f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b549e959-aa43-4ccc-8c45-ea357c25fb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b549e959-aa43-4ccc-8c45-ea357c25fb8c.jpg?1",
             "name": "Dormant Sliver",
             "text": "All Slivers have defender and \"When this creature comes into play, draw a card.\"",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "6b9fbb4e-7f19-5015-a833-1aa8d9f6e9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b1d87-ff9d-4511-a196-b8ae8b5b5e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b1d87-ff9d-4511-a196-b8ae8b5b5e1d.jpg?1",
             "name": "Frenetic Sliver",
             "text": "All Slivers have \"{0}: If this creature is in play, flip a coin. If you win the flip, remove this creature from the game and return it to play under its owner's control at end of turn. If you lose the flip, sacrifice it.\"",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "7c03c2f8-c869-578a-b651-518dbc8b5cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394e4fe9-2bb0-4a5c-bf10-b72b519d5226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394e4fe9-2bb0-4a5c-bf10-b72b519d5226.jpg?1",
             "name": "Intet, the Dreamer",
             "text": "Flying\nWhenever Intet, the Dreamer deals combat damage to a player, you may pay {2}{U}. If you do, remove the top card of your library from the game face down. You may look at that card as long as it remains removed from the game. You may play that card without paying its mana cost as long as Intet remains in play.",
             "colours": [
@@ -5457,7 +5457,7 @@
         },
         {
             "id": "9223603e-0bfa-5885-a2d4-05bd537e68e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e18843-06b4-480c-9291-c502542f72b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e18843-06b4-480c-9291-c502542f72b1.jpg?1",
             "name": "Necrotic Sliver",
             "text": "All Slivers have \"{3}, Sacrifice this creature: Destroy target permanent.\"",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "bc2e9b64-68a3-5d9a-8703-49623bbe708e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bf777a-a232-4504-afbb-13d2f79b4355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bf777a-a232-4504-afbb-13d2f79b4355.jpg?1",
             "name": "Numot, the Devastator",
             "text": "Flying\nWhenever Numot, the Devastator deals combat damage to a player, you may pay {2}{R}. If you do, destroy up to two target lands.",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "ce65a12a-e121-50a6-81d9-450b6777736e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2790685-f6ae-4106-ae4d-fe97954bcb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2790685-f6ae-4106-ae4d-fe97954bcb82.jpg?1",
             "name": "Oros, the Avenger",
             "text": "Flying\nWhenever Oros, the Avenger deals combat damage to a player, you may pay {2}{W}. If you do, Oros deals 3 damage to each nonwhite creature.",
             "colours": [
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "d3fcb530-c8ca-5775-b4a5-c44de5eba360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc23b2e-9124-4f88-b93e-8bfe90e6eb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc23b2e-9124-4f88-b93e-8bfe90e6eb41.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R} to your mana pool.\n{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "a9046c00-7af7-5022-8059-e3ba072fa4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c1b26c-97f0-4e7e-8744-8497a83a11ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c1b26c-97f0-4e7e-8744-8497a83a11ab.jpg?1",
             "name": "Teneb, the Harvester",
             "text": "Flying\nWhenever Teneb, the Harvester deals combat damage to a player, you may pay {2}{B}. If you do, put target creature card in a graveyard into play under your control.",
             "colours": [
@@ -5652,7 +5652,7 @@
         },
         {
             "id": "009231ae-6d65-5eb3-b786-25ee2dad051c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4438fe-b11b-4adb-b8dd-b44e12ef6124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4438fe-b11b-4adb-b8dd-b44e12ef6124.jpg?1",
             "name": "Vorosh, the Hunter",
             "text": "Flying\nWhenever Vorosh, the Hunter deals combat damage to a player, you may pay {2}{G}. If you do, put six +1/+1 counters on Vorosh.",
             "colours": [
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "c4390b5b-13ff-55a0-bb62-898d7c758d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e1224f-82cb-4f41-8739-f880cba61bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e1224f-82cb-4f41-8739-f880cba61bbb.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],

--- a/Assets/Resources/Sets/PLS.json
+++ b/Assets/Resources/Sets/PLS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8ce57c19-2905-5bf7-827b-53fe450ff2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f5ad6-e10e-49b3-8643-51a4e792517c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f5ad6-e10e-49b3-8643-51a4e792517c.jpg?1",
             "name": "Aura Blast",
             "text": "Destroy target enchantment.\nDraw a card.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "9e4f4460-ff0a-581a-8570-639b89fd6896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6c695-1944-4bb0-a701-0daf47cdbcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6c695-1944-4bb0-a701-0daf47cdbcb4.jpg?1",
             "name": "Aurora Griffin",
             "text": "Flying\no\nW: Target permanent becomes white until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "e9cb3842-250d-500f-af38-97e21e28b822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e268fe16-070b-4b78-9793-59755edb2fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e268fe16-070b-4b78-9793-59755edb2fd5.jpg?1",
             "name": "Disciple of Kangee",
             "text": "o\nU, oc\nT: Target creature gains flying and becomes blue until end of turn.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "0959cb88-17ca-5937-8ffa-e043c0226c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9703d090-b415-48e2-8158-dd8fc57ecc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9703d090-b415-48e2-8158-dd8fc57ecc50.jpg?1",
             "name": "Dominaria's Judgment",
             "text": "Until end of turn, creatures you control gain protection from white if you control a plains, from blue if you control an island, from black if you control a swamp, from red if you control a mountain, and from green if you control a forest.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "87e89326-a262-587b-9b70-6be118e8583c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32eee7-10ba-4f0b-8a87-c3ecfa22ae41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32eee7-10ba-4f0b-8a87-c3ecfa22ae41.jpg?1",
             "name": "Guard Dogs",
             "text": "o2o\nW, oc\nT: Choose a permanent you control. Prevent all combat damage target creature would deal this turn if it shares a color with that permanent.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "d98c1260-dc4f-5379-b0ff-4100f5cf5521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc1aa36-5d3b-4d25-9d54-937cdabf72a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc1aa36-5d3b-4d25-9d54-937cdabf72a4.jpg?1",
             "name": "Heroic Defiance",
             "text": "Enchanted creature gets +3/+3 unless it shares a color with the most common color among all permanents or a color tied for most common.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "a6838491-11c1-5915-a77d-37701d7ec8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c76a22-f9e3-408b-a5bd-403add57e31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c76a22-f9e3-408b-a5bd-403add57e31a.jpg?1",
             "name": "Hobble",
             "text": "When Hobble comes into play, draw a card.\nEnchanted creature can't attack.\nEnchanted creature can't block if it's black.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "af68d99d-ad07-55d4-8ba6-0637f2b736f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd311758-0352-4b7d-a24f-7f3f2b5d7b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd311758-0352-4b7d-a24f-7f3f2b5d7b0f.jpg?1",
             "name": "Honorable Scout",
             "text": "When Honorable Scout comes into play, you gain 2 life for each black and/or red creature target opponent controls.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "85b61b06-68c8-53a2-ac4d-6daa8ccafc51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2485c10d-de02-4be9-8119-afb2296e3317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2485c10d-de02-4be9-8119-afb2296e3317.jpg?1",
             "name": "Lashknife Barrier",
             "text": "When Lashknife Barrier comes into play, draw a card.\nIf a source would deal damage to a creature you control, it deals that much damage minus 1 to that creature instead.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "be92b3c7-774b-5d77-9498-c83e183accd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07dd0f1-b80b-4af0-ae76-907ec55ec7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07dd0f1-b80b-4af0-ae76-907ec55ec7d5.jpg?1",
             "name": "March of Souls",
             "text": "Destroy all creatures. They can't be regenerated. For each creature destroyed this way, its controller puts a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "6e9b8491-7120-5d14-bb9f-3094b57512b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055afa78-b969-498f-a3ad-c792426e5ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055afa78-b969-498f-a3ad-c792426e5ee6.jpg?1",
             "name": "Orim's Chant",
             "text": "Kicker o\nW (You may pay an additional o\nW as you play this spell.)\nTarget player can't play spells this turn.\nIf you paid the kicker cost, creatures can't attack this turn.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "0c904aec-dd4d-52ca-83e9-0cd24f2da68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0205d094-c846-4aa0-ade8-2a52c57b11da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0205d094-c846-4aa0-ade8-2a52c57b11da.jpg?1",
             "name": "Planeswalker's Mirth",
             "text": "o3o\nW: Target opponent reveals a card at random from his or her hand. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "3b6f5982-ef4a-545b-9cd6-9258d7d5d0d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c813-0cda-44ad-ae41-330e9bde9cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c813-0cda-44ad-ae41-330e9bde9cb9.jpg?1",
             "name": "Pollen Remedy",
             "text": "Kicker\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs as you play this spell.)\nPrevent the next 3 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose. If you paid the kicker cost, prevent the next 6 damage this way instead.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "e957e5e0-af17-50ac-80a7-7e111b48cd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c5dccc-2a48-4dcc-a796-fa6fdc11a14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c5dccc-2a48-4dcc-a796-fa6fdc11a14e.jpg?1",
             "name": "Samite Elder",
             "text": "oc\nT: Creatures you control gain protection from the color(s) of target permanent you control until end of turn.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "0b58190d-e889-5005-8b62-5d324531ac29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12529e4-f4b1-45be-8252-28783badbec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12529e4-f4b1-45be-8252-28783badbec5.jpg?1",
             "name": "Samite Pilgrim",
             "text": "oc\nT: Prevent the next X damage that would be dealt to target creature this turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "7945e1a8-b60e-5e86-833d-c9a0cc025fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e590f-0a4a-4ad0-b8ef-d3a18edadc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e590f-0a4a-4ad0-b8ef-d3a18edadc05.jpg?1",
             "name": "Sunscape Battlemage",
             "text": "Kicker o1o\nG and/or o2o\nU\nWhen Sunscape Battlemage comes into play, if you paid the o1o\nG kicker cost, destroy target creature with flying.\nWhen Sunscape Battlemage comes into play, if you paid the o2o\nU kicker cost, draw two cards.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "4314b8d5-c006-5a68-b5b1-55f5875c0135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621f341-bf85-4b77-bf19-2fb013b4c955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621f341-bf85-4b77-bf19-2fb013b4c955.jpg?1",
             "name": "Sunscape Familiar",
             "text": "(Walls can't attack.)\nGreen spells and blue spells you play cost o1 less to play.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "6c8009e7-3cde-5d0e-a3b9-e37f8887b030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26148b-b981-4af5-995b-52b1426737e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26148b-b981-4af5-995b-52b1426737e3.jpg?1",
             "name": "Surprise Deployment",
             "text": "Play Surprise Deployment only during combat.\nPut a nonwhite creature card from your hand into play. At end of turn, return that creature to your hand. (Return it only if it's in play.)",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "1f811e0c-5a19-50f6-bb16-69818397d944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f37536-db3d-4726-9e45-b9108247d0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f37536-db3d-4726-9e45-b9108247d0e6.jpg?1",
             "name": "Voice of All",
             "text": "Flying\nAs Voice of All comes into play, choose a color.\nVoice of All has protection from the chosen color.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "3baab717-273c-5a1b-ae27-9dd1daecbe0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4f211-10e8-486d-b982-287ab0c060c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4f211-10e8-486d-b982-287ab0c060c9.jpg?1",
             "name": "Allied Strategies",
             "text": "Target player draws a card for each basic land type among lands he or she controls.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "30e73f2c-fd65-50c6-a32e-39b7339f53e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86369fe5-d86d-4f4c-8f3d-dedc174f2032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86369fe5-d86d-4f4c-8f3d-dedc174f2032.jpg?1",
             "name": "Arctic Merfolk",
             "text": "Kicker\u2014\nReturn a creature you control to its owner's hand. (You may return a creature you control to its owner's hand in addition to any other costs as you play this spell.)\nIf you paid the kicker cost, Arctic Merfolk comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "3f49a8e7-6f04-5559-9931-959e069223f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b7d39-ce98-48e2-b2bf-0d55b4d3102b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b7d39-ce98-48e2-b2bf-0d55b4d3102b.jpg?1",
             "name": "Confound",
             "text": "Counter target spell that targets one or more creatures.\nDraw a card.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "973fc21e-18b7-5827-94b4-1d41ba814823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f4daf-7b54-4425-a93a-19532dfb83ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f4daf-7b54-4425-a93a-19532dfb83ca.jpg?1",
             "name": "Dralnu's Pet",
             "text": "Kicker\u2014o2o\nB, Discard a creature card from your hand. (You may pay o2o\nB and discard a creature card from your hand in addition to any other costs as you play this spell.)\nIf you paid the kicker cost, Dralnu's Pet has flying and comes into play with X +1/+1 counters on it, where X is the discarded card's converted mana cost.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "0973d41e-72d5-5a4a-b967-7d18852ebaeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544e3575-9fb6-41f7-a4e6-f8460dfae344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544e3575-9fb6-41f7-a4e6-f8460dfae344.jpg?1",
             "name": "Ertai's Trickery",
             "text": "Counter target spell if a kicker cost was paid for it.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "9455e0b3-015f-5e77-9ab8-67302037ca02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc9062e-ddd9-41ac-a88a-33f5a7b22103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc9062e-ddd9-41ac-a88a-33f5a7b22103.jpg?1",
             "name": "Escape Routes",
             "text": "o2o\nU: Return target white or black creature you control to its owner's hand.",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "6dc19cc5-2c4f-5d64-a16d-18813d2bb5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70a2092-5048-49c0-9351-a3f882c2f56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70a2092-5048-49c0-9351-a3f882c2f56e.jpg?1",
             "name": "Gainsay",
             "text": "Counter target blue spell.",
             "colours": [
@@ -872,7 +872,7 @@
         },
         {
             "id": "8d0ad1ba-5cdd-53a6-b79d-4b82e9553169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0293a9-48fe-4018-bd25-3e02c227a3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0293a9-48fe-4018-bd25-3e02c227a3dd.jpg?1",
             "name": "Hunting Drake",
             "text": "Flying\nWhen Hunting Drake comes into play, put target red or green creature on top of its owner's library.",
             "colours": [
@@ -906,7 +906,7 @@
         },
         {
             "id": "942a7fc4-2d8f-58b0-b83f-8de1c50f051d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1315fef0-234e-44f5-a7a3-bf3db78943c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1315fef0-234e-44f5-a7a3-bf3db78943c3.jpg?1",
             "name": "Planar Overlay",
             "text": "Each player chooses a land he or she controls of each basic land type. Return those lands to their owners' hands.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "60707b67-c552-5e51-a569-7e64a04761ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa232c-3f16-4c68-99dc-09a7aeef477b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa232c-3f16-4c68-99dc-09a7aeef477b.jpg?1",
             "name": "Planeswalker's Mischief",
             "text": "o3o\nU: Target opponent reveals a card at random from his or her hand. If it's an instant or sorcery card, remove it from the game. As long as it remains removed from the game, you may play it as though it were in your hand without paying its mana cost. If it has X in its mana cost, X is 0. At end of turn, if you haven't played it, return it to its owner's hand. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -970,7 +970,7 @@
         },
         {
             "id": "1d433d60-e483-5b00-ac00-5edb4a686621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ddf7bf-de9c-4657-8d5b-79869d36fa63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ddf7bf-de9c-4657-8d5b-79869d36fa63.jpg?1",
             "name": "Rushing River",
             "text": "Kicker\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs as you play this spell.)\nReturn target nonland permanent to its owner's hand. If you paid the kicker cost, return another target nonland permanent to its owner's hand.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "afbd07ea-0623-54e6-84fc-3236e80a027d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11015e-200b-488c-8bf5-662dcc03cd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11015e-200b-488c-8bf5-662dcc03cd2d.jpg?1",
             "name": "Sea Snidd",
             "text": "oc\nT: Target land's type becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "cc2388d2-3a96-5720-9b78-9996749d902d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071726d-48f0-46d6-802b-dd9589489580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071726d-48f0-46d6-802b-dd9589489580.jpg?1",
             "name": "Shifting Sky",
             "text": "As Shifting Sky comes into play, choose a color.\nAll nonland permanents are the chosen color.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "10e92b09-ebc4-5d20-a7bf-0477cfc5dbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe20cc1-621a-4813-9bbb-ace006e173ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe20cc1-621a-4813-9bbb-ace006e173ff.jpg?1",
             "name": "Sisay's Ingenuity",
             "text": "When Sisay's Ingenuity comes into play, draw a card.\nEnchanted creature has \"o2o\nU: Target creature becomes the color of your choice until end of turn.\"",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "080a47d1-e3c6-5bd8-888a-cf4762deb6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f79f4b2-71cd-4f78-a161-d75b162c745e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f79f4b2-71cd-4f78-a161-d75b162c745e.jpg?1",
             "name": "Sleeping Potion",
             "text": "When Sleeping Potion comes into play, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhen enchanted creature becomes the target of a spell or ability, sacrifice Sleeping Potion.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "beeb6bcf-223b-5d41-aa42-b0cfe20503bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46a39d-c6f4-4281-b31f-f0a0c9fba887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46a39d-c6f4-4281-b31f-f0a0c9fba887.jpg?1",
             "name": "Stormscape Battlemage",
             "text": "Kicker o\nW and/or o2o\nB\nWhen Stormscape Battlemage comes into play, if you paid the o\nW kicker cost, you gain 3 life.\nWhen Stormscape Battlemage comes into play, if you paid the o2o\nB kicker cost, destroy target nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -1173,7 +1173,7 @@
         },
         {
             "id": "4d783b25-5b95-53f9-b11f-459536142400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c831c42-77a0-4f4f-9628-ad630541cf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c831c42-77a0-4f4f-9628-ad630541cf66.jpg?1",
             "name": "Stormscape Familiar",
             "text": "Flying\nWhite spells and black spells you play cost {1} less to play.",
             "colours": [
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "75dc6a8b-7726-5d43-9516-f35da01ae75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12ac0c-cfe6-4f08-b6df-20be4ce83e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12ac0c-cfe6-4f08-b6df-20be4ce83e8c.jpg?1",
             "name": "Sunken Hope",
             "text": "At the beginning of each player's upkeep, that player returns a creature he or she controls to its owner's hand.",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "0d2d7d77-1c66-5684-80ed-4fc867c77930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425156e6-8eee-4bff-8f2f-86edd9a4f73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425156e6-8eee-4bff-8f2f-86edd9a4f73b.jpg?1",
             "name": "Waterspout Elemental",
             "text": "Kicker o\nU (You may pay an additional o\nU as you play this spell.)\nFlying\nWhen Waterspout Elemental comes into play, if you paid the kicker cost, return all other creatures to their owners' hands and you skip your next turn.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "87515dd9-3574-555b-8707-cec4b845ab4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8752a605-38f8-4d75-b122-063a788dff6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8752a605-38f8-4d75-b122-063a788dff6e.jpg?1",
             "name": "Bog Down",
             "text": "Kicker\u2014\nSacrifice two lands. (You may sacrifice two lands in addition to any other costs as you play this spell.)\nTarget player discards two cards from his or her hand. If you paid the kicker cost, that player discards three cards from his or her hand instead.",
             "colours": [
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "65dfc8a7-27bd-58fc-93cb-c95209d2aaf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518e2fd-7767-43d7-92e3-62a4a465154c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518e2fd-7767-43d7-92e3-62a4a465154c.jpg?1",
             "name": "Dark Suspicions",
             "text": "At the beginning of each opponent's upkeep, that player loses 1 life for each card in his or her hand more than you have in your hand.",
             "colours": [
@@ -1337,7 +1337,7 @@
         },
         {
             "id": "c5681401-b898-5287-808d-2d451e245c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a84715-c5dc-4a19-af6a-796c6ee912c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a84715-c5dc-4a19-af6a-796c6ee912c2.jpg?1",
             "name": "Death Bomb",
             "text": "As an additional cost to play Death Bomb, sacrifice a creature.\nDestroy target nonblack creature. It can't be regenerated. Its controller loses 2 life.",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "dbc1f65a-6a48-5f9f-a63d-9af50294a31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d1b5c5-cc47-465f-8549-4fd1ca4280df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d1b5c5-cc47-465f-8549-4fd1ca4280df.jpg?1",
             "name": "Diabolic Intent",
             "text": "As an additional cost to play Diabolic Intent, sacrifice a creature.\nSearch your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "56ef52f1-cc45-55ec-83d5-3fc41db0ed25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9624e5-79a2-41de-997b-12d871d4be66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9624e5-79a2-41de-997b-12d871d4be66.jpg?1",
             "name": "Exotic Disease",
             "text": "Target player loses X life and you gain X life, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "6e76db16-0bc2-527d-b0a9-98b94fa43c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7f50f4-37a0-476e-8655-edba228aafd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7f50f4-37a0-476e-8655-edba228aafd6.jpg?1",
             "name": "Lord of the Undead",
             "text": "All Zombies get +1/+1.\no1o\nB, oc\nT: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "5b1d5e02-6af1-5ccb-8163-c9ab9b32c0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2c3dc4-bb49-4ec3-a6c8-4256d1939326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2c3dc4-bb49-4ec3-a6c8-4256d1939326.jpg?1",
             "name": "Maggot Carrier",
             "text": "When Maggot Carrier comes into play, each player loses 1 life.",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "bc259785-df34-5342-acd5-bebe2d1d78d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8ae73-70d1-4082-8581-5f74c1aaa63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8ae73-70d1-4082-8581-5f74c1aaa63b.jpg?1",
             "name": "Morgue Toad",
             "text": "Sacrifice Morgue Toad: Add o\nUo\nR to your mana pool.",
             "colours": [
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "cdba7571-bb85-5a42-a76d-d70a93d96a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5389643-4cc0-4a17-bc2d-7f9b76d30f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5389643-4cc0-4a17-bc2d-7f9b76d30f9f.jpg?1",
             "name": "Nightscape Battlemage",
             "text": "Kicker o2o\nU and/or o2o\nR\nWhen Nightscape Battlemage comes into play, if you paid the o2o\nU kicker cost, return up to two target nonblack creatures to their owners' hands.\nWhen Nightscape Battlemage comes into play, if you paid the o2o\nR kicker cost, destroy target land.",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "27900460-ae79-5b11-bdff-9926cfbbb643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fa6853-09b0-4c9f-a138-9dd005780255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fa6853-09b0-4c9f-a138-9dd005780255.jpg?1",
             "name": "Nightscape Familiar",
             "text": "Blue spells and red spells you play cost o1 less to play.\no1o\nB: Regenerate Nightscape Familiar.",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "088278b7-b10e-5234-86fa-1931f223b671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9326-6e1c-4a05-abea-16d6b6cb2a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9326-6e1c-4a05-abea-16d6b6cb2a6d.jpg?1",
             "name": "Noxious Vapors",
             "text": "Each player reveals his or her hand and chooses one card of each color from it, then discards all other nonland cards from it.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "d841c9c2-1279-516e-96d2-00e542dd9795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e1a67-af94-48e8-bb37-4999d1fb4c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e1a67-af94-48e8-bb37-4999d1fb4c66.jpg?1",
             "name": "Phyrexian Bloodstock",
             "text": "When Phyrexian Bloodstock leaves play, destroy target white creature. It can't be regenerated.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "b2bde8b6-9509-5a37-8bd1-f306d24acbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb57e656-c94e-4cc2-ae8d-9300f51f941f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb57e656-c94e-4cc2-ae8d-9300f51f941f.jpg?1",
             "name": "Phyrexian Scuta",
             "text": "Kicker\u2014\nPay 3 life. (You may pay 3 life in addition to any other costs as you play this spell.)\nIf you paid the kicker cost, Phyrexian Scuta comes into play with two +1/+1 counters on it.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "3e86b5c5-6ce7-5032-8bfa-c083c3c71f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed08376-836f-4313-83d0-481895ead9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed08376-836f-4313-83d0-481895ead9da.jpg?1",
             "name": "Planeswalker's Scorn",
             "text": "o3o\nB: Target opponent reveals a card at random from his or her hand. Target creature gets -X/-X until end of turn, where X is the revealed card's converted mana cost. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "097a4ad2-5210-5ed8-8063-499925351573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a7fb3b-8e81-4763-b2a1-7c2108a00afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a7fb3b-8e81-4763-b2a1-7c2108a00afe.jpg?1",
             "name": "Shriek of Dread",
             "text": "Target creature can't be blocked this turn except by artifact creatures and/or black creatures.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "0c54c78a-dfc3-50b7-b4e9-3458e43c1d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe487b8-c1ae-483d-bcd5-62c62b66a22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe487b8-c1ae-483d-bcd5-62c62b66a22e.jpg?1",
             "name": "Sinister Strength",
             "text": "Enchanted creature gets +3/+1 and is black.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "139f4f43-a39b-5d3a-b76b-b4c9b5f8e094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccda747-2680-4793-8a13-35e49b4de12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccda747-2680-4793-8a13-35e49b4de12f.jpg?1",
             "name": "Slay",
             "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "fa25ffd2-6dbe-5803-afb4-491765d39805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8281cc6-2132-4f76-841e-d1ade9cafb84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8281cc6-2132-4f76-841e-d1ade9cafb84.jpg?1",
             "name": "Volcano Imp",
             "text": "Flying\no1o\nR: Volcano Imp gains first strike until end of turn.",
             "colours": [
@@ -1875,7 +1875,7 @@
         },
         {
             "id": "95561d09-fa4a-552b-a52e-3a95ccba6923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bce620f-799a-4ad8-9edb-6fb3d9ea1cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bce620f-799a-4ad8-9edb-6fb3d9ea1cc6.jpg?1",
             "name": "Warped Devotion",
             "text": "Whenever a permanent is returned to a player's hand, that player discards a card from his or her hand.",
             "colours": [
@@ -1907,7 +1907,7 @@
         },
         {
             "id": "97c7174f-9fa0-5cdd-9c21-824b4f1c7bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcad32aa-2ce1-402d-a9d8-ad5c81fe4c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcad32aa-2ce1-402d-a9d8-ad5c81fe4c5b.jpg?1",
             "name": "Caldera Kavu",
             "text": "o1o\nB: Caldera Kavu gets +1/+1 until end of turn.\no\nG: Caldera Kavu becomes the color of your choice until end of turn.",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "816a6f1e-c6f5-582e-858d-8217df08063b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc93b3d-bde4-422f-9edc-e337719be7b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc93b3d-bde4-422f-9edc-e337719be7b4.jpg?1",
             "name": "Deadapult",
             "text": "o\nR, Sacrifice a Zombie: Deadapult deals 2 damage to target creature or player.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "c506bf42-ac04-5b39-a8b8-3b1bfaca00f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5056bca-bd90-4b50-8630-105558f8ef92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5056bca-bd90-4b50-8630-105558f8ef92.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu comes into play, it deals 4 damage to target creature.",
             "colours": [
@@ -2009,7 +2009,7 @@
         },
         {
             "id": "6cdf8e34-ae2a-53b3-8692-b3f19cfba2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe6e7e5-ffea-4c6c-8a42-28e695029f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe6e7e5-ffea-4c6c-8a42-28e695029f24.jpg?1",
             "name": "Goblin Game",
             "text": "Each player hides at least one object, then all players reveal them simultaneously. Each player loses life equal to the number of objects he or she revealed. The player who revealed the fewest objects then loses half his or her life, rounded up. If two or more players are tied for fewest, each loses half his or her life, rounded up.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "eefd3b77-e95f-5f6f-8a63-fe6d38bc3292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ee318-8126-4ebf-884d-8369ae8726ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ee318-8126-4ebf-884d-8369ae8726ac.jpg?1",
             "name": "Implode",
             "text": "Destroy target land.\nDraw a card.",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "a0136e48-0c39-54e6-b647-bb84eccc68e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8009a37-f966-4a71-9a2a-469127758dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8009a37-f966-4a71-9a2a-469127758dc6.jpg?1",
             "name": "Insolence",
             "text": "Whenever enchanted creature becomes tapped, Insolence deals 2 damage to that creature's controller.",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "f50aa24c-7659-5f01-b8c4-cafe3d1ef17c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f04ac02-3eff-4a66-8320-ee7b4357522f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f04ac02-3eff-4a66-8320-ee7b4357522f.jpg?1",
             "name": "Kavu Recluse",
             "text": "oc\nT: Target land becomes a forest until end of turn.",
             "colours": [
@@ -2141,7 +2141,7 @@
         },
         {
             "id": "0c7395e8-38b2-5c6d-a5ef-bf0ba485811e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bb73df-f488-468c-a9ad-72f52c8da3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bb73df-f488-468c-a9ad-72f52c8da3dc.jpg?1",
             "name": "Keldon Mantle",
             "text": "o\nB: Regenerate enchanted creature.\no\nR: Enchanted creature gets +1/+0 until end of turn.\no\nG: Enchanted creature gains trample until end of turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "f5ce237d-54ce-5fc6-a800-4a216fc1d66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9752bc3-0bdf-4657-8750-73c8cbc8e83f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9752bc3-0bdf-4657-8750-73c8cbc8e83f.jpg?1",
             "name": "Magma Burst",
             "text": "Kicker\u2014\nSacrifice two lands. (You may sacrifice two lands in addition to any other costs as you play this spell.)\nMagma Burst deals 3 damage to target creature or player. If you paid the kicker cost, Magma Burst deals 3 damage to another target creature or player.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "0010f07c-a2e4-5ca5-b91a-fbc5f0380d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd0086-eb27-48b3-91cb-a113aa1de102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd0086-eb27-48b3-91cb-a113aa1de102.jpg?1",
             "name": "Mire Kavu",
             "text": "Mire Kavu gets +1/+1 as long as you control a swamp.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "e57027a5-68e8-5596-b8fc-57f04ba91dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52513235-0e6c-40ea-8ead-a050e6da676e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52513235-0e6c-40ea-8ead-a050e6da676e.jpg?1",
             "name": "Mogg Jailer",
             "text": "Mogg Jailer can't attack if defending player controls an untapped creature with power 2 or less.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "05b0a4a4-e65a-5edc-a22d-a4ad3b631912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536ec54-cebd-4d44-8e52-42344a3e6daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536ec54-cebd-4d44-8e52-42344a3e6daa.jpg?1",
             "name": "Mogg Sentry",
             "text": "Whenever an opponent plays a spell, Mogg Sentry gets +2/+2 until end of turn.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "b9edaf0c-2727-5ad1-b820-4f3861c2388e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa09e3a-bc7e-4292-aa5d-ce97c1b1f79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa09e3a-bc7e-4292-aa5d-ce97c1b1f79f.jpg?1",
             "name": "Planeswalker's Fury",
             "text": "o3o\nR: Target opponent reveals a card at random from his or her hand. Planeswalker's Fury deals damage equal to that card's converted mana cost to that player. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "a75db63b-3c0a-55b9-9bd2-93cc03113ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32323277-db9a-48a7-b9a4-8e6914386e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32323277-db9a-48a7-b9a4-8e6914386e26.jpg?1",
             "name": "Singe",
             "text": "Singe deals 1 damage to target creature. That creature becomes black until end of turn.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "eeb43bcf-421b-528b-bf41-936d8de53ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81825aef-bef7-46b7-bf52-29e32c1836b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81825aef-bef7-46b7-bf52-29e32c1836b0.jpg?1",
             "name": "Slingshot Goblin",
             "text": "o\nR, oc\nT: Slingshot Goblin deals 2 damage to target blue creature.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "eef8286d-a535-53fb-bfde-8dc49d6b8815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b77cf-9c1e-4c8f-b452-295cc1570d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b77cf-9c1e-4c8f-b452-295cc1570d0e.jpg?1",
             "name": "Strafe",
             "text": "Strafe deals 3 damage to target nonred creature.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "f6f5fae0-0fc2-5289-be7e-9093215892db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1778f37-af01-4f8c-ab9d-a4c60abf7e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1778f37-af01-4f8c-ab9d-a4c60abf7e78.jpg?1",
             "name": "Tahngarth, Talruum Hero",
             "text": "Attacking doesn't cause Tahngarth, Talruum Hero to tap.\no1o\nR, oc\nT: Tahngarth deals damage equal to its power to target creature. That creature deals damage equal to its power to Tahngarth.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "2e8d1ebb-db0b-5976-a936-f83fba5cd95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdab0f9-7208-4555-b509-e61773ebc1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdab0f9-7208-4555-b509-e61773ebc1f9.jpg?1",
             "name": "Tahngarth, Talruum Hero",
             "text": "Attacking doesn't cause Tahngarth, Talruum Hero to tap.\no1o\nR, oc\nT: Tahngarth deals damage equal to its power to target creature. That creature deals damage equal to its power to Tahngarth.",
             "colours": [
@@ -2519,7 +2519,7 @@
         },
         {
             "id": "19b02e4d-3584-563e-8e28-1abc74f86a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707243e-7f11-44bc-b8b8-af635ab1dc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707243e-7f11-44bc-b8b8-af635ab1dc87.jpg?1",
             "name": "Thunderscape Battlemage",
             "text": "Kicker o1o\nB and/or o\nG\nWhen Thunderscape Battlemage comes into play, if you paid the o1o\nB kicker cost, target player discards two cards from his or her hand.\nWhen Thunderscape Battlemage comes into play, if you paid the o\nG kicker cost, destroy target enchantment.",
             "colours": [
@@ -2556,7 +2556,7 @@
         },
         {
             "id": "06e9a08c-f135-5f53-bdc3-e427f855db24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c9c0aa-9412-4320-aaee-e05369b8bc7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c9c0aa-9412-4320-aaee-e05369b8bc7b.jpg?1",
             "name": "Thunderscape Familiar",
             "text": "First strike\nBlack spells and green spells you play cost o1 less to play.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "b61822ce-c549-553c-9207-f2955c302606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545ed916-59fc-4c60-9260-8c2dc88e67a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545ed916-59fc-4c60-9260-8c2dc88e67a1.jpg?1",
             "name": "Alpha Kavu",
             "text": "o1o\nG: Target Kavu gets -1/+1 until end of turn.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "9bb04c0f-43cb-5cd3-97be-b8525aeb4016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d94fb2-958c-487e-9f64-52d2771c6ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d94fb2-958c-487e-9f64-52d2771c6ea4.jpg?1",
             "name": "Amphibious Kavu",
             "text": "Whenever Amphibious Kavu blocks or becomes blocked by one or more blue and/or black creatures, Amphibious Kavu gets +3/+3 until end of turn.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "2f5e6386-32d8-5ee7-b6a5-00eb2daffd28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e54c84d-ccc9-4c52-b02c-e0392e8fe447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e54c84d-ccc9-4c52-b02c-e0392e8fe447.jpg?1",
             "name": "Falling Timber",
             "text": "Kicker\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs as you play this spell.)\nPrevent all combat damage target creature would deal this turn. If you paid the kicker cost, prevent all combat damage another target creature would deal this turn.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "3e02adbb-5c6c-54c7-8540-bf81809ce9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa52bc97-109a-4de5-b287-bce21dad6a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa52bc97-109a-4de5-b287-bce21dad6a9c.jpg?1",
             "name": "Gaea's Herald",
             "text": "Creature spells can't be countered by spells or abilities.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "d53c5091-657e-50d2-a78d-aa78867e9c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e5adce-7735-4fa5-aa14-8dce012e9fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e5adce-7735-4fa5-aa14-8dce012e9fcc.jpg?1",
             "name": "Gaea's Might",
             "text": "Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "de543f98-d170-55a7-a73a-01a38a90fdaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2869b-43cf-4d5e-8a54-9ae200f5bff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2869b-43cf-4d5e-8a54-9ae200f5bff9.jpg?1",
             "name": "Magnigoth Treefolk",
             "text": "For each basic land type among lands you control, Magnigoth Treefolk has landwalk of that type. (It's unblockable as long as defending player controls a land of that type.)",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "ba9ac79f-53a3-5361-90e9-d71efdf21492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9a1c94-2b7f-4df7-8517-a122616d9ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9a1c94-2b7f-4df7-8517-a122616d9ae4.jpg?1",
             "name": "Mirrorwood Treefolk",
             "text": "o2o\nRo\nW: The next time damage would be dealt to Mirrorwood Treefolk this turn, that damage is dealt to target creature or player instead.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "a4d1629c-8f0f-5bfd-a143-df60b51fb653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76352ea-e3d2-4221-8ebe-e953301c35ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76352ea-e3d2-4221-8ebe-e953301c35ab.jpg?1",
             "name": "Multani's Harmony",
             "text": "Enchanted creature has \"oc\nT: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "7c78533a-ce63-5dbd-a495-71d47ec384ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2.jpg?1",
             "name": "Nemata, Grove Guardian",
             "text": "o2o\nG: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: All Saprolings get +1/+1 until end of turn.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "81eac25f-c260-59e6-abc0-2ad001c00df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3387540-93bf-451e-8e7a-fc78caab42b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3387540-93bf-451e-8e7a-fc78caab42b0.jpg?1",
             "name": "Planeswalker's Favor",
             "text": "o3o\nG: Target opponent reveals a card at random from his or her hand. Target creature gets +X/+X until end of turn, where X is the revealed card's converted mana cost.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "9da93f26-1af3-5eed-97fa-2b3e373c2ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4a3c83-faaa-4dd9-9349-abcaf09cc7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4a3c83-faaa-4dd9-9349-abcaf09cc7a8.jpg?1",
             "name": "Primal Growth",
             "text": "Kicker\u2014\nSacrifice a creature. (You may sacrifice a creature in addition to any other costs as you play this spell.)\nSearch your library for a basic land card, put that card into play, then shuffle your library. If you paid the kicker cost, instead search your library for two basic land cards, put them into play, then shuffle your library.",
             "colours": [
@@ -2960,7 +2960,7 @@
         },
         {
             "id": "e470925c-ac42-5eba-8833-e21b7aa3410d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31c69ec-feb5-430a-a3e9-3a6f3fb8ee1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31c69ec-feb5-430a-a3e9-3a6f3fb8ee1c.jpg?1",
             "name": "Pygmy Kavu",
             "text": "When Pygmy Kavu comes into play, draw a card for each black creature your opponents control.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "58a9d6b3-ed82-571b-a02f-cb1c66b81983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6841ae6-b15f-488e-9cae-2cc5ec668278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6841ae6-b15f-488e-9cae-2cc5ec668278.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you play a white, blue, black, or red spell, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "3cb0b2a5-58b4-5ea2-a97c-6a6a22f6fecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a031d-f899-497b-adf7-4af142078085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a031d-f899-497b-adf7-4af142078085.jpg?1",
             "name": "Quirion Explorer",
             "text": "oc\nT: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [
@@ -3064,7 +3064,7 @@
         },
         {
             "id": "70984f12-b185-5b7a-919c-197769fedb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306e3429-b3b4-4186-935b-18cfc308d22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306e3429-b3b4-4186-935b-18cfc308d22c.jpg?1",
             "name": "Root Greevil",
             "text": "o2o\nG, oc\nT, Sacrifice Root Greevil: Destroy all enchantments of the color of your choice.",
             "colours": [
@@ -3098,7 +3098,7 @@
         },
         {
             "id": "ed85869b-361a-5bbd-a3db-ebb44b6e0860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c10b16-97b1-4a36-b2b4-f0c28ead3eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c10b16-97b1-4a36-b2b4-f0c28ead3eb4.jpg?1",
             "name": "Skyshroud Blessing",
             "text": "Lands can't be the targets of spells or abilities this turn.\nDraw a card.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "eb5959c2-ed7d-517b-8758-1ad48fa7530f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a1cdca-d48c-4936-ad6a-4610aeb991ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a1cdca-d48c-4936-ad6a-4610aeb991ce.jpg?1",
             "name": "Stone Kavu",
             "text": "o\nR: Stone Kavu gets +1/+0 until end of turn.\no\nW: Stone Kavu gets +0/+1 until end of turn.",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "3d331144-0a97-5f20-a513-0f3a29eb5fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f24f89-3996-4740-a6c9-d26b8869554b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f24f89-3996-4740-a6c9-d26b8869554b.jpg?1",
             "name": "Thornscape Battlemage",
             "text": "Kicker o\nR and/or o\nW\nWhen Thornscape Battlemage comes into play, if you paid the o\nR kicker cost, Thornscape Battlemage deals 2 damage to target creature or player.\nWhen Thornscape Battlemage comes into play, if you paid the o\nW kicker cost, destroy target artifact.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "d08321fd-143d-5a39-86f6-bbbe497ae75a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c6e426-6165-4f8e-8766-de768ae13452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c6e426-6165-4f8e-8766-de768ae13452.jpg?1",
             "name": "Thornscape Familiar",
             "text": "Red spells and white spells you play cost o1 less to play.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "6d7b8ab2-376e-52e8-9101-19288b43c0e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca99de-57e7-47c4-b40a-6e41e3b18069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca99de-57e7-47c4-b40a-6e41e3b18069.jpg?1",
             "name": "Ancient Spider",
             "text": "First strike\nAncient Spider may block as though it had flying.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "adcba755-a00e-51f5-a707-54efa08f7bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfb0804-50d6-4bca-8733-72e01030a543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfb0804-50d6-4bca-8733-72e01030a543.jpg?1",
             "name": "Cavern Harpy",
             "text": "Flying\nWhen Cavern Harpy comes into play, return a blue or black creature you control to its owner's hand.\nPay 1 life: Return Cavern Harpy to its owner's hand.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "4622450a-601f-5426-8354-e55853b22382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943b3886-5556-474f-8dc1-18219e25abc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943b3886-5556-474f-8dc1-18219e25abc3.jpg?1",
             "name": "Cloud Cover",
             "text": "Whenever another permanent you control becomes the target of a spell or ability an opponent controls, you may return that permanent to its owner's hand.",
             "colours": [
@@ -3344,7 +3344,7 @@
         },
         {
             "id": "6b8c22a9-7af4-54d8-af73-81e8b15f7977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59a9e75-9988-4040-a718-b1655fc20d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59a9e75-9988-4040-a718-b1655fc20d11.jpg?1",
             "name": "Crosis's Charm",
             "text": "Choose one Return target permanent to its owner's hand; or destroy target nonblack creature, and it can't be regenerated; or destroy target artifact.",
             "colours": [
@@ -3380,7 +3380,7 @@
         },
         {
             "id": "d26a98f8-8b31-5668-9500-934e9ba6c413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c9d6a-86eb-45be-9405-473eb263b94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c9d6a-86eb-45be-9405-473eb263b94c.jpg?1",
             "name": "Darigaaz's Charm",
             "text": "Choose one Return target creature card from your graveyard to your hand; or Darigaaz's Charm deals 3 damage to target creature or player; or target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "003dfe5d-0406-59c5-9d8b-f2493ccfe74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ec6c4b-2de0-4759-a25d-007706cb18cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ec6c4b-2de0-4759-a25d-007706cb18cc.jpg?1",
             "name": "Daring Leap",
             "text": "Target creature gets +1/+1 and gains flying and first strike until end of turn.",
             "colours": [
@@ -3450,7 +3450,7 @@
         },
         {
             "id": "17302f09-7ffc-553f-83bb-8bf3a7aade72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db86e34-c3ec-4a29-8779-81350a985644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db86e34-c3ec-4a29-8779-81350a985644.jpg?1",
             "name": "Destructive Flow",
             "text": "At the beginning of each player's upkeep, that player sacrifices a nonbasic land.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "f1af98bb-3409-56a7-a268-c3fdad8c58b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85206cc1-5484-40c6-b11d-b8d6fad4fc5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85206cc1-5484-40c6-b11d-b8d6fad4fc5c.jpg?1",
             "name": "Doomsday Specter",
             "text": "Flying\nWhen Doomsday Specter comes into play, return a blue or black creature you control to its owner's hand.\nWhenever Doomsday Specter deals combat damage to a player, look at that player's hand and choose a card from it. The player discards that card.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "da2e8a09-acb4-5797-9cbb-056c6d098f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a35d227-4489-4a0b-8f81-eb8e5949e1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a35d227-4489-4a0b-8f81-eb8e5949e1fc.jpg?1",
             "name": "Dralnu's Crusade",
             "text": "All Goblins get +1/+1, are black, and are Zombies in addition to their creature types.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "a47bca32-5f88-57fd-9d25-1496167a26e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a1894c-af4e-4530-960f-2225916be8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a1894c-af4e-4530-960f-2225916be8cb.jpg?1",
             "name": "Dromar's Charm",
             "text": "Choose one You gain 5 life; or counter target spell; or target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "654325fc-a312-5e4c-9233-6bb8bc317b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb79f39-5ef3-4ad6-9a43-04beb27d8480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb79f39-5ef3-4ad6-9a43-04beb27d8480.jpg?1",
             "name": "Eladamri's Call",
             "text": "Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "64f532aa-9a4a-51c0-97d3-2af8619d9c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b950d9-8fef-4deb-b51b-26edb90abc56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b950d9-8fef-4deb-b51b-26edb90abc56.jpg?1",
             "name": "Ertai, the Corrupted",
             "text": "o\nU, oc\nT, Sacrifice a creature or enchantment: Counter target spell.",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "d22484cb-0c49-5e45-80fe-4b626d67624d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbfeb32-1654-4bf6-9a38-891f1a03e02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbfeb32-1654-4bf6-9a38-891f1a03e02b.jpg?1",
             "name": "Ertai, the Corrupted",
             "text": "o\nU, oc\nT, Sacrifice a creature or enchantment: Counter target spell.",
             "colours": [
@@ -3713,7 +3713,7 @@
         },
         {
             "id": "8d68411a-1daa-51c2-bd1a-2319a21cbe47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70220d8-f81b-44a4-b92e-d66de8c1b4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70220d8-f81b-44a4-b92e-d66de8c1b4ce.jpg?1",
             "name": "Fleetfoot Panther",
             "text": "You may play Fleetfoot Panther any time you could play an instant.\nWhen Fleetfoot Panther comes into play, return a green or white creature you control to its owner's hand.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "66e11c6c-c433-5137-a492-c559ba1e01aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fda263-b6a7-43e3-998a-72a9d84c4572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fda263-b6a7-43e3-998a-72a9d84c4572.jpg?1",
             "name": "Gerrard's Command",
             "text": "Untap target creature. It gets +3/+3 until end of turn.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "05ca4249-6011-5085-a81f-3d268033b9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd79fbf-626d-4549-917b-435f16b973d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd79fbf-626d-4549-917b-435f16b973d9.jpg?1",
             "name": "Horned Kavu",
             "text": "When Horned Kavu comes into play, return a red or green creature you control to its owner's hand.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "a0d09e84-8d24-59bf-bf13-aaad1b5e3175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6907fa19-29ed-4319-8835-68f424c92831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6907fa19-29ed-4319-8835-68f424c92831.jpg?1",
             "name": "Hull Breach",
             "text": "Choose one Destroy target artifact; or destroy target enchantment; or destroy target artifact and target enchantment.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "a955c77a-86f1-57ba-b15a-567bafd5b1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e071665e-bb72-42e0-a42d-0d0ff02abd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e071665e-bb72-42e0-a42d-0d0ff02abd2b.jpg?1",
             "name": "Keldon Twilight",
             "text": "At the end of each player's turn, if no creatures attacked that turn, that player sacrifices a creature he or she controlled since the beginning of the turn.",
             "colours": [
@@ -3887,7 +3887,7 @@
         },
         {
             "id": "15899809-bc96-56a8-ba0a-fadf9f4b7eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd87185b-1242-4fb3-abee-44bc267ee5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd87185b-1242-4fb3-abee-44bc267ee5fb.jpg?1",
             "name": "Lava Zombie",
             "text": "When Lava Zombie comes into play, return a black or red creature you control to its owner's hand.\no2: Lava Zombie gets +1/+0 until end of turn.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "488c4a55-1124-5ffc-855f-988016a5718e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1547c2-ae9f-4871-a675-4026bf20e7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1547c2-ae9f-4871-a675-4026bf20e7e1.jpg?1",
             "name": "Malicious Advice",
             "text": "Tap X target artifacts, creatures, and/or lands. You lose X life.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "5243207f-65be-5420-bd31-46c76ca42d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813279d1-d7bd-4d49-bd9d-fc9a6595dd39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813279d1-d7bd-4d49-bd9d-fc9a6595dd39.jpg?1",
             "name": "Marsh Crocodile",
             "text": "When Marsh Crocodile comes into play, return a blue or black creature you control to its owner's hand.\nWhen Marsh Crocodile comes into play, each player discards a card from his or her hand.",
             "colours": [
@@ -3993,7 +3993,7 @@
         },
         {
             "id": "d85ee5f6-7334-57fc-b5af-2df8a3b12836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176f84c6-aa5e-449c-bd2b-cc91a898f0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176f84c6-aa5e-449c-bd2b-cc91a898f0c7.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage comes into play, name a nonland card.\nThe named card can't be played.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "d491394a-d569-52b4-bd35-bce831812913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb4857-7c66-42e4-913c-97a0306366d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb4857-7c66-42e4-913c-97a0306366d5.jpg?1",
             "name": "Natural Emergence",
             "text": "When Natural Emergence comes into play, return a red or green enchantment you control to its owner's hand.\nLands you control are 2/2 creatures with first strike. They're still lands.",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "c1cc879d-887e-5d77-b63a-7e8990111c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8440ca8-73ca-462b-a735-f6fb3d0de603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8440ca8-73ca-462b-a735-f6fb3d0de603.jpg?1",
             "name": "Phyrexian Tyranny",
             "text": "Whenever a player draws a card, that player loses 2 life unless he or she pays o2.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "295c896e-4c00-5f78-8c37-53e599bf1602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea4cfef-6736-42a5-9f3e-10de8d0cd8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea4cfef-6736-42a5-9f3e-10de8d0cd8d3.jpg?1",
             "name": "Questing Phelddagrif",
             "text": "o\nG: Questing Phelddagrif gets +1/+1 until end of turn. Target opponent puts a 1/1 green Hippo creature token into play.\no\nW: Questing Phelddagrif gains protection from black and from red until end of turn. Target opponent gains 2 life.\no\nU: Questing Phelddagrif gains flying until end of turn. Target opponent may draw a card.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "8375fab2-d00a-5259-8056-d50bdcdaf448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153077a8-38c0-44aa-9b84-cdd9ade50ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153077a8-38c0-44aa-9b84-cdd9ade50ad6.jpg?1",
             "name": "Radiant Kavu",
             "text": "o\nRo\nGo\nW: Prevent all combat damage blue creatures and black creatures would deal this turn.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "776ea205-4cbb-5330-88b0-c1b89b1966b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2090b80-2ce2-4c9a-87fe-d221f3c677b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2090b80-2ce2-4c9a-87fe-d221f3c677b4.jpg?1",
             "name": "Razing Snidd",
             "text": "When Razing Snidd comes into play, return a black or red creature you control to its owner's hand.\nWhen Razing Snidd comes into play, each player sacrifices a land.",
             "colours": [
@@ -4212,7 +4212,7 @@
         },
         {
             "id": "2347a4b0-0210-56f7-ae9b-578f1284db1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd30f389-bac8-4b82-a8a7-6948d43a9f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd30f389-bac8-4b82-a8a7-6948d43a9f60.jpg?1",
             "name": "Rith's Charm",
             "text": "Choose one Destroy target nonbasic land; or put three 1/1 green Saproling creature tokens into play; or prevent all damage a source of your choice would deal this turn.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "4e283726-d57b-50c4-9656-865b0c54dc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0a87f-e946-4ef1-b30d-fe32c19a0f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0a87f-e946-4ef1-b30d-fe32c19a0f52.jpg?1",
             "name": "Sawtooth Loon",
             "text": "Flying\nWhen Sawtooth Loon comes into play, return a white or blue creature you control to its owner's hand.\nWhen Sawtooth Loon comes into play, draw two cards, then put two cards from your hand on the bottom of your library.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "e74cb19d-fe18-5dd0-891e-4a1415e5d5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc72997-78b0-47aa-a029-bf55f77c3e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc72997-78b0-47aa-a029-bf55f77c3e73.jpg?1",
             "name": "Shivan Wurm",
             "text": "Trample\nWhen Shivan Wurm comes into play, return a red or green creature you control to its owner's hand.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "ec4ff6f5-c8ea-5764-b7c1-8d1baaf28e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ee86-96b2-47aa-a1ba-2988737f11ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ee86-96b2-47aa-a1ba-2988737f11ee.jpg?1",
             "name": "Silver Drake",
             "text": "Flying\nWhen Silver Drake comes into play, return a white or blue creature you control to its owner's hand.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "b06211d3-ac38-5326-a692-eaa56f63b5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf442b3-fa39-4f6a-90a0-22dcd9df649c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf442b3-fa39-4f6a-90a0-22dcd9df649c.jpg?1",
             "name": "Sparkcaster",
             "text": "When Sparkcaster comes into play, return a red or green creature you control to its owner's hand.\nWhen Sparkcaster comes into play, it deals 1 damage to target player.",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "8dc49c9c-c85c-506c-9934-5db57a9cdae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e8697f-fdf3-4a1a-a84d-dd29b17336c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e8697f-fdf3-4a1a-a84d-dd29b17336c2.jpg?1",
             "name": "Steel Leaf Paladin",
             "text": "First strike\nWhen Steel Leaf Paladin comes into play, return a green or white creature you control to its owner's hand.",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "907ada8a-00c0-59eb-93ca-6dfcfb09fcb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ca502-672d-4cc0-b6e0-b9de517058d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ca502-672d-4cc0-b6e0-b9de517058d0.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -4463,7 +4463,7 @@
         },
         {
             "id": "68cd0fc0-44e2-53e4-9c0d-dbe21b9893eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72acb67d-01cb-4fde-8b0b-199e8d1e396a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72acb67d-01cb-4fde-8b0b-199e8d1e396a.jpg?1",
             "name": "Treva's Charm",
             "text": "Choose one Destroy target enchantment; or remove target attacking creature from the game; or draw a card, then discard a card from your hand.",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "c6d992e9-0b9f-5ac4-a5b4-036c4ae2070a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d429233e-1cf9-4f87-b191-894a73e7a876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d429233e-1cf9-4f87-b191-894a73e7a876.jpg?1",
             "name": "Urza's Guilt",
             "text": "Each player draws two cards, then discards three cards from his or her hand, then loses 4 life.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "7ff52aaf-39e7-56c3-b591-694348f29d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e3edb-62f1-4680-884f-70323547f8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e3edb-62f1-4680-884f-70323547f8ad.jpg?1",
             "name": "Draco",
             "text": "Draco costs o2 less to play for each basic land type among lands you control.\nFlying\nAt the beginning of your upkeep, sacrifice Draco unless you pay o10. This cost is reduced by o2 for each basic land type among lands you control.",
             "colours": [],
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "54c44056-8115-5af4-9178-add3c1d3b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f95767-afda-4d74-bbd4-1b702eeae54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f95767-afda-4d74-bbd4-1b702eeae54b.jpg?1",
             "name": "Mana Cylix",
             "text": "o1, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "a05c82be-c929-5720-a509-7b9f51156db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f5498b-bb12-48ec-811b-b52e45ffddaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f5498b-bb12-48ec-811b-b52e45ffddaf.jpg?1",
             "name": "Skyship Weatherlight",
             "text": "When Skyship Weatherlight comes into play, search your library for any number of artifact and/or creature cards and remove them from the game. Then shuffle your library.\no4, oc\nT: Choose a card at random that was removed from the game with Skyship Weatherlight. Put that card into your hand.",
             "colours": [],
@@ -4624,7 +4624,7 @@
         },
         {
             "id": "dcc4ee11-6a61-55f0-966a-d19732010ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99791ef7-ff51-4982-b0ef-55560f9577ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99791ef7-ff51-4982-b0ef-55560f9577ff.jpg?1",
             "name": "Skyship Weatherlight",
             "text": "When Skyship Weatherlight comes into play, search your library for any number of artifact and/or creature cards and remove them from the game. Then shuffle your library.\no4, oc\nT: Choose a card at random that was removed from the game with Skyship Weatherlight. Put that card into your hand.",
             "colours": [],
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "208bc9d2-3c62-53ee-aade-bd057cf4abb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0beb4-c3dd-4bb1-b49b-a48b2d4ad38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0beb4-c3dd-4bb1-b49b-a48b2d4ad38d.jpg?1",
             "name": "Star Compass",
             "text": "Star Compass comes into play tapped.\noc\nT: Add to your mana pool one mana of any color a basic land you control could produce.",
             "colours": [],
@@ -4683,7 +4683,7 @@
         },
         {
             "id": "5bdedf8d-6f37-51b7-bdc2-258e6573222a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324bc757-9942-4862-b691-5af42e07f682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324bc757-9942-4862-b691-5af42e07f682.jpg?1",
             "name": "Stratadon",
             "text": "Stratadon costs o1 less to play for each basic land type among lands you control.\nTrample",
             "colours": [],
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "8425ddef-69df-509f-b870-558db4dacc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caad74f-c0d0-4eca-94be-b89a2c9a3980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caad74f-c0d0-4eca-94be-b89a2c9a3980.jpg?1",
             "name": "Crosis's Catacombs",
             "text": "Crosis's Catacombs is a Lair in addition to its land type.\nWhen Crosis's Catacombs comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nU, o\nB, or o\nR to your mana pool.",
             "colours": [],
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "bc710e9e-0b80-5979-bb9d-0f370276df98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f6f0c-af30-4937-b4a7-48f493e007a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f6f0c-af30-4937-b4a7-48f493e007a0.jpg?1",
             "name": "Darigaaz's Caldera",
             "text": "Darigaaz's Caldera is a Lair in addition to its land type.\nWhen Darigaaz's Caldera comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nB, o\nR, or o\nG to your mana pool.",
             "colours": [],
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "6bacfb09-ac19-55bf-a214-bba1b060f4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f10cee-6a63-438e-a9df-6b902dd025b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f10cee-6a63-438e-a9df-6b902dd025b8.jpg?1",
             "name": "Dromar's Cavern",
             "text": "Dromar's Cavern is a Lair in addition to its land type.\nWhen Dromar's Cavern comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nW, o\nU, or o\nB to your mana pool.",
             "colours": [],
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "bf573d7c-63cd-5bd2-96f0-0db504f0243e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676703fe-bd80-413c-8704-1da5d3248b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676703fe-bd80-413c-8704-1da5d3248b7e.jpg?1",
             "name": "Forsaken City",
             "text": "Forsaken City doesn't untap during your untap step.\nAt the beginning of your upkeep, you may remove a card in your hand from the game. If you do, untap Forsaken City.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "734e5e9a-2672-542b-a20c-0c69bcb5a326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043a2299-1cfc-4732-a10a-58c773b9992c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043a2299-1cfc-4732-a10a-58c773b9992c.jpg?1",
             "name": "Meteor Crater",
             "text": "oc\nT: Choose a color of a permanent you control. Add one mana of that color to your mana pool.",
             "colours": [],
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "de5793cc-64f3-56ae-baef-738f8cf6006b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740fa25d-9c1f-44eb-9eb4-0dd514cb315a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740fa25d-9c1f-44eb-9eb4-0dd514cb315a.jpg?1",
             "name": "Rith's Grove",
             "text": "Rith's Grove is a Lair in addition to its land type.\nWhen Rith's Grove comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nR, o\nG, or o\nW to your mana pool.",
             "colours": [],
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "06385292-2d0c-5279-92d2-0dc07ecf48d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353a8ea8-3f1f-4f77-95bc-b09b96996285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353a8ea8-3f1f-4f77-95bc-b09b96996285.jpg?1",
             "name": "Terminal Moraine",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT, Sacrifice Terminal Moraine: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [],
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "90f44f37-ef3b-57ef-9a9c-29a80d35bd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae2458-b54f-426a-ad40-13529a73c423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae2458-b54f-426a-ad40-13529a73c423.jpg?1",
             "name": "Treva's Ruins",
             "text": "Treva's Ruins is a Lair in addition to its land type.\nWhen Treva's Ruins comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nG, o\nW, or o\nU to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/POR.json
+++ b/Assets/Resources/Sets/POR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "90710375-0dc2-5682-92f5-f6ce171ff472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc6ec1-3b34-45e0-8573-39eba1d10efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc6ec1-3b34-45e0-8573-39eba1d10efa.jpg?1",
             "name": "Alabaster Dragon",
             "text": "Flying\nIf Alabaster Dragon is put into your discard pile from play, shuffle Alabaster Dragon back into your deck.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "0da19281-7435-570b-a98e-3eb88ddaf7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dda640-2a00-437e-855f-173c487e7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dda640-2a00-437e-855f-173c487e7395.jpg?1",
             "name": "Angelic Blessing",
             "text": "Any one creature gets +3/+3 and gains flying until the end of the turn.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "20cdb535-5b57-522e-9cf6-c30036b525cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387b9236-1241-44b7-9436-1fbc9970b692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387b9236-1241-44b7-9436-1fbc9970b692.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking doesn't cause Archangel to tap.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "d99d4140-3d3f-55aa-85b7-ca86b0c91156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543f8c6a-bcf1-4400-82e5-83d36cb60464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543f8c6a-bcf1-4400-82e5-83d36cb60464.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "d6ee2968-f939-5158-88fc-6a28c8264fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2073ca8b-2bca-4539-94d7-989da157e4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2073ca8b-2bca-4539-94d7-989da157e4b8.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands. (This includes your lands.)",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "7fecb362-e6b5-5692-a202-538e39ebeebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81b61af-cdb7-468f-9ff0-db82aa084023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81b61af-cdb7-468f-9ff0-db82aa084023.jpg?1",
             "name": "Armored Pegasus",
             "text": "Flying",
             "colours": [
@@ -201,7 +201,7 @@
         },
         {
             "id": "f40ecd98-872f-51b7-8909-b37b0e1e9954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f021a79-a182-4914-9ff4-d6fcba7c1d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f021a79-a182-4914-9ff4-d6fcba7c1d22.jpg?1",
             "name": "Armored Pegasus",
             "text": "",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "4e7e8175-828a-5c1f-b184-7a1a33623db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecc19-8106-4e5a-bb25-aaea9684ba0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecc19-8106-4e5a-bb25-aaea9684ba0e.jpg?1",
             "name": "Blessed Reversal",
             "text": "Play Blessed Reversal only after you're attacked, before you declare interceptors.\nFor each attacking creature, you gain 3 life.",
             "colours": [
@@ -267,7 +267,7 @@
         },
         {
             "id": "3618f64c-02c3-52de-ad26-bd596b23acea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea283d2-8f00-4836-81b4-c041b0469dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea283d2-8f00-4836-81b4-c041b0469dcb.jpg?1",
             "name": "Blinding Light",
             "text": "Tap all creatures except for white creatures. (This includes your creatures.)",
             "colours": [
@@ -298,7 +298,7 @@
         },
         {
             "id": "7a83750b-22a6-57c5-908b-0ee0ad0c82d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985af775-2036-459d-83c6-31ac84a0ffb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985af775-2036-459d-83c6-31ac84a0ffb1.jpg?1",
             "name": "Border Guard",
             "text": "",
             "colours": [
@@ -332,7 +332,7 @@
         },
         {
             "id": "c62d3aaf-5cad-52ea-a994-4cfc3bbafdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcea5e09-6385-41df-970b-ac26c9b46127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcea5e09-6385-41df-970b-ac26c9b46127.jpg?1",
             "name": "Breath of Life",
             "text": "Take any one summon creature from your discard pile and put that card into play. Treat it as though you just played it from your hand.",
             "colours": [
@@ -363,7 +363,7 @@
         },
         {
             "id": "60bf84c2-b584-5d6f-bcd0-d89f3d060800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db1bbf-a6cf-460c-bec8-dbd682157af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db1bbf-a6cf-460c-bec8-dbd682157af4.jpg?1",
             "name": "Charging Paladin",
             "text": "If Charging Paladin attacks, it gets +0/+3 until the end of the turn.",
             "colours": [
@@ -397,7 +397,7 @@
         },
         {
             "id": "cfab17cf-c6ff-593a-a06d-19242476cd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc37fd2-5c34-4522-8113-e6dd2181550b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc37fd2-5c34-4522-8113-e6dd2181550b.jpg?1",
             "name": "Defiant Stand",
             "text": "Play Defiant Stand only after you're attacked, before you declare interceptors.\nAny one creature gets +1/+3 until the end of the turn. If that creature is tapped, untap it.",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "a2643431-ab68-59ad-bcf6-b8c93f0a7d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4bf8-51b6-44a8-92ac-e5aec4e4f2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4bf8-51b6-44a8-92ac-e5aec4e4f2bc.jpg?1",
             "name": "Devoted Hero",
             "text": "",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "0f9a7ae4-9953-5e8f-b240-9cfd3178d29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4234262-56c6-4bd1-b425-12db931829d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4234262-56c6-4bd1-b425-12db931829d5.jpg?1",
             "name": "False Peace",
             "text": "Choose any one player. That player can't attack on his or her next turn.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "3cbe4dc6-5efe-50e4-a63c-a0e99bc37694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd972d-1cc1-4fb1-9b4e-a88ea115cf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd972d-1cc1-4fb1-9b4e-a88ea115cf7f.jpg?1",
             "name": "Fleet-Footed Monk",
             "text": "Fleet-Footed Monk can't be intercepted by any creature with offense 2 or greater.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "2e51d8b3-7e12-505c-9f98-4c18d3f71e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ddb33-66c4-4753-b1eb-8937ab812a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ddb33-66c4-4753-b1eb-8937ab812a81.jpg?1",
             "name": "Foot Soldiers",
             "text": "",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "76c22e9a-2764-5158-acef-4ab126bdf882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342b5afe-544f-4fa1-a833-4e0590b41eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342b5afe-544f-4fa1-a833-4e0590b41eed.jpg?1",
             "name": "Gift of Estates",
             "text": "If your opponent has more lands in play than you do, search your deck for up to three plains and put them into your hand. Shuffle your deck afterwards.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "6c128d3a-08f7-58c6-a72b-d478d0ac73d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3657001a-7f79-4d3f-9d35-462ecf684fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3657001a-7f79-4d3f-9d35-462ecf684fa8.jpg?1",
             "name": "Harsh Justice",
             "text": "Play Harsh Justice only after you're attacked, before you declare interceptors.\nThis turn, each attacking creature that damages you also deals equal damage to the attacking player.",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "79ba84d7-d35d-5aba-9d62-7d8320fe1a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594de429-58ed-4a0c-9631-464cde7a48c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594de429-58ed-4a0c-9631-464cde7a48c3.jpg?1",
             "name": "Keen-Eyed Archers",
             "text": "Keen-Eyed Archers can intercept as though it had flying.",
             "colours": [
@@ -657,7 +657,7 @@
         },
         {
             "id": "03a1d676-30e3-5dc4-a57e-ca7027d41797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c31b4b4-18fc-4a6e-8d74-fd5340964320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c31b4b4-18fc-4a6e-8d74-fd5340964320.jpg?1",
             "name": "Knight Errant",
             "text": "",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "2d9c3a7d-35a1-5959-95ee-1ad0757fe4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f3e1c9-bfad-49a1-b171-6fa344ef2eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f3e1c9-bfad-49a1-b171-6fa344ef2eef.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy any one creature. That creature's owner gains 4 life.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "7ed5d802-6ee7-53ae-8943-3eb360821d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1fb8c-12fa-4e9c-979f-55e89356acaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1fb8c-12fa-4e9c-979f-55e89356acaf.jpg?1",
             "name": "Regal Unicorn",
             "text": "",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "a13d491c-aa21-511f-84e5-9d34cdfb6787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56300cb-6b44-47fe-9508-c33ad5670b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56300cb-6b44-47fe-9508-c33ad5670b4b.jpg?1",
             "name": "Renewing Dawn",
             "text": "For each mountain your opponent has in play, you gain 2 life.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "69930d1a-8ac2-55d2-973e-16d835a83999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b19990-c4a2-433d-a9ce-005216e9e4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b19990-c4a2-433d-a9ce-005216e9e4ac.jpg?1",
             "name": "Sacred Knight",
             "text": "Sacred Knight can't be intercepted by black or red creatures.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "cd4fbfa3-df4f-5fa2-b860-f6f9f1332a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484d1b31-5363-49ef-9b13-2005568636c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484d1b31-5363-49ef-9b13-2005568636c1.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "445a10b9-2d68-500b-8326-ed3b7b411ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db0060-3667-4c8c-ae9b-d62dceac64e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db0060-3667-4c8c-ae9b-d62dceac64e3.jpg?1",
             "name": "Seasoned Marshal",
             "text": "If Seasoned Marshal attacks, you may choose to tap any one creature. (Tapped creatures can't intercept.)",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "b939f6e2-2cb1-5ed3-9c1d-b1749e4a322d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbea02f-9124-4e1a-8693-d988a0a3adae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbea02f-9124-4e1a-8693-d988a0a3adae.jpg?1",
             "name": "Spiritual Guardian",
             "text": "When Spiritual Guardian comes into play from your hand, you gain 4 life.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "d18eb139-b680-5bce-95df-a88644b16b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b708b-368f-48d2-8eca-40f2ae6d5178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b708b-368f-48d2-8eca-40f2ae6d5178.jpg?1",
             "name": "Spotted Griffin",
             "text": "Flying",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "0c83dc67-4c88-519c-aeb4-5be4537298c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6992524-6921-473b-8301-cb63fe502600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6992524-6921-473b-8301-cb63fe502600.jpg?1",
             "name": "Starlight",
             "text": "For each black creature your opponent has in play, you gain 3 life.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "6e577811-9d4d-586c-ac9b-0056e3a36f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36691cd0-c709-4452-a61a-d6e2049fdfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36691cd0-c709-4452-a61a-d6e2049fdfcf.jpg?1",
             "name": "Starlit Angel",
             "text": "Flying",
             "colours": [
@@ -1017,7 +1017,7 @@
         },
         {
             "id": "dc831bbf-3ce8-5a53-86a8-4d0e1dd5e73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d76e2d-6720-4f0e-a5b1-71a59d47a3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d76e2d-6720-4f0e-a5b1-71a59d47a3fb.jpg?1",
             "name": "Starlit Angel",
             "text": "",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "851c9595-ff76-5d4f-98cb-236a13a51e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4693b3-d5d7-4401-aee3-119d3eb276a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4693b3-d5d7-4401-aee3-119d3eb276a2.jpg?1",
             "name": "Steadfastness",
             "text": "All your creatures get +0/+3 until the end of the turn.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "50583b4e-af62-56af-aeb5-074ad7dea0fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fbfbc0-c55b-4e56-a3d2-5d09571c36c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fbfbc0-c55b-4e56-a3d2-5d09571c36c8.jpg?1",
             "name": "Stern Marshal",
             "text": "On your turn, before you attack, you may tap Stern Marshal to give any one creature +2/+2 until the end of the turn.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "1d21a238-18e7-59ba-9ea4-ff8e307f1e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6ee294-7dbb-4872-81d1-c69c7337cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6ee294-7dbb-4872-81d1-c69c7337cf9f.jpg?1",
             "name": "Temporary Truce",
             "text": "Each player may draw up to two cards. For each card less than two any player draws, that player gains 2 life. (You choose whether to draw first.)",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "622e1dc2-ade7-541b-8a1c-f40f800a5120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f61bdf-cbcd-4a63-8866-eb13ec9b351c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f61bdf-cbcd-4a63-8866-eb13ec9b351c.jpg?1",
             "name": "Valorous Charge",
             "text": "All white creatures get +2/+0 until the end of the turn. (This includes other players' white creatures.)",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "33b63bae-4541-5960-a0f0-e0ba08cee326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72322032-c287-4a9e-9d61-a452f6c45bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72322032-c287-4a9e-9d61-a452f6c45bfb.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play from your hand, you gain 2 life.",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "628309e3-d015-5c46-a3cb-130319405a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c249b-157c-4f1d-8171-29d1e75b1c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c249b-157c-4f1d-8171-29d1e75b1c9f.jpg?1",
             "name": "Vengeance",
             "text": "Destroy any one tapped creature.",
             "colours": [
@@ -1245,7 +1245,7 @@
         },
         {
             "id": "773f9e18-d017-54da-878d-d3de9284fa0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8d55a3-0d7f-4fba-9879-9a8264110e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8d55a3-0d7f-4fba-9879-9a8264110e78.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying\nWall of Swords can't attack.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "8ac10fee-4aed-5683-b5a1-d3a9b70a40ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8668e4af-ae89-4fab-8015-8dc643c6cd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8668e4af-ae89-4fab-8015-8dc643c6cd36.jpg?1",
             "name": "Warrior's Charge",
             "text": "All your creatures get +1/+1 until the end of the turn.",
             "colours": [
@@ -1311,7 +1311,7 @@
         },
         {
             "id": "d49220e5-4eee-5825-85b3-e6f68fdbb03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9279d545-28b7-41c5-bb88-6dc4bbbcd71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9279d545-28b7-41c5-bb88-6dc4bbbcd71f.jpg?1",
             "name": "Warrior's Charge",
             "text": "All your creatures get +1/+1 until the end of the turn. (For example, a 1/2 creature would become 2/3.)",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "de2fe9e8-57f7-5800-8a61-ec080736f776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75d8204-6f9d-4a7a-bb8b-d51ac65a30fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75d8204-6f9d-4a7a-bb8b-d51ac65a30fa.jpg?1",
             "name": "Wrath of God",
             "text": "Put all creatures into their owners' discard piles. (This includes your creatures.)",
             "colours": [
@@ -1375,7 +1375,7 @@
         },
         {
             "id": "cfad670c-545a-517a-9fa9-e9d8e09a8614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b613c-61bf-4c2d-9c90-2949e442aea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b613c-61bf-4c2d-9c90-2949e442aea5.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your deck. Put two of them into your hand and the rest into your discard pile.",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "2b8d5ea9-ddb0-5848-95eb-65d1a26f69ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875e753-117a-40b6-9cd2-dd5dfd11a38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875e753-117a-40b6-9cd2-dd5dfd11a38d.jpg?1",
             "name": "Balance of Power",
             "text": "If you have fewer cards in your hand than your opponent does, draw until you have the same number. (When you play Balance of Power, it doesn't count as in your hand.)",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "6bc7d046-97bc-5ecb-8aeb-e8064c602d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb46c8-30ae-4457-a726-6fe1ddd183d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb46c8-30ae-4457-a726-6fe1ddd183d5.jpg?1",
             "name": "Baleful Stare",
             "text": "Look at your opponent's hand. For each mountain and red card there, you draw a card. (You draw from your deck.)",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "9873ed7d-857f-5b20-a762-41645777a043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d5eec0-0afe-4af9-ba1b-70282df8cd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d5eec0-0afe-4af9-ba1b-70282df8cd0a.jpg?1",
             "name": "Capricious Sorcerer",
             "text": "On your turn, before you attack, you may tap Capricious Sorcerer to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "2f16fcb2-3055-500d-8b27-98a61ebe57d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746790c-a426-4135-8c9d-afb82a0c26b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746790c-a426-4135-8c9d-afb82a0c26b8.jpg?1",
             "name": "Cloak of Feathers",
             "text": "Any one creature gains flying until the end of the turn. You draw a card.",
             "colours": [
@@ -1533,7 +1533,7 @@
         },
         {
             "id": "402d9afa-f7bf-5536-9c10-e76c54a8598b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb7fb59-65c0-4af6-9d3a-79cd6602d004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb7fb59-65c0-4af6-9d3a-79cd6602d004.jpg?1",
             "name": "Cloud Dragon",
             "text": "Flying\nCloud Dragon can intercept only creatures with flying.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "04dd5497-5d48-5e62-b02c-1a4d5219bce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7386c6-d17a-4c7d-884d-2471b87d8b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7386c6-d17a-4c7d-884d-2471b87d8b8e.jpg?1",
             "name": "Cloud Pirates",
             "text": "Flying\nCloud Pirates can intercept only creatures with flying.",
             "colours": [
@@ -1603,7 +1603,7 @@
         },
         {
             "id": "399a36ae-aba7-5c74-9d57-74e6d4c66ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88425a48-7b03-4ecf-88cd-d72ef98ca814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88425a48-7b03-4ecf-88cd-d72ef98ca814.jpg?1",
             "name": "Cloud Pirates",
             "text": "",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "33745b3f-a5d3-5c27-a627-ca216ef1f49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7547aa-fcf7-4b6e-955d-cc5ebc40cd7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7547aa-fcf7-4b6e-955d-cc5ebc40cd7d.jpg?1",
             "name": "Cloud Spirit",
             "text": "Flying\nCloud Spirit can intercept only creatures with flying.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "dc4a1259-b2bb-5373-b77b-5597f1bd5d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b97fc-fa42-40a6-918e-e06383bfcae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b97fc-fa42-40a6-918e-e06383bfcae3.jpg?1",
             "name": "Command of Unsummoning",
             "text": "Play Command of Unsummoning only after you're attacked, before you declare interceptors.\nReturn any one or two attacking creatures to their owner's hand.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "75f7edd2-7cbd-59f8-80d2-e2bc18eb5e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bbb10f-c118-4905-8329-3963af415178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bbb10f-c118-4905-8329-3963af415178.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "63be29ad-9428-5830-93d8-c403d6bee4b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bea0d4-946e-4cb8-b6f1-50231d52bfbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bea0d4-946e-4cb8-b6f1-50231d52bfbe.jpg?1",
             "name": "Cruel Fate",
             "text": "Look at the top five cards of your opponent's deck. Put one of them into your opponent's discard pile and the rest on top of his or her deck in any order.",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "12ca2ddc-1edf-544a-a8f5-d25af6eb83ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d7f8d8-30fb-47c7-8927-646c41f0b9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d7f8d8-30fb-47c7-8927-646c41f0b9bc.jpg?1",
             "name": "Deep-Sea Serpent",
             "text": "Deep-Sea Serpent can attack only if the defending player has an island in play.",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "17d5b6c9-b1b1-566b-8e64-a246b24e7649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e7b52-2663-4140-9758-f24b8b947876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e7b52-2663-4140-9758-f24b8b947876.jpg?1",
             "name": "Djinn of the Lamp",
             "text": "Flying",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "ac42975d-0a00-53e3-9bee-aece5ea29b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c93d4e9-7fd6-4814-b86b-89b92d1dad3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c93d4e9-7fd6-4814-b86b-89b92d1dad3b.jpg?1",
             "name": "D\u00e9j\u00e0 Vu",
             "text": "Return any one sorcery card from your discard pile to your hand.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "0c1d82e4-0bf4-54f3-9965-8c26a30d38c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6a5c33-cf74-4cec-a4f4-1aac9e7b8f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6a5c33-cf74-4cec-a4f4-1aac9e7b8f79.jpg?1",
             "name": "Exhaustion",
             "text": "At the beginning of your opponent's next turn, he or she skips untapping his or her creatures and lands.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "e0566418-0763-5152-8be1-cff2ef472bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26bf66-8fa8-4f69-9556-c9fcc56a7f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26bf66-8fa8-4f69-9556-c9fcc56a7f33.jpg?1",
             "name": "Flux",
             "text": "Each player chooses and discards from his or her hand any number of cards and then draws that many cards. You then draw a card. (You choose first.)",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "b7c426ae-5015-5644-9273-40be2f0c202a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4528edca-cc36-4f63-9615-24ca315d672c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4528edca-cc36-4f63-9615-24ca315d672c.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "9a5144aa-6457-5bb7-b412-8db200f5ad64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d25497-36b4-48b9-ba01-f24f6222d6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d25497-36b4-48b9-ba01-f24f6222d6be.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "452a6156-e6a4-5d15-be25-377a4b023c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5e413-85ea-4528-97b9-e1db5117ec2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5e413-85ea-4528-97b9-e1db5117ec2a.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -2029,7 +2029,7 @@
         },
         {
             "id": "a4042a4c-72a2-507f-9b00-93f6905637b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be341805-b4de-456e-8b46-4ee5fdbca7e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be341805-b4de-456e-8b46-4ee5fdbca7e0.jpg?1",
             "name": "Ingenious Thief",
             "text": "Flying\nWhen Ingenious Thief comes into play from your hand, look at your opponent's hand.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "4adc83da-a535-5bd4-9ebb-eef411276c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e835b618-83c1-46e2-b8bd-aec56f58ccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e835b618-83c1-46e2-b8bd-aec56f58ccfc.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War comes into play from your hand, return any one creature to its owner's hand. (If you're the only one with creatures, return one of them to your hand.)",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "236fd88c-a04f-5d8a-96d8-868b66777e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126fec7a-4f36-49e5-a2d7-96deb7af856f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126fec7a-4f36-49e5-a2d7-96deb7af856f.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "04376b80-edff-5093-b36a-f9caa79a12a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d60f29-6da0-4ce6-9c92-96f313007271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d60f29-6da0-4ce6-9c92-96f313007271.jpg?1",
             "name": "Mystic Denial",
             "text": "Play Mystic Denial only in response to another player playing a summon creature or a sorcery. That card has no effect, and that player puts it into his or her discard pile.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "bde51bef-cd14-5180-994e-e0e2e94e698f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be1956e-c43e-4a6c-950a-5be6e6ca013f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be1956e-c43e-4a6c-950a-5be6e6ca013f.jpg?1",
             "name": "Omen",
             "text": "Look at the top three cards of your deck and return them in any order. You may choose to shuffle your deck. Then draw a card.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "297062f9-5481-57c9-b0bf-ad162323e713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587bcb-0ece-4b36-85dc-76899e403b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587bcb-0ece-4b36-85dc-76899e403b08.jpg?1",
             "name": "Owl Familiar",
             "text": "Flying\nWhen Owl Familiar comes into play from your hand, draw a card, then choose and discard a card from your hand.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "fce3cbbf-78e9-5029-b586-dca894b2287d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc3917-fded-4773-8f8d-62bd861c1131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc3917-fded-4773-8f8d-62bd861c1131.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your deck for a sorcery and reveal that card to all players. Shuffle your deck and put the revealed card on top of it.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "63d6290b-5c46-5460-985e-2197622673c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbcb0df-d1cc-4718-ba1e-b590852cce20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbcb0df-d1cc-4718-ba1e-b590852cce20.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior can't be intercepted.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "04333668-23fb-59d8-b682-45e02fb63114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269bb4fc-9d8f-42cc-8f71-6a658e41533c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269bb4fc-9d8f-42cc-8f71-6a658e41533c.jpg?1",
             "name": "Prosperity",
             "text": "Each player draws X cards.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "6581eebc-bbf2-5d44-b325-d97e371bb59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd755a7-914a-4547-8d38-34d8cc3b9a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd755a7-914a-4547-8d38-34d8cc3b9a7f.jpg?1",
             "name": "Prosperity",
             "text": "",
             "colours": [
@@ -2355,7 +2355,7 @@
         },
         {
             "id": "e5735040-dfc6-5f31-b313-99b521cc0a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b49dd4c-ead6-4d94-9acb-0518d1f6426e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b49dd4c-ead6-4d94-9acb-0518d1f6426e.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "e2898af1-3e83-5775-a5e4-3618cc961075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fadc0d-d6de-4634-9c15-d9c9732cdc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fadc0d-d6de-4634-9c15-d9c9732cdc87.jpg?1",
             "name": "Snapping Drake",
             "text": "",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "021e7810-9aa6-5d44-956a-2de1dd9b19bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfd43dc-e5fd-43bc-babb-fe7ecb6ccd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfd43dc-e5fd-43bc-babb-fe7ecb6ccd00.jpg?1",
             "name": "Sorcerous Sight",
             "text": "Look at your opponent's hand. You draw a card. (Draw the card from your deck.)",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "f48b65ad-b88c-5204-b83a-f3e5007ac0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe87b59-b456-4532-a695-0dea3110d878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe87b59-b456-4532-a695-0dea3110d878.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "6763a230-d521-512c-9671-9fc7f74fda59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb2fa5-8f88-4d08-badb-3e52358d21d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb2fa5-8f88-4d08-badb-3e52358d21d6.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "e5eb9aa4-3039-503e-aa33-011b1a247492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55811106-9f30-4e34-924e-2c9401b49574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55811106-9f30-4e34-924e-2c9401b49574.jpg?1",
             "name": "Symbol of Unsummoning",
             "text": "Return any one creature to its owner's hand. You draw a card.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "24297d27-2fea-56ec-bccd-76af529e969a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d87322-aba4-4187-9655-1da1f18615f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d87322-aba4-4187-9655-1da1f18615f8.jpg?1",
             "name": "Taunt",
             "text": "Choose any one player. On that player's next turn, all his or her creatures that can attack you must do so.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "915ca991-1d1b-557b-bb42-fe0d5afb9b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ce2daa-8d47-4417-a5bb-3354a7c24bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ce2daa-8d47-4417-a5bb-3354a7c24bab.jpg?1",
             "name": "Taunt",
             "text": "",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "07f6937f-4905-5857-aa3b-ddb57b3d91e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29019e28-4ef8-4732-9972-0a47305fe303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29019e28-4ef8-4732-9972-0a47305fe303.jpg?1",
             "name": "Theft of Dreams",
             "text": "For each tapped creature your opponent has in play, you draw a card.",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "27b43196-c569-5ba6-b6a2-6ac349b88394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9682-7f3a-4857-9ecf-01f3530659fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9682-7f3a-4857-9ecf-01f3530659fc.jpg?1",
             "name": "Thing from the Deep",
             "text": "If Thing from the Deep attacks, destroy one of your islands or destroy Thing from the Deep.",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "da77969d-1307-567c-acaf-a491ea7a62cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027c31d-c662-4ce1-a0d1-a32e62f6a724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027c31d-c662-4ce1-a0d1-a32e62f6a724.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap any one, two, or three creatures without flying. (Tapped creatures can't intercept.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "a49696ed-2136-5ea2-9b59-e49cbb19aff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd26ca-dc7d-453d-8653-7f967e8f6dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd26ca-dc7d-453d-8653-7f967e8f6dc7.jpg?1",
             "name": "Time Ebb",
             "text": "Return any one creature to the top of its owner's deck.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "3c65134c-f60d-57a8-81ef-f78d1fa1088c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196474ce-e28e-48f0-b407-dc5535adf1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196474ce-e28e-48f0-b407-dc5535adf1b6.jpg?1",
             "name": "Touch of Brilliance",
             "text": "Draw two cards.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "15acfd8c-02ac-525b-b20a-0d59d18ab084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5486d2dc-9a5d-4f58-a5ec-d94de54b852f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5486d2dc-9a5d-4f58-a5ec-d94de54b852f.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2813,7 +2813,7 @@
         },
         {
             "id": "20a5c82b-b8ba-58d0-a16f-a93385597593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952a48-9e60-4fce-8423-7f0bafd29bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952a48-9e60-4fce-8423-7f0bafd29bb1.jpg?1",
             "name": "Withering Gaze",
             "text": "Look at your opponent's hand. For each forest and green card there, you draw a card. (You draw from your deck.)",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "17ae61d5-5195-5775-ac7d-686cb3897b7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7342875-d49b-4fa7-a2fb-8dfc5e3d6e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7342875-d49b-4fa7-a2fb-8dfc5e3d6e4f.jpg?1",
             "name": "Arrogant Vampire",
             "text": "Flying",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "9c6f7fe2-544c-5d92-b5c7-777a5c944561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80e8fe0-eccb-4268-a6ce-1365c68e6b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80e8fe0-eccb-4268-a6ce-1365c68e6b13.jpg?1",
             "name": "Assassin's Blade",
             "text": "Play Assassin's Blade only after you're attacked, before you declare interceptors.\nDestroy any one attacking creature that isn't black.",
             "colours": [
@@ -2910,7 +2910,7 @@
         },
         {
             "id": "f22e8485-7401-5486-83a5-a980edf79cf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235f25bf-e079-4957-bbb1-0f90716275ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235f25bf-e079-4957-bbb1-0f90716275ad.jpg?1",
             "name": "Assassin's Blade",
             "text": "",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "81b5897f-f36f-595f-943a-a510063a5fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8681b3fd-33e5-4a45-8650-a4a142405096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8681b3fd-33e5-4a45-8650-a4a142405096.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "f89ca1fd-8fa7-5599-979b-75bf793f309d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bbb7a-b59a-4a01-b1cb-66eef881ffcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bbb7a-b59a-4a01-b1cb-66eef881ffcd.jpg?1",
             "name": "Bog Raiders",
             "text": "Swampwalk (If defending player has any swamps in play, Bog Raiders can't be intercepted.)",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "e900c794-43d9-587c-916a-643ef4f70d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4487d7d0-d5a5-4b0c-bf30-e0ec511e9aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4487d7d0-d5a5-4b0c-bf30-e0ec511e9aa4.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (If defending player has any swamps in play, Bog Wraith can't be intercepted.)",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "180a08f1-c565-54b1-9ff0-da71be102396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1721ee11-c7ee-4878-b2ab-4f090e0c5def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1721ee11-c7ee-4878-b2ab-4f090e0c5def.jpg?1",
             "name": "Charging Bandits",
             "text": "If Charging Bandits attacks, it gets +2/+0 until the end of the turn.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "36df5a31-b3bf-56d1-ade3-9627b7589b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cbae27-4a1a-4e16-8876-9a2925c45302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cbae27-4a1a-4e16-8876-9a2925c45302.jpg?1",
             "name": "Craven Knight",
             "text": "Craven Knight can't intercept.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "0af2ef33-847e-5fda-8b06-8cbea8cdea82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96837a9e-dd68-4ce8-b760-0e1c22837164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96837a9e-dd68-4ce8-b760-0e1c22837164.jpg?1",
             "name": "Cruel Bargain",
             "text": "Draw four cards. You lose half your life, rounded up. (For example, if you have 11 life, you lose 6 life.)",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "982e153c-d084-588f-8769-080e41bc6e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05bfb5-dd36-44c5-a60d-43f7f8c68a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05bfb5-dd36-44c5-a60d-43f7f8c68a6b.jpg?1",
             "name": "Cruel Tutor",
             "text": "Search your deck for any card. Shuffle your deck and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "771f8c40-388e-5714-8ebe-9c9467207c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ca934-6989-415b-8816-7c66d22b4707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ca934-6989-415b-8816-7c66d22b4707.jpg?1",
             "name": "Dread Charge",
             "text": "This turn, your black creatures can be intercepted only by other black creatures.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "475a0af5-e7b9-5d53-b53b-629699370adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb25d674-11f3-42d2-ba2f-e9a5d55a7852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb25d674-11f3-42d2-ba2f-e9a5d55a7852.jpg?1",
             "name": "Dread Reaper",
             "text": "Flying\nWhen Dread Reaper comes into play from your hand, you lose 5 life. (The person who plays Dread Reaper loses the life.)",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "1f6599fd-f44e-50ba-87e1-9e1d1f629692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a142f369-8fdd-4dc8-b5d9-3493455cc588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a142f369-8fdd-4dc8-b5d9-3493455cc588.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and player. (This includes your creatures and you.)",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "710705e6-7e03-5036-b439-235f166b48ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f10cf69-d3dc-43a4-9595-0f7d245c5efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f10cf69-d3dc-43a4-9595-0f7d245c5efa.jpg?1",
             "name": "Ebon Dragon",
             "text": "Flying\nWhen Ebon Dragon comes into play from your hand, you may force your opponent to choose and discard a card from his or her hand.",
             "colours": [
@@ -3300,7 +3300,7 @@
         },
         {
             "id": "0a9fc296-a750-546d-996b-eaa86d41d87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3d18b9-ad59-435b-934b-703e10287e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3d18b9-ad59-435b-934b-703e10287e32.jpg?1",
             "name": "Endless Cockroaches",
             "text": "If Endless Cockroaches is put into your discard pile from play, return Endless Cockroaches to your hand.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "6daea72e-ed16-541a-913c-c724c050ea20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f4c00-6bf8-440b-9761-b17a0e36c27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f4c00-6bf8-440b-9761-b17a0e36c27e.jpg?1",
             "name": "Feral Shadow",
             "text": "Flying",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "0b9699f6-adc7-5212-a9a5-0f56a4847936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200365f5-05a1-461e-904e-daf99f4b92bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200365f5-05a1-461e-904e-daf99f4b92bb.jpg?1",
             "name": "Feral Shadow",
             "text": "",
             "colours": [
@@ -3403,7 +3403,7 @@
         },
         {
             "id": "0491d03f-e4e4-5bd3-b5b5-55394caa8e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdfcb03-2f77-4f54-af62-3012cd3efd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdfcb03-2f77-4f54-af62-3012cd3efd4f.jpg?1",
             "name": "Final Strike",
             "text": "Choose one of your creatures. Final Strike deals to your opponent damage equal to that creature's offense. Then, put the creature in your discard pile.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "058bbaab-64ee-5153-95e4-67486c645852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979d70e-d514-420f-886c-f60e2bb1861f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979d70e-d514-420f-886c-f60e2bb1861f.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play from your hand, you may choose to return a summon creature from your discard pile to your hand.",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "a97e1cae-adf2-539e-95c5-3ac5957ff208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f136b8-52be-49b9-919b-2b9785254350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f136b8-52be-49b9-919b-2b9785254350.jpg?1",
             "name": "Hand of Death",
             "text": "Destroy any one creature that isn't black. (A creature is black if it has o\nB in its cost.)",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "ea3ed272-c08f-5537-b152-4d4e7cbec7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64afd70a-cde2-4980-9ec9-275e6198b40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64afd70a-cde2-4980-9ec9-275e6198b40f.jpg?1",
             "name": "Hand of Death",
             "text": "Destroy any one creature that isn't black.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "f51a448b-fef0-50c1-9814-8d0b5cd92260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a7c61-8696-4bab-9c96-05028db3a9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a7c61-8696-4bab-9c96-05028db3a9f9.jpg?1",
             "name": "Howling Fury",
             "text": "Any one creature gets +4/+0 until the end of the turn.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "7c48b22e-a7f8-5c96-8f4a-289ae1da2cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a3149-54fb-4fd2-bc66-3ee9bcc3519d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a3149-54fb-4fd2-bc66-3ee9bcc3519d.jpg?1",
             "name": "King's Assassin",
             "text": "On your turn, before you attack, you may tap King's Assassin to destroy any one tapped creature.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "f8e2bd41-4eaa-531a-98d9-09cdfc7150e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f97a2-b04e-418b-89c7-1c019288f27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f97a2-b04e-418b-89c7-1c019288f27a.jpg?1",
             "name": "Mercenary Knight",
             "text": "When Mercenary Knight comes into play from your hand, choose and discard a summon creature from your hand or destroy Mercenary Knight.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "705ce6ac-ae24-540a-a684-4a7ca3fe3549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17e23a6-6313-416d-b826-5df5833371dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17e23a6-6313-416d-b826-5df5833371dc.jpg?1",
             "name": "Mind Knives",
             "text": "Your opponent discards a card at random from his or her hand.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "924737f2-81db-5730-b580-a27271b53dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91d355d-8409-4f0b-87ce-7590a8b9ebc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91d355d-8409-4f0b-87ce-7590a8b9ebc0.jpg?1",
             "name": "Mind Rot",
             "text": "Your opponent chooses and discards two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "da583dd0-cdb6-5a6d-8868-1c4a02da0070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4041226-7ce2-46d1-8844-20fa50b6568a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4041226-7ce2-46d1-8844-20fa50b6568a.jpg?1",
             "name": "Muck Rats",
             "text": "",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "f6ee2168-6587-5e37-9eff-fbca593a05ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5950f52a-493e-432e-9175-0272c0edb232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5950f52a-493e-432e-9175-0272c0edb232.jpg?1",
             "name": "Nature's Ruin",
             "text": "Destroy all green creatures. (This includes your green creatures.)",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "0bc4846a-53ce-5088-b0cc-5aabc4a17e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec75ba-bae2-4ccc-b18b-ad4639cfb548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec75ba-bae2-4ccc-b18b-ad4639cfb548.jpg?1",
             "name": "Noxious Toad",
             "text": "If Noxious Toad is put into your discard pile from play, your opponent chooses and discards a card from his or her hand.",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "71bce205-f0a5-5949-8dca-e911bc3266ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c552a1-6245-4caf-8249-765ce7ea80d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c552a1-6245-4caf-8249-765ce7ea80d2.jpg?1",
             "name": "Python",
             "text": "",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "1ca45e63-1613-5b16-b3e9-8aed1c14f70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803ba4ef-24ed-4f45-aed8-f9442322e31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803ba4ef-24ed-4f45-aed8-f9442322e31e.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy any one land.",
             "colours": [
@@ -3856,7 +3856,7 @@
         },
         {
             "id": "7e553249-7790-5013-b99d-b150824371d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0584553-a25e-4030-ab39-53550cba3f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0584553-a25e-4030-ab39-53550cba3f0b.jpg?1",
             "name": "Raise Dead",
             "text": "Return any one summon creature from your discard pile to your hand.",
             "colours": [
@@ -3889,7 +3889,7 @@
         },
         {
             "id": "2b1d34a4-040b-51ea-8b35-d19e56791350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c06d6-d20d-4aa6-85f8-ed6b75007330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c06d6-d20d-4aa6-85f8-ed6b75007330.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -3922,7 +3922,7 @@
         },
         {
             "id": "fc9d7052-3055-519f-8cee-dd3ed2fe9340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018f6ff-5eaa-4fe1-ba20-544df799f5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018f6ff-5eaa-4fe1-ba20-544df799f5b2.jpg?1",
             "name": "Serpent Assassin",
             "text": "When Serpent Assassin comes into play from your hand, you may choose to destroy any one creature that isn't black.",
             "colours": [
@@ -3956,7 +3956,7 @@
         },
         {
             "id": "e89e626b-34a4-5560-93e8-25f3af514a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c364fd06-64c5-45f6-8ed5-64f44a1e8bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c364fd06-64c5-45f6-8ed5-64f44a1e8bda.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play from your hand, you lose 3 life. (The person who plays Serpent Warrior loses the life.)",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "0a07c5ad-ee69-54aa-91a2-5d9bc77a9567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcbbd6f-2915-4b4c-85d3-1d9b55d36c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcbbd6f-2915-4b4c-85d3-1d9b55d36c11.jpg?1",
             "name": "Skeletal Crocodile",
             "text": "",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "f2aca4ce-dfa6-57e8-aa78-f8bef39d4c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bd4896-4191-4479-be57-070753f8725c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bd4896-4191-4479-be57-070753f8725c.jpg?1",
             "name": "Skeletal Snake",
             "text": "",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "cd6f476c-f435-516c-9521-55645fbe33c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990902d2-9594-4963-807c-48a90324d487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990902d2-9594-4963-807c-48a90324d487.jpg?1",
             "name": "Soul Shred",
             "text": "Soul Shred deals 3 damage to any one creature that isn't black. You gain 3 life.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "06904be9-38a5-5247-a3fe-22dec94e6aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c95c752-3add-4830-8159-036b8689f40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c95c752-3add-4830-8159-036b8689f40a.jpg?1",
             "name": "Undying Beast",
             "text": "If Undying Beast is put into your discard pile from play, put Undying Beast on top of your deck.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "a4e612c4-b7f5-5e3d-9234-633ec5dcc82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19500ffb-bfad-46d6-8a6e-d134405959c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19500ffb-bfad-46d6-8a6e-d134405959c0.jpg?1",
             "name": "Vampiric Feast",
             "text": "Vampiric Feast deals 4 damage to any one creature or player. You gain 4 life.",
             "colours": [
@@ -4155,7 +4155,7 @@
         },
         {
             "id": "8d0d24eb-21c6-564c-9d55-3b8b1cf1cb3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfc875c-e79e-435a-906f-fb7e88550f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfc875c-e79e-435a-906f-fb7e88550f01.jpg?1",
             "name": "Vampiric Feast",
             "text": "",
             "colours": [
@@ -4188,7 +4188,7 @@
         },
         {
             "id": "33ae2400-0016-5acb-b1ce-5a5704d49f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231f7598-8c47-4828-8240-e2a545a7ac5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231f7598-8c47-4828-8240-e2a545a7ac5b.jpg?1",
             "name": "Vampiric Touch",
             "text": "Vampiric Touch deals 2 damage to your opponent. You gain 2 life.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "3c528b1d-dc79-555a-adb8-7e793adc91b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7854928a-d467-4616-b96b-de7e5fe7303e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7854928a-d467-4616-b96b-de7e5fe7303e.jpg?1",
             "name": "Virtue's Ruin",
             "text": "Destroy all white creatures. (This includes your white creatures.)",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "71cb32cb-1dc2-573b-95f9-ed4c0bd85412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d7c251-cb65-4ffc-8bf0-5e9692004a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d7c251-cb65-4ffc-8bf0-5e9692004a87.jpg?1",
             "name": "Wicked Pact",
             "text": "Destroy any two creatures that aren't black. You lose 5 life. (You can't play Wicked Pact unless you can choose two creatures to destroy.)",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "507fa887-3dae-59f1-9915-b160a143c7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc849bf-9c29-41a7-8fc0-ad0137c5724e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc849bf-9c29-41a7-8fc0-ad0137c5724e.jpg?1",
             "name": "Wicked Pact",
             "text": "",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "744f9c1e-8bad-5501-97cb-57cb8c3ce808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175c959-3b5d-46a3-9194-fad2359bbff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175c959-3b5d-46a3-9194-fad2359bbff9.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "926d19d0-8292-5983-a90f-32e84be8d257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8d48-539e-4eb4-9ac1-025722aae459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8d48-539e-4eb4-9ac1-025722aae459.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "73b7e8ec-6b0c-5c35-92ca-dc0cd1156456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab9da23-624e-4c33-ab5d-82a30015b0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab9da23-624e-4c33-ab5d-82a30015b0e7.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player. (For example, if you tap a mountain plus four other lands when you play Blaze, it deals 4 damage.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "5bdcf2f7-f8a0-52e0-9690-be68f0a6c2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1523c1b-2ba1-4581-8502-47544d450d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1523c1b-2ba1-4581-8502-47544d450d8e.jpg?1",
             "name": "Boiling Seas",
             "text": "Destroy all islands. (This includes your islands.)",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "bfdd2f5e-9ddb-5eda-8927-894c50b4e326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b8f443-dba5-45a5-bb2e-f57b4fdd1d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b8f443-dba5-45a5-bb2e-f57b4fdd1d01.jpg?1",
             "name": "Burning Cloak",
             "text": "Any one creature gets +2/+0 until the end of the turn.\nBurning Cloak deals 2 damage to that creature.",
             "colours": [
@@ -4480,7 +4480,7 @@
         },
         {
             "id": "930af056-7db9-530c-aff0-bfa899e847f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e1c12-f848-43b4-9505-851c66a509f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e1c12-f848-43b4-9505-851c66a509f1.jpg?1",
             "name": "Craven Giant",
             "text": "Craven Giant can't intercept.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "0d46fc50-7b80-5b94-b60e-15c94f25f4fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24673b35-aed2-40c0-a4ae-93bc4d392562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24673b35-aed2-40c0-a4ae-93bc4d392562.jpg?1",
             "name": "Desert Drake",
             "text": "Flying",
             "colours": [
@@ -4546,7 +4546,7 @@
         },
         {
             "id": "dff99c94-f218-5b27-a788-35c53f1fc197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cce019-162c-4969-89ac-1cf94148a032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cce019-162c-4969-89ac-1cf94148a032.jpg?1",
             "name": "Devastation",
             "text": "Destroy all creatures and lands. (This includes your creatures and lands.)",
             "colours": [
@@ -4577,7 +4577,7 @@
         },
         {
             "id": "29a217c1-496a-52d9-a48e-2331b38b2075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272f65a3-3c0c-417d-b5b6-276a643d643e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272f65a3-3c0c-417d-b5b6-276a643d643e.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each player and each creature without flying. (This includes you and your creatures without flying.)",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "f1a29989-a38d-5c4e-b99e-f6c162c7cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1f26d1-4381-470a-bfbf-ef226f980597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1f26d1-4381-470a-bfbf-ef226f980597.jpg?1",
             "name": "Fire Dragon",
             "text": "Flying\nWhen Fire Dragon comes into play from your hand, it deals to any one creature damage equal to the number of mountains you have in play.",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "45c75de8-e504-5ad6-8d7c-75a2c772ab32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edaf3-7941-4085-bdbc-e5c9832b6444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edaf3-7941-4085-bdbc-e5c9832b6444.jpg?1",
             "name": "Fire Imp",
             "text": "When Fire Imp comes into play from your hand, it deals 2 damage to any one creature. (If you're the only player with creatures, Fire Imp deals 2 damage to one of your creatures.)",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "70cb9bd2-65c4-5083-b98c-6eb16b6db6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c36e32-59e8-4e3d-903e-a264211f2a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c36e32-59e8-4e3d-903e-a264211f2a82.jpg?1",
             "name": "Fire Snake",
             "text": "If Fire Snake is put into your discard pile from play, destroy any one land.",
             "colours": [
@@ -4707,7 +4707,7 @@
         },
         {
             "id": "c68f8555-55fb-5ec7-a47c-04265dcd0892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92334ebe-3d7a-46de-8b91-931e5d56a5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92334ebe-3d7a-46de-8b91-931e5d56a5a5.jpg?1",
             "name": "Fire Tempest",
             "text": "Fire Tempest deals 6 damage to each creature and player. (This includes your creatures and you. If all players drop to 0 life or less, the game is a draw.)",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "6c96bd5a-bf5f-5fd2-afef-9c88610ac906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e88867-6acb-43f8-806b-21480aaa1afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e88867-6acb-43f8-806b-21480aaa1afc.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains. (This includes your plains.)",
             "colours": [
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "4986aeaf-1f4f-51e7-8875-41f9ffe1dcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85883197-fd55-4e82-862f-87be4f789493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85883197-fd55-4e82-862f-87be4f789493.jpg?1",
             "name": "Forked Lightning",
             "text": "Forked Lightning deals 4 damage divided any way you choose among any one, two, or three creatures.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "df8f44b9-d545-59a8-a0ce-015cdbeb34d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2094f2f6-8b38-47d6-973d-271986b5d982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2094f2f6-8b38-47d6-973d-271986b5d982.jpg?1",
             "name": "Goblin Bully",
             "text": "",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "1229e660-133d-56cc-9846-e04aa11d032b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f49716-1522-4f36-92c9-63ef2059c4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f49716-1522-4f36-92c9-63ef2059c4ef.jpg?1",
             "name": "Highland Giant",
             "text": "",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "27f2aaa4-7a4b-552c-b266-b7e0dc814f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd36579-c108-40c0-bce4-38ab837a8c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd36579-c108-40c0-bce4-38ab837a8c65.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "b57805f1-d9fb-54e4-be0f-9b4f7117b511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ae982-8a70-4dd3-8254-0d447954f580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ae982-8a70-4dd3-8254-0d447954f580.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops can't intercept.",
             "colours": [
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "d96d9173-7e82-501a-9f51-ef87cc61d929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca7851-1267-4dcc-ab5d-0ab205624562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca7851-1267-4dcc-ab5d-0ab205624562.jpg?1",
             "name": "Hulking Cyclops",
             "text": "",
             "colours": [
@@ -4969,7 +4969,7 @@
         },
         {
             "id": "32b2204d-1250-52d3-9958-454e1bc9e386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3eead8-7e07-4463-9e67-c396d2d7931e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3eead8-7e07-4463-9e67-c396d2d7931e.jpg?1",
             "name": "Hulking Goblin",
             "text": "Hulking Goblin can't intercept.",
             "colours": [
@@ -5002,7 +5002,7 @@
         },
         {
             "id": "9f2dd65b-f09a-5d7f-97a9-974c3c1ab5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f2c423-1694-466e-9a7d-4ec99e53578d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f2c423-1694-466e-9a7d-4ec99e53578d.jpg?1",
             "name": "Last Chance",
             "text": "Take another turn after this one. You lose the game at the end of that turn. (You don't lose if you've already won.)",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "8e383a51-4d11-5f2d-9258-34bd61248e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bebbad-76aa-4388-891a-583e8af9509d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bebbad-76aa-4388-891a-583e8af9509d.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to your opponent.",
             "colours": [
@@ -5064,7 +5064,7 @@
         },
         {
             "id": "f7099840-f20f-5e69-87e3-6ff7a0c769e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e825e4-98be-49f0-bc5e-c8988118dcef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e825e4-98be-49f0-bc5e-c8988118dcef.jpg?1",
             "name": "Lava Flow",
             "text": "Destroy any one creature or land.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "b5c9e9fa-10f3-5747-a471-6d823de92a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053cd970-5b79-410b-8420-82d9a490b897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053cd970-5b79-410b-8420-82d9a490b897.jpg?1",
             "name": "Lizard Warrior",
             "text": "",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "bb156d73-ba18-58ab-82d1-bf30de5e6625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694f5db-a4ad-4abd-acff-d6b340d2387c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694f5db-a4ad-4abd-acff-d6b340d2387c.jpg?1",
             "name": "Minotaur Warrior",
             "text": "",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "dce40ade-1ac0-58b3-8554-995a2b3e92e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325100f1-d424-4db0-bfa9-24877156c0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325100f1-d424-4db0-bfa9-24877156c0ba.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk (If defending player has any mountains in play, Mountain Goat can't be intercepted.)",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "fab4d2d4-336c-51c9-8a92-56662dc67723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daad744-e6b2-4bd8-83df-2e97e9e60d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daad744-e6b2-4bd8-83df-2e97e9e60d16.jpg?1",
             "name": "Pillaging Horde",
             "text": "When Pillaging Horde comes into play from your hand, discard a card at random from your hand or destroy Pillaging Horde.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "2abd5445-eb9a-564d-afef-0d8ca4c7e02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de214247-e5e3-4d8f-935a-797218416be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de214247-e5e3-4d8f-935a-797218416be1.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "7222da2c-ae5a-58e6-a1dc-3acc85cce18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d126a-9db9-4adc-9cf6-11408c63201d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d126a-9db9-4adc-9cf6-11408c63201d.jpg?1",
             "name": "Raging Cougar",
             "text": "Raging Cougar is unaffected by summoning sickness.",
             "colours": [
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "7fb39bce-19e7-5def-91cd-265fe6be19f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed57a17-7847-4e60-bc40-4452880f12a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed57a17-7847-4e60-bc40-4452880f12a3.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness.",
             "colours": [
@@ -5330,7 +5330,7 @@
         },
         {
             "id": "e410cea1-ca02-5fce-b4e9-ad8b6dfb6a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0fa444-5534-4476-8bfa-78b2364f2dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0fa444-5534-4476-8bfa-78b2364f2dd3.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness. (It can attack the turn you play it, unless another card prevents this.)",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "a6e9d24f-26a9-55be-816f-4b2db03fa2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea4be95-8147-431c-8bb8-8fe7e5a2ad53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea4be95-8147-431c-8bb8-8fe7e5a2ad53.jpg?1",
             "name": "Raging Minotaur",
             "text": "Raging Minotaur is unaffected by summoning sickness.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "b4937a8b-6d56-5956-ab52-bb619dda2e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661ffab2-9cf5-492d-874f-de73d7a13e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661ffab2-9cf5-492d-874f-de73d7a13e2b.jpg?1",
             "name": "Rain of Salt",
             "text": "Destroy any two lands.",
             "colours": [
@@ -5431,7 +5431,7 @@
         },
         {
             "id": "152db94d-231f-51b0-846c-25a35c7ccdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4817bd-68e8-4a85-983a-ee6dda2bbf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4817bd-68e8-4a85-983a-ee6dda2bbf33.jpg?1",
             "name": "Scorching Spear",
             "text": "Scorching Spear deals 1 damage to any one creature or player.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "c3b9d48d-ddd1-5866-8e7c-28d770e48fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec371e-d4ba-439f-b1b8-2aac3f5b36bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec371e-d4ba-439f-b1b8-2aac3f5b36bf.jpg?1",
             "name": "Scorching Winds",
             "text": "Play Scorching Winds only after you're attacked, before you declare interceptors.\nScorching Winds deals 1 damage to each attacking creature.",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "34171bda-9d1f-5f12-ad9f-2db02c2d398f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb16998c-cfa4-49cc-8e37-2dfc33fa2f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb16998c-cfa4-49cc-8e37-2dfc33fa2f1e.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to any one creature damage equal to the number of mountains you have in play. (This includes both tapped and untapped mountains.)",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "61148866-6288-5369-9922-cfc0f7b2769a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f84a13-d7dc-491b-a77c-1b99b6797d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f84a13-d7dc-491b-a77c-1b99b6797d7e.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy any one land.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "d26bd36a-1417-58dd-8376-65d3738e9c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a9f3f5-c80f-47a4-bf84-b7262437017f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a9f3f5-c80f-47a4-bf84-b7262437017f.jpg?1",
             "name": "Thundermare",
             "text": "Thundermare is unaffected by summoning sickness.\nWhen Thundermare comes into play from your hand, tap all other creatures. (This includes your creatures.)",
             "colours": [
@@ -5589,7 +5589,7 @@
         },
         {
             "id": "2549d446-7e97-5255-9489-61990dbb4ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99c5c70-7568-42d3-939c-b6ee1ed94b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99c5c70-7568-42d3-939c-b6ee1ed94b9f.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nVolcanic Dragon is unaffected by summoning sickness.",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "3f2fd372-c7d9-5878-9c42-9f0e2ab13321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9563d7c1-4ed1-4919-b0b8-ea1ec9d4bbf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9563d7c1-4ed1-4919-b0b8-ea1ec9d4bbf6.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to any one creature or player.",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "ccc16e04-6cd9-5e2c-9ba0-6e306c5f85c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c5ac71-bf45-4b99-8184-36ce88dd728a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c5ac71-bf45-4b99-8184-36ce88dd728a.jpg?1",
             "name": "Wall of Granite",
             "text": "Wall of Granite can't attack.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "754a66ac-e376-54a5-a734-1923dee297f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b8aec-62d4-46db-9a68-a6c69cb6fd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b8aec-62d4-46db-9a68-a6c69cb6fd98.jpg?1",
             "name": "Winds of Change",
             "text": "Each player counts the cards in his or her hand, shuffles those cards into his or her deck, and then draws that many cards. (When you play Winds of Change, it doesn't count as a card in your hand.)",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "bbcb1ca9-df3b-5441-abc8-92a39a0d7d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726242e-bfd8-4ed5-a016-ac0c82e4762b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726242e-bfd8-4ed5-a016-ac0c82e4762b.jpg?1",
             "name": "Alluring Scent",
             "text": "Choose any one creature. This turn, all creatures able to intercept that creature do so.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "263836cf-f2fe-54d1-9a78-3fb7c2006a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2012ad-6425-4935-83af-fc7309ec2ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2012ad-6425-4935-83af-fc7309ec2ece.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (If defending player has any swamps in play, Anaconda can't be intercepted.)",
             "colours": [
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "c8b7c22f-1a06-5b51-8e4c-37a97fa8f47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffba7a5-8845-46f4-bb86-4722d6cbd4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffba7a5-8845-46f4-bb86-4722d6cbd4c1.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (If defending player has any swamps in play, Anaconda can't be intercepted. Swamps are in play regardless of whether they're tapped or untapped.)",
             "colours": [
@@ -5818,7 +5818,7 @@
         },
         {
             "id": "9175f689-027c-5cde-aeb8-e1d17c8fe91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcf64a-ae3d-4abb-acc7-81bba237f37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcf64a-ae3d-4abb-acc7-81bba237f37b.jpg?1",
             "name": "Bee Sting",
             "text": "Bee Sting deals 2 damage to any one creature or player.",
             "colours": [
@@ -5849,7 +5849,7 @@
         },
         {
             "id": "83bf932d-33c7-5089-993d-d3dc12fcccf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dd236b-94fc-4c56-aeae-215c71a009ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dd236b-94fc-4c56-aeae-215c71a009ea.jpg?1",
             "name": "Bull Hippo",
             "text": "Islandwalk (If defending player has any islands in play, Bull Hippo can't be intercepted.)",
             "colours": [
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "d37b7dff-e00e-5785-9671-4bcf97dfe240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbe115b-ded7-4749-95e2-b69bff26fc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbe115b-ded7-4749-95e2-b69bff26fc74.jpg?1",
             "name": "Bull Hippo",
             "text": "",
             "colours": [
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "1ae26179-d8d3-5ed0-9bf9-fb9dc4684636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e47248-051c-4ee6-aad2-352ebd1f38ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e47248-051c-4ee6-aad2-352ebd1f38ca.jpg?1",
             "name": "Charging Rhino",
             "text": "Charging Rhino can't be intercepted by more than one creature.",
             "colours": [
@@ -5952,7 +5952,7 @@
         },
         {
             "id": "e0a94f62-a38c-5587-9257-94ea290d1b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216c5aa-9df0-4e7c-b3e9-a3f712b17ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216c5aa-9df0-4e7c-b3e9-a3f712b17ce7.jpg?1",
             "name": "Deep Wood",
             "text": "Play Deep Wood only after you're attacked, before you declare interceptors.\nThis turn, all damage dealt to you by attacking creatures is reduced to 0.",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "189dd8e1-7412-53b5-b8a0-56443c5e8349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7396c4e9-b0d8-4b8f-8c17-6f913a967b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7396c4e9-b0d8-4b8f-8c17-6f913a967b17.jpg?1",
             "name": "Elite Cat Warrior",
             "text": "Forestwalk (If defending player has any forests in play, Elite Cat Warrior can't be intercepted.)",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "844d01a4-2cb5-5c52-b132-7221d3a84c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4d16b-5bfc-4e35-8a8e-16cf84f54586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4d16b-5bfc-4e35-8a8e-16cf84f54586.jpg?1",
             "name": "Elite Cat Warrior",
             "text": "Forestwalk (If defending player has any forests in play, Elite Cat Warrior can't be intercepted. Forests are in play regardless of whether they're tapped or untapped.)",
             "colours": [
@@ -6055,7 +6055,7 @@
         },
         {
             "id": "fc006f54-6a8f-52d0-a0db-41305cac4d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68939020-eb6a-4d77-a850-4df96cf01918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68939020-eb6a-4d77-a850-4df96cf01918.jpg?1",
             "name": "Elven Cache",
             "text": "Return any one card from your discard pile to your hand.",
             "colours": [
@@ -6088,7 +6088,7 @@
         },
         {
             "id": "e019addd-eaf5-5aa7-865c-3c2c9a76f6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0b0afb-75c0-4613-be3b-f4b739fa7954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0b0afb-75c0-4613-be3b-f4b739fa7954.jpg?1",
             "name": "Elven Cache",
             "text": "",
             "colours": [
@@ -6121,7 +6121,7 @@
         },
         {
             "id": "d46fcdcb-62b0-53f4-9f4c-c5f442e88591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26caff65-3a96-46f2-8f0b-e5091b632a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26caff65-3a96-46f2-8f0b-e5091b632a2e.jpg?1",
             "name": "Elvish Ranger",
             "text": "",
             "colours": [
@@ -6155,7 +6155,7 @@
         },
         {
             "id": "fad5903a-b3e9-5cad-ad46-10f6f58d15e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147082a3-1408-44f9-ab39-f069cee5c710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147082a3-1408-44f9-ab39-f069cee5c710.jpg?1",
             "name": "Fruition",
             "text": "For each forest you and your opponent have in play, you gain 1 life.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "d4c53a0d-da42-5a31-b2dc-734776b1a80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695fcf4-1eef-4671-a11e-da6b1ff8d466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695fcf4-1eef-4671-a11e-da6b1ff8d466.jpg?1",
             "name": "Fruition",
             "text": "",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "756a24f4-3498-5662-8aaa-d441014bbf07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995530c-16bd-4dcb-99c2-008bba00052c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995530c-16bd-4dcb-99c2-008bba00052c.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can intercept as though it had flying.",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "d24e95e9-948e-5ad4-82ab-c974f4a7645a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f9c3f3-0d4d-4eec-bd14-9be3233178dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f9c3f3-0d4d-4eec-bd14-9be3233178dc.jpg?1",
             "name": "Gorilla Warrior",
             "text": "",
             "colours": [
@@ -6288,7 +6288,7 @@
         },
         {
             "id": "c5f10306-f840-51c6-b438-fb194724527d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1b99c-97d0-48f2-bfdf-faa65bc0b608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1b99c-97d0-48f2-bfdf-faa65bc0b608.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -6321,7 +6321,7 @@
         },
         {
             "id": "542ec783-c856-54d8-a809-07ff57e9b9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b97904e-80ba-4d65-808a-a528200430f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b97904e-80ba-4d65-808a-a528200430f8.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each player and each creature with flying. (This includes you and your creatures with flying.)",
             "colours": [
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "0151cfd9-168f-5eef-a7f7-2b1c1dcc0ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ceee3-92c7-46f1-8267-d6229ab15df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ceee3-92c7-46f1-8267-d6229ab15df5.jpg?1",
             "name": "Jungle Lion",
             "text": "Jungle Lion can't intercept.",
             "colours": [
@@ -6385,7 +6385,7 @@
         },
         {
             "id": "b9ceee94-3af8-563d-ba50-1f587e9b5585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9712ecaa-4059-44ba-98b7-07bfe7411b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9712ecaa-4059-44ba-98b7-07bfe7411b5b.jpg?1",
             "name": "Mobilize",
             "text": "Untap all your creatures.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "40f6a94d-3a35-5f1f-ad92-aa12138f73d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2edb9-0b53-432e-bb3b-171d2a85439d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2edb9-0b53-432e-bb3b-171d2a85439d.jpg?1",
             "name": "Monstrous Growth",
             "text": "Any one creature gets +4/+4 until the end of the turn.",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "0740eb1a-ad8b-5850-a227-b95968995eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523c816-dddf-4b63-8db8-5e41dc673e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523c816-dddf-4b63-8db8-5e41dc673e5f.jpg?1",
             "name": "Monstrous Growth",
             "text": "Any one creature gets +4/+4 until the end of the turn. (For example, a 6/3 creature would become 10/7.)",
             "colours": [
@@ -6482,7 +6482,7 @@
         },
         {
             "id": "25b6ed49-af73-5908-be25-a23d773ec577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0944759-ee9f-4ae0-9d1b-2533ff6791a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0944759-ee9f-4ae0-9d1b-2533ff6791a2.jpg?1",
             "name": "Moon Sprite",
             "text": "Flying",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "ddb98d47-b0d1-575c-8b99-fb21386074f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecb34f8-6961-4c27-9368-26d156714d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecb34f8-6961-4c27-9368-26d156714d7b.jpg?1",
             "name": "Natural Order",
             "text": "Search your deck for a green summon creature and put that card into play. Treat it as though you just played it from your hand. Then put one of your green creatures into your discard pile. Shuffle your deck afterwards.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "2e8407af-68cd-576a-9625-0aadcce9c46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfc1cc-5c13-443c-a0ae-0bcc931923e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfc1cc-5c13-443c-a0ae-0bcc931923e7.jpg?1",
             "name": "Natural Spring",
             "text": "You gain 8 life.",
             "colours": [
@@ -6577,7 +6577,7 @@
         },
         {
             "id": "ca805058-bd33-5a83-9347-8d27644a2fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfaba58-d0ab-4d1d-91dd-48543c862165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfaba58-d0ab-4d1d-91dd-48543c862165.jpg?1",
             "name": "Nature's Cloak",
             "text": "All your green creatures gain forestwalk until the end of the turn. (If defending player has any forests in play, none of your green creatures can be intercepted.)",
             "colours": [
@@ -6608,7 +6608,7 @@
         },
         {
             "id": "57ac8211-7439-5210-b744-19dedc8d52ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5242227-d033-4e03-b1e6-b334b17bb158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5242227-d033-4e03-b1e6-b334b17bb158.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your deck for a forest and put that card into play. Shuffle your deck afterwards.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "4df18683-a323-57a4-912e-c4e9414d28de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a44e44-94b1-4bd2-8e00-6bd2ec07ee4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a44e44-94b1-4bd2-8e00-6bd2ec07ee4c.jpg?1",
             "name": "Needle Storm",
             "text": "Needle Storm deals 4 damage to each creature with flying. (This includes your creatures with flying.)",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "734551ab-9679-5c08-bfe6-f0a73303070b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be610ce-5b84-416e-b427-98887642ff01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be610ce-5b84-416e-b427-98887642ff01.jpg?1",
             "name": "Panther Warriors",
             "text": "",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "cdfccea6-5623-5e30-b014-b9954608f09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892594db-1d66-4c45-bd54-608a9972ca77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892594db-1d66-4c45-bd54-608a9972ca77.jpg?1",
             "name": "Plant Elemental",
             "text": "When Plant Elemental comes into play from your hand, destroy one of your forests or destroy Plant Elemental.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "3d4c007b-765d-5974-ae66-ba7995ce5e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce7fc51-0ed8-49d9-bdba-ba5a89e1e852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce7fc51-0ed8-49d9-bdba-ba5a89e1e852.jpg?1",
             "name": "Primeval Force",
             "text": "When Primeval Force comes into play from your hand, destroy three of your forests or destroy Primeval Force.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "717df58c-4080-54b0-a272-b53953eb579b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9399667-ae2a-4b64-84dd-8f97f3e5fe79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9399667-ae2a-4b64-84dd-8f97f3e5fe79.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "34c97a31-117b-52a9-84cb-a5ddcee5b66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852a0956-8558-4754-ab57-6f1cc4de740e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852a0956-8558-4754-ab57-6f1cc4de740e.jpg?1",
             "name": "Rowan Treefolk",
             "text": "",
             "colours": [
@@ -6837,7 +6837,7 @@
         },
         {
             "id": "de7f95f6-d179-5fee-91e1-826b8ff02e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053bd00-90fd-48c2-8f79-952d5d1e3e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053bd00-90fd-48c2-8f79-952d5d1e3e74.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "cba02608-3101-5476-8854-ef8746d5e042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc78337-2d1a-4a1d-8630-fcf7a7f6abce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc78337-2d1a-4a1d-8630-fcf7a7f6abce.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be intercepted by more than one creature.",
             "colours": [
@@ -6903,7 +6903,7 @@
         },
         {
             "id": "aa046c0b-61a0-5696-8c2d-3f4c8b79bdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e86abcc-272e-4959-90ee-343b9f546ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e86abcc-272e-4959-90ee-343b9f546ea7.jpg?1",
             "name": "Summer Bloom",
             "text": "Take up to three lands from your hand and put them into play.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "bc221a10-d2fd-5a04-aaae-8ff18e0a4df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ba07e-6434-4850-940f-454fcab3f535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ba07e-6434-4850-940f-454fcab3f535.jpg?1",
             "name": "Sylvan Tutor",
             "text": "Search your deck for a summon creature and reveal that card to all players. Then shuffle your deck and put the revealed card on top of it.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "6cf38661-461f-5233-b7d1-15019ace784e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0ba623-d17f-4f0e-b914-da139a3971df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0ba623-d17f-4f0e-b914-da139a3971df.jpg?1",
             "name": "Thundering Wurm",
             "text": "When Thundering Wurm comes into play from your hand, discard a land from your hand or destroy Thundering Wurm.",
             "colours": [
@@ -6998,7 +6998,7 @@
         },
         {
             "id": "c3d9ed7a-2502-5d2a-a5c9-a1025748aa91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e134b3-e8af-41e9-928d-c217ea7b2b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e134b3-e8af-41e9-928d-c217ea7b2b13.jpg?1",
             "name": "Treetop Defense",
             "text": "Play Treetop Defense only after you're attacked, before you declare interceptors.\nThis turn, all your creatures can intercept as though they had flying.",
             "colours": [
@@ -7029,7 +7029,7 @@
         },
         {
             "id": "8468bfbb-abab-5327-be42-21cdbe3ab606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fd77e-ee43-4de7-9ee8-1075ff70b5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fd77e-ee43-4de7-9ee8-1075ff70b5e7.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your deck for a plains, island, swamp, mountain, or forest and put that card into play. Shuffle your deck afterwards.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "1c27d83f-f8d9-538e-9c3a-2b7912e36668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e76072-e76d-485e-b94c-c29849bc8a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e76072-e76d-485e-b94c-c29849bc8a6f.jpg?1",
             "name": "Whiptail Wurm",
             "text": "",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "a410f62a-6f9a-5d43-9428-defecc14df2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def835b-aabb-4a9d-8fb9-460452de0d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def835b-aabb-4a9d-8fb9-460452de0d79.jpg?1",
             "name": "Willow Dryad",
             "text": "Forestwalk (If defending player has any forests in play, Willow Dryad can't be intercepted.)",
             "colours": [
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "67f5318b-f0a8-5ebd-8118-a4ba15ef1a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2215de4-da49-4270-aec7-5e16a938bae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2215de4-da49-4270-aec7-5e16a938bae4.jpg?1",
             "name": "Winter's Grasp",
             "text": "Destroy any one land.",
             "colours": [
@@ -7157,7 +7157,7 @@
         },
         {
             "id": "6617d060-cc87-5f01-8928-34e80881fc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f1fb90-5c85-46a5-802d-248cc0250921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f1fb90-5c85-46a5-802d-248cc0250921.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play from your hand, search your deck for a forest and put that card into play. Shuffle your deck afterwards.",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "117f2f69-8556-5431-bb32-d04deaa94828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d35453-7fe3-4053-aad9-a124ecc7dcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d35453-7fe3-4053-aad9-a124ecc7dcf0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7232,7 +7232,7 @@
         },
         {
             "id": "0e63764d-1f5c-53ab-b3cc-f9743cce8a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b90ae-6f52-412f-88fa-1a5585f486bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b90ae-6f52-412f-88fa-1a5585f486bd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "0cabcd45-81cb-5d8b-9428-b7a983223e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1de52fb-796c-4146-b592-00ce0cc5a187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1de52fb-796c-4146-b592-00ce0cc5a187.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "8b5af06c-8757-5270-9ebd-ba50d6414f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc84a2-8892-437e-bbb3-991dbbfe5cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc84a2-8892-437e-bbb3-991dbbfe5cdd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7355,7 +7355,7 @@
         },
         {
             "id": "45aafbd5-4480-5f38-806a-17f763d39ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a48c07b-ddbe-4251-b9e7-38ea60d66e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a48c07b-ddbe-4251-b9e7-38ea60d66e72.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7396,7 +7396,7 @@
         },
         {
             "id": "408a8109-81e1-5d8d-b418-4ff558d77b61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee9d25-0f3f-4a50-802a-23122bc4c6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee9d25-0f3f-4a50-802a-23122bc4c6b2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7437,7 +7437,7 @@
         },
         {
             "id": "bc3e104e-9553-5852-a163-0e22aafe9d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e511581-2739-445e-b486-c2b2d15c9be4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e511581-2739-445e-b486-c2b2d15c9be4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "4c4079bd-7987-5cce-92f3-712ea9aeb983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db83947-3441-4e1d-bd47-dd015ae55d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db83947-3441-4e1d-bd47-dd015ae55d15.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "9423c529-6e6c-5af6-a2d3-d6b7932ee69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d1e6f-5902-4e67-91a6-30eb5c3ce4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d1e6f-5902-4e67-91a6-30eb5c3ce4a1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7560,7 +7560,7 @@
         },
         {
             "id": "f1e2ecf8-c67f-56fe-85ba-6c2591a2a3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f049121-5daf-4bc6-9431-3ab665a3dc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f049121-5daf-4bc6-9431-3ab665a3dc8a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "8eaf556c-f058-50e5-abf4-a45cee829b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fcc1eb-8689-4b0f-9e56-cfeb4c8c1edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fcc1eb-8689-4b0f-9e56-cfeb4c8c1edb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "cbf897b5-5621-51bb-98e4-222e1c442889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d494cfbe-8017-41a6-84df-f8f16fb40016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d494cfbe-8017-41a6-84df-f8f16fb40016.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "c4993564-d770-511c-a183-ea6220b8bf63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36da118a-d54d-489d-85da-5cbcd0d80519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36da118a-d54d-489d-85da-5cbcd0d80519.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "5b4c98f2-d5d9-5fcf-95e1-4c586334412f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29b600a-3a8e-4ae2-a186-b6d5cdcbd496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29b600a-3a8e-4ae2-a186-b6d5cdcbd496.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7765,7 +7765,7 @@
         },
         {
             "id": "96e916dd-8a96-5052-8510-2014c7eac8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591c9c1-ce72-4b68-b32f-4d048dcfa495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591c9c1-ce72-4b68-b32f-4d048dcfa495.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7806,7 +7806,7 @@
         },
         {
             "id": "19fb2e61-3218-5311-adb4-3f0431a4b3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ca67a8-2922-4c12-a888-d89981e28f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ca67a8-2922-4c12-a888-d89981e28f0e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "41304c50-b867-519b-b563-d3f3233e7c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0da69e-4ab6-4ef1-a7ae-4d6c47172c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0da69e-4ab6-4ef1-a7ae-4d6c47172c81.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7884,7 +7884,7 @@
         },
         {
             "id": "5970dc96-d6a5-52e9-b111-43fb9a65925d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6c1c8d-dd83-4dbe-b022-495edd1a909f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6c1c8d-dd83-4dbe-b022-495edd1a909f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7921,7 +7921,7 @@
         },
         {
             "id": "6d5add97-7ecf-5b5d-a447-8b35b297ab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c5cf6-f91d-45eb-a5c1-5aacec9cda69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c5cf6-f91d-45eb-a5c1-5aacec9cda69.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7958,7 +7958,7 @@
         },
         {
             "id": "f18e9001-e542-5933-b683-2cf2aedaf857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd26e01-cbd2-4787-bc01-aff58c13840f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd26e01-cbd2-4787-bc01-aff58c13840f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7995,7 +7995,7 @@
         },
         {
             "id": "770f5dec-542c-5dab-adda-91f182474058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17cf7ce4-d5d7-49f2-a7e4-021d1a2d58c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17cf7ce4-d5d7-49f2-a7e4-021d1a2d58c5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "2ebe4799-b0d6-5e10-b2aa-41bfb3764c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c40d24d-a81d-46b9-87ef-d5304d438c0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c40d24d-a81d-46b9-87ef-d5304d438c0e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "3209acb7-d63a-5c2c-a49c-05a4cd702eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86914cf-0808-4c7c-b364-1539087688bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86914cf-0808-4c7c-b364-1539087688bc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "4653cd0d-56c3-5b93-93bc-28078bcd35fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163c2b6b-d8cd-4a46-b4da-81cbd42e0511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163c2b6b-d8cd-4a46-b4da-81cbd42e0511.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8159,7 +8159,7 @@
         },
         {
             "id": "fffdd333-3789-5104-a8be-37be199a2cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16a4aa-7476-4999-ad1f-5d8bc27bf418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16a4aa-7476-4999-ad1f-5d8bc27bf418.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8200,7 +8200,7 @@
         },
         {
             "id": "dfabc7e4-ce65-5bf0-9a22-e41d0ea8a6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4641987d-e69e-4399-9b20-f85765ecf5f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4641987d-e69e-4399-9b20-f85765ecf5f3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8241,7 +8241,7 @@
         },
         {
             "id": "9cf11aa2-12f9-5b2b-81ca-f64d0642a35c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5f3d2-6728-47b9-8178-a640e23ba30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5f3d2-6728-47b9-8178-a640e23ba30a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8282,7 +8282,7 @@
         },
         {
             "id": "a49db359-5a8d-5c72-9b8f-d86e19322003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd723ea-66fe-439e-84f7-2b4625fcc22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd723ea-66fe-439e-84f7-2b4625fcc22a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "c6c1e6ca-decd-5f9d-aed5-ec21d7686619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40146f61-d3f0-45e7-82b5-788ff7b0e520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40146f61-d3f0-45e7-82b5-788ff7b0e520.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "097984fb-70df-59f2-9924-7183d68e9f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2db57-be7f-4963-aef3-aa57fe6c0cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2db57-be7f-4963-aef3-aa57fe6c0cdf.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "75e2ce34-36e2-599c-b3ba-f02c1fd7727c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f15f2-abfa-4176-856f-be815152b620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f15f2-abfa-4176-856f-be815152b620.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "fd3d7dbb-1353-507a-880b-bc755ce27cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b36fbc-c2c2-4e17-962b-cd018493ff6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b36fbc-c2c2-4e17-962b-cd018493ff6f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "aa80ba2f-8a0d-5c91-865d-fc7d2a26fc89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37ea002-f81e-4fa6-ac24-bba1cb6d7edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37ea002-f81e-4fa6-ac24-bba1cb6d7edf.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "c615f748-729d-54ca-a8eb-2a7953311ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776e2ad-5bf8-4b2a-89bd-4f7e7ee723a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776e2ad-5bf8-4b2a-89bd-4f7e7ee723a7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8569,7 +8569,7 @@
         },
         {
             "id": "a67d2c87-9a4f-5854-ac14-24758af648ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a98ba-d999-41b7-a5c6-f3efa6056800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a98ba-d999-41b7-a5c6-f3efa6056800.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "5b1dca0f-5271-53cf-9d32-e6c91812aad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620b6d41-562f-4225-bbfc-59655141c4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620b6d41-562f-4225-bbfc-59655141c4d0.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/PTK.json
+++ b/Assets/Resources/Sets/PTK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c70cc38d-339d-5315-98c7-5353394d1033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a92a9-060e-42d3-a8d1-49425defc08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a92a9-060e-42d3-a8d1-49425defc08a.jpg?1",
             "name": "Alert Shu Infantry",
             "text": "Attacking doesn't cause Alert Shu Infantry to tap.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "781a8d6f-6d04-5cb5-9f84-6124db814269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg?1",
             "name": "Eightfold Maze",
             "text": "Play Eightfold Maze only after you're attacked, before you declare blockers.\nDestroy any one attacking creature.",
             "colours": [
@@ -69,7 +69,7 @@
         },
         {
             "id": "6a1c3727-7ffb-5c3f-aae7-40f6adb62056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d37c84c-80e5-453d-bd2e-4f77ff864c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d37c84c-80e5-453d-bd2e-4f77ff864c89.jpg?1",
             "name": "Empty City Ruse",
             "text": "Your opponent can't attack on his or her next turn.",
             "colours": [
@@ -100,7 +100,7 @@
         },
         {
             "id": "2f4ea5a2-3dee-5b33-97c1-d3cea9422a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca71ce3-8633-428a-8d9e-9b807b77a8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca71ce3-8633-428a-8d9e-9b807b77a8e2.jpg?1",
             "name": "False Defeat",
             "text": "Take any one creature card from your graveyard and put that creature into play.",
             "colours": [
@@ -131,7 +131,7 @@
         },
         {
             "id": "2d4d4812-eca7-51f2-a83c-df4078a0bd21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a219a031-2466-4850-b646-79a09e30cf18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a219a031-2466-4850-b646-79a09e30cf18.jpg?1",
             "name": "Flanking Troops",
             "text": "When Flanking Troops attacks, you may tap any one creature. (Tapped creatures can't block.)",
             "colours": [
@@ -165,7 +165,7 @@
         },
         {
             "id": "17e974ff-129e-5d7f-a901-0f2ac91c90b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1575fadf-cd5c-4b4f-8965-c006e571334b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1575fadf-cd5c-4b4f-8965-c006e571334b.jpg?1",
             "name": "Guan Yu, Sainted Warrior",
             "text": "Horsemanship\nWhen Guan Yu is put into your graveyard from play, you may shuffle Guan Yu into your library.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "519cf3ab-5b48-59bb-a6e2-23c96a85eb12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7526a-7a4e-4b3d-b96e-91f2bbf1c7bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7526a-7a4e-4b3d-b96e-91f2bbf1c7bd.jpg?1",
             "name": "Guan Yu's 1,000-Li March",
             "text": "Destroy all tapped creatures. (This includes your tapped creatures.)",
             "colours": [
@@ -233,7 +233,7 @@
         },
         {
             "id": "b8c02fd0-84d8-5229-9bf5-f07233f9d67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg?1",
             "name": "Huang Zhong, Shu General",
             "text": "Huang Zhong can't be blocked by more than one creature each turn.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "5be0c76f-f539-5dfa-a024-c3f171e9e15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ae0a05-1870-4f4a-b8a2-bfb5381acacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ae0a05-1870-4f4a-b8a2-bfb5381acacb.jpg?1",
             "name": "Kongming, \"Sleeping Dragon\"",
             "text": "All your other creatures get +1/+1 as long as Kongming is in play.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "aa0f8d33-5a92-599e-8dee-6008afe83d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6729eb0b-5655-4191-af14-4f7e4a8dded7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6729eb0b-5655-4191-af14-4f7e4a8dded7.jpg?1",
             "name": "Kongming's Contraptions",
             "text": "After you're attacked, before you declare blockers, you may tap Kongming's Contraptions to have it deal 2 damage to any one attacking creature.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "ce8229dd-d7f2-54ec-8744-2c370001ff90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804c879-fe23-4d7f-9e7d-1da41b5c0973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804c879-fe23-4d7f-9e7d-1da41b5c0973.jpg?1",
             "name": "Liu Bei, Lord of Shu",
             "text": "Horsemanship\nAs long as you have Guan Yu and/or Zhang Fei in play, Liu Bei gets +2/+2.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "f6169dc5-4b7a-5a05-9a50-ce77ea7c15c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c37964-1c0d-40e6-9947-8be04fe14427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c37964-1c0d-40e6-9947-8be04fe14427.jpg?1",
             "name": "Loyal Retainers",
             "text": "On your turn, before you attack you may put Loyal Retainers in your graveyard to take any one Legend card from your graveyard and put that creature into play.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "7383a382-84fc-548f-8587-3e4fc4b77b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80abd7c1-8f7a-4279-b76f-251a02624345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80abd7c1-8f7a-4279-b76f-251a02624345.jpg?1",
             "name": "Misfortune's Gain",
             "text": "Destroy any one creature. That creature's owner gains 4 life.",
             "colours": [
@@ -440,7 +440,7 @@
         },
         {
             "id": "5217a4fc-541a-559e-93ae-72c0f11295de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg?1",
             "name": "Pang Tong, \"Young Phoenix\"",
             "text": "On your turn, before you attack, you may tap Pang Tong to give any one creature +0/+2 until the end of the turn.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "0f56b784-08cf-53e4-8ed2-93f0a3ce37d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bfd51a-0aca-4686-a9c5-11288f409a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bfd51a-0aca-4686-a9c5-11288f409a22.jpg?1",
             "name": "Peach Garden Oath",
             "text": "For each creature you have in play, you gain 2 life.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "d6e1beee-f942-51ce-9144-86a6fe14123a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ee74d6-bd06-48e5-89de-f926e0c9413f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ee74d6-bd06-48e5-89de-f926e0c9413f.jpg?1",
             "name": "Rally the Troops",
             "text": "Play Rally the Troops only after you're attacked, before you declare blockers.\nUntap all your creatures.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "fd003cc1-79ea-5cf4-86cb-b22a76dee0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11dca9ba-b27f-4af8-9962-3794e743886f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11dca9ba-b27f-4af8-9962-3794e743886f.jpg?1",
             "name": "Ravages of War",
             "text": "Destroy all lands. (This includes your lands.)",
             "colours": [
@@ -569,7 +569,7 @@
         },
         {
             "id": "0c3ac77d-340d-5cf7-bab9-11d36642f8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0504a24-4b92-471a-8da4-02ec57eb43be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0504a24-4b92-471a-8da4-02ec57eb43be.jpg?1",
             "name": "Riding Red Hare",
             "text": "Any one creature gets +3/+3 and gains horsemanship until the end of the turn.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "dcf287f6-078a-5e9d-8d17-1d25c2ae29db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0433bee7-406d-4dd3-8d1b-dfd6cb64d038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0433bee7-406d-4dd3-8d1b-dfd6cb64d038.jpg?1",
             "name": "Shu Cavalry",
             "text": "Horsemanship",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "28e5e88c-ed16-5e37-9c1a-dd70ab4bebc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee57a9ab-c385-4a51-aff7-6a654f5d7611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee57a9ab-c385-4a51-aff7-6a654f5d7611.jpg?1",
             "name": "Shu Defender",
             "text": "When Shu Defender blocks, it gets +0/+2 until the end of the turn.",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "a428f582-0b2d-5577-ba2f-5e652c9217aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ac63f6-cd61-4334-902a-777410311b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ac63f6-cd61-4334-902a-777410311b2d.jpg?1",
             "name": "Shu Elite Companions",
             "text": "Horsemanship",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "b688038f-6a89-503a-a695-b1493f6ce25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg?1",
             "name": "Shu Elite Infantry",
             "text": "",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "c43d2a8f-6f88-5c71-b593-8d481d74071e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6524-d8bd-4eb9-9222-747443492b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6524-d8bd-4eb9-9222-747443492b8c.jpg?1",
             "name": "Shu Farmer",
             "text": "On your turn, before you attack, you may tap Shu Farmer to gain 1 life.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "b41f4194-a321-5445-9c1f-54c4a229cedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4268d5-f27b-44a5-91f6-6c90521825fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4268d5-f27b-44a5-91f6-6c90521825fd.jpg?1",
             "name": "Shu Foot Soldiers",
             "text": "",
             "colours": [
@@ -803,7 +803,7 @@
         },
         {
             "id": "c3f59565-b4e5-5d80-907c-5020bd87ca33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c3be7a-82a8-411c-bfe2-16749ada1244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c3be7a-82a8-411c-bfe2-16749ada1244.jpg?1",
             "name": "Shu General",
             "text": "Horsemanship\nAttacking doesn't cause Shu General to tap.",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "8496a9f5-f7a7-594d-8d2b-efec5cdd642d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf26eb7-8a31-4022-87bb-67394653f06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf26eb7-8a31-4022-87bb-67394653f06a.jpg?1",
             "name": "Shu Grain Caravan",
             "text": "When Shu Grain Caravan comes into play, you gain 2 life.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "84c2e875-0343-5be0-8c40-06c3d928ef8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb576e9-98ba-4bd1-9d1e-e316acf2e7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb576e9-98ba-4bd1-9d1e-e316acf2e7f5.jpg?1",
             "name": "Shu Soldier-Farmers",
             "text": "When Shu Soldier-Farmers comes into play, you gain 4 life.",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "429d8f59-4f0e-52f6-8316-6c029f9aaa5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a882fbcc-b2b9-44f3-b5cc-56759879f473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a882fbcc-b2b9-44f3-b5cc-56759879f473.jpg?1",
             "name": "Vengeance",
             "text": "Destroy any one tapped creature.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "030d9c02-073b-52bb-9f8c-f2d3038f5e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad4c79-a85d-4fc6-95ab-5a6d6d667579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad4c79-a85d-4fc6-95ab-5a6d6d667579.jpg?1",
             "name": "Virtuous Charge",
             "text": "All your creatures get +1/+1 until the end of the turn.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "5bdf7276-6c45-5787-87de-d06b34f59a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af243f6-ef28-49d1-afeb-ac03d568ed6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af243f6-ef28-49d1-afeb-ac03d568ed6a.jpg?1",
             "name": "Volunteer Militia",
             "text": "",
             "colours": [
@@ -1001,7 +1001,7 @@
         },
         {
             "id": "4b3a5d52-3cf8-5ef6-8b6d-ea629518268b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bffc2e-67b6-4eb0-9742-e2a5918cc8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bffc2e-67b6-4eb0-9742-e2a5918cc8d8.jpg?1",
             "name": "Warrior's Stand",
             "text": "Play Warrior's Stand only after you're attacked, before you declare blockers.\nAll your creatures get +2/+2 until the end of the turn.",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "c1449798-f08d-5d27-a073-af4ec827c855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg?1",
             "name": "Zhang Fei, Fierce Warrior",
             "text": "Horsemanship\nAttacking doesn't cause Zhang Fei to tap.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "91946740-2846-5b8b-b8b7-f112bad19290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg?1",
             "name": "Zhao Zilong, Tiger General",
             "text": "Horsemanship\nWhen Zhao Zilong blocks, it gets +1/+1 until the end of the turn.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "24fbd51f-0f3c-53ea-aac9-6ac502c7baff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae27edb4-424b-4a2f-a588-d3b60c8d78e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae27edb4-424b-4a2f-a588-d3b60c8d78e5.jpg?1",
             "name": "Balance of Power",
             "text": "If you have fewer cards in your hand than your opponent does, you draw until you have the same number. (When you play Balance of Power it doesn't count as in your hand.)",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "3c6ac177-8efe-5efb-92c3-1ce1b25e215b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b5362a-bbca-4dc3-a320-3664609fe169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b5362a-bbca-4dc3-a320-3664609fe169.jpg?1",
             "name": "Borrowing 100,000 Arrows",
             "text": "For each tapped creature your opponent has in play, you draw a card.",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "30314223-eb68-5db4-9a37-48850e83a464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg?1",
             "name": "Brilliant Plan",
             "text": "Draw three cards.",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "5e7682c0-42e8-5749-ba08-5046715825ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b8b1-f1dc-46a3-8f4a-c6181e8a049f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b8b1-f1dc-46a3-8f4a-c6181e8a049f.jpg?1",
             "name": "Broken Dam",
             "text": "Tap any one or two creatures without horsemanship. (Tapped creatures can't block.)",
             "colours": [
@@ -1230,7 +1230,7 @@
         },
         {
             "id": "79af494f-06c2-520c-97cd-0e54c10ed3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2df84f2-08e8-43e4-825f-dccfe096d92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2df84f2-08e8-43e4-825f-dccfe096d92b.jpg?1",
             "name": "Capture of Jingzhou",
             "text": "You take another turn after this one.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "85ed4573-25f5-50bb-9c06-5c5c0a390a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451ef657-8590-497a-9d98-a732d4de6165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451ef657-8590-497a-9d98-a732d4de6165.jpg?1",
             "name": "Champion's Victory",
             "text": "Play Champion's Victory only after you're attacked, before you declare blockers.\nReturn any one attacking creature to its owner's hand.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "1c5f4d7b-5834-5eba-b171-b1db2a5735a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59f45b-46fa-4494-9b25-cf9d3e462539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59f45b-46fa-4494-9b25-cf9d3e462539.jpg?1",
             "name": "Council of Advisors",
             "text": "When Council of Advisors comes into play, draw a card.",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "85056678-6c67-5d26-b177-e74f2fec75a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbeafb-ef84-4a8d-9ca8-ca305b1feeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbeafb-ef84-4a8d-9ca8-ca305b1feeea.jpg?1",
             "name": "Counterintelligence",
             "text": "Return any one or two creatures to their owner's hand.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "fd6b2bbc-dace-52d8-98fe-c8b4b984245f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad34ed-c811-432d-b9c7-bff7c024cd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad34ed-c811-432d-b9c7-bff7c024cd4f.jpg?1",
             "name": "Exhaustion",
             "text": "At the beginning of your opponent's next turn, he or she skips untapping creatures and lands.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "df74fa32-b524-52a4-8d5b-b07846af46c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21140417-09f5-4d05-b94c-355fde9b4719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21140417-09f5-4d05-b94c-355fde9b4719.jpg?1",
             "name": "Extinguish",
             "text": "Play Extinguish only in response to another player playing a sorcery.\nThat sorcery has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "56cc2b80-f49e-521b-ad50-270d8a6291fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9753d211-3436-4a9b-86d9-54a541770ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9753d211-3436-4a9b-86d9-54a541770ec2.jpg?1",
             "name": "Forced Retreat",
             "text": "Return any one creature from play to the top of its owner's library.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "6bded0a1-5a83-5f68-b252-681e5de7ce1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f45e837-7b98-46ef-b21b-e3508ce999e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f45e837-7b98-46ef-b21b-e3508ce999e5.jpg?1",
             "name": "Lady Sun",
             "text": "On your turn, before you attack, you may tap Lady Sun to return it and any one other creature to their owners' hands.",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "c12e8ed9-4118-5e5e-b499-5ee8e94de24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg?1",
             "name": "Lu Meng, Wu General",
             "text": "Horsemanship",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "cefa3821-0268-5936-a558-cf4b2ff943b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg?1",
             "name": "Lu Su, Wu Advisor",
             "text": "On your turn, before you attack, you may tap Lu Su to draw a card.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "b5d585f3-32a2-5703-bebd-440e3be91780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0882d4c8-32f1-4d86-b5c5-75a16697004c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0882d4c8-32f1-4d86-b5c5-75a16697004c.jpg?1",
             "name": "Lu Xun, Scholar General",
             "text": "Horsemanship\nWhen Lu Xun successfully damages your opponent, you may draw a card.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "c5ba9f9e-2725-533e-9100-4b52b4c448da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1296ddc4-300d-44f6-95d8-1b392613d379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1296ddc4-300d-44f6-95d8-1b392613d379.jpg?1",
             "name": "Mystic Denial",
             "text": "Play Mystic Denial only in response to another player playing a creature or a sorcery. That card has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "eb5e99c0-6bee-5b59-a8d2-66ccc09668f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2314bf1-b22d-48c2-860f-e1081f56296b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2314bf1-b22d-48c2-860f-e1081f56296b.jpg?1",
             "name": "Preemptive Strike",
             "text": "Play Preemptive Strike only in response to another player playing a creature card.\nThat creature has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "cd5009f9-87c4-559c-a8b5-571794780ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fe0f33-35c7-439b-bece-4a9461b92352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fe0f33-35c7-439b-bece-4a9461b92352.jpg?1",
             "name": "Red Cliffs Armada",
             "text": "Red Cliffs Armada can't attack unless the defending player has an island in play.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "f029413b-2d2a-5e6b-a7c9-95643d1c7683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156d7c70-6c6d-4052-9d44-029ba1bb66e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156d7c70-6c6d-4052-9d44-029ba1bb66e4.jpg?1",
             "name": "Sage's Knowledge",
             "text": "Return any one sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "938d621f-db7a-5e1c-9b48-f69c4e9aeb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7727e7b5-39a3-46ba-935b-ee093c694c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7727e7b5-39a3-46ba-935b-ee093c694c38.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1752,7 +1752,7 @@
         },
         {
             "id": "75a802e3-7538-5e65-bd8a-4a09692bdb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae5ba21-eb8e-4663-bfd8-3e19a0c10774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae5ba21-eb8e-4663-bfd8-3e19a0c10774.jpg?1",
             "name": "Straw Soldiers",
             "text": "",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "c3f11ece-154b-5598-a446-d03409b073df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg?1",
             "name": "Sun Ce, Young Conquerer",
             "text": "Horsemanship\nWhen Sun Ce comes into play, you may return any one creature from play to its owner's hand.",
             "colours": [
@@ -1822,7 +1822,7 @@
         },
         {
             "id": "a71cb10d-6d11-58b7-934f-448156036f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def4492-3f67-4cdb-8a25-c3ddebd125c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def4492-3f67-4cdb-8a25-c3ddebd125c7.jpg?1",
             "name": "Sun Quan, Lord of Wu",
             "text": "All your creatures gain horsemanship as long as Sun Quan is in play. (This includes Sun Quan.)",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "f0eb8d93-0391-513e-83ad-4f3ee4cf5909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ae191-80ac-42bf-b49d-db343803bd56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ae191-80ac-42bf-b49d-db343803bd56.jpg?1",
             "name": "Wu Admiral",
             "text": "As long as your opponent has an island in play, Wu Admiral gets +1/+1.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "6a9280b6-2956-5642-8e81-c02879ce5272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf562e2-be8e-4514-b2c8-3268dc1ab0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf562e2-be8e-4514-b2c8-3268dc1ab0db.jpg?1",
             "name": "Wu Elite Cavalry",
             "text": "Horsemanship",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "484abf49-9192-5a71-b9c0-d0ba12157110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe4115e-7ca3-4996-a390-133c2e6d09b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe4115e-7ca3-4996-a390-133c2e6d09b7.jpg?1",
             "name": "Wu Infantry",
             "text": "",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "2a1a09e2-bf18-553f-879f-2afe33f645e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e55b25-fde2-4b57-b5db-65b75262ff3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e55b25-fde2-4b57-b5db-65b75262ff3d.jpg?1",
             "name": "Wu Light Cavalry",
             "text": "Horsemanship",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "93ed7a23-82f7-5eba-98a2-fc044f36930e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e68635-b0ed-4a56-8b18-679f95db12b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e68635-b0ed-4a56-8b18-679f95db12b6.jpg?1",
             "name": "Wu Longbowman",
             "text": "On your turn, before you attack, you may tap Wu Longbowman to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -2029,7 +2029,7 @@
         },
         {
             "id": "d5b3293d-cd53-57d6-82a7-a4b6ce115ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d13330f-6e07-451f-b17a-4e1606a74c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d13330f-6e07-451f-b17a-4e1606a74c3f.jpg?1",
             "name": "Wu Scout",
             "text": "Horsemanship\nWhen Wu Scout comes into play, look at your opponent's hand.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "8dd467ed-b1e5-57c6-8e52-540726b1bf3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77b8e34-e7e9-4ac6-bc21-0ef52c6696c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77b8e34-e7e9-4ac6-bc21-0ef52c6696c7.jpg?1",
             "name": "Wu Spy",
             "text": "When Wu Spy comes into play, look at the top two cards of any player's library. Put one of them on the top of that player's library and the other in his or her graveyard.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "01972011-ea46-544c-a6d4-33877acb697e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e211d47-dab4-429a-a90b-5b8489441886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e211d47-dab4-429a-a90b-5b8489441886.jpg?1",
             "name": "Wu Warship",
             "text": "Wu Warship can't attack unless the defending player has an island in play.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "8535386f-520e-5c5d-b4b3-8007f2b34e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg?1",
             "name": "Zhou Yu, Chief Commander",
             "text": "Zhou Yu can't attack unless your opponent has an island in play.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "803a0851-06da-57ac-98fb-dde59f138a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg?1",
             "name": "Zhuge Jin, Wu Strategist",
             "text": "On your turn, before you attack, you may tap Zhuge Jin to make any one creature unblockable this turn.",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "28549153-dc56-5d84-9ea0-103c356f9561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0b1613-e879-4c28-b27e-f3997b9ebccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0b1613-e879-4c28-b27e-f3997b9ebccd.jpg?1",
             "name": "Ambition's Cost",
             "text": "Draw three cards. You lose 3 life.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "0176a59d-b4ba-5d13-9edb-24e95f5283d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e5a530-c954-4696-85ce-6afaf7de1808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e5a530-c954-4696-85ce-6afaf7de1808.jpg?1",
             "name": "Cao Cao, Lord of Wei",
             "text": "On your turn, before you attack, you may tap Cao Cao to force your opponent to choose and discard two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "0bafd599-9c98-5457-87f0-b55bd00163f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg?1",
             "name": "Cao Ren, Wei Commander",
             "text": "Horsemanship\nWhen Cao Ren comes into play, you lose 3 life.",
             "colours": [
@@ -2309,7 +2309,7 @@
         },
         {
             "id": "fa9e4f50-37ba-524d-b9fd-696689a9b112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a193b33-0db2-411d-8f91-2247cb2d924a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a193b33-0db2-411d-8f91-2247cb2d924a.jpg?1",
             "name": "Coercion",
             "text": "Look at your opponent's hand and choose a card from it. Your opponent discards that card.",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "880cf404-f7ca-5661-9f4d-8fcba7abc28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3ba2e3-e680-47cd-81c5-555deea7d00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3ba2e3-e680-47cd-81c5-555deea7d00f.jpg?1",
             "name": "Corrupt Court Official",
             "text": "When Corrupt Official comes into play, your opponent chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "76c93178-d55a-5f0e-b25c-e95361f0eb3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e31ede4-b0bb-4f63-b8df-1330152611a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e31ede4-b0bb-4f63-b8df-1330152611a4.jpg?1",
             "name": "Cunning Advisor",
             "text": "On your turn, before you attack, you may tap Cunning Advisor to force your opponent to choose and discard a card from his or her hand.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "7d4e58f6-faf8-55e3-a805-090fc9188dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63768-2d8a-4a74-a312-b981dd462cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63768-2d8a-4a74-a312-b981dd462cdc.jpg?1",
             "name": "Deception",
             "text": "Your opponent chooses and discards two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "d0affbb9-9c42-519a-8c5c-538f994bf260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5587089-b17e-4187-97aa-1c3eec070a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5587089-b17e-4187-97aa-1c3eec070a0b.jpg?1",
             "name": "Desperate Charge",
             "text": "All your creatures get +2/+0 until the end of the turn.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "1195f32a-a1c4-594e-9154-2aa3d8fb56fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6c10ca-f6d6-4322-aa17-7e874cb10bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6c10ca-f6d6-4322-aa17-7e874cb10bb1.jpg?1",
             "name": "Famine",
             "text": "Famine deals 3 damage to each creature and player. (This includes your creatures and you.)",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "e351f4d2-fe0a-5e34-9746-771e1f4388cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6938a-229a-4521-b5d5-7999ce5fb372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6938a-229a-4521-b5d5-7999ce5fb372.jpg?1",
             "name": "Ghostly Visit",
             "text": "Destroy any one creature that isn't black.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "a96fdd10-7aee-5ea3-ba87-ba99be1b549b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a7f91d-b4ee-45c1-a229-bb23daf68e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a7f91d-b4ee-45c1-a229-bb23daf68e6b.jpg?1",
             "name": "Imperial Edict",
             "text": "Your opponent chooses one of his or her creatures. Destroy that creature.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "79d1f5fb-ee62-5bc8-b6ea-52400714263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e30db-40c5-4099-868b-185ad9b7c7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e30db-40c5-4099-868b-185ad9b7c7dc.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for any one card. Shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "02588e8d-8e3a-5ace-ba23-a51b6d09ad31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56c7fb4-8b7b-40fc-879c-76cfb5d417b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56c7fb4-8b7b-40fc-879c-76cfb5d417b8.jpg?1",
             "name": "Overwhelming Forces",
             "text": "Destroy all your opponent's creatures. you draw a card for each creature destroyed in this way.",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "d87a62c6-fb48-502c-9101-ff1a624e6bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7b5f34-c250-484e-9bae-94789b2a87fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7b5f34-c250-484e-9bae-94789b2a87fb.jpg?1",
             "name": "Poison Arrow",
             "text": "Destroy any one creature that isn't black. You gain 3 life.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "33ebc68a-b941-52f7-ba79-85288272551a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1841e615-fdcd-4187-bd69-d07abde0e1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1841e615-fdcd-4187-bd69-d07abde0e1ae.jpg?1",
             "name": "Return to Battle",
             "text": "Return any one creature card from your graveyard to your hand.",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "f8116aa3-0d13-5473-8127-37995143d5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg?1",
             "name": "Sima Yi, Wei Field Marshal",
             "text": "Sima Yi has power equal to the number of swamp cards you have in play. (This includes both tapped and untapped swamp cards.)",
             "colours": [
@@ -2723,7 +2723,7 @@
         },
         {
             "id": "b7f5a3c1-d008-5ddc-8c79-4e4dbe780d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f08862-5107-46a0-8c14-a961a5c4b135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f08862-5107-46a0-8c14-a961a5c4b135.jpg?1",
             "name": "Stolen Grain",
             "text": "Stolen Grain deals 5 damage to your opponent. You gain 5 life.",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "ea114b43-7070-5252-a2c3-ef9e93503d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60303bfe-9158-4e25-a905-6522883ab671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60303bfe-9158-4e25-a905-6522883ab671.jpg?1",
             "name": "Stone Catapult",
             "text": "On your turn, before you attack, you may tap Stone Catapult to destroy any one tapped creature that isn't black.",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "3209612e-055d-50fc-8706-30efec9ac184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b241ba4-cff5-48ce-83bd-d70fb5e20ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b241ba4-cff5-48ce-83bd-d70fb5e20ff4.jpg?1",
             "name": "Wei Ambush Force",
             "text": "When Wei Ambush Force attacks, it gets +2/+0 until the end of the turn.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "547b3eea-b531-55a9-a3bc-db3300adaf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b448c08-140f-41d6-aed5-ce9b68efafa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b448c08-140f-41d6-aed5-ce9b68efafa9.jpg?1",
             "name": "Wei Assassins",
             "text": "When Wei Assassins comes into play, your opponent chooses one of his or her creatures. Destroy that creature. (Ignore this effect if your opponent has no creatures in play.)",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "52708cdf-2e84-5f41-9ae7-886998333a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843cbf18-60ac-4d97-b156-874735db61c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843cbf18-60ac-4d97-b156-874735db61c6.jpg?1",
             "name": "Wei Elite Companions",
             "text": "Horsemanship",
             "colours": [
@@ -2891,7 +2891,7 @@
         },
         {
             "id": "64568a6f-0708-5b54-9f0a-8cfc6745e8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6465f-3144-4faf-b248-a9fb941dc002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6465f-3144-4faf-b248-a9fb941dc002.jpg?1",
             "name": "Wei Infantry",
             "text": "",
             "colours": [
@@ -2925,7 +2925,7 @@
         },
         {
             "id": "58c7ceaa-2c45-5a8b-9e09-74d1a4dbcfe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a0292e-ecf4-42df-8abf-f4479f8ad6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a0292e-ecf4-42df-8abf-f4479f8ad6cb.jpg?1",
             "name": "Wei Night Raiders",
             "text": "Horsemanship\nWhen Wei Night Raiders successfully damages your opponent, he or she chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "bdaba705-26fa-5428-a14f-1686aebc5744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d58fb-fb70-4e8f-8f64-232ad2c1f59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d58fb-fb70-4e8f-8f64-232ad2c1f59b.jpg?1",
             "name": "Wei Scout",
             "text": "Horsemanship",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "8cf06c52-5132-5102-9954-5e78c64c8111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eae8ce1-b21f-4d64-91ff-e98bf6a4548a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eae8ce1-b21f-4d64-91ff-e98bf6a4548a.jpg?1",
             "name": "Wei Strike Force",
             "text": "Horsemanship",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "3163a015-f521-563d-8d9d-506df92b41de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bed8a9-ede6-4fdc-966e-d1e4261c68e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bed8a9-ede6-4fdc-966e-d1e4261c68e4.jpg?1",
             "name": "Xiahou Dun, the One-Eyed",
             "text": "Horsemanship\nOn your turn, before you attack, you may put Xiahou Dun into your graveyard to return a black card from your graveyard to your hand.",
             "colours": [
@@ -3064,7 +3064,7 @@
         },
         {
             "id": "af810a66-5ff3-5615-866b-d2ea429a5232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg?1",
             "name": "Xun Yu, Wei Advisor",
             "text": "On your turn, before you attack, you may tap Xun Yu to give one of your creatures +2/+0 until the end of the turn.",
             "colours": [
@@ -3100,7 +3100,7 @@
         },
         {
             "id": "cddb37c7-0a48-5b9d-94d1-321b6bd13be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11431c4c-b0bb-4747-a34a-4a90238ec9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11431c4c-b0bb-4747-a34a-4a90238ec9c6.jpg?1",
             "name": "Young Wei Recruits",
             "text": "Young Wei Recruits can't block.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "437ba741-5494-5077-8c6a-95b9395caf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e4bf1-fee9-47cc-9bbc-093f21c77297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e4bf1-fee9-47cc-9bbc-093f21c77297.jpg?1",
             "name": "Zhang He, Wei General",
             "text": "Horsemanship\nWhen Zhang He attacks, all your other creatures get +1/+0 until the end of the turn.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "77dfcd44-6ebb-5312-8818-d9b1cf3efd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42a953-3073-4e74-9bb8-c8c5a45d1dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42a953-3073-4e74-9bb8-c8c5a45d1dfa.jpg?1",
             "name": "Zhang Liao, Hero of Hefei",
             "text": "When Zhang Liao successfully damages your opponent, he or she chooses and discard a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "e7567865-e5fb-5256-99fd-327a1e005ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e364b5-55ca-4df5-8755-6643218b0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e364b5-55ca-4df5-8755-6643218b0969.jpg?1",
             "name": "Zodiac Pig",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Pig can't be blocked.)",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "a83be79b-0a90-570b-bff4-46b95d38fe53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6e5814-e1b5-48d2-9c4f-62b5727f333f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6e5814-e1b5-48d2-9c4f-62b5727f333f.jpg?1",
             "name": "Zodiac Rat",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Rat can't be blocked.)",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "276e2354-304b-523f-9a6d-bc67c6bd0c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d30d6f0-ca4c-4442-a47f-ecdf52088ecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d30d6f0-ca4c-4442-a47f-ecdf52088ecc.jpg?1",
             "name": "Zodiac Snake",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Snake can't be blocked.)",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "33758738-ca23-5aa2-9c07-a48fd63939d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060da652-03c7-45e3-ad83-f0a9fa9d1049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060da652-03c7-45e3-ad83-f0a9fa9d1049.jpg?1",
             "name": "Barbarian General",
             "text": "Horsemanship",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "719b88f2-fdc1-5ca2-aa15-e3b436a30776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f930c2-e828-4566-b2df-3b054f311be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f930c2-e828-4566-b2df-3b054f311be5.jpg?1",
             "name": "Barbarian Horde",
             "text": "",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "38b02df8-69bf-5742-b881-72afeffed172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b6cfd3-4fb1-40a7-a090-de6f8b283cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b6cfd3-4fb1-40a7-a090-de6f8b283cb3.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player.",
             "colours": [
@@ -3406,7 +3406,7 @@
         },
         {
             "id": "90cb37b6-c1d8-5903-86a5-c4e4de40fc7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee12f01-581e-4a3c-a8b5-41bef2516781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee12f01-581e-4a3c-a8b5-41bef2516781.jpg?1",
             "name": "Burning Fields",
             "text": "Burning Fields deals 5 damage to your opponent.",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "68501ed1-94c5-5cb0-ad14-36356707001c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a1fe45-52d2-4c50-bedc-eee156ab69c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a1fe45-52d2-4c50-bedc-eee156ab69c8.jpg?1",
             "name": "Burning of Xinye",
             "text": "You destroy four of your lands and your opponent destroys four of his or her lands. Then Burning of Xinye deals 4 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -3468,7 +3468,7 @@
         },
         {
             "id": "63b912d9-30e0-5860-9db2-90592396a13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4f0005-4f19-4352-9cd2-3993ae6db879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4f0005-4f19-4352-9cd2-3993ae6db879.jpg?1",
             "name": "Control of the Court",
             "text": "Draw four cards and put them into your hand. Then discard three cards at random from your hand.",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "e1a70b79-2441-55ce-bdd5-ad9a93f7e587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e084664-2faf-4f7a-9068-d58d3f4b8456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e084664-2faf-4f7a-9068-d58d3f4b8456.jpg?1",
             "name": "Corrupt Eunuchs",
             "text": "When Corrupt Eunuchs comes into play, it deals 2 damage to any one creature. (If you're the only one with creatures, deal the damage to one of them.)",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "8b350151-a93d-5c9b-a807-2931edb120fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588ad2bf-405d-4c36-b485-e415c22f2703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588ad2bf-405d-4c36-b485-e415c22f2703.jpg?1",
             "name": "Desert Sandstorm",
             "text": "Desert Sandstorm deals 1 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "d9fb3856-addd-5ca1-9a27-9c6a09426d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6180c476-dadf-4c03-ab1e-639386bd4319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6180c476-dadf-4c03-ab1e-639386bd4319.jpg?1",
             "name": "Diaochan, Artful Beauty",
             "text": "On your turn, before you attack, you may tap Diaochan to destroy any one creature. Then, your opponent destroys any one creature of his or her choice.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "8ed16cc7-6668-5da9-9154-f4b60773ae97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ccdca0-2c29-4b5c-ba5a-364cc6945801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ccdca0-2c29-4b5c-ba5a-364cc6945801.jpg?1",
             "name": "Dong Zhou, the Tyrant",
             "text": "When Dong Zhou comes into play, choose one of your opponent's creatures. That creature deals damage to him or her equal to its power. (Ignore this effect if your opponent doesn't have any creatures in play.)",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "e6bfaaa2-dc10-5496-a8fe-e4d117e112f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7ca92f-770d-4147-8eaf-f1fa69340dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7ca92f-770d-4147-8eaf-f1fa69340dc9.jpg?1",
             "name": "Eunuchs' Intrigues",
             "text": "Your opponent chooses one of his or her creatures. Only that creature can block this turn.",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "c8efc191-84ff-55dd-a07e-675461207ca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8bdbd-99c9-4fa7-936a-acc7f4238507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8bdbd-99c9-4fa7-936a-acc7f4238507.jpg?1",
             "name": "Fire Ambush",
             "text": "Fire Ambush deals 3 damage to any one creature or player.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "03338dd9-fffb-51e5-8a32-9274dd7673e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acc721-e9ae-4ba4-b435-754e41fb541e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acc721-e9ae-4ba4-b435-754e41fb541e.jpg?1",
             "name": "Fire Bowman",
             "text": "On your turn, before you attack, you may destroy Fire Bowman to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "8e71a983-531a-5b54-b697-47ec0aabe503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c473253-3992-4cc1-8b46-5d1da308c537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c473253-3992-4cc1-8b46-5d1da308c537.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter comes into play, search your library for a creature card with power no greater than 2, reveal that card, and put it into your hand. Shuffle your library afterward.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "f56b0bda-3f05-55bc-b6ae-a1bc3ad36437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7a4769-7a64-4016-8db0-b56c6b98aff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7a4769-7a64-4016-8db0-b56c6b98aff3.jpg?1",
             "name": "Independent Troops",
             "text": "",
             "colours": [
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "06b30f55-2632-5a19-a87d-1d6f501030f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d60c27-8625-48eb-a3f0-1e26d6930ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d60c27-8625-48eb-a3f0-1e26d6930ae7.jpg?1",
             "name": "Lu Bu, Master-at-Arms",
             "text": "Horsemanship\nLu Bu is unaffected by summoning sickness.",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "32cb68b3-fa51-5838-be53-56cbb2bec115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf7f-8c40-40e9-8118-e8626c3c6433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf7f-8c40-40e9-8118-e8626c3c6433.jpg?1",
             "name": "Ma Chao, Western Warrior",
             "text": "Horsemanship\nWhenever Ma Chao attacks and no other creatures do, Ma Chao can't be blocked.",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "3df53f2c-a86d-52a7-961e-116518c8d8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd541d-9956-4595-9527-a83db4c5f74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd541d-9956-4595-9527-a83db4c5f74f.jpg?1",
             "name": "Mountain Bandit",
             "text": "Mountain Bandit is unaffected by summoning sickness.",
             "colours": [
@@ -3910,7 +3910,7 @@
         },
         {
             "id": "15cc12b2-3eda-5fd9-8d10-2e14d2485185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6278d679-fc54-4527-ab16-90735574ab9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6278d679-fc54-4527-ab16-90735574ab9b.jpg?1",
             "name": "Ravaging Horde",
             "text": "When Ravaging Horde comes into play, destroy any one land.",
             "colours": [
@@ -3944,7 +3944,7 @@
         },
         {
             "id": "7d09ec3e-7d39-5038-8f26-7f43d1cea638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f23cc3-da79-4e08-964f-b52815c40990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f23cc3-da79-4e08-964f-b52815c40990.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You may declare an additional attack this turn.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "2bbec8b2-0de8-52e9-a243-69920f869c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75095f4-a77f-4237-ae25-2e6f2f8788c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75095f4-a77f-4237-ae25-2e6f2f8788c1.jpg?1",
             "name": "Renegade Troops",
             "text": "Renegade Troops is unaffected by summoning sickness.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "9c5bdad2-85d7-5557-b08a-190c6557af14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5faf1-25c9-46c0-88f2-c59e7b9c08c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5faf1-25c9-46c0-88f2-c59e7b9c08c5.jpg?1",
             "name": "Rockslide Ambush",
             "text": "Rockslide Ambush deals to any one creature damage equal to the number of mountain cards you have in play. (This includes both tapped and untapped mountain cards.)",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "3791cca6-ed91-5dac-a6f9-acb56e61b4bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1bf210-ecdb-4b49-8504-51360c269e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1bf210-ecdb-4b49-8504-51360c269e66.jpg?1",
             "name": "Rolling Earthquake",
             "text": "Rolling Earthquake deals X damage to each player and each creature without horsemanship. (This includes you and your creatures without horsemanship.)",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "bad3fdc3-326f-5a01-90b4-6357d6a464a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67738ab8-75cf-4ea1-aa1d-b840d94b2601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67738ab8-75cf-4ea1-aa1d-b840d94b2601.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy any one land.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "cce8b731-6dd3-5811-9a4f-4ed41670047f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d582861a-ca6e-4b74-adf0-3eb588ea5ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d582861a-ca6e-4b74-adf0-3eb588ea5ed2.jpg?1",
             "name": "Warrior's Oath",
             "text": "Take another turn after this one. At the end of that turn, you lose the game. (You don't lose if you've already won.)",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "b263322b-b6fb-5976-ac4a-7592bf95f2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84460666-4f6b-422c-b20e-dc1651c66e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84460666-4f6b-422c-b20e-dc1651c66e15.jpg?1",
             "name": "Yellow Scarves Cavalry",
             "text": "Horsemanship\nYellow Scarves Cavalry can't block.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "bddd1c3e-e3e4-5d4c-829b-88fb10b8025f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg?1",
             "name": "Yellow Scarves General",
             "text": "Horsemanship\nYellow Scarves General can't block.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "54438a3b-2052-5c3b-b566-39d1192bd48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca36a8d-ca44-485e-a219-85814f160c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca36a8d-ca44-485e-a219-85814f160c4d.jpg?1",
             "name": "Yellow Scarves Troops",
             "text": "Yellow Scarves Troops can't block.",
             "colours": [
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "89c90fc6-b343-5dc2-8036-38a58e633dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9b3794-d0f0-4d28-85cb-22492e195ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9b3794-d0f0-4d28-85cb-22492e195ae1.jpg?1",
             "name": "Yuan Shao, the Indecisive",
             "text": "Horsemanship\nEach of your creatures can't be blocked by more than one creature each turn as long as Yuan Shao is in play.",
             "colours": [
@@ -4271,7 +4271,7 @@
         },
         {
             "id": "d0b7faaa-9940-5af2-a71e-e63acf3248f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2623481-cee3-4a9d-933b-235fcde9a27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2623481-cee3-4a9d-933b-235fcde9a27b.jpg?1",
             "name": "Yuan Shao's Infantry",
             "text": "Whenever Yuan Shao's Infantry attacks and no other creatures do, Yuan Shao's Infantry can't be blocked.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "3879e971-4e75-5664-a431-b244dcaa2dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61aa62-25ee-40a4-9b6e-d6277316b464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61aa62-25ee-40a4-9b6e-d6277316b464.jpg?1",
             "name": "Zodiac Dog",
             "text": "Mountainwalk (If defending player has a mountain in play, Zodiac Dog can't be blocked.)",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "45515ae3-e32e-5f20-ad76-573125398107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46652ae3-6572-4296-939b-0789923180d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46652ae3-6572-4296-939b-0789923180d5.jpg?1",
             "name": "Zodiac Dragon",
             "text": "If Zodiac Dragon is put into your graveyard, you may return Zodiac Dragon to your hand.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "f6cfe841-abc3-5eee-a4ab-ffe84b201689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510462-2802-4e16-87d4-da376ee2e3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510462-2802-4e16-87d4-da376ee2e3be.jpg?1",
             "name": "Zodiac Goat",
             "text": "Mountainwalk (If defending player has a mountain in play, Zodiac Goat can't be blocked.)",
             "colours": [
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "0f0a4ff2-f9fd-54fb-8af3-cb9fc9dcca7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg?1",
             "name": "Borrowing the East Wind",
             "text": "Borrowing the East Wind deals X damage to each player and each creature with horsemanship. (This includes you and your creatures with horsemanship.)",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "3bb416e9-79e3-5bd4-9a5a-76f96dae5c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bdfefb-f2e2-409c-b5e1-66d24ab3ee5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bdfefb-f2e2-409c-b5e1-66d24ab3ee5d.jpg?1",
             "name": "False Mourning",
             "text": "Take any one card from your graveyard and put that card on the top of your library.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "15a8f0ec-7112-5009-bf9f-163a736d2ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae9abc7-ecd3-4042-a5b0-5f2b24491fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae9abc7-ecd3-4042-a5b0-5f2b24491fa6.jpg?1",
             "name": "Forest Bear",
             "text": "",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "3b4639d6-1c9a-5648-8f7c-f53624a7886b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499fee7b-1942-4eb9-b1d0-806a1f6c0cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499fee7b-1942-4eb9-b1d0-806a1f6c0cd8.jpg?1",
             "name": "Heavy Fog",
             "text": "Play Heavy Fog only after you're attacked, before you declare blockers.\nThis turn, all damage dealt to you by attacking creatures is reduced to 0.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "3f1cf845-98f4-5abf-a517-ca8528cfe9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9c02e-f569-43b5-929a-ec04f661f644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9c02e-f569-43b5-929a-ec04f661f644.jpg?1",
             "name": "Hua Tuo, Honored Physician",
             "text": "On your turn, before you attack, you may tap Hua Tuo to put any one creature card from your graveyard on the top of your library.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "13d51e3f-b660-53b8-8184-c0673514be6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a63628-17e6-4845-96b4-c82c3e7e8fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a63628-17e6-4845-96b4-c82c3e7e8fb5.jpg?1",
             "name": "Hunting Cheetah",
             "text": "When Hunting Cheetah successfully damages your opponent, you may search your library for a forest card, reveal that card, and put it into your hand. Shuffle your library afterward.",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "eb3ae076-241e-52e6-9ef5-a186633a08e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg?1",
             "name": "Lady Zhurong, Warrior Queen",
             "text": "Horsemanship",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "2fbda095-87a1-5ee4-a87b-3a9c3d16d465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d085684-aabf-4b63-a0b3-3deb4679909b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d085684-aabf-4b63-a0b3-3deb4679909b.jpg?1",
             "name": "Lone Wolf",
             "text": "When Lone Wolf attacks and is blocked, you may have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "35808f6c-d5ec-532a-a7c6-89736d1517a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e4df87-7908-4274-a07f-81d42be89f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e4df87-7908-4274-a07f-81d42be89f18.jpg?1",
             "name": "Marshaling the Troops",
             "text": "Tap any number of your creatures. You gain 4 life for each creature tapped this way. (Tapped creatures can't block.)",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "1c2008ae-6f0a-5396-9eee-3b4378192128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340647c-fb6d-45a6-9f42-235390b40337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340647c-fb6d-45a6-9f42-235390b40337.jpg?1",
             "name": "Meng Huo, Barbarian King",
             "text": "All your other green creatures get +1/+1 as long as Meng Huo is in play.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "343fad84-43a5-51d0-88be-efe149f4d2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1642802-055e-44d2-a261-c2a45ad515e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1642802-055e-44d2-a261-c2a45ad515e8.jpg?1",
             "name": "Meng Huo's Horde",
             "text": "",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "ed4e9a4a-3e45-5e66-9f09-8ea39f8de36b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fea93-7f39-4fc7-89ab-bb3ea3f15951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fea93-7f39-4fc7-89ab-bb3ea3f15951.jpg?1",
             "name": "Riding the Dilu Horse",
             "text": "Any one creature gets +2/+2 and gains horsemanship.",
             "colours": [
@@ -4801,7 +4801,7 @@
         },
         {
             "id": "1f37cc04-01db-57aa-96ff-1728f9207f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg?1",
             "name": "Slashing Tiger",
             "text": "When Slashing Tiger attacks and is blocked, it gets +2/+2 until the end of the turn.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "5682cb75-ef16-5a53-bb7b-b36843ebfb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e138c7-1166-4e20-b039-e94c1319ad42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e138c7-1166-4e20-b039-e94c1319ad42.jpg?1",
             "name": "Southern Elephant",
             "text": "",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "11eee547-45f2-55d8-a7d3-7227e3ca0440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ed2d85-0e28-40d1-bd44-d36caa0d4e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ed2d85-0e28-40d1-bd44-d36caa0d4e31.jpg?1",
             "name": "Spoils of Victory",
             "text": "Search your library for a plains, island, swamp, mountain, or forest card and put that land into play. Shuffle your library afterward.",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "8830dfe3-371b-5763-ab14-cbedab2b4735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6862d7a-04ee-48ac-a5b3-46a4e8694d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6862d7a-04ee-48ac-a5b3-46a4e8694d5b.jpg?1",
             "name": "Spring of Eternal Peace",
             "text": "You gain 8 life.",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "ae04be01-827e-5ed1-86eb-af0c3bbbd464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d39e5c-40c7-4f1a-8576-c8b4d12a4bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d39e5c-40c7-4f1a-8576-c8b4d12a4bbc.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be blocked by more than one creature each turn.",
             "colours": [
@@ -4962,7 +4962,7 @@
         },
         {
             "id": "d982995b-6daa-5758-a89f-eeb615c8112f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d818c231-8d66-4024-91de-fe29f8622902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d818c231-8d66-4024-91de-fe29f8622902.jpg?1",
             "name": "Taoist Hermit",
             "text": "Whenever your opponent chooses a creature in play, he or she can't choose Taoist Hermit.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "a5f9db41-3fd4-5cce-aba0-603e7958f642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg?1",
             "name": "Taoist Mystic",
             "text": "Taoist Mystic can't be blocked by creatures with horsemanship.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "db08ba19-fae8-59ba-95f1-abcbcee328fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg?1",
             "name": "Taunting Challenge",
             "text": "Choose any one creature. This turn, all creatures able to block it do so.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "cec6666d-6ebf-5b90-9e89-bfad2388de08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306d22ae-657e-4b52-8cd9-6fc3df9e8376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306d22ae-657e-4b52-8cd9-6fc3df9e8376.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a forest card and put that forest into play. Shuffle your library afterward.",
             "colours": [
@@ -5092,7 +5092,7 @@
         },
         {
             "id": "e42b2dd5-284d-566c-bb64-75ae7c11a90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab242eab-5cab-41a0-bcf8-93a6919e4558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab242eab-5cab-41a0-bcf8-93a6919e4558.jpg?1",
             "name": "Trained Cheetah",
             "text": "When Trained Cheetah attacks and is blocked, it gets +1/+1 until the end of the turn.",
             "colours": [
@@ -5125,7 +5125,7 @@
         },
         {
             "id": "3d8259ff-3ed9-5daa-885a-5f1656e7328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01deb3cc-91e8-4ef3-964f-f36c6a21207c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01deb3cc-91e8-4ef3-964f-f36c6a21207c.jpg?1",
             "name": "Trained Jackal",
             "text": "",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "1e08d1c4-d4b6-5d44-8e93-69dd7ec565ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb1e16f-002e-4a81-ba41-cfe41f3a9071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb1e16f-002e-4a81-ba41-cfe41f3a9071.jpg?1",
             "name": "Trip Wire",
             "text": "Destroy any one creature with horsemanship.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "c2daffe0-8be9-5e88-9011-8c2be34f0a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b138167-8129-4109-a58b-af26c95577e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b138167-8129-4109-a58b-af26c95577e4.jpg?1",
             "name": "Wielding the Green Dragon",
             "text": "Any one creature gets +4/+4 until the end of the turn.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "20a5de2a-5f50-54cd-b8ac-cab2bdb17309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f395d-0827-4f62-b117-4766d4ab5dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f395d-0827-4f62-b117-4766d4ab5dca.jpg?1",
             "name": "Wolf Pack",
             "text": "When Wolf Pack attacks and is blocked, you may have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "4b2f29a9-172a-5433-ad32-034c963f46fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24cb19-3409-45f7-b0e0-7c652064d2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24cb19-3409-45f7-b0e0-7c652064d2dd.jpg?1",
             "name": "Zodiac Horse",
             "text": "Islandwalk (If defending player has an island in play, Zodiac Horse can't be blocked.)",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "9a1828e6-e633-5b65-bbe0-fdb05e0de545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e98eb0b-c3b5-4561-b8a2-f22bd0fe1115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e98eb0b-c3b5-4561-b8a2-f22bd0fe1115.jpg?1",
             "name": "Zodiac Monkey",
             "text": "Forestwalk (If defending player has a forest in play, Zodaic Monkey can't be blocked.)",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "6ddca5f3-8985-52c4-b225-63830103161c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a731b3a-0065-448d-841c-28700d78a4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a731b3a-0065-448d-841c-28700d78a4fd.jpg?1",
             "name": "Zodiac Ox",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Ox can't be blocked.)",
             "colours": [
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "e6febf2d-f151-5652-9007-f8eb598e89a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4211d0-deef-4113-84e0-47ce0df7a5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4211d0-deef-4113-84e0-47ce0df7a5c6.jpg?1",
             "name": "Zodiac Rabbit",
             "text": "Forestwalk (If defending player has a forest in play, Zodiac Hare can't be blocked.)",
             "colours": [
@@ -5385,7 +5385,7 @@
         },
         {
             "id": "bfab250a-ca54-51c4-b298-9cc15b529109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dd362e-42f6-4eeb-9fe7-0d9cbeb4f21e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dd362e-42f6-4eeb-9fe7-0d9cbeb4f21e.jpg?1",
             "name": "Zodiac Rooster",
             "text": "Plainswalk (If defending player has a plain in play, Zodiac Rooster can't be blocked.)",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "e7451974-fc76-5228-86d0-59b6d78d80c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd78d5-df9f-46a3-a634-ebf7634a6358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd78d5-df9f-46a3-a634-ebf7634a6358.jpg?1",
             "name": "Zodiac Tiger",
             "text": "Forestwalk (If defending player has a forest in play, Zodiac Tiger can't be blocked.)",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "cc18dc70-3fce-54cf-9f7d-303e1ff3121c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg?1",
             "name": "Zuo Ci, the Mocking Sage",
             "text": "Zuo Ci can't be blocked by creatures with horsemanship.\nWhenever your opponent chooses a creature in play, he or she can't choose Zuo Ci.",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "026eba13-6231-5299-a9bb-338f2d9eeeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82f466-ee1c-4942-9b4d-a8bffd548b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82f466-ee1c-4942-9b4d-a8bffd548b30.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "38d2c545-c12e-51d6-905c-72c6dfeb8d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe3d8c0-1640-42bb-bb15-0b82c553976f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe3d8c0-1640-42bb-bb15-0b82c553976f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "cbcdf426-581c-51d2-a423-ecd26644e0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4801e24d-7c45-4d23-9461-0c7771eddd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4801e24d-7c45-4d23-9461-0c7771eddd91.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "0570e88d-b393-55f5-98fa-7d6d59d27c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76033c90-1e06-473b-ba44-a94e16ac5348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76033c90-1e06-473b-ba44-a94e16ac5348.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "79fe06b6-215c-5f9c-9da2-64d71a164403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899cfba6-9131-43ef-9e8d-803a0e64d0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899cfba6-9131-43ef-9e8d-803a0e64d0b0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "b9ed627f-4897-51ab-a058-1a50d29ba2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74b6430-0ddb-4433-b3bc-6f0ab42560e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74b6430-0ddb-4433-b3bc-6f0ab42560e6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5703,7 +5703,7 @@
         },
         {
             "id": "f9355027-2bfe-566b-b3b0-278dc216e9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b4a8a4-caa8-472d-bf90-ee70250bc0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b4a8a4-caa8-472d-bf90-ee70250bc0ab.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5739,7 +5739,7 @@
         },
         {
             "id": "8321c0e2-fedc-507a-a63f-02d297ae095a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc74272-8dc7-4a07-85e3-e7a13573345e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc74272-8dc7-4a07-85e3-e7a13573345e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5775,7 +5775,7 @@
         },
         {
             "id": "2ba89636-f5fa-5e3f-b69b-162a90e916ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6447bb-fffc-41c8-91cb-e526ed727b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6447bb-fffc-41c8-91cb-e526ed727b3e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5811,7 +5811,7 @@
         },
         {
             "id": "11ace9a8-8f8d-518b-9c97-eebefddc8fc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95046649-bc6d-46f5-8dbc-85d3fa5097c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95046649-bc6d-46f5-8dbc-85d3fa5097c4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "7de09b0b-da1d-5b38-b050-f601819430d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a6f28b-6910-416e-86e1-bd428360bb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a6f28b-6910-416e-86e1-bd428360bb27.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "c837ad88-ca1a-515d-91b0-67a01ad8b44a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f0ab3f-86c5-49f6-948b-ace35bc03889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f0ab3f-86c5-49f6-948b-ace35bc03889.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "8b50c63b-8c84-5a66-947a-fbf7f87c3e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6677baa6-a38f-48f2-9ff2-2e3321b22959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6677baa6-a38f-48f2-9ff2-2e3321b22959.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "04db31b4-d70e-578d-a044-4a695b8c8611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c94d6c-ed6d-4544-8565-35f1ea8bfc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c94d6c-ed6d-4544-8565-35f1ea8bfc26.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "1d587a7b-e261-580b-b93c-e910cba1761f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84722185-dffb-498e-8ce7-f50236b716f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84722185-dffb-498e-8ce7-f50236b716f5.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/RAV.json
+++ b/Assets/Resources/Sets/RAV.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c5bea520-b7bb-57e2-ab7f-0f0ac0af7f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d6414-11e1-4822-9c5d-e4f96846a85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d6414-11e1-4822-9c5d-e4f96846a85f.jpg?1",
             "name": "Auratouched Mage",
             "text": "When Auratouched Mage comes into play, search your library for an Aura card that could enchant it. If Auratouched Mage is still in play, attach that Aura to it. Otherwise, reveal the Aura card and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "2156ca78-8bd5-5dfd-80c9-4b84045c7b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bd976e-56c7-482e-8d2f-073b0b589274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bd976e-56c7-482e-8d2f-073b0b589274.jpg?1",
             "name": "Bathe in Light",
             "text": "Radiance Choose a color. Target creature and each other creature that shares a color with it gain protection from the chosen color until end of turn.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "6c573dc0-d686-50ae-809a-f081bd7e6e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23110b5-0dd4-49a2-8991-bc673aed53c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23110b5-0dd4-49a2-8991-bc673aed53c9.jpg?1",
             "name": "Benevolent Ancestor",
             "text": "Defender (This creature can't attack.)\n{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "19138380-cdbe-5415-b52f-4540d14c5603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0bc05b-ec48-41fd-a97a-ffb0d5a2dee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0bc05b-ec48-41fd-a97a-ffb0d5a2dee0.jpg?1",
             "name": "Blazing Archon",
             "text": "Flying\nCreatures can't attack you.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "88cbea86-d91d-58f0-829a-bdfaa0175d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b2f5c-3c7a-4421-9d6f-81197e93d8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b2f5c-3c7a-4421-9d6f-81197e93d8d0.jpg?1",
             "name": "Boros Fury-Shield",
             "text": "Prevent all combat damage that would be dealt by target attacking or blocking creature this turn. If {R} was spent to play Boros Fury-Shield, it deals damage to that creature's controller equal to the creature's power.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "16173684-12c4-5395-92ec-944c02955526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c33d3fe-cdd3-4829-8f10-6611f063983b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c33d3fe-cdd3-4829-8f10-6611f063983b.jpg?1",
             "name": "Caregiver",
             "text": "{W}, Sacrifice a creature: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "173e1b87-7df8-5b15-b0a2-bfac3855a5e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c22d01-1d14-4f73-a2db-a77f96a9a0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c22d01-1d14-4f73-a2db-a77f96a9a0e3.jpg?1",
             "name": "Chant of Vitu-Ghazi",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nPrevent all damage that would be dealt by creatures this turn. You gain 1 life for each damage prevented this way.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "23ca41e9-ae22-5408-b650-c38624fa1e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afa3367-eb7e-4c92-96a1-2b6865b24f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afa3367-eb7e-4c92-96a1-2b6865b24f52.jpg?1",
             "name": "Concerted Effort",
             "text": "At the beginning of each player's upkeep, all creatures you control gain flying until end of turn if a creature you control has flying. The same is true for fear, first strike, double strike, landwalk, protection, trample, and vigilance.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "f5a29620-e87e-5e61-a5b7-8ffd3ac95b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd663560-915a-4762-a3a6-0b9f6d7a9c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd663560-915a-4762-a3a6-0b9f6d7a9c64.jpg?1",
             "name": "Conclave Equenaut",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nFlying",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "13e191cd-92ff-5fdb-b83d-82e9cc3363a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83854443-736b-4650-8a7e-e123ee6e0b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83854443-736b-4650-8a7e-e123ee6e0b8b.jpg?1",
             "name": "Conclave Phalanx",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nWhen Conclave Phalanx comes into play, you gain 1 life for each creature you control.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "37e10ac8-9eec-5fc5-9879-491b490e44b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86235d9f-ba69-417d-9203-812ab428b374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86235d9f-ba69-417d-9203-812ab428b374.jpg?1",
             "name": "Conclave's Blessing",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nEnchant creature\nEnchanted creature gets +0/+2 for each other creature you control.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "dbc5ab55-8883-536b-a6a5-9269e05bee1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2fb5-248d-4d2d-aa06-f325d786e949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2fb5-248d-4d2d-aa06-f325d786e949.jpg?1",
             "name": "Courier Hawk",
             "text": "Flying, vigilance",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "100c6b84-514e-5349-9db4-f16c85f6d6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fcc46c-682c-4482-8422-811b951d96cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fcc46c-682c-4482-8422-811b951d96cf.jpg?1",
             "name": "Devouring Light",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nRemove target attacking or blocking creature from the game.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "fa313ba3-3dd7-5a2e-a5e2-74d343897dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa5a010-6253-4dfb-952e-df05ff08eb9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa5a010-6253-4dfb-952e-df05ff08eb9e.jpg?1",
             "name": "Divebomber Griffin",
             "text": "Flying\n{T}, Sacrifice Divebomber Griffin: Divebomber Griffin deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "2365fe4f-8581-50fd-8c89-c8b1133fe787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0106caf1-2201-4661-96a5-56af02963fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0106caf1-2201-4661-96a5-56af02963fa6.jpg?1",
             "name": "Dromad Purebred",
             "text": "Whenever Dromad Purebred is dealt damage, you gain 1 life.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "4df80668-7f59-57ab-b6ec-dea5acb261da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ffba3-44a9-41ce-a5a1-37413346db2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ffba3-44a9-41ce-a5a1-37413346db2f.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters comes into play, you gain 4 life.\nEnchanted permanent's activated abilities can't be played unless they're mana abilities. If enchanted permanent is a creature, it can't attack or block.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "86de92d9-2b2a-5537-b274-dca7316b2823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fc49c-07a9-4e55-a977-24f7b7c2df1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fc49c-07a9-4e55-a977-24f7b7c2df1a.jpg?1",
             "name": "Festival of the Guildpact",
             "text": "Prevent the next X damage that would be dealt to you this turn.\nDraw a card.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "857e7193-7d32-5a88-9cd7-255eec459a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165de5d-57f0-419b-95a1-02bd53e5a0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165de5d-57f0-419b-95a1-02bd53e5a0c5.jpg?1",
             "name": "Flickerform",
             "text": "Enchant creature\n{2}{W}{W}: Remove enchanted creature and all Auras attached to it from the game. At end of turn, return that card to play under its owner's control. If you do, return those Auras to play under their owners' control enchanting that creature.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "881710f4-7857-5ac4-9913-3270ddd2ab51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06732c6f-c3b5-4c68-82a0-655cffff79db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06732c6f-c3b5-4c68-82a0-655cffff79db.jpg?1",
             "name": "Gate Hound",
             "text": "Creatures you control have vigilance as long as Gate Hound is enchanted.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "b3b8d0c1-14e6-55de-8e23-4065d18246f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg?1",
             "name": "Ghosts of the Innocent",
             "text": "If a source would deal damage to a creature or player, it deals half that damage, rounded down, to that creature or player instead.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "b9e6f15f-3822-505a-beb9-25d7e22ffe55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec7a987-1ef2-40aa-a744-92d90b246df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec7a987-1ef2-40aa-a744-92d90b246df4.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nDestroy all nontoken creatures.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "5cadf5f4-29fb-5321-ab4f-b892d23373e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84de052-65e5-4723-a746-5c554fa1612d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84de052-65e5-4723-a746-5c554fa1612d.jpg?1",
             "name": "Hunted Lammasu",
             "text": "Flying\nWhen Hunted Lammasu comes into play, put a 4/4 black Horror creature token into play under target opponent's control.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "5e6a3099-2597-5755-8a6f-67f1569a3b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58466d46-7225-42ff-8471-6d489be32cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58466d46-7225-42ff-8471-6d489be32cf3.jpg?1",
             "name": "Leave No Trace",
             "text": "Radiance Destroy target enchantment and each other enchantment that shares a color with it.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "81e0350d-bc10-5fb7-9376-b888f126eea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg?1",
             "name": "Light of Sanction",
             "text": "Prevent all damage that would be dealt to creatures you control by sources you control.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "a545fbce-71ef-5cd5-9fc9-6b2ecf518f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg?1",
             "name": "Loxodon Gatekeeper",
             "text": "Artifacts, creatures, and lands your opponents control come into play tapped.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "a77a2998-aab7-589e-852d-321eff5439e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20377fbf-70c0-441b-b2e3-62ed26aaab4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20377fbf-70c0-441b-b2e3-62ed26aaab4a.jpg?1",
             "name": "Nightguard Patrol",
             "text": "First strike, vigilance",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "a7b117de-9a95-5e69-a702-fb738b49bc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c342b0f-a8a5-4991-a0a2-fd75b54e1de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c342b0f-a8a5-4991-a0a2-fd75b54e1de2.jpg?1",
             "name": "Oathsworn Giant",
             "text": "Vigilance\nOther creatures you control get +0/+2 and have vigilance.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "d933a9d3-ef7a-5803-94e5-34d877a98449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43472fbe-d4f6-41b5-9928-965336d44a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43472fbe-d4f6-41b5-9928-965336d44a8f.jpg?1",
             "name": "Sandsower",
             "text": "Tap three untapped creatures you control: Tap target creature.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "67120c42-2f52-5dff-8713-e52da8587155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2fa710-4615-42de-8716-41b009b56d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2fa710-4615-42de-8716-41b009b56d32.jpg?1",
             "name": "Screeching Griffin",
             "text": "Flying\n{R}: Target creature can't block Screeching Griffin this turn.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "f94b63d5-f264-58a1-96b7-963c57ed8ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af31cf-d730-4f54-a0be-3229cdccf60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af31cf-d730-4f54-a0be-3229cdccf60c.jpg?1",
             "name": "Seed Spark",
             "text": "Destroy target artifact or enchantment. If {G} was spent to play Seed Spark, put two 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "0c35953b-6a1d-5017-aa41-31092d1bd7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df7883b-f744-4410-a682-7391bd697afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df7883b-f744-4410-a682-7391bd697afb.jpg?1",
             "name": "Suppression Field",
             "text": "Activated abilities cost {2} more to play unless they're mana abilities.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "351ed5ba-4a3f-5e88-bb80-ef6de001d4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb144b8-f2ee-4d35-814d-ceb728b2ab75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb144b8-f2ee-4d35-814d-ceb728b2ab75.jpg?1",
             "name": "Three Dreams",
             "text": "Search your library for up to three Aura cards with different names, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "df8ca654-2a54-579b-b8dc-e667fbd13cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc33bb6-d71c-45f9-9030-bdef3d40a08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc33bb6-d71c-45f9-9030-bdef3d40a08a.jpg?1",
             "name": "Twilight Drover",
             "text": "Whenever a creature token leaves play, put a +1/+1 counter on Twilight Drover.\n{2}{W}, Remove a +1/+1 counter from Twilight Drover: Put two 1/1 white Spirit creature tokens with flying into play.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "191c3f5d-a2fa-52aa-9424-a66f58fab9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151a455f-c364-4600-a5f8-98da86aabc48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151a455f-c364-4600-a5f8-98da86aabc48.jpg?1",
             "name": "Veteran Armorer",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "f911f60e-5fb0-5d36-8747-773b990270ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6f929-5a19-421b-ae88-9bbb7e64756c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6f929-5a19-421b-ae88-9bbb7e64756c.jpg?1",
             "name": "Votary of the Conclave",
             "text": "{2}{G}: Regenerate Votary of the Conclave.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "285ab785-2527-5c1e-9d55-6e370d4d5d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef74fea5-2345-4ffd-8951-f420e17259e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef74fea5-2345-4ffd-8951-f420e17259e6.jpg?1",
             "name": "Wojek Apothecary",
             "text": "Radiance {T}: Prevent the next 1 damage that would be dealt to target creature and each other creature that shares a color with it this turn.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "1435efe1-ab58-56c4-9cf5-c9247b0a9ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c0d7d-2325-4d7e-b449-c8fdcf988ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c0d7d-2325-4d7e-b449-c8fdcf988ec0.jpg?1",
             "name": "Wojek Siren",
             "text": "Radiance Target creature and each other creature that shares a color with it get +1/+1 until end of turn.",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "bb03093f-7960-5f0e-b72e-549a738a90e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452a23a0-62de-4561-b361-9c0de9151129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452a23a0-62de-4561-b361-9c0de9151129.jpg?1",
             "name": "Belltower Sphinx",
             "text": "Flying\nWhenever a source deals damage to Belltower Sphinx, that source's controller puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "6c2e0539-1113-57b5-a79c-7172f5e8ef43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg?1",
             "name": "Cerulean Sphinx",
             "text": "Flying\n{U}: Cerulean Sphinx's owner shuffles it into his or her library.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "ab0cb01c-9603-50ae-bf0c-90dd781793a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b9c057-b80a-4e4e-a0d7-34b7ff3a69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b9c057-b80a-4e4e-a0d7-34b7ff3a69f4.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless he or she discards a land card.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "e0212035-bc31-5a56-8d30-2abe471aae83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac88052-96a3-4a4d-95a2-c5a652fcb275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac88052-96a3-4a4d-95a2-c5a652fcb275.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "e3bfe874-e441-5f3c-b749-6b08fccddde8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac22117d-bd58-439f-b199-da72bc7160b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac22117d-bd58-439f-b199-da72bc7160b2.jpg?1",
             "name": "Copy Enchantment",
             "text": "As Copy Enchantment comes into play, you may choose an enchantment in play. If you do, Copy Enchantment comes into play as a copy of that enchantment.",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "b05f27ce-7be0-50dd-87c8-de0d56179ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0db10d-fb6d-44df-9ff2-6f1e0e8f8209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0db10d-fb6d-44df-9ff2-6f1e0e8f8209.jpg?1",
             "name": "Dizzy Spell",
             "text": "Target creature gets -3/-0 until end of turn.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "5abbc7a5-c183-5e36-bba8-5f5036e7720b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4583623-e367-48cc-8e86-e6c5e35f1a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4583623-e367-48cc-8e86-e6c5e35f1a9c.jpg?1",
             "name": "Drake Familiar",
             "text": "Flying\nWhen Drake Familiar comes into play, sacrifice it unless you return an enchantment in play to its owner's hand.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "478a3585-847e-5301-8b64-c9740dc5fd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de4fa3d-a144-4918-b032-7495ab2e1c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de4fa3d-a144-4918-b032-7495ab2e1c8c.jpg?1",
             "name": "Dream Leash",
             "text": "Enchant permanent\nYou may play Dream Leash only on a tapped permanent.\nYou control enchanted permanent.",
             "colours": [
@@ -1515,7 +1515,7 @@
         },
         {
             "id": "871f57cd-c548-5ab0-bf6d-7123de40a5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1096ce5-f776-4028-b231-e6eaee35014b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1096ce5-f776-4028-b231-e6eaee35014b.jpg?1",
             "name": "Drift of Phantasms",
             "text": "Defender (This creature can't attack.)\nFlying\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -1549,7 +1549,7 @@
         },
         {
             "id": "e9362913-95e1-5d45-9900-fd938573f929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908901b7-fb40-4358-bca5-5e71bdafcbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908901b7-fb40-4358-bca5-5e71bdafcbe7.jpg?1",
             "name": "Ethereal Usher",
             "text": "{U}, {T}: Target creature is unblockable this turn.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -1583,7 +1583,7 @@
         },
         {
             "id": "3d70cd8d-dd52-5ff5-9ede-42571789b7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49967eb9-5020-4f0a-8775-5114f6d96d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49967eb9-5020-4f0a-8775-5114f6d96d75.jpg?1",
             "name": "Eye of the Storm",
             "text": "Whenever a player plays an instant or sorcery card, remove it from the game. Then that player copies each instant or sorcery card removed from the game with Eye of the Storm. For each copy, the player may play the copy without paying its mana cost.",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "676c2fc8-f58b-5500-b762-21b7073191fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ad201-ce70-45bf-9ac3-51f5ccfa8df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ad201-ce70-45bf-9ac3-51f5ccfa8df9.jpg?1",
             "name": "Flight of Fancy",
             "text": "Enchant creature\nWhen Flight of Fancy comes into play, draw two cards.\nEnchanted creature has flying.",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "f91f1231-19b0-54cd-829f-4f9353bb2a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27203b79-b383-4698-8b81-b6198c51c2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27203b79-b383-4698-8b81-b6198c51c2f6.jpg?1",
             "name": "Flow of Ideas",
             "text": "Draw a card for each Island you control.",
             "colours": [
@@ -1681,7 +1681,7 @@
         },
         {
             "id": "38be89d2-4140-5cad-afaa-9e16d4565849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e2fcc-0fa2-451e-8c69-7a24ba533e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e2fcc-0fa2-451e-8c69-7a24ba533e0b.jpg?1",
             "name": "Followed Footsteps",
             "text": "Enchant creature\nAt the beginning of your upkeep, put a creature token into play that's a copy of enchanted creature.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "318b2200-e965-5d48-b519-c6be20667b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2c94a-31df-4789-a309-4cdfe7f6a719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2c94a-31df-4789-a309-4cdfe7f6a719.jpg?1",
             "name": "Grayscaled Gharial",
             "text": "Islandwalk",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "f1dbb8e7-2518-5693-b525-4a94f18fd489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg?1",
             "name": "Grozoth",
             "text": "Defender (This creature can't attack.)\nWhen Grozoth comes into play, you may search your library for any number of cards that have converted mana cost 9, reveal them, and put them into your hand. If you do, shuffle your library.\n{4}: Grozoth loses defender until end of turn.\nTransmute {1}{U}{U}",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "05f9cecd-c595-56fb-9310-b61bc7e8c666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafd3018-1cfe-4c41-a08c-5c2ba3528c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafd3018-1cfe-4c41-a08c-5c2ba3528c7e.jpg?1",
             "name": "Halcyon Glaze",
             "text": "Whenever you play a creature spell, Halcyon Glaze becomes a 4/4 Illusion creature with flying until end of turn. It's still an enchantment.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "b89b4abb-8074-5a3c-80d6-b125bddfb1d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg?1",
             "name": "Hunted Phantasm",
             "text": "Hunted Phantasm is unblockable.\nWhen Hunted Phantasm comes into play, put five 1/1 red Goblin creature tokens into play under target opponent's control.",
             "colours": [
@@ -1849,7 +1849,7 @@
         },
         {
             "id": "0c3b8a14-c705-5c63-a6d2-c3eb9b24b5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc462b75-8b08-47a3-be22-d7b5c062ec5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc462b75-8b08-47a3-be22-d7b5c062ec5b.jpg?1",
             "name": "Induce Paranoia",
             "text": "Counter target spell. If {B} was spent to play Induce Paranoia, that spell's controller puts the top X cards of his or her library into his or her graveyard, where X is the spell's converted mana cost.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "7b047b4b-9226-502b-9688-9dbc1a0c419f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7935b2b-aebe-44b3-b91b-52978bb4ded5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7935b2b-aebe-44b3-b91b-52978bb4ded5.jpg?1",
             "name": "Lore Broker",
             "text": "{T}: Each player draws a card, then discards a card.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "dd6f05b7-199e-524c-be86-fbffb54ee312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae826236-e591-4afb-817b-0017a11010ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae826236-e591-4afb-817b-0017a11010ad.jpg?1",
             "name": "Mark of Eviction",
             "text": "Enchant creature\nAt the beginning of your upkeep, return enchanted creature and all Auras attached to that creature to their owners' hands.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "22c24c12-734d-5ecc-a397-e2aa1e5075ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200edda9-7ad9-47fc-837e-37ec9e5b4b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200edda9-7ad9-47fc-837e-37ec9e5b4b51.jpg?1",
             "name": "Mnemonic Nexus",
             "text": "Each player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "041fc2a9-ffc5-5f90-bca4-27d1d2890c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc785b0-0a77-4b02-b0b4-2bda2fc621cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc785b0-0a77-4b02-b0b4-2bda2fc621cc.jpg?1",
             "name": "Muddle the Mixture",
             "text": "Counter target instant or sorcery spell.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "b2245378-cd00-595a-a6a4-b8acd91315db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6ca71-ba17-4a16-a331-b787363874e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6ca71-ba17-4a16-a331-b787363874e2.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "89010831-054c-5a2a-b4f4-6566eb673465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f90c1a1-679d-45c5-a1d4-53dad05e45fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f90c1a1-679d-45c5-a1d4-53dad05e45fa.jpg?1",
             "name": "Quickchange",
             "text": "Target creature's color becomes the color or colors of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -2079,7 +2079,7 @@
         },
         {
             "id": "eb0dcd1a-2f31-55d3-b206-29defc6f2abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581f3780-c480-48c6-b15c-1618f2feccb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581f3780-c480-48c6-b15c-1618f2feccb9.jpg?1",
             "name": "Remand",
             "text": "Counter target spell. If you do, return that spell card to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2111,7 +2111,7 @@
         },
         {
             "id": "6fc476ea-e7bb-5d74-8bbe-aa0ef9fb1596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1e21fa-4d85-464b-9e64-3ba284769df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1e21fa-4d85-464b-9e64-3ba284769df9.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "fec8c1e3-0b02-5198-a6f6-2513d90ef588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg?1",
             "name": "Spawnbroker",
             "text": "When Spawnbroker comes into play, you may exchange control of target creature you control and target creature with power less than or equal to that creature's power an opponent controls.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "d554c083-f57a-5629-ab7d-97031c2af219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75611d2-6e87-4032-a71c-b46806798a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75611d2-6e87-4032-a71c-b46806798a29.jpg?1",
             "name": "Stasis Cell",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\n{3}{U}: Attach Stasis Cell to target creature.",
             "colours": [
@@ -2214,7 +2214,7 @@
         },
         {
             "id": "d0e1e2d3-8536-50b7-9042-a82d78bc6d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec114de-bee9-4a4a-826c-82a836b4bda1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec114de-bee9-4a4a-826c-82a836b4bda1.jpg?1",
             "name": "Surveilling Sprite",
             "text": "Flying\nWhen Surveilling Sprite is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "fc8d5861-efb7-50af-9c93-ad12c5c240a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28cbc8-4dbb-465b-813d-52b2b2f73b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28cbc8-4dbb-465b-813d-52b2b2f73b14.jpg?1",
             "name": "Tattered Drake",
             "text": "Flying\n{B}: Regenerate Tattered Drake.",
             "colours": [
@@ -2285,7 +2285,7 @@
         },
         {
             "id": "f86ce5ad-d28b-5295-a14f-442ea4954567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e6cf4-e86f-4538-85a1-3abbc83b303d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e6cf4-e86f-4538-85a1-3abbc83b303d.jpg?1",
             "name": "Telling Time",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
             "colours": [
@@ -2317,7 +2317,7 @@
         },
         {
             "id": "fa0018d6-932f-5b56-a7b1-d7828897bf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b9d4f3-4570-4fe0-857f-97f5bd6ead44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b9d4f3-4570-4fe0-857f-97f5bd6ead44.jpg?1",
             "name": "Terraformer",
             "text": "{1}: Choose a basic land type. The land type of each land you control becomes that type until end of turn.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "4697eb5c-8044-5a26-84df-ae164b2ad4d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffa68f-cc21-41c8-ad3d-d6b60a4ccd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffa68f-cc21-41c8-ad3d-d6b60a4ccd36.jpg?1",
             "name": "Tidewater Minion",
             "text": "Defender (This creature can't attack.)\n{4}: Tidewater Minion loses defender until end of turn.\n{T}: Untap target permanent.",
             "colours": [
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "fd66388e-cb05-5ecb-8230-30eee32b4561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eba31-02eb-449a-8a36-899ada5664bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eba31-02eb-449a-8a36-899ada5664bc.jpg?1",
             "name": "Tunnel Vision",
             "text": "Name a card. Target player reveals cards from the top of his or her library until the named card is revealed. If it is, that player puts the rest of the revealed cards into his or her graveyard and puts the named card on top of his or her library. Otherwise, the player shuffles his or her library.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "2b08db37-d14a-587d-9497-063e6090a801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0656f4eb-40c5-4a21-b994-4ab07bc63981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0656f4eb-40c5-4a21-b994-4ab07bc63981.jpg?1",
             "name": "Vedalken Dismisser",
             "text": "When Vedalken Dismisser comes into play, put target creature on top of its owner's library.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "23256ba2-3e0f-5151-81bb-f081d9ab179b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf5e4b8-3bb9-4a4c-b8fa-2cae5372ba24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf5e4b8-3bb9-4a4c-b8fa-2cae5372ba24.jpg?1",
             "name": "Vedalken Entrancer",
             "text": "{U}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "6f44a088-9ac9-5b0d-9bc2-6404ea7c5488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35807a-a003-4a99-a883-03b8e097f1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35807a-a003-4a99-a883-03b8e097f1b2.jpg?1",
             "name": "Wizened Snitches",
             "text": "Flying\nPlayers play with the top card of their libraries revealed.",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "4702eda5-f2e0-545a-b988-3f9327e00aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cbe78f-4325-416b-bf23-282efed5b407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cbe78f-4325-416b-bf23-282efed5b407.jpg?1",
             "name": "Zephyr Spirit",
             "text": "When Zephyr Spirit blocks, return it to its owner's hand.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "4def6314-05fc-56d0-8120-e55598fad4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg?1",
             "name": "Blood Funnel",
             "text": "Noncreature spells you play cost {2} less to play.\nWhenever you play a noncreature spell, counter that spell unless you sacrifice a creature.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "f71c872e-c0a6-5856-b71b-c11b4bbdcdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34fa44f-274e-4914-bbd5-71193f8d2f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34fa44f-274e-4914-bbd5-71193f8d2f96.jpg?1",
             "name": "Brainspoil",
             "text": "Destroy target creature that isn't enchanted. It can't be regenerated.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "e07c7d91-6ed3-5c3b-b6c6-a22d153cdfb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff031f4-df27-40de-8615-f3ea225f9830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff031f4-df27-40de-8615-f3ea225f9830.jpg?1",
             "name": "Carrion Howler",
             "text": "Pay 1 life: Carrion Howler gets +2/-1 until end of turn.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "b2cf2eb4-3d30-5c98-a717-a7a934b29195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a939a4e-5a9e-454f-8716-cee7470f05e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a939a4e-5a9e-454f-8716-cee7470f05e2.jpg?1",
             "name": "Clinging Darkness",
             "text": "Enchant creature\nEnchanted creature gets -4/-1.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "4732deef-6d46-54c3-86be-fd081d780893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7a441-bf2d-46fb-a7b6-9bd6137f86d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7a441-bf2d-46fb-a7b6-9bd6137f86d9.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "6d7a2057-ac91-5351-939a-8118012c2250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcaba91-06d3-4492-9e07-36a1b858ca47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcaba91-06d3-4492-9e07-36a1b858ca47.jpg?1",
             "name": "Darkblast",
             "text": "Target creature gets -1/-1 until end of turn.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "2071323d-38f3-583d-a736-6b930e0c950a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a021caf-d9e7-470b-85be-3af42a3adfd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a021caf-d9e7-470b-85be-3af42a3adfd3.jpg?1",
             "name": "Dimir House Guard",
             "text": "Fear\nSacrifice a creature: Regenerate Dimir House Guard.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "40abda02-95db-557c-9a53-26f5a0ba252e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bfd72a-78c1-4167-89bf-ea1fccccd5b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bfd72a-78c1-4167-89bf-ea1fccccd5b1.jpg?1",
             "name": "Dimir Machinations",
             "text": "Look at the top three cards of target player's library. Remove any number of those cards from the game, then put the rest back in any order.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "a3687f8a-033e-5ffb-87e8-42b94bc8d10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1edb79d-0031-4dc6-8881-f6d1fe4acba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1edb79d-0031-4dc6-8881-f6d1fe4acba2.jpg?1",
             "name": "Disembowel",
             "text": "Destroy target creature with converted mana cost X.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "796a788f-854f-5391-9b06-de20911008aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg?1",
             "name": "Empty the Catacombs",
             "text": "Each player returns all creature cards from his or her graveyard to his or her hand.",
             "colours": [
@@ -2888,7 +2888,7 @@
         },
         {
             "id": "7df087df-c692-5e19-aff5-6351d5e71b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c39e21-3e2f-4cbf-9f99-69e977924a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c39e21-3e2f-4cbf-9f99-69e977924a73.jpg?1",
             "name": "Golgari Thug",
             "text": "When Golgari Thug is put into a graveyard from play, put target creature card in your graveyard on top of your library.\nDredge 4 (If you would draw a card, instead you may put exactly four cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "beb83d7c-3be4-5865-b31e-42a4fdc07181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5be07-166c-4b51-9ca5-655e21c32370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5be07-166c-4b51-9ca5-655e21c32370.jpg?1",
             "name": "Helldozer",
             "text": "{B}{B}{B}, {T}: Destroy target land. If that land is nonbasic, untap Helldozer.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "af9a1faa-9e0f-5830-864f-dc7f75c55aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6af730f-a86d-4b0f-a120-fb56f065351b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6af730f-a86d-4b0f-a120-fb56f065351b.jpg?1",
             "name": "Hex",
             "text": "Destroy six target creatures.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "6d48ee04-8395-5242-8bfe-09cd66a461aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca680e3-2d10-4a32-8b0c-8b0c6be96540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca680e3-2d10-4a32-8b0c-8b0c6be96540.jpg?1",
             "name": "Hunted Horror",
             "text": "Trample\nWhen Hunted Horror comes into play, put two 3/3 green Centaur creature tokens with protection from black into play under target opponent's control.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "e2c145ba-ba0e-520c-879c-36b2b427ea6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11858b4f-3a90-4990-9984-d888c000ec73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11858b4f-3a90-4990-9984-d888c000ec73.jpg?1",
             "name": "Infectious Host",
             "text": "When Infectious Host is put into a graveyard from play, target player loses 2 life.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "b33f22d5-f922-582c-ac8d-f9f788a8723e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0866b383-dced-459e-9510-38248a29dd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0866b383-dced-459e-9510-38248a29dd14.jpg?1",
             "name": "Keening Banshee",
             "text": "Flying\nWhen Keening Banshee comes into play, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "da980357-f250-534a-86ad-2f07487f3255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e035b3-bd83-43a4-8f31-d2393d29cd94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e035b3-bd83-43a4-8f31-d2393d29cd94.jpg?1",
             "name": "Last Gasp",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -3124,7 +3124,7 @@
         },
         {
             "id": "c46fae5b-6852-51ba-a525-8f38e7ef2b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b6dc7d-fc8a-4842-bf30-3dc9fec708c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b6dc7d-fc8a-4842-bf30-3dc9fec708c4.jpg?1",
             "name": "Mausoleum Turnkey",
             "text": "When Mausoleum Turnkey comes into play, return target creature card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "10a7cb5a-652e-51f3-92eb-a8de0aa38747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7957c37f-96da-4b7e-9581-afdf73a85edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7957c37f-96da-4b7e-9581-afdf73a85edd.jpg?1",
             "name": "Moonlight Bargain",
             "text": "Look at the top five cards of your library. For each card, put that card into your graveyard unless you pay 2 life. Then put the rest into your hand.",
             "colours": [
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "0cd54ad4-6fb8-527c-be8b-fd36503982be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a8ae6e-51b1-4985-9d09-f9c3818df911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a8ae6e-51b1-4985-9d09-f9c3818df911.jpg?1",
             "name": "Mortipede",
             "text": "{2}{G}: All creatures able to block Mortipede this turn do so.",
             "colours": [
@@ -3226,7 +3226,7 @@
         },
         {
             "id": "526500ae-1dc5-507c-b80c-7a09655d4a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a46880c-a9f4-452d-8b91-51d8aa97cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a46880c-a9f4-452d-8b91-51d8aa97cbd2.jpg?1",
             "name": "Necromantic Thirst",
             "text": "Enchant creature\nWhenever enchanted creature deals combat damage to a player, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "4b3e61aa-0999-543a-9695-b0e79df6d497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372424cf-85b3-4a78-bcf2-0543b0b88c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372424cf-85b3-4a78-bcf2-0543b0b88c0b.jpg?1",
             "name": "Necroplasm",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on Necroplasm.\nAt the end of your turn, destroy each creature with converted mana cost equal to the number of +1/+1 counters on Necroplasm.\nDredge 2",
             "colours": [
@@ -3294,7 +3294,7 @@
         },
         {
             "id": "b5bfaf79-f600-5b8a-b4c0-6f685876b127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665e905-cb06-48b7-9f50-5916277e237d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665e905-cb06-48b7-9f50-5916277e237d.jpg?1",
             "name": "Netherborn Phalanx",
             "text": "When Netherborn Phalanx comes into play, each opponent loses 1 life for each creature he or she controls.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -3328,7 +3328,7 @@
         },
         {
             "id": "23947bd1-9a9f-5ae5-89b9-5808e0807286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892299e9-8ee9-4a81-b4aa-b03ad2565eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892299e9-8ee9-4a81-b4aa-b03ad2565eb4.jpg?1",
             "name": "Nightmare Void",
             "text": "Target player reveals his or her hand. Choose a card from it. That player discards that card.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "681cd4d5-740e-5443-99bd-588413c12dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a2e910-5a61-4ca0-8d69-0a6d4ea12ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a2e910-5a61-4ca0-8d69-0a6d4ea12ed7.jpg?1",
             "name": "Ribbons of Night",
             "text": "Ribbons of Night deals 4 damage to target creature and you gain 4 life. If {U} was spent to play Ribbons of Night, draw a card.",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "07a41c27-dfb7-52ca-8831-238c090b2945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43fb78-497b-4a05-84cd-d2aca4b2db1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43fb78-497b-4a05-84cd-d2aca4b2db1b.jpg?1",
             "name": "Roofstalker Wight",
             "text": "{1}{U}: Roofstalker Wight gains flying until end of turn.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "ee42531d-6a3d-5903-b4be-b8044b6b0471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40283989-c2cc-4f17-a817-2c548d2ce71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40283989-c2cc-4f17-a817-2c548d2ce71f.jpg?1",
             "name": "Sadistic Augermage",
             "text": "When Sadistic Augermage is put into a graveyard from play, each player puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "dc69fac7-8112-5714-a0df-ebb05b3efa19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b216ad4e-29b4-4e03-8c16-5796277bd05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b216ad4e-29b4-4e03-8c16-5796277bd05f.jpg?1",
             "name": "Sewerdreg",
             "text": "Swampwalk\nSacrifice Sewerdreg: Remove target card in a graveyard from the game.",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "bacf9bd8-e17c-588f-9ca1-21c297766f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38192e5-814f-4269-bae8-13867a73e7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38192e5-814f-4269-bae8-13867a73e7fa.jpg?1",
             "name": "Shred Memory",
             "text": "Remove up to four target cards in a single graveyard from the game.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "f38eebd1-1b23-504a-8ec2-7bb90a647b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c518792-a50f-40b1-b6fb-674432093b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c518792-a50f-40b1-b6fb-674432093b6a.jpg?1",
             "name": "Sins of the Past",
             "text": "Until end of turn, you may play target instant or sorcery card in your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, remove it from the game instead. Remove Sins of the Past from the game.",
             "colours": [
@@ -3561,7 +3561,7 @@
         },
         {
             "id": "0e27a1f7-56f1-527e-a5e3-75ed597029f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628903a0-6695-4643-80f3-9a6efc4d6a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628903a0-6695-4643-80f3-9a6efc4d6a27.jpg?1",
             "name": "Stinkweed Imp",
             "text": "Flying\nWhenever Stinkweed Imp deals combat damage to a creature, destroy that creature.\nDredge 5 (If you would draw a card, instead you may put exactly five cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "eb814d11-b4b0-5d88-ae20-1bc27cba06ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ced365-f445-4a4a-b33f-986279404fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ced365-f445-4a4a-b33f-986279404fde.jpg?1",
             "name": "Strands of Undeath",
             "text": "Enchant creature\nWhen Strands of Undeath comes into play, target player discards two cards.\n{B}: Regenerate enchanted creature.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "966a2934-b693-57d4-aaa5-aed86516aedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8df33-a955-403c-aafc-85e5589c5041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8df33-a955-403c-aafc-85e5589c5041.jpg?1",
             "name": "Thoughtpicker Witch",
             "text": "{1}, Sacrifice a creature: Look at the top two cards of target opponent's library, then remove one of them from the game.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "ec3680b9-b116-570a-be1b-dec1825cb496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6609aa2e-6832-4c20-beda-e5f2506bf9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6609aa2e-6832-4c20-beda-e5f2506bf9b2.jpg?1",
             "name": "Undercity Shade",
             "text": "Fear\n{B}: Undercity Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "8b3b91cd-ff6f-5939-a0bf-2d9676d2f9cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe06560-bb3f-4f0b-ad3c-7257419eb8ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe06560-bb3f-4f0b-ad3c-7257419eb8ef.jpg?1",
             "name": "Vigor Mortis",
             "text": "Return target creature card from your graveyard to play. If {G} was spent to play Vigor Mortis, that creature comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -3731,7 +3731,7 @@
         },
         {
             "id": "0bdc99d8-3bab-5b41-a950-a883532f869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5c72c-982c-4cfd-b576-089200b4cc04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5c72c-982c-4cfd-b576-089200b4cc04.jpg?1",
             "name": "Vindictive Mob",
             "text": "When Vindictive Mob comes into play, sacrifice a creature.\nVindictive Mob can't be blocked by Saprolings.",
             "colours": [
@@ -3766,7 +3766,7 @@
         },
         {
             "id": "d1e92fe0-056a-531f-a487-5aef0f94e601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg?1",
             "name": "Woebringer Demon",
             "text": "Flying\nAt the beginning of each player's upkeep, that player sacrifices a creature. If the player can't, sacrifice Woebringer Demon.",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "8ce2e7b2-f706-58af-b4fb-17f6c452327d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f4cfa-4f03-404d-a6f7-24c27505906f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f4cfa-4f03-404d-a6f7-24c27505906f.jpg?1",
             "name": "Barbarian Riftcutter",
             "text": "{R}, Sacrifice Barbarian Riftcutter: Destroy target land.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "dc601e4e-3199-518d-a65f-e4ff6a7389ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a28b9d-1bd2-4ca4-a1e1-4138891d6739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a28b9d-1bd2-4ca4-a1e1-4138891d6739.jpg?1",
             "name": "Blockbuster",
             "text": "{1}{R}, Sacrifice Blockbuster: Blockbuster deals 3 damage to each tapped creature and each player.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "2e5a7cb9-4f63-567c-a543-9376cc68039b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbef6f4a-f9a0-4a4c-b8a2-6c3a8fb7e14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbef6f4a-f9a0-4a4c-b8a2-6c3a8fb7e14a.jpg?1",
             "name": "Breath of Fury",
             "text": "Enchant creature you control\nWhen enchanted creature deals combat damage to a player, sacrifice it and attach Breath of Fury to a creature you control. If you do, untap all creatures you control and after this phase, there is an additional combat phase.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "e4ffc6c2-a498-5bdb-8f26-3179fe3eeac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg?1",
             "name": "Char",
             "text": "Char deals 4 damage to target creature or player and 2 damage to you.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "bdfbd727-7a68-54e4-8bfe-fed6492d4369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cbaab6-db0d-40bb-bdf4-aee6543d9f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cbaab6-db0d-40bb-bdf4-aee6543d9f27.jpg?1",
             "name": "Cleansing Beam",
             "text": "Radiance Cleansing Beam deals 2 damage to target creature and each other creature that shares a color with it.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "c3b26b0c-2533-5896-a29f-6d8968746925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc001cef-3afd-4128-989f-ac99dc76b243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc001cef-3afd-4128-989f-ac99dc76b243.jpg?1",
             "name": "Coalhauler Swine",
             "text": "Whenever Coalhauler Swine is dealt damage, it deals that much damage to each player.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "f151a61c-f8b1-5bdd-942d-906796d8ea9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26316b00-22db-4546-8366-8a624f10c1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26316b00-22db-4546-8366-8a624f10c1ba.jpg?1",
             "name": "Dogpile",
             "text": "Dogpile deals damage to target creature or player equal to the number of attacking creatures you control.",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "621370fc-4675-5734-a022-453d08a3df0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg?1",
             "name": "Excruciator",
             "text": "Damage that would be dealt by Excruciator can't be prevented.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "c85f4b2d-ef90-5786-b0ee-c1bd06894128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9a92c-9fde-4313-ac4c-9791604d7f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9a92c-9fde-4313-ac4c-9791604d7f4f.jpg?1",
             "name": "Fiery Conclusion",
             "text": "As an additional cost to play Fiery Conclusion, sacrifice a creature.\nFiery Conclusion deals 5 damage to target creature.",
             "colours": [
@@ -4098,7 +4098,7 @@
         },
         {
             "id": "03167eac-d546-57da-9855-9c4dc0bfb704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg?1",
             "name": "Flame Fusillade",
             "text": "Until end of turn, permanents you control gain \"{T}: This permanent deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "f51e3962-0417-5ab3-9875-b1a7d240f7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52361237-a653-4470-9ed5-c531c040c686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52361237-a653-4470-9ed5-c531c040c686.jpg?1",
             "name": "Flash Conscription",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. If {W} was spent to play Flash Conscription, the creature gains \"Whenever this creature deals combat damage, you gain that much life\" until end of turn.",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "0d2667a4-6fcb-50bb-aa16-bde72dcf279d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d307d8c7-b9b5-4f8f-933d-f1c64cbbf92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d307d8c7-b9b5-4f8f-933d-f1c64cbbf92f.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "532bab05-2992-5a6f-ac23-d6428a1959b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d816df-51e5-46f8-ad9a-68f3f656dbcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d816df-51e5-46f8-ad9a-68f3f656dbcd.jpg?1",
             "name": "Galvanic Arc",
             "text": "Enchant creature\nWhen Galvanic Arc comes into play, it deals 3 damage to target creature or player.\nEnchanted creature has first strike.",
             "colours": [
@@ -4232,7 +4232,7 @@
         },
         {
             "id": "9aa9b58a-a5a0-52cb-a273-6bce4b9d8cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d3b2d2-4ec2-495d-833d-7476cbfc80f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d3b2d2-4ec2-495d-833d-7476cbfc80f6.jpg?1",
             "name": "Goblin Fire Fiend",
             "text": "Haste\nDefending player blocks Goblin Fire Fiend if able.\n{R}: Goblin Fire Fiend gets +1/+0 until end of turn.",
             "colours": [
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "20485139-3683-5987-a27b-deeca3146092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3889c5-3321-486c-b03c-8607f2393a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3889c5-3321-486c-b03c-8607f2393a75.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "Mountainwalk",
             "colours": [
@@ -4302,7 +4302,7 @@
         },
         {
             "id": "70daa522-b753-56d2-a755-c2585b3870ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8ad11-4ffa-4878-9354-737be6f9e90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8ad11-4ffa-4878-9354-737be6f9e90c.jpg?1",
             "name": "Greater Forgeling",
             "text": "{1}{R}: Greater Forgeling gets +3/-3 until end of turn.",
             "colours": [
@@ -4336,7 +4336,7 @@
         },
         {
             "id": "148911b5-8f68-5dfb-ad4b-a0097b1613c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f946d-9715-466e-b322-905995d28107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f946d-9715-466e-b322-905995d28107.jpg?1",
             "name": "Hammerfist Giant",
             "text": "{T}: Hammerfist Giant deals 4 damage to each creature without flying and each player.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "c079d6b9-58d8-51b4-88b8-0194ceeba38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b9cc6e-47db-47d5-84c9-975e4b618261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b9cc6e-47db-47d5-84c9-975e4b618261.jpg?1",
             "name": "Hunted Dragon",
             "text": "Flying, haste\nWhen Hunted Dragon comes into play, put three 2/2 white Knight creature tokens with first strike into play under target opponent's control.",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "e47860fd-5892-5b39-a07b-e55179ff9c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f5060-df9e-4665-bf60-a8e33da55c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f5060-df9e-4665-bf60-a8e33da55c84.jpg?1",
             "name": "Incite Hysteria",
             "text": "Radiance Creatures that share a color with target creature can't block this turn.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "2c1d7914-b9f1-51fb-b589-787bc8baf273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e976c-3c0b-4ba5-b614-e1b576b57e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e976c-3c0b-4ba5-b614-e1b576b57e86.jpg?1",
             "name": "Indentured Oaf",
             "text": "Prevent all damage that Indentured Oaf would deal to red creatures.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "f8d155b6-5cf2-5ec6-b8d3-13a0a429b463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6164762-c02d-4553-9064-2b99ff6352c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6164762-c02d-4553-9064-2b99ff6352c9.jpg?1",
             "name": "Instill Furor",
             "text": "Enchant creature\nEnchanted creature has \"At the end of your turn, sacrifice this creature unless it attacked this turn.\"",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "42482800-d2cf-5e1c-9310-4f75593a962a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg?1",
             "name": "Mindmoil",
             "text": "Whenever you play a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "99c00f38-d62c-5adb-84c0-5eda08055032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg?1",
             "name": "Molten Sentry",
             "text": "As Molten Sentry comes into play, flip a coin. If the coin comes up heads, Molten Sentry comes into play as a 5/2 creature with haste. If it comes up tails, Molten Sentry comes into play as a 2/5 creature with defender.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "65e21696-54ab-596f-9f0b-64aab27211f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa726c0e-3a7e-4299-8842-4ce1f9f26567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa726c0e-3a7e-4299-8842-4ce1f9f26567.jpg?1",
             "name": "Ordruun Commando",
             "text": "{W}: Prevent the next 1 damage that would be dealt to Ordruun Commando this turn.",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "0f868b90-c4bf-576b-93bb-4954c1f2b4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5391a9-6c30-4f9b-b746-a4427a3e63fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5391a9-6c30-4f9b-b746-a4427a3e63fc.jpg?1",
             "name": "Rain of Embers",
             "text": "Rain of Embers deals 1 damage to each creature and each player.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "fa529bbe-f35b-5b72-8612-cb69beab386b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42794e10-ddcd-4d2d-ab0c-a6b99b6d4662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42794e10-ddcd-4d2d-ab0c-a6b99b6d4662.jpg?1",
             "name": "Reroute",
             "text": "Change the target of target activated ability with a single target.\nDraw a card.",
             "colours": [
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "bacdba65-7b9a-5d60-a603-3b60b9ce6354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec817c-c414-4a56-b455-748c6e5cac0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec817c-c414-4a56-b455-748c6e5cac0d.jpg?1",
             "name": "Sabertooth Alley Cat",
             "text": "Sabertooth Alley Cat attacks each turn if able.\n{1}{R}: Creatures without defender can't block Sabertooth Alley Cat this turn.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "52347240-0e93-5d8f-a830-493a22421c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9caddbe-1329-4ac2-9071-6fc5059d4dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9caddbe-1329-4ac2-9071-6fc5059d4dec.jpg?1",
             "name": "Seismic Spike",
             "text": "Destroy target land. Add {R}{R} to your mana pool.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "4eeb942c-45ca-534c-b855-373aa6ff9f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db513835-af5a-4ff3-8cf8-31936732a4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db513835-af5a-4ff3-8cf8-31936732a4db.jpg?1",
             "name": "Sell-Sword Brute",
             "text": "When Sell-Sword Brute is put into a graveyard from play, it deals 2 damage to you.",
             "colours": [
@@ -4773,7 +4773,7 @@
         },
         {
             "id": "f5f4af58-5bb2-59e7-b58a-d54ef013f432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692b1487-7752-4c40-ba91-09ef67016032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692b1487-7752-4c40-ba91-09ef67016032.jpg?1",
             "name": "Smash",
             "text": "Destroy target artifact.\nDraw a card.",
             "colours": [
@@ -4805,7 +4805,7 @@
         },
         {
             "id": "2bcf0804-87e7-5e32-83bf-d243d4f0da53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca91f7f-4b17-469e-8650-4c18e1521ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca91f7f-4b17-469e-8650-4c18e1521ea9.jpg?1",
             "name": "Sparkmage Apprentice",
             "text": "When Sparkmage Apprentice comes into play, it deals 1 damage to target creature or player.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "01eef3f8-f30d-5ce8-8378-f9668da1257d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a0edb0-697a-4e0b-872b-f3c15c19cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a0edb0-697a-4e0b-872b-f3c15c19cbda.jpg?1",
             "name": "Stoneshaker Shaman",
             "text": "At the end of each player's turn, that player sacrifices an untapped land.",
             "colours": [
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "8c12bfa3-5df9-528e-b364-2fe1be0be3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c07fa6-b575-46f9-ab39-fb777d4b8acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c07fa6-b575-46f9-ab39-fb777d4b8acd.jpg?1",
             "name": "Surge of Zeal",
             "text": "Radiance Target creature and each other creature that shares a color with it gain haste until end of turn.",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "de85c263-3371-5d41-b473-8db3563e1675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900ff91-0e47-4903-a680-9031f4a23cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900ff91-0e47-4903-a680-9031f4a23cb4.jpg?1",
             "name": "Torpid Moloch",
             "text": "Defender (This creature can't attack.)\nSacrifice three lands: Torpid Moloch loses defender until end of turn.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "b741bc5e-040d-5dcb-87ba-1de123d88af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616dac9-bbcf-453a-9205-8e433a1c62aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616dac9-bbcf-453a-9205-8e433a1c62aa.jpg?1",
             "name": "Viashino Fangtail",
             "text": "{T}: Viashino Fangtail deals 1 damage to target creature or player.",
             "colours": [
@@ -4976,7 +4976,7 @@
         },
         {
             "id": "1875f3ca-2630-5024-a316-02d61bf95034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa18f23-c995-4fcc-8e95-bbf76426e703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa18f23-c995-4fcc-8e95-bbf76426e703.jpg?1",
             "name": "Viashino Slasher",
             "text": "{R}: Viashino Slasher gets +1/-1 until end of turn.",
             "colours": [
@@ -5011,7 +5011,7 @@
         },
         {
             "id": "5be4d719-cb8c-56ef-8cc4-e354a3006fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbf743a-6e28-47c4-acfe-1c5d42f80eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbf743a-6e28-47c4-acfe-1c5d42f80eee.jpg?1",
             "name": "Warp World",
             "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way into play, then puts all enchantment cards revealed this way into play, then puts the rest on the bottom of his or her library in any order.",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "20c738fe-f52f-592a-8e74-8f74772f73bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259469b3-1212-4030-97ae-a84f132798d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259469b3-1212-4030-97ae-a84f132798d4.jpg?1",
             "name": "War-Torch Goblin",
             "text": "{R}, Sacrifice War-Torch Goblin: War-Torch Goblin deals 2 damage to target blocking creature.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "1df8ad3a-43c2-52bc-acf5-691c2139765f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1614866-fb0b-47bd-ab26-5c20ff175d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1614866-fb0b-47bd-ab26-5c20ff175d10.jpg?1",
             "name": "Wojek Embermage",
             "text": "Radiance {T}: Wojek Embermage deals 1 damage to target creature and each other creature that shares a color with it.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "f362c4ef-1ae3-59b1-8502-2812c85794d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a4396a-0f22-482b-ad1d-4d9b68a1ed96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a4396a-0f22-482b-ad1d-4d9b68a1ed96.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "dc2ea262-20bb-508a-94a7-0cfb13e6ab8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470665e5-fa48-4772-ba71-5d4008d042f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470665e5-fa48-4772-ba71-5d4008d042f3.jpg?1",
             "name": "Bramble Elemental",
             "text": "Whenever an Aura becomes attached to Bramble Elemental, put two 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "3e047da3-603c-57b9-8e2e-b39e9afceb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba52a417-0950-4ddf-9bd5-3557f659fdf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba52a417-0950-4ddf-9bd5-3557f659fdf5.jpg?1",
             "name": "Carven Caryatid",
             "text": "Defender (This creature can't attack.)\nWhen Carven Caryatid comes into play, draw a card.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "c8c7504a-28d0-54a2-9e14-f89c64ae3da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e064174b-8f07-4fea-9eef-c3b5d0220b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e064174b-8f07-4fea-9eef-c3b5d0220b1a.jpg?1",
             "name": "Chord of Calling",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "9606c306-0ba7-5dd6-bcf9-a8ff80374a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654eacc9-5f80-44ea-8d7b-71cd8227fa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654eacc9-5f80-44ea-8d7b-71cd8227fa38.jpg?1",
             "name": "Civic Wayfinder",
             "text": "When Civic Wayfinder comes into play, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5283,7 +5283,7 @@
         },
         {
             "id": "ba3c07bc-9856-59e2-ba17-7329df4b456a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e71299-98f6-494e-b187-8d22ce5f50af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e71299-98f6-494e-b187-8d22ce5f50af.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would put one or more tokens into play under your control, it puts twice that many into play instead.\nIf an effect would place one or more counters on a permanent you control, it places twice that many on that permanent instead.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "a3a26725-807e-5f50-a495-942a29fa170e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34ac5bd-2d2f-4c44-8f2d-aaa8fa18e81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34ac5bd-2d2f-4c44-8f2d-aaa8fa18e81a.jpg?1",
             "name": "Dowsing Shaman",
             "text": "{2}{G}, {T}: Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "6c14653e-de15-5546-8604-12d49360d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf707f2-1a62-458e-bcc8-8b1cd081f225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf707f2-1a62-458e-bcc8-8b1cd081f225.jpg?1",
             "name": "Dryad's Caress",
             "text": "You gain 1 life for each creature in play. If {W} was spent to play Dryad's Caress, untap all creatures you control.",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "19f52df8-e5f7-5d3c-ad95-2f2dfe5f337d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bea6dea-d767-4092-a285-305d9997357a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bea6dea-d767-4092-a285-305d9997357a.jpg?1",
             "name": "Elves of Deep Shadow",
             "text": "{T}: Add {B} to your mana pool. Elves of Deep Shadow deals 1 damage to you.",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "2093aee8-7a31-5d05-86a5-d1583dc4bfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80b91e8-c498-4178-8310-3cd3b039a3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80b91e8-c498-4178-8310-3cd3b039a3dc.jpg?1",
             "name": "Elvish Skysweeper",
             "text": "{4}{G}, Sacrifice a creature: Destroy target creature with flying.",
             "colours": [
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "141896a7-bf04-560f-8775-846bd9b30768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8180abec-9459-4b81-987e-b1794e45d543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8180abec-9459-4b81-987e-b1794e45d543.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card and put it into play tapped. Then shuffle your library.",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "76cc2925-7584-5677-bed8-d8db041ab74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7193c00f-0398-485c-974d-346ee59cd4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7193c00f-0398-485c-974d-346ee59cd4c7.jpg?1",
             "name": "Fists of Ironwood",
             "text": "Enchant creature\nWhen Fists of Ironwood comes into play, put two 1/1 green Saproling creature tokens into play.\nEnchanted creature has trample.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "cc68c560-3af9-592e-b912-55fcc8d29da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93311f80-0d0e-4005-ba43-5dbfe438d127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93311f80-0d0e-4005-ba43-5dbfe438d127.jpg?1",
             "name": "Gather Courage",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5552,7 +5552,7 @@
         },
         {
             "id": "00910c78-dd97-5feb-a2d4-e04e987dfabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690cfc79-da41-4ac0-b0cc-719aa650b207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690cfc79-da41-4ac0-b0cc-719aa650b207.jpg?1",
             "name": "Golgari Brownscale",
             "text": "When Golgari Brownscale is put into your hand from your graveyard, you gain 2 life.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "11bc8f66-b5b3-54a7-b76c-f6291c194e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b50e6-2166-435d-bf48-c4a0cff9999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b50e6-2166-435d-bf48-c4a0cff9999c.jpg?1",
             "name": "Golgari Grave-Troll",
             "text": "Golgari Grave-Troll comes into play with a +1/+1 counter on it for each creature card in your graveyard.\n{1}, Remove a +1/+1 counter from Golgari Grave-Troll: Regenerate Golgari Grave-Troll.\nDredge 6",
             "colours": [
@@ -5621,7 +5621,7 @@
         },
         {
             "id": "593baf77-dc3e-5051-8c84-f4756922a60d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecc53b1-942e-4b44-bf93-dd2d8cc92d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecc53b1-942e-4b44-bf93-dd2d8cc92d6d.jpg?1",
             "name": "Goliath Spider",
             "text": "Goliath Spider can block as though it had flying.",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "90b5c97e-63c5-5e98-b8c6-78e95e23ef68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f75b44-01a3-47f6-96c9-9ce327111e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f75b44-01a3-47f6-96c9-9ce327111e64.jpg?1",
             "name": "Greater Mossdog",
             "text": "Dredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "4403a43c-d8ab-55da-8132-13b078821a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d891e-ae8c-485a-b999-d1e08fffd164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d891e-ae8c-485a-b999-d1e08fffd164.jpg?1",
             "name": "Hunted Troll",
             "text": "When Hunted Troll comes into play, put four 1/1 blue Faerie creature tokens with flying into play under target opponent's control.\n{G}: Regenerate Hunted Troll.",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "92d05c9c-7ed9-5bdf-b1b9-ac5fe1b9554f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73597c90-a527-4338-9668-126c6cf15927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73597c90-a527-4338-9668-126c6cf15927.jpg?1",
             "name": "Ivy Dancer",
             "text": "{T}: Target creature gains forestwalk until end of turn.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "ce783790-bdb1-54ea-8433-c35e797e8aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac16d09-8bc7-407c-a757-666f4707bc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac16d09-8bc7-407c-a757-666f4707bc90.jpg?1",
             "name": "Life from the Loam",
             "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "5b4cbdfb-9659-5c54-8f39-24ac175904a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c3f80-aaa7-485f-b519-57363f5905dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c3f80-aaa7-485f-b519-57363f5905dd.jpg?1",
             "name": "Moldervine Cloak",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "9bbf9c3a-8077-5b86-aec4-f59bd0a89c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f2a6de-1598-4dd9-81a0-9a4f3dd4de0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f2a6de-1598-4dd9-81a0-9a4f3dd4de0b.jpg?1",
             "name": "Nullmage Shepherd",
             "text": "Tap four untapped creatures you control: Destroy target artifact or enchantment.",
             "colours": [
@@ -5861,7 +5861,7 @@
         },
         {
             "id": "9cf1da14-c2e1-5c47-9119-66c0c9039f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f6cc6-52ed-417f-b816-5733a71566e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f6cc6-52ed-417f-b816-5733a71566e8.jpg?1",
             "name": "Overwhelm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "be3901f3-b843-5080-8cb9-162d11b96926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210a148-d16c-42de-b0d6-83c05c553dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210a148-d16c-42de-b0d6-83c05c553dd4.jpg?1",
             "name": "Perilous Forays",
             "text": "{1}, Sacrifice a creature: Search your library for a land card with a basic land type and put it into play tapped. Then shuffle your library.",
             "colours": [
@@ -5925,7 +5925,7 @@
         },
         {
             "id": "4294ccb7-7d57-5f82-804f-67bdc4425951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e11e6d8-d375-4278-8cb0-94deeecaeeca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e11e6d8-d375-4278-8cb0-94deeecaeeca.jpg?1",
             "name": "Primordial Sage",
             "text": "Whenever you play a creature spell, you may draw a card.",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "c6407cc8-db5e-50c2-8cfb-91898200f7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa7f09-a2cc-4bef-857a-32bcccb7366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa7f09-a2cc-4bef-857a-32bcccb7366a.jpg?1",
             "name": "Recollect",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "84a77197-1c1a-575e-b682-e72da9d7e209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c5546f-2429-4099-a9bd-eda3f52779b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c5546f-2429-4099-a9bd-eda3f52779b7.jpg?1",
             "name": "Rolling Spoil",
             "text": "Destroy target land. If {B} was spent to play Rolling Spoil, all creatures get -1/-1 until end of turn.",
             "colours": [
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "2a35aa39-5ff6-5f70-9dd0-7a6fa2d0ba8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e469162b-c8c9-4746-80f3-d2c2acd89e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e469162b-c8c9-4746-80f3-d2c2acd89e0f.jpg?1",
             "name": "Root-Kin Ally",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTap two untapped creatures you control: Root-Kin Ally gets +2/+2 until end of turn.",
             "colours": [
@@ -6059,7 +6059,7 @@
         },
         {
             "id": "5f51c98c-dd84-5b95-8d3f-744bf8968df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4415070-4304-482b-b8e5-2bf689af0843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4415070-4304-482b-b8e5-2bf689af0843.jpg?1",
             "name": "Scatter the Seeds",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nPut three 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -6091,7 +6091,7 @@
         },
         {
             "id": "f2035de2-ab53-5d76-908a-31c909c5ea1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb05072-c619-4024-8ed8-440b01f73113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb05072-c619-4024-8ed8-440b01f73113.jpg?1",
             "name": "Scion of the Wild",
             "text": "Scion of the Wild's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -6125,7 +6125,7 @@
         },
         {
             "id": "12d36672-1455-5c7a-a7a7-47ea8757134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae199825-563e-4837-a6d2-7b009b93cd4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae199825-563e-4837-a6d2-7b009b93cd4d.jpg?1",
             "name": "Siege Wurm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTrample",
             "colours": [
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "a4237af4-952f-546f-a1c7-a49eb690403e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e1b9f9-e58c-4474-9a31-8e5d9f96492e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e1b9f9-e58c-4474-9a31-8e5d9f96492e.jpg?1",
             "name": "Stone-Seeder Hierophant",
             "text": "Whenever a land comes into play under your control, untap Stone-Seeder Hierophant.\n{T}: Untap target land.",
             "colours": [
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "febb466a-a484-5a03-b1d2-8bb518b79cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab15b40-c5c8-4d77-a4c0-982b6bf94267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab15b40-c5c8-4d77-a4c0-982b6bf94267.jpg?1",
             "name": "Sundering Vitae",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "bf18d50d-461f-568c-ae19-c068c0cf7343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ce4ef-38bd-4360-895f-457587164197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ce4ef-38bd-4360-895f-457587164197.jpg?1",
             "name": "Transluminant",
             "text": "{W}, Sacrifice Transluminant: Put a 1/1 white Spirit creature token with flying into play at end of turn.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "f8ff0acb-cc0c-59f1-8c5b-903107bc2ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d1047-9010-437c-94ab-7a8ad3a0250f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d1047-9010-437c-94ab-7a8ad3a0250f.jpg?1",
             "name": "Trophy Hunter",
             "text": "{1}{G}: Trophy Hunter deals 1 damage to target creature with flying.\nWhenever a creature with flying dealt damage by Trophy Hunter this turn is put into a graveyard, put a +1/+1 counter on Trophy Hunter.",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "cf82230f-aba8-5f6f-977b-b0cf27056efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba547810-c82a-498b-81eb-e81a8dcbbd42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba547810-c82a-498b-81eb-e81a8dcbbd42.jpg?1",
             "name": "Ursapine",
             "text": "{G}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -6331,7 +6331,7 @@
         },
         {
             "id": "2b004b9e-40e1-52b4-83b2-11ec74543700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34955f52-521f-466c-9025-c117f6162e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34955f52-521f-466c-9025-c117f6162e97.jpg?1",
             "name": "Vinelasher Kudzu",
             "text": "Whenever a land comes into play under your control, put a +1/+1 counter on Vinelasher Kudzu.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "f082e76d-1746-5635-8e10-53e917d1de45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2521942-0ecd-45a9-bac6-04267a2c29ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2521942-0ecd-45a9-bac6-04267a2c29ed.jpg?1",
             "name": "Agrus Kos, Wojek Veteran",
             "text": "Whenever Agrus Kos, Wojek Veteran attacks, attacking red creatures get +2/+0 and attacking white creatures get +0/+2 until end of turn.",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "8b40b5e3-4405-558f-aab3-7f338ff98dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7002a87b-a55f-42ec-b247-119a3229129f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7002a87b-a55f-42ec-b247-119a3229129f.jpg?1",
             "name": "Autochthon Wurm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTrample",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "58cf0961-f32d-59b8-8518-89ee1f3929e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb977f5b-2202-43c1-a8c0-7fba8c093fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb977f5b-2202-43c1-a8c0-7fba8c093fa2.jpg?1",
             "name": "Bloodbond March",
             "text": "Whenever a creature spell is played, each player returns all cards with the same name as that spell from his or her graveyard to play.",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "2bbd9b32-af50-55f9-bccd-cdb3c3db1b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf25cd63-3304-4eea-841b-1f058010c627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf25cd63-3304-4eea-841b-1f058010c627.jpg?1",
             "name": "Boros Swiftblade",
             "text": "Double strike",
             "colours": [
@@ -6511,7 +6511,7 @@
         },
         {
             "id": "d031d813-2876-56d6-a4f8-2b01220c95ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3acf27-5d07-48e6-8e19-a2e6d4cd49d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3acf27-5d07-48e6-8e19-a2e6d4cd49d1.jpg?1",
             "name": "Brightflame",
             "text": "Radiance Brightflame deals X damage to target creature and each other creature that shares a color with it. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -6545,7 +6545,7 @@
         },
         {
             "id": "13579ae3-2808-51a3-a3f3-cab709a30dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2792033-19e1-4629-8155-85c6c2d89106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2792033-19e1-4629-8155-85c6c2d89106.jpg?1",
             "name": "Chorus of the Conclave",
             "text": "Forestwalk\nAs an additional cost to play creature spells, you may pay any amount of mana. If you do, that creature comes into play with that many additional +1/+1 counters on it.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "453557f6-8c03-50cb-92c5-dac1bca10dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b19c0f3-68a5-4544-985a-677aa2c2b50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b19c0f3-68a5-4544-985a-677aa2c2b50b.jpg?1",
             "name": "Circu, Dimir Lobotomist",
             "text": "Whenever you play a blue spell, remove the top card of target library from the game.\nWhenever you play a black spell, remove the top card of target library from the game.\nYour opponents can't play nonland cards with the same name as a card removed from the game with Circu, Dimir Lobotomist.",
             "colours": [
@@ -6622,7 +6622,7 @@
         },
         {
             "id": "2f63a51d-f3b2-56b5-a8dd-cd8bc605121c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24437641-85a1-4fcd-93dc-bd19a7abf969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24437641-85a1-4fcd-93dc-bd19a7abf969.jpg?1",
             "name": "Clutch of the Undercity",
             "text": "Return target permanent to its owner's hand. Its controller loses 3 life.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -6656,7 +6656,7 @@
         },
         {
             "id": "fa4ba4b4-d3ea-5c35-a0bd-103584e2442c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b950a-b2fe-4afc-bb79-c9f4c272ea36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b950a-b2fe-4afc-bb79-c9f4c272ea36.jpg?1",
             "name": "Congregation at Dawn",
             "text": "Search your library for up to three creature cards and reveal them. Shuffle your library, then put those cards on top of it in any order.",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "5b2c7849-7049-50d7-9642-5a0aef702353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f51484b-3bad-4332-87f8-61924e153799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f51484b-3bad-4332-87f8-61924e153799.jpg?1",
             "name": "Consult the Necrosages",
             "text": "Choose one Target player draws two cards; or target player discards two cards.",
             "colours": [
@@ -6724,7 +6724,7 @@
         },
         {
             "id": "cdb47081-cb5e-51d1-90c2-373fa4442ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa3ae99-a770-4487-8de6-68a347ee64bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa3ae99-a770-4487-8de6-68a347ee64bb.jpg?1",
             "name": "Dark Heart of the Wood",
             "text": "Sacrifice a Forest: You gain 3 life.",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "fc519b02-d387-58ef-9c50-4c32685e920c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2b0b24-83bf-479b-baa4-3244a114852d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2b0b24-83bf-479b-baa4-3244a114852d.jpg?1",
             "name": "Dimir Cutpurse",
             "text": "Whenever Dimir Cutpurse deals combat damage to a player, that player discards a card and you draw a card.",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "395cbbdd-35bc-5e53-8cfb-c3e829055d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48be841-d35c-4d99-aebc-3684b36760ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48be841-d35c-4d99-aebc-3684b36760ac.jpg?1",
             "name": "Dimir Doppelganger",
             "text": "{1}{U}{B}: Remove target creature card in a graveyard from the game. Dimir Doppelganger becomes a copy of that card and gains this ability.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "f530fa6e-3693-506d-90e1-c50fced85654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db9204c-dde8-4241-aac2-1f090566f604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db9204c-dde8-4241-aac2-1f090566f604.jpg?1",
             "name": "Dimir Infiltrator",
             "text": "Dimir Infiltrator is unblockable.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -6866,7 +6866,7 @@
         },
         {
             "id": "ccd23eca-52a3-5898-aac1-c4b58afe9f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de33c222-0d74-4eb5-8794-39f3601eb8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de33c222-0d74-4eb5-8794-39f3601eb8f4.jpg?1",
             "name": "Drooling Groodion",
             "text": "{2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "183d005e-9f6f-5252-9df3-f50bf7ab8db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493730ab-c30d-4830-a188-0462426fc5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493730ab-c30d-4830-a188-0462426fc5bf.jpg?1",
             "name": "Firemane Angel",
             "text": "Flying, first strike\nAt the beginning of your upkeep, if Firemane Angel is in your graveyard or in play, you may gain 1 life.\n{6}{R}{R}{W}{W}: Return Firemane Angel from your graveyard to play. Play this ability only during your upkeep.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "5d2cc56e-38c8-5681-bdb4-29f69938fcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec53f16-5bf7-4ef5-b83e-9e36463d1640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec53f16-5bf7-4ef5-b83e-9e36463d1640.jpg?1",
             "name": "Flame-Kin Zealot",
             "text": "When Flame-Kin Zealot comes into play, creatures you control get +1/+1 and gain haste until end of turn.",
             "colours": [
@@ -6975,7 +6975,7 @@
         },
         {
             "id": "53b8c3a5-8d06-53f4-915e-e2556baddc63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6166c1-3c2e-47af-873e-d3b39f42bd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6166c1-3c2e-47af-873e-d3b39f42bd27.jpg?1",
             "name": "Glare of Subdual",
             "text": "Tap an untapped creature you control: Tap target artifact or creature.",
             "colours": [
@@ -7009,7 +7009,7 @@
         },
         {
             "id": "5b1744f0-fe62-5d3b-9d6d-3afc718e37fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48058253-54b8-403b-8d95-94d8da986e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48058253-54b8-403b-8d95-94d8da986e69.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player puts the top ten cards of his or her library into his or her graveyard.",
             "colours": [
@@ -7043,7 +7043,7 @@
         },
         {
             "id": "995420bb-d38b-5ac1-b037-dd553acfc9f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a1db16-d936-4f92-9611-327a988ce04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a1db16-d936-4f92-9611-327a988ce04c.jpg?1",
             "name": "Golgari Germination",
             "text": "Whenever a nontoken creature you control is put into a graveyard from play, put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7077,7 +7077,7 @@
         },
         {
             "id": "3d3e337a-c4fe-553f-a3f7-a1f8836c3b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc97674-f60a-4854-a807-60dbcf90637e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc97674-f60a-4854-a807-60dbcf90637e.jpg?1",
             "name": "Golgari Rotwurm",
             "text": "{B}, Sacrifice a creature: Target player loses 1 life.",
             "colours": [
@@ -7114,7 +7114,7 @@
         },
         {
             "id": "2b87f5e4-7a9a-5f2b-901e-4a9f90fc178a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f7c7d0-a48b-4153-8386-a9ab71e01dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f7c7d0-a48b-4153-8386-a9ab71e01dbe.jpg?1",
             "name": "Grave-Shell Scarab",
             "text": "{1}, Sacrifice Grave-Shell Scarab: Draw a card.\nDredge 1 (If you would draw a card, instead you may put exactly one card from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -7150,7 +7150,7 @@
         },
         {
             "id": "00a9a91f-5e03-55dd-8056-fa9a1487e2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c293144-df82-481d-8d24-2bdc164a355f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c293144-df82-481d-8d24-2bdc164a355f.jpg?1",
             "name": "Guardian of Vitu-Ghazi",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nVigilance",
             "colours": [
@@ -7186,7 +7186,7 @@
         },
         {
             "id": "e61fd0ed-2584-5418-8eda-895e195a01ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ecf55-c1cc-4b28-b7ce-e1b25305155e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ecf55-c1cc-4b28-b7ce-e1b25305155e.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -7220,7 +7220,7 @@
         },
         {
             "id": "4bbdd0b5-fa9b-5c01-9bcb-7f3d00219ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d3ccca-8040-4a5f-9f2b-6fdb1a033234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d3ccca-8040-4a5f-9f2b-6fdb1a033234.jpg?1",
             "name": "Loxodon Hierarch",
             "text": "When Loxodon Hierarch comes into play, you gain 4 life.\n{G}{W}, Sacrifice Loxodon Hierarch: Regenerate each creature you control.",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "48f883d8-4058-56bd-8faa-96ba0664835f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd1ace7-d4fe-4f96-9434-7ab1442bf36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd1ace7-d4fe-4f96-9434-7ab1442bf36f.jpg?1",
             "name": "Mindleech Mass",
             "text": "Trample\nWhenever Mindleech Mass deals combat damage to a player, you may look at that player's hand. If you do, you may play a nonland card in it without paying that card's mana cost.",
             "colours": [
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "c1b576c5-065d-5087-885c-6fcedf90ec60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ce70-67d1-4007-94ed-4545867e90c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ce70-67d1-4007-94ed-4545867e90c8.jpg?1",
             "name": "Moroii",
             "text": "Flying\nAt the beginning of your upkeep, you lose 1 life.",
             "colours": [
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "fae008d9-5c98-514e-a421-19ee462b615c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db57459-29f0-4ef6-b256-56955036c0ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db57459-29f0-4ef6-b256-56955036c0ef.jpg?1",
             "name": "Perplex",
             "text": "Counter target spell unless its controller discards his or her hand.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "7a996930-adb2-5ddf-b461-dc260ff1299e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c336d2-cc14-4b74-a6f9-aab7a084d0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c336d2-cc14-4b74-a6f9-aab7a084d0de.jpg?1",
             "name": "Phytohydra",
             "text": "If damage would be dealt to Phytohydra, put that many +1/+1 counters on it instead.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "bf6b7f41-54c7-57c6-a191-104752a1ffb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4f3b9-c952-4fd3-a586-3e063b62b23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4f3b9-c952-4fd3-a586-3e063b62b23d.jpg?1",
             "name": "Pollenbright Wings",
             "text": "Enchant creature\nEnchanted creature has flying.\nWhenever enchanted creature deals combat damage to a player, put that many 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "b08979df-d3d0-5233-892f-3e5b0d41c96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fd2d8-76ce-4334-b772-a5dc64fc2989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fd2d8-76ce-4334-b772-a5dc64fc2989.jpg?1",
             "name": "Psychic Drain",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard and you gain X life.",
             "colours": [
@@ -7470,7 +7470,7 @@
         },
         {
             "id": "053430c0-71b0-581d-bd3d-a71245169850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a16086c-5a74-45d0-8b38-e832cfbc80f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a16086c-5a74-45d0-8b38-e832cfbc80f7.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "9d6d70be-5377-508c-a46c-1b6ad93b678a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da51b6c-2e27-4b41-8fb0-bd9f6ad47b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da51b6c-2e27-4b41-8fb0-bd9f6ad47b19.jpg?1",
             "name": "Rally the Righteous",
             "text": "Radiance Untap target creature and each other creature that shares a color with it. Those creatures get +2/+0 until end of turn.",
             "colours": [
@@ -7538,7 +7538,7 @@
         },
         {
             "id": "a0e6342a-749e-51c9-8724-0307c6b76b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4580cc4-ee26-41d9-a81c-91505c9e2a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4580cc4-ee26-41d9-a81c-91505c9e2a99.jpg?1",
             "name": "Razia, Boros Archangel",
             "text": "Flying, vigilance, haste\n{T}: The next 3 damage that would be dealt to target creature you control this turn is dealt to another target creature instead.",
             "colours": [
@@ -7576,7 +7576,7 @@
         },
         {
             "id": "76134657-9512-53e5-a6fc-612936fe5430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bfefd3-bddd-47bb-92f3-9356a7bca637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bfefd3-bddd-47bb-92f3-9356a7bca637.jpg?1",
             "name": "Razia's Purification",
             "text": "Each player chooses three permanents he or she controls, then sacrifices the rest.",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "41ced48b-e899-595b-b597-c1713a9b23d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15accf35-a174-4ba5-a633-cc46da848dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15accf35-a174-4ba5-a633-cc46da848dbe.jpg?1",
             "name": "Savra, Queen of the Golgari",
             "text": "Whenever you sacrifice a black creature, you may pay 2 life. If you do, each other player sacrifices a creature.\nWhenever you sacrifice a green creature, you may gain 2 life.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "093f3647-e200-5d25-91a4-c2203c1a8e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c1fbdd-884d-467a-956e-7c28881002ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c1fbdd-884d-467a-956e-7c28881002ab.jpg?1",
             "name": "Searing Meditation",
             "text": "Whenever you gain life, you may pay {2}. If you do, Searing Meditation deals 2 damage to target creature or player.",
             "colours": [
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "b35aa8d3-6a4c-5e15-af92-3e31e01a605b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1ac13-adbd-439a-90b2-9c506aec0836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1ac13-adbd-439a-90b2-9c506aec0836.jpg?1",
             "name": "Seeds of Strength",
             "text": "Target creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7717,7 +7717,7 @@
         },
         {
             "id": "81a24c93-3e7b-588d-89fd-35986a869c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc93c1-f236-4d1b-bb54-5041b3cae5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc93c1-f236-4d1b-bb54-5041b3cae5a6.jpg?1",
             "name": "Selesnya Evangel",
             "text": "{1}, {T}, Tap an untapped creature you control: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "397533b3-b323-55d0-8b45-c886a135431e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72e933-d977-4be9-985f-8b8cf1267f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72e933-d977-4be9-985f-8b8cf1267f8c.jpg?1",
             "name": "Selesnya Sagittars",
             "text": "Selesnya Sagittars can block as though it had flying.\nSelesnya Sagittars can block an additional creature.",
             "colours": [
@@ -7791,7 +7791,7 @@
         },
         {
             "id": "91999a15-77f6-52de-8cc3-ece4533870ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c93baa2-a23e-4e18-b4cd-779c992d2042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c93baa2-a23e-4e18-b4cd-779c992d2042.jpg?1",
             "name": "Shambling Shell",
             "text": "Sacrifice Shambling Shell: Put a +1/+1 counter on target creature.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "83ac4bbb-3524-5919-b694-948835fcaa47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d214d25b-96c3-4479-88f0-3996805d6e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d214d25b-96c3-4479-88f0-3996805d6e6f.jpg?1",
             "name": "Sisters of Stone Death",
             "text": "{G}: Target creature blocks Sisters of Stone Death this turn if able.\n{B}{G}: Remove from the game target creature blocking or blocked by Sisters of Stone Death.\n{2}{B}: Put a creature card removed from the game with Sisters of Stone Death into play under your control.",
             "colours": [
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "0d1accb6-0750-5106-86fa-e2d306957ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d697ef7f-0e51-4bf1-b0f5-742325706d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d697ef7f-0e51-4bf1-b0f5-742325706d2a.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "c4c283d1-38e1-54c1-8f78-9fb2cdd3c9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d5a88e-fc8f-4dd6-a1db-8e44b74ee0a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d5a88e-fc8f-4dd6-a1db-8e44b74ee0a1.jpg?1",
             "name": "Sunhome Enforcer",
             "text": "Whenever Sunhome Enforcer deals combat damage, you gain that much life.\n{1}{R}: Sunhome Enforcer gets +1/+0 until end of turn.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "5b121bea-6ded-5381-ac80-356798db0f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2882793e-5d7d-47f0-9308-652a5e036c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2882793e-5d7d-47f0-9308-652a5e036c2c.jpg?1",
             "name": "Szadek, Lord of Secrets",
             "text": "Flying\nIf Szadek, Lord of Secrets would deal combat damage to a player, instead put that many +1/+1 counters on Szadek and that player puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "05953b58-a7c9-5e3d-8453-fd2864ec9a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7410c546-745c-469f-b3b8-eafb69391600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7410c546-745c-469f-b3b8-eafb69391600.jpg?1",
             "name": "Thundersong Trumpeter",
             "text": "{T}: Target creature can't attack or block this turn.",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "2d44bf3a-1e70-51b0-8916-ca2d1637e093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069ac859-e0ef-4685-bad3-5c741102b5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069ac859-e0ef-4685-bad3-5c741102b5b9.jpg?1",
             "name": "Tolsimir Wolfblood",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\n{T}: Put a legendary 2/2 green and white Wolf creature token named Voja into play.",
             "colours": [
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "56830f0b-574b-542e-b359-1e1f96d00945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8efa02d-c301-47e1-8cdf-26ff9e97a243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8efa02d-c301-47e1-8cdf-26ff9e97a243.jpg?1",
             "name": "Twisted Justice",
             "text": "Target player sacrifices a creature. You draw cards equal to that creature's power.",
             "colours": [
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "d78b4876-e7c1-57c4-8add-1e03c1641619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0fb8e7-14aa-4f2d-aa05-c98b2c9c463c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0fb8e7-14aa-4f2d-aa05-c98b2c9c463c.jpg?1",
             "name": "Vulturous Zombie",
             "text": "Flying\nWhenever a card is put into an opponent's graveyard from anywhere, put a +1/+1 counter on Vulturous Zombie.",
             "colours": [
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "4105410d-0c37-5789-bd00-5ab797869010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e5828a-3e54-4b9c-9e84-21880930f2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e5828a-3e54-4b9c-9e84-21880930f2d5.jpg?1",
             "name": "Watchwolf",
             "text": "",
             "colours": [
@@ -8161,7 +8161,7 @@
         },
         {
             "id": "74a0677a-51e1-5aad-96f9-82b551cf6d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ee1ceb-61dd-4c98-bc48-a0763315a14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ee1ceb-61dd-4c98-bc48-a0763315a14f.jpg?1",
             "name": "Woodwraith Corrupter",
             "text": "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.",
             "colours": [
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "4702b4cc-8657-5a1b-9fd2-4fe243a435d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be72ff91-f810-46c3-884f-6e65827824bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be72ff91-f810-46c3-884f-6e65827824bc.jpg?1",
             "name": "Woodwraith Strangler",
             "text": "Remove a creature card in your graveyard from the game: Regenerate Woodwraith Strangler.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "58ff5d21-c09e-5db2-8c2f-a7dec1044c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072a1ff1-9c50-426a-a83c-817bde5beab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072a1ff1-9c50-426a-a83c-817bde5beab7.jpg?1",
             "name": "Boros Guildmage",
             "text": "({GU} can be paid with either {R} or {W}.)\n{1}{R}: Target creature gains haste until end of turn.\n{1}{W}: Target creature gains first strike until end of turn.",
             "colours": [
@@ -8272,7 +8272,7 @@
         },
         {
             "id": "e7281adb-90f4-5846-84fc-b37d9fffd0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af01330-05c2-4c5b-9830-2886711b2b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af01330-05c2-4c5b-9830-2886711b2b5d.jpg?1",
             "name": "Boros Recruit",
             "text": "({GU} can be paid with either {R} or {W}.)\nFirst strike",
             "colours": [
@@ -8309,7 +8309,7 @@
         },
         {
             "id": "e6907eca-7ab7-50b7-8643-54e3ef59dfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d3e06-93e6-4948-a3ec-6a00bdfc0f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d3e06-93e6-4948-a3ec-6a00bdfc0f99.jpg?1",
             "name": "Centaur Safeguard",
             "text": "({RW} can be paid with either {G} or {W}.)\nWhen Centaur Safeguard is put into a graveyard from play, you may gain 3 life.",
             "colours": [
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "5e253a9c-ac94-5adb-a43b-977bbeddb0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b822aa-4144-400a-b993-f146cbeed54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b822aa-4144-400a-b993-f146cbeed54f.jpg?1",
             "name": "Dimir Guildmage",
             "text": "({UB} can be paid with either {U} or {B}.)\n{3}{U}: Target player draws a card. Play this ability only any time you could play a sorcery.\n{3}{B}: Target player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "6f8dd65f-541e-5648-a5e6-46ac14dab8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c9e772-5213-4c28-9b6c-1cfa6675ee8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c9e772-5213-4c28-9b6c-1cfa6675ee8f.jpg?1",
             "name": "Gaze of the Gorgon",
             "text": "({BG} can be paid with either {B} or {G}.)\nRegenerate target creature. At end of combat, destroy all creatures that blocked or were blocked by that creature this turn.",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "c6fe3337-c030-5027-bd04-8a3efc82c974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ebb44b-bf3e-4b9e-b568-c20970bb969d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ebb44b-bf3e-4b9e-b568-c20970bb969d.jpg?1",
             "name": "Gleancrawler",
             "text": "({BG} can be paid with either {B} or {G}.)\nTrample\nAt the end of your turn, return to your hand all creature cards in your graveyard that were put into your graveyard from play this turn.",
             "colours": [
@@ -8454,7 +8454,7 @@
         },
         {
             "id": "09a6caee-5d4c-5ecb-94cb-3a87f7f716f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91b994b-3cf2-43f7-8af6-7925e882208f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91b994b-3cf2-43f7-8af6-7925e882208f.jpg?1",
             "name": "Golgari Guildmage",
             "text": "({BG} can be paid with either {B} or {G}.)\n{4}{B}, Sacrifice a creature: Return target creature card from your graveyard to your hand.\n{4}{G}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -8491,7 +8491,7 @@
         },
         {
             "id": "09f94154-ca76-516b-935d-ea73506ce16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012a7f5d-f798-4030-86e3-05956487a383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012a7f5d-f798-4030-86e3-05956487a383.jpg?1",
             "name": "Lurking Informant",
             "text": "({UB} can be paid with either {U} or {B}.)\n{2}, {T}: Look at the top card of target player's library. You may put that card into that player's graveyard.",
             "colours": [
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "183f0174-15d9-5f8a-893d-b6c1b8d1ab88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d111510-ca7f-4127-b540-48265aa36311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d111510-ca7f-4127-b540-48265aa36311.jpg?1",
             "name": "Master Warcraft",
             "text": "({GU} can be paid with either {R} or {W}.)\nPlay Master Warcraft only before attackers are declared.\nYou choose which creatures attack this turn. You choose how each creature blocks this turn.",
             "colours": [
@@ -8562,7 +8562,7 @@
         },
         {
             "id": "990b4608-845a-5e46-a7ce-5841036d5792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fa7566-6f7d-4c01-a442-ff7b38684de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fa7566-6f7d-4c01-a442-ff7b38684de5.jpg?1",
             "name": "Privileged Position",
             "text": "({RW} can be paid with either {G} or {W}.)\nOther permanents you control can't be the targets of spells or abilities your opponents control.",
             "colours": [
@@ -8596,7 +8596,7 @@
         },
         {
             "id": "5e01676c-e569-5361-a283-a955985a1c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061ce3-d098-4057-b341-c5db6ee1b6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061ce3-d098-4057-b341-c5db6ee1b6d4.jpg?1",
             "name": "Selesnya Guildmage",
             "text": "({RW} can be paid with either {G} or {W}.)\n{3}{G}: Put a 1/1 green Saproling creature token into play.\n{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8633,7 +8633,7 @@
         },
         {
             "id": "81752769-5fae-5f84-8ef3-b0a54ae4a07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd0e3c-b26d-4080-b7cf-1c64fce09668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd0e3c-b26d-4080-b7cf-1c64fce09668.jpg?1",
             "name": "Shadow of Doubt",
             "text": "({UB} can be paid with either {U} or {B}.)\nPlayers can't search libraries this turn.\nDraw a card.",
             "colours": [
@@ -8667,7 +8667,7 @@
         },
         {
             "id": "efeafb7b-1469-57d2-ad0b-ce14fb1a4d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fbdf87-2424-4fc2-904e-b1e5fef2a335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fbdf87-2424-4fc2-904e-b1e5fef2a335.jpg?1",
             "name": "Bloodletter Quill",
             "text": "{2}, {T}, Put a blood counter on Bloodletter Quill: Draw a card, then lose 1 life for each blood counter on Bloodletter Quill.\n{U}{B}: Remove a blood counter from Bloodletter Quill.",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "9c2d81ca-5226-5e4b-86e8-25f7db1b55e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bae1f86-4639-4424-b47b-fdc826bf6e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bae1f86-4639-4424-b47b-fdc826bf6e97.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -8729,7 +8729,7 @@
         },
         {
             "id": "4b3fd16f-651c-5a95-ac77-d531f3404215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf42acc-d2d3-4165-b257-6885df2d1ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf42acc-d2d3-4165-b257-6885df2d1ba4.jpg?1",
             "name": "Bottled Cloister",
             "text": "At the beginning of each opponent's upkeep, remove your hand from the game face down.\nAt the beginning of your upkeep, return all cards removed from the game with Bottled Cloister to your hand, then draw a card.",
             "colours": [],
@@ -8757,7 +8757,7 @@
         },
         {
             "id": "3e762ce1-a71e-5628-96fe-16f023b26692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cbda17-d368-4dc3-b41c-95b146468b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cbda17-d368-4dc3-b41c-95b146468b44.jpg?1",
             "name": "Cloudstone Curio",
             "text": "Whenever a nonartifact permanent comes into play under your control, you may return another permanent you control that shares a permanent type with it to its owner's hand.",
             "colours": [],
@@ -8785,7 +8785,7 @@
         },
         {
             "id": "2af36b8a-b78e-59c6-a39a-389c9130e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9f8c8-2927-4746-a540-dd3853b9a00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9f8c8-2927-4746-a540-dd3853b9a00e.jpg?1",
             "name": "Crown of Convergence",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is a creature card, creatures you control that share a color with that card get +1/+1.\n{G}{W}: Put the top card of your library on the bottom of your library.",
             "colours": [],
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "9c789793-c943-5610-9932-df7f18bac118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ba776a-c959-4d15-aa36-9fba1fcb512d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ba776a-c959-4d15-aa36-9fba1fcb512d.jpg?1",
             "name": "Cyclopean Snare",
             "text": "{3}, {T}: Tap target creature, then return Cyclopean Snare to its owner's hand.",
             "colours": [],
@@ -8844,7 +8844,7 @@
         },
         {
             "id": "ce7fef66-cc4b-51eb-a04a-a80a07c39b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a1df5-a4e8-49a4-aebe-ca93894ccfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a1df5-a4e8-49a4-aebe-ca93894ccfcf.jpg?1",
             "name": "Dimir Signet",
             "text": "{1}, {T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "e50d20e1-d4be-5ebc-b894-ae035d53f1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87dc27-3cea-4101-aec5-ca0b96978476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87dc27-3cea-4101-aec5-ca0b96978476.jpg?1",
             "name": "Glass Golem",
             "text": "",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "322cac64-5434-522e-9e63-eac1789cb457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be03b002-1a3e-4b21-bc23-7f5a9cedb74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be03b002-1a3e-4b21-bc23-7f5a9cedb74f.jpg?1",
             "name": "Golgari Signet",
             "text": "{1}, {T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -8937,7 +8937,7 @@
         },
         {
             "id": "f7ccd7a2-5491-5a75-96d3-03ea414aba9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c411784-fe96-42c0-baaa-36616d2be0b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c411784-fe96-42c0-baaa-36616d2be0b3.jpg?1",
             "name": "Grifter's Blade",
             "text": "You may play Grifter's Blade any time you could play an instant.\nGrifter's Blade comes into play equipping a creature of your choice you control.\nEquipped creature gets +1/+1.\nEquip {1}",
             "colours": [],
@@ -8967,7 +8967,7 @@
         },
         {
             "id": "076aecd2-ee13-5312-b855-c0c22b611d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2c5f0a-755f-4d4f-b5f8-a938562797f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2c5f0a-755f-4d4f-b5f8-a938562797f9.jpg?1",
             "name": "Junktroller",
             "text": "Defender (This creature can't attack.)\n{T}: Put target card in a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -8998,7 +8998,7 @@
         },
         {
             "id": "ed229ac6-bf5d-5c62-b7f3-4f3a19f93e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132551d3-ef8e-4ed0-a363-53db4f0621f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132551d3-ef8e-4ed0-a363-53db4f0621f0.jpg?1",
             "name": "Leashling",
             "text": "Put a card in your hand on top of your library: Return Leashling to its owner's hand.",
             "colours": [],
@@ -9029,7 +9029,7 @@
         },
         {
             "id": "f5962af1-362b-51fd-85e4-ce61b9e2616f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3aa88-2555-4862-a771-e9d5b9eab3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3aa88-2555-4862-a771-e9d5b9eab3ad.jpg?1",
             "name": "Nullstone Gargoyle",
             "text": "Flying\nWhenever the first noncreature spell each turn is played, counter that spell.",
             "colours": [],
@@ -9060,7 +9060,7 @@
         },
         {
             "id": "695aff1d-4e37-5ea8-84f2-7801224ddf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc316f1e-84ce-4013-a150-d537f964a604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc316f1e-84ce-4013-a150-d537f964a604.jpg?1",
             "name": "Pariah's Shield",
             "text": "All damage that would be dealt to you is dealt to equipped creature instead.\nEquip {3}",
             "colours": [],
@@ -9090,7 +9090,7 @@
         },
         {
             "id": "fcfb1c77-470a-5621-9b88-eaf258cd2648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9196f43e-f905-4e83-8e47-9d8fd53a4c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9196f43e-f905-4e83-8e47-9d8fd53a4c9f.jpg?1",
             "name": "Peregrine Mask",
             "text": "Equipped creature has defender, flying, and first strike.\nEquip {2}",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "3df6d500-7ad3-52da-8ae6-a43bbfb16436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889bab2c-d383-4a04-9f93-d507ba1973d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889bab2c-d383-4a04-9f93-d507ba1973d9.jpg?1",
             "name": "Plague Boiler",
             "text": "At the beginning of your upkeep, put a plague counter on Plague Boiler.\n{1}{B}{G}: Put a plague counter on Plague Boiler or remove a plague counter from it.\nWhen Plague Boiler has three or more plague counters on it, sacrifice it. If you do, destroy all nonland permanents.",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "273fbe25-2b2e-5985-9275-a80faf21cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296d86a-2c79-43c8-8a1c-1d4bb600bc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296d86a-2c79-43c8-8a1c-1d4bb600bc6b.jpg?1",
             "name": "Selesnya Signet",
             "text": "{1}, {T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -9182,7 +9182,7 @@
         },
         {
             "id": "243d65bb-1327-5675-ab41-9fa124bd65e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7209e2-8e62-40aa-ad84-16c6ad52fd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7209e2-8e62-40aa-ad84-16c6ad52fd69.jpg?1",
             "name": "Spectral Searchlight",
             "text": "{T}: Choose a player. That player adds one mana of any color he or she chooses to his or her mana pool.",
             "colours": [],
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "9c306e3a-2110-50ae-b597-e16b1c7b2cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d5e027-aa74-444b-a945-1bafa9bdec4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d5e027-aa74-444b-a945-1bafa9bdec4c.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and play that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "a789a1ae-4b80-5eae-b2c7-22c793b2f092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4b07f-c6ed-4a92-aab3-54ee6adfb793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4b07f-c6ed-4a92-aab3-54ee6adfb793.jpg?1",
             "name": "Terrarion",
             "text": "Terrarion comes into play tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana of any combination of colors to your mana pool.\nWhen Terrarion is put into a graveyard from play, draw a card.",
             "colours": [],
@@ -9271,7 +9271,7 @@
         },
         {
             "id": "976bf8cd-e60a-5276-bd19-7f3a0335c773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76554c65-edea-48b0-b3a5-483dfe80eaac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76554c65-edea-48b0-b3a5-483dfe80eaac.jpg?1",
             "name": "Voyager Staff",
             "text": "{2}, Sacrifice Voyager Staff: Remove target creature from the game. Return that creature to play under its owner's control at end of turn.",
             "colours": [],
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "2127bd81-012a-54c2-95f3-1103658dd954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfe3f03-078f-44fb-89cd-efa3ebfaf637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfe3f03-078f-44fb-89cd-efa3ebfaf637.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison comes into play tapped.\nWhen Boros Garrison comes into play, return a land you control to its owner's hand.\n{T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -9330,7 +9330,7 @@
         },
         {
             "id": "2ecd3ce5-e0d7-56e4-8d87-df9b678d7208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3c3d56-8291-407e-87a1-94b7d12811fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3c3d56-8291-407e-87a1-94b7d12811fd.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct comes into play tapped.\nWhen Dimir Aqueduct comes into play, return a land you control to its owner's hand.\n{T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "32d6d03c-eef1-529f-9553-01ff8e8b9424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c85e2-58a5-4469-85ea-7e89268f310c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c85e2-58a5-4469-85ea-7e89268f310c.jpg?1",
             "name": "Duskmantle, House of Shadow",
             "text": "{T}: Add {1} to your mana pool.\n{U}{B}, {T}: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "911117a2-7e08-56c3-b461-71d3f6efa207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104364d5-ede8-4ac5-900f-19947f51bbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104364d5-ede8-4ac5-900f-19947f51bbc1.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm comes into play tapped.\nWhen Golgari Rot Farm comes into play, return a land you control to its owner's hand.\n{T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -9423,7 +9423,7 @@
         },
         {
             "id": "2e023e3e-dc65-5aac-905e-6c139346e1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce07335-cc78-4683-b2f0-9c98a06ea1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce07335-cc78-4683-b2f0-9c98a06ea1d8.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G} to your mana pool.)\nAs Overgrown Tomb comes into play, you may pay 2 life. If you don't, Overgrown Tomb comes into play tapped instead.",
             "colours": [],
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "3b30c16d-eb6d-59fa-9729-bc868450a204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168ef687-5797-4b45-b75b-393d8117cebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168ef687-5797-4b45-b75b-393d8117cebd.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W} to your mana pool.)\nAs Sacred Foundry comes into play, you may pay 2 life. If you don't, Sacred Foundry comes into play tapped instead.",
             "colours": [],
@@ -9491,7 +9491,7 @@
         },
         {
             "id": "9da98b27-6527-5f23-8814-11a4404474f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e51787-f9c9-4926-9df1-a384a3092676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e51787-f9c9-4926-9df1-a384a3092676.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary comes into play tapped.\nWhen Selesnya Sanctuary comes into play, return a land you control to its owner's hand.\n{T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "39ea48df-0fce-566b-b832-0e44f4ced3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a69f7b-be68-43f7-b1ed-df528bde74e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a69f7b-be68-43f7-b1ed-df528bde74e5.jpg?1",
             "name": "Sunhome, Fortress of the Legion",
             "text": "{T}: Add {1} to your mana pool.\n{2}{R}{W}, {T}: Target creature gains double strike until end of turn.",
             "colours": [],
@@ -9553,7 +9553,7 @@
         },
         {
             "id": "3f6aa6a9-4174-5a58-8695-b8acb9e1a4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3ba87-93a0-44db-83d9-92e23a677a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3ba87-93a0-44db-83d9-92e23a677a62.jpg?1",
             "name": "Svogthos, the Restless Tomb",
             "text": "{T}: Add {1} to your mana pool.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land.",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "e43df04f-3552-5dc1-844e-6c13fe84b8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794a2b79-8c55-4423-8843-7e6e96f84071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794a2b79-8c55-4423-8843-7e6e96f84071.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W} to your mana pool.)\nAs Temple Garden comes into play, you may pay 2 life. If you don't, Temple Garden comes into play tapped instead.",
             "colours": [],
@@ -9618,7 +9618,7 @@
         },
         {
             "id": "558bbbc5-0820-559c-a66f-64559033c5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc35026-a29e-4fb0-931f-5e90faf41802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc35026-a29e-4fb0-931f-5e90faf41802.jpg?1",
             "name": "Vitu-Ghazi, the City-Tree",
             "text": "{T}: Add {1} to your mana pool.\n{2}{G}{W}, {T}: Put a 1/1 green Saproling creature token into play.",
             "colours": [],
@@ -9649,7 +9649,7 @@
         },
         {
             "id": "428d14f6-a8a5-566a-8a7e-6d1d14024ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b90cd-8272-457a-be32-1298145345be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b90cd-8272-457a-be32-1298145345be.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B} to your mana pool.)\nAs Watery Grave comes into play, you may pay 2 life. If you don't, Watery Grave comes into play tapped instead.",
             "colours": [],
@@ -9683,7 +9683,7 @@
         },
         {
             "id": "7270b504-f20f-5c8a-9e9e-50c3fa469f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8d3cd4-0f5f-4424-82ee-d8ba81da47fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8d3cd4-0f5f-4424-82ee-d8ba81da47fd.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9721,7 +9721,7 @@
         },
         {
             "id": "c6838738-e772-547a-b134-c068ff344e49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b7beb9-0805-47b9-8e62-ff110e9e086a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b7beb9-0805-47b9-8e62-ff110e9e086a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9759,7 +9759,7 @@
         },
         {
             "id": "37f35b53-f822-55f6-87e6-3455af0a577d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3d0fe-6af6-4d02-b41d-0b88b510be4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3d0fe-6af6-4d02-b41d-0b88b510be4f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9797,7 +9797,7 @@
         },
         {
             "id": "8c858455-36e8-594f-8e98-980047513237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2839fa-33eb-47fb-9541-77c68612aa02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2839fa-33eb-47fb-9541-77c68612aa02.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9835,7 +9835,7 @@
         },
         {
             "id": "0f096e5b-5527-5de3-9a2d-eb0901488344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c8056-f155-434c-a4cb-a532a4707245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c8056-f155-434c-a4cb-a532a4707245.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "4c4f7a66-0c6a-548f-9242-3b730fceccd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d603978-3877-454e-8910-53a4cc95431d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d603978-3877-454e-8910-53a4cc95431d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "b0a3ed8a-7fdb-5e71-a6f1-5164dee9c1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a272ca-98a7-4887-b6b7-903a1adc33e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a272ca-98a7-4887-b6b7-903a1adc33e0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9949,7 +9949,7 @@
         },
         {
             "id": "7b3d7000-0a6b-585b-aee0-671b2a95d93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cba2b8-d865-46e8-81f1-752598a0d729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cba2b8-d865-46e8-81f1-752598a0d729.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9987,7 +9987,7 @@
         },
         {
             "id": "565ec80b-b7b0-5752-b9ec-e18d666414ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2755f9f7-95f9-4907-8ec9-21853eb376f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2755f9f7-95f9-4907-8ec9-21853eb376f4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "b0b09dc7-fed0-586e-a2c8-55d5e8f67416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18dd43d-0d9e-4d61-90f9-63822cf0cb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18dd43d-0d9e-4d61-90f9-63822cf0cb2d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10063,7 +10063,7 @@
         },
         {
             "id": "96d4e248-f789-5b85-9cc2-bf011b67ea84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd659b0-1f79-4e3b-bc20-8f384aa43670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd659b0-1f79-4e3b-bc20-8f384aa43670.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10101,7 +10101,7 @@
         },
         {
             "id": "e99b0d0a-3cdb-5c08-b474-6643a348780e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a1df0-e6dc-4815-bb73-9d100ee6e0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a1df0-e6dc-4815-bb73-9d100ee6e0b2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10139,7 +10139,7 @@
         },
         {
             "id": "ba5758ab-f72b-5434-bd60-8dc1f236c3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad3662a-f7b4-45d5-a35e-fc6c38474692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad3662a-f7b4-45d5-a35e-fc6c38474692.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10177,7 +10177,7 @@
         },
         {
             "id": "16a09531-820b-55fa-969e-fef72eab9fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477ebad-e1e5-4508-aa20-39b47e39a5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477ebad-e1e5-4508-aa20-39b47e39a5c6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10215,7 +10215,7 @@
         },
         {
             "id": "25b204d8-06b5-5004-9062-d103e5fae03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312d7b-f505-45c3-bb87-650259e5db50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312d7b-f505-45c3-bb87-650259e5db50.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10253,7 +10253,7 @@
         },
         {
             "id": "c53bf60b-d201-51c8-9429-d372a8d0dc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e135c9f9-5099-4029-bc19-dd9a0760d86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e135c9f9-5099-4029-bc19-dd9a0760d86f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "bee0fa2a-7b02-5317-bc94-5adbe57cd4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706be1bd-720d-4e74-b71f-568081afcab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706be1bd-720d-4e74-b71f-568081afcab1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "80ac629e-1bd1-523d-b68e-db8f998e1dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839f63ad-476a-4344-b6c3-911c1075c2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839f63ad-476a-4344-b6c3-911c1075c2b8.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "2f5d8dd0-d45b-5e21-b18f-1e8c2d57b3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2e6db4-94a4-4fa9-be52-1ec235d2b137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2e6db4-94a4-4fa9-be52-1ec235d2b137.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10405,7 +10405,7 @@
         },
         {
             "id": "6201acf1-9e78-551e-b0a2-f6afc9a26c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade29c12-43f6-473d-bcc8-1e3f2cf4ee8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade29c12-43f6-473d-bcc8-1e3f2cf4ee8f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/RIX.json
+++ b/Assets/Resources/Sets/RIX.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7cc3f061-5568-55ff-810c-6a0fa247959e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208c6f51-3c00-4fc6-8579-8f57444d0e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208c6f51-3c00-4fc6-8579-8f57444d0e97.jpg?1",
             "name": "Baffling End",
             "text": "When Baffling End enters the battlefield, exile target creature an opponent controls with converted mana cost 3 or less.\nWhen Baffling End leaves the battlefield, target opponent creates a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "3156f0ba-53f3-579d-ba2d-829741f552c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaadceb3-8a57-45de-b3f1-aca94f20de18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaadceb3-8a57-45de-b3f1-aca94f20de18.jpg?1",
             "name": "Bishop of Binding",
             "text": "When Bishop of Binding enters the battlefield, exile target creature an opponent controls until Bishop of Binding leaves the battlefield.\nWhenever Bishop of Binding attacks, target Vampire gets +X/+X until end of turn, where X is the power of the exiled card.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "99d6fc09-bab7-5ca4-8244-51811fc772e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6beac36-e12f-408d-a37b-a70e0e6c52d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6beac36-e12f-408d-a37b-a70e0e6c52d8.jpg?1",
             "name": "Blazing Hope",
             "text": "Exile target creature with power greater than or equal to your life total.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d47fc463-2114-5c1a-a92c-45fbfca77760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf94184-e745-469a-9d55-af0ddacbb9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf94184-e745-469a-9d55-af0ddacbb9cf.jpg?1",
             "name": "Cleansing Ray",
             "text": "Choose one \u2014\n\u2022 Destroy target Vampire.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "c09aee38-0a29-5a0f-a3eb-88e8541206a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed07b708-7232-4b87-b5d9-edaa20a69293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed07b708-7232-4b87-b5d9-edaa20a69293.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "f6fee20f-95be-5d58-9a1a-9b63c7452432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a74fa9-1338-40ea-95d9-0f4e78b85f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a74fa9-1338-40ea-95d9-0f4e78b85f60.jpg?1",
             "name": "Everdawn Champion",
             "text": "Prevent all combat damage that would be dealt to Everdawn Champion.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "d85ca0b2-54e2-5a3a-bb78-4b6ae306f914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffe7b2b-22c3-4e6a-9b1b-c6d7b29b9f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffe7b2b-22c3-4e6a-9b1b-c6d7b29b9f86.jpg?1",
             "name": "Exultant Skymarcher",
             "text": "Flying",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "7601b75a-c4ba-5ca6-847f-c8c5167be5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e3bc9-7b67-4eab-916a-6d83da06f20a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e3bc9-7b67-4eab-916a-6d83da06f20a.jpg?1",
             "name": "Famished Paladin",
             "text": "Famished Paladin doesn't untap during your untap step.\nWhenever you gain life, untap Famished Paladin.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "64a89f6c-59d6-5112-98f2-d7a15bbc7790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10718d37-63d4-44b7-9450-5d49cffce944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10718d37-63d4-44b7-9450-5d49cffce944.jpg?1",
             "name": "Forerunner of the Legion",
             "text": "When Forerunner of the Legion enters the battlefield, you may search your library for a Vampire card, reveal it, then shuffle your library and put that card on top of it.\nWhenever another Vampire enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "749e4fdb-7fda-5107-876d-ee4eab6213e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5030e80-58c4-4ce3-877e-8395b653f6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5030e80-58c4-4ce3-877e-8395b653f6e8.jpg?1",
             "name": "Imperial Ceratops",
             "text": "Enrage \u2014 Whenever Imperial Ceratops is dealt damage, you gain 2 life.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "571baaef-97f6-56b1-832c-b6115346bdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba197b31-97b8-447e-b8fd-3eefd5ccdc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba197b31-97b8-447e-b8fd-3eefd5ccdc72.jpg?1",
             "name": "Legion Conquistador",
             "text": "When Legion Conquistador enters the battlefield, you may search your library for any number of cards named Legion Conquistador, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "845b5f40-974a-515b-a5b8-2cc7050c3a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca3a547-ef22-4b87-b90f-e8ffb42f73ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca3a547-ef22-4b87-b90f-e8ffb42f73ac.jpg?1",
             "name": "Luminous Bonds",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "8cf30ca9-3b4d-5216-b811-1e47dc394e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a012af0-c54e-4658-8a3b-b81cc8835e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a012af0-c54e-4658-8a3b-b81cc8835e1b.jpg?1",
             "name": "Majestic Heliopterus",
             "text": "Flying\nWhenever Majestic Heliopterus attacks, another target Dinosaur you control gains flying until end of turn.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "cbe44955-3cbe-5d4a-9e59-ebe7e55ee0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04134be2-5e40-4732-832c-f616009eceff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04134be2-5e40-4732-832c-f616009eceff.jpg?1",
             "name": "Martyr of Dusk",
             "text": "When Martyr of Dusk dies, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "a786a8c0-da1c-5099-9875-13d967a311ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be8c18-eca3-4960-b174-e4a78579ed63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be8c18-eca3-4960-b174-e4a78579ed63.jpg?1",
             "name": "Moment of Triumph",
             "text": "Target creature gets +2/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "b88257cf-72b5-55c4-a7ba-8db3e55be5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad263e-7ff0-459b-b04b-1d03b09c48aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad263e-7ff0-459b-b04b-1d03b09c48aa.jpg?1",
             "name": "Paladin of Atonement",
             "text": "At the beginning of each upkeep, if you lost life last turn, put a +1/+1 counter on Paladin of Atonement.\nWhen Paladin of Atonement dies, you gain life equal to its toughness.",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "72848888-20cb-5a1d-b34a-aead3c3c7159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a769c-6602-4f6f-a388-f5aa15fb3c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a769c-6602-4f6f-a388-f5aa15fb3c90.jpg?1",
             "name": "Pride of Conquerors",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nCreatures you control get +1/+1 until end of turn. If you have the city's blessing, those creatures get +2/+2 until end of turn instead.",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "265eefca-faff-53f1-a69d-03aed2ab3a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44584d-e501-40aa-b3f2-a6155e2ee6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44584d-e501-40aa-b3f2-a6155e2ee6e7.jpg?1",
             "name": "Radiant Destiny",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAs Radiant Destiny enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1. As long as you have the city's blessing, they also have vigilance.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "94d19ceb-a343-580c-b3fb-1626b944f8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f2ffb-2780-47d2-bcdf-9cef82716b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f2ffb-2780-47d2-bcdf-9cef82716b20.jpg?1",
             "name": "Raptor Companion",
             "text": "",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "3089f919-a547-59bc-8077-0c6784cddbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12993e53-8790-4d6f-9da1-a259f67aa5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12993e53-8790-4d6f-9da1-a259f67aa5bf.jpg?1",
             "name": "Sanguine Glorifier",
             "text": "When Sanguine Glorifier enters the battlefield, put a +1/+1 counter on another target Vampire you control.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "71207f09-164c-5aad-aeb3-7a06dc5833e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473190f-5e96-4cf7-a0fa-a77d916acc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473190f-5e96-4cf7-a0fa-a77d916acc2e.jpg?1",
             "name": "Skymarcher Aspirant",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nSkymarcher Aspirant has flying as long as you have the city's blessing.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "aaa442e3-f5a9-5737-9659-5841c217a030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4217ab21-181e-4c32-97c3-d8bd441287e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4217ab21-181e-4c32-97c3-d8bd441287e0.jpg?1",
             "name": "Slaughter the Strong",
             "text": "Each player chooses any number of creatures he or she controls with total power 4 or less, then sacrifices all other creatures he or she controls.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "c2f77a4b-9c4f-5a3b-b001-2dc8b14bd6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee111e7-5309-46d5-b3ea-a049b3962c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee111e7-5309-46d5-b3ea-a049b3962c23.jpg?1",
             "name": "Snubhorn Sentry",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nSnubhorn Sentry gets +3/+0 as long as you have the city's blessing.",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "92c4276c-530e-57d0-99a9-f8ddd1b1b12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5058a729-9739-4548-b420-deebbc0950b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5058a729-9739-4548-b420-deebbc0950b7.jpg?1",
             "name": "Sphinx's Decree",
             "text": "Each opponent can't cast instant or sorcery spells during that player's next turn.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "6fdb1b70-ffc6-5ccd-aec7-badd4b01c6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91de07da-564d-42f3-987d-a2321c3216bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91de07da-564d-42f3-987d-a2321c3216bc.jpg?1",
             "name": "Squire's Devotion",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has lifelink.\nWhen Squire's Devotion enters the battlefield, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "977b5947-86bf-553a-b2de-385ba3ebaf26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867fd5a-3bbe-416d-96a6-1db0b341260e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867fd5a-3bbe-416d-96a6-1db0b341260e.jpg?1",
             "name": "Sun Sentinel",
             "text": "Vigilance",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "5c1b905d-d6fc-5efd-b3bb-79e7bf0d8a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c298b51f-b725-4a51-a91e-4c66cf6dfe9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c298b51f-b725-4a51-a91e-4c66cf6dfe9d.jpg?1",
             "name": "Sun-Crested Pterodon",
             "text": "Flying\nSun-Crested Pterodon has vigilance as long as you control another Dinosaur.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "3ba6a1b1-a472-514c-90a6-906342bfac68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8f8d61-51d6-479b-a812-6cbacc7ea1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8f8d61-51d6-479b-a812-6cbacc7ea1fc.jpg?1",
             "name": "Temple Altisaur",
             "text": "If a source would deal damage to another Dinosaur you control, prevent all but 1 of that damage.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "23a6192f-d543-5351-b47a-4c69f1e2c461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c280c8-3471-4ae1-be96-0f392b095ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c280c8-3471-4ae1-be96-0f392b095ce2.jpg?1",
             "name": "Trapjaw Tyrant",
             "text": "Enrage \u2014 Whenever Trapjaw Tyrant is dealt damage, exile target creature an opponent controls until Trapjaw Tyrant leaves the battlefield.",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "a3dec5d1-f5b7-5e45-afd3-811ea8775c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10560f-199d-4d04-b573-90024f8aecc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10560f-199d-4d04-b573-90024f8aecc4.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "e0b3b9ae-7441-5663-8bf2-86e7cc9d3b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dc0310-afd9-49b4-b58f-a0e91120c38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dc0310-afd9-49b4-b58f-a0e91120c38c.jpg?1",
             "name": "Admiral's Order",
             "text": "Raid \u2014 If you attacked with a creature this turn, you may pay {U} rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "daab4fdd-b79f-5fe6-99a1-a155e372e1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cb8fa2-337b-4596-9c31-01f0c0b171b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cb8fa2-337b-4596-9c31-01f0c0b171b7.jpg?1",
             "name": "Aquatic Incursion",
             "text": "When Aquatic Incursion enters the battlefield, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)\n{3}{U}: Target Merfolk can't be blocked this turn.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "a33e369b-77da-5539-a7c0-fc5904b0a19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6afc4c-3c41-44e8-ad8c-186c277267a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6afc4c-3c41-44e8-ad8c-186c277267a1.jpg?1",
             "name": "Crafty Cutpurse",
             "text": "Flash\nWhen Crafty Cutpurse enters the battlefield, each token that would be created under an opponent's control this turn is created under your control instead.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "eebc4ecf-5de1-5a58-8c7e-5c9b45eb139b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312980a-7b3c-43f8-81cf-53ff818cea30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312980a-7b3c-43f8-81cf-53ff818cea30.jpg?1",
             "name": "Crashing Tide",
             "text": "Crashing Tide has flash as long as you control a Merfolk.\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1151,7 +1151,7 @@
         },
         {
             "id": "2013b972-5ae4-5ee9-9e1b-34ed8a6dbf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f998c62-30c9-4fc3-a045-5becc04f9e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f998c62-30c9-4fc3-a045-5becc04f9e3e.jpg?1",
             "name": "Curious Obsession",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, you may draw a card.\"\nAt the beginning of your end step, if you didn't attack with a creature this turn, sacrifice Curious Obsession.",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "4b588b45-7ccc-5ccf-9e4e-5bdfb5d19b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db310d8f-0db7-44c9-9f2d-9a0773b565b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db310d8f-0db7-44c9-9f2d-9a0773b565b0.jpg?1",
             "name": "Deadeye Rig-Hauler",
             "text": "Raid \u2014 When Deadeye Rig-Hauler enters the battlefield, if you attacked with a creature this turn, you may return target creature to its owner's hand.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "2cce85d1-f6df-5baf-a587-9477a8efe2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f5119f-3921-48a5-a8fb-0cb1bbabde30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f5119f-3921-48a5-a8fb-0cb1bbabde30.jpg?1",
             "name": "Expel from Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nReturn target nonland permanent to its owner's hand. If you have the city's blessing, you may put that permanent on top of its owner's library instead.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "7681078a-73cb-5659-844d-dad87dadcb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a353c1-a640-4b01-9754-3fb6011c8211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a353c1-a640-4b01-9754-3fb6011c8211.jpg?1",
             "name": "Flood of Recollection",
             "text": "Return target instant or sorcery card from your graveyard to your hand. Exile Flood of Recollection.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "d3c20eee-bc3f-5d0a-b294-f27d4db24071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10b8f15-b323-44d8-85a7-ed662a40889d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10b8f15-b323-44d8-85a7-ed662a40889d.jpg?1",
             "name": "Hornswoggle",
             "text": "Counter target creature spell. You create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "56d5d9db-e138-5d6f-b367-1f77d0cde8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ee56f1-9f08-459f-8517-0fe7bc645fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ee56f1-9f08-459f-8517-0fe7bc645fa3.jpg?1",
             "name": "Induced Amnesia",
             "text": "When Induced Amnesia enters the battlefield, target player exiles all cards from his or her hand face down, then draws that many cards.\nWhen Induced Amnesia is put into a graveyard from the battlefield, return the exiled cards to their owner's hand.",
             "colours": [
@@ -1348,7 +1348,7 @@
         },
         {
             "id": "d487d82b-4d7a-5e6b-b943-b4958bdbbf42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8d0e8d-c2d4-4682-8095-827ffd79539b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8d0e8d-c2d4-4682-8095-827ffd79539b.jpg?1",
             "name": "Kitesail Corsair",
             "text": "Kitesail Corsair has flying as long as it's attacking.",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "05d0d71c-a2d8-5267-b0c0-920cc95d38f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86f499-a2d4-47f1-9fc1-b543e5ad5c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86f499-a2d4-47f1-9fc1-b543e5ad5c82.jpg?1",
             "name": "Kumena's Awakening",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, each player draws a card. If you have the city's blessing, instead only you draw a card.",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "79a0f0d1-af9b-558a-852d-37c0fcaf1455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c1368e-114b-4618-922b-1d824ba0d1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c1368e-114b-4618-922b-1d824ba0d1d5.jpg?1",
             "name": "Mist-Cloaked Herald",
             "text": "Mist-Cloaked Herald can't be blocked.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "d6b934a2-b92d-5040-b79d-29fbaa5c3db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31534f45-43e6-4103-bf58-ad8fa688e4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31534f45-43e6-4103-bf58-ad8fa688e4b0.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "a83581bb-dbf4-5f5c-8d1e-be61a6d70bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eba418-94ab-46a3-958c-4d5058fc2bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eba418-94ab-46a3-958c-4d5058fc2bcd.jpg?1",
             "name": "Nezahal, Primal Tide",
             "text": "Nezahal, Primal Tide can't be countered.\nYou have no maximum hand size.\nWhenever an opponent casts a noncreature spell, draw a card.\nDiscard three cards: Exile Nezahal. Return it to the battlefield tapped under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "edf14f5c-0144-51bb-bb1e-317848a54a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4f72ef-3939-467c-8fe4-fd1c215f2b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4f72ef-3939-467c-8fe4-fd1c215f2b1e.jpg?1",
             "name": "Release to the Wind",
             "text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may cast it without paying its mana cost.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "85d2c10c-bc02-5cd2-80d3-c1c214d0cb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d766eb87-19ef-460b-982f-e55ae5890e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d766eb87-19ef-460b-982f-e55ae5890e6a.jpg?1",
             "name": "River Darter",
             "text": "River Darter can't be blocked by Dinosaurs.",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "8cc14ebd-01f2-5a9e-b815-9a57b08ba3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea5ac8f-f83d-47ca-a20e-3d129afb34d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea5ac8f-f83d-47ca-a20e-3d129afb34d2.jpg?1",
             "name": "Riverwise Augur",
             "text": "When Riverwise Augur enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "d273b78c-1188-5547-8fbc-a83f8d47a9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963425c-4694-42f4-a969-8f30e13276d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963425c-4694-42f4-a969-8f30e13276d3.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "3c27add8-ff8e-594e-bb41-dee05b616475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae48b747-b9ea-4af1-84c5-3f5835d1ba1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae48b747-b9ea-4af1-84c5-3f5835d1ba1f.jpg?1",
             "name": "Sea Legs",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +0/+2 as long as it's a Pirate. Otherwise, it gets -2/-0.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "5c3774d3-6de1-52ae-9e7b-c075c0a6d2e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4316eacf-4b78-4b99-833c-53ecf49a0ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4316eacf-4b78-4b99-833c-53ecf49a0ae5.jpg?1",
             "name": "Seafloor Oracle",
             "text": "Whenever a Merfolk you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "ccbf3896-c94e-5099-8de9-2411226420e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecd7a-bfd6-42a4-8cb2-18bac40b4401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecd7a-bfd6-42a4-8cb2-18bac40b4401.jpg?1",
             "name": "Secrets of the Golden City",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nDraw two cards. If you have the city's blessing, draw three cards instead.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "79d168e7-df1d-5e81-a8e9-8039639e2902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ea8ca1-612d-4984-8572-06710d38bfa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ea8ca1-612d-4984-8572-06710d38bfa6.jpg?1",
             "name": "Silvergill Adept",
             "text": "As an additional cost to cast Silvergill Adept, reveal a Merfolk card from your hand or pay {3}.\nWhen Silvergill Adept enters the battlefield, draw a card.",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "eb695018-56b9-53ba-b113-cd214d9df259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5827a7-8ee3-4a89-b936-00a3283ddad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5827a7-8ee3-4a89-b936-00a3283ddad3.jpg?1",
             "name": "Siren Reaver",
             "text": "Raid \u2014 Siren Reaver costs {1} less to cast if you attacked with a creature this turn.\nFlying",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "be317768-3acc-5477-a51b-c1ef754499d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262f3c10-f29a-494f-88c6-0d44b2cbdc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262f3c10-f29a-494f-88c6-0d44b2cbdc82.jpg?1",
             "name": "Slippery Scoundrel",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAs long as you have the city's blessing, Slippery Scoundrel has hexproof and can't be blocked.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "ba2c7169-f34d-5da3-818e-3b90b7ca16ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1aed7d-4236-4d44-9366-ee03e15469bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1aed7d-4236-4d44-9366-ee03e15469bc.jpg?1",
             "name": "Soul of the Rapids",
             "text": "Flying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1896,7 +1896,7 @@
         },
         {
             "id": "6e1b7fdd-2d8f-5bd7-89b7-2223f5173580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca438d7-1134-4fee-9fad-85c3b1abe8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca438d7-1134-4fee-9fad-85c3b1abe8ed.jpg?1",
             "name": "Spire Winder",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nSpire Winder gets +1/+1 as long as you have the city's blessing.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "10ef515f-7232-5516-b145-dc4e5642fcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6452ba94-6bb0-409c-99f7-71e6457c3f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6452ba94-6bb0-409c-99f7-71e6457c3f2a.jpg?1",
             "name": "Sworn Guardian",
             "text": "",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "1b2fb9f1-1e79-57dc-90f7-1b08e553371f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14770537-209a-4260-88a4-30f4e2b5ede0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14770537-209a-4260-88a4-30f4e2b5ede0.jpg?1",
             "name": "Timestream Navigator",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{2}{U}{U}, {T}, Put Timestream Navigator on the bottom of its owner's library: Take an extra turn after this one. Activate this ability only if you have the city's blessing.",
             "colours": [
@@ -2001,7 +2001,7 @@
         },
         {
             "id": "62f28b0f-1416-5a0f-a10a-cf673be58b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ff9cf-f739-40cb-8974-77f6850150eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ff9cf-f739-40cb-8974-77f6850150eb.jpg?1",
             "name": "Warkite Marauder",
             "text": "Flying\nWhenever Warkite Marauder attacks, target creature defending player controls loses all abilities and has base power and toughness 0/1 until end of turn.",
             "colours": [
@@ -2036,7 +2036,7 @@
         },
         {
             "id": "16ed8ce0-df99-5dff-9095-fb1b44093a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4579ee-76c4-4ed6-9208-55d2b598d3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4579ee-76c4-4ed6-9208-55d2b598d3b5.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "7d91f7cf-9aa3-5c11-930f-4afcbdea84a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c41212-9f16-48e0-8c4b-985ce331164b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c41212-9f16-48e0-8c4b-985ce331164b.jpg?1",
             "name": "Arterial Flow",
             "text": "Each opponent discards two cards. If you control a Vampire, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "338a81cf-45c8-5d37-934d-0794350cca2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78226edc-87dd-4c38-987c-52aefe0f9531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78226edc-87dd-4c38-987c-52aefe0f9531.jpg?1",
             "name": "Canal Monitor",
             "text": "",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "913522e7-467d-52b3-93a0-3ef13fd1ece7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507a4fb1-d27b-4393-9eed-48fe05b367d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507a4fb1-d27b-4393-9eed-48fe05b367d8.jpg?1",
             "name": "Champion of Dusk",
             "text": "When Champion of Dusk enters the battlefield, you draw X cards and you lose X life, where X is the number of Vampires you control.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "ef67aad2-e01e-5981-9daa-f2b57778acef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eaa634-0add-4e3d-9eee-5712598dda3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eaa634-0add-4e3d-9eee-5712598dda3f.jpg?1",
             "name": "Dark Inquiry",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "8d69d6c6-47ac-5123-bb00-eb4f1a948ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ac1d9-b0df-4dec-b133-057cc5902071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ac1d9-b0df-4dec-b133-057cc5902071.jpg?1",
             "name": "Dead Man's Chest",
             "text": "Enchant creature an opponent controls\nWhen enchanted creature dies, exile cards equal to its power from the top of its owner's library. You may cast nonland cards from among them for as long as they remain exiled, and you may spend mana as though it were mana of any type to cast those spells.",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "9eae30fc-2d1b-58c0-adc2-3052e91795b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ff5a4e-9ec5-4b52-90f5-b8b6753c958d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ff5a4e-9ec5-4b52-90f5-b8b6753c958d.jpg?1",
             "name": "Dinosaur Hunter",
             "text": "Whenever Dinosaur Hunter deals damage to a Dinosaur, destroy that creature.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "b3fd718b-5782-54ed-b175-0c1e8e7abc8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88273b1e-b33b-44d3-8777-4e78a04eed65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88273b1e-b33b-44d3-8777-4e78a04eed65.jpg?1",
             "name": "Dire Fleet Poisoner",
             "text": "Flash\nDeathtouch\nWhen Dire Fleet Poisoner enters the battlefield, target attacking Pirate you control gets +1/+1 and gains deathtouch until end of turn.",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "e50e0698-eaac-5ca3-9cc6-5e6e5bc08c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce54a3-f3eb-48a0-bfa2-5f4b90e413f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce54a3-f3eb-48a0-bfa2-5f4b90e413f0.jpg?1",
             "name": "Dusk Charger",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nDusk Charger gets +2/+2 as long as you have the city's blessing.",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "4914f55f-df2d-5f85-8659-a197117ff69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3190cea3-fbea-464f-999b-4b4473be745e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3190cea3-fbea-464f-999b-4b4473be745e.jpg?1",
             "name": "Dusk Legion Zealot",
             "text": "When Dusk Legion Zealot enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "abeb3431-0346-5115-a634-d87e65ce3ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f447eb83-c805-4ba8-b9f2-0add092f6795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f447eb83-c805-4ba8-b9f2-0add092f6795.jpg?1",
             "name": "Fathom Fleet Boarder",
             "text": "When Fathom Fleet Boarder enters the battlefield, you lose 2 life unless you control another Pirate.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "dab2bb72-e065-590e-b3d0-88d7456044ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b499fc26-26b0-4b0f-9c62-5ed599baf41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b499fc26-26b0-4b0f-9c62-5ed599baf41d.jpg?1",
             "name": "Forerunner of the Coalition",
             "text": "When Forerunner of the Coalition enters the battlefield, you may search your library for a Pirate card, reveal it, then shuffle your library and put that card on top of it.\nWhenever another Pirate enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "d5c7348c-80d9-52c6-8796-004d5ae3a12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bb420a-8bf1-4504-b1b5-2d929be978be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bb420a-8bf1-4504-b1b5-2d929be978be.jpg?1",
             "name": "Golden Demise",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAll creatures get -2/-2 until end of turn. If you have the city's blessing, instead only creatures your opponents control get -2/-2 until end of turn.",
             "colours": [
@@ -2478,7 +2478,7 @@
         },
         {
             "id": "64129b7a-ded5-5baa-9323-d7e4cdf677f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6da2e7-4cf0-49ae-b0ba-3b994ff21587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6da2e7-4cf0-49ae-b0ba-3b994ff21587.jpg?1",
             "name": "Grasping Scoundrel",
             "text": "Grasping Scoundrel gets +1/+0 as long as it's attacking.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "42002605-c387-5008-83a8-70d2eaec584a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea07116-afe7-4d88-a530-54424e791b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea07116-afe7-4d88-a530-54424e791b74.jpg?1",
             "name": "Gruesome Fate",
             "text": "Each opponent loses 1 life for each creature you control.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "0b5db650-d052-5ced-8c78-aa4204b29204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa0c4f7-3497-467d-9453-104fb4b5a0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa0c4f7-3497-467d-9453-104fb4b5a0f3.jpg?1",
             "name": "Impale",
             "text": "Destroy target creature.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "c92976c6-d234-52ff-ae5f-1cb5a52d4b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00f09b-a113-460e-ac2f-d3988a83179e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00f09b-a113-460e-ac2f-d3988a83179e.jpg?1",
             "name": "Mastermind's Acquisition",
             "text": "Choose one \u2014\n\u2022 Search your library for a card, put it into your hand, then shuffle your library.\n\u2022 Choose a card you own from outside the game and put it into your hand.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "df56747e-b7e3-53c4-bf8d-5179f7992254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b40f3c-d75e-483f-b978-8b3bf30cc7ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b40f3c-d75e-483f-b978-8b3bf30cc7ce.jpg?1",
             "name": "Mausoleum Harpy",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever another creature you control dies, if you have the city's blessing, put a +1/+1 counter on Mausoleum Harpy.",
             "colours": [
@@ -2643,7 +2643,7 @@
         },
         {
             "id": "0574d7a9-c811-5710-b8bd-e4685fbe438c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e3ea55-162d-4466-ba4e-b938a0845fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e3ea55-162d-4466-ba4e-b938a0845fb5.jpg?1",
             "name": "Moment of Craving",
             "text": "Target creature gets -2/-2 until end of turn. You gain 2 life.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "8db97b18-02e6-57e1-af5c-89eaebff0388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405f82d6-2991-4958-a563-572f0d298346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405f82d6-2991-4958-a563-572f0d298346.jpg?1",
             "name": "Oathsworn Vampire",
             "text": "Oathsworn Vampire enters the battlefield tapped.\nYou may cast Oathsworn Vampire from your graveyard if you gained life this turn.",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "63e72c36-6219-5d77-89d3-84d4e32dbc23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87ebffe-5907-427b-9f9b-7c36a12b4a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87ebffe-5907-427b-9f9b-7c36a12b4a03.jpg?1",
             "name": "Pitiless Plunderer",
             "text": "Whenever another creature you control dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2745,7 +2745,7 @@
         },
         {
             "id": "937d36d0-40e0-5be3-9d61-2218011bfe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551196-ecea-472f-9547-3c9658d0489e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551196-ecea-472f-9547-3c9658d0489e.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "776dc1b4-5406-5041-b375-68751b08743e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaac2f-b26c-4da9-bf4f-c7672394dd7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaac2f-b26c-4da9-bf4f-c7672394dd7f.jpg?1",
             "name": "Reaver Ambush",
             "text": "Exile target creature with power 3 or less.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "c343c911-af2f-534e-80b6-60461370a90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f4e0a8-7af7-4422-a964-c19503692ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f4e0a8-7af7-4422-a964-c19503692ba6.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "77050f7e-2d28-5f9f-9030-4b0ebd688a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1334ee90-c798-42ec-b2be-68dac766a7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1334ee90-c798-42ec-b2be-68dac766a7eb.jpg?1",
             "name": "Sadistic Skymarcher",
             "text": "As an additional cost to cast Sadistic Skymarcher, reveal a Vampire card from your hand or pay {1}.\nFlying, lifelink",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "819b4448-aeea-50a1-ba0d-c7f97dacd779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a0b40e-7a43-4722-b787-a5d7ec6453ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a0b40e-7a43-4722-b787-a5d7ec6453ac.jpg?1",
             "name": "Tetzimoc, Primal Death",
             "text": "Deathtouch\n{B}, Reveal Tetzimoc, Primal Death from your hand: Put a prey counter on target creature. Activate this ability only during your turn.\nWhen Tetzimoc enters the battlefield, destroy each creature your opponents control with a prey counter on it.",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "c83db6a1-b03a-5426-8bdf-a1caf1a9809a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68132a28-b33b-48cb-acf8-42245312934e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68132a28-b33b-48cb-acf8-42245312934e.jpg?1",
             "name": "Tomb Robber",
             "text": "Menace\n{1}, Discard a card: Tomb Robber explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -2951,7 +2951,7 @@
         },
         {
             "id": "fb2e5522-233a-547f-b600-b81701a2a29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6974f-6753-48ac-98cd-86412cc93726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6974f-6753-48ac-98cd-86412cc93726.jpg?1",
             "name": "Twilight Prophet",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, if you have the city's blessing, reveal the top card of your library and put it into your hand. Each opponent loses X life and you gain X life, where X is that card's converted mana cost.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "8b2db8d5-fdd2-5cd0-97cf-0bf34cab8e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3a6c6-33b8-4530-9d80-c488898afd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3a6c6-33b8-4530-9d80-c488898afd6e.jpg?1",
             "name": "Vampire Revenant",
             "text": "Flying",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "25d88c53-0422-53fc-bcc2-c6ebc0e9fa89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab958d5-9c1f-420f-b358-ec0325f22f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab958d5-9c1f-420f-b358-ec0325f22f84.jpg?1",
             "name": "Vona's Hunger",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nEach opponent sacrifices a creature. If you have the city's blessing, instead each opponent sacrifices half the creatures he or she controls, rounded up.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "f963e456-3974-5b3a-a4b8-7ace25a08013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66a9f1b-31c8-4557-888b-a927922d37af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66a9f1b-31c8-4557-888b-a927922d37af.jpg?1",
             "name": "Voracious Vampire",
             "text": "Menace\nWhen Voracious Vampire enters the battlefield, target Vampire you control gets +1/+1 and gains menace until end of turn.",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "d35c83d3-edd6-5aab-9439-d31af3f36967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875832f4-e541-4c87-8479-731e0eab2cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875832f4-e541-4c87-8479-731e0eab2cc6.jpg?1",
             "name": "Blood Sun",
             "text": "When Blood Sun enters the battlefield, draw a card.\nAll lands lose all abilities except mana abilities.",
             "colours": [
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "222ab458-ff55-54d2-97c3-098abbdea8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a605abc-78e8-47ba-9022-0fad9006fd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a605abc-78e8-47ba-9022-0fad9006fd05.jpg?1",
             "name": "Bombard",
             "text": "Bombard deals 4 damage to target creature.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "3d710017-f4fc-5bdc-b06b-88d8dc4f7aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505866-6ce9-4d11-b3f3-fc2f09839b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505866-6ce9-4d11-b3f3-fc2f09839b71.jpg?1",
             "name": "Brass's Bounty",
             "text": "For each land you control, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "3bcfc59b-dc26-5f06-9c6b-5875f769de5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3d3b6-6805-4476-aea1-a95c31bd21d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3d3b6-6805-4476-aea1-a95c31bd21d7.jpg?1",
             "name": "Brazen Freebooter",
             "text": "When Brazen Freebooter enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "99af8a0a-745f-5a04-852b-b86b193efc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82c583f-3d2b-4c7f-a6f4-97da150423b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82c583f-3d2b-4c7f-a6f4-97da150423b4.jpg?1",
             "name": "Buccaneer's Bravado",
             "text": "Choose one \u2014\n\u2022 Target creature gets +1/+1 and gains first strike until end of turn.\n\u2022 Target Pirate gets +1/+1 and gains double strike until end of turn.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "fe5274fb-c694-523a-8bd7-5e8abe1b6836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e49960d-4b45-4d3b-9c6e-e7b717b4feaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e49960d-4b45-4d3b-9c6e-e7b717b4feaa.jpg?1",
             "name": "Charging Tuskodon",
             "text": "Trample\nIf Charging Tuskodon would deal combat damage to a player, it deals double that damage to that player instead.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "edcfbec6-3518-5f3c-9ae5-38163d4432e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d413b88-8f5d-415f-bd07-169f6c175e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d413b88-8f5d-415f-bd07-169f6c175e6b.jpg?1",
             "name": "Daring Buccaneer",
             "text": "As an additional cost to cast Daring Buccaneer, reveal a Pirate card from your hand or pay {2}.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "30a726f0-ee3c-514b-9213-f4d11c084e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e3c0c5-7451-4da9-acc0-d6e4e1f2655e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e3c0c5-7451-4da9-acc0-d6e4e1f2655e.jpg?1",
             "name": "Dire Fleet Daredevil",
             "text": "First strike\nWhen Dire Fleet Daredevil enters the battlefield, exile target instant or sorcery card from an opponent's graveyard. You may cast that card this turn, and you may spend mana as though it were mana of any type to cast that spell. If that card would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -3355,7 +3355,7 @@
         },
         {
             "id": "ee67bb54-1048-52df-90da-1bc939eef340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d8bb4-0430-45bb-930d-5d6db6521945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d8bb4-0430-45bb-930d-5d6db6521945.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of nonland cards exiled this way without paying their mana costs.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "6b74e330-691d-54cf-8cd8-77e0f07d5085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5565de-028c-4799-a9f6-4dcd685639eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5565de-028c-4799-a9f6-4dcd685639eb.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to target creature or player.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "e7ea1b86-3aab-5d4c-8b73-bdb4d49229f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947644ab-02b3-4ebe-b62a-c087ab205ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947644ab-02b3-4ebe-b62a-c087ab205ab0.jpg?1",
             "name": "Forerunner of the Empire",
             "text": "When Forerunner of the Empire enters the battlefield, you may search your library for a Dinosaur card, reveal it, then shuffle your library and put that card on top of it.\nWhenever a Dinosaur enters the battlefield under your control, you may have Forerunner of the Empire deal 1 damage to each creature.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "f173d647-5e2b-5310-b13b-de8af6ff27cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e4fe86-281d-4174-bb72-ac5bb9560b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e4fe86-281d-4174-bb72-ac5bb9560b7e.jpg?1",
             "name": "Form of the Dinosaur",
             "text": "When Form of the Dinosaur enters the battlefield, your life total becomes 15.\nAt the beginning of your upkeep, Form of the Dinosaur deals 15 damage to target creature an opponent controls and that creature deals damage equal to its power to you.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "d66e04bb-40d8-5558-9e22-15f312912b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3825798-f673-4d8a-9997-ccb73681cbf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3825798-f673-4d8a-9997-ccb73681cbf2.jpg?1",
             "name": "Frilled Deathspitter",
             "text": "Enrage \u2014 Whenever Frilled Deathspitter is dealt damage, it deals 2 damage to target opponent.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "3ea142de-d40c-50c1-980e-8fb27a8f097f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b2d16-bdf5-4249-9dc1-bb51498aa33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b2d16-bdf5-4249-9dc1-bb51498aa33b.jpg?1",
             "name": "Goblin Trailblazer",
             "text": "Menace",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "0c48e17e-8435-50a2-9919-df4e4f0f9135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010711a0-5e95-4a8c-816f-e314f2a909ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010711a0-5e95-4a8c-816f-e314f2a909ef.jpg?1",
             "name": "Mutiny",
             "text": "Target creature an opponent controls deals damage equal to its power to another target creature that player controls.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "01803680-5dab-5060-ad04-64ba34e83598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a90b68-d5f4-4f3c-bd4b-af59dd868919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a90b68-d5f4-4f3c-bd4b-af59dd868919.jpg?1",
             "name": "Needletooth Raptor",
             "text": "Enrage \u2014 Whenever Needletooth Raptor is dealt damage, it deals 5 damage to target creature an opponent controls.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "45135e6c-c7bc-5cd0-934d-f908cbe7e2a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7080f86-0a9f-4471-a52b-0d44d19e6e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7080f86-0a9f-4471-a52b-0d44d19e6e59.jpg?1",
             "name": "Orazca Raptor",
             "text": "",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "f761a081-3f2f-54f3-9d2f-705682b5e268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c812f-89b1-4741-a50d-8634e003a7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c812f-89b1-4741-a50d-8634e003a7c0.jpg?1",
             "name": "Pirate's Pillage",
             "text": "As an additional cost to cast Pirate's Pillage, discard a card.\nDraw two cards and create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "18d320b3-3b97-5cfc-959c-66e22911627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4b97a3-8f6f-461e-aa55-ab752752f539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4b97a3-8f6f-461e-aa55-ab752752f539.jpg?1",
             "name": "Reckless Rage",
             "text": "Reckless Rage deals 4 damage to target creature you don't control and 2 damage to target creature you control.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "93797c70-fc1e-536d-94c5-ea6f89efd56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daccec32-84c6-4de4-9b00-c497a6ba5de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daccec32-84c6-4de4-9b00-c497a6ba5de8.jpg?1",
             "name": "Rekindling Phoenix",
             "text": "Flying\nWhen Rekindling Phoenix dies, create a 0/1 red Elemental creature token with \"At the beginning of your upkeep, sacrifice this creature and return target card named Rekindling Phoenix from your graveyard to the battlefield. It gains haste until end of turn.\"",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "3171448a-6b1e-5d72-a2e3-1d8d7913198d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686cbaf-1de8-4f30-8027-c6c8a85dde7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686cbaf-1de8-4f30-8027-c6c8a85dde7a.jpg?1",
             "name": "See Red",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has first strike.\nAt the beginning of your end step, if you didn't attack with a creature this turn, sacrifice See Red.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "399928ff-a13d-59c2-b451-5ed8ada59ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd4bdd-3a2a-40d9-9f86-fefe0a462cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd4bdd-3a2a-40d9-9f86-fefe0a462cd2.jpg?1",
             "name": "Shake the Foundations",
             "text": "Shake the Foundations deals 1 damage to each creature without flying.\nDraw a card.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "4346a32a-2274-5d16-8f4d-b97e2634642a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929a41f7-f52d-4190-a80c-5ceb3e368a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929a41f7-f52d-4190-a80c-5ceb3e368a31.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "ebd6b24e-5a71-5036-9a79-9d5793afd627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0d0c8d-c057-4a44-bd1e-38e1dd175778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0d0c8d-c057-4a44-bd1e-38e1dd175778.jpg?1",
             "name": "Silverclad Ferocidons",
             "text": "Enrage \u2014 Whenever Silverclad Ferocidons is dealt damage, each opponent sacrifices a permanent.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "7e71a186-3bdb-5ae7-a075-7873c6cef9a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d4bb3-583c-4c3b-b6b7-342a78bbaec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d4bb3-583c-4c3b-b6b7-342a78bbaec6.jpg?1",
             "name": "Stampeding Horncrest",
             "text": "Stampeding Horncrest has haste as long as you control another Dinosaur.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "2e305d44-3256-5b5b-b7b6-f7f85afb04a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7093bd0e-3b98-4f46-9717-202ddd277bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7093bd0e-3b98-4f46-9717-202ddd277bf5.jpg?1",
             "name": "Storm Fleet Swashbuckler",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nStorm Fleet Swashbuckler has double strike as long as you have the city's blessing.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "e37a41e1-49db-521f-bbf2-42f3c2e97bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fbd1bc-3e57-43d5-ad54-443ca740fcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fbd1bc-3e57-43d5-ad54-443ca740fcc4.jpg?1",
             "name": "Sun-Collared Raptor",
             "text": "Trample\n{2}{R}: Sun-Collared Raptor gets +3/+0 until end of turn.",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "3da35b7f-6125-5efa-972f-68c901ec8563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22da9f6a-9598-4cfe-b465-719266b65dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22da9f6a-9598-4cfe-b465-719266b65dee.jpg?1",
             "name": "Swaggering Corsair",
             "text": "Raid \u2014 Swaggering Corsair enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "b708f580-9823-5b59-8dd7-ccabfb051db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e941a7-c2c1-4855-b79a-c0dfebb28854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e941a7-c2c1-4855-b79a-c0dfebb28854.jpg?1",
             "name": "Tilonalli's Crown",
             "text": "Enchant creature\nWhen Tilonalli's Crown enters the battlefield, it deals 1 damage to enchanted creature.\nEnchanted creature gets +3/+0 and has trample.",
             "colours": [
@@ -4065,7 +4065,7 @@
         },
         {
             "id": "0dedf3ea-c2e1-58c8-bcd7-b82fdd05083b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b107726-3a44-4b0f-86ef-4dbbf4473e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b107726-3a44-4b0f-86ef-4dbbf4473e7e.jpg?1",
             "name": "Tilonalli's Summoner",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever Tilonalli's Summoner attacks, you may pay {X}{R}. If you do, create X 1/1 red Elemental creature tokens that are tapped and attacking. At the beginning of the next end step, exile those tokens unless you have the city's blessing.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "7b3a1afc-6200-5868-88ff-6b0df8b165d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38252c3-fcc1-4bb7-8dd7-ba0e54ade6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38252c3-fcc1-4bb7-8dd7-ba0e54ade6b7.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -4132,7 +4132,7 @@
         },
         {
             "id": "e3e31c01-dbe8-5473-b89a-c32aee9e5cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351b213e-b23e-4287-947a-6bd81f1cf751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351b213e-b23e-4287-947a-6bd81f1cf751.jpg?1",
             "name": "Cacophodon",
             "text": "Enrage \u2014 Whenever Cacophodon is dealt damage, untap target permanent.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "4125530b-29ef-5f5e-a4e0-f237bb804e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14fe6c-b272-415b-974d-c60d016ab786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14fe6c-b272-415b-974d-c60d016ab786.jpg?1",
             "name": "Cherished Hatchling",
             "text": "When Cherished Hatchling dies, you may cast Dinosaur spells this turn as though they had flash, and whenever you cast a Dinosaur spell this turn, it gains \"When this creature enters the battlefield, you may have it fight another target creature.\"",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "fd3db5e3-54e5-55fd-998e-4e5905363bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "ced52be1-d9b8-578d-b73b-c57ee411c0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bccca0-6425-4676-a98a-e0721a6beff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bccca0-6425-4676-a98a-e0721a6beff7.jpg?1",
             "name": "Crested Herdcaller",
             "text": "Trample\nWhen Crested Herdcaller enters the battlefield, create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -4268,7 +4268,7 @@
         },
         {
             "id": "0bdc85fb-5b13-55fb-bc62-28013a27a2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b738ce-a609-448f-97ea-bbf90ba833d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b738ce-a609-448f-97ea-bbf90ba833d7.jpg?1",
             "name": "Deeproot Elite",
             "text": "Whenever another Merfolk enters the battlefield under your control, put a +1/+1 counter on target Merfolk you control.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "2fa066de-0813-507c-be47-958667ac5c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96acf94b-75bb-4f0e-92be-978ce5920710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96acf94b-75bb-4f0e-92be-978ce5920710.jpg?1",
             "name": "Enter the Unknown",
             "text": "Target creature you control explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)\nYou may play an additional land this turn.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "dbf1e48b-2aa0-5a42-aa84-e439e456c0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bc2bd2-adfc-490e-998a-303598e6a942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bc2bd2-adfc-490e-998a-303598e6a942.jpg?1",
             "name": "Forerunner of the Heralds",
             "text": "When Forerunner of the Heralds enters the battlefield, you may search your library for a Merfolk card, reveal it, then shuffle your library and put that card on top of it.\nWhenever another Merfolk enters the battlefield under your control, put a +1/+1 counter on Forerunner of the Heralds.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "81581621-27dd-50b5-83f4-7ad5248b5c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b5b3-9376-4ad7-9a77-3e564e9c42e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b5b3-9376-4ad7-9a77-3e564e9c42e6.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "Ghalta, Primal Hunger costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "f03cdaa6-0c11-55f3-ba16-0db14c80cb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47963f87-d5c2-4e5b-8dff-b25735182841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47963f87-d5c2-4e5b-8dff-b25735182841.jpg?1",
             "name": "Giltgrove Stalker",
             "text": "Giltgrove Stalker can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "6162336c-2a08-5b38-9b83-a59d158b9e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f2755f-276f-4260-a201-f02af88b5708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f2755f-276f-4260-a201-f02af88b5708.jpg?1",
             "name": "Hardy Veteran",
             "text": "As long as it's your turn, Hardy Veteran gets +0/+2.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "3e86ab8e-4238-50d0-9149-d9bd37fd68f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6cab6-b0f9-4631-a4bd-5ff1d6d53880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6cab6-b0f9-4631-a4bd-5ff1d6d53880.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "c7e6a529-ad40-5ad7-8e5d-b9c2392f430f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696bb954-353e-488b-a1e8-0df75da6339b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696bb954-353e-488b-a1e8-0df75da6339b.jpg?1",
             "name": "Jade Bearer",
             "text": "When Jade Bearer enters the battlefield, put a +1/+1 counter on another target Merfolk you control.",
             "colours": [
@@ -4544,7 +4544,7 @@
         },
         {
             "id": "ee9428c9-443e-5ac3-bed5-5a22308b16d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b745934-c1fe-49f5-bda4-b0eafa1408e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b745934-c1fe-49f5-bda4-b0eafa1408e1.jpg?1",
             "name": "Jadecraft Artisan",
             "text": "When Jadecraft Artisan enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "cbfeb7da-e30d-5b9e-9b8f-b59d93321401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe5c719-f20d-4469-9750-fb689d5f3fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe5c719-f20d-4469-9750-fb689d5f3fc8.jpg?1",
             "name": "Jadelight Ranger",
             "text": "When Jadelight Ranger enters the battlefield, it explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard. Then repeat this process.)",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "b67ec0c9-af29-5b71-87f0-3d6cff7e601a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f01ae0d-db1e-4912-b8ad-3069f6938e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f01ae0d-db1e-4912-b8ad-3069f6938e04.jpg?1",
             "name": "Jungleborn Pioneer",
             "text": "When Jungleborn Pioneer enters the battlefield, create a 1/1 blue Merfolk creature token with hexproof. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "ffa78954-1122-5221-af63-31b9c5bc5d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81565a4-cbbe-4820-8473-15ceda42d553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81565a4-cbbe-4820-8473-15ceda42d553.jpg?1",
             "name": "Knight of the Stampede",
             "text": "Dinosaur spells you cast cost {2} less to cast.",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "0926e139-730e-541d-9e76-a3cc20245f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c187d05-0df4-48b6-8e75-690e725b8bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c187d05-0df4-48b6-8e75-690e725b8bcf.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "016b5ac0-f8e3-593b-ac32-602f4658ce31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c81160-192c-4077-8ed1-3643919a2025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c81160-192c-4077-8ed1-3643919a2025.jpg?1",
             "name": "Orazca Frillback",
             "text": "",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "deac24ff-bf96-5f63-982a-72716deb1adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6558db-6332-42ac-8a61-4524c200b62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6558db-6332-42ac-8a61-4524c200b62f.jpg?1",
             "name": "Overgrown Armasaur",
             "text": "Enrage \u2014 Whenever Overgrown Armasaur is dealt damage, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "c7a04b22-6096-5099-936b-71d0a5a93467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9d5518-34ea-418d-b34d-74d773db8bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9d5518-34ea-418d-b34d-74d773db8bcb.jpg?1",
             "name": "Path of Discovery",
             "text": "Whenever a creature enters the battlefield under your control, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "01db9ec9-12e4-5770-8bd0-ba11a95b5209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a0afaa-f99f-4c7a-9fa1-c6a46dfb2a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a0afaa-f99f-4c7a-9fa1-c6a46dfb2a29.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "275430fa-1ed2-5a06-80ad-b0ab6dab81d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8965a3a-93fe-4021-a665-b6013bdc86f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8965a3a-93fe-4021-a665-b6013bdc86f7.jpg?1",
             "name": "Polyraptor",
             "text": "Enrage \u2014 Whenever Polyraptor is dealt damage, create a token that's a copy of Polyraptor.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "ce2dfafe-0cde-54bd-b7b7-284a313a3e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dd7d94-e2bd-4320-8452-9e0deb1be351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dd7d94-e2bd-4320-8452-9e0deb1be351.jpg?1",
             "name": "Strength of the Pack",
             "text": "Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "5242c5c3-f26a-5ad7-bfcf-67a2891b2001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531cb47-b0ff-4d66-acf2-ef5bb5f690fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531cb47-b0ff-4d66-acf2-ef5bb5f690fc.jpg?1",
             "name": "Swift Warden",
             "text": "Flash\nWhen Swift Warden enters the battlefield, target Merfolk you control gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "d1e5524f-526b-5596-963b-b5bbf0be5037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a159830a-698f-423c-9da0-a734b210ecab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a159830a-698f-423c-9da0-a734b210ecab.jpg?1",
             "name": "Tendershoot Dryad",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of each upkeep, create a 1/1 green Saproling creature token.\nSaprolings you control get +2/+2 as long as you have the city's blessing.",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "9794bb4e-cc43-5416-9ebd-90d0ac9da127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9264ff-9f7c-46f3-862a-fee7ad213250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9264ff-9f7c-46f3-862a-fee7ad213250.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -5018,7 +5018,7 @@
         },
         {
             "id": "612c1c3a-5c9e-5ca4-bd94-7229eb4b7c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56de4a3-f5ab-469e-ab66-b8187c8c04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56de4a3-f5ab-469e-ab66-b8187c8c04a0.jpg?1",
             "name": "Thunderherd Migration",
             "text": "As an additional cost to cast Thunderherd Migration, reveal a Dinosaur card from your hand or pay {1}.\nSearch your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5050,7 +5050,7 @@
         },
         {
             "id": "19f97ee8-9e55-530f-b86d-ca7525625700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351e8b1b-4e4e-4ffc-a134-3cf0e2a1dd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351e8b1b-4e4e-4ffc-a134-3cf0e2a1dd6d.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.",
             "colours": [
@@ -5084,7 +5084,7 @@
         },
         {
             "id": "ecc4ad08-01f3-5a24-947d-19e9b93adf9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59c87f5-95ab-4385-abbe-99a3149bdbcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59c87f5-95ab-4385-abbe-99a3149bdbcf.jpg?1",
             "name": "World Shaper",
             "text": "Whenever World Shaper attacks, you may put the top three cards of your library into your graveyard.\nWhen World Shaper dies, put all land cards from your graveyard onto the battlefield tapped.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "92ebbe6a-d5fb-5c96-9a83-cc607673bdd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d76d03-4fcf-42f8-8c2e-ad6b03d58677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d76d03-4fcf-42f8-8c2e-ad6b03d58677.jpg?1",
             "name": "Angrath, the Flame-Chained",
             "text": "+1: Each opponent discards a card and loses 2 life.\n\u22123: Gain control of target creature until end of turn. Untap it. It gains haste until end of turn. Sacrifice it at the beginning of the next end step if it has converted mana cost 3 or less.\n\u22128: Each opponent loses life equal to the number of cards in his or her graveyard.",
             "colours": [
@@ -5157,7 +5157,7 @@
         },
         {
             "id": "a549806d-f763-550a-8c12-6258166e6075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe84b3c0-bca2-42d3-a82c-540644e59625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe84b3c0-bca2-42d3-a82c-540644e59625.jpg?1",
             "name": "Atzocan Seer",
             "text": "{T}: Add one mana of any color to your mana pool.\nSacrifice Atzocan Seer: Return target Dinosaur card from your graveyard to your hand.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "6f13efa3-e0ee-5628-85b8-95932e3cc6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc237e-b28a-4b65-9790-6b434828bf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc237e-b28a-4b65-9790-6b434828bf2e.jpg?1",
             "name": "Azor, the Lawbringer",
             "text": "Flying\nWhen Azor, the Lawbringer enters the battlefield, each opponent can't cast instant or sorcery spells during that player's next turn.\nWhenever Azor attacks, you may pay {X}{W}{U}{U}. If you do, you gain X life and draw X cards.",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "024c9e4d-bed7-5ecf-8cef-babb5c79e923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb1ab66-f2ce-4094-b2dd-1fc63d78eea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb1ab66-f2ce-4094-b2dd-1fc63d78eea2.jpg?1",
             "name": "Deadeye Brawler",
             "text": "Deathtouch\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever Deadeye Brawler deals combat damage to a player, if you have the city's blessing, draw a card.",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "0a79cb65-ff26-5bf5-b4c5-220e84835371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5146dd15-f696-42c3-b0e5-6a1b1d7be6b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5146dd15-f696-42c3-b0e5-6a1b1d7be6b4.jpg?1",
             "name": "Dire Fleet Neckbreaker",
             "text": "Attacking Pirates you control get +2/+0.",
             "colours": [
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "618c125d-bc56-5b10-8afd-bc3294592d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52af49b-cfeb-47a8-9ce5-5d35bfa9eb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52af49b-cfeb-47a8-9ce5-5d35bfa9eb75.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "d5b69801-24de-5dcc-ad79-6a21cd2b12dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg?1",
             "name": "Hadana's Climb // Winged Temple of Orazca",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if that creature has three or more +1/+1 counters on it, transform Hadana's Climb.",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "6e299ca2-d620-5fe6-9fc4-35d1305d318a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg?1",
             "name": "Hadana's Climb // Winged Temple of Orazca",
             "text": "(Transforms from Hadana's Climb.)\n{T}: Add one mana of any color to your mana pool.\n{1}{G}{U}, {T}: Target creature you control gains flying and gets +X/+X until end of turn, where X is its power.",
             "colours": [],
@@ -5414,7 +5414,7 @@
         },
         {
             "id": "80f0d8bf-6ca9-5768-8bee-29051616f3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bcc48a-efdb-443f-93b8-bc0b54aa0eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bcc48a-efdb-443f-93b8-bc0b54aa0eb8.jpg?1",
             "name": "Huatli, Radiant Champion",
             "text": "+1: Put a loyalty counter on Huatli, Radiant Champion for each creature you control.\n\u22121: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.\n\u22128: You get an emblem with \"Whenever a creature enters the battlefield under your control, you may draw a card.\"",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "88400e25-72b6-54b9-8e0d-40851b42bcdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg?1",
             "name": "Journey to Eternity // Atzal, Cave of Eternity",
             "text": "Enchant creature you control\nWhen enchanted creature dies, return it to the battlefield under your control, then return Journey to Eternity to the battlefield transformed under your control.",
             "colours": [
@@ -5490,7 +5490,7 @@
         },
         {
             "id": "7664ab16-0936-560c-97ad-38da8f083349",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg?1",
             "name": "Journey to Eternity // Atzal, Cave of Eternity",
             "text": "(Transforms from Journey to Eternity.)\n{T}: Add one mana of any color to your mana pool.\n{3}{B}{G}, {T}: Return target creature card from your graveyard to the battlefield.",
             "colours": [],
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "0b03d1e9-4c22-5d0a-b45f-548ec32c0dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71282d-021c-4028-9ab7-f10e43e92c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71282d-021c-4028-9ab7-f10e43e92c80.jpg?1",
             "name": "Jungle Creeper",
             "text": "{3}{B}{G}: Return Jungle Creeper from your graveyard to your hand.",
             "colours": [
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "50dd34dc-b85f-5668-bb1e-583e9dff2721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aef818-c896-46e6-aaff-56aee52a066c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aef818-c896-46e6-aaff-56aee52a066c.jpg?1",
             "name": "Kumena, Tyrant of Orazca",
             "text": "Tap another untapped Merfolk you control: Kumena, Tyrant of Orazca can't be blocked this turn.\nTap three untapped Merfolk you control: Draw a card.\nTap five untapped Merfolk you control: Put a +1/+1 counter on each Merfolk you control.",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "748c9b9d-fd0e-5c14-87db-501661fb334f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7ff99-65d6-4e97-bdfa-b6e6eac0588f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7ff99-65d6-4e97-bdfa-b6e6eac0588f.jpg?1",
             "name": "Legion Lieutenant",
             "text": "Other Vampires you control get +1/+1.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "5b841a0b-80b8-5f61-bba1-4c6f1ff5dd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2935b829-23fb-415e-90f2-2e0016b5cde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2935b829-23fb-415e-90f2-2e0016b5cde9.jpg?1",
             "name": "Merfolk Mistbinder",
             "text": "Other Merfolk you control get +1/+1.",
             "colours": [
@@ -5672,7 +5672,7 @@
         },
         {
             "id": "7030cce5-cda0-52f4-a90b-7389387a3062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1",
             "name": "Path of Mettle // Metzali, Tower of Triumph",
             "text": "When Path of Mettle enters the battlefield, it deals 1 damage to each creature that doesn't have first strike, double strike, vigilance, or haste.\nWhenever you attack with at least two creatures that have first strike, double strike, vigilance, and/or haste, transform Path of Mettle.",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "a632754f-2552-5c91-90d2-063175557774",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1",
             "name": "Path of Mettle // Metzali, Tower of Triumph",
             "text": "(Transforms from Path of Mettle.)\n{T}: Add one mana of any color to your mana pool.\n{1}{R}, {T}: Metzali, Tower of Triumph deals 2 damage to each opponent.\n{2}{W}, {T}: Choose a creature at random that attacked this turn. Destroy that creature.",
             "colours": [],
@@ -5741,7 +5741,7 @@
         },
         {
             "id": "92584313-4011-514e-bc54-13723aada3a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg?1",
             "name": "Profane Procession // Tomb of the Dusk Rose",
             "text": "{3}{W}{B}: Exile target creature. Then if there are three or more cards exiled with Profane Procession, transform it.",
             "colours": [
@@ -5777,7 +5777,7 @@
         },
         {
             "id": "0f7191ec-1143-5483-b44b-7ad31989968d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg?1",
             "name": "Profane Procession // Tomb of the Dusk Rose",
             "text": "(Transforms from Profane Procession.)\n{T}: Add one mana of any color to your mana pool.\n{2}{W}{B}, {T}: Put a creature card exiled with this permanent onto the battlefield under your control.",
             "colours": [],
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "b578b9a0-f980-5d4f-b1a2-a597268e2456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ed9247-16c0-4ca4-9b46-d3da5a375e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ed9247-16c0-4ca4-9b46-d3da5a375e4c.jpg?1",
             "name": "Protean Raider",
             "text": "Raid \u2014 If you attacked with a creature this turn, you may have Protean Raider enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "72f0e60a-b3b0-56ee-8c7c-a0f90ef569ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6c43a7-e9c5-4b1c-9a6d-0d8798303045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6c43a7-e9c5-4b1c-9a6d-0d8798303045.jpg?1",
             "name": "Raging Regisaur",
             "text": "Whenever Raging Regisaur attacks, it deals 1 damage to target creature or player.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "cbba7335-c833-5313-b9dc-a2790d3c8fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0727ba-4180-4908-93be-a8abf29a8958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0727ba-4180-4908-93be-a8abf29a8958.jpg?1",
             "name": "Relentless Raptor",
             "text": "Vigilance\nRelentless Raptor attacks or blocks each combat if able.",
             "colours": [
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "96ff7ee4-097f-58c6-80d8-a3dee32464c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915f2ad9-fd39-465c-8261-bfa34116cbcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915f2ad9-fd39-465c-8261-bfa34116cbcc.jpg?1",
             "name": "Resplendent Griffin",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever Resplendent Griffin attacks, if you have the city's blessing, put a +1/+1 counter on it.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "44de3305-1657-5e19-b10b-7a4091287d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9c4c63-402e-489e-ab0d-1c98309b010a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9c4c63-402e-489e-ab0d-1c98309b010a.jpg?1",
             "name": "Siegehorn Ceratops",
             "text": "Enrage \u2014 Whenever Siegehorn Ceratops is dealt damage, put two +1/+1 counters on it. (It must survive the damage to get the counters.)",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "81bb9071-b002-5cfa-b057-eac428e0f1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad8525-7618-4c2b-8037-46f53dd42ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad8525-7618-4c2b-8037-46f53dd42ee0.jpg?1",
             "name": "Storm Fleet Sprinter",
             "text": "Haste\nStorm Fleet Sprinter can't be blocked.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "334707ec-651b-5c1d-bf11-330cf58e3282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg?1",
             "name": "Storm the Vault // Vault of Catlacan",
             "text": "Whenever one or more creatures you control deal combat damage to a player, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nAt the beginning of your end step, if you control five or more artifacts, transform Storm the Vault.",
             "colours": [
@@ -6064,7 +6064,7 @@
         },
         {
             "id": "ae385080-8c4b-5dfd-9c1b-fda792310c20",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg?1",
             "name": "Storm the Vault // Vault of Catlacan",
             "text": "(Transforms from Storm the Vault.)\n{T}: Add one mana of any color to your mana pool.\n{T}: Add {U} to your mana pool for each artifact you control.",
             "colours": [],
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "ba3f6ea7-2699-552f-b11c-2041a03ce5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa75f2b-53c5-47c5-96d2-ab796358a96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa75f2b-53c5-47c5-96d2-ab796358a96f.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -6138,7 +6138,7 @@
         },
         {
             "id": "c0cec6af-73e2-5677-a339-d778a13c4d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b14ea-04f0-4d4b-970e-efc65d64945e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b14ea-04f0-4d4b-970e-efc65d64945e.jpg?1",
             "name": "Awakened Amalgam",
             "text": "Awakened Amalgam's power and toughness are each equal to the number of differently named lands you control.",
             "colours": [],
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "84cabf87-ea4e-53e6-9f48-2bfe3d2f4216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg?1",
             "name": "Azor's Gateway // Sanctum of the Sun",
             "text": "{1}, {T}: Draw a card, then exile a card from your hand. If cards with five or more different converted mana costs are exiled with Azor's Gateway, you gain 5 life, untap Azor's Gateway, and transform it.",
             "colours": [],
@@ -6199,7 +6199,7 @@
         },
         {
             "id": "d0b0fece-d4bd-5013-b718-df9d2db81d05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg?1",
             "name": "Azor's Gateway // Sanctum of the Sun",
             "text": "(Transforms from Azor's Gateway.)\n{T}: Add X mana of any one color to your mana pool, where X is your life total.",
             "colours": [],
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "28dcfe92-70f7-559a-af25-9fd83d2e5ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3f777-b33a-454a-8d5d-993260ddda03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3f777-b33a-454a-8d5d-993260ddda03.jpg?1",
             "name": "Captain's Hook",
             "text": "Equipped creature gets +2/+0, has menace, and is a Pirate in addition to its other creature types.\nWhenever Captain's Hook becomes unattached from a permanent, destroy that permanent.\nEquip {1}",
             "colours": [],
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "507c36c2-9c37-58de-9ebf-445125b4f2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62447a76-4aa7-4823-941e-84bc18eb672a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62447a76-4aa7-4823-941e-84bc18eb672a.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen Gleaming Barrier dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [],
@@ -6290,7 +6290,7 @@
         },
         {
             "id": "b9d63a33-71cc-5824-a614-b511480cf3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg?1",
             "name": "Golden Guardian // Gold-Forge Garrison",
             "text": "Defender\n{2}: Golden Guardian fights another target creature you control. When Golden Guardian dies this turn, return it to the battlefield transformed under your control.",
             "colours": [],
@@ -6321,7 +6321,7 @@
         },
         {
             "id": "7cc06729-21e7-5cb0-822f-c88156a98eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg?1",
             "name": "Golden Guardian // Gold-Forge Garrison",
             "text": "(Transforms from Golden Guardian.)\n{T}: Add two mana of any one color to your mana pool.\n{4}, {T}: Create a 4/4 colorless Golem artifact creature token.",
             "colours": [],
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "ad1528f9-a4b4-58ea-955d-0f4cad3f3398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeccd88-8dc0-4cc1-943f-27d540d248bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeccd88-8dc0-4cc1-943f-27d540d248bb.jpg?1",
             "name": "The Immortal Sun",
             "text": "Players can't activate planeswalkers' loyalty abilities.\nAt the beginning of your draw step, draw an additional card.\nSpells you cast cost {1} less to cast.\nCreatures you control get +1/+1.",
             "colours": [],
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "fd962248-4199-565b-8dce-9a4b2b011348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed70bc5-8ea9-404e-a8cd-04322c8bc689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed70bc5-8ea9-404e-a8cd-04322c8bc689.jpg?1",
             "name": "Orazca Relic",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C} to your mana pool.\n{T}, Sacrifice Orazca Relic: You gain 3 life and draw a card. Activate this ability only if you have the city's blessing.",
             "colours": [],
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "6906c333-1051-5710-8aee-f8b97f544938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff60f685-a17e-4be6-bbb6-d14a053533ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff60f685-a17e-4be6-bbb6-d14a053533ef.jpg?1",
             "name": "Silent Gravestone",
             "text": "Cards in graveyards can't be the targets of spells or abilities.\n{4}, {T}: Exile Silent Gravestone and all cards from all graveyards. Draw a card.",
             "colours": [],
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "5b67b730-8892-529d-98d2-a2e059b8825e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94daa9-5b9b-4fd2-829e-081eed22c18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94daa9-5b9b-4fd2-829e-081eed22c18f.jpg?1",
             "name": "Strider Harness",
             "text": "Equipped creature gets +1/+1 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6465,7 +6465,7 @@
         },
         {
             "id": "2ce650b2-8b3a-59aa-abe1-7205ea7fba29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e2aa2-110e-4824-a9c9-5a76cb2bec23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e2aa2-110e-4824-a9c9-5a76cb2bec23.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "0b10bbf7-5ce1-5913-838c-67660bd87a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d47162-749b-47d5-9589-8f1dbf60b9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d47162-749b-47d5-9589-8f1dbf60b9f3.jpg?1",
             "name": "Arch of Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C} to your mana pool.\n{5}, {T}: Draw a card. Activate this ability only if you have the city's blessing.",
             "colours": [],
@@ -6521,7 +6521,7 @@
         },
         {
             "id": "c13c66ee-1db9-5674-876b-11cc0fdb47ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62df0466-3bb4-423c-aae8-412205fb9f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62df0466-3bb4-423c-aae8-412205fb9f14.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "9719235d-3592-549d-a96b-30dddba8acf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e5daf3-6a55-4c2f-92d1-33e0755ee280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e5daf3-6a55-4c2f-92d1-33e0755ee280.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "b06c36fe-a25b-593c-b776-f2b74ff9eb49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66f9017-e04b-4f13-aae0-28a903f2fac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66f9017-e04b-4f13-aae0-28a903f2fac2.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -6611,7 +6611,7 @@
         },
         {
             "id": "28f8f87d-ecb7-5bee-b444-6bb02d3fcc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344f5678-d25b-40af-aa91-b0eed90fd037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344f5678-d25b-40af-aa91-b0eed90fd037.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -6642,7 +6642,7 @@
         },
         {
             "id": "2411512a-1770-5702-91b3-ed1ee0885a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e782c-2159-4e8d-b2d7-9f96b7609db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e782c-2159-4e8d-b2d7-9f96b7609db4.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -6673,7 +6673,7 @@
         },
         {
             "id": "5cf45853-425e-5511-970e-9cdffe2d57b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f14b4d-b90e-4ce4-aa32-13c9969aa46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f14b4d-b90e-4ce4-aa32-13c9969aa46a.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "42d0ea18-a81d-591a-ac58-7923d0beb500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92342f45-ccfe-4d94-82ba-2fd55128326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92342f45-ccfe-4d94-82ba-2fd55128326f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "a446efdc-27fc-5e7a-9c68-d8326396586e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22fb908-e616-48ce-a388-46eabe26221a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22fb908-e616-48ce-a388-46eabe26221a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "a6f143e5-b88a-5f3e-9259-68fc97ea0a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674de0e1-be2d-4fda-8519-8775802a7b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674de0e1-be2d-4fda-8519-8775802a7b36.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6806,7 +6806,7 @@
         },
         {
             "id": "fcc6374e-1f2e-5363-a0d9-797bb037bb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd9acc5-0088-4621-8f48-e997da5f27c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd9acc5-0088-4621-8f48-e997da5f27c5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "5a894232-5b7b-5d7c-a803-5cadd21c52e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c9e16d-525b-4ba9-890d-fa2719206ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c9e16d-525b-4ba9-890d-fa2719206ba0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "aefe8769-bc31-51e4-89e7-dece664724f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91685732-c118-4f52-ac77-f96866a687a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91685732-c118-4f52-ac77-f96866a687a3.jpg?1",
             "name": "Vraska, Scheming Gorgon",
             "text": "+2: Creatures you control get +1/+0 until end of turn.\n\u22123: Destroy target creature.\n\u221210: Until end of turn, creatures you control gain deathtouch and \"Whenever this creature deals damage to an opponent, that player loses the game.\"",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "7e5bef08-30ce-55a6-8a13-853f0309caf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47f91ff-c916-4938-8e01-2c684004dd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47f91ff-c916-4938-8e01-2c684004dd9a.jpg?1",
             "name": "Vampire Champion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6943,7 +6943,7 @@
         },
         {
             "id": "fad9f64b-d800-5982-9a31-87c2c80c6aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d890a17-ffd4-4bda-bef3-2c116f7bf66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d890a17-ffd4-4bda-bef3-2c116f7bf66f.jpg?1",
             "name": "Vraska's Conquistador",
             "text": "Whenever Vraska's Conquistador attacks or blocks, if you control a Vraska planeswalker, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -6977,7 +6977,7 @@
         },
         {
             "id": "194d8db7-67aa-5bc3-9695-fde4701a6cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569ff807-365d-4f25-9fad-86617ed1c8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569ff807-365d-4f25-9fad-86617ed1c8f2.jpg?1",
             "name": "Vraska's Scorn",
             "text": "Target opponent loses 4 life. You may search your library and/or graveyard for a card named Vraska, Scheming Gorgon, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "8c5ddefb-ae09-50f0-883f-9a9ea7962fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17103dd-f31b-4f6e-b2ea-4ea91815bdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17103dd-f31b-4f6e-b2ea-4ea91815bdd6.jpg?1",
             "name": "Angrath, Minotaur Pirate",
             "text": "+2: Angrath, Minotaur Pirate deals 1 damage to target opponent and each creature that player controls.\n\u22123: Return target Pirate card from your graveyard to the battlefield.\n\u221211: Destroy all creatures target opponent controls. Angrath, Minotaur Pirate deals damage to that player equal to their total power.",
             "colours": [
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "e3daa823-204d-5ac3-84c3-70f7ea7bdc74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48181263-11fd-444e-9fef-02ccfe016c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48181263-11fd-444e-9fef-02ccfe016c8c.jpg?1",
             "name": "Angrath's Ambusher",
             "text": "Angrath's Ambusher gets +2/+0 as long as you control an Angrath planeswalker.",
             "colours": [
@@ -7079,7 +7079,7 @@
         },
         {
             "id": "3b09bc67-eb02-5be2-b9bc-20000072995d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0403b8e5-29c5-4a4a-b9e7-1e79a7452f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0403b8e5-29c5-4a4a-b9e7-1e79a7452f14.jpg?1",
             "name": "Swab Goblin",
             "text": "",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "a6b382c7-4539-57c8-85df-0559c052d9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708006ba-d494-4093-b108-8249b110831e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708006ba-d494-4093-b108-8249b110831e.jpg?1",
             "name": "Angrath's Fury",
             "text": "Destroy target creature. Angrath's Fury deals 3 damage to target player. You may search your library and/or graveyard for a card named Angrath, Minotaur Pirate, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "34f9410d-1167-5e7a-ad3b-3151909383cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6bd6b-92fb-4b4f-89c2-762cc2c465f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6bd6b-92fb-4b4f-89c2-762cc2c465f3.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "ffe14eda-bdfb-5982-9749-71ceb4fad071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf1d7-2e66-41fd-ae9a-ea86b939e7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf1d7-2e66-41fd-ae9a-ea86b939e7c9.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -7210,7 +7210,7 @@
         },
         {
             "id": "1a5ed6ee-d893-5407-9e68-78b5ccb46175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236ab9c-7730-46d9-a543-84ff7b245ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236ab9c-7730-46d9-a543-84ff7b245ece.jpg?1",
             "name": "Rivals of Ixalan Checklist",
             "text": "",
             "colours": [],
@@ -7237,7 +7237,7 @@
         },
         {
             "id": "199f5634-c706-5103-84c8-9d3100ee5edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577a3396-e974-47fb-91bd-01751cae83bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577a3396-e974-47fb-91bd-01751cae83bf.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -7271,7 +7271,7 @@
         },
         {
             "id": "001779ab-ab90-512e-9e9f-cd5bf1a39d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925715e5-bb94-406b-82b1-93b4d51f0cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925715e5-bb94-406b-82b1-93b4d51f0cc2.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -7305,7 +7305,7 @@
         },
         {
             "id": "dbcdc2ad-8a30-56df-840b-e8db8edf53cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7820eb9-6d7f-4bc4-b421-4e4420642fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7820eb9-6d7f-4bc4-b421-4e4420642fb7.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -7336,7 +7336,7 @@
         },
         {
             "id": "69216e15-1df0-5748-a037-172be13eeb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859f645b-24e0-4c34-ae82-ba0ae9854377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859f645b-24e0-4c34-ae82-ba0ae9854377.jpg?1",
             "name": "Huatli, Radiant Champion Emblem",
             "text": "",
             "colours": [],
@@ -7365,7 +7365,7 @@
         },
         {
             "id": "ef50f1ce-9ec6-5f7c-a5b5-3bdc1097e5c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64ed3e-93c5-406f-a38d-65cc68472122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64ed3e-93c5-406f-a38d-65cc68472122.jpg?1",
             "name": "City's Blessing",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/RNA.json
+++ b/Assets/Resources/Sets/RNA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b659bb15-30b1-5fb8-b57c-2addaaccbe69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80164e61-3e94-4e10-9bd1-518b8dc7fc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80164e61-3e94-4e10-9bd1-518b8dc7fc4c.jpg?1",
             "name": "Angel of Grace",
             "text": "Flash\nFlying\nWhen Angel of Grace enters the battlefield, until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.\n{4}{W}{W}, Exile Angel of Grace from your graveyard: Your life total becomes 10.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "d995c603-e44a-5fe1-a7e1-4a8451326968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7b5ae5-0f6b-4f45-8597-4e6212d2ad0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7b5ae5-0f6b-4f45-8597-4e6212d2ad0e.jpg?1",
             "name": "Angelic Exaltation",
             "text": "Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "d27b0d0d-f775-534b-bd39-deb6d15ab4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b209d219-b946-4226-a8b4-65a5f3837fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b209d219-b946-4226-a8b4-65a5f3837fac.jpg?1",
             "name": "Archway Angel",
             "text": "Flying\nWhen Archway Angel enters the battlefield, you gain 2 life for each Gate you control.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "7f937f1a-6c12-5de9-950e-8a6285d6b832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b075a6f2-5196-45e9-b062-f131f7b1a347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b075a6f2-5196-45e9-b062-f131f7b1a347.jpg?1",
             "name": "Arrester's Zeal",
             "text": "Target creature gets +2/+2 until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, that creature gains flying until end of turn.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "d9b1484c-cadd-501c-bd6f-35a2f69d8478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d566fc-0936-4035-96fd-f8b0c4eadbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d566fc-0936-4035-96fd-f8b0c4eadbf5.jpg?1",
             "name": "Bring to Trial",
             "text": "Exile target creature with power 4 or greater.",
             "colours": [
@@ -168,7 +168,7 @@
         },
         {
             "id": "94b5308d-2717-58c9-80de-1dde77a16d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa981489-4301-43f6-b1d7-2aa42e00cf75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa981489-4301-43f6-b1d7-2aa42e00cf75.jpg?1",
             "name": "Civic Stalwart",
             "text": "When Civic Stalwart enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "c1b58101-a228-584d-bd76-1ad73f8021c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7fdf7b-022c-4900-9344-9b13d41c1604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7fdf7b-022c-4900-9344-9b13d41c1604.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "6e318808-aa42-5397-a883-fe630f804ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c2ac3-040f-41fe-9a37-c037d90baec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c2ac3-040f-41fe-9a37-c037d90baec0.jpg?1",
             "name": "Expose to Daylight",
             "text": "Destroy target artifact or enchantment. Scry 1.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "49e5508d-9d8c-5e25-af21-90ff15698fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17056e7-95c6-4bed-a747-3b40dcda275a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17056e7-95c6-4bed-a747-3b40dcda275a.jpg?1",
             "name": "Forbidding Spirit",
             "text": "When Forbidding Spirit enters the battlefield, until your next turn, creatures can't attack you or a planeswalker you control unless their controller pays {2} for each of those creatures.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "c6f8a3a0-df8a-51cb-a7b8-85a228734679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba5f096-c6ea-4db6-966b-617e3454813f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba5f096-c6ea-4db6-966b-617e3454813f.jpg?1",
             "name": "Haazda Officer",
             "text": "When Haazda Officer enters the battlefield, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "bea6fb15-9ca5-5dfb-8e58-53a59cc18307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87732718-1067-4e5f-a76d-409539c9ef3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87732718-1067-4e5f-a76d-409539c9ef3f.jpg?1",
             "name": "Hero of Precinct One",
             "text": "Whenever you cast a multicolored spell, create a 1/1 white Human creature token.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "d3be5dc8-0909-569b-a53b-012171e85a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd746e3-8934-4c86-894e-2cb1738b1d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd746e3-8934-4c86-894e-2cb1738b1d58.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "8ce91e86-b3b7-510e-a40a-1ae177123d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df611df-3490-4b07-8034-6da9a0122a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df611df-3490-4b07-8034-6da9a0122a81.jpg?1",
             "name": "Justiciar's Portal",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. It gains first strike until end of turn.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "e349d3d5-f71a-553b-8b1f-7d3c7f963ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce239e9-9b35-4dde-8a44-6c7ce4eb2d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce239e9-9b35-4dde-8a44-6c7ce4eb2d1a.jpg?1",
             "name": "Knight of Sorrows",
             "text": "Knight of Sorrows can block an additional creature each combat.\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "2dbf5c4b-aeb1-57bf-b25b-a0a69fbdf92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2469bc93-57ca-4077-bda2-160b4160adad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2469bc93-57ca-4077-bda2-160b4160adad.jpg?1",
             "name": "Lumbering Battlement",
             "text": "Vigilance\nWhen Lumbering Battlement enters the battlefield, exile any number of other nontoken creatures you control until it leaves the battlefield.\nLumbering Battlement gets +2/+2 for each card exiled with it.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "88658929-152b-5ae7-9be8-9be49c0efd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2a093a-25f0-4247-94dc-550865d86317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2a093a-25f0-4247-94dc-550865d86317.jpg?1",
             "name": "Ministrant of Obligation",
             "text": "Afterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "3d199dc5-f9e4-5d3e-8ee8-dc297e02c900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5382fc4-3384-449e-a83f-43a59158d55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5382fc4-3384-449e-a83f-43a59158d55b.jpg?1",
             "name": "Prowling Caracal",
             "text": "",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "9bfea731-d787-5a7f-8680-5939f1586c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0798546-1ef4-485e-b094-cba12a12c67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0798546-1ef4-485e-b094-cba12a12c67c.jpg?1",
             "name": "Rally to Battle",
             "text": "Creatures you control get +1/+3 until end of turn. Untap them.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "c2f125ec-847c-501a-8974-59edd31b696d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d86909-b7f3-4a46-9904-e173853b79f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d86909-b7f3-4a46-9904-e173853b79f1.jpg?1",
             "name": "Resolute Watchdog",
             "text": "Defender\n{1}, Sacrifice Resolute Watchdog: Target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "cef6d8f1-2085-5dc6-98be-8f1eb6faaee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f4f661-ee4b-4fa5-99c4-106731d117ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f4f661-ee4b-4fa5-99c4-106731d117ce.jpg?1",
             "name": "Sentinel's Mark",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+2 and has vigilance.\nAddendum \u2014 When Sentinel's Mark enters the battlefield, if you cast it during your main phase, enchanted creature gains lifelink until end of turn.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "a72ba1f4-b5fc-51a9-81ad-8d9c2bdb98b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c47be3-0228-46de-b4b5-911fb86d4596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c47be3-0228-46de-b4b5-911fb86d4596.jpg?1",
             "name": "Sky Tether",
             "text": "Enchant creature\nEnchanted creature has defender and loses flying.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "fdccaf49-4190-5740-bf6c-2fc9139489f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af082fa-86a3-4f7b-966d-2be1f1d0c0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af082fa-86a3-4f7b-966d-2be1f1d0c0bc.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color.\"",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "01f2c604-0473-57df-a39e-e6d47759636c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd11910-58e2-4233-a18c-e97413126597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd11910-58e2-4233-a18c-e97413126597.jpg?1",
             "name": "Spirit of the Spires",
             "text": "Flying\nOther creatures you control with flying get +0/+1.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "5f499cfe-240d-514e-8480-b86d1b1d2ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b20fec-8373-4c6c-b3c1-ee7cff64dd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b20fec-8373-4c6c-b3c1-ee7cff64dd37.jpg?1",
             "name": "Summary Judgment",
             "text": "Summary Judgment deals 3 damage to target tapped creature.\nAddendum \u2014 If you cast this spell during your main phase, it deals 5 damage to that creature instead.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "9daddc47-6090-5fd8-8cce-2460d8731c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10273046-4c74-42d8-afaa-6cfbe0bd4e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10273046-4c74-42d8-afaa-6cfbe0bd4e8f.jpg?1",
             "name": "Syndicate Messenger",
             "text": "Flying\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "9a2878ae-c247-51df-a3e7-e347f17bbbfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef573e92-3106-4b42-90e8-0e165de0659f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef573e92-3106-4b42-90e8-0e165de0659f.jpg?1",
             "name": "Tenth District Veteran",
             "text": "Vigilance\nWhenever Tenth District Veteran attacks, untap another target creature you control.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "be77ca12-561c-5153-8952-0259d365d96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26b7b1-992d-4b8c-bc33-51aab5abdf98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26b7b1-992d-4b8c-bc33-51aab5abdf98.jpg?1",
             "name": "Tithe Taker",
             "text": "During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities.\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "0712bc53-5228-54cd-92f3-5bce00b429a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb149cc-74ca-4bc3-8efc-10ce872b59fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb149cc-74ca-4bc3-8efc-10ce872b59fb.jpg?1",
             "name": "Twilight Panther",
             "text": "{B}: Twilight Panther gains deathtouch until end of turn.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "50289b0b-7c1a-5c8d-99b1-de02a10118c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cc8574-7b8c-492c-8a36-75cb0192f853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cc8574-7b8c-492c-8a36-75cb0192f853.jpg?1",
             "name": "Unbreakable Formation",
             "text": "Creatures you control gain indestructible until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, put a +1/+1 counter on each of those creatures and they gain vigilance until end of turn.",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "263b5478-6d78-5fed-abc1-3e48f2d2ac65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a38f24-1eb3-4914-be1f-0b5f6d4b09d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a38f24-1eb3-4914-be1f-0b5f6d4b09d5.jpg?1",
             "name": "Watchful Giant",
             "text": "When Watchful Giant enters the battlefield, create a 1/1 white Human creature token.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "6e5a5a2c-d78e-5646-a06f-cacb53969a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c2d6a-e6b8-4dc5-81aa-da1b7384e006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c2d6a-e6b8-4dc5-81aa-da1b7384e006.jpg?1",
             "name": "Arrester's Admonition",
             "text": "Return target creature to its owner's hand.\nAddendum \u2014 If you cast this spell during your main phase, draw a card.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "0070f147-8697-5fb9-8da7-1981aec68dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0cb4d6-350b-4e66-b035-dac7b3ba77cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0cb4d6-350b-4e66-b035-dac7b3ba77cc.jpg?1",
             "name": "Benthic Biomancer",
             "text": "{1}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Benthic Biomancer, draw a card, then discard a card.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "fd6776d7-69c4-5333-92b4-23c008348940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158547fa-7313-4e77-949f-afc68ebfb022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158547fa-7313-4e77-949f-afc68ebfb022.jpg?1",
             "name": "Chillbringer",
             "text": "Flying\nWhen Chillbringer enters the battlefield, tap target creature an opponent controls. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "62525794-0d8b-5788-a238-b49f0aec9366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da6982-9e57-41d2-a052-f2a3bb646436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da6982-9e57-41d2-a052-f2a3bb646436.jpg?1",
             "name": "Clear the Mind",
             "text": "Target player shuffles their graveyard into their library.\nDraw a card.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "0a3ba2fb-0acb-570f-8bcc-0e288cf21861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258aeef1-565a-4f19-b12c-d46d54ba231d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258aeef1-565a-4f19-b12c-d46d54ba231d.jpg?1",
             "name": "Code of Constraint",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.\nAddendum \u2014 If you cast this spell during your main phase, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "fb2d4fb4-e82e-5307-a8b2-afaf0948d7c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg?1",
             "name": "Coral Commando",
             "text": "",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "7a6ef288-74cb-5cbf-9521-b3be3f23daee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce137910-0f0e-4f94-9b95-6e0eeeba164e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce137910-0f0e-4f94-9b95-6e0eeeba164e.jpg?1",
             "name": "Essence Capture",
             "text": "Counter target creature spell. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "ab0962f8-f4b0-5791-b55e-1fd42d314579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdbf073-3ee6-402b-bd40-4781f40a6cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdbf073-3ee6-402b-bd40-4781f40a6cae.jpg?1",
             "name": "Eyes Everywhere",
             "text": "At the beginning of your upkeep, scry 1.\n{5}{U}: Exchange control of Eyes Everywhere and target nonland permanent. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "88c317e3-0a38-5991-99e1-b028890e4c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da9c9b-aeef-4f48-bc8f-39425841cc8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da9c9b-aeef-4f48-bc8f-39425841cc8c.jpg?1",
             "name": "Faerie Duelist",
             "text": "Flash\nFlying\nWhen Faerie Duelist enters the battlefield, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "fd8c9492-f8d9-5688-af02-db9c27ac8063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc0229d-05e6-41b7-b7a9-2a8b2b258add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc0229d-05e6-41b7-b7a9-2a8b2b258add.jpg?1",
             "name": "Gateway Sneak",
             "text": "Whenever a Gate enters the battlefield under your control, Gateway Sneak can't be blocked this turn.\nWhenever Gateway Sneak deals combat damage to a player, draw a card.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "4e86ea22-e47c-55bc-8108-b6e34126a9d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21982dc7-4f79-4251-8382-95cd1f627e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21982dc7-4f79-4251-8382-95cd1f627e0f.jpg?1",
             "name": "Humongulus",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1387,7 +1387,7 @@
         },
         {
             "id": "08a26304-d0cd-58fb-a001-23f7963e09b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782760d7-59cc-4d40-a885-6a7980094fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782760d7-59cc-4d40-a885-6a7980094fee.jpg?1",
             "name": "Mass Manipulation",
             "text": "Gain control of X target creatures and/or planeswalkers.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "675d9fac-40b4-515e-8323-53b64ead6402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bed7c69-1302-4c1a-b410-b4e6c4ef4c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bed7c69-1302-4c1a-b410-b4e6c4ef4c0c.jpg?1",
             "name": "Mesmerizing Benthid",
             "text": "When Mesmerizing Benthid enters the battlefield, create two 0/2 blue Illusion creature tokens with \"Whenever this creature blocks a creature, that creature doesn't untap during its controller's next untap step.\"\nMesmerizing Benthid has hexproof as long as you control an Illusion.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "b58ff632-8260-542a-b66b-61b0fbbccddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93f0c57-eb80-4dde-bdb0-326970491621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93f0c57-eb80-4dde-bdb0-326970491621.jpg?1",
             "name": "Persistent Petitioners",
             "text": "{1}, {T}: Target player puts the top card of their library into their graveyard.\nTap four untapped Advisors you control: Target player puts the top twelve cards of their library into their graveyard.\nA deck can have any number of cards named Persistent Petitioners.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "5804d99c-b7d0-5389-8794-5d50038ab4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724fd1ea-05ad-497c-9989-825ada48e684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724fd1ea-05ad-497c-9989-825ada48e684.jpg?1",
             "name": "Precognitive Perception",
             "text": "Draw three cards.\nAddendum \u2014 If you cast this spell during your main phase, instead scry 3, then draw three cards.",
             "colours": [
@@ -1520,7 +1520,7 @@
         },
         {
             "id": "6477f2b3-0b86-515e-b9cc-d13cca19fdf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ee2c64-68f1-434b-8092-ae80d6575666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ee2c64-68f1-434b-8092-ae80d6575666.jpg?1",
             "name": "Prying Eyes",
             "text": "Draw four cards, then discard two cards.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "4d22da4b-79b2-5d5f-b250-39e12273375d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280f2a85-1900-460b-a768-164fc2dea636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280f2a85-1900-460b-a768-164fc2dea636.jpg?1",
             "name": "Pteramander",
             "text": "Flying\n{7}{U}: Adapt 4. This ability costs {1} less to activate for each instant and sorcery card in your graveyard. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "9261f315-9202-589f-9d33-8ccae165b4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ba01b-de96-4f8f-9405-ff3ad288afac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ba01b-de96-4f8f-9405-ff3ad288afac.jpg?1",
             "name": "Quench",
             "text": "Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -1619,7 +1619,7 @@
         },
         {
             "id": "5bee2743-65fc-5364-9869-314cbb7e1e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg?1",
             "name": "Sage's Row Savant",
             "text": "When Sage's Row Savant enters the battlefield, scry 2.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "d68676bf-52ce-52e5-b5c4-d3e4cfbb313d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8dc5c8-4eb7-4e41-8431-b41251f7814e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8dc5c8-4eb7-4e41-8431-b41251f7814e.jpg?1",
             "name": "Senate Courier",
             "text": "Flying\n{1}{W}: Senate Courier gains vigilance until end of turn.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "2b33686d-8d6c-5282-8950-9356dd1e763c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e3092d-2422-438c-b5dd-bf8eca33a76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e3092d-2422-438c-b5dd-bf8eca33a76e.jpg?1",
             "name": "Shimmer of Possibility",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "39cb70b4-33cd-56cc-bdc1-7fa63329662f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4a517c-515b-4adc-8ea6-fb86820f22ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4a517c-515b-4adc-8ea6-fb86820f22ed.jpg?1",
             "name": "Skatewing Spy",
             "text": "{5}{U}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "00aa8ab6-2c28-5cfd-8af6-d6a30f9ee8ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328f03-7dae-445b-8e71-99dd88f26a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328f03-7dae-445b-8e71-99dd88f26a9e.jpg?1",
             "name": "Skitter Eel",
             "text": "{2}{U}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "aa58db2f-a869-5cf0-89bb-37ed029d5e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6263410-20c5-43b4-8183-3c02c10d07fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6263410-20c5-43b4-8183-3c02c10d07fb.jpg?1",
             "name": "Slimebind",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -4/-0.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "ad67e5ce-06a6-5f12-9a57-e84abfdb1110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2386fd-edc0-4731-8f4e-7a7c45548bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2386fd-edc0-4731-8f4e-7a7c45548bf3.jpg?1",
             "name": "Sphinx of Foresight",
             "text": "You may reveal this card from your opening hand. If you do, scry 3 at the beginning of your first upkeep.\nFlying\nAt the beginning of your upkeep, scry 1.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "4e788d84-1799-53b1-b2d7-7bb9d104dff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb3d2f-4ee4-46e2-98aa-4aa388bd5375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb3d2f-4ee4-46e2-98aa-4aa388bd5375.jpg?1",
             "name": "Swirling Torrent",
             "text": "Choose one or both \u2014\n\u2022 Put target creature on top of its owner's library.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "d59efcc4-1a29-56b7-92a9-d1d3b42f9519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b569b-6341-418b-99b5-f79dfb3fe8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b569b-6341-418b-99b5-f79dfb3fe8dd.jpg?1",
             "name": "Thought Collapse",
             "text": "Counter target spell. Its controller puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -1924,7 +1924,7 @@
         },
         {
             "id": "8d710981-34d1-5305-9d66-a0d7ddc1c3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d866d26-b630-46d3-bcc2-b810c844cc89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d866d26-b630-46d3-bcc2-b810c844cc89.jpg?1",
             "name": "Verity Circle",
             "text": "Whenever a creature an opponent controls becomes tapped, if it isn't being declared as an attacker, you may draw a card.\n{4}{U}: Tap target creature without flying.",
             "colours": [
@@ -1956,7 +1956,7 @@
         },
         {
             "id": "0569f9d3-c22a-550d-9523-9b594a0b60df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a0a627-ea7a-48bb-bf30-60b2677dd8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a0a627-ea7a-48bb-bf30-60b2677dd8ae.jpg?1",
             "name": "Wall of Lost Thoughts",
             "text": "Defender\nWhen Wall of Lost Thoughts enters the battlefield, target player puts the top four cards of their library into their graveyard.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "7cb9cd80-3ebe-5fb7-b2c7-3e319b5ac4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120aa3b3-d358-4df3-be39-9b7ce926673a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120aa3b3-d358-4df3-be39-9b7ce926673a.jpg?1",
             "name": "Windstorm Drake",
             "text": "Flying\nOther creatures you control with flying get +1/+0.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "266da262-9891-5741-8817-efccb42d6a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea166114-2f9b-4ca6-b573-1f49f7485580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea166114-2f9b-4ca6-b573-1f49f7485580.jpg?1",
             "name": "Awaken the Erstwhile",
             "text": "Each player discards all the cards in their hand, then creates that many 2/2 black Zombie creature tokens.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "43a662a7-d2a9-5416-abb5-68b7c5fd527b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635c433-0398-442a-856e-1869f6bf2cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635c433-0398-442a-856e-1869f6bf2cfd.jpg?1",
             "name": "Bankrupt in Blood",
             "text": "As an additional cost to cast this spell, sacrifice two creatures.\nDraw three cards.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "183065ff-7e3a-5598-acbb-31170983a839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099bc474-e656-4167-b105-3a3a36c0b23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099bc474-e656-4167-b105-3a3a36c0b23e.jpg?1",
             "name": "Blade Juggler",
             "text": "Spectacle {2}{B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nWhen Blade Juggler enters the battlefield, it deals 1 damage to you and you draw a card.",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "e6919189-513a-58a8-ab9d-cd382456f94c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f738545d-5483-45ec-bb31-d62b0fae9ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f738545d-5483-45ec-bb31-d62b0fae9ea7.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "60ca4fc3-0a43-578c-800d-a1c46c1de0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909489a9-2678-4b6f-9d5e-2c04bb4cbd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909489a9-2678-4b6f-9d5e-2c04bb4cbd66.jpg?1",
             "name": "Bloodmist Infiltrator",
             "text": "Whenever Bloodmist Infiltrator attacks, you may sacrifice another creature. If you do, Bloodmist Infiltrator can't be blocked this turn.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "3ac029bd-1e61-5a95-aed3-5f0b3cba3f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958caf1d-b159-4c27-8248-00c345f880be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958caf1d-b159-4c27-8248-00c345f880be.jpg?1",
             "name": "Carrion Imp",
             "text": "Flying\nWhen Carrion Imp enters the battlefield, you may exile target creature card from a graveyard. If you do, you gain 2 life.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "5bf11981-a6f8-5347-afb7-d5ed8a403932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c53f0-7922-4e14-802d-d7a22f8fed85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c53f0-7922-4e14-802d-d7a22f8fed85.jpg?1",
             "name": "Catacomb Crocodile",
             "text": "",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "ce00e9ad-ec71-58cb-9952-ab0315af833a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65975-6ff5-4863-b7b7-d7dbea213b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65975-6ff5-4863-b7b7-d7dbea213b50.jpg?1",
             "name": "Clear the Stage",
             "text": "Target creature gets -3/-3 until end of turn. If you control a creature with power 4 or greater, you may return up to one target creature card from your graveyard to your hand.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "c46c1906-96d7-5213-a20d-c05658e7f3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09991fad-4282-4a17-bfb1-03eaa13502df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09991fad-4282-4a17-bfb1-03eaa13502df.jpg?1",
             "name": "Consign to the Pit",
             "text": "Destroy target creature. Consign to the Pit deals 2 damage to that creature's controller.",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "d02ddc80-40be-588a-ab0e-4fb95f55445d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715a14a3-046e-45ca-b943-dd630e5202b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715a14a3-046e-45ca-b943-dd630e5202b7.jpg?1",
             "name": "Cry of the Carnarium",
             "text": "All creatures get -2/-2 until end of turn. Exile all creature cards in all graveyards that were put there from the battlefield this turn. If a creature would die this turn, exile it instead.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "468648b9-7e18-578d-93aa-bb641abf9af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2c21a-419d-4896-82e3-1b5cb32b158e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2c21a-419d-4896-82e3-1b5cb32b158e.jpg?1",
             "name": "Dead Revels",
             "text": "Spectacle {1}{B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "fce95457-eadb-5d2c-bc07-b98c045b13d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03b99-d62e-428a-9e0d-097f1227a4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03b99-d62e-428a-9e0d-097f1227a4da.jpg?1",
             "name": "Debtors' Transport",
             "text": "Afterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "9d694d26-1cd5-533e-97d4-d8b07b99d798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8710c-9c5e-4d11-b45f-0728c54bd631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8710c-9c5e-4d11-b45f-0728c54bd631.jpg?1",
             "name": "Drill Bit",
             "text": "Spectacle {B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nTarget player reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "15e0f9ed-d09f-5286-9950-2ae06f6e7122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c02aec-4a89-4ccc-8525-6f979c10d799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c02aec-4a89-4ccc-8525-6f979c10d799.jpg?1",
             "name": "Font of Agonies",
             "text": "Whenever you pay life, put that many blood counters on Font of Agonies.\n{1}{B}, Remove four blood counters from Font of Agonies: Destroy target creature.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "7b430b0a-2a5e-58ba-b654-63d36676818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b698c5e1-3816-4f35-8e39-65dc68f5c64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b698c5e1-3816-4f35-8e39-65dc68f5c64f.jpg?1",
             "name": "Grotesque Demise",
             "text": "Exile target creature with power 3 or less.",
             "colours": [
@@ -2515,7 +2515,7 @@
         },
         {
             "id": "21c1a3b4-9561-547d-8b1f-49b81985e5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1c710b-bd67-4174-ab02-6ae98a7575ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1c710b-bd67-4174-ab02-6ae98a7575ac.jpg?1",
             "name": "Gutterbones",
             "text": "Gutterbones enters the battlefield tapped.\n{1}{B}: Return Gutterbones from your graveyard to your hand. Activate this ability only during your turn and only if an opponent lost life this turn.",
             "colours": [
@@ -2550,7 +2550,7 @@
         },
         {
             "id": "9274ff14-981b-567b-8cb9-aab693b36420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d44b342-f611-4836-a9d5-83b00a24318f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d44b342-f611-4836-a9d5-83b00a24318f.jpg?1",
             "name": "Ill-Gotten Inheritance",
             "text": "At the beginning of your upkeep, Ill-Gotten Inheritance deals 1 damage to each opponent and you gain 1 life.\n{5}{B}, Sacrifice Ill-Gotten Inheritance: It deals 4 damage to target opponent and you gain 4 life.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "21d9c49e-8332-5cb8-a6cf-d82d4e40c096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb3d78-1a60-4e9b-b387-afeb58677536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb3d78-1a60-4e9b-b387-afeb58677536.jpg?1",
             "name": "Noxious Groodion",
             "text": "Deathtouch",
             "colours": [
@@ -2616,7 +2616,7 @@
         },
         {
             "id": "26ca8bf8-5caf-5807-bd55-972a3d6145a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72b49e-be14-485b-a467-31cbac9aa1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72b49e-be14-485b-a467-31cbac9aa1c5.jpg?1",
             "name": "Orzhov Enforcer",
             "text": "Deathtouch\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "a9dcb67c-497b-5d34-8e7c-f82906233577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b89f68-72ba-493d-95c4-eb37751fbd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b89f68-72ba-493d-95c4-eb37751fbd3d.jpg?1",
             "name": "Orzhov Racketeers",
             "text": "Whenever Orzhov Racketeers deals combat damage to a player, that player discards a card.\nAfterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "1712dfad-c570-53ff-b806-f5d8dba401df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9a0387-5116-484b-bb2b-064bd42e7fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9a0387-5116-484b-bb2b-064bd42e7fff.jpg?1",
             "name": "Pestilent Spirit",
             "text": "Menace, deathtouch\nInstant and sorcery spells you control have deathtouch. (Any amount of damage they deal to a creature is enough to destroy it.)",
             "colours": [
@@ -2720,7 +2720,7 @@
         },
         {
             "id": "1dcaa9bf-915b-5da5-8f8a-d7845690d51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d354f-f2ad-4b47-8666-0ed64543b676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d354f-f2ad-4b47-8666-0ed64543b676.jpg?1",
             "name": "Plague Wight",
             "text": "Whenever Plague Wight becomes blocked, each creature blocking it gets -1/-1 until end of turn.",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "5f97ff82-01c0-574d-a397-9c48981a16ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3378fe8-3355-48aa-90d4-9cb739200160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3378fe8-3355-48aa-90d4-9cb739200160.jpg?1",
             "name": "Priest of Forgotten Gods",
             "text": "{T}, Sacrifice two other creatures: Any number of target players each lose 2 life and sacrifice a creature. You add {B}{B} and draw a card.",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "01cae04a-5a52-50c7-a536-fef6cf204761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2822aff3-9985-424b-9f19-b49e987c25e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2822aff3-9985-424b-9f19-b49e987c25e4.jpg?1",
             "name": "Rakdos Trumpeter",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{3}{R}: Rakdos Trumpeter gets +2/+0 until end of turn.",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "060fbad4-7652-57ed-979c-71a1d4f0c2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be01b8d-e0ef-44d1-ac97-39bb5a0e76be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be01b8d-e0ef-44d1-ac97-39bb5a0e76be.jpg?1",
             "name": "Spawn of Mayhem",
             "text": "Spectacle {1}{B}{B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nFlying, trample\nAt the beginning of your upkeep, Spawn of Mayhem deals 1 damage to each player. Then if you have 10 or less life, put a +1/+1 counter on Spawn of Mayhem.",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "556c0ae7-a569-5400-bda7-a9c2dc31e280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce548d-764a-4397-bae3-d348dca78421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce548d-764a-4397-bae3-d348dca78421.jpg?1",
             "name": "Spire Mangler",
             "text": "Flash\nFlying\nWhen Spire Mangler enters the battlefield, target creature with flying you control gets +2/+0 until end of turn.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "e5f63891-1a27-58e7-8345-58b431817202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a920c2e6-4a1f-487c-ad3f-b772443f0633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a920c2e6-4a1f-487c-ad3f-b772443f0633.jpg?1",
             "name": "Thirsting Shade",
             "text": "Lifelink\n{2}{B}: Thirsting Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -2927,7 +2927,7 @@
         },
         {
             "id": "69c39a38-eaad-5e44-94b0-05b1cece3bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7e297-4602-44f8-b919-07015813fd7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7e297-4602-44f8-b919-07015813fd7e.jpg?1",
             "name": "Undercity Scavenger",
             "text": "When Undercity Scavenger enters the battlefield, you may sacrifice another creature. If you do, put two +1/+1 counters on Undercity Scavenger, then scry 2.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "3eca8050-3e3f-5832-981a-3ce8321acab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb9805-eca0-476c-9480-0c958acdb50f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb9805-eca0-476c-9480-0c958acdb50f.jpg?1",
             "name": "Undercity's Embrace",
             "text": "Target opponent sacrifices a creature. If you control a creature with power 4 or greater, you gain 4 life.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "3bf56d70-7be2-5f10-ad7e-f749224c126b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0bfb47-c753-42fa-969b-7b10b87b0462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0bfb47-c753-42fa-969b-7b10b87b0462.jpg?1",
             "name": "Vindictive Vampire",
             "text": "Whenever another creature you control dies, Vindictive Vampire deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "87a47456-1237-54ea-a8d6-53d708d63e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2328c4-7344-48bf-b515-977499bcfd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2328c4-7344-48bf-b515-977499bcfd1c.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "4e2ecd9f-45ad-50c2-88d3-de4debdb43a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58c77f-7c15-44f4-8011-6046482a2d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58c77f-7c15-44f4-8011-6046482a2d08.jpg?1",
             "name": "Amplifire",
             "text": "At the beginning of your upkeep, reveal cards from the top of your library until you reveal a creature card. Until your next turn, Amplifire's base power becomes twice that card's power and its base toughness becomes twice that card's toughness. Put the revealed cards on the bottom of your library in a random order.",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "3834e130-a5cf-580c-bb9a-97021ca47a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8574ffd-3e72-41de-90bf-69363189f047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8574ffd-3e72-41de-90bf-69363189f047.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "fb6f99b5-c2ea-5cdf-9458-5fea270ed6b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5674753-17e4-4e35-a12c-13e1e077ec70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5674753-17e4-4e35-a12c-13e1e077ec70.jpg?1",
             "name": "Burning-Tree Vandal",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhenever Burning-Tree Vandal attacks, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "98cfa0cb-81bb-59a2-98d3-5044de0f2632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a81e889-490b-4aeb-8e84-ea9a390bb8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a81e889-490b-4aeb-8e84-ea9a390bb8fe.jpg?1",
             "name": "Cavalcade of Calamity",
             "text": "Whenever a creature you control with power 1 or less attacks, Cavalcade of Calamity deals 1 damage to the player or planeswalker that creature is attacking.",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "4cedd9e4-169f-5456-abbe-7ddb327ff421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f073d7-f60a-44c1-aec9-cf42bbdb3153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f073d7-f60a-44c1-aec9-cf42bbdb3153.jpg?1",
             "name": "Clamor Shaman",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhenever Clamor Shaman attacks, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "534027d7-35f9-5e02-a990-4ed49749c047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a7ac34-ec4a-4571-abb1-bff1fb67c78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a7ac34-ec4a-4571-abb1-bff1fb67c78f.jpg?1",
             "name": "Dagger Caster",
             "text": "When Dagger Caster enters the battlefield, it deals 1 damage to each opponent and 1 damage to each creature your opponents control.",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "f207cf11-e470-51ea-9712-a7c11c3c1ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43df9f41-944e-4cf3-ac80-524eadac221d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43df9f41-944e-4cf3-ac80-524eadac221d.jpg?1",
             "name": "Deface",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature with defender.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "2755ca61-b8bd-50cf-ae64-04445c823543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c63877b-cdab-4ce4-a1c0-c088eb62a57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c63877b-cdab-4ce4-a1c0-c088eb62a57a.jpg?1",
             "name": "Electrodominance",
             "text": "Electrodominance deals X damage to any target. You may cast a card with converted mana cost X or less from your hand without paying its mana cost.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "f4e7a65c-903b-51c2-9582-936617fe05d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c969aa0-b0e5-42cd-abba-0a3c7266142c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c969aa0-b0e5-42cd-abba-0a3c7266142c.jpg?1",
             "name": "Feral Maaka",
             "text": "",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "bb4346fb-c395-51fa-8158-9fede4168161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16957271-12bb-4031-b476-f7678b753ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16957271-12bb-4031-b476-f7678b753ae3.jpg?1",
             "name": "Flames of the Raze-Boar",
             "text": "Flames of the Raze-Boar deals 4 damage to target creature an opponent controls. Then Flames of the Raze-Boar deals 2 damage to each other creature that player controls if you control a creature with power 4 or greater.",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "df7c7bd6-a42a-5cec-9226-8f845cd2cad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b574b44-01e1-4197-99bd-57e54aebc5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b574b44-01e1-4197-99bd-57e54aebc5ff.jpg?1",
             "name": "Gates Ablaze",
             "text": "Gates Ablaze deals X damage to each creature, where X is the number of Gates you control.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "d4454ca5-bca7-5c6c-8c04-3c1f04bc51c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3969c-1979-4eee-828a-4a7189121eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3969c-1979-4eee-828a-4a7189121eba.jpg?1",
             "name": "Ghor-Clan Wrecker",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3460,7 +3460,7 @@
         },
         {
             "id": "35bcb407-36c9-5f2f-8f90-fbd969c2b691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147bef05-4497-44d5-9dd6-fb5dc08e78f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147bef05-4497-44d5-9dd6-fb5dc08e78f7.jpg?1",
             "name": "Goblin Gathering",
             "text": "Create a number of 1/1 red Goblin creature tokens equal to two plus the number of cards named Goblin Gathering in your graveyard.",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "7862b280-31b5-5b64-bfe9-ff953d9345c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4942068c-ffde-4a6b-849e-8acf05e1d2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4942068c-ffde-4a6b-849e-8acf05e1d2e1.jpg?1",
             "name": "Gravel-Hide Goblin",
             "text": "{3}{G}: Gravel-Hide Goblin gets +2/+2 until end of turn.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "817890c6-61cb-59df-9f99-98033755d97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e668e5-ef50-43eb-852e-b111370459c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e668e5-ef50-43eb-852e-b111370459c8.jpg?1",
             "name": "Immolation Shaman",
             "text": "Whenever an opponent activates an ability of an artifact, creature, or land that isn't a mana ability, Immolation Shaman deals 1 damage to that player.\n{3}{R}{R}: Immolation Shaman gets +3/+3 and gains menace until end of turn.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "38aa0617-9a4e-5cab-aee8-4c2b2275db87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9287b848-2aeb-4c70-ac4a-acafb871b7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9287b848-2aeb-4c70-ac4a-acafb871b7a4.jpg?1",
             "name": "Light Up the Stage",
             "text": "Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nExile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "6ebafe7f-35f2-5f4b-b0f3-bc2054504241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a27943-f08c-4cbd-affb-8e59411b3d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a27943-f08c-4cbd-affb-8e59411b3d4f.jpg?1",
             "name": "Mirror March",
             "text": "Whenever a nontoken creature enters the battlefield under your control, flip a coin until you lose a flip. For each flip you won, create a token that's a copy of that creature. Those tokens gain haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "b1292f71-65ac-5832-a390-65dcb9b252c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40396da-18e2-42ca-a78c-4838a38f68b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40396da-18e2-42ca-a78c-4838a38f68b8.jpg?1",
             "name": "Rix Maadi Reveler",
             "text": "Spectacle {2}{B}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nWhen Rix Maadi Reveler enters the battlefield, discard a card, then draw a card. If Rix Maadi Reveler's spectacle cost was paid, instead discard your hand, then draw three cards.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "394b853a-49fd-5806-905f-bbf535e9e40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ace095a-3ea9-4121-8ffb-5b3612b96985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ace095a-3ea9-4121-8ffb-5b3612b96985.jpg?1",
             "name": "Rubble Reading",
             "text": "Destroy target land. Scry 2.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "8edcf759-c1b7-552c-b465-10411447b00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faac11b-4ece-4537-aa55-c2d0afa41786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faac11b-4ece-4537-aa55-c2d0afa41786.jpg?1",
             "name": "Rubblebelt Recluse",
             "text": "Rubblebelt Recluse attacks each combat if able.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "4c03605e-e6f2-5cd5-838e-54188103037c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fe7057-de70-456d-8f33-f64652447bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fe7057-de70-456d-8f33-f64652447bdd.jpg?1",
             "name": "Rumbling Ruin",
             "text": "When Rumbling Ruin enters the battlefield, count the number of +1/+1 counters on creatures you control. Creatures your opponents control with power less than or equal to that number can't block this turn.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "fc3ce67a-23ed-5120-8f5a-f330e66f19f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a14834f-78ae-4ca5-9ce0-5b928ad3d76c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a14834f-78ae-4ca5-9ce0-5b928ad3d76c.jpg?1",
             "name": "Scorchmark",
             "text": "Scorchmark deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "5631a047-f3ec-57ef-a483-ef01ab0d4ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be941a2e-4eb0-45b3-9da0-834053907a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be941a2e-4eb0-45b3-9da0-834053907a65.jpg?1",
             "name": "Skarrgan Hellkite",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nFlying\n{3}{R}: Skarrgan Hellkite deals 2 damage divided as you choose among one or two targets. Activate this ability only if Skarrgan Hellkite has a +1/+1 counter on it.",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "cdd3640a-0501-5d20-9f7d-b40529144f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97295660-6bea-46ae-9a3b-0fc6abba407f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97295660-6bea-46ae-9a3b-0fc6abba407f.jpg?1",
             "name": "Skewer the Critics",
             "text": "Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nSkewer the Critics deals 3 damage to any target.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "1746683d-8474-555d-9379-c24ce0456001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24b2b6-b994-455f-b8e6-aa73e1be81b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24b2b6-b994-455f-b8e6-aa73e1be81b4.jpg?1",
             "name": "Smelt-Ward Ignus",
             "text": "{2}{R}, Sacrifice Smelt-Ward Ignus: Gain control of target creature with power 3 or less until end of turn. Untap that creature. It gains haste until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "dd07dfc2-c270-5ccd-95de-0f0b66f9b2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbee1daa-b4ba-49ee-bed1-e70fa09942a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbee1daa-b4ba-49ee-bed1-e70fa09942a2.jpg?1",
             "name": "Spear Spewer",
             "text": "Defender\n{T}: Spear Spewer deals 1 damage to each player.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "28c697fc-f9bb-5c0d-a876-e21a474e5454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f70b8a-62ec-4ae6-97d2-3c6ae86a3602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f70b8a-62ec-4ae6-97d2-3c6ae86a3602.jpg?1",
             "name": "Spikewheel Acrobat",
             "text": "Spectacle {2}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "d6f90bec-aa08-53bb-b867-bcd005a05852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de24cba-545a-438b-9516-1c19a50ca78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de24cba-545a-438b-9516-1c19a50ca78c.jpg?1",
             "name": "Storm Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -3998,7 +3998,7 @@
         },
         {
             "id": "4dbf6293-d035-5a14-9fb8-f1f9de5b1165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3815ab6-87cd-4310-8068-ec721ee10a24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3815ab6-87cd-4310-8068-ec721ee10a24.jpg?1",
             "name": "Tin Street Dodger",
             "text": "Haste\n{R}: Tin Street Dodger can't be blocked this turn except by creatures with defender.",
             "colours": [
@@ -4033,7 +4033,7 @@
         },
         {
             "id": "03b0eb04-7ebd-5583-b034-4ab85e3166fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f420b35-1f73-41c8-a15f-1aee4af0999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f420b35-1f73-41c8-a15f-1aee4af0999c.jpg?1",
             "name": "Axebane Beast",
             "text": "",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "a28e7e23-363d-58f5-a823-71115bad6b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11029a-b24d-4248-834f-b852b56857f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11029a-b24d-4248-834f-b852b56857f6.jpg?1",
             "name": "Biogenic Ooze",
             "text": "When Biogenic Ooze enters the battlefield, create a 2/2 green Ooze creature token.\nAt the beginning of your end step, put a +1/+1 counter on each Ooze you control.\n{1}{G}{G}{G}: Create a 2/2 green Ooze creature token.",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "10fcb2c8-5daf-5e60-8184-830d22ee5e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd73fb2-453f-40b9-8beb-dfa99e6a706e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd73fb2-453f-40b9-8beb-dfa99e6a706e.jpg?1",
             "name": "Biogenic Upgrade",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "203ccb31-5060-54ff-8d5b-35ca006b1fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50d79fe-6d37-42f3-b7b0-0c3018282fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50d79fe-6d37-42f3-b7b0-0c3018282fa2.jpg?1",
             "name": "End-Raze Forerunners",
             "text": "Vigilance, trample, haste\nWhen End-Raze Forerunners enters the battlefield, other creatures you control get +2/+2 and gain vigilance and trample until end of turn.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "f9d4e9b2-1968-51fd-a30c-7b74cbf82751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44fc50f-8958-422f-933f-fd043d642c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44fc50f-8958-422f-933f-fd043d642c97.jpg?1",
             "name": "Enraged Ceratok",
             "text": "Enraged Ceratok can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "5ac609a4-f4b1-5600-bcc1-e62eeca7db47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef592d1-e5e1-4252-8741-402c32d65dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef592d1-e5e1-4252-8741-402c32d65dfd.jpg?1",
             "name": "Gatebreaker Ram",
             "text": "Gatebreaker Ram gets +1/+1 for each Gate you control.\nAs long as you control two or more Gates, Gatebreaker Ram has vigilance and trample.",
             "colours": [
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "f636dd63-e033-5086-990e-93569501243d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb363b1d-0b80-453c-98ca-e9f873bb7add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb363b1d-0b80-453c-98ca-e9f873bb7add.jpg?1",
             "name": "Gift of Strength",
             "text": "Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "68b1f7de-507f-5a1f-aa0c-b3f6613bbd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f97cdf4-231d-4bd0-af5e-bcb64ce1556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f97cdf4-231d-4bd0-af5e-bcb64ce1556c.jpg?1",
             "name": "Growth-Chamber Guardian",
             "text": "{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Growth-Chamber Guardian, you may search your library for a card named Growth-Chamber Guardian, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "5dd6be38-ceab-5a84-ba6f-b78e87d59fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0aaded-515f-4ac9-a72f-6948b4d4df51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0aaded-515f-4ac9-a72f-6948b4d4df51.jpg?1",
             "name": "Gruul Beastmaster",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhenever Gruul Beastmaster attacks, another target creature you control gets +X/+0 until end of turn, where X is Gruul Beastmaster's power.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "b2e31d4d-a7db-58ec-99f7-5e25fa1fea63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad6ce0-ddf0-458d-bdae-3d7805fdc775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad6ce0-ddf0-458d-bdae-3d7805fdc775.jpg?1",
             "name": "Guardian Project",
             "text": "Whenever a nontoken creature enters the battlefield under your control, if it doesn't have the same name as another creature you control or a creature card in your graveyard, draw a card.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "8dbaa0f7-789b-547d-94b0-b6747b46068a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bbe5d-d0f3-4be3-a3a6-072d5d3d614c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bbe5d-d0f3-4be3-a3a6-072d5d3d614c.jpg?1",
             "name": "Incubation Druid",
             "text": "{T}: Add one mana of any type that a land you control could produce. If Incubation Druid has a +1/+1 counter on it, add three mana of that type instead.\n{3}{G}{G}: Adapt 3. (If this creature has no +1/+1 counters on it, put three +1/+1 counters on it.)",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "022fda96-964b-5b97-b311-3b0b0bcd0254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a684871-ff6e-4474-82da-30757c324c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a684871-ff6e-4474-82da-30757c324c73.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "b6842dd6-0b53-5c4a-bfc6-ee33e1219729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff326c57-accb-4b75-9bc9-b5ef1a85f38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff326c57-accb-4b75-9bc9-b5ef1a85f38d.jpg?1",
             "name": "Open the Gates",
             "text": "Search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "b0c7809d-bbcc-547f-bb78-2c979b773536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebab7d-d03d-4473-aa9b-485aebb66433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebab7d-d03d-4473-aa9b-485aebb66433.jpg?1",
             "name": "Rampage of the Clans",
             "text": "Destroy all artifacts and enchantments. For each permanent destroyed this way, its controller creates a 3/3 green Centaur creature token.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "d0e63b33-28bb-549a-90e0-98c37bec313b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b820-0f06-41f6-804f-5c98f60c1529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b820-0f06-41f6-804f-5c98f60c1529.jpg?1",
             "name": "Rampaging Rendhorn",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "31c9eded-82a4-5199-8d50-f2e9496b295d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a362c1-af92-4094-a7c2-f09952767606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a362c1-af92-4094-a7c2-f09952767606.jpg?1",
             "name": "Regenesis",
             "text": "Return up to two target permanent cards from your graveyard to your hand.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "7710120c-393e-5e4e-86d6-ff81e1835dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f38b1a2-3f85-4dcd-b90d-bb049651b8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f38b1a2-3f85-4dcd-b90d-bb049651b8b7.jpg?1",
             "name": "Root Snare",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -4601,7 +4601,7 @@
         },
         {
             "id": "7b08f6dc-0260-58c7-8c3c-a634c7a937ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3104cad-e684-4bd7-b26b-5aa862f7a2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3104cad-e684-4bd7-b26b-5aa862f7a2b3.jpg?1",
             "name": "Sagittars' Volley",
             "text": "Destroy target creature with flying. Sagittars' Volley deals 1 damage to each creature with flying your opponents control.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "2230ced2-cee6-5583-a2bd-ed7e936b9d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3358cb-714c-49bf-b7e9-a69d02d7799e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3358cb-714c-49bf-b7e9-a69d02d7799e.jpg?1",
             "name": "Saruli Caretaker",
             "text": "Defender\n{T}, Tap an untapped creature you control: Add one mana of any color.",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "5f340c1c-450f-5b0d-9ea2-9699194a0e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7ecad5-8bb5-416f-b8ef-a04aba4dc4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7ecad5-8bb5-416f-b8ef-a04aba4dc4b5.jpg?1",
             "name": "Sauroform Hybrid",
             "text": "{4}{G}{G}: Adapt 4. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "d8d27350-5129-5c9d-afbf-49be71c3c1a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6cd6a5-da6c-483c-a9f7-49e666ac0b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6cd6a5-da6c-483c-a9f7-49e666ac0b6c.jpg?1",
             "name": "Silhana Wayfinder",
             "text": "When Silhana Wayfinder enters the battlefield, look at the top four cards of your library. You may reveal a creature or land card from among them and put it on top of your library. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "75122993-1d45-51a1-93d8-dcb486a70c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afafb4-3fc0-4ccf-a942-e4bd2f146d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afafb4-3fc0-4ccf-a942-e4bd2f146d89.jpg?1",
             "name": "Steeple Creeper",
             "text": "{3}{U}: Steeple Creeper gains flying until end of turn.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "0ab2ecba-d2cf-5084-abfa-8e02a2d0e0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbab274-69dd-44a9-9310-a15779c35cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbab274-69dd-44a9-9310-a15779c35cad.jpg?1",
             "name": "Stony Strength",
             "text": "Put a +1/+1 counter on target creature you control. Untap that creature.",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "d35038c6-16dd-5844-bd5b-ef02531b9032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc288a3-ea56-450a-96fd-c2123121f663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc288a3-ea56-450a-96fd-c2123121f663.jpg?1",
             "name": "Sylvan Brushstrider",
             "text": "When Sylvan Brushstrider enters the battlefield, you gain 2 life.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "6d9dbbf7-a896-5250-b469-8112c90bd369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ddae7-7e7c-46c7-ad7d-9a686c256b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ddae7-7e7c-46c7-ad7d-9a686c256b9d.jpg?1",
             "name": "Territorial Boar",
             "text": "Whenever a creature with power 4 or greater enters the battlefield under your control, Territorial Boar gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "66e38fbb-22b4-59b2-a5d6-8b74b4e04024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf9b57a-a759-4488-965a-651070cd2156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf9b57a-a759-4488-965a-651070cd2156.jpg?1",
             "name": "Titanic Brawl",
             "text": "This spell costs {1} less to cast if it targets a creature you control with a +1/+1 counter on it.\nTarget creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "7dfc89b9-2ca0-540c-8fce-d174ebe36fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195e94a4-a698-4c66-9428-5cc8a40d42c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195e94a4-a698-4c66-9428-5cc8a40d42c6.jpg?1",
             "name": "Tower Defense",
             "text": "Creatures you control get +0/+5 and gain reach until end of turn.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "84f303cb-9a07-5f4e-82cd-fe072018aa63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e51f6-7091-4cf3-86a3-b8c5946f3796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e51f6-7091-4cf3-86a3-b8c5946f3796.jpg?1",
             "name": "Trollbred Guardian",
             "text": "{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "221c667a-7e2c-5c29-bfcb-b6371e292b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af08f7-9c6c-464e-b2f7-2b5803f36481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af08f7-9c6c-464e-b2f7-2b5803f36481.jpg?1",
             "name": "Wilderness Reclamation",
             "text": "At the beginning of your end step, untap all lands you control.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "e1335217-0d38-5625-a903-d0b0b90e2568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e6f7be-4493-4081-ac67-d782ab2b3723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e6f7be-4493-4081-ac67-d782ab2b3723.jpg?1",
             "name": "Wrecking Beast",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nTrample",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "7d6637d8-1d04-5977-a925-f4187ac3fd1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8a43c1-42d1-45ef-8a63-4b87775a6e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8a43c1-42d1-45ef-8a63-4b87775a6e88.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "4ab1d468-b666-50cc-b255-359b6d7bc6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671c94c1-df52-4985-ad78-3e1c9c78df18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671c94c1-df52-4985-ad78-3e1c9c78df18.jpg?1",
             "name": "Aeromunculus",
             "text": "Flying\n{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "aef7a3ed-b927-5321-a8ca-5b1492dedee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91ed618-7b0b-4a70-95ad-d9ed46e28692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91ed618-7b0b-4a70-95ad-d9ed46e28692.jpg?1",
             "name": "Applied Biomancy",
             "text": "Choose one or both \u2014\n\u2022 Target creature gets +1/+1 until end of turn.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "6101883a-fb23-5ea8-9b23-ead08153f112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60befc28-2ab8-4b59-a33f-0328c5d2f995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60befc28-2ab8-4b59-a33f-0328c5d2f995.jpg?1",
             "name": "Azorius Knight-Arbiter",
             "text": "Vigilance\nAzorius Knight-Arbiter can't be blocked.",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "fadd66d8-9fed-5c6d-aa27-8c5cf4ebad19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fddecd-e660-43de-bccc-52f60a089052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fddecd-e660-43de-bccc-52f60a089052.jpg?1",
             "name": "Azorius Skyguard",
             "text": "Flying, first strike\nCreatures your opponents control get -1/-0.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "bbb88fa6-3b6f-547c-9731-ff677e68309f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f4329-db6f-4284-b63e-55f22a0a0f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f4329-db6f-4284-b63e-55f22a0a0f6e.jpg?1",
             "name": "Basilica Bell-Haunt",
             "text": "When Basilica Bell-Haunt enters the battlefield, each opponent discards a card and you gain 3 life.",
             "colours": [
@@ -5255,7 +5255,7 @@
         },
         {
             "id": "0cdc27a1-3a6d-5bca-a930-b10aa9eb269d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e2b96b-ecf2-4dd9-bc9d-3c46ee8c59e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e2b96b-ecf2-4dd9-bc9d-3c46ee8c59e6.jpg?1",
             "name": "Bedevil",
             "text": "Destroy target artifact, creature, or planeswalker.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "a4d7c303-aecb-5414-9e4a-f4e3b41c62a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38c9891-36d1-4565-9c4a-1cd9dbf8c048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38c9891-36d1-4565-9c4a-1cd9dbf8c048.jpg?1",
             "name": "Biomancer's Familiar",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.\n{T}: The next time target creature adapts this turn, it adapts as though it had no +1/+1 counters on it.",
             "colours": [
@@ -5325,7 +5325,7 @@
         },
         {
             "id": "c62abeb8-34ae-56ea-a459-1f53fe7aa5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5080975e-693a-44f5-a718-9ee947dada6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5080975e-693a-44f5-a718-9ee947dada6d.jpg?1",
             "name": "Bolrac-Clan Crusher",
             "text": "{T}, Remove a +1/+1 counter from a creature you control: Bolrac-Clan Crusher deals 2 damage to any target.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "ef0304f9-653b-58bf-a831-cfa94f60b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065f63b2-472e-4148-8294-88ed38a5685f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065f63b2-472e-4148-8294-88ed38a5685f.jpg?1",
             "name": "Captive Audience",
             "text": "Captive Audience enters the battlefield under the control of an opponent of your choice.\nAt the beginning of your upkeep, choose one that hasn't been chosen \u2014\n\u2022 Your life total becomes 4.\n\u2022 Discard your hand.\n\u2022 Each opponent creates five 2/2 black Zombie creature tokens.",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "3b19c0b7-b71a-5738-b573-7b0edf56302f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f970f79-3051-4ba1-badb-697ef321cbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f970f79-3051-4ba1-badb-697ef321cbb3.jpg?1",
             "name": "Cindervines",
             "text": "Whenever an opponent casts a noncreature spell, Cindervines deals 1 damage to that player.\n{1}, Sacrifice Cindervines: Destroy target artifact or enchantment. Cindervines deals 2 damage to that permanent's controller.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "896cbb9a-ad01-589e-a2a3-ba983ee7c06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a18415-015c-4d3f-8042-b156a673e125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a18415-015c-4d3f-8042-b156a673e125.jpg?1",
             "name": "Clan Guildmage",
             "text": "{1}{R}, {T}: Target creature can't block this turn.\n{2}{G}, {T}: Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "d8eca791-88cb-5e58-807b-561457b52889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e2816-d50b-41a5-b503-faa58dc7c94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e2816-d50b-41a5-b503-faa58dc7c94a.jpg?1",
             "name": "Combine Guildmage",
             "text": "{1}{G}, {T}: This turn, each creature you control enters the battlefield with an additional +1/+1 counter on it.\n{1}{U}, {T}: Move a +1/+1 counter from target creature you control onto another target creature you control.",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "fee4cfe3-2c7b-5d4d-9daf-301f78b4293b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0536c2fa-7402-49a1-9016-dcf5633ca9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0536c2fa-7402-49a1-9016-dcf5633ca9ef.jpg?1",
             "name": "Cult Guildmage",
             "text": "{3}{B}, {T}: Target player discards a card. Activate this ability only any time you could cast a sorcery.\n{R}, {T}: Cult Guildmage deals 1 damage to target opponent or planeswalker.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "1c568923-fb51-5ec8-a9cf-b961165b1aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e362055-78a1-48fa-a4ef-6cf7e0b21b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e362055-78a1-48fa-a4ef-6cf7e0b21b14.jpg?1",
             "name": "Deputy of Detention",
             "text": "When Deputy of Detention enters the battlefield, exile target nonland permanent an opponent controls and all other nonland permanents that player controls with the same name as that permanent until Deputy of Detention leaves the battlefield.",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "68e69f37-48d2-57c9-ada5-677f8775da2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f56bbf3-3884-495a-b9cd-6585d86f76f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f56bbf3-3884-495a-b9cd-6585d86f76f1.jpg?1",
             "name": "Domri, Chaos Bringer",
             "text": "+1: Add {R} or {G}. If that mana is spent on a creature spell, it gains riot.\n\u22123: Look at the top four cards of your library. You may reveal up to two creature cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.\n\u22128: You get an emblem with \"At the beginning of each end step, create a 4/4 red and green Beast creature token with trample.\"",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "6e3e8558-0ed1-5579-9d7d-76eb2575417c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6784910-0204-4a39-bb38-50daa03e94c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6784910-0204-4a39-bb38-50daa03e94c2.jpg?1",
             "name": "Dovin, Grand Arbiter",
             "text": "+1: Until end of turn, whenever a creature you control deals combat damage to a player, put a loyalty counter on Dovin, Grand Arbiter.\n\u22121: Create a 1/1 colorless Thopter artifact creature token with flying. You gain 1 life.\n\u22127: Look at the top ten cards of your library. Put three of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "5e30587e-00b9-597c-aea3-150adca20318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b191592-7221-422a-8b5a-65f7b1caec1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b191592-7221-422a-8b5a-65f7b1caec1a.jpg?1",
             "name": "Dovin's Acuity",
             "text": "When Dovin's Acuity enters the battlefield, you gain 2 life and draw a card.\nWhenever you cast an instant spell during your main phase, you may return Dovin's Acuity to its owner's hand.",
             "colours": [
@@ -5688,7 +5688,7 @@
         },
         {
             "id": "a04f3c61-7d3b-5073-aa13-4afa1396187a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6473a93f-879f-4f44-8650-ee05a647c763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6473a93f-879f-4f44-8650-ee05a647c763.jpg?1",
             "name": "Emergency Powers",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards. Exile Emergency Powers.\nAddendum \u2014 If you cast this spell during your main phase, you may put a permanent card with converted mana cost 7 or less from your hand onto the battlefield.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "0b13e229-b305-5042-8f7c-f1d290e5195a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0872d0ff-1060-44cc-9ed0-a6aa496440c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0872d0ff-1060-44cc-9ed0-a6aa496440c8.jpg?1",
             "name": "Ethereal Absolution",
             "text": "Creatures you control get +1/+1.\nCreatures your opponents control get -1/-1.\n{2}{W}{B}: Exile target card from an opponent's graveyard. If it was a creature card, you create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "9488e9af-2dee-5ad6-b650-473155749c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a21a8f-9c7b-4ae8-8635-f2ee2151c8de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a21a8f-9c7b-4ae8-8635-f2ee2151c8de.jpg?1",
             "name": "Final Payment",
             "text": "As an additional cost to cast this spell, pay 5 life or sacrifice a creature or enchantment.\nDestroy target creature.",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "8d6a363a-f219-5a2f-b5ae-0f6ec5e1404e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1161f-bd2c-45a7-a86b-3b2e5210f148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1161f-bd2c-45a7-a86b-3b2e5210f148.jpg?1",
             "name": "Fireblade Artist",
             "text": "Haste\nAt the beginning of your upkeep, you may sacrifice a creature. When you do, Fireblade Artist deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "bb6cfc91-337d-5666-998a-87c6a8986206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2eef7-03a4-415f-8bb7-a29d50ce1b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2eef7-03a4-415f-8bb7-a29d50ce1b0f.jpg?1",
             "name": "Frenzied Arynx",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nTrample\n{4}{R}{G}: Frenzied Arynx gets +3/+0 until end of turn.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "0c1337fc-e8c0-5373-a2bc-311389088fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50595d02-edad-48a6-b10c-6fa859cc88bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50595d02-edad-48a6-b10c-6fa859cc88bb.jpg?1",
             "name": "Frilled Mystic",
             "text": "Flash\nWhen Frilled Mystic enters the battlefield, you may counter target spell.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "b970f9e8-9851-521e-9579-1e46bdea913d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2b7cfe-4696-4448-93d2-33be596e32d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2b7cfe-4696-4448-93d2-33be596e32d9.jpg?1",
             "name": "Galloping Lizrog",
             "text": "Trample\nWhen Galloping Lizrog enters the battlefield, you may remove any number of +1/+1 counters from among creatures you control. If you do, put twice that many +1/+1 counters on Galloping Lizrog.",
             "colours": [
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "dff5ffb4-f509-5652-86b5-52adbf20542c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821c4ab5-eb75-445a-bbec-e50af54dba7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821c4ab5-eb75-445a-bbec-e50af54dba7a.jpg?1",
             "name": "Get the Point",
             "text": "Destroy target creature. Scry 1.",
             "colours": [
@@ -5973,7 +5973,7 @@
         },
         {
             "id": "d941457e-c88d-52fe-a096-f81c51d663b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f82d97-ce50-490c-ad7f-46d70a73e454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f82d97-ce50-490c-ad7f-46d70a73e454.jpg?1",
             "name": "Grasping Thrull",
             "text": "Flying\nWhen Grasping Thrull enters the battlefield, it deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "ce5c7d0c-324a-58af-a74c-dcacd99af21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c77a6b1-ef06-4da5-8e86-a5204216cb77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c77a6b1-ef06-4da5-8e86-a5204216cb77.jpg?1",
             "name": "Growth Spiral",
             "text": "Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "85903b81-e520-51cf-9a8e-810f7bccb7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326679a2-782d-45a0-9a06-b147ceff3979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326679a2-782d-45a0-9a06-b147ceff3979.jpg?1",
             "name": "Gruul Spellbreaker",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nTrample\nAs long as it's your turn, you and Gruul Spellbreaker have hexproof.",
             "colours": [
@@ -6080,7 +6080,7 @@
         },
         {
             "id": "c5bf7592-d426-56cf-a8f4-4565ba01fa74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dd6a1d-4dcb-4392-9856-c0e4140efbd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dd6a1d-4dcb-4392-9856-c0e4140efbd7.jpg?1",
             "name": "Gyre Engineer",
             "text": "{T}: Add {G}{U}.",
             "colours": [
@@ -6117,7 +6117,7 @@
         },
         {
             "id": "d3633ea3-64ad-536c-ac01-524a9666b111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41335c2-3d11-4f95-8d9f-66b04398c10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41335c2-3d11-4f95-8d9f-66b04398c10b.jpg?1",
             "name": "Hackrobat",
             "text": "Spectacle {B}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\n{B}: Hackrobat gains deathtouch until end of turn.\n{R}: Hackrobat gets +2/-2 until end of turn.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "e8b1f616-9d82-5f85-9ac1-5adfdaa9b207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce124f6e-ef0c-4d01-a876-e34d3e445108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce124f6e-ef0c-4d01-a876-e34d3e445108.jpg?1",
             "name": "High Alert",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\nCreatures you control can attack as though they didn't have defender.\n{2}{W}{U}: Untap target creature.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "7dfa9036-98ef-50ad-bf74-f18e1ba20951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801dd9c6-b159-4e1c-af2c-214c1f573633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801dd9c6-b159-4e1c-af2c-214c1f573633.jpg?1",
             "name": "Hydroid Krasis",
             "text": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nHydroid Krasis enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "bd0d0b32-5705-57be-88a2-e66c284d730e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd27ba9e-5b9c-468f-9a44-bf2e89138e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd27ba9e-5b9c-468f-9a44-bf2e89138e72.jpg?1",
             "name": "Imperious Oligarch",
             "text": "Vigilance\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "1528bace-73e5-5cfb-ad31-a940fa42e882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742125-730d-4082-bfd8-5feb7733def4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742125-730d-4082-bfd8-5feb7733def4.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -6302,7 +6302,7 @@
         },
         {
             "id": "9f721028-eed0-534d-8e30-cc5df513c852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb4b2ef-5196-4f7f-88ff-64b2cdb36c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb4b2ef-5196-4f7f-88ff-64b2cdb36c6b.jpg?1",
             "name": "Kaya, Orzhov Usurper",
             "text": "+1: Exile up to two target cards from a single graveyard. You gain 2 life if at least one creature card was exiled this way.\n\u22121: Exile target nonland permanent with converted mana cost 1 or less.\n\u22125: Kaya, Orzhov Usurper deals damage to target player equal to the number of cards that player owns in exile and you gain that much life.",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "732b93cc-72ed-54ba-bf71-0d227d8e943d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed140c1-752b-4539-88f2-1fa354049b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed140c1-752b-4539-88f2-1fa354049b17.jpg?1",
             "name": "Kaya's Wrath",
             "text": "Destroy all creatures. You gain life equal to the number of creatures you controlled that were destroyed this way.",
             "colours": [
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "402c4fa9-85e0-5c7c-af79-c0ffd45dfe9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fccf60-2df5-4c14-893f-41d3f86c545f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fccf60-2df5-4c14-893f-41d3f86c545f.jpg?1",
             "name": "Knight of the Last Breath",
             "text": "{3}, Sacrifice another nontoken creature: Create a 1/1 white and black Spirit creature token with flying.\nAfterlife 3 (When this creature dies, create three 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "5a7d18d9-7625-5f2d-a932-909741023ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c497d496-1232-4614-93b0-9864fa93c29f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c497d496-1232-4614-93b0-9864fa93c29f.jpg?1",
             "name": "Lavinia, Azorius Renegade",
             "text": "Each opponent can't cast noncreature spells with converted mana cost greater than the number of lands that player controls.\nWhenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "4caa256a-1aee-5db0-9822-8ef23ab9e8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a7be1f-3fba-4ff2-a4f1-aebd3d20da8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a7be1f-3fba-4ff2-a4f1-aebd3d20da8f.jpg?1",
             "name": "Lawmage's Binding",
             "text": "Flash\nEnchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "d1bd7c3d-d9ee-5431-9c08-a4045246d450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1aee37-dcee-4e58-be9b-81ca57cedb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1aee37-dcee-4e58-be9b-81ca57cedb53.jpg?1",
             "name": "Macabre Mockery",
             "text": "Put target creature card from an opponent's graveyard onto the battlefield under your control. It gets +2/+0 and gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -6520,7 +6520,7 @@
         },
         {
             "id": "fe0411b4-7b85-57ff-8a5e-1266df630e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6c0dc-5c7b-4170-99bc-2637ea44e716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6c0dc-5c7b-4170-99bc-2637ea44e716.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "5069f2d0-4af1-5df5-be3a-9292b167fcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdad71-323e-41e0-a1b3-9fd5b753e71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdad71-323e-41e0-a1b3-9fd5b753e71c.jpg?1",
             "name": "Nikya of the Old Ways",
             "text": "You can't cast noncreature spells.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "9470d134-acce-58d1-94b4-4c5c167e4b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f66c03-cf79-4de0-be55-b921cbdc5038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f66c03-cf79-4de0-be55-b921cbdc5038.jpg?1",
             "name": "Pitiless Pontiff",
             "text": "{1}, Sacrifice another creature: Pitiless Pontiff gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "9dab4d0a-75a4-50b1-a4cc-a307b7d054a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84abfc59-10a7-4cb5-9cdd-81797116c810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84abfc59-10a7-4cb5-9cdd-81797116c810.jpg?1",
             "name": "Prime Speaker Vannifar",
             "text": "{T}, Sacrifice another creature: Search your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "33d27a6f-6d6a-5249-8184-cc31b43ccd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8dad4d-bc4f-46fb-892c-dbf6481cdc46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8dad4d-bc4f-46fb-892c-dbf6481cdc46.jpg?1",
             "name": "Rafter Demon",
             "text": "Spectacle {3}{B}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nWhen Rafter Demon enters the battlefield, if its spectacle cost was paid, each opponent discards a card.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "7dc13d61-a1b8-59a2-8061-a43265b0895e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d819a944-0b3e-4e26-87da-2417081928e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d819a944-0b3e-4e26-87da-2417081928e7.jpg?1",
             "name": "Rakdos Firewheeler",
             "text": "When Rakdos Firewheeler enters the battlefield, it deals 2 damage to target opponent and 2 damage to up to one target creature or planeswalker.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "37be5c37-cecf-52ea-880f-5ad6488e9243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed534af-e16a-4d1d-8884-938fc7e13ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed534af-e16a-4d1d-8884-938fc7e13ca8.jpg?1",
             "name": "Rakdos Roustabout",
             "text": "Whenever Rakdos Roustabout becomes blocked, it deals 1 damage to the player or planeswalker it's attacking.",
             "colours": [
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "18fb37b1-8616-5c0d-88bc-40591c2c8164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3c30c7-c52e-41a0-b7c2-21d39c05160b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3c30c7-c52e-41a0-b7c2-21d39c05160b.jpg?1",
             "name": "Rakdos, the Showstopper",
             "text": "Flying, trample\nWhen Rakdos, the Showstopper enters the battlefield, flip a coin for each creature that isn't a Demon, Devil, or Imp. Destroy each creature whose coin comes up tails.",
             "colours": [
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "caa919c0-d50b-57a6-bd48-1f4ae534b795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5a6085-bb5d-412e-8831-757996bbc8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5a6085-bb5d-412e-8831-757996bbc8fb.jpg?1",
             "name": "Ravager Wurm",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhen Ravager Wurm enters the battlefield, choose up to one \u2014\n\u2022 Ravager Wurm fights target creature you don't control.\n\u2022 Destroy target land with an activated ability that isn't a mana ability.",
             "colours": [
@@ -6854,7 +6854,7 @@
         },
         {
             "id": "a930efbf-1397-5665-863d-50a674b4f934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84062ce2-fea2-4e06-b83b-7cc597fb2a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84062ce2-fea2-4e06-b83b-7cc597fb2a1b.jpg?1",
             "name": "Rhythm of the Wild",
             "text": "Creature spells you control can't be countered.\nNontoken creatures you control have riot. (They enter the battlefield with your choice of a +1/+1 counter or haste.)",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "47f4ec18-0623-5ac3-875f-c24a5168056d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cc4e02-949f-4879-9f32-7c33490d0b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cc4e02-949f-4879-9f32-7c33490d0b45.jpg?1",
             "name": "Rubblebelt Runner",
             "text": "Rubblebelt Runner can't be blocked by creature tokens.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "dac81423-041b-5406-a5c3-195f2c25e1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca942d7-a3a3-429f-a159-fc2363d9bca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca942d7-a3a3-429f-a159-fc2363d9bca6.jpg?1",
             "name": "Savage Smash",
             "text": "Target creature you control gets +2/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "ad419cf2-5e14-5275-800a-ff2a2a98bd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b3a2a-e3fd-4095-ab2a-5e356ea179df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b3a2a-e3fd-4095-ab2a-5e356ea179df.jpg?1",
             "name": "Senate Guildmage",
             "text": "{W}, {T}: You gain 2 life.\n{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "41010ff9-be8b-5ab9-92c6-ab9d04aad88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d602e9e6-31ed-4d17-b39c-457b3b182943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d602e9e6-31ed-4d17-b39c-457b3b182943.jpg?1",
             "name": "Seraph of the Scales",
             "text": "Flying\n{W}: Seraph of the Scales gains vigilance until end of turn.\n{B}: Seraph of the Scales gains deathtouch until end of turn.\nAfterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "4e1175fc-eaed-5b7c-b625-c64d3588eab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f31228-0c47-4c51-932d-50fdec965f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f31228-0c47-4c51-932d-50fdec965f15.jpg?1",
             "name": "Sharktocrab",
             "text": "{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Sharktocrab, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -7070,7 +7070,7 @@
         },
         {
             "id": "df8e477b-7ba4-5e7b-82da-4ed214d8654b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff824392-fb5c-496c-be2f-6dfa6e04e3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff824392-fb5c-496c-be2f-6dfa6e04e3a2.jpg?1",
             "name": "Simic Ascendancy",
             "text": "{1}{G}{U}: Put a +1/+1 counter on target creature you control.\nWhenever one or more +1/+1 counters are put on a creature you control, put that many growth counters on Simic Ascendancy.\nAt the beginning of your upkeep, if Simic Ascendancy has twenty or more growth counters on it, you win the game.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "281478bf-61fa-56db-92f0-43fda9fa4bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9aec56e-50a3-491f-89c6-32907ea3161a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9aec56e-50a3-491f-89c6-32907ea3161a.jpg?1",
             "name": "Sphinx of New Prahv",
             "text": "Flying, vigilance\nSpells your opponents cast that target Sphinx of New Prahv cost {2} more to cast.",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "5f2f9d22-f27d-5aa4-9632-4143c2207557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71c2435-0312-4279-a9e1-fab7432756b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71c2435-0312-4279-a9e1-fab7432756b7.jpg?1",
             "name": "Sphinx's Insight",
             "text": "Draw two cards.\nAddendum \u2014 If you cast this spell during your main phase, you gain 2 life.",
             "colours": [
@@ -7174,7 +7174,7 @@
         },
         {
             "id": "41d06cf5-32a1-50f9-bdc2-591329fd6520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6a8bb-9eec-4f9b-a5a8-604631e4b823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6a8bb-9eec-4f9b-a5a8-604631e4b823.jpg?1",
             "name": "Sunder Shaman",
             "text": "Sunder Shaman can't be blocked by more than one creature.\nWhenever Sunder Shaman deals combat damage to a player, destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "2b50de06-d5f2-5cf1-8573-6ce601ed6a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82d3c8d-849a-445b-bc7c-365514d1511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82d3c8d-849a-445b-bc7c-365514d1511f.jpg?1",
             "name": "Syndicate Guildmage",
             "text": "{1}{W}, {T}: Tap target creature with power 4 or greater.\n{4}{B}, {T}: Syndicate Guildmage deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "4e54e567-962d-58cc-aeb3-b9448fe82d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaa19e-995e-447d-a0a2-46e5d117d5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaa19e-995e-447d-a0a2-46e5d117d5ec.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "343fb908-188c-5d9c-be3b-5aa0bad45baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42efd5-79c8-44f9-b3d6-d9058e0cb0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42efd5-79c8-44f9-b3d6-d9058e0cb0f6.jpg?1",
             "name": "Theater of Horrors",
             "text": "At the beginning of your upkeep, exile the top card of your library.\nDuring your turn, if an opponent lost life this turn, you may play cards exiled with Theater of Horrors.\n{3}{R}: Theater of Horrors deals 1 damage to target opponent or planeswalker.",
             "colours": [
@@ -7321,7 +7321,7 @@
         },
         {
             "id": "ccdabe5f-edcb-561c-b2c8-95ff1bba5c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd199a48-5ac8-4ab9-a33c-bbce6f7c9d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd199a48-5ac8-4ab9-a33c-bbce6f7c9d1b.jpg?1",
             "name": "Zegana, Utopian Speaker",
             "text": "When Zegana, Utopian Speaker enters the battlefield, if you control another creature with a +1/+1 counter on it, draw a card.\n{4}{G}{U}: Adapt 4. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "1eda886f-d307-5b4f-93ed-6a43e7358e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13070db2-cf89-4552-8b6c-76426274321a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13070db2-cf89-4552-8b6c-76426274321a.jpg?1",
             "name": "Zhur-Taa Goblin",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "0994914c-2d8c-50eb-9b6b-4ad69bbcb847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c604697-5c81-4329-9b16-f19bd90ba08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c604697-5c81-4329-9b16-f19bd90ba08c.jpg?1",
             "name": "Footlight Fiend",
             "text": "When Footlight Fiend dies, it deals 1 damage to any target.",
             "colours": [
@@ -7433,7 +7433,7 @@
         },
         {
             "id": "27c78013-9fc8-54da-b1f3-4c229d329932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f006255f-b18d-4d52-b97a-17909b67decc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f006255f-b18d-4d52-b97a-17909b67decc.jpg?1",
             "name": "Rubble Slinger",
             "text": "Reach",
             "colours": [
@@ -7470,7 +7470,7 @@
         },
         {
             "id": "3d37d14c-5a3d-5f54-b2a5-9e913617b4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886fd9a-7800-41f1-b692-32a439b045da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886fd9a-7800-41f1-b692-32a439b045da.jpg?1",
             "name": "Scuttlegator",
             "text": "Defender\n{6}{GW}{GW}: Adapt 3. (If this creature has no +1/+1 counters on it, put three +1/+1 counters on it.)\nAs long as Scuttlegator has a +1/+1 counter on it, it can attack as though it didn't have defender.",
             "colours": [
@@ -7508,7 +7508,7 @@
         },
         {
             "id": "f8cd94dc-8662-5320-b114-be6d1cb7ea36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465adbb4-4c64-44eb-8323-61d23282c6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465adbb4-4c64-44eb-8323-61d23282c6b8.jpg?1",
             "name": "Senate Griffin",
             "text": "Flying\nWhen Senate Griffin enters the battlefield, scry 1.",
             "colours": [
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "b58bcaf1-1489-5ca9-9025-eadd2d800444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61245466-694f-4a80-b556-4e7f876aedca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61245466-694f-4a80-b556-4e7f876aedca.jpg?1",
             "name": "Vizkopa Vampire",
             "text": "Lifelink",
             "colours": [
@@ -7580,7 +7580,7 @@
         },
         {
             "id": "ef3c9a4e-ee5f-56f1-b1aa-d942c50f98ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg?1",
             "name": "Bedeck // Bedazzle",
             "text": "Target creature gets +3/-3 until end of turn.",
             "colours": [
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "8b1435d3-64a8-562d-8e1b-3c64c51492b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg?1",
             "name": "Bedeck // Bedazzle",
             "text": "Destroy target nonbasic land. Bedazzle deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -7648,7 +7648,7 @@
         },
         {
             "id": "48e54abe-a208-5578-aa03-036d8142e4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg?1",
             "name": "Carnival // Carnage",
             "text": "Carnival deals 1 damage to target creature or planeswalker and 1 damage to that permanent's controller.",
             "colours": [
@@ -7682,7 +7682,7 @@
         },
         {
             "id": "f7201a85-2421-55e8-b9bf-003da8abc29f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg?1",
             "name": "Carnival // Carnage",
             "text": "Carnage deals 3 damage to target opponent. That player discards two cards.",
             "colours": [
@@ -7716,7 +7716,7 @@
         },
         {
             "id": "d96649dd-4281-5e05-aa80-f59b8ce2c671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg?1",
             "name": "Collision // Colossus",
             "text": "Collision deals 6 damage to target creature with flying.",
             "colours": [
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "3b2890b8-fd78-5f97-8dab-8de86fc5c66f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg?1",
             "name": "Collision // Colossus",
             "text": "Target creature gets +4/+2 and gains trample until end of turn.",
             "colours": [
@@ -7784,7 +7784,7 @@
         },
         {
             "id": "0edb8bf4-3578-5140-b05f-8e66b282f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1",
             "name": "Consecrate // Consume",
             "text": "Exile target card from a graveyard.\nDraw a card.",
             "colours": [
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "14e343b7-c684-57b8-bdec-633828e6ae60",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1",
             "name": "Consecrate // Consume",
             "text": "Target player sacrifices a creature with the greatest power among creatures they control. You gain life equal to its power.",
             "colours": [
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "d58a6df4-6066-5049-b705-10c1dd865084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg?1",
             "name": "Depose // Deploy",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -7886,7 +7886,7 @@
         },
         {
             "id": "3a0dd57f-a855-570e-8cc3-a4a72c3d50f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg?1",
             "name": "Depose // Deploy",
             "text": "Create two 1/1 colorless Thopter artifact creature tokens with flying, then you gain 1 life for each creature you control.",
             "colours": [
@@ -7920,7 +7920,7 @@
         },
         {
             "id": "b0506af8-075d-5629-85f4-c3860c02573c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg?1",
             "name": "Incubation // Incongruity",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "0c08602c-0d20-5ede-85d7-1e0f8458ba72",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg?1",
             "name": "Incubation // Incongruity",
             "text": "Exile target creature. That creature's controller creates a 3/3 green Frog Lizard creature token.",
             "colours": [
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "654f4f6a-158d-5721-a9e7-d8cd807b2fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg?1",
             "name": "Repudiate // Replicate",
             "text": "Counter target activated or triggered ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -8022,7 +8022,7 @@
         },
         {
             "id": "1f9a0bbd-341f-5153-b7a8-73ffccf0eb40",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg?1",
             "name": "Repudiate // Replicate",
             "text": "Create a token that's a copy of target creature you control.",
             "colours": [
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "ac399fe8-535f-530a-bab8-62b882477efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg?1",
             "name": "Revival // Revenge",
             "text": "Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -8090,7 +8090,7 @@
         },
         {
             "id": "cbec6fc3-8b6e-5ec9-a3db-f95b935bff9c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg?1",
             "name": "Revival // Revenge",
             "text": "Double your life total. Target opponent loses half their life, rounded up.",
             "colours": [
@@ -8124,7 +8124,7 @@
         },
         {
             "id": "da8df4d6-425c-5e3f-9d7f-182ff8b5aa26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg?1",
             "name": "Thrash // Threat",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "7d01cd4c-a6f8-5d88-acc3-d6ab76e8e884",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg?1",
             "name": "Thrash // Threat",
             "text": "Create a 4/4 red and green Beast creature token with trample.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "3d5ceb46-ca7b-52b7-a0aa-0e1a5876b1e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg?1",
             "name": "Warrant // Warden",
             "text": "Put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "b5046154-a12d-56f1-8698-405c153932eb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg?1",
             "name": "Warrant // Warden",
             "text": "Create a 4/4 white and blue Sphinx creature token with flying and vigilance.",
             "colours": [
@@ -8260,7 +8260,7 @@
         },
         {
             "id": "f8fcc657-60a6-5194-92a0-84b97560a85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13aed078-9e29-48e7-b145-5252362031a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13aed078-9e29-48e7-b145-5252362031a0.jpg?1",
             "name": "Azorius Locket",
             "text": "{T}: Add {W} or {U}.\n{WU}{WU}{WU}{WU}, {T}, Sacrifice Azorius Locket: Draw two cards.",
             "colours": [],
@@ -8291,7 +8291,7 @@
         },
         {
             "id": "c262806c-6190-50d8-98d3-5dca4a24d9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99767e2f-a558-4d63-b9b6-923d15b433e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99767e2f-a558-4d63-b9b6-923d15b433e1.jpg?1",
             "name": "Gate Colossus",
             "text": "This spell costs {1} less to cast for each Gate you control.\nGate Colossus can't be blocked by creatures with power 2 or less.\nWhenever a Gate enters the battlefield under your control, you may put Gate Colossus from your graveyard on top of your library.",
             "colours": [],
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "6e285cad-4126-5f15-b0cd-0c14e0310a84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1022d41-c1d0-42bf-b3e5-d6fb02d47119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1022d41-c1d0-42bf-b3e5-d6fb02d47119.jpg?1",
             "name": "Glass of the Guildpact",
             "text": "Multicolored creatures you control get +1/+1.",
             "colours": [],
@@ -8350,7 +8350,7 @@
         },
         {
             "id": "7d5c303c-8912-5faa-821c-39c62c258f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec78880-a8ec-4c87-bc3f-e2a79d154884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec78880-a8ec-4c87-bc3f-e2a79d154884.jpg?1",
             "name": "Gruul Locket",
             "text": "{T}: Add {R} or {G}.\n{RG}{RG}{RG}{RG}, {T}, Sacrifice Gruul Locket: Draw two cards.",
             "colours": [],
@@ -8381,7 +8381,7 @@
         },
         {
             "id": "b3f56f87-5fc5-501d-a90e-2cd2f99b626f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd8ee5-0a2a-4c68-9b09-01945c7189ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd8ee5-0a2a-4c68-9b09-01945c7189ab.jpg?1",
             "name": "Junktroller",
             "text": "Defender\n{T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -8412,7 +8412,7 @@
         },
         {
             "id": "f6640841-ffeb-5c57-a689-bcdd5eb0f394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761e7188-bad1-4775-84a2-15da9a42a57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761e7188-bad1-4775-84a2-15da9a42a57c.jpg?1",
             "name": "Orzhov Locket",
             "text": "{T}: Add {W} or {B}.\n{WB}{WB}{WB}{WB}, {T}, Sacrifice Orzhov Locket: Draw two cards.",
             "colours": [],
@@ -8443,7 +8443,7 @@
         },
         {
             "id": "6a5cf777-c480-55ea-ba14-ae8cd3a774b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd60d9b-2282-4b32-9bff-efb2bcf87d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd60d9b-2282-4b32-9bff-efb2bcf87d22.jpg?1",
             "name": "Rakdos Locket",
             "text": "{T}: Add {B} or {R}.\n{BR}{BR}{BR}{BR}, {T}, Sacrifice Rakdos Locket: Draw two cards.",
             "colours": [],
@@ -8474,7 +8474,7 @@
         },
         {
             "id": "adcf663c-70e6-5299-a64f-ba4cfc9c1c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b06cb5-5e74-456f-81b1-fced1346cc47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b06cb5-5e74-456f-81b1-fced1346cc47.jpg?1",
             "name": "Scrabbling Claws",
             "text": "{T}: Target player exiles a card from their graveyard.\n{1}, Sacrifice Scrabbling Claws: Exile target card from a graveyard. Draw a card.",
             "colours": [],
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "d31643a7-3585-50a3-a845-5d9900570fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb42a80-0442-4850-b0e7-41182d5633ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb42a80-0442-4850-b0e7-41182d5633ff.jpg?1",
             "name": "Screaming Shield",
             "text": "Equipped creature gets +0/+3 and has \"{2}, {T}: Target player puts the top three cards of their library into their graveyard.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8532,7 +8532,7 @@
         },
         {
             "id": "2675ce8f-c940-59f5-9c2a-2adf969ad2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c65978-e5b0-428e-aace-f99768ca6106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c65978-e5b0-428e-aace-f99768ca6106.jpg?1",
             "name": "Simic Locket",
             "text": "{T}: Add {G} or {U}.\n{GW}{GW}{GW}{GW}, {T}, Sacrifice Simic Locket: Draw two cards.",
             "colours": [],
@@ -8563,7 +8563,7 @@
         },
         {
             "id": "a6a50123-9636-522d-a77b-05a8176efadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d30399e-2ecb-4de2-b830-673a3f059197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d30399e-2ecb-4de2-b830-673a3f059197.jpg?1",
             "name": "Sphinx of the Guildpact",
             "text": "Sphinx of the Guildpact is all colors.\nFlying\nHexproof from monocolored (This creature can't be the target of monocolored spells or abilities your opponents control.)",
             "colours": [
@@ -8606,7 +8606,7 @@
         },
         {
             "id": "8ff15b8b-19eb-57c7-926d-a3e62bcf5e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e307d4-7e5f-4f00-869e-da0e7abbf27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e307d4-7e5f-4f00-869e-da0e7abbf27f.jpg?1",
             "name": "Tome of the Guildpact",
             "text": "Whenever you cast a multicolored spell, draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8634,7 +8634,7 @@
         },
         {
             "id": "3beb486e-c2ca-5a87-be8d-baf99e3ac809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5412-c711-41b4-ab3b-7788a0a22228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5412-c711-41b4-ab3b-7788a0a22228.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "6bac2c36-a718-5730-b9c3-d55255388936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52013ba-9b17-497b-a844-1e7eb5607019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52013ba-9b17-497b-a844-1e7eb5607019.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8704,7 +8704,7 @@
         },
         {
             "id": "bf3e3575-8eb1-520f-be3a-b26b778ea003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5faba6c8-3463-47c1-ba01-09eb87fcb2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5faba6c8-3463-47c1-ba01-09eb87fcb2d5.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R}.)\nAs Blood Crypt enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "2c89affc-1e48-5e11-9d6d-d1435d1f59ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb54233c-0844-4965-9cde-e8a4ef3e11b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb54233c-0844-4965-9cde-e8a4ef3e11b8.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U}.)\nAs Breeding Pool enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8772,7 +8772,7 @@
         },
         {
             "id": "7eff0d87-e24e-5e4c-96ac-5578933bcea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3433a2c2-d252-4cd8-97e8-389875b2cda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3433a2c2-d252-4cd8-97e8-389875b2cda0.jpg?1",
             "name": "Gateway Plaza",
             "text": "Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8802,7 +8802,7 @@
         },
         {
             "id": "19c54a73-e7d5-525f-89b0-d48faacfeab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4c824-2dfc-42ae-84e6-09f8e3f51b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4c824-2dfc-42ae-84e6-09f8e3f51b5b.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B}.)\nAs Godless Shrine enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "8ac9cfdf-8334-505a-9b14-bf2589e3519b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d10573-1695-4a73-b92d-d478572b85ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d10573-1695-4a73-b92d-d478572b85ec.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "7005a1e1-bda9-5c06-9959-4c11b388fbd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd445-de4f-45de-95b9-6e0855926a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd445-de4f-45de-95b9-6e0855926a6a.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "0fdc024f-665d-5098-8b0f-af684a39a4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97a6d34-03ab-49f1-b02e-405b733f8843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97a6d34-03ab-49f1-b02e-405b733f8843.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U}.)\nAs Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "fef05c98-a52a-5a41-b309-68ce3c1e84c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fb67-e161-4e89-be3e-c8021122ff19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fb67-e161-4e89-be3e-c8021122ff19.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "259cc2a3-6031-5a97-94f1-4ddc64b4e63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7046b5e-622f-4ae8-9ddd-709ccd61000e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7046b5e-622f-4ae8-9ddd-709ccd61000e.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "554c74b1-91c2-581b-a7b8-799e91bf47e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f2ae00-206d-4984-84eb-d10ab75d3791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f2ae00-206d-4984-84eb-d10ab75d3791.jpg?1",
             "name": "Plaza of Harmony",
             "text": "When Plaza of Harmony enters the battlefield, if you control two or more Gates, you gain 3 life.\n{T}: Add {C}.\n{T}: Add one mana of any type that a Gate you control could produce.",
             "colours": [],
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "08f88182-c117-59cc-8e76-be9aba5b5ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7e55d-d4c9-4755-ab87-a592ba3fb64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7e55d-d4c9-4755-ab87-a592ba3fb64f.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9073,7 +9073,7 @@
         },
         {
             "id": "4c1020e7-9b19-5e0e-83f8-b025236efcba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88b90fa-a7f1-4739-a507-d22dede9384f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88b90fa-a7f1-4739-a507-d22dede9384f.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "0a32f328-fb8a-5178-84fb-3c93a5b73436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e73e082-b16a-45d5-bc4a-24c694b0b9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e73e082-b16a-45d5-bc4a-24c694b0b9af.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9143,7 +9143,7 @@
         },
         {
             "id": "263a0ce7-237d-5f51-a2bf-c2c49cc146aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62537433-3c49-417d-89ef-c12d5288bb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62537433-3c49-417d-89ef-c12d5288bb6f.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9178,7 +9178,7 @@
         },
         {
             "id": "c9bd32eb-a01b-55b6-b3b5-5399bba48f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaa1ff6-304e-4660-9df3-36de8e89592e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaa1ff6-304e-4660-9df3-36de8e89592e.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G}.)\nAs Stomping Ground enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9212,7 +9212,7 @@
         },
         {
             "id": "0479b61d-cd43-577e-aa02-145c73977f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9433619d-5bd1-41e9-ab7a-364c98347b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9433619d-5bd1-41e9-ab7a-364c98347b1d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9246,7 +9246,7 @@
         },
         {
             "id": "3ef716ae-3c49-5067-b752-d2dab5216495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5bd0-5ab3-4bf4-b20e-1389c0e9527a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5bd0-5ab3-4bf4-b20e-1389c0e9527a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "0e7fc903-869c-5581-9c21-f4a72211b814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308809ad-c150-49b1-83e3-b78494156d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308809ad-c150-49b1-83e3-b78494156d7a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "1e16c2cc-400c-56f0-bc4f-c4f65945b076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a773e3-93f0-4bf8-ab6a-8cee939d743a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a773e3-93f0-4bf8-ab6a-8cee939d743a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9348,7 +9348,7 @@
         },
         {
             "id": "6944bec7-7702-5f77-b0e6-6942f90b2f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48764854-d268-462d-a016-27329c8f062d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48764854-d268-462d-a016-27329c8f062d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9382,7 +9382,7 @@
         },
         {
             "id": "2f378ee8-5661-5be5-8856-53f5bbfdf4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7cffe-8751-4da7-8c1c-59f472ef3735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7cffe-8751-4da7-8c1c-59f472ef3735.jpg?1",
             "name": "Dovin, Architect of Law",
             "text": "+1: You gain 2 life and draw a card.\n\u22121: Tap target creature. It doesn't untap during its controller's next untap step.\n\u22129: Tap all permanents target opponent controls. That player skips their next untap step.",
             "colours": [
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "cecf0914-d9f6-5b8b-9946-d0113d9b59c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070f0a21-8e06-46ec-9d84-c65067b23893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070f0a21-8e06-46ec-9d84-c65067b23893.jpg?1",
             "name": "Elite Arrester",
             "text": "{1}{U}, {T}: Tap target creature.",
             "colours": [
@@ -9454,7 +9454,7 @@
         },
         {
             "id": "6976c560-32cb-53b8-ae70-aaff9e18b43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6328e6b5-9dfb-4fd4-99ee-a1ffc2c707da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6328e6b5-9dfb-4fd4-99ee-a1ffc2c707da.jpg?1",
             "name": "Dovin's Dismissal",
             "text": "Put up to one target tapped creature on top of its owner's library. You may search your library and/or graveyard for a card named Dovin, Architect of Law, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "facb2935-8a79-5ca9-97a6-ee94f01b0621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a962509-2e77-4655-b397-9625b2f3407a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a962509-2e77-4655-b397-9625b2f3407a.jpg?1",
             "name": "Dovin's Automaton",
             "text": "As long as you control a Dovin planeswalker, Dovin's Automaton gets +2/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "885f98a7-3163-5720-8063-f0cd901ea3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe16cdb-90df-4670-a084-55c505791d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe16cdb-90df-4670-a084-55c505791d85.jpg?1",
             "name": "Domri, City Smasher",
             "text": "+2: Creatures you control get +1/+1 and gain haste until end of turn.\n\u22123: Domri, City Smasher deals 3 damage to any target.\n\u22128: Put three +1/+1 counters on each creature you control. Those creatures gain trample until end of turn.",
             "colours": [
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "bbefba15-4dda-53ba-a4d8-3a26db00d484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13420d-d295-4000-9c38-fa5d10e06ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13420d-d295-4000-9c38-fa5d10e06ece.jpg?1",
             "name": "Ragefire",
             "text": "Ragefire deals 3 damage to target creature.",
             "colours": [
@@ -9585,7 +9585,7 @@
         },
         {
             "id": "dbf30816-d953-54e0-afe7-d6dbf98b2181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cef5a4-e8fd-4ebd-b121-67059308c772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cef5a4-e8fd-4ebd-b121-67059308c772.jpg?1",
             "name": "Charging War Boar",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAs long as you control a Domri planeswalker, Charging War Boar gets +1/+1 and has trample. (It can deal excess damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "464169d8-253b-5243-8705-4491434fb58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe58d8-67d1-4719-8e84-27747dea3506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe58d8-67d1-4719-8e84-27747dea3506.jpg?1",
             "name": "Domri's Nodorog",
             "text": "Trample\nWhen Domri's Nodorog enters the battlefield, you may search your library and/or graveyard for a card named Domri, City Smasher, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9655,7 +9655,7 @@
         },
         {
             "id": "70119b58-5449-581a-b5bd-2ce6f7a752b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a908e8-6952-46c0-94ec-3962b7a4caef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a908e8-6952-46c0-94ec-3962b7a4caef.jpg?1",
             "name": "The Haunt of Hightower",
             "text": "Flying, lifelink\nWhenever The Haunt of Hightower attacks, defending player discards a card.\nWhenever a card is put into an opponent's graveyard from anywhere, put a +1/+1 counter on The Haunt of Hightower.",
             "colours": [
@@ -9690,7 +9690,7 @@
         },
         {
             "id": "95f964bc-416c-5241-8e2d-8d8378d91016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a2483-d21f-4c31-9a36-ed7c5672894b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a2483-d21f-4c31-9a36-ed7c5672894b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -9724,7 +9724,7 @@
         },
         {
             "id": "f021ed7e-996c-5af2-94a2-9d707a276482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3d8da-9005-44d9-bb10-18cdac7a32f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3d8da-9005-44d9-bb10-18cdac7a32f5.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -9758,7 +9758,7 @@
         },
         {
             "id": "31a18be7-bf42-5723-b1fb-880471a2597c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b69e52-f394-4863-943b-239e96b5cc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b69e52-f394-4863-943b-239e96b5cc95.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9792,7 +9792,7 @@
         },
         {
             "id": "d450ce97-dd62-59ff-921f-f73a276817fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993613a6-09a9-45a5-b35f-5a5fdb6d14ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993613a6-09a9-45a5-b35f-5a5fdb6d14ec.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9826,7 +9826,7 @@
         },
         {
             "id": "6f6d519d-0848-54a0-96d0-81cd8a5d4c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc993a7-a1ce-4403-a0a0-2afc9f9eca42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc993a7-a1ce-4403-a0a0-2afc9f9eca42.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -9860,7 +9860,7 @@
         },
         {
             "id": "3ede2133-21e1-5a02-9e74-7921242a84a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d3391-6311-418e-b55a-10c0af751026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d3391-6311-418e-b55a-10c0af751026.jpg?1",
             "name": "Frog Lizard",
             "text": "",
             "colours": [
@@ -9895,7 +9895,7 @@
         },
         {
             "id": "aa0ad8d3-c95b-56b0-ae31-6b7e8dfc424b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0260e0ae-bf09-430a-a449-c16219d84b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0260e0ae-bf09-430a-a449-c16219d84b63.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9929,7 +9929,7 @@
         },
         {
             "id": "888e284a-6bfa-5d0c-b01f-410a813bddf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec9ade-1e06-43c9-97df-55465cabdf32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec9ade-1e06-43c9-97df-55465cabdf32.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9965,7 +9965,7 @@
         },
         {
             "id": "2b2ad031-308d-5b77-a25c-3ca2d2cce68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82ba894-7b10-45ae-9322-60ef85a2869d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82ba894-7b10-45ae-9322-60ef85a2869d.jpg?1",
             "name": "Sphinx",
             "text": "",
             "colours": [
@@ -10001,7 +10001,7 @@
         },
         {
             "id": "ecb4f782-2e1d-599e-b215-50205578124c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3bdd7-b093-4bfd-8a9a-965e72bfefb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3bdd7-b093-4bfd-8a9a-965e72bfefb3.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -10037,7 +10037,7 @@
         },
         {
             "id": "66373335-28d6-53e4-abd9-d2f69976ac62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd768c3-f278-41f8-b329-8403391d6326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd768c3-f278-41f8-b329-8403391d6326.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "689f3fc1-adb2-5cbe-9f22-65d4b99d5dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559f9f3-eff0-465d-93c1-e875a8afe87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559f9f3-eff0-465d-93c1-e875a8afe87f.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10098,7 +10098,7 @@
         },
         {
             "id": "9d6edd76-8452-5786-b276-7b93f3795897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44717d19-d8c2-45ba-9904-00c0c79ee0c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44717d19-d8c2-45ba-9904-00c0c79ee0c3.jpg?1",
             "name": "Domri, Chaos Bringer Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ROE.json
+++ b/Assets/Resources/Sets/ROE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ceeeaa92-ff8e-5943-8842-3bb7efa6b673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dba377-7446-4517-a504-ee04568fd6cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dba377-7446-4517-a504-ee04568fd6cf.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all colored permanents he or she controls.",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "6f2e877f-e72b-5254-b016-d178324e6a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac80eb8-321d-476a-87e7-d25bdac6a91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac80eb8-321d-476a-87e7-d25bdac6a91c.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast Artisan of Kozilek, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "f0700782-7ba6-5ed1-858a-e04100a000b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f26fb7-43cc-4a3b-8ba3-b90101c8ee3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f26fb7-43cc-4a3b-8ba3-b90101c8ee3a.jpg?1",
             "name": "Eldrazi Conscription",
             "text": "Enchant creature\nEnchanted creature gets +10/+10 and has trample and annihilator 2. (Whenever it attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "644a5c05-371f-507d-83a3-aa54c76f8436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67600383-bbb8-411c-b8e6-2296650bc747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67600383-bbb8-411c-b8e6-2296650bc747.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "Emrakul, the Aeons Torn can't be countered.\nWhen you cast Emrakul, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -129,7 +129,7 @@
         },
         {
             "id": "29f4faa8-a65e-5e61-8ef3-43707d1c72c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d602f4-5876-416a-95e5-821a285358bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d602f4-5876-416a-95e5-821a285358bf.jpg?1",
             "name": "Hand of Emrakul",
             "text": "You may sacrifice four Eldrazi Spawn rather than pay Hand of Emrakul's mana cost.\nAnnihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)",
             "colours": [],
@@ -159,7 +159,7 @@
         },
         {
             "id": "5af77709-cb2e-5494-baf9-89ac2d6e95da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fac91-2483-4678-b86a-2c54a3a480cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fac91-2483-4678-b86a-2c54a3a480cf.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast Kozilek, Butcher of Truth, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -191,7 +191,7 @@
         },
         {
             "id": "b5d65681-69ee-5068-b0fa-f34ffa85ad88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d790ad-3559-4c32-9057-e2e326740bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d790ad-3559-4c32-9057-e2e326740bdc.jpg?1",
             "name": "It That Betrays",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nWhenever an opponent sacrifices a nontoken permanent, put that card onto the battlefield under your control.",
             "colours": [],
@@ -221,7 +221,7 @@
         },
         {
             "id": "1c047837-e79f-52bc-8d48-3938e4ddacaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569e2c39-7a49-4a3b-afe5-1862a7da8026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569e2c39-7a49-4a3b-afe5-1862a7da8026.jpg?1",
             "name": "Not of This World",
             "text": "Counter target spell or ability that targets a permanent you control.\nNot of This World costs {7} less to cast if it targets a spell or ability that targets a creature you control with power 7 or greater.",
             "colours": [],
@@ -252,7 +252,7 @@
         },
         {
             "id": "0858b6af-64a4-548c-a6c3-2c6164f68562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd84b5-fd93-483e-a131-028d04d9dea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd84b5-fd93-483e-a131-028d04d9dea7.jpg?1",
             "name": "Pathrazer of Ulamog",
             "text": "Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents.)\nPathrazer of Ulamog can't be blocked except by three or more creatures.",
             "colours": [],
@@ -282,7 +282,7 @@
         },
         {
             "id": "c499f072-6654-50a2-89e1-5549266f11bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270f0e5b-2c46-4816-a195-cfce16570bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270f0e5b-2c46-4816-a195-cfce16570bde.jpg?1",
             "name": "Skittering Invasion",
             "text": "Put five 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -313,7 +313,7 @@
         },
         {
             "id": "841e58c4-8cc7-5f4c-a6b0-0177e3d48b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff46819-bfb3-4448-ab4f-f22ff9e2b2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff46819-bfb3-4448-ab4f-f22ff9e2b2b4.jpg?1",
             "name": "Spawnsire of Ulamog",
             "text": "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\n{4}: Put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"\n{2}0: Cast any number of Eldrazi cards you own from outside the game without paying their mana costs.",
             "colours": [],
@@ -343,7 +343,7 @@
         },
         {
             "id": "02c5da97-edd3-56a7-8686-e5a92e51672e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225e3cc6-34d0-4f81-9f49-162d97e2ea59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225e3cc6-34d0-4f81-9f49-162d97e2ea59.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast Ulamog, the Infinite Gyre, destroy target permanent.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nUlamog is indestructible.\nWhen Ulamog is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -375,7 +375,7 @@
         },
         {
             "id": "e6d66504-1737-5eb1-9264-d12a9e8bea9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bacedb-9fa8-4a21-b0eb-e7ead64360b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bacedb-9fa8-4a21-b0eb-e7ead64360b4.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each turn if able.",
             "colours": [],
@@ -405,7 +405,7 @@
         },
         {
             "id": "eaa2e6b5-33f1-5afb-8af0-b378160f6c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85623f54-1c18-4b1e-a8da-df66de3832a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85623f54-1c18-4b1e-a8da-df66de3832a6.jpg?1",
             "name": "Affa Guard Hound",
             "text": "Flash\nWhen Affa Guard Hound enters the battlefield, target creature gets +0/+3 until end of turn.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "04adfada-5fa1-504b-afe4-ae9e2f1881a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8452b0b7-8157-4a3f-8bef-a34e322b9463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8452b0b7-8157-4a3f-8bef-a34e322b9463.jpg?1",
             "name": "Caravan Escort",
             "text": "Level up {2} ({2}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n2/2\n\nLEVEL 5+\n5/5\nFirst strike",
             "colours": [
@@ -474,7 +474,7 @@
         },
         {
             "id": "1c1f989e-7669-5c7d-ae6f-888c2f042daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e255235f-9e0c-44c0-b903-47af24d87d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e255235f-9e0c-44c0-b903-47af24d87d1f.jpg?1",
             "name": "Dawnglare Invoker",
             "text": "Flying\n{8}: Tap all creatures target player controls.",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "9aa90a10-16f4-5564-adbd-5fb0fd2e37f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg?1",
             "name": "Deathless Angel",
             "text": "Flying\n{W}{W}: Target creature is indestructible this turn.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "3de93dce-a2b5-5a85-8880-d6f81e2cc707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e109007a-9d4a-4a6d-bf97-edadb9a1c745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e109007a-9d4a-4a6d-bf97-edadb9a1c745.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "20230f94-a434-599c-85d5-0554d8fb79d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a2ec16-bee4-4dfd-81cb-cb81b017170c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a2ec16-bee4-4dfd-81cb-cb81b017170c.jpg?1",
             "name": "Eland Umbra",
             "text": "Enchant creature\nEnchanted creature gets +0/+4.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "826cbf1f-0bc2-5fbd-922e-d0af8f9f5687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23013b-4202-45c1-a756-b9a8c5a9dc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23013b-4202-45c1-a756-b9a8c5a9dc05.jpg?1",
             "name": "Emerge Unscathed",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "f40f60aa-45b4-57e4-b2ae-b75496012d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0440668-1b0e-437c-9e42-7166dd14dfe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0440668-1b0e-437c-9e42-7166dd14dfe5.jpg?1",
             "name": "Gideon Jura",
             "text": "+2: During target opponent's next turn, creatures that player controls attack Gideon Jura if able.\n-2: Destroy target tapped creature.\n0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "a0677cf6-118d-55a2-bf42-265f3c3694a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5a3110-0081-4dee-b7b1-597dfd568eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5a3110-0081-4dee-b7b1-597dfd568eed.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "efe76751-4a89-5834-92c1-8685b1b19b94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77efd36-f9e7-4c34-a6ee-9e1c9b273fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77efd36-f9e7-4c34-a6ee-9e1c9b273fb7.jpg?1",
             "name": "Guard Duty",
             "text": "Enchant creature\nEnchanted creature has defender.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "7108201e-8661-5f2f-a7e4-f407c048d395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77fef2c-227e-474e-896e-c0ebe227f494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77fef2c-227e-474e-896e-c0ebe227f494.jpg?1",
             "name": "Harmless Assault",
             "text": "Prevent all combat damage that would be dealt this turn by attacking creatures.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "080da8f4-975c-5298-aba8-ae17babfd401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48e9f90-4b13-4281-943c-126be4ff1ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48e9f90-4b13-4281-943c-126be4ff1ce0.jpg?1",
             "name": "Hedron-Field Purists",
             "text": "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n1/4\nIf a source would deal damage to you or a creature you control, prevent 1 of that damage.\nLEVEL 5+\n2/5\nIf a source would deal damage to you or a creature you control, prevent 2 of that damage.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "888e0ae2-e190-51c2-8e0f-e87eb0309320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1461e2f-fb1d-4092-9935-4cee092f27e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1461e2f-fb1d-4092-9935-4cee092f27e7.jpg?1",
             "name": "Hyena Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has first strike.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "8826dccd-4188-50f5-b4be-2b1dd5c46bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1532b1-6f3b-48d3-ada9-ec395e842b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1532b1-6f3b-48d3-ada9-ec395e842b96.jpg?1",
             "name": "Ikiral Outrider",
             "text": "Level up {4} ({4}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n2/6\nVigilance\nLEVEL 4+\n3/10\nVigilance",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "bf232a80-2961-5780-bc5a-faa82b1205c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31551a-ab7a-4e49-b545-77afb3be72d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31551a-ab7a-4e49-b545-77afb3be72d3.jpg?1",
             "name": "Kabira Vindicator",
             "text": "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-4\n3/6\nOther creatures you control get +1/+1.\nLEVEL 5+\n4/8\nOther creatures you control get +2/+2.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "e19e3d0f-bb66-5ac0-8609-f26ebb6d445f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8332e9-7b02-4d58-b081-11004e690524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8332e9-7b02-4d58-b081-11004e690524.jpg?1",
             "name": "Knight of Cliffhaven",
             "text": "Level up {3} ({3}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n2/3\nFlying\nLEVEL 4+\n4/4\nFlying, vigilance",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "cd7d0aaa-4f23-5b25-aeae-f9c77be2f6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068943d2-c456-42a3-8088-3e4923bf6d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068943d2-c456-42a3-8088-3e4923bf6d74.jpg?1",
             "name": "Kor Line-Slinger",
             "text": "{T}: Tap target creature with power 3 or less.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "5d9d3bd2-7aa7-579e-94d0-e86a4332e2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03066fa1-ea16-4a87-9218-120efa976909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03066fa1-ea16-4a87-9218-120efa976909.jpg?1",
             "name": "Kor Spiritdancer",
             "text": "Kor Spiritdancer gets +2/+2 for each Aura attached to it.\nWhenever you cast an Aura spell, you may draw a card.",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "4c3ba2f9-8dd9-5fc0-a100-990a18659292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602b52a-5904-4780-9192-72990d07c975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602b52a-5904-4780-9192-72990d07c975.jpg?1",
             "name": "Lightmine Field",
             "text": "Whenever one or more creatures attack, Lightmine Field deals damage to each of those creatures equal to the number of attacking creatures.",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "2048b59f-351c-5fd3-a8f1-63ff60637f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b80a09-7e75-4091-a60e-04aff79339a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b80a09-7e75-4091-a60e-04aff79339a3.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "Flying\nActivated abilities of creatures your opponents control can't be activated.",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "0d25af92-1bd9-5bd3-ab95-821c0e6a809a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc00f4b-ca9a-468a-91e1-c81fe6585765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc00f4b-ca9a-468a-91e1-c81fe6585765.jpg?1",
             "name": "Lone Missionary",
             "text": "When Lone Missionary enters the battlefield, you gain 4 life.",
             "colours": [
@@ -1125,7 +1125,7 @@
         },
         {
             "id": "90e79abf-7e35-54a5-9b7e-106a03638ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d5a36-cc29-47fc-bdf7-b753f3bc5197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d5a36-cc29-47fc-bdf7-b753f3bc5197.jpg?1",
             "name": "Luminous Wake",
             "text": "Enchant creature\nWhenever enchanted creature attacks or blocks, you gain 4 life.",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "a63fbfdb-1e98-5fe7-a4bb-f7ff27378064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f839a5e-3cbb-4179-9267-02f40645bdbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f839a5e-3cbb-4179-9267-02f40645bdbc.jpg?1",
             "name": "Makindi Griffin",
             "text": "Flying",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "dc40e345-1fb2-51de-856e-499d480528fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f1abef-385d-4202-8a45-835c37c4e242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f1abef-385d-4202-8a45-835c37c4e242.jpg?1",
             "name": "Mammoth Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has vigilance.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "1f5508d2-e8bd-538d-8e78-a7fe635266ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d61706-f9c1-4590-8057-7aa7fa199e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d61706-f9c1-4590-8057-7aa7fa199e6d.jpg?1",
             "name": "Near-Death Experience",
             "text": "At the beginning of your upkeep, if you have exactly 1 life, you win the game.",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "e4163f8c-6b86-54d0-804b-95225e58a98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52f249-14bd-4489-aaba-03e50fe42c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52f249-14bd-4489-aaba-03e50fe42c2e.jpg?1",
             "name": "Nomads' Assembly",
             "text": "Put a 1/1 white Kor Soldier creature token onto the battlefield for each creature you control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "b0ba5a24-8ef1-588c-a552-2732634750cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07313dd3-d0dc-40ca-98a3-fa4d39e5bcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07313dd3-d0dc-40ca-98a3-fa4d39e5bcae.jpg?1",
             "name": "Oust",
             "text": "Put target creature into its owner's library second from the top. Its controller gains 3 life.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "ab689654-26a9-5c8e-9d6f-9a960e2cb0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d260a-e1ca-4228-855e-2e104b86fd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d260a-e1ca-4228-855e-2e104b86fd6c.jpg?1",
             "name": "Puncturing Light",
             "text": "Destroy target attacking or blocking creature with power 3 or less.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "5d44176f-6306-5f80-b796-e91d92167b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fa47c3-3209-4e01-920a-aed2184520c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fa47c3-3209-4e01-920a-aed2184520c2.jpg?1",
             "name": "Repel the Darkness",
             "text": "Tap up to two target creatures.\nDraw a card.",
             "colours": [
@@ -1387,7 +1387,7 @@
         },
         {
             "id": "3029b331-18fd-511c-8863-706f324f6b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2698f01a-8574-4ae8-9441-a4361b1c29c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2698f01a-8574-4ae8-9441-a4361b1c29c6.jpg?1",
             "name": "Smite",
             "text": "Destroy target blocked creature.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "6f016fc1-21ac-5382-a060-5996397df1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3223c0ac-cc22-4886-8919-11273b477cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3223c0ac-cc22-4886-8919-11273b477cc7.jpg?1",
             "name": "Soul's Attendant",
             "text": "Whenever another creature enters the battlefield, you may gain 1 life.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "118942c9-6602-5c1e-ab9e-f97dc0e2c9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e8128f-9858-4c48-ab43-1beca3db70e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e8128f-9858-4c48-ab43-1beca3db70e5.jpg?1",
             "name": "Soulbound Guardians",
             "text": "Defender, flying",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "c85b7ce2-3ba6-5d32-8b2e-5bbc2c3ecc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868256bb-d4e2-42eb-a43a-360148aec06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868256bb-d4e2-42eb-a43a-360148aec06f.jpg?1",
             "name": "Stalwart Shield-Bearers",
             "text": "Defender\nOther creatures you control with defender get +0/+2.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "67367dca-2d31-5d5e-8f38-2bcfa3e47caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4df9be-324b-458a-9379-ab4aa437a6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4df9be-324b-458a-9379-ab4aa437a6d2.jpg?1",
             "name": "Student of Warfare",
             "text": "Level up {W} ({W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-6\n3/3\nFirst strike\nLEVEL 7+\n4/4\nDouble strike",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "d5475175-b171-5cef-8d2b-11b57352e28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4333f864-6b1c-4720-b2d6-490d5c7b31a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4333f864-6b1c-4720-b2d6-490d5c7b31a1.jpg?1",
             "name": "Survival Cache",
             "text": "You gain 2 life. Then if you have more life than an opponent, draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "559717cd-72b9-585d-8943-ff4512b37c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f70224d-e723-436d-8493-dcec5049f1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f70224d-e723-436d-8493-dcec5049f1a0.jpg?1",
             "name": "Time of Heroes",
             "text": "Each creature you control with a level counter on it gets +2/+2.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "ef98060a-60ed-50de-ae22-950fdf21152f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1364a830-36b7-48b9-bf69-6fd35eed9399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1364a830-36b7-48b9-bf69-6fd35eed9399.jpg?1",
             "name": "Totem-Guide Hartebeest",
             "text": "When Totem-Guide Hartebeest enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "5199914a-6c45-5263-82b9-fa811584b15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b007f42-9ec2-466b-8d6b-1d55c516080b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b007f42-9ec2-466b-8d6b-1d55c516080b.jpg?1",
             "name": "Transcendent Master",
             "text": "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 6-11\n6/6\nLifelink\nLEVEL 12+\n9/9\nLifelink\nTranscendent Master is indestructible.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "c27aa762-f53c-5fd5-b5ea-db33f5f8d31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55705d3-8640-478e-ace4-f4f900d617c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55705d3-8640-478e-ace4-f4f900d617c5.jpg?1",
             "name": "Umbra Mystic",
             "text": "Auras attached to permanents you control have totem armor. (If an enchanted permanent you control would be destroyed, instead remove all damage from it and destroy an Aura attached to it.)",
             "colours": [
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "1d24cdaa-6da9-519b-b818-252af3935e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3510f5-e450-400b-98ea-341dbf212054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3510f5-e450-400b-98ea-341dbf212054.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "8db3d175-201e-5ec7-b91a-3e0ce14a4820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e398a02-1456-4fae-be75-4231c968bf47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e398a02-1456-4fae-be75-4231c968bf47.jpg?1",
             "name": "Aura Finesse",
             "text": "Attach target Aura you control to target creature.\nDraw a card.",
             "colours": [
@@ -1794,7 +1794,7 @@
         },
         {
             "id": "5e31c03a-7c6b-58ec-8354-4d063621f464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9850489-c056-4b17-8743-a5b514d8edf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9850489-c056-4b17-8743-a5b514d8edf4.jpg?1",
             "name": "Cast Through Time",
             "text": "Instant and sorcery spells you control have rebound. (Exile the spell as it resolves if you cast it from your hand. At the beginning of your next upkeep, you may cast that card from exile without paying its mana cost.)",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "ffbd1c75-65cc-5175-9130-7bcec50b0f67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7585316f-ba3d-4472-9a7e-7db6f6dd9d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7585316f-ba3d-4472-9a7e-7db6f6dd9d15.jpg?1",
             "name": "Champion's Drake",
             "text": "Flying\nChampion's Drake gets +3/+3 as long as you control a creature with three or more level counters on it.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "24fd524e-c6ca-560c-a94b-82ea273fb72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d1bea-58cd-4483-a70a-0330ad5ab4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d1bea-58cd-4483-a70a-0330ad5ab4a1.jpg?1",
             "name": "Coralhelm Commander",
             "text": "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n3/3\nFlying\nLEVEL 4+\n4/4\nFlying\nOther Merfolk creatures you control get +1/+1.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "85b0ef54-77e7-5fb5-bf98-d9d8062a7a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe6e1ce-bc46-4f86-9504-f8cc062ed3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe6e1ce-bc46-4f86-9504-f8cc062ed3c6.jpg?1",
             "name": "Crab Umbra",
             "text": "Enchant creature\n{2}{U}: Untap enchanted creature.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "27400ded-49ba-5290-a2fa-e886f2baa23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efecdd9-bd3a-4b79-92da-6485589d5bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efecdd9-bd3a-4b79-92da-6485589d5bde.jpg?1",
             "name": "Deprive",
             "text": "As an additional cost to cast Deprive, return a land you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "2bd345d7-6fa7-56f8-9861-fc14eb3c1229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315f1cf8-7bde-4592-a14e-ef9e2e3e7ac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315f1cf8-7bde-4592-a14e-ef9e2e3e7ac0.jpg?1",
             "name": "Distortion Strike",
             "text": "Target creature gets +1/+0 until end of turn and is unblockable this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "b50cb42e-16c6-5c11-b0a6-154b658e03d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f15831-8dfd-4232-875c-efa6744c9a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f15831-8dfd-4232-875c-efa6744c9a12.jpg?1",
             "name": "Domestication",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your end step, if enchanted creature's power is 4 or greater, sacrifice Domestication.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "7ea99336-7f00-5b1b-953a-05ba55a8c6fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131d2925-d87c-415f-aa84-97f14030624e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131d2925-d87c-415f-aa84-97f14030624e.jpg?1",
             "name": "Dormant Gomazoa",
             "text": "Flying\nDormant Gomazoa enters the battlefield tapped.\nDormant Gomazoa doesn't untap during your untap step.\nWhenever you become the target of a spell, you may untap Dormant Gomazoa.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "468cc1ae-4264-571e-ade8-ca359f459ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f7334-658d-44da-a81c-26b258e44c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f7334-658d-44da-a81c-26b258e44c26.jpg?1",
             "name": "Drake Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has flying.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "4898f809-5f39-50bc-8474-35fbbec7e167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb327b4-01b0-468c-9916-129c7c64341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb327b4-01b0-468c-9916-129c7c64341d.jpg?1",
             "name": "Echo Mage",
             "text": "Level up {1}{U} ({1}{U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n2/4\n{U}{U}, {T}: Copy target instant or sorcery spell. You may choose new targets for the copy.\nLEVEL 4+\n2/5\n{U}{U}, {T}: Copy target instant or sorcery spell twice. You may choose new targets for the copies.",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "b3336c47-c42f-5c14-994e-705bfff35868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca550605-a0fc-4392-b8b6-a4f06868d9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca550605-a0fc-4392-b8b6-a4f06868d9f2.jpg?1",
             "name": "Eel Umbra",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +1/+1.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "ffe14e5f-5e65-5fd3-9f29-fa291ce7d390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d3b541-40aa-469e-be97-20496a7632d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d3b541-40aa-469e-be97-20496a7632d4.jpg?1",
             "name": "Enclave Cryptologist",
             "text": "Level up {1}{U} ({1}{U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n0/1\n{T}: Draw a card, then discard a card.\nLEVEL 3+\n0/1\n{T}: Draw a card.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "b95cd3ac-9e14-51dc-9930-8480464e64b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed843c4d-28b5-4a4c-8bae-8f03f329bf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed843c4d-28b5-4a4c-8bae-8f03f329bf2b.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "f6d3228c-ad04-56fb-861d-2577720b8ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ec9a28-3b36-4b6a-b420-7b4266b64f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ec9a28-3b36-4b6a-b420-7b4266b64f69.jpg?1",
             "name": "Frostwind Invoker",
             "text": "Flying\n{8}: Creatures you control gain flying until end of turn.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "6c15804c-0d94-5f93-b37c-2440c10486b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg?1",
             "name": "Gravitational Shift",
             "text": "Creatures with flying get +2/+0.\nCreatures without flying get -2/-0.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "f58e406c-b010-5d2a-a00a-313b5122fcaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523e59a-91f7-4893-a4fe-8814a745b422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523e59a-91f7-4893-a4fe-8814a745b422.jpg?1",
             "name": "Guard Gomazoa",
             "text": "Defender, flying\nPrevent all combat damage that would be dealt to Guard Gomazoa.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "f05c33b1-f344-5ea4-936a-1b85e82f3b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb6af-1727-4fa9-938f-13962efadd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb6af-1727-4fa9-938f-13962efadd74.jpg?1",
             "name": "Hada Spy Patrol",
             "text": "Level up {2}{U} ({2}{U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n2/2\nHada Spy Patrol is unblockable.\nLEVEL 3+\n3/3\nShroud\nHada Spy Patrol is unblockable.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "dd1dbf66-b43b-5d0b-a485-9a8a73f62027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff68d2f-6758-45ee-8109-4e8909f49de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff68d2f-6758-45ee-8109-4e8909f49de8.jpg?1",
             "name": "Halimar Wavewatch",
             "text": "Level up {2} ({2}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n0/6\n\nLEVEL 5+\n6/6\nIslandwalk",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "1f6d50b3-7cfd-518f-ad6b-46e4914b3c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04129038-3b02-418a-862a-229e9dde339b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04129038-3b02-418a-862a-229e9dde339b.jpg?1",
             "name": "Jwari Scuttler",
             "text": "",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "8a222f2f-906e-597a-aa28-8d8ee47b069e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0454c2a8-b17d-4cdf-8562-9a28bc6cf0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0454c2a8-b17d-4cdf-8562-9a28bc6cf0be.jpg?1",
             "name": "Lay Bare",
             "text": "Counter target spell. Look at its controller's hand.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "d54a7f1c-9bd9-51fa-ba81-bc947048c4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3087f7e7-9163-45b5-907d-7667c1075a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3087f7e7-9163-45b5-907d-7667c1075a74.jpg?1",
             "name": "Lighthouse Chronologist",
             "text": "Level up {U} ({U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 4-6\n2/4\n\nLEVEL 7+\n3/5\nAt the beginning of each end step, if it's not your turn, take an extra turn after this one.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "4f51809c-9f24-5342-a3fe-4e833b680092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fa8c72-320b-4a7e-9181-bad7ec0c865c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fa8c72-320b-4a7e-9181-bad7ec0c865c.jpg?1",
             "name": "Merfolk Observer",
             "text": "When Merfolk Observer enters the battlefield, look at the top card of target player's library.",
             "colours": [
@@ -2538,7 +2538,7 @@
         },
         {
             "id": "bf998952-3358-5352-ade7-8754c34d2c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce213c7-7835-4b81-a983-059dd97b0214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce213c7-7835-4b81-a983-059dd97b0214.jpg?1",
             "name": "Merfolk Skyscout",
             "text": "Flying\nWhenever Merfolk Skyscout attacks or blocks, untap target permanent.",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "0a513dae-62ec-52e5-b486-5fd84abec5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaebb4a-cb9b-4ac8-b661-3e63d9d984f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaebb4a-cb9b-4ac8-b661-3e63d9d984f4.jpg?1",
             "name": "Mnemonic Wall",
             "text": "Defender\nWhen Mnemonic Wall enters the battlefield, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "477e0ae4-6441-5bf4-8ef8-bc5a6fb60751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88e502e-2421-46fb-b880-a9000930e6d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88e502e-2421-46fb-b880-a9000930e6d9.jpg?1",
             "name": "Narcolepsy",
             "text": "Enchant creature\nAt the beginning of each upkeep, if enchanted creature is untapped, tap it.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "21d4b1f0-0658-562c-8e09-68227fa24233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d9c83f-ddd2-4929-887f-9df6155c4b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d9c83f-ddd2-4929-887f-9df6155c4b82.jpg?1",
             "name": "Phantasmal Abomination",
             "text": "Defender\nWhen Phantasmal Abomination becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "3bfcf047-e615-5c2d-9472-29347e998291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec85a97d-4f02-4d0d-ab9a-e172e327da0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec85a97d-4f02-4d0d-ab9a-e172e327da0e.jpg?1",
             "name": "Reality Spasm",
             "text": "Choose one \u2014 Tap X target permanents; or untap X target permanents.",
             "colours": [
@@ -2707,7 +2707,7 @@
         },
         {
             "id": "d1254d85-f424-57a7-81b4-d2f1b2f469a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db92d00c-e5eb-4e69-9ebc-fec6d9c0f71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db92d00c-e5eb-4e69-9ebc-fec6d9c0f71e.jpg?1",
             "name": "Recurring Insight",
             "text": "Draw cards equal to the number of cards in target opponent's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "b396c136-3377-50e5-a7ae-9edf1beec64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7aba8e0-34e7-43ec-bce5-b6b472daa841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7aba8e0-34e7-43ec-bce5-b6b472daa841.jpg?1",
             "name": "Regress",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "db15c2c2-9635-5c96-8768-c41657aec271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6453040-38a3-4d3a-8e4b-51b72aa80186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6453040-38a3-4d3a-8e4b-51b72aa80186.jpg?1",
             "name": "Renegade Doppelganger",
             "text": "Whenever another creature enters the battlefield under your control, you may have Renegade Doppelganger become a copy of that creature until end of turn. (If it does, it loses this ability for the rest of the turn.)",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "43482d97-1431-5c9b-80ab-4e6edf905ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd056c91-5026-41ea-bc9e-68078d78ca82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd056c91-5026-41ea-bc9e-68078d78ca82.jpg?1",
             "name": "Sea Gate Oracle",
             "text": "When Sea Gate Oracle enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "39f6d895-4f39-54d9-bc6b-5602f5af900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7242e6e-b2e6-42f5-b611-3e8e0dfc0b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7242e6e-b2e6-42f5-b611-3e8e0dfc0b6b.jpg?1",
             "name": "See Beyond",
             "text": "Draw two cards, then shuffle a card from your hand into your library.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "bea58510-a620-50d1-87ec-97c9f28c7103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0b99f1-d706-4332-a1c2-86d789919069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0b99f1-d706-4332-a1c2-86d789919069.jpg?1",
             "name": "Shared Discovery",
             "text": "As an additional cost to cast Shared Discovery, tap four untapped creatures you control.\nDraw three cards.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "c684724c-48ff-52b1-89ba-ee8272997d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be61e893-4bf5-4550-83f4-42ebe7f1e3b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be61e893-4bf5-4550-83f4-42ebe7f1e3b0.jpg?1",
             "name": "Skywatcher Adept",
             "text": "Level up {3} ({3}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n2/2\nFlying\nLEVEL 3+\n4/2\nFlying",
             "colours": [
@@ -2939,7 +2939,7 @@
         },
         {
             "id": "83212856-03ac-53d7-ad21-a9f77c141b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff88609-f55e-45c5-be10-087d88789a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff88609-f55e-45c5-be10-087d88789a83.jpg?1",
             "name": "Sphinx of Magosi",
             "text": "Flying\n{2}{U}: Draw a card, then put a +1/+1 counter on Sphinx of Magosi.",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "9192d5cd-abb3-5f0a-9263-7a78bfd813bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4199be-e1ec-4f0e-a31f-29a7007128a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4199be-e1ec-4f0e-a31f-29a7007128a5.jpg?1",
             "name": "Surrakar Spellblade",
             "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Surrakar Spellblade.\nWhenever Surrakar Spellblade deals combat damage to a player, you may draw X cards, where X is the number of charge counters on it.",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "49e82b1f-b3d1-5440-b1ee-cd05e3f74318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cf16f8-6e69-46b3-8453-1d1a2a5670e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cf16f8-6e69-46b3-8453-1d1a2a5670e2.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost up to {2} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "ac67c7fd-c8bd-517e-8d9f-836b2e6b95aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb50db7-f1d4-4f9d-ac60-564398af79ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb50db7-f1d4-4f9d-ac60-564398af79ea.jpg?1",
             "name": "Unified Will",
             "text": "Counter target spell if you control more creatures than that spell's controller.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "84c25a3c-051a-5309-805f-7634208f2359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec4d902-8841-4f37-9b07-9e8d0f671071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec4d902-8841-4f37-9b07-9e8d0f671071.jpg?1",
             "name": "Venerated Teacher",
             "text": "When Venerated Teacher enters the battlefield, put two level counters on each creature you control with level up.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "4c6487c2-24c4-514c-927f-9dbe205e8385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed08a7f-6682-46a4-89df-b9b418df3f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed08a7f-6682-46a4-89df-b9b418df3f1a.jpg?1",
             "name": "Arrogant Bloodlord",
             "text": "Whenever Arrogant Bloodlord blocks or becomes blocked by a creature with power 1 or less, destroy Arrogant Bloodlord at end of combat.",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "54c47d6d-fc4c-5f6d-87b9-ed8936778565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acb66bd-6abd-46dd-a272-09bea66e2917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acb66bd-6abd-46dd-a272-09bea66e2917.jpg?1",
             "name": "Bala Ged Scorpion",
             "text": "When Bala Ged Scorpion enters the battlefield, you may destroy target creature with power 1 or less.",
             "colours": [
@@ -3175,7 +3175,7 @@
         },
         {
             "id": "bfc318a1-0396-5e27-acc0-6af7fe460fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff6e03-b6af-4f54-b365-9a6db2dbb595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff6e03-b6af-4f54-b365-9a6db2dbb595.jpg?1",
             "name": "Baneful Omen",
             "text": "At the beginning of your end step, you may reveal the top card of your library. If you do, each opponent loses life equal to that card's converted mana cost.",
             "colours": [
@@ -3207,7 +3207,7 @@
         },
         {
             "id": "b1026154-2251-59f4-966b-ab1d0b967f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc36f94-2499-4d94-a506-27d42b9da667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc36f94-2499-4d94-a506-27d42b9da667.jpg?1",
             "name": "Bloodrite Invoker",
             "text": "{8}: Target player loses 3 life and you gain 3 life.",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "674b0da5-4ac6-5548-8bd9-dc95311a383f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bf0233-1d2e-40cb-9a69-8eeeeb2959ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bf0233-1d2e-40cb-9a69-8eeeeb2959ca.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "6aebd0ee-f1bc-5d84-9cea-66c81d315ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f83d5-9269-4297-b507-558c2bdec32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f83d5-9269-4297-b507-558c2bdec32b.jpg?1",
             "name": "Cadaver Imp",
             "text": "Flying\nWhen Cadaver Imp enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "0bd7b3d1-e596-5d31-8ffd-46c930e48a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921ebea0-48bf-4338-9e84-2cd06ffe6f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921ebea0-48bf-4338-9e84-2cd06ffe6f4b.jpg?1",
             "name": "Consume the Meek",
             "text": "Destroy each creature with converted mana cost 3 or less. They can't be regenerated.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "38c5da70-bde2-54cb-8539-fb237a728a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008de17e-aa79-4d4c-ab66-d516eca49e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008de17e-aa79-4d4c-ab66-d516eca49e42.jpg?1",
             "name": "Consuming Vapors",
             "text": "Target player sacrifices a creature. You gain life equal to that creature's toughness.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "5ac95cfb-0700-512a-9087-136121d3dc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2ba8f3-58f5-43e5-9201-974ba58f56f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2ba8f3-58f5-43e5-9201-974ba58f56f8.jpg?1",
             "name": "Contaminated Ground",
             "text": "Enchant land\nEnchanted land is a Swamp.\nWhenever enchanted land becomes tapped, its controller loses 2 life.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "359c0f47-5d73-5cf1-a8b8-ef8db1cddf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c152d-1829-438c-b571-74361e09df62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c152d-1829-438c-b571-74361e09df62.jpg?1",
             "name": "Corpsehatch",
             "text": "Destroy target nonblack creature. Put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "a14d259f-0865-50f0-a603-af653a5617b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162535ea-87be-4ea7-a006-b63ae981f453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162535ea-87be-4ea7-a006-b63ae981f453.jpg?1",
             "name": "Curse of Wizardry",
             "text": "As Curse of Wizardry enters the battlefield, choose a color.\nWhenever a player casts a spell of the chosen color, that player loses 1 life.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "88b8fbaf-2a26-54ca-9296-6cc5552b2200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a2fe3-45ab-4bac-aca7-a6418e28d0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a2fe3-45ab-4bac-aca7-a6418e28d0be.jpg?1",
             "name": "Death Cultist",
             "text": "Sacrifice Death Cultist: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3507,7 +3507,7 @@
         },
         {
             "id": "9be799c9-85e9-544a-9930-1260cc409613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca51786a-d58c-455f-910d-01efa5ef8470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca51786a-d58c-455f-910d-01efa5ef8470.jpg?1",
             "name": "Demonic Appetite",
             "text": "Enchant creature you control\nEnchanted creature gets +3/+3.\nAt the beginning of your upkeep, sacrifice a creature.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "e118bda5-c585-5ce6-993f-b87c56d665f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca8d295-e8e9-4213-bc9b-f1acf57fb520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca8d295-e8e9-4213-bc9b-f1acf57fb520.jpg?1",
             "name": "Drana, Kalastria Bloodchief",
             "text": "Flying\n{X}{B}{B}: Target creature gets -0/-X until end of turn and Drana, Kalastria Bloodchief gets +X/+0 until end of turn.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "3bfa8c34-70fe-5ee2-9db5-7ea3b35c4b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d65339-e419-40b9-814a-374874f5585f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d65339-e419-40b9-814a-374874f5585f.jpg?1",
             "name": "Dread Drone",
             "text": "When Dread Drone enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "b4a2290b-8ab5-5114-84c4-fbd4b8d9fdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364dbe9-ee9a-4dcc-b058-4e669c75f060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364dbe9-ee9a-4dcc-b058-4e669c75f060.jpg?1",
             "name": "Escaped Null",
             "text": "Lifelink\nWhenever Escaped Null blocks or becomes blocked, it gets +5/+0 until end of turn.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "9098564a-1082-5cd2-8b73-d088fa874843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf2116-7ae5-4b6a-830a-919a55235690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf2116-7ae5-4b6a-830a-919a55235690.jpg?1",
             "name": "Essence Feed",
             "text": "Target player loses 3 life. You gain 3 life and put three 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3680,7 +3680,7 @@
         },
         {
             "id": "b84af5b4-acb4-5389-865b-8dc602d638cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db4317-9850-44c1-884b-d8d3abe1afeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db4317-9850-44c1-884b-d8d3abe1afeb.jpg?1",
             "name": "Gloomhunter",
             "text": "Flying",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "3a89c619-691a-5926-807d-3c538aa2409b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de01ef-cdf2-44ad-bf2f-a927d82a4f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de01ef-cdf2-44ad-bf2f-a927d82a4f72.jpg?1",
             "name": "Guul Draz Assassin",
             "text": "Level up {1}{B} ({1}{B}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n2/2\n{B}, {T}: Target creature gets -2/-2 until end of turn.\nLEVEL 4+\n4/4\n{B}, {T}: Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "afd18131-6d0a-55da-ba45-c88c7534562c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984a037b-63c0-497d-b3b1-15726ef11a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984a037b-63c0-497d-b3b1-15726ef11a60.jpg?1",
             "name": "Hellcarver Demon",
             "text": "Flying\nWhenever Hellcarver Demon deals combat damage to a player, sacrifice all other permanents you control and discard your hand. Exile the top six cards of your library. You may cast any number of nonland cards exiled this way without paying their mana costs.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "03fd8773-3984-599d-bc1f-b53da722ce06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0c6980-a371-4cb5-b684-3ebddd4890f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0c6980-a371-4cb5-b684-3ebddd4890f8.jpg?1",
             "name": "Induce Despair",
             "text": "As an additional cost to cast Induce Despair, reveal a creature card from your hand.\nTarget creature gets -X/-X until end of turn, where X is the revealed card's converted mana cost.",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "a14f1e62-e4b9-517b-89a9-9bcc0fa65610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3ff5c3-0fdb-4d54-b4e5-ce7bad9953f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3ff5c3-0fdb-4d54-b4e5-ce7bad9953f0.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals his or her hand. You choose a nonland card from it with converted mana cost 3 or less. That player discards that card.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "d40a907b-2cbd-5483-89fb-418e44757d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f480f-8f68-4060-b964-f67515930549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f480f-8f68-4060-b964-f67515930549.jpg?1",
             "name": "Last Kiss",
             "text": "Last Kiss deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "11d7ae93-b9c5-5e81-890a-5f6fc8884d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19ee3e4-5f76-4c28-bee6-f1c063ec0cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19ee3e4-5f76-4c28-bee6-f1c063ec0cb3.jpg?1",
             "name": "Mortician Beetle",
             "text": "Whenever a player sacrifices a creature, you may put a +1/+1 counter on Mortician Beetle.",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "47e901f1-026f-5ca9-9403-49770c56eb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290b215b-13cb-493a-83f9-f89edfa6b314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290b215b-13cb-493a-83f9-f89edfa6b314.jpg?1",
             "name": "Nighthaze",
             "text": "Target creature gains swampwalk until end of turn.\nDraw a card.",
             "colours": [
@@ -3945,7 +3945,7 @@
         },
         {
             "id": "bbd586c3-9668-56a8-8cee-9a9ebe483b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341f4ea1-8101-4e2e-b824-4b0e88ea71f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341f4ea1-8101-4e2e-b824-4b0e88ea71f1.jpg?1",
             "name": "Nirkana Cutthroat",
             "text": "Level up {2}{B} ({2}{B}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n4/3\nDeathtouch\nLEVEL 3+\n5/4\nFirst strike, deathtouch",
             "colours": [
@@ -3980,7 +3980,7 @@
         },
         {
             "id": "aea6cdba-3769-5f27-8f50-dde173af054a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7c53cf-d314-4f60-bb5b-cf5068ed9915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7c53cf-d314-4f60-bb5b-cf5068ed9915.jpg?1",
             "name": "Nirkana Revenant",
             "text": "Whenever you tap a Swamp for mana, add {B} to your mana pool (in addition to the mana the land produces).\n{B}: Nirkana Revenant gets +1/+1 until end of turn.",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "1a098c93-4d08-5215-acba-b7ef0245c43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf39e84-a554-49e3-8f65-e304e1720818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf39e84-a554-49e3-8f65-e304e1720818.jpg?1",
             "name": "Null Champion",
             "text": "Level up {3} ({3}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n4/2\n\nLEVEL 4+\n7/3\n{B}: Regenerate Null Champion.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "1471a0dd-b18d-5c1b-a848-3671e43e8082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4d77d-e0de-48fe-899b-5718cee779e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4d77d-e0de-48fe-899b-5718cee779e2.jpg?1",
             "name": "Pawn of Ulamog",
             "text": "Whenever Pawn of Ulamog or another nontoken creature you control is put into a graveyard from the battlefield, you may put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "a8dbf36c-4609-5d79-9161-139bebdb97ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1dd413-6e5a-4e36-b1b0-eca39e132e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1dd413-6e5a-4e36-b1b0-eca39e132e38.jpg?1",
             "name": "Perish the Thought",
             "text": "Target opponent reveals his or her hand. You choose a card from it. That player shuffles that card into his or her library.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "1ed83589-59d7-525a-9564-e8cddafb5aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6931673-20e0-410e-bc2a-d14efa2b488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6931673-20e0-410e-bc2a-d14efa2b488a.jpg?1",
             "name": "Pestilence Demon",
             "text": "Flying\n{B}: Pestilence Demon deals 1 damage to each creature and each player.",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "85066470-fc57-5bf4-8855-abd41df42110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d1db4c-1e79-410a-92ab-c9d58c5e58a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d1db4c-1e79-410a-92ab-c9d58c5e58a6.jpg?1",
             "name": "Repay in Kind",
             "text": "Each player's life total becomes the lowest life total among all players.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "85e5776c-8e33-5874-b70f-85e8a4b02321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c80a1-5818-45fd-9a37-a2ee3396626e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c80a1-5818-45fd-9a37-a2ee3396626e.jpg?1",
             "name": "Shrivel",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "66095e06-f2c4-5fa4-9d70-b1d05595ae08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feedcf2-c443-4363-80cf-a90579a64342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feedcf2-c443-4363-80cf-a90579a64342.jpg?1",
             "name": "Skeletal Wurm",
             "text": "{B}: Regenerate Skeletal Wurm.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "eed220a5-98a1-5df7-835c-0fc56a571543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e959ec-7ba2-429d-a5b9-b5e4d97dfd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e959ec-7ba2-429d-a5b9-b5e4d97dfd4e.jpg?1",
             "name": "Suffer the Past",
             "text": "Exile X target cards from target player's graveyard. For each card exiled this way, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "2293ffd6-376b-57be-a6eb-7226d56661eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b6b512-6252-4899-bb9c-5c304f37d10a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b6b512-6252-4899-bb9c-5c304f37d10a.jpg?1",
             "name": "Thought Gorger",
             "text": "Trample\nWhen Thought Gorger enters the battlefield, put a +1/+1 counter on it for each card in your hand. If you do, discard your hand.\nWhen Thought Gorger leaves the battlefield, draw a card for each +1/+1 counter on it.",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "ef3f0e10-1d09-5ef1-9f6a-40f643a818bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039fc76d-3b7e-4329-a997-07c25509e421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039fc76d-3b7e-4329-a997-07c25509e421.jpg?1",
             "name": "Vendetta",
             "text": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "6adf4227-85dc-5774-bb38-cfe4b0f53008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61d7f4b-e3c3-49f1-a600-6e6ac71a5515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61d7f4b-e3c3-49f1-a600-6e6ac71a5515.jpg?1",
             "name": "Virulent Swipe",
             "text": "Target creature gets +2/+0 and gains deathtouch until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "925ad53b-623e-5b90-9c72-263011db74ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46976d4-7266-4359-bf7a-7e81983ae6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46976d4-7266-4359-bf7a-7e81983ae6e3.jpg?1",
             "name": "Zof Shade",
             "text": "{2}{B}: Zof Shade gets +2/+2 until end of turn.",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "7baba623-85cf-5357-bf9d-991f2582b87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975d18a-df3f-4c1f-8fde-d11dabbc4adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975d18a-df3f-4c1f-8fde-d11dabbc4adc.jpg?1",
             "name": "Zulaport Enforcer",
             "text": "Level up {4} ({4}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n3/3\n\nLEVEL 3+\n5/5\nZulaport Enforcer can't be blocked except by black creatures.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "cb384cf2-4571-5696-8531-32b99247d458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e8f7b6-1214-447b-8665-ff3c85845564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e8f7b6-1214-447b-8665-ff3c85845564.jpg?1",
             "name": "Akoum Boulderfoot",
             "text": "When Akoum Boulderfoot enters the battlefield, it deals 1 damage to target creature or player.",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "694cc0ef-7fcc-5214-98a5-fd192cb31c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223ec005-e089-4dd4-85dc-2998bff56b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223ec005-e089-4dd4-85dc-2998bff56b75.jpg?1",
             "name": "Battle Rampart",
             "text": "Defender\n{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "0c78e3e2-b4f0-5510-bcd2-918fe4e16132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1df08a-ccef-44cf-936a-838e238c27c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1df08a-ccef-44cf-936a-838e238c27c1.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "ce3d381c-bf67-58f0-bcc4-8062e4e769f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f65ebef-e159-4698-8852-650b7b6a08d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f65ebef-e159-4698-8852-650b7b6a08d3.jpg?1",
             "name": "Brimstone Mage",
             "text": "Level up {3}{R} ({3}{R}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n2/3\n{T}: Brimstone Mage deals 1 damage to target creature or player.\nLEVEL 3+\n2/4\n{T}: Brimstone Mage deals 3 damage to target creature or player.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "ffcb0745-08fd-50a7-b29e-892bda2e7253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e44f7ff-1cfa-4bc4-a0f7-9d71ba48a97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e44f7ff-1cfa-4bc4-a0f7-9d71ba48a97a.jpg?1",
             "name": "Brood Birthing",
             "text": "If you control an Eldrazi Spawn, put three 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\" Otherwise, put one of those tokens onto the battlefield.",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "92f87f72-df7c-525c-96ed-59927a6b8624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1dc898-bf60-406f-922a-aa50cbffe5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1dc898-bf60-406f-922a-aa50cbffe5b0.jpg?1",
             "name": "Conquering Manticore",
             "text": "Flying\nWhen Conquering Manticore enters the battlefield, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "717535ee-be5b-501c-97c6-3dc78ff693e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b09784-8e89-4013-975d-57e4d26cc926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b09784-8e89-4013-975d-57e4d26cc926.jpg?1",
             "name": "Devastating Summons",
             "text": "As an additional cost to cast Devastating Summons, sacrifice X lands.\nPut two X/X red Elemental creature tokens onto the battlefield.",
             "colours": [
@@ -4686,7 +4686,7 @@
         },
         {
             "id": "24d92dd0-2aa8-58c7-98b5-ffe9e1654225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9318ae4a-1084-49d9-b5de-dbe4d80836cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9318ae4a-1084-49d9-b5de-dbe4d80836cb.jpg?1",
             "name": "Disaster Radius",
             "text": "As an additional cost to cast Disaster Radius, reveal a creature card from your hand.\nDisaster Radius deals X damage to each creature your opponents control, where X is the revealed card's converted mana cost.",
             "colours": [
@@ -4718,7 +4718,7 @@
         },
         {
             "id": "b14b47fd-667f-52b3-ab40-64eb8f9c23ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a901c3f-313d-495e-96a0-29f1a33b8225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a901c3f-313d-495e-96a0-29f1a33b8225.jpg?1",
             "name": "Emrakul's Hatcher",
             "text": "When Emrakul's Hatcher enters the battlefield, put three 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "b55ca80c-b582-5626-ba98-f0af7ad209b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a38cd0-2cd3-436d-bb44-79778d5808ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a38cd0-2cd3-436d-bb44-79778d5808ad.jpg?1",
             "name": "Explosive Revelation",
             "text": "Choose target creature or player. Reveal cards from the top of your library until you reveal a nonland card. Explosive Revelation deals damage equal to that card's converted mana cost to that creature or player. Put the nonland card into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "9e94cd68-e02b-5728-905a-eebac88ecad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4f813-f04c-4309-a007-b0549c00d6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4f813-f04c-4309-a007-b0549c00d6ab.jpg?1",
             "name": "Fissure Vent",
             "text": "Choose one or both \u2014 Destroy target artifact; and/or destroy target nonbasic land.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "c6a40375-dd7c-5086-916b-73f3e22ead81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d2bf1-20f7-4b09-8d98-8233d91682bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d2bf1-20f7-4b09-8d98-8233d91682bd.jpg?1",
             "name": "Flame Slash",
             "text": "Flame Slash deals 4 damage to target creature.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "c1f03e3a-78ef-53ac-8a94-dea9eb867052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127297-fdaa-45bf-a82e-4fc61315e0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127297-fdaa-45bf-a82e-4fc61315e0e2.jpg?1",
             "name": "Forked Bolt",
             "text": "Forked Bolt deals 2 damage divided as you choose among one or two target creatures and/or players.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "7bc403bc-663c-5d47-9243-d32989241f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707d396d-950b-4ab8-9db2-f40c8f7db062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707d396d-950b-4ab8-9db2-f40c8f7db062.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist is put into a graveyard from the battlefield, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "c8c23c66-0ef5-59ba-a0f6-858903912b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e4a34-6255-4f89-a62d-941996c573e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e4a34-6255-4f89-a62d-941996c573e1.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "2db71ef4-cfe4-570b-8389-1815974f9bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c1a241-38ad-453e-b6c2-a79006031e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c1a241-38ad-453e-b6c2-a79006031e2d.jpg?1",
             "name": "Grotag Siege-Runner",
             "text": "{R}, Sacrifice Grotag Siege-Runner: Destroy target creature with defender. Grotag Siege-Runner deals 2 damage to that creature's controller.",
             "colours": [
@@ -4986,7 +4986,7 @@
         },
         {
             "id": "ec52b5ce-4134-551b-b100-2b9fa23be33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82227287-1774-448b-8c3a-573ddd58cc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82227287-1774-448b-8c3a-573ddd58cc80.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -5018,7 +5018,7 @@
         },
         {
             "id": "155421d6-f41f-5035-93e3-891835f73dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6529c92e-c79b-4953-8bd0-50ceae2ce261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6529c92e-c79b-4953-8bd0-50ceae2ce261.jpg?1",
             "name": "Hellion Eruption",
             "text": "Sacrifice all creatures you control, then put that many 4/4 red Hellion creature tokens onto the battlefield.",
             "colours": [
@@ -5050,7 +5050,7 @@
         },
         {
             "id": "7f0d677d-0547-5beb-918a-6c25bae3ccb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669d2d9-649b-4941-9a76-9833bdf77ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669d2d9-649b-4941-9a76-9833bdf77ca4.jpg?1",
             "name": "Kargan Dragonlord",
             "text": "Level up {R} ({R}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 4-7\n4/4\nFlying\nLEVEL 8+\n8/8\nFlying, trample\n{R}: Kargan Dragonlord gets +1/+0 until end of turn.",
             "colours": [
@@ -5085,7 +5085,7 @@
         },
         {
             "id": "60141b8d-150a-5dea-8c3a-7b2311823b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c584268-67c3-411b-a26c-aee3adf23872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c584268-67c3-411b-a26c-aee3adf23872.jpg?1",
             "name": "Kiln Fiend",
             "text": "Whenever you cast an instant or sorcery spell, Kiln Fiend gets +3/+0 until end of turn.",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "41b7937a-3296-5d34-bf79-5479121ec8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e9cfa-5547-4ef3-9e36-8d0f36dfa59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e9cfa-5547-4ef3-9e36-8d0f36dfa59a.jpg?1",
             "name": "Lagac Lizard",
             "text": "",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "c96c863f-1672-568b-bb25-e60e0daac949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e773b3f-37ef-4e37-8b1e-99b7b6314877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e773b3f-37ef-4e37-8b1e-99b7b6314877.jpg?1",
             "name": "Lavafume Invoker",
             "text": "{8}: Creatures you control get +3/+0 until end of turn.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "f7d566c4-6822-51da-a2de-52a2485b429b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2159a7d-e37a-4c43-a7b9-1e7179a7e43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2159a7d-e37a-4c43-a7b9-1e7179a7e43b.jpg?1",
             "name": "Lord of Shatterskull Pass",
             "text": "Level up {1}{R} ({1}{R}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-5\n6/6\n\nLEVEL 6+\n6/6\nWhenever Lord of Shatterskull Pass attacks, it deals 6 damage to each creature defending player controls.",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "127384f1-9821-57f2-a565-9510a7e145fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fa150-383d-448c-8e14-f24f65e13770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fa150-383d-448c-8e14-f24f65e13770.jpg?1",
             "name": "Lust for War",
             "text": "Enchant creature\nWhenever enchanted creature becomes tapped, Lust for War deals 3 damage to that creature's controller.\nEnchanted creature attacks each turn if able.",
             "colours": [
@@ -5258,7 +5258,7 @@
         },
         {
             "id": "d2eb59d0-6c26-50e0-bd90-796b873baf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015de202-e796-4194-a06b-d74230759f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015de202-e796-4194-a06b-d74230759f38.jpg?1",
             "name": "Magmaw",
             "text": "{1}, Sacrifice a nonland permanent: Magmaw deals 1 damage to target creature or player.",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "f88cf00f-705e-52c9-941a-dd5a80191723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71db75c-c896-4887-ba18-92416fa6cbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71db75c-c896-4887-ba18-92416fa6cbd5.jpg?1",
             "name": "Ogre Sentry",
             "text": "Defender",
             "colours": [
@@ -5327,7 +5327,7 @@
         },
         {
             "id": "7cf64a3d-b004-551c-bd4b-fdf0dcea495c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c213b45-d86b-4ced-9ab9-44cd84ad94a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c213b45-d86b-4ced-9ab9-44cd84ad94a4.jpg?1",
             "name": "Rage Nimbus",
             "text": "Defender, flying\n{1}{R}: Target creature attacks this turn if able.",
             "colours": [
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "d6a525ae-38ff-5616-9f56-ed68f1a5e242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2d1a48-efde-4134-95f0-b23f6cf85259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2d1a48-efde-4134-95f0-b23f6cf85259.jpg?1",
             "name": "Raid Bombardment",
             "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to defending player.",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "792a202b-6051-5af9-abd9-6c801fb75c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3befaa0-55a3-4e34-8051-1ab19eabd7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3befaa0-55a3-4e34-8051-1ab19eabd7d2.jpg?1",
             "name": "Rapacious One",
             "text": "Trample\nWhenever Rapacious One deals combat damage to a player, put that many 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5428,7 +5428,7 @@
         },
         {
             "id": "2003ba06-2bbc-5ab9-9efb-d63bf80480d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dcb81b-dcdb-44ca-9ef5-0b45d276c0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dcb81b-dcdb-44ca-9ef5-0b45d276c0dd.jpg?1",
             "name": "Soulsurge Elemental",
             "text": "First strike\nSoulsurge Elemental's power is equal to the number of creatures you control.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "f0cd56d0-4b3f-5716-b186-13cb2d2e1c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ec1540-e8cb-4edc-a3b3-f71423cb46fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ec1540-e8cb-4edc-a3b3-f71423cb46fc.jpg?1",
             "name": "Spawning Breath",
             "text": "Spawning Breath deals 1 damage to target creature or player. Put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5494,7 +5494,7 @@
         },
         {
             "id": "82526226-c84f-5167-8fd2-0c559b214e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8f22fb-7291-4517-9b15-e98501f2856b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8f22fb-7291-4517-9b15-e98501f2856b.jpg?1",
             "name": "Splinter Twin",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put a token that's a copy of this creature onto the battlefield. That token has haste. Exile it at the beginning of the next end step.\"",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "ce859abe-90f7-5b33-9dc5-7fd1c56523f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75624ab3-ddbd-4fe8-8a07-7d1f78ec8a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75624ab3-ddbd-4fe8-8a07-7d1f78ec8a84.jpg?1",
             "name": "Staggershock",
             "text": "Staggershock deals 2 damage to target creature or player.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "11c0f120-33dc-5b22-9a6b-e27c78ce603c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9108d6-d103-47f5-98ed-0d0d7564d328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9108d6-d103-47f5-98ed-0d0d7564d328.jpg?1",
             "name": "Surreal Memoir",
             "text": "Return an instant card at random from your graveyard to your hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -5592,7 +5592,7 @@
         },
         {
             "id": "c177efbe-173b-5ea0-b9d1-f4ea68a0a7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b63ea-e3c3-465d-8cd9-7251cda9cc63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b63ea-e3c3-465d-8cd9-7251cda9cc63.jpg?1",
             "name": "Traitorous Instinct",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "6efa287c-a208-5870-9827-886bfa7fb84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd23ab54-1eec-4bb4-81ce-b5cbe83fa940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd23ab54-1eec-4bb4-81ce-b5cbe83fa940.jpg?1",
             "name": "Tuktuk the Explorer",
             "text": "Haste\nWhen Tuktuk the Explorer is put into a graveyard from the battlefield, put a legendary 5/5 colorless Goblin Golem artifact creature token named Tuktuk the Returned onto the battlefield.",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "adf94f4d-38a1-55fa-a321-66a7e7c66c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5718b282-d3e9-4c68-8623-9ea8a3c937d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5718b282-d3e9-4c68-8623-9ea8a3c937d0.jpg?1",
             "name": "Valakut Fireboar",
             "text": "Whenever Valakut Fireboar attacks, switch its power and toughness until end of turn.",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "3761729b-0620-5f1b-8bbc-8e59b7bd6c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07989612-d3c4-44f7-b1ee-1ddf2d93a7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07989612-d3c4-44f7-b1ee-1ddf2d93a7da.jpg?1",
             "name": "Vent Sentinel",
             "text": "Defender\n{1}{R}, {T}: Vent Sentinel deals damage to target player equal to the number of creatures with defender you control.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "549b9c8b-093c-588c-8552-c8f27cb59ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47a05ad-fe86-481e-b770-e1760be4f852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47a05ad-fe86-481e-b770-e1760be4f852.jpg?1",
             "name": "World at War",
             "text": "After the first postcombat main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "252a5eb5-685b-5146-8812-8cd8e03bd4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babdaf80-f9a3-42cb-9df6-10878301f335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babdaf80-f9a3-42cb-9df6-10878301f335.jpg?1",
             "name": "Wrap in Flames",
             "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "cc7325d7-3b21-55c2-a3f1-55b8306d348a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ac2766-a597-4949-882d-c5e61e6dd268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ac2766-a597-4949-882d-c5e61e6dd268.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order. (Cards with no colored mana in their mana costs are colorless. Lands are also colorless.)",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "4b841832-1d52-5262-afb3-fb2c3bc0b558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8dbb4f-4b01-4666-b62f-a2323dac7a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8dbb4f-4b01-4666-b62f-a2323dac7a19.jpg?1",
             "name": "Aura Gnarlid",
             "text": "Creatures with power less than Aura Gnarlid's power can't block it.\nAura Gnarlid gets +1/+1 for each Aura on the battlefield.",
             "colours": [
@@ -5859,7 +5859,7 @@
         },
         {
             "id": "d449c934-e2fe-519c-bd06-08c1fc1a5671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080dbd69-95a8-4fed-bbaf-875a8a34a2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080dbd69-95a8-4fed-bbaf-875a8a34a2c9.jpg?1",
             "name": "Awakening Zone",
             "text": "At the beginning of your upkeep, you may put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "4a4558e9-5718-5e4b-99fc-9deecdc66400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a953b-3205-41bf-a5b2-5b852e889c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a953b-3205-41bf-a5b2-5b852e889c5a.jpg?1",
             "name": "Bear Umbra",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"Whenever this creature attacks, untap all lands you control.\"\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5925,7 +5925,7 @@
         },
         {
             "id": "90b78804-b91b-5f4a-8b47-e0931716c5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24c2406-ba46-428b-9d5c-38954818edc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24c2406-ba46-428b-9d5c-38954818edc0.jpg?1",
             "name": "Beastbreaker of Bala Ged",
             "text": "Level up {2}{G} ({2}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n4/4\n\nLEVEL 4+\n6/6\nTrample",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "260d9c28-ce51-5e2b-bf02-57f44171288d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfdec4f-e66a-48f8-ba6d-13459e80b52c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfdec4f-e66a-48f8-ba6d-13459e80b52c.jpg?1",
             "name": "Boar Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "d6efba25-b256-5444-8f96-468669670125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcddd71f-bb8d-4153-854f-af87189babe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcddd71f-bb8d-4153-854f-af87189babe7.jpg?1",
             "name": "Bramblesnap",
             "text": "Trample\nTap an untapped creature you control: Bramblesnap gets +1/+1 until end of turn.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "b3403270-5f2c-5db1-84f5-5c18cf937720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a1ca42-0fb1-4962-8663-39fc07443aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a1ca42-0fb1-4962-8663-39fc07443aef.jpg?1",
             "name": "Broodwarden",
             "text": "Eldrazi Spawn creatures you control get +2/+1.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "29ee7782-955f-5e0a-8739-029b18b90e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4343cb0-6490-496c-9d58-ac1f7d3a91c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4343cb0-6490-496c-9d58-ac1f7d3a91c6.jpg?1",
             "name": "Daggerback Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "f0b8a2ba-d0ac-55fc-9019-e4a046e73ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea40dc5-de1b-4d2b-ae0e-df8e52876647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea40dc5-de1b-4d2b-ae0e-df8e52876647.jpg?1",
             "name": "Gelatinous Genesis",
             "text": "Put X X/X green Ooze creature tokens onto the battlefield.",
             "colours": [
@@ -6129,7 +6129,7 @@
         },
         {
             "id": "d352ed1c-9e16-5b15-bdfa-b3af97e1fa03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af25e35c-d1a4-4c10-8574-82babaaac4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af25e35c-d1a4-4c10-8574-82babaaac4fd.jpg?1",
             "name": "Gigantomancer",
             "text": "{1}: Target creature you control becomes 7/7 until end of turn.",
             "colours": [
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "f45c1802-099f-5b1f-9f72-7bb452aa8f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb13d0-1a62-4acd-9267-3b2df4b6a199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb13d0-1a62-4acd-9267-3b2df4b6a199.jpg?1",
             "name": "Gravity Well",
             "text": "Whenever a creature with flying attacks, it loses flying until end of turn.",
             "colours": [
@@ -6196,7 +6196,7 @@
         },
         {
             "id": "f076404a-1be2-5f0e-83d2-85e7b126b0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6a649-ae48-4cf1-b0e3-ba627b4ac1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6a649-ae48-4cf1-b0e3-ba627b4ac1e1.jpg?1",
             "name": "Growth Spasm",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -6228,7 +6228,7 @@
         },
         {
             "id": "40bbb7e0-ac56-50a3-9fb6-ec2f4ab7cfcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8e000-5b4c-4340-ab85-7522107ab589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8e000-5b4c-4340-ab85-7522107ab589.jpg?1",
             "name": "Haze Frog",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Haze Frog enters the battlefield, prevent all combat damage that other creatures would deal this turn.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "bf026018-e684-5bc8-a431-75f466adda57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1511d4d-3e70-4688-ab88-37e26cb1a46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1511d4d-3e70-4688-ab88-37e26cb1a46f.jpg?1",
             "name": "Irresistible Prey",
             "text": "Target creature must be blocked this turn if able.\nDraw a card.",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "f8113c31-297f-5158-9487-512efaf35813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22144b6f-e8a8-4fcb-ac2b-83693481ffba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22144b6f-e8a8-4fcb-ac2b-83693481ffba.jpg?1",
             "name": "Jaddi Lifestrider",
             "text": "When Jaddi Lifestrider enters the battlefield, you may tap any number of untapped creatures you control. You gain 2 life for each creature tapped this way.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "5989bc5b-2c14-5977-ab5b-4a25cf624339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1132218d-56cd-441e-9006-df3c50344491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1132218d-56cd-441e-9006-df3c50344491.jpg?1",
             "name": "Joraga Treespeaker",
             "text": "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n1/2\n{T}: Add {G}{G} to your mana pool.\nLEVEL 5+\n1/4\nElves you control have \"{T}: Add {G}{G} to your mana pool.\"",
             "colours": [
@@ -6363,7 +6363,7 @@
         },
         {
             "id": "3c413416-e9b1-5397-a673-8fb159b17bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54908d58-c7b4-46e1-9cad-3a7ea0bc7a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54908d58-c7b4-46e1-9cad-3a7ea0bc7a6b.jpg?1",
             "name": "Kazandu Tuskcaller",
             "text": "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-5\n1/1\n{T}: Put a 3/3 green Elephant creature token onto the battlefield.\nLEVEL 6+\n1/1\n{T}: Put two 3/3 green Elephant creature tokens onto the battlefield.",
             "colours": [
@@ -6398,7 +6398,7 @@
         },
         {
             "id": "b277e6cf-7316-5625-bb6e-b4480717dbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d27a00e-4402-4410-bab7-ccb34a0de72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d27a00e-4402-4410-bab7-ccb34a0de72f.jpg?1",
             "name": "Khalni Hydra",
             "text": "Khalni Hydra costs {G} less to cast for each green creature you control.\nTrample",
             "colours": [
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "11625c17-8191-5f61-a3bf-3cfec7a1a15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab37d0e-5542-4ae0-a48e-d0a4e6bf48e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab37d0e-5542-4ae0-a48e-d0a4e6bf48e7.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -6467,7 +6467,7 @@
         },
         {
             "id": "73a64c46-a6eb-5e16-ab03-90da5eb889a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d531ba4-df99-41e4-9dd3-a27a420ad63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d531ba4-df99-41e4-9dd3-a27a420ad63c.jpg?1",
             "name": "Leaf Arrow",
             "text": "Leaf Arrow deals 3 damage to target creature with flying.",
             "colours": [
@@ -6499,7 +6499,7 @@
         },
         {
             "id": "e51fbc2d-a650-579f-84b8-81470aaf2560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361399a4-04f3-4eef-8090-2caec7d1bb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361399a4-04f3-4eef-8090-2caec7d1bb66.jpg?1",
             "name": "Living Destiny",
             "text": "As an additional cost to cast Living Destiny, reveal a creature card from your hand.\nYou gain life equal to the revealed card's converted mana cost.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "4cf09b2c-d34e-5a5a-8c80-97ef96cd9597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10465f4f-f4ff-45d8-bc97-3ec85e5eea70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10465f4f-f4ff-45d8-bc97-3ec85e5eea70.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -6563,7 +6563,7 @@
         },
         {
             "id": "3e3681ac-35a2-5de8-b706-12784247c377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0271550a-0610-4e21-849a-f29547a77bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0271550a-0610-4e21-849a-f29547a77bdc.jpg?1",
             "name": "Momentous Fall",
             "text": "As an additional cost to cast Momentous Fall, sacrifice a creature.\nYou draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness.",
             "colours": [
@@ -6595,7 +6595,7 @@
         },
         {
             "id": "d09c7994-6784-5286-b22e-562a300d25c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d362c3b-f9e1-476b-b5fd-d1292bbc257c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d362c3b-f9e1-476b-b5fd-d1292bbc257c.jpg?1",
             "name": "Mul Daya Channelers",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is a creature card, Mul Daya Channelers gets +3/+3.\nAs long as the top card of your library is a land card, Mul Daya Channelers has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -6631,7 +6631,7 @@
         },
         {
             "id": "4261ba57-e778-5d8c-94d1-297ed8cf9be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02618f5-ae78-47a9-855a-65a3408fcba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02618f5-ae78-47a9-855a-65a3408fcba4.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6663,7 +6663,7 @@
         },
         {
             "id": "5d95329e-e4c7-51aa-a31d-e2b015e199ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477e081-949f-4cf0-b0d2-b9bdff6c760d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477e081-949f-4cf0-b0d2-b9bdff6c760d.jpg?1",
             "name": "Nema Siltlurker",
             "text": "",
             "colours": [
@@ -6697,7 +6697,7 @@
         },
         {
             "id": "29e16d30-174e-52a5-9509-82b4857c0d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24517d9c-6cde-41e8-9e82-ee73f069379a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24517d9c-6cde-41e8-9e82-ee73f069379a.jpg?1",
             "name": "Nest Invader",
             "text": "When Nest Invader enters the battlefield, put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "e3a5f2e1-7ac1-5e3e-83b4-7497c64233d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8b1e5-418f-4e64-a2ac-0e03b387ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8b1e5-418f-4e64-a2ac-0e03b387ed33.jpg?1",
             "name": "Ondu Giant",
             "text": "When Ondu Giant enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "293e889f-0378-5ed2-a233-48930112f2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e3d197-e978-4ec6-ab69-3c5fd8ac3fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e3d197-e978-4ec6-ab69-3c5fd8ac3fc1.jpg?1",
             "name": "Overgrown Battlement",
             "text": "Defender\n{T}: Add {G} to your mana pool for each creature with defender you control.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "bb0e2320-83b6-5a56-9d54-e1f03a556797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e732593-0bdc-4dd4-9b07-9aa1a780e6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e732593-0bdc-4dd4-9b07-9aa1a780e6e8.jpg?1",
             "name": "Pelakka Wurm",
             "text": "Trample\nWhen Pelakka Wurm enters the battlefield, you gain 7 life.\nWhen Pelakka Wurm is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "4e59eba0-4f0e-5b6a-91bd-9e854997aad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd0d15f-8200-46a4-a9e9-e7f0ee2aa0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd0d15f-8200-46a4-a9e9-e7f0ee2aa0e4.jpg?1",
             "name": "Prey's Vengeance",
             "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "78ec72a6-b643-5bb2-9b97-73ca7e2efccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8967ceff-9e25-46da-926b-e05f4ee98325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8967ceff-9e25-46da-926b-e05f4ee98325.jpg?1",
             "name": "Realms Uncharted",
             "text": "Search your library for four land cards with different names and reveal them. An opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -6899,7 +6899,7 @@
         },
         {
             "id": "a7497c68-7ee6-565f-8b2c-78c390ec888d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a011820-80c6-484f-84be-f07f0e45f1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a011820-80c6-484f-84be-f07f0e45f1a8.jpg?1",
             "name": "Snake Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals damage to an opponent, you may draw a card.\"\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6933,7 +6933,7 @@
         },
         {
             "id": "afe206ff-cf0e-50f1-8832-9b0a441a1a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e593a5b-0de6-4df2-bbda-54195400dc69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e593a5b-0de6-4df2-bbda-54195400dc69.jpg?1",
             "name": "Spider Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has reach. (It can block creatures with flying.)\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6967,7 +6967,7 @@
         },
         {
             "id": "c094f21c-35d5-53ea-a963-c83533e93357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb1d18f-7a94-4a2f-a60c-0af852d44501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb1d18f-7a94-4a2f-a60c-0af852d44501.jpg?1",
             "name": "Sporecap Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "5c8adfef-dd8b-5daa-8422-d622a116d608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89be64a8-dd78-48c3-bb47-4f2a5ad9ec10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89be64a8-dd78-48c3-bb47-4f2a5ad9ec10.jpg?1",
             "name": "Stomper Cub",
             "text": "Trample",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "7d6ff481-216c-5e99-a54d-4a5747ea0924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d03346-0802-4058-b89e-1b6076963c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d03346-0802-4058-b89e-1b6076963c8e.jpg?1",
             "name": "Tajuru Preserver",
             "text": "Spells and abilities your opponents control can't cause you to sacrifice permanents.",
             "colours": [
@@ -7070,7 +7070,7 @@
         },
         {
             "id": "236cbb40-c946-55a3-8d01-5ea24c556c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb9f05-9d5a-4196-9329-626ce4793c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb9f05-9d5a-4196-9329-626ce4793c42.jpg?1",
             "name": "Vengevine",
             "text": "Haste\nWhenever you cast a spell, if it's the second creature spell you cast this turn, you may return Vengevine from your graveyard to the battlefield.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "5ba157f7-dd80-58da-a5c5-38927a67f049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8315bf-03af-4f19-92c7-556e486cb099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8315bf-03af-4f19-92c7-556e486cb099.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "8fc6ecd8-9901-519b-9565-f6ff548b03dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c1ba92-556e-4da9-8e3a-a4a82612cb29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c1ba92-556e-4da9-8e3a-a4a82612cb29.jpg?1",
             "name": "Sarkhan the Mad",
             "text": "0: Reveal the top card of your library and put it into your hand. Sarkhan the Mad deals damage to himself equal to that card's converted mana cost.\n-2: Target creature's controller sacrifices it, then that player puts a 5/5 red Dragon creature token with flying onto the battlefield.\n-4: Each Dragon creature you control deals damage equal to its power to target player.",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "6e19885e-a466-5c76-bf49-ee333cafcfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1fe7a-eb30-4252-bada-ce3f8096e091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1fe7a-eb30-4252-bada-ce3f8096e091.jpg?1",
             "name": "Angelheart Vial",
             "text": "Whenever you're dealt damage, you may put that many charge counters on Angelheart Vial.\n{2}, {T}, Remove four charge counters from Angelheart Vial: You gain 2 life and draw a card.",
             "colours": [],
@@ -7205,7 +7205,7 @@
         },
         {
             "id": "cddf42c0-8b90-5f7f-bd7b-6109d9972f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79090d66-19ab-456e-96c0-023c84f4e521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79090d66-19ab-456e-96c0-023c84f4e521.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {3} to your mana pool.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "ab8027cc-6f14-5d6c-9894-faabfd03e56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b2e63d-61c6-46e4-9a6f-56653c49b2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b2e63d-61c6-46e4-9a6f-56653c49b2ea.jpg?1",
             "name": "Enatu Golem",
             "text": "When Enatu Golem is put into a graveyard from the battlefield, you gain 4 life.",
             "colours": [],
@@ -7264,7 +7264,7 @@
         },
         {
             "id": "b86309ee-8922-567b-b84f-bb179e96d8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26a7d8-3bc5-4666-a0dc-c5fbd68f9441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26a7d8-3bc5-4666-a0dc-c5fbd68f9441.jpg?1",
             "name": "Hedron Matrix",
             "text": "Equipped creature gets +X/+X, where X is its converted mana cost.\nEquip {4}",
             "colours": [],
@@ -7294,7 +7294,7 @@
         },
         {
             "id": "3dcd4b30-e38a-5cbe-a58c-13eb582a107a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f9355b-3a3e-417c-9fbc-afddb4d8f9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f9355b-3a3e-417c-9fbc-afddb4d8f9af.jpg?1",
             "name": "Keening Stone",
             "text": "{5}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards in that player's graveyard.",
             "colours": [],
@@ -7322,7 +7322,7 @@
         },
         {
             "id": "cd1a31e1-0f9c-597b-8f15-248e8c2a80c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec319380-bede-49e8-9d0c-473688033601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec319380-bede-49e8-9d0c-473688033601.jpg?1",
             "name": "Ogre's Cleaver",
             "text": "Equipped creature gets +5/+0.\nEquip {5}",
             "colours": [],
@@ -7352,7 +7352,7 @@
         },
         {
             "id": "8f5d27a5-2a29-5b67-a28f-752fcc9e7e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a64a1b-4816-4d8f-a8ba-ba39c92c61ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a64a1b-4816-4d8f-a8ba-ba39c92c61ec.jpg?1",
             "name": "Pennon Blade",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {4}",
             "colours": [],
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "0d36f401-a08b-5e07-bdbf-b9ac51d115c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb90d44-8cb1-4b83-b2f2-92c19d6304fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb90d44-8cb1-4b83-b2f2-92c19d6304fb.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7410,7 +7410,7 @@
         },
         {
             "id": "573efbcb-e5ad-5820-bcec-94651b5066df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437a91e7-f98e-4ed8-9ab7-f4db62979f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437a91e7-f98e-4ed8-9ab7-f4db62979f5b.jpg?1",
             "name": "Reinforced Bulwark",
             "text": "Defender\n{T}: Prevent the next 1 damage that would be dealt to you this turn.",
             "colours": [],
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "74aafdcd-1379-52a9-a987-8540dd828054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbbbbf6-e3ed-4a36-bedf-11c3514ff965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbbbbf6-e3ed-4a36-bedf-11c3514ff965.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor is put into a graveyard from the battlefield, each player draws a card.",
             "colours": [],
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "27f52867-06e3-50d0-8043-3a4a5deef695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da189e-f692-4b91-a452-3c628c3c2b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da189e-f692-4b91-a452-3c628c3c2b1c.jpg?1",
             "name": "Sphinx-Bone Wand",
             "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Sphinx-Bone Wand. If you do, Sphinx-Bone Wand deals damage equal to the number of charge counters on it to target creature or player.",
             "colours": [],
@@ -7500,7 +7500,7 @@
         },
         {
             "id": "12458f3e-2b0a-5724-9c40-d3cfd18a5e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44da7915-98bd-4f4e-9bcc-801eb10c8a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44da7915-98bd-4f4e-9bcc-801eb10c8a18.jpg?1",
             "name": "Warmonger's Chariot",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature has defender, it can attack as though it didn't have defender.\nEquip {3}",
             "colours": [],
@@ -7530,7 +7530,7 @@
         },
         {
             "id": "9999b1ed-df21-5699-9a73-6367d6273c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315924c9-77e3-405b-9bbf-852ed563c6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315924c9-77e3-405b-9bbf-852ed563c6e3.jpg?1",
             "name": "Eldrazi Temple",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {2} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
             "colours": [],
@@ -7558,7 +7558,7 @@
         },
         {
             "id": "25231603-90bb-5a91-8f6e-e05389c26438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7e0407-fea1-43ef-8580-82271e440bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7e0407-fea1-43ef-8580-82271e440bb3.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "f6b063a0-815a-5105-9ddb-4f1acbb9e52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3345553-8f04-4a83-9b6b-95ca0654921d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3345553-8f04-4a83-9b6b-95ca0654921d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "414a8436-d86f-5b80-ba3d-0f9cbea4f21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dc47f2-a92d-446b-b788-8287b5d609c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dc47f2-a92d-446b-b788-8287b5d609c4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "fa3851f7-56af-5ebf-9ffb-9fc5fd3d2345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf39f344-1204-4c90-93b5-c04a24f0f1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf39f344-1204-4c90-93b5-c04a24f0f1f5.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "13e78170-7ba8-5be1-b1f1-76c780aa68a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45031d49-c82b-47a4-a652-f8904cd9bb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45031d49-c82b-47a4-a652-f8904cd9bb66.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "35639b2e-3779-54c1-a887-c3b77e1dc51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c799192-43bb-4c25-ab4f-b1d4ef0df660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c799192-43bb-4c25-ab4f-b1d4ef0df660.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "33f49aad-9755-5d7e-b005-6d3ff3d25452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15973a22-cf86-447d-94ef-d62ac824aa49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15973a22-cf86-447d-94ef-d62ac824aa49.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7814,7 +7814,7 @@
         },
         {
             "id": "7f87cfb5-46a6-56d0-ad52-2c2268a01bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32a5e25-8e85-474e-ab32-ab28898ac87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32a5e25-8e85-474e-ab32-ab28898ac87a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "6e095630-c7b4-5690-becb-c5b8db09212e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcc2609-59ba-4eca-8b90-993cab90364a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcc2609-59ba-4eca-8b90-993cab90364a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "b3ad9125-7358-5cac-b8cf-fdf9e9b2bd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75f4aa-cede-452b-80c1-bd3b8221dbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75f4aa-cede-452b-80c1-bd3b8221dbcb.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "d4a8435a-c0f4-56c5-990e-b42dea233fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d7edb2-3bb4-4a0f-ad66-eef31cc8ed6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d7edb2-3bb4-4a0f-ad66-eef31cc8ed6b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7966,7 +7966,7 @@
         },
         {
             "id": "fe9de957-e587-5bea-952c-049e2902dcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bdea83-efb5-4371-8d25-5703c6efee65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bdea83-efb5-4371-8d25-5703c6efee65.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8004,7 +8004,7 @@
         },
         {
             "id": "ec7ae475-5c55-50fd-a224-76bce8668a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1660f317-d337-4c24-8523-613dc3072ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1660f317-d337-4c24-8523-613dc3072ca9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "5b9b39bc-22b0-5757-83bb-ab54fe2add7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf940cc3-282e-4b6b-877d-5ce71ee797bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf940cc3-282e-4b6b-877d-5ce71ee797bc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "ba0b5086-fdb3-50f2-945c-15de60074be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acc9266-3a8e-4a5b-9c00-bbc30e3bf5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acc9266-3a8e-4a5b-9c00-bbc30e3bf5e7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "9d98a217-174a-57c5-9931-0130b6cf061a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352288b-ff7b-43c7-a5ae-3f6577d11708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352288b-ff7b-43c7-a5ae-3f6577d11708.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8156,7 +8156,7 @@
         },
         {
             "id": "5e834126-996b-5757-9ea9-ee22f2c5626e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56424d3-ceda-4cd3-988f-48ced72d17b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56424d3-ceda-4cd3-988f-48ced72d17b8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "f65a752f-3712-57d5-a754-7b97f42675c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e2588b-7781-418c-abc8-08601fbb2336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e2588b-7781-418c-abc8-08601fbb2336.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8232,7 +8232,7 @@
         },
         {
             "id": "74422852-01dd-59f0-9264-1984810e00a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af153b-5cc6-4130-8694-dcdb1fd45cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af153b-5cc6-4130-8694-dcdb1fd45cdc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8270,7 +8270,7 @@
         },
         {
             "id": "34a6cf7f-c1cc-55ce-93c0-189f95ec183f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776470f5-3a47-475b-a599-cb5fee156593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776470f5-3a47-475b-a599-cb5fee156593.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8308,7 +8308,7 @@
         },
         {
             "id": "51f2710a-8cd9-5b82-917a-b7b46f861047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dd7a8a-a560-481a-a16e-dc60cdb440bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dd7a8a-a560-481a-a16e-dc60cdb440bb.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "946a7482-bf4a-5eab-8c8f-3b06b9ba413b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3826c-3c85-4910-bd6c-04894ea328d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3826c-3c85-4910-bd6c-04894ea328d0.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8377,7 +8377,7 @@
         },
         {
             "id": "2858a0da-25df-526d-b946-74c309c4bc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb1a3d-3f1a-45ba-a643-1dca435c77de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb1a3d-3f1a-45ba-a643-1dca435c77de.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8408,7 +8408,7 @@
         },
         {
             "id": "72736a8e-7059-58e0-83df-1a88d355766b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0da4f8d-cce9-4d08-8d11-792e0b2af7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0da4f8d-cce9-4d08-8d11-792e0b2af7d0.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "f9482da1-1da5-5ed9-a322-f3b5031d8904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c9fb3-5f4c-47f9-a9b3-369d4936de60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c9fb3-5f4c-47f9-a9b3-369d4936de60.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8473,7 +8473,7 @@
         },
         {
             "id": "c2d9fa31-b2b6-5c1e-bbd9-65206fbb04aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acabc3ce-a3c1-4c6c-8022-9a96ffba59c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acabc3ce-a3c1-4c6c-8022-9a96ffba59c6.jpg?1",
             "name": "Hellion",
             "text": "",
             "colours": [
@@ -8507,7 +8507,7 @@
         },
         {
             "id": "6e7758ec-e4bb-59fc-a314-6a52cc158724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e91df-0647-4c9f-9c3e-fb8c77c4886c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e91df-0647-4c9f-9c3e-fb8c77c4886c.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "8a2b5077-33e8-52c8-af65-28159fe2bc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f55fa2-bb6f-4609-85ec-72703638fbd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f55fa2-bb6f-4609-85ec-72703638fbd9.jpg?1",
             "name": "Tuktuk the Returned",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/RTR.json
+++ b/Assets/Resources/Sets/RTR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "923d8c9a-79e6-52de-82c3-b04646c10141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d82f7-7759-457e-a9bb-f9a5bd968f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d82f7-7759-457e-a9bb-f9a5bd968f82.jpg?1",
             "name": "Angel of Serenity",
             "text": "Flying\nWhen Angel of Serenity enters the battlefield, you may exile up to three other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Angel of Serenity leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "d4b10a8e-f7ee-5ad5-8c11-80a521aaf560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03498c1-b7f7-41fb-8e2a-1c087d4e9990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03498c1-b7f7-41fb-8e2a-1c087d4e9990.jpg?1",
             "name": "Armory Guard",
             "text": "Armory Guard has vigilance as long as you control a Gate.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "c6fc40d9-8bf5-51b3-9def-44347e649f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498f74a2-7e5e-4082-97e7-b938d703f869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498f74a2-7e5e-4082-97e7-b938d703f869.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "09b0b6ed-d1ce-5006-a150-3094bfcc6dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696678ff-44dc-4fe4-bf17-024e86cd0220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696678ff-44dc-4fe4-bf17-024e86cd0220.jpg?1",
             "name": "Avenging Arrow",
             "text": "Destroy target creature that dealt damage this turn.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "85b45749-eb8c-5cea-8a64-f627510075d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199f7563-563e-483c-8317-5380a83db955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199f7563-563e-483c-8317-5380a83db955.jpg?1",
             "name": "Azorius Arrester",
             "text": "When Azorius Arrester enters the battlefield, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "8f6448ec-8748-5bdc-adb7-4c701e5be6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f56272e-c05e-446b-8871-e3783dd29a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f56272e-c05e-446b-8871-e3783dd29a8b.jpg?1",
             "name": "Azorius Justiciar",
             "text": "When Azorius Justiciar enters the battlefield, detain up to two target creatures your opponents control. (Until your next turn, those creatures can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "2cf4daa9-029b-532f-add2-0cb2a98d85ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07bb2fe-3a9b-47d0-864b-99a662d9544b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07bb2fe-3a9b-47d0-864b-99a662d9544b.jpg?1",
             "name": "Bazaar Krovod",
             "text": "Whenever Bazaar Krovod attacks, another target attacking creature gets +0/+2 until end of turn. Untap that creature.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "98f7bca4-7d9f-583a-baee-81049a09feac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0333d0b-ae42-48aa-83d8-a4f2c7483a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0333d0b-ae42-48aa-83d8-a4f2c7483a46.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "ae1abfc0-ad32-55c2-81b6-8df85b5ddba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76960e65-e5c7-4414-b9a5-37d7b2ded4a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76960e65-e5c7-4414-b9a5-37d7b2ded4a0.jpg?1",
             "name": "Ethereal Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each enchantment you control and has first strike.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "85d04b65-f196-5c53-bf52-bfa9778b2537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befef095-3429-4dd7-aa01-2f7f619675d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befef095-3429-4dd7-aa01-2f7f619675d4.jpg?1",
             "name": "Eyes in the Skies",
             "text": "Put a 1/1 white Bird creature token with flying onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "6125dc0e-1b9d-50a4-8658-5412e45358b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42d3066-f4ec-4d28-83ab-e48141206c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42d3066-f4ec-4d28-83ab-e48141206c72.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "cbbe0ac3-2d99-5f3d-91f5-b539f77d77fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657b242c-46cb-44d1-86fd-fb2485144a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657b242c-46cb-44d1-86fd-fb2485144a5b.jpg?1",
             "name": "Keening Apparition",
             "text": "Sacrifice Keening Apparition: Destroy target enchantment.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "9c3244e8-be90-52af-939e-355621d1ecf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d821f-c8dd-4a3c-a6d7-b42fe5491f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d821f-c8dd-4a3c-a6d7-b42fe5491f02.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, put a 2/2 white Knight creature token with vigilance onto the battlefield.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "a6b3eef6-c010-5084-9db9-d9aab87f4645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21078b6f-a39d-4ec8-879e-ad10d97c3ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21078b6f-a39d-4ec8-879e-ad10d97c3ff6.jpg?1",
             "name": "Martial Law",
             "text": "At the beginning of your upkeep, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "8bc748ac-8c22-509a-9299-670e2fa1c77d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfd37ca-e4c9-4674-a75f-15d8ebcce72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfd37ca-e4c9-4674-a75f-15d8ebcce72b.jpg?1",
             "name": "Palisade Giant",
             "text": "All damage that would be dealt to you or another permanent you control is dealt to Palisade Giant instead.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "247e592d-051e-551d-9f39-0fb20b4551c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f42791-070a-4e3a-91c8-b801980abb76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f42791-070a-4e3a-91c8-b801980abb76.jpg?1",
             "name": "Phantom General",
             "text": "Creature tokens you control get +1/+1.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "81e26755-b763-5ddb-b158-580254fec1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1f6178-4071-401f-bd0d-cac0c5967661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1f6178-4071-401f-bd0d-cac0c5967661.jpg?1",
             "name": "Precinct Captain",
             "text": "First strike\nWhenever Precinct Captain deals combat damage to a player, put a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "058b3b18-e305-57b2-a47b-1624691d08aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b1d1-faa0-40fd-82f4-216604ce7635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b1d1-faa0-40fd-82f4-216604ce7635.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all cards from all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "1f030a24-e4e3-583c-b7f5-d74be97e6b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deccfa48-b8df-4dcc-ba1b-920f8352def7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deccfa48-b8df-4dcc-ba1b-920f8352def7.jpg?1",
             "name": "Rootborn Defenses",
             "text": "Populate. Creatures you control are indestructible this turn. (To populate, put a token onto the battlefield that's a copy of a creature token you control. Damage and effects that say \"destroy\" don't destroy indestructible creatures.)",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "b3a0f22b-f7dc-5280-972c-b0bc736a0d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6250b31-8592-48b2-a877-3637c9ee7d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6250b31-8592-48b2-a877-3637c9ee7d49.jpg?1",
             "name": "Security Blockade",
             "text": "Enchant land\nWhen Security Blockade enters the battlefield, put a 2/2 white Knight creature token with vigilance onto the battlefield.\nEnchanted land has \"{T}: Prevent the next 1 damage that would be dealt to you this turn.\"",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "e0f2e287-df8e-530b-9f70-aa974945c593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c34c1f5-d509-4c66-ba41-c7958ef5ee44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c34c1f5-d509-4c66-ba41-c7958ef5ee44.jpg?1",
             "name": "Selesnya Sentry",
             "text": "{5}{G}: Regenerate Selesnya Sentry.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "bb1257e9-854f-54d6-89d6-490645b5b6bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41edbe-4c5a-4535-a082-235dc3ffe60a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41edbe-4c5a-4535-a082-235dc3ffe60a.jpg?1",
             "name": "Seller of Songbirds",
             "text": "When Seller of Songbirds enters the battlefield, put a 1/1 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "e9fb19be-142f-5cd5-b7d2-e9f7f8560328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e546ce-f498-4136-9015-bb262c301716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e546ce-f498-4136-9015-bb262c301716.jpg?1",
             "name": "Soul Tithe",
             "text": "Enchant nonland permanent\nAt the beginning of the upkeep of enchanted permanent's controller, that player sacrifices it unless he or she pays {X}, where X is its converted mana cost.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "d9652ea5-7f5b-517a-afcc-b9d70d69a74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3bd0d8-7e44-4cf2-9012-8ff0bc39417f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3bd0d8-7e44-4cf2-9012-8ff0bc39417f.jpg?1",
             "name": "Sphere of Safety",
             "text": "Creatures can't attack you or a planeswalker you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "231c0c47-791d-586d-9c97-1ba482dcbfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1388ce6e-8199-46c1-8ee3-71266b0929bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1388ce6e-8199-46c1-8ee3-71266b0929bf.jpg?1",
             "name": "Sunspire Griffin",
             "text": "Flying",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "265f137e-6345-5523-af49-7a3c7f48ef43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94801ba-0295-4611-abda-4c6508d69cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94801ba-0295-4611-abda-4c6508d69cc3.jpg?1",
             "name": "Swift Justice",
             "text": "Until end of turn, target creature gets +1/+0 and gains first strike and lifelink.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "ea5773c1-d8f7-50be-9656-67b5b3c0bd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e45d1-d17d-40c0-bfdf-ec533784e676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e45d1-d17d-40c0-bfdf-ec533784e676.jpg?1",
             "name": "Trained Caracal",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "072810c9-d48f-5f30-b37c-bcfa9e3a2e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707bdb1-1f8c-4cc0-be01-496f3f03b878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707bdb1-1f8c-4cc0-be01-496f3f03b878.jpg?1",
             "name": "Trostani's Judgment",
             "text": "Exile target creature, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "b272de9f-3986-5cdb-b03f-11fa17e00b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af643949-7a9b-4195-8ab8-d43b1928b85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af643949-7a9b-4195-8ab8-d43b1928b85a.jpg?1",
             "name": "Aquus Steed",
             "text": "{2}{U}, {T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "d5f0d7b3-a97d-576e-8788-19f47e6ab996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998847b-323d-406a-b08e-0da66edcc7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998847b-323d-406a-b08e-0da66edcc7b3.jpg?1",
             "name": "Blustersquall",
             "text": "Tap target creature you don't control.\nOverload {3}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "ee08823a-35d8-532f-aef8-eee8a3ef682f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd994a26-65ff-43be-8d52-476e887d3ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd994a26-65ff-43be-8d52-476e887d3ed2.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "b874549d-15a0-5968-8e20-ac23e4c9720a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a757425-3cf2-4aca-b415-5ec2d5f753fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a757425-3cf2-4aca-b415-5ec2d5f753fe.jpg?1",
             "name": "Chronic Flooding",
             "text": "Enchant land\nWhenever enchanted land becomes tapped, its controller puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "eef71db2-265c-585e-8841-7b09ec652ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c2ea6e-7d29-4526-b135-9bbb1eed9d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c2ea6e-7d29-4526-b135-9bbb1eed9d4a.jpg?1",
             "name": "Conjured Currency",
             "text": "At the beginning of your upkeep, you may exchange control of Conjured Currency and target permanent you neither own nor control.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "53e8cccd-fc00-5b81-bbae-c181d66d727e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8875a3-9f56-4947-9655-aa5d95f06de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8875a3-9f56-4947-9655-aa5d95f06de0.jpg?1",
             "name": "Crosstown Courier",
             "text": "Whenever Crosstown Courier deals combat damage to a player, that player puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "edd213b6-1f31-5895-a139-771c4036ed06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c4689-8b02-4d40-9274-3c1fcafa8b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c4689-8b02-4d40-9274-3c1fcafa8b82.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "31df7d20-cbe6-5367-8daf-9a3b1f974a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d4a8d7-c136-472f-8146-a1100701ca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d4a8d7-c136-472f-8146-a1100701ca4f.jpg?1",
             "name": "Dispel",
             "text": "Counter target instant spell.",
             "colours": [
@@ -1211,7 +1211,7 @@
         },
         {
             "id": "c81b2c8e-ba1f-561e-801e-f458414ace5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c31221f-3753-4d5c-905a-6b558ab648ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c31221f-3753-4d5c-905a-6b558ab648ae.jpg?1",
             "name": "Doorkeeper",
             "text": "Defender\n{2}{U}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of creatures with defender you control.",
             "colours": [
@@ -1245,7 +1245,7 @@
         },
         {
             "id": "0d9bff05-eb55-5caa-b267-3f8c3d7e90c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8408a52-d34a-4e03-9312-700dec75d844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8408a52-d34a-4e03-9312-700dec75d844.jpg?1",
             "name": "Downsize",
             "text": "Target creature you don't control gets -4/-0 until end of turn.\nOverload {2}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1277,7 +1277,7 @@
         },
         {
             "id": "a53d8d00-74c9-5088-b434-498d855d92d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfddc9d-85f6-4b37-9973-14c69f6818ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfddc9d-85f6-4b37-9973-14c69f6818ec.jpg?1",
             "name": "Faerie Impostor",
             "text": "Flying\nWhen Faerie Impostor enters the battlefield, sacrifice it unless you return another creature you control to its owner's hand.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "6683bc9b-e0b3-56db-8d98-ad3fd32e37f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884afdb3-0d5f-45a1-b57e-6c3760aa0031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884afdb3-0d5f-45a1-b57e-6c3760aa0031.jpg?1",
             "name": "Hover Barrier",
             "text": "Defender, flying",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "85b3e1ad-d09e-5c91-b5c7-c515ee8bf6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5342ec3c-9d26-474a-9df5-c21ac90bb233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5342ec3c-9d26-474a-9df5-c21ac90bb233.jpg?1",
             "name": "Inaction Injunction",
             "text": "Detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)\nDraw a card.",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "e01eee9a-f0a7-5574-b618-a0d5a4193d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9dc0-0a12-459c-88e2-97ed94653058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9dc0-0a12-459c-88e2-97ed94653058.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "c6531295-fb79-5acd-9c86-5bef027b9fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba84d-d236-45c5-a8ad-75def7736d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba84d-d236-45c5-a8ad-75def7736d0c.jpg?1",
             "name": "Isperia's Skywatch",
             "text": "Flying\nWhen Isperia's Skywatch enters the battlefield, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -1446,7 +1446,7 @@
         },
         {
             "id": "41162bba-7a2b-57d3-8c70-a2377a308bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df3a38-678e-42dc-a3fd-d1d399368f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df3a38-678e-42dc-a3fd-d1d399368f07.jpg?1",
             "name": "Jace, Architect of Thought",
             "text": "+1: Until your next turn, whenever a creature an opponent controls attacks, it gets -1/-0 until end of turn.\n-2: Reveal the top three cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other on the bottom of your library in any order.\n-8: For each player, search that player's library for a nonland card and exile it, then that player shuffles his or her library. You may cast those cards without paying their mana costs.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "a1956347-0326-50fb-9c4f-7074091efcea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9859344-4efc-4b87-a3fb-147e496cee68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9859344-4efc-4b87-a3fb-147e496cee68.jpg?1",
             "name": "Mizzium Skin",
             "text": "Target creature you control gets +0/+1 and gains hexproof until end of turn.\nOverload {1}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "e01bee1f-0e7a-56af-ba75-0d164cffe00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd97b3-d83e-406f-af45-40eec6347462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd97b3-d83e-406f-af45-40eec6347462.jpg?1",
             "name": "Paralyzing Grasp",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "528e8a90-b17e-57f0-9f26-456051838cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b09c16-f611-4c90-a990-e22bf46bd0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b09c16-f611-4c90-a990-e22bf46bd0e2.jpg?1",
             "name": "Psychic Spiral",
             "text": "Shuffle all cards from your graveyard into your library. Target player puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "7aa59b59-6f9e-5d61-a0f8-bdd8b59ce0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749961e6-b135-4629-ae9d-124de0d70db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749961e6-b135-4629-ae9d-124de0d70db9.jpg?1",
             "name": "Runewing",
             "text": "Flying\nWhen Runewing dies, draw a card.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "48bcd8cf-bb4a-5155-a0d4-39ad14c18dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd77575-fedc-45b1-a53b-dfed0f34c875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd77575-fedc-45b1-a53b-dfed0f34c875.jpg?1",
             "name": "Search the City",
             "text": "When Search the City enters the battlefield, exile the top five cards of your library.\nWhenever you play a card with the same name as one of the exiled cards, you may put one of those cards with that name into its owner's hand. Then if there are no cards exiled with Search the City, sacrifice it. If you do, take an extra turn after this one.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "9a985fc1-3c41-521a-9461-1aa3a22505a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839556c-6635-44c4-96ed-666e4466b929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839556c-6635-44c4-96ed-666e4466b929.jpg?1",
             "name": "Skyline Predator",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "cc906bd8-c861-5e8c-bb4f-ecdad723697d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32602ed9-c0a7-4498-a333-235eaae628df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32602ed9-c0a7-4498-a333-235eaae628df.jpg?1",
             "name": "Soulsworn Spirit",
             "text": "Soulsworn Spirit is unblockable.\nWhen Soulsworn Spirit enters the battlefield, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "143ee4ec-71d5-54c0-a1e8-e0d93edcbc79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a0cae5-925f-4d00-a4da-1db8bae5511b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a0cae5-925f-4d00-a4da-1db8bae5511b.jpg?1",
             "name": "Sphinx of the Chimes",
             "text": "Flying\nDiscard two nonland cards with the same name: Draw four cards.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "d4edf62b-643d-5935-be7f-3ebb62b453ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ae7001-4d0f-4160-b41c-2fcb83fdb60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ae7001-4d0f-4160-b41c-2fcb83fdb60b.jpg?1",
             "name": "Stealer of Secrets",
             "text": "Whenever Stealer of Secrets deals combat damage to a player, draw a card.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "9f6cb568-a4dd-5840-9046-c0df4dcc882a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f218f-83b0-4b68-a00f-0327cd79f32a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f218f-83b0-4b68-a00f-0327cd79f32a.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays {X}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "1b7e86d5-81ec-541f-ba59-097f084a3635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d759d6f-daf0-47f4-8a35-81c9d6437495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d759d6f-daf0-47f4-8a35-81c9d6437495.jpg?1",
             "name": "Tower Drake",
             "text": "Flying\n{W}: Tower Drake gets +0/+1 until end of turn.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "b1200a6a-4808-549e-9ff7-234e57a7b34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23723bc7-a68e-4810-bc87-60df916cbb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23723bc7-a68e-4810-bc87-60df916cbb8a.jpg?1",
             "name": "Voidwielder",
             "text": "When Voidwielder enters the battlefield, you may return target creature to its owner's hand.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "e9640ade-9c2d-501c-94c8-d4159e1189ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f796e320-9898-45d4-9d7a-6d35de53c9ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f796e320-9898-45d4-9d7a-6d35de53c9ab.jpg?1",
             "name": "Assassin's Strike",
             "text": "Destroy target creature. Its controller discards a card.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "8c223cb8-e9cc-54c4-9d9a-c9ff29103b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b36fba-6a0e-4f03-8bee-03919062537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b36fba-6a0e-4f03-8bee-03919062537f.jpg?1",
             "name": "Catacomb Slug",
             "text": "",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "64054348-27a8-53d5-a61c-ea3263ec7cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d5260-f906-4f6a-97ed-725197743b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d5260-f906-4f6a-97ed-725197743b60.jpg?1",
             "name": "Cremate",
             "text": "Exile target card from a graveyard.\nDraw a card.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "84255e6d-df65-53cc-b53c-87b89778a4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70639887-bdba-4879-a3f8-c716f97fc325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70639887-bdba-4879-a3f8-c716f97fc325.jpg?1",
             "name": "Daggerdrome Imp",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "19f419d9-d172-5efd-a9ba-1ff0240bca11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167cc6d-ddb5-4f13-8905-a0c5123b852a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167cc6d-ddb5-4f13-8905-a0c5123b852a.jpg?1",
             "name": "Dark Revenant",
             "text": "Flying\nWhen Dark Revenant dies, put it on top of its owner's library.",
             "colours": [
@@ -2051,7 +2051,7 @@
         },
         {
             "id": "426f2ff4-207b-5ed6-a019-cc1fe8393084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a0a38-2c22-4b49-8938-1a8162c077e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a0a38-2c22-4b49-8938-1a8162c077e6.jpg?1",
             "name": "Dead Reveler",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "4f6a7de7-3a17-58d1-862f-ee07b3053a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8242fade-754c-4404-b3fb-f3cccf84b3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8242fade-754c-4404-b3fb-f3cccf84b3b6.jpg?1",
             "name": "Desecration Demon",
             "text": "Flying\nAt the beginning of each combat, any opponent may sacrifice a creature. If a player does, tap Desecration Demon and put a +1/+1 counter on it.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "f52d2840-3c97-54d6-9c86-bf84aae433d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca53097-108d-457e-831c-e3d6cb499a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca53097-108d-457e-831c-e3d6cb499a41.jpg?1",
             "name": "Destroy the Evidence",
             "text": "Destroy target land. Its controller reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2151,7 +2151,7 @@
         },
         {
             "id": "f5cb29d6-eb53-5d73-abdf-dbdc5a9a6745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150896e-8745-42ac-894b-8f42a92bd7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150896e-8745-42ac-894b-8f42a92bd7a7.jpg?1",
             "name": "Deviant Glee",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has \"{R}: This creature gains trample until end of turn.\"",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "24d562ca-b8e4-534b-a6ee-ac6f464940d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7251f3-df66-4611-a84c-1897f74431f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7251f3-df66-4611-a84c-1897f74431f7.jpg?1",
             "name": "Drainpipe Vermin",
             "text": "When Drainpipe Vermin dies, you may pay {B}. If you do, target player discards a card.",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "ab2e7086-04c8-53f6-8ba6-1b85a4fef606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b38c68-8e72-4afc-bb5e-0b40880fdda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b38c68-8e72-4afc-bb5e-0b40880fdda9.jpg?1",
             "name": "Grave Betrayal",
             "text": "Whenever a creature you don't control dies, return it to the battlefield under your control with an additional +1/+1 counter on it at the beginning of the next end step. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "c66721e7-d8e5-51e5-bcc1-7f892bfe06ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5ae3f5-5466-4058-a2cd-1a036cb38a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5ae3f5-5466-4058-a2cd-1a036cb38a8e.jpg?1",
             "name": "Grim Roustabout",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\n{1}{B}: Regenerate Grim Roustabout.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "a0e81854-3b73-55da-b708-cfc310a94099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f29821-902e-41bc-97a2-6fc7a710cbdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f29821-902e-41bc-97a2-6fc7a710cbdb.jpg?1",
             "name": "Launch Party",
             "text": "As an additional cost to cast Launch Party, sacrifice a creature.\nDestroy target creature. Its controller loses 2 life.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "fb261cd7-14cc-5029-8d16-88ea883222c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5261ab4b-dfe7-4761-a71c-44a893fc4a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5261ab4b-dfe7-4761-a71c-44a893fc4a69.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "2d921eb3-2ed1-5c65-80bf-dc8fbab1c5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b421dcc9-0299-416d-86bc-c70ef49bcf98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b421dcc9-0299-416d-86bc-c70ef49bcf98.jpg?1",
             "name": "Necropolis Regent",
             "text": "Flying\nWhenever a creature you control deals combat damage to a player, put that many +1/+1 counters on it.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "0a55694e-2e6b-5463-b10f-04cfa2aa9b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a96c83d-96d9-4f8f-8020-77990130ad81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a96c83d-96d9-4f8f-8020-77990130ad81.jpg?1",
             "name": "Ogre Jailbreaker",
             "text": "Defender\nOgre Jailbreaker can attack as though it didn't have defender as long as you control a Gate.",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "9f208978-8567-5188-a3ee-b30fad0a0ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170693f5-13db-4191-99b1-e527ffb5b88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170693f5-13db-4191-99b1-e527ffb5b88e.jpg?1",
             "name": "Pack Rat",
             "text": "Pack Rat's power and toughness are each equal to the number of Rats you control.\n{2}{B}, Discard a card: Put a token onto the battlefield that's a copy of Pack Rat.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "758b9b10-7a81-5e02-8c3c-e1f97824c599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c101171-a988-4c1d-9954-634e2f1c6f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c101171-a988-4c1d-9954-634e2f1c6f01.jpg?1",
             "name": "Perilous Shadow",
             "text": "{1}{B}: Perilous Shadow gets +2/+2 until end of turn.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "a4381290-926d-57bb-abdd-2d91f5247cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7ba14-c901-4266-ae31-812e001916d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7ba14-c901-4266-ae31-812e001916d3.jpg?1",
             "name": "Sewer Shambler",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)\nScavenge {2}{B} ({2}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "ebaaac19-e2f1-5d66-9de1-5499df8bad51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd08894-2534-4114-9365-40809ba95eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd08894-2534-4114-9365-40809ba95eb2.jpg?1",
             "name": "Shrieking Affliction",
             "text": "At the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, he or she loses 3 life.",
             "colours": [
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "04dca176-da8b-54f9-9171-785764829113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0fea13-63cf-4574-8752-3c357eee4524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0fea13-63cf-4574-8752-3c357eee4524.jpg?1",
             "name": "Slum Reaper",
             "text": "When Slum Reaper enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "fad7dda1-2e5e-5785-a5d5-ae28bd47c9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b562269-e6ec-4f8d-844e-26b272248d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b562269-e6ec-4f8d-844e-26b272248d9d.jpg?1",
             "name": "Stab Wound",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 2 life.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "bae292a3-7418-55a6-991c-518088119ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47240ed3-f256-45fb-ab38-7b07e672d2ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47240ed3-f256-45fb-ab38-7b07e672d2ed.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "ad5cab67-211c-59e0-830d-700012fb0a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1998135c-7b7f-402b-a8a5-4f4af131b1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1998135c-7b7f-402b-a8a5-4f4af131b1bc.jpg?1",
             "name": "Terrus Wurm",
             "text": "Scavenge {6}{B} ({6}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "4e822d23-9bc1-5a66-b182-1818404f5841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f32204-eda7-4184-92e5-9da8b15b2359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f32204-eda7-4184-92e5-9da8b15b2359.jpg?1",
             "name": "Thrill-Kill Assassin",
             "text": "Deathtouch\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "741491a6-daa6-5480-b0a0-f57e4baf77fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b4912a-83a2-4870-8fac-81fa79da2830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b4912a-83a2-4870-8fac-81fa79da2830.jpg?1",
             "name": "Ultimate Price",
             "text": "Destroy target monocolored creature.",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "65617e56-4d64-561c-a6b2-3024737a0b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c52e3b-b3b8-4243-96fe-fa4c8eea7c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c52e3b-b3b8-4243-96fe-fa4c8eea7c59.jpg?1",
             "name": "Underworld Connections",
             "text": "Enchant land\nEnchanted land has \"{T}, Pay 1 life: Draw a card.\"",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "8f14290c-36e5-5a90-a1dd-bf976db4bb0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbd7ee-8958-46fe-abb0-e899e7d2e654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbd7ee-8958-46fe-abb0-e899e7d2e654.jpg?1",
             "name": "Zanikev Locust",
             "text": "Flying\nScavenge {2}{B}{B} ({2}{B}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "82cb0a64-dc06-54fc-9fe7-0f43299d94a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae12fd10-c13e-4777-a233-96204ec75ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae12fd10-c13e-4777-a233-96204ec75ac1.jpg?1",
             "name": "Annihilating Fire",
             "text": "Annihilating Fire deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "c506205f-c45d-5b80-8184-9cc2f80e2b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f61b1a3-4b3b-4490-a9dc-17aac258cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f61b1a3-4b3b-4490-a9dc-17aac258cbda.jpg?1",
             "name": "Ash Zealot",
             "text": "First strike, haste\nWhenever a player casts a spell from a graveyard, Ash Zealot deals 3 damage to that player.",
             "colours": [
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "aaeca27d-bdc0-54cf-aa3a-78e5643e7b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b40f74-893f-4bfc-87b2-7f8df4c912d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b40f74-893f-4bfc-87b2-7f8df4c912d8.jpg?1",
             "name": "Batterhorn",
             "text": "When Batterhorn enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -2929,7 +2929,7 @@
         },
         {
             "id": "6935f64a-b7c9-5f89-b184-8c43b3359f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg?1",
             "name": "Bellows Lizard",
             "text": "{1}{R}: Bellows Lizard gets +1/+0 until end of turn.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "4b385cc5-8546-561c-9735-71b8b4b1c9e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c468cd-1255-4257-9a69-c6b40a27c427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c468cd-1255-4257-9a69-c6b40a27c427.jpg?1",
             "name": "Bloodfray Giant",
             "text": "Trample\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2997,7 +2997,7 @@
         },
         {
             "id": "0322876d-22b3-541d-a651-ed23815044b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a702a-c9be-4bee-9087-22b5905f783a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a702a-c9be-4bee-9087-22b5905f783a.jpg?1",
             "name": "Chaos Imps",
             "text": "Flying\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\nChaos Imps has trample as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "990d84c3-3e63-5cf1-9d7e-924163bdd48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e038376-801f-454e-a635-0e2d58ccbf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e038376-801f-454e-a635-0e2d58ccbf7c.jpg?1",
             "name": "Cobblebrute",
             "text": "",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "d6be1a9f-734f-5b2a-8fee-2d7b3af5c977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e612a032-39be-44cd-a78c-29f89dc384b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e612a032-39be-44cd-a78c-29f89dc384b0.jpg?1",
             "name": "Dynacharge",
             "text": "Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "ee1fcc47-974e-5863-a0cb-7caafefba6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed81ee8-d5e4-4127-876e-9bff81f9c726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed81ee8-d5e4-4127-876e-9bff81f9c726.jpg?1",
             "name": "Electrickery",
             "text": "Electrickery deals 1 damage to target creature you don't control.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "a1ba0c6d-47ad-588e-b6a2-9a6a89a0eef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3e2b45-b086-4ffd-aa1a-1d03046e0d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3e2b45-b086-4ffd-aa1a-1d03046e0d61.jpg?1",
             "name": "Explosive Impact",
             "text": "Explosive Impact deals 5 damage to target creature or player.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "cf11a456-e11a-533b-92cf-0fd7b6ff97cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec8ada-09a6-449a-ac4a-7d3acbd08014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec8ada-09a6-449a-ac4a-7d3acbd08014.jpg?1",
             "name": "Goblin Rally",
             "text": "Put four 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "aedc7efa-d2bd-5135-bade-a0db62bdbe04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ba132f-95fc-4b99-a1dc-ebe6f622bb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ba132f-95fc-4b99-a1dc-ebe6f622bb41.jpg?1",
             "name": "Gore-House Chainwalker",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "d0bcc932-d1f2-509c-90de-42512b6fef75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e622878-0aea-4401-873e-d34bf05ee98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e622878-0aea-4401-873e-d34bf05ee98d.jpg?1",
             "name": "Guild Feud",
             "text": "At the beginning of your upkeep, target opponent reveals the top three cards of his or her library, may put a creature card from among them onto the battlefield, then puts the rest into his or her graveyard. You do the same with the top three cards of your library. If two creatures are put onto the battlefield this way, those creatures fight each other.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "b688633e-b2a8-5c6a-9f6c-0030383c9552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8590ea-512c-4e09-97cc-7f07d0706f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8590ea-512c-4e09-97cc-7f07d0706f2b.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "4e8c4a4d-a426-5d0f-8cdd-2fdf4ec5ffdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4aa15-a3c2-42a3-a87a-443e7dd20c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4aa15-a3c2-42a3-a87a-443e7dd20c04.jpg?1",
             "name": "Lobber Crew",
             "text": "Defender\n{T}: Lobber Crew deals 1 damage to each opponent.\nWhenever you cast a multicolored spell, untap Lobber Crew.",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "7f09067c-b1c0-57bb-8db3-93cbf0c38413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22959dc-8759-454e-80b9-623a799af354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22959dc-8759-454e-80b9-623a799af354.jpg?1",
             "name": "Minotaur Aggressor",
             "text": "First strike, haste",
             "colours": [
@@ -3365,7 +3365,7 @@
         },
         {
             "id": "a53b4afe-d825-58e2-917f-3c536c2809c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ded88d-2688-4f5e-a8b2-16216cf9c792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ded88d-2688-4f5e-a8b2-16216cf9c792.jpg?1",
             "name": "Mizzium Mortars",
             "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "6d854ef9-35ad-5581-a369-a2e65fd6cd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a6290c-a0a8-4032-972b-84a7eef04dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a6290c-a0a8-4032-972b-84a7eef04dae.jpg?1",
             "name": "Pursuit of Flight",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{U}: This creature gains flying until end of turn.\"",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "da166780-223b-55ff-a254-11f4684cd5db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff95b7-79eb-4796-9a01-31ff355681ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff95b7-79eb-4796-9a01-31ff355681ab.jpg?1",
             "name": "Pyroconvergence",
             "text": "Whenever you cast a multicolored spell, Pyroconvergence deals 2 damage to target creature or player.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "1979e9a2-ab9e-57cf-b259-acb8fc2a0a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d13d35-b5f7-4d3d-a1fa-84178b28acae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d13d35-b5f7-4d3d-a1fa-84178b28acae.jpg?1",
             "name": "Racecourse Fury",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature gains haste until end of turn.\"",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "37e00c39-f9e7-5fc1-acd5-e7a83f931d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c511805-3392-4033-8679-811711a0aaca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c511805-3392-4033-8679-811711a0aaca.jpg?1",
             "name": "Splatter Thug",
             "text": "First strike\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "35ab4fa1-c10c-5606-9918-4692e4b193df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a19d3b8-80d0-480f-8900-47be527d0e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a19d3b8-80d0-480f-8900-47be527d0e53.jpg?1",
             "name": "Street Spasm",
             "text": "Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "3eb39c04-fa37-5341-a14b-70e926c96da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e750f9-ad86-4d60-98a3-78d11cd52cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e750f9-ad86-4d60-98a3-78d11cd52cd1.jpg?1",
             "name": "Survey the Wreckage",
             "text": "Destroy target land. Put a 1/1 red Goblin creature token onto the battlefield.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "8e8d801e-aa10-53dd-8da6-92698821da63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af9170-bd99-4fde-b673-62d988312b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af9170-bd99-4fde-b673-62d988312b2d.jpg?1",
             "name": "Tenement Crasher",
             "text": "Haste",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "1b3ad3df-34c9-59d0-9290-879fb1456d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4456951-844a-4847-b933-c32cfafbfef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4456951-844a-4847-b933-c32cfafbfef0.jpg?1",
             "name": "Traitorous Instinct",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "3d4164df-ea3a-59fa-8841-214a7698cdb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c6478-dd80-4854-9560-bfc5ef597872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c6478-dd80-4854-9560-bfc5ef597872.jpg?1",
             "name": "Utvara Hellkite",
             "text": "Flying\nWhenever a Dragon you control attacks, put a 6/6 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "44f04176-a1ff-5f22-8407-f765f5ef53f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5925c559-3e3c-481b-ba95-20a405cbffce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5925c559-3e3c-481b-ba95-20a405cbffce.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "a74a95ae-4fa5-5309-863c-b3232b14cd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4c2d22-9c36-42cc-854d-f96410bb5cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4c2d22-9c36-42cc-854d-f96410bb5cf1.jpg?1",
             "name": "Viashino Racketeer",
             "text": "When Viashino Racketeer enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "0df57484-69dd-5e5a-9a49-2c019d1c3590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3c023c-037e-495a-b7df-32be42a75f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3c023c-037e-495a-b7df-32be42a75f36.jpg?1",
             "name": "Aerial Predation",
             "text": "Destroy target creature with flying. You gain 2 life.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "9a1025f8-82fa-5ca9-bf63-05f98b8353f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc8ff-932c-4d56-9253-99ce9e145306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc8ff-932c-4d56-9253-99ce9e145306.jpg?1",
             "name": "Archweaver",
             "text": "Reach, trample",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "be3665a5-1190-5a2a-b998-77c5383adedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/725584fe-9e97-4020-89b1-5e5b45a5beb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/725584fe-9e97-4020-89b1-5e5b45a5beb2.jpg?1",
             "name": "Axebane Guardian",
             "text": "Defender\n{T}: Add X mana in any combination of colors to your mana pool, where X is the number of creatures with defender you control.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "12b932bc-bad5-5c4c-bcab-081e9cdd2b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfce7c02-ccc3-44cd-8087-627eaa6a072e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfce7c02-ccc3-44cd-8087-627eaa6a072e.jpg?1",
             "name": "Axebane Stag",
             "text": "",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "80b5b104-02a6-5b14-befa-a672aad9ae7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bd1534-52d1-4946-b430-d26f039a9067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bd1534-52d1-4946-b430-d26f039a9067.jpg?1",
             "name": "Brushstrider",
             "text": "Vigilance",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "9d8b71ef-83cc-527a-8f3b-56cb4f40fda2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08598b2b-6fd2-4a1d-8d74-7ca6d93ad382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08598b2b-6fd2-4a1d-8d74-7ca6d93ad382.jpg?1",
             "name": "Centaur's Herald",
             "text": "{2}{G}, Sacrifice Centaur's Herald: Put a 3/3 green Centaur creature token onto the battlefield.",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "00e4745d-cedf-5173-856f-c73edee25cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214dc9c1-154d-4c35-845d-dd2928f1e142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214dc9c1-154d-4c35-845d-dd2928f1e142.jpg?1",
             "name": "Chorus of Might",
             "text": "Until end of turn, target creature gets +1/+1 for each creature you control and gains trample.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "03db94d3-2c73-50c6-81fb-14e497990dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad03e99-25d3-4a09-819b-9192dfd8c9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad03e99-25d3-4a09-819b-9192dfd8c9d2.jpg?1",
             "name": "Deadbridge Goliath",
             "text": "Scavenge {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "ae6fd184-c286-5b53-a50f-d0b01b9025a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa82c57d-4bb9-407c-b973-7abc793b6f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa82c57d-4bb9-407c-b973-7abc793b6f47.jpg?1",
             "name": "Death's Presence",
             "text": "Whenever a creature you control dies, put X +1/+1 counters on target creature you control, where X is the power of the creature that died.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "bfac6c0b-94c9-5356-b827-e2f225aea6a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4812e81-beca-4afc-b2f2-24d5ab27abff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4812e81-beca-4afc-b2f2-24d5ab27abff.jpg?1",
             "name": "Drudge Beetle",
             "text": "Scavenge {5}{G} ({5}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "6690d7a1-714a-50a0-9684-c7b78df7b237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b35961-f4d5-4e14-a793-335147110627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b35961-f4d5-4e14-a793-335147110627.jpg?1",
             "name": "Druid's Deliverance",
             "text": "Prevent all combat damage that would be dealt to you this turn. Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -4132,7 +4132,7 @@
         },
         {
             "id": "be87d656-d71f-587e-af69-6ea3fa6a4e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabcc2f-7536-44e3-a495-bbfc526fdc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabcc2f-7536-44e3-a495-bbfc526fdc5d.jpg?1",
             "name": "Gatecreeper Vine",
             "text": "Defender\nWhen Gatecreeper Vine enters the battlefield, you may search your library for a basic land card or a Gate card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "495ac685-41cc-5658-8854-6d095e77a02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1f6503-e4b2-4085-92cd-e9c522b4b10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1f6503-e4b2-4085-92cd-e9c522b4b10d.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "58ad4f24-d439-5afc-ba4c-81e21b786bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8a63-0ced-4aec-be34-2098b72c8af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8a63-0ced-4aec-be34-2098b72c8af6.jpg?1",
             "name": "Gobbling Ooze",
             "text": "{G}, Sacrifice another creature: Put a +1/+1 counter on Gobbling Ooze.",
             "colours": [
@@ -4232,7 +4232,7 @@
         },
         {
             "id": "9d4e2346-db5f-5d97-ab1c-7bd3156ee761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511a42a8-71ce-476f-98fa-fc0dc822edcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511a42a8-71ce-476f-98fa-fc0dc822edcf.jpg?1",
             "name": "Golgari Decoy",
             "text": "All creatures able to block Golgari Decoy do so.\nScavenge {3}{G}{G} ({3}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "92c0ae74-e970-5124-870c-c17f45c101ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8d33ed-9ca2-41d1-ba35-fdeb5b88ad44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8d33ed-9ca2-41d1-ba35-fdeb5b88ad44.jpg?1",
             "name": "Horncaller's Chant",
             "text": "Put a 4/4 green Rhino creature token with trample onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "f18a3687-0be5-5fbd-8da2-9f26dc4802b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f319d57-7a54-4b10-86d4-58d7b3994844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f319d57-7a54-4b10-86d4-58d7b3994844.jpg?1",
             "name": "Korozda Monitor",
             "text": "Trample\nScavenge {5}{G}{G} ({5}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "1c9c846a-9e28-5570-bd35-7cd321a11d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7592d88-64e8-4a31-b00a-f65d4b1867fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7592d88-64e8-4a31-b00a-f65d4b1867fc.jpg?1",
             "name": "Mana Bloom",
             "text": "Mana Bloom enters the battlefield with X charge counters on it.\nRemove a charge counter from Mana Bloom: Add one mana of any color to your mana pool. Activate this ability only once each turn.\nAt the beginning of your upkeep, if Mana Bloom has no charge counters on it, return it to its owner's hand.",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "3b7bb5b6-a397-5d6a-b28e-19659eba65e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08274d1b-52b7-46c1-8f93-7631d2e21def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08274d1b-52b7-46c1-8f93-7631d2e21def.jpg?1",
             "name": "Oak Street Innkeeper",
             "text": "As long as it's not your turn, tapped creatures you control have hexproof.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "e7aff0b6-ca88-5e74-ba87-2a0bd464af82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51daaf9b-d8a8-49a6-94e1-0c8be2c6188b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51daaf9b-d8a8-49a6-94e1-0c8be2c6188b.jpg?1",
             "name": "Rubbleback Rhino",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "0daaac60-9627-5ade-b0de-644109b1ad25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa74aae-e857-410c-8836-953c8623d0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa74aae-e857-410c-8836-953c8623d0b0.jpg?1",
             "name": "Savage Surge",
             "text": "Target creature gets +2/+2 until end of turn. Untap that creature.",
             "colours": [
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "62071fce-5cb6-58a4-982e-cf70f216fa2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f52ac7-933f-4b31-8576-338f5dcf4285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f52ac7-933f-4b31-8576-338f5dcf4285.jpg?1",
             "name": "Seek the Horizon",
             "text": "Search your library for up to three basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "7c74fa2a-0972-5f1b-a69c-a0ee197df30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a439e8-d586-4995-abfc-3dee5c860968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a439e8-d586-4995-abfc-3dee5c860968.jpg?1",
             "name": "Slime Molding",
             "text": "Put an X/X green Ooze creature token onto the battlefield.",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "ffd3b061-b52f-521e-b9f9-a3cd10aff163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2517d74-0589-49dc-88f1-1fc02b27bc9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2517d74-0589-49dc-88f1-1fc02b27bc9d.jpg?1",
             "name": "Stonefare Crocodile",
             "text": "{2}{B}: Stonefare Crocodile gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "4f9c21bd-3be1-5ead-b62f-c2c1dbc651ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6049e92-6c52-44be-a3c7-aa8e8bf9c10a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6049e92-6c52-44be-a3c7-aa8e8bf9c10a.jpg?1",
             "name": "Towering Indrik",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "d7594213-b078-5fe3-91a5-0e3f4561af3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393c230f-5bc3-4b71-b5ac-81d5ce227df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393c230f-5bc3-4b71-b5ac-81d5ce227df5.jpg?1",
             "name": "Urban Burgeoning",
             "text": "Enchant land\nEnchanted land has \"Untap this land during each other player's untap step.\"",
             "colours": [
@@ -4632,7 +4632,7 @@
         },
         {
             "id": "a7df1656-dff2-532a-89ab-a53fa444ede6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d4ef98-949b-49db-b4f9-a070f8b4ff47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d4ef98-949b-49db-b4f9-a070f8b4ff47.jpg?1",
             "name": "Wild Beastmaster",
             "text": "Whenever Wild Beastmaster attacks, each other creature you control gets +X/+X until end of turn, where X is Wild Beastmaster's power.",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "bd46f5f7-4382-52e5-b6b9-a3d9a84cb4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d55cb-3a6b-4620-af25-10ae74ed32c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d55cb-3a6b-4620-af25-10ae74ed32c4.jpg?1",
             "name": "Worldspine Wurm",
             "text": "Trample\nWhen Worldspine Wurm dies, put three 5/5 green Wurm creature tokens with trample onto the battlefield.\nWhen Worldspine Wurm is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "62f644b3-742d-5aaf-a3a0-3e574fe96beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1e92b4-6e53-4dba-a572-c67e01965ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1e92b4-6e53-4dba-a572-c67e01965ac5.jpg?1",
             "name": "Abrupt Decay",
             "text": "Abrupt Decay can't be countered by spells or abilities.\nDestroy target nonland permanent with converted mana cost 3 or less.",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "9e882b7f-eca9-5c65-a1ae-22e63d8b3c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf91d847-4a87-4a65-8d6d-e20d538c5cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf91d847-4a87-4a65-8d6d-e20d538c5cec.jpg?1",
             "name": "Archon of the Triumvirate",
             "text": "Flying\nWhenever Archon of the Triumvirate attacks, detain up to two target nonland permanents your opponents control. (Until your next turn, those permanents can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "afaf189b-c45b-5aa4-a43c-dfd69f974901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cb4bf3-70d1-4acc-a1fb-49f4ea74ca16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cb4bf3-70d1-4acc-a1fb-49f4ea74ca16.jpg?1",
             "name": "Armada Wurm",
             "text": "Trample\nWhen Armada Wurm enters the battlefield, put a 5/5 green Wurm creature token with trample onto the battlefield.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "25d99b40-9fa1-5366-a49a-17c432d74341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9580a40b-b413-4f0d-9b38-13903a9d367d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9580a40b-b413-4f0d-9b38-13903a9d367d.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "7263c6e6-efe0-5d5a-aae1-ee7fff299792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26adc211-d089-4102-91e5-225bbeb5f382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26adc211-d089-4102-91e5-225bbeb5f382.jpg?1",
             "name": "Azorius Charm",
             "text": "Choose one \u2014 Creatures you control gain lifelink until end of turn; or draw a card; or put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "6f261cee-b479-5dc5-8547-6069f218fc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6df8f4d-a07a-4664-878d-efec8b2affb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6df8f4d-a07a-4664-878d-efec8b2affb9.jpg?1",
             "name": "Call of the Conclave",
             "text": "Put a 3/3 green Centaur creature token onto the battlefield.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "62c2c962-3471-51d0-a126-442baac64fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ada7ce-c693-48f0-a6e3-766f61d93370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ada7ce-c693-48f0-a6e3-766f61d93370.jpg?1",
             "name": "Carnival Hellsteed",
             "text": "First strike, haste\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "a8b5bc7d-8820-55fc-a5c5-69cbbcd4868d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833835d1-9beb-4ad8-b675-7adebdbd7d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833835d1-9beb-4ad8-b675-7adebdbd7d82.jpg?1",
             "name": "Centaur Healer",
             "text": "When Centaur Healer enters the battlefield, you gain 3 life.",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "e1f795ea-b79d-5a2c-bdcb-b7481c9b2dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfc2748-351f-4b5d-8a7e-bc51851578bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfc2748-351f-4b5d-8a7e-bc51851578bb.jpg?1",
             "name": "Chemister's Trick",
             "text": "Target creature you don't control gets -2/-0 until end of turn and attacks this turn if able.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "1ef0800a-f196-5a5e-a889-ba7936c18b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c84c4d-e6d6-4eac-9d14-5b6cba914c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c84c4d-e6d6-4eac-9d14-5b6cba914c3d.jpg?1",
             "name": "Collective Blessing",
             "text": "Creatures you control get +3/+3.",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "fcb4a480-82d5-5ade-a437-181b5a08d0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59965953-1522-4103-9a6c-5534205d34d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59965953-1522-4103-9a6c-5534205d34d9.jpg?1",
             "name": "Common Bond",
             "text": "Put a +1/+1 counter on target creature.\nPut a +1/+1 counter on target creature.",
             "colours": [
@@ -5085,7 +5085,7 @@
         },
         {
             "id": "4ba8d403-aca7-597b-a448-98fe891dfe0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35a8efe-2a3e-4060-9134-d4150e4bdf28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35a8efe-2a3e-4060-9134-d4150e4bdf28.jpg?1",
             "name": "Corpsejack Menace",
             "text": "If one or more +1/+1 counters would be placed on a creature you control, twice that many +1/+1 counters are placed on it instead.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "d52b7a2b-ba21-5b51-8d2c-d7fee6550dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4b773-40a4-4272-85dd-f728ada22748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4b773-40a4-4272-85dd-f728ada22748.jpg?1",
             "name": "Counterflux",
             "text": "Counterflux can't be countered by spells or abilities.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -5155,7 +5155,7 @@
         },
         {
             "id": "aae50f78-3afe-517f-9337-e9e7e3a11b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f027ceb0-5d2b-4cf6-87ad-e6b9b1e20634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f027ceb0-5d2b-4cf6-87ad-e6b9b1e20634.jpg?1",
             "name": "Coursers' Accord",
             "text": "Put a 3/3 green Centaur creature token onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "fbe1c72e-a3dd-5561-87f5-f5cb786cdbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee5464-83b7-4d7a-b407-9ee7de21535b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee5464-83b7-4d7a-b407-9ee7de21535b.jpg?1",
             "name": "Detention Sphere",
             "text": "When Detention Sphere enters the battlefield, you may exile target nonland permanent not named Detention Sphere and all other permanents with the same name as that permanent.\nWhen Detention Sphere leaves the battlefield, return the exiled cards to the battlefield under their owner's control.",
             "colours": [
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "c36f4a97-8f85-58ac-bc4c-8027d92ebaf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041afd23-1ecc-4cca-9244-fe42203ad689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041afd23-1ecc-4cca-9244-fe42203ad689.jpg?1",
             "name": "Dramatic Rescue",
             "text": "Return target creature to its owner's hand. You gain 2 life.",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "0799ee5c-7fee-5730-a0dc-1db9f9bdd192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83945c6-4dc6-4d9a-9bc2-2d4a264e5422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83945c6-4dc6-4d9a-9bc2-2d4a264e5422.jpg?1",
             "name": "Dreadbore",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -5291,7 +5291,7 @@
         },
         {
             "id": "ad0cd4da-3122-5b50-a625-e0b1c1678cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d42d6a-e9a0-449e-9b31-436c09b7c1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d42d6a-e9a0-449e-9b31-436c09b7c1ba.jpg?1",
             "name": "Dreg Mangler",
             "text": "Haste\nScavenge {3}{B}{G} ({3}{B}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "267545e0-b280-59bd-85b8-cfbe57b56095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f0b68a-de4b-4c0c-98ac-a812017f88a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f0b68a-de4b-4c0c-98ac-a812017f88a7.jpg?1",
             "name": "Epic Experiment",
             "text": "Exile the top X cards of your library. For each instant and sorcery card with converted mana cost X or less among them, you may cast that card without paying its mana cost. Then put all cards exiled this way that weren't cast into your graveyard.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "da71d3d1-73ff-5d5d-9d74-050d552fcd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98609dc-ea90-4c7e-a191-5e5d0ba16847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98609dc-ea90-4c7e-a191-5e5d0ba16847.jpg?1",
             "name": "Essence Backlash",
             "text": "Counter target creature spell. Essence Backlash deals damage equal to that spell's power to its controller.",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "2899b11b-3f1e-5848-ba90-c7eb9319251a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f42848-963b-4b16-aeec-66d0f349758b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f42848-963b-4b16-aeec-66d0f349758b.jpg?1",
             "name": "Fall of the Gavel",
             "text": "Counter target spell. You gain 5 life.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "b1970773-3e98-51c5-8349-9b66e75221b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5cb63-e7ec-4fc3-a389-4d8b5a4b96b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5cb63-e7ec-4fc3-a389-4d8b5a4b96b9.jpg?1",
             "name": "Firemind's Foresight",
             "text": "Search your library for an instant card with converted mana cost 3, reveal it, and put it into your hand. Then repeat this process for instant cards with converted mana costs 2 and 1. Then shuffle your library.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "c80c5386-f13a-539e-b343-704b02829a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb620f-4057-4f60-94b9-56ab855be974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb620f-4057-4f60-94b9-56ab855be974.jpg?1",
             "name": "Goblin Electromancer",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5501,7 +5501,7 @@
         },
         {
             "id": "295c7e0b-9513-5745-9016-ae1a11ae52bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fce388-eefc-4234-8dd9-1260c1ba97eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fce388-eefc-4234-8dd9-1260c1ba97eb.jpg?1",
             "name": "Golgari Charm",
             "text": "Choose one \u2014 All creatures get -1/-1 until end of turn; or destroy target enchantment; or regenerate each creature you control.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "9d3a4196-3813-5c64-832c-601ecd58db60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb5eb2a-ae7a-4416-970c-6e9306689c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb5eb2a-ae7a-4416-970c-6e9306689c88.jpg?1",
             "name": "Grisly Salvage",
             "text": "Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5569,7 +5569,7 @@
         },
         {
             "id": "a1c5f597-a919-5cdc-9bc4-627439fb572a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04560623-c768-4273-a40d-7e3f39e832cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04560623-c768-4273-a40d-7e3f39e832cf.jpg?1",
             "name": "Havoc Festival",
             "text": "Players can't gain life.\nAt the beginning of each player's upkeep, that player loses half his or her life, rounded up.",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "ad58f109-4aec-5587-a5bc-750d5e1989db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4984a089-84af-4387-9a0d-819b119b5565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4984a089-84af-4387-9a0d-819b119b5565.jpg?1",
             "name": "Hellhole Flailer",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\n{2}{B}{R}, Sacrifice Hellhole Flailer: Hellhole Flailer deals damage equal to its power to target player.",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "f5973c53-2f01-5600-be88-f96152fdb6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b56515-f688-495c-b721-2b9abc6628c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b56515-f688-495c-b721-2b9abc6628c2.jpg?1",
             "name": "Heroes' Reunion",
             "text": "Target player gains 7 life.",
             "colours": [
@@ -5674,7 +5674,7 @@
         },
         {
             "id": "d80c3626-c912-52fc-9f87-05ec436bd549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd775231-e1e0-41e2-ad9a-0726624f57f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd775231-e1e0-41e2-ad9a-0726624f57f9.jpg?1",
             "name": "Hussar Patrol",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nVigilance",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "29819eaf-27c4-5561-9e93-e16d61ea1269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f024b19a-923a-4313-be06-e743d3fbab46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f024b19a-923a-4313-be06-e743d3fbab46.jpg?1",
             "name": "Hypersonic Dragon",
             "text": "Flying, haste\nYou may cast sorcery spells as though they had flash. (You may cast them any time you could cast an instant.)",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "87428154-aad4-5739-a437-40930250f7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cce2d4-3944-4ff0-98e8-80f19697f108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cce2d4-3944-4ff0-98e8-80f19697f108.jpg?1",
             "name": "Isperia, Supreme Judge",
             "text": "Flying\nWhenever a creature attacks you or a planeswalker you control, you may draw a card.",
             "colours": [
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "da1add41-63d0-50e6-a4d0-074d93ec6589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5af6-5423-442b-a207-364e97a871d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5af6-5423-442b-a207-364e97a871d8.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014 Counter target noncreature spell unless its controller pays {2}; or Izzet Charm deals 2 damage to target creature; or draw two cards, then discard two cards.",
             "colours": [
@@ -5819,7 +5819,7 @@
         },
         {
             "id": "a039e0d1-b6b1-5ca0-b266-ea742fa3c251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ac2fe-532d-4d7e-9d74-07ae6850aac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ac2fe-532d-4d7e-9d74-07ae6850aac8.jpg?1",
             "name": "Izzet Staticaster",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nHaste\n{T}: Izzet Staticaster deals 1 damage to target creature and each other creature with the same name as that creature.",
             "colours": [
@@ -5856,7 +5856,7 @@
         },
         {
             "id": "8700a1ac-6c89-57b1-b0fd-ac27c8c446c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef18d1-fd05-4dbc-9fa7-a383799b34e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef18d1-fd05-4dbc-9fa7-a383799b34e9.jpg?1",
             "name": "Jarad, Golgari Lich Lord",
             "text": "Jarad, Golgari Lich Lord gets +1/+1 for each creature card in your graveyard.\n{1}{B}{G}, Sacrifice another creature: Each opponent loses life equal to the sacrificed creature's power.\nSacrifice a Swamp and a Forest: Return Jarad from your graveyard to your hand.",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "8f111c1b-ae7f-574d-b8a1-710ec873b78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59171ce-7dc6-4dd9-a124-3c2c3028d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59171ce-7dc6-4dd9-a124-3c2c3028d93d.jpg?1",
             "name": "Jarad's Orders",
             "text": "Search your library for up to two creature cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle your library.",
             "colours": [
@@ -5929,7 +5929,7 @@
         },
         {
             "id": "26db2038-94f2-5275-a76f-858d0a5f8cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761c16aa-d4a7-492d-9275-98d0e07de45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761c16aa-d4a7-492d-9275-98d0e07de45a.jpg?1",
             "name": "Korozda Guildmage",
             "text": "{1}{B}{G}: Target creature gets +1/+1 and gains intimidate until end of turn.\n{2}{B}{G}, Sacrifice a nontoken creature: Put X 1/1 green Saproling creature tokens onto the battlefield, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "42b4f76e-fef7-5a62-81ed-c0530eafc2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b628197-f26c-457a-b9a4-c1f1d3e02f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b628197-f26c-457a-b9a4-c1f1d3e02f3d.jpg?1",
             "name": "Lotleth Troll",
             "text": "Trample\nDiscard a creature card: Put a +1/+1 counter on Lotleth Troll.\n{B}: Regenerate Lotleth Troll.",
             "colours": [
@@ -6003,7 +6003,7 @@
         },
         {
             "id": "98e14bfd-45e0-565d-b314-3b362f298fc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69247168-2bfb-4cce-a2a6-61459a0fbce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69247168-2bfb-4cce-a2a6-61459a0fbce4.jpg?1",
             "name": "Loxodon Smiter",
             "text": "Loxodon Smiter can't be countered.\nIf a spell or ability an opponent controls causes you to discard Loxodon Smiter, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6040,7 +6040,7 @@
         },
         {
             "id": "74f86a46-9a4b-51e7-aecc-ea47968e6b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbeb3b-1579-4318-a024-4a2c06896eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbeb3b-1579-4318-a024-4a2c06896eaf.jpg?1",
             "name": "Lyev Skyknight",
             "text": "Flying\nWhen Lyev Skyknight enters the battlefield, detain target nonland permanent an opponent controls. (Until your next turn, that permanent can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -6077,7 +6077,7 @@
         },
         {
             "id": "b2779a0e-bc02-586d-8f41-b877e0bb345f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881728ce-4b18-410e-9cdb-4d439ce0b21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881728ce-4b18-410e-9cdb-4d439ce0b21d.jpg?1",
             "name": "Mercurial Chemister",
             "text": "{U}, {T}: Draw two cards.\n{R}, {T}, Discard a card: Mercurial Chemister deals damage to target creature equal to the discarded card's converted mana cost.",
             "colours": [
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "7e41f87f-f008-5bf3-8c0e-f8275bb3d33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b47d1-c72e-4dc3-b28b-7421e0163f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b47d1-c72e-4dc3-b28b-7421e0163f22.jpg?1",
             "name": "New Prahv Guildmage",
             "text": "{W}{U}: Target creature gains flying until end of turn.\n{3}{W}{U}: Detain target nonland permanent an opponent controls. (Until your next turn, that permanent can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "1b81600d-c722-52ea-a9c3-6657b6603ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fde47-8d9e-4a84-b8a5-dcfe0c1d443c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fde47-8d9e-4a84-b8a5-dcfe0c1d443c.jpg?1",
             "name": "Nivix Guildmage",
             "text": "{1}{U}{R}: Draw a card, then discard a card.\n{2}{U}{R}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "d08934de-8b16-5cdc-bfe1-de8aa6d5494b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345e475-8095-41b5-90b4-771fcf80b939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345e475-8095-41b5-90b4-771fcf80b939.jpg?1",
             "name": "Niv-Mizzet, Dracogenius",
             "text": "Flying\nWhenever Niv-Mizzet, Dracogenius deals damage to a player, you may draw a card.\n{U}{R}: Niv-Mizzet, Dracogenius deals 1 damage to target creature or player.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "d27352ef-8c8e-56d9-9b5f-15d039bd09f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd4394-d22d-4eec-ad73-ffaf10ad60de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd4394-d22d-4eec-ad73-ffaf10ad60de.jpg?1",
             "name": "Rakdos Charm",
             "text": "Choose one \u2014 Exile all cards from target player's graveyard; or destroy target artifact; or each creature deals 1 damage to its controller.",
             "colours": [
@@ -6261,7 +6261,7 @@
         },
         {
             "id": "7dc2a217-deb6-54cb-af9e-1e3753349604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb36840a-3f85-4fca-87ab-379dfce8e542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb36840a-3f85-4fca-87ab-379dfce8e542.jpg?1",
             "name": "Rakdos Ragemutt",
             "text": "Lifelink, haste",
             "colours": [
@@ -6298,7 +6298,7 @@
         },
         {
             "id": "faba4d3d-8baa-5016-b079-e382c08e3641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b54fbe8-324a-4066-bed1-dda1dca319fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b54fbe8-324a-4066-bed1-dda1dca319fc.jpg?1",
             "name": "Rakdos Ringleader",
             "text": "First strike\nWhenever Rakdos Ringleader deals combat damage to a player, that player discards a card at random.\n{B}: Regenerate Rakdos Ringleader.",
             "colours": [
@@ -6335,7 +6335,7 @@
         },
         {
             "id": "cc1f6453-9998-5adb-ae53-1c1ac30ee807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f3db71-802f-488c-b40d-ac90df2d660a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f3db71-802f-488c-b40d-ac90df2d660a.jpg?1",
             "name": "Rakdos, Lord of Riots",
             "text": "You can't cast Rakdos, Lord of Riots unless an opponent lost life this turn.\nFlying, trample\nCreature spells you cast cost {1} less to cast for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "7482cf30-2829-54a1-b377-09387bffc406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72981c0-1632-4d64-9341-2a76047d9b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72981c0-1632-4d64-9341-2a76047d9b36.jpg?1",
             "name": "Rakdos's Return",
             "text": "Rakdos's Return deals X damage to target opponent. That player discards X cards.",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "e26d82dd-fb07-5e1b-ba57-3732ef09c299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6695e5bb-56a9-49ab-8940-72336e845875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6695e5bb-56a9-49ab-8940-72336e845875.jpg?1",
             "name": "Righteous Authority",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each card in its controller's hand.\nAt the beginning of the draw step of enchanted creature's controller, that player draws an additional card.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "261d27d7-0744-541f-9f11-d21a0dc37f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6c136-2bbe-48c1-ac53-2a8221b96936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6c136-2bbe-48c1-ac53-2a8221b96936.jpg?1",
             "name": "Risen Sanctuary",
             "text": "Vigilance",
             "colours": [
@@ -6479,7 +6479,7 @@
         },
         {
             "id": "a32a9c14-b4ce-5169-bdc1-d4340a7ca2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115d504f-3aec-4374-8cd8-732d56c448f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115d504f-3aec-4374-8cd8-732d56c448f2.jpg?1",
             "name": "Rites of Reaping",
             "text": "Target creature gets +3/+3 until end of turn. Another target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -6513,7 +6513,7 @@
         },
         {
             "id": "a90b8ea5-cf4d-5258-9702-1ab18c97200a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb737465-5de8-4015-befe-2bf386da2a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb737465-5de8-4015-befe-2bf386da2a89.jpg?1",
             "name": "Rix Maadi Guildmage",
             "text": "{B}{R}: Target blocking creature gets -1/-1 until end of turn.\n{B}{R}: Target player who lost life this turn loses 1 life.",
             "colours": [
@@ -6550,7 +6550,7 @@
         },
         {
             "id": "4a740a27-923f-5629-9f93-0dc4ab5e298f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f625a-6e9e-40ba-ae46-cf6bafc0a41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f625a-6e9e-40ba-ae46-cf6bafc0a41b.jpg?1",
             "name": "Search Warrant",
             "text": "Target player reveals his or her hand. You gain life equal to the number of cards in that player's hand.",
             "colours": [
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "38e76f56-4271-56c7-95cb-92cf22d183d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9848eab-1d3a-4ab0-adf6-c20858aa3afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9848eab-1d3a-4ab0-adf6-c20858aa3afb.jpg?1",
             "name": "Selesnya Charm",
             "text": "Choose one \u2014 Target creature gets +2/+2 and gains trample until end of turn; or exile target creature with power 5 or greater; or put a 2/2 white Knight creature token with vigilance onto the battlefield.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "86ce8b1e-75b5-59e8-84e1-850d3bdd7a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8efb23-bac0-41d2-b4ee-27a6b1fe3134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8efb23-bac0-41d2-b4ee-27a6b1fe3134.jpg?1",
             "name": "Skull Rend",
             "text": "Skull Rend deals 2 damage to each opponent. Those players each discard two cards at random.",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "da00e288-5639-5e95-8809-5a52ab09c11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60601296-2229-4c48-94cc-1903926750ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60601296-2229-4c48-94cc-1903926750ce.jpg?1",
             "name": "Skymark Roc",
             "text": "Flying\nWhenever Skymark Roc attacks, you may return target creature defending player controls with toughness 2 or less to its owner's hand.",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "d2655e7a-1075-5cf2-b733-f7fdc9e50b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf37391d-db35-40a7-908a-abb53895793c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf37391d-db35-40a7-908a-abb53895793c.jpg?1",
             "name": "Slaughter Games",
             "text": "Slaughter Games can't be countered by spells or abilities.\nName a nonland card. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -6722,7 +6722,7 @@
         },
         {
             "id": "25a0576e-ee90-5fb7-aabe-8c62c01593f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6dbadf-a6f7-4876-9c3f-44e4a33b2bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6dbadf-a6f7-4876-9c3f-44e4a33b2bee.jpg?1",
             "name": "Sluiceway Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nScavenge {1}{B}{G} ({1}{B}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "7dbc20b9-c41c-5b2e-a338-35c4374ffbba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6196e702-7f76-49db-8ee4-bd343359d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6196e702-7f76-49db-8ee4-bd343359d498.jpg?1",
             "name": "Spawn of Rix Maadi",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "42af1e4f-ccd3-5a1c-890e-c5074c217cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404d9413-ef57-4b6e-8584-48a1dc7fe6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404d9413-ef57-4b6e-8584-48a1dc7fe6f1.jpg?1",
             "name": "Sphinx's Revelation",
             "text": "You gain X life and draw X cards.",
             "colours": [
@@ -6828,7 +6828,7 @@
         },
         {
             "id": "9f3eb978-cf16-5f9f-85ca-bbabecb160c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9648f9-7a67-4717-bca1-861d1f7fed43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9648f9-7a67-4717-bca1-861d1f7fed43.jpg?1",
             "name": "Supreme Verdict",
             "text": "Supreme Verdict can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -6862,7 +6862,7 @@
         },
         {
             "id": "75474a07-64de-52c2-ba8c-27e26d74d565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438c718-ac18-45d5-824e-5b697c5f0692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438c718-ac18-45d5-824e-5b697c5f0692.jpg?1",
             "name": "Teleportal",
             "text": "Target creature you control gets +1/+0 until end of turn and is unblockable this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "80953f98-2522-5e04-96c5-3a6e258fbb63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90514aa-e356-4502-9e0e-76ab7644a07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90514aa-e356-4502-9e0e-76ab7644a07a.jpg?1",
             "name": "Thoughtflare",
             "text": "Draw four cards, then discard two cards.",
             "colours": [
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "91c7d237-7aee-5e22-a790-6e5d7a4ec652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c0e00b-2290-493f-a3fc-3b9bff2830cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c0e00b-2290-493f-a3fc-3b9bff2830cc.jpg?1",
             "name": "Treasured Find",
             "text": "Return target card from your graveyard to your hand. Exile Treasured Find.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "3e0da6f3-6cc2-56ab-990f-e5348cd51e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d224279-83f3-4a29-9fd9-86b72407b87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d224279-83f3-4a29-9fd9-86b72407b87a.jpg?1",
             "name": "Trestle Troll",
             "text": "Defender\nReach (This creature can block creatures with flying.)\n{1}{B}{G}: Regenerate Trestle Troll.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "3dfc134d-58d9-506d-8f99-9ade811624ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d9d86-5666-4e59-9766-137657b4e040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d9d86-5666-4e59-9766-137657b4e040.jpg?1",
             "name": "Trostani, Selesnya's Voice",
             "text": "Whenever another creature enters the battlefield under your control, you gain life equal to that creature's toughness.\n{1}{G}{W}, {T}: Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7038,7 +7038,7 @@
         },
         {
             "id": "beebbebd-a4b6-566e-b208-015157af6ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54f8e61-550f-4493-b8ba-65f81b2457d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54f8e61-550f-4493-b8ba-65f81b2457d3.jpg?1",
             "name": "Vitu-Ghazi Guildmage",
             "text": "{4}{G}{W}: Put a 3/3 green Centaur creature token onto the battlefield.\n{2}{G}{W}: Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7075,7 +7075,7 @@
         },
         {
             "id": "48e634f1-32cd-5773-a6ed-93cd70e05f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8971938c-cd26-4b83-96d7-1408cd0b0de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8971938c-cd26-4b83-96d7-1408cd0b0de6.jpg?1",
             "name": "Vraska the Unseen",
             "text": "+1: Until your next turn, whenever a creature deals combat damage to Vraska the Unseen, destroy that creature.\n-3: Destroy target nonland permanent.\n-7: Put three 1/1 black Assassin creature tokens onto the battlefield with \"Whenever this creature deals combat damage to a player, that player loses the game.\"",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "7bfb1a19-dcfd-51c6-9c1a-20f79be810ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125e6aa-f916-4dfa-a9fe-82bb546012af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125e6aa-f916-4dfa-a9fe-82bb546012af.jpg?1",
             "name": "Wayfaring Temple",
             "text": "Wayfaring Temple's power and toughness are each equal to the number of creatures you control.\nWhenever Wayfaring Temple deals combat damage to a player, populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "a1d0f719-4825-5938-8a0f-503a1effae99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e82934-546b-4734-a715-b22ace4c5a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e82934-546b-4734-a715-b22ace4c5a9b.jpg?1",
             "name": "Azor's Elocutors",
             "text": "At the beginning of your upkeep, put a filibuster counter on Azor's Elocutors. Then if Azor's Elocutors has five or more filibuster counters on it, you win the game.\nWhenever a source deals damage to you, remove a filibuster counter from Azor's Elocutors.",
             "colours": [
@@ -7186,7 +7186,7 @@
         },
         {
             "id": "c25092b0-f825-5c25-bef8-21d70492393c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a8e716-ea33-4ae2-9ff8-5e78b0e50459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a8e716-ea33-4ae2-9ff8-5e78b0e50459.jpg?1",
             "name": "Blistercoil Weird",
             "text": "Whenever you cast an instant or sorcery spell, Blistercoil Weird gets +1/+1 until end of turn. Untap it.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "99327fe0-7d94-565a-805e-97a57bfb9683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffd77d7-3fe6-4493-96eb-f62183c0358d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffd77d7-3fe6-4493-96eb-f62183c0358d.jpg?1",
             "name": "Cryptborn Horror",
             "text": "Trample\nCryptborn Horror enters the battlefield with X +1/+1 counters on it, where X is the total life lost by your opponents this turn.",
             "colours": [
@@ -7258,7 +7258,7 @@
         },
         {
             "id": "407ac6a4-cb3c-54f9-beb0-08e7e5d81c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70496f16-c4c0-4c03-beef-454eb4824cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70496f16-c4c0-4c03-beef-454eb4824cd1.jpg?1",
             "name": "Deathrite Shaman",
             "text": "{T}: Exile target land card from a graveyard. Add one mana of any color to your mana pool.\n{B}, {T}: Exile target instant or sorcery card from a graveyard. Each opponent loses 2 life.\n{G}, {T}: Exile target creature card from a graveyard. You gain 2 life.",
             "colours": [
@@ -7295,7 +7295,7 @@
         },
         {
             "id": "ba4f0d83-c19a-529f-9983-6d2845970883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb8cb8c-0d03-4cbf-b7f2-a97324817698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb8cb8c-0d03-4cbf-b7f2-a97324817698.jpg?1",
             "name": "Dryad Militant",
             "text": "If an instant or sorcery card would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -7332,7 +7332,7 @@
         },
         {
             "id": "fe23238c-357b-5cbb-98a4-1ebd8ec5743e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5a68d3-6bc9-4de8-bc06-e1106cf9b3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5a68d3-6bc9-4de8-bc06-e1106cf9b3d4.jpg?1",
             "name": "Frostburn Weird",
             "text": "{UR}: Frostburn Weird gets +1/-1 until end of turn.",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "51d539bb-b34f-530e-9c12-9b865503ceef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44058ba-3419-4777-8d59-05dea5e864e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44058ba-3419-4777-8d59-05dea5e864e1.jpg?1",
             "name": "Golgari Longlegs",
             "text": "",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "8c0afb1c-fb48-51a9-a6e6-92ec52e3debc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f31616-1249-4964-b81a-4435405a2449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f31616-1249-4964-b81a-4435405a2449.jpg?1",
             "name": "Growing Ranks",
             "text": "At the beginning of your upkeep, populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "ded40915-eb69-56ed-82de-ed0e454cb51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc51899-3970-416b-b7de-fadbc9678955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc51899-3970-416b-b7de-fadbc9678955.jpg?1",
             "name": "Judge's Familiar",
             "text": "Flying\nSacrifice Judge's Familiar: Counter target instant or sorcery spell unless its controller pays {1}.",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "3f5440f7-cd72-523d-9526-f455ba084e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1892003-2e4c-43bd-8a37-3a97a76f113a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1892003-2e4c-43bd-8a37-3a97a76f113a.jpg?1",
             "name": "Nivmagus Elemental",
             "text": "Exile an instant or sorcery spell you control: Put two +1/+1 counters on Nivmagus Elemental. (That spell won't resolve.)",
             "colours": [
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "8a798a57-5261-5d35-9b30-1eb10e871cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f873c0b-e779-4f09-8e9c-94a1765eb5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f873c0b-e779-4f09-8e9c-94a1765eb5da.jpg?1",
             "name": "Rakdos Cackler",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -7546,7 +7546,7 @@
         },
         {
             "id": "0b2f5e44-6d29-5f58-9c56-e3e723153f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06899549-5534-4d11-86c1-afd1796e18b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06899549-5534-4d11-86c1-afd1796e18b1.jpg?1",
             "name": "Rakdos Shred-Freak",
             "text": "Haste",
             "colours": [
@@ -7583,7 +7583,7 @@
         },
         {
             "id": "3c1d4f62-a592-5ded-ac9e-f876097e6ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9327905-a254-4885-8310-69fc153ec52f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9327905-a254-4885-8310-69fc153ec52f.jpg?1",
             "name": "Slitherhead",
             "text": "Scavenge {0} ({0}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -7620,7 +7620,7 @@
         },
         {
             "id": "25aa872b-5d06-5769-81c5-b280d432311c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5048e-cb76-48c4-8a95-70dcc14775f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5048e-cb76-48c4-8a95-70dcc14775f6.jpg?1",
             "name": "Sundering Growth",
             "text": "Destroy target artifact or enchantment, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7654,7 +7654,7 @@
         },
         {
             "id": "6a677ade-135e-5763-a464-53e14b87de26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc61748-029f-4bae-a7ec-e08b7059226d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc61748-029f-4bae-a7ec-e08b7059226d.jpg?1",
             "name": "Vassal Soul",
             "text": "Flying",
             "colours": [
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "fe109cd6-5c42-516b-ae92-8d5ccfefde45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a05db7-dcae-4180-8ad1-60ba6fb30816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a05db7-dcae-4180-8ad1-60ba6fb30816.jpg?1",
             "name": "Azorius Keyrune",
             "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}: Azorius Keyrune becomes a 2/2 white and blue Bird artifact creature with flying until end of turn.",
             "colours": [],
@@ -7721,7 +7721,7 @@
         },
         {
             "id": "94e92c02-a660-50b9-9fd0-601bcc547837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f4e0f0-13d1-43ed-8d95-13cff94a26e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f4e0f0-13d1-43ed-8d95-13cff94a26e7.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "f7489abf-d449-5475-b35c-5056d8bd1ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c9247e-05f4-44bb-86e3-90a60e880374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c9247e-05f4-44bb-86e3-90a60e880374.jpg?1",
             "name": "Civic Saber",
             "text": "Equipped creature gets +1/+0 for each of its colors.\nEquip {1}",
             "colours": [],
@@ -7779,7 +7779,7 @@
         },
         {
             "id": "e9f14529-25ce-56cd-bdee-22e3eca7c9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b632b-ee20-4082-8376-1dae53f91b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b632b-ee20-4082-8376-1dae53f91b70.jpg?1",
             "name": "Codex Shredder",
             "text": "{T}: Target player puts the top card of his or her library into his or her graveyard.\n{5}, {T}, Sacrifice Codex Shredder: Return target card from your graveyard to your hand.",
             "colours": [],
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "1acf866f-bbcb-531f-94fc-fd07165b1bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b803f-ba82-4660-86be-49677d1e32c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b803f-ba82-4660-86be-49677d1e32c9.jpg?1",
             "name": "Golgari Keyrune",
             "text": "{T}: Add {B} or {G} to your mana pool.\n{B}{G}: Golgari Keyrune becomes a 2/2 black and green Insect artifact creature with deathtouch until end of turn.",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "a7ac23c6-1586-5731-81ad-8802c65e0d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e4e83b-cbb8-4efd-b6c4-4459a29177ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e4e83b-cbb8-4efd-b6c4-4459a29177ac.jpg?1",
             "name": "Izzet Keyrune",
             "text": "{T}: Add {U} or {R} to your mana pool.\n{U}{R}: Until end of turn, Izzet Keyrune becomes a 2/1 blue and red Elemental artifact creature.\nWhenever Izzet Keyrune deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [],
@@ -7869,7 +7869,7 @@
         },
         {
             "id": "0c090097-dc52-5593-bad4-f0397994e1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c1e91-9d75-46a3-9e0d-56d29fcb01a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c1e91-9d75-46a3-9e0d-56d29fcb01a7.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, name a card.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "b51d3bd3-090a-58dd-ac2d-e3e559550f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6124b4c-49a1-42e3-a6ff-62de231c7823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6124b4c-49a1-42e3-a6ff-62de231c7823.jpg?1",
             "name": "Rakdos Keyrune",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{B}{R}: Rakdos Keyrune becomes a 3/1 black and red Devil artifact creature with first strike until end of turn.",
             "colours": [],
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "744899b4-461b-5e2a-b50d-e705a554a109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1645eafd-cd17-463a-9d7e-42f5f7b5196f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1645eafd-cd17-463a-9d7e-42f5f7b5196f.jpg?1",
             "name": "Selesnya Keyrune",
             "text": "{T}: Add {G} or {W} to your mana pool.\n{G}{W}: Selesnya Keyrune becomes a 3/3 green and white Wolf artifact creature until end of turn.",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "f1817e1d-df5a-57ef-b4c2-3cd78261a7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a62827a-183f-4bef-b6ce-20a4577f6d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a62827a-183f-4bef-b6ce-20a4577f6d30.jpg?1",
             "name": "Street Sweeper",
             "text": "Whenever Street Sweeper attacks, destroy all Auras attached to target land.",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "104dfd9f-21b2-5e94-9739-48aa5d35fc02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b006384-6fb6-4129-b1d2-7674d1141f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b006384-6fb6-4129-b1d2-7674d1141f8f.jpg?1",
             "name": "Tablet of the Guilds",
             "text": "As Tablet of the Guilds enters the battlefield, choose two colors.\nWhenever you cast a spell, if it's at least one of the chosen colors, you gain 1 life for each of the chosen colors it is.",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "f0d80ec2-2f6e-57e0-bbb1-232624482086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5055ed18-b234-4702-92eb-4d483431ff47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5055ed18-b234-4702-92eb-4d483431ff47.jpg?1",
             "name": "Volatile Rig",
             "text": "Trample\nVolatile Rig attacks each turn if able.\nWhenever Volatile Rig is dealt damage, flip a coin. If you lose the flip, sacrifice Volatile Rig.\nWhen Volatile Rig dies, flip a coin. If you lose the flip, it deals 4 damage to each creature and each player.",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "5a32f8d8-aeac-5393-a41a-ba40cad7af39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984e37df-0734-493a-a958-f519a0c98580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984e37df-0734-493a-a958-f519a0c98580.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "a8e77a71-0ddb-5d2c-bc96-4f1a6e9f5274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd5828b-8dcd-4ce6-b834-ebe9cbaa12d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd5828b-8dcd-4ce6-b834-ebe9cbaa12d1.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R} to your mana pool.)\nAs Blood Crypt enters the battlefield, you may pay 2 life. If you don't, Blood Crypt enters the battlefield tapped.",
             "colours": [],
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "a6110455-8f32-5819-9c2c-4f934d80b38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe2fd1a-f7d3-48b4-bad8-be5ee45d6121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe2fd1a-f7d3-48b4-bad8-be5ee45d6121.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "aceaeff5-6070-5f26-b825-34da90891163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf60ca0-e01f-499c-8d04-d59050f38c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf60ca0-e01f-499c-8d04-d59050f38c33.jpg?1",
             "name": "Grove of the Guardian",
             "text": "{T}: Add {1} to your mana pool.\n{3}{G}{W}, {T}, Tap two untapped creatures you control, Sacrifice Grove of the Guardian: Put an 8/8 green and white Elemental creature token with vigilance onto the battlefield.",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "a48a7df6-1a09-5c2f-8879-8134249a7555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7091c9-5f98-4078-a42b-c9e057346d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7091c9-5f98-4078-a42b-c9e057346d9b.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U} to your mana pool.)\nAs Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, Hallowed Fountain enters the battlefield tapped.",
             "colours": [],
@@ -8214,7 +8214,7 @@
         },
         {
             "id": "7cb7f243-78d3-5622-bd52-c8461b3d1822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6951d84f-2d3c-4203-8d31-e08f4bc707f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6951d84f-2d3c-4203-8d31-e08f4bc707f0.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8247,7 +8247,7 @@
         },
         {
             "id": "05e270c9-fac0-5bd8-8654-3ff9e1ddd957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7d50d6-b63a-4d8c-88fa-1d78ae693a45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7d50d6-b63a-4d8c-88fa-1d78ae693a45.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G} to your mana pool.)\nAs Overgrown Tomb enters the battlefield, you may pay 2 life. If you don't, Overgrown Tomb enters the battlefield tapped.",
             "colours": [],
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "cbf17453-adf0-597e-996d-99e484418919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207048f5-268b-4cdb-b4e7-c8282cac1b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207048f5-268b-4cdb-b4e7-c8282cac1b28.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "85699155-7a97-5a3d-8fb3-817e1fcf34b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f416e36a-15cb-43c8-b27f-82f65a95ddef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f416e36a-15cb-43c8-b27f-82f65a95ddef.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {1} to your mana pool.\n{4}, {T}: Target creature is unblockable this turn.",
             "colours": [],
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "6bd7acda-c26d-5558-917a-fa7233494954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff61d4e4-3c8c-48f7-a994-ec2317bbd9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff61d4e4-3c8c-48f7-a994-ec2317bbd9a0.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "e471d793-14da-551b-a4e7-fbf0a1bfc3f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de911c88-f5c8-4955-9fa5-1f28a9b17236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de911c88-f5c8-4955-9fa5-1f28a9b17236.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R} to your mana pool.)\nAs Steam Vents enters the battlefield, you may pay 2 life. If you don't, Steam Vents enters the battlefield tapped.",
             "colours": [],
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "a740fc1f-cab9-5a5e-9d82-c480c5adcfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b821e604-f9fd-47a4-b5ff-bfb5022834c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b821e604-f9fd-47a4-b5ff-bfb5022834c2.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W} to your mana pool.)\nAs Temple Garden enters the battlefield, you may pay 2 life. If you don't, Temple Garden enters the battlefield tapped.",
             "colours": [],
@@ -8443,7 +8443,7 @@
         },
         {
             "id": "40f96673-3900-592d-bffd-d15665a25898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ce8115-41fe-44c2-8719-741ba87bcb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ce8115-41fe-44c2-8719-741ba87bcb17.jpg?1",
             "name": "Transguild Promenade",
             "text": "Transguild Promenade enters the battlefield tapped.\nWhen Transguild Promenade enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "bdfd114d-cad4-5b1c-a4a0-c9d5266758a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac754820-343e-4c01-bcfa-89fa5c8c7e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac754820-343e-4c01-bcfa-89fa5c8c7e1d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8510,7 +8510,7 @@
         },
         {
             "id": "cfde8495-0254-582c-a40f-ebd0686eb737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34044cf5-79ed-479c-abdc-3718ec193dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34044cf5-79ed-479c-abdc-3718ec193dd3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8549,7 +8549,7 @@
         },
         {
             "id": "7ac30db4-5f2e-593b-93be-ede877251f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9bcca-b41a-4a6a-b380-36bfea9f0715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9bcca-b41a-4a6a-b380-36bfea9f0715.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "68779ab2-469a-5969-8495-319aca24958a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d293ea0f-8b87-4d8a-ad8f-650131c83c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d293ea0f-8b87-4d8a-ad8f-650131c83c20.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8627,7 +8627,7 @@
         },
         {
             "id": "22a77a78-9b38-5ec2-a07a-9511d8c5f034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0334fe-3de3-4779-a31d-d021db50b62b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0334fe-3de3-4779-a31d-d021db50b62b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8666,7 +8666,7 @@
         },
         {
             "id": "77977e3a-9366-5a59-bf56-ff863278ec45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f35064-c662-48ff-a2a9-d26f594500f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f35064-c662-48ff-a2a9-d26f594500f5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "d2cae570-18ad-5b8f-82ba-7180464316c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc5e0d9-1c8f-4d38-9915-40469988983d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc5e0d9-1c8f-4d38-9915-40469988983d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8744,7 +8744,7 @@
         },
         {
             "id": "15612963-4a63-5c3f-bcad-82d9ea4a3000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10e5b17-6099-445d-9a7b-484eeff7cea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10e5b17-6099-445d-9a7b-484eeff7cea8.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "1c1c7e9f-d959-532e-a2ff-253366d7e0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7869f14e-d1d5-4a99-bc2c-f3a0d63077a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7869f14e-d1d5-4a99-bc2c-f3a0d63077a5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8822,7 +8822,7 @@
         },
         {
             "id": "5bac5f92-3821-5c1d-8bea-929222fe3d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070e97c-142a-4d5d-ae89-c0c6d85a97ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070e97c-142a-4d5d-ae89-c0c6d85a97ac.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8861,7 +8861,7 @@
         },
         {
             "id": "c84fb37b-2ebf-5eba-8485-8bd9aa847f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8c3f29-121e-42d1-be21-29f403f97708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8c3f29-121e-42d1-be21-29f403f97708.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "58df248d-fc92-5bb4-9dbe-8d97a76f6af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73b50e-8230-41e5-8492-db8f749d00a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73b50e-8230-41e5-8492-db8f749d00a4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8939,7 +8939,7 @@
         },
         {
             "id": "ca7d5bf1-3358-5fab-93a2-cc5b6353cabc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46908606-f572-4b2d-9562-ed9c6f50f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46908606-f572-4b2d-9562-ed9c6f50f1ad.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "4e18e9da-11e4-54c6-bd08-30a9d979cef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cd375e-f41c-42b1-bbd4-36032d4fb92d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cd375e-f41c-42b1-bbd4-36032d4fb92d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "5974900b-fc2a-599c-854f-7b1bff284bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745b1731-af31-44d2-ad50-b3e43b620913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745b1731-af31-44d2-ad50-b3e43b620913.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9056,7 +9056,7 @@
         },
         {
             "id": "8ed8d3d1-47da-5acb-a7f7-c5354992559e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4a196f-de7e-4100-ad65-56cf8b0a8b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4a196f-de7e-4100-ad65-56cf8b0a8b23.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9095,7 +9095,7 @@
         },
         {
             "id": "a82cd940-f0e4-5d30-b157-288ea7a10cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b2d0ed-0b47-459a-8f5c-554dd816c03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b2d0ed-0b47-459a-8f5c-554dd816c03a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9134,7 +9134,7 @@
         },
         {
             "id": "818ad8df-ec4c-57cd-bafc-f3552f848744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5353e8b2-3280-48ec-9bc2-8c8e7a15b460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5353e8b2-3280-48ec-9bc2-8c8e7a15b460.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "7b1f34d0-ebd9-5cf2-aaba-8311ac58d11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b61852-860e-4f89-a1b2-6429168f0c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b61852-860e-4f89-a1b2-6429168f0c02.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9212,7 +9212,7 @@
         },
         {
             "id": "1d4bb587-5cce-593a-a64c-a26232c53a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96614dc1-9386-4861-b792-b83bcc6c5811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96614dc1-9386-4861-b792-b83bcc6c5811.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9251,7 +9251,7 @@
         },
         {
             "id": "9255569f-4eba-5d9a-b6ed-9f5517a93974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00849dd-c1ba-4171-a503-603fe77c0a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00849dd-c1ba-4171-a503-603fe77c0a43.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "9303cb30-5ff4-5086-ad35-8bd3fdce39f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1428575c-f18e-41a0-b58a-259d2feafd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1428575c-f18e-41a0-b58a-259d2feafd06.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "59cfbbcd-9195-575e-9a1d-83f3fbe37441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6850740-6219-4f82-a705-2e7b20ede751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6850740-6219-4f82-a705-2e7b20ede751.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9368,7 +9368,7 @@
         },
         {
             "id": "db7bf927-d540-53fe-89ad-f84e0091983a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc50993-1fd4-4dba-9d2f-ae7a18559829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc50993-1fd4-4dba-9d2f-ae7a18559829.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9407,7 +9407,7 @@
         },
         {
             "id": "d54ead09-b0a2-590c-a817-e37ca4278208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfcde62-1b20-48ce-8ba0-7929edcd26fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfcde62-1b20-48ce-8ba0-7929edcd26fc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9446,7 +9446,7 @@
         },
         {
             "id": "eef39312-4e8d-5768-93e0-2a29cd65a030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4dbe1-12ac-404f-a1fe-96e0b620533e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4dbe1-12ac-404f-a1fe-96e0b620533e.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -9480,7 +9480,7 @@
         },
         {
             "id": "9c8242c0-385f-5376-b45c-c4059d30cb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d3d039-248a-4eb8-be5c-12959b458fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d3d039-248a-4eb8-be5c-12959b458fea.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "c9ab1a15-5d57-567b-ade2-47532db5b778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944a40e8-5469-4d8b-b044-67ff3382ec92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944a40e8-5469-4d8b-b044-67ff3382ec92.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9548,7 +9548,7 @@
         },
         {
             "id": "343e8a60-15d6-5115-b490-64e639348116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89eb9f92-d189-4438-b6fe-cb253055d63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89eb9f92-d189-4438-b6fe-cb253055d63e.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "2fcc3061-95f2-59ee-88eb-beb5f3eb18b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84310f84-3e5f-4db8-bff1-16bef64de1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84310f84-3e5f-4db8-bff1-16bef64de1a0.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -9616,7 +9616,7 @@
         },
         {
             "id": "f9ad44ed-4d40-5eb7-b192-d444a13bab27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577c2e32-deb6-40d9-a050-c2acb5bfc05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577c2e32-deb6-40d9-a050-c2acb5bfc05f.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "fa42ee21-15bf-591e-93c7-0f78f10e338f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880d5dc1-ceec-4c5f-93c2-c88b7dbfcac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880d5dc1-ceec-4c5f-93c2-c88b7dbfcac2.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -9684,7 +9684,7 @@
         },
         {
             "id": "89047637-7bd8-5e84-9360-5f00bae47f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a686e51d-e8c3-4ed6-8357-c3d38d56dd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a686e51d-e8c3-4ed6-8357-c3d38d56dd09.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9718,7 +9718,7 @@
         },
         {
             "id": "8919ba50-388c-5db4-8e92-eda31e897401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1331008a-ae86-4640-b823-a73be766ac16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1331008a-ae86-4640-b823-a73be766ac16.jpg?1",
             "name": "Rhino",
             "text": "",
             "colours": [
@@ -9752,7 +9752,7 @@
         },
         {
             "id": "ec48d786-606c-5cdb-9ff7-9dda3252239c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6544989-91b4-4db7-ad44-f1355f1d6e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6544989-91b4-4db7-ad44-f1355f1d6e6b.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "50d906a7-4408-5cfd-9dc9-e0546a2963b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ee3f6c-5df6-4271-b2f9-86b9afffab7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ee3f6c-5df6-4271-b2f9-86b9afffab7b.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "8fda9b74-0f10-5f90-8500-a5fa3024c84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64c5f80-4676-4860-be0e-20bcf2227405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64c5f80-4676-4860-be0e-20bcf2227405.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/SCG.json
+++ b/Assets/Resources/Sets/SCG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "43d45f84-f88b-5b40-a959-57638302e41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa4a19-8eba-4c43-8a9a-636e234df751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa4a19-8eba-4c43-8a9a-636e234df751.jpg?1",
             "name": "Ageless Sentinels",
             "text": "(Walls can't attack.)\nFlying\nWhen Ageless Sentinels blocks, its creature type becomes Giant Bird. (It's no longer a Wall. This effect doesn't end at end of turn.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "9af7a130-c5e7-52dc-b3bd-4694ce5cfc65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f836d3-52c8-4628-b18a-8c8fb67969c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f836d3-52c8-4628-b18a-8c8fb67969c9.jpg?1",
             "name": "Astral Steel",
             "text": "Target creature gets +1/+2 until end of turn.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "e2490c2b-368e-5fe3-8d46-be5815aa1367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47854e89-4d22-4eb6-a77d-6f04407bd2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47854e89-4d22-4eb6-a77d-6f04407bd2e5.jpg?1",
             "name": "Aven Farseer",
             "text": "Flying\nWhenever a creature is turned face up, put a +1/+1 counter on Aven Farseer.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "e74e8390-80ca-5f3b-b4c2-973e31ed2434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2804006-2a60-400c-be0b-8aa042469372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2804006-2a60-400c-be0b-8aa042469372.jpg?1",
             "name": "Aven Liberator",
             "text": "Flying\nMorph {3}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Aven Liberator is turned face up, target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "a4ce8241-679e-59af-b7f8-ec7e17a11bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f26b88-cffc-47ed-a70a-7d704a32c8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f26b88-cffc-47ed-a70a-7d704a32c8bb.jpg?1",
             "name": "Daru Spiritualist",
             "text": "Whenever a Cleric you control becomes the target of a spell or ability, it gets +0/+2 until end of turn.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "399f714a-8c06-5fe4-b5e5-1e698e6a3446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2630d3b5-8f3a-4aad-a45e-22a7979429f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2630d3b5-8f3a-4aad-a45e-22a7979429f3.jpg?1",
             "name": "Daru Warchief",
             "text": "Soldier spells you play cost {1} less to play.\nSoldiers you control get +1/+2.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "7441ab94-d4ba-5f4c-bd82-7a9c52f2e8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90a303-25fb-460b-bd55-6249f61c361c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90a303-25fb-460b-bd55-6249f61c361c.jpg?1",
             "name": "Dawn Elemental",
             "text": "Flying\nPrevent all damage that would be dealt to Dawn Elemental.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "6f1977e3-15a4-5d3c-b3f3-5342e90d1506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8a7e5c-f252-4de8-94d7-e7327210bf26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8a7e5c-f252-4de8-94d7-e7327210bf26.jpg?1",
             "name": "Decree of Justice",
             "text": "Put X 4/4 white Angel creature tokens with flying into play.\nCycling {2}{W}\nWhen you cycle Decree of Justice, you may pay {X}. If you do, put X 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "e4702bbe-937a-51e5-a09d-70a937bf122e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2832-07c5-47be-8966-b250fb997f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2832-07c5-47be-8966-b250fb997f78.jpg?1",
             "name": "Dimensional Breach",
             "text": "Remove all permanents from the game. As long as any of those cards remain removed from the game, at the beginning of each player's upkeep, that player returns one of the removed cards he or she owns to play.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "09257f29-80d3-5535-a6ae-5db5919ff22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e78b364-015d-4074-ad9e-55c973ce2f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e78b364-015d-4074-ad9e-55c973ce2f4b.jpg?1",
             "name": "Dragon Scales",
             "text": "Enchanted creature gets +1/+2 and attacking doesn't cause it to tap.\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Scales from your graveyard to play enchanting that creature.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "5bd404f8-b3e5-5f0e-b7fd-981ba0bb4e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58017ff1-74d2-4be2-976a-8dff53e16150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58017ff1-74d2-4be2-976a-8dff53e16150.jpg?1",
             "name": "Dragonstalker",
             "text": "Flying, protection from Dragons",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "6b2cb786-eff3-50e1-b474-1f3559f46ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0596928c-2b20-4dbb-aa78-3ab6c3ce0d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0596928c-2b20-4dbb-aa78-3ab6c3ce0d72.jpg?1",
             "name": "Eternal Dragon",
             "text": "Flying\n{3}{W}{W}: Return Eternal Dragon from your graveyard to your hand. Play this ability only during your upkeep.\nPlainscycling {2} ({2}, Discard this card from your hand: Search your library for a plains card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "67849427-5dbc-541a-bfda-be44ccbd968f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aaf095-143a-43fc-a858-b1e82a4b906e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aaf095-143a-43fc-a858-b1e82a4b906e.jpg?1",
             "name": "Exiled Doomsayer",
             "text": "All morph costs cost {2} more. (This doesn't affect the cost to play creatures face down.)",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "517df31b-6ff3-5c42-b578-c11e143e3ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742ac116-86ed-4ce6-9805-76f47a41c4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742ac116-86ed-4ce6-9805-76f47a41c4c4.jpg?1",
             "name": "Force Bubble",
             "text": "If damage would be dealt to you, put that many depletion counters on Force Bubble instead.\nWhen there are four or more depletion counters on Force Bubble, sacrifice it.\nAt end of turn, remove all depletion counters from Force Bubble.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "12c63c1d-7950-5c85-a6e5-c30b7f96e24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c43fac2-62fb-4924-848d-a8d739773d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c43fac2-62fb-4924-848d-a8d739773d6e.jpg?1",
             "name": "Frontline Strategist",
             "text": "Morph {W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Frontline Strategist is turned face up, prevent all combat damage non-Soldiers would deal this turn.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "a548ddea-6a92-5758-b319-f6417c617f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b92597-cb1e-4b8f-9ee9-07b48cf1a5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b92597-cb1e-4b8f-9ee9-07b48cf1a5c6.jpg?1",
             "name": "Gilded Light",
             "text": "You can't be the target of spells or abilities this turn.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "d47059e6-c124-5d2e-9d3f-cc800dd3ec47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b8701c-0f03-4ad0-9097-3caf885abd59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b8701c-0f03-4ad0-9097-3caf885abd59.jpg?1",
             "name": "Guilty Conscience",
             "text": "Whenever enchanted creature deals damage, Guilty Conscience deals that much damage to enchanted creature.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "63d88e58-fd41-527b-a200-e29e6af02b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914a1200-b77c-4a2c-96c6-7cc624ee9a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914a1200-b77c-4a2c-96c6-7cc624ee9a6a.jpg?1",
             "name": "Karona's Zealot",
             "text": "Morph {3}{W}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Karona's Zealot is turned face up, all damage that would be dealt to it this turn is dealt to target creature instead.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "027d67ed-65ee-5ef2-ad4e-b721ae135c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ede92-e64f-44a5-afb6-c7495077fb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ede92-e64f-44a5-afb6-c7495077fb0b.jpg?1",
             "name": "Noble Templar",
             "text": "Attacking doesn't cause Noble Templar to tap.\nPlainscycling {2} ({2}, Discard this card from your hand: Search your library for a plains card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "e4961221-87a4-56c5-9aac-ea15becb9152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418476cd-94da-47a5-ba77-6bb4771e9c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418476cd-94da-47a5-ba77-6bb4771e9c89.jpg?1",
             "name": "Rain of Blades",
             "text": "Rain of Blades deals 1 damage to each attacking creature.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "c6fb2f97-27e5-5e9b-8abd-5d2847759ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5945397-0906-48dd-80d1-c65bfa2b31a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5945397-0906-48dd-80d1-c65bfa2b31a6.jpg?1",
             "name": "Recuperate",
             "text": "Choose one You gain 6 life; or prevent the next 6 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "ceede19d-f4a8-5504-8768-b91f20532c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6e8844-3736-4fb1-bedb-6a6bfa6ccdc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6e8844-3736-4fb1-bedb-6a6bfa6ccdc8.jpg?1",
             "name": "Reward the Faithful",
             "text": "Any number of target players each gains life equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "9052d841-ceb6-506b-9fc2-92dc8a873c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f559da-08ad-402d-8c6b-3050bce5867b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f559da-08ad-402d-8c6b-3050bce5867b.jpg?1",
             "name": "Silver Knight",
             "text": "First strike, protection from red",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "0e48be1e-1df9-5a88-ac0b-31ce1f829f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cd76bf-db08-45f8-b3ae-501bcca6df3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cd76bf-db08-45f8-b3ae-501bcca6df3c.jpg?1",
             "name": "Trap Digger",
             "text": "{2}{W}, {T}: Put a trap counter on target land you control.\nSacrifice a land with a trap counter on it: Trap Digger deals 3 damage to target attacking creature without flying.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "bf3e54c1-ee22-5b26-ba4b-e1ecc2bc8034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65efa443-666a-45c1-8784-e98c510854b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65efa443-666a-45c1-8784-e98c510854b5.jpg?1",
             "name": "Wing Shards",
             "text": "Target player sacrifices an attacking creature.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "9cccb55c-22dd-5ac0-9c3f-13d60d142b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7c14c9-cb5a-49f0-be2c-eb3166f02510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7c14c9-cb5a-49f0-be2c-eb3166f02510.jpg?1",
             "name": "Wipe Clean",
             "text": "Remove target enchantment from the game.\nCycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "12679b57-cbd4-5e8d-9bf1-fb9c6105b202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb821b6-4e73-4970-b1ac-b67c93990ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb821b6-4e73-4970-b1ac-b67c93990ec0.jpg?1",
             "name": "Zealous Inquisitor",
             "text": "{1}{W}: The next 1 damage that would be dealt to Zealous Inquisitor this turn is dealt to target creature instead.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "278a0d76-cef1-5361-b8c9-20576d2adbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5de028-91ce-48d8-8557-ae12542adea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5de028-91ce-48d8-8557-ae12542adea2.jpg?1",
             "name": "Aphetto Runecaster",
             "text": "Whenever a creature is turned face up, you may draw a card.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "130d664e-a4e0-52cc-95ce-3b6898df53e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a43ef5-08f0-44fc-802d-b6cfd56b7d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a43ef5-08f0-44fc-802d-b6cfd56b7d1f.jpg?1",
             "name": "Brain Freeze",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "ca4b5f54-4c84-502b-88fb-2230f2548156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbbc67d-99d0-4277-a8f2-64509e59ec00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbbc67d-99d0-4277-a8f2-64509e59ec00.jpg?1",
             "name": "Coast Watcher",
             "text": "Flying, protection from green",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "eb192481-dcb7-5a3c-b9d6-d2ab01a280d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366a934c-eb01-48c6-8393-c2fe0708ff91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366a934c-eb01-48c6-8393-c2fe0708ff91.jpg?1",
             "name": "Day of the Dragons",
             "text": "When Day of the Dragons comes into play, remove all creatures you control from the game. Then put that many 5/5 red Dragon creature tokens with flying into play.\nWhen Day of the Dragons leaves play, sacrifice all Dragons you control. Then return the removed cards to play under your control.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "253cfe94-24d3-592b-84f2-a625a59046c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fc46e2-5e19-4999-a4cd-1e84697066c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fc46e2-5e19-4999-a4cd-1e84697066c1.jpg?1",
             "name": "Decree of Silence",
             "text": "Whenever an opponent plays a spell, counter that spell and put a depletion counter on Decree of Silence. If there are three or more depletion counters on Decree of Silence, sacrifice it.\nCycling {4}{U}{U}\nWhen you cycle Decree of Silence, you may counter target spell.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "02074273-34d1-5677-ae91-7c8c29ef4ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c257df6-f275-40db-bfe3-a9291356cdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c257df6-f275-40db-bfe3-a9291356cdf7.jpg?1",
             "name": "Dispersal Shield",
             "text": "Counter target spell if its converted mana cost is less than or equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "2df53bea-4a1d-5d58-b531-d354cd735ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7674ab4d-9bc0-45c3-88e1-3fd2c947cfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7674ab4d-9bc0-45c3-88e1-3fd2c947cfaa.jpg?1",
             "name": "Dragon Wings",
             "text": "Enchanted creature has flying.\nCycling {1}{U} ({1}{U}, Discard this card from your hand: Draw a card.)\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Wings from your graveyard to play enchanting that creature.",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "c06479c3-bfac-5e01-ab75-941bd0ba1d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6dc35b-eb26-498f-ae35-0e860871446e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6dc35b-eb26-498f-ae35-0e860871446e.jpg?1",
             "name": "Faces of the Past",
             "text": "Whenever a creature is put into a graveyard from play, tap or untap all creatures that share a creature type with it.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "7b5ac839-3ffb-531b-a10f-71544eec787e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b98d-0245-4b64-b835-d101ce2bd3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b98d-0245-4b64-b835-d101ce2bd3fa.jpg?1",
             "name": "Frozen Solid",
             "text": "Enchanted creature doesn't untap during its controller's untap step.\nWhen damage is dealt to enchanted creature, destroy it.",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "773946d4-0de2-53ea-9a33-6858b3eb8c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9735d9-4aac-4175-8ec8-fc9bfd8f2c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9735d9-4aac-4175-8ec8-fc9bfd8f2c5c.jpg?1",
             "name": "Hindering Touch",
             "text": "Counter target spell unless its controller pays {2}.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1246,7 +1246,7 @@
         },
         {
             "id": "ffd6d5f3-fa27-571e-ae02-05ca2b26ab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0422d9-9694-45b6-9c2b-2ca31198cebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0422d9-9694-45b6-9c2b-2ca31198cebf.jpg?1",
             "name": "Long-Term Plans",
             "text": "Search your library for a card, shuffle your library, then put that card third from the top.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "e9a025b7-da4a-5133-80fb-72fbc35eb36a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bc8655-ae27-40be-8d61-e80a5924e955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bc8655-ae27-40be-8d61-e80a5924e955.jpg?1",
             "name": "Mercurial Kite",
             "text": "Flying\nWhenever Mercurial Kite deals combat damage to a creature, tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "39202306-5005-54c9-aeb2-9fa44762d8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0c20c-184e-4d27-ae8b-933abb6fee0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0c20c-184e-4d27-ae8b-933abb6fee0c.jpg?1",
             "name": "Metamorphose",
             "text": "Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from his or her hand into play.",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "ab6730a4-f31b-555b-8c7f-9f561a93c2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7474e1-cfae-4867-a11a-d5cf9ff7ea5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7474e1-cfae-4867-a11a-d5cf9ff7ea5f.jpg?1",
             "name": "Mind's Desire",
             "text": "Shuffle your library. Then remove the top card of your library from the game. Until end of turn, you may play it as though it were in your hand without paying its mana cost. (If it has X in its mana cost, X is 0.)\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "9aa3d1aa-c52e-54fb-9873-9de14c84a5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc48c2db-f5b4-4c24-a5fa-00750b7ff56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc48c2db-f5b4-4c24-a5fa-00750b7ff56f.jpg?1",
             "name": "Mischievous Quanar",
             "text": "{3}{U}{U}: Turn Mischievous Quanar face down.\nMorph {1}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Mischievous Quanar is turned face up, copy target instant or sorcery spell. You may choose new targets for that copy.",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "b65144db-04b9-5b05-b2f1-8517c5010788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a633d85b-4be1-44a2-8fd8-1ccec4a95ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a633d85b-4be1-44a2-8fd8-1ccec4a95ecb.jpg?1",
             "name": "Mistform Warchief",
             "text": "Creature spells you play that share a creature type with Mistform Warchief cost {1} less to play.\n{T}: Mistform Warchief's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "6e41075d-21c4-52c6-96f3-35cce7f10605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913c541-a8fb-4383-bbab-988be3e0f5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913c541-a8fb-4383-bbab-988be3e0f5d5.jpg?1",
             "name": "Parallel Thoughts",
             "text": "When Parallel Thoughts comes into play, search your library for seven cards, remove them from the game in a face-down pile, and shuffle that pile. Then shuffle your library.\nIf you would draw a card, you may instead put the top card of the pile you removed into your hand.",
             "colours": [
@@ -1476,7 +1476,7 @@
         },
         {
             "id": "dc1d8d6d-5f15-589a-be8d-0814f928bf09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb3e38b-086e-4fbc-b7b1-8564c18276d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb3e38b-086e-4fbc-b7b1-8564c18276d7.jpg?1",
             "name": "Pemmin's Aura",
             "text": "{U}: Untap enchanted creature.\n{U}: Enchanted creature gains flying until end of turn.\n{U}: Enchanted creature can't be the target of spells or abilities this turn.\n{1}: Enchanted creature gets +1/-1 or -1/+1 until end of turn.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "260d6d6d-87d0-5d21-ba10-ab578e132058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e11f70-06c3-4dc5-aafe-82d65080085e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e11f70-06c3-4dc5-aafe-82d65080085e.jpg?1",
             "name": "Raven Guild Initiate",
             "text": "Morph\u2014\nReturn a Bird you control to its owner's hand. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "df3a0d04-a358-5da0-aad5-60516bc590f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9843f847-6a8f-4042-86b6-f7fe5a47cc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9843f847-6a8f-4042-86b6-f7fe5a47cc57.jpg?1",
             "name": "Raven Guild Master",
             "text": "Whenever Raven Guild Master deals combat damage to a player, that player removes the top ten cards of his or her library from the game.\nMorph {2}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1581,7 +1581,7 @@
         },
         {
             "id": "cb7e65bf-0fa3-5def-af9d-396872c58eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7515187f-4821-400d-b78f-cec173df6b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7515187f-4821-400d-b78f-cec173df6b84.jpg?1",
             "name": "Riptide Survivor",
             "text": "Morph {1}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Riptide Survivor is turned face up, discard two cards from your hand, then draw three cards.",
             "colours": [
@@ -1616,7 +1616,7 @@
         },
         {
             "id": "55316be7-0aea-5ea7-9ea0-b7174a534619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b03b40-671f-4973-8d75-c3fa878ef603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b03b40-671f-4973-8d75-c3fa878ef603.jpg?1",
             "name": "Rush of Knowledge",
             "text": "Draw cards equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "530eb7a3-abb8-5aed-9981-62361205fb38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec6b189-97e7-4627-9785-a9ce2f1ad89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec6b189-97e7-4627-9785-a9ce2f1ad89f.jpg?1",
             "name": "Scornful Egotist",
             "text": "Morph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "cac6f843-75c2-5065-897c-82b962e2cdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed813c4-fff0-43f1-bc62-cbc3a126d600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed813c4-fff0-43f1-bc62-cbc3a126d600.jpg?1",
             "name": "Shoreline Ranger",
             "text": "Flying\nIslandcycling {2} ({2}, Discard this card from your hand: Search your library for an island card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "d3e9de63-2b01-51c1-864c-c62a7e90236a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7643c0-b2db-478f-944e-b27b77bad3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7643c0-b2db-478f-944e-b27b77bad3eb.jpg?1",
             "name": "Stifle",
             "text": "Counter target activated or triggered ability. (Mana abilities can't be countered.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "ce1a12da-d30f-5d77-969b-273343fdd3bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97949c53-aef7-4c0c-b846-8d4003193ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97949c53-aef7-4c0c-b846-8d4003193ced.jpg?1",
             "name": "Temporal Fissure",
             "text": "Return target permanent to its owner's hand.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "1edce411-939b-57b7-ad24-c0c2bfdefa6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597aea42-43e0-41ed-bfe7-fc92b6b8e680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597aea42-43e0-41ed-bfe7-fc92b6b8e680.jpg?1",
             "name": "Thundercloud Elemental",
             "text": "Flying\n{3}{U}: Tap all creatures with toughness 2 or less.\n{3}{U}: All other creatures lose flying until end of turn.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "f3e2bbca-c062-583c-b891-d42b783b0f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07e0d28-6383-4846-89d3-72910a7bbdcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07e0d28-6383-4846-89d3-72910a7bbdcd.jpg?1",
             "name": "Bladewing's Thrall",
             "text": "Bladewing's Thrall has flying as long as you control a Dragon.\nWhen a Dragon comes into play, you may return Bladewing's Thrall from your graveyard to play.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "7431985d-c197-5e28-86a4-d6eb37d03b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81c6e6-fded-4cd3-a6fa-486419a5408a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81c6e6-fded-4cd3-a6fa-486419a5408a.jpg?1",
             "name": "Cabal Conditioning",
             "text": "Any number of target players each discards cards from his or her hand equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -1883,7 +1883,7 @@
         },
         {
             "id": "a49c636b-99f3-5968-b68a-60dcb9b810be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a7a37-6f47-47a3-b149-5692aee8b34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a7a37-6f47-47a3-b149-5692aee8b34a.jpg?1",
             "name": "Cabal Interrogator",
             "text": "{X}{B}, {T}: Target player reveals X cards from his or her hand and you choose one of them. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "0221d078-4da1-5993-a63a-792d4ec602f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a346b4a-ac8a-4f99-9ed7-dd41102e56ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a346b4a-ac8a-4f99-9ed7-dd41102e56ce.jpg?1",
             "name": "Call to the Grave",
             "text": "At the beginning of each player's upkeep, that player sacrifices a non-Zombie creature.\nAt end of turn, if no creatures are in play, sacrifice Call to the Grave.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "9a0e0cc7-f5ac-5d2d-8b77-bbc931d02ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88042031-64af-4f84-85d5-95992b43aa6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88042031-64af-4f84-85d5-95992b43aa6c.jpg?1",
             "name": "Carrion Feeder",
             "text": "Carrion Feeder can't block.\nSacrifice a creature: Put a +1/+1 counter on Carrion Feeder.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "af34fa91-b98e-5f28-9a86-c6dc77a0de38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91035d03-2bf8-4e6b-945b-4dfbed0873ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91035d03-2bf8-4e6b-945b-4dfbed0873ec.jpg?1",
             "name": "Chill Haunting",
             "text": "As an additional cost to play Chill Haunting, remove X creature cards in your graveyard from the game.\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "715d4c07-797d-5fd4-945f-6bd01619c38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7301fdec-ca17-47ae-9a0a-84ea8665ece1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7301fdec-ca17-47ae-9a0a-84ea8665ece1.jpg?1",
             "name": "Clutch of Undeath",
             "text": "Enchanted creature gets +3/+3 as long as it's a Zombie. Otherwise, it gets -3/-3.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "63b195b2-cb12-599d-9311-960e7dfa66b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0f549f-6607-483a-9d89-2019ca9ef571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0f549f-6607-483a-9d89-2019ca9ef571.jpg?1",
             "name": "Consumptive Goo",
             "text": "{2}{B}{B}: Target creature gets -1/-1 until end of turn. Put a +1/+1 counter on Consumptive Goo.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "c68caf19-3a22-5917-ad7a-17988cf47518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8d4fd9-1f9e-41f0-9114-d1a698506ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8d4fd9-1f9e-41f0-9114-d1a698506ad9.jpg?1",
             "name": "Death's-Head Buzzard",
             "text": "Flying\nWhen Death's-Head Buzzard is put into a graveyard from play, all creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "c66e98f0-a2d6-5cd2-b3b5-10227e306c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1958a07-fc75-41cd-ac45-d92d49587754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1958a07-fc75-41cd-ac45-d92d49587754.jpg?1",
             "name": "Decree of Pain",
             "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B}\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "9c54b402-8bd6-506e-925a-9517d69e6ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec35e03-022b-417c-9987-7379cf3956f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec35e03-022b-417c-9987-7379cf3956f9.jpg?1",
             "name": "Dragon Shadow",
             "text": "Enchanted creature gets +1/+0 and has fear. (It can't be blocked except by artifact creatures and/or black creatures.)\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Shadow from your graveyard to play enchanting that creature.",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "4bce565e-3808-5484-bc5a-27431452d7fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cf9f50-8858-44a6-8bd5-0ce1e281a584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cf9f50-8858-44a6-8bd5-0ce1e281a584.jpg?1",
             "name": "Fatal Mutation",
             "text": "When enchanted creature is turned face up, destroy it. It can't be regenerated.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "a869c403-e18d-596e-8026-d8e0c97ce4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097dbfae-1a18-4c10-8d1f-b2c20971c75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097dbfae-1a18-4c10-8d1f-b2c20971c75e.jpg?1",
             "name": "Final Punishment",
             "text": "Target player loses life equal to the damage already dealt to him or her this turn.",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "6b5e4823-8697-53e7-a93b-7e15ccd3615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96acfea-009a-4ac9-8746-64f65199024f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96acfea-009a-4ac9-8746-64f65199024f.jpg?1",
             "name": "Lethal Vapors",
             "text": "Whenever a creature comes into play, destroy it.\n{0}: Destroy Lethal Vapors. You skip your next turn. Any player may play this ability.",
             "colours": [
@@ -2282,7 +2282,7 @@
         },
         {
             "id": "987ecec9-1867-5834-a95e-869012503daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f174fd76-f28d-4272-8cb0-7f66cd60579e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f174fd76-f28d-4272-8cb0-7f66cd60579e.jpg?1",
             "name": "Lingering Death",
             "text": "The controller of enchanted creature sacrifices it at the end of his or her turn.",
             "colours": [
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "eeb85ea9-da4b-591f-b701-fafdb3af70c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7046acc2-e2fd-43e6-9d46-a729d48ba562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7046acc2-e2fd-43e6-9d46-a729d48ba562.jpg?1",
             "name": "Nefashu",
             "text": "Whenever Nefashu attacks, up to five target creatures each get -1/-1 until end of turn.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "07ae9bc1-7caf-5c63-b8f1-8d89a184ce19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9127942b-d73d-42a9-9f97-6a39fa798a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9127942b-d73d-42a9-9f97-6a39fa798a8b.jpg?1",
             "name": "Putrid Raptor",
             "text": "Morph\u2014\nDiscard a Zombie card from your hand. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "c2fb28d6-30ea-5fab-ae97-d0c1e2f592dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a66bd-2821-4710-8f02-3c30772dd884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a66bd-2821-4710-8f02-3c30772dd884.jpg?1",
             "name": "Reaping the Graves",
             "text": "Return target creature card from your graveyard to your hand.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "7d94b2fb-6707-5c28-980c-56792a3fa876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a90779-008e-401f-9877-be0a935d2ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a90779-008e-401f-9877-be0a935d2ccd.jpg?1",
             "name": "Skulltap",
             "text": "As an additional cost to play Skulltap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "de6ec24f-2f2d-550c-871f-3e7858e589f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec78c0e8-a354-46d2-95ad-012f120c3df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec78c0e8-a354-46d2-95ad-012f120c3df8.jpg?1",
             "name": "Soul Collector",
             "text": "Flying\nWhenever a creature dealt damage by Soul Collector this turn is put into a graveyard, return that card to play under your control.\nMorph {B}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "e2a6d92f-c154-52b6-9b8b-ded783b6933a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559352e-95c1-403b-bd8f-d0679717cfa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559352e-95c1-403b-bd8f-d0679717cfa2.jpg?1",
             "name": "Tendrils of Agony",
             "text": "Target player loses 2 life and you gain 2 life.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "8671df71-046e-5b01-9c55-09aa02016c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e672f-87aa-4308-98bb-d00548c5bcef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e672f-87aa-4308-98bb-d00548c5bcef.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card from your hand: Search your library for a swamp card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "bba0106b-2881-5fac-9b4a-47f6dfa333c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fc0e0-4ee5-40eb-a9f0-9b1fff2adefc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fc0e0-4ee5-40eb-a9f0-9b1fff2adefc.jpg?1",
             "name": "Unburden",
             "text": "Target player discards two cards.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "360ad77f-bfd7-5cef-9714-ad06ca3a186c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3bcfe-be82-458b-ba59-ecb84436d747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3bcfe-be82-458b-ba59-ecb84436d747.jpg?1",
             "name": "Undead Warchief",
             "text": "Zombie spells you play cost {1} less to play.\nZombies you control get +2/+1.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "4d73aa99-eebe-53f0-86f5-96bb2463147a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc4601b-5f34-4733-8c32-9779de4c502c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc4601b-5f34-4733-8c32-9779de4c502c.jpg?1",
             "name": "Unspeakable Symbol",
             "text": "Pay 3 life: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "bed7e944-a917-5fc8-9915-05c115033d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11c11d-9809-4031-8cbc-21aef07d7f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11c11d-9809-4031-8cbc-21aef07d7f1f.jpg?1",
             "name": "Vengeful Dead",
             "text": "Whenever Vengeful Dead or another Zombie is put into a graveyard from play, each opponent loses 1 life.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "26ed4f5f-f613-5876-93ee-6c3347878f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe491cba-6ec7-4c44-ad1e-832d936986a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe491cba-6ec7-4c44-ad1e-832d936986a0.jpg?1",
             "name": "Zombie Cutthroat",
             "text": "Morph\u2014\nPay 5 life. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "8c571023-ab8b-5747-bc5e-b2d1fdd4b340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d7326-ad03-464d-97e2-443042d48f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d7326-ad03-464d-97e2-443042d48f92.jpg?1",
             "name": "Bonethorn Valesk",
             "text": "Whenever a creature is turned face up, Bonethorn Valesk deals 1 damage to target creature or player.",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "c6cb48b6-2f3b-55a8-b510-0971805d7443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f565fa1-a1a0-4dd0-b7f4-df65a807d156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f565fa1-a1a0-4dd0-b7f4-df65a807d156.jpg?1",
             "name": "Carbonize",
             "text": "Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -2784,7 +2784,7 @@
         },
         {
             "id": "cac6db53-40f2-5eeb-927a-90788b505c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c9c07-c3db-46ca-a204-b710c3a34ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c9c07-c3db-46ca-a204-b710c3a34ae9.jpg?1",
             "name": "Chartooth Cougar",
             "text": "{R}: Chartooth Cougar gets +1/+0 until end of turn.\nMountaincycling {2} ({2}, Discard this card from your hand: Search your library for a mountain card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "24bab718-4e6c-5ea7-900c-443d923f206f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73744717-518c-478e-9da9-201c49124f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73744717-518c-478e-9da9-201c49124f37.jpg?1",
             "name": "Decree of Annihilation",
             "text": "Remove all artifacts, creatures, lands, graveyards, and hands from the game.\nCycling {5}{R}{R}\nWhen you cycle Decree of Annihilation, destroy all lands.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "83269e21-7e8e-5f4e-a718-5dca8ce105e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1832aaed-e164-4f78-9bc9-ec6c015835f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1832aaed-e164-4f78-9bc9-ec6c015835f5.jpg?1",
             "name": "Dragon Breath",
             "text": "Enchanted creature has haste.\noo\nR Enchanted creature gets +1/+0 until end of turn.\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Breath from your graveyard to play enchanting that creature.",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "840c5f81-fdb7-575c-a756-95fa328313bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7687a201-0ecc-4739-86e3-3b4090d345a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7687a201-0ecc-4739-86e3-3b4090d345a8.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever Dragon Mage deals combat damage to a player, each player discards his or her hand and draws seven cards.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "61b572f2-d1b3-5b9e-a36c-11c811a3167c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1a29b-af80-4f9a-881b-ef7374ecbce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1a29b-af80-4f9a-881b-ef7374ecbce1.jpg?1",
             "name": "Dragon Tyrant",
             "text": "Flying, trample\nDouble strike (This creature deals both first-strike and regular combat damage.)\nAt the beginning of your upkeep, sacrifice Dragon Tyrant unless you pay {R}{R}{R}{R}.\n{R}: Dragon Tyrant gets +1/+0 until end of turn.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "4589adfe-ad64-5301-ad21-10f88076ec52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f5fa96-dcfb-4d29-bea9-7dd99e8c43d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f5fa96-dcfb-4d29-bea9-7dd99e8c43d8.jpg?1",
             "name": "Dragonspeaker Shaman",
             "text": "Dragon spells you play cost {2} less to play.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "d096e9e7-eede-52b5-81a0-319c5911d994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9aa594-39e6-4824-aed9-75d1a301ac51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9aa594-39e6-4824-aed9-75d1a301ac51.jpg?1",
             "name": "Dragonstorm",
             "text": "Search your library for a Dragon card and put it into play. Then shuffle your library.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "96f4741d-fd1f-55f9-9ba5-126dd56ff6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed7866-9eef-49c3-9b9e-4247b6e71a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed7866-9eef-49c3-9b9e-4247b6e71a6c.jpg?1",
             "name": "Enrage",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "aaf83980-42a7-5ee4-8102-91ece333a219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28efa11c-6aeb-4c22-bbb3-b41f26d65c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28efa11c-6aeb-4c22-bbb3-b41f26d65c65.jpg?1",
             "name": "Extra Arms",
             "text": "Whenever enchanted creature attacks, it deals 2 damage to target creature or player.",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "81639bc8-0b41-58c7-b601-cf56160f7a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058bcb4-50ac-4323-ab49-3b80a5891894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058bcb4-50ac-4323-ab49-3b80a5891894.jpg?1",
             "name": "Form of the Dragon",
             "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the end of each turn, your life total becomes 5.\nCreatures without flying can't attack you.",
             "colours": [
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "ebf78c72-8f48-5918-a8fb-7699627458b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b024afe-7a28-4e3b-afbd-b42f1c45f338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b024afe-7a28-4e3b-afbd-b42f1c45f338.jpg?1",
             "name": "Goblin Brigand",
             "text": "Goblin Brigand attacks each turn if able.",
             "colours": [
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "d15a19ee-7a3b-50b9-9caf-f18788b7e95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52287036-00f1-4b6d-8cd8-b8cbc70c5135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52287036-00f1-4b6d-8cd8-b8cbc70c5135.jpg?1",
             "name": "Goblin Psychopath",
             "text": "Whenever Goblin Psychopath attacks or blocks, flip a coin. If you lose the flip, the next time it would deal combat damage this turn, it deals that damage to you instead.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "d7c13930-f4d4-5563-bc42-104aeb988907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce59945-37a2-4f09-8831-9d44b4a59ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce59945-37a2-4f09-8831-9d44b4a59ea7.jpg?1",
             "name": "Goblin War Strike",
             "text": "Goblin War Strike deals damage equal to the number of Goblins you control to target player.",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "fa9d9c8c-30b0-5f62-a6c9-83bab74ebc69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66864a4b-8924-40ef-a337-15b12413a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66864a4b-8924-40ef-a337-15b12413a158.jpg?1",
             "name": "Goblin Warchief",
             "text": "Goblin spells you play cost {1} less to play.\nGoblins you control have haste.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "1837a89f-c66e-5622-8ef0-1d51a7d95e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defbbd3a-0e7d-4af2-b25f-9003ddad0bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defbbd3a-0e7d-4af2-b25f-9003ddad0bf5.jpg?1",
             "name": "Grip of Chaos",
             "text": "Whenever a spell or ability is put onto the stack, reselect its target at random if it has a single target. (Select from among all legal targets.)",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "3f8bf6b4-37cb-57e2-9840-121cb437279f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b5e00a-fef0-4711-9112-2fd067321890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b5e00a-fef0-4711-9112-2fd067321890.jpg?1",
             "name": "Misguided Rage",
             "text": "Target player sacrifices a permanent.",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "ecfca0db-5dc3-5ddb-a2e5-b184360b1027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5973cd53-f6cd-4edc-b952-f6d3eef97988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5973cd53-f6cd-4edc-b952-f6d3eef97988.jpg?1",
             "name": "Pyrostatic Pillar",
             "text": "Whenever a player plays a spell with converted mana cost 3 or less, Pyrostatic Pillar deals 2 damage to that player.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "7f816a77-ed0c-5f98-9702-b16754fb982a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f836e90-3255-48bd-a174-6a127528551e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f836e90-3255-48bd-a174-6a127528551e.jpg?1",
             "name": "Rock Jockey",
             "text": "You can't play Rock Jockey if you played a land this turn.\nYou can't play lands if you played Rock Jockey this turn.",
             "colours": [
@@ -3387,7 +3387,7 @@
         },
         {
             "id": "12e035a3-0ec7-5a1a-b390-55b977b44196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf22f3e7-1626-4bab-9f62-7d4774704395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf22f3e7-1626-4bab-9f62-7d4774704395.jpg?1",
             "name": "Scattershot",
             "text": "Scattershot deals 1 damage to target creature.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "18211630-f9fa-5a42-a046-dec36d9bf135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e78cec-aaf9-4fe8-887b-b7e356d63315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e78cec-aaf9-4fe8-887b-b7e356d63315.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander comes into play, put three 1/1 red Goblin creature tokens into play.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "33119ea1-75b9-53a6-9e21-cda786c986d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdfb7e3-e077-400a-868d-3f3811e7a35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdfb7e3-e077-400a-868d-3f3811e7a35c.jpg?1",
             "name": "Skirk Volcanist",
             "text": "Morph\u2014\nSacrifice two mountains. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Skirk Volcanist is turned face up, it deals 3 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "77e62bcc-fd91-5f52-a48e-72fb809b4e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60d8716-4297-484c-8e02-c30ce2773a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60d8716-4297-484c-8e02-c30ce2773a65.jpg?1",
             "name": "Spark Spray",
             "text": "Spark Spray deals 1 damage to target creature or player.\nCycling {R} ({R}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "71aab515-d674-5dcb-9b7b-830a3aad578a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79955e27-eef7-43bd-9895-e9209ed1537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79955e27-eef7-43bd-9895-e9209ed1537f.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -3551,7 +3551,7 @@
         },
         {
             "id": "2f6f2c14-79b5-52ca-8252-1211782b7e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeee859-f64a-4cd8-be0b-ad60cff8812e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeee859-f64a-4cd8-be0b-ad60cff8812e.jpg?1",
             "name": "Torrent of Fire",
             "text": "Torrent of Fire deals damage equal to the highest converted mana cost among permanents you control to target creature or player.",
             "colours": [
@@ -3583,7 +3583,7 @@
         },
         {
             "id": "43b39301-6ee4-53b4-84bb-1c5c7b7f9cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ead6c3-a4e9-43e0-ae2a-6eb73033bc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ead6c3-a4e9-43e0-ae2a-6eb73033bc49.jpg?1",
             "name": "Uncontrolled Infestation",
             "text": "Uncontrolled Infestation can enchant only a nonbasic land.\nWhen enchanted land becomes tapped, destroy it.",
             "colours": [
@@ -3617,7 +3617,7 @@
         },
         {
             "id": "f8a98973-7dcf-51e8-ae20-1a287cf1c678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f808c-0b58-4b98-aeda-f606a10d1a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f808c-0b58-4b98-aeda-f606a10d1a4b.jpg?1",
             "name": "Accelerated Mutation",
             "text": "Target creature gets +X/+X until end of turn, where X is the highest converted mana cost among permanents you control.",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "db31216c-c491-54c9-93d0-7c7027f724b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd210c45-57f3-4d7d-93ba-81fe4298ade3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd210c45-57f3-4d7d-93ba-81fe4298ade3.jpg?1",
             "name": "Alpha Status",
             "text": "Enchanted creature gets +2/+2 for each other creature in play that shares a creature type with it.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "33757323-c327-5779-af26-b63f8f772fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7485da91-a051-4680-8a25-c81fdaa77130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7485da91-a051-4680-8a25-c81fdaa77130.jpg?1",
             "name": "Ambush Commander",
             "text": "Forests you control are 1/1 green Elf creatures that are still lands.\n{1}{G}, Sacrifice an Elf: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3717,7 +3717,7 @@
         },
         {
             "id": "8f695933-0388-5e31-8a1f-a14705eda727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b57b41c-f99c-4525-8541-f025b7e31974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b57b41c-f99c-4525-8541-f025b7e31974.jpg?1",
             "name": "Ancient Ooze",
             "text": "Ancient Ooze's power and toughness are each equal to the total converted mana cost of other creatures you control.",
             "colours": [
@@ -3751,7 +3751,7 @@
         },
         {
             "id": "926b7851-fefc-58ae-8223-add40f15ace2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb989895-a5c7-4151-8620-ab277d826303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb989895-a5c7-4151-8620-ab277d826303.jpg?1",
             "name": "Break Asunder",
             "text": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "ff7b52ca-c0e8-5688-b511-22257efa27c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94cd33f-40b6-4b11-97a4-8676ef27631e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94cd33f-40b6-4b11-97a4-8676ef27631e.jpg?1",
             "name": "Claws of Wirewood",
             "text": "Claws of Wirewood deals 3 damage to each creature with flying and each player.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "6432c2d0-6bdc-58a2-85d9-ca998e61cd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e643fbf1-74d5-412b-beba-ab3c712edb3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e643fbf1-74d5-412b-beba-ab3c712edb3b.jpg?1",
             "name": "Decree of Savagery",
             "text": "Put four +1/+1 counters on each creature you control.\nCycling {4}{G}{G}\nWhen you cycle Decree of Savagery, you may put four +1/+1 counters on target creature.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "ad3220fe-8c5c-57b6-b15e-84e6605ec6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e609448-7868-4e28-b399-3750556a693c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e609448-7868-4e28-b399-3750556a693c.jpg?1",
             "name": "Divergent Growth",
             "text": "Until end of turn, lands you control gain \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "13c0f7f1-743a-52f0-a4a1-f10d57fb0524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9754f52f-8937-4402-8956-2c18b520898a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9754f52f-8937-4402-8956-2c18b520898a.jpg?1",
             "name": "Dragon Fangs",
             "text": "Enchanted creature gets +1/+1 and has trample.\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Fangs from your graveyard to play enchanting that creature.",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "0d964329-dba8-5089-9adc-208faf66a76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137d326f-83e1-449a-b934-71c7986c64e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137d326f-83e1-449a-b934-71c7986c64e7.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G} to your mana pool.\nForestcycling {2} ({2}, Discard this card from your hand: Search your library for a forest card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "fbcfafba-3f42-567d-b2ce-476457ad395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237e169-f152-4ddf-a5a1-32ca46cfa16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237e169-f152-4ddf-a5a1-32ca46cfa16d.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath comes into play, you may search your library for a creature card with converted mana cost 6 or more, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -3982,7 +3982,7 @@
         },
         {
             "id": "f7b4d4d5-23ed-53d9-8430-8470cf16b6a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d3b91d-2e4f-4574-89f8-7b804f1d21bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d3b91d-2e4f-4574-89f8-7b804f1d21bf.jpg?1",
             "name": "Forgotten Ancient",
             "text": "Whenever a player plays a spell, you may put a +1/+1 counter on Forgotten Ancient.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Forgotten Ancient onto other creatures.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "83ac18fb-5af3-5cff-8782-d1a21f246e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0f5d29-5342-4591-bdc9-c2bc9289ed41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0f5d29-5342-4591-bdc9-c2bc9289ed41.jpg?1",
             "name": "Hunting Pack",
             "text": "Put a 4/4 green Beast creature token into play.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -4048,7 +4048,7 @@
         },
         {
             "id": "7202f230-9b8a-5450-a92e-29ae5d984b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92a7141-119f-4bf8-a82d-eb7c0c37185c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92a7141-119f-4bf8-a82d-eb7c0c37185c.jpg?1",
             "name": "Krosan Drover",
             "text": "Creature spells you play with converted mana cost 6 or more cost {2} less to play.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "8dd583cb-d635-5fca-a28f-e9880bfbb5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b700b-2072-47c0-9725-ad04414d2474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b700b-2072-47c0-9725-ad04414d2474.jpg?1",
             "name": "Krosan Warchief",
             "text": "Beast spells you play cost {1} less to play.\n{1}{G}: Regenerate target Beast.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "ddcb152b-15e3-5449-a214-fee641ef03f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1758c-849a-4de3-b674-857c3c9bf399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1758c-849a-4de3-b674-857c3c9bf399.jpg?1",
             "name": "Kurgadon",
             "text": "Whenever you play a creature spell with converted mana cost 6 or more, put three +1/+1 counters on Kurgadon.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "76380ab9-1007-5911-bd8e-73ef46d24447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2321b01c-7eef-48cc-a86b-4074dfa5b86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2321b01c-7eef-48cc-a86b-4074dfa5b86b.jpg?1",
             "name": "One with Nature",
             "text": "Whenever enchanted creature deals combat damage to a player, you may search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "2650025a-9355-51f9-8a9f-40c89c903b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae26b8d-c3af-42d1-94f4-56950ceac1c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae26b8d-c3af-42d1-94f4-56950ceac1c7.jpg?1",
             "name": "Primitive Etchings",
             "text": "Reveal the first card you draw each turn. Whenever you reveal a creature card this way, draw a card.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "a0a9aa67-ce89-55a3-8d97-2e6d294e17e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5161968e-b757-45b8-826f-98415291024d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5161968e-b757-45b8-826f-98415291024d.jpg?1",
             "name": "Root Elemental",
             "text": "Morph {5}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Root Elemental is turned face up, you may put a creature card from your hand into play.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "cb59fd1f-1a21-528d-9f06-31e3b715eafa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3246a6-b604-4f9f-adb9-3692e0fa8638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3246a6-b604-4f9f-adb9-3692e0fa8638.jpg?1",
             "name": "Sprouting Vines",
             "text": "Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "b1f90826-a9cc-5fed-969c-4724f3022d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f42c4d7-b555-449c-a539-119c1ae62232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f42c4d7-b555-449c-a539-119c1ae62232.jpg?1",
             "name": "Titanic Bulvox",
             "text": "Trample\nMorph {4}{G}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "e1637652-b3c4-5672-b05e-174687c62398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa39646-a609-4b37-b8de-97893ae43c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa39646-a609-4b37-b8de-97893ae43c49.jpg?1",
             "name": "Treetop Scout",
             "text": "Treetop Scout can't be blocked except by creatures with flying.",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "d5e4a562-7d22-592f-9aca-9f8c109a1afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab4600-1f71-48fa-a291-f5c5628c7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab4600-1f71-48fa-a291-f5c5628c7395.jpg?1",
             "name": "Upwelling",
             "text": "Mana pools don't empty at the end of phases or turns. (This effect stops mana burn.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "a56e3a7d-abba-5700-b37d-85229a4b3914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8676b1f-e37c-4ae1-9dbe-d000369fa422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8676b1f-e37c-4ae1-9dbe-d000369fa422.jpg?1",
             "name": "Wirewood Guardian",
             "text": "Forestcycling {2} ({2}, Discard this card from your hand: Search your library for a forest card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "2f890777-47f2-5989-9a6f-c868bd8750ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49488b76-abaf-4dba-b01f-7b418e4ff295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49488b76-abaf-4dba-b01f-7b418e4ff295.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "Return an Elf you control to its owner's hand: Untap target creature. Play this ability only once each turn.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "ec2f397f-dd39-5d35-b2ed-828876f16f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa85e09-a1cd-473d-98cd-c6a7c7aff949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa85e09-a1cd-473d-98cd-c6a7c7aff949.jpg?1",
             "name": "Woodcloaker",
             "text": "Morph {2}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Woodcloaker is turned face up, target creature gains trample until end of turn.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "f4b3e36e-f2a1-54ab-b7cc-8fb2d0ee5647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a87911a-3931-46aa-9348-2728c4b73b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a87911a-3931-46aa-9348-2728c4b73b96.jpg?1",
             "name": "Xantid Swarm",
             "text": "Flying\nWhenever Xantid Swarm attacks, defending player can't play spells this turn.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "219cdfe0-ed89-53e1-9fcc-7702b82f74d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3e13d-53f8-42bf-aa83-09a9ca94a9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3e13d-53f8-42bf-aa83-09a9ca94a9f0.jpg?1",
             "name": "Bladewing the Risen",
             "text": "Flying\nWhen Bladewing the Risen comes into play, you may return target Dragon card from your graveyard to play.\n{B}{R}: All Dragons get +1/+1 until end of turn.",
             "colours": [
@@ -4559,7 +4559,7 @@
         },
         {
             "id": "c22926e3-a4e3-5d39-b5db-33c7777c8923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b477c2-2cd5-41f2-8754-d4d5000df58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b477c2-2cd5-41f2-8754-d4d5000df58d.jpg?1",
             "name": "Edgewalker",
             "text": "Cleric spells you play cost {W}{B} less to play. This effect reduces only the amount of colored mana you pay. (For example, if you play a Cleric with mana cost {1}{W}, it costs {1} to play.)",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "d4809483-04f4-5ac9-8cd1-d980405306e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53d083-251e-42a4-9e2e-c2978c80615b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53d083-251e-42a4-9e2e-c2978c80615b.jpg?1",
             "name": "Karona, False God",
             "text": "Haste\nAt the beginning of each player's upkeep, that player untaps Karona, False God and gains control of it.\nWhenever Karona attacks, creatures of the type of your choice get +3/+3 until end of turn.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "d68863a5-3d85-56ca-9a34-cdd34ef95a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c16915b-c50d-4fb5-830f-9ca4597a9c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c16915b-c50d-4fb5-830f-9ca4597a9c0f.jpg?1",
             "name": "Sliver Overlord",
             "text": "{3}: Search your library for a Sliver card, reveal that card, and put it into your hand. Then shuffle your library.\n{3}: Gain control of target Sliver. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "f09faaa1-e873-58c9-ac7f-35dbd93926ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b09956-cc34-4472-8b9f-ae355522bd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b09956-cc34-4472-8b9f-ae355522bd5a.jpg?1",
             "name": "Ark of Blight",
             "text": "{3}, {T}, Sacrifice Ark of Blight: Destroy target land.",
             "colours": [],
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "0092018c-5fb5-5c6c-9aef-797a881f6c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c8cff1-b289-41a4-9fa3-cc5e7ba70802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c8cff1-b289-41a4-9fa3-cc5e7ba70802.jpg?1",
             "name": "Proteus Machine",
             "text": "Morph {0} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Proteus Machine is turned face up, its type becomes the creature type of your choice. (This effect doesn't end at end of turn.)",
             "colours": [],
@@ -4744,7 +4744,7 @@
         },
         {
             "id": "550c4e06-f550-50c0-9e8d-e9fe79671eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72dbe81-96d0-4b0d-97a7-c59345f081e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72dbe81-96d0-4b0d-97a7-c59345f081e8.jpg?1",
             "name": "Stabilizer",
             "text": "Players can't cycle cards.",
             "colours": [],
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "cdc5e093-58ca-5e5c-9988-fb9c0422199b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7036f51-10a6-4036-8650-9bc12d2a55cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7036f51-10a6-4036-8650-9bc12d2a55cb.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {2} to your mana pool. Play this ability only if you control five or more lands.",
             "colours": [],

--- a/Assets/Resources/Sets/SHM.json
+++ b/Assets/Resources/Sets/SHM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "46b19147-5715-5059-a455-c5f62e88d98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6ae637-bdb7-4117-8539-e424159bad6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6ae637-bdb7-4117-8539-e424159bad6f.jpg?1",
             "name": "Apothecary Initiate",
             "text": "Whenever a player plays a white spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "bee80027-536b-59e7-a2e0-8cbbdda497a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66dc28a-3d52-49cf-b1b3-0a1d335d0f5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66dc28a-3d52-49cf-b1b3-0a1d335d0f5c.jpg?1",
             "name": "Armored Ascension",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "73825ec0-56bd-50ac-8529-8686bf8dd507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c54ec5-2917-4acf-b56f-8273781477f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c54ec5-2917-4acf-b56f-8273781477f6.jpg?1",
             "name": "Ballynock Cohort",
             "text": "First strike\nBallynock Cohort gets +1/+1 as long as you control another white creature.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "5a1d1095-2d0e-5327-aa9c-ded736bfb65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8888e0aa-3682-4800-9c50-fff5d5c9547d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8888e0aa-3682-4800-9c50-fff5d5c9547d.jpg?1",
             "name": "Barrenton Medic",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\nPut a -1/-1 counter on Barrenton Medic: Untap Barrenton Medic.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "198b02bb-3e9f-590d-ac80-0834dbff4387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a27ba4d-53af-427d-9e51-be04db077fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a27ba4d-53af-427d-9e51-be04db077fac.jpg?1",
             "name": "Boon Reflection",
             "text": "If you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "d7065945-7043-5fc4-83f1-0427ff36d194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12030927-7af2-448f-bc6b-c2035e0b799d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12030927-7af2-448f-bc6b-c2035e0b799d.jpg?1",
             "name": "Goldenglow Moth",
             "text": "Flying\nWhenever Goldenglow Moth blocks, you may gain 4 life.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "210f1dd7-483f-558a-a7ad-4501d03199ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177787f-bf1e-438b-9615-97d03b04128c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177787f-bf1e-438b-9615-97d03b04128c.jpg?1",
             "name": "Greater Auramancy",
             "text": "Other enchantments you control have shroud.\nEnchanted creatures you control have shroud.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "8be2b693-e20b-5f39-ba44-4faaeb15cdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c607ec00-2d44-485e-ad85-24c0c7a284f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c607ec00-2d44-485e-ad85-24c0c7a284f9.jpg?1",
             "name": "Inquisitor's Snare",
             "text": "Prevent all damage target attacking or blocking creature would deal this turn. If that creature is black or red, destroy it.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "450809b6-b536-56b6-9134-19c739cb014b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a0afa-50e6-4bce-b261-4559fd31295e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a0afa-50e6-4bce-b261-4559fd31295e.jpg?1",
             "name": "Kithkin Rabble",
             "text": "Vigilance\nKithkin Rabble's power and toughness are each equal to the number of white permanents you control.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "47b96acc-bec6-5a09-bb28-57b8d588242f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5102a7-2147-4e22-b683-c08b4a725617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5102a7-2147-4e22-b683-c08b4a725617.jpg?1",
             "name": "Kithkin Shielddare",
             "text": "{W}, {T}: Target blocking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "65147038-bb26-593c-94e1-adfafdb10a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225447a5-41e1-4e57-ab6a-bff74d4523b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225447a5-41e1-4e57-ab6a-bff74d4523b3.jpg?1",
             "name": "Last Breath",
             "text": "Remove target creature with power 2 or less from the game. Its controller gains 4 life.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "898c74e0-238b-5563-8f2d-b8cda087362b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24be94-9922-43bb-83c8-98090adc3f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24be94-9922-43bb-83c8-98090adc3f32.jpg?1",
             "name": "Mass Calcify",
             "text": "Destroy all nonwhite creatures.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "2e163eec-3032-5b93-b317-1c45fceb1440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9dce2-3d2c-4ac4-a61e-3e352b6d4557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9dce2-3d2c-4ac4-a61e-3e352b6d4557.jpg?1",
             "name": "Mine Excavation",
             "text": "Return target artifact or enchantment card in a graveyard to its owner's hand.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "2c1b0e97-9df8-5d28-b8ee-87f9ecaf3271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18ff12f-3b0e-404a-8e35-3f7d05d0c0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18ff12f-3b0e-404a-8e35-3f7d05d0c0a7.jpg?1",
             "name": "Mistmeadow Skulk",
             "text": "Lifelink, protection from converted mana cost 3 or greater",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "b3e16055-293f-5008-a121-8797ba66e1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea1e2c4-1671-4322-b8ba-e4e1a879cf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea1e2c4-1671-4322-b8ba-e4e1a879cf37.jpg?1",
             "name": "Niveous Wisps",
             "text": "Target creature becomes white until end of turn. Tap that creature.\nDraw a card.",
             "colours": [
@@ -505,7 +505,7 @@
         },
         {
             "id": "34fa1899-4052-5d35-92ca-69a195ff881d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eb5f06-7f9c-4240-bbbb-6c59a49a5f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eb5f06-7f9c-4240-bbbb-6c59a49a5f0c.jpg?1",
             "name": "Order of Whiteclay",
             "text": "{1}{W}{W}, {Q}: Return target creature card with converted mana cost 3 or less from your graveyard to play. ({Q} is the untap symbol.)",
             "colours": [
@@ -540,7 +540,7 @@
         },
         {
             "id": "46e23fae-aec6-5662-b09a-e95dde4ac5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f852508e-7087-42e1-ad9b-c84708e92de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f852508e-7087-42e1-ad9b-c84708e92de7.jpg?1",
             "name": "Pale Wayfarer",
             "text": "{2}{W}{W}, {Q}: Target creature gains protection from the color of its controller's choice until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "953cb857-1309-5aa8-9eb3-263bacdc0d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ceb21d-6b51-4634-a2cf-13ef8f559287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ceb21d-6b51-4634-a2cf-13ef8f559287.jpg?1",
             "name": "Prison Term",
             "text": "Enchant creature\nEnchanted creature can't attack or block and its activated abilities can't be played.\nWhenever a creature comes into play under an opponent's control, you may attach Prison Term to that creature.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "e4019922-95b4-5e13-b05e-894d8840ce15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87e59d-422c-4dd7-8867-423e784830a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87e59d-422c-4dd7-8867-423e784830a2.jpg?1",
             "name": "Resplendent Mentor",
             "text": "White creatures you control have \"{T}: You gain 1 life.\"",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "5d917fb6-dd0e-5f0f-99ad-e175a7218bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9574f6-40b3-4fe2-950c-234bc358ecf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9574f6-40b3-4fe2-950c-234bc358ecf6.jpg?1",
             "name": "Rune-Cervin Rider",
             "text": "Flying\n{RW}{RW}: Rune-Cervin Rider gets +1/+1 until end of turn.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "cb1af308-50fb-5801-8158-1afef49af3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b45f79-f23e-4eef-8cac-91780dc2a044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b45f79-f23e-4eef-8cac-91780dc2a044.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo comes into play, name a card.\nYou have protection from the chosen name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "28aa77b1-24ca-56bf-a3a1-28f674bb88e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa8bd74-9897-4515-b1a0-50d5f1bda673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa8bd74-9897-4515-b1a0-50d5f1bda673.jpg?1",
             "name": "Safehold Sentry",
             "text": "{2}{W}, {Q}: Safehold Sentry gets +0/+2 until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "7b52c62e-c70f-5694-b715-de76956e9879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e26bd0c-5ec7-4653-8e63-747157c20af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e26bd0c-5ec7-4653-8e63-747157c20af1.jpg?1",
             "name": "Spectral Procession",
             "text": "({2\nW} can be paid with any two mana or with {W}. This card's converted mana cost is 6.)\nPut three 1/1 white Spirit creature tokens with flying into play.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "bbd4c6a8-c1db-5821-89df-8ca802d5a65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51173fa1-7cd4-4093-982a-db0d46564a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51173fa1-7cd4-4093-982a-db0d46564a8a.jpg?1",
             "name": "Strip Bare",
             "text": "Destroy all Auras and Equipment attached to target creature.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "4fec6221-386e-5451-a65e-0dc063328e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c24ba-4d1d-48ca-bc1c-ea0ed087de80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c24ba-4d1d-48ca-bc1c-ea0ed087de80.jpg?1",
             "name": "Twilight Shepherd",
             "text": "Flying, vigilance\nWhen Twilight Shepherd comes into play, return to your hand all cards in your graveyard put there from play this turn.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "88a55b3b-3842-5203-8a48-4a27da874400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg?1",
             "name": "Windbrisk Raptor",
             "text": "Flying\nAttacking creatures you control have lifelink.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "9d232ce2-3c60-53bf-96be-0f018a60bd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05c7868-e589-478e-af0c-512d0fe4f253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05c7868-e589-478e-af0c-512d0fe4f253.jpg?1",
             "name": "Woeleecher",
             "text": "{W}, {T}: Remove a -1/-1 counter from target creature. If you do, you gain 2 life.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "3d71f5be-3b0b-5e0e-b343-638c8f4c5b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d874f345-e623-4317-9aa7-66d14a011303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d874f345-e623-4317-9aa7-66d14a011303.jpg?1",
             "name": "Advice from the Fae",
             "text": "({2\nU} can be paid with any two mana or with {U}. This card's converted mana cost is 6.)\nLook at the top five cards of your library. If you control more creatures than any other player, put two of those cards into your hand. Otherwise, put one of them into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "d4289a8e-e3a5-5f37-8cab-21d3ce8c7bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ed9c9f-37d1-4f33-b62f-11ed2c208763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ed9c9f-37d1-4f33-b62f-11ed2c208763.jpg?1",
             "name": "Biting Tether",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -979,7 +979,7 @@
         },
         {
             "id": "7c781fb6-4633-5168-94f2-fc6d8734497d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9d87a-533c-4641-9738-e7b98d92b015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9d87a-533c-4641-9738-e7b98d92b015.jpg?1",
             "name": "Briarberry Cohort",
             "text": "Flying\nBriarberry Cohort gets +1/+1 as long as you control another blue creature.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "bf2a0e81-a033-5961-995a-f58b758376a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dca4f46-0aad-484f-b4ea-ed61a4fc1a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dca4f46-0aad-484f-b4ea-ed61a4fc1a89.jpg?1",
             "name": "Cerulean Wisps",
             "text": "Target creature becomes blue until end of turn. Untap that creature.\nDraw a card.",
             "colours": [
@@ -1046,7 +1046,7 @@
         },
         {
             "id": "d50bb1d7-08a2-52e6-bd13-9f5345c8a67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e866d86-5bfa-473d-be17-d8f4aea70ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e866d86-5bfa-473d-be17-d8f4aea70ddb.jpg?1",
             "name": "Consign to Dream",
             "text": "Return target permanent to its owner's hand. If that permanent is red or green, put it on top of its owner's library instead.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "18225efd-713d-589f-bc8e-1eb8551ccca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4228b80-d87d-4ebe-ae92-04e4a7d0dc43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4228b80-d87d-4ebe-ae92-04e4a7d0dc43.jpg?1",
             "name": "Counterbore",
             "text": "Counter target spell. Search its controller's graveyard, hand, and library for all cards with the same name as that spell and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "8d608f98-5a99-5013-933f-71277f745cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f2bfa5-bc30-46a4-b114-9d8c5b62e197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f2bfa5-bc30-46a4-b114-9d8c5b62e197.jpg?1",
             "name": "Cursecatcher",
             "text": "Sacrifice Cursecatcher: Counter target instant or sorcery spell unless its controller pays {1}.",
             "colours": [
@@ -1145,7 +1145,7 @@
         },
         {
             "id": "44188572-8618-581d-a70c-78e57de3640f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae429d-c09d-4818-8eb8-7e1c97e4b0c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae429d-c09d-4818-8eb8-7e1c97e4b0c9.jpg?1",
             "name": "Deepchannel Mentor",
             "text": "Blue creatures you control are unblockable.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "142783e8-97db-55ad-8a12-7dad756cf9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28accc5f-63a5-47d0-b0e6-747aa0aa43e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28accc5f-63a5-47d0-b0e6-747aa0aa43e5.jpg?1",
             "name": "Drowner Initiate",
             "text": "Whenever a player plays a blue spell, you may pay {1}. If you do, target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1215,7 +1215,7 @@
         },
         {
             "id": "cbf01a25-3b64-5906-8fbd-fda39e0c5b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90598bb2-d96c-4f74-864b-1947b7d39e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90598bb2-d96c-4f74-864b-1947b7d39e58.jpg?1",
             "name": "Faerie Swarm",
             "text": "Flying\nFaerie Swarm's power and toughness are each equal to the number of blue permanents you control.",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "b69e40ae-766b-53b3-afda-3a264dc0ee38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194d88d-6f2c-47ed-ad9c-d55bb1858e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194d88d-6f2c-47ed-ad9c-d55bb1858e79.jpg?1",
             "name": "Flow of Ideas",
             "text": "Draw a card for each Island you control.",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "aa1ca3f0-d2d0-57fc-b394-328aebde6198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbd510a-d71f-4b0c-bc6c-e403f632cbdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbd510a-d71f-4b0c-bc6c-e403f632cbdb.jpg?1",
             "name": "Ghastly Discovery",
             "text": "Draw two cards, then discard a card.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "5dfdcdee-57bb-5606-9e52-202cfc00be2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e769b1b2-c2a9-4db1-bf1f-01863aa2cd0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e769b1b2-c2a9-4db1-bf1f-01863aa2cd0b.jpg?1",
             "name": "Isleback Spawn",
             "text": "Shroud\nIsleback Spawn gets +4/+8 as long as a library has twenty or fewer cards in it.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "e257eace-4dfd-57a8-af7e-7e41936bb9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfde34-f76b-47ab-b83e-1c188d61a613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfde34-f76b-47ab-b83e-1c188d61a613.jpg?1",
             "name": "Kinscaer Harpoonist",
             "text": "Flying\nWhenever Kinscaer Harpoonist attacks, you may have target creature lose flying until end of turn.",
             "colours": [
@@ -1382,7 +1382,7 @@
         },
         {
             "id": "4292cda5-a229-57da-9714-879a759cd2b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22353590-f248-460e-a1a5-0b7431a4c82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22353590-f248-460e-a1a5-0b7431a4c82d.jpg?1",
             "name": "Knacksaw Clique",
             "text": "Flying\n{1}{U}, {Q}: Target opponent removes the top card of his or her library from the game. Until end of turn, you may play that card. ({Q} is the untap symbol.)",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "a33259d6-fc9d-577c-9f63-8789ee894690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86562c6-91bd-4866-a2a9-0062ffdf07ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86562c6-91bd-4866-a2a9-0062ffdf07ce.jpg?1",
             "name": "Leech Bonder",
             "text": "Leech Bonder comes into play with two -1/-1 counters on it.\n{U}, {Q}: Move a counter from target creature onto another target creature. ({Q} is the untap symbol.)",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "32d2a2e8-6a84-560e-bb57-356b8da657ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919382e-3dcd-4f83-8135-be71345e57c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919382e-3dcd-4f83-8135-be71345e57c0.jpg?1",
             "name": "Merrow Wavebreakers",
             "text": "{1}{U}, {Q}: Merrow Wavebreakers gains flying until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "97ea1e23-908f-555e-8527-61cc0ce7b7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f9987-87d8-4cd3-98c4-b6976c70739e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f9987-87d8-4cd3-98c4-b6976c70739e.jpg?1",
             "name": "Parapet Watchers",
             "text": "{WU}: Parapet Watchers gets +0/+1 until end of turn.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "6c9605c4-89fd-5d2c-b6fe-6a6d56523b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7ac836-07c9-469d-9ed0-4a0aab457e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7ac836-07c9-469d-9ed0-4a0aab457e31.jpg?1",
             "name": "Prismwake Merrow",
             "text": "Flash\nWhen Prismwake Merrow comes into play, target permanent becomes the color or colors of your choice until end of turn.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "dd5887fe-2e33-5a6c-ad59-7b0ed37b399a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380bd90-35f2-4936-995b-af6427f61752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380bd90-35f2-4936-995b-af6427f61752.jpg?1",
             "name": "Puca's Mischief",
             "text": "At the beginning of your upkeep, you may exchange control of target nonland permanent you control and target nonland permanent an opponent controls with an equal or lesser converted mana cost.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "32ab3d2a-12bf-52aa-8d6a-8a295d2cae50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17dff9e-23f7-4b12-95e7-aa1c00ab3d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17dff9e-23f7-4b12-95e7-aa1c00ab3d18.jpg?1",
             "name": "Put Away",
             "text": "Counter target spell. You may shuffle up to one target card from your graveyard into your library.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "0b61b9d8-518b-5ca8-baa2-c695cac930d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970adaaf-1534-4529-8da4-c4dcf7c08b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970adaaf-1534-4529-8da4-c4dcf7c08b7b.jpg?1",
             "name": "River Kelpie",
             "text": "Whenever River Kelpie or another permanent is put into play from a graveyard, draw a card.\nWhenever a spell is played from a graveyard, draw a card.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "b6bd6b55-34b7-5d24-a014-70c85099d760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0d9ad-31bf-4561-a5b2-f44a12a2c2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0d9ad-31bf-4561-a5b2-f44a12a2c2c2.jpg?1",
             "name": "Savor the Moment",
             "text": "Take an extra turn after this one. Skip the untap step of that turn.",
             "colours": [
@@ -1688,7 +1688,7 @@
         },
         {
             "id": "3c90d662-7ba7-5c6d-8428-4f3b530f9f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aac9a8a-7594-4270-a8b6-57b4f8f2a390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aac9a8a-7594-4270-a8b6-57b4f8f2a390.jpg?1",
             "name": "Sinking Feeling",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"{1}, Put a -1/-1 counter on this creature: Untap this creature.\"",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "34a85898-5d6a-5492-85c2-bfbd8ef6906a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883113c-e52b-4633-b4a4-016093327b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883113c-e52b-4633-b4a4-016093327b6a.jpg?1",
             "name": "Spell Syphon",
             "text": "Counter target spell unless its controller pays {1} for each blue permanent you control.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "7de2179c-05a4-5f24-b79b-9b133733d19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3090b11-3df3-40bc-bd3c-27218c2e19e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3090b11-3df3-40bc-bd3c-27218c2e19e2.jpg?1",
             "name": "Thought Reflection",
             "text": "If you would draw a card, draw two cards instead.",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "948a4eeb-43cd-5d78-b8cb-63c6a37d6b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e1d8b-edae-4b5e-b897-2c0a307e650c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e1d8b-edae-4b5e-b897-2c0a307e650c.jpg?1",
             "name": "Whimwader",
             "text": "Whimwader can't attack unless defending player controls a blue permanent.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "1f41da58-f8b2-5800-bb0b-1eb5c4908287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd47e7-02c5-4f91-bb3b-697c4c53232a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd47e7-02c5-4f91-bb3b-697c4c53232a.jpg?1",
             "name": "Aphotic Wisps",
             "text": "Target creature becomes black and gains fear until end of turn.\nDraw a card.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "eeb5d45c-a1ff-5f21-8c0a-eeabecbcd8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdef552-17d0-4b48-868e-058af02101be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdef552-17d0-4b48-868e-058af02101be.jpg?1",
             "name": "Ashenmoor Cohort",
             "text": "Ashenmoor Cohort gets +1/+1 as long as you control another black creature.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "7f89d4bb-04a5-5f4a-b8a1-a40138c82cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee0a93-0f6d-42be-bdca-1de5422d8d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee0a93-0f6d-42be-bdca-1de5422d8d54.jpg?1",
             "name": "Beseech the Queen",
             "text": "({2\nB} can be paid with any two mana or with {B}. This card's converted mana cost is 6.)\nSearch your library for a card with converted mana cost less than or equal to the number of lands you control, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "5947f81e-9349-54a8-bedd-a36edb93fea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae027b38-a6cc-41f7-8f0d-9d1402b46517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae027b38-a6cc-41f7-8f0d-9d1402b46517.jpg?1",
             "name": "Blowfly Infestation",
             "text": "Whenever a creature is put into a graveyard from play, if it had a -1/-1 counter on it, put a -1/-1 counter on target creature.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "96cb98f4-12e0-5d0b-b6e9-2fa05b814788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dcf40c-62fb-4205-807e-71655066a61b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dcf40c-62fb-4205-807e-71655066a61b.jpg?1",
             "name": "Cinderbones",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{1}{B}: Regenerate Cinderbones.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "6905f0b7-43a9-5d34-8f13-4925081e2fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644319c2-f122-4369-b1f8-56ad7d8ce861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644319c2-f122-4369-b1f8-56ad7d8ce861.jpg?1",
             "name": "Cinderhaze Wretch",
             "text": "{T}: Target player discards a card. Play this ability only during your turn.\nPut a -1/-1 counter on Cinderhaze Wretch: Untap Cinderhaze Wretch.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "aa24a1f9-0cb1-5f9e-975c-fdb8542df283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140457ff-ee7d-48ec-8b91-ef5c2cc1ed74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140457ff-ee7d-48ec-8b91-ef5c2cc1ed74.jpg?1",
             "name": "Corrosive Mentor",
             "text": "Black creatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "cf79b6bc-5167-5e9d-a850-22cbf9efdbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3504249-d226-4a9a-8855-69723cefaeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3504249-d226-4a9a-8855-69723cefaeff.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of Swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "13f726d0-1e5f-54b3-b148-20ab08390820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd88305-d57b-4e77-aec9-f0a3ace42c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd88305-d57b-4e77-aec9-f0a3ace42c37.jpg?1",
             "name": "Crowd of Cinders",
             "text": "Fear\nCrowd of Cinders's power and toughness are each equal to the number of black permanents you control.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "0c8876cb-2821-549e-a9a6-c61f177806a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7796925-fe69-4019-82ab-7cb75760b045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7796925-fe69-4019-82ab-7cb75760b045.jpg?1",
             "name": "Disturbing Plot",
             "text": "Return target creature card in a graveyard to its owner's hand.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "26f92dca-7d7b-5918-8a0e-3a27871725f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adce41c5-3a43-4fe0-b84e-8baaad1a0777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adce41c5-3a43-4fe0-b84e-8baaad1a0777.jpg?1",
             "name": "Dusk Urchins",
             "text": "Whenever Dusk Urchins attacks or blocks, put a -1/-1 counter on it.\nWhen Dusk Urchins is put into a graveyard from play, draw a card for each -1/-1 counter on it.",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "07be9f95-dc09-5638-8867-8006a19ce035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8befa-27dd-4ec4-b317-1c231407e0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8befa-27dd-4ec4-b317-1c231407e0ac.jpg?1",
             "name": "Faerie Macabre",
             "text": "Flying\nDiscard Faerie Macabre: Remove up to two target cards in graveyards from the game.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "2b0a22ce-178a-5f92-a01b-75a366224fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b45bfb2-7c48-4da5-a0fd-29d353221814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b45bfb2-7c48-4da5-a0fd-29d353221814.jpg?1",
             "name": "Gloomlance",
             "text": "Destroy target creature. If that creature was green or white, its controller discards a card.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "10fba05f-1f7b-5e34-b797-18aedd1bd74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544fba3c-0db4-4ac3-ac70-ae9a5468ab5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544fba3c-0db4-4ac3-ac70-ae9a5468ab5d.jpg?1",
             "name": "Hollowborn Barghest",
             "text": "At the beginning of your upkeep, if you have no cards in hand, each opponent loses 2 life.\nAt the beginning of each opponent's upkeep, if that player has no cards in hand, he or she loses 2 life.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "1567f628-c3f1-5893-a0f9-8e7dd7a624c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6618713-0573-44f6-82d9-dfc16dfef052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6618713-0573-44f6-82d9-dfc16dfef052.jpg?1",
             "name": "Hollowsage",
             "text": "Whenever Hollowsage becomes untapped, you may have target player discard a card.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "21bf4eb8-efc8-5f48-94c0-880ea0a75ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2633f1c-0563-4b3d-bab0-415757bc5ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2633f1c-0563-4b3d-bab0-415757bc5ecd.jpg?1",
             "name": "Incremental Blight",
             "text": "Put a -1/-1 counter on target creature, two -1/-1 counters on another target creature, and three -1/-1 counters on a third target creature.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "e167e82a-79a2-5ac7-b79e-5f1572736513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964b501-5b7f-4225-9dd3-e7519bf34048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964b501-5b7f-4225-9dd3-e7519bf34048.jpg?1",
             "name": "Loch Korrigan",
             "text": "{UB}: Loch Korrigan gets +1/+1 until end of turn.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "034f1fc5-d5c1-5506-a77f-a369caf3612a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0ff253-001a-45bc-98ab-4713a813fb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0ff253-001a-45bc-98ab-4713a813fb11.jpg?1",
             "name": "Midnight Banshee",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nAt the beginning of your upkeep, put a -1/-1 counter on each nonblack creature.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "b6ae85a4-544a-5a79-b1da-91637b5c15e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231613d6-d3b8-4b41-bc93-4d5da3fec5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231613d6-d3b8-4b41-bc93-4d5da3fec5d0.jpg?1",
             "name": "Plague of Vermin",
             "text": "Starting with you, each player may pay any amount of life. Repeat this process until no one pays life. Each player puts a 1/1 black Rat creature token into play for each 1 life he or she paid this way.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "13e8e109-d9f5-5904-8ec7-cd4032f434b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6439222-de30-44cd-a53f-a7de0cb00b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6439222-de30-44cd-a53f-a7de0cb00b8f.jpg?1",
             "name": "Polluted Bonds",
             "text": "Whenever a land comes into play under an opponent's control, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "348c4621-66ef-5493-abbe-2cd7202dc96d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff839e1-6f76-4a24-a87c-d4589b1abf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff839e1-6f76-4a24-a87c-d4589b1abf66.jpg?1",
             "name": "Puppeteer Clique",
             "text": "Flying\nWhen Puppeteer Clique comes into play, put target creature card in an opponent's graveyard into play under your control. It has haste. At the end of your turn, remove it from the game.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "e2e30e7b-a62f-5d87-af60-9ba5f48ddd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62d999c-c81e-4bea-aefd-0d12251dcdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62d999c-c81e-4bea-aefd-0d12251dcdd1.jpg?1",
             "name": "Rite of Consumption",
             "text": "As an additional cost to play Rite of Consumption, sacrifice a creature.\nRite of Consumption deals damage equal to the sacrificed creature's power to target player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "ec96ffa4-97be-54bd-97fd-8bdd15809c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c4e5f-5de7-45ec-b502-0e6d7c5c359d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c4e5f-5de7-45ec-b502-0e6d7c5c359d.jpg?1",
             "name": "Sickle Ripper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "87955378-3d18-5f56-ba0c-321a66bef355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ecbed3-3a41-4823-8cd2-498daaaa0d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ecbed3-3a41-4823-8cd2-498daaaa0d4f.jpg?1",
             "name": "Smolder Initiate",
             "text": "Whenever a player plays a black spell, you may pay {1}. If you do, target player loses 1 life.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "f8d88b13-c79b-51df-8714-b63522ad4611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168d790f-9163-498c-b96d-fdeb2070bda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168d790f-9163-498c-b96d-fdeb2070bda0.jpg?1",
             "name": "Splitting Headache",
             "text": "Choose one Target player discards two cards; or target player reveals his or her hand, you choose a card from it, then that player discards that card.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "bd1fc581-5f62-5a9c-bba2-285ab9e3c4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fed16d-c800-4c0f-be88-9fddde2c018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fed16d-c800-4c0f-be88-9fddde2c018e.jpg?1",
             "name": "Torture",
             "text": "Enchant creature\n{1}{B}: Put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "0cc21525-2e70-5260-b828-f96e249fb300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cf8332-0ff2-40c5-980a-6f6be690fad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cf8332-0ff2-40c5-980a-6f6be690fad0.jpg?1",
             "name": "Wound Reflection",
             "text": "At the end of each turn, each opponent loses life equal to the life he or she lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -2725,7 +2725,7 @@
         },
         {
             "id": "f46e71c5-016f-5953-bcab-e34028bb9c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5720a5b2-60ca-49f9-83e8-b801471c92ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5720a5b2-60ca-49f9-83e8-b801471c92ea.jpg?1",
             "name": "Blistering Dieflyn",
             "text": "Flying\n{BR}: Blistering Dieflyn gets +1/+0 until end of turn.",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "5caef7a6-bfde-5f8e-a633-c2b5131628fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322a389-44cc-4a3d-bd39-93c156640f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322a389-44cc-4a3d-bd39-93c156640f8e.jpg?1",
             "name": "Bloodmark Mentor",
             "text": "Red creatures you control have first strike.",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "f7deb67d-b240-5bce-bddf-f94a5918a23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b92320-6f83-4731-93c8-7eb9fd90ee83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b92320-6f83-4731-93c8-7eb9fd90ee83.jpg?1",
             "name": "Bloodshed Fever",
             "text": "Enchant creature\nEnchanted creature attacks each turn if able.",
             "colours": [
@@ -2829,7 +2829,7 @@
         },
         {
             "id": "84037f69-a0bf-541e-a889-11400ee419f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a837b6-c8b0-4971-ae95-0b49d38bc830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a837b6-c8b0-4971-ae95-0b49d38bc830.jpg?1",
             "name": "Boggart Arsonists",
             "text": "Plainswalk\n{2}{R}, Sacrifice Boggart Arsonists: Destroy target Scarecrow or Plains.",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "e6d01741-e4c8-5147-b944-a06b62753af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01f9a0-f1d0-4241-a270-df4ed673d1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01f9a0-f1d0-4241-a270-df4ed673d1fd.jpg?1",
             "name": "Burn Trail",
             "text": "Burn Trail deals 3 damage to target creature or player.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "aebb787a-ab84-5f23-90b7-ea24539ab132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9297506-8656-483d-892e-217ecd8bab0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9297506-8656-483d-892e-217ecd8bab0c.jpg?1",
             "name": "Cragganwick Cremator",
             "text": "When Cragganwick Cremator comes into play, discard a card at random. If you discard a creature card this way, Cragganwick Cremator deals damage equal to that card's power to target player.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "4f531821-36ee-5f16-baea-26c9067bc348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65c81ff-fc5d-4191-93fb-52eb806457b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65c81ff-fc5d-4191-93fb-52eb806457b7.jpg?1",
             "name": "Crimson Wisps",
             "text": "Target creature becomes red and gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "7b3d71b4-2167-570b-bc6b-61334ca9ac1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg?1",
             "name": "Deep-Slumber Titan",
             "text": "Deep-Slumber Titan comes into play tapped.\nDeep-Slumber Titan doesn't untap during your untap step.\nWhenever Deep-Slumber Titan is dealt damage, untap it.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "9cfd09a8-563d-52bd-ab23-2767ba01a49c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91705d63-8aae-47c2-a880-1b07c6d33bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91705d63-8aae-47c2-a880-1b07c6d33bde.jpg?1",
             "name": "Elemental Mastery",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put X 1/1 red Elemental creature tokens with haste into play, where X is this creature's power. Remove them from the game at end of turn.\"",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "5ef0a25d-554a-5d44-96f9-89ab34f59715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cafc-ca14-4c1a-8237-565515a81dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cafc-ca14-4c1a-8237-565515a81dec.jpg?1",
             "name": "Ember Gale",
             "text": "Creatures target player controls can't block this turn. Ember Gale deals 1 damage to each white and/or blue creature that player controls.",
             "colours": [
@@ -3064,7 +3064,7 @@
         },
         {
             "id": "ada11962-b845-5809-9ab8-5c0bebf8c04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a567b570-81e4-4068-929c-9ce406fe7474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a567b570-81e4-4068-929c-9ce406fe7474.jpg?1",
             "name": "Flame Javelin",
             "text": "({2\nR} can be paid with any two mana or with {R}. This card's converted mana cost is 6.)\nFlame Javelin deals 4 damage to target creature or player.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "663083ae-f041-5a3a-bc76-425437b16e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b102dc6-d7ef-48dd-8b77-2ce43955f7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b102dc6-d7ef-48dd-8b77-2ce43955f7fa.jpg?1",
             "name": "Furystoke Giant",
             "text": "When Furystoke Giant comes into play, other creatures you control gain \"{T}: This creature deals 2 damage to target creature or player\" until end of turn.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "736c37e0-2924-5099-b96f-3ba9f70735a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023562bf-da7d-486d-93fc-60353f55b8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023562bf-da7d-486d-93fc-60353f55b8a7.jpg?1",
             "name": "Horde of Boggarts",
             "text": "Horde of Boggarts's power and toughness are each equal to the number of red permanents you control.\nHorde of Boggarts can't be blocked except by two or more creatures.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "e5ffb25b-0be4-5995-a88e-bc03c7361895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4a1d42-eaf8-424a-9649-5f3b4602bf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4a1d42-eaf8-424a-9649-5f3b4602bf0d.jpg?1",
             "name": "Inescapable Brute",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nInescapable Brute must be blocked if able.",
             "colours": [
@@ -3200,7 +3200,7 @@
         },
         {
             "id": "e302363b-7e08-55d3-8f04-d196035fb6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19dd557-dd49-450d-8446-71ce351d4f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19dd557-dd49-450d-8446-71ce351d4f52.jpg?1",
             "name": "Intimidator Initiate",
             "text": "Whenever a player plays a red spell, you may pay {1}. If you do, target creature can't block this turn.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "531c570e-3b7a-5221-bb97-47edefc8976a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75021156-61af-4a85-8ac5-15cf18482140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75021156-61af-4a85-8ac5-15cf18482140.jpg?1",
             "name": "Jaws of Stone",
             "text": "Jaws of Stone deals X damage divided as you choose among any number of target creatures and/or players, where X is the number of Mountains you control as you play Jaws of Stone.",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "bc024a0c-b7e0-5b7e-88c6-8853bc2f524d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcfec58-bfe4-4b04-80e3-ee11c44e91a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcfec58-bfe4-4b04-80e3-ee11c44e91a7.jpg?1",
             "name": "Knollspine Dragon",
             "text": "Flying\nWhen Knollspine Dragon comes into play, you may discard your hand and draw cards equal to the damage dealt to target opponent this turn.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "09d5d53b-4569-5e88-862e-0a1e1ae35201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8157aade-9dfc-402d-8e1f-468bf2bccb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8157aade-9dfc-402d-8e1f-468bf2bccb9c.jpg?1",
             "name": "Knollspine Invocation",
             "text": "{X}, Discard a card with converted mana cost X: Knollspine Invocation deals X damage to target creature or player.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "43518675-12a4-57f9-8bcd-4c96ce292ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcb1f26-9a2a-40bd-b291-4ef8ce375cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcb1f26-9a2a-40bd-b291-4ef8ce375cdf.jpg?1",
             "name": "Mudbrawler Cohort",
             "text": "Haste\nMudbrawler Cohort gets +1/+1 as long as you control another red creature.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "008d434b-e1df-59a5-a324-5b288fa6be7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02d053-0885-4720-bf74-b65b3f87cfd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02d053-0885-4720-bf74-b65b3f87cfd9.jpg?1",
             "name": "Power of Fire",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "ca7adbb0-c8fb-5119-aff0-1edddae79d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a0bc1-ab01-4381-8f54-7381a2213cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a0bc1-ab01-4381-8f54-7381a2213cdf.jpg?1",
             "name": "Puncture Bolt",
             "text": "Puncture Bolt deals 1 damage to target creature. Put a -1/-1 counter on that creature.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "f418c932-de21-5508-9472-8b251302b4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de320e0d-c1e9-4b5e-84a0-057f3f162bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de320e0d-c1e9-4b5e-84a0-057f3f162bbf.jpg?1",
             "name": "Pyre Charger",
             "text": "Haste\n{R}: Pyre Charger gets +1/+0 until end of turn.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "280e8dbe-a227-547c-84e4-1f90d15ec20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275e118d-1d50-47ee-a2c9-76169ce372cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275e118d-1d50-47ee-a2c9-76169ce372cf.jpg?1",
             "name": "Rage Reflection",
             "text": "Creatures you control have double strike.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "4807f2a2-8951-533a-b969-38e41ae0487c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa0dd3e-51d1-4d75-b0f4-835992f420d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa0dd3e-51d1-4d75-b0f4-835992f420d6.jpg?1",
             "name": "Rustrazor Butcher",
             "text": "First strike\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "2f4be608-fe53-57f0-8fed-1fdf41855204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259c6cd-43c8-415e-baca-b31e2374631f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259c6cd-43c8-415e-baca-b31e2374631f.jpg?1",
             "name": "Slinking Giant",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever Slinking Giant blocks or becomes blocked, it gets -3/-0 until end of turn.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "885888ad-ea6e-54d9-b42c-386a856c2628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eda1524-44dd-4f70-ac21-bac51578860e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eda1524-44dd-4f70-ac21-bac51578860e.jpg?1",
             "name": "Smash to Smithereens",
             "text": "Destroy target artifact. Smash to Smithereens deals 3 damage to that artifact's controller.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "1a0aeccf-29a5-5c2d-a48e-8570e27c006c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320ade77-30be-4930-80ca-86028c010b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320ade77-30be-4930-80ca-86028c010b1b.jpg?1",
             "name": "Wild Swing",
             "text": "Choose three target nonenchantment permanents. Destroy one of them at random.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "b423e36a-78cf-5595-8bdc-fcac367f3380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c17b102-a25d-4fff-8718-3bdd53092552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c17b102-a25d-4fff-8718-3bdd53092552.jpg?1",
             "name": "Crabapple Cohort",
             "text": "Crabapple Cohort gets +1/+1 as long as you control another green creature.",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "4c3aac53-af3c-5f99-8082-3e0106ecc737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820e2f07-f637-4144-b45a-0e1430dcf55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820e2f07-f637-4144-b45a-0e1430dcf55e.jpg?1",
             "name": "Devoted Druid",
             "text": "{T}: Add {G} to your mana pool.\nPut a -1/-1 counter on Devoted Druid: Untap Devoted Druid.",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "f4f129ab-0610-5fc5-a50b-d0e49dfd6453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4562a300-8777-4a47-8650-8a2bc2678def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4562a300-8777-4a47-8650-8a2bc2678def.jpg?1",
             "name": "Dramatic Entrance",
             "text": "You may put a green creature card from your hand into play.",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "620a451c-6ff3-59f0-a1c0-e552e5c3186f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b657ad23-e84b-4b53-a6b6-80f359624ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b657ad23-e84b-4b53-a6b6-80f359624ab8.jpg?1",
             "name": "Drove of Elves",
             "text": "Drove of Elves's power and toughness are each equal to the number of green permanents you control.\nDrove of Elves can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "357889f7-b134-5d46-9acc-7ea83af0911b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ff79-779f-4fb1-a842-56ba38e80fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ff79-779f-4fb1-a842-56ba38e80fdd.jpg?1",
             "name": "Farhaven Elf",
             "text": "When Farhaven Elf comes into play, you may search your library for a basic land card and put it into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "3ba7aff3-82f1-5758-a81c-a74493d2daf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223f5d6-83f1-454e-9cd5-aba157850430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223f5d6-83f1-454e-9cd5-aba157850430.jpg?1",
             "name": "Flourishing Defenses",
             "text": "Whenever a -1/-1 counter is placed on a creature, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "c1d4cb37-2a04-5b6f-9727-03777d4b1591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e23eae-7630-40db-b265-2fa00715878e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e23eae-7630-40db-b265-2fa00715878e.jpg?1",
             "name": "Foxfire Oak",
             "text": "{RG}{RG}{RG}: Foxfire Oak gets +3/+0 until end of turn.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "0dc2ad9a-a5a6-50ff-897c-91910e72b078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7d043-5f52-4df6-8dcf-5174a5b0c9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7d043-5f52-4df6-8dcf-5174a5b0c9cc.jpg?1",
             "name": "Gleeful Sabotage",
             "text": "Destroy target artifact or enchantment.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "a5e1336f-b67c-5c3b-85d7-f8beb93fed30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bda306-1e37-4359-a649-fcd8a5a7e2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bda306-1e37-4359-a649-fcd8a5a7e2fc.jpg?1",
             "name": "Gloomwidow",
             "text": "Reach\nGloomwidow can't block creatures without flying.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "7c968d41-9f54-55d7-815a-7dea88c2a8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b989b4-692c-4ccb-a290-0ff00abacba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b989b4-692c-4ccb-a290-0ff00abacba9.jpg?1",
             "name": "Gloomwidow's Feast",
             "text": "Destroy target creature with flying. If that creature was blue or black, put a 1/2 green Spider creature token with reach into play. (It can block creatures with flying.)",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "6d89e293-7ed2-5f7e-8206-ddb182c6dcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293f7768-6279-4f26-979f-ea4e48095ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293f7768-6279-4f26-979f-ea4e48095ae5.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "Put a 2/2 green Wolf creature token into play for each Forest you control.",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "4ca8a768-4ea1-5c33-900d-019c7fcd9da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be81b15-eb12-452b-8fdd-bde64807f422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be81b15-eb12-452b-8fdd-bde64807f422.jpg?1",
             "name": "Hungry Spriggan",
             "text": "Trample\nWhenever Hungry Spriggan attacks, it gets +3/+3 until end of turn.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "184a57bb-c023-5246-ac65-16da7d27dacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f323d5-f26c-46e9-9d6a-be5c254fe8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f323d5-f26c-46e9-9d6a-be5c254fe8b6.jpg?1",
             "name": "Juvenile Gloomwidow",
             "text": "Reach (This can block creatures with flying.)\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "7b60ef04-e3c0-5509-9f6a-7e29e59d8e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcf02eb-2aaa-4c22-a3b3-f57019664118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcf02eb-2aaa-4c22-a3b3-f57019664118.jpg?1",
             "name": "Mana Reflection",
             "text": "If you tap a permanent for mana, it produces twice as much of that mana instead.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "6aad08f7-af15-5216-a7c7-2d603bb31b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537c39cc-44d3-4869-9e76-dd9c2c68ee90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537c39cc-44d3-4869-9e76-dd9c2c68ee90.jpg?1",
             "name": "Mossbridge Troll",
             "text": "If Mossbridge Troll would be destroyed, regenerate it.\nTap any number of untapped creatures you control other than Mossbridge Troll with total power 10 or greater: Mossbridge Troll gets +20/+20 until end of turn.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "69cc6caf-ddea-57b0-9553-94bd3036ce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2330c78d-1655-4074-a650-27740be4cee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2330c78d-1655-4074-a650-27740be4cee1.jpg?1",
             "name": "Nurturer Initiate",
             "text": "Whenever a player plays a green spell, you may pay {1}. If you do, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "e2405fae-10d1-5a1e-8764-98f2abc5fa0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546c647d-8d0a-4b88-804e-ce0348eb772a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546c647d-8d0a-4b88-804e-ce0348eb772a.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put a 1/1 green Elf Warrior creature token into play.\"",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "3e8b888a-f5d3-5c45-a7c3-f78050e11ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75594cc-de47-49f2-9a8b-ba76c576368e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75594cc-de47-49f2-9a8b-ba76c576368e.jpg?1",
             "name": "Prismatic Omen",
             "text": "Lands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "d4e1ea72-3f2b-5816-b43c-2c27ee034c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df529b30-9ac6-4944-9d21-ecf6d64a8845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df529b30-9ac6-4944-9d21-ecf6d64a8845.jpg?1",
             "name": "Raking Canopy",
             "text": "Whenever a creature with flying attacks you, Raking Canopy deals 4 damage to it.",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "960ad773-03cf-52a6-991f-a576e733a209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe77862-516f-4eb2-9a41-0c6401d02843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe77862-516f-4eb2-9a41-0c6401d02843.jpg?1",
             "name": "Roughshod Mentor",
             "text": "Green creatures you control have trample.",
             "colours": [
@@ -4307,7 +4307,7 @@
         },
         {
             "id": "f6d5d416-77c8-5f04-9e7f-0fe10bf1afef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8724b3-c956-476b-9885-95542eee5742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8724b3-c956-476b-9885-95542eee5742.jpg?1",
             "name": "Spawnwrithe",
             "text": "Trample\nWhenever Spawnwrithe deals combat damage to a player, put a token into play that's a copy of Spawnwrithe.",
             "colours": [
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "c9fd9c7d-750b-5666-8813-0b928631c3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fd436-35eb-4207-9439-de652234dd50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fd436-35eb-4207-9439-de652234dd50.jpg?1",
             "name": "Toil to Renown",
             "text": "You gain 1 life for each tapped artifact, creature, and land you control.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "b63b112c-045e-5986-b14c-521102733889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc1e47-3786-4ba9-b837-bf5b43323135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc1e47-3786-4ba9-b837-bf5b43323135.jpg?1",
             "name": "Tower Above",
             "text": "({2\nG} can be paid with any two mana or with {G}. This card's converted mana cost is 6.)\nUntil end of turn, target creature gets +4/+4 and gains trample, wither, and \"When this creature attacks, target creature blocks it this turn if able.\" (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "a8190a03-c67b-5048-b2fa-c278bf003981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c33871f-0e6a-4616-b484-e79b1945255f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c33871f-0e6a-4616-b484-e79b1945255f.jpg?1",
             "name": "Viridescent Wisps",
             "text": "Target creature becomes green and gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "f896817b-0eac-5388-b6cd-33687e6ccf65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323467c-132f-469a-90fc-9d3b0fb004aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323467c-132f-469a-90fc-9d3b0fb004aa.jpg?1",
             "name": "Wildslayer Elves",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "98a23d96-5333-5cae-8330-acf6bde53e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5187fc71-e4d3-4071-9ea1-d4513f30c529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5187fc71-e4d3-4071-9ea1-d4513f30c529.jpg?1",
             "name": "Witherscale Wurm",
             "text": "Whenever Witherscale Wurm blocks or becomes blocked by a creature, that creature gains wither until end of turn. (It deals damage to creatures in the form of -1/-1 counters.)\nWhenever Witherscale Wurm deals damage to an opponent, remove all -1/-1 counters from it.",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "948b94de-cc26-5dec-a201-a922e1055eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43aa7e35-55ee-4e02-a8aa-ea2b267055d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43aa7e35-55ee-4e02-a8aa-ea2b267055d1.jpg?1",
             "name": "Woodfall Primus",
             "text": "Trample\nWhen Woodfall Primus comes into play, destroy target noncreature permanent.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "ddd968b7-591b-5906-a724-3fc9976f3313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a656e7-9c1c-40b6-91fe-0098f72d8384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a656e7-9c1c-40b6-91fe-0098f72d8384.jpg?1",
             "name": "Aethertow",
             "text": "Put target attacking or blocking creature on top of its owner's library.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "b63a6563-1707-503d-8485-6e9c7b66c6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba392e1-f310-4496-9d29-99a8783cc0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba392e1-f310-4496-9d29-99a8783cc0f3.jpg?1",
             "name": "Augury Adept",
             "text": "Whenever Augury Adept deals combat damage to a player, reveal the top card of your library and put that card into your hand. You gain life equal to its converted mana cost.",
             "colours": [
@@ -4612,7 +4612,7 @@
         },
         {
             "id": "627daf32-8fe4-543a-9675-fd1ecfcaf11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361dab9e-22f0-45e4-a793-aa6c97a96781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361dab9e-22f0-45e4-a793-aa6c97a96781.jpg?1",
             "name": "Barrenton Cragtreads",
             "text": "Barrenton Cragtreads can't be blocked by red creatures.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "0ea48ce2-c9f0-5d3b-b3ba-7962d2cd98c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db21bcb-60e8-4d15-8ea7-7298c2b1607c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db21bcb-60e8-4d15-8ea7-7298c2b1607c.jpg?1",
             "name": "Curse of Chains",
             "text": "Enchant creature\nAt the beginning of each upkeep, tap enchanted creature.",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "4daf2e40-5009-5cb0-a4f3-37db5a92d2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033a7b0-39b0-4c49-b332-7ea62d85455d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033a7b0-39b0-4c49-b332-7ea62d85455d.jpg?1",
             "name": "Enchanted Evening",
             "text": "All permanents are enchantments in addition to their other types.",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "f7efe90f-79da-5532-a670-ec397331b642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc402e-8e84-4d47-9638-e94b12f3f667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc402e-8e84-4d47-9638-e94b12f3f667.jpg?1",
             "name": "Glamer Spinners",
             "text": "Flash\nFlying\nWhen Glamer Spinners comes into play, attach all Auras enchanting target permanent to another permanent with the same controller.",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "f38a1222-c8fb-5522-825e-b201d14a37a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e34d294-c0ec-4e3c-a731-31b7a29c59b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e34d294-c0ec-4e3c-a731-31b7a29c59b4.jpg?1",
             "name": "Godhead of Awe",
             "text": "Flying\nOther creatures are 1/1.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "5f211557-5ea7-5c33-ba5d-9a60ddf1a8a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea002c6-d15f-4536-9349-92c77ae5021a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea002c6-d15f-4536-9349-92c77ae5021a.jpg?1",
             "name": "Mirrorweave",
             "text": "Each other creature becomes a copy of target nonlegendary creature until end of turn.",
             "colours": [
@@ -4827,7 +4827,7 @@
         },
         {
             "id": "92e11249-c314-54d9-85e5-8789a34fd0a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e776fe0-6574-4fca-91bd-eb6e7383e5be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e776fe0-6574-4fca-91bd-eb6e7383e5be.jpg?1",
             "name": "Mistmeadow Witch",
             "text": "{2}{W}{U}: Remove target creature from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -4864,7 +4864,7 @@
         },
         {
             "id": "4998dc75-46de-515c-96cf-3baede060256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8b0449-3ae5-4fee-b870-af12be5e5a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8b0449-3ae5-4fee-b870-af12be5e5a64.jpg?1",
             "name": "Plumeveil",
             "text": "Flash\nFlying, defender",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "40676037-46d6-54c8-b9ee-c0ba31ade198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f25680-d1b3-4bf6-83e2-2eea0b5419ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f25680-d1b3-4bf6-83e2-2eea0b5419ad.jpg?1",
             "name": "Puresight Merrow",
             "text": "{WU}, {Q}: Look at the top card of your library. You may remove that card from the game. ({Q} is the untap symbol.)",
             "colours": [
@@ -4937,7 +4937,7 @@
         },
         {
             "id": "d602f602-1e7a-5890-8296-5fec785972cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e64b09-1a58-4669-b7f2-baa3ccc85f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e64b09-1a58-4669-b7f2-baa3ccc85f2d.jpg?1",
             "name": "Repel Intruders",
             "text": "Put two 1/1 white Kithkin Soldier creature tokens into play if {W} was spent to play Repel Intruders. Counter up to one target creature spell if {U} was spent to play Repel Intruders. (Do both if {W}{U} was spent.)",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "d4585183-1e13-5208-9f5e-6e166bb67f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d06328-a124-40e4-a9d8-2342a881970e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d06328-a124-40e4-a9d8-2342a881970e.jpg?1",
             "name": "Silkbind Faerie",
             "text": "Flying\n{1}{WU}, {Q}: Tap target creature. ({Q} is the untap symbol.)",
             "colours": [
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "7c33d1c4-6bae-5458-a093-a687a45d2c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf51122-fd7c-40b5-b759-65e21c28e3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf51122-fd7c-40b5-b759-65e21c28e3d6.jpg?1",
             "name": "Somnomancer",
             "text": "When Somnomancer comes into play, you may tap target creature.",
             "colours": [
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "9a6caa66-6054-52a0-8843-0b8951fed53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf8181-68c7-4f5a-b999-70f985b1f2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf8181-68c7-4f5a-b999-70f985b1f2ac.jpg?1",
             "name": "Steel of the Godhead",
             "text": "Enchant creature\nAs long as enchanted creature is white, it gets +1/+1 and has lifelink. (Whenever it deals damage, its controller gains that much life.)\nAs long as enchanted creature is blue, it gets +1/+1 and is unblockable.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "6c4ba486-edbe-5dbe-a4e2-bfcd16d51ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdf78b7-3c32-422a-a73f-d198e6f06290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdf78b7-3c32-422a-a73f-d198e6f06290.jpg?1",
             "name": "Swans of Bryn Argoll",
             "text": "Flying\nIf a source would deal damage to Swans of Bryn Argoll, prevent that damage. The source's controller draws cards equal to the damage prevented this way.",
             "colours": [
@@ -5118,7 +5118,7 @@
         },
         {
             "id": "ce0d7bf5-ed25-5faa-901d-f203771ecd57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57ba0ce-0390-42fd-9473-2436fac53631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57ba0ce-0390-42fd-9473-2436fac53631.jpg?1",
             "name": "Thistledown Duo",
             "text": "Whenever you play a white spell, Thistledown Duo gets +1/+1 until end of turn.\nWhenever you play a blue spell, Thistledown Duo gains flying until end of turn.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "b59c311b-6932-52a2-a84f-bf76120f669f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e34233-0972-4aa7-a5ab-eabed2235148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e34233-0972-4aa7-a5ab-eabed2235148.jpg?1",
             "name": "Thistledown Liege",
             "text": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
             "colours": [
@@ -5193,7 +5193,7 @@
         },
         {
             "id": "0f3cda9b-4cf3-51a6-98bb-98e0ffe89407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7990b23-d460-46e2-bb05-396e2a653429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7990b23-d460-46e2-bb05-396e2a653429.jpg?1",
             "name": "Thoughtweft Gambit",
             "text": "Tap all creatures your opponents control and untap all creatures you control.",
             "colours": [
@@ -5227,7 +5227,7 @@
         },
         {
             "id": "f3f08dcd-89ac-5b53-be4a-21aa1e3551f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a62b31-986c-4722-97da-d984272f0f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a62b31-986c-4722-97da-d984272f0f05.jpg?1",
             "name": "Turn to Mist",
             "text": "Remove target creature from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "ae1d2346-eb44-5bd6-ad1e-f3d48802b07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f70fdb-264f-4545-97fa-3702168a66d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f70fdb-264f-4545-97fa-3702168a66d4.jpg?1",
             "name": "Worldpurge",
             "text": "Return all permanents to their owners' hands. Each player chooses up to seven cards in his or her hand, then shuffles the rest into his or her library. Empty all mana pools.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "0edb9ef4-2009-57d2-9230-336d923cfca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951214b-43a9-4c51-bbb4-05bac81b9866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951214b-43a9-4c51-bbb4-05bac81b9866.jpg?1",
             "name": "Zealous Guardian",
             "text": "Flash",
             "colours": [
@@ -5332,7 +5332,7 @@
         },
         {
             "id": "1e400076-578c-545e-810d-1a342552c429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec3b06b-d8c5-459c-aae5-3e51059cfdf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec3b06b-d8c5-459c-aae5-3e51059cfdf1.jpg?1",
             "name": "Cemetery Puca",
             "text": "Whenever a creature is put into a graveyard from play, you may pay {1}. If you do, Cemetery Puca becomes a copy of that creature and gains this ability.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "4ba5aba7-ac73-591f-aa01-842bb52292f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6fb3b2-eef2-4699-ab5e-ff7d8de2a1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6fb3b2-eef2-4699-ab5e-ff7d8de2a1de.jpg?1",
             "name": "Dire Undercurrents",
             "text": "Whenever a blue creature comes into play under your control, you may have target player draw a card.\nWhenever a black creature comes into play under your control, you may have target player discard a card.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "e603fd00-6605-546c-b849-59b77698e55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac999cc-c5c0-4309-a255-3eb7399af340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac999cc-c5c0-4309-a255-3eb7399af340.jpg?1",
             "name": "Dream Salvage",
             "text": "Draw cards equal to the number of cards target opponent discarded this turn.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "4801ef0b-0311-57b4-a691-094c34cab124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e052cde-985a-401f-828a-2d98511bbcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e052cde-985a-401f-828a-2d98511bbcd5.jpg?1",
             "name": "Fate Transfer",
             "text": "Move all counters from target creature onto another target creature.",
             "colours": [
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "e89eb08b-08cc-5d2c-9758-54f839bf17d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b118200-55e0-4d06-9e7e-ecde2814d24e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b118200-55e0-4d06-9e7e-ecde2814d24e.jpg?1",
             "name": "Ghastlord of Fugue",
             "text": "Ghastlord of Fugue is unblockable.\nWhenever Ghastlord of Fugue deals combat damage to a player, that player reveals his or her hand. Choose a card from it. That player removes that card from the game.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "45d5384f-2820-5d0d-8a22-0d42fe996ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cc72b7-b593-438f-a07a-35f2452e1c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cc72b7-b593-438f-a07a-35f2452e1c48.jpg?1",
             "name": "Glen Elendra Liege",
             "text": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
             "colours": [
@@ -5544,7 +5544,7 @@
         },
         {
             "id": "9d517048-6d92-51b7-b2ed-a45649d06303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efc174a-f710-4602-aace-c2165473f6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efc174a-f710-4602-aace-c2165473f6c2.jpg?1",
             "name": "Gravelgill Axeshark",
             "text": "Persist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "0470473c-7572-5d90-93b6-13b63ba924c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fd4959-bfff-46dc-b568-b6d69ef8eac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fd4959-bfff-46dc-b568-b6d69ef8eac9.jpg?1",
             "name": "Gravelgill Duo",
             "text": "Whenever you play a blue spell, Gravelgill Duo gets +1/+1 until end of turn.\nWhenever you play a black spell, Gravelgill Duo gains fear until end of turn.",
             "colours": [
@@ -5619,7 +5619,7 @@
         },
         {
             "id": "116ace74-9a3e-51a3-9503-5d4a33620d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653dd5b7-1ad3-4df1-bd2a-4e6ae362a8a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653dd5b7-1ad3-4df1-bd2a-4e6ae362a8a2.jpg?1",
             "name": "Helm of the Ghastlord",
             "text": "Enchant creature\nAs long as enchanted creature is blue, it gets +1/+1 and has \"Whenever this creature deals damage to an opponent, draw a card.\"\nAs long as enchanted creature is black, it gets +1/+1 and has \"Whenever this creature deals damage to an opponent, that player discards a card.\"",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "7b3780e9-75ea-5e4e-a6d1-ca0ee0c5497b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28854f0f-48d3-4a54-8811-c6329ad2e88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28854f0f-48d3-4a54-8811-c6329ad2e88e.jpg?1",
             "name": "Inkfathom Infiltrator",
             "text": "Inkfathom Infiltrator can't block and is unblockable.",
             "colours": [
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "2adac44d-8956-5f99-a7fc-425a67ed5f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a48062c-faac-4183-830f-919ab255b907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a48062c-faac-4183-830f-919ab255b907.jpg?1",
             "name": "Inkfathom Witch",
             "text": "Fear\n{2}{U}{B}: Each unblocked creature becomes 4/1 until end of turn.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "b0988821-6294-5cdb-8724-5176913ceb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6808a-1816-4ac7-bbb2-c7a5a47428d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6808a-1816-4ac7-bbb2-c7a5a47428d6.jpg?1",
             "name": "Memory Plunder",
             "text": "You may play target instant or sorcery card in an opponent's graveyard without paying its mana cost.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "156ffa61-48ea-5d11-ac97-9e352dae47a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd93980-55f6-43a0-87db-5fa1203aa7b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd93980-55f6-43a0-87db-5fa1203aa7b6.jpg?1",
             "name": "Memory Sluice",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "68205de9-ca1c-5709-a25d-be8baaaef24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b839c9d0-ef08-4661-8009-3bcb256bf508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b839c9d0-ef08-4661-8009-3bcb256bf508.jpg?1",
             "name": "Merrow Grimeblotter",
             "text": "{1}{UB}, {Q}: Target creature gets -2/-0 until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "e710a967-6778-5f5f-a922-1d2d35135e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ae75f6-fb74-422c-93f6-a0be7f919e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ae75f6-fb74-422c-93f6-a0be7f919e47.jpg?1",
             "name": "Oona, Queen of the Fae",
             "text": "Flying\n{X}{UB}: Choose a color. Target opponent removes the top X cards of his or her library from the game. For each card of the chosen color removed this way, put a 1/1 blue and black Faerie Rogue creature token with flying into play.",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "617521c1-23ac-5173-8f72-b3194ba226a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972bb6e4-300c-49f5-8305-459a3ba67baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972bb6e4-300c-49f5-8305-459a3ba67baa.jpg?1",
             "name": "Oona's Gatewarden",
             "text": "Flying, defender\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -5910,7 +5910,7 @@
         },
         {
             "id": "bf7b99df-bd27-52e5-b078-8f67ad3104fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1209bb9d-8aeb-4d7c-85bb-d9e9a24e36ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1209bb9d-8aeb-4d7c-85bb-d9e9a24e36ac.jpg?1",
             "name": "River's Grasp",
             "text": "If {U} was spent to play River's Grasp, return up to one target creature to its owner's hand. If {B} was spent to play River's Grasp, target player reveals his or her hand, you choose a nonland card from it, then that player discards that card. (Do both if {U}{B} was spent.)",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "94a3d029-489e-537d-b6bd-fe23f2b2bdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d3f64a-ffb9-4f66-91c0-463b5d2d381b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d3f64a-ffb9-4f66-91c0-463b5d2d381b.jpg?1",
             "name": "Scarscale Ritual",
             "text": "As an additional cost to play Scarscale Ritual, put a -1/-1 counter on a creature you control.\nDraw two cards.",
             "colours": [
@@ -5978,7 +5978,7 @@
         },
         {
             "id": "8a45b4b4-890d-5f47-b357-244b5bb66766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3926f037-aaec-416e-a486-b59aae6faf44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3926f037-aaec-416e-a486-b59aae6faf44.jpg?1",
             "name": "Sygg, River Cutthroat",
             "text": "At end of turn, if an opponent lost 3 or more life this turn, you may draw a card. (Damage causes loss of life.)",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "0edef408-ece3-59d8-b1a7-860ddb490c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8840551f-d43a-487f-a960-9b220dec5df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8840551f-d43a-487f-a960-9b220dec5df4.jpg?1",
             "name": "Torpor Dust",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -6053,7 +6053,7 @@
         },
         {
             "id": "de0eaa9c-2c4e-5c8f-a49e-b40256f5a865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab739d64-cdcd-4f07-9854-e067c37c4f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab739d64-cdcd-4f07-9854-e067c37c4f41.jpg?1",
             "name": "Wanderbrine Rootcutters",
             "text": "Wanderbrine Rootcutters can't be blocked by green creatures.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "514cea50-1266-58b3-bf28-74fc13ee7256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac48a4ff-433b-4fd0-b0d1-43b188ee81b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac48a4ff-433b-4fd0-b0d1-43b188ee81b6.jpg?1",
             "name": "Wasp Lancer",
             "text": "Flying",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "2cc05e9e-5389-556d-9547-4a7f275776e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c7931f-e979-4f43-81dd-c34166526f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c7931f-e979-4f43-81dd-c34166526f87.jpg?1",
             "name": "Ashenmoor Gouger",
             "text": "Ashenmoor Gouger can't block.",
             "colours": [
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "5b02eae9-1251-5ff0-8f52-1cfb654dddb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40793a-f5d1-4a1b-a7ab-0cb7513a00ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40793a-f5d1-4a1b-a7ab-0cb7513a00ca.jpg?1",
             "name": "Ashenmoor Liege",
             "text": "Other black creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\nWhenever Ashenmoor Liege becomes the target of a spell or ability an opponent controls, that player loses 4 life.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "5f2963fe-ee99-5ee1-9e94-055ac1b9e7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b80a10-a9a9-445e-8040-6cc0155271d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b80a10-a9a9-445e-8040-6cc0155271d8.jpg?1",
             "name": "Cultbrand Cinder",
             "text": "When Cultbrand Cinder comes into play, put a -1/-1 counter on target creature.",
             "colours": [
@@ -6238,7 +6238,7 @@
         },
         {
             "id": "e3730089-436c-5905-819a-a1a4e539e0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe235a9-9ecb-49a9-b91c-18e9725550cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe235a9-9ecb-49a9-b91c-18e9725550cd.jpg?1",
             "name": "Demigod of Revenge",
             "text": "Flying, haste\nWhen you play Demigod of Revenge, return all cards named Demigod of Revenge from your graveyard to play.",
             "colours": [
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "c30c2a5b-7b87-50ea-a088-4f5c86274245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde655f-9f49-42f8-a168-9cbca0592bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde655f-9f49-42f8-a168-9cbca0592bb8.jpg?1",
             "name": "Din of the Fireherd",
             "text": "Put a 5/5 black and red Elemental creature token into play. Target opponent sacrifices a creature for each black creature you control, then sacrifices a land for each red creature you control.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "17907887-6bb7-5ac5-8c8a-9947b40d6209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccd4374-5339-4529-99f3-f7dcc939e874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccd4374-5339-4529-99f3-f7dcc939e874.jpg?1",
             "name": "Emberstrike Duo",
             "text": "Whenever you play a black spell, Emberstrike Duo gets +1/+1 until end of turn.\nWhenever you play a red spell, Emberstrike Duo gains first strike until end of turn.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "b1c558ca-f2f1-5695-b5e3-90880ebfe1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa67c32-aeca-473d-994f-58ffc3a6a310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa67c32-aeca-473d-994f-58ffc3a6a310.jpg?1",
             "name": "Everlasting Torment",
             "text": "Players can't gain life.\nDamage can't be prevented.\nAll damage is dealt as though its source had wither. (A source with wither deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "9c6a4698-4979-5e96-ac8d-4b5153a79a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b28e501-fbb1-443b-a296-420716e49ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b28e501-fbb1-443b-a296-420716e49ab0.jpg?1",
             "name": "Fists of the Demigod",
             "text": "Enchant creature\nAs long as enchanted creature is black, it gets +1/+1 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)\nAs long as enchanted creature is red, it gets +1/+1 and has first strike.",
             "colours": [
@@ -6417,7 +6417,7 @@
         },
         {
             "id": "15af6279-34dc-55b2-b86d-437e1aad172e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1df367-8e85-4fd8-aa6f-f02a478fecb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1df367-8e85-4fd8-aa6f-f02a478fecb3.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -6454,7 +6454,7 @@
         },
         {
             "id": "6302ad0e-f44d-5cba-8f9e-6f1b96d04802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971a3b39-5b4b-41a4-9f67-1f24c48ba621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971a3b39-5b4b-41a4-9f67-1f24c48ba621.jpg?1",
             "name": "Grief Tyrant",
             "text": "Grief Tyrant comes into play with four -1/-1 counters on it.\nWhen Grief Tyrant is put into a graveyard from play, put a -1/-1 counter on target creature for each -1/-1 counter on Grief Tyrant.",
             "colours": [
@@ -6490,7 +6490,7 @@
         },
         {
             "id": "43c02d92-50cb-56c0-ab6b-529666c61b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b0bb-37d6-48a3-b140-c826de74c3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b0bb-37d6-48a3-b140-c826de74c3a0.jpg?1",
             "name": "Kulrath Knight",
             "text": "Flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nCreatures your opponents control with counters on them can't attack or block.",
             "colours": [
@@ -6527,7 +6527,7 @@
         },
         {
             "id": "079b5dae-54b8-54d1-8460-fc465ceb81f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4eb6-06bb-4bc9-83da-0141f7ee4730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4eb6-06bb-4bc9-83da-0141f7ee4730.jpg?1",
             "name": "Manaforge Cinder",
             "text": "{1}: Add {B} or {R} to your mana pool. Play this ability no more than three times each turn.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "bc2782e4-5f24-5e4f-b978-6e45bf4f20c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7171f0-7d42-47c9-ab46-93c2bb42c914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7171f0-7d42-47c9-ab46-93c2bb42c914.jpg?1",
             "name": "Murderous Redcap",
             "text": "When Murderous Redcap comes into play, it deals damage equal to its power to target creature or player.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "a1c909bb-99d3-59da-b0b9-9c58983b69d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb86eeec-d50f-4823-86bd-35437926a6e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb86eeec-d50f-4823-86bd-35437926a6e4.jpg?1",
             "name": "Poison the Well",
             "text": "Destroy target land. Poison the Well deals 2 damage to that land's controller.",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "402e7827-5794-5d85-8b80-bd177505533c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34e3f7c-468a-456c-8ed0-0cb88f6d86fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34e3f7c-468a-456c-8ed0-0cb88f6d86fc.jpg?1",
             "name": "Scar",
             "text": "Put a -1/-1 counter on target creature.",
             "colours": [
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "7127ac03-fef4-5db3-98fb-79134ce51355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2260b4-c069-4f59-9bd9-35745c98c518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2260b4-c069-4f59-9bd9-35745c98c518.jpg?1",
             "name": "Sootstoke Kindler",
             "text": "Haste\n{T}: Target black or red creature gains haste until end of turn.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "ea247551-5a27-5b54-8616-c73e92734392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36c7932-cc1e-4b1f-ae39-2f04b84bcddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36c7932-cc1e-4b1f-ae39-2f04b84bcddb.jpg?1",
             "name": "Sootwalkers",
             "text": "Sootwalkers can't be blocked by white creatures.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "6bd4dcbd-ca5e-5b6a-8601-20faac284b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d1a332-f950-4f56-9b1e-37c0954e72f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d1a332-f950-4f56-9b1e-37c0954e72f6.jpg?1",
             "name": "Spiteflame Witch",
             "text": "{B}{R}: Each player loses 1 life.",
             "colours": [
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "29215741-aab3-5057-bb8f-ae45c8e4d1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19039ac4-1aaa-4aca-ba09-f7fc400b9ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19039ac4-1aaa-4aca-ba09-f7fc400b9ada.jpg?1",
             "name": "Spiteful Visions",
             "text": "At the beginning of each player's draw step, that player draws a card.\nWhenever a player draws a card, Spiteful Visions deals 1 damage to that player.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "9b15050b-9fab-5fd4-8c59-0357940d2a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1e3eff-d6b2-4758-ac50-91f79cd21b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1e3eff-d6b2-4758-ac50-91f79cd21b93.jpg?1",
             "name": "Torrent of Souls",
             "text": "Return up to one target creature card from your graveyard to play if {B} was spent to play Torrent of Souls. Creatures target player controls get +2/+0 and gain haste until end of turn if {R} was spent to play Torrent of Souls. (Do both if {B}{R} was spent.)",
             "colours": [
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "450500e2-0917-530b-b8b4-0ef9d46dadaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e2700-6425-45b8-b026-8c78098f08b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e2700-6425-45b8-b026-8c78098f08b2.jpg?1",
             "name": "Traitor's Roar",
             "text": "Tap target untapped creature. It deals damage equal to its power to its controller.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -6882,7 +6882,7 @@
         },
         {
             "id": "e5fbc917-c922-5f73-a9e5-ca266b341e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7428b-8fff-4839-8b59-b268af0699c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7428b-8fff-4839-8b59-b268af0699c2.jpg?1",
             "name": "Tyrannize",
             "text": "Target player discards his or her hand unless he or she pays 7 life.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "1fd14a88-0346-5a50-a6a8-04929f1fe551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318338f8-f52b-4b9a-8d38-08291bcc2e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318338f8-f52b-4b9a-8d38-08291bcc2e98.jpg?1",
             "name": "Boartusk Liege",
             "text": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
             "colours": [
@@ -6953,7 +6953,7 @@
         },
         {
             "id": "1db97a52-161e-5922-bd27-2310ab3f4cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25b70-fa21-4663-aabd-34b7e0b75c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25b70-fa21-4663-aabd-34b7e0b75c34.jpg?1",
             "name": "Boggart Ram-Gang",
             "text": "Haste\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "f75d5eea-b50a-5584-9bff-51b8d218d87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eaac2e-51ff-45cb-a554-fdb724ddbb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eaac2e-51ff-45cb-a554-fdb724ddbb91.jpg?1",
             "name": "Deus of Calamity",
             "text": "Trample\nWhenever Deus of Calamity deals 6 or more damage to an opponent, destroy target land that player controls.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "4c928541-bf3d-5027-8542-cf3a31ce94f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13454f69-1458-4c03-ab02-bd697a32eb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13454f69-1458-4c03-ab02-bd697a32eb17.jpg?1",
             "name": "Firespout",
             "text": "Firespout deals 3 damage to each creature without flying if {R} was spent to play Firespout and 3 damage to each creature with flying if {G} was spent to play it. (Do both if {R}{G} was spent.)",
             "colours": [
@@ -7061,7 +7061,7 @@
         },
         {
             "id": "4cfc697b-7ba9-57f9-ba04-7f6cb09ae691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff61d34-f38f-440b-a234-7bb7251eb5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff61d34-f38f-440b-a234-7bb7251eb5b8.jpg?1",
             "name": "Fossil Find",
             "text": "Return a card at random from your graveyard to your hand, then reorder your graveyard as you choose.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "5d8b526d-bbca-5d69-a30c-9a6d88ec1dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3dd33-7240-4b32-b5ee-a67f24b42e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3dd33-7240-4b32-b5ee-a67f24b42e4d.jpg?1",
             "name": "Giantbaiting",
             "text": "Put a 4/4 red and green Giant Warrior creature token with haste into play. Remove it from the game at end of turn.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "21c7d749-00e0-5621-9214-b592af287ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0662ab6-b475-4b8d-ae77-a9b654e611da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0662ab6-b475-4b8d-ae77-a9b654e611da.jpg?1",
             "name": "Guttural Response",
             "text": "Counter target blue instant spell.",
             "colours": [
@@ -7163,7 +7163,7 @@
         },
         {
             "id": "9eddab7e-4b7c-53e2-9adb-8fa5fdeca19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2171e1c-fd36-43a6-ade3-c3aba8915139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2171e1c-fd36-43a6-ade3-c3aba8915139.jpg?1",
             "name": "Impromptu Raid",
             "text": "{2}{RG}: Reveal the top card of your library. If it isn't a creature card, put it into your graveyard. Otherwise, put that card into play. That creature has haste. Sacrifice it at end of turn.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "cf6b6b6b-fc13-5101-b022-340c5c9640ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a27bbe4-5341-4b2b-9ae8-eb56585a9c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a27bbe4-5341-4b2b-9ae8-eb56585a9c3a.jpg?1",
             "name": "Loamdragger Giant",
             "text": "",
             "colours": [
@@ -7234,7 +7234,7 @@
         },
         {
             "id": "a7e8ecbf-f5bd-5129-8209-1f925664eefe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50283122-b8c4-4fb3-8eba-6252b72222f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50283122-b8c4-4fb3-8eba-6252b72222f4.jpg?1",
             "name": "Manamorphose",
             "text": "Add two mana in any combination of colors to your mana pool.\nDraw a card.",
             "colours": [
@@ -7268,7 +7268,7 @@
         },
         {
             "id": "cca855b3-5084-55bb-9968-1a42c35e33a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589f477e-fd69-4410-b9ba-1d45b25fec31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589f477e-fd69-4410-b9ba-1d45b25fec31.jpg?1",
             "name": "Morselhoarder",
             "text": "Morselhoarder comes into play with two -1/-1 counters on it.\nRemove a -1/-1 counter from Morselhoarder: Add one mana of any color to your mana pool.",
             "colours": [
@@ -7304,7 +7304,7 @@
         },
         {
             "id": "98d2f37b-9daf-5b6a-97cc-c3ee048d6f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe4af47-d913-4c19-a027-501e2c78758c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe4af47-d913-4c19-a027-501e2c78758c.jpg?1",
             "name": "Mudbrawler Raiders",
             "text": "Mudbrawler Raiders can't be blocked by blue creatures.",
             "colours": [
@@ -7341,7 +7341,7 @@
         },
         {
             "id": "1de02933-1507-550a-9055-96e50d714dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3424135d-70f3-4a67-8477-cbf7ced7e611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3424135d-70f3-4a67-8477-cbf7ced7e611.jpg?1",
             "name": "Rosheen Meanderer",
             "text": "{T}: Add {4} to your mana pool. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -7380,7 +7380,7 @@
         },
         {
             "id": "a745a03c-5645-5b8c-81f5-e2c76cf27b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a84c7-c27f-49a2-8ae8-cb8e34ce0766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a84c7-c27f-49a2-8ae8-cb8e34ce0766.jpg?1",
             "name": "Runes of the Deus",
             "text": "Enchant creature\nAs long as enchanted creature is red, it gets +1/+1 and has double strike. (It deals both first-strike and regular combat damage.)\nAs long as enchanted creature is green, it gets +1/+1 and has trample.",
             "colours": [
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "f4234411-6d9c-5825-984d-7725f7cfb5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738d2b7-2773-4146-8f95-8d95b8402266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738d2b7-2773-4146-8f95-8d95b8402266.jpg?1",
             "name": "Scuzzback Marauders",
             "text": "Trample\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "4efd28b7-c005-5000-95e4-27082b1f3b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ed66f-75bd-43d8-90c4-cb0a5827b2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ed66f-75bd-43d8-90c4-cb0a5827b2f0.jpg?1",
             "name": "Scuzzback Scrapper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -7490,7 +7490,7 @@
         },
         {
             "id": "54cac059-68b7-586e-a992-2a8e6ee3d81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac93faba-8b40-48f4-b4eb-7c8677ed07e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac93faba-8b40-48f4-b4eb-7c8677ed07e2.jpg?1",
             "name": "Tattermunge Duo",
             "text": "Whenever you play a red spell, Tattermunge Duo gets +1/+1 until end of turn.\nWhenever you play a green spell, Tattermunge Duo gains forestwalk until end of turn.",
             "colours": [
@@ -7528,7 +7528,7 @@
         },
         {
             "id": "0d8f70b7-8145-5a01-ae94-831e10c2171f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f80d05-0bc9-4f35-afc4-8e2ae81b94df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f80d05-0bc9-4f35-afc4-8e2ae81b94df.jpg?1",
             "name": "Tattermunge Maniac",
             "text": "Tattermunge Maniac attacks each turn if able.",
             "colours": [
@@ -7565,7 +7565,7 @@
         },
         {
             "id": "4321dd8c-8a66-5094-bd4c-f3fe16b22942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee564d-d663-4ed7-afbd-713e90ba5c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee564d-d663-4ed7-afbd-713e90ba5c50.jpg?1",
             "name": "Tattermunge Witch",
             "text": "{R}{G}: Each blocked creature gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "b3ba48c5-d5fc-54a4-a761-203467a55335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4fa59-8315-4a66-b5fb-f78daa92aca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4fa59-8315-4a66-b5fb-f78daa92aca7.jpg?1",
             "name": "Valleymaker",
             "text": "{T}, Sacrifice a Mountain: Valleymaker deals 3 damage to target creature.\n{T}, Sacrifice a Forest: Choose a player. That player adds {G}{G}{G} to his or her mana pool.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "4e120d12-b1ee-5ce9-8a0c-62b60f2ee5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae04d776-c9e3-4ff7-998d-d264754d61db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae04d776-c9e3-4ff7-998d-d264754d61db.jpg?1",
             "name": "Vexing Shusher",
             "text": "Vexing Shusher can't be countered.\n{RG}: Target spell can't be countered by spells or abilities.",
             "colours": [
@@ -7676,7 +7676,7 @@
         },
         {
             "id": "c6306a2a-5399-535a-bdfe-679f84013388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535189ec-572f-44ed-9741-09b9f575fc40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535189ec-572f-44ed-9741-09b9f575fc40.jpg?1",
             "name": "Wort, the Raidmother",
             "text": "When Wort, the Raidmother comes into play, put two 1/1 red and green Goblin Warrior creature tokens into play.\nEach red or green instant or sorcery spell you play has conspire. (As you play the spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose new targets for the copy.)",
             "colours": [
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "611a60f9-1fef-58bd-9872-8a9ae5cdc856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd273ef2-4aed-4c7e-8c97-fe8b1af9ce69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd273ef2-4aed-4c7e-8c97-fe8b1af9ce69.jpg?1",
             "name": "Barkshell Blessing",
             "text": "Target creature gets +2/+2 until end of turn.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "c5b723b0-e7a3-52b1-808c-fb56d3730d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038bec82-24a0-4764-a1a0-671f597ebc35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038bec82-24a0-4764-a1a0-671f597ebc35.jpg?1",
             "name": "Dawnglow Infusion",
             "text": "You gain X life if {G} was spent to play Dawnglow Infusion and X life if {W} was spent to play it. (Do both if {G}{W} was spent.)",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "f46b6045-16c7-52f6-b3bc-09e9dd970ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7f4d7-278b-45fc-98aa-b7c8b9162bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7f4d7-278b-45fc-98aa-b7c8b9162bcd.jpg?1",
             "name": "Elvish Hexhunter",
             "text": "{RW}, {T}, Sacrifice Elvish Hexhunter: Destroy target enchantment.",
             "colours": [
@@ -7820,7 +7820,7 @@
         },
         {
             "id": "f2b271b6-c293-5b3a-bfb5-2b38e8343421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd726ce-85f8-4570-96e8-e0cfbd05045a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd726ce-85f8-4570-96e8-e0cfbd05045a.jpg?1",
             "name": "Fracturing Gust",
             "text": "Destroy all artifacts and enchantments. You gain 2 life for each permanent destroyed this way.",
             "colours": [
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "732367fc-243e-50aa-bbfe-6d0fa2359738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c1070-cb58-4948-99c9-febef7fef0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c1070-cb58-4948-99c9-febef7fef0d5.jpg?1",
             "name": "Heartmender",
             "text": "At the beginning of your upkeep, remove a -1/-1 counter from each creature you control.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "c8d0adf1-df31-52bd-81d4-4c4d0213d0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d203208-8a21-4c68-afa2-4efd8726f026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d203208-8a21-4c68-afa2-4efd8726f026.jpg?1",
             "name": "Kitchen Finks",
             "text": "When Kitchen Finks comes into play, you gain 2 life.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "dc74ca8c-e4d8-5288-8871-09355e110895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97638795-0771-4862-9afc-dbbbfd39515c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97638795-0771-4862-9afc-dbbbfd39515c.jpg?1",
             "name": "Medicine Runner",
             "text": "When Medicine Runner comes into play, you may remove a counter from target permanent.",
             "colours": [
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "0f898385-0be0-522a-9e39-a03ba3aad2dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f55536d-8573-42c2-9e8a-5a2ce24d1878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f55536d-8573-42c2-9e8a-5a2ce24d1878.jpg?1",
             "name": "Mercy Killing",
             "text": "Target creature's controller sacrifices it, then puts X 1/1 green and white Elf Warrior creature tokens into play, where X is that creature's power.",
             "colours": [
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "403865ab-0ddc-5cf4-b6c8-417182e8dd39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5ab941-89cc-4fdd-a916-3a54651f6478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5ab941-89cc-4fdd-a916-3a54651f6478.jpg?1",
             "name": "Old Ghastbark",
             "text": "",
             "colours": [
@@ -8034,7 +8034,7 @@
         },
         {
             "id": "c71ef292-1922-5730-b083-a9ead79406a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6bb004-b8ef-45a0-b9bf-5a3d513689b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6bb004-b8ef-45a0-b9bf-5a3d513689b9.jpg?1",
             "name": "Oracle of Nectars",
             "text": "{X}, {T}: You gain X life.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "e0894416-4d93-5b3b-a605-c8584db52f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893842f-aa3f-45f6-8139-ca775d33792b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893842f-aa3f-45f6-8139-ca775d33792b.jpg?1",
             "name": "Oversoul of Dusk",
             "text": "Protection from blue, from black, and from red",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "c74a61a4-210c-519a-a481-2687894682bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b868da85-9d19-4407-a0c3-fc3b2b237cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b868da85-9d19-4407-a0c3-fc3b2b237cda.jpg?1",
             "name": "Raven's Run Dragoon",
             "text": "Raven's Run Dragoon can't be blocked by black creatures.",
             "colours": [
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "c458f3b3-c545-55ca-8dc1-6e5b2cfc13c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bde9be-0ad8-4f42-a9a9-838bc476c7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bde9be-0ad8-4f42-a9a9-838bc476c7a6.jpg?1",
             "name": "Reknit",
             "text": "Regenerate target permanent.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "f9430958-c1da-5189-ba18-cd011bf0fae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59327a58-cd41-479c-81c7-31c9d3b29508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59327a58-cd41-479c-81c7-31c9d3b29508.jpg?1",
             "name": "Rhys the Redeemed",
             "text": "{2}{RW}, {T}: Put a 1/1 green and white Elf Warrior creature token into play.\n{4}{RW}{RW}, {T}: For each creature token you control, put a token into play that's a copy of that creature.",
             "colours": [
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "2db6e502-4e9a-5cc7-bf40-7f3eae8675d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b70339-9918-4f7e-9cd0-d4ce36b65997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b70339-9918-4f7e-9cd0-d4ce36b65997.jpg?1",
             "name": "Safehold Duo",
             "text": "Whenever you play a green spell, Safehold Duo gets +1/+1 until end of turn.\nWhenever you play a white spell, Safehold Duo gains vigilance until end of turn.",
             "colours": [
@@ -8256,7 +8256,7 @@
         },
         {
             "id": "64b3993c-b507-5a58-ba57-fdd31c6d4d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dee5be-94fd-4b5d-9265-edd1b58c8026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dee5be-94fd-4b5d-9265-edd1b58c8026.jpg?1",
             "name": "Safehold Elite",
             "text": "Persist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "85f74958-e66c-5633-9a6d-d7035378a922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61edb39b-ff82-4568-971f-baf22e209c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61edb39b-ff82-4568-971f-baf22e209c88.jpg?1",
             "name": "Safewright Quest",
             "text": "Search your library for a Forest or Plains card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "e4dc4e5f-54c8-5cc0-a09e-d11884824d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae8525-ce10-40bd-8980-a05fb81a0fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae8525-ce10-40bd-8980-a05fb81a0fac.jpg?1",
             "name": "Seedcradle Witch",
             "text": "{2}{G}{W}: Target creature gets +3/+3 until end of turn. Untap that creature.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "a5a7c2f1-946d-579e-9682-4ab0fa2cc876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54040bc6-dd7c-4933-bfac-d0d6d2c78157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54040bc6-dd7c-4933-bfac-d0d6d2c78157.jpg?1",
             "name": "Shield of the Oversoul",
             "text": "Enchant creature\nAs long as enchanted creature is green, it gets +1/+1 and is indestructible. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)\nAs long as enchanted creature is white, it gets +1/+1 and has flying.",
             "colours": [
@@ -8400,7 +8400,7 @@
         },
         {
             "id": "86ec08d3-aaa9-5e1b-8a28-86d90e61dae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55976e4b-718f-44b2-b93d-de5f75dc3bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55976e4b-718f-44b2-b93d-de5f75dc3bbe.jpg?1",
             "name": "Wheel of Sun and Moon",
             "text": "Enchant player\nIf a card would be put into enchanted player's graveyard from anywhere, instead that card is revealed and put on the bottom of that player's library.",
             "colours": [
@@ -8436,7 +8436,7 @@
         },
         {
             "id": "af1acfb3-79c3-58ba-8780-59b769a36507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ffe320-c88a-4eb7-a091-e128e6c1f37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ffe320-c88a-4eb7-a091-e128e6c1f37c.jpg?1",
             "name": "Wilt-Leaf Cavaliers",
             "text": "Vigilance",
             "colours": [
@@ -8473,7 +8473,7 @@
         },
         {
             "id": "f962cc66-9255-5ecd-98e5-eac9293078f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a2881f-e771-47d7-a39e-692054ee727f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a2881f-e771-47d7-a39e-692054ee727f.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it into play instead of putting it into your graveyard.",
             "colours": [
@@ -8510,7 +8510,7 @@
         },
         {
             "id": "ab7dc39a-8384-5b82-b02f-fb1594634709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44793043-82b4-415b-a9ab-d564fdbcd314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44793043-82b4-415b-a9ab-d564fdbcd314.jpg?1",
             "name": "Blazethorn Scarecrow",
             "text": "Blazethorn Scarecrow has haste as long as you control a red creature.\nBlazethorn Scarecrow has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [],
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "07be0caf-8aeb-5cf6-bd33-cc0be6efcb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f828c7-aedc-462b-8455-46e8a90feb85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f828c7-aedc-462b-8455-46e8a90feb85.jpg?1",
             "name": "Blight Sickle",
             "text": "Equipped creature gets +1/+0 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)\nEquip {2}",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "4a54ba2c-447c-50f0-beac-caa1523888e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7546996-aa71-45f2-93df-3e1f61b252a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7546996-aa71-45f2-93df-3e1f61b252a9.jpg?1",
             "name": "Cauldron of Souls",
             "text": "{T}: Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it's put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -8599,7 +8599,7 @@
         },
         {
             "id": "0949698c-b3b0-53a4-9d22-988f0e7d0ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094b023e-d5a3-4a57-adf0-898f3dcc8de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094b023e-d5a3-4a57-adf0-898f3dcc8de2.jpg?1",
             "name": "Chainbreaker",
             "text": "Chainbreaker comes into play with two -1/-1 counters on it.\n{3}, {T}: Remove a -1/-1 counter from target creature.",
             "colours": [],
@@ -8630,7 +8630,7 @@
         },
         {
             "id": "d42bc75a-e11a-5a67-b39d-010d41d0a669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273a17d-114b-4d54-a2a5-1047df8caa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273a17d-114b-4d54-a2a5-1047df8caa9d.jpg?1",
             "name": "Elsewhere Flask",
             "text": "When Elsewhere Flask comes into play, draw a card.\nSacrifice Elsewhere Flask: Choose a basic land type. Each land you control becomes that type until end of turn.",
             "colours": [],
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "a1c95c0e-3b3f-5b7e-93a5-451418b0bcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6aee954-2a04-425d-8d05-09dad58af656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6aee954-2a04-425d-8d05-09dad58af656.jpg?1",
             "name": "Gnarled Effigy",
             "text": "{4}, {T}: Put a -1/-1 counter on target creature.",
             "colours": [],
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "53f5dc57-ac0b-52c6-be20-491b1b5ce757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac9d9c-6685-465b-8933-dd6164569f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac9d9c-6685-465b-8933-dd6164569f4d.jpg?1",
             "name": "Grim Poppet",
             "text": "Grim Poppet comes into play with three -1/-1 counters on it.\nRemove a -1/-1 counter from Grim Poppet: Put a -1/-1 counter on another target creature.",
             "colours": [],
@@ -8717,7 +8717,7 @@
         },
         {
             "id": "78ccb419-d2b9-5bcc-ade5-4f00c0682ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d726e1-a363-4d77-97d4-e8c94f93fd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d726e1-a363-4d77-97d4-e8c94f93fd51.jpg?1",
             "name": "Heap Doll",
             "text": "Sacrifice Heap Doll: Remove target card in a graveyard from the game.",
             "colours": [],
@@ -8748,7 +8748,7 @@
         },
         {
             "id": "c492c576-7eb4-5721-8b57-f622f60e0dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d473d9-f52e-4357-b25a-e8bdcc833f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d473d9-f52e-4357-b25a-e8bdcc833f09.jpg?1",
             "name": "Illuminated Folio",
             "text": "{1}, {T}, Reveal two cards from your hand that share a color: Draw a card.",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "c8b2ccd6-3951-5da7-80b4-0a60d721ae9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae1cc40-12c0-4300-b6fa-7af32167a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae1cc40-12c0-4300-b6fa-7af32167a158.jpg?1",
             "name": "Lockjaw Snapper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhen Lockjaw Snapper is put into a graveyard from play, put a -1/-1 counter on each creature with a -1/-1 counter on it.",
             "colours": [],
@@ -8807,7 +8807,7 @@
         },
         {
             "id": "4921306b-7e7c-5030-8d73-829e9aac87a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89503bf6-d720-4fd5-b2cf-fc1197bf0f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89503bf6-d720-4fd5-b2cf-fc1197bf0f16.jpg?1",
             "name": "Lurebound Scarecrow",
             "text": "As Lurebound Scarecrow comes into play, choose a color.\nWhen you control no permanents of the chosen color, sacrifice Lurebound Scarecrow.",
             "colours": [],
@@ -8838,7 +8838,7 @@
         },
         {
             "id": "e8a0b28b-01e3-5e11-b57c-27f761cde41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be407a81-b25a-4e5d-845e-be0cc0d18db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be407a81-b25a-4e5d-845e-be0cc0d18db8.jpg?1",
             "name": "Painter's Servant",
             "text": "As Painter's Servant comes into play, choose a color.\nAll cards that aren't in play, spells, and permanents are the chosen color in addition to their other colors.",
             "colours": [],
@@ -8869,7 +8869,7 @@
         },
         {
             "id": "a1f99065-aa57-5d50-95f9-a59752ca5f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4892c152-1f4a-4616-8e7f-0ca4911e621a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4892c152-1f4a-4616-8e7f-0ca4911e621a.jpg?1",
             "name": "Pili-Pala",
             "text": "Flying\n{2}, {Q}: Add one mana of any color to your mana pool. ({Q} is the untap symbol.)",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "f3e4fd4e-3b9b-5d54-b0f1-0d15a1e47797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b46425f-516c-42f5-8df1-79af17d02a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b46425f-516c-42f5-8df1-79af17d02a4a.jpg?1",
             "name": "Rattleblaze Scarecrow",
             "text": "Rattleblaze Scarecrow has persist as long as you control a black creature. (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)\nRattleblaze Scarecrow has haste as long as you control a red creature.",
             "colours": [],
@@ -8931,7 +8931,7 @@
         },
         {
             "id": "9b3ab708-22bb-5be9-a2da-99211d331693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502740bf-0bff-4358-8996-1a27e5f0343f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502740bf-0bff-4358-8996-1a27e5f0343f.jpg?1",
             "name": "Reaper King",
             "text": "({2\nW} can be paid with any two mana or with {W}. This card's converted mana cost is 10.)\nOther Scarecrow creatures you control get +1/+1.\nWhenever another Scarecrow comes into play under your control, destroy target permanent.",
             "colours": [
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "ef10c3b5-3be5-59f3-be01-35364c93a635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a4801c-fa69-47a0-bdfa-f5f110fd0976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a4801c-fa69-47a0-bdfa-f5f110fd0976.jpg?1",
             "name": "Revelsong Horn",
             "text": "{1}, {T}, Tap an untapped creature you control: Target creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -9004,7 +9004,7 @@
         },
         {
             "id": "48625863-b03c-5e8b-9420-1f0e5442e7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7f0a6d-4127-4ea4-be16-2ed6b263a3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7f0a6d-4127-4ea4-be16-2ed6b263a3f3.jpg?1",
             "name": "Scrapbasket",
             "text": "{1}: Scrapbasket becomes all colors until end of turn.",
             "colours": [],
@@ -9035,7 +9035,7 @@
         },
         {
             "id": "b59bb969-da9c-5a56-a777-a6b509833b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb3ab2-6d34-4cbf-ad46-070516a7cc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb3ab2-6d34-4cbf-ad46-070516a7cc54.jpg?1",
             "name": "Scuttlemutt",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}: Target creature becomes the color or colors of your choice until end of turn.",
             "colours": [],
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "48d6092f-428b-5534-a2e5-ef957f89f04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf852c-b8a9-44d4-b2cd-3f1e071a8be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf852c-b8a9-44d4-b2cd-3f1e071a8be9.jpg?1",
             "name": "Tatterkite",
             "text": "Flying\nTatterkite can't have counters placed on it.",
             "colours": [],
@@ -9097,7 +9097,7 @@
         },
         {
             "id": "515e2ddd-255f-5ba8-b4bb-7efb26ed8646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489ac0a-cbdb-43d5-be73-6cb65ae54a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489ac0a-cbdb-43d5-be73-6cb65ae54a20.jpg?1",
             "name": "Thornwatch Scarecrow",
             "text": "Thornwatch Scarecrow has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)\nThornwatch Scarecrow has vigilance as long as you control a white creature.",
             "colours": [],
@@ -9128,7 +9128,7 @@
         },
         {
             "id": "38708338-be42-5bee-a863-c947e62c38ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b3dd8-cedb-4577-8897-967952dd3c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b3dd8-cedb-4577-8897-967952dd3c13.jpg?1",
             "name": "Trip Noose",
             "text": "{2}, {T}: Tap target creature.",
             "colours": [],
@@ -9156,7 +9156,7 @@
         },
         {
             "id": "3038faf1-3dfc-5b22-9e12-a56adb39f88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e35711-aec9-4024-a2a6-9efff8c71df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e35711-aec9-4024-a2a6-9efff8c71df2.jpg?1",
             "name": "Umbral Mantle",
             "text": "Equipped creature has \"{3}, {Q}: This creature gets +2/+2 until end of turn.\" ({Q} is the untap symbol.)\nEquip {0}",
             "colours": [],
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "9bf3d037-64ae-5264-ac06-d6114e439c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7774fd-3460-46e3-9c9c-7aa70f2ff6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7774fd-3460-46e3-9c9c-7aa70f2ff6d8.jpg?1",
             "name": "Watchwing Scarecrow",
             "text": "Watchwing Scarecrow has vigilance as long as you control a white creature.\nWatchwing Scarecrow has flying as long as you control a blue creature.",
             "colours": [],
@@ -9217,7 +9217,7 @@
         },
         {
             "id": "addd4f16-13a8-5fbb-9bd5-10f86385ef5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488e7c73-62bc-4d51-bcb6-8126ec559b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488e7c73-62bc-4d51-bcb6-8126ec559b41.jpg?1",
             "name": "Wicker Warcrawler",
             "text": "Whenever Wicker Warcrawler attacks or blocks, put a -1/-1 counter on it at end of combat.",
             "colours": [],
@@ -9248,7 +9248,7 @@
         },
         {
             "id": "e824e5f0-f74a-5269-8d74-679c3961cd7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c5d86e-1ce1-4386-b70f-73b24351d6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c5d86e-1ce1-4386-b70f-73b24351d6ae.jpg?1",
             "name": "Wingrattle Scarecrow",
             "text": "Wingrattle Scarecrow has flying as long as you control a blue creature.\nWingrattle Scarecrow has persist as long as you control a black creature. (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "0b6c2c00-9330-5a59-9e47-e67d1ae02ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab9d6ad-f819-4a1e-b4ff-8dc00791f0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab9d6ad-f819-4a1e-b4ff-8dc00791f0fd.jpg?1",
             "name": "Fire-Lit Thicket",
             "text": "{T}: Add {1} to your mana pool.\n{RG}, {T}: Add {R}{R}, {R}{G}, or {G}{G} to your mana pool.",
             "colours": [],
@@ -9310,7 +9310,7 @@
         },
         {
             "id": "7215963c-5de6-5902-95cc-6041a7c8e7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c355bf63-f456-43ad-a6df-6c2a17511f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c355bf63-f456-43ad-a6df-6c2a17511f43.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {1} to your mana pool.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "38ba0339-fd21-5d9a-aede-b060b7513baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa47202-5824-4f6a-b306-465976d4d422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa47202-5824-4f6a-b306-465976d4d422.jpg?1",
             "name": "Leechridden Swamp",
             "text": "({T}: Add {B} to your mana pool.)\nLeechridden Swamp comes into play tapped.\n{B}, {T}: Each opponent loses 1 life. Play this ability only if you control two or more black permanents.",
             "colours": [],
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "0af4af93-a89b-5161-92cd-6065aaa74c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513adae2-6436-4284-9f23-87ef627e81b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513adae2-6436-4284-9f23-87ef627e81b7.jpg?1",
             "name": "Madblind Mountain",
             "text": "({T}: Add {R} to your mana pool.)\nMadblind Mountain comes into play tapped.\n{R}, {T}: Shuffle your library. Play this ability only if you control two or more red permanents.",
             "colours": [],
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "6a7ff952-47ac-5e3c-905d-6065a2482766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af06f923-0c89-42ae-a4a8-618be7f39cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af06f923-0c89-42ae-a4a8-618be7f39cce.jpg?1",
             "name": "Mistveil Plains",
             "text": "({T}: Add {W} to your mana pool.)\nMistveil Plains comes into play tapped.\n{W}, {T}: Put target card in your graveyard on the bottom of your library. Play this ability only if you control two or more white permanents.",
             "colours": [],
@@ -9437,7 +9437,7 @@
         },
         {
             "id": "16528283-6022-5766-8d0d-f5b31b8de8e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b36993-666c-40d0-b61a-1d162bd06dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b36993-666c-40d0-b61a-1d162bd06dcc.jpg?1",
             "name": "Moonring Island",
             "text": "({T}: Add {U} to your mana pool.)\nMoonring Island comes into play tapped.\n{U}, {T}: Look at the top card of target player's library. Play this ability only if you control two or more blue permanents.",
             "colours": [],
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "f4138035-5ee7-58a8-aff8-f177d9c8be28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfa866b-93e2-4365-91b0-f12d1f7c5395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfa866b-93e2-4365-91b0-f12d1f7c5395.jpg?1",
             "name": "Mystic Gate",
             "text": "{T}: Add {1} to your mana pool.\n{WU}, {T}: Add {W}{W}, {W}{U}, or {U}{U} to your mana pool.",
             "colours": [],
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "0940a360-14f1-5b9e-910c-580dcc86e628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d03dc37-03fb-47b2-aa25-60a85d0d94dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d03dc37-03fb-47b2-aa25-60a85d0d94dd.jpg?1",
             "name": "Reflecting Pool",
             "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",
             "colours": [],
@@ -9529,7 +9529,7 @@
         },
         {
             "id": "9e017907-efd8-50fb-81fd-27d3d2ae33e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d7eed-38ee-42de-904d-56c837186198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d7eed-38ee-42de-904d-56c837186198.jpg?1",
             "name": "Reflecting Pool",
             "text": "",
             "colours": [],
@@ -9558,7 +9558,7 @@
         },
         {
             "id": "1b88cac5-4e64-50c3-ad36-fb44e2c98c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e29d9f-6aa9-49ef-8484-54af216aa509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e29d9f-6aa9-49ef-8484-54af216aa509.jpg?1",
             "name": "Sapseep Forest",
             "text": "({T}: Add {G} to your mana pool.)\nSapseep Forest comes into play tapped.\n{G}, {T}: You gain 1 life. Play this ability only if you control two or more green permanents.",
             "colours": [],
@@ -9590,7 +9590,7 @@
         },
         {
             "id": "6ce6d845-440e-5e8c-a1de-02b127ad788c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d91a31c-b70a-45bd-a8dd-48d49b277f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d91a31c-b70a-45bd-a8dd-48d49b277f24.jpg?1",
             "name": "Sunken Ruins",
             "text": "{T}: Add {1} to your mana pool.\n{UB}, {T}: Add {U}{U}, {U}{B}, or {B}{B} to your mana pool.",
             "colours": [],
@@ -9621,7 +9621,7 @@
         },
         {
             "id": "9d1ff277-46f7-50e6-bbab-15b654cf0a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e088fe6-e47a-4e27-b07e-ec35db045359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e088fe6-e47a-4e27-b07e-ec35db045359.jpg?1",
             "name": "Wooded Bastion",
             "text": "{T}: Add {1} to your mana pool.\n{RW}, {T}: Add {G}{G}, {G}{W}, or {W}{W} to your mana pool.",
             "colours": [],
@@ -9652,7 +9652,7 @@
         },
         {
             "id": "3955ae53-6c4f-5853-945e-3a0786b0f5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf67e21-3306-4c4e-a021-9b997cc8c48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf67e21-3306-4c4e-a021-9b997cc8c48c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9690,7 +9690,7 @@
         },
         {
             "id": "eb220c98-931b-5cbd-96a7-3a4f69894952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a646c9-8347-4b62-829e-6af6b275346a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a646c9-8347-4b62-829e-6af6b275346a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9728,7 +9728,7 @@
         },
         {
             "id": "c4ffdd69-b2b5-59a6-8556-49c222f739e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b104eb8-7095-4aba-a155-d8e147639692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b104eb8-7095-4aba-a155-d8e147639692.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "2fc2bc4a-0281-5926-b6fb-d76bd8694723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ba7ff5-7f2a-4268-9bdd-96061ce5e86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ba7ff5-7f2a-4268-9bdd-96061ce5e86a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "efdc1040-db63-5d33-b878-4ff82b8d4d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d84005-faac-4e02-9fea-40757b43cf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d84005-faac-4e02-9fea-40757b43cf03.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9842,7 +9842,7 @@
         },
         {
             "id": "176de16a-3b5f-5559-b3d3-5612978f485d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae96b4b-7568-4463-b26c-a567e4a418d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae96b4b-7568-4463-b26c-a567e4a418d7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9880,7 +9880,7 @@
         },
         {
             "id": "9ca4daaa-7bab-5631-bef0-7ada4a26b05c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196a004a-ec08-4e1b-8eeb-2ad766fccd25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196a004a-ec08-4e1b-8eeb-2ad766fccd25.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9918,7 +9918,7 @@
         },
         {
             "id": "cec78f77-64e1-5001-848e-cbd3bddccdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28da317c-8512-4342-9be5-d14b87a509c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28da317c-8512-4342-9be5-d14b87a509c7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9956,7 +9956,7 @@
         },
         {
             "id": "90d1e326-f8bb-5f02-b8c6-21f94a1a54c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4324380c-68b8-4955-ad92-76f921e6ffc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4324380c-68b8-4955-ad92-76f921e6ffc1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "059f9534-b743-5667-a8e4-b8b30abe3c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a310639-99ca-4a7e-9f65-731779f3ea46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a310639-99ca-4a7e-9f65-731779f3ea46.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10032,7 +10032,7 @@
         },
         {
             "id": "a4a2e2d5-7ab6-5acc-8f29-19315be112fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0be63-ec99-4291-b504-e17061c15a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0be63-ec99-4291-b504-e17061c15a67.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10070,7 +10070,7 @@
         },
         {
             "id": "7a5264c2-5997-5e38-8eb5-2ff081ef51f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d2dedf-d0d8-42c5-a498-31e172a1b503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d2dedf-d0d8-42c5-a498-31e172a1b503.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "f4c2862d-ad19-5c40-80f4-51deed075436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497551e-eb90-48db-90e9-0f917da41d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497551e-eb90-48db-90e9-0f917da41d9e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10146,7 +10146,7 @@
         },
         {
             "id": "955c98b4-4acd-5238-89ab-df9e4e1abb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc8e7e-3d78-456a-b4ef-c9f2eaa6ec7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc8e7e-3d78-456a-b4ef-c9f2eaa6ec7c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10184,7 +10184,7 @@
         },
         {
             "id": "1d82e430-6358-5564-9822-0dd5b23c4efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d671616-f58c-4ee9-9ed7-78ebc385948a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d671616-f58c-4ee9-9ed7-78ebc385948a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "0318e5af-2a5b-53ab-b4a8-4902ff24e01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a63f1a-8224-4c66-9a3a-6c04c656c73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a63f1a-8224-4c66-9a3a-6c04c656c73b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10260,7 +10260,7 @@
         },
         {
             "id": "9e4508f1-f524-571b-befc-a8b55fbe4d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b763764f-efb0-48c6-b353-1831164c2db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b763764f-efb0-48c6-b353-1831164c2db5.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10298,7 +10298,7 @@
         },
         {
             "id": "412c0d25-ea50-5937-ba5d-3f456cff6c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa690e4-dbc8-4490-8958-6eb323a05daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa690e4-dbc8-4490-8958-6eb323a05daa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10336,7 +10336,7 @@
         },
         {
             "id": "953c3d7c-5066-52d4-939b-13a96f4029e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6424d21-d852-4af5-96d7-cda2ba0e5912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6424d21-d852-4af5-96d7-cda2ba0e5912.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10374,7 +10374,7 @@
         },
         {
             "id": "6bd614f1-f1ef-55eb-b88c-6689032da7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62131862-1256-4082-a83d-a0048714acb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62131862-1256-4082-a83d-a0048714acb1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "cd4f88a7-c6c0-597f-b4fa-0f6600fb51a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061cb705-695a-4f65-adbf-869ebb4eb946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061cb705-695a-4f65-adbf-869ebb4eb946.jpg?1",
             "name": "Kithkin Soldier",
             "text": "",
             "colours": [
@@ -10447,7 +10447,7 @@
         },
         {
             "id": "c94a7b9a-270f-5e20-9830-d60600df3c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba50f25-ad8c-4244-8dc1-f8656f4c8c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba50f25-ad8c-4244-8dc1-f8656f4c8c0b.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "1e926fdb-3ca5-5a7a-b04f-483060004a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a85fe9d-ef18-46c4-88b0-cf2e222e30e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a85fe9d-ef18-46c4-88b0-cf2e222e30e4.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "fd68571c-fcb2-5ccc-b7f7-7a035e1023eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c14f3d-1578-426b-b64b-07c7e88ab572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c14f3d-1578-426b-b64b-07c7e88ab572.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "51c43f03-a499-5fda-8281-38eb06faf3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7663358-c85c-4ba4-ac9b-6be6105363a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7663358-c85c-4ba4-ac9b-6be6105363a9.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -10584,7 +10584,7 @@
         },
         {
             "id": "e00466d1-307b-5117-bb06-69ed13d6f2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df0de51-8d05-475a-832e-de8a0f60849e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df0de51-8d05-475a-832e-de8a0f60849e.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -10618,7 +10618,7 @@
         },
         {
             "id": "501a119f-9fba-5ba6-aad7-880575207506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c138bf9-8be6-4f1a-a82c-a84938ab84f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c138bf9-8be6-4f1a-a82c-a84938ab84f5.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "503bc871-2fc6-57e4-82c9-f1d546c24756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b4786-1592-42c7-9d3e-d0d66abaed99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b4786-1592-42c7-9d3e-d0d66abaed99.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "0d54973b-0600-5ea7-bb7c-28ee330c448b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5afb0a-a158-4995-881e-eae0f20805a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5afb0a-a158-4995-881e-eae0f20805a6.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "4ec1e6d8-04cd-57cc-b8fd-ece3c48152eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f84b406-112d-4b01-8500-60391692a17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f84b406-112d-4b01-8500-60391692a17e.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -10762,7 +10762,7 @@
         },
         {
             "id": "afe81bef-8851-5a9e-882c-66c59e09994e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36334f1-afe3-497c-82d9-aaf149934b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36334f1-afe3-497c-82d9-aaf149934b54.jpg?1",
             "name": "Goblin Warrior",
             "text": "",
             "colours": [
@@ -10799,7 +10799,7 @@
         },
         {
             "id": "1ee3ec14-2249-5992-b6bb-a0cc3c598164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49180301-f72f-48ca-8be1-df295e89cdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49180301-f72f-48ca-8be1-df295e89cdd7.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/SLD.json
+++ b/Assets/Resources/Sets/SLD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a78f0947-fc4e-5831-89af-d7ff3e5a1e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3066cc8b-7a5a-4822-a202-dd560a4fda85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3066cc8b-7a5a-4822-a202-dd560a4fda85.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -42,7 +42,7 @@
         },
         {
             "id": "778193e7-59cb-57d9-8837-9a7543c022b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7c3929-cd56-448d-9752-6d5f9d1fd778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7c3929-cd56-448d-9752-6d5f9d1fd778.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -80,7 +80,7 @@
         },
         {
             "id": "c9f3cc8a-52a5-5743-819a-a83a20a20e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dce8b37-50da-4f21-9664-e4d6ce6c4e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dce8b37-50da-4f21-9664-e4d6ce6c4e3c.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -118,7 +118,7 @@
         },
         {
             "id": "3775114c-c464-5a2d-b0c8-454e7f4e2389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a9d6d-497b-44a1-963f-501d61ea7f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a9d6d-497b-44a1-963f-501d61ea7f66.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -156,7 +156,7 @@
         },
         {
             "id": "ba437894-c60c-558a-a8ed-436118d794e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92195708-cc07-44bf-85d8-6c5d6f0d789e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92195708-cc07-44bf-85d8-6c5d6f0d789e.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -194,7 +194,7 @@
         },
         {
             "id": "e86b79ae-e7b5-5218-9ec4-fc34756ebdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87089d28-46a7-4247-a784-c34b9f822172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87089d28-46a7-4247-a784-c34b9f822172.jpg?1",
             "name": "Bloodghast",
             "text": "",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "7f5fe3c6-13f3-587d-9366-79a2cfbe9dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddee704-5315-4b35-9f77-0c12def26ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddee704-5315-4b35-9f77-0c12def26ce1.jpg?1",
             "name": "Golgari Thug",
             "text": "",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "0b01460f-a11a-5403-9c6a-34aad284e22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ed197-e434-4f01-a71f-053ae3820d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ed197-e434-4f01-a71f-053ae3820d6c.jpg?1",
             "name": "Life from the Loam",
             "text": "",
             "colours": [
@@ -293,7 +293,7 @@
         },
         {
             "id": "8c73c87b-959a-5c6d-8272-5aa87d039439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3463a8-79f6-4fec-afd6-ad8c412d648c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3463a8-79f6-4fec-afd6-ad8c412d648c.jpg?1",
             "name": "Reaper King",
             "text": "",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "c3eb2450-4ad2-51ec-94fe-51d6be98ad17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fad8ca2-032d-40ee-b3d6-29ab2b59ba86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fad8ca2-032d-40ee-b3d6-29ab2b59ba86.jpg?1",
             "name": "Sliver Overlord",
             "text": "",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "2c334c2c-6664-5bb8-8052-d7e88ed4b835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea949741-af94-47ae-a577-2953c69ab71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea949741-af94-47ae-a577-2953c69ab71d.jpg?1",
             "name": "The Ur-Dragon",
             "text": "",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "3993a2c3-a626-526b-b2b7-7d58c2651b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f88df1-4e1a-4557-bb7a-1ac86641043e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f88df1-4e1a-4557-bb7a-1ac86641043e.jpg?1",
             "name": "Bitterblossom",
             "text": "",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "7484825f-cf0f-5721-91af-9f388b812410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450c7d6-4c09-4264-a711-b956f62f4d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450c7d6-4c09-4264-a711-b956f62f4d0e.jpg?1",
             "name": "Goblin Bushwhacker",
             "text": "",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "c54d07d1-0947-5a6b-98a1-a41f1d972c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad66330e-166c-4613-b788-e5c2f052cd9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad66330e-166c-4613-b788-e5c2f052cd9d.jpg?1",
             "name": "Goblin Sharpshooter",
             "text": "",
             "colours": [
@@ -526,7 +526,7 @@
         },
         {
             "id": "03518f51-fcd0-5891-b365-99f74c0672ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455dff34-0ab2-4798-84a9-66dcf37f1789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455dff34-0ab2-4798-84a9-66dcf37f1789.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "64857a21-7825-57ac-8c15-4c03c8d5b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd57c7f3-4ca5-45e7-9be2-c5c1c3d6ad31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd57c7f3-4ca5-45e7-9be2-c5c1c3d6ad31.jpg?1",
             "name": "Goblin Lackey",
             "text": "",
             "colours": [
@@ -597,7 +597,7 @@
         },
         {
             "id": "cf7e1b75-1301-56ea-9529-a425830f8b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b920dbc-0a61-43b2-9571-dc9d726842eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b920dbc-0a61-43b2-9571-dc9d726842eb.jpg?1",
             "name": "Goblin Piledriver",
             "text": "",
             "colours": [
@@ -631,7 +631,7 @@
         },
         {
             "id": "f2fb2522-184c-5c62-afb3-cd70b1002125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9793cbf-9338-450f-8ef0-8033e7aae49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9793cbf-9338-450f-8ef0-8033e7aae49a.jpg?1",
             "name": "Leonin Warleader",
             "text": "",
             "colours": [
@@ -665,7 +665,7 @@
         },
         {
             "id": "a4302153-bc7b-5860-972c-20656a7f8708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05783c-fd85-4fb2-bddc-2eef72513cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05783c-fd85-4fb2-bddc-2eef72513cf0.jpg?1",
             "name": "Regal Caracal",
             "text": "",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "6e94e581-8563-561b-92f8-c68739fbd039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8ce2aa-cb2b-4e5f-98b9-1f3cac5cab1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8ce2aa-cb2b-4e5f-98b9-1f3cac5cab1c.jpg?1",
             "name": "Qasali Slingers",
             "text": "",
             "colours": [
@@ -732,7 +732,7 @@
         },
         {
             "id": "b97ec876-4b14-5ee4-bdd6-39a7524509b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda28572-654e-4d43-b88c-cf8c8b0f5eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda28572-654e-4d43-b88c-cf8c8b0f5eb5.jpg?1",
             "name": "Arahbo, Roar of the World",
             "text": "",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "89445970-2a9b-5156-a92c-9ab4eea26c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e856be87-6f2b-4846-87f1-53e2c1c71a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e856be87-6f2b-4846-87f1-53e2c1c71a16.jpg?1",
             "name": "Mirri, Weatherlight Duelist",
             "text": "",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "9e9ab6d0-fcd8-523c-a8e9-8773b0443dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca3457c-4924-4824-8f32-7f4a12d2e2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca3457c-4924-4824-8f32-7f4a12d2e2ea.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "fb3bdc21-d1c3-5fa2-8ea6-3ff48b11a5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac65dd-31d2-4f59-bf89-537d870bd6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac65dd-31d2-4f59-bf89-537d870bd6a9.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "ef228daa-505c-5fbf-83c4-110eba5b5946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5444140b-9acf-4d28-bf41-2218f1c12831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5444140b-9acf-4d28-bf41-2218f1c12831.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "f93fa4d1-068d-5126-bbba-3863884b39c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4077e3d5-e0b6-4d2f-8c94-e1f78433c05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4077e3d5-e0b6-4d2f-8c94-e1f78433c05c.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "938acf65-6f5e-514a-8913-f89d79ab9d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a11a1a-ebdf-495d-9511-33ee22c07521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a11a1a-ebdf-495d-9511-33ee22c07521.jpg?1",
             "name": "Ink-Eyes, Servant of Oni",
             "text": "",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "88339ccb-b4f2-53df-97a9-0d8b2e8bca9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0ce55-bf61-491e-9136-6f62b5aa5795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0ce55-bf61-491e-9136-6f62b5aa5795.jpg?1",
             "name": "Marrow-Gnawer",
             "text": "",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "8b3eaf0e-8a2a-5e1d-8ae9-0e34b05183aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3864bc8-f86e-4c41-b454-e19d1939147b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3864bc8-f86e-4c41-b454-e19d1939147b.jpg?1",
             "name": "Pack Rat",
             "text": "",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "c8dc8db7-6a76-5f7d-b9ec-d95f6246cdb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4227afa-780b-4755-9b61-46255717c6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4227afa-780b-4755-9b61-46255717c6be.jpg?1",
             "name": "Rat Colony",
             "text": "",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "7cba949d-88c9-516f-bfc9-b68a6f43004f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05031dc-f99c-49d3-9a20-3453587d8dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05031dc-f99c-49d3-9a20-3453587d8dea.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "696679ff-91c6-53a4-bd90-f51eba23237f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbde9d9-1723-4f26-8700-63c459ac80cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbde9d9-1723-4f26-8700-63c459ac80cb.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "2322a15f-3028-52f2-a962-33d3b7e11284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717de388-0c07-4346-9c7e-7b06b14f1cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717de388-0c07-4346-9c7e-7b06b14f1cc1.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "5af9d664-4932-5e96-8d0a-9863ed9b4d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67a5aac-dbda-4e5d-ae4a-eb78dec6765b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67a5aac-dbda-4e5d-ae4a-eb78dec6765b.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "2dfdcffa-746b-5273-8991-017bf506c418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f8b11a-6b21-4532-96c9-bdb2cad603e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f8b11a-6b21-4532-96c9-bdb2cad603e8.jpg?1",
             "name": "Spell Pierce",
             "text": "",
             "colours": [
@@ -1279,7 +1279,7 @@
         },
         {
             "id": "e3b61ca3-b574-5b51-97ad-72dc4a11e67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5b65ed-250c-42a6-84c0-ac06662ca5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5b65ed-250c-42a6-84c0-ac06662ca5ed.jpg?1",
             "name": "Blood Artist",
             "text": "",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "13d2f88e-05a1-5f41-9786-89972b4b3505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bb37b7-3474-42af-abf0-0b713bf34174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bb37b7-3474-42af-abf0-0b713bf34174.jpg?1",
             "name": "Eternal Witness",
             "text": "",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "c4417193-b9c4-5df7-b3ea-bdd749ff6832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e503b59c-df3e-4f52-9a59-195f02a6cb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e503b59c-df3e-4f52-9a59-195f02a6cb18.jpg?1",
             "name": "Pithing Needle",
             "text": "",
             "colours": [],
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "9a7d9a2b-14d3-5c0f-bb62-a1c28493610f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c41b06-407e-497a-adb9-a19687fad1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c41b06-407e-497a-adb9-a19687fad1e8.jpg?1",
             "name": "Inkmoth Nexus",
             "text": "",
             "colours": [],
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "b1877893-452e-5444-a216-b1219b03647f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282908d5-29e8-4a55-915e-64883ec3b714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282908d5-29e8-4a55-915e-64883ec3b714.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "c31101e6-7238-55e9-a305-4d95108cd812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4d5c0-7ad2-446d-b49e-5ee446bb23cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4d5c0-7ad2-446d-b49e-5ee446bb23cd.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "b919003a-1e07-5c7b-870f-c2e6c9f0ff32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c5c795-5463-425b-9720-627004925e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c5c795-5463-425b-9720-627004925e20.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -1603,7 +1603,7 @@
         },
         {
             "id": "b4f35ef2-aa7a-507b-9a01-be001e2c92c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e820a082-f876-4cfc-95a2-34be5b994d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e820a082-f876-4cfc-95a2-34be5b994d80.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "d8e4f596-2c78-5c1d-bf1a-ca9860625719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc8f49-6b8f-4466-908c-c6ff3e5c8c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc8f49-6b8f-4466-908c-c6ff3e5c8c32.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "3f80c076-6102-5273-9710-b5a83c61dfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d22ed-7b85-4669-b49c-b1872a448611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d22ed-7b85-4669-b49c-b1872a448611.jpg?1",
             "name": "Captain Sisay",
             "text": "",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "897a3d5e-ec9c-52b5-967c-914d90aeb10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91190972-7c9d-4a16-b7b8-0fcf3dbcebd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91190972-7c9d-4a16-b7b8-0fcf3dbcebd5.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "",
             "colours": [
@@ -1818,7 +1818,7 @@
         },
         {
             "id": "7a317099-ea5e-5392-a595-1aa81334270b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c187ac-6b33-4cf6-b407-1dfa265780e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c187ac-6b33-4cf6-b407-1dfa265780e6.jpg?1",
             "name": "Narset, Enlightened Master",
             "text": "",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "abc61539-34ee-5b31-a88d-c9b8841d776a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83ad5fa-b9b8-4c3f-bc42-3ff6282eb941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83ad5fa-b9b8-4c3f-bc42-3ff6282eb941.jpg?1",
             "name": "Oona, Queen of the Fae",
             "text": "",
             "colours": [
@@ -1896,7 +1896,7 @@
         },
         {
             "id": "cf265ce3-a76a-562d-a9f0-7720f22b0590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd2c01-fb77-4079-b5cf-bcde816386c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd2c01-fb77-4079-b5cf-bcde816386c9.jpg?1",
             "name": "Saskia the Unyielding",
             "text": "",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "a7d45e03-a1aa-527f-a5ab-5fd806111ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a898fbf-5c73-4a50-8bf5-126051747659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a898fbf-5c73-4a50-8bf5-126051747659.jpg?1",
             "name": "Arcbound Ravager",
             "text": "",
             "colours": [],
@@ -1968,7 +1968,7 @@
         },
         {
             "id": "08585c69-7aa0-540e-8474-c975207abd3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012fb2-9dbc-408a-b84b-1302b442f699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012fb2-9dbc-408a-b84b-1302b442f699.jpg?1",
             "name": "Darksteel Colossus",
             "text": "",
             "colours": [],
@@ -1998,7 +1998,7 @@
         },
         {
             "id": "f9e17610-a7f2-5943-bd29-626453de5ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60107410-7076-4fcc-b1f7-123dd3b442b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60107410-7076-4fcc-b1f7-123dd3b442b0.jpg?1",
             "name": "Walking Ballista",
             "text": "",
             "colours": [],
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "020c47a2-f45c-58ee-a8c0-722f8b9fb067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4391e8-8d3e-42d2-ab01-08fe68771ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4391e8-8d3e-42d2-ab01-08fe68771ed1.jpg?1",
             "name": "Squire",
             "text": "",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "a2bcb6ae-f8df-5fa5-9126-2434a5f475a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7aa8e1-ada6-491a-b96f-43e89dae7834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7aa8e1-ada6-491a-b96f-43e89dae7834.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "348445c7-44e0-5231-a64f-37d6cd335bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9e8d45-a7e7-4131-9985-eaf693c1b55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9e8d45-a7e7-4131-9985-eaf693c1b55b.jpg?1",
             "name": "Goblin Snowman",
             "text": "",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "c26de73e-8b35-53c9-aa17-c8f295185ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f2e82-4970-4298-a3a7-c42cb1780eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f2e82-4970-4298-a3a7-c42cb1780eb5.jpg?1",
             "name": "Mudhole",
             "text": "",
             "colours": [
@@ -2161,7 +2161,7 @@
         },
         {
             "id": "f916309d-fabb-549a-a216-d5b788439fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4bf87b-1e31-4c09-b685-86592eb32be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4bf87b-1e31-4c09-b685-86592eb32be9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "aa42098a-51ee-5368-96e7-e61f82bce5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f05fa-30e4-4b2c-9641-8a5847b59d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f05fa-30e4-4b2c-9641-8a5847b59d65.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "76a81fd3-8410-581b-8c08-b796210d8126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed633b-6452-4a0c-b308-ac28ad438933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed633b-6452-4a0c-b308-ac28ad438933.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "d599d800-2e6c-5833-a885-71253b320d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05712bcb-eb67-4e84-a640-7e507675756a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05712bcb-eb67-4e84-a640-7e507675756a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -2429,7 +2429,7 @@
         },
         {
             "id": "4cd1bf17-bd7d-58e3-ac4e-f03b8cd06e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed189e2b-a4e5-493b-9085-a5aae892e5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed189e2b-a4e5-493b-9085-a5aae892e5a8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "b5fb8ec2-d763-53f2-9f39-8b54120bca1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6365e12-c470-40a2-95b0-827ec4404c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6365e12-c470-40a2-95b0-827ec4404c38.jpg?1",
             "name": "Heliod, God of the Sun",
             "text": "",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "15fffe16-8007-5eba-ad0d-dccfab8ff28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe0295f-c731-4e13-9edd-f0e9a9d81769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe0295f-c731-4e13-9edd-f0e9a9d81769.jpg?1",
             "name": "Karametra, God of Harvests",
             "text": "",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "c5f9b56c-eada-5c69-981b-6d32ac432f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc3e4ba-726d-4ec5-be73-c68bc186fb2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc3e4ba-726d-4ec5-be73-c68bc186fb2f.jpg?1",
             "name": "Iroas, God of Victory",
             "text": "",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "6de61478-4cad-5f8b-98f1-9ddd23f5b823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bcfb09-ca60-405b-9603-eb3e4b2a8bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bcfb09-ca60-405b-9603-eb3e4b2a8bd0.jpg?1",
             "name": "Thassa, God of the Sea",
             "text": "",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "1639b187-476f-5d5a-bf22-7e7d9a324a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549057e-fb55-4752-903c-41355f9a0589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549057e-fb55-4752-903c-41355f9a0589.jpg?1",
             "name": "Ephara, God of the Polis",
             "text": "",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "dd196bd8-2a99-5335-9935-d0a4976540aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf153db-742a-42c0-bc8c-5093c1d6e734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf153db-742a-42c0-bc8c-5093c1d6e734.jpg?1",
             "name": "Kruphix, God of Horizons",
             "text": "",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "641dfec5-2976-5e62-9cc0-b4c8bda9f359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8bdb4c-2d68-4cb4-904f-1649427751dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8bdb4c-2d68-4cb4-904f-1649427751dc.jpg?1",
             "name": "Erebos, God of the Dead",
             "text": "",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "8ae84b1a-0e5d-5b96-802a-529f558102d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f9e502-23a3-4f1c-af10-e6c48a5262b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f9e502-23a3-4f1c-af10-e6c48a5262b2.jpg?1",
             "name": "Phenax, God of Deception",
             "text": "",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "b17abbf5-8b0d-5723-9f9e-fb69d518ee12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380a687-c96b-4e1a-bfd9-3849d085b803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380a687-c96b-4e1a-bfd9-3849d085b803.jpg?1",
             "name": "Athreos, God of Passage",
             "text": "",
             "colours": [
@@ -2829,7 +2829,7 @@
         },
         {
             "id": "67c99f0e-7735-5b1b-b99d-eef24d845dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2698e2d-16d8-4b76-923f-e18775104de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2698e2d-16d8-4b76-923f-e18775104de0.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "43a82ca6-338d-5ef9-ae82-1ed44ebb6c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8df131-c29d-4181-8dc4-815a581b0209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8df131-c29d-4181-8dc4-815a581b0209.jpg?1",
             "name": "Mogis, God of Slaughter",
             "text": "",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "1890023b-f3ed-58bf-add9-a95760d1bbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c13445-60e3-43a0-a56a-de91c6442367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c13445-60e3-43a0-a56a-de91c6442367.jpg?1",
             "name": "Keranos, God of Storms",
             "text": "",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "4b519479-1493-5758-9211-df4c7d3940b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ce5e5d-2be2-4cf1-8011-a3c79bf8a573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ce5e5d-2be2-4cf1-8011-a3c79bf8a573.jpg?1",
             "name": "Nylea, God of the Hunt",
             "text": "",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "184745b0-6ba3-5fc0-9304-8f6acd7c386f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e144aa4d-3ea7-44fb-b1cb-ad51cf84bba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e144aa4d-3ea7-44fb-b1cb-ad51cf84bba2.jpg?1",
             "name": "Xenagos, God of Revels",
             "text": "",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "276ea161-aa92-55e8-a716-f7299174eb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109bfa3d-02e0-4395-bd6e-edaad77f25f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109bfa3d-02e0-4395-bd6e-edaad77f25f7.jpg?1",
             "name": "Pharika, God of Affliction",
             "text": "",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "26bb9b31-fc82-54b3-b13e-56dd1dba312a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45184cd7-b037-4a85-a063-e622ca928d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45184cd7-b037-4a85-a063-e622ca928d17.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "fa340683-e523-511d-8c98-ea498d69da0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb94c1b-8002-4d79-add0-c4dfef9019ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb94c1b-8002-4d79-add0-c4dfef9019ee.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "20446d8e-c01e-5d05-93c1-488efb00087c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab06973-6440-4b12-8947-8c412500fa41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab06973-6440-4b12-8947-8c412500fa41.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "6787846a-9e3d-52cb-a190-24f29331c62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb3895-b64c-46ab-b704-3c46963920ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb3895-b64c-46ab-b704-3c46963920ba.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "1571957b-0497-5eb4-98ea-fa1a8773299b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370e6f6f-67a7-4eea-9a33-efbb64783e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370e6f6f-67a7-4eea-9a33-efbb64783e4a.jpg?1",
             "name": "Ajani Steadfast",
             "text": "",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "e419bf41-b88c-5dba-9c8a-1d4cb1d073f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e724c648-0585-451f-afcd-7efff2521151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e724c648-0585-451f-afcd-7efff2521151.jpg?1",
             "name": "Domri Rade",
             "text": "",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "4d9c6f9c-67bb-5d10-a39c-b77234623cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8320f71-e958-4e40-9304-bd115f29d67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8320f71-e958-4e40-9304-bd115f29d67c.jpg?1",
             "name": "Tamiyo, Field Researcher",
             "text": "",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "33721f15-5b41-5b3a-b430-89adada99a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d004e922-1f2b-4325-93f1-04a336192c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d004e922-1f2b-4325-93f1-04a336192c06.jpg?1",
             "name": "Vraska, Golgari Queen",
             "text": "",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "af9a0ba0-d941-56c7-b479-da3c92994cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fc6412-df1c-4bfa-842b-8c3a6f14e19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fc6412-df1c-4bfa-842b-8c3a6f14e19d.jpg?1",
             "name": "Swan Song",
             "text": "",
             "colours": [
@@ -3400,7 +3400,7 @@
         },
         {
             "id": "1ef8afc8-77f4-58e7-9ba0-d78a7cb73a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfeeb64-0f86-45e9-97e3-dcec72683164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfeeb64-0f86-45e9-97e3-dcec72683164.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "07992efb-4ddd-561a-a30c-1fa8a89e31c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb08b642-aff6-4c37-a952-f8ddcfc4767e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb08b642-aff6-4c37-a952-f8ddcfc4767e.jpg?1",
             "name": "Gilded Goose",
             "text": "",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "d946e317-7f8d-5397-9a3a-963101b5c430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7c9b54-0b40-4007-8d24-bc3945be319f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7c9b54-0b40-4007-8d24-bc3945be319f.jpg?1",
             "name": "Baleful Strix",
             "text": "",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "d1907fec-42d8-5100-a4b5-cb6e01d6a0fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebc97bd-508f-4af5-a308-46cb1f256534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebc97bd-508f-4af5-a308-46cb1f256534.jpg?1",
             "name": "Dovescape",
             "text": "",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "91addac9-2096-57a4-be4d-52c365c4fa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9008f826-9e24-4ba1-b17e-1638b7cdd78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9008f826-9e24-4ba1-b17e-1638b7cdd78d.jpg?1",
             "name": "Rest in Peace",
             "text": "",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "f288db5b-f80b-5d7b-bfaa-ed45910e6056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06025c01-1d70-4e8d-b030-60a773631b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06025c01-1d70-4e8d-b030-60a773631b54.jpg?1",
             "name": "Dig Through Time",
             "text": "",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "4f86556f-d146-5c8f-8101-88d3d155335b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8adb0c-a322-4447-bf2e-7a74e3b735c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8adb0c-a322-4447-bf2e-7a74e3b735c4.jpg?1",
             "name": "Ancient Grudge",
             "text": "",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "cae4d1fa-6b49-5d7e-be34-f09268a0a787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19080c3f-67fa-4f98-9b5a-ede8579823d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19080c3f-67fa-4f98-9b5a-ede8579823d6.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "f8aea3de-9ff7-5367-b45c-f538b99a25bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20726fa-d99b-4e3d-8054-b7d313ceb02f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20726fa-d99b-4e3d-8054-b7d313ceb02f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "942decbf-a723-5cd6-837e-318c0c4c62ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ebf9dd-2f3d-440c-9935-bb3903ca7452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ebf9dd-2f3d-440c-9935-bb3903ca7452.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "20e9d603-6d6b-5967-9539-846658aed8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d433685-601d-4da2-9e4c-796646003ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d433685-601d-4da2-9e4c-796646003ffe.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "ca1bd514-26d2-578a-b3c5-65e9b5ea3108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0298749b-089e-49b9-8c89-02431a3d6457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0298749b-089e-49b9-8c89-02431a3d6457.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "223a63df-114e-5586-bdbe-4330491709ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8e7cd9-354d-4b2e-9823-79d6e8eed7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8e7cd9-354d-4b2e-9823-79d6e8eed7e4.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "ddabe805-5f2f-529e-83f1-8b3a76ec57ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f4fbb8-c91a-4193-b6ef-0a3d4436caad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f4fbb8-c91a-4193-b6ef-0a3d4436caad.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "12e03067-275d-51c1-a3a0-19ca96a3840e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03683fbb-9843-4c14-bb95-387150e97c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03683fbb-9843-4c14-bb95-387150e97c90.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "fb6d7f6f-e157-5693-b494-308c443bc6e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d52300-3fb9-49a6-8fe9-bd32adcbdb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d52300-3fb9-49a6-8fe9-bd32adcbdb4b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "0eddaaaf-3786-5eda-af80-c9a96e337e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e38987-e257-4da0-b270-bc48404947cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e38987-e257-4da0-b270-bc48404947cd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "113a66d3-5780-5a78-818e-e6d4af2dc568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c96a89-32e3-4412-9e79-51411362b9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c96a89-32e3-4412-9e79-51411362b9d5.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "1f8ea226-550c-59df-ac54-ae49b84716dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ef813e-2bec-431f-b010-995791285d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ef813e-2bec-431f-b010-995791285d0a.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "6391a5e5-d41b-5a8f-85b2-746d411dac67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bb062-eb03-4d9a-b028-91c089442187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bb062-eb03-4d9a-b028-91c089442187.jpg?1",
             "name": "Opt",
             "text": "",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "7dc1a803-e2b2-55d6-bb1c-3a9f1de6bd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5427d8a6-ac9e-4e50-bd39-81713b2ade25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5427d8a6-ac9e-4e50-bd39-81713b2ade25.jpg?1",
             "name": "Fatal Push",
             "text": "",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "4a445e1e-95fb-52b1-a26d-b64592693a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec898bc9-9ab8-4394-8c4c-8d652f313919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec898bc9-9ab8-4394-8c4c-8d652f313919.jpg?1",
             "name": "Anger of the Gods",
             "text": "",
             "colours": [
@@ -4480,7 +4480,7 @@
         },
         {
             "id": "1625e47e-39eb-50b1-bcf8-1a19cc9b7c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098e528a-bd6c-41f3-a246-cba986c54776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098e528a-bd6c-41f3-a246-cba986c54776.jpg?1",
             "name": "Explore",
             "text": "",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "d4b7bdbd-8ff0-5054-b278-e022598a20db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9c1419-aa54-4dd3-8d7d-4e2f60e7f581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9c1419-aa54-4dd3-8d7d-4e2f60e7f581.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "",
             "colours": [
@@ -4546,7 +4546,7 @@
         },
         {
             "id": "e9764bed-301d-57dd-b894-7747d337971d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8acace-57fb-4759-b15e-f4a8be1d13eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8acace-57fb-4759-b15e-f4a8be1d13eb.jpg?1",
             "name": "Mistbind Clique",
             "text": "",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "1f0edaff-6efb-506c-9033-5ad8705392ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650221f7-d935-498b-a9a1-ec23c89fc5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650221f7-d935-498b-a9a1-ec23c89fc5f8.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "",
             "colours": [
@@ -4614,7 +4614,7 @@
         },
         {
             "id": "0d093ec1-249b-5c36-b575-4baa1a70e5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebe58d-0f94-47f7-b17b-0d9492b931d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebe58d-0f94-47f7-b17b-0d9492b931d5.jpg?1",
             "name": "Vendilion Clique",
             "text": "",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "b65d2b26-bfda-5a14-bb4b-281d5b60ae96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50205489-2960-462c-a6cb-35a491dc54d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50205489-2960-462c-a6cb-35a491dc54d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "8873b958-99d5-5059-b3f4-51479abf9dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830158d4-1105-4d4c-ae0a-b4cec5f9266b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830158d4-1105-4d4c-ae0a-b4cec5f9266b.jpg?1",
             "name": "Sower of Temptation",
             "text": "",
             "colours": [
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "9fa47a00-0798-5399-a029-cae37352fd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc1d7db-11a3-4ff9-8d27-1fe401053080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc1d7db-11a3-4ff9-8d27-1fe401053080.jpg?1",
             "name": "Damnation",
             "text": "",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "87aacaac-e07e-59c7-b1cc-26cf2c511271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca3c93-ac49-4976-aa77-ee308b1c59bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca3c93-ac49-4976-aa77-ee308b1c59bd.jpg?1",
             "name": "Enchanted Evening",
             "text": "",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "2866fcb3-bbf1-51f1-9f29-37b317b547b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321aa38-7aaf-48fd-b516-18e702fbddef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321aa38-7aaf-48fd-b516-18e702fbddef.jpg?1",
             "name": "Hallowed Fountain",
             "text": "",
             "colours": [],
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "35588b8c-73da-5f08-9c34-a59951479df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef01b3-93f7-41e8-834d-9f6768e3b16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef01b3-93f7-41e8-834d-9f6768e3b16c.jpg?1",
             "name": "Watery Grave",
             "text": "",
             "colours": [],
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "fe8ba661-8169-5d62-902a-86c3ee206b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1716b4dd-9045-462b-b053-72de450a8cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1716b4dd-9045-462b-b053-72de450a8cde.jpg?1",
             "name": "Blood Crypt",
             "text": "",
             "colours": [],
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "5d903efa-c338-5459-819f-01deb46e0039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acf970d-d2d7-413d-aba7-587ee53d8d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acf970d-d2d7-413d-aba7-587ee53d8d5c.jpg?1",
             "name": "Stomping Ground",
             "text": "",
             "colours": [],
@@ -4947,7 +4947,7 @@
         },
         {
             "id": "bb3bf815-6e8b-5cff-ac38-bef89ec3f35a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a3039d-46cd-4a51-b726-6eb0b485c9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a3039d-46cd-4a51-b726-6eb0b485c9c5.jpg?1",
             "name": "Temple Garden",
             "text": "",
             "colours": [],
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "1a74f3aa-ba73-5f54-8814-cd1072b073d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c39866-98c2-4c60-98e1-eaf8e40b2d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c39866-98c2-4c60-98e1-eaf8e40b2d29.jpg?1",
             "name": "Godless Shrine",
             "text": "",
             "colours": [],
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "b2231b85-4504-56f9-a829-21972e69d0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516b248-c0be-4c49-83ab-393354c33563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516b248-c0be-4c49-83ab-393354c33563.jpg?1",
             "name": "Steam Vents",
             "text": "",
             "colours": [],
@@ -5046,7 +5046,7 @@
         },
         {
             "id": "3c36da14-f58f-5fb9-8033-0f37fcd90bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc75949-0bd1-4cd9-9e66-6624dcd41872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc75949-0bd1-4cd9-9e66-6624dcd41872.jpg?1",
             "name": "Overgrown Tomb",
             "text": "",
             "colours": [],
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "369893f8-85e4-5a1c-8d7e-6cfc0741670c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e55b85-92c1-4b83-9a9d-4afb8e938e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e55b85-92c1-4b83-9a9d-4afb8e938e4f.jpg?1",
             "name": "Sacred Foundry",
             "text": "",
             "colours": [],
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "e8b6f485-ed96-5d8d-9e31-38f74a725a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19477aca-b8db-4061-9a78-ebb189a9df22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19477aca-b8db-4061-9a78-ebb189a9df22.jpg?1",
             "name": "Breeding Pool",
             "text": "",
             "colours": [],
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "473b3896-44de-5ddf-88fb-afec760c379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cbcf51-3824-4ab3-89e3-cdcc1a0c7267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cbcf51-3824-4ab3-89e3-cdcc1a0c7267.jpg?1",
             "name": "Necrotic Ooze",
             "text": "",
             "colours": [
@@ -5178,7 +5178,7 @@
         },
         {
             "id": "4f83eed0-9565-5f56-9354-67f69fc9877d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6bd3fa-0d07-4519-b67f-67867ad13c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6bd3fa-0d07-4519-b67f-67867ad13c89.jpg?1",
             "name": "Acidic Slime",
             "text": "",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "1d697a84-f961-5999-99af-75ba182309ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae57dc27-539b-45f2-a18a-ca1f699f645d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae57dc27-539b-45f2-a18a-ca1f699f645d.jpg?1",
             "name": "Scavenging Ooze",
             "text": "",
             "colours": [
@@ -5244,7 +5244,7 @@
         },
         {
             "id": "81e80eb8-bbc0-5727-a0b0-d0d4245fb72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142076ee-870e-4962-8471-be4ae2e6e07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142076ee-870e-4962-8471-be4ae2e6e07c.jpg?1",
             "name": "The Mimeoplasm",
             "text": "",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "8a11fe5f-2a95-5ee0-92d4-21be912dcb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e640664f-5cc7-4970-b966-6e6e5ae09c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e640664f-5cc7-4970-b966-6e6e5ae09c5a.jpg?1",
             "name": "Voidslime",
             "text": "",
             "colours": [
@@ -5318,7 +5318,7 @@
         },
         {
             "id": "a129a845-b1c4-5640-9eef-3032ef4b3780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd79be1-3e84-41a3-89ae-b1132cb31ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd79be1-3e84-41a3-89ae-b1132cb31ed9.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -5353,7 +5353,7 @@
         },
         {
             "id": "b33c751e-6971-5c4f-a983-99edbcb9b506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00efb55-a859-408c-b727-6914584c06d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00efb55-a859-408c-b727-6914584c06d2.jpg?1",
             "name": "Assassin's Trophy",
             "text": "",
             "colours": [
@@ -5386,7 +5386,7 @@
         },
         {
             "id": "909b95a4-635e-5cb3-af25-fa29d4b7edf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d00d0f-8838-4fd0-b058-7039301af338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d00d0f-8838-4fd0-b058-7039301af338.jpg?1",
             "name": "Decimate",
             "text": "",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "3394fced-9fef-52e3-966d-45b3dc9d18be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf26b-d9cd-4aa6-a832-793b8631d681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf26b-d9cd-4aa6-a832-793b8631d681.jpg?1",
             "name": "Dreadbore",
             "text": "",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "e579e030-1eb4-55c2-a441-54f9fa5212f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048c829a-3f14-493d-b961-c7fb9cd23613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048c829a-3f14-493d-b961-c7fb9cd23613.jpg?1",
             "name": "Thraximundar",
             "text": "",
             "colours": [
@@ -5492,7 +5492,7 @@
         },
         {
             "id": "b2fdd701-c62f-5c47-a88b-70ecc3324907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8e78b3-3232-4d48-9d6c-540951a0330e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8e78b3-3232-4d48-9d6c-540951a0330e.jpg?1",
             "name": "Greymond, Avacyn's Stalwart",
             "text": "",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "321f9489-2946-56bf-a06c-9218337e52a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bffb892-e5dc-413d-924e-b9bda7bf7100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bffb892-e5dc-413d-924e-b9bda7bf7100.jpg?1",
             "name": "Hansk, Slayer Zealot",
             "text": "",
             "colours": [
@@ -5566,7 +5566,7 @@
         },
         {
             "id": "555fbe91-5eea-5c5b-8e53-4dc25cc844dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5df29a-af3b-4acc-8312-f2024ab039e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5df29a-af3b-4acc-8312-f2024ab039e0.jpg?1",
             "name": "Gregor, Shrewd Magistrate",
             "text": "",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "ece715c0-9621-5048-8973-7df0a1b85386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c68c630-c0e1-4e94-8352-b65631cc2caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c68c630-c0e1-4e94-8352-b65631cc2caa.jpg?1",
             "name": "Enkira, Hostile Scavenger",
             "text": "",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "cb04c4bc-0a19-5261-9456-686b30f0ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d03f86-5219-4456-8136-802699ff26d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d03f86-5219-4456-8136-802699ff26d3.jpg?1",
             "name": "Malik, Grim Manipulator",
             "text": "",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "15280321-c2d7-5ccc-b182-9045301d555f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4800ebc2-d5a7-4c26-a2f7-943a540ae47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4800ebc2-d5a7-4c26-a2f7-943a540ae47e.jpg?1",
             "name": "Admonition Angel",
             "text": "",
             "colours": [
@@ -5716,7 +5716,7 @@
         },
         {
             "id": "4de2c651-9c41-5c2b-9426-106f5b280c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61514906-0041-49b7-8990-0643dd3431f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61514906-0041-49b7-8990-0643dd3431f0.jpg?1",
             "name": "Roil Elemental",
             "text": "",
             "colours": [
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "00c7b274-c16e-5cad-93a2-619585cb1afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db5cf4-e023-4bd8-9f51-4dc42957007e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db5cf4-e023-4bd8-9f51-4dc42957007e.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "9216c4a1-67bd-5dfd-9ac0-7fc7066fbc13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abab3d4-d525-41bf-85ee-fba7f999001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abab3d4-d525-41bf-85ee-fba7f999001f.jpg?1",
             "name": "Warren Instigator",
             "text": "",
             "colours": [
@@ -5821,7 +5821,7 @@
         },
         {
             "id": "4c9bb394-0501-59fb-a0e0-c5a069593d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43add9-f948-41fe-b40c-e1d357db5f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43add9-f948-41fe-b40c-e1d357db5f05.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "",
             "colours": [
@@ -5855,7 +5855,7 @@
         },
         {
             "id": "09be9392-39b1-5901-bcc5-0bdfd73f3fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27197660-8489-419b-9ad6-29a8713e4673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27197660-8489-419b-9ad6-29a8713e4673.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "",
             "colours": [
@@ -5894,7 +5894,7 @@
         },
         {
             "id": "e771d473-2b2e-54c9-824e-1e309cdf42ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58cb4d-2091-40c8-b97c-09bf9c022a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58cb4d-2091-40c8-b97c-09bf9c022a8b.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "77d661e7-b0e0-50b5-ba7f-5c2f28a27052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624eff1-9347-4a99-8986-a2312258791c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624eff1-9347-4a99-8986-a2312258791c.jpg?1",
             "name": "Griselbrand",
             "text": "",
             "colours": [
@@ -5971,7 +5971,7 @@
         },
         {
             "id": "eeeea359-07bc-5a6e-937a-c581e6097d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c506f57a-e8b9-410f-9b7e-086900e26e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c506f57a-e8b9-410f-9b7e-086900e26e46.jpg?1",
             "name": "Griselbrand",
             "text": "",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "4a7a7ea9-ed6f-5412-89bf-97ad09184ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57c5ab1-3a36-47eb-8cf9-66b0c59d3e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57c5ab1-3a36-47eb-8cf9-66b0c59d3e03.jpg?1",
             "name": "Liliana's Contract",
             "text": "",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "5d79457e-d198-57cc-b079-347e4fa8b00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e5c89f-e181-4a77-8127-6afad5354004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e5c89f-e181-4a77-8127-6afad5354004.jpg?1",
             "name": "Liliana's Contract",
             "text": "",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "2e5cc393-c33a-5baa-b229-35f04f363338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615a6845-f58a-4ee5-aa83-a5747b890140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615a6845-f58a-4ee5-aa83-a5747b890140.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "",
             "colours": [
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "2108ded8-5fa6-5b26-a53c-d4317d6b37e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37f93d4-166a-41cd-86b2-0eeeae33ff9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37f93d4-166a-41cd-86b2-0eeeae33ff9d.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "49dff80a-61b3-5550-af95-8d3cce7686e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb98f5c-9ef2-4549-9603-814726f1ffcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb98f5c-9ef2-4549-9603-814726f1ffcc.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "3f70b4a7-2f84-5610-a256-6c6bbb5796c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bc7380-e417-4f30-a4aa-356d782b5e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bc7380-e417-4f30-a4aa-356d782b5e4d.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "f5016e90-917e-5a9a-9740-60e4775e811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f4627-58ab-45c8-b31b-eaa52dad33fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f4627-58ab-45c8-b31b-eaa52dad33fc.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "ffda0b30-2c36-57bc-a0b3-951a9c178e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09084e38-195a-45d6-a245-1c6d3e86500f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09084e38-195a-45d6-a245-1c6d3e86500f.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "b91834a6-59ff-5774-bc56-25c3b0e2c050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba6a508-3286-4938-b0a5-94b794ab6456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba6a508-3286-4938-b0a5-94b794ab6456.jpg?1",
             "name": "Collected Company",
             "text": "",
             "colours": [
@@ -6325,7 +6325,7 @@
         },
         {
             "id": "15d2153c-840b-54b3-a740-faa289453e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311af3f7-463b-4fe0-aefc-5cd26a5fbd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311af3f7-463b-4fe0-aefc-5cd26a5fbd3d.jpg?1",
             "name": "Amulet of Vigor",
             "text": "",
             "colours": [],
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "afddf66d-0d75-5ab4-8bab-1026877a5fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8619034-173c-4950-a0b4-1ae1dcfd0bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8619034-173c-4950-a0b4-1ae1dcfd0bc5.jpg?1",
             "name": "Balance",
             "text": "",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "85041861-3d64-544b-8aa2-97619186a8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0da5b-0916-4dd6-99a2-a58e9d83bb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0da5b-0916-4dd6-99a2-a58e9d83bb26.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "b2860b41-ceb3-5ea8-b9ca-17b49b167c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5932f2dc-3bb6-4f5e-8e8d-c62e7413ac0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5932f2dc-3bb6-4f5e-8e8d-c62e7413ac0a.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "67e1f03c-37c4-5752-9ee2-ac5049cb0a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "ca32c6fd-5119-5d34-b8b0-b0e7d23cb6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a509149-9864-4622-8122-21a723defaa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a509149-9864-4622-8122-21a723defaa8.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -6521,7 +6521,7 @@
         },
         {
             "id": "da44e28c-7ea3-5ae5-89ad-3235f0504071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53f7e3-f76a-440b-8c84-994d378bda97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53f7e3-f76a-440b-8c84-994d378bda97.jpg?1",
             "name": "Wasteland",
             "text": "",
             "colours": [],
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "4472fc52-ef97-5691-9a96-348c28a0c8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caff117f-844b-4d11-a104-930d7f238114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caff117f-844b-4d11-a104-930d7f238114.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "0131c33e-6cb8-53f7-911e-a2c82b8fc8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382c608-b3db-4112-b0c3-0e12199c4898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382c608-b3db-4112-b0c3-0e12199c4898.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "a170ec3d-a5a9-5431-86db-41423cb63de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ad5bcb-7bdc-44ec-be67-f4dd49a17450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ad5bcb-7bdc-44ec-be67-f4dd49a17450.jpg?1",
             "name": "Decree of Pain",
             "text": "",
             "colours": [
@@ -6646,7 +6646,7 @@
         },
         {
             "id": "3365882c-9c59-5e46-915b-739790c21527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e57561-17d4-48db-8e40-f41019010bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e57561-17d4-48db-8e40-f41019010bc9.jpg?1",
             "name": "Gamble",
             "text": "",
             "colours": [
@@ -6677,7 +6677,7 @@
         },
         {
             "id": "646643b3-eece-5c2d-93cc-c66f0283cf37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9f5e0c-8bf4-46ab-ad79-332ceeaed3d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9f5e0c-8bf4-46ab-ad79-332ceeaed3d5.jpg?1",
             "name": "Nature's Lore",
             "text": "",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "ad022f20-e0cd-58b1-8cf2-2bd7f82cfcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58d181-500f-4698-a2ba-e378e5335676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58d181-500f-4698-a2ba-e378e5335676.jpg?1",
             "name": "Soul-Scar Mage",
             "text": "",
             "colours": [
@@ -6745,7 +6745,7 @@
         },
         {
             "id": "c6f713d7-3cda-5dba-b2e0-21d7912bba6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e22287-21c5-4733-a527-b176fbf3725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e22287-21c5-4733-a527-b176fbf3725d.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "a4049112-c629-5d16-ac75-f524c43b25fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b064748-515a-4234-ad00-8a735d7aa385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b064748-515a-4234-ad00-8a735d7aa385.jpg?1",
             "name": "Sakura-Tribe Elder",
             "text": "",
             "colours": [
@@ -6816,7 +6816,7 @@
         },
         {
             "id": "7c8a6f00-961f-57ed-ba02-2531276c5d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1320b1-3eac-4c5a-9f75-6fdff3cc2639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1320b1-3eac-4c5a-9f75-6fdff3cc2639.jpg?1",
             "name": "Spell Queller",
             "text": "",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "3ab4b358-19c1-5a6f-bfb6-3ee53a8be282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23caa9ce-057a-40f6-a9fe-073c60b69fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23caa9ce-057a-40f6-a9fe-073c60b69fc2.jpg?1",
             "name": "Metallic Mimic",
             "text": "",
             "colours": [],
@@ -6883,7 +6883,7 @@
         },
         {
             "id": "94b7fa3c-7ff2-5fd6-9fe1-a3fd0bf63804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320d7e7-aa1e-4c00-9b45-525352393e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320d7e7-aa1e-4c00-9b45-525352393e00.jpg?1",
             "name": "Chatter of the Squirrel",
             "text": "",
             "colours": [
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "80e83a50-39e3-58d6-9b74-bdec1525a7e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ea2f2d-14ca-4b57-b973-5ce7db35bebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ea2f2d-14ca-4b57-b973-5ce7db35bebf.jpg?1",
             "name": "Krosan Beast",
             "text": "",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "4a5eb51d-dfda-56a8-bde0-357f89081e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff276249-e7ca-4264-9039-d32b38cc4a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff276249-e7ca-4264-9039-d32b38cc4a7e.jpg?1",
             "name": "Squirrel Mob",
             "text": "",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "d7b68e45-69c2-5514-be55-487befc5281a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881ed685-bf7c-4ba3-8401-2ead8c24ca0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881ed685-bf7c-4ba3-8401-2ead8c24ca0f.jpg?1",
             "name": "Squirrel Wrangler",
             "text": "",
             "colours": [
@@ -7015,7 +7015,7 @@
         },
         {
             "id": "0e112855-529f-5fd8-8c7c-8792d8acf69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db231a23-c556-4667-bf83-9216f13b9618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db231a23-c556-4667-bf83-9216f13b9618.jpg?1",
             "name": "Swarmyard",
             "text": "",
             "colours": [],
@@ -7042,7 +7042,7 @@
         },
         {
             "id": "2d5fc9f9-b5a2-5d13-afbd-60fef514a001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c385447a-f56d-4b65-a090-bae48b0313c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c385447a-f56d-4b65-a090-bae48b0313c0.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -7079,7 +7079,7 @@
         },
         {
             "id": "bee111e0-5d94-505f-8e29-80841d9a4b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97594249-704b-4ef2-a86a-d1442d0fe689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97594249-704b-4ef2-a86a-d1442d0fe689.jpg?1",
             "name": "Chromatic Lantern",
             "text": "",
             "colours": [],
@@ -7107,7 +7107,7 @@
         },
         {
             "id": "e5db05b7-1076-55b0-9099-f3808f7204ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4e5a4-dcd0-4565-afcb-42a089f1559a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4e5a4-dcd0-4565-afcb-42a089f1559a.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -7137,7 +7137,7 @@
         },
         {
             "id": "7f1be45c-5838-5e49-a0d6-9e8ba5387444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dddc050-56ed-43b4-a34d-fea76f3e8a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dddc050-56ed-43b4-a34d-fea76f3e8a55.jpg?1",
             "name": "Darksteel Ingot",
             "text": "",
             "colours": [],
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "c1a02626-6975-5976-aab8-c7d0a1bc5895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed78861-4877-4f27-b900-981af79c2450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed78861-4877-4f27-b900-981af79c2450.jpg?1",
             "name": "Gilded Lotus",
             "text": "",
             "colours": [],
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "3cf62271-58d7-554d-a94b-31ff0c580799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dad59-27a4-4dbb-bec8-f0683d6e2a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dad59-27a4-4dbb-bec8-f0683d6e2a67.jpg?1",
             "name": "Exquisite Blood",
             "text": "",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "2fcf8f72-6010-57ab-a620-21b358e34dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f415a76e-6b35-442e-a2e1-9e368f550566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f415a76e-6b35-442e-a2e1-9e368f550566.jpg?1",
             "name": "Night's Whisper",
             "text": "",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "df33fdfa-bd34-5864-9645-798f19f85dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097b876-ffb4-4388-beb1-d25d887593b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097b876-ffb4-4388-beb1-d25d887593b9.jpg?1",
             "name": "Phyrexian Tower",
             "text": "",
             "colours": [],
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "4e42db45-2263-575e-a9f7-bd331e81ca05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436e594-ec27-465d-a570-7645ddbbc2f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436e594-ec27-465d-a570-7645ddbbc2f7.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "dc360824-ea98-57f1-a332-f2c14e0ee5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5341194-90c3-4554-8c45-f4442ad2eef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5341194-90c3-4554-8c45-f4442ad2eef0.jpg?1",
             "name": "Jin-Gitaxias, Core Augur",
             "text": "",
             "colours": [
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "5b3b1901-c208-5d90-8831-2575ab911d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18206ae6-08e2-4ad2-bc0a-6626a89b9516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18206ae6-08e2-4ad2-bc0a-6626a89b9516.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "f694951f-53c0-5683-bdef-0b37839ef305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60f6330-f1ce-4a39-ab58-49bb5fa96081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60f6330-f1ce-4a39-ab58-49bb5fa96081.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "08d693b7-26e7-50c8-a7f7-e4827e99ace3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603a7305-c036-47ef-8926-25b66a7905df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603a7305-c036-47ef-8926-25b66a7905df.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "",
             "colours": [
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "f581df2b-2693-504e-a9ce-92fe4c47aba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aae46bb-15d3-4049-9eae-86c6c5b5dcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aae46bb-15d3-4049-9eae-86c6c5b5dcff.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "",
             "colours": [
@@ -7517,7 +7517,7 @@
         },
         {
             "id": "eef6958f-5124-5b44-b55c-e8c2113c2b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab03d01-ec92-473d-b983-18cf5f06ff39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab03d01-ec92-473d-b983-18cf5f06ff39.jpg?1",
             "name": "Goblin Rabblemaster",
             "text": "",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "7a9411b2-a6f4-5277-91e6-e4a5ad7e32e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef14b6-e604-40c3-bf7e-587a192a68bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef14b6-e604-40c3-bf7e-587a192a68bc.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "",
             "colours": [
@@ -7587,7 +7587,7 @@
         },
         {
             "id": "38fde9cc-e511-511e-8379-0201f289fcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8cd7a1-3f79-405b-8930-2206f32c2035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8cd7a1-3f79-405b-8930-2206f32c2035.jpg?1",
             "name": "Boros Charm",
             "text": "",
             "colours": [
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "c220d9d3-1586-58c9-b500-09ce1a977f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2178-8e1f-4d64-9711-5b7264632200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2178-8e1f-4d64-9711-5b7264632200.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "",
             "colours": [
@@ -7661,7 +7661,7 @@
         },
         {
             "id": "fd129eaf-9100-5cb5-a16e-5b70cb049343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8073af-bd3d-48f1-99d4-d216e3f1ff60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8073af-bd3d-48f1-99d4-d216e3f1ff60.jpg?1",
             "name": "Frost Titan",
             "text": "",
             "colours": [
@@ -7695,7 +7695,7 @@
         },
         {
             "id": "93c87e31-3c6a-5630-b6bf-e90d5b5245ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3377096-d89c-408f-ab0b-6f96f1b240f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3377096-d89c-408f-ab0b-6f96f1b240f6.jpg?1",
             "name": "Primeval Titan",
             "text": "",
             "colours": [
@@ -7731,7 +7731,7 @@
         },
         {
             "id": "5dbed221-602d-51d7-aeca-e73e6002bfa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b4542-bf78-4450-a4e0-bf757445c3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b4542-bf78-4450-a4e0-bf757445c3c3.jpg?1",
             "name": "Uro, Titan of Nature's Wrath",
             "text": "",
             "colours": [
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "50157c38-6e9a-5cfb-9dd0-3d39031614f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1a018f-ce08-428b-9be2-937204dd25c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1a018f-ce08-428b-9be2-937204dd25c2.jpg?1",
             "name": "Grave Titan",
             "text": "",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "d533b30f-e91c-5369-82ee-130022630cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be293048-1df6-4df4-869c-b3b19534b35b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be293048-1df6-4df4-869c-b3b19534b35b.jpg?1",
             "name": "Inferno Titan",
             "text": "",
             "colours": [
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "ec988c5c-7f1c-5661-a479-8ac49058b75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6186ca35-4d28-4176-aaff-5b384a688aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6186ca35-4d28-4176-aaff-5b384a688aa6.jpg?1",
             "name": "Kroxa, Titan of Death's Hunger",
             "text": "",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "bcd70cb6-cc76-5b20-8448-a5f96783dba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe951-4820-4555-8cee-621c66ed8620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe951-4820-4555-8cee-621c66ed8620.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -7911,7 +7911,7 @@
         },
         {
             "id": "29a577ee-1af6-5b8d-a08d-6ec810fa7fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7d9a4-c36e-4989-b448-fa56705a4aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7d9a4-c36e-4989-b448-fa56705a4aa6.jpg?1",
             "name": "Well of Lost Dreams",
             "text": "",
             "colours": [],
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "2bb3c4b8-2677-5713-96da-2358e6575c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2e5b6e-ca2e-4149-bad6-784f40afa9fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2e5b6e-ca2e-4149-bad6-784f40afa9fb.jpg?1",
             "name": "Frantic Search",
             "text": "",
             "colours": [
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "5e80dc18-f61b-5d43-99bb-cb327a3e9573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50093179-2369-49db-a66d-ce3225363f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50093179-2369-49db-a66d-ce3225363f5d.jpg?1",
             "name": "Intruder Alarm",
             "text": "",
             "colours": [
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "7411bb46-acbd-59e3-861e-9f4cf8514caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e093eb73-3780-4735-9e6b-fb4f621978e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e093eb73-3780-4735-9e6b-fb4f621978e9.jpg?1",
             "name": "Shelldock Isle",
             "text": "",
             "colours": [],
@@ -8037,7 +8037,7 @@
         },
         {
             "id": "40a5c908-c467-54cf-90cb-4ebf4d8a679d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e62436-8e4a-48d0-bcb2-fa650b1aafbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e62436-8e4a-48d0-bcb2-fa650b1aafbb.jpg?1",
             "name": "Gravecrawler",
             "text": "",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "431e3aa8-3ae3-50ed-b888-f6996e304a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fe57c2-68c6-44c9-ac2b-9d531c0d000c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fe57c2-68c6-44c9-ac2b-9d531c0d000c.jpg?1",
             "name": "Liliana, Death's Majesty",
             "text": "",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "66b39666-bf65-5040-b9e7-8c4fdb1c8dcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ed0f96-7dc2-47c0-9cac-d24dab264e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ed0f96-7dc2-47c0-9cac-d24dab264e05.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "91e8dcc3-d0d2-5f91-aa3a-adabc4df9112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -8174,7 +8174,7 @@
         },
         {
             "id": "bcedbe0a-3778-57f2-a56f-acca400eb720",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "d27a5b13-44e6-5b48-a6d5-055f20a1a237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3189e68-623f-4da4-baa7-a2912db145e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3189e68-623f-4da4-baa7-a2912db145e1.jpg?1",
             "name": "Vindictive Lich",
             "text": "",
             "colours": [
@@ -8243,7 +8243,7 @@
         },
         {
             "id": "916bc664-8aa5-52c8-b438-d50003e7537c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf037a6-9004-49a3-b4a2-2c814fc63d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf037a6-9004-49a3-b4a2-2c814fc63d1c.jpg?1",
             "name": "Meandering Towershell",
             "text": "",
             "colours": [
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "a6c5dba0-94f7-5c09-91d2-b345bebf13b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9b8337-5e55-4f6b-a5c5-ecbd112408eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9b8337-5e55-4f6b-a5c5-ecbd112408eb.jpg?1",
             "name": "Ohran Frostfang",
             "text": "",
             "colours": [
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "9bfa8e5e-988e-5d3f-8088-d95f88437f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1e3f3-a9b8-4185-9be9-798fe3cddd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1e3f3-a9b8-4185-9be9-798fe3cddd5c.jpg?1",
             "name": "Thragtusk",
             "text": "",
             "colours": [
@@ -8347,7 +8347,7 @@
         },
         {
             "id": "56b7949c-b860-5112-876c-62e41a03829e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fe1359-c78c-41fb-95d9-fcc7c46f0bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fe1359-c78c-41fb-95d9-fcc7c46f0bb1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "4eeb9934-5d5e-58da-98d5-6393743e23b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaf2e2-b4af-4a84-ab27-d8a6b40c9552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaf2e2-b4af-4a84-ab27-d8a6b40c9552.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -8481,7 +8481,7 @@
         },
         {
             "id": "e5dcf29e-36b2-55f0-bdd5-bcf51a0310bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b53b7-4a20-48eb-a0bd-4ddf40aae740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b53b7-4a20-48eb-a0bd-4ddf40aae740.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -8545,7 +8545,7 @@
         },
         {
             "id": "44db6c8e-d75e-50e2-b2e8-d3e2532cd8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277af45a-1f91-4fd4-804d-5b34241386b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277af45a-1f91-4fd4-804d-5b34241386b8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "572efbfb-efcf-50ce-b0ba-177e9a667a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6cdc-f92f-497c-8cd9-b69586098512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6cdc-f92f-497c-8cd9-b69586098512.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "659121fe-9953-5360-8826-62905675d5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882d3475-4fb9-49ad-bc19-e6331428701b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882d3475-4fb9-49ad-bc19-e6331428701b.jpg?1",
             "name": "Shalai, Voice of Plenty",
             "text": "",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "b589541a-9fb6-51f3-a146-790fbe5ede7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d02bf4-eefd-4916-ab5a-cc16b3e6a186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d02bf4-eefd-4916-ab5a-cc16b3e6a186.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -8755,7 +8755,7 @@
         },
         {
             "id": "48c9c472-8d88-5f46-93ac-07b33985d26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a4b1e-f6c0-489b-878b-533dd46cdd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a4b1e-f6c0-489b-878b-533dd46cdd1a.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "cc21ecef-9558-59db-aa51-963f2e850e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67851439-26d6-422d-9bce-8c9c25ffc0c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67851439-26d6-422d-9bce-8c9c25ffc0c2.jpg?1",
             "name": "Kaya, Ghost Assassin",
             "text": "",
             "colours": [
@@ -8825,7 +8825,7 @@
         },
         {
             "id": "24213593-cac5-54f2-a146-dc539d051b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6721431-418e-4c92-818a-50417066c229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6721431-418e-4c92-818a-50417066c229.jpg?1",
             "name": "Teferi, Hero of Dominaria",
             "text": "",
             "colours": [
@@ -8863,7 +8863,7 @@
         },
         {
             "id": "34b8fdb8-5d8d-5d67-ba31-de9528757c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf22be9-bf1a-48ec-a825-d19504f9dfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf22be9-bf1a-48ec-a825-d19504f9dfcc.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "b4f357f8-fec9-5687-90ff-c1373fcfa123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35425069-0d8d-4a02-ba7c-50e7abfecb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35425069-0d8d-4a02-ba7c-50e7abfecb4c.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -8928,7 +8928,7 @@
         },
         {
             "id": "f1dfb3fc-ec30-5194-9169-ab9a77186466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3fa12-531b-41a1-a71b-a1a2670cf2db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3fa12-531b-41a1-a71b-a1a2670cf2db.jpg?1",
             "name": "Dack Fayden",
             "text": "",
             "colours": [
@@ -8967,7 +8967,7 @@
         },
         {
             "id": "ac2baf81-9f79-5bba-a293-95ac780e535e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066cee3d-1bc9-43bb-a1e5-70256875eb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066cee3d-1bc9-43bb-a1e5-70256875eb9b.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "33a31e70-8084-5a9d-bd51-3a0fcd733862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefa41f-2970-4312-b0ec-5596fcc49f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefa41f-2970-4312-b0ec-5596fcc49f02.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "c6098fb4-015e-5b43-b79b-85a3abeb213f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a19fcc-f465-43ac-8d08-ba0d2345b66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a19fcc-f465-43ac-8d08-ba0d2345b66d.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "8062bdc1-f68f-57fb-a67f-82cbc58c731f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd07b50a-0bd7-49fa-9ada-96a8f96a62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd07b50a-0bd7-49fa-9ada-96a8f96a62cc.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "200ce942-11de-50d5-8c65-b88765f521ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdc3f2-0e3e-45b4-a141-2eb029275e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdc3f2-0e3e-45b4-a141-2eb029275e9a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9237,7 +9237,7 @@
         },
         {
             "id": "724005e6-4cb8-5865-bba1-0adfe0c2cf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4072f8-4833-4219-b620-3092a9f08874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4072f8-4833-4219-b620-3092a9f08874.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9311,7 +9311,7 @@
         },
         {
             "id": "024784f5-f04c-52b6-95cf-3ada79698b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37620d-4fa4-4d2f-a668-7b1e556b3b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37620d-4fa4-4d2f-a668-7b1e556b3b04.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9376,7 +9376,7 @@
         },
         {
             "id": "2fe8251a-d24b-5ee0-bf53-0e415a7257f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf546a-83ac-470f-a5c7-2b214d18f5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf546a-83ac-470f-a5c7-2b214d18f5c1.jpg?1",
             "name": "Michiko Konda, Truth Seeker",
             "text": "",
             "colours": [
@@ -9413,7 +9413,7 @@
         },
         {
             "id": "07ea17e2-d4c2-59c9-8ee7-1fded8e0403c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326979d-3620-4f7b-999c-b827ff725b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326979d-3620-4f7b-999c-b827ff725b16.jpg?1",
             "name": "Kami of the Crescent Moon",
             "text": "",
             "colours": [
@@ -9449,7 +9449,7 @@
         },
         {
             "id": "8ac79ce6-c997-5a42-94ff-5662cb8d9961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8da57c-88ff-4fea-b19e-856a4c89cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8da57c-88ff-4fea-b19e-856a4c89cb8e.jpg?1",
             "name": "Toshiro Umezawa",
             "text": "",
             "colours": [
@@ -9486,7 +9486,7 @@
         },
         {
             "id": "1ff56bcf-a9ab-5ee6-a30a-7bdfae459666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fe9de5-3b0d-47ed-9302-ef58972592b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fe9de5-3b0d-47ed-9302-ef58972592b7.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "",
             "colours": [
@@ -9523,7 +9523,7 @@
         },
         {
             "id": "1b5c4647-7e23-5d3f-94dd-5985697f7bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fac46f-cf4e-47df-8f20-e1710744630b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fac46f-cf4e-47df-8f20-e1710744630b.jpg?1",
             "name": "Reki, the History of Kamigawa",
             "text": "",
             "colours": [
@@ -9560,7 +9560,7 @@
         },
         {
             "id": "ac85400f-4c72-5633-8e48-bc6ac15a9ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc7280c-8136-4ac3-b2d6-6679e13b0470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc7280c-8136-4ac3-b2d6-6679e13b0470.jpg?1",
             "name": "All Is Dust",
             "text": "",
             "colours": [],
@@ -9591,7 +9591,7 @@
         },
         {
             "id": "c2b0cf3a-8695-5054-8870-21018961edd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f5de3e-f3ca-439f-8b7c-f0b1807f34b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f5de3e-f3ca-439f-8b7c-f0b1807f34b4.jpg?1",
             "name": "Artifact Mutation",
             "text": "",
             "colours": [
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "f3002d9f-f90e-57d2-8f51-de128f49a52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acd1c1-86b2-4423-9ba7-5b9725c0514f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acd1c1-86b2-4423-9ba7-5b9725c0514f.jpg?1",
             "name": "Drown in the Loch",
             "text": "",
             "colours": [
@@ -9661,7 +9661,7 @@
         },
         {
             "id": "3e26f1fd-48f0-5cde-bc9a-dbdb915a3b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf2da97-3331-4614-b4ff-f03d061500a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf2da97-3331-4614-b4ff-f03d061500a7.jpg?1",
             "name": "Fire Covenant",
             "text": "",
             "colours": [
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "2a8ee0c1-5c6c-5888-93bc-c3f1d738db62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db735ea-f9cf-4e3c-9200-4f180df55baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db735ea-f9cf-4e3c-9200-4f180df55baa.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -9731,7 +9731,7 @@
         },
         {
             "id": "d8e131d3-8405-502e-8f63-9910ab1a9f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7f3579-452d-4531-a00a-ee74c67a79e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7f3579-452d-4531-a00a-ee74c67a79e3.jpg?1",
             "name": "Fracturing Gust",
             "text": "",
             "colours": [
@@ -9765,7 +9765,7 @@
         },
         {
             "id": "3bb5f33e-cb2a-51ac-a809-876b99f7d8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2221e-60c9-4880-9513-f7223772bb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2221e-60c9-4880-9513-f7223772bb0b.jpg?1",
             "name": "Ob Nixilis Reignited",
             "text": "",
             "colours": [
@@ -9801,7 +9801,7 @@
         },
         {
             "id": "26fa0e01-9f8a-5acf-9107-851f556fe3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba1fa6-b96b-48e8-b0d2-e58de7fbc71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba1fa6-b96b-48e8-b0d2-e58de7fbc71d.jpg?1",
             "name": "Sire of Insanity",
             "text": "",
             "colours": [
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "75009016-5fb7-5ab4-bbe8-869e6c44c294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b117d-f2bf-4bf0-b70c-d45e252e1456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b117d-f2bf-4bf0-b70c-d45e252e1456.jpg?1",
             "name": "Sliver Hivelord",
             "text": "",
             "colours": [
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "c115cd9c-2af7-502c-9996-a685fa044641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9151465-4d98-419e-8cd0-b18ef5716507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9151465-4d98-419e-8cd0-b18ef5716507.jpg?1",
             "name": "Spellskite",
             "text": "",
             "colours": [],
@@ -9917,7 +9917,7 @@
         },
         {
             "id": "ebfe8443-acf1-5318-aac1-de1a4ded0a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba7c2-7ae5-47cc-8fbe-c053628c72e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba7c2-7ae5-47cc-8fbe-c053628c72e1.jpg?1",
             "name": "Sanctum Prelate",
             "text": "",
             "colours": [
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "9849ad98-9e6c-57e0-b5bb-f8fc2b3d0e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c3499-d2c0-4e21-be7b-925e23a1d4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c3499-d2c0-4e21-be7b-925e23a1d4df.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "ff23e0e7-2c80-56c9-8573-370c4f14155e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c378b614-ad53-40cd-86fa-6b6c7b82b824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c378b614-ad53-40cd-86fa-6b6c7b82b824.jpg?1",
             "name": "Sphere of Safety",
             "text": "",
             "colours": [
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "78b1b4ff-a5d0-5731-bb44-8335d28b8a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15090117-5fef-454d-8972-8f31e9fd870f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15090117-5fef-454d-8972-8f31e9fd870f.jpg?1",
             "name": "Karmic Guide",
             "text": "",
             "colours": [
@@ -10053,7 +10053,7 @@
         },
         {
             "id": "0fb11ef2-7d80-54ce-952a-ce84bc0c2438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5335eb-e81f-46c5-a9e8-011f0c962b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5335eb-e81f-46c5-a9e8-011f0c962b41.jpg?1",
             "name": "Mesa Enchantress",
             "text": "",
             "colours": [
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "855787fd-bfd5-5337-bc2a-0bac75149fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb59c-085f-4caf-8430-ba6e2888ea6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb59c-085f-4caf-8430-ba6e2888ea6d.jpg?1",
             "name": "Archaeomancer",
             "text": "",
             "colours": [
@@ -10123,7 +10123,7 @@
         },
         {
             "id": "57f5196f-8c07-5f2c-9489-15297377bc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35dbe45e-16df-4ebb-a76a-df24124de23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35dbe45e-16df-4ebb-a76a-df24124de23b.jpg?1",
             "name": "Bloom Tender",
             "text": "",
             "colours": [
@@ -10158,7 +10158,7 @@
         },
         {
             "id": "e559acf1-18e6-5db5-873f-26c913df93e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4565ed0-36a1-4d36-987e-cae10e36830f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4565ed0-36a1-4d36-987e-cae10e36830f.jpg?1",
             "name": "Meteor Golem",
             "text": "",
             "colours": [],
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "efa86084-f45f-5a62-91e0-446b2c522275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4da73-2faa-4992-8f61-e668ce82ba17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4da73-2faa-4992-8f61-e668ce82ba17.jpg?1",
             "name": "Azorius Signet",
             "text": "",
             "colours": [],
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "ab000450-357f-5296-883e-6157708a6247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35148573-7788-4023-a63c-4a09f48273c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35148573-7788-4023-a63c-4a09f48273c1.jpg?1",
             "name": "Dimir Signet",
             "text": "",
             "colours": [],
@@ -10253,7 +10253,7 @@
         },
         {
             "id": "cf7f1584-fc48-5088-95f8-6ad0504021e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0310bb0e-bd22-470e-8711-4e15aec86578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0310bb0e-bd22-470e-8711-4e15aec86578.jpg?1",
             "name": "Gruul Signet",
             "text": "",
             "colours": [],
@@ -10284,7 +10284,7 @@
         },
         {
             "id": "6570cd48-0249-54f9-9b05-af48776a3a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f1ee3-d83b-410b-b51f-ad4be841ac59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f1ee3-d83b-410b-b51f-ad4be841ac59.jpg?1",
             "name": "Rakdos Signet",
             "text": "",
             "colours": [],
@@ -10315,7 +10315,7 @@
         },
         {
             "id": "fb6699a3-0931-5485-8bea-7bd69a35d6f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcfd873-da1f-4f0b-a41d-54f383ec1724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcfd873-da1f-4f0b-a41d-54f383ec1724.jpg?1",
             "name": "Selesnya Signet",
             "text": "",
             "colours": [],
@@ -10346,7 +10346,7 @@
         },
         {
             "id": "5c8df2de-5f69-5b7a-8d46-c2fb3c7d18f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d4532d-f948-4eb3-b855-592080e171e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d4532d-f948-4eb3-b855-592080e171e5.jpg?1",
             "name": "Boros Signet",
             "text": "",
             "colours": [],
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "b5e48ca3-fb55-5913-8bc5-bd5277672fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c0ba5-a83a-40a9-919a-0bda0fef3b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c0ba5-a83a-40a9-919a-0bda0fef3b4f.jpg?1",
             "name": "Golgari Signet",
             "text": "",
             "colours": [],
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "1d4999ee-6141-5384-9897-89ab66c30613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab29ff99-b246-49e8-bb77-c7906b502232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab29ff99-b246-49e8-bb77-c7906b502232.jpg?1",
             "name": "Izzet Signet",
             "text": "",
             "colours": [],
@@ -10439,7 +10439,7 @@
         },
         {
             "id": "990827a4-d289-508c-95f4-ace9e7c199cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072b7b7-7ca1-4106-a9b2-49cde7c47faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072b7b7-7ca1-4106-a9b2-49cde7c47faa.jpg?1",
             "name": "Orzhov Signet",
             "text": "",
             "colours": [],
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "9593ce8a-ceca-5903-b694-78f8a3df27cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58e931a-d4dd-4705-ae31-89c0aecbf192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58e931a-d4dd-4705-ae31-89c0aecbf192.jpg?1",
             "name": "Simic Signet",
             "text": "",
             "colours": [],
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "ff3ed33a-3cb5-5f12-89c9-7d69b5c07de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb0349-a759-473e-a192-7ca85ef8e515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb0349-a759-473e-a192-7ca85ef8e515.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "92c2dc61-6103-5460-9990-6c9c93d460f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527010e-d382-4bd5-8de6-0e3898b80deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527010e-d382-4bd5-8de6-0e3898b80deb.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "0ca42d7c-53e4-5ac2-af58-bb492d52f26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a96d0b-5c8f-4563-92a0-a2c9e595100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a96d0b-5c8f-4563-92a0-a2c9e595100b.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "ad7ba83f-e51e-5788-a4b3-341edd135b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69db7d6-80fd-4832-b9f4-47eb4aab54e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69db7d6-80fd-4832-b9f4-47eb4aab54e6.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "6d8dde8f-6971-52e5-aa9c-98981d112697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f4c301-6015-456a-8989-e0055402809e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f4c301-6015-456a-8989-e0055402809e.jpg?1",
             "name": "Ancient Den",
             "text": "",
             "colours": [],
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "040bfcf1-dd45-545e-8a4c-2f5078a8b0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea58393a-7d69-4f99-90b7-ef6f31e4c80b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea58393a-7d69-4f99-90b7-ef6f31e4c80b.jpg?1",
             "name": "Seat of the Synod",
             "text": "",
             "colours": [],
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "a8a96968-0bd5-5da6-af3c-80b5b0c40ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2320e6f4-ff1f-4c07-86b7-ee0e7904a573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2320e6f4-ff1f-4c07-86b7-ee0e7904a573.jpg?1",
             "name": "Vault of Whispers",
             "text": "",
             "colours": [],
@@ -10754,7 +10754,7 @@
         },
         {
             "id": "4e66bc54-668f-5990-91ee-a4749cc3f2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49411808-630f-4bb4-af52-137932adcd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49411808-630f-4bb4-af52-137932adcd7c.jpg?1",
             "name": "Great Furnace",
             "text": "",
             "colours": [],
@@ -10785,7 +10785,7 @@
         },
         {
             "id": "ca59dc28-2f05-5823-a176-6d5e3e3c365f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da48f6c-df82-4290-a476-6e4358fac4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da48f6c-df82-4290-a476-6e4358fac4ff.jpg?1",
             "name": "Tree of Tales",
             "text": "",
             "colours": [],
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "c3f7a479-17ad-5572-a37a-9d83b3982217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2af348-e768-44ca-b847-d541a0b0e6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2af348-e768-44ca-b847-d541a0b0e6e0.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "",
             "colours": [
@@ -10853,7 +10853,7 @@
         },
         {
             "id": "a0fab005-b156-59aa-bcf7-160224984bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11944685-56b1-42e4-b9b8-fc468c81e9a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11944685-56b1-42e4-b9b8-fc468c81e9a6.jpg?1",
             "name": "Managorger Hydra",
             "text": "",
             "colours": [
@@ -10887,7 +10887,7 @@
         },
         {
             "id": "10bf674b-15af-5caf-a0d9-21210306cd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd9868-f0c5-452c-9619-a8f3bbf5ea69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd9868-f0c5-452c-9619-a8f3bbf5ea69.jpg?1",
             "name": "Pathbreaker Ibex",
             "text": "",
             "colours": [
@@ -10921,7 +10921,7 @@
         },
         {
             "id": "9aca87f9-ef27-5b03-ae55-37383b1e50d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1a7802-92bd-401d-a1a6-705c398359bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1a7802-92bd-401d-a1a6-705c398359bb.jpg?1",
             "name": "Temur Sabertooth",
             "text": "",
             "colours": [
@@ -10955,7 +10955,7 @@
         },
         {
             "id": "08cd6f82-d502-5380-b06b-642d0bbdd471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f94220-9565-429b-af8b-1d4348ae7a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f94220-9565-429b-af8b-1d4348ae7a1a.jpg?1",
             "name": "Winding Constrictor",
             "text": "",
             "colours": [
@@ -10991,7 +10991,7 @@
         },
         {
             "id": "2909deb9-8389-516a-9cb9-9b0339a29883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07af73d7-5d8e-4c64-91f0-1ecc35b57024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07af73d7-5d8e-4c64-91f0-1ecc35b57024.jpg?1",
             "name": "Unbreakable Formation",
             "text": "",
             "colours": [
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "3ebd4cf4-f0ef-53ab-ab1f-6d1ddb5ad842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460aebc5-6150-4927-8d92-72bad788be42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460aebc5-6150-4927-8d92-72bad788be42.jpg?1",
             "name": "Whir of Invention",
             "text": "",
             "colours": [
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "ddc6e0d4-1f13-5599-ae9f-f1c156c4d4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed96b05d-b2ca-4c8f-969b-cac9b4562fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed96b05d-b2ca-4c8f-969b-cac9b4562fab.jpg?1",
             "name": "Hero's Downfall",
             "text": "",
             "colours": [
@@ -11087,7 +11087,7 @@
         },
         {
             "id": "11f18985-2a4d-5a26-9a7b-ca1fd603ab16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1ebfa2-7e23-48a3-a9bc-59a24a2c1ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1ebfa2-7e23-48a3-a9bc-59a24a2c1ed7.jpg?1",
             "name": "Impact Tremors",
             "text": "",
             "colours": [
@@ -11119,7 +11119,7 @@
         },
         {
             "id": "72b0ed72-dd5e-5c99-bbe3-c73dd3403bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1611b15e-3d33-4fc5-89c7-5bfd6b380cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1611b15e-3d33-4fc5-89c7-5bfd6b380cef.jpg?1",
             "name": "Primal Vigor",
             "text": "",
             "colours": [
@@ -11153,7 +11153,7 @@
         },
         {
             "id": "d21e003d-f4b2-5cdb-add7-bf68a523f3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad783ed-69b9-48b5-9610-4fa4d8f9a6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad783ed-69b9-48b5-9610-4fa4d8f9a6e6.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -11183,7 +11183,7 @@
         },
         {
             "id": "eb149e90-52c6-55f4-867d-d2676444a538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd334816-f058-4296-b1c3-924f22e91820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd334816-f058-4296-b1c3-924f22e91820.jpg?1",
             "name": "Fleet Swallower",
             "text": "",
             "colours": [
@@ -11217,7 +11217,7 @@
         },
         {
             "id": "07f05df5-c7aa-50e4-9843-a6b8690f5ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05441a9-9603-4a35-90cc-85e24eef09b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05441a9-9603-4a35-90cc-85e24eef09b8.jpg?1",
             "name": "Goblin Trashmaster",
             "text": "",
             "colours": [
@@ -11252,7 +11252,7 @@
         },
         {
             "id": "9c5da468-e611-5dc3-a4fd-8c3e13681004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3af587-d08d-4ae0-9599-390ade85c735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3af587-d08d-4ae0-9599-390ade85c735.jpg?1",
             "name": "Ilharg, the Raze-Boar",
             "text": "",
             "colours": [
@@ -11289,7 +11289,7 @@
         },
         {
             "id": "8eacd2f7-8f4e-5a91-b8b2-5b096a4771d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88269739-8a38-4f75-a53e-4b4ce70f2aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88269739-8a38-4f75-a53e-4b4ce70f2aef.jpg?1",
             "name": "Protean Hulk",
             "text": "",
             "colours": [
@@ -11323,7 +11323,7 @@
         },
         {
             "id": "1532e682-9597-5a1b-87ec-0671d4e453b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c7f7-8022-4457-9a8a-6b87ff3348b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c7f7-8022-4457-9a8a-6b87ff3348b0.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "efe33cfc-84e7-5229-a54a-4ef5f28e57e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03da66e3-a369-4433-a2b8-8625403d34b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03da66e3-a369-4433-a2b8-8625403d34b0.jpg?1",
             "name": "Dismember",
             "text": "",
             "colours": [
@@ -11398,7 +11398,7 @@
         },
         {
             "id": "5d5b41b0-aa8b-5d2c-a698-b62149bbb3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a184a4a-2c8c-4a10-9b26-a174859fa1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a184a4a-2c8c-4a10-9b26-a174859fa1e8.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -11430,7 +11430,7 @@
         },
         {
             "id": "f3d01750-3ff4-5741-ab04-80c751d78c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23446e7-8573-4e8e-8698-e4ca62424416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23446e7-8573-4e8e-8698-e4ca62424416.jpg?1",
             "name": "Beast Within",
             "text": "",
             "colours": [
@@ -11462,7 +11462,7 @@
         },
         {
             "id": "939390c3-307a-5fbe-bcf0-ebe8ae2aeaff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b5c132-c4d0-42df-bc5b-e7fe0a31a9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b5c132-c4d0-42df-bc5b-e7fe0a31a9e7.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "",
             "colours": [],
@@ -11490,7 +11490,7 @@
         },
         {
             "id": "33a40f1c-b396-5e2b-8d96-ad20db458479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ed0c75-0ec3-4f06-8c37-750fefb8136d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ed0c75-0ec3-4f06-8c37-750fefb8136d.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -11530,7 +11530,7 @@
         },
         {
             "id": "52040343-74a0-577e-87c4-59194a9cc312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af8122a-2943-4507-a93a-564fe63a035b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af8122a-2943-4507-a93a-564fe63a035b.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -11570,7 +11570,7 @@
         },
         {
             "id": "3f21f389-bb00-5e91-99e5-4fd269802b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d95c5-278f-4ad5-99ea-9fcf85520de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d95c5-278f-4ad5-99ea-9fcf85520de2.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -11610,7 +11610,7 @@
         },
         {
             "id": "8dee5491-eee5-514e-8120-412c9986fb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23fb3767-544d-4ae7-b7c4-af0944a0281b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23fb3767-544d-4ae7-b7c4-af0944a0281b.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -11650,7 +11650,7 @@
         },
         {
             "id": "c61de754-15e7-59ac-8a6b-1dd9c69e5dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9a891d-a2c6-418d-a6bd-be2353b3e980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9a891d-a2c6-418d-a6bd-be2353b3e980.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -11690,7 +11690,7 @@
         },
         {
             "id": "6c7ee803-90f7-5781-818b-1127a1dd11b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1aa91-ec97-4fe8-b4b1-a213f050f956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1aa91-ec97-4fe8-b4b1-a213f050f956.jpg?1",
             "name": "Aether Gust",
             "text": "",
             "colours": [
@@ -11722,7 +11722,7 @@
         },
         {
             "id": "cdb44c69-b167-50ec-8837-9838960001bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35ec9da-f38b-4b7f-9eb5-090ca7755668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35ec9da-f38b-4b7f-9eb5-090ca7755668.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "28a9407e-89db-5d7c-a108-5150a56ec95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc6b89-c428-4b7a-ab9c-58323b2d0aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc6b89-c428-4b7a-ab9c-58323b2d0aac.jpg?1",
             "name": "Fabricate",
             "text": "",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "3b54bba0-25fa-523e-beeb-d28d6b5b73c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0983f89c-d6ae-479e-aa2f-b2a0c2997608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0983f89c-d6ae-479e-aa2f-b2a0c2997608.jpg?1",
             "name": "Fact or Fiction",
             "text": "",
             "colours": [
@@ -11823,7 +11823,7 @@
         },
         {
             "id": "5ec27fa6-d1f8-5095-88db-c5ffa2c9cb9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0095386-6e4d-432f-a5ac-7407ffaf7938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0095386-6e4d-432f-a5ac-7407ffaf7938.jpg?1",
             "name": "Mystical Tutor",
             "text": "",
             "colours": [
@@ -11855,7 +11855,7 @@
         },
         {
             "id": "d465de12-cc8b-58a8-aa5f-3b9d2b13adca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbaa2f0-9ad0-4ce2-8ce6-359d01bd524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbaa2f0-9ad0-4ce2-8ce6-359d01bd524c.jpg?1",
             "name": "Arvinox, the Mind Flail",
             "text": "",
             "colours": [
@@ -11892,7 +11892,7 @@
         },
         {
             "id": "8ce60f81-4d78-5fb5-95fb-d0381484fd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49414b93-55c5-4eea-8699-01bad0b9a7ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49414b93-55c5-4eea-8699-01bad0b9a7ac.jpg?1",
             "name": "Sophina, Spearsage Deserter",
             "text": "",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "2c53909f-3730-5fef-abeb-60475028ffa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f1182-8ab2-4ae6-a38c-13cdbdb1fe43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f1182-8ab2-4ae6-a38c-13cdbdb1fe43.jpg?1",
             "name": "Hargilde, Kindly Runechanter",
             "text": "",
             "colours": [
@@ -11969,7 +11969,7 @@
         },
         {
             "id": "35422858-fe8b-574c-8149-c0f44968fa53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1e8fc-77b4-409d-9fc4-7bc6f6ae3e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1e8fc-77b4-409d-9fc4-7bc6f6ae3e26.jpg?1",
             "name": "Cecily, Haunted Mage",
             "text": "",
             "colours": [
@@ -12010,7 +12010,7 @@
         },
         {
             "id": "aef74d80-a1d8-5e80-97ca-65be6322c3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09edfe-5bef-430e-853d-a6b4b612805a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09edfe-5bef-430e-853d-a6b4b612805a.jpg?1",
             "name": "Bjorna, Nightfall Alchemist",
             "text": "",
             "colours": [
@@ -12048,7 +12048,7 @@
         },
         {
             "id": "a72058aa-a7f3-56db-9397-41f0a8c0742a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb04ab1-2a74-432f-b3d3-d4f5b2534066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb04ab1-2a74-432f-b3d3-d4f5b2534066.jpg?1",
             "name": "Elmar, Ulvenwald Informant",
             "text": "",
             "colours": [
@@ -12086,7 +12086,7 @@
         },
         {
             "id": "08d9e716-2384-5fb9-8122-0d42ad869bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142edc65-232b-492e-805a-6905f13e9e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142edc65-232b-492e-805a-6905f13e9e6d.jpg?1",
             "name": "Othelm, Sigardian Outcast",
             "text": "",
             "colours": [
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "361e3a5d-681f-5d5a-bfcd-8b4ef6eb52c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a4af68-6e5e-4b44-9c1c-25ecdbd555b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a4af68-6e5e-4b44-9c1c-25ecdbd555b5.jpg?1",
             "name": "Wernog, Rider's Chaplain",
             "text": "",
             "colours": [
@@ -12162,7 +12162,7 @@
         },
         {
             "id": "4aa7f721-c282-5e8a-bcb7-747efbfc8781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d6b87f-c750-4ed1-8da6-261bb955d3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d6b87f-c750-4ed1-8da6-261bb955d3b9.jpg?1",
             "name": "Moorland Haunt",
             "text": "",
             "colours": [],
@@ -12193,7 +12193,7 @@
         },
         {
             "id": "2e2292e6-d0cc-5a1f-8b24-bb264dcbf6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0c1d5d-767d-4d64-81b0-0d0fb09d6b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0c1d5d-767d-4d64-81b0-0d0fb09d6b31.jpg?1",
             "name": "Vault of the Archangel",
             "text": "",
             "colours": [],
@@ -12224,7 +12224,7 @@
         },
         {
             "id": "5719a2e1-990f-531c-b465-ba12f87d37b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7819a326-1d07-4194-a1eb-01d4081ed192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7819a326-1d07-4194-a1eb-01d4081ed192.jpg?1",
             "name": "Nephalia Drownyard",
             "text": "",
             "colours": [],
@@ -12255,7 +12255,7 @@
         },
         {
             "id": "d6f309d2-ea33-5250-b2e0-9baf7c2ab1aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034ad345-96f6-40aa-b610-1eaab258fb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034ad345-96f6-40aa-b610-1eaab258fb38.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -12286,7 +12286,7 @@
         },
         {
             "id": "64b7b938-8cdf-5940-a31d-ce98a9094fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf002ecb-9afb-41b4-a6b8-327558ac947c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf002ecb-9afb-41b4-a6b8-327558ac947c.jpg?1",
             "name": "Stensia Bloodhall",
             "text": "",
             "colours": [],
@@ -12317,7 +12317,7 @@
         },
         {
             "id": "69eff3fe-1933-5dfb-adf6-dcb20fb83c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f6d2-a339-4598-af5f-b526fbe276a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f6d2-a339-4598-af5f-b526fbe276a2.jpg?1",
             "name": "Grim Backwoods",
             "text": "",
             "colours": [],
@@ -12348,7 +12348,7 @@
         },
         {
             "id": "ff729c4e-844a-5320-a917-11505c06e512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4e64b-e978-49ba-8e3e-4792f975fb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4e64b-e978-49ba-8e3e-4792f975fb61.jpg?1",
             "name": "Kessig Wolf Run",
             "text": "",
             "colours": [],
@@ -12379,7 +12379,7 @@
         },
         {
             "id": "18c9fd90-69a0-5a93-a66b-e8fb7f0d3250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed9a072-fd0b-45f2-8962-9d601840c7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed9a072-fd0b-45f2-8962-9d601840c7c3.jpg?1",
             "name": "Slayers' Stronghold",
             "text": "",
             "colours": [],
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "ba813a06-9d53-5ad4-b8f9-ac448a7a9b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd782cf-414c-4340-9431-4b7809c8c04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd782cf-414c-4340-9431-4b7809c8c04e.jpg?1",
             "name": "Gavony Township",
             "text": "",
             "colours": [],
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "928d334b-927c-59c1-ba87-161b9f320229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6cf714-29b9-4c06-9412-d958a5ffbd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6cf714-29b9-4c06-9412-d958a5ffbd66.jpg?1",
             "name": "Alchemist's Refuge",
             "text": "",
             "colours": [],
@@ -12472,7 +12472,7 @@
         },
         {
             "id": "77387e7a-bd4b-5b7f-ae21-401b8a9509f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673e184-2b58-44ef-bb68-bd3d139ed0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673e184-2b58-44ef-bb68-bd3d139ed0ba.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "0841d85c-386c-58ec-8103-f3a084391f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f64a6-ba1b-4cd9-8cf9-15f394f9524b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f64a6-ba1b-4cd9-8cf9-15f394f9524b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12606,7 +12606,7 @@
         },
         {
             "id": "19f57223-55bb-5077-a63e-f6d2f3d4baf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f5c55d-09e5-49dd-906c-0f48a79b4c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f5c55d-09e5-49dd-906c-0f48a79b4c15.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12670,7 +12670,7 @@
         },
         {
             "id": "2778e3b9-6dd9-573c-94a3-c011677cb654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96549393-9607-43c8-91de-905462cbcb19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96549393-9607-43c8-91de-905462cbcb19.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12744,7 +12744,7 @@
         },
         {
             "id": "42d0c6e8-9c33-59a8-ac6f-ac2d78e6ed17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f57347-7206-4a2f-a41b-0612d456cd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f57347-7206-4a2f-a41b-0612d456cd30.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "562d772a-96c5-5217-b70f-fe1adb24fa32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68357502-cf23-4bf6-ab4e-371428e540d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68357502-cf23-4bf6-ab4e-371428e540d0.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -12846,7 +12846,7 @@
         },
         {
             "id": "bc4b85ab-5143-530f-a59c-ffad337dac77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be03def-6e43-4420-8380-8f4e5cf39500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be03def-6e43-4420-8380-8f4e5cf39500.jpg?1",
             "name": "Grim Tutor",
             "text": "",
             "colours": [
@@ -12879,7 +12879,7 @@
         },
         {
             "id": "16a23e53-07cd-516c-8efc-6d0b00466151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaa4c77-0a5c-4b2f-aa22-bfce9cce99f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaa4c77-0a5c-4b2f-aa22-bfce9cce99f9.jpg?1",
             "name": "Blood Moon",
             "text": "",
             "colours": [
@@ -12910,7 +12910,7 @@
         },
         {
             "id": "c19342af-7bfb-5f6b-9b03-f84c3ff2ca4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg?1",
             "name": "Cut // Ribbons",
             "text": "",
             "colours": [
@@ -12942,7 +12942,7 @@
         },
         {
             "id": "ee40c8c1-5b59-5d82-ba67-a1125fae470b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg?1",
             "name": "Cut // Ribbons",
             "text": "",
             "colours": [
@@ -12974,7 +12974,7 @@
         },
         {
             "id": "c11a1f79-9ec8-5bb1-a25a-602979e52f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb88b2-5dc6-43de-8a38-1f8982ed395a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb88b2-5dc6-43de-8a38-1f8982ed395a.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "f5dfdfe2-543d-5eda-bf60-52d493baa285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d4e224-e630-4696-85ef-cf42f9d03ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d4e224-e630-4696-85ef-cf42f9d03ca5.jpg?1",
             "name": "Generous Gift",
             "text": "",
             "colours": [
@@ -13033,7 +13033,7 @@
         },
         {
             "id": "5cddefd7-aeca-5ef8-a454-899e882a3ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb7fe8e-e348-4bf9-aa71-65f0675147e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb7fe8e-e348-4bf9-aa71-65f0675147e4.jpg?1",
             "name": "Chain Lightning",
             "text": "",
             "colours": [
@@ -13065,7 +13065,7 @@
         },
         {
             "id": "6bb38ab9-44b2-56f0-a0e0-382d7c744005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18381713-3f20-4d5d-8cd4-f3d1fdfad4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18381713-3f20-4d5d-8cd4-f3d1fdfad4f4.jpg?1",
             "name": "Kodama's Reach",
             "text": "",
             "colours": [
@@ -13099,7 +13099,7 @@
         },
         {
             "id": "affbbba1-36b4-56a8-b6fa-4a41117dcb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01b0d7f-5184-4651-a83d-14c27c8bb1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01b0d7f-5184-4651-a83d-14c27c8bb1bc.jpg?1",
             "name": "Heirloom Blade",
             "text": "",
             "colours": [],
@@ -13129,7 +13129,7 @@
         },
         {
             "id": "16501944-cdc8-59b0-986a-b9b159b4b317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad7ebb-4994-49f1-a211-90bdccb6a91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad7ebb-4994-49f1-a211-90bdccb6a91b.jpg?1",
             "name": "Mulldrifter",
             "text": "",
             "colours": [
@@ -13165,7 +13165,7 @@
         },
         {
             "id": "751cf6f9-6f2c-5c89-b0ac-94d542131245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcae2f-fcf3-4dfd-8818-606d16a03beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcae2f-fcf3-4dfd-8818-606d16a03beb.jpg?1",
             "name": "Mulldrifter",
             "text": "",
             "colours": [
@@ -13201,7 +13201,7 @@
         },
         {
             "id": "b2bc2b80-c5bd-5c26-9e3c-0937576bdc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2750bee4-7dfa-4128-989c-5f81af1b322a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2750bee4-7dfa-4128-989c-5f81af1b322a.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "",
             "colours": [
@@ -13237,7 +13237,7 @@
         },
         {
             "id": "af53aaf0-b345-59dd-8e1b-cd2556b3c109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640be32d-dcc8-408a-b8a6-077472f1e70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640be32d-dcc8-408a-b8a6-077472f1e70b.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "",
             "colours": [
@@ -13273,7 +13273,7 @@
         },
         {
             "id": "787a7c9f-8531-56f4-86f7-3cb5e4616211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482c454-425e-4d83-a8db-9b1c2d50403c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482c454-425e-4d83-a8db-9b1c2d50403c.jpg?1",
             "name": "Metalwork Colossus",
             "text": "",
             "colours": [],
@@ -13306,7 +13306,7 @@
         },
         {
             "id": "cfd0a8bb-3663-55bf-9592-7ad8c283d5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91a198-49f9-4685-b03f-6f9513bddfd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91a198-49f9-4685-b03f-6f9513bddfd7.jpg?1",
             "name": "Metalwork Colossus",
             "text": "",
             "colours": [],
@@ -13339,7 +13339,7 @@
         },
         {
             "id": "9f9c49af-02d5-5219-8827-98b857cfae3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "c765d1e2-2e30-50fb-af77-a6b128061a05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13415,7 +13415,7 @@
         },
         {
             "id": "2ef3715f-fcb9-5385-a161-962c83ae5bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "2f7b07c3-fc95-5e5e-a63e-393d685b15ac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13491,7 +13491,7 @@
         },
         {
             "id": "dd0c9dde-abc3-5a05-a7b7-71c210b33a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13530,7 +13530,7 @@
         },
         {
             "id": "3b069438-1548-5596-81bb-d187284bf9df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13569,7 +13569,7 @@
         },
         {
             "id": "24c022f9-c60c-5d61-828b-aa21771073c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13608,7 +13608,7 @@
         },
         {
             "id": "ab00064b-f3a1-54aa-8311-a561d83ab29e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13647,7 +13647,7 @@
         },
         {
             "id": "4df6612d-7a84-54a5-8fc0-00438fb3e1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1",
             "name": "Propaganda // Propaganda",
             "text": "",
             "colours": [
@@ -13678,7 +13678,7 @@
         },
         {
             "id": "4116e76a-bf4c-5dba-8c08-c0daa02f961c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1",
             "name": "Propaganda // Propaganda",
             "text": "",
             "colours": [
@@ -13709,7 +13709,7 @@
         },
         {
             "id": "5e0c6939-8a95-5410-a164-bce4abf08fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg?1",
             "name": "Stitch in Time // Stitch in Time",
             "text": "",
             "colours": [
@@ -13742,7 +13742,7 @@
         },
         {
             "id": "1ca6407c-0152-5291-95e6-ec7e71ae7510",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg?1",
             "name": "Stitch in Time // Stitch in Time",
             "text": "",
             "colours": [
@@ -13775,7 +13775,7 @@
         },
         {
             "id": "3a6203a3-4a97-50a1-8662-8788443b68d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg?1",
             "name": "Krark's Thumb // Krark's Thumb",
             "text": "",
             "colours": [],
@@ -13804,7 +13804,7 @@
         },
         {
             "id": "f2cc62d6-6d1d-52e3-b34f-35996052abe7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg?1",
             "name": "Krark's Thumb // Krark's Thumb",
             "text": "",
             "colours": [],
@@ -13833,7 +13833,7 @@
         },
         {
             "id": "25e983e0-835a-584a-bf31-687ea6a382d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6079aea9-145a-445d-a00f-1c0f4018a529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6079aea9-145a-445d-a00f-1c0f4018a529.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13897,7 +13897,7 @@
         },
         {
             "id": "4620a669-fd13-5326-9b14-2dfdee0d19e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e306586a-427f-45b7-9e3b-cd9157cec07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e306586a-427f-45b7-9e3b-cd9157cec07f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13962,7 +13962,7 @@
         },
         {
             "id": "aa01eb1a-a9fe-5e48-94fe-980eccbefb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4555e99-7f95-4c76-914f-0a42d49975cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4555e99-7f95-4c76-914f-0a42d49975cd.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "f7d14913-c5f4-5140-87f4-3ec6f4445421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa08a961-cd6a-403e-a098-1e7f716262bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa08a961-cd6a-403e-a098-1e7f716262bb.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14101,7 +14101,7 @@
         },
         {
             "id": "553966c4-8794-5d81-b973-84a6b8242ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249104ba-65fc-42d6-ad8b-d97640545d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249104ba-65fc-42d6-ad8b-d97640545d89.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14166,7 +14166,7 @@
         },
         {
             "id": "f0a54aac-613e-57a8-b0e7-98aa3f0ac3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4abaf5-3bc0-464c-b31d-d579d0a9128d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4abaf5-3bc0-464c-b31d-d579d0a9128d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14240,7 +14240,7 @@
         },
         {
             "id": "d5f1d387-0f81-5f43-a7c6-27bdeb2397f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb59eef-385b-4a9d-b70c-952387b30310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb59eef-385b-4a9d-b70c-952387b30310.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14309,7 +14309,7 @@
         },
         {
             "id": "e48be9d7-a9b5-5f46-8c58-da5100a9c282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771294b5-c1a1-4456-8399-1391bc5ba40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771294b5-c1a1-4456-8399-1391bc5ba40e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14378,7 +14378,7 @@
         },
         {
             "id": "5a28c76c-14de-5f99-a9c0-cdd223845235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3352b213-4ebc-4b4c-ae75-f256fbb33d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3352b213-4ebc-4b4c-ae75-f256fbb33d95.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14443,7 +14443,7 @@
         },
         {
             "id": "a1dbd57b-3a73-5ec5-9e2d-d9bc0efeb2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825f809d-fb64-4101-a985-c3533f26a345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825f809d-fb64-4101-a985-c3533f26a345.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "d0e442c7-718e-5a12-b48f-8a64c382734c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c331d-56c6-47d9-bd52-30a92b6415b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c331d-56c6-47d9-bd52-30a92b6415b3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14576,7 +14576,7 @@
         },
         {
             "id": "d37f80d8-ceca-5252-aa91-02d8e0b54fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c5d09-6f93-44f5-894d-4c7be40bb006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c5d09-6f93-44f5-894d-4c7be40bb006.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14641,7 +14641,7 @@
         },
         {
             "id": "19654c6d-50af-5700-a3da-30555eeddf18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284b87f-d249-43c2-a198-dd03e961bedb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284b87f-d249-43c2-a198-dd03e961bedb.jpg?1",
             "name": "Tamiyo, the Moon Sage",
             "text": "",
             "colours": [
@@ -14677,7 +14677,7 @@
         },
         {
             "id": "ecf324eb-c500-557e-a0dd-f14eb4e610f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbfc1b2-2407-4079-a847-6bb6b9a2c9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbfc1b2-2407-4079-a847-6bb6b9a2c9de.jpg?1",
             "name": "Ajani, Mentor of Heroes",
             "text": "",
             "colours": [
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "ccc4f2e0-68ae-5f0e-bc32-62d79d5cf74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba48c787-a444-4e15-bab7-39994a6e23e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba48c787-a444-4e15-bab7-39994a6e23e7.jpg?1",
             "name": "Angrath, the Flame-Chained",
             "text": "",
             "colours": [
@@ -14753,7 +14753,7 @@
         },
         {
             "id": "cedab658-2a9c-57d7-952d-fe0bf9f3e6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f76d4-a2b3-40e5-b6a7-b27c42caf615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f76d4-a2b3-40e5-b6a7-b27c42caf615.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "",
             "colours": [
@@ -14793,7 +14793,7 @@
         },
         {
             "id": "62da8de4-31c6-5c2d-af7e-3fd3330800f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25c3609-a200-4532-9df8-8e92c24544bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25c3609-a200-4532-9df8-8e92c24544bc.jpg?1",
             "name": "Sorin, Grim Nemesis",
             "text": "",
             "colours": [
@@ -14831,7 +14831,7 @@
         },
         {
             "id": "db91c9d5-7c82-5ddf-8d7e-d652c030aa6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252e55c-03ee-44f7-ae07-067ace8e49ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252e55c-03ee-44f7-ae07-067ace8e49ed.jpg?1",
             "name": "Peek",
             "text": "",
             "colours": [
@@ -14862,7 +14862,7 @@
         },
         {
             "id": "672a75e6-0457-5769-80cd-f4d56f03412e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ee3699-7fbb-4662-ba36-a1a7e19d161d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ee3699-7fbb-4662-ba36-a1a7e19d161d.jpg?1",
             "name": "Greed",
             "text": "",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "b4fe3da6-e621-510e-a601-fef6f1776bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2433b8e1-749b-4086-8819-e45e65e9df7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2433b8e1-749b-4086-8819-e45e65e9df7c.jpg?1",
             "name": "Curiosity",
             "text": "",
             "colours": [
@@ -14926,7 +14926,7 @@
         },
         {
             "id": "2a2fbe2d-2fef-5664-9f51-77b8c605deb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00576634-29da-4f9d-bcbb-07a2f80ceba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00576634-29da-4f9d-bcbb-07a2f80ceba5.jpg?1",
             "name": "Vandalblast",
             "text": "",
             "colours": [
@@ -14957,7 +14957,7 @@
         },
         {
             "id": "8d5a1027-5b4a-5ad6-a1ed-e26cd72a56f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e2a53d-eb33-42b3-a5fd-60fb232e99c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e2a53d-eb33-42b3-a5fd-60fb232e99c7.jpg?1",
             "name": "Last Chance",
             "text": "",
             "colours": [
@@ -14988,7 +14988,7 @@
         },
         {
             "id": "6823b456-723d-5391-b904-abc4b5fc4ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf76c6a4-d6e8-4d50-b65f-020252f7b659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf76c6a4-d6e8-4d50-b65f-020252f7b659.jpg?1",
             "name": "Mystic Remora",
             "text": "",
             "colours": [
@@ -15020,7 +15020,7 @@
         },
         {
             "id": "e3dc1ab1-1520-543e-b54f-d567ac68f90b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d268b09-acc7-474d-86be-537d6449755c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d268b09-acc7-474d-86be-537d6449755c.jpg?1",
             "name": "Retreat to Coralhelm",
             "text": "",
             "colours": [
@@ -15052,7 +15052,7 @@
         },
         {
             "id": "5de5d492-17e5-5c9e-bbb9-0fe601b52361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30641539-de35-46c7-99ab-e4478afe064c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30641539-de35-46c7-99ab-e4478afe064c.jpg?1",
             "name": "Burgeoning",
             "text": "",
             "colours": [
@@ -15084,7 +15084,7 @@
         },
         {
             "id": "b11bde20-3888-597e-99d4-96d566a7ad52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04c8a2-dcdd-4e87-85d3-9841561cdcdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04c8a2-dcdd-4e87-85d3-9841561cdcdf.jpg?1",
             "name": "Utopia Sprawl",
             "text": "",
             "colours": [
@@ -15118,7 +15118,7 @@
         },
         {
             "id": "6155bd41-fed4-56b5-b02f-bb4131804766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33ff8fc-b2b7-4cd9-8724-b926459b519d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33ff8fc-b2b7-4cd9-8724-b926459b519d.jpg?1",
             "name": "Brain Freeze",
             "text": "",
             "colours": [
@@ -15150,7 +15150,7 @@
         },
         {
             "id": "d35c69d1-1b1f-5b8f-badf-6597596d223b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0cb4bc-c2de-4d4a-8daa-df68350239a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0cb4bc-c2de-4d4a-8daa-df68350239a9.jpg?1",
             "name": "Bribery",
             "text": "",
             "colours": [
@@ -15184,7 +15184,7 @@
         },
         {
             "id": "8a7c4ff8-d2d5-5cdb-b42b-37d3d6a197d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d53b6d-edce-47eb-84a9-528cd60f18e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d53b6d-edce-47eb-84a9-528cd60f18e2.jpg?1",
             "name": "Snap",
             "text": "",
             "colours": [
@@ -15216,7 +15216,7 @@
         },
         {
             "id": "5be2c85f-cdf8-5c34-afd5-1e6f764f5145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a28148-7f9a-4a96-a878-fc15476c5820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a28148-7f9a-4a96-a878-fc15476c5820.jpg?1",
             "name": "Unmask",
             "text": "",
             "colours": [
@@ -15248,7 +15248,7 @@
         },
         {
             "id": "b20569cb-2fc1-5bdc-b0b7-0109e4eb4130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10be9a82-4008-45ae-a739-fdee95e39619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10be9a82-4008-45ae-a739-fdee95e39619.jpg?1",
             "name": "Shadow of Doubt",
             "text": "",
             "colours": [
@@ -15282,7 +15282,7 @@
         },
         {
             "id": "563874e8-6788-5630-9880-dc55fe95dffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71446bd-08f2-41fe-ae44-db44814c8afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71446bd-08f2-41fe-ae44-db44814c8afb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15351,7 +15351,7 @@
         },
         {
             "id": "532d0d30-ff55-580b-bac1-270c192480f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd081bbf-8e82-405c-a522-f826fa0a6e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd081bbf-8e82-405c-a522-f826fa0a6e1d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15416,7 +15416,7 @@
         },
         {
             "id": "939e2ffe-f4ff-5be9-88fd-a3132b5dbea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085b4641-62fb-4820-aded-ccc9403d319e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085b4641-62fb-4820-aded-ccc9403d319e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15480,7 +15480,7 @@
         },
         {
             "id": "de2b8c55-a7c5-58c3-9e0a-24f4b853f21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8611ec-6db3-4d29-8d3b-01e87bb38a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8611ec-6db3-4d29-8d3b-01e87bb38a55.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15554,7 +15554,7 @@
         },
         {
             "id": "db011a97-ad8a-5d78-9941-2460a8842622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5dbb-8d5e-4471-94f6-e0944cf60ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5dbb-8d5e-4471-94f6-e0944cf60ed2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15619,7 +15619,7 @@
         },
         {
             "id": "a9055e67-7638-5f60-82bc-aa6c363cd3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2c8052-f995-4a8a-b63c-dbe2e8a22498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2c8052-f995-4a8a-b63c-dbe2e8a22498.jpg?1",
             "name": "Hokori, Dust Drinker",
             "text": "",
             "colours": [
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "f526a50b-21b8-5075-b37f-97d98a215339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e26f6c-44e9-4d6f-8eb1-efdef8d04ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e26f6c-44e9-4d6f-8eb1-efdef8d04ff5.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "",
             "colours": [
@@ -15691,7 +15691,7 @@
         },
         {
             "id": "b0538a4e-d57f-5b27-937a-e64b37786284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4ab9d-91af-4cb9-90dc-b6bd6897b1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4ab9d-91af-4cb9-90dc-b6bd6897b1ed.jpg?1",
             "name": "Eidolon of the Great Revel",
             "text": "",
             "colours": [
@@ -15726,7 +15726,7 @@
         },
         {
             "id": "97ebd186-0ad6-56b1-a3f3-8894ddb7f74b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024110ee-5520-49f8-afab-54dcce87c650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024110ee-5520-49f8-afab-54dcce87c650.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "",
             "colours": [
@@ -15761,7 +15761,7 @@
         },
         {
             "id": "69184d37-e76c-5146-a967-ff1d74befabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a43d9e8-3320-4873-b322-b323c792ce5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a43d9e8-3320-4873-b322-b323c792ce5e.jpg?1",
             "name": "Ghostly Prison",
             "text": "",
             "colours": [
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "5f5a545e-9766-5ddd-bfc4-9c99e8018bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db826546-6a96-4272-b72f-d1d2be78b318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db826546-6a96-4272-b72f-d1d2be78b318.jpg?1",
             "name": "Freed from the Real",
             "text": "",
             "colours": [
@@ -15825,7 +15825,7 @@
         },
         {
             "id": "e8bb34fe-3112-5b25-ab4e-685bfb302ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca68ea1-5aad-4d08-b460-768f5a91f1fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca68ea1-5aad-4d08-b460-768f5a91f1fa.jpg?1",
             "name": "Boseiju, Who Shelters All",
             "text": "",
             "colours": [],
@@ -15854,7 +15854,7 @@
         },
         {
             "id": "1eda3486-4635-5465-969a-655e7c6f5134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d75ad-82a9-4145-ba3c-df4a86bd91d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d75ad-82a9-4145-ba3c-df4a86bd91d7.jpg?1",
             "name": "Hall of the Bandit Lord",
             "text": "",
             "colours": [],
@@ -15883,7 +15883,7 @@
         },
         {
             "id": "6d9098c8-aaa6-52ec-a801-cec430fb770f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecf013-130d-4cf3-b47e-54b5fb718878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecf013-130d-4cf3-b47e-54b5fb718878.jpg?1",
             "name": "Baldin, Century Herdmaster",
             "text": "",
             "colours": [
@@ -15920,7 +15920,7 @@
         },
         {
             "id": "563a9671-4a63-58bd-9be5-a79d33c350c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65a3a8b-ebf8-4e51-8b57-5b14e5cb7abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65a3a8b-ebf8-4e51-8b57-5b14e5cb7abb.jpg?1",
             "name": "Vikya, Scorching Stalwart",
             "text": "",
             "colours": [
@@ -15958,7 +15958,7 @@
         },
         {
             "id": "ae0c3106-c58e-5b72-b5fd-a9a091b44c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f54a1-caf1-499e-aa71-e081a4dd916d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f54a1-caf1-499e-aa71-e081a4dd916d.jpg?1",
             "name": "Aisha of Sparks and Smoke",
             "text": "",
             "colours": [
@@ -15996,7 +15996,7 @@
         },
         {
             "id": "55af0bdb-fac7-5db6-9f62-ef91fe568f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fecfd4-40c1-4ed3-bf58-22c7b98699a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fecfd4-40c1-4ed3-bf58-22c7b98699a9.jpg?1",
             "name": "The Howling Abomination",
             "text": "",
             "colours": [
@@ -16036,7 +16036,7 @@
         },
         {
             "id": "03b1d07b-70c4-511d-a77e-810d893b40d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ee4a5-c74b-46eb-b709-808ebc803757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ee4a5-c74b-46eb-b709-808ebc803757.jpg?1",
             "name": "Zethi, Arcane Blademaster",
             "text": "",
             "colours": [
@@ -16075,7 +16075,7 @@
         },
         {
             "id": "c9f07a16-4037-5894-a911-f4d2a5f581df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f32937-ca7e-407c-aa23-117b1eae9798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f32937-ca7e-407c-aa23-117b1eae9798.jpg?1",
             "name": "Tadeas, Juniper Ascendant",
             "text": "",
             "colours": [
@@ -16114,7 +16114,7 @@
         },
         {
             "id": "58ac95b5-8813-56fd-bb24-db083c0b363b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fca7f9-ed46-440f-9ea3-225440fc5be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fca7f9-ed46-440f-9ea3-225440fc5be5.jpg?1",
             "name": "Immard, the Stormcleaver",
             "text": "",
             "colours": [
@@ -16155,7 +16155,7 @@
         },
         {
             "id": "5145500a-6b46-549f-8922-6d137eb39d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9976eb70-0d39-4882-8041-a4d29527c292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9976eb70-0d39-4882-8041-a4d29527c292.jpg?1",
             "name": "Maarika, Brutal Gladiator",
             "text": "",
             "colours": [
@@ -16196,7 +16196,7 @@
         },
         {
             "id": "1a3ea672-6b59-5366-a117-1a67ee9cc050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b431fd-7a4b-4cba-b5cb-554d7813b1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b431fd-7a4b-4cba-b5cb-554d7813b1f5.jpg?1",
             "name": "Windbrisk Heights",
             "text": "",
             "colours": [],
@@ -16226,7 +16226,7 @@
         },
         {
             "id": "e47164b5-62b8-55ef-94ac-ad95c4c9b88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8a4de-02ea-4efd-873d-8d936d5b6893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8a4de-02ea-4efd-873d-8d936d5b6893.jpg?1",
             "name": "Shelldock Isle",
             "text": "",
             "colours": [],
@@ -16258,7 +16258,7 @@
         },
         {
             "id": "7013ac0b-f73b-5f67-a854-38dba4d4d394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dc73d6-a2b1-4e19-92a5-fe03d1fb3bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dc73d6-a2b1-4e19-92a5-fe03d1fb3bd2.jpg?1",
             "name": "Howltooth Hollow",
             "text": "",
             "colours": [],
@@ -16288,7 +16288,7 @@
         },
         {
             "id": "286b91b5-d000-5a04-9270-919bee430558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776ebdf-6d32-4e8b-ab7f-ea16adf352bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776ebdf-6d32-4e8b-ab7f-ea16adf352bf.jpg?1",
             "name": "Spinerock Knoll",
             "text": "",
             "colours": [],
@@ -16318,7 +16318,7 @@
         },
         {
             "id": "fb418090-eb5c-5d6f-b062-a9a6139927ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851a7251-7af5-4137-8422-159314f7351a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851a7251-7af5-4137-8422-159314f7351a.jpg?1",
             "name": "Mosswort Bridge",
             "text": "",
             "colours": [],
@@ -16348,7 +16348,7 @@
         },
         {
             "id": "980d6920-aba8-54a9-9176-08a99b12009c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3831-93d9-4995-b8c8-0d8c03fee872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3831-93d9-4995-b8c8-0d8c03fee872.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -16382,7 +16382,7 @@
         },
         {
             "id": "7e531bc8-d80e-5ec2-807d-1a57c2a73168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556f7cc0-0fcb-4022-8a2d-9aebe889c891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556f7cc0-0fcb-4022-8a2d-9aebe889c891.jpg?1",
             "name": "Dance of Many",
             "text": "",
             "colours": [
@@ -16414,7 +16414,7 @@
         },
         {
             "id": "3c0841f8-d88f-5db1-9930-c49994fad202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f9bbf2-aa52-4daf-937e-29aef8810d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f9bbf2-aa52-4daf-937e-29aef8810d35.jpg?1",
             "name": "Etherium Sculptor",
             "text": "",
             "colours": [
@@ -16450,7 +16450,7 @@
         },
         {
             "id": "bf0d421a-de15-5d3f-88a8-0285291a5ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8eb787-02e9-47d1-a0d2-bac3f7eb8ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8eb787-02e9-47d1-a0d2-bac3f7eb8ce0.jpg?1",
             "name": "Grim Tutor",
             "text": "",
             "colours": [
@@ -16484,7 +16484,7 @@
         },
         {
             "id": "742cde9b-52f0-5276-b0a2-d29365ae86d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5bf2-6032-4016-8ede-91e65c87e1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5bf2-6032-4016-8ede-91e65c87e1c2.jpg?1",
             "name": "Triumph of the Hordes",
             "text": "",
             "colours": [
@@ -16516,7 +16516,7 @@
         },
         {
             "id": "56c15695-3786-568b-a136-a5fdedf78111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daf0244-ffb9-42f3-8301-34cee7b9ae1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daf0244-ffb9-42f3-8301-34cee7b9ae1b.jpg?1",
             "name": "Smuggler's Copter",
             "text": "",
             "colours": [],
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "1c1ce283-686e-5ad0-9302-d985b02173f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593cbbd0-6ec3-4506-be0c-a229f070ce6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593cbbd0-6ec3-4506-be0c-a229f070ce6d.jpg?1",
             "name": "Planar Bridge",
             "text": "",
             "colours": [],
@@ -16576,7 +16576,7 @@
         },
         {
             "id": "30ee6225-fcf2-5632-ba9c-277415654e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715b89c9-2820-41ec-8a87-b2657ca0c7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715b89c9-2820-41ec-8a87-b2657ca0c7fe.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -16645,7 +16645,7 @@
         },
         {
             "id": "6a7a647a-3e66-5337-a3a7-43c2ac4cde01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c81707-adf0-48fd-8720-25db4d21b0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c81707-adf0-48fd-8720-25db4d21b0b2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -16710,7 +16710,7 @@
         },
         {
             "id": "f7df56ba-1197-5f9c-919a-ae113a2cf30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0520813a-fe20-4bde-8dc9-9a7add51c722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0520813a-fe20-4bde-8dc9-9a7add51c722.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -16774,7 +16774,7 @@
         },
         {
             "id": "8496effd-cd3a-59de-bbb4-274080a8be3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52248fe8-0f1b-4e3d-9024-842c921b6071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52248fe8-0f1b-4e3d-9024-842c921b6071.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16848,7 +16848,7 @@
         },
         {
             "id": "5ee92c69-36a6-5434-9249-b965500829bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940a241-4efd-42f7-a670-2c4fed4755bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940a241-4efd-42f7-a670-2c4fed4755bb.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16913,7 +16913,7 @@
         },
         {
             "id": "378eda7c-bc89-5df9-89cb-83772d671b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc19f85-7ef6-4fd2-83e5-0dbae1d80f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc19f85-7ef6-4fd2-83e5-0dbae1d80f2b.jpg?1",
             "name": "Atraxa, Praetors' Voice",
             "text": "",
             "colours": [
@@ -16956,7 +16956,7 @@
         },
         {
             "id": "b2dd308c-14ff-532d-a8e7-5bd00f0f9453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581591f0-b3c7-4fca-b4b9-1d1d098ca7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581591f0-b3c7-4fca-b4b9-1d1d098ca7fb.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "",
             "colours": [
@@ -16998,7 +16998,7 @@
         },
         {
             "id": "9dcb465c-b70f-5602-a05a-30f8382a3fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd008c4-884a-4c98-8842-8f4b35fbdf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd008c4-884a-4c98-8842-8f4b35fbdf81.jpg?1",
             "name": "Yidris, Maelstrom Wielder",
             "text": "",
             "colours": [
@@ -17040,7 +17040,7 @@
         },
         {
             "id": "63d0b867-d88f-5d66-a425-7b88ff582318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff751c7-34c9-498a-bd9f-c6b0c8a194f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff751c7-34c9-498a-bd9f-c6b0c8a194f4.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -17071,7 +17071,7 @@
         },
         {
             "id": "69f00130-e3d5-5039-803f-6dcf8247b2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afd57f-d4cb-4219-a2c7-28ed9b1abe0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afd57f-d4cb-4219-a2c7-28ed9b1abe0f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -17102,7 +17102,7 @@
         },
         {
             "id": "73351878-a198-5524-9729-4aa2f87f76f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ecd9bf-757b-4eeb-bef3-0b9ad2e86fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ecd9bf-757b-4eeb-bef3-0b9ad2e86fca.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -17133,7 +17133,7 @@
         },
         {
             "id": "8b7b55b9-2a84-56d6-baf1-b0e62908cf74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0481ee-a028-436d-a4f8-a43720d1e542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0481ee-a028-436d-a4f8-a43720d1e542.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -17164,7 +17164,7 @@
         },
         {
             "id": "4cf6c6c8-54a9-5f9d-9344-2e96ca864412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe0942-a5c9-4821-9992-19467e3a1176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe0942-a5c9-4821-9992-19467e3a1176.jpg?1",
             "name": "Sunpetal Grove",
             "text": "",
             "colours": [],
@@ -17195,7 +17195,7 @@
         },
         {
             "id": "45b88c0e-5ae5-567e-9ed5-f746ff20df7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbfddff-bf1b-49c3-a169-f45e53150a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbfddff-bf1b-49c3-a169-f45e53150a6c.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "",
             "colours": [
@@ -17232,7 +17232,7 @@
         },
         {
             "id": "122c4f95-af05-5bb5-aad9-c18ab8294c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06379f71-2125-4d9b-b0d2-b7b80451076c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06379f71-2125-4d9b-b0d2-b7b80451076c.jpg?1",
             "name": "Balthor the Defiled",
             "text": "",
             "colours": [
@@ -17269,7 +17269,7 @@
         },
         {
             "id": "66bd9fcc-2b7c-57e7-a21a-b188c22fe9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a767f185-bf9c-450a-b699-9a20bb3686c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a767f185-bf9c-450a-b699-9a20bb3686c6.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "",
             "colours": [
@@ -17308,7 +17308,7 @@
         },
         {
             "id": "398d6058-0252-5178-8743-c1ea568918ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27b8285-69f7-441e-91b0-7519f306b512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27b8285-69f7-441e-91b0-7519f306b512.jpg?1",
             "name": "Depala, Pilot Exemplar",
             "text": "",
             "colours": [
@@ -17347,7 +17347,7 @@
         },
         {
             "id": "22e6bfe2-fa7f-508a-ab9a-dea60c70f519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d354e2c-b83d-47f2-a8c4-0234ea9ef5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d354e2c-b83d-47f2-a8c4-0234ea9ef5bf.jpg?1",
             "name": "Nomad Outpost",
             "text": "",
             "colours": [],
@@ -17379,7 +17379,7 @@
         },
         {
             "id": "2231ab92-6cfb-5eca-90f9-dc2af6f9c611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c23ffd3-dcee-4b29-99f0-4502c19f0947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c23ffd3-dcee-4b29-99f0-4502c19f0947.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17444,7 +17444,7 @@
         },
         {
             "id": "832c7718-fb81-5815-8abe-a558f341c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23df4919-1a2f-489a-ad21-e8df0e2847ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23df4919-1a2f-489a-ad21-e8df0e2847ee.jpg?1",
             "name": "Concordant Crossroads",
             "text": "",
             "colours": [
@@ -17478,7 +17478,7 @@
         },
         {
             "id": "077a153d-4c5c-5357-8a19-4dc042ff47bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b58a5d-1eed-41ca-a2ea-d17763e7e22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b58a5d-1eed-41ca-a2ea-d17763e7e22d.jpg?1",
             "name": "Ghost Quarter",
             "text": "",
             "colours": [],
@@ -17508,7 +17508,7 @@
         },
         {
             "id": "72a92fa5-7e15-5d54-8e50-c12793d9fac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a28aa07-8b36-4048-9b71-dcb34b96068a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a28aa07-8b36-4048-9b71-dcb34b96068a.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -17535,7 +17535,7 @@
         },
         {
             "id": "4dc0dd58-53d9-5f57-82c8-aeeb5b99eda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ed19f-65c4-4459-9bb9-65156a62e84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ed19f-65c4-4459-9bb9-65156a62e84d.jpg?1",
             "name": "Command Beacon",
             "text": "",
             "colours": [],
@@ -17565,7 +17565,7 @@
         },
         {
             "id": "288775f3-ac12-5fda-85de-440a9bf81ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5227dec4-5015-462b-94e9-a1dda8b9de49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5227dec4-5015-462b-94e9-a1dda8b9de49.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -17596,7 +17596,7 @@
         },
         {
             "id": "0d0fc053-5833-5624-937b-38bd68b674fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570ecdd3-ad07-4445-9172-81a185a0d838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570ecdd3-ad07-4445-9172-81a185a0d838.jpg?1",
             "name": "Strip Mine",
             "text": "",
             "colours": [],
@@ -17623,7 +17623,7 @@
         },
         {
             "id": "ce7a496d-b006-53b7-8b69-d8262c3de1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a292b47-95b2-4e10-a31f-a619ed046b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a292b47-95b2-4e10-a31f-a619ed046b8e.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -17663,7 +17663,7 @@
         },
         {
             "id": "54aa7009-2467-5a59-ac8a-610667dc7520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776cb6c-548f-45a9-b605-b386c5468885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776cb6c-548f-45a9-b605-b386c5468885.jpg?1",
             "name": "Death's Shadow",
             "text": "",
             "colours": [
@@ -17697,7 +17697,7 @@
         },
         {
             "id": "80a3cdbc-6d0e-5d52-8170-d348a0e36c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9da45b-54ae-49c1-af50-8b88912c5bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9da45b-54ae-49c1-af50-8b88912c5bcd.jpg?1",
             "name": "Elvish Mystic",
             "text": "",
             "colours": [
@@ -17734,7 +17734,7 @@
         },
         {
             "id": "5e969568-0cd3-5773-b714-338ab7f87f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5a81e-1efc-46f3-b169-0422cbc8cd5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5a81e-1efc-46f3-b169-0422cbc8cd5e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17799,7 +17799,7 @@
         },
         {
             "id": "4db1b7ed-7ebc-5c79-94f1-e4bd961f0268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75192ef-5087-43ed-88bc-2dcd17793483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75192ef-5087-43ed-88bc-2dcd17793483.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -17833,7 +17833,7 @@
         },
         {
             "id": "1df90f3c-8ca1-5ffd-ba84-43e73ec44660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85474-e0e5-40cf-b0a3-a2b7da7f7000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85474-e0e5-40cf-b0a3-a2b7da7f7000.jpg?1",
             "name": "Rhystic Study",
             "text": "",
             "colours": [
@@ -17865,7 +17865,7 @@
         },
         {
             "id": "685364a7-05e3-5001-8bc8-113eeaa03705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948bd881-f926-413f-99cf-013b5761c851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948bd881-f926-413f-99cf-013b5761c851.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -17897,7 +17897,7 @@
         },
         {
             "id": "1ecdcf0d-0a2f-5cf6-b4fc-08ca628814d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20006931-eaef-4a86-8082-cf487156ef71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20006931-eaef-4a86-8082-cf487156ef71.jpg?1",
             "name": "Seize the Day",
             "text": "",
             "colours": [
@@ -17931,7 +17931,7 @@
         },
         {
             "id": "9eabc885-ed84-5e7c-97f2-11addeabd2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b631f-7b03-441a-b551-59236d79804c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b631f-7b03-441a-b551-59236d79804c.jpg?1",
             "name": "Krosan Grip",
             "text": "",
             "colours": [
@@ -17963,7 +17963,7 @@
         },
         {
             "id": "81e823e1-f931-5b53-90f8-22a1d93d0a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864fd80-baee-468e-9dc3-e650cc203b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864fd80-baee-468e-9dc3-e650cc203b23.jpg?1",
             "name": "Counterflux",
             "text": "",
             "colours": [
@@ -17997,7 +17997,7 @@
         },
         {
             "id": "89a6f0a2-4fd6-539c-9f85-f0fcb4b70513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186a57f5-5806-4373-90a6-0da950a11054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186a57f5-5806-4373-90a6-0da950a11054.jpg?1",
             "name": "Thran Dynamo",
             "text": "",
             "colours": [],
@@ -18025,7 +18025,7 @@
         },
         {
             "id": "c89dbb21-eb43-58d7-8e21-0675a676d103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37dd1c-27f6-409d-932e-56520a65791a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37dd1c-27f6-409d-932e-56520a65791a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18094,7 +18094,7 @@
         },
         {
             "id": "9375a92c-10e1-5833-ae66-b490cd7bb926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31915934-1e12-49ad-a745-30e1106b4eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31915934-1e12-49ad-a745-30e1106b4eff.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18159,7 +18159,7 @@
         },
         {
             "id": "731a07a7-c749-58a7-972c-9a628d490977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa4980a-dcd8-48e0-aca8-ef1590f51c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa4980a-dcd8-48e0-aca8-ef1590f51c10.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -18223,7 +18223,7 @@
         },
         {
             "id": "ce8cbf0c-2694-5ada-87b3-d11c591506b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5687c7d1-4794-4132-9ca2-b039905882a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5687c7d1-4794-4132-9ca2-b039905882a3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -18297,7 +18297,7 @@
         },
         {
             "id": "b3e076dc-319b-57f6-bc44-7b5de877d5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9fe02-124c-4d5c-8526-a763272e05f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9fe02-124c-4d5c-8526-a763272e05f4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -18362,7 +18362,7 @@
         },
         {
             "id": "8c49521d-944f-5456-a54b-8e0b61854e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf75f895-3481-4c21-a85f-c819613bccc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf75f895-3481-4c21-a85f-c819613bccc3.jpg?1",
             "name": "Akroma, Angel of Wrath",
             "text": "",
             "colours": [
@@ -18398,7 +18398,7 @@
         },
         {
             "id": "179954f3-675b-5575-bbcd-c70a09400695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39059423-c4f6-4371-b530-48cdc36e513f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39059423-c4f6-4371-b530-48cdc36e513f.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "",
             "colours": [
@@ -18435,7 +18435,7 @@
         },
         {
             "id": "db15cb3f-5362-543b-9c15-5a166202eea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba320b49-5f1a-4487-8d75-504c534cf522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba320b49-5f1a-4487-8d75-504c534cf522.jpg?1",
             "name": "Glissa Sunseeker",
             "text": "",
             "colours": [
@@ -18472,7 +18472,7 @@
         },
         {
             "id": "7d2f6b02-ead9-51c1-9b1d-b03ad9f6f8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f860fcf-eda1-4a83-9be7-80b7c34fff94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f860fcf-eda1-4a83-9be7-80b7c34fff94.jpg?1",
             "name": "Olivia, Mobilized for War",
             "text": "",
             "colours": [
@@ -18513,7 +18513,7 @@
         },
         {
             "id": "b67b5795-19dc-5240-bde6-4d3a98a7a13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9fe41f-c81d-439c-ae40-72312036678a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9fe41f-c81d-439c-ae40-72312036678a.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "",
             "colours": [],
@@ -18545,7 +18545,7 @@
         },
         {
             "id": "3a97762e-8bf8-5dc3-8e13-cefdae2657a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66bda12-18da-43e2-a5e2-16d2c5e4d070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66bda12-18da-43e2-a5e2-16d2c5e4d070.jpg?1",
             "name": "Primeval Titan",
             "text": "",
             "colours": [
@@ -18581,7 +18581,7 @@
         },
         {
             "id": "b943872d-f3b8-59e0-9fa1-a6df31399225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -18620,7 +18620,7 @@
         },
         {
             "id": "d85fd1dd-7593-51d9-a5bf-5ec39782408a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -18658,7 +18658,7 @@
         },
         {
             "id": "91e5908a-97d9-5ee0-83e2-4dc68c973313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94765871-5785-429b-8980-e2b1667278a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94765871-5785-429b-8980-e2b1667278a5.jpg?1",
             "name": "Platinum Angel",
             "text": "",
             "colours": [],
@@ -18689,7 +18689,7 @@
         },
         {
             "id": "15a9821e-3d6d-5d74-8952-6926d2038146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e475d2-a813-43d0-aa6b-4a16e92d7375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e475d2-a813-43d0-aa6b-4a16e92d7375.jpg?1",
             "name": "Brimaz, King of Oreskos",
             "text": "",
             "colours": [
@@ -18726,7 +18726,7 @@
         },
         {
             "id": "783e15bc-1fa7-5d82-b803-5bb39cc6604a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ff3bdd-bfd0-4cea-9493-85632b126cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ff3bdd-bfd0-4cea-9493-85632b126cf1.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "",
             "colours": [
@@ -18762,7 +18762,7 @@
         },
         {
             "id": "232b3ca7-6b40-589f-ac8e-d3197e83947b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15bebe2-ae6a-48b4-b203-5ab78996b86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15bebe2-ae6a-48b4-b203-5ab78996b86f.jpg?1",
             "name": "Queen Marchesa",
             "text": "",
             "colours": [
@@ -18805,7 +18805,7 @@
         },
         {
             "id": "47812b57-599e-5f4c-85dc-8a27a6b503ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df93b357-f1be-423a-96c3-a4ceecdeb441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df93b357-f1be-423a-96c3-a4ceecdeb441.jpg?1",
             "name": "Savra, Queen of the Golgari",
             "text": "",
             "colours": [
@@ -18844,7 +18844,7 @@
         },
         {
             "id": "8cad1462-e198-5146-bbb2-97c43f1f55bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c0968c-1377-447b-bede-5a2482d4cd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c0968c-1377-447b-bede-5a2482d4cd2b.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "",
             "colours": [],
@@ -18877,7 +18877,7 @@
         },
         {
             "id": "05336fdd-de97-5283-8a23-864d1eba50be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86395749-e85a-460a-b14d-7228030bde59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86395749-e85a-460a-b14d-7228030bde59.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "",
             "colours": [],
@@ -18910,7 +18910,7 @@
         },
         {
             "id": "baf25a2d-bccb-5498-89d5-b479217f29b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d82cf3e-b29f-4eb1-a58f-dadddc6d7ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d82cf3e-b29f-4eb1-a58f-dadddc6d7ec2.jpg?1",
             "name": "Gideon Blackblade",
             "text": "",
             "colours": [
@@ -18945,7 +18945,7 @@
         },
         {
             "id": "20b0881f-3359-53ec-864f-cd0b1469fc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8ca73-388c-429f-8c75-afb5839cfb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8ca73-388c-429f-8c75-afb5839cfb42.jpg?1",
             "name": "Teyo, the Shieldmage",
             "text": "",
             "colours": [
@@ -18980,7 +18980,7 @@
         },
         {
             "id": "6453be0d-20ab-5acf-bef2-36feafc3b932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c428225-e17f-46b8-96d4-933ad0023d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c428225-e17f-46b8-96d4-933ad0023d2a.jpg?1",
             "name": "The Wanderer",
             "text": "",
             "colours": [
@@ -19013,7 +19013,7 @@
         },
         {
             "id": "cb8780b3-7dc0-5b88-a5d9-e24ad0360098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802d126d-f56c-4990-ba85-9ecbe41f5c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802d126d-f56c-4990-ba85-9ecbe41f5c9a.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -19051,7 +19051,7 @@
         },
         {
             "id": "fef3dba0-5182-5b2c-9037-f079fd0ef4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a25476-a256-457f-a5b8-82c6919ac13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a25476-a256-457f-a5b8-82c6919ac13a.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "",
             "colours": [
@@ -19086,7 +19086,7 @@
         },
         {
             "id": "364581d5-2179-51f4-92db-e8fd6694d069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6710a1e4-299c-4ce1-afda-265d27097061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6710a1e4-299c-4ce1-afda-265d27097061.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -19124,7 +19124,7 @@
         },
         {
             "id": "3ca4fa1e-06a9-59ac-813e-b4e7a35aa58d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba61ea6-67b5-49f4-bd1d-9674337f9004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba61ea6-67b5-49f4-bd1d-9674337f9004.jpg?1",
             "name": "Davriel, Rogue Shadowmage",
             "text": "",
             "colours": [
@@ -19159,7 +19159,7 @@
         },
         {
             "id": "a060260c-3686-5a1d-9f2c-fac8fc5f6589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcf9ac-f0f7-405b-960b-ebf15b2640a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcf9ac-f0f7-405b-960b-ebf15b2640a7.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "",
             "colours": [
@@ -19194,7 +19194,7 @@
         },
         {
             "id": "e05ba1f6-9930-52d0-94b3-fa45f4c41087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9ac88-d6d4-4c20-8a3e-269d22884ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9ac88-d6d4-4c20-8a3e-269d22884ca5.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "",
             "colours": [
@@ -19229,7 +19229,7 @@
         },
         {
             "id": "fe2101a6-d415-51b3-b6a1-52fda7d4ded3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c5033c-3f25-4b31-8f4b-784d8aaf6150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c5033c-3f25-4b31-8f4b-784d8aaf6150.jpg?1",
             "name": "Chandra, Fire Artisan",
             "text": "",
             "colours": [
@@ -19264,7 +19264,7 @@
         },
         {
             "id": "1f40664a-37ae-5f9c-8592-1da87f0bf272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6c3050-965a-466c-b7a2-d190cee42bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6c3050-965a-466c-b7a2-d190cee42bdf.jpg?1",
             "name": "Jaya, Venerated Firemage",
             "text": "",
             "colours": [
@@ -19299,7 +19299,7 @@
         },
         {
             "id": "413a5fec-a916-56da-85cf-dcb7769a1ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c6d2-270e-401d-8039-328adf280389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c6d2-270e-401d-8039-328adf280389.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "",
             "colours": [
@@ -19334,7 +19334,7 @@
         },
         {
             "id": "82ecc191-7b07-566e-9ac9-3052a4a2b8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd6cc0-91b5-47ca-8f3d-c25cf26b81d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd6cc0-91b5-47ca-8f3d-c25cf26b81d7.jpg?1",
             "name": "Tibalt, Rakish Instigator",
             "text": "",
             "colours": [
@@ -19369,7 +19369,7 @@
         },
         {
             "id": "2b04625c-8f93-547d-81bd-673930c71e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792a7e8-1afd-4fe9-9a20-4131954f1983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792a7e8-1afd-4fe9-9a20-4131954f1983.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "",
             "colours": [
@@ -19404,7 +19404,7 @@
         },
         {
             "id": "76fdee6a-5612-5160-9c1c-9bb80770ad29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d78dcd4-c64c-4d10-91e2-432d24e801d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d78dcd4-c64c-4d10-91e2-432d24e801d4.jpg?1",
             "name": "Jiang Yanggu, Wildcrafter",
             "text": "",
             "colours": [
@@ -19439,7 +19439,7 @@
         },
         {
             "id": "ff52648a-1ed8-59ed-a803-5af75f4fa303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966bb2-1634-400e-9dd0-b8befda81f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966bb2-1634-400e-9dd0-b8befda81f6a.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "",
             "colours": [
@@ -19476,7 +19476,7 @@
         },
         {
             "id": "fc3bf4c5-da81-5b1f-9e1f-016fcfb8814f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9967520f-3c8e-42a2-b9dd-887714477c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9967520f-3c8e-42a2-b9dd-887714477c2d.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "",
             "colours": [
@@ -19511,7 +19511,7 @@
         },
         {
             "id": "14b61553-65c4-5d37-9621-1d9f60039ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b33e71-ef08-4aeb-bca2-a2a4a43c2e0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b33e71-ef08-4aeb-bca2-a2a4a43c2e0d.jpg?1",
             "name": "Ajani, the Greathearted",
             "text": "",
             "colours": [
@@ -19548,7 +19548,7 @@
         },
         {
             "id": "9ac26cdc-1b5e-5bf0-b1f6-0e82564f5622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd69ed9-4c33-4bb5-89a3-fd042d1daa1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd69ed9-4c33-4bb5-89a3-fd042d1daa1f.jpg?1",
             "name": "Domri, Anarch of Bolas",
             "text": "",
             "colours": [
@@ -19585,7 +19585,7 @@
         },
         {
             "id": "ce5bbfc6-7e82-58b5-a001-e5aa574f1528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830e76d-7d38-4f6e-8ab7-abd9ac3fb0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830e76d-7d38-4f6e-8ab7-abd9ac3fb0d9.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "",
             "colours": [
@@ -19626,7 +19626,7 @@
         },
         {
             "id": "1072c9aa-f4bd-53a5-bf91-70a8434693b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828289fa-6335-43c3-9d42-1c0199b9af67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828289fa-6335-43c3-9d42-1c0199b9af67.jpg?1",
             "name": "Ral, Storm Conduit",
             "text": "",
             "colours": [
@@ -19663,7 +19663,7 @@
         },
         {
             "id": "f5f5e528-1470-5281-89ec-621de9d17896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48b7f2a-2195-4b1a-a5f2-3d9e99aa1b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48b7f2a-2195-4b1a-a5f2-3d9e99aa1b5a.jpg?1",
             "name": "Sorin, Vengeful Bloodlord",
             "text": "",
             "colours": [
@@ -19700,7 +19700,7 @@
         },
         {
             "id": "38a3fb90-1e62-5aa0-ba67-d6e1571c6d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b45d79-4526-490d-9771-9445e45307a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b45d79-4526-490d-9771-9445e45307a7.jpg?1",
             "name": "Tamiyo, Collector of Tales",
             "text": "",
             "colours": [
@@ -19737,7 +19737,7 @@
         },
         {
             "id": "2584786d-7f06-5a9e-ae9a-9115302af3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b2e55-21a3-4f71-a14b-d3d1b137d18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b2e55-21a3-4f71-a14b-d3d1b137d18c.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -19776,7 +19776,7 @@
         },
         {
             "id": "e414f7b7-9bdc-5c1b-8693-c134d3263101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129851e1-8dca-4a90-8615-5ea642b61e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129851e1-8dca-4a90-8615-5ea642b61e71.jpg?1",
             "name": "Angrath, Captain of Chaos",
             "text": "",
             "colours": [
@@ -19813,7 +19813,7 @@
         },
         {
             "id": "c62fe142-8eb3-5409-a575-1cc38ca86de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c48e42-5c82-4212-ace5-348177dc04b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c48e42-5c82-4212-ace5-348177dc04b2.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "",
             "colours": [
@@ -19852,7 +19852,7 @@
         },
         {
             "id": "1d0f782e-1a38-50d3-9bbd-61537f5d39d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f906233-7223-4e59-a6dd-2fb2db2d8e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f906233-7223-4e59-a6dd-2fb2db2d8e40.jpg?1",
             "name": "Dovin, Hand of Control",
             "text": "",
             "colours": [
@@ -19889,7 +19889,7 @@
         },
         {
             "id": "bb75cecf-fd39-511d-8752-6b39fbb5fed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d05299-27bd-4826-bbdb-f24ac9a5005b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d05299-27bd-4826-bbdb-f24ac9a5005b.jpg?1",
             "name": "Huatli, the Sun's Heart",
             "text": "",
             "colours": [
@@ -19926,7 +19926,7 @@
         },
         {
             "id": "f9747b6a-4e4d-599c-a92c-995e9b1fefd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ef2d-d94a-4970-b7dd-47f335f33dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ef2d-d94a-4970-b7dd-47f335f33dfc.jpg?1",
             "name": "Kaya, Bane of the Dead",
             "text": "",
             "colours": [
@@ -19963,7 +19963,7 @@
         },
         {
             "id": "ab09b581-bb4d-5349-93fd-4fb701aad879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cf8664-a29d-4d64-af14-7c2002488ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cf8664-a29d-4d64-af14-7c2002488ba2.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "",
             "colours": [
@@ -20002,7 +20002,7 @@
         },
         {
             "id": "f3a2fe37-1c53-53d0-b4f6-ec6f0d52419b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c664a0f7-f1df-4c34-8755-a53afea7ddba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c664a0f7-f1df-4c34-8755-a53afea7ddba.jpg?1",
             "name": "Nahiri, Storm of Stone",
             "text": "",
             "colours": [
@@ -20039,7 +20039,7 @@
         },
         {
             "id": "709ff9c9-890f-5e52-a7c8-c05cbcd946f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bbc692-8d2e-4487-bd19-1a5c78fd3d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bbc692-8d2e-4487-bd19-1a5c78fd3d53.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "",
             "colours": [
@@ -20078,7 +20078,7 @@
         },
         {
             "id": "6d6e9894-af90-5731-84fb-3f79a8065414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cdce67-67c0-4b1e-8f86-6e7d6b9fc6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cdce67-67c0-4b1e-8f86-6e7d6b9fc6c2.jpg?1",
             "name": "Samut, Tyrant Smasher",
             "text": "",
             "colours": [
@@ -20115,7 +20115,7 @@
         },
         {
             "id": "1ceb0101-f995-5d4b-8738-9f948055c3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a1df85-9dc9-470b-a0d8-956b63440a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a1df85-9dc9-470b-a0d8-956b63440a20.jpg?1",
             "name": "Vraska, Swarm's Eminence",
             "text": "",
             "colours": [
@@ -20152,7 +20152,7 @@
         },
         {
             "id": "7b013c74-2c7a-5500-86a9-f6b1cc6f5763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da28f3-2b23-47ad-975a-6b7b204efecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da28f3-2b23-47ad-975a-6b7b204efecb.jpg?1",
             "name": "Tibalt, the Fiend-Blooded",
             "text": "",
             "colours": [
@@ -20187,7 +20187,7 @@
         },
         {
             "id": "871e70ac-ab31-53e6-85fc-dfcf472776dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3df6-da4e-48bd-92d5-349bc60d7150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3df6-da4e-48bd-92d5-349bc60d7150.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -20217,7 +20217,7 @@
         },
         {
             "id": "d8d3610f-e848-51d4-9614-70734390dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8f29a-5771-4407-8a2b-cfeeeff04611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8f29a-5771-4407-8a2b-cfeeeff04611.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -20281,7 +20281,7 @@
         },
         {
             "id": "e38ec94c-070a-5590-94e4-86d62dbd64d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3733ca13-1398-4f8f-a885-4b0b2c498d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3733ca13-1398-4f8f-a885-4b0b2c498d2b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20349,7 +20349,7 @@
         },
         {
             "id": "fc3601c3-aa97-5d3e-8ba3-4e0878194c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796f129d-912f-400b-8077-7b2873ec2040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796f129d-912f-400b-8077-7b2873ec2040.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20417,7 +20417,7 @@
         },
         {
             "id": "f360db77-eb35-577a-aec9-eac9263155ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4323e4e0-399e-495e-b090-7f3783fc4e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4323e4e0-399e-495e-b090-7f3783fc4e4c.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20485,7 +20485,7 @@
         },
         {
             "id": "f2bace3e-1288-5d5e-9ea2-a0a432702826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceb6a79-6d36-4780-b9c0-557fc3676c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceb6a79-6d36-4780-b9c0-557fc3676c19.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20553,7 +20553,7 @@
         },
         {
             "id": "4c547692-5209-5c0b-bd4b-1534a248e64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d21476a-6112-4f2a-b87e-e4aea514dcc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d21476a-6112-4f2a-b87e-e4aea514dcc7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20621,7 +20621,7 @@
         },
         {
             "id": "930530ee-d546-5b14-b7de-edeea8102f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43da6f6-fe15-41d3-932d-4ec3d16cc0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43da6f6-fe15-41d3-932d-4ec3d16cc0b2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20689,7 +20689,7 @@
         },
         {
             "id": "c7ed00f8-7186-51af-9cd7-bba7a3453da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959d473-10aa-482a-b5aa-ff7bb15cc128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959d473-10aa-482a-b5aa-ff7bb15cc128.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20757,7 +20757,7 @@
         },
         {
             "id": "8eadb3f9-97d5-5dae-9e81-184bad08e6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ec1f39-08e0-45ce-b4ec-c25d64bd3461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ec1f39-08e0-45ce-b4ec-c25d64bd3461.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20825,7 +20825,7 @@
         },
         {
             "id": "0c2b38c5-f60e-5eb5-96ae-316407a40a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0563dcbc-59da-468a-97ed-37cd5e36d14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0563dcbc-59da-468a-97ed-37cd5e36d14a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -20889,7 +20889,7 @@
         },
         {
             "id": "b8cae71f-699c-5c9c-ab64-76ce9dc94930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41829a8c-5ab2-4c44-bf6a-09bad991ab78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41829a8c-5ab2-4c44-bf6a-09bad991ab78.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -20953,7 +20953,7 @@
         },
         {
             "id": "2dfdd05b-d953-5792-b10d-73364635bafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fa28f3-0a91-48c5-9433-4da6e223011c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fa28f3-0a91-48c5-9433-4da6e223011c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21017,7 +21017,7 @@
         },
         {
             "id": "c536a9f4-bdc0-5bf1-828e-7cfd8e2c93af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b62f53-0fde-488b-bdac-986a870ff6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b62f53-0fde-488b-bdac-986a870ff6cb.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21081,7 +21081,7 @@
         },
         {
             "id": "d755a7ea-d9ad-520e-bfb5-4293ffeb6a58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b487e4c0-1135-46f4-807d-cab3f1743132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b487e4c0-1135-46f4-807d-cab3f1743132.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21145,7 +21145,7 @@
         },
         {
             "id": "5b4b42a4-f4dd-5640-a23c-2dc3a59a3b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5df5731-c9ce-417a-ae07-0359f4e1a989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5df5731-c9ce-417a-ae07-0359f4e1a989.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21209,7 +21209,7 @@
         },
         {
             "id": "eb9295cc-ca63-5551-90f3-1660f14b14ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f83a756-e520-4f72-932c-73fa6ee10500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f83a756-e520-4f72-932c-73fa6ee10500.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21273,7 +21273,7 @@
         },
         {
             "id": "51650413-c00b-5967-8492-b030dd124370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff1e8ef-4856-46c0-a72c-83a8b4d34238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff1e8ef-4856-46c0-a72c-83a8b4d34238.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21337,7 +21337,7 @@
         },
         {
             "id": "e1a10fcb-a6e6-5fad-b877-528244b141d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8ea25-dfed-4453-9e63-57339f948cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8ea25-dfed-4453-9e63-57339f948cac.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21400,7 +21400,7 @@
         },
         {
             "id": "edf14f47-98ea-562c-be74-4851411f98e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551eeb34-09d7-4d08-a0fa-dc313c946279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551eeb34-09d7-4d08-a0fa-dc313c946279.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21463,7 +21463,7 @@
         },
         {
             "id": "7587099e-0e27-592e-b5c1-6d94ec0275b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453aa0d9-b535-4bd9-951c-4304773399b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453aa0d9-b535-4bd9-951c-4304773399b1.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21526,7 +21526,7 @@
         },
         {
             "id": "c9be36b7-cc99-5d5a-ace9-bfface591e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d6c388-5da9-4c7a-907f-dfa7237e71aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d6c388-5da9-4c7a-907f-dfa7237e71aa.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21589,7 +21589,7 @@
         },
         {
             "id": "23f890d0-6800-5e0e-9cde-eb4c1103f01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084efea7-2a22-4cca-a1f9-b47aad2ebcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084efea7-2a22-4cca-a1f9-b47aad2ebcac.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21652,7 +21652,7 @@
         },
         {
             "id": "6d7456db-b6a0-5e2f-96db-0452224da8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf253ee5-378b-4396-b826-4c0f2fae38a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf253ee5-378b-4396-b826-4c0f2fae38a0.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21715,7 +21715,7 @@
         },
         {
             "id": "1e48e4be-022d-5284-8ede-9c6da9ba0224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13964bf9-c391-438a-a28c-2a0716375e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13964bf9-c391-438a-a28c-2a0716375e0c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21778,7 +21778,7 @@
         },
         {
             "id": "6bdbc284-b15b-503e-a6ae-af63740bace3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65422b02-47ee-4c68-ac27-81fa6368864e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65422b02-47ee-4c68-ac27-81fa6368864e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21841,7 +21841,7 @@
         },
         {
             "id": "a8e59b37-79a0-510d-9540-6b595307acf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d25ead-70d6-4abd-b611-6c94ce042c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d25ead-70d6-4abd-b611-6c94ce042c89.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21914,7 +21914,7 @@
         },
         {
             "id": "f36c5de3-7e73-5d11-88a6-63b3b2ff7271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b46e72-6ed0-47c1-ad42-38a893620fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b46e72-6ed0-47c1-ad42-38a893620fa1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21987,7 +21987,7 @@
         },
         {
             "id": "3cf3ef03-f0e2-5014-b215-7f8514f97cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a2aea9-8b3a-4be3-aaa0-4c4a19f63d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a2aea9-8b3a-4be3-aaa0-4c4a19f63d02.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22060,7 +22060,7 @@
         },
         {
             "id": "b8cbc454-7fb8-5560-b53a-7e0c58e2fced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9894ec2c-e5c2-42a5-b44a-76ec02684171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9894ec2c-e5c2-42a5-b44a-76ec02684171.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22133,7 +22133,7 @@
         },
         {
             "id": "5d95b204-f001-5c06-9059-5ac56188bd8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340b671-7daf-4f84-80a9-2ca4278aa33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340b671-7daf-4f84-80a9-2ca4278aa33b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22206,7 +22206,7 @@
         },
         {
             "id": "ac68899a-afdd-548d-b053-04c39856efe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831f40f9-2642-4313-99ec-a4a7afe2839d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831f40f9-2642-4313-99ec-a4a7afe2839d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22279,7 +22279,7 @@
         },
         {
             "id": "4b209caf-f91e-53f5-9d8f-f872606534ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eda14c-5e33-41cc-8651-109f5ef97bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eda14c-5e33-41cc-8651-109f5ef97bb0.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22352,7 +22352,7 @@
         },
         {
             "id": "098401e9-632b-581c-8197-31bbdc6eb21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9252dd84-ba93-440a-bc2f-36fb703fb57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9252dd84-ba93-440a-bc2f-36fb703fb57d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22425,7 +22425,7 @@
         },
         {
             "id": "5f280509-aabb-5891-a0c6-d4f6528645b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0560b5ed-821a-479f-91fb-98ade4a8d470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0560b5ed-821a-479f-91fb-98ade4a8d470.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22489,7 +22489,7 @@
         },
         {
             "id": "ace78bd8-8b1d-5e82-affb-109874796cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3093b-4f83-41fb-9290-757a3b2fa468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3093b-4f83-41fb-9290-757a3b2fa468.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22553,7 +22553,7 @@
         },
         {
             "id": "997355f9-60e2-5418-9312-33d76d5aa23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345293f-e71e-4754-bf88-b3c8b9824ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345293f-e71e-4754-bf88-b3c8b9824ab3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22617,7 +22617,7 @@
         },
         {
             "id": "da62f480-a4a3-5050-9243-cea5ae234fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81b803f-e065-4f79-b5e4-e45fb1815443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81b803f-e065-4f79-b5e4-e45fb1815443.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22681,7 +22681,7 @@
         },
         {
             "id": "636c69ab-6a4f-5703-8908-ce42c5823f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016e556-5597-440d-b737-b419acb4e44e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016e556-5597-440d-b737-b419acb4e44e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22745,7 +22745,7 @@
         },
         {
             "id": "0e46181c-d563-5f77-b3e2-d3558ac7573e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f774cc-ac13-4bc6-967c-af09358a8da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f774cc-ac13-4bc6-967c-af09358a8da4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22809,7 +22809,7 @@
         },
         {
             "id": "d40dd836-c202-5743-b044-d8a94f2d6f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc1b2e-945c-4d44-b973-3a299325e756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc1b2e-945c-4d44-b973-3a299325e756.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22873,7 +22873,7 @@
         },
         {
             "id": "5cb1a341-f791-584c-b53d-10dbd437554a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849969bd-60ec-4e91-9d14-3a50b0346ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849969bd-60ec-4e91-9d14-3a50b0346ca9.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22937,7 +22937,7 @@
         },
         {
             "id": "5ed427ac-a783-5a2c-9c96-a9cfba688e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f06af-47bd-4ede-a174-21be69387c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f06af-47bd-4ede-a174-21be69387c1b.jpg?1",
             "name": "Gisa's Favorite Shovel",
             "text": "",
             "colours": [
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "81804f37-fb5c-5679-80fb-28fbc8820140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04872b4a-8231-494e-8a6e-596c66797011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04872b4a-8231-494e-8a6e-596c66797011.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -23007,7 +23007,7 @@
         },
         {
             "id": "fd684563-5118-5eb2-b766-f74959e5308a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b168b85-323c-4d95-80a5-851988522606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b168b85-323c-4d95-80a5-851988522606.jpg?1",
             "name": "Fblthp, the Lost",
             "text": "",
             "colours": [
@@ -23043,7 +23043,7 @@
         },
         {
             "id": "bb935e2e-2860-50b1-8654-c6e5e1bd25b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f621e8-4787-42ce-828d-72cec68acc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f621e8-4787-42ce-828d-72cec68acc6c.jpg?1",
             "name": "Wrexial, the Risen Deep",
             "text": "",
             "colours": [
@@ -23080,7 +23080,7 @@
         },
         {
             "id": "891264cf-3526-5384-b43e-d0065e05daaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2fad3e-dbcd-4aa6-a2f5-8be673fd01ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2fad3e-dbcd-4aa6-a2f5-8be673fd01ba.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -23107,7 +23107,7 @@
         },
         {
             "id": "632e35a3-81c9-5bed-aa6b-f1a77e5e1cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc7c56d-1a28-477b-b1d1-854b127e1afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc7c56d-1a28-477b-b1d1-854b127e1afc.jpg?1",
             "name": "Spellskite",
             "text": "",
             "colours": [],
@@ -23143,7 +23143,7 @@
         },
         {
             "id": "971bf69a-c271-5d7e-b32c-6efcbf6de5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62388bb9-db71-4687-b6e7-772e90828759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62388bb9-db71-4687-b6e7-772e90828759.jpg?1",
             "name": "Sphere of Safety",
             "text": "",
             "colours": [
@@ -23176,7 +23176,7 @@
         },
         {
             "id": "21046320-dffb-5487-a481-6ed322d0ac93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac9fdee-ad50-486a-9fde-4aba6848a6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac9fdee-ad50-486a-9fde-4aba6848a6c6.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -23214,7 +23214,7 @@
         },
         {
             "id": "fb7fcf6c-e9b4-5ac2-be9f-4e55b126f4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9b42b-1f5d-4aae-8b91-6fb1b302aff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9b42b-1f5d-4aae-8b91-6fb1b302aff6.jpg?1",
             "name": "Lurking Crocodile",
             "text": "",
             "colours": [
@@ -23248,7 +23248,7 @@
         },
         {
             "id": "4d176f23-67af-5282-b9a1-0a219b11f25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13556e56-24bf-4149-a61f-80850cfc0523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13556e56-24bf-4149-a61f-80850cfc0523.jpg?1",
             "name": "Crash Through",
             "text": "",
             "colours": [
@@ -23280,7 +23280,7 @@
         },
         {
             "id": "14e0447f-ef62-5553-b0d6-a3b4bc71a3e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdfdb25-cfde-404f-b2f6-74283c8daa03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdfdb25-cfde-404f-b2f6-74283c8daa03.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23322,7 +23322,7 @@
         },
         {
             "id": "52b46022-2925-5fd0-94db-1cc1ccdc7d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174eafc5-1489-45dd-9555-123647f2268f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174eafc5-1489-45dd-9555-123647f2268f.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23364,7 +23364,7 @@
         },
         {
             "id": "59b0504c-5e91-55bb-ab44-ca5392ff5e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251d8c4a-a40c-4f89-9738-4928a7d4a97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251d8c4a-a40c-4f89-9738-4928a7d4a97c.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23406,7 +23406,7 @@
         },
         {
             "id": "a9460baa-5a40-5fa3-bdce-ac0f3be900b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dae6b1-0407-4ac0-94fe-9711e978258a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dae6b1-0407-4ac0-94fe-9711e978258a.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23448,7 +23448,7 @@
         },
         {
             "id": "f3001c69-54c8-5ed8-8549-1b8dd7847ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05fbd5a-1114-4887-9dad-5ba398c59f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05fbd5a-1114-4887-9dad-5ba398c59f13.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23490,7 +23490,7 @@
         },
         {
             "id": "cc5c64ac-a386-598c-8157-ce0a52a7c3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd502a-2c3e-4f4f-a206-4bccf175ca11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd502a-2c3e-4f4f-a206-4bccf175ca11.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23532,7 +23532,7 @@
         },
         {
             "id": "6d44837d-3c16-5b98-809f-c792adbfc92b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115e864c-a47f-48f6-a0e1-739e1427cb37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115e864c-a47f-48f6-a0e1-739e1427cb37.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23574,7 +23574,7 @@
         },
         {
             "id": "5f022bd5-c908-5c66-af7c-0b80e0203970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d419927-f5c0-42fd-a780-b91911909f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d419927-f5c0-42fd-a780-b91911909f2e.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23616,7 +23616,7 @@
         },
         {
             "id": "446a6877-b893-51bc-86b7-e378ffea56ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a63ff8-97ae-4ba2-a62b-4be10892a7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a63ff8-97ae-4ba2-a62b-4be10892a7a2.jpg?1",
             "name": "Eldrazi Monument",
             "text": "",
             "colours": [],
@@ -23643,7 +23643,7 @@
         },
         {
             "id": "4719ecce-a6a2-56e5-a4cc-6a98b60fd1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd789709-6613-4688-9272-6d5624140053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd789709-6613-4688-9272-6d5624140053.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -23673,7 +23673,7 @@
         },
         {
             "id": "f132bdee-5981-50c0-b36b-c170e7baa43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41465e-b702-4b69-8969-ca1da2ef07fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41465e-b702-4b69-8969-ca1da2ef07fa.jpg?1",
             "name": "Panharmonicon",
             "text": "",
             "colours": [],
@@ -23700,7 +23700,7 @@
         },
         {
             "id": "efb5736b-93be-574e-b848-d57b58ea02f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47803242-f744-445b-b645-e6e72b741589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47803242-f744-445b-b645-e6e72b741589.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "",
             "colours": [],
@@ -23729,7 +23729,7 @@
         },
         {
             "id": "fe012952-70fd-5dcb-9a56-112b7b1eae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c63f09-c9ab-4926-85de-6199856fff86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c63f09-c9ab-4926-85de-6199856fff86.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -23756,7 +23756,7 @@
         },
         {
             "id": "45502bd2-e585-59b5-9df5-252bcfb7a8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfafa38-e7db-4a42-99b8-fc65ab41c572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfafa38-e7db-4a42-99b8-fc65ab41c572.jpg?1",
             "name": "Darksteel Citadel",
             "text": "",
             "colours": [],
@@ -23785,7 +23785,7 @@
         },
         {
             "id": "16015cde-4407-5b6a-b12b-62808c71be8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg?1",
             "name": "Havengul Laboratory // Havengul Mystery",
             "text": "",
             "colours": [],
@@ -23817,7 +23817,7 @@
         },
         {
             "id": "f21ea2f3-8ef4-55fc-b7fb-5d68ad005a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg?1",
             "name": "Havengul Laboratory // Havengul Mystery",
             "text": "",
             "colours": [],
@@ -23849,7 +23849,7 @@
         },
         {
             "id": "c6ae1a7f-3660-5f0a-99da-bca806b7aceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e367827c-e0b5-44d0-bccf-65ffc6d5318a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e367827c-e0b5-44d0-bccf-65ffc6d5318a.jpg?1",
             "name": "Bonescythe Sliver",
             "text": "",
             "colours": [
@@ -23882,7 +23882,7 @@
         },
         {
             "id": "7c0fdb8d-8592-511f-8a54-d77bb3107a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348837a-7d77-4419-b329-137f1dd0aff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348837a-7d77-4419-b329-137f1dd0aff4.jpg?1",
             "name": "Constricting Sliver",
             "text": "",
             "colours": [
@@ -23915,7 +23915,7 @@
         },
         {
             "id": "86b7ba3b-123e-539c-9d52-06aefc2f0fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738bba27-b9cf-4fac-ae70-384799da04df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738bba27-b9cf-4fac-ae70-384799da04df.jpg?1",
             "name": "Essence Sliver",
             "text": "",
             "colours": [
@@ -23948,7 +23948,7 @@
         },
         {
             "id": "1e0c1bce-065a-5898-b795-469a65acafb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7879f2-fb02-45f6-a8b5-a371b704bdf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7879f2-fb02-45f6-a8b5-a371b704bdf1.jpg?1",
             "name": "Pulmonic Sliver",
             "text": "",
             "colours": [
@@ -23981,7 +23981,7 @@
         },
         {
             "id": "bc6b7293-d614-510a-b78c-8b9294b74ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84505a4e-5715-4731-9831-0107ff79ae05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84505a4e-5715-4731-9831-0107ff79ae05.jpg?1",
             "name": "Sidewinder Sliver",
             "text": "",
             "colours": [
@@ -24014,7 +24014,7 @@
         },
         {
             "id": "cef9b3a3-f2c7-57da-ac7d-99da79b2e041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79337a-cb6d-44cd-a1c9-c2c4cd698011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79337a-cb6d-44cd-a1c9-c2c4cd698011.jpg?1",
             "name": "Ward Sliver",
             "text": "",
             "colours": [
@@ -24047,7 +24047,7 @@
         },
         {
             "id": "86ccb355-b895-5c73-8542-ac465cfe85c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810076dc-e8e8-4fa4-aa2c-07ab4f9a9a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810076dc-e8e8-4fa4-aa2c-07ab4f9a9a11.jpg?1",
             "name": "Diffusion Sliver",
             "text": "",
             "colours": [
@@ -24080,7 +24080,7 @@
         },
         {
             "id": "dc074643-4d9e-5c17-9852-b0ca75d23333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a768f0cb-031f-4a7a-bb4a-4c6b672a7f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a768f0cb-031f-4a7a-bb4a-4c6b672a7f34.jpg?1",
             "name": "Galerider Sliver",
             "text": "",
             "colours": [
@@ -24113,7 +24113,7 @@
         },
         {
             "id": "d0af25f9-2e48-5240-b19d-6bd0d7a717f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99182657-e5b5-4594-92d8-f9228e9c4c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99182657-e5b5-4594-92d8-f9228e9c4c3a.jpg?1",
             "name": "Mesmeric Sliver",
             "text": "",
             "colours": [
@@ -24146,7 +24146,7 @@
         },
         {
             "id": "82b67f61-0c5b-53e7-82b1-b6ec8c78b111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b2ad56-6d4f-4cc5-8ecd-8d2e2824dfb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b2ad56-6d4f-4cc5-8ecd-8d2e2824dfb5.jpg?1",
             "name": "Psionic Sliver",
             "text": "",
             "colours": [
@@ -24179,7 +24179,7 @@
         },
         {
             "id": "2dcfdcb9-299f-5c4e-bcd1-f3a4a189e8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf10ad8-5f62-44be-bba8-2dfbf72a4ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf10ad8-5f62-44be-bba8-2dfbf72a4ac9.jpg?1",
             "name": "Screeching Sliver",
             "text": "",
             "colours": [
@@ -24212,7 +24212,7 @@
         },
         {
             "id": "8042b07f-4c66-5ca5-b39b-4e9e18bf521f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0d1e8-fc95-4698-9df7-a09f790c490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0d1e8-fc95-4698-9df7-a09f790c490c.jpg?1",
             "name": "Scuttling Sliver",
             "text": "",
             "colours": [
@@ -24246,7 +24246,7 @@
         },
         {
             "id": "807651a3-cbe8-5b19-b8a3-c4ed22abcedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a757de-b218-4334-9056-e75898316adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a757de-b218-4334-9056-e75898316adf.jpg?1",
             "name": "Shadow Sliver",
             "text": "",
             "colours": [
@@ -24279,7 +24279,7 @@
         },
         {
             "id": "70c5dac2-0022-5a79-8aff-c59eed744746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de510e3-a688-4133-980a-5cbd6b2dbed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de510e3-a688-4133-980a-5cbd6b2dbed7.jpg?1",
             "name": "Synapse Sliver",
             "text": "",
             "colours": [
@@ -24312,7 +24312,7 @@
         },
         {
             "id": "11670e89-3082-53e2-b281-94afab950134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b69f65-8494-49ff-ae8c-b85b82abe808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b69f65-8494-49ff-ae8c-b85b82abe808.jpg?1",
             "name": "Telekinetic Sliver",
             "text": "",
             "colours": [
@@ -24345,7 +24345,7 @@
         },
         {
             "id": "af24a6ee-9f83-5949-9736-cdb8842e7663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d7fdf9-bbf6-4298-acca-88aa81b6b848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d7fdf9-bbf6-4298-acca-88aa81b6b848.jpg?1",
             "name": "Winged Sliver",
             "text": "",
             "colours": [
@@ -24378,7 +24378,7 @@
         },
         {
             "id": "a116509a-fa37-5d13-b8d1-c78cf3fe06df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e5856-26f9-4c0f-a753-cce3a45a0d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e5856-26f9-4c0f-a753-cce3a45a0d17.jpg?1",
             "name": "Basal Sliver",
             "text": "",
             "colours": [
@@ -24411,7 +24411,7 @@
         },
         {
             "id": "213480f8-16a6-5b5d-a2e7-faf822dd9b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf8c12ff-036e-4eeb-95fb-7564ae728936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf8c12ff-036e-4eeb-95fb-7564ae728936.jpg?1",
             "name": "Dregscape Sliver",
             "text": "",
             "colours": [
@@ -24444,7 +24444,7 @@
         },
         {
             "id": "38d1f975-1b3b-5047-8328-61f5ca71ddba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f81ce-8731-4ff7-9bd8-8d108217fad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f81ce-8731-4ff7-9bd8-8d108217fad2.jpg?1",
             "name": "Leeching Sliver",
             "text": "",
             "colours": [
@@ -24477,7 +24477,7 @@
         },
         {
             "id": "e3f480e1-2b69-5c0c-8999-9ffcfb023da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a1e50a-cf65-487c-a6e0-e19dcd535046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a1e50a-cf65-487c-a6e0-e19dcd535046.jpg?1",
             "name": "Plague Sliver",
             "text": "",
             "colours": [
@@ -24512,7 +24512,7 @@
         },
         {
             "id": "2723d888-5a01-59fe-bd37-029822be1a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae3bfc8-1c89-494a-ba03-4b53b7c71fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae3bfc8-1c89-494a-ba03-4b53b7c71fe6.jpg?1",
             "name": "Plague Sliver",
             "text": "",
             "colours": [
@@ -24547,7 +24547,7 @@
         },
         {
             "id": "196c8038-c208-515b-a8be-bcb96496cfe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a991e21-5a1e-4c7e-b5bf-65f7f0882d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a991e21-5a1e-4c7e-b5bf-65f7f0882d8f.jpg?1",
             "name": "Syphon Sliver",
             "text": "",
             "colours": [
@@ -24580,7 +24580,7 @@
         },
         {
             "id": "c0bf904c-5bb8-58e0-bf76-b0f202b206c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966596a0-cddd-4056-bdd7-dff9154d12b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966596a0-cddd-4056-bdd7-dff9154d12b2.jpg?1",
             "name": "Toxin Sliver",
             "text": "",
             "colours": [
@@ -24615,7 +24615,7 @@
         },
         {
             "id": "62124746-eb93-5cb7-9c0f-14113c16133e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec479019-1581-4f8b-9e34-f9ccded05337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec479019-1581-4f8b-9e34-f9ccded05337.jpg?1",
             "name": "Toxin Sliver",
             "text": "",
             "colours": [
@@ -24650,7 +24650,7 @@
         },
         {
             "id": "533b217a-00df-54c2-b28d-43cc2af595ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fcb1c5-7fad-43df-901f-6389ee886340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fcb1c5-7fad-43df-901f-6389ee886340.jpg?1",
             "name": "Belligerent Sliver",
             "text": "",
             "colours": [
@@ -24683,7 +24683,7 @@
         },
         {
             "id": "68db1001-019c-560f-a6f2-378a13b40851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cdca59-6f98-437a-b3fd-a48264dd276f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cdca59-6f98-437a-b3fd-a48264dd276f.jpg?1",
             "name": "Blur Sliver",
             "text": "",
             "colours": [
@@ -24716,7 +24716,7 @@
         },
         {
             "id": "39524f3e-1ca5-5794-a3d1-c7a5c7e1380b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ba1e44-0beb-45ae-8880-3423c3f98015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ba1e44-0beb-45ae-8880-3423c3f98015.jpg?1",
             "name": "Fury Sliver",
             "text": "",
             "colours": [
@@ -24749,7 +24749,7 @@
         },
         {
             "id": "7444299f-f8ff-5f86-bc3b-4e2d5105e32e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc92a34-a623-49eb-8ea5-6d04d8688567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc92a34-a623-49eb-8ea5-6d04d8688567.jpg?1",
             "name": "Homing Sliver",
             "text": "",
             "colours": [
@@ -24782,7 +24782,7 @@
         },
         {
             "id": "da131a1a-753b-5cc2-b322-c15e2d8a039b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e467e-7dec-451f-b5c7-b15a357553ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e467e-7dec-451f-b5c7-b15a357553ae.jpg?1",
             "name": "Magma Sliver",
             "text": "",
             "colours": [
@@ -24815,7 +24815,7 @@
         },
         {
             "id": "a6782b6f-f021-5241-b885-97126f09a1ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e08306-5028-41d6-b19c-a8ce96b70279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e08306-5028-41d6-b19c-a8ce96b70279.jpg?1",
             "name": "Sedge Sliver",
             "text": "",
             "colours": [
@@ -24849,7 +24849,7 @@
         },
         {
             "id": "5621a042-b969-5f94-99b6-b92e16c088f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9d170-ad06-4bc6-bb4d-350136bb93fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9d170-ad06-4bc6-bb4d-350136bb93fd.jpg?1",
             "name": "Spiteful Sliver",
             "text": "",
             "colours": [
@@ -24882,7 +24882,7 @@
         },
         {
             "id": "79bbbb9a-e8ec-58c7-a66e-7e0366c086ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b99739-f4b1-4ad1-bc99-d125d4a7fd28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b99739-f4b1-4ad1-bc99-d125d4a7fd28.jpg?1",
             "name": "Striking Sliver",
             "text": "",
             "colours": [
@@ -24915,7 +24915,7 @@
         },
         {
             "id": "7db92f7f-8c8a-5419-9075-1b0aa88d3e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95409fb-e5ef-45b8-81b4-89fdfd581413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95409fb-e5ef-45b8-81b4-89fdfd581413.jpg?1",
             "name": "Thorncaster Sliver",
             "text": "",
             "colours": [
@@ -24948,7 +24948,7 @@
         },
         {
             "id": "0efaedb3-b512-515c-a19f-fc2f96555677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d127e747-fc45-4271-9ab1-cda4043bd43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d127e747-fc45-4271-9ab1-cda4043bd43d.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "",
             "colours": [
@@ -24981,7 +24981,7 @@
         },
         {
             "id": "1f2fedcb-1b4a-5b1f-bf5a-6f93d33d529c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bffc93-1162-49e5-a38b-8a7271915d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bffc93-1162-49e5-a38b-8a7271915d0c.jpg?1",
             "name": "Brood Sliver",
             "text": "",
             "colours": [
@@ -25014,7 +25014,7 @@
         },
         {
             "id": "2d9009a7-23f2-5d54-b69d-9f495aca0784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf38fc5-4f64-4c0c-9679-edf901fc416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf38fc5-4f64-4c0c-9679-edf901fc416c.jpg?1",
             "name": "Gemhide Sliver",
             "text": "",
             "colours": [
@@ -25047,7 +25047,7 @@
         },
         {
             "id": "09f5dc78-884d-5b54-9f04-495a6180e36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f28575-b1a8-4ed0-9bb2-d72c56b9fee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f28575-b1a8-4ed0-9bb2-d72c56b9fee1.jpg?1",
             "name": "Horned Sliver",
             "text": "",
             "colours": [
@@ -25080,7 +25080,7 @@
         },
         {
             "id": "8c9f7922-771a-53ba-bdd9-ce4ef2bcb919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9612d2-0379-4f33-88d2-e4098bfd53ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9612d2-0379-4f33-88d2-e4098bfd53ac.jpg?1",
             "name": "Manaweft Sliver",
             "text": "",
             "colours": [
@@ -25113,7 +25113,7 @@
         },
         {
             "id": "fe712318-e16b-5912-8300-605fc2434406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a2390f-6d5b-4f65-bc7f-e6e75e85d721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a2390f-6d5b-4f65-bc7f-e6e75e85d721.jpg?1",
             "name": "Megantic Sliver",
             "text": "",
             "colours": [
@@ -25146,7 +25146,7 @@
         },
         {
             "id": "d0dee3f1-0df5-50af-be37-82117fa714c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a397f-448e-4e6a-9b8a-b8034a5ac33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a397f-448e-4e6a-9b8a-b8034a5ac33c.jpg?1",
             "name": "Might Sliver",
             "text": "",
             "colours": [
@@ -25179,7 +25179,7 @@
         },
         {
             "id": "63ae1f43-f0ef-51a9-a1e7-2c5a9900ce29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96fa876-5474-4374-bc51-fa5df9278042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96fa876-5474-4374-bc51-fa5df9278042.jpg?1",
             "name": "Muscle Sliver",
             "text": "",
             "colours": [
@@ -25212,7 +25212,7 @@
         },
         {
             "id": "89a1da55-7b34-567b-b966-7b8e8904ef43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06206a5b-ea4b-4b15-b61f-e0543077d4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06206a5b-ea4b-4b15-b61f-e0543077d4fb.jpg?1",
             "name": "Predatory Sliver",
             "text": "",
             "colours": [
@@ -25245,7 +25245,7 @@
         },
         {
             "id": "06619745-e841-5099-a239-ccfc727b76ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702896b-7bd7-48fa-9bbb-69d50a31178e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702896b-7bd7-48fa-9bbb-69d50a31178e.jpg?1",
             "name": "Quick Sliver",
             "text": "",
             "colours": [
@@ -25278,7 +25278,7 @@
         },
         {
             "id": "1f7224b3-7027-5e3d-a02d-75038d6f81b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb818ad-fba5-4012-a951-f6bcd72d6812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb818ad-fba5-4012-a951-f6bcd72d6812.jpg?1",
             "name": "Root Sliver",
             "text": "",
             "colours": [
@@ -25311,7 +25311,7 @@
         },
         {
             "id": "01e1e172-f45b-541f-8a6e-dee48d197712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b074f3-13fc-44df-84e1-e557b045fb4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b074f3-13fc-44df-84e1-e557b045fb4f.jpg?1",
             "name": "Tempered Sliver",
             "text": "",
             "colours": [
@@ -25344,7 +25344,7 @@
         },
         {
             "id": "ed676606-0254-5973-b3a9-9651931cac10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27047e1-0f6a-4f78-a3ed-02fc417dde29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27047e1-0f6a-4f78-a3ed-02fc417dde29.jpg?1",
             "name": "Virulent Sliver",
             "text": "",
             "colours": [
@@ -25379,7 +25379,7 @@
         },
         {
             "id": "7f054dc5-611f-5cf9-8211-7106a158f84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c145b06b-45b0-4133-b88d-9cb130aeeeb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c145b06b-45b0-4133-b88d-9cb130aeeeb5.jpg?1",
             "name": "Virulent Sliver",
             "text": "",
             "colours": [
@@ -25414,7 +25414,7 @@
         },
         {
             "id": "b16b4de7-6fab-540e-b0a8-8b43b450a699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e1f39d-b1e4-416d-98a4-3d9755706335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e1f39d-b1e4-416d-98a4-3d9755706335.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "",
             "colours": [
@@ -25449,7 +25449,7 @@
         },
         {
             "id": "0e571a77-27cf-59d7-bcf8-18ba2e002788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a1b96a-ff75-4b4c-aea7-b41d9f9ac710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a1b96a-ff75-4b4c-aea7-b41d9f9ac710.jpg?1",
             "name": "Crystalline Sliver",
             "text": "",
             "colours": [
@@ -25484,7 +25484,7 @@
         },
         {
             "id": "13f283ac-7470-560a-9539-6a38e86f3568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4190231-8f16-4c1c-82cb-6432e106f0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4190231-8f16-4c1c-82cb-6432e106f0e5.jpg?1",
             "name": "Frenetic Sliver",
             "text": "",
             "colours": [
@@ -25519,7 +25519,7 @@
         },
         {
             "id": "b1c1aeb2-69e6-5174-a51e-b6e6f85c8aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba161cb4-e2b7-440b-a981-4a052af3f034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba161cb4-e2b7-440b-a981-4a052af3f034.jpg?1",
             "name": "Harmonic Sliver",
             "text": "",
             "colours": [
@@ -25554,7 +25554,7 @@
         },
         {
             "id": "5a825b36-2e68-514b-bfbe-8f5c7455e621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b6edd1-f617-45e3-9680-6da6942fdd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b6edd1-f617-45e3-9680-6da6942fdd45.jpg?1",
             "name": "Hibernation Sliver",
             "text": "",
             "colours": [
@@ -25589,7 +25589,7 @@
         },
         {
             "id": "f93e0834-293e-5f8d-9963-7198b0ea9072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d000551-f457-4050-a36b-4df7d8dcd9e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d000551-f457-4050-a36b-4df7d8dcd9e4.jpg?1",
             "name": "Lavabelly Sliver",
             "text": "",
             "colours": [
@@ -25624,7 +25624,7 @@
         },
         {
             "id": "eb0f044c-3a23-580f-8532-babde9fdbf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699dc42d-3ceb-46dc-bc91-6a93c0d7ddc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699dc42d-3ceb-46dc-bc91-6a93c0d7ddc3.jpg?1",
             "name": "Necrotic Sliver",
             "text": "",
             "colours": [
@@ -25659,7 +25659,7 @@
         },
         {
             "id": "3bf31ea6-26e7-5420-b6d5-765bfa6bb105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df20594-5483-4050-80ed-dc8096295b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df20594-5483-4050-80ed-dc8096295b66.jpg?1",
             "name": "Opaline Sliver",
             "text": "",
             "colours": [
@@ -25694,7 +25694,7 @@
         },
         {
             "id": "61f37adc-e59e-5100-914f-eb1f4352205e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04541650-6ee7-4825-984e-4794b306c274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04541650-6ee7-4825-984e-4794b306c274.jpg?1",
             "name": "Sliver Hive",
             "text": "",
             "colours": [],
@@ -25721,7 +25721,7 @@
         },
         {
             "id": "5476c579-9498-559f-8ce9-1cea7d3c79de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb35ff06-c5bf-460e-8a79-422bda257cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb35ff06-c5bf-460e-8a79-422bda257cfe.jpg?1",
             "name": "Battlefield Forge",
             "text": "",
             "colours": [],
@@ -25751,7 +25751,7 @@
         },
         {
             "id": "21a3ecdb-e282-5f28-a464-3cf7bb5e900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb949a6-9261-4175-bcf1-5519d82f9dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb949a6-9261-4175-bcf1-5519d82f9dc3.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -25819,7 +25819,7 @@
         },
         {
             "id": "b32faab5-0e9c-5bc3-9669-a2e1e201be6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afa7ab5-feac-4cc5-ba2d-2b60a4f3308a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afa7ab5-feac-4cc5-ba2d-2b60a4f3308a.jpg?1",
             "name": "Questing Phelddagrif",
             "text": "",
             "colours": [
@@ -25859,7 +25859,7 @@
         },
         {
             "id": "708deab2-ae0e-5ce6-b333-c5f3c0c82ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97f18f-84f7-4ef5-b99e-267d6e7981e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97f18f-84f7-4ef5-b99e-267d6e7981e8.jpg?1",
             "name": "Questing Phelddagrif",
             "text": "",
             "colours": [
@@ -25899,7 +25899,7 @@
         },
         {
             "id": "08f8ffae-101b-568e-8377-d412605437a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6d4527-a88e-4001-b8a7-53db87784c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6d4527-a88e-4001-b8a7-53db87784c8f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -25963,7 +25963,7 @@
         },
         {
             "id": "57d63daf-91e4-5ce4-ac39-1467562a5c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8993e4d0-d306-4993-b5a7-dbba754d479e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8993e4d0-d306-4993-b5a7-dbba754d479e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -26036,7 +26036,7 @@
         },
         {
             "id": "28774c48-654f-5fdc-9547-42a187ff57c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27740ea5-79c8-420f-bc49-6d5eac58dac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27740ea5-79c8-420f-bc49-6d5eac58dac5.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -26078,7 +26078,7 @@
         },
         {
             "id": "b126253c-304c-522e-a75a-b05b3866083b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac01b7b-7f0c-44ce-a183-28b52dd09833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac01b7b-7f0c-44ce-a183-28b52dd09833.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "",
             "colours": [],
@@ -26108,7 +26108,7 @@
         },
         {
             "id": "b15e263f-6952-5472-9a60-1a4e006e9c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e97d936-c3dc-42ae-a028-4a183d13ccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e97d936-c3dc-42ae-a028-4a183d13ccc8.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -26147,7 +26147,7 @@
         },
         {
             "id": "1c802eab-0fb9-5e5d-8d39-940fc5f3da00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4438562b-d5af-473d-a6c9-1bc0076341f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4438562b-d5af-473d-a6c9-1bc0076341f7.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "",
             "colours": [
@@ -26186,7 +26186,7 @@
         },
         {
             "id": "79a9faa4-1a36-5578-871c-c70901126319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842bc7d-a37b-44ae-96e5-3ab42c95c4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842bc7d-a37b-44ae-96e5-3ab42c95c4be.jpg?1",
             "name": "Ghost Quarter",
             "text": "",
             "colours": [],
@@ -26216,7 +26216,7 @@
         },
         {
             "id": "e9fa2b68-5699-5736-aa65-633db309d088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebc3424-456c-4b84-8e14-60c20828db0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebc3424-456c-4b84-8e14-60c20828db0d.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26260,7 +26260,7 @@
         },
         {
             "id": "f3ea40cd-c702-560d-a7a6-6dbe3a5b7751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5ed779-b400-489f-a419-4208de15efad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5ed779-b400-489f-a419-4208de15efad.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26304,7 +26304,7 @@
         },
         {
             "id": "2c28317d-3a8b-56ce-9467-e52270a234ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92d596-679f-4340-990d-29ae7900b5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92d596-679f-4340-990d-29ae7900b5c8.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26348,7 +26348,7 @@
         },
         {
             "id": "ccc9d450-0702-5d4a-8ede-fc746f3cb831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0b2ddc-eb21-4518-973c-4841b1f2ef52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0b2ddc-eb21-4518-973c-4841b1f2ef52.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26392,7 +26392,7 @@
         },
         {
             "id": "30518e3e-a847-5b56-a86d-136f9b23b3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29c6d37-785b-4d3a-9e7d-7963710538b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29c6d37-785b-4d3a-9e7d-7963710538b1.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26436,7 +26436,7 @@
         },
         {
             "id": "707bce4a-160f-5df3-8075-32837931a7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78bc53e-7106-489f-8818-adef7200e2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78bc53e-7106-489f-8818-adef7200e2f8.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26480,7 +26480,7 @@
         },
         {
             "id": "40fc750a-c595-5d4a-9088-617b30b054f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3544806-daf9-438f-aec5-087abb40d2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3544806-daf9-438f-aec5-087abb40d2e6.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26524,7 +26524,7 @@
         },
         {
             "id": "5d0baf88-f632-5ee1-8bdf-e7789fa2aaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c609eef-7ccc-4687-bd06-9b206d9d5b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c609eef-7ccc-4687-bd06-9b206d9d5b11.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26568,7 +26568,7 @@
         },
         {
             "id": "1c89406f-49d4-5b6d-aef9-e7bcd92df49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f1740-1a79-42c5-bc0b-33a79a00621e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f1740-1a79-42c5-bc0b-33a79a00621e.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26612,7 +26612,7 @@
         },
         {
             "id": "3f0167d1-83a1-5cdb-8f4f-b44a41f94196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25ba4c-42f2-4d23-9299-b5343a7bad2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25ba4c-42f2-4d23-9299-b5343a7bad2e.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26656,7 +26656,7 @@
         },
         {
             "id": "f70df975-a65f-522a-a02e-f986a9c8cdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f7c03-647f-4e5a-98b1-1faa3d330e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f7c03-647f-4e5a-98b1-1faa3d330e7b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -26721,7 +26721,7 @@
         },
         {
             "id": "1634d8b4-db10-57c0-b85e-033d34b1bf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797bd0ea-5c4d-477e-9d92-199a99d6c2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797bd0ea-5c4d-477e-9d92-199a99d6c2cf.jpg?1",
             "name": "Hedron Archive",
             "text": "",
             "colours": [],
@@ -26748,7 +26748,7 @@
         },
         {
             "id": "7a1ad599-5f44-5f19-bdf2-9fc226777b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438767ea-4f77-426e-bc01-eab18d5c6b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438767ea-4f77-426e-bc01-eab18d5c6b17.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "",
             "colours": [],
@@ -26778,7 +26778,7 @@
         },
         {
             "id": "dc61f0f4-61e2-5c5f-a919-0172cd666eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924c4849-ede1-4aee-aa08-16b99282e6c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924c4849-ede1-4aee-aa08-16b99282e6c1.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "",
             "colours": [],
@@ -26805,7 +26805,7 @@
         },
         {
             "id": "32e27f1a-9877-58b4-8459-22433313d9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baec9c6-6f10-4e16-b3a0-910a9e1bf09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baec9c6-6f10-4e16-b3a0-910a9e1bf09e.jpg?1",
             "name": "Tangle Wire",
             "text": "",
             "colours": [],
@@ -26832,7 +26832,7 @@
         },
         {
             "id": "b8aa4163-1d3e-5e99-89c0-f9e5bf313937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb1ddf8-7a58-4440-9b60-ba77e12e7a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb1ddf8-7a58-4440-9b60-ba77e12e7a0e.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -26862,7 +26862,7 @@
         },
         {
             "id": "7b8abbab-1a9d-515d-9832-b50d5198c692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0d52a9-8694-46b4-aa0e-7b42b45b11db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0d52a9-8694-46b4-aa0e-7b42b45b11db.jpg?1",
             "name": "Spore Frog",
             "text": "",
             "colours": [
@@ -26896,7 +26896,7 @@
         },
         {
             "id": "a45a4e2c-1437-51dd-837a-5e62520c3e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e863861-eb0d-4f86-9770-bd32b8227d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e863861-eb0d-4f86-9770-bd32b8227d07.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -26935,7 +26935,7 @@
         },
         {
             "id": "98d0d6d9-9cdb-525c-a7be-adc9d5cd4ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeb8c31-cf87-4058-bc14-991310a9e1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeb8c31-cf87-4058-bc14-991310a9e1d5.jpg?1",
             "name": "Dakkon Blackblade",
             "text": "",
             "colours": [
@@ -26976,7 +26976,7 @@
         },
         {
             "id": "1a0a8b4f-e4d0-5a56-8e2f-627fe73942e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890887b-38ed-4794-99d1-f1a574428d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890887b-38ed-4794-99d1-f1a574428d2b.jpg?1",
             "name": "Olivia, Mobilized for War",
             "text": "",
             "colours": [
@@ -27017,7 +27017,7 @@
         },
         {
             "id": "8f762042-59f4-533e-99dd-aff86478d2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -27056,7 +27056,7 @@
         },
         {
             "id": "c3c4b6be-1cb5-5280-be35-b50ed288f7e2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -27094,7 +27094,7 @@
         },
         {
             "id": "9c74d4c6-8604-5f99-a673-531d51a8c13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f40636-6899-4ea8-adda-9b60bcde18a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f40636-6899-4ea8-adda-9b60bcde18a0.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "",
             "colours": [
@@ -27132,7 +27132,7 @@
         },
         {
             "id": "5f3885de-116f-5b8a-87f0-0cb478541458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f93e8ad-8ef6-4cf1-a664-d1477f1ebae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f93e8ad-8ef6-4cf1-a664-d1477f1ebae4.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -27166,7 +27166,7 @@
         },
         {
             "id": "108ddd7e-8b2d-50e8-a2d2-fd3e5c697f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b38015-985f-4718-a6f8-fe19de225801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b38015-985f-4718-a6f8-fe19de225801.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -27200,7 +27200,7 @@
         },
         {
             "id": "55e7c072-0648-5864-ae09-d2bec3c11144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0040569-c4b1-46ad-8115-1fdb82ba3710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0040569-c4b1-46ad-8115-1fdb82ba3710.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -27234,7 +27234,7 @@
         },
         {
             "id": "c00dcbb2-b13f-593e-b8d5-b701961be340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23361f62-c24f-42a6-9720-89a84069ce33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23361f62-c24f-42a6-9720-89a84069ce33.jpg?1",
             "name": "Knight Exemplar",
             "text": "",
             "colours": [
@@ -27271,7 +27271,7 @@
         },
         {
             "id": "3a298291-86d1-50ff-9b68-5ebed28e25ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228933f3-3bca-4417-ab8a-5ccd19829c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228933f3-3bca-4417-ab8a-5ccd19829c69.jpg?1",
             "name": "Fellwar Stone",
             "text": "",
             "colours": [],
@@ -27301,7 +27301,7 @@
         },
         {
             "id": "0ae54900-2e2a-5cdb-8926-f20306569d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f29c3b1-58b9-4a7b-8874-3db705cc96f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f29c3b1-58b9-4a7b-8874-3db705cc96f5.jpg?1",
             "name": "Dragon's Hoard",
             "text": "",
             "colours": [],
@@ -27328,7 +27328,7 @@
         },
         {
             "id": "e93f698b-5d46-54cc-ad04-6ba93a3bca57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a380bca-e64d-4582-9f55-02f91a1f3c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a380bca-e64d-4582-9f55-02f91a1f3c2f.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -27367,7 +27367,7 @@
         },
         {
             "id": "e487538a-0c76-51b8-8b9d-8d9214918cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c024f-db49-4b98-ad80-b46ee1be32fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c024f-db49-4b98-ad80-b46ee1be32fe.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -27404,7 +27404,7 @@
         },
         {
             "id": "0ba51819-42ff-5cd3-9242-2ec04dd7f0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6597c9-8271-49c7-b4f6-9265f5d95f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6597c9-8271-49c7-b4f6-9265f5d95f99.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -27441,7 +27441,7 @@
         },
         {
             "id": "e1dba0a1-c241-5211-a353-efaf84b521b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff7380-ac9c-46c4-9544-da6554cb0819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff7380-ac9c-46c4-9544-da6554cb0819.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -27474,7 +27474,7 @@
         },
         {
             "id": "739c92c3-6c33-50d5-84ff-5624f00d4f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fefff7-2ff5-4abf-a9ec-0e2e737ee225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fefff7-2ff5-4abf-a9ec-0e2e737ee225.jpg?1",
             "name": "Lord of the Pit",
             "text": "",
             "colours": [
@@ -27507,7 +27507,7 @@
         },
         {
             "id": "40508241-7da4-5240-bf3b-277d4763379b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a04baf-5301-4e47-ac8f-243d2a73f18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a04baf-5301-4e47-ac8f-243d2a73f18e.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -27542,7 +27542,7 @@
         },
         {
             "id": "478443e8-3f28-5be0-87c2-e1952c281841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a168b8-285b-4725-a982-671557d4f0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a168b8-285b-4725-a982-671557d4f0bc.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -27573,7 +27573,7 @@
         },
         {
             "id": "d833b558-9825-5c35-8cea-a8c02044303a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f677da5a-cd08-4b5f-8862-51ba239f3329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f677da5a-cd08-4b5f-8862-51ba239f3329.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -27608,7 +27608,7 @@
         },
         {
             "id": "a8e4fdd9-dffd-5ad3-aaed-6be1c560a714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11528f4f-35b7-457d-8b83-1954bd3289c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11528f4f-35b7-457d-8b83-1954bd3289c3.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -27643,7 +27643,7 @@
         },
         {
             "id": "b7dc73a6-8368-5044-bffb-78645b2186da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f586a8ef-2a22-47d9-a45d-eb27def385ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f586a8ef-2a22-47d9-a45d-eb27def385ca.jpg?1",
             "name": "Thought-Knot Seer",
             "text": "",
             "colours": [],
@@ -27675,7 +27675,7 @@
         },
         {
             "id": "0d2350e5-a7e7-5b6e-a8e4-d2b31bfbad3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6150f2-cc6c-405d-9812-bbbc524ce450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6150f2-cc6c-405d-9812-bbbc524ce450.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -27708,7 +27708,7 @@
         },
         {
             "id": "72a1f10e-54cc-54ab-bf05-f51fed52c302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "",
             "colours": [
@@ -27742,7 +27742,7 @@
         },
         {
             "id": "095d1f2f-b86a-5d6f-a278-b00a065b6562",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "",
             "colours": [
@@ -27776,7 +27776,7 @@
         },
         {
             "id": "b45bc70f-7b32-5d0d-8a9a-bb0c9cfe4d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f947de-fc90-49f1-aad9-d6166a23ee9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f947de-fc90-49f1-aad9-d6166a23ee9e.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -27812,7 +27812,7 @@
         },
         {
             "id": "d2474a78-46af-52c0-90a8-f573df52d855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee11ea-213d-4f71-b3bf-a136b8de700d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee11ea-213d-4f71-b3bf-a136b8de700d.jpg?1",
             "name": "Lightning Strike",
             "text": "",
             "colours": [
@@ -27844,7 +27844,7 @@
         },
         {
             "id": "18b7640e-bd5b-5d1e-a26a-802f2df285ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f597a-94d0-4117-af92-58e23fdf2c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f597a-94d0-4117-af92-58e23fdf2c6c.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "",
             "colours": [
@@ -27881,7 +27881,7 @@
         },
         {
             "id": "255caab7-f7ea-555f-919a-11948c0d7c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5468fd0-822b-40f2-bf23-c5ca11c9e1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5468fd0-822b-40f2-bf23-c5ca11c9e1ba.jpg?1",
             "name": "Zur the Enchanter",
             "text": "",
             "colours": [
@@ -27921,7 +27921,7 @@
         },
         {
             "id": "919a42fb-c9a5-5e2c-9789-3a7a554e483c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ee3d9-055d-4223-96f9-506ecf4ce0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ee3d9-055d-4223-96f9-506ecf4ce0f5.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -27952,7 +27952,7 @@
         },
         {
             "id": "9d826d71-e2fe-52c3-925b-9a46c937935c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce332e85-a842-4afc-a5c5-b5064c5c4569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce332e85-a842-4afc-a5c5-b5064c5c4569.jpg?1",
             "name": "Themberchaud",
             "text": "",
             "colours": [
@@ -27988,7 +27988,7 @@
         },
         {
             "id": "9e069df0-9e09-5d3f-b576-d9d85b12e420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84468eb-c971-4e5c-92ab-338b4aaa48c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84468eb-c971-4e5c-92ab-338b4aaa48c6.jpg?1",
             "name": "Braid of Fire",
             "text": "",
             "colours": [
@@ -28021,7 +28021,7 @@
         },
         {
             "id": "933ba936-8280-5d41-9437-d62e6e3f1e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84590fb7-a79e-4708-bce4-bb16b1b0dd7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84590fb7-a79e-4708-bce4-bb16b1b0dd7e.jpg?1",
             "name": "Cleansing Nova",
             "text": "",
             "colours": [
@@ -28055,7 +28055,7 @@
         },
         {
             "id": "02ac098f-0b44-51a3-b15a-06c29080b5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1ff426-31d8-4336-a952-3074e9f40f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1ff426-31d8-4336-a952-3074e9f40f3f.jpg?1",
             "name": "Sigarda's Aid",
             "text": "",
             "colours": [
@@ -28088,7 +28088,7 @@
         },
         {
             "id": "5041546d-cfdb-52b3-a04d-1f2e549eb603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b4316-e5f2-40a4-8d7a-a7d7059ebfad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b4316-e5f2-40a4-8d7a-a7d7059ebfad.jpg?1",
             "name": "Selfless Savior",
             "text": "",
             "colours": [
@@ -28124,7 +28124,7 @@
         },
         {
             "id": "32cafc37-e0bf-58ef-b091-ae38d6d10924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff491659-0756-4450-acc5-0a1cd792f0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff491659-0756-4450-acc5-0a1cd792f0f0.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "",
             "colours": [],
@@ -28155,7 +28155,7 @@
         },
         {
             "id": "3aae9350-6a5e-5fdb-8527-35a2238959fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2731d3c-48be-46d1-8fb3-13a99ac380b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2731d3c-48be-46d1-8fb3-13a99ac380b4.jpg?1",
             "name": "Gr\u00edma Wormtongue",
             "text": "",
             "colours": [
@@ -28192,7 +28192,7 @@
         },
         {
             "id": "96455386-038e-5c1d-bfec-9fca93917636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb93d27-ca54-4d56-a55e-19cec740cd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb93d27-ca54-4d56-a55e-19cec740cd69.jpg?1",
             "name": "Gaea's Blessing",
             "text": "",
             "colours": [
@@ -28226,7 +28226,7 @@
         },
         {
             "id": "236a6b4b-ecfc-5ef5-bfcc-acf00a5ff575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8879c10-6b89-459f-a8f7-0251fca58498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8879c10-6b89-459f-a8f7-0251fca58498.jpg?1",
             "name": "Colossus Hammer",
             "text": "",
             "colours": [],
@@ -28256,7 +28256,7 @@
         },
         {
             "id": "e76b293b-4d9c-5ec5-bfba-17b11eced398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd3c43f-c5ff-42ee-a220-82aa7aef88e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd3c43f-c5ff-42ee-a220-82aa7aef88e7.jpg?1",
             "name": "Mountain Goat",
             "text": "",
             "colours": [
@@ -28290,7 +28290,7 @@
         },
         {
             "id": "cb00a69c-d443-5a7e-8d37-4b73825c8d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b62c98-8ca3-4768-addf-e255ca98c63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b62c98-8ca3-4768-addf-e255ca98c63c.jpg?1",
             "name": "Woodland Cemetery",
             "text": "",
             "colours": [],
@@ -28321,7 +28321,7 @@
         },
         {
             "id": "eb4bd950-f1fd-5c62-a2b7-dfc153f6feae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e286b0-b4c4-4b42-ba11-2eec962fee8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e286b0-b4c4-4b42-ba11-2eec962fee8c.jpg?1",
             "name": "Isolated Chapel",
             "text": "",
             "colours": [],
@@ -28352,7 +28352,7 @@
         },
         {
             "id": "8fd76051-34cb-5fb7-a9b3-8c398338cee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4fd0a3-c596-4a88-809b-6f16caf35adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4fd0a3-c596-4a88-809b-6f16caf35adb.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "",
             "colours": [
@@ -28387,7 +28387,7 @@
         },
         {
             "id": "7db7d1f7-8558-53cf-9e99-fa1abb098b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a0e3e-6e0f-412f-8bc7-1a1211c30e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a0e3e-6e0f-412f-8bc7-1a1211c30e1e.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "",
             "colours": [
@@ -28422,7 +28422,7 @@
         },
         {
             "id": "71ae9b6e-689a-5af9-a18a-1f51093aeadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917b8f0-f35c-44ec-8a59-e09b179a4328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917b8f0-f35c-44ec-8a59-e09b179a4328.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -28456,7 +28456,7 @@
         },
         {
             "id": "06239993-414b-5bad-9217-85933e4c75a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3e700f-71ec-4cb7-a795-7b7265fda71b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3e700f-71ec-4cb7-a795-7b7265fda71b.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -28490,7 +28490,7 @@
         },
         {
             "id": "42a48bb1-1f32-517f-91b1-a921621430be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347a7b0f-1239-4113-827c-aa67a6e0552e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347a7b0f-1239-4113-827c-aa67a6e0552e.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -28529,7 +28529,7 @@
         },
         {
             "id": "e8d1911d-3b62-5e34-8bbb-cf2802a1abf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -28567,7 +28567,7 @@
         },
         {
             "id": "c8e14900-b85b-5249-85e1-c71d1fcc9164",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -28605,7 +28605,7 @@
         },
         {
             "id": "abb57760-b05b-55ce-b261-7ddfdfce1954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -28643,7 +28643,7 @@
         },
         {
             "id": "52b84e65-99e2-5f1c-a8c3-3384c53da6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -28681,7 +28681,7 @@
         },
         {
             "id": "4a811142-c4a3-5b83-aa48-feaac9be3be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -28719,7 +28719,7 @@
         },
         {
             "id": "57eeee15-5a76-5413-bb2d-243b6c7419c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -28757,7 +28757,7 @@
         },
         {
             "id": "79416179-0526-5d8d-bf2a-ae4ba3632761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -28795,7 +28795,7 @@
         },
         {
             "id": "70835df7-9d50-5756-a438-dd91f6476e24",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -28833,7 +28833,7 @@
         },
         {
             "id": "9c52adbe-7776-5ee1-aab8-ba13fcfbfbc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -28871,7 +28871,7 @@
         },
         {
             "id": "c9bfa288-66d2-51f6-97db-3dcab3a7b600",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -28909,7 +28909,7 @@
         },
         {
             "id": "bf1c5fa5-8ee8-5b4f-8237-9540d7bad0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg?1",
             "name": "Terror // Terror",
             "text": "",
             "colours": [
@@ -28941,7 +28941,7 @@
         },
         {
             "id": "a8ee4f4d-55cd-55fd-a1a4-434fb2487a54",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg?1",
             "name": "Terror // Terror",
             "text": "",
             "colours": [
@@ -28973,7 +28973,7 @@
         },
         {
             "id": "c5f1bc0e-f65e-52fa-b0d8-fedb2f948183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d306864-1eeb-422a-a014-cb683faba096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d306864-1eeb-422a-a014-cb683faba096.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29011,7 +29011,7 @@
         },
         {
             "id": "8f519576-169e-58d7-97ff-dfe65c7c4a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939e67-17f0-4cd0-9ad1-be3dcb9fb299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939e67-17f0-4cd0-9ad1-be3dcb9fb299.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29049,7 +29049,7 @@
         },
         {
             "id": "2e766432-2ab3-5bd6-a6a8-bac7705e7200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd52f2e-5d07-4a10-8d1b-a456eaca977c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd52f2e-5d07-4a10-8d1b-a456eaca977c.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29087,7 +29087,7 @@
         },
         {
             "id": "3ade7809-fe3b-56f0-8271-3e4e3da06f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d296b765-c650-44d5-a4b6-1b58074c0007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d296b765-c650-44d5-a4b6-1b58074c0007.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29125,7 +29125,7 @@
         },
         {
             "id": "441273ec-dbe6-5713-8837-ddb5a492384d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4543516e-890f-44e8-acaa-da4e941e31dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4543516e-890f-44e8-acaa-da4e941e31dd.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29163,7 +29163,7 @@
         },
         {
             "id": "17b2e338-989d-5e8d-b4c6-c3a28a08e5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbf73e9-91ff-4c25-b618-62d652e75587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbf73e9-91ff-4c25-b618-62d652e75587.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -29202,7 +29202,7 @@
         },
         {
             "id": "d3a08696-fdf9-5ba8-b486-8d6dc386fc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40b82-ed28-451f-b191-b9eca2770ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40b82-ed28-451f-b191-b9eca2770ca5.jpg?1",
             "name": "Skemfar Shadowsage",
             "text": "",
             "colours": [
@@ -29236,7 +29236,7 @@
         },
         {
             "id": "e255b81c-f688-58ae-9082-67a5e7474a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb1b3d7-a48f-49c8-bb00-046ab5f61b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb1b3d7-a48f-49c8-bb00-046ab5f61b49.jpg?1",
             "name": "Elvish Vanguard",
             "text": "",
             "colours": [
@@ -29270,7 +29270,7 @@
         },
         {
             "id": "c9393ecb-c883-54e5-a09a-6ae90b2c613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef03e37-e5eb-4f46-885a-4c27044262da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef03e37-e5eb-4f46-885a-4c27044262da.jpg?1",
             "name": "Elvish Visionary",
             "text": "",
             "colours": [
@@ -29304,7 +29304,7 @@
         },
         {
             "id": "b306e9c1-5697-5a17-ab22-29a26d6adeb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4232b0-43e4-4352-948b-10cdc9660ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4232b0-43e4-4352-948b-10cdc9660ac2.jpg?1",
             "name": "Evolution Sage",
             "text": "",
             "colours": [
@@ -29338,7 +29338,7 @@
         },
         {
             "id": "b364964a-bb02-5906-88b0-f0e1fe9ee3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbbb398-9784-4a65-9caf-1d49b98cef20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbbb398-9784-4a65-9caf-1d49b98cef20.jpg?1",
             "name": "Farhaven Elf",
             "text": "",
             "colours": [
@@ -29372,7 +29372,7 @@
         },
         {
             "id": "ab22784c-0fe5-5c5e-8de9-146e195b276d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68581571-cd66-40b9-8a08-c54adf3515d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68581571-cd66-40b9-8a08-c54adf3515d1.jpg?1",
             "name": "Fierce Empath",
             "text": "",
             "colours": [
@@ -29405,7 +29405,7 @@
         },
         {
             "id": "ab89c5a1-c3e8-55f2-b2f5-6d8e5658188b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4596f46-d59d-4bff-afc4-a8235612da23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4596f46-d59d-4bff-afc4-a8235612da23.jpg?1",
             "name": "Generous Patron",
             "text": "",
             "colours": [
@@ -29439,7 +29439,7 @@
         },
         {
             "id": "79b4329d-7316-55fd-9407-c6b6630b840c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e810d32d-c073-4bc5-9ff5-7946c54e045d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e810d32d-c073-4bc5-9ff5-7946c54e045d.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "",
             "colours": [
@@ -29473,7 +29473,7 @@
         },
         {
             "id": "9f3d23d3-c678-5f6a-a15e-b8200263433a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9853c-8335-45e1-87a3-03cc2d35988c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9853c-8335-45e1-87a3-03cc2d35988c.jpg?1",
             "name": "Jaspera Sentinel",
             "text": "",
             "colours": [
@@ -29507,7 +29507,7 @@
         },
         {
             "id": "fb8d440b-d9ee-5c04-8c4b-858a098764d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168b0af2-aa4f-421d-bb0a-54f5ac3f72fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168b0af2-aa4f-421d-bb0a-54f5ac3f72fc.jpg?1",
             "name": "Llanowar Visionary",
             "text": "",
             "colours": [
@@ -29541,7 +29541,7 @@
         },
         {
             "id": "6195a00f-3111-53a6-8407-6ea83f3efa70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fc9e54-8fc4-4de4-be74-e925a85187b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fc9e54-8fc4-4de4-be74-e925a85187b4.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "",
             "colours": [
@@ -29575,7 +29575,7 @@
         },
         {
             "id": "c6b81f75-e166-5814-aeba-5c80734e1340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a03a37-08b7-403a-a5d6-efa1dd4cb8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a03a37-08b7-403a-a5d6-efa1dd4cb8d0.jpg?1",
             "name": "Nettle Sentinel",
             "text": "",
             "colours": [
@@ -29609,7 +29609,7 @@
         },
         {
             "id": "0be1caba-db21-5c84-8088-3a885a083328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9277591c-cf20-4f82-b308-84e69c51113a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9277591c-cf20-4f82-b308-84e69c51113a.jpg?1",
             "name": "Nullmage Shepherd",
             "text": "",
             "colours": [
@@ -29643,7 +29643,7 @@
         },
         {
             "id": "9eb8fc6c-c7c9-53e7-850a-d3e0a6345727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07425bc6-eb70-4b2b-a9e1-e56b098a0f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07425bc6-eb70-4b2b-a9e1-e56b098a0f22.jpg?1",
             "name": "Paradise Druid",
             "text": "",
             "colours": [
@@ -29677,7 +29677,7 @@
         },
         {
             "id": "dffe6d42-0d11-5b53-906f-0bd0c6ee98ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422e29a7-caf4-4d78-813d-10b6d83802d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422e29a7-caf4-4d78-813d-10b6d83802d3.jpg?1",
             "name": "Pollenbright Druid",
             "text": "",
             "colours": [
@@ -29711,7 +29711,7 @@
         },
         {
             "id": "e5b2c240-0e83-52fe-8b63-404b7e9b57ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3636c97-d21d-441d-baa8-7b1795b1548d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3636c97-d21d-441d-baa8-7b1795b1548d.jpg?1",
             "name": "Reclamation Sage",
             "text": "",
             "colours": [
@@ -29745,7 +29745,7 @@
         },
         {
             "id": "f6822898-27a9-5d0c-970d-9c7cf2be3ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70664ccf-07c6-470b-bfcf-e95442e86aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70664ccf-07c6-470b-bfcf-e95442e86aa5.jpg?1",
             "name": "Sylvan Ranger",
             "text": "",
             "colours": [
@@ -29780,7 +29780,7 @@
         },
         {
             "id": "38162fd1-21c2-5ef4-9f29-db701f019604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a513bd7e-b843-4bec-a50f-9f014cc86503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a513bd7e-b843-4bec-a50f-9f014cc86503.jpg?1",
             "name": "Timberwatch Elf",
             "text": "",
             "colours": [
@@ -29813,7 +29813,7 @@
         },
         {
             "id": "6d7987f0-3956-5760-af8d-4670dfa82652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2053d78-ec36-4159-8b5d-5b4757122e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2053d78-ec36-4159-8b5d-5b4757122e06.jpg?1",
             "name": "Viridian Shaman",
             "text": "",
             "colours": [
@@ -29847,7 +29847,7 @@
         },
         {
             "id": "cf561813-36d7-5b83-ab0a-bba602e5dc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cda011d-da71-4836-9795-f12a23041aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cda011d-da71-4836-9795-f12a23041aad.jpg?1",
             "name": "Wellwisher",
             "text": "",
             "colours": [
@@ -29880,7 +29880,7 @@
         },
         {
             "id": "08f7010f-5a47-5fdf-b10c-d3d1149f4a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a6012a-8bb5-436e-9ec2-54a0f06c9d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a6012a-8bb5-436e-9ec2-54a0f06c9d4e.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "",
             "colours": [
@@ -29913,7 +29913,7 @@
         },
         {
             "id": "1b1f3b2a-2775-533d-a276-cc57297edbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbcd517-12cf-4cec-b13a-7590b8874c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbcd517-12cf-4cec-b13a-7590b8874c5b.jpg?1",
             "name": "Frilled Mystic",
             "text": "",
             "colours": [
@@ -29950,7 +29950,7 @@
         },
         {
             "id": "0e5179c4-48ca-5dc5-9d1d-41c657e8f478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4241fbb-9874-4c6b-baa7-62527bc24991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4241fbb-9874-4c6b-baa7-62527bc24991.jpg?1",
             "name": "Poison-Tip Archer",
             "text": "",
             "colours": [
@@ -29986,7 +29986,7 @@
         },
         {
             "id": "0c6d861e-cd42-5abb-b6da-0ec0b126f5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfda3de9-2eea-44f6-ba1b-d001ede8f7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfda3de9-2eea-44f6-ba1b-d001ede8f7bb.jpg?1",
             "name": "Shaman of the Pack",
             "text": "",
             "colours": [
@@ -30022,7 +30022,7 @@
         },
         {
             "id": "366812fd-ef58-58e9-8f51-31400e63f0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa3fc7c-c340-454f-b89c-2d059d376cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa3fc7c-c340-454f-b89c-2d059d376cb1.jpg?1",
             "name": "Codex Shredder",
             "text": "",
             "colours": [],
@@ -30049,7 +30049,7 @@
         },
         {
             "id": "859a91b0-74f5-54a1-8dc3-e82560b61106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bd6b4a-4470-4e4d-9f7b-9b6f1d1dcde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bd6b4a-4470-4e4d-9f7b-9b6f1d1dcde7.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -30082,7 +30082,7 @@
         },
         {
             "id": "62ebd730-69fc-53b2-a8f3-e7937bd60cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1218c13-3b70-419f-bf95-84b04f2479f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1218c13-3b70-419f-bf95-84b04f2479f5.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -30115,7 +30115,7 @@
         },
         {
             "id": "2972b089-a5a7-5f98-a565-9266e960fc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57f710-7af0-44f0-9070-47e1b7c3560e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57f710-7af0-44f0-9070-47e1b7c3560e.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -30153,7 +30153,7 @@
         },
         {
             "id": "78b52e1c-0a24-563d-8fa6-6ce885a61cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1733387-4b5b-43b2-aa44-668330cb9922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1733387-4b5b-43b2-aa44-668330cb9922.jpg?1",
             "name": "Nine Lives",
             "text": "",
             "colours": [
@@ -30184,7 +30184,7 @@
         },
         {
             "id": "06146e6c-e4db-5a30-bd32-bb7889115f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c8803-f33a-4530-9882-bff1bf810c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c8803-f33a-4530-9882-bff1bf810c19.jpg?1",
             "name": "Yoshimaru, Ever Faithful",
             "text": "",
             "colours": [
@@ -30219,7 +30219,7 @@
         },
         {
             "id": "1bb2861a-ccf3-51a3-a2e3-f490d98d5b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837edd3f-5380-4c1c-8323-0e61dac385e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837edd3f-5380-4c1c-8323-0e61dac385e5.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -30252,7 +30252,7 @@
         },
         {
             "id": "d6e8ce9f-1d5b-5f8a-b440-532f59e57e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20b3a5b-c07e-4314-ab3e-097212ff5e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20b3a5b-c07e-4314-ab3e-097212ff5e6e.jpg?1",
             "name": "Mana Vault",
             "text": "",
             "colours": [],
@@ -30279,7 +30279,7 @@
         },
         {
             "id": "58afab62-ac14-5955-811e-43461da52ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff49618-4612-4a44-a0b7-9d710a7cd60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff49618-4612-4a44-a0b7-9d710a7cd60b.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "",
             "colours": [],
@@ -30309,7 +30309,7 @@
         },
         {
             "id": "22c509d2-3024-56fe-9664-3d35a65f1929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474c0f1-08c7-4183-b024-297a11594a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474c0f1-08c7-4183-b024-297a11594a96.jpg?1",
             "name": "Discord, Lord of Disharmony",
             "text": "",
             "colours": [
@@ -30347,7 +30347,7 @@
         },
         {
             "id": "66e7b77f-7f6d-58b3-adff-63f398e4c372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7726e1-f121-4283-9c54-66509f332f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7726e1-f121-4283-9c54-66509f332f39.jpg?1",
             "name": "Coveted Jewel",
             "text": "",
             "colours": [],
@@ -30375,7 +30375,7 @@
         },
         {
             "id": "c7872b2e-6097-5936-89fe-8e8eb628e867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9f1f7e-2e6a-4af3-8272-68cee14b6156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9f1f7e-2e6a-4af3-8272-68cee14b6156.jpg?1",
             "name": "Spiteful Prankster",
             "text": "",
             "colours": [
@@ -30409,7 +30409,7 @@
         },
         {
             "id": "eab30384-8280-5474-9367-5dc93a64f0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a70aa6-ac7d-4592-94b0-9ce862d71d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a70aa6-ac7d-4592-94b0-9ce862d71d50.jpg?1",
             "name": "Haystack",
             "text": "",
             "colours": [
@@ -30441,7 +30441,7 @@
         },
         {
             "id": "e4d688bd-6850-55ec-b508-f8c4bed4c644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3b2b9f-623f-4993-ad45-099ec3b570c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3b2b9f-623f-4993-ad45-099ec3b570c6.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30469,7 +30469,7 @@
         },
         {
             "id": "3d7e29ad-c87d-5a17-91a8-2262be528028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe8763-1373-49f8-b4a6-dd5984b1d25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe8763-1373-49f8-b4a6-dd5984b1d25f.jpg?1",
             "name": "Elvish Mystic",
             "text": "",
             "colours": [
@@ -30506,7 +30506,7 @@
         },
         {
             "id": "adf27287-c24b-5c50-95a2-1bdb4c998b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe98f7c-e6c0-4632-96da-a4c2e1a1c094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe98f7c-e6c0-4632-96da-a4c2e1a1c094.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -30545,7 +30545,7 @@
         },
         {
             "id": "a49f173e-c6df-5e16-9ac8-728f1e0661ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b4416-61da-4cd5-b3f1-79238a8e2503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b4416-61da-4cd5-b3f1-79238a8e2503.jpg?1",
             "name": "Chandra, Flamecaller",
             "text": "",
             "colours": [
@@ -30581,7 +30581,7 @@
         },
         {
             "id": "482fced3-4e5c-5315-88c8-9ce471e732d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcec142-ba44-4d66-a1cc-9f98870a69d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcec142-ba44-4d66-a1cc-9f98870a69d5.jpg?1",
             "name": "Snapcaster Mage",
             "text": "",
             "colours": [
@@ -30616,7 +30616,7 @@
         },
         {
             "id": "97933f1e-0675-5650-8754-3280470734fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637216e9-ff5f-4dd5-ac08-a26a334431fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637216e9-ff5f-4dd5-ac08-a26a334431fb.jpg?1",
             "name": "Immerwolf",
             "text": "",
             "colours": [
@@ -30652,7 +30652,7 @@
         },
         {
             "id": "93f31c45-0c82-50bc-822d-fdbc9a47f377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3776ea-c599-4e39-8259-41d33fdfbb7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3776ea-c599-4e39-8259-41d33fdfbb7e.jpg?1",
             "name": "Thrun, the Last Troll",
             "text": "",
             "colours": [
@@ -30689,7 +30689,7 @@
         },
         {
             "id": "819979c0-2d0b-5284-b99f-05e8adcb6cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c000fe-726f-4236-9317-c9dfeba4fb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c000fe-726f-4236-9317-c9dfeba4fb66.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "",
             "colours": [
@@ -30727,7 +30727,7 @@
         },
         {
             "id": "d0b1e043-d5e4-5feb-8066-b271adfe8d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6002d99a-c7b4-4845-aca9-b55dabb62d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6002d99a-c7b4-4845-aca9-b55dabb62d9f.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -30763,7 +30763,7 @@
         },
         {
             "id": "f4d4bb37-348c-5ef4-be48-c7a5943a7ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3722c7e8-bba3-4db0-a157-577cf37f53b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3722c7e8-bba3-4db0-a157-577cf37f53b4.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -30799,7 +30799,7 @@
         },
         {
             "id": "7fdf74ff-d4cd-59ad-8143-64d86835676f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2a3a29-b629-45f8-bd20-68a8d5018504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2a3a29-b629-45f8-bd20-68a8d5018504.jpg?1",
             "name": "Echo of Eons",
             "text": "",
             "colours": [
@@ -30830,7 +30830,7 @@
         },
         {
             "id": "f5fbfde9-bc18-5125-8e72-e53dbf2eedcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bff89a1-f7e7-4da9-9020-8618afdffda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bff89a1-f7e7-4da9-9020-8618afdffda2.jpg?1",
             "name": "Hive Mind",
             "text": "",
             "colours": [
@@ -30861,7 +30861,7 @@
         },
         {
             "id": "563203b8-dcfc-58dd-8124-acc69335f589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10adb81c-d6c1-4335-83d8-10561bbed490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10adb81c-d6c1-4335-83d8-10561bbed490.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -30895,7 +30895,7 @@
         },
         {
             "id": "249c2f83-0956-5389-8e69-e35fb3afbcf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd37785-bbef-4628-b88a-4ff28b0a7034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd37785-bbef-4628-b88a-4ff28b0a7034.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -30924,7 +30924,7 @@
         },
         {
             "id": "e725c841-7efb-524e-94ee-8d8090a19898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1f94b-ab3e-4adb-b72a-89f3ea9f5859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1f94b-ab3e-4adb-b72a-89f3ea9f5859.jpg?1",
             "name": "Goblin Bombardment",
             "text": "",
             "colours": [
@@ -30956,7 +30956,7 @@
         },
         {
             "id": "ae47d3c0-94db-53a0-8d49-5d7b44323835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c51a722-633c-4325-ab50-633cebbb5cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c51a722-633c-4325-ab50-633cebbb5cd9.jpg?1",
             "name": "Kezzerdrix",
             "text": "",
             "colours": [
@@ -30991,7 +30991,7 @@
         },
         {
             "id": "781657aa-cfa7-5d2e-9bed-76bee77572b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg?1",
             "name": "Norin the Wary // Norin the Wary",
             "text": "",
             "colours": [
@@ -31028,7 +31028,7 @@
         },
         {
             "id": "2ea5cc89-736d-53a2-ba81-7b0f4f0410b7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg?1",
             "name": "Norin the Wary // Norin the Wary",
             "text": "",
             "colours": [
@@ -31065,7 +31065,7 @@
         },
         {
             "id": "12d6bd30-bbf2-552d-bb2d-b14e28d75c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0491d-1aea-4d16-83c3-2f58e8bbda5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0491d-1aea-4d16-83c3-2f58e8bbda5a.jpg?1",
             "name": "Keen Duelist",
             "text": "",
             "colours": [
@@ -31100,7 +31100,7 @@
         },
         {
             "id": "28c61000-afb0-5e0a-960c-d85cc2759f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d974ae0-5d39-4b2d-8ca0-2ebed2657e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d974ae0-5d39-4b2d-8ca0-2ebed2657e25.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "",
             "colours": [],
@@ -31130,7 +31130,7 @@
         },
         {
             "id": "083dd03d-c680-5f20-bc6f-50e351ea2732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f824b34-f783-48b3-b5d5-579935101148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f824b34-f783-48b3-b5d5-579935101148.jpg?1",
             "name": "Sculpting Steel",
             "text": "",
             "colours": [],
@@ -31158,7 +31158,7 @@
         },
         {
             "id": "eff20120-c2d2-5e76-b4fc-0821cb327261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a86d3-83ed-4df3-923f-3117296b7224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a86d3-83ed-4df3-923f-3117296b7224.jpg?1",
             "name": "Unnatural Growth",
             "text": "",
             "colours": [
@@ -31190,7 +31190,7 @@
         },
         {
             "id": "ebd3b847-b5df-52d5-acd5-297dd1330c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851ceb9-0efa-42a6-9fd6-434817a43815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851ceb9-0efa-42a6-9fd6-434817a43815.jpg?1",
             "name": "Regrowth",
             "text": "",
             "colours": [
@@ -31222,7 +31222,7 @@
         },
         {
             "id": "ba09d4b0-afda-577b-87a8-4be611b0f517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bec40e-d97b-4d13-a77f-128baf4cca14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bec40e-d97b-4d13-a77f-128baf4cca14.jpg?1",
             "name": "Nature's Lore",
             "text": "",
             "colours": [
@@ -31256,7 +31256,7 @@
         },
         {
             "id": "3c98b54f-b584-5460-a223-4d2976488ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200d01f-7cb6-47e0-8dd8-0b5f901fb66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200d01f-7cb6-47e0-8dd8-0b5f901fb66f.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "",
             "colours": [],
@@ -31284,7 +31284,7 @@
         },
         {
             "id": "5bea591e-3738-5a6f-8296-3a99a8fda1dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f519bd-b396-4e45-881e-707f6822c402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f519bd-b396-4e45-881e-707f6822c402.jpg?1",
             "name": "Yargle and Multani",
             "text": "",
             "colours": [
@@ -31324,7 +31324,7 @@
         },
         {
             "id": "14e4ba07-790b-51c0-bcdb-137d0fec36f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e234227-d91e-4049-ad4a-3beca6b89023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e234227-d91e-4049-ad4a-3beca6b89023.jpg?1",
             "name": "Dark Deal",
             "text": "",
             "colours": [
@@ -31356,7 +31356,7 @@
         },
         {
             "id": "4e35ac21-63a4-5885-922e-289c48fe88ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5100d6c-ca6e-40e5-8c55-50e74237ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5100d6c-ca6e-40e5-8c55-50e74237ced4.jpg?1",
             "name": "Archivist of Oghma",
             "text": "",
             "colours": [
@@ -31390,7 +31390,7 @@
         },
         {
             "id": "7fb59749-390f-517e-8a59-ba55ebb22e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3c8050-6acb-4d53-ba46-646ca88d4eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3c8050-6acb-4d53-ba46-646ca88d4eb6.jpg?1",
             "name": "Battle Angels of Tyr",
             "text": "",
             "colours": [
@@ -31424,7 +31424,7 @@
         },
         {
             "id": "fa4f835d-4d7c-53f8-9b09-119ddfc9f1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d09b91-d4da-4e8f-a6ef-09482e09842d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d09b91-d4da-4e8f-a6ef-09482e09842d.jpg?1",
             "name": "Xorn",
             "text": "",
             "colours": [
@@ -31457,7 +31457,7 @@
         },
         {
             "id": "1713be40-f07d-5ed3-a1a9-7d52b532a038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1aa886-dc3b-44f7-880c-52370242e81f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1aa886-dc3b-44f7-880c-52370242e81f.jpg?1",
             "name": "Druid of Purification",
             "text": "",
             "colours": [
@@ -31491,7 +31491,7 @@
         },
         {
             "id": "ae60423b-7dce-5529-b7fa-500e5a058c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab26569-5e7a-410c-86d3-a7ab989f7a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab26569-5e7a-410c-86d3-a7ab989f7a31.jpg?1",
             "name": "Prosperous Innkeeper",
             "text": "",
             "colours": [
@@ -31525,7 +31525,7 @@
         },
         {
             "id": "e68dbaf2-8a86-53c8-a336-7f08f29c047a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149b45d-b7d4-46bf-ba3a-5137e93ea607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149b45d-b7d4-46bf-ba3a-5137e93ea607.jpg?1",
             "name": "Minsc & Boo, Timeless Heroes",
             "text": "",
             "colours": [
@@ -31562,7 +31562,7 @@
         },
         {
             "id": "9bd879ca-c5b7-54c2-8ee5-92178ba6c29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b5e4e-e68f-4b7d-a9c3-af01aa92c4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b5e4e-e68f-4b7d-a9c3-af01aa92c4e8.jpg?1",
             "name": "Stuffy Doll",
             "text": "",
             "colours": [],
@@ -31593,7 +31593,7 @@
         },
         {
             "id": "35e83c6e-3669-5a42-bc1a-9e437348f2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c547c39-9ef8-4e8c-a6fd-6d9b6a8345a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c547c39-9ef8-4e8c-a6fd-6d9b6a8345a5.jpg?1",
             "name": "Solve the Equation",
             "text": "",
             "colours": [
@@ -31627,7 +31627,7 @@
         },
         {
             "id": "38dc92e1-2c72-54d4-b40e-95b68b976803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2025bd7b-ddef-40cf-9ffd-80591a67b508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2025bd7b-ddef-40cf-9ffd-80591a67b508.jpg?1",
             "name": "The Scarab God",
             "text": "",
             "colours": [
@@ -31664,7 +31664,7 @@
         },
         {
             "id": "19afaf76-fd5c-5a14-bbc7-c1a8fb31de32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c0b1-da97-49c1-a539-7fbaa1f77419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c0b1-da97-49c1-a539-7fbaa1f77419.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -31705,7 +31705,7 @@
         },
         {
             "id": "ad89ae78-b8b9-57e0-b58e-04a4d3dc03a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdf04a4-ba1e-4e0d-8c50-d7cea15fd0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdf04a4-ba1e-4e0d-8c50-d7cea15fd0a2.jpg?1",
             "name": "The Locust God",
             "text": "",
             "colours": [
@@ -31742,7 +31742,7 @@
         },
         {
             "id": "96a8bdb7-09c2-5c2d-b3bc-0687f362c808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb52dfd-f603-4fdf-bd9f-20c84c2c28c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb52dfd-f603-4fdf-bd9f-20c84c2c28c4.jpg?1",
             "name": "The Scorpion God",
             "text": "",
             "colours": [
@@ -31779,7 +31779,7 @@
         },
         {
             "id": "bdac9f73-e7c5-5caf-a071-29bede21016a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99beb62-7c89-41e7-9ac2-c1722f679a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99beb62-7c89-41e7-9ac2-c1722f679a2c.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "",
             "colours": [
@@ -31815,7 +31815,7 @@
         },
         {
             "id": "4b08fdab-b445-54b9-b6de-963b61ca12e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b00b40e-338a-48d0-b95a-c1d5815370a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b00b40e-338a-48d0-b95a-c1d5815370a0.jpg?1",
             "name": "Seedborn Muse",
             "text": "",
             "colours": [
@@ -31848,7 +31848,7 @@
         },
         {
             "id": "b097a7b6-0700-5073-8fca-9572cddac774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ed44c-7b95-4153-afde-cfa2fef4e146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ed44c-7b95-4153-afde-cfa2fef4e146.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -31884,7 +31884,7 @@
         },
         {
             "id": "608517b6-5dc0-5c20-b90a-9642ffd4aa25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cfc62a-2bd0-4292-968e-64c77f427f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cfc62a-2bd0-4292-968e-64c77f427f78.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "",
             "colours": [
@@ -31922,7 +31922,7 @@
         },
         {
             "id": "2a1857df-95fb-5af0-94fb-1bb6a589f772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c327b8-0b21-425b-87d8-3d04397becfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c327b8-0b21-425b-87d8-3d04397becfe.jpg?1",
             "name": "Patron Wizard",
             "text": "",
             "colours": [
@@ -31957,7 +31957,7 @@
         },
         {
             "id": "1e10289a-c9a9-54d9-a7e6-699208ed6738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ec6360-d69d-41b8-bfca-2c1a3aea2272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ec6360-d69d-41b8-bfca-2c1a3aea2272.jpg?1",
             "name": "Berserk",
             "text": "",
             "colours": [
@@ -31991,7 +31991,7 @@
         },
         {
             "id": "ad536aa2-655b-5ac0-b13e-6b1438169639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526138f9-5003-4597-9ea6-0d83fee5035a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526138f9-5003-4597-9ea6-0d83fee5035a.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -32026,7 +32026,7 @@
         },
         {
             "id": "935f9538-607c-55ec-b43c-c7bf5cb99a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b822c67-77af-4778-ad1a-374fd780991d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b822c67-77af-4778-ad1a-374fd780991d.jpg?1",
             "name": "Triumphant Reckoning",
             "text": "",
             "colours": [
@@ -32058,7 +32058,7 @@
         },
         {
             "id": "9c1a08b1-8317-5a1a-ad0f-99accfc689c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8280fe-aea3-4796-af6e-6226c6085b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8280fe-aea3-4796-af6e-6226c6085b99.jpg?1",
             "name": "Savor the Moment",
             "text": "",
             "colours": [
@@ -32090,7 +32090,7 @@
         },
         {
             "id": "ecf85371-fbf3-5ac3-a934-712b47080329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e38facb-f520-4950-aa73-bebd2011565c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e38facb-f520-4950-aa73-bebd2011565c.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "",
             "colours": [
@@ -32129,7 +32129,7 @@
         },
         {
             "id": "424ef30a-d0c8-5e41-b433-dace84a422c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8855d65-98fc-4b5f-bd68-95d2fda6345f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8855d65-98fc-4b5f-bd68-95d2fda6345f.jpg?1",
             "name": "Bearscape",
             "text": "",
             "colours": [
@@ -32161,7 +32161,7 @@
         },
         {
             "id": "83713cae-fbfa-5321-967d-ff1405f7d42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54c9dfe-685a-4400-aa7c-0a944c33577b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54c9dfe-685a-4400-aa7c-0a944c33577b.jpg?1",
             "name": "Collective Voyage",
             "text": "",
             "colours": [
@@ -32193,7 +32193,7 @@
         },
         {
             "id": "ee93cd55-1bb5-5ebc-85ac-5f3989d329d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2714874e-ad9c-4b9a-a91d-16865d29b183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2714874e-ad9c-4b9a-a91d-16865d29b183.jpg?1",
             "name": "Heartbeat of Spring",
             "text": "",
             "colours": [
@@ -32225,7 +32225,7 @@
         },
         {
             "id": "006bd15a-3949-51a7-9c11-06142f3bcc41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b2235b-6c18-436e-9d80-4a82ce0cac14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b2235b-6c18-436e-9d80-4a82ce0cac14.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -32262,7 +32262,7 @@
         },
         {
             "id": "9e53baaf-2db0-5bc2-b81e-ef11d225c6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4b80b1-fc8d-4da6-964a-3b85451c3049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4b80b1-fc8d-4da6-964a-3b85451c3049.jpg?1",
             "name": "Mana Confluence",
             "text": "",
             "colours": [],
@@ -32290,7 +32290,7 @@
         },
         {
             "id": "8759ce91-1023-5340-95f1-055717ae0630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebbdc78-4317-4595-a3c7-f265026c11d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebbdc78-4317-4595-a3c7-f265026c11d1.jpg?1",
             "name": "Icingdeath, Frost Tyrant",
             "text": "",
             "colours": [
@@ -32325,7 +32325,7 @@
         },
         {
             "id": "b0513660-82f2-5158-ab44-ec9244e37aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b381c1a-63e7-4f35-947a-f2b76c49c1ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b381c1a-63e7-4f35-947a-f2b76c49c1ec.jpg?1",
             "name": "Iymrith, Desert Doom",
             "text": "",
             "colours": [
@@ -32360,7 +32360,7 @@
         },
         {
             "id": "202d407a-2364-58d0-bc06-85ed0d4997d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea750e6-cdb8-4119-b26d-86abdbc14fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea750e6-cdb8-4119-b26d-86abdbc14fb2.jpg?1",
             "name": "Ebondeath, Dracolich",
             "text": "",
             "colours": [
@@ -32396,7 +32396,7 @@
         },
         {
             "id": "a96c02e5-788e-5c9d-99f5-5426a7a53722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830baa09-6098-4530-ae1f-8c94e60e733d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830baa09-6098-4530-ae1f-8c94e60e733d.jpg?1",
             "name": "Inferno of the Star Mounts",
             "text": "",
             "colours": [
@@ -32431,7 +32431,7 @@
         },
         {
             "id": "0ceadb69-5e40-589a-a257-b08bd52f6e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0737-e1a5-4112-afde-34a3375e23f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0737-e1a5-4112-afde-34a3375e23f7.jpg?1",
             "name": "Old Gnawbone",
             "text": "",
             "colours": [
@@ -32466,7 +32466,7 @@
         },
         {
             "id": "453ddf17-aee4-509d-8d4b-6e0151e27aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ed714e-28df-4bf3-9752-112a6e9e3609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ed714e-28df-4bf3-9752-112a6e9e3609.jpg?1",
             "name": "Tiamat",
             "text": "",
             "colours": [
@@ -32510,7 +32510,7 @@
         },
         {
             "id": "0b920de3-eee6-54d3-b1b3-7176d8e47ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ccb445-53dc-40d7-abea-d6d8dff60ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ccb445-53dc-40d7-abea-d6d8dff60ce4.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -32545,7 +32545,7 @@
         },
         {
             "id": "1f56bb70-91d3-591c-95d7-6d7103dd7f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004dc79-3857-4663-930c-59b2240e84bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004dc79-3857-4663-930c-59b2240e84bc.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -32583,7 +32583,7 @@
         },
         {
             "id": "5151c92a-cdb6-544e-ad06-4f22d0a4329d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e8c1c1-1917-4858-afd1-ea4412d02375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e8c1c1-1917-4858-afd1-ea4412d02375.jpg?1",
             "name": "Solve the Equation",
             "text": "",
             "colours": [
@@ -32617,7 +32617,7 @@
         },
         {
             "id": "63d376a1-dcf3-5efa-b250-1eb25ad1ca84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e9151-d8b7-43f6-ac21-a8760cc04c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e9151-d8b7-43f6-ac21-a8760cc04c7a.jpg?1",
             "name": "Praetor's Grasp",
             "text": "",
             "colours": [
@@ -32649,7 +32649,7 @@
         },
         {
             "id": "9f5509f4-de0c-5088-941a-0b52fe07ee16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d727c345-4c96-4087-bfe3-f54b47b01da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d727c345-4c96-4087-bfe3-f54b47b01da6.jpg?1",
             "name": "Veil of Summer",
             "text": "",
             "colours": [
@@ -32681,7 +32681,7 @@
         },
         {
             "id": "035798e9-575e-5cd2-acdd-1fd2b238b7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d054f9-ef77-4552-aa49-e9dfd840d8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d054f9-ef77-4552-aa49-e9dfd840d8f6.jpg?1",
             "name": "Merciless Executioner",
             "text": "",
             "colours": [
@@ -32716,7 +32716,7 @@
         },
         {
             "id": "5d2d2a06-526d-5345-be2c-56262f9be32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcfc82b-3e8a-4785-a87e-e96b5bfca90f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcfc82b-3e8a-4785-a87e-e96b5bfca90f.jpg?1",
             "name": "Aggravated Assault",
             "text": "",
             "colours": [
@@ -32748,7 +32748,7 @@
         },
         {
             "id": "e3fdb723-5441-5602-83d5-8ca5c9917077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a762a954-1166-4c6c-bf87-0f68a5a24f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a762a954-1166-4c6c-bf87-0f68a5a24f3e.jpg?1",
             "name": "Krenko, Tin Street Kingpin",
             "text": "",
             "colours": [
@@ -32784,7 +32784,7 @@
         },
         {
             "id": "04ed9d32-b51b-57ed-9b7d-efdceca5dcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd4c537-e2ef-4c6f-93d0-f427a40c1cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd4c537-e2ef-4c6f-93d0-f427a40c1cf5.jpg?1",
             "name": "Zurgo Helmsmasher",
             "text": "",
             "colours": [
@@ -32825,7 +32825,7 @@
         },
         {
             "id": "ad7d1a7f-995e-58da-9795-6cde98637a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9438e910-2974-49f8-825d-9835e72cee2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9438e910-2974-49f8-825d-9835e72cee2a.jpg?1",
             "name": "Skysovereign, Consul Flagship",
             "text": "",
             "colours": [],
@@ -32857,7 +32857,7 @@
         },
         {
             "id": "f7d71764-f0cd-560f-8ee8-1d6c036ebe51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b387332-5725-40c2-abf5-2562038e85a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b387332-5725-40c2-abf5-2562038e85a3.jpg?1",
             "name": "Blind Obedience",
             "text": "",
             "colours": [
@@ -32889,7 +32889,7 @@
         },
         {
             "id": "78e6306f-518f-5096-b189-afa28bc1a9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf204f62-999b-4a2c-95de-a733d9c54f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf204f62-999b-4a2c-95de-a733d9c54f1a.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "",
             "colours": [
@@ -32926,7 +32926,7 @@
         },
         {
             "id": "ccc07905-0c56-5946-b6fd-3134fa2b31b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84d0c3c-7382-46f9-a826-44100ac7cb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84d0c3c-7382-46f9-a826-44100ac7cb41.jpg?1",
             "name": "Najeela, the Blade-Blossom",
             "text": "",
             "colours": [
@@ -32969,7 +32969,7 @@
         },
         {
             "id": "37b1cdf4-992c-5906-9434-8591274b6e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4c7818-4523-44e9-baa4-013695d57bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4c7818-4523-44e9-baa4-013695d57bc4.jpg?1",
             "name": "Scourge of the Throne",
             "text": "",
             "colours": [
@@ -33003,7 +33003,7 @@
         },
         {
             "id": "5bb27b48-44ba-5423-a948-0edb1d2e8753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e2117e-fc5f-4783-87e8-8d733c836b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e2117e-fc5f-4783-87e8-8d733c836b0f.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "",
             "colours": [],
@@ -33033,7 +33033,7 @@
         },
         {
             "id": "eb93124f-5f07-5b0d-b93d-390532b81bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd2850b-8b86-4af0-a6f0-5dddfed6e811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd2850b-8b86-4af0-a6f0-5dddfed6e811.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -33065,7 +33065,7 @@
         },
         {
             "id": "34b19e1a-6f92-5554-aa2a-f297e2eab75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f2538a-9446-45bd-8d28-7a03f812170e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f2538a-9446-45bd-8d28-7a03f812170e.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -33099,7 +33099,7 @@
         },
         {
             "id": "43158c6b-27b8-5a98-88a8-b2d952e4babe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a35bb96-89de-4a0a-a53e-aa97f800e92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a35bb96-89de-4a0a-a53e-aa97f800e92f.jpg?1",
             "name": "Bone Splinters",
             "text": "",
             "colours": [
@@ -33131,7 +33131,7 @@
         },
         {
             "id": "6f44b9d1-a831-5393-bd2f-2bb56e5e0246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7121b5b3-7f05-4914-9af8-5d2bcde9b28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7121b5b3-7f05-4914-9af8-5d2bcde9b28a.jpg?1",
             "name": "Fling",
             "text": "",
             "colours": [
@@ -33165,7 +33165,7 @@
         },
         {
             "id": "1176a559-acc9-5e33-b631-3873de0311e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0c008-e0d9-43b3-9781-d4abbb410413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0c008-e0d9-43b3-9781-d4abbb410413.jpg?1",
             "name": "Defense of the Heart",
             "text": "",
             "colours": [
@@ -33197,7 +33197,7 @@
         },
         {
             "id": "a0c48483-1f11-5732-b4fb-9e8573fcc473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cd70c4-17e9-4bbe-a8f8-2a29450835a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cd70c4-17e9-4bbe-a8f8-2a29450835a9.jpg?1",
             "name": "Fellwar Stone",
             "text": "",
             "colours": [],
@@ -33227,7 +33227,7 @@
         },
         {
             "id": "6ab06fa1-b53f-5dec-a1b5-a52b2ed29339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5e5f25-41c8-4626-bb14-a121167a9d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5e5f25-41c8-4626-bb14-a121167a9d79.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -33266,7 +33266,7 @@
         },
         {
             "id": "b4f4e3c5-6df5-5387-95e7-91fa005696e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a31fb1-a323-47e1-b455-489623889794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a31fb1-a323-47e1-b455-489623889794.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "",
             "colours": [
@@ -33304,7 +33304,7 @@
         },
         {
             "id": "2d156d05-2b8b-5005-82f3-6b8be88ad304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0b540a-3f90-4730-a3a1-034992363b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0b540a-3f90-4730-a3a1-034992363b53.jpg?1",
             "name": "Tezzeret, Agent of Bolas",
             "text": "",
             "colours": [
@@ -33342,7 +33342,7 @@
         },
         {
             "id": "576fd091-b2e5-5605-9c32-207c51362cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fac637-9440-4994-b15a-a65364c51089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fac637-9440-4994-b15a-a65364c51089.jpg?1",
             "name": "Knight Exemplar",
             "text": "",
             "colours": [
@@ -33379,7 +33379,7 @@
         },
         {
             "id": "94d9092a-01b3-5970-8470-dd7509fc19dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc8ddc-140a-4e1d-a89a-93ba4756cf5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc8ddc-140a-4e1d-a89a-93ba4756cf5a.jpg?1",
             "name": "Knight of the White Orchid",
             "text": "",
             "colours": [
@@ -33414,7 +33414,7 @@
         },
         {
             "id": "4df40b20-df8a-565c-84f2-7bab4568106b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9249230d-6cd4-4f2e-8f8b-c046824a1c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9249230d-6cd4-4f2e-8f8b-c046824a1c72.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -33448,7 +33448,7 @@
         },
         {
             "id": "3d0a2362-5626-51ed-9418-e4e1f2137b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf89e72-1448-48c0-b2b4-ebac0262efdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf89e72-1448-48c0-b2b4-ebac0262efdb.jpg?1",
             "name": "Compost",
             "text": "",
             "colours": [
@@ -33480,7 +33480,7 @@
         },
         {
             "id": "9e171985-ac1b-5d1b-9d60-2c28521d8ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff105f-58bd-4c4c-ba18-dedbe7aab75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff105f-58bd-4c4c-ba18-dedbe7aab75e.jpg?1",
             "name": "Matter Reshaper",
             "text": "",
             "colours": [],
@@ -33510,7 +33510,7 @@
         },
         {
             "id": "cb2e7b83-8745-530b-ba89-8662bc194a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182556f-3a01-41b5-a469-50ce5363c863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182556f-3a01-41b5-a469-50ce5363c863.jpg?1",
             "name": "Toothy, Imaginary Friend",
             "text": "",
             "colours": [
@@ -33546,7 +33546,7 @@
         },
         {
             "id": "c8170053-4d6e-5f87-8342-aa0a17e2e913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e84108-c54f-4074-b38c-91dc8abc2f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e84108-c54f-4074-b38c-91dc8abc2f64.jpg?1",
             "name": "Pir, Imaginative Rascal",
             "text": "",
             "colours": [
@@ -33582,7 +33582,7 @@
         },
         {
             "id": "b021111e-4fb2-58aa-abf7-e8b8b6ece830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f569425-465f-42a8-ae4e-7e98d70cc2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f569425-465f-42a8-ae4e-7e98d70cc2af.jpg?1",
             "name": "The Gitrog Monster",
             "text": "",
             "colours": [
@@ -33621,7 +33621,7 @@
         },
         {
             "id": "3cb6b3cc-5e5d-50f0-a3b7-7369806f9b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7333e089-dc31-4c2f-9230-c2033d95c7e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7333e089-dc31-4c2f-9230-c2033d95c7e6.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -33652,7 +33652,7 @@
         },
         {
             "id": "363f6b00-6a05-58e2-973b-37a2008a6655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5713b7-f2a6-41c5-a485-058b7393570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5713b7-f2a6-41c5-a485-058b7393570b.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -33683,7 +33683,7 @@
         },
         {
             "id": "1ffcd397-6268-52e0-aa5e-e98f8e7f7f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85dab-5887-47bb-b5f2-fd11ff77ef91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85dab-5887-47bb-b5f2-fd11ff77ef91.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -33714,7 +33714,7 @@
         },
         {
             "id": "32743d64-e7e4-5d4d-b2a3-2fd6ce5e450c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb35429-30ee-4e2f-80ad-083faf53e264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb35429-30ee-4e2f-80ad-083faf53e264.jpg?1",
             "name": "Talisman of Impulse",
             "text": "",
             "colours": [],
@@ -33745,7 +33745,7 @@
         },
         {
             "id": "760de224-66ec-5d0b-b026-588a5bb8a15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b6bdac-02d4-4661-b022-103f19232985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b6bdac-02d4-4661-b022-103f19232985.jpg?1",
             "name": "Talisman of Unity",
             "text": "",
             "colours": [],
@@ -33776,7 +33776,7 @@
         },
         {
             "id": "22caa1e2-3059-51d4-a896-4143da0377c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36168640-0708-4d51-bc8e-d32e24ae095a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36168640-0708-4d51-bc8e-d32e24ae095a.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "",
             "colours": [],
@@ -33807,7 +33807,7 @@
         },
         {
             "id": "48d71efe-fa4d-550b-85bb-de85c88cc651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc0a11c-99f0-439d-a372-4fd77e007df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc0a11c-99f0-439d-a372-4fd77e007df4.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -33838,7 +33838,7 @@
         },
         {
             "id": "0ad03e94-eac8-5aaa-9bdd-807303af390b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a259eb-c6a2-4890-810a-239df5461e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a259eb-c6a2-4890-810a-239df5461e2f.jpg?1",
             "name": "Talisman of Resilience",
             "text": "",
             "colours": [],
@@ -33869,7 +33869,7 @@
         },
         {
             "id": "951501c3-b786-5631-879a-2f52eb0f1721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832cfe00-bc3e-46bb-b4bd-43f758290a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832cfe00-bc3e-46bb-b4bd-43f758290a41.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -33900,7 +33900,7 @@
         },
         {
             "id": "e6e4d49e-fe75-58b3-9e20-f285dc4db156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc83e0-7de2-4680-9d68-15a6018095fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc83e0-7de2-4680-9d68-15a6018095fe.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -33931,7 +33931,7 @@
         },
         {
             "id": "b7109b64-9964-53aa-abe6-770b77ba0d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699a5f43-2433-401c-be13-7ef15882983f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699a5f43-2433-401c-be13-7ef15882983f.jpg?1",
             "name": "Jaya Ballard",
             "text": "",
             "colours": [
@@ -33967,7 +33967,7 @@
         },
         {
             "id": "4644b4b9-ad7f-50ce-844b-79144804e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41277c6-95f8-4f0e-ad4a-43b8bb7cdb19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41277c6-95f8-4f0e-ad4a-43b8bb7cdb19.jpg?1",
             "name": "Jaya's Immolating Inferno",
             "text": "",
             "colours": [
@@ -34001,7 +34001,7 @@
         },
         {
             "id": "17588444-b1ad-51dc-820f-98def84f4fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb425ed1-d428-495a-a56f-07b81e97dcd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb425ed1-d428-495a-a56f-07b81e97dcd3.jpg?1",
             "name": "Pyretic Ritual",
             "text": "",
             "colours": [
@@ -34033,7 +34033,7 @@
         },
         {
             "id": "10f13dc5-a9a8-52ee-afaf-c0fd70d8fa04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da327c8-730b-4fab-827f-64e7f5b60e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da327c8-730b-4fab-827f-64e7f5b60e1d.jpg?1",
             "name": "Repercussion",
             "text": "",
             "colours": [
@@ -34065,7 +34065,7 @@
         },
         {
             "id": "7461f0b7-6b34-571b-b37e-5bc8635523a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b25bd-6a0f-4521-a6ff-deee9c2ada98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b25bd-6a0f-4521-a6ff-deee9c2ada98.jpg?1",
             "name": "Pyromancer's Goggles",
             "text": "",
             "colours": [],
@@ -34097,7 +34097,7 @@
         },
         {
             "id": "bd22d556-019c-5851-bc8d-c0dc28953421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b99807-cbb9-4d77-b36e-0bc9ccea27a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b99807-cbb9-4d77-b36e-0bc9ccea27a6.jpg?1",
             "name": "Arcades Sabboth",
             "text": "",
             "colours": [
@@ -34137,7 +34137,7 @@
         },
         {
             "id": "f6a68c60-65de-5a53-b6d7-60a0cf37c288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488a3ee9-a8c4-4a39-ad07-857560bff200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488a3ee9-a8c4-4a39-ad07-857560bff200.jpg?1",
             "name": "Chromium",
             "text": "",
             "colours": [
@@ -34177,7 +34177,7 @@
         },
         {
             "id": "e3829365-ea26-5ff6-9ad2-6580e2ce9f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f4e969-242f-41a9-9d5f-90c7f95cf472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f4e969-242f-41a9-9d5f-90c7f95cf472.jpg?1",
             "name": "Nicol Bolas",
             "text": "",
             "colours": [
@@ -34217,7 +34217,7 @@
         },
         {
             "id": "8b8a58fb-2ce9-5708-ba10-edb71857ebc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd3abf1-7641-4f5f-99d3-0c9ae65ba5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd3abf1-7641-4f5f-99d3-0c9ae65ba5fe.jpg?1",
             "name": "Vaevictis Asmadi",
             "text": "",
             "colours": [
@@ -34257,7 +34257,7 @@
         },
         {
             "id": "49b219fc-8f51-51b8-8930-192d0f304003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455fe817-0921-4497-a041-04030b0aac55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455fe817-0921-4497-a041-04030b0aac55.jpg?1",
             "name": "Palladia-Mors",
             "text": "",
             "colours": [
@@ -34297,7 +34297,7 @@
         },
         {
             "id": "94880280-4b33-5832-be36-dfa4bc94be22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2dbb1a-4b83-47b6-92ca-145fa5c9c16b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2dbb1a-4b83-47b6-92ca-145fa5c9c16b.jpg?1",
             "name": "Mox Opal",
             "text": "",
             "colours": [],
@@ -34326,7 +34326,7 @@
         },
         {
             "id": "8d96c02b-8203-51d7-8dd3-f00528765cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4845994-1d56-4f69-9895-c6142acf3cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4845994-1d56-4f69-9895-c6142acf3cb4.jpg?1",
             "name": "Mox Tantalite",
             "text": "",
             "colours": [],
@@ -34353,7 +34353,7 @@
         },
         {
             "id": "3f54dbed-8fc2-536b-9778-0d2b395170c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ea0aa3-30c0-4eb4-b262-ce70781277ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ea0aa3-30c0-4eb4-b262-ce70781277ce.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -34389,7 +34389,7 @@
         },
         {
             "id": "2650fc8d-893c-5eaa-aba3-9554fd39b1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ef9cd-ee4d-4cbe-a07d-89f9322e5362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ef9cd-ee4d-4cbe-a07d-89f9322e5362.jpg?1",
             "name": "Void Winnower",
             "text": "",
             "colours": [],
@@ -34419,7 +34419,7 @@
         },
         {
             "id": "bf70459d-b1f2-562c-a22f-3cbd316b9bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d75604-4941-4faf-8f1a-7fc529e64962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d75604-4941-4faf-8f1a-7fc529e64962.jpg?1",
             "name": "Goblin Settler",
             "text": "",
             "colours": [
@@ -34453,7 +34453,7 @@
         },
         {
             "id": "33afeae3-79ed-5335-b036-429dc2042de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6550a-b01e-45b0-807c-5593ed419bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6550a-b01e-45b0-807c-5593ed419bac.jpg?1",
             "name": "Collector Ouphe",
             "text": "",
             "colours": [
@@ -34487,7 +34487,7 @@
         },
         {
             "id": "796621e2-e789-5c75-96e9-77a2a3b76dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7bb5f3-3488-442f-a0e6-92d93f9e7231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7bb5f3-3488-442f-a0e6-92d93f9e7231.jpg?1",
             "name": "Vengevine",
             "text": "",
             "colours": [
@@ -34521,7 +34521,7 @@
         },
         {
             "id": "7beb2d19-5f06-5d83-a9bb-312627934e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg?1",
             "name": "Blightsteel Colossus // Blightsteel Colossus",
             "text": "",
             "colours": [],
@@ -34553,7 +34553,7 @@
         },
         {
             "id": "3bac1725-5087-5b5e-bd9f-cb6b5e27d190",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg?1",
             "name": "Blightsteel Colossus // Blightsteel Colossus",
             "text": "",
             "colours": [],
@@ -34585,7 +34585,7 @@
         },
         {
             "id": "6a3c769c-af38-5fcc-adb7-126dad4f7f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg?1",
             "name": "Doubling Cube // Doubling Cube",
             "text": "",
             "colours": [],
@@ -34613,7 +34613,7 @@
         },
         {
             "id": "334a4e94-9f80-579b-8553-343b9801ec2b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg?1",
             "name": "Doubling Cube // Doubling Cube",
             "text": "",
             "colours": [],
@@ -34641,7 +34641,7 @@
         },
         {
             "id": "ff9fd322-ceac-5456-8012-f927248a3ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg?1",
             "name": "Darksteel Colossus // Darksteel Colossus",
             "text": "",
             "colours": [],
@@ -34672,7 +34672,7 @@
         },
         {
             "id": "2096ddd1-b8e9-5237-83b7-896582de5c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg?1",
             "name": "Darksteel Colossus // Darksteel Colossus",
             "text": "",
             "colours": [],
@@ -34703,7 +34703,7 @@
         },
         {
             "id": "e51c97d8-21a2-53c4-b78b-b3ee771a5450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879adda-c2a7-4e5e-99db-31024e75b585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879adda-c2a7-4e5e-99db-31024e75b585.jpg?1",
             "name": "True Conviction",
             "text": "",
             "colours": [
@@ -34735,7 +34735,7 @@
         },
         {
             "id": "d41a8e54-79bc-53ca-973a-65572d30a7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e99bb96-dc40-4623-b133-b5def847477d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e99bb96-dc40-4623-b133-b5def847477d.jpg?1",
             "name": "Dramatic Reversal",
             "text": "",
             "colours": [
@@ -34767,7 +34767,7 @@
         },
         {
             "id": "538a12e4-b65f-56e5-8a32-6c1767a81788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f19307-5b4e-4b1d-91b5-2adef6a12e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f19307-5b4e-4b1d-91b5-2adef6a12e0c.jpg?1",
             "name": "Fabricate",
             "text": "",
             "colours": [
@@ -34801,7 +34801,7 @@
         },
         {
             "id": "7d22eb37-db60-543f-a6c9-e2c0fba68f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a01e89-f109-49d9-a33e-03afef650636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a01e89-f109-49d9-a33e-03afef650636.jpg?1",
             "name": "Collective Brutality",
             "text": "",
             "colours": [
@@ -34833,7 +34833,7 @@
         },
         {
             "id": "0db533e5-14dd-5884-b1bf-afb4105aa252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa8c556-2d3e-4f29-8457-e2162def7353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa8c556-2d3e-4f29-8457-e2162def7353.jpg?1",
             "name": "By Force",
             "text": "",
             "colours": [
@@ -34865,7 +34865,7 @@
         },
         {
             "id": "d19dea28-2ded-5705-adda-4e8db66935ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf97573c-65e3-4eec-92af-c364c1cbceea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf97573c-65e3-4eec-92af-c364c1cbceea.jpg?1",
             "name": "Greater Good",
             "text": "",
             "colours": [
@@ -34899,7 +34899,7 @@
         },
         {
             "id": "cbc75981-362b-5ebf-8f34-6e15c6299e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026777d1-e3a7-45a3-8967-527c0b4236e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026777d1-e3a7-45a3-8967-527c0b4236e2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -34968,7 +34968,7 @@
         },
         {
             "id": "7dedbb51-46d7-508b-b398-d1c54b00e5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a2259b-9ee8-42d7-92c0-d9421dd196e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a2259b-9ee8-42d7-92c0-d9421dd196e5.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -35033,7 +35033,7 @@
         },
         {
             "id": "c59d4cb5-828c-5c06-9c86-0ba9e495c6f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d825e-0a51-43e8-9b5a-43a376b58d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d825e-0a51-43e8-9b5a-43a376b58d6f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -35097,7 +35097,7 @@
         },
         {
             "id": "fdde36e4-3e6b-50a6-911a-2693534ba1ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40698-620e-4032-b2e3-0d513a4a4250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40698-620e-4032-b2e3-0d513a4a4250.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -35171,7 +35171,7 @@
         },
         {
             "id": "4e595d9c-a6f1-5e94-a6b2-9333ceec6150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f694e1-f9c9-428e-a85c-d09b3474c79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f694e1-f9c9-428e-a85c-d09b3474c79b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -35236,7 +35236,7 @@
         },
         {
             "id": "bf400a96-ac6d-5606-8740-9fcc9bfd4aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04ddd06-0082-44aa-8782-7bd5631f2e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04ddd06-0082-44aa-8782-7bd5631f2e77.jpg?1",
             "name": "Deepglow Skate",
             "text": "",
             "colours": [
@@ -35270,7 +35270,7 @@
         },
         {
             "id": "5f20732b-2ce1-5e23-a94b-dd1ab3d6da08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12eb1d-1027-436a-86a3-455128cc0641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12eb1d-1027-436a-86a3-455128cc0641.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -35307,7 +35307,7 @@
         },
         {
             "id": "e3343aa0-6cb4-504f-9ba1-010a00655335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acd847d-7474-4d6a-8281-aa59991a1b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acd847d-7474-4d6a-8281-aa59991a1b87.jpg?1",
             "name": "Contagion Engine",
             "text": "",
             "colours": [],
@@ -35335,7 +35335,7 @@
         },
         {
             "id": "8982c4ae-4ea4-50c2-90c7-c9305b36d99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a14a7-0e77-4445-8d72-be8adcff2f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a14a7-0e77-4445-8d72-be8adcff2f3e.jpg?1",
             "name": "Sword of Truth and Justice",
             "text": "",
             "colours": [],
@@ -35365,7 +35365,7 @@
         },
         {
             "id": "8aa7c8c4-2708-5e23-b9ab-68f6581a9863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15bd831-aa75-42c1-905c-6e8cc644c7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15bd831-aa75-42c1-905c-6e8cc644c7fc.jpg?1",
             "name": "Laboratory Maniac",
             "text": "",
             "colours": [
@@ -35403,7 +35403,7 @@
         },
         {
             "id": "f6f51d35-520d-5228-9b5d-e9df4aa7508c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28c7fe5-bc61-4fc2-acb9-810f2e4ec682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28c7fe5-bc61-4fc2-acb9-810f2e4ec682.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "",
             "colours": [
@@ -35437,7 +35437,7 @@
         },
         {
             "id": "b603099b-7901-5f49-887a-8e72ed8b9ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c818547c-a6f6-4c69-9e4d-33741e605093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c818547c-a6f6-4c69-9e4d-33741e605093.jpg?1",
             "name": "Beast Whisperer",
             "text": "",
             "colours": [
@@ -35472,7 +35472,7 @@
         },
         {
             "id": "5cfc928b-27e4-5669-ad7b-79bc4c191751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1965955-57fc-4447-8b60-de1d81617204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1965955-57fc-4447-8b60-de1d81617204.jpg?1",
             "name": "Vizier of the Menagerie",
             "text": "",
             "colours": [
@@ -35507,7 +35507,7 @@
         },
         {
             "id": "5bd227f3-a24a-51fd-ab67-b8ff392181c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b536948f-9a29-4811-a3b2-9d3f73117965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b536948f-9a29-4811-a3b2-9d3f73117965.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -35542,7 +35542,7 @@
         },
         {
             "id": "35f1ab83-8e50-5e41-9f3c-97bc68bc6a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75a663c-f12f-49d6-b84f-3f941049872e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75a663c-f12f-49d6-b84f-3f941049872e.jpg?1",
             "name": "Imprisoned in the Moon",
             "text": "",
             "colours": [
@@ -35576,7 +35576,7 @@
         },
         {
             "id": "b3c42841-d655-5397-8ac8-751f01b58c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201c6c9-c7c2-405c-b61d-77e7f3a9a1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201c6c9-c7c2-405c-b61d-77e7f3a9a1ca.jpg?1",
             "name": "Stasis",
             "text": "",
             "colours": [
@@ -35608,7 +35608,7 @@
         },
         {
             "id": "6468c008-2043-5ce1-8d25-0ef0d4decef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6989d1d-00ca-4d5d-acdc-0b7c6a522e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6989d1d-00ca-4d5d-acdc-0b7c6a522e30.jpg?1",
             "name": "Prismatic Omen",
             "text": "",
             "colours": [
@@ -35640,7 +35640,7 @@
         },
         {
             "id": "db4207f1-6180-5311-8451-73a42fbe3f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d6d636-51f1-4f98-94af-5307c3399dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d6d636-51f1-4f98-94af-5307c3399dae.jpg?1",
             "name": "Wheel of Sun and Moon",
             "text": "",
             "colours": [
@@ -35676,7 +35676,7 @@
         },
         {
             "id": "89265655-e0bb-57f0-9a47-cdc003725f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d974a337-3139-43ff-a368-6f3d10f53646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d974a337-3139-43ff-a368-6f3d10f53646.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "",
             "colours": [
@@ -35713,7 +35713,7 @@
         },
         {
             "id": "43a47dc3-a49c-5d35-9cbd-d55687a50849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8751d-0eb6-46fd-88a6-7dd5255a1077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8751d-0eb6-46fd-88a6-7dd5255a1077.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "",
             "colours": [
@@ -35751,7 +35751,7 @@
         },
         {
             "id": "f68088e8-c488-59fe-b322-285b134050a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85397a1d-1fd1-4ca1-a1fc-f32e3a063c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85397a1d-1fd1-4ca1-a1fc-f32e3a063c81.jpg?1",
             "name": "Reflector Mage",
             "text": "",
             "colours": [
@@ -35788,7 +35788,7 @@
         },
         {
             "id": "70e9603d-ce4d-566c-a352-00e10717b32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f038672-d03c-4349-9261-1b76ae4594c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f038672-d03c-4349-9261-1b76ae4594c6.jpg?1",
             "name": "Adaptive Automaton",
             "text": "",
             "colours": [],
@@ -35819,7 +35819,7 @@
         },
         {
             "id": "217a093a-8dbe-53e9-b6a1-67c4df48b5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7501a66-76f8-4f1d-8b4c-2a82b5f930c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7501a66-76f8-4f1d-8b4c-2a82b5f930c4.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "",
             "colours": [
@@ -35857,7 +35857,7 @@
         },
         {
             "id": "3c82ac09-fefb-58dd-bcff-597a9e359137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62835e03-49c8-42b8-91ba-3aa4beb5df66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62835e03-49c8-42b8-91ba-3aa4beb5df66.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "",
             "colours": [
@@ -35895,7 +35895,7 @@
         },
         {
             "id": "0f4899b6-2178-5d39-ac52-b5d342a30b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3668996e-659d-413b-84e6-9f3099518d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3668996e-659d-413b-84e6-9f3099518d7f.jpg?1",
             "name": "Skullclamp",
             "text": "",
             "colours": [],
@@ -35927,7 +35927,7 @@
         },
         {
             "id": "92cdc45a-4135-5e7c-a177-a381f9b99e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b2e5-a34c-48a0-a054-6a459ebe60c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b2e5-a34c-48a0-a054-6a459ebe60c9.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -35961,7 +35961,7 @@
         },
         {
             "id": "147afe00-7883-5ee1-8cdf-3630c0d3c21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e175cb-ffea-473f-8422-53273f263016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e175cb-ffea-473f-8422-53273f263016.jpg?1",
             "name": "Carrion Feeder",
             "text": "",
             "colours": [
@@ -35995,7 +35995,7 @@
         },
         {
             "id": "3c56729d-64d8-566c-9ad2-b21389594924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cb8aec-21cf-49c1-8407-e45afe377f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cb8aec-21cf-49c1-8407-e45afe377f4f.jpg?1",
             "name": "Doomsday",
             "text": "",
             "colours": [
@@ -36027,7 +36027,7 @@
         },
         {
             "id": "7d7cf901-d465-5c34-8c89-0c7937f56607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a10efc-4b8d-4e32-90fb-50ab73810b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a10efc-4b8d-4e32-90fb-50ab73810b59.jpg?1",
             "name": "Plaguecrafter",
             "text": "",
             "colours": [
@@ -36062,7 +36062,7 @@
         },
         {
             "id": "d0191a06-6d20-5b90-8922-c887fb69fbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc64b6-6f2c-4b20-aa80-54cc47382606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc64b6-6f2c-4b20-aa80-54cc47382606.jpg?1",
             "name": "Thoughtseize",
             "text": "",
             "colours": [
@@ -36094,7 +36094,7 @@
         },
         {
             "id": "a42e3d15-43b3-590e-b9ce-84008f3c18c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger // Ulamog, the Ceaseless Hunger",
             "text": "",
             "colours": [],
@@ -36126,7 +36126,7 @@
         },
         {
             "id": "ecd5b8fa-4d1e-5947-877c-a1e541e6a268",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger // Ulamog, the Ceaseless Hunger",
             "text": "",
             "colours": [],
@@ -36158,7 +36158,7 @@
         },
         {
             "id": "77778260-be35-5d20-b69a-d04325b5ccc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg?1",
             "name": "Etali, Primal Storm // Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -36195,7 +36195,7 @@
         },
         {
             "id": "3bd2dedb-041b-59a7-a94e-388de22d977c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg?1",
             "name": "Etali, Primal Storm // Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -36232,7 +36232,7 @@
         },
         {
             "id": "8ccf2256-e912-53cd-96ed-6d45c80f9144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg?1",
             "name": "Ghalta, Primal Hunger // Ghalta, Primal Hunger",
             "text": "",
             "colours": [
@@ -36269,7 +36269,7 @@
         },
         {
             "id": "d29ad67b-392f-51fe-8116-211da7ff2368",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg?1",
             "name": "Ghalta, Primal Hunger // Ghalta, Primal Hunger",
             "text": "",
             "colours": [
@@ -36306,7 +36306,7 @@
         },
         {
             "id": "a5e09cb3-bd6d-5246-91c9-4895c9481d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddf66f9-a98a-4edf-831d-68b68065d75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddf66f9-a98a-4edf-831d-68b68065d75d.jpg?1",
             "name": "Serra Ascendant",
             "text": "",
             "colours": [
@@ -36341,7 +36341,7 @@
         },
         {
             "id": "0c31ba98-60e4-52c8-938a-baceb925f3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423ed9cd-94d9-49a1-a167-69899b630f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423ed9cd-94d9-49a1-a167-69899b630f95.jpg?1",
             "name": "Rapid Hybridization",
             "text": "",
             "colours": [
@@ -36373,7 +36373,7 @@
         },
         {
             "id": "00f7677f-2110-590b-b350-9ed567872336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bdfd40-dbc7-42a8-a122-5834193b8f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bdfd40-dbc7-42a8-a122-5834193b8f5e.jpg?1",
             "name": "Demonic Consultation",
             "text": "",
             "colours": [
@@ -36405,7 +36405,7 @@
         },
         {
             "id": "7c05a485-59b5-58d5-b1a0-6d536779dd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f954a-8cd4-4cf4-8f30-d4396d44bc5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f954a-8cd4-4cf4-8f30-d4396d44bc5e.jpg?1",
             "name": "Winds of Change",
             "text": "",
             "colours": [
@@ -36437,7 +36437,7 @@
         },
         {
             "id": "5066f628-d50c-5ef0-a405-840efb9ca6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be44d1-da6b-4427-955b-d7f32ebf1813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be44d1-da6b-4427-955b-d7f32ebf1813.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -36472,7 +36472,7 @@
         },
         {
             "id": "6c0930ea-de5a-52bc-a492-33d6580c9130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912e30e7-9b8b-4c27-af3a-ffdcfe8b6feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912e30e7-9b8b-4c27-af3a-ffdcfe8b6feb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -36541,7 +36541,7 @@
         },
         {
             "id": "df0d8f4a-7f62-5983-9fcc-76f2a44e2f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cb4d9d-4f2b-4f60-b48f-749747aa7c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cb4d9d-4f2b-4f60-b48f-749747aa7c15.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -36606,7 +36606,7 @@
         },
         {
             "id": "2658f988-0d25-55cd-867e-c6b3e1efaca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a6e87-a9fb-4bd8-a09d-b160aa302a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a6e87-a9fb-4bd8-a09d-b160aa302a2b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -36670,7 +36670,7 @@
         },
         {
             "id": "ea5858a0-ed46-569a-9885-f8584d468bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b5f331-3d6f-4e0f-b5a4-61040ed61d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b5f331-3d6f-4e0f-b5a4-61040ed61d39.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -36744,7 +36744,7 @@
         },
         {
             "id": "b43253f0-41c0-5380-ab65-c2bd9af0f490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a13a86b-c4c5-4a7a-9e01-8669e9ed6557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a13a86b-c4c5-4a7a-9e01-8669e9ed6557.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -36809,7 +36809,7 @@
         },
         {
             "id": "acd87101-5a2a-5cac-a1f2-02742468c635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b77346-d6e4-4d2f-b054-19fdea686d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b77346-d6e4-4d2f-b054-19fdea686d40.jpg?1",
             "name": "Abundant Growth",
             "text": "",
             "colours": [
@@ -36843,7 +36843,7 @@
         },
         {
             "id": "1cbddd35-ceb1-5d40-bbca-d9c8bdfc27f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798748d5-cb17-4f9a-85d4-1bc518222bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798748d5-cb17-4f9a-85d4-1bc518222bb8.jpg?1",
             "name": "Mycoloth",
             "text": "",
             "colours": [
@@ -36877,7 +36877,7 @@
         },
         {
             "id": "5e657300-bb30-5813-ab72-22c86a45aa71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817f782f-7e62-44b3-9bb2-3a57d34dfe67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817f782f-7e62-44b3-9bb2-3a57d34dfe67.jpg?1",
             "name": "Ghave, Guru of Spores",
             "text": "",
             "colours": [
@@ -36918,7 +36918,7 @@
         },
         {
             "id": "f0cd836c-f2cb-53d6-a47a-7a3b6e876c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16055a39-484e-490d-9ae8-398cd36f80a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16055a39-484e-490d-9ae8-398cd36f80a9.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "",
             "colours": [
@@ -36956,7 +36956,7 @@
         },
         {
             "id": "b5f376f5-ee25-5890-b6a6-6b059ae3f46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f8d1ca-bc82-453a-b237-ef75ce027b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f8d1ca-bc82-453a-b237-ef75ce027b8f.jpg?1",
             "name": "Elspeth, Sun's Champion",
             "text": "",
             "colours": [
@@ -36992,7 +36992,7 @@
         },
         {
             "id": "90f4022b-3cd0-58dd-aaaa-cedb1ac9f02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -37031,7 +37031,7 @@
         },
         {
             "id": "0e7c42dd-89b9-511c-a64c-c772680cfdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbd5627-2f55-4101-981b-49f5f45db578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbd5627-2f55-4101-981b-49f5f45db578.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -37067,7 +37067,7 @@
         },
         {
             "id": "571a41a7-fd9f-5591-8336-499d0a9767b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5662d0a5-3222-4ab9-9e15-f06477730b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5662d0a5-3222-4ab9-9e15-f06477730b75.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "",
             "colours": [
@@ -37107,7 +37107,7 @@
         },
         {
             "id": "df1eaa35-859a-5fa2-afbd-e2a516c9bfdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df8d25e-e519-4197-aa8e-ec596cb2a2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df8d25e-e519-4197-aa8e-ec596cb2a2d8.jpg?1",
             "name": "Sarkhan Vol",
             "text": "",
             "colours": [
@@ -37145,7 +37145,7 @@
         },
         {
             "id": "2423b127-7a0e-5226-a534-5fb21b569d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0cdff4-c81e-4e53-8721-748eb71d9e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0cdff4-c81e-4e53-8721-748eb71d9e81.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "",
             "colours": [
@@ -37183,7 +37183,7 @@
         },
         {
             "id": "58a40753-56c9-5a2d-9081-6cc338288b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29da3c7f-f886-4be0-bce5-d2707c5fc926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29da3c7f-f886-4be0-bce5-d2707c5fc926.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "",
             "colours": [
@@ -37221,7 +37221,7 @@
         },
         {
             "id": "2e1e251a-310b-5348-8dbb-3b4904bdd027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d8bf03-42f3-4200-96a7-03e822b102e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d8bf03-42f3-4200-96a7-03e822b102e9.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -37259,7 +37259,7 @@
         },
         {
             "id": "1130bd10-6b25-5120-9bfd-f1c7b87cbeff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a931b6-607c-4cbb-ad1e-14e2cad14947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a931b6-607c-4cbb-ad1e-14e2cad14947.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -37297,7 +37297,7 @@
         },
         {
             "id": "4da09baa-ae37-5a66-8026-9eb1f0692532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a229f0-3cca-4c2a-8cb5-064040eece72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a229f0-3cca-4c2a-8cb5-064040eece72.jpg?1",
             "name": "Sliver Legion",
             "text": "",
             "colours": [
@@ -37343,7 +37343,7 @@
         },
         {
             "id": "cdcfc495-1c88-5dc5-af96-4e5bd107ce79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feef6ea3-67f3-42d8-bf19-02ba9151c2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feef6ea3-67f3-42d8-bf19-02ba9151c2a3.jpg?1",
             "name": "Sliver Legion",
             "text": "",
             "colours": [
@@ -37389,7 +37389,7 @@
         },
         {
             "id": "558822e7-4406-5fbc-a05e-ce2387f9c57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396dc9ce-bf25-4f51-9b07-baea8bfa1718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396dc9ce-bf25-4f51-9b07-baea8bfa1718.jpg?1",
             "name": "Thought-Knot Seer",
             "text": "",
             "colours": [],
@@ -37421,7 +37421,7 @@
         },
         {
             "id": "60c71c5a-64c7-5b36-9219-e453b027d6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9f9fb7-c79a-4991-914f-c3500a488bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9f9fb7-c79a-4991-914f-c3500a488bf1.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "",
             "colours": [
@@ -37453,7 +37453,7 @@
         },
         {
             "id": "0bc6709f-62d2-5ba4-8dd4-8ee4c550c2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00449fad-6b06-40b1-8179-cbc86acec907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00449fad-6b06-40b1-8179-cbc86acec907.jpg?1",
             "name": "Reality Smasher",
             "text": "",
             "colours": [],
@@ -37483,7 +37483,7 @@
         },
         {
             "id": "0d600fd0-7c52-58d9-b526-0b52476a95e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00372c7a-2e83-4a26-9642-0d092dfcf861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00372c7a-2e83-4a26-9642-0d092dfcf861.jpg?1",
             "name": "Eldrazi Temple",
             "text": "",
             "colours": [],
@@ -37511,7 +37511,7 @@
         },
         {
             "id": "2fc3021d-c5e9-50aa-80f0-869929d9c34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -37552,7 +37552,7 @@
         },
         {
             "id": "a66bc29f-804d-54ac-84a8-ceb07140df77",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -37595,7 +37595,7 @@
         },
         {
             "id": "554a2c4d-7701-5dbd-bc7d-5900e01351fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -37633,7 +37633,7 @@
         },
         {
             "id": "73f57d4f-8bbb-5f05-9a71-c4ae57b07e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -37671,7 +37671,7 @@
         },
         {
             "id": "61b8865c-4e98-53dd-a92f-c610aa3a25a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -37706,7 +37706,7 @@
         },
         {
             "id": "8e223007-324a-5c85-9f78-6f61e992468b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -37741,7 +37741,7 @@
         },
         {
             "id": "30a2715d-2a38-5762-9e1a-f3c1a683bdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -37783,7 +37783,7 @@
         },
         {
             "id": "09686798-9901-5a01-bbc1-c610ace5e8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -37824,7 +37824,7 @@
         },
         {
             "id": "10beaa6b-a4a1-5ca5-905e-bb734188eb7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [],
@@ -37855,7 +37855,7 @@
         },
         {
             "id": "63b6b0a7-6696-524b-ab0b-79b5d9e8f531",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [
@@ -37892,7 +37892,7 @@
         },
         {
             "id": "54b700ba-9026-5919-8eb3-fbda19eb7229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eec0470-82bf-4a07-a7d9-e5d40a518041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eec0470-82bf-4a07-a7d9-e5d40a518041.jpg?1",
             "name": "Emrakul, the Promised End",
             "text": "",
             "colours": [],
@@ -37924,7 +37924,7 @@
         },
         {
             "id": "fd30a3f6-af03-59c7-b83f-acb8e4cd5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad4c850-097e-4909-87ec-a33ef8f2ba34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad4c850-097e-4909-87ec-a33ef8f2ba34.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -37958,7 +37958,7 @@
         },
         {
             "id": "52894677-7541-55da-acd3-76ced43c680b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3fb533-84a8-4414-ba1f-56bebe04b061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3fb533-84a8-4414-ba1f-56bebe04b061.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -37994,7 +37994,7 @@
         },
         {
             "id": "ba88b6fb-380b-57ca-87b7-f4841d4afbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae63d70a-9ecc-4912-aeb7-7d41c91b3b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae63d70a-9ecc-4912-aeb7-7d41c91b3b9d.jpg?1",
             "name": "Progenitus",
             "text": "",
             "colours": [
@@ -38039,7 +38039,7 @@
         },
         {
             "id": "f64a9383-4056-5cb9-8e4e-ec4978c1701c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38315a5-820e-4f31-b359-5c367bdf2cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38315a5-820e-4f31-b359-5c367bdf2cfc.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "",
             "colours": [
@@ -38078,7 +38078,7 @@
         },
         {
             "id": "c09287b1-8787-5488-a46c-ece1468fce00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea53e1ee-fc87-4aaf-b876-a0b5622414f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea53e1ee-fc87-4aaf-b876-a0b5622414f7.jpg?1",
             "name": "Spellseeker",
             "text": "",
             "colours": [
@@ -38113,7 +38113,7 @@
         },
         {
             "id": "0d35b45b-6136-522d-941d-9acf72b34e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb06c55-186b-45e2-ad0b-3790ed83e1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb06c55-186b-45e2-ad0b-3790ed83e1de.jpg?1",
             "name": "Magus of the Wheel",
             "text": "",
             "colours": [
@@ -38148,7 +38148,7 @@
         },
         {
             "id": "9593699f-8426-57f1-9671-517063fad3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a795db-6b70-4534-b6e9-240895875d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a795db-6b70-4534-b6e9-240895875d12.jpg?1",
             "name": "Kess, Dissident Mage",
             "text": "",
             "colours": [
@@ -38189,7 +38189,7 @@
         },
         {
             "id": "7bf58d10-c862-5768-ac45-2055305c5c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81e16f-8e5c-42e2-9d4e-220eb3b4aa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81e16f-8e5c-42e2-9d4e-220eb3b4aa38.jpg?1",
             "name": "Field Marshal",
             "text": "",
             "colours": [
@@ -38224,7 +38224,7 @@
         },
         {
             "id": "40e3c7a4-4a06-5c72-a297-1aa39ea17ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1",
             "name": "Temporal Manipulation",
             "text": "",
             "colours": [
@@ -38256,7 +38256,7 @@
         },
         {
             "id": "5fd26b71-4358-505f-a020-ae1dba0044cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e169f68-d336-429d-bdd0-f034a53391a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e169f68-d336-429d-bdd0-f034a53391a3.jpg?1",
             "name": "Dark Ritual",
             "text": "",
             "colours": [
@@ -38288,7 +38288,7 @@
         },
         {
             "id": "27a5ad8a-3930-526a-8787-532a45f5cbc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040c95-8233-4f7f-807d-7c9e33388d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040c95-8233-4f7f-807d-7c9e33388d49.jpg?1",
             "name": "Midnight Reaper",
             "text": "",
             "colours": [
@@ -38323,7 +38323,7 @@
         },
         {
             "id": "cca9a4fa-c50a-558b-8c0d-370ea4646c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f582e8-148f-432f-a6ba-f12a35750781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f582e8-148f-432f-a6ba-f12a35750781.jpg?1",
             "name": "Seize the Day",
             "text": "",
             "colours": [
@@ -38357,7 +38357,7 @@
         },
         {
             "id": "8370ef49-a736-5028-a95d-a80abf43b7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc472a09-7634-429e-a594-94491aabed5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc472a09-7634-429e-a594-94491aabed5c.jpg?1",
             "name": "Faeburrow Elder",
             "text": "",
             "colours": [
@@ -38394,7 +38394,7 @@
         },
         {
             "id": "b0b73522-d703-5b70-a30e-0fa4bbca7214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300e11b6-12df-4d28-95d7-d6514f8eeb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300e11b6-12df-4d28-95d7-d6514f8eeb6b.jpg?1",
             "name": "Carnage Tyrant",
             "text": "",
             "colours": [
@@ -38428,7 +38428,7 @@
         },
         {
             "id": "c9f3cefb-9929-51b1-a035-ae1d630a15a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d49ad9-3600-4f64-b284-4f096ed90b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d49ad9-3600-4f64-b284-4f096ed90b4d.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "",
             "colours": [
@@ -38465,7 +38465,7 @@
         },
         {
             "id": "90fef68d-cc40-5bfc-a9c1-bf1ce76bd867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bc0682-f21a-4c35-bdb2-deb10a6cd8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bc0682-f21a-4c35-bdb2-deb10a6cd8b8.jpg?1",
             "name": "It That Betrays",
             "text": "",
             "colours": [],
@@ -38495,7 +38495,7 @@
         },
         {
             "id": "3249d50b-de63-58c3-b913-50584b46b38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ccf45b-dee2-4d92-bd45-05d77840d0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ccf45b-dee2-4d92-bd45-05d77840d0c6.jpg?1",
             "name": "Forced Fruition",
             "text": "",
             "colours": [
@@ -38527,7 +38527,7 @@
         },
         {
             "id": "5001002d-e7ad-5fed-bb01-a5a23d170855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82117419-4d97-4ac6-abb9-316fc6460ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82117419-4d97-4ac6-abb9-316fc6460ddf.jpg?1",
             "name": "Future Sight",
             "text": "",
             "colours": [
@@ -38559,7 +38559,7 @@
         },
         {
             "id": "c2b80cb2-e06e-5214-b929-8d2569cb7496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1efaa-b92f-495d-8c6f-eb6c7481afd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1efaa-b92f-495d-8c6f-eb6c7481afd0.jpg?1",
             "name": "Mental Misstep",
             "text": "",
             "colours": [
@@ -38591,7 +38591,7 @@
         },
         {
             "id": "96f17f8f-14b1-5c9b-8e13-25f15a6e4beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e611d3c6-ede9-43ca-a4fc-aacd43b7c1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e611d3c6-ede9-43ca-a4fc-aacd43b7c1fc.jpg?1",
             "name": "Mind's Dilation",
             "text": "",
             "colours": [
@@ -38623,7 +38623,7 @@
         },
         {
             "id": "839eba73-99b6-55d8-9977-8e2464eb7fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da828d8e-69a2-4900-a87a-111445220e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da828d8e-69a2-4900-a87a-111445220e1c.jpg?1",
             "name": "Well of Lost Dreams",
             "text": "",
             "colours": [],
@@ -38653,7 +38653,7 @@
         },
         {
             "id": "469ea989-0951-5cfb-a4c8-d8c928996d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7138e87-9a3c-4031-8c87-d3630c89e88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7138e87-9a3c-4031-8c87-d3630c89e88c.jpg?1",
             "name": "Felidar Sovereign",
             "text": "",
             "colours": [
@@ -38687,7 +38687,7 @@
         },
         {
             "id": "d5b095df-82c8-5127-8bf4-7e99bcde041d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97797cf-1e4a-4e76-91a4-cac557a17416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97797cf-1e4a-4e76-91a4-cac557a17416.jpg?1",
             "name": "Descendants' Path",
             "text": "",
             "colours": [
@@ -38718,7 +38718,7 @@
         },
         {
             "id": "6bb1a6f9-6569-591d-bf4e-36b5091fe265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da180aa8-7490-4165-bcc9-86b3ca697225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da180aa8-7490-4165-bcc9-86b3ca697225.jpg?1",
             "name": "Lord Windgrace",
             "text": "",
             "colours": [
@@ -38757,7 +38757,7 @@
         },
         {
             "id": "72bae57c-765f-5afa-a919-2d4734afa1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed589f-8635-44a5-9978-d68c2bd1071b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed589f-8635-44a5-9978-d68c2bd1071b.jpg?1",
             "name": "Violent Outburst",
             "text": "",
             "colours": [
@@ -38790,7 +38790,7 @@
         },
         {
             "id": "80776dad-cb79-5614-9bd5-46edb58a3931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995fd27-b4c9-4620-b759-4755101e1534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995fd27-b4c9-4620-b759-4755101e1534.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "",
             "colours": [
@@ -38830,7 +38830,7 @@
         },
         {
             "id": "8e4005a6-ad95-5c1e-aa00-bf35a477b684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7572bb1d-0578-4ebb-9180-dbb709ec9a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7572bb1d-0578-4ebb-9180-dbb709ec9a5c.jpg?1",
             "name": "Bolas's Citadel",
             "text": "",
             "colours": [
@@ -38864,7 +38864,7 @@
         },
         {
             "id": "19550fcc-fbc1-55bf-b4e0-6b9255e1fa88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3672010d-7293-4906-b76d-759112c89c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3672010d-7293-4906-b76d-759112c89c51.jpg?1",
             "name": "Leshrac's Sigil",
             "text": "",
             "colours": [
@@ -38896,7 +38896,7 @@
         },
         {
             "id": "a8d0a1c6-d95e-5abb-a69c-87fba0137354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521bad8e-46b3-4cd8-bd1a-884ebfa1accd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521bad8e-46b3-4cd8-bd1a-884ebfa1accd.jpg?1",
             "name": "Jet Medallion",
             "text": "",
             "colours": [],
@@ -38924,7 +38924,7 @@
         },
         {
             "id": "9ec18572-c229-575d-8210-ab0b9e68abf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bc1f3-4e6b-4be9-8d3e-2a268a1eae60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bc1f3-4e6b-4be9-8d3e-2a268a1eae60.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -38993,7 +38993,7 @@
         },
         {
             "id": "a3fcd526-942f-5eab-9073-3d929dfb4b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0a1a30-8bef-4297-b566-d5f6b4d277a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0a1a30-8bef-4297-b566-d5f6b4d277a1.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -39058,7 +39058,7 @@
         },
         {
             "id": "bfe2e3bd-fa5a-59f6-946f-5b7a7e148061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e701b-4a03-4c3d-9574-ca2f035a7a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e701b-4a03-4c3d-9574-ca2f035a7a5c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -39122,7 +39122,7 @@
         },
         {
             "id": "100ccd50-7553-557e-acd3-aea91d46b367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3eb87a-8f77-4859-95fd-10988f03da7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3eb87a-8f77-4859-95fd-10988f03da7b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -39196,7 +39196,7 @@
         },
         {
             "id": "cf4934c0-2bde-564a-a786-64c0cf1d6816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fafd821-5bb3-4083-bf3b-ecc4cf6c7468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fafd821-5bb3-4083-bf3b-ecc4cf6c7468.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -39261,7 +39261,7 @@
         },
         {
             "id": "5b4ab551-989b-55ed-ba74-b8f69fa5bc12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e39cb1-0b57-4d70-afa6-67b307068273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e39cb1-0b57-4d70-afa6-67b307068273.jpg?1",
             "name": "Phage the Untouchable",
             "text": "",
             "colours": [
@@ -39297,7 +39297,7 @@
         },
         {
             "id": "9337ee55-2963-5e0c-9069-77875b3c11f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc5127-b6d1-45e4-b434-0841eb46e4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc5127-b6d1-45e4-b434-0841eb46e4e9.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "",
             "colours": [
@@ -39334,7 +39334,7 @@
         },
         {
             "id": "e8f998df-6957-59c1-91c7-dfee120f35ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad257a3-aacc-4981-b6f3-53fdbf56e834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad257a3-aacc-4981-b6f3-53fdbf56e834.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "",
             "colours": [
@@ -39377,7 +39377,7 @@
         },
         {
             "id": "0b2b53fa-b1e9-5a2b-9f91-b7b7e2815a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7f7eb-4e29-40d1-acc7-a6819f64771c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7f7eb-4e29-40d1-acc7-a6819f64771c.jpg?1",
             "name": "Sen Triplets",
             "text": "",
             "colours": [
@@ -39418,7 +39418,7 @@
         },
         {
             "id": "ca946f86-9096-5094-9f41-58ecf23f374a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affc8ed-9ba1-47fe-aa81-8fde61345bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affc8ed-9ba1-47fe-aa81-8fde61345bfc.jpg?1",
             "name": "Tevesh Szat, Doom of Fools",
             "text": "",
             "colours": [
@@ -39454,7 +39454,7 @@
         },
         {
             "id": "ef22f649-2f96-53b6-aecd-e075c0da0f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0424f97c-b8ba-4c19-9238-cf2d7eed150f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0424f97c-b8ba-4c19-9238-cf2d7eed150f.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "",
             "colours": [
@@ -39491,7 +39491,7 @@
         },
         {
             "id": "e0579d7e-7e78-5a38-9c04-6341ac6235fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d028f-b57f-4f68-9694-c5a2bd7295b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d028f-b57f-4f68-9694-c5a2bd7295b9.jpg?1",
             "name": "Jeska, Thrice Reborn",
             "text": "",
             "colours": [
@@ -39527,7 +39527,7 @@
         },
         {
             "id": "663b1f77-4248-5b08-9c31-c68bfd88138d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e439cd0-5ba1-45af-a868-f408e0a50465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e439cd0-5ba1-45af-a868-f408e0a50465.jpg?1",
             "name": "Vial Smasher the Fierce",
             "text": "",
             "colours": [
@@ -39566,7 +39566,7 @@
         },
         {
             "id": "da49e51e-50f7-5f3a-ac43-260433929bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01842079-5c70-4e87-a1c5-c814a44ba0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01842079-5c70-4e87-a1c5-c814a44ba0f5.jpg?1",
             "name": "Blighted Agent",
             "text": "",
             "colours": [
@@ -39602,7 +39602,7 @@
         },
         {
             "id": "4e4cbf9d-aaed-5798-926c-d39dd84fb9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068d2a94-e4f5-4789-9228-30d72684e3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068d2a94-e4f5-4789-9228-30d72684e3b9.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "",
             "colours": [
@@ -39642,7 +39642,7 @@
         },
         {
             "id": "e8825aa3-e822-53e0-a5bf-d0e608163ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97685645-43ab-4dd3-926a-f7439d7a31e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97685645-43ab-4dd3-926a-f7439d7a31e6.jpg?1",
             "name": "Glistener Elf",
             "text": "",
             "colours": [
@@ -39678,7 +39678,7 @@
         },
         {
             "id": "dc9671fa-9cf1-5074-9bf1-84baa82ffafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5358745-44d8-4452-9cee-06ec6006214b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5358745-44d8-4452-9cee-06ec6006214b.jpg?1",
             "name": "Batterskull",
             "text": "",
             "colours": [],
@@ -39708,7 +39708,7 @@
         },
         {
             "id": "b3135abf-5790-5fe6-a794-4d1dcd8b0859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928d19f-a88e-4558-878e-af49c50c70ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928d19f-a88e-4558-878e-af49c50c70ee.jpg?1",
             "name": "Inkmoth Nexus",
             "text": "",
             "colours": [],
@@ -39738,7 +39738,7 @@
         },
         {
             "id": "ab071747-f34e-54c4-9632-b5881107ff75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -39779,7 +39779,7 @@
         },
         {
             "id": "b7a89717-0fba-55a6-afed-0367bf99bd58",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -39822,7 +39822,7 @@
         },
         {
             "id": "b1a39a29-54dd-5c8b-95f9-e309ddbd0600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -39860,7 +39860,7 @@
         },
         {
             "id": "a56f89e1-cca7-588b-8e3b-5f294f9c42fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -39898,7 +39898,7 @@
         },
         {
             "id": "ba2da389-0890-5b86-a4b0-7c32aa437f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -39933,7 +39933,7 @@
         },
         {
             "id": "d6b76063-6762-5de2-940d-0e0ee2254479",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -39968,7 +39968,7 @@
         },
         {
             "id": "8cf87357-5705-5217-a157-61dd8529cfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -40010,7 +40010,7 @@
         },
         {
             "id": "c516d697-6a79-5a15-9061-be56ba4ddf8e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -40051,7 +40051,7 @@
         },
         {
             "id": "035d1eda-c67a-5558-a293-ea2430494150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [],
@@ -40082,7 +40082,7 @@
         },
         {
             "id": "15de3999-3a97-5ab3-b375-2cb6738753a0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [
@@ -40119,7 +40119,7 @@
         },
         {
             "id": "db0fa823-83a7-5b38-85ba-5d69a42f0263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c274214-9cef-4b0c-971d-43f0f17d73ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c274214-9cef-4b0c-971d-43f0f17d73ed.jpg?1",
             "name": "Phyrexian Unlife",
             "text": "",
             "colours": [
@@ -40150,7 +40150,7 @@
         },
         {
             "id": "960ab9ae-076b-5130-971f-373682a8f470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35494d-411f-46b4-903d-773d37992e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35494d-411f-46b4-903d-773d37992e9e.jpg?1",
             "name": "Phyrexian Crusader",
             "text": "",
             "colours": [
@@ -40185,7 +40185,7 @@
         },
         {
             "id": "a70771b7-5992-5a27-b343-e1ca380d0023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58751c9-6b6b-4650-80b3-a72be558ad26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58751c9-6b6b-4650-80b3-a72be558ad26.jpg?1",
             "name": "Plague Engineer",
             "text": "",
             "colours": [
@@ -40219,7 +40219,7 @@
         },
         {
             "id": "753e6ecd-88f9-5091-a887-b610f2709894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3476e706-f71a-4f7a-b026-cd8cb0665c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3476e706-f71a-4f7a-b026-cd8cb0665c39.jpg?1",
             "name": "Ertai, the Corrupted",
             "text": "",
             "colours": [
@@ -40260,7 +40260,7 @@
         },
         {
             "id": "9715aad9-3476-5652-bcd9-5fe097cd08c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d62d95-26af-4a63-91fd-feeb85362299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d62d95-26af-4a63-91fd-feeb85362299.jpg?1",
             "name": "Glissa, the Traitor",
             "text": "",
             "colours": [
@@ -40299,7 +40299,7 @@
         },
         {
             "id": "0c71032d-3f75-50e7-8a93-8993f2093f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53740e51-ee3f-4158-93f4-395d168820aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53740e51-ee3f-4158-93f4-395d168820aa.jpg?1",
             "name": "Eldrazi Conscription",
             "text": "",
             "colours": [],
@@ -40331,7 +40331,7 @@
         },
         {
             "id": "4e9389ae-48eb-57c2-9e45-ed3661608449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e44ae7-3363-45e9-970e-5789e7721305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e44ae7-3363-45e9-970e-5789e7721305.jpg?1",
             "name": "Deafening Silence",
             "text": "",
             "colours": [
@@ -40363,7 +40363,7 @@
         },
         {
             "id": "5fdd638f-4521-5698-bb0e-b5e41db50975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c46071-b94c-460e-ab3a-9f9633eee833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c46071-b94c-460e-ab3a-9f9633eee833.jpg?1",
             "name": "Counterbalance",
             "text": "",
             "colours": [
@@ -40395,7 +40395,7 @@
         },
         {
             "id": "b6fc80f8-df47-5c83-9036-e76847298264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e376a75-77ea-40f0-a61e-afcdea2c763a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e376a75-77ea-40f0-a61e-afcdea2c763a.jpg?1",
             "name": "Bruna, Light of Alabaster",
             "text": "",
             "colours": [
@@ -40433,7 +40433,7 @@
         },
         {
             "id": "00a1f936-ee43-55a3-aaa2-03adeb7d8f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c2044-328a-4e29-8b3a-0eeb75fee2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c2044-328a-4e29-8b3a-0eeb75fee2bf.jpg?1",
             "name": "Hexdrinker",
             "text": "",
             "colours": [
@@ -40467,7 +40467,7 @@
         },
         {
             "id": "e2362853-d8c2-5929-b531-40e60ce1c714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9bf59f-6879-4343-9158-207ddd170bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9bf59f-6879-4343-9158-207ddd170bfb.jpg?1",
             "name": "Lotus Cobra",
             "text": "",
             "colours": [
@@ -40501,7 +40501,7 @@
         },
         {
             "id": "909c97ed-80cb-5e2b-8a94-209311b46502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f966-c081-49eb-8114-1690d1fd19b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f966-c081-49eb-8114-1690d1fd19b2.jpg?1",
             "name": "Seshiro the Anointed",
             "text": "",
             "colours": [
@@ -40538,7 +40538,7 @@
         },
         {
             "id": "272f5d31-6aa8-56cc-88b9-67a724dbe18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1950aed0-f34b-4dc6-a01e-31313fa442bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1950aed0-f34b-4dc6-a01e-31313fa442bc.jpg?1",
             "name": "Ice-Fang Coatl",
             "text": "",
             "colours": [
@@ -40576,7 +40576,7 @@
         },
         {
             "id": "64de767b-b9e5-50ca-8bda-86188e2ce1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f7b125-46ab-4034-b96a-8cc0e6cc5103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f7b125-46ab-4034-b96a-8cc0e6cc5103.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "",
             "colours": [],
@@ -40607,7 +40607,7 @@
         },
         {
             "id": "cd5dba55-46cc-51ea-947a-62f4160b33f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da88239e-1155-4657-9685-ab3f323672ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da88239e-1155-4657-9685-ab3f323672ea.jpg?1",
             "name": "Alms Collector",
             "text": "",
             "colours": [
@@ -40642,7 +40642,7 @@
         },
         {
             "id": "cf48278b-aa11-5671-8ae7-71b9d8a6b6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f101-0df2-4b33-b818-90c77c69ef23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f101-0df2-4b33-b818-90c77c69ef23.jpg?1",
             "name": "Crested Sunmare",
             "text": "",
             "colours": [
@@ -40676,7 +40676,7 @@
         },
         {
             "id": "9b6a41f2-30e2-559d-bad7-bc692bdde9d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410bf6b3-885a-41cf-97f7-2e942922a4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410bf6b3-885a-41cf-97f7-2e942922a4ec.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "",
             "colours": [
@@ -40712,7 +40712,7 @@
         },
         {
             "id": "9fb6ea2e-0508-59b7-bea9-4ce8640ea24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c7202-ca36-46a3-ae04-c7da41ecc67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c7202-ca36-46a3-ae04-c7da41ecc67d.jpg?1",
             "name": "Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -40753,7 +40753,7 @@
         },
         {
             "id": "b287c5b4-4f48-501c-a521-040add7682e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07baf1d-a399-478e-9ae1-0a9e6cfe4933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07baf1d-a399-478e-9ae1-0a9e6cfe4933.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -40781,7 +40781,7 @@
         },
         {
             "id": "264d793e-8dd2-5bc1-b6e2-47356603d7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7815c90b-f7f7-46ac-9dc1-fc3d8cfdbac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7815c90b-f7f7-46ac-9dc1-fc3d8cfdbac5.jpg?1",
             "name": "Sakashima the Impostor",
             "text": "",
             "colours": [
@@ -40818,7 +40818,7 @@
         },
         {
             "id": "6934b23c-05bb-5aa6-8f6a-e28f344fb8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca1926-6809-4924-a80c-f322266ac38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca1926-6809-4924-a80c-f322266ac38e.jpg?1",
             "name": "Massacre Girl",
             "text": "",
             "colours": [
@@ -40855,7 +40855,7 @@
         },
         {
             "id": "64a6047a-de6a-5c48-b86a-9dacbafce482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fa88e-1ba5-4166-a7c3-cead597c65b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fa88e-1ba5-4166-a7c3-cead597c65b8.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "",
             "colours": [
@@ -40895,7 +40895,7 @@
         },
         {
             "id": "bbdc03c9-a94a-5f7a-91ba-1d0b3fb909f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a80fbb2-4b3a-46fc-b105-09e512bc414a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a80fbb2-4b3a-46fc-b105-09e512bc414a.jpg?1",
             "name": "Teysa Karlov",
             "text": "",
             "colours": [
@@ -40934,7 +40934,7 @@
         },
         {
             "id": "609f0a19-b50c-5765-ad5d-87eadefcd31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaf50b-5491-474b-8501-8814e2629fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaf50b-5491-474b-8501-8814e2629fe4.jpg?1",
             "name": "Paradise Mantle",
             "text": "",
             "colours": [],
@@ -40964,7 +40964,7 @@
         },
         {
             "id": "84b7b10f-beec-5d2d-9446-ef2a0de2bd17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150240c-10c7-439c-a076-740bd0f2cc0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150240c-10c7-439c-a076-740bd0f2cc0a.jpg?1",
             "name": "Xenk, Paladin Unbroken",
             "text": "",
             "colours": [
@@ -41001,7 +41001,7 @@
         },
         {
             "id": "da5605bc-5e20-5ba3-a10d-2cda13c7874a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9a9cf1-f480-48e8-a9b8-75d7f1640d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9a9cf1-f480-48e8-a9b8-75d7f1640d1a.jpg?1",
             "name": "Simon, Wild Magic Sorcerer",
             "text": "",
             "colours": [
@@ -41039,7 +41039,7 @@
         },
         {
             "id": "4fcdb7f5-1a1f-5e6f-83d2-1bc53ceeaa09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2091e863-30f3-475e-9a61-e76fc4cf1ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2091e863-30f3-475e-9a61-e76fc4cf1ce2.jpg?1",
             "name": "Forge, Neverwinter Charlatan",
             "text": "",
             "colours": [
@@ -41076,7 +41076,7 @@
         },
         {
             "id": "820aefe1-1d39-53b1-a2b5-689515f96d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab07547-a6b8-487a-9688-8f93aaa71f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab07547-a6b8-487a-9688-8f93aaa71f5b.jpg?1",
             "name": "Holga, Relentless Rager",
             "text": "",
             "colours": [
@@ -41113,7 +41113,7 @@
         },
         {
             "id": "22c9ed5d-6030-5cec-afea-01cd68bac036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg?1",
             "name": "Doric, Nature's Warden // Doric, Owlbear Avenger",
             "text": "",
             "colours": [
@@ -41150,7 +41150,7 @@
         },
         {
             "id": "901b90d1-44db-5c82-a5ed-61976b3ab0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg?1",
             "name": "Doric, Nature's Warden // Doric, Owlbear Avenger",
             "text": "",
             "colours": [
@@ -41187,7 +41187,7 @@
         },
         {
             "id": "9d2e0398-91cd-5a5f-87de-ef2d1dcd45cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80c7702-3226-4ec6-bb75-26621a146a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80c7702-3226-4ec6-bb75-26621a146a7e.jpg?1",
             "name": "Edgin, Larcenous Lutenist",
             "text": "",
             "colours": [
@@ -41226,7 +41226,7 @@
         },
         {
             "id": "433f1681-b1e0-5f05-9597-74312e3b1d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99285945-0d97-4e29-9be2-2d2cfd9bac4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99285945-0d97-4e29-9be2-2d2cfd9bac4e.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "",
             "colours": [],
@@ -41259,7 +41259,7 @@
         },
         {
             "id": "3abf28aa-de3c-534b-b9b5-c4481969326f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655722c3-e361-48cb-95f8-d5627de56a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655722c3-e361-48cb-95f8-d5627de56a1b.jpg?1",
             "name": "Sorin, Imperious Bloodlord",
             "text": "",
             "colours": [
@@ -41294,7 +41294,7 @@
         },
         {
             "id": "7835cd29-9d71-580c-8803-9a1621f84a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbd6f05-bbd5-4491-a979-ffb3db1d6a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbd6f05-bbd5-4491-a979-ffb3db1d6a64.jpg?1",
             "name": "Sarkhan, Dragonsoul",
             "text": "",
             "colours": [
@@ -41329,7 +41329,7 @@
         },
         {
             "id": "39a2b2cf-26f4-55fe-be54-fc2c00e6b9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee1dee4-651a-4038-ba96-d265bd53c9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee1dee4-651a-4038-ba96-d265bd53c9a0.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "",
             "colours": [
@@ -41370,7 +41370,7 @@
         },
         {
             "id": "a35ada4f-67fc-50a3-a3f4-31e8ebd4e01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b8f805-9a02-4704-a5b6-6becdf030804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b8f805-9a02-4704-a5b6-6becdf030804.jpg?1",
             "name": "Braid of Fire",
             "text": "",
             "colours": [
@@ -41404,7 +41404,7 @@
         },
         {
             "id": "be86fcc2-f4c3-5489-82c1-7ab3b32d4baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74af08d9-76ef-48aa-86c5-b92ea6e10c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74af08d9-76ef-48aa-86c5-b92ea6e10c9f.jpg?1",
             "name": "Koth of the Hammer",
             "text": "",
             "colours": [
@@ -41440,7 +41440,7 @@
         },
         {
             "id": "6058f8fa-1bcd-5957-896e-c95eaaa197f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4dcc14-0f3b-46b0-a37e-31d0c3e70732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4dcc14-0f3b-46b0-a37e-31d0c3e70732.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "",
             "colours": [
@@ -41475,7 +41475,7 @@
         },
         {
             "id": "2b6ef13f-7689-558a-98ec-03ce5591c2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c248ce-d101-4a26-a8ed-7f98b39b357e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c248ce-d101-4a26-a8ed-7f98b39b357e.jpg?1",
             "name": "Karrthus, Tyrant of Jund",
             "text": "",
             "colours": [
@@ -41515,7 +41515,7 @@
         },
         {
             "id": "f23df117-6437-513a-b78e-82261bd18b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4310db6-9757-469a-a20a-496331d6ff53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4310db6-9757-469a-a20a-496331d6ff53.jpg?1",
             "name": "Cleansing Nova",
             "text": "",
             "colours": [
@@ -41549,7 +41549,7 @@
         },
         {
             "id": "126bcfde-60c5-51f4-94cb-7d7b72dee61a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6748788-496c-42b4-9f68-e0bd5692b511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6748788-496c-42b4-9f68-e0bd5692b511.jpg?1",
             "name": "Serra the Benevolent",
             "text": "",
             "colours": [
@@ -41585,7 +41585,7 @@
         },
         {
             "id": "a5835d71-9605-56e6-99d5-1c366bbba6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb220c6c-8dda-45f4-87fa-f754e94fac42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb220c6c-8dda-45f4-87fa-f754e94fac42.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "",
             "colours": [
@@ -41620,7 +41620,7 @@
         },
         {
             "id": "10165410-d7d2-58db-be98-dc7dd46666d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c28fcb-09e8-4b58-bda2-339afb68fc9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c28fcb-09e8-4b58-bda2-339afb68fc9a.jpg?1",
             "name": "Muddle the Mixture",
             "text": "",
             "colours": [
@@ -41652,7 +41652,7 @@
         },
         {
             "id": "89aa378c-89bc-5271-8fff-14f4192b9d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0420119f-a25b-44c7-b82f-51d05dfd94c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0420119f-a25b-44c7-b82f-51d05dfd94c5.jpg?1",
             "name": "Flamekin Harbinger",
             "text": "",
             "colours": [
@@ -41687,7 +41687,7 @@
         },
         {
             "id": "b5dbe80c-3b12-5697-9560-47e298fd37e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b75fc9-7045-4a87-b459-8d32f6c5402c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b75fc9-7045-4a87-b459-8d32f6c5402c.jpg?1",
             "name": "Omnath, Locus of Rage",
             "text": "",
             "colours": [
@@ -41725,7 +41725,7 @@
         },
         {
             "id": "828b903e-424b-5db4-9f45-51be3c4bf52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88f895-b5d6-47ea-a69c-eb4e5d65e401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88f895-b5d6-47ea-a69c-eb4e5d65e401.jpg?1",
             "name": "Risen Reef",
             "text": "",
             "colours": [
@@ -41761,7 +41761,7 @@
         },
         {
             "id": "fc36cbcc-d16a-596c-a8fc-18ee80844b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dacda4-ed81-4daf-8718-cc59bffd95fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dacda4-ed81-4daf-8718-cc59bffd95fc.jpg?1",
             "name": "Voice of Resurgence",
             "text": "",
             "colours": [
@@ -41797,7 +41797,7 @@
         },
         {
             "id": "dcfa2844-4ada-5c5b-8f77-5b856f0e326f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ba709f-e9eb-4cf0-ab68-d1aa88eeaf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ba709f-e9eb-4cf0-ab68-d1aa88eeaf07.jpg?1",
             "name": "Wheel and Deal",
             "text": "",
             "colours": [
@@ -41828,7 +41828,7 @@
         },
         {
             "id": "adc38dff-855b-536e-b1a4-9cef5e947177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c717a-ede7-4f6d-b9a9-da6cf0fd3d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c717a-ede7-4f6d-b9a9-da6cf0fd3d5d.jpg?1",
             "name": "Questing Beast",
             "text": "",
             "colours": [
@@ -41863,7 +41863,7 @@
         },
         {
             "id": "0a9586e5-d86b-58c1-9326-b4634a3e922e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c5b9d-71f2-45e4-a177-494c231c79fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c5b9d-71f2-45e4-a177-494c231c79fd.jpg?1",
             "name": "Olivia Voldaren",
             "text": "",
             "colours": [
@@ -41900,7 +41900,7 @@
         },
         {
             "id": "e71364dd-0c57-5dbd-aa07-e754b0192884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a696f69-ba08-4b0b-86e9-37e3671674ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a696f69-ba08-4b0b-86e9-37e3671674ec.jpg?1",
             "name": "Walking Ballista",
             "text": "",
             "colours": [],
@@ -41932,7 +41932,7 @@
         },
         {
             "id": "1e59abcf-73a7-56eb-bbdc-31d69865ed91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb15155-9bd8-4062-aa81-de275748faf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb15155-9bd8-4062-aa81-de275748faf2.jpg?1",
             "name": "The World Tree",
             "text": "",
             "colours": [],
@@ -41965,7 +41965,7 @@
         },
         {
             "id": "8931ddae-f433-53fa-b33c-0ac92016e8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b17ebb8-23e1-4c76-9184-52faa49be274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b17ebb8-23e1-4c76-9184-52faa49be274.jpg?1",
             "name": "Higure, the Still Wind",
             "text": "",
             "colours": [
@@ -42001,7 +42001,7 @@
         },
         {
             "id": "a7467f24-dfbc-5e41-a8d3-cfe8d3c53137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346701fc-f2ca-44dc-8d58-19b40cf83a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346701fc-f2ca-44dc-8d58-19b40cf83a8c.jpg?1",
             "name": "Nezahal, Primal Tide",
             "text": "",
             "colours": [
@@ -42037,7 +42037,7 @@
         },
         {
             "id": "bf0d143b-c89d-56d3-9305-0fb4a760f476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169b04a-d799-4693-999e-114dd085b378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169b04a-d799-4693-999e-114dd085b378.jpg?1",
             "name": "Dragonlord Kolaghan",
             "text": "",
             "colours": [
@@ -42075,7 +42075,7 @@
         },
         {
             "id": "dd126808-a793-50ac-8a4d-2323a5995f43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a377b68-9d70-427a-8829-be370e3a0600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a377b68-9d70-427a-8829-be370e3a0600.jpg?1",
             "name": "Mina and Denn, Wildborn",
             "text": "",
             "colours": [
@@ -42113,7 +42113,7 @@
         },
         {
             "id": "59e52ccb-1ae4-5fbe-8603-5f9ef39ff8ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4772947-acf2-44ed-86da-48a623ce4f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4772947-acf2-44ed-86da-48a623ce4f97.jpg?1",
             "name": "Xantcha, Sleeper Agent",
             "text": "",
             "colours": [
@@ -42151,7 +42151,7 @@
         },
         {
             "id": "a6ce5a0b-4271-596b-9581-a6c3c25d9df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fe1eff-e475-4949-9914-c49cb15ec433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fe1eff-e475-4949-9914-c49cb15ec433.jpg?1",
             "name": "Misdirection",
             "text": "",
             "colours": [
@@ -42182,7 +42182,7 @@
         },
         {
             "id": "81dda362-5f87-5b74-b4ee-ec0db97b38b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61243a31-6608-451f-9ba1-4f8ecc5aaad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61243a31-6608-451f-9ba1-4f8ecc5aaad1.jpg?1",
             "name": "Utvara Hellkite",
             "text": "",
             "colours": [
@@ -42215,7 +42215,7 @@
         },
         {
             "id": "c8f8fa2c-9316-5dcb-861b-f175cbca8b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b05ce09-b752-46f0-b0a7-508838a41a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b05ce09-b752-46f0-b0a7-508838a41a94.jpg?1",
             "name": "Kogla, the Titan Ape",
             "text": "",
             "colours": [
@@ -42250,7 +42250,7 @@
         },
         {
             "id": "668fd789-ba3c-5e1b-90ae-41ce326a6f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9929e-95bc-4d97-8579-d85c6f4e2dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9929e-95bc-4d97-8579-d85c6f4e2dc8.jpg?1",
             "name": "Nyxbloom Ancient",
             "text": "",
             "colours": [
@@ -42284,7 +42284,7 @@
         },
         {
             "id": "049fbac0-87a5-54ae-8f06-b4435ca0963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c275f66-32dd-4f40-9b6e-f4423c8e7ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c275f66-32dd-4f40-9b6e-f4423c8e7ec1.jpg?1",
             "name": "Jhoira, Weatherlight Captain",
             "text": "",
             "colours": [
@@ -42322,7 +42322,7 @@
         },
         {
             "id": "a4b7a9ab-c2a6-5f28-b077-03da0913a0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc29468-66bb-4136-a233-283004800d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc29468-66bb-4136-a233-283004800d35.jpg?1",
             "name": "Llawan, Cephalid Empress",
             "text": "",
             "colours": [
@@ -42359,7 +42359,7 @@
         },
         {
             "id": "df6ae14b-3f5d-5f64-bb03-dbd52d73cc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cca3f7c-f0b1-4a0e-a2b9-ffb4a00e2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cca3f7c-f0b1-4a0e-a2b9-ffb4a00e2ac6.jpg?1",
             "name": "Master of Waves",
             "text": "",
             "colours": [
@@ -42394,7 +42394,7 @@
         },
         {
             "id": "221b3159-1dce-5ff3-ba55-f5b77bcbbb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffb0ecd-1326-43d8-9a68-39bc238e5d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffb0ecd-1326-43d8-9a68-39bc238e5d3c.jpg?1",
             "name": "Thassa, Deep-Dwelling",
             "text": "",
             "colours": [
@@ -42431,7 +42431,7 @@
         },
         {
             "id": "dac06452-0759-5ca3-a664-b18ea347b2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9de4-0d31-431f-b060-69a33e9d9c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9de4-0d31-431f-b060-69a33e9d9c85.jpg?1",
             "name": "Thassa's Oracle",
             "text": "",
             "colours": [
@@ -42466,7 +42466,7 @@
         },
         {
             "id": "b1cc3020-4f53-5a05-817a-8008c8f48536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d71b38-c770-4d06-aa03-73d5e8381b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d71b38-c770-4d06-aa03-73d5e8381b9d.jpg?1",
             "name": "Joraga Treespeaker",
             "text": "",
             "colours": [
@@ -42501,7 +42501,7 @@
         },
         {
             "id": "40c8c3f2-74db-5dda-a4c8-c57b3989a541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0bb4a-11e0-442f-b4fe-e54a16b52dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0bb4a-11e0-442f-b4fe-e54a16b52dad.jpg?1",
             "name": "Nature's Will",
             "text": "",
             "colours": [
@@ -42533,7 +42533,7 @@
         },
         {
             "id": "a58d4fa0-ae35-5ec1-a0dd-0b9aad132b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf611cc-6a54-40bb-8fc3-b66d942254db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf611cc-6a54-40bb-8fc3-b66d942254db.jpg?1",
             "name": "Ulvenwald Tracker",
             "text": "",
             "colours": [
@@ -42568,7 +42568,7 @@
         },
         {
             "id": "2fe82a0b-b982-5812-8a07-a662c83b33d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c45f04-b844-4219-b7c5-5fd42edacc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c45f04-b844-4219-b7c5-5fd42edacc78.jpg?1",
             "name": "Yeva, Nature's Herald",
             "text": "",
             "colours": [
@@ -42605,7 +42605,7 @@
         },
         {
             "id": "06b8620a-d829-57e0-aa2e-f84685b3ef65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120139f9-3dc5-482f-a70c-7c6a4f264c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120139f9-3dc5-482f-a70c-7c6a4f264c19.jpg?1",
             "name": "Grand Abolisher",
             "text": "",
             "colours": [
@@ -42640,7 +42640,7 @@
         },
         {
             "id": "b60d482f-40a5-5297-9c4a-c9c9fbafb3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee658648-7bfc-4311-ba4a-395dec49f207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee658648-7bfc-4311-ba4a-395dec49f207.jpg?1",
             "name": "Selfless Savior",
             "text": "",
             "colours": [
@@ -42676,7 +42676,7 @@
         },
         {
             "id": "72694983-2e64-5d0d-babd-a5fe4e5f7643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635ca686-c04e-47df-b1b5-687bb7c69d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635ca686-c04e-47df-b1b5-687bb7c69d4c.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "",
             "colours": [
@@ -42712,7 +42712,7 @@
         },
         {
             "id": "b3755d49-6c88-5d53-af96-94c627dcf454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94756cbe-022d-4fdf-a3b8-ad368174c90d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94756cbe-022d-4fdf-a3b8-ad368174c90d.jpg?1",
             "name": "Umezawa's Jitte",
             "text": "",
             "colours": [],
@@ -42744,7 +42744,7 @@
         },
         {
             "id": "55626bac-10f6-5c99-884b-942bf1a107ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8cf4ef-0545-4876-b089-bfc723b521ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8cf4ef-0545-4876-b089-bfc723b521ed.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "",
             "colours": [
@@ -42780,7 +42780,7 @@
         },
         {
             "id": "ccc989e1-6378-57db-ac93-282af03dcac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99aad0c2-1df3-4043-8aba-e9cbb9bd5c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99aad0c2-1df3-4043-8aba-e9cbb9bd5c85.jpg?1",
             "name": "Sunblast Angel",
             "text": "",
             "colours": [
@@ -42814,7 +42814,7 @@
         },
         {
             "id": "8622475a-a29a-5a79-9afe-e9b50b25c486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ecba0-a9dd-4adf-ad9d-0c068bf526fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ecba0-a9dd-4adf-ad9d-0c068bf526fa.jpg?1",
             "name": "Emeria, the Sky Ruin",
             "text": "",
             "colours": [],
@@ -42844,7 +42844,7 @@
         },
         {
             "id": "2df0d23e-f7a6-5c81-9008-66688c69152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec09c30-b1bb-4380-9c4a-f57c25c67a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec09c30-b1bb-4380-9c4a-f57c25c67a2e.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "",
             "colours": [],
@@ -42875,7 +42875,7 @@
         },
         {
             "id": "e1257085-e57c-5529-9ff4-f8c6555c2fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4eccc6-26a3-48d3-bb15-522ba51327e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4eccc6-26a3-48d3-bb15-522ba51327e0.jpg?1",
             "name": "Slip On the Ring",
             "text": "",
             "colours": [
@@ -42907,7 +42907,7 @@
         },
         {
             "id": "2f52013b-f080-5ae6-accc-e54c5dc85456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745f592-8d4d-46f4-b631-c014da1ab3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745f592-8d4d-46f4-b631-c014da1ab3a9.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -42944,7 +42944,7 @@
         },
         {
             "id": "9b4d30d9-b1b0-56ac-a209-f1c94e3e5d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d04970-12c7-460f-a7bc-beb97b161246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d04970-12c7-460f-a7bc-beb97b161246.jpg?1",
             "name": "Mirror of Galadriel",
             "text": "",
             "colours": [],
@@ -42974,7 +42974,7 @@
         },
         {
             "id": "62099e8e-5c0c-5732-8d60-473ff26429a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233144a-9e88-44a2-9ea9-88ecc116bcd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233144a-9e88-44a2-9ea9-88ecc116bcd6.jpg?1",
             "name": "Shire Terrace",
             "text": "",
             "colours": [],
@@ -43002,7 +43002,7 @@
         },
         {
             "id": "c887befb-934a-50d6-b540-7350b0b4742a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b49030-55fe-4bf4-a2b9-c78f36e2d425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b49030-55fe-4bf4-a2b9-c78f36e2d425.jpg?1",
             "name": "Syr Konrad, the Grim",
             "text": "",
             "colours": [
@@ -43039,7 +43039,7 @@
         },
         {
             "id": "3da47f93-fdea-5a18-b906-e2a8b05b9b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549b913-556a-4aeb-899e-438ff6874f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549b913-556a-4aeb-899e-438ff6874f56.jpg?1",
             "name": "Underworld Dreams",
             "text": "",
             "colours": [
@@ -43071,7 +43071,7 @@
         },
         {
             "id": "0203c3ad-ae84-5d3f-a8f3-64a9a669dcd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fc8e83-471a-4d75-9703-d8f3998a705a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fc8e83-471a-4d75-9703-d8f3998a705a.jpg?1",
             "name": "Waste Not",
             "text": "",
             "colours": [
@@ -43103,7 +43103,7 @@
         },
         {
             "id": "6bdfd75a-23dc-599b-a5c5-f86973f8ddfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9d0f64-2bc2-42da-a2f3-f56235c2bf54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9d0f64-2bc2-42da-a2f3-f56235c2bf54.jpg?1",
             "name": "Wheel of Misfortune",
             "text": "",
             "colours": [
@@ -43135,7 +43135,7 @@
         },
         {
             "id": "027d8827-486b-5074-9a8e-016ec0ca5df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e1b0f-c2e5-4b75-817d-19ab5f734139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e1b0f-c2e5-4b75-817d-19ab5f734139.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "",
             "colours": [
@@ -43176,7 +43176,7 @@
         },
         {
             "id": "6ee65967-e6f7-5d01-9d9a-7bfa488a5816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26affcc7-e64a-4dc0-8f01-432288161f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26affcc7-e64a-4dc0-8f01-432288161f9d.jpg?1",
             "name": "Nemesis of Reason",
             "text": "",
             "colours": [
@@ -43213,7 +43213,7 @@
         },
         {
             "id": "288c58fb-65b8-5305-9e9c-3a19e6d80930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df786-c2ed-49c5-a5f2-73f5daf34ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df786-c2ed-49c5-a5f2-73f5daf34ca9.jpg?1",
             "name": "Gaea's Blessing",
             "text": "",
             "colours": [
@@ -43247,7 +43247,7 @@
         },
         {
             "id": "88868471-2fb5-5def-976c-c230de6ecdcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ec13cf-e164-4222-90b1-af3e92e03b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ec13cf-e164-4222-90b1-af3e92e03b2e.jpg?1",
             "name": "Twilight Prophet",
             "text": "",
             "colours": [
@@ -43282,7 +43282,7 @@
         },
         {
             "id": "7d7676dc-d04f-5426-a3ce-738ec4522010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada90827-f11b-495b-8962-66dd6345b454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada90827-f11b-495b-8962-66dd6345b454.jpg?1",
             "name": "Worldspine Wurm",
             "text": "",
             "colours": [
@@ -43316,7 +43316,7 @@
         },
         {
             "id": "dcebbfa7-cad3-5211-bf52-b310c26dc404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd79f1-88dd-40a0-b348-6eb6757e3b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd79f1-88dd-40a0-b348-6eb6757e3b13.jpg?1",
             "name": "Goblin Lackey",
             "text": "",
             "colours": [
@@ -43352,7 +43352,7 @@
         },
         {
             "id": "db868ae3-197c-5aac-8ff6-ace16ba81fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8b2dd7-fabd-4b2a-a9e7-5a02bba89e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8b2dd7-fabd-4b2a-a9e7-5a02bba89e10.jpg?1",
             "name": "Goblin Lackey",
             "text": "",
             "colours": [
@@ -43388,7 +43388,7 @@
         },
         {
             "id": "c694a639-b62a-5ea2-8e2f-2cbb649b3fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f56067-4b86-4788-8fd7-648c9041dbd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f56067-4b86-4788-8fd7-648c9041dbd4.jpg?1",
             "name": "Goblin Matron",
             "text": "",
             "colours": [
@@ -43423,7 +43423,7 @@
         },
         {
             "id": "ea633847-dd70-565a-bad1-dd778d9b8797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a040d62-d9eb-42a1-ac22-690d497d4de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a040d62-d9eb-42a1-ac22-690d497d4de8.jpg?1",
             "name": "Goblin Matron",
             "text": "",
             "colours": [
@@ -43458,7 +43458,7 @@
         },
         {
             "id": "a17db5f1-6299-58f6-a7e4-d42d9d0565de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb3b4c-ac12-406c-8517-9fccefdd1544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb3b4c-ac12-406c-8517-9fccefdd1544.jpg?1",
             "name": "Goblin Recruiter",
             "text": "",
             "colours": [
@@ -43493,7 +43493,7 @@
         },
         {
             "id": "bdb98213-fa96-53dc-a3ec-8fbd09f2aaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df52e94a-9836-4afd-b7cc-fd77cdd31eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df52e94a-9836-4afd-b7cc-fd77cdd31eb2.jpg?1",
             "name": "Goblin Recruiter",
             "text": "",
             "colours": [
@@ -43528,7 +43528,7 @@
         },
         {
             "id": "32367441-7d9e-535f-a19f-ce66eb89b6a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f8035b-c776-4213-a5e2-e6c7c3f5961f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f8035b-c776-4213-a5e2-e6c7c3f5961f.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "",
             "colours": [
@@ -43566,7 +43566,7 @@
         },
         {
             "id": "7dd7272f-13a9-51d4-9e25-d035747e0508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea8f92fb-9ecc-4a41-aabc-7261acb4e8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea8f92fb-9ecc-4a41-aabc-7261acb4e8fc.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "",
             "colours": [
@@ -43604,7 +43604,7 @@
         },
         {
             "id": "f32e01cc-5930-5319-a6c0-72628a1f571a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f909489-4567-4886-9191-05119b338cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f909489-4567-4886-9191-05119b338cfd.jpg?1",
             "name": "Shattergang Brothers",
             "text": "",
             "colours": [
@@ -43646,7 +43646,7 @@
         },
         {
             "id": "61158e3c-73ed-5fdc-80b4-67ce53f7d249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e84d2-2685-4b41-a06b-9d54e9d3d725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e84d2-2685-4b41-a06b-9d54e9d3d725.jpg?1",
             "name": "Shattergang Brothers",
             "text": "",
             "colours": [
@@ -43688,7 +43688,7 @@
         },
         {
             "id": "0606aa2b-a7f4-5c38-987f-59b61cdc2bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ab62b-7f22-49e4-b8af-9062eb782ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ab62b-7f22-49e4-b8af-9062eb782ef7.jpg?1",
             "name": "Nirkana Revenant",
             "text": "",
             "colours": [
@@ -43723,7 +43723,7 @@
         },
         {
             "id": "af056c7c-c2bd-54cb-a9f3-75f654406d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bce60-78f6-4f42-9fcd-383f66f85de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bce60-78f6-4f42-9fcd-383f66f85de5.jpg?1",
             "name": "Arbor Elf",
             "text": "",
             "colours": [
@@ -43758,7 +43758,7 @@
         },
         {
             "id": "7dba9454-ff2d-590e-ac38-5a074b417531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48783dc1-0976-4955-b7e3-afa311160d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48783dc1-0976-4955-b7e3-afa311160d68.jpg?1",
             "name": "Terastodon",
             "text": "",
             "colours": [
@@ -43792,7 +43792,7 @@
         },
         {
             "id": "aa2f837a-a703-5890-92a9-3293c31a1183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c835f-2a60-46bb-9046-106ce8fba676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c835f-2a60-46bb-9046-106ce8fba676.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "",
             "colours": [
@@ -43832,7 +43832,7 @@
         },
         {
             "id": "5cea7287-022e-54b9-8b97-4b21260fa210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574057d5-d4a3-4d51-9f53-830d533426b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574057d5-d4a3-4d51-9f53-830d533426b2.jpg?1",
             "name": "Gargos, Vicious Watcher",
             "text": "",
             "colours": [
@@ -43867,7 +43867,7 @@
         },
         {
             "id": "4fb3c1b9-19b8-5645-831d-00b0da5cc474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe14302-26be-4e65-8863-d711d33454cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe14302-26be-4e65-8863-d711d33454cd.jpg?1",
             "name": "Primordial Hydra",
             "text": "",
             "colours": [
@@ -43900,7 +43900,7 @@
         },
         {
             "id": "7053c058-ff2b-5425-95e7-62ad6f75119f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e8a326-4438-45f5-8695-a9d85a2858fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e8a326-4438-45f5-8695-a9d85a2858fe.jpg?1",
             "name": "Unbound Flourishing",
             "text": "",
             "colours": [
@@ -43931,7 +43931,7 @@
         },
         {
             "id": "7dbee963-22b1-5475-89e7-87d1d842dc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab115f5d-e182-4d78-bbe9-327e5b612f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab115f5d-e182-4d78-bbe9-327e5b612f39.jpg?1",
             "name": "Hydroid Krasis",
             "text": "",
             "colours": [
@@ -43968,7 +43968,7 @@
         },
         {
             "id": "71b71daf-9419-5b4e-a594-54349765570e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44043b50-9837-40d2-ad08-d515faed216c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44043b50-9837-40d2-ad08-d515faed216c.jpg?1",
             "name": "Zaxara, the Exemplary",
             "text": "",
             "colours": [
@@ -44008,7 +44008,7 @@
         },
         {
             "id": "014e335e-840a-57ad-ba6a-d570ee41e93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc318-9c3e-471f-90eb-dc76454da957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc318-9c3e-471f-90eb-dc76454da957.jpg?1",
             "name": "Gisela, the Broken Blade // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -44046,7 +44046,7 @@
         },
         {
             "id": "ebd91441-1663-50c8-b5ca-23d7f5d062e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a0347e-8ec6-463e-aef5-33f7d62899e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a0347e-8ec6-463e-aef5-33f7d62899e2.jpg?1",
             "name": "Bruna, the Fading Light // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -44084,7 +44084,7 @@
         },
         {
             "id": "c1f975cc-cb83-5d58-86d3-ff70a4fe3900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd83c0e-8e37-40bf-87a5-5b4c009248fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd83c0e-8e37-40bf-87a5-5b4c009248fb.jpg?1",
             "name": "Brisela, Voice of Nightmares",
             "text": "",
             "colours": [],
@@ -44120,7 +44120,7 @@
         },
         {
             "id": "767e6c07-6a10-5405-addb-b42225229a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929b98-e81c-48b9-87d8-11c8830974ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929b98-e81c-48b9-87d8-11c8830974ce.jpg?1",
             "name": "Archangel of Thune",
             "text": "",
             "colours": [
@@ -44153,7 +44153,7 @@
         },
         {
             "id": "7de26f64-6e5f-5ff0-ab10-901dfec3eb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098d5b-0cdb-422f-8bd2-7afd81a7b7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098d5b-0cdb-422f-8bd2-7afd81a7b7c3.jpg?1",
             "name": "Court of Grace",
             "text": "",
             "colours": [
@@ -44184,7 +44184,7 @@
         },
         {
             "id": "688bf216-ebe2-5383-b800-51ed39998c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a14f93-6896-4b8e-a0b2-e081dfea5958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a14f93-6896-4b8e-a0b2-e081dfea5958.jpg?1",
             "name": "Commander's Plate",
             "text": "",
             "colours": [],
@@ -44215,7 +44215,7 @@
         },
         {
             "id": "7410a574-586c-5234-86e3-2e1073516c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634950f2-3149-41b5-a93d-81f9f1957801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634950f2-3149-41b5-a93d-81f9f1957801.jpg?1",
             "name": "Angel of Finality",
             "text": "",
             "colours": [
@@ -44248,7 +44248,7 @@
         },
         {
             "id": "de38eca4-0829-5e71-b79a-14b64339f928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc1e38-a44e-4127-946e-eac0c8db2b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc1e38-a44e-4127-946e-eac0c8db2b2f.jpg?1",
             "name": "Angel of the Ruins",
             "text": "",
             "colours": [
@@ -44284,7 +44284,7 @@
         },
         {
             "id": "042a355f-2fbe-5952-9ac2-0c9f0b6b4d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb42fb7-1ac5-4923-bec8-2aa2d4dbefd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb42fb7-1ac5-4923-bec8-2aa2d4dbefd5.jpg?1",
             "name": "Arden Angel",
             "text": "",
             "colours": [
@@ -44317,7 +44317,7 @@
         },
         {
             "id": "0fa8b187-cdb5-541e-a6ae-e1ea31fc99f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270c252d-1248-450b-bbc3-3af475a94834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270c252d-1248-450b-bbc3-3af475a94834.jpg?1",
             "name": "Breathkeeper Seraph",
             "text": "",
             "colours": [
@@ -44350,7 +44350,7 @@
         },
         {
             "id": "8f36161e-44be-5d48-b0f1-fc2cba2167a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c48a5-c80f-43e6-ab4e-fa7bd7b5c3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c48a5-c80f-43e6-ab4e-fa7bd7b5c3a0.jpg?1",
             "name": "Dawnbreak Reclaimer",
             "text": "",
             "colours": [
@@ -44383,7 +44383,7 @@
         },
         {
             "id": "d4ea6152-ecf8-5e78-a4e7-bb983ffa1898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79ecdf5-2167-4590-a964-e9d7eb32dfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79ecdf5-2167-4590-a964-e9d7eb32dfe6.jpg?1",
             "name": "Valkyrie Harbinger",
             "text": "",
             "colours": [
@@ -44417,7 +44417,7 @@
         },
         {
             "id": "ebf52f9c-bd76-5b4d-a46b-ff175a7fc62a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5173aa-1eca-46ae-81ea-0b1dfe5e12de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5173aa-1eca-46ae-81ea-0b1dfe5e12de.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44485,7 +44485,7 @@
         },
         {
             "id": "f3600030-e743-5089-87d6-5c56c5fbf564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77924e4-0f15-48a3-b494-89b544ee9d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77924e4-0f15-48a3-b494-89b544ee9d37.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44553,7 +44553,7 @@
         },
         {
             "id": "e7ee8833-ff69-5335-9da3-58133e6c73f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9deeda0b-81f7-484d-a99d-0e7d2449d157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9deeda0b-81f7-484d-a99d-0e7d2449d157.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44621,7 +44621,7 @@
         },
         {
             "id": "ea5d01c0-c28e-5ac6-a742-23c3fd12e944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63607a09-b00c-4c0e-b8ad-d1bb5a45517b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63607a09-b00c-4c0e-b8ad-d1bb5a45517b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44689,7 +44689,7 @@
         },
         {
             "id": "9a254b50-9412-5661-9ad3-2154e6fbdc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890e6cd-f5af-4651-a55a-8526617152bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890e6cd-f5af-4651-a55a-8526617152bb.jpg?1",
             "name": "Puresteel Paladin",
             "text": "",
             "colours": [
@@ -44724,7 +44724,7 @@
         },
         {
             "id": "a4beb479-16f3-50da-ad29-fc3d302c1245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1215c98-e372-4261-b3bf-8b64ac0fb470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1215c98-e372-4261-b3bf-8b64ac0fb470.jpg?1",
             "name": "Vanquish the Horde",
             "text": "",
             "colours": [
@@ -44756,7 +44756,7 @@
         },
         {
             "id": "c5379ecb-8ef1-5810-a496-6288162d0aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d19ea1f-8b39-4a7d-8aaa-e87fc09b15f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d19ea1f-8b39-4a7d-8aaa-e87fc09b15f2.jpg?1",
             "name": "Zombie Apocalypse",
             "text": "",
             "colours": [
@@ -44788,7 +44788,7 @@
         },
         {
             "id": "5665e1a5-73a0-59e0-93c8-1af0cd1d5c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e72a97-4739-41ca-8e79-1978a7baf54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e72a97-4739-41ca-8e79-1978a7baf54d.jpg?1",
             "name": "Varina, Lich Queen",
             "text": "",
             "colours": [
@@ -44829,7 +44829,7 @@
         },
         {
             "id": "fab0d7b9-51c2-549a-8ec4-4777b6695155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7acd81-1fcb-4758-95f4-e64cb696c9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7acd81-1fcb-4758-95f4-e64cb696c9d2.jpg?1",
             "name": "Field of the Dead",
             "text": "",
             "colours": [],
@@ -44857,7 +44857,7 @@
         },
         {
             "id": "97e85c59-007c-54a9-826a-d309e987735c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b373adfa-ebc2-4060-8ff3-d1f0eca03c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b373adfa-ebc2-4060-8ff3-d1f0eca03c02.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -44931,7 +44931,7 @@
         },
         {
             "id": "a2b373b5-657d-5aa1-bb71-66f2a2982221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f6a52-67d6-4215-9f3f-3b0a17dd8889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f6a52-67d6-4215-9f3f-3b0a17dd8889.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45005,7 +45005,7 @@
         },
         {
             "id": "9017486f-97e9-5024-a034-0ad2b2086b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34410953-113a-45ae-89d4-2ce39f75c3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34410953-113a-45ae-89d4-2ce39f75c3c6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45079,7 +45079,7 @@
         },
         {
             "id": "dcc5ea4c-a271-5af9-8539-e870e27c6dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6651e0fd-50ca-449e-84f1-ebb07fb305f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6651e0fd-50ca-449e-84f1-ebb07fb305f5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45153,7 +45153,7 @@
         },
         {
             "id": "eb6efaa6-283c-5376-ab35-f3d8c706bd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54278194-fc8b-4208-a3ca-e655fddca2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54278194-fc8b-4208-a3ca-e655fddca2df.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45227,7 +45227,7 @@
         },
         {
             "id": "7fd3c247-a13d-59e9-a8ad-2516cfcaee51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0627111-1390-43cb-84e7-d6c0e46c02ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0627111-1390-43cb-84e7-d6c0e46c02ea.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45301,7 +45301,7 @@
         },
         {
             "id": "ea7c578e-040e-5225-af30-012f48b5868a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd0396-2e7b-4b87-9504-953bd35e4fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd0396-2e7b-4b87-9504-953bd35e4fea.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45375,7 +45375,7 @@
         },
         {
             "id": "96add785-f216-554e-84c8-62fd745de237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b150a6d-a33d-456a-a2b0-286e43bc636e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b150a6d-a33d-456a-a2b0-286e43bc636e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45449,7 +45449,7 @@
         },
         {
             "id": "a8467d6d-6213-5267-89a2-8e447f60fc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88d76e-d71f-43ea-a272-5dc8b5928c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88d76e-d71f-43ea-a272-5dc8b5928c6b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45523,7 +45523,7 @@
         },
         {
             "id": "17305186-a617-570c-ae7a-a036158d3e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad38f6-ca2a-41a4-96cf-f41a41d54a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad38f6-ca2a-41a4-96cf-f41a41d54a37.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45597,7 +45597,7 @@
         },
         {
             "id": "f4761df1-1fc4-58ef-b9a5-a859453820de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374cd0e-d06a-4976-9483-202015c845ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374cd0e-d06a-4976-9483-202015c845ff.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -45631,7 +45631,7 @@
         },
         {
             "id": "82068a26-40b3-56df-83e8-de728bf54e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df323b67-e5f9-4958-90de-1af722c482dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df323b67-e5f9-4958-90de-1af722c482dd.jpg?1",
             "name": "Food Chain",
             "text": "",
             "colours": [
@@ -45663,7 +45663,7 @@
         },
         {
             "id": "bf146a81-aa15-573d-aaba-6058f263d6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5558bc8-31b8-4a83-8bd2-362f4e7be69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5558bc8-31b8-4a83-8bd2-362f4e7be69d.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -45695,7 +45695,7 @@
         },
         {
             "id": "82e731a4-4bdf-51d3-86dc-f05e3923ce07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecdb244-aeb5-42ef-b1ce-e586580c6b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecdb244-aeb5-42ef-b1ce-e586580c6b6c.jpg?1",
             "name": "The First Sliver",
             "text": "",
             "colours": [
@@ -45739,7 +45739,7 @@
         },
         {
             "id": "ba39c6b9-50d2-598d-92d9-374642538925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23146653-3573-4582-ae28-9764cd99f1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23146653-3573-4582-ae28-9764cd99f1d6.jpg?1",
             "name": "Concealed Courtyard",
             "text": "",
             "colours": [],
@@ -45770,7 +45770,7 @@
         },
         {
             "id": "658ee528-986f-5133-9e35-3a0fa9a29b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd8310d-6a91-46f6-aa85-f73ea37a66a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd8310d-6a91-46f6-aa85-f73ea37a66a2.jpg?1",
             "name": "Spirebluff Canal",
             "text": "",
             "colours": [],
@@ -45801,7 +45801,7 @@
         },
         {
             "id": "acce8a6b-88c4-5088-9e6f-e526d4e6d6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056f1559-cca9-4aae-810b-a7db56c214e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056f1559-cca9-4aae-810b-a7db56c214e9.jpg?1",
             "name": "Blooming Marsh",
             "text": "",
             "colours": [],
@@ -45832,7 +45832,7 @@
         },
         {
             "id": "a7925fb7-384b-54c9-a0fe-fa5e0e9af2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b1139d-e87c-415d-be20-d4d31480ebdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b1139d-e87c-415d-be20-d4d31480ebdc.jpg?1",
             "name": "Inspiring Vantage",
             "text": "",
             "colours": [],
@@ -45866,7 +45866,7 @@
         },
         {
             "id": "52da59be-f508-5ae3-99d2-f6f262a57a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c257d-ad28-4029-bb45-324bf262d1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c257d-ad28-4029-bb45-324bf262d1e5.jpg?1",
             "name": "Botanical Sanctum",
             "text": "",
             "colours": [],
@@ -45897,7 +45897,7 @@
         },
         {
             "id": "a749d964-de6e-5ec3-b37c-214ab92dbe16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17c9df-7d78-4228-a4ca-2f39b69f2ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17c9df-7d78-4228-a4ca-2f39b69f2ace.jpg?1",
             "name": "Angel of Serenity",
             "text": "",
             "colours": [
@@ -45931,7 +45931,7 @@
         },
         {
             "id": "771b2378-d55b-59a9-a041-0818f8226b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e33e540-538c-4c39-9f52-df26bdcac3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e33e540-538c-4c39-9f52-df26bdcac3fc.jpg?1",
             "name": "Angel of the Ruins",
             "text": "",
             "colours": [
@@ -45968,7 +45968,7 @@
         },
         {
             "id": "12fd738b-04fd-5ff0-aefc-079a6502af0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8599310-6b83-46a8-a38b-c48775d9c92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8599310-6b83-46a8-a38b-c48775d9c92f.jpg?1",
             "name": "Blinding Angel",
             "text": "",
             "colours": [
@@ -46002,7 +46002,7 @@
         },
         {
             "id": "954777cc-b498-5805-a677-2ba1ac2969d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb225a1-d005-4e4d-98b2-7ebe2e9141df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb225a1-d005-4e4d-98b2-7ebe2e9141df.jpg?1",
             "name": "Restoration Angel",
             "text": "",
             "colours": [
@@ -46036,7 +46036,7 @@
         },
         {
             "id": "449927bc-a041-5a8b-b3b3-d9fff6df2d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac93d2-80dd-4e2a-93b6-3e85526c7372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac93d2-80dd-4e2a-93b6-3e85526c7372.jpg?1",
             "name": "Sublime Archangel",
             "text": "",
             "colours": [
@@ -46070,7 +46070,7 @@
         },
         {
             "id": "a329f6ce-91f3-504a-b613-a43e65f9a6ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7147b73-a7fa-4ecf-b9a1-a3f4851a5bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7147b73-a7fa-4ecf-b9a1-a3f4851a5bef.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -46139,7 +46139,7 @@
         },
         {
             "id": "ce2ceb5e-6273-52b9-afc1-585e926feab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca2b9b7-9c12-488d-8f8b-540249d0d350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca2b9b7-9c12-488d-8f8b-540249d0d350.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -46204,7 +46204,7 @@
         },
         {
             "id": "02be70bb-528b-5500-80fc-4d4307f2ba65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387ec72f-dd6b-4769-be3a-981d580715be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387ec72f-dd6b-4769-be3a-981d580715be.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -46268,7 +46268,7 @@
         },
         {
             "id": "c8efff9c-3d4a-596c-8936-9ed3f79f8fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70099566-ba66-4d66-aafa-8232aa664a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70099566-ba66-4d66-aafa-8232aa664a6d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -46342,7 +46342,7 @@
         },
         {
             "id": "beb211b4-e110-5c3e-bcf3-6cc9c60d5d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56afe767-c967-4094-8d60-165bc7d11ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56afe767-c967-4094-8d60-165bc7d11ab1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -46407,7 +46407,7 @@
         },
         {
             "id": "223a202f-83e5-57cd-9212-0297790a36ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128e73b3-19a0-4740-b32b-5882d3937a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128e73b3-19a0-4740-b32b-5882d3937a79.jpg?1",
             "name": "Gisela, the Broken Blade // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -46445,7 +46445,7 @@
         },
         {
             "id": "4e72e006-c6cf-5c36-b5a3-59ead838241b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2e842-d953-4e97-b95a-2b1af51173a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2e842-d953-4e97-b95a-2b1af51173a9.jpg?1",
             "name": "Bruna, the Fading Light // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -46483,7 +46483,7 @@
         },
         {
             "id": "8fa74b32-ad1f-5d2b-98f1-b252c4ec3fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcd6747-f763-4e74-bb24-e93afe23cb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcd6747-f763-4e74-bb24-e93afe23cb32.jpg?1",
             "name": "Brisela, Voice of Nightmares",
             "text": "",
             "colours": [],
@@ -46519,7 +46519,7 @@
         },
         {
             "id": "4a3e102a-c030-5ee6-9b9e-dea76e298983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ed5f8-8bfa-483c-beeb-b4a7e7affd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ed5f8-8bfa-483c-beeb-b4a7e7affd65.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -46557,7 +46557,7 @@
         },
         {
             "id": "77e4fce8-4b12-5617-b10c-a450768ab0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37614b03-332b-4aa9-8a9a-340b552c7c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37614b03-332b-4aa9-8a9a-340b552c7c12.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -46595,7 +46595,7 @@
         },
         {
             "id": "9e059267-0a7f-57b1-8e7f-70c966eecd17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201a805-9d9c-4433-8a32-0edac93db271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201a805-9d9c-4433-8a32-0edac93db271.jpg?1",
             "name": "Rampaging Ferocidon",
             "text": "",
             "colours": [
@@ -46630,7 +46630,7 @@
         },
         {
             "id": "86bf5a75-aa0e-506e-96e9-c1e3a7136690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed9782f-6789-41b6-a04e-03d8f0e8d5cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed9782f-6789-41b6-a04e-03d8f0e8d5cf.jpg?1",
             "name": "Rampaging Ferocidon",
             "text": "",
             "colours": [
@@ -46665,7 +46665,7 @@
         },
         {
             "id": "78a6e140-24ce-5e28-ad97-1248ae4c8c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8973d1-171b-4d30-abab-9b8e9ace8912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8973d1-171b-4d30-abab-9b8e9ace8912.jpg?1",
             "name": "Polyraptor",
             "text": "",
             "colours": [
@@ -46700,7 +46700,7 @@
         },
         {
             "id": "51dc65ea-c2da-5a11-b279-4461b2fb542c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366303b8-13ce-4f9f-a0db-3b2eff0c1e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366303b8-13ce-4f9f-a0db-3b2eff0c1e8a.jpg?1",
             "name": "Polyraptor",
             "text": "",
             "colours": [
@@ -46735,7 +46735,7 @@
         },
         {
             "id": "0089833b-2bd9-596c-a752-518387022b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccfc3b7-235c-4680-aabf-4cb2e8d9a2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccfc3b7-235c-4680-aabf-4cb2e8d9a2fe.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "",
             "colours": [
@@ -46770,7 +46770,7 @@
         },
         {
             "id": "082647e2-79d8-5c12-adce-1c430df4a6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076c5abd-6ae5-4c59-b1f4-f18eeb9159d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076c5abd-6ae5-4c59-b1f4-f18eeb9159d9.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "",
             "colours": [
@@ -46805,7 +46805,7 @@
         },
         {
             "id": "45c2f14c-fcab-5653-894f-a0eb7010c1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a51e82-cbfc-4487-9a81-6e793e93f545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a51e82-cbfc-4487-9a81-6e793e93f545.jpg?1",
             "name": "Regisaur Alpha",
             "text": "",
             "colours": [
@@ -46842,7 +46842,7 @@
         },
         {
             "id": "c8ffadea-f14f-557a-879f-7c767d5a700a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22585cf-f84e-4c3d-a219-bd493d1122b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22585cf-f84e-4c3d-a219-bd493d1122b3.jpg?1",
             "name": "Regisaur Alpha",
             "text": "",
             "colours": [
@@ -46879,7 +46879,7 @@
         },
         {
             "id": "c0b36e3a-f74a-5547-b012-fbee743fe970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e13cf-4cb4-41f3-88e0-6836a16e905b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e13cf-4cb4-41f3-88e0-6836a16e905b.jpg?1",
             "name": "Laboratory Maniac",
             "text": "",
             "colours": [
@@ -46916,7 +46916,7 @@
         },
         {
             "id": "2cf7af0a-7112-5fcb-8656-9eeda9da02a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1c7054-d6a7-4962-804d-c470bb8e39d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1c7054-d6a7-4962-804d-c470bb8e39d3.jpg?1",
             "name": "Laboratory Maniac",
             "text": "",
             "colours": [
@@ -46953,7 +46953,7 @@
         },
         {
             "id": "6685fffd-056b-5fc6-9af4-16e68e332a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209bac6-fc0c-4a05-a459-7f0951a918e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209bac6-fc0c-4a05-a459-7f0951a918e8.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "",
             "colours": [
@@ -46986,7 +46986,7 @@
         },
         {
             "id": "55731677-e7d5-5f04-a8a4-cef10b66b48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45543f2b-abf9-42eb-88d6-6a6a104ee632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45543f2b-abf9-42eb-88d6-6a6a104ee632.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "",
             "colours": [
@@ -47019,7 +47019,7 @@
         },
         {
             "id": "b006aa26-f3ff-5f9d-beb0-140018c5c274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1683cb7f-9623-4ab8-8f88-f8255dac352c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1683cb7f-9623-4ab8-8f88-f8255dac352c.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "",
             "colours": [
@@ -47059,7 +47059,7 @@
         },
         {
             "id": "4995b264-f00b-565e-8029-6b8b37c861fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf11f3-2755-4f0a-bdb7-bb68ac498e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf11f3-2755-4f0a-bdb7-bb68ac498e41.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "",
             "colours": [
@@ -47099,7 +47099,7 @@
         },
         {
             "id": "574cef2c-b466-5b2e-b314-2fc4e2a44214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c872b04-e80d-4c02-ac26-8f5cbb82e99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c872b04-e80d-4c02-ac26-8f5cbb82e99f.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "",
             "colours": [
@@ -47141,7 +47141,7 @@
         },
         {
             "id": "8e901343-551e-5eab-a015-ccdbd5c80f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2559933-958b-4dfd-a037-3778b914f319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2559933-958b-4dfd-a037-3778b914f319.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "",
             "colours": [
@@ -47183,7 +47183,7 @@
         },
         {
             "id": "35b5dc5a-eb6d-50e0-a901-5ef9c19a84fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefbe595-93a9-4a5d-b5a5-4f517cec7bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefbe595-93a9-4a5d-b5a5-4f517cec7bdd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -47252,7 +47252,7 @@
         },
         {
             "id": "2a953fd4-a132-5d0a-ae67-e095a0447a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5eda4-6339-4303-97ef-c5a467585949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5eda4-6339-4303-97ef-c5a467585949.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -47317,7 +47317,7 @@
         },
         {
             "id": "0949b3fb-9dd8-5347-a262-921e16ca5105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22f49c5-1dcd-453c-b169-0b2519c44d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22f49c5-1dcd-453c-b169-0b2519c44d0c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -47381,7 +47381,7 @@
         },
         {
             "id": "39df34be-3930-59a7-91a4-3678e7d875f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3740beb-7fa5-4b83-be7d-039750b126c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3740beb-7fa5-4b83-be7d-039750b126c5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -47455,7 +47455,7 @@
         },
         {
             "id": "3d6bce5f-d264-54e9-b0e1-9704a70ea1f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715c6de3-5f4a-483f-9b73-ddb23207c0f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715c6de3-5f4a-483f-9b73-ddb23207c0f4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -47520,7 +47520,7 @@
         },
         {
             "id": "03bdcac7-3f93-54f7-ab54-4a0c854a0280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd9517-a063-4c42-8e1c-c298b314b798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd9517-a063-4c42-8e1c-c298b314b798.jpg?1",
             "name": "Bottomless Pit",
             "text": "",
             "colours": [
@@ -47552,7 +47552,7 @@
         },
         {
             "id": "0a545e63-eed6-5032-a8da-2e6febdb30ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14309ac9-5e75-4ac8-9f17-a256decd52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14309ac9-5e75-4ac8-9f17-a256decd52e9.jpg?1",
             "name": "Necrogen Mists",
             "text": "",
             "colours": [
@@ -47584,7 +47584,7 @@
         },
         {
             "id": "f151a071-ba13-56f9-acec-c50fc7d1da3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea44c06-900d-41b8-88fa-c1bede6ce757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea44c06-900d-41b8-88fa-c1bede6ce757.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "",
             "colours": [
@@ -47619,7 +47619,7 @@
         },
         {
             "id": "fdfbd70d-1cc7-5187-bdb9-a6d4dd1c420a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3edb27c-4faa-464a-9bb1-fbe17013c022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3edb27c-4faa-464a-9bb1-fbe17013c022.jpg?1",
             "name": "Tinybones, Trinket Thief",
             "text": "",
             "colours": [
@@ -47656,7 +47656,7 @@
         },
         {
             "id": "e3f7f3a3-3e9e-56f2-b8f6-29f081b631b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d80ec47-0e47-49e3-9c43-1c126d8523e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d80ec47-0e47-49e3-9c43-1c126d8523e1.jpg?1",
             "name": "Geier Reach Sanitarium",
             "text": "",
             "colours": [],
@@ -47686,7 +47686,7 @@
         },
         {
             "id": "3a886daa-ef87-5012-8d9f-26bd9e20a525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f67a2a1-2700-408e-b58c-34f3d2d75a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f67a2a1-2700-408e-b58c-34f3d2d75a98.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "",
             "colours": [
@@ -47724,7 +47724,7 @@
         },
         {
             "id": "7c774606-9ace-5498-bd74-2002429d5939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38944d0-710f-47d1-a117-ee4ede103b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38944d0-710f-47d1-a117-ee4ede103b30.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "",
             "colours": [
@@ -47762,7 +47762,7 @@
         },
         {
             "id": "e062f86c-c40b-5802-a21e-982ee71d2b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13e2b43-bf51-47e1-bc4e-fa80fa50f607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13e2b43-bf51-47e1-bc4e-fa80fa50f607.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "",
             "colours": [
@@ -47805,7 +47805,7 @@
         },
         {
             "id": "c598baa4-a658-5d5b-84cf-43a996113825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3ec2c5-9fe3-4b2a-b649-14e9bd31d0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3ec2c5-9fe3-4b2a-b649-14e9bd31d0e2.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "",
             "colours": [
@@ -47848,7 +47848,7 @@
         },
         {
             "id": "4dc14a8d-f5fc-5575-8451-674e3574af2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c42be7-84fe-4d9d-bf5c-e75e4d5635fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c42be7-84fe-4d9d-bf5c-e75e4d5635fa.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "",
             "colours": [
@@ -47888,7 +47888,7 @@
         },
         {
             "id": "11c81e79-66a4-549d-b3bd-6517136011df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec098fee-4f80-4336-af87-d1586c9ea1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec098fee-4f80-4336-af87-d1586c9ea1e9.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "",
             "colours": [
@@ -47928,7 +47928,7 @@
         },
         {
             "id": "26b4ed59-4eaf-5489-a94d-6819ce420f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ae71-29de-45d6-97bb-f60e6f821d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ae71-29de-45d6-97bb-f60e6f821d6e.jpg?1",
             "name": "Kumena, Tyrant of Orazca",
             "text": "",
             "colours": [
@@ -47968,7 +47968,7 @@
         },
         {
             "id": "6d56f7a1-8795-54dc-b524-50ba08eb191c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae2f932-9723-4ddc-aa59-1c61e182714a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae2f932-9723-4ddc-aa59-1c61e182714a.jpg?1",
             "name": "Kumena, Tyrant of Orazca",
             "text": "",
             "colours": [
@@ -48008,7 +48008,7 @@
         },
         {
             "id": "64af2737-61c6-590a-8ac3-0c5c838a1bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1033640-5676-4f19-acea-2a69a549c8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1033640-5676-4f19-acea-2a69a549c8b3.jpg?1",
             "name": "Vona, Butcher of Magan",
             "text": "",
             "colours": [
@@ -48048,7 +48048,7 @@
         },
         {
             "id": "6ac78f5b-5783-52f8-a830-ff3036b390c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6502f54-4045-40f5-98a0-d9eeca61dc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6502f54-4045-40f5-98a0-d9eeca61dc87.jpg?1",
             "name": "Vona, Butcher of Magan",
             "text": "",
             "colours": [
@@ -48088,7 +48088,7 @@
         },
         {
             "id": "b75f6b36-379c-5e95-9eb7-feb302f5da57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57906b54-9fea-4608-87ce-43a16b95df9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57906b54-9fea-4608-87ce-43a16b95df9a.jpg?1",
             "name": "Eldritch Evolution",
             "text": "",
             "colours": [
@@ -48120,7 +48120,7 @@
         },
         {
             "id": "4498447f-5f3b-5250-849d-2b9b06356cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca93d7d-869d-4437-829f-9cd0a3b9192b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca93d7d-869d-4437-829f-9cd0a3b9192b.jpg?1",
             "name": "Giant Adephage",
             "text": "",
             "colours": [
@@ -48154,7 +48154,7 @@
         },
         {
             "id": "b36fe590-6b2f-5486-b446-b6f30b6ea695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab584c-1f27-4452-89b4-3b93a2486d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab584c-1f27-4452-89b4-3b93a2486d61.jpg?1",
             "name": "Noxious Revival",
             "text": "",
             "colours": [
@@ -48186,7 +48186,7 @@
         },
         {
             "id": "76751876-c491-5bcf-a4a1-fbcc4aa23515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10b0238-fe30-4543-ae8a-ed834a0930b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10b0238-fe30-4543-ae8a-ed834a0930b1.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "",
             "colours": [
@@ -48224,7 +48224,7 @@
         },
         {
             "id": "28c8218d-4976-50fd-98d4-b7463017203f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13175ed2-c306-4a0a-a50d-b50879e2add6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13175ed2-c306-4a0a-a50d-b50879e2add6.jpg?1",
             "name": "Mazirek, Kraul Death Priest",
             "text": "",
             "colours": [
@@ -48265,7 +48265,7 @@
         },
         {
             "id": "3bdf314f-00a9-5fdd-ad3a-520af9008435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e3de28-d6e9-4f27-a544-0434fb4b55bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e3de28-d6e9-4f27-a544-0434fb4b55bb.jpg?1",
             "name": "Karn, Scion of Urza",
             "text": "",
             "colours": [],
@@ -48298,7 +48298,7 @@
         },
         {
             "id": "c3d7f1ef-f479-5e54-b0d3-0c57efc2092c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c7572e-4547-4ab5-b335-7d31de657cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c7572e-4547-4ab5-b335-7d31de657cc6.jpg?1",
             "name": "Karn, Scion of Urza",
             "text": "",
             "colours": [],
@@ -48331,7 +48331,7 @@
         },
         {
             "id": "6c5c8a7b-008c-5fe7-8723-af1c11021f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7427e78c-4881-42bd-930c-39aae324fc58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7427e78c-4881-42bd-930c-39aae324fc58.jpg?1",
             "name": "Chandra, Flame's Catalyst",
             "text": "",
             "colours": [
@@ -48368,7 +48368,7 @@
         },
         {
             "id": "4eaf59de-58a6-5230-b035-8b61c080f3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f98e65-60bd-44db-acfa-5df98cb60321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f98e65-60bd-44db-acfa-5df98cb60321.jpg?1",
             "name": "Chandra, Flame's Catalyst",
             "text": "",
             "colours": [
@@ -48405,7 +48405,7 @@
         },
         {
             "id": "6cd878a4-dbf7-5bd5-887e-320515691fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe22cd8-31e6-491b-bce2-db257668eb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe22cd8-31e6-491b-bce2-db257668eb92.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "",
             "colours": [
@@ -48446,7 +48446,7 @@
         },
         {
             "id": "61da8ef4-8ffd-5e72-a6cb-98ca1be4fcc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3748cbe2-ae41-49fd-823a-40c52496b65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3748cbe2-ae41-49fd-823a-40c52496b65b.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "",
             "colours": [
@@ -48487,7 +48487,7 @@
         },
         {
             "id": "dd0595ce-f289-59a7-b603-5ede61fdc163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b3f79-74d0-4756-b7e7-1cd17685bbb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b3f79-74d0-4756-b7e7-1cd17685bbb7.jpg?1",
             "name": "Daretti, Ingenious Iconoclast",
             "text": "",
             "colours": [
@@ -48526,7 +48526,7 @@
         },
         {
             "id": "52dc8098-33bc-57a1-9692-b6229c9687f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e3a7c2-12fb-4f23-a0d1-a79df048201b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e3a7c2-12fb-4f23-a0d1-a79df048201b.jpg?1",
             "name": "Daretti, Ingenious Iconoclast",
             "text": "",
             "colours": [
@@ -48565,7 +48565,7 @@
         },
         {
             "id": "931f3fad-8c2b-50cf-a979-894761f27175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2813cb-c73c-4a50-b278-2f13deb71773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2813cb-c73c-4a50-b278-2f13deb71773.jpg?1",
             "name": "Venser, the Sojourner",
             "text": "",
             "colours": [
@@ -48604,7 +48604,7 @@
         },
         {
             "id": "2af87d83-3c40-539e-a0f1-8b2064b10bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc2c6f-90bf-45c3-a836-3fe92a0b98cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc2c6f-90bf-45c3-a836-3fe92a0b98cf.jpg?1",
             "name": "Venser, the Sojourner",
             "text": "",
             "colours": [
@@ -48643,7 +48643,7 @@
         },
         {
             "id": "13575d4a-5dbb-5361-a13c-dd14daafe567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148685c3-5c92-4439-aedd-55d451444e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148685c3-5c92-4439-aedd-55d451444e74.jpg?1",
             "name": "Oppression",
             "text": "",
             "colours": [
@@ -48675,7 +48675,7 @@
         },
         {
             "id": "ebf98cd4-6830-52da-a410-ecfe108d8f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f501f5-2bf4-40a5-8ac5-bff8a64b6762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f501f5-2bf4-40a5-8ac5-bff8a64b6762.jpg?1",
             "name": "Abrade",
             "text": "",
             "colours": [
@@ -48707,7 +48707,7 @@
         },
         {
             "id": "a98f8f84-0ec2-55c4-9aee-3b41e87e7624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d938eab-76f9-4168-8de2-ec11a38d789f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d938eab-76f9-4168-8de2-ec11a38d789f.jpg?1",
             "name": "Mass Hysteria",
             "text": "",
             "colours": [
@@ -48739,7 +48739,7 @@
         },
         {
             "id": "c7c628a2-2994-5c59-a120-6e81945874ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eec665f-9bcc-476b-a8c6-0ea2e03a8b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eec665f-9bcc-476b-a8c6-0ea2e03a8b7a.jpg?1",
             "name": "Terminate",
             "text": "",
             "colours": [
@@ -48773,7 +48773,7 @@
         },
         {
             "id": "b6bd61f7-02e3-52bd-a56a-49c0c22f141f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c35da2-7dc0-4901-ac44-5ed197e5ea43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c35da2-7dc0-4901-ac44-5ed197e5ea43.jpg?1",
             "name": "Mycosynth Golem",
             "text": "",
             "colours": [],
@@ -48805,7 +48805,7 @@
         },
         {
             "id": "ef8153f6-4db5-5e5b-951b-83324a67e3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e9fe7-ff64-4741-87e8-e2c2904839f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e9fe7-ff64-4741-87e8-e2c2904839f7.jpg?1",
             "name": "Mycosynth Golem",
             "text": "",
             "colours": [],
@@ -48837,7 +48837,7 @@
         },
         {
             "id": "7e01508e-d53f-5acf-b984-a41ab98a7342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9904ef62-3328-4474-a3b4-21428fb9d911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9904ef62-3328-4474-a3b4-21428fb9d911.jpg?1",
             "name": "Mycosynth Lattice",
             "text": "",
             "colours": [],
@@ -48866,7 +48866,7 @@
         },
         {
             "id": "bcd37c7e-1141-59c6-b91d-b62e77cac0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede96b86-55b0-4303-a875-a972b47fd372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede96b86-55b0-4303-a875-a972b47fd372.jpg?1",
             "name": "Mycosynth Lattice",
             "text": "",
             "colours": [],
@@ -48895,7 +48895,7 @@
         },
         {
             "id": "c6ba0c66-7644-5c0b-8630-19f042914ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d951e0f-3f20-4c1c-ba5a-8cd17dfe5f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d951e0f-3f20-4c1c-ba5a-8cd17dfe5f0b.jpg?1",
             "name": "Mycosynth Wellspring",
             "text": "",
             "colours": [],
@@ -48924,7 +48924,7 @@
         },
         {
             "id": "0f3e69d5-b3e2-5fc9-a809-f8eb857dbffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23aa711-d88c-4b57-a980-2fc0de7e89c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23aa711-d88c-4b57-a980-2fc0de7e89c7.jpg?1",
             "name": "Mycosynth Wellspring",
             "text": "",
             "colours": [],
@@ -48953,7 +48953,7 @@
         },
         {
             "id": "4e4e5aa7-3d01-5f47-a3fa-418b47af9fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54e310c-060c-40a9-a0e3-d35de672ef13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54e310c-060c-40a9-a0e3-d35de672ef13.jpg?1",
             "name": "Sisay, Weatherlight Captain",
             "text": "",
             "colours": [
@@ -48996,7 +48996,7 @@
         },
         {
             "id": "9bfc4624-741d-5a6d-902d-d3327f0ffad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c66de-a153-4317-9589-2db861bb9640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c66de-a153-4317-9589-2db861bb9640.jpg?1",
             "name": "Silence",
             "text": "",
             "colours": [
@@ -49028,7 +49028,7 @@
         },
         {
             "id": "3c18188a-0234-5932-bd89-35fa0fcf70ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36c4f5-5eff-4b46-9671-9a038d4d1788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36c4f5-5eff-4b46-9671-9a038d4d1788.jpg?1",
             "name": "Battle of Wits",
             "text": "",
             "colours": [
@@ -49060,7 +49060,7 @@
         },
         {
             "id": "aedb7d51-c724-5914-a581-2b696db84660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67793e8e-0b7f-4dac-b37d-697149276856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67793e8e-0b7f-4dac-b37d-697149276856.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "",
             "colours": [
@@ -49099,7 +49099,7 @@
         },
         {
             "id": "a76d1718-d771-5ffd-a55e-ce49d4ad4c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb161c-ff04-4bf2-8320-48302dfb085c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb161c-ff04-4bf2-8320-48302dfb085c.jpg?1",
             "name": "Pack Rat",
             "text": "",
             "colours": [
@@ -49135,7 +49135,7 @@
         },
         {
             "id": "bee6ef5d-3541-5968-8ecb-460c4136593a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb05d34-05cb-4536-b7e6-2d526dc30a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb05d34-05cb-4536-b7e6-2d526dc30a9f.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "",
             "colours": [
@@ -49172,7 +49172,7 @@
         },
         {
             "id": "4a817d90-bd38-502f-b0c4-c569087f986c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cf891b-efa0-465f-8029-245f09b6b1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cf891b-efa0-465f-8029-245f09b6b1b2.jpg?1",
             "name": "Brion Stoutarm",
             "text": "",
             "colours": [
@@ -49211,7 +49211,7 @@
         },
         {
             "id": "375022e4-822c-50d3-970a-e769b7089a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ea1c6-30b2-4612-8911-03fde5ecbb2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ea1c6-30b2-4612-8911-03fde5ecbb2a.jpg?1",
             "name": "Samut, Voice of Dissent",
             "text": "",
             "colours": [
@@ -49251,7 +49251,7 @@
         },
         {
             "id": "09a4d082-704f-560d-86a9-01d0db95efa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f3f243-927d-4b84-87cd-43c48f6c371a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f3f243-927d-4b84-87cd-43c48f6c371a.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "",
             "colours": [
@@ -49292,7 +49292,7 @@
         },
         {
             "id": "33d1b3c9-c27c-5512-a71c-248aa3adaaf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -49331,7 +49331,7 @@
         },
         {
             "id": "6c5824e9-d695-52b7-8b6f-2a0d3de369dd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -49370,7 +49370,7 @@
         },
         {
             "id": "bb1ae076-3c81-568b-b34b-d6bc9cd29eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -49409,7 +49409,7 @@
         },
         {
             "id": "5e2eba73-44fc-5bb4-8e62-65af34c8a02f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -49448,7 +49448,7 @@
         },
         {
             "id": "6573e1f6-1c03-52bf-b493-811d89043b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -49487,7 +49487,7 @@
         },
         {
             "id": "76947e90-3eb4-5a22-8d91-d8291cb5b5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -49526,7 +49526,7 @@
         },
         {
             "id": "92bbc67c-3e44-52f2-a4fa-182f95155a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -49565,7 +49565,7 @@
         },
         {
             "id": "971fd38a-b1f8-5886-865f-a1eb3e4811a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -49604,7 +49604,7 @@
         },
         {
             "id": "1d6d8b1a-be16-5d1a-9b49-d0fb7e9178fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -49643,7 +49643,7 @@
         },
         {
             "id": "868f04b2-2e04-57c9-96fb-0bf0f63543e4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -49682,7 +49682,7 @@
         },
         {
             "id": "6f93f356-dbe7-597f-9b06-362872b8aa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg?1",
             "name": "Death Baron // Death Baron",
             "text": "",
             "colours": [
@@ -49717,7 +49717,7 @@
         },
         {
             "id": "4f04b2a7-3a97-59d2-a3cc-0ce88a63f30c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg?1",
             "name": "Death Baron // Death Baron",
             "text": "",
             "colours": [
@@ -49752,7 +49752,7 @@
         },
         {
             "id": "4be1397f-aad2-5d12-9f0c-c92a84b5d209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg?1",
             "name": "Noxious Ghoul // Noxious Ghoul",
             "text": "",
             "colours": [
@@ -49786,7 +49786,7 @@
         },
         {
             "id": "0aa37a8a-f7eb-5ce9-91c8-7db34c4bafb9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg?1",
             "name": "Noxious Ghoul // Noxious Ghoul",
             "text": "",
             "colours": [
@@ -49820,7 +49820,7 @@
         },
         {
             "id": "ce665ebb-3003-543a-bae6-a70957ff0a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg?1",
             "name": "Zombie Master // Zombie Master",
             "text": "",
             "colours": [
@@ -49854,7 +49854,7 @@
         },
         {
             "id": "19047b90-bde7-5649-aeec-1178f2edbb94",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg?1",
             "name": "Zombie Master // Zombie Master",
             "text": "",
             "colours": [
@@ -49888,7 +49888,7 @@
         },
         {
             "id": "664d25e1-5888-5786-a83d-51f26fde2de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg?1",
             "name": "Grimgrin, Corpse-Born // Grimgrin, Corpse-Born",
             "text": "",
             "colours": [
@@ -49927,7 +49927,7 @@
         },
         {
             "id": "edb065e2-b45d-55db-9a69-89b6db7892e7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg?1",
             "name": "Grimgrin, Corpse-Born // Grimgrin, Corpse-Born",
             "text": "",
             "colours": [
@@ -49966,7 +49966,7 @@
         },
         {
             "id": "436000c1-96d5-5cd1-8b94-2f6879aa21e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg?1",
             "name": "Unholy Grotto // Unholy Grotto",
             "text": "",
             "colours": [],
@@ -49996,7 +49996,7 @@
         },
         {
             "id": "3e304def-f802-5b43-a8a7-675fde5dbf70",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg?1",
             "name": "Unholy Grotto // Unholy Grotto",
             "text": "",
             "colours": [],
@@ -50026,7 +50026,7 @@
         },
         {
             "id": "45bf7508-7db9-5130-a083-1905eaa85af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b56d67-a3f1-4f66-820e-4b354453b091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b56d67-a3f1-4f66-820e-4b354453b091.jpg?1",
             "name": "Giver of Runes",
             "text": "",
             "colours": [
@@ -50062,7 +50062,7 @@
         },
         {
             "id": "9e3b4542-e6ed-5b0d-97af-94f2d3bdd16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b85f9-0e15-4409-b96a-1f50d6aedf60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b85f9-0e15-4409-b96a-1f50d6aedf60.jpg?1",
             "name": "Giver of Runes",
             "text": "",
             "colours": [
@@ -50098,7 +50098,7 @@
         },
         {
             "id": "cf5acac6-fdd9-549d-b915-da09480040ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf6f926-8dde-45ce-8aa6-966fbcf79a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf6f926-8dde-45ce-8aa6-966fbcf79a7f.jpg?1",
             "name": "Distant Melody",
             "text": "",
             "colours": [
@@ -50131,7 +50131,7 @@
         },
         {
             "id": "fe3a390b-ca06-5b2c-af57-b9f1c7eb2862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c293461-ca8d-4be3-a8ec-4f76e8b6aff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c293461-ca8d-4be3-a8ec-4f76e8b6aff5.jpg?1",
             "name": "Distant Melody",
             "text": "",
             "colours": [
@@ -50164,7 +50164,7 @@
         },
         {
             "id": "7031ebe0-73d2-5e8f-af91-d6953c357131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70abfaeb-1253-4217-9194-67f40b5ee4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70abfaeb-1253-4217-9194-67f40b5ee4b1.jpg?1",
             "name": "Cathartic Reunion",
             "text": "",
             "colours": [
@@ -50197,7 +50197,7 @@
         },
         {
             "id": "3ffdbcaa-c04f-5c0d-83a1-43903a2eb2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f252720-11b7-43a6-83bc-0d670a54ae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f252720-11b7-43a6-83bc-0d670a54ae31.jpg?1",
             "name": "Cathartic Reunion",
             "text": "",
             "colours": [
@@ -50230,7 +50230,7 @@
         },
         {
             "id": "d4485e18-3cee-58bd-8066-409ab3ba506d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b05002-0039-4e51-8493-37e64405e342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b05002-0039-4e51-8493-37e64405e342.jpg?1",
             "name": "Moment's Peace",
             "text": "",
             "colours": [
@@ -50263,7 +50263,7 @@
         },
         {
             "id": "caf17d51-bfe0-5c4d-af0f-6b1bd054c521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4531802-d9e1-4374-b9fd-5e5ad52b8d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4531802-d9e1-4374-b9fd-5e5ad52b8d50.jpg?1",
             "name": "Moment's Peace",
             "text": "",
             "colours": [
@@ -50296,7 +50296,7 @@
         },
         {
             "id": "58747277-a82d-5ef8-856e-6669302d4371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0449831a-a07e-4dc0-991f-7406629291b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0449831a-a07e-4dc0-991f-7406629291b6.jpg?1",
             "name": "Homeward Path",
             "text": "",
             "colours": [],
@@ -50325,7 +50325,7 @@
         },
         {
             "id": "71789ccc-f917-5a2d-ae38-7d089eefa436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b522dcf-fc81-4b91-9649-f080016f4339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b522dcf-fc81-4b91-9649-f080016f4339.jpg?1",
             "name": "Homeward Path",
             "text": "",
             "colours": [],
@@ -50354,7 +50354,7 @@
         },
         {
             "id": "970b4acb-af6f-59b6-87a5-a30a8ab4a5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7432b894-e7a9-4de7-9470-846e65cd4d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7432b894-e7a9-4de7-9470-846e65cd4d0c.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -50423,7 +50423,7 @@
         },
         {
             "id": "08608728-5605-5a66-a261-cd751a894bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839e97b5-c04d-4088-af4e-fa64f4575e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839e97b5-c04d-4088-af4e-fa64f4575e51.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -50488,7 +50488,7 @@
         },
         {
             "id": "ac332504-6463-527f-8e9c-269541febc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c0baf-9b5c-44ff-86eb-ca0f24ab0fe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c0baf-9b5c-44ff-86eb-ca0f24ab0fe1.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -50552,7 +50552,7 @@
         },
         {
             "id": "1609e468-b06a-596e-a057-a208f18782ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01550676-3659-47d7-9a47-67c31438ec09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01550676-3659-47d7-9a47-67c31438ec09.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -50626,7 +50626,7 @@
         },
         {
             "id": "4b0661b3-9ae7-599f-a527-c4ad85a64c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadcd72e-90ca-4cfc-a181-742e35c4a8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadcd72e-90ca-4cfc-a181-742e35c4a8ed.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -50691,7 +50691,7 @@
         },
         {
             "id": "c93278a9-0764-5574-ba68-edab3ada8438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc0bbe-a901-4565-940b-9f763cf006a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc0bbe-a901-4565-940b-9f763cf006a4.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -50729,7 +50729,7 @@
         },
         {
             "id": "dca77707-0e76-562a-b52a-32e0644bdbb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e5104-02b1-48db-a70e-d267066d2561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e5104-02b1-48db-a70e-d267066d2561.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -50767,7 +50767,7 @@
         },
         {
             "id": "70c42767-6f41-54ed-bc8d-be92358ca6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7e936-bd27-4955-a5ea-c1e88a9ab646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7e936-bd27-4955-a5ea-c1e88a9ab646.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -50805,7 +50805,7 @@
         },
         {
             "id": "55186109-3d6e-53f2-9cd3-8995f03b52f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328fc009-d9c1-472d-8e07-778f60947642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328fc009-d9c1-472d-8e07-778f60947642.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -50843,7 +50843,7 @@
         },
         {
             "id": "79fe0703-7288-5e18-8ab6-4b38c5b3e99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de8c3b-410e-4fc6-abfb-7315010e05d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de8c3b-410e-4fc6-abfb-7315010e05d5.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -50881,7 +50881,7 @@
         },
         {
             "id": "c4363bab-65a5-537c-80bf-ebd09bb3c7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a04eb28-cba8-4619-972c-4e6ebff73f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a04eb28-cba8-4619-972c-4e6ebff73f34.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -50919,7 +50919,7 @@
         },
         {
             "id": "78bb7978-4f31-5c14-a0ef-37990816c3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee2b472-8cb0-4722-a1b7-b700ac42a6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee2b472-8cb0-4722-a1b7-b700ac42a6c0.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -50957,7 +50957,7 @@
         },
         {
             "id": "4cfd2a9a-7d85-5dff-9374-b65166833233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4fab9d-7753-489e-a63c-c107e7d27668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4fab9d-7753-489e-a63c-c107e7d27668.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -50995,7 +50995,7 @@
         },
         {
             "id": "4c64c5a4-43e7-5dea-89e7-da9f4671cfae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3995734f-5fa2-4039-af64-0bca88741089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3995734f-5fa2-4039-af64-0bca88741089.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -51033,7 +51033,7 @@
         },
         {
             "id": "57a0151b-1ac6-5a39-a15b-dbfc9aabe11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d1476-7778-4743-804a-e3f497d38d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d1476-7778-4743-804a-e3f497d38d77.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -51071,7 +51071,7 @@
         },
         {
             "id": "cc305309-8dea-548e-a75a-9140dea5c2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bde779-b9aa-409f-bd8b-94d7cfde8346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bde779-b9aa-409f-bd8b-94d7cfde8346.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "",
             "colours": [
@@ -51111,7 +51111,7 @@
         },
         {
             "id": "a7f983f0-6e1c-5a7d-a4f6-675414245c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ce8ee-8abe-4973-ae6e-a97e20836d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ce8ee-8abe-4973-ae6e-a97e20836d05.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "",
             "colours": [
@@ -51151,7 +51151,7 @@
         },
         {
             "id": "eb6f4524-69c7-5d50-8a81-df079c494ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7afa73-2f60-4ccc-8f5b-d7e6487c0b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7afa73-2f60-4ccc-8f5b-d7e6487c0b2b.jpg?1",
             "name": "Sphere of Resistance",
             "text": "",
             "colours": [],
@@ -51180,7 +51180,7 @@
         },
         {
             "id": "bd5d3fe0-c888-513f-a7d1-8b3fe741fc8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d1908-487a-4264-8cab-49adc23d2802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d1908-487a-4264-8cab-49adc23d2802.jpg?1",
             "name": "Sphere of Resistance",
             "text": "",
             "colours": [],
@@ -51209,7 +51209,7 @@
         },
         {
             "id": "1d171c09-66cd-5ba7-9643-9db8c818c4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea8286-225b-4990-981a-6b8c49748794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea8286-225b-4990-981a-6b8c49748794.jpg?1",
             "name": "Trinisphere",
             "text": "",
             "colours": [],
@@ -51238,7 +51238,7 @@
         },
         {
             "id": "c48dc430-5eaf-5c78-932a-0da7e5301c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2689f7-b075-4e64-b2a6-d7b26f1be908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2689f7-b075-4e64-b2a6-d7b26f1be908.jpg?1",
             "name": "Trinisphere",
             "text": "",
             "colours": [],
@@ -51267,7 +51267,7 @@
         },
         {
             "id": "ac9283b1-5e13-569c-8f68-a471bbaa6108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146a0ab1-683e-43e4-a07b-1faa1eb4c7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146a0ab1-683e-43e4-a07b-1faa1eb4c7c6.jpg?1",
             "name": "Winter Orb",
             "text": "",
             "colours": [],
@@ -51296,7 +51296,7 @@
         },
         {
             "id": "e9a6fed7-6b05-549e-b728-54a4c63d3682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9076a877-d2c3-43f8-8f27-29434a06816f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9076a877-d2c3-43f8-8f27-29434a06816f.jpg?1",
             "name": "Winter Orb",
             "text": "",
             "colours": [],
@@ -51325,7 +51325,7 @@
         },
         {
             "id": "a642a7d7-6836-5cc8-87ce-5beb53f9414a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b464549-a84d-44bf-a684-d59db5babc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b464549-a84d-44bf-a684-d59db5babc6d.jpg?1",
             "name": "Felidar Guardian",
             "text": "",
             "colours": [
@@ -51361,7 +51361,7 @@
         },
         {
             "id": "9803542d-38d2-56bb-9b9d-f7bcbd2ce92e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e19dd-53f9-484c-9ece-1401e2a219a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e19dd-53f9-484c-9ece-1401e2a219a6.jpg?1",
             "name": "Felidar Guardian",
             "text": "",
             "colours": [
@@ -51397,7 +51397,7 @@
         },
         {
             "id": "7bd3a7fd-8309-5df2-aeac-c3ea7c6cddf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0915174-102d-4d86-b386-8647aa231f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0915174-102d-4d86-b386-8647aa231f95.jpg?1",
             "name": "Peregrine Drake",
             "text": "",
             "colours": [
@@ -51432,7 +51432,7 @@
         },
         {
             "id": "95aca11c-946b-5908-acfc-0c4a00d302d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a971066-5e32-4582-b392-880919d11388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a971066-5e32-4582-b392-880919d11388.jpg?1",
             "name": "Peregrine Drake",
             "text": "",
             "colours": [
@@ -51467,7 +51467,7 @@
         },
         {
             "id": "7bd327f3-ac0b-58eb-ae1f-9b82447e4857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad89f6d0-e965-49b8-adeb-ad07e40f00f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad89f6d0-e965-49b8-adeb-ad07e40f00f0.jpg?1",
             "name": "Serpent of Yawning Depths",
             "text": "",
             "colours": [
@@ -51503,7 +51503,7 @@
         },
         {
             "id": "31509c9a-233b-5039-8126-3b80bd70b39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a83655-646e-4ccb-b015-13a2092f1444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a83655-646e-4ccb-b015-13a2092f1444.jpg?1",
             "name": "Serpent of Yawning Depths",
             "text": "",
             "colours": [
@@ -51539,7 +51539,7 @@
         },
         {
             "id": "0f826745-a622-5cf1-8f58-48a34176a470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebab854f-f041-49d8-bd7c-3d1cdca72cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebab854f-f041-49d8-bd7c-3d1cdca72cc6.jpg?1",
             "name": "Scourge of Valkas",
             "text": "",
             "colours": [
@@ -51574,7 +51574,7 @@
         },
         {
             "id": "3bf093e7-c167-5252-bbd8-677d8780477c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61a5022-1590-44d7-9def-73173c0dec04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61a5022-1590-44d7-9def-73173c0dec04.jpg?1",
             "name": "Scourge of Valkas",
             "text": "",
             "colours": [
@@ -51609,7 +51609,7 @@
         },
         {
             "id": "44deef76-30ef-5ba4-8a24-d0333ce7abf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd58870d-8625-4d35-a51b-e191970cadf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd58870d-8625-4d35-a51b-e191970cadf3.jpg?1",
             "name": "Voracious Hydra",
             "text": "",
             "colours": [
@@ -51644,7 +51644,7 @@
         },
         {
             "id": "3d856879-a19f-5fb1-85a0-207c465ece4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76648b3-a893-4f06-8055-12b87ab7ba32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76648b3-a893-4f06-8055-12b87ab7ba32.jpg?1",
             "name": "Voracious Hydra",
             "text": "",
             "colours": [
@@ -51679,7 +51679,7 @@
         },
         {
             "id": "255cc92a-37a5-5f2c-b02b-340237cb9433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6b109-4657-4e9e-82f3-53ddd56aef1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6b109-4657-4e9e-82f3-53ddd56aef1c.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -51715,7 +51715,7 @@
         },
         {
             "id": "44c12349-04fb-5938-a157-a1b6a455f79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf977357-e13d-4c67-ae53-397adf55131e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf977357-e13d-4c67-ae53-397adf55131e.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -51751,7 +51751,7 @@
         },
         {
             "id": "c84e8bea-8c65-57c8-9d08-222787bde76f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfac7625-4c7b-4417-930e-f0de536a34f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfac7625-4c7b-4417-930e-f0de536a34f0.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -51784,7 +51784,7 @@
         },
         {
             "id": "11a30ea2-b647-5636-8185-e5564e0b2b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b840da3-2818-4fed-8cff-19754ab1efdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b840da3-2818-4fed-8cff-19754ab1efdc.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -51817,7 +51817,7 @@
         },
         {
             "id": "b3cf7e34-f1e3-5c1f-94fe-f4430f309ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858e0b83-7927-4e34-ae25-6ad7a787ad97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858e0b83-7927-4e34-ae25-6ad7a787ad97.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -51853,7 +51853,7 @@
         },
         {
             "id": "981a1715-e8a2-5564-ab75-d9fa04b1591b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21365def-bec7-4ec0-a1e9-34c85bf6c274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21365def-bec7-4ec0-a1e9-34c85bf6c274.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -51889,7 +51889,7 @@
         },
         {
             "id": "65e4ed20-ae1a-5161-84f7-040897c13d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584b7e75-6523-4d6f-ada1-f8a8459a0b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584b7e75-6523-4d6f-ada1-f8a8459a0b50.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -51919,7 +51919,7 @@
         },
         {
             "id": "fa191134-bef3-54f1-87c3-2fb2afc48345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd71be2d-5ffc-418e-92d0-a36cf10ac5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd71be2d-5ffc-418e-92d0-a36cf10ac5d6.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -51949,7 +51949,7 @@
         },
         {
             "id": "a274cb0b-7f3c-5793-9e21-f9f38e297cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea9aa06-d0ad-4dae-a36f-f84278a45c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea9aa06-d0ad-4dae-a36f-f84278a45c3a.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -51987,7 +51987,7 @@
         },
         {
             "id": "104c46d9-014c-54b6-8e4c-6823f208ed27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c36efb0-1a5b-4576-b5d9-c9b966716f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c36efb0-1a5b-4576-b5d9-c9b966716f65.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -52025,7 +52025,7 @@
         },
         {
             "id": "500c5d5d-00ad-503e-b127-3492d1e2f59e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd002b2-acc3-421a-ad2e-22117d347b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd002b2-acc3-421a-ad2e-22117d347b29.jpg?1",
             "name": "Beacon of Tomorrows",
             "text": "",
             "colours": [
@@ -52058,7 +52058,7 @@
         },
         {
             "id": "2f93b419-96e5-5b2f-b49b-f080c39b21d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519e3161-5048-47c6-b803-fb46ff5a4e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519e3161-5048-47c6-b803-fb46ff5a4e4b.jpg?1",
             "name": "Beacon of Tomorrows",
             "text": "",
             "colours": [
@@ -52091,7 +52091,7 @@
         },
         {
             "id": "68afb741-aba9-51b7-bff2-614f834ad93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87648fda-7359-4554-aec8-bc98f5ba4f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87648fda-7359-4554-aec8-bc98f5ba4f1c.jpg?1",
             "name": "Nexus of Fate",
             "text": "",
             "colours": [
@@ -52124,7 +52124,7 @@
         },
         {
             "id": "7b18c8fc-59f5-5fbd-9ce6-11b92182cc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7369f643-3f80-4d76-816c-0193a03cd6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7369f643-3f80-4d76-816c-0193a03cd6e6.jpg?1",
             "name": "Nexus of Fate",
             "text": "",
             "colours": [
@@ -52157,7 +52157,7 @@
         },
         {
             "id": "0b78c168-7d5d-594c-b905-9b5619e85ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97deaec0-09a7-4f73-86d2-6f6759afb778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97deaec0-09a7-4f73-86d2-6f6759afb778.jpg?1",
             "name": "Time Reversal",
             "text": "",
             "colours": [
@@ -52190,7 +52190,7 @@
         },
         {
             "id": "3d3a4a1e-dc91-5072-95fd-b2413c45322f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a884bda9-a7e2-419f-a729-9244ba39fa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a884bda9-a7e2-419f-a729-9244ba39fa1a.jpg?1",
             "name": "Time Reversal",
             "text": "",
             "colours": [
@@ -52223,7 +52223,7 @@
         },
         {
             "id": "879cffe6-73ca-5012-a7cf-9948d7c9fb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3ed349-c9f2-412d-9e60-01362680d373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3ed349-c9f2-412d-9e60-01362680d373.jpg?1",
             "name": "Time Stop",
             "text": "",
             "colours": [
@@ -52256,7 +52256,7 @@
         },
         {
             "id": "9de13896-4b01-5dbd-80f3-35f403dee0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4791c4-acde-4325-82d9-8b410ef5c1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4791c4-acde-4325-82d9-8b410ef5c1a0.jpg?1",
             "name": "Time Stop",
             "text": "",
             "colours": [
@@ -52289,7 +52289,7 @@
         },
         {
             "id": "5000c005-b6ec-5a12-bac8-4ab137b66279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c976b-6096-4ac7-8d52-2f219ae21d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c976b-6096-4ac7-8d52-2f219ae21d1f.jpg?1",
             "name": "Lara Croft, Tomb Raider",
             "text": "",
             "colours": [
@@ -52330,7 +52330,7 @@
         },
         {
             "id": "07998e8f-01fa-59f7-8b0b-5ccf1bfa1b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "",
             "colours": [
@@ -52364,7 +52364,7 @@
         },
         {
             "id": "2062e220-6701-5642-a49d-096f429eb360",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "",
             "colours": [],
@@ -52396,7 +52396,7 @@
         },
         {
             "id": "6ef69beb-e4d6-5aa9-9056-0d1ecc168369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1665ec-7617-4754-b604-656411f7476a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1665ec-7617-4754-b604-656411f7476a.jpg?1",
             "name": "Anger of the Gods",
             "text": "",
             "colours": [
@@ -52430,7 +52430,7 @@
         },
         {
             "id": "e7c54417-0e17-52df-9e41-3a4a9f95b2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfd2d0-bdd4-485d-a8a3-d3c3ad31014b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfd2d0-bdd4-485d-a8a3-d3c3ad31014b.jpg?1",
             "name": "Bow of Nylea",
             "text": "",
             "colours": [
@@ -52465,7 +52465,7 @@
         },
         {
             "id": "412d3d95-c97e-548c-b660-d4727ea78bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da507391-4dbd-4fff-8c81-db64bfa4162f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da507391-4dbd-4fff-8c81-db64bfa4162f.jpg?1",
             "name": "Shadowspear",
             "text": "",
             "colours": [],
@@ -52497,7 +52497,7 @@
         },
         {
             "id": "a834aae5-4e27-56cc-8e80-3ee6ec74cc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b2979-a887-4ad8-b123-4aea916de36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b2979-a887-4ad8-b123-4aea916de36a.jpg?1",
             "name": "Academy Ruins",
             "text": "",
             "colours": [],
@@ -52529,7 +52529,7 @@
         },
         {
             "id": "11bb434a-fbe0-55f9-8515-7c13c9030d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -52572,7 +52572,7 @@
         },
         {
             "id": "bb0d0e57-b790-50ad-8b00-7cccb9ae8e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -52615,7 +52615,7 @@
         },
         {
             "id": "9ed5924a-3b03-5c34-bc5b-b8c5ff1cbd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -52658,7 +52658,7 @@
         },
         {
             "id": "10c8e4d8-d935-56d9-8b50-fa565e01e1c5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -52701,7 +52701,7 @@
         },
         {
             "id": "60c0a4ce-663e-5477-ab82-b8fe8e8db821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -52744,7 +52744,7 @@
         },
         {
             "id": "216505a2-ed88-59ed-ba05-43d9a740ec9b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -52787,7 +52787,7 @@
         },
         {
             "id": "bbe04204-3f5c-5e6f-b462-845a75d99d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg?1",
             "name": "Anointed Procession // Anointed Procession",
             "text": "",
             "colours": [
@@ -52818,7 +52818,7 @@
         },
         {
             "id": "7f608cc4-c02c-5910-b7ce-c5ca57714b85",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg?1",
             "name": "Anointed Procession // Anointed Procession",
             "text": "",
             "colours": [
@@ -52849,7 +52849,7 @@
         },
         {
             "id": "2204fa4d-32e6-50b0-9339-55f668732d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg?1",
             "name": "Sol Ring // Sol Ring",
             "text": "",
             "colours": [],
@@ -52876,7 +52876,7 @@
         },
         {
             "id": "f687278c-44b6-5605-a251-1066cabc1807",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg?1",
             "name": "Sol Ring // Sol Ring",
             "text": "",
             "colours": [],
@@ -52903,7 +52903,7 @@
         },
         {
             "id": "b6ee6ed4-4ae9-5638-8ca6-7ff2d06e9834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b86eac-3cd5-48ef-9fda-b4beff540c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b86eac-3cd5-48ef-9fda-b4beff540c94.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -52971,7 +52971,7 @@
         },
         {
             "id": "841ec073-5326-51c5-8443-74e7b49a0fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76d6ecc-a774-44d5-8c16-e2ba4bf7d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76d6ecc-a774-44d5-8c16-e2ba4bf7d283.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -53044,7 +53044,7 @@
         },
         {
             "id": "d8007f07-7d57-59c0-975f-3ba54a3e3d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79053ce4-62d4-416c-b001-93740521fd07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79053ce4-62d4-416c-b001-93740521fd07.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -53108,7 +53108,7 @@
         },
         {
             "id": "3617d042-b435-5945-ba25-e55ca25d4eb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f4d580-0a3c-4f4f-9700-4a2afed4ded0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f4d580-0a3c-4f4f-9700-4a2afed4ded0.jpg?1",
             "name": "Wall of Omens",
             "text": "",
             "colours": [
@@ -53143,7 +53143,7 @@
         },
         {
             "id": "04ab46ac-b266-5bf1-b7ff-c43784fe4a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de38a06-7b5d-4358-99da-3266186c0144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de38a06-7b5d-4358-99da-3266186c0144.jpg?1",
             "name": "Wall of Omens",
             "text": "",
             "colours": [
@@ -53178,7 +53178,7 @@
         },
         {
             "id": "b86d0873-a723-5b10-ab1e-ec68823b01f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0392db52-c77c-4310-be26-7daccc661d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0392db52-c77c-4310-be26-7daccc661d07.jpg?1",
             "name": "Circular Logic",
             "text": "",
             "colours": [
@@ -53211,7 +53211,7 @@
         },
         {
             "id": "77205f20-da9d-5010-8a3c-cf299dec8da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93201f-d2d0-46ff-8024-3b92cc0878a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93201f-d2d0-46ff-8024-3b92cc0878a5.jpg?1",
             "name": "Circular Logic",
             "text": "",
             "colours": [
@@ -53244,7 +53244,7 @@
         },
         {
             "id": "ebdf0ea0-e98e-5113-a7b7-7cc40356cbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef7e2af-c7f6-4634-87d8-0d580d20f9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef7e2af-c7f6-4634-87d8-0d580d20f9d9.jpg?1",
             "name": "Scheming Symmetry",
             "text": "",
             "colours": [
@@ -53277,7 +53277,7 @@
         },
         {
             "id": "df6d5d9c-0369-5f7e-8b4f-3cbd5e9a081f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e641ae-f138-4861-a115-4bc9e29689e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e641ae-f138-4861-a115-4bc9e29689e9.jpg?1",
             "name": "Scheming Symmetry",
             "text": "",
             "colours": [
@@ -53310,7 +53310,7 @@
         },
         {
             "id": "9462d472-5ea5-5f2c-996f-a4d66a044405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e3fd0-c6a9-493c-83b2-9386245c4cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e3fd0-c6a9-493c-83b2-9386245c4cbe.jpg?1",
             "name": "Price of Progress",
             "text": "",
             "colours": [
@@ -53343,7 +53343,7 @@
         },
         {
             "id": "6469d02d-4d93-549c-872d-75ce32d12ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f22283-6a46-46c0-b6ba-8155392ccbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f22283-6a46-46c0-b6ba-8155392ccbc7.jpg?1",
             "name": "Price of Progress",
             "text": "",
             "colours": [
@@ -53376,7 +53376,7 @@
         },
         {
             "id": "594ae525-aaef-5158-b3c3-1f786dfdaf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362b72b5-4f63-43e2-bd09-4398b6aef5f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362b72b5-4f63-43e2-bd09-4398b6aef5f3.jpg?1",
             "name": "Eternal Witness",
             "text": "",
             "colours": [
@@ -53413,7 +53413,7 @@
         },
         {
             "id": "e39aa890-6476-5af0-8980-fa2af4f4490a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f615-e2db-428b-9459-50190ee614ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f615-e2db-428b-9459-50190ee614ea.jpg?1",
             "name": "Eternal Witness",
             "text": "",
             "colours": [
@@ -53450,7 +53450,7 @@
         },
         {
             "id": "965ce4f7-ce35-564e-ae9b-9546cdbad69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b136d-34ad-4bf4-bb1b-1523df01f441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b136d-34ad-4bf4-bb1b-1523df01f441.jpg?1",
             "name": "Inspiring Overseer",
             "text": "",
             "colours": [
@@ -53484,7 +53484,7 @@
         },
         {
             "id": "d9a231ff-aa8b-5233-85ea-657e661cc8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80f726b-471c-4bc1-8fd7-66db5207e4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80f726b-471c-4bc1-8fd7-66db5207e4ce.jpg?1",
             "name": "Consider",
             "text": "",
             "colours": [
@@ -53515,7 +53515,7 @@
         },
         {
             "id": "0ae7c0e3-6279-538b-9b84-79be112ae033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a084e1-b181-49cc-acb0-8b074ba36fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a084e1-b181-49cc-acb0-8b074ba36fde.jpg?1",
             "name": "Price of Glory",
             "text": "",
             "colours": [
@@ -53546,7 +53546,7 @@
         },
         {
             "id": "8ad57761-408c-512d-b967-3dfc7d700a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfaf199-af57-4889-924f-9ac2257983ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfaf199-af57-4889-924f-9ac2257983ac.jpg?1",
             "name": "Reckless Fireweaver",
             "text": "",
             "colours": [
@@ -53580,7 +53580,7 @@
         },
         {
             "id": "4d435242-d5e5-560c-b7b1-6165afa8f325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e8ddc-2e8f-4a6c-a20d-a37f2c24fd97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e8ddc-2e8f-4a6c-a20d-a37f2c24fd97.jpg?1",
             "name": "Akroma's Memorial",
             "text": "",
             "colours": [],
@@ -53609,7 +53609,7 @@
         },
         {
             "id": "fe3a1560-dc82-53c9-960e-f8a4933f21bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f730eba-fef1-4d2c-bcaf-9fe51f6bf270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f730eba-fef1-4d2c-bcaf-9fe51f6bf270.jpg?1",
             "name": "Bojuka Bog",
             "text": "",
             "colours": [],
@@ -53640,7 +53640,7 @@
         },
         {
             "id": "5ded1ac9-50a6-5115-8357-7b77d8beceae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80ead0d-00ee-46eb-9399-f21027fe3d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80ead0d-00ee-46eb-9399-f21027fe3d6f.jpg?1",
             "name": "Bojuka Bog",
             "text": "",
             "colours": [],
@@ -53671,7 +53671,7 @@
         },
         {
             "id": "cbe3b8b3-316f-5408-8a81-ee7d614e9975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d40c3-d6dd-4af8-b6f2-dc7dc609d77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d40c3-d6dd-4af8-b6f2-dc7dc609d77a.jpg?1",
             "name": "Command Beacon",
             "text": "",
             "colours": [],
@@ -53701,7 +53701,7 @@
         },
         {
             "id": "870abcb1-62cd-5d56-a1b0-883a2ed0d277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e272810-0142-4957-a543-d71b6f1ac3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e272810-0142-4957-a543-d71b6f1ac3ee.jpg?1",
             "name": "Command Beacon",
             "text": "",
             "colours": [],
@@ -53731,7 +53731,7 @@
         },
         {
             "id": "d46fd2c3-ac42-576b-bcfb-43a21550d1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d65e45-1a3b-4f1b-a148-e498953f966d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d65e45-1a3b-4f1b-a148-e498953f966d.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -53762,7 +53762,7 @@
         },
         {
             "id": "e3300b02-0ff9-578f-a6d3-82b13b906733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfc846e-1326-4055-bce6-68366b08f17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfc846e-1326-4055-bce6-68366b08f17c.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -53793,7 +53793,7 @@
         },
         {
             "id": "96f77a98-a789-537c-9ccb-0cdf1566536e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26abf89e-45c9-4c1d-89c5-749eb3c4d301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26abf89e-45c9-4c1d-89c5-749eb3c4d301.jpg?1",
             "name": "Reflecting Pool",
             "text": "",
             "colours": [],
@@ -53822,7 +53822,7 @@
         },
         {
             "id": "2d4236c4-3da5-5247-8952-b07b732764f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90028340-b9e8-476a-9cf0-b1ed06b1489b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90028340-b9e8-476a-9cf0-b1ed06b1489b.jpg?1",
             "name": "Reflecting Pool",
             "text": "",
             "colours": [],
@@ -53851,7 +53851,7 @@
         },
         {
             "id": "04e86f8e-b385-5027-b13a-55eed8fd14df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7bbf6e-28a9-4ead-9b82-ff6ed4ff89fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7bbf6e-28a9-4ead-9b82-ff6ed4ff89fb.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -53881,7 +53881,7 @@
         },
         {
             "id": "fa7d7182-1ed5-5a63-b185-0c207ba8ca18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac58084-6404-46bd-bf4e-b99fdacebc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac58084-6404-46bd-bf4e-b99fdacebc19.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -53911,7 +53911,7 @@
         },
         {
             "id": "c60237f6-6ab7-555a-8389-1f45a7000fd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f02241-b268-43c8-b69e-bf10c8a9b9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f02241-b268-43c8-b69e-bf10c8a9b9ca.jpg?1",
             "name": "Applejack",
             "text": "",
             "colours": [
@@ -53949,7 +53949,7 @@
         },
         {
             "id": "a83c2ac8-710e-59b8-84de-9e29d19aa88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9c0698-aaa3-4aef-b1a6-0963e10cd94b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9c0698-aaa3-4aef-b1a6-0963e10cd94b.jpg?1",
             "name": "Fluttershy",
             "text": "",
             "colours": [
@@ -53987,7 +53987,7 @@
         },
         {
             "id": "d5180354-0090-5941-a63c-170172277f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790770c-110d-4eb2-b9ae-3aa2bc745a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790770c-110d-4eb2-b9ae-3aa2bc745a9d.jpg?1",
             "name": "Pinkie Pie",
             "text": "",
             "colours": [
@@ -54025,7 +54025,7 @@
         },
         {
             "id": "14e5c636-2934-5ba5-a401-f44d7e284dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab2cbaa-58c5-4612-8d99-10f5ee5041ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab2cbaa-58c5-4612-8d99-10f5ee5041ee.jpg?1",
             "name": "Rainbow Dash",
             "text": "",
             "colours": [
@@ -54066,7 +54066,7 @@
         },
         {
             "id": "48b8e7c9-1ebe-5a78-a208-f36151158084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg?1",
             "name": "Sakashima of a Thousand Faces // Sakashima of a Thousand Faces",
             "text": "",
             "colours": [
@@ -54103,7 +54103,7 @@
         },
         {
             "id": "04372b77-6c57-5b77-a681-36a0909fba02",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg?1",
             "name": "Sakashima of a Thousand Faces // Sakashima of a Thousand Faces",
             "text": "",
             "colours": [
@@ -54140,7 +54140,7 @@
         },
         {
             "id": "a8c7213a-045d-5d9a-8455-1b412aa3f052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg?1",
             "name": "Yargle, Glutton of Urborg // Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -54177,7 +54177,7 @@
         },
         {
             "id": "3f61bbf9-ff9b-5a76-a9de-503a2148f094",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg?1",
             "name": "Yargle, Glutton of Urborg // Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -54214,7 +54214,7 @@
         },
         {
             "id": "23b7f441-fd4b-57fb-88e1-96d71dba33e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg?1",
             "name": "Krark, the Thumbless // Krark, the Thumbless",
             "text": "",
             "colours": [
@@ -54251,7 +54251,7 @@
         },
         {
             "id": "a051c040-14bc-5de4-95dc-51e0b686168e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg?1",
             "name": "Krark, the Thumbless // Krark, the Thumbless",
             "text": "",
             "colours": [
@@ -54288,7 +54288,7 @@
         },
         {
             "id": "369280c8-f34e-5272-8988-2a7cdea40018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg?1",
             "name": "Adrix and Nev, Twincasters // Adrix and Nev, Twincasters",
             "text": "",
             "colours": [
@@ -54327,7 +54327,7 @@
         },
         {
             "id": "f472b16d-3667-526d-96fc-5d8642ec6ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg?1",
             "name": "Adrix and Nev, Twincasters // Adrix and Nev, Twincasters",
             "text": "",
             "colours": [
@@ -54366,7 +54366,7 @@
         },
         {
             "id": "88ad53a0-ca1f-5b90-b46b-151ae5109c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1535dc66-763b-4b14-bd2e-684a2fc7cdfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1535dc66-763b-4b14-bd2e-684a2fc7cdfb.jpg?1",
             "name": "Arcane Denial",
             "text": "",
             "colours": [
@@ -54399,7 +54399,7 @@
         },
         {
             "id": "c7cc1274-0cd9-52de-b3cb-8116eed6248d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b6268-6253-4b46-a7da-2225e27c9fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b6268-6253-4b46-a7da-2225e27c9fd7.jpg?1",
             "name": "Arcane Denial",
             "text": "",
             "colours": [
@@ -54432,7 +54432,7 @@
         },
         {
             "id": "ab7471b0-1d04-530c-a2a2-8584b84c8bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf313ba7-d031-4dd3-aee0-36f2c4533da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf313ba7-d031-4dd3-aee0-36f2c4533da5.jpg?1",
             "name": "Nightscape Familiar",
             "text": "",
             "colours": [
@@ -54467,7 +54467,7 @@
         },
         {
             "id": "cd601610-6a3e-5958-bbf1-909e36d12e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17558592-2e66-48d3-b38a-3738e5a2a01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17558592-2e66-48d3-b38a-3738e5a2a01f.jpg?1",
             "name": "Nightscape Familiar",
             "text": "",
             "colours": [
@@ -54502,7 +54502,7 @@
         },
         {
             "id": "99a4a94f-768b-50ae-8e64-903a71523a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd39e21d-89cf-4211-8b03-c53e7c48311b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd39e21d-89cf-4211-8b03-c53e7c48311b.jpg?1",
             "name": "Rain of Filth",
             "text": "",
             "colours": [
@@ -54535,7 +54535,7 @@
         },
         {
             "id": "2e0374bf-8167-501b-969f-4458de2dbd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6143f4dc-3a32-4158-bb74-101810d1528d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6143f4dc-3a32-4158-bb74-101810d1528d.jpg?1",
             "name": "Rain of Filth",
             "text": "",
             "colours": [
@@ -54568,7 +54568,7 @@
         },
         {
             "id": "4262d037-dffa-53a6-9062-9bcf5ac4d84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234b53a3-cf34-46dd-a556-653e2348c5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234b53a3-cf34-46dd-a556-653e2348c5da.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "",
             "colours": [
@@ -54604,7 +54604,7 @@
         },
         {
             "id": "dd65373d-0f4e-591d-86a0-29e9c56fa24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac2428-87a3-4aea-8c91-a02c0b401469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac2428-87a3-4aea-8c91-a02c0b401469.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "",
             "colours": [
@@ -54640,7 +54640,7 @@
         },
         {
             "id": "5d11e7dc-4ce2-5fea-810d-4ee8d2940a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c7da42-cd73-443e-9f0e-d6aefe08523a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c7da42-cd73-443e-9f0e-d6aefe08523a.jpg?1",
             "name": "Prince of Thralls",
             "text": "",
             "colours": [
@@ -54679,7 +54679,7 @@
         },
         {
             "id": "284931c6-27a3-56dc-b123-201a2644fadf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689fbfbc-1eea-4cc0-801b-72305160bf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689fbfbc-1eea-4cc0-801b-72305160bf8e.jpg?1",
             "name": "Prince of Thralls",
             "text": "",
             "colours": [
@@ -54718,7 +54718,7 @@
         },
         {
             "id": "c4942bed-2823-537e-8f5f-be3129d08291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -54761,7 +54761,7 @@
         },
         {
             "id": "95142a8f-f792-509a-9692-16e27eaef713",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -54804,7 +54804,7 @@
         },
         {
             "id": "669a3767-8ded-545f-aad6-1bc94c599829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -54847,7 +54847,7 @@
         },
         {
             "id": "944935e8-a39b-587a-97fe-1dc9c7e6022c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -54890,7 +54890,7 @@
         },
         {
             "id": "52718cc6-73de-538b-9f29-6dca5e30b36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -54933,7 +54933,7 @@
         },
         {
             "id": "c765b079-5dee-5d7d-930d-37122012aff6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -54976,7 +54976,7 @@
         },
         {
             "id": "d093ee37-6706-57e6-a482-cd1e1a1bce46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bd474-fb4b-4c19-b583-ac2fa2e18475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bd474-fb4b-4c19-b583-ac2fa2e18475.jpg?1",
             "name": "Najeela, the Blade-Blossom",
             "text": "",
             "colours": [
@@ -55019,7 +55019,7 @@
         },
         {
             "id": "205d0b1b-d677-590d-b543-9a4ce117a053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec569-111d-4c0c-a146-4d043ad27c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec569-111d-4c0c-a146-4d043ad27c8e.jpg?1",
             "name": "Kelsien, the Plague",
             "text": "",
             "colours": [
@@ -55060,7 +55060,7 @@
         },
         {
             "id": "b00094d8-7e5c-5fea-ba2a-641c39e18a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b04456-c692-47e1-90d7-53bba320bbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b04456-c692-47e1-90d7-53bba320bbda.jpg?1",
             "name": "Queen Marchesa",
             "text": "",
             "colours": [
@@ -55103,7 +55103,7 @@
         },
         {
             "id": "3ec6e904-e9d8-512a-8307-2c82493eb303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0d2967-b11a-498d-b7be-bef1b6160d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0d2967-b11a-498d-b7be-bef1b6160d9a.jpg?1",
             "name": "Ramses, Assassin Lord",
             "text": "",
             "colours": [
@@ -55142,7 +55142,7 @@
         },
         {
             "id": "185a8e42-3a6e-5418-b700-8e99aaf44991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d69040-2065-4975-88d3-60bd32731771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d69040-2065-4975-88d3-60bd32731771.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "",
             "colours": [
@@ -55186,7 +55186,7 @@
         },
         {
             "id": "f5ed76ea-3d67-5cb8-9764-379208fd7309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d741a56f-c490-4e7f-b1d9-f12f37efdfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d741a56f-c490-4e7f-b1d9-f12f37efdfdd.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "",
             "colours": [
@@ -55224,7 +55224,7 @@
         },
         {
             "id": "efe14ed4-0f74-5f83-9bb6-963a4385f665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060ed17-779a-49bc-a3b0-bcda89edc4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060ed17-779a-49bc-a3b0-bcda89edc4b0.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "",
             "colours": [
@@ -55262,7 +55262,7 @@
         },
         {
             "id": "aa9f0c08-6fe8-5bb7-af5d-07f397a65cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c30638e-d094-4e50-8656-f6980b102781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c30638e-d094-4e50-8656-f6980b102781.jpg?1",
             "name": "Vilis, Broker of Blood",
             "text": "",
             "colours": [
@@ -55299,7 +55299,7 @@
         },
         {
             "id": "08e30b06-d44e-5317-a44e-1ed421bb7afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da866-c6b7-4a12-b442-30e3105b45a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da866-c6b7-4a12-b442-30e3105b45a8.jpg?1",
             "name": "Vilis, Broker of Blood",
             "text": "",
             "colours": [
@@ -55336,7 +55336,7 @@
         },
         {
             "id": "6598c204-cc74-5d57-90d0-c9c41ffaf708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41026-4988-44f0-9281-93b3d4905be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41026-4988-44f0-9281-93b3d4905be9.jpg?1",
             "name": "Anowon, the Ruin Thief",
             "text": "",
             "colours": [
@@ -55376,7 +55376,7 @@
         },
         {
             "id": "58f715e2-9a42-5b51-a479-2b89ddacd872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e39a5ae-de10-4412-8939-97dc40fa24d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e39a5ae-de10-4412-8939-97dc40fa24d4.jpg?1",
             "name": "Anowon, the Ruin Thief",
             "text": "",
             "colours": [
@@ -55416,7 +55416,7 @@
         },
         {
             "id": "029e1904-8130-5b0c-907e-e2659999eb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f09945-6098-4bc5-a9e7-03eb56b18030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f09945-6098-4bc5-a9e7-03eb56b18030.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "",
             "colours": [
@@ -55456,7 +55456,7 @@
         },
         {
             "id": "72ecab64-2beb-5501-9e0b-ba6cc3992f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d07abd2-e7a2-484a-8c84-931cb85e36a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d07abd2-e7a2-484a-8c84-931cb85e36a0.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "",
             "colours": [
@@ -55496,7 +55496,7 @@
         },
         {
             "id": "60b28963-7722-5ad2-b540-64441d7a6e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f6fec8-2932-456c-91c1-c12d7dd0c31c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f6fec8-2932-456c-91c1-c12d7dd0c31c.jpg?1",
             "name": "Blade of Selves",
             "text": "",
             "colours": [],
@@ -55526,7 +55526,7 @@
         },
         {
             "id": "a4cca700-47e4-5627-b164-67426d348df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7c2428-a3a9-4498-a743-2cb35fd99403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7c2428-a3a9-4498-a743-2cb35fd99403.jpg?1",
             "name": "Conqueror's Flail",
             "text": "",
             "colours": [],
@@ -55556,7 +55556,7 @@
         },
         {
             "id": "7ae26b49-33e9-539f-8bba-282cff813aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876fb8d6-1ac5-4b3d-a300-2a954000b1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876fb8d6-1ac5-4b3d-a300-2a954000b1cb.jpg?1",
             "name": "Darksteel Plate",
             "text": "",
             "colours": [],
@@ -55586,7 +55586,7 @@
         },
         {
             "id": "2d67d858-ae4d-53a6-96fe-030800ca7808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07de695f-aac5-4367-9fdc-3b11740c7f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07de695f-aac5-4367-9fdc-3b11740c7f97.jpg?1",
             "name": "Deathrender",
             "text": "",
             "colours": [],
@@ -55616,7 +55616,7 @@
         },
         {
             "id": "a4cdc839-a7df-50d0-9080-a74870ff3a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a90bb-5ff0-48ec-b578-63ebcf7f1e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a90bb-5ff0-48ec-b578-63ebcf7f1e70.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "",
             "colours": [],
@@ -55646,7 +55646,7 @@
         },
         {
             "id": "ba7b3a9d-2555-576e-bee0-634937d4f9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214828eb-434c-47ed-b4af-faaa6c784fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214828eb-434c-47ed-b4af-faaa6c784fb4.jpg?1",
             "name": "Reconnaissance",
             "text": "",
             "colours": [
@@ -55679,7 +55679,7 @@
         },
         {
             "id": "41baafcc-8abd-56d7-ba8d-fd8efa8c052f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e15b958-237d-4705-a515-02ab2698d3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e15b958-237d-4705-a515-02ab2698d3bb.jpg?1",
             "name": "Reconnaissance",
             "text": "",
             "colours": [
@@ -55712,7 +55712,7 @@
         },
         {
             "id": "f8543a17-e314-56c7-95d5-27b02a77b568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b2d33b-2689-4d03-b297-a196b376804d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b2d33b-2689-4d03-b297-a196b376804d.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -55750,7 +55750,7 @@
         },
         {
             "id": "ce23be65-ac1b-5b53-97d5-534ad41bc37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f13face-aa33-4f57-ad06-5313b4834e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f13face-aa33-4f57-ad06-5313b4834e02.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -55788,7 +55788,7 @@
         },
         {
             "id": "99716b52-c81a-514e-8385-e52d18964e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9817714-70b2-4e36-ae56-14052a9c12a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9817714-70b2-4e36-ae56-14052a9c12a1.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -55821,7 +55821,7 @@
         },
         {
             "id": "34ae078f-e8a4-5cbd-94ce-90a48df0093c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43937afe-6ec4-4d9c-acf9-0fe0df8ca7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43937afe-6ec4-4d9c-acf9-0fe0df8ca7b5.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -55854,7 +55854,7 @@
         },
         {
             "id": "604848f4-6c3f-59ca-af72-01ec99bc0ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfa3947-3c50-4bd2-89cc-e4634858244b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfa3947-3c50-4bd2-89cc-e4634858244b.jpg?1",
             "name": "Dire Undercurrents",
             "text": "",
             "colours": [
@@ -55889,7 +55889,7 @@
         },
         {
             "id": "18bf702f-65e1-51e7-b451-217f52ce4094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0e63c-778e-4749-9a96-a192699904c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0e63c-778e-4749-9a96-a192699904c5.jpg?1",
             "name": "Dire Undercurrents",
             "text": "",
             "colours": [
@@ -55924,7 +55924,7 @@
         },
         {
             "id": "c162e052-7484-5411-894f-60a038fa027e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4ee119-8d1e-4630-93cc-11339d1f5e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4ee119-8d1e-4630-93cc-11339d1f5e95.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "",
             "colours": [
@@ -55966,7 +55966,7 @@
         },
         {
             "id": "d21e4d29-ac69-59c5-a2d8-abe854a34426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc54001-db2f-4d64-ac7b-99bc5ccea52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc54001-db2f-4d64-ac7b-99bc5ccea52b.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "",
             "colours": [
@@ -56008,7 +56008,7 @@
         },
         {
             "id": "3beaab38-1eef-57e0-adb4-d69892a3ffb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39edd98a-2ee9-4799-9194-5b5a3efb6255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39edd98a-2ee9-4799-9194-5b5a3efb6255.jpg?1",
             "name": "Rose Noble",
             "text": "",
             "colours": [
@@ -56044,7 +56044,7 @@
         },
         {
             "id": "7f132a3d-e335-5b2f-991f-9112a01c10ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c4cdb-c6f2-4ee8-b5fb-acb59a9931bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c4cdb-c6f2-4ee8-b5fb-acb59a9931bf.jpg?1",
             "name": "The Meep",
             "text": "",
             "colours": [
@@ -56080,7 +56080,7 @@
         },
         {
             "id": "64f80ee0-c68e-5d7c-a56a-0161d307e577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c9e915-9cee-45c3-96aa-9dfd5a600d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c9e915-9cee-45c3-96aa-9dfd5a600d0a.jpg?1",
             "name": "The Celestial Toymaker",
             "text": "",
             "colours": [
@@ -56121,7 +56121,7 @@
         },
         {
             "id": "03a073d6-b062-536d-af5a-9562980f0861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a78cf-ee6c-4852-9651-eeaa634daaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a78cf-ee6c-4852-9651-eeaa634daaa1.jpg?1",
             "name": "The Fourteenth Doctor",
             "text": "",
             "colours": [
@@ -56164,7 +56164,7 @@
         },
         {
             "id": "856410e7-026b-5591-9c9a-f13deeca1c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530a26f1-cf7a-4e56-886b-6799b057c739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530a26f1-cf7a-4e56-886b-6799b057c739.jpg?1",
             "name": "The Fifteenth Doctor",
             "text": "",
             "colours": [
@@ -56203,7 +56203,7 @@
         },
         {
             "id": "9ee63fab-29f4-5291-a1de-e42b23a36dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d3a061-03b4-4004-8a6c-4374513de17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d3a061-03b4-4004-8a6c-4374513de17a.jpg?1",
             "name": "Elspeth Tirel",
             "text": "",
             "colours": [
@@ -56239,7 +56239,7 @@
         },
         {
             "id": "1a8c34cd-8745-57fb-bb94-ccf08573d63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbf4c7-ea2c-413b-8226-6aaa46a44661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbf4c7-ea2c-413b-8226-6aaa46a44661.jpg?1",
             "name": "Shelter",
             "text": "",
             "colours": [
@@ -56272,7 +56272,7 @@
         },
         {
             "id": "60764127-dd30-5e7d-b34a-3767d7093009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c7161a-6168-436a-93de-3010841d5a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c7161a-6168-436a-93de-3010841d5a27.jpg?1",
             "name": "Shelter",
             "text": "",
             "colours": [
@@ -56305,7 +56305,7 @@
         },
         {
             "id": "7bd01195-558e-5af8-906f-382d08d28338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d595f6-7b51-4a4a-acb5-08e12bac6ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d595f6-7b51-4a4a-acb5-08e12bac6ea7.jpg?1",
             "name": "Jace, Unraveler of Secrets",
             "text": "",
             "colours": [
@@ -56341,7 +56341,7 @@
         },
         {
             "id": "31f4a318-9199-5b73-a8fb-b1b4c0b5f87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6ba63e-0168-45e4-abf3-f7a5b87a4b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6ba63e-0168-45e4-abf3-f7a5b87a4b85.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -56375,7 +56375,7 @@
         },
         {
             "id": "840b1c8c-9cd2-5b87-ad3e-6874fab726b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb89c6b9-991a-453f-a787-7fb4c1642737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb89c6b9-991a-453f-a787-7fb4c1642737.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "",
             "colours": [
@@ -56413,7 +56413,7 @@
         },
         {
             "id": "4802e51c-287b-5301-b38c-edacaf787aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243b872-c90f-4d25-9d8c-dbbcc8004a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243b872-c90f-4d25-9d8c-dbbcc8004a48.jpg?1",
             "name": "Chandra's Ignition",
             "text": "",
             "colours": [
@@ -56446,7 +56446,7 @@
         },
         {
             "id": "dfd7bab4-3417-5f1a-bf75-812785cae999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec9ffa6-3f61-448a-a5ab-68eeef29ff45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec9ffa6-3f61-448a-a5ab-68eeef29ff45.jpg?1",
             "name": "Chandra's Ignition",
             "text": "",
             "colours": [
@@ -56479,7 +56479,7 @@
         },
         {
             "id": "8f1c43c8-cdda-5c84-bc48-84f57f92b128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f009d4a-3b50-40ae-b52e-0b9535049265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f009d4a-3b50-40ae-b52e-0b9535049265.jpg?1",
             "name": "Chord of Calling",
             "text": "",
             "colours": [
@@ -56511,7 +56511,7 @@
         },
         {
             "id": "f395c060-dfc3-5ead-a36f-ce8cfcab6fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40064484-3ed0-4724-ba51-6bf3b66cc0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40064484-3ed0-4724-ba51-6bf3b66cc0ae.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -56544,7 +56544,7 @@
         },
         {
             "id": "bd8b641a-83d5-5192-873a-375d8386b377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02ef5ff-353f-4874-ab0d-ee3a8a5f9bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02ef5ff-353f-4874-ab0d-ee3a8a5f9bf1.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -56577,7 +56577,7 @@
         },
         {
             "id": "5d2aa40c-fafc-5aff-b7fa-e57b663693bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b25568-46e9-4f4e-a4b5-7f371314e49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b25568-46e9-4f4e-a4b5-7f371314e49e.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "",
             "colours": [
@@ -56616,7 +56616,7 @@
         },
         {
             "id": "2b67ab0a-1879-5093-ba1c-54eb1681c503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f3807-9258-452c-80cc-ad8ef6b6863f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f3807-9258-452c-80cc-ad8ef6b6863f.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "",
             "colours": [
@@ -56655,7 +56655,7 @@
         },
         {
             "id": "6b8c133b-2357-5dff-a96a-3089ef6b614e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a4035e-e8ec-4be0-8009-666bc7a5dd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a4035e-e8ec-4be0-8009-666bc7a5dd69.jpg?1",
             "name": "Freyalise, Llanowar's Fury",
             "text": "",
             "colours": [
@@ -56691,7 +56691,7 @@
         },
         {
             "id": "4ea48c8d-cfbc-50cd-8b74-9e839e8f0d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906482a9-4b9d-4fc3-a3e5-ac135ed076d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906482a9-4b9d-4fc3-a3e5-ac135ed076d3.jpg?1",
             "name": "Child of Alara",
             "text": "",
             "colours": [
@@ -56735,7 +56735,7 @@
         },
         {
             "id": "93aaa928-e5a0-5e10-a7f4-49acf686f5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ecf1fd-f963-4bc0-8c01-ef781c14e463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ecf1fd-f963-4bc0-8c01-ef781c14e463.jpg?1",
             "name": "The Royal Scions",
             "text": "",
             "colours": [
@@ -56774,7 +56774,7 @@
         },
         {
             "id": "f138a8b5-fc91-58ec-a7d5-b306d942ff63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97162e95-5cc6-4c83-996c-622bc25e7d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97162e95-5cc6-4c83-996c-622bc25e7d0f.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "",
             "colours": [
@@ -56813,7 +56813,7 @@
         },
         {
             "id": "df7392d0-cf60-5ae2-843e-97323712daa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563fe38-f690-40e9-96a6-6ce333b2cfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563fe38-f690-40e9-96a6-6ce333b2cfcc.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "",
             "colours": [
@@ -56852,7 +56852,7 @@
         },
         {
             "id": "607307d3-d622-566f-a084-af71ca892a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd4d0c-1aef-4b76-92e7-ceb7ab9bc5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd4d0c-1aef-4b76-92e7-ceb7ab9bc5e7.jpg?1",
             "name": "Song of Creation",
             "text": "",
             "colours": [
@@ -56888,7 +56888,7 @@
         },
         {
             "id": "0ce7faa6-c766-5d07-bb8f-b32db5216e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b145dd-8529-4bff-b381-b4be53f24b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b145dd-8529-4bff-b381-b4be53f24b54.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -56925,7 +56925,7 @@
         },
         {
             "id": "5143b8a4-00f2-50ca-b098-a9577ecfd9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d1eb-4d45-4c39-b361-48fcf61d8a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d1eb-4d45-4c39-b361-48fcf61d8a26.jpg?1",
             "name": "Inspiring Vantage",
             "text": "",
             "colours": [],
@@ -56958,7 +56958,7 @@
         },
         {
             "id": "61591b18-3b28-5d03-affb-cb1ca05b616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71132c-306a-4e37-a34a-777f1028e4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71132c-306a-4e37-a34a-777f1028e4a1.jpg?1",
             "name": "Inspiring Vantage",
             "text": "",
             "colours": [],
@@ -56991,7 +56991,7 @@
         },
         {
             "id": "2a56ce98-5979-524a-8ae3-c50d7d2a3115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d618c6b2-6ca2-4584-9926-b1d184c144bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d618c6b2-6ca2-4584-9926-b1d184c144bd.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -57019,7 +57019,7 @@
         },
         {
             "id": "c2e8d3fb-c386-514f-bf38-1cec06143a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "",
             "colours": [
@@ -57054,7 +57054,7 @@
         },
         {
             "id": "764f6ce3-147a-58cc-9a43-65f4d3bceaac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "",
             "colours": [
@@ -57088,7 +57088,7 @@
         },
         {
             "id": "1931c189-bce5-5c5b-90ed-a3b3da33fc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d087fc-2fd5-4ce7-bece-b12dea3d300a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d087fc-2fd5-4ce7-bece-b12dea3d300a.jpg?1",
             "name": "Beastmaster Ascension",
             "text": "",
             "colours": [
@@ -57120,7 +57120,7 @@
         },
         {
             "id": "a3071287-8544-5ee1-bd22-ac78ab3af6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f60ebd-4f6b-4562-8dec-d4b4e124cb73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f60ebd-4f6b-4562-8dec-d4b4e124cb73.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "",
             "colours": [
@@ -57152,7 +57152,7 @@
         },
         {
             "id": "a53c2276-715a-57b6-aae6-557e4df917b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7def-59e3-4eef-a571-b97db54ce641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7def-59e3-4eef-a571-b97db54ce641.jpg?1",
             "name": "Second Harvest",
             "text": "",
             "colours": [
@@ -57184,7 +57184,7 @@
         },
         {
             "id": "74df2ade-09c3-529b-90c0-7be2bba81421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -57223,7 +57223,7 @@
         },
         {
             "id": "cd032078-67e7-5778-92ee-09c9e552284a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -57261,7 +57261,7 @@
         },
         {
             "id": "35937fc6-930f-5f67-8bd1-a4a78f2330f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6fd16-a7cd-49cb-bb70-806f8eb622dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6fd16-a7cd-49cb-bb70-806f8eb622dd.jpg?1",
             "name": "Brash Taunter",
             "text": "",
             "colours": [
@@ -57295,7 +57295,7 @@
         },
         {
             "id": "df6e801b-4a2f-52e6-8f6c-c3583e63bfe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c6c448-13c6-4453-965e-6576035aa738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c6c448-13c6-4453-965e-6576035aa738.jpg?1",
             "name": "Goblin Chieftain",
             "text": "",
             "colours": [
@@ -57329,7 +57329,7 @@
         },
         {
             "id": "de3a8370-785f-5e2c-a1b8-79dc7742f441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba83c0d-f72b-442c-ae30-6cf557bd157d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba83c0d-f72b-442c-ae30-6cf557bd157d.jpg?1",
             "name": "Goblin Ringleader",
             "text": "",
             "colours": [
@@ -57363,7 +57363,7 @@
         },
         {
             "id": "b6b3df14-fce3-5f7f-bd69-d362b42aedea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427b231-3419-407c-803f-d6bcc37efb1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427b231-3419-407c-803f-d6bcc37efb1d.jpg?1",
             "name": "Goblin Welder",
             "text": "",
             "colours": [
@@ -57398,7 +57398,7 @@
         },
         {
             "id": "186de077-c8b1-5f29-83e8-9bfa5e5a0d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd170aa1-18be-470e-aa36-bfb11e9f92c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd170aa1-18be-470e-aa36-bfb11e9f92c1.jpg?1",
             "name": "Mogg War Marshal",
             "text": "",
             "colours": [
@@ -57433,7 +57433,7 @@
         },
         {
             "id": "8f75232b-f217-57fa-8c10-465ba182066b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b3d65d-3485-4d82-ba2e-9e2071f284b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b3d65d-3485-4d82-ba2e-9e2071f284b5.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "",
             "colours": [
@@ -57471,7 +57471,7 @@
         },
         {
             "id": "9bdc6045-4e35-5204-a034-9fdf2dbd6936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61805d7f-382c-46ff-8380-d995fc0b9d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61805d7f-382c-46ff-8380-d995fc0b9d25.jpg?1",
             "name": "Griselbrand",
             "text": "",
             "colours": [
@@ -57510,7 +57510,7 @@
         },
         {
             "id": "eb6848cf-118f-5fb4-af6f-9e0251f8b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6f7f0e-7a0a-42ae-8bc9-c20f62dd3264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6f7f0e-7a0a-42ae-8bc9-c20f62dd3264.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "",
             "colours": [
@@ -57547,7 +57547,7 @@
         },
         {
             "id": "9c8fba2e-4a09-56d7-ae4a-01705ed8e027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab6843-6bdd-439a-b81c-0be83b8d4c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab6843-6bdd-439a-b81c-0be83b8d4c52.jpg?1",
             "name": "Nicol Bolas, Planeswalker",
             "text": "",
             "colours": [
@@ -57587,7 +57587,7 @@
         },
         {
             "id": "0a13e567-d0cd-5b8a-9e85-7e85133f4e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182dc47c-897e-4922-ba9d-80204bed7b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182dc47c-897e-4922-ba9d-80204bed7b5a.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "",
             "colours": [
@@ -57626,7 +57626,7 @@
         },
         {
             "id": "4b1d6253-120d-5d52-b3b7-56b128da213d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03988a88-090d-4daf-bb0a-ca0dabee917f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03988a88-090d-4daf-bb0a-ca0dabee917f.jpg?1",
             "name": "Karona, False God",
             "text": "",
             "colours": [
@@ -57670,7 +57670,7 @@
         },
         {
             "id": "85199f42-dad2-5bd8-913a-e8733f99afae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e2c910-6ada-41f6-b5ea-2dc25167666c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e2c910-6ada-41f6-b5ea-2dc25167666c.jpg?1",
             "name": "Korvold, Fae-Cursed King",
             "text": "",
             "colours": [
@@ -57711,7 +57711,7 @@
         },
         {
             "id": "73aaf059-59ab-554f-9d59-fd5882d8b75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246b1de7-0b50-4edd-b1a7-fd6856351b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246b1de7-0b50-4edd-b1a7-fd6856351b76.jpg?1",
             "name": "Memnarch",
             "text": "",
             "colours": [],
@@ -57746,7 +57746,7 @@
         },
         {
             "id": "d92ce913-2122-5181-b276-e4e6dd31b9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae26b5-bb60-4138-ab08-740e45455373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae26b5-bb60-4138-ab08-740e45455373.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -57783,7 +57783,7 @@
         },
         {
             "id": "c4100878-b071-5d59-a5eb-cb98428e6611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ace56-18ec-47d8-bfeb-5680912b2ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ace56-18ec-47d8-bfeb-5680912b2ec5.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -57820,7 +57820,7 @@
         },
         {
             "id": "9b4ee2a3-2d8d-520f-871a-ed43458f0dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8f7a42-b41e-4065-878a-1f350fd0766a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8f7a42-b41e-4065-878a-1f350fd0766a.jpg?1",
             "name": "Faerie Artisans",
             "text": "",
             "colours": [
@@ -57856,7 +57856,7 @@
         },
         {
             "id": "92a62126-f2cf-52a2-9005-a13e84eaf3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8cefaa-d005-4b9c-a2b0-90ed97f3157f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8cefaa-d005-4b9c-a2b0-90ed97f3157f.jpg?1",
             "name": "Faerie Artisans",
             "text": "",
             "colours": [
@@ -57892,7 +57892,7 @@
         },
         {
             "id": "5399cf82-bd4e-5ddf-8a6a-c881e081a276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697fcd59-1ad7-439f-8307-abe92c457b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697fcd59-1ad7-439f-8307-abe92c457b05.jpg?1",
             "name": "Dockside Chef",
             "text": "",
             "colours": [
@@ -57929,7 +57929,7 @@
         },
         {
             "id": "9be52081-f89a-55fe-84ec-9104685addae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9692d4-8543-4f76-b9ec-e08240091c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9692d4-8543-4f76-b9ec-e08240091c50.jpg?1",
             "name": "Dockside Chef",
             "text": "",
             "colours": [
@@ -57966,7 +57966,7 @@
         },
         {
             "id": "0945c5f2-92da-501c-bbec-da1647b67c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f7528-5162-4454-afa8-9ecb912d7ec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f7528-5162-4454-afa8-9ecb912d7ec7.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "",
             "colours": [
@@ -58009,7 +58009,7 @@
         },
         {
             "id": "54c96c25-5ef2-5395-a9a7-b17ef4ebff93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a94f62-2060-494b-924a-792b728dcf99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a94f62-2060-494b-924a-792b728dcf99.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "",
             "colours": [
@@ -58052,7 +58052,7 @@
         },
         {
             "id": "e1bcf9d2-7f73-56f0-83cd-21fa97207815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d102a60-383c-45f1-ab1b-be0ab9b87332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d102a60-383c-45f1-ab1b-be0ab9b87332.jpg?1",
             "name": "Door of Destinies",
             "text": "",
             "colours": [],
@@ -58081,7 +58081,7 @@
         },
         {
             "id": "09e830c3-6be2-5b98-9746-79e6d83a7ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e714d-cd70-4ba2-b125-1affa6b5d4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e714d-cd70-4ba2-b125-1affa6b5d4f7.jpg?1",
             "name": "Door of Destinies",
             "text": "",
             "colours": [],
@@ -58110,7 +58110,7 @@
         },
         {
             "id": "f88641dd-eb7c-569f-b3de-b0055fa03e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602f394-2bfa-4383-b1aa-2715cc36683d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602f394-2bfa-4383-b1aa-2715cc36683d.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "",
             "colours": [
@@ -58143,7 +58143,7 @@
         },
         {
             "id": "5c25289e-a862-5328-b5ec-d5e5badde349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7444fb-1a01-4917-80af-d0be4e9e721e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7444fb-1a01-4917-80af-d0be4e9e721e.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "",
             "colours": [
@@ -58176,7 +58176,7 @@
         },
         {
             "id": "127a6212-24eb-5acf-9d42-ba26c46b7de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8aa419-dc96-4cd7-9e6a-c2d071df98d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8aa419-dc96-4cd7-9e6a-c2d071df98d1.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -58209,7 +58209,7 @@
         },
         {
             "id": "fa9161bb-b485-5b98-a476-9ba010fac3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040aaf3-1331-4960-8220-22bb2c2591da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040aaf3-1331-4960-8220-22bb2c2591da.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -58242,7 +58242,7 @@
         },
         {
             "id": "8ce31439-54c2-5e58-aa39-abfec1bc6d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82f79da-7284-444b-9dd2-ee7085b3c589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82f79da-7284-444b-9dd2-ee7085b3c589.jpg?1",
             "name": "Elixir of Immortality",
             "text": "",
             "colours": [],
@@ -58271,7 +58271,7 @@
         },
         {
             "id": "46ae4864-e4ac-5852-b0b1-67e1abc5d1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efb5f-b8ca-4800-87d8-df3d4270d17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efb5f-b8ca-4800-87d8-df3d4270d17d.jpg?1",
             "name": "Elixir of Immortality",
             "text": "",
             "colours": [],
@@ -58300,7 +58300,7 @@
         },
         {
             "id": "6498edb2-cbfe-5629-8be8-82a865abaf7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf102ad-f44b-401b-9ba2-c514961b0b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf102ad-f44b-401b-9ba2-c514961b0b91.jpg?1",
             "name": "Council's Judgment",
             "text": "",
             "colours": [
@@ -58333,7 +58333,7 @@
         },
         {
             "id": "d0425e6b-b592-5341-ad52-0cf49b1b09c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90290ee-2967-4d22-85f3-83b9dcb52ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90290ee-2967-4d22-85f3-83b9dcb52ac8.jpg?1",
             "name": "Council's Judgment",
             "text": "",
             "colours": [
@@ -58366,7 +58366,7 @@
         },
         {
             "id": "8db9486f-7ca8-595c-b472-05e041b0c3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89855f5-d1de-4bb5-94bf-506fba24f438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89855f5-d1de-4bb5-94bf-506fba24f438.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -58400,7 +58400,7 @@
         },
         {
             "id": "a71b5be3-5676-513e-af98-d3805af7ea04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359573eb-be80-4c6e-98a0-fd6e6f5f1477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359573eb-be80-4c6e-98a0-fd6e6f5f1477.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -58434,7 +58434,7 @@
         },
         {
             "id": "438f9189-491e-521d-98da-2f608bccc3e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c8447-40bf-4ec0-8a93-0810ade9ec88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c8447-40bf-4ec0-8a93-0810ade9ec88.jpg?1",
             "name": "Anger",
             "text": "",
             "colours": [
@@ -58469,7 +58469,7 @@
         },
         {
             "id": "d0fed492-3c1c-5037-980b-d2a17c3a7787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0fb1-58c0-45f6-84ae-a413bd029b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0fb1-58c0-45f6-84ae-a413bd029b74.jpg?1",
             "name": "Anger",
             "text": "",
             "colours": [
@@ -58504,7 +58504,7 @@
         },
         {
             "id": "94a799db-acfa-5331-a678-5ce13a0c8499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43c378-9e6a-4ece-9c24-5dc08c977746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43c378-9e6a-4ece-9c24-5dc08c977746.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -58545,7 +58545,7 @@
         },
         {
             "id": "19765667-ab55-5eb2-8453-ab52a6c4b8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54199d7c-02f8-4ff0-9e43-e7bf66ef9715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54199d7c-02f8-4ff0-9e43-e7bf66ef9715.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -58586,7 +58586,7 @@
         },
         {
             "id": "9e47a88d-2bc0-5c20-bb38-505f425ae91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887d320-2c65-4295-bd6e-9e49eb1bc2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887d320-2c65-4295-bd6e-9e49eb1bc2e6.jpg?1",
             "name": "Inalla, Archmage Ritualist",
             "text": "",
             "colours": [
@@ -58628,7 +58628,7 @@
         },
         {
             "id": "5d0ac569-0ab0-5f6b-b72c-27159a140b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e28fbc7-b74b-4828-a0e9-08e98cdb5a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e28fbc7-b74b-4828-a0e9-08e98cdb5a92.jpg?1",
             "name": "Inalla, Archmage Ritualist",
             "text": "",
             "colours": [
@@ -58670,7 +58670,7 @@
         },
         {
             "id": "0167f5e6-af71-5d5b-9a8c-c9f92812ab01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6151f39-966e-4af6-a20a-d761781abed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6151f39-966e-4af6-a20a-d761781abed9.jpg?1",
             "name": "Aether Vial",
             "text": "",
             "colours": [],
@@ -58699,7 +58699,7 @@
         },
         {
             "id": "2313830e-9020-5c9f-9d8a-5d36f81401e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641c238d-e14a-41cc-bb5c-ad3993406d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641c238d-e14a-41cc-bb5c-ad3993406d4b.jpg?1",
             "name": "Aether Vial",
             "text": "",
             "colours": [],
@@ -58728,7 +58728,7 @@
         },
         {
             "id": "5f713c7d-0d41-5e1a-a1a9-6d612c4f2f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed972e99-c563-4da7-a60a-895949d5f032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed972e99-c563-4da7-a60a-895949d5f032.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -58764,7 +58764,7 @@
         },
         {
             "id": "2c8618da-8fec-5de7-b92d-76821edfb3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36333600-7c9c-4dc2-ba5a-dacd039716ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36333600-7c9c-4dc2-ba5a-dacd039716ea.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -58800,7 +58800,7 @@
         },
         {
             "id": "b0472839-79c7-52ad-b89a-f203e8c295ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285e4f85-c54b-4dda-9b59-fca7a2626671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285e4f85-c54b-4dda-9b59-fca7a2626671.jpg?1",
             "name": "Sword of the Animist",
             "text": "",
             "colours": [],
@@ -58833,7 +58833,7 @@
         },
         {
             "id": "8c63f5e0-858a-5465-abcc-7a81314d4a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20bca1-1f4b-47d6-8e37-b71c98d3e539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20bca1-1f4b-47d6-8e37-b71c98d3e539.jpg?1",
             "name": "Sword of the Animist",
             "text": "",
             "colours": [],
@@ -58866,7 +58866,7 @@
         },
         {
             "id": "531309e0-1d7c-5db1-8ab1-3f32105f1489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814dd29f-439b-4e0b-94a8-b57a1f9ef251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814dd29f-439b-4e0b-94a8-b57a1f9ef251.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "",
             "colours": [
@@ -58903,7 +58903,7 @@
         },
         {
             "id": "f348a73a-fc31-5b87-a70b-034b47f60c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ba5374-5d70-4300-9f4f-bedac5150cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ba5374-5d70-4300-9f4f-bedac5150cd7.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "",
             "colours": [
@@ -58940,7 +58940,7 @@
         },
         {
             "id": "aefe0456-f29b-5279-b1fb-2829b1be1424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a956ab72-6abd-48f5-863d-7f8b39caf8fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a956ab72-6abd-48f5-863d-7f8b39caf8fd.jpg?1",
             "name": "Aura Shards",
             "text": "",
             "colours": [
@@ -58975,7 +58975,7 @@
         },
         {
             "id": "3a0afa52-87a2-5fef-9e97-d30efc8073dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e737c6c5-7fdc-44fa-9fa6-27b1e34fea7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e737c6c5-7fdc-44fa-9fa6-27b1e34fea7a.jpg?1",
             "name": "Aura Shards",
             "text": "",
             "colours": [
@@ -59010,7 +59010,7 @@
         },
         {
             "id": "8f3f9987-7752-5288-b7d1-98dd5462ef47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681a8036-7eea-4408-887b-a4efcee46124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681a8036-7eea-4408-887b-a4efcee46124.jpg?1",
             "name": "Fiend Artisan",
             "text": "",
             "colours": [
@@ -59047,7 +59047,7 @@
         },
         {
             "id": "1aae9cbf-40be-5fa3-8bed-440a9522b6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25efaa39-fd86-4aef-9309-60b9a864042f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25efaa39-fd86-4aef-9309-60b9a864042f.jpg?1",
             "name": "Fiend Artisan",
             "text": "",
             "colours": [
@@ -59084,7 +59084,7 @@
         },
         {
             "id": "5b196ef0-1fa5-5b0a-887f-04d5fa656fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c718f2-b7a2-4d3d-b5de-629347e6a45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c718f2-b7a2-4d3d-b5de-629347e6a45b.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "",
             "colours": [
@@ -59126,7 +59126,7 @@
         },
         {
             "id": "9c9fe773-e821-5689-8da0-1aa03e878131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9317408a-374e-4b9c-b438-01618ded2cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9317408a-374e-4b9c-b438-01618ded2cbc.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "",
             "colours": [
@@ -59168,7 +59168,7 @@
         },
         {
             "id": "562c1bae-50be-53d2-b581-46c52ae34af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bccd95-0703-4755-8f31-bd8ab615bd04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bccd95-0703-4755-8f31-bd8ab615bd04.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -59237,7 +59237,7 @@
         },
         {
             "id": "b5f49c02-32eb-58c9-899f-29595861afa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b7f1bb-b47d-4096-b17a-db0587f566c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b7f1bb-b47d-4096-b17a-db0587f566c6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -59302,7 +59302,7 @@
         },
         {
             "id": "9959d5e9-b8db-5402-9692-a8e40b408d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c70db5a-3d7f-4534-9e5a-01d510b8d62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c70db5a-3d7f-4534-9e5a-01d510b8d62a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -59366,7 +59366,7 @@
         },
         {
             "id": "53227708-e57e-5c2b-8356-273725be1bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603114eb-c0eb-4734-87e6-7fc94beda3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603114eb-c0eb-4734-87e6-7fc94beda3c7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -59440,7 +59440,7 @@
         },
         {
             "id": "80de5aa3-f175-59f4-9961-a10ef0d3362c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da462ed3-c8f5-409e-bdc8-53e36a4961dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da462ed3-c8f5-409e-bdc8-53e36a4961dd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -59505,7 +59505,7 @@
         },
         {
             "id": "2ce0dea0-d732-54d5-945d-779492ac8923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81973f-c7a8-4855-affe-6a65b7f88406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81973f-c7a8-4855-affe-6a65b7f88406.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -59574,7 +59574,7 @@
         },
         {
             "id": "89ee6746-e0dc-5434-9ecf-106d8ee345c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d03913-c905-439c-a603-7d7fae6b9cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d03913-c905-439c-a603-7d7fae6b9cd9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -59639,7 +59639,7 @@
         },
         {
             "id": "ca94aaf6-5448-5371-9722-3dc83db1f81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4187a894-1a26-43ec-8e38-5422ae7e6b9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4187a894-1a26-43ec-8e38-5422ae7e6b9b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -59703,7 +59703,7 @@
         },
         {
             "id": "5ef6526f-5767-5947-b7f5-929d0976bc7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf928c4-c8ee-479c-88df-d6bb35e0778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf928c4-c8ee-479c-88df-d6bb35e0778a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -59777,7 +59777,7 @@
         },
         {
             "id": "71cd86a2-5866-522b-90c4-620a565cf3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaa22a-d679-48ef-805a-d09d6f1091aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaa22a-d679-48ef-805a-d09d6f1091aa.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -59842,7 +59842,7 @@
         },
         {
             "id": "d369368b-3929-5d8a-94b7-1b9e82d26783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb064da-aba8-445c-bde7-e0f2172b3176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb064da-aba8-445c-bde7-e0f2172b3176.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "",
             "colours": [
@@ -59878,7 +59878,7 @@
         },
         {
             "id": "d52abb54-dab2-5015-8da9-4df8619c707e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a209ed7c-132c-47ac-9210-d951d2f9e0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a209ed7c-132c-47ac-9210-d951d2f9e0a3.jpg?1",
             "name": "Chaotic Goo",
             "text": "",
             "colours": [
@@ -59912,7 +59912,7 @@
         },
         {
             "id": "b460b4a1-1576-5529-87a9-70bd8dece0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4694a-ac36-497c-a3f4-09d3f69939fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4694a-ac36-497c-a3f4-09d3f69939fe.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "",
             "colours": [
@@ -59949,7 +59949,7 @@
         },
         {
             "id": "9801f73f-747f-5c21-b386-b5c62085b0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32758999-b0f1-4acc-b59a-ead3dce27724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32758999-b0f1-4acc-b59a-ead3dce27724.jpg?1",
             "name": "Meteor Golem",
             "text": "",
             "colours": [],
@@ -59982,7 +59982,7 @@
         },
         {
             "id": "78dd3226-9dc8-57c0-beb7-8620b9958b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc01aa1-55f3-4557-a5b0-734f3b9ed050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc01aa1-55f3-4557-a5b0-734f3b9ed050.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "",
             "colours": [],
@@ -60014,7 +60014,7 @@
         },
         {
             "id": "a74e76a4-8384-542d-b940-68525579fc81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202a98ec-3ce9-47c6-8f8e-cd421e71631d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202a98ec-3ce9-47c6-8f8e-cd421e71631d.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -60048,7 +60048,7 @@
         },
         {
             "id": "f4e8eb53-2212-5f67-9b24-c44c25a5a2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc351e-2711-48f1-8301-183d70b046d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc351e-2711-48f1-8301-183d70b046d1.jpg?1",
             "name": "Skullclamp",
             "text": "",
             "colours": [],
@@ -60080,7 +60080,7 @@
         },
         {
             "id": "ceafab64-4789-5a39-93b8-f53a4f631d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fe249-9bda-462b-922c-f01c904c233a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fe249-9bda-462b-922c-f01c904c233a.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -60117,7 +60117,7 @@
         },
         {
             "id": "5b294965-b7e0-569b-9ec5-16e2e0dff789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f49a899-e549-48c1-85c5-766fda0ecf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f49a899-e549-48c1-85c5-766fda0ecf03.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -60148,7 +60148,7 @@
         },
         {
             "id": "96cba9e7-8106-5308-a0bd-96544d991078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec750874-33fb-44d6-915e-ba0ece9bef74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec750874-33fb-44d6-915e-ba0ece9bef74.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -60187,7 +60187,7 @@
         },
         {
             "id": "b1d7bb98-49be-507a-a027-e104974de924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7993b049-09d8-4c1a-9455-bb092249e0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7993b049-09d8-4c1a-9455-bb092249e0b6.jpg?1",
             "name": "Aetherize",
             "text": "",
             "colours": [
@@ -60219,7 +60219,7 @@
         },
         {
             "id": "611e0130-8270-5d99-94ed-f9857e41ae50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c5562d-a3d2-4241-92f0-8d021106819a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c5562d-a3d2-4241-92f0-8d021106819a.jpg?1",
             "name": "Drown in Dreams",
             "text": "",
             "colours": [
@@ -60251,7 +60251,7 @@
         },
         {
             "id": "e4cda4c7-ad4b-5340-ba01-beeaad76f02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac21208-eeab-49db-bd55-d2f2fad40c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac21208-eeab-49db-bd55-d2f2fad40c2a.jpg?1",
             "name": "Psychic Corrosion",
             "text": "",
             "colours": [
@@ -60283,7 +60283,7 @@
         },
         {
             "id": "6f56ae96-0f5c-5fd0-8d53-b6be1b5fe104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75829dd7-b694-4818-8f93-f66f4b1a81c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75829dd7-b694-4818-8f93-f66f4b1a81c4.jpg?1",
             "name": "Visions of Beyond",
             "text": "",
             "colours": [
@@ -60315,7 +60315,7 @@
         },
         {
             "id": "b7ff5c77-596a-56ca-b380-51a61d538cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384a1033-bf43-44d7-8d82-d61fc6c2d65a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384a1033-bf43-44d7-8d82-d61fc6c2d65a.jpg?1",
             "name": "Time Sieve",
             "text": "",
             "colours": [
@@ -60349,7 +60349,7 @@
         },
         {
             "id": "8c78297c-00b2-5413-b5bc-bbeff7610f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bce5aeb-0087-4ac6-96d2-6b3df55e4266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bce5aeb-0087-4ac6-96d2-6b3df55e4266.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "",
             "colours": [
@@ -60384,7 +60384,7 @@
         },
         {
             "id": "d95eb35e-84e7-5982-ae58-8d1a807131bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06ef600-51a0-48e7-b19b-0b15b3e6fc69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06ef600-51a0-48e7-b19b-0b15b3e6fc69.jpg?1",
             "name": "Buried Alive",
             "text": "",
             "colours": [
@@ -60416,7 +60416,7 @@
         },
         {
             "id": "cf205fec-95fc-5a8a-8b8b-e3e0d9808780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1aff-9d0d-4003-84e9-3b63bd4e4fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1aff-9d0d-4003-84e9-3b63bd4e4fae.jpg?1",
             "name": "Dismember",
             "text": "",
             "colours": [
@@ -60450,7 +60450,7 @@
         },
         {
             "id": "7e4065c7-6741-521b-968f-8c0ed4322e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg?1",
             "name": "Birds of Paradise // Birds of Paradise",
             "text": "",
             "colours": [
@@ -60484,7 +60484,7 @@
         },
         {
             "id": "8254af3f-befb-5d82-b8d4-ad95bc0ff52f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg?1",
             "name": "Birds of Paradise // Birds of Paradise",
             "text": "",
             "colours": [
@@ -60518,7 +60518,7 @@
         },
         {
             "id": "e4125f56-30c0-56f5-b333-0cdf53baac73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e40ddc-0483-4a2e-a776-807b37bada7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e40ddc-0483-4a2e-a776-807b37bada7f.jpg?1",
             "name": "Three Visits",
             "text": "",
             "colours": [
@@ -60550,7 +60550,7 @@
         },
         {
             "id": "6c719ea0-8b87-5286-a25b-187a192682d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b688b165-5783-47e3-94d6-56d4690171bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b688b165-5783-47e3-94d6-56d4690171bd.jpg?1",
             "name": "Door to Nothingness",
             "text": "",
             "colours": [],
@@ -60584,7 +60584,7 @@
         },
         {
             "id": "fd795a6a-a4bb-5a08-a811-a4e7c03c91a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe96fe60-f251-403c-acd1-d658a1d0c930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe96fe60-f251-403c-acd1-d658a1d0c930.jpg?1",
             "name": "Ashnod's Altar",
             "text": "",
             "colours": [],
@@ -60612,7 +60612,7 @@
         },
         {
             "id": "eb863054-26d0-5930-acab-5450362fc1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea979ce3-5ac3-4ca1-a28c-aa6071c32616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea979ce3-5ac3-4ca1-a28c-aa6071c32616.jpg?1",
             "name": "Dark Depths",
             "text": "",
             "colours": [],
@@ -60643,7 +60643,7 @@
         },
         {
             "id": "d893a284-4617-5d96-8bca-956667b619d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b899c29e-d1b5-4fba-8a48-073d5c303c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b899c29e-d1b5-4fba-8a48-073d5c303c27.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "",
             "colours": [
@@ -60678,7 +60678,7 @@
         },
         {
             "id": "f001ea09-7814-53a9-84ed-20601347af67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfdc564-51cc-4523-9d84-9d07907f41fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfdc564-51cc-4523-9d84-9d07907f41fe.jpg?1",
             "name": "Orvar, the All-Form",
             "text": "",
             "colours": [
@@ -60713,7 +60713,7 @@
         },
         {
             "id": "fb084450-6df0-5f6a-9ece-b68481a028c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99645cf7-fd27-487b-949a-cf9f86d43947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99645cf7-fd27-487b-949a-cf9f86d43947.jpg?1",
             "name": "Drana, the Last Bloodchief",
             "text": "",
             "colours": [
@@ -60749,7 +60749,7 @@
         },
         {
             "id": "21c52894-c200-51f9-b099-33b810a5ed07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96ef600-a96c-4563-bc4e-157ea62d14d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96ef600-a96c-4563-bc4e-157ea62d14d4.jpg?1",
             "name": "Lavinia, Azorius Renegade",
             "text": "",
             "colours": [
@@ -60787,7 +60787,7 @@
         },
         {
             "id": "67d2dfd2-cbe3-585a-a3b2-ccbdc3820809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ad6aa-61c2-440c-a911-2c1bd7a63bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ad6aa-61c2-440c-a911-2c1bd7a63bc1.jpg?1",
             "name": "Omnath, Locus of Creation",
             "text": "",
             "colours": [
@@ -60828,7 +60828,7 @@
         },
         {
             "id": "b794c687-800a-5131-9bd0-41124078c725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89dbc5d-1299-4dad-bb3c-c3160cdf8a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89dbc5d-1299-4dad-bb3c-c3160cdf8a0c.jpg?1",
             "name": "Kalitas, Traitor of Ghet",
             "text": "",
             "colours": [
@@ -60865,7 +60865,7 @@
         },
         {
             "id": "4c4db020-d85e-5426-bd61-a15af5d456f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f229b2-5246-4399-8468-eb030842a17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f229b2-5246-4399-8468-eb030842a17b.jpg?1",
             "name": "Magda, Brazen Outlaw",
             "text": "",
             "colours": [
@@ -60902,7 +60902,7 @@
         },
         {
             "id": "1d266bb8-7951-5ecc-ba30-c018845921a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b14e33d-2c01-49be-b03b-d08aea900f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b14e33d-2c01-49be-b03b-d08aea900f50.jpg?1",
             "name": "Dack Fayden",
             "text": "",
             "colours": [
@@ -60942,7 +60942,7 @@
         },
         {
             "id": "de74047c-81e6-5840-8e12-93f561a74033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c717062-7a4e-4231-9fb3-2c04a750a685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c717062-7a4e-4231-9fb3-2c04a750a685.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "",
             "colours": [
@@ -60981,7 +60981,7 @@
         },
         {
             "id": "5919800a-fb63-5178-9c6c-9d12d5b9fc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7210c3a-bbd3-4f3a-933b-a5618a4f7a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7210c3a-bbd3-4f3a-933b-a5618a4f7a52.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -61015,7 +61015,7 @@
         },
         {
             "id": "05d725d6-74ab-5b23-8785-5c455323dcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f999f30-df29-4b60-9415-ef7c4fbd5d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f999f30-df29-4b60-9415-ef7c4fbd5d77.jpg?1",
             "name": "Eladamri's Vineyard",
             "text": "",
             "colours": [
@@ -61047,7 +61047,7 @@
         },
         {
             "id": "ec0ba6a3-526a-53a3-8883-45201041e51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935e21d-f20c-4f73-92b6-e2e2ea8841af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935e21d-f20c-4f73-92b6-e2e2ea8841af.jpg?1",
             "name": "Greater Good",
             "text": "",
             "colours": [
@@ -61081,7 +61081,7 @@
         },
         {
             "id": "0e12c1e2-fd02-5f70-8476-9d1bbf934a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c442af6a-8f9c-466f-815c-f7890caff0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c442af6a-8f9c-466f-815c-f7890caff0d0.jpg?1",
             "name": "Inkshield",
             "text": "",
             "colours": [
@@ -61115,7 +61115,7 @@
         },
         {
             "id": "bdef6cb7-8e46-5e31-83e4-2274aee4b8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebe58a3-ba3f-451e-b834-30e71f071861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebe58a3-ba3f-451e-b834-30e71f071861.jpg?1",
             "name": "Ruhan of the Fomori",
             "text": "",
             "colours": [
@@ -61156,7 +61156,7 @@
         },
         {
             "id": "cd84cfd2-c24c-5cb3-a6cd-21c86694e1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d698bdd-b485-409d-b03e-c7c7d3fe9a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d698bdd-b485-409d-b03e-c7c7d3fe9a92.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -61193,7 +61193,7 @@
         },
         {
             "id": "8dcdfb83-896c-541d-8d12-846a6c67c7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37309cf-8b80-402b-9d29-fe5de56ced38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37309cf-8b80-402b-9d29-fe5de56ced38.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -61232,7 +61232,7 @@
         },
         {
             "id": "7be26781-b801-5807-af36-fb7634336e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f502f4-0295-40de-8ffe-48f23d72006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f502f4-0295-40de-8ffe-48f23d72006c.jpg?1",
             "name": "Sorin Markov",
             "text": "",
             "colours": [
@@ -61268,7 +61268,7 @@
         },
         {
             "id": "ae39ee35-41bb-5310-8822-b6ceb67e2667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e9d584-2a61-4966-b2c1-f22e0dd94de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e9d584-2a61-4966-b2c1-f22e0dd94de6.jpg?1",
             "name": "Huatli, Radiant Champion",
             "text": "",
             "colours": [
@@ -61306,7 +61306,7 @@
         },
         {
             "id": "0ab0352d-29ef-5b23-9dcb-336313281663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe59ce-b4f3-44ff-9972-44c0549cb9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe59ce-b4f3-44ff-9972-44c0549cb9eb.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "",
             "colours": [
@@ -61346,7 +61346,7 @@
         },
         {
             "id": "804dd017-10fe-5a86-8873-edb026ed466f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf29f1d-b30e-4c5b-a581-a0386d75ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf29f1d-b30e-4c5b-a581-a0386d75ebe1.jpg?1",
             "name": "Tezzeret, Master of the Bridge",
             "text": "",
             "colours": [
@@ -61384,7 +61384,7 @@
         },
         {
             "id": "a629afff-ac05-5ccd-b451-313a85c5722c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d8d96-5d5c-4549-87df-458fc43e4444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d8d96-5d5c-4549-87df-458fc43e4444.jpg?1",
             "name": "Vraska, Golgari Queen",
             "text": "",
             "colours": [
@@ -61424,7 +61424,7 @@
         },
         {
             "id": "aa0980e2-7e8e-5cb6-a3c4-4e078e04ac6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41e21ba-0165-41a7-acbf-9bcaf3095e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41e21ba-0165-41a7-acbf-9bcaf3095e03.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "",
             "colours": [
@@ -61461,7 +61461,7 @@
         },
         {
             "id": "a86fc080-e5cb-5398-ba09-dbe5fd7b01fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697cba66-1d06-4c8b-bb82-0adc4a73d295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697cba66-1d06-4c8b-bb82-0adc4a73d295.jpg?1",
             "name": "Coffin Queen",
             "text": "",
             "colours": [
@@ -61496,7 +61496,7 @@
         },
         {
             "id": "d89debde-dec9-5078-8a38-a63031fa9fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac38d90-1269-4884-a301-4664d69f1e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac38d90-1269-4884-a301-4664d69f1e8f.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -61532,7 +61532,7 @@
         },
         {
             "id": "88d899c6-72fa-5c67-a6c4-e292178a2209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7c8626-3c82-43f1-98a7-db165b30cf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7c8626-3c82-43f1-98a7-db165b30cf3b.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "",
             "colours": [
@@ -61567,7 +61567,7 @@
         },
         {
             "id": "c8b5ee29-a83a-53db-8146-6c563147ef5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97776800-5647-4d24-9870-72aeb355926a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97776800-5647-4d24-9870-72aeb355926a.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "",
             "colours": [
@@ -61604,7 +61604,7 @@
         },
         {
             "id": "44a6a706-8216-5cfc-8787-6de72e9e7090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e883f62-57de-4005-a937-27d0809ca04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e883f62-57de-4005-a937-27d0809ca04a.jpg?1",
             "name": "Soul Warden",
             "text": "",
             "colours": [
@@ -61639,7 +61639,7 @@
         },
         {
             "id": "5ba4e056-c34a-5a46-ad8a-9c726b9ce675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda24b2-a9ab-4aca-8bbf-1bfb0990f68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda24b2-a9ab-4aca-8bbf-1bfb0990f68f.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -61675,7 +61675,7 @@
         },
         {
             "id": "fff5a9bb-378b-5946-b906-e0623403d488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90438697-02be-4bb4-8ef3-8536c4fb0446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90438697-02be-4bb4-8ef3-8536c4fb0446.jpg?1",
             "name": "Elves of Deep Shadow",
             "text": "",
             "colours": [
@@ -61711,7 +61711,7 @@
         },
         {
             "id": "6828e5e8-55ae-5e4b-a4cb-44d4189e800a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a633f22-eae1-4fba-b81f-d79125ac88ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a633f22-eae1-4fba-b81f-d79125ac88ca.jpg?1",
             "name": "Good-Fortune Unicorn",
             "text": "",
             "colours": [
@@ -61747,7 +61747,7 @@
         },
         {
             "id": "a3a4da9a-b7a7-545e-8886-9abc4f874e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0359f9-b9da-46fe-a1bb-2fa8319792d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0359f9-b9da-46fe-a1bb-2fa8319792d0.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -61775,7 +61775,7 @@
         },
         {
             "id": "77be5ca7-3f0b-50fd-af1d-b8ec425cada4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93789500-bcc5-40b0-991d-84d17cef95a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93789500-bcc5-40b0-991d-84d17cef95a6.jpg?1",
             "name": "Dictate of Erebos",
             "text": "",
             "colours": [
@@ -61807,7 +61807,7 @@
         },
         {
             "id": "e1e1b702-9d64-5272-8fa2-f89fa5cf4402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c402380-2de7-4a47-993e-c365dc104dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c402380-2de7-4a47-993e-c365dc104dad.jpg?1",
             "name": "Fecundity",
             "text": "",
             "colours": [
@@ -61839,7 +61839,7 @@
         },
         {
             "id": "8d4e4b2d-8674-542a-83d8-e36fff2d480d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e5c8cb-ef19-499e-b428-00dfb5e75b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e5c8cb-ef19-499e-b428-00dfb5e75b4f.jpg?1",
             "name": "Mayhem Devil",
             "text": "",
             "colours": [
@@ -61875,7 +61875,7 @@
         },
         {
             "id": "5ad955be-ca35-5965-80d8-663d91fc9884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68dd98c-8b89-4b5d-88fb-498c13d6a191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68dd98c-8b89-4b5d-88fb-498c13d6a191.jpg?1",
             "name": "Moldervine Reclamation",
             "text": "",
             "colours": [
@@ -61909,7 +61909,7 @@
         },
         {
             "id": "c50994c1-15fa-5b01-a3a3-749084e862cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd0ab9-ac1b-48bd-8304-2c15bdbd7bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd0ab9-ac1b-48bd-8304-2c15bdbd7bf5.jpg?1",
             "name": "Prossh, Skyraider of Kher",
             "text": "",
             "colours": [
@@ -61949,7 +61949,7 @@
         },
         {
             "id": "5a149b7c-9906-5af6-a890-434df3550f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0dbb1c-ae8e-4f40-b7b4-016fea692da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0dbb1c-ae8e-4f40-b7b4-016fea692da9.jpg?1",
             "name": "Back to Basics",
             "text": "",
             "colours": [
@@ -61981,7 +61981,7 @@
         },
         {
             "id": "3f2bb7c9-47d8-5f9e-9448-b04bda4fa17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a125806c-a837-4220-bd05-083e00b1638d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a125806c-a837-4220-bd05-083e00b1638d.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -62015,7 +62015,7 @@
         },
         {
             "id": "4f61f4d6-d5a2-5095-ab48-ebc361d5fdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0ca3bd-da1d-46ce-843a-cc583b3ecda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0ca3bd-da1d-46ce-843a-cc583b3ecda9.jpg?1",
             "name": "Sphinx of the Second Sun",
             "text": "",
             "colours": [
@@ -62049,7 +62049,7 @@
         },
         {
             "id": "c6d3824c-9fee-5a6a-8535-9a1c27cbefda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db5492c-dc2d-4a06-ae97-f03669b88fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db5492c-dc2d-4a06-ae97-f03669b88fb0.jpg?1",
             "name": "Teferi's Ageless Insight",
             "text": "",
             "colours": [
@@ -62083,7 +62083,7 @@
         },
         {
             "id": "b7d04774-7205-5730-9447-28fe16ba318f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba7e9c8-c24c-4bd3-b398-fe42b1fcfb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba7e9c8-c24c-4bd3-b398-fe42b1fcfb5d.jpg?1",
             "name": "Captain America, First Avenger",
             "text": "",
             "colours": [
@@ -62125,7 +62125,7 @@
         },
         {
             "id": "28c0eb7e-efed-5fbc-ad82-feece83bb3b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e6040-84a1-42fe-8537-a000b4cb902f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e6040-84a1-42fe-8537-a000b4cb902f.jpg?1",
             "name": "Sigarda's Aid",
             "text": "",
             "colours": [
@@ -62159,7 +62159,7 @@
         },
         {
             "id": "4cfcc2a8-74a6-5dfc-94f5-c549dac53738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becd6a66-51b5-4ef1-a8a4-f65343bda3f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becd6a66-51b5-4ef1-a8a4-f65343bda3f8.jpg?1",
             "name": "Flawless Maneuver",
             "text": "",
             "colours": [
@@ -62191,7 +62191,7 @@
         },
         {
             "id": "7b715e9e-8876-5d90-8f81-6c81690eece6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee77da5-3e96-42fc-84ce-7ec9bc28595f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee77da5-3e96-42fc-84ce-7ec9bc28595f.jpg?1",
             "name": "In the Trenches",
             "text": "",
             "colours": [
@@ -62223,7 +62223,7 @@
         },
         {
             "id": "9aef52ef-eff5-5ca2-a1ba-a2a2860b3c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429e4523-5b11-40dc-83cb-2c8cc26a675f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429e4523-5b11-40dc-83cb-2c8cc26a675f.jpg?1",
             "name": "Sword of War and Peace",
             "text": "",
             "colours": [],
@@ -62253,7 +62253,7 @@
         },
         {
             "id": "959bb6b3-3374-52b4-be77-bb41ec5f44f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7542b1d1-e34d-46dc-af24-1b718034c0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7542b1d1-e34d-46dc-af24-1b718034c0e4.jpg?1",
             "name": "Iron Man, Titan of Innovation",
             "text": "",
             "colours": [
@@ -62293,7 +62293,7 @@
         },
         {
             "id": "8437c844-0d9f-52d2-9ad8-be8c688ffbe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b739607d-0d29-4d29-a926-f8dcb661738c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b739607d-0d29-4d29-a926-f8dcb661738c.jpg?1",
             "name": "Galvanic Blast",
             "text": "",
             "colours": [
@@ -62325,7 +62325,7 @@
         },
         {
             "id": "12279d27-94ee-57cc-a1ca-fd9b912352b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228abefc-9f64-4d64-ad58-41b0201eb82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228abefc-9f64-4d64-ad58-41b0201eb82e.jpg?1",
             "name": "Commander's Plate",
             "text": "",
             "colours": [],
@@ -62357,7 +62357,7 @@
         },
         {
             "id": "b1ec8286-13b2-5b02-9f25-bb8ba5c13f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2824f3fb-82e6-43bd-babf-da6777a5b075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2824f3fb-82e6-43bd-babf-da6777a5b075.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -62394,7 +62394,7 @@
         },
         {
             "id": "535bd266-0ad0-5184-9574-84180233b037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39000966-42f7-45ef-b25b-eb4b442f9c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39000966-42f7-45ef-b25b-eb4b442f9c8b.jpg?1",
             "name": "Inventors' Fair",
             "text": "",
             "colours": [],
@@ -62424,7 +62424,7 @@
         },
         {
             "id": "d6596ee4-d827-5ba4-b9f9-66ed4f361a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe83332-195e-4ac1-878f-f52eef62ce6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe83332-195e-4ac1-878f-f52eef62ce6a.jpg?1",
             "name": "Wolverine, Best There Is",
             "text": "",
             "colours": [
@@ -62464,7 +62464,7 @@
         },
         {
             "id": "6118d23d-02ff-579f-965c-11d4f128ded7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9866e64e-308b-4920-a76b-ddea0c6bc830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9866e64e-308b-4920-a76b-ddea0c6bc830.jpg?1",
             "name": "Berserk",
             "text": "",
             "colours": [
@@ -62498,7 +62498,7 @@
         },
         {
             "id": "9e3f955d-baeb-5be7-8576-5bddc2fee08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498508dd-fefb-463e-ad13-4cbf9e006b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498508dd-fefb-463e-ad13-4cbf9e006b34.jpg?1",
             "name": "Rite of Passage",
             "text": "",
             "colours": [
@@ -62530,7 +62530,7 @@
         },
         {
             "id": "894e6e38-a1b7-55ed-8b26-c6f794dd19cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32202c0-2572-42f2-b54c-7654914e5729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32202c0-2572-42f2-b54c-7654914e5729.jpg?1",
             "name": "Rhythm of the Wild",
             "text": "",
             "colours": [
@@ -62564,7 +62564,7 @@
         },
         {
             "id": "1a5f3d2c-46aa-50ec-94cb-575917d77168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aaee13-bfeb-47fd-93cb-2ccdd5d44e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aaee13-bfeb-47fd-93cb-2ccdd5d44e75.jpg?1",
             "name": "The Ozolith",
             "text": "",
             "colours": [],
@@ -62594,7 +62594,7 @@
         },
         {
             "id": "37a9b4a1-e14a-599c-bbae-b74f93d7bad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af7766e-7438-4128-a1f2-8b3b3ba3c650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af7766e-7438-4128-a1f2-8b3b3ba3c650.jpg?1",
             "name": "Storm, Force of Nature",
             "text": "",
             "colours": [
@@ -62635,7 +62635,7 @@
         },
         {
             "id": "0a31c1e5-968f-5e6f-bbef-3e1f2317d088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24484578-7885-4125-b95f-e677d970a5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24484578-7885-4125-b95f-e677d970a5a1.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -62677,7 +62677,7 @@
         },
         {
             "id": "a85e7ae5-4aef-56ba-bb23-67bf4801f657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f2e39f-bf39-4b27-b211-e46b6045039d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f2e39f-bf39-4b27-b211-e46b6045039d.jpg?1",
             "name": "Jeska's Will",
             "text": "",
             "colours": [
@@ -62709,7 +62709,7 @@
         },
         {
             "id": "8b3356b4-82fe-5f18-a70c-fa8f082947f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801185a5-78e0-4a5d-8aee-9a99f32ffbdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801185a5-78e0-4a5d-8aee-9a99f32ffbdc.jpg?1",
             "name": "Ice Storm",
             "text": "",
             "colours": [
@@ -62741,7 +62741,7 @@
         },
         {
             "id": "199a6410-6063-5e26-9bf3-41269514e1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96ce5e6-70a0-47d7-ac1c-2019a8c77b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96ce5e6-70a0-47d7-ac1c-2019a8c77b45.jpg?1",
             "name": "Manamorphose",
             "text": "",
             "colours": [
@@ -62775,7 +62775,7 @@
         },
         {
             "id": "dc2f9d16-72b8-5d6f-8885-f0807ecd3b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93a12d-6913-4d9e-8e9c-8067147e37f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93a12d-6913-4d9e-8e9c-8067147e37f2.jpg?1",
             "name": "Black Panther, Wakandan King",
             "text": "",
             "colours": [
@@ -62815,7 +62815,7 @@
         },
         {
             "id": "4f3084bb-0d81-5c84-bb14-911d3687269f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0da2e-3513-4891-bea2-27dd138064b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0da2e-3513-4891-bea2-27dd138064b3.jpg?1",
             "name": "Secure the Wastes",
             "text": "",
             "colours": [
@@ -62847,7 +62847,7 @@
         },
         {
             "id": "ea0dcc36-1c25-52e7-a285-dcd33408ef09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359a4ef6-14e9-410a-bb9b-bc5b66b3e47c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359a4ef6-14e9-410a-bb9b-bc5b66b3e47c.jpg?1",
             "name": "Primal Vigor",
             "text": "",
             "colours": [
@@ -62881,7 +62881,7 @@
         },
         {
             "id": "8190b37d-6fbe-570f-80cd-a550615fba9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7ffb0-ad48-4f2c-af43-a86a9546a1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7ffb0-ad48-4f2c-af43-a86a9546a1b2.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -62913,7 +62913,7 @@
         },
         {
             "id": "612bf3d0-d4c3-5229-8d3a-4a5bc4c9b253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d247eb-0482-481e-824f-996ae1b20177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d247eb-0482-481e-824f-996ae1b20177.jpg?1",
             "name": "Karn's Bastion",
             "text": "",
             "colours": [],
@@ -62941,7 +62941,7 @@
         },
         {
             "id": "708b1777-d363-5c03-8909-be870c22086d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7169ecb8-20be-4c40-8dcb-a93265281538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7169ecb8-20be-4c40-8dcb-a93265281538.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "",
             "colours": [
@@ -62979,7 +62979,7 @@
         },
         {
             "id": "6eba8b50-8137-52bf-8183-c0281cb6d5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38afc2f2-29d2-413d-abee-d8ad9fa85dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38afc2f2-29d2-413d-abee-d8ad9fa85dec.jpg?1",
             "name": "Cauldron Familiar",
             "text": "",
             "colours": [
@@ -63013,7 +63013,7 @@
         },
         {
             "id": "5e1dd046-7840-5940-90e5-3b5a1cdc5b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e853d-05bd-49b2-b7da-c968e24a2400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e853d-05bd-49b2-b7da-c968e24a2400.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "",
             "colours": [
@@ -63048,7 +63048,7 @@
         },
         {
             "id": "032cf0c4-2fb4-5718-b7f7-544773ce1922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f5cfdd-9c48-405d-bfd7-1e20558bbd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f5cfdd-9c48-405d-bfd7-1e20558bbd5a.jpg?1",
             "name": "Magus of the Moon",
             "text": "",
             "colours": [
@@ -63083,7 +63083,7 @@
         },
         {
             "id": "a5ba0303-12aa-55ea-8485-9f564f316d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1546013b-89d7-46b8-bfcb-9d150a50499f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1546013b-89d7-46b8-bfcb-9d150a50499f.jpg?1",
             "name": "Witch's Oven",
             "text": "",
             "colours": [],
@@ -63111,7 +63111,7 @@
         },
         {
             "id": "30c70a6e-f7bc-5df9-a29f-2fe140c69f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1a8780-726b-47f2-904b-a840cfc69d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1a8780-726b-47f2-904b-a840cfc69d76.jpg?1",
             "name": "Doom Whisperer",
             "text": "",
             "colours": [
@@ -63146,7 +63146,7 @@
         },
         {
             "id": "8eacdefe-6d99-5ebf-8675-a29e7bb46674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a7f2f0-3c12-4dba-975e-26d01f3f9c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a7f2f0-3c12-4dba-975e-26d01f3f9c0d.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "",
             "colours": [
@@ -63183,7 +63183,7 @@
         },
         {
             "id": "90f296fa-be75-5c28-9953-0de96a4f6a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac5042c-758a-4bd7-b5cc-370425a067a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac5042c-758a-4bd7-b5cc-370425a067a0.jpg?1",
             "name": "Koma, Cosmos Serpent",
             "text": "",
             "colours": [
@@ -63221,7 +63221,7 @@
         },
         {
             "id": "a0acd9ef-5c03-5ff8-85ab-e084bea036a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce045260-7811-45f7-8cbe-902b1cbc6177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce045260-7811-45f7-8cbe-902b1cbc6177.jpg?1",
             "name": "Mazirek, Kraul Death Priest",
             "text": "",
             "colours": [
@@ -63262,7 +63262,7 @@
         },
         {
             "id": "e1c924fe-4192-5953-b1a8-300c7cdbc31b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e4d5f-48bc-4bd3-bedb-4fad8f843a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e4d5f-48bc-4bd3-bedb-4fad8f843a2e.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "",
             "colours": [
@@ -63302,7 +63302,7 @@
         },
         {
             "id": "5d2e2873-ee7e-5807-b379-3225f46742ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feefb72-f6fa-4897-b2cf-6f14a3e5d466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feefb72-f6fa-4897-b2cf-6f14a3e5d466.jpg?1",
             "name": "Careful Study",
             "text": "",
             "colours": [
@@ -63334,7 +63334,7 @@
         },
         {
             "id": "f3146759-a62e-5cc2-b1c1-0e9d2f610181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e7fd7-a21e-42ae-bad3-b35e4fab62f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e7fd7-a21e-42ae-bad3-b35e4fab62f4.jpg?1",
             "name": "Living End",
             "text": "",
             "colours": [
@@ -63366,7 +63366,7 @@
         },
         {
             "id": "11056ae8-c046-5962-b7ac-68959d620951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90a8649-4303-4915-bb8b-f7bc76712afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90a8649-4303-4915-bb8b-f7bc76712afb.jpg?1",
             "name": "Eladamri's Call",
             "text": "",
             "colours": [
@@ -63400,7 +63400,7 @@
         },
         {
             "id": "ca88caa6-7d85-58cc-b5d8-fde33e3e7f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f2f6fa-80b0-45c8-92f3-b0c2826ffb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f2f6fa-80b0-45c8-92f3-b0c2826ffb06.jpg?1",
             "name": "Boros Charm",
             "text": "",
             "colours": [
@@ -63436,7 +63436,7 @@
         },
         {
             "id": "7b2361fb-7fa7-5bf2-9ce1-31836a19e0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19650c4e-d251-4659-ae35-3200cc4acb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19650c4e-d251-4659-ae35-3200cc4acb5d.jpg?1",
             "name": "Unlicensed Hearse",
             "text": "",
             "colours": [],
@@ -63466,7 +63466,7 @@
         },
         {
             "id": "1c961503-d3f6-592b-9a6a-753f839a90e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada30541-faea-45af-853c-de85ff8e251e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada30541-faea-45af-853c-de85ff8e251e.jpg?1",
             "name": "The Mimeoplasm",
             "text": "",
             "colours": [
@@ -63508,7 +63508,7 @@
         },
         {
             "id": "7c970492-d20d-5735-95ac-4ec64642e539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b54349c-d649-4947-8dfa-bcf2aebeab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b54349c-d649-4947-8dfa-bcf2aebeab57.jpg?1",
             "name": "Trickbind",
             "text": "",
             "colours": [
@@ -63540,7 +63540,7 @@
         },
         {
             "id": "0b5769ee-3ed9-5ff4-9ecb-e5dcd27d583a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d30fc-b1a1-45cc-a89a-d2593bf22031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d30fc-b1a1-45cc-a89a-d2593bf22031.jpg?1",
             "name": "Windfall",
             "text": "",
             "colours": [
@@ -63572,7 +63572,7 @@
         },
         {
             "id": "3eb9c1d1-d346-5121-8a42-525d06d15539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388e5b06-fbd0-4238-87e0-5ed44650870d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388e5b06-fbd0-4238-87e0-5ed44650870d.jpg?1",
             "name": "Incarnation Technique",
             "text": "",
             "colours": [
@@ -63604,7 +63604,7 @@
         },
         {
             "id": "4a2e188d-edf7-5c70-872b-b39bc0741c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cce1a-468a-430c-ba24-a60f1151e23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cce1a-468a-430c-ba24-a60f1151e23a.jpg?1",
             "name": "Pernicious Deed",
             "text": "",
             "colours": [
@@ -63638,7 +63638,7 @@
         },
         {
             "id": "2b852c75-67f8-5940-8365-4eab6597c378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e8f6-d68f-480b-9fa3-5205cd6bfc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e8f6-d68f-480b-9fa3-5205cd6bfc83.jpg?1",
             "name": "Fell the Mighty",
             "text": "",
             "colours": [
@@ -63670,7 +63670,7 @@
         },
         {
             "id": "1ad1afd8-8ea9-5b8f-b603-1addb17a7d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b069ede2-dec3-43b3-85ce-b9d60a1e96a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b069ede2-dec3-43b3-85ce-b9d60a1e96a7.jpg?1",
             "name": "Faithless Looting",
             "text": "",
             "colours": [
@@ -63702,7 +63702,7 @@
         },
         {
             "id": "419067bf-5832-5237-b649-05e17060811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1183d4d7-094b-4024-ab1d-23c458cb7e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1183d4d7-094b-4024-ab1d-23c458cb7e71.jpg?1",
             "name": "Goldspan Dragon",
             "text": "",
             "colours": [
@@ -63736,7 +63736,7 @@
         },
         {
             "id": "557722d9-ce1f-5ad7-8e31-d789abe562be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2488c-c252-42a6-b487-c358c16b7ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2488c-c252-42a6-b487-c358c16b7ae1.jpg?1",
             "name": "Reality Shift",
             "text": "",
             "colours": [
@@ -63768,7 +63768,7 @@
         },
         {
             "id": "013cb887-ead5-5e51-976e-2299e274678f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -63800,7 +63800,7 @@
         },
         {
             "id": "09a70481-ee89-5513-81f5-64ba4dbc34c9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -63834,7 +63834,7 @@
         },
         {
             "id": "51e1d30c-03a8-5c1c-be82-ff147d59233d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c17b3-53f6-4f2e-a6a2-36e851f6d001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c17b3-53f6-4f2e-a6a2-36e851f6d001.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -63868,7 +63868,7 @@
         },
         {
             "id": "46b9c36a-03fd-5000-880e-fb01f1702bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfd08aa-0e6b-42e1-aa4a-a2bd09581a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfd08aa-0e6b-42e1-aa4a-a2bd09581a70.jpg?1",
             "name": "Acererak the Archlich",
             "text": "",
             "colours": [
@@ -63905,7 +63905,7 @@
         },
         {
             "id": "acaacfcf-c2cc-5516-a5b8-770cf074cba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f1cd3-e93b-4b59-bcf2-e1c850ef7572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f1cd3-e93b-4b59-bcf2-e1c850ef7572.jpg?1",
             "name": "Xanathar, Guild Kingpin",
             "text": "",
             "colours": [
@@ -63943,7 +63943,7 @@
         },
         {
             "id": "d14c16d1-16b1-5e29-8430-d5282bb5c665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b8a9a2-55d8-4cf8-9912-787bdbc90ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b8a9a2-55d8-4cf8-9912-787bdbc90ebb.jpg?1",
             "name": "Bribery",
             "text": "",
             "colours": [
@@ -63977,7 +63977,7 @@
         },
         {
             "id": "1f029b21-0fdf-5917-ade8-766a480fe040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f141feb-f6c3-4232-9a11-43d81cc8076f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f141feb-f6c3-4232-9a11-43d81cc8076f.jpg?1",
             "name": "Stifle",
             "text": "",
             "colours": [
@@ -64009,7 +64009,7 @@
         },
         {
             "id": "d41d9dcf-407c-560b-8463-1d9480ec4507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256283-be94-4a34-805e-fc17503c7fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256283-be94-4a34-805e-fc17503c7fbd.jpg?1",
             "name": "Delay",
             "text": "",
             "colours": [
@@ -64041,7 +64041,7 @@
         },
         {
             "id": "64ac063a-a346-5a9e-80a2-9720e9d2e9bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bd6ec3-7597-499b-8b69-fe7d50ece069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bd6ec3-7597-499b-8b69-fe7d50ece069.jpg?1",
             "name": "Blood Money",
             "text": "",
             "colours": [
@@ -64073,7 +64073,7 @@
         },
         {
             "id": "0eaa0518-e74a-5fa4-bb6f-21c1c5fc26a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b705171c-8bff-4394-9d4d-084b13b20159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b705171c-8bff-4394-9d4d-084b13b20159.jpg?1",
             "name": "Drown in the Loch",
             "text": "",
             "colours": [
@@ -64109,7 +64109,7 @@
         },
         {
             "id": "db720753-5a36-512f-9305-12af4fadc019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb382d12-88a2-4ace-942b-9c0f87bfbacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb382d12-88a2-4ace-942b-9c0f87bfbacc.jpg?1",
             "name": "Karazikar, the Eye Tyrant",
             "text": "",
             "colours": [
@@ -64147,7 +64147,7 @@
         },
         {
             "id": "b8ff58ea-1641-503a-9dbc-e731c406c51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eba002c-3562-4295-81e4-5f408f1556c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eba002c-3562-4295-81e4-5f408f1556c6.jpg?1",
             "name": "Snuff Out",
             "text": "",
             "colours": [
@@ -64179,7 +64179,7 @@
         },
         {
             "id": "9f250c0d-c409-57a2-b6a4-011efcda2e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b48bd5d8-65f7-42a6-9910-556ad12e8899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b48bd5d8-65f7-42a6-9910-556ad12e8899.jpg?1",
             "name": "Defile",
             "text": "",
             "colours": [
@@ -64211,7 +64211,7 @@
         },
         {
             "id": "4dd84d06-1ea9-5c6a-9087-5043ed064f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149eb8-7935-4e45-8092-6baa2a6fb8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149eb8-7935-4e45-8092-6baa2a6fb8d2.jpg?1",
             "name": "Oubliette",
             "text": "",
             "colours": [
@@ -64243,7 +64243,7 @@
         },
         {
             "id": "cac936f0-0a8f-570e-89b1-7fcffe7a51d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6873b4a8-90cb-4096-922a-4fa23cdec3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6873b4a8-90cb-4096-922a-4fa23cdec3c8.jpg?1",
             "name": "Fling",
             "text": "",
             "colours": [
@@ -64277,7 +64277,7 @@
         },
         {
             "id": "cb159e76-6172-5e2c-9d98-7e8ba76ddd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7eff10-4e4e-44f0-aa2b-f6c0f5e2edb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7eff10-4e4e-44f0-aa2b-f6c0f5e2edb8.jpg?1",
             "name": "Fire Covenant",
             "text": "",
             "colours": [
@@ -64313,7 +64313,7 @@
         },
         {
             "id": "2ee32611-21c6-5f55-9b9b-1b5826b3bb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555f7253-0126-4c3c-a264-877d4c8e005b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555f7253-0126-4c3c-a264-877d4c8e005b.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "",
             "colours": [
@@ -64353,7 +64353,7 @@
         },
         {
             "id": "c6e7403b-1f3f-5d37-8fe2-3dd44e783d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba9d69-0a54-4a58-8d1a-25cca4f452a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba9d69-0a54-4a58-8d1a-25cca4f452a2.jpg?1",
             "name": "Exquisite Blood",
             "text": "",
             "colours": [
@@ -64387,7 +64387,7 @@
         },
         {
             "id": "e489e162-44bc-57eb-9a36-e5d557b46f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a3356c-738e-4dd9-b25a-3f10f923d0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a3356c-738e-4dd9-b25a-3f10f923d0df.jpg?1",
             "name": "Sanguine Bond",
             "text": "",
             "colours": [
@@ -64419,7 +64419,7 @@
         },
         {
             "id": "7653a010-ed28-54cb-97fc-af30f1783a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47aeb51f-dca8-4862-be9a-4a633e43825c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47aeb51f-dca8-4862-be9a-4a633e43825c.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -64455,7 +64455,7 @@
         },
         {
             "id": "0ee6df5e-f32d-5b9d-9eec-c570fcaafbb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad253c0d-c64a-4748-824b-3a999e6d5ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad253c0d-c64a-4748-824b-3a999e6d5ae3.jpg?1",
             "name": "Mortify",
             "text": "",
             "colours": [
@@ -64489,7 +64489,7 @@
         },
         {
             "id": "125d19b1-3fc4-5db0-af97-016c722eb462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6c502-08ba-4c0d-aee9-98ce40058227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6c502-08ba-4c0d-aee9-98ce40058227.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "",
             "colours": [
@@ -64526,7 +64526,7 @@
         },
         {
             "id": "9429d00e-4556-510a-ad63-08cae162ed93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a54c29a-cc7a-4d0e-a427-2d8be0cb1dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a54c29a-cc7a-4d0e-a427-2d8be0cb1dcd.jpg?1",
             "name": "City on Fire",
             "text": "",
             "colours": [
@@ -64558,7 +64558,7 @@
         },
         {
             "id": "201e4912-7e8d-531e-b2ac-e157ee953c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1fe16c-93c3-43a3-80b9-112e82a7321e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1fe16c-93c3-43a3-80b9-112e82a7321e.jpg?1",
             "name": "Stranglehold",
             "text": "",
             "colours": [
@@ -64590,7 +64590,7 @@
         },
         {
             "id": "13dad24b-1baa-5d3d-beba-e3add6bf69c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5746f057-7387-4fa9-aaaa-8f292e79036a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5746f057-7387-4fa9-aaaa-8f292e79036a.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -64622,7 +64622,7 @@
         },
         {
             "id": "f4662b94-8d0c-5194-bf12-07a0829933c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17518e8e-46ad-4730-b10b-b8875c0536b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17518e8e-46ad-4730-b10b-b8875c0536b6.jpg?1",
             "name": "Dolmen Gate",
             "text": "",
             "colours": [],
@@ -64650,7 +64650,7 @@
         },
         {
             "id": "89b4aa42-f221-56b3-93ac-680d52363933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg?1",
             "name": "Kardur, Doomscourge // Kardur, Doomscourge",
             "text": "",
             "colours": [
@@ -64689,7 +64689,7 @@
         },
         {
             "id": "392d6e41-a602-5719-8e35-e0a4f7b430a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg?1",
             "name": "Kardur, Doomscourge // Kardur, Doomscourge",
             "text": "",
             "colours": [
@@ -64728,7 +64728,7 @@
         },
         {
             "id": "fcaa49f4-b93a-5abd-9c97-966492e521bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490d482-535a-4080-bc36-941e2536282b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490d482-535a-4080-bc36-941e2536282b.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "",
             "colours": [
@@ -64760,7 +64760,7 @@
         },
         {
             "id": "de01de0c-605e-5bfd-aa73-d6c81f37794b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026dbfcb-6c83-478b-a790-1a7541c206aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026dbfcb-6c83-478b-a790-1a7541c206aa.jpg?1",
             "name": "Varragoth, Bloodsky Sire",
             "text": "",
             "colours": [
@@ -64797,7 +64797,7 @@
         },
         {
             "id": "a09f0ecc-9c46-5029-a378-8e4ae368134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3459de92-62e8-482c-8241-3addc0a92066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3459de92-62e8-482c-8241-3addc0a92066.jpg?1",
             "name": "Twinflame",
             "text": "",
             "colours": [
@@ -64829,7 +64829,7 @@
         },
         {
             "id": "4234b1d7-ebf3-56d9-a096-fdcce237554e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c3656-5cdd-4be8-a158-5d5801f8e382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c3656-5cdd-4be8-a158-5d5801f8e382.jpg?1",
             "name": "Genesis Chamber",
             "text": "",
             "colours": [],
@@ -64857,7 +64857,7 @@
         },
         {
             "id": "acc35265-be03-5571-ac25-06f40e492291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cfa-c08e-4c38-aeeb-dc6f0693ff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cfa-c08e-4c38-aeeb-dc6f0693ff72.jpg?1",
             "name": "Mana Geyser",
             "text": "",
             "colours": [
@@ -64889,7 +64889,7 @@
         },
         {
             "id": "670e2919-0145-5657-b4fa-2ac40890222a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb6751-1072-4fc0-8b54-836d05950914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb6751-1072-4fc0-8b54-836d05950914.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -64931,7 +64931,7 @@
         },
         {
             "id": "e478762e-f1a7-52eb-9beb-aacfb1c272b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180679fa-b820-4793-8f2e-a2d8791192d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180679fa-b820-4793-8f2e-a2d8791192d5.jpg?1",
             "name": "Fierce Guardianship",
             "text": "",
             "colours": [
@@ -64963,7 +64963,7 @@
         },
         {
             "id": "13a3276f-2ee5-5295-b275-e852afa3812d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6468b6-ac2f-4af5-985f-e9cae5eb2251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6468b6-ac2f-4af5-985f-e9cae5eb2251.jpg?1",
             "name": "Delayed Blast Fireball",
             "text": "",
             "colours": [
@@ -64995,7 +64995,7 @@
         },
         {
             "id": "84efcf29-d327-5693-a695-f8045c9ea4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20e671-9b41-4591-b1ef-2a297411beb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20e671-9b41-4591-b1ef-2a297411beb7.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "",
             "colours": [
@@ -65031,7 +65031,7 @@
         },
         {
             "id": "084501f1-884f-56ab-b879-bcdcde480ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da9358b-cfe4-4e95-9a9e-a236d6373dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da9358b-cfe4-4e95-9a9e-a236d6373dcf.jpg?1",
             "name": "Doom Blade",
             "text": "",
             "colours": [
@@ -65063,7 +65063,7 @@
         },
         {
             "id": "2b0d0c6d-defa-5b95-9386-0974b930ba71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4472b2e-b47a-4bc3-992b-9f8a218594f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4472b2e-b47a-4bc3-992b-9f8a218594f6.jpg?1",
             "name": "Massacre",
             "text": "",
             "colours": [
@@ -65095,7 +65095,7 @@
         },
         {
             "id": "727091a2-0fc3-5e84-95bc-699135507ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fc8dff-4d26-4dfd-b279-d06e10cba54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fc8dff-4d26-4dfd-b279-d06e10cba54f.jpg?1",
             "name": "Torment of Hailfire",
             "text": "",
             "colours": [
@@ -65127,7 +65127,7 @@
         },
         {
             "id": "8d73cb36-f526-5c17-913b-d2bbec2b069a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad3c3-da9c-4233-9d7c-2c786e860dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad3c3-da9c-4233-9d7c-2c786e860dd3.jpg?1",
             "name": "Ruination",
             "text": "",
             "colours": [
@@ -65159,7 +65159,7 @@
         },
         {
             "id": "9db1ea4e-b76d-52bc-b5d0-4eb23fafa8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff7be28-275e-4a02-a4c6-f3040d64b9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff7be28-275e-4a02-a4c6-f3040d64b9a8.jpg?1",
             "name": "Mogis, God of Slaughter",
             "text": "",
             "colours": [
@@ -65200,7 +65200,7 @@
         },
         {
             "id": "dd8599d9-81aa-5717-a2f3-cc516c80a07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08460-3043-4de7-b8ae-92f238318844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08460-3043-4de7-b8ae-92f238318844.jpg?1",
             "name": "Garruk, Caller of Beasts",
             "text": "",
             "colours": [
@@ -65236,7 +65236,7 @@
         },
         {
             "id": "9dc5ca13-82c7-5452-bbad-c08e7d5ea957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb16341a-f793-4b0e-b4ef-3fc56aae3807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb16341a-f793-4b0e-b4ef-3fc56aae3807.jpg?1",
             "name": "Rograkh, Son of Rohgahh",
             "text": "",
             "colours": [
@@ -65273,7 +65273,7 @@
         },
         {
             "id": "148822d3-41c7-587c-8fae-a758dc97425d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dc44e-d207-4330-aa41-ba5683450e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dc44e-d207-4330-aa41-ba5683450e60.jpg?1",
             "name": "Geralf's Messenger",
             "text": "",
             "colours": [
@@ -65307,7 +65307,7 @@
         },
         {
             "id": "b492a5d3-552d-5d45-b687-568c0d5f4589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76435d9-beab-4419-95f9-afc8b5c8f3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76435d9-beab-4419-95f9-afc8b5c8f3f1.jpg?1",
             "name": "Empress Galina",
             "text": "",
             "colours": [
@@ -65344,7 +65344,7 @@
         },
         {
             "id": "4bd3715b-c984-57b6-8522-8a79dde1b564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcb20-219c-4175-8600-a946d83210e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcb20-219c-4175-8600-a946d83210e0.jpg?1",
             "name": "Sisay, Weatherlight Captain",
             "text": "",
             "colours": [
@@ -65387,7 +65387,7 @@
         },
         {
             "id": "43a4c626-e28a-58a9-a724-de287a1bd7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3271da-cc20-48c2-ac61-b64a8e47f9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3271da-cc20-48c2-ac61-b64a8e47f9e5.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -65421,7 +65421,7 @@
         },
         {
             "id": "a691ae77-149f-5aac-8b1d-b95d6f4935f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba1cf83-e13d-401e-b76f-b12a51b307f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba1cf83-e13d-401e-b76f-b12a51b307f9.jpg?1",
             "name": "Viscera Seer",
             "text": "",
             "colours": [
@@ -65455,7 +65455,7 @@
         },
         {
             "id": "f5e43c62-7cab-50dc-834c-9e552c029f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aceb1db-c48f-4985-a0b8-132fe12a5021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aceb1db-c48f-4985-a0b8-132fe12a5021.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65490,7 +65490,7 @@
         },
         {
             "id": "3f69e09e-11e0-5299-9384-811c264a97ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce18f1-0eff-4354-97b8-cb58295f4865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce18f1-0eff-4354-97b8-cb58295f4865.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65525,7 +65525,7 @@
         },
         {
             "id": "65b923f1-61cc-5d2c-a2c5-4a7877ac8263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f51f4d-eb6d-4503-b9a4-559db1b9b16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f51f4d-eb6d-4503-b9a4-559db1b9b16f.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65560,7 +65560,7 @@
         },
         {
             "id": "0ceb2be9-c70c-5370-976a-56308634f813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df94cc3-fed3-493d-9aa5-c85d6a2aeb05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df94cc3-fed3-493d-9aa5-c85d6a2aeb05.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65595,7 +65595,7 @@
         },
         {
             "id": "01a9f60d-207a-56e2-9d39-9734ce7ba567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255dcc91-7b3d-4b58-85f3-b21be805966e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255dcc91-7b3d-4b58-85f3-b21be805966e.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -65629,7 +65629,7 @@
         },
         {
             "id": "7c4596d5-af5c-5e16-802e-38e3cee1fdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -65663,7 +65663,7 @@
         },
         {
             "id": "1f4c2ec0-a94c-5ff4-88aa-28a349501426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d03f760-6e5a-404e-beb9-07d78a53364d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d03f760-6e5a-404e-beb9-07d78a53364d.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65697,7 +65697,7 @@
         },
         {
             "id": "50fcb456-82d6-5452-8318-8a58a6ee5f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c637c4-c1cc-4852-9561-78add390ef52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c637c4-c1cc-4852-9561-78add390ef52.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65731,7 +65731,7 @@
         },
         {
             "id": "7f4dc7cc-dad3-572a-9185-406ca1c9d075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a121c039-ec93-4383-bdb5-bc7acf9e1a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a121c039-ec93-4383-bdb5-bc7acf9e1a05.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65765,7 +65765,7 @@
         },
         {
             "id": "327bd47a-e2c3-515e-8d20-325a6a6ddfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7940307-6ae3-423e-b752-a72acddb9087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7940307-6ae3-423e-b752-a72acddb9087.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65799,7 +65799,7 @@
         },
         {
             "id": "81a3c48b-c87b-51f3-9a71-d4bf0838290c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b236f7a-62b0-4605-9328-6994ca65909b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b236f7a-62b0-4605-9328-6994ca65909b.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65833,7 +65833,7 @@
         },
         {
             "id": "537327a8-6f4c-529c-bdbc-21673381bd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e752ca8-5404-4898-8b75-a0848e3850f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e752ca8-5404-4898-8b75-a0848e3850f2.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -65863,7 +65863,7 @@
         },
         {
             "id": "af354f52-13cb-522d-89b0-29ff3c182502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2311cf5-ab73-48d6-9fa0-54c19a7ae98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2311cf5-ab73-48d6-9fa0-54c19a7ae98f.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -65897,7 +65897,7 @@
         },
         {
             "id": "8b60170d-7935-583e-82ca-408c9c80ce9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99cc0a4-4868-47f3-bd1d-f46b7cb74650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99cc0a4-4868-47f3-bd1d-f46b7cb74650.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -65932,7 +65932,7 @@
         },
         {
             "id": "d76af2c5-2e22-582a-bd84-97dc25d3601b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c52125-929a-4e03-a955-d55ae34a905b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c52125-929a-4e03-a955-d55ae34a905b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -65963,7 +65963,7 @@
         },
         {
             "id": "fe03a7b1-bbc4-5e44-89ec-3a2aab7e4cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb668a-c8f8-491f-8534-08a7f94baf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb668a-c8f8-491f-8534-08a7f94baf19.jpg?1",
             "name": "Icingdeath, Frost Tongue",
             "text": "",
             "colours": [
@@ -65999,7 +65999,7 @@
         },
         {
             "id": "993318ee-4e8f-58a6-b55f-894b9310a3d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88aa73-baca-49c2-a6c3-0a1624b6078b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88aa73-baca-49c2-a6c3-0a1624b6078b.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -66034,7 +66034,7 @@
         },
         {
             "id": "0976687a-e6ed-583f-a2ec-34c328ef73d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e82b125-df5e-4e5f-8759-51c32c447c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e82b125-df5e-4e5f-8759-51c32c447c1d.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -66069,7 +66069,7 @@
         },
         {
             "id": "11aae81c-fac5-5132-b358-737931d73dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cad0da-ac47-4324-9810-cf2ae94fd5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cad0da-ac47-4324-9810-cf2ae94fd5e0.jpg?1",
             "name": "Hydra",
             "text": "",
             "colours": [
@@ -66103,7 +66103,7 @@
         },
         {
             "id": "80ba4741-7769-5d02-8088-a30b8b8a6474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089874c5-4f1e-4d03-a4c5-50f6ac0814dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089874c5-4f1e-4d03-a4c5-50f6ac0814dd.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -66137,7 +66137,7 @@
         },
         {
             "id": "a8d15e9b-675f-5c44-a604-70c49d17b8bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9b18e5-d842-4114-b395-ff5dd42c94d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9b18e5-d842-4114-b395-ff5dd42c94d9.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -66171,7 +66171,7 @@
         },
         {
             "id": "ce24f27b-16b5-596b-b810-805a9384991b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8150833a-9c83-4d00-ae2f-470088700fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8150833a-9c83-4d00-ae2f-470088700fdb.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -66206,7 +66206,7 @@
         },
         {
             "id": "73389c20-54f0-5c52-884b-3deff0fab42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e134190e-772a-458d-b0e1-633154f16809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e134190e-772a-458d-b0e1-633154f16809.jpg?1",
             "name": "Egg",
             "text": "",
             "colours": [
@@ -66240,7 +66240,7 @@
         },
         {
             "id": "2920e221-5ed1-517f-a049-cc6acbeb6f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b36476-71f3-4128-81a6-726ed18c0023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b36476-71f3-4128-81a6-726ed18c0023.jpg?1",
             "name": "Egg",
             "text": "",
             "colours": [
@@ -66274,7 +66274,7 @@
         },
         {
             "id": "e772badb-41b9-5571-a36c-15f08b6e5a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7c6d71-c575-4c1b-a161-a4d4186ea9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7c6d71-c575-4c1b-a161-a4d4186ea9c6.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -66305,7 +66305,7 @@
         },
         {
             "id": "b038f379-b2fa-52ba-b9f9-b689ab164edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d07ad5-0701-4696-91fd-87451997ef23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d07ad5-0701-4696-91fd-87451997ef23.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -66339,7 +66339,7 @@
         },
         {
             "id": "d455d547-bb4c-5999-8561-b7cbe0ac2871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53bf06-f681-4d5c-b303-cc7c050f5b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53bf06-f681-4d5c-b303-cc7c050f5b01.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -66373,7 +66373,7 @@
         },
         {
             "id": "838671eb-24c5-5246-b969-5190055b6e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ffdaf6-472e-46be-a74a-4be985b29df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ffdaf6-472e-46be-a74a-4be985b29df4.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -66408,7 +66408,7 @@
         },
         {
             "id": "7499c3c7-8227-53a6-828e-788bcde1fa47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd2627-3118-4643-83e2-4637f8821ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd2627-3118-4643-83e2-4637f8821ab4.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -66445,7 +66445,7 @@
         },
         {
             "id": "5ea170f8-44cc-5e15-b536-99d283ab936a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bae2c8-9d6d-42d4-a63b-c1133d772fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bae2c8-9d6d-42d4-a63b-c1133d772fec.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -66476,7 +66476,7 @@
         },
         {
             "id": "792e05f4-14b4-5f1f-b788-5a7b60d63d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3053e02b-7157-4fb6-9427-d64a68ea29c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3053e02b-7157-4fb6-9427-d64a68ea29c3.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/SNC.json
+++ b/Assets/Resources/Sets/SNC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a7104e86-1f2e-5cf1-9664-032394204ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cce4d3-e6d8-4c6f-9d9c-c0a8a607a42f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cce4d3-e6d8-4c6f-9d9c-c0a8a607a42f.jpg?1",
             "name": "Angelic Observer",
             "text": "This spell costs {1} less to cast for each Citizen you control.\nFlying",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "75b86b4c-f99c-5145-9743-09980bcf8e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a46af75-3880-4141-b26e-19834d67e7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a46af75-3880-4141-b26e-19834d67e7a8.jpg?1",
             "name": "Backup Agent",
             "text": "When Backup Agent enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "e28e6e49-36ed-5f0b-b261-95d36871aa0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5615a2-03a2-41f4-ab3b-de5e60d1504e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5615a2-03a2-41f4-ab3b-de5e60d1504e.jpg?1",
             "name": "Ballroom Brawlers",
             "text": "Whenever Ballroom Brawlers attacks, Ballroom Brawlers and up to one other target creature you control both gain your choice of first strike or lifelink until end of turn.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "671a76bb-def5-5dfd-9c42-d7ea3e6343fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2069310a-9fb6-41b7-bbd5-849e3df05632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2069310a-9fb6-41b7-bbd5-849e3df05632.jpg?1",
             "name": "Boon of Safety",
             "text": "Put a shield counter on target creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nScry 1.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "82c7749f-f290-518f-a8fc-5d5321bb69df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7867f2d-e89d-429f-9ab8-5337b40b4d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7867f2d-e89d-429f-9ab8-5337b40b4d8d.jpg?1",
             "name": "Brokers Initiate",
             "text": "{4}{GW}: Brokers Initiate has base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "1e65ce62-5937-5205-bace-3eb263767a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9ac05f-f47c-4569-a06e-793d28cbb936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9ac05f-f47c-4569-a06e-793d28cbb936.jpg?1",
             "name": "Buy Your Silence",
             "text": "Exile target nonland permanent. Its controller creates a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "7da72ad5-47b5-55e4-ba63-7b3f3c807624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c0cecd-c718-4238-9164-ebb6c20fc99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c0cecd-c718-4238-9164-ebb6c20fc99c.jpg?1",
             "name": "A-Buy Your Silence",
             "text": "",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "343204bb-39ed-5d1a-8b36-a3961fa13527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afb5c5c-06e0-4b11-ad07-aef7be6e2cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afb5c5c-06e0-4b11-ad07-aef7be6e2cd4.jpg?1",
             "name": "Celebrity Fencer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, put a +1/+1 counter on Celebrity Fencer.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "e3d3f0b7-048d-54ce-85b5-30908478d1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9428ae-9c59-4cac-a29b-039a34cfdb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9428ae-9c59-4cac-a29b-039a34cfdb6d.jpg?1",
             "name": "A-Celebrity Fencer",
             "text": "",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "5a5817f9-934b-5141-8321-0fe3463e2b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68896f5-1e13-400a-a327-b6c6f00858b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68896f5-1e13-400a-a327-b6c6f00858b7.jpg?1",
             "name": "Citizen's Crowbar",
             "text": "When Citizen's Crowbar enters the battlefield, create a 1/1 green and white Citizen creature token, then attach Citizen's Crowbar to it.\nEquipped creature gets +1/+1 and has \"{W}, {T}, Sacrifice Citizen's Crowbar: Destroy target artifact or enchantment.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "722bf00d-695f-53e0-8355-da295a41b23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce9c33-4ab3-43c9-b6bc-ee2d40d8f9b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce9c33-4ab3-43c9-b6bc-ee2d40d8f9b6.jpg?1",
             "name": "Dapper Shieldmate",
             "text": "Dapper Shieldmate enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nAs long as it's your turn, Dapper Shieldmate gets +2/+0.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "307d92d6-f4fb-566c-8507-fc075b2029ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53c1898-9107-4bf8-b249-d0502fb9596d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53c1898-9107-4bf8-b249-d0502fb9596d.jpg?1",
             "name": "Depopulate",
             "text": "Each player who controls a multicolored creature draws a card. Then destroy all creatures.",
             "colours": [
@@ -413,7 +413,7 @@
         },
         {
             "id": "eebb0d09-cffe-5da6-bbba-a9519c5153b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c606af0-f3d1-44a4-b24e-ee1263569b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c606af0-f3d1-44a4-b24e-ee1263569b1f.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "+1: Choose up to one target creature. Put a +1/+1 counter and a counter from among flying, first strike, lifelink, or vigilance on it.\n\u22123: Look at the top seven cards of your library. You may put a permanent card with mana value 3 or less from among them onto the battlefield with a shield counter on it. Put the rest on the bottom of your library in a random order.\n\u22127: Create five 3/3 white Angel creature tokens with flying.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "dadfde8d-5774-5e36-a201-76032a5c85ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404d6c7-0b65-4c6a-b141-9dffbeb120db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404d6c7-0b65-4c6a-b141-9dffbeb120db.jpg?1",
             "name": "Extraction Specialist",
             "text": "Lifelink\nWhen Extraction Specialist enters the battlefield, return target creature card with mana value 2 or less from your graveyard to the battlefield. That creature can't attack or block for as long as you control Extraction Specialist.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "c6da916a-a190-5813-9eba-3d8729b6ddde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290347b9-d3cc-4882-8da6-9d8b8677f276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290347b9-d3cc-4882-8da6-9d8b8677f276.jpg?1",
             "name": "Gathering Throng",
             "text": "When Gathering Throng enters the battlefield, you may search your library for any number of cards named Gathering Throng, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "71b42f72-5bfb-5d4f-8563-3e3b7f0c282f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae077bd-fc8d-44d7-8c75-8dc8699c168e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae077bd-fc8d-44d7-8c75-8dc8699c168e.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters the battlefield with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "347106a1-4241-5296-bca3-2fb9aa6a0efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee79399-715c-4c46-9fa1-e76b1087f009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee79399-715c-4c46-9fa1-e76b1087f009.jpg?1",
             "name": "Halo Fountain",
             "text": "{W}, {T}, Untap a tapped creature you control: Create a 1/1 green and white Citizen creature token.\n{W}{W}, {T}, Untap two tapped creatures you control: Draw a card.\n{W}{W}{W}{W}{W}, {T}, Untap fifteen tapped creatures you control: You win the game.",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "e254e687-4541-5586-ad91-72224164d752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e74a99-11d9-40b8-b1d6-8f68a3f490fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e74a99-11d9-40b8-b1d6-8f68a3f490fa.jpg?1",
             "name": "Hold for Ransom",
             "text": "Enchant creature\nEnchanted creature can't attack or block and has \"{7}: Hold for Ransom's controller sacrifices it and draws a card. Activate only as a sorcery.\"",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "8030f1a5-9a25-529b-91e1-1da1de9f32b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba20d9-9423-4114-8734-1dac307483c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba20d9-9423-4114-8734-1dac307483c8.jpg?1",
             "name": "Illuminator Virtuoso",
             "text": "Double strike\nWhenever Illuminator Virtuoso becomes the target of a spell you control, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "1ee98c19-e6f5-5ca1-bc21-6e7bd320dac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d9da1d-8678-4252-b0f8-9960795642f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d9da1d-8678-4252-b0f8-9960795642f0.jpg?1",
             "name": "Inspiring Overseer",
             "text": "Flying\nWhen Inspiring Overseer enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "496dede2-f95a-5f81-bfe5-437a8bd4161e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b0b9a3-8f50-4fba-9978-409f3369afa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b0b9a3-8f50-4fba-9978-409f3369afa6.jpg?1",
             "name": "Kill Shot",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "4f6724c4-8ed5-5cc4-af10-70a249a16394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b00bbec-61d0-464c-bf82-4ecf5ddb3451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b00bbec-61d0-464c-bf82-4ecf5ddb3451.jpg?1",
             "name": "Knockout Blow",
             "text": "This spell costs {2} less to cast if it targets a red creature.\nKnockout Blow deals 4 damage to target attacking or blocking creature and you gain 2 life.",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "4908e50a-c26b-5a9f-b544-cc9495be7082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce08e8-340b-4a67-9884-4cbf01d63790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce08e8-340b-4a67-9884-4cbf01d63790.jpg?1",
             "name": "Mage's Attendant",
             "text": "When Mage's Attendant enters the battlefield, create a 1/1 blue Wizard creature token with \"{1}, Sacrifice this creature: Counter target noncreature spell unless its controller pays {1}.\"",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "a00bb75a-c708-5724-975b-60a6e5e09523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cb742-0ba7-4795-9772-25d4db0bc4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cb742-0ba7-4795-9772-25d4db0bc4ce.jpg?1",
             "name": "Mysterious Limousine",
             "text": "Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2",
             "colours": [
@@ -838,7 +838,7 @@
         },
         {
             "id": "356cd720-c4ae-5e8b-a8f9-ffe2be175802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce30c92-c5f2-45d2-819e-177390bc26f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce30c92-c5f2-45d2-819e-177390bc26f5.jpg?1",
             "name": "Patch Up",
             "text": "Return up to three target creature cards with total mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "ce8f1063-d08f-56b5-993d-a16e58af6130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206c8529-56df-4ed9-97bc-6c9b5e2a04c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206c8529-56df-4ed9-97bc-6c9b5e2a04c4.jpg?1",
             "name": "Rabble Rousing",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWhenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens. Then if you control ten or more creatures, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "8bcd2834-fd16-5590-a313-a68cc4fc85e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36e25fa-9ab4-4832-afb9-827c4b6ba732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36e25fa-9ab4-4832-afb9-827c4b6ba732.jpg?1",
             "name": "Raffine's Guidance",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nYou may cast Raffine's Guidance from your graveyard by paying {2}{W} rather than paying its mana cost.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "cd1a95c4-5e7a-5f97-b347-2fd46fa268f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e64ff87-2099-4360-94f6-164277b7b514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e64ff87-2099-4360-94f6-164277b7b514.jpg?1",
             "name": "Raffine's Informant",
             "text": "When Raffine's Informant enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -973,7 +973,7 @@
         },
         {
             "id": "acc4960c-14eb-56cf-bd63-6ee8a76611f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b597b3-5792-49e4-9bcb-74012e4e9cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b597b3-5792-49e4-9bcb-74012e4e9cb6.jpg?1",
             "name": "Refuse to Yield",
             "text": "Target creature gets +2/+7 until end of turn. Untap it.",
             "colours": [
@@ -1005,7 +1005,7 @@
         },
         {
             "id": "8037d08d-4224-5a07-9892-a65f01c87118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e010b11-8f3e-4792-afe4-0a376650b6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e010b11-8f3e-4792-afe4-0a376650b6c4.jpg?1",
             "name": "Revelation of Power",
             "text": "Target creature gets +2/+2 until end of turn. If it has a counter on it, it also gains flying and lifelink until end of turn.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "cd389091-91c0-5a44-82af-77a21e6326eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b87807-cac5-4e33-a8ed-a9ced0cd83a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b87807-cac5-4e33-a8ed-a9ced0cd83a1.jpg?1",
             "name": "Rumor Gatherer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, scry 1. If this is the second time this ability has resolved this turn, draw a card instead.",
             "colours": [
@@ -1074,7 +1074,7 @@
         },
         {
             "id": "3e8af920-fe10-5fae-bf77-77432036d24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfdab77-d7c3-4e6a-bb4b-55153bd2fd4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfdab77-d7c3-4e6a-bb4b-55153bd2fd4d.jpg?1",
             "name": "Sanctuary Warden",
             "text": "Flying\nSanctuary Warden enters the battlefield with two shield counters on it.\nWhenever Sanctuary Warden enters the battlefield or attacks, you may remove a counter from a creature or planeswalker you control. If you do, draw a card and create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "2309e6ac-ddd4-5f24-a022-e29fa5ad6d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e01fa9-9127-4250-94f1-39e71cc3c2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e01fa9-9127-4250-94f1-39e71cc3c2bc.jpg?1",
             "name": "Sky Crier",
             "text": "Flying, lifelink\n{3}{W}: You and target opponent each draw a card.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "074c9700-cc2b-5052-980b-62ff00fad23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e014d9d0-e6e1-4afb-b94f-b927a09b76c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e014d9d0-e6e1-4afb-b94f-b927a09b76c1.jpg?1",
             "name": "Speakeasy Server",
             "text": "Flying\nWhen Speakeasy Server enters the battlefield, you gain 1 life for each other creature you control.",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "7b490074-287d-5f47-aa06-a26ec2f1e77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77ea3bd-0d52-4d36-9d73-2b9d68c01e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77ea3bd-0d52-4d36-9d73-2b9d68c01e88.jpg?1",
             "name": "A-Speakeasy Server",
             "text": "",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "6937a799-34f5-59e1-914d-06fdcb6e0eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8713498f-a467-4a11-9de2-53a1bbd0b18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8713498f-a467-4a11-9de2-53a1bbd0b18b.jpg?1",
             "name": "Swooping Protector",
             "text": "Flash\nFlying\nSwooping Protector enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "220c642a-e0ba-5680-b27e-890d7f932cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832c0b8-aefa-459c-8de8-aa32400612cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832c0b8-aefa-459c-8de8-aa32400612cd.jpg?1",
             "name": "All-Seeing Arbiter",
             "text": "Flying\nWhenever All-Seeing Arbiter enters the battlefield or attacks, draw two cards, then discard a card.\nWhenever you discard a card, target creature an opponent controls gets -X/-0 until your next turn, where X is the number of different mana values among cards in your graveyard.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "7fda4e29-3413-55bc-bf7b-bab8fd1326df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3a94c8-a7eb-4f05-8d48-d42e5129b09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3a94c8-a7eb-4f05-8d48-d42e5129b09a.jpg?1",
             "name": "Backstreet Bruiser",
             "text": "Defender\nAs long as there are two or more counters among creatures you control, Backstreet Bruiser can attack as though it didn't have defender.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "61150275-1274-59ea-b941-68fff4ae0fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4a54bd-5598-4313-b5e6-29fd38da016a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4a54bd-5598-4313-b5e6-29fd38da016a.jpg?1",
             "name": "Brokers Veteran",
             "text": "When Brokers Veteran dies, put a shield counter on target creature you control. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "7aa5b644-7034-530b-b103-75b67e06d648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9edf04-681d-45f9-975f-704154040506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9edf04-681d-45f9-975f-704154040506.jpg?1",
             "name": "Case the Joint",
             "text": "Draw two cards, then look at the top card of each player's library.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "1508473b-5b9d-50be-a1dd-a2843c8473ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa1331-3a2b-4c1e-a1ab-b53756141b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa1331-3a2b-4c1e-a1ab-b53756141b35.jpg?1",
             "name": "A-Case the Joint",
             "text": "",
             "colours": [
@@ -1420,7 +1420,7 @@
         },
         {
             "id": "c9f92aea-0875-50dc-a790-f1ef2c135cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31184dd0-4080-44c1-a3e0-f6d10a4d1fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31184dd0-4080-44c1-a3e0-f6d10a4d1fcb.jpg?1",
             "name": "Cut Your Losses",
             "text": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nTarget player mills half their library, rounded down.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "180a3f6e-7a22-5e86-8ed0-dcd778ab8100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492aa24c-61c4-48bc-b7b7-f423be2662da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492aa24c-61c4-48bc-b7b7-f423be2662da.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with mana value 4 or greater.",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "1e4818f5-b4d4-5c2d-a2d6-622b07fcf7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e530ea-ba51-4f7a-bf56-b657a48e86ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e530ea-ba51-4f7a-bf56-b657a48e86ae.jpg?1",
             "name": "Echo Inspector",
             "text": "Flying\nWhen Echo Inspector enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "ff5b09eb-02bf-562a-8e6a-9460d4d303aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d23407-9fe0-4cbf-b4b5-bc1e132c36e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d23407-9fe0-4cbf-b4b5-bc1e132c36e4.jpg?1",
             "name": "Errant, Street Artist",
             "text": "Flash\nDefender, haste\n{1}{U}, {T}: Copy target spell you control that wasn't cast. You may choose new targets for the copy.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "caf6d7bc-88fb-5c97-91ca-4a76b7cf4804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c629217f-4a10-4d92-86f8-22dc4067a724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c629217f-4a10-4d92-86f8-22dc4067a724.jpg?1",
             "name": "Even the Score",
             "text": "This spell costs {U}{U}{U} less to cast if an opponent has drawn four or more cards this turn.\nDraw X cards.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "48a7676a-7ad4-5806-b1f9-c04d04b846a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515329a-0738-4b23-a326-ff417f47da77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515329a-0738-4b23-a326-ff417f47da77.jpg?1",
             "name": "Expendable Lackey",
             "text": "{1}{U}, Exile Expendable Lackey from your graveyard: Create a 1/1 blue Fish creature token with \"This creature can't be blocked.\" Activate only as a sorcery.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "a9730b95-1875-5f7b-8c95-55f18f02d468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7645247b-e65a-4912-ac22-e6a0fa806dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7645247b-e65a-4912-ac22-e6a0fa806dd7.jpg?1",
             "name": "Faerie Vandal",
             "text": "Flash\nFlying\nWhenever you draw your second card each turn, put a +1/+1 counter on Faerie Vandal.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "4ece1119-11db-53f4-9279-b441769e695a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af30b3-d4b0-453a-891f-4506e06b5e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af30b3-d4b0-453a-891f-4506e06b5e14.jpg?1",
             "name": "Hypnotic Grifter",
             "text": "{3}: Hypnotic Grifter connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "156f8195-a3ce-5faa-94a0-5897134708ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea4b5bc-18a4-45db-a56a-ab3f8bd2fb0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea4b5bc-18a4-45db-a56a-ab3f8bd2fb0d.jpg?1",
             "name": "Ledger Shredder",
             "text": "Flying\nWhenever a player casts their second spell each turn, Ledger Shredder connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "d5d6a8fe-9585-591d-9333-c7425f5e3333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7424b6-b56a-47b7-8204-294d3dca925f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7424b6-b56a-47b7-8204-294d3dca925f.jpg?1",
             "name": "A Little Chat",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nLook at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "7d600701-4251-52c7-b9c4-2278b4d305e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaebea6-9e3f-4ac7-abe1-5445912f5b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaebea6-9e3f-4ac7-abe1-5445912f5b44.jpg?1",
             "name": "Majestic Metamorphosis",
             "text": "Until end of turn, target artifact or creature becomes a 4/4 Angel artifact creature and gains flying.\nDraw a card.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "dbe3d4da-c552-519a-85bd-8984ee7a24d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d6a21-ea77-484b-9e3a-1bd49806f907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d6a21-ea77-484b-9e3a-1bd49806f907.jpg?1",
             "name": "Make Disappear",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nCounter target spell unless its controller pays {2}.",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "78f4a2de-f0dd-54b8-9c7a-07351ce69198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67774a11-158b-437c-ac16-2d42fbb5c223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67774a11-158b-437c-ac16-2d42fbb5c223.jpg?1",
             "name": "Obscura Initiate",
             "text": "Flying\n{1}{WB}: Obscura Initiate gains lifelink until end of turn.",
             "colours": [
@@ -1870,7 +1870,7 @@
         },
         {
             "id": "1353cfed-ac40-52af-8f91-c34f51be1573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d349f3-5be2-4b1f-a4c3-ba94822cf0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d349f3-5be2-4b1f-a4c3-ba94822cf0cf.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "b2f0d4cf-2718-5194-82e8-76d809d964a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2201ade5-8add-49f2-8045-ae351aaf061c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2201ade5-8add-49f2-8045-ae351aaf061c.jpg?1",
             "name": "Out of the Way",
             "text": "This spell costs {2} less to cast if it targets a green permanent.\nReturn target nonland permanent an opponent controls to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1936,7 +1936,7 @@
         },
         {
             "id": "9ce0a878-2ded-5335-b81a-d2f5956949b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e04834-7335-4b25-bedf-b7739c5c3aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e04834-7335-4b25-bedf-b7739c5c3aad.jpg?1",
             "name": "Psionic Snoop",
             "text": "Flash\nWhen Psionic Snoop enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "85646f6e-b800-53a3-b8f7-27f34cb6ae05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91372333-e02e-46ed-af2f-ea8b32a3e0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91372333-e02e-46ed-af2f-ea8b32a3e0fa.jpg?1",
             "name": "A-Psionic Snoop",
             "text": "",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "a8321a97-949c-52ec-be25-aae0b0662501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b90ca-1012-4132-bf2f-bc3825ed16ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b90ca-1012-4132-bf2f-bc3825ed16ac.jpg?1",
             "name": "Psychic Pickpocket",
             "text": "When Psychic Pickpocket enters the battlefield, it connives. When it connives this way, return up to one target nonland permanent to its owner's hand. (To have a creature connive, draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "4a20bda5-2630-57ea-8f4e-4e4e9f027154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e69ba61-8c16-4112-9601-fac978b88667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e69ba61-8c16-4112-9601-fac978b88667.jpg?1",
             "name": "Public Enemy",
             "text": "Enchant creature\nAll creatures attack enchanted creature's controller each combat if able.\nWhen enchanted creature dies, draw a card.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "91b7b1a3-fb87-509e-b77d-3cad8f1cc048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c75011-1cad-49eb-b104-7223c2e3b1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c75011-1cad-49eb-b104-7223c2e3b1e0.jpg?1",
             "name": "A-Public Enemy",
             "text": "",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "d637112a-299a-5989-a3b7-19b4d96dd175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf9152-da16-4289-9a2d-331e7b9cb839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf9152-da16-4289-9a2d-331e7b9cb839.jpg?1",
             "name": "Reservoir Kraken",
             "text": "Trample, ward {2}\nAt the beginning of each combat, if Reservoir Kraken is untapped, any opponent may tap an untapped creature they control. If they do, tap Reservoir Kraken and create a 1/1 blue Fish creature token with \"This creature can't be blocked.\"",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "3fe960c9-e079-574b-96cf-f43aa09caf65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a84781-b40c-41e0-a0b9-86e466c9b12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a84781-b40c-41e0-a0b9-86e466c9b12d.jpg?1",
             "name": "Rooftop Nuisance",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "b114d714-7246-589d-838c-12feebe9fb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf00112-0844-49db-a061-d0eb488de68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf00112-0844-49db-a061-d0eb488de68a.jpg?1",
             "name": "Run Out of Town",
             "text": "The owner of target nonland permanent puts it on the top or bottom of their library.",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "44909dd6-fb99-5952-8412-2e1340b996fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c155be9-8432-4e35-b586-96b6339d27ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c155be9-8432-4e35-b586-96b6339d27ae.jpg?1",
             "name": "Security Bypass",
             "text": "Enchant creature\nAs long as enchanted creature is attacking alone, it can't be blocked.\nEnchanted creature has \"Whenever this creature deals combat damage to a player, it connives.\" (Its controller draws a card, then discards a card. If they discarded a nonland card, they put a +1/+1 counter on this creature.)",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "616e28b1-2832-5123-be09-83351badb2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06ac58b-6d72-4eb4-a1c9-61b5314c7769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06ac58b-6d72-4eb4-a1c9-61b5314c7769.jpg?1",
             "name": "Sewer Crocodile",
             "text": "{3}{U}: Sewer Crocodile can't be blocked this turn. This ability costs {3} less to activate if there are five or more mana values among cards in your graveyard.",
             "colours": [
@@ -2275,7 +2275,7 @@
         },
         {
             "id": "1e12a7c6-8515-58d9-9537-02d4f90822e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c9b674-b13e-4ba0-8eef-067e62db1b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c9b674-b13e-4ba0-8eef-067e62db1b8a.jpg?1",
             "name": "A-Sewer Crocodile",
             "text": "",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "2379daf8-90aa-5d70-9a4c-0c6c7f3e271a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3742a0fb-4b86-49d6-b6fb-bd6a42fa1bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3742a0fb-4b86-49d6-b6fb-bd6a42fa1bcb.jpg?1",
             "name": "Sleep with the Fishes",
             "text": "Enchant creature\nWhen Sleep with the Fishes enters the battlefield, tap enchanted creature and you create a 1/1 blue Fish creature token with \"This creature can't be blocked.\"\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "134e52c9-d7ec-5e1f-9795-a3f65067b93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725f4c4-fad7-460e-b86c-ff81674f0980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725f4c4-fad7-460e-b86c-ff81674f0980.jpg?1",
             "name": "Slip Out the Back",
             "text": "Put a +1/+1 counter on target creature. It phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "99f04d72-2ec0-5337-b21b-c9d8df150cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecec953-ab86-409b-b618-04bb07ff3eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecec953-ab86-409b-b618-04bb07ff3eac.jpg?1",
             "name": "Undercover Operative",
             "text": "You may have Undercover Operative enter the battlefield as a copy of any creature on the battlefield, except it enters with a shield counter on it if you control that creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "1e2d27db-506e-5e2e-adb9-72a38b8e6c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec36ec-1a9c-41db-b304-c23286a4d182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec36ec-1a9c-41db-b304-c23286a4d182.jpg?1",
             "name": "Wingshield Agent",
             "text": "Wingshield Agent enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever Wingshield Agent attacks, up to one other target creature gains flying until end of turn.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "99429fca-4b0d-5c52-b36e-10197c467346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859ed6fc-1f9a-428d-82d8-8e4b5bae6d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859ed6fc-1f9a-428d-82d8-8e4b5bae6d5a.jpg?1",
             "name": "Wiretapping",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWhenever you draw your first card during each of your draw steps, draw a card. Then if you have nine or more cards in hand, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -2480,7 +2480,7 @@
         },
         {
             "id": "8135a0bd-a7c4-5401-bd2e-41232e4504b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be6f2c-8ad0-402d-a7ca-9fe817e83b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be6f2c-8ad0-402d-a7ca-9fe817e83b72.jpg?1",
             "name": "Witness Protection",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a green and white Citizen creature with base power and toughness 1/1 named Legitimate Businessperson. (It loses all other colors, card types, creature types, and names.)",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "13c245cc-3655-5287-b252-7025a423a99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4aee25-496d-453e-95b7-d773fe21cacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4aee25-496d-453e-95b7-d773fe21cacc.jpg?1",
             "name": "Angel of Suffering",
             "text": "Flying\nIf damage would be dealt to you, prevent that damage and mill twice that many cards.",
             "colours": [
@@ -2551,7 +2551,7 @@
         },
         {
             "id": "3d16fea1-8001-5967-ac8d-acde33a80fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d7d77a-35b6-451a-af44-ecaf38facccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d7d77a-35b6-451a-af44-ecaf38facccb.jpg?1",
             "name": "Body Launderer",
             "text": "Deathtouch\nWhenever another nontoken creature you control dies, Body Launderer connives.\nWhen Body Launderer dies, return another target non-Rogue creature card with equal or lesser power from your graveyard to the battlefield.",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "aba0ced3-f350-59ed-bbaf-88c897ebaa89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6e8d37-badd-4b9a-94e5-2d50ec78182c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6e8d37-badd-4b9a-94e5-2d50ec78182c.jpg?1",
             "name": "Cemetery Tampering",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nAt the beginning of your upkeep, you may mill three cards. Then if there are twenty or more cards in your graveyard, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "635f5f08-1ecc-52db-917a-61fe6bd97185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c6215-4006-4c4f-897a-be051cb73fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c6215-4006-4c4f-897a-be051cb73fa7.jpg?1",
             "name": "Corrupt Court Official",
             "text": "When Corrupt Court Official enters the battlefield, target opponent discards a card.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "80c4d8e3-3b27-51c2-9270-129778f9b8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d6f60-3e8a-4c58-8b3c-9ba59a01c867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d6f60-3e8a-4c58-8b3c-9ba59a01c867.jpg?1",
             "name": "Crooked Custodian",
             "text": "Crooked Custodian enters the battlefield tapped.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "0a90b8d7-eb14-5d40-96ee-c5326855bb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e86078-1629-40dc-88a9-102c543255b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e86078-1629-40dc-88a9-102c543255b8.jpg?1",
             "name": "Cut of the Profits",
             "text": "Casualty 3 (As you cast this spell, you may sacrifice a creature with power 3 or greater. When you do, copy this spell.)\nYou draw X cards and you lose X life.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "daf89f89-b704-5def-958d-1e9a47ab70bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b23b3e4-58cf-4b5d-bdcb-410a403b4987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b23b3e4-58cf-4b5d-bdcb-410a403b4987.jpg?1",
             "name": "Cutthroat Contender",
             "text": "Pay 1 life: Cutthroat Contender gets +1/+0 until end of turn. Activate only once each turn.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "3c4a96d6-507e-58b4-83e7-c6304c0a1942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3359f13d-9946-49fa-b621-28b1ea714e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3359f13d-9946-49fa-b621-28b1ea714e55.jpg?1",
             "name": "Deal Gone Bad",
             "text": "Target creature gets -3/-3 until end of turn. Target player mills three cards. (They put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "21e385d3-b4fa-5cdd-bffa-8f34c3d20cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d88ac4-cde5-4878-934e-cd670a7c9b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d88ac4-cde5-4878-934e-cd670a7c9b9e.jpg?1",
             "name": "A-Deal Gone Bad",
             "text": "",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "d0499812-b2da-577e-91d0-69efc530c326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e59fb98-c887-42f1-a620-9e6b40b94cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e59fb98-c887-42f1-a620-9e6b40b94cb5.jpg?1",
             "name": "Demon's Due",
             "text": "Scry 2, then draw two cards. You lose 2 life.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "428fc6f0-8f3d-5d30-809a-e0bbf3bb70af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9f5336-130a-41aa-9df0-9bbb5dd747d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9f5336-130a-41aa-9df0-9bbb5dd747d9.jpg?1",
             "name": "A-Demon's Due",
             "text": "",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "3b342bb5-29ee-57be-b590-fa60001acc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902abe4d-5c19-4c96-b825-e6cd4d954a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902abe4d-5c19-4c96-b825-e6cd4d954a84.jpg?1",
             "name": "Dig Up the Body",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nMill two cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "28acbfb1-213e-5154-993e-106a72380e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86825b2-5b03-4311-b7d9-f8131b17249d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86825b2-5b03-4311-b7d9-f8131b17249d.jpg?1",
             "name": "Dusk Mangler",
             "text": "As an additional cost to cast this spell, sacrifice a creature, discard a card, or pay 4 life.\nWhen Dusk Mangler enters the battlefield, each opponent sacrifices a creature, discards a card, and loses 4 life.",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "4205b972-2ea8-54d9-a1e9-b83fce8e79a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb9df1-4475-45e7-bc9c-40937c8c1722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb9df1-4475-45e7-bc9c-40937c8c1722.jpg?1",
             "name": "Extract the Truth",
             "text": "Choose one \u2014\n\u2022 Target opponent reveals their hand. You may choose a creature, enchantment, or planeswalker card from it. That player discards that card.\n\u2022 Target opponent sacrifices an enchantment.",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "ca8099fe-492a-5165-8d7c-a2523915f538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e117a8-3291-4f9a-ab00-c820c8e2aa00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e117a8-3291-4f9a-ab00-c820c8e2aa00.jpg?1",
             "name": "Fake Your Own Death",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control and you create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "3b0b0f66-3340-5e25-9124-a9d7a6c0a123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd6449-31a1-4572-8f9c-3f6f4670dc9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd6449-31a1-4572-8f9c-3f6f4670dc9d.jpg?1",
             "name": "Girder Goons",
             "text": "When Girder Goons dies, create a tapped 2/2 black Rogue creature token.\nBlitz {3}{B} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -3052,7 +3052,7 @@
         },
         {
             "id": "7e692266-839b-50e2-9dba-e8fb3f37cdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394d7fb3-44ee-409f-a992-27e5aabd9c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394d7fb3-44ee-409f-a992-27e5aabd9c2b.jpg?1",
             "name": "Graveyard Shift",
             "text": "This spell has flash as long as there are five or more mana values among cards in your graveyard.\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "e73e5a18-0f18-5847-b281-135cee8099dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a87a-ecb2-4f1c-93ad-17091af3da15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a87a-ecb2-4f1c-93ad-17091af3da15.jpg?1",
             "name": "A-Graveyard Shift",
             "text": "",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "c7f3792e-5197-5bd2-9c93-133f0aabb9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322e12d-b932-4ca1-a51d-e2a928140cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322e12d-b932-4ca1-a51d-e2a928140cc7.jpg?1",
             "name": "Grisly Sigil",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nChoose target creature or planeswalker. If it was dealt noncombat damage this turn, Grisly Sigil deals 3 damage to it and you gain 3 life. Otherwise, Grisly Sigil deals 1 damage to it and you gain 1 life.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "d4995138-f583-5c66-8888-0cb2b3a1980e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cced2-390b-499f-ace3-e52fd53d4712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cced2-390b-499f-ace3-e52fd53d4712.jpg?1",
             "name": "Illicit Shipment",
             "text": "Casualty 3 (As you cast this spell, you may sacrifice a creature with power 3 or greater. When you do, copy this spell.)\nSearch your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -3179,7 +3179,7 @@
         },
         {
             "id": "c13d50dc-197e-549c-abc1-73ca9ad43544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198ec497-4e95-4386-9ca4-35d2d3f59733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198ec497-4e95-4386-9ca4-35d2d3f59733.jpg?1",
             "name": "Incriminate",
             "text": "Choose two target creatures controlled by the same player. That player sacrifices one of them.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "0ccafea2-47bd-5dae-a70d-5bdc7f38585b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf60fdcf-f07a-4daa-b670-f6c2793e72eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf60fdcf-f07a-4daa-b670-f6c2793e72eb.jpg?1",
             "name": "A-Incriminate",
             "text": "",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "c8e0c504-a045-5905-9c7e-38643edaef94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2665f7-6cf8-4f9b-810e-17e264753225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2665f7-6cf8-4f9b-810e-17e264753225.jpg?1",
             "name": "Join the Maestros",
             "text": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell.)\nCreate a 4/3 black Ogre Warrior creature token.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "98327724-2039-565f-8ae6-a93a016a2be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db94f2a9-53be-449e-8240-77f013cdd7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db94f2a9-53be-449e-8240-77f013cdd7e3.jpg?1",
             "name": "Maestros Initiate",
             "text": "{4}{UR}, Exile Maestros Initiate from your graveyard: Draw two cards, then discard a card.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "8d9535ba-ef75-5f54-b1fc-9e43b50d0824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a4a5b3-0477-4709-8bce-3e01f54001b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a4a5b3-0477-4709-8bce-3e01f54001b6.jpg?1",
             "name": "Midnight Assassin",
             "text": "Flying, deathtouch",
             "colours": [
@@ -3348,7 +3348,7 @@
         },
         {
             "id": "4d98f663-7d4a-51d6-9850-53c625545331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37409205-a750-475a-9755-5ad21792acd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37409205-a750-475a-9755-5ad21792acd7.jpg?1",
             "name": "A-Midnight Assassin",
             "text": "",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "8a9222fd-3214-530d-94ad-a1be1acb0eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c13ac76-7cd9-456f-9b89-92bfa07c64c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c13ac76-7cd9-456f-9b89-92bfa07c64c5.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3414,7 +3414,7 @@
         },
         {
             "id": "bf3430b6-172b-5ab7-abc2-4d44b995666a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fd3f8a-a13b-4a0a-bb27-b9246949ea7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fd3f8a-a13b-4a0a-bb27-b9246949ea7b.jpg?1",
             "name": "Night Clubber",
             "text": "When Night Clubber enters the battlefield, creatures your opponents control get -1/-1 until end of turn.\nBlitz {2}{B} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "86ee8518-ea66-514f-9bc8-1aa8bb7b3bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba72399-c827-43f3-b072-08597dbafb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba72399-c827-43f3-b072-08597dbafb2d.jpg?1",
             "name": "Raffine's Silencer",
             "text": "When Raffine's Silencer enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)\nWhen Raffine's Silencer dies, target creature an opponent controls gets -X/-X until end of turn, where X is Raffine's Silencer's power.",
             "colours": [
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "25f52318-6762-5fc5-b32f-c5cbe7b2d481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fbe7f0-8a91-4832-8953-54ab3669372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fbe7f0-8a91-4832-8953-54ab3669372c.jpg?1",
             "name": "Revel Ruiner",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Revel Ruiner enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "7e487655-89ac-575e-80bb-be539dea0ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fe4c78-41da-4643-841f-07d54670f1be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fe4c78-41da-4643-841f-07d54670f1be.jpg?1",
             "name": "A-Revel Ruiner",
             "text": "",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "cc7b5fff-382f-5409-a49b-bd6956ce44c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b1fce-585f-442c-99a6-3b9767d68f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b1fce-585f-442c-99a6-3b9767d68f13.jpg?1",
             "name": "Rogues' Gallery",
             "text": "For each color, return up to one target creature card of that color from your graveyard to your hand.",
             "colours": [
@@ -3585,7 +3585,7 @@
         },
         {
             "id": "bca4ead8-1d00-572c-b1b9-7d5e09200f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d52ea1e-5b66-47c7-9a6d-95f5996565d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d52ea1e-5b66-47c7-9a6d-95f5996565d8.jpg?1",
             "name": "Sanguine Spy",
             "text": "Menace, lifelink\n{1}, Sacrifice another creature: Look at the top card of your library. You may put that card into your graveyard.\nAt the beginning of your end step, if there are five or more mana values among cards in your graveyard, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "eedca4c7-5be6-5d46-bf75-0d8ce0c64959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cbb0db-94e9-4988-b900-ced4f9e6d4ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cbb0db-94e9-4988-b900-ced4f9e6d4ed.jpg?1",
             "name": "Shadow of Mortality",
             "text": "If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.",
             "colours": [
@@ -3658,7 +3658,7 @@
         },
         {
             "id": "49b16ab0-9d08-5edb-9388-71256c721ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce418184-a672-46bc-a17d-c559614defb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce418184-a672-46bc-a17d-c559614defb5.jpg?1",
             "name": "Shakedown Heavy",
             "text": "Menace\nWhenever Shakedown Heavy attacks, defending player may have you draw a card. If they do, untap Shakedown Heavy and remove it from combat.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "112dbb10-8bc8-594a-9fbe-cb2c2c07f7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17114ed-f98f-4b82-ba03-ef7ec5f572ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17114ed-f98f-4b82-ba03-ef7ec5f572ba.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "a5a0d116-10c7-58ba-b382-77da93aa9a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a6d00-3e00-4827-8420-13343ac3d0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a6d00-3e00-4827-8420-13343ac3d0fd.jpg?1",
             "name": "Tenacious Underdog",
             "text": "Blitz\u2014{2}{B}{B}, Pay 2 life. (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)\nYou may cast Tenacious Underdog from your graveyard using its blitz ability.",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "cf31864f-54c6-5587-a4fe-134e28021cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702315d7-dec9-49e8-a508-feacd47198dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702315d7-dec9-49e8-a508-feacd47198dc.jpg?1",
             "name": "Vampire Scrivener",
             "text": "Flying\nWhenever you gain life during your turn, put a +1/+1 counter on Vampire Scrivener.\nWhenever you lose life during your turn, put a +1/+1 counter on Vampire Scrivener.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "5a9956bf-4e2f-55b3-8b81-191506a82495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7daf9711-4064-4f09-9371-aa1165d3d1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7daf9711-4064-4f09-9371-aa1165d3d1db.jpg?1",
             "name": "A-Vampire Scrivener",
             "text": "",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "b5ecf98a-4290-5f50-a5f7-9ca4232c7d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862769d-f8bd-4cb6-b2b2-816179795f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862769d-f8bd-4cb6-b2b2-816179795f8b.jpg?1",
             "name": "Whack",
             "text": "This spell costs {3} less to cast if it targets a white creature.\nTarget creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "5e1ae175-f5e3-5be6-9f65-fff36a0a7edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bac1d2a-99dd-40b3-8823-ce9225efcdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bac1d2a-99dd-40b3-8823-ce9225efcdcf.jpg?1",
             "name": "Antagonize",
             "text": "Target creature gets +4/+3 until end of turn.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "d17ac04d-3615-5ecc-ab68-0dc6ef01f06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f1b2bd-fe06-45ec-99dc-ff357a7a31d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f1b2bd-fe06-45ec-99dc-ff357a7a31d2.jpg?1",
             "name": "Arcane Bombardment",
             "text": "Whenever you cast your first instant or sorcery spell each turn, exile an instant or sorcery card at random from your graveyard. Then copy each card exiled with Arcane Bombardment. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "d5abbcee-de41-5e9b-9338-8dd66f7f0506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d1578f-e2cf-4b93-8204-ed5434feb183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d1578f-e2cf-4b93-8204-ed5434feb183.jpg?1",
             "name": "Big Score",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "6d93af53-1f4a-5b71-83af-07e9399ebb5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead68c0a-eed1-4a9c-a790-56f8a79b444c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead68c0a-eed1-4a9c-a790-56f8a79b444c.jpg?1",
             "name": "Call In a Professional",
             "text": "Players can't gain life this turn. Damage can't be prevented this turn. Call In a Professional deals 3 damage to any target. (Shield counters don't prevent this damage as they're removed.)",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "68416cf0-de86-51f2-8a1e-d568481de223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09dbcd-188b-4b52-943e-947cbf2c0002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09dbcd-188b-4b52-943e-947cbf2c0002.jpg?1",
             "name": "Daring Escape",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "169a9ece-6111-5ca4-817a-6fd40f094e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d3fc69-6c5e-4ede-9f8d-c1cee096a78a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d3fc69-6c5e-4ede-9f8d-c1cee096a78a.jpg?1",
             "name": "Devilish Valet",
             "text": "Trample, haste\nAlliance \u2014 Whenever another creature enters the battlefield under your control, double Devilish Valet's power until end of turn.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "fa228e9b-1aa5-59ca-9f7a-eface296c7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb4479f-3157-44b4-b18b-7553c7513118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb4479f-3157-44b4-b18b-7553c7513118.jpg?1",
             "name": "Exhibition Magician",
             "text": "When Exhibition Magician enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 green and white Citizen creature token.\n\u2022 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "def2f4e0-2ca1-57a5-985c-4e098b1046d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a222b6a5-27b9-4a8a-a727-ad113808ca7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a222b6a5-27b9-4a8a-a727-ad113808ca7d.jpg?1",
             "name": "A-Exhibition Magician",
             "text": "",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "b98aac71-9558-55e4-bc5d-a77236be7005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973685e8-3df1-436b-b5c2-01573a92b61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973685e8-3df1-436b-b5c2-01573a92b61e.jpg?1",
             "name": "Glittering Stockpile",
             "text": "{T}: Add {R}. Put a stash counter on Glittering Stockpile.\n{T}, Sacrifice Glittering Stockpile: Add X mana of any one color, where X is the number of stash counters on Glittering Stockpile.",
             "colours": [
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "dea71bb5-52d3-54db-8607-37b9b460e804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059e4b4-1542-4b5c-810a-9f0abac5792b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059e4b4-1542-4b5c-810a-9f0abac5792b.jpg?1",
             "name": "Goldhound",
             "text": "First strike\nMenace (This creature can't be blocked except by two or more creatures.)\n{T}, Sacrifice Goldhound: Add one mana of any color.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "c4296f30-bf9b-5845-add2-8ac27f6e3bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f190e9-52f3-4e34-8fb6-88174c189ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f190e9-52f3-4e34-8fb6-88174c189ee7.jpg?1",
             "name": "Hoard Hauler",
             "text": "Trample\nWhenever Hoard Hauler deals combat damage to a player, create a Treasure token for each artifact they control.\nCrew 3",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "f2fab2f0-08f9-56a7-aefc-c2f01b24e1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7626e2-0041-4ac5-97b3-2db8dcb094d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7626e2-0041-4ac5-97b3-2db8dcb094d4.jpg?1",
             "name": "Involuntary Employment",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "9f6a0ceb-f2b9-56c2-a83d-4c30f8d2f6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74ba9fe-2dcb-4da7-ba64-cd932edb5b24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74ba9fe-2dcb-4da7-ba64-cd932edb5b24.jpg?1",
             "name": "Jackhammer",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "3e1a7583-f759-520c-ac76-2fa17c7c4537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68068a3a-8258-4e7d-8031-3dc93adf3c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68068a3a-8258-4e7d-8031-3dc93adf3c3b.jpg?1",
             "name": "A-Jackhammer",
             "text": "",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "e706b0b7-fd25-55aa-9d58-4bec287a05d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78127c0c-672f-4e4b-9c23-6a5f237228fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78127c0c-672f-4e4b-9c23-6a5f237228fd.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "{R}, {T}, Discard a card: Create a token that's a copy of another target creature you control. It gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\nBlitz {1}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "5a308c44-f787-51f9-803a-2a6709fa7aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee31d56a-9b7e-4de0-81cb-3b7c76b6fbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee31d56a-9b7e-4de0-81cb-3b7c76b6fbd5.jpg?1",
             "name": "Light 'Em Up",
             "text": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nLight 'Em Up deals 2 damage to target creature or planeswalker.",
             "colours": [
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "f6b5031b-01dd-56ed-b0da-5d7373f6dff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50162cdd-ba30-48df-93ff-197c7f4a2913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50162cdd-ba30-48df-93ff-197c7f4a2913.jpg?1",
             "name": "Mayhem Patrol",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Mayhem Patrol attacks, target creature gets +1/+0 until end of turn.\nBlitz {1}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4451,7 +4451,7 @@
         },
         {
             "id": "26853c5e-254c-5bd2-ad02-391c6d6f0585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741ed811-cbcd-4178-a874-dc79d2a5d6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741ed811-cbcd-4178-a874-dc79d2a5d6f1.jpg?1",
             "name": "Plasma Jockey",
             "text": "Whenever Plasma Jockey attacks, target creature an opponent controls can't block this turn.\nBlitz {2}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "14752dc2-de66-5a31-9e3c-928411540af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acbf52-b137-44f0-a815-2817fe8d2da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acbf52-b137-44f0-a815-2817fe8d2da2.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "Menace\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token.\nSacrifice a Treasure: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "b2638abe-1993-53e4-a013-f5a671f863f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98022d2-3b46-41f4-8f31-0a238d881ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98022d2-3b46-41f4-8f31-0a238d881ac6.jpg?1",
             "name": "Pugnacious Pugilist",
             "text": "Whenever Pugnacious Pugilist attacks, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\nBlitz {3}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4558,7 +4558,7 @@
         },
         {
             "id": "e8c6ddd5-8964-5359-a376-d06be20ed246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c5fd3e-3799-4535-8c33-9c567f4f5709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c5fd3e-3799-4535-8c33-9c567f4f5709.jpg?1",
             "name": "Pyre-Sledge Arsonist",
             "text": "{1}, {T}: Pyre-Sledge Arsonist deals X damage to any target, where X is the number of permanents you've sacrificed this turn.",
             "colours": [
@@ -4593,7 +4593,7 @@
         },
         {
             "id": "a2365a98-cc17-51f8-aa18-592ce10c0348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6016155a-d694-45af-bd05-1b2d8046d993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6016155a-d694-45af-bd05-1b2d8046d993.jpg?1",
             "name": "A-Pyre-Sledge Arsonist",
             "text": "",
             "colours": [
@@ -4627,7 +4627,7 @@
         },
         {
             "id": "4a835e9c-49f2-553b-8062-22d53a3ad0ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16998689-345d-41e3-a368-e97b696ed689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16998689-345d-41e3-a368-e97b696ed689.jpg?1",
             "name": "Ready to Rumble",
             "text": "Choose one \u2014\n\u2022 Ready to Rumble deals 5 damage to target creature or planeswalker.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "23ee4336-c573-5bd5-853b-35f0767f758a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392ab2d-d3aa-466f-837e-27365ebcec6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392ab2d-d3aa-466f-837e-27365ebcec6e.jpg?1",
             "name": "A-Ready to Rumble",
             "text": "",
             "colours": [
@@ -4690,7 +4690,7 @@
         },
         {
             "id": "52587e79-87d9-5739-b16d-c349f8a9abd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e65a50-d2bc-43a0-a9d4-0e846d170f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e65a50-d2bc-43a0-a9d4-0e846d170f78.jpg?1",
             "name": "Riveteers Initiate",
             "text": "{1}{BG}: Riveteers Initiate gains deathtouch until end of turn.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "c2acdf80-6adb-5bf3-a9b6-a96f93d8a695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62e39e3-f266-41ac-a0c3-3dce45e783f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62e39e3-f266-41ac-a0c3-3dce45e783f7.jpg?1",
             "name": "A-Riveteers Initiate",
             "text": "",
             "colours": [
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "c1d9f153-75be-55f7-92f2-95b809429627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5152d-767a-47d5-acfc-f439810aaeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5152d-767a-47d5-acfc-f439810aaeea.jpg?1",
             "name": "Riveteers Requisitioner",
             "text": "When Riveteers Requisitioner dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nBlitz {2}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4798,7 +4798,7 @@
         },
         {
             "id": "25b043d0-32cc-5c36-98b2-d124d8d17cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ec95f6-88c8-4daf-882f-8b4bc73452c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ec95f6-88c8-4daf-882f-8b4bc73452c3.jpg?1",
             "name": "Rob the Archives",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nExile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -4830,7 +4830,7 @@
         },
         {
             "id": "507c83ed-eaf6-5c7f-a28f-88890c2bef0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958dfd59-7dbd-45e0-b6e1-e432c78b6878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958dfd59-7dbd-45e0-b6e1-e432c78b6878.jpg?1",
             "name": "Sizzling Soloist",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, target creature an opponent controls can't block this turn. If this is the second time this ability has resolved this turn, that creature attacks during its controller's next combat phase if able.",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "6fecc13a-5f15-5411-86d0-efe85dc8981b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a755e0ed-92fe-4910-8113-f2b9f83294e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a755e0ed-92fe-4910-8113-f2b9f83294e6.jpg?1",
             "name": "A-Sizzling Soloist",
             "text": "",
             "colours": [
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "bb3e8638-59d7-5981-9712-585531304b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678fa3d-d41f-4b7a-b25e-6fc5f78876c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678fa3d-d41f-4b7a-b25e-6fc5f78876c7.jpg?1",
             "name": "Sticky Fingers",
             "text": "Enchant creature\nEnchanted creature has menace and \"Whenever this creature deals combat damage to a player, create a Treasure token.\" (It can't be blocked except by two or more creatures. The token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhen enchanted creature dies, draw a card.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "35b32e7c-6be7-566e-9e5d-4851b3d9ef4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b91d727-c0ee-4bf0-8c7d-8475ecb88083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b91d727-c0ee-4bf0-8c7d-8475ecb88083.jpg?1",
             "name": "Strangle",
             "text": "Strangle deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "5f18dca7-2ed8-5fad-84ea-7317cd06d465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbdb50e3-fe15-4431-b9bd-c4de65820734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbdb50e3-fe15-4431-b9bd-c4de65820734.jpg?1",
             "name": "Structural Assault",
             "text": "Destroy all artifacts, then Structural Assault deals damage to each creature equal to the number of artifacts that were put into graveyards from the battlefield this turn.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "12267498-968a-5e93-a5a7-13be63e2cc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbd4a8-c44c-42fc-b946-bdc7e20e1668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbd4a8-c44c-42fc-b946-bdc7e20e1668.jpg?1",
             "name": "Torch Breath",
             "text": "This spell costs {2} less to cast if it targets a blue permanent.\nThis spell can't be countered.\nTorch Breath deals X damage to target creature or planeswalker.",
             "colours": [
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "d3ab66aa-cd12-58dd-8b1f-c43a5900ea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6430c0-67c1-4793-b4be-8f47545c57d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6430c0-67c1-4793-b4be-8f47545c57d6.jpg?1",
             "name": "Unlucky Witness",
             "text": "When Unlucky Witness dies, exile the top two cards of your library. Until your next end step, you may play one of those cards.",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "685baf4b-1ede-5ff4-be0e-dc0bf8d1429d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a4ec18-1da4-43c6-a79a-03fbd4aef3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a4ec18-1da4-43c6-a79a-03fbd4aef3db.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "Haste\nAt the beginning of your upkeep, exile the top card of your library. You may play it this turn.\nAt the beginning of each opponent's upkeep, the next time they would draw a card this turn, instead they exile the top card of their library. They may play it this turn.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "107f2e6e-4d37-5d26-9d42-0672b44c9376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd22723d-855f-4b31-827f-a4e388ebbc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd22723d-855f-4b31-827f-a4e388ebbc07.jpg?1",
             "name": "Widespread Thieving",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWhenever you cast a multicolored spell, create a Treasure token. Then you may pay {W}{U}{B}{R}{G}. If you do, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "7b785eba-d9dd-556b-959e-83ec218dab94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d13f19-482b-4a2e-9692-b7d7caf2f9f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d13f19-482b-4a2e-9692-b7d7caf2f9f5.jpg?1",
             "name": "Witty Roastmaster",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, Witty Roastmaster deals 1 damage to each opponent.",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "0cddd98a-3e7c-5888-88f2-1b74bed3e759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92691507-b1ce-40d0-87e7-b79e81370511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92691507-b1ce-40d0-87e7-b79e81370511.jpg?1",
             "name": "Wrecking Crew",
             "text": "Reach, trample",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "43596353-6d32-5337-a6f9-db65ade1409b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bccccf9-3ee5-4485-ae01-4dcbad989d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bccccf9-3ee5-4485-ae01-4dcbad989d18.jpg?1",
             "name": "Attended Socialite",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, Attended Socialite gets +1/+1 until end of turn.",
             "colours": [
@@ -5252,7 +5252,7 @@
         },
         {
             "id": "8fa4658a-ff0e-552f-98a6-e9b9d3cf9fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg?1",
             "name": "Bootleggers' Stash",
             "text": "Lands you control have \"{T}: Create a Treasure token.\"",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "48f11fba-d67a-5e7b-9bd9-4cdbfdd26be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54772e15-d99d-4eec-ba8d-b9202a7e318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54772e15-d99d-4eec-ba8d-b9202a7e318b.jpg?1",
             "name": "Bouncer's Beatdown",
             "text": "This spell costs {2} less to cast if it targets a black permanent.\nBouncer's Beatdown deals X damage to target creature or planeswalker, where X is the greatest power among creatures you control. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -5318,7 +5318,7 @@
         },
         {
             "id": "c16da7d7-bd82-5226-9c2f-dfb050b0b907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb94908-4f4a-487e-87ac-8d5bdefe9983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb94908-4f4a-487e-87ac-8d5bdefe9983.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "85225ced-5890-5544-91fc-99e4d5ce2492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c691f62-009b-4178-8e8b-d6e88229a282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c691f62-009b-4178-8e8b-d6e88229a282.jpg?1",
             "name": "Cabaretti Initiate",
             "text": "{2}{GU}: Cabaretti Initiate gains double strike until end of turn.",
             "colours": [
@@ -5387,7 +5387,7 @@
         },
         {
             "id": "32ab28eb-8598-563d-a7f7-15cb4fe34001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b431d2-33c1-49d8-b45d-690c174bb456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b431d2-33c1-49d8-b45d-690c174bb456.jpg?1",
             "name": "Caldaia Strongarm",
             "text": "When Caldaia Strongarm enters the battlefield, put two +1/+1 counters on target creature.\nBlitz {3}{G} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -5422,7 +5422,7 @@
         },
         {
             "id": "51e15047-3901-5b8f-b4df-00f2d759cf53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5530b04-f086-4d09-97e9-eda45f8b1f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5530b04-f086-4d09-97e9-eda45f8b1f7b.jpg?1",
             "name": "Capenna Express",
             "text": "Sacrifice a Treasure: Capenna Express becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "ee1015c0-caf7-5a04-affc-0ef5dddbc6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc5b78-2156-4a9a-863f-b2f82fbdc87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc5b78-2156-4a9a-863f-b2f82fbdc87d.jpg?1",
             "name": "A-Capenna Express",
             "text": "",
             "colours": [
@@ -5489,7 +5489,7 @@
         },
         {
             "id": "132621ef-a1bf-5470-a0cc-84c63901b80a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58d39d7-62bf-43c8-97b3-0f9069af0e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58d39d7-62bf-43c8-97b3-0f9069af0e29.jpg?1",
             "name": "Civic Gardener",
             "text": "Whenever Civic Gardener attacks, untap target creature or land.",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "0c6db980-2c68-5e78-8c1c-f9d7357d7b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5354868b-c96b-4765-b0c8-8895093e4019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5354868b-c96b-4765-b0c8-8895093e4019.jpg?1",
             "name": "Cleanup Crew",
             "text": "When Cleanup Crew enters the battlefield, choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "99335ba6-d6a8-596c-a070-d50bd20d72fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f375674-7ae2-4430-b1f3-c26fa5b201d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f375674-7ae2-4430-b1f3-c26fa5b201d1.jpg?1",
             "name": "Courier's Briefcase",
             "text": "When Courier's Briefcase enters the battlefield, create a 1/1 green and white Citizen creature token.\n{T}, Sacrifice Courier's Briefcase: Add one mana of any color.\n{W}{U}{B}{R}{G}, {T}, Sacrifice Courier's Briefcase: Draw three cards.",
             "colours": [
@@ -5599,7 +5599,7 @@
         },
         {
             "id": "2f2f34c3-29c7-56d4-91ff-0f5acbf7139d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d3500e-09ba-48b6-933f-25b4625b79aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d3500e-09ba-48b6-933f-25b4625b79aa.jpg?1",
             "name": "Elegant Entourage",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, target creature other than Elegant Entourage gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "94dbf776-bb5d-560a-8c99-dc778c9c2cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bc3b04-46b7-43df-9b29-1502b9f18bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bc3b04-46b7-43df-9b29-1502b9f18bbf.jpg?1",
             "name": "Evolving Door",
             "text": "{1}, {T}, Sacrifice a creature: Count the colors of the sacrificed creature, then search your library for a creature card that's exactly that many colors plus one. Exile that card, then shuffle. You may cast the exiled card. Activate only as a sorcery.",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "d43bd345-1f49-5339-ba0b-300facdfab7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg?1",
             "name": "Fight Rigging",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if you control a creature with power 7 or greater, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -5702,7 +5702,7 @@
         },
         {
             "id": "2d4b768b-857b-5b33-9d8c-58a6ec966bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052be93c-1970-4d05-a3d1-e87a6e51c423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052be93c-1970-4d05-a3d1-e87a6e51c423.jpg?1",
             "name": "For the Family",
             "text": "Target creature gets +2/+2 until end of turn. If you control four or more creatures, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -5734,7 +5734,7 @@
         },
         {
             "id": "8c2c1cf2-df53-5eeb-8c88-2d02e22cf2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570f7c90-109b-4d6d-8205-d158753719e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570f7c90-109b-4d6d-8205-d158753719e8.jpg?1",
             "name": "Freelance Muscle",
             "text": "Whenever Freelance Muscle attacks or blocks, it gets +X/+X until end of turn, where X is the greatest power and/or toughness among other creatures you control.",
             "colours": [
@@ -5769,7 +5769,7 @@
         },
         {
             "id": "18e8dca4-b446-50e2-891d-ce7bc114622a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1baaa2-bd0b-4627-b93a-0753e0acd0f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1baaa2-bd0b-4627-b93a-0753e0acd0f2.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -5817,7 +5817,7 @@
         },
         {
             "id": "108db9ee-97cd-5bd1-97d2-ce976f3579b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3d70d2-0604-41b3-8dd1-bfeb05832271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3d70d2-0604-41b3-8dd1-bfeb05832271.jpg?1",
             "name": "Glittermonger",
             "text": "{T}: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "5070c2ae-223a-517c-8f31-a339b4cb8d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf8438c-9738-4577-b55d-f1e270c06890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf8438c-9738-4577-b55d-f1e270c06890.jpg?1",
             "name": "A-Glittermonger",
             "text": "",
             "colours": [
@@ -5886,7 +5886,7 @@
         },
         {
             "id": "5f87fd59-b2ec-5c5c-b222-14c347957f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2399c6d7-57f9-4100-ad64-3c8897a438f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2399c6d7-57f9-4100-ad64-3c8897a438f7.jpg?1",
             "name": "High-Rise Sawjack",
             "text": "Reach\nWhenever High-Rise Sawjack blocks a creature with flying, High-Rise Sawjack gets +2/+0 until end of turn.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "cbd8bd62-cc9b-5da9-afd9-ea52adadbe18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287079a9-d2ae-4ba8-b74b-6cd49c0f4109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287079a9-d2ae-4ba8-b74b-6cd49c0f4109.jpg?1",
             "name": "A-High-Rise Sawjack",
             "text": "",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "1f0ffe97-dfe4-56bc-955e-daa3de9c17db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e498e-1245-40c1-96a4-c9bcfd1cfe1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e498e-1245-40c1-96a4-c9bcfd1cfe1f.jpg?1",
             "name": "Jewel Thief",
             "text": "Vigilance, trample\nWhen Jewel Thief enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "0906fd55-3248-5fe3-ac3c-717ae4bece94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0e818-db6a-453a-a1f0-a7fade6509d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0e818-db6a-453a-a1f0-a7fade6509d3.jpg?1",
             "name": "Luxurious Libation",
             "text": "Target creature gets +X/+X until end of turn. Create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -6022,7 +6022,7 @@
         },
         {
             "id": "a5d91e9f-5632-5c77-aca7-8140d84c4eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573c0f68-9ed8-4657-b709-b7f3804aaa68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573c0f68-9ed8-4657-b709-b7f3804aaa68.jpg?1",
             "name": "Most Wanted",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+1.\nWhen enchanted creature dies, create two Treasure tokens.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "e3179103-df36-5537-904d-72a2eb9134d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cdaf8e-1d2f-4443-b071-7fc500ea50ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cdaf8e-1d2f-4443-b071-7fc500ea50ad.jpg?1",
             "name": "A-Most Wanted",
             "text": "",
             "colours": [
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "a721500e-6354-51e4-a85f-72a6ad772423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544c810b-5f90-4535-aa76-14f8c6b9428a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544c810b-5f90-4535-aa76-14f8c6b9428a.jpg?1",
             "name": "Prizefight",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6121,7 +6121,7 @@
         },
         {
             "id": "0feb75ff-f8d4-53c4-9b8a-5a6dba31d990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f5b02-16b9-4672-b0ec-f77662e9de76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f5b02-16b9-4672-b0ec-f77662e9de76.jpg?1",
             "name": "Rhox Pummeler",
             "text": "Rhox Pummeler enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nRhox Pummeler has trample as long as it has a shield counter on it.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "8f00943c-1355-53de-9624-4829604aa755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d21701b-6a99-4e1c-82b2-0219f170b09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d21701b-6a99-4e1c-82b2-0219f170b09f.jpg?1",
             "name": "Riveteers Decoy",
             "text": "Riveteers Decoy must be blocked if able.\nBlitz {3}{G} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -6191,7 +6191,7 @@
         },
         {
             "id": "f8e31d20-3644-5875-bf64-77f38213dc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fb74fd-767f-4dd4-822a-828d59f633ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fb74fd-767f-4dd4-822a-828d59f633ad.jpg?1",
             "name": "Social Climber",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "d5bc7f7d-df49-580e-8aaa-d67c24de61fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666a480-33d9-4a4b-9c65-0dac90476541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666a480-33d9-4a4b-9c65-0dac90476541.jpg?1",
             "name": "A-Social Climber",
             "text": "",
             "colours": [
@@ -6260,7 +6260,7 @@
         },
         {
             "id": "b4d8a15e-14a9-5b5c-8ee6-9d97eaae89e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4a5122-6922-4ab5-aa43-94cf2d7f9c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4a5122-6922-4ab5-aa43-94cf2d7f9c8a.jpg?1",
             "name": "Take to the Streets",
             "text": "Creatures you control get +2/+2 until end of turn. Citizens you control get an additional +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -6292,7 +6292,7 @@
         },
         {
             "id": "87267c6a-ed1c-56ad-bd51-69290d9992d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6f03c1-9e9d-4a0c-af3b-9753b440cd9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6f03c1-9e9d-4a0c-af3b-9753b440cd9f.jpg?1",
             "name": "Titan of Industry",
             "text": "Reach, trample\nWhen Titan of Industry enters the battlefield, choose two \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Target player gains 5 life.\n\u2022 Create a 4/4 green Rhino Warrior creature token.\n\u2022 Put a shield counter on a creature you control.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "62cb6537-d09e-52e1-8f2a-57e195138279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bb2699-280f-4e1e-b3f8-73efe6088f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bb2699-280f-4e1e-b3f8-73efe6088f31.jpg?1",
             "name": "Topiary Stomper",
             "text": "Vigilance\nWhen Topiary Stomper enters the battlefield, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nTopiary Stomper can't attack or block unless you control seven or more lands.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "8915adaa-a39f-5dbc-8d5f-472e363a66ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04897d8c-ee05-45eb-80f7-76487dbcc449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04897d8c-ee05-45eb-80f7-76487dbcc449.jpg?1",
             "name": "Venom Connoisseur",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, Venom Connoisseur gains deathtouch until end of turn. If this is the second time this ability has resolved this turn, all creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -6400,7 +6400,7 @@
         },
         {
             "id": "6354e10c-550e-5498-bc32-807d4322b9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edfb119-abc9-4d4d-bc46-33cce1a0922d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edfb119-abc9-4d4d-bc46-33cce1a0922d.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "+2: You may sacrifice a creature. If you do, search your library for a creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it onto the battlefield, then shuffle.\n+1: Mill five cards, then put any number of creature cards milled this way into your hand.\n\u22121: Create a 4/4 green Rhino Warrior creature token.",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "3c964967-79bc-5b4b-b7f5-6fae70049b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e0eb-23a5-46a5-b719-5a6f9a1fc4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e0eb-23a5-46a5-b719-5a6f9a1fc4ce.jpg?1",
             "name": "Voice of the Vermin",
             "text": "Voice of the Vermin enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever Voice of the Vermin attacks, target creature you control has base power and toughness 4/4 until end of turn.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "bb7a8595-b012-5b2d-8a11-cf5ada140177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad9e58e-c9a3-4a0d-9a59-71c20a3275b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad9e58e-c9a3-4a0d-9a59-71c20a3275b6.jpg?1",
             "name": "Warm Welcome",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -6507,7 +6507,7 @@
         },
         {
             "id": "ecd7d5d4-dbbe-5459-a59a-2cb35b622468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfc1b1d-66f5-49e9-b6bc-c7f78b206c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfc1b1d-66f5-49e9-b6bc-c7f78b206c11.jpg?1",
             "name": "A-Warm Welcome",
             "text": "",
             "colours": [
@@ -6538,7 +6538,7 @@
         },
         {
             "id": "a863f580-ab35-5527-81d3-c4de46457d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27851834-688f-4929-967d-dfa015194f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27851834-688f-4929-967d-dfa015194f7f.jpg?1",
             "name": "Workshop Warchief",
             "text": "Trample\nWhen Workshop Warchief enters the battlefield, you gain 3 life.\nWhen Workshop Warchief dies, create a 4/4 green Rhino Warrior creature token.\nBlitz {4}{G}{G} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "055680c3-8ee8-5618-b533-7dcdaa9bb746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef329c-61e6-41c1-8d89-ff2417949839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef329c-61e6-41c1-8d89-ff2417949839.jpg?1",
             "name": "Aven Heartstabber",
             "text": "Flying\nAs long as there are five or more mana values among cards in your graveyard, Aven Heartstabber gets +2/+2 and has deathtouch.\nWhen Aven Heartstabber dies, mill two cards, then draw a card.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "70d7e6b8-adbe-5644-8b44-eea73b762086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92b13-8b23-4c78-b690-c5d9ca835809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92b13-8b23-4c78-b690-c5d9ca835809.jpg?1",
             "name": "Black Market Tycoon",
             "text": "At the beginning of your upkeep, Black Market Tycoon deals 2 damage to you for each Treasure you control.\n{T}: Create a Treasure token.",
             "colours": [
@@ -6653,7 +6653,7 @@
         },
         {
             "id": "d40f437a-5467-5469-b2d8-e5c3c1182c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcb6d47-dccb-4b69-aed4-7a6215857606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcb6d47-dccb-4b69-aed4-7a6215857606.jpg?1",
             "name": "Body Dropper",
             "text": "Whenever you sacrifice another creature, put a +1/+1 counter on Body Dropper.\n{B}{R}, Sacrifice another creature: Body Dropper gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "74b430c9-e060-5827-bc55-d6224eff2431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae69722-9cb9-4fb7-830f-a284d4a72027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae69722-9cb9-4fb7-830f-a284d4a72027.jpg?1",
             "name": "Brazen Upstart",
             "text": "Vigilance\nWhen Brazen Upstart dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "05a024b6-535f-588b-91ae-4f849401bb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799de0f1-6bf2-4158-8a4f-bedc3d2f6578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799de0f1-6bf2-4158-8a4f-bedc3d2f6578.jpg?1",
             "name": "Brokers Ascendancy",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control and a loyalty counter on each planeswalker you control.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "14403351-8ace-5327-b23a-2a5699ea06b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c9c315-1cf4-468e-a74a-b5f3be4a63a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c9c315-1cf4-468e-a74a-b5f3be4a63a1.jpg?1",
             "name": "Brokers Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature or planeswalker an opponent controls.\n\u2022 Destroy target enchantment.\n\u2022 Draw two cards.",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "603668e4-e9aa-5355-b0ea-249215f22c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9738d616-b38f-4968-89d6-805ae368e2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9738d616-b38f-4968-89d6-805ae368e2d4.jpg?1",
             "name": "Cabaretti Ascendancy",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it on the bottom of your library.",
             "colours": [
@@ -6849,7 +6849,7 @@
         },
         {
             "id": "7b0024ea-3746-535e-922b-85817f5cc610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f33c8a-8e93-4296-964b-da132a854b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f33c8a-8e93-4296-964b-da132a854b3b.jpg?1",
             "name": "Cabaretti Charm",
             "text": "Choose one \u2014\n\u2022 Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Create two 1/1 green and white Citizen creature tokens.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "617d7fa1-9c6a-5c12-89af-edb9c024a3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e82413-9736-4013-a39a-5498c1c85bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e82413-9736-4013-a39a-5498c1c85bba.jpg?1",
             "name": "A-Cabaretti Charm",
             "text": "",
             "colours": [
@@ -6923,7 +6923,7 @@
         },
         {
             "id": "767cade4-2bd0-57b9-bfae-a24838ff3973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25803f0b-4475-447e-abdf-dcd6a98dd654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25803f0b-4475-447e-abdf-dcd6a98dd654.jpg?1",
             "name": "Celestial Regulator",
             "text": "Flying\nWhen Celestial Regulator enters the battlefield, choose target creature you don't control and tap it. If you control a creature with a counter on it, the chosen creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "87a1f65e-856b-53ca-a1da-439c758bc70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ede1b10-56df-4e17-bf86-1082edff1b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ede1b10-56df-4e17-bf86-1082edff1b51.jpg?1",
             "name": "A-Celestial Regulator",
             "text": "",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "4f82d89d-f2b2-5e56-9d2c-a86a434802d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a542616-aa4d-40d9-acad-47bc98bd6281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a542616-aa4d-40d9-acad-47bc98bd6281.jpg?1",
             "name": "Ceremonial Groundbreaker",
             "text": "Equipped creature gets +2/+1 and has trample.\nEquip Citizen {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "a7915a9b-bf8a-5a42-8fd4-4f1f3507005f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf5da68-a79b-40a3-93bc-785fb2352b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf5da68-a79b-40a3-93bc-785fb2352b05.jpg?1",
             "name": "Civil Servant",
             "text": "Whenever Civil Servant attacks, you may tap another untapped Citizen you control. If you do, Civil Servant gets +1/+0 and gains lifelink until end of turn.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "43d65e42-97f3-5961-ac82-8afe1492f725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e9707-b20e-4ea6-b353-9abd98174011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e9707-b20e-4ea6-b353-9abd98174011.jpg?1",
             "name": "A-Civil Servant",
             "text": "",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "5f0c7709-f42b-5bb4-94e9-5c3882c46f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221ac34a-94ed-4c49-afad-b19cac541731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221ac34a-94ed-4c49-afad-b19cac541731.jpg?1",
             "name": "Cormela, Glamour Thief",
             "text": "Haste\n{1}, {T}: Add {U}{B}{R}. Spend this mana only to cast instant and/or sorcery spells.\nWhen Cormela, Glamour Thief dies, return up to one target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "b8bd116a-5c5e-5ab4-8d18-8d2528bac8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f254bb-ec77-4147-ab9c-559bc7fba8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f254bb-ec77-4147-ab9c-559bc7fba8cd.jpg?1",
             "name": "Corpse Appraiser",
             "text": "When Corpse Appraiser enters the battlefield, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "7fc0312e-166d-57cd-bd09-bfc7c6270c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700eff3-138b-4d4c-ba36-58b98986168c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700eff3-138b-4d4c-ba36-58b98986168c.jpg?1",
             "name": "Corpse Explosion",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nCorpse Explosion deals damage equal to the exiled card's power to each creature and each planeswalker.",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "3c7a2e24-0964-57ee-9974-3ae95107b96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99806615-2f4a-4fe4-82f8-83445ae93a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99806615-2f4a-4fe4-82f8-83445ae93a97.jpg?1",
             "name": "Crew Captain",
             "text": "Haste\nCrew Captain has indestructible as long as it entered the battlefield this turn.",
             "colours": [
@@ -7269,7 +7269,7 @@
         },
         {
             "id": "7d760970-5a2a-5a6e-8093-4e62567e6f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa9815-6b47-4c80-87c7-4277166ea0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa9815-6b47-4c80-87c7-4277166ea0df.jpg?1",
             "name": "Darling of the Masses",
             "text": "Other Citizens you control get +1/+0.\nWhenever Darling of the Masses attacks, create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "e3559818-5ede-5ba0-a507-d6f09db100f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23cdb0a-e114-47f8-aceb-c54c4683bbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23cdb0a-e114-47f8-aceb-c54c4683bbc5.jpg?1",
             "name": "Disciplined Duelist",
             "text": "Double strike\nDisciplined Duelist enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -7348,7 +7348,7 @@
         },
         {
             "id": "090ccd5b-d395-5103-98e9-21057b3e6c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13798c8c-1aa5-4f95-979b-b971e73d715f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13798c8c-1aa5-4f95-979b-b971e73d715f.jpg?1",
             "name": "Endless Detour",
             "text": "The owner of target spell, nonland permanent, or card in a graveyard puts it on the top or bottom of their library.",
             "colours": [
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "7237575a-a39f-5616-918f-d8927e515aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dad61f-36cd-46af-82b7-a02e04efd676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dad61f-36cd-46af-82b7-a02e04efd676.jpg?1",
             "name": "Evelyn, the Covetous",
             "text": "Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "96831799-d9b3-5e04-ac1d-e7b1b7acaf4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f1ed8-5c10-45e4-8f2f-182e800faab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f1ed8-5c10-45e4-8f2f-182e800faab4.jpg?1",
             "name": "Exotic Pets",
             "text": "Create two 1/1 blue Fish creature tokens with \"This creature can't be blocked.\" Then for each kind of counter among creatures you control, put a counter of that kind on either of those tokens.",
             "colours": [
@@ -7465,7 +7465,7 @@
         },
         {
             "id": "00adcf10-69b4-56f5-b393-c17511ba207c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae25db8c-3d10-4196-b002-9d2aabd5f4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae25db8c-3d10-4196-b002-9d2aabd5f4de.jpg?1",
             "name": "Falco Spara, Pactweaver",
             "text": "Flying, trample\nFalco Spara, Pactweaver enters the battlefield with a shield counter on it.\nYou may look at the top card of your library any time.\nYou may cast spells from the top of your library by removing a counter from a creature you control in addition to paying their other costs.",
             "colours": [
@@ -7509,7 +7509,7 @@
         },
         {
             "id": "e2562d73-1325-5812-8cd9-2ab39f923d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7de8d6-edad-4845-9868-781351480258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7de8d6-edad-4845-9868-781351480258.jpg?1",
             "name": "Fatal Grudge",
             "text": "As an additional cost to cast this spell, sacrifice a nonland permanent.\nEach opponent chooses a permanent they control that shares a type with the sacrificed permanent and sacrifices it.\nDraw a card.",
             "colours": [
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "5118c416-027c-5148-bade-323be3f4c307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2473d738-fe15-402a-ad24-0d6e5c4dfda3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2473d738-fe15-402a-ad24-0d6e5c4dfda3.jpg?1",
             "name": "Fleetfoot Dancer",
             "text": "Trample, lifelink, haste",
             "colours": [
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "51a693bc-d95c-5852-9b3c-86af8bbb4a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5052247d-ef72-47f0-973d-2be98bf754c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5052247d-ef72-47f0-973d-2be98bf754c1.jpg?1",
             "name": "Forge Boss",
             "text": "Whenever you sacrifice one or more other creatures, Forge Boss deals 2 damage to each opponent. This ability triggers only once each turn.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "4bb9d293-db66-5b25-b09f-9a74ea7528d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6942a-f6fd-455f-be4a-0cdd16d67e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6942a-f6fd-455f-be4a-0cdd16d67e13.jpg?1",
             "name": "A-Forge Boss",
             "text": "",
             "colours": [
@@ -7658,7 +7658,7 @@
         },
         {
             "id": "cb07a160-3b21-5bed-a758-bb41007ed2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452abab0-cf23-4b9d-831a-7b9fa1fd582a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452abab0-cf23-4b9d-831a-7b9fa1fd582a.jpg?1",
             "name": "Glamorous Outlaw",
             "text": "When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you scry 2.\n{2}, Exile Glamorous Outlaw from your hand: Target land gains \"{T}: Add {U}, {B}, or {R}\" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.",
             "colours": [
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "989d2792-298a-5f7b-9f34-59da69b3236d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab334c44-0cdb-4521-bb7d-162131155796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab334c44-0cdb-4521-bb7d-162131155796.jpg?1",
             "name": "A-Glamorous Outlaw",
             "text": "",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "befaa804-b38b-5a47-9d78-791d386a97b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7df727-50ea-4ea8-bdb9-d7ef16199d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7df727-50ea-4ea8-bdb9-d7ef16199d8a.jpg?1",
             "name": "Hostile Takeover",
             "text": "Up to one target creature has base power and toughness 1/1 until end of turn. Up to one other target creature has base power and toughness 4/4 until end of turn. Then Hostile Takeover deals 3 damage to each creature.",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "a4e13092-2604-510d-ab8f-b80bcdf4427d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e2ed9e-ee1d-440a-94b4-d4b17d30b800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e2ed9e-ee1d-440a-94b4-d4b17d30b800.jpg?1",
             "name": "Incandescent Aria",
             "text": "Incandescent Aria deals 3 damage to each nontoken creature.",
             "colours": [
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "8ef49fa1-ad88-580c-8934-0d92406638f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c69d75-651f-4b75-b65d-79999d2069f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c69d75-651f-4b75-b65d-79999d2069f6.jpg?1",
             "name": "Jetmir, Nexus of Revels",
             "text": "Creatures you control get +1/+0 and have vigilance as long as you control three or more creatures.\nCreatures you control also get +1/+0 and have trample as long as you control six or more creatures.\nCreatures you control also get +1/+0 and have double strike as long as you control nine or more creatures.",
             "colours": [
@@ -7860,7 +7860,7 @@
         },
         {
             "id": "f568f39a-04ed-57c1-a519-c6b399f9efe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5aa701-28e8-47fa-8c26-4da2f943f582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5aa701-28e8-47fa-8c26-4da2f943f582.jpg?1",
             "name": "Jetmir's Fixer",
             "text": "{R}{G}: Jetmir's Fixer gets +1/+1 until end of turn. If mana from a Treasure was spent to activate this ability, put a +1/+1 counter on Jetmir's Fixer instead.",
             "colours": [
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "eb8f0320-29fd-5a13-909a-0c8cd6d060cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9326a-2a41-45b3-97c3-548f0bdc0882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9326a-2a41-45b3-97c3-548f0bdc0882.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second",
             "text": "If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.",
             "colours": [
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "b3675cb1-ed57-5402-a60a-5209e969d13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20f271-26c8-429f-a422-e7d95f3bda74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20f271-26c8-429f-a422-e7d95f3bda74.jpg?1",
             "name": "Lagrella, the Magpie",
             "text": "When Lagrella, the Magpie enters the battlefield, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters the battlefield under your control this way, put two +1/+1 counters on it.",
             "colours": [
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "28d239bb-1cd4-50c7-a478-9b2de2d797b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0a078d-045f-401b-a561-dcb1ad02bf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0a078d-045f-401b-a561-dcb1ad02bf62.jpg?1",
             "name": "Lord Xander, the Collector",
             "text": "When Lord Xander, the Collector enters the battlefield, target opponent discards half the cards in their hand, rounded down.\nWhenever Lord Xander attacks, defending player mills half their library, rounded down.\nWhen Lord Xander dies, target opponent sacrifices half the nonland permanents they control, rounded down.",
             "colours": [
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "361940e2-210a-5d54-bd33-4a6f479fdae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469a0f03-7874-453d-b9e4-275c13244f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469a0f03-7874-453d-b9e4-275c13244f4a.jpg?1",
             "name": "Maestros Ascendancy",
             "text": "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -8069,7 +8069,7 @@
         },
         {
             "id": "8a890ec3-652b-5af9-9cd8-6b80acc1aa61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcdedb6-3c24-4a29-b9b9-27cc47d8ee56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcdedb6-3c24-4a29-b9b9-27cc47d8ee56.jpg?1",
             "name": "Maestros Charm",
             "text": "Choose one \u2014\n\u2022 Look at the top five cards of your library. Put one of those cards into your hand and the rest into your graveyard.\n\u2022 Each opponent loses 3 life and you gain 3 life.\n\u2022 Maestros Charm deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "cd09970c-b19c-51a1-ad79-13df8698624e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7206db10-e248-420d-bf92-4d57bc72da56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7206db10-e248-420d-bf92-4d57bc72da56.jpg?1",
             "name": "Maestros Diabolist",
             "text": "Deathtouch, haste\nWhenever Maestros Diabolist attacks, if you don't control a Devil token, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -8150,7 +8150,7 @@
         },
         {
             "id": "53f54beb-0888-5b0f-8504-b8d6c955e22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03757415-6b58-42d3-9452-a862e90647ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03757415-6b58-42d3-9452-a862e90647ee.jpg?1",
             "name": "Masked Bandits",
             "text": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)\n{2}, Exile Masked Bandits from your hand: Target land gains \"{T}: Add {B}, {R}, or {G}\" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "196a3ca1-135e-5826-9678-9b2f421a3e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2073bd-be49-4d3a-9aca-b8ea6b747503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2073bd-be49-4d3a-9aca-b8ea6b747503.jpg?1",
             "name": "A-Masked Bandits",
             "text": "",
             "colours": [
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "fd8a29d1-e9f1-5f5b-ae92-af45cb362977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c3c08f-ae9d-4932-ba0e-65652b8b318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c3c08f-ae9d-4932-ba0e-65652b8b318b.jpg?1",
             "name": "Meeting of the Five",
             "text": "Exile the top ten cards of your library. You may cast spells with exactly three colors from among them this turn. Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Spend this mana only to cast spells with exactly three colors.",
             "colours": [
@@ -8272,7 +8272,7 @@
         },
         {
             "id": "931441a3-a739-5e27-a56f-15b3f87bb568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633c7e38-fdad-461c-9ecb-3e89d5b80f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633c7e38-fdad-461c-9ecb-3e89d5b80f24.jpg?1",
             "name": "Metropolis Angel",
             "text": "Flying\nWhenever you attack with one or more creatures with counters on them, draw a card.",
             "colours": [
@@ -8309,7 +8309,7 @@
         },
         {
             "id": "c3694bd1-bafa-51ee-995b-0c2c0a13c822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5601410-9c2b-488f-a123-9637d0d97d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5601410-9c2b-488f-a123-9637d0d97d06.jpg?1",
             "name": "A-Metropolis Angel",
             "text": "",
             "colours": [
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "6d9de08a-3851-57a6-891e-24452497d4a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97caaa92-2a7d-4f79-8d42-86733c902072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97caaa92-2a7d-4f79-8d42-86733c902072.jpg?1",
             "name": "Mr. Orfeo, the Boulder",
             "text": "Whenever you attack, double target creature's power until end of turn.",
             "colours": [
@@ -8389,7 +8389,7 @@
         },
         {
             "id": "641f0f6f-09cb-5009-8ea2-16c414365d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b8196-ec05-4732-aec2-50629cf4ebb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b8196-ec05-4732-aec2-50629cf4ebb4.jpg?1",
             "name": "A-Mr. Orfeo, the Boulder",
             "text": "",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "221a37d5-2c14-53b8-af86-576042e2ac71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150d4c7-2c90-4a71-b2d3-3d9a0079fea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150d4c7-2c90-4a71-b2d3-3d9a0079fea1.jpg?1",
             "name": "Nimble Larcenist",
             "text": "Flying\nWhen Nimble Larcenist enters the battlefield, target opponent reveals their hand. You choose an artifact, instant, or sorcery card from it and exile that card.",
             "colours": [
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "1c945fc7-d270-5e1d-86c5-8142240fd52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80226520-6b0a-48ea-a868-a29eb3fbd403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80226520-6b0a-48ea-a868-a29eb3fbd403.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "Casualty X. The copy isn't legendary and has starting loyalty X. (As you cast this spell, you may sacrifice a creature with power X. When you do, copy this spell. The copy becomes a token.)\n+1: Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22127: Target player draws seven cards and loses 7 life.",
             "colours": [
@@ -8513,7 +8513,7 @@
         },
         {
             "id": "dfd1b523-d92b-5966-903a-8f737b7524cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a11e5e-d2a9-4490-90f3-a643fc7ed7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a11e5e-d2a9-4490-90f3-a643fc7ed7c3.jpg?1",
             "name": "Obscura Ascendancy",
             "text": "Whenever you cast a spell, if its mana value is equal to 1 plus the number of soul counters on Obscura Ascendancy, put a soul counter on Obscura Ascendancy, then create a 2/2 white Spirit creature token with flying.\nAs long as there are five or more soul counters on Obscura Ascendancy, Spirits you control get +3/+3.",
             "colours": [
@@ -8552,7 +8552,7 @@
         },
         {
             "id": "99dc6b97-e5a3-5233-991f-e44da1b507ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961562d-cad9-40e5-afae-3ebce77a2260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961562d-cad9-40e5-afae-3ebce77a2260.jpg?1",
             "name": "Obscura Charm",
             "text": "Choose one \u2014\n\u2022 Return target multicolored permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\n\u2022 Counter target instant or sorcery spell.\n\u2022 Destroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "98f8289f-a8a8-534e-a18c-21a45690b7be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08886346-2405-47ee-997f-c0fb7776c783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08886346-2405-47ee-997f-c0fb7776c783.jpg?1",
             "name": "Obscura Interceptor",
             "text": "Flash\nLifelink\nWhen Obscura Interceptor enters the battlefield, it connives. When it connives this way, return up to one target spell to its owner's hand. (To have a creature connive, draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)",
             "colours": [
@@ -8633,7 +8633,7 @@
         },
         {
             "id": "1fc40098-e282-524a-980c-0ef11ab3fa00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636058c3-bacc-4a66-8988-832ab0cc9be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636058c3-bacc-4a66-8988-832ab0cc9be6.jpg?1",
             "name": "Ognis, the Dragon's Lash",
             "text": "Haste\nWhenever a creature you control with haste attacks, create a tapped Treasure token.",
             "colours": [
@@ -8677,7 +8677,7 @@
         },
         {
             "id": "86216679-02fd-5827-b575-d6350f4f33a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba250e8-1ceb-40f5-95f1-fb00a2a723eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba250e8-1ceb-40f5-95f1-fb00a2a723eb.jpg?1",
             "name": "Park Heights Pegasus",
             "text": "Flying, trample\nWhenever Park Heights Pegasus deals combat damage to a player, draw a card if you had two or more creatures enter the battlefield under your control this turn.",
             "colours": [
@@ -8715,7 +8715,7 @@
         },
         {
             "id": "d473ada7-00e4-57be-9813-600ab3cc7f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edb7a26-82be-4efd-9a5c-a3816e1ee2d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edb7a26-82be-4efd-9a5c-a3816e1ee2d6.jpg?1",
             "name": "Queza, Augur of Agonies",
             "text": "Whenever you draw a card, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "dc0faba5-ac21-5610-b725-1ca2e9f25476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3da27e-4fdd-46ce-bb81-0b2dfec1c6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3da27e-4fdd-46ce-bb81-0b2dfec1c6ed.jpg?1",
             "name": "A-Queza, Augur of Agonies",
             "text": "",
             "colours": [
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "12151123-1ef3-5c66-a91e-31aee92a06c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716a44b4-f6b0-4f14-a270-6442aed3251f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716a44b4-f6b0-4f14-a270-6442aed3251f.jpg?1",
             "name": "Raffine, Scheming Seer",
             "text": "Flying, ward {1}\nWhenever you attack, target attacking creature connives X, where X is the number of attacking creatures. (Draw X cards, then discard X cards. Put a +1/+1 counter on that creature for each nonland card discarded this way.)",
             "colours": [
@@ -8843,7 +8843,7 @@
         },
         {
             "id": "83e06117-fee3-5e58-97ae-982c1bc969fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c74197a-367c-40a4-9eb5-6943490bba09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c74197a-367c-40a4-9eb5-6943490bba09.jpg?1",
             "name": "Rakish Revelers",
             "text": "When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{2}, Exile Rakish Revelers from your hand: Target land gains \"{T}: Add {R}, {G}, or {W}\" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "7748f39d-fbc1-5aa5-80ff-7aab475c935a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b799b01d-2e9b-4ef0-b518-bb3684cd524d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b799b01d-2e9b-4ef0-b518-bb3684cd524d.jpg?1",
             "name": "A-Rakish Revelers",
             "text": "",
             "colours": [
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "ecaf5993-3299-511a-b284-c77755324a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c6aef6-d846-4e02-a5f9-6eb0b2212208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c6aef6-d846-4e02-a5f9-6eb0b2212208.jpg?1",
             "name": "Rigo, Streetwise Mentor",
             "text": "Rigo, Streetwise Mentor enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever you attack a player or planeswalker with one or more creatures with power 1 or less, draw a card.",
             "colours": [
@@ -8969,7 +8969,7 @@
         },
         {
             "id": "15d1abbc-b7f3-5207-9075-d634cfb540c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21235916-2379-470c-b9ee-84246043d703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21235916-2379-470c-b9ee-84246043d703.jpg?1",
             "name": "Riveteers Ascendancy",
             "text": "Whenever you sacrifice a creature, you may return target creature card with lesser mana value from your graveyard to the battlefield tapped. Do this only once each turn.",
             "colours": [
@@ -9008,7 +9008,7 @@
         },
         {
             "id": "2de899c8-a028-569d-b844-712ff24ae768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784a5915-bc42-49d6-8a1b-45da7749f03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784a5915-bc42-49d6-8a1b-45da7749f03a.jpg?1",
             "name": "Riveteers Charm",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature or planeswalker they control with the highest mana value among creatures and planeswalkers they control.\n\u2022 Exile the top three cards of your library. Until your next end step, you may play those cards.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -9047,7 +9047,7 @@
         },
         {
             "id": "4a9f6e45-b462-59fd-bc7c-49e96cfa0c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cf8b35-2a81-40fd-b383-becb81bef806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cf8b35-2a81-40fd-b383-becb81bef806.jpg?1",
             "name": "Rocco, Cabaretti Caterer",
             "text": "When Rocco, Cabaretti Caterer enters the battlefield, if you cast it, you may search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -9091,7 +9091,7 @@
         },
         {
             "id": "08167fb4-cce0-5341-911e-e8a487eabd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7ef030-7bae-4820-b51a-8fad57a8ff2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7ef030-7bae-4820-b51a-8fad57a8ff2f.jpg?1",
             "name": "Scheming Fence",
             "text": "As Scheming Fence enters the battlefield, you may choose a nonland permanent.\nActivated abilities of the chosen permanent can't be activated.\nScheming Fence has all activated abilities of the chosen permanent except for loyalty abilities. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "530c5ace-2c3a-5e19-999b-08a32ffec03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050dd40-9a18-41e4-97e6-fce5bf220ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050dd40-9a18-41e4-97e6-fce5bf220ccf.jpg?1",
             "name": "Security Rhox",
             "text": "You may pay {R}{G} rather than pay this spell's mana cost. Spend only mana produced by Treasures to cast it this way.",
             "colours": [
@@ -9168,7 +9168,7 @@
         },
         {
             "id": "a22f5b9e-4863-5bfc-a132-99ca52151402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61a849b-601b-4d5a-9a4e-84e7eb685b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61a849b-601b-4d5a-9a4e-84e7eb685b09.jpg?1",
             "name": "A-Security Rhox",
             "text": "",
             "colours": [
@@ -9204,7 +9204,7 @@
         },
         {
             "id": "9a7ad1e4-e7e6-5379-9b82-4c546c601816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75ba0d-230e-4ca4-bb40-bd05af2a4457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75ba0d-230e-4ca4-bb40-bd05af2a4457.jpg?1",
             "name": "Shattered Seraph",
             "text": "Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{2}, Exile Shattered Seraph from your hand: Target land gains \"{T}: Add {W}, {U}, or {B}\" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.",
             "colours": [
@@ -9246,7 +9246,7 @@
         },
         {
             "id": "f33b68df-48d6-52e6-b5b2-c1f04e703097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574a8645-9f6e-4657-afac-5d8242e011cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574a8645-9f6e-4657-afac-5d8242e011cb.jpg?1",
             "name": "A-Shattered Seraph",
             "text": "",
             "colours": [
@@ -9284,7 +9284,7 @@
         },
         {
             "id": "ace33caf-b031-5a60-a62f-194dbb424d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed1e957-3df1-4640-9980-783817826602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed1e957-3df1-4640-9980-783817826602.jpg?1",
             "name": "Snooping Newsie",
             "text": "When Snooping Newsie enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)\nAs long as there are five or more mana values among cards in your graveyard, Snooping Newsie gets +1/+1 and has lifelink.",
             "colours": [
@@ -9321,7 +9321,7 @@
         },
         {
             "id": "2f84cef6-d0d6-5469-b68d-f22656cc7611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13b82-0650-48f2-9e42-3610b43e2e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13b82-0650-48f2-9e42-3610b43e2e10.jpg?1",
             "name": "Soul of Emancipation",
             "text": "When Soul of Emancipation enters the battlefield, destroy up to three other target nonland permanents. For each of those permanents, its controller creates a 3/3 white Angel creature token with flying.",
             "colours": [
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "276cf6af-10c9-57de-9daf-d3e32c783608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29eb0e40-d184-423f-8484-ee288fda00cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29eb0e40-d184-423f-8484-ee288fda00cd.jpg?1",
             "name": "Spara's Adjudicators",
             "text": "When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{2}, Exile Spara's Adjudicators from your hand: Target land gains \"{T}: Add {G}, {W}, or {U}\" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.",
             "colours": [
@@ -9404,7 +9404,7 @@
         },
         {
             "id": "271e916e-c3ef-5ebc-a542-4fa1bedfb489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564085e-2abd-4ecc-9b7a-19a69ddabc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564085e-2abd-4ecc-9b7a-19a69ddabc84.jpg?1",
             "name": "A-Spara's Adjudicators",
             "text": "",
             "colours": [
@@ -9442,7 +9442,7 @@
         },
         {
             "id": "8e6fd3ca-3fc0-5579-b8e5-e94628dbddd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbe7459-8613-4ab8-84dc-deab19c08511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbe7459-8613-4ab8-84dc-deab19c08511.jpg?1",
             "name": "Stimulus Package",
             "text": "When Stimulus Package enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nSacrifice a Treasure: Create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -9476,7 +9476,7 @@
         },
         {
             "id": "93cbf7ec-2a74-5acd-a058-69186dde9bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7187e3-0b8e-4a63-a6e5-aeef3c0e8872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7187e3-0b8e-4a63-a6e5-aeef3c0e8872.jpg?1",
             "name": "A-Stimulus Package",
             "text": "",
             "colours": [
@@ -9509,7 +9509,7 @@
         },
         {
             "id": "64ac350f-d715-5386-97c7-7caf53eba902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf86c5f2-0caf-48ca-b7ad-a1cdcd014539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf86c5f2-0caf-48ca-b7ad-a1cdcd014539.jpg?1",
             "name": "Syndicate Infiltrator",
             "text": "Flying\nAs long as there are five or more mana values among cards in your graveyard, Syndicate Infiltrator gets +2/+2.",
             "colours": [
@@ -9546,7 +9546,7 @@
         },
         {
             "id": "1bdb024a-04db-5b79-9152-9b6650e5dbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0edc749-8603-4849-9426-6105dddd7566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0edc749-8603-4849-9426-6105dddd7566.jpg?1",
             "name": "A-Syndicate Infiltrator",
             "text": "",
             "colours": [
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "71f162ec-d88d-5db0-b421-511af0a0a744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347d883c-84ab-4547-813b-f4385366fbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347d883c-84ab-4547-813b-f4385366fbce.jpg?1",
             "name": "Tainted Indulgence",
             "text": "Draw two cards. Then discard a card unless there are five or more mana values among cards in your graveyard.",
             "colours": [
@@ -9616,7 +9616,7 @@
         },
         {
             "id": "82b9e789-985a-5827-8323-ad752f99a35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01f12e0-f354-43aa-9e2d-b59a99571a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01f12e0-f354-43aa-9e2d-b59a99571a5f.jpg?1",
             "name": "Toluz, Clever Conductor",
             "text": "When Toluz, Clever Conductor enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)\nWhenever you discard one or more cards, exile them from your graveyard.\nWhen Toluz dies, put the cards exiled with it into their owner's hand.",
             "colours": [
@@ -9660,7 +9660,7 @@
         },
         {
             "id": "c102bc68-8ce3-50ae-aaa6-e13827033cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f892607-8672-4013-86e6-0779d0b726de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f892607-8672-4013-86e6-0779d0b726de.jpg?1",
             "name": "Unleash the Inferno",
             "text": "Unleash the Inferno deals 7 damage to target creature or planeswalker. When it deals excess damage this way, destroy target artifact or enchantment an opponent controls with mana value less than or equal to that amount of excess damage.",
             "colours": [
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "b3f8347a-8cc7-558d-99f7-537e74194e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daab74d-d66b-4164-aa19-24e8d5536f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daab74d-d66b-4164-aa19-24e8d5536f7d.jpg?1",
             "name": "Void Rend",
             "text": "This spell can't be countered.\nDestroy target nonland permanent.",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "c309e894-bdfb-582b-b110-f74f3137254c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4fa4c8-f09f-4d97-a7d1-1b93caf7d4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4fa4c8-f09f-4d97-a7d1-1b93caf7d4f9.jpg?1",
             "name": "Ziatora, the Incinerator",
             "text": "Flying\nAt the beginning of your end step, you may sacrifice another creature. When you do, Ziatora, the Incinerator deals damage equal to that creature's power to any target and you create three Treasure tokens.",
             "colours": [
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "2ef058cb-bb32-5322-9dec-10e55a5d2f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba39154c-aace-4d55-a3ad-7c9eb717ed2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba39154c-aace-4d55-a3ad-7c9eb717ed2b.jpg?1",
             "name": "Ziatora's Envoy",
             "text": "Trample\nWhenever Ziatora's Envoy deals combat damage to a player, look at the top card of your library. You may play a land from the top of your library or cast a spell with mana value less than or equal to the damage dealt from the top of your library without paying its mana cost. If you don't, put that card into your hand.\nBlitz {2}{B}{R}{G}",
             "colours": [
@@ -9824,7 +9824,7 @@
         },
         {
             "id": "7ca97156-5224-5271-ba6c-c786f0a8745a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a00ed-dc77-4dcd-9e14-6902565974b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a00ed-dc77-4dcd-9e14-6902565974b5.jpg?1",
             "name": "Arc Spitter",
             "text": "Equipped creature has \"{1}: This creature deals 1 damage to target creature that's blocking it.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9854,7 +9854,7 @@
         },
         {
             "id": "3bc1de2b-964b-50ec-ad4e-1dc5840648bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd31ee9e-1af7-4eb4-bda8-11451ebd6927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd31ee9e-1af7-4eb4-bda8-11451ebd6927.jpg?1",
             "name": "Brass Knuckles",
             "text": "When you cast this spell, copy it. (The copy becomes a token.)\nEquipped creature has double strike as long as two or more Equipment are attached to it.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9884,7 +9884,7 @@
         },
         {
             "id": "a453cf7a-b244-5fff-91e3-ba12294db816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1100dba-de2d-481e-b29c-71f6d34663ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1100dba-de2d-481e-b29c-71f6d34663ba.jpg?1",
             "name": "Cement Shoes",
             "text": "Equipped creature gets +3/+3 and has \"At the beginning of your end step, tap this creature.\"\nEquipped creature doesn't untap during its controller's untap step.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9914,7 +9914,7 @@
         },
         {
             "id": "06a02af5-c940-5857-ab65-91b9004c9940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da50ba-2061-40f0-b3af-950b87f812cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da50ba-2061-40f0-b3af-950b87f812cd.jpg?1",
             "name": "Chrome Cat",
             "text": "When Chrome Cat enters the battlefield, scry 1.",
             "colours": [],
@@ -9945,7 +9945,7 @@
         },
         {
             "id": "c04fdfb9-b6da-58e1-8e4b-63e1130105bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d2fa3-3f5a-4b6f-8b7e-6a8bf65c07ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d2fa3-3f5a-4b6f-8b7e-6a8bf65c07ad.jpg?1",
             "name": "Getaway Car",
             "text": "Haste\nWhenever Getaway Car attacks or blocks, return up to one target creature that crewed it this turn to its owner's hand.\nCrew 1",
             "colours": [],
@@ -9977,7 +9977,7 @@
         },
         {
             "id": "58c7e5f7-3674-58f5-9af2-ed561883d130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca8554a-f74c-4d2d-95b6-ef6e74431d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca8554a-f74c-4d2d-95b6-ef6e74431d7c.jpg?1",
             "name": "Gilded Pinions",
             "text": "When Gilded Pinions enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10007,7 +10007,7 @@
         },
         {
             "id": "ff39b047-eea7-5666-b122-7bf3faa1a377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eead159-b9a1-4c64-affe-c77b0a9e4775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eead159-b9a1-4c64-affe-c77b0a9e4775.jpg?1",
             "name": "Halo Scarab",
             "text": "{2}, Exile Halo Scarab from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -10038,7 +10038,7 @@
         },
         {
             "id": "dc198ede-887f-55e3-95cb-627043929ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1833662b-ccf3-4c16-9767-666d6407aa65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1833662b-ccf3-4c16-9767-666d6407aa65.jpg?1",
             "name": "Luxior, Giada's Gift",
             "text": "Equipped creature gets +1/+1 for each counter on it.\nEquipped permanent isn't a planeswalker and is a creature in addition to its other types. (Loyalty abilities can still be activated.)\nEquip planeswalker {1}\nEquip {3}",
             "colours": [],
@@ -10072,7 +10072,7 @@
         },
         {
             "id": "15fdb024-c094-5fe7-8f36-56ea48965195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1691374-e9f2-4a8b-abdb-0bb1dbc96715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1691374-e9f2-4a8b-abdb-0bb1dbc96715.jpg?1",
             "name": "Ominous Parcel",
             "text": "{2}, {T}, Sacrifice Ominous Parcel: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{5}, {T}, Sacrifice Ominous Parcel: It deals 4 damage to target creature.",
             "colours": [],
@@ -10100,7 +10100,7 @@
         },
         {
             "id": "1d620f05-bddf-5c47-9424-f4d0f4cc6ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc9bf5-0f22-4e41-b2ad-f4c9ce390826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc9bf5-0f22-4e41-b2ad-f4c9ce390826.jpg?1",
             "name": "A-Ominous Parcel",
             "text": "",
             "colours": [],
@@ -10127,7 +10127,7 @@
         },
         {
             "id": "aa7e0218-3eb8-5384-a482-697def437345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939450d7-1107-4645-ad23-68749b1ec4c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939450d7-1107-4645-ad23-68749b1ec4c2.jpg?1",
             "name": "Paragon of Modernity",
             "text": "Flying\n{3}: Paragon of Modernity gets +1/+1 until end of turn. If exactly three colors of mana were spent to activate this ability, put a +1/+1 counter on it instead.",
             "colours": [],
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "8d57c205-0a5b-5f24-a22f-21130098409c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58708-3d62-4ab9-bf65-1cd707f2b753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58708-3d62-4ab9-bf65-1cd707f2b753.jpg?1",
             "name": "A-Paragon of Modernity",
             "text": "",
             "colours": [],
@@ -10190,7 +10190,7 @@
         },
         {
             "id": "f26f0ea4-f3c5-50f3-a59a-ab7671225f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64110f4-c4b6-4966-a23a-8da7d1983499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64110f4-c4b6-4966-a23a-8da7d1983499.jpg?1",
             "name": "Quick-Draw Dagger",
             "text": "Flash\nWhen Quick-Draw Dagger enters the battlefield, attach it to target creature you control. That creature gains first strike until end of turn.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10220,7 +10220,7 @@
         },
         {
             "id": "b4cbd923-0245-56e9-b87b-b5024f009d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edbece0-8444-4634-a47b-7c88d1b8325e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edbece0-8444-4634-a47b-7c88d1b8325e.jpg?1",
             "name": "Scuttling Butler",
             "text": "At the beginning of combat on your turn, if you control two or more multicolored permanents, Scuttling Butler gains double strike until end of turn.",
             "colours": [],
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "5362af50-d8cb-53fd-a8ea-c40ccd956c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc574b42-e1bb-428f-a71f-bc3d7f5451da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc574b42-e1bb-428f-a71f-bc3d7f5451da.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -10282,7 +10282,7 @@
         },
         {
             "id": "caf3eb8d-449b-58c2-8d27-7a7bb6abfbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ee60f7-31dd-4bc6-b71f-57a1a0d19d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ee60f7-31dd-4bc6-b71f-57a1a0d19d20.jpg?1",
             "name": "Unlicensed Hearse",
             "text": "{T}: Exile up to two target cards from a single graveyard.\nUnlicensed Hearse's power and toughness are each equal to the number of cards exiled with it.\nCrew 2",
             "colours": [],
@@ -10314,7 +10314,7 @@
         },
         {
             "id": "7ff2b8fe-9fd1-5684-8ba5-5a346ecda6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a6f93-1fc8-4690-add4-538763277f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a6f93-1fc8-4690-add4-538763277f8e.jpg?1",
             "name": "Botanical Plaza",
             "text": "Botanical Plaza enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}, {T}, Sacrifice Botanical Plaza: Draw a card.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "babfd0d5-c4b2-561a-98ca-7eb6997b10cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b299b-daa9-4bda-94e2-9a2f0e8f2bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b299b-daa9-4bda-94e2-9a2f0e8f2bce.jpg?1",
             "name": "Brokers Hideout",
             "text": "When Brokers Hideout enters the battlefield, sacrifice it. When you do, search your library for a basic Forest, Plains, or Island card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10375,7 +10375,7 @@
         },
         {
             "id": "77ae2788-503b-5114-a7e7-0d6f56a67085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda1e1c-b330-42e0-8547-97e2afc7615f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda1e1c-b330-42e0-8547-97e2afc7615f.jpg?1",
             "name": "Cabaretti Courtyard",
             "text": "When Cabaretti Courtyard enters the battlefield, sacrifice it. When you do, search your library for a basic Mountain, Forest, or Plains card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10403,7 +10403,7 @@
         },
         {
             "id": "125b1fac-a9a2-5114-99f6-a0881ee0baba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d40e03-6de4-4373-9fbf-04c1dd79e995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d40e03-6de4-4373-9fbf-04c1dd79e995.jpg?1",
             "name": "Jetmir's Garden",
             "text": "({T}: Add {R}, {G}, or {W}.)\nJetmir's Garden enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10442,7 +10442,7 @@
         },
         {
             "id": "b97a06ac-b779-52a2-90b4-ec72b73ed22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb4a44-a5c8-49ed-b440-2462626bb638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb4a44-a5c8-49ed-b440-2462626bb638.jpg?1",
             "name": "Maestros Theater",
             "text": "When Maestros Theater enters the battlefield, sacrifice it. When you do, search your library for a basic Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "00542ebe-9ff3-5ba1-9015-1028e95b7f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016b884-9a4c-41de-bd65-14271f4f6f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016b884-9a4c-41de-bd65-14271f4f6f9a.jpg?1",
             "name": "Obscura Storefront",
             "text": "When Obscura Storefront enters the battlefield, sacrifice it. When you do, search your library for a basic Plains, Island, or Swamp card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10498,7 +10498,7 @@
         },
         {
             "id": "485589c2-6fac-5123-854b-640a1b60b1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a11bdb2-a269-4038-85f3-69fbd02982e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a11bdb2-a269-4038-85f3-69fbd02982e9.jpg?1",
             "name": "Racers' Ring",
             "text": "Racers' Ring enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}, {T}, Sacrifice Racers' Ring: Draw a card.",
             "colours": [],
@@ -10531,7 +10531,7 @@
         },
         {
             "id": "f720ce4d-53e8-5609-85c1-b6c1a48ba9a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c56479-4bee-4edb-80d7-4af010b7c793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c56479-4bee-4edb-80d7-4af010b7c793.jpg?1",
             "name": "Raffine's Tower",
             "text": "({T}: Add {W}, {U}, or {B}.)\nRaffine's Tower enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10570,7 +10570,7 @@
         },
         {
             "id": "9b7b4f27-258f-5669-a017-ca2844dcd021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d161f81-c01a-4c91-b025-52dcb1881638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d161f81-c01a-4c91-b025-52dcb1881638.jpg?1",
             "name": "Riveteers Overlook",
             "text": "When Riveteers Overlook enters the battlefield, sacrifice it. When you do, search your library for a basic Swamp, Mountain, or Forest card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "167cdd89-20de-54a5-a9a7-a49861378897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28c871f-a96a-4e7d-a159-2e93aeb276d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28c871f-a96a-4e7d-a159-2e93aeb276d4.jpg?1",
             "name": "Skybridge Towers",
             "text": "Skybridge Towers enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice Skybridge Towers: Draw a card.",
             "colours": [],
@@ -10631,7 +10631,7 @@
         },
         {
             "id": "a4741f3f-c856-541b-ad21-1bdc8ef3603e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7363f1fb-9af3-4212-921f-d59533faf0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7363f1fb-9af3-4212-921f-d59533faf0e5.jpg?1",
             "name": "Spara's Headquarters",
             "text": "({T}: Add {G}, {W}, or {U}.)\nSpara's Headquarters enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10670,7 +10670,7 @@
         },
         {
             "id": "abdf3fb3-b44f-593a-8412-5fd75405f666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0532304-da6d-45cd-b1e6-4779d3f3b2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0532304-da6d-45cd-b1e6-4779d3f3b2bc.jpg?1",
             "name": "Tramway Station",
             "text": "Tramway Station enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice Tramway Station: Draw a card.",
             "colours": [],
@@ -10703,7 +10703,7 @@
         },
         {
             "id": "37854b64-5137-5d0d-be4d-1e5eae1fcb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debf7aac-4d31-49b4-955b-79036258df69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debf7aac-4d31-49b4-955b-79036258df69.jpg?1",
             "name": "Waterfront District",
             "text": "Waterfront District enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}, {T}, Sacrifice Waterfront District: Draw a card.",
             "colours": [],
@@ -10736,7 +10736,7 @@
         },
         {
             "id": "3ceba63f-5328-525b-ac05-463aa2572340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f449ff-4025-465e-9ec5-a5cf42c4c9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f449ff-4025-465e-9ec5-a5cf42c4c9d3.jpg?1",
             "name": "Xander's Lounge",
             "text": "({T}: Add {U}, {B}, or {R}.)\nXander's Lounge enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "0a37f434-4d9d-5b4d-834d-b7e26d1671b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fdce80-e338-4a50-bdc6-786511feaeef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fdce80-e338-4a50-bdc6-786511feaeef.jpg?1",
             "name": "Ziatora's Proving Ground",
             "text": "({T}: Add {B}, {R}, or {G}.)\nZiatora's Proving Ground enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "534bbb04-1ee6-5bf2-a6e0-df2365eefe9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbb3646-c427-4302-86ac-9ac28d045959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbb3646-c427-4302-86ac-9ac28d045959.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10852,7 +10852,7 @@
         },
         {
             "id": "f9a0b1b6-a02b-51f5-9602-c81db95aa26e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6f0743-c433-4348-bcef-20cfe7b28293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6f0743-c433-4348-bcef-20cfe7b28293.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10890,7 +10890,7 @@
         },
         {
             "id": "08ca354f-d163-5aa7-80cb-6b8dab4893e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef2c956-cf03-462c-8981-ae80edfc0c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef2c956-cf03-462c-8981-ae80edfc0c5a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10928,7 +10928,7 @@
         },
         {
             "id": "3c120d84-891a-592a-a929-db42ace24012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd1b4d2-ccf0-498d-81e0-c9d755f5eb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd1b4d2-ccf0-498d-81e0-c9d755f5eb13.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10966,7 +10966,7 @@
         },
         {
             "id": "58ba82cb-f820-5bc3-b18b-11a85dcb2a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0175a2a-db46-4d25-ab8e-feca7e565b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0175a2a-db46-4d25-ab8e-feca7e565b8d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "bbdc0fde-ad25-502e-b561-bda44c83992b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8515d2-e8a4-45ab-b361-88eb4ec959bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8515d2-e8a4-45ab-b361-88eb4ec959bd.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "d6597d84-7cfa-55ab-83cf-5b60138132b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac247df-aa19-4627-8d65-6ddf5e7e5c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac247df-aa19-4627-8d65-6ddf5e7e5c8c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11080,7 +11080,7 @@
         },
         {
             "id": "432b0a1c-dceb-5a9c-ae8b-6e4a1ae9155d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abb2702-6f5e-4832-9e23-46aaf9f960f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abb2702-6f5e-4832-9e23-46aaf9f960f8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11118,7 +11118,7 @@
         },
         {
             "id": "7b48a4f1-bca0-5957-a0fe-65845bda7e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086cb5e-3146-4a41-a471-fcbbf8fa4e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086cb5e-3146-4a41-a471-fcbbf8fa4e09.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11156,7 +11156,7 @@
         },
         {
             "id": "57271aa6-7adc-5753-a50f-fe04e8269c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818442df-fb81-4f1c-bcf2-fbd6b05912ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818442df-fb81-4f1c-bcf2-fbd6b05912ed.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "673545ff-4a80-522f-a4fb-2cd55713b44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882099c-63cd-42f0-b160-35e6922106b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882099c-63cd-42f0-b160-35e6922106b1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11232,7 +11232,7 @@
         },
         {
             "id": "c0c0e897-4ca8-5e95-9c74-18cf30a6bef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa69cedc-49ce-48f3-88e1-94b9bc061bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa69cedc-49ce-48f3-88e1-94b9bc061bf4.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "0e0fb850-9541-5bb0-8cd8-2010d5903ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8221d15c-c993-4345-a6bb-6a7d215e3273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8221d15c-c993-4345-a6bb-6a7d215e3273.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "e6d1f3b9-96f4-5f2d-9014-b154c0efa933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaba7cd-c1dc-49cf-8d63-8bb3594a6541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaba7cd-c1dc-49cf-8d63-8bb3594a6541.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11346,7 +11346,7 @@
         },
         {
             "id": "6aaf0f1d-8969-578f-a0ae-8ccdb269fc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f917d8d-7037-4f11-91f6-1ef96b3541bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f917d8d-7037-4f11-91f6-1ef96b3541bb.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11384,7 +11384,7 @@
         },
         {
             "id": "fb9c240c-b962-529c-b028-c10793caae98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4569823-af23-4eea-acc9-2a2c62bce3b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4569823-af23-4eea-acc9-2a2c62bce3b0.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11422,7 +11422,7 @@
         },
         {
             "id": "34160ea7-88c7-5374-8533-6090560496fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a58066e-f9a2-4508-9cc0-908b1cf747e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a58066e-f9a2-4508-9cc0-908b1cf747e3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11460,7 +11460,7 @@
         },
         {
             "id": "65fe61dc-09b9-5a36-88cd-17585de8df52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97dadd-0849-4c18-9523-4775d09fca9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97dadd-0849-4c18-9523-4775d09fca9a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11498,7 +11498,7 @@
         },
         {
             "id": "3f20eb1c-d261-54e2-bdd2-d18cf700e60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c726424a-3336-4e15-9055-4a26371df361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c726424a-3336-4e15-9055-4a26371df361.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11536,7 +11536,7 @@
         },
         {
             "id": "2a25f107-c0c1-56d4-afd9-20bccc42b727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633eb269-916e-4d79-821e-1f304283416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633eb269-916e-4d79-821e-1f304283416c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "b369aae6-5d3d-55b2-9072-45bc6735e46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d75499-1be8-42a0-8520-9cd8adbd0ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d75499-1be8-42a0-8520-9cd8adbd0ca3.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "+1: Choose up to one target creature. Put a +1/+1 counter and a counter from among flying, first strike, lifelink, or vigilance on it.\n\u22123: Look at the top seven cards of your library. You may put a permanent card with mana value 3 or less from among them onto the battlefield with a shield counter on it. Put the rest on the bottom of your library in a random order.\n\u22127: Create five 3/3 white Angel creature tokens with flying.",
             "colours": [
@@ -11614,7 +11614,7 @@
         },
         {
             "id": "dfd29f52-5a15-5bcd-99f6-2b1ba55721a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3979b3d5-7551-4161-bfe5-fe4b54fd96e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3979b3d5-7551-4161-bfe5-fe4b54fd96e5.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "+2: You may sacrifice a creature. If you do, search your library for a creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it onto the battlefield, then shuffle.\n+1: Mill five cards, then put any number of creature cards milled this way into your hand.\n\u22121: Create a 4/4 green Rhino Warrior creature token.",
             "colours": [
@@ -11654,7 +11654,7 @@
         },
         {
             "id": "6113cfa0-182c-5789-9701-9a2f3b243cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb93677-12a7-489c-a88a-0963dc5f3f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb93677-12a7-489c-a88a-0963dc5f3f1d.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "Casualty X. The copy isn't legendary and has starting loyalty X. (As you cast this spell, you may sacrifice a creature with power X. When you do, copy this spell. The copy becomes a token.)\n+1: Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22127: Target player draws seven cards and loses 7 life.",
             "colours": [
@@ -11696,7 +11696,7 @@
         },
         {
             "id": "6620d5aa-2842-56c7-afb1-0edc3691907a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131b10f-f14f-40e1-969b-224fcce2ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131b10f-f14f-40e1-969b-224fcce2ed18.jpg?1",
             "name": "Halo Fountain",
             "text": "{W}, {T}, Untap a tapped creature you control: Create a 1/1 green and white Citizen creature token.\n{W}{W}, {T}, Untap two tapped creatures you control: Draw a card.\n{W}{W}{W}{W}{W}, {T}, Untap fifteen tapped creatures you control: You win the game.",
             "colours": [
@@ -11730,7 +11730,7 @@
         },
         {
             "id": "743fa882-90fb-56d8-b547-498cfa891240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac7e199-c32e-4479-a92f-df52f1182c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac7e199-c32e-4479-a92f-df52f1182c9a.jpg?1",
             "name": "All-Seeing Arbiter",
             "text": "Flying\nWhenever All-Seeing Arbiter enters the battlefield or attacks, draw two cards, then discard a card.\nWhenever you discard a card, target creature an opponent controls gets -X/-0 until your next turn, where X is the number of different mana values among cards in your graveyard.",
             "colours": [
@@ -11766,7 +11766,7 @@
         },
         {
             "id": "fab575b9-45c6-5311-a8d2-1937ce3cbe09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a05539-ec37-46b4-92f3-feda5f02ddb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a05539-ec37-46b4-92f3-feda5f02ddb3.jpg?1",
             "name": "Shadow of Mortality",
             "text": "If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.",
             "colours": [
@@ -11802,7 +11802,7 @@
         },
         {
             "id": "bbf5e68a-e6e9-59d6-80f8-332fcce894e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32eb60a-14ac-4ea9-a4c5-6597194af0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32eb60a-14ac-4ea9-a4c5-6597194af0c1.jpg?1",
             "name": "Bootleggers' Stash",
             "text": "Lands you control have \"{T}: Create a Treasure token.\"",
             "colours": [
@@ -11836,7 +11836,7 @@
         },
         {
             "id": "90eb020b-6e49-5748-bef1-3e697945abe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb623e9-384e-41bb-b3af-f593212a0e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb623e9-384e-41bb-b3af-f593212a0e77.jpg?1",
             "name": "Titan of Industry",
             "text": "Reach, trample\nWhen Titan of Industry enters the battlefield, choose two \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Target player gains 5 life.\n\u2022 Create a 4/4 green Rhino Warrior creature token.\n\u2022 Put a shield counter on a creature you control.",
             "colours": [
@@ -11872,7 +11872,7 @@
         },
         {
             "id": "2e8f6e08-f419-55ca-9610-26d3e7dca6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4cf10c-be3f-42df-aaf8-42378b8a15d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4cf10c-be3f-42df-aaf8-42378b8a15d1.jpg?1",
             "name": "Topiary Stomper",
             "text": "Vigilance\nWhen Topiary Stomper enters the battlefield, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nTopiary Stomper can't attack or block unless you control seven or more lands.",
             "colours": [
@@ -11909,7 +11909,7 @@
         },
         {
             "id": "3fa82687-0f93-59b9-8f8e-1272df5c955e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bb5f59-2a63-421b-94a1-4cbef00f0c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bb5f59-2a63-421b-94a1-4cbef00f0c7e.jpg?1",
             "name": "Jetmir's Garden",
             "text": "({T}: Add {R}, {G}, or {W}.)\nJetmir's Garden enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "088c97ed-fbc0-52db-9896-3d732f8c5983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa23075-d826-4654-9d5e-993c9824593d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa23075-d826-4654-9d5e-993c9824593d.jpg?1",
             "name": "Raffine's Tower",
             "text": "({T}: Add {W}, {U}, or {B}.)\nRaffine's Tower enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -11987,7 +11987,7 @@
         },
         {
             "id": "e094d05e-ec3d-527c-851a-57d9feb1daf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a0d4a-3777-451d-a2fb-f1a2fdf8019f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a0d4a-3777-451d-a2fb-f1a2fdf8019f.jpg?1",
             "name": "Spara's Headquarters",
             "text": "({T}: Add {G}, {W}, or {U}.)\nSpara's Headquarters enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -12026,7 +12026,7 @@
         },
         {
             "id": "57a68792-e6db-5cdd-809b-e18821e1a933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9412a7ce-ffaa-4224-8434-c326280283a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9412a7ce-ffaa-4224-8434-c326280283a8.jpg?1",
             "name": "Xander's Lounge",
             "text": "({T}: Add {U}, {B}, or {R}.)\nXander's Lounge enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "df152162-21b0-5533-a9c7-621f3fa278c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea8c9f0-cec9-4ba4-b8df-6e52f2d77dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea8c9f0-cec9-4ba4-b8df-6e52f2d77dff.jpg?1",
             "name": "Ziatora's Proving Ground",
             "text": "({T}: Add {B}, {R}, or {G}.)\nZiatora's Proving Ground enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -12104,7 +12104,7 @@
         },
         {
             "id": "32f197d7-82f8-5cbb-9ec1-fbddc1d511fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fd80c9-e86c-48bd-8c8b-654a29665931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fd80c9-e86c-48bd-8c8b-654a29665931.jpg?1",
             "name": "Brazen Upstart",
             "text": "Vigilance\nWhen Brazen Upstart dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12146,7 +12146,7 @@
         },
         {
             "id": "361779da-167f-5d57-993f-94d1664637e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa2713b-5df0-4e54-89bf-30b5aeba9ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa2713b-5df0-4e54-89bf-30b5aeba9ac7.jpg?1",
             "name": "Brokers Ascendancy",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control and a loyalty counter on each planeswalker you control.",
             "colours": [
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "87cbd0bb-e133-5d4a-88ae-e9e034c0b938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aac0943-6c9a-4c65-9d17-3ca0f2ba2340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aac0943-6c9a-4c65-9d17-3ca0f2ba2340.jpg?1",
             "name": "Brokers Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature or planeswalker an opponent controls.\n\u2022 Destroy target enchantment.\n\u2022 Draw two cards.",
             "colours": [
@@ -12224,7 +12224,7 @@
         },
         {
             "id": "fd9bbc2d-a5a9-582f-afd5-fb45cf741544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3951927-9649-4cde-8690-d371b7953738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3951927-9649-4cde-8690-d371b7953738.jpg?1",
             "name": "Cabaretti Ascendancy",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it on the bottom of your library.",
             "colours": [
@@ -12263,7 +12263,7 @@
         },
         {
             "id": "cb171706-95e7-5cde-bf95-16fcae6ddc85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb456da8-6a20-4d5e-9587-e8661ced525b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb456da8-6a20-4d5e-9587-e8661ced525b.jpg?1",
             "name": "Cabaretti Charm",
             "text": "Choose one \u2014\n\u2022 Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Create two 1/1 green and white Citizen creature tokens.",
             "colours": [
@@ -12302,7 +12302,7 @@
         },
         {
             "id": "555a23d5-0ca1-5092-a88b-fa08b44ab800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b43fca7-3b37-4d40-88c8-aa178b68f75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b43fca7-3b37-4d40-88c8-aa178b68f75c.jpg?1",
             "name": "Cormela, Glamour Thief",
             "text": "Haste\n{1}, {T}: Add {U}{B}{R}. Spend this mana only to cast instant and/or sorcery spells.\nWhen Cormela, Glamour Thief dies, return up to one target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -12346,7 +12346,7 @@
         },
         {
             "id": "000a1b60-9edf-55c7-89e4-2e7bf96448d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198ea7-729a-47ce-89dd-43f77f60247b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198ea7-729a-47ce-89dd-43f77f60247b.jpg?1",
             "name": "Corpse Appraiser",
             "text": "When Corpse Appraiser enters the battlefield, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -12388,7 +12388,7 @@
         },
         {
             "id": "529a6409-21a6-59bd-b5d6-8f34bc083a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9e01f5-393e-4f01-86b9-112a9084ad2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9e01f5-393e-4f01-86b9-112a9084ad2f.jpg?1",
             "name": "Crew Captain",
             "text": "Haste\nCrew Captain has indestructible as long as it entered the battlefield this turn.",
             "colours": [
@@ -12430,7 +12430,7 @@
         },
         {
             "id": "377b95d3-b470-5852-8a2a-40d6b4e63d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b348b-c147-4d02-b26c-d610f515bce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b348b-c147-4d02-b26c-d610f515bce0.jpg?1",
             "name": "Disciplined Duelist",
             "text": "Double strike\nDisciplined Duelist enters the battlefield with a shield counter on it.",
             "colours": [
@@ -12472,7 +12472,7 @@
         },
         {
             "id": "f108c307-e3d2-5ef1-93b6-ecef0c95eee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55503d2-1b32-43cf-95c6-a4a61047a4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55503d2-1b32-43cf-95c6-a4a61047a4dc.jpg?1",
             "name": "Endless Detour",
             "text": "The owner of target spell, nonland permanent, or card in a graveyard puts it on the top or bottom of their library.",
             "colours": [
@@ -12511,7 +12511,7 @@
         },
         {
             "id": "b00d2918-a700-5552-b3bd-cdfb09d5ad1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd914b-4f66-4b80-8249-86f2e77f0452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd914b-4f66-4b80-8249-86f2e77f0452.jpg?1",
             "name": "Evelyn, the Covetous",
             "text": "Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.",
             "colours": [
@@ -12555,7 +12555,7 @@
         },
         {
             "id": "37180584-80ec-5531-8751-b298eec4641d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bbac59-da58-49d8-887e-272dd90724b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bbac59-da58-49d8-887e-272dd90724b4.jpg?1",
             "name": "Falco Spara, Pactweaver",
             "text": "Flying, trample\nFalco Spara, Pactweaver enters the battlefield with a shield counter on it.\nYou may look at the top card of your library any time.\nYou may cast spells from the top of your library by removing a counter from a creature you control in addition to paying their other costs.",
             "colours": [
@@ -12599,7 +12599,7 @@
         },
         {
             "id": "8c3a5bb7-16fe-5c5e-9053-205d741a13ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235929c8-a2eb-4afa-a058-ef733da01b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235929c8-a2eb-4afa-a058-ef733da01b66.jpg?1",
             "name": "Fleetfoot Dancer",
             "text": "Trample, lifelink, haste",
             "colours": [
@@ -12641,7 +12641,7 @@
         },
         {
             "id": "757beca7-a0e9-5967-bfa2-1d866d1220e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c50607c-8bf1-4a69-97da-41cd794fda62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c50607c-8bf1-4a69-97da-41cd794fda62.jpg?1",
             "name": "Glamorous Outlaw",
             "text": "When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you scry 2.\n{2}, Exile Glamorous Outlaw from your hand: Target land gains \"{T}: Add {U}, {B}, or {R}\" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.",
             "colours": [
@@ -12683,7 +12683,7 @@
         },
         {
             "id": "d5a24ec5-833a-50f9-be0f-4e9b76ecb55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8137f134-0148-4df1-b575-ec861192c65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8137f134-0148-4df1-b575-ec861192c65c.jpg?1",
             "name": "Hostile Takeover",
             "text": "Up to one target creature has base power and toughness 1/1 until end of turn. Up to one other target creature has base power and toughness 4/4 until end of turn. Then Hostile Takeover deals 3 damage to each creature.",
             "colours": [
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "7b1bd61e-0f97-5236-afa0-2b1f46670ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63167d77-a8d5-468f-9132-a5000c57901a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63167d77-a8d5-468f-9132-a5000c57901a.jpg?1",
             "name": "Incandescent Aria",
             "text": "Incandescent Aria deals 3 damage to each nontoken creature.",
             "colours": [
@@ -12761,7 +12761,7 @@
         },
         {
             "id": "71af925f-9440-508d-994e-1736f901d8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca12f3-4649-4c3a-b9f3-7ed9b7254f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca12f3-4649-4c3a-b9f3-7ed9b7254f18.jpg?1",
             "name": "Jetmir, Nexus of Revels",
             "text": "Creatures you control get +1/+0 and have vigilance as long as you control three or more creatures.\nCreatures you control also get +1/+0 and have trample as long as you control six or more creatures.\nCreatures you control also get +1/+0 and have double strike as long as you control nine or more creatures.",
             "colours": [
@@ -12805,7 +12805,7 @@
         },
         {
             "id": "3b768c16-8f46-5419-9980-4aa1b0e6dae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f2011-be9c-4b83-b503-59a59284ab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f2011-be9c-4b83-b503-59a59284ab51.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second",
             "text": "If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.",
             "colours": [
@@ -12849,7 +12849,7 @@
         },
         {
             "id": "6fe33e47-b2b5-52ea-8f54-ea5cb2dca395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5956dbe0-0d4c-42b1-8554-0fa6de1ee6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5956dbe0-0d4c-42b1-8554-0fa6de1ee6bc.jpg?1",
             "name": "Lagrella, the Magpie",
             "text": "When Lagrella, the Magpie enters the battlefield, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters the battlefield under your control this way, put two +1/+1 counters on it.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "c07a23c8-8695-5c53-8957-756c65043879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ef8f69-41d1-48f2-8ab8-69871399cc96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ef8f69-41d1-48f2-8ab8-69871399cc96.jpg?1",
             "name": "Lord Xander, the Collector",
             "text": "When Lord Xander, the Collector enters the battlefield, target opponent discards half the cards in their hand, rounded down.\nWhenever Lord Xander attacks, defending player mills half their library, rounded down.\nWhen Lord Xander dies, target opponent sacrifices half the nonland permanents they control, rounded down.",
             "colours": [
@@ -12938,7 +12938,7 @@
         },
         {
             "id": "ce0bd237-0cc1-591e-a5fd-bb32e70c7838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7d57a-10f0-4079-9dec-8d6169dbdebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7d57a-10f0-4079-9dec-8d6169dbdebc.jpg?1",
             "name": "Maestros Ascendancy",
             "text": "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -12977,7 +12977,7 @@
         },
         {
             "id": "eda91356-7a9c-556a-86cf-c0ac6f762402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e1bec-67d2-43fd-b799-b7c12b94d1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e1bec-67d2-43fd-b799-b7c12b94d1f0.jpg?1",
             "name": "Maestros Charm",
             "text": "Choose one \u2014\n\u2022 Look at the top five cards of your library. Put one of those cards into your hand and the rest into your graveyard.\n\u2022 Each opponent loses 3 life and you gain 3 life.\n\u2022 Maestros Charm deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -13016,7 +13016,7 @@
         },
         {
             "id": "8a694e38-5676-581e-9a0e-afeb2ac13bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d29c250-4673-4ae2-b9e5-cf463535a1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d29c250-4673-4ae2-b9e5-cf463535a1a3.jpg?1",
             "name": "Maestros Diabolist",
             "text": "Deathtouch, haste\nWhenever Maestros Diabolist attacks, if you don't control a Devil token, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -13058,7 +13058,7 @@
         },
         {
             "id": "db50e71b-abc7-57a8-ae5b-351f6b576c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b68f6f-d70b-4ed6-93f4-47964ee36a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b68f6f-d70b-4ed6-93f4-47964ee36a52.jpg?1",
             "name": "Masked Bandits",
             "text": "Vigilance, menace\n{2}, Exile Masked Bandits from your hand: Target land gains \"{T}: Add {B}, {R}, or {G}\" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "bfc60dce-989d-5442-84e9-6e5bc4567c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0524fc64-f51c-4991-9e43-da56afd28c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0524fc64-f51c-4991-9e43-da56afd28c00.jpg?1",
             "name": "Mr. Orfeo, the Boulder",
             "text": "Whenever you attack, double target creature's power until end of turn.",
             "colours": [
@@ -13144,7 +13144,7 @@
         },
         {
             "id": "7f9e3a79-c25c-5b4b-a65d-953f7be3ec9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f640d69-b690-4262-b3d8-e9e28c813f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f640d69-b690-4262-b3d8-e9e28c813f94.jpg?1",
             "name": "Nimble Larcenist",
             "text": "Flying\nWhen Nimble Larcenist enters the battlefield, target opponent reveals their hand. You choose an artifact, instant, or sorcery card from it and exile that card.",
             "colours": [
@@ -13186,7 +13186,7 @@
         },
         {
             "id": "2dd74cd0-36e5-59ca-b168-755b0f4bb5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9913f7-0e75-4b49-ada4-986e96b32f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9913f7-0e75-4b49-ada4-986e96b32f74.jpg?1",
             "name": "Obscura Ascendancy",
             "text": "Whenever you cast a spell, if its mana value is equal to 1 plus the number of soul counters on Obscura Ascendancy, put a soul counter on Obscura Ascendancy, then create a 2/2 white Spirit creature token with flying.\nAs long as there are five or more soul counters on Obscura Ascendancy, Spirits you control get +3/+3.",
             "colours": [
@@ -13225,7 +13225,7 @@
         },
         {
             "id": "5257dfdc-ac4c-507d-9eac-1730cf212deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a02b758-65b6-4c25-83b9-de63a1a92b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a02b758-65b6-4c25-83b9-de63a1a92b51.jpg?1",
             "name": "Obscura Charm",
             "text": "Choose one \u2014\n\u2022 Return target multicolored permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\n\u2022 Counter target instant or sorcery spell.\n\u2022 Destroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -13264,7 +13264,7 @@
         },
         {
             "id": "cefdf863-edaf-514b-a11e-814e48bd7fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3f849-bc0a-49fa-ae97-939a9eef075a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3f849-bc0a-49fa-ae97-939a9eef075a.jpg?1",
             "name": "Obscura Interceptor",
             "text": "Flash\nLifelink\nWhen Obscura Interceptor enters the battlefield, it connives. When it connives this way, return up to one target spell to its owner's hand.",
             "colours": [
@@ -13306,7 +13306,7 @@
         },
         {
             "id": "92dd0299-4646-53eb-b53b-6b2cc3d685f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1279e32d-2921-41e1-9783-7cd4391a2eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1279e32d-2921-41e1-9783-7cd4391a2eb7.jpg?1",
             "name": "Ognis, the Dragon's Lash",
             "text": "Haste\nWhenever a creature you control with haste attacks, create a tapped Treasure token.",
             "colours": [
@@ -13350,7 +13350,7 @@
         },
         {
             "id": "d9146343-67ed-587b-9294-e343582fc451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be62891-93fa-4642-ad44-8c8695a9c960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be62891-93fa-4642-ad44-8c8695a9c960.jpg?1",
             "name": "Queza, Augur of Agonies",
             "text": "Whenever you draw a card, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "7b1278d3-b67f-5785-99df-9da59fcb3b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a0ae-aee8-4a19-a8fc-9f915d7c1499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a0ae-aee8-4a19-a8fc-9f915d7c1499.jpg?1",
             "name": "Raffine, Scheming Seer",
             "text": "Flying, ward {1}\nWhenever you attack, target attacking creature connives X, where X is the number of attacking creatures.",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "3c5e3b7b-58ba-586a-a582-980da3621703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2258b7b6-e679-4fcf-9cfe-2ff01a8996dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2258b7b6-e679-4fcf-9cfe-2ff01a8996dc.jpg?1",
             "name": "Rakish Revelers",
             "text": "When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{2}, Exile Rakish Revelers from your hand: Target land gains \"{T}: Add {R}, {G}, or {W}\" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.",
             "colours": [
@@ -13481,7 +13481,7 @@
         },
         {
             "id": "1bb82142-9887-5293-84e7-a7804b37850a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7f28a1-e9bb-4fba-8984-3e4e386f77ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7f28a1-e9bb-4fba-8984-3e4e386f77ed.jpg?1",
             "name": "Rigo, Streetwise Mentor",
             "text": "Rigo, Streetwise Mentor enters the battlefield with a shield counter on it.\nWhenever you attack a player or planeswalker with one or more creatures with power 1 or less, draw a card.",
             "colours": [
@@ -13525,7 +13525,7 @@
         },
         {
             "id": "53d4dcf3-2cc7-589d-ae47-40fe2538c990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68904481-c02f-469a-806a-4db9fd151414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68904481-c02f-469a-806a-4db9fd151414.jpg?1",
             "name": "Riveteers Ascendancy",
             "text": "Whenever you sacrifice a creature, you may return target creature card with lesser mana value from your graveyard to the battlefield tapped. Do this only once each turn.",
             "colours": [
@@ -13564,7 +13564,7 @@
         },
         {
             "id": "119b2173-3eaf-5e00-8deb-c35fe7b4bbc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca0eb05-95d2-4eba-a3de-0e08739459a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca0eb05-95d2-4eba-a3de-0e08739459a3.jpg?1",
             "name": "Riveteers Charm",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature or planeswalker they control with the highest mana value among creatures and planeswalkers they control.\n\u2022 Exile the top three cards of your library. Until your next end step, you may play those cards.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -13603,7 +13603,7 @@
         },
         {
             "id": "23304103-368e-51be-8b6c-9fc12bed5024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc93cb-8df4-446f-b99f-21238355ad64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc93cb-8df4-446f-b99f-21238355ad64.jpg?1",
             "name": "Rocco, Cabaretti Caterer",
             "text": "When Rocco, Cabaretti Caterer enters the battlefield, if you cast it, you may search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -13647,7 +13647,7 @@
         },
         {
             "id": "36e858e5-6765-50f4-a454-fcb8428ab31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23dfcb-9e17-42bf-9a86-f9e3ce8b4b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23dfcb-9e17-42bf-9a86-f9e3ce8b4b9c.jpg?1",
             "name": "Shattered Seraph",
             "text": "Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{2}, Exile Shattered Seraph from your hand: Target land gains \"{T}: Add {W}, {U}, or {B}\" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.",
             "colours": [
@@ -13689,7 +13689,7 @@
         },
         {
             "id": "eea7931a-3550-510b-9827-515f06d1949b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b4f07d-eb74-4f7e-8705-3fd237133cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b4f07d-eb74-4f7e-8705-3fd237133cb6.jpg?1",
             "name": "Soul of Emancipation",
             "text": "When Soul of Emancipation enters the battlefield, destroy up to three other target nonland permanents. For each of those permanents, its controller creates a 3/3 white Angel creature token with flying.",
             "colours": [
@@ -13730,7 +13730,7 @@
         },
         {
             "id": "8d08e6db-7086-5884-8a47-361188e7f9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4495468f-a587-48f7-875d-dad80b86c156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4495468f-a587-48f7-875d-dad80b86c156.jpg?1",
             "name": "Spara's Adjudicators",
             "text": "When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{2}, Exile Spara's Adjudicators from your hand: Target land gains \"{T}: Add {G}, {W}, or {U}\" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.",
             "colours": [
@@ -13772,7 +13772,7 @@
         },
         {
             "id": "f891bf0b-982f-5d37-95bf-be197139b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6da6284-1577-4bc2-85dd-5984aea72ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6da6284-1577-4bc2-85dd-5984aea72ac6.jpg?1",
             "name": "Toluz, Clever Conductor",
             "text": "When Toluz, Clever Conductor enters the battlefield, it connives.\nWhenever you discard one or more cards, exile them from your graveyard.\nWhen Toluz dies, put the cards exiled with it into their owner's hand.",
             "colours": [
@@ -13816,7 +13816,7 @@
         },
         {
             "id": "808a04c0-9076-50d4-936c-d25cfb0c0c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746c267f-ae38-45f4-9dca-8c7278843526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746c267f-ae38-45f4-9dca-8c7278843526.jpg?1",
             "name": "Unleash the Inferno",
             "text": "Unleash the Inferno deals 7 damage to target creature or planeswalker. When it deals excess damage this way, destroy target artifact or enchantment an opponent controls with mana value less than or equal to that amount of excess damage.",
             "colours": [
@@ -13855,7 +13855,7 @@
         },
         {
             "id": "abd60a1d-883f-58d7-9bc0-57e297b9bcc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f2392d-7b1d-4521-b940-5ef44c464813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f2392d-7b1d-4521-b940-5ef44c464813.jpg?1",
             "name": "Void Rend",
             "text": "This spell can't be countered.\nDestroy target nonland permanent.",
             "colours": [
@@ -13894,7 +13894,7 @@
         },
         {
             "id": "a8cc1cff-ac1b-5f19-a695-9d4e70e64c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be56f915-0c52-4824-b684-b0612ea76643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be56f915-0c52-4824-b684-b0612ea76643.jpg?1",
             "name": "Ziatora, the Incinerator",
             "text": "Flying\nAt the beginning of your end step, you may sacrifice another creature. When you do, Ziatora, the Incinerator deals damage equal to that creature's power to any target and you create three Treasure tokens.",
             "colours": [
@@ -13938,7 +13938,7 @@
         },
         {
             "id": "ae38c020-47e0-598a-b807-a1664b7ad52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c4ac9-f256-47a9-9dec-a42df3695fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c4ac9-f256-47a9-9dec-a42df3695fcd.jpg?1",
             "name": "Ziatora's Envoy",
             "text": "Trample\nWhenever Ziatora's Envoy deals combat damage to a player, look at the top card of your library. You may play a land from the top of your library or cast a spell with mana value less than or equal to the damage dealt from the top of your library without paying its mana cost. If you don't, put that card into your hand.\nBlitz {2}{B}{R}{G}",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "31a668a2-724b-5716-8304-ab90120af5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a883eb5-2666-487b-b8c8-fd8ad12afaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a883eb5-2666-487b-b8c8-fd8ad12afaeb.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "+1: Choose up to one target creature. Put a +1/+1 counter and a counter from among flying, first strike, lifelink, or vigilance on it.\n\u22123: Look at the top seven cards of your library. You may put a permanent card with mana value 3 or less from among them onto the battlefield with a shield counter on it. Put the rest on the bottom of your library in a random order.\n\u22127: Create five 3/3 white Angel creature tokens with flying.",
             "colours": [
@@ -14020,7 +14020,7 @@
         },
         {
             "id": "b45d0946-4b2e-59ab-a13d-79d6961260fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80798911-6cb6-4b67-90b9-0fb83685ea92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80798911-6cb6-4b67-90b9-0fb83685ea92.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters the battlefield with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -14059,7 +14059,7 @@
         },
         {
             "id": "a4562f92-3e17-51be-b337-1676c1edb6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c43f0d-bca6-43c6-9fea-83fc5e178a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c43f0d-bca6-43c6-9fea-83fc5e178a70.jpg?1",
             "name": "Sanctuary Warden",
             "text": "Flying\nSanctuary Warden enters the battlefield with two shield counters on it.\nWhenever Sanctuary Warden enters the battlefield or attacks, you may remove a counter from a creature or planeswalker you control. If you do, draw a card and create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -14097,7 +14097,7 @@
         },
         {
             "id": "22fa4a4e-40f1-5c28-a9a7-f353b50f9db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0116c9-8b8a-4ffd-b688-bf7dd0d3a8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0116c9-8b8a-4ffd-b688-bf7dd0d3a8f8.jpg?1",
             "name": "Errant, Street Artist",
             "text": "Flash\nDefender, haste\n{1}{U}, {T}: Copy target spell you control that wasn't cast. You may choose new targets for the copy.",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "a162be02-27d3-5f9a-9c78-97ca9333c540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a102db09-fae9-4714-951c-bbdf9d4658d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a102db09-fae9-4714-951c-bbdf9d4658d7.jpg?1",
             "name": "Tenacious Underdog",
             "text": "Blitz\u2014{2}{B}{B}, Pay 2 life.\nYou may cast Tenacious Underdog from your graveyard using its blitz ability.",
             "colours": [
@@ -14175,7 +14175,7 @@
         },
         {
             "id": "e621d8f1-11ea-5f82-bf85-ae07aef1733d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1152a35a-9483-446e-a2d8-539b4518a1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1152a35a-9483-446e-a2d8-539b4518a1ad.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "Haste\nAt the beginning of your upkeep, exile the top card of your library. You may play it this turn.\nAt the beginning of each opponent's upkeep, the next time they would draw a card this turn, instead they exile the top card of their library. They may play it this turn.",
             "colours": [
@@ -14218,7 +14218,7 @@
         },
         {
             "id": "7cafed23-cb48-5a76-be93-f9bc39242343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e23d7-f4db-437d-bfe4-be35f0a443b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e23d7-f4db-437d-bfe4-be35f0a443b3.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "+2: You may sacrifice a creature. If you do, search your library for a creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it onto the battlefield, then shuffle.\n+1: Mill five cards, then put any number of creature cards milled this way into your hand.\n\u22121: Create a 4/4 green Rhino Warrior creature token.",
             "colours": [
@@ -14258,7 +14258,7 @@
         },
         {
             "id": "75dc2d77-46a0-5d7b-bd25-1f1260d3c51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8a7966-97cf-47f8-ab85-4f95335425a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8a7966-97cf-47f8-ab85-4f95335425a7.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "Casualty X. The copy isn't legendary and has starting loyalty X. (As you cast this spell, you may sacrifice a creature with power X. When you do, copy this spell. The copy becomes a token.)\n+1: Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22127: Target player draws seven cards and loses 7 life.",
             "colours": [
@@ -14300,7 +14300,7 @@
         },
         {
             "id": "d37cde89-7172-5765-ac34-b0b8da7a56c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08ce85-f030-485f-81d8-bdf47ed04a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08ce85-f030-485f-81d8-bdf47ed04a8e.jpg?1",
             "name": "Scheming Fence",
             "text": "As Scheming Fence enters the battlefield, you may choose a nonland permanent.\nActivated abilities of the chosen permanent can't be activated.\nScheming Fence has all activated abilities of the chosen permanent except for loyalty abilities. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -14340,7 +14340,7 @@
         },
         {
             "id": "3fcc53d9-d121-5f26-897d-b6a9b5792644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac068b57-568b-41f6-90d2-7b0eef99a74d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac068b57-568b-41f6-90d2-7b0eef99a74d.jpg?1",
             "name": "Botanical Plaza",
             "text": "Botanical Plaza enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}, {T}, Sacrifice Botanical Plaza: Draw a card.",
             "colours": [],
@@ -14373,7 +14373,7 @@
         },
         {
             "id": "b53edec2-f0d1-537f-a34c-f801b38d17f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9203fa-12db-4fa0-affd-4db277c871b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9203fa-12db-4fa0-affd-4db277c871b7.jpg?1",
             "name": "Jetmir's Garden",
             "text": "({T}: Add {R}, {G}, or {W}.)\nJetmir's Garden enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14412,7 +14412,7 @@
         },
         {
             "id": "7c5ee01e-c37e-5c43-b3ab-642f9f35e85c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa5d34b-b052-47f4-95e1-42a9c2d21cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa5d34b-b052-47f4-95e1-42a9c2d21cdf.jpg?1",
             "name": "Racers' Ring",
             "text": "Racers' Ring enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}, {T}, Sacrifice Racers' Ring: Draw a card.",
             "colours": [],
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "e3bf9a28-c78d-5508-a3cc-f91c7fe42e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb77f3-8ec4-4b8a-a283-4126037f4d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb77f3-8ec4-4b8a-a283-4126037f4d00.jpg?1",
             "name": "Raffine's Tower",
             "text": "({T}: Add {W}, {U}, or {B}.)\nRaffine's Tower enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14484,7 +14484,7 @@
         },
         {
             "id": "ff89be7c-64ae-5bd6-9609-ebb5a7f60de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906bdba-534c-4f47-b00b-bb93f92774cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906bdba-534c-4f47-b00b-bb93f92774cd.jpg?1",
             "name": "Skybridge Towers",
             "text": "Skybridge Towers enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice Skybridge Towers: Draw a card.",
             "colours": [],
@@ -14517,7 +14517,7 @@
         },
         {
             "id": "ee7b8caf-f0f9-5a81-b9e0-2986977da161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddd6093-eb29-4a1a-a0af-debb86c9cadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddd6093-eb29-4a1a-a0af-debb86c9cadd.jpg?1",
             "name": "Spara's Headquarters",
             "text": "({T}: Add {G}, {W}, or {U}.)\nSpara's Headquarters enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14556,7 +14556,7 @@
         },
         {
             "id": "c620370f-0541-5b62-b424-b962f3526d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c5428-0ec0-4778-801b-a5ea83c88691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c5428-0ec0-4778-801b-a5ea83c88691.jpg?1",
             "name": "Tramway Station",
             "text": "Tramway Station enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice Tramway Station: Draw a card.",
             "colours": [],
@@ -14589,7 +14589,7 @@
         },
         {
             "id": "fbad67b2-67f0-556a-8f20-dd024f373d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e3add-48d4-4330-9a5c-28f3f4defaf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e3add-48d4-4330-9a5c-28f3f4defaf8.jpg?1",
             "name": "Waterfront District",
             "text": "Waterfront District enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}, {T}, Sacrifice Waterfront District: Draw a card.",
             "colours": [],
@@ -14622,7 +14622,7 @@
         },
         {
             "id": "f43bb54e-22ad-5947-b3a1-c222a75f92db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96f496-1fc1-4e66-878a-b0905e920cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96f496-1fc1-4e66-878a-b0905e920cdc.jpg?1",
             "name": "Xander's Lounge",
             "text": "({T}: Add {U}, {B}, or {R}.)\nXander's Lounge enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14661,7 +14661,7 @@
         },
         {
             "id": "7084a384-47f1-52fb-817e-756dfabb5a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307c4a30-a859-487c-b72d-f10eebcd01c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307c4a30-a859-487c-b72d-f10eebcd01c4.jpg?1",
             "name": "Ziatora's Proving Ground",
             "text": "({T}: Add {B}, {R}, or {G}.)\nZiatora's Proving Ground enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14700,7 +14700,7 @@
         },
         {
             "id": "cdca0e63-4e54-5618-8b84-6a79c20dc742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979eee11-9843-49c0-8a1e-bb0616926f90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979eee11-9843-49c0-8a1e-bb0616926f90.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "Haste\nAt the beginning of your upkeep, exile the top card of your library. You may play it this turn.\nAt the beginning of each opponent's upkeep, the next time they would draw a card this turn, instead they exile the top card of their library. They may play it this turn.",
             "colours": [
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "711a4420-c625-500d-a659-2bd1a5ab6183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9387bd-25b9-4d40-8863-14b5a25272be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9387bd-25b9-4d40-8863-14b5a25272be.jpg?1",
             "name": "Brazen Upstart",
             "text": "Vigilance\nWhen Brazen Upstart dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14784,7 +14784,7 @@
         },
         {
             "id": "adc66b02-3d6e-59c2-9eb3-13f920cb2275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a87184-100d-415e-a4d4-d59d1269dbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a87184-100d-415e-a4d4-d59d1269dbea.jpg?1",
             "name": "Brokers Ascendancy",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control and a loyalty counter on each planeswalker you control.",
             "colours": [
@@ -14822,7 +14822,7 @@
         },
         {
             "id": "983bc20e-4451-5ddb-887e-fe2e555a0076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51157e88-32c5-4add-9127-565d3833ce21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51157e88-32c5-4add-9127-565d3833ce21.jpg?1",
             "name": "Brokers Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature or planeswalker an opponent controls.\n\u2022 Destroy target enchantment.\n\u2022 Draw two cards.",
             "colours": [
@@ -14860,7 +14860,7 @@
         },
         {
             "id": "accf7549-3628-5b4a-afc1-4130daa83088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df8fcb2-9915-4b99-a192-90f28bf79f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df8fcb2-9915-4b99-a192-90f28bf79f53.jpg?1",
             "name": "Cabaretti Ascendancy",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it on the bottom of your library.",
             "colours": [
@@ -14898,7 +14898,7 @@
         },
         {
             "id": "73a83fb5-24b4-559f-9d5e-73f7abe31e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce4e34d-cf32-48ab-8554-caa0518ab1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce4e34d-cf32-48ab-8554-caa0518ab1fb.jpg?1",
             "name": "Cabaretti Charm",
             "text": "Choose one \u2014\n\u2022 Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Create two 1/1 green and white Citizen creature tokens.",
             "colours": [
@@ -14936,7 +14936,7 @@
         },
         {
             "id": "13269147-2efc-58d5-baf3-b4b090b44e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31458c7-c1ad-44dd-9c9f-b4a16f1fad0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31458c7-c1ad-44dd-9c9f-b4a16f1fad0e.jpg?1",
             "name": "Cormela, Glamour Thief",
             "text": "Haste\n{1}, {T}: Add {U}{B}{R}. Spend this mana only to cast instant and/or sorcery spells.\nWhen Cormela, Glamour Thief dies, return up to one target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -14979,7 +14979,7 @@
         },
         {
             "id": "a9935aab-3885-5969-8f8f-7d8e30b2578d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a66da6-03bf-46e2-b729-3719d6bcc7ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a66da6-03bf-46e2-b729-3719d6bcc7ce.jpg?1",
             "name": "Corpse Appraiser",
             "text": "When Corpse Appraiser enters the battlefield, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -15020,7 +15020,7 @@
         },
         {
             "id": "c2c20d85-ed9a-5999-9272-da5d9afba58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a66fa80-f385-44a7-95ef-b09e91ce6a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a66fa80-f385-44a7-95ef-b09e91ce6a60.jpg?1",
             "name": "Crew Captain",
             "text": "Haste\nCrew Captain has indestructible as long as it entered the battlefield this turn.",
             "colours": [
@@ -15061,7 +15061,7 @@
         },
         {
             "id": "0d836178-4215-558c-82ad-913052d1f693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77ba1d-9e88-49db-b4e4-63824a0fe490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77ba1d-9e88-49db-b4e4-63824a0fe490.jpg?1",
             "name": "Disciplined Duelist",
             "text": "Double strike\nDisciplined Duelist enters the battlefield with a shield counter on it.",
             "colours": [
@@ -15102,7 +15102,7 @@
         },
         {
             "id": "3dcdcc1d-4291-512a-bd0d-c774d7a5b354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648d9f4-8f56-4bd4-8654-b166c959ebea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648d9f4-8f56-4bd4-8654-b166c959ebea.jpg?1",
             "name": "Endless Detour",
             "text": "The owner of target spell, nonland permanent, or card in a graveyard puts it on the top or bottom of their library.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "267bc7d5-6463-5fc9-af7c-d6cb0ba58828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf30b561-7ae6-4423-9184-6574e68f9038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf30b561-7ae6-4423-9184-6574e68f9038.jpg?1",
             "name": "Evelyn, the Covetous",
             "text": "Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.",
             "colours": [
@@ -15183,7 +15183,7 @@
         },
         {
             "id": "af476609-bda9-598d-9f4c-b2a6660968b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518c19e-c8f4-4598-849c-c073c8c33923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518c19e-c8f4-4598-849c-c073c8c33923.jpg?1",
             "name": "Falco Spara, Pactweaver",
             "text": "Flying, trample\nFalco Spara, Pactweaver enters the battlefield with a shield counter on it.\nYou may look at the top card of your library any time.\nYou may cast spells from the top of your library by removing a counter from a creature you control in addition to paying their other costs.",
             "colours": [
@@ -15226,7 +15226,7 @@
         },
         {
             "id": "a7a1cbef-97dc-5b6e-98f6-f93f4561ee30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84cd002-0780-45af-a4b9-1f8d2a3dc07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84cd002-0780-45af-a4b9-1f8d2a3dc07a.jpg?1",
             "name": "Fleetfoot Dancer",
             "text": "Trample, lifelink, haste",
             "colours": [
@@ -15267,7 +15267,7 @@
         },
         {
             "id": "9e11720f-89c0-5f95-bfca-c6f81167e17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce205611-15c0-413e-ad2b-b561ae530a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce205611-15c0-413e-ad2b-b561ae530a30.jpg?1",
             "name": "Glamorous Outlaw",
             "text": "When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you scry 2.\n{2}, Exile Glamorous Outlaw from your hand: Target land gains \"{T}: Add {U}, {B}, or {R}\" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "765e9ec9-1286-596e-81a8-6589b7162daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d196a9-25aa-44da-baa7-2a0191ad7609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d196a9-25aa-44da-baa7-2a0191ad7609.jpg?1",
             "name": "Hostile Takeover",
             "text": "Up to one target creature has base power and toughness 1/1 until end of turn. Up to one other target creature has base power and toughness 4/4 until end of turn. Then Hostile Takeover deals 3 damage to each creature.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "83a1ad3c-ce26-5e40-9379-2907a61007fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9c3c10-8524-4be3-b7a2-5ee34a582dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9c3c10-8524-4be3-b7a2-5ee34a582dd6.jpg?1",
             "name": "Incandescent Aria",
             "text": "Incandescent Aria deals 3 damage to each nontoken creature.",
             "colours": [
@@ -15384,7 +15384,7 @@
         },
         {
             "id": "188815f6-593a-5ba5-b2a9-7bcf647edf5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3530e3-aa7f-422b-b3f1-100afad673e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3530e3-aa7f-422b-b3f1-100afad673e4.jpg?1",
             "name": "Jetmir, Nexus of Revels",
             "text": "Creatures you control get +1/+0 and have vigilance as long as you control three or more creatures.\nCreatures you control also get +1/+0 and have trample as long as you control six or more creatures.\nCreatures you control also get +1/+0 and have double strike as long as you control nine or more creatures.",
             "colours": [
@@ -15427,7 +15427,7 @@
         },
         {
             "id": "4ba284c9-ee22-5a6f-add1-269d710f671a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5915902a-25b4-4e87-939a-2f9ba7552091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5915902a-25b4-4e87-939a-2f9ba7552091.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second",
             "text": "If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.",
             "colours": [
@@ -15470,7 +15470,7 @@
         },
         {
             "id": "3202a35f-6a0f-5777-a4ae-1f7903377f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db9c6a-aa6c-44e1-86bd-8621abf64d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db9c6a-aa6c-44e1-86bd-8621abf64d4f.jpg?1",
             "name": "Lagrella, the Magpie",
             "text": "When Lagrella, the Magpie enters the battlefield, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters the battlefield under your control this way, put two +1/+1 counters on it.",
             "colours": [
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "c890b624-2af2-5d58-8de6-3056d15c074d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8ad1ac-da5f-4852-b697-d77087f98d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8ad1ac-da5f-4852-b697-d77087f98d1a.jpg?1",
             "name": "Lord Xander, the Collector",
             "text": "When Lord Xander, the Collector enters the battlefield, target opponent discards half the cards in their hand, rounded down.\nWhenever Lord Xander attacks, defending player mills half their library, rounded down.\nWhen Lord Xander dies, target opponent sacrifices half the nonland permanents they control, rounded down.",
             "colours": [
@@ -15557,7 +15557,7 @@
         },
         {
             "id": "574aac1f-0476-5cde-8db2-3bd037db2846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5003bd-fafa-4a91-a3ca-31d8b23e0561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5003bd-fafa-4a91-a3ca-31d8b23e0561.jpg?1",
             "name": "Maestros Ascendancy",
             "text": "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -15595,7 +15595,7 @@
         },
         {
             "id": "7551f18a-3dd4-555e-be02-429299aeeadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b023c-3edc-4e34-9221-490e264e289c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b023c-3edc-4e34-9221-490e264e289c.jpg?1",
             "name": "Maestros Charm",
             "text": "Choose one \u2014\n\u2022 Look at the top five cards of your library. Put one of those cards into your hand and the rest into your graveyard.\n\u2022 Each opponent loses 3 life and you gain 3 life.\n\u2022 Maestros Charm deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -15633,7 +15633,7 @@
         },
         {
             "id": "9729bc88-7ca2-5ad1-bcf4-fd5c2b88f0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9875b763-0971-4124-bd12-30d4e9c5d674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9875b763-0971-4124-bd12-30d4e9c5d674.jpg?1",
             "name": "Maestros Diabolist",
             "text": "Deathtouch, haste\nWhenever Maestros Diabolist attacks, if you don't control a Devil token, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -15674,7 +15674,7 @@
         },
         {
             "id": "1d3f07d7-93d3-5cd0-8de3-abb8001561d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af412300-55ed-43ed-9c9a-87881e23f806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af412300-55ed-43ed-9c9a-87881e23f806.jpg?1",
             "name": "Masked Bandits",
             "text": "Vigilance, menace\n{2}, Exile Masked Bandits from your hand: Target land gains \"{T}: Add {B}, {R}, or {G}\" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.",
             "colours": [
@@ -15715,7 +15715,7 @@
         },
         {
             "id": "66d5f1d1-4e63-5282-8be8-d63c58daf99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319bd9a-23dc-4afc-b7fe-8e2469b521a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319bd9a-23dc-4afc-b7fe-8e2469b521a3.jpg?1",
             "name": "Mr. Orfeo, the Boulder",
             "text": "Whenever you attack, double target creature's power until end of turn.",
             "colours": [
@@ -15758,7 +15758,7 @@
         },
         {
             "id": "e3b62996-0b40-5aed-a34e-7206e6c80415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dc7d21-e56a-4758-b5a0-3acd7eb8c367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dc7d21-e56a-4758-b5a0-3acd7eb8c367.jpg?1",
             "name": "Nimble Larcenist",
             "text": "Flying\nWhen Nimble Larcenist enters the battlefield, target opponent reveals their hand. You choose an artifact, instant, or sorcery card from it and exile that card.",
             "colours": [
@@ -15799,7 +15799,7 @@
         },
         {
             "id": "4376dec7-436d-5dfd-8346-5f3263b8ce97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d3971-a35e-41a6-813d-a936575c45e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d3971-a35e-41a6-813d-a936575c45e5.jpg?1",
             "name": "Obscura Ascendancy",
             "text": "Whenever you cast a spell, if its mana value is equal to 1 plus the number of soul counters on Obscura Ascendancy, put a soul counter on Obscura Ascendancy, then create a 2/2 white Spirit creature token with flying.\nAs long as there are five or more soul counters on Obscura Ascendancy, Spirits you control get +3/+3.",
             "colours": [
@@ -15837,7 +15837,7 @@
         },
         {
             "id": "5290bbd0-f2e7-562f-a918-bcd2553fb530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529f8ae-a673-4573-b74c-2e3cafc67f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529f8ae-a673-4573-b74c-2e3cafc67f44.jpg?1",
             "name": "Obscura Charm",
             "text": "Choose one \u2014\n\u2022 Return target multicolored permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\n\u2022 Counter target instant or sorcery spell.\n\u2022 Destroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -15875,7 +15875,7 @@
         },
         {
             "id": "512262bf-8cb7-5178-97aa-7e99d2896f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfb1a4-ac28-4800-ae58-f729e6533680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfb1a4-ac28-4800-ae58-f729e6533680.jpg?1",
             "name": "Obscura Interceptor",
             "text": "Flash\nLifelink\nWhen Obscura Interceptor enters the battlefield, it connives. When it connives this way, return up to one target spell to its owner's hand.",
             "colours": [
@@ -15916,7 +15916,7 @@
         },
         {
             "id": "53511276-375e-5768-bb94-f293e94da789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3941b30-ee01-47f8-895b-73b0f258fa80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3941b30-ee01-47f8-895b-73b0f258fa80.jpg?1",
             "name": "Ognis, the Dragon's Lash",
             "text": "Haste\nWhenever a creature you control with haste attacks, create a tapped Treasure token.",
             "colours": [
@@ -15959,7 +15959,7 @@
         },
         {
             "id": "f87c7646-04f8-597f-aaae-2a633533fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a84dd-bb7c-4980-a031-23c778e37f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a84dd-bb7c-4980-a031-23c778e37f73.jpg?1",
             "name": "Queza, Augur of Agonies",
             "text": "Whenever you draw a card, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -16002,7 +16002,7 @@
         },
         {
             "id": "8105d5ce-7a6a-5b9c-b746-7c3cfa96633e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549bdaa3-15a9-4b59-b30b-9d3d013664d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549bdaa3-15a9-4b59-b30b-9d3d013664d6.jpg?1",
             "name": "Raffine, Scheming Seer",
             "text": "Flying, ward {1}\nWhenever you attack, target attacking creature connives X, where X is the number of attacking creatures.",
             "colours": [
@@ -16045,7 +16045,7 @@
         },
         {
             "id": "f9f2effc-78e8-57ad-a712-3e1e3f5f0722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be3c9b0-88fa-441a-a61d-ba7e00760117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be3c9b0-88fa-441a-a61d-ba7e00760117.jpg?1",
             "name": "Rakish Revelers",
             "text": "When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{2}, Exile Rakish Revelers from your hand: Target land gains \"{T}: Add {R}, {G}, or {W}\" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.",
             "colours": [
@@ -16087,7 +16087,7 @@
         },
         {
             "id": "42c6dbb6-c5b8-5380-9e27-ff0b71705cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ad3b18-1666-4cd8-ad7f-ddf021522dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ad3b18-1666-4cd8-ad7f-ddf021522dfb.jpg?1",
             "name": "Rigo, Streetwise Mentor",
             "text": "Rigo, Streetwise Mentor enters the battlefield with a shield counter on it.\nWhenever you attack a player or planeswalker with one or more creatures with power 1 or less, draw a card.",
             "colours": [
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "3031e30a-e995-528e-ae51-e4af604d2302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3058460c-56cb-46b7-9c72-d239bc728714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3058460c-56cb-46b7-9c72-d239bc728714.jpg?1",
             "name": "Riveteers Ascendancy",
             "text": "Whenever you sacrifice a creature, you may return target creature card with lesser mana value from your graveyard to the battlefield tapped. Do this only once each turn.",
             "colours": [
@@ -16168,7 +16168,7 @@
         },
         {
             "id": "5fc42b5d-5b2c-5d3b-9bca-90654300accc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a403bd2a-5759-45f6-a913-d28a2bbbb9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a403bd2a-5759-45f6-a913-d28a2bbbb9ff.jpg?1",
             "name": "Riveteers Charm",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature or planeswalker they control with the highest mana value among creatures and planeswalkers they control.\n\u2022 Exile the top three cards of your library. Until your next end step, you may play those cards.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "b86904ad-1794-5c05-9b25-6af1f2bad24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e024dea-ce4e-46a6-b9ae-4c5016cfe3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e024dea-ce4e-46a6-b9ae-4c5016cfe3b5.jpg?1",
             "name": "Rocco, Cabaretti Caterer",
             "text": "When Rocco, Cabaretti Caterer enters the battlefield, if you cast it, you may search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -16249,7 +16249,7 @@
         },
         {
             "id": "172da40f-9134-5c60-af78-0a09661d82f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee468a-0dcf-42b5-bc8b-9b86727162ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee468a-0dcf-42b5-bc8b-9b86727162ae.jpg?1",
             "name": "Shattered Seraph",
             "text": "Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{2}, Exile Shattered Seraph from your hand: Target land gains \"{T}: Add {W}, {U}, or {B}\" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.",
             "colours": [
@@ -16290,7 +16290,7 @@
         },
         {
             "id": "723572b0-221c-5e75-a039-8580001f2abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9294f6-6160-4c83-8f62-3e27ebbb020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9294f6-6160-4c83-8f62-3e27ebbb020f.jpg?1",
             "name": "Soul of Emancipation",
             "text": "When Soul of Emancipation enters the battlefield, destroy up to three other target nonland permanents. For each of those permanents, its controller creates a 3/3 white Angel creature token with flying.",
             "colours": [
@@ -16330,7 +16330,7 @@
         },
         {
             "id": "a3a12e2e-4312-5f59-8355-76130e086f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93df6b13-d898-4afe-a60c-828933f5be32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93df6b13-d898-4afe-a60c-828933f5be32.jpg?1",
             "name": "Spara's Adjudicators",
             "text": "When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{2}, Exile Spara's Adjudicators from your hand: Target land gains \"{T}: Add {G}, {W}, or {U}\" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.",
             "colours": [
@@ -16371,7 +16371,7 @@
         },
         {
             "id": "caa45028-2ae1-5bfc-b3fc-10486e7cb2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb9bc34-783e-492d-b97f-89b39d80a62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb9bc34-783e-492d-b97f-89b39d80a62f.jpg?1",
             "name": "Toluz, Clever Conductor",
             "text": "When Toluz, Clever Conductor enters the battlefield, it connives.\nWhenever you discard one or more cards, exile them from your graveyard.\nWhen Toluz dies, put the cards exiled with it into their owner's hand.",
             "colours": [
@@ -16414,7 +16414,7 @@
         },
         {
             "id": "0c54a1be-3913-59da-a1b4-710e0678eb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4436b093-2c8a-45ad-b84b-b4282d3b61c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4436b093-2c8a-45ad-b84b-b4282d3b61c3.jpg?1",
             "name": "Unleash the Inferno",
             "text": "Unleash the Inferno deals 7 damage to target creature or planeswalker. When it deals excess damage this way, destroy target artifact or enchantment an opponent controls with mana value less than or equal to that amount of excess damage.",
             "colours": [
@@ -16452,7 +16452,7 @@
         },
         {
             "id": "6c6c2e24-893b-5c11-92a0-2b198e657bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592e2cd-25f7-4968-8664-29288e5eaa82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592e2cd-25f7-4968-8664-29288e5eaa82.jpg?1",
             "name": "Void Rend",
             "text": "This spell can't be countered.\nDestroy target nonland permanent.",
             "colours": [
@@ -16490,7 +16490,7 @@
         },
         {
             "id": "b94aec21-bcaf-5f59-9ca0-ecf8c2c915f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd6b307-c3a5-4dfd-b137-e1077700c51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd6b307-c3a5-4dfd-b137-e1077700c51f.jpg?1",
             "name": "Ziatora, the Incinerator",
             "text": "Flying\nAt the beginning of your end step, you may sacrifice another creature. When you do, Ziatora, the Incinerator deals damage equal to that creature's power to any target and you create three Treasure tokens.",
             "colours": [
@@ -16533,7 +16533,7 @@
         },
         {
             "id": "1fe6c16b-318e-559e-9eb5-e86d0a36db63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640273fe-631c-4efb-9221-9fd808a60fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640273fe-631c-4efb-9221-9fd808a60fae.jpg?1",
             "name": "Ziatora's Envoy",
             "text": "Trample\nWhenever Ziatora's Envoy deals combat damage to a player, look at the top card of your library. You may play a land from the top of your library or cast a spell with mana value less than or equal to the damage dealt from the top of your library without paying its mana cost. If you don't, put that card into your hand.\nBlitz {2}{B}{R}{G}",
             "colours": [
@@ -16574,7 +16574,7 @@
         },
         {
             "id": "bd52cb38-afa2-5e6a-8d29-35bae05bad45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737f2d9a-171d-4b0d-bae3-930aa9c88e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737f2d9a-171d-4b0d-bae3-930aa9c88e95.jpg?1",
             "name": "Depopulate",
             "text": "Each player who controls a multicolored creature draws a card. Then destroy all creatures.",
             "colours": [
@@ -16608,7 +16608,7 @@
         },
         {
             "id": "4bafce64-0b8d-52cc-b99b-f90b63ecea8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a1ca00-820f-4c2c-af3b-912bf7aca0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a1ca00-820f-4c2c-af3b-912bf7aca0a0.jpg?1",
             "name": "Extraction Specialist",
             "text": "Lifelink\nWhen Extraction Specialist enters the battlefield, return target creature card with mana value 2 or less from your graveyard to the battlefield. That creature can't attack or block for as long as you control Extraction Specialist.",
             "colours": [
@@ -16645,7 +16645,7 @@
         },
         {
             "id": "825ca638-86ab-5d9f-91cf-f65f62e48c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5783904-0950-4034-8277-5cf3b3865856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5783904-0950-4034-8277-5cf3b3865856.jpg?1",
             "name": "Mysterious Limousine",
             "text": "Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2",
             "colours": [
@@ -16682,7 +16682,7 @@
         },
         {
             "id": "46f98473-acc9-5822-8426-65b78bd3d71f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dafe2f2-9b1e-484b-a60e-9cf9ec875a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dafe2f2-9b1e-484b-a60e-9cf9ec875a6b.jpg?1",
             "name": "Rabble Rousing",
             "text": "Hideaway 5\nWhenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens. Then if you control ten or more creatures, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -16716,7 +16716,7 @@
         },
         {
             "id": "a1a8d137-e802-5f90-98dc-73c579248666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0717ca-7fc0-4e87-b904-e1584ea02c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0717ca-7fc0-4e87-b904-e1584ea02c14.jpg?1",
             "name": "Cut Your Losses",
             "text": "Casualty 2\nTarget player mills half their library, rounded down.",
             "colours": [
@@ -16750,7 +16750,7 @@
         },
         {
             "id": "dc10732e-3260-55c4-b005-c97ce8e873c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcba6c-9d8e-4a66-99ac-48e737e14263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcba6c-9d8e-4a66-99ac-48e737e14263.jpg?1",
             "name": "Even the Score",
             "text": "This spell costs {U}{U}{U} less to cast if an opponent has drawn four or more cards this turn.\nDraw X cards.",
             "colours": [
@@ -16784,7 +16784,7 @@
         },
         {
             "id": "31dce0d0-a9e1-5ace-bdcb-b45bc6db5b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b1bf08-aba1-4197-8afe-05c1fc783307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b1bf08-aba1-4197-8afe-05c1fc783307.jpg?1",
             "name": "Ledger Shredder",
             "text": "Flying\nWhenever a player casts their second spell each turn, Ledger Shredder connives.",
             "colours": [
@@ -16821,7 +16821,7 @@
         },
         {
             "id": "42158cd7-a5c4-57e0-bf5a-d9dd075174be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479b8a-b5a4-4d45-9073-5d24becad45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479b8a-b5a4-4d45-9073-5d24becad45b.jpg?1",
             "name": "Reservoir Kraken",
             "text": "Trample, ward {2}\nAt the beginning of each combat, if Reservoir Kraken is untapped, any opponent may tap an untapped creature they control. If they do, tap Reservoir Kraken and create a 1/1 blue Fish creature token with \"This creature can't be blocked.\"",
             "colours": [
@@ -16857,7 +16857,7 @@
         },
         {
             "id": "fb723527-9d5d-50f7-8f89-3d4c2d3a1bee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7585bac-eee3-445e-87a0-befef301b440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7585bac-eee3-445e-87a0-befef301b440.jpg?1",
             "name": "Undercover Operative",
             "text": "You may have Undercover Operative enter the battlefield as a copy of any creature on the battlefield, except it enters with a shield counter on it if you control that creature.",
             "colours": [
@@ -16894,7 +16894,7 @@
         },
         {
             "id": "d2d4e84a-d5b6-514f-962b-1c30ab30c807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1aa2e-13cf-490d-b142-5735bac153a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1aa2e-13cf-490d-b142-5735bac153a1.jpg?1",
             "name": "Wiretapping",
             "text": "Hideaway 5\nWhenever you draw your first card during each of your draw steps, draw a card. Then if you have nine or more cards in hand, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -16928,7 +16928,7 @@
         },
         {
             "id": "06a35cde-c54b-5599-b3e6-cd2322e190b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc0e94-f608-4a57-a719-3f8fe675d0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc0e94-f608-4a57-a719-3f8fe675d0ae.jpg?1",
             "name": "Angel of Suffering",
             "text": "Flying\nIf damage would be dealt to you, prevent that damage and mill twice that many cards.",
             "colours": [
@@ -16965,7 +16965,7 @@
         },
         {
             "id": "980319ad-1db8-5458-810d-8ecc40e46890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c9c2a3-3844-4524-a2cb-8c2c3e6ebea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c9c2a3-3844-4524-a2cb-8c2c3e6ebea3.jpg?1",
             "name": "Body Launderer",
             "text": "Deathtouch\nWhenever another nontoken creature you control dies, Body Launderer connives.\nWhen Body Launderer dies, return another target non-Rogue creature card with equal or lesser power from your graveyard to the battlefield.",
             "colours": [
@@ -17002,7 +17002,7 @@
         },
         {
             "id": "82239dba-32c6-5778-b901-3234b32b9ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f199fc-11ff-45bd-bed2-5ac98eb80456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f199fc-11ff-45bd-bed2-5ac98eb80456.jpg?1",
             "name": "Cemetery Tampering",
             "text": "Hideaway 5\nAt the beginning of your upkeep, you may mill three cards. Then if there are twenty or more cards in your graveyard, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -17036,7 +17036,7 @@
         },
         {
             "id": "a160cc04-02af-5edd-9114-e9e0df760549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb8b328-7886-4e91-9f3d-4103cfdd5b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb8b328-7886-4e91-9f3d-4103cfdd5b23.jpg?1",
             "name": "Cut of the Profits",
             "text": "Casualty 3\nYou draw X cards and you lose X life.",
             "colours": [
@@ -17070,7 +17070,7 @@
         },
         {
             "id": "ac8c9b0c-f092-517f-83d5-de78322699fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef0a253-e822-4912-90d6-dd1a781a55b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef0a253-e822-4912-90d6-dd1a781a55b7.jpg?1",
             "name": "Sanguine Spy",
             "text": "Menace, lifelink\n{1}, Sacrifice another creature: Look at the top card of your library. You may put that card into your graveyard.\nAt the beginning of your end step, if there are five or more mana values among cards in your graveyard, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -17107,7 +17107,7 @@
         },
         {
             "id": "33b127a1-6fa5-5dd5-ba24-1beec5b88698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044f9aeb-9cce-4eea-9ddb-868720cd8287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044f9aeb-9cce-4eea-9ddb-868720cd8287.jpg?1",
             "name": "Shakedown Heavy",
             "text": "Menace\nWhenever Shakedown Heavy attacks, defending player may have you draw a card. If they do, untap Shakedown Heavy and remove it from combat.",
             "colours": [
@@ -17144,7 +17144,7 @@
         },
         {
             "id": "431215bb-d32a-5244-a6f2-4a7d0ea7ff4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e05615-063d-40ea-9dbb-885934b61fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e05615-063d-40ea-9dbb-885934b61fc9.jpg?1",
             "name": "Arcane Bombardment",
             "text": "Whenever you cast your first instant or sorcery spell each turn, exile an instant or sorcery card at random from your graveyard. Then copy each card exiled with Arcane Bombardment. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -17178,7 +17178,7 @@
         },
         {
             "id": "fcb609be-9004-5ef1-a363-57fad67d3f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae0d2c-f943-4100-92f9-61eb6e7ba1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae0d2c-f943-4100-92f9-61eb6e7ba1df.jpg?1",
             "name": "Devilish Valet",
             "text": "Trample, haste\nAlliance \u2014 Whenever another creature enters the battlefield under your control, double Devilish Valet's power until end of turn.",
             "colours": [
@@ -17215,7 +17215,7 @@
         },
         {
             "id": "7d46684e-3f69-5f78-a27b-74dff4ee5003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58dd56-0bbb-4b2b-95b3-6b2a7da9eabd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58dd56-0bbb-4b2b-95b3-6b2a7da9eabd.jpg?1",
             "name": "Hoard Hauler",
             "text": "Trample\nWhenever Hoard Hauler deals combat damage to a player, create a Treasure token for each artifact they control.\nCrew 3",
             "colours": [
@@ -17251,7 +17251,7 @@
         },
         {
             "id": "1ce6402e-8c65-5195-8dcc-070fad6445c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fa6dc3-3f4d-4501-8647-07b0252b6d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fa6dc3-3f4d-4501-8647-07b0252b6d93.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "{R}, {T}, Discard a card: Create a token that's a copy of another target creature you control. It gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\nBlitz {1}{R}",
             "colours": [
@@ -17291,7 +17291,7 @@
         },
         {
             "id": "fe813900-9e90-52ae-b466-d9e3ade1ae26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7e703f-dcd2-4a99-846f-758d4858453a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7e703f-dcd2-4a99-846f-758d4858453a.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "Menace\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token.\nSacrifice a Treasure: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -17328,7 +17328,7 @@
         },
         {
             "id": "2c0b9e01-beb7-512c-b026-0c813e9efbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83d83-6401-41ae-aa50-dfd14e4070b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83d83-6401-41ae-aa50-dfd14e4070b3.jpg?1",
             "name": "Structural Assault",
             "text": "Destroy all artifacts, then Structural Assault deals damage to each creature equal to the number of artifacts that were put into graveyards from the battlefield this turn.",
             "colours": [
@@ -17362,7 +17362,7 @@
         },
         {
             "id": "16531353-39b8-56e6-aa97-be7784a30358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5503-4bc1-46e4-95b9-abafe0f38580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5503-4bc1-46e4-95b9-abafe0f38580.jpg?1",
             "name": "Widespread Thieving",
             "text": "Hideaway 5\nWhenever you cast a multicolored spell, create a Treasure token. Then you may pay {W}{U}{B}{R}{G}. If you do, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -17400,7 +17400,7 @@
         },
         {
             "id": "ce4b2891-c225-5f11-969f-c186f955e281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bf264-9d93-4f5d-b0e1-15beae7c4702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bf264-9d93-4f5d-b0e1-15beae7c4702.jpg?1",
             "name": "Evolving Door",
             "text": "{1}, {T}, Sacrifice a creature: Count the colors of the sacrificed creature, then search your library for a creature card that's exactly that many colors plus one. Exile that card, then shuffle. You may cast the exiled card. Activate only as a sorcery.",
             "colours": [
@@ -17434,7 +17434,7 @@
         },
         {
             "id": "2b356a3b-2e00-5b9d-8816-b9496eba4703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a556e-615f-416d-9e1b-fcc3304e0199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a556e-615f-416d-9e1b-fcc3304e0199.jpg?1",
             "name": "Fight Rigging",
             "text": "Hideaway 5\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if you control a creature with power 7 or greater, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -17468,7 +17468,7 @@
         },
         {
             "id": "93c48108-c366-51d9-be63-ae2c316798e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f723ae1e-be60-4cd6-9485-7f07fa1f8fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f723ae1e-be60-4cd6-9485-7f07fa1f8fe7.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -17516,7 +17516,7 @@
         },
         {
             "id": "63772276-423a-5557-a1dc-04e9e330bdad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5052562-ea98-4703-ba40-58534beead90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5052562-ea98-4703-ba40-58534beead90.jpg?1",
             "name": "Workshop Warchief",
             "text": "Trample\nWhen Workshop Warchief enters the battlefield, you gain 3 life.\nWhen Workshop Warchief dies, create a 4/4 green Rhino Warrior creature token.\nBlitz {4}{G}{G}",
             "colours": [
@@ -17553,7 +17553,7 @@
         },
         {
             "id": "b6662877-5797-5ee0-a183-24a0611e9662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08c9c2e-f863-46cb-b3a4-f83291a1a03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08c9c2e-f863-46cb-b3a4-f83291a1a03b.jpg?1",
             "name": "Aven Heartstabber",
             "text": "Flying\nAs long as there are five or more mana values among cards in your graveyard, Aven Heartstabber gets +2/+2 and has deathtouch.\nWhen Aven Heartstabber dies, mill two cards, then draw a card.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "769fce8a-2b32-5c07-b2c9-6b440735dd04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b4930d-6a27-43d4-acef-3c36ed967a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b4930d-6a27-43d4-acef-3c36ed967a82.jpg?1",
             "name": "Black Market Tycoon",
             "text": "At the beginning of your upkeep, Black Market Tycoon deals 2 damage to you for each Treasure you control.\n{T}: Create a Treasure token.",
             "colours": [
@@ -17631,7 +17631,7 @@
         },
         {
             "id": "08fe876f-cc69-5e66-8bfe-695074ba2fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f510ca1-8d33-4703-b36b-377b99bcc163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f510ca1-8d33-4703-b36b-377b99bcc163.jpg?1",
             "name": "Corpse Explosion",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nCorpse Explosion deals damage equal to the exiled card's power to each creature and each planeswalker.",
             "colours": [
@@ -17667,7 +17667,7 @@
         },
         {
             "id": "f032198c-3ce8-5ac8-9aa8-b9e746c419f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57055f98-a642-4d88-967d-7828fc6cea72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57055f98-a642-4d88-967d-7828fc6cea72.jpg?1",
             "name": "Meeting of the Five",
             "text": "Exile the top ten cards of your library. You may cast spells with exactly three colors from among them this turn. Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Spend this mana only to cast spells with exactly three colors.",
             "colours": [
@@ -17709,7 +17709,7 @@
         },
         {
             "id": "89a3e2fd-394f-5c42-893d-a12cced5da35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88d365a-99aa-4e76-833e-b08aa83476a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88d365a-99aa-4e76-833e-b08aa83476a0.jpg?1",
             "name": "Park Heights Pegasus",
             "text": "Flying, trample\nWhenever Park Heights Pegasus deals combat damage to a player, draw a card if you had two or more creatures enter the battlefield under your control this turn.",
             "colours": [
@@ -17747,7 +17747,7 @@
         },
         {
             "id": "a56b279e-c83e-5d6f-834d-e1c7b0ce3e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65100cc0-6a0e-4083-975c-9c6633885e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65100cc0-6a0e-4083-975c-9c6633885e6c.jpg?1",
             "name": "Getaway Car",
             "text": "Haste\nWhenever Getaway Car attacks or blocks, return up to one target creature that crewed it this turn to its owner's hand.\nCrew 1",
             "colours": [],
@@ -17779,7 +17779,7 @@
         },
         {
             "id": "c4ccd051-ba24-5c48-86c0-2b55392bca95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7090d8-d9f8-4285-8898-b6fd26a608ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7090d8-d9f8-4285-8898-b6fd26a608ef.jpg?1",
             "name": "Luxior, Giada's Gift",
             "text": "Equipped creature gets +1/+1 for each counter on it.\nEquipped permanent isn't a planeswalker and is a creature in addition to its other types. (Loyalty abilities can still be activated.)\nEquip planeswalker {1}\nEquip {3}",
             "colours": [],
@@ -17813,7 +17813,7 @@
         },
         {
             "id": "2367179e-73f9-5046-9c12-cb6a1188efd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9066fb8f-8568-4e87-bee9-573f6c204a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9066fb8f-8568-4e87-bee9-573f6c204a26.jpg?1",
             "name": "Unlicensed Hearse",
             "text": "{T}: Exile up to two target cards from a single graveyard.\nUnlicensed Hearse's power and toughness are each equal to the number of cards exiled with it.\nCrew 2",
             "colours": [],
@@ -17845,7 +17845,7 @@
         },
         {
             "id": "9a52e12c-220d-5d50-bcc6-1c014dad5883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b14a07-7cbf-48b4-91b1-af93837adbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b14a07-7cbf-48b4-91b1-af93837adbf3.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "",
             "colours": [
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "36990199-e48a-5ef5-9615-99e0d96ce43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78b6d2e-29dd-4659-a162-3de5910ce948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78b6d2e-29dd-4659-a162-3de5910ce948.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "",
             "colours": [
@@ -17922,7 +17922,7 @@
         },
         {
             "id": "089a8c37-42be-557d-89f2-fca041494e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22288f-4fd4-45d4-9fcc-08aeba4d93a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22288f-4fd4-45d4-9fcc-08aeba4d93a7.jpg?1",
             "name": "Sanctuary Warden",
             "text": "",
             "colours": [
@@ -17959,7 +17959,7 @@
         },
         {
             "id": "5f5f0f88-7ab9-52a0-9bdf-969ba9e0661c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df2f7bd-2aa2-4ab4-b16a-557333efa02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df2f7bd-2aa2-4ab4-b16a-557333efa02c.jpg?1",
             "name": "Errant, Street Artist",
             "text": "",
             "colours": [
@@ -17998,7 +17998,7 @@
         },
         {
             "id": "d1c4640d-c9cf-5c16-b5ab-03d8b8a16e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b133877c-0e62-464d-959d-131b9b626aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b133877c-0e62-464d-959d-131b9b626aea.jpg?1",
             "name": "Tenacious Underdog",
             "text": "",
             "colours": [
@@ -18035,7 +18035,7 @@
         },
         {
             "id": "c48f4dac-076a-54e3-87a5-b37f9298899b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1269764e-cc05-4487-a75b-be8012287a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1269764e-cc05-4487-a75b-be8012287a80.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "",
             "colours": [
@@ -18077,7 +18077,7 @@
         },
         {
             "id": "f9f554a4-d905-5039-aca5-d9c4037458dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63c976-a6cd-42b4-b799-8624a9da4d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63c976-a6cd-42b4-b799-8624a9da4d32.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "",
             "colours": [
@@ -18116,7 +18116,7 @@
         },
         {
             "id": "1e0d46c0-6153-5c1d-8248-eddf0bbcb856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54630dd4-65bc-468a-b9a5-f24242459e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54630dd4-65bc-468a-b9a5-f24242459e61.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "",
             "colours": [
@@ -18157,7 +18157,7 @@
         },
         {
             "id": "a82b5034-98a7-5948-bf4e-40c7cff94eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac46c1-4439-46c3-8180-302057dbbd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac46c1-4439-46c3-8180-302057dbbd69.jpg?1",
             "name": "Scheming Fence",
             "text": "",
             "colours": [
@@ -18196,7 +18196,7 @@
         },
         {
             "id": "56dc3452-c05d-52ac-94c3-d13bce92ba34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746b45a-abd8-4a60-9139-48c1522bfd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746b45a-abd8-4a60-9139-48c1522bfd4b.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18243,7 +18243,7 @@
         },
         {
             "id": "964a360c-fc47-59ad-ae23-bb797ab6f97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476c0f4b-7b16-47a6-946e-b658d7c26bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476c0f4b-7b16-47a6-946e-b658d7c26bfa.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18290,7 +18290,7 @@
         },
         {
             "id": "23af7b66-8adc-5b70-a2cf-8f1b4f53682b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0323-ec90-4f10-aaeb-f26033c1a7ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0323-ec90-4f10-aaeb-f26033c1a7ea.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18337,7 +18337,7 @@
         },
         {
             "id": "db018c55-b1a3-56fa-93b5-893adb8f4b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f7c23b-3091-4b13-9209-0d8d23301027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f7c23b-3091-4b13-9209-0d8d23301027.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18384,7 +18384,7 @@
         },
         {
             "id": "4c0e3f54-7980-5c5e-9fb4-cc6f7a14ac11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192e737a-57c9-4142-9613-cb19bbbbf2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192e737a-57c9-4142-9613-cb19bbbbf2af.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18431,7 +18431,7 @@
         },
         {
             "id": "bb375d9e-d098-580a-9f80-4aec4de4d262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460db3d4-5c50-4c2c-a066-a4e264ecbb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460db3d4-5c50-4c2c-a066-a4e264ecbb1e.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18478,7 +18478,7 @@
         },
         {
             "id": "139048bf-7d25-50ba-ad95-987cee91ebf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da271d69-f086-4267-b044-5dbc01e5c6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da271d69-f086-4267-b044-5dbc01e5c6de.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18525,7 +18525,7 @@
         },
         {
             "id": "36edeb5c-f938-53bb-b5f9-62510d5ebc56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5475a6ab-7cab-4381-8814-257789fd5791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5475a6ab-7cab-4381-8814-257789fd5791.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18572,7 +18572,7 @@
         },
         {
             "id": "3d616a02-8e3f-5a5b-84b2-e32470e20248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9fed5b-95ca-4ffa-8754-6b4e43b9e494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9fed5b-95ca-4ffa-8754-6b4e43b9e494.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18619,7 +18619,7 @@
         },
         {
             "id": "c83b7d5a-9b79-5000-ade7-78a859910e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4440f3-bf89-4493-bb50-ebf84902e4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4440f3-bf89-4493-bb50-ebf84902e4d0.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18666,7 +18666,7 @@
         },
         {
             "id": "95151def-ad27-52f4-94a1-63960c4e5dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61760019-a7c7-4c11-871b-d72186b1d220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61760019-a7c7-4c11-871b-d72186b1d220.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18713,7 +18713,7 @@
         },
         {
             "id": "8681cb34-94c7-5328-8483-b795ff067b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab120b59-8c50-47af-af21-5dd60377bc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab120b59-8c50-47af-af21-5dd60377bc81.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "{R}, {T}, Discard a card: Create a token that's a copy of another target creature you control. It gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\nBlitz {1}{R}",
             "colours": [
@@ -18752,7 +18752,7 @@
         },
         {
             "id": "ab954754-3ace-5503-b424-a060b99bb8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721bc380-00ac-40bd-a605-0853e97efad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721bc380-00ac-40bd-a605-0853e97efad8.jpg?1",
             "name": "Mysterious Limousine",
             "text": "Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2",
             "colours": [
@@ -18788,7 +18788,7 @@
         },
         {
             "id": "ade05a63-24a2-5618-aa7f-bf25c6093c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5a0c6a-6aac-44bc-88c0-52f589980679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5a0c6a-6aac-44bc-88c0-52f589980679.jpg?1",
             "name": "Rumor Gatherer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, scry 1. If this is the second time this ability has resolved this turn, draw a card instead.",
             "colours": [
@@ -18825,7 +18825,7 @@
         },
         {
             "id": "83cbd9e2-2c30-5edf-a86f-381a55de614a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ecf5f7-db15-4917-ad7f-1c652b0a97da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ecf5f7-db15-4917-ad7f-1c652b0a97da.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens.",
             "colours": [
@@ -18859,7 +18859,7 @@
         },
         {
             "id": "27b39b1c-9169-53a0-93d1-87439485baa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b46ca6-6fbd-41c5-9434-b18bce32165c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b46ca6-6fbd-41c5-9434-b18bce32165c.jpg?1",
             "name": "Incriminate",
             "text": "Choose two target creatures controlled by the same player. That player sacrifices one of them.",
             "colours": [
@@ -18893,7 +18893,7 @@
         },
         {
             "id": "4dcfad27-d6c2-5470-ba76-37cd0bc570a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c80b3da-bda1-4d8d-ba50-7162574f4564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c80b3da-bda1-4d8d-ba50-7162574f4564.jpg?1",
             "name": "Light 'Em Up",
             "text": "Casualty 2\nLight 'Em Up deals 2 damage to target creature or planeswalker.",
             "colours": [
@@ -18927,7 +18927,7 @@
         },
         {
             "id": "85706cc0-04d4-5567-8c7f-d0d0db149a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd325574-cdc9-48b1-bdcb-98afde83c6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd325574-cdc9-48b1-bdcb-98afde83c6b9.jpg?1",
             "name": "Courier's Briefcase",
             "text": "When Courier's Briefcase enters the battlefield, create a 1/1 green and white Citizen creature token.\n{T}, Sacrifice Courier's Briefcase: Add one mana of any color.\n{W}{U}{B}{R}{G}, {T}, Sacrifice Courier's Briefcase: Draw three cards.",
             "colours": [
@@ -18967,7 +18967,7 @@
         },
         {
             "id": "97be86fb-f947-5903-92bc-9be3bad43e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13670af-e266-4e19-b479-92fae2b15f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13670af-e266-4e19-b479-92fae2b15f4a.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "",
             "colours": [
@@ -19010,7 +19010,7 @@
         },
         {
             "id": "aff50d55-5c85-5871-b7b5-20f00bf6f617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0e4dae-1be7-430c-81a3-d1f9137a81e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0e4dae-1be7-430c-81a3-d1f9137a81e0.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "",
             "colours": [
@@ -19052,7 +19052,7 @@
         },
         {
             "id": "9b02e27b-70be-56ba-a683-9e2a622ec8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6ce56c-ca2e-48e8-a4d9-671cb4de8a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6ce56c-ca2e-48e8-a4d9-671cb4de8a9d.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -19080,7 +19080,7 @@
         },
         {
             "id": "96180d9e-f0c7-5108-af2b-3c2f1e2d76eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bae778-0dee-47d5-a7cd-f2be11b5e79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bae778-0dee-47d5-a7cd-f2be11b5e79b.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -19115,7 +19115,7 @@
         },
         {
             "id": "11a2bb16-b17e-5f8e-aef3-5e3c2cb97169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a7f7c-29e3-4b98-ad2f-2d585ec7610e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a7f7c-29e3-4b98-ad2f-2d585ec7610e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -19150,7 +19150,7 @@
         },
         {
             "id": "5cd0f0ce-7820-5507-b6db-8ceb32d7830e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2e726b-f124-43f7-87e4-bb06bbe8e3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2e726b-f124-43f7-87e4-bb06bbe8e3d7.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -19185,7 +19185,7 @@
         },
         {
             "id": "04a068bc-ff53-5736-9819-67f29d4e2bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3edaf7-0ebd-4a8b-9954-dd91bb797744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3edaf7-0ebd-4a8b-9954-dd91bb797744.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -19220,7 +19220,7 @@
         },
         {
             "id": "f0d54291-d008-5e6d-a4c8-0ee450ab575e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca43425-d007-4181-9182-18dc01ad7e90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca43425-d007-4181-9182-18dc01ad7e90.jpg?1",
             "name": "Ogre Warrior",
             "text": "",
             "colours": [
@@ -19256,7 +19256,7 @@
         },
         {
             "id": "0abeb86c-be42-5320-8192-82721ed09ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e503b9-a822-4c42-b478-1f598bc5941d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e503b9-a822-4c42-b478-1f598bc5941d.jpg?1",
             "name": "Rogue",
             "text": "",
             "colours": [
@@ -19291,7 +19291,7 @@
         },
         {
             "id": "be16489a-6054-58d9-ab8a-c7a4d7c91538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75fdab-818c-4f3a-94c1-fd3f577a87f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75fdab-818c-4f3a-94c1-fd3f577a87f5.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -19326,7 +19326,7 @@
         },
         {
             "id": "88c22910-0015-50f7-8109-53e64e7c4784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bd0b29-0860-4ee3-832a-f62ba7bf4aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bd0b29-0860-4ee3-832a-f62ba7bf4aac.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -19361,7 +19361,7 @@
         },
         {
             "id": "b89a4851-8648-572f-b78e-f55c00c1f6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6736fe71-bd55-4602-b0aa-ece6193048a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6736fe71-bd55-4602-b0aa-ece6193048a9.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -19396,7 +19396,7 @@
         },
         {
             "id": "76d4a480-d8bc-5786-ae16-c0c9cccc46fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230419f9-a9f7-441d-bad7-0ed867326aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230419f9-a9f7-441d-bad7-0ed867326aa1.jpg?1",
             "name": "Rhino Warrior",
             "text": "",
             "colours": [
@@ -19432,7 +19432,7 @@
         },
         {
             "id": "6b8f4014-0a30-5459-9cd7-ad8f456e4d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f03e9fe-cb71-498e-bf16-5af6af37a192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f03e9fe-cb71-498e-bf16-5af6af37a192.jpg?1",
             "name": "Citizen",
             "text": "",
             "colours": [
@@ -19469,7 +19469,7 @@
         },
         {
             "id": "923ecdbd-0175-575b-b374-fc5fd6cd1397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19500,7 +19500,7 @@
         },
         {
             "id": "02235d38-af30-57e9-82d6-6e335a378023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883958b-1d82-4c1a-9f19-ab20fc01d5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883958b-1d82-4c1a-9f19-ab20fc01d5f4.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19531,7 +19531,7 @@
         },
         {
             "id": "a5c96d41-cabd-57a5-b7d7-90957340d40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c7dce-a51b-4ce2-9359-a17c577f535d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c7dce-a51b-4ce2-9359-a17c577f535d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19562,7 +19562,7 @@
         },
         {
             "id": "49b2a8ce-fcd7-5a00-b706-d5001f70db86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a356a2-c851-41e5-a389-7019575d5ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a356a2-c851-41e5-a389-7019575d5ace.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19593,7 +19593,7 @@
         },
         {
             "id": "02eda719-658b-52e3-8f94-b66dda715865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116d98-2dad-4b80-a3af-9e36e34da6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116d98-2dad-4b80-a3af-9e36e34da6d4.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/SOI.json
+++ b/Assets/Resources/Sets/SOI.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "968190ab-528a-52cb-97ed-7732eedab72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84826f49-b5fb-4bd6-ab46-98e84b0d25c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84826f49-b5fb-4bd6-ab46-98e84b0d25c8.jpg?1",
             "name": "Always Watching",
             "text": "Nontoken creatures you control get +1/+1 and have vigilance.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "c97476d0-8dee-537b-86fc-0ce120e1a19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e12f83-eab8-4113-ab63-3f7a830861d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e12f83-eab8-4113-ab63-3f7a830861d4.jpg?1",
             "name": "Angel of Deliverance",
             "text": "Flying\nDelirium \u2014 Whenever Angel of Deliverance deals damage, if there are four or more card types among cards in your graveyard, exile target creature an opponent controls.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "6389c766-0830-51e3-85aa-6e8f99813fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38bae3e-95f3-413a-bb4d-6a0814112a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38bae3e-95f3-413a-bb4d-6a0814112a7a.jpg?1",
             "name": "Angelic Purge",
             "text": "As an additional cost to cast Angelic Purge, sacrifice a permanent.\nExile target artifact, creature, or enchantment.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "832a7296-f172-5b78-81d7-06f9fc83460d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e2358c-211e-4d79-8120-88bb9e656cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e2358c-211e-4d79-8120-88bb9e656cba.jpg?1",
             "name": "Apothecary Geist",
             "text": "Flying\nWhen Apothecary Geist enters the battlefield, if you control another Spirit, you gain 3 life.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "ad53597a-4448-5cbd-82bf-11d163b0c14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "Flash\nFlying, vigilance\nWhen Archangel Avacyn enters the battlefield, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "16371f62-73e5-54f5-bce1-801098de2d53",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "Flying\nWhen this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other creature and each opponent.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "56e99141-2a16-519d-9090-196744bbef39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg?1",
             "name": "Avacynian Missionaries // Lunarch Inquisitors",
             "text": "At the beginning of your end step, if Avacynian Missionaries is equipped, transform it.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "f697c781-350b-5b51-9b4b-779259528007",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg?1",
             "name": "Avacynian Missionaries // Lunarch Inquisitors",
             "text": "When this creature transforms into Lunarch Inquisitors, you may exile another target creature until Lunarch Inquisitors leaves the battlefield.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "4bee28c0-925b-5e11-8ff1-16c0595326c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdf107d-eb67-421c-a7a9-b3e62e03f766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdf107d-eb67-421c-a7a9-b3e62e03f766.jpg?1",
             "name": "Bound by Moonsilver",
             "text": "Enchant creature\nEnchanted creature can't attack, block, or transform.\nSacrifice another permanent: Attach Bound by Moonsilver to target creature. Activate this ability only any time you could cast a sorcery and only once each turn.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "4a4720e5-1903-53b8-beb8-4eac31c9c868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c45198f-fb2b-4c83-abdc-8b1a0071cfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c45198f-fb2b-4c83-abdc-8b1a0071cfed.jpg?1",
             "name": "Bygone Bishop",
             "text": "Flying\nWhenever you cast a creature spell with converted mana cost 3 or less, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "99551a7b-4736-5273-b686-8b4d7daf61f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg?1",
             "name": "Cathar's Companion",
             "text": "Whenever you cast a noncreature spell, Cathar's Companion gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "f3e05db8-b29f-5526-8a18-af3a685585eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70ea481-1751-4097-af41-2d13fe79e788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70ea481-1751-4097-af41-2d13fe79e788.jpg?1",
             "name": "Chaplain's Blessing",
             "text": "You gain 5 life.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "28f72709-958d-5145-9e55-0dfa08ec16e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1a458a-d3b6-44d9-ac80-a7a46b505805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1a458a-d3b6-44d9-ac80-a7a46b505805.jpg?1",
             "name": "Dauntless Cathar",
             "text": "{1}{W}, Exile Dauntless Cathar from your graveyard: Put a 1/1 white Spirit creature token with flying onto the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "fb2bfd69-920b-56fa-9b32-fb80d99509c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f685445d-e2af-455f-b3b2-97cf15362f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f685445d-e2af-455f-b3b2-97cf15362f3c.jpg?1",
             "name": "Declaration in Stone",
             "text": "Exile target creature and all other creatures its controller controls with the same name as that creature. That player investigates for each nontoken creature exiled this way.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "c120ef08-8b06-599f-bef5-6076124b1b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ff2cbf-a1dc-4cc5-9a5d-8439899d4e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ff2cbf-a1dc-4cc5-9a5d-8439899d4e87.jpg?1",
             "name": "Descend upon the Sinful",
             "text": "Exile all creatures.\nDelirium \u2014 Put a 4/4 white Angel creature token with flying onto the battlefield if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "7d156a37-d258-58a7-ac64-81b61881d834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bea4c2-7a15-4f31-938d-c4c906e4ebe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bea4c2-7a15-4f31-938d-c4c906e4ebe7.jpg?1",
             "name": "Devilthorn Fox",
             "text": "",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "f376f236-5ba1-5430-8e5e-ab7e1b6897a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg?1",
             "name": "Drogskol Cavalry",
             "text": "Flying\nWhenever another Spirit enters the battlefield under your control, you gain 2 life.\n{3}{W}: Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "823de294-576e-54fd-9602-ea0bc133412a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbab6e4-d317-4e73-a6ff-bed49aa6b70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbab6e4-d317-4e73-a6ff-bed49aa6b70b.jpg?1",
             "name": "Eerie Interlude",
             "text": "Exile any number of target creatures you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "47f74f98-9ed2-527d-9f38-41867f954567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5fa496-a830-4031-a19a-d6467d074ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5fa496-a830-4031-a19a-d6467d074ad1.jpg?1",
             "name": "Emissary of the Sleepless",
             "text": "Flying\nWhen Emissary of the Sleepless enters the battlefield, if a creature died this turn, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "fb11c608-90ef-5239-92af-a11f9d9118a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47dd220-6193-4e31-a1df-591b6424ad27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47dd220-6193-4e31-a1df-591b6424ad27.jpg?1",
             "name": "Ethereal Guidance",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "1841fb54-3633-559c-adfa-241e2f9f320f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0341a-cd45-439c-adc2-8d24c47c4bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0341a-cd45-439c-adc2-8d24c47c4bd5.jpg?1",
             "name": "Expose Evil",
             "text": "Tap up to two target creatures.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "69998416-ca20-5ea2-9cdf-855e5cdaec4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8aecb0-c535-493c-bf64-4964e061deba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8aecb0-c535-493c-bf64-4964e061deba.jpg?1",
             "name": "Gryff's Boon",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has flying.\n{3}{W}: Return Gryff's Boon from your graveyard to the battlefield attached to target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "a3a82054-33c3-53b2-81f5-6bd5faa8add9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg?1",
             "name": "Hanweir Militia Captain // Westvale Cult Leader",
             "text": "",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "4bb6738b-5e20-56f6-b82e-a8e821b9f6b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg?1",
             "name": "Hanweir Militia Captain // Westvale Cult Leader",
             "text": "",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "7be682bd-0c2b-56d0-a919-82af2a4e72d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f7c6f5-159a-40ed-823a-8740a1ce373e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f7c6f5-159a-40ed-823a-8740a1ce373e.jpg?1",
             "name": "Hope Against Hope",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each creature you control.\nAs long as enchanted creature is a Human, it has first strike.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "add688bc-7d47-57ab-9e22-562b2e090e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c105686-8b45-494a-b9ef-8aa267bb1b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c105686-8b45-494a-b9ef-8aa267bb1b5a.jpg?1",
             "name": "Humble the Brute",
             "text": "Destroy target creature with power 4 or greater.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "d47725fd-f53a-55b5-9043-d421ab26a8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1401fe-9e88-401b-96f0-5f58808a519f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1401fe-9e88-401b-96f0-5f58808a519f.jpg?1",
             "name": "Inquisitor's Ox",
             "text": "Delirium \u2014 Inquisitor's Ox gets +1/+0 and has vigilance as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "f65afd64-5321-577b-b3cf-79a9a837b5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45704604-a1b3-4225-8466-aa76136c84a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45704604-a1b3-4225-8466-aa76136c84a8.jpg?1",
             "name": "Inspiring Captain",
             "text": "When Inspiring Captain enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "b5b81dc2-cb6d-57a1-9657-70b9797c910b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d99f1f-80d6-4b5e-aeae-83fb8ae62cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d99f1f-80d6-4b5e-aeae-83fb8ae62cdc.jpg?1",
             "name": "Militant Inquisitor",
             "text": "Militant Inquisitor gets +1/+0 for each Equipment you control.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "e8140b3c-b605-5498-adac-e8ada9b1b4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839942c-0ad1-4f77-97a0-142b8ef2266c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839942c-0ad1-4f77-97a0-142b8ef2266c.jpg?1",
             "name": "Moorland Drifter",
             "text": "Delirium \u2014 Moorland Drifter has flying as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "0bc6adf4-dd98-5cfa-9d8d-4a966b32db61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba0f1c-8641-4f5a-8f2e-f969fc7a058a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba0f1c-8641-4f5a-8f2e-f969fc7a058a.jpg?1",
             "name": "Nahiri's Machinations",
             "text": "At the beginning of combat on your turn, target creature you control gains indestructible until end of turn.\n{1}{R}: Nahiri's Machinations deals 1 damage to target blocking creature.",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "b594bcaa-e8ce-5941-97b5-eaa2cc9f2727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ec364-39c1-4a4b-8dfa-268fad2effdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ec364-39c1-4a4b-8dfa-268fad2effdd.jpg?1",
             "name": "Nearheath Chaplain",
             "text": "Lifelink\n{2}{W}, Exile Nearheath Chaplain from your graveyard: Put two 1/1 white Spirit creature tokens with flying onto the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "de7ad3c0-622e-5f26-97cd-b2ecb9cdb9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ecdadf-56f7-4dfb-9c3c-7d240ba19b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ecdadf-56f7-4dfb-9c3c-7d240ba19b00.jpg?1",
             "name": "Not Forgotten",
             "text": "Put target card from a graveyard on the top or bottom of its owner's library. Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "34c24b4a-8546-52d2-8de4-210dbbdf6db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77c30f-d813-46e6-9cdd-938b4a6359ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77c30f-d813-46e6-9cdd-938b4a6359ad.jpg?1",
             "name": "Odric, Lunarch Marshal",
             "text": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "7b97f09d-0182-5fb7-886b-c354d8f50918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dc0c44-908f-40e9-9c6a-e1ef699e6d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dc0c44-908f-40e9-9c6a-e1ef699e6d2e.jpg?1",
             "name": "Open the Armory",
             "text": "Search your library for an Aura or Equipment card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "d95a3cd9-1435-5369-af37-44584d831183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb6c60-1889-49ed-8767-8144cc5a9571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb6c60-1889-49ed-8767-8144cc5a9571.jpg?1",
             "name": "Paranoid Parish-Blade",
             "text": "Delirium \u2014 Paranoid Parish-Blade gets +1/+0 and has first strike as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "3a757a3e-d83b-5854-a672-1315c924b0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg?1",
             "name": "Pious Evangel // Wayward Disciple",
             "text": "Whenever Pious Evangel or another creature enters the battlefield under your control, you gain 1 life.\n{2}, {T}, Sacrifice another permanent: Transform Pious Evangel.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "e5bc22bb-3b80-5356-bd36-c131079a9722",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg?1",
             "name": "Pious Evangel // Wayward Disciple",
             "text": "Whenever Wayward Disciple or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "475fb6c9-a833-5692-a5bc-98c5ff65281a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b101264-4994-43b7-9156-228f7d10d2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b101264-4994-43b7-9156-228f7d10d2bd.jpg?1",
             "name": "Puncturing Light",
             "text": "Destroy target attacking or blocking creature with power 3 or less.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "6399c97c-82c5-594e-8692-4efbfc115df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cf3ac8-db59-4acc-abb6-e63b95b849ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cf3ac8-db59-4acc-abb6-e63b95b849ac.jpg?1",
             "name": "Reaper of Flight Moonsilver",
             "text": "Flying\nDelirium \u2014 Sacrifice another creature: Reaper of Flight Moonsilver gets +2/+1 until end of turn. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "56ddc013-4a6c-5219-af75-2c2ec18c5366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27b92a-cde9-41bc-9b23-d83b74b167d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27b92a-cde9-41bc-9b23-d83b74b167d4.jpg?1",
             "name": "Silverstrike",
             "text": "Destroy target attacking creature. You gain 3 life.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "2b891732-bae9-5f0d-9bb9-ed1017458609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac355ae2-7553-4b51-bcce-1c4168dad0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac355ae2-7553-4b51-bcce-1c4168dad0d6.jpg?1",
             "name": "Spectral Shepherd",
             "text": "Flying\n{1}{U}: Return target Spirit you control to its owner's hand.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "ef83719c-6efc-592a-ad41-2c5561c4302f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f87d4-5fed-415c-918a-c3546697a3da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f87d4-5fed-415c-918a-c3546697a3da.jpg?1",
             "name": "Stern Constable",
             "text": "{T}, Discard a card: Tap target creature.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "7032b5e7-d382-5934-85d8-d93b6149bf61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c5c5cf-0ed6-4953-a03a-af51038e3f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c5c5cf-0ed6-4953-a03a-af51038e3f54.jpg?1",
             "name": "Strength of Arms",
             "text": "Target creature gets +2/+2 until end of turn. If you control an Equipment, put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "8e8858dd-a88e-55ce-8742-3da65443c745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4a0bc-196a-466b-a704-377f5c7eb5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4a0bc-196a-466b-a704-377f5c7eb5b7.jpg?1",
             "name": "Survive the Night",
             "text": "Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "b66920af-1e59-5c5d-9cd3-95110ddc7bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fbe149-3e1f-495e-be1b-efc3a6dbcb08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fbe149-3e1f-495e-be1b-efc3a6dbcb08.jpg?1",
             "name": "Tenacity",
             "text": "Creatures you control get +1/+1 and gain lifelink until end of turn. Untap those creatures.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "a2239d00-3fd1-5c49-b893-e1d399f6af97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe162594-2332-4816-a9e1-57eb19b12651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe162594-2332-4816-a9e1-57eb19b12651.jpg?1",
             "name": "Thalia's Lieutenant",
             "text": "When Thalia's Lieutenant enters the battlefield, put a +1/+1 counter on each other Human you control.\nWhenever another Human enters the battlefield under your control, put a +1/+1 counter on Thalia's Lieutenant.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "154e2745-5d63-5ee9-b8a4-e5a5a8a5ee15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d140c3b7-ca78-483d-baeb-307b624fea8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d140c3b7-ca78-483d-baeb-307b624fea8b.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "9b3bc399-139e-5415-98a0-6c5ecb1bf2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9e8653-13ae-446c-b341-85c9b3fa6ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9e8653-13ae-446c-b341-85c9b3fa6ca8.jpg?1",
             "name": "Topplegeist",
             "text": "Flying\nWhen Topplegeist enters the battlefield, tap target creature an opponent controls.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, tap target creature that player controls.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "927811db-dfed-5295-983f-951a460731c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg?1",
             "name": "Town Gossipmonger // Incited Rabble",
             "text": "{T}, Tap an untapped creature you control: Transform Town Gossipmonger.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "4692edd1-f8d4-56e8-96cf-4fef2e441036",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg?1",
             "name": "Town Gossipmonger // Incited Rabble",
             "text": "Incited Rabble attacks each combat if able.\n{2}: Incited Rabble gets +1/+0 until end of turn.",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "510d4709-4147-5bd2-821f-63f734c5c544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012d76b7-1445-4853-9e54-159154bbb144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012d76b7-1445-4853-9e54-159154bbb144.jpg?1",
             "name": "Unruly Mob",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Unruly Mob.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "ae2a58bd-0893-5ab5-a626-4ed7ccccf391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4051020-688c-473a-9a08-b62f0fd75675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4051020-688c-473a-9a08-b62f0fd75675.jpg?1",
             "name": "Vessel of Ephemera",
             "text": "{2}{W}, Sacrifice Vessel of Ephemera: Put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "f6cfb232-a68b-5da3-8dac-fcbb825aaabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1",
             "name": "Aberrant Researcher // Perfected Form",
             "text": "Flying\nAt the beginning of your upkeep, put the top card of your library into your graveyard. If it's an instant or sorcery card, transform Aberrant Researcher.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "d5c07595-a48a-56b1-a6ee-77a95886974c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1",
             "name": "Aberrant Researcher // Perfected Form",
             "text": "Flying",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "ee51532f-f0b6-527c-9ec5-15d6c894f42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252eef1f-0a62-420d-aad8-e3d7f1e07c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252eef1f-0a62-420d-aad8-e3d7f1e07c1b.jpg?1",
             "name": "Broken Concentration",
             "text": "Counter target spell.\nMadness {3}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "677c299e-9909-58b6-8ad0-fab0e30bddea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b069516-1465-4acf-b4b9-ca7f1238b4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b069516-1465-4acf-b4b9-ca7f1238b4fe.jpg?1",
             "name": "Catalog",
             "text": "Draw two cards, then discard a card.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "bdf8ae27-bfd4-5eaf-b8c1-7afaadc208e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b728f4-d209-4334-9501-4f69b1196739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b728f4-d209-4334-9501-4f69b1196739.jpg?1",
             "name": "Compelling Deterrence",
             "text": "Return target nonland permanent to its owner's hand. Then that player discards a card if you control a Zombie.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "13dd5b6a-2f55-5e93-a477-a3f09eae3d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fcbc2-1034-442d-9f2a-7d79ea40ac3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fcbc2-1034-442d-9f2a-7d79ea40ac3d.jpg?1",
             "name": "Confirm Suspicions",
             "text": "Counter target spell.\nInvestigate three times. (To investigate, put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "bd7ebf46-cea6-5c33-b858-d765d5b1f4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg?1",
             "name": "Daring Sleuth // Bearer of Overwhelming Truths",
             "text": "When you sacrifice a Clue, transform Daring Sleuth.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "3fe4768e-b540-5381-923b-b2e685666ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg?1",
             "name": "Daring Sleuth // Bearer of Overwhelming Truths",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Bearer of Overwhelming Truths deals combat damage to a player, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "b3ba3d34-47c6-5cd4-a28c-e8472b7ad266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a14eeb-1c85-4029-a047-39a4efef3f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a14eeb-1c85-4029-a047-39a4efef3f74.jpg?1",
             "name": "Deny Existence",
             "text": "Counter target creature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "034b172e-843d-5ce9-a983-27105d6a3b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714713f-deb4-4b1c-8764-35287293ca18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714713f-deb4-4b1c-8764-35287293ca18.jpg?1",
             "name": "Drownyard Explorers",
             "text": "When Drownyard Explorers enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "ced32fd1-d7b8-5012-8650-393005f1f8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1997e6a0-9e66-486d-921d-d64137c3221d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1997e6a0-9e66-486d-921d-d64137c3221d.jpg?1",
             "name": "Drunau Corpse Trawler",
             "text": "When Drunau Corpse Trawler enters the battlefield, put a 2/2 black Zombie creature token onto the battlefield.\n{2}{B}: Target Zombie gains deathtouch until end of turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "92f7b182-200d-515c-aab9-8b2bb50c40d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22909767-a088-49ff-83be-37f967d1da3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22909767-a088-49ff-83be-37f967d1da3d.jpg?1",
             "name": "Engulf the Shore",
             "text": "Return to their owners' hands all creatures with toughness less than or equal to the number of Islands you control.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "bb4ef9f9-4cba-54b5-9cc9-184ad3f89531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b44364-8f83-4dcf-8458-0fd54a698524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b44364-8f83-4dcf-8458-0fd54a698524.jpg?1",
             "name": "Epiphany at the Drownyard",
             "text": "Reveal the top X plus one cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2235,7 +2235,7 @@
         },
         {
             "id": "9e815ad7-be35-560b-a1aa-c46bb27dcc16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63df99f9-4f85-4c76-8d76-9075c9ef2b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63df99f9-4f85-4c76-8d76-9075c9ef2b86.jpg?1",
             "name": "Erdwal Illuminator",
             "text": "Flying\nWhenever you investigate for the first time each turn, investigate an additional time.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "b8448bea-fc1a-54a6-8e97-5cc295e17d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639bdbb5-8c2d-439d-bcea-dc54da9686ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639bdbb5-8c2d-439d-bcea-dc54da9686ea.jpg?1",
             "name": "Essence Flux",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. If it's a Spirit, put a +1/+1 counter on it.",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "102aec35-4e4a-56e1-aea8-c818cd7fb0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9eaf90-2a9e-44a7-bdae-03c26f9d21e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9eaf90-2a9e-44a7-bdae-03c26f9d21e7.jpg?1",
             "name": "Fleeting Memories",
             "text": "When Fleeting Memories enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "bfc263c7-b447-516c-a583-04e9334e431b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f82ee6-b8cd-4dce-b213-3910302f30e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f82ee6-b8cd-4dce-b213-3910302f30e9.jpg?1",
             "name": "Forgotten Creation",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nAt the beginning of your upkeep, you may discard all the cards in your hand. If you do, draw that many cards.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "e2e7c95e-b8ea-5327-b845-83ef5d6b0bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f376ec9b-48ac-4ed7-bfa2-60e9dca32dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f376ec9b-48ac-4ed7-bfa2-60e9dca32dd7.jpg?1",
             "name": "Furtive Homunculus",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "b3d8b85b-091a-5fef-b27e-146e75bb7bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d28b8-2ed8-4266-a870-d308f9ebd5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d28b8-2ed8-4266-a870-d308f9ebd5da.jpg?1",
             "name": "Geralf's Masterpiece",
             "text": "Flying\nGeralf's Masterpiece gets -1/-1 for each card in your hand.\n{3}{U}, Discard three cards: Return Geralf's Masterpiece from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "79061cd1-16de-5f0a-9850-502987c38900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b1848c-3160-45f5-91a0-74ab6d91c01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b1848c-3160-45f5-91a0-74ab6d91c01b.jpg?1",
             "name": "Ghostly Wings",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nDiscard a card: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "a1308f9e-893d-5a45-b7e0-fafc7ab66cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88ae6bf-9c58-4543-ba66-19ea41d01e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88ae6bf-9c58-4543-ba66-19ea41d01e9b.jpg?1",
             "name": "Gone Missing",
             "text": "Put target permanent on top of its owner's library.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "a6bcde5d-52bc-580c-b745-dd1b3c8b6878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e644e38-39bf-40bd-9be1-5eb80f472e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e644e38-39bf-40bd-9be1-5eb80f472e81.jpg?1",
             "name": "Invasive Surgery",
             "text": "Counter target sorcery spell.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, search the graveyard, hand, and library of that spell's controller for any number of cards with the same name as that spell, exile those cards, then that player shuffles his or her library.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "27e2e483-8064-5f92-a905-3d1984af4c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5521d-e9f1-49e0-aa13-8e6de794cb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5521d-e9f1-49e0-aa13-8e6de794cb12.jpg?1",
             "name": "Jace, Unraveler of Secrets",
             "text": "+1: Scry 1, then draw a card.\n\u22122: Return target creature to its owner's hand.\n\u22128: You get an emblem with \"Whenever an opponent casts his or her first spell each turn, counter that spell.\"",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "8c76b6ad-39c7-5761-98e4-61f5b1fd33db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0eea0d-c790-4d91-962f-f05b22d0c8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0eea0d-c790-4d91-962f-f05b22d0c8fa.jpg?1",
             "name": "Jace's Scrutiny",
             "text": "Target creature gets -4/-0 until end of turn.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "38b10c2f-db96-5fd1-bd27-4e56e2341ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b3d18c-7029-4eff-a918-f75e7d9d79d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b3d18c-7029-4eff-a918-f75e7d9d79d7.jpg?1",
             "name": "Just the Wind",
             "text": "Return target creature to its owner's hand.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "31ae6849-6e26-56a4-a91f-a8ce398b3a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dadecc-f1f1-44a2-8829-6c94aade73a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dadecc-f1f1-44a2-8829-6c94aade73a0.jpg?1",
             "name": "Lamplighter of Selhoff",
             "text": "When Lamplighter of Selhoff enters the battlefield, if you control another Zombie, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "10959d65-ead1-5070-88a4-9fceca1cb8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0fadba-4205-47ce-b4cf-e0ff7308749b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0fadba-4205-47ce-b4cf-e0ff7308749b.jpg?1",
             "name": "Manic Scribe",
             "text": "When Manic Scribe enters the battlefield, each opponent puts the top three cards of his or her library into his or her graveyard.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, that player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "954f3b5a-bcec-5c94-99ae-294b9e1f075b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a6d6e4-e91f-444f-9eed-88fceaf1a4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a6d6e4-e91f-444f-9eed-88fceaf1a4b8.jpg?1",
             "name": "Nagging Thoughts",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\nMadness {1}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2737,7 +2737,7 @@
         },
         {
             "id": "d47cf17c-d443-55d3-8193-3e231c08f5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f714d6c4-b1e1-40dd-806f-a3d87020292e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f714d6c4-b1e1-40dd-806f-a3d87020292e.jpg?1",
             "name": "Nephalia Moondrakes",
             "text": "Flying\nWhen Nephalia Moondrakes enters the battlefield, target creature gains flying until end of turn.\n{4}{U}{U}, Exile Nephalia Moondrakes from your graveyard: Creatures you control gain flying until end of turn.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "057bdb71-2d77-551a-b99c-0d398ae23a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394dd931-e34e-4314-88c9-774a2f3c8c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394dd931-e34e-4314-88c9-774a2f3c8c1b.jpg?1",
             "name": "Niblis of Dusk",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "7df523f0-8b2a-5d98-bc91-c3dc95442e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b8f962-8d4e-4dd8-a157-c0a55f9e152a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b8f962-8d4e-4dd8-a157-c0a55f9e152a.jpg?1",
             "name": "Ongoing Investigation",
             "text": "Whenever one or more creatures you control deal combat damage to a player, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\n{1}{G}, Exile a creature card from your graveyard: Investigate. You gain 2 life.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "70033045-b1de-5b13-8598-0cd97f8c980d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69204c83-2e43-4ca1-a4cd-d75399a7d6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69204c83-2e43-4ca1-a4cd-d75399a7d6dd.jpg?1",
             "name": "Pieces of the Puzzle",
             "text": "Reveal the top five cards of your library. Put up to two instant and/or sorcery cards from among them into your hand and the rest into your graveyard.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "1577c8eb-32fb-5072-89d3-325728690193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2288f7b-05b1-4a6c-8d02-42ffcadc6f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2288f7b-05b1-4a6c-8d02-42ffcadc6f0b.jpg?1",
             "name": "Pore Over the Pages",
             "text": "Draw three cards, untap up to two lands, then discard a card.",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "d7a65050-d854-53c7-944a-6711b73a185b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec8b8bf-7b02-4f5e-bbd3-9560f9888192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec8b8bf-7b02-4f5e-bbd3-9560f9888192.jpg?1",
             "name": "Press for Answers",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "39fe9492-4f19-5f59-97c0-e39701a9f011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fc4db9-a29c-4f50-8e41-105b45af0be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fc4db9-a29c-4f50-8e41-105b45af0be9.jpg?1",
             "name": "Rattlechains",
             "text": "Flash\nFlying\nWhen Rattlechains enters the battlefield, target Spirit gains hexproof until end of turn.\nYou may cast Spirit spells as though they had flash.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "1f9fa5e1-1eb4-5ec5-bf43-1fafe452abfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f9dd3-45cc-4682-a6a0-99f67c0b73c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f9dd3-45cc-4682-a6a0-99f67c0b73c6.jpg?1",
             "name": "Reckless Scholar",
             "text": "{T}: Target player draws a card, then discards a card.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "eb9dcfeb-53ff-57ca-9c03-a8ad5d87e3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e099a6a-97c4-42cd-aca6-5e1a2da0d5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e099a6a-97c4-42cd-aca6-5e1a2da0d5e5.jpg?1",
             "name": "Rise from the Tides",
             "text": "Put a 2/2 black Zombie creature token onto the battlefield tapped for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "75fa307b-e86b-54d7-8388-71d1cb806d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065d497d-5cfd-43c9-8c86-9a1da3d7e17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065d497d-5cfd-43c9-8c86-9a1da3d7e17e.jpg?1",
             "name": "Seagraf Skaab",
             "text": "",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "4665fabb-f01c-5e04-8bf8-8c3ffd9a538b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7347f4c-a4b3-4c71-91e5-699475e5926e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7347f4c-a4b3-4c71-91e5-699475e5926e.jpg?1",
             "name": "Silburlind Snapper",
             "text": "Silburlind Snapper can't attack unless you've cast a noncreature spell this turn.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "fd2e6413-6bc2-58d9-9a3d-c306633e3d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535e3d1b-b71b-406a-bec6-73b2cb45f6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535e3d1b-b71b-406a-bec6-73b2cb45f6c8.jpg?1",
             "name": "Silent Observer",
             "text": "Flying",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "8a301150-e576-5446-8ef4-c2cfa8f24f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f010e4f4-f1a3-4062-834c-eec5f1f443d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f010e4f4-f1a3-4062-834c-eec5f1f443d6.jpg?1",
             "name": "Sleep Paralysis",
             "text": "Enchant creature\nWhen Sleep Paralysis enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "1798c541-e178-57e0-983c-b570aaeae033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg?1",
             "name": "Startled Awake // Persistent Nightmare",
             "text": "Target opponent puts the top thirteen cards of his or her library into his or her graveyard.\n{3}{U}{U}: Put Startled Awake from your graveyard onto the battlefield transformed. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "24a04391-2ed8-5ead-8d5c-afa81139acdd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg?1",
             "name": "Startled Awake // Persistent Nightmare",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Persistent Nightmare deals combat damage to a player, return it to its owner's hand.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "b88ad810-d710-5c5c-9e6a-0b11bd6106d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03c643c-8e4c-4dc9-8756-c253fa057729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03c643c-8e4c-4dc9-8756-c253fa057729.jpg?1",
             "name": "Stitched Mangler",
             "text": "Stitched Mangler enters the battlefield tapped.\nWhen Stitched Mangler enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "0374be60-c356-5967-8abe-38e216d882da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84bb1ce-a8a0-4a29-9129-b1d7041fd01a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84bb1ce-a8a0-4a29-9129-b1d7041fd01a.jpg?1",
             "name": "Stitchwing Skaab",
             "text": "Flying\n{1}{U}, Discard two cards: Return Stitchwing Skaab from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "eed09232-bf57-5aaf-bf92-a47f1d9a1318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0fb4be-df73-43a9-bd48-fd47a4190fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0fb4be-df73-43a9-bd48-fd47a4190fc1.jpg?1",
             "name": "Stormrider Spirit",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "8bdd9d7d-3ed8-5569-a892-ad109dbd64e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1",
             "name": "Thing in the Ice // Awoken Horror",
             "text": "Defender\nThing in the Ice enters the battlefield with four ice counters on it.\nWhenever you cast an instant or sorcery spell, remove an ice counter from Thing in the Ice. Then if it has no ice counters on it, transform it.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "8c23c710-3169-5569-b5b4-08eebdab978a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1",
             "name": "Thing in the Ice // Awoken Horror",
             "text": "When this creature transforms into Awoken Horror, return all non-Horror creatures to their owners' hands.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "a211b3cc-febb-56f2-a4ae-06817fcdf03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b150797-ee8d-42f8-adcb-2f4b1783c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b150797-ee8d-42f8-adcb-2f4b1783c074.jpg?1",
             "name": "Trail of Evidence",
             "text": "Whenever you cast an instant or sorcery spell, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "6d2eaae5-cae0-574d-99cc-b7299f4323a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg?1",
             "name": "Uninvited Geist // Unimpeded Trespasser",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Uninvited Geist deals combat damage to a player, transform it.",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "9c85b134-7c69-5ff9-a217-8994a572c76d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg?1",
             "name": "Uninvited Geist // Unimpeded Trespasser",
             "text": "Unimpeded Trespasser can't be blocked.",
             "colours": [
@@ -3510,7 +3510,7 @@
         },
         {
             "id": "cbc6fcf8-d2f9-5766-8942-dc97a053a0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4596140-1113-4349-aabe-4e828ea574e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4596140-1113-4349-aabe-4e828ea574e8.jpg?1",
             "name": "Vessel of Paramnesia",
             "text": "{U}, Sacrifice Vessel of Paramnesia: Target player puts the top three cards of his or her library into his or her graveyard. Draw a card.",
             "colours": [
@@ -3542,7 +3542,7 @@
         },
         {
             "id": "2663e21b-d349-55af-8aff-288ab0c25f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d07fbe1-e66a-4893-86ee-7752ad77b120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d07fbe1-e66a-4893-86ee-7752ad77b120.jpg?1",
             "name": "Welcome to the Fold",
             "text": "Madness {X}{U}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nGain control of target creature if its toughness is 2 or less. If Welcome to the Fold's madness cost was paid, instead gain control of that creature if its toughness is X or less.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "b861e3ff-0099-5177-b3b2-5478c6cbe8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg?1",
             "name": "Accursed Witch // Infectious Curse",
             "text": "Spells your opponents cast that target Accursed Witch cost {1} less to cast.\nWhen Accursed Witch dies, return it to the battlefield transformed under your control attached to target opponent.",
             "colours": [
@@ -3609,7 +3609,7 @@
         },
         {
             "id": "8930db56-7b9b-5ad0-a7f0-89f785839fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg?1",
             "name": "Accursed Witch // Infectious Curse",
             "text": "Enchant player\nSpells you cast that target enchanted player cost {1} less to cast.\nAt the beginning of enchanted player's upkeep, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "3c403e7e-838b-5184-824f-228b5fd4b300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b80948-a3cd-4962-8fce-d58f2db7e68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b80948-a3cd-4962-8fce-d58f2db7e68e.jpg?1",
             "name": "Alms of the Vein",
             "text": "Target opponent loses 3 life and you gain 3 life.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "e7969d9e-21b5-5e3b-9fde-3471c7abbe03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a4bf6c-167a-4122-a55b-7bc28ca4f0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a4bf6c-167a-4122-a55b-7bc28ca4f0d4.jpg?1",
             "name": "Asylum Visitor",
             "text": "At the beginning of each player's upkeep, if that player has no cards in hand, you draw a card and you lose 1 life.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "33678b5f-1459-5880-a518-6b55d68475d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fac171d-a8b6-4bb7-a559-473574aa02a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fac171d-a8b6-4bb7-a559-473574aa02a8.jpg?1",
             "name": "Behind the Scenes",
             "text": "Creatures you control have skulk. (They can't be blocked by creatures with greater power.)\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "2ecf97c6-6b2b-5286-a465-f1bb305aafe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd22350b-d48c-4ae6-b95f-63336fabe0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd22350b-d48c-4ae6-b95f-63336fabe0e3.jpg?1",
             "name": "Behold the Beyond",
             "text": "Discard your hand. Search your library for three cards and put those cards into your hand. Then shuffle your library.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "7b56eee2-3d67-54bf-9cad-04533c262dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac62d2f-6834-4d98-b69d-bd7b5831d981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac62d2f-6834-4d98-b69d-bd7b5831d981.jpg?1",
             "name": "Biting Rain",
             "text": "All creatures get -2/-2 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "839e8d57-b28d-5000-9474-1ecced0ad3e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec85cca-ac2c-4b1b-850b-6a762df72bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec85cca-ac2c-4b1b-850b-6a762df72bd0.jpg?1",
             "name": "Call the Bloodline",
             "text": "{1}, Discard a card: Put a 1/1 black Vampire Knight creature token with lifelink onto the battlefield. Activate this ability only once each turn.",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "582c372f-6a03-587a-a765-785852f0e7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3376c4-369a-4d63-bd48-966bcfb0c9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3376c4-369a-4d63-bd48-966bcfb0c9b9.jpg?1",
             "name": "Creeping Dread",
             "text": "At the beginning of your upkeep, each player discards a card. Each opponent who discarded a card that shares a card type with the card you discarded loses 3 life. (Players reveal the discarded cards simultaneously.)",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "d3a75fe2-c639-50d7-968a-c2dd97e50640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4d1b5-72de-4062-9fdd-e9bfd655ee79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4d1b5-72de-4062-9fdd-e9bfd655ee79.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "1cebea6c-5a6e-5fdc-a018-b8813b47c295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09a09de-35c9-4a4e-a4ac-1ce24e166ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09a09de-35c9-4a4e-a4ac-1ce24e166ad9.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -3941,7 +3941,7 @@
         },
         {
             "id": "7cd9e633-1d95-52d5-b5a3-d9e3be39d67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039e8f6-5513-4307-a1b5-07209dc8e1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039e8f6-5513-4307-a1b5-07209dc8e1c8.jpg?1",
             "name": "Diregraf Colossus",
             "text": "Diregraf Colossus enters the battlefield with a +1/+1 counter on it for each Zombie card in your graveyard.\nWhenever you cast a Zombie spell, put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "b3141523-8960-53f1-9b5a-0b2b874d3341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg?1",
             "name": "Elusive Tormentor // Insidious Mist",
             "text": "{1}, Discard a card: Transform Elusive Tormentor.",
             "colours": [
@@ -4012,7 +4012,7 @@
         },
         {
             "id": "a9bfb7bd-4d95-5f98-9eb3-8ac1ac39ff53",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg?1",
             "name": "Elusive Tormentor // Insidious Mist",
             "text": "Hexproof, indestructible\nInsidious Mist can't block and can't be blocked.\nWhenever Insidious Mist attacks and isn't blocked, you may pay {2}{B}. If you do, transform it.",
             "colours": [
@@ -4047,7 +4047,7 @@
         },
         {
             "id": "19092dcc-c213-53e3-8bf1-0924e21b5c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a530a54-2711-4858-bc88-559d90be4f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a530a54-2711-4858-bc88-559d90be4f05.jpg?1",
             "name": "Ever After",
             "text": "Return up to two target creature cards from your graveyard to the battlefield. Each of those creatures is a black Zombie in addition to its other colors and types. Put Ever After on the bottom of its owner's library.",
             "colours": [
@@ -4079,7 +4079,7 @@
         },
         {
             "id": "597c3208-fbf8-5275-84f0-66818fc392fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6de332-debb-49f3-8b29-1719060ab00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6de332-debb-49f3-8b29-1719060ab00c.jpg?1",
             "name": "Farbog Revenant",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "8f2bc907-5bc6-54b7-8377-8dbdfd660651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644706-223d-4e56-9614-b224e281be2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644706-223d-4e56-9614-b224e281be2f.jpg?1",
             "name": "From Under the Floorboards",
             "text": "Madness {X}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nPut three 2/2 black Zombie creature tokens onto the battlefield tapped and you gain 3 life. If From Under the Floorboards's madness cost was paid, instead put X of those tokens onto the battlefield tapped and you gain X life.",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "2db77325-7638-53cc-b18d-207118d02909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f48828d-5f97-434f-a3b8-9e8c75cc8932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f48828d-5f97-434f-a3b8-9e8c75cc8932.jpg?1",
             "name": "Ghoulcaller's Accomplice",
             "text": "{3}{B}, Exile Ghoulcaller's Accomplice from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "5dd75cdc-a6dd-5e1c-ba8b-d7b4e0331a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5ba8dd-d2cd-4ee6-bdb4-390968f1ff54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5ba8dd-d2cd-4ee6-bdb4-390968f1ff54.jpg?1",
             "name": "Ghoulsteed",
             "text": "{2}{B}, Discard two cards: Return Ghoulsteed from your graveyard to the battlefield tapped.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "623af577-386b-58c9-91a0-71331636f12e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01e904c-7d8e-447b-90cb-1f4ae3fb304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01e904c-7d8e-447b-90cb-1f4ae3fb304d.jpg?1",
             "name": "Gisa's Bidding",
             "text": "Put two 2/2 black Zombie creature tokens onto the battlefield.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "42a3309d-7c37-5435-8c1c-4a65cbb970a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce84d54c-ef63-4b90-a2b6-99a4aa21c02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce84d54c-ef63-4b90-a2b6-99a4aa21c02d.jpg?1",
             "name": "Grotesque Mutation",
             "text": "Target creature gets +3/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "b12a47cb-dfd1-5b53-a7a3-1b01d514e786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg?1",
             "name": "Heir of Falkenrath // Heir to the Night",
             "text": "",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "4c713c08-4ea3-51a6-85f2-07ec2d726e99",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg?1",
             "name": "Heir of Falkenrath // Heir to the Night",
             "text": "",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "ad112fbf-bebc-586c-aba8-b2fcda87bfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc37615-ef72-4176-9e94-080e56af1d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc37615-ef72-4176-9e94-080e56af1d8a.jpg?1",
             "name": "Hound of the Farbogs",
             "text": "Delirium \u2014 Hound of the Farbogs has menace as long as there are four or more card types among cards in your graveyard. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "15ae168a-76dd-5cdb-a978-a34da745be01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24200d4-cd98-424c-bc2f-69f8b361d8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24200d4-cd98-424c-bc2f-69f8b361d8fc.jpg?1",
             "name": "Indulgent Aristocrat",
             "text": "Lifelink\n{2}, Sacrifice a creature: Put a +1/+1 counter on each Vampire you control.",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "f2d3e38e-d1ab-597f-a86a-1580daff5c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg?1",
             "name": "Kindly Stranger // Demon-Possessed Witch",
             "text": "Delirium \u2014 {2}{B}: Transform Kindly Stranger. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "9372b55f-19d0-5e88-921e-774954ae3393",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg?1",
             "name": "Kindly Stranger // Demon-Possessed Witch",
             "text": "When this creature transforms into Demon-Possessed Witch, you may destroy target creature.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "a01e6a61-0078-5e38-91cf-304c0b64dead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3817ea1a-b3d8-46f1-ac6c-69caf2466bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3817ea1a-b3d8-46f1-ac6c-69caf2466bab.jpg?1",
             "name": "Liliana's Indignation",
             "text": "Put the top X cards of your library into your graveyard. Target player loses 2 life for each creature card put into your graveyard this way.",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "7fa4d04e-3b5f-5698-a0fe-067458247aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ec8571-690e-405f-89d5-b7cc99e8ee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ec8571-690e-405f-89d5-b7cc99e8ee63.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -4551,7 +4551,7 @@
         },
         {
             "id": "594c8198-8116-516c-9c70-217978981479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg?1",
             "name": "Markov Dreadknight",
             "text": "Flying\n{2}{B}, Discard a card: Put two +1/+1 counters on Markov Dreadknight.",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "54b7123a-a033-50c8-a510-5a0e980c4bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356af156-a059-416c-b78b-d9058b742818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356af156-a059-416c-b78b-d9058b742818.jpg?1",
             "name": "Merciless Resolve",
             "text": "As an additional cost to cast Merciless Resolve, sacrifice a creature or land.\nDraw two cards.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "2deba3aa-6c3c-542c-9950-b5b883d00076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804cb9c-349e-4143-a372-cf65470d5b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804cb9c-349e-4143-a372-cf65470d5b46.jpg?1",
             "name": "Mindwrack Demon",
             "text": "Flying, trample\nWhen Mindwrack Demon enters the battlefield, put the top four cards of your library into your graveyard.\nDelirium \u2014 At the beginning of your upkeep, you lose 4 life unless there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -4652,7 +4652,7 @@
         },
         {
             "id": "d98db9f8-d53e-54b4-b48e-8adbe192e047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726f215-d0a5-4e2c-b874-9dc209479993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726f215-d0a5-4e2c-b874-9dc209479993.jpg?1",
             "name": "Morkrut Necropod",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Morkrut Necropod attacks or blocks, sacrifice another creature or land.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "7157fd09-d3cd-5bc5-a656-d7819f1f5022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b94db1-ac8c-4667-81d5-408df0f30879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b94db1-ac8c-4667-81d5-408df0f30879.jpg?1",
             "name": "Murderous Compulsion",
             "text": "Destroy target tapped creature.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "b8a0bd7e-5d71-5223-89a7-4ebb96ad11d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdda34e9-f28b-4606-8298-b2d0c15033e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdda34e9-f28b-4606-8298-b2d0c15033e6.jpg?1",
             "name": "Olivia's Bloodsworn",
             "text": "Flying\nOlivia's Bloodsworn can't block.\n{R}: Target Vampire gains haste until end of turn.",
             "colours": [
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "f24663e1-25f8-5efc-861b-c7582443893c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dad70b8-0dec-4634-a31a-b78438a313a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dad70b8-0dec-4634-a31a-b78438a313a2.jpg?1",
             "name": "Pale Rider of Trostad",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Pale Rider of Trostad enters the battlefield, discard a card.",
             "colours": [
@@ -4789,7 +4789,7 @@
         },
         {
             "id": "ef07ff13-bf1d-546b-a307-62ef4f951e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53503e59-6b6c-4de1-8528-458ab94f4e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53503e59-6b6c-4de1-8528-458ab94f4e9a.jpg?1",
             "name": "Pick the Brain",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from it and exile that card.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, search that player's graveyard, hand, and library for any number of cards with the same name as the exiled card, exile those cards, then that player shuffles his or her library.",
             "colours": [
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "7e9bccf5-1cc2-555a-9189-599539c54be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336e0a75-8104-4e88-aad0-af7ac3efc115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336e0a75-8104-4e88-aad0-af7ac3efc115.jpg?1",
             "name": "Rancid Rats",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "6910f954-4fc8-5cd5-aaa9-474e22ad759c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d7998-2f3d-43b8-a0be-6ff7e5c83223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d7998-2f3d-43b8-a0be-6ff7e5c83223.jpg?1",
             "name": "Relentless Dead",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Relentless Dead dies, you may pay {B}. If you do, return it to its owner's hand.\nWhen Relentless Dead dies, you may pay {X}. If you do, return another target Zombie creature card with converted mana cost X from your graveyard to the battlefield.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "625168f5-4a95-5afc-9c9c-447f484e70e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933f0504-c611-4557-b1e6-f5be72154805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933f0504-c611-4557-b1e6-f5be72154805.jpg?1",
             "name": "Rottenheart Ghoul",
             "text": "When Rottenheart Ghoul dies, target player discards a card.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "e755cdae-ffe9-5a36-857b-db4df783bb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b69045-2b22-4fba-868a-b91c93eb960a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b69045-2b22-4fba-868a-b91c93eb960a.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "8d328479-e635-54cc-810b-eaf3518e6ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6913dce-05f5-4e1b-9dd9-67eb347b5be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6913dce-05f5-4e1b-9dd9-67eb347b5be8.jpg?1",
             "name": "Shamble Back",
             "text": "Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield. You gain 2 life.",
             "colours": [
@@ -4990,7 +4990,7 @@
         },
         {
             "id": "cc9cf18a-4dd5-5c90-af1e-28703d824cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815ca911-ccc1-4466-8d12-054b8d241992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815ca911-ccc1-4466-8d12-054b8d241992.jpg?1",
             "name": "Sinister Concoction",
             "text": "{B}, Pay 1 life, Put the top card of your library into your graveyard, Discard a card, Sacrifice Sinister Concoction: Destroy target creature.",
             "colours": [
@@ -5022,7 +5022,7 @@
         },
         {
             "id": "f0279149-7ca2-504e-8f98-0a08a12b3a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b465a5d-3ce4-4c96-a3f3-4ad9716946c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b465a5d-3ce4-4c96-a3f3-4ad9716946c4.jpg?1",
             "name": "Stallion of Ashmouth",
             "text": "Delirium \u2014 {1}{B}: Stallion of Ashmouth gets +1/+1 until end of turn. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "f59b7aef-5f27-5543-ba45-2eaec5337fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90b7dc-fb90-411e-a762-06a800bae0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90b7dc-fb90-411e-a762-06a800bae0cf.jpg?1",
             "name": "Stromkirk Mentor",
             "text": "When Stromkirk Mentor enters the battlefield, put a +1/+1 counter on another target Vampire you control.",
             "colours": [
@@ -5092,7 +5092,7 @@
         },
         {
             "id": "d86ecd66-66ee-5eaf-b141-8be182b78e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f9001-17b2-4087-8d87-5dbaa6c48b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f9001-17b2-4087-8d87-5dbaa6c48b16.jpg?1",
             "name": "Throttle",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "b4babb4f-3d0c-5a52-a07e-0f457d8245f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a645c8d-7cfb-466b-9fd0-e1c26bf6f652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a645c8d-7cfb-466b-9fd0-e1c26bf6f652.jpg?1",
             "name": "To the Slaughter",
             "text": "Target player sacrifices a creature or planeswalker.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead that player sacrifices a creature and a planeswalker.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "c66efe39-9af0-5b38-b99a-7d05ebad7512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc9f63-a225-438d-b835-07a561ba91f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc9f63-a225-438d-b835-07a561ba91f5.jpg?1",
             "name": "Tooth Collector",
             "text": "When Tooth Collector enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, target creature that player controls gets -1/-1 until end of turn.",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "850618a6-9a6b-5c11-8892-dfa5d9d9fbb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8060b717-94c9-4962-9676-0b1ca6a357a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8060b717-94c9-4962-9676-0b1ca6a357a8.jpg?1",
             "name": "Triskaidekaphobia",
             "text": "At the beginning of your upkeep, choose one \u2014\n\u2022 Each player with exactly 13 life loses the game, then each player gains 1 life.\n\u2022 Each player with exactly 13 life loses the game, then each player loses 1 life.",
             "colours": [
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "6d1fe9e1-618e-5ff2-a7b9-b8721185f505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc13a00-bd58-44fa-93af-846001ca4f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc13a00-bd58-44fa-93af-846001ca4f84.jpg?1",
             "name": "Twins of Maurer Estate",
             "text": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "54055ab6-a3c9-5fe0-921e-23434d13b510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2435f17-0378-4480-8d56-d256245c7ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2435f17-0378-4480-8d56-d256245c7ced.jpg?1",
             "name": "Vampire Noble",
             "text": "",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "743684e2-59a6-5538-b5a2-a7dbfa59560b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b44857-1edb-4de4-b646-917101faf881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b44857-1edb-4de4-b646-917101faf881.jpg?1",
             "name": "Vessel of Malignity",
             "text": "{1}{B}, Sacrifice Vessel of Malignity: Target opponent exiles two cards from his or her hand. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -5324,7 +5324,7 @@
         },
         {
             "id": "12b60a03-402b-57f6-b847-2e0fcd7072e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5f44ce-1464-4282-9afa-20e9ea44c613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5f44ce-1464-4282-9afa-20e9ea44c613.jpg?1",
             "name": "Avacyn's Judgment",
             "text": "Madness {X}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nAvacyn's Judgment deals 2 damage divided as you choose among any number of target creatures and/or players. If Avacyn's Judgment's madness cost was paid, it deals X damage divided as you choose among those creatures and/or players instead.",
             "colours": [
@@ -5356,7 +5356,7 @@
         },
         {
             "id": "540df9e6-6641-5074-8648-da3610a51dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e974a-3cf7-49f1-9d5a-c74f920f0169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e974a-3cf7-49f1-9d5a-c74f920f0169.jpg?1",
             "name": "Bloodmad Vampire",
             "text": "Whenever Bloodmad Vampire deals combat damage to a player, put a +1/+1 counter on it.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5391,7 +5391,7 @@
         },
         {
             "id": "6f5cd81f-d833-5bc6-b3e7-ddd58c2c0adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg?1",
             "name": "Breakneck Rider // Neck Breaker",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Breakneck Rider.",
             "colours": [
@@ -5427,7 +5427,7 @@
         },
         {
             "id": "c5193e2e-11ed-57cb-a5ef-8c937ebb4e11",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg?1",
             "name": "Breakneck Rider // Neck Breaker",
             "text": "Attacking creatures you control get +1/+0 and have trample.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Neck Breaker.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "db5291b6-f0b1-5b9d-b99d-f294c57fdff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bdc165-4c6f-47e6-8bda-877c0be3613b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bdc165-4c6f-47e6-8bda-877c0be3613b.jpg?1",
             "name": "Burn from Within",
             "text": "Burn from Within deals X damage to target creature or player. If a creature is dealt damage this way, it loses indestructible until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "281b5e91-bd67-511d-883e-bc0805e8ee2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg?1",
             "name": "Convicted Killer // Branded Howler",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Convicted Killer.",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "da093346-5e2b-52b5-aaa1-ce1568451f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg?1",
             "name": "Convicted Killer // Branded Howler",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Branded Howler.",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "20ed97c9-4670-5c39-b634-7817aebf27bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1112ebe-2a42-48b9-b0e5-f708305d088a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1112ebe-2a42-48b9-b0e5-f708305d088a.jpg?1",
             "name": "Dance with Devils",
             "text": "Put two 1/1 red Devil creature tokens onto the battlefield. They have \"When this creature dies, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "4459544f-ac06-5b4f-88b8-fb69225e4a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207e6eb-15a7-4ec4-91b3-880375704bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207e6eb-15a7-4ec4-91b3-880375704bb6.jpg?1",
             "name": "Devils' Playground",
             "text": "Put four 1/1 red Devil creature tokens onto the battlefield. They have \"When this creature dies, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -5626,7 +5626,7 @@
         },
         {
             "id": "dd4fdba6-6fd2-5afc-9114-d22e8612e384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1b563a-7856-40bf-954a-a0110ed4880d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1b563a-7856-40bf-954a-a0110ed4880d.jpg?1",
             "name": "Dissension in the Ranks",
             "text": "Target blocking creature fights another target blocking creature.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "9dedb9ca-9cb7-59cf-9b13-b894cbd79dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ac4fa4-4a03-41a9-b7e4-c3a6da89472f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ac4fa4-4a03-41a9-b7e4-c3a6da89472f.jpg?1",
             "name": "Dual Shot",
             "text": "Dual Shot deals 1 damage to each of up to two target creatures.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "2850c055-510f-5e88-b7e8-544c9beb46b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fe1e1e-b14a-4efe-894b-b9da635f007f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fe1e1e-b14a-4efe-894b-b9da635f007f.jpg?1",
             "name": "Ember-Eye Wolf",
             "text": "Haste\n{1}{R}: Ember-Eye Wolf gets +2/+0 until end of turn.",
             "colours": [
@@ -5724,7 +5724,7 @@
         },
         {
             "id": "729ffd1e-98a9-568e-b40d-f3d831d41753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474895d8-1f2c-45bb-b721-4cf7c290eb23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474895d8-1f2c-45bb-b721-4cf7c290eb23.jpg?1",
             "name": "Falkenrath Gorger",
             "text": "Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost. (If you discard a card with madness, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5759,7 +5759,7 @@
         },
         {
             "id": "cd1693c5-0546-5074-be62-4a18b4429c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61caf82d-e077-4931-a6ad-09fa7f04b36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61caf82d-e077-4931-a6ad-09fa7f04b36f.jpg?1",
             "name": "Fiery Temper",
             "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "5b8c9d72-4eda-52d9-8c1c-ea6c756f9b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1031ec22-c99f-4843-a7cf-c8332234eca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1031ec22-c99f-4843-a7cf-c8332234eca8.jpg?1",
             "name": "Flameblade Angel",
             "text": "Flying\nWhenever a source an opponent controls deals damage to you or a permanent you control, you may have Flameblade Angel deal 1 damage to that source's controller.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "d620864f-6860-54ab-b32f-6d38134f5c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg?1",
             "name": "Gatstaf Arsonists // Gatstaf Ravagers",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Gatstaf Arsonists.",
             "colours": [
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "407b2282-9449-54d4-a3d6-088742c51a85",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg?1",
             "name": "Gatstaf Arsonists // Gatstaf Ravagers",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Gatstaf Ravagers.",
             "colours": [
@@ -5894,7 +5894,7 @@
         },
         {
             "id": "6bdd8ac3-d562-5bbd-8937-15aec59dc98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1",
             "name": "Geier Reach Bandit // Vildin-Pack Alpha",
             "text": "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform Geier Reach Bandit.",
             "colours": [
@@ -5930,7 +5930,7 @@
         },
         {
             "id": "b2a2095b-5ca3-5d1f-9366-a2a45c3ab3c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1",
             "name": "Geier Reach Bandit // Vildin-Pack Alpha",
             "text": "Whenever a Werewolf enters the battlefield under your control, you may transform it.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Vildin-Pack Alpha.",
             "colours": [
@@ -5964,7 +5964,7 @@
         },
         {
             "id": "5aa7d6e8-b325-538d-8570-10a08f30ebd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b1dfd9-b717-4c23-b8e5-a6ec835b278a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b1dfd9-b717-4c23-b8e5-a6ec835b278a.jpg?1",
             "name": "Geistblast",
             "text": "Geistblast deals 2 damage to target creature or player.\n{2}{U}, Exile Geistblast from your graveyard: Copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "40c77f8c-21c9-59e7-b02a-8945c350f297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5113c437-3276-4591-b95e-c2afb9d6329a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5113c437-3276-4591-b95e-c2afb9d6329a.jpg?1",
             "name": "Gibbering Fiend",
             "text": "When Gibbering Fiend enters the battlefield, it deals 1 damage to each opponent.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, Gibbering Fiend deals 1 damage to that player.",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "77c06c61-8a04-565e-8eb8-f812b1c7f9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d3c9a-d41b-4743-87a6-68d116460fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d3c9a-d41b-4743-87a6-68d116460fe2.jpg?1",
             "name": "Goldnight Castigator",
             "text": "Flying, haste\nIf a source would deal damage to you, it deals double that damage to you instead.\nIf a source would deal damage to Goldnight Castigator, it deals double that damage to Goldnight Castigator instead.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "0fdc0846-595b-577c-be09-d037d570ed25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5294d359-c599-40ed-9e06-2a3cc8624d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5294d359-c599-40ed-9e06-2a3cc8624d6a.jpg?1",
             "name": "Harness the Storm",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast target card with the same name as that spell from your graveyard. (You still pay its costs.)",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "ce636de3-662b-5a0d-8079-33db7469a29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7379689-8e4f-4c23-9276-3510f70ba7ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7379689-8e4f-4c23-9276-3510f70ba7ff.jpg?1",
             "name": "Howlpack Wolf",
             "text": "Howlpack Wolf can't block unless you control another Wolf or Werewolf.",
             "colours": [
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "febef854-1bcd-5483-84ce-e9718535ccff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031ecfc4-cc84-4f74-8eb1-3eaa234d8093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031ecfc4-cc84-4f74-8eb1-3eaa234d8093.jpg?1",
             "name": "Hulking Devil",
             "text": "",
             "colours": [
@@ -6165,7 +6165,7 @@
         },
         {
             "id": "30330d1a-c07b-5a46-a465-56f85a87f82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e826571-6f00-4b40-975b-d51b2b17b4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e826571-6f00-4b40-975b-d51b2b17b4a4.jpg?1",
             "name": "Incorrigible Youths",
             "text": "Haste\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6199,7 +6199,7 @@
         },
         {
             "id": "6f8dbcc4-05e1-5718-b97e-cd4a5a0c73f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43be50a-8624-46f6-860a-39ffbfbdaa6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43be50a-8624-46f6-860a-39ffbfbdaa6a.jpg?1",
             "name": "Inner Struggle",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -6231,7 +6231,7 @@
         },
         {
             "id": "dd130b6c-a8e2-5e67-ac7d-6b34d7966163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813104f6-e6e4-4709-8626-12fe4262a11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813104f6-e6e4-4709-8626-12fe4262a11f.jpg?1",
             "name": "Insolent Neonate",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nDiscard a card, Sacrifice Insolent Neonate: Draw a card.",
             "colours": [
@@ -6265,7 +6265,7 @@
         },
         {
             "id": "e5ba9672-9bba-5d1b-b30b-b22994d7cd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg?1",
             "name": "Kessig Forgemaster // Flameheart Werewolf",
             "text": "Whenever Kessig Forgemaster blocks or becomes blocked by a creature, Kessig Forgemaster deals 1 damage to that creature.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Kessig Forgemaster.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "c33d3fb3-298d-5e1e-a484-1343803b815d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg?1",
             "name": "Kessig Forgemaster // Flameheart Werewolf",
             "text": "Whenever Flameheart Werewolf blocks or becomes blocked by a creature, Flameheart Werewolf deals 2 damage to that creature.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Flameheart Werewolf.",
             "colours": [
@@ -6335,7 +6335,7 @@
         },
         {
             "id": "c194d6c3-6f56-5753-92cb-2f69d92b57cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3105d-4cf9-48bf-8d12-27e856ae7a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3105d-4cf9-48bf-8d12-27e856ae7a87.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast Lightning Axe, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -6367,7 +6367,7 @@
         },
         {
             "id": "2a17e881-33ef-5743-8991-966d4abfe017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f498cb6-2be2-4cd0-b002-564a0f006a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f498cb6-2be2-4cd0-b002-564a0f006a69.jpg?1",
             "name": "Mad Prophet",
             "text": "Haste\n{T}, Discard a card: Draw a card.",
             "colours": [
@@ -6402,7 +6402,7 @@
         },
         {
             "id": "176bb87b-2cba-5b90-b9e6-841c4ea13cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d5de8b-0286-4fca-86fd-e983a91f4a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d5de8b-0286-4fca-86fd-e983a91f4a8c.jpg?1",
             "name": "Magmatic Chasm",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -6434,7 +6434,7 @@
         },
         {
             "id": "e7cef3f2-ba64-53f7-8f1e-9860d4ecc202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674d33d6-dfd4-4972-aaa3-6de0236a8c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674d33d6-dfd4-4972-aaa3-6de0236a8c45.jpg?1",
             "name": "Malevolent Whispers",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "be8b9603-c706-5124-ab31-a4779cf0ce5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d19c5fb-01af-4ca4-af7e-00ec2a748afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d19c5fb-01af-4ca4-af7e-00ec2a748afd.jpg?1",
             "name": "Pyre Hound",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on Pyre Hound.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "7b7c44c6-f914-5996-9f41-5db576775bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4d04bc-6263-43b0-9b01-894a532cd3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4d04bc-6263-43b0-9b01-894a532cd3ed.jpg?1",
             "name": "Ravenous Bloodseeker",
             "text": "Discard a card: Ravenous Bloodseeker gets +2/-2 until end of turn.",
             "colours": [
@@ -6536,7 +6536,7 @@
         },
         {
             "id": "3e2a5a42-0365-5fee-b904-5b016d096528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e23215-ced7-4c44-8595-dd9df3d8227b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e23215-ced7-4c44-8595-dd9df3d8227b.jpg?1",
             "name": "Reduce to Ashes",
             "text": "Reduce to Ashes deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -6568,7 +6568,7 @@
         },
         {
             "id": "3dd6a6c8-e927-5e2e-a9ea-0b2b4fc5501d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg?1",
             "name": "Rush of Adrenaline",
             "text": "Target creature gets +2/+1 and gains trample until end of turn.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "adadc0de-46c5-5453-8ed9-fe8e30a8bad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace86fac-769c-4440-9a40-318d7172555b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace86fac-769c-4440-9a40-318d7172555b.jpg?1",
             "name": "Sanguinary Mage",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "5ce62879-0166-5f30-b2c2-8b8aad298fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072f47ad-3055-4bd2-b7fd-cfbd22720d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072f47ad-3055-4bd2-b7fd-cfbd22720d58.jpg?1",
             "name": "Scourge Wolf",
             "text": "First strike\nDelirium \u2014 Scourge Wolf has double strike as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "dbffc493-5237-5a64-980c-d12b99d4bd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c779cb6-3454-4d5a-85a1-bea5cf8005b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c779cb6-3454-4d5a-85a1-bea5cf8005b1.jpg?1",
             "name": "Senseless Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "520a6b39-7615-5e0c-9688-bece4aae5c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefeb031-9dda-4717-a8d1-e2c21551e43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefeb031-9dda-4717-a8d1-e2c21551e43a.jpg?1",
             "name": "Sin Prodder",
             "text": "Menace\nAt the beginning of your upkeep, reveal the top card of your library. Any opponent may have you put that card into your graveyard. If a player does, Sin Prodder deals damage to that player equal to that card's converted mana cost. Otherwise, put that card into your hand.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "73a278af-00a6-5386-ad47-3791e00ceecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg?1",
             "name": "Skin Invasion // Skin Shedder",
             "text": "Enchant creature\nEnchanted creature attacks each combat if able.\nWhen enchanted creature dies, return Skin Invasion to the battlefield transformed under your control.",
             "colours": [
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "8fedef1e-c540-5f2c-aa7e-fb95cf771b37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg?1",
             "name": "Skin Invasion // Skin Shedder",
             "text": "",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "7ae26ebb-74b3-549a-9d90-ea58b6039766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d7349-d066-49b0-9920-c1ec1595e00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d7349-d066-49b0-9920-c1ec1595e00d.jpg?1",
             "name": "Spiteful Motives",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +3/+0 and has first strike.",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "98fae5d3-d8b1-5d14-ac67-470bfc09cbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f1b024-d7d5-4e81-b016-06826e2b8bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f1b024-d7d5-4e81-b016-06826e2b8bbf.jpg?1",
             "name": "Stensia Masquerade",
             "text": "Attacking creatures you control have first strike.\nWhenever a Vampire you control deals combat damage to a player, put a +1/+1 counter on it.\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "6d80eff1-0087-5398-852b-2754aa6299b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7895890-a774-4c7c-9f15-78b8aadfd9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7895890-a774-4c7c-9f15-78b8aadfd9ef.jpg?1",
             "name": "Structural Distortion",
             "text": "Exile target artifact or land. Structural Distortion deals 2 damage to that permanent's controller.",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "b747d38b-10e5-5663-829f-7a501037e1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b0a20-2422-465e-b74e-4402b34fb57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b0a20-2422-465e-b74e-4402b34fb57b.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -6937,7 +6937,7 @@
         },
         {
             "id": "43fe4bba-497e-54cc-8ea9-96e5e1ac54ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d0ee03-a8c6-4f37-9885-60a26a2e2728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d0ee03-a8c6-4f37-9885-60a26a2e2728.jpg?1",
             "name": "Ulrich's Kindred",
             "text": "Trample\n{3}{G}: Target attacking Wolf or Werewolf gains indestructible until end of turn.",
             "colours": [
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "09f4ea69-3f7d-5e90-b291-e52990425b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40440487-5ff2-43da-aa06-c649bf972ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40440487-5ff2-43da-aa06-c649bf972ef1.jpg?1",
             "name": "Uncaged Fury",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -7004,7 +7004,7 @@
         },
         {
             "id": "331efc27-0224-5da1-af65-5d1918afbc73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81647b86-2c84-4a14-8d5a-919f7a5b8bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81647b86-2c84-4a14-8d5a-919f7a5b8bc7.jpg?1",
             "name": "Vessel of Volatility",
             "text": "{1}{R}, Sacrifice Vessel of Volatility: Add {R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "ff9bb16e-1697-5205-8201-6f36fff33391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1",
             "name": "Village Messenger // Moonrise Intruder",
             "text": "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform Village Messenger.",
             "colours": [
@@ -7071,7 +7071,7 @@
         },
         {
             "id": "80e1108f-03b5-52ff-ad95-51989989beb0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1",
             "name": "Village Messenger // Moonrise Intruder",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Moonrise Intruder.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "e76d3e0b-3d07-507c-93a8-846fb350e5a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ca081d-6771-407e-ae03-3d6b2ec61dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ca081d-6771-407e-ae03-3d6b2ec61dff.jpg?1",
             "name": "Voldaren Duelist",
             "text": "Haste\nWhen Voldaren Duelist enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "08173ae3-7807-574f-aaa4-bb55b93fec0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedce04c-e7bc-4db0-94a1-66131761512c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedce04c-e7bc-4db0-94a1-66131761512c.jpg?1",
             "name": "Wolf of Devil's Breach",
             "text": "Whenever Wolf of Devil's Breach attacks, you may pay {1}{R} and discard a card. If you do, Wolf of Devil's Breach deals damage to target creature or planeswalker equal to the discarded card's converted mana cost.",
             "colours": [
@@ -7175,7 +7175,7 @@
         },
         {
             "id": "39bbbaca-a429-56d8-8d6f-fc2cfae0433b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cd33cc-df39-4db1-a4a0-09756ec8372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cd33cc-df39-4db1-a4a0-09756ec8372c.jpg?1",
             "name": "Aim High",
             "text": "Untap target creature. It gets +2/+2 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -7207,7 +7207,7 @@
         },
         {
             "id": "ec30d374-624c-5028-8a2a-fb899486033b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg?1",
             "name": "Autumnal Gloom // Ancient of the Equinox",
             "text": "{B}: Put the top card of your library into your graveyard.\nDelirium \u2014 At the beginning of your end step, if there are four or more card types among cards in your graveyard, transform Autumnal Gloom.",
             "colours": [
@@ -7240,7 +7240,7 @@
         },
         {
             "id": "d7c24f54-ce35-515d-815f-d40c6280a31d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg?1",
             "name": "Autumnal Gloom // Ancient of the Equinox",
             "text": "Trample, hexproof",
             "colours": [
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "fe6e209a-1e95-5c2b-b7b1-fcbb8ccc3a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a017b-40cb-4c15-b9ea-a3ed904e4e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a017b-40cb-4c15-b9ea-a3ed904e4e49.jpg?1",
             "name": "Briarbridge Patrol",
             "text": "Whenever Briarbridge Patrol deals damage to one or more creatures, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nAt the beginning of each end step, if you sacrificed three or more Clues this turn, you may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -7310,7 +7310,7 @@
         },
         {
             "id": "bb9b68e4-1c65-5cc3-a57d-9419ad3b27f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f243a51-bbd3-4028-a469-469ab5591aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f243a51-bbd3-4028-a469-469ab5591aae.jpg?1",
             "name": "Byway Courier",
             "text": "When Byway Courier dies, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "c0ff9d43-24e9-5591-9235-5952578dba05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2835993-6c71-4a63-bad5-cb25aedc4a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2835993-6c71-4a63-bad5-cb25aedc4a15.jpg?1",
             "name": "Clip Wings",
             "text": "Each opponent sacrifices a creature with flying.",
             "colours": [
@@ -7377,7 +7377,7 @@
         },
         {
             "id": "c8bec8d6-5021-5d67-9cd4-c1324755de62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59557c3-aba2-4f80-8f37-accb7b991cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59557c3-aba2-4f80-8f37-accb7b991cb9.jpg?1",
             "name": "Confront the Unknown",
             "text": "Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7409,7 +7409,7 @@
         },
         {
             "id": "aaabffba-1518-5c24-8e88-7cdb6327cedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d5abe-22b5-4ef1-ad74-af3e75e22a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d5abe-22b5-4ef1-ad74-af3e75e22a07.jpg?1",
             "name": "Crawling Sensation",
             "text": "At the beginning of your upkeep, you may put the top two cards of your library into your graveyard.\nWhenever one or more land cards are put into your graveyard from anywhere for the first time each turn, put a 1/1 green Insect creature token onto the battlefield.",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "e884ed8e-1ee0-5b8c-a94e-bda1d15b75b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2910adcd-882a-46af-8236-ca1a9e2c19ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2910adcd-882a-46af-8236-ca1a9e2c19ab.jpg?1",
             "name": "Cryptolith Rite",
             "text": "Creatures you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "f03bd93d-277a-54ba-9b25-3411f42fd7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a13669-4656-476a-8984-ec3d47960907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a13669-4656-476a-8984-ec3d47960907.jpg?1",
             "name": "Cult of the Waxing Moon",
             "text": "Whenever a permanent you control transforms into a non-Human creature, put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -7508,7 +7508,7 @@
         },
         {
             "id": "009d31ce-b47f-5cd3-9a54-51dbca6c7f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4aee46-ac42-4ede-ad06-906e2955a9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4aee46-ac42-4ede-ad06-906e2955a9d3.jpg?1",
             "name": "Deathcap Cultivator",
             "text": "{T}: Add {B} or {G} to your mana pool.\nDelirium \u2014 Deathcap Cultivator has deathtouch as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "b8f2b734-6f99-5f8a-9003-31fa49aa1a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1",
             "name": "Duskwatch Recruiter // Krallenhorde Howler",
             "text": "{2}{G}: Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Duskwatch Recruiter.",
             "colours": [
@@ -7580,7 +7580,7 @@
         },
         {
             "id": "ed551490-1e38-5b31-87ba-83ad03f23b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1",
             "name": "Duskwatch Recruiter // Krallenhorde Howler",
             "text": "Creature spells you cast cost {1} less to cast.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Krallenhorde Howler.",
             "colours": [
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "cad2aad7-bd3f-509c-bf7a-d9c8e5a29269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af14d1-a304-4744-9d6f-9ff5fcd92ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af14d1-a304-4744-9d6f-9ff5fcd92ad3.jpg?1",
             "name": "Equestrian Skill",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nAs long as enchanted creature is a Human, it has trample.",
             "colours": [
@@ -7648,7 +7648,7 @@
         },
         {
             "id": "6ccf5c66-4840-5f4e-ac8f-26645e9c0b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7ad701-65c3-494a-8986-b4ea1bab46bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7ad701-65c3-494a-8986-b4ea1bab46bc.jpg?1",
             "name": "Fork in the Road",
             "text": "Search your library for up to two basic land cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle your library.",
             "colours": [
@@ -7680,7 +7680,7 @@
         },
         {
             "id": "d01577e5-a066-536a-b779-6768edc47684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04dfd8-e704-46d7-bdf8-b0b2ee747a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04dfd8-e704-46d7-bdf8-b0b2ee747a49.jpg?1",
             "name": "Gloomwidow",
             "text": "Reach\nGloomwidow can block only creatures with flying.",
             "colours": [
@@ -7714,7 +7714,7 @@
         },
         {
             "id": "b749d8cf-4bf4-587c-ab8f-3f5b330a4bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a40334-65d8-46d2-9c56-389e9b32107c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a40334-65d8-46d2-9c56-389e9b32107c.jpg?1",
             "name": "Graf Mole",
             "text": "Whenever you sacrifice a Clue, you gain 3 life.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "d7afcbed-75cb-5bbc-a849-5f4fe030f4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae029a5b-bcfb-4004-86aa-aaeca561545c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae029a5b-bcfb-4004-86aa-aaeca561545c.jpg?1",
             "name": "Groundskeeper",
             "text": "{1}{G}: Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -7784,7 +7784,7 @@
         },
         {
             "id": "0b7eead2-861d-555e-885a-14b8a7892ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg?1",
             "name": "Hermit of the Natterknolls // Lone Wolf of the Natterknolls",
             "text": "Whenever an opponent casts a spell during your turn, draw a card.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Hermit of the Natterknolls.",
             "colours": [
@@ -7819,7 +7819,7 @@
         },
         {
             "id": "8e3a188c-a417-5013-8a38-3984f15b7c31",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg?1",
             "name": "Hermit of the Natterknolls // Lone Wolf of the Natterknolls",
             "text": "Whenever an opponent casts a spell during your turn, draw two cards.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Lone Wolf of the Natterknolls.",
             "colours": [
@@ -7853,7 +7853,7 @@
         },
         {
             "id": "d5d4e44e-9fb1-5e19-9ab9-537a1d1bc5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1",
             "name": "Hinterland Logger // Timber Shredder",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Hinterland Logger.",
             "colours": [
@@ -7888,7 +7888,7 @@
         },
         {
             "id": "52937d0e-6bed-5f57-a045-74956142a6be",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1",
             "name": "Hinterland Logger // Timber Shredder",
             "text": "Trample\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Timber Shredder.",
             "colours": [
@@ -7922,7 +7922,7 @@
         },
         {
             "id": "c621867d-24b5-5858-b629-2a617c6f1077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0063470-3728-4d7e-8f77-5e9c9c7d6a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0063470-3728-4d7e-8f77-5e9c9c7d6a6a.jpg?1",
             "name": "Howlpack Resurgence",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEach creature you control that's a Wolf or a Werewolf gets +1/+1 and has trample.",
             "colours": [
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "006cb9a2-0ee2-5404-b3c9-4a23e200f67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0210ff44-19d9-4d24-9d32-f1f9f219d9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0210ff44-19d9-4d24-9d32-f1f9f219d9e0.jpg?1",
             "name": "Inexorable Blob",
             "text": "Delirium \u2014 Whenever Inexorable Blob attacks, if there are four or more card types among cards in your graveyard, put a 3/3 green Ooze creature token onto the battlefield tapped and attacking.",
             "colours": [
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "80a73a6e-a3ba-5740-ad24-295320742689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ac63b-8386-4175-9555-84c54566f5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ac63b-8386-4175-9555-84c54566f5b4.jpg?1",
             "name": "Intrepid Provisioner",
             "text": "Trample\nWhen Intrepid Provisioner enters the battlefield, another target Human you control gets +2/+2 until end of turn.",
             "colours": [
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "15f7e245-1355-5116-a2e6-c60fda16a074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ac46-dac9-46e6-9c7f-a69caaee1a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ac46-dac9-46e6-9c7f-a69caaee1a2e.jpg?1",
             "name": "Kessig Dire Swine",
             "text": "Delirium \u2014 Kessig Dire Swine has trample as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -8058,7 +8058,7 @@
         },
         {
             "id": "c45e24b8-c1e3-5fa8-b282-df5b290d0d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg?1",
             "name": "Lambholt Pacifist // Lambholt Butcher",
             "text": "Lambholt Pacifist can't attack unless you control a creature with power 4 or greater.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Lambholt Pacifist.",
             "colours": [
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "b31f2f7d-1d86-551a-b76c-d9799c487767",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg?1",
             "name": "Lambholt Pacifist // Lambholt Butcher",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Lambholt Butcher.",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "a053cca1-be2d-5b6f-819a-89add5a638e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9441d-18d9-4ec6-859e-e9a7893b54e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9441d-18d9-4ec6-859e-e9a7893b54e3.jpg?1",
             "name": "Loam Dryad",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "dbb6848b-2425-5d52-9b22-5fa86d233c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a274689-82f1-488a-baf8-cd8ef3477b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a274689-82f1-488a-baf8-cd8ef3477b72.jpg?1",
             "name": "Might Beyond Reason",
             "text": "Put two +1/+1 counters on target creature.\nDelirium \u2014 Put three +1/+1 counters on that creature instead if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "3ca21044-1be0-5d86-9ff5-bd84453cac50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76755763-7c02-451f-b799-2106a3a4973b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76755763-7c02-451f-b799-2106a3a4973b.jpg?1",
             "name": "Moldgraf Scavenger",
             "text": "Delirium \u2014 Moldgraf Scavenger gets +3/+0 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "6d975f17-1a20-57ef-adda-c01cc535bc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633603-a80f-448d-98d9-00064d379c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633603-a80f-448d-98d9-00064d379c26.jpg?1",
             "name": "Moonlight Hunt",
             "text": "Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf deals damage equal to its power to that creature.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "cfbb76b6-047b-53de-99ec-5a690a574865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cc3b9d-4b32-4b2e-9027-876210ccf18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cc3b9d-4b32-4b2e-9027-876210ccf18e.jpg?1",
             "name": "Obsessive Skinner",
             "text": "When Obsessive Skinner enters the battlefield, put a +1/+1 counter on target creature.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8296,7 +8296,7 @@
         },
         {
             "id": "389cb7e6-6824-5530-b729-a26c957aa814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dcc129-88c2-4f20-be0b-36c4141688c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dcc129-88c2-4f20-be0b-36c4141688c9.jpg?1",
             "name": "Pack Guardian",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Pack Guardian enters the battlefield, you may discard a land card. If you do, put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "61c89c82-6709-5655-a31d-426f60cfddcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1569b5-94ef-4ba5-98c6-f1bd4f73c7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1569b5-94ef-4ba5-98c6-f1bd4f73c7d5.jpg?1",
             "name": "Quilled Wolf",
             "text": "{5}{G}: Quilled Wolf gets +4/+4 until end of turn.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "d591d074-3461-592c-bbc4-1d2317696d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f573622-877b-4d21-adfc-40a32b7c2e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f573622-877b-4d21-adfc-40a32b7c2e6d.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -8397,7 +8397,7 @@
         },
         {
             "id": "35ba4b1a-84eb-5e84-be41-6716e1a8e432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb04258-d6ab-440c-85d2-05a995aeba2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb04258-d6ab-440c-85d2-05a995aeba2c.jpg?1",
             "name": "Root Out",
             "text": "Destroy target artifact or enchantment.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "48d425cf-efc8-54ea-882f-e41c249b2f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg?1",
             "name": "Sage of Ancient Lore // Werewolf of Ancient Hunger",
             "text": "Sage of Ancient Lore's power and toughness are each equal to the number of cards in your hand.\nWhen Sage of Ancient Lore enters the battlefield, draw a card.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Sage of Ancient Lore.",
             "colours": [
@@ -8465,7 +8465,7 @@
         },
         {
             "id": "ce8b1494-ef1d-53fd-afd5-454c4b4d0e03",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg?1",
             "name": "Sage of Ancient Lore // Werewolf of Ancient Hunger",
             "text": "Vigilance, trample\nWerewolf of Ancient Hunger's power and toughness are each equal to the total number of cards in all players' hands.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Werewolf of Ancient Hunger.",
             "colours": [
@@ -8499,7 +8499,7 @@
         },
         {
             "id": "8bdef707-c13e-521b-b375-c629abb44648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668afd78-3cf5-4daf-8dfb-fca90de0ae5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668afd78-3cf5-4daf-8dfb-fca90de0ae5a.jpg?1",
             "name": "Seasons Past",
             "text": "Return any number of cards with different converted mana costs from your graveyard to your hand. Put Seasons Past on the bottom of its owner's library.",
             "colours": [
@@ -8531,7 +8531,7 @@
         },
         {
             "id": "ab9a870e-2ad7-5c6b-a6b1-107679cc83c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0c5127-cd17-4859-8de8-165c4c748e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0c5127-cd17-4859-8de8-165c4c748e89.jpg?1",
             "name": "Second Harvest",
             "text": "For each token you control, put a token onto the battlefield that's a copy of that permanent.",
             "colours": [
@@ -8563,7 +8563,7 @@
         },
         {
             "id": "479a242e-8398-5e5b-b714-4a9ff3fb62a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20f5392-5cde-4326-a322-7463ec4b0515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20f5392-5cde-4326-a322-7463ec4b0515.jpg?1",
             "name": "Silverfur Partisan",
             "text": "Trample\nWhenever a Wolf or Werewolf you control becomes the target of an instant or sorcery spell, put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "eb31a539-c7ca-5b9d-9d8a-bacbd64a8e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg?1",
             "name": "Solitary Hunter // One of the Pack",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Solitary Hunter.",
             "colours": [
@@ -8634,7 +8634,7 @@
         },
         {
             "id": "ea346e0a-ec77-5ede-8b16-f66290dc7368",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg?1",
             "name": "Solitary Hunter // One of the Pack",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform One of the Pack.",
             "colours": [
@@ -8668,7 +8668,7 @@
         },
         {
             "id": "16f07200-e737-5e91-b0c5-9a7f2046af1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fbc045-2c86-4816-8622-db56929ae94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fbc045-2c86-4816-8622-db56929ae94d.jpg?1",
             "name": "Soul Swallower",
             "text": "Trample\nDelirium \u2014 At the beginning of your upkeep, if there are four or more card types among cards in your graveyard, put three +1/+1 counters on Soul Swallower.",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "b6687728-4ee3-598d-8f10-fbf75a71fddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0820f17c-ab4a-4a14-84ff-4ea200bef112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0820f17c-ab4a-4a14-84ff-4ea200bef112.jpg?1",
             "name": "Stoic Builder",
             "text": "When Stoic Builder enters the battlefield, you may return target land card from your graveyard to your hand.",
             "colours": [
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "e8f84e42-0eed-56ad-ae10-db91caea22ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c699b5f-a2de-4c87-a7bc-16be4bc0a8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c699b5f-a2de-4c87-a7bc-16be4bc0a8cd.jpg?1",
             "name": "Thornhide Wolves",
             "text": "",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "93cfae75-d5de-5034-a75c-9de8a8522d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e9928-d9b2-4570-adb8-44b34115decd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e9928-d9b2-4570-adb8-44b34115decd.jpg?1",
             "name": "Tireless Tracker",
             "text": "Whenever a land enters the battlefield under your control, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "fc0f0b4e-f99b-581d-83a6-edc55d62ad95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc69a17-db08-4b4a-bc37-98a12ea108dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc69a17-db08-4b4a-bc37-98a12ea108dc.jpg?1",
             "name": "Traverse the Ulvenwald",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead search your library for a creature or land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -8837,7 +8837,7 @@
         },
         {
             "id": "7152ff2e-426c-574b-8d4b-226671677c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5d48df-7d21-462c-b721-b769a785bb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5d48df-7d21-462c-b721-b769a785bb00.jpg?1",
             "name": "Ulvenwald Hydra",
             "text": "Reach\nUlvenwald Hydra's power and toughness are each equal to the number of lands you control.\nWhen Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "92634ebf-3e7f-56f7-942b-2912b497dad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911a2b5d-7e2d-4358-8e38-cbae7192e4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911a2b5d-7e2d-4358-8e38-cbae7192e4d4.jpg?1",
             "name": "Ulvenwald Mysteries",
             "text": "Whenever a nontoken creature you control dies, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "e533f3e4-a9ee-596f-8efa-44345b77a1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89533790-38c2-4b53-90fa-8abf8c1a6abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89533790-38c2-4b53-90fa-8abf8c1a6abb.jpg?1",
             "name": "Vessel of Nascency",
             "text": "{1}{G}, Sacrifice Vessel of Nascency: Reveal the top four cards of your library. You may put an artifact, creature, enchantment, land, or planeswalker card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -8935,7 +8935,7 @@
         },
         {
             "id": "845d2d29-60ce-5755-9543-d73dabb471bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a471e83e-c0e0-4af6-bfcf-7f4a39f6fccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a471e83e-c0e0-4af6-bfcf-7f4a39f6fccf.jpg?1",
             "name": "Veteran Cathar",
             "text": "{3}{W}: Target Human gains double strike until end of turn.",
             "colours": [
@@ -8971,7 +8971,7 @@
         },
         {
             "id": "dbd54a82-c4a6-5007-ac40-cb722bce03b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1ee2d4-5992-4081-9907-4bc26750aff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1ee2d4-5992-4081-9907-4bc26750aff0.jpg?1",
             "name": "Watcher in the Web",
             "text": "Reach (This creature can block creatures with flying.)\nWatcher in the Web can block an additional seven creatures each combat.",
             "colours": [
@@ -9005,7 +9005,7 @@
         },
         {
             "id": "0ef495aa-3817-5e3c-a63a-c3c7439575da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8033b16-7a48-4455-9b1b-f62ceb7b9b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8033b16-7a48-4455-9b1b-f62ceb7b9b61.jpg?1",
             "name": "Weirding Wood",
             "text": "Enchant land\nWhen Weirding Wood enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "3d725f1e-83c4-5b27-9f7c-f3a88b56b365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05da08d-8fac-47bc-80d8-78a80d1463d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05da08d-8fac-47bc-80d8-78a80d1463d2.jpg?1",
             "name": "Altered Ego",
             "text": "Altered Ego can't be countered.\nYou may have Altered Ego enter the battlefield as a copy of any creature on the battlefield, except it enters with X additional +1/+1 counters on it.",
             "colours": [
@@ -9075,7 +9075,7 @@
         },
         {
             "id": "fff27b15-ccc8-555f-a0df-a26e3bc1a3d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ced4fa-6509-4f7a-9da7-efc70de6f90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ced4fa-6509-4f7a-9da7-efc70de6f90c.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "b7c09e3f-f692-5ed0-8919-6a2875c4ab29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1",
             "name": "Arlinn Kord // Arlinn, Embraced by the Moon",
             "text": "+1: Until end of turn, up to one target creature gets +2/+2 and gains vigilance and haste.\n0: Put a 2/2 green Wolf creature token onto the battlefield. Transform Arlinn Kord.",
             "colours": [
@@ -9147,7 +9147,7 @@
         },
         {
             "id": "a815a066-80c8-5913-b94a-866c8af561df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1",
             "name": "Arlinn Kord // Arlinn, Embraced by the Moon",
             "text": "+1: Creatures you control get +1/+1 and gain trample until end of turn.\n\u22121: Arlinn, Embraced by the Moon deals 3 damage to target creature or player. Transform Arlinn, Embraced by the Moon.\n\u22126: You get an emblem with \"Creatures you control have haste and \u2018{T}: This creature deals damage equal to its power to target creature or player.'\"",
             "colours": [
@@ -9185,7 +9185,7 @@
         },
         {
             "id": "0add6147-a0ca-5ea2-81dc-906ebabe3717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3fc2b-c2e4-421d-ac1d-6a111bb44f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3fc2b-c2e4-421d-ac1d-6a111bb44f44.jpg?1",
             "name": "Fevered Visions",
             "text": "At the beginning of each player's end step, that player draws a card. If the player is your opponent and has four or more cards in hand, Fevered Visions deals 2 damage to him or her.",
             "colours": [
@@ -9219,7 +9219,7 @@
         },
         {
             "id": "02b2a314-ab60-5dbe-ba6d-1a7959d2ea8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790dd89-2be5-4a77-9450-2d3c1422bfc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790dd89-2be5-4a77-9450-2d3c1422bfc9.jpg?1",
             "name": "The Gitrog Monster",
             "text": "Deathtouch\nAt the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land.\nYou may play an additional land on each of your turns.\nWhenever one or more land cards are put into your graveyard from anywhere, draw a card.",
             "colours": [
@@ -9258,7 +9258,7 @@
         },
         {
             "id": "40f7cc69-aa01-58a0-ba44-638313da5c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64077da-9e55-4ced-91f7-db478383172f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64077da-9e55-4ced-91f7-db478383172f.jpg?1",
             "name": "Invocation of Saint Traft",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, put a 4/4 white Angel creature token with flying onto the battlefield tapped and attacking. Exile that token at end of combat.\"",
             "colours": [
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "eb5412a6-f19e-5d32-867f-ec08447f21d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d70487-21d1-4897-ac20-2a996e893b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d70487-21d1-4897-ac20-2a996e893b5b.jpg?1",
             "name": "Nahiri, the Harbinger",
             "text": "+2: You may discard a card. If you do, draw a card.\n\u22122: Exile target enchantment, tapped artifact, or tapped creature.\n\u22128: Search your library for an artifact or creature card, put it onto the battlefield, then shuffle your library. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -9332,7 +9332,7 @@
         },
         {
             "id": "1564f560-914a-593a-8b20-203c71e3204b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7297dd81-8367-42e9-abf9-9227e202e7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7297dd81-8367-42e9-abf9-9227e202e7ae.jpg?1",
             "name": "Olivia, Mobilized for War",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may discard a card. If you do, put a +1/+1 counter on that creature, it gains haste until end of turn, and it becomes a Vampire in addition to its other types.",
             "colours": [
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "b4bd7b86-501d-5123-af62-dc38c18483ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634cedb6-8b00-4f4b-8790-541188955295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634cedb6-8b00-4f4b-8790-541188955295.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -9407,7 +9407,7 @@
         },
         {
             "id": "c097973c-1a55-524f-8b33-f478b45b46cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db953cb9-52b4-4bf0-86ab-2c3af2faeccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db953cb9-52b4-4bf0-86ab-2c3af2faeccf.jpg?1",
             "name": "Sigarda, Heron's Grace",
             "text": "Flying\nYou and Humans you control have hexproof.\n{2}, Exile a card from your graveyard: Put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -9445,7 +9445,7 @@
         },
         {
             "id": "d85b64b7-a42f-54ad-89c4-672673a07fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2933144-c931-498a-9e91-f5165873c3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2933144-c931-498a-9e91-f5165873c3b7.jpg?1",
             "name": "Sorin, Grim Nemesis",
             "text": "+1: Reveal the top card of your library and put that card into your hand. Each opponent loses life equal to its converted mana cost.\n\u2212X: Sorin, Grim Nemesis deals X damage to target creature or planeswalker and you gain X life.\n\u22129: Put a number of 1/1 black Vampire Knight creature tokens with lifelink onto the battlefield equal to the highest life total among all players.",
             "colours": [
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "17c985ef-c8f6-57a3-b8b7-1d023f4568bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ecfcbe-e8db-4f08-aa8b-5b7b3e6c6ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ecfcbe-e8db-4f08-aa8b-5b7b3e6c6ce7.jpg?1",
             "name": "Brain in a Jar",
             "text": "{1}, {T}: Put a charge counter on Brain in a Jar, then you may cast an instant or sorcery card with converted mana cost equal to the number of charge counters on Brain in a Jar from your hand without paying its mana cost.\n{3}, {T}, Remove X charge counters from Brain in a Jar: Scry X.",
             "colours": [],
@@ -9511,7 +9511,7 @@
         },
         {
             "id": "bb080b08-2fba-5a62-961d-5c48bab9319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa34cc-4042-4d2b-a7a0-eca0b593eeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa34cc-4042-4d2b-a7a0-eca0b593eeb6.jpg?1",
             "name": "Corrupted Grafstone",
             "text": "Corrupted Grafstone enters the battlefield tapped.\n{T}: Choose a color of a card in your graveyard. Add one mana of that color to your mana pool.",
             "colours": [],
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "17fd87b4-740f-5e94-833a-92faea179e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937aaed7-d9ad-45e0-915c-df61316c606a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937aaed7-d9ad-45e0-915c-df61316c606a.jpg?1",
             "name": "Epitaph Golem",
             "text": "{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "ad3c8a84-68ac-5e51-9d04-af899f656cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7329a19-2f68-4d2c-a725-e0d862cd234e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7329a19-2f68-4d2c-a725-e0d862cd234e.jpg?1",
             "name": "Explosive Apparatus",
             "text": "{3}, {T}, Sacrifice Explosive Apparatus: Explosive Apparatus deals 2 damage to target creature or player.",
             "colours": [],
@@ -9598,7 +9598,7 @@
         },
         {
             "id": "1e379538-8581-5690-80a1-4ecf8b30946c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1",
             "name": "Harvest Hand // Scrounged Scythe",
             "text": "When Harvest Hand dies, return it to the battlefield transformed under your control.",
             "colours": [],
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "1456b0c6-e03f-56df-b2b9-6779204ac011",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1",
             "name": "Harvest Hand // Scrounged Scythe",
             "text": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human, it has menace. (It can't be blocked except by two or more creatures.)\nEquip {2}",
             "colours": [],
@@ -9659,7 +9659,7 @@
         },
         {
             "id": "d64b7bf3-71cc-5231-b52a-341fef981a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef142a2a-08e8-4344-8626-239690b3bb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef142a2a-08e8-4344-8626-239690b3bb87.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1}",
             "colours": [],
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "9c16027b-fb51-58ca-9e04-6aeaaa88c5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a708d5-f757-4fcf-a167-5b5920c6adeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a708d5-f757-4fcf-a167-5b5920c6adeb.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -9717,7 +9717,7 @@
         },
         {
             "id": "bf3b86e4-0f2e-5acb-9ea4-bc95c113cf54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696dcb79-4915-424f-ba8f-5363ae3395a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696dcb79-4915-424f-ba8f-5363ae3395a6.jpg?1",
             "name": "Murderer's Axe",
             "text": "Equipped creature gets +2/+2.\nEquip\u2014\nDiscard a card.",
             "colours": [],
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "ca9311b9-9acd-5d99-b43f-b022d37880de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1",
             "name": "Neglected Heirloom // Ashmouth Blade",
             "text": "Equipped creature gets +1/+1.\nWhen equipped creature transforms, transform Neglected Heirloom.\nEquip {1}",
             "colours": [],
@@ -9777,7 +9777,7 @@
         },
         {
             "id": "66d7d0d7-56dc-50ed-8a44-81620036b310",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1",
             "name": "Neglected Heirloom // Ashmouth Blade",
             "text": "Equipped creature gets +3/+3 and has first strike.\nEquip {3}",
             "colours": [],
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "66ac6636-bec9-5a1a-b1c1-c04591b0ea96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8ce5d3-0184-4cfb-a41d-3d58229b2a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8ce5d3-0184-4cfb-a41d-3d58229b2a5f.jpg?1",
             "name": "Runaway Carriage",
             "text": "Trample\nWhen Runaway Carriage attacks or blocks, sacrifice it at end of combat.",
             "colours": [],
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "7a95c41e-3eff-5ac3-8af6-d6119bd9d177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4924d7-f787-474b-beca-3b369903485c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4924d7-f787-474b-beca-3b369903485c.jpg?1",
             "name": "Shard of Broken Glass",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature attacks, you may put the top two cards of your library into your graveyard.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9868,7 +9868,7 @@
         },
         {
             "id": "a9b12123-56e4-5b69-a439-562b20b2b437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3168317b-b166-483e-9d9a-20cdfcdc255c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3168317b-b166-483e-9d9a-20cdfcdc255c.jpg?1",
             "name": "Skeleton Key",
             "text": "Equipped creature has skulk. (It can't be blocked by creatures with greater power.)\nWhenever equipped creature deals combat damage to a player, you may draw a card. If you do, discard a card.\nEquip {2}",
             "colours": [],
@@ -9898,7 +9898,7 @@
         },
         {
             "id": "ab6150a0-ff33-551f-91f5-e4f5dd458572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0810651-0301-46d4-b9d7-c2283ef4031a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0810651-0301-46d4-b9d7-c2283ef4031a.jpg?1",
             "name": "Slayer's Plate",
             "text": "Equipped creature gets +4/+2.\nWhenever equipped creature dies, if it was a Human, put a 1/1 white Spirit creature token with flying onto the battlefield.\nEquip {3}",
             "colours": [],
@@ -9928,7 +9928,7 @@
         },
         {
             "id": "b33e380c-0615-5559-93da-2ba3610d2b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b474378c-5fa8-418f-8d76-23e78003ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b474378c-5fa8-418f-8d76-23e78003ed18.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "At the beginning of your upkeep, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\n{T}, Sacrifice three Clues: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -9963,7 +9963,7 @@
         },
         {
             "id": "9b53ce45-735c-5247-b744-9fcac2dbdc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45242fd6-6e36-468c-b9ef-140fc969d343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45242fd6-6e36-468c-b9ef-140fc969d343.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -9998,7 +9998,7 @@
         },
         {
             "id": "eb08862e-454a-510e-90f4-04e5adc335d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae5c06-b8da-4f74-9ee6-dbcba6d638ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae5c06-b8da-4f74-9ee6-dbcba6d638ad.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "7f10a3cb-8209-5273-bcfc-e5698aaaf5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f4323-525f-440f-b7bd-3363f2180971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f4323-525f-440f-b7bd-3363f2180971.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "c7843559-f071-5c8b-8384-8cc79b12be2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240c4920-09a8-452a-8fa3-784f3d00d434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240c4920-09a8-452a-8fa3-784f3d00d434.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10103,7 +10103,7 @@
         },
         {
             "id": "bbb7dc42-0a75-5c32-b54d-a876a0b7ea14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f732c92e-8e0a-4c77-a3c0-d9b9384e363f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f732c92e-8e0a-4c77-a3c0-d9b9384e363f.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "31e4954a-d167-57d2-9b5f-945798f7d855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg?1",
             "name": "Thraben Gargoyle // Stonewing Antagonizer",
             "text": "Defender\n{6}: Transform Thraben Gargoyle.",
             "colours": [],
@@ -10169,7 +10169,7 @@
         },
         {
             "id": "152a156b-d1b9-544e-913b-aba5ada950d4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg?1",
             "name": "Thraben Gargoyle // Stonewing Antagonizer",
             "text": "Flying",
             "colours": [],
@@ -10201,7 +10201,7 @@
         },
         {
             "id": "2294dd22-1783-525b-9aa1-574119828581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815eb91c-06fa-4362-803e-e9bf7d374856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815eb91c-06fa-4362-803e-e9bf7d374856.jpg?1",
             "name": "True-Faith Censer",
             "text": "Equipped creature gets +1/+1 and has vigilance.\nAs long as equipped creature is a Human, it gets an additional +1/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10231,7 +10231,7 @@
         },
         {
             "id": "08e0baa8-fe4a-5515-88dc-7040178a3300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae115587-012d-40ff-a20d-270fabf2f8c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae115587-012d-40ff-a20d-270fabf2f8c6.jpg?1",
             "name": "Wicker Witch",
             "text": "",
             "colours": [],
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "cd953f3f-1659-5067-b5e7-291bd90f19da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285b444-1668-4a3d-9fcd-8ce4e95c6d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285b444-1668-4a3d-9fcd-8ce4e95c6d2f.jpg?1",
             "name": "Wild-Field Scarecrow",
             "text": "Defender\n{2}, Sacrifice Wild-Field Scarecrow: Search your library for up to two basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [],
@@ -10293,7 +10293,7 @@
         },
         {
             "id": "2e92670c-400b-52fd-99fa-ca04865e6dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995d44ca-626d-4c95-97af-ee53fa8baaf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995d44ca-626d-4c95-97af-ee53fa8baaf0.jpg?1",
             "name": "Choked Estuary",
             "text": "As Choked Estuary enters the battlefield, you may reveal an Island or Swamp card from your hand. If you don't, Choked Estuary enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "5db6ba4e-8d09-5c72-b6c7-92bf2b2e07fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb5657-18a1-455c-a87a-4e67971184ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb5657-18a1-455c-a87a-4e67971184ac.jpg?1",
             "name": "Drownyard Temple",
             "text": "{T}: Add {C} to your mana pool.\n{3}: Return Drownyard Temple from your graveyard to the battlefield tapped.",
             "colours": [],
@@ -10352,7 +10352,7 @@
         },
         {
             "id": "89203438-f2b3-5f00-9580-c71847006ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26ee31-7e2a-4eed-b448-04989fb57523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26ee31-7e2a-4eed-b448-04989fb57523.jpg?1",
             "name": "Foreboding Ruins",
             "text": "As Foreboding Ruins enters the battlefield, you may reveal a Swamp or Mountain card from your hand. If you don't, Foreboding Ruins enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -10383,7 +10383,7 @@
         },
         {
             "id": "8030adc4-cd4b-520f-8cd8-f63fa2324ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd86cac-08c1-4db0-ab54-4bb65a771efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd86cac-08c1-4db0-ab54-4bb65a771efe.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "6a7c91e3-f11b-5647-ad51-44fb5434963a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb9dc1-671d-43ad-ae22-ed1a9916b140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb9dc1-671d-43ad-ae22-ed1a9916b140.jpg?1",
             "name": "Fortified Village",
             "text": "As Fortified Village enters the battlefield, you may reveal a Forest or Plains card from your hand. If you don't, Fortified Village enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -10445,7 +10445,7 @@
         },
         {
             "id": "f70dd634-c7be-5ed1-8fdf-559c2f0f440a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2378ac21-9912-40d7-972d-b1b71a8e4984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2378ac21-9912-40d7-972d-b1b71a8e4984.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -10476,7 +10476,7 @@
         },
         {
             "id": "0ec60fc3-dd1d-5b44-b3c6-9227c83ab72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb5950-adaa-438d-998b-3a64bd4a2b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb5950-adaa-438d-998b-3a64bd4a2b3e.jpg?1",
             "name": "Game Trail",
             "text": "As Game Trail enters the battlefield, you may reveal a Mountain or Forest card from your hand. If you don't, Game Trail enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -10507,7 +10507,7 @@
         },
         {
             "id": "be7ca0a0-bbff-5bd4-b617-76431991952d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b97a23-c4cf-47c9-9dbf-34215ea0e908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b97a23-c4cf-47c9-9dbf-34215ea0e908.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -10538,7 +10538,7 @@
         },
         {
             "id": "085583ad-b39d-5cfe-88cf-3cf5fc74120c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866712a-c3ef-4a43-ac0f-146c7836f0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866712a-c3ef-4a43-ac0f-146c7836f0d6.jpg?1",
             "name": "Port Town",
             "text": "As Port Town enters the battlefield, you may reveal a Plains or Island card from your hand. If you don't, Port Town enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -10569,7 +10569,7 @@
         },
         {
             "id": "71ff8941-eebb-5007-8606-be992b364744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e636cdc3-4b83-4f15-ad4a-6c8fa3533408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e636cdc3-4b83-4f15-ad4a-6c8fa3533408.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -10600,7 +10600,7 @@
         },
         {
             "id": "9dc466a0-6900-5b10-90ae-edd8f11897f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16793435-8eb3-4d57-8683-de1120eb46b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16793435-8eb3-4d57-8683-de1120eb46b6.jpg?1",
             "name": "Warped Landscape",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Warped Landscape: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "85a80a8d-8f95-5b94-a56d-42e6a83674f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "{T}: Add {C} to your mana pool.\n{5}, {T}, Pay 1 life: Put a 1/1 white and black Human Cleric creature token onto the battlefield.\n{5}, {T}, Sacrifice five creatures: Transform Westvale Abbey, then untap it.",
             "colours": [],
@@ -10658,7 +10658,7 @@
         },
         {
             "id": "18539842-2be6-5a9f-ae62-d12f943c870e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "Flying, lifelink, indestructible, haste",
             "colours": [
@@ -10694,7 +10694,7 @@
         },
         {
             "id": "9217a89a-f00a-5e5f-a1df-0e2dabb6ca87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a0c745-dee6-4cb2-acaa-3d2b8e0cce5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a0c745-dee6-4cb2-acaa-3d2b8e0cce5b.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "b49d1212-c06d-5ca1-8ba1-e9921fb7ebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbcfb7-cfbc-4752-9b6c-ffbd5d3dd678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbcfb7-cfbc-4752-9b6c-ffbd5d3dd678.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10762,7 +10762,7 @@
         },
         {
             "id": "fb30c1ba-67e0-5429-9fb5-2900f7261538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6401c6e7-3415-4e68-b40c-9777c33785eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6401c6e7-3415-4e68-b40c-9777c33785eb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10799,7 +10799,7 @@
         },
         {
             "id": "04f32645-75cd-5405-9def-ed1b6f1bf697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcab7eaa-5e16-40b5-992b-9cc51a95376b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcab7eaa-5e16-40b5-992b-9cc51a95376b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10836,7 +10836,7 @@
         },
         {
             "id": "a609b537-3df7-5a2e-a535-bdde0dedd819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffca348-2af9-44bb-815f-f7f7240ac975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffca348-2af9-44bb-815f-f7f7240ac975.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "5fb307a7-f155-566e-a007-b7cb7fd908dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74e713-11f7-4341-9b22-5300a4587a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74e713-11f7-4341-9b22-5300a4587a51.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10910,7 +10910,7 @@
         },
         {
             "id": "a57d3a91-a4cc-5f2e-b160-8da22f895e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e4610-9bdc-4ee2-8aac-26cbdee13046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e4610-9bdc-4ee2-8aac-26cbdee13046.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "2ac08ec2-b146-5870-a074-b445cff191bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f62f5c-ddea-4564-bc47-5845ab15d8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f62f5c-ddea-4564-bc47-5845ab15d8e2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10984,7 +10984,7 @@
         },
         {
             "id": "9b527ba1-cb13-5cbe-8bde-5701f74af4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fae7689-a9df-4f69-8040-9fbe24f64838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fae7689-a9df-4f69-8040-9fbe24f64838.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11021,7 +11021,7 @@
         },
         {
             "id": "343ac1d0-30f8-57d9-be6f-a1dafbbaabf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87861e3c-d445-4452-b7e0-19b53e69b6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87861e3c-d445-4452-b7e0-19b53e69b6e3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "cda553ec-aa69-58a0-875a-77255a1baee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7878436-bf83-45c6-a040-e2fad447862a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7878436-bf83-45c6-a040-e2fad447862a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11095,7 +11095,7 @@
         },
         {
             "id": "5f61e14b-4a0e-56fe-94c8-303097f236a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55384ef-6e5e-4e0b-8156-edad0fc9b25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55384ef-6e5e-4e0b-8156-edad0fc9b25b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "e9ffdd5d-bf6d-5932-9eaa-9f5bee9e0b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37dc16e-3631-46df-acc4-19040fb8a86e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37dc16e-3631-46df-acc4-19040fb8a86e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11169,7 +11169,7 @@
         },
         {
             "id": "1e071913-2122-5572-9acc-1e44287a3013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42efdb6a-1c54-497a-9058-af4256241649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42efdb6a-1c54-497a-9058-af4256241649.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11206,7 +11206,7 @@
         },
         {
             "id": "6487f87a-627b-5fa6-a778-b0878859ecdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8c30af-055a-4921-99a8-f99c472c7315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8c30af-055a-4921-99a8-f99c472c7315.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11243,7 +11243,7 @@
         },
         {
             "id": "0e5a6ea7-57a7-5d69-8f74-4287e8fea227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1ebe0b-995f-4239-aad3-bfe471a88b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1ebe0b-995f-4239-aad3-bfe471a88b6e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11280,7 +11280,7 @@
         },
         {
             "id": "4ac5ff5a-42f4-59d9-8376-23d977f8ca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb975fe-ac30-4249-bb55-7efb64645e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb975fe-ac30-4249-bb55-7efb64645e4d.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -11314,7 +11314,7 @@
         },
         {
             "id": "42280d88-63a2-5a69-93d9-76e021eae52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d323ead-24f5-42e4-9e23-aa14eb66264d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d323ead-24f5-42e4-9e23-aa14eb66264d.jpg?1",
             "name": "Shadows Over Innistrad Checklist 1",
             "text": "",
             "colours": [],
@@ -11341,7 +11341,7 @@
         },
         {
             "id": "e8584f9e-1a99-55f8-af35-5f3b831aeb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -11376,7 +11376,7 @@
         },
         {
             "id": "5b12b49c-65a3-5545-b9b1-d31786f4ba27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4825c59d-9e27-4a12-ba84-642b8540e573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4825c59d-9e27-4a12-ba84-642b8540e573.jpg?1",
             "name": "Shadows Over Innistrad Checklist 2",
             "text": "",
             "colours": [],
@@ -11403,7 +11403,7 @@
         },
         {
             "id": "f9d674a3-6c0b-5949-b09b-9bc93cd11a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53a7c6-6b32-4491-8c96-e564abea8880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53a7c6-6b32-4491-8c96-e564abea8880.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -11437,7 +11437,7 @@
         },
         {
             "id": "5a28cd23-684e-554a-87dd-710c22b6f805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8989fdb4-723b-4c80-89b4-930ccac13b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8989fdb4-723b-4c80-89b4-930ccac13b22.jpg?1",
             "name": "Vampire Knight",
             "text": "",
             "colours": [
@@ -11472,7 +11472,7 @@
         },
         {
             "id": "7fe203e8-ade2-52ac-9171-1f08d59f5898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a12a72-5cd9-4f1b-997d-7dabb65e9f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a12a72-5cd9-4f1b-997d-7dabb65e9f51.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -11506,7 +11506,7 @@
         },
         {
             "id": "41c442fc-576c-5b46-8bd3-e344e40baf88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e78c4b8-371b-43d7-a315-fb299704aa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e78c4b8-371b-43d7-a315-fb299704aa60.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -11540,7 +11540,7 @@
         },
         {
             "id": "f8568c16-1f85-5473-a15c-997951b1e9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057f94e-c2be-44e1-a93b-e31432f4ffa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057f94e-c2be-44e1-a93b-e31432f4ffa5.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "f54e4a20-d38c-5779-84b9-61f23b630b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a7905-3a10-4d23-96fa-4960cac8f4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a7905-3a10-4d23-96fa-4960cac8f4e3.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -11608,7 +11608,7 @@
         },
         {
             "id": "675657d3-e2cb-5145-b0fc-f9ba1f1f3951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5ac360-dc47-4bc5-a4cc-ff223abc3ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5ac360-dc47-4bc5-a4cc-ff223abc3ffc.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -11642,7 +11642,7 @@
         },
         {
             "id": "e1520eed-5f7f-5d76-8dd8-121276dae02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg?1",
             "name": "Human Cleric",
             "text": "",
             "colours": [
@@ -11679,7 +11679,7 @@
         },
         {
             "id": "8dd78d67-3a54-53ed-8da6-636e03f78a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c859e1-181e-44d1-afbd-bbd6e52cf42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c859e1-181e-44d1-afbd-bbd6e52cf42a.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "0b6f24fb-d1ec-517e-82fa-d55a3b1914f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1241c3-d960-4eb4-a726-ca474209645b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1241c3-d960-4eb4-a726-ca474209645b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11739,7 +11739,7 @@
         },
         {
             "id": "a13cc16f-ab6b-5ae8-80fd-5c28416cf9c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271afa7e-2126-4497-b871-9795b7355d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271afa7e-2126-4497-b871-9795b7355d69.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11769,7 +11769,7 @@
         },
         {
             "id": "c3dec01c-0e74-565d-a796-093fb902f936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291e6490-6727-45ae-90ba-de2ff8f63162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291e6490-6727-45ae-90ba-de2ff8f63162.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11799,7 +11799,7 @@
         },
         {
             "id": "cb8cfcde-9131-53c9-9523-5fbe4352dc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d16818-7812-4d36-b1bf-fb954e5ac958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d16818-7812-4d36-b1bf-fb954e5ac958.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11829,7 +11829,7 @@
         },
         {
             "id": "927a866b-95f0-5216-b876-88d4ba2651c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66ec9c-7e5d-47ca-bce4-46798152d1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66ec9c-7e5d-47ca-bce4-46798152d1f4.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "65cfc4bf-c7d7-5b2a-9d30-ab1b7c2b94dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa30438-3733-467e-aa31-f8e8ad2e62f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa30438-3733-467e-aa31-f8e8ad2e62f3.jpg?1",
             "name": "Jace, Unraveler of Secrets Emblem",
             "text": "",
             "colours": [],
@@ -11888,7 +11888,7 @@
         },
         {
             "id": "70572701-f73b-5376-a090-d772fcbad46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0686c3-a44a-449d-ab12-eeb9c0c25489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0686c3-a44a-449d-ab12-eeb9c0c25489.jpg?1",
             "name": "Arlinn Kord Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/SOK.json
+++ b/Assets/Resources/Sets/SOK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fcbbd230-a29b-5dbb-9933-4b08a519c239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214d2e9-5aa1-42a7-8f1a-f4eaa2def1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214d2e9-5aa1-42a7-8f1a-f4eaa2def1b1.jpg?1",
             "name": "Aether Shockwave",
             "text": "Choose one Tap all Spirits; or tap all non-Spirit creatures.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "46a0bace-3832-5571-9798-ade7bfb9d66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e4a170-1075-47e4-abe6-996b161573c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e4a170-1075-47e4-abe6-996b161573c1.jpg?1",
             "name": "Araba Mothrider",
             "text": "Flying\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "b11cd2ab-acc0-58ae-b8e6-a1e6ca8726af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003e99a0-2caa-407b-be40-92ec17836eb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003e99a0-2caa-407b-be40-92ec17836eb3.jpg?1",
             "name": "Celestial Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, destroy all permanents with that spell's converted mana cost.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "7036978e-263f-5cee-ae19-5831d3d41dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e0bd8-d80f-4cda-b381-ed185072d83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e0bd8-d80f-4cda-b381-ed185072d83c.jpg?1",
             "name": "Charge Across the Araba",
             "text": "Sweep Return any number of Plains you control to their owner's hand. Creatures you control get +1/+1 until end of turn for each Plains returned this way.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "b2e7ab3a-6139-5f40-9ec4-2aa261f5a8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81b329-4ef5-4b55-9fe7-9ed69477e96b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81b329-4ef5-4b55-9fe7-9ed69477e96b.jpg?1",
             "name": "Cowed by Wisdom",
             "text": "Enchanted creature can't attack or block unless its controller pays {1} for each card in your hand. (This cost is paid as attackers or blockers are declared.)",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "6d5a2e3a-de21-5c61-8529-2521d5545fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc382831-e338-49bd-a37f-931bf611b165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc382831-e338-49bd-a37f-931bf611b165.jpg?1",
             "name": "Curtain of Light",
             "text": "Target attacking unblocked creature becomes blocked.\nDraw a card.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "18873a49-2749-5bca-bfdc-bd1f33b935cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354af7fc-fd15-4209-b3e8-8729a401b6a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354af7fc-fd15-4209-b3e8-8729a401b6a6.jpg?1",
             "name": "Descendant of Kiyomaro",
             "text": "As long as you have more cards in hand than each opponent, Descendant of Kiyomaro gets +1/+2 and has \"Whenever this creature deals combat damage, you gain 3 life.\"",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "05bcfc47-671c-549b-888a-0696b1f9173e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe47bbc5-6f7f-4135-9e83-9e2a428c97f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe47bbc5-6f7f-4135-9e83-9e2a428c97f5.jpg?1",
             "name": "Eiganjo Free-Riders",
             "text": "Flying\nAt the beginning of your upkeep, return a white creature you control to its owner's hand.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "bc15b328-bfa6-563e-b0e4-dab29e3bdcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc7091e-0c98-434d-9190-dcab813d3e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc7091e-0c98-434d-9190-dcab813d3e14.jpg?1",
             "name": "Enduring Ideal",
             "text": "Search your library for an enchantment card and put it into play. Then shuffle your library.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability.)",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "035aa37c-6226-558a-955c-72c76199d4a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90c02d-3090-402e-b74b-fc0358953263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90c02d-3090-402e-b74b-fc0358953263.jpg?1",
             "name": "Ghost-Lit Redeemer",
             "text": "{W}, {T}: You gain 2 life.\nChannel {1}{W}, Discard Ghost-Lit Redeemer: You gain 4 life.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "7ac76e3c-c875-59f9-99f5-74a5db11e3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a57083-e82c-41aa-94b9-2e6db97f7159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a57083-e82c-41aa-94b9-2e6db97f7159.jpg?1",
             "name": "Hail of Arrows",
             "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "a27a22f3-c2cd-5798-a56e-fd4cfa77124e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddef832c-b2be-4fa6-8d66-ac0d442f2d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddef832c-b2be-4fa6-8d66-ac0d442f2d7d.jpg?1",
             "name": "Hand of Honor",
             "text": "Protection from black\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "3a080cad-2080-59e4-b7bb-50a43bbd5a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d34bfb9-abc7-4469-9546-aa8988da8259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d34bfb9-abc7-4469-9546-aa8988da8259.jpg?1",
             "name": "Inner-Chamber Guard",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "e71b07dc-3fcd-5a80-b65a-4c0b4e37d6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c99ac4-6551-4cc2-9a70-6e66b259b2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c99ac4-6551-4cc2-9a70-6e66b259b2a2.jpg?1",
             "name": "Kataki, War's Wage",
             "text": "All artifacts have \"At the beginning of your upkeep, sacrifice this artifact unless you pay {1}.\"",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "12097065-3f7d-5bea-b4fe-88c4550e43fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94c12e0-8eb1-43f9-a421-43ca9bcffb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94c12e0-8eb1-43f9-a421-43ca9bcffb0e.jpg?1",
             "name": "Kitsune Bonesetter",
             "text": "{T}: Prevent the next 3 damage that would be dealt to target creature this turn. Play this ability only if you have more cards in hand than each opponent.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "a6174963-79d5-57a7-9c52-fc3e3dc6dadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09ab22e-aa22-4d6b-87c6-970563486f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09ab22e-aa22-4d6b-87c6-970563486f21.jpg?1",
             "name": "Kitsune Dawnblade",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhen Kitsune Dawnblade comes into play, you may tap target creature.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "cae74f33-1e2b-54ad-b6c7-144ab3fdbbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11d4490-fe4f-4526-befd-f4c9c22c76a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11d4490-fe4f-4526-befd-f4c9c22c76a6.jpg?1",
             "name": "Kitsune Loreweaver",
             "text": "{1}{W}: Kitsune Loreweaver gets +0/+X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "3c24604a-56bb-51f8-9104-523ed866236c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3351bb-5c4e-498b-b6c9-94f571baffd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3351bb-5c4e-498b-b6c9-94f571baffd5.jpg?1",
             "name": "Kiyomaro, First to Stand",
             "text": "Kiyomaro, First to Stand's power and toughness are each equal to the number of cards in your hand.\nAs long as you have four or more cards in hand, Kiyomaro has vigilance.\nWhenever Kiyomaro deals damage, if you have seven or more cards in hand, you gain 7 life.",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "bb18300e-03bc-51c9-81c4-594f44865f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c56bf0-ad9f-4419-902c-f3a3880c716c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c56bf0-ad9f-4419-902c-f3a3880c716c.jpg?1",
             "name": "Michiko Konda, Truth Seeker",
             "text": "Whenever a source an opponent controls deals damage to you, that player sacrifices a permanent.",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "edce9684-2d98-5ccc-a847-bc3e0ec561e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f646ed53-c323-4f84-b8c9-39e31da1aca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f646ed53-c323-4f84-b8c9-39e31da1aca8.jpg?1",
             "name": "Moonwing Moth",
             "text": "Flying\n{W}: Moonwing Moth gets +0/+1 until end of turn.",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "0c08a78c-da61-53ce-9477-c6c08d97fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7ecd0c-9cfb-4cf3-be62-d949b58b19a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7ecd0c-9cfb-4cf3-be62-d949b58b19a4.jpg?1",
             "name": "Nikko-Onna",
             "text": "When Nikko-Onna comes into play, destroy target enchantment.\nWhenever you play a Spirit or Arcane spell, you may return Nikko-Onna to its owner's hand.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "a06a05bf-e2ab-5618-89a0-57e4f8289424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e78f75-bf58-4c61-9654-c5d355b5e526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e78f75-bf58-4c61-9654-c5d355b5e526.jpg?1",
             "name": "Plow Through Reito",
             "text": "Sweep Return any number of Plains you control to their owner's hand. Target creature gets +1/+1 until end of turn for each Plains returned this way.",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "2ce031bb-2fd0-56e6-942e-e5dbffe14ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aedb5a-48f5-47db-9469-14075e2b9269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aedb5a-48f5-47db-9469-14075e2b9269.jpg?1",
             "name": "Presence of the Wise",
             "text": "You gain 2 life for each card in your hand.",
             "colours": [
@@ -794,7 +794,7 @@
         },
         {
             "id": "2a3b0b0f-1689-52be-abb1-5e7a6d7d0337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250735d-d43b-488f-bddf-ed10261a6382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250735d-d43b-488f-bddf-ed10261a6382.jpg?1",
             "name": "Promise of Bunrei",
             "text": "Whenever a creature you control is put into a graveyard from play, sacrifice Promise of Bunrei. If you do, put four 1/1 colorless Spirit creature tokens into play.",
             "colours": [
@@ -826,7 +826,7 @@
         },
         {
             "id": "cfc784ff-a519-5729-95be-2e6c1f9ed74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231d818-df57-4e2d-9603-babe0c2c4568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231d818-df57-4e2d-9603-babe0c2c4568.jpg?1",
             "name": "Pure Intentions",
             "text": "Whenever a spell or ability an opponent controls causes you to discard cards this turn, return those cards from your graveyard to your hand.\nWhenever a spell or ability an opponent controls causes you to discard Pure Intentions, return Pure Intentions from your graveyard to your hand at end of turn.",
             "colours": [
@@ -860,7 +860,7 @@
         },
         {
             "id": "7358995d-884f-5cc2-9926-dc120e8912af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5e65e1-be52-4023-81cc-ee4948444195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5e65e1-be52-4023-81cc-ee4948444195.jpg?1",
             "name": "Reverence",
             "text": "Creatures with power 2 or less can't attack you.",
             "colours": [
@@ -892,7 +892,7 @@
         },
         {
             "id": "b0fbb04d-0861-57b6-858c-0cc09ab65afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg?1",
             "name": "Rune-Tail, Kitsune Ascendant // Rune-Tail's Essence",
             "text": "When you have 30 or more life, flip Rune-Tail, Kitsune Ascendant.",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "43bfb2e8-8cb5-5fd4-b9e7-41af62494202",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg?1",
             "name": "Rune-Tail, Kitsune Ascendant // Rune-Tail's Essence",
             "text": "Prevent all damage that would be dealt to creatures you control.",
             "colours": [
@@ -963,7 +963,7 @@
         },
         {
             "id": "68562d9c-e038-5b5b-ace1-e2603c3e5c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd3ee0-d893-4346-98b6-7d7896ad7663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd3ee0-d893-4346-98b6-7d7896ad7663.jpg?1",
             "name": "Shinen of Stars' Light",
             "text": "First strike\nChannel {1}{W}, Discard Shinen of Stars' Light: Target creature gains first strike until end of turn.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "e04f8244-680c-5309-8f59-6c579ca45df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4866e-13a8-4130-9895-60e762b7efea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4866e-13a8-4130-9895-60e762b7efea.jpg?1",
             "name": "Spiritual Visit",
             "text": "Put a 1/1 colorless Spirit creature token into play.\nSplice onto Arcane {W} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "dc4c4e8c-865b-5edc-ada4-a4ce5b430d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ec0916-f320-4fad-9ec5-99aeecfda0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ec0916-f320-4fad-9ec5-99aeecfda0e3.jpg?1",
             "name": "Torii Watchward",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -1065,7 +1065,7 @@
         },
         {
             "id": "0431ceae-10b7-58b0-8c08-d86d9ec2fd10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0d70-8d66-47aa-9228-25dcdb4e7dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0d70-8d66-47aa-9228-25dcdb4e7dad.jpg?1",
             "name": "Cloudhoof Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may put the top X cards of target player's library into his or her graveyard, where X is that spell's converted mana cost.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "bede805f-92c2-55cd-9ab9-fd9d09b828e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066f185d-5f81-472a-8aff-2c11ba10d18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066f185d-5f81-472a-8aff-2c11ba10d18c.jpg?1",
             "name": "Cut the Earthly Bond",
             "text": "Return target enchanted permanent to its owner's hand.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "47a2b48c-0e2a-57f9-8b0f-7c76fad097c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5217d17-3667-46c6-8fba-763197fb2970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5217d17-3667-46c6-8fba-763197fb2970.jpg?1",
             "name": "Descendant of Soramaro",
             "text": "{1}{U}: Look at the top X cards of your library, where X is the number of cards in your hand, then put them back in any order.",
             "colours": [
@@ -1171,7 +1171,7 @@
         },
         {
             "id": "b021f71e-ecd0-58b0-9d51-f11cfbfd5f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90ab82e-84d7-462a-b3c2-abaccfb46dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90ab82e-84d7-462a-b3c2-abaccfb46dd3.jpg?1",
             "name": "Dreamcatcher",
             "text": "Whenever you play a Spirit or Arcane spell, you may sacrifice Dreamcatcher. If you do, draw a card.",
             "colours": [
@@ -1205,7 +1205,7 @@
         },
         {
             "id": "b51a897e-7184-53b2-a18f-6973c7d8a414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg?1",
             "name": "Erayo, Soratami Ascendant // Erayo's Essence",
             "text": "Flying\nWhenever the fourth spell of a turn is played, flip Erayo, Soratami Ascendant.",
             "colours": [
@@ -1242,7 +1242,7 @@
         },
         {
             "id": "16d280c8-0efc-5168-b1c9-68047cbffed9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg?1",
             "name": "Erayo, Soratami Ascendant // Erayo's Essence",
             "text": "Counter the first spell played by each opponent each turn.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "b46e9b01-47bf-5681-b78b-c0e329d86108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067a9bd-991a-462d-862a-2518ae31c382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067a9bd-991a-462d-862a-2518ae31c382.jpg?1",
             "name": "Eternal Dominion",
             "text": "Search target opponent's library for an artifact, creature, enchantment, or land card. Put that card into play under your control. Then that player shuffles his or her library.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability. You may choose a new target for the copy.)",
             "colours": [
@@ -1308,7 +1308,7 @@
         },
         {
             "id": "baabc264-16a3-5176-8482-9b8d0e0a1c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0186a93c-000a-4b8f-983d-e1471185dc1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0186a93c-000a-4b8f-983d-e1471185dc1f.jpg?1",
             "name": "Evermind",
             "text": "(Spells without mana costs can't be played.)\nDraw a card.\nEvermind is blue.\nSplice onto Arcane {1}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "f60214cf-c219-54da-9a49-3aa198aa26b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ecee02-12c0-4aed-a679-41bce95e0cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ecee02-12c0-4aed-a679-41bce95e0cda.jpg?1",
             "name": "Freed from the Real",
             "text": "{U}: Tap enchanted creature.\n{U}: Untap enchanted creature.",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "cc195f87-a7af-55ee-a8f8-6f0bc8ed6227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b7666-8c58-48e5-8ec3-754611700e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b7666-8c58-48e5-8ec3-754611700e75.jpg?1",
             "name": "Ghost-Lit Warder",
             "text": "{3}{U}, {T}: Counter target spell unless its controller pays {2}.\nChannel {3}{U}, Discard Ghost-Lit Warder: Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "f3dd5f22-35cd-573c-bb87-bc6414af904a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fe46d-08d6-48c3-be0d-650d8d3d66af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fe46d-08d6-48c3-be0d-650d8d3d66af.jpg?1",
             "name": "Ideas Unbound",
             "text": "Draw three cards. Discard three cards at end of turn.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "91b927df-2c89-5c09-a053-df93c566fee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a5f54-9b79-4c3d-b983-021b4b01b122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a5f54-9b79-4c3d-b983-021b4b01b122.jpg?1",
             "name": "Kaho, Minamo Historian",
             "text": "When Kaho, Minamo Historian comes into play, search your library for up to three instant cards and remove them from the game. Then shuffle your library.\n{X}, {T}: You may play a card with converted mana cost X removed from the game with Kaho without paying its mana cost.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "928c1aec-551e-594f-9bd9-c212b84ef001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01ee008-76dd-4d4d-8273-ad5b28c8a2c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01ee008-76dd-4d4d-8273-ad5b28c8a2c7.jpg?1",
             "name": "Kami of the Crescent Moon",
             "text": "At the beginning of each player's draw step, that player draws a card.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "ed249c3d-054c-5646-826d-f8912e1cddf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb963c-18a5-4770-afb9-0121c614de40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb963c-18a5-4770-afb9-0121c614de40.jpg?1",
             "name": "Kiri-Onna",
             "text": "When Kiri-Onna comes into play, return target creature to its owner's hand.\nWhenever you play a Spirit or Arcane spell, you may return Kiri-Onna to its owner's hand.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "1b55cf3a-fcac-5f13-a8e9-6c770b9b62ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc52b-7852-44c4-9825-d5e1bd796160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc52b-7852-44c4-9825-d5e1bd796160.jpg?1",
             "name": "Meishin, the Mind Cage",
             "text": "All creatures get -X/-0, where X is the number of cards in your hand.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "520005ec-73da-5910-be16-a0acbab65001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f85e2-63bb-4c9a-8290-0bb8e2318e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f85e2-63bb-4c9a-8290-0bb8e2318e68.jpg?1",
             "name": "Minamo Scrollkeeper",
             "text": "Defender (This creature can't attack.)\nYour maximum hand size is increased by one.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "f17b0f7b-c839-52c9-a133-7c2500407338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4960789-1a45-4273-b2f2-34713f19d697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4960789-1a45-4273-b2f2-34713f19d697.jpg?1",
             "name": "Moonbow Illusionist",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target land's type becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "05268560-4d7c-50ba-a930-dd36a724f73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa70562c-8e1e-44d0-b46c-ccd791be6644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa70562c-8e1e-44d0-b46c-ccd791be6644.jpg?1",
             "name": "Murmurs from Beyond",
             "text": "Reveal the top three cards of your library. An opponent chooses one. Put that card into your graveyard and the rest into your hand.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "f33f12f6-7e5c-5db8-9411-c49b2be31d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a382a9b8-0b19-46c2-a547-a22d6e23d0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a382a9b8-0b19-46c2-a547-a22d6e23d0ac.jpg?1",
             "name": "Oboro Breezecaller",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Untap target land.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "6509860b-ee98-5f74-a58d-86bafc2594f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0309dcb-6c13-4ffe-b44d-3b735c8277d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0309dcb-6c13-4ffe-b44d-3b735c8277d2.jpg?1",
             "name": "Oboro Envoy",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target creature gets -X/-0, where X is the number of cards in your hand.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "d985a5af-872c-5fb2-b06a-059c69f9b822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcb5e75-c7a1-41de-a952-05aefb115270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcb5e75-c7a1-41de-a952-05aefb115270.jpg?1",
             "name": "Oppressive Will",
             "text": "Counter target spell unless its controller pays {1} for each card in your hand.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "3a1fc8d0-77cf-5894-aa9d-7ef2d135f608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeea686-7efc-48f5-b90b-bf1befc76a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeea686-7efc-48f5-b90b-bf1befc76a30.jpg?1",
             "name": "Overwhelming Intellect",
             "text": "Counter target creature spell. Draw cards equal to that spell's converted mana cost.",
             "colours": [
@@ -1823,7 +1823,7 @@
         },
         {
             "id": "4e8633b4-1292-58d4-b2f3-96d235fdc75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a5357b-b479-46a7-8c3a-d51ed8f71a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a5357b-b479-46a7-8c3a-d51ed8f71a17.jpg?1",
             "name": "Rushing-Tide Zubera",
             "text": "When Rushing-Tide Zubera is put into a graveyard from play, if 4 or more damage was dealt to it this turn, draw three cards.",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "f77bd69d-3a33-59d8-b9e4-ca8d89f6fe9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2f54-3637-4caa-9741-36ff14dc5527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2f54-3637-4caa-9741-36ff14dc5527.jpg?1",
             "name": "Sakashima the Impostor",
             "text": "As Sakashima the Impostor comes into play, you may choose a creature in play. If you do, Sakashima comes into play as a copy of that creature, except its name is still Sakashima the Impostor, it's still legendary, and it gains \"{2}{U}{U}: Return Sakashima the Impostor to its owner's hand at end of turn.\"",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "b3122445-9168-5c19-a038-7aac31098434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03247e03-747a-462a-ad74-49ce02d20f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03247e03-747a-462a-ad74-49ce02d20f13.jpg?1",
             "name": "Secretkeeper",
             "text": "As long as you have more cards in hand than each opponent, Secretkeeper gets +2/+2 and has flying.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "0cb46eb0-f1fe-5720-ad7a-fa8661021644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a4871-8bc3-4db0-9f9e-b2e96b90ebd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a4871-8bc3-4db0-9f9e-b2e96b90ebd5.jpg?1",
             "name": "Shape Stealer",
             "text": "Whenever Shape Stealer blocks or becomes blocked by a creature, change Shape Stealer's power and toughness to that creature's power and toughness until end of turn.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "a7e9789e-2e6e-573e-b5e9-48322daa38bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbe44b0-e770-41f2-b91c-c574976e6b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbe44b0-e770-41f2-b91c-c574976e6b53.jpg?1",
             "name": "Shifting Borders",
             "text": "Exchange control of two target lands.\nSplice onto Arcane {3}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1998,7 +1998,7 @@
         },
         {
             "id": "efe9c770-594a-5182-bc65-b570bd4396db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cdad5d-5979-4bbd-90a4-00173d23707b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cdad5d-5979-4bbd-90a4-00173d23707b.jpg?1",
             "name": "Shinen of Flight's Wings",
             "text": "Flying\nChannel {U}, Discard Shinen of Flight's Wings: Target creature gains flying until end of turn.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "a3a371da-1e66-5aaf-84fc-6713279758a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56de23d-7281-42f9-afce-7a81438dae5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56de23d-7281-42f9-afce-7a81438dae5d.jpg?1",
             "name": "Soramaro, First to Dream",
             "text": "Flying\nSoramaro, First to Dream's power and toughness are each equal to the number of cards in your hand.\n{4}, Return a land you control to its owner's hand: Draw a card.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "ceee8fed-43d1-5325-b053-ff93ecf85a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee63cba4-ab12-4adb-8463-d42edbf5794d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee63cba4-ab12-4adb-8463-d42edbf5794d.jpg?1",
             "name": "Trusted Advisor",
             "text": "Your maximum hand size is increased by two.\nAt the beginning of your upkeep, return a blue creature you control to its owner's hand.",
             "colours": [
@@ -2103,7 +2103,7 @@
         },
         {
             "id": "917e520a-728c-503d-bd27-63138d5b8788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a367559-1d84-4f6f-9e6e-ff90de420389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a367559-1d84-4f6f-9e6e-ff90de420389.jpg?1",
             "name": "Twincast",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "686d7b2a-2195-5e23-bae6-db20e4c92b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08730b49-e51e-4868-9cc8-4ddc4a1dce4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08730b49-e51e-4868-9cc8-4ddc4a1dce4c.jpg?1",
             "name": "Akuta, Born of Ash",
             "text": "Haste\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may sacrifice a Swamp. If you do, return Akuta, Born of Ash from your graveyard to play.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "66fa580f-31db-5a9c-9f78-f6552a769851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05939f15-2d95-47df-b66f-131c3e7ea95f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05939f15-2d95-47df-b66f-131c3e7ea95f.jpg?1",
             "name": "Choice of Damnations",
             "text": "Target opponent chooses a number. You may have that player lose that much life. If you don't, that player sacrifices all but that many permanents.",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "0fd5a0d2-f53c-5ef8-b582-ac0adc05f402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f66ddc5-f5e6-44de-8189-87b6521d1fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f66ddc5-f5e6-44de-8189-87b6521d1fea.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "212c697a-3cfb-5b12-a4ed-13803ca4e3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31ca907-a274-436e-8433-7f11b0303f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31ca907-a274-436e-8433-7f11b0303f75.jpg?1",
             "name": "Death of a Thousand Stings",
             "text": "Target player loses 1 life and you gain 1 life.\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may return Death of a Thousand Stings from your graveyard to your hand.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "c5d874b8-9bfd-55a1-aa51-9250d08a2547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09535c14-ae50-4528-b9db-7eacee14e3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09535c14-ae50-4528-b9db-7eacee14e3fa.jpg?1",
             "name": "Deathknell Kami",
             "text": "Flying\n{2}: Deathknell Kami gets +1/+1 until end of turn. Sacrifice it at end of turn.\nSoulshift 1 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 1 or less from your graveyard to your hand.)",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "8491afc1-c329-5db6-a19f-af843c315731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743e38d1-b1cd-4828-ad3d-529a9f882115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743e38d1-b1cd-4828-ad3d-529a9f882115.jpg?1",
             "name": "Deathmask Nezumi",
             "text": "As long as you have seven or more cards in hand, Deathmask Nezumi gets +2/+1 and has fear.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "c09716da-5eb7-5699-a1ea-7f06facc4a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6ac32c-9555-4408-8b18-c3098802b7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6ac32c-9555-4408-8b18-c3098802b7ad.jpg?1",
             "name": "Exile into Darkness",
             "text": "Target player sacrifices a creature with converted mana cost 3 or less.\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may return Exile into Darkness from your graveyard to your hand.",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "9b77b501-2875-5b1d-99e5-196bb5d63dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7bedbe-8b87-402f-9a0c-83e46ae10279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7bedbe-8b87-402f-9a0c-83e46ae10279.jpg?1",
             "name": "Footsteps of the Goryo",
             "text": "Return target creature card from your graveyard to play. Sacrifice that creature at end of turn.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "25371b7f-a3e1-574f-b4f2-7e8189f8afc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3cc092-b673-4f4e-b9a8-8e60ff562dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3cc092-b673-4f4e-b9a8-8e60ff562dbd.jpg?1",
             "name": "Ghost-Lit Stalker",
             "text": "{4}{B}, {T}: Target player discards two cards. Play this ability only any time you could play a sorcery.\nChannel {5}{B}{B}, Discard Ghost-Lit Stalker: Target player discards four cards. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "d7e609ab-4bca-5aa2-bfa8-d6df6e082c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c51ee1-d6f6-42d7-9be6-fe3f982984ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c51ee1-d6f6-42d7-9be6-fe3f982984ba.jpg?1",
             "name": "Gnat Miser",
             "text": "Each opponent's maximum hand size is reduced by one.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "d3635841-cb11-548f-b79f-a3f58f2256cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee194055-579a-4977-900e-e976259552ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee194055-579a-4977-900e-e976259552ab.jpg?1",
             "name": "Hand of Cruelty",
             "text": "Protection from white\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "458e0088-f8f6-5f23-83ed-9e6251b4bed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79e7a4c-e0e7-42ac-b125-1db2f3d9325c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79e7a4c-e0e7-42ac-b125-1db2f3d9325c.jpg?1",
             "name": "Infernal Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, target player reveals his or her hand and discards all cards with that spell's converted mana cost.",
             "colours": [
@@ -2549,7 +2549,7 @@
         },
         {
             "id": "98b15dfb-31ed-5839-8b48-ace61a8881e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f8672-1c37-4ab2-b290-fe3147784475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f8672-1c37-4ab2-b290-fe3147784475.jpg?1",
             "name": "Kagemaro, First to Suffer",
             "text": "Kagemaro, First to Suffer's power and toughness are each equal to the number of cards in your hand.\n{B}, Sacrifice Kagemaro: All creatures get -X/-X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "a5318b1f-2c2a-516e-8ada-581d4d21a5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe4bb8d-bed8-4373-af9d-9332de910e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe4bb8d-bed8-4373-af9d-9332de910e06.jpg?1",
             "name": "Kagemaro's Clutch",
             "text": "Enchanted creature gets -X/-X, where X is the number of cards in your hand.",
             "colours": [
@@ -2620,7 +2620,7 @@
         },
         {
             "id": "dfd47231-0365-5014-a91c-ca186bf55a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30502f07-760c-46d1-8b4a-d4bd4a23201f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30502f07-760c-46d1-8b4a-d4bd4a23201f.jpg?1",
             "name": "Kami of Empty Graves",
             "text": "Soulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "71bf2c6b-62e5-58b1-bfc7-640ef820958d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eed13fd-68be-4bc3-af6a-d88baaf9c98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eed13fd-68be-4bc3-af6a-d88baaf9c98d.jpg?1",
             "name": "Kemuri-Onna",
             "text": "When Kemuri-Onna comes into play, target player discards a card.\nWhenever you play a Spirit or Arcane spell, you may return Kemuri-Onna to its owner's hand.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "a7d623d4-7ad5-5d9f-a8b1-70cc36c78f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38700c7d-2f24-47e4-a899-d294daed5549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38700c7d-2f24-47e4-a899-d294daed5549.jpg?1",
             "name": "Kiku's Shadow",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -2720,7 +2720,7 @@
         },
         {
             "id": "49ffa332-1496-5f66-8aef-9cf5d5a08f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg?1",
             "name": "Kuon, Ogre Ascendant // Kuon's Essence",
             "text": "At end of turn, if three or more creatures were put into graveyards from play this turn, flip Kuon, Ogre Ascendant.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "d0c5851b-c827-52ba-94b2-817c11ab212d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg?1",
             "name": "Kuon, Ogre Ascendant // Kuon's Essence",
             "text": "At the beginning of each player's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "ec2515eb-d62b-574b-8882-aea47553ad1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e301a46-f321-4fa6-a8c4-08dd4079a458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e301a46-f321-4fa6-a8c4-08dd4079a458.jpg?1",
             "name": "Kuro's Taken",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{1}{B}: Regenerate Kuro's Taken.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "d3ea72c5-fd09-5be5-9cfb-7f54af05cfa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bf4dda-0ce8-4e35-88d9-18a22400e6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bf4dda-0ce8-4e35-88d9-18a22400e6cb.jpg?1",
             "name": "Locust Miser",
             "text": "Each opponent's maximum hand size is reduced by two.",
             "colours": [
@@ -2861,7 +2861,7 @@
         },
         {
             "id": "a3e7c8c8-507e-5901-b909-3bcc4fdd021e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2563fd68-afdd-466f-8137-0769565674bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2563fd68-afdd-466f-8137-0769565674bf.jpg?1",
             "name": "Maga, Traitor to Mortals",
             "text": "Maga, Traitor to Mortals comes into play with X +1/+1 counters on it.\nWhen Maga comes into play, target player loses life equal to the number of +1/+1 counters on it.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "f520c589-440d-588d-a478-79c33b1a96e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6776c-f286-4b43-8f5f-d70b5585e635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6776c-f286-4b43-8f5f-d70b5585e635.jpg?1",
             "name": "Measure of Wickedness",
             "text": "At the end of your turn, sacrifice Measure of Wickedness and you lose 8 life.\nWhenever another card is put into your graveyard from anywhere, target opponent gains control of Measure of Wickedness.",
             "colours": [
@@ -2930,7 +2930,7 @@
         },
         {
             "id": "b210c855-c69f-5bd2-b2c5-499d660899b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f91f678-9d3a-4502-81a6-3e1676aa447a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f91f678-9d3a-4502-81a6-3e1676aa447a.jpg?1",
             "name": "Neverending Torment",
             "text": "Search target player's library for X cards, where X is the number of cards in your hand, and remove them from the game. Then that player shuffles his or her library.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability. You may choose a new target for the copy.)",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "5563c3b0-801b-5a5b-84a8-02d18bc33616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5841fa-4f30-495a-b840-3ef5a2af8fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5841fa-4f30-495a-b840-3ef5a2af8fad.jpg?1",
             "name": "One with Nothing",
             "text": "Discard your hand.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "9fe682e0-1435-5b79-b635-ad6c75b1ba7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d16da68-85f6-4d54-9751-9cf046f5e99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d16da68-85f6-4d54-9751-9cf046f5e99a.jpg?1",
             "name": "Pain's Reward",
             "text": "You bid any amount of life. In turn order, each player may top the high bid. The bidding ends if the high bid stands. The high bidder loses life equal to the high bid and draws four cards.",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "b9a6e440-1fba-56d8-bd09-b33701dee284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d16271-9302-463b-938d-01dad0c3ce29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d16271-9302-463b-938d-01dad0c3ce29.jpg?1",
             "name": "Raving Oni-Slave",
             "text": "When Raving Oni-Slave comes into play, you lose 3 life if you don't control a Demon.\nWhen Raving Oni-Slave leaves play, you lose 3 life if you don't control a Demon.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "35d466ea-6e8d-5614-bcb2-627fd01f8291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a44255-2f3e-4e0b-aeab-9d2385b2afcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a44255-2f3e-4e0b-aeab-9d2385b2afcd.jpg?1",
             "name": "Razorjaw Oni",
             "text": "Black creatures can't block.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "71d059ab-4c6a-545d-8a24-225812478d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762499b4-4b4f-456e-8a03-2de300b2db5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762499b4-4b4f-456e-8a03-2de300b2db5e.jpg?1",
             "name": "Shinen of Fear's Chill",
             "text": "Shinen of Fear's Chill can't block.\nChannel {1}{B}, Discard Shinen of Fear's Chill: Target creature can't block this turn.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "2826aa27-c0fd-5341-9810-3de602ef0aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d519df1b-0c81-4d0d-85c6-2a288c6fa269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d519df1b-0c81-4d0d-85c6-2a288c6fa269.jpg?1",
             "name": "Sink into Takenuma",
             "text": "Sweep Return any number of Swamps you control to their owner's hand. Target player discards a card for each Swamp returned this way.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "acc0cdec-0527-53cb-8cfd-8453db66ac02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4b1bf-eef5-4a86-a861-be448845a743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4b1bf-eef5-4a86-a861-be448845a743.jpg?1",
             "name": "Skull Collector",
             "text": "At the beginning of your upkeep, return a black creature you control to its owner's hand.\n{1}{B}: Regenerate Skull Collector.",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "77bb5961-5c9b-5b17-912f-0ead8d96ba9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2fa85ea-f5d5-4be3-a874-ce246c3e4245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2fa85ea-f5d5-4be3-a874-ce246c3e4245.jpg?1",
             "name": "Adamaro, First to Desire",
             "text": "Adamaro, First to Desire's power and toughness are each equal to the number of cards in the hand of the opponent with the most cards in hand.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "d93846c8-a142-5349-9833-6966fb5076be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb63254-5786-43fb-8ccd-132095a55e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb63254-5786-43fb-8ccd-132095a55e64.jpg?1",
             "name": "Akki Drillmaster",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -3270,7 +3270,7 @@
         },
         {
             "id": "c4ad8d78-01d4-5eda-8efb-dc60025e78d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106382db-56aa-4061-9d1e-17821937f1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106382db-56aa-4061-9d1e-17821937f1de.jpg?1",
             "name": "Akki Underling",
             "text": "As long as you have seven or more cards in hand, Akki Underling gets +2/+1 and has first strike.",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "15ea617d-824b-58c2-b3e8-3de06b65eed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c52e00-ad17-42aa-9f5f-38fb52dad5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c52e00-ad17-42aa-9f5f-38fb52dad5ea.jpg?1",
             "name": "Barrel Down Sokenzan",
             "text": "Sweep Return any number of Mountains you control to their owner's hand. Barrel Down Sokenzan deals damage to target creature equal to twice the number of Mountains returned this way.",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "05dfaae7-cb91-5194-8da2-9b76bfe4d593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ca5c3-8367-4e08-a318-634f9d36dbdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ca5c3-8367-4e08-a318-634f9d36dbdc.jpg?1",
             "name": "Burning-Eye Zubera",
             "text": "When Burning-Eye Zubera is put into a graveyard from play, if 4 or more damage was dealt to it this turn, Burning-Eye Zubera deals 3 damage to target creature or player.",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "e2f971b9-7949-5fd0-9103-803c78090b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd2142-b41b-4456-9b76-bb83ba91e6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd2142-b41b-4456-9b76-bb83ba91e6be.jpg?1",
             "name": "Captive Flame",
             "text": "{R}: Target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -3406,7 +3406,7 @@
         },
         {
             "id": "3fea6f69-13aa-564f-9490-9c067ed545ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2391265f-ef0c-463f-9371-5a0b71dbbb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2391265f-ef0c-463f-9371-5a0b71dbbb49.jpg?1",
             "name": "Feral Lightning",
             "text": "Put three 3/1 red Elemental creature tokens with haste into play. Remove them from the game at end of turn.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "b9955a6d-2832-5347-a16f-3e1a7d9ce45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44cab92a-54d8-496c-8a97-7f3448f5b1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44cab92a-54d8-496c-8a97-7f3448f5b1e9.jpg?1",
             "name": "Gaze of Adamaro",
             "text": "Gaze of Adamaro deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "484ba96b-c73b-5f1e-8c4c-3fa65bef8356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4280a08a-90fe-445e-b49d-1a3b13d3c6e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4280a08a-90fe-445e-b49d-1a3b13d3c6e9.jpg?1",
             "name": "Ghost-Lit Raider",
             "text": "{2}{R}, {T}: Ghost-Lit Raider deals 2 damage to target creature.\nChannel {3}{R}, Discard Ghost-Lit Raider: Ghost-Lit Raider deals 4 damage to target creature.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "dfe42161-8ee2-5529-91d2-e7ba54a7ffb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1519521-7f53-4f13-a104-daf52e8c7234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1519521-7f53-4f13-a104-daf52e8c7234.jpg?1",
             "name": "Glitterfang",
             "text": "Haste\nAt end of turn, return Glitterfang to its owner's hand.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "7527c7c0-cf4b-5267-b32e-b94030b3f57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a7afc5-be73-459d-8bd1-116a0bf1210f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a7afc5-be73-459d-8bd1-116a0bf1210f.jpg?1",
             "name": "Godo's Irregulars",
             "text": "{R}: Godo's Irregulars deals 1 damage to target creature blocking it.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "a7749e24-6c44-53f9-ad14-f41670406c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg?1",
             "name": "Hidetsugu's Second Rite",
             "text": "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "3042d741-2594-57e5-a2b8-31a290600128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg?1",
             "name": "Homura, Human Ascendant // Homura's Essence",
             "text": "Homura, Human Ascendant can't block.\nWhen Homura is put into a graveyard from play, return it to play flipped.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "8eafaf05-aa1a-5989-acf0-4e4a90becacb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg?1",
             "name": "Homura, Human Ascendant // Homura's Essence",
             "text": "Creatures you control get +2/+2 and have flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "01d336d3-c397-5734-8b77-e3b0539faa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce461f7-385d-4379-83de-49571247c30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce461f7-385d-4379-83de-49571247c30d.jpg?1",
             "name": "Iizuka the Ruthless",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{2}{R}, Sacrifice a Samurai: Samurai you control gain double strike until end of turn.",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "eae2e636-a9d2-58a5-ade9-dcc86fee25fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d886a2-ae83-4d95-9ec0-582c563181e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d886a2-ae83-4d95-9ec0-582c563181e6.jpg?1",
             "name": "Inner Fire",
             "text": "Add {R} to your mana pool for each card in your hand.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "6bf9d80f-dc1c-5431-a92e-decd9040ef0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99d116c-41c0-41af-9a68-9ac995f3000b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99d116c-41c0-41af-9a68-9ac995f3000b.jpg?1",
             "name": "Into the Fray",
             "text": "Target creature attacks this turn if able.\nSplice onto Arcane {R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "248ae485-a58c-5801-a0ac-7bc8468dab01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b46105b-32c2-48fc-b71d-c3e8fcb8a8ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b46105b-32c2-48fc-b71d-c3e8fcb8a8ea.jpg?1",
             "name": "Jiwari, the Earth Aflame",
             "text": "{X}{R}, {T}: Jiwari, the Earth Aflame deals X damage to target creature without flying.\nChannel {X}{R}{R}{R}, Discard Jiwari: Jiwari deals X damage to each creature without flying.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "dc471b26-3316-5a34-9044-8573809054b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf61b5-cb7e-4303-a6b4-4abc8332fd58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf61b5-cb7e-4303-a6b4-4abc8332fd58.jpg?1",
             "name": "Oni of Wild Places",
             "text": "Haste\nAt the beginning of your upkeep, return a red creature you control to its owner's hand.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "8f6e6f3a-e446-59e6-99a5-3e315a3cc280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fd4b1-d3a4-4859-a0d4-0e8341e6c6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fd4b1-d3a4-4859-a0d4-0e8341e6c6c7.jpg?1",
             "name": "Path of Anger's Flame",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "e1755d26-6a47-59bc-883e-f948670cbcb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b292a8d2-44b1-4c20-8035-0f5912cc09a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b292a8d2-44b1-4c20-8035-0f5912cc09a4.jpg?1",
             "name": "Rally the Horde",
             "text": "Remove the top three cards of your library from the game. If the last card removed isn't a land, repeat this process until the last card removed is a land. Put a 1/1 red Warrior creature token into play for each nonland card removed from the game this way.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "603fc9c4-2f3e-5bea-9b2d-1e48fabb36dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c532e5a-01f4-4258-ba48-99257cc577d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c532e5a-01f4-4258-ba48-99257cc577d4.jpg?1",
             "name": "Ronin Cavekeeper",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -3953,7 +3953,7 @@
         },
         {
             "id": "9e1f6104-8d97-5560-abbd-908c33fa71eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c05acc-7cb2-4a06-9e6f-cb9419298385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c05acc-7cb2-4a06-9e6f-cb9419298385.jpg?1",
             "name": "Shinen of Fury's Fire",
             "text": "Haste\nChannel {R}, Discard Shinen of Fury's Fire: Target creature gains haste until end of turn.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "f71b6680-e76f-5f5d-adca-d8b0861f830a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d425562-3f0f-4aa3-a761-48ba445b8380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d425562-3f0f-4aa3-a761-48ba445b8380.jpg?1",
             "name": "Skyfire Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may gain control of target creature with that spell's converted mana cost until end of turn.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "d11bc4d7-ca7d-5bbc-ba0c-e49aadee6ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9b3164-3de2-4b25-88d0-2dffee32148a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9b3164-3de2-4b25-88d0-2dffee32148a.jpg?1",
             "name": "Sokenzan Renegade",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nAt the beginning of your upkeep, if a player has more cards in hand than any other, the player with the most cards in hand gains control of Sokenzan Renegade.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "0576cb0b-3ce1-5d94-8047-eb3babb5b9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500eeccb-aee2-48d4-8a43-bb9668f1c1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500eeccb-aee2-48d4-8a43-bb9668f1c1ab.jpg?1",
             "name": "Sokenzan Spellblade",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{1}{R}: Sokenzan Spellblade gets +X/+0 until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "fa9a03aa-4bf6-530f-85c8-db98a7ffbca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73503423-30d8-42bc-a697-6d986e4945c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73503423-30d8-42bc-a697-6d986e4945c8.jpg?1",
             "name": "Spiraling Embers",
             "text": "Spiraling Embers deals damage to target creature or player equal to the number of cards in your hand.",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "32f1acbc-f33a-57ee-8a4d-ea9ab03bed67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46783ba7-6e23-43d0-b5aa-9a0ea75cfb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46783ba7-6e23-43d0-b5aa-9a0ea75cfb67.jpg?1",
             "name": "Sunder from Within",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "14b5b31b-9d31-58ee-b630-fd7a36c78c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0f2db3-41a6-4283-9812-46b6ae6d1df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0f2db3-41a6-4283-9812-46b6ae6d1df6.jpg?1",
             "name": "Thoughts of Ruin",
             "text": "Each player sacrifices a land for each card in your hand.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "fef17dfb-64dd-58f4-acd0-919f5b917ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606206c7-1a8a-46f4-b368-cf18e02f3df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606206c7-1a8a-46f4-b368-cf18e02f3df8.jpg?1",
             "name": "Undying Flames",
             "text": "Remove cards from the top of your library from the game until you remove a nonland card. Undying Flames deals damage to target creature or player equal to that card's converted mana cost.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability. You may choose a new target for the copy.)",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "0b9bcf1c-36a3-5aba-86d8-27757b5acbed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c6e1cd-e25d-41ff-a918-c495998376d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c6e1cd-e25d-41ff-a918-c495998376d8.jpg?1",
             "name": "Yuki-Onna",
             "text": "When Yuki-Onna comes into play, destroy target artifact.\nWhenever you play a Spirit or Arcane spell, you may return Yuki-Onna to its owner's hand.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "fe0e210f-1b0b-5caa-8a2e-f7febf6681f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d627b2-5298-45f5-acd2-56de59209820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d627b2-5298-45f5-acd2-56de59209820.jpg?1",
             "name": "Arashi, the Sky Asunder",
             "text": "{X}{G}, {T}: Arashi, the Sky Asunder deals X damage to target creature with flying.\nChannel {X}{G}{G}, Discard Arashi: Arashi deals X damage to each creature with flying.",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "2fc6e0bd-9573-50e5-94bc-9087ace3e12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f037520e-2a44-4650-b7cb-c81d93d1418d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f037520e-2a44-4650-b7cb-c81d93d1418d.jpg?1",
             "name": "Ayumi, the Last Visitor",
             "text": "Legendary landwalk",
             "colours": [
@@ -4334,7 +4334,7 @@
         },
         {
             "id": "1c9dd6de-a49a-5a07-a8b6-b083b932ea98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fe65e-81b1-4e69-913a-25fc99d96d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fe65e-81b1-4e69-913a-25fc99d96d81.jpg?1",
             "name": "Bounteous Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may gain life equal to that spell's converted mana cost.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "6dbf623f-a046-55f4-aa77-9ed3a046b1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c042f8b-df20-48c1-a291-4d7e1bc5b384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c042f8b-df20-48c1-a291-4d7e1bc5b384.jpg?1",
             "name": "Briarknit Kami",
             "text": "Whenever you play a Spirit or Arcane spell, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "cd1b88da-8c0c-50d7-9e55-90f5154bbde8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1480d4-51f8-4233-874c-94502726fe0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1480d4-51f8-4233-874c-94502726fe0d.jpg?1",
             "name": "Dense Canopy",
             "text": "Creatures with flying can't block creatures without flying.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "5d28aec1-4181-58e6-a3fa-d6d521a35870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7512d74-4330-4de7-9c0c-4bb7f37f6066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7512d74-4330-4de7-9c0c-4bb7f37f6066.jpg?1",
             "name": "Descendant of Masumaro",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on Descendant of Masumaro for each card in your hand, then remove a +1/+1 counter from Descendant of Masumaro for each card in target opponent's hand.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "4eecc672-693f-500f-be40-89c188f22a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b525f824-fcce-48cc-887d-98d4058b1d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b525f824-fcce-48cc-887d-98d4058b1d31.jpg?1",
             "name": "Dosan's Oldest Chant",
             "text": "You gain 6 life.\nDraw a card.",
             "colours": [
@@ -4504,7 +4504,7 @@
         },
         {
             "id": "272e6888-1403-59d9-973b-c9843e341e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c3e47b-a788-46b7-bf15-1216692e637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c3e47b-a788-46b7-bf15-1216692e637a.jpg?1",
             "name": "Elder Pine of Jukai",
             "text": "Whenever you play a Spirit or Arcane spell, reveal the top three cards of your library. Put all land cards revealed this way into your hand and the rest on the bottom of your library in any order.\nSoulshift 2",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "468dcf22-2c6a-507c-9a7b-7af7b389ca6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64d9404-9685-495d-a591-63d6164a88a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64d9404-9685-495d-a591-63d6164a88a9.jpg?1",
             "name": "Endless Swarm",
             "text": "Put a 1/1 green Snake creature token into play for each card in your hand.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability.)",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "71aa5daf-60f6-5557-b4bc-c4c95cf6c29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328ac4-1b7d-4310-9798-8c8dc8740062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328ac4-1b7d-4310-9798-8c8dc8740062.jpg?1",
             "name": "Fiddlehead Kami",
             "text": "Whenever you play a Spirit or Arcane spell, regenerate Fiddlehead Kami.",
             "colours": [
@@ -4604,7 +4604,7 @@
         },
         {
             "id": "a1e45812-50b1-519e-afda-665c313c42db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4becdbb-9089-4c54-a681-6510d90cc99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4becdbb-9089-4c54-a681-6510d90cc99e.jpg?1",
             "name": "Ghost-Lit Nourisher",
             "text": "{2}{G}, {T}: Target creature gets +2/+2 until end of turn.\nChannel {3}{G}, Discard Ghost-Lit Nourisher: Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "f999f824-6aea-5af4-b1b2-2fef88e3b427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaacab4-f13b-4189-ac78-89fc4cdbaa55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaacab4-f13b-4189-ac78-89fc4cdbaa55.jpg?1",
             "name": "Haru-Onna",
             "text": "When Haru-Onna comes into play, draw a card.\nWhenever you play a Spirit or Arcane spell, you may return Haru-Onna to its owner's hand.",
             "colours": [
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "3923a10a-cf14-59b5-9d76-bea606c6ffc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f56817-aabf-469c-a82c-37315decc73c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f56817-aabf-469c-a82c-37315decc73c.jpg?1",
             "name": "Inner Calm, Outer Strength",
             "text": "Target creature gets +X/+X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "e93d31ce-2c80-532e-8f01-e43f9a71f658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedd830-9200-4e8b-84b4-00dc58cace35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedd830-9200-4e8b-84b4-00dc58cace35.jpg?1",
             "name": "Kami of the Tended Garden",
             "text": "At the beginning of your upkeep, sacrifice Kami of the Tended Garden unless you pay {G}.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "a2cdb75a-ef0f-5926-a72e-253783a8e2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12adf2d-ebf9-464e-9957-c8518d364a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12adf2d-ebf9-464e-9957-c8518d364a40.jpg?1",
             "name": "Kashi-Tribe Elite",
             "text": "Legendary Snakes you control can't be the targets of spells or abilities.\nWhenever Kashi-Tribe Elite deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4775,7 +4775,7 @@
         },
         {
             "id": "3a32a637-2df7-5a87-867d-08d0dbee9b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4625b7-c8b1-4fdf-af9f-935313436b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4625b7-c8b1-4fdf-af9f-935313436b35.jpg?1",
             "name": "Masumaro, First to Live",
             "text": "Masumaro, First to Live's power and toughness are each equal to twice the number of cards in your hand.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "94acbe44-aa68-5048-a64b-00d2dd84fceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1afb0c0-e138-4d2b-b3aa-fa40778f8d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1afb0c0-e138-4d2b-b3aa-fa40778f8d79.jpg?1",
             "name": "Matsu-Tribe Birdstalker",
             "text": "Whenever Matsu-Tribe Birdstalker deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\n{G}: Matsu-Tribe Birdstalker may block as though it had flying until end of turn.",
             "colours": [
@@ -4847,7 +4847,7 @@
         },
         {
             "id": "b3a6837a-0863-540b-8b87-afc9fe0dab3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0797186-01ae-4de0-b188-7fc3079b2800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0797186-01ae-4de0-b188-7fc3079b2800.jpg?1",
             "name": "Molting Skin",
             "text": "Return Molting Skin to its owner's hand: Regenerate target creature.",
             "colours": [
@@ -4879,7 +4879,7 @@
         },
         {
             "id": "cd2c7a36-876c-56d5-8e90-59ab90ee4c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5902f863-171e-4bb2-9d48-2c679d41f1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5902f863-171e-4bb2-9d48-2c679d41f1a9.jpg?1",
             "name": "Nightsoil Kami",
             "text": "Soulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -4913,7 +4913,7 @@
         },
         {
             "id": "85de6f7e-02d0-50c1-9f04-0d1bcdae816c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eea50b1-ba6e-4c57-9b49-488b883be638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eea50b1-ba6e-4c57-9b49-488b883be638.jpg?1",
             "name": "Okina Nightwatch",
             "text": "As long as you have more cards in hand than each opponent, Okina Nightwatch gets +3/+3.",
             "colours": [
@@ -4948,7 +4948,7 @@
         },
         {
             "id": "55b6b7c2-f908-524c-94b4-bfd4f2d65842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aac4236-9573-4cff-88d9-711a56da4346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aac4236-9573-4cff-88d9-711a56da4346.jpg?1",
             "name": "Promised Kannushi",
             "text": "Soulshift 7 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 7 or less from your graveyard to your hand.)",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "531f8101-00c4-542b-860b-19acd2906eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86317339-5a39-41eb-8aee-5ea926da8cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86317339-5a39-41eb-8aee-5ea926da8cd4.jpg?1",
             "name": "Reki, the History of Kamigawa",
             "text": "Whenever you play a legendary spell, draw a card.",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "1e33a9e9-915e-574f-8be2-31bcff029695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cf7931-d086-496e-98dc-5daa60e01f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cf7931-d086-496e-98dc-5daa60e01f5b.jpg?1",
             "name": "Rending Vines",
             "text": "Destroy target artifact or enchantment if its converted mana cost is less than or equal to the number of cards in your hand.\nDraw a card.",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "7755e874-4941-53e3-b414-eb7a6d2a9687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbdda50-8a27-4094-849d-b6f66def82ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbdda50-8a27-4094-849d-b6f66def82ce.jpg?1",
             "name": "Sakura-Tribe Scout",
             "text": "{T}: You may put a land card from your hand into play.",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "1bc88089-68cc-56e6-a9d1-1617556f60c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg?1",
             "name": "Sasaya, Orochi Ascendant // Sasaya's Essence",
             "text": "Reveal your hand: If you have seven or more land cards in your hand, flip Sasaya, Orochi Ascendant.",
             "colours": [
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "36ba5bdd-881e-5282-8484-20a0eb0a095f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg?1",
             "name": "Sasaya, Orochi Ascendant // Sasaya's Essence",
             "text": "Whenever a land you control is tapped for mana, add one mana of that type to your mana pool for each other land you control with the same name.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "dd616938-89f1-5569-b7fb-cb0b504a8d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b0a4e-e52e-4d4e-9b12-24676d8571b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b0a4e-e52e-4d4e-9b12-24676d8571b1.jpg?1",
             "name": "Seed the Land",
             "text": "Whenever a land comes into play, its controller puts a 1/1 green Snake creature token into play.",
             "colours": [
@@ -5193,7 +5193,7 @@
         },
         {
             "id": "fc701702-baea-5faa-a9c3-8ceff1668fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f8a9e7-f505-4fc5-b820-0af1ee1960c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f8a9e7-f505-4fc5-b820-0af1ee1960c7.jpg?1",
             "name": "Seek the Horizon",
             "text": "Search your library for up to three basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "3a93180d-50d2-5790-a02c-d908cc78045d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9883e973-54c3-4bec-91d8-22f2829cdfa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9883e973-54c3-4bec-91d8-22f2829cdfa2.jpg?1",
             "name": "Sekki, Seasons' Guide",
             "text": "Sekki, Seasons' Guide comes into play with eight +1/+1 counters on it.\nIf damage would be dealt to Sekki, prevent that damage, remove that many +1/+1 counters from Sekki, and put that many 1/1 colorless Spirit creature tokens into play.\nSacrifice eight Spirits: Return Sekki from your graveyard to play.",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "5c5bda93-a963-55a8-bb8e-72ff0ca0f4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d9516-7275-40df-8989-418933671263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d9516-7275-40df-8989-418933671263.jpg?1",
             "name": "Shinen of Life's Roar",
             "text": "All creatures able to block Shinen of Life's Roar do so.\nChannel {2}{G}{G}, Discard Shinen of Life's Roar: All creatures able to block target creature this turn do so.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "b87a0578-930a-5a70-9a4c-01e9172e5808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c63065-6051-4193-8457-713a8a800393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c63065-6051-4193-8457-713a8a800393.jpg?1",
             "name": "Stampeding Serow",
             "text": "Trample\nAt the beginning of your upkeep, return a green creature you control to its owner's hand.",
             "colours": [
@@ -5330,7 +5330,7 @@
         },
         {
             "id": "190237cd-da91-5ab4-8964-4bdb227b2a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e13f122-0dfe-42f3-9815-9ae1a29fca99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e13f122-0dfe-42f3-9815-9ae1a29fca99.jpg?1",
             "name": "Iname as One",
             "text": "When Iname as One comes into play, if you played it from your hand, you may search your library for a Spirit card, put it into play, then shuffle your library.\nWhen Iname as One is put into a graveyard from play, you may remove it from the game. If you do, return target Spirit card from your graveyard to play.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "7b3abb16-afac-573b-bced-b666147f7cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59df09f-d8b9-4398-a705-329b768d5004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59df09f-d8b9-4398-a705-329b768d5004.jpg?1",
             "name": "Ashes of the Fallen",
             "text": "As Ashes of the Fallen comes into play, choose a creature type.\nEach creature card in your graveyard has the chosen creature type in addition to its other types.",
             "colours": [],
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "735d28b5-1718-5f4d-81e2-80fba800cae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28328b4d-99d1-4460-9bbe-a64c6c0b6cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28328b4d-99d1-4460-9bbe-a64c6c0b6cb2.jpg?1",
             "name": "Blood Clock",
             "text": "At the beginning of each player's upkeep, that player returns a permanent he or she controls to its owner's hand unless he or she pays 2 life.",
             "colours": [],
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "eaa7fb58-2c5f-5ac5-a444-94a11eef40fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e0c24f-2312-4b40-9cd1-2b83d501e485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e0c24f-2312-4b40-9cd1-2b83d501e485.jpg?1",
             "name": "Ebony Owl Netsuke",
             "text": "At the beginning of each opponent's upkeep, if that player has seven or more cards in hand, Ebony Owl Netsuke deals 4 damage to him or her.",
             "colours": [],
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "9c8d26dd-275d-5fb3-9fd2-7ae30e5b069c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd84d1a-1e74-4779-996f-f8518f0b5f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd84d1a-1e74-4779-996f-f8518f0b5f8c.jpg?1",
             "name": "Ivory Crane Netsuke",
             "text": "At the beginning of your upkeep, if you have seven or more cards in hand, you gain 4 life.",
             "colours": [],
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "ae650f5e-d078-50f1-935a-0e01e82971b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc6542b-7672-4ea1-816c-33bc0c300f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc6542b-7672-4ea1-816c-33bc0c300f3c.jpg?1",
             "name": "Manriki-Gusari",
             "text": "Equipped creature gets +1/+2 and has \"{T}: Destroy target Equipment.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "b0679358-a150-5a55-8541-c9bef0fc9e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a353d5-d3b1-4ec1-8f2e-792f1bc79c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a353d5-d3b1-4ec1-8f2e-792f1bc79c96.jpg?1",
             "name": "O-Naginata",
             "text": "O-Naginata can be attached only to a creature with 3 or more power.\nEquipped creature gets +3/+0 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "a6cf6b0a-947f-59b6-82b7-2d059734dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb9e1d-113e-45ff-8435-32ee42fa5631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb9e1d-113e-45ff-8435-32ee42fa5631.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle comes into play, name a card.\nActivated abilities of the named card can't be played unless they're mana abilities.",
             "colours": [],
@@ -5568,7 +5568,7 @@
         },
         {
             "id": "d6e1cad5-116a-51a0-8df7-17012f23b63c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b39d20-47b5-468b-aaf8-f6b7c7048b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b39d20-47b5-468b-aaf8-f6b7c7048b33.jpg?1",
             "name": "Scroll of Origins",
             "text": "{2}, {T}: Draw a card if you have seven or more cards in hand.",
             "colours": [],
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "04f14233-36f5-5724-bc59-9d66114d7e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e6129a-fa5c-4e27-a4d4-cbde7392164b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e6129a-fa5c-4e27-a4d4-cbde7392164b.jpg?1",
             "name": "Soratami Cloud Chariot",
             "text": "{2}: Target creature you control gains flying until end of turn.\n{2}: Prevent all combat damage that would be dealt to and dealt by target creature you control this turn.",
             "colours": [],
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "d911812a-7531-5935-a707-0a7240629679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6f80dc-72a4-409b-bc92-69fa3885cd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6f80dc-72a4-409b-bc92-69fa3885cd6d.jpg?1",
             "name": "Wine of Blood and Iron",
             "text": "{4}: Target creature gets +X/+0 until end of turn, where X is its power. Sacrifice Wine of Blood and Iron at end of turn.",
             "colours": [],
@@ -5652,7 +5652,7 @@
         },
         {
             "id": "1d36b391-2f1b-5d3a-b708-00f6f8c473bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef72797-328e-4303-8ffb-9686086648b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef72797-328e-4303-8ffb-9686086648b8.jpg?1",
             "name": "Mikokoro, Center of the Sea",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Each player draws a card.",
             "colours": [],
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "427a56ab-56e5-5468-a8d3-01ccd25413ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d414f0-15ae-446b-a8d7-56c1b502740c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d414f0-15ae-446b-a8d7-56c1b502740c.jpg?1",
             "name": "Miren, the Moaning Well",
             "text": "{T}: Add {1} to your mana pool.\n{3}, {T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [],
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "e07e29db-b50f-5ff7-a8c2-c0d0ba6a6404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc2d68e-6543-43ec-b67a-afff1325a32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc2d68e-6543-43ec-b67a-afff1325a32f.jpg?1",
             "name": "Oboro, Palace in the Clouds",
             "text": "{T}: Add {U} to your mana pool.\n{1}: Return Oboro, Palace in the Clouds to its owner's hand.",
             "colours": [],
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "c0c920ea-7b9b-5bef-b095-553d817d3745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fedf90-825c-4814-8f0d-170f537db44c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fedf90-825c-4814-8f0d-170f537db44c.jpg?1",
             "name": "Tomb of Urami",
             "text": "{T}: Add {B} to your mana pool. Tomb of Urami deals 1 damage to you if you don't control an Ogre.\n{2}{B}{B}, {T}, Sacrifice all lands you control: Put a legendary 5/5 black Demon Spirit creature token with flying named Urami into play.",
             "colours": [],

--- a/Assets/Resources/Sets/SOM.json
+++ b/Assets/Resources/Sets/SOM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "116a354a-aa21-5431-89a1-2891d8040895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e17bbf7-00c0-46f2-9718-2762fd7388d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e17bbf7-00c0-46f2-9718-2762fd7388d3.jpg?1",
             "name": "Abuna Acolyte",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\n{T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "3d90e43f-e4c2-5c2a-a68c-5529d94f421a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52d6cf9-1d92-4d3b-8631-0db19a073b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52d6cf9-1d92-4d3b-8631-0db19a073b44.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "669585f9-c691-500c-a677-624dbf634362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f76b18a-396b-41f5-b34b-ac232b7f316b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f76b18a-396b-41f5-b34b-ac232b7f316b.jpg?1",
             "name": "Auriok Edgewright",
             "text": "Metalcraft \u2014 Auriok Edgewright has double strike as long as you control three or more artifacts.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "edd41970-82c5-5af9-80cb-e1523fbf1eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e274a8b3-2d92-43d9-a436-d3f6f619ca95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e274a8b3-2d92-43d9-a436-d3f6f619ca95.jpg?1",
             "name": "Auriok Sunchaser",
             "text": "Metalcraft \u2014 As long as you control three or more artifacts, Auriok Sunchaser gets +2/+2 and has flying.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "a1865a89-27bd-53cc-a0be-3aa8efed372b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3330a1-98b6-4b09-9bca-6c7c89447ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3330a1-98b6-4b09-9bca-6c7c89447ba2.jpg?1",
             "name": "Dispense Justice",
             "text": "Target player sacrifices an attacking creature.\nMetalcraft \u2014 That player sacrifices two attacking creatures instead if you control three or more artifacts.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "4883a163-501c-56cc-8b5a-4e6e402852c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9116e-7b04-4f2a-aa67-89a42c6e1801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9116e-7b04-4f2a-aa67-89a42c6e1801.jpg?1",
             "name": "Elspeth Tirel",
             "text": "+2: You gain 1 life for each creature you control.\n-2: Put three 1/1 white Soldier creature tokens onto the battlefield.\n-5: Destroy all other permanents except\nfor lands and tokens.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "3f30989f-bdab-5578-a0ac-7dad0f7c7b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33a8cf1-e413-4633-b348-2ef594a945a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33a8cf1-e413-4633-b348-2ef594a945a5.jpg?1",
             "name": "Fulgent Distraction",
             "text": "Choose two target creatures. Tap those creatures, then unattach all Equipment from them.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "c3a4e163-c1a1-596f-bfaf-f435743210ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbf5ff1-6539-4116-ad4f-ce412ae20640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbf5ff1-6539-4116-ad4f-ce412ae20640.jpg?1",
             "name": "Ghalma's Warden",
             "text": "Metalcraft \u2014 Ghalma's Warden gets +2/+2 as long as you control three or more artifacts.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "94b5d736-be66-5e2f-898a-28ab71761d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb553f3-b1f6-47e7-94c1-8c09410c7163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb553f3-b1f6-47e7-94c1-8c09410c7163.jpg?1",
             "name": "Glimmerpoint Stag",
             "text": "Vigilance\nWhen Glimmerpoint Stag enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "81f8333a-4dd1-539f-a9a7-d2c0587ca188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c4710-4183-4743-9c8b-515cc98cbbb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c4710-4183-4743-9c8b-515cc98cbbb8.jpg?1",
             "name": "Glint Hawk",
             "text": "Flying\nWhen Glint Hawk enters the battlefield, sacrifice it unless you return an artifact you control to its owner's hand.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "fc1ec09b-a727-5440-8198-ab866950d00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50e72a2-1e94-43cf-a605-bf3bb456d12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50e72a2-1e94-43cf-a605-bf3bb456d12f.jpg?1",
             "name": "Indomitable Archangel",
             "text": "Flying\nMetalcraft \u2014 Artifacts you control have shroud as long as you control three or more artifacts.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "5897dad3-3ccc-5809-b99f-644088a20827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1964ca48-3260-4e2d-9014-984c1efc9a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1964ca48-3260-4e2d-9014-984c1efc9a43.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, put a 2/2 white Cat creature token onto the battlefield for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "be9e802d-efc0-51ba-a9af-b9f1096ad31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f20a74-7614-4bd9-ac08-0e098f98df0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f20a74-7614-4bd9-ac08-0e098f98df0c.jpg?1",
             "name": "Kemba's Skyguard",
             "text": "Flying\nWhen Kemba's Skyguard enters the battlefield, you gain 2 life.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "62f24a52-4303-5b1d-bea8-d60b2c3f031a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0453cd-62ab-41ba-8d9c-9d6d25dc9a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0453cd-62ab-41ba-8d9c-9d6d25dc9a56.jpg?1",
             "name": "Leonin Arbiter",
             "text": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "d2109b0a-e870-5a15-b97a-1783eda6dd43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356c5e6a-c0bd-43f7-bc84-a6ae8718a7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356c5e6a-c0bd-43f7-bc84-a6ae8718a7a2.jpg?1",
             "name": "Loxodon Wayfarer",
             "text": "",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "369a9e4f-06c8-5baf-9f3d-c722437ed2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13429b63-085c-4c78-9ce3-247db5841b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13429b63-085c-4c78-9ce3-247db5841b9d.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [
@@ -557,7 +557,7 @@
         },
         {
             "id": "c4257147-f419-56c6-bab6-c0772631adfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7ac3bf-eed2-417d-8b60-e8c84bfb98ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7ac3bf-eed2-417d-8b60-e8c84bfb98ab.jpg?1",
             "name": "Razor Hippogriff",
             "text": "Flying\nWhen Razor Hippogriff enters the battlefield, return target artifact card from your graveyard to your hand. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -591,7 +591,7 @@
         },
         {
             "id": "3b16d502-d91e-51e7-930b-6d1c845371f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ae62f9-361c-4849-b0af-2b08fc0421c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ae62f9-361c-4849-b0af-2b08fc0421c8.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "3009d6fb-4b95-538a-ba71-d48f1d9f2a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5909e77e-a930-4713-bca4-c6b265238c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5909e77e-a930-4713-bca4-c6b265238c17.jpg?1",
             "name": "Salvage Scout",
             "text": "{W}, Sacrifice Salvage Scout: Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -658,7 +658,7 @@
         },
         {
             "id": "8c4719f5-5d9d-5498-ac60-0ce1276e4c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d745f35-944a-4157-a351-baa06f67b725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d745f35-944a-4157-a351-baa06f67b725.jpg?1",
             "name": "Seize the Initiative",
             "text": "Target creature gets +1/+1 and gains first strike until end of turn.",
             "colours": [
@@ -690,7 +690,7 @@
         },
         {
             "id": "a3bd04f1-559c-5893-97c3-f07877abd6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e241ea47-cbbe-4241-94f9-315cc7cfd79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e241ea47-cbbe-4241-94f9-315cc7cfd79b.jpg?1",
             "name": "Soul Parry",
             "text": "Prevent all damage one or two target creatures would deal this turn.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "822ff758-f2a1-5f86-83c0-711c1b496801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32217d3b-8a44-40e3-a4fd-c849fdffc1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32217d3b-8a44-40e3-a4fd-c849fdffc1e4.jpg?1",
             "name": "Sunblast Angel",
             "text": "Flying\nWhen Sunblast Angel enters the battlefield, destroy all tapped creatures.",
             "colours": [
@@ -756,7 +756,7 @@
         },
         {
             "id": "3a29328c-c0be-5f0d-87c1-0d0e465487d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac29ef-02e1-4500-bb83-5987beeaa849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac29ef-02e1-4500-bb83-5987beeaa849.jpg?1",
             "name": "Sunspear Shikari",
             "text": "As long as Sunspear Shikari is equipped, it has first strike and lifelink.",
             "colours": [
@@ -791,7 +791,7 @@
         },
         {
             "id": "231d9b07-265c-51e5-85cd-522509c4eaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6661b39d-505a-48f4-bc06-59084c6a3b0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6661b39d-505a-48f4-bc06-59084c6a3b0c.jpg?1",
             "name": "Tempered Steel",
             "text": "Artifact creatures you control get +2/+2.",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "7108b3c6-6b45-509b-8467-4c6e9e9f837e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a1d384-1b36-42d0-957f-48103f9cdbdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a1d384-1b36-42d0-957f-48103f9cdbdd.jpg?1",
             "name": "True Conviction",
             "text": "Creatures you control have double strike and lifelink.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "53366845-32f2-5329-813e-d7f61fb3dab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a87b48b-2ae9-4753-8719-62411f94ca87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a87b48b-2ae9-4753-8719-62411f94ca87.jpg?1",
             "name": "Vigil for the Lost",
             "text": "Whenever a creature you control is put into a graveyard from the battlefield, you may pay {X}. If you do, you gain X life.",
             "colours": [
@@ -887,7 +887,7 @@
         },
         {
             "id": "423032c6-4acb-5901-92a6-800e60e7fd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d1bf3-4630-4be0-af5f-590789d27a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d1bf3-4630-4be0-af5f-590789d27a0c.jpg?1",
             "name": "Whitesun's Passage",
             "text": "You gain 5 life.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "b6e42188-cdf0-5181-b955-cd345cbc8804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e75af-7e43-4c15-a8a8-bec7389c6c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e75af-7e43-4c15-a8a8-bec7389c6c4e.jpg?1",
             "name": "Argent Sphinx",
             "text": "Flying\nMetalcraft \u2014 {U}: Exile Argent Sphinx. Return it to the battlefield under your control at the beginning of the next end step. Activate this ability only if you control three or more artifacts.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "2539237f-964a-51b2-b231-faa90e68ab4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c071dca0-fccb-48b8-b65a-74741b12e3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c071dca0-fccb-48b8-b65a-74741b12e3f0.jpg?1",
             "name": "Bonds of Quicksilver",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "8fdf6421-242f-5fbf-8b26-5f514dd2fddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234f4131-1e7f-4220-b46c-bb4a6713876e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234f4131-1e7f-4220-b46c-bb4a6713876e.jpg?1",
             "name": "Darkslick Drake",
             "text": "Flying\nWhen Darkslick Drake is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "fb113368-cd90-5102-a6e0-3cf0444b2b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1572457f-90e0-4ffc-a403-6f877c6a8186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1572457f-90e0-4ffc-a403-6f877c6a8186.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "674f0eeb-dcbd-549a-8ae0-2611cc2fb534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247694c5-5813-4256-9fd8-478d4be52081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247694c5-5813-4256-9fd8-478d4be52081.jpg?1",
             "name": "Dissipation Field",
             "text": "Whenever a permanent deals damage to you, return it to its owner's hand.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "aebd21fe-1737-528c-8160-c043e501be0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59599de-c781-4c26-a159-cbf0cd72d361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59599de-c781-4c26-a159-cbf0cd72d361.jpg?1",
             "name": "Grand Architect",
             "text": "Other blue creatures you control get +1/+1.\n{U}: Target artifact creature becomes blue until end of turn.\nTap an untapped blue creature you control: Add {2} to your mana pool. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "eab98698-4096-5f6e-be0c-3848e0d8fe18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fed18af-7301-4d03-ba7c-e94f07f078b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fed18af-7301-4d03-ba7c-e94f07f078b3.jpg?1",
             "name": "Halt Order",
             "text": "Counter target artifact spell.\nDraw a card.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "6b4b4a0a-d9c8-55ae-8317-43ea95d8ebc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41e281-fcbb-450b-8a67-7b072c55c6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41e281-fcbb-450b-8a67-7b072c55c6f0.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "e51e43e3-768e-5841-bd6f-28657c7210ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e9820-2209-40a2-bc4f-46b440c05e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e9820-2209-40a2-bc4f-46b440c05e9d.jpg?1",
             "name": "Lumengrid Drake",
             "text": "Flying\nMetalcraft \u2014 When Lumengrid Drake enters the battlefield, if you control three or more artifacts, return target creature to its owner's hand.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "ab123ec3-6092-5ce2-a761-daec864cca15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88f78f4-77d8-4c3e-a5bf-a9dd902aaae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88f78f4-77d8-4c3e-a5bf-a9dd902aaae1.jpg?1",
             "name": "Neurok Invisimancer",
             "text": "Neurok Invisimancer is unblockable.\nWhen Neurok Invisimancer enters the battlefield, target creature is unblockable this turn.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "3643ddbc-3573-50e8-bc20-d2174ff34b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97171611-c677-48a6-b081-98a27ecef979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97171611-c677-48a6-b081-98a27ecef979.jpg?1",
             "name": "Plated Seastrider",
             "text": "",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "27b26876-de5f-5ce5-b8ce-56a49f87b40e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f5aea-80f2-4f3d-8508-9619413e0087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f5aea-80f2-4f3d-8508-9619413e0087.jpg?1",
             "name": "Quicksilver Gargantuan",
             "text": "You may have Quicksilver Gargantuan enter the battlefield as a copy of any creature on the battlefield, except it's still 7/7.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "75f8af9d-0e14-50d1-a1c0-6ddf331a63e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e25713-05ea-4eed-aa7f-5ca4e57a8152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e25713-05ea-4eed-aa7f-5ca4e57a8152.jpg?1",
             "name": "Riddlesmith",
             "text": "Whenever you cast an artifact spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "9a636637-7353-5a52-bc6b-8004769e6545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b5db0-7d2c-4337-b1c4-9e1219f603c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b5db0-7d2c-4337-b1c4-9e1219f603c7.jpg?1",
             "name": "Scrapdiver Serpent",
             "text": "Scrapdiver Serpent is unblockable as long as defending player controls an artifact.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "910e33df-8fa4-5aee-9847-24e74d623bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1767355d-82a2-495e-ae95-d91984a9c62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1767355d-82a2-495e-ae95-d91984a9c62a.jpg?1",
             "name": "Screeching Silcaw",
             "text": "Flying\nMetalcraft \u2014 Whenever Screeching Silcaw deals combat damage to a player, if you control three or more artifacts, that player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "68fa7911-b55c-5976-a34e-64695547daf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5462e-f60c-4550-b29e-4d9f9cd72385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5462e-f60c-4550-b29e-4d9f9cd72385.jpg?1",
             "name": "Shape Anew",
             "text": "The controller of target artifact sacrifices it, then reveals cards from the top of his or her library until he or she reveals an artifact card. That player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "69a9d6e4-d840-5dac-aa97-82366f610e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc4db7-13b5-4c88-91f2-581c9792f1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc4db7-13b5-4c88-91f2-581c9792f1ff.jpg?1",
             "name": "Sky-Eel School",
             "text": "Flying\nWhen Sky-Eel School enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "b0be3ab8-8456-5389-a62b-1c425bfafda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe212ed-31cb-4f10-8ba7-e97af1d30d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe212ed-31cb-4f10-8ba7-e97af1d30d24.jpg?1",
             "name": "Steady Progress",
             "text": "Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)\nDraw a card.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "e5e998bb-7892-5684-9a04-72d564540937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2805239-f30a-4eca-a10b-41673daaa287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2805239-f30a-4eca-a10b-41673daaa287.jpg?1",
             "name": "Stoic Rebuttal",
             "text": "Metalcraft \u2014 Stoic Rebuttal costs {1} less to cast if you control three or more artifacts.\nCounter target spell.",
             "colours": [
@@ -1555,7 +1555,7 @@
         },
         {
             "id": "1e6d17ee-84dc-5d36-b297-376d945a779f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2dd336-e457-49a1-88ae-c35f0c846e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2dd336-e457-49a1-88ae-c35f0c846e99.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "66160dd6-6de4-5fb1-8298-0f9374e685e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb52e7ba-5340-44e1-9b63-775e1f387925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb52e7ba-5340-44e1-9b63-775e1f387925.jpg?1",
             "name": "Trinket Mage",
             "text": "When Trinket Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "147fe93a-fd02-5a5d-83f1-63b156589e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56226f57-6ff0-430e-aba6-6b3dd51f8d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56226f57-6ff0-430e-aba6-6b3dd51f8d3c.jpg?1",
             "name": "Turn Aside",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -1658,7 +1658,7 @@
         },
         {
             "id": "5983b6cd-f5dd-5359-8226-275f80be6554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa18c2c2-f1a1-469d-acd8-9d6e0605bcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa18c2c2-f1a1-469d-acd8-9d6e0605bcf9.jpg?1",
             "name": "Twisted Image",
             "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "90595c42-703c-511d-9831-b5a473dfbf57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934192-2ea3-48fe-a2a9-42c2ee9b22f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934192-2ea3-48fe-a2a9-42c2ee9b22f7.jpg?1",
             "name": "Vault Skyward",
             "text": "Target creature gains flying until end of turn. Untap it.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "8cce22f2-64c3-5e9f-b98b-b33a5f3e58bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbc2a26-32f1-4d9c-8ee7-74698f64dce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbc2a26-32f1-4d9c-8ee7-74698f64dce0.jpg?1",
             "name": "Vedalken Certarch",
             "text": "Metalcraft \u2014 {T}: Tap target artifact, creature, or land. Activate this ability only if you control three or more artifacts.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "8ba68112-4be3-5126-9d52-3668c8347cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8fa025-56e6-4d24-a615-a51b6be937e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8fa025-56e6-4d24-a615-a51b6be937e9.jpg?1",
             "name": "Volition Reins",
             "text": "Enchant permanent\nWhen Volition Reins enters the battlefield, if enchanted permanent is tapped, untap it.\nYou control enchanted permanent.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "735b8149-7073-528e-b369-cbcbbc880e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95986875-59f5-414f-867f-94f30cefa5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95986875-59f5-414f-867f-94f30cefa5d6.jpg?1",
             "name": "Blackcleave Goblin",
             "text": "Haste\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "f8aca348-cf0e-5c37-a26d-39606f091502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3386e4-bbd6-4756-b29d-f55619e98d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3386e4-bbd6-4756-b29d-f55619e98d0d.jpg?1",
             "name": "Bleak Coven Vampires",
             "text": "Metalcraft \u2014 When Bleak Coven Vampires enters the battlefield, if you control three or more artifacts, target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "d3d1946e-fa7a-5a59-b22a-976c38959235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5431debc-0037-49ff-a38f-3fa2f9f5ee33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5431debc-0037-49ff-a38f-3fa2f9f5ee33.jpg?1",
             "name": "Blistergrub",
             "text": "Swampwalk\nWhen Blistergrub is put into a graveyard from the battlefield, each opponent loses 2 life.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "cd8b32f4-0cbc-5ca5-b770-f9dea6486410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191dba2-659d-40e7-a558-c99ece872197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191dba2-659d-40e7-a558-c99ece872197.jpg?1",
             "name": "Carnifex Demon",
             "text": "Flying\nCarnifex Demon enters the battlefield with two -1/-1 counters on it.\n{B}, Remove a -1/-1 counter from Carnifex Demon: Put a -1/-1 counter on each other creature.",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "29a41d54-e82c-5273-9f60-98ff3184e491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a9dea-2aa1-48cd-afe2-f98057b95f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a9dea-2aa1-48cd-afe2-f98057b95f6e.jpg?1",
             "name": "Contagious Nim",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "e49480fe-df66-5a1f-b0d4-830f6a18eca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54625ac-484f-4522-8048-38e01c545ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54625ac-484f-4522-8048-38e01c545ac3.jpg?1",
             "name": "Corrupted Harvester",
             "text": "{B}, Sacrifice a creature: Regenerate Corrupted Harvester.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "3d94c809-3423-5c79-9665-52ddc3e1c453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0656f6-a016-479a-a003-72e106e986b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0656f6-a016-479a-a003-72e106e986b0.jpg?1",
             "name": "Dross Hopper",
             "text": "Sacrifice a creature: Dross Hopper gains flying until end of turn.",
             "colours": [
@@ -2038,7 +2038,7 @@
         },
         {
             "id": "7cda8b30-2a5d-59e8-89ee-41cc356219be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878b541-a730-49db-b062-5a01656e269d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878b541-a730-49db-b062-5a01656e269d.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "f841865f-8d2a-5a51-bf24-1487f94e032c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c729525-b954-42dd-9877-f4360d99b961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c729525-b954-42dd-9877-f4360d99b961.jpg?1",
             "name": "Flesh Allergy",
             "text": "As an additional cost to cast Flesh Allergy, sacrifice a creature.\nDestroy target creature. Its controller loses life equal to the number of creatures put into all graveyards from the battlefield this turn.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "6ebb9805-3b84-56c7-acce-b7ac58b1dddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cd149b-ecf4-43ed-b6e5-98870953b4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cd149b-ecf4-43ed-b6e5-98870953b4b8.jpg?1",
             "name": "Fume Spitter",
             "text": "Sacrifice Fume Spitter: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "e6567b20-26fb-5d01-b1b7-841bb0b0a777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed31f2f-370d-4bbe-aa57-82249ed1b4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed31f2f-370d-4bbe-aa57-82249ed1b4d4.jpg?1",
             "name": "Geth, Lord of the Vault",
             "text": "Intimidate\n{X}{B}: Put target artifact or creature card with converted mana cost X from an opponent's graveyard onto the battlefield under your control tapped. Then that player puts the top X cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "c3d8406d-7f44-5cbb-8c96-9ef4a5e120d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda628ba-19f4-4e24-9500-cca295a992bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda628ba-19f4-4e24-9500-cca295a992bb.jpg?1",
             "name": "Grasp of Darkness",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "548218a7-db25-544e-a3f6-ddad80793e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca493e-f09b-4b11-bb47-0562dfc203ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca493e-f09b-4b11-bb47-0562dfc203ca.jpg?1",
             "name": "Hand of the Praetors",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nOther creatures you control with infect get +1/+1.\nWhenever you cast a creature spell with infect, target player gets a poison counter.",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "439a8fc0-f91e-5226-9378-1a5f4e143327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013aed6-7415-4bf0-a3bb-46d6beecbaff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013aed6-7415-4bf0-a3bb-46d6beecbaff.jpg?1",
             "name": "Ichor Rats",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Ichor Rats enters the battlefield, each player gets a poison counter.",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "02978515-f8c8-5afe-8d80-46dcf509926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef2567-f798-4447-9735-c7c0d88aba85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef2567-f798-4447-9735-c7c0d88aba85.jpg?1",
             "name": "Instill Infection",
             "text": "Put a -1/-1 counter on target creature.\nDraw a card.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "847187d7-03ad-51aa-98e4-bbd6fefbdd08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc5b944-a9fe-4a64-bf11-51817a26f22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc5b944-a9fe-4a64-bf11-51817a26f22b.jpg?1",
             "name": "Memoricide",
             "text": "Name a nonland card. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "3725872d-69e7-5fef-9808-86e5cd027704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a0410f-95c5-49bf-856d-dea796c96e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a0410f-95c5-49bf-856d-dea796c96e3b.jpg?1",
             "name": "Moriok Reaver",
             "text": "",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "ed2a3294-e470-50ee-8557-ed3afb54b506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d69c045-d705-478b-9e8f-272a24737225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d69c045-d705-478b-9e8f-272a24737225.jpg?1",
             "name": "Necrogen Scudder",
             "text": "Flying\nWhen Necrogen Scudder enters the battlefield, you lose 3 life.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "692b459a-907b-5757-ac9c-4bb44d722384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2c79f-a151-4628-90fe-c0ff7ccd9c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2c79f-a151-4628-90fe-c0ff7ccd9c2c.jpg?1",
             "name": "Necrotic Ooze",
             "text": "As long as Necrotic Ooze is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
             "colours": [
@@ -2444,7 +2444,7 @@
         },
         {
             "id": "efcfcd26-febb-5eba-a258-d41fded27a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecf3dae-1a0c-4cf3-b9bd-ec2ad6acaa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecf3dae-1a0c-4cf3-b9bd-ec2ad6acaa1b.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless he or she discards a card.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "caaae53b-770f-5531-80a6-650ad560b8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e531ab-29ed-4e54-ae9c-681a220666ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e531ab-29ed-4e54-ae9c-681a220666ad.jpg?1",
             "name": "Painsmith",
             "text": "Whenever you cast an artifact spell, you may have target creature get +2/+0 and gain deathtouch until end of turn.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "48ad23dd-06b8-587a-a97c-ae4f5234c20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae856bc-f65f-42ba-9344-1a30b356c041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae856bc-f65f-42ba-9344-1a30b356c041.jpg?1",
             "name": "Plague Stinger",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "02b24252-def9-5979-a4a5-87f02ead102d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9c3267-7988-416c-85a4-0e314e42ddb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9c3267-7988-416c-85a4-0e314e42ddb9.jpg?1",
             "name": "Psychic Miasma",
             "text": "Target player discards a card. If a land card is discarded this way, return Psychic Miasma to its owner's hand.",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "052548e8-6b6c-582d-934e-f90064c3295d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca940b4e-6f5e-4492-b6e0-dbf619eddadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca940b4e-6f5e-4492-b6e0-dbf619eddadd.jpg?1",
             "name": "Relic Putrescence",
             "text": "Enchant artifact\nWhenever enchanted artifact becomes tapped, its controller gets a poison counter.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "9a5c98ca-d5a3-558d-9ead-bc49dcda7ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be358357-2abe-4ead-bb18-76cad8274489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be358357-2abe-4ead-bb18-76cad8274489.jpg?1",
             "name": "Skinrender",
             "text": "When Skinrender enters the battlefield, put three -1/-1 counters on target creature.",
             "colours": [
@@ -2648,7 +2648,7 @@
         },
         {
             "id": "c5425ac3-e7e2-557e-ab91-31948e1e2184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c930c9cc-1b64-4f36-afe2-6bf120a74ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c930c9cc-1b64-4f36-afe2-6bf120a74ce2.jpg?1",
             "name": "Skithiryx, the Blight Dragon",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{B}: Skithiryx, the Blight Dragon gains haste until end of turn.\n{B}{B}: Regenerate Skithiryx.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "ee7eacb3-ac16-54a4-97b6-e16725f372ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f82007-99f6-4c6c-8182-ee631c33531f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f82007-99f6-4c6c-8182-ee631c33531f.jpg?1",
             "name": "Tainted Strike",
             "text": "Target creature gets +1/+0 and gains infect until end of turn. (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "967d7d8b-d1cf-5681-8d7a-309f1e740b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e3a0a-29a7-4dc0-80fe-569b9e751db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e3a0a-29a7-4dc0-80fe-569b9e751db3.jpg?1",
             "name": "Arc Trail",
             "text": "Arc Trail deals 2 damage to target creature or player and 1 damage to another target creature or player.",
             "colours": [
@@ -2750,7 +2750,7 @@
         },
         {
             "id": "bedad837-5f8c-544f-a70f-be6861e6b3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b505c78-5dbd-483d-92bb-5144060e962f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b505c78-5dbd-483d-92bb-5144060e962f.jpg?1",
             "name": "Assault Strobe",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "be60b273-ba2c-5ec6-9797-bdcac722fa89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c6f71-2448-47e1-9133-7af6a4d4577a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c6f71-2448-47e1-9133-7af6a4d4577a.jpg?1",
             "name": "Barrage Ogre",
             "text": "{T}, Sacrifice an artifact: Barrage Ogre deals 2 damage to target creature or player.",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "e47346b1-3c26-5ba5-b349-518fae9500ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd124bb-1ed1-469c-8527-d7261ea720b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd124bb-1ed1-469c-8527-d7261ea720b9.jpg?1",
             "name": "Blade-Tribe Berserkers",
             "text": "Metalcraft \u2014 When Blade-Tribe Berserkers enters the battlefield, if you control three or more artifacts, Blade-Tribe Berserkers gets +3/+3 and gains haste until end of turn.",
             "colours": [
@@ -2852,7 +2852,7 @@
         },
         {
             "id": "b692d3e8-1924-5960-a3bc-e45ba424562d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5ce81-6cca-4990-a515-34ac44cae039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5ce81-6cca-4990-a515-34ac44cae039.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "5468467a-d7c5-5640-bab7-80bf5c59bbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77161159-ee2c-485d-8674-d8590ccc62e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77161159-ee2c-485d-8674-d8590ccc62e1.jpg?1",
             "name": "Cerebral Eruption",
             "text": "Target opponent reveals the top card of his or her library. Cerebral Eruption deals damage equal to the revealed card's converted mana cost to that player and each creature he or she controls. If a land card is revealed this way, return Cerebral Eruption to its owner's hand.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "005879e4-0fd0-5508-b175-5275d4a2677d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee86cfc8-9faa-474c-90a9-5405f3f6037c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee86cfc8-9faa-474c-90a9-5405f3f6037c.jpg?1",
             "name": "Embersmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, Embersmith deals 1 damage to target creature or player.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "9e3cdb0c-b0a4-57c3-b3ca-18d5ce521478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcc7170-38d9-4b9e-a5f9-73ac1208c439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcc7170-38d9-4b9e-a5f9-73ac1208c439.jpg?1",
             "name": "Ferrovore",
             "text": "{R}, Sacrifice an artifact: Ferrovore gets +3/+0 until end of turn.",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "fab765e7-fe5e-5490-b554-5cdcf0e38368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0e5f5-b51a-4386-827b-c0eb8c877efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0e5f5-b51a-4386-827b-c0eb8c877efb.jpg?1",
             "name": "Flameborn Hellion",
             "text": "Haste\nFlameborn Hellion attacks each turn if able.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "9c84746b-6ecd-5ffb-a1d4-bc825eb794c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21fa7cb-a8ac-4312-80d4-82ee87650a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21fa7cb-a8ac-4312-80d4-82ee87650a55.jpg?1",
             "name": "Furnace Celebration",
             "text": "Whenever you sacrifice another permanent, you may pay {2}. If you do, Furnace Celebration deals 2 damage to target creature or player.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "60834b42-64dc-572a-8438-631417312191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5881bbc-8600-464d-9dcd-5a7780918d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5881bbc-8600-464d-9dcd-5a7780918d1d.jpg?1",
             "name": "Galvanic Blast",
             "text": "Galvanic Blast deals 2 damage to target creature or player.\nMetalcraft \u2014 Galvanic Blast deals 4 damage to that creature or player instead if you control three or more artifacts.",
             "colours": [
@@ -3086,7 +3086,7 @@
         },
         {
             "id": "d1876664-591a-59d0-ac30-7ea974303a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65af25-8007-415d-a3fa-7736f6118284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65af25-8007-415d-a3fa-7736f6118284.jpg?1",
             "name": "Goblin Gaveleer",
             "text": "Trample\nGoblin Gaveleer gets +2/+0 for each Equipment attached to it.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "cc7bfd65-4a93-5190-ac17-2caf39b4933f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdd1d89-719d-4552-aeae-499c09b2ec6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdd1d89-719d-4552-aeae-499c09b2ec6e.jpg?1",
             "name": "Hoard-Smelter Dragon",
             "text": "Flying\n{3}{R}: Destroy target artifact. Hoard-Smelter Dragon gets +X/+0 until end of turn, where X is that artifact's converted mana cost.",
             "colours": [
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "131b8963-eeac-5c4b-a551-6f0a584c11dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b9c79-a161-4d7d-944d-82a44a5f2ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b9c79-a161-4d7d-944d-82a44a5f2ab9.jpg?1",
             "name": "Koth of the Hammer",
             "text": "+1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.\n-2: Add {R} to your mana pool for each Mountain you control.\n-5: You get an emblem with \"Mountains you control have \u2018{T}: This land deals 1 damage to target creature or player.'\"",
             "colours": [
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "f628d312-cb02-5971-9d0a-c535313db50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb79b56-81f1-417f-b5ad-030ad29f904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb79b56-81f1-417f-b5ad-030ad29f904b.jpg?1",
             "name": "Kuldotha Phoenix",
             "text": "Flying, haste\nMetalcraft \u2014 {4}: Return Kuldotha Phoenix from your graveyard to the battlefield. Activate this ability only during your upkeep and only if you control three or more artifacts.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "76422066-3b3b-57ba-a17d-b4719b9f6437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee07266-a95d-4cd8-9863-1664922e9490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee07266-a95d-4cd8-9863-1664922e9490.jpg?1",
             "name": "Kuldotha Rebirth",
             "text": "As an additional cost to cast Kuldotha Rebirth, sacrifice an artifact.\nPut three 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "e9cf87a0-9b2e-53be-ac23-7b77dd7520cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94a1d1-6d24-46e1-9568-42e1a810ad31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94a1d1-6d24-46e1-9568-42e1a810ad31.jpg?1",
             "name": "Melt Terrain",
             "text": "Destroy target land. Melt Terrain deals 2 damage to that land's controller.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "ccbe3ddf-dd99-5aa9-99d4-72742eeeb316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2382d-1f27-40d1-b809-c188c19ebc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2382d-1f27-40d1-b809-c188c19ebc72.jpg?1",
             "name": "Molten Psyche",
             "text": "Each player shuffles the cards from his or her hand into his or her library, then draws that many cards.\nMetalcraft \u2014 If you control three or more artifacts, Molten Psyche deals damage to each opponent equal to the number of cards that player has drawn this turn.",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "05017f71-81c6-59f1-a5eb-62af43ee5908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f6e2c3-0e0d-47ff-9d92-afc86a8c8aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f6e2c3-0e0d-47ff-9d92-afc86a8c8aac.jpg?1",
             "name": "Ogre Geargrabber",
             "text": "Whenever Ogre Geargrabber attacks, gain control of target Equipment an opponent controls until end of turn. Attach it to Ogre Geargrabber. When you lose control of that Equipment, unattach it.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "7bfb5e99-88b0-51dd-9975-c87e5e85217e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bde7b-dc2d-45d2-b124-69b4b51ef3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bde7b-dc2d-45d2-b124-69b4b51ef3d9.jpg?1",
             "name": "Oxidda Daredevil",
             "text": "Sacrifice an artifact: Oxidda Daredevil gains haste until end of turn.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "c6703068-1b93-5a28-8ca0-f950266cc460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64fe85b-e471-489a-8c38-2357da1c7969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64fe85b-e471-489a-8c38-2357da1c7969.jpg?1",
             "name": "Oxidda Scrapmelter",
             "text": "When Oxidda Scrapmelter enters the battlefield, destroy target artifact.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "5c146a24-8f3f-5b0d-aa7c-d34c083c8497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d9198-52a7-4dfe-8f7f-4fa6e19a2479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d9198-52a7-4dfe-8f7f-4fa6e19a2479.jpg?1",
             "name": "Scoria Elemental",
             "text": "",
             "colours": [
@@ -3459,7 +3459,7 @@
         },
         {
             "id": "d1c9c868-fe90-5a28-9610-5360ac4b46e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d70f7e-5ae9-455f-8430-123623920a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d70f7e-5ae9-455f-8430-123623920a92.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "d3da4b00-c23d-50d5-9995-8edf7cf0fd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad5621d-eb77-4b4a-80e7-1bfa75a6fcfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad5621d-eb77-4b4a-80e7-1bfa75a6fcfb.jpg?1",
             "name": "Spikeshot Elder",
             "text": "{1}{R}{R}: Spikeshot Elder deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "cbd6ee7a-bd83-5cfc-a29a-f5027d4413f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3016e6b-32b2-4fa7-91c0-ec8fbe345760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3016e6b-32b2-4fa7-91c0-ec8fbe345760.jpg?1",
             "name": "Tunnel Ignus",
             "text": "Whenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under his or her control this turn, Tunnel Ignus deals 3 damage to that player.",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "dd2db92e-df0d-54f6-8e42-f5851b59aaed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fd5b49-b4f2-40da-94d5-6d6fc69506f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fd5b49-b4f2-40da-94d5-6d6fc69506f6.jpg?1",
             "name": "Turn to Slag",
             "text": "Turn to Slag deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "9cee4c80-2f68-522d-a4e3-88ffbd24b1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3152bc-5c59-4e98-95de-a51de05a3c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3152bc-5c59-4e98-95de-a51de05a3c98.jpg?1",
             "name": "Vulshok Heartstoker",
             "text": "When Vulshok Heartstoker enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "e689acce-2500-5cf3-9499-56d86f22b414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a25a5-9ec1-47fa-bf1f-e65eb75fdb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a25a5-9ec1-47fa-bf1f-e65eb75fdb00.jpg?1",
             "name": "Acid Web Spider",
             "text": "Reach\nWhen Acid Web Spider enters the battlefield, you may destroy target Equipment.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "ef685bf7-87d2-575f-83d2-04221aba8a2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e5279-f28c-4a78-9f8a-16c9f72f8d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e5279-f28c-4a78-9f8a-16c9f72f8d38.jpg?1",
             "name": "Alpha Tyrranax",
             "text": "",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "2946d60e-6493-5fce-9738-e60a9c56ca50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg?1",
             "name": "Asceticism",
             "text": "Creatures you control can't be the targets of spells or abilities your opponents control.\n{1}{G}: Regenerate target creature.",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "0c3c2bb1-0ed9-5f26-bedd-e1390eb8528d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44eb3e3a-60ee-4293-a321-daa452d4c70d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44eb3e3a-60ee-4293-a321-daa452d4c70d.jpg?1",
             "name": "Bellowing Tanglewurm",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nOther green creatures you control have intimidate.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "44bca4c8-afdc-5319-8d70-284847030b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b3335-565c-406d-bd94-f36974602552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b3335-565c-406d-bd94-f36974602552.jpg?1",
             "name": "Blight Mamba",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{1}{G}: Regenerate Blight Mamba.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "0a0f1783-67c3-5c94-8fc8-a49a4a750824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecff12a-37d5-4a7b-b615-4c5e3bd950bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecff12a-37d5-4a7b-b615-4c5e3bd950bb.jpg?1",
             "name": "Blunt the Assault",
             "text": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "4bd76b92-4922-54b4-b146-7d353e9b5592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9948e4c-d583-4fde-a305-df926cf00199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9948e4c-d583-4fde-a305-df926cf00199.jpg?1",
             "name": "Carapace Forger",
             "text": "Metalcraft \u2014 Carapace Forger gets +2/+2 as long as you control three or more artifacts.",
             "colours": [
@@ -3864,7 +3864,7 @@
         },
         {
             "id": "99fac9be-4698-5c49-84a1-83e66930204d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c1a8e-3bdb-42cf-9442-5de7e4670d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c1a8e-3bdb-42cf-9442-5de7e4670d66.jpg?1",
             "name": "Carrion Call",
             "text": "Put two 1/1 green Insect creature tokens with infect onto the battlefield. (They deal damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "0dcb1a28-5162-5320-aa26-8729c86f615b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7f99e-7324-4d16-b163-8f1b2edb7b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7f99e-7324-4d16-b163-8f1b2edb7b89.jpg?1",
             "name": "Copperhorn Scout",
             "text": "Whenever Copperhorn Scout attacks, untap each other creature you control.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "2d89c1d9-f215-50f3-a6e7-7b68fa71760d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c10302-f0b3-4076-ae5c-a8c8c09a7d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c10302-f0b3-4076-ae5c-a8c8c09a7d41.jpg?1",
             "name": "Cystbearer",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "6773272c-88d5-5643-8aef-b45992783461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeabc4a-7b4f-4e3d-bcc7-423bb703563a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeabc4a-7b4f-4e3d-bcc7-423bb703563a.jpg?1",
             "name": "Engulfing Slagwurm",
             "text": "Whenever Engulfing Slagwurm blocks or becomes blocked by a creature, destroy that creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "8f21ee62-438e-55b8-95de-933caf33b1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9544132-bbb5-4ec4-af82-dad56e5091af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9544132-bbb5-4ec4-af82-dad56e5091af.jpg?1",
             "name": "Ezuri, Renegade Leader",
             "text": "{G}: Regenerate another target Elf.\n{2}{G}{G}{G}: Elf creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "6951c244-7233-5777-8e7f-188c92720c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cc93af-d9a0-4ed8-8c22-686d005ea77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cc93af-d9a0-4ed8-8c22-686d005ea77e.jpg?1",
             "name": "Ezuri's Archers",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Ezuri's Archers blocks a creature with flying, Ezuri's Archers gets +3/+0 until end of turn.",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "9e713af4-08ca-5728-a2f7-55008aea728a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg?1",
             "name": "Ezuri's Brigade",
             "text": "Metalcraft \u2014 As long as you control three or more artifacts, Ezuri's Brigade gets +4/+4 and has trample.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "e0048ebb-4e37-5d4d-8387-1739219bc677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c920236f-c3d7-421c-b021-103996da790e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c920236f-c3d7-421c-b021-103996da790e.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "257b6dba-aa50-57f6-a3b5-0bdcde1ac009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fc5b67-f521-4ba4-a10f-103e8b6af688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fc5b67-f521-4ba4-a10f-103e8b6af688.jpg?1",
             "name": "Liege of the Tangle",
             "text": "Trample\nWhenever Liege of the Tangle deals combat damage to a player, you may choose any number of target lands you control and put an awakening counter on each of them. Each of those lands is an 8/8 green Elemental creature for as long as it has an awakening counter on it. They're still lands.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "69e48277-820d-5be2-955a-802f4846a4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e5dcac-0d59-4bcc-8a0e-036cc23065b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e5dcac-0d59-4bcc-8a0e-036cc23065b5.jpg?1",
             "name": "Lifesmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, you gain 3 life.",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "bf4837b9-f117-5a4b-8c38-1477bd7cebce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1340a63-f549-440b-aad3-14247113896a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1340a63-f549-440b-aad3-14247113896a.jpg?1",
             "name": "Molder Beast",
             "text": "Trample\nWhenever an artifact is put into a graveyard from the battlefield, Molder Beast gets +2/+0 until end of turn.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "a48e9c7f-6182-5bb5-bdcf-d019898a9b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b2c3f9-a831-4fd2-80e8-b67b0df3e98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b2c3f9-a831-4fd2-80e8-b67b0df3e98b.jpg?1",
             "name": "Putrefax",
             "text": "Trample, haste\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nAt the beginning of the end step, sacrifice Putrefax.",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "809f1246-5a60-5f80-8e72-9d09aa858037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c572a-6dc0-432f-92e9-c52fb0efddb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c572a-6dc0-432f-92e9-c52fb0efddb5.jpg?1",
             "name": "Slice in Twain",
             "text": "Destroy target artifact or enchantment.\nDraw a card.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "bc90e2e6-401a-57d7-bf0f-5f130c700d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b678bd68-e866-4081-95f9-2bd93a84d400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b678bd68-e866-4081-95f9-2bd93a84d400.jpg?1",
             "name": "Tangle Angler",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{G}: Target creature blocks Tangle Angler this turn if able.",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "6778dc31-bfaf-5443-a55d-9ae123959f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef01d3f6-c172-43fb-bc65-ff12567111da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef01d3f6-c172-43fb-bc65-ff12567111da.jpg?1",
             "name": "Tel-Jilad Defiance",
             "text": "Target creature gains protection from artifacts until end of turn.\nDraw a card.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "26551c5e-4ccb-5cad-9a8f-665477f2914a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643891b6-23d0-4734-81e0-b315d2d58f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643891b6-23d0-4734-81e0-b315d2d58f50.jpg?1",
             "name": "Tel-Jilad Fallen",
             "text": "Protection from artifacts\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "269e86be-d51d-51e4-be56-b3057644e86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17979f0e-bd39-449f-b4ed-9156c229223b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17979f0e-bd39-449f-b4ed-9156c229223b.jpg?1",
             "name": "Untamed Might",
             "text": "Target creature gets +X/+X until end of turn.",
             "colours": [
@@ -4444,7 +4444,7 @@
         },
         {
             "id": "153b2b1f-149b-558a-8db0-7b7aa9953ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f565e-0fb8-40c8-9540-213d35af846a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f565e-0fb8-40c8-9540-213d35af846a.jpg?1",
             "name": "Viridian Revel",
             "text": "Whenever an artifact is put into an opponent's graveyard from the battlefield, you may draw a card.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "52b46fab-f497-5dd7-9722-94b0cb2a5450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a5188b-9ae3-4ca0-8289-b8a266a9073b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a5188b-9ae3-4ca0-8289-b8a266a9073b.jpg?1",
             "name": "Wing Puncture",
             "text": "Target creature you control deals damage equal to its power to target creature with flying.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "83520e33-d9d2-5291-9836-70fb43492cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059cca0-2373-428b-a3a6-c8be5523c96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059cca0-2373-428b-a3a6-c8be5523c96f.jpg?1",
             "name": "Withstand Death",
             "text": "Target creature is indestructible this turn. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "da2ccb29-71df-5026-940a-60412a9c5150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d48d62e-5c1f-464c-aa81-8a5d2690f48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d48d62e-5c1f-464c-aa81-8a5d2690f48e.jpg?1",
             "name": "Venser, the Sojourner",
             "text": "+2: Exile target permanent you own. Return it to the battlefield under your control at the beginning of the next end step.\n-1: Creatures are unblockable this turn.\n-8: You get an emblem with \"Whenever you cast a spell, exile target permanent.\"",
             "colours": [
@@ -4578,7 +4578,7 @@
         },
         {
             "id": "43fc47a1-f95d-57e5-a323-eb3ac2db599b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7305c18-5058-42dd-b62a-7f6a42624036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7305c18-5058-42dd-b62a-7f6a42624036.jpg?1",
             "name": "Accorder's Shield",
             "text": "Equipped creature gets +0/+3 and has vigilance.\nEquip {3}",
             "colours": [],
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "b3de99b4-9f7f-5adf-90ae-899334850432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1283c05a-905b-421a-9096-e86b9c807aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1283c05a-905b-421a-9096-e86b9c807aaf.jpg?1",
             "name": "Argentum Armor",
             "text": "Equipped creature gets +6/+6.\nWhenever equipped creature attacks, destroy target permanent.\nEquip {6}",
             "colours": [],
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "57920f91-f25f-5fd7-a652-a6b45540ea58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02745a0a-9872-4c30-a25d-61695c5fa9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02745a0a-9872-4c30-a25d-61695c5fa9cc.jpg?1",
             "name": "Auriok Replica",
             "text": "{W}, Sacrifice Auriok Replica: Prevent all damage a source of your choice would deal to you this turn.",
             "colours": [],
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "89758ea0-8eb2-50d6-9df8-6d962884f78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b80b2f-8d07-4ad3-9b20-4ba0fe9f37a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b80b2f-8d07-4ad3-9b20-4ba0fe9f37a2.jpg?1",
             "name": "Barbed Battlegear",
             "text": "Equipped creature gets +4/-1.\nEquip {2}",
             "colours": [],
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "88e1a519-ad8b-562b-9d6a-0f483ab87139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf479c90-c791-4152-a8e6-fd3123f698df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf479c90-c791-4152-a8e6-fd3123f698df.jpg?1",
             "name": "Bladed Pinions",
             "text": "Equipped creature has flying and first strike.\nEquip {2}",
             "colours": [],
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "ad8ff267-1f2c-5a7e-8bf1-4f7705b390d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdb3af4-eaba-47b0-b242-dafa25ff0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdb3af4-eaba-47b0-b242-dafa25ff0969.jpg?1",
             "name": "Chimeric Mass",
             "text": "Chimeric Mass enters the battlefield with X charge counters on it.\n{1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"",
             "colours": [],
@@ -4759,7 +4759,7 @@
         },
         {
             "id": "72dd879a-b7cd-5769-83b5-ee12934cae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce881675-690f-4d4c-a951-ab8302e904ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce881675-690f-4d4c-a951-ab8302e904ab.jpg?1",
             "name": "Chrome Steed",
             "text": "Metalcraft \u2014 Chrome Steed gets +2/+2 as long as you control three or more artifacts.",
             "colours": [],
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "babfa662-a06a-5930-be40-ece4ee45d618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc386c6c-c27e-4673-96eb-1d004fd71993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc386c6c-c27e-4673-96eb-1d004fd71993.jpg?1",
             "name": "Clone Shell",
             "text": "Imprint \u2014 When Clone Shell enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library in any order.\nWhen Clone Shell is put into a graveyard from the battlefield, turn the exiled card face up. If it's a creature card, put it onto the battlefield under your control.",
             "colours": [],
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "f58bc388-234e-5f49-9fd9-59fb5921d6f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fafcefa-d33c-4d73-b3b7-2930f28b845e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fafcefa-d33c-4d73-b3b7-2930f28b845e.jpg?1",
             "name": "Contagion Clasp",
             "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "7dc86c33-dc1a-567b-930c-0e71c80894ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce72636-08e4-484e-ad81-4d1597a31ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce72636-08e4-484e-ad81-4d1597a31ffb.jpg?1",
             "name": "Contagion Engine",
             "text": "When Contagion Engine enters the battlefield, put a -1/-1 counter on each creature target player controls.\n{4}, {T}: Proliferate, then proliferate again. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there. Then do it again.)",
             "colours": [],
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "7a9f31b6-8c6b-5c5d-b3f3-a37448ad7ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323efe27-da58-4207-9c0c-dba5031bfa04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323efe27-da58-4207-9c0c-dba5031bfa04.jpg?1",
             "name": "Copper Myr",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -4910,7 +4910,7 @@
         },
         {
             "id": "0e236f50-d5c8-57c5-ba11-ab64f89a1109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6e19a1-b9ea-4724-96d6-63c4b4967257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6e19a1-b9ea-4724-96d6-63c4b4967257.jpg?1",
             "name": "Corpse Cur",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Corpse Cur enters the battlefield, you may return target creature card with infect from your graveyard to your hand.",
             "colours": [],
@@ -4942,7 +4942,7 @@
         },
         {
             "id": "b187f7cf-69c0-5f0d-bee9-70d5d5db920b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7665c7-c211-45d7-bde1-f7952548025f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7665c7-c211-45d7-bde1-f7952548025f.jpg?1",
             "name": "Culling Dais",
             "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
             "colours": [],
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "9db73f43-9b62-5a35-94a3-1db83a44d87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b997c3e6-4b0e-4f4a-9f66-3fc1d8395494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b997c3e6-4b0e-4f4a-9f66-3fc1d8395494.jpg?1",
             "name": "Darksteel Axe",
             "text": "Darksteel Axe is indestructible. (Effects that say \"destroy\" don't destroy it.)\nEquipped creature gets +2/+0.\nEquip {2}",
             "colours": [],
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "d3a0c73b-18d4-52fe-89e3-a4f516791873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1f540f-0d51-4e32-a4f9-c8977834572a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1f540f-0d51-4e32-a4f9-c8977834572a.jpg?1",
             "name": "Darksteel Juggernaut",
             "text": "Darksteel Juggernaut's power and toughness are each equal to the number of artifacts you control.\nDarksteel Juggernaut is indestructible and attacks each turn if able.",
             "colours": [],
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "a2bccb1c-13c0-58a3-8c25-88b0f9f34a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5712cf-c6a9-4a2e-90db-8ca17c621724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5712cf-c6a9-4a2e-90db-8ca17c621724.jpg?1",
             "name": "Darksteel Myr",
             "text": "Darksteel Myr is indestructible. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [],
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "f71969ff-63fe-54b3-a63a-d4181b4c5625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768e9dde-59e5-4b50-9b38-b46e2a593107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768e9dde-59e5-4b50-9b38-b46e2a593107.jpg?1",
             "name": "Darksteel Sentinel",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nVigilance\nDarksteel Sentinel is indestructible. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [],
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "ccc462d7-920c-5c6d-b9f2-37beb199bc37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e661c6-bc3e-45b4-ae1c-5002e381faf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e661c6-bc3e-45b4-ae1c-5002e381faf3.jpg?1",
             "name": "Echo Circlet",
             "text": "Equipped creature can block an additional creature.\nEquip {1}",
             "colours": [],
@@ -5123,7 +5123,7 @@
         },
         {
             "id": "2022be11-8834-5f89-ac1f-ead55b1c8e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2242c2-7379-4fff-a745-d180685da6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2242c2-7379-4fff-a745-d180685da6db.jpg?1",
             "name": "Etched Champion",
             "text": "Metalcraft \u2014 Etched Champion has protection from all colors as long as you control three or more artifacts.",
             "colours": [],
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "586f8c07-4fad-5fae-b860-b53d8d5e9659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa09e06-08fd-4ecd-83fe-f0e0856547a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa09e06-08fd-4ecd-83fe-f0e0856547a5.jpg?1",
             "name": "Flight Spellbomb",
             "text": "{T}, Sacrifice Flight Spellbomb: Target creature gains flying until end of turn.\nWhen Flight Spellbomb is put into a graveyard from the battlefield, you may pay {U}. If you do, draw a card.",
             "colours": [],
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "68491310-4595-5e9e-b19d-2f14458bc300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742da4-638d-4888-94f1-db2f4ada9f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742da4-638d-4888-94f1-db2f4ada9f94.jpg?1",
             "name": "Glint Hawk Idol",
             "text": "Whenever another artifact enters the battlefield under your control, you may have Glint Hawk Idol become a 2/2 artifact creature with flying until end of turn.\n{W}: Glint Hawk Idol becomes a 2/2 artifact creature with flying until end of turn.",
             "colours": [],
@@ -5214,7 +5214,7 @@
         },
         {
             "id": "f18f75f8-7288-54cf-82cb-fff54a30a46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac92126c-fb22-4b97-bbc5-b0533a0baad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac92126c-fb22-4b97-bbc5-b0533a0baad8.jpg?1",
             "name": "Gold Myr",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "9426e21e-a307-5934-a66d-4c95b39c4cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7abeca-da01-4962-b107-dd7a77469753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7abeca-da01-4962-b107-dd7a77469753.jpg?1",
             "name": "Golden Urn",
             "text": "At the beginning of your upkeep, you may put a charge counter on Golden Urn.\n{T}, Sacrifice Golden Urn: You gain life equal to the number of charge counters on Golden Urn.",
             "colours": [],
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "8c56ccc9-a13d-58c9-b598-62ed6366a6ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc314-2f18-43c2-9ccd-59bb5dbe35e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc314-2f18-43c2-9ccd-59bb5dbe35e9.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "efdf0b0a-00c3-54a1-9beb-f6a6b25b3a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cef2e6a-e46b-4425-b507-3213cfd1400c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cef2e6a-e46b-4425-b507-3213cfd1400c.jpg?1",
             "name": "Golem Foundry",
             "text": "Whenever you cast an artifact spell, you may put a charge counter on Golem Foundry.\nRemove three charge counters from Golem Foundry: Put a 3/3 colorless Golem artifact creature token onto the battlefield.",
             "colours": [],
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "af0321a3-c960-5177-b908-6be9e72f3970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647ecb81-2d23-40f3-8570-0b86e2ed1c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647ecb81-2d23-40f3-8570-0b86e2ed1c5e.jpg?1",
             "name": "Golem's Heart",
             "text": "Whenever a player casts an artifact spell, you may gain 1 life.",
             "colours": [],
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "2a22d2ca-1001-51fd-87a8-a976bcbfc3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa64374-0693-47c9-8b69-56def3817b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa64374-0693-47c9-8b69-56def3817b14.jpg?1",
             "name": "Grafted Exoskeleton",
             "text": "Equipped creature gets +2/+2 and has infect. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Grafted Exoskeleton becomes unattached from a permanent, sacrifice that permanent.\nEquip {2}",
             "colours": [],
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "e6e44a8c-f528-5de3-b9bd-53bf1e6eee04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6df2e7f-e46e-4808-8125-42a3aa66377c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6df2e7f-e46e-4808-8125-42a3aa66377c.jpg?1",
             "name": "Grindclock",
             "text": "{T}: Put a charge counter on Grindclock.\n{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of charge counters on Grindclock.",
             "colours": [],
@@ -5420,7 +5420,7 @@
         },
         {
             "id": "bf3e5e01-f604-5abf-86e5-83f5f37cdff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5737246f-1292-4af6-aecf-8f161f5300cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5737246f-1292-4af6-aecf-8f161f5300cb.jpg?1",
             "name": "Heavy Arbalest",
             "text": "Equipped creature doesn't untap during its controller's untap step.\nEquipped creature has \"{T}: This creature deals 2 damage to target creature or player.\"\nEquip {4}",
             "colours": [],
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "83f99a4b-ec3d-598b-b273-cb2613d5badc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d93378e-1de2-4954-9458-dd3306f2996e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d93378e-1de2-4954-9458-dd3306f2996e.jpg?1",
             "name": "Horizon Spellbomb",
             "text": "{2}, {T}, Sacrifice Horizon Spellbomb: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.\nWhen Horizon Spellbomb is put into a graveyard from the battlefield, you may pay {G}. If you do, draw a card.",
             "colours": [],
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "037cdfa9-56d8-566d-a4c8-76d07d3f34de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faef8b8b-2c45-4fed-b6ba-a8ac49c66330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faef8b8b-2c45-4fed-b6ba-a8ac49c66330.jpg?1",
             "name": "Ichorclaw Myr",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Ichorclaw Myr becomes blocked, it gets +2/+2 until end of turn.",
             "colours": [],
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "827bed05-8af8-59aa-b783-7dad2ccbc0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baa10da-2733-4657-a1ea-74eb5a5a82b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baa10da-2733-4657-a1ea-74eb5a5a82b1.jpg?1",
             "name": "Infiltration Lens",
             "text": "Whenever equipped creature becomes blocked by a creature, you may draw two cards.\nEquip {1}",
             "colours": [],
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "3b28d602-b0cb-51bb-a115-d5801a859a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd0a588-b695-4060-b5d5-c6a74710ff0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd0a588-b695-4060-b5d5-c6a74710ff0f.jpg?1",
             "name": "Iron Myr",
             "text": "{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "a9ee6770-a805-5f90-86c9-a97b7189c03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad590bea-b872-4af7-a612-c8e8759d59df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad590bea-b872-4af7-a612-c8e8759d59df.jpg?1",
             "name": "Kuldotha Forgemaster",
             "text": "{T}, Sacrifice three artifacts: Search your library for an artifact card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "f754d138-18a0-5505-aab9-22817ffadac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a709559-fec3-44f4-a2bf-3396989b9189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a709559-fec3-44f4-a2bf-3396989b9189.jpg?1",
             "name": "Leaden Myr",
             "text": "{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -5639,7 +5639,7 @@
         },
         {
             "id": "9368df7b-e340-5e8b-8162-9f179e5ca0f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9201-06e7-4a70-8dcf-7462a019965d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9201-06e7-4a70-8dcf-7462a019965d.jpg?1",
             "name": "Liquimetal Coating",
             "text": "{T}: Target permanent becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "9403c3ac-3f88-5abb-a5b7-36645b84afc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef3e31-eb5a-43f7-a0b2-12348df6968d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef3e31-eb5a-43f7-a0b2-12348df6968d.jpg?1",
             "name": "Livewire Lash",
             "text": "Equipped creature gets +2/+0 and has \"Whenever this creature becomes the target of a spell, this creature deals 2 damage to target creature or player.\"\nEquip {2}",
             "colours": [],
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "d6c68192-f0f7-56b3-8196-4a490070f609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e274ea-e8f6-48ea-a877-c84b77c96d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e274ea-e8f6-48ea-a877-c84b77c96d0c.jpg?1",
             "name": "Lux Cannon",
             "text": "{T}: Put a charge counter on Lux Cannon.\n{T}, Remove three charge counters from Lux Cannon: Destroy target permanent.",
             "colours": [],
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "80fbb371-969d-5f8d-89a6-8c10b1d7c9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469cc4e0-49c0-4009-97ea-28e44addec69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469cc4e0-49c0-4009-97ea-28e44addec69.jpg?1",
             "name": "Memnite",
             "text": "",
             "colours": [],
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "09d82b86-d60b-5efe-a4d0-d4c157314185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736fff86-2417-4a77-b8eb-be2d1d142a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736fff86-2417-4a77-b8eb-be2d1d142a9f.jpg?1",
             "name": "Mimic Vat",
             "text": "Imprint \u2014 Whenever a nontoken creature is put into a graveyard from the battlefield, you may exile that card. If you do, return each other card exiled with Mimic Vat to its owner's graveyard.\n{3}, {T}: Put a token onto the battlefield that's a copy of the exiled card. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -5784,7 +5784,7 @@
         },
         {
             "id": "d45c262a-2656-5f92-ad86-c54cec771bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d03b17-75ae-40d2-8570-b219ef0dfd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d03b17-75ae-40d2-8570-b219ef0dfd4a.jpg?1",
             "name": "Mindslaver",
             "text": "{4}, {T}, Sacrifice Mindslaver: You control target player during that player's next turn. (You see all cards that player could see and make all decisions for the player.)",
             "colours": [],
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "9d77fa8a-6a24-5d8e-9b79-b348da31fe2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48311a45-c0e1-4170-8dab-2b3495096c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48311a45-c0e1-4170-8dab-2b3495096c48.jpg?1",
             "name": "Molten-Tail Masticore",
             "text": "At the beginning of your upkeep, sacrifice Molten-Tail Masticore unless you discard a card.\n{4}, Exile a creature card from your graveyard: Molten-Tail Masticore deals 4 damage to target creature or player.\n{2}: Regenerate Molten-Tail Masticore.",
             "colours": [],
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "a9a8ce3a-2d95-566c-b3d3-d7ada7cf2ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480311ae-b9af-4fb7-881b-35566598cf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480311ae-b9af-4fb7-881b-35566598cf07.jpg?1",
             "name": "Moriok Replica",
             "text": "{1}{B}, Sacrifice Moriok Replica: You draw two cards and lose 2 life.",
             "colours": [],
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "766bf6fd-1dbc-5892-89c6-b98c69641451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be9b1d5-9ab8-4adb-ba54-2c0117e842fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be9b1d5-9ab8-4adb-ba54-2c0117e842fa.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color to your mana pool. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "f76239ef-359a-592e-8c3b-808089704667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae94ed-7314-470b-baba-f2f58bbc894a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae94ed-7314-470b-baba-f2f58bbc894a.jpg?1",
             "name": "Myr Battlesphere",
             "text": "When Myr Battlesphere enters the battlefield, put four 1/1 colorless Myr artifact creature tokens onto the battlefield.\nWhenever Myr Battlesphere attacks, you may tap X untapped Myr you control. If you do, Myr Battlesphere gets +X/+0 until end of turn and deals X damage to defending player.",
             "colours": [],
@@ -5940,7 +5940,7 @@
         },
         {
             "id": "3ce92115-cf3c-592f-a6aa-f29c13ae39f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ca835-b7f3-497c-b0bc-50a182cabecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ca835-b7f3-497c-b0bc-50a182cabecf.jpg?1",
             "name": "Myr Galvanizer",
             "text": "Other Myr creatures you control get +1/+1.\n{1}, {T}: Untap each other Myr you control.",
             "colours": [],
@@ -5971,7 +5971,7 @@
         },
         {
             "id": "ebed48ca-6199-54e7-b14f-b59155316b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837e4b25-d70b-48d8-aaad-9622ad93e154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837e4b25-d70b-48d8-aaad-9622ad93e154.jpg?1",
             "name": "Myr Propagator",
             "text": "{3}, {T}: Put a token that's a copy of Myr Propagator onto the battlefield.",
             "colours": [],
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "84306e46-0bf5-53d2-b247-60423f86ea3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60678391-44b2-4525-94dc-ffc5a433b79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60678391-44b2-4525-94dc-ffc5a433b79b.jpg?1",
             "name": "Myr Reservoir",
             "text": "{T}: Add {2} to your mana pool. Spend this mana only to cast Myr spells or activate abilities of Myr.\n{3}, {T}: Return target Myr card from your graveyard to your hand.",
             "colours": [],
@@ -6030,7 +6030,7 @@
         },
         {
             "id": "6ad5da91-71fb-5745-9858-0146bb4d0a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f707119-ede9-4697-b723-d6cea96e6f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f707119-ede9-4697-b723-d6cea96e6f2b.jpg?1",
             "name": "Necrogen Censer",
             "text": "Necrogen Censer enters the battlefield with two charge counters on it.\n{T}, Remove a charge counter from Necrogen Censer: Target player loses 2 life.",
             "colours": [],
@@ -6058,7 +6058,7 @@
         },
         {
             "id": "4507013e-cabb-5a64-9f19-04ee95d0af7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2e522b-e6f8-4fae-8c08-ce2bb8bed04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2e522b-e6f8-4fae-8c08-ce2bb8bed04f.jpg?1",
             "name": "Necropede",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Necropede is put into a graveyard from the battlefield, you may put a -1/-1 counter on target creature.",
             "colours": [],
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "7fad137a-9367-516b-8468-58afbb1f6c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e32d5a8-0916-4728-9cb2-3903262bf873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e32d5a8-0916-4728-9cb2-3903262bf873.jpg?1",
             "name": "Neurok Replica",
             "text": "{1}{U}, Sacrifice Neurok Replica: Return target creature to its owner's hand.",
             "colours": [],
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "65dfa5c0-18cf-53f3-b6b9-3ee558200e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603d217b-6375-46fc-992a-8dbd779da1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603d217b-6375-46fc-992a-8dbd779da1e5.jpg?1",
             "name": "Nihil Spellbomb",
             "text": "{T}, Sacrifice Nihil Spellbomb: Exile all cards from target player's graveyard.\nWhen Nihil Spellbomb is put into a graveyard from the battlefield, you may pay {B}. If you do, draw a card.",
             "colours": [],
@@ -6153,7 +6153,7 @@
         },
         {
             "id": "25065b4f-42ba-5fe5-870f-e0a50d8e2ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f638bd96-8424-461f-87bf-4b7a7153fd35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f638bd96-8424-461f-87bf-4b7a7153fd35.jpg?1",
             "name": "Nim Deathmantle",
             "text": "Equipped creature gets +2/+2, has intimidate, and is a black Zombie.\nWhenever a nontoken creature is put into your graveyard from the battlefield, you may pay {4}. If you do, return that card to the battlefield and attach Nim Deathmantle to it.\nEquip {4}",
             "colours": [],
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "bec1bfb1-03d0-5a9f-a507-daf95cfa48aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e7faa4-160e-47d9-a9a1-5928d9d2b5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e7faa4-160e-47d9-a9a1-5928d9d2b5e4.jpg?1",
             "name": "Origin Spellbomb",
             "text": "{1}, {T}, Sacrifice Origin Spellbomb: Put a 1/1 colorless Myr artifact creature token onto the battlefield.\nWhen Origin Spellbomb is put into a graveyard from the battlefield, you may pay {W}. If you do, draw a card.",
             "colours": [],
@@ -6213,7 +6213,7 @@
         },
         {
             "id": "59536d0e-a729-5594-a527-5ed981f8ca50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c016ad-bb82-4944-8c06-ab180b808041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c016ad-bb82-4944-8c06-ab180b808041.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "0addd93f-2430-5528-b53a-50d076ed0f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a29832-8630-498a-9ac3-bc709a6dc95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a29832-8630-498a-9ac3-bc709a6dc95d.jpg?1",
             "name": "Panic Spellbomb",
             "text": "{T}, Sacrifice Panic Spellbomb: Target creature can't block this turn.\nWhen Panic Spellbomb is put into a graveyard from the battlefield, you may pay {R}. If you do, draw a card.",
             "colours": [],
@@ -6274,7 +6274,7 @@
         },
         {
             "id": "367bcfb1-1f7f-5e5d-8780-252617fb05e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b942605-eb4a-452d-9b07-a4f912f96958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b942605-eb4a-452d-9b07-a4f912f96958.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr is put into a graveyard from the battlefield, it deals 2 damage to target creature or player.",
             "colours": [],
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "f5609084-e5d4-5426-8df8-9f3404c828d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7919474-db2b-441a-b368-9e430ddf70ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7919474-db2b-441a-b368-9e430ddf70ab.jpg?1",
             "name": "Platinum Emperion",
             "text": "Your life total can't change. (You can't gain or lose life. You can't pay any amount of life except 0.)",
             "colours": [],
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "af7e6dc0-636e-538b-956a-9cee90365bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4625ad-1c83-4095-a5a2-0fc9fa4dd5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4625ad-1c83-4095-a5a2-0fc9fa4dd5f2.jpg?1",
             "name": "Precursor Golem",
             "text": "When Precursor Golem enters the battlefield, put two 3/3 colorless Golem artifact creature tokens onto the battlefield.\nWhenever a player casts an instant or sorcery spell that targets only a single Golem, that player copies that spell for each other Golem that spell could target. Each copy targets a different one of those Golems.",
             "colours": [],
@@ -6368,7 +6368,7 @@
         },
         {
             "id": "b5a4cc82-7886-5ea3-a0f1-1ce5489b3acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b264aa-303b-4982-a653-9573d39c28de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b264aa-303b-4982-a653-9573d39c28de.jpg?1",
             "name": "Prototype Portal",
             "text": "Imprint \u2014 When Prototype Portal enters the battlefield, you may exile an artifact card from your hand.\n{X}, {T}: Put a token that's a copy of the exiled card onto the battlefield. X is the converted mana cost of that card.",
             "colours": [],
@@ -6396,7 +6396,7 @@
         },
         {
             "id": "cfda9f24-8817-5ea7-8fda-b0d0ad8cf0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3db7645-20b9-4884-849b-a7d4b6d3aa00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3db7645-20b9-4884-849b-a7d4b6d3aa00.jpg?1",
             "name": "Ratchet Bomb",
             "text": "{T}: Put a charge counter on Ratchet Bomb.\n{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
             "colours": [],
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "00b156fc-649b-593e-b62d-ba0fe89e648e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a74203-d342-489d-a584-bca78ef3331d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a74203-d342-489d-a584-bca78ef3331d.jpg?1",
             "name": "Razorfield Thresher",
             "text": "",
             "colours": [],
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "bc57f8a1-f6b2-516b-9d96-941b51d5210a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d638741-1cfe-4496-8d7e-7849a82dcb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d638741-1cfe-4496-8d7e-7849a82dcb24.jpg?1",
             "name": "Rust Tick",
             "text": "You may choose not to untap Rust Tick during your untap step.\n{1}, {T}: Tap target artifact. It doesn't untap during its controller's untap step for as long as Rust Tick remains tapped.",
             "colours": [],
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "fcedce3c-f34b-56b1-80b6-75653c8897b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2419dd5-9c31-42b2-b6ef-bbdf11c558ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2419dd5-9c31-42b2-b6ef-bbdf11c558ac.jpg?1",
             "name": "Rusted Relic",
             "text": "Metalcraft \u2014 Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.",
             "colours": [],
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "fde6c2b6-a76c-5967-96b7-b38fb4574d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656b6d1-1c92-4da4-8afb-36f11610b0b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656b6d1-1c92-4da4-8afb-36f11610b0b4.jpg?1",
             "name": "Saberclaw Golem",
             "text": "{R}: Saberclaw Golem gains first strike until end of turn.",
             "colours": [],
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "4e87b8b7-077d-56de-b809-9fe1d67d6cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380b46d-1660-404d-9d11-705d8809ea46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380b46d-1660-404d-9d11-705d8809ea46.jpg?1",
             "name": "Semblance Anvil",
             "text": "Imprint \u2014 When Semblance Anvil enters the battlefield, you may exile a nonland card from your hand.\nSpells you cast that share a card type with the exiled card cost {2} less to cast.",
             "colours": [],
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "ccd5b280-af91-58b2-a403-6e69fd6b2b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd60081-3942-4e0e-aacd-a0c121bb08c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd60081-3942-4e0e-aacd-a0c121bb08c7.jpg?1",
             "name": "Silver Myr",
             "text": "{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -6608,7 +6608,7 @@
         },
         {
             "id": "8f2f47b3-4e20-5c69-bdc2-8818baf707cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e0af-b18e-4172-bc56-19952ebd0303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e0af-b18e-4172-bc56-19952ebd0303.jpg?1",
             "name": "Snapsail Glider",
             "text": "Metalcraft \u2014 Snapsail Glider has flying as long as you control three or more artifacts.",
             "colours": [],
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "5bef02c6-f28e-573c-bd20-e350584c0014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608c28-18cc-47d6-861e-2fd783aa3ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608c28-18cc-47d6-861e-2fd783aa3ade.jpg?1",
             "name": "Soliton",
             "text": "{U}: Untap Soliton.",
             "colours": [],
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "91fdc245-fb65-5079-a019-5813ca1278b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126ee24-9597-4ee8-9c4d-5caed585424a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126ee24-9597-4ee8-9c4d-5caed585424a.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: Steel Hellkite gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with converted mana cost X whose controller was dealt combat damage by Steel Hellkite this turn. Activate this ability only once each turn.",
             "colours": [],
@@ -6703,7 +6703,7 @@
         },
         {
             "id": "ca32758a-7f43-5dc6-b564-b80d58d4a62a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2cb906-3748-4675-89b3-bde2f9a8444a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2cb906-3748-4675-89b3-bde2f9a8444a.jpg?1",
             "name": "Strata Scythe",
             "text": "Imprint \u2014 When Strata Scythe enters the battlefield, search your library for a land card, exile it, then shuffle your library.\nEquipped creature gets +1/+1 for each land on the battlefield with the same name as the exiled card.\nEquip {3}",
             "colours": [],
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "1eee5906-a598-5f48-a047-98008a4e2d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b9e54-b3ef-44fb-9240-0d67c1c4b7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b9e54-b3ef-44fb-9240-0d67c1c4b7f6.jpg?1",
             "name": "Strider Harness",
             "text": "Equipped creature gets +1/+1 and has haste.\nEquip {1}",
             "colours": [],
@@ -6763,7 +6763,7 @@
         },
         {
             "id": "fa97a94c-ca67-545b-a1b9-120959952077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cc5caf-b2d7-4211-a1a4-f0ad6e70e3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cc5caf-b2d7-4211-a1a4-f0ad6e70e3f4.jpg?1",
             "name": "Sword of Body and Mind",
             "text": "Equipped creature gets +2/+2 and has protection from green and from blue.\nWhenever equipped creature deals combat damage to a player, you put a 2/2 green Wolf creature token onto the battlefield and that player puts the top ten cards of his or her library into his or her graveyard.\nEquip {2}",
             "colours": [],
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "a4b120c8-0344-55fa-ab7d-467d3df971af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbc5ae5-8e8b-4106-844f-2d49d2a51ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbc5ae5-8e8b-4106-844f-2d49d2a51ed9.jpg?1",
             "name": "Sylvok Lifestaff",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature is put into a graveyard, you gain 3 life.\nEquip {1}",
             "colours": [],
@@ -6823,7 +6823,7 @@
         },
         {
             "id": "1190bc1e-45b3-58df-a8c7-bc2ca6106213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caa3ce3-15a9-40ca-ad45-baff0f276483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caa3ce3-15a9-40ca-ad45-baff0f276483.jpg?1",
             "name": "Sylvok Replica",
             "text": "{G}, Sacrifice Sylvok Replica: Destroy target artifact or enchantment.",
             "colours": [],
@@ -6856,7 +6856,7 @@
         },
         {
             "id": "6ab396ba-ad6c-51b6-8960-b6a29c7cf753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583d7386-3eb5-4f1d-8da9-f00e020a307b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583d7386-3eb5-4f1d-8da9-f00e020a307b.jpg?1",
             "name": "Throne of Geth",
             "text": "{T}, Sacrifice an artifact: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "0b76a866-a557-5b67-8783-ecb9e472232c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a77391b-5727-4408-bb50-970f7a13a83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a77391b-5727-4408-bb50-970f7a13a83c.jpg?1",
             "name": "Tower of Calamities",
             "text": "{8}, {T}: Tower of Calamities deals 12 damage to target creature.",
             "colours": [],
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "e0f2cd21-8879-5033-b12d-1e04954cce4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e215e0-836c-4b37-8f9a-9093a535bff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e215e0-836c-4b37-8f9a-9093a535bff1.jpg?1",
             "name": "Trigon of Corruption",
             "text": "Trigon of Corruption enters the battlefield with three charge counters on it.\n{B}{B}, {T}: Put a charge counter on Trigon of Corruption.\n{2}, {T}, Remove a charge counter from Trigon of Corruption: Put a -1/-1 counter on target creature.",
             "colours": [],
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "ddee5287-96c1-5cd9-8e76-18f451f66610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be409a80-846c-4883-8aee-c2e3f973fc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be409a80-846c-4883-8aee-c2e3f973fc0f.jpg?1",
             "name": "Trigon of Infestation",
             "text": "Trigon of Infestation enters the battlefield with three charge counters on it.\n{G}{G}, {T}: Put a charge counter on Trigon of Infestation.\n{2}, {T}, Remove a charge counter from Trigon of Infestation: Put a 1/1 green Insect creature token with infect onto the battlefield.",
             "colours": [],
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "afcf5dac-22e6-51f6-abb2-8ec4ca68b50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241142e0-3a79-4bce-8535-18ae7e392f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241142e0-3a79-4bce-8535-18ae7e392f5e.jpg?1",
             "name": "Trigon of Mending",
             "text": "Trigon of Mending enters the battlefield with three charge counters on it.\n{W}{W}, {T}: Put a charge counter on Trigon of Mending.\n{2}, {T}, Remove a charge counter from Trigon of Mending: Target player gains 3 life.",
             "colours": [],
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "fca98a7f-9149-53e8-be8d-9e18746903ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1135f3b7-8c6b-47ff-b895-b7127836b0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1135f3b7-8c6b-47ff-b895-b7127836b0bf.jpg?1",
             "name": "Trigon of Rage",
             "text": "Trigon of Rage enters the battlefield with three charge counters on it.\n{R}{R}, {T}: Put a charge counter on Trigon of Rage.\n{2}, {T}, Remove a charge counter from Trigon of Rage: Target creature gets +3/+0 until end of turn.",
             "colours": [],
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "ccc33e95-800a-53db-8191-91038e4faf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da37ba-52e3-417e-8d7b-6c3e060552a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da37ba-52e3-417e-8d7b-6c3e060552a4.jpg?1",
             "name": "Trigon of Thought",
             "text": "Trigon of Thought enters the battlefield with three charge counters on it.\n{U}{U}, {T}: Put a charge counter on Trigon of Thought.\n{2}, {T}, Remove a charge counter from Trigon of Thought: Draw a card.",
             "colours": [],
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "0491c938-4a32-5c63-ac20-751ccfa13672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6478389-15be-405f-b755-108c942d72ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6478389-15be-405f-b755-108c942d72ec.jpg?1",
             "name": "Tumble Magnet",
             "text": "Tumble Magnet enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Tumble Magnet: Tap target artifact or creature.",
             "colours": [],
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "bd304b92-5a89-55d6-95d4-656fce3d0b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe86e1-ad47-4ccb-aa55-119dc681d370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe86e1-ad47-4ccb-aa55-119dc681d370.jpg?1",
             "name": "Vector Asp",
             "text": "{B}: Vector Asp gains infect until end of turn. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "d5605293-dffa-5353-9448-55c633534d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2763643d-5b53-49d0-bc3d-5626bf00f3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2763643d-5b53-49d0-bc3d-5626bf00f3f4.jpg?1",
             "name": "Venser's Journal",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, you gain 1 life for each card in your hand.",
             "colours": [],
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "206933ef-fda7-5778-a8b7-c919eee340d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32885a6c-b293-405f-9f2e-9e0dd7d1cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32885a6c-b293-405f-9f2e-9e0dd7d1cb8c.jpg?1",
             "name": "Vulshok Replica",
             "text": "{1}{R}, Sacrifice Vulshok Replica: Vulshok Replica deals 3 damage to target player.",
             "colours": [],
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "7151e70c-f27b-579b-866a-f3d335e52d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e2aed-ce6e-4fa1-a31c-a4574e5cf1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e2aed-ce6e-4fa1-a31c-a4574e5cf1f5.jpg?1",
             "name": "Wall of Tanglecord",
             "text": "Defender\n{G}: Wall of Tanglecord gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [],
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "2cd697fb-53b0-54f1-a2b6-8a29c20073d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33672990-4860-4aa6-ac1b-f9da66f5da59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33672990-4860-4aa6-ac1b-f9da66f5da59.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Engine is put into a graveyard from the battlefield, put a 3/3 colorless Wurm artifact creature token with deathtouch and a 3/3 colorless Wurm artifact creature token with lifelink onto the battlefield.",
             "colours": [],
@@ -7250,7 +7250,7 @@
         },
         {
             "id": "1849f292-cd71-567c-9c8f-4ae293796761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71be5f-0fd7-4a88-8041-f4d6bc4cc9ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71be5f-0fd7-4a88-8041-f4d6bc4cc9ac.jpg?1",
             "name": "Blackcleave Cliffs",
             "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "e7dfec87-8f0e-504a-957d-527470fff597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f1d784-f286-418d-a712-bc07ad10d4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f1d784-f286-418d-a712-bc07ad10d4a2.jpg?1",
             "name": "Copperline Gorge",
             "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7312,7 +7312,7 @@
         },
         {
             "id": "0fb9c18c-fdc2-525e-9ced-d4e5652e855b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530388b-eb19-4211-abd8-8a4c3c38c3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530388b-eb19-4211-abd8-8a4c3c38c3af.jpg?1",
             "name": "Darkslick Shores",
             "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7343,7 +7343,7 @@
         },
         {
             "id": "e0cd6d4a-a610-52cd-b583-b010eddac408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63efb6-249c-4f57-9af1-baffe938520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63efb6-249c-4f57-9af1-baffe938520c.jpg?1",
             "name": "Glimmerpost",
             "text": "When Glimmerpost enters the battlefield, you gain 1 life for each Locus on the battlefield.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7373,7 +7373,7 @@
         },
         {
             "id": "d0701f80-4fc1-5549-9468-75db1f267506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345e053a-3178-485c-8602-1624bbf2f064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345e053a-3178-485c-8602-1624bbf2f064.jpg?1",
             "name": "Razorverge Thicket",
             "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "4fbb40f8-934a-5ac3-8577-396133ddc2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99939b90-e88c-4c2f-ba78-56d455611703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99939b90-e88c-4c2f-ba78-56d455611703.jpg?1",
             "name": "Seachrome Coast",
             "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "a2852484-3e71-5f26-a710-48fa6de67dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e95b-afd0-4ac4-beb5-96163b411fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e95b-afd0-4ac4-beb5-96163b411fe2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "e6987881-ef68-536f-8504-816e1520ba35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440680d3-1eea-442a-b58e-96db09bc279e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440680d3-1eea-442a-b58e-96db09bc279e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "bae5939e-d5c8-5e90-9279-7b0737a7e1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d5ea-eb76-4378-a3da-5d5cdad809b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d5ea-eb76-4378-a3da-5d5cdad809b8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7549,7 +7549,7 @@
         },
         {
             "id": "86c455d0-5781-56d9-866e-28cdb841517c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f48ac3-f0cb-4e5c-8ea6-e423aa92ce11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f48ac3-f0cb-4e5c-8ea6-e423aa92ce11.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7587,7 +7587,7 @@
         },
         {
             "id": "89558e11-4ce5-5e8e-a00c-f71ed09a9375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2748f53-0d81-4656-8e4b-5f0128215879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2748f53-0d81-4656-8e4b-5f0128215879.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7625,7 +7625,7 @@
         },
         {
             "id": "d0166b4f-c28f-57b6-9e62-b3190683737b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6549f83-e3da-4df2-a1e4-f01773607d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6549f83-e3da-4df2-a1e4-f01773607d56.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "06470238-8b38-5523-9610-b02a14aaa9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e879fe-a79b-427f-9901-c989fa73e234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e879fe-a79b-427f-9901-c989fa73e234.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "72c0489e-dd06-551f-86c9-00dc88f7b607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e160cb2a-1d8a-47cb-b136-8347eaab67d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e160cb2a-1d8a-47cb-b136-8347eaab67d7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7739,7 +7739,7 @@
         },
         {
             "id": "8528bac9-e3ed-55cc-a6f9-5252adceb17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a1264f-bda3-45ac-b959-463c6e532fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a1264f-bda3-45ac-b959-463c6e532fd3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "7eb989e8-b9e3-5078-a283-d57911fc9c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8897b2-0ef2-4812-9772-cd99c5ce5586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8897b2-0ef2-4812-9772-cd99c5ce5586.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7815,7 +7815,7 @@
         },
         {
             "id": "4ead0bf8-44c7-5efb-bd77-6fadde9f20b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239511f0-34b7-423c-b53b-1327d6b7da28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239511f0-34b7-423c-b53b-1327d6b7da28.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7853,7 +7853,7 @@
         },
         {
             "id": "52fa1705-0ce5-534d-939b-241ab371005d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeccfafb-0b3e-4e22-8c5c-6d5a0f5896c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeccfafb-0b3e-4e22-8c5c-6d5a0f5896c5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7891,7 +7891,7 @@
         },
         {
             "id": "9678b7e7-271a-5155-ac2c-da1f9832b84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df2f49d-097e-4685-8ddb-69c55f07f60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df2f49d-097e-4685-8ddb-69c55f07f60c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "0d16e923-8cb2-5aea-b8b9-2ec742005533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68647c2-a343-4314-8abb-00e7de6ecf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68647c2-a343-4314-8abb-00e7de6ecf0d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "e25fb2c9-1e05-5596-87c2-6c7e35a28c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bad0eb-807f-4391-82c9-edc9d14070f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bad0eb-807f-4391-82c9-edc9d14070f5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "43fd9ee5-87a4-5f0a-930e-aa0960093219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dcb5ef-85f8-48ce-be39-d0a4eb8345af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dcb5ef-85f8-48ce-be39-d0a4eb8345af.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8043,7 +8043,7 @@
         },
         {
             "id": "4e454606-8a5a-56dc-95df-b4a03f5d73e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cc6a36-b551-40c7-b081-53beffbca235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cc6a36-b551-40c7-b081-53beffbca235.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "de7270b3-24ae-5295-9dc5-badca38244e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c661a6-322a-4460-9d75-a2c95d1a49de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c661a6-322a-4460-9d75-a2c95d1a49de.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8119,7 +8119,7 @@
         },
         {
             "id": "51666869-9f49-5e10-931c-eb2f57f939fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798b4f41-1e33-4da6-99c1-de926297c073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798b4f41-1e33-4da6-99c1-de926297c073.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "b6344758-6965-5112-945f-6fd73232df3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2bf35-efe6-4ad4-bf6e-55848ba71dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2bf35-efe6-4ad4-bf6e-55848ba71dfe.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "aaa57966-d63b-5b2b-bc7c-5b4dd6638678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ab51-43e8-4b24-9830-de0ad9b9d3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ab51-43e8-4b24-9830-de0ad9b9d3dc.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "fdad2865-1030-5dcb-88a1-f00662ce7dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a563df7-7b9d-4692-ab1b-578be1887b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a563df7-7b9d-4692-ab1b-578be1887b62.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "98f2791c-083f-5f95-a9ee-c6cbcf07a8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f4fdb-1533-4c38-a654-f715fbef6abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f4fdb-1533-4c38-a654-f715fbef6abf.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "351ac8e7-77b1-548f-9a8c-a2847ef1f746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9e977-f718-41b2-b30b-77a9a17e9733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9e977-f718-41b2-b30b-77a9a17e9733.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "566a357e-7469-513a-8123-7df7cc542f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde8b3e-c006-41fd-a926-8746c794e149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde8b3e-c006-41fd-a926-8746c794e149.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "22a0cb0c-791c-5899-83f3-033f51fff8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c705b843-ca62-47bb-95dd-f303c60088bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c705b843-ca62-47bb-95dd-f303c60088bb.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -8396,7 +8396,7 @@
         },
         {
             "id": "5fd00c20-e3d2-586d-91af-2701a638aa8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182308b3-86e0-46d8-9104-95576a3d3921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182308b3-86e0-46d8-9104-95576a3d3921.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "b5e9130a-8862-51b5-abd3-147d3d2d9aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e46e703-2157-41e5-9c21-c17af43e0d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e46e703-2157-41e5-9c21-c17af43e0d3f.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -8458,7 +8458,7 @@
         },
         {
             "id": "b6f48f68-a6b1-52b4-881a-273e566157fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee53b9a0-8e07-404d-87ae-ff8397a0ba29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee53b9a0-8e07-404d-87ae-ff8397a0ba29.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -8489,7 +8489,7 @@
         },
         {
             "id": "37d32a67-9435-513a-bbe1-48b94ae9ab12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856e308d-6268-4311-9667-c2f761db8f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856e308d-6268-4311-9667-c2f761db8f99.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/STA.json
+++ b/Assets/Resources/Sets/STA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "88efa464-925a-5de1-a66a-5cdf8d159277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d18742-d661-4223-8880-9ed995379b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d18742-d661-4223-8880-9ed995379b2e.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "9d2a92b9-948b-58b9-9c65-d38bba0eec61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf85d00-52cc-4594-b4fd-5ec424210524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf85d00-52cc-4594-b4fd-5ec424210524.jpg?1",
             "name": "Day of Judgment",
             "text": "",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "48cfda73-cf41-5982-98ed-43edb8cae82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f339-4afb-477a-9434-e6cd9126cd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f339-4afb-477a-9434-e6cd9126cd10.jpg?1",
             "name": "Defiant Strike",
             "text": "",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "178d0b92-79cc-5852-868c-023fbeecbcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3b199-92a0-4d94-819c-fbf24a87d353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3b199-92a0-4d94-819c-fbf24a87d353.jpg?1",
             "name": "Divine Gambit",
             "text": "",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "adddd59b-3e9a-5442-b845-e0b6d6ec3893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5092f-cd24-4aea-824e-67b9767019b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5092f-cd24-4aea-824e-67b9767019b2.jpg?1",
             "name": "Ephemerate",
             "text": "",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "b2c6af8d-cf32-5912-bddb-84618802cde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bc15bf-1923-45d7-988f-9a4adf3982ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bc15bf-1923-45d7-988f-9a4adf3982ee.jpg?1",
             "name": "Gift of Estates",
             "text": "",
             "colours": [
@@ -214,7 +214,7 @@
         },
         {
             "id": "efa08b5e-7551-50eb-a884-1874730b2d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e547cd-eba4-4a75-9c4e-8eeb6e00ddc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e547cd-eba4-4a75-9c4e-8eeb6e00ddc4.jpg?1",
             "name": "Gods Willing",
             "text": "",
             "colours": [
@@ -249,7 +249,7 @@
         },
         {
             "id": "74fa505a-c62e-5cfe-b0b2-182cf86ff304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f32354-893d-4f0b-b555-e0757fb5443b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f32354-893d-4f0b-b555-e0757fb5443b.jpg?1",
             "name": "Mana Tithe",
             "text": "",
             "colours": [
@@ -284,7 +284,7 @@
         },
         {
             "id": "f92b7147-0e3c-5d8a-9633-3b1aabc86e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da7312-91e8-4f8d-84ef-6888360b3718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da7312-91e8-4f8d-84ef-6888360b3718.jpg?1",
             "name": "Revitalize",
             "text": "",
             "colours": [
@@ -319,7 +319,7 @@
         },
         {
             "id": "0590be09-b330-5ebe-b4bb-4fa5d2b3906d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9ece2f-7eda-4fc5-a562-3e16e71560e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9ece2f-7eda-4fc5-a562-3e16e71560e9.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "c84aa1e0-61f0-5b48-bdca-9c5617378bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e21c8c-5ad1-4830-8621-f0fd6500ca79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e21c8c-5ad1-4830-8621-f0fd6500ca79.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "7614890a-ea60-5a3d-9029-5ff0ea90fd8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cad77b5-94eb-4715-9fc1-75c45c28e83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cad77b5-94eb-4715-9fc1-75c45c28e83a.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "de91326d-b96c-5b5d-a357-efd949296c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d27509-07c2-4445-a1d5-e56523fb8566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d27509-07c2-4445-a1d5-e56523fb8566.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "dffa8fdb-f9c0-5d3b-8206-1d544724a4fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f578fbf-c3c7-4407-9fda-3c13b165798c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f578fbf-c3c7-4407-9fda-3c13b165798c.jpg?1",
             "name": "Compulsive Research",
             "text": "",
             "colours": [
@@ -494,7 +494,7 @@
         },
         {
             "id": "7b1ef751-82d0-5318-8a19-3e159c8ab41a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf9d2a-c163-43df-9a2f-20b8749c86ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf9d2a-c163-43df-9a2f-20b8749c86ae.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "834c37f7-8d88-58fe-b00b-8c5b53bb3576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c1b465-b6d9-491b-bfc2-c034cc825d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c1b465-b6d9-491b-bfc2-c034cc825d27.jpg?1",
             "name": "Memory Lapse",
             "text": "",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "377b3bc0-2182-5a7e-b0a9-1a127026e087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f4e609-7fb7-4903-8d4c-45d38cf743be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f4e609-7fb7-4903-8d4c-45d38cf743be.jpg?1",
             "name": "Mind's Desire",
             "text": "",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "cd52f045-8069-5cbf-a1ed-6bdfcbd3c73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfe3a17-3349-4fcc-a9b5-418faa55cc43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfe3a17-3349-4fcc-a9b5-418faa55cc43.jpg?1",
             "name": "Negate",
             "text": "",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "9f35aba6-72d9-565b-bb8b-2ba628282b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab59ac4f-2a77-4566-85c0-32666447dcf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab59ac4f-2a77-4566-85c0-32666447dcf2.jpg?1",
             "name": "Opt",
             "text": "",
             "colours": [
@@ -669,7 +669,7 @@
         },
         {
             "id": "aba109b4-61b3-518a-84e6-dcc73d892e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7b2ee8-9f2f-4624-a788-15b88e6a2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7b2ee8-9f2f-4624-a788-15b88e6a2d50.jpg?1",
             "name": "Strategic Planning",
             "text": "",
             "colours": [
@@ -704,7 +704,7 @@
         },
         {
             "id": "0812003f-f7a8-59aa-b5ec-c5fb3fb9af2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e5dbfd-84cf-4fe1-850f-3d2965ed3120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e5dbfd-84cf-4fe1-850f-3d2965ed3120.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "aab28e8e-a9c6-5cdc-86b4-204292662a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e70332c-de0b-45ce-bbd1-5de4314c08db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e70332c-de0b-45ce-bbd1-5de4314c08db.jpg?1",
             "name": "Time Warp",
             "text": "",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "e942282d-8dcc-5730-9681-1fe21ba4ae75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a0c25a-8760-44ea-a418-fcd4a9761632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a0c25a-8760-44ea-a418-fcd4a9761632.jpg?1",
             "name": "Whirlwind Denial",
             "text": "",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "26304f37-675a-5832-b1f5-e4f0aadad1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b7f7bd-6db3-4716-b1c3-015b0a6d37e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b7f7bd-6db3-4716-b1c3-015b0a6d37e3.jpg?1",
             "name": "Agonizing Remorse",
             "text": "",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "50e6dca0-a622-5670-8117-9375b34afef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ccea48-ee90-4da8-832d-8c30c98bf1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ccea48-ee90-4da8-832d-8c30c98bf1dd.jpg?1",
             "name": "Crux of Fate",
             "text": "",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "817f1fd9-bd59-595a-a51c-e1b72005a739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc57076-cac4-4f5e-956b-e3d77bd258b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc57076-cac4-4f5e-956b-e3d77bd258b2.jpg?1",
             "name": "Dark Ritual",
             "text": "",
             "colours": [
@@ -914,7 +914,7 @@
         },
         {
             "id": "f2aa69f2-db69-5564-8661-d51855c6796a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009ba46-c9f8-46dc-8ffc-2aa4cef7b17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009ba46-c9f8-46dc-8ffc-2aa4cef7b17c.jpg?1",
             "name": "Demonic Tutor",
             "text": "",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "0c3b0de9-32a1-557f-ab42-1b886c73e625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6c0fe2-a82b-42cb-8629-b9f00b7f08e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6c0fe2-a82b-42cb-8629-b9f00b7f08e9.jpg?1",
             "name": "Doom Blade",
             "text": "",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "103e51a2-feca-56d0-bb6c-f77d0e3a0ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb89f3f-f3b0-402d-9f3c-5b4b8a9d1e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb89f3f-f3b0-402d-9f3c-5b4b8a9d1e91.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "8ffef6e3-ee90-5a11-8187-65e0770ca8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b2b50-ac83-4a78-8f84-580193d1ca0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b2b50-ac83-4a78-8f84-580193d1ca0f.jpg?1",
             "name": "Eliminate",
             "text": "",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "6899e4fb-846e-5fb1-90d3-f63df501fcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47df2c2-437d-4b8e-82cc-1707e3efd5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47df2c2-437d-4b8e-82cc-1707e3efd5b5.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "cd5f30e5-b26d-594d-b827-552510ad5cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef84fcc-7685-41e5-bcd0-25b974ce570f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef84fcc-7685-41e5-bcd0-25b974ce570f.jpg?1",
             "name": "Sign in Blood",
             "text": "",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "2b2cf787-360b-528c-82a6-94954930ec4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c92756f-1dc2-49be-bb38-0f8cf10079fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c92756f-1dc2-49be-bb38-0f8cf10079fa.jpg?1",
             "name": "Tainted Pact",
             "text": "",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "712fcd6d-86d2-5103-999e-b4ae10ef89f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659d0ca7-90c9-473a-8b46-4fe40351b57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659d0ca7-90c9-473a-8b46-4fe40351b57d.jpg?1",
             "name": "Tendrils of Agony",
             "text": "",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "748b5456-64a6-587e-a334-ebf09bd1fff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3de5c0-acda-4116-b0c5-eceb2c19cb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3de5c0-acda-4116-b0c5-eceb2c19cb2d.jpg?1",
             "name": "Village Rites",
             "text": "",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "ac375796-adb4-5e37-bb1b-304b360f0df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0a3996-5a03-481b-9bda-15c6f6e5f9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0a3996-5a03-481b-9bda-15c6f6e5f9c4.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -1264,7 +1264,7 @@
         },
         {
             "id": "e259e555-7c57-5e1b-a4a7-4e2d2af428ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cb6157-ea56-4921-b803-59e3fbef0b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cb6157-ea56-4921-b803-59e3fbef0b94.jpg?1",
             "name": "Claim the Firstborn",
             "text": "",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "0639be88-adee-5b9b-94d3-efcb6ff8542f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b429172f-2182-49dd-b6f6-e5e09493628d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b429172f-2182-49dd-b6f6-e5e09493628d.jpg?1",
             "name": "Faithless Looting",
             "text": "",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "0e49e698-cb26-5392-9d1a-6c4803991150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99b45df-9602-4037-a695-09decb5f21d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99b45df-9602-4037-a695-09decb5f21d7.jpg?1",
             "name": "Grapeshot",
             "text": "",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "a93f901c-e74f-5a71-9be5-8b8c70a17d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef32c03-14f5-4ee2-af3a-4cbee45cd152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef32c03-14f5-4ee2-af3a-4cbee45cd152.jpg?1",
             "name": "Increasing Vengeance",
             "text": "",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "3024219e-e13e-5d49-b57e-564164bc7ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5dfad-c8b4-46cc-9a06-73d23b269df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5dfad-c8b4-46cc-9a06-73d23b269df8.jpg?1",
             "name": "Infuriate",
             "text": "",
             "colours": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "952756ad-89fd-5524-95dc-baaa99cdbc19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaac4fd-95f5-4f38-b593-0101e79a20f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaac4fd-95f5-4f38-b593-0101e79a20f9.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "42da1cdd-b371-50bc-b674-8f5e235193b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89978bd5-8222-4052-9625-3a5db81baa27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89978bd5-8222-4052-9625-3a5db81baa27.jpg?1",
             "name": "Mizzix's Mastery",
             "text": "",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "a2e4a35d-ff98-5460-ad3c-2d98a711f4e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60eeb025-704c-4a82-90b2-f91202ae30d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60eeb025-704c-4a82-90b2-f91202ae30d9.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "d15d4f5f-55a3-54d5-a94e-f75e234cf0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60687e5-9384-4453-833e-2c76f25bfac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60687e5-9384-4453-833e-2c76f25bfac5.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "d6a74ae0-8494-54e6-b218-eafd3d1736bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ba24c2-73c3-4630-bb8e-7431e5b3aebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ba24c2-73c3-4630-bb8e-7431e5b3aebd.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "e0139acf-4043-52b6-a831-4ee7894f0214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e9897-d84c-4992-9e8e-3a00f377c7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e9897-d84c-4992-9e8e-3a00f377c7e5.jpg?1",
             "name": "Urza's Rage",
             "text": "",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "1d9cabd0-0d9a-5889-a42e-dfbef37723dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16782095-0b7f-4489-8a97-b74f8efef352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16782095-0b7f-4489-8a97-b74f8efef352.jpg?1",
             "name": "Abundant Harvest",
             "text": "",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "ea235ab0-fb4c-592b-ab41-29152e12a95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b44893-e6d1-48d0-ba69-06b9569e1e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b44893-e6d1-48d0-ba69-06b9569e1e38.jpg?1",
             "name": "Adventurous Impulse",
             "text": "",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "8f19c488-4679-5a78-b741-87ead6b987e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07a16f-d836-40f9-85e3-a78582a97109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07a16f-d836-40f9-85e3-a78582a97109.jpg?1",
             "name": "Channel",
             "text": "",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "c66ab597-41eb-5630-9649-188f334995cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3896717-1e46-4aa2-88b7-1c4fe76edde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3896717-1e46-4aa2-88b7-1c4fe76edde1.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "7734305a-0e03-58c9-81c6-08e8b49277b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1f1110-0919-49cd-8b5b-979b2744fd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1f1110-0919-49cd-8b5b-979b2744fd3c.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "f4815e02-8a63-5264-8690-ac8c16f3032e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f847439f-a9b6-4a3c-abd1-76d54e0aed99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f847439f-a9b6-4a3c-abd1-76d54e0aed99.jpg?1",
             "name": "Krosan Grip",
             "text": "",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "f2dcba03-a3af-5765-a1cc-cf9d5c74be12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb72f05-5173-4e70-9e71-278249b378e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb72f05-5173-4e70-9e71-278249b378e7.jpg?1",
             "name": "Natural Order",
             "text": "",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "cc9bd5a0-29d0-567a-acf2-e4802f2b8e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a95986b-532b-4e3a-acf4-c93c6db7282f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a95986b-532b-4e3a-acf4-c93c6db7282f.jpg?1",
             "name": "Primal Command",
             "text": "",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "57c98957-faf8-5e50-b99d-e3a759b8b95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af727601-5251-48b6-b5e3-b68ca0608bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af727601-5251-48b6-b5e3-b68ca0608bc9.jpg?1",
             "name": "Regrowth",
             "text": "",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "2ee6bf47-28c5-572c-bf13-814d89b0c97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9849b22-1fba-4f6a-bd94-df1bc1764e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9849b22-1fba-4f6a-bd94-df1bc1764e6b.jpg?1",
             "name": "Snakeskin Veil",
             "text": "",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "89201a00-004d-5c31-8ec3-22aa29955cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f960f2-1324-4d48-bab7-c46b836a8907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f960f2-1324-4d48-bab7-c46b836a8907.jpg?1",
             "name": "Weather the Storm",
             "text": "",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "4e12c252-8472-585d-ab45-0899b881964d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2743ca3-8b4a-429a-9f9b-090d632b6601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2743ca3-8b4a-429a-9f9b-090d632b6601.jpg?1",
             "name": "Despark",
             "text": "",
             "colours": [
@@ -2071,7 +2071,7 @@
         },
         {
             "id": "5505e002-9b32-5663-a6cf-e0f7feafdc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a4d142-b98b-4027-94cb-314f67fb1d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a4d142-b98b-4027-94cb-314f67fb1d4a.jpg?1",
             "name": "Electrolyze",
             "text": "",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "548269c5-ec1b-57c9-9ee7-3ddf15b87342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f9b3d-d463-4bc6-b822-872a1f8867c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f9b3d-d463-4bc6-b822-872a1f8867c8.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "f954cf5c-27f6-5697-bbbb-d0e9e0e512a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227ac87a-7196-40d0-ab00-98ebafcca09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227ac87a-7196-40d0-ab00-98ebafcca09a.jpg?1",
             "name": "Lightning Helix",
             "text": "",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "5b8b55a6-e617-5193-ae47-fbf37c1e7039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3882ebea-2864-40ef-a21d-6ba80a0bd417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3882ebea-2864-40ef-a21d-6ba80a0bd417.jpg?1",
             "name": "Putrefy",
             "text": "",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "ed046aad-eca7-5748-9758-45cf57ec808d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058a72-ebfe-4957-a7dd-ee7471db2498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058a72-ebfe-4957-a7dd-ee7471db2498.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "4e6a712b-1915-5a36-871f-509c1e80bee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6d72d-ef92-46b2-853f-003ae6250d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6d72d-ef92-46b2-853f-003ae6250d30.jpg?1",
             "name": "Day of Judgment",
             "text": "",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "f0b1e552-c3ae-55e4-87d4-b74e2603fe4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7d1e-8bf9-4558-9480-6f0423f36b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7d1e-8bf9-4558-9480-6f0423f36b81.jpg?1",
             "name": "Defiant Strike",
             "text": "",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "12bcd131-e24e-5e41-90b9-a4029e7b4b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac62fae3-2525-4b71-80d1-83e608070e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac62fae3-2525-4b71-80d1-83e608070e4f.jpg?1",
             "name": "Divine Gambit",
             "text": "",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "d408e6ad-7071-52f4-97fa-171008b0db3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704397a-c180-44ae-9e4e-90180556b87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704397a-c180-44ae-9e4e-90180556b87b.jpg?1",
             "name": "Ephemerate",
             "text": "",
             "colours": [
@@ -2394,7 +2394,7 @@
         },
         {
             "id": "be9bf7bc-4443-542e-ac67-8d250301762c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfaa364-55d3-402b-83f0-69ffae82304f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfaa364-55d3-402b-83f0-69ffae82304f.jpg?1",
             "name": "Gift of Estates",
             "text": "",
             "colours": [
@@ -2429,7 +2429,7 @@
         },
         {
             "id": "7f3eaea7-fb9e-5f64-8b51-9bf425d7233c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54bc478b-fb90-4071-acdd-ae6ff33334fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54bc478b-fb90-4071-acdd-ae6ff33334fd.jpg?1",
             "name": "Gods Willing",
             "text": "",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "8b415ddf-2d01-5e98-9b14-ac39df65cc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89aafeb7-31e3-4389-9c4e-4903c342a021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89aafeb7-31e3-4389-9c4e-4903c342a021.jpg?1",
             "name": "Mana Tithe",
             "text": "",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "55405865-7008-553b-b538-9230c3097376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dbdc3f-aa48-4a59-adab-e0a8e981295a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dbdc3f-aa48-4a59-adab-e0a8e981295a.jpg?1",
             "name": "Revitalize",
             "text": "",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "54146218-c228-5e3f-b7de-58fe8df5aabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d364f3-e3e7-46fb-8273-aabd56ded0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d364f3-e3e7-46fb-8273-aabd56ded0c5.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -2569,7 +2569,7 @@
         },
         {
             "id": "e96b5624-8d29-5d50-a9e4-7d76c84588a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f56fbb-c88a-4d10-a6c1-fef72403c4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f56fbb-c88a-4d10-a6c1-fef72403c4b9.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "58b1d759-8203-5f28-bdd6-560ed86c9197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ca1405-fb1d-467b-ab00-f28fc0fe6c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ca1405-fb1d-467b-ab00-f28fc0fe6c03.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "ca755309-6af6-58f4-aa3b-46c39e59a94c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6118d1d-28c1-4f54-97cb-c4f934b6739c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6118d1d-28c1-4f54-97cb-c4f934b6739c.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "8c0010d7-e40f-5d61-b6f1-6ff66d3dacb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5bd95-4de8-4acc-8e6f-bbfbf55d57a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5bd95-4de8-4acc-8e6f-bbfbf55d57a9.jpg?1",
             "name": "Compulsive Research",
             "text": "",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "401e8986-c5d1-5d58-a8af-5e4986281bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8118282a-1473-4c0b-a283-1f58e0d0209a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8118282a-1473-4c0b-a283-1f58e0d0209a.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "d7fdf083-e660-5529-b274-6188542b34fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13636e52-aee6-4262-9b4d-a2979193bfa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13636e52-aee6-4262-9b4d-a2979193bfa3.jpg?1",
             "name": "Memory Lapse",
             "text": "",
             "colours": [
@@ -2779,7 +2779,7 @@
         },
         {
             "id": "c9f23490-55b7-5c3c-a1fb-d59c8d38cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7550cf1f-bf03-489e-8ec5-19c835f785ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7550cf1f-bf03-489e-8ec5-19c835f785ff.jpg?1",
             "name": "Mind's Desire",
             "text": "",
             "colours": [
@@ -2814,7 +2814,7 @@
         },
         {
             "id": "6c82bc6b-0e97-5283-ae43-e5d16f53e19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35308c10-f8e9-4c35-a680-a3dfe16ac63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35308c10-f8e9-4c35-a680-a3dfe16ac63a.jpg?1",
             "name": "Negate",
             "text": "",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "147f4ba1-2e38-557c-bce6-4c9c46654d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5017e7-2da9-48be-8dc3-458a1374b97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5017e7-2da9-48be-8dc3-458a1374b97c.jpg?1",
             "name": "Opt",
             "text": "",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "a0989a7f-3ab5-5cf6-9581-312186301a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f48a9-4d6a-4ca6-b99e-d6b1dfac7e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f48a9-4d6a-4ca6-b99e-d6b1dfac7e04.jpg?1",
             "name": "Strategic Planning",
             "text": "",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "ca46692a-ee82-520f-931f-3810b818e6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de53b7d-f2de-47aa-b5d4-9427c12484b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de53b7d-f2de-47aa-b5d4-9427c12484b0.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "1701ae3a-110d-5281-946a-cae994a333d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f0f4cb-1ef6-44cd-8cca-1d1e138c0344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f0f4cb-1ef6-44cd-8cca-1d1e138c0344.jpg?1",
             "name": "Time Warp",
             "text": "",
             "colours": [
@@ -2989,7 +2989,7 @@
         },
         {
             "id": "f41d4b9d-8e58-56d6-a889-92024fde8001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7949ab59-cd09-4500-a323-5ba05392623f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7949ab59-cd09-4500-a323-5ba05392623f.jpg?1",
             "name": "Whirlwind Denial",
             "text": "",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "d50b8669-352c-58d9-8cb4-6352e1f0a5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31b98f3-acc0-4113-8f70-86bf2d36b9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31b98f3-acc0-4113-8f70-86bf2d36b9c1.jpg?1",
             "name": "Agonizing Remorse",
             "text": "",
             "colours": [
@@ -3059,7 +3059,7 @@
         },
         {
             "id": "bc6e4406-cd15-5fea-b6db-4244ded0c3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb53cc-384e-4ae2-afa5-541100c92951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb53cc-384e-4ae2-afa5-541100c92951.jpg?1",
             "name": "Crux of Fate",
             "text": "",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "3dc7594d-7284-57ad-ac69-6df7721f55d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734cb11-2024-411f-9885-dafda14bb431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734cb11-2024-411f-9885-dafda14bb431.jpg?1",
             "name": "Dark Ritual",
             "text": "",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "b076bded-cee7-5f26-b9d8-3540918f68fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b6e466-784b-48a6-8e72-beff72f39231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b6e466-784b-48a6-8e72-beff72f39231.jpg?1",
             "name": "Demonic Tutor",
             "text": "",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "ac7ced0f-271b-5894-bad8-b18ae97683c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6565f48-185f-4977-8edc-4840b784d29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6565f48-185f-4977-8edc-4840b784d29d.jpg?1",
             "name": "Doom Blade",
             "text": "",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "306faf06-ccfb-52ec-a65c-472844647a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e96127-83e2-42e2-9799-998b1408d444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e96127-83e2-42e2-9799-998b1408d444.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "323320b5-ac87-5bbc-ae38-1ce1bc04f876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e93381-0192-4b89-af64-dcc7150b757b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e93381-0192-4b89-af64-dcc7150b757b.jpg?1",
             "name": "Eliminate",
             "text": "",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "66dea51f-cfc8-5b34-8eb7-0d3c9b576c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6af6cee-a60a-4953-8e22-c3bddc435619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6af6cee-a60a-4953-8e22-c3bddc435619.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "cc4c252a-2218-570b-bd74-507b4bd6532e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d32dfc4-ba8f-4421-b05f-4bf3afd592f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d32dfc4-ba8f-4421-b05f-4bf3afd592f7.jpg?1",
             "name": "Sign in Blood",
             "text": "",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "d61b8327-42fb-5ce2-a75d-e1446ceb5c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8f466f-83ec-4d72-90de-0e30069f7ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8f466f-83ec-4d72-90de-0e30069f7ecd.jpg?1",
             "name": "Tainted Pact",
             "text": "",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "dff7bd91-c681-54e3-becd-1b5dec60a02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1541b593-a7f1-4e6b-aff6-d6341cf8fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1541b593-a7f1-4e6b-aff6-d6341cf8fec5.jpg?1",
             "name": "Tendrils of Agony",
             "text": "",
             "colours": [
@@ -3409,7 +3409,7 @@
         },
         {
             "id": "271a4d0e-c34c-5d67-af23-fc6b43e92794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e6276c-0b80-4d11-b889-8a24b210c4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e6276c-0b80-4d11-b889-8a24b210c4f0.jpg?1",
             "name": "Village Rites",
             "text": "",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "ff95a769-1dd1-5576-bd0a-c754a73580b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb63b8-9c7f-411a-a1bf-6c9cccdc6307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb63b8-9c7f-411a-a1bf-6c9cccdc6307.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "552dcb7d-66a5-5ef2-9b97-b87823452a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fba553e-eca3-453e-8f67-ec7e5c9f3946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fba553e-eca3-453e-8f67-ec7e5c9f3946.jpg?1",
             "name": "Claim the Firstborn",
             "text": "",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "f01f5f69-d141-5648-9db8-9261cfc16743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052a5cd-81b3-40ef-94e0-7c89e9554e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052a5cd-81b3-40ef-94e0-7c89e9554e33.jpg?1",
             "name": "Faithless Looting",
             "text": "",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "c0a2cbd7-84cb-5158-93f5-71a439fb7f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc58957e-dbf0-40ac-9ec4-05fea0c61880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc58957e-dbf0-40ac-9ec4-05fea0c61880.jpg?1",
             "name": "Grapeshot",
             "text": "",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "1c5df8c2-95a9-5bf0-8910-244cb8f33324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4867546-a609-4958-a48e-522fb9258faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4867546-a609-4958-a48e-522fb9258faf.jpg?1",
             "name": "Increasing Vengeance",
             "text": "",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "ae5d691c-6ddf-58b0-ada0-4a1c07fd904e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67983e97-a990-4f89-811c-a58a0a10a701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67983e97-a990-4f89-811c-a58a0a10a701.jpg?1",
             "name": "Infuriate",
             "text": "",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "440af151-df38-5152-979d-84009ab7e1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14fae63-2e82-49c1-8e62-d84a65f27479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14fae63-2e82-49c1-8e62-d84a65f27479.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "655b0332-f1f3-5826-9267-1f09f5e25a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25534-2bc3-4813-ae63-63cadfe36df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25534-2bc3-4813-ae63-63cadfe36df6.jpg?1",
             "name": "Mizzix's Mastery",
             "text": "",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "bfa5663c-7ba1-59c7-b3f4-e59f2e4c838d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a8702-464b-44fd-b706-8a73dd9b0097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a8702-464b-44fd-b706-8a73dd9b0097.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "7f74148c-89e5-5b9a-995c-1ba08dab347c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290f3d7-3c45-464c-afae-78bb2615aaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290f3d7-3c45-464c-afae-78bb2615aaf4.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "daee9af1-069c-5c25-8582-6b40867e1ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05123ba5-7e35-4d3f-8354-e784ce8f1b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05123ba5-7e35-4d3f-8354-e784ce8f1b98.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "624254f7-c66d-5443-a51f-3df1d232c3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d27e1f-ed0d-44c6-8070-d764d4e9c0fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d27e1f-ed0d-44c6-8070-d764d4e9c0fb.jpg?1",
             "name": "Urza's Rage",
             "text": "",
             "colours": [
@@ -3864,7 +3864,7 @@
         },
         {
             "id": "b9170a8e-452a-5f9d-8452-7ffbb762da24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb246be3-d9cb-4753-8d8c-0c770a584090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb246be3-d9cb-4753-8d8c-0c770a584090.jpg?1",
             "name": "Abundant Harvest",
             "text": "",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "d19869ca-98cd-58a0-a17e-0e5d518c382e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c56784-e106-4f17-a1a3-2c0bbb41d316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c56784-e106-4f17-a1a3-2c0bbb41d316.jpg?1",
             "name": "Adventurous Impulse",
             "text": "",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "ed372693-6581-5688-8c9f-5eb8927980b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f4583d-a532-4c67-ad50-138f35fa7490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f4583d-a532-4c67-ad50-138f35fa7490.jpg?1",
             "name": "Channel",
             "text": "",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "bd664d3f-7430-5f0f-95e8-cde214836267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8386ca9-0359-4a18-abea-0cb0e955a947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8386ca9-0359-4a18-abea-0cb0e955a947.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "07e6a104-44d6-5ec4-859f-9d9af3d3204b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb853d72-9b29-4ea1-80db-da9e0b547ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb853d72-9b29-4ea1-80db-da9e0b547ad5.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "1a23f3a0-c996-55b2-afbe-6662c30a9ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea70da6-8da5-4c9b-8b6d-6a876b046274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea70da6-8da5-4c9b-8b6d-6a876b046274.jpg?1",
             "name": "Krosan Grip",
             "text": "",
             "colours": [
@@ -4074,7 +4074,7 @@
         },
         {
             "id": "f1a12f85-224c-5cc6-b7c4-438d46ea6028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac43bf2-08e1-4b63-ac4f-ccc565ca2cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac43bf2-08e1-4b63-ac4f-ccc565ca2cee.jpg?1",
             "name": "Natural Order",
             "text": "",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "5d130600-f768-58db-804b-9498c0080b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f2c89-dbe9-4b44-b892-8e2325860e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f2c89-dbe9-4b44-b892-8e2325860e62.jpg?1",
             "name": "Primal Command",
             "text": "",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "52fdddb8-ba70-5af9-a307-fe74d2f90e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d0ec3e-10c6-4401-a21f-b767318120b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d0ec3e-10c6-4401-a21f-b767318120b6.jpg?1",
             "name": "Regrowth",
             "text": "",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "df348b74-ab45-5fcd-8103-9b959ab7690d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e909bd04-5394-4888-aa4a-4f90855663bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e909bd04-5394-4888-aa4a-4f90855663bb.jpg?1",
             "name": "Snakeskin Veil",
             "text": "",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "24fe9ab0-39ed-582a-b9d5-3b4b94624f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b9f50-2b6c-4ef5-8b72-0bf7e160909e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b9f50-2b6c-4ef5-8b72-0bf7e160909e.jpg?1",
             "name": "Weather the Storm",
             "text": "",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "c8e877ab-1888-5e7a-bb97-2fd8f7a447d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e0de9d-de5b-4a95-95af-aef4cc546a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e0de9d-de5b-4a95-95af-aef4cc546a94.jpg?1",
             "name": "Despark",
             "text": "",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "fd84e759-71d3-5168-8a2e-d664c45429f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8212125e-1742-41db-a7e9-32df59441f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8212125e-1742-41db-a7e9-32df59441f4e.jpg?1",
             "name": "Electrolyze",
             "text": "",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "5ffc4691-8ad0-5098-bedd-82123231fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffea9e1d-10e1-458b-afba-e33ce9695322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffea9e1d-10e1-458b-afba-e33ce9695322.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "2a940483-818a-5090-9d38-ac59eaed5521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47eb569f-9f8d-4856-acf9-f8e87baa19d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47eb569f-9f8d-4856-acf9-f8e87baa19d0.jpg?1",
             "name": "Lightning Helix",
             "text": "",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "782fea05-9868-595d-889a-dcb6eb3034af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee093aa-87ad-4a9e-8edf-e397fb1dd6aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee093aa-87ad-4a9e-8edf-e397fb1dd6aa.jpg?1",
             "name": "Putrefy",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/STH.json
+++ b/Assets/Resources/Sets/STH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "675bebc5-f1bd-5afb-9fd8-6539d4fefb7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ed559a-9a88-43d2-85d1-4bbec038f71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ed559a-9a88-43d2-85d1-4bbec038f71e.jpg?1",
             "name": "Bandage",
             "text": "Prevent 1 damage to any creature or player.\nDraw a card.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "b2e435b3-11f6-564a-8945-41a51581a960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155fc239-c2eb-41cc-9a0a-2414da3c3d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155fc239-c2eb-41cc-9a0a-2414da3c3d7b.jpg?1",
             "name": "Calming Licid",
             "text": "o\nW, oc\nT: Calming Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature cannot attack\" instead of a creature. Move Calming Licid onto target creature. You may pay o\nW to end this effect.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "e0f32f03-8dfc-5ae7-8027-4b74d0a759a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afaf277e-b430-4c96-880c-ae654973478c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afaf277e-b430-4c96-880c-ae654973478c.jpg?1",
             "name": "Change of Heart",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature cannot attack this turn.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "933cbf49-c2d5-5c7c-a918-4c4e0e4b05ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848672be-b1cd-40ef-a7ed-ce1620aebd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848672be-b1cd-40ef-a7ed-ce1620aebd2e.jpg?1",
             "name": "Contemplation",
             "text": "Whenever you successfully cast a spell, gain 1 life.",
             "colours": [
@@ -130,7 +130,7 @@
         },
         {
             "id": "ce2f567b-34db-5dda-ad8e-38b30e070b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190332b3-6a1c-4c25-af61-d8923fc9a0c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190332b3-6a1c-4c25-af61-d8923fc9a0c3.jpg?1",
             "name": "Conviction",
             "text": "Enchanted creature gets +1/+3.\noo\nW Return Conviction to owner's hand.",
             "colours": [
@@ -163,7 +163,7 @@
         },
         {
             "id": "75085e3d-ed0b-578c-9e47-2f621405d7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be86f1f-c85a-4396-aa16-a39fbf493c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be86f1f-c85a-4396-aa16-a39fbf493c96.jpg?1",
             "name": "Hidden Retreat",
             "text": "Choose a card in your hand and put it on top of your library: Prevent all damage from an instant or sorcery. (Treat further damage from that source normally.)",
             "colours": [
@@ -194,7 +194,7 @@
         },
         {
             "id": "b2e74650-cf80-553b-851c-bf97aedc2c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c44137-ddcc-42fa-baff-a0c3785b84ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c44137-ddcc-42fa-baff-a0c3785b84ee.jpg?1",
             "name": "Honor Guard",
             "text": "oo\nW Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "810874fa-d086-55bd-814a-5469f6f928a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7cd99c2-6d4a-48e8-8848-6fdc0788525d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7cd99c2-6d4a-48e8-8848-6fdc0788525d.jpg?1",
             "name": "Lancers en-Kor",
             "text": "Trample\no0: Redirect 1 damage from Lancers en-Kor to a creature you control.",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "7e43fde6-6164-52f6-8e55-05733aaea941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a03c68-0ebe-488a-8e6c-7cbf7a448416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a03c68-0ebe-488a-8e6c-7cbf7a448416.jpg?1",
             "name": "Nomads en-Kor",
             "text": "o0: Redirect 1 damage from Nomads\nen-Kor to a creature you control.",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "f222e812-013d-5251-bdd5-12217fa71a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa577b1-2604-4065-a973-166521682a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa577b1-2604-4065-a973-166521682a86.jpg?1",
             "name": "Pursuit of Knowledge",
             "text": "Skip drawing a card: Put a study counter on Pursuit of Knowledge.\nRemove three study counters from Pursuit of Knowledge, Sacrifice Pursuit of Knowledge: Draw seven cards.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "9120f6dd-1fa6-570d-a6fd-6577d145e1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27e9c9-0a47-4fa3-9da5-1993f20305c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27e9c9-0a47-4fa3-9da5-1993f20305c2.jpg?1",
             "name": "Rolling Stones",
             "text": "Walls can attack as though they were not Walls.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "186d626a-0758-5658-9a54-b469ff712e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ae4b01-a9c1-4eec-9204-78cb2508e0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ae4b01-a9c1-4eec-9204-78cb2508e0df.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever an effect controlled by any opponent puts a land into your graveyard from play, put that land into play.",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "2c73e61e-a1e3-5154-8f93-b82ea14fc687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b21aa2e-df36-4101-89b6-515858f2ab88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b21aa2e-df36-4101-89b6-515858f2ab88.jpg?1",
             "name": "Samite Blessing",
             "text": "Enchanted creature gains \"oc\nT: Prevent all damage to any creature from any one source.\" (Treat further damage from that source normally.)",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "8fba3d96-0973-5145-98ab-d488c71793f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20454d36-d98d-4421-b3aa-d2dd4b368d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20454d36-d98d-4421-b3aa-d2dd4b368d84.jpg?1",
             "name": "Scapegoat",
             "text": "Sacrifice a creature: Return any number of target creatures you control to owner's hand.",
             "colours": [
@@ -454,7 +454,7 @@
         },
         {
             "id": "9225312b-0bc4-5731-81c4-ba550d7cdece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a13c4c-d5c0-4947-bb68-d2e9611bcdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a13c4c-d5c0-4947-bb68-d2e9611bcdea.jpg?1",
             "name": "Shaman en-Kor",
             "text": "o0: Redirect 1 damage from Shaman en-Kor to a creature you control.\no1oo\nW Redirect to Shaman en-Kor all damage dealt to any one creature from any one source.",
             "colours": [
@@ -489,7 +489,7 @@
         },
         {
             "id": "708332d1-35b0-53db-ab76-c23defb855a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb86621-1a6e-4d56-ab0e-531105775c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb86621-1a6e-4d56-ab0e-531105775c56.jpg?1",
             "name": "Skyshroud Falcon",
             "text": "Flying\nAttacking does not cause Skyshroud Falcon to tap.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "eb74fc17-bf66-5a4d-b611-f0669e1dcbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f165ad-cfe6-4a5d-8073-a70969494855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f165ad-cfe6-4a5d-8073-a70969494855.jpg?1",
             "name": "Smite",
             "text": "Destroy target blocked creature.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "2c0ef642-0713-5393-bbeb-a23383b8c319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a112edf3-c976-426c-a407-e86255586e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a112edf3-c976-426c-a407-e86255586e41.jpg?1",
             "name": "Soltari Champion",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Champion attacks, all other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "26f8edd8-f69a-5e49-988c-764aab89b319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8adc368-ede3-4b1c-af93-a5e0f2e24d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8adc368-ede3-4b1c-af93-a5e0f2e24d83.jpg?1",
             "name": "Spirit en-Kor",
             "text": "Flying\no0: Redirect 1 damage from Spirit en-Kor to a creature you control.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "92a3aa8d-9893-531d-a889-e97c5350c0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bff910-24ab-45a0-b014-30bef6263c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bff910-24ab-45a0-b014-30bef6263c38.jpg?1",
             "name": "Temper",
             "text": "Prevent up to X damage to target creature. For each 1 damage prevented in this way, put a +1/+1 counter on that creature.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "b615becb-2e05-5634-9e79-89280b090134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b8be3-4ed8-4e94-aa66-c7187a299088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b8be3-4ed8-4e94-aa66-c7187a299088.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, gain 2 life.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "418f7715-2e6e-5205-a2b2-76f762188919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f237426-a657-4234-9f79-0a06558eeb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f237426-a657-4234-9f79-0a06558eeb39.jpg?1",
             "name": "Wall of Essence",
             "text": "(Walls cannot attack.)\nFor each 1 combat damage dealt to Wall of Essence, gain 1 life.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "62bca95c-03f4-5226-96b9-0315db43adb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9ca33-3e9b-4ed9-b503-a1c09c17ca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9ca33-3e9b-4ed9-b503-a1c09c17ca8b.jpg?1",
             "name": "Warrior en-Kor",
             "text": "o0: Redirect 1 damage from Warrior en-Kor to a creature you control.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "bb9be985-8890-5773-93a1-e859e2ff4270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d2c6e3-e556-4cc6-94b6-fdbc62d6853e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d2c6e3-e556-4cc6-94b6-fdbc62d6853e.jpg?1",
             "name": "Warrior Angel",
             "text": "Flying\nFor each 1 damage Warrior Angel deals, gain 1 life.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "f5b894d4-cf06-513f-afdd-38711427b399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd3b7a7-c5e8-4179-ade3-31625620f3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd3b7a7-c5e8-4179-ade3-31625620f3a9.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "2b1d303c-14a8-541a-911e-c717d302d8d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d6c51-903b-4e0b-8702-291666581f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d6c51-903b-4e0b-8702-291666581f2a.jpg?1",
             "name": "Cloud Spirit",
             "text": "Flying\nCloud Spirit can block only creatures with flying.",
             "colours": [
@@ -856,7 +856,7 @@
         },
         {
             "id": "ef342c7d-9d56-57d3-82cc-6bee47b9c745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fa8e60-c32f-4586-b133-224f0aec3355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fa8e60-c32f-4586-b133-224f0aec3355.jpg?1",
             "name": "Contempt",
             "text": "If enchanted creature attacks, return that creature and Contempt to owner's hand at end of combat.",
             "colours": [
@@ -889,7 +889,7 @@
         },
         {
             "id": "5c6b0226-1c2d-508c-a460-31cf3c2f41f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a22d9-007b-4eb7-af9e-b5c2cae36238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a22d9-007b-4eb7-af9e-b5c2cae36238.jpg?1",
             "name": "Dream Halls",
             "text": "Instead of paying the casting cost for a spell of any color, its caster may choose and discard a card that shares at least one color with that spell. If the spell has o\nX in its casting cost, X is 0.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "4dc92ace-d99d-5ea2-afb1-aff99dc1fb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1444f76b-c876-4166-b957-b17313221fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1444f76b-c876-4166-b957-b17313221fea.jpg?1",
             "name": "Dream Prowler",
             "text": "Dream Prowler is unblockable as long as no other creatures are attacking.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "f4eb5e64-6ab1-5c3c-8bcb-b74750b9d840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8ae53-a53f-4a0f-94f7-559aca041797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8ae53-a53f-4a0f-94f7-559aca041797.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to owners' hands.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "cafe8b4e-1311-5e8a-a056-f715222abf8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0148f3ca-4dba-4408-86d0-1190c387ee69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0148f3ca-4dba-4408-86d0-1190c387ee69.jpg?1",
             "name": "Gliding Licid",
             "text": "o\nU, oc\nT: Gliding Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature gains flying\" instead of a creature. Move Gliding Licid onto target creature. You may pay o\nU to end this effect.",
             "colours": [
@@ -1017,7 +1017,7 @@
         },
         {
             "id": "86664b5b-f1ae-5d45-b0fa-b01c40af163c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854627ab-38bd-4894-94d8-9ef51a57579c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854627ab-38bd-4894-94d8-9ef51a57579c.jpg?1",
             "name": "Hammerhead Shark",
             "text": "Hammerhead Shark cannot attack unless defending player controls any islands.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "55d1ca21-c94e-5ee1-8388-bcb1bc51e28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ce5dbc-3597-42e8-859a-cac105c8102e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ce5dbc-3597-42e8-859a-cac105c8102e.jpg?1",
             "name": "Hesitation",
             "text": "If any spell is played, counter that spell and sacrifice Hesitation.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "7eca4342-5eb0-5d72-96b3-de3bb5015555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55f653-0952-4713-8d43-ca50acff9e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55f653-0952-4713-8d43-ca50acff9e3b.jpg?1",
             "name": "Intruder Alarm",
             "text": "Creatures do not untap during their controllers' untap phases.\nWhenever any creature comes into play, untap all creatures.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "9c899942-cbf5-5b17-b229-c64917490240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0841423d-7a27-4bc5-9ac2-0ba47648c6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0841423d-7a27-4bc5-9ac2-0ba47648c6f1.jpg?1",
             "name": "Leap",
             "text": "Target creature gains flying until end of turn.\nDraw a card.",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "617799a8-2f8f-50a4-98fe-f2537f5c1563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcaf16d-aa02-43e2-aa38-bb1835d47a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcaf16d-aa02-43e2-aa38-bb1835d47a05.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its caster pays an additional o3.",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "36ca89b7-ada5-5906-9015-fca253ffc7c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09891c87-eb74-4174-ad46-11a7f79de859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09891c87-eb74-4174-ad46-11a7f79de859.jpg?1",
             "name": "Mask of the Mimic",
             "text": "Sacrifice a creature: Search your library for any copy of target creature card and put it into play. Shuffle your library afterwards.",
             "colours": [
@@ -1205,7 +1205,7 @@
         },
         {
             "id": "81ae7143-71fe-5f80-84c0-c5a237afb57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da50979-1f5d-48d1-9406-dfc785273c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da50979-1f5d-48d1-9406-dfc785273c04.jpg?1",
             "name": "Mind Games",
             "text": "Buyback o2o\nU (You may pay an additional o2o\nU when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTap target artifact, creature, or land.",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "6d2ebf2f-0602-5945-b9dc-cf2321f803c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b438802b-629a-42c8-824d-f081a1619f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b438802b-629a-42c8-824d-f081a1619f68.jpg?1",
             "name": "Ransack",
             "text": "Look at the top five cards of target player's library. Put any number of those cards on the bottom of that library in any order and the rest on top of the library in any order.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "bfc7396c-7bbd-504f-883e-70e679e310e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6ca66e-1116-4739-8375-87af99e9bba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6ca66e-1116-4739-8375-87af99e9bba5.jpg?1",
             "name": "Rebound",
             "text": "Target spell, which targets only a single player, targets another player of your choice instead.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "7f9037ae-3986-56f3-8300-75312e0296fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a9242f-0516-4dae-8cbc-1f7f78931782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a9242f-0516-4dae-8cbc-1f7f78931782.jpg?1",
             "name": "Reins of Power",
             "text": "You and target opponent each untap and gain control of all creatures the other controls until end of turn. Those creatures are unaffected by summoning sickness this turn.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "08176bc3-2707-53aa-ac1e-6ff5153d8965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b23da-9ba8-4b43-a5c9-51e1fc253913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b23da-9ba8-4b43-a5c9-51e1fc253913.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then choose and discard a card.",
             "colours": [
@@ -1360,7 +1360,7 @@
         },
         {
             "id": "68602373-23d5-5cc6-8ae2-2383003fcb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a20067-4ac2-4688-b8e8-3463185c4a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a20067-4ac2-4688-b8e8-3463185c4a41.jpg?1",
             "name": "Silver Wyvern",
             "text": "Flying\noo\nU Target spell or ability, which targets only Silver Wyvern, targets another creature of your choice instead. Play this ability as an interrupt.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "82b756c1-7c31-5d6f-9eb7-0dfd4f51fde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c881c388-430f-4a4b-9cd1-fba0a2bc2cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c881c388-430f-4a4b-9cd1-fba0a2bc2cd6.jpg?1",
             "name": "Spindrift Drake",
             "text": "Flying\nDuring your upkeep, pay o\nU or sacrifice Spindrift Drake.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "7e8c8da9-ecb2-5aad-8048-e6128ec5cfaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cc2f5-3a50-40c8-87ea-6b92f081f55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cc2f5-3a50-40c8-87ea-6b92f081f55c.jpg?1",
             "name": "Thalakos Deceiver",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSacrifice Thalakos Deceiver: Gain control of target creature permanently. Use this ability only if Thalakos Deceiver is attacking and unblocked.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "8b981db6-4480-5bf6-ab9c-31aacbfd7bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8737440b-0bf0-483f-895b-aa24da2b9cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8737440b-0bf0-483f-895b-aa24da2b9cfe.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap up to three target creatures without flying.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "cfd2004e-5849-5253-bd00-7973e996d7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab89a30a-ac4d-4a5e-bbff-a02366bc9cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab89a30a-ac4d-4a5e-bbff-a02366bc9cf6.jpg?1",
             "name": "Tidal Warrior",
             "text": "oc\nT: Target land is an island until end of turn.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "1f38c990-914f-5ee1-908e-7d5f97c8bc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec89ee13-34ef-41c8-8fe4-0a6b21df2032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec89ee13-34ef-41c8-8fe4-0a6b21df2032.jpg?1",
             "name": "Volrath's Shapeshifter",
             "text": "As long as the top card of your graveyard is a creature card, Volrath's Shapeshifter is a copy of that card, except that Volrath's Shapeshifter retains its abilities.\no2: Choose and discard a card.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "d83138d3-7134-59a1-b595-3588049e892a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2f906d-b127-400a-809b-449f1e7f647b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2f906d-b127-400a-809b-449f1e7f647b.jpg?1",
             "name": "Walking Dream",
             "text": "Walking Dream is unblockable.\nWalking Dream does not untap during your untap phase if any opponent controls two or more creatures.",
             "colours": [
@@ -1592,7 +1592,7 @@
         },
         {
             "id": "b0120f4d-a14c-5cd6-931d-5259e08b8086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4638d815-fb86-490c-84d6-777a1c6131d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4638d815-fb86-490c-84d6-777a1c6131d6.jpg?1",
             "name": "Wall of Tears",
             "text": "(Walls cannot attack.)\nIf Wall of Tears blocks any creatures, return each of those creatures to owner's hand at end of combat.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "fb9d985f-65da-51e6-ba2e-d644592af2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f05fc3-da6e-45d4-8566-f4e7bdce1fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f05fc3-da6e-45d4-8566-f4e7bdce1fe5.jpg?1",
             "name": "Bottomless Pit",
             "text": "During each player's upkeep, that player discards a card at random.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "12e89573-7164-58c8-9cc7-e09824810855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04013bc6-7774-400b-a6af-de755b4c324d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04013bc6-7774-400b-a6af-de755b4c324d.jpg?1",
             "name": "Brush with Death",
             "text": "Buyback o2o\nBo\nB (You may pay an additional o2o\nBo\nB when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget opponent loses 2 life. You gain 2 life.",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "e8105f21-8e30-53e6-85f9-6f7ab9552402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0896ae6-fe96-44e8-ba62-a6d3fc1aae4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0896ae6-fe96-44e8-ba62-a6d3fc1aae4f.jpg?1",
             "name": "Cannibalize",
             "text": "Choose two target creatures controlled by any one player. Remove one of those creatures from the game and put two +1/+1 counters on the other.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "8987f955-a2d2-5880-8581-ab2d47ab58d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12c6548-20e6-4697-ba26-e711590f9e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12c6548-20e6-4697-ba26-e711590f9e28.jpg?1",
             "name": "Corrupting Licid",
             "text": "o\nB, oc\nT: Corrupting Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature cannot be blocked except by artifact creatures and black creatures\" instead of a creature. Move Corrupting Licid onto target creature. You may pay o\nB to end this effect.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "e18cfffd-dd92-55a2-92e7-fd9ef0531ec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a9b76d-6ce1-40d4-bc04-7ae6237f5eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a9b76d-6ce1-40d4-bc04-7ae6237f5eaf.jpg?1",
             "name": "Crovax the Cursed",
             "text": "Crovax the Cursed counts as a Vampire.\nCrovax comes into play with four +1/+1 counters on it.\nDuring your upkeep, sacrifice a creature and put a +1/+1 counter on Crovax, or remove a +1/+1 counter from Crovax.\noo\nB Crovax gains flying until end of turn.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "326d810e-2c26-545c-a4a6-d4ce2325e030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d83770e-16ff-49c6-b4e7-eb7fc566eef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d83770e-16ff-49c6-b4e7-eb7fc566eef8.jpg?1",
             "name": "Dauthi Trapper",
             "text": "oc\nT: Target creature gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "8b780dbd-2c72-57e5-b2e8-5f0690034ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7478a471-3bd2-4038-a4eb-70c38a43afa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7478a471-3bd2-4038-a4eb-70c38a43afa9.jpg?1",
             "name": "Death Stroke",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "bb7ff696-9066-510f-8366-5fca6bfc1abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a818483-de47-454d-bb24-3410aa95289c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a818483-de47-454d-bb24-3410aa95289c.jpg?1",
             "name": "Dungeon Shade",
             "text": "Flying\noo\nB Dungeon Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "dd04b71b-216b-5295-8da1-3bcd90d15eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35ab62e-d6c6-448c-bbe0-42abe5780adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35ab62e-d6c6-448c-bbe0-42abe5780adc.jpg?1",
             "name": "Foul Imp",
             "text": "Flying\nWhen Foul Imp comes into play, lose 2 life.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "cc027aeb-669d-5ea8-b577-4c94bdb952eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940536be-fce1-4a90-9126-195815a43e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940536be-fce1-4a90-9126-195815a43e0f.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever any creature you control is put into any graveyard, each other player sacrifices a creature.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "405bfda4-8c81-5753-9624-808884938d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3132c128-e0bd-4524-9526-914b3c7181fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3132c128-e0bd-4524-9526-914b3c7181fc.jpg?1",
             "name": "Lab Rats",
             "text": "Buyback o4 (You may pay an additional o4 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPut a Rat token into play. Treat this token as a 1/1 black creature.",
             "colours": [
@@ -1981,7 +1981,7 @@
         },
         {
             "id": "6d0672da-0a20-5c9b-a5e5-3acc27859aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eacd05b-078a-468c-b137-a802346d348a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eacd05b-078a-468c-b137-a802346d348a.jpg?1",
             "name": "Megrim",
             "text": "Whenever any opponent discards a card, Megrim deals 2 damage to him or her.",
             "colours": [
@@ -2012,7 +2012,7 @@
         },
         {
             "id": "fb175e29-7c19-5553-94b2-e636b9870ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bd531c-fdd1-4a22-816e-258b2975c1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bd531c-fdd1-4a22-816e-258b2975c1a3.jpg?1",
             "name": "Mind Peel",
             "text": "Buyback o2o\nBo\nB (You may pay an additional o2o\nBo\nB when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget player chooses and discards a card.",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "3afbccc7-5229-53dc-93f4-313b32a6c3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe796e1-97f9-469a-a6b6-a09161058e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe796e1-97f9-469a-a6b6-a09161058e12.jpg?1",
             "name": "Mindwarper",
             "text": "Mindwarper comes into play with three +1/+1 counters on it.\no2o\nB, Remove a +1/+1 counter from Mindwarper: Target player chooses and discards a card. Play this ability as a sorcery.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "b4c42f35-6d39-5583-9b45-e9a3dbd26bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a26ce-3435-4fef-bc34-abbc6f1cf3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a26ce-3435-4fef-bc34-abbc6f1cf3f4.jpg?1",
             "name": "Morgue Thrull",
             "text": "Sacrifice Morgue Thrull: Put the top three cards of your library into your graveyard.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "3813f06b-052c-5657-af38-57a19217ad1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860f46ea-6fd0-456d-971d-8d1eccc7fa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860f46ea-6fd0-456d-971d-8d1eccc7fa60.jpg?1",
             "name": "Mortuary",
             "text": "Whenever any creature is put into your graveyard from play, put that creature on top of your library.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "f27fa1bf-8cc5-5c79-80d9-28af7f22cb3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8c028e-6656-47ef-97fb-de99f8833d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8c028e-6656-47ef-97fb-de99f8833d5f.jpg?1",
             "name": "Rabid Rats",
             "text": "oc\nT: Target blocking creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2173,7 +2173,7 @@
         },
         {
             "id": "8974d8ac-714c-55d2-8f76-8d31fda79e98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da40601-b6a3-47ca-b5b6-8fdbdf81f3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da40601-b6a3-47ca-b5b6-8fdbdf81f3d4.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant has power and toughness each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "090983e9-557b-5c7c-aba5-07375e74f2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab726e7d-171f-48b2-9652-545e17913330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab726e7d-171f-48b2-9652-545e17913330.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, lose 3 life.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "67de1458-f311-58b9-b700-22233353336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57af1b3f-661a-4b02-be08-0ec721d7cab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57af1b3f-661a-4b02-be08-0ec721d7cab8.jpg?1",
             "name": "Skeleton Scavengers",
             "text": "Skeleton Scavengers comes into play with one +1/+1 counter on it.\nPay o1 for each +1/+1 counter on Skeleton Scavengers: Regenerate Skeleton Scavengers and put a +1/+1 counter on it.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "40e75e1f-f2e7-55cf-a17a-14445d18380f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0f043c-efb3-4392-ae25-b3ec180b0cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0f043c-efb3-4392-ae25-b3ec180b0cb2.jpg?1",
             "name": "Stronghold Assassin",
             "text": "oc\nT, Sacrifice a creature: Destroy target nonblack creature.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "dffe1042-6537-5186-93bb-bcb7f2fe9e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171c210-01b5-45a9-9dd3-dbf96a33a750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171c210-01b5-45a9-9dd3-dbf96a33a750.jpg?1",
             "name": "Stronghold Taskmaster",
             "text": "All other black creatures get -1/-1.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "ea01e34d-ad39-5299-9c99-31f96ba2a225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe74a415-ea8f-4f16-8889-ae649f1483b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe74a415-ea8f-4f16-8889-ae649f1483b2.jpg?1",
             "name": "Torment",
             "text": "Enchanted creature gets -3/-0.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "d5d40677-5087-5f5d-9a7a-9b1597160b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754b92b-d6f9-4503-af01-dee03f72a048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754b92b-d6f9-4503-af01-dee03f72a048.jpg?1",
             "name": "Tortured Existence",
             "text": "o\nB, Choose and discard a creature card: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "f461a63e-d443-521f-bc72-f20587ec234d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca2c333-405f-4c1b-a02a-f1fadb3e1d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca2c333-405f-4c1b-a02a-f1fadb3e1d29.jpg?1",
             "name": "Wall of Souls",
             "text": "(Walls cannot attack.)\nWhenever Wall of Souls is dealt combat damage, it deals an equal amount of damage to target opponent.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "5b740c6e-e20f-528a-a2bf-fbc205953503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5bdb8c-2a2e-47cf-a502-2d62f9ada3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5bdb8c-2a2e-47cf-a502-2d62f9ada3fa.jpg?1",
             "name": "Amok",
             "text": "o1, Discard a card at random: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "8d8824a0-2522-585d-8afb-d22a1263626b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e50a1d-b9f5-4a03-a1c2-ca45ace53a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e50a1d-b9f5-4a03-a1c2-ca45ace53a52.jpg?1",
             "name": "Convulsing Licid",
             "text": "o\nR, oc\nT: Convulsing Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature cannot block\" instead of a creature. Move Convulsing Licid onto target creature. You may pay o\nR to end this effect.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "6e57cfe4-0d2a-5bd9-b773-e77161a9f814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cf964-88f6-4e62-97ce-cf0e179a53fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cf964-88f6-4e62-97ce-cf0e179a53fb.jpg?1",
             "name": "Craven Giant",
             "text": "Craven Giant cannot block.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "df310d27-3c6b-511a-9bf2-fec7615a4637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90af852f-57a2-4a00-82dc-7c0f23899361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90af852f-57a2-4a00-82dc-7c0f23899361.jpg?1",
             "name": "Duct Crawler",
             "text": "o1oo\nR Target creature cannot block Duct Crawler this turn.",
             "colours": [
@@ -2569,7 +2569,7 @@
         },
         {
             "id": "33bbb19d-0117-5324-9996-2a17e5379130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79075361-e6ee-4cc9-990b-88fef27bbb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79075361-e6ee-4cc9-990b-88fef27bbb1c.jpg?1",
             "name": "Fanning the Flames",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nFanning the Flames deals X damage to target creature or player.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "47524893-6553-5830-ac36-05ac49bf74e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069d90a-e7d9-4967-a872-0dd8a0a9934a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069d90a-e7d9-4967-a872-0dd8a0a9934a.jpg?1",
             "name": "Flame Wave",
             "text": "Flame Wave deals 4 damage to target player and each creature he or she controls.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "927a1f22-5275-5f05-a262-83e9b30f55e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b144452-2e91-4e46-abe9-ed76b39f8314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b144452-2e91-4e46-abe9-ed76b39f8314.jpg?1",
             "name": "Fling",
             "text": "Sacrifice a creature: Fling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "b1a4233e-d7aa-540d-879d-af6e981c1a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9781fd-10c9-4790-8279-51c3cc6653cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9781fd-10c9-4790-8279-51c3cc6653cf.jpg?1",
             "name": "Flowstone Blade",
             "text": "oo\nR Enchanted creature gets +1/-1 until end of turn.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "44f821eb-d309-521c-b74d-664bb8af5864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680ccbc7-aa97-4f01-9d26-0df184af3c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680ccbc7-aa97-4f01-9d26-0df184af3c3e.jpg?1",
             "name": "Flowstone Hellion",
             "text": "Flowstone Hellion is unaffected by summoning sickness.\no0: Flowstone Hellion gets +1/-1 until end of turn.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "7c655ac8-a5ce-5fd2-bac4-5340f7468719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3165251-6ac6-4294-8bca-595c362f4ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3165251-6ac6-4294-8bca-595c362f4ceb.jpg?1",
             "name": "Flowstone Mauler",
             "text": "Trample\noo\nR Flowstone Mauler gets +1/-1 until end of turn.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "95289db7-c1b6-5690-a5a1-0b2a0bebfe97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2b70a5-db13-4c3f-829d-d4b9e0a16245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2b70a5-db13-4c3f-829d-d4b9e0a16245.jpg?1",
             "name": "Flowstone Shambler",
             "text": "oo\nR Flowstone Shambler gets +1/-1 until end of turn.",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "ea81d2ed-8292-55f5-bceb-32b5f48398cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a79dc7-ce46-41f7-9375-8d12afe6355a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a79dc7-ce46-41f7-9375-8d12afe6355a.jpg?1",
             "name": "Furnace Spirit",
             "text": "Furnace Spirit is unaffected by summoning sickness.\noo\nR Furnace Spirit gets +1/+0 until end of turn.",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "64465711-b806-50cc-8f28-ec571f683c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb98db-f2ee-446f-9170-dd05b1a7dbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb98db-f2ee-446f-9170-dd05b1a7dbd8.jpg?1",
             "name": "Heat of Battle",
             "text": "Whenever any creature blocks, Heat of Battle deals 1 damage to that creature's controller.",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "3f39f757-9d7f-52e3-a45f-ca45b0a6c16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c2f83-9535-4ee5-9964-5cc01e617981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c2f83-9535-4ee5-9964-5cc01e617981.jpg?1",
             "name": "Invasion Plans",
             "text": "Each creature blocks whenever able.\nAttacking player chooses how each creature blocks. (All blocking assignments must still be legal.)",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "ab9a1ca9-513c-5e63-be64-d43efa449e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b790d789-bb21-4119-a0e3-43af9bef8acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b790d789-bb21-4119-a0e3-43af9bef8acc.jpg?1",
             "name": "Mob Justice",
             "text": "Mob Justice deals 1 damage to target player for each creature you control.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "855c7bf1-b53a-5f38-8b89-968221645d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16064ad4-eec2-4c32-b66d-a2bdb1a6191f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16064ad4-eec2-4c32-b66d-a2bdb1a6191f.jpg?1",
             "name": "Mogg Bombers",
             "text": "If any other creature comes into play, sacrifice Mogg Bombers and it deals 3 damage to target player.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "a53d9cfa-b060-5d87-9599-77dc2e832c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1b384e-a7d5-4b5f-87d5-95ac1a6c6320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1b384e-a7d5-4b5f-87d5-95ac1a6c6320.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies cannot attack or block during a turn in which no other creature you control attacks or blocks.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "c464fb45-f2e1-5c44-9457-2cc74d1d7942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a91aa6f-cb2f-4aad-9415-bba4eb9b76ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a91aa6f-cb2f-4aad-9415-bba4eb9b76ca.jpg?1",
             "name": "Mogg Infestation",
             "text": "Destroy all creatures target player controls. For each creature put into any graveyard in this way, put two Goblin tokens into play under that player's control. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "efd5c31d-9cd1-5ef5-a3dd-249ddc81c6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd33c58-f25d-4117-a266-75a91e9ddc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd33c58-f25d-4117-a266-75a91e9ddc75.jpg?1",
             "name": "Mogg Maniac",
             "text": "Whenever Mogg Maniac is dealt damage, it deals an equal amount of damage to target opponent.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "ae00a93a-c62d-5e1c-ba75-315e6bbef400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eea06-806b-4163-ac86-de6ed6d1a91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eea06-806b-4163-ac86-de6ed6d1a91e.jpg?1",
             "name": "Ruination",
             "text": "Destroy all nonbasic lands.",
             "colours": [
@@ -3082,7 +3082,7 @@
         },
         {
             "id": "27ed30e6-feac-58cf-8a84-552031878aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f1edb8-fff4-4f84-944c-fa5a032f4fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f1edb8-fff4-4f84-944c-fa5a032f4fb1.jpg?1",
             "name": "Seething Anger",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature gets +3/+0 until end of turn.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "84746f0b-116a-598a-9386-034ddba4ae8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6a6d56-e73f-4dc6-a7df-d105010e52ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6a6d56-e73f-4dc6-a7df-d105010e52ab.jpg?1",
             "name": "Shard Phoenix",
             "text": "Flying\no\nRo\nRoo\nR Put Shard Phoenix into your hand. Use this ability only if Shard Phoenix is in your graveyard and only during your upkeep.\nSacrifice Shard Phoenix: Shard Phoenix deals 2 damage to each creature without flying.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "84df7699-c0f1-571d-9a42-6cea0617d0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2ff2a-6dfe-4635-8da2-22d525e82b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2ff2a-6dfe-4635-8da2-22d525e82b94.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "a4d6ebf6-186b-56b1-af1f-81a9a7dde8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c25d65-16bd-4628-b6ec-9e5495818277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c25d65-16bd-4628-b6ec-9e5495818277.jpg?1",
             "name": "Spitting Hydra",
             "text": "Spitting Hydra comes into play with four +1/+1 counters on it.\no1o\nR, Remove a +1/+1 counter from Spitting Hydra: Spitting Hydra deals 1 damage to target creature.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "a489fb53-f732-586f-ba95-55dd5db7d51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb37bcd-0bbd-4f3f-9623-803885750344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb37bcd-0bbd-4f3f-9623-803885750344.jpg?1",
             "name": "Wall of Razors",
             "text": "(Walls cannot attack.)\nFirst strike",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "e3c82961-faa3-5aeb-9d72-50f738c370c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59612c02-6028-4953-ac4d-aca94b0ce4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59612c02-6028-4953-ac4d-aca94b0ce4b9.jpg?1",
             "name": "Awakening",
             "text": "At the beginning of each player's upkeep, untap all creatures and lands.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "a93741d6-2baf-5ab0-a6a1-45fc0a06df37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9af8e5-bc97-4704-ae5c-e3d2d5b72586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9af8e5-bc97-4704-ae5c-e3d2d5b72586.jpg?1",
             "name": "Burgeoning",
             "text": "Whenever any opponent plays a land, you may choose a land card from your hand and put it into play.",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "c7fa0286-d0af-53bf-a238-68e4c4218dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae10e7fe-ee51-4c39-86ec-503324d19f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae10e7fe-ee51-4c39-86ec-503324d19f6c.jpg?1",
             "name": "Carnassid",
             "text": "Trample\no1oo\nG Regenerate Carnassid.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "209cba73-dc37-5761-9648-370fd070e9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a8a5fe-0391-489b-9556-0a1bf7e1900d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a8a5fe-0391-489b-9556-0a1bf7e1900d.jpg?1",
             "name": "Constant Mists",
             "text": "Buyback\u2014\nSacrifice a land (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Constant Mists into your hand instead of your graveyard as part of the spell's effect.)\nCreatures deal no combat damage this turn.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "56e4dc71-29c7-58e3-b386-812d48a6fdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283146fd-2307-4019-b23d-7fb1893dc46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283146fd-2307-4019-b23d-7fb1893dc46c.jpg?1",
             "name": "Crossbow Ambush",
             "text": "All creatures you control can block creatures with flying until end of turn.",
             "colours": [
@@ -3400,7 +3400,7 @@
         },
         {
             "id": "0bcfaab6-31a4-53a4-8ef3-1421b5ad227a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daba8742-c246-4e64-8af1-8f4ebcdc4b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daba8742-c246-4e64-8af1-8f4ebcdc4b5f.jpg?1",
             "name": "Elven Rite",
             "text": "Put two +1/+1 counters, distributed any way you choose, on any number of target creatures.",
             "colours": [
@@ -3431,7 +3431,7 @@
         },
         {
             "id": "5c98d14d-06e5-53a4-964f-5748f052c2d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d43e8f-a914-44ed-bbd3-3746fb4ea6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d43e8f-a914-44ed-bbd3-3746fb4ea6da.jpg?1",
             "name": "Endangered Armodon",
             "text": "If you control any creature with toughness 2 or less, sacrifice Endangered Armodon.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "02267816-b923-55cc-a0ae-797f7d03e3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efc0622-ac2c-4722-ba05-961cc98c5940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efc0622-ac2c-4722-ba05-961cc98c5940.jpg?1",
             "name": "Hermit Druid",
             "text": "o\nG, oc\nT: Reveal cards from the top of your library until you reveal a basic land card. Put that card into your hand and put all other revealed cards into your graveyard.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "f30e0af3-fc64-5917-9882-e8aa7175e268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454d6938-b87a-46b1-99d8-74573544ac5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454d6938-b87a-46b1-99d8-74573544ac5b.jpg?1",
             "name": "Lowland Basilisk",
             "text": "Whenever Lowland Basilisk damages any creature, destroy that creature at end of combat.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "d805aa76-def2-5af6-b2ec-c01a9613c902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9e9a9-325a-4010-acb8-1406adcaeca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9e9a9-325a-4010-acb8-1406adcaeca9.jpg?1",
             "name": "Mulch",
             "text": "Reveal the top four cards of your library to all players. Put any of those cards that are lands into your hand and the rest into your graveyard.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "4c23990e-fce2-5b9c-b106-024cc63b2f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9179f5-c3e0-4499-9cfb-6cb7e8329a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9179f5-c3e0-4499-9cfb-6cb7e8329a59.jpg?1",
             "name": "Overgrowth",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional o\nGo\nG.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "dcc9b660-8144-5d04-84e3-88f554c8c596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78026e4-edb8-4f55-bd80-4152f4dfb461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78026e4-edb8-4f55-bd80-4152f4dfb461.jpg?1",
             "name": "Primal Rage",
             "text": "All creatures you control gain trample.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "1eda3cb8-f846-5898-8a48-66193deaf5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c58f1-5276-420e-8c09-d256492ee87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c58f1-5276-420e-8c09-d256492ee87b.jpg?1",
             "name": "Provoke",
             "text": "Untap target creature you do not control. That creature blocks this turn if able.\nDraw a card.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "7bd425fd-b017-5b60-a51a-b309ceefa7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485aeabb-4a9b-4d88-80ad-83e31da6804b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485aeabb-4a9b-4d88-80ad-83e31da6804b.jpg?1",
             "name": "Skyshroud Archer",
             "text": "oc\nT: Target creature with flying gets -1/-1 until end of turn.",
             "colours": [
@@ -3691,7 +3691,7 @@
         },
         {
             "id": "d144b3a4-d232-5307-a109-e6e294e3186b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5197937-023c-412c-bf2c-b8e811ca04e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5197937-023c-412c-bf2c-b8e811ca04e1.jpg?1",
             "name": "Skyshroud Troopers",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "2ff18fd6-55b2-522a-92e0-d9bba571f0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e11ef7-18a9-4ab1-981e-b337b1488ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e11ef7-18a9-4ab1-981e-b337b1488ebd.jpg?1",
             "name": "Spike Breeder",
             "text": "Spike Breeder comes into play with three +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Breeder: Put a +1/+1 counter on target creature.\no2, Remove a +1/+1 counter from Spike Breeder: Put a Spike token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "46d6301b-b0c2-50dc-9809-0f96c23a37c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea4703-8521-4576-8405-4b923e0a9522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea4703-8521-4576-8405-4b923e0a9522.jpg?1",
             "name": "Spike Colony",
             "text": "Spike Colony comes into play with four +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Colony: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "d659a572-59c4-55c0-bb53-5e84585d5f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3751b2ae-a234-4691-984b-2f9f6b1cd1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3751b2ae-a234-4691-984b-2f9f6b1cd1df.jpg?1",
             "name": "Spike Feeder",
             "text": "Spike Feeder comes into play with two +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Feeder: Put a +1/+1 counter on target creature.\nRemove a +1/+1 counter from Spike Feeder: Gain 2 life.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "2f2aebc2-f70a-5ccc-bb57-df71dca59171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa45664c-ac39-40f8-9f56-cf25ed60a84a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa45664c-ac39-40f8-9f56-cf25ed60a84a.jpg?1",
             "name": "Spike Soldier",
             "text": "Spike Soldier comes into play with three +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Soldier: Put a +1/+1 counter on target creature.\nRemove a +1/+1 counter from Spike Soldier: Spike Soldier gets +2/+2 until end of turn.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "2f27b2d0-f938-595e-b9f6-0801523e19da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2713de6c-b754-435c-8d11-5215fd602a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2713de6c-b754-435c-8d11-5215fd602a40.jpg?1",
             "name": "Spike Worker",
             "text": "Spike Worker comes into play with two +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Worker: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "0cd1b205-e1ec-5291-98b6-0154bb7888b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113fad70-36bc-4ab7-962a-cda3bddd02fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113fad70-36bc-4ab7-962a-cda3bddd02fc.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "bc0fae69-5eed-5dcc-8ccb-75b023a07fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7f3e0b-0600-4451-b621-e40c902a16cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7f3e0b-0600-4451-b621-e40c902a16cb.jpg?1",
             "name": "Tempting Licid",
             "text": "o\nG, oc\nT: Tempting Licid loses ability and becomes a creature enchantment that reads \"All creatures able to block enchanted creature do so\" instead of a creature. Move Tempting Licid onto target creature. You may pay o\nG to end this effect.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "30864f09-78bc-5d63-8839-520884c4649c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7079bf55-4827-4b8b-a178-8c7b903d93b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7079bf55-4827-4b8b-a178-8c7b903d93b9.jpg?1",
             "name": "Verdant Touch",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget land becomes a 2/2 creature permanently. (This creature still counts as a land.)",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "6ef0c72f-3f9a-5d54-95e3-de7dee1cca2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d74f7d8-10eb-4082-9b07-41de13359b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d74f7d8-10eb-4082-9b07-41de13359b8c.jpg?1",
             "name": "Volrath's Gardens",
             "text": "o2, Tap a creature you control: Gain 2 life. Play this ability as a sorcery.",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "bfa2a700-1b2a-5436-a7aa-fe0795f5c033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb4a1a3-efcf-4c9a-ad1f-0a3f8f2b456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb4a1a3-efcf-4c9a-ad1f-0a3f8f2b456f.jpg?1",
             "name": "Wall of Blossoms",
             "text": "(Walls cannot attack.)\nWhen Wall of Blossoms comes into play, draw a card.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "eac4d995-632d-53f7-a8d6-c2817c24bee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92c3f7-a589-4c87-aa17-0d9707605ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92c3f7-a589-4c87-aa17-0d9707605ff4.jpg?1",
             "name": "Acidic Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: This creature deals 2 damage to target creature or player.\"",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "1cdfde14-5af8-5d6a-98c9-58106cf45aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06551990-713c-4b8b-bebb-4e849babb5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06551990-713c-4b8b-bebb-4e849babb5bb.jpg?1",
             "name": "Crystalline Sliver",
             "text": "Slivers cannot be the target of spells or abilities.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "9eaa67cd-e4b5-545c-a693-a5836ca622dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94934d64-6518-4c5e-90d9-a3bf23b8973f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94934d64-6518-4c5e-90d9-a3bf23b8973f.jpg?1",
             "name": "Hibernation Sliver",
             "text": "Each Sliver gains \"Pay 2 life: Return this creature to owner's hand.\"",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "d1c0b29b-b820-5679-b7d8-e1caf25cdf75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c0ece-aed0-4120-99cc-5d0e28fa70ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c0ece-aed0-4120-99cc-5d0e28fa70ab.jpg?1",
             "name": "Sliver Queen",
             "text": "Sliver Queen counts as a Sliver.\no2: Put a Sliver token into play. Treat this token as a 1/1 colorless creature.",
             "colours": [
@@ -4202,7 +4202,7 @@
         },
         {
             "id": "311efb31-04fe-5c65-ade2-a6bf4b53e784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8a9442-7b08-4cc8-94ec-bddb8feab1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8a9442-7b08-4cc8-94ec-bddb8feab1a8.jpg?1",
             "name": "Spined Sliver",
             "text": "If any Sliver is blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "aef5604a-84b4-59e0-8849-0bffa93e64f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e58908e-7095-4fb9-b7cb-a67d12f33b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e58908e-7095-4fb9-b7cb-a67d12f33b8a.jpg?1",
             "name": "Victual Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: Gain 4 life.\"",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "34b1d2f2-e6d4-5b13-9199-a286218ce6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff312dd7-456c-4ce5-9614-e2cbe3c2219c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff312dd7-456c-4ce5-9614-e2cbe3c2219c.jpg?1",
             "name": "Bullwhip",
             "text": "o2, oc\nT: Bullwhip deals 1 damage to target creature. That creature attacks this turn if able.",
             "colours": [],
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "b9feac79-3880-57e6-94b3-6d6cef2e5b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d838a1-2739-45f7-a856-6202334fa76a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d838a1-2739-45f7-a856-6202334fa76a.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Each creature with power greater than the number of cards in your hand cannot attack.",
             "colours": [],
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "29fa5147-7b21-5c7b-aec2-f5277792895f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed17325-6d2f-404e-b13f-d2d419d522b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed17325-6d2f-404e-b13f-d2d419d522b7.jpg?1",
             "name": "Heartstone",
             "text": "The cost of each creature ability requiring an activation cost is reduced by o1. This cannot reduce an ability's generic mana cost to less then o1.",
             "colours": [],
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "03101362-e8cc-5864-9023-43d91e7d27a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950660f9-b185-4979-a08b-cce4ec6ce07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950660f9-b185-4979-a08b-cce4ec6ce07d.jpg?1",
             "name": "Horn of Greed",
             "text": "Whenever any player plays a land, that player draws a card.",
             "colours": [],
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "13845a3d-f3b9-52a1-90e5-b6afca6fd8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e9afeb-4d27-441c-b379-3dfe974053b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e9afeb-4d27-441c-b379-3dfe974053b8.jpg?1",
             "name": "Hornet Cannon",
             "text": "o3, oc\nT: Put a Hornet token into play. Treat this token as a 1/1 artifact creature with flying that is unaffected by summoning sickness. At end of turn, destroy the token.",
             "colours": [],
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "26920490-e5ee-50b2-8991-5bbb37211745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c675814-094c-45d4-93ee-0f50b4755e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c675814-094c-45d4-93ee-0f50b4755e79.jpg?1",
             "name": "Jinxed Ring",
             "text": "Whenever any card is put into your graveyard from play, Jinxed Ring deals 1 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Ring permanently",
             "colours": [],
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "d13aede2-f106-5d02-b52e-47d3a6871071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28028830-83ed-45e2-b495-3b9ad9d3e988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28028830-83ed-45e2-b495-3b9ad9d3e988.jpg?1",
             "name": "Mox Diamond",
             "text": "When Mox Diamond comes into play, choose and discard a land card or sacrifice Mox Diamond.\noc\nT: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "6e65d7d4-8eac-5191-a516-9a5a7d1a8850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4de4af2-fa75-4a87-b0e1-0117727917a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4de4af2-fa75-4a87-b0e1-0117727917a5.jpg?1",
             "name": "Portcullis",
             "text": "Whenever any creature comes into play, if there are two or more other creatures in play, set that creature aside. If Portcullis leaves play, put the creature into play under its owner's control.",
             "colours": [],
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "035db611-b24d-542b-b843-41e74c260a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b7a950-bf79-46fa-8b29-b7856b38e0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b7a950-bf79-46fa-8b29-b7856b38e0fd.jpg?1",
             "name": "Shifting Wall",
             "text": "Shifting Wall counts as a Wall. (Walls cannot attack.)\nShifting Wall comes into play with X +1/+1 counters on it.",
             "colours": [],
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "9d184eaa-4752-54e1-8d4e-74fa4cb71331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401678d7-11dc-47ec-be28-4facdd949bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401678d7-11dc-47ec-be28-4facdd949bc1.jpg?1",
             "name": "Sword of the Chosen",
             "text": "oc\nT: Target legend gets +2/+2 until end of turn.",
             "colours": [],
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "75fa03eb-7d51-501a-aa43-a9aca3cfbda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e9e60a-5718-460d-b031-b47d6f6715d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e9e60a-5718-460d-b031-b47d6f6715d1.jpg?1",
             "name": "Volrath's Laboratory",
             "text": "When you play Volrath's Laboratory, choose a color and a creature type.\no5, oc\nT: Put a token creature into play. Treat this token as a 2/2 creature of the chosen color and creature type.",
             "colours": [],
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "c5c88002-3a6d-50fa-9c80-fcb8e2623512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf015b-152e-4d67-b773-e75fb2487a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf015b-152e-4d67-b773-e75fb2487a32.jpg?1",
             "name": "Volrath's Stronghold",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1o\nB, oc\nT: Put target creature card from your graveyard on top of your library.",
             "colours": [],

--- a/Assets/Resources/Sets/STX.json
+++ b/Assets/Resources/Sets/STX.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ee54b9ff-a776-567a-b149-ca32caf17076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b394fc-a99c-44e7-9226-da0699167541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b394fc-a99c-44e7-9226-da0699167541.jpg?1",
             "name": "Environmental Sciences",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "f7c19487-0efe-5a39-a2d1-dc3f99dbcecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5642b9d-0daa-4e6b-ad48-f88dd37d6574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5642b9d-0daa-4e6b-ad48-f88dd37d6574.jpg?1",
             "name": "Expanded Anatomy",
             "text": "Put two +1/+1 counters on target creature. It gains vigilance until end of turn.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "55be78d3-bbe2-53e3-89ba-b158134f7a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc4682-bcaf-4f51-be0b-9f2851a16e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc4682-bcaf-4f51-be0b-9f2851a16e3b.jpg?1",
             "name": "Introduction to Annihilation",
             "text": "Exile target nonland permanent. Its controller draws a card.",
             "colours": [],
@@ -94,7 +94,7 @@
         },
         {
             "id": "85a585d3-dcd9-5282-929c-8fbb8b89470b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7820923e-bad2-4d6a-92b3-97b9737d2ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7820923e-bad2-4d6a-92b3-97b9737d2ca9.jpg?1",
             "name": "Introduction to Prophecy",
             "text": "Scry 2, then draw a card.",
             "colours": [],
@@ -124,7 +124,7 @@
         },
         {
             "id": "0ccc2be8-b6ca-5a71-89fc-d3d1a7cd6958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047592c-739c-41dd-b3e8-31ae1c7688ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047592c-739c-41dd-b3e8-31ae1c7688ab.jpg?1",
             "name": "Mascot Exhibition",
             "text": "Create a 2/1 white and black Inkling creature token with flying, a 3/2 red and white Spirit creature token, and a 4/4 blue and red Elemental creature token.",
             "colours": [],
@@ -156,7 +156,7 @@
         },
         {
             "id": "d0903ef7-72e6-5a8e-842a-dd39839262ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -188,7 +188,7 @@
         },
         {
             "id": "bffa0c9a-7ab0-5166-80f0-d1e6389b1ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -218,7 +218,7 @@
         },
         {
             "id": "4f708469-c678-56b0-8768-37b49616cf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05521edf-f47f-4e7a-aec5-cdc4ae7368c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05521edf-f47f-4e7a-aec5-cdc4ae7368c2.jpg?1",
             "name": "Academic Probation",
             "text": "Choose one \u2014\n\u2022 Choose a nonland card name. Opponents can't cast spells with the chosen name until your next turn.\n\u2022 Choose target nonland permanent. Until your next turn, it can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -254,7 +254,7 @@
         },
         {
             "id": "d7e765d4-34b2-57fd-85f6-2f19a543f4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5ff6af-402f-4bf6-a75b-dc1e0e40aff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5ff6af-402f-4bf6-a75b-dc1e0e40aff6.jpg?1",
             "name": "Ageless Guardian",
             "text": "",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "1fc2e034-b085-5272-9c61-19f913838207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22411c-11c1-4770-8491-7952dd406e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22411c-11c1-4770-8491-7952dd406e01.jpg?1",
             "name": "Beaming Defiance",
             "text": "Target creature you control gets +2/+2 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "92e91515-1792-5b3d-a449-e9541db7595b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69957656-cfdf-4001-8e84-0ef29e4a468d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69957656-cfdf-4001-8e84-0ef29e4a468d.jpg?1",
             "name": "Clever Lumimancer",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Clever Lumimancer gets +2/+2 until end of turn.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "49424381-3ccb-59ad-b069-c705e6b8c889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f669ac4-98ed-4e23-91a9-281f8277ab04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f669ac4-98ed-4e23-91a9-281f8277ab04.jpg?1",
             "name": "Combat Professor",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "c9b8e24d-95d1-51b8-b5d9-fea2853606ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4e1b5-77d6-4af4-b22e-6f6b4d129f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4e1b5-77d6-4af4-b22e-6f6b4d129f5d.jpg?1",
             "name": "Defend the Campus",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +1/+1 until end of turn.\n\u2022 Destroy target creature with power 4 or greater.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "258b0ad9-fc37-53a8-a2a4-4e250b0db22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ebe581-be17-415a-a160-28d8f4e95636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ebe581-be17-415a-a160-28d8f4e95636.jpg?1",
             "name": "Detention Vortex",
             "text": "Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.\n{3}: Destroy Detention Vortex. Only your opponents may activate this ability and only as a sorcery.",
             "colours": [
@@ -457,7 +457,7 @@
         },
         {
             "id": "ef101081-bd92-518b-86f4-0e44ac84d5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6be019-29b9-4c81-9899-aefeaf9cc977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6be019-29b9-4c81-9899-aefeaf9cc977.jpg?1",
             "name": "Devastating Mastery",
             "text": "You may pay {2}{W}{W} rather than pay this spell's mana cost.\nIf the {2}{W}{W} cost was paid, an opponent chooses up to two nonland permanents they control and returns them to their owner's hand.\nDestroy all nonland permanents.",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "55b4c151-2e0f-5312-9c39-13eff8e7584a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3dbb0-0d68-4351-bfc9-a09c50454bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3dbb0-0d68-4351-bfc9-a09c50454bf7.jpg?1",
             "name": "Dueling Coach",
             "text": "When Dueling Coach enters the battlefield, put a +1/+1 counter on target creature.\n{4}{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -526,7 +526,7 @@
         },
         {
             "id": "d8e48e55-b80c-5632-89a4-4a3a350f92e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b19a46-f4e9-4a08-b118-a62a93901c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b19a46-f4e9-4a08-b118-a62a93901c1e.jpg?1",
             "name": "A-Dueling Coach",
             "text": "",
             "colours": [
@@ -560,7 +560,7 @@
         },
         {
             "id": "19c9011e-5688-5226-8127-c3fd0b3b70f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83543b-3b6f-4e28-96f9-007b814bcfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83543b-3b6f-4e28-96f9-007b814bcfd6.jpg?1",
             "name": "Eager First-Year",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Eager First-Year gets +1/+0 until end of turn.",
             "colours": [
@@ -595,7 +595,7 @@
         },
         {
             "id": "acaf336b-8483-5807-9844-e56861c9d7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a7998-ccac-45ad-a4e9-3a2cb057f63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a7998-ccac-45ad-a4e9-3a2cb057f63b.jpg?1",
             "name": "Elite Spellbinder",
             "text": "Flying\nWhen Elite Spellbinder enters the battlefield, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A spell cast this way costs {2} more to cast.",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "b54bd61b-b3c2-5a6f-8901-9915663256d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be517a58-b7ee-4213-98a5-8c19e1b2def6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be517a58-b7ee-4213-98a5-8c19e1b2def6.jpg?1",
             "name": "Expel",
             "text": "Exile target tapped creature.",
             "colours": [
@@ -664,7 +664,7 @@
         },
         {
             "id": "19ccd656-a63f-56a3-a265-e8f9951a5f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb3163-12ca-4a7f-a0c7-b8ddfc9408a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb3163-12ca-4a7f-a0c7-b8ddfc9408a0.jpg?1",
             "name": "Guiding Voice",
             "text": "Put a +1/+1 counter on target creature.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "edc7c20c-3cb1-557f-b79a-6b391e02c67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a465d7b-398c-444b-9eae-331ea2513f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a465d7b-398c-444b-9eae-331ea2513f6d.jpg?1",
             "name": "Leonin Lightscribe",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "250a144b-4734-53d4-af58-820b8060ef9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3d521f-31cd-4bd2-b6b6-771c79252789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3d521f-31cd-4bd2-b6b6-771c79252789.jpg?1",
             "name": "Mavinda, Students' Advocate",
             "text": "Flying\n{0}: You may cast target instant or sorcery card from your graveyard this turn. If that spell doesn't target a creature you control, it costs {8} more to cast this way. If that spell would be put into your graveyard, exile it instead. Activate only once each turn. (You still pay the spell's costs. Timing rules for the spell still apply.)",
             "colours": [
@@ -772,7 +772,7 @@
         },
         {
             "id": "05d975b9-8c5f-5331-8c91-b8691795c572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86714f5-e909-413f-8eb6-99dbea4d1897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86714f5-e909-413f-8eb6-99dbea4d1897.jpg?1",
             "name": "Pilgrim of the Ages",
             "text": "When Pilgrim of the Ages enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n{6}: Return Pilgrim of the Ages from your graveyard to your hand.",
             "colours": [
@@ -806,7 +806,7 @@
         },
         {
             "id": "8c73e1cc-0311-5cde-b8aa-11e375492dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884666e-8f9b-44b1-a1e3-c1c8941e2152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884666e-8f9b-44b1-a1e3-c1c8941e2152.jpg?1",
             "name": "Pillardrop Rescuer",
             "text": "Flying\nWhen Pillardrop Rescuer enters the battlefield, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "c7cf1265-b6d6-547e-acff-b7d85e8c3490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f427cf73-9f5e-4ef5-bc4f-29ffbfda9d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f427cf73-9f5e-4ef5-bc4f-29ffbfda9d57.jpg?1",
             "name": "Professor of Symbology",
             "text": "When Professor of Symbology enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "5a61dcea-89f2-5df0-9544-a4e017d4037d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfc408e-34d6-4e94-8678-4cc229cbc6f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfc408e-34d6-4e94-8678-4cc229cbc6f5.jpg?1",
             "name": "Reduce to Memory",
             "text": "Exile target nonland permanent. Its controller creates a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "853765a2-31e0-5322-b76b-75f9ebf724ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39528cf0-343e-499b-a69f-c5c3c2898c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39528cf0-343e-499b-a69f-c5c3c2898c25.jpg?1",
             "name": "Secret Rendezvous",
             "text": "You and target opponent each draw three cards.",
             "colours": [
@@ -942,7 +942,7 @@
         },
         {
             "id": "02b6343a-cda5-578d-8bd8-e297bef461e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4743f7-28db-4d72-bfce-09cfbe413514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4743f7-28db-4d72-bfce-09cfbe413514.jpg?1",
             "name": "Semester's End",
             "text": "Exile any number of target creatures and/or planeswalkers you control. At the beginning of the next end step, return each of them to the battlefield under its owner's control. Each of them enters the battlefield with an additional +1/+1 counter on it if it's a creature and an additional loyalty counter on it if it's a planeswalker.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "18b977a1-ac7e-5fcd-b471-4340a4dd5036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65837f39-deb7-4a4b-8b67-125a71cd0d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65837f39-deb7-4a4b-8b67-125a71cd0d45.jpg?1",
             "name": "Show of Confidence",
             "text": "When you cast this spell, copy it for each other instant and sorcery spell you've cast this turn. You may choose new targets for the copies.\nPut a +1/+1 counter on target creature. It gains vigilance until end of turn.",
             "colours": [
@@ -1008,7 +1008,7 @@
         },
         {
             "id": "06d0af1a-a51a-5c12-86e3-2d2ab0300f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg?1",
             "name": "Sparring Regimen",
             "text": "When Sparring Regimen enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nWhenever you attack, put a +1/+1 counter on target attacking creature and untap it.",
             "colours": [
@@ -1042,7 +1042,7 @@
         },
         {
             "id": "95713773-bf3c-5bbe-acb8-e632b378f441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9318f-2e17-4b6e-895f-c17cd5d0d282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9318f-2e17-4b6e-895f-c17cd5d0d282.jpg?1",
             "name": "Star Pupil",
             "text": "Star Pupil enters the battlefield with a +1/+1 counter on it.\nWhen Star Pupil dies, put its counters on target creature you control.",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "d2e148ea-4041-54f6-bccb-95f7893fc346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de4a01-98d3-4af3-9c6e-29e16d2c1767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de4a01-98d3-4af3-9c6e-29e16d2c1767.jpg?1",
             "name": "Stonebinder's Familiar",
             "text": "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on Stonebinder's Familiar. This ability triggers only once each turn.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "3bb58aca-1040-520e-ad46-ac41037084f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388f2e45-570f-4a35-b205-37e1345b5d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388f2e45-570f-4a35-b205-37e1345b5d06.jpg?1",
             "name": "Stonerise Spirit",
             "text": "Flying\n{4}, Exile a card from your graveyard: Target creature gains flying until end of turn.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "deeabc53-f49b-5f9f-8194-60137f4455b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f1e36a-6838-49de-b7dc-697cbcd1e892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f1e36a-6838-49de-b7dc-697cbcd1e892.jpg?1",
             "name": "Strict Proctor",
             "text": "Flying\nWhenever a permanent entering the battlefield causes a triggered ability to trigger, counter that ability unless its controller pays {2}.",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "aff19c2a-d3ad-588d-9672-b82d40f86128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0826e210-2002-43fe-942d-41922dfd7bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0826e210-2002-43fe-942d-41922dfd7bc2.jpg?1",
             "name": "Strict Proctor",
             "text": "",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "a23c89c5-71d0-558b-8413-63f4bc663e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7cd813-0781-4fd7-8748-2716e1eeb4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7cd813-0781-4fd7-8748-2716e1eeb4b9.jpg?1",
             "name": "Study Break",
             "text": "Tap up to two target creatures.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "a18d1d5d-f2de-5a01-9606-e5d2033ffec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3b2961-559f-42b1-be13-ff3d03e62809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3b2961-559f-42b1-be13-ff3d03e62809.jpg?1",
             "name": "Thunderous Orator",
             "text": "Vigilance\nWhenever Thunderous Orator attacks, it gains flying until end of turn if you control a creature with flying. The same is true for first strike, double strike, deathtouch, indestructible, lifelink, menace, and trample.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "15e497fd-555c-5490-a3c9-b4ab0e1f5a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cdb00c-ea86-4b72-8f62-570820edfa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cdb00c-ea86-4b72-8f62-570820edfa1b.jpg?1",
             "name": "Arcane Subtraction",
             "text": "Target creature gets -4/-0 until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "1c987201-cf20-5a34-9846-461b92fe2ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761df6cd-0928-4167-8902-58fdb50181a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761df6cd-0928-4167-8902-58fdb50181a0.jpg?1",
             "name": "Archmage Emeritus",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, draw a card.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "1db4b61e-f200-55cb-8ac6-770cdaf8fd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6040c573-cd8c-4593-8ade-d9922482035c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6040c573-cd8c-4593-8ade-d9922482035c.jpg?1",
             "name": "Burrog Befuddler",
             "text": "Flash\nWhen Burrog Befuddler enters the battlefield, target creature an opponent controls gets -1/-0 until end of turn.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "c5dc7ac8-7498-5ede-b5c9-fdf1fc70b029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2cf5-80cf-4c06-8b04-bc04a5460de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2cf5-80cf-4c06-8b04-bc04a5460de5.jpg?1",
             "name": "Bury in Books",
             "text": "This spell costs {2} less to cast if it targets an attacking creature.\nPut target creature into its owner's library second from the top.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "c3f83af7-ba47-59fd-805e-7183b03e51bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0e716-22b7-4a5e-9b7a-d4a806ee7427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0e716-22b7-4a5e-9b7a-d4a806ee7427.jpg?1",
             "name": "Curate",
             "text": "Look at the top two cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDraw a card.",
             "colours": [
@@ -1458,7 +1458,7 @@
         },
         {
             "id": "f458f1e5-d4d6-52b4-87b2-d4f601518a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1958d96e-ec44-48ab-80b1-5b01a24ac7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1958d96e-ec44-48ab-80b1-5b01a24ac7b8.jpg?1",
             "name": "Divide by Zero",
             "text": "Return target spell or permanent with mana value 1 or greater to its owner's hand.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "c9f36082-28ae-56b5-b936-bf6621d031a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg?1",
             "name": "Dream Strix",
             "text": "Flying\nWhen Dream Strix becomes the target of a spell, sacrifice it.\nWhen Dream Strix dies, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "5ff14a02-5ab0-5d42-9c1e-1f7c11a1f1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd79c9cc-0a8c-4d88-96e2-cb177134a18d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd79c9cc-0a8c-4d88-96e2-cb177134a18d.jpg?1",
             "name": "Frost Trickster",
             "text": "Flying\nWhen Frost Trickster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "f5326d64-fc7a-5df5-9f2a-417410c1c041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2386d020-a9ae-4d54-b5e4-f2cb5a7298cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2386d020-a9ae-4d54-b5e4-f2cb5a7298cc.jpg?1",
             "name": "Ingenious Mastery",
             "text": "You may pay {2}{U} rather than pay this spell's mana cost.\nIf the {2}{U} cost was paid, you draw three cards, then an opponent creates two Treasure tokens and they scry 2. If that cost wasn't paid, you draw X cards.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "8a1abf73-c0d2-56f0-b113-3064a5c291b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0112ebfb-55ad-401c-9dc5-ffd829f5b5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0112ebfb-55ad-401c-9dc5-ffd829f5b5bf.jpg?1",
             "name": "Kelpie Guide",
             "text": "{T}: Untap another target permanent you control.\n{T}: Tap target permanent. Activate only if you control eight or more lands.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "978fb797-bc9e-5ecc-b8be-e843b1ad6592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbb1230-a465-4499-bb9c-35a06712a08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbb1230-a465-4499-bb9c-35a06712a08b.jpg?1",
             "name": "Mentor's Guidance",
             "text": "When you cast this spell, copy it if you control a planeswalker, Cleric, Druid, Shaman, Warlock, or Wizard.\nScry 1, then draw a card.",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "ba6356d0-db83-54b9-ac4c-de8ce0c91f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf572a77-bd21-48e3-9640-3f17a5416ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf572a77-bd21-48e3-9640-3f17a5416ab1.jpg?1",
             "name": "A-Mentor's Guidance",
             "text": "",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "e1c806ac-37fd-5c4c-82dc-f195730479f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbe115-5482-4e5a-95bb-8ccbb01d3547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbe115-5482-4e5a-95bb-8ccbb01d3547.jpg?1",
             "name": "Mercurial Transformation",
             "text": "Until end of turn, target nonland permanent loses all abilities and becomes your choice of a blue Frog creature with base power and toughness 1/1 or a blue Octopus creature with base power and toughness 4/4.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "1294bd7f-15b6-5cab-acb1-e8ff912197a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c9890f-7081-42f6-89eb-35c83911b443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c9890f-7081-42f6-89eb-35c83911b443.jpg?1",
             "name": "Multiple Choice",
             "text": "If X is 1, scry 1, then draw a card.\nIf X is 2, you may choose a player. They return a creature they control to its owner's hand.\nIf X is 3, create a 4/4 blue and red Elemental creature token.\nIf X is 4 or more, do all of the above.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "d4caed8f-4f91-507c-bd40-88a5aea8c42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16892d8-9d10-45de-ab79-0e645c4b5588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16892d8-9d10-45de-ab79-0e645c4b5588.jpg?1",
             "name": "Pop Quiz",
             "text": "Draw a card.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "de3f9cdd-1a7d-529c-a1d6-ce3ee747017f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f0731-fb40-4dc2-8530-afcb5ce1f27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f0731-fb40-4dc2-8530-afcb5ce1f27f.jpg?1",
             "name": "Reject",
             "text": "Counter target creature or planeswalker spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "ea7a3205-d0d3-51b7-805f-d9f57a9b2b3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb1fcb-a411-4c1c-b8fc-496242ae3a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb1fcb-a411-4c1c-b8fc-496242ae3a9b.jpg?1",
             "name": "Resculpt",
             "text": "Exile target artifact or creature. Its controller creates a 4/4 blue and red Elemental creature token.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "7fb59d3a-0e67-56da-a695-4c1a0c928cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d651b9e9-d723-4340-a010-d71b2a697e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d651b9e9-d723-4340-a010-d71b2a697e73.jpg?1",
             "name": "Serpentine Curve",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is one plus the total number of instant and sorcery cards you own in exile and in your graveyard.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "9893ccbe-8aa6-5574-ad33-79c8f7c5877a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b6f17d-45ba-4d60-a963-5eee026f2219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b6f17d-45ba-4d60-a963-5eee026f2219.jpg?1",
             "name": "Snow Day",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.\nDraw two cards, then discard a card.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "3c8c6eac-f5aa-55bf-bc93-d179166bbbd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c04ee2-c1e0-45fb-aaf5-1b4459df80fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c04ee2-c1e0-45fb-aaf5-1b4459df80fc.jpg?1",
             "name": "Solve the Equation",
             "text": "Search your library for an instant or sorcery card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "8a0b907b-24c4-5a86-9b92-339a0c80bd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb93c9d2-88eb-403d-bb67-8e8b0462ac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb93c9d2-88eb-403d-bb67-8e8b0462ac27.jpg?1",
             "name": "Soothsayer Adept",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "a16ef2e1-3688-523e-a270-07fcf4b08fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e726fc7-36cf-405c-9b7c-d1e41cd6c68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e726fc7-36cf-405c-9b7c-d1e41cd6c68f.jpg?1",
             "name": "Symmetry Sage",
             "text": "Flying\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, target creature you control has base power 2 until end of turn.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "9579d1df-ff66-5d0a-a3b7-14a745e434e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2409aee-3a80-4533-80bc-9383624c285d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2409aee-3a80-4533-80bc-9383624c285d.jpg?1",
             "name": "A-Symmetry Sage",
             "text": "",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "90ddb56f-87c5-5098-8223-1d88b6f2bf66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967148b1-2bb6-4bc0-95e6-c45fcf99afd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967148b1-2bb6-4bc0-95e6-c45fcf99afd2.jpg?1",
             "name": "Teachings of the Archaics",
             "text": "If an opponent has more cards in hand than you, draw two cards. Draw three cards instead if an opponent has at least four more cards in hand than you.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "aed563dd-6796-5a51-a762-0cae7cfa44b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23e64f9-531e-4735-9960-b0a76b32c340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23e64f9-531e-4735-9960-b0a76b32c340.jpg?1",
             "name": "Tempted by the Oriq",
             "text": "For each opponent, gain control of up to one target creature or planeswalker that player controls with mana value 3 or less.",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "62e66ae0-25fc-5ef9-a175-0f05ed8acc3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b6236-b40c-430c-98b0-7940b942657a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b6236-b40c-430c-98b0-7940b942657a.jpg?1",
             "name": "Test of Talents",
             "text": "Counter target instant or sorcery spell. Search its controller's graveyard, hand, and library for any number of cards with the same name as that spell and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "dd1de253-1315-5471-9557-c7f7e92f7279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab4a68d-5d26-42d8-bc51-15e3c1f95ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab4a68d-5d26-42d8-bc51-15e3c1f95ebe.jpg?1",
             "name": "Vortex Runner",
             "text": "As long as you control eight or more lands, Vortex Runner gets +1/+0 and can't be blocked.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "b954ecf7-3f06-5a76-8f0f-def25aa34e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc6966c-18d9-4675-9594-6f0b2d11c405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc6966c-18d9-4675-9594-6f0b2d11c405.jpg?1",
             "name": "Waterfall Aerialist",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "96a4a991-2396-595f-a63f-0d0b51aac6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0fd73f-e161-4e42-b4f9-9246a9dba785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0fd73f-e161-4e42-b4f9-9246a9dba785.jpg?1",
             "name": "Wormhole Serpent",
             "text": "{3}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -2263,7 +2263,7 @@
         },
         {
             "id": "0869e433-2d7d-5bbb-ba60-0ac67edc0b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556a0816-83c5-41dc-8546-213b21e2cceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556a0816-83c5-41dc-8546-213b21e2cceb.jpg?1",
             "name": "Arrogant Poet",
             "text": "Whenever Arrogant Poet attacks, you may pay 2 life. If you do, it gains flying until end of turn.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "1496523b-b328-5fe9-9bf8-b30391b14322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f1a6ba-e46f-44fb-93f4-fb883d677b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f1a6ba-e46f-44fb-93f4-fb883d677b36.jpg?1",
             "name": "Baleful Mastery",
             "text": "You may pay {1}{B} rather than pay this spell's mana cost.\nIf the {1}{B} cost was paid, an opponent draws a card.\nExile target creature or planeswalker.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "94186fc8-bb56-5e20-898a-3dbcd21a4386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ba37ee-159f-421f-8d37-a7b5f1b562f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ba37ee-159f-421f-8d37-a7b5f1b562f0.jpg?1",
             "name": "Brackish Trudge",
             "text": "Brackish Trudge enters the battlefield tapped.\n{1}{B}: Return Brackish Trudge from your graveyard to your hand. Activate only if you gained life this turn.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "b1517784-9912-5934-97e0-71dfac97781d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81358736-65cf-44d8-819e-d0268d14cc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81358736-65cf-44d8-819e-d0268d14cc76.jpg?1",
             "name": "Callous Bloodmage",
             "text": "When Callous Bloodmage enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\u2022 You draw a card and you lose 1 life.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "e24f3df3-b854-5f68-8202-00815862746f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1951763-be97-400c-aa95-6b101f47bddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1951763-be97-400c-aa95-6b101f47bddf.jpg?1",
             "name": "Confront the Past",
             "text": "Choose one \u2014\n\u2022 Return target planeswalker card with mana value X or less from your graveyard to the battlefield.\n\u2022 Remove twice X loyalty counters from target planeswalker an opponent controls.",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "ca0e01ae-e4be-5d91-8057-0ce08878c26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbe8cf1-11df-4ca4-9a6b-265193c49250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbe8cf1-11df-4ca4-9a6b-265193c49250.jpg?1",
             "name": "Crushing Disappointment",
             "text": "Each player loses 2 life. You draw two cards.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "9fdcd8b1-b22c-5712-923f-45802ad14a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a48d0c-1e5b-43f2-8974-e2e5bb06310d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a48d0c-1e5b-43f2-8974-e2e5bb06310d.jpg?1",
             "name": "Essence Infusion",
             "text": "Put two +1/+1 counters on target creature. It gains lifelink until end of turn.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "aeff99be-3903-5e42-b542-12a223428105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4d1bb6-cb8f-4d01-9879-0b3a0585cbf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4d1bb6-cb8f-4d01-9879-0b3a0585cbf4.jpg?1",
             "name": "Eyetwitch",
             "text": "Flying\nWhen Eyetwitch dies, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "867aa4de-ba46-57d2-9bed-6456e0b0b115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8487884-e991-4feb-823b-90d9125edf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8487884-e991-4feb-823b-90d9125edf19.jpg?1",
             "name": "Flunk",
             "text": "Target creature gets -X/-X until end of turn, where X is 7 minus the number of cards in that creature's controller's hand.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "621be861-9c88-54df-bbb2-87e0cfdf7a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846e8657-7435-44c6-a997-b8b156d0cd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846e8657-7435-44c6-a997-b8b156d0cd2c.jpg?1",
             "name": "Go Blank",
             "text": "Target player discards two cards. Then exile all cards from that player's graveyard.",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "4d468474-e309-5b6b-aa1e-f11be577a7c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff0f47f-75cb-42b0-ba4d-78522cad9861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff0f47f-75cb-42b0-ba4d-78522cad9861.jpg?1",
             "name": "Hunt for Specimens",
             "text": "Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "885d8bc1-03a3-5bec-a84d-dcaacef3ad6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3da2c6-29ed-4563-8bae-d1cc05df8897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3da2c6-29ed-4563-8bae-d1cc05df8897.jpg?1",
             "name": "Lash of Malice",
             "text": "Target creature gets +2/-2 until end of turn.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "970f7c7e-fa4d-5a16-9a3d-8978498d033e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f9fe7-241b-4eb6-a059-be5384b4a1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f9fe7-241b-4eb6-a059-be5384b4a1b6.jpg?1",
             "name": "Leech Fanatic",
             "text": "As long as it's your turn, Leech Fanatic has lifelink.",
             "colours": [
@@ -2702,7 +2702,7 @@
         },
         {
             "id": "66a949d1-519b-53d0-ace7-4de888ce85f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fcbe4a-2d98-4fa9-a6c3-e28255171a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fcbe4a-2d98-4fa9-a6c3-e28255171a4d.jpg?1",
             "name": "Mage Hunter",
             "text": "Whenever an opponent casts or copies an instant or sorcery spell, they lose 1 life.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "035721d5-49cd-5409-bea4-b55800017a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed85140f-f0e0-4ac1-a67f-26d17ff95e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed85140f-f0e0-4ac1-a67f-26d17ff95e31.jpg?1",
             "name": "Mage Hunters' Onslaught",
             "text": "Destroy target creature or planeswalker.\nWhenever a creature blocks this turn, its controller loses 1 life.",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "7be72d1b-6bfa-5d0c-a777-6c173fcb5cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b68a4-fb8d-4b59-b049-73505296f775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b68a4-fb8d-4b59-b049-73505296f775.jpg?1",
             "name": "Necrotic Fumes",
             "text": "As an additional cost to cast this spell, exile a creature you control.\nExile target creature or planeswalker.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "acb827c0-effd-56ed-ad81-0b5d8d4baaa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4677bc-736b-4bf2-851e-b158718a4224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4677bc-736b-4bf2-851e-b158718a4224.jpg?1",
             "name": "Novice Dissector",
             "text": "{1}, Sacrifice another creature: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "b0d89140-9711-5eb8-b8ba-eb2e1fcf984b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25214a91-2f64-46ee-9834-7fbf684800f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25214a91-2f64-46ee-9834-7fbf684800f7.jpg?1",
             "name": "Oriq Loremage",
             "text": "{T}: Search your library for a card, put it into your graveyard, then shuffle. If it's an instant or sorcery card, put a +1/+1 counter on Oriq Loremage.",
             "colours": [
@@ -2874,7 +2874,7 @@
         },
         {
             "id": "4d23ea02-252a-538b-954f-3317ba77e587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5034227f-3b8a-45bf-917c-c2cbd98f2192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5034227f-3b8a-45bf-917c-c2cbd98f2192.jpg?1",
             "name": "Plumb the Forbidden",
             "text": "As an additional cost to cast this spell, you may sacrifice one or more creatures. When you do, copy this spell for each creature sacrificed this way.\nYou draw a card and you lose 1 life.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "bc37a4e4-e812-5681-a5d5-cc6f21cc97cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg?1",
             "name": "Poet's Quill",
             "text": "When Poet's Quill enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nEquipped creature gets +1/+1 and has lifelink.\nEquip {1}{B}",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "1420f900-a294-5a49-8a03-3275a17dc90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013eeb99-1b66-4fba-ad96-78deee901ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013eeb99-1b66-4fba-ad96-78deee901ea4.jpg?1",
             "name": "Professor Onyx",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, each opponent loses 2 life and you gain 2 life.\n+1: You lose 1 life. Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n\u22123: Each opponent sacrifices a creature with the greatest power among creatures that player controls.\n\u22128: Each opponent may discard a card. If they don't, they lose 3 life. Repeat this process six more times.",
             "colours": [
@@ -2980,7 +2980,7 @@
         },
         {
             "id": "516cf4a7-cf2c-54cc-96ae-a68889b8c0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fded6-e474-4b20-86d8-fd9af5f25b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fded6-e474-4b20-86d8-fd9af5f25b1a.jpg?1",
             "name": "Professor's Warning",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3012,7 +3012,7 @@
         },
         {
             "id": "1bf3503f-6ee9-5a9e-a13d-e8424eb28fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea0dff9-71c3-4d56-aa7b-e0fb9938529a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea0dff9-71c3-4d56-aa7b-e0fb9938529a.jpg?1",
             "name": "Promising Duskmage",
             "text": "When Promising Duskmage dies, if it had a +1/+1 counter on it, draw a card.",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "b0258edc-a8be-5b9a-9b72-8e95cfeb44f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e900c1eb-968b-4046-b824-c167a7a5b682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e900c1eb-968b-4046-b824-c167a7a5b682.jpg?1",
             "name": "Sedgemoor Witch",
             "text": "Menace\nWard\u2014\nPay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "889563cb-2e57-5027-91f8-b17bc23c305c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3cfbc-7177-4bbc-89c4-560c9c2f97db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3cfbc-7177-4bbc-89c4-560c9c2f97db.jpg?1",
             "name": "Specter of the Fens",
             "text": "Flying\n{5}{B}: Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3118,7 +3118,7 @@
         },
         {
             "id": "9fe6076d-f2c0-551d-ba6f-0799f3bbddbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eba33e-efea-4e58-a832-1c6049fb211f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eba33e-efea-4e58-a832-1c6049fb211f.jpg?1",
             "name": "Tenured Inkcaster",
             "text": "When Tenured Inkcaster enters the battlefield, put a +1/+1 counter on target creature.\nWhenever a creature you control with a +1/+1 counter on it attacks, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "3ad30ecf-43e9-52b9-b2ac-8800036709e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ea2dad-f276-47b8-912c-267a832f1d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ea2dad-f276-47b8-912c-267a832f1d36.jpg?1",
             "name": "A-Tenured Inkcaster",
             "text": "",
             "colours": [
@@ -3187,7 +3187,7 @@
         },
         {
             "id": "09661ca1-1ab2-57ec-afca-96fe858c246b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbd0921-e953-492b-ad73-c8a8bfaa750b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbd0921-e953-492b-ad73-c8a8bfaa750b.jpg?1",
             "name": "Umbral Juke",
             "text": "Choose one \u2014\n\u2022 Target player sacrifices a creature or planeswalker.\n\u2022 Create a 2/1 white and black Inkling creature token with flying.",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "b8a11a8d-ecfc-5451-9cb3-7550cc497b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30448144-639a-43c7-a408-bd6ed543c231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30448144-639a-43c7-a408-bd6ed543c231.jpg?1",
             "name": "Unwilling Ingredient",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{2}{B}, Exile Unwilling Ingredient from your graveyard: You draw a card and you lose 1 life.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "d4fd94e8-acbe-5863-8d66-4cd643e1ce3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620cc3b-e401-4096-b310-fed080806344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620cc3b-e401-4096-b310-fed080806344.jpg?1",
             "name": "Academic Dispute",
             "text": "Target creature blocks this turn if able. You may have it gain reach until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "229da747-3dc8-542a-9684-36f095f07e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4832a-26c0-4da5-abbb-1941e7084e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4832a-26c0-4da5-abbb-1941e7084e72.jpg?1",
             "name": "Ardent Dustspeaker",
             "text": "Whenever Ardent Dustspeaker attacks, you may put an instant or sorcery card from your graveyard on the bottom of your library. If you do, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "a3662e76-73ff-5bee-b073-ce1c28cdb4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b12c44-9537-4863-a678-c982e8714a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b12c44-9537-4863-a678-c982e8714a5a.jpg?1",
             "name": "A-Ardent Dustspeaker",
             "text": "",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "b13a39a2-951d-58e3-b106-9d6e9e8b74ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30237cc-27c8-4075-acbd-d75a16588a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30237cc-27c8-4075-acbd-d75a16588a68.jpg?1",
             "name": "Blood Age General",
             "text": "{T}: Attacking Spirits get +1/+0 until end of turn.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "c0502579-0903-57f8-8a77-01c372ada9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742a7487-70a2-448b-8e66-c33cba798a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742a7487-70a2-448b-8e66-c33cba798a32.jpg?1",
             "name": "Conspiracy Theorist",
             "text": "Whenever Conspiracy Theorist attacks, you may pay {1} and discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards, you may exile one of them from your graveyard. If you do, you may cast it this turn.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "e893af38-0a32-5027-b7b8-4a447e542e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de547f52-3798-4b3a-947d-24873251204b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de547f52-3798-4b3a-947d-24873251204b.jpg?1",
             "name": "Crackle with Power",
             "text": "Crackle with Power deals five times X damage to each of up to X targets.",
             "colours": [
@@ -3460,7 +3460,7 @@
         },
         {
             "id": "a1a98abb-23dc-592d-9040-a494c3ef54d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657de246-b9fc-47b1-b932-091e9500bb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657de246-b9fc-47b1-b932-091e9500bb82.jpg?1",
             "name": "Draconic Intervention",
             "text": "As an additional cost to cast this spell, exile an instant or sorcery card from your graveyard.\nDraconic Intervention deals X damage to each non-Dragon creature, where X is the exiled card's mana value. If a creature dealt damage this way would die this turn, exile it instead.\nExile Draconic Intervention.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "e0aa2342-1a29-5b34-8174-25f7d75b3e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb504a0-1dfb-49d0-84c3-7bd318d55481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb504a0-1dfb-49d0-84c3-7bd318d55481.jpg?1",
             "name": "Dragon's Approach",
             "text": "Dragon's Approach deals 3 damage to each opponent. You may exile Dragon's Approach and four cards named Dragon's Approach from your graveyard. If you do, search your library for a Dragon creature card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Dragon's Approach.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "927c494a-fdc5-5bab-841c-e423b7630f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f0731c-2a3d-4613-bffa-8b967e4f142e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f0731c-2a3d-4613-bffa-8b967e4f142e.jpg?1",
             "name": "Efreet Flamepainter",
             "text": "Double strike\nWhenever Efreet Flamepainter deals combat damage to a player, you may cast target instant or sorcery card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "ba28847e-89d5-5a97-afef-1a0e8f646e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543c64ff-2c51-4a63-a940-dc8645717c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543c64ff-2c51-4a63-a940-dc8645717c85.jpg?1",
             "name": "Enthusiastic Study",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "0b939e2f-5c3d-546e-a082-a1dc92915758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122c01e6-38a6-456e-971e-9004df85ac1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122c01e6-38a6-456e-971e-9004df85ac1c.jpg?1",
             "name": "Explosive Welcome",
             "text": "Explosive Welcome deals 5 damage to any target and 3 damage to any other target. Add {R}{R}{R}.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "b7782885-29c5-5b11-a5f2-22d52fd70cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f824caf-b32c-442a-8631-887831a57360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f824caf-b32c-442a-8631-887831a57360.jpg?1",
             "name": "Fervent Mastery",
             "text": "You may pay {2}{R}{R} rather than pay this spell's mana cost.\nIf the {2}{R}{R} cost was paid, an opponent discards any number of cards, then draws that many cards.\nSearch your library for up to three cards, put them into your hand, shuffle, then discard three cards at random.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "d4171971-acfe-5a89-b6c2-0adff025b7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091eb13d-9318-4b12-9f94-6276b11981d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091eb13d-9318-4b12-9f94-6276b11981d1.jpg?1",
             "name": "First Day of Class",
             "text": "Whenever a creature enters the battlefield under your control this turn, put a +1/+1 counter on it and it gains haste until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "55da3b0f-1a14-5d3b-b008-c1ef5080daf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce76a38-fc5f-4e29-ba24-4a877179a62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce76a38-fc5f-4e29-ba24-4a877179a62c.jpg?1",
             "name": "Fuming Effigy",
             "text": "Whenever one or more cards leave your graveyard, Fuming Effigy deals 1 damage to each opponent.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "8b870715-7326-5724-b859-f136a519c26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04897-6438-45e5-a10b-2e8afaf2b9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04897-6438-45e5-a10b-2e8afaf2b9eb.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {C}{C}{R}. Activate only as a sorcery.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "88f4e95d-886f-58a4-8ac7-d6d032461ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fdc551-0b22-49f4-8765-143ad82f16a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fdc551-0b22-49f4-8765-143ad82f16a3.jpg?1",
             "name": "Hall Monitor",
             "text": "Haste\n{1}{R}, {T}: Target creature can't block this turn.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "1eb27463-abee-5a62-ab17-ae2be76d8793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c88e2-28ed-4e5b-bcb3-4397d6a15a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c88e2-28ed-4e5b-bcb3-4397d6a15a6f.jpg?1",
             "name": "Heated Debate",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nHeated Debate deals 4 damage to target creature or planeswalker.",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "99fd4bd9-0d11-541a-80ef-cd32e812869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5781ad7b-dc1b-4cc1-9e72-6e714b9ba1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5781ad7b-dc1b-4cc1-9e72-6e714b9ba1de.jpg?1",
             "name": "Igneous Inspiration",
             "text": "Igneous Inspiration deals 3 damage to any target.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3860,7 +3860,7 @@
         },
         {
             "id": "f67fa68e-5cc3-5601-9fac-2f696dd08b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98739789-80b5-4224-a2e4-09e00654aa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98739789-80b5-4224-a2e4-09e00654aa9d.jpg?1",
             "name": "Illuminate History",
             "text": "Discard any number of cards, then draw that many cards. Then if there are seven or more cards in your graveyard, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "e7445d36-852d-5e02-a8af-3ba3fb09ff97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc4e7d-3b06-4938-9023-d903912350c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc4e7d-3b06-4938-9023-d903912350c0.jpg?1",
             "name": "Illustrious Historian",
             "text": "{5}, Exile Illustrious Historian from your graveyard: Create a tapped 3/2 red and white Spirit creature token.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "9a05ec6f-deb6-5539-a53e-0276e5bda7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0ea66f-1756-4b0d-8ccc-3b3a7370b531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0ea66f-1756-4b0d-8ccc-3b3a7370b531.jpg?1",
             "name": "Mascot Interception",
             "text": "This spell costs {3} less to cast if it targets a creature token.\nGain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "e6620102-4262-529d-97d8-acb19792fdb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d285a7a1-bb7e-4a78-a49f-c2add62b829a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d285a7a1-bb7e-4a78-a49f-c2add62b829a.jpg?1",
             "name": "Pigment Storm",
             "text": "Pigment Storm deals 5 damage to target creature. Excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -3995,7 +3995,7 @@
         },
         {
             "id": "1b4a82f1-032d-54cc-8f63-5af4a09a9609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d509f73-cd62-4116-9652-0ed801ed8b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d509f73-cd62-4116-9652-0ed801ed8b36.jpg?1",
             "name": "Pillardrop Warden",
             "text": "Reach\n{2}, {T}, Sacrifice Pillardrop Warden: Return target instant or sorcery card from your graveyard to your hand. Activate only as a sorcery.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "0b0cc9ce-0788-5241-ae58-9b05f4a7d48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd6cb53-3c82-4ac3-be1e-311322729198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd6cb53-3c82-4ac3-be1e-311322729198.jpg?1",
             "name": "Retriever Phoenix",
             "text": "Flying, haste\nWhen Retriever Phoenix enters the battlefield, if you cast it, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nAs long as Retriever Phoenix is in your graveyard, if you would learn, you may instead return Retriever Phoenix to the battlefield.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "7a0b2101-f675-58c9-9f46-ca36c277e601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c99486-ae64-4293-81fb-a4b02e8fcae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c99486-ae64-4293-81fb-a4b02e8fcae6.jpg?1",
             "name": "Start from Scratch",
             "text": "Choose one \u2014\n\u2022 Start from Scratch deals 1 damage to any target.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "55dc28b3-b20f-538d-a0eb-aafcb348be3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa96b8dc-233a-4884-ab84-235cbc7df0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa96b8dc-233a-4884-ab84-235cbc7df0b6.jpg?1",
             "name": "Storm-Kiln Artist",
             "text": "Storm-Kiln Artist gets +1/+0 for each artifact you control.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a Treasure token.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "d22f72a4-5adc-55cb-828f-f237ece17a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b011707a-471b-41c2-bc73-376a55d26bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b011707a-471b-41c2-bc73-376a55d26bee.jpg?1",
             "name": "Sudden Breakthrough",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "f2227a3b-912c-5164-880d-ce00bb9b8694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cc9ea8-db4e-4f41-800f-fb0dbcb2c345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cc9ea8-db4e-4f41-800f-fb0dbcb2c345.jpg?1",
             "name": "Tome Shredder",
             "text": "Haste\n{T}, Exile an instant or sorcery card from your graveyard: Put a +1/+1 counter on Tome Shredder.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "86de9023-6281-5e06-b512-05d109d7bb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2952a34c-b0c0-4e1c-9a00-c74c7e6b7d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2952a34c-b0c0-4e1c-9a00-c74c7e6b7d32.jpg?1",
             "name": "A-Tome Shredder",
             "text": "",
             "colours": [
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "b8d2f2a7-b630-57ee-b159-c309966ced0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193af5-4b6b-48d0-9b75-8171bb1d6e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193af5-4b6b-48d0-9b75-8171bb1d6e53.jpg?1",
             "name": "Twinscroll Shaman",
             "text": "Double strike",
             "colours": [
@@ -4269,7 +4269,7 @@
         },
         {
             "id": "68d2b8d8-f36d-51e1-b8fe-3c0a4516a9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b7830-b65e-4c53-98e8-152026764e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b7830-b65e-4c53-98e8-152026764e4b.jpg?1",
             "name": "Accomplished Alchemist",
             "text": "{T}: Add one mana of any color.\n{T}: Add X mana of any one color, where X is the amount of life you gained this turn.",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "5d44e374-6a7d-5ab4-b7fe-4d99917cf401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg?1",
             "name": "Basic Conjuration",
             "text": "Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "bb7c872a-07e0-51ff-91ba-7a1610bdeaac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82b032-b1ba-456c-abab-c0f7430b0587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82b032-b1ba-456c-abab-c0f7430b0587.jpg?1",
             "name": "Bayou Groff",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}.",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "01b6e372-397c-5938-9af1-a792b451e841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016d667-50a9-4093-9a99-b34dcdafe60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016d667-50a9-4093-9a99-b34dcdafe60b.jpg?1",
             "name": "Big Play",
             "text": "Target creature gets +2/+2 and gains reach until end of turn. Put a +1/+1 counter on it.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "919d569a-665b-5c07-a58e-41d0bb790e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d230fc-d382-40b4-bdbd-5fe880fa16bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d230fc-d382-40b4-bdbd-5fe880fa16bf.jpg?1",
             "name": "Bookwurm",
             "text": "Trample\nWhen Bookwurm enters the battlefield, you gain 3 life and draw a card.\n{2}{G}: Put Bookwurm from your graveyard into your library third from the top.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "988fcafa-2144-54a0-a167-0688983a78c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed16926f-feb0-481a-8c5e-88ea119752cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed16926f-feb0-481a-8c5e-88ea119752cd.jpg?1",
             "name": "Charge Through",
             "text": "Target creature gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -4475,7 +4475,7 @@
         },
         {
             "id": "a18d7e04-9518-5f89-ab40-72dc8f3f84b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcca120-b72e-4007-98e1-cb22e7b9a705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcca120-b72e-4007-98e1-cb22e7b9a705.jpg?1",
             "name": "Containment Breach",
             "text": "Destroy target artifact or enchantment. If its mana value is 2 or less, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "9f19e2cd-5551-5db9-8b6d-9f3985048f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7444555-da19-4d2d-ad81-233c54fbb78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7444555-da19-4d2d-ad81-233c54fbb78e.jpg?1",
             "name": "Devouring Tendrils",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control. When the permanent you don't control dies this turn, you gain 2 life.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "ca8b9a11-3bdd-5680-9088-365a4ffce125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658ec634-3eb2-4967-b938-d20d31ab77e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658ec634-3eb2-4967-b938-d20d31ab77e3.jpg?1",
             "name": "Dragonsguard Elite",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Dragonsguard Elite.\n{4}{G}{G}: Double the number of +1/+1 counters on Dragonsguard Elite.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "66d29d3a-280c-54d8-a61f-9e89e204cbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115f3d72-1aaf-4237-91b9-389256e5e5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115f3d72-1aaf-4237-91b9-389256e5e5c8.jpg?1",
             "name": "Ecological Appreciation",
             "text": "Search your library and graveyard for up to four creature cards with different names that each have mana value X or less and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest onto the battlefield. Exile Ecological Appreciation.",
             "colours": [
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "ae6067fc-2e5b-583c-8eda-4e2413bae84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a81975-5f0e-4593-a2da-b9689f9a985f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a81975-5f0e-4593-a2da-b9689f9a985f.jpg?1",
             "name": "Emergent Sequence",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. That land becomes a 0/0 green and blue Fractal creature that's still a land. Put a +1/+1 counter on it for each land you had enter the battlefield under your control this turn.",
             "colours": [
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "dd174633-ac4e-55b2-ae1a-e0ff1f00a0dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c129bb7-9489-44bd-a46d-c5f738bf9d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c129bb7-9489-44bd-a46d-c5f738bf9d25.jpg?1",
             "name": "Exponential Growth",
             "text": "Until end of turn, double target creature's power X times.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "4e62bc4c-ca9e-59b1-bc36-8ee7dab438af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f235060a-eb49-4a73-bb5f-01228c3c4070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f235060a-eb49-4a73-bb5f-01228c3c4070.jpg?1",
             "name": "Field Trip",
             "text": "Search your library for a basic Forest card, put that card onto the battlefield tapped, then shuffle.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -4711,7 +4711,7 @@
         },
         {
             "id": "7ebe8288-c967-5f4a-a5f5-5fd3c94ed922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6789b717-a000-464a-a39b-32c1aeefe560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6789b717-a000-464a-a39b-32c1aeefe560.jpg?1",
             "name": "Fortifying Draught",
             "text": "You gain 2 life. Target creature gets +X/+X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "66485f80-10b2-54ad-98a4-7e2d57d472bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg?1",
             "name": "Gnarled Professor",
             "text": "Trample\nWhen Gnarled Professor enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "e1634908-4cec-5d28-9345-0a7a7bd650f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6a6b9-f00c-46a5-8dab-796483e3a262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6a6b9-f00c-46a5-8dab-796483e3a262.jpg?1",
             "name": "Honor Troll",
             "text": "Vigilance\nIf you would gain life, you gain that much life plus 1 instead.\nHonor Troll gets +2/+1 as long as you have 25 or more life.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "31fbdb67-ec53-5e65-8187-6302c32d1f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74729320-f6ee-4176-9463-397d6e477d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74729320-f6ee-4176-9463-397d6e477d7a.jpg?1",
             "name": "Karok Wrangler",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -4850,7 +4850,7 @@
         },
         {
             "id": "d5a37960-5faa-5020-b9d9-917a1c8d8eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbed0-0c0d-4aa5-bfe0-5268aff0f958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbed0-0c0d-4aa5-bfe0-5268aff0f958.jpg?1",
             "name": "Leyline Invocation",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of lands you control.",
             "colours": [
@@ -4882,7 +4882,7 @@
         },
         {
             "id": "10f41540-1e49-5872-8eaf-ad9469821f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92325638-0321-4409-8910-2287c64c182e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92325638-0321-4409-8910-2287c64c182e.jpg?1",
             "name": "Mage Duel",
             "text": "This spell costs {2} less to cast if you've cast another instant or sorcery spell this turn.\nTarget creature you control gets +1/+2 until end of turn. Then it fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "0bd9370a-baef-553c-9761-004ec21771fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255cdc39-6ad8-4831-9718-6712cb17654c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255cdc39-6ad8-4831-9718-6712cb17654c.jpg?1",
             "name": "Master Symmetrist",
             "text": "Reach\nWhenever a creature you control with power equal to its toughness attacks, it gains trample until end of turn.",
             "colours": [
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "cf587c42-c21d-5f6e-864a-270d29cef923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71dddf5-8f72-4018-9cc8-5f63a17f1ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71dddf5-8f72-4018-9cc8-5f63a17f1ee5.jpg?1",
             "name": "Overgrown Arch",
             "text": "Defender\n{T}: You gain 1 life.\n{2}, Sacrifice Overgrown Arch: Learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "339c8411-ee94-57bf-96d4-0aea20f23cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8347f2e8-ef70-4879-860a-12f7cab25902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8347f2e8-ef70-4879-860a-12f7cab25902.jpg?1",
             "name": "Professor of Zoomancy",
             "text": "When Professor of Zoomancy enters the battlefield, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "15e24f7f-8822-5fb0-827e-b50d4777fdb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8072b1-6080-45cd-b1c7-353b54a55931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8072b1-6080-45cd-b1c7-353b54a55931.jpg?1",
             "name": "Reckless Amplimancer",
             "text": "{4}{G}: Double Reckless Amplimancer's power and toughness until end of turn.",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "244e8e81-0c6f-5053-8ef9-82dedc59664c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0a096-870d-443c-92d3-f7ec1f362616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0a096-870d-443c-92d3-f7ec1f362616.jpg?1",
             "name": "Scurrid Colony",
             "text": "Reach\nScurrid Colony gets +2/+2 as long as you control eight or more lands.",
             "colours": [
@@ -5088,7 +5088,7 @@
         },
         {
             "id": "0731017a-2eef-5795-afa6-69ef12b416b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37ae6b5-225a-410e-ab22-13e923bdfb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37ae6b5-225a-410e-ab22-13e923bdfb65.jpg?1",
             "name": "Spined Karok",
             "text": "",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "a87fb203-7298-5b11-b0ff-0672159e8b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b0eac4-0262-4eed-97d4-0f2e6f06c8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b0eac4-0262-4eed-97d4-0f2e6f06c8e1.jpg?1",
             "name": "Springmane Cervin",
             "text": "When Springmane Cervin enters the battlefield, you gain 2 life.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "6ff57442-57a3-5901-9688-6114872e82bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fbf729-00c0-4237-8294-c857f96364d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fbf729-00c0-4237-8294-c857f96364d3.jpg?1",
             "name": "Tangletrap",
             "text": "Choose one \u2014\n\u2022 Tangletrap deals 5 damage to target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5188,7 +5188,7 @@
         },
         {
             "id": "34f18c07-6eb9-5e87-a604-50cb8f6f8210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197455e5-7929-47b8-ad00-8d3918949eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197455e5-7929-47b8-ad00-8d3918949eb7.jpg?1",
             "name": "Verdant Mastery",
             "text": "You may pay {3}{G} rather than pay this spell's mana cost.\nSearch your library for up to four basic land cards and reveal them. Put one of them onto the battlefield tapped under an opponent's control if the {3}{G} cost was paid. Put two of them onto the battlefield tapped under your control and the rest into your hand. Then shuffle.",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "9e0936f9-4044-51e7-8c67-843a27d5ac9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "657f4e54-d473-56bb-be88-2796de7070cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "5a52cce7-3897-5901-a0ab-d1ed087c41ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "55cd326c-01c3-5523-b2fe-22a614594d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "c3881b6c-fe9c-5fbf-bfcf-136795dd0e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "1585babb-53a5-5c2b-bcbc-e239fa209d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -5448,7 +5448,7 @@
         },
         {
             "id": "993ad70a-a847-5a5f-bb1f-337f6a69526c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "bdae9711-1cd5-5232-9b44-4794195009b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "ba2a5b47-8058-5de2-bc8b-28b57b56615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "cf445c3c-3759-5b0c-aa94-78312ce2ed7c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "67c72f64-55f6-5699-9ee7-e6fa5bf3a456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "635efd48-a593-5ade-86ca-8b2ca6a17aed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "8317df72-f217-529b-b3f3-33bac02d8971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -5715,7 +5715,7 @@
         },
         {
             "id": "a56db6de-2653-5737-b9b3-2b71592759d3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "d07c3edc-397e-5a1a-aa15-3c212ca1dcfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -5789,7 +5789,7 @@
         },
         {
             "id": "c82b54a3-005d-5985-bf04-83e2ce45ce79",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "8a55d6cc-c013-5f09-9ff9-ebdff6a1b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "3a8c839f-e8a2-5d79-846a-36dc1a642f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "fabd03c7-6c79-552c-ae47-a907a2dd60b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "bec42168-2b9d-5bc6-815b-e4c120fc4f51",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -5982,7 +5982,7 @@
         },
         {
             "id": "c5b21dfd-cb00-5fea-b3ef-a0fafb4e91b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg?1",
             "name": "A-Rowan, Scholar of Sparks // A-Will, Scholar of Frost",
             "text": "",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "877af095-2742-58dc-b317-e042d600e697",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg?1",
             "name": "A-Rowan, Scholar of Sparks // A-Will, Scholar of Frost",
             "text": "",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "21b5995b-8c46-5e6d-95a1-4d617b7c414c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "2d4b9802-2ac9-5997-9d0d-5b725d1a7439",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "e2d2a0fc-fca8-5c65-b05c-a7142981c3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "d1a986ca-1e4e-5422-9975-b16428a4823c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -6207,7 +6207,7 @@
         },
         {
             "id": "ededb64b-23a7-5be4-8536-946d19c43dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2}\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "c0ffa53f-7cdd-5d8a-999e-4cd6f6e04c78",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "ba394357-d2ed-5be4-a2a9-41ee487571f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "db8894bb-dcb4-5d7c-8572-9c2a88ad04b4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "6eac70af-6c27-5b83-9514-0eb13f05ad48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -6400,7 +6400,7 @@
         },
         {
             "id": "c4983060-0fdf-5c60-9930-5db6683ab7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "31e83999-43c6-56ab-a3a9-853532be5c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1c653e-f629-4105-a52c-379c5cd78208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1c653e-f629-4105-a52c-379c5cd78208.jpg?1",
             "name": "Aether Helix",
             "text": "Return target permanent to its owner's hand. Return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "590ae1e0-a8c9-5407-81c9-d9f93285402f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f786a2-a7b7-4f9e-92e8-9a6a11efe290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f786a2-a7b7-4f9e-92e8-9a6a11efe290.jpg?1",
             "name": "Beledros Witherbloom",
             "text": "Flying\nAt the beginning of each upkeep, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\nPay 10 life: Untap all lands you control. Activate only once each turn.",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "237fa397-f19b-59c1-b06e-e8b2de2bfd11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a35ef-dae1-4534-a12a-d3951b285273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a35ef-dae1-4534-a12a-d3951b285273.jpg?1",
             "name": "Biomathematician",
             "text": "When Biomathematician enters the battlefield, create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on each Fractal you control.",
             "colours": [
@@ -6552,7 +6552,7 @@
         },
         {
             "id": "6f90e775-194e-574e-a005-b7bfee276556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46d64ec-aca4-428e-bce6-66cd755c8cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46d64ec-aca4-428e-bce6-66cd755c8cc3.jpg?1",
             "name": "Blade Historian",
             "text": "Attacking creatures you control have double strike.",
             "colours": [
@@ -6591,7 +6591,7 @@
         },
         {
             "id": "90370be4-443c-542c-9ef8-e4fcc80e5f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e35e9ba-a10e-4926-a7a6-3a65efc2a730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e35e9ba-a10e-4926-a7a6-3a65efc2a730.jpg?1",
             "name": "Blood Researcher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever you gain life, put a +1/+1 counter on Blood Researcher.",
             "colours": [
@@ -6628,7 +6628,7 @@
         },
         {
             "id": "494545b2-2e57-5c6c-ba39-07b289ca4bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0141312f-4b68-4c56-b1dc-5b7e6afbb96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0141312f-4b68-4c56-b1dc-5b7e6afbb96c.jpg?1",
             "name": "Blot Out the Sky",
             "text": "Create X tapped 2/1 white and black Inkling creature tokens with flying. If X is 6 or more, destroy all noncreature, nonland permanents.",
             "colours": [
@@ -6664,7 +6664,7 @@
         },
         {
             "id": "2569a3ee-b2aa-5aba-8a3b-136e39b2edd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b56823-0076-49cc-b5aa-4accb8e2782e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b56823-0076-49cc-b5aa-4accb8e2782e.jpg?1",
             "name": "Body of Research",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your library.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "1e5efac7-f7d8-5434-b71e-c5edab51aca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e6d07-fe40-4723-b963-02da0a0987c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e6d07-fe40-4723-b963-02da0a0987c7.jpg?1",
             "name": "Closing Statement",
             "text": "This spell costs {2} less to cast during your end step.\nDestroy target creature or planeswalker you don't control. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "d1514285-38e2-5ff5-80bf-bdca8c0cb63c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59a249f-35ed-447a-845b-32ba5a53124e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59a249f-35ed-447a-845b-32ba5a53124e.jpg?1",
             "name": "Cram Session",
             "text": "You gain 4 life.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "9c44bf9d-9994-58d0-9cf7-c9f12885842e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab58d87-bf01-45dc-8958-e2b3375f914b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab58d87-bf01-45dc-8958-e2b3375f914b.jpg?1",
             "name": "Creative Outburst",
             "text": "Creative Outburst deals 5 damage to any target. Look at the top five cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.\n{UR}{UR}, Discard Creative Outburst: Create a Treasure token.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "e1cdc29e-b9aa-558b-a657-7120167dd34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6f91d3-cc07-4a42-99a0-5fb83b29cc25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6f91d3-cc07-4a42-99a0-5fb83b29cc25.jpg?1",
             "name": "Culling Ritual",
             "text": "Destroy each nonland permanent with mana value 2 or less. Add {B} or {G} for each permanent destroyed this way.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "6fe2417c-dc87-5d55-9db8-5a7dd842c06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2483060e-9d3f-48ae-80ea-0119bf6b4d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2483060e-9d3f-48ae-80ea-0119bf6b4d67.jpg?1",
             "name": "Culmination of Studies",
             "text": "Exile the top X cards of your library. For each land card exiled this way, create a Treasure token. For each blue card exiled this way, draw a card. For each red card exiled this way, Culmination of Studies deals 1 damage to each opponent.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "ce592fac-5d34-5f78-ab70-e04beb76f53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f18828-ade7-4b99-97b2-e34bc2fdb68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f18828-ade7-4b99-97b2-e34bc2fdb68c.jpg?1",
             "name": "Daemogoth Titan",
             "text": "Whenever Daemogoth Titan attacks or blocks, sacrifice a creature.",
             "colours": [
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "f0510f58-64b3-50d1-a63b-b1329bb75662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c965cbe3-50e5-41bb-bdb9-e65d97aab716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c965cbe3-50e5-41bb-bdb9-e65d97aab716.jpg?1",
             "name": "Daemogoth Woe-Eater",
             "text": "At the beginning of your upkeep, sacrifice a creature.\nWhen you sacrifice Daemogoth Woe-Eater, each opponent discards a card, you draw a card, and you gain 2 life.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "3de709fc-2798-52a8-afe1-efab392bc9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33e48-90fc-4aac-b09a-68050bc053b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33e48-90fc-4aac-b09a-68050bc053b5.jpg?1",
             "name": "Deadly Brew",
             "text": "Each player sacrifices a creature or planeswalker. If you sacrificed a permanent this way, you may return another permanent card from your graveyard to your hand.",
             "colours": [
@@ -6982,7 +6982,7 @@
         },
         {
             "id": "52e047af-7800-55e2-b3ae-05ebb0a1a2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e9d132-95f7-4ee7-9c91-be19e4ad7a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e9d132-95f7-4ee7-9c91-be19e4ad7a5d.jpg?1",
             "name": "Decisive Denial",
             "text": "Choose one \u2014\n\u2022 Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\n\u2022 Counter target noncreature spell unless its controller pays {3}.",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "ba8b4d5c-8409-50c8-8d3a-010a99cc0513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd2b567-0cf7-4441-b3ce-e31141dd91c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd2b567-0cf7-4441-b3ce-e31141dd91c8.jpg?1",
             "name": "Dina, Soul Steeper",
             "text": "Whenever you gain life, each opponent loses 1 life.\n{1}, Sacrifice another creature: Dina, Soul Steeper gets +X/+0 until end of turn, where X is the sacrificed creature's power.",
             "colours": [
@@ -7057,7 +7057,7 @@
         },
         {
             "id": "67dd6c24-8393-5c99-8ee7-f7c25e35a1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d35413-8742-4443-8859-93c91112978d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d35413-8742-4443-8859-93c91112978d.jpg?1",
             "name": "Double Major",
             "text": "Copy target creature spell you control, except it isn't legendary if the spell is legendary. (A copy of a creature spell becomes a token.)",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "bc6609f0-0592-52c8-9c15-43f88760b612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ec9be6-c8ad-4a82-8253-c49cdb9443ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ec9be6-c8ad-4a82-8253-c49cdb9443ba.jpg?1",
             "name": "Dramatic Finale",
             "text": "Creature tokens you control get +1/+1.\nWhenever one or more nontoken creatures you control die, create a 2/1 white and black Inkling creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "72c86b4a-6059-595a-a3ca-5db89652ac16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473db42-905b-4fda-af8c-fd24d906b642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473db42-905b-4fda-af8c-fd24d906b642.jpg?1",
             "name": "Elemental Expressionist",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, choose target creature you control. Until end of turn, it gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else\" and \"When you exile this creature, create a 4/4 blue and red Elemental creature token.\" (Each instance of that ability triggers separately.)",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "9dc927c8-5ded-5a1b-b303-734208eaea6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4331a7a6-e98e-4517-b0f9-ace379426a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4331a7a6-e98e-4517-b0f9-ace379426a94.jpg?1",
             "name": "Elemental Masterpiece",
             "text": "Create two 4/4 blue and red Elemental creature tokens.\n{UR}{UR}, Discard Elemental Masterpiece: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "3ec41a53-ce44-5e06-8dbf-e328262afea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea51991c-1589-4c62-965b-5ae8d233520b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea51991c-1589-4c62-965b-5ae8d233520b.jpg?1",
             "name": "Elemental Summoning",
             "text": "Create a 4/4 blue and red Elemental creature token.",
             "colours": [
@@ -7238,7 +7238,7 @@
         },
         {
             "id": "6a538fbc-2272-5a57-9a21-6287af8a9e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400c9b7-c789-49dd-9f72-b9d1df03fcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400c9b7-c789-49dd-9f72-b9d1df03fcca.jpg?1",
             "name": "Eureka Moment",
             "text": "Draw two cards. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "ee516c09-537d-5365-8e42-0bd9e0dab9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8468417d-7ef5-43e0-9190-e88f3eed9e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8468417d-7ef5-43e0-9190-e88f3eed9e82.jpg?1",
             "name": "Exhilarating Elocution",
             "text": "Put two +1/+1 counters on target creature you control. Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "82ee6986-02f8-50fb-81a5-26f0d3bc0b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b770cc-09e7-4c0b-b2a4-462ab4f7200d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b770cc-09e7-4c0b-b2a4-462ab4f7200d.jpg?1",
             "name": "Expressive Iteration",
             "text": "Look at the top three cards of your library. Put one of them into your hand, put one of them on the bottom of your library, and exile one of them. You may play the exiled card this turn.",
             "colours": [
@@ -7342,7 +7342,7 @@
         },
         {
             "id": "841e8b02-e657-5bcb-81c9-82c8040d3b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3f1f7e-eb19-49c1-a1ee-93b85ac8815c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3f1f7e-eb19-49c1-a1ee-93b85ac8815c.jpg?1",
             "name": "Fractal Summoning",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "afb258f6-63f8-58b6-8dc2-d39446885baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11224f8-06ea-4ec3-85e6-d5c8d906840c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11224f8-06ea-4ec3-85e6-d5c8d906840c.jpg?1",
             "name": "Fracture",
             "text": "Destroy target artifact, enchantment, or planeswalker.",
             "colours": [
@@ -7414,7 +7414,7 @@
         },
         {
             "id": "995fd0ec-402a-5d0e-b462-9d790966157f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9158c-064b-4d12-b860-d2c1450d1897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9158c-064b-4d12-b860-d2c1450d1897.jpg?1",
             "name": "Galazeth Prismari",
             "text": "Flying\nWhen Galazeth Prismari enters the battlefield, create a Treasure token.\nArtifacts you control have \"{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.\"",
             "colours": [
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "37665229-ea67-537c-8ff8-fb57049c0743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626fbddb-3963-4dd2-8507-9777ed66bbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626fbddb-3963-4dd2-8507-9777ed66bbbc.jpg?1",
             "name": "Golden Ratio",
             "text": "Draw a card for each different power among creatures you control.",
             "colours": [
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "fbf89fdd-c085-5a70-a0ce-b9cdfeb22440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74120ce-9f11-449f-bb72-04fe2a27a9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74120ce-9f11-449f-bb72-04fe2a27a9f6.jpg?1",
             "name": "Harness Infinity",
             "text": "Exchange your hand and graveyard.\nExile Harness Infinity.",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "2e02531c-9439-577f-b3f3-838098b0a386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8deecf-eded-418b-ac4c-5c3e8f54e86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8deecf-eded-418b-ac4c-5c3e8f54e86d.jpg?1",
             "name": "Hofri Ghostforge",
             "text": "Spirits you control get +1/+1 and have trample and haste.\nWhenever another nontoken creature you control dies, exile it. If you do, create a token that's a copy of that creature, except it's a Spirit in addition to its other types and it has \"When this creature leaves the battlefield, return the exiled card to your graveyard.\"",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "73bdcc8e-07df-5e45-807b-e4c2878208c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3ae8cb-fbdb-45a8-83c2-cbf4aff01f90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3ae8cb-fbdb-45a8-83c2-cbf4aff01f90.jpg?1",
             "name": "Humiliate",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Put a +1/+1 counter on a creature you control.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "2d6235a9-e0b8-5281-9ba2-2794e4bc12c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840600a9-3e78-48a6-b75b-860446b82c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840600a9-3e78-48a6-b75b-860446b82c1b.jpg?1",
             "name": "Infuse with Vitality",
             "text": "Until end of turn, target creature gains deathtouch and \"When this creature dies, return it to the battlefield tapped under its owner's control.\"\nYou gain 2 life.",
             "colours": [
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "3686b458-2c93-5b15-a9a6-726b1d20fb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a8a5b8-9743-4d1a-89e9-61bdf180b2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a8a5b8-9743-4d1a-89e9-61bdf180b2e0.jpg?1",
             "name": "Inkling Summoning",
             "text": "Create a 2/1 white and black Inkling creature token with flying.",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "021c5b4a-120d-501a-b3c9-c29d94adb830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bf300-38cf-4ab2-9e66-6fcaa112b649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bf300-38cf-4ab2-9e66-6fcaa112b649.jpg?1",
             "name": "Kasmina, Enigma Sage",
             "text": "Each other planeswalker you control has the loyalty abilities of Kasmina, Enigma Sage.\n+2: Scry 1.\n\u2212X: Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.\n\u22128: Search your library for an instant or sorcery card that shares a color with this planeswalker, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -7710,7 +7710,7 @@
         },
         {
             "id": "50cc691d-cd66-5f22-a153-cc8b5996df5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ef4f09-2aa1-4a03-b2e2-66d1522f1e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ef4f09-2aa1-4a03-b2e2-66d1522f1e46.jpg?1",
             "name": "Killian, Ink Duelist",
             "text": "Lifelink\nMenace (This creature can't be blocked except by two or more creatures.)\nSpells you cast that target a creature cost {2} less to cast.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "c8050495-655f-5de4-8a6c-4d75b543c289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048157c6-4626-4881-ba19-deddd13622dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048157c6-4626-4881-ba19-deddd13622dc.jpg?1",
             "name": "Lorehold Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, until end of turn, Spirit creatures you control gain \"{T}: This creature deals 1 damage to each opponent.\"",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "48d7f3f9-3225-5104-ab39-b3f3c9808195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0885f-1049-4a19-853d-f4e6d4bec29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0885f-1049-4a19-853d-f4e6d4bec29e.jpg?1",
             "name": "Lorehold Command",
             "text": "Choose two \u2014\n\u2022 Create a 3/2 red and white Spirit creature token.\n\u2022 Creatures you control get +1/+0 and gain indestructible and haste until end of turn.\n\u2022 Lorehold Command deals 3 damage to any target. Target player gains 3 life.\n\u2022 Sacrifice a permanent, then draw two cards.",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "0ca896cd-6565-57ac-b4a6-41048ed2b126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43105beb-46f3-4914-8222-4907bd76d48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43105beb-46f3-4914-8222-4907bd76d48f.jpg?1",
             "name": "Lorehold Excavation",
             "text": "At the beginning of your end step, mill a card. If a land card was milled this way, you gain 1 life. Otherwise, Lorehold Excavation deals 1 damage to each opponent. (To mill a card, put the top card of your library into your graveyard.)\n{5}, Exile a creature card from your graveyard: Create a tapped 3/2 red and white Spirit creature token.",
             "colours": [
@@ -7856,7 +7856,7 @@
         },
         {
             "id": "b519407c-4fa6-5d87-9976-8464523abda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b88b38-6b5a-4a89-80ca-add79c11e8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b88b38-6b5a-4a89-80ca-add79c11e8b9.jpg?1",
             "name": "Lorehold Pledgemage",
             "text": "First strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Lorehold Pledgemage gets +1/+0 until end of turn.",
             "colours": [
@@ -7893,7 +7893,7 @@
         },
         {
             "id": "fe4758ca-e854-53c7-800f-8aceb676821d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516e81e-16ea-411c-9df0-ed3b03670220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516e81e-16ea-411c-9df0-ed3b03670220.jpg?1",
             "name": "Maelstrom Muse",
             "text": "Flying\nWhenever Maelstrom Muse attacks, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is Maelstrom Muse's power as this ability resolves.",
             "colours": [
@@ -7930,7 +7930,7 @@
         },
         {
             "id": "6ffb8f88-4ddb-5b75-b8b4-27b5e4b6fe7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53e674b-5d48-4734-beeb-2a3deeb935e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53e674b-5d48-4734-beeb-2a3deeb935e0.jpg?1",
             "name": "A-Maelstrom Muse",
             "text": "",
             "colours": [
@@ -7966,7 +7966,7 @@
         },
         {
             "id": "b4d30a18-7e7c-54f7-aecc-9b9a6ce8e628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c914a3-2294-4feb-9450-c012cfd307a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c914a3-2294-4feb-9450-c012cfd307a6.jpg?1",
             "name": "Magma Opus",
             "text": "Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.\n{UR}{UR}, Discard Magma Opus: Create a Treasure token.",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "1bbc52e0-b429-599f-9692-514121c154cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e937830-3804-44e8-b9d0-3e5f5cf39eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e937830-3804-44e8-b9d0-3e5f5cf39eab.jpg?1",
             "name": "Make Your Mark",
             "text": "Target creature gets +1/+0 until end of turn. When that creature dies this turn, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "7aae8080-879a-58f3-b9ad-3de19673479b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fc5cd2-fbb0-4d13-9089-0292b356de48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fc5cd2-fbb0-4d13-9089-0292b356de48.jpg?1",
             "name": "Manifestation Sage",
             "text": "When Manifestation Sage enters the battlefield, create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your hand.",
             "colours": [
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "5a728304-6b93-5815-b65a-2599944ea227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c2ef30-0db5-4ef5-999c-7ffa48769421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c2ef30-0db5-4ef5-999c-7ffa48769421.jpg?1",
             "name": "Moldering Karok",
             "text": "Trample, lifelink",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "c2cb909b-a773-520e-a96e-5a1e61fb0c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f39fe7-dc12-49c9-80ac-4135dc1f8f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f39fe7-dc12-49c9-80ac-4135dc1f8f08.jpg?1",
             "name": "Mortality Spear",
             "text": "This spell costs {2} less to cast if you gained life this turn.\nDestroy target nonland permanent.",
             "colours": [
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "dd4a7b02-fe9b-5f8e-b912-14bad0d3540f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0cf2c4-723e-46c4-b2aa-4c957177209a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0cf2c4-723e-46c4-b2aa-4c957177209a.jpg?1",
             "name": "Needlethorn Drake",
             "text": "Flying, deathtouch",
             "colours": [
@@ -8184,7 +8184,7 @@
         },
         {
             "id": "509552e7-5d33-5cd1-844f-69b30d20e822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38329f1-af6e-47b8-86e4-f2a39e1edbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38329f1-af6e-47b8-86e4-f2a39e1edbf8.jpg?1",
             "name": "Oggyar Battle-Seer",
             "text": "Haste\n{T}: Scry 1.",
             "colours": [
@@ -8221,7 +8221,7 @@
         },
         {
             "id": "0dc382da-ee78-57c4-a882-5df7bba3cbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3350367-42bd-44af-be13-ad31c002f8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3350367-42bd-44af-be13-ad31c002f8ac.jpg?1",
             "name": "Owlin Shieldmage",
             "text": "Flying\nWard\u2014\nPay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)",
             "colours": [
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "0194f654-381c-5aea-97c8-bd0f80e7851a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6267e19a-a777-4767-8433-86b6624362b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6267e19a-a777-4767-8433-86b6624362b6.jpg?1",
             "name": "Pest Summoning",
             "text": "Create two 1/1 black and green Pest creature tokens with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "de47c882-1f2d-5fb9-8e17-20f7a6bb98b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74edd3e3-b2de-4ba0-a508-0418b0151d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74edd3e3-b2de-4ba0-a508-0418b0151d87.jpg?1",
             "name": "Practical Research",
             "text": "Draw four cards. Then discard two cards unless you discard an instant or sorcery card.",
             "colours": [
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "e6d5f05d-3e03-5867-a9b5-cec843880e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca3aa59-c8ac-4930-abf7-0a74d657122a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca3aa59-c8ac-4930-abf7-0a74d657122a.jpg?1",
             "name": "Prismari Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Prismari Apprentice can't be blocked this turn. If that spell has mana value 5 or greater, put a +1/+1 counter on Prismari Apprentice.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "ba51cc14-e18b-5b04-b2e1-66c7f6620938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866b7fd4-86e3-4b42-b1ea-33bad0db1f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866b7fd4-86e3-4b42-b1ea-33bad0db1f9f.jpg?1",
             "name": "Prismari Command",
             "text": "Choose two \u2014\n\u2022 Prismari Command deals 2 damage to any target.\n\u2022 Target player draws two cards, then discards two cards.\n\u2022 Target player creates a Treasure token.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -8401,7 +8401,7 @@
         },
         {
             "id": "b403ff54-aeb1-5022-92bb-6c0babd017ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404b4c7b-5d40-4ad1-bd40-3da1d08f5c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404b4c7b-5d40-4ad1-bd40-3da1d08f5c78.jpg?1",
             "name": "Prismari Pledgemage",
             "text": "Defender\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Prismari Pledgemage can attack this turn as though it didn't have defender.",
             "colours": [
@@ -8438,7 +8438,7 @@
         },
         {
             "id": "a1eda01b-93cf-54b5-b34d-88e61c23f2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291c909-bb87-47cb-9b06-5e409e654f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291c909-bb87-47cb-9b06-5e409e654f15.jpg?1",
             "name": "Quandrix Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, look at the top three cards of your library. You may reveal a land card from among them and put that card into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "4015addf-a9d0-5cc3-9c9c-bc05468ec069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b62d8-d160-47f5-bc51-0474f160d13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b62d8-d160-47f5-bc51-0474f160d13f.jpg?1",
             "name": "Quandrix Command",
             "text": "Choose two \u2014\n\u2022 Return target creature or planeswalker to its owner's hand.\n\u2022 Counter target artifact or enchantment spell.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player shuffles up to three target cards from their graveyard into their library.",
             "colours": [
@@ -8511,7 +8511,7 @@
         },
         {
             "id": "2fe95b78-17f9-5125-b029-74f7dd2f8c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca9ff7-0dcf-4ecc-879c-957d290ad7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca9ff7-0dcf-4ecc-879c-957d290ad7f5.jpg?1",
             "name": "Quandrix Cultivator",
             "text": "When Quandrix Cultivator enters the battlefield, you may search your library for a basic Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "2a10ba58-28a0-5c8c-9e76-b0ae516ce1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07633b7f-4150-458b-89c3-d05dc0e3c4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07633b7f-4150-458b-89c3-d05dc0e3c4bd.jpg?1",
             "name": "Quandrix Pledgemage",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Quandrix Pledgemage.",
             "colours": [
@@ -8585,7 +8585,7 @@
         },
         {
             "id": "8db139fd-7ccb-52fd-b358-af887b837a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c55ef1-8e62-4d43-bd4c-b2c3c5203338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c55ef1-8e62-4d43-bd4c-b2c3c5203338.jpg?1",
             "name": "Quintorius, Field Historian",
             "text": "Spirits you control get +1/+0.\nWhenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -8624,7 +8624,7 @@
         },
         {
             "id": "9e22a8a8-17e1-560c-8a50-729eb6b1956c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8152ab0-c6fc-4568-b837-4e84129e7b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8152ab0-c6fc-4568-b837-4e84129e7b57.jpg?1",
             "name": "Radiant Scrollwielder",
             "text": "Instant and sorcery spells you control have lifelink.\nAt the beginning of your upkeep, exile an instant or sorcery card at random from your graveyard. You may cast it this turn. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -8663,7 +8663,7 @@
         },
         {
             "id": "10d3c681-1cdf-59ee-a712-eb0aaea538b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e565e38-43d5-482e-a911-ce525dfee74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e565e38-43d5-482e-a911-ce525dfee74f.jpg?1",
             "name": "Reconstruct History",
             "text": "Return up to one target artifact card, up to one target enchantment card, up to one target instant card, up to one target sorcery card, and up to one target planeswalker card from your graveyard to your hand.\nExile Reconstruct History.",
             "colours": [
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "fb4cb89d-ac23-58b5-a4ca-4456514c34fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cb483f-c567-4cfd-9fe8-1503e7b40542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cb483f-c567-4cfd-9fe8-1503e7b40542.jpg?1",
             "name": "Relic Sloth",
             "text": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -8733,7 +8733,7 @@
         },
         {
             "id": "afb26e65-3d60-5e89-8a52-f05a5ede2d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa0e762-0fec-4f6b-b3d7-ad8295bf557d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa0e762-0fec-4f6b-b3d7-ad8295bf557d.jpg?1",
             "name": "Returned Pastcaller",
             "text": "Flying\nWhen Returned Pastcaller enters the battlefield, return target Spirit, instant, or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "562ca1ed-0009-595c-a621-ec2d526fb6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b5b510-fd5c-415d-98b0-386e7508f7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b5b510-fd5c-415d-98b0-386e7508f7af.jpg?1",
             "name": "Rip Apart",
             "text": "Choose one \u2014\n\u2022 Rip Apart deals 3 damage to target creature or planeswalker.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "0c43d62c-817b-5dba-932c-ac5cde05c2e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf97a71-485e-4d47-98de-bdf6f6dae0c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf97a71-485e-4d47-98de-bdf6f6dae0c2.jpg?1",
             "name": "Rise of Extus",
             "text": "Exile target creature. Exile up to one target instant or sorcery card from a graveyard.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "22e24241-47ee-5d01-86b0-2b35cee253c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb8f24d-8d1d-48aa-a534-238e969a474c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb8f24d-8d1d-48aa-a534-238e969a474c.jpg?1",
             "name": "Rootha, Mercurial Artist",
             "text": "{2}, Return Rootha, Mercurial Artist to its owner's hand: Copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "f24d7333-3d46-5b9a-84d9-21ffa256426c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b7c952-5ab7-4546-8369-4d213bf868bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b7c952-5ab7-4546-8369-4d213bf868bf.jpg?1",
             "name": "Rushed Rebirth",
             "text": "Choose target creature. When that creature dies this turn, search your library for a creature card with lesser mana value, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -8915,7 +8915,7 @@
         },
         {
             "id": "46650ffe-77d4-5357-969e-df7bff636822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64795a8b-8cf2-436e-8f95-9e8bb40c0d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64795a8b-8cf2-436e-8f95-9e8bb40c0d7d.jpg?1",
             "name": "Shadewing Laureate",
             "text": "Flying\nWhenever another creature you control with flying dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8952,7 +8952,7 @@
         },
         {
             "id": "eed253c8-84f1-5a3e-ab23-056cf3fc7aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab701909-83d6-4d39-9a84-e6a9b2cb38d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab701909-83d6-4d39-9a84-e6a9b2cb38d6.jpg?1",
             "name": "Shadrix Silverquill",
             "text": "Flying, double strike\nAt the beginning of combat on your turn, you may choose two. Each mode must target a different player.\n\u2022 Target player creates a 2/1 white and black Inkling creature token with flying.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target player puts a +1/+1 counter on each creature they control.",
             "colours": [
@@ -8993,7 +8993,7 @@
         },
         {
             "id": "e5b182c7-8cd0-5456-8ac1-bcbd341a3d69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d0770e-9084-4aa7-b543-2b6ba18378dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d0770e-9084-4aa7-b543-2b6ba18378dc.jpg?1",
             "name": "Silverquill Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -9030,7 +9030,7 @@
         },
         {
             "id": "e7c4d4d5-da34-5338-8d72-9fddfd489b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c55f533-9d31-4ad1-b336-927aba6e74d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c55f533-9d31-4ad1-b336-927aba6e74d6.jpg?1",
             "name": "Silverquill Command",
             "text": "Choose two \u2014\n\u2022 Target creature gets +3/+3 and gains flying until end of turn.\n\u2022 Return target creature card with mana value 2 or less from your graveyard to the battlefield.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target opponent sacrifices a creature.",
             "colours": [
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "5cdd9127-e160-5438-8090-3cb6f5c93470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f64ad2-4041-421d-baa2-206cedcecf0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f64ad2-4041-421d-baa2-206cedcecf0e.jpg?1",
             "name": "Silverquill Pledgemage",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Silverquill Pledgemage gains your choice of flying or lifelink until end of turn.",
             "colours": [
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "93258f82-b432-55de-9ca1-1cbb55c04391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb60dcc-cb4a-414d-850f-c98efd872894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb60dcc-cb4a-414d-850f-c98efd872894.jpg?1",
             "name": "Silverquill Silencer",
             "text": "As Silverquill Silencer enters the battlefield, choose a nonland card name.\nWhenever an opponent casts a spell with the chosen name, they lose 3 life and you draw a card.",
             "colours": [
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "90ed34a9-0672-5235-b231-4c9695c86a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74223e1-b66b-42fa-aaac-001f5dab2aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74223e1-b66b-42fa-aaac-001f5dab2aac.jpg?1",
             "name": "Spectacle Mage",
             "text": "Flying\nInstant and sorcery spells you cast with mana value 5 or greater cost {1} less to cast.",
             "colours": [
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "4b57cc09-bd57-5507-80fc-603941958f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74be6236-4095-419c-9927-fbd874df21f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74be6236-4095-419c-9927-fbd874df21f8.jpg?1",
             "name": "Spirit Summoning",
             "text": "Create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -9215,7 +9215,7 @@
         },
         {
             "id": "b47f36e7-ca1f-5dbf-93ad-80abc4a60ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88355e-c986-4b69-93b4-0abf04916e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88355e-c986-4b69-93b4-0abf04916e86.jpg?1",
             "name": "Spiteful Squad",
             "text": "Deathtouch\nSpiteful Squad enters the battlefield with two +1/+1 counters on it.\nWhen Spiteful Squad dies, put its counters on target creature you control.",
             "colours": [
@@ -9252,7 +9252,7 @@
         },
         {
             "id": "2232ea00-9d5c-5842-8003-001d2ff6d60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d548d5a-1dd7-448a-8483-249572e08c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d548d5a-1dd7-448a-8483-249572e08c47.jpg?1",
             "name": "Square Up",
             "text": "Target creature has base power and toughness 4/4 until end of turn.",
             "colours": [
@@ -9286,7 +9286,7 @@
         },
         {
             "id": "30970086-dd03-5fab-88a0-f365420b1d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c64e954-adfc-40a2-a3b2-85f1b4626976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c64e954-adfc-40a2-a3b2-85f1b4626976.jpg?1",
             "name": "Stonebound Mentor",
             "text": "Whenever one or more cards leave your graveyard, scry 1.",
             "colours": [
@@ -9323,7 +9323,7 @@
         },
         {
             "id": "e37993ef-6e3a-5523-8c8b-fccf7a2b87dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd62ee4-e654-44ba-a650-889782cc9ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd62ee4-e654-44ba-a650-889782cc9ac3.jpg?1",
             "name": "Tanazir Quandrix",
             "text": "Flying, trample\nWhen Tanazir Quandrix enters the battlefield, double the number of +1/+1 counters on target creature you control.\nWhenever Tanazir Quandrix attacks, you may have the base power and toughness of other creatures you control become equal to Tanazir Quandrix's power and toughness until end of turn.",
             "colours": [
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "d4518fe9-c627-52d1-91b4-16b8f6b2f471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957117fe-ddc9-4c5d-bff8-f74602a24dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957117fe-ddc9-4c5d-bff8-f74602a24dd8.jpg?1",
             "name": "A-Tanazir Quandrix",
             "text": "",
             "colours": [
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "c9e371a9-2b44-5ec7-85ae-39af14390e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7fbb9b-50a8-4d18-a667-fe965468ca16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7fbb9b-50a8-4d18-a667-fe965468ca16.jpg?1",
             "name": "Teach by Example",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "2a6a7af1-1755-578b-9fb8-033a0d4fecc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43ed93-008d-44db-8204-ef2cc3b7cf8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43ed93-008d-44db-8204-ef2cc3b7cf8a.jpg?1",
             "name": "Tend the Pests",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nCreate X 1/1 black and green Pest creature tokens with \"When this creature dies, you gain 1 life,\" where X is the sacrificed creature's power.",
             "colours": [
@@ -9470,7 +9470,7 @@
         },
         {
             "id": "5160373b-6973-5468-b3c1-82602fe01315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac1f45e-1884-490e-a94f-f7d312f0e229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac1f45e-1884-490e-a94f-f7d312f0e229.jpg?1",
             "name": "Thrilling Discovery",
             "text": "You gain 2 life. Then you may discard two cards. If you do, draw three cards.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "6cfd9a1f-0190-55c9-a2ad-b623b1905910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12573fe-aee3-49db-93e2-d00972cbb3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12573fe-aee3-49db-93e2-d00972cbb3b1.jpg?1",
             "name": "Vanishing Verse",
             "text": "Exile target monocolored permanent.",
             "colours": [
@@ -9540,7 +9540,7 @@
         },
         {
             "id": "d5318727-2060-5162-a2b2-4082beedf3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ea9067-ad50-4c43-ae4d-3f66890cd898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ea9067-ad50-4c43-ae4d-3f66890cd898.jpg?1",
             "name": "Velomachus Lorehold",
             "text": "Flying, vigilance, haste\nWhenever Velomachus Lorehold attacks, look at the top seven cards of your library. You may cast an instant or sorcery spell with mana value less than or equal to Velomachus Lorehold's power from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9581,7 +9581,7 @@
         },
         {
             "id": "7c76683e-96df-5779-bb2f-68e721ee40d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006313f8-cc60-4a4e-8ec6-953cdf1c16e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006313f8-cc60-4a4e-8ec6-953cdf1c16e3.jpg?1",
             "name": "Venerable Warsinger",
             "text": "Vigilance, trample\nWhenever Venerable Warsinger deals combat damage to a player, you may return target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of damage Venerable Warsinger dealt to that player.",
             "colours": [
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "9bf23faa-5f42-56c3-ac10-527498819612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f80a11b-188b-464c-b00d-c9d1cfb8ddee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f80a11b-188b-464c-b00d-c9d1cfb8ddee.jpg?1",
             "name": "Witherbloom Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "a8cb13d9-d835-5b86-b39a-aa10eae25763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5e94b-0b35-4efd-9158-1767dcaea38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5e94b-0b35-4efd-9158-1767dcaea38c.jpg?1",
             "name": "Witherbloom Command",
             "text": "Choose two \u2014\n\u2022 Target player mills three cards, then you return a land card from your graveyard to your hand.\n\u2022 Destroy target noncreature, nonland permanent with mana value 2 or less.\n\u2022 Target creature gets -3/-1 until end of turn.\n\u2022 Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -9693,7 +9693,7 @@
         },
         {
             "id": "28c374c9-d41c-53ec-aa19-d5bb6339b63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc6914-2dcb-411d-90a5-01853ff2d5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc6914-2dcb-411d-90a5-01853ff2d5b8.jpg?1",
             "name": "Witherbloom Pledgemage",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, you gain 1 life.",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "f4c002ad-63fd-55e2-b256-59c3e3a61156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca14c17-dc72-4f68-92f2-14a6c4019f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca14c17-dc72-4f68-92f2-14a6c4019f4e.jpg?1",
             "name": "Zimone, Quandrix Prodigy",
             "text": "{1}, {T}: You may put a land card from your hand onto the battlefield tapped.\n{4}, {T}: Draw a card. If you control eight or more lands, draw two cards instead.",
             "colours": [
@@ -9769,7 +9769,7 @@
         },
         {
             "id": "ceb12d3c-5458-5eb5-a727-874e5e43e134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e1117-0196-4268-be97-a1e81b5dc90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e1117-0196-4268-be97-a1e81b5dc90e.jpg?1",
             "name": "Biblioplex Assistant",
             "text": "Flying\nWhen Biblioplex Assistant enters the battlefield, put up to one target instant or sorcery card from your graveyard on top of your library.",
             "colours": [],
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "406de8a0-5582-5013-9b1c-f93a43b7b6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a9a8a2-de81-441b-b501-418311b677f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a9a8a2-de81-441b-b501-418311b677f7.jpg?1",
             "name": "Campus Guide",
             "text": "When Campus Guide enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -9831,7 +9831,7 @@
         },
         {
             "id": "aaf3d518-71c7-55c2-ad6e-4d3dea880de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea476ee1-67d9-4dd8-a5ac-f68a155eb18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea476ee1-67d9-4dd8-a5ac-f68a155eb18b.jpg?1",
             "name": "Codie, Vociferous Codex",
             "text": "You can't cast permanent spells.\n{4}, {T}: Add {W}{U}{B}{R}{G}. When you cast your next spell this turn, exile cards from the top of your library until you exile an instant or sorcery card with lesser mana value. Until end of turn, you may cast that card without paying its mana cost. Put each other card exiled this way on the bottom of your library in a random order.",
             "colours": [],
@@ -9872,7 +9872,7 @@
         },
         {
             "id": "a07d9c53-3614-5e64-aa56-4220fd87568e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c024a2d-20fb-478b-a62e-e3590a1e3ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c024a2d-20fb-478b-a62e-e3590a1e3ac1.jpg?1",
             "name": "Cogwork Archivist",
             "text": "Reach\n{2}, {T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9903,7 +9903,7 @@
         },
         {
             "id": "10214f80-a6ea-502b-9ff6-0879e7272833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed54d00-b11f-4529-864c-63a114617b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed54d00-b11f-4529-864c-63a114617b36.jpg?1",
             "name": "Excavated Wall",
             "text": "Defender\n{1}, {T}: Mill a card. (Put the top card of your library into your graveyard.)",
             "colours": [],
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "8f6c76c7-ef40-5b4c-ab3f-de2b1a762be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750231-34aa-401c-b192-47b56588923a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750231-34aa-401c-b192-47b56588923a.jpg?1",
             "name": "Letter of Acceptance",
             "text": "{T}: Add one mana of any color.\n{2}, {T}, Sacrifice Letter of Acceptance: Draw a card.",
             "colours": [],
@@ -9962,7 +9962,7 @@
         },
         {
             "id": "6e57ad82-b39a-5912-9073-39660c19a007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01770c4-8848-495d-8af4-26152d45e9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01770c4-8848-495d-8af4-26152d45e9d3.jpg?1",
             "name": "Reflective Golem",
             "text": "Whenever you cast an instant or sorcery spell that targets only Reflective Golem, you may pay {2}. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [],
@@ -9993,7 +9993,7 @@
         },
         {
             "id": "b2592e54-02e1-512b-9451-adee04f9166d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de826a0-6e68-4d40-a51c-8d6e7a4148d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de826a0-6e68-4d40-a51c-8d6e7a4148d1.jpg?1",
             "name": "Spell Satchel",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a book counter on Spell Satchel.\n{T}, Remove a book counter from Spell Satchel: Add {C}.\n{3}, {T}, Remove three book counters from Spell Satchel: Draw a card.",
             "colours": [],
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "63555550-6908-59df-8947-712b9abbf491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8acc65-c7e0-4ba5-b956-af0679ffb830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8acc65-c7e0-4ba5-b956-af0679ffb830.jpg?1",
             "name": "A-Spell Satchel",
             "text": "",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "2aa28782-1aa7-52f5-bb4d-2d652d59d59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421674ee-4b85-4942-b166-952598165826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421674ee-4b85-4942-b166-952598165826.jpg?1",
             "name": "Strixhaven Stadium",
             "text": "{T}: Add {C}. Put a point counter on Strixhaven Stadium.\nWhenever a creature deals combat damage to you, remove a point counter from Strixhaven Stadium.\nWhenever a creature you control deals combat damage to an opponent, put a point counter on Strixhaven Stadium. Then if it has ten or more point counters on it, remove them all and that player loses the game.",
             "colours": [],
@@ -10078,7 +10078,7 @@
         },
         {
             "id": "191befce-57e3-5d01-b1b3-b5fbba9a4586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be294c4e-712b-459c-a36c-e26ed5c27edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be294c4e-712b-459c-a36c-e26ed5c27edb.jpg?1",
             "name": "Team Pennant",
             "text": "Equipped creature gets +1/+1 and has vigilance and trample.\nEquip creature token {1}\nEquip {3}",
             "colours": [],
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "665afe18-cb19-5c67-bd20-5997935152a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0566fd-3775-48f1-ba22-6e659558c3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0566fd-3775-48f1-ba22-6e659558c3d3.jpg?1",
             "name": "Zephyr Boots",
             "text": "Equipped creature has flying.\nWhenever equipped creature deals combat damage to a player, draw a card, then discard a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "72922bde-a549-58ab-a50e-ee62898e1b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8eb51-9643-4c54-b38e-e7abea92bbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8eb51-9643-4c54-b38e-e7abea92bbe1.jpg?1",
             "name": "Access Tunnel",
             "text": "{T}: Add {C}.\n{3}, {T}: Target creature with power 3 or less can't be blocked this turn.",
             "colours": [],
@@ -10166,7 +10166,7 @@
         },
         {
             "id": "fa8c87cb-e97f-529c-9015-1d191afef5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6a2ff-7eb7-4680-af2b-e69ac88a65c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6a2ff-7eb7-4680-af2b-e69ac88a65c9.jpg?1",
             "name": "Archway Commons",
             "text": "Archway Commons enters the battlefield tapped.\nWhen Archway Commons enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -10194,7 +10194,7 @@
         },
         {
             "id": "5c5ae5d5-4cc4-5ae8-8c6a-41fa29b6e845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae4481-977f-4bb7-bb1a-ab7100e6ba47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae4481-977f-4bb7-bb1a-ab7100e6ba47.jpg?1",
             "name": "The Biblioplex",
             "text": "{T}: Add {C}.\n{2}, {T}: Look at the top card of your library. If it's an instant or sorcery card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard. Activate only if you have exactly zero or seven cards in hand.",
             "colours": [],
@@ -10224,7 +10224,7 @@
         },
         {
             "id": "b862e0ce-b028-5741-a7a1-da37ce8e9a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ba565-da08-4957-93bb-8d266fe0b0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ba565-da08-4957-93bb-8d266fe0b0d8.jpg?1",
             "name": "Frostboil Snarl",
             "text": "As Frostboil Snarl enters the battlefield, you may reveal an Island or Mountain card from your hand. If you don't, Frostboil Snarl enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10257,7 +10257,7 @@
         },
         {
             "id": "b65d10a1-edcc-54f6-8887-0b7bb6b4c691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e33f37-7fd1-4431-a032-cd61b644401c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e33f37-7fd1-4431-a032-cd61b644401c.jpg?1",
             "name": "Furycalm Snarl",
             "text": "As Furycalm Snarl enters the battlefield, you may reveal a Mountain or Plains card from your hand. If you don't, Furycalm Snarl enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "17733030-2217-5594-9589-79ab4345854a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642dddd-4461-46dd-b396-9e0a89f7232e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642dddd-4461-46dd-b396-9e0a89f7232e.jpg?1",
             "name": "Hall of Oracles",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on target creature. Activate only as a sorcery and only if you've cast an instant or sorcery spell this turn.",
             "colours": [],
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "59a41526-a7dc-5683-a5d0-4e880b1f285b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35461cf-becf-4399-8329-64b4496b7fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35461cf-becf-4399-8329-64b4496b7fc2.jpg?1",
             "name": "Lorehold Campus",
             "text": "Lorehold Campus enters the battlefield tapped.\n{T}: Add {R} or {W}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "940655c3-b42b-5847-85ff-7622cef2cecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aed316-c28a-4c1a-a0a3-ab75ceba3ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aed316-c28a-4c1a-a0a3-ab75ceba3ee7.jpg?1",
             "name": "Necroblossom Snarl",
             "text": "As Necroblossom Snarl enters the battlefield, you may reveal a Swamp or Forest card from your hand. If you don't, Necroblossom Snarl enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10384,7 +10384,7 @@
         },
         {
             "id": "48b0f651-c4a7-5bce-b261-07a1234c2fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768120f5-9401-4e52-924e-3374bde65b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768120f5-9401-4e52-924e-3374bde65b3d.jpg?1",
             "name": "Prismari Campus",
             "text": "Prismari Campus enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10415,7 +10415,7 @@
         },
         {
             "id": "26f41d3b-6c73-5c6a-97cd-41821e3e7b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f788da28-481b-41fa-a70c-b53db6b0f068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f788da28-481b-41fa-a70c-b53db6b0f068.jpg?1",
             "name": "Quandrix Campus",
             "text": "Quandrix Campus enters the battlefield tapped.\n{T}: Add {G} or {U}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "f6aefd9d-9445-5003-8b73-662325e93ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a46ebf-6938-4100-8f5f-0605ad2be4fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a46ebf-6938-4100-8f5f-0605ad2be4fc.jpg?1",
             "name": "Shineshadow Snarl",
             "text": "As Shineshadow Snarl enters the battlefield, you may reveal a Plains or Swamp card from your hand. If you don't, Shineshadow Snarl enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10479,7 +10479,7 @@
         },
         {
             "id": "47fea69b-31c8-50d1-885e-147b8212b3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42583850-ba5c-4a71-8717-406b5c6d048f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42583850-ba5c-4a71-8717-406b5c6d048f.jpg?1",
             "name": "Silverquill Campus",
             "text": "Silverquill Campus enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10510,7 +10510,7 @@
         },
         {
             "id": "2f89640e-710f-5a81-ba17-57565e67163b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e5ca7-dde1-435f-9b40-87558dd88749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e5ca7-dde1-435f-9b40-87558dd88749.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "As Vineglimmer Snarl enters the battlefield, you may reveal a Forest or Island card from your hand. If you don't, Vineglimmer Snarl enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10543,7 +10543,7 @@
         },
         {
             "id": "228f69aa-5e38-5afd-a45c-46963b7996d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7346fb2e-754e-47de-b33d-eb089b357ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7346fb2e-754e-47de-b33d-eb089b357ee4.jpg?1",
             "name": "Witherbloom Campus",
             "text": "Witherbloom Campus enters the battlefield tapped.\n{T}: Add {B} or {G}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10574,7 +10574,7 @@
         },
         {
             "id": "1650c445-7420-5c07-9962-da32a94d0b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8536-15f6-42c1-8521-dc37feee8e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8536-15f6-42c1-8521-dc37feee8e67.jpg?1",
             "name": "Professor Onyx",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, each opponent loses 2 life and you gain 2 life.\n+1: You lose 1 life. Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n\u22123: Each opponent sacrifices a creature with the greatest power among creatures that player controls.\n\u22128: Each opponent may discard a card. If they don't, they lose 3 life. Repeat this process six more times.",
             "colours": [
@@ -10612,7 +10612,7 @@
         },
         {
             "id": "90aea4cc-2057-5518-a41e-5d6d53d11e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "0f9214dc-2fc9-5bee-95e2-51ebd262625e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -10690,7 +10690,7 @@
         },
         {
             "id": "b842741f-5393-5c0c-89c5-67bbc3bf5f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "9a44af27-5825-52f3-9b63-4412dc593176",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -10768,7 +10768,7 @@
         },
         {
             "id": "fdc4c759-e3e7-50b8-b316-359a9e552145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed5f87d-3bca-44fc-a1ea-fc01e36ba092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed5f87d-3bca-44fc-a1ea-fc01e36ba092.jpg?1",
             "name": "Kasmina, Enigma Sage",
             "text": "Each other planeswalker you control has the loyalty abilities of Kasmina, Enigma Sage.\n+2: Scry 1.\n\u2212X: Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.\n\u22128: Search your library for an instant or sorcery card that shares a color with this planeswalker, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -10808,7 +10808,7 @@
         },
         {
             "id": "39b0ac9f-b31e-56f4-a5eb-faa3df0ccd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23468e63-2e7a-4e3b-970c-cb57b067d6c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23468e63-2e7a-4e3b-970c-cb57b067d6c1.jpg?1",
             "name": "Shadrix Silverquill",
             "text": "Flying, double strike\nAt the beginning of combat on your turn, you may choose two. Each mode must target a different player.\n\u2022 Target player creates a 2/1 white and black Inkling creature token with flying.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target player puts a +1/+1 counter on each creature they control.",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "75c7edda-b257-5560-a031-f670db91128d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b9185-9033-4e57-a312-adcc91903aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b9185-9033-4e57-a312-adcc91903aec.jpg?1",
             "name": "Galazeth Prismari",
             "text": "Flying\nWhen Galazeth Prismari enters the battlefield, create a Treasure token.\nArtifacts you control have \"{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.\"",
             "colours": [
@@ -10890,7 +10890,7 @@
         },
         {
             "id": "124d1e8e-030d-52be-87a8-a2298ebc1962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34dd2ef-a52d-48b6-becc-825f0e78eb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34dd2ef-a52d-48b6-becc-825f0e78eb75.jpg?1",
             "name": "Beledros Witherbloom",
             "text": "Flying\nAt the beginning of each upkeep, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\nPay 10 life: Untap all lands you control. Activate only once each turn.",
             "colours": [
@@ -10931,7 +10931,7 @@
         },
         {
             "id": "49097800-a412-5832-9b17-01e6f1092d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7151c4b-4d42-44c1-a6f4-8be29ace1df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7151c4b-4d42-44c1-a6f4-8be29ace1df3.jpg?1",
             "name": "Velomachus Lorehold",
             "text": "Flying, vigilance, haste\nWhenever Velomachus Lorehold attacks, look at the top seven cards of your library. You may cast an instant or sorcery spell with mana value less than or equal to Velomachus Lorehold's power from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "1d0ea9c0-0ccb-5da3-8b31-8ad1fc869aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7241c-c053-440b-b91c-f7298080d626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7241c-c053-440b-b91c-f7298080d626.jpg?1",
             "name": "Tanazir Quandrix",
             "text": "Flying, trample\nWhen Tanazir Quandrix enters the battlefield, double the number of +1/+1 counters on target creature you control.\nWhenever Tanazir Quandrix attacks, you may have the base power and toughness of other creatures you control become equal to Tanazir Quandrix's power and toughness until end of turn.",
             "colours": [
@@ -11013,7 +11013,7 @@
         },
         {
             "id": "d515f64c-fc10-5d34-9321-9a181af15bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b3d46-8f46-4ddf-b4bb-53b0dfd1ab37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b3d46-8f46-4ddf-b4bb-53b0dfd1ab37.jpg?1",
             "name": "Mascot Exhibition",
             "text": "Create a 2/1 white and black Inkling creature token with flying, a 3/2 red and white Spirit creature token, and a 4/4 blue and red Elemental creature token.",
             "colours": [],
@@ -11045,7 +11045,7 @@
         },
         {
             "id": "74d3aa3c-ada9-5520-a19d-87b9362fdaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -11077,7 +11077,7 @@
         },
         {
             "id": "753e0e24-2204-562f-b077-6b1cd1d5e540",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -11107,7 +11107,7 @@
         },
         {
             "id": "e324627a-57bf-568a-ab47-732efdefdff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4384-95b5-44ae-bec5-15b383777b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4384-95b5-44ae-bec5-15b383777b41.jpg?1",
             "name": "Academic Probation",
             "text": "Choose one \u2014\n\u2022 Choose a nonland card name. Opponents can't cast spells with the chosen name until your next turn.\n\u2022 Choose target nonland permanent. Until your next turn, it can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -11143,7 +11143,7 @@
         },
         {
             "id": "f2efd469-a321-586e-9d84-d0280125688b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a4740-7a11-4157-bfd7-1249980aa323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a4740-7a11-4157-bfd7-1249980aa323.jpg?1",
             "name": "Devastating Mastery",
             "text": "You may pay {2}{W}{W} rather than pay this spell's mana cost.\nIf the {2}{W}{W} cost was paid, an opponent chooses up to two nonland permanents they control and returns them to their owner's hand.\nDestroy all nonland permanents.",
             "colours": [
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "6305ac01-9de1-52fd-973d-a5c1f15ed710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25608957-fe71-4ed7-9c55-fb7f2fcf103e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25608957-fe71-4ed7-9c55-fb7f2fcf103e.jpg?1",
             "name": "Elite Spellbinder",
             "text": "Flying\nWhen Elite Spellbinder enters the battlefield, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A spell cast this way costs {2} more to cast.",
             "colours": [
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "7ee0c5ac-7b78-579d-82a5-e929b206fdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca307662-9454-4edb-ab64-13c6b41fb864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca307662-9454-4edb-ab64-13c6b41fb864.jpg?1",
             "name": "Leonin Lightscribe",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -11251,7 +11251,7 @@
         },
         {
             "id": "142e1c40-c16f-56d5-a1cf-acdf9f4b918a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32e0bb1-073f-4583-ad9c-1dc0c7eb8ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32e0bb1-073f-4583-ad9c-1dc0c7eb8ef8.jpg?1",
             "name": "Mavinda, Students' Advocate",
             "text": "Flying\n{0}: You may cast target instant or sorcery card from your graveyard this turn. If that spell doesn't target a creature you control, it costs {8} more to cast this way. If that spell would be put into your graveyard, exile it instead. Activate only once each turn. (You still pay the spell's costs. Timing rules for the spell still apply.)",
             "colours": [
@@ -11290,7 +11290,7 @@
         },
         {
             "id": "7520eb43-4ccf-5df6-9b44-0fe008bf9d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121f61c8-2ddc-47bb-a8a1-b7e0b5cac156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121f61c8-2ddc-47bb-a8a1-b7e0b5cac156.jpg?1",
             "name": "Semester's End",
             "text": "Exile any number of target creatures and/or planeswalkers you control. At the beginning of the next end step, return each of them to the battlefield under its owner's control. Each of them enters the battlefield with an additional +1/+1 counter on it if it's a creature and an additional loyalty counter on it if it's a planeswalker.",
             "colours": [
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "da988a52-f75c-5350-84e4-35f5603daf3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584a3d18-0360-48aa-87d2-51e9078b00f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584a3d18-0360-48aa-87d2-51e9078b00f5.jpg?1",
             "name": "Sparring Regimen",
             "text": "When Sparring Regimen enters the battlefield, learn.\nWhenever you attack, put a +1/+1 counter on target attacking creature and untap it.",
             "colours": [
@@ -11358,7 +11358,7 @@
         },
         {
             "id": "a2ffd39d-a43e-5553-9e3d-7473e4d3ec3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833ffc46-bbfe-47b3-96ad-ff5fe14405cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833ffc46-bbfe-47b3-96ad-ff5fe14405cb.jpg?1",
             "name": "Strict Proctor",
             "text": "Flying\nWhenever a permanent entering the battlefield causes a triggered ability to trigger, counter that ability unless its controller pays {2}.",
             "colours": [
@@ -11396,7 +11396,7 @@
         },
         {
             "id": "e79bb025-5878-5982-80cf-f5cb6ed23f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5e6937-800c-4870-b234-f2907a55ce31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5e6937-800c-4870-b234-f2907a55ce31.jpg?1",
             "name": "Archmage Emeritus",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, draw a card.",
             "colours": [
@@ -11434,7 +11434,7 @@
         },
         {
             "id": "01fa4980-ddc3-51f6-a234-3d83395878bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9f0734-7bdf-4d06-b1ac-15919fb7bce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9f0734-7bdf-4d06-b1ac-15919fb7bce3.jpg?1",
             "name": "Dream Strix",
             "text": "Flying\nWhen Dream Strix becomes the target of a spell, sacrifice it.\nWhen Dream Strix dies, learn.",
             "colours": [
@@ -11471,7 +11471,7 @@
         },
         {
             "id": "a15eb013-9e13-5624-ac9c-cc6a817cf065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b4f3c5-4129-4e4b-98b9-91d2ca33ab7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b4f3c5-4129-4e4b-98b9-91d2ca33ab7c.jpg?1",
             "name": "Ingenious Mastery",
             "text": "You may pay {2}{U} rather than pay this spell's mana cost.\nIf the {2}{U} cost was paid, you draw three cards, then an opponent creates two Treasure tokens and they scry 2. If that cost wasn't paid, you draw X cards.",
             "colours": [
@@ -11505,7 +11505,7 @@
         },
         {
             "id": "fa963d86-db0e-5a3d-a905-dfaaada605d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc26b17-fff6-4bd1-8fb6-736ba7babac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc26b17-fff6-4bd1-8fb6-736ba7babac7.jpg?1",
             "name": "Multiple Choice",
             "text": "If X is 1, scry 1, then draw a card.\nIf X is 2, you may choose a player. They return a creature they control to its owner's hand.\nIf X is 3, create a 4/4 blue and red Elemental creature token.\nIf X is 4 or more, do all of the above.",
             "colours": [
@@ -11539,7 +11539,7 @@
         },
         {
             "id": "8586fff9-8474-569d-ae0d-c929c6d34666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2c8894-fb24-4356-a71e-2cb924dd4cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2c8894-fb24-4356-a71e-2cb924dd4cf0.jpg?1",
             "name": "Teachings of the Archaics",
             "text": "If an opponent has more cards in hand than you, draw two cards. Draw three cards instead if an opponent has at least four more cards in hand than you.",
             "colours": [
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "65de3c26-4c7a-59a4-bff8-52cb07a078d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c142a00b-ba0a-49a2-879f-ed46c4f81b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c142a00b-ba0a-49a2-879f-ed46c4f81b64.jpg?1",
             "name": "Tempted by the Oriq",
             "text": "For each opponent, gain control of up to one target creature or planeswalker that player controls with mana value 3 or less.",
             "colours": [
@@ -11609,7 +11609,7 @@
         },
         {
             "id": "22c617f3-811f-5e6a-a08e-33e73365c3b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefe86f-9998-4259-bf71-2b2ed1d6bf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefe86f-9998-4259-bf71-2b2ed1d6bf50.jpg?1",
             "name": "Baleful Mastery",
             "text": "You may pay {1}{B} rather than pay this spell's mana cost.\nIf the {1}{B} cost was paid, an opponent draws a card.\nExile target creature or planeswalker.",
             "colours": [
@@ -11643,7 +11643,7 @@
         },
         {
             "id": "591c29a1-c671-5a53-b754-88a9aaa6e726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9786ce79-3cb1-4ac7-9f85-1f7c0e1acff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9786ce79-3cb1-4ac7-9f85-1f7c0e1acff7.jpg?1",
             "name": "Callous Bloodmage",
             "text": "When Callous Bloodmage enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\u2022 You draw a card and you lose 1 life.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -11680,7 +11680,7 @@
         },
         {
             "id": "41bf4ae7-a9d4-5618-81ef-c1c1def4dfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9975e3c0-cd32-4658-9802-3749a1a475aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9975e3c0-cd32-4658-9802-3749a1a475aa.jpg?1",
             "name": "Confront the Past",
             "text": "Choose one \u2014\n\u2022 Return target planeswalker card with mana value X or less from your graveyard to the battlefield.\n\u2022 Remove twice X loyalty counters from target planeswalker an opponent controls.",
             "colours": [
@@ -11716,7 +11716,7 @@
         },
         {
             "id": "ad8020b8-b83b-5cc7-a8b2-380e8e33e813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd30d87e-552d-4b30-9123-2047e4e381a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd30d87e-552d-4b30-9123-2047e4e381a2.jpg?1",
             "name": "Oriq Loremage",
             "text": "{T}: Search your library for a card, put it into your graveyard, then shuffle. If it's an instant or sorcery card, put a +1/+1 counter on Oriq Loremage.",
             "colours": [
@@ -11753,7 +11753,7 @@
         },
         {
             "id": "d891b14c-e774-5f76-a856-411e0db80c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4802149c-b7f0-40d5-a312-df8cc920e7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4802149c-b7f0-40d5-a312-df8cc920e7d4.jpg?1",
             "name": "Poet's Quill",
             "text": "When Poet's Quill enters the battlefield, learn.\nEquipped creature gets +1/+1 and has lifelink.\nEquip {1}{B}",
             "colours": [
@@ -11789,7 +11789,7 @@
         },
         {
             "id": "7454c3aa-71d2-53b1-a294-b716b9025717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bfaa8-3d54-4934-aaf6-72be43a87324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bfaa8-3d54-4934-aaf6-72be43a87324.jpg?1",
             "name": "Sedgemoor Witch",
             "text": "Menace\nWard\u2014\nPay 3 life.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -11826,7 +11826,7 @@
         },
         {
             "id": "c6072381-f3ee-5f4e-ad0b-c60b73b276b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3509c-8d67-4c5e-83bf-1a67f87589b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3509c-8d67-4c5e-83bf-1a67f87589b9.jpg?1",
             "name": "Conspiracy Theorist",
             "text": "Whenever Conspiracy Theorist attacks, you may pay {1} and discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards, you may exile one of them from your graveyard. If you do, you may cast it this turn.",
             "colours": [
@@ -11863,7 +11863,7 @@
         },
         {
             "id": "22c784f1-cf53-5fdb-b82b-3b4fd3cb5de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c038e6-2346-4544-bea1-b64098f63f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c038e6-2346-4544-bea1-b64098f63f23.jpg?1",
             "name": "Crackle with Power",
             "text": "Crackle with Power deals five times X damage to each of up to X targets.",
             "colours": [
@@ -11897,7 +11897,7 @@
         },
         {
             "id": "09722748-23af-5f83-8c5d-95206bacfe16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ddfc9-1ecd-45e1-b9aa-3390a2e3776f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ddfc9-1ecd-45e1-b9aa-3390a2e3776f.jpg?1",
             "name": "Draconic Intervention",
             "text": "As an additional cost to cast this spell, exile an instant or sorcery card from your graveyard.\nDraconic Intervention deals X damage to each non-Dragon creature, where X is the exiled card's mana value. If a creature dealt damage this way would die this turn, exile it instead.\nExile Draconic Intervention.",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "9904863e-ac89-5e85-bf27-24093764710b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bdcfde9-1c0a-49fc-8996-37a24a2379e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bdcfde9-1c0a-49fc-8996-37a24a2379e3.jpg?1",
             "name": "Efreet Flamepainter",
             "text": "Double strike\nWhenever Efreet Flamepainter deals combat damage to a player, you may cast target instant or sorcery card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "1268b0d8-1e86-54b7-b8cd-f43e1a21ddaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf5c70-25e8-489a-9cab-ce45eab191ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf5c70-25e8-489a-9cab-ce45eab191ed.jpg?1",
             "name": "Fervent Mastery",
             "text": "You may pay {2}{R}{R} rather than pay this spell's mana cost.\nIf the {2}{R}{R} cost was paid, an opponent discards any number of cards, then draws that many cards.\nSearch your library for up to three cards, put them into your hand, shuffle, then discard three cards at random.",
             "colours": [
@@ -12002,7 +12002,7 @@
         },
         {
             "id": "1f02814a-5ab0-5374-acc8-d613ad4e4f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caa9c12-ac06-458e-bf03-21dd1b3ed986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caa9c12-ac06-458e-bf03-21dd1b3ed986.jpg?1",
             "name": "Illuminate History",
             "text": "Discard any number of cards, then draw that many cards. Then if there are seven or more cards in your graveyard, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -12038,7 +12038,7 @@
         },
         {
             "id": "d587edc6-a284-5487-a559-9cedb82a430f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81c6751-b97e-4935-a18f-fb97ee9e8a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81c6751-b97e-4935-a18f-fb97ee9e8a68.jpg?1",
             "name": "Retriever Phoenix",
             "text": "Flying, haste\nWhen Retriever Phoenix enters the battlefield, if you cast it, learn.\nAs long as Retriever Phoenix is in your graveyard, if you would learn, you may instead return Retriever Phoenix to the battlefield.",
             "colours": [
@@ -12074,7 +12074,7 @@
         },
         {
             "id": "ebce9c48-14b4-5f70-9aad-04a369b11a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee50e9b-7414-4a4e-8c12-5b8c4043f4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee50e9b-7414-4a4e-8c12-5b8c4043f4b1.jpg?1",
             "name": "Accomplished Alchemist",
             "text": "{T}: Add one mana of any color.\n{T}: Add X mana of any one color, where X is the amount of life you gained this turn.",
             "colours": [
@@ -12111,7 +12111,7 @@
         },
         {
             "id": "21049f9a-f473-5c9f-bf2b-33b19558e1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f222fdb-eddd-4179-b779-a45171bfb010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f222fdb-eddd-4179-b779-a45171bfb010.jpg?1",
             "name": "Basic Conjuration",
             "text": "Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life.",
             "colours": [
@@ -12147,7 +12147,7 @@
         },
         {
             "id": "2a165d2e-3ad7-5fc4-9abe-8be6fb5f8d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87d007f-9dee-4525-8298-04c317c52c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87d007f-9dee-4525-8298-04c317c52c96.jpg?1",
             "name": "Dragonsguard Elite",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Dragonsguard Elite.\n{4}{G}{G}: Double the number of +1/+1 counters on Dragonsguard Elite.",
             "colours": [
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "665cfb40-b945-55df-b363-f09dbe34b222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76ba861-beb0-4cd2-8e06-626f587f6f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76ba861-beb0-4cd2-8e06-626f587f6f44.jpg?1",
             "name": "Ecological Appreciation",
             "text": "Search your library and graveyard for up to four creature cards with different names that each have mana value X or less and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest onto the battlefield. Exile Ecological Appreciation.",
             "colours": [
@@ -12219,7 +12219,7 @@
         },
         {
             "id": "db583f4b-1ffd-54be-a3ee-386616302c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7771e5a4-cc4b-43fb-8a44-9382de73fa0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7771e5a4-cc4b-43fb-8a44-9382de73fa0f.jpg?1",
             "name": "Exponential Growth",
             "text": "Until end of turn, double target creature's power X times.",
             "colours": [
@@ -12253,7 +12253,7 @@
         },
         {
             "id": "5034145c-5de8-5e53-a7c0-68639523c1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831607fb-92ba-46d2-85a8-0aa7023e3e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831607fb-92ba-46d2-85a8-0aa7023e3e30.jpg?1",
             "name": "Gnarled Professor",
             "text": "Trample\nWhen Gnarled Professor enters the battlefield, learn.",
             "colours": [
@@ -12290,7 +12290,7 @@
         },
         {
             "id": "454f4f08-1388-55ab-bb56-d884cd56cd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99b2e32-5272-4f66-b05e-a9d32d9e9f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99b2e32-5272-4f66-b05e-a9d32d9e9f8d.jpg?1",
             "name": "Verdant Mastery",
             "text": "You may pay {3}{G} rather than pay this spell's mana cost.\nSearch your library for up to four basic land cards and reveal them. Put one of them onto the battlefield tapped under an opponent's control if the {3}{G} cost was paid. Put two of them onto the battlefield tapped under your control and the rest into your hand. Then shuffle.",
             "colours": [
@@ -12324,7 +12324,7 @@
         },
         {
             "id": "19b80ef3-e8ad-55bd-92c5-92b1ce261508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -12362,7 +12362,7 @@
         },
         {
             "id": "0bd08e74-ee4a-5bdb-a850-35d3ffe2b155",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -12397,7 +12397,7 @@
         },
         {
             "id": "70c713a0-f8a4-5980-9f69-4580764c3955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -12436,7 +12436,7 @@
         },
         {
             "id": "caa57405-19ac-5d47-923a-af2a132cc509",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -12471,7 +12471,7 @@
         },
         {
             "id": "47229f00-8426-5346-b41f-1d2c5b926197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -12513,7 +12513,7 @@
         },
         {
             "id": "b3ce0192-4259-50a2-8548-8be986fa454a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -12550,7 +12550,7 @@
         },
         {
             "id": "9246ffb1-5d96-5932-b857-df34dc5fe4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -12588,7 +12588,7 @@
         },
         {
             "id": "46f49a85-f659-550f-8588-a270a607bd07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -12623,7 +12623,7 @@
         },
         {
             "id": "1181384e-826b-5079-8d9a-064d2f955539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -12663,7 +12663,7 @@
         },
         {
             "id": "16d703d7-6310-58a6-b32b-a2c0ad852ced",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -12698,7 +12698,7 @@
         },
         {
             "id": "fdb0d757-1597-5a87-acb6-f7f997d3eb0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -12738,7 +12738,7 @@
         },
         {
             "id": "557b13f5-780e-530d-aa82-6135158089ae",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -12778,7 +12778,7 @@
         },
         {
             "id": "77b6c21f-9e23-5f34-9895-6080a598bd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -12813,7 +12813,7 @@
         },
         {
             "id": "239e98ea-8241-5860-88a1-43693287189b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -12848,7 +12848,7 @@
         },
         {
             "id": "682a19c7-f70b-5875-b29c-32f6df880995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -12888,7 +12888,7 @@
         },
         {
             "id": "cc6e71b3-4a8b-5add-b9dc-56531805bacd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -12928,7 +12928,7 @@
         },
         {
             "id": "156944be-f868-56f3-b895-1fa640c65ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -12966,7 +12966,7 @@
         },
         {
             "id": "18fa77d7-3a9a-5c55-9dbd-052624cd3179",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "39ee3f39-26ae-52cc-9553-d14c6ece8bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -13041,7 +13041,7 @@
         },
         {
             "id": "e3ae7f29-0054-503b-9ecd-8b2456cfec3c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -13081,7 +13081,7 @@
         },
         {
             "id": "ce9b41a9-71eb-58c8-bc04-3d0fce792601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -13119,7 +13119,7 @@
         },
         {
             "id": "fd68f24d-939d-5028-aacf-6d00a883e384",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -13154,7 +13154,7 @@
         },
         {
             "id": "74cc26a4-2b6f-51de-8193-e0474ee88254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -13194,7 +13194,7 @@
         },
         {
             "id": "3915cc79-3148-5f08-b688-cd1a9f7699b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -13234,7 +13234,7 @@
         },
         {
             "id": "870a8de3-0179-5d80-a776-5c495879268b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -13274,7 +13274,7 @@
         },
         {
             "id": "783762f0-4049-5417-9378-76f563475f87",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -13314,7 +13314,7 @@
         },
         {
             "id": "9dfbdaeb-182c-5eed-8977-eb20a37a0162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a3aa-bc1b-4a57-915c-36c35ae9d92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a3aa-bc1b-4a57-915c-36c35ae9d92a.jpg?1",
             "name": "Blade Historian",
             "text": "Attacking creatures you control have double strike.",
             "colours": [
@@ -13353,7 +13353,7 @@
         },
         {
             "id": "4bc3f436-46dd-5eb3-b060-cd90b03bd52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdafd5bf-573d-4d3b-94ff-c39834a92d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdafd5bf-573d-4d3b-94ff-c39834a92d39.jpg?1",
             "name": "Blot Out the Sky",
             "text": "Create X tapped 2/1 white and black Inkling creature tokens with flying. If X is 6 or more, destroy all noncreature, nonland permanents.",
             "colours": [
@@ -13389,7 +13389,7 @@
         },
         {
             "id": "8fb5988b-f31c-58a1-828a-78f8cc85fb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecda818-2729-436c-bde0-c893ca8be7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecda818-2729-436c-bde0-c893ca8be7a8.jpg?1",
             "name": "Body of Research",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your library.",
             "colours": [
@@ -13425,7 +13425,7 @@
         },
         {
             "id": "af179fa7-f9a4-5a00-8d48-5b8a52503129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba72e51-ca69-48d4-96dc-df9519468c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba72e51-ca69-48d4-96dc-df9519468c01.jpg?1",
             "name": "Culling Ritual",
             "text": "Destroy each nonland permanent with mana value 2 or less. Add {B} or {G} for each permanent destroyed this way.",
             "colours": [
@@ -13461,7 +13461,7 @@
         },
         {
             "id": "3a399f7a-8651-5432-9935-2c444b22a3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f198c49-9192-4b7f-bbc6-9f01395836f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f198c49-9192-4b7f-bbc6-9f01395836f2.jpg?1",
             "name": "Culmination of Studies",
             "text": "Exile the top X cards of your library. For each land card exiled this way, create a Treasure token. For each blue card exiled this way, draw a card. For each red card exiled this way, Culmination of Studies deals 1 damage to each opponent.",
             "colours": [
@@ -13497,7 +13497,7 @@
         },
         {
             "id": "265bd0e8-f7d1-5481-a577-b77ea78877d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a595a8-20f3-49e9-82ca-18923958f21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a595a8-20f3-49e9-82ca-18923958f21b.jpg?1",
             "name": "Daemogoth Titan",
             "text": "Whenever Daemogoth Titan attacks or blocks, sacrifice a creature.",
             "colours": [
@@ -13535,7 +13535,7 @@
         },
         {
             "id": "e4e383bc-79d8-5ad9-a35a-b8299641d488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235079f1-2226-4a6d-9682-ae932e67d660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235079f1-2226-4a6d-9682-ae932e67d660.jpg?1",
             "name": "Double Major",
             "text": "Copy target creature spell you control, except it isn't legendary if the spell is legendary.",
             "colours": [
@@ -13571,7 +13571,7 @@
         },
         {
             "id": "39d0ecec-7607-5838-aef7-df6375e9f1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb164ab-ee63-4025-9d72-6db71b99bdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb164ab-ee63-4025-9d72-6db71b99bdd7.jpg?1",
             "name": "Dramatic Finale",
             "text": "Creature tokens you control get +1/+1.\nWhenever one or more nontoken creatures you control die, create a 2/1 white and black Inkling creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "77ca5ad4-bc4d-5cc4-a709-a12592fbfcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b6e53f-f605-430e-9455-b3653cbd8e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b6e53f-f605-430e-9455-b3653cbd8e1d.jpg?1",
             "name": "Elemental Expressionist",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, choose target creature you control. Until end of turn, it gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else\" and \"When you exile this creature, create a 4/4 blue and red Elemental creature token.\"",
             "colours": [
@@ -13646,7 +13646,7 @@
         },
         {
             "id": "d0bb74a8-6440-5727-ad71-030a7efb9875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7b626d-8536-4c57-b075-8320fcf1cdec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7b626d-8536-4c57-b075-8320fcf1cdec.jpg?1",
             "name": "Harness Infinity",
             "text": "Exchange your hand and graveyard.\nExile Harness Infinity.",
             "colours": [
@@ -13682,7 +13682,7 @@
         },
         {
             "id": "5ce988ab-6312-5be8-8a44-8bbb5e697cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b530c0-86ac-4054-8067-e08764438aaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b530c0-86ac-4054-8067-e08764438aaa.jpg?1",
             "name": "Hofri Ghostforge",
             "text": "Spirits you control get +1/+1 and have trample and haste.\nWhenever another nontoken creature you control dies, exile it. If you do, create a token that's a copy of that creature, except it's a Spirit in addition to its other types and it has \"When this creature leaves the battlefield, return the exiled card to your graveyard.\"",
             "colours": [
@@ -13723,7 +13723,7 @@
         },
         {
             "id": "3fce5952-94ad-524e-aa46-3fb9809de70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7df16-e01d-4053-88d3-db78ed26bfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7df16-e01d-4053-88d3-db78ed26bfe1.jpg?1",
             "name": "Lorehold Command",
             "text": "Choose two \u2014\n\u2022 Create a 3/2 red and white Spirit creature token.\n\u2022 Creatures you control get +1/+0 and gain indestructible and haste until end of turn.\n\u2022 Lorehold Command deals 3 damage to any target. Target player gains 3 life.\n\u2022 Sacrifice a permanent, then draw two cards.",
             "colours": [
@@ -13759,7 +13759,7 @@
         },
         {
             "id": "a7f249b1-0148-5531-93ef-6be4726d6272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f15bee-c4fa-4ad4-acaf-bb8023ebd6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f15bee-c4fa-4ad4-acaf-bb8023ebd6f0.jpg?1",
             "name": "Magma Opus",
             "text": "Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.\n{UR}{UR}, Discard Magma Opus: Create a Treasure token.",
             "colours": [
@@ -13795,7 +13795,7 @@
         },
         {
             "id": "6b022dca-de20-59f0-9e68-041508c78ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7a615-d187-45bd-8f65-3458d896ce5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7a615-d187-45bd-8f65-3458d896ce5e.jpg?1",
             "name": "Manifestation Sage",
             "text": "When Manifestation Sage enters the battlefield, create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your hand.",
             "colours": [
@@ -13834,7 +13834,7 @@
         },
         {
             "id": "68194a33-5a60-581f-8231-1aab5df013ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffb6717-93f5-4774-9cc3-29b883b144b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffb6717-93f5-4774-9cc3-29b883b144b5.jpg?1",
             "name": "Prismari Command",
             "text": "Choose two \u2014\n\u2022 Prismari Command deals 2 damage to any target.\n\u2022 Target player draws two cards, then discards two cards.\n\u2022 Target player creates a Treasure token.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -13870,7 +13870,7 @@
         },
         {
             "id": "f17ee1ca-2725-55e1-947e-d02854bdc138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b362583b-f5d7-45cf-add1-71e790547203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b362583b-f5d7-45cf-add1-71e790547203.jpg?1",
             "name": "Quandrix Command",
             "text": "Choose two \u2014\n\u2022 Return target creature or planeswalker to its owner's hand.\n\u2022 Counter target artifact or enchantment spell.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player shuffles up to three target cards from their graveyard into their library.",
             "colours": [
@@ -13906,7 +13906,7 @@
         },
         {
             "id": "0c98cab2-b9d0-5186-b54c-d172651c2d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74eea36-f7b6-4586-a16c-cd20ab89ab54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74eea36-f7b6-4586-a16c-cd20ab89ab54.jpg?1",
             "name": "Radiant Scrollwielder",
             "text": "Instant and sorcery spells you control have lifelink.\nAt the beginning of your upkeep, exile an instant or sorcery card at random from your graveyard. You may cast it this turn. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "d851a317-5e8d-59ee-b899-3015fb57ae5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5ce6dd-5994-4e85-9479-fa924c8ab42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5ce6dd-5994-4e85-9479-fa924c8ab42b.jpg?1",
             "name": "Rushed Rebirth",
             "text": "Choose target creature. When that creature dies this turn, search your library for a creature card with lesser mana value, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13981,7 +13981,7 @@
         },
         {
             "id": "5e980a6e-f84e-5f90-8280-905f2fe010c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbde59f8-dadd-4b5f-a55c-69317af7c2b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbde59f8-dadd-4b5f-a55c-69317af7c2b7.jpg?1",
             "name": "Silverquill Command",
             "text": "Choose two \u2014\n\u2022 Target creature gets +3/+3 and gains flying until end of turn.\n\u2022 Return target creature card with mana value 2 or less from your graveyard to the battlefield.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target opponent sacrifices a creature.",
             "colours": [
@@ -14017,7 +14017,7 @@
         },
         {
             "id": "375dcf31-adc4-5c41-8bb8-a530bad073cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ae964b-a3dd-4747-a229-d0b4e112179e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ae964b-a3dd-4747-a229-d0b4e112179e.jpg?1",
             "name": "Silverquill Silencer",
             "text": "As Silverquill Silencer enters the battlefield, choose a nonland card name.\nWhenever an opponent casts a spell with the chosen name, they lose 3 life and you draw a card.",
             "colours": [
@@ -14056,7 +14056,7 @@
         },
         {
             "id": "31dbfa17-da37-5712-aff3-1dfcf757b335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7441bf-8783-48b9-b828-31c071e97847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7441bf-8783-48b9-b828-31c071e97847.jpg?1",
             "name": "Vanishing Verse",
             "text": "Exile target monocolored permanent.",
             "colours": [
@@ -14092,7 +14092,7 @@
         },
         {
             "id": "8810ba59-b1c4-5a27-b5b7-864376f10d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cae78b-75a4-4c0e-92c3-f24379a23271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cae78b-75a4-4c0e-92c3-f24379a23271.jpg?1",
             "name": "Venerable Warsinger",
             "text": "Vigilance, trample\nWhenever Venerable Warsinger deals combat damage to a player, you may return target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of damage Venerable Warsinger dealt to that player.",
             "colours": [
@@ -14131,7 +14131,7 @@
         },
         {
             "id": "86ac72b4-333c-5674-8e42-870f8a564895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f04535d-a6b7-4d91-918d-fccc1adfcaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f04535d-a6b7-4d91-918d-fccc1adfcaf3.jpg?1",
             "name": "Witherbloom Command",
             "text": "Choose two \u2014\n\u2022 Target player mills three cards, then you return a land card from your graveyard to your hand.\n\u2022 Destroy target noncreature, nonland permanent with mana value 2 or less.\n\u2022 Target creature gets -3/-1 until end of turn.\n\u2022 Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -14167,7 +14167,7 @@
         },
         {
             "id": "a9ad89b5-df19-53ce-943a-b4c8f6ad4ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7e96e-5d35-41dc-9a8a-2049e2e56350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7e96e-5d35-41dc-9a8a-2049e2e56350.jpg?1",
             "name": "Codie, Vociferous Codex",
             "text": "You can't cast permanent spells.\n{4}, {T}: Add {W}{U}{B}{R}{G}. When you cast your next spell this turn, exile cards from the top of your library until you exile an instant or sorcery card with lesser mana value. Until end of turn, you may cast that card without paying its mana cost. Put each other card exiled this way on the bottom of your library in a random order.",
             "colours": [],
@@ -14208,7 +14208,7 @@
         },
         {
             "id": "df5c8820-391b-5326-8eb5-b4ae0f1b7973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795abd9-7294-4f8a-8491-0fe39ae6e273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795abd9-7294-4f8a-8491-0fe39ae6e273.jpg?1",
             "name": "Strixhaven Stadium",
             "text": "{T}: Add {C}. Put a point counter on Strixhaven Stadium.\nWhenever a creature deals combat damage to you, remove a point counter from Strixhaven Stadium.\nWhenever a creature you control deals combat damage to an opponent, put a point counter on Strixhaven Stadium. Then if it has ten or more point counters on it, remove them all and that player loses the game.",
             "colours": [],
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "34b7c089-5aec-5147-8d1b-435696979ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de969f0a-23df-408e-9f92-4b909caf73d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de969f0a-23df-408e-9f92-4b909caf73d0.jpg?1",
             "name": "The Biblioplex",
             "text": "{T}: Add {C}.\n{2}, {T}: Look at the top card of your library. If it's an instant or sorcery card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard. Activate only if you have exactly zero or seven cards in hand.",
             "colours": [],
@@ -14268,7 +14268,7 @@
         },
         {
             "id": "554021a0-3d65-51e6-ba6d-262c8d67500f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79f483-88c5-461c-a7c5-6b898317b1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79f483-88c5-461c-a7c5-6b898317b1e3.jpg?1",
             "name": "Frostboil Snarl",
             "text": "As Frostboil Snarl enters the battlefield, you may reveal an Island or Mountain card from your hand. If you don't, Frostboil Snarl enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -14301,7 +14301,7 @@
         },
         {
             "id": "9162a32c-a851-5da1-90ad-04dd07d794e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58115f3f-1157-4efd-94d8-3a1a71bd6816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58115f3f-1157-4efd-94d8-3a1a71bd6816.jpg?1",
             "name": "Furycalm Snarl",
             "text": "As Furycalm Snarl enters the battlefield, you may reveal a Mountain or Plains card from your hand. If you don't, Furycalm Snarl enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -14334,7 +14334,7 @@
         },
         {
             "id": "2eacad9b-1808-5895-bf3a-3fb4ffc76dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a1a974-8275-4878-9863-9466569aac00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a1a974-8275-4878-9863-9466569aac00.jpg?1",
             "name": "Hall of Oracles",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on target creature. Activate only as a sorcery and only if you've cast an instant or sorcery spell this turn.",
             "colours": [],
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "0a654fdf-ecf7-59f4-899c-6250bd514cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68589e-d71f-4a2b-9a97-b768e81aefa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68589e-d71f-4a2b-9a97-b768e81aefa4.jpg?1",
             "name": "Necroblossom Snarl",
             "text": "As Necroblossom Snarl enters the battlefield, you may reveal a Swamp or Forest card from your hand. If you don't, Necroblossom Snarl enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "c34a12a4-6abf-5eb2-976c-591a48726d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba00634-b62c-4a95-941d-775fc4c9e3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba00634-b62c-4a95-941d-775fc4c9e3a2.jpg?1",
             "name": "Shineshadow Snarl",
             "text": "As Shineshadow Snarl enters the battlefield, you may reveal a Plains or Swamp card from your hand. If you don't, Shineshadow Snarl enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -14430,7 +14430,7 @@
         },
         {
             "id": "7dadd13d-67a4-5e31-82da-c1b4d1e27e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa184596-3a3c-43fe-8e20-b09ab100cd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa184596-3a3c-43fe-8e20-b09ab100cd00.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "As Vineglimmer Snarl enters the battlefield, you may reveal a Forest or Island card from your hand. If you don't, Vineglimmer Snarl enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -14463,7 +14463,7 @@
         },
         {
             "id": "663a508e-294f-5fae-857d-d865c3d10929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abadcf9e-46ed-4a8b-888c-0cd3756bc8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abadcf9e-46ed-4a8b-888c-0cd3756bc8ab.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14499,7 +14499,7 @@
         },
         {
             "id": "a91545ec-1a4c-5846-8065-bd364a0d490d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7e5de-1fa8-406e-a411-fc8a11937000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7e5de-1fa8-406e-a411-fc8a11937000.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14535,7 +14535,7 @@
         },
         {
             "id": "79fc1f2b-9bbc-54df-8059-c3951a4eccb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96f9fb6-ef52-43f9-a458-8602a7c83333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96f9fb6-ef52-43f9-a458-8602a7c83333.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14571,7 +14571,7 @@
         },
         {
             "id": "790c241b-3c46-5389-b6ef-70aaed263f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a217f-d532-4a7c-bcbf-d127641f6edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a217f-d532-4a7c-bcbf-d127641f6edf.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14607,7 +14607,7 @@
         },
         {
             "id": "4f1b0270-be24-5887-88a1-f2ff9e25e636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bd1c69-2561-4ff1-af00-bb519b3897c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bd1c69-2561-4ff1-af00-bb519b3897c2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14643,7 +14643,7 @@
         },
         {
             "id": "163e1402-4a2d-5029-ba3b-3ca2841caa74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11093e3f-092e-49d9-aef9-b9855b040bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11093e3f-092e-49d9-aef9-b9855b040bf2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14679,7 +14679,7 @@
         },
         {
             "id": "07be00b8-3035-52e4-9288-f7db23c14522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9660fb20-f499-4f7a-9f25-e463f095ab90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9660fb20-f499-4f7a-9f25-e463f095ab90.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "b1919663-4074-5309-b395-f1425bd5b705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8fffd1-aff1-4aad-bfa0-9907adb5ce25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8fffd1-aff1-4aad-bfa0-9907adb5ce25.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14751,7 +14751,7 @@
         },
         {
             "id": "399ca0f2-1540-5465-b38e-67d25f670e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf517f-86a1-45eb-bd71-e0bffb610396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf517f-86a1-45eb-bd71-e0bffb610396.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14787,7 +14787,7 @@
         },
         {
             "id": "2f78811e-e99e-5d44-a78d-211f92c1c635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659a7d45-af0d-4a4a-a878-e8e40b732bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659a7d45-af0d-4a4a-a878-e8e40b732bfa.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14823,7 +14823,7 @@
         },
         {
             "id": "66468e25-da7d-56e7-8ae8-542eeadfbb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f213fb1e-f159-4088-8b0e-f10771e4b095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f213fb1e-f159-4088-8b0e-f10771e4b095.jpg?1",
             "name": "Dragonsguard Elite",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Dragonsguard Elite.\n{4}{G}{G}: Double the number of +1/+1 counters on Dragonsguard Elite.",
             "colours": [
@@ -14860,7 +14860,7 @@
         },
         {
             "id": "79636fc8-4089-5a80-ac3a-9d78569b8acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f7218a-511a-4ca8-899d-ae78a935f7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f7218a-511a-4ca8-899d-ae78a935f7a0.jpg?1",
             "name": "Archmage Emeritus",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, draw a card.",
             "colours": [
@@ -14898,7 +14898,7 @@
         },
         {
             "id": "f38b6cfd-e43c-5b3c-802d-4148aa5c1689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033ffe6-3e81-440f-bde7-0cf267a54b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033ffe6-3e81-440f-bde7-0cf267a54b36.jpg?1",
             "name": "Fracture",
             "text": "Destroy target artifact, enchantment, or planeswalker.",
             "colours": [
@@ -14934,7 +14934,7 @@
         },
         {
             "id": "6a07c8a9-0429-54ff-a475-66e6b57c5007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e5c7e8-e6bf-4186-8140-d1171fbb8552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e5c7e8-e6bf-4186-8140-d1171fbb8552.jpg?1",
             "name": "Expressive Iteration",
             "text": "Look at the top three cards of your library. Put one of them into your hand, put one of them on the bottom of your library, and exile one of them. You may play the exiled card this turn.",
             "colours": [
@@ -14970,7 +14970,7 @@
         },
         {
             "id": "fec2bc24-35a3-54bf-b616-2a1a4a107768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddfc5f7-911b-4159-8540-530d642d0e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddfc5f7-911b-4159-8540-530d642d0e7c.jpg?1",
             "name": "Mortality Spear",
             "text": "This spell costs {2} less to cast if you gained life this turn.\nDestroy target nonland permanent.",
             "colours": [
@@ -15006,7 +15006,7 @@
         },
         {
             "id": "341bf2d2-87e0-5e47-9644-5515a50c54c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f135f-1404-4333-946e-62d3aa919a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f135f-1404-4333-946e-62d3aa919a62.jpg?1",
             "name": "Rip Apart",
             "text": "Choose one \u2014\n\u2022 Rip Apart deals 3 damage to target creature or planeswalker.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -15042,7 +15042,7 @@
         },
         {
             "id": "80df58da-e739-5b4c-9402-c90eeaa4cb2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b05c98-7799-4104-a0d0-3632bd5b8846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b05c98-7799-4104-a0d0-3632bd5b8846.jpg?1",
             "name": "Decisive Denial",
             "text": "Choose one \u2014\n\u2022 Target creature you control fights target creature you don't control.\n\u2022 Counter target noncreature spell unless its controller pays {3}.",
             "colours": [
@@ -15078,7 +15078,7 @@
         },
         {
             "id": "2ce340c2-2ee0-55a9-a085-f21475429fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a50acd-ac2d-47bf-b331-0bcf5edd9c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a50acd-ac2d-47bf-b331-0bcf5edd9c75.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -15115,7 +15115,7 @@
         },
         {
             "id": "9a4cae1d-a07e-5a10-8fb3-776eefa1fc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0b9b88-705e-4df0-8a93-3e240b81355b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0b9b88-705e-4df0-8a93-3e240b81355b.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -15151,7 +15151,7 @@
         },
         {
             "id": "f1eeabc4-d35f-513e-a146-1f76051b3ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f48ab-b04e-4874-b31d-a86a7bc5af14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f48ab-b04e-4874-b31d-a86a7bc5af14.jpg?1",
             "name": "Fractal",
             "text": "",
             "colours": [
@@ -15187,7 +15187,7 @@
         },
         {
             "id": "aca46592-54ab-50f2-90ae-7dabf972573e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9deae5c-80d4-4701-b425-91853b7ee03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9deae5c-80d4-4701-b425-91853b7ee03b.jpg?1",
             "name": "Inkling",
             "text": "",
             "colours": [
@@ -15223,7 +15223,7 @@
         },
         {
             "id": "ef89b1c0-dd6f-59fd-9f80-d329f2fb5a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg?1",
             "name": "Pest",
             "text": "",
             "colours": [
@@ -15259,7 +15259,7 @@
         },
         {
             "id": "73d91ea5-cea0-51f3-9ad1-a7ee5f82804b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98c0167-7434-4607-87c4-315fa8b6972e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98c0167-7434-4607-87c4-315fa8b6972e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -15295,7 +15295,7 @@
         },
         {
             "id": "84e8350e-916c-5bde-9c98-f4ec1d2b1f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d027f-8996-4761-a776-47cd428f6779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d027f-8996-4761-a776-47cd428f6779.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -15326,7 +15326,7 @@
         },
         {
             "id": "802758d8-7975-5041-80eb-69f438c279dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e090a47-3187-44f2-9dea-c2bc1407b053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e090a47-3187-44f2-9dea-c2bc1407b053.jpg?1",
             "name": "Lukka, Wayward Bonder Emblem",
             "text": "",
             "colours": [],
@@ -15354,7 +15354,7 @@
         },
         {
             "id": "4a610a7b-cf8d-5231-bc2f-a3cd64009fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18b93e-b590-4fbb-be47-d63a25cde811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18b93e-b590-4fbb-be47-d63a25cde811.jpg?1",
             "name": "Rowan, Scholar of Sparks Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/TDM.json
+++ b/Assets/Resources/Sets/TDM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "22e8c995-d185-5f9f-84cf-a7e799daeeda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a5d494-efa1-446b-bebe-2ad36e154376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a5d494-efa1-446b-bebe-2ad36e154376.jpg?1",
             "name": "Ugin, Eye of the Storms",
             "text": "When you cast this spell, exile up to one target permanent that's one or more colors.\nWhenever you cast a colorless spell, exile up to one target permanent that's one or more colors.\n+2: You gain 3 life and draw a card.\n0: Add {C}{C}{C}.\n\u221211: Search your library for any number of colorless nonland cards, exile them, then shuffle. Until end of turn, you may cast those cards without paying their mana costs.",
             "colours": [],
@@ -39,7 +39,7 @@
         },
         {
             "id": "760e6b1a-c1c9-5f1a-be46-a1fb6b85245b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29957f49-9a6b-42f6-b2fb-b48f653ab725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29957f49-9a6b-42f6-b2fb-b48f653ab725.jpg?1",
             "name": "Anafenza, Unyielding Lineage",
             "text": "Flash\nFirst strike\nWhenever another nontoken creature you control dies, Anafenza endures 2. (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "926b2054-5a1e-54e3-8fb9-feea8c6cde33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7102d8-90b3-45a1-b66d-dcca469b1fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7102d8-90b3-45a1-b66d-dcca469b1fb6.jpg?1",
             "name": "Arashin Sunshield",
             "text": "When this creature enters, exile up to two target cards from a single graveyard.\n{W}, {T}: Tap target creature.",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "46992657-f172-5163-a420-6dbd1bf403df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d91e42-43db-428d-a4dd-ef9d40306314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d91e42-43db-428d-a4dd-ef9d40306314.jpg?1",
             "name": "Bearer of Glory",
             "text": "During your turn, this creature has first strike.\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "9de42322-cb51-5a85-a711-766c4039ccdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f892d156-371c-4391-8ae6-25513c5032b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f892d156-371c-4391-8ae6-25513c5032b0.jpg?1",
             "name": "Clarion Conqueror",
             "text": "Flying\nActivated abilities of artifacts, creatures, and planeswalkers can't be activated.",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "a56be8e0-36c9-5c52-857c-3183073126b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6569487-53c5-4b91-877d-e4e31bfa90c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6569487-53c5-4b91-877d-e4e31bfa90c0.jpg?1",
             "name": "Coordinated Maneuver",
             "text": "Choose one \u2014\n\u2022 Coordinated Maneuver deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "da9218fe-9065-5bb1-8440-c33f863be247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df7b253-6107-47d6-b650-cb4d3e0aec6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df7b253-6107-47d6-b650-cb4d3e0aec6b.jpg?1",
             "name": "Dalkovan Packbeasts",
             "text": "Vigilance\nMobilize 3 (Whenever this creature attacks, create three tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "e89ec9d4-6752-5288-b513-b31a32bb5c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f632be90-9e7f-41f8-a52e-a2952354d730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f632be90-9e7f-41f8-a52e-a2952354d730.jpg?1",
             "name": "Descendant of Storms",
             "text": "Whenever this creature attacks, you may pay {1}{W}. If you do, it endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "0d0c0f15-2645-50a6-94a0-3c345b34988b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200a8c5-3293-48d0-a523-ba148680f588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200a8c5-3293-48d0-a523-ba148680f588.jpg?1",
             "name": "Dragonback Lancer",
             "text": "Flying\nMobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "62538893-cd6a-53a7-b0a8-c5ad1d6ef70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92640d-768b-4357-905f-bea017d351cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92640d-768b-4357-905f-bea017d351cc.jpg?1",
             "name": "Duty Beyond Death",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nCreatures you control gain indestructible until end of turn. Put a +1/+1 counter on each creature you control. (Damage and effects that say \"destroy\" don't destroy those creatures.)",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "49fc65ab-f09a-5a9a-b550-f8fde7ac1b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a065e3-b530-4e62-ab3c-4f6f908184ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a065e3-b530-4e62-ab3c-4f6f908184ec.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n+1: Create a 1/1 white Soldier creature token.\n0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your next turn.\n\u22123: Destroy target creature an opponent controls with mana value 3 or greater.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "dd0cb2f7-d303-54e5-b78b-95f9ad6bd31b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b647a018-1d70-43a1-a265-928bcd863689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b647a018-1d70-43a1-a265-928bcd863689.jpg?1",
             "name": "Fortress Kin-Guard",
             "text": "When this creature enters, it endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "9898d496-cd30-5655-a951-b0f8788978e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f247b6-8212-4e78-a452-d2d3be228d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f247b6-8212-4e78-a452-d2d3be228d8e.jpg?1",
             "name": "Furious Forebear",
             "text": "Whenever a creature you control dies while this card is in your graveyard, you may pay {1}{W}. If you do, return this card from your graveyard to your hand.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "b569148b-9f90-5529-aaf4-b75719e8a227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1a41-d44d-4184-9147-b4233e73de65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1a41-d44d-4184-9147-b4233e73de65.jpg?1",
             "name": "Lightfoot Technique",
             "text": "Put a +1/+1 counter on target creature. It gains flying and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "67332abb-86e6-5b9e-8004-029166f90930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a527cdb0-f54a-4b53-83a0-6b3e8cafa45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a527cdb0-f54a-4b53-83a0-6b3e8cafa45e.jpg?1",
             "name": "Loxodon Battle Priest",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "2925f044-bca0-5bb2-a342-b3a70d7ff41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da45e9b0-a4f6-413b-9e62-666c511eb5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da45e9b0-a4f6-413b-9e62-666c511eb5b0.jpg?1",
             "name": "Mardu Devotee",
             "text": "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{1}: Add {R}, {W}, or {B}. Activate only once each turn.",
             "colours": [
@@ -567,7 +567,7 @@
         },
         {
             "id": "2aeff58b-6d33-5faf-8941-c778c073e8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300da2f-2297-4c2f-90c1-11ce2b42d91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300da2f-2297-4c2f-90c1-11ce2b42d91f.jpg?1",
             "name": "Osseous Exhale",
             "text": "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)\nOsseous Exhale deals 5 damage to target attacking or blocking creature. If a Dragon was beheld, you gain 2 life.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "3768817d-2372-5cb6-8a90-b29ed03701ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb25366d-a647-4c5e-bcc7-7e54659aacbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb25366d-a647-4c5e-bcc7-7e54659aacbd.jpg?1",
             "name": "Poised Practitioner",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, put a +1/+1 counter on this creature. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "e12cf1d0-7e91-50da-b53f-6c135c2d51b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56e0037-8143-4c13-83e1-0c3f44e685ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56e0037-8143-4c13-83e1-0c3f44e685ea.jpg?1",
             "name": "Rally the Monastery",
             "text": "This spell costs {2} less to cast if you've cast another spell this turn.\nChoose one \u2014\n\u2022 Create two 1/1 white Monk creature tokens with prowess.\n\u2022 Up to two target creatures you control each get +2/+2 until end of turn.\n\u2022 Destroy target creature with power 4 or greater.",
             "colours": [
@@ -666,7 +666,7 @@
         },
         {
             "id": "8fe74dbd-e5a3-563c-a2f0-a88a6e1139c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bafe19-3bd6-4da0-b3e5-e0b89262504c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bafe19-3bd6-4da0-b3e5-e0b89262504c.jpg?1",
             "name": "Rebellious Strike",
             "text": "Target creature gets +3/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "2e3b9f6b-f1de-5d43-ae9a-8d87f9c88b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Flying, vigilance\nAt the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "afa9211a-6738-5f6a-89ad-b1788cea68f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Create a 2/2 white Soldier creature token. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "ac332121-208e-56a7-a086-f7110a62a53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade6918-6d1d-448d-ab56-93996051e9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade6918-6d1d-448d-ab56-93996051e9a9.jpg?1",
             "name": "Sage of the Skies",
             "text": "When you cast this spell, if you've cast another spell this turn, copy this spell. (The copy becomes a token.)\nFlying, lifelink",
             "colours": [
@@ -807,7 +807,7 @@
         },
         {
             "id": "ba163ee9-1825-51ab-9cd1-dda5d9788e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d548c9-42bc-4155-8211-0aea801c3724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d548c9-42bc-4155-8211-0aea801c3724.jpg?1",
             "name": "Salt Road Packbeast",
             "text": "This spell costs {1} less to cast for each creature you control.\nWhen this creature enters, draw a card.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "4ad174ae-4315-5257-80de-fd571027a770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2da18f-0d7d-446c-b463-8bf170ed95da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2da18f-0d7d-446c-b463-8bf170ed95da.jpg?1",
             "name": "Smile at Death",
             "text": "At the beginning of your upkeep, return up to two target creature cards with power 2 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "b886d284-6601-5f4e-9e97-866135215388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3cc15e-1c82-454e-b541-4ab47c44814e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3cc15e-1c82-454e-b541-4ab47c44814e.jpg?1",
             "name": "Starry-Eyed Skyrider",
             "text": "Flying\nWhenever this creature attacks, another target creature you control gains flying until end of turn.\nAttacking tokens you control have flying.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "1136f4f6-05df-5a33-a630-0804a1d6f095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce50932-03a6-48bc-8aee-bc8defd896cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce50932-03a6-48bc-8aee-bc8defd896cf.jpg?1",
             "name": "Static Snare",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature.\nWhen this enchantment enters, exile target artifact or creature an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "3375afd5-0239-57c6-a685-14608fd96d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f12684-c80a-422b-9c3f-ed4f31742b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f12684-c80a-422b-9c3f-ed4f31742b9d.jpg?1",
             "name": "Stormbeacon Blade",
             "text": "Equipped creature gets +3/+0.\nWhenever equipped creature attacks, draw a card if you control three or more attacking creatures.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "a8eb6e61-1382-51eb-b064-76ab52579b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f3aab5-7b54-4b55-8114-c6f9f79c255d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f3aab5-7b54-4b55-8114-c6f9f79c255d.jpg?1",
             "name": "Stormplain Detainment",
             "text": "When this enchantment enters, exile target nonland permanent an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "474cb907-f981-581a-a9f1-1dfe325e141f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18292b9c-0f42-4ce2-8b85-35d06cf45a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18292b9c-0f42-4ce2-8b85-35d06cf45a63.jpg?1",
             "name": "Sunpearl Kirin",
             "text": "Flash\nFlying\nWhen this creature enters, return up to one other target nonland permanent you control to its owner's hand. If it was a token, draw a card.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "406e79eb-3cc1-54ae-b74c-0745c96243cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d771f-24dc-4ed6-8051-62df576a2ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d771f-24dc-4ed6-8051-62df576a2ba5.jpg?1",
             "name": "Teeming Dragonstorm",
             "text": "When this enchantment enters, create two 2/2 white Soldier creature tokens.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "3e18f169-8d68-518c-baab-2e0ca8551b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422f9453-ab12-4e3c-8c51-be87391395a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422f9453-ab12-4e3c-8c51-be87391395a1.jpg?1",
             "name": "Tempest Hawk",
             "text": "Flying\nWhenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\nA deck can have any number of cards named Tempest Hawk.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "cb884575-e62b-5a08-a3b1-a41dabc1856b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff398be-4ba4-4976-9acc-be99d2e07a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff398be-4ba4-4976-9acc-be99d2e07a61.jpg?1",
             "name": "United Battlefront",
             "text": "Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "986e3fe2-b49e-5158-8e51-05f6da78ba79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3de5f4-bb55-4ab9-995f-f3e0dc22c1bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3de5f4-bb55-4ab9-995f-f3e0dc22c1bb.jpg?1",
             "name": "Voice of Victory",
             "text": "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "a7f88b11-1920-5a9b-85bc-2abfa8e0092d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5b2324-69fe-4105-b6f8-14dfbe359d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5b2324-69fe-4105-b6f8-14dfbe359d59.jpg?1",
             "name": "Wayspeaker Bodyguard",
             "text": "When this creature enters, return target nonland permanent card with mana value 2 or less from your graveyard to your hand.\nFlurry \u2014 Whenever you cast your second spell each turn, tap target creature an opponent controls.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "47c93168-0e06-56c6-ba1d-501cd4687ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c1417a-9719-46f6-8749-d92b93ce0529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c1417a-9719-46f6-8749-d92b93ce0529.jpg?1",
             "name": "Aegis Sculptor",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your upkeep, you may exile two cards from your graveyard. If you do, put a +1/+1 counter on this creature.",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "7327d54b-3567-5419-911b-2097de8f779a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0462-0158-467f-951d-a7a121188a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0462-0158-467f-951d-a7a121188a10.jpg?1",
             "name": "Agent of Kotis",
             "text": "Renew \u2014 {3}{U}, Exile this card from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "0cb54f9b-069c-527d-8692-fd98150ff73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74d4a57-0f66-4965-9ed7-f88a08aa1d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74d4a57-0f66-4965-9ed7-f88a08aa1d15.jpg?1",
             "name": "Ambling Stormshell",
             "text": "Ward {2}\nWhenever this creature attacks, put three stun counters on it and draw three cards. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you cast a Turtle spell, untap this creature.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "b055ae1a-0c5e-56ab-87cf-3fcfe637d378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b25843-1aa0-484a-b6c7-0c284fe7214a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b25843-1aa0-484a-b6c7-0c284fe7214a.jpg?1",
             "name": "Bewildering Blizzard",
             "text": "Draw three cards. Creatures your opponents control get -3/-0 until end of turn.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "cd712915-c5b5-5588-98d6-f286f4761798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f160d7-c832-4b83-8f2e-aaeb190add3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f160d7-c832-4b83-8f2e-aaeb190add3f.jpg?1",
             "name": "Constrictor Sage",
             "text": "When this creature enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nRenew \u2014 {2}{U}, Exile this card from your graveyard: Tap target creature an opponent controls and put a stun counter on it. Activate only as a sorcery.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "7fb4b23d-c157-5a10-bd3b-c0e37cd2ee0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "64dd7d14-facf-5db3-b5f7-8a165d5fc30f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Tap up to one target creature. Draw a card. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "5ce9463f-21d2-5fd3-b84c-2157b301bfec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9af3f1-711e-42ae-803a-1100eba3fb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9af3f1-711e-42ae-803a-1100eba3fb13.jpg?1",
             "name": "Dispelling Exhale",
             "text": "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)\nCounter target spell unless its controller pays {2}. If a Dragon was beheld, counter that spell unless its controller pays {4} instead.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "5fd67db4-87e9-5c6c-8a06-6feddd08fca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8810ebb4-9e51-46f0-a54a-a0b4d77b762a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8810ebb4-9e51-46f0-a54a-a0b4d77b762a.jpg?1",
             "name": "Dragonologist",
             "text": "When this creature enters, look at the top six cards of your library. You may reveal an instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nUntapped Dragons you control have hexproof.",
             "colours": [
@@ -1532,7 +1532,7 @@
         },
         {
             "id": "94744d82-42c2-5e0d-a48f-73ea19c4c65a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec7a31-1893-493c-926b-dc3a8a770e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec7a31-1893-493c-926b-dc3a8a770e72.jpg?1",
             "name": "Dragonstorm Forecaster",
             "text": "{2}, {T}: Search your library for a card named Dragonstorm Globe or Boulderborn Dragon, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "71247423-507b-5a6a-b29d-1d0e33e54d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c4509-918e-44ba-aa13-1991199fee9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c4509-918e-44ba-aa13-1991199fee9f.jpg?1",
             "name": "Essence Anchor",
             "text": "At the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Create a 2/2 black Zombie Druid creature token. Activate only during your turn and only if a card left your graveyard this turn.",
             "colours": [
@@ -1599,7 +1599,7 @@
         },
         {
             "id": "016939df-525f-58dc-85e1-3edf49a5cb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb0ba34-6904-4c17-a04d-ea4f12c7cf21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb0ba34-6904-4c17-a04d-ea4f12c7cf21.jpg?1",
             "name": "Focus the Mind",
             "text": "This spell costs {2} less to cast if you've cast another spell this turn.\nDraw three cards, then discard a card.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "6b914eca-41af-5ecb-8573-f214e584e6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f7af08-ac05-45d0-979f-282943130c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f7af08-ac05-45d0-979f-282943130c61.jpg?1",
             "name": "Fresh Start",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -5/-0 and loses all abilities.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "df234add-39ff-5e67-b013-3ac29eb57150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75dccf7-2894-4c4a-b516-3eee73acddd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75dccf7-2894-4c4a-b516-3eee73acddd3.jpg?1",
             "name": "Highspire Bell-Ringer",
             "text": "Flying\nThe second spell you cast each turn costs {1} less to cast.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "4cf6f52f-734d-562f-99f2-dcd4dbc31557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a84c3f8-0030-4653-880e-b2d19272f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a84c3f8-0030-4653-880e-b2d19272f5fa.jpg?1",
             "name": "Humbling Elder",
             "text": "Flash\nWhen this creature enters, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "5299374a-390d-5ada-a285-d25178b85062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13f117b-b8e4-48db-8ce9-5da9c7ce23a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13f117b-b8e4-48db-8ce9-5da9c7ce23a5.jpg?1",
             "name": "Iceridge Serpent",
             "text": "When this creature enters, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "c70bfdc4-39fc-569e-849c-f9602d6f7331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fbc55-e8e9-4077-9532-1de7406baabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fbc55-e8e9-4077-9532-1de7406baabf.jpg?1",
             "name": "Kishla Trawlers",
             "text": "When this creature enters, you may exile a creature card from your graveyard. When you do, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1804,7 +1804,7 @@
         },
         {
             "id": "926dfc80-8c5c-5cb2-bf53-18cf2a0bff01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg?1",
             "name": "Marang River Regent // Coil and Catch",
             "text": "",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "aa811ede-dcbf-557e-9792-a03ec078b8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg?1",
             "name": "Marang River Regent // Coil and Catch",
             "text": "",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "22247f86-2612-5cea-81d7-8bf7a1c00b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df17423-9fdd-4432-8660-1d267c685595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df17423-9fdd-4432-8660-1d267c685595.jpg?1",
             "name": "Naga Fleshcrafter",
             "text": "You may have this creature enter as a copy of any creature on the battlefield.\nRenew \u2014 {2}{U}, Exile this card from your graveyard: Put a +1/+1 counter on target nonlegendary creature you control. Each other creature you control becomes a copy of that creature until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -1909,7 +1909,7 @@
         },
         {
             "id": "33da33e2-ff60-5206-97af-b5a0241b2fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4fc7ec-05f5-479a-8fbb-31e12a67b57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4fc7ec-05f5-479a-8fbb-31e12a67b57e.jpg?1",
             "name": "Ringing Strike Mastery",
             "text": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"{5}: Untap this creature.\"",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "bd3efd17-1da9-5609-9c34-00fae8138145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043c25d5-13ee-4cab-98d5-fb89db9cf6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043c25d5-13ee-4cab-98d5-fb89db9cf6e3.jpg?1",
             "name": "Riverwalk Technique",
             "text": "Choose one \u2014\n\u2022 The owner of target nonland permanent puts it on their choice of the top or bottom of their library.\n\u2022 Counter target noncreature spell.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "0663aff5-789c-5dac-90a7-281f3859efcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4c96-684b-4b14-bd21-6799da2e1fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4c96-684b-4b14-bd21-6799da2e1fa7.jpg?1",
             "name": "Roiling Dragonstorm",
             "text": "When this enchantment enters, draw two cards, then discard a card.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -2010,7 +2010,7 @@
         },
         {
             "id": "4d3597fb-92c7-5a6e-a684-1e647019e3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c5b96-bac6-449b-a2bd-cb43750d3911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c5b96-bac6-449b-a2bd-cb43750d3911.jpg?1",
             "name": "Sibsig Appraiser",
             "text": "When this creature enters, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "3de37533-6d41-551e-a35c-d88603fa878d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b3b131-704a-4586-84f8-db465cd4a277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b3b131-704a-4586-84f8-db465cd4a277.jpg?1",
             "name": "Snowmelt Stag",
             "text": "Vigilance\nDuring your turn, this creature has base power and toughness 5/2.\n{5}{U}{U}: This creature can't be blocked this turn.",
             "colours": [
@@ -2080,7 +2080,7 @@
         },
         {
             "id": "09ad11fa-bec7-59e0-8cbc-f5caf65800ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e732a-1ffd-463d-92c2-26187659cfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e732a-1ffd-463d-92c2-26187659cfc3.jpg?1",
             "name": "Spectral Denial",
             "text": "This spell costs {1} less to cast for each creature you control with power 4 or greater.\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "81702e04-ec5d-51df-9ae1-8edb49ad70df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6289251-17e4-4987-96b9-2fb1a8f90e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6289251-17e4-4987-96b9-2fb1a8f90e2a.jpg?1",
             "name": "Stillness in Motion",
             "text": "At the beginning of your upkeep, mill three cards. Then if your library has no cards in it, exile this enchantment and put five cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "d0bbfe65-d93a-5227-b51d-1035e7bcf073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693d631-05f6-414d-9e49-6385746e8960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693d631-05f6-414d-9e49-6385746e8960.jpg?1",
             "name": "Taigam, Master Opportunist",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, copy it, then exile the spell you cast with four time counters on it. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, they remove a time counter. When the last is removed, they may play it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "d0c0963b-1c1c-57bd-9dd1-1c3c44c56ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ef698e-5466-43bd-985d-020f2e5d8205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ef698e-5466-43bd-985d-020f2e5d8205.jpg?1",
             "name": "Temur Devotee",
             "text": "Defender\n{1}: Add {G}, {U}, or {R}. Activate only once each turn.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "3db33e63-601d-55c4-b465-e9c6c1e53e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48180a-ccac-469f-938d-c050821d0160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48180a-ccac-469f-938d-c050821d0160.jpg?1",
             "name": "Unending Whisper",
             "text": "Draw a card.\nHarmonize {5}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "534555e9-9c0a-5e87-87cc-e2bffc8055ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722716df-9cea-40a7-924b-c28497e227e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722716df-9cea-40a7-924b-c28497e227e6.jpg?1",
             "name": "Ureni's Rebuff",
             "text": "Return target creature to its owner's hand.\nHarmonize {5}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "4bb854ef-2423-53c6-a556-e9107053a816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcccfd7b-2846-4552-a89a-2b868bc9ab20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcccfd7b-2846-4552-a89a-2b868bc9ab20.jpg?1",
             "name": "Veteran Ice Climber",
             "text": "Vigilance\nThis creature can't be blocked.\nWhenever this creature attacks, up to one target player mills cards equal to this creature's power. (They put that many cards from the top of their library into their graveyard.)",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "d32e3ca2-2918-5c4c-b6b9-9d14d861190a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de7dca-0231-4407-86a0-c7fc95f5aaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de7dca-0231-4407-86a0-c7fc95f5aaa0.jpg?1",
             "name": "Wingblade Disciple",
             "text": "Flying\nFlurry \u2014 Whenever you cast your second spell each turn, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "b11a6f7f-5a67-50ca-b3ac-5836e92f25bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a0e24-c332-4558-bb60-f5504ddde88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a0e24-c332-4558-bb60-f5504ddde88c.jpg?1",
             "name": "Wingspan Stride",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\n{2}{U}: Return this Aura to its owner's hand.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "11580597-fe19-520c-bcde-61cd9d1a675a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9367c-f50c-4568-aa63-6760c44ecaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9367c-f50c-4568-aa63-6760c44ecaeb.jpg?1",
             "name": "Winternight Stories",
             "text": "Draw three cards. Then discard two cards unless you discard a creature card.\nHarmonize {4}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "3ef6f351-6508-5897-9d63-4a56b550ceb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66555946-e747-46fa-b1ac-b103a8edcd93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66555946-e747-46fa-b1ac-b103a8edcd93.jpg?1",
             "name": "Abzan Devotee",
             "text": "{1}: Add {W}, {B}, or {G}. Activate only once each turn.\n{2}{B}: Return this card from your graveyard to your hand.",
             "colours": [
@@ -2461,7 +2461,7 @@
         },
         {
             "id": "8ce55b02-57d2-5f8b-b9fc-62d59cc373a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb13a34b-6ac8-47cb-9e91-47106a585fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb13a34b-6ac8-47cb-9e91-47106a585fc1.jpg?1",
             "name": "Adorned Crocodile",
             "text": "When this creature dies, create a 2/2 black Zombie Druid creature token.\nRenew \u2014 {B}, Exile this card from your graveyard: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "5e2a5ac0-b602-58cd-8f06-ff4e75efbdaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993ade84-031f-4a3e-bd68-55f61b559248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993ade84-031f-4a3e-bd68-55f61b559248.jpg?1",
             "name": "Aggressive Negotiations",
             "text": "Target opponent reveals their hand. You choose a nonland card from it and exile that card. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "0f552c64-f190-5137-b416-b310ceee037c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d305609-64f8-4f3f-bf67-cd5257f0d01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d305609-64f8-4f3f-bf67-cd5257f0d01e.jpg?1",
             "name": "Alchemist's Assistant",
             "text": "Lifelink\nRenew \u2014 {1}{B}, Exile this card from your graveyard: Put a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "f46400e2-8d3f-5720-87b5-83e25aa88163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9262bf6-df6a-446c-ba70-18270a09842d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9262bf6-df6a-446c-ba70-18270a09842d.jpg?1",
             "name": "Alesha's Legacy",
             "text": "Target creature you control gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "54cbdf55-0815-5111-ae57-989521583726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5397366-151f-46b0-b9b2-fa4d5bd892d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5397366-151f-46b0-b9b2-fa4d5bd892d8.jpg?1",
             "name": "Avenger of the Fallen",
             "text": "Deathtouch\nMobilize X, where X is the number of creature cards in your graveyard. (Whenever this creature attacks, create X tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)",
             "colours": [
@@ -2630,7 +2630,7 @@
         },
         {
             "id": "5897a44b-b2c0-5e6d-b3ca-e15c926852fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488152ce-2048-4ccb-b2d6-b9628958286f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488152ce-2048-4ccb-b2d6-b9628958286f.jpg?1",
             "name": "Caustic Exhale",
             "text": "As an additional cost to cast this spell, behold a Dragon or pay {1}. (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\nTarget creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "00d93aa3-4e25-5022-82f8-65a542efd0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a2d395-26d6-4eb2-9e8c-ed7dbbd3a8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a2d395-26d6-4eb2-9e8c-ed7dbbd3a8f5.jpg?1",
             "name": "Corroding Dragonstorm",
             "text": "When this enchantment enters, each opponent loses 2 life and you gain 2 life. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "a2951dcd-2e13-5d6c-99a9-29003cc65087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6852b4d5-74e0-44ba-ba44-20aa91e3c4c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6852b4d5-74e0-44ba-ba44-20aa91e3c4c8.jpg?1",
             "name": "Cruel Truths",
             "text": "Surveil 2, then draw two cards. You lose 2 life. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "1e4a898c-eb1d-56cc-8f55-46ac93efcb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119bb72d-aed9-47dc-9285-7bc836cc3776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119bb72d-aed9-47dc-9285-7bc836cc3776.jpg?1",
             "name": "Delta Bloodflies",
             "text": "Flying\nWhenever this creature attacks, if you control a creature with a counter on it, each opponent loses 1 life.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "fa293b8d-3b65-5ce3-a99e-dad6261e62dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc6fd0-42bc-4e8b-96bc-69a631ba7106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc6fd0-42bc-4e8b-96bc-69a631ba7106.jpg?1",
             "name": "Desperate Measures",
             "text": "Target creature gets +1/-1 until end of turn. When it dies under your control this turn, draw two cards.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "900cac44-2838-54bd-a05f-55b123f2093d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6004ff-4180-4332-8b51-960f8c7521d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6004ff-4180-4332-8b51-960f8c7521d9.jpg?1",
             "name": "Dragon's Prey",
             "text": "This spell costs {2} more to cast if it targets a Dragon.\nDestroy target creature.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "b2bbcbbd-6695-5c01-9b4f-408c0d5d880c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Flying, deathtouch\nWhen this creature enters, exile up to two target cards from a single graveyard.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "0120acd4-e5ae-57eb-87fd-c1d8599a2e22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Put a +1/+1 counter on up to one target creature. Draw a card. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "ef01dc6e-35e8-5e01-a70f-b6b6189580c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05ad909-8860-473b-9a30-a322f7670b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05ad909-8860-473b-9a30-a322f7670b32.jpg?1",
             "name": "Gurmag Rakshasa",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, target creature an opponent controls gets -2/-2 until end of turn and target creature you control gets +2/+2 until end of turn.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "894620e7-f101-5f31-9a07-282a2233b3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53adf93-2db5-4087-a2dc-c8f53401d700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53adf93-2db5-4087-a2dc-c8f53401d700.jpg?1",
             "name": "Hundred-Battle Veteran",
             "text": "As long as there are three or more different kinds of counters among creatures you control, this creature gets +2/+4.\nYou may cast this card from your graveyard. If you do, it enters with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "28943f30-e152-53f4-83d8-d370c4684837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177ef64-28bf-4acf-b1f1-c1408f03c411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177ef64-28bf-4acf-b1f1-c1408f03c411.jpg?1",
             "name": "Kin-Tree Nurturer",
             "text": "Lifelink\nWhen this creature enters, it endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "986e47d9-6713-5c38-9adf-2f4629b9c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc66680f-24ab-433a-8197-feac3a174075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc66680f-24ab-433a-8197-feac3a174075.jpg?1",
             "name": "Krumar Initiate",
             "text": "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery. (Put X +1/+1 counters on it or create an X/X white Spirit creature token.)",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "a120f078-8422-5c90-b484-5287c4ad403c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648debd9-d4cf-4788-8882-f1601a3d87f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648debd9-d4cf-4788-8882-f1601a3d87f5.jpg?1",
             "name": "Nightblade Brigade",
             "text": "Deathtouch\nMobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nWhen this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "a5f35eb4-bbc3-5098-a5eb-edf804ee2607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c93a0f6-5e50-4dda-9ff6-da741fb839ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c93a0f6-5e50-4dda-9ff6-da741fb839ff.jpg?1",
             "name": "Qarsi Revenant",
             "text": "Flying, deathtouch, lifelink\nRenew \u2014 {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch counter, and a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -3109,7 +3109,7 @@
         },
         {
             "id": "afa58949-29f5-5e73-a5a1-d725f320dfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31276460-fa9d-47da-85c5-c4baa8074d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31276460-fa9d-47da-85c5-c4baa8074d0d.jpg?1",
             "name": "Rot-Curse Rakshasa",
             "text": "Trample\nDecayed (This creature can't block. When it attacks, sacrifice it at end of combat.)\nRenew \u2014 {X}{B}{B}, Exile this card from your graveyard: Put a decayed counter on each of X target creatures. Activate only as a sorcery.",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "d52e5552-338f-5e19-a813-4270dff6da25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f529a2e-5102-492e-84ab-68541d83b5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f529a2e-5102-492e-84ab-68541d83b5a3.jpg?1",
             "name": "Salt Road Skirmish",
             "text": "Destroy target creature. Create two 1/1 red Warrior creature tokens. They gain haste until end of turn. Sacrifice them at the beginning of the next end step.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "4dd1a262-3f7d-5598-bdf3-c09043064ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4bfebe-f10f-44bd-9368-33e273ba5a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4bfebe-f10f-44bd-9368-33e273ba5a55.jpg?1",
             "name": "Sandskitter Outrider",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, it endures 2. (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "b30a3061-ce20-54eb-b25c-7520aa76f8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg?1",
             "name": "Scavenger Regent // Exude Toxin",
             "text": "",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "4ab899da-900a-576c-822c-ba6ac481381e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg?1",
             "name": "Scavenger Regent // Exude Toxin",
             "text": "",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "8903ebca-b7c9-5e4a-a80f-b840c4f8e22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9f2a62-1c61-4d2e-86d9-18cd84c31748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9f2a62-1c61-4d2e-86d9-18cd84c31748.jpg?1",
             "name": "The Sibsig Ceremony",
             "text": "Creature spells you cast cost {2} less to cast.\nWhenever a creature you control enters, if you cast it, destroy that creature, then create a 2/2 black Zombie Druid creature token.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "845714ec-53bc-57f6-9066-c430842f43c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47374d23-662b-4ba7-a94f-37c9bc759cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47374d23-662b-4ba7-a94f-37c9bc759cc6.jpg?1",
             "name": "Sidisi, Regent of the Mire",
             "text": "{T}, Sacrifice a creature you control with mana value X other than Sidisi: Return target creature card with mana value X plus 1 from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "9aeded27-70dd-560c-a5f7-4f8a726630f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cb5599-7d2c-48e9-978b-902a01a74bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cb5599-7d2c-48e9-978b-902a01a74bde.jpg?1",
             "name": "Sinkhole Surveyor",
             "text": "Flying\nWhenever this creature attacks, you lose 1 life and this creature endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "4b5578c9-d5f6-50a9-8c9f-d8bc4cd0af7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95617742-548d-464a-bb89-a858ffa9018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95617742-548d-464a-bb89-a858ffa9018f.jpg?1",
             "name": "Strategic Betrayal",
             "text": "Target opponent exiles a creature they control and their graveyard.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "d98af773-ed46-5b78-8f36-cf9cddcbeafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab5e71e-dc8d-4ed8-bcef-6497177c4a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab5e71e-dc8d-4ed8-bcef-6497177c4a9d.jpg?1",
             "name": "Unburied Earthcarver",
             "text": "{2}, Sacrifice another creature: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "bc64c117-3407-53e5-972a-37409853e2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6394b125-21a8-4439-9958-94b76684138e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6394b125-21a8-4439-9958-94b76684138e.jpg?1",
             "name": "Unrooted Ancestor",
             "text": "Flash\n{1}, Sacrifice another creature: This creature gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "20e9643e-2123-573a-84e0-bc4b69516901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4e985-facd-47e6-b680-3023c82c2957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4e985-facd-47e6-b680-3023c82c2957.jpg?1",
             "name": "Venerated Stormsinger",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nWhenever this creature or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "c38a53e5-62b6-5a9d-b438-bcecde7ec4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9430dd-f583-400d-808a-64e2b5fa54f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9430dd-f583-400d-808a-64e2b5fa54f1.jpg?1",
             "name": "Wail of War",
             "text": "Choose one \u2014\n\u2022 Creatures target opponent controls get -1/-1 until end of turn.\n\u2022 Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "363e307a-d1a6-5812-823d-6cc70273be10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc18edc-01d8-4a7e-a87b-a854e50aa75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc18edc-01d8-4a7e-a87b-a854e50aa75e.jpg?1",
             "name": "Worthy Cost",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nExile target creature or planeswalker.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "b1befaad-d222-520e-aaf8-e284d0535c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e65d487-705a-4c3b-9bb6-69351e5dae81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e65d487-705a-4c3b-9bb6-69351e5dae81.jpg?1",
             "name": "Yathan Tombguard",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever a creature you control with a counter on it deals combat damage to a player, you draw a card and you lose 1 life.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "4d83e66d-0c88-5331-9d1f-25e33333bba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c2a069-7553-4879-abfb-b2aa3349e4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c2a069-7553-4879-abfb-b2aa3349e4b8.jpg?1",
             "name": "Breaching Dragonstorm",
             "text": "When this enchantment enters, exile cards from the top of your library until you exile a nonland card. You may cast it without paying its mana cost if that spell's mana value is 8 or less. If you don't, put that card into your hand.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "0bd1269f-ac1b-536b-9f98-ec32bc8e0634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24204881-690c-4043-8771-20cb93385072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24204881-690c-4043-8771-20cb93385072.jpg?1",
             "name": "Channeled Dragonfire",
             "text": "Channeled Dragonfire deals 2 damage to any target.\nHarmonize {5}{R}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "914298c5-4bfa-55e8-b398-25e109183c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg?1",
             "name": "Cori-Steel Cutter",
             "text": "Equipped creature gets +1/+1 and has trample and haste.\nFlurry \u2014 Whenever you cast your second spell each turn, create a 1/1 white Monk creature token with prowess. You may attach this Equipment to it. (Whenever you cast a noncreature spell, the token gets +1/+1 until end of turn.)\nEquip {1}{R}",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "e77b3601-57bf-5e9f-a6d5-93d3e8d2ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9c673-37b4-48ed-a9ea-13f8e3e6c47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9c673-37b4-48ed-a9ea-13f8e3e6c47b.jpg?1",
             "name": "Devoted Duelist",
             "text": "Haste\nFlurry \u2014 Whenever you cast your second spell each turn, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -3770,7 +3770,7 @@
         },
         {
             "id": "51c8c874-9bfa-5af6-8570-b6ab9d63ba2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5674f9-22b2-45f9-902d-4fd245485c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5674f9-22b2-45f9-902d-4fd245485c60.jpg?1",
             "name": "Dracogenesis",
             "text": "You may cast Dragon spells without paying their mana costs.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "997f1a78-c793-5f29-85be-6a5b3c4bf2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ba6d74-c6be-4a5e-8859-b791bb6b8f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ba6d74-c6be-4a5e-8859-b791bb6b8f51.jpg?1",
             "name": "Equilibrium Adept",
             "text": "When this creature enters, exile the top card of your library. Until the end of your next turn, you may play that card.\nFlurry \u2014 Whenever you cast your second spell each turn, this creature gains double strike until end of turn.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "1e058df0-8555-5e70-8ab3-855ece3f0388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dc1bf4-a135-449f-848f-361a5360fae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dc1bf4-a135-449f-848f-361a5360fae1.jpg?1",
             "name": "Fire-Rim Form",
             "text": "Flash\nEnchant creature\nWhen this Aura enters, enchanted creature gains first strike until end of turn.\nEnchanted creature gets +2/+0.",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "e5aecc5e-d228-5a3c-a2c0-e029dbd8b994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1971fd6c-0a1c-41b2-93a6-886a176fbb73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1971fd6c-0a1c-41b2-93a6-886a176fbb73.jpg?1",
             "name": "Fleeting Effigy",
             "text": "Haste\nAt the beginning of your end step, return this creature to its owner's hand. (Return it only if it's on the battlefield.)\n{2}{R}: This creature gets +2/+0 until end of turn.",
             "colours": [
@@ -3909,7 +3909,7 @@
         },
         {
             "id": "1007ad24-7288-5165-a8a0-19d983ae9eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbc8b-2bf8-478e-a541-f8019d150054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbc8b-2bf8-478e-a541-f8019d150054.jpg?1",
             "name": "Iridescent Tiger",
             "text": "When this creature enters, if you cast it, add {W}{U}{B}{R}{G}.",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "4db22f04-9204-590f-9f1e-6702f01ef8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f31f9c-7149-4608-9b18-b3530a2efd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f31f9c-7149-4608-9b18-b3530a2efd4a.jpg?1",
             "name": "Jeskai Devotee",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, this creature gets +1/+1 until end of turn.\n{1}: Add {U}, {R}, or {W}. Activate only once each turn.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "f7d05183-821d-57ff-ac3d-210dee74c890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b3aec8-d931-4c7f-86b5-1e7dfb717b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b3aec8-d931-4c7f-86b5-1e7dfb717b59.jpg?1",
             "name": "Magmatic Hellkite",
             "text": "Flying\nWhen this creature enters, destroy target nonbasic land an opponent controls. Its controller searches their library for a basic land card, puts it onto the battlefield tapped with a stun counter on it, then shuffles. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "ff94af76-5353-599a-9a44-886a205cec62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf4c9dd-0546-41ac-a7ba-0bc312fef31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf4c9dd-0546-41ac-a7ba-0bc312fef31e.jpg?1",
             "name": "Meticulous Artisan",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -4055,7 +4055,7 @@
         },
         {
             "id": "df6caa4f-d16e-5115-9ea5-11962a8b64cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab95aab-a4bf-4131-83a0-2c138b6f20c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab95aab-a4bf-4131-83a0-2c138b6f20c3.jpg?1",
             "name": "Molten Exhale",
             "text": "You may cast this spell as though it had flash if you behold a Dragon as an additional cost to cast it. (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\nMolten Exhale deals 4 damage to target creature or planeswalker.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "694dd7d6-68c3-5ff4-a95b-daf91496a2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5098bd73-d51c-4db4-bf06-fd4854089d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5098bd73-d51c-4db4-bf06-fd4854089d37.jpg?1",
             "name": "Narset's Rebuke",
             "text": "Narset's Rebuke deals 5 damage to target creature. Add {U}{R}{W}. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "3377808a-5028-5425-a1b5-f21bebf92a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7af85f-354e-468a-990b-bd774e68240f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7af85f-354e-468a-990b-bd774e68240f.jpg?1",
             "name": "Overwhelming Surge",
             "text": "Choose one or both \u2014\n\u2022 Overwhelming Surge deals 3 damage to target creature.\n\u2022 Destroy target noncreature artifact.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "44cb3635-ead0-555b-92a7-8aa58ea84507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056136a8-84be-477c-b654-63238fb8236e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056136a8-84be-477c-b654-63238fb8236e.jpg?1",
             "name": "Rescue Leopard",
             "text": "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4187,7 +4187,7 @@
         },
         {
             "id": "42fe6060-40d9-5ba9-9d2f-1881805ce2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af19ce8-bc0c-420c-9e3b-9059b4df32cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af19ce8-bc0c-420c-9e3b-9059b4df32cb.jpg?1",
             "name": "Reverberating Summons",
             "text": "At the beginning of each combat, if you've cast two or more spells this turn, this enchantment becomes a 3/3 Monk creature with haste in addition to its other types until end of turn.\n{1}{R}, Discard your hand, Sacrifice this enchantment: Draw two cards.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "a496e8ba-a448-58c1-9332-973fd04d7027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2200646-7b7c-489d-bbae-16b03e1d7fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2200646-7b7c-489d-bbae-16b03e1d7fb2.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token. (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\nWhenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "ad93fbdf-f66b-5566-9d1b-172a091b876d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7818d28-b9a5-4341-9adc-666070b8878d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7818d28-b9a5-4341-9adc-666070b8878d.jpg?1",
             "name": "Seize Opportunity",
             "text": "Choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Up to two target creatures each get +2/+1 until end of turn.",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "58083b32-90ea-5c18-b8f7-6f22308f578a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66940466-8e9d-4a85-bfb0-e92189b7a121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66940466-8e9d-4a85-bfb0-e92189b7a121.jpg?1",
             "name": "Shock Brigade",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nMobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "d859d0c0-142c-5f69-a3dd-9b1995fb2f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a10342d-ca04-4d1e-bca9-79f531951a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a10342d-ca04-4d1e-bca9-79f531951a16.jpg?1",
             "name": "Shocking Sharpshooter",
             "text": "Reach\nWhenever another creature you control enters, this creature deals 1 damage to target opponent.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "8093c4a6-1844-5d2b-9a98-b0e0884701bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4ab2a-a06a-4768-b5e1-e1def957d7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4ab2a-a06a-4768-b5e1-e1def957d7f4.jpg?1",
             "name": "Stadium Headliner",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\n{1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control to target creature.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "9709ca48-4092-5e8b-8e3e-c663bccec9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac43386-bd32-425c-8776-cec00b064cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac43386-bd32-425c-8776-cec00b064cbc.jpg?1",
             "name": "Stormscale Scion",
             "text": "Flying\nOther Dragons you control get +1/+1.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. Copies become tokens.)",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "62d2d50b-77ba-5cca-9558-5c5ec1c9e3d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Flying, haste\n{1}{R}: This creature gets +1/+0 until end of turn.",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "1205d7f8-2685-55b5-a2b4-099ffa187b46",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Discard a card. If you do, draw two cards. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "9e49031e-4985-5494-abb4-e322feec7c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cba0b1-7c22-4e51-b9cf-5bf01e67a222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cba0b1-7c22-4e51-b9cf-5bf01e67a222.jpg?1",
             "name": "Summit Intimidator",
             "text": "Reach\nWhen this creature enters, target creature can't block this turn.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "3c9634a4-1105-5360-b8cc-2499fd66b3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1a2f2-526d-4b2c-985b-0acfdc21a2ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1a2f2-526d-4b2c-985b-0acfdc21a2ee.jpg?1",
             "name": "Sunset Strikemaster",
             "text": "{T}: Add {R}.\n{2}{R}, {T}, Sacrifice this creature: It deals 6 damage to target creature with flying.",
             "colours": [
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "35630003-15d5-5c62-8936-13dbd9f1aede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e96b34-b1c4-4647-a38e-2cf1aedaaace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e96b34-b1c4-4647-a38e-2cf1aedaaace.jpg?1",
             "name": "Tersa Lightshatter",
             "text": "Haste\nWhen Tersa Lightshatter enters, discard up to two cards, then draw that many cards.\nWhenever Tersa Lightshatter attacks, if there are seven or more cards in your graveyard, exile a card at random from your graveyard. You may play that card this turn.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "9265667c-9d77-5f33-a70f-a070db00a117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688d8e93-d071-4089-9ef9-565ac4ae9ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688d8e93-d071-4089-9ef9-565ac4ae9ae0.jpg?1",
             "name": "Twin Bolt",
             "text": "Twin Bolt deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "cf7aa213-1bcd-592d-8207-eb55fb8ee3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049acc79-1d68-410f-a081-88a7d40e823a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049acc79-1d68-410f-a081-88a7d40e823a.jpg?1",
             "name": "Underfoot Underdogs",
             "text": "When this creature enters, create a 1/1 red Goblin creature token.\n{1}, {T}: Target creature you control with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "2af0e309-78f9-563b-9f11-234f5eee67a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f5e5e-d87f-4aee-84e3-28afe8e21591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f5e5e-d87f-4aee-84e3-28afe8e21591.jpg?1",
             "name": "Unsparing Boltcaster",
             "text": "When this creature enters, it deals 5 damage to target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "0fbc403f-68e0-5e40-8263-6a7cdb8aaac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7f0413-c009-4c08-b877-9c1b776cbf26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7f0413-c009-4c08-b877-9c1b776cbf26.jpg?1",
             "name": "War Effort",
             "text": "Creatures you control get +1/+0.\nWhenever you attack, create a 1/1 red Warrior creature token that's tapped and attacking. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "5e66aa98-36e0-5c51-b5f6-1ae98b07a30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8c6f5-6135-428e-8476-1751f82623f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8c6f5-6135-428e-8476-1751f82623f9.jpg?1",
             "name": "Wild Ride",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nHarmonize {4}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "7103934d-6cff-5c0c-8a80-f0617c47a3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa3501-5738-4063-a7f4-51d2600b0041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa3501-5738-4063-a7f4-51d2600b0041.jpg?1",
             "name": "Zurgo's Vanguard",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nThis creature's power is equal to the number of creatures you control.",
             "colours": [
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "a81cb159-e6dd-576d-aacb-e672054798b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57695a9b-8f72-4ccc-a946-5d5037b09b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57695a9b-8f72-4ccc-a946-5d5037b09b8f.jpg?1",
             "name": "Ainok Wayfarer",
             "text": "When this creature enters, mill three cards. You may put a land card from among them into your hand. If you don't, put a +1/+1 counter on this creature. (To mill three cards, put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -4851,7 +4851,7 @@
         },
         {
             "id": "79d1d88e-a603-5f4f-a399-709a97289ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4f502-86a9-49fb-9cb9-7918d13c5313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4f502-86a9-49fb-9cb9-7918d13c5313.jpg?1",
             "name": "Attuned Hunter",
             "text": "Trample\nWhenever one or more cards leave your graveyard during your turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "4af6371b-944b-598e-89e0-265bca597d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg?1",
             "name": "Bloomvine Regent // Claim Territory",
             "text": "",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "831bd9e8-299e-594a-a38e-7df008fff612",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg?1",
             "name": "Bloomvine Regent // Claim Territory",
             "text": "",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "32283932-026d-5cbb-aec6-10c6e91e0f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c51dcdab-38ee-4804-8859-09adc353c182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c51dcdab-38ee-4804-8859-09adc353c182.jpg?1",
             "name": "Champion of Dusan",
             "text": "Trample\nRenew \u2014 {1}{G}, Exile this card from your graveyard: Put a +1/+1 counter and a trample counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "6ec5cd9b-aea6-54f0-8332-bc71ff98f5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f5cee-a501-4658-bd4d-7a044bf1ccbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f5cee-a501-4658-bd4d-7a044bf1ccbc.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen this creature enters, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "87dfbf12-7a6b-5720-b7b9-ac5826ba4568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074b1e00-45bb-4436-8f5e-058512b2d08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074b1e00-45bb-4436-8f5e-058512b2d08a.jpg?1",
             "name": "Dragon Sniper",
             "text": "Vigilance, reach, deathtouch",
             "colours": [
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "09d44499-6796-5ff1-9aa5-f9517ea63776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d634087-77ba-4543-aa7a-8a3774d69cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d634087-77ba-4543-aa7a-8a3774d69cd7.jpg?1",
             "name": "Dragonbroods' Relic",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color.\n{3}{W}{U}{B}{R}{G}, Sacrifice this artifact: Create a 4/4 Dragon creature token named Reliquary Dragon that's all colors. It has flying, lifelink, and \"When this token enters, it deals 3 damage to any target.\" Activate only as a sorcery.",
             "colours": [
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "03619678-7720-578e-b980-96beb524ced1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98ecc96-f557-479a-8685-2b5487d5b407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98ecc96-f557-479a-8685-2b5487d5b407.jpg?1",
             "name": "Dusyut Earthcarver",
             "text": "Reach\nWhen this creature enters, it endures 3. (Put three +1/+1 counters on it or create a 3/3 white Spirit creature token.)",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "4dab92ca-65dd-540b-bf3c-070d2b8c376b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddd4477-f8c9-4d05-9177-f8344ba8f40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddd4477-f8c9-4d05-9177-f8344ba8f40b.jpg?1",
             "name": "Encroaching Dragonstorm",
             "text": "When this enchantment enters, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "71b4fc95-7bf8-5ab7-9a42-88048c9c4ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8e8f-3ef6-4339-8c66-68c5aca4867a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8e8f-3ef6-4339-8c66-68c5aca4867a.jpg?1",
             "name": "Formation Breaker",
             "text": "Creatures with power less than this creature's power can't block it.\nAs long as you control a creature with a counter on it, this creature gets +1/+2.",
             "colours": [
@@ -5202,7 +5202,7 @@
         },
         {
             "id": "76bdf413-e394-57ef-8eac-287016377485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c7713-b3a9-4685-b1d3-623d35b62365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c7713-b3a9-4685-b1d3-623d35b62365.jpg?1",
             "name": "Herd Heirloom",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\n{T}: Until end of turn, target creature you control with power 4 or greater gains trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "532f9a7d-25f1-5ea3-aa86-b8ccb35811ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8fee37-a050-4329-8b10-46d150e7a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8fee37-a050-4329-8b10-46d150e7a95e.jpg?1",
             "name": "Heritage Reclamation",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile up to one target card from a graveyard. Draw a card.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "575ba3a6-243d-5380-ab73-f15049bc6fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c642d6ac-f0f0-4b4c-a7ee-50631531f6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c642d6ac-f0f0-4b4c-a7ee-50631531f6d1.jpg?1",
             "name": "Inspirited Vanguard",
             "text": "Whenever this creature enters or attacks, it endures 2. (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)",
             "colours": [
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "35e9c2d7-1656-5560-a370-840c0a11a662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d218831-2a41-46a3-8e9d-93462cae5cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d218831-2a41-46a3-8e9d-93462cae5cab.jpg?1",
             "name": "Knockout Maneuver",
             "text": "Put a +1/+1 counter on target creature you control, then it deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "51ee683d-554a-5e04-b613-9d4385ad9535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d0a9fb-1068-478d-a78c-6fd77cc313f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d0a9fb-1068-478d-a78c-6fd77cc313f0.jpg?1",
             "name": "Krotiq Nestguard",
             "text": "Defender\n{2}{G}: This creature can attack this turn as though it didn't have defender.",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "43417fc1-214a-5280-a1f9-757f3d65d4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f5c8ef-8e9e-4264-a7d2-126a30a5d341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f5c8ef-8e9e-4264-a7d2-126a30a5d341.jpg?1",
             "name": "Lasyd Prowler",
             "text": "When this creature enters, you may mill cards equal to the number of lands you control.\nRenew \u2014 {1}{G}, Exile this card from your graveyard: Put X +1/+1 counters on target creature, where X is the number of land cards in your graveyard. Activate only as a sorcery.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "309fef85-6d9b-5234-8651-1e4c5c9c2e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397d904-c51d-451e-8505-7f3118acc1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397d904-c51d-451e-8505-7f3118acc1f6.jpg?1",
             "name": "Nature's Rhythm",
             "text": "Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.\nHarmonize {X}{G}{G}{G}{G} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by an amount of generic mana equal to its power. Then exile this spell.)",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "4b9d9df0-d051-5111-9604-e89c265bc585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a0deb9-5bc3-42d5-9e1e-5f463d176aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a0deb9-5bc3-42d5-9e1e-5f463d176aef.jpg?1",
             "name": "Piercing Exhale",
             "text": "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)\nTarget creature you control deals damage equal to its power to target creature or planeswalker. If a Dragon was beheld, surveil 2.",
             "colours": [
@@ -5472,7 +5472,7 @@
         },
         {
             "id": "ac3dfb86-94c2-58b9-a638-1fe550342653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc5c316-6a41-48ba-864b-da3030dd3e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc5c316-6a41-48ba-864b-da3030dd3e0e.jpg?1",
             "name": "Rainveil Rejuvenator",
             "text": "When this creature enters, you may mill three cards. (You may put the top three cards of your library into your graveyard.)\n{T}: Add an amount of {G} equal to this creature's power.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "b39aa61c-7a73-5aad-b0cb-161437f86c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737698a-d934-4851-b238-828959ef4835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737698a-d934-4851-b238-828959ef4835.jpg?1",
             "name": "Rite of Renewal",
             "text": "Return up to two target permanent cards from your graveyard to your hand. Target player shuffles up to four target cards from their graveyard into their library. Exile Rite of Renewal.",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "3d811e19-2b06-538f-89c9-042769ea7bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8c2d5c-ba0c-4d50-8898-5c6574b1e974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8c2d5c-ba0c-4d50-8898-5c6574b1e974.jpg?1",
             "name": "Roamer's Routine",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nHarmonize {4}{G} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "f79c0e7e-3d74-5fd4-bfc4-a321f2e1b042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebf4a9d-d90c-4017-9f00-fca89899f301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebf4a9d-d90c-4017-9f00-fca89899f301.jpg?1",
             "name": "Sage of the Fang",
             "text": "When this creature enters, put a +1/+1 counter on target creature.\nRenew \u2014 {3}{G}, Exile this card from your graveyard: Put a +1/+1 counter on target creature, then double the number of +1/+1 counters on that creature. Activate only as a sorcery.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "7ada5b5a-1f3a-5beb-b086-4bfddfa0e3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def9cb5b-4062-481e-b682-3a30443c2e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def9cb5b-4062-481e-b682-3a30443c2e56.jpg?1",
             "name": "Sagu Pummeler",
             "text": "Reach\nRenew \u2014 {4}{G}, Exile this card from your graveyard: Put two +1/+1 counters and a reach counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "5a1e59f8-b2ba-5bb8-873c-d9bf96758acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Flying\nWhen this creature enters, you gain 3 life.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "60e631dd-3511-539a-a0a1-ccf76eeee5df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle. (Also shuffle this card.)",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "c0f3427e-19ca-5a33-81c0-127db358fd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae56fef-b661-4bc5-b9a1-3871ae06e491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae56fef-b661-4bc5-b9a1-3871ae06e491.jpg?1",
             "name": "Sarkhan's Resolve",
             "text": "Choose one \u2014\n\u2022 Target creature gets +3/+3 until end of turn.\n\u2022 Destroy target creature with flying.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "220afd9d-cbb5-5e56-8f58-cedde65bed6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d2c692-7566-468e-9c86-47a9f768fde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d2c692-7566-468e-9c86-47a9f768fde2.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5776,7 +5776,7 @@
         },
         {
             "id": "48a54fcc-7517-5fae-b18d-e99aaffd1eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32487e9-f3ac-472e-b6ea-81bd9254770c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32487e9-f3ac-472e-b6ea-81bd9254770c.jpg?1",
             "name": "Sultai Devotee",
             "text": "Deathtouch\n{1}: Add {B}, {G}, or {U}. Activate only once each turn.",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "3d9fc7ef-55d6-575e-a1c9-c5117c919e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4775a26-0b66-40e9-8f64-41d9308ca032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4775a26-0b66-40e9-8f64-41d9308ca032.jpg?1",
             "name": "Surrak, Elusive Hunter",
             "text": "This spell can't be countered.\nTrample\nWhenever a creature you control or a creature spell you control becomes the target of a spell or ability an opponent controls, draw a card.",
             "colours": [
@@ -5853,7 +5853,7 @@
         },
         {
             "id": "f5bd431d-2983-52ba-88db-0cf0349f540d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f721f8d-fd2f-480b-8645-4bf6ce38dde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f721f8d-fd2f-480b-8645-4bf6ce38dde9.jpg?1",
             "name": "Synchronized Charge",
             "text": "Distribute two +1/+1 counters among one or two target creatures you control. Creatures you control with counters on them gain vigilance and trample until end of turn.\nHarmonize {4}{G} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -5885,7 +5885,7 @@
         },
         {
             "id": "5cc57a65-08d3-5816-9408-10fffb64e1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c89d95-d697-4cfa-9dfa-52d7adb96176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c89d95-d697-4cfa-9dfa-52d7adb96176.jpg?1",
             "name": "Trade Route Envoy",
             "text": "When this creature enters, draw a card if you control a creature with a counter on it. If you don't draw a card this way, put a +1/+1 counter on this creature.",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "b13bfeb2-42ab-55d9-9295-cbd7adbf74b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890b11b4-777a-4f1e-8c4d-21c5ebbfb0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890b11b4-777a-4f1e-8c4d-21c5ebbfb0a2.jpg?1",
             "name": "Traveling Botanist",
             "text": "Whenever this creature becomes tapped, look at the top card of your library. If it's a land card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "f3be5f9d-3487-52e1-8a60-26d1dea58930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8f9a-b17c-452f-b4ef-a3f91909e3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8f9a-b17c-452f-b4ef-a3f91909e3de.jpg?1",
             "name": "Undergrowth Leopard",
             "text": "Vigilance\n{1}, Sacrifice this creature: Destroy target artifact or enchantment.",
             "colours": [
@@ -5989,7 +5989,7 @@
         },
         {
             "id": "19ae21a6-f2d5-5627-b3bc-da5e6d9c628f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2414db96-0e2b-4f7c-9b97-41f8e310b752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2414db96-0e2b-4f7c-9b97-41f8e310b752.jpg?1",
             "name": "Warden of the Grove",
             "text": "At the beginning of your end step, put a +1/+1 counter on this creature.\nWhenever another nontoken creature you control enters, it endures X, where X is the number of counters on this creature. (Put X +1/+1 counters on the creature that entered or create an X/X white Spirit creature token.)",
             "colours": [
@@ -6025,7 +6025,7 @@
         },
         {
             "id": "d249c274-5f3f-57f4-9102-da6d0b515b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74876d8-f6a6-4b47-b960-b01a331bab01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74876d8-f6a6-4b47-b960-b01a331bab01.jpg?1",
             "name": "All-Out Assault",
             "text": "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment enters, if it's your main phase, there is an additional combat phase after this phase followed by an additional main phase. When you next attack this turn, untap each creature you control.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "c6508d07-4b04-5042-b097-97f66b908f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f61c01-0a41-4fa1-ac34-ffa83baad989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f61c01-0a41-4fa1-ac34-ffa83baad989.jpg?1",
             "name": "Armament Dragon",
             "text": "Flying\nWhen this creature enters, distribute three +1/+1 counters among one, two, or three target creatures you control.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "b241adf3-0d69-5855-99b9-84e095897fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f94ad-65d6-4c7d-925d-165ef264626f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f94ad-65d6-4c7d-925d-165ef264626f.jpg?1",
             "name": "Auroral Procession",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -6139,7 +6139,7 @@
         },
         {
             "id": "0860270f-fa0b-535d-96b4-a375cca0ec72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14078a49-2230-4ad7-aea0-0c253813c646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14078a49-2230-4ad7-aea0-0c253813c646.jpg?1",
             "name": "Awaken the Honored Dead",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target nonland permanent.\nII \u2014 Mill three cards.\nIII \u2014 You may discard a card. When you do, return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "9410b8b5-8f1f-5b9b-a9c3-ba199b8c5f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2556a35b-2229-42c7-8cb3-c8c668403dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2556a35b-2229-42c7-8cb3-c8c668403dd2.jpg?1",
             "name": "Barrensteppe Siege",
             "text": "As this enchantment enters, choose Abzan or Mardu.\n\u2022 Abzan \u2014 At the beginning of your end step, put a +1/+1 counter on each creature you control.\n\u2022 Mardu \u2014 At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "6dc09ffa-7a9b-5110-890b-7352b5bdf8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b475b071-5545-483e-a397-89451f258602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b475b071-5545-483e-a397-89451f258602.jpg?1",
             "name": "Betor, Kin to All",
             "text": "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "d3263501-ae28-5838-b397-54c13f5f6c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf36bc-6702-4c5d-b52d-ab7217cc8787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf36bc-6702-4c5d-b52d-ab7217cc8787.jpg?1",
             "name": "Bone-Cairn Butcher",
             "text": "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\nAttacking tokens you control have deathtouch.",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "ccd54215-0baf-53d6-9533-6065f5a39fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ad91db-5f16-4392-baf1-f8400ec11e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ad91db-5f16-4392-baf1-f8400ec11e0a.jpg?1",
             "name": "Call the Spirit Dragons",
             "text": "Dragons you control have indestructible.\nAt the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control of that color. If you put +1/+1 counters on five Dragons this way, you win the game.",
             "colours": [
@@ -6339,7 +6339,7 @@
         },
         {
             "id": "03016f67-fe67-5325-a191-9f06196371c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cbf54e-f30e-4e7b-b17c-217fa424971c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cbf54e-f30e-4e7b-b17c-217fa424971c.jpg?1",
             "name": "Cori Mountain Stalwart",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, this creature deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -6376,7 +6376,7 @@
         },
         {
             "id": "22234ee0-03f6-583f-8841-26872116c3aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faab43d-587d-44f6-9516-c8e3965bbc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faab43d-587d-44f6-9516-c8e3965bbc20.jpg?1",
             "name": "Death Begets Life",
             "text": "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "f39f0a34-b27f-5842-9f57-4c9951491f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a18cf-03db-4eb0-8d53-0c1a71e184da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a18cf-03db-4eb0-8d53-0c1a71e184da.jpg?1",
             "name": "Defibrillating Current",
             "text": "Defibrillating Current deals 4 damage to target creature or planeswalker and you gain 2 life.",
             "colours": [
@@ -6452,7 +6452,7 @@
         },
         {
             "id": "9982f6ef-e616-5b0d-ba61-7e8d3534c060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Flying\nWhen this creature enters, destroy up to one target artifact or enchantment.",
             "colours": [
@@ -6489,7 +6489,7 @@
         },
         {
             "id": "1de8a051-80eb-53b6-94f5-30b1a9cbc607",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Destroy target creature with power 3 or less. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -6526,7 +6526,7 @@
         },
         {
             "id": "989d1917-e3fe-53b2-a4fa-8571dbf5b5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54cc838-d79d-433a-99fb-d6e4d1c1431d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54cc838-d79d-433a-99fb-d6e4d1c1431d.jpg?1",
             "name": "Dragonback Assault",
             "text": "When this enchantment enters, it deals 3 damage to each creature and each planeswalker.\nLandfall \u2014 Whenever a land you control enters, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "d776213e-0bf8-531c-b61f-1ac18957b728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7692ef-7091-4365-85a8-1edbd374f279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7692ef-7091-4365-85a8-1edbd374f279.jpg?1",
             "name": "Dragonclaw Strike",
             "text": "Double the power and toughness of target creature you control until end of turn. Then it fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "95358c96-720d-52fe-abc6-19cfdd6a943c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae03ca5-cd4b-42b7-8cd5-3f7e753b4147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae03ca5-cd4b-42b7-8cd5-3f7e753b4147.jpg?1",
             "name": "Effortless Master",
             "text": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)\nThis creature enters with two +1/+1 counters on it if you've cast two or more spells this turn.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "545d78ef-9ec5-5c45-a2d2-71861696851a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d369c44-78ee-4f3c-bf2b-cddba7fe26d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d369c44-78ee-4f3c-bf2b-cddba7fe26d4.jpg?1",
             "name": "Eshki Dragonclaw",
             "text": "Vigilance, trample, ward {1}\nAt the beginning of combat on your turn, if you've cast both a creature spell and a noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "70c7b210-fc7f-5f73-83fd-458813deceee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655fa2e1-3e1c-424c-b17a-daa7b8fface4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655fa2e1-3e1c-424c-b17a-daa7b8fface4.jpg?1",
             "name": "Fangkeeper's Familiar",
             "text": "Flash\nWhen this creature enters, choose one \u2014\n\u2022 You gain 3 life and surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n\u2022 Destroy target enchantment.\n\u2022 Counter target creature spell.",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "c1f7ce4c-092d-5d47-8740-bf6357b2f239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e11f20-6524-4fba-9603-0b97e2d69aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e11f20-6524-4fba-9603-0b97e2d69aac.jpg?1",
             "name": "Felothar, Dawn of the Abzan",
             "text": "Trample\nWhenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6763,7 +6763,7 @@
         },
         {
             "id": "65c1fb47-dcd9-5c1f-8e49-1aa6ddb0a06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8443a6-282f-4218-9dc8-144b5570d891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8443a6-282f-4218-9dc8-144b5570d891.jpg?1",
             "name": "Flamehold Grappler",
             "text": "First strike\nWhen this creature enters, copy the next spell you cast this turn when you cast it. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "cc54256c-4c49-5a08-b1fe-76a0b899998a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce8a205-99d6-4a9c-83a7-18b7220177d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce8a205-99d6-4a9c-83a7-18b7220177d3.jpg?1",
             "name": "Frontline Rush",
             "text": "Choose one \u2014\n\u2022 Create two 1/1 red Goblin creature tokens.\n\u2022 Target creature gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "d2b9c781-b783-523d-b488-05c37af8b91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a750aabb-9788-494a-841f-bf75717970a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a750aabb-9788-494a-841f-bf75717970a7.jpg?1",
             "name": "Frostcliff Siege",
             "text": "As this enchantment enters, choose Jeskai or Temur.\n\u2022 Jeskai \u2014 Whenever one or more creatures you control deal combat damage to a player, draw a card.\n\u2022 Temur \u2014 Creatures you control get +1/+0 and have trample and haste.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "79dfdc0b-b3fb-50d6-ad83-56aa0d61cd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95994c88-e404-4a4f-8be6-b99d703d4609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95994c88-e404-4a4f-8be6-b99d703d4609.jpg?1",
             "name": "Glacial Dragonhunt",
             "text": "Draw a card, then you may discard a card. When you discard a nonland card this way, Glacial Dragonhunt deals 3 damage to target creature.\nHarmonize {4}{U}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "00ddf81f-e719-5099-9a97-7142885c2c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f37fad7-2385-409b-8375-fa5dfbcad833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f37fad7-2385-409b-8375-fa5dfbcad833.jpg?1",
             "name": "Glacierwood Siege",
             "text": "As this enchantment enters, choose Temur or Sultai.\n\u2022 Temur \u2014 Whenever you cast an instant or sorcery spell, target player mills four cards.\n\u2022 Sultai \u2014 You may play lands from your graveyard.",
             "colours": [
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "c25c5b87-ec93-5767-a8e3-9a9d3e40521b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de731430-6bbf-4782-953e-b69c46353959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de731430-6bbf-4782-953e-b69c46353959.jpg?1",
             "name": "Gurmag Nightwatch",
             "text": "When this creature enters, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
             "colours": [
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "7d03cb0a-9c6e-5514-830b-4f7bc526c202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b225cb-5c45-4da1-a64e-b04091e483e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b225cb-5c45-4da1-a64e-b04091e483e8.jpg?1",
             "name": "Hardened Tactician",
             "text": "{1}, Sacrifice a token: Draw a card.",
             "colours": [
@@ -7020,7 +7020,7 @@
         },
         {
             "id": "4682ecf2-2723-57d4-b2b8-6751f7ee3486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac0e136-8877-4bfc-a831-2bf7b7b5ad1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac0e136-8877-4bfc-a831-2bf7b7b5ad1e.jpg?1",
             "name": "Hollowmurk Siege",
             "text": "As this enchantment enters, choose Sultai or Abzan.\n\u2022 Sultai \u2014 Whenever a counter is put on a creature you control, draw a card. This ability triggers only once each turn.\n\u2022 Abzan \u2014 Whenever you attack, put a +1/+1 counter on target attacking creature. It gains menace until end of turn.",
             "colours": [
@@ -7056,7 +7056,7 @@
         },
         {
             "id": "ff73bc5b-1558-5462-86dc-05c295387262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f182957-8133-45a7-80a3-1944bead4d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f182957-8133-45a7-80a3-1944bead4d43.jpg?1",
             "name": "Host of the Hereafter",
             "text": "This creature enters with two +1/+1 counters on it.\nWhenever this creature or another creature you control dies, if it had counters on it, put its counters on up to one target creature you control.",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "67875c08-75fd-51db-b288-149f7a894441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d677980-b608-407e-9f17-790a81263f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d677980-b608-407e-9f17-790a81263f15.jpg?1",
             "name": "Inevitable Defeat",
             "text": "This spell can't be countered.\nExile target nonland permanent. Its controller loses 3 life and you gain 3 life.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "a80842a1-01ba-5d2d-946f-509a5cd7c84f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb06c36-cf7e-47a9-819e-adfc54284153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb06c36-cf7e-47a9-819e-adfc54284153.jpg?1",
             "name": "Jeskai Brushmaster",
             "text": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -7170,7 +7170,7 @@
         },
         {
             "id": "8f3d82fa-0978-536f-9b05-71ae9cae1726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cac0ad3-5107-4ed6-a688-d44bbd65e407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cac0ad3-5107-4ed6-a688-d44bbd65e407.jpg?1",
             "name": "Jeskai Revelation",
             "text": "Return target spell or permanent to its owner's hand. Jeskai Revelation deals 4 damage to any target. Create two 1/1 white Monk creature tokens with prowess. Draw two cards. You gain 4 life.",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "33d8cac4-f528-59cf-8fe6-d2411629915e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec8fa0b-c695-4326-aebd-042cb1974925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec8fa0b-c695-4326-aebd-042cb1974925.jpg?1",
             "name": "Jeskai Shrinekeeper",
             "text": "Flying, haste\nWhenever this creature deals combat damage to a player, you gain 1 life and draw a card.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "d2a65357-3ec3-586d-9a8b-a5c2e30dd9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77b08-c3f6-4458-8636-f226f9843b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77b08-c3f6-4458-8636-f226f9843b6d.jpg?1",
             "name": "Karakyk Guardian",
             "text": "Flying, vigilance, trample\nThis creature has hexproof if it hasn't dealt damage yet. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "11e44f82-3bca-5345-bf0a-dee2588c6c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d11183a-57f5-4ddb-8a6e-15fff704b114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d11183a-57f5-4ddb-8a6e-15fff704b114.jpg?1",
             "name": "Kheru Goldkeeper",
             "text": "Flying\nWhenever one or more cards leave your graveyard during your turn, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nRenew \u2014 {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a flying counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "6e332de8-7b67-50e2-bcc0-33f5ae816ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b577e246-3377-42aa-856e-b9fa89f3603a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b577e246-3377-42aa-856e-b9fa89f3603a.jpg?1",
             "name": "Kin-Tree Severance",
             "text": "Exile target permanent with mana value 3 or greater.",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "ee243735-5c81-5e07-876b-d17ca48e4c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f1acb0-d73e-4814-8158-3645daf5c4cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f1acb0-d73e-4814-8158-3645daf5c4cc.jpg?1",
             "name": "Kishla Skimmer",
             "text": "Flying\nWhenever a card leaves your graveyard during your turn, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "188a5a74-a4bb-5f69-a54f-d6386db0b1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3736f17-f80b-4b2c-b919-2c963bc14682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3736f17-f80b-4b2c-b919-2c963bc14682.jpg?1",
             "name": "Kotis, the Fangkeeper",
             "text": "Indestructible\nWhenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -7444,7 +7444,7 @@
         },
         {
             "id": "f0139f32-f199-51d9-ac76-1cb6b677c851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff22c-282b-4849-82ce-890013b53262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff22c-282b-4849-82ce-890013b53262.jpg?1",
             "name": "Lie in Wait",
             "text": "Return target creature card from your graveyard to your hand. Lie in Wait deals damage equal to that card's power to target creature.",
             "colours": [
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "547f3d1d-261a-5450-abc2-7a86dd7f54b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aa2593-4a79-46f1-a2bd-b71fb504d0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aa2593-4a79-46f1-a2bd-b71fb504d0ab.jpg?1",
             "name": "Lotuslight Dancers",
             "text": "Lifelink\nWhen this creature enters, search your library for a black card, a green card, and a blue card. Put those cards into your graveyard, then shuffle.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "c3d81c5f-7b82-57bd-bc32-6ab0ad13f467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b17b4-79ce-4dfa-8873-a9cfc347e38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b17b4-79ce-4dfa-8873-a9cfc347e38f.jpg?1",
             "name": "Mammoth Bellow",
             "text": "Create a 5/5 green Elephant creature token.\nHarmonize {5}{G}{U}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "e0074151-d042-5905-94d6-311ddc91eef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044b232-edf4-4000-9273-cc4653ad653a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044b232-edf4-4000-9273-cc4653ad653a.jpg?1",
             "name": "Mardu Siegebreaker",
             "text": "Deathtouch, haste\nWhen this creature enters, exile up to one other target creature you control until this creature leaves the battlefield.\nWhenever this creature attacks, for each opponent, create a tapped token that's a copy of the exiled card attacking that opponent. At the beginning of your end step, sacrifice those tokens.",
             "colours": [
@@ -7598,7 +7598,7 @@
         },
         {
             "id": "30fb18af-7adc-54ad-b9fc-f003866f9759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fbaa16-67c3-4ed2-9545-39abbbde61dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fbaa16-67c3-4ed2-9545-39abbbde61dc.jpg?1",
             "name": "Marshal of the Lost",
             "text": "Deathtouch\nWhenever you attack, target creature gets +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -7635,7 +7635,7 @@
         },
         {
             "id": "66054d69-242f-502d-bc77-f780b6a8d13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9eeced-6464-41f0-bbea-05b3af4cc005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9eeced-6464-41f0-bbea-05b3af4cc005.jpg?1",
             "name": "Monastery Messenger",
             "text": "Flying, vigilance\nWhen this creature enters, put up to one target noncreature, nonland card from your graveyard on top of your library.",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "7cb21941-9187-52f7-9859-acf604a59373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77cbc1-dbc8-44d9-aa29-15cbb19afecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77cbc1-dbc8-44d9-aa29-15cbb19afecd.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "At the beginning of your end step, you may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "c6a95111-f7b3-58bc-b704-981ee44399fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58112b0-a05c-4b98-b650-fd27ad97789f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58112b0-a05c-4b98-b650-fd27ad97789f.jpg?1",
             "name": "Neriv, Heart of the Storm",
             "text": "Flying\nIf a creature you control that entered this turn would deal damage, it deals twice that much damage instead.",
             "colours": [
@@ -7763,7 +7763,7 @@
         },
         {
             "id": "3354a9f8-1df3-552c-aae6-03fc9c219c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d48f9e-79f0-478c-9db0-ff7ac4a8f401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d48f9e-79f0-478c-9db0-ff7ac4a8f401.jpg?1",
             "name": "New Way Forward",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. When damage is prevented this way, New Way Forward deals that much damage to that source's controller and you draw that many cards.",
             "colours": [
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "41920764-c3e0-5b52-a580-9709b5310d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe7071e-a214-44e8-a571-129f0db44f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe7071e-a214-44e8-a571-129f0db44f76.jpg?1",
             "name": "Perennation",
             "text": "Return target permanent card from your graveyard to the battlefield with a hexproof counter and an indestructible counter on it.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "59851cfc-f7e6-53aa-9c29-17f414551e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Flying\nWard\u2014\nPay 2 life.\nWhen this creature enters, remove all counters from up to one target creature.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "fd02f823-23fd-5c22-883a-c6b98307a20c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Target creature gets +2/+2 and gains lifelink and hexproof until end of turn. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "e5d0f341-c801-59dd-8a79-bee331fb8432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c409f4f-3b2c-4c33-b850-55b2a46f51ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c409f4f-3b2c-4c33-b850-55b2a46f51ca.jpg?1",
             "name": "Rakshasa's Bargain",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "6ecbb40f-83c3-5b74-be2b-fd3d1043e862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6decf-afd5-4e96-b87e-fd7ab7e3c068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6decf-afd5-4e96-b87e-fd7ab7e3c068.jpg?1",
             "name": "Rediscover the Way",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\nIII \u2014 Whenever you cast a noncreature spell this turn, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "33af6e3b-1dfd-513b-8ca1-1567740a6d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a394112a-032b-4047-887a-6522cf7b83d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a394112a-032b-4047-887a-6522cf7b83d5.jpg?1",
             "name": "Reigning Victor",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nWhen this creature enters, target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "495ccff1-2d1c-58cb-a177-f5fb843270ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d0591e-7fb7-40ea-ba2a-cfe544d40216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d0591e-7fb7-40ea-ba2a-cfe544d40216.jpg?1",
             "name": "Reputable Merchant",
             "text": "When this creature enters or dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "cf43733f-454e-5f63-822b-e9aba7033731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd742ff5-f0ea-4f4b-911e-4c09e2154dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd742ff5-f0ea-4f4b-911e-4c09e2154dba.jpg?1",
             "name": "Revival of the Ancestors",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create three 1/1 white Spirit creature tokens.\nII \u2014 Distribute three +1/+1 counters among one, two, or three target creatures you control.\nIII \u2014 Creatures you control gain trample and lifelink until end of turn.",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "8345b71c-e5a8-5aa4-8915-e13fddf729b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686fe623-ee50-407d-87c9-664fb039f4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686fe623-ee50-407d-87c9-664fb039f4d9.jpg?1",
             "name": "Riverwheel Sweep",
             "text": "Tap target creature. Put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nExile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -8143,7 +8143,7 @@
         },
         {
             "id": "8cd2944f-9bcf-5fea-870f-b18892ee869a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9c3531-61a8-43f5-82a2-5166e5f5a6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9c3531-61a8-43f5-82a2-5166e5f5a6b9.jpg?1",
             "name": "Roar of Endless Song",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a 5/5 green Elephant creature token.\nIII \u2014 Double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -8183,7 +8183,7 @@
         },
         {
             "id": "4a71a68d-061a-5faf-945a-046bdf43bbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Flying\nWhenever you cast a noncreature spell or a Dragon spell, this creature gets +2/+0 until end of turn.",
             "colours": [
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "0326e0d3-8af0-510e-9deb-c65029593058",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Counter target spell with mana value 2 or less. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -8257,7 +8257,7 @@
         },
         {
             "id": "039a562e-68c0-57cf-85e7-087da1bd11fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc779a1b-128c-4c74-bebd-bdb687867f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc779a1b-128c-4c74-bebd-bdb687867f68.jpg?1",
             "name": "Severance Priest",
             "text": "Deathtouch\nWhen this creature enters, target opponent reveals their hand. You may choose a nonland card from it. If you do, exile that card.\nWhen this creature leaves the battlefield, the exiled card's owner creates an X/X white Spirit creature token, where X is the mana value of the exiled card.",
             "colours": [
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "885d1973-b375-577f-a6bf-b7207aae3fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8138cf10-1e3e-483f-86ad-cc399192657d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8138cf10-1e3e-483f-86ad-cc399192657d.jpg?1",
             "name": "Shiko, Paragon of the Way",
             "text": "Flying, vigilance\nWhen Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "ccecdfae-a133-555c-83ce-f4bdba0b5a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e9ba1-c254-41e3-9845-4e81f9fec38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e9ba1-c254-41e3-9845-4e81f9fec38d.jpg?1",
             "name": "Skirmish Rhino",
             "text": "Trample\nWhen this creature enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "5c2a2488-b663-5fbc-9ae8-b60cbbe8c169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9523bc07-49e5-409c-ae6b-b28e305eef36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9523bc07-49e5-409c-ae6b-b28e305eef36.jpg?1",
             "name": "Songcrafter Mage",
             "text": "Flash\nWhen this creature enters, target instant or sorcery card in your graveyard gains harmonize until end of turn. Its harmonize cost is equal to its mana cost. (You may cast that card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile the spell.)",
             "colours": [
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "69b8d250-ceaa-5702-b7cb-4565800ef102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c231437-8bec-42e0-9175-af74c752b119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c231437-8bec-42e0-9175-af74c752b119.jpg?1",
             "name": "Sonic Shrieker",
             "text": "Flying\nWhen this creature enters, it deals 2 damage to any target and you gain 2 life. If a player is dealt damage this way, they discard a card.",
             "colours": [
@@ -8464,7 +8464,7 @@
         },
         {
             "id": "2fdfc097-97e4-5610-a7d3-53f8194596f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b206f-8190-46e6-bb9e-44763d3eb4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b206f-8190-46e6-bb9e-44763d3eb4ac.jpg?1",
             "name": "Stalwart Successor",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever one or more counters are put on a creature you control, if it's the first time counters have been put on that creature this turn, put a +1/+1 counter on that creature.",
             "colours": [
@@ -8501,7 +8501,7 @@
         },
         {
             "id": "82150fed-3464-5f9e-bbab-336685b4540c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72184791-0767-4108-920c-763e92dae2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72184791-0767-4108-920c-763e92dae2d4.jpg?1",
             "name": "Temur Battlecrier",
             "text": "During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.",
             "colours": [
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "47469a54-6b24-5e17-ba92-61f4fd69dce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb383f-bc04-46d1-aa3a-7459d57f1fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb383f-bc04-46d1-aa3a-7459d57f1fec.jpg?1",
             "name": "Temur Tawnyback",
             "text": "When this creature enters, draw a card, then discard a card.",
             "colours": [
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "1e071805-cd26-5a7e-a882-535e5d67fd12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a93f5b-7b32-49f0-a179-b897828fe49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a93f5b-7b32-49f0-a179-b897828fe49a.jpg?1",
             "name": "Teval, Arbiter of Virtue",
             "text": "Flying, lifelink\nSpells you cast have delve. (Each card you exile from your graveyard while casting those spells pays for {1}.)\nWhenever you cast a spell, you lose life equal to its mana value.",
             "colours": [
@@ -8625,7 +8625,7 @@
         },
         {
             "id": "b509e306-9b7c-5493-aa45-5225cedf261c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c953b36-f5e4-4258-91cb-f07e799321f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c953b36-f5e4-4258-91cb-f07e799321f7.jpg?1",
             "name": "Thunder of Unity",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You draw two cards and you lose 2 life.\nII, III \u2014 Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -8665,7 +8665,7 @@
         },
         {
             "id": "ea33b50c-09a0-5f64-a692-33f1abc8e4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Flying\nWhen this creature enters, you gain 5 life.",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "5966987d-57ff-577f-8161-d1a5712fc249",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Charring Bite deals 5 damage to target creature without flying. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "f3d6e464-e338-5266-8ffb-7c05062c524d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227802c0-4ff6-43a8-a850-ed0f546dc5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227802c0-4ff6-43a8-a850-ed0f546dc5ac.jpg?1",
             "name": "Ureni, the Song Unending",
             "text": "Flying, protection from white and from black\nWhen Ureni enters, it deals X damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control, where X is the number of lands you control.",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "8a3d21cb-9061-5413-ae3c-e5e836359427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Flash\nFlying\nYou may cast sorcery spells and Dragon spells as though they had flash.",
             "colours": [
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "d2516742-2a1e-5302-8382-e2de4ff3e27f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Put three +1/+1 counters on target creature you control. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "47366dca-0ac2-5560-93f1-f4901d8d3025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a8329b-23a1-4c49-a579-a5da8d01435a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a8329b-23a1-4c49-a579-a5da8d01435a.jpg?1",
             "name": "Windcrag Siege",
             "text": "As this enchantment enters, choose Mardu or Jeskai.\n\u2022 Mardu \u2014 If a creature attacking causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n\u2022 Jeskai \u2014 At the beginning of your upkeep, create a 1/1 red Goblin creature token. It gains lifelink and haste until end of turn.",
             "colours": [
@@ -8893,7 +8893,7 @@
         },
         {
             "id": "d7bae76c-6406-5303-87f5-05ba4c19d6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e77339b-dd82-481c-9ee2-4156ca69ad35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e77339b-dd82-481c-9ee2-4156ca69ad35.jpg?1",
             "name": "Yathan Roadwatcher",
             "text": "When this creature enters, if you cast it, mill four cards. When you do, return target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -8934,7 +8934,7 @@
         },
         {
             "id": "c688ab18-c6fe-5c35-8331-0c976b86a1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd93fb95-4268-45dc-8f0d-590c481a526d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd93fb95-4268-45dc-8f0d-590c481a526d.jpg?1",
             "name": "Zurgo, Thunder's Decree",
             "text": "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\nDuring your end step, Warrior tokens you control have \"This token can't be sacrificed.\"",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "95a09b28-a742-54e4-822c-9daedb6220e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2da9024-3b58-4a57-8f7d-4094c193daee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2da9024-3b58-4a57-8f7d-4094c193daee.jpg?1",
             "name": "Abzan Monument",
             "text": "When this artifact enters, search your library for a basic Plains, Swamp, or Forest card, reveal it, put it into your hand, then shuffle.\n{1}{W}{B}{G}, {T}, Sacrifice this artifact: Create an X/X white Spirit creature token, where X is the greatest toughness among creatures you control. Activate only as a sorcery.",
             "colours": [],
@@ -9009,7 +9009,7 @@
         },
         {
             "id": "c23b0e78-2752-5e1c-bbe8-781651b7157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c6e815-bfe7-4599-9227-d36504a3640f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c6e815-bfe7-4599-9227-d36504a3640f.jpg?1",
             "name": "Boulderborn Dragon",
             "text": "Flying, vigilance\nWhenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9042,7 +9042,7 @@
         },
         {
             "id": "51cb9979-cd26-5e6a-8aa7-bd9cb0a827e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031afea3-fbfb-4663-a8cc-9b7eb7b16020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031afea3-fbfb-4663-a8cc-9b7eb7b16020.jpg?1",
             "name": "Dragonfire Blade",
             "text": "Equipped creature gets +2/+2 and has hexproof from monocolored.\nEquip {4}. This ability costs {1} less to activate for each color of the creature it targets.",
             "colours": [],
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "c3576a11-5eeb-58fd-b362-9a52682c3835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f50aa6e-ce6a-4479-9725-202926245f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f50aa6e-ce6a-4479-9725-202926245f2c.jpg?1",
             "name": "Dragonstorm Globe",
             "text": "Each Dragon you control enters with an additional +1/+1 counter on it.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "99d25e00-84b8-5fc2-9bac-342c8f512f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f75d5-da5b-4605-885a-561ccd999cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f75d5-da5b-4605-885a-561ccd999cc6.jpg?1",
             "name": "Embermouth Sentinel",
             "text": "When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top. If you control a Dragon, put that card onto the battlefield tapped instead.",
             "colours": [],
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "3b7bb38b-aa77-5ea3-a0ed-58eaae48dd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ce5fa-bd00-429b-ba22-b38c7dd9306c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ce5fa-bd00-429b-ba22-b38c7dd9306c.jpg?1",
             "name": "Jade-Cast Sentinel",
             "text": "Reach\n{2}, {T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9165,7 +9165,7 @@
         },
         {
             "id": "43cf017c-d0e9-5310-bb84-bb560b4611c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0193ad6-39b7-4558-bd3e-36f809332ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0193ad6-39b7-4558-bd3e-36f809332ea2.jpg?1",
             "name": "Jeskai Monument",
             "text": "When this artifact enters, search your library for a basic Island, Mountain, or Plains card, reveal it, put it into your hand, then shuffle.\n{1}{U}{R}{W}, {T}, Sacrifice this artifact: Create two 1/1 white Bird creature tokens with flying. Activate only as a sorcery.",
             "colours": [],
@@ -9197,7 +9197,7 @@
         },
         {
             "id": "f265e641-80a3-5c2b-9678-10163d39d311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd0c794-77bc-4d4a-a769-3829e2ce4bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd0c794-77bc-4d4a-a769-3829e2ce4bdf.jpg?1",
             "name": "Mardu Monument",
             "text": "When this artifact enters, search your library for a basic Mountain, Plains, or Swamp card, reveal it, put it into your hand, then shuffle.\n{2}{R}{W}{B}, {T}, Sacrifice this artifact: Create three 1/1 red Warrior creature tokens. They gain menace and haste until end of turn. Activate only as a sorcery. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [],
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "0bb61288-bcc4-56fe-8eb5-a6cc401aeb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a851d2d3-7e93-4887-bee5-4d6c9aaf9419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a851d2d3-7e93-4887-bee5-4d6c9aaf9419.jpg?1",
             "name": "Mox Jasper",
             "text": "{T}: Add one mana of any color. Activate only if you control a Dragon.",
             "colours": [],
@@ -9262,7 +9262,7 @@
         },
         {
             "id": "587123ed-943a-55df-9762-f193411edc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45308e0e-b515-49ac-9960-a24e898dd321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45308e0e-b515-49ac-9960-a24e898dd321.jpg?1",
             "name": "Sultai Monument",
             "text": "When this artifact enters, search your library for a basic Swamp, Forest, or Island card, reveal it, put it into your hand, then shuffle.\n{2}{B}{G}{U}, {T}, Sacrifice this artifact: Create two 2/2 black Zombie Druid creature tokens. Activate only as a sorcery.",
             "colours": [],
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "157e74d0-355b-5ad1-a64e-74db2f104497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e97b40-d898-4da5-8159-cca48eb298eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e97b40-d898-4da5-8159-cca48eb298eb.jpg?1",
             "name": "Temur Monument",
             "text": "When this artifact enters, search your library for a basic Forest, Island, or Mountain card, reveal it, put it into your hand, then shuffle.\n{3}{G}{U}{R}, {T}, Sacrifice this artifact: Create a 5/5 green Elephant creature token. Activate only as a sorcery.",
             "colours": [],
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "7301b2f7-461c-57e2-9ecb-895f6f1bb8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcafdac-a293-4adc-a540-3b3f469cf6f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcafdac-a293-4adc-a540-3b3f469cf6f3.jpg?1",
             "name": "Watcher of the Wayside",
             "text": "When this creature enters, target player mills two cards. You gain 2 life. (To mill two cards, a player puts the top two cards of their library into their graveyard.)",
             "colours": [],
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "21076e8f-7473-5e7b-87e0-48bdfaa8ea85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde3c68-6f29-4c00-b668-c25ac9e3e13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde3c68-6f29-4c00-b668-c25ac9e3e13b.jpg?1",
             "name": "Bloodfell Caves",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9388,7 +9388,7 @@
         },
         {
             "id": "80734665-9a30-5a21-a46a-2b65d6a32d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9df994-e0f4-4919-af99-4f643eb9199c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9df994-e0f4-4919-af99-4f643eb9199c.jpg?1",
             "name": "Blossoming Sands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "4408b2a5-ea1a-5a22-930a-2088bfc5e5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312821a-2059-4f44-9b20-c9522b827e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312821a-2059-4f44-9b20-c9522b827e38.jpg?1",
             "name": "Cori Mountain Monastery",
             "text": "This land enters tapped unless you control a Plains or an Island.\n{T}: Add {R}.\n{3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [],
@@ -9451,7 +9451,7 @@
         },
         {
             "id": "ddd08f46-d88d-5e04-a552-5441d40b37ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ad5f0c-8775-4e89-8e92-84a6ade93e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ad5f0c-8775-4e89-8e92-84a6ade93e35.jpg?1",
             "name": "Dalkovan Encampment",
             "text": "This land enters tapped unless you control a Swamp or a Mountain.\n{T}: Add {W}.\n{2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens that are tapped and attacking. Sacrifice them at the beginning of the next end step.",
             "colours": [],
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "0e338302-0243-544a-b9a7-278ec4f07f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b52c9-c46e-44d3-b723-546ba528e07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b52c9-c46e-44d3-b723-546ba528e07b.jpg?1",
             "name": "Dismal Backwater",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "5726bb05-ea3c-5714-99f8-a009e50c27e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62209251-4118-4843-895b-46afb7284c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62209251-4118-4843-895b-46afb7284c75.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9542,7 +9542,7 @@
         },
         {
             "id": "16fa0b8c-ad66-5fae-a10e-f721fec79d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/679fff07-4796-4d91-8dd6-4e294383ce88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/679fff07-4796-4d91-8dd6-4e294383ce88.jpg?1",
             "name": "Frontier Bivouac",
             "text": "This land enters tapped.\n{T}: Add {G}, {U}, or {R}.",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "279ebff6-f9dd-5920-a886-6d6f241a0640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba23b6-9f3a-431e-bc22-f1fb04d27b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba23b6-9f3a-431e-bc22-f1fb04d27b68.jpg?1",
             "name": "Great Arashin City",
             "text": "This land enters tapped unless you control a Forest or a Plains.\n{T}: Add {B}.\n{1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit creature token.",
             "colours": [],
@@ -9606,7 +9606,7 @@
         },
         {
             "id": "42fc89ce-a3f0-5d8d-8fdc-f6b8e4faa9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea13440b-3f7b-4182-9541-27c1fa3121e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea13440b-3f7b-4182-9541-27c1fa3121e5.jpg?1",
             "name": "Jungle Hollow",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "6fa6dc8b-9935-50dc-8eb5-ca1edd39892c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0ff90d-7312-44df-afc5-29c768fa7758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0ff90d-7312-44df-afc5-29c768fa7758.jpg?1",
             "name": "Kishla Village",
             "text": "This land enters tapped unless you control an Island or a Swamp.\n{T}: Add {G}.\n{3}{G}, {T}: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [],
@@ -9669,7 +9669,7 @@
         },
         {
             "id": "5eb5434e-6367-5549-ba1d-288621e8c10b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e90bfb-d9a5-48a9-9ff9-b0f50a813eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e90bfb-d9a5-48a9-9ff9-b0f50a813eee.jpg?1",
             "name": "Maelstrom of the Spirit Dragon",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.\n{4}, {T}, Sacrifice this land: Search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "7703e3b6-8694-53fb-8e63-e17649e610b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44bccbf-6fab-46e4-8ddb-6577e27ec6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44bccbf-6fab-46e4-8ddb-6577e27ec6e8.jpg?1",
             "name": "Mistrise Village",
             "text": "This land enters tapped unless you control a Mountain or a Forest.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn can't be countered.",
             "colours": [],
@@ -9731,7 +9731,7 @@
         },
         {
             "id": "dca7b69f-246e-52fd-83dc-e2f452522064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b8a01c-c400-47c7-8270-78902efe850e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b8a01c-c400-47c7-8270-78902efe850e.jpg?1",
             "name": "Mystic Monastery",
             "text": "This land enters tapped.\n{T}: Add {U}, {R}, or {W}.",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "0076c28f-c93d-56ae-aee7-13c325f7f52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fbeaa-941f-4d53-becd-f93ed22b9a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fbeaa-941f-4d53-becd-f93ed22b9a54.jpg?1",
             "name": "Nomad Outpost",
             "text": "This land enters tapped.\n{T}: Add {R}, {W}, or {B}.",
             "colours": [],
@@ -9795,7 +9795,7 @@
         },
         {
             "id": "f05d3b0a-d43d-5b63-b7a4-eac882267f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb3b3b-0738-4c2e-a3fc-927fd6b9d3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb3b3b-0738-4c2e-a3fc-927fd6b9d3fb.jpg?1",
             "name": "Opulent Palace",
             "text": "This land enters tapped.\n{T}: Add {B}, {G}, or {U}.",
             "colours": [],
@@ -9827,7 +9827,7 @@
         },
         {
             "id": "bcfb9a29-0435-5b99-903b-b7f329e8b620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31261eca-28ad-407c-84ef-0c124d0d7451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31261eca-28ad-407c-84ef-0c124d0d7451.jpg?1",
             "name": "Rugged Highlands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9858,7 +9858,7 @@
         },
         {
             "id": "0109de79-a881-5811-8660-dfdf308024a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f47e7f-39ba-4807-8e32-7262a61dfbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f47e7f-39ba-4807-8e32-7262a61dfbba.jpg?1",
             "name": "Sandsteppe Citadel",
             "text": "This land enters tapped.\n{T}: Add {W}, {B}, or {G}.",
             "colours": [],
@@ -9890,7 +9890,7 @@
         },
         {
             "id": "5c73ca42-b4ef-5d04-a7c6-11757f06cd43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b47b80-69ed-44b0-afa0-ca90206dc16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b47b80-69ed-44b0-afa0-ca90206dc16d.jpg?1",
             "name": "Scoured Barrens",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9921,7 +9921,7 @@
         },
         {
             "id": "a27b82b2-7fe2-5ead-b6c2-d58cc96a865b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca53fb19-b8ca-485b-af1a-5117ae54bfe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca53fb19-b8ca-485b-af1a-5117ae54bfe3.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "e64f2ef2-48c4-5a00-bb4a-273eec19524d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb502c2-5fd0-46a9-b77d-010f4a942056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb502c2-5fd0-46a9-b77d-010f4a942056.jpg?1",
             "name": "Thornwood Falls",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "23bb0b86-c90a-5eb0-9c16-ddbc2b3e0128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4efa6c-4f29-41cd-a728-bf0e479ace05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4efa6c-4f29-41cd-a728-bf0e479ace05.jpg?1",
             "name": "Tranquil Cove",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -10014,7 +10014,7 @@
         },
         {
             "id": "15dd825a-25f0-577f-b4ac-227e335b70db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4912e4d0-b16a-4aa6-a583-3430d26bd591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4912e4d0-b16a-4aa6-a583-3430d26bd591.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10045,7 +10045,7 @@
         },
         {
             "id": "14d18dda-5a48-5bb3-adc9-b8223560cbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f1dd6-9564-4adc-af7d-f83252e8581a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f1dd6-9564-4adc-af7d-f83252e8581a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10083,7 +10083,7 @@
         },
         {
             "id": "40bd478c-3ecf-50c5-9f6e-6d0732fb3566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4208e66c-8c98-4c48-ab07-8523c0b26ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4208e66c-8c98-4c48-ab07-8523c0b26ca4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "4015a9de-b920-5be9-a4a5-5e8187d1d787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef235170-8276-4ef0-bdfd-ba68d5b218ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef235170-8276-4ef0-bdfd-ba68d5b218ec.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "6ba271fa-0b3c-5ece-9133-dac432001a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0865ba-47c0-40bc-b0c6-e1ea5ae08a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0865ba-47c0-40bc-b0c6-e1ea5ae08a98.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10197,7 +10197,7 @@
         },
         {
             "id": "620a04ad-e485-51e1-a5a8-2a1a277e1dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48811e13-5774-4da1-95ec-6ea5dc4976ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48811e13-5774-4da1-95ec-6ea5dc4976ad.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "17166409-51ab-50bc-8259-35c538537473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cff32a-a365-43ee-a196-8ce32b3bb9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cff32a-a365-43ee-a196-8ce32b3bb9fd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10273,7 +10273,7 @@
         },
         {
             "id": "1cfa64b7-ea43-5b5f-ac64-121ec8b622e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c391f2-b340-43c7-89e6-afac5b70491f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c391f2-b340-43c7-89e6-afac5b70491f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10311,7 +10311,7 @@
         },
         {
             "id": "f48089ee-4511-5278-ae10-02002ba23df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff6acc9-581c-468f-894d-41f725da7f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff6acc9-581c-468f-894d-41f725da7f33.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10349,7 +10349,7 @@
         },
         {
             "id": "0e723169-35a9-5800-999f-438afb9e6773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15be7923-6efc-4650-b8d1-f61cb33ef81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15be7923-6efc-4650-b8d1-f61cb33ef81d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10387,7 +10387,7 @@
         },
         {
             "id": "0a85e2cf-c4c0-5da7-9ae8-5599c520dd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfdb9e-318f-4acd-9fbd-41b98a8875d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfdb9e-318f-4acd-9fbd-41b98a8875d6.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10425,7 +10425,7 @@
         },
         {
             "id": "8b5fa12b-33ae-571b-8f17-57270ed6ec8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac885eb7-9dae-4c48-b45c-97ef9c62c99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac885eb7-9dae-4c48-b45c-97ef9c62c99e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10463,7 +10463,7 @@
         },
         {
             "id": "c56f6511-7ce6-59e6-9bd0-41dca5093249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa10a88-12e0-4b79-80bb-6f4620277e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa10a88-12e0-4b79-80bb-6f4620277e20.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "c2143cb7-99b2-5cf7-a374-cb7146d46ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df7c206-97b6-49d7-ba01-7a35fd8c61d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df7c206-97b6-49d7-ba01-7a35fd8c61d9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "4699678e-00c2-57fd-9315-f4e95d0002fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8100bceb-ffba-487a-bb45-4fe2a156a8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8100bceb-ffba-487a-bb45-4fe2a156a8dc.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10577,7 +10577,7 @@
         },
         {
             "id": "96e0cf4b-a8b0-5f04-9c30-affa24189153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e83d2-96ba-4d5c-a1ed-6c08a90b339c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e83d2-96ba-4d5c-a1ed-6c08a90b339c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10615,7 +10615,7 @@
         },
         {
             "id": "0812ab63-65f6-5923-a54b-18ddf265ea3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c67e5-587a-43b2-af47-bbad1f8b52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c67e5-587a-43b2-af47-bbad1f8b52e9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "6dc572dc-9211-5488-9834-2bb1a88ef0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b300be80-6618-4284-b5c3-95c1ab373e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b300be80-6618-4284-b5c3-95c1ab373e6f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "4589786e-9dc5-5135-956e-91515d41895a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57da24a0-89a7-4756-b4ca-4dea132e8f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57da24a0-89a7-4756-b4ca-4dea132e8f67.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "65151c13-b4c2-59b9-a765-9d160ce6e191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db1b7a-93f2-40a5-b649-80a099ddeb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db1b7a-93f2-40a5-b649-80a099ddeb62.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "a29f61fa-fdc5-5ac1-bf1c-a5541f843d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e33e540-2828-46ad-a441-366552843d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e33e540-2828-46ad-a441-366552843d9c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10805,7 +10805,7 @@
         },
         {
             "id": "d712f631-b0d7-50e6-a566-06d67b7d36f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Flying, vigilance\nAt the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "1fb9ec32-f91e-5c34-9f17-3661d09a97a9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Create a 2/2 white Soldier creature token.",
             "colours": [
@@ -10877,7 +10877,7 @@
         },
         {
             "id": "78408a3c-96ee-53be-8a46-c1fb7c350b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717301c-1ae8-44b4-b6e5-d3bdf052f5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717301c-1ae8-44b4-b6e5-d3bdf052f5da.jpg?1",
             "name": "Teeming Dragonstorm",
             "text": "When this enchantment enters, create two 2/2 white Soldier creature tokens.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -10911,7 +10911,7 @@
         },
         {
             "id": "473ef613-93b7-5340-8d27-1e356226755d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Flying, ward {2}",
             "colours": [
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "67d74fb4-04dd-5a09-b238-c046a7e214ac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Tap up to one target creature. Draw a card.",
             "colours": [
@@ -10983,7 +10983,7 @@
         },
         {
             "id": "2edab94a-a3cc-540a-b2ca-45b703b5c151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8d7d3-7e80-4742-9951-eb6679a0aa66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8d7d3-7e80-4742-9951-eb6679a0aa66.jpg?1",
             "name": "Dragonologist",
             "text": "When this creature enters, look at the top six cards of your library. You may reveal an instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nUntapped Dragons you control have hexproof.",
             "colours": [
@@ -11020,7 +11020,7 @@
         },
         {
             "id": "31e75a75-a0de-51c1-bcac-664214f5e8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c725add-1cca-4003-8f37-c68f8f8fcc33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c725add-1cca-4003-8f37-c68f8f8fcc33.jpg?1",
             "name": "Roiling Dragonstorm",
             "text": "When this enchantment enters, draw two cards, then discard a card.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "f79a344c-2f52-54a2-9799-c1822e5cc3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f19964-b37b-4877-bdd5-c5c3022439ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f19964-b37b-4877-bdd5-c5c3022439ef.jpg?1",
             "name": "Corroding Dragonstorm",
             "text": "When this enchantment enters, each opponent loses 2 life and you gain 2 life. Surveil 2.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11089,7 +11089,7 @@
         },
         {
             "id": "6f1b3818-22a3-5675-bc28-5e7fa98a9076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Flying, deathtouch\nWhen this creature enters, exile up to two target cards from a single graveyard.",
             "colours": [
@@ -11125,7 +11125,7 @@
         },
         {
             "id": "c5208366-64c8-5a77-9c78-45b659120eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Put a +1/+1 counter on up to one target creature. Draw a card.",
             "colours": [
@@ -11161,7 +11161,7 @@
         },
         {
             "id": "f3c8775b-55ce-5c8b-8580-cc7ff9e7a98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbfdf32-8b21-4f7a-aa30-42d5362ee352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbfdf32-8b21-4f7a-aa30-42d5362ee352.jpg?1",
             "name": "Breaching Dragonstorm",
             "text": "When this enchantment enters, exile cards from the top of your library until you exile a nonland card. You may cast it without paying its mana cost if that spell's mana value is 8 or less. If you don't, put that card into your hand.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11195,7 +11195,7 @@
         },
         {
             "id": "e84ba09b-95c4-5893-9e10-cfba0d9723ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f7c75a-c8f7-4f34-bc86-9d0441dc3a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f7c75a-c8f7-4f34-bc86-9d0441dc3a40.jpg?1",
             "name": "Dracogenesis",
             "text": "You may cast Dragon spells without paying their mana costs.",
             "colours": [
@@ -11231,7 +11231,7 @@
         },
         {
             "id": "f6150b8e-04be-5146-a89d-0bd2cce459db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a8906f-8593-4ae8-ba65-f2a1cc4c8fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a8906f-8593-4ae8-ba65-f2a1cc4c8fa6.jpg?1",
             "name": "Magmatic Hellkite",
             "text": "Flying\nWhen this creature enters, destroy target nonbasic land an opponent controls. Its controller searches their library for a basic land card, puts it onto the battlefield tapped with a stun counter on it, then shuffles.",
             "colours": [
@@ -11267,7 +11267,7 @@
         },
         {
             "id": "18d9cd0c-3903-528b-99ad-ebf4fecda30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c03255-e3dc-44c2-982b-7efa188280df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c03255-e3dc-44c2-982b-7efa188280df.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token.\nWhenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying.",
             "colours": [
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "4c762144-26fc-526f-8681-9ead4a95c12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c250cbd2-2b78-4721-9977-02de20c3d7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c250cbd2-2b78-4721-9977-02de20c3d7d1.jpg?1",
             "name": "Stormscale Scion",
             "text": "Flying\nOther Dragons you control get +1/+1.\nStorm",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "d4a127de-95ad-5674-9c78-02e74bce22cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Flying, haste\n{1}{R}: This creature gets +1/+0 until end of turn.",
             "colours": [
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "a47ed85a-8e94-5626-bca2-9045f278d4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Discard a card. If you do, draw two cards.",
             "colours": [
@@ -11416,7 +11416,7 @@
         },
         {
             "id": "673bcab7-23d6-5dc7-9723-9545179916c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1e6797-f938-4161-a231-dac2da23b573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1e6797-f938-4161-a231-dac2da23b573.jpg?1",
             "name": "Encroaching Dragonstorm",
             "text": "When this enchantment enters, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "9ce827a1-e18d-5773-af12-0411cbad8223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Flying\nWhen this creature enters, you gain 3 life.",
             "colours": [
@@ -11487,7 +11487,7 @@
         },
         {
             "id": "fe35bb56-ee0c-573d-9233-9ea274d807cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -11523,7 +11523,7 @@
         },
         {
             "id": "c28f4f1a-5fd9-5a29-931e-8b0b9d0be616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a49553-fc4a-427d-9818-dc8b33fe6127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a49553-fc4a-427d-9818-dc8b33fe6127.jpg?1",
             "name": "Armament Dragon",
             "text": "Flying\nWhen this creature enters, distribute three +1/+1 counters among one, two, or three target creatures you control.",
             "colours": [
@@ -11563,7 +11563,7 @@
         },
         {
             "id": "1f882c53-ff76-5e9c-a6e2-914c5e3875c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1969dec-4d6b-493a-8233-76faf8fa3cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1969dec-4d6b-493a-8233-76faf8fa3cea.jpg?1",
             "name": "Betor, Kin to All",
             "text": "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
             "colours": [
@@ -11607,7 +11607,7 @@
         },
         {
             "id": "e7f14ccf-f52d-5ec9-adcf-4c503c27a0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473ac65-acb4-454b-84ce-2a505387cc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473ac65-acb4-454b-84ce-2a505387cc24.jpg?1",
             "name": "Call the Spirit Dragons",
             "text": "Dragons you control have indestructible.\nAt the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control of that color. If you put +1/+1 counters on five Dragons this way, you win the game.",
             "colours": [
@@ -11649,7 +11649,7 @@
         },
         {
             "id": "f4571dda-8c6d-525e-9de7-cc8d58b91d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Flying\nWhen this creature enters, destroy up to one target artifact or enchantment.",
             "colours": [
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "cd798ff4-840b-5e83-9cc8-c4221bcfb5de",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "6d6868a1-4cc3-5bad-9cce-32677168c860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171ba15b-f981-4b0f-8062-24e4c78fc213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171ba15b-f981-4b0f-8062-24e4c78fc213.jpg?1",
             "name": "Jeskai Shrinekeeper",
             "text": "Flying, haste\nWhenever this creature deals combat damage to a player, you gain 1 life and draw a card.",
             "colours": [
@@ -11763,7 +11763,7 @@
         },
         {
             "id": "1c8713b3-9910-523d-863c-956a76ebcf70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a7d6a-c429-4b66-b5b0-953335c5108e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a7d6a-c429-4b66-b5b0-953335c5108e.jpg?1",
             "name": "Karakyk Guardian",
             "text": "Flying, vigilance, trample\nThis creature has hexproof if it hasn't dealt damage yet.",
             "colours": [
@@ -11803,7 +11803,7 @@
         },
         {
             "id": "f28a0520-23a8-59ff-acd1-cd80f8a5cc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d85ba44-8f29-4c49-b77f-8a6692d23c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d85ba44-8f29-4c49-b77f-8a6692d23c8c.jpg?1",
             "name": "Kheru Goldkeeper",
             "text": "Flying\nWhenever one or more cards leave your graveyard during your turn, create a Treasure token.\nRenew \u2014 {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a flying counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -11843,7 +11843,7 @@
         },
         {
             "id": "034afac2-7835-5f10-85c1-9e25410f81ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc53504-0eab-4ed2-b498-d8a5267bd40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc53504-0eab-4ed2-b498-d8a5267bd40f.jpg?1",
             "name": "Neriv, Heart of the Storm",
             "text": "Flying\nIf a creature you control that entered this turn would deal damage, it deals twice that much damage instead.",
             "colours": [
@@ -11887,7 +11887,7 @@
         },
         {
             "id": "ec9a7771-205f-542e-974c-82bbd18627bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Flying\nWard\u2014\nPay 2 life.\nWhen this creature enters, remove all counters from up to one target creature.",
             "colours": [
@@ -11924,7 +11924,7 @@
         },
         {
             "id": "17153ab0-839f-5f8a-95c1-ead5b13b45f1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Target creature gets +2/+2 and gains lifelink and hexproof until end of turn.",
             "colours": [
@@ -11961,7 +11961,7 @@
         },
         {
             "id": "aa14ba88-f174-5e11-a88b-ebeaebccc2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Flying\nWhenever you cast a noncreature spell or a Dragon spell, this creature gets +2/+0 until end of turn.",
             "colours": [
@@ -11998,7 +11998,7 @@
         },
         {
             "id": "7cf045a5-8535-5edf-8d61-a5326984a29e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Counter target spell with mana value 2 or less.",
             "colours": [
@@ -12035,7 +12035,7 @@
         },
         {
             "id": "46e3359c-42e0-5a0d-aad9-f439a1399218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465b6a8-3b8a-47c6-b3d0-119552556d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465b6a8-3b8a-47c6-b3d0-119552556d35.jpg?1",
             "name": "Shiko, Paragon of the Way",
             "text": "Flying, vigilance\nWhen Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost.",
             "colours": [
@@ -12079,7 +12079,7 @@
         },
         {
             "id": "a51b34bc-767e-50ff-b569-3c62d484c020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a8ee3f-cee5-4971-9112-393f639a210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a8ee3f-cee5-4971-9112-393f639a210e.jpg?1",
             "name": "Sonic Shrieker",
             "text": "Flying\nWhen this creature enters, it deals 2 damage to any target and you gain 2 life. If a player is dealt damage this way, they discard a card.",
             "colours": [
@@ -12119,7 +12119,7 @@
         },
         {
             "id": "a0cba0b4-aec1-5d64-813c-46f1762ce906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3e165a-60e2-4e50-a0de-1cf7c46cb406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3e165a-60e2-4e50-a0de-1cf7c46cb406.jpg?1",
             "name": "Teval, Arbiter of Virtue",
             "text": "Flying, lifelink\nSpells you cast have delve.\nWhenever you cast a spell, you lose life equal to its mana value.",
             "colours": [
@@ -12163,7 +12163,7 @@
         },
         {
             "id": "8a2e4296-6ff6-599e-bb28-c7674fd67569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Flying\nWhen this creature enters, you gain 5 life.",
             "colours": [
@@ -12200,7 +12200,7 @@
         },
         {
             "id": "de548080-b357-5270-ae8b-16ed4704e35f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Charring Bite deals 5 damage to target creature without flying.",
             "colours": [
@@ -12237,7 +12237,7 @@
         },
         {
             "id": "3a75d55a-6ea1-5668-a753-3b98659817d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683c32f-325a-42f5-826f-5cc978b8333c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683c32f-325a-42f5-826f-5cc978b8333c.jpg?1",
             "name": "Ureni, the Song Unending",
             "text": "Flying, protection from white and from black\nWhen Ureni enters, it deals X damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control, where X is the number of lands you control.",
             "colours": [
@@ -12281,7 +12281,7 @@
         },
         {
             "id": "c28156ff-a993-57c6-97cf-68410bd21744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Flash\nFlying\nYou may cast sorcery spells and Dragon spells as though they had flash.",
             "colours": [
@@ -12318,7 +12318,7 @@
         },
         {
             "id": "5fc1cb34-1b78-5016-bed4-9552a5ecdd1d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Put three +1/+1 counters on target creature you control.",
             "colours": [
@@ -12355,7 +12355,7 @@
         },
         {
             "id": "8431c225-aac9-55f5-83e8-e56a6c19ca91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970e11f0-337a-46b5-9bff-4bcb7843ed3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970e11f0-337a-46b5-9bff-4bcb7843ed3a.jpg?1",
             "name": "Boulderborn Dragon",
             "text": "Flying, vigilance\nWhenever this creature attacks, surveil 1.",
             "colours": [],
@@ -12388,7 +12388,7 @@
         },
         {
             "id": "e89ea40b-1d3f-5987-97cb-9dd88e7c4649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f039ce-cbfd-46d7-a575-5e6c049f83ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f039ce-cbfd-46d7-a575-5e6c049f83ff.jpg?1",
             "name": "Dragonfire Blade",
             "text": "Equipped creature gets +2/+2 and has hexproof from monocolored.\nEquip {4}. This ability costs {1} less to activate for each color of the creature it targets.",
             "colours": [],
@@ -12420,7 +12420,7 @@
         },
         {
             "id": "2266f524-232c-53ad-9fd2-bbca85627469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0372d8-362d-486e-96c0-5738427a1087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0372d8-362d-486e-96c0-5738427a1087.jpg?1",
             "name": "Mox Jasper",
             "text": "{T}: Add one mana of any color. Activate only if you control a Dragon.",
             "colours": [],
@@ -12453,7 +12453,7 @@
         },
         {
             "id": "c61dac4e-cd87-5f82-ae80-cadf12b0d4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b89e6d-da58-465e-a9b1-69629da159f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b89e6d-da58-465e-a9b1-69629da159f6.jpg?1",
             "name": "Maelstrom of the Spirit Dragon",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.\n{4}, {T}, Sacrifice this land: Search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -12483,7 +12483,7 @@
         },
         {
             "id": "82df3262-c519-5a46-a8e4-fb3ad5cc03ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f31696-2307-4ec6-a568-c255a25b59b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f31696-2307-4ec6-a568-c255a25b59b6.jpg?1",
             "name": "Anafenza, Unyielding Lineage",
             "text": "Flash\nFirst strike\nWhenever another nontoken creature you control dies, Anafenza endures 2.",
             "colours": [
@@ -12522,7 +12522,7 @@
         },
         {
             "id": "3b07fdcb-7c5d-554f-bfa5-4b76b5e856b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e7ddf5-5aaf-4233-834d-c9992a9c2b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e7ddf5-5aaf-4233-834d-c9992a9c2b0e.jpg?1",
             "name": "Sage of the Skies",
             "text": "When you cast this spell, if you've cast another spell this turn, copy this spell.\nFlying, lifelink",
             "colours": [
@@ -12559,7 +12559,7 @@
         },
         {
             "id": "8f2d3e58-dca9-5d45-9e91-792687b20751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5121b5a4-5f91-4bd3-a8b1-c2dc2a449378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5121b5a4-5f91-4bd3-a8b1-c2dc2a449378.jpg?1",
             "name": "Smile at Death",
             "text": "At the beginning of your upkeep, return up to two target creature cards with power 2 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures.",
             "colours": [
@@ -12593,7 +12593,7 @@
         },
         {
             "id": "61720e0c-3f75-500e-91fb-37e1e70defd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d8e5c-4b3d-4c5c-89c5-a2746cd4b578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d8e5c-4b3d-4c5c-89c5-a2746cd4b578.jpg?1",
             "name": "United Battlefront",
             "text": "Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12627,7 +12627,7 @@
         },
         {
             "id": "919f2be0-249b-5bca-9b2a-54c098adbf9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f24785-c7b3-46ab-833e-666af3d86c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f24785-c7b3-46ab-833e-666af3d86c63.jpg?1",
             "name": "Voice of Victory",
             "text": "Mobilize 2\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -12664,7 +12664,7 @@
         },
         {
             "id": "80326b0e-3aa9-5d50-a745-eca125ca2b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67235e-13d3-40ba-9cb7-03c1db6d455e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67235e-13d3-40ba-9cb7-03c1db6d455e.jpg?1",
             "name": "Ambling Stormshell",
             "text": "Ward {2}\nWhenever this creature attacks, put three stun counters on it and draw three cards.\nWhenever you cast a Turtle spell, untap this creature.",
             "colours": [
@@ -12700,7 +12700,7 @@
         },
         {
             "id": "d3bd7639-f0f2-5825-927b-a2b1d85fcc49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4863c-51bc-445d-97a5-289b5a87c871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4863c-51bc-445d-97a5-289b5a87c871.jpg?1",
             "name": "Naga Fleshcrafter",
             "text": "You may have this creature enter as a copy of any creature on the battlefield.\nRenew \u2014 {2}{U}, Exile this card from your graveyard: Put a +1/+1 counter on target nonlegendary creature you control. Each other creature you control becomes a copy of that creature until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -12737,7 +12737,7 @@
         },
         {
             "id": "3a6161db-d36f-5daf-b7ca-52d36a243a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ae35fd-5fb6-440a-9e82-13998b928ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ae35fd-5fb6-440a-9e82-13998b928ee3.jpg?1",
             "name": "Stillness in Motion",
             "text": "At the beginning of your upkeep, mill three cards. Then if your library has no cards in it, exile this enchantment and put five cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -12771,7 +12771,7 @@
         },
         {
             "id": "c76c7adf-015e-5757-a512-6b173967d008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8c278-781d-4c9c-9f1c-99d799384a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8c278-781d-4c9c-9f1c-99d799384a29.jpg?1",
             "name": "Taigam, Master Opportunist",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, copy it, then exile the spell you cast with four time counters on it. If it doesn't have suspend, it gains suspend.",
             "colours": [
@@ -12810,7 +12810,7 @@
         },
         {
             "id": "d6bece2e-e235-597b-803c-1af2ca39462e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94538c3-320c-4903-a689-bb8e9f4ae40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94538c3-320c-4903-a689-bb8e9f4ae40f.jpg?1",
             "name": "Winternight Stories",
             "text": "Draw three cards. Then discard two cards unless you discard a creature card.\nHarmonize {4}{U}",
             "colours": [
@@ -12844,7 +12844,7 @@
         },
         {
             "id": "789719b8-2375-578a-93ae-f8b42fc13b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae9ca3b-cc32-410f-82e9-85cb9c4fa447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae9ca3b-cc32-410f-82e9-85cb9c4fa447.jpg?1",
             "name": "Avenger of the Fallen",
             "text": "Deathtouch\nMobilize X, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -12881,7 +12881,7 @@
         },
         {
             "id": "1a22d2b2-87ca-5329-b675-0fb192c7b35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca69694-c345-4255-9c92-0110aa5c8004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca69694-c345-4255-9c92-0110aa5c8004.jpg?1",
             "name": "Qarsi Revenant",
             "text": "Flying, deathtouch, lifelink\nRenew \u2014 {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch counter, and a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -12918,7 +12918,7 @@
         },
         {
             "id": "59696c13-d8ed-59b8-9526-b63d6f36a3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd34da53-1a96-4f06-aaf6-e70581de112d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd34da53-1a96-4f06-aaf6-e70581de112d.jpg?1",
             "name": "Rot-Curse Rakshasa",
             "text": "Trample\nDecayed\nRenew \u2014 {X}{B}{B}, Exile this card from your graveyard: Put a decayed counter on each of X target creatures. Activate only as a sorcery.",
             "colours": [
@@ -12954,7 +12954,7 @@
         },
         {
             "id": "2e49d5aa-c132-5430-ab91-7e5239779c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daa156c-478f-47dd-9284-b95e82ccfd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daa156c-478f-47dd-9284-b95e82ccfd68.jpg?1",
             "name": "The Sibsig Ceremony",
             "text": "Creature spells you cast cost {2} less to cast.\nWhenever a creature you control enters, if you cast it, destroy that creature, then create a 2/2 black Zombie Druid creature token.",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "261956d1-43b9-5590-96e9-1afb3d896722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9e3ddc-a4e7-4304-bfd8-890c9c71f53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9e3ddc-a4e7-4304-bfd8-890c9c71f53d.jpg?1",
             "name": "Sidisi, Regent of the Mire",
             "text": "{T}, Sacrifice a creature you control with mana value X other than Sidisi: Return target creature card with mana value X plus 1 from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -13030,7 +13030,7 @@
         },
         {
             "id": "744ab549-a1cd-52ae-8690-f837d57c4403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b155cd-c3a0-4f27-8d3c-7778354abbd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b155cd-c3a0-4f27-8d3c-7778354abbd4.jpg?1",
             "name": "Sinkhole Surveyor",
             "text": "Flying\nWhenever this creature attacks, you lose 1 life and this creature endures 1.",
             "colours": [
@@ -13067,7 +13067,7 @@
         },
         {
             "id": "d152ccf9-4f01-54f8-9c43-e3db60eebe22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470dd3c8-07c9-42ef-aa9e-3c73b23607ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470dd3c8-07c9-42ef-aa9e-3c73b23607ff.jpg?1",
             "name": "Cori-Steel Cutter",
             "text": "Equipped creature gets +1/+1 and has trample and haste.\nFlurry \u2014 Whenever you cast your second spell each turn, create a 1/1 white Monk creature token with prowess. You may attach this Equipment to it.\nEquip {1}{R}",
             "colours": [
@@ -13103,7 +13103,7 @@
         },
         {
             "id": "0f4e43d1-0bce-56e8-8cec-4899028d5fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7a1ddf-bf52-4d44-92cd-8d8127472bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7a1ddf-bf52-4d44-92cd-8d8127472bd9.jpg?1",
             "name": "Stadium Headliner",
             "text": "Mobilize 1\n{1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control to target creature.",
             "colours": [
@@ -13140,7 +13140,7 @@
         },
         {
             "id": "3eebfc13-e1d4-5f4c-83f2-4a7568b964c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1689bb-f7a4-4b53-8473-75b7ce7b496d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1689bb-f7a4-4b53-8473-75b7ce7b496d.jpg?1",
             "name": "Tersa Lightshatter",
             "text": "Haste\nWhen Tersa Lightshatter enters, discard up to two cards, then draw that many cards.\nWhenever Tersa Lightshatter attacks, if there are seven or more cards in your graveyard, exile a card at random from your graveyard. You may play that card this turn.",
             "colours": [
@@ -13179,7 +13179,7 @@
         },
         {
             "id": "07cd6e47-ce93-52ce-8d79-6a7b5dd79d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c966c8a0-e73d-4484-9307-a793a65222ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c966c8a0-e73d-4484-9307-a793a65222ea.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen this creature enters, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -13217,7 +13217,7 @@
         },
         {
             "id": "6c522b08-9860-5937-816a-27ac960c4fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e7d936-60f8-40fc-b6a9-be677a97395b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e7d936-60f8-40fc-b6a9-be677a97395b.jpg?1",
             "name": "Herd Heirloom",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\n{T}: Until end of turn, target creature you control with power 4 or greater gains trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "5d29751f-e733-5569-8be2-aba18d6b3531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2683ba05-13aa-44ca-8465-d9fa19ae610d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2683ba05-13aa-44ca-8465-d9fa19ae610d.jpg?1",
             "name": "Lasyd Prowler",
             "text": "When this creature enters, you may mill cards equal to the number of lands you control.\nRenew \u2014 {1}{G}, Exile this card from your graveyard: Put X +1/+1 counters on target creature, where X is the number of land cards in your graveyard. Activate only as a sorcery.",
             "colours": [
@@ -13288,7 +13288,7 @@
         },
         {
             "id": "42a5809c-bd9b-5c85-90e3-ee44337dc16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0ee309-b6c4-455d-8af6-48d8ac1426cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0ee309-b6c4-455d-8af6-48d8ac1426cb.jpg?1",
             "name": "Nature's Rhythm",
             "text": "Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.\nHarmonize {X}{G}{G}{G}{G}",
             "colours": [
@@ -13322,7 +13322,7 @@
         },
         {
             "id": "8557f671-af04-50b0-8b7f-ab1dc0972999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc80d937-a166-42e7-a7b3-56150e11d27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc80d937-a166-42e7-a7b3-56150e11d27e.jpg?1",
             "name": "Surrak, Elusive Hunter",
             "text": "This spell can't be countered.\nTrample\nWhenever a creature you control or a creature spell you control becomes the target of a spell or ability an opponent controls, draw a card.",
             "colours": [
@@ -13361,7 +13361,7 @@
         },
         {
             "id": "707f1d02-3458-5023-8013-6ad3b97c0c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3d7969-5dcb-434d-8a8b-fb16da288bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3d7969-5dcb-434d-8a8b-fb16da288bc4.jpg?1",
             "name": "Warden of the Grove",
             "text": "At the beginning of your end step, put a +1/+1 counter on this creature.\nWhenever another nontoken creature you control enters, it endures X, where X is the number of counters on this creature.",
             "colours": [
@@ -13397,7 +13397,7 @@
         },
         {
             "id": "fe85a233-b23b-5a85-aeb8-3cba2bc09d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febe8c-7e00-485a-bd06-1d7c4d4e816e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febe8c-7e00-485a-bd06-1d7c4d4e816e.jpg?1",
             "name": "All-Out Assault",
             "text": "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment enters, if it's your main phase, there is an additional combat phase after this phase followed by an additional main phase. When you next attack this turn, untap each creature you control.",
             "colours": [
@@ -13437,7 +13437,7 @@
         },
         {
             "id": "7a2237f0-fa18-5dd3-9a9a-0c9e90d9d50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cf348-7db8-4f93-8f83-8b1f2035ed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cf348-7db8-4f93-8f83-8b1f2035ed4e.jpg?1",
             "name": "Betor, Kin to All",
             "text": "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
             "colours": [
@@ -13481,7 +13481,7 @@
         },
         {
             "id": "90a0e078-a974-5cf4-bbb9-036a3831c384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e94b23-955b-45c0-9cef-713a0a6c38ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e94b23-955b-45c0-9cef-713a0a6c38ac.jpg?1",
             "name": "Death Begets Life",
             "text": "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.",
             "colours": [
@@ -13521,7 +13521,7 @@
         },
         {
             "id": "91830022-db72-5e8a-a4ca-35a9015e1499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87970548-bbec-4f07-b534-e463c9128469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87970548-bbec-4f07-b534-e463c9128469.jpg?1",
             "name": "Dragonback Assault",
             "text": "When this enchantment enters, it deals 3 damage to each creature and each planeswalker.\nLandfall \u2014 Whenever a land you control enters, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -13559,7 +13559,7 @@
         },
         {
             "id": "fe172a43-7776-5044-86b9-5832dfa72094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafaa59e-87e1-4953-8c04-8e7a3a509827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafaa59e-87e1-4953-8c04-8e7a3a509827.jpg?1",
             "name": "Eshki Dragonclaw",
             "text": "Vigilance, trample, ward {1}\nAt the beginning of combat on your turn, if you've cast both a creature spell and a noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw.",
             "colours": [
@@ -13602,7 +13602,7 @@
         },
         {
             "id": "8d265b9c-3f3a-5fa3-9a6c-90a3783e699c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8178e63d-caa6-4088-aaef-367fb24638a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8178e63d-caa6-4088-aaef-367fb24638a4.jpg?1",
             "name": "Fangkeeper's Familiar",
             "text": "Flash\nWhen this creature enters, choose one \u2014\n\u2022 You gain 3 life and surveil 3.\n\u2022 Destroy target enchantment.\n\u2022 Counter target creature spell.",
             "colours": [
@@ -13642,7 +13642,7 @@
         },
         {
             "id": "7a4228ea-df00-5648-a8f7-f4eac0b0ef1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4f9d0f-11fa-4986-a7e8-64a922681906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4f9d0f-11fa-4986-a7e8-64a922681906.jpg?1",
             "name": "Felothar, Dawn of the Abzan",
             "text": "Trample\nWhenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -13685,7 +13685,7 @@
         },
         {
             "id": "e93a7579-d411-5d34-8a79-6cae9bc5c7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60667979-40c1-4144-a3f8-0115fb77341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60667979-40c1-4144-a3f8-0115fb77341d.jpg?1",
             "name": "Flamehold Grappler",
             "text": "First strike\nWhen this creature enters, copy the next spell you cast this turn when you cast it. You may choose new targets for the copy.",
             "colours": [
@@ -13726,7 +13726,7 @@
         },
         {
             "id": "a00747b3-01bc-5e44-8a43-61e428763ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f049ce-6bc7-437d-a530-8c4278151569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f049ce-6bc7-437d-a530-8c4278151569.jpg?1",
             "name": "Inevitable Defeat",
             "text": "This spell can't be countered.\nExile target nonland permanent. Its controller loses 3 life and you gain 3 life.",
             "colours": [
@@ -13764,7 +13764,7 @@
         },
         {
             "id": "d6569638-b53b-54e7-b46e-bc9d886fdb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7679a6a2-7704-4f37-9fdd-24414d411599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7679a6a2-7704-4f37-9fdd-24414d411599.jpg?1",
             "name": "Jeskai Revelation",
             "text": "Return target spell or permanent to its owner's hand. Jeskai Revelation deals 4 damage to any target. Create two 1/1 white Monk creature tokens with prowess. Draw two cards. You gain 4 life.",
             "colours": [
@@ -13802,7 +13802,7 @@
         },
         {
             "id": "3001522a-bc02-589b-a27b-15f9bbb25855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70098f2-e5a8-4056-b5b3-1229fc290c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70098f2-e5a8-4056-b5b3-1229fc290c51.jpg?1",
             "name": "Kotis, the Fangkeeper",
             "text": "Indestructible\nWhenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "39f2f18a-c019-5c5a-ab83-a7d135438bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc69dc-6245-43fc-95a2-85b2c2957182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc69dc-6245-43fc-95a2-85b2c2957182.jpg?1",
             "name": "Lotuslight Dancers",
             "text": "Lifelink\nWhen this creature enters, search your library for a black card, a green card, and a blue card. Put those cards into your graveyard, then shuffle.",
             "colours": [
@@ -13886,7 +13886,7 @@
         },
         {
             "id": "5c4adf3a-be95-58f5-930f-afed30dc76e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa10a98-1d1f-4e66-b81d-615ffaf43ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa10a98-1d1f-4e66-b81d-615ffaf43ca1.jpg?1",
             "name": "Mardu Siegebreaker",
             "text": "Deathtouch, haste\nWhen this creature enters, exile up to one other target creature you control until this creature leaves the battlefield.\nWhenever this creature attacks, for each opponent, create a tapped token that's a copy of the exiled card attacking that opponent. At the beginning of your end step, sacrifice those tokens.",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "6b2c9a4f-3cf8-5722-81bc-d5a4b8273471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccfb58a-4844-466c-81ea-5fb73863bccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccfb58a-4844-466c-81ea-5fb73863bccf.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "At the beginning of your end step, you may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn.",
             "colours": [
@@ -13972,7 +13972,7 @@
         },
         {
             "id": "8f2e38cb-6fcb-57ca-9a58-f1e9bc05e555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72f191b-81d5-4db4-ac42-c5482f15385d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72f191b-81d5-4db4-ac42-c5482f15385d.jpg?1",
             "name": "Neriv, Heart of the Storm",
             "text": "Flying\nIf a creature you control that entered this turn would deal damage, it deals twice that much damage instead.",
             "colours": [
@@ -14016,7 +14016,7 @@
         },
         {
             "id": "9cefef1e-f127-5aaa-adff-801327cdf564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc8ee7-3a1c-49f7-aa67-ff68c377e38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc8ee7-3a1c-49f7-aa67-ff68c377e38c.jpg?1",
             "name": "New Way Forward",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. When damage is prevented this way, New Way Forward deals that much damage to that source's controller and you draw that many cards.",
             "colours": [
@@ -14054,7 +14054,7 @@
         },
         {
             "id": "851ce330-44a1-50f4-a1f7-2b688deb3c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5596f0c7-8007-4136-bab0-58a9cd852a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5596f0c7-8007-4136-bab0-58a9cd852a6e.jpg?1",
             "name": "Perennation",
             "text": "Return target permanent card from your graveyard to the battlefield with a hexproof counter and an indestructible counter on it.",
             "colours": [
@@ -14092,7 +14092,7 @@
         },
         {
             "id": "fdb6fcde-c5a6-5a57-b51c-931ce98c6277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ccfa2-24e3-47aa-b244-31e29b216058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ccfa2-24e3-47aa-b244-31e29b216058.jpg?1",
             "name": "Severance Priest",
             "text": "Deathtouch\nWhen this creature enters, target opponent reveals their hand. You may choose a nonland card from it. If you do, exile that card.\nWhen this creature leaves the battlefield, the exiled card's owner creates an X/X white Spirit creature token, where X is the mana value of the exiled card.",
             "colours": [
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "5b9cde5e-7e77-5407-a9cd-d50bf0962f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fd0437-bfb4-4a9e-9109-d172bfb3faab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fd0437-bfb4-4a9e-9109-d172bfb3faab.jpg?1",
             "name": "Shiko, Paragon of the Way",
             "text": "Flying, vigilance\nWhen Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost.",
             "colours": [
@@ -14177,7 +14177,7 @@
         },
         {
             "id": "3312282d-221a-5335-86dd-889a8b958469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584eb844-91e2-47fb-b4e0-f5def65b824a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584eb844-91e2-47fb-b4e0-f5def65b824a.jpg?1",
             "name": "Songcrafter Mage",
             "text": "Flash\nWhen this creature enters, target instant or sorcery card in your graveyard gains harmonize until end of turn. Its harmonize cost is equal to its mana cost.",
             "colours": [
@@ -14218,7 +14218,7 @@
         },
         {
             "id": "bbd3e325-955b-52f4-a3f9-737ff8bf4b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141492f-f971-4b7f-afdd-e37537f4d3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141492f-f971-4b7f-afdd-e37537f4d3f5.jpg?1",
             "name": "Temur Battlecrier",
             "text": "During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.",
             "colours": [
@@ -14260,7 +14260,7 @@
         },
         {
             "id": "dcbebd66-cf08-5e8d-8933-fa872f4ee5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19c38bc-946c-438a-ac8b-f59ff0b4c613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19c38bc-946c-438a-ac8b-f59ff0b4c613.jpg?1",
             "name": "Teval, Arbiter of Virtue",
             "text": "Flying, lifelink\nSpells you cast have delve.\nWhenever you cast a spell, you lose life equal to its mana value.",
             "colours": [
@@ -14304,7 +14304,7 @@
         },
         {
             "id": "92e1f5b4-d20b-5ee4-9810-269d1350949e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ea13cf-2fa3-411f-9dc5-13d75f0c67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ea13cf-2fa3-411f-9dc5-13d75f0c67dd.jpg?1",
             "name": "Ureni, the Song Unending",
             "text": "Flying, protection from white and from black\nWhen Ureni enters, it deals X damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control, where X is the number of lands you control.",
             "colours": [
@@ -14348,7 +14348,7 @@
         },
         {
             "id": "d6ccd2a5-944e-59f1-89a7-cf4dd94a59a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715afdde-ef3b-40c0-8b1d-59c59381a54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715afdde-ef3b-40c0-8b1d-59c59381a54e.jpg?1",
             "name": "Yathan Roadwatcher",
             "text": "When this creature enters, if you cast it, mill four cards. When you do, return target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -14389,7 +14389,7 @@
         },
         {
             "id": "d9a8c368-1e36-55fc-a152-b11a86ec5607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d899dde2-68e6-4807-b0e9-3f4e28824822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d899dde2-68e6-4807-b0e9-3f4e28824822.jpg?1",
             "name": "Zurgo, Thunder's Decree",
             "text": "Mobilize 2\nDuring your end step, Warrior tokens you control have \"This token can't be sacrificed.\"",
             "colours": [
@@ -14432,7 +14432,7 @@
         },
         {
             "id": "1aaaaffe-949e-528f-8738-c9fcfb770942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg?1",
             "name": "Clarion Conqueror // Clarion Conqueror",
             "text": "Flying\nActivated abilities of artifacts, creatures, and planeswalkers can't be activated.",
             "colours": [
@@ -14466,7 +14466,7 @@
         },
         {
             "id": "8c72b366-acf7-52ab-b68d-a58c66387d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg?1",
             "name": "Clarion Conqueror // Clarion Conqueror",
             "text": "",
             "colours": [
@@ -14500,7 +14500,7 @@
         },
         {
             "id": "86bff115-01db-56ff-98e0-be341b3a5418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg?1",
             "name": "Marang River Regent // Coil and Catch // Marang River Regent",
             "text": "",
             "colours": [
@@ -14534,7 +14534,7 @@
         },
         {
             "id": "0f2a46c0-bcd9-5daa-9c0b-f54781ac224f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg?1",
             "name": "Marang River Regent // Coil and Catch // Marang River Regent",
             "text": "",
             "colours": [
@@ -14568,7 +14568,7 @@
         },
         {
             "id": "8b4d35ae-8a75-5b17-80b1-1d74905aaca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg?1",
             "name": "Scavenger Regent // Exude Toxin // Scavenger Regent",
             "text": "",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "929154b4-131f-5a71-8804-5b21e2e1940d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg?1",
             "name": "Scavenger Regent // Exude Toxin // Scavenger Regent",
             "text": "",
             "colours": [
@@ -14636,7 +14636,7 @@
         },
         {
             "id": "a530ac93-a5a3-5405-b88a-0567d12dd958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg?1",
             "name": "Magmatic Hellkite // Magmatic Hellkite",
             "text": "Flying\nWhen this creature enters, destroy target nonbasic land an opponent controls. Its controller searches their library for a basic land card, puts it onto the battlefield tapped with a stun counter on it, then shuffles.",
             "colours": [
@@ -14670,7 +14670,7 @@
         },
         {
             "id": "20908821-b28a-5709-b6a1-1d63bce29407",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg?1",
             "name": "Magmatic Hellkite // Magmatic Hellkite",
             "text": "",
             "colours": [
@@ -14704,7 +14704,7 @@
         },
         {
             "id": "f673f839-7985-5159-ad35-61c3c553c94e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg?1",
             "name": "Bloomvine Regent // Claim Territory // Bloomvine Regent",
             "text": "",
             "colours": [
@@ -14738,7 +14738,7 @@
         },
         {
             "id": "188638aa-0bdd-5690-9333-e51cdd087eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg?1",
             "name": "Bloomvine Regent // Claim Territory // Bloomvine Regent",
             "text": "",
             "colours": [
@@ -14772,7 +14772,7 @@
         },
         {
             "id": "6fca668c-fd12-5512-a110-9de5c1634c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg?1",
             "name": "Ugin, Eye of the Storms // Ugin, Eye of the Storms",
             "text": "When you cast this spell, exile up to one target permanent that's one or more colors.\nWhenever you cast a colorless spell, exile up to one target permanent that's one or more colors.\n+2: You gain 3 life and draw a card.\n0: Add {C}{C}{C}.\n\u221211: Search your library for any number of colorless nonland cards, exile them, then shuffle. Until end of turn, you may cast those cards without paying their mana costs.",
             "colours": [],
@@ -14804,7 +14804,7 @@
         },
         {
             "id": "0d3dfdf9-27b9-5077-b13a-5ea3ebea2d91",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg?1",
             "name": "Ugin, Eye of the Storms // Ugin, Eye of the Storms",
             "text": "",
             "colours": [],
@@ -14836,7 +14836,7 @@
         },
         {
             "id": "cacfb167-dfce-52b3-b845-4b113102dfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bd76c7-7a1e-4119-8f4a-12b536b30a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bd76c7-7a1e-4119-8f4a-12b536b30a32.jpg?1",
             "name": "Awaken the Honored Dead",
             "text": "I \u2014 Destroy target nonland permanent.\nII \u2014 Mill three cards.\nIII \u2014 You may discard a card. When you do, return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "a5d4170c-cb6d-5f62-9719-c1cf9d0374f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09d4015-f101-4529-a603-c66192dcfd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09d4015-f101-4529-a603-c66192dcfd92.jpg?1",
             "name": "Barrensteppe Siege",
             "text": "As this enchantment enters, choose Abzan or Mardu.\n\u2022 Abzan \u2014 At the beginning of your end step, put a +1/+1 counter on each creature you control.\n\u2022 Mardu \u2014 At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
             "colours": [
@@ -14912,7 +14912,7 @@
         },
         {
             "id": "a3511d29-d929-5ed9-8288-a1b3c3a85144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32ab782-5f99-489c-895a-49c5c5ea249d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32ab782-5f99-489c-895a-49c5c5ea249d.jpg?1",
             "name": "Frostcliff Siege",
             "text": "As this enchantment enters, choose Jeskai or Temur.\n\u2022 Jeskai \u2014 Whenever one or more creatures you control deal combat damage to a player, draw a card.\n\u2022 Temur \u2014 Creatures you control get +1/+0 and have trample and haste.",
             "colours": [
@@ -14948,7 +14948,7 @@
         },
         {
             "id": "51561b32-c0a3-5fa6-8621-46ec41b7df07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6626cc5e-3a9f-4832-a88a-abf6466e2bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6626cc5e-3a9f-4832-a88a-abf6466e2bae.jpg?1",
             "name": "Glacierwood Siege",
             "text": "As this enchantment enters, choose Temur or Sultai.\n\u2022 Temur \u2014 Whenever you cast an instant or sorcery spell, target player mills four cards.\n\u2022 Sultai \u2014 You may play lands from your graveyard.",
             "colours": [
@@ -14984,7 +14984,7 @@
         },
         {
             "id": "e686dfe3-c104-5e7c-8e62-da44fd9f3e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9a6427-09cc-4ddf-88a6-fc23498a7c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9a6427-09cc-4ddf-88a6-fc23498a7c08.jpg?1",
             "name": "Hollowmurk Siege",
             "text": "As this enchantment enters, choose Sultai or Abzan.\n\u2022 Sultai \u2014 Whenever a counter is put on a creature you control, draw a card. This ability triggers only once each turn.\n\u2022 Abzan \u2014 Whenever you attack, put a +1/+1 counter on target attacking creature. It gains menace until end of turn.",
             "colours": [
@@ -15020,7 +15020,7 @@
         },
         {
             "id": "3f7de260-8a02-5493-bf72-4e09f9e6725d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0797b4-7e06-4f64-95f3-3a7d694d601a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0797b4-7e06-4f64-95f3-3a7d694d601a.jpg?1",
             "name": "Rediscover the Way",
             "text": "I, II \u2014 Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\nIII \u2014 Whenever you cast a noncreature spell this turn, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -15060,7 +15060,7 @@
         },
         {
             "id": "9a7e66d3-e97b-5670-ac52-3f73c2b202f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae833e4-b1b8-44cf-a831-d10b78328b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae833e4-b1b8-44cf-a831-d10b78328b81.jpg?1",
             "name": "Revival of the Ancestors",
             "text": "I \u2014 Create three 1/1 white Spirit creature tokens.\nII \u2014 Distribute three +1/+1 counters among one, two, or three target creatures you control.\nIII \u2014 Creatures you control gain trample and lifelink until end of turn.",
             "colours": [
@@ -15100,7 +15100,7 @@
         },
         {
             "id": "bcc68561-b809-5ae5-9578-323229ea0bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2624c7f-1c10-49c7-be74-e7b2dc8dac12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2624c7f-1c10-49c7-be74-e7b2dc8dac12.jpg?1",
             "name": "Roar of Endless Song",
             "text": "I, II \u2014 Create a 5/5 green Elephant creature token.\nIII \u2014 Double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "31cde842-b500-52c2-997e-d44947559dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd218be-b4c1-4dc7-9672-a16892f1b1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd218be-b4c1-4dc7-9672-a16892f1b1e7.jpg?1",
             "name": "Thunder of Unity",
             "text": "I \u2014 You draw two cards and you lose 2 life.\nII, III \u2014 Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -15180,7 +15180,7 @@
         },
         {
             "id": "35526741-35c6-5b8b-ab70-ef9aa7c134e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32111e6-c389-4dcd-9dcd-29ee7ee238e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32111e6-c389-4dcd-9dcd-29ee7ee238e6.jpg?1",
             "name": "Windcrag Siege",
             "text": "As this enchantment enters, choose Mardu or Jeskai.\n\u2022 Mardu \u2014 If a creature attacking causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n\u2022 Jeskai \u2014 At the beginning of your upkeep, create a 1/1 red Goblin creature token. It gains lifelink and haste until end of turn.",
             "colours": [
@@ -15216,7 +15216,7 @@
         },
         {
             "id": "bd83e20a-0bee-5382-8358-3221287b64be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b84c4c-465d-4d8d-8d38-2ed08a9213b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b84c4c-465d-4d8d-8d38-2ed08a9213b3.jpg?1",
             "name": "Cori Mountain Monastery",
             "text": "This land enters tapped unless you control a Plains or an Island.\n{T}: Add {R}.\n{3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [],
@@ -15248,7 +15248,7 @@
         },
         {
             "id": "bc9b810f-1605-55a9-891a-c51a6814e1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af006f6-135e-4ea0-8ce4-7824934e87da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af006f6-135e-4ea0-8ce4-7824934e87da.jpg?1",
             "name": "Dalkovan Encampment",
             "text": "This land enters tapped unless you control a Swamp or a Mountain.\n{T}: Add {W}.\n{2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens that are tapped and attacking. Sacrifice them at the beginning of the next end step.",
             "colours": [],
@@ -15280,7 +15280,7 @@
         },
         {
             "id": "b2ff3a0f-1b47-5741-b93c-aea65f63f15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98fdfc0-5dd2-4059-8fd6-73378235de55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98fdfc0-5dd2-4059-8fd6-73378235de55.jpg?1",
             "name": "Great Arashin City",
             "text": "This land enters tapped unless you control a Forest or a Plains.\n{T}: Add {B}.\n{1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit creature token.",
             "colours": [],
@@ -15312,7 +15312,7 @@
         },
         {
             "id": "a730ceee-a34f-5837-9818-526b29db1c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687459d1-f487-4ef6-9532-d68425d71210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687459d1-f487-4ef6-9532-d68425d71210.jpg?1",
             "name": "Kishla Village",
             "text": "This land enters tapped unless you control an Island or a Swamp.\n{T}: Add {G}.\n{3}{G}, {T}: Surveil 2.",
             "colours": [],
@@ -15344,7 +15344,7 @@
         },
         {
             "id": "0dcfd635-84c9-5f2b-bc5b-eb2a09c18896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4f775c-98dd-4506-a02c-d22024f31d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4f775c-98dd-4506-a02c-d22024f31d67.jpg?1",
             "name": "Mistrise Village",
             "text": "This land enters tapped unless you control a Mountain or a Forest.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn can't be countered.",
             "colours": [],
@@ -15376,7 +15376,7 @@
         },
         {
             "id": "ef7955f4-0aca-53a4-9b00-ffb5ddbae260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdf9438-fd5f-4638-8f41-dae35ae8f257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdf9438-fd5f-4638-8f41-dae35ae8f257.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n+1: Create a 1/1 white Soldier creature token.\n0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your next turn.\n\u22123: Destroy target creature an opponent controls with mana value 3 or greater.",
             "colours": [
@@ -15416,7 +15416,7 @@
         },
         {
             "id": "8cc28706-1594-582f-b0d1-ae4bbfa6e5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43085bc6-4d16-4a78-af31-b10cea602fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43085bc6-4d16-4a78-af31-b10cea602fc8.jpg?1",
             "name": "Ugin, Eye of the Storms",
             "text": "When you cast this spell, exile up to one target permanent that's one or more colors.\nWhenever you cast a colorless spell, exile up to one target permanent that's one or more colors.\n+2: You gain 3 life and draw a card.\n0: Add {C}{C}{C}.\n\u221211: Search your library for any number of colorless nonland cards, exile them, then shuffle. Until end of turn, you may cast those cards without paying their mana costs.",
             "colours": [],
@@ -15450,7 +15450,7 @@
         },
         {
             "id": "a571b4ec-fc18-5297-95c3-6b0f990cc6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa73d25-c887-487a-ba77-0d4ca992f106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa73d25-c887-487a-ba77-0d4ca992f106.jpg?1",
             "name": "Clarion Conqueror",
             "text": "Flying\nActivated abilities of artifacts, creatures, and planeswalkers can't be activated.",
             "colours": [
@@ -15486,7 +15486,7 @@
         },
         {
             "id": "f305af5b-7c2a-52f4-8a6f-b296a1664f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f421da3b-b88d-4e9f-865b-61120bff917a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f421da3b-b88d-4e9f-865b-61120bff917a.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n+1: Create a 1/1 white Soldier creature token.\n0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your next turn.\n\u22123: Destroy target creature an opponent controls with mana value 3 or greater.",
             "colours": [
@@ -15525,7 +15525,7 @@
         },
         {
             "id": "79dcdacb-7e9f-5730-be27-3e773ce0d57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737d2ab6-bb45-432c-9ce2-e9ecb513ee4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737d2ab6-bb45-432c-9ce2-e9ecb513ee4d.jpg?1",
             "name": "Dracogenesis",
             "text": "You may cast Dragon spells without paying their mana costs.",
             "colours": [
@@ -15560,7 +15560,7 @@
         },
         {
             "id": "7b0d3123-e1b3-5278-ae77-29bf44bb74d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be50dc-3735-47a6-9af3-e8d8e425b5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be50dc-3735-47a6-9af3-e8d8e425b5b2.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token.\nWhenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying.",
             "colours": [
@@ -15600,7 +15600,7 @@
         },
         {
             "id": "0c563730-02bd-5be9-9001-9583763bc768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e172790-7ab4-4dea-9439-e3cedd3e5cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e172790-7ab4-4dea-9439-e3cedd3e5cab.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen this creature enters, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "bdd58a30-e494-55c5-829f-81aa9c8e73b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c0f348-2435-4c62-9bf7-c1efded1fca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c0f348-2435-4c62-9bf7-c1efded1fca0.jpg?1",
             "name": "All-Out Assault",
             "text": "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment enters, if it's your main phase, there is an additional combat phase after this phase followed by an additional main phase. When you next attack this turn, untap each creature you control.",
             "colours": [
@@ -15676,7 +15676,7 @@
         },
         {
             "id": "bfebc48e-84c5-5ddc-b4b8-3a8acdaebd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08cb3168-6872-43b6-9980-35ddc20cf192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08cb3168-6872-43b6-9980-35ddc20cf192.jpg?1",
             "name": "Death Begets Life",
             "text": "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.",
             "colours": [
@@ -15715,7 +15715,7 @@
         },
         {
             "id": "14cea93c-589e-54e3-864a-4e0a4ebc1632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a1c532-e0f6-456a-a6d9-5f7bf1a6b47c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a1c532-e0f6-456a-a6d9-5f7bf1a6b47c.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "At the beginning of your end step, you may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn.",
             "colours": [
@@ -15759,7 +15759,7 @@
         },
         {
             "id": "2e5b82ab-4b43-5174-a97e-aad9948fcecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaca731-0886-4617-b012-451a5ba768db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaca731-0886-4617-b012-451a5ba768db.jpg?1",
             "name": "Skirmish Rhino",
             "text": "Trample\nWhen this creature enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -15799,7 +15799,7 @@
         },
         {
             "id": "186c47bd-4d0c-57a2-a3b4-ebada06aa583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7cb37b-3ab5-42d0-860a-0c0760924850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7cb37b-3ab5-42d0-860a-0c0760924850.jpg?1",
             "name": "Ugin, Eye of the Storms",
             "text": "",
             "colours": [],
@@ -15833,7 +15833,7 @@
         },
         {
             "id": "cbf169a5-761c-5873-9249-37c13eeaab21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eada03-eaca-4091-8fa0-f8e996a402ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eada03-eaca-4091-8fa0-f8e996a402ad.jpg?1",
             "name": "Clarion Conqueror",
             "text": "",
             "colours": [
@@ -15869,7 +15869,7 @@
         },
         {
             "id": "15693f55-81b8-500b-9fd2-90d7893015ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b98fd0-e2e5-4533-af2b-5230af2c88bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b98fd0-e2e5-4533-af2b-5230af2c88bd.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "",
             "colours": [
@@ -15908,7 +15908,7 @@
         },
         {
             "id": "e01bdac8-c83f-52b3-a203-4cdd6554141d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b6d099-e31f-45b5-b78a-72a4b38d60f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b6d099-e31f-45b5-b78a-72a4b38d60f0.jpg?1",
             "name": "Dracogenesis",
             "text": "",
             "colours": [
@@ -15943,7 +15943,7 @@
         },
         {
             "id": "afe8f05c-11ed-5b2a-9157-4270d3f6eae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267ced0-34af-483c-ba42-517f3f7e22dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267ced0-34af-483c-ba42-517f3f7e22dc.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "",
             "colours": [
@@ -15983,7 +15983,7 @@
         },
         {
             "id": "3b19c00f-4af2-5263-9d80-4b61f9c78192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13f37b1-48ff-45b5-8625-d089073ca90b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13f37b1-48ff-45b5-8625-d089073ca90b.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "",
             "colours": [
@@ -16020,7 +16020,7 @@
         },
         {
             "id": "cefe78f6-8c84-55ed-8a5c-ba7e80cf3edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37821af8-a873-497a-82cc-51095f1eed37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37821af8-a873-497a-82cc-51095f1eed37.jpg?1",
             "name": "All-Out Assault",
             "text": "",
             "colours": [
@@ -16059,7 +16059,7 @@
         },
         {
             "id": "08fb8375-5c62-5848-9de4-64193caa312e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1251fb-1f39-4afb-b902-140032f20192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1251fb-1f39-4afb-b902-140032f20192.jpg?1",
             "name": "Death Begets Life",
             "text": "",
             "colours": [
@@ -16098,7 +16098,7 @@
         },
         {
             "id": "232404a7-0c55-5cb6-b594-9f7c24c4667e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104106-2922-404e-a959-5d6d071aad74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104106-2922-404e-a959-5d6d071aad74.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "",
             "colours": [
@@ -16142,7 +16142,7 @@
         },
         {
             "id": "235c80f7-7c22-5085-9d99-ed665ae23bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5346269a-aa11-4a93-9fbc-109421afe579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5346269a-aa11-4a93-9fbc-109421afe579.jpg?1",
             "name": "Skirmish Rhino",
             "text": "",
             "colours": [
@@ -16182,7 +16182,7 @@
         },
         {
             "id": "b48f16cd-53a6-57f7-a5d1-3385075cc0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec33ea23-c8e8-4066-91b9-5e0ad191bcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec33ea23-c8e8-4066-91b9-5e0ad191bcdb.jpg?1",
             "name": "Mox Jasper",
             "text": "",
             "colours": [],
@@ -16214,7 +16214,7 @@
         },
         {
             "id": "ada1c311-94fa-5e5d-9d6a-b166996b7a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3c128-e4a9-4d21-8cf4-dfc122cc0957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3c128-e4a9-4d21-8cf4-dfc122cc0957.jpg?1",
             "name": "Static Snare",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature.\nWhen this enchantment enters, exile target artifact or creature an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -16248,7 +16248,7 @@
         },
         {
             "id": "0e7e80f4-edcf-5ca6-9211-8f6790afcd1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31cd0d01-8d3f-4a00-acfd-a43a93e14e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31cd0d01-8d3f-4a00-acfd-a43a93e14e7d.jpg?1",
             "name": "Roiling Dragonstorm",
             "text": "When this enchantment enters, draw two cards, then discard a card.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -16283,7 +16283,7 @@
         },
         {
             "id": "63bc614a-e22b-586e-86f8-6d05c685a0e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8e99f9-7557-45e3-af72-c5cb87927202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8e99f9-7557-45e3-af72-c5cb87927202.jpg?1",
             "name": "Strategic Betrayal",
             "text": "Target opponent exiles a creature they control and their graveyard.",
             "colours": [
@@ -16317,7 +16317,7 @@
         },
         {
             "id": "c3712143-38ec-5566-b060-254d5675d74c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377aac92-3278-4c81-9095-04ff7d7a81dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377aac92-3278-4c81-9095-04ff7d7a81dc.jpg?1",
             "name": "Channeled Dragonfire",
             "text": "Channeled Dragonfire deals 2 damage to any target.\nHarmonize {5}{R}{R}",
             "colours": [
@@ -16351,7 +16351,7 @@
         },
         {
             "id": "e29b2af3-2234-5f59-a29c-9881140805df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07d668d-bff0-4bae-a42e-4130fdc1016d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07d668d-bff0-4bae-a42e-4130fdc1016d.jpg?1",
             "name": "Encroaching Dragonstorm",
             "text": "When this enchantment enters, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -16386,7 +16386,7 @@
         },
         {
             "id": "2a6157b9-f349-574e-942a-f039b8e78b93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee706aa4-3188-47ee-b164-35287b26e677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee706aa4-3188-47ee-b164-35287b26e677.jpg?1",
             "name": "Temur Battlecrier",
             "text": "During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.",
             "colours": [
@@ -16427,7 +16427,7 @@
         },
         {
             "id": "5aa634bb-b8b5-5190-bc3e-be77dc92b46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f54ff0-e10a-4f22-ada8-43b61d46ee75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f54ff0-e10a-4f22-ada8-43b61d46ee75.jpg?1",
             "name": "Qarsi Revenant",
             "text": "Flying, deathtouch, lifelink\nRenew \u2014 {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch counter, and a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -16463,7 +16463,7 @@
         },
         {
             "id": "bfc3fdde-e02b-5444-995c-bd8fcbbd9724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45364163-62b7-4641-b2c9-c2e46d61335c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45364163-62b7-4641-b2c9-c2e46d61335c.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -16491,7 +16491,7 @@
         },
         {
             "id": "67253fa4-f6af-57e9-b7e2-bf973e4c1bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6105623a-ff2c-46bf-8881-e8b899d47d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6105623a-ff2c-46bf-8881-e8b899d47d54.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16526,7 +16526,7 @@
         },
         {
             "id": "f8052c87-e8c0-5b14-a382-60686eee82a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -16561,7 +16561,7 @@
         },
         {
             "id": "df272d7c-be2c-5f53-8edf-9816e578f5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6455d903-6996-448f-9148-9068febecb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6455d903-6996-448f-9148-9068febecb00.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16596,7 +16596,7 @@
         },
         {
             "id": "56f90b98-163e-52ad-a14d-6996fda56f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16631,7 +16631,7 @@
         },
         {
             "id": "aa9952f1-590d-551e-a881-cb4be1e83adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22410b3-5c0b-4282-9b0b-5ba61229b6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22410b3-5c0b-4282-9b0b-5ba61229b6e7.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16666,7 +16666,7 @@
         },
         {
             "id": "c5d0dea4-a25d-5c20-8ddd-f9684af1a48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a7343-9f5f-4b79-8929-c84011de401c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a7343-9f5f-4b79-8929-c84011de401c.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16701,7 +16701,7 @@
         },
         {
             "id": "e5d40de2-cdaf-5c3a-a4e1-e8cc8d2383ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997edcc4-6021-4443-9470-3fd7f7595cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997edcc4-6021-4443-9470-3fd7f7595cc6.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16736,7 +16736,7 @@
         },
         {
             "id": "ce47d822-2ec8-5683-91d7-96716305caac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4fc2f-95a4-49d0-b06e-b88d19637737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4fc2f-95a4-49d0-b06e-b88d19637737.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16771,7 +16771,7 @@
         },
         {
             "id": "ff34c783-11e6-5b8d-af52-5d3ce32c3599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d5813-7818-43e8-b08d-4ed8c54d0366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d5813-7818-43e8-b08d-4ed8c54d0366.jpg?1",
             "name": "Zombie Druid",
             "text": "",
             "colours": [],
@@ -16805,7 +16805,7 @@
         },
         {
             "id": "3faefddb-e3f0-521e-a62f-1aea5459f650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434c2965-82b8-4e89-bf45-a8fc093f9a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434c2965-82b8-4e89-bf45-a8fc093f9a21.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -16840,7 +16840,7 @@
         },
         {
             "id": "624155e0-9fb2-5dc4-ab66-fb7cd6196d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e265ca24-96c0-4654-a8f3-bbffe288970a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e265ca24-96c0-4654-a8f3-bbffe288970a.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16875,7 +16875,7 @@
         },
         {
             "id": "0639a7f1-e1a9-5c70-9d2f-e43e36448115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -16910,7 +16910,7 @@
         },
         {
             "id": "6c2e98d6-9d2b-563f-85b9-c902eee269e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243bcfa9-0310-4d68-9864-df46069906fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243bcfa9-0310-4d68-9864-df46069906fa.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -16945,7 +16945,7 @@
         },
         {
             "id": "51357bef-a714-5243-8133-3edafc0b71b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44465924-8cc2-49a4-bc07-8dbae7570af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44465924-8cc2-49a4-bc07-8dbae7570af6.jpg?1",
             "name": "Reliquary Dragon",
             "text": "",
             "colours": [
@@ -16988,7 +16988,7 @@
         },
         {
             "id": "198c5204-6b23-5085-b962-e6db6c948bd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8f66e1-4eab-4d51-b10e-9cedd607d709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8f66e1-4eab-4d51-b10e-9cedd607d709.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/THB.json
+++ b/Assets/Resources/Sets/THB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "aa8816f1-8810-5132-af0e-96fbd1e08888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c8c075-9597-412e-9fc4-9d73b4405d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c8c075-9597-412e-9fc4-9d73b4405d12.jpg?1",
             "name": "Alseid of Life's Bounty",
             "text": "Lifelink\n{1}, Sacrifice Alseid of Life's Bounty: Target creature or enchantment you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "c7bbaa90-21aa-531b-a16b-72adf3b84346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dd1e40-a514-42df-8cc1-364998c7700c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dd1e40-a514-42df-8cc1-364998c7700c.jpg?1",
             "name": "Archon of Falling Stars",
             "text": "Flying\nWhen Archon of Falling Stars dies, you may return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "3b93324d-e472-59a5-8bdf-a77c1dd92771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e5999-e8e5-4093-adff-9d47aec70d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e5999-e8e5-4093-adff-9d47aec70d10.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, create a 2/2 white Pegasus creature token with flying.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "8ddf8751-7b37-53b8-aefc-379a2ea10ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddd113-140f-49c9-b45c-cf1b0d1dffd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddd113-140f-49c9-b45c-cf1b0d1dffd8.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "262785a1-96ca-5a63-b325-0f5aff23d979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d824f8bd-58f8-4796-80b5-5cd3033d35e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d824f8bd-58f8-4796-80b5-5cd3033d35e8.jpg?1",
             "name": "The Birth of Meletis",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle your library.\nII \u2014 Create a 0/4 colorless Wall artifact creature token with defender.\nIII \u2014 You gain 2 life.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "cd7db13c-d0cc-53ce-b68b-10e1d0444632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13893599-0b87-4fc0-863d-f3e0ae51cc31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13893599-0b87-4fc0-863d-f3e0ae51cc31.jpg?1",
             "name": "Captivating Unicorn",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "14dea815-1242-58b0-a495-02e03b6da059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e2f681-918e-4f1f-afb1-0f9587c0d7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e2f681-918e-4f1f-afb1-0f9587c0d7bf.jpg?1",
             "name": "Commanding Presence",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has first strike and \"Whenever this creature deals combat damage to a player, create a 1/1 white Human Soldier creature token.\"",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "5ab92e40-6d8a-5127-a686-ac3930174553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e152ae-43ec-4b9d-a43f-786c2f6c7366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e152ae-43ec-4b9d-a43f-786c2f6c7366.jpg?1",
             "name": "Dawn Evangel",
             "text": "Whenever a creature dies, if an Aura you controlled was attached to it, return target creature card with converted mana cost 2 or less from your graveyard to your hand.",
             "colours": [
@@ -281,7 +281,7 @@
         },
         {
             "id": "33bb725c-5cbe-50b7-accd-dd714a2e610e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd2adb3-a6f4-448e-af2a-15ca92b1de63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd2adb3-a6f4-448e-af2a-15ca92b1de63.jpg?1",
             "name": "Daxos, Blessed by the Sun",
             "text": "Daxos's toughness is equal to your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)\nWhenever another creature you control enters the battlefield or dies, you gain 1 life.",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "b93c2a9e-6e7e-5e00-9b32-e63c6d7e0eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c1de31-73d4-4c32-9f99-e15df48638e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c1de31-73d4-4c32-9f99-e15df48638e9.jpg?1",
             "name": "Daybreak Chimera",
             "text": "This spell costs {X} less to cast, where X is your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)\nFlying",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "6bb55a8e-4e44-50f9-9205-45ede947601e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20c2369-db77-465e-9f0e-bb009225345a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20c2369-db77-465e-9f0e-bb009225345a.jpg?1",
             "name": "Dreadful Apathy",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
             "colours": [
@@ -388,7 +388,7 @@
         },
         {
             "id": "8a339c7f-b4f6-5309-8d1a-8952e0f2de17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48f802-df9d-45b2-afea-98699bcdf0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48f802-df9d-45b2-afea-98699bcdf0d6.jpg?1",
             "name": "Eidolon of Obstruction",
             "text": "First strike\nLoyalty abilities of planeswalkers your opponents control cost {1} more to activate.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "1ac3ade3-a329-5325-a710-ef85dc8aa014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20208b-1939-4c69-8cfd-c0a42f9dc427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20208b-1939-4c69-8cfd-c0a42f9dc427.jpg?1",
             "name": "Elspeth Conquers Death",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile target permanent an opponent controls with converted mana cost 3 or greater.\nII \u2014 Noncreature spells your opponents cast cost {2} more to cast until your next turn.\nIII \u2014 Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter or a loyalty counter on it.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "57f20483-d1a9-56ea-ba93-28b4ac1ddde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aec42f-abb7-42f9-96f5-f1ee2f94db52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aec42f-abb7-42f9-96f5-f1ee2f94db52.jpg?1",
             "name": "Elspeth, Sun's Nemesis",
             "text": "\u22121: Up to two target creatures you control each get +2/+1 until end of turn.\n\u22122: Create two 1/1 white Human Soldier creature tokens.\n\u22123: You gain 5 life.\nEscape\u2014{4}{W}{W}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "652ff129-9588-5dda-84c9-0675fe60e5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09e7aff-d873-4420-b0d5-1c63d686dd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09e7aff-d873-4420-b0d5-1c63d686dd73.jpg?1",
             "name": "Favored of Iroas",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Favored of Iroas gains double strike until end of turn.",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "022c745c-b45c-5645-8689-17a7a06f94dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e19bac-176c-4e37-bfc8-27c00de7c37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e19bac-176c-4e37-bfc8-27c00de7c37f.jpg?1",
             "name": "Flicker of Fate",
             "text": "Exile target creature or enchantment, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "d1542b77-fe30-555c-885a-f3f4f62496e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a70e1be-f04a-43c1-8fca-205a24e3db38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a70e1be-f04a-43c1-8fca-205a24e3db38.jpg?1",
             "name": "Glory Bearers",
             "text": "Whenever another creature you control attacks, it gets +0/+1 until end of turn.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "3d745060-ab05-541d-9677-7fd7aff1b64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a8576e-cadc-4521-aadd-3a05f0bc4d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a8576e-cadc-4521-aadd-3a05f0bc4d20.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nWhenever you gain life, put a +1/+1 counter on target creature or enchantment you control.\n{1}{W}: Another target creature gains lifelink until end of turn.",
             "colours": [
@@ -639,7 +639,7 @@
         },
         {
             "id": "c67e23df-18de-5668-83f8-4fc9c23299bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1c16dd-38e9-4974-b570-8678c114a549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1c16dd-38e9-4974-b570-8678c114a549.jpg?1",
             "name": "Heliod's Intervention",
             "text": "Choose one \u2014\n\u2022 Destroy X target artifacts and/or enchantments.\n\u2022 Target player gains twice X life.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "ece6f08a-85c1-50df-8d6c-ee0273cc1be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafce2f5-f4f4-465b-96dc-bcdd29d4e4bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafce2f5-f4f4-465b-96dc-bcdd29d4e4bb.jpg?1",
             "name": "Heliod's Pilgrim",
             "text": "When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -708,7 +708,7 @@
         },
         {
             "id": "9a31c5b9-d3a0-5488-beab-d8c3a997a8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8e6878-06aa-4505-b3a5-172083b7d258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8e6878-06aa-4505-b3a5-172083b7d258.jpg?1",
             "name": "Heliod's Punishment",
             "text": "Enchant creature\nHeliod's Punishment enters the battlefield with four task counters on it.\nEnchanted creature can't attack or block. It loses all abilities and has \"{T}: Remove a task counter from Heliod's Punishment. Then if it has no task counters on it, destroy Heliod's Punishment.\"",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "05319d55-caae-59ec-854f-dd907b07b132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b56863-a52a-4559-a662-f6d9145d5804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b56863-a52a-4559-a662-f6d9145d5804.jpg?1",
             "name": "Hero of the Pride",
             "text": "Whenever you cast a spell that targets Hero of the Pride, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "d09384c0-b4da-52cf-953a-9b06d0986426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da95097-dbe7-416a-8571-6ab6d88a531a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da95097-dbe7-416a-8571-6ab6d88a531a.jpg?1",
             "name": "Hero of the Winds",
             "text": "Flying\nWhenever you cast a spell that targets Hero of the Winds, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "32607cf3-a4d1-5f09-af20-26659fc052e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06edd53-f3ac-44b0-a087-5670ba8f0fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06edd53-f3ac-44b0-a087-5670ba8f0fa5.jpg?1",
             "name": "Idyllic Tutor",
             "text": "Search your library for an enchantment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "825782e1-f5fc-510f-b781-b4812c4ac875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47772a34-c72f-44e8-b272-4ef2d2af5c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47772a34-c72f-44e8-b272-4ef2d2af5c82.jpg?1",
             "name": "Indomitable Will",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "fe1f7415-f552-5c72-9d63-2769dc94e164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c8e4dc-5378-48d6-85b2-f5ea9ec7cf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c8e4dc-5378-48d6-85b2-f5ea9ec7cf36.jpg?1",
             "name": "Karametra's Blessing",
             "text": "Target creature gets +2/+2 until end of turn. If it's an enchanted creature or enchantment creature, it also gains hexproof and indestructible until end of turn. (It can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "5da6274b-799d-52cd-8f25-f7e9d15b5c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a87498-2c2c-411a-aa71-d594b2c6cb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a87498-2c2c-411a-aa71-d594b2c6cb26.jpg?1",
             "name": "Lagonna-Band Storyteller",
             "text": "When Lagonna-Band Storyteller enters the battlefield, you may put target enchantment card from your graveyard on top of your library. If you do, you gain life equal to its converted mana cost.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "2b42a8fa-26a6-5b9c-97fc-9e1e5a0698e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1be3729-7970-45df-8c26-4fe09e56629d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1be3729-7970-45df-8c26-4fe09e56629d.jpg?1",
             "name": "Leonin of the Lost Pride",
             "text": "When Leonin of the Lost Pride dies, exile target card from an opponent's graveyard.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "df22ce58-abba-5753-b17e-436a44e15f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd32240-c003-4e18-adf1-e2e992c702b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd32240-c003-4e18-adf1-e2e992c702b1.jpg?1",
             "name": "Nyxborn Courser",
             "text": "",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "00234fb5-1fea-5993-8303-ab1bd0bb2e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86586fe3-1a6e-4648-b3ff-b0d9340e66ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86586fe3-1a6e-4648-b3ff-b0d9340e66ff.jpg?1",
             "name": "Omen of the Sun",
             "text": "Flash\nWhen Omen of the Sun enters the battlefield, create two 1/1 white Human Soldier creature tokens and you gain 2 life.\n{2}{W}, Sacrifice Omen of the Sun: Scry 2.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "85eb8d28-7a1f-538b-b6af-fc55ab97c279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f114a10-0b00-4f3a-bd73-d4c791fbf4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f114a10-0b00-4f3a-bd73-d4c791fbf4d5.jpg?1",
             "name": "Phalanx Tactics",
             "text": "Target creature you control gets +2/+1 until end of turn. Each other creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "a370cee0-c785-5231-8035-d3a71a023fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg?1",
             "name": "Pious Wayfarer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "b838d14f-a7fa-5c21-b9e6-3d4e1f0e7c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54153b9c-483e-4e5c-a1ab-b1c8a7a657d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54153b9c-483e-4e5c-a1ab-b1c8a7a657d4.jpg?1",
             "name": "Reverent Hoplite",
             "text": "When Reverent Hoplite enters the battlefield, create a number of 1/1 white Human Soldier creature tokens equal to your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "5de5bca0-7d03-58b9-894c-0820ad95758c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb9f86-f487-44b1-815f-30d87868b531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb9f86-f487-44b1-815f-30d87868b531.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "a6a0ad77-0628-5c7b-9001-8f9b2b43aada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f93f3c9-b317-40c1-87f5-0038c09b646d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f93f3c9-b317-40c1-87f5-0038c09b646d.jpg?1",
             "name": "Rumbling Sentry",
             "text": "When Rumbling Sentry enters the battlefield, scry 1.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "cee1fbfb-f780-50ef-8fa4-e1db9798b21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32adc118-b81e-48c2-b7ef-b62e8c3308d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32adc118-b81e-48c2-b7ef-b62e8c3308d6.jpg?1",
             "name": "Sentinel's Eyes",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has vigilance.\nEscape\u2014{W}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "330c7051-1ada-5935-baea-f9f20c408019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b706977b-db8e-4810-882d-ed3745404489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b706977b-db8e-4810-882d-ed3745404489.jpg?1",
             "name": "Shatter the Sky",
             "text": "Each player who controls a creature with power 4 or greater draws a card. Then destroy all creatures.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "1f3cbefd-2aba-5bae-b2ae-00df4c4cda53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg?1",
             "name": "Sunmane Pegasus",
             "text": "Flying\n{1}{W}: Sunmane Pegasus gains vigilance and lifelink until end of turn.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "cfa25e48-918f-5d00-8e6b-478c37e75d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8edd707-5ba3-4978-9a0b-efd0cda367c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8edd707-5ba3-4978-9a0b-efd0cda367c1.jpg?1",
             "name": "Taranika, Akroan Veteran",
             "text": "Vigilance\nWhenever Taranika, Akroan Veteran attacks, untap another target creature you control. Until end of turn, that creature has base power and toughness 4/4 and gains indestructible.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "50b3a49c-d0fb-5b37-948e-3cec37ab604a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9241289-28d2-4827-970e-81bdecbb5c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9241289-28d2-4827-970e-81bdecbb5c16.jpg?1",
             "name": "Transcendent Envoy",
             "text": "Flying\nAura spells you cast cost {1} less to cast.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "87d65077-bc12-53fd-80c1-e09f0a204a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d6eb18-a49d-4fa5-a333-78aafbc4abcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d6eb18-a49d-4fa5-a333-78aafbc4abcb.jpg?1",
             "name": "Triumphant Surge",
             "text": "Destroy target creature with power 4 or greater. You gain 3 life.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "af413de0-1e2f-5eb7-97b6-cdf4f7b1993b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f9ebbe-3791-4d19-88d2-d5de95faff48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f9ebbe-3791-4d19-88d2-d5de95faff48.jpg?1",
             "name": "Alirios, Enraptured",
             "text": "Alirios, Enraptured enters the battlefield tapped.\nAlirios doesn't untap during your untap step if you control a Reflection.\nWhen Alirios enters the battlefield, create a 3/2 blue Reflection creature token.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "84207d23-4633-59dd-9dc1-797763561d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568c679-8421-4184-a73c-b18c4164fea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568c679-8421-4184-a73c-b18c4164fea5.jpg?1",
             "name": "Ashiok's Erasure",
             "text": "Flash\nWhen Ashiok's Erasure enters the battlefield, exile target spell.\nYour opponents can't cast spells with the same name as the exiled card.\nWhen Ashiok's Erasure leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "f7ef1bf2-ecb0-5a40-85b1-4d9b0ddf1896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6811a9dc-e521-4c9e-accb-1efb8346c1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6811a9dc-e521-4c9e-accb-1efb8346c1db.jpg?1",
             "name": "Brine Giant",
             "text": "This spell costs {1} less to cast for each enchantment you control.",
             "colours": [
@@ -1530,7 +1530,7 @@
         },
         {
             "id": "352c3e24-88d5-50d8-bba7-235361147381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d433f2-0a3b-4f45-83a3-ed600a6d10b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d433f2-0a3b-4f45-83a3-ed600a6d10b1.jpg?1",
             "name": "Callaphe, Beloved of the Sea",
             "text": "Callaphe's power is equal to your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)\nCreatures and enchantments you control have \"Spells your opponents cast that target this permanent cost {1} more to cast.\"",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "e99c1832-05e5-51da-9e82-537f592f58f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0e1a22-8f27-4c5b-a65c-c35abd2ff05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0e1a22-8f27-4c5b-a65c-c35abd2ff05b.jpg?1",
             "name": "Chain to Memory",
             "text": "Target creature gets -4/-0 until end of turn. Scry 2.",
             "colours": [
@@ -1601,7 +1601,7 @@
         },
         {
             "id": "6955a085-32f8-5582-9533-c506ef88213b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1200f68a-a8ea-4777-b6b0-de48b2203fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1200f68a-a8ea-4777-b6b0-de48b2203fd1.jpg?1",
             "name": "Deny the Divine",
             "text": "Counter target creature or enchantment spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1633,7 +1633,7 @@
         },
         {
             "id": "ad74973c-e006-5d3d-ac8e-30459e2699b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2897635-b387-485d-932f-5655244a381f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2897635-b387-485d-932f-5655244a381f.jpg?1",
             "name": "Eidolon of Philosophy",
             "text": "{6}{U}, Sacrifice Eidolon of Philosophy: Draw three cards.",
             "colours": [
@@ -1668,7 +1668,7 @@
         },
         {
             "id": "ed54f11c-cdae-5c26-ae32-06dda743f23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cd2dd-aa03-4c55-b9e4-98e0284889d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cd2dd-aa03-4c55-b9e4-98e0284889d3.jpg?1",
             "name": "Elite Instructor",
             "text": "When Elite Instructor enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "8a478c6f-d930-5f92-9a52-b147e41fc06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9c025-1cdb-4da8-8d28-14ad5efb512d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9c025-1cdb-4da8-8d28-14ad5efb512d.jpg?1",
             "name": "Glimpse of Freedom",
             "text": "Draw a card.\nEscape\u2014{2}{U}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "c1ea0da4-7858-5fad-834d-86686fc6f940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4763b6c-6471-41bd-b3e4-785564bcf06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4763b6c-6471-41bd-b3e4-785564bcf06f.jpg?1",
             "name": "Ichthyomorphosis",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a blue Fish with base power and toughness 0/1.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "0b922fe8-0130-5a97-bea1-141f9e6705f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b604451-4f6c-4cfa-8d3a-01f18d01d88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b604451-4f6c-4cfa-8d3a-01f18d01d88f.jpg?1",
             "name": "Kiora Bests the Sea God",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create an 8/8 blue Kraken creature token with hexproof.\nII \u2014 Tap all nonland permanents target opponent controls. They don't untap during their controller's next untap step.\nIII \u2014 Gain control of target permanent an opponent controls. Untap it.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "dd73cb5c-2553-527f-a198-56e07fe82be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2bd7b4-28de-4d9e-86c5-a46bd608cb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2bd7b4-28de-4d9e-86c5-a46bd608cb02.jpg?1",
             "name": "Medomai's Prophecy",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI \u2014 Scry 2.\nII \u2014 Choose a card name.\nIII \u2014 When you cast a spell with the chosen name for the first time this turn, draw two cards.\nIV \u2014 Look at the top card of each player's library.",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "3495a86b-e37c-545a-961e-cc538c841a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadc1809-d6bb-455c-b6ce-dd11521808b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadc1809-d6bb-455c-b6ce-dd11521808b6.jpg?1",
             "name": "Memory Drain",
             "text": "Counter target spell. Scry 2.",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "d5953f14-1221-51bc-8917-5d532fbe08cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7817e039-e509-4b6f-b5a3-deb3769bbdc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7817e039-e509-4b6f-b5a3-deb3769bbdc8.jpg?1",
             "name": "Nadir Kraken",
             "text": "Whenever you draw a card, you may pay {1}. If you do, put a +1/+1 counter on Nadir Kraken and create a 1/1 blue Tentacle creature token.",
             "colours": [
@@ -1905,7 +1905,7 @@
         },
         {
             "id": "b7acf506-6547-5ce4-acc3-ba137e15327c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6ae489-658b-4c12-b204-f7b58ce84375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6ae489-658b-4c12-b204-f7b58ce84375.jpg?1",
             "name": "Naiad of Hidden Coves",
             "text": "As long as it's not your turn, spells you cast cost {1} less to cast.",
             "colours": [
@@ -1940,7 +1940,7 @@
         },
         {
             "id": "5ff31e60-202e-584e-979f-60fa475cc4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad0c7d7-0e44-496f-a2fc-fafc604cb1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad0c7d7-0e44-496f-a2fc-fafc604cb1f1.jpg?1",
             "name": "Nyxborn Seaguard",
             "text": "",
             "colours": [
@@ -1976,7 +1976,7 @@
         },
         {
             "id": "4466b7e2-ecc8-590a-baf7-9f45ff7971f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f30ecd-d009-4d44-aef4-c926ed55a521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f30ecd-d009-4d44-aef4-c926ed55a521.jpg?1",
             "name": "Omen of the Sea",
             "text": "Flash\nWhen Omen of the Sea enters the battlefield, scry 2, then draw a card.\n{2}{U}, Sacrifice Omen of the Sea: Scry 2.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "25620574-ecff-5b31-a3d7-d38a7822ad72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b7070d-4b09-4390-aa21-1bc0aa2b629c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b7070d-4b09-4390-aa21-1bc0aa2b629c.jpg?1",
             "name": "One with the Stars",
             "text": "Enchant creature or enchantment\nEnchanted permanent is an enchantment and loses all other card types. (It still has its abilities, but it's no longer a creature.)",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "a124b943-2cec-584d-9ce3-056cbf462523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749bfd81-c61b-4901-8efb-72611fd08244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749bfd81-c61b-4901-8efb-72611fd08244.jpg?1",
             "name": "Protean Thaumaturge",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may have Protean Thaumaturge become a copy of another target creature, except it has this ability.",
             "colours": [
@@ -2079,7 +2079,7 @@
         },
         {
             "id": "497e942d-68b6-5c1a-ac11-8c8ddb609843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4ba296-950c-4e39-ab5e-06be07e4a190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4ba296-950c-4e39-ab5e-06be07e4a190.jpg?1",
             "name": "Riptide Turtle",
             "text": "Flash\nDefender",
             "colours": [
@@ -2113,7 +2113,7 @@
         },
         {
             "id": "7f71dd8e-b657-5f67-90b1-627a0a794f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138fd65-e0c3-42a1-9c0d-4d5f20228b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138fd65-e0c3-42a1-9c0d-4d5f20228b55.jpg?1",
             "name": "Sage of Mysteries",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "a20efd71-cd6f-56af-aa9c-c79341af5902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9504dc26-f5d8-4b9d-9eb1-51a12b893beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9504dc26-f5d8-4b9d-9eb1-51a12b893beb.jpg?1",
             "name": "Sea God's Scorn",
             "text": "Return up to three target creatures and/or enchantments to their owners' hands.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "86adb2fc-ae2f-5381-8889-04c89931f129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b54bea-f2c5-4000-9cbd-04c03a1d2ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b54bea-f2c5-4000-9cbd-04c03a1d2ea2.jpg?1",
             "name": "Shimmerwing Chimera",
             "text": "Flying\nAt the beginning of your upkeep, return up to one other target enchantment you control to its owner's hand.",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "c2d367cb-a3f9-5666-9d8d-ce9eeb8fd5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec538182-efba-48d0-91ad-457461b44748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec538182-efba-48d0-91ad-457461b44748.jpg?1",
             "name": "Shoal Kraken",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "71e287b8-1605-51cf-b41d-ad3365e32d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4007572b-a6c8-4a56-b1a7-ff099189c9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4007572b-a6c8-4a56-b1a7-ff099189c9c0.jpg?1",
             "name": "Sleep of the Dead",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nEscape\u2014{2}{U}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "aa85f029-5dde-59d4-b864-27c10d1d9171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c53625-6928-494a-af87-7eee2f6643a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c53625-6928-494a-af87-7eee2f6643a5.jpg?1",
             "name": "Starlit Mantle",
             "text": "Flash\nEnchant creature you control\nWhen Starlit Mantle enters the battlefield, enchanted creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "76bae12a-6047-57f3-a3f8-153ad67d19c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aec4d0f-ba1e-45f8-9764-9bcc3fa50e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aec4d0f-ba1e-45f8-9764-9bcc3fa50e51.jpg?1",
             "name": "Stern Dismissal",
             "text": "Return target creature or enchantment an opponent controls to its owner's hand.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "abc19e5b-4b66-5974-ab88-7e9a56a072ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162a0b8-a2d1-4664-a445-331aee6d5175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162a0b8-a2d1-4664-a445-331aee6d5175.jpg?1",
             "name": "Stinging Lionfish",
             "text": "Whenever you cast your first spell during each opponent's turn, you may tap or untap target nonland permanent.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "f7e7638a-1237-5a9f-8709-c622f7722b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ac77d4-f918-4bbc-b023-8117a8c401ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ac77d4-f918-4bbc-b023-8117a8c401ee.jpg?1",
             "name": "Sweet Oblivion",
             "text": "Target player puts the top four cards of their library into their graveyard.\nEscape\u2014{3}{U}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "d10be5ed-839b-5b56-bddb-8a4be0aff8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ed3e0-82d0-4410-a6ca-b0f923eadf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ed3e0-82d0-4410-a6ca-b0f923eadf83.jpg?1",
             "name": "Thassa, Deep-Dwelling",
             "text": "Indestructible\nAs long as your devotion to blue is less than five, Thassa isn't a creature.\nAt the beginning of your end step, exile up to one other target creature you control, then return that card to the battlefield under your control.\n{3}{U}: Tap another target creature.",
             "colours": [
@@ -2453,7 +2453,7 @@
         },
         {
             "id": "d51ac0b9-f323-517f-b33f-ff4079e2f3aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1241d0-20d4-4eab-970d-74e476f023b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1241d0-20d4-4eab-970d-74e476f023b4.jpg?1",
             "name": "Thassa's Intervention",
             "text": "Choose one \u2014\n\u2022 Look at the top X cards of your library. Put up to two of them into your hand and the rest on the bottom of your library in a random order.\n\u2022 Counter target spell unless its controller pays twice {X}.",
             "colours": [
@@ -2487,7 +2487,7 @@
         },
         {
             "id": "3c2b75a7-05c5-54eb-a56f-7ae202ccd748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e8b29-13e9-4138-b6a9-d2a0d8188d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e8b29-13e9-4138-b6a9-d2a0d8188d1c.jpg?1",
             "name": "Thassa's Oracle",
             "text": "When Thassa's Oracle enters the battlefield, look at the top X cards of your library, where X is your devotion to blue. Put up to one of them on top of your library and the rest on the bottom of your library in a random order. If X is greater than or equal to the number of cards in your library, you win the game. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "fcec5935-d8da-56de-9756-01bbf53632f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2422973d-36ee-4b8c-9a47-fcd160aa9f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2422973d-36ee-4b8c-9a47-fcd160aa9f63.jpg?1",
             "name": "Thirst for Meaning",
             "text": "Draw three cards. Then discard two cards unless you discard an enchantment card.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "8e5c790c-87dd-59ac-9cdc-b59d473933f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242cdffb-5037-4d49-b194-4b60274a8758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242cdffb-5037-4d49-b194-4b60274a8758.jpg?1",
             "name": "Threnody Singer",
             "text": "Flash\nFlying\nWhen Threnody Singer enters the battlefield, target creature an opponent controls gets -X/-0 until end of turn, where X is your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "13289b16-fdc1-5e59-8cf4-fe94658999b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238b089-c6d8-4e4b-b6a1-a0f89e3b4968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238b089-c6d8-4e4b-b6a1-a0f89e3b4968.jpg?1",
             "name": "Thryx, the Sudden Storm",
             "text": "Flash\nFlying\nSpells you cast with converted mana cost 5 or greater cost {1} less to cast and can't be countered.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "e97ffd62-cf7a-53c2-89ca-3d7f404f21c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2b4ffc-b1e1-4b16-9a51-1a12f8256a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2b4ffc-b1e1-4b16-9a51-1a12f8256a27.jpg?1",
             "name": "Towering-Wave Mystic",
             "text": "Whenever Towering-Wave Mystic deals damage, target player puts that many cards from the top of their library into their graveyard.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "7e6695f0-ebfe-5d28-82fe-c791585e2d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb11d7-feae-4511-9a03-bda23119b6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb11d7-feae-4511-9a03-bda23119b6a5.jpg?1",
             "name": "Triton Waverider",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Triton Waverider gains flying until end of turn.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "17250fe8-0786-502f-b42a-722a7599130f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fee23-df75-448d-9fca-6ba6713d459f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fee23-df75-448d-9fca-6ba6713d459f.jpg?1",
             "name": "Vexing Gull",
             "text": "Flash\nFlying",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "ade86b64-cd7d-5f2e-8fac-3f6bbbfedc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d900dff5-1196-443f-b9b0-b8e75c67c868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d900dff5-1196-443f-b9b0-b8e75c67c868.jpg?1",
             "name": "Wavebreak Hippocamp",
             "text": "Whenever you cast your first spell during each opponent's turn, draw a card.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "07954e51-60a3-5ddc-abdc-c74b1671743c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e127856-bedd-40a9-9e8e-d1f9fbefe07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e127856-bedd-40a9-9e8e-d1f9fbefe07d.jpg?1",
             "name": "Whirlwind Denial",
             "text": "For each spell and ability your opponents control, counter it unless its controller pays {4}.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "aa06bd0b-9691-5466-931e-a6914e836671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd9d60-826c-4b35-9684-dccb0880399e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd9d60-826c-4b35-9684-dccb0880399e.jpg?1",
             "name": "Witness of Tomorrows",
             "text": "Flying\n{3}{U}: Scry 1.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "af58bcd5-2b99-50ad-8bf8-d1ea3e6b9eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09270c65-546e-4737-a6b7-402cbb87917a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09270c65-546e-4737-a6b7-402cbb87917a.jpg?1",
             "name": "Agonizing Remorse",
             "text": "Target opponent reveals their hand. You choose a nonland card from it or a card from their graveyard. Exile that card. You lose 1 life.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "4846ee70-007c-592b-ad1c-ad2cfae8de03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b359607-d699-4ba9-a438-48f0dd8f1bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b359607-d699-4ba9-a438-48f0dd8f1bf5.jpg?1",
             "name": "Aphemia, the Cacophony",
             "text": "Flying\nAt the beginning of your end step, you may exile an enchantment card from your graveyard. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "05aeced9-889b-5b7c-842e-c7db2504a704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27157f01-8aed-4485-9f0f-9e7486492e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27157f01-8aed-4485-9f0f-9e7486492e6e.jpg?1",
             "name": "Aspect of Lamprey",
             "text": "Enchant creature you control\nWhen Aspect of Lamprey enters the battlefield, target opponent discards two cards.\nEnchanted creature has lifelink.",
             "colours": [
@@ -2945,7 +2945,7 @@
         },
         {
             "id": "90965b96-0b9c-55bb-800d-9539ddc78500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7865c079-1d91-48d4-852d-d104b6e0c157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7865c079-1d91-48d4-852d-d104b6e0c157.jpg?1",
             "name": "Blight-Breath Catoblepas",
             "text": "When Blight-Breath Catoblepas enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "32c98e4b-1776-51a8-bdbd-364a1c6e2cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c2de5f-e486-4cfe-9fb6-be0078ce5f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c2de5f-e486-4cfe-9fb6-be0078ce5f93.jpg?1",
             "name": "Cling to Dust",
             "text": "Exile target card from a graveyard. If it was a creature card, you gain 3 life. Otherwise, you draw a card.\nEscape\u2014{3}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "f6a4b7f1-41fb-5422-a019-036886c84dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cce294-f6ee-4b18-8b65-7d01d0317b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cce294-f6ee-4b18-8b65-7d01d0317b00.jpg?1",
             "name": "Discordant Piper",
             "text": "When Discordant Piper dies, create a 0/1 white Goat creature token.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "25890017-c880-59f1-8d53-614155d02f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91852444-9361-4588-a44f-fb90ba1b30e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91852444-9361-4588-a44f-fb90ba1b30e5.jpg?1",
             "name": "Drag to the Underworld",
             "text": "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\nDestroy target creature.",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "71ba4ae1-36a5-56ee-9267-82227418ba95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg?1",
             "name": "Eat to Extinction",
             "text": "Exile target creature or planeswalker. Look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "a1f08713-0eed-5cbc-8345-4730d3f0e9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ccd974-d2bc-4fcf-94a7-0a868a04cb98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ccd974-d2bc-4fcf-94a7-0a868a04cb98.jpg?1",
             "name": "Elspeth's Nightmare",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target creature an opponent controls with power 2 or less.\nII \u2014 Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.\nIII \u2014 Exile target opponent's graveyard.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "2360b80c-6f9c-5e8e-b2c4-86676bfa0075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf15e0-f61b-43b9-9113-39bd341a0163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf15e0-f61b-43b9-9113-39bd341a0163.jpg?1",
             "name": "Enemy of Enlightenment",
             "text": "Flying\nEnemy of Enlightenment gets -1/-1 for each card in your opponents' hands.\nAt the beginning of your upkeep, each player discards a card.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "1cd63876-2f4e-5b7a-aa3b-b76a31e836e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340df19-b89a-403f-9736-4bd30b65de74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340df19-b89a-403f-9736-4bd30b65de74.jpg?1",
             "name": "Erebos, Bleak-Hearted",
             "text": "Indestructible\nAs long as your devotion to black is less than five, Erebos isn't a creature.\nWhenever another creature you control dies, you may pay 2 life. If you do, draw a card.\n{1}{B}, Sacrifice another creature: Target creature gets -2/-1 until end of turn.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "3e280979-2766-5e5f-ae33-47e49631c7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e35c80-6cfe-49fc-8138-562233ccf987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e35c80-6cfe-49fc-8138-562233ccf987.jpg?1",
             "name": "Erebos's Intervention",
             "text": "Choose one \u2014\n\u2022 Target creature gets -X/-X until end of turn. You gain X life.\n\u2022 Exile up to twice X target cards from graveyards.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "fdfe4558-1d6e-5687-adac-f9205a6533a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b8580-9198-4735-83c1-289400c1d814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b8580-9198-4735-83c1-289400c1d814.jpg?1",
             "name": "Final Death",
             "text": "Exile target creature.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "750a7acf-8d5b-5f65-b54d-fffa02e172ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e577a0-e5d7-4e6a-919c-d85c2ae819ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e577a0-e5d7-4e6a-919c-d85c2ae819ce.jpg?1",
             "name": "Fruit of Tizerus",
             "text": "Target player loses 2 life.\nEscape\u2014{3}{B}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3318,7 +3318,7 @@
         },
         {
             "id": "39b3dbdf-de3b-5ad7-a98c-a54e63c9e5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30aa6796-0cb6-426b-9e3f-4d7e4959a6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30aa6796-0cb6-426b-9e3f-4d7e4959a6a4.jpg?1",
             "name": "Funeral Rites",
             "text": "You draw two cards, lose 2 life, and put the top two cards of your library into your graveyard.",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "117bd555-86c2-55ef-9fbe-8892cc8012f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408a2073-d068-44bc-b596-5a3a3a446ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408a2073-d068-44bc-b596-5a3a3a446ee1.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "Lifelink\nWhen Gravebreaker Lamia enters the battlefield, search your library for a card, put it into your graveyard, then shuffle your library.\nSpells you cast from your graveyard cost {1} less to cast.",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "6a048699-0569-5805-abb2-7520a4d7198d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a7dd8-8034-4f59-a351-33666b26ff5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a7dd8-8034-4f59-a351-33666b26ff5a.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "When Gray Merchant of Asphodel enters the battlefield, each opponent loses X life, where X is your devotion to black. You gain life equal to the life lost this way. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "296cf984-ce59-53f4-9650-7b90f831afce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e92c82-840f-4c75-b617-7b58a07be5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e92c82-840f-4c75-b617-7b58a07be5b4.jpg?1",
             "name": "Grim Physician",
             "text": "When Grim Physician dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "318c7cfd-f66d-5c83-b20a-be296cbc3543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0f15-f738-4644-9d29-2589d7e66915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0f15-f738-4644-9d29-2589d7e66915.jpg?1",
             "name": "Hateful Eidolon",
             "text": "Lifelink\nWhenever an enchanted creature dies, draw a card for each Aura you controlled that was attached to it.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "68ac45fd-e7ec-5a66-8450-3cf9c92f4d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6522f01-ae7a-467e-9a05-530a5ccd304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6522f01-ae7a-467e-9a05-530a5ccd304d.jpg?1",
             "name": "Inevitable End",
             "text": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, sacrifice a creature.\"",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "241db690-fd49-55cf-a607-c3fc2074a9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c9ada9-ea25-4a96-a4be-e4cf8f7a014f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c9ada9-ea25-4a96-a4be-e4cf8f7a014f.jpg?1",
             "name": "Lampad of Death's Vigil",
             "text": "{1}, Sacrifice a creature: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "a3da4db7-8c02-5fde-870f-6f29eaf2e254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce763778-0a35-41d2-9286-fdf2302554f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce763778-0a35-41d2-9286-fdf2302554f5.jpg?1",
             "name": "Minion's Return",
             "text": "Flash\nEnchant creature\nWhen enchanted creature dies, return that card to the battlefield under your control.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "b53122ff-ea2c-5921-8934-fe2805da041d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8427d3-4d9e-48c9-838b-239fd1357d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8427d3-4d9e-48c9-838b-239fd1357d95.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, put the top two cards of your library into your graveyard and you gain 2 life.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "09c7fed3-1886-50a0-b31c-538c82658d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae0c536-612d-4916-a8da-5aaaf14218b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae0c536-612d-4916-a8da-5aaaf14218b1.jpg?1",
             "name": "Mire's Grasp",
             "text": "Enchant creature\nEnchanted creature gets -3/-3.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "73a985a4-025a-5c39-b01c-20cfe7c5ad73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6bf7fb-11ca-4878-8072-cebaa763a549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6bf7fb-11ca-4878-8072-cebaa763a549.jpg?1",
             "name": "Mogis's Favor",
             "text": "Enchant creature\nEnchanted creature gets +2/-1.\nEscape\u2014{2}{B}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "9de38d69-f317-5d94-99a5-009bcb87daab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a46eec7-bb79-441c-959f-eea599e5c341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a46eec7-bb79-441c-959f-eea599e5c341.jpg?1",
             "name": "Nightmare Shepherd",
             "text": "Flying\nWhenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that creature, except it's 1/1 and it's a Nightmare in addition to its other types.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "050f6696-dd09-586c-9013-fb90fe6d7c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2a923a-1f9c-4a29-9c6b-344ae4d5ae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2a923a-1f9c-4a29-9c6b-344ae4d5ae8f.jpg?1",
             "name": "Nyxborn Marauder",
             "text": "",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "1c004f44-4c62-5b5e-a538-9c6b3b7c9771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8023fc44-fb8e-420d-a68c-b45912c4e5bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8023fc44-fb8e-420d-a68c-b45912c4e5bd.jpg?1",
             "name": "Omen of the Dead",
             "text": "Flash\nWhen Omen of the Dead enters the battlefield, return target creature card from your graveyard to your hand.\n{2}{B}, Sacrifice Omen of the Dead: Scry 2.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "267f1bef-eea5-59f6-8331-76bf81a0e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0307bb5c-0a46-4f6b-b6d5-58cf31987bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0307bb5c-0a46-4f6b-b6d5-58cf31987bb5.jpg?1",
             "name": "Pharika's Libation",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature.\n\u2022 Target opponent sacrifices an enchantment.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "76adb30f-be96-52db-b243-a4e62f3ef293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c8244b-7d86-4dff-9419-3945beb2a7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c8244b-7d86-4dff-9419-3945beb2a7b7.jpg?1",
             "name": "Pharika's Spawn",
             "text": "Escape\u2014{5}{B}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nPharika's Spawn escapes with two +1/+1 counters on it. When it enters the battlefield this way, each opponent sacrifices a non-Gorgon creature.",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "d02b5b43-81fa-5173-bfea-2b1f3b9103f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f76d7c4-a5d6-4144-b5f3-e43b96b695b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f76d7c4-a5d6-4144-b5f3-e43b96b695b7.jpg?1",
             "name": "Rage-Scarred Berserker",
             "text": "When Rage-Scarred Berserker enters the battlefield, target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3904,7 +3904,7 @@
         },
         {
             "id": "505b4f82-43d2-59b9-9e8b-f53fb5aa3c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e237c5-45b4-49df-adb9-62b9f3b62986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e237c5-45b4-49df-adb9-62b9f3b62986.jpg?1",
             "name": "Scavenging Harpy",
             "text": "Flying\nWhen Scavenging Harpy enters the battlefield, exile target card from an opponent's graveyard.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "3a3617df-0186-56c5-a1ec-55578d61e2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e2f383-d2a0-4424-bf7a-79e82d6f691f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e2f383-d2a0-4424-bf7a-79e82d6f691f.jpg?1",
             "name": "Soulreaper of Mogis",
             "text": "{2}{B}, Sacrifice a creature: Draw a card.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "af311dbe-8576-5f64-8338-58c7ee6ae038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4a61aa-75d2-46bc-b13f-b863f5f49d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4a61aa-75d2-46bc-b13f-b863f5f49d32.jpg?1",
             "name": "Temple Thief",
             "text": "Temple Thief can't be blocked by enchanted creatures or enchantment creatures.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "516b0999-70cd-5050-aeb8-b4be278cb0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3ad6b-9966-489f-a4c9-2639a634fd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3ad6b-9966-489f-a4c9-2639a634fd62.jpg?1",
             "name": "Treacherous Blessing",
             "text": "When Treacherous Blessing enters the battlefield, draw three cards.\nWhenever you cast a spell, you lose 1 life.\nWhen Treacherous Blessing becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "b0067ca9-1abb-57fa-8894-651fb74a73a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c0d087-540a-4249-9265-f13cc8e776ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c0d087-540a-4249-9265-f13cc8e776ea.jpg?1",
             "name": "Tymaret Calls the Dead",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put the top three cards of your library into your graveyard. Then you may exile a creature or enchantment card from your graveyard. If you do, create a 2/2 black Zombie creature token.\nIII \u2014 You gain X life and scry X, where X is the number of Zombies you control.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "17f931e5-d09f-5c47-a577-12cc13b4e20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b28eae-e8ed-4b99-b6ec-86d0716ec473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b28eae-e8ed-4b99-b6ec-86d0716ec473.jpg?1",
             "name": "Tymaret, Chosen from Death",
             "text": "Tymaret's toughness is equal to your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n{1}{B}: Exile up to two target cards from graveyards. You gain 1 life for each creature card exiled this way.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "30a41704-456c-5658-9ebe-27fd48cc6c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dd847f-0db2-4f6a-bdfb-5c88ce7802f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dd847f-0db2-4f6a-bdfb-5c88ce7802f9.jpg?1",
             "name": "Underworld Charger",
             "text": "Underworld Charger can't block.\nEscape\u2014{4}{B}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nUnderworld Charger escapes with two +1/+1 counters on it.",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "356014f0-1cf5-5ef0-8728-4645a77554a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03919c86-1c4a-43b0-a2db-54ca6ae1ac57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03919c86-1c4a-43b0-a2db-54ca6ae1ac57.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to that player.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "2cc6611b-aab7-575c-af60-68e6ce58837a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc2b661-2f42-419d-837f-bbf097c1153c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc2b661-2f42-419d-837f-bbf097c1153c.jpg?1",
             "name": "Venomous Hierophant",
             "text": "Deathtouch\nWhen Venomous Hierophant enters the battlefield, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "40d69dbd-17dd-5a97-9829-3bf0827b7717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457b558-b35b-49fd-b499-b1ec755f86ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457b558-b35b-49fd-b499-b1ec755f86ce.jpg?1",
             "name": "Woe Strider",
             "text": "When Woe Strider enters the battlefield, create a 0/1 white Goat creature token.\nSacrifice another creature: Scry 1.\nEscape\u2014{3}{B}{B}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nWoe Strider escapes with two +1/+1 counters on it.",
             "colours": [
@@ -4254,7 +4254,7 @@
         },
         {
             "id": "b9f2a87e-3b67-5547-8cca-91b6bd06b4f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ea046b-1bbc-4430-a859-321602c9e928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ea046b-1bbc-4430-a859-321602c9e928.jpg?1",
             "name": "The Akroan War",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Gain control of target creature for as long as The Akroan War remains on the battlefield.\nII \u2014 Until your next turn, creatures your opponents control attack each combat if able.\nIII \u2014 Each tapped creature deals damage to itself equal to its power.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "7eaed8a7-3cd9-5895-b11c-be17aad8a462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07285b4-77c5-4a38-8810-20d7e49593ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07285b4-77c5-4a38-8810-20d7e49593ec.jpg?1",
             "name": "Anax, Hardened in the Forge",
             "text": "Anax's power is equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)\nWhenever Anax or another nontoken creature you control dies, create a 1/1 red Satyr creature token with \"This creature can't block.\" If the creature had power 4 or greater, create two of those tokens instead.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "18a774fc-c616-5404-a5ef-8d60df0aaaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e096049d-9f02-4abb-bb5a-97b14fd17099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e096049d-9f02-4abb-bb5a-97b14fd17099.jpg?1",
             "name": "Arena Trickster",
             "text": "Whenever you cast your first spell during each opponent's turn, put a +1/+1 counter on Arena Trickster.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "bc85b359-e715-5d49-a124-4f14a254b328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d0091-1925-44a5-89f3-21c2afd5665c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d0091-1925-44a5-89f3-21c2afd5665c.jpg?1",
             "name": "Aspect of Manticore",
             "text": "Flash\nEnchant creature\nWhen Aspect of Manticore enters the battlefield, enchanted creature gains first strike until end of turn.\nEnchanted creature gets +2/+0.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "5ea26bab-cc00-599d-bf40-e04ba7a51803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f3fa3-ba1f-48dc-a56b-738936f1bf86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f3fa3-ba1f-48dc-a56b-738936f1bf86.jpg?1",
             "name": "Blood Aspirant",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Blood Aspirant.\n{1}{R}, {T}, Sacrifice a creature or enchantment: Blood Aspirant deals 1 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "735d4cc2-156f-5b24-92ea-c233228cc320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6bdd4-b25b-41f6-835d-7d1570cdb951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6bdd4-b25b-41f6-835d-7d1570cdb951.jpg?1",
             "name": "Careless Celebrant",
             "text": "When Careless Celebrant dies, it deals 2 damage to target creature or planeswalker an opponent controls.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "b083057f-dcad-5c5e-85c6-c01427706916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b04ec8-68c9-468c-b137-707db994af68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b04ec8-68c9-468c-b137-707db994af68.jpg?1",
             "name": "Dreamshaper Shaman",
             "text": "At the beginning of your end step, you may pay {2}{R} and sacrifice a nonland permanent. If you do, reveal cards from the top of your library until you reveal a nonland permanent card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "ab9b4826-b2df-5146-859a-46666c7d512d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee10eaa0-dbe0-45ee-9a7d-395ec5d27e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee10eaa0-dbe0-45ee-9a7d-395ec5d27e08.jpg?1",
             "name": "Dreamstalker Manticore",
             "text": "Whenever you cast your first spell during each opponent's turn, Dreamstalker Manticore deals 1 damage to any target.",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "3c26b805-7f48-5d16-a957-ab205e63359a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2a3da-2458-4921-8574-9eb9d5925ae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2a3da-2458-4921-8574-9eb9d5925ae8.jpg?1",
             "name": "Escape Velocity",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has haste.\nEscape\u2014{1}{R}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "27a0b59d-6d7f-5845-9616-9be319f13272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56455067-92c0-45b5-ac2e-525c35b41215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56455067-92c0-45b5-ac2e-525c35b41215.jpg?1",
             "name": "Fateful End",
             "text": "Fateful End deals 3 damage to any target. Scry 1.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "14e61178-c2e1-599c-84ee-f8a9ab487721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c95dee-a480-4878-a967-9e46be9ee372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c95dee-a480-4878-a967-9e46be9ee372.jpg?1",
             "name": "Final Flare",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nFinal Flare deals 5 damage to target creature.",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "b1eb22be-e22d-5802-9c7e-16beeed9afc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70bcef-7ab6-4547-aca4-dd3ba68fd26b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70bcef-7ab6-4547-aca4-dd3ba68fd26b.jpg?1",
             "name": "Flummoxed Cyclops",
             "text": "Reach\nWhenever two or more creatures your opponents control attack, Flummoxed Cyclops can't block this combat.",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "fecf6825-43da-5fd0-a8a1-760c47e016f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2531fb76-038b-49ab-b4d6-31b291faa7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2531fb76-038b-49ab-b4d6-31b291faa7ca.jpg?1",
             "name": "Furious Rise",
             "text": "At the beginning of your end step, if you control a creature with power 4 or greater, exile the top card of your library. You may play that card until you exile another card with Furious Rise.",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "31319ded-6690-5f90-befe-055d61b8a0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb7c7a6-4e9b-4300-a776-b7e7916950c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb7c7a6-4e9b-4300-a776-b7e7916950c8.jpg?1",
             "name": "Hero of the Games",
             "text": "Whenever you cast a spell that targets Hero of the Games, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "b30cdd1c-5b0b-5629-b578-8c0b217f7fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfb481-3446-42f4-a1c3-a88b69f2189a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfb481-3446-42f4-a1c3-a88b69f2189a.jpg?1",
             "name": "Heroes of the Revel",
             "text": "When Heroes of the Revel enters the battlefield, create a 1/1 red Satyr creature token with \"This creature can't block.\"\nWhenever you cast a spell that targets Heroes of the Revel, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "8d379429-d624-5a30-996e-3f081c7deb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681db91-5dab-41e6-96f2-275ec9495e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681db91-5dab-41e6-96f2-275ec9495e5b.jpg?1",
             "name": "Impending Doom",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and attacks each combat if able.\nWhen enchanted creature dies, Impending Doom deals 3 damage to that creature's controller.",
             "colours": [
@@ -4805,7 +4805,7 @@
         },
         {
             "id": "d0c19b45-55f2-545f-89e6-3d6e6ae28258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6b9b5c-35ff-47ac-9b04-71257314b686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6b9b5c-35ff-47ac-9b04-71257314b686.jpg?1",
             "name": "Incendiary Oracle",
             "text": "{1}{R}: Incendiary Oracle gets +1/+0 until end of turn.\nIf a creature dealt damage by Incendiary Oracle this turn would die, exile it instead.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "67b00420-7887-5c7c-b219-95e9ad2e18cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a74392-4056-428c-a807-b062957e838e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a74392-4056-428c-a807-b062957e838e.jpg?1",
             "name": "Infuriate",
             "text": "Target creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "46c62c43-73b0-58a2-87e4-532583e26b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e99a5-b105-489e-aff6-7d2ca50d8ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e99a5-b105-489e-aff6-7d2ca50d8ba9.jpg?1",
             "name": "Iroas's Blessing",
             "text": "Enchant creature you control\nWhen Iroas's Blessing enters the battlefield, it deals 4 damage to target creature or planeswalker an opponent controls.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "c349a957-4907-5e86-87fc-31d74b45bcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg?1",
             "name": "Irreverent Revelers",
             "text": "When Irreverent Revelers enters the battlefield, choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Irreverent Revelers gains haste until end of turn.",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "ea31f3c8-0f36-5344-8579-b7adc2638856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bc4236-566f-401b-b9d7-f58126fa228b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bc4236-566f-401b-b9d7-f58126fa228b.jpg?1",
             "name": "Nyxborn Brute",
             "text": "",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "488bbeac-6461-5181-8762-b7985f8884b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70388773-709b-4cd8-a8b7-56093fd77a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70388773-709b-4cd8-a8b7-56093fd77a1d.jpg?1",
             "name": "Omen of the Forge",
             "text": "Flash\nWhen Omen of the Forge enters the battlefield, it deals 2 damage to any target.\n{2}{R}, Sacrifice Omen of the Forge: Scry 2.",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "dda5d473-b744-50e5-94ed-72d9114071d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9bb73a-5b4e-4c9b-b0a6-8e531dc27394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9bb73a-5b4e-4c9b-b0a6-8e531dc27394.jpg?1",
             "name": "Oread of Mountain's Blaze",
             "text": "{2}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "82cd6def-fef5-5e08-8af8-934f1be45237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75caefa7-94d5-472e-a540-daad3ee69899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75caefa7-94d5-472e-a540-daad3ee69899.jpg?1",
             "name": "Ox of Agonas",
             "text": "When Ox of Agonas enters the battlefield, discard your hand, then draw three cards.\nEscape\u2014{R}{R}, Exile eight other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nOx of Agonas escapes with a +1/+1 counter on it.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "6ed2ceda-d928-56d9-8322-c0fe5670352a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7010ce26-16de-44cb-ba7e-3d904175b429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7010ce26-16de-44cb-ba7e-3d904175b429.jpg?1",
             "name": "Phoenix of Ash",
             "text": "Flying, haste\n{2}{R}: Phoenix of Ash gets +2/+0 until end of turn.\nEscape\u2014{2}{R}{R}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nPhoenix of Ash escapes with a +1/+1 counter on it.",
             "colours": [
@@ -5114,7 +5114,7 @@
         },
         {
             "id": "937db07f-6d46-5c77-aee8-f81070c2d843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c2b855-5079-418e-bfb4-9fc575ebe4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c2b855-5079-418e-bfb4-9fc575ebe4f7.jpg?1",
             "name": "Portent of Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "d9dc4f37-a58a-5f7f-9f87-eaa6e37b9e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3af5c4-0960-44a2-976e-abdf7803c436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3af5c4-0960-44a2-976e-abdf7803c436.jpg?1",
             "name": "Purphoros, Bronze-Blooded",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nOther creatures you control have haste.\n{2}{R}: You may put a red creature card or an artifact creature card from your hand onto the battlefield. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "e06a4d6c-dc62-5ce9-9fbd-4aea646d1ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc911ee-0e12-4b10-add7-9a9d63c29443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc911ee-0e12-4b10-add7-9a9d63c29443.jpg?1",
             "name": "Purphoros's Intervention",
             "text": "Choose one \u2014\n\u2022 Create an X/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n\u2022 Purphoros's Intervention deals twice X damage to target creature or planeswalker.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "0798c148-9813-5efe-b516-0c0e2f3e5a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d8201-be68-42fa-bcfd-42d81a2ad195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d8201-be68-42fa-bcfd-42d81a2ad195.jpg?1",
             "name": "Satyr's Cunning",
             "text": "Create a 1/1 red Satyr creature token with \"This creature can't block.\"\nEscape\u2014{2}{R}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -5251,7 +5251,7 @@
         },
         {
             "id": "1794449f-5002-5d3a-8d7d-6e52052183d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f470a7b-63ef-4efa-855e-f8a3ce1ab534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f470a7b-63ef-4efa-855e-f8a3ce1ab534.jpg?1",
             "name": "Skophos Maze-Warden",
             "text": "{1}: Skophos Maze-Warden gets +1/-1 until end of turn.\nWhenever another creature becomes the target of an ability of a land you control named Labyrinth of Skophos, you may have Skophos Maze-Warden fight that creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "fd57d7a5-4847-5412-b2c5-de3645984be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c39c70-8360-4c7c-b5fa-61c42828609a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c39c70-8360-4c7c-b5fa-61c42828609a.jpg?1",
             "name": "Skophos Warleader",
             "text": "{R}, Sacrifice another creature or an enchantment: Skophos Warleader gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5321,7 +5321,7 @@
         },
         {
             "id": "c2103439-16a4-540c-a556-2679e57dd87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32c6192-2f8d-4656-af8b-c488e27a75e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32c6192-2f8d-4656-af8b-c488e27a75e1.jpg?1",
             "name": "Stampede Rider",
             "text": "Trample\nAt the beginning of each combat, if you control a creature with power 4 or greater, Stampede Rider gets +1/+1 until end of turn.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "022eb4c1-4216-5443-84e1-3743bcf6e19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0594aa2-1c53-4271-a0d0-9002c07f3697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0594aa2-1c53-4271-a0d0-9002c07f3697.jpg?1",
             "name": "Storm Herald",
             "text": "Haste\nWhen Storm Herald enters the battlefield, return any number of Aura cards from your graveyard to the battlefield attached to creatures you control. Exile those Auras at the beginning of your next end step. If those Auras would leave the battlefield, exile them instead of putting them anywhere else.",
             "colours": [
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "0f01c41a-7011-5059-a646-84396cc70fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9ecd2-7664-471b-90f2-2d0dd1acec80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9ecd2-7664-471b-90f2-2d0dd1acec80.jpg?1",
             "name": "Storm's Wrath",
             "text": "Storm's Wrath deals 4 damage to each creature and each planeswalker.",
             "colours": [
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "774b6d6b-76c4-556c-9b10-a9be9558a987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f226550-fc9f-4964-ac62-74f84d0ac3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f226550-fc9f-4964-ac62-74f84d0ac3f3.jpg?1",
             "name": "Tectonic Giant",
             "text": "Whenever Tectonic Giant attacks or becomes the target of a spell an opponent controls, choose one \u2014\n\u2022 Tectonic Giant deals 3 damage to each opponent.\n\u2022 Exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -5463,7 +5463,7 @@
         },
         {
             "id": "50a15975-6cf0-5171-83d6-3ce4e815e89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e807edb-838d-44fe-a37e-fb864d59beaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e807edb-838d-44fe-a37e-fb864d59beaa.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5497,7 +5497,7 @@
         },
         {
             "id": "0dcd85c3-7a40-5d64-8be1-805d2c118d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b5b348-1415-4062-a2a7-017694424c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b5b348-1415-4062-a2a7-017694424c05.jpg?1",
             "name": "The Triumph of Anax",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Until end of turn, target creature gains trample and gets +X/+0, where X is the number of lore counters on The Triumph of Anax.\nIV \u2014 Target creature you control fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5531,7 +5531,7 @@
         },
         {
             "id": "4ef5567b-6c15-5306-b7d6-c434b71c5e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e51d796-7279-4c06-87f0-37adbdaa41df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e51d796-7279-4c06-87f0-37adbdaa41df.jpg?1",
             "name": "Underworld Breach",
             "text": "Each nonland card in your graveyard has escape. The escape cost is equal to the card's mana cost plus exile three other cards from your graveyard. (You may cast cards from your graveyard for their escape cost.)\nAt the beginning of the end step, sacrifice Underworld Breach.",
             "colours": [
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "3d1f0f19-17ab-5eef-afc5-cafaded60938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe616c4-dcb0-4284-ba10-6fbf7cecd217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe616c4-dcb0-4284-ba10-6fbf7cecd217.jpg?1",
             "name": "Underworld Fires",
             "text": "Underworld Fires deals 1 damage to each creature and each planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -5597,7 +5597,7 @@
         },
         {
             "id": "ac3f9f56-e55e-5d9f-8ce3-b5a9f0a852e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04eef82-fd53-41f4-9c7e-28b9ac039032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04eef82-fd53-41f4-9c7e-28b9ac039032.jpg?1",
             "name": "Underworld Rage-Hound",
             "text": "Underworld Rage-Hound attacks each combat if able.\nEscape\u2014{3}{R}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nUnderworld Rage-Hound escapes with a +1/+1 counter on it.",
             "colours": [
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "c11c6a73-6bc4-56aa-85b1-5a25b42a234d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f7ff4f-3fd6-4084-aaf7-9f290ecc0181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f7ff4f-3fd6-4084-aaf7-9f290ecc0181.jpg?1",
             "name": "Wrap in Flames",
             "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "ea4dc631-6483-5ec2-8879-52a578f6fd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "e315c459-a7d3-529f-8a40-862d2f5a8bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fb94ad-f9be-48b4-b65a-4e736e5ffdbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fb94ad-f9be-48b4-b65a-4e736e5ffdbb.jpg?1",
             "name": "The Binding of the Titans",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player puts the top three cards of their library into their graveyard.\nII \u2014 Exile up to two target cards from graveyards. For each creature card exiled this way, you gain 1 life.\nIII \u2014 Return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "f3ed51c4-958d-5845-b488-4f3945f10eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874afaad-546a-4cb2-ad01-2b4a4862b219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874afaad-546a-4cb2-ad01-2b4a4862b219.jpg?1",
             "name": "Chainweb Aracnir",
             "text": "Reach\nWhen Chainweb Aracnir enters the battlefield, it deals damage equal to its power to target creature with flying an opponent controls.\nEscape\u2014{3}{G}{G}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nChainweb Aracnir escapes with three +1/+1 counters on it.",
             "colours": [
@@ -5772,7 +5772,7 @@
         },
         {
             "id": "7cf75f1b-e193-5c4e-aa45-2adade7fe822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba264166-948b-47d4-b302-64476acc1a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba264166-948b-47d4-b302-64476acc1a55.jpg?1",
             "name": "Destiny Spinner",
             "text": "Creature and enchantment spells you control can't be countered.\n{3}{G}: Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "58e20f22-5b6d-53f7-a1e6-02efb650a67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d964876-194b-49f1-8e74-cfe9269f2c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d964876-194b-49f1-8e74-cfe9269f2c62.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "You may play an additional land on each of your turns.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "f48206a6-6ac2-5f8e-98b3-64d443543ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b05ada5-8e5f-4158-bd28-e6c24e4a2299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b05ada5-8e5f-4158-bd28-e6c24e4a2299.jpg?1",
             "name": "The First Iroan Games",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI \u2014 Create a 1/1 white Human Soldier creature token.\nII \u2014 Put three +1/+1 counters on target creature you control.\nIII \u2014 If you control a creature with power 4 or greater, draw two cards.\nIV \u2014 Create a Gold token.",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "6c0b2969-16e4-5d29-b622-64c2165320cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5e144-4dd6-441f-b3e2-433aa82bdf7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5e144-4dd6-441f-b3e2-433aa82bdf7b.jpg?1",
             "name": "Gift of Strength",
             "text": "Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "e12e1086-8273-5916-b90d-0f487290fe32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112ee2a-a6f3-4280-a915-000a97a9cdef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112ee2a-a6f3-4280-a915-000a97a9cdef.jpg?1",
             "name": "Hydra's Growth",
             "text": "Enchant creature\nWhen Hydra's Growth enters the battlefield, put a +1/+1 counter on enchanted creature.\nAt the beginning of your upkeep, double the number of +1/+1 counters on enchanted creature.",
             "colours": [
@@ -5945,7 +5945,7 @@
         },
         {
             "id": "85630686-a2d8-5133-ab25-e923266fff81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7f2638-d757-4df6-90b0-b616534dd3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7f2638-d757-4df6-90b0-b616534dd3a0.jpg?1",
             "name": "Hyrax Tower Scout",
             "text": "When Hyrax Tower Scout enters the battlefield, untap target creature.",
             "colours": [
@@ -5980,7 +5980,7 @@
         },
         {
             "id": "b9ba2b05-4133-5ad8-8db6-c5a837fe3c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdf8ab8-f221-4f7b-9af9-3849cad1f596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdf8ab8-f221-4f7b-9af9-3849cad1f596.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "8971ae82-f791-5f5a-a1ee-784b2b152801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c8b5a-2e18-4dd8-b236-5b1fd356f867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c8b5a-2e18-4dd8-b236-5b1fd356f867.jpg?1",
             "name": "Inspire Awe",
             "text": "Prevent all combat damage that would be dealt this turn except combat damage that would be dealt by enchanted creatures and enchantment creatures. Scry 2.",
             "colours": [
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "a8f58718-1f50-53cb-a04a-5e948c3938f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b6b7a7-0ac8-470a-949b-4779ded95359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b6b7a7-0ac8-470a-949b-4779ded95359.jpg?1",
             "name": "Klothys's Design",
             "text": "Creatures you control get +X/+X until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "7fe695a1-e064-5b3a-a863-6690981d0464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe6283-3642-4883-ac6e-83ae3280af9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe6283-3642-4883-ac6e-83ae3280af9c.jpg?1",
             "name": "Loathsome Chimera",
             "text": "Escape\u2014{4}{G}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nLoathsome Chimera escapes with a +1/+1 counter on it.",
             "colours": [
@@ -6112,7 +6112,7 @@
         },
         {
             "id": "0d3fa0b8-1a84-50d3-88ab-a962ecc9396d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a786fa-4b86-40f7-ac58-1a05fb38fcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a786fa-4b86-40f7-ac58-1a05fb38fcdb.jpg?1",
             "name": "Mantle of the Wolf",
             "text": "Enchant creature\nEnchanted creature gets +4/+4.\nWhen Mantle of the Wolf is put into a graveyard from the battlefield, create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "10fbd30b-1b25-549d-8a32-836cb864e9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg?1",
             "name": "Moss Viper",
             "text": "Deathtouch",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "07a3716e-3335-5ce0-8823-69f274b3a6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6797195a-508f-45b1-964d-da842dc46ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6797195a-508f-45b1-964d-da842dc46ca8.jpg?1",
             "name": "Mystic Repeal",
             "text": "Put target enchantment on the bottom of its owner's library.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "25d2afff-6850-5de1-be74-1ff0300c4532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf91fc2-7317-47e4-9e6c-d7d74cdf0153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf91fc2-7317-47e4-9e6c-d7d74cdf0153.jpg?1",
             "name": "Nessian Boar",
             "text": "All creatures able to block Nessian Boar do so.\nWhenever Nessian Boar becomes blocked by a creature, that creature's controller draws a card.",
             "colours": [
@@ -6250,7 +6250,7 @@
         },
         {
             "id": "63704522-3ee1-573b-afcf-e366c596608b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200fcda-e30c-460f-9964-47e657b7c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200fcda-e30c-460f-9964-47e657b7c758.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on Nessian Hornbeetle.",
             "colours": [
@@ -6284,7 +6284,7 @@
         },
         {
             "id": "7173e8f1-4044-5c37-9442-fe54310aecb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d50576-c3ee-479a-8533-6c147f5cb1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d50576-c3ee-479a-8533-6c147f5cb1c4.jpg?1",
             "name": "Nessian Wanderer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, look at the top three cards of your library. You may reveal a land card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "8f0f4a37-2d43-577a-8776-c314f8744b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb4e56-bcad-43a3-8600-a3594047205a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb4e56-bcad-43a3-8600-a3594047205a.jpg?1",
             "name": "Nexus Wardens",
             "text": "Reach\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, you gain 2 life.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "820520f3-09d0-53ed-bf82-d7ed56f8df78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf894d4-1a06-4952-a481-22786ab87a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf894d4-1a06-4952-a481-22786ab87a73.jpg?1",
             "name": "Nylea, Keen-Eyed",
             "text": "Indestructible\nAs long as your devotion to green is less than five, Nylea isn't a creature.\nCreature spells you cast cost {1} less to cast.\n{2}{G}: Reveal the top card of your library. If it's a creature card, put it into your hand. Otherwise, you may put it into your graveyard.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "6313907b-6895-581e-a4b1-73e27b6b4f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2b6be-80a8-4464-a909-8cc658196a14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2b6be-80a8-4464-a909-8cc658196a14.jpg?1",
             "name": "Nylea's Forerunner",
             "text": "Trample\nOther creatures you control have trample.",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "600407f1-d5f2-5155-902d-f5eba0e8d090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4fe89a-0d2b-493f-883e-a1e0b0918340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4fe89a-0d2b-493f-883e-a1e0b0918340.jpg?1",
             "name": "Nylea's Huntmaster",
             "text": "When Nylea's Huntmaster enters the battlefield, target creature you control gets +X/+0 until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -6463,7 +6463,7 @@
         },
         {
             "id": "f72f9e0a-8a02-5128-995e-0c8f8b3491ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2f963-9d16-4224-b24e-b6a79f2b9d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2f963-9d16-4224-b24e-b6a79f2b9d75.jpg?1",
             "name": "Nylea's Intervention",
             "text": "Choose one \u2014\n\u2022 Search your library for up to X land cards, reveal them, put them into your hand, then shuffle your library.\n\u2022 Nylea's Intervention deals twice X damage to each creature with flying.",
             "colours": [
@@ -6497,7 +6497,7 @@
         },
         {
             "id": "f93ffcdc-7057-518c-a181-27ee311c4fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866dcef0-8d3e-4126-963a-05598d8a9e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866dcef0-8d3e-4126-963a-05598d8a9e79.jpg?1",
             "name": "Nyx Herald",
             "text": "At the beginning of combat on your turn, target enchanted creature or enchantment creature you control gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -6533,7 +6533,7 @@
         },
         {
             "id": "484b4501-a6a7-5fba-a62e-c309a4e0c5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391da36-0b40-46ea-b771-50d2b920207e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391da36-0b40-46ea-b771-50d2b920207e.jpg?1",
             "name": "Nyxbloom Ancient",
             "text": "Trample\nIf you tap a permanent for mana, it produces three times as much of that mana instead.",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "681b84bf-fd9a-55b9-86df-4602af85b096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f003c-1e99-4e53-ad6d-81ff3c592b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f003c-1e99-4e53-ad6d-81ff3c592b2c.jpg?1",
             "name": "Nyxborn Colossus",
             "text": "",
             "colours": [
@@ -6605,7 +6605,7 @@
         },
         {
             "id": "722a3230-4712-5c49-aed8-b80c30af942d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ebdea-78d4-4034-921b-735bdb11a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ebdea-78d4-4034-921b-735bdb11a716.jpg?1",
             "name": "Omen of the Hunt",
             "text": "Flash\nWhen Omen of the Hunt enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\n{2}{G}, Sacrifice Omen of the Hunt: Scry 2.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "07af694c-36eb-5c4f-bf0f-977634727349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ac20a9-6b10-4165-ad81-a47587b64d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ac20a9-6b10-4165-ad81-a47587b64d1e.jpg?1",
             "name": "Pheres-Band Brawler",
             "text": "When Pheres-Band Brawler enters the battlefield, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "437d3f42-ff9e-5549-8e6f-1718889923da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b2f186-4e04-49cb-a206-257cfb7e9361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b2f186-4e04-49cb-a206-257cfb7e9361.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "0b778d79-e588-5534-be7e-54e3acf9527c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b9560-b1d6-441c-8bc8-bf6988112d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b9560-b1d6-441c-8bc8-bf6988112d25.jpg?1",
             "name": "Relentless Pursuit",
             "text": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6736,7 +6736,7 @@
         },
         {
             "id": "c28e6a4f-c5ca-5bf2-99cc-a7d411c70d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27e6b2-13ad-42b2-a121-70935913723d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27e6b2-13ad-42b2-a121-70935913723d.jpg?1",
             "name": "Renata, Called to the Hunt",
             "text": "Renata's power is equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)\nEach other creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "562a6d1b-f445-5ea2-805b-9a53f6555931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4515a76-53f0-40a2-8b88-70b73447d1e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4515a76-53f0-40a2-8b88-70b73447d1e6.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "5ec2ee5c-3908-5815-bdeb-562a3ed1239d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ce9858-747e-441c-95a8-6af44aa2098d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ce9858-747e-441c-95a8-6af44aa2098d.jpg?1",
             "name": "Setessan Champion",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, put a +1/+1 counter on Setessan Champion and draw a card.",
             "colours": [
@@ -6844,7 +6844,7 @@
         },
         {
             "id": "f320c7d6-f13e-5d11-8a5e-f1ba0c05603c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384495c2-238b-4f8d-89c2-e05b64f9dde0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384495c2-238b-4f8d-89c2-e05b64f9dde0.jpg?1",
             "name": "Setessan Petitioner",
             "text": "When Setessan Petitioner enters the battlefield, you gain life equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "ba0b3755-2365-5273-8f6a-05a2c8fb90b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46739993-6afe-428d-bf63-b57649e38a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46739993-6afe-428d-bf63-b57649e38a65.jpg?1",
             "name": "Setessan Skirmisher",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Setessan Skirmisher gets +1/+1 until end of turn.",
             "colours": [
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "df4d1799-22a5-5c25-ad42-bb10e302055a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322d31-6194-4fda-99a3-b6426c57488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322d31-6194-4fda-99a3-b6426c57488a.jpg?1",
             "name": "Setessan Training",
             "text": "Enchant creature you control\nWhen Setessan Training enters the battlefield, draw a card.\nEnchanted creature gets +1/+0 and has trample.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "794b71e8-452d-548d-82fa-f3552fa84f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076ec900-345d-4720-96b6-441bce01618a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076ec900-345d-4720-96b6-441bce01618a.jpg?1",
             "name": "Skola Grovedancer",
             "text": "Whenever a land card is put into your graveyard from anywhere, you gain 1 life.\n{2}{G}: Put the top card of your library into your graveyard.",
             "colours": [
@@ -6984,7 +6984,7 @@
         },
         {
             "id": "0e84a444-7d05-5c2a-88e2-0c744103f13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2bccb-0e01-4629-b9a8-5c0ea26239b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2bccb-0e01-4629-b9a8-5c0ea26239b3.jpg?1",
             "name": "Voracious Typhon",
             "text": "Escape\u2014{5}{G}{G}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nVoracious Typhon escapes with three +1/+1 counters on it.",
             "colours": [
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "ec7baadc-0c57-5460-a03e-638c79a9a8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d64cab-2ed1-46d9-8034-0c2ba3f2e1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d64cab-2ed1-46d9-8034-0c2ba3f2e1ed.jpg?1",
             "name": "Warbriar Blessing",
             "text": "Enchant creature you control\nWhen Warbriar Blessing enters the battlefield, enchanted creature fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "c94d1a5a-82ee-5caa-8739-b4769754f500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b886c3-234c-49ce-9a11-456c1e8f092f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b886c3-234c-49ce-9a11-456c1e8f092f.jpg?1",
             "name": "Wolfwillow Haven",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.\n{4}{G}, Sacrifice Wolfwillow Haven: Create a 2/2 green Wolf creature token. Activate this ability only during your turn.",
             "colours": [
@@ -7089,7 +7089,7 @@
         },
         {
             "id": "3a61e0b3-4c1a-5971-a27d-81ee96d85b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14afed6-ca42-442d-ba86-621179e6957c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14afed6-ca42-442d-ba86-621179e6957c.jpg?1",
             "name": "Acolyte of Affliction",
             "text": "When Acolyte of Affliction enters the battlefield, put the top two cards of your library into your graveyard, then you may return a permanent card from your graveyard to your hand.",
             "colours": [
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "828e4c85-e1d9-5aea-bbef-b646b9f9cae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e09c3-917c-4bbb-bb94-60f4e9417832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e09c3-917c-4bbb-bb94-60f4e9417832.jpg?1",
             "name": "Allure of the Unknown",
             "text": "Reveal the top six cards of your library. An opponent exiles a nonland card from among them, then you put the rest into your hand. That opponent may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "f2772c04-3e2a-5262-8e62-1954e2767d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112eb5ce-4fe5-45b3-b810-79fef74b07f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112eb5ce-4fe5-45b3-b810-79fef74b07f9.jpg?1",
             "name": "Ashiok, Nightmare Muse",
             "text": "+1: Create a 2/3 blue and black Nightmare creature token with \"Whenever this creature attacks or blocks, each opponent exiles the top two cards of their library.\"\n\u22123: Return target nonland permanent to its owner's hand, then that player exiles a card from their hand.\n\u22127: You may cast up to three face-up cards your opponents own from exile without paying their mana costs.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "dfdef194-7a62-5626-8924-40a25c155755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c91ec-df14-460f-967c-f182562fe7d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c91ec-df14-460f-967c-f182562fe7d8.jpg?1",
             "name": "Atris, Oracle of Half-Truths",
             "text": "Menace\nWhen Atris, Oracle of Half-Truths enters the battlefield, target opponent looks at the top three cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -7243,7 +7243,7 @@
         },
         {
             "id": "8d3c89fb-3851-54c8-bdf0-13d97b8fab24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdafadb-fa04-4282-b576-b85e79c242c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdafadb-fa04-4282-b576-b85e79c242c9.jpg?1",
             "name": "Bronzehide Lion",
             "text": "{G}{W}: Bronzehide Lion gains indestructible until end of turn.\nWhen Bronzehide Lion dies, return it to the battlefield. It's an Aura enchantment with enchant creature you control and \"{G}{W}: Enchanted creature gains indestructible until end of turn,\" and it loses all other abilities.",
             "colours": [
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "8411f0c8-7ca7-58b2-8f8f-8f4c721c56f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86458929-ea21-4de8-84d8-a07398ed3bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86458929-ea21-4de8-84d8-a07398ed3bc0.jpg?1",
             "name": "Calix, Destiny's Hand",
             "text": "+1: Look at the top four cards of your library. You may reveal an enchantment card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Exile target creature or enchantment you don't control until target enchantment you control leaves the battlefield.\n\u22127: Return all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -7321,7 +7321,7 @@
         },
         {
             "id": "f793d4f3-f6c9-5bc2-99c6-53a15f0cf5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ea0ba2-3ccf-4313-ad1d-161272c48851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ea0ba2-3ccf-4313-ad1d-161272c48851.jpg?1",
             "name": "Dalakos, Crafter of Wonders",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\nEquipped creatures you control have flying and haste.",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "e0ce9a72-3f2d-5f69-aeec-bf6b14a9da8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514a6206-c2e5-4a0f-8a20-7efd6628dd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514a6206-c2e5-4a0f-8a20-7efd6628dd0a.jpg?1",
             "name": "Devourer of Memory",
             "text": "Whenever one or more cards are put into your graveyard from your library, Devourer of Memory gets +1/+1 until end of turn and can't be blocked this turn.\n{1}{U}{B}: Put the top card of your library into your graveyard.",
             "colours": [
@@ -7398,7 +7398,7 @@
         },
         {
             "id": "a42cd1f8-bee3-57cc-8b25-c9f4cd11afac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e97d8-92c7-43c4-bdaf-7b0a6ce7cb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e97d8-92c7-43c4-bdaf-7b0a6ce7cb5f.jpg?1",
             "name": "Dream Trawler",
             "text": "Flying, lifelink\nWhenever you draw a card, Dream Trawler gets +1/+0 until end of turn.\nWhenever Dream Trawler attacks, draw a card.\nDiscard a card: Dream Trawler gains hexproof until end of turn. Tap it.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "6ef2dc1f-3ca3-5fed-a53a-92aaca6728ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd116c0b-0404-42ba-978f-7044b1a03d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd116c0b-0404-42ba-978f-7044b1a03d90.jpg?1",
             "name": "Enigmatic Incarnation",
             "text": "At the beginning of your end step, you may sacrifice another enchantment. If you do, search your library for a creature card with converted mana cost equal to 1 plus the sacrificed enchantment's converted mana cost, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "21fb030f-30e5-57ed-9680-b99f7279c540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2159949-3d21-448d-bc34-a3dbaf219476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2159949-3d21-448d-bc34-a3dbaf219476.jpg?1",
             "name": "Eutropia the Twice-Favored",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, put a +1/+1 counter on target creature. That creature gains flying until end of turn.",
             "colours": [
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "23688b6d-341f-5fb6-84b2-e6979d78cac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0744f08e-a588-4efe-ad56-5e9ed91dda40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0744f08e-a588-4efe-ad56-5e9ed91dda40.jpg?1",
             "name": "Gallia of the Endless Dance",
             "text": "Haste\nOther Satyrs you control get +1/+1 and have haste.\nWhenever you attack with three or more creatures, you may discard a card at random. If you do, draw two cards.",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "df3d4450-0921-5d5b-9cc7-1717bcb031db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe5cbef-0f4e-4d05-9a94-4739e09d7a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe5cbef-0f4e-4d05-9a94-4739e09d7a9c.jpg?1",
             "name": "Haktos the Unscarred",
             "text": "Haktos the Unscarred attacks each combat if able.\nAs Haktos enters the battlefield, choose 2, 3, or 4 at random.\nHaktos has protection from each converted mana cost other than the chosen number.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "7ce033f9-de61-5935-b6e9-cb6eed43da9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854e673-1816-4a76-b9db-bb399ac7489f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854e673-1816-4a76-b9db-bb399ac7489f.jpg?1",
             "name": "Hero of the Nyxborn",
             "text": "When Hero of the Nyxborn enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever you cast a spell that targets Hero of the Nyxborn, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -7630,7 +7630,7 @@
         },
         {
             "id": "bed702eb-e2ed-5989-9341-3b1198980180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c393c-3596-4bd9-a553-e0b03c2eb950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c393c-3596-4bd9-a553-e0b03c2eb950.jpg?1",
             "name": "Klothys, God of Destiny",
             "text": "Indestructible\nAs long as your devotion to red and green is less than seven, Klothys isn't a creature.\nAt the beginning of your precombat main phase, exile target card from a graveyard. If it was a land card, add {R} or {G}. Otherwise, you gain 2 life and Klothys deals 2 damage to each opponent.",
             "colours": [
@@ -7671,7 +7671,7 @@
         },
         {
             "id": "bfeed138-46d7-5ff0-9717-962e331c22ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee0459b-9aac-4d2f-abe4-4d5fedde7eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee0459b-9aac-4d2f-abe4-4d5fedde7eb8.jpg?1",
             "name": "Kroxa, Titan of Death's Hunger",
             "text": "When Kroxa enters the battlefield, sacrifice it unless it escaped.\nWhenever Kroxa enters the battlefield or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.\nEscape\u2014{B}{B}{R}{R}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "939cfd55-3be9-58f1-a807-c71b0b222914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc0d2c3-8060-4155-b10e-d641648a4e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc0d2c3-8060-4155-b10e-d641648a4e6b.jpg?1",
             "name": "Kunoros, Hound of Athreos",
             "text": "Vigilance, menace, lifelink\nCreature cards in graveyards can't enter the battlefield.\nPlayers can't cast spells from graveyards.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "521298ff-5a0e-591f-8fe7-8f8b1cbdf8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3df0e-4ee8-458b-adf5-56aca20493e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3df0e-4ee8-458b-adf5-56aca20493e9.jpg?1",
             "name": "Mischievous Chimera",
             "text": "Flying\nWhenever you cast your first spell during each opponent's turn, Mischievous Chimera deals 1 damage to each opponent. Scry 1.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "e5338395-ff6e-5959-b163-9c5842371ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87858278-632c-4d82-b3a3-adfc6f2f4fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87858278-632c-4d82-b3a3-adfc6f2f4fc6.jpg?1",
             "name": "Polukranos, Unchained",
             "text": "Polukranos enters the battlefield with six +1/+1 counters on it. It escapes with twelve +1/+1 counters on it instead.\nIf damage would be dealt to Polukranos while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from it.\n{1}{B}{G}: Polukranos fights another target creature.\nEscape\u2014{4}{B}{G}, Exile six other cards from your graveyard.",
             "colours": [
@@ -7830,7 +7830,7 @@
         },
         {
             "id": "84492fe4-ad28-5ae0-a399-a6e3b76c1695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6c11c8-64a1-46a4-979c-56a6d5b873d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6c11c8-64a1-46a4-979c-56a6d5b873d3.jpg?1",
             "name": "Rise to Glory",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to the battlefield.\n\u2022 Return target Aura card from your graveyard to the battlefield.",
             "colours": [
@@ -7864,7 +7864,7 @@
         },
         {
             "id": "b20c0aaf-5b35-5d82-8dad-0f0aa6e435eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1d890f-7ef8-47b9-9ec8-f3884a1d09db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1d890f-7ef8-47b9-9ec8-f3884a1d09db.jpg?1",
             "name": "Siona, Captain of the Pyleas",
             "text": "When Siona, Captain of the Pyleas enters the battlefield, look at the top seven cards of your library. You may reveal an Aura card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nWhenever an Aura you control becomes attached to a creature you control, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "0788871e-f510-5576-8925-8877208e1a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b441c0-261e-4094-b694-5e11ea3c14ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b441c0-261e-4094-b694-5e11ea3c14ab.jpg?1",
             "name": "Slaughter-Priest of Mogis",
             "text": "Whenever you sacrifice a permanent, Slaughter-Priest of Mogis gets +2/+0 until end of turn.\n{2}, Sacrifice another creature or an enchantment: Slaughter-Priest of Mogis gains first strike until end of turn.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "664be9a7-acf5-5d97-8ccb-c21dd49e2566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125b8be1-76b9-434e-a505-5099d950767c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125b8be1-76b9-434e-a505-5099d950767c.jpg?1",
             "name": "Staggering Insight",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has lifelink and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -7976,7 +7976,7 @@
         },
         {
             "id": "0b70248d-ff8a-555b-b003-4146ebe4370a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6a71e-56cb-4d25-8f2b-7a4f1b60900d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6a71e-56cb-4d25-8f2b-7a4f1b60900d.jpg?1",
             "name": "Uro, Titan of Nature's Wrath",
             "text": "When Uro enters the battlefield, sacrifice it unless it escaped.\nWhenever Uro enters the battlefield or attacks, you gain 3 life and draw a card, then you may put a land card from your hand onto the battlefield.\nEscape\u2014{G}{G}{U}{U}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -8017,7 +8017,7 @@
         },
         {
             "id": "6bcc75d3-c090-5dcb-b506-96a1bd08c84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff48d55e-aa8b-4061-9c77-fd7e696fd7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff48d55e-aa8b-4061-9c77-fd7e696fd7ba.jpg?1",
             "name": "Warden of the Chained",
             "text": "Trample\nWarden of the Chained can't attack unless you control another creature with power 4 or greater.",
             "colours": [
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "e43442bd-067c-5c4c-b3b3-b07b61156658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2a587-443d-4626-a6f6-9a26838a42b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2a587-443d-4626-a6f6-9a26838a42b1.jpg?1",
             "name": "Altar of the Pantheon",
             "text": "Your devotion to each color and each combination of colors is increased by one.\n{T}: Add one mana of any color. If you control a God, a Demigod, or a legendary enchantment, you gain 1 life.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "335f443a-5290-57c8-ac56-61aacba7caab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33162d-8d8f-4312-b31e-04ce86e3b914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33162d-8d8f-4312-b31e-04ce86e3b914.jpg?1",
             "name": "Bronze Sword",
             "text": "Equipped creature gets +2/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "6ed57dc7-e6c7-50cc-acd1-666055df6ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064abee6-7394-4b75-946f-4ad9840034ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064abee6-7394-4b75-946f-4ad9840034ac.jpg?1",
             "name": "Entrancing Lyre",
             "text": "You may choose not to untap Entrancing Lyre during your untap step.\n{X}, {T}: Tap target creature with power X or less. It doesn't untap during its controller's untap step for as long as Entrancing Lyre remains tapped.",
             "colours": [],
@@ -8140,7 +8140,7 @@
         },
         {
             "id": "7ed2faef-d768-518e-b5bb-4c7b189c0087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7624e84-93ce-4983-8624-ebc934cab67f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7624e84-93ce-4983-8624-ebc934cab67f.jpg?1",
             "name": "Mirror Shield",
             "text": "Equipped creature gets +0/+2 and has hexproof and \"Whenever a creature with deathtouch blocks or becomes blocked by this creature, destroy that creature.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "ad501554-c342-5e97-b139-790c879110a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd6353f-d119-40e6-895c-030a11a7a2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd6353f-d119-40e6-895c-030a11a7a2fe.jpg?1",
             "name": "Nyx Lotus",
             "text": "Nyx Lotus enters the battlefield tapped.\n{T}: Choose a color. Add an amount of mana of that color equal to your devotion to that color. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)",
             "colours": [],
@@ -8202,7 +8202,7 @@
         },
         {
             "id": "22982d8a-5424-587a-a3c1-c98047c801f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939c6e19-4b27-4023-bb9c-ae440f91e21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939c6e19-4b27-4023-bb9c-ae440f91e21c.jpg?1",
             "name": "Shadowspear",
             "text": "Equipped creature gets +1/+1 and has trample and lifelink.\n{1}: Permanents your opponents control lose hexproof and indestructible until end of turn.\nEquip {2}",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "f1d6ff7c-e756-5b78-be96-204de60b1ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "When Soul-Guide Lantern enters the battlefield, exile target card from a graveyard.\n{T}, Sacrifice Soul-Guide Lantern: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice Soul-Guide Lantern: Draw a card.",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "98cd5be0-aa66-5d24-b30d-de002205ac98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg?1",
             "name": "Thaumaturge's Familiar",
             "text": "Flying\nWhen Thaumaturge's Familiar enters the battlefield, scry 1.",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "6c7e6630-df83-51a1-a675-d51266aacdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2fa92d-5521-421c-b3f8-7c14bbef3080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2fa92d-5521-421c-b3f8-7c14bbef3080.jpg?1",
             "name": "Thundering Chariot",
             "text": "First strike, trample, haste\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "d5de0e91-931e-527b-a20a-846e0d5cc290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590926db-279c-494a-b92d-680b8abf9699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590926db-279c-494a-b92d-680b8abf9699.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "e3e4ebc2-dcb5-5677-82fd-3a15dfbd0b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ef8f96-3e3c-4b1b-8180-3b38c7deaaff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ef8f96-3e3c-4b1b-8180-3b38c7deaaff.jpg?1",
             "name": "Wings of Hubris",
             "text": "Equipped creature has flying.\nSacrifice Wings of Hubris: Equipped creature can't be blocked this turn. Sacrifice it at the beginning of the next end step.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "5cfed6ed-f19a-5943-a441-75b0ffce0302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84e179-9d59-4d08-8a36-51ad2fc32ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84e179-9d59-4d08-8a36-51ad2fc32ae3.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles their library.",
             "colours": [],
@@ -8411,7 +8411,7 @@
         },
         {
             "id": "216271f1-8703-5e29-81ff-f67350ee3753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0dd221-2660-43f6-8e28-8000e3fe72a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0dd221-2660-43f6-8e28-8000e3fe72a4.jpg?1",
             "name": "Labyrinth of Skophos",
             "text": "{T}: Add {C}.\n{4}, {T}: Remove target attacking or blocking creature from combat.",
             "colours": [],
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "cc39002d-4973-5a0c-bec3-9e40357e2554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5f8481-47f7-4531-9dad-686cdfb5d2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5f8481-47f7-4531-9dad-686cdfb5d2ad.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "1223134d-1168-51b6-b274-61f532c1e606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4fd29-dab5-481f-94c9-eeb70f3c29dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4fd29-dab5-481f-94c9-eeb70f3c29dd.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "2aa51f70-e23d-5355-8acb-e1025992aa42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adad8390-66d8-4022-a059-c68e44e718fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adad8390-66d8-4022-a059-c68e44e718fe.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "6a9d0209-b78e-56f5-a451-541712ddf1e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9490a495-9f17-45a8-b10c-7de4fcbd2778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9490a495-9f17-45a8-b10c-7de4fcbd2778.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "61c04daf-db4f-5dcf-aaf4-44ae08f20a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6256ea-ccb5-4595-8278-44266f922e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6256ea-ccb5-4595-8278-44266f922e31.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8607,7 +8607,7 @@
         },
         {
             "id": "00f6a8fe-62d8-5996-9ad6-e4e0577a3ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492181e4-5825-45d4-b8a1-37f29c32a845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492181e4-5825-45d4-b8a1-37f29c32a845.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "bb363f5e-b338-5d50-b31c-461faeeb9774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9891b7b-fc52-470c-9f74-292ae665f378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9891b7b-fc52-470c-9f74-292ae665f378.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "ed23bfd4-0cb8-5015-a96a-8a3870eb276d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7b664-3e75-4018-81f6-2a14ab59f258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7b664-3e75-4018-81f6-2a14ab59f258.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8709,7 +8709,7 @@
         },
         {
             "id": "7661719d-f392-5ff9-94d6-ae1783c0522f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cb5cfd-018e-4c5e-bef1-166262aa5f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cb5cfd-018e-4c5e-bef1-166262aa5f1d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "67bc64a0-fef7-5bf6-9709-949e961c48d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fb7b99-9e47-46a6-9c8a-88e28b5197f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fb7b99-9e47-46a6-9c8a-88e28b5197f1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "c39b4bb8-fe17-55fc-bdee-651c74bc2f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af9f41-89e2-4e7a-9fec-fffe79cae077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af9f41-89e2-4e7a-9fec-fffe79cae077.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "73dd9a92-8dc7-5b19-b2ea-616c3ee2d4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedff53b-b5c7-470e-bb66-797d5d20b983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedff53b-b5c7-470e-bb66-797d5d20b983.jpg?1",
             "name": "Elspeth, Sun's Nemesis",
             "text": "",
             "colours": [
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "4aee7d96-11f6-5bf1-87df-7ea0b7f807a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18d2a4a-cfde-434e-85eb-f9aae0da9dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18d2a4a-cfde-434e-85eb-f9aae0da9dce.jpg?1",
             "name": "Ashiok, Nightmare Muse",
             "text": "",
             "colours": [
@@ -8898,7 +8898,7 @@
         },
         {
             "id": "ac3a03fb-f346-59cf-b196-743a112efc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11529e37-0558-4ba9-ad04-3ddda05d25f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11529e37-0558-4ba9-ad04-3ddda05d25f5.jpg?1",
             "name": "Calix, Destiny's Hand",
             "text": "",
             "colours": [
@@ -8938,7 +8938,7 @@
         },
         {
             "id": "e499ebe7-6154-5180-9818-4b2336358979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5770e8a-045d-42bc-b6aa-17b89488c9d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5770e8a-045d-42bc-b6aa-17b89488c9d4.jpg?1",
             "name": "Daxos, Blessed by the Sun",
             "text": "",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "a8aabe56-13b2-584f-8def-28617d525c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11cf760-da35-41f2-8cf5-a5141103eeb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11cf760-da35-41f2-8cf5-a5141103eeb3.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "",
             "colours": [
@@ -9016,7 +9016,7 @@
         },
         {
             "id": "fcf571c1-2b6e-5245-96fb-4ceec471a1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69641e64-d4f5-4654-8da8-9eb9a71e51c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69641e64-d4f5-4654-8da8-9eb9a71e51c8.jpg?1",
             "name": "Callaphe, Beloved of the Sea",
             "text": "",
             "colours": [
@@ -9055,7 +9055,7 @@
         },
         {
             "id": "c485d8a2-6cdb-5dca-8708-b0631abcbf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b52628-de05-4ec1-9978-e998cf17bb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b52628-de05-4ec1-9978-e998cf17bb26.jpg?1",
             "name": "Thassa, Deep-Dwelling",
             "text": "",
             "colours": [
@@ -9094,7 +9094,7 @@
         },
         {
             "id": "f57a58d7-d4b4-5c54-86a3-2a5c79c5fc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3c60d-2fcb-476f-bcc6-eec5879b08ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3c60d-2fcb-476f-bcc6-eec5879b08ee.jpg?1",
             "name": "Erebos, Bleak-Hearted",
             "text": "",
             "colours": [
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "ac8a60bc-93ca-5413-96ee-5475c7746f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bcb02d3-dcf4-41a6-8b9a-f8ad477faea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bcb02d3-dcf4-41a6-8b9a-f8ad477faea0.jpg?1",
             "name": "Tymaret, Chosen from Death",
             "text": "",
             "colours": [
@@ -9172,7 +9172,7 @@
         },
         {
             "id": "5f89b684-6c2a-540d-977e-1dfae9df4b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badac9b4-bfaf-4b02-a48a-ec141393566c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badac9b4-bfaf-4b02-a48a-ec141393566c.jpg?1",
             "name": "Anax, Hardened in the Forge",
             "text": "",
             "colours": [
@@ -9211,7 +9211,7 @@
         },
         {
             "id": "c61d4134-9b72-5443-9fbb-57bd00b2f6ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176596fd-fc6d-46ae-a64d-d9147430fe0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176596fd-fc6d-46ae-a64d-d9147430fe0f.jpg?1",
             "name": "Purphoros, Bronze-Blooded",
             "text": "",
             "colours": [
@@ -9250,7 +9250,7 @@
         },
         {
             "id": "4c21956a-fa3c-5101-9cde-8d8af8ede238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a022e36-5074-4875-ac30-aaa09b7ef421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a022e36-5074-4875-ac30-aaa09b7ef421.jpg?1",
             "name": "Nylea, Keen-Eyed",
             "text": "",
             "colours": [
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "cb0847b3-ef9b-560c-9cbd-37e91acfd86d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ce113d-6757-45ac-8517-5fd531079ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ce113d-6757-45ac-8517-5fd531079ff9.jpg?1",
             "name": "Renata, Called to the Hunt",
             "text": "",
             "colours": [
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "2d343b2e-9dd7-5125-8768-7fb2dd194c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d747889-04db-4e7a-ad4c-7549514b5112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d747889-04db-4e7a-ad4c-7549514b5112.jpg?1",
             "name": "Klothys, God of Destiny",
             "text": "",
             "colours": [
@@ -9369,7 +9369,7 @@
         },
         {
             "id": "5636e28c-6778-5aa9-bf4d-05d545c6edc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c19fc-7d99-4022-9e13-d679a9e3547e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c19fc-7d99-4022-9e13-d679a9e3547e.jpg?1",
             "name": "Athreos, Shroud-Veiled",
             "text": "Indestructible\nAs long as your devotion to white and black is less than seven, Athreos isn't a creature.\nAt the beginning of your end step, put a coin counter on another target creature.\nWhenever a creature with a coin counter on it dies or is put into exile, return that card to the battlefield under your control.",
             "colours": [
@@ -9408,7 +9408,7 @@
         },
         {
             "id": "ac8fc242-0d73-591f-8abf-5fde183f5dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9867e5-9d69-400c-a84f-3b085a4fd510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9867e5-9d69-400c-a84f-3b085a4fd510.jpg?1",
             "name": "Elspeth, Undaunted Hero",
             "text": "+2: Put a +1/+1 counter on each of up to two target creatures.\n\u22122: Search your library and/or graveyard for a card named Sunlit Hoplite and put it onto the battlefield. If you search your library this way, shuffle it.\n\u22128: Until end of turn, creatures you control gain flying and get +X/+X, where X is your devotion to white.",
             "colours": [
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "1a727ecd-8325-5f6e-80dd-809889a42ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53343a0c-d97c-4d6f-b696-5343a962e3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53343a0c-d97c-4d6f-b696-5343a962e3dd.jpg?1",
             "name": "Eidolon of Inspiration",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.",
             "colours": [
@@ -9478,7 +9478,7 @@
         },
         {
             "id": "193c4fcf-e45b-52b3-abf6-4010ea54299f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f82064c-b335-454c-9be6-9fbcb21aa8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f82064c-b335-454c-9be6-9fbcb21aa8e5.jpg?1",
             "name": "Elspeth's Devotee",
             "text": "When Elspeth's Devotee enters the battlefield, you may search your library and/or graveyard for a card named Elspeth, Undaunted Hero, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9512,7 +9512,7 @@
         },
         {
             "id": "f3a45f6c-f419-5ab7-b4c7-b2e725697208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89cf0f-f682-44f8-879c-ed1e22f849b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89cf0f-f682-44f8-879c-ed1e22f849b0.jpg?1",
             "name": "Sunlit Hoplite",
             "text": "As long as it's your turn, Sunlit Hoplite has first strike.\nSunlit Hoplite gets +1/+0 as long as you control an Elspeth planeswalker.",
             "colours": [
@@ -9546,7 +9546,7 @@
         },
         {
             "id": "3d93625b-fd10-5a2f-bfad-d5ec5d9a0d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a5fc37-e7bd-41a9-88ac-74a3f14fea8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a5fc37-e7bd-41a9-88ac-74a3f14fea8b.jpg?1",
             "name": "Ashiok, Sculptor of Fears",
             "text": "+2: Draw a card. Each player puts the top two cards of their library into their graveyard.\n\u22125: Put target creature card from a graveyard onto the battlefield under your control.\n\u221211: Gain control of all creatures target opponent controls.",
             "colours": [
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "602c3bd3-d383-5903-8ffe-c62698a1818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc6b5ee-e764-444e-8b27-26e00f4b2074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc6b5ee-e764-444e-8b27-26e00f4b2074.jpg?1",
             "name": "Swimmer in Nightmares",
             "text": "Swimmer in Nightmares gets +3/+0 as long as there are ten or more cards in a single graveyard.\nSwimmer in Nightmares can't be blocked as long as you control an Ashiok planeswalker.",
             "colours": [
@@ -9618,7 +9618,7 @@
         },
         {
             "id": "921db3e2-3d8a-561d-8fff-4027b2158900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5ce79a-fcbd-46ab-8911-480f967ca57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5ce79a-fcbd-46ab-8911-480f967ca57f.jpg?1",
             "name": "Mindwrack Harpy",
             "text": "Flying\nAt the beginning of combat on your turn, each player puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -9652,7 +9652,7 @@
         },
         {
             "id": "0679efa4-1580-5e44-ad22-785ae74fad8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781bfbae-acd9-4583-88d2-d31978eef565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781bfbae-acd9-4583-88d2-d31978eef565.jpg?1",
             "name": "Ashiok's Forerunner",
             "text": "Flash\nWhen Ashiok's Forerunner enters the battlefield, you may search your library and/or graveyard for a card named Ashiok, Sculptor of Fears, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "7c416def-b8db-5457-a430-6d006596af8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40aca5ca-a37b-4919-aef6-2510b4779161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40aca5ca-a37b-4919-aef6-2510b4779161.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9725,7 +9725,7 @@
         },
         {
             "id": "c4ee840e-2c11-5312-adbe-d9313fa965bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db68b6a3-10e5-42d1-9325-94a4a821782a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db68b6a3-10e5-42d1-9325-94a4a821782a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9762,7 +9762,7 @@
         },
         {
             "id": "9a8020da-28ae-5cf2-a7c2-c4db716957fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92daaa39-cd2f-4c03-8f41-92d99d0a3366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92daaa39-cd2f-4c03-8f41-92d99d0a3366.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "5a181c25-6347-54ed-b378-b90d66e9f438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c12c2-2ebf-470b-b0d2-92ccc5faa056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c12c2-2ebf-470b-b0d2-92ccc5faa056.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "3661c754-96b2-5cf2-bb6f-128993c98aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66bb5192-58bc-4efe-a145-2e804fd3483d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66bb5192-58bc-4efe-a145-2e804fd3483d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "942cf74e-7ac1-5f62-ba69-26c18366f6db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54a44f2-70bf-4782-bd13-9d03e109d60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54a44f2-70bf-4782-bd13-9d03e109d60d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9910,7 +9910,7 @@
         },
         {
             "id": "4ee811f0-c35f-5ddc-ab95-5f7a20362fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3f4154-9347-4ceb-8744-9f1ace90d33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3f4154-9347-4ceb-8744-9f1ace90d33f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "b0e27953-1173-5cde-9763-aadc57414efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d759b-db5b-4a59-840c-05bcbf2381f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d759b-db5b-4a59-840c-05bcbf2381f3.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "61b496d7-8dfa-589d-ace9-8b44465eba1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4be31c4-9cb3-4a07-865b-5621127df660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4be31c4-9cb3-4a07-865b-5621127df660.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "dfb58178-c3a8-5059-87a8-d8a44596b351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af0c659-f182-4ad4-bca7-e6c3377f808d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af0c659-f182-4ad4-bca7-e6c3377f808d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "9ae2c11b-e156-5501-876e-883f77f042e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238aa9c-661e-449a-8f05-70b7954e544f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238aa9c-661e-449a-8f05-70b7954e544f.jpg?1",
             "name": "Grasping Giant",
             "text": "Vigilance\nWhenever Grasping Giant becomes blocked by a creature, exile that creature until Grasping Giant leaves the battlefield.",
             "colours": [
@@ -10091,7 +10091,7 @@
         },
         {
             "id": "243d868a-78a2-5191-9b9e-7c9f22782eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7fa9e2-4c16-4e94-9b0e-09657303132c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7fa9e2-4c16-4e94-9b0e-09657303132c.jpg?1",
             "name": "Victory's Envoy",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -10125,7 +10125,7 @@
         },
         {
             "id": "960a9267-9aae-591b-b81b-53a6c9bf4e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg?1",
             "name": "Sphinx Mindbreaker",
             "text": "Flying\nWhen Sphinx Mindbreaker enters the battlefield, each opponent puts the top ten cards of their library into their graveyard.",
             "colours": [
@@ -10158,7 +10158,7 @@
         },
         {
             "id": "caf035a9-1060-548c-8e97-656498df3e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac18ae-0d1e-43f5-9cc9-722fa6e36fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac18ae-0d1e-43f5-9cc9-722fa6e36fe5.jpg?1",
             "name": "Serpent of Yawning Depths",
             "text": "Krakens, Leviathans, Octopuses, and Serpents you control can't be blocked except by Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "3365d3cb-d481-5d77-aa47-910cc85392ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57564f6f-7c99-4325-8a0e-22342e73767b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57564f6f-7c99-4325-8a0e-22342e73767b.jpg?1",
             "name": "Demon of Loathing",
             "text": "Flying, trample\nWhenever Demon of Loathing deals combat damage to a player, that player sacrifices a creature.",
             "colours": [
@@ -10226,7 +10226,7 @@
         },
         {
             "id": "da8244ce-fde3-5398-9639-4fa7648ae15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c7aa89-3777-49ec-a6d0-c568150864e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c7aa89-3777-49ec-a6d0-c568150864e8.jpg?1",
             "name": "Underworld Sentinel",
             "text": "Whenever Underworld Sentinel attacks, exile target creature card from your graveyard.\nWhen Underworld Sentinel dies, put all cards exiled with it onto the battlefield.",
             "colours": [
@@ -10260,7 +10260,7 @@
         },
         {
             "id": "6a34e617-33bc-516f-8f25-d4a1601faf7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f58ac-88ef-445c-a12b-0bb1cf482298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f58ac-88ef-445c-a12b-0bb1cf482298.jpg?1",
             "name": "Deathbellow War Cry",
             "text": "Search your library for up to four Minotaur creature cards with different names, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "a492a455-24ff-5949-9611-484bc472120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332dc6c3-7802-4bde-aa4e-0feab70c216f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332dc6c3-7802-4bde-aa4e-0feab70c216f.jpg?1",
             "name": "Terror of Mount Velus",
             "text": "Flying, double strike\nWhen Terror of Mount Velus enters the battlefield, creatures you control gain double strike until end of turn.",
             "colours": [
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "9b1aa4e0-b0fe-54ba-b87b-aa398f731618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0215cbbf-7bac-4ff7-bceb-23d728797848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0215cbbf-7bac-4ff7-bceb-23d728797848.jpg?1",
             "name": "Ironscale Hydra",
             "text": "If a creature would deal combat damage to Ironscale Hydra, prevent that damage and put a +1/+1 counter on Ironscale Hydra.",
             "colours": [
@@ -10358,7 +10358,7 @@
         },
         {
             "id": "ac362d48-c5ca-5090-95ba-19609a39edbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456627ec-81a4-40db-91dc-d25a59cd2837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456627ec-81a4-40db-91dc-d25a59cd2837.jpg?1",
             "name": "Treeshaker Chimera",
             "text": "All creatures able to block Treeshaker Chimera do so.\nWhen Treeshaker Chimera dies, draw three cards.",
             "colours": [
@@ -10391,7 +10391,7 @@
         },
         {
             "id": "3c078eb4-d1b3-5ba3-ae8d-7738e1c169c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146a721-8655-496c-97c0-d6691fa2043e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146a721-8655-496c-97c0-d6691fa2043e.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "",
             "colours": [
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "15351096-6b95-5a8c-bbb2-80bfdf7d5a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02694fb6-7695-4296-b5d6-cfe60829f1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02694fb6-7695-4296-b5d6-cfe60829f1e7.jpg?1",
             "name": "Eidolon of Obstruction",
             "text": "",
             "colours": [
@@ -10464,7 +10464,7 @@
         },
         {
             "id": "39b197ca-526c-5aa4-be3c-97b5db042efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0674c3-4e6c-4dbb-a4b0-a5607fcfc3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0674c3-4e6c-4dbb-a4b0-a5607fcfc3f1.jpg?1",
             "name": "Heliod's Intervention",
             "text": "",
             "colours": [
@@ -10498,7 +10498,7 @@
         },
         {
             "id": "2dea177d-9732-5f09-9692-9bcc4cb8bcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef062a2-8664-49fd-92d6-413fcf2b9dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef062a2-8664-49fd-92d6-413fcf2b9dae.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -10532,7 +10532,7 @@
         },
         {
             "id": "2e6314a8-82ce-51ed-90d6-5021469792fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ca9f3-f8d4-4fd3-b6dd-1a1d56ffd97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ca9f3-f8d4-4fd3-b6dd-1a1d56ffd97c.jpg?1",
             "name": "Shatter the Sky",
             "text": "",
             "colours": [
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "ae356bcb-1055-5937-9caa-1d9e8e41bb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef670df9-0dda-4542-b1c1-3e8963e5f5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef670df9-0dda-4542-b1c1-3e8963e5f5a8.jpg?1",
             "name": "Taranika, Akroan Veteran",
             "text": "",
             "colours": [
@@ -10605,7 +10605,7 @@
         },
         {
             "id": "2a5f7b56-fec9-5d44-bd8d-57c12508ab45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a0d2ba-c75b-4f40-a03b-914a10c35939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a0d2ba-c75b-4f40-a03b-914a10c35939.jpg?1",
             "name": "Ashiok's Erasure",
             "text": "",
             "colours": [
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "58d145c7-a271-5538-8286-9e1c8dc0e655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5d004-78bd-4564-9f4a-fcf463f3a76a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5d004-78bd-4564-9f4a-fcf463f3a76a.jpg?1",
             "name": "Nadir Kraken",
             "text": "",
             "colours": [
@@ -10675,7 +10675,7 @@
         },
         {
             "id": "0c4cb366-deb6-5836-a7a5-7364fa528c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8206247e-43e6-4936-9ef5-42b174ff57c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8206247e-43e6-4936-9ef5-42b174ff57c9.jpg?1",
             "name": "Protean Thaumaturge",
             "text": "",
             "colours": [
@@ -10712,7 +10712,7 @@
         },
         {
             "id": "5ce03192-3e6f-5ccb-bc34-2880944e1c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8688bfcb-4d31-423f-bee3-de8f6ca2f99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8688bfcb-4d31-423f-bee3-de8f6ca2f99d.jpg?1",
             "name": "Thassa's Intervention",
             "text": "",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "ff53f78e-abe3-5732-8531-965288544d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d7e352-4d01-4947-a76f-f8a01dd876cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d7e352-4d01-4947-a76f-f8a01dd876cc.jpg?1",
             "name": "Thassa's Oracle",
             "text": "",
             "colours": [
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "0ae02851-33db-557e-acc8-3e35c94bf2c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044489e-84e0-453e-9248-a200d27ad17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044489e-84e0-453e-9248-a200d27ad17c.jpg?1",
             "name": "Thryx, the Sudden Storm",
             "text": "",
             "colours": [
@@ -10822,7 +10822,7 @@
         },
         {
             "id": "1d413cd8-9807-5f4a-95f8-7ebb73d12ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543356bc-d4ab-4250-80c8-5ca69c11af87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543356bc-d4ab-4250-80c8-5ca69c11af87.jpg?1",
             "name": "Wavebreak Hippocamp",
             "text": "",
             "colours": [
@@ -10860,7 +10860,7 @@
         },
         {
             "id": "86284b38-b719-5be7-b9e0-59603c5f671b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f0dd24-d28c-4f94-8131-3061a1b92e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f0dd24-d28c-4f94-8131-3061a1b92e93.jpg?1",
             "name": "Aphemia, the Cacophony",
             "text": "",
             "colours": [
@@ -10899,7 +10899,7 @@
         },
         {
             "id": "83688735-7a63-57f4-977e-9a7d3bb54209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c06877-a78b-470d-82ab-9d93d5c5e189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c06877-a78b-470d-82ab-9d93d5c5e189.jpg?1",
             "name": "Eat to Extinction",
             "text": "",
             "colours": [
@@ -10933,7 +10933,7 @@
         },
         {
             "id": "01901d2d-02f4-5a9e-9ceb-8ac94ed2ad28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e0691a-7a97-497c-9b57-6a8afa156d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e0691a-7a97-497c-9b57-6a8afa156d87.jpg?1",
             "name": "Erebos's Intervention",
             "text": "",
             "colours": [
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "adcd2b41-f1f6-5b56-bfd1-8e1c69571d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f75fdb-1559-4f4e-b14b-0dfb7305f55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f75fdb-1559-4f4e-b14b-0dfb7305f55b.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "",
             "colours": [
@@ -11005,7 +11005,7 @@
         },
         {
             "id": "cb6f0119-f9af-5ef5-8c49-be2bfb896d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210d25be-7766-4994-9ae5-dce945449d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210d25be-7766-4994-9ae5-dce945449d98.jpg?1",
             "name": "Nightmare Shepherd",
             "text": "",
             "colours": [
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "31662ed1-823c-5532-bd11-09ad3e9aea12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cde9bcb-1c60-4f3f-af07-7db3f8baf1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cde9bcb-1c60-4f3f-af07-7db3f8baf1cc.jpg?1",
             "name": "Treacherous Blessing",
             "text": "",
             "colours": [
@@ -11076,7 +11076,7 @@
         },
         {
             "id": "7a0ea79c-acbc-54fb-a424-9b1ff11ef8ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05500b14-d36d-49b3-82b0-d0c533d4ec00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05500b14-d36d-49b3-82b0-d0c533d4ec00.jpg?1",
             "name": "Woe Strider",
             "text": "",
             "colours": [
@@ -11112,7 +11112,7 @@
         },
         {
             "id": "3c805777-8278-5cd4-9546-f4820e6207a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38beac66-fab1-4999-b43c-524e3225d70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38beac66-fab1-4999-b43c-524e3225d70c.jpg?1",
             "name": "Ox of Agonas",
             "text": "",
             "colours": [
@@ -11148,7 +11148,7 @@
         },
         {
             "id": "4a975221-2258-5d81-995b-ce72794b200d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2be6f0-1cc1-4153-bdcf-528d49a474f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2be6f0-1cc1-4153-bdcf-528d49a474f4.jpg?1",
             "name": "Phoenix of Ash",
             "text": "",
             "colours": [
@@ -11184,7 +11184,7 @@
         },
         {
             "id": "ad5bfbd7-f044-5d1e-98e2-bdf35034db46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b23ba3-0b20-492d-a529-c6e4aeafd5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b23ba3-0b20-492d-a529-c6e4aeafd5aa.jpg?1",
             "name": "Purphoros's Intervention",
             "text": "",
             "colours": [
@@ -11218,7 +11218,7 @@
         },
         {
             "id": "8dde3391-41f8-5d17-9ce6-542f05ac6cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d50d7-6b7c-4109-8f47-443bce9c4451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d50d7-6b7c-4109-8f47-443bce9c4451.jpg?1",
             "name": "Storm Herald",
             "text": "",
             "colours": [
@@ -11255,7 +11255,7 @@
         },
         {
             "id": "225eec1e-5b98-5061-aab9-1209e70db3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f774b26-7b8b-4d06-bec8-764429445e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f774b26-7b8b-4d06-bec8-764429445e93.jpg?1",
             "name": "Storm's Wrath",
             "text": "",
             "colours": [
@@ -11289,7 +11289,7 @@
         },
         {
             "id": "94891233-11c3-5e13-8aa7-8777872bfb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a270521e-5db7-480b-9320-abd64c589f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a270521e-5db7-480b-9320-abd64c589f3d.jpg?1",
             "name": "Tectonic Giant",
             "text": "",
             "colours": [
@@ -11326,7 +11326,7 @@
         },
         {
             "id": "1f438093-8e90-5ded-bca1-34686856abc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e1bdc9-be60-4abd-9756-d3e70e2fcdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e1bdc9-be60-4abd-9756-d3e70e2fcdb5.jpg?1",
             "name": "Underworld Breach",
             "text": "",
             "colours": [
@@ -11360,7 +11360,7 @@
         },
         {
             "id": "4cf8f4d5-8213-5e7a-a129-8b0b1aaeb83f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9304c-9993-4539-9165-48568eb81db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9304c-9993-4539-9165-48568eb81db1.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "",
             "colours": [
@@ -11400,7 +11400,7 @@
         },
         {
             "id": "2669e8f7-745b-5dc5-8d13-514c49ed38b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36adefc7-44a8-40d0-8bdf-ad12d010b0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36adefc7-44a8-40d0-8bdf-ad12d010b0bd.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "",
             "colours": [
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "d72b27b7-673c-5c5f-b243-62a18770135d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168614ac-0126-47f6-a491-5a57490c74a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168614ac-0126-47f6-a491-5a57490c74a7.jpg?1",
             "name": "Mantle of the Wolf",
             "text": "",
             "colours": [
@@ -11474,7 +11474,7 @@
         },
         {
             "id": "54f1337b-39e6-56e6-91c6-6a321b481c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12df807-f100-4a22-b75c-ae7f69431b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12df807-f100-4a22-b75c-ae7f69431b61.jpg?1",
             "name": "Nessian Boar",
             "text": "",
             "colours": [
@@ -11510,7 +11510,7 @@
         },
         {
             "id": "50f49a76-df0d-526a-8c3d-79797da159b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cadcc3a-653d-48f3-8f0f-13c9bb502f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cadcc3a-653d-48f3-8f0f-13c9bb502f37.jpg?1",
             "name": "Nylea's Intervention",
             "text": "",
             "colours": [
@@ -11544,7 +11544,7 @@
         },
         {
             "id": "2a0dc2c9-219a-52e1-8cdb-3066c5156b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a8e37b-0b97-4355-8e00-169a82c38ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a8e37b-0b97-4355-8e00-169a82c38ea0.jpg?1",
             "name": "Nyxbloom Ancient",
             "text": "",
             "colours": [
@@ -11581,7 +11581,7 @@
         },
         {
             "id": "12592467-3670-5b05-8e6f-d15011403589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b2168d-38e5-429f-8663-f0d258c9c441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b2168d-38e5-429f-8663-f0d258c9c441.jpg?1",
             "name": "Setessan Champion",
             "text": "",
             "colours": [
@@ -11618,7 +11618,7 @@
         },
         {
             "id": "ebb27451-f88f-5b72-a411-8bc36daf754d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c543e785-2c6b-4347-a9c3-25940bbadcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c543e785-2c6b-4347-a9c3-25940bbadcff.jpg?1",
             "name": "Allure of the Unknown",
             "text": "",
             "colours": [
@@ -11654,7 +11654,7 @@
         },
         {
             "id": "f074ae9e-0a30-5be9-a69c-587204fb969c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3085763-e65b-49cb-a4e0-2cbad2658a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3085763-e65b-49cb-a4e0-2cbad2658a1b.jpg?1",
             "name": "Atris, Oracle of Half-Truths",
             "text": "",
             "colours": [
@@ -11695,7 +11695,7 @@
         },
         {
             "id": "2b80549d-0c28-5f5c-b338-7260aefd916a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f4d9d-aa87-439c-8db5-3789cabcce4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f4d9d-aa87-439c-8db5-3789cabcce4c.jpg?1",
             "name": "Bronzehide Lion",
             "text": "",
             "colours": [
@@ -11733,7 +11733,7 @@
         },
         {
             "id": "a9d98dac-db30-5221-8f75-79fed98ef13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadfb33-7082-47b8-a498-f3bb963a8d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadfb33-7082-47b8-a498-f3bb963a8d78.jpg?1",
             "name": "Dalakos, Crafter of Wonders",
             "text": "",
             "colours": [
@@ -11774,7 +11774,7 @@
         },
         {
             "id": "ba1b6923-64ed-5e1c-bc72-cfdcc0a166e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1072d6-afda-4282-8dff-06a76ceb447d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1072d6-afda-4282-8dff-06a76ceb447d.jpg?1",
             "name": "Dream Trawler",
             "text": "",
             "colours": [
@@ -11812,7 +11812,7 @@
         },
         {
             "id": "c473c93e-a932-5ca0-ab44-37c995b62aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1059102b-d094-47ea-b39c-8627a50f5bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1059102b-d094-47ea-b39c-8627a50f5bbf.jpg?1",
             "name": "Enigmatic Incarnation",
             "text": "",
             "colours": [
@@ -11848,7 +11848,7 @@
         },
         {
             "id": "ae652f27-5a37-58d9-91dd-787a67ea1761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f721cc84-8d76-4c57-b4ba-e384c67aeef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f721cc84-8d76-4c57-b4ba-e384c67aeef7.jpg?1",
             "name": "Gallia of the Endless Dance",
             "text": "",
             "colours": [
@@ -11888,7 +11888,7 @@
         },
         {
             "id": "8661c7c1-aaee-5d7b-9499-fdbef212852b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426919af-93d1-4825-ac38-98c0d6b5f62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426919af-93d1-4825-ac38-98c0d6b5f62e.jpg?1",
             "name": "Haktos the Unscarred",
             "text": "",
             "colours": [
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "b2184e08-fbf6-5a23-bea9-e454464f5117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050ff430-2ad8-46d0-bfdc-cc7323b87101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050ff430-2ad8-46d0-bfdc-cc7323b87101.jpg?1",
             "name": "Kroxa, Titan of Death's Hunger",
             "text": "",
             "colours": [
@@ -11970,7 +11970,7 @@
         },
         {
             "id": "c75f4ec0-4157-5a41-b926-132b84f4b5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee5698-1a40-434c-937b-9462825a752b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee5698-1a40-434c-937b-9462825a752b.jpg?1",
             "name": "Kunoros, Hound of Athreos",
             "text": "",
             "colours": [
@@ -12010,7 +12010,7 @@
         },
         {
             "id": "31938571-ce74-5765-a9ec-5ec4d2a2e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2674-7882-46b5-9b99-3a13b434a2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2674-7882-46b5-9b99-3a13b434a2a2.jpg?1",
             "name": "Polukranos, Unchained",
             "text": "",
             "colours": [
@@ -12051,7 +12051,7 @@
         },
         {
             "id": "095ecbbf-7e08-5bc7-85f9-7d830b9141a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf6e4d1-1b4f-450c-a0fc-2d02313979ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf6e4d1-1b4f-450c-a0fc-2d02313979ca.jpg?1",
             "name": "Uro, Titan of Nature's Wrath",
             "text": "",
             "colours": [
@@ -12092,7 +12092,7 @@
         },
         {
             "id": "6765d376-9ca8-58aa-8581-9819a4f51a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e73185-afdf-4fae-82c3-b5ea355c1572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e73185-afdf-4fae-82c3-b5ea355c1572.jpg?1",
             "name": "Nyx Lotus",
             "text": "",
             "colours": [],
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "a82e3d86-2ffb-593d-88b5-16db79ce2025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131cb967-9569-4fbf-8143-c410d3a94538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131cb967-9569-4fbf-8143-c410d3a94538.jpg?1",
             "name": "Shadowspear",
             "text": "",
             "colours": [],
@@ -12158,7 +12158,7 @@
         },
         {
             "id": "886095ef-4a62-5321-8e5e-8410e9dbd084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c49891-3972-4af8-a86a-f37320a280ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c49891-3972-4af8-a86a-f37320a280ae.jpg?1",
             "name": "Labyrinth of Skophos",
             "text": "",
             "colours": [],
@@ -12188,7 +12188,7 @@
         },
         {
             "id": "38fc8e52-821b-5701-a5bd-7402ee13a51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4471a4-efcf-46a9-87df-62af9d616bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4471a4-efcf-46a9-87df-62af9d616bd1.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -12221,7 +12221,7 @@
         },
         {
             "id": "a67c3cd2-d09d-5c2e-807b-5f4772c367e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b543f825-dc15-4267-8579-5d07c771dd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b543f825-dc15-4267-8579-5d07c771dd95.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -12254,7 +12254,7 @@
         },
         {
             "id": "84eeea1a-8845-5665-b69f-50ed0505f750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c6be18-356e-4e8b-899c-4a82f5d41a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c6be18-356e-4e8b-899c-4a82f5d41a41.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -12287,7 +12287,7 @@
         },
         {
             "id": "c7ea1c94-3c16-5e9c-9743-27db61d02119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b705a44-b1b6-491b-aaab-53e0577fdde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b705a44-b1b6-491b-aaab-53e0577fdde3.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -12320,7 +12320,7 @@
         },
         {
             "id": "d0cc0b4a-2586-5808-9cd2-6f59b0f74f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f80f4d-0858-46ff-9305-ee6e380eb521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f80f4d-0858-46ff-9305-ee6e380eb521.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -12353,7 +12353,7 @@
         },
         {
             "id": "36e6b862-67b5-5db5-aa59-3cc25879092b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc9a80-850c-4945-b84a-85381cc3ee85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc9a80-850c-4945-b84a-85381cc3ee85.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -12386,7 +12386,7 @@
         },
         {
             "id": "911c3ff3-8068-5580-bb92-049bb5a67deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5ea68-b77d-4fe0-a277-b20d55bc78a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5ea68-b77d-4fe0-a277-b20d55bc78a6.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "",
             "colours": [
@@ -12425,7 +12425,7 @@
         },
         {
             "id": "61ca0be6-5672-5d82-a9df-b10d15fc6be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad40aed-f247-41b3-8198-6367fdeee953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad40aed-f247-41b3-8198-6367fdeee953.jpg?1",
             "name": "Alseid of Life's Bounty",
             "text": "",
             "colours": [
@@ -12462,7 +12462,7 @@
         },
         {
             "id": "c030ff43-7e47-554c-8c1e-f749bb1920a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb95d4e0-02e6-4159-8cc0-c8da27edf2f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb95d4e0-02e6-4159-8cc0-c8da27edf2f9.jpg?1",
             "name": "Thirst for Meaning",
             "text": "",
             "colours": [
@@ -12496,7 +12496,7 @@
         },
         {
             "id": "1651644f-fc18-5464-9473-59b903ecd096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d794d0a4-4041-43c0-aedb-e2a76611a3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d794d0a4-4041-43c0-aedb-e2a76611a3ea.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "",
             "colours": [
@@ -12532,7 +12532,7 @@
         },
         {
             "id": "aa3f32c1-74dd-5ab1-8518-92a283c3a86e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38a0c3-0e1d-487d-99c8-4504d327c64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38a0c3-0e1d-487d-99c8-4504d327c64d.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "f723ff72-acca-50a1-bd6c-00fc67f1176b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc4be7b-a948-464d-8327-575ccb7dccf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc4be7b-a948-464d-8327-575ccb7dccf3.jpg?1",
             "name": "Wolfwillow Haven",
             "text": "",
             "colours": [
@@ -12602,7 +12602,7 @@
         },
         {
             "id": "a6e497f6-6cdd-57f3-be8c-55c6efd96005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd5f96-5683-4959-b973-37f3c2fcf9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd5f96-5683-4959-b973-37f3c2fcf9bf.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -12636,7 +12636,7 @@
         },
         {
             "id": "67cca079-4ef0-5c92-a8a4-495d84a5d5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e76f0e3-9411-401d-ab38-9c3c64769483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e76f0e3-9411-401d-ab38-9c3c64769483.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -12671,7 +12671,7 @@
         },
         {
             "id": "ab6a49f3-7679-59c9-873b-d56dd6b6780a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1c2ee-d92e-409a-995a-b4c91620c918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1c2ee-d92e-409a-995a-b4c91620c918.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -12705,7 +12705,7 @@
         },
         {
             "id": "428dbbb9-3246-58f4-9c76-e07283c3ac55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3365aea-823d-44a9-94d3-ed2a31d85f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3365aea-823d-44a9-94d3-ed2a31d85f34.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -12739,7 +12739,7 @@
         },
         {
             "id": "9ecf9c47-d8b4-5708-b014-a650cd59f5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c23b2-ac39-46b1-aa2b-7d6cbedba767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c23b2-ac39-46b1-aa2b-7d6cbedba767.jpg?1",
             "name": "Reflection",
             "text": "",
             "colours": [
@@ -12773,7 +12773,7 @@
         },
         {
             "id": "24c94ad6-fea2-5622-8c67-2f127fc68254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9f04f7-587e-4774-8aaa-09e8520efacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9f04f7-587e-4774-8aaa-09e8520efacb.jpg?1",
             "name": "Tentacle",
             "text": "",
             "colours": [
@@ -12807,7 +12807,7 @@
         },
         {
             "id": "bf36c4da-3480-500f-bada-b0ace2b290af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -12841,7 +12841,7 @@
         },
         {
             "id": "d2064065-01fd-54fb-89d7-a4bdd51f9ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60466c78-155e-442b-8022-795e1e9de8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60466c78-155e-442b-8022-795e1e9de8df.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -12875,7 +12875,7 @@
         },
         {
             "id": "8ce68783-b5c6-5d6e-a6fe-dcf41cf0ab45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903e30f3-580e-4a14-989b-ae0632363407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903e30f3-580e-4a14-989b-ae0632363407.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -12909,7 +12909,7 @@
         },
         {
             "id": "8eefbdfc-a8cd-561b-a4ce-0fc89dc39635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f28541-9711-42cd-9c83-993a81af96b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f28541-9711-42cd-9c83-993a81af96b6.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -12943,7 +12943,7 @@
         },
         {
             "id": "1bd8aa0a-9d1f-58c9-815a-7c6867b35285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411f4bf6-7f09-4e24-b483-0068d2f974e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411f4bf6-7f09-4e24-b483-0068d2f974e5.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -12977,7 +12977,7 @@
         },
         {
             "id": "0413f5cd-b054-5f30-8e6c-dad8fe9071d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c528581f-f671-45ae-8d7a-ae26a4e62ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c528581f-f671-45ae-8d7a-ae26a4e62ceb.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -13013,7 +13013,7 @@
         },
         {
             "id": "ecdcdb66-d39d-5491-a127-238ff8ec1236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c315a76-9561-426e-b726-288424a5069b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c315a76-9561-426e-b726-288424a5069b.jpg?1",
             "name": "Gold",
             "text": "",
             "colours": [],
@@ -13043,7 +13043,7 @@
         },
         {
             "id": "d25ca38c-26d0-56d5-985c-2fcd0d3e3bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdd5d53-65e7-42c3-a325-791f11335e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdd5d53-65e7-42c3-a325-791f11335e62.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/THS.json
+++ b/Assets/Resources/Sets/THS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "230bc14b-04a1-5dff-90e1-41eafb73c745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d967a4c-2323-4361-a907-5ca9140d8793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d967a4c-2323-4361-a907-5ca9140d8793.jpg?1",
             "name": "Battlewise Valor",
             "text": "Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "b8442a94-14d3-5593-9876-9ed2cb9401f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecd213-2e03-40a8-9323-7b9e6e521a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecd213-2e03-40a8-9323-7b9e6e521a9a.jpg?1",
             "name": "Cavalry Pegasus",
             "text": "Flying\nWhenever Cavalry Pegasus attacks, each attacking Human gains flying until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "d3d3595c-4914-5e24-96d3-2c9f5c0a812c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa9a809-eda4-406a-8bce-d2a1c5f06388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa9a809-eda4-406a-8bce-d2a1c5f06388.jpg?1",
             "name": "Celestial Archon",
             "text": "Bestow {5}{W}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying, first strike\nEnchanted creature gets +4/+4 and has flying and first strike.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "01caa474-14be-5983-bd08-c8f50b054fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5af083f-5820-4185-ac04-4c4368f7703c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5af083f-5820-4185-ac04-4c4368f7703c.jpg?1",
             "name": "Chained to the Rocks",
             "text": "Enchant Mountain you control\nWhen Chained to the Rocks enters the battlefield, exile target creature an opponent controls until Chained to the Rocks leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "1a093f6d-9fc2-5d3a-a026-00d44cc95ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ead499-920c-465a-a23d-f08710d7e9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ead499-920c-465a-a23d-f08710d7e9bc.jpg?1",
             "name": "Chosen by Heliod",
             "text": "Enchant creature\nWhen Chosen by Heliod enters the battlefield, draw a card.\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "91f5873f-7fa7-57db-85f0-f776e498fd98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e652229d-81fe-4261-bebc-9e405bb2d991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e652229d-81fe-4261-bebc-9e405bb2d991.jpg?1",
             "name": "Dauntless Onslaught",
             "text": "Up to two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "c69559ab-8cda-5dc5-8419-84818e23f88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2f3a0-444d-4cad-970f-6c4a63b02cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2f3a0-444d-4cad-970f-6c4a63b02cce.jpg?1",
             "name": "Decorated Griffin",
             "text": "Flying\n{1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "53f454c7-ee96-548f-a277-9ff9685b8414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f46ac0-9e2f-4f9f-beee-0a7914475ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f46ac0-9e2f-4f9f-beee-0a7914475ac1.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "0e1d4ca6-9c17-5382-810c-59cf75c4db28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5b1633-c41d-42b1-af1b-4a872077ffbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5b1633-c41d-42b1-af1b-4a872077ffbd.jpg?1",
             "name": "Elspeth, Sun's Champion",
             "text": "+1: Put three 1/1 white Soldier creature tokens onto the battlefield.\n-3: Destroy all creatures with power 4 or greater.\n-7: You get an emblem with \"Creatures you control get +2/+2 and have flying.\"",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "2b0f03b4-af39-5170-b9b1-2f080e87099f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f7f788-2795-46a7-82ae-270f1e9415ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f7f788-2795-46a7-82ae-270f1e9415ca.jpg?1",
             "name": "Ephara's Warden",
             "text": "{T}: Tap target creature with power 3 or less.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "0c0a106e-bcdd-5cec-9bf0-6b61f515698f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb914a85-3755-4663-8309-6f6d0319262e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb914a85-3755-4663-8309-6f6d0319262e.jpg?1",
             "name": "Evangel of Heliod",
             "text": "When Evangel of Heliod enters the battlefield, put a number of 1/1 white Soldier creature tokens onto the battlefield equal to your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "badb3783-ebae-521c-94eb-0914ec564c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9a5c-5697-4747-adce-5a71bcf1c086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9a5c-5697-4747-adce-5a71bcf1c086.jpg?1",
             "name": "Fabled Hero",
             "text": "Double strike\nHeroic \u2014 Whenever you cast a spell that targets Fabled Hero, put a +1/+1 counter on Fabled Hero.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "8214fe88-7941-5654-9db8-403492f6351a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251015ed-9408-4941-894a-158551ed2613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251015ed-9408-4941-894a-158551ed2613.jpg?1",
             "name": "Favored Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Favored Hoplite, put a +1/+1 counter on Favored Hoplite and prevent all damage that would be dealt to it this turn.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "11c14208-e282-538d-90aa-d1c0e2ac8f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336faaa-fc6d-4fbb-bdd4-969eae565c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336faaa-fc6d-4fbb-bdd4-969eae565c72.jpg?1",
             "name": "Gift of Immortality",
             "text": "Enchant creature\nWhen enchanted creature dies, return that card to the battlefield under its owner's control. Return Gift of Immortality to the battlefield attached to that creature at the beginning of the next end step.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "6d1dda40-291f-5587-bbd9-e586ffc8ee37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3d16f-f0c6-4080-8913-758208b08234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3d16f-f0c6-4080-8913-758208b08234.jpg?1",
             "name": "Glare of Heresy",
             "text": "Exile target white permanent.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "99687962-d5e1-552a-9a5c-61fe8c39bfea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abafabb3-b2e7-4d78-b4b7-d8f701d3ee8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abafabb3-b2e7-4d78-b4b7-d8f701d3ee8b.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "7a8005b0-280f-51cb-9b89-20645ea8965d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d01c9-e76e-42ff-b0fa-8b6786242aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d01c9-e76e-42ff-b0fa-8b6786242aae.jpg?1",
             "name": "Heliod, God of the Sun",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)\nOther creatures you control have vigilance.\n{2}{W}{W}: Put a 2/1 white Cleric enchantment creature token onto the battlefield.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "3857f9d5-b703-58ae-a2b7-62c128afe6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49663acb-582e-495a-b45e-5fc5f4949f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49663acb-582e-495a-b45e-5fc5f4949f22.jpg?1",
             "name": "Heliod's Emissary",
             "text": "Bestow {6}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhenever Heliod's Emissary or enchanted creature attacks, tap target creature an opponent controls.\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "6749867e-00b3-5019-b7db-e7ee4f79bf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c69995b-ef31-4635-8d5a-b31f73993364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c69995b-ef31-4635-8d5a-b31f73993364.jpg?1",
             "name": "Hopeful Eidolon",
             "text": "Bestow {3}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nEnchanted creature gets +1/+1 and has lifelink.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "38ac0d46-4ec0-5921-b46b-1233f3721c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8dae-6248-41a4-80a7-7e8102479de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8dae-6248-41a4-80a7-7e8102479de4.jpg?1",
             "name": "Hundred-Handed One",
             "text": "Vigilance\n{3}{W}{W}{W}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nAs long as Hundred-Handed One is monstrous, it has reach and can block an additional ninety-nine creatures each combat.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "f5c5872a-1a4c-57f6-afac-c9582e8a6ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9df54-e78e-4a86-a8b1-b735ec08a812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9df54-e78e-4a86-a8b1-b735ec08a812.jpg?1",
             "name": "Lagonna-Band Elder",
             "text": "When Lagonna-Band Elder enters the battlefield, if you control an enchantment, you gain 3 life.",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "18391d76-2b33-56f0-bba6-67165f561cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1857fc37-1e7e-4b93-9fa9-ec139f16b7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1857fc37-1e7e-4b93-9fa9-ec139f16b7fa.jpg?1",
             "name": "Last Breath",
             "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "6743309f-ac2f-541d-9fbb-452ba95bc8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade9b739-122c-4659-b1b2-ea0510d96dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade9b739-122c-4659-b1b2-ea0510d96dbc.jpg?1",
             "name": "Leonin Snarecaster",
             "text": "When Leonin Snarecaster enters the battlefield, you may tap target creature.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "477084ad-71d0-5526-9207-a620676a8159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1410d10-476a-4ed2-ae44-75383ed0e359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1410d10-476a-4ed2-ae44-75383ed0e359.jpg?1",
             "name": "Observant Alseid",
             "text": "Bestow {4}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nVigilance\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "c2e6cc8f-f751-57e0-a7cf-c5da6b1c22a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e85180-f3c9-4b03-9c25-223599b937ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e85180-f3c9-4b03-9c25-223599b937ad.jpg?1",
             "name": "Ordeal of Heliod",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Heliod.\nWhen you sacrifice Ordeal of Heliod, you gain 10 life.",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "6de1ca74-0f6a-595f-96cc-e1aad456d6a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c2458-edb7-4822-866b-ca1b2ea7a8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c2458-edb7-4822-866b-ca1b2ea7a8e8.jpg?1",
             "name": "Phalanx Leader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Phalanx Leader, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -892,7 +892,7 @@
         },
         {
             "id": "57ab6bd9-8f66-597a-ab47-bff17d40d94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55c31d1-6b05-4ea1-a444-51ad57ebcfa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55c31d1-6b05-4ea1-a444-51ad57ebcfa0.jpg?1",
             "name": "Ray of Dissolution",
             "text": "Destroy target enchantment. You gain 3 life.",
             "colours": [
@@ -924,7 +924,7 @@
         },
         {
             "id": "45476981-e55f-506f-b8b0-4e22f6d60f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a36e06-39f3-47d0-b6a9-43728afceb4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a36e06-39f3-47d0-b6a9-43728afceb4a.jpg?1",
             "name": "Scholar of Athreos",
             "text": "{2}{B}: Each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "d96c724d-ef64-5106-a0c4-fd16981fce1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfa33-dcec-4b34-9218-c08ad932d27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfa33-dcec-4b34-9218-c08ad932d27b.jpg?1",
             "name": "Setessan Battle Priest",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Setessan Battle Priest, you gain 2 life.",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "462e83b1-f584-5aed-90f0-33542f01d806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2ae77-b16c-4a01-84ce-5c78be5a54d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2ae77-b16c-4a01-84ce-5c78be5a54d8.jpg?1",
             "name": "Setessan Griffin",
             "text": "Flying\n{2}{G}{G}: Setessan Griffin gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -1030,7 +1030,7 @@
         },
         {
             "id": "3d6386e0-77e8-502e-b296-69b55be2318f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5647d-1546-4eff-a2a2-9e9ef26db533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5647d-1546-4eff-a2a2-9e9ef26db533.jpg?1",
             "name": "Silent Artisan",
             "text": "",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "1cd47d1a-6ff8-5f40-bd8e-2d756551f4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc0f46-4df4-4ae3-bfe6-391916eb590f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc0f46-4df4-4ae3-bfe6-391916eb590f.jpg?1",
             "name": "Soldier of the Pantheon",
             "text": "Protection from multicolored\nWhenever an opponent casts a multicolored spell, you gain 1 life.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "da95f43f-b71d-53a0-b06d-e76552c21d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ef01da-d311-4d4f-9f7b-328e7bb17db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ef01da-d311-4d4f-9f7b-328e7bb17db4.jpg?1",
             "name": "Spear of Heliod",
             "text": "Creatures you control get +1/+1.\n{1}{W}{W}, {T}: Destroy target creature that dealt damage to you this turn.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "e2a8a4aa-69ab-506a-bef6-52358e4c303d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edad0276-45d1-45e5-a6b1-1cd2a99b4f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edad0276-45d1-45e5-a6b1-1cd2a99b4f2c.jpg?1",
             "name": "Traveling Philosopher",
             "text": "",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "a654649c-8833-5409-b9be-06119d98921b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdcec06-e33c-4737-b81e-b156d6e3fd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdcec06-e33c-4737-b81e-b156d6e3fd77.jpg?1",
             "name": "Vanquish the Foul",
             "text": "Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "a18999b5-09ca-51f2-892f-8857f982546d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04751f2-b571-49fa-94b6-ec589d314ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04751f2-b571-49fa-94b6-ec589d314ee6.jpg?1",
             "name": "Wingsteed Rider",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "1b0f59c4-d34d-586b-adea-3c29c5489a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc09d4-e6ce-428b-818b-b465093af88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc09d4-e6ce-428b-818b-b465093af88e.jpg?1",
             "name": "Yoked Ox",
             "text": "",
             "colours": [
@@ -1270,7 +1270,7 @@
         },
         {
             "id": "0ab3985f-a160-529f-8d2c-5b9fa278987e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e71b6ad-4b81-4277-8512-0a3f2266cd23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e71b6ad-4b81-4277-8512-0a3f2266cd23.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "4c282718-9eed-5163-8f5b-57f2a44dd2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba104245-0483-407f-971b-ad6d8efd9733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba104245-0483-407f-971b-ad6d8efd9733.jpg?1",
             "name": "Aqueous Form",
             "text": "Enchant creature\nEnchanted creature can't be blocked.\nWhenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "c3791ddf-8bc3-57a7-ac96-6eb8a3c0564b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f10198-1eef-4577-b375-b900b15060e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f10198-1eef-4577-b375-b900b15060e1.jpg?1",
             "name": "Artisan of Forms",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Artisan of Forms, you may have Artisan of Forms become a copy of target creature and gain this ability.",
             "colours": [
@@ -1371,7 +1371,7 @@
         },
         {
             "id": "dd61a575-d3c8-57a9-8be0-2e9a8c73cb88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f9eb0-5a75-4f86-aca9-3f76b0213c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f9eb0-5a75-4f86-aca9-3f76b0213c41.jpg?1",
             "name": "Benthic Giant",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "781d310f-080a-5788-b1b5-544babf91f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e45d14-a501-40b9-af0a-720ecd20dad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e45d14-a501-40b9-af0a-720ecd20dad7.jpg?1",
             "name": "Bident of Thassa",
             "text": "Whenever a creature you control deals combat damage to a player, you may draw a card.\n{1}{U}, {T}: Creatures your opponents control attack this turn if able.",
             "colours": [
@@ -1440,7 +1440,7 @@
         },
         {
             "id": "62f88189-04a0-51e2-bb57-a0b186bf189f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8841c01e-015e-4541-942a-f8859dd03fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8841c01e-015e-4541-942a-f8859dd03fea.jpg?1",
             "name": "Breaching Hippocamp",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Breaching Hippocamp enters the battlefield, untap another target creature you control.",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "48936cb2-3369-590b-b84e-bac5ac03c0a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01320a31-25fa-4324-8225-d150c6aa58a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01320a31-25fa-4324-8225-d150c6aa58a1.jpg?1",
             "name": "Coastline Chimera",
             "text": "Flying\n{1}{W}: Coastline Chimera can block an additional creature this turn.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "acb507a9-1d72-5bc6-8336-25bd7e4f2e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6bb19c-3610-4609-b23c-21d4d80e4582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6bb19c-3610-4609-b23c-21d4d80e4582.jpg?1",
             "name": "Crackling Triton",
             "text": "{2}{R}, Sacrifice Crackling Triton: Crackling Triton deals 2 damage to target creature or player.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "5888d5fb-39d1-5114-b81c-46cd40e76af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78831fc6-ea90-4546-b46a-9c192dbefc65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78831fc6-ea90-4546-b46a-9c192dbefc65.jpg?1",
             "name": "Curse of the Swine",
             "text": "Exile X target creatures. For each creature exiled this way, its controller puts a 2/2 green Boar creature token onto the battlefield.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "ab5494a6-fca4-5993-82b5-f721511c7b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992e8119-f933-4e54-bb04-e1cc78f7e87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992e8119-f933-4e54-bb04-e1cc78f7e87b.jpg?1",
             "name": "Dissolve",
             "text": "Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "0b3a62ea-46e6-5089-9b4e-5f3b6519803f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d3ef99-6c86-4d70-a9a4-9c3cd4eb9538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d3ef99-6c86-4d70-a9a4-9c3cd4eb9538.jpg?1",
             "name": "Fate Foretold",
             "text": "Enchant creature\nWhen Fate Foretold enters the battlefield, draw a card.\nWhen enchanted creature dies, its controller draws a card.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "6e4b510a-5373-5546-aa2f-c8f75d06f977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e658939a-fa5a-4497-b35c-b6fbfa3f6882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e658939a-fa5a-4497-b35c-b6fbfa3f6882.jpg?1",
             "name": "Gainsay",
             "text": "Counter target blue spell.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "3657b31b-a6af-5869-8b9c-91398c834411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8228b-ff9c-4a2a-a0e3-12f6d388a3c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8228b-ff9c-4a2a-a0e3-12f6d388a3c2.jpg?1",
             "name": "Griptide",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "00bda72f-3d27-543b-8fde-d1a7510c9552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbbb721-0c80-4cc2-b036-e629c0c95956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbbb721-0c80-4cc2-b036-e629c0c95956.jpg?1",
             "name": "Horizon Scholar",
             "text": "Flying\nWhen Horizon Scholar enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "1a48d716-2904-5997-9fc2-0a3af869dab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa7744-680f-4c2a-8fa0-9cb0c176ae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa7744-680f-4c2a-8fa0-9cb0c176ae8f.jpg?1",
             "name": "Lost in a Labyrinth",
             "text": "Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "2c4f1d73-877f-5c5e-a8c1-8a7563c35587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19242db3-660d-4d66-800c-d6cee636bcaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19242db3-660d-4d66-800c-d6cee636bcaf.jpg?1",
             "name": "Master of Waves",
             "text": "Protection from red\nElemental creatures you control get +1/+1.\nWhen Master of Waves enters the battlefield, put a number of 1/0 blue Elemental creature tokens onto the battlefield equal to your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -1809,7 +1809,7 @@
         },
         {
             "id": "c362ee3f-1d52-585e-8e94-bcc42a5a273a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22da0c-5bf5-4c81-9422-671ce17c8ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22da0c-5bf5-4c81-9422-671ce17c8ffa.jpg?1",
             "name": "Meletis Charlatan",
             "text": "{2}{U}, {T}: The controller of target instant or sorcery spell copies it. That player may choose new targets for the copy.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "dd6128eb-e2b6-5849-8e77-67e6da98c452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a5946-6f9a-433f-9f1c-b99144daa170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a5946-6f9a-433f-9f1c-b99144daa170.jpg?1",
             "name": "Mnemonic Wall",
             "text": "Defender\nWhen Mnemonic Wall enters the battlefield, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "6d8ae824-6e2c-500f-877c-cda0adb22bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e9c9a2-4c5b-4518-a127-e4ffb23437d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e9c9a2-4c5b-4518-a127-e4ffb23437d6.jpg?1",
             "name": "Nimbus Naiad",
             "text": "Bestow {4}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "8c3e5ca5-b593-591a-add5-acab1c0af026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f347eb88-7d1d-4ed5-b841-2bf81f00d5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f347eb88-7d1d-4ed5-b841-2bf81f00d5f0.jpg?1",
             "name": "Omenspeaker",
             "text": "When Omenspeaker enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1948,7 +1948,7 @@
         },
         {
             "id": "9c413b5f-fc94-5c96-a5ff-9b5bae5ab587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa764244-c5d5-4f27-9c56-866566a1404a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa764244-c5d5-4f27-9c56-866566a1404a.jpg?1",
             "name": "Ordeal of Thassa",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Thassa.\nWhen you sacrifice Ordeal of Thassa, draw two cards.",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "8b64c11d-94a7-572b-8ff0-c4f2e656fd09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9342aba-e3aa-4210-ad72-e609c7c027b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9342aba-e3aa-4210-ad72-e609c7c027b8.jpg?1",
             "name": "Prescient Chimera",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "2c12728a-bdfe-50a2-ae34-62b2f802c994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0a27a6-54b8-4615-89b3-591a4e3ef626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0a27a6-54b8-4615-89b3-591a4e3ef626.jpg?1",
             "name": "Prognostic Sphinx",
             "text": "Flying\nDiscard a card: Prognostic Sphinx gains hexproof until end of turn. Tap it.\nWhenever Prognostic Sphinx attacks, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "a95ad08a-3c12-502a-ae98-439bc392f951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acdf4e4-5933-43dc-bf8b-25f89415db5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acdf4e4-5933-43dc-bf8b-25f89415db5b.jpg?1",
             "name": "Sea God's Revenge",
             "text": "Return up to three target creatures your opponents control to their owners' hands. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "f4be6763-0d55-5852-8230-508feb54996b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f942075-b285-495c-941e-6f1da48d7948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f942075-b285-495c-941e-6f1da48d7948.jpg?1",
             "name": "Sealock Monster",
             "text": "Sealock Monster can't attack unless defending player controls an Island.\n{5}{U}{U}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Sealock Monster becomes monstrous, target land becomes an Island in addition to its other types.",
             "colours": [
@@ -2116,7 +2116,7 @@
         },
         {
             "id": "846d32fb-698f-5150-b244-b5c5745f6aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4585565b-c743-4264-a647-4480ff5a3bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4585565b-c743-4264-a647-4480ff5a3bbf.jpg?1",
             "name": "Shipbreaker Kraken",
             "text": "{6}{U}{U}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)\nWhen Shipbreaker Kraken becomes monstrous, tap up to four target creatures. Those creatures don't untap during their controllers' untap steps for as long as you control Shipbreaker Kraken.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "b88d8416-f3f2-555c-8816-2846308c0913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702b757-5be5-4a48-bc73-a87ec4f3193b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702b757-5be5-4a48-bc73-a87ec4f3193b.jpg?1",
             "name": "Stymied Hopes",
             "text": "Counter target spell unless its controller pays {1}. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "d6ca6fc5-52f4-5d69-b94d-d98c109ade9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd26041-059b-4a1e-9ce8-c3cfd69a3721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd26041-059b-4a1e-9ce8-c3cfd69a3721.jpg?1",
             "name": "Swan Song",
             "text": "Counter target enchantment, instant, or sorcery spell. Its controller puts a 2/2 blue Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -2214,7 +2214,7 @@
         },
         {
             "id": "3de293d5-9d5e-5fbe-a06c-a24f09dd5cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6876c7a-8bbe-484e-b733-70229fa336cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6876c7a-8bbe-484e-b733-70229fa336cd.jpg?1",
             "name": "Thassa, God of the Sea",
             "text": "Indestructible\nAs long as your devotion to blue is less than five, Thassa isn't a creature. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)\nAt the beginning of your upkeep, scry 1.\n{1}{U}: Target creature you control can't be blocked this turn.",
             "colours": [
@@ -2251,7 +2251,7 @@
         },
         {
             "id": "b2af76f8-338c-5bbb-b33c-e797ce6e7774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac987ac-3f81-4704-b42c-651f44670641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac987ac-3f81-4704-b42c-651f44670641.jpg?1",
             "name": "Thassa's Bounty",
             "text": "Draw three cards. Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "c90135d3-85bc-5207-8d77-81bb11d8348f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b325b-3ea9-4a99-ae99-9d158560e45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b325b-3ea9-4a99-ae99-9d158560e45b.jpg?1",
             "name": "Thassa's Emissary",
             "text": "Bestow {5}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhenever Thassa's Emissary or enchanted creature deals combat damage to a player, draw a card.\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -2318,7 +2318,7 @@
         },
         {
             "id": "12ba3023-d384-5569-944c-2b7037b2c4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1173ff96-998c-4fe7-9b28-602d990e0339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1173ff96-998c-4fe7-9b28-602d990e0339.jpg?1",
             "name": "Triton Fortune Hunter",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Triton Fortune Hunter, draw a card.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "b3becf8c-b102-5cb6-b66a-fa3ae0e2f092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg?1",
             "name": "Triton Shorethief",
             "text": "",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "76e22acd-11d4-5e63-a6d5-975b4b0714c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2609e3-ec28-4a41-884e-3d10be5e31b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2609e3-ec28-4a41-884e-3d10be5e31b4.jpg?1",
             "name": "Triton Tactics",
             "text": "Up to two target creatures each get +0/+3 until end of turn. Untap those creatures. At this turn's next end of combat, tap each creature that was blocked by one of those creatures this turn and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "b2fba37f-dce3-5cb2-a442-d9a2c7d7f6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b661a5-359b-4f21-b1b6-aa0988810b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b661a5-359b-4f21-b1b6-aa0988810b4d.jpg?1",
             "name": "Vaporkin",
             "text": "Flying\nVaporkin can block only creatures with flying.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "a1c24d79-409a-5fc6-909e-f7d3c915b647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992ae67-ad0b-40be-a97d-d7fb36754918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992ae67-ad0b-40be-a97d-d7fb36754918.jpg?1",
             "name": "Voyage's End",
             "text": "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "c1815852-d608-511f-a9d2-58ff3c6eec86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7336ca1e-13ef-4e49-a526-3f285bc339bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7336ca1e-13ef-4e49-a526-3f285bc339bb.jpg?1",
             "name": "Wavecrash Triton",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Wavecrash Triton, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2521,7 +2521,7 @@
         },
         {
             "id": "56c53552-6f92-51fa-974a-40edcb6ca76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4415d050-7a76-4f8b-bf78-e33dd21fe4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4415d050-7a76-4f8b-bf78-e33dd21fe4f1.jpg?1",
             "name": "Abhorrent Overlord",
             "text": "Flying\nWhen Abhorrent Overlord enters the battlefield, put a number of 1/1 black Harpy creature tokens with flying onto the battlefield equal to your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\nAt the beginning of your upkeep, sacrifice a creature.",
             "colours": [
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "9229ed47-d286-5bb9-bd02-4b056d53a253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd59977-8788-417d-ba50-e21b8a636bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd59977-8788-417d-ba50-e21b8a636bd3.jpg?1",
             "name": "Agent of the Fates",
             "text": "Deathtouch\nHeroic \u2014 Whenever you cast a spell that targets Agent of the Fates, each opponent sacrifices a creature.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "e748475e-fabc-546a-aab0-1a52c70f7091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675112db-c477-43f4-b755-54162445fb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675112db-c477-43f4-b755-54162445fb49.jpg?1",
             "name": "Asphodel Wanderer",
             "text": "{2}{B}: Regenerate Asphodel Wanderer.",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "1bc5ba0d-80b6-5c45-af79-0bf69c8e046d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853a89c6-63f9-4b12-8a5b-2c382e22b226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853a89c6-63f9-4b12-8a5b-2c382e22b226.jpg?1",
             "name": "Baleful Eidolon",
             "text": "Bestow {4}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nEnchanted creature gets +1/+1 and has deathtouch.",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "6d9dda76-4665-535a-83da-4f82f8f86a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d334fc9b-c1f4-411e-8619-a92f1cc4e7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d334fc9b-c1f4-411e-8619-a92f1cc4e7db.jpg?1",
             "name": "Blood-Toll Harpy",
             "text": "Flying\nWhen Blood-Toll Harpy enters the battlefield, each player loses 1 life.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "a8b51edd-a073-5b60-90c3-fd01c66cf564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4371083b-c300-4464-a7ea-6168db4e345c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4371083b-c300-4464-a7ea-6168db4e345c.jpg?1",
             "name": "Boon of Erebos",
             "text": "Target creature gets +2/+0 until end of turn. Regenerate it. You lose 2 life.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "1857ac1f-f31b-56b6-a113-1320c1e394fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340de29-026f-4c76-8cb5-1abfcecbb3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340de29-026f-4c76-8cb5-1abfcecbb3b1.jpg?1",
             "name": "Cavern Lampad",
             "text": "Bestow {5}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nIntimidate\nEnchanted creature gets +2/+2 and has intimidate.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "5049aec5-1d49-5285-a299-3c9ad4337cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62497880-64dc-4911-8513-f95b73086136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62497880-64dc-4911-8513-f95b73086136.jpg?1",
             "name": "Cutthroat Maneuver",
             "text": "Up to two target creatures each get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "8f277e41-a99a-561f-8c84-91bf8ca382f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56adf4ea-1b1c-4737-8574-1848ca47d4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56adf4ea-1b1c-4737-8574-1848ca47d4f3.jpg?1",
             "name": "Dark Betrayal",
             "text": "Destroy target black creature.",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "ba4cbc7a-2fee-501a-977f-742e6a56c89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1137c-1cbd-4918-9d1c-a9d2bd88562e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1137c-1cbd-4918-9d1c-a9d2bd88562e.jpg?1",
             "name": "Disciple of Phenax",
             "text": "When Disciple of Phenax enters the battlefield, target player reveals a number of cards from his or her hand equal to your devotion to black. You choose one of them. That player discards that card. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "6a110de8-0d7a-5946-a344-cf85143501fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0787e1f-0b75-44ab-a8fd-90358906a787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0787e1f-0b75-44ab-a8fd-90358906a787.jpg?1",
             "name": "Erebos, God of the Dead",
             "text": "Indestructible\nAs long as your devotion to black is less than five, Erebos isn't a creature. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\nYour opponents can't gain life.\n{1}{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "f253f437-9bd8-5aae-8587-29ded15e6212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96f63-d5c3-47d3-a54d-a67883406fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96f63-d5c3-47d3-a54d-a67883406fc5.jpg?1",
             "name": "Erebos's Emissary",
             "text": "Bestow {5}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nDiscard a creature card: Erebos's Emissary gets +2/+2 until end of turn. If Erebos's Emissary is an Aura, enchanted creature gets +2/+2 until end of turn instead.\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "d68d3674-ff55-5361-abe7-a90787f380b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e424de-81be-4f90-a7a2-4102c8ba8989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e424de-81be-4f90-a7a2-4102c8ba8989.jpg?1",
             "name": "Felhide Minotaur",
             "text": "",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "b9c549c2-f516-57f7-a6d3-911832e762b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378c5ba0-bf4f-43d5-b371-0991db5a2e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378c5ba0-bf4f-43d5-b371-0991db5a2e32.jpg?1",
             "name": "Fleshmad Steed",
             "text": "Whenever another creature dies, tap Fleshmad Steed.",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "90c843d9-d4c2-5e61-8492-e9dc292489ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06078ce-f534-4e16-9a70-d51620a33eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06078ce-f534-4e16-9a70-d51620a33eb2.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "When Gray Merchant of Asphodel enters the battlefield, each opponent loses X life, where X is your devotion to black. You gain life equal to the life lost this way. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3034,7 +3034,7 @@
         },
         {
             "id": "e0f6f377-76cf-5ff1-a299-3e86f8022c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596822f6-dbd4-4cc8-aa50-9331ff42544e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596822f6-dbd4-4cc8-aa50-9331ff42544e.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -3066,7 +3066,7 @@
         },
         {
             "id": "a3b74065-fa6f-5f01-986d-7007a7a26663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fbc814-4281-4ac6-a844-68bcd848f229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fbc814-4281-4ac6-a844-68bcd848f229.jpg?1",
             "name": "Hythonia the Cruel",
             "text": "Deathtouch\n{6}{B}{B}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Hythonia the Cruel becomes monstrous, destroy all non-Gorgon creatures.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "b70ba267-ff83-5703-9eeb-aa599dec3b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439ed8d-ae11-4159-9420-5d98c6cc93b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439ed8d-ae11-4159-9420-5d98c6cc93b3.jpg?1",
             "name": "Insatiable Harpy",
             "text": "Flying, lifelink",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "9069285b-96ca-51a7-9567-d9ba79727a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac988f7b-9a10-4b48-8215-50376dc8678c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac988f7b-9a10-4b48-8215-50376dc8678c.jpg?1",
             "name": "Keepsake Gorgon",
             "text": "Deathtouch\n{5}{B}{B}: Monstrosity 1. (If this creature isn't monstrous, put a +1/+1 counter on it and it becomes monstrous.)\nWhen Keepsake Gorgon becomes monstrous, destroy target non-Gorgon creature an opponent controls.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "8ef9ff40-9408-5613-a2d3-0830e436b466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32cf1f-375c-4cc5-9963-c4f9510e3b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32cf1f-375c-4cc5-9963-c4f9510e3b39.jpg?1",
             "name": "Lash of the Whip",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "5118664b-1ea0-5565-8c06-6a831191c21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8cff2f-ba52-4d22-83e8-13c56368f1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8cff2f-ba52-4d22-83e8-13c56368f1df.jpg?1",
             "name": "Loathsome Catoblepas",
             "text": "{2}{G}: Loathsome Catoblepas must be blocked this turn if able.\nWhen Loathsome Catoblepas dies, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "3c5df390-303a-5a8b-84bd-b2609d0f7d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f7521-16e3-4057-a482-7d86392daa57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f7521-16e3-4057-a482-7d86392daa57.jpg?1",
             "name": "March of the Returned",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "f52171a0-d622-5e89-90e1-47bf04c0e128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfd36c5-a484-4973-873c-b6a433da8e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfd36c5-a484-4973-873c-b6a433da8e7a.jpg?1",
             "name": "Mogis's Marauder",
             "text": "When Mogis's Marauder enters the battlefield, up to X target creatures each gain intimidate and haste until end of turn, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "a8cbe21c-88e9-5cfc-91b3-4a9dd618d47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2527a490-6c56-41ba-949c-c78905a128ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2527a490-6c56-41ba-949c-c78905a128ba.jpg?1",
             "name": "Nighthowler",
             "text": "Bestow {2}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nNighthowler and enchanted creature each get +X/+X, where X is the number of creature cards in all graveyards.",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "53d37c85-1c25-5760-a0f3-6b3f8ddc76c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e02ddba-fdc1-4d7b-89eb-00a0417f8963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e02ddba-fdc1-4d7b-89eb-00a0417f8963.jpg?1",
             "name": "Ordeal of Erebos",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Erebos.\nWhen you sacrifice Ordeal of Erebos, target player discards two cards.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "5602ba3d-6c4e-5290-92c6-76b02a6a21f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efc963-5848-44eb-a654-c08b5bd4501d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efc963-5848-44eb-a654-c08b5bd4501d.jpg?1",
             "name": "Pharika's Cure",
             "text": "Pharika's Cure deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3405,7 +3405,7 @@
         },
         {
             "id": "3f087218-35dd-5796-9ff5-6c3af18d523c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbdbf1a-2d15-4291-aa19-614f854d8cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbdbf1a-2d15-4291-aa19-614f854d8cb3.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "c3b7a09e-1a81-550d-b8c2-9c580fcc8d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e46aa9c-7a29-4eb4-bc44-a201c22824d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e46aa9c-7a29-4eb4-bc44-a201c22824d2.jpg?1",
             "name": "Rescue from the Underworld",
             "text": "As an additional cost to cast Rescue from the Underworld, sacrifice a creature.\nChoose target creature card in your graveyard. Return that card and the sacrificed card to the battlefield under your control at the beginning of your next upkeep. Exile Rescue from the Underworld.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "421fc1f6-c09a-5b54-8d88-5928410f84c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1067cf71-a270-4b1b-aa06-0ec0e732ed16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1067cf71-a270-4b1b-aa06-0ec0e732ed16.jpg?1",
             "name": "Returned Centaur",
             "text": "When Returned Centaur enters the battlefield, target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "f8579903-ad2e-5b4f-9962-e3ffe14d6df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93613e23-b363-4bcb-8f63-8f1d25f7f174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93613e23-b363-4bcb-8f63-8f1d25f7f174.jpg?1",
             "name": "Returned Phalanx",
             "text": "Defender\n{1}{U}: Returned Phalanx can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "9bed296f-819c-5a38-9819-be94198288b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed36a150-a686-4fa6-8364-8be262ad7d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed36a150-a686-4fa6-8364-8be262ad7d98.jpg?1",
             "name": "Scourgemark",
             "text": "Enchant creature\nWhen Scourgemark enters the battlefield, draw a card.\nEnchanted creature gets +1/+0.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "50fe9506-dd6d-5c92-84ad-809c16a904b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22051427-9b2a-4571-8c9f-ee84d8d0e4d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22051427-9b2a-4571-8c9f-ee84d8d0e4d1.jpg?1",
             "name": "Sip of Hemlock",
             "text": "Destroy target creature. Its controller loses 2 life.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "63d66511-e1db-5693-b3c1-2534e27dbc91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7275a-5305-42e6-b5c3-8b88568b4e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7275a-5305-42e6-b5c3-8b88568b4e28.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -3638,7 +3638,7 @@
         },
         {
             "id": "6f5b7257-23ed-5507-8ce3-adab87ba2434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c101cf1b-cedf-4b74-9e3c-35f9a8695a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c101cf1b-cedf-4b74-9e3c-35f9a8695a8f.jpg?1",
             "name": "Tormented Hero",
             "text": "Tormented Hero enters the battlefield tapped.\nHeroic \u2014 Whenever you cast a spell that targets Tormented Hero, each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "59174bd3-7339-533e-b991-751a15b8dbda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906ebfc-4756-4caf-83ff-859e181f3bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906ebfc-4756-4caf-83ff-859e181f3bef.jpg?1",
             "name": "Viper's Kiss",
             "text": "Enchant creature\nEnchanted creature gets -1/-1, and its activated abilities can't be activated.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "cacb3198-0a84-57d7-91fc-319f7ecd13f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ec47c-47a2-4eda-b81a-4a07f04e5989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ec47c-47a2-4eda-b81a-4a07f04e5989.jpg?1",
             "name": "Whip of Erebos",
             "text": "Creatures you control have lifelink.\n{2}{B}{B}, {T}: Return target creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step. If it would leave the battlefield, exile it instead of putting it anywhere else. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "19ee36b2-2a45-552d-8be4-a9a71123df32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c50d9-11ec-486b-a5ce-5a6b70858f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c50d9-11ec-486b-a5ce-5a6b70858f30.jpg?1",
             "name": "Akroan Crusader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Crusader, put a 1/1 red Soldier creature token with haste onto the battlefield.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "3113de16-5d09-5443-9378-7baddad56c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90795891-5e67-47c0-8d52-a5e5c5a9ef81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90795891-5e67-47c0-8d52-a5e5c5a9ef81.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "bebc21c5-9014-572e-8a64-8c673f99fc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e201d9e6-d611-4dc4-b665-9062b449f859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e201d9e6-d611-4dc4-b665-9062b449f859.jpg?1",
             "name": "Arena Athlete",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Arena Athlete, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "2186d924-373a-57f8-a044-a75bf8e120dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7f6eb2-feae-4dc9-a009-0ad60f89a592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7f6eb2-feae-4dc9-a009-0ad60f89a592.jpg?1",
             "name": "Borderland Minotaur",
             "text": "",
             "colours": [
@@ -3878,7 +3878,7 @@
         },
         {
             "id": "258d812d-c2f6-56e7-a18d-a8dd12a20bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66470bac-cce0-4e79-82f9-9fb77aa950eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66470bac-cce0-4e79-82f9-9fb77aa950eb.jpg?1",
             "name": "Boulderfall",
             "text": "Boulderfall deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -3910,7 +3910,7 @@
         },
         {
             "id": "19630929-2761-5924-9f7a-1ffb0fcd7098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c29f484-5f4b-4d29-846f-192425ab7fe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c29f484-5f4b-4d29-846f-192425ab7fe3.jpg?1",
             "name": "Coordinated Assault",
             "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -3942,7 +3942,7 @@
         },
         {
             "id": "d678f617-a92a-5e77-9cd2-4d1491fff48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29fc64e-297e-4e10-8f4e-289dc1c3ebfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29fc64e-297e-4e10-8f4e-289dc1c3ebfd.jpg?1",
             "name": "Deathbellow Raider",
             "text": "Deathbellow Raider attacks each turn if able.\n{2}{B}: Regenerate Deathbellow Raider.",
             "colours": [
@@ -3978,7 +3978,7 @@
         },
         {
             "id": "be4c3b43-07cc-5c88-b5f3-3a3fb0c126f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2446dd-d70f-4fdd-87d0-d402ba35d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2446dd-d70f-4fdd-87d0-d402ba35d044.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "9ab2b708-6f65-5a0c-9fcb-4e1f0d01531f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b1080-9001-4751-b2f5-7f56d9f58dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b1080-9001-4751-b2f5-7f56d9f58dff.jpg?1",
             "name": "Dragon Mantle",
             "text": "Enchant creature\nWhen Dragon Mantle enters the battlefield, draw a card.\nEnchanted creature has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4044,7 +4044,7 @@
         },
         {
             "id": "fef651fe-167a-5ef4-accb-4113d2931ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2715851-9def-42a0-bed4-0923e599e19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2715851-9def-42a0-bed4-0923e599e19a.jpg?1",
             "name": "Ember Swallower",
             "text": "{5}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Ember Swallower becomes monstrous, each player sacrifices three lands.",
             "colours": [
@@ -4078,7 +4078,7 @@
         },
         {
             "id": "e7501a2f-979e-512a-922b-332fb805fb13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581eaadb-442b-40c9-b8f9-9e19d5eba824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581eaadb-442b-40c9-b8f9-9e19d5eba824.jpg?1",
             "name": "Fanatic of Mogis",
             "text": "When Fanatic of Mogis enters the battlefield, it deals damage to each opponent equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "2638170f-08ea-5bd4-88dd-8c8f4b6524e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683eaf5a-2f43-477f-b212-70ca5fe04f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683eaf5a-2f43-477f-b212-70ca5fe04f13.jpg?1",
             "name": "Firedrinker Satyr",
             "text": "Whenever Firedrinker Satyr is dealt damage, it deals that much damage to you.\n{1}{R}: Firedrinker Satyr gets +1/+0 until end of turn and deals 1 damage to you.",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "bdef3e49-69f4-5052-bbdd-99f60a6c626c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84b90b6-71e2-429e-9853-50bcbd6538db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84b90b6-71e2-429e-9853-50bcbd6538db.jpg?1",
             "name": "Flamespeaker Adept",
             "text": "Whenever you scry, Flamespeaker Adept gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "d4529fe6-8fa2-5288-a570-e624add0b3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f867f61-676e-40b3-8e22-e60d0606c733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f867f61-676e-40b3-8e22-e60d0606c733.jpg?1",
             "name": "Hammer of Purphoros",
             "text": "Creatures you control have haste.\n{2}{R}, {T}, Sacrifice a land: Put a 3/3 colorless Golem enchantment artifact creature token onto the battlefield.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "53144fd3-9da9-55eb-b084-41afdc608035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f7f757-31ac-43e6-8be0-c5948d478d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f7f757-31ac-43e6-8be0-c5948d478d2f.jpg?1",
             "name": "Ill-Tempered Cyclops",
             "text": "Trample\n{5}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "f167b228-4d12-51bd-9d4a-7a54e6a3ecdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f86d035-a86d-4c2a-a19d-3b90e0f9ff0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f86d035-a86d-4c2a-a19d-3b90e0f9ff0f.jpg?1",
             "name": "Labyrinth Champion",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Labyrinth Champion, Labyrinth Champion deals 2 damage to target creature or player.",
             "colours": [
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "8579aa67-2d39-59c1-a293-2ac55038ae92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb03f2e-2b92-4aa1-afae-301ed5d151d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb03f2e-2b92-4aa1-afae-301ed5d151d3.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to target creature or player.",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "4cd3c18b-4225-5dc2-9193-8923e0d67db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0686b0-27a2-46bc-bc04-717f368d9a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0686b0-27a2-46bc-bc04-717f368d9a78.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to target creature or player. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "41d35d1c-435d-5112-bc98-f8a566314a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d7f033-217f-4fb3-a57b-e32291257ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d7f033-217f-4fb3-a57b-e32291257ec8.jpg?1",
             "name": "Messenger's Speed",
             "text": "Enchant creature\nEnchanted creature has trample and haste.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "c75e2bf6-f3bf-5600-9aa1-31460052d509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6854c913-d4bd-42f7-901c-f3c25be5c4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6854c913-d4bd-42f7-901c-f3c25be5c4b2.jpg?1",
             "name": "Minotaur Skullcleaver",
             "text": "Haste\nWhen Minotaur Skullcleaver enters the battlefield, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "d07019e3-01f6-50c0-bd3e-1e43e5fc14c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb74ccc-5ae5-4437-a0b4-c621ab4c2257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb74ccc-5ae5-4437-a0b4-c621ab4c2257.jpg?1",
             "name": "Ordeal of Purphoros",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Purphoros.\nWhen you sacrifice Ordeal of Purphoros, it deals 3 damage to target creature or player.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "5e6cbfa6-7bc3-55d0-9b38-3d74f901e8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0a00f7-aee0-4ab2-bab6-bc0949176a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0a00f7-aee0-4ab2-bab6-bc0949176a7a.jpg?1",
             "name": "Peak Eruption",
             "text": "Destroy target Mountain. Peak Eruption deals 3 damage to that land's controller.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "eb63e1cd-41fd-5df1-8762-89925977e56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcdf4df-1900-427b-998f-957754ce1b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcdf4df-1900-427b-998f-957754ce1b75.jpg?1",
             "name": "Portent of Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "30cb2f48-eb57-5aae-92ce-d1467a343f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013ec9f5-8bf3-4067-a942-d535d011af82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013ec9f5-8bf3-4067-a942-d535d011af82.jpg?1",
             "name": "Priest of Iroas",
             "text": "{3}{W}, Sacrifice Priest of Iroas: Destroy target enchantment.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "0289496f-53e7-5d8b-b8ff-330abcf15cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf6baf2-d20b-467d-8929-abefcf7dfa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf6baf2-d20b-467d-8929-abefcf7dfa99.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "1941d22d-3462-52e1-aeec-e8e542845fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4ddc30-844c-4860-b394-d3c807c31162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4ddc30-844c-4860-b394-d3c807c31162.jpg?1",
             "name": "Purphoros's Emissary",
             "text": "Bestow {6}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nPurphoros's Emissary can't be blocked except by two or more creatures.\nEnchanted creature gets +3/+3 and can't be blocked except by two or more creatures.",
             "colours": [
@@ -4626,7 +4626,7 @@
         },
         {
             "id": "c6d8ccd7-5f0a-52d7-bcff-686b663d68b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e249f31-cc67-4d0c-9db5-962d10cf74ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e249f31-cc67-4d0c-9db5-962d10cf74ca.jpg?1",
             "name": "Rage of Purphoros",
             "text": "Rage of Purphoros deals 4 damage to target creature. It can't be regenerated this turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "405a826b-ba15-5533-a120-c54bcc46a9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaa31fd-5ba5-49d4-90b6-fafb9f1a8b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaa31fd-5ba5-49d4-90b6-fafb9f1a8b3a.jpg?1",
             "name": "Rageblood Shaman",
             "text": "Trample\nOther Minotaur creatures you control get +1/+1 and have trample.",
             "colours": [
@@ -4693,7 +4693,7 @@
         },
         {
             "id": "a1145800-2955-575c-a703-fe19efca69f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabccddd-c0ea-45a5-bebc-d8f858242a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabccddd-c0ea-45a5-bebc-d8f858242a2a.jpg?1",
             "name": "Satyr Rambler",
             "text": "Trample",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "d8d2b4b1-10cd-58f6-bb67-698bbf01bafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee479c2-a115-450b-bc2e-b03d23b82f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee479c2-a115-450b-bc2e-b03d23b82f2d.jpg?1",
             "name": "Spark Jolt",
             "text": "Spark Jolt deals 1 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4759,7 +4759,7 @@
         },
         {
             "id": "e1bd7be9-3002-5f20-9043-81566a52e336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d9d241-74b8-4b40-b4b7-b8584012d482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d9d241-74b8-4b40-b4b7-b8584012d482.jpg?1",
             "name": "Spearpoint Oread",
             "text": "Bestow {5}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFirst strike\nEnchanted creature gets +2/+2 and has first strike.",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "f47d77aa-a862-55b2-98ca-6dbdd37aa6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d890801-5ffa-48af-959f-72e5f371fc61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d890801-5ffa-48af-959f-72e5f371fc61.jpg?1",
             "name": "Stoneshock Giant",
             "text": "{6}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Stoneshock Giant becomes monstrous, creatures without flying your opponents control can't block this turn.",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "809bd9cf-5b28-5a2f-8123-e7b0092b666d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471979de-f569-444a-8651-12d7e726949a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471979de-f569-444a-8651-12d7e726949a.jpg?1",
             "name": "Stormbreath Dragon",
             "text": "Flying, haste, protection from white\n{5}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Stormbreath Dragon becomes monstrous, it deals damage to each opponent equal to the number of cards in that player's hand.",
             "colours": [
@@ -4862,7 +4862,7 @@
         },
         {
             "id": "9020af19-3cc4-5c6b-b016-b55e563356e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb8e4df-930c-4fb1-9258-184ff6c415d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb8e4df-930c-4fb1-9258-184ff6c415d0.jpg?1",
             "name": "Titan of Eternal Fire",
             "text": "Each Human creature you control has \"{R}, {T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4896,7 +4896,7 @@
         },
         {
             "id": "54cf8999-5880-5bc7-9f57-6cddf7a9e7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6ee53-c5e6-4344-9f35-084cd8cc9cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6ee53-c5e6-4344-9f35-084cd8cc9cd3.jpg?1",
             "name": "Titan's Strength",
             "text": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "937058ce-e120-5173-bf14-db82476e3722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d2f75c-ef2a-4d30-86d1-c47307fc47ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d2f75c-ef2a-4d30-86d1-c47307fc47ac.jpg?1",
             "name": "Two-Headed Cerberus",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -4962,7 +4962,7 @@
         },
         {
             "id": "8de41ea4-21c3-5e04-8e35-3fd39c70efb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ab4e29-44c7-431a-ba11-b2f4f9c75ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ab4e29-44c7-431a-ba11-b2f4f9c75ab1.jpg?1",
             "name": "Wild Celebrants",
             "text": "When Wild Celebrants enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "1c5a3a15-4a5b-5538-8d15-d229126e39cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc08576f-1d48-4db4-9bb9-e039f75c98b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc08576f-1d48-4db4-9bb9-e039f75c98b8.jpg?1",
             "name": "Agent of Horizons",
             "text": "{2}{U}: Agent of Horizons can't be blocked this turn.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "f0ff1973-a630-5edd-a751-33d40fca7c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca89e4d4-185d-4a08-b7af-03f6eff38ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca89e4d4-185d-4a08-b7af-03f6eff38ba3.jpg?1",
             "name": "Anthousa, Setessan Hero",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Anthousa, Setessan Hero, up to three target lands you control each become 2/2 Warrior creatures until end of turn. They're still lands.",
             "colours": [
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "7b89a8e0-9433-593a-a47e-51351986d82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbd7c65-ebe5-47a6-8d2f-9a8c63a30a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbd7c65-ebe5-47a6-8d2f-9a8c63a30a7b.jpg?1",
             "name": "Arbor Colossus",
             "text": "Reach\n{3}{G}{G}{G}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Arbor Colossus becomes monstrous, destroy target creature with flying an opponent controls.",
             "colours": [
@@ -5103,7 +5103,7 @@
         },
         {
             "id": "25eb1266-37d5-518c-a98f-b8c62091c764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f38f7e-2369-48c9-9121-4b13c29ea869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f38f7e-2369-48c9-9121-4b13c29ea869.jpg?1",
             "name": "Artisan's Sorrow",
             "text": "Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "cd4195c1-80ab-5b0b-99bd-e5d35a15dcad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50c12c4-5565-449a-b30e-7cd896da7735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50c12c4-5565-449a-b30e-7cd896da7735.jpg?1",
             "name": "Boon Satyr",
             "text": "Flash\nBestow {3}{G}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +4/+2.",
             "colours": [
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "801d1852-1d24-5666-8151-8d9601b9218b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a2c408-e953-4386-abaf-4af85aba9620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a2c408-e953-4386-abaf-4af85aba9620.jpg?1",
             "name": "Bow of Nylea",
             "text": "Attacking creatures you control have deathtouch.\n{1}{G}, {T}: Choose one \u2014 Put a +1/+1 counter on target creature; or Bow of Nylea deals 2 damage to target creature with flying; or you gain 3 life; or put up to four target cards from your graveyard on the bottom of your library in any order.",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "75cd0e58-6e8f-54bd-ad34-26acd19d0800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975a0b4-7436-4588-8f79-c001a291c459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975a0b4-7436-4588-8f79-c001a291c459.jpg?1",
             "name": "Centaur Battlemaster",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Centaur Battlemaster, put three +1/+1 counters on Centaur Battlemaster.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "731c3367-5cf4-5c3e-93ea-9c95e9ae55b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101ae5f-c3ea-4788-b27f-d9452234eaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101ae5f-c3ea-4788-b27f-d9452234eaef.jpg?1",
             "name": "Commune with the Gods",
             "text": "Reveal the top five cards of your library. You may put a creature or enchantment card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "d358125a-e0ac-5465-9281-ec06b93a67e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e4c4c3-db3c-49d4-8080-1c93470f8b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e4c4c3-db3c-49d4-8080-1c93470f8b4d.jpg?1",
             "name": "Defend the Hearth",
             "text": "Prevent all combat damage that would be dealt to players this turn.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "fff1ecb0-c0e3-538d-bfda-6336ed71ba42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e46a6-f7de-482a-a386-73932d1d9002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e46a6-f7de-482a-a386-73932d1d9002.jpg?1",
             "name": "Fade into Antiquity",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "c46bbaf0-b14d-503f-8fa0-283530861581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f15a2-0058-4188-9696-385fa6974bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f15a2-0058-4188-9696-385fa6974bd4.jpg?1",
             "name": "Feral Invocation",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "4e3c2397-54f4-503c-b761-36b7eb15e4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d4899f-11a4-4a2c-a499-3a447b792f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d4899f-11a4-4a2c-a499-3a447b792f86.jpg?1",
             "name": "Hunt the Hunter",
             "text": "Target green creature you control gets +2/+2 until end of turn. It fights target green creature an opponent controls.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "bf3f15a2-2b67-5009-8b7b-93b357e86516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374a1b7c-ce11-4734-aff2-b0bd00857fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374a1b7c-ce11-4734-aff2-b0bd00857fad.jpg?1",
             "name": "Karametra's Acolyte",
             "text": "{T}: Add an amount of {G} to your mana pool equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "7bb0fba4-e97e-5574-ba32-aad7e532b940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8202e426-ad91-4d2e-9373-7a829b58fff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8202e426-ad91-4d2e-9373-7a829b58fff5.jpg?1",
             "name": "Leafcrown Dryad",
             "text": "Bestow {3}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nReach\nEnchanted creature gets +2/+2 and has reach.",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "aa8e9af1-f6fc-508a-a9fc-a30c2f9d6b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg?1",
             "name": "Mistcutter Hydra",
             "text": "Mistcutter Hydra can't be countered.\nHaste, protection from blue\nMistcutter Hydra enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "576939ab-64cb-544e-9ce3-a8482f43419e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4010889-1d7a-4db3-a27c-c39baa024765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4010889-1d7a-4db3-a27c-c39baa024765.jpg?1",
             "name": "Nemesis of Mortals",
             "text": "Nemesis of Mortals costs {1} less to cast for each creature card in your graveyard.\n{7}{G}{G}: Monstrosity 5. This ability costs {1} less to activate for each creature card in your graveyard. (If this creature isn't monstrous, put five +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "87e5de24-9054-5606-a57b-db89d3da9f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d922596-4c2d-47fd-8c28-0e62972effbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d922596-4c2d-47fd-8c28-0e62972effbf.jpg?1",
             "name": "Nessian Asp",
             "text": "Reach\n{6}{G}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "14e19573-a095-5905-93c1-4c87e6f311a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4697f3aa-abde-4379-af82-f30115f59be0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4697f3aa-abde-4379-af82-f30115f59be0.jpg?1",
             "name": "Nessian Courser",
             "text": "",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "18288b67-754e-5627-8ec4-6bd4633a6d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f185a734-a32a-4244-88e8-dabafbfd064f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f185a734-a32a-4244-88e8-dabafbfd064f.jpg?1",
             "name": "Nylea, God of the Hunt",
             "text": "Indestructible\nAs long as your devotion to green is less than five, Nylea isn't a creature. (Each o\nG in the mana costs of permanents you control counts toward your devotion to green.)\nOther creatures you control have trample.\n{3}{G}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "ff421438-f4ea-531c-b0f5-9faf24ea34e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365d716a-1435-48ac-b85f-2cceca1056dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365d716a-1435-48ac-b85f-2cceca1056dd.jpg?1",
             "name": "Nylea's Disciple",
             "text": "When Nylea's Disciple enters the battlefield, you gain life equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "0641c111-ef7e-5ab4-b8b1-48483a4f9f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f133775-09b3-4df4-a97f-0df75809b724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f133775-09b3-4df4-a97f-0df75809b724.jpg?1",
             "name": "Nylea's Emissary",
             "text": "Bestow {5}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nTrample\nEnchanted creature gets +3/+3 and has trample.",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "aa8f512e-1e3b-5c8f-805b-ad7916c85aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68f1fd4-1a2f-405b-a592-6c4af6214eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68f1fd4-1a2f-405b-a592-6c4af6214eae.jpg?1",
             "name": "Nylea's Presence",
             "text": "Enchant land\nWhen Nylea's Presence enters the battlefield, draw a card.\nEnchanted land is every basic land type in addition to its other types.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "b46e717d-3968-5568-8edb-c48a0f1a8112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c48950-c246-47ad-94e1-bf42a62c2fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c48950-c246-47ad-94e1-bf42a62c2fe7.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea.\nWhen you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "2cae07b4-ce60-5723-bad8-0ae0aa1e353e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168fcf4-cf87-4ab8-9710-6ec672750a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168fcf4-cf87-4ab8-9710-6ec672750a9a.jpg?1",
             "name": "Pheres-Band Centaurs",
             "text": "",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "097c4814-d88e-5abc-b0ab-2d6f6ee6928b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979cc1b-9c1a-47e4-ae37-7c41798eb89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979cc1b-9c1a-47e4-ae37-7c41798eb89a.jpg?1",
             "name": "Polukranos, World Eater",
             "text": "{X}{X}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen Polukranos, World Eater becomes monstrous, it deals X damage divided as you choose among any number of target creatures your opponents control. Each of those creatures deals damage equal to its power to Polukranos.",
             "colours": [
@@ -5856,7 +5856,7 @@
         },
         {
             "id": "e182d6bd-bd9e-5a88-b6c9-45b9976c7b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b4e736-d19a-42ac-8bcb-b8e6b7b7b539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b4e736-d19a-42ac-8bcb-b8e6b7b7b539.jpg?1",
             "name": "Reverent Hunter",
             "text": "When Reverent Hunter enters the battlefield, put a number of +1/+1 counters on it equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "159b8393-353e-5f3a-8f37-e16735c65a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c67e15-833c-406a-b75f-8de97fbacf5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c67e15-833c-406a-b75f-8de97fbacf5a.jpg?1",
             "name": "Satyr Hedonist",
             "text": "{R}, Sacrifice Satyr Hedonist: Add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5926,7 +5926,7 @@
         },
         {
             "id": "48176ff3-0b84-5002-a899-015ba5c4ae5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c4d0-2c30-4a56-94bb-0fff9ffe4a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c4d0-2c30-4a56-94bb-0fff9ffe4a6a.jpg?1",
             "name": "Satyr Piper",
             "text": "{3}{G}: Target creature must be blocked this turn if able.",
             "colours": [
@@ -5961,7 +5961,7 @@
         },
         {
             "id": "59028d57-fe27-58dd-a33e-6de2d654584c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5916d5e7-0825-4d72-82e4-1e4c86d1fafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5916d5e7-0825-4d72-82e4-1e4c86d1fafe.jpg?1",
             "name": "Savage Surge",
             "text": "Target creature gets +2/+2 until end of turn. Untap that creature.",
             "colours": [
@@ -5993,7 +5993,7 @@
         },
         {
             "id": "1f895f10-9fc5-5508-9f20-2fbc2fdcff5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66733fcb-fddc-4c15-bc51-c2cd42ac5a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66733fcb-fddc-4c15-bc51-c2cd42ac5a70.jpg?1",
             "name": "Sedge Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "a82c8c6f-42f2-5e38-ae59-00875848f8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f36143-85b6-412c-8c79-053728b45c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f36143-85b6-412c-8c79-053728b45c25.jpg?1",
             "name": "Shredding Winds",
             "text": "Shredding Winds deals 7 damage to target creature with flying.",
             "colours": [
@@ -6059,7 +6059,7 @@
         },
         {
             "id": "6294df85-7a33-58db-bd8a-b384ba662b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3485eb83-f83c-4776-b164-abd72f3c9547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3485eb83-f83c-4776-b164-abd72f3c9547.jpg?1",
             "name": "Staunch-Hearted Warrior",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Staunch-Hearted Warrior, put two +1/+1 counters on Staunch-Hearted Warrior.",
             "colours": [
@@ -6094,7 +6094,7 @@
         },
         {
             "id": "da9f85d4-caa4-545e-b992-6ccc24ba70b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40b65c1-b24d-492d-81b9-d8474ebdc08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40b65c1-b24d-492d-81b9-d8474ebdc08c.jpg?1",
             "name": "Sylvan Caryatid",
             "text": "Defender, hexproof\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -6128,7 +6128,7 @@
         },
         {
             "id": "3350738a-bb3d-5dd3-b312-b4e16cc6b820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799d08a6-d978-4731-98ad-38acd57f3196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799d08a6-d978-4731-98ad-38acd57f3196.jpg?1",
             "name": "Time to Feed",
             "text": "Choose target creature an opponent controls. When that creature dies this turn, you gain 3 life. Target creature you control fights that\ncreature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6160,7 +6160,7 @@
         },
         {
             "id": "686e80ce-1992-51ba-9f80-68f29fd741ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155ae6c0-5085-45f1-ba9f-508d501fee2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155ae6c0-5085-45f1-ba9f-508d501fee2c.jpg?1",
             "name": "Voyaging Satyr",
             "text": "{T}: Untap target land.",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "a22cb634-7b50-5620-a084-1e484df85375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdacb147-35ce-4751-961e-576b5f958048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdacb147-35ce-4751-961e-576b5f958048.jpg?1",
             "name": "Vulpine Goliath",
             "text": "Trample",
             "colours": [
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "97a87b14-d8dd-5d77-995e-84f6e2c138f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7e81a-6f9e-4cad-a911-fba7a431cd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7e81a-6f9e-4cad-a911-fba7a431cd55.jpg?1",
             "name": "Warriors' Lesson",
             "text": "Until end of turn, up to two target creatures you control each gain \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -6261,7 +6261,7 @@
         },
         {
             "id": "38fd0936-e113-5642-8988-2b5e8cd90d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695ccac5-c87e-49af-9131-8f1730e84bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695ccac5-c87e-49af-9131-8f1730e84bc0.jpg?1",
             "name": "Akroan Hoplite",
             "text": "Whenever Akroan Hoplite attacks, it gets +X/+0 until end of turn, where X is the number of attacking creatures you control.",
             "colours": [
@@ -6298,7 +6298,7 @@
         },
         {
             "id": "7a6feb5a-99fc-5b8b-80da-7bb64d767a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb977e-bd42-43b1-83d1-124e7a413aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb977e-bd42-43b1-83d1-124e7a413aca.jpg?1",
             "name": "Anax and Cymede",
             "text": "First strike, vigilance\nHeroic \u2014 Whenever you cast a spell that targets Anax and Cymede, creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "d98bf477-d9ed-59ba-9a01-ce9fc9752a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602e43b1-1b1c-4eb1-be0a-61b673646c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602e43b1-1b1c-4eb1-be0a-61b673646c6f.jpg?1",
             "name": "Ashen Rider",
             "text": "Flying\nWhen Ashen Rider enters the battlefield or dies, exile target permanent.",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "8e0baa3b-a457-53e7-b6e0-27a1e18194f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599c3c9f-dfb7-4357-9d9c-9a1a4616b103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599c3c9f-dfb7-4357-9d9c-9a1a4616b103.jpg?1",
             "name": "Ashiok, Nightmare Weaver",
             "text": "+2: Exile the top three cards of target opponent's library.\n-X: Put a creature card with converted mana cost X exiled with Ashiok, Nightmare Weaver onto the battlefield under your control. That creature is a Nightmare in addition to its other types.\n-10: Exile all cards from all opponents' hands and graveyards.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "5e1a3147-c08d-5b26-8318-cc94aa2b5b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c929a57-2c23-4bbf-b265-666630a4fde8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c929a57-2c23-4bbf-b265-666630a4fde8.jpg?1",
             "name": "Battlewise Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Battlewise Hoplite, put a +1/+1 counter on Battlewise Hoplite, then scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "9fb5c140-5c54-5078-8945-b4070c72c47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1cbee6-61f4-40f0-86fe-93831a0b87d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1cbee6-61f4-40f0-86fe-93831a0b87d8.jpg?1",
             "name": "Chronicler of Heroes",
             "text": "When Chronicler of Heroes enters the battlefield, draw a card if you control a creature with a +1/+1 counter on it.",
             "colours": [
@@ -6485,7 +6485,7 @@
         },
         {
             "id": "a45ba28d-7fa5-571a-9f05-8bc7297983c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb68644-e99d-4ecb-a804-8d4ad1c3325d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb68644-e99d-4ecb-a804-8d4ad1c3325d.jpg?1",
             "name": "Daxos of Meletis",
             "text": "Daxos of Meletis can't be blocked by creatures with power 3 or greater.\nWhenever Daxos of Meletis deals combat damage to a player, exile the top card of that player's library. You gain life equal to that card's converted mana cost. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -6524,7 +6524,7 @@
         },
         {
             "id": "29396a36-31bf-50d1-bcc0-ce00c74eca11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798af7cb-645f-4526-8a19-6e4595b93964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798af7cb-645f-4526-8a19-6e4595b93964.jpg?1",
             "name": "Destructive Revelry",
             "text": "Destroy target artifact or enchantment. Destructive Revelry deals 2 damage to that permanent's controller.",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "fa047a14-2bf0-5ac9-af6d-493737e426b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622d6c46-82bb-4a97-abe6-b388def44bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622d6c46-82bb-4a97-abe6-b388def44bda.jpg?1",
             "name": "Fleecemane Lion",
             "text": "{3}{G}{W}: Monstrosity 1. (If this creature isn't monstrous, put a +1/+1 counter on it and it becomes monstrous.)\nAs long as Fleecemane Lion is monstrous, it has hexproof and indestructible.",
             "colours": [
@@ -6594,7 +6594,7 @@
         },
         {
             "id": "fc6a857b-cf3f-54a0-a488-69c7f499f38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b0e296-d556-4e76-bb2e-5a640e070bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b0e296-d556-4e76-bb2e-5a640e070bb5.jpg?1",
             "name": "Horizon Chimera",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying, trample\nWhenever you draw a card, you gain 1 life.",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "a9a369fb-73eb-5046-a04e-52790059743d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78791fc6-054f-45eb-b8b0-28f2512d72b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78791fc6-054f-45eb-b8b0-28f2512d72b6.jpg?1",
             "name": "Kragma Warcaller",
             "text": "Minotaur creatures you control have haste.\nWhenever a Minotaur you control attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "9ef64e5b-2feb-5710-84d3-687246244f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f4b3cf-2c78-42c9-9873-3758c7f7bb7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f4b3cf-2c78-42c9-9873-3758c7f7bb7d.jpg?1",
             "name": "Medomai the Ageless",
             "text": "Flying\nWhenever Medomai the Ageless deals combat damage to a player, take an extra turn after this one.\nMedomai the Ageless can't attack during extra turns.",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "386c6151-346b-5565-b42c-647d3af8c3f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcd1ce-717c-431a-9895-f7701d276743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcd1ce-717c-431a-9895-f7701d276743.jpg?1",
             "name": "Pharika's Mender",
             "text": "When Pharika's Mender enters the battlefield, you may return target creature or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -6741,7 +6741,7 @@
         },
         {
             "id": "ded936ed-1b66-54d0-a9a3-d7e3cc61a923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80874006-d057-49b8-981c-1d685ad1474b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80874006-d057-49b8-981c-1d685ad1474b.jpg?1",
             "name": "Polis Crusher",
             "text": "Trample, protection from enchantments\n{4}{R}{G}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhenever Polis Crusher deals combat damage to a player, if Polis Crusher is monstrous, destroy target enchantment that player controls.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "fb7dd906-b404-53f1-a89b-82adf6d0e798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45de923f-fdab-460c-96f4-f62aefa9ad73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45de923f-fdab-460c-96f4-f62aefa9ad73.jpg?1",
             "name": "Prophet of Kruphix",
             "text": "Untap all creatures and lands you control during each other player's untap step.\nYou may cast creature cards as though they had flash.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "fe928bd0-ac91-5192-b655-7158bb3e62a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6e1d03-ad24-4bde-ab3c-28f94e776a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6e1d03-ad24-4bde-ab3c-28f94e776a4e.jpg?1",
             "name": "Psychic Intrusion",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from that player's graveyard or hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "b0a4bce2-f4b4-54b2-a643-76d5ae332974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6c78f-b868-4171-b231-4dee45cfa6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6c78f-b868-4171-b231-4dee45cfa6e0.jpg?1",
             "name": "Reaper of the Wilds",
             "text": "Whenever another creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{B}: Reaper of the Wilds gains deathtouch until end of turn.\n{1}{G}: Reaper of the Wilds gains hexproof until end of turn.",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "3b2c2d28-d1aa-5c9e-8ff4-cf8c7c5e0754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a9c98-1cb4-4c53-a765-c15808c4ab44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a9c98-1cb4-4c53-a765-c15808c4ab44.jpg?1",
             "name": "Sentry of the Underworld",
             "text": "Flying, vigilance\n{W}{B}, Pay 3 life: Regenerate Sentry of the Underworld.",
             "colours": [
@@ -6921,7 +6921,7 @@
         },
         {
             "id": "43ecff8f-c523-5918-b28f-5e9b61dc659f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ad0c03-66d9-4fe3-bc0d-ca67d959c285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ad0c03-66d9-4fe3-bc0d-ca67d959c285.jpg?1",
             "name": "Shipwreck Singer",
             "text": "Flying\n{1}{U}: Target creature an opponent controls attacks this turn if able.\n{1}{B}, {T}: Attacking creatures get -1/-1 until end of turn.",
             "colours": [
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "f82ee6ab-7903-5b66-9713-caa2e0ba6dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19670c-5afa-4e22-b3ff-258faca19556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19670c-5afa-4e22-b3ff-258faca19556.jpg?1",
             "name": "Spellheart Chimera",
             "text": "Flying, trample\nSpellheart Chimera's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "84fc40d8-d24b-52ff-8440-24370a58c1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb69801-b574-4b5f-82e7-8fd34cdadf74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb69801-b574-4b5f-82e7-8fd34cdadf74.jpg?1",
             "name": "Steam Augury",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "fc901b35-df67-5db3-b363-7b3e2d7eb139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588a8f90-4344-4882-9671-4c7295186a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588a8f90-4344-4882-9671-4c7295186a58.jpg?1",
             "name": "Triad of Fates",
             "text": "{1}, {T}: Put a fate counter on another target creature.\n{W}, {T}: Exile target creature that has a fate counter on it, then return it to the battlefield under its owner's control.\n{B}, {T}: Exile target creature that has a fate counter on it. Its controller draws two cards.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "4e7b4762-b610-529f-8a86-0b654c6332c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4ce848-a57d-4e88-8093-9fb1408523bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4ce848-a57d-4e88-8093-9fb1408523bc.jpg?1",
             "name": "Tymaret, the Murder King",
             "text": "{1}{R}, Sacrifice another creature: Tymaret, the Murder King deals 2 damage to target player.\n{1}{B}, Sacrifice a creature: Return Tymaret from your graveyard to your hand.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "6b83a1c3-cdee-5e33-9c35-b954645b643c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a078c3d-88db-4459-9667-ce610ae2f660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a078c3d-88db-4459-9667-ce610ae2f660.jpg?1",
             "name": "Underworld Cerberus",
             "text": "Underworld Cerberus can't be blocked except by three or more creatures.\nCards in graveyards can't be the targets of spells or abilities.\nWhen Underworld Cerberus dies, exile it and each player returns all creature cards from his or her graveyard to his or her hand.",
             "colours": [
@@ -7141,7 +7141,7 @@
         },
         {
             "id": "2f4d970e-2031-5bf6-b1d0-46f792485985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecfe99-9c4b-4087-84ee-fb208fd22820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecfe99-9c4b-4087-84ee-fb208fd22820.jpg?1",
             "name": "Xenagos, the Reveler",
             "text": "+1: Add X mana in any combination of {R} and/or {G} to your mana pool, where X is the number of creatures you control.\n0: Put a 2/2 red and green Satyr creature token with haste onto the battlefield.\n-6: Exile the top seven cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "4ddd4c29-d187-585e-846a-1e949bb91b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec95a60f-5164-47f9-9430-11b114c87815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec95a60f-5164-47f9-9430-11b114c87815.jpg?1",
             "name": "Akroan Horse",
             "text": "Defender\nWhen Akroan Horse enters the battlefield, an opponent gains control of it.\nAt the beginning of your upkeep, each opponent puts a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [],
@@ -7210,7 +7210,7 @@
         },
         {
             "id": "591b95c2-e63d-56e1-89dd-67fa12b26c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76330494-ce39-444e-b5da-8905bcccb8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76330494-ce39-444e-b5da-8905bcccb8ad.jpg?1",
             "name": "Anvilwrought Raptor",
             "text": "Flying, first strike",
             "colours": [],
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "1a6200fd-f88a-5b4d-816f-42e8796f43f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7e563d-964c-4afd-9e21-9d400f8719d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7e563d-964c-4afd-9e21-9d400f8719d4.jpg?1",
             "name": "Bronze Sable",
             "text": "",
             "colours": [],
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "62e2bb8a-2c0a-505c-8c47-7f0c2d08f49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772cbcba-9efa-4894-9b57-e73fd296333d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772cbcba-9efa-4894-9b57-e73fd296333d.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -7303,7 +7303,7 @@
         },
         {
             "id": "fa1ec580-5fd1-5fa7-b9fc-a6ad5a5a0b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e394ffe-7460-4c59-a403-e9404b0d10c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e394ffe-7460-4c59-a403-e9404b0d10c1.jpg?1",
             "name": "Colossus of Akros",
             "text": "Defender, indestructible\n{1}0: Monstrosity 10. (If this creature isn't monstrous, put ten +1/+1 counters on it and it becomes monstrous.)\nAs long as Colossus of Akros is monstrous, it has trample and can attack as though it didn't have defender.",
             "colours": [],
@@ -7334,7 +7334,7 @@
         },
         {
             "id": "0b8d9eaa-3435-511a-aaa7-d8a512c80690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfa31c9-5a11-4366-9063-056a659f3d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfa31c9-5a11-4366-9063-056a659f3d0d.jpg?1",
             "name": "Flamecast Wheel",
             "text": "{5}, {T}, Sacrifice Flamecast Wheel: Flamecast Wheel deals 3 damage to target creature.",
             "colours": [],
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "dfd8a93a-845f-5d51-b388-5df465498f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2222f499-09f9-45a6-8255-9de79df76f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2222f499-09f9-45a6-8255-9de79df76f1c.jpg?1",
             "name": "Fleetfeather Sandals",
             "text": "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "d38d64fe-1d33-5e10-8cad-919626523e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85284586-7a9d-4344-aebd-f0e072c1f266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85284586-7a9d-4344-aebd-f0e072c1f266.jpg?1",
             "name": "Guardians of Meletis",
             "text": "Defender",
             "colours": [],
@@ -7423,7 +7423,7 @@
         },
         {
             "id": "766a998c-20f8-5cbf-839c-7ed3267c8d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba304c-9cb8-4d5c-b70d-b7f61a365977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba304c-9cb8-4d5c-b70d-b7f61a365977.jpg?1",
             "name": "Opaline Unicorn",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7454,7 +7454,7 @@
         },
         {
             "id": "ffaacfbd-9547-5f5e-9e6a-121e6929997a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c100a22c-bf34-42b7-9339-4733698c0935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c100a22c-bf34-42b7-9339-4733698c0935.jpg?1",
             "name": "Prowler's Helm",
             "text": "Equipped creature can't be blocked except by Walls.\nEquip {2}",
             "colours": [],
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "6418f321-2d28-569b-9aa5-8836743ccc22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc6a246-f32a-4dc0-9785-4038804f372f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc6a246-f32a-4dc0-9785-4038804f372f.jpg?1",
             "name": "Pyxis of Pandemonium",
             "text": "{T}: Each player exiles the top card of his or her library face down.\n{7}, {T}, Sacrifice Pyxis of Pandemonium: Each player turns face up all cards he or she owns exiled with Pyxis of Pandemonium, then puts all permanent cards among them onto the battlefield.",
             "colours": [],
@@ -7512,7 +7512,7 @@
         },
         {
             "id": "2023d6ff-81cd-5d50-a1ba-fd485b0204d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245a683f-280e-405c-aa2a-dfabb78dc34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245a683f-280e-405c-aa2a-dfabb78dc34e.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -7540,7 +7540,7 @@
         },
         {
             "id": "441d58a8-8ca5-506f-8d71-3b2026ce75f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d989daa-78eb-4120-81b5-7866a7b04590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d989daa-78eb-4120-81b5-7866a7b04590.jpg?1",
             "name": "Witches' Eye",
             "text": "Equipped creature has \"{1}, {T}: Scry 1.\" (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)\nEquip {1}",
             "colours": [],
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "2146dc43-13a0-58d5-b622-e2a69fd8ab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b27a0-dfd7-4f96-8cde-cacac4b24acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b27a0-dfd7-4f96-8cde-cacac4b24acc.jpg?1",
             "name": "Nykthos, Shrine to Nyx",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Choose a color. Add to your mana pool an amount of mana of that color equal to your devotion to that color. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)",
             "colours": [],
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "e3433b72-1b36-5079-b596-0577b37afcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46febc5d-1625-4e48-bb3f-31ee06fc13dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46febc5d-1625-4e48-bb3f-31ee06fc13dd.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "847fa90a-b899-5c3c-9c83-60cba4d0e0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686559d7-8ac1-496b-a5a6-1467bf8fc7c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686559d7-8ac1-496b-a5a6-1467bf8fc7c5.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "c0a266ee-64b6-5819-88b6-be4b3caa8271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66945b-3e64-498a-9478-5f96a61d4ec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66945b-3e64-498a-9478-5f96a61d4ec7.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -7693,7 +7693,7 @@
         },
         {
             "id": "2acc900e-8911-5a65-a77b-40b18555e29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f14b6b3-5f40-4328-a3be-28fe32dd7cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f14b6b3-5f40-4328-a3be-28fe32dd7cb1.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "925c9cee-7bd0-5780-a9c9-8522504d4068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f53049c-2491-4d20-aa19-00eb5c55b438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f53049c-2491-4d20-aa19-00eb5c55b438.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "1712e524-94cd-5909-988c-d33daac434c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff118a5-765b-4ba1-8f12-ce6f24b2459b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff118a5-765b-4ba1-8f12-ce6f24b2459b.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "4df17997-b991-56fe-a7ab-c1d900edac2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18013a78-d156-42bf-89b7-72e7070872c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18013a78-d156-42bf-89b7-72e7070872c0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "a721a881-7539-54c9-8de2-4919c7365894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e891d622-9369-4eeb-b7e2-183c60ec54d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e891d622-9369-4eeb-b7e2-183c60ec54d2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "b748d169-c818-510c-81d4-3d3d1b5aba13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa4b03f-60f1-441f-8066-8bc13d5637d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa4b03f-60f1-441f-8066-8bc13d5637d1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "8a5cd30b-3cd7-5ffa-aefe-6b11540a4902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37db921-ab2a-46db-82c1-1f1abf7a3cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37db921-ab2a-46db-82c1-1f1abf7a3cf7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "0adc470d-9e5d-5011-8827-6b5cd1ad4d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d851b88b-6ce6-4889-83c2-e191307bcee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d851b88b-6ce6-4889-83c2-e191307bcee6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "e9b566da-fd12-58cf-ae6d-59a1271b19cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac928336-f534-4682-a952-c536a1b14e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac928336-f534-4682-a952-c536a1b14e1e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8011,7 +8011,7 @@
         },
         {
             "id": "36730c74-4f7b-53e8-92c0-4a4e6e8e2357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c266e3-d403-434a-b645-dcb9cf441680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c266e3-d403-434a-b645-dcb9cf441680.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "ae863d06-4045-5bd6-8e62-41472ed6aeb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51852e9d-9183-4f9a-a724-cb60cf677e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51852e9d-9183-4f9a-a724-cb60cf677e38.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8087,7 +8087,7 @@
         },
         {
             "id": "3a69d732-3920-5989-882d-0e554c08a797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b153bb8-f9d9-44dc-ae19-d0eb2ea26ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b153bb8-f9d9-44dc-ae19-d0eb2ea26ba1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "864bfd43-ab00-5568-a4b9-10605e3a1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc9f472-c410-4595-b08d-87c115b9148d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc9f472-c410-4595-b08d-87c115b9148d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "f5e6f375-d476-5931-ba2f-e22a0e496ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a9a01-46fb-4e9d-8e7d-5f2c267ab1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a9a01-46fb-4e9d-8e7d-5f2c267ab1f9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "105cec81-df12-5d34-a7e0-ed00c87f7af9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81047292-e537-47b5-acfa-ed839707109c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81047292-e537-47b5-acfa-ed839707109c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "3e491015-5d10-5ffe-9f7b-e7704c76f977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78801a7-af8c-4f1d-b29e-7a36676b6818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78801a7-af8c-4f1d-b29e-7a36676b6818.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "0f5e0f6f-414d-5cca-a1e3-8321f7dc5180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0a5a9c-e59a-4e33-b584-d6daa7f81547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0a5a9c-e59a-4e33-b584-d6daa7f81547.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8315,7 +8315,7 @@
         },
         {
             "id": "a10db8c0-1614-596f-8779-62cf89a028e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7245d4-7a29-4423-8b44-5e9694e1d9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7245d4-7a29-4423-8b44-5e9694e1d9a1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "447e0157-bd87-5d35-ab1a-64574586a30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29557b92-fded-4aa8-8db7-99168c8e70d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29557b92-fded-4aa8-8db7-99168c8e70d8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "b1062523-47d5-5912-829d-5f08f0e0c2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1469-94b9-4964-ada6-4fb43b0b9282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1469-94b9-4964-ada6-4fb43b0b9282.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "c5363eac-648d-5cf6-bf16-052a9391fce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a37f57-5d3e-488e-a909-f53bd4c2576b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a37f57-5d3e-488e-a909-f53bd4c2576b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "27e3e966-5ec2-515d-89bf-c160e50fbf7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b34d7-e2a6-4cbc-9d5f-b6fe05a1c701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b34d7-e2a6-4cbc-9d5f-b6fe05a1c701.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "bee00f89-d874-53d0-833b-6d9b006412ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a80d346-84e3-4eaf-9635-09da472475d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a80d346-84e3-4eaf-9635-09da472475d8.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "41f58752-13d7-531e-803c-97dcf276ac58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4c9173-e530-4237-a03b-9aeca60ab0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4c9173-e530-4237-a03b-9aeca60ab0e4.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -8578,7 +8578,7 @@
         },
         {
             "id": "bbea12aa-a847-5a57-b8d3-2c247d82f7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f320f4-baae-46cb-840e-421f010a0a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f320f4-baae-46cb-840e-421f010a0a20.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8612,7 +8612,7 @@
         },
         {
             "id": "d4ada9c2-4c71-59c8-a16f-9316fa9955de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c8e63-1462-4ad6-8872-216384160b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c8e63-1462-4ad6-8872-216384160b58.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8646,7 +8646,7 @@
         },
         {
             "id": "ffd6ec4a-93f8-5371-a1e0-4957168a2bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca72703f-d45b-4c80-98a8-55fad1fcf431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca72703f-d45b-4c80-98a8-55fad1fcf431.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8680,7 +8680,7 @@
         },
         {
             "id": "14d38ed8-49f6-5ef4-bb6a-db81e08afeb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e68ed9-d863-4822-b281-e184f3d62faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e68ed9-d863-4822-b281-e184f3d62faa.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8714,7 +8714,7 @@
         },
         {
             "id": "665541d3-79df-5179-8339-762a1d974503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b24bbe-f5bc-44d3-b716-6612d39b07bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b24bbe-f5bc-44d3-b716-6612d39b07bc.jpg?1",
             "name": "Harpy",
             "text": "",
             "colours": [
@@ -8748,7 +8748,7 @@
         },
         {
             "id": "54e19b43-4fbd-56b2-97ed-9cfc0f5381f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e44d4-72c1-4d68-b942-c3e8de6ed7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e44d4-72c1-4d68-b942-c3e8de6ed7a8.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8782,7 +8782,7 @@
         },
         {
             "id": "dc555351-c611-56b1-be9a-81cc7fc72722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f40613b-1bde-4939-86ad-6bd40f9db0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f40613b-1bde-4939-86ad-6bd40f9db0d6.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "5ddad5c0-c242-5bc9-a33e-a5ddc2156f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa93038-2849-4c26-ab4f-1d50d276659f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa93038-2849-4c26-ab4f-1d50d276659f.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "aabe516a-3436-5a37-b36d-ef4beb5c470a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee70ef-6285-4f09-8a71-8b7960e8fa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee70ef-6285-4f09-8a71-8b7960e8fa99.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "c577e7bc-c4c4-5106-afc0-ad752fbf494b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177c37bd-c53d-43b2-88c4-0b80d17a5744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177c37bd-c53d-43b2-88c4-0b80d17a5744.jpg?1",
             "name": "Elspeth, Sun's Champion Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/TMP.json
+++ b/Assets/Resources/Sets/TMP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f0d7f313-cdb1-5759-be20-ad93098bcaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ce7e1e-ffe5-4ced-8967-9a6917245240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ce7e1e-ffe5-4ced-8967-9a6917245240.jpg?1",
             "name": "Advance Scout",
             "text": "First strike\no\nW: Target creature gains first strike until end of turn.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "97439bc8-720f-5439-914d-d43f8c7fb59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44faefbe-d5e7-48f3-ba88-833da0b19707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44faefbe-d5e7-48f3-ba88-833da0b19707.jpg?1",
             "name": "Angelic Protector",
             "text": "Flying\nIf Angelic Protector is the target of a spell or ability, it gets +0/+3 until end of turn.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "1b87afc9-0ade-589e-b8af-80a58f3be05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65ee0f-fdd7-4a5e-a4a3-5dd9c62096ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65ee0f-fdd7-4a5e-a4a3-5dd9c62096ab.jpg?1",
             "name": "Anoint",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPrevent up to 3 damage to any creature.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "1ddd86ce-9016-59e3-96de-6c6634039d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c275aba7-cac6-48e8-b12c-6bd77a5c38fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c275aba7-cac6-48e8-b12c-6bd77a5c38fe.jpg?1",
             "name": "Armor Sliver",
             "text": "Each Sliver gains \"o2: This creature gets +0/+1 until end of turn.\"",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "64e9fdd5-50d9-58e7-90db-da4067c3e37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012049f8-0936-49ed-948d-0d34af28550f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012049f8-0936-49ed-948d-0d34af28550f.jpg?1",
             "name": "Armored Pegasus",
             "text": "Flying",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "f6b7417f-6f43-57c6-b036-27211d462d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dca066-d5e3-442a-95a0-e695c1d5850c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dca066-d5e3-442a-95a0-e695c1d5850c.jpg?1",
             "name": "Auratog",
             "text": "Sacrifice an enchantment: Auratog gets +2/+2 until end of turn.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "4e6979af-ea4e-5097-a26f-dfe15827a947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28333138-60bc-459b-a0cd-1b7fd19c89cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28333138-60bc-459b-a0cd-1b7fd19c89cd.jpg?1",
             "name": "Avenging Angel",
             "text": "Flying\nIf Avenging Angel is put into any graveyard from play, you may put Avenging Angel on top of owner's library.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "f9daa28e-2ef6-548d-8e95-756844099cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6dda88-fc2a-4404-8a82-40c5d77860da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6dda88-fc2a-4404-8a82-40c5d77860da.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage to you from a black source. (Treat further damage from that source normally.)",
             "colours": [
@@ -266,7 +266,7 @@
         },
         {
             "id": "7f917c34-02bb-5422-8677-295e62eb3f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430fb60-78f6-4577-9ec5-a93d6662ef76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430fb60-78f6-4577-9ec5-a93d6662ef76.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage to you from a blue source. (Treat further damage from that source normally.)",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "909d173a-ec1f-522e-872e-9755c1dee71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c76e49-ddd2-4967-a81a-86405260b4bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c76e49-ddd2-4967-a81a-86405260b4bc.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage to you from a green source. (Treat further damage from that source normally.)",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "ffc7da4f-5b80-5be2-b242-8594946203bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38872d-f389-43aa-b6f7-97b2c90e5a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38872d-f389-43aa-b6f7-97b2c90e5a1f.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage to you from a red source. (Treat further damage from that source normally.)",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "77b42787-9b79-5863-a863-d01f0a96fc92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f29a3b-7136-496c-bc29-8808bfff0f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f29a3b-7136-496c-bc29-8808bfff0f82.jpg?1",
             "name": "Circle of Protection: Shadow",
             "text": "o1: Prevent all damage to you from a creature with shadow. (Treat further damage from that source normally.)",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "60a8b937-86ab-5943-9158-ec2a8115fcaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eff4351-5501-4061-a409-49f518ba9628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eff4351-5501-4061-a409-49f518ba9628.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage to you from a white source. (Treat further damage from that source normally.)",
             "colours": [
@@ -421,7 +421,7 @@
         },
         {
             "id": "4b9571b7-6012-5544-bc67-d64bebc8beb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb0e068-16d0-4e1c-acad-0a6d34148c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb0e068-16d0-4e1c-acad-0a6d34148c5a.jpg?1",
             "name": "Clergy en-Vec",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "9ad7b6f9-7502-5c24-9044-9057cc9bb882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a70a6da-dea3-49c0-8c49-6a2229c3ac91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a70a6da-dea3-49c0-8c49-6a2229c3ac91.jpg?1",
             "name": "Cloudchaser Eagle",
             "text": "Flying\nWhen Cloudchaser Eagle comes into play, destroy target enchantment.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "dd87e4e9-be52-54a0-beda-cd8a5f8d52d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65e678-dcb9-4c6c-9a30-8332030dead6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65e678-dcb9-4c6c-9a30-8332030dead6.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "cfef9a05-78ab-51d6-b362-ac07affa6d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1c730f-76da-4eae-b3fc-b428b860ea93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1c730f-76da-4eae-b3fc-b428b860ea93.jpg?1",
             "name": "Elite Javelineer",
             "text": "If Elite Javelineer blocks, it deals 1 damage to target attacking creature.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "42e50284-68c2-5bb0-87a0-4309b505432b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9816a3ef-e2a8-4d97-afbf-d190a62265bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9816a3ef-e2a8-4d97-afbf-d190a62265bf.jpg?1",
             "name": "Field of Souls",
             "text": "Whenever a nontoken creature is put into your graveyard from play, put an Essence token into play. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "14a1fb0b-1f97-5607-a511-48f83e896ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d2b011-bb0d-463c-bf2a-04b6650771a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d2b011-bb0d-463c-bf2a-04b6650771a3.jpg?1",
             "name": "Flickering Ward",
             "text": "When you play Flickering Ward, choose a color.\nEnchanted creature gains protection from the chosen color.\no\nW: Return Flickering Ward to owner's hand.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "d5fdc3c8-52d5-5579-a937-694f068e629a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdca3b-7d53-4d19-bd15-9a1b148c4aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdca3b-7d53-4d19-bd15-9a1b148c4aaf.jpg?1",
             "name": "Gallantry",
             "text": "Target blocking creature gets +4/+4 until end of turn.\nDraw a card.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "7a1e696a-823a-5b77-9bdd-eb94e956b242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504950d5-2df7-4518-b987-fe3a57ad1c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504950d5-2df7-4518-b987-fe3a57ad1c58.jpg?1",
             "name": "Gerrard's Battle Cry",
             "text": "o2o\nW: All creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "378efd48-3f84-58d9-bff3-f0c2678f16fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea44536-ef4e-4dcf-9c1a-c1122dd00cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea44536-ef4e-4dcf-9c1a-c1122dd00cbb.jpg?1",
             "name": "Hanna's Custody",
             "text": "Artifacts cannot be the target of spells or abilities.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "f17dda3c-40f3-5fd6-8c78-6caab0d80f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4cdcc7c-0d01-4aa2-8934-079dfc00eef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4cdcc7c-0d01-4aa2-8934-079dfc00eef2.jpg?1",
             "name": "Hero's Resolve",
             "text": "Enchanted creature gets +1/+5.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "dab4f41a-6119-54ed-adb8-d95c99344220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fb7128-806b-4148-80fe-eb967f248021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fb7128-806b-4148-80fe-eb967f248021.jpg?1",
             "name": "Humility",
             "text": "Each creature loses all abilities and is a 1/1 creature.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "4af22df6-28be-5218-a11f-aacdd855beff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66d1f00-e857-4bc3-a36d-a33669d281e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66d1f00-e857-4bc3-a36d-a33669d281e9.jpg?1",
             "name": "Invulnerability",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPrevent all damage to you from one source. (Treat further damage from that source normally.)",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "9c70f5e6-d389-520e-8d9c-c2330e844f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e5034-a134-4eb6-af8e-b2419b92b3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e5034-a134-4eb6-af8e-b2419b92b3a6.jpg?1",
             "name": "Knight of Dawn",
             "text": "First strike\no\nWo\nW: Knight of Dawn gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "fe2e4f4c-70c9-5102-a3fd-2ab1825b27a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fa9ebe-bdf5-4359-aa3e-6cfa1a1d96cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fa9ebe-bdf5-4359-aa3e-6cfa1a1d96cf.jpg?1",
             "name": "Light of Day",
             "text": "Black creatures cannot attack or block",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "7fcc24d5-b9ea-5e6d-a4f9-d96e88ac55e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca62c97-0bbd-4f74-afd5-99b48c063aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca62c97-0bbd-4f74-afd5-99b48c063aa0.jpg?1",
             "name": "Marble Titan",
             "text": "Creatures with power 3 or greater do not untap during their controllers' untap phases.",
             "colours": [
@@ -903,7 +903,7 @@
         },
         {
             "id": "a3da25ea-cb80-5d73-9eb2-caadc742aa03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e11097-1ace-4ae8-a9e8-d00b9f709e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e11097-1ace-4ae8-a9e8-d00b9f709e54.jpg?1",
             "name": "Master Decoy",
             "text": "o\nW, oc\nT: Tap target creature.",
             "colours": [
@@ -937,7 +937,7 @@
         },
         {
             "id": "85984128-0760-5588-ab52-c67b39cd951f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3abcf2-fe52-4096-8fdb-6917d75a04e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3abcf2-fe52-4096-8fdb-6917d75a04e3.jpg?1",
             "name": "Mounted Archers",
             "text": "Mounted Archers can block creatures with flying.\no\nW: Mounted Archers can block an additional creature this turn. (All blocking assignments must still be legal.)",
             "colours": [
@@ -972,7 +972,7 @@
         },
         {
             "id": "3b904b30-52ec-5e10-b00a-00a048a14fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc538730-c46c-4e5f-bc1f-0efb7765086d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc538730-c46c-4e5f-bc1f-0efb7765086d.jpg?1",
             "name": "Oracle en-Vec",
             "text": "oc\nT: Target opponent chooses any number of creatures he or she controls. During that player's next turn, those creatures attack if able, and no other creatures can attack. At the end of that turn, destroy each of those creatures that did not attack. Use this ability only during your turn.",
             "colours": [
@@ -1006,7 +1006,7 @@
         },
         {
             "id": "142684db-8e16-590c-82a3-0864a48d5a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc45565-4b56-49ba-b115-be8e0de7d937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc45565-4b56-49ba-b115-be8e0de7d937.jpg?1",
             "name": "Orim's Prayer",
             "text": "If any creatures attack you, gain 1 life for each attacking creature.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "dbd59829-b65a-5695-b1ee-42e88a4eb899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7086d077-f083-4870-8b0b-2d34aca49df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7086d077-f083-4870-8b0b-2d34aca49df1.jpg?1",
             "name": "Orim, Samite Healer",
             "text": "Orim, Samite Healer counts as a Cleric.\noc\nT: Prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -1073,7 +1073,7 @@
         },
         {
             "id": "ac654749-a783-52c2-9681-9c0d884477c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6492bf53-ad49-4cd5-83df-0005a5b77811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6492bf53-ad49-4cd5-83df-0005a5b77811.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature cannot attack or block.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "9c903bb2-491a-54bb-9e88-2f4b9ca65d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bce334-0ae6-4a7d-85db-99ee205ce546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bce334-0ae6-4a7d-85db-99ee205ce546.jpg?1",
             "name": "Pegasus Refuge",
             "text": "o2, Choose and discard a card: Put a Pegasus token into play. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "bdd1151a-2828-57a6-bd41-ba22af8bbf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e91f3d-5a23-4df1-a879-d18a3af92a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e91f3d-5a23-4df1-a879-d18a3af92a28.jpg?1",
             "name": "Quickening Licid",
             "text": "o1o\nW, oc\nT: Quickening Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature gains first strike\" instead of a creature. Move Quickening Licid onto target creature. You may pay o\nW to end this effect.",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "a2c0a9da-4995-54c4-80d7-1d4a8f9e7984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e28ac76-c671-4be1-bcfc-17f2d7bbe08f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e28ac76-c671-4be1-bcfc-17f2d7bbe08f.jpg?1",
             "name": "Repentance",
             "text": "Target creature deals to itself damage equal to its power.",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "e837fa66-1bbf-5af3-96d0-9433384edb7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f10c37d-d25a-47d6-83b0-dbe0a9cfc938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f10c37d-d25a-47d6-83b0-dbe0a9cfc938.jpg?1",
             "name": "Sacred Guide",
             "text": "o1o\nW, Sacrifice Sacred Guide: Reveal cards from your library until you reveal a white card. Put that card into your hand. Remove all other revealed cards from the game.",
             "colours": [
@@ -1235,7 +1235,7 @@
         },
         {
             "id": "21745536-d59b-5df7-bcc0-80abf4cfaa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8e174c-7abb-4a93-aa1d-8c2a2e815ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8e174c-7abb-4a93-aa1d-8c2a2e815ba6.jpg?1",
             "name": "Safeguard",
             "text": "o2o\nW: Target creature deals no combat damage this turn.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "f3f30fef-73b8-5513-b632-34ed37f3443c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0b3795-7f30-4c61-b5d8-f238055d6be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0b3795-7f30-4c61-b5d8-f238055d6be1.jpg?1",
             "name": "Serene Offering",
             "text": "Destroy target enchantment. Gain life equal to that enchantment's total casting cost.",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "e0d18b0e-e286-5892-a16f-03313d9c0c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd07471-b216-465c-9946-1eac689db32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd07471-b216-465c-9946-1eac689db32e.jpg?1",
             "name": "Soltari Crusader",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no1o\nW: Soltari Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "230effb4-ebf3-5707-b579-ab33c18ace8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18751d3-052b-4ae5-ba07-16f00a1af40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18751d3-052b-4ae5-ba07-16f00a1af40e.jpg?1",
             "name": "Soltari Emissary",
             "text": "o\nW: Soltari Emissary gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "ed8b0bc5-9da3-503d-a5f9-bedadc07a2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf295dc-72df-4097-b767-d89ab807bf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf295dc-72df-4097-b767-d89ab807bf2e.jpg?1",
             "name": "Soltari Foot Soldier",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "9b1e4e0b-d196-51fa-a849-5da843fe6134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b6c91-dd07-4d39-bd36-6fbf28e7698e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b6c91-dd07-4d39-bd36-6fbf28e7698e.jpg?1",
             "name": "Soltari Lancer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nFirst strike when attacking",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "b8fdc4bd-74f4-5ff1-8f30-6a2470bab2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0d969-3e4d-4ff9-8bda-3a6ac8df01b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0d969-3e4d-4ff9-8bda-3a6ac8df01b2.jpg?1",
             "name": "Soltari Monk",
             "text": "Protection from black; shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "c4d46cf7-f639-552e-a558-6413a4600024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a71390-3fa8-43eb-ad86-67de2a7aeab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a71390-3fa8-43eb-ad86-67de2a7aeab8.jpg?1",
             "name": "Soltari Priest",
             "text": "Protection from red; shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "dd2b0963-7821-50f8-a124-82d6b53a8719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f74aa3-4003-4f53-b774-22b111935391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f74aa3-4003-4f53-b774-22b111935391.jpg?1",
             "name": "Soltari Trooper",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Trooper attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "e7757853-c2f9-5ead-b62b-2085ce328c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7089c9-70ba-4009-86a5-d4e322c00fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7089c9-70ba-4009-86a5-d4e322c00fba.jpg?1",
             "name": "Spirit Mirror",
             "text": "During your upkeep, if there are no Reflection tokens in play, put a Reflection token into play. Treat this token as a 2/2 white creature.\no0: Destroy target Reflection.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "59f0923a-5156-5c0a-9a78-cb3acbd4845d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed7210-17a4-4750-a003-617ba75bff3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed7210-17a4-4750-a003-617ba75bff3e.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, gain 4 life.",
             "colours": [
@@ -1601,7 +1601,7 @@
         },
         {
             "id": "0d2d72eb-dd17-5444-a784-c17f8735e873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186c4b1-b7ec-46eb-a961-257411b401b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186c4b1-b7ec-46eb-a961-257411b401b0.jpg?1",
             "name": "Talon Sliver",
             "text": "All Slivers gain first strike.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "afe8af21-4063-5bb1-9d16-df2ebf1fdfb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbeea8-06b0-4482-bdae-aa82b9db8856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbeea8-06b0-4482-bdae-aa82b9db8856.jpg?1",
             "name": "Warmth",
             "text": "Whenever target opponent successfully casts a red spell, gain 2 life.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "3727b742-eb55-5480-b01e-b0ee820c68a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d731b2-0113-4fd5-8b78-1aa1064bb4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d731b2-0113-4fd5-8b78-1aa1064bb4f5.jpg?1",
             "name": "Winds of Rath",
             "text": "Destroy all creatures with no enchantments on them. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "76b7f8c1-e457-52b3-8bdb-af867e39f8d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f610d8b-1782-43a4-bfb3-40887bdedba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f610d8b-1782-43a4-bfb3-40887bdedba0.jpg?1",
             "name": "Worthy Cause",
             "text": "Buyback o2 (You may pay an additional o2 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nSacrifice a creature: Gain life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "60052f07-1cf8-51f2-a292-c38a8763ba52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9fb7b6-d20c-4c08-9dae-4ccc9138b662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9fb7b6-d20c-4c08-9dae-4ccc9138b662.jpg?1",
             "name": "Benthic Behemoth",
             "text": "Islandwalk (If defending player controls any islands, this creature is unblockable.)",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "fa277afa-5e22-5f66-8f57-a1b36c0bd4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e538b359-d893-422d-9d60-5f3e8ee0fa9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e538b359-d893-422d-9d60-5f3e8ee0fa9e.jpg?1",
             "name": "Capsize",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nReturn target permanent to owner's hand.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "8ebc5af2-45f2-5734-869b-475a60861e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7bd777-6f11-441e-887f-9cee1ef96035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7bd777-6f11-441e-887f-9cee1ef96035.jpg?1",
             "name": "Chill",
             "text": "Red spells cost an additional o2 to play.",
             "colours": [
@@ -1822,7 +1822,7 @@
         },
         {
             "id": "03debc19-ddaa-5ff2-9474-f2bb9e3210f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdd380-71cf-4832-bd02-3697501325f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdd380-71cf-4832-bd02-3697501325f3.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "50a7645d-aaa0-58da-a250-3c900a6119e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e55d6be-7682-4786-9872-e847afd710b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e55d6be-7682-4786-9872-e847afd710b0.jpg?1",
             "name": "Dismiss",
             "text": "Counter target spell.\nDraw a card.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "b3537ac6-03ef-51ef-8800-2dd6275b7e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875f81cf-5f27-451e-9248-746fad1e43d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875f81cf-5f27-451e-9248-746fad1e43d7.jpg?1",
             "name": "Dream Cache",
             "text": "Draw three cards. Choose two cards from your hand and put both on either the top or the bottom of your library.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "4b2e6481-b18f-5f67-a83f-60b34879471d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529cb33-292d-40e3-8cfe-db5eeb0d711e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529cb33-292d-40e3-8cfe-db5eeb0d711e.jpg?1",
             "name": "Duplicity",
             "text": "When Duplicity comes into play, put the top five cards of your library face down on Duplicity.\nDuring your upkeep, you may exchange all the cards in your hand for the cards on Duplicity.\nAt the end of your turn, choose and discard a card.\nIf you lose control of Duplicity, put all cards on it into owner's graveyard.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "dd3eaad9-b4e2-5cba-a484-067b6f6ccc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7e7fa-1493-4ef8-9cdb-b02b07a1ad85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7e7fa-1493-4ef8-9cdb-b02b07a1ad85.jpg?1",
             "name": "Ertai's Meddling",
             "text": "When target spell is successfully cast, put X delay counters on it. X cannot be 0.\nDuring each upkeep of that spell's caster, remove a delay counter from the spell. If the spell has no delay counters on it, it resolves.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "96b7e149-cd52-55ed-baef-77bc29fc2984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0171d4f-c871-4a7f-821a-82b7f401e9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0171d4f-c871-4a7f-821a-82b7f401e9ca.jpg?1",
             "name": "Escaped Shapeshifter",
             "text": "As long as your opponent controls any creatures with flying, Escaped Shapeshifter gains flying. The same is true for first strike, trample, and protection from any color.",
             "colours": [
@@ -2010,7 +2010,7 @@
         },
         {
             "id": "da13a986-6280-50bd-bd0c-417e29832679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be436b65-9193-45ca-93e0-c5e9718f7e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be436b65-9193-45ca-93e0-c5e9718f7e72.jpg?1",
             "name": "Fighting Drake",
             "text": "Flying",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "e68555fd-f321-54e8-b853-05647abbb5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4f686-79e3-4067-81f9-7fae0c25dc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4f686-79e3-4067-81f9-7fae0c25dc8f.jpg?1",
             "name": "Fylamarid",
             "text": "Flying\nFylamarid cannot be blocked by blue creatures.\no\nU: Target creature is blue until end of turn.",
             "colours": [
@@ -2077,7 +2077,7 @@
         },
         {
             "id": "1b181f7e-d47f-53a9-9257-5d09d34dca59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8402d6-b509-4771-ba80-128db343880d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8402d6-b509-4771-ba80-128db343880d.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchanted creature neither deals nor receives combat damage.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "fef756f5-e1eb-58eb-aef9-a9d4c560f756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c65a35-e219-4b60-ab95-ce7eff67d646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c65a35-e219-4b60-ab95-ce7eff67d646.jpg?1",
             "name": "Giant Crab",
             "text": "o\nU: Until end of turn, Giant Crab cannot be the target of spells or abilities.",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "45806b72-c2d4-56cb-8de9-ce6237a8c1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348ce1-6305-42a7-8061-64275f6dc5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348ce1-6305-42a7-8061-64275f6dc5c6.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "1bb3b4b6-e77c-5f2a-8b24-4551e5e44b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfd9cb9-51f6-4d09-b5c0-5b0ed9d16542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfd9cb9-51f6-4d09-b5c0-5b0ed9d16542.jpg?1",
             "name": "Insight",
             "text": "Whenever target opponent successfully casts a green spell, draw a card.",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "d9b1df67-45ee-5de6-a68d-f27b7c65cb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3442c919-73b9-4d29-a014-87293f456325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3442c919-73b9-4d29-a014-87293f456325.jpg?1",
             "name": "Interdict",
             "text": "Counter target artifact, creature, enchantment, or land ability requiring an activation cost. Abilities of that permanent cannot be played again this turn.\nDraw a card.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "349602f1-ca72-53a4-809a-d0431bc18041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f6785-e5a1-4fdc-9fb5-e1a372e7e848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f6785-e5a1-4fdc-9fb5-e1a372e7e848.jpg?1",
             "name": "Intuition",
             "text": "Search your library for any three cards and reveal them to target opponent. He or she chooses one. Put that card into your hand and the rest into your graveyard. Shuffle your library afterwards.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "1560a1af-eb61-55c2-82f3-ac3c737e7610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a89c5-71bd-4fee-ae35-78081e4e0353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a89c5-71bd-4fee-ae35-78081e4e0353.jpg?1",
             "name": "Legacy's Allure",
             "text": "During your upkeep, you may put a treasure counter on Legacy's Allure.\nSacrifice Legacy's Allure: Permanently gain control of target creature with power no greater than the number of treasure counters on Legacy's Allure.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "6f45ac4c-2ec2-5ff2-b51a-48dfc8240143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65506830-fa2c-4e3b-9f64-5a569dd28249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65506830-fa2c-4e3b-9f64-5a569dd28249.jpg?1",
             "name": "Legerdemain",
             "text": "Permanently exchange control of target artifact or creature for control of target permanent of the same type.",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "af860e7e-a714-575a-a282-a01fb80be3cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854dc5e6-63f7-4c8b-83e5-a364f41c9a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854dc5e6-63f7-4c8b-83e5-a364f41c9a15.jpg?1",
             "name": "Mana Severance",
             "text": "Search your library for any number of land cards and remove them from the game. Shuffle your library afterwards.",
             "colours": [
@@ -2362,7 +2362,7 @@
         },
         {
             "id": "d2efd5cd-35c6-51ed-acd7-8c3b1e6d6fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdff306c-1c7e-49ae-b10f-99e1927bbef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdff306c-1c7e-49ae-b10f-99e1927bbef1.jpg?1",
             "name": "Manta Riders",
             "text": "o\nU: Manta Riders gains flying until end of turn.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "3d925d81-2f26-543f-97b3-e4d479809557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f50971e-2a18-4db7-8b5b-83dd5e85766e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f50971e-2a18-4db7-8b5b-83dd5e85766e.jpg?1",
             "name": "Mawcor",
             "text": "Flying\noc\nT: Mawcor deals 1 damage to target creature or player.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "c5cee9c7-5cd3-502b-84ce-462c008a2f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb79a97-c1fc-4aa3-bb13-3d24a6dabeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb79a97-c1fc-4aa3-bb13-3d24a6dabeea.jpg?1",
             "name": "Meditate",
             "text": "Skip your next turn: Draw four cards.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "c7454834-abdc-5657-8b1e-1ed037109693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b167347-2f8f-4338-a651-c7543d812597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b167347-2f8f-4338-a651-c7543d812597.jpg?1",
             "name": "Mnemonic Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: Draw a card.\"",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "a77b7d97-bba9-5fae-805e-842d8abdff91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc58c34-c3de-47f8-a42f-3a974dcb9c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc58c34-c3de-47f8-a42f-3a974dcb9c47.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless its caster pays an additional o\nX. If he or she does not, tap all mana-producing lands that player controls and remove all mana from his or her mana pool.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "7ad6534b-af42-5a16-a84e-31e9177b4182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a0e317-5a76-4eac-a903-b0e3f0a45873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a0e317-5a76-4eac-a903-b0e3f0a45873.jpg?1",
             "name": "Precognition",
             "text": "During your upkeep, you may look at the top card of target opponent's library. You may then put that card on the bottom of his or her library.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "70bc2262-21c2-539d-affb-f5e9bb187ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67dde4d-3df1-480d-a8b8-ab22c768bb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67dde4d-3df1-480d-a8b8-ab22c768bb12.jpg?1",
             "name": "Propaganda",
             "text": "Each turn, each creature cannot attack you unless its controller pays an additional o2 for that creature.",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "c37c6c88-8448-5205-91b4-841c2c4626f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6315323-cf82-46c0-b164-e6ea1bf809f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6315323-cf82-46c0-b164-e6ea1bf809f4.jpg?1",
             "name": "Rootwater Diver",
             "text": "oc\nT, Sacrifice Rootwater Diver: Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "97afb46f-6080-5da9-967c-4b19eff3400f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf7ea34-2cde-4ec5-9b12-99b0002da986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf7ea34-2cde-4ec5-9b12-99b0002da986.jpg?1",
             "name": "Rootwater Hunter",
             "text": "oc\nT: Rootwater Hunter deals 1 damage to target creature or player.",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "b034ec46-4ca1-5f54-9e0c-be7a6257737b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46812d-0721-4e93-b1a7-1d38f477fab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46812d-0721-4e93-b1a7-1d38f477fab6.jpg?1",
             "name": "Rootwater Matriarch",
             "text": "oc\nT: Gain control of target creature as long as that creature has any enchantments on it.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "2ef78d1e-c8bf-59bf-96d1-7d5aa90d4ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa1b84b-efda-4324-9106-0d1d00385cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa1b84b-efda-4324-9106-0d1d00385cdc.jpg?1",
             "name": "Rootwater Shaman",
             "text": "You may play creature enchantments whenever you could play an instant.",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "7dabca43-0548-5caf-8ff7-0632f2ade721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3837ac-54af-44f7-b576-ad5badbee9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3837ac-54af-44f7-b576-ad5badbee9f2.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster cannot attack unless defending player controls any islands.",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "5e65c9fb-8895-52ac-8788-a43d215ba114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c11175-9feb-4801-9b46-d577d5ecef40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c11175-9feb-4801-9b46-d577d5ecef40.jpg?1",
             "name": "Shadow Rift",
             "text": "Target creature gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)\nDraw a card.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "81174841-7299-5b6c-851f-9fd8b81154b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a8dc46-04c7-479a-90c1-b55e6c67e0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a8dc46-04c7-479a-90c1-b55e6c67e0e3.jpg?1",
             "name": "Shimmering Wings",
             "text": "Enchanted creature gains flying.\no\nU: Return Shimmering Wings to owner's hand.",
             "colours": [
@@ -2815,7 +2815,7 @@
         },
         {
             "id": "6857fc88-8cf5-52fd-8b6b-44162557d6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d05ef5-c046-4929-b59d-988f0313a645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d05ef5-c046-4929-b59d-988f0313a645.jpg?1",
             "name": "Skyshroud Condor",
             "text": "Flying\nYou cannot play Skyshroud Condor unless you have successfully cast another spell this turn.",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "8a818b43-806d-5304-accf-73ad0e85a358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe58a24-f6a6-4858-82a5-0ca1d524efe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe58a24-f6a6-4858-82a5-0ca1d524efe1.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with total casting cost equal to X.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "7020c08a-a88d-5093-ad82-3598848f8ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734be7fa-0998-4771-9b97-4989b3fc1471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734be7fa-0998-4771-9b97-4989b3fc1471.jpg?1",
             "name": "Steal Enchantment",
             "text": "Gain control of enchanted enchantment",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "d1d2ecfb-bf4b-534d-931b-28f102ecc3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807227d7-2eb2-4d47-bb3c-9d1ec9befeb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807227d7-2eb2-4d47-bb3c-9d1ec9befeb7.jpg?1",
             "name": "Stinging Licid",
             "text": "o1o\nU, oc\nT: Stinging Licid loses this ability and becomes a creature enchantment that reads \"Whenever enchanted creature becomes tapped, Stinging Licid deals 2 damage to that creature's controller\" instead of a creature. Move Stinging Licid onto target creature. You may pay o\nU to end this effect.",
             "colours": [
@@ -2945,7 +2945,7 @@
         },
         {
             "id": "570edb3b-f63a-5310-b8c7-29ccc3f3eed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d725cdc0-3a85-4722-bb13-40c336f511b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d725cdc0-3a85-4722-bb13-40c336f511b6.jpg?1",
             "name": "Thalakos Dreamsower",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nYou may choose not to untap Thalakos Dreamsower during your untap phase.\nIf Thalakos Dreamsower damages any opponent, tap target creature. As long as Thalakos Dreamsower remains tapped, that creature does not untap during its controller's untap phase.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "55999112-78fe-5eac-9cd4-0bbb7c25ed14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7b5b00-9d14-4090-b8c3-28b70375571e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7b5b00-9d14-4090-b8c3-28b70375571e.jpg?1",
             "name": "Thalakos Mistfolk",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no\nU: Put Thalakos Mistfolk on top of owner's library.",
             "colours": [
@@ -3013,7 +3013,7 @@
         },
         {
             "id": "d404f511-59ea-50e1-882c-38db19691b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a7d63-94ae-4d92-86ab-12bf9d78a803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a7d63-94ae-4d92-86ab-12bf9d78a803.jpg?1",
             "name": "Thalakos Seer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Thalakos Seer leaves play, draw a card.",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "a2ef9ac3-b014-5bf7-941e-c6b7527f0990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a13d6-5f73-4166-b923-9db8ee3f2cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a13d6-5f73-4166-b923-9db8ee3f2cf7.jpg?1",
             "name": "Thalakos Sentry",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow)",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "180f38c8-58db-5597-8c5d-876add5612d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e63f0c-a09f-493d-a8a9-ddcc0a0ca383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e63f0c-a09f-493d-a8a9-ddcc0a0ca383.jpg?1",
             "name": "Time Ebb",
             "text": "Put target creature on top of owner's library.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "a1870678-360f-5e90-b936-c9afa5c4e4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447aeaf-3b26-442a-99d4-0a7ee76c8e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447aeaf-3b26-442a-99d4-0a7ee76c8e76.jpg?1",
             "name": "Time Warp",
             "text": "Target player takes an extra turn after this one.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "a1120060-415c-501a-90ab-c0fc68e56e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09412374-3645-4644-952e-2beaefb3104b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09412374-3645-4644-952e-2beaefb3104b.jpg?1",
             "name": "Tradewind Rider",
             "text": "Flying\noc\nT, Tap two creatures you control: Return target permanent to owner's hand.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "63179f11-93c0-5ba6-b335-85067a67868c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba021eb-3d8b-41bf-aec4-af211e0860ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba021eb-3d8b-41bf-aec4-af211e0860ad.jpg?1",
             "name": "Twitch",
             "text": "Tap or untap target artifact, creature, or land.\nDraw a card.",
             "colours": [
@@ -3207,7 +3207,7 @@
         },
         {
             "id": "261b3644-8080-5325-a2f9-be5d9c2a19d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8cbd4-f49d-420d-a027-3be64ca58989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8cbd4-f49d-420d-a027-3be64ca58989.jpg?1",
             "name": "Unstable Shapeshifter",
             "text": "Whenever any creature comes into play, Unstable Shapeshifter permanently becomes a copy of that creature and retains this ability.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "360c013d-47ab-5e72-a091-aba495e8502b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce63d86-8748-428a-aa9c-d3c0526537a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce63d86-8748-428a-aa9c-d3c0526537a2.jpg?1",
             "name": "Volrath's Curse",
             "text": "Enchanted creature cannot attack, block, or play any ability requiring an activation cost. That creature's controller may sacrifice a permanent to ignore this ability until end of turn.\no1o\nU: Return Volrath's Curse to owner's hand.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "d2a6eaf5-a9a7-5844-b462-88c112855c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e259da60-c8bc-4a77-98ed-e529dc067732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e259da60-c8bc-4a77-98ed-e529dc067732.jpg?1",
             "name": "Whim of Volrath",
             "text": "Buyback o2 (You may pay an additional o2 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nChange the text of target permanent by replacing all instances of one color word or basic land type with another until end of turn.",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "46ee2739-ea66-53d3-b2e3-df0f0c857524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c5cfd1-3f7c-4250-a84d-8db83c6d7eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c5cfd1-3f7c-4250-a84d-8db83c6d7eb7.jpg?1",
             "name": "Whispers of the Muse",
             "text": "Buyback o5 (You may pay an additional o5 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDraw a card.",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "876356c7-e36c-520d-8375-463c20531aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7f7a94-700a-4f3b-846c-a36505b80875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7f7a94-700a-4f3b-846c-a36505b80875.jpg?1",
             "name": "Wind Dancer",
             "text": "Flying\noc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "f118c486-ba96-56b6-872c-0244b6bfcfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0c9e2-a45d-44d1-b73e-73c0a22d0752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0c9e2-a45d-44d1-b73e-73c0a22d0752.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "ed56502a-ce4a-505a-8b2f-ff609b083a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03aa58b4-dbc2-414e-aa7a-f09360d59b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03aa58b4-dbc2-414e-aa7a-f09360d59b3c.jpg?1",
             "name": "Winged Sliver",
             "text": "All Slivers gain flying.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "abf27f5f-85f8-5c84-997a-6c6271b3ec3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942cf220-472c-48f6-8f60-993939ea5ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942cf220-472c-48f6-8f60-993939ea5ab8.jpg?1",
             "name": "Abandon Hope",
             "text": "Choose and discard X cards: Look at target opponent's hand and choose X of those cards. That player discards the chosen cards.",
             "colours": [
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "6b0bc964-606d-56a7-8a96-b08be9065d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26915b4b-ada1-45f3-b908-04a774011b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26915b4b-ada1-45f3-b908-04a774011b66.jpg?1",
             "name": "Bellowing Fiend",
             "text": "Flying\nWhenever Bellowing Fiend damages any creature, Bellowing Fiend deals 3 damage to that creature's controller and 3 damage to you.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "a9dbe133-0934-5f0b-99a2-b382038935ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a89ba1b-e68b-4d70-a25e-27be9bf48a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a89ba1b-e68b-4d70-a25e-27be9bf48a3b.jpg?1",
             "name": "Blood Pet",
             "text": "Sacrifice Blood Pet: Add o\nB to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "c4a55b73-b824-5294-b670-6f9b43b1a025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98319fd3-0aad-4fc3-bb83-3c027d0ed652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98319fd3-0aad-4fc3-bb83-3c027d0ed652.jpg?1",
             "name": "Bounty Hunter",
             "text": "oc\nT: Put a bounty counter on target nonblack creature.\noc\nT: Destroy target creature with any bounty counters on it.",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "511f3129-da24-53a3-8560-190422be12a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884e19fb-67a4-42d8-b163-720a99cb8506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884e19fb-67a4-42d8-b163-720a99cb8506.jpg?1",
             "name": "Carrionette",
             "text": "o2o\nBo\nB: Remove Carrionette and target creature from the game. That creature's controller may pay o2 to counter this ability. Use this ability only if Carrionette is in your graveyard.",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "29d01d6b-74b1-544f-af44-d9c134153762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdead1f4-a6e4-4370-80ae-811881a90d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdead1f4-a6e4-4370-80ae-811881a90d01.jpg?1",
             "name": "Clot Sliver",
             "text": "Each Sliver gains \"o2: Regenerate this creature.\"",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "6f8e8551-623d-5ae1-aa42-f922068232c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df7b947-bdb2-4204-8eb0-92fe66411613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df7b947-bdb2-4204-8eb0-92fe66411613.jpg?1",
             "name": "Coercion",
             "text": "Look at target opponent's hand and choose one of those cards. That player discards that card.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "b7e9a982-e4c7-59d2-aa9f-db87e0d2ac10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8af70-c26d-4b78-aad6-bd51b5afc590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8af70-c26d-4b78-aad6-bd51b5afc590.jpg?1",
             "name": "Coffin Queen",
             "text": "You may choose not to untap Coffin Queen during your untap phase.\no2o\nB, oc\nT: Put target creature card from any graveyard into play under your control. Remove that creature from the game if Coffin Queen becomes untapped or if you lose control of Coffin Queen.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "0aff0691-2b01-5bfe-bd48-1b84909c8548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ce69f-a259-4801-9ac3-f6754040434c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ce69f-a259-4801-9ac3-f6754040434c.jpg?1",
             "name": "Commander Greven il-Vec",
             "text": "When Commander Greven il-Vec comes into play, sacrifice a creature.\nGreven cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "77bc2c2b-fc67-537f-8a5b-5efb87664b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae81ea-13e3-4ab8-b956-4c7b139a5e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae81ea-13e3-4ab8-b956-4c7b139a5e9c.jpg?1",
             "name": "Corpse Dance",
             "text": "Buyback o2 (You may pay an additional o2 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPut the top creature card from your graveyard into play. That creature is unaffected by summoning sickness this turn. Remove the creature from the game at end of turn.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "d34a69a6-3c3e-5099-a3b1-760f66ff1224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922d6c8b-70ae-4db4-bf26-1904e4906211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922d6c8b-70ae-4db4-bf26-1904e4906211.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. That creature cannot be regenerated this turn.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "a09a9fab-0d6e-54e4-9cc7-49c095004ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4708e8-2149-4990-987c-2ea55fc6c508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4708e8-2149-4990-987c-2ea55fc6c508.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "86e0bd44-7390-5cb8-95f4-236c93977e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb883b7-da6a-45c3-9dde-61334a0ddcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb883b7-da6a-45c3-9dde-61334a0ddcae.jpg?1",
             "name": "Darkling Stalker",
             "text": "o\nB: Regenerate Darkling Stalker.\no\nB: Darkling Stalker gets +1/+1 until end of turn.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "b2613736-9235-51c3-9a77-7a66fd1b395e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84bb94-d654-4d69-89d9-0a398a940125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84bb94-d654-4d69-89d9-0a398a940125.jpg?1",
             "name": "Dauthi Embrace",
             "text": "o\nBo\nB: Target creature gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "03319ea9-da2c-5dee-8867-b19a288152b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70778e-8171-4d97-b86c-d4d92b7e7f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70778e-8171-4d97-b86c-d4d92b7e7f06.jpg?1",
             "name": "Dauthi Ghoul",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever any creature with shadow is put into any graveyard from play, put a +1/+1 counter on Dauthi Ghoul.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "1b48951c-99db-55f7-a2d9-f321421789d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8bb3a-3a84-442f-8e31-8af2f04408ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8bb3a-3a84-442f-8e31-8af2f04408ab.jpg?1",
             "name": "Dauthi Horror",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Horror cannot be blocked by white creatures.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "999b3b4c-78d9-5911-aac8-6bb5f06e8b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee847d84-ec8d-4ec3-8436-68d6f144e22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee847d84-ec8d-4ec3-8436-68d6f144e22f.jpg?1",
             "name": "Dauthi Marauder",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "1c1d5412-5ed0-5ffb-b4d5-5d44dc46aad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c340e779-c648-48fd-a159-174b46f2d1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c340e779-c648-48fd-a159-174b46f2d1b3.jpg?1",
             "name": "Dauthi Mercenary",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no1o\nB: Dauthi Mercenary gets +1/+0 until end of turn.",
             "colours": [
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "2b18ec64-d26b-56cb-bfc6-10f696b8b567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb990ee-f027-4c74-a67e-98ada6aa21e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb990ee-f027-4c74-a67e-98ada6aa21e4.jpg?1",
             "name": "Dauthi Mindripper",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSacrifice Dauthi Mindripper: Defending player chooses and discards three cards. Use this ability only if Dauthi Mindripper is attacking and unblocked.",
             "colours": [
@@ -4063,7 +4063,7 @@
         },
         {
             "id": "7328f413-46f2-5f6d-bb1b-9aa3c30a26af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652ccd79-aefd-4b45-b747-75190da0cfc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652ccd79-aefd-4b45-b747-75190da0cfc6.jpg?1",
             "name": "Dauthi Slayer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nEach turn, Dauthi Slayer attacks if able.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "898cdb98-40dd-5934-a7fe-f7d694f65618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72122e8f-97ab-495e-aade-5d736c432873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72122e8f-97ab-495e-aade-5d736c432873.jpg?1",
             "name": "Death Pits of Rath",
             "text": "Whenever any creature is dealt damage, destroy it. That creature cannot be regenerated this turn.",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "d4c7a523-fa21-58dc-8837-b456d77a73f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2ee-1e2d-4ab2-8b2c-717c794b09b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2ee-1e2d-4ab2-8b2c-717c794b09b2.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "f94632af-8349-5e2e-a8fc-a67d46a6e558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06254b6c-eb22-4ec9-9420-74e9ee15e072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06254b6c-eb22-4ec9-9420-74e9ee15e072.jpg?1",
             "name": "Disturbed Burial",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nReturn target creature card from your graveyard to your hand.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "26a56253-cc4a-5ca3-852c-dda682952137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08586d4-8163-454c-b8d8-c5034c4aee6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08586d4-8163-454c-b8d8-c5034c4aee6c.jpg?1",
             "name": "Dread of Night",
             "text": "All white creatures get -1/-1.",
             "colours": [
@@ -4221,7 +4221,7 @@
         },
         {
             "id": "e6625084-3005-5e0a-a14f-dd6d786a5e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e4203a-ff11-4075-a03a-11448779b413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e4203a-ff11-4075-a03a-11448779b413.jpg?1",
             "name": "Dregs of Sorrow",
             "text": "Destroy X target nonblack creatures. Draw X cards.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "55f4075a-5ca8-5b5e-b3a0-30afbf8e92b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9474231-34c5-4563-8a61-fd1bc2693f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9474231-34c5-4563-8a61-fd1bc2693f86.jpg?1",
             "name": "Endless Scream",
             "text": "Enchanted creature gets +X/+0.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "c3780723-4970-5832-b0d0-bf45f4d717bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71705205-0165-4774-8209-90ce800b9450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71705205-0165-4774-8209-90ce800b9450.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchanted creature gets -2/-2.",
             "colours": [
@@ -4318,7 +4318,7 @@
         },
         {
             "id": "5977cf32-9c29-51a9-b427-cd01a1b3d09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d53f46f-b069-4b34-af4b-98143328c078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d53f46f-b069-4b34-af4b-98143328c078.jpg?1",
             "name": "Evincar's Justice",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nEvincar's Justice deals 2 damage to each creature and player.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "94a73106-24df-5bf1-af34-118d5058e067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a233a244-7f84-4525-b0ce-e10db0a95385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a233a244-7f84-4525-b0ce-e10db0a95385.jpg?1",
             "name": "Extinction",
             "text": "Destroy all creatures of any creature type of your choice.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "38689d27-5a85-50e6-a427-dcbc74732213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a790769-e76e-49e9-9d6d-05ce8e858243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a790769-e76e-49e9-9d6d-05ce8e858243.jpg?1",
             "name": "Fevered Convulsions",
             "text": "o2o\nBo\nB: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "a7dcc664-c4a4-58af-8e66-80c482a5a111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f3328-c65d-49eb-a1bb-ca40e9c05627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f3328-c65d-49eb-a1bb-ca40e9c05627.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4444,7 +4444,7 @@
         },
         {
             "id": "7c336716-90b7-51f4-abdc-3f33097020c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6ed64-9f5c-4233-85a9-028b8e5949c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6ed64-9f5c-4233-85a9-028b8e5949c3.jpg?1",
             "name": "Imps' Taunt",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature attacks this turn if able.",
             "colours": [
@@ -4475,7 +4475,7 @@
         },
         {
             "id": "2d8243a4-9dff-51c3-8d5b-7662b83bbc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95d3a-bb19-474d-9939-8817038fe9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95d3a-bb19-474d-9939-8817038fe9fc.jpg?1",
             "name": "Kezzerdrix",
             "text": "First strike\nDuring your upkeep, if your opponents control no creatures, Kezzerdrix deals 4 damage to you.",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "d3dbd08d-af5f-508c-812c-f8639fa5d694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aba09c4-9259-4743-9e4a-a63505f1efe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aba09c4-9259-4743-9e4a-a63505f1efe6.jpg?1",
             "name": "Knight of Dusk",
             "text": "o\nBo\nB: Destroy target creature blocking Knight of Dusk.",
             "colours": [
@@ -4543,7 +4543,7 @@
         },
         {
             "id": "88d6b320-1a79-535b-9925-b89de9562275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bffefb-23c0-4d03-b716-b1a7eff39a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bffefb-23c0-4d03-b716-b1a7eff39a05.jpg?1",
             "name": "Leeching Licid",
             "text": "o\nB, oc\nT: Leeching Licid loses this ability and becomes a creature enchantment that reads \"During the upkeep of enchanted creature's controller, Leeching Licid deals 1 damage to that player\" instead of a creature. Move Leeching Licid onto target creature. You may pay o\nB to end this effect.",
             "colours": [
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "f9d34eca-e79f-540c-b995-ca0c0b3b4c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c820476-fbda-4073-baf6-51e71f45ed58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c820476-fbda-4073-baf6-51e71f45ed58.jpg?1",
             "name": "Living Death",
             "text": "Set aside all creature cards in all graveyards. Then, put each creature that is in play into its owner's graveyard. Then, put each creature card set aside in this way into play under its owner's control.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "71bba96d-0a2d-5cdb-a04b-0ec70a4cb070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda08eb5-c75c-4c21-bfd1-1f04a3575241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda08eb5-c75c-4c21-bfd1-1f04a3575241.jpg?1",
             "name": "Maddening Imp",
             "text": "Flying\noc\nT: All non-Wall creatures target opponent controls attack this turn if able. At end of turn, destroy each of those creatures that did not attack. Use this ability only during target opponent's turn and only before combat.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "0c84a12b-640f-507b-b49e-13bad4230f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b759-f53d-4977-8d97-a93762622e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b759-f53d-4977-8d97-a93762622e75.jpg?1",
             "name": "Marsh Lurker",
             "text": "Sacrifice a swamp: Marsh Lurker cannot be blocked this turn except by artifact creatures and black creatures.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "69e81102-e150-52c0-ad65-f7bcc0037bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa966fbb-140d-4057-a4fc-998ebe07c307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa966fbb-140d-4057-a4fc-998ebe07c307.jpg?1",
             "name": "Mindwhip Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: Target player discards a card at random. Play this ability as a sorcery.\"",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "0f3336be-30cd-5405-bd19-328a66ca9c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f120fc-c681-47b6-827e-1cc7ead47a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f120fc-c681-47b6-827e-1cc7ead47a0f.jpg?1",
             "name": "Minion of the Wastes",
             "text": "Trample\nWhen you play Minion of the Wastes, pay any amount of life.\nMinion of the Wastes has power and toughness each equal to that amount.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "8c50b2ef-0ebd-52dd-bea1-6363e4b3287b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47ace1d-73de-44aa-a3fe-2e2a21ebec79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47ace1d-73de-44aa-a3fe-2e2a21ebec79.jpg?1",
             "name": "Perish",
             "text": "Destroy all green creatures. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "07bd8c3e-a2ac-584c-897c-a7dc273f8c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7acfe-b5b2-426f-a5a1-1ff8ef7ebf72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7acfe-b5b2-426f-a5a1-1ff8ef7ebf72.jpg?1",
             "name": "Pit Imp",
             "text": "Flying\no\nB: Pit Imp gets +1/+0 until end of turn. You cannot spend more than o\nBo\nB in this way each turn.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "d6d167eb-eef8-5e90-9300-2a1820520f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad93919-273f-4a26-8ebd-13503dd6b220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad93919-273f-4a26-8ebd-13503dd6b220.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy target land.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "dbb98845-d9e8-5a86-ac24-e512949407c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb8d3a2-ed96-4490-9432-401da19ad3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb8d3a2-ed96-4490-9432-401da19ad3c5.jpg?1",
             "name": "Rats of Rath",
             "text": "o\nB: Destroy target artifact, creature, or land you control.",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "7e1e1ecc-fb74-5617-80e9-d82b0f959c59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1ef31c-8ca5-444c-8f39-e1d1827318f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1ef31c-8ca5-444c-8f39-e1d1827318f5.jpg?1",
             "name": "Reanimate",
             "text": "Put target creature card from any graveyard into play under your control. Lose life equal to that creature's total casting cost.",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "b429c716-f2b7-5b28-90f1-7d3c2c30d560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9141daea-1f4f-4227-b7d7-20753e3cb4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9141daea-1f4f-4227-b7d7-20753e3cb4d4.jpg?1",
             "name": "Reckless Spite",
             "text": "Destroy two target nonblack creatures. Lose 5 life.",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "37d0c1c2-9bcb-5180-8b47-2e88cdbb2653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e1959c-b87b-4e17-a0d2-0489ea79220b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e1959c-b87b-4e17-a0d2-0489ea79220b.jpg?1",
             "name": "Sadistic Glee",
             "text": "Whenever any creature is put into any graveyard from play, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -4962,7 +4962,7 @@
         },
         {
             "id": "c3822d63-2c83-59b4-b817-8b96cd3d1999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5730f5-a44c-4f75-a26f-90815cfcd31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5730f5-a44c-4f75-a26f-90815cfcd31e.jpg?1",
             "name": "Sarcomancy",
             "text": "When Sarcomancy comes into play, put a Zombie token into play. Treat this token as a 2/2 black creature.\nDuring your upkeep, if there are no Zombies in play, Sarcomancy deals 1 damage to you.",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "dc8ed4e6-e173-5d25-b20b-5dc42b1cf300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c02902-4e3a-445e-9dd9-116806ddc966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c02902-4e3a-445e-9dd9-116806ddc966.jpg?1",
             "name": "Screeching Harpy",
             "text": "Flying\no1o\nB: Regenerate Screeching Harpy.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "48ed7a17-a040-58a5-9eea-5a7d6ab0d934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691afabb-f266-45fd-b5a3-577be4f10f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691afabb-f266-45fd-b5a3-577be4f10f86.jpg?1",
             "name": "Servant of Volrath",
             "text": "If Servant of Volrath leaves play, sacrifice a creature.",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "e66bc9ba-ed48-5183-912b-ee4f94ec9b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed2c97b-f003-436c-9faa-5518aba42fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed2c97b-f003-436c-9faa-5518aba42fc1.jpg?1",
             "name": "Skyshroud Vampire",
             "text": "Flying\nChoose and discard a creature card: Skyshroud Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "7ada7491-6a85-5cd4-ac91-f6d861079d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d2d0ff-e44e-427a-9d68-3ed2d51b1b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d2d0ff-e44e-427a-9d68-3ed2d51b1b86.jpg?1",
             "name": "Souldrinker",
             "text": "Pay 3 life: Put a +1/+1 counter on Souldrinker.",
             "colours": [
@@ -5126,7 +5126,7 @@
         },
         {
             "id": "4068fa91-a525-55bc-8228-f9a451a6b14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a073b0c-2309-4070-a18e-0937ec8d4d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a073b0c-2309-4070-a18e-0937ec8d4d1c.jpg?1",
             "name": "Spinal Graft",
             "text": "Enchanted creature gets +3/+3.\nIf enchanted creature is the target of a spell or ability, destroy that creature. The creature cannot be regenerated this turn.",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "629883c3-78c3-5c25-9e14-fd99460ca845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91a26b2-03f8-43f0-a3a4-ff6c5a3690c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91a26b2-03f8-43f0-a3a4-ff6c5a3690c4.jpg?1",
             "name": "Aftershock",
             "text": "Destroy target artifact, creature, or land. Aftershock deals 3 damage to you.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "5daeb4be-e577-5c7d-ad48-222824b7772d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e315c1c2-436e-48ff-9214-938697178393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e315c1c2-436e-48ff-9214-938697178393.jpg?1",
             "name": "Ancient Runes",
             "text": "During each player's upkeep, Ancient Runes deals 1 damage to that player for each artifact he or she controls.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "747eb3b0-104f-5c01-9eed-9e69eb949f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff23780-d183-4cca-ad0c-448ef325bf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff23780-d183-4cca-ad0c-448ef325bf36.jpg?1",
             "name": "Apocalypse",
             "text": "Remove all permanents from the game. Discard your hand.",
             "colours": [
@@ -5252,7 +5252,7 @@
         },
         {
             "id": "662c141a-09c9-53bd-80cd-028a4313d4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bddea7-daa7-4bdb-9b91-f7fcbc0d7a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bddea7-daa7-4bdb-9b91-f7fcbc0d7a57.jpg?1",
             "name": "Barbed Sliver",
             "text": "Each Sliver gains \"o2: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "277e2e45-0799-5f66-9883-aca07377db82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f39d83-e1ea-45c9-8181-2a2b6e5148da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f39d83-e1ea-45c9-8181-2a2b6e5148da.jpg?1",
             "name": "Blood Frenzy",
             "text": "Target attacking or blocking creature gets +4/+0 until end of turn. At end of turn, destroy that creature.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "8fc1cd83-a76a-54b9-85c6-eb60d30c5ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa1c529-44e5-41b6-9704-ae2319f31f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa1c529-44e5-41b6-9704-ae2319f31f13.jpg?1",
             "name": "Boil",
             "text": "Destroy all islands.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "33d2b7ef-96f1-5787-8fcc-dea928257721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg?1",
             "name": "Canyon Drake",
             "text": "Flying\no1, Discard a card at random: Canyon Drake gets +2/+0 until end of turn.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "23519797-725b-5efa-bc84-93728e916fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0169e52b-7909-4a8f-8ca2-62f030f9a85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0169e52b-7909-4a8f-8ca2-62f030f9a85a.jpg?1",
             "name": "Canyon Wildcat",
             "text": "Mountainwalk (If defending player controls any mountains, this creature is unblockable.)",
             "colours": [
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "0108d635-1c56-57d8-877b-b8f040ce59cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9881a4-3078-4fe0-be09-54ddad1d18a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9881a4-3078-4fe0-be09-54ddad1d18a0.jpg?1",
             "name": "Chaotic Goo",
             "text": "Chaotic Goo comes into play with three +1/+1 counters on it.\nDuring your upkeep, you may flip a coin. If you win the flip, add a +1/+1 counter to Chaotic Goo. Otherwise, remove a +1/+1 counter from it.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "6bc8b1cd-a03e-5216-822e-096a740ad54e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c82741-2869-41f9-82f4-6ed88756e2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c82741-2869-41f9-82f4-6ed88756e2fd.jpg?1",
             "name": "Crown of Flames",
             "text": "o\nR: Enchanted creature gets +1/+0 until end of turn.\no\nR: Return Crown of Flames to owner's hand.",
             "colours": [
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "f739fbb6-cb73-5fe0-acde-a4a29fd7607c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d212c5-1642-456f-829f-57f68a2116b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d212c5-1642-456f-829f-57f68a2116b6.jpg?1",
             "name": "Deadshot",
             "text": "Tap target creature. That creature deals damage equal to its power to another target creature.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "748ba962-678a-5019-91a4-bc6b6a4353b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7bff44-36e1-4855-aa2d-5c7bd6bf6f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7bff44-36e1-4855-aa2d-5c7bd6bf6f10.jpg?1",
             "name": "Enraging Licid",
             "text": "o\nR, oc\nT: Enraging Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature is unaffected by summoning sickness\" instead of a creature. Move Enraging Licid onto target creature. You may pay o\nR to end this effect.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "4cde2e39-6836-524c-8d50-46acafa4eb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a312f0cf-225a-4f3d-b9a7-c47dd03b25c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a312f0cf-225a-4f3d-b9a7-c47dd03b25c3.jpg?1",
             "name": "Firefly",
             "text": "Flying\no\nR: Firefly gets +1/+0 until end of turn.",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "d5a6a940-cc5b-5e98-a917-7c6b4695d727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de253d94-9968-47da-bb7a-9c8ebf50f4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de253d94-9968-47da-bb7a-9c8ebf50f4e0.jpg?1",
             "name": "Fireslinger",
             "text": "oc\nT: Fireslinger deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "efe81109-ac4a-5ebc-a945-ff07ae4d90fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8240a-d882-4f60-8960-1856284e04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8240a-d882-4f60-8960-1856284e04a0.jpg?1",
             "name": "Flowstone Giant",
             "text": "o\nR: Flowstone Giant gets +2/-2 until end of turn.",
             "colours": [
@@ -5643,7 +5643,7 @@
         },
         {
             "id": "28bf920e-5215-594a-9db1-7e0a04f48f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b6749-42a6-498b-8908-b28d1749dea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b6749-42a6-498b-8908-b28d1749dea6.jpg?1",
             "name": "Flowstone Salamander",
             "text": "o\nR: Flowstone Salamander deals 1 damage to target creature blocking it.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "4db9a84b-d96a-5f3f-af2b-78dfcbdbb566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7949c7-ab80-46a1-9cf7-d8e8c004df6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7949c7-ab80-46a1-9cf7-d8e8c004df6e.jpg?1",
             "name": "Flowstone Wyvern",
             "text": "Flying\no\nR: Flowstone Wyvern gets +2/-2 until end of turn.",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "9f65716e-3c89-53f4-9b00-3ab60cb70500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606abea6-109a-4dd5-99cf-0d5ce492d7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606abea6-109a-4dd5-99cf-0d5ce492d7f0.jpg?1",
             "name": "Furnace of Rath",
             "text": "Double all damage assigned to any creature or player.",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "8b29acd6-cab9-58f4-a6ee-5f69f601aa1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb43289-35dc-4983-9c49-22b1b3a7d85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb43289-35dc-4983-9c49-22b1b3a7d85a.jpg?1",
             "name": "Giant Strength",
             "text": "Enchanted creature gets +2/+2.",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "928e2a80-0519-5778-9e30-6cc95340dd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179e954f-1d90-4ef4-b800-25845cc338e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179e954f-1d90-4ef4-b800-25845cc338e2.jpg?1",
             "name": "Goblin Bombardment",
             "text": "Sacrifice a creature: Goblin Bombardment deals 1 damage to target creature or player.",
             "colours": [
@@ -5804,7 +5804,7 @@
         },
         {
             "id": "254651b1-b177-5ddf-a4c2-2edc318b8f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cb86a-db01-4d9a-99e9-bb50ce23507f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cb86a-db01-4d9a-99e9-bb50ce23507f.jpg?1",
             "name": "Hand to Hand",
             "text": "Instants and abilities requiring an activation cost cannot be played during combat.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "dd84f384-bc5b-5b43-9117-e30dccd4985b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b032a1-6e43-4e22-9efa-43cfbf211e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b032a1-6e43-4e22-9efa-43cfbf211e1c.jpg?1",
             "name": "Havoc",
             "text": "Whenever target opponent successfully casts a white spell, he or she loses 2 life.",
             "colours": [
@@ -5866,7 +5866,7 @@
         },
         {
             "id": "68e65ef3-55a8-5f26-8ce9-7a78f4261ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a83ab6-0d15-49e4-90e3-b3a2a095c632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a83ab6-0d15-49e4-90e3-b3a2a095c632.jpg?1",
             "name": "Heart Sliver",
             "text": "All Slivers are unaffected by summoning sickness.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "af74b4a7-c02a-5f9a-8a29-0b6b38d7d5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707ab74-9aec-4d30-86e0-ffa5f72d5b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707ab74-9aec-4d30-86e0-ffa5f72d5b4f.jpg?1",
             "name": "Jackal Pup",
             "text": "For each 1 damage dealt to Jackal Pup, it deals 1 damage to you.",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "c166b069-6173-57bd-8a4d-6d309f1a43d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930745eb-b038-4b55-97f3-bf8d99b54d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930745eb-b038-4b55-97f3-bf8d99b54d32.jpg?1",
             "name": "Kindle",
             "text": "Kindle deals to target creature or player an amount of damage equal to 2 plus the number of Kindle cards in all graveyards.",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "b0f90832-3d66-5bd5-ade3-7fc8dd3a3913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fec3f9-d399-48e6-84b6-c8410c24c382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fec3f9-d399-48e6-84b6-c8410c24c382.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "a514ffe4-905c-574a-a215-c67b00424e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f6d2a4-cc97-43f3-a8b2-f96262c27371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f6d2a4-cc97-43f3-a8b2-f96262c27371.jpg?1",
             "name": "Lightning Elemental",
             "text": "Lightning Elemental is unaffected by summoning sickness.",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "5c2c7c64-a26a-5125-97b2-1c0605894547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7398dec7-5e60-43c0-81a0-ab49beb37077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7398dec7-5e60-43c0-81a0-ab49beb37077.jpg?1",
             "name": "Lowland Giant",
             "text": "",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "7989968a-a8ac-521f-9ed7-64837670209b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48115601-fa00-4d33-8205-faac02997bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48115601-fa00-4d33-8205-faac02997bb4.jpg?1",
             "name": "Magmasaur",
             "text": "Magmasaur comes into play with five +1/+1 counters on it.\nDuring your upkeep, remove a +1/+1 counter from Magmasaur, or sacrifice Magmasaur and it deals 1 damage for each +1/+1 counter on it to each creature without flying and each player.",
             "colours": [
@@ -6094,7 +6094,7 @@
         },
         {
             "id": "8899a60c-b4cb-529c-8854-6dee53fd21b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73719325-b091-4464-b0b0-77dfbb19562a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73719325-b091-4464-b0b0-77dfbb19562a.jpg?1",
             "name": "Mogg Conscripts",
             "text": "Mogg Conscripts cannot attack unless you have successfully cast a creature spell this turn.",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "6f86cc82-9f50-5665-a80e-31fbab1da20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2ecfd4-c874-4468-8601-87aa110d5a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2ecfd4-c874-4468-8601-87aa110d5a00.jpg?1",
             "name": "Mogg Fanatic",
             "text": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
             "colours": [
@@ -6160,7 +6160,7 @@
         },
         {
             "id": "6dd26fe3-0933-5773-ab85-7bff97115df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e9cc0a-c210-4525-8c7f-9c6306cc21b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e9cc0a-c210-4525-8c7f-9c6306cc21b0.jpg?1",
             "name": "Mogg Raider",
             "text": "Sacrifice a Goblin: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -6193,7 +6193,7 @@
         },
         {
             "id": "12e22e5e-d947-5039-b519-55138cf99ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b267071-42a6-4e25-9c92-5bca32f8d9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b267071-42a6-4e25-9c92-5bca32f8d9af.jpg?1",
             "name": "Mogg Squad",
             "text": "Mogg Squad gets -1/-1 for each other creature in play.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "df8f80d0-657f-5f59-851f-94325ff9f789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c317ee7-ed92-4e3e-92bb-502099caccf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c317ee7-ed92-4e3e-92bb-502099caccf8.jpg?1",
             "name": "No Quarter",
             "text": "Whenever any creature blocks or is blocked by a creature with lesser power, destroy the creature with the lesser power.",
             "colours": [
@@ -6257,7 +6257,7 @@
         },
         {
             "id": "ad300b23-7294-5fb9-8618-eb75885fd716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0026c0-8f61-4485-8909-6a44c2ca9169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0026c0-8f61-4485-8909-6a44c2ca9169.jpg?1",
             "name": "Opportunist",
             "text": "oc\nT: Opportunist deals 1 damage to target creature that was damaged this turn.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "41bc96bf-5c0d-56a8-ac78-3c69d381a824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61adc314-cfb2-4fdd-925c-cc1dc4692992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61adc314-cfb2-4fdd-925c-cc1dc4692992.jpg?1",
             "name": "Pallimud",
             "text": "Pallimud has power equal to the number of tapped lands target opponent controls.",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "3af612d1-d9a9-55b4-8457-8e7e2891e58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df61bff-a459-4ddb-a084-f47859a43795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df61bff-a459-4ddb-a084-f47859a43795.jpg?1",
             "name": "Rathi Dragon",
             "text": "Flying\nWhen Rathi Dragon comes into play, sacrifice two mountains or sacrifice Rathi Dragon.",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "181e733f-0bdc-5a2d-8aae-45699d940c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69ea676-60ba-4807-bc9b-976bf5666485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69ea676-60ba-4807-bc9b-976bf5666485.jpg?1",
             "name": "Renegade Warlord",
             "text": "First strike\nIf Renegade Warlord attacks, each other attacking creature gets +1/+0 until end of turn.",
             "colours": [
@@ -6391,7 +6391,7 @@
         },
         {
             "id": "39ca7e65-c60c-5726-83fb-e66dc63a00a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb07402-d526-4938-89a3-9174d5b5a4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb07402-d526-4938-89a3-9174d5b5a4de.jpg?1",
             "name": "Rolling Thunder",
             "text": "Rolling Thunder deals X damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "bad8c50a-af9b-50b0-a25b-d9886d8fcf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa61413-3c6a-4895-b8e7-2723e273a952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa61413-3c6a-4895-b8e7-2723e273a952.jpg?1",
             "name": "Sandstone Warrior",
             "text": "First strike\no\nR: Sandstone Warrior gets +1/+0 until end of turn.",
             "colours": [
@@ -6457,7 +6457,7 @@
         },
         {
             "id": "92834498-b035-53f0-a72d-539af9df2f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a97817-d1fd-4ba4-9ced-c2702b081523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a97817-d1fd-4ba4-9ced-c2702b081523.jpg?1",
             "name": "Scorched Earth",
             "text": "Choose and discard X land cards: Destroy X target lands.",
             "colours": [
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "ad27bc6c-a59b-5565-8b45-57642eec6de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9091667-d5a8-4978-9023-032ff65f9642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9091667-d5a8-4978-9023-032ff65f9642.jpg?1",
             "name": "Searing Touch",
             "text": "Buyback o4 (You may pay an additional o4 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nSearing Touch deals 1 damage to target creature or player.",
             "colours": [
@@ -6519,7 +6519,7 @@
         },
         {
             "id": "3a7285b9-85cd-5f29-82e5-8d2b07fd2b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367c4ad6-973d-47ba-9431-312f9f2996f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367c4ad6-973d-47ba-9431-312f9f2996f6.jpg?1",
             "name": "Shadowstorm",
             "text": "Shadowstorm deals 2 damage to each creature with shadow.",
             "colours": [
@@ -6550,7 +6550,7 @@
         },
         {
             "id": "3edf98f6-b158-536b-9ec6-54b762acd562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa05258-2ce3-4604-938c-e8c3fb8cf142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa05258-2ce3-4604-938c-e8c3fb8cf142.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -6581,7 +6581,7 @@
         },
         {
             "id": "e8616716-2bcb-5abc-bdaa-4bb4a5829ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90954848-af7e-47b3-82e7-9fedde6ad606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90954848-af7e-47b3-82e7-9fedde6ad606.jpg?1",
             "name": "Shocker",
             "text": "If Shocker damages any player, that player discards his or her hand, then draws a new hand of as many cards as he or she had before.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "51f802cc-757f-50d9-8768-0ac6f4c5db70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de398b32-10a3-45aa-9886-76806e1602c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de398b32-10a3-45aa-9886-76806e1602c6.jpg?1",
             "name": "Starke of Rath",
             "text": "oc\nT: Destroy target artifact or creature. That permanent's controller gains control of Starke of Rath permanently.",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "b3befb02-6b2c-5b30-abe7-4faef0181702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92548d9-cba6-495f-bef1-73e4519fe336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92548d9-cba6-495f-bef1-73e4519fe336.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6681,7 +6681,7 @@
         },
         {
             "id": "6d008a04-48f2-5a35-9838-049ad8452294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09c0da6-37a7-42ba-b264-18898ee372f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09c0da6-37a7-42ba-b264-18898ee372f0.jpg?1",
             "name": "Stun",
             "text": "Target creature cannot block this turn.\nDraw a card.",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "711a721c-01aa-5225-a75f-8759f94998a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fd516-4b0d-407f-b0c2-d656ad160b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fd516-4b0d-407f-b0c2-d656ad160b8d.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals 1 damage to target player for each card in his or her hand.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "18412687-2b7a-5367-a764-cd27f661674e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36658368-88c8-4c55-8147-f6e581f6af36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36658368-88c8-4c55-8147-f6e581f6af36.jpg?1",
             "name": "Tahngarth's Rage",
             "text": "If enchanted creature is attacking, it gets +3/+0. Otherwise, it gets -2/-1.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "3c65cd4b-2e6d-563f-aa1a-697781ea7119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71696093-0867-4889-8fb4-56fa143f9b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71696093-0867-4889-8fb4-56fa143f9b27.jpg?1",
             "name": "Tooth and Claw",
             "text": "Sacrifice two creatures: Put a Carnivore token into play. Treat this token as a 3/1 red creature.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "e9177e5f-2a18-5b3a-935a-c00d71eaa7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6a469e-3d67-4edf-a735-03dcd626f858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6a469e-3d67-4edf-a735-03dcd626f858.jpg?1",
             "name": "Wall of Diffusion",
             "text": "(Walls cannot attack.)\nWall of Diffusion can block creatures with shadow.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "d6d1b26e-dee0-5437-9dff-00d1bb62e902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a1b213-cba0-4eca-b058-93f4fde717c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a1b213-cba0-4eca-b058-93f4fde717c8.jpg?1",
             "name": "Wild Wurm",
             "text": "When Wild Wurm comes into play, flip a coin. If you lose the flip, return Wild Wurm to owner's hand.",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "89cad384-b845-5268-bdd7-df51190cfbb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268403bc-733d-446e-a7c1-abc957c42bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268403bc-733d-446e-a7c1-abc957c42bc2.jpg?1",
             "name": "Aluren",
             "text": "Any player may play a creature card with total casting cost 3 or less whenever he or she could play an instant and without paying its casting cost.",
             "colours": [
@@ -6904,7 +6904,7 @@
         },
         {
             "id": "73491e40-bbee-5edc-aa98-370f8475ef1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff287-6b53-4e6d-9da2-d80d05bb8c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff287-6b53-4e6d-9da2-d80d05bb8c51.jpg?1",
             "name": "Apes of Rath",
             "text": "If Apes of Rath attacks, it does not untap during your next untap phase.",
             "colours": [
@@ -6937,7 +6937,7 @@
         },
         {
             "id": "d26a5d41-2993-5e5c-8c2d-5b98a95fabd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cfcca5-070b-4946-b17b-0c94b1e47fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cfcca5-070b-4946-b17b-0c94b1e47fcd.jpg?1",
             "name": "Bayou Dragonfly",
             "text": "Flying; swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "4ac73b29-7ce7-5f0d-ab83-148a07279174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43f5349-a3f8-492d-a835-24a9f948741c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43f5349-a3f8-492d-a835-24a9f948741c.jpg?1",
             "name": "Broken Fall",
             "text": "Return Broken Fall to owner's hand: Regenerate target creature.",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "c408493e-2580-530b-a72c-1403cc31f03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc114b0-2e95-4143-a4b6-6537813946e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc114b0-2e95-4143-a4b6-6537813946e7.jpg?1",
             "name": "Canopy Spider",
             "text": "Canopy Spider can block creatures with flying.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "1932fa29-3c32-5870-9534-30fdede715f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f89e5-9ce2-4713-aca9-6581005f6ca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f89e5-9ce2-4713-aca9-6581005f6ca2.jpg?1",
             "name": "Charging Rhino",
             "text": "Charging Rhino cannot be blocked by more than one creature.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "01cfeb86-c276-5644-8d42-e93065baaee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f85205-3c4f-4411-b09c-d1271be56dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f85205-3c4f-4411-b09c-d1271be56dde.jpg?1",
             "name": "Choke",
             "text": "Islands do not untap during their controllers' untap phases.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "f6ff50c6-d2dc-53f1-aacf-69701672d048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e4b36-57c1-493d-ab79-52075990b2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e4b36-57c1-493d-ab79-52075990b2d5.jpg?1",
             "name": "Crazed Armodon",
             "text": "o\nG: Crazed Armodon gets +3/+0 and gains trample until end of turn. At end of turn, destroy Crazed Armodon. Use this ability only once each turn.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "51cd21e5-3486-5fe4-acd3-0a57d1de4995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2df7d-5d72-4a32-a453-6d8611f0d63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2df7d-5d72-4a32-a453-6d8611f0d63c.jpg?1",
             "name": "Dirtcowl Wurm",
             "text": "Whenever any opponent plays a land, put a +1/+1 counter on Dirtcowl Wurm.",
             "colours": [
@@ -7164,7 +7164,7 @@
         },
         {
             "id": "9edfe8f4-204e-5b6e-9a74-ac2f8b0d6a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda7531-82a1-4f49-8858-601ddbc6e2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda7531-82a1-4f49-8858-601ddbc6e2bc.jpg?1",
             "name": "Earthcraft",
             "text": "Tap an untapped creature you control: Untap target basic land.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "f5638076-4574-583d-a9ba-01b7b3647aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8531643-5657-44b6-89d1-9cdf67ed09c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8531643-5657-44b6-89d1-9cdf67ed09c4.jpg?1",
             "name": "Eladamri's Vineyard",
             "text": "At the beginning of each player's main phase, add o\nGo\nG to that player's mana pool.",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "88336bb5-51a0-5252-a01a-d6aadad90a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1689f3-9dfa-4525-90b3-7af15f7eb720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1689f3-9dfa-4525-90b3-7af15f7eb720.jpg?1",
             "name": "Eladamri, Lord of Leaves",
             "text": "All Elves gain forestwalk. (If defending player controls any forests, those creatures are unblockable.)\nElves cannot be the target of spells or abilities.",
             "colours": [
@@ -7262,7 +7262,7 @@
         },
         {
             "id": "d0076174-521c-560f-b29d-32746dbfa68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29138c1e-11cb-488f-8e04-f5488e08a81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29138c1e-11cb-488f-8e04-f5488e08a81e.jpg?1",
             "name": "Elven Warhounds",
             "text": "If Elven Warhounds is blocked by any creature, put that creature on top of owner's library.",
             "colours": [
@@ -7295,7 +7295,7 @@
         },
         {
             "id": "f8d07edf-a03a-5624-bd89-bc198f931127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99c10b5-b93b-40c3-936c-d1b81b49c5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99c10b5-b93b-40c3-936c-d1b81b49c5a4.jpg?1",
             "name": "Elvish Fury",
             "text": "Buyback o4 (You may pay an additional o4 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -7326,7 +7326,7 @@
         },
         {
             "id": "117d438c-c8b8-56fe-860b-c0b8345f7ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d246ac-1ca5-4c55-856c-4a83a4d638ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d246ac-1ca5-4c55-856c-4a83a4d638ab.jpg?1",
             "name": "Flailing Drake",
             "text": "Flying\nIf Flailing Drake blocks or is blocked by any creature, that creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7359,7 +7359,7 @@
         },
         {
             "id": "05ecfa54-c6eb-52d9-89d5-cc288d5ee59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941e799-a254-423e-90bb-091dbe56ca6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941e799-a254-423e-90bb-091dbe56ca6a.jpg?1",
             "name": "Frog Tongue",
             "text": "When Frog Tongue comes into play, draw a card.\nEnchanted creature can block creatures with flying.",
             "colours": [
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "e0d8a90e-99cd-532b-88a7-c96a0d2bcba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe165cd-8ef7-408e-ae56-3c6a0cc4e409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe165cd-8ef7-408e-ae56-3c6a0cc4e409.jpg?1",
             "name": "Fugitive Druid",
             "text": "Whenever any player successfully casts an enchantment spell that targets Fugitive Druid, draw a card.",
             "colours": [
@@ -7426,7 +7426,7 @@
         },
         {
             "id": "166b286c-6c0f-5271-8d1c-d353474af37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c207142-4880-4935-9827-b91bc7d9d643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c207142-4880-4935-9827-b91bc7d9d643.jpg?1",
             "name": "Harrow",
             "text": "Sacrifice a land: Search your library for up to two basic land cards and put them into play. Shuffle your library afterwards.",
             "colours": [
@@ -7457,7 +7457,7 @@
         },
         {
             "id": "47316b2d-61da-5138-b000-1919029706c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b9a001-2a1e-4fc4-9b84-c776f741a858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b9a001-2a1e-4fc4-9b84-c776f741a858.jpg?1",
             "name": "Heartwood Dryad",
             "text": "Heartwood Dryad can block creatures with shadow.",
             "colours": [
@@ -7490,7 +7490,7 @@
         },
         {
             "id": "775f42e6-05c0-555d-a7d2-bd4160637917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baacffe-76d1-4cfb-a047-d6d126bb8de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baacffe-76d1-4cfb-a047-d6d126bb8de0.jpg?1",
             "name": "Heartwood Giant",
             "text": "oc\nT, Sacrifice a forest: Heartwood Giant deals 2 damage to target player.",
             "colours": [
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "a5468020-84b5-5402-a935-0789c07ba79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de263f02-8e3e-4785-9c06-9adc168994f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de263f02-8e3e-4785-9c06-9adc168994f3.jpg?1",
             "name": "Heartwood Treefolk",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)",
             "colours": [
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "b0c0bcf4-4ee8-5a2c-aec1-7deb86e8f722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0175cec-e64c-45c6-9208-76127e76a7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0175cec-e64c-45c6-9208-76127e76a7cf.jpg?1",
             "name": "Horned Sliver",
             "text": "All Slivers gain trample.",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "ef9d49d9-2c16-5c4a-b3c9-379abc93507b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90442e8-9d22-4767-9e08-bd314169ea70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90442e8-9d22-4767-9e08-bd314169ea70.jpg?1",
             "name": "Krakilin",
             "text": "Krakilin comes into play with X +1/+1 counters on it.\no1o\nG: Regenerate Krakilin.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "b514e4e4-1272-575d-a238-829ec1c2b5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d51a3c-95c0-4810-b847-4b8afd12fd64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d51a3c-95c0-4810-b847-4b8afd12fd64.jpg?1",
             "name": "Mirri's Guile",
             "text": "During your upkeep, you may look at the top three cards of your library and put them back in any order.",
             "colours": [
@@ -7653,7 +7653,7 @@
         },
         {
             "id": "a6042fef-225f-53fe-ba96-949f80a07342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b84315-5287-4401-a4c8-34c192423270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b84315-5287-4401-a4c8-34c192423270.jpg?1",
             "name": "Mongrel Pack",
             "text": "If Mongrel Pack is put into any graveyard from play during combat, put four Hound tokens into play. Treat these tokens as 1/1 green creatures.",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "72b4c462-570e-5918-93b2-473cfac15d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602a1e1f-4195-48c0-8290-562e7e0db6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602a1e1f-4195-48c0-8290-562e7e0db6d8.jpg?1",
             "name": "Muscle Sliver",
             "text": "All Slivers get +1/+1.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "ec28b4da-08ad-5769-b153-fecdb47b9449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff5d12a-8634-468b-86ca-4ba0f7c013ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff5d12a-8634-468b-86ca-4ba0f7c013ca.jpg?1",
             "name": "Natural Spring",
             "text": "Target player gains 8 life.",
             "colours": [
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "aa81b531-f7ed-5a65-9780-c6ea9889d490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70386c5-053a-46c4-b26d-c6f92f536bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70386c5-053a-46c4-b26d-c6f92f536bed.jpg?1",
             "name": "Nature's Revolt",
             "text": "All lands are 2/2 creatures. (These creatures still count as lands.)",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "264345aa-f7e7-53e1-b6f5-aa3c8bb8a5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be80dd2d-f595-4d80-84ae-66d3d18e7399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be80dd2d-f595-4d80-84ae-66d3d18e7399.jpg?1",
             "name": "Needle Storm",
             "text": "Needle Storm deals 4 damage to each creature with flying.",
             "colours": [
@@ -7812,7 +7812,7 @@
         },
         {
             "id": "136eaefa-78b7-5dde-9f75-ec0a5715a01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf53069-44ac-49c5-83bf-9c3c1274e407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf53069-44ac-49c5-83bf-9c3c1274e407.jpg?1",
             "name": "Nurturing Licid",
             "text": "o\nG, oc\nT: Nurturing Licid loses this ability and becomes a creature enchantment that reads \"o\nG: Regenerate enchanted creature\" instead of a creature. Move Nurturing Licid onto target creature. You may pay o\nG to end this effect.",
             "colours": [
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "058d39de-fb6e-52e6-9c8a-0fd4590a6f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad7a961-d3a1-471a-8472-8407d1057de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad7a961-d3a1-471a-8472-8407d1057de0.jpg?1",
             "name": "Overrun",
             "text": "All creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "6b051b86-2e0f-58ae-8a05-84ad783237d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba68902-1e05-414a-8c3d-1f97da61d09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba68902-1e05-414a-8c3d-1f97da61d09d.jpg?1",
             "name": "Pincher Beetles",
             "text": "Pincher Beetles cannot be the target of spells or abilities.",
             "colours": [
@@ -7909,7 +7909,7 @@
         },
         {
             "id": "80dc87a8-f0d8-55ed-a9bc-393a0e47f021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffbf716-9c3a-45aa-8fdb-632128cc97e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffbf716-9c3a-45aa-8fdb-632128cc97e2.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put it into play, tapped. Shuffle your library afterwards.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "05925dd2-1ff8-5b59-934b-f3e4f5d8e727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21204f62-c253-4d88-a4cd-7c0f6f0513e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21204f62-c253-4d88-a4cd-7c0f6f0513e0.jpg?1",
             "name": "Reality Anchor",
             "text": "Target creature loses shadow until end of turn.\nDraw a card.",
             "colours": [
@@ -7971,7 +7971,7 @@
         },
         {
             "id": "549769f3-876d-58f3-a248-6fee896522cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229f8a3d-d1a5-46d7-9b1b-e165397e6579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229f8a3d-d1a5-46d7-9b1b-e165397e6579.jpg?1",
             "name": "Reap",
             "text": "Return any number of target cards from your graveyard to your hand. You cannot choose more cards than the number of black permanents target opponent controls.",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "86c71ae6-9d20-5379-bfd1-637c24ff82bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae984b86-ac6d-45e2-9c8d-0b7ac50021a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae984b86-ac6d-45e2-9c8d-0b7ac50021a1.jpg?1",
             "name": "Recycle",
             "text": "Skip your draw phase.\nWhenever you play a card, draw a card.\nDuring your discard phase, choose and discard all but two cards.",
             "colours": [
@@ -8033,7 +8033,7 @@
         },
         {
             "id": "f14f9839-cc20-59b9-b5a3-943f3b24ca22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a8d29-cc14-49c7-ae24-5847344583ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a8d29-cc14-49c7-ae24-5847344583ed.jpg?1",
             "name": "Respite",
             "text": "Creatures deal no combat damage this turn. Gain 1 life for each attacking creature.",
             "colours": [
@@ -8064,7 +8064,7 @@
         },
         {
             "id": "c7f52912-f1e7-52c4-9d6f-79930f0287cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a12b74-f191-4362-81ab-77590ae5e68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a12b74-f191-4362-81ab-77590ae5e68f.jpg?1",
             "name": "Root Maze",
             "text": "All artifacts and lands come into play tapped.",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "3ae93f02-3ad8-519a-8476-6e4e3df1296d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a686ed6-fc13-4882-b56c-667f556d9804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a686ed6-fc13-4882-b56c-667f556d9804.jpg?1",
             "name": "Rootbreaker Wurm",
             "text": "Trample",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "64ee24f6-4549-54b1-8f47-3c902694510f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce4d5d-63cb-47b6-94ce-2063977db9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce4d5d-63cb-47b6-94ce-2063977db9b4.jpg?1",
             "name": "Rootwalla",
             "text": "o1o\nG: Rootwalla gets +2/+2 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -8161,7 +8161,7 @@
         },
         {
             "id": "60208f44-3abb-554e-beab-ec1831cdd033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80f7fa7-e7c4-4fc4-99bf-8a8502965fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80f7fa7-e7c4-4fc4-99bf-8a8502965fc8.jpg?1",
             "name": "Scragnoth",
             "text": "Protection from blue\nWhile Scragnoth is being cast, it cannot be countered.",
             "colours": [
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "2827ecd0-3322-5320-925c-1cabc1527c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bb98ba-d599-4597-911c-2b472fa8817c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bb98ba-d599-4597-911c-2b472fa8817c.jpg?1",
             "name": "Seeker of Skybreak",
             "text": "oc\nT: Untap target creature.",
             "colours": [
@@ -8227,7 +8227,7 @@
         },
         {
             "id": "b86a6181-8016-5d46-9c9f-e75b1751110e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26877a52-dec3-433d-b7a5-767f6cdf2365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26877a52-dec3-433d-b7a5-767f6cdf2365.jpg?1",
             "name": "Skyshroud Elf",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.\no1: Add o\nW or o\nR to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "8a0c3a70-599b-562e-9518-1012ecdaceb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe01296-2b8b-4cdf-a041-a08bebea9c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe01296-2b8b-4cdf-a041-a08bebea9c29.jpg?1",
             "name": "Skyshroud Ranger",
             "text": "oc\nT: Choose a land card in your hand and put it into play. Play this ability as a sorcery.",
             "colours": [
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "b1a7a59d-00d9-56a8-9e8b-3eeff73b00d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c488d-79db-47d1-b7be-851f31732026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c488d-79db-47d1-b7be-851f31732026.jpg?1",
             "name": "Skyshroud Troll",
             "text": "o1o\nG: Regenerate Skyshroud Troll.",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "42c48186-33e6-5c29-97ab-859bd522a90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45a3d3-a114-496e-b575-504179a297cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45a3d3-a114-496e-b575-504179a297cc.jpg?1",
             "name": "Spike Drone",
             "text": "Spike Drone comes into play with one +1/+1 counter on it.\no2, Remove a +1/+1 counter from Spike Drone: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "fe441cd3-a63b-5537-844c-541fb87f9a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994bb02d-6fef-454b-b1b1-d3d1af8dcd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994bb02d-6fef-454b-b1b1-d3d1af8dcd1a.jpg?1",
             "name": "Storm Front",
             "text": "o\nGo\nG: Tap target creature with flying.",
             "colours": [
@@ -8396,7 +8396,7 @@
         },
         {
             "id": "2eb18c6c-bb66-55de-af52-66eb5fe2e6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2380ab8f-58d2-4e1c-a115-cd2615b5a871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2380ab8f-58d2-4e1c-a115-cd2615b5a871.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "3e0bdc2a-f694-5bd6-9946-6422b35556ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b8060-e755-4a96-9193-b76550d4a6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b8060-e755-4a96-9193-b76550d4a6ba.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -8460,7 +8460,7 @@
         },
         {
             "id": "19bbfbf8-0110-5c95-a186-e9a1cb07537b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f94fd1-6f85-41ad-9674-f05cc893324f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f94fd1-6f85-41ad-9674-f05cc893324f.jpg?1",
             "name": "Trumpeting Armodon",
             "text": "o1o\nG: Target creature blocks Trumpeting Armodon this turn if able.",
             "colours": [
@@ -8493,7 +8493,7 @@
         },
         {
             "id": "a2a9fab5-2d84-5c35-95bd-105015cf96ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bd094c-fcc1-4abf-ba3e-03a5b9b6d1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bd094c-fcc1-4abf-ba3e-03a5b9b6d1c2.jpg?1",
             "name": "Verdant Force",
             "text": "During each player's upkeep, put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -8526,7 +8526,7 @@
         },
         {
             "id": "515d195e-0379-5a0e-8d73-379906157bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79664d-3461-44e7-afe6-33ec54e312ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79664d-3461-44e7-afe6-33ec54e312ad.jpg?1",
             "name": "Verdigris",
             "text": "Destroy target artifact.",
             "colours": [
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "59e963bf-2e8a-5f15-a337-a15102bd2cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af28a5d-45dc-4e31-9009-5c0bd25a9032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af28a5d-45dc-4e31-9009-5c0bd25a9032.jpg?1",
             "name": "Winter's Grasp",
             "text": "Destroy target land.",
             "colours": [
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "8c85a01b-3e32-5ea6-a355-0d221ed11b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3560556c-f1d3-4d69-afe7-c2a5fa2a5c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3560556c-f1d3-4d69-afe7-c2a5fa2a5c3d.jpg?1",
             "name": "Dracoplasm",
             "text": "Flying\nWhen you play Dracoplasm, sacrifice any number of creatures.\nDracoplasm comes into play with power equal to the total power of the sacrificed creatures and toughness equal to the total toughness of those creatures.\no\nR: Dracoplasm gets +1/+0 until end of turn.",
             "colours": [
@@ -8623,7 +8623,7 @@
         },
         {
             "id": "ec5602cd-8764-5a91-93ba-b3b7d2c34f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7ba92d-d327-4b1c-be40-708c5abb27df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7ba92d-d327-4b1c-be40-708c5abb27df.jpg?1",
             "name": "Lobotomy",
             "text": "Look at target player's hand and choose any of those cards other than a basic land. Search that player's graveyard, hand, and library for all copies of the chosen card and remove them from the game. That player shuffles his or her library afterwards.",
             "colours": [
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "6ae48dd2-d08c-5e32-a918-2d43cbc61450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a89e82c-7206-4d74-95c6-ad3627e5a9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a89e82c-7206-4d74-95c6-ad3627e5a9ce.jpg?1",
             "name": "Ranger en-Vec",
             "text": "First strike\no\nG: Regenerate Ranger en-Vec.",
             "colours": [
@@ -8694,7 +8694,7 @@
         },
         {
             "id": "514624c1-e4bb-5fcd-894d-59c17c00a5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be7cfa-bf75-407d-b79f-2fec4b1aacf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be7cfa-bf75-407d-b79f-2fec4b1aacf5.jpg?1",
             "name": "Segmented Wurm",
             "text": "Whenever Segmented Wurm is the target of a spell or ability, put a -1/-1 counter on it.",
             "colours": [
@@ -8729,7 +8729,7 @@
         },
         {
             "id": "1082a564-ed2c-5319-bcf7-58a19b9d8ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1624f7-8275-46d3-ab7e-7b162e27593f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1624f7-8275-46d3-ab7e-7b162e27593f.jpg?1",
             "name": "Selenia, Dark Angel",
             "text": "Flying\nSelenia, Dark Angel counts as an Angel.\nPay 2 life: Return Selenia to owner's hand.",
             "colours": [
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "ee4d47a2-7678-5084-970e-25cf8b8e0fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8efbec-e8bf-4e34-bf13-b43916d2e9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8efbec-e8bf-4e34-bf13-b43916d2e9ff.jpg?1",
             "name": "Sky Spirit",
             "text": "Flying, first strike",
             "colours": [
@@ -8802,7 +8802,7 @@
         },
         {
             "id": "cf967b93-9b78-594d-8739-c7d46a2d116a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b683571-6ac5-4d65-99a6-981755ed4764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b683571-6ac5-4d65-99a6-981755ed4764.jpg?1",
             "name": "Soltari Guerrillas",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Guerrillas assigns combat damage to any opponent, you may redirect that damage to target creature.",
             "colours": [
@@ -8838,7 +8838,7 @@
         },
         {
             "id": "0e900f01-a8d8-5964-9564-80ffcafeffee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e6c04f-9d1a-497b-bc96-a0e48a1c1904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e6c04f-9d1a-497b-bc96-a0e48a1c1904.jpg?1",
             "name": "Spontaneous Combustion",
             "text": "Sacrifice a creature: Spontaneous Combustion deals 3 damage to each creature.",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "f3cd08af-7432-5777-8e25-426360213511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be535a4a-c00d-4c58-a663-a3419a54da51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be535a4a-c00d-4c58-a663-a3419a54da51.jpg?1",
             "name": "Vhati il-Dal",
             "text": "oc\nT: Target creature's power or toughness is 1 until end of turn.",
             "colours": [
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "e7b6a6da-ecff-5718-8fcc-f3f63ddca4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073ac1-be1b-49c0-98b4-bf8165e2f872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073ac1-be1b-49c0-98b4-bf8165e2f872.jpg?1",
             "name": "Wood Sage",
             "text": "oc\nT: Name a creature card. Reveal the top four cards of your library to all players. If any of those cards are the named card, put them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "222ce096-8616-508e-82ee-3362beb4b807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2da99f-3c53-4980-97d6-2158c765aac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2da99f-3c53-4980-97d6-2158c765aac0.jpg?1",
             "name": "Altar of Dementia",
             "text": "Sacrifice a creature: Target player puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [],
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "d047619b-ecc6-5169-b6e7-63a0a60f2abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedc78e-47dc-43e3-aed7-2d5c8e97fdac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedc78e-47dc-43e3-aed7-2d5c8e97fdac.jpg?1",
             "name": "Booby Trap",
             "text": "When Booby Trap comes into play, name a card other than a basic land.\nWhenever target opponent draws any cards, he or she reveals those cards to all players. If any of those cards is the named card, Sacrifice Booby Trap and it deals 10 damage to that player.",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "1e5de5dc-f49e-5033-afd9-4bfc63d691c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645297d1-ee77-4879-83eb-8114fbabb9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645297d1-ee77-4879-83eb-8114fbabb9a4.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: Gain 3 life.",
             "colours": [],
@@ -9029,7 +9029,7 @@
         },
         {
             "id": "15ce30ba-e6e6-5a25-b4b1-bd5ffcac25a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426a28bd-033d-41af-b577-ece73cbd7b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426a28bd-033d-41af-b577-ece73cbd7b3a.jpg?1",
             "name": "Coiled Tinviper",
             "text": "First strike",
             "colours": [],
@@ -9059,7 +9059,7 @@
         },
         {
             "id": "240d8053-572c-5f07-a167-6c55130d217b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e28d4-50e1-41db-984d-c55781295012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e28d4-50e1-41db-984d-c55781295012.jpg?1",
             "name": "Cold Storage",
             "text": "o3: Put target creature you control on Cold Storage.\nSacrifice Cold Storage: Put all creature cards on Cold Storage into play.",
             "colours": [],
@@ -9086,7 +9086,7 @@
         },
         {
             "id": "1af8b1b8-9572-503a-8ea8-ed9628925206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31415b9b-fb30-4132-a9a3-795b4573a901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31415b9b-fb30-4132-a9a3-795b4573a901.jpg?1",
             "name": "Cursed Scroll",
             "text": "o3, oc\nT: Name a card. Target opponent chooses a card at random from your hand. If he or she chooses the named card, Cursed Scroll deals 2 damage to target creature or player.",
             "colours": [],
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "3a287189-df95-5ba8-84bd-4784ca65c277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06425615-6c10-4766-8128-a1a09a35649d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06425615-6c10-4766-8128-a1a09a35649d.jpg?1",
             "name": "Echo Chamber",
             "text": "o4, oc\nT: Target opponent chooses target creature he or she controls. Put a token creature into play and treat it as a copy of that creature. The token creature is unaffected by summoning sickness this turn. At end of turn, remove the token creature from the game. Play this ability as a sorcery.",
             "colours": [],
@@ -9140,7 +9140,7 @@
         },
         {
             "id": "707451c9-a9fa-51ea-88e1-247de9324d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e87f30-b27a-48e2-a133-192309dd5902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e87f30-b27a-48e2-a133-192309dd5902.jpg?1",
             "name": "Emerald Medallion",
             "text": "Your green spells cost o1 less to play.",
             "colours": [],
@@ -9167,7 +9167,7 @@
         },
         {
             "id": "c6b66c06-2903-57ef-b4c4-7f1baa2ea976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a870e48a-41ae-4d9f-b181-074deb067d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a870e48a-41ae-4d9f-b181-074deb067d40.jpg?1",
             "name": "Emmessi Tome",
             "text": "o5, oc\nT: Draw two cards, then choose and discard a card.",
             "colours": [],
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "3f7dc8c4-d47c-55a5-958e-80b3b3fa8072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f204c-7f3d-41f2-a771-0b6227d539eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f204c-7f3d-41f2-a771-0b6227d539eb.jpg?1",
             "name": "Energizer",
             "text": "o2, oc\nT: Put a +1/+1 counter on Energizer.",
             "colours": [],
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "08878a0e-b850-5a65-bfc8-2d813b80085a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3c7760-04d8-424d-a097-df0ca8297837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3c7760-04d8-424d-a097-df0ca8297837.jpg?1",
             "name": "Essence Bottle",
             "text": "o3, oc\nT: Put an elixir counter on Essence Bottle.\noc\nT, Remove all elixir counters from Essence Bottle: Gain 2 life for each elixir counter removed in this way.",
             "colours": [],
@@ -9251,7 +9251,7 @@
         },
         {
             "id": "3d962848-d6cd-5041-a26f-151d2dc60b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc3d5b4-b04f-4b34-afd2-72fb3de0a33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc3d5b4-b04f-4b34-afd2-72fb3de0a33b.jpg?1",
             "name": "Excavator",
             "text": "oc\nT, Sacrifice a basic land: Target creature gains that landwalk ability until end of turn. (If defending player controls any lands of that type, this creature is unblockable.)",
             "colours": [],
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "f458deb3-0a62-5554-81be-8bcf24e3d27f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89f599-b063-4568-b7b9-08b96d04bde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89f599-b063-4568-b7b9-08b96d04bde1.jpg?1",
             "name": "Flowstone Sculpture",
             "text": "o2, Choose and discard a card: Flowstone Sculpture gains flying, first strike, or trample permanently, or put a +1/+1 counter on Flowstone Sculpture.",
             "colours": [],
@@ -9308,7 +9308,7 @@
         },
         {
             "id": "126e5f4c-c842-57da-b7a5-22f808fab74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83be257c-8945-46be-8b58-fb2881084026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83be257c-8945-46be-8b58-fb2881084026.jpg?1",
             "name": "Fool's Tome",
             "text": "o2, oc\nT: Draw a card. Use this ability only if you have no cards in your hand.",
             "colours": [],
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "255abdf0-6cea-57f1-9d6c-d5d3d3bd4196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4459187-de64-456f-bb66-56dea40d5c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4459187-de64-456f-bb66-56dea40d5c3e.jpg?1",
             "name": "Grindstone",
             "text": "o3, oc\nT: Put the top two cards of target player's library into that player's graveyard. If both cards share at least one color, repeat this process.",
             "colours": [],
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "94db1ee4-9f87-5ee1-87e1-341e4bc0db6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e16191-8dca-491b-b892-17696023d581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e16191-8dca-491b-b892-17696023d581.jpg?1",
             "name": "Helm of Possession",
             "text": "You may choose not to untap Helm of Possession during your untap phase.\no2, oc\nT, Sacrifice a creature: Gain control of target creature as long as you control Helm of Possession and Helm of Possession remains tapped.",
             "colours": [],
@@ -9389,7 +9389,7 @@
         },
         {
             "id": "81dbb83e-a116-5b77-ae5a-4fb91f9b638e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0db458c-2ced-454c-8061-fff8bd363b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0db458c-2ced-454c-8061-fff8bd363b33.jpg?1",
             "name": "Jet Medallion",
             "text": "Your black spells cost o1 less to play.",
             "colours": [],
@@ -9416,7 +9416,7 @@
         },
         {
             "id": "377e7437-2494-56d0-9a76-eb1779502e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c728e38-5656-4feb-8610-0cf45fb38094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c728e38-5656-4feb-8610-0cf45fb38094.jpg?1",
             "name": "Jinxed Idol",
             "text": "During your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol permanently.",
             "colours": [],
@@ -9443,7 +9443,7 @@
         },
         {
             "id": "8f3cb64b-4d14-5ecd-a0ae-03dfa2584f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c877da3-68fa-41d0-8a24-8c79fcd8ecc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c877da3-68fa-41d0-8a24-8c79fcd8ecc1.jpg?1",
             "name": "Lotus Petal",
             "text": "oc\nT, Sacrifice Lotus Petal: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9470,7 +9470,7 @@
         },
         {
             "id": "7c652607-d1fc-5f4a-9e16-c41e93b90160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3c7309-4efb-49ce-a9cc-a8f7b04c1a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3c7309-4efb-49ce-a9cc-a8f7b04c1a15.jpg?1",
             "name": "Magnetic Web",
             "text": "If any creature with any magnet counters on it attacks, all creatures with magnet counters on them that the attacking player controls attack if able.\nIf any creature with any magnet counters on it attacks, all creatures with magnet counters on them that the defending player controls block that creature if able.\no1, oc\nT: Put a magnet counter on target creature.",
             "colours": [],
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "3ac8b989-03c8-526c-b18f-8a1482f46fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d33ce7f-f318-4161-843a-f5bb6d6e3d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d33ce7f-f318-4161-843a-f5bb6d6e3d29.jpg?1",
             "name": "Manakin",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9527,7 +9527,7 @@
         },
         {
             "id": "4cc7c7c3-88d6-5ed9-b01a-a2195b0a651b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30143f4f-9846-448d-8797-8fe0bc0cc5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30143f4f-9846-448d-8797-8fe0bc0cc5df.jpg?1",
             "name": "Metallic Sliver",
             "text": "Metallic Sliver counts as a Sliver.",
             "colours": [],
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "4075b7b4-24f5-51ff-be8b-fafe029ec225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee64a77-5308-45c7-b865-400820968c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee64a77-5308-45c7-b865-400820968c74.jpg?1",
             "name": "Mogg Cannon",
             "text": "oc\nT: Target creature you control gets +1/+0 and gains flying until end of turn. At end of turn, destroy that creature.",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "b705cec3-7d7b-55db-908c-c56278318fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaa9ac4-b742-4a24-a316-97538adfd361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaa9ac4-b742-4a24-a316-97538adfd361.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Choose and discard a card: Regenerate Patchwork Gnomes.",
             "colours": [],
@@ -9614,7 +9614,7 @@
         },
         {
             "id": "2dbbc1ae-1725-5df0-a938-c37cd5aa7d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44588d53-7cce-406a-8e61-cd9866691966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44588d53-7cce-406a-8e61-cd9866691966.jpg?1",
             "name": "Pearl Medallion",
             "text": "Your white spells cost o1 less to play.",
             "colours": [],
@@ -9641,7 +9641,7 @@
         },
         {
             "id": "0b460db5-c40a-5bac-b825-031253302df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcf5b8a-563b-48d7-a874-e9c226192320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcf5b8a-563b-48d7-a874-e9c226192320.jpg?1",
             "name": "Phyrexian Grimoire",
             "text": "o4, oc\nT: Target opponent chooses one of the top two cards in your graveyard. Remove that card from the game and put the other into your hand.",
             "colours": [],
@@ -9668,7 +9668,7 @@
         },
         {
             "id": "8689b23b-5255-5305-9bf1-023006a497a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f5d5e-3a4b-430e-8769-fb553216befa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f5d5e-3a4b-430e-8769-fb553216befa.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "86c9c999-e517-5244-ae77-6bb38d8e15ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e9061a-b9e6-49ec-bc7e-c18557da9fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e9061a-b9e6-49ec-bc7e-c18557da9fd5.jpg?1",
             "name": "Phyrexian Splicer",
             "text": "o2, oc\nT: Choose flying, first strike, trample, or shadow. Target creature with that ability loses it until end of turn. Another target creature gains that ability until end of turn.",
             "colours": [],
@@ -9726,7 +9726,7 @@
         },
         {
             "id": "8e4c5aa3-e0cf-53c3-b648-8eb2fe76abc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b55586-9ea3-403e-96ec-2604f91c79cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b55586-9ea3-403e-96ec-2604f91c79cc.jpg?1",
             "name": "Puppet Strings",
             "text": "o2, oc\nT: Tap or untap target creature.",
             "colours": [],
@@ -9753,7 +9753,7 @@
         },
         {
             "id": "305998c4-b9f0-557a-8024-8dcc19ef533a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb28b-85f3-41ae-b1f5-fac766b2dcd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb28b-85f3-41ae-b1f5-fac766b2dcd2.jpg?1",
             "name": "Ruby Medallion",
             "text": "Your red spells cost o1 less to play.",
             "colours": [],
@@ -9780,7 +9780,7 @@
         },
         {
             "id": "6353030e-ea72-53f9-9873-c1dab4b6bd31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab1e253-47cb-4089-87d5-0f998025d98c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab1e253-47cb-4089-87d5-0f998025d98c.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Your blue spells cost o1 less to play.",
             "colours": [],
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "9e92ea3d-0a34-5c08-b3fc-c9035bbe5ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34136f2c-3edd-4ca3-b1ef-1fdcaa4518a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34136f2c-3edd-4ca3-b1ef-1fdcaa4518a0.jpg?1",
             "name": "Scalding Tongs",
             "text": "During your upkeep, if you have three or fewer cards in your hand, Scalding Tongs deals 1 damage to target opponent.",
             "colours": [],
@@ -9834,7 +9834,7 @@
         },
         {
             "id": "d548df5d-5bbd-520b-b829-bbd34272e10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7346d8-1aef-4618-88e6-74bd8865e0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7346d8-1aef-4618-88e6-74bd8865e0f3.jpg?1",
             "name": "Scroll Rack",
             "text": "o1, oc\nT: Choose any number of cards in your hand and set those cards aside. Put an equal number of cards from the top of your library into your hand. Then put the cards set aside in this way on top of your library in any order.",
             "colours": [],
@@ -9861,7 +9861,7 @@
         },
         {
             "id": "d38e5290-d399-56a6-8209-161cdcc0f8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b524ae7-cb24-41af-b41b-3cb3ee8cf3b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b524ae7-cb24-41af-b41b-3cb3ee8cf3b0.jpg?1",
             "name": "Squee's Toy",
             "text": "oc\nT: Prevent 1 damage to any creature.",
             "colours": [],
@@ -9888,7 +9888,7 @@
         },
         {
             "id": "8ac9f441-5750-5e73-82cb-074b7efd08eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3574d758-9143-4a2b-9ebd-ed8dab238251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3574d758-9143-4a2b-9ebd-ed8dab238251.jpg?1",
             "name": "Static Orb",
             "text": "Players cannot untap more than two permanents during their untap phases.",
             "colours": [],
@@ -9915,7 +9915,7 @@
         },
         {
             "id": "cef0077d-8122-599c-86e8-379088fd8ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d26c29-cd98-446b-b4e1-687561ed6d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d26c29-cd98-446b-b4e1-687561ed6d3f.jpg?1",
             "name": "Telethopter",
             "text": "Tap a creature you control: Telethopter gains flying until end of turn.",
             "colours": [],
@@ -9945,7 +9945,7 @@
         },
         {
             "id": "7d5c3cf7-8dc9-53d4-806f-2c96d3fe3954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71025a6b-3aed-4943-a907-9584d135f6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71025a6b-3aed-4943-a907-9584d135f6c0.jpg?1",
             "name": "Thumbscrews",
             "text": "During your upkeep, if you have five or more cards in your hand, Thumbscrews deals 1 damage to target opponent.",
             "colours": [],
@@ -9972,7 +9972,7 @@
         },
         {
             "id": "e505cd40-4a58-5951-94c4-539311aa6ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5648158d-38d4-4167-8af5-ee5d7d6fd7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5648158d-38d4-4167-8af5-ee5d7d6fd7cb.jpg?1",
             "name": "Torture Chamber",
             "text": "During your upkeep, put a pain counter on Torture Chamber.\nAt the end of your turn, Torture Chamber deals 1 damage to you for each pain counter on it.\no1, oc\nT, Remove all pain counters from Torture Chamber: Torture Chamber deals 1 damage for each pain counter on it to target creature.",
             "colours": [],
@@ -9999,7 +9999,7 @@
         },
         {
             "id": "8b7bbdfb-3b99-54b4-b3a9-3a09272d4150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ffc07-9993-40de-b36e-33c7afd4cfc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ffc07-9993-40de-b36e-33c7afd4cfc2.jpg?1",
             "name": "Watchdog",
             "text": "Watchdog blocks if able.\nAs long as Watchdog is untapped, all creatures attacking you get -1/-0.",
             "colours": [],
@@ -10029,7 +10029,7 @@
         },
         {
             "id": "b487402f-54ef-56d8-8490-d655b7a7f251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e401e3-282b-4524-87e1-c6cd50cd6d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e401e3-282b-4524-87e1-c6cd50cd6d00.jpg?1",
             "name": "Ancient Tomb",
             "text": "oc\nT: Add two colorless mana to your mana pool. Ancient Tomb deals 2 damage to you.",
             "colours": [],
@@ -10056,7 +10056,7 @@
         },
         {
             "id": "e45e8a74-89eb-5c40-b28f-892f91f49f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01fe22-e8ff-4106-8ac5-693ef920b2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01fe22-e8ff-4106-8ac5-693ef920b2c9.jpg?1",
             "name": "Caldera Lake",
             "text": "Caldera Lake comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nR to your mana pool. Caldera Lake deals 1 damage to you.",
             "colours": [],
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "1c80ccea-d41a-54c0-b99b-1cadb2b52e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fee067d-c31f-4b09-99f5-84d1102f96b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fee067d-c31f-4b09-99f5-84d1102f96b0.jpg?1",
             "name": "Cinder Marsh",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Cinder Marsh does not untap during your next untap phase.",
             "colours": [],
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "e3475cc5-893d-540e-978e-1a77fc1e72cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4218cdda-3a62-43fb-aaf7-7ac836392796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4218cdda-3a62-43fb-aaf7-7ac836392796.jpg?1",
             "name": "Ghost Town",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no0: Return Ghost Town to owner's hand. Use this ability only during another player's turn.",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "df331a3d-bd88-50c1-b08c-df5ab24f7d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg?1",
             "name": "Maze of Shadows",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Untap target attacking creature with shadow. That creature neither deals nor receives combat damage this turn.",
             "colours": [],
@@ -10170,7 +10170,7 @@
         },
         {
             "id": "1777ff7e-c953-58ad-8ebc-98c7a516a372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474e3fb0-b0f9-4c6d-8c57-e5079a3a3c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474e3fb0-b0f9-4c6d-8c57-e5079a3a3c66.jpg?1",
             "name": "Mogg Hollows",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Mogg Hollows does not untap during your next untap phase.",
             "colours": [],
@@ -10200,7 +10200,7 @@
         },
         {
             "id": "544488d1-622b-55cf-b9dd-fecca0751145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac39e8-bd0e-4fa3-bc1e-a93944d013f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac39e8-bd0e-4fa3-bc1e-a93944d013f3.jpg?1",
             "name": "Pine Barrens",
             "text": "Pine Barrens comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nG to your mana pool. Pine Barrens deals 1 damage to you.",
             "colours": [],
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "76a83d04-c864-5274-8cf3-54e48a653ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b633ac2-bf98-42bd-8c26-8737a7d8edc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b633ac2-bf98-42bd-8c26-8737a7d8edc7.jpg?1",
             "name": "Reflecting Pool",
             "text": "oc\nT: Add to your mana pool one mana of any type that any land you control can produce.",
             "colours": [],
@@ -10257,7 +10257,7 @@
         },
         {
             "id": "2b997f85-c7e4-5eb9-af12-0144e35ef440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4bcbef-66bf-4625-82d5-a01c39d3d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4bcbef-66bf-4625-82d5-a01c39d3d78e.jpg?1",
             "name": "Rootwater Depths",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Rootwater Depths does not untap during your next untap phase.",
             "colours": [],
@@ -10287,7 +10287,7 @@
         },
         {
             "id": "96e6dece-21b1-51b6-9a9c-439b9c274da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224cb63f-9af0-4b00-ba0b-0b604abf20c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224cb63f-9af0-4b00-ba0b-0b604abf20c8.jpg?1",
             "name": "Salt Flats",
             "text": "Salt Flats comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nB to your mana pool. Salt Flats deals 1 damage to you.",
             "colours": [],
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "a3fb9209-827d-59a6-932c-26b76ad43e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374f269-b07e-43af-911a-5454b35f14e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374f269-b07e-43af-911a-5454b35f14e6.jpg?1",
             "name": "Scabland",
             "text": "Scabland comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nW to your mana pool. Scabland deals 1 damage to you.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "d7fa33d9-d2f8-5395-8da7-081fae05561f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01f43b-d0b3-4cd5-9694-aed30a79462c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01f43b-d0b3-4cd5-9694-aed30a79462c.jpg?1",
             "name": "Skyshroud Forest",
             "text": "Skyshroud Forest comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nG to your mana pool. Skyshroud Forest deals 1 damage to you.",
             "colours": [],
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "c6a4a1a1-e598-5987-8e88-da1675e3533c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3d349-5c23-43a9-b25e-0e1a35b84673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3d349-5c23-43a9-b25e-0e1a35b84673.jpg?1",
             "name": "Stalking Stones",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no6: Stalking Stones becomes a 3/3 artifact creature permanently. (This creature still counts as a land.)",
             "colours": [],
@@ -10404,7 +10404,7 @@
         },
         {
             "id": "d73a6e7f-bf7e-5847-af3b-19c53b49f6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3dcb12-e224-40c8-aecf-941fceb1d323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3dcb12-e224-40c8-aecf-941fceb1d323.jpg?1",
             "name": "Thalakos Lowlands",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Thalakos Lowlands does not untap during your next untap phase.",
             "colours": [],
@@ -10434,7 +10434,7 @@
         },
         {
             "id": "4b8a13f9-9012-5a61-8932-3f4d19e10d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15377e49-e929-413f-9501-8f3e4afa0050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15377e49-e929-413f-9501-8f3e4afa0050.jpg?1",
             "name": "Vec Townships",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Vec Townships does not untap during your next untap phase.",
             "colours": [],
@@ -10464,7 +10464,7 @@
         },
         {
             "id": "2392456a-7a4a-5554-884f-b7ccaef08651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff731b-8399-40c8-b539-ba6ba5783771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff731b-8399-40c8-b539-ba6ba5783771.jpg?1",
             "name": "Wasteland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Wasteland: Destroy target nonbasic land.",
             "colours": [],
@@ -10491,7 +10491,7 @@
         },
         {
             "id": "1747e687-231b-59e8-87a3-56431946d886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e339a9-3f9b-401e-a459-dc3affc9a114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e339a9-3f9b-401e-a459-dc3affc9a114.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10528,7 +10528,7 @@
         },
         {
             "id": "e8b1924f-5a4e-5c78-a2c8-38fc89f42a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da37f78a-a0a6-4ca3-921c-4bc2c17ccda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da37f78a-a0a6-4ca3-921c-4bc2c17ccda6.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10565,7 +10565,7 @@
         },
         {
             "id": "c9c45a3b-ffc1-5728-8383-a99f11cae83f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd35bef-1702-4b3d-b149-8761c5cc5ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd35bef-1702-4b3d-b149-8761c5cc5ed9.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10602,7 +10602,7 @@
         },
         {
             "id": "4cd7be76-69c4-5182-a578-3e9a06bbb559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f7baf6-de14-40f8-871f-dda889672608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f7baf6-de14-40f8-871f-dda889672608.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "e5b357bd-2c3a-5019-93f8-dd2950a3d18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22578bc8-10c6-4598-82bc-70e970a8f518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22578bc8-10c6-4598-82bc-70e970a8f518.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "913ee0c4-5ab7-5d1f-9037-c87265893eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f891c3f-82e2-4f9d-ae4b-443fce0bdd71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f891c3f-82e2-4f9d-ae4b-443fce0bdd71.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "bf1ea798-07c2-5268-91d2-3e58b2e6a42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38e48ff-17c8-470c-ba8b-966da1777e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38e48ff-17c8-470c-ba8b-966da1777e77.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "acfea428-2fa8-5f12-8994-f9a5ccfa547e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6e59d7-5038-46b4-9f60-3d9d0cbf0a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6e59d7-5038-46b4-9f60-3d9d0cbf0a4e.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10787,7 +10787,7 @@
         },
         {
             "id": "b3f49a68-1590-5e6b-95ef-15e3c9b340e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5912d2aa-fe91-4cea-9c7a-6dca745f8560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5912d2aa-fe91-4cea-9c7a-6dca745f8560.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10824,7 +10824,7 @@
         },
         {
             "id": "e7f4cbbc-3c8f-5e82-a9a6-533b9b0debf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10861,7 +10861,7 @@
         },
         {
             "id": "854e9559-122c-52d5-a5d6-186167ff9418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96dbfea-3b79-4e5b-a356-3c04d1e78e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96dbfea-3b79-4e5b-a356-3c04d1e78e83.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "b77d2bea-6adc-5f7a-9bc7-b37e988b6e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9330376c-0242-4e28-b535-26c84b43c3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9330376c-0242-4e28-b535-26c84b43c3e6.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10935,7 +10935,7 @@
         },
         {
             "id": "b491f8f6-1349-5a15-8814-f7642bc35d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6dc341-89dc-4e99-baa2-ad0ae59f0e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6dc341-89dc-4e99-baa2-ad0ae59f0e94.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "09ff5e23-3a99-546d-8eaf-e72de329f23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fb0ed-5a19-4fde-b2c4-f46c7e0915f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fb0ed-5a19-4fde-b2c4-f46c7e0915f8.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "a87d8455-9b61-5e88-aea2-63d60da77407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515ced4-b679-48f0-bf62-8b7baef5e1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515ced4-b679-48f0-bf62-8b7baef5e1c2.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11046,7 +11046,7 @@
         },
         {
             "id": "40273ea8-5c14-5791-9ac1-69e05efa4773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e043bf-a6d7-4778-8460-13bdf38b7d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e043bf-a6d7-4778-8460-13bdf38b7d39.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11083,7 +11083,7 @@
         },
         {
             "id": "bba765cb-187a-58eb-b976-fb7b7942142c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b3ffbd-3f3e-4fca-80c2-94f9fdc198a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b3ffbd-3f3e-4fca-80c2-94f9fdc198a5.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11120,7 +11120,7 @@
         },
         {
             "id": "c5b0850e-b467-5a6a-a3db-0af6027e7e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bac71a-c326-4640-bdf8-43682f59060b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bac71a-c326-4640-bdf8-43682f59060b.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11157,7 +11157,7 @@
         },
         {
             "id": "5ff15278-d1d0-5487-9122-a26d6f088b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b667225-a808-43e9-955e-6c4e7ecd53f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b667225-a808-43e9-955e-6c4e7ecd53f2.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "26981e7a-8dff-55f6-bc90-bcdbdd93c7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32411c3a-da2b-4316-9848-971e90951303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32411c3a-da2b-4316-9848-971e90951303.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/TOR.json
+++ b/Assets/Resources/Sets/TOR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fc1a0569-b60f-5552-9e70-4173a8ed2ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3215ba-e492-4cfd-aa16-0da4818eed1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3215ba-e492-4cfd-aa16-0da4818eed1b.jpg?1",
             "name": "Angel of Retribution",
             "text": "Flying, first strike",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "ddb07907-9ce1-5938-b972-d34c53eaa94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c8f774-6d4f-4fd0-85c0-26ef713e6b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c8f774-6d4f-4fd0-85c0-26ef713e6b89.jpg?1",
             "name": "Aven Trooper",
             "text": "Flying\no2o\nW, Discard a card from your hand: Aven Trooper gets +1/+2 until end of turn.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "441ceda3-1ceb-5502-bad4-43254850608e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6609ef-71af-4775-affc-34153700c556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6609ef-71af-4775-affc-34153700c556.jpg?1",
             "name": "Cleansing Meditation",
             "text": "Destroy all enchantments.\nThreshold Instead destroy all enchantments, then return to play all cards in your graveyard destroyed this way. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "bc146494-d03f-5c9f-81ff-71aea02c7946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310cb525-9299-471e-b310-392353b25472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310cb525-9299-471e-b310-392353b25472.jpg?1",
             "name": "Equal Treatment",
             "text": "If any source would deal 1 or more damage to a creature or player this turn, it deals 2 damage to that creature or player instead.\nDraw a card.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "1f6c1d56-0c51-5274-a2d4-7bc58e56be59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbda39b-a998-4ad9-95df-72ed9556c390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbda39b-a998-4ad9-95df-72ed9556c390.jpg?1",
             "name": "Floating Shield",
             "text": "As Floating Shield comes into play, choose a color.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Floating Shield.\nSacrifice Floating Shield: Target creature gains protection from the chosen color until end of turn.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "08f51ca5-bd07-5616-a787-a75d0cebd0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f156d1-2655-42aa-a785-d8eb15cb5422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f156d1-2655-42aa-a785-d8eb15cb5422.jpg?1",
             "name": "Frantic Purification",
             "text": "Destroy target enchantment.\nMadness o\nW (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "c55b66dc-8ca0-5396-a889-981c0f86a055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467c940-dae4-4667-bec8-524dbce13283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467c940-dae4-4667-bec8-524dbce13283.jpg?1",
             "name": "Hypochondria",
             "text": "o\nW, Discard a card from your hand: Prevent the next 3 damage that would be dealt to target creature or player this turn.\no\nW, Sacrifice Hypochondria: Prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "519e48b8-482c-561f-99e2-7c103c1adc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3229ca5a-5340-48b8-bd46-b0b924c8faf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3229ca5a-5340-48b8-bd46-b0b924c8faf7.jpg?1",
             "name": "Major Teroh",
             "text": "Flying\no3o\nWo\nW, Sacrifice Major Teroh: Remove all black creatures from the game.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "d6b06a6f-7427-5b46-8f97-f6beb053d727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886a3cfd-7f83-480a-bb22-eec67ad35e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886a3cfd-7f83-480a-bb22-eec67ad35e4f.jpg?1",
             "name": "Militant Monk",
             "text": "Attacking doesn't cause Militant Monk to tap.\noc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "6f4643e0-8b63-536f-996b-e5dbfe8b28e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62e17a7-3602-45af-bdb6-fa5f2a9f1155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62e17a7-3602-45af-bdb6-fa5f2a9f1155.jpg?1",
             "name": "Morningtide",
             "text": "Remove all cards in all graveyards from the game.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "0874b6d9-0619-5649-9208-e02fbed73a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b235567a-424e-48da-a94b-c6674a73b3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b235567a-424e-48da-a94b-c6674a73b3fa.jpg?1",
             "name": "Mystic Familiar",
             "text": "Flying\nThreshold Mystic Familiar gets +1/+1 and has protection from black. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "1fcdafc5-bbbe-5cc8-97ee-34d542ccae5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9520a1be-db77-4f31-a67d-6309a3ddc566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9520a1be-db77-4f31-a67d-6309a3ddc566.jpg?1",
             "name": "Pay No Heed",
             "text": "Prevent all damage a source of your choice would deal this turn.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "cf426dc0-d57a-5d18-b439-7ab99d16b5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9dfae5-63f6-401a-9dec-afe838190824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9dfae5-63f6-401a-9dec-afe838190824.jpg?1",
             "name": "Possessed Nomad",
             "text": "Attacking doesn't cause Possessed Nomad to tap.\nThreshold Possessed Nomad gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target white creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "29dadd6e-660b-52a0-80b7-ef4e3a714a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4acbc7f-c86e-4285-a66d-d7b03fe44377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4acbc7f-c86e-4285-a66d-d7b03fe44377.jpg?1",
             "name": "Reborn Hero",
             "text": "Attacking doesn't cause Reborn Hero to tap.\nThreshold When Reborn Hero is put into a graveyard from play, you may pay o\nWo\nW. If you do, return Reborn Hero to play under your control. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "0fa43b6d-f844-5790-89c9-834903b07496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdbe7c6-99ad-4c73-bffe-7bbdc6965854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdbe7c6-99ad-4c73-bffe-7bbdc6965854.jpg?1",
             "name": "Spirit Flare",
             "text": "Tap target untapped creature you control. If you do, it deals damage equal to its power to target attacking or blocking creature an opponent controls.\nFlashback\u2014o1o\nW, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "d4a31710-0637-50eb-8fe3-41817842b686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436044d7-981c-4273-a0b4-6dd455608c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436044d7-981c-4273-a0b4-6dd455608c47.jpg?1",
             "name": "Stern Judge",
             "text": "oc\nT: Each player loses 1 life for each swamp he or she controls.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "cba1546a-9dc6-5b14-8b38-8f14b66ab860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676e6fb-030d-40aa-a914-27ab6d7d5fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676e6fb-030d-40aa-a914-27ab6d7d5fc5.jpg?1",
             "name": "Strength of Isolation",
             "text": "Enchanted creature gets +1/+2 and has protection from black.\nMadness o\nW (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "3cc5aa27-fd04-51ea-9165-fc2be033009c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff8cf45-c84f-49d7-ad3d-b5e046286cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff8cf45-c84f-49d7-ad3d-b5e046286cb3.jpg?1",
             "name": "Teroh's Faithful",
             "text": "When Teroh's Faithful comes into play, you gain 4 life.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "c018f0c1-d898-5b54-837f-03dc011182c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a39f909-7114-4482-8302-b2a56ca9f556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a39f909-7114-4482-8302-b2a56ca9f556.jpg?1",
             "name": "Teroh's Vanguard",
             "text": "You may play Teroh's Vanguard any time you could play an instant.\nThreshold When Teroh's Vanguard comes into play, creatures you control gain protection from black until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "9a42fd02-1943-568d-9fc3-7a2d9b7a6e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8bee2-9e3d-493c-a937-645bf3dcf0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8bee2-9e3d-493c-a937-645bf3dcf0db.jpg?1",
             "name": "Transcendence",
             "text": "You don't lose the game for having 0 or less life.\nWhen you have 20 or more life, you lose the game.\nWhenever you lose life, you gain 2 life for each 1 life you lost. (Damage dealt to you causes you to lose life.)",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "23f5d9b5-4bb5-576e-a00b-ebd15fb35dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfe8b2-cc98-4430-b576-085163bdf0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfe8b2-cc98-4430-b576-085163bdf0b6.jpg?1",
             "name": "Vengeful Dreams",
             "text": "As an additional cost to play Vengeful Dreams, discard X cards from your hand.\nRemove X target attacking creatures from the game.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "ab88c891-75d4-5d09-acf9-a758cd440f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd68be-6e6a-4577-8465-a892463b6d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd68be-6e6a-4577-8465-a892463b6d6c.jpg?1",
             "name": "Alter Reality",
             "text": "Change the text of target permanent or spell by replacing all instances of one color word with another. (This effect doesn't end at end of turn.)\nFlashback o1o\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "bc9aee0e-058a-5127-a7fd-83a6d730caf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887cac61-2001-4bd1-aeeb-20149ebc5856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887cac61-2001-4bd1-aeeb-20149ebc5856.jpg?1",
             "name": "Ambassador Laquatus",
             "text": "o3: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "ba9a0a67-c125-5d43-9344-d723c316127f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1243552a-ca57-42ce-817e-d6268fc673e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1243552a-ca57-42ce-817e-d6268fc673e0.jpg?1",
             "name": "Aquamoeba",
             "text": "Discard a card from your hand: Switch Aquamoeba's power and toughness until end of turn.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "2610df1e-b8cc-5b79-8abc-e02e17ba4675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23ebd3b-59bf-4f3d-b320-9283871c4540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23ebd3b-59bf-4f3d-b320-9283871c4540.jpg?1",
             "name": "Balshan Collaborator",
             "text": "Flying\no\nB: Balshan Collaborator gets +1/+1 until end of turn.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "71c348ea-ccbf-52df-9a9c-990675344cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59a2cea-3b65-43da-bc6e-0e3c82f25b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59a2cea-3b65-43da-bc6e-0e3c82f25b3c.jpg?1",
             "name": "Breakthrough",
             "text": "Draw four cards, then choose X cards in your hand and discard the rest from it.",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "e2151173-fc41-5970-96e1-4a4291e72dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9ca63d-7e77-48f3-abdc-2d2f9cb3a0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9ca63d-7e77-48f3-abdc-2d2f9cb3a0d9.jpg?1",
             "name": "Cephalid Aristocrat",
             "text": "Whenever Cephalid Aristocrat becomes the target of a spell or ability, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "0d815dba-bbcc-5a5e-a2cd-556a618d6bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dceb8cf5-b31a-400e-aea5-ad0c3552d697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dceb8cf5-b31a-400e-aea5-ad0c3552d697.jpg?1",
             "name": "Cephalid Illusionist",
             "text": "Whenever Cephalid Illusionist becomes the target of a spell or ability, put the top three cards of your library into your graveyard.\no2o\nU, oc\nT: This turn prevent all combat damage that would be dealt to and dealt by target creature you control.",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "1e6a2789-eff5-5d79-9904-26898236e81b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434e2ece-7b00-4ad1-9c35-cca16fbb002b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434e2ece-7b00-4ad1-9c35-cca16fbb002b.jpg?1",
             "name": "Cephalid Sage",
             "text": "Threshold When Cephalid Sage comes into play, draw three cards, then discard two cards from your hand. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "412122d4-1f92-5039-81c5-53b246e31b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d989b2-0198-4e5b-8aad-ee939191dd28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d989b2-0198-4e5b-8aad-ee939191dd28.jpg?1",
             "name": "Cephalid Snitch",
             "text": "Sacrifice Cephalid Snitch: Target creature loses protection from black until end of turn.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "4987901a-a992-5217-b716-9243a0c6f8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2500976f-a329-4a51-bcc1-cafe39bc3ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2500976f-a329-4a51-bcc1-cafe39bc3ccf.jpg?1",
             "name": "Cephalid Vandal",
             "text": "At the beginning of your upkeep, put a shred counter on Cephalid Vandal. Then put the top card of your library into your graveyard for each shred counter on Cephalid Vandal.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "44185394-1935-5e9f-9bd3-5b9771ac7697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd28bc8e-842f-4788-92a0-3019e3c2385f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd28bc8e-842f-4788-92a0-3019e3c2385f.jpg?1",
             "name": "Churning Eddy",
             "text": "Return target creature and target land to their owners' hands.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "e8462ebd-de29-557a-8358-b88d87d8d34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9198d6-201d-4175-8f70-eef92d7d5bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9198d6-201d-4175-8f70-eef92d7d5bb5.jpg?1",
             "name": "Circular Logic",
             "text": "Counter target spell unless its controller pays o1 for each card in your graveyard.\nMadness o\nU (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "5c150d9b-681a-50e8-8395-294543ffaeae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1f56e8-55cb-4b81-9946-9f0f813e3d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1f56e8-55cb-4b81-9946-9f0f813e3d4a.jpg?1",
             "name": "Compulsion",
             "text": "o1o\nU, Discard a card from your hand: Draw a card.\no1o\nU, Sacrifice Compulsion: Draw a card.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "78de564a-f64b-51d7-90b1-4c84496409b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9cf1e-d398-41e0-8b11-afe1015e4fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9cf1e-d398-41e0-8b11-afe1015e4fd9.jpg?1",
             "name": "Coral Net",
             "text": "Coral Net can enchant only a green or white creature.\nEnchanted creature has \"At the beginning of your upkeep, sacrifice this creature unless you discard a card from your hand.\"",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "63e92ee1-de37-5cc9-85f3-2cf9d9ad750f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e3c2e9-d8df-4a7a-be86-7be8c6254fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e3c2e9-d8df-4a7a-be86-7be8c6254fa2.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014o1o\nU, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "d565f956-c713-5105-800a-07cf2deec32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a45ea90-03af-446e-9df3-ef64e9613f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a45ea90-03af-446e-9df3-ef64e9613f2c.jpg?1",
             "name": "False Memories",
             "text": "Put the top seven cards of your library into your graveyard. At end of turn, remove seven cards in your graveyard from the game.",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "5f54f814-b452-59ff-8fbb-a791fb7c4462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb2705-82e7-49d9-b8cc-f98f652dd6c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb2705-82e7-49d9-b8cc-f98f652dd6c1.jpg?1",
             "name": "Ghostly Wings",
             "text": "Enchanted creature gets +1/+1 and has flying.\nDiscard a card from your hand: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "e44d3e62-17dc-5cd7-b637-f1c0f18cf811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e4ace0-421d-4e8e-ab85-8f74757e99c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e4ace0-421d-4e8e-ab85-8f74757e99c7.jpg?1",
             "name": "Hydromorph Guardian",
             "text": "o\nU, Sacrifice Hydromorph Guardian: Counter target spell that targets one or more creatures you control.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "d317e668-b43c-5760-ba06-62765c8d1bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b1c8fc-e09b-479b-ac15-f659acb2f50f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b1c8fc-e09b-479b-ac15-f659acb2f50f.jpg?1",
             "name": "Hydromorph Gull",
             "text": "Flying\no\nU, Sacrifice Hydromorph Gull: Counter target spell that targets one or more creatures you control.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "b9839771-6017-5edd-8c0f-250cb73c6d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fadf25-0995-440d-a3e6-7964ed86cff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fadf25-0995-440d-a3e6-7964ed86cff6.jpg?1",
             "name": "Liquify",
             "text": "Counter target spell with converted mana cost 3 or less. If it's countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "a913c87d-8234-5ee5-ae72-0ec343f9e62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9821970-a5da-4045-93d8-f58c9e5797c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9821970-a5da-4045-93d8-f58c9e5797c1.jpg?1",
             "name": "Llawan, Cephalid Empress",
             "text": "When Llawan, Cephalid Empress comes into play, return all blue creatures your opponents control to their owners' hands.\nYour opponents can't play blue creature spells.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "ced723da-ba01-575d-9bb1-417982807a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79977d84-7a20-47ef-930f-0ce7a5eff88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79977d84-7a20-47ef-930f-0ce7a5eff88e.jpg?1",
             "name": "Obsessive Search",
             "text": "Draw a card.\nMadness o\nU (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "addaa28a-1f9c-5197-968d-3170447224bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333bbcba-19a7-4307-abe7-7cffa3569e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333bbcba-19a7-4307-abe7-7cffa3569e4d.jpg?1",
             "name": "Plagiarize",
             "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "393bf366-6e5d-5170-8458-fd5e8dc2f91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997c56c7-c625-4209-b4b6-d274dee2db48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997c56c7-c625-4209-b4b6-d274dee2db48.jpg?1",
             "name": "Possessed Aven",
             "text": "Flying\nThreshold Possessed Aven gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target blue creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "44627f26-cd3b-5a40-a724-b92d4df76e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62fa778-ce44-4a3e-958a-91dfe5398944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62fa778-ce44-4a3e-958a-91dfe5398944.jpg?1",
             "name": "Retraced Image",
             "text": "Reveal a card in your hand, then put that card into play if it has the same name as a permanent in play.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "77a56a80-ccff-560f-8994-7b882a5eaaba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a20b6b-43e6-4feb-9792-909332e1a846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a20b6b-43e6-4feb-9792-909332e1a846.jpg?1",
             "name": "Skywing Aven",
             "text": "Flying\nDiscard a card from your hand: Return Skywing Aven to its owner's hand.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "d23e0bc2-550e-5718-872d-b6e8529672d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f817379-9c0b-4e43-a345-492516ccb6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f817379-9c0b-4e43-a345-492516ccb6e1.jpg?1",
             "name": "Stupefying Touch",
             "text": "When Stupefying Touch comes into play, draw a card.\nEnchanted creature's activated abilities can't be played.",
             "colours": [
@@ -1627,7 +1627,7 @@
         },
         {
             "id": "f2d75518-971f-5b19-8f68-4a03aed356c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d879226b-8ee3-4a48-b03a-d183594dc586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d879226b-8ee3-4a48-b03a-d183594dc586.jpg?1",
             "name": "Turbulent Dreams",
             "text": "As an additional cost to play Turbulent Dreams, discard X cards from your hand.\nReturn X target nonland permanents to their owners' hands.",
             "colours": [
@@ -1659,7 +1659,7 @@
         },
         {
             "id": "c77bbbae-3eac-5600-9d8c-bb6c30f7315e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27201370-32cc-4b90-890d-8c3f5362ad70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27201370-32cc-4b90-890d-8c3f5362ad70.jpg?1",
             "name": "Boneshard Slasher",
             "text": "Flying\nThreshold Boneshard Slasher gets +2/+2 and has \"When Boneshard Slasher becomes the target of a spell or ability, sacrifice it.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "87ba5908-55bc-52df-aecc-98f3ec6edad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5403b49d-03a7-4cc3-af3c-df098c1c9c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5403b49d-03a7-4cc3-af3c-df098c1c9c2e.jpg?1",
             "name": "Cabal Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.\nThreshold Instead add o\nBo\nBo\nBo\nBo\nB to your mana pool. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "0e7cf4e2-dd04-55be-87ca-cf437596ed23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ce55a2-d838-48ab-862e-d419b0cda3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ce55a2-d838-48ab-862e-d419b0cda3c9.jpg?1",
             "name": "Cabal Surgeon",
             "text": "o2o\nBo\nB, oc\nT, Remove two cards in your graveyard from the game: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "4c6f714f-a315-5464-8622-1844834013a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcf8dd7-f45c-4ac2-9507-fa175fe89887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcf8dd7-f45c-4ac2-9507-fa175fe89887.jpg?1",
             "name": "Cabal Torturer",
             "text": "o\nB, oc\nT: Target creature gets -1/-1 until end of turn.\nThreshold o3o\nBo\nB, oc\nT: Target creature gets -2/-2 until end of turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "e23652ea-49ac-5817-b59f-8e380a7eada0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efa2579-c048-4506-babc-ec1c29bb99a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efa2579-c048-4506-babc-ec1c29bb99a8.jpg?1",
             "name": "Carrion Rats",
             "text": "Whenever Carrion Rats attacks or blocks, any player may remove a card in his or her graveyard from the game. If a player does, Carrion Rats deals no combat damage this turn.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "dadc3a3e-4ea8-5658-904d-4b246b432fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b228-94c0-4e84-ad6d-80b170bb6c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b228-94c0-4e84-ad6d-80b170bb6c0c.jpg?1",
             "name": "Carrion Wurm",
             "text": "Whenever Carrion Wurm attacks or blocks, any player may remove three cards in his or her graveyard from the game. If a player does, Carrion Wurm deals no combat damage this turn.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "9b8a549d-4cd1-53d6-900c-7f10cbf8a14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40342b11-1005-4ccc-bef4-9ea4c640b048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40342b11-1005-4ccc-bef4-9ea4c640b048.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\no\nBo\nBo\nB, Pay 3 life: Put target creature card from a graveyard into play under your control. That creature is black and is a Nightmare in addition to its creature types.\nWhen Chainer, Dementia Master leaves play, remove all Nightmares from the game.",
             "colours": [
@@ -1901,7 +1901,7 @@
         },
         {
             "id": "96789104-3d73-5cc6-be73-02f78ccf43e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014af391-3b4a-4aab-a3e9-f60e61016985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014af391-3b4a-4aab-a3e9-f60e61016985.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback o5o\nBo\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "3aef2983-40c6-544b-9393-27814e6df47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb53a87-ba48-4c77-b284-3be321c8836e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb53a87-ba48-4c77-b284-3be321c8836e.jpg?1",
             "name": "Crippling Fatigue",
             "text": "Target creature gets -2/-2 until end of turn.\nFlashback\u2014o1o\nB, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "54c78af4-d7ea-5a67-ba83-4caf764364a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabadd3-3fc1-4c9a-ad3b-c79d60fb3390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabadd3-3fc1-4c9a-ad3b-c79d60fb3390.jpg?1",
             "name": "Dawn of the Dead",
             "text": "At the beginning of your upkeep, you lose 1 life.\nAt the beginning of your upkeep, you may return target creature card from your graveyard to play. That creature gains haste until end of turn. Remove it from the game at end of turn.",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "29217f6e-fdd2-5eaa-aa4f-31b0cb668e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073be21-c54a-4eee-9109-f3adfe757c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073be21-c54a-4eee-9109-f3adfe757c4e.jpg?1",
             "name": "Faceless Butcher",
             "text": "When Faceless Butcher comes into play, remove target creature other than Faceless Butcher from the game.\nWhen Faceless Butcher leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "4fbeefa6-7da4-57b4-b4f0-43532ff49a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaf8c24-3f5e-4ea5-941b-40ad1299af39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaf8c24-3f5e-4ea5-941b-40ad1299af39.jpg?1",
             "name": "Gloomdrifter",
             "text": "Flying\nThreshold When Gloomdrifter comes into play, nonblack creatures get -2/-2 until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "ee49e3aa-982f-58ed-9fd3-598d6e10b48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfcd559-374e-4e6f-9333-2e5c855abff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfcd559-374e-4e6f-9333-2e5c855abff5.jpg?1",
             "name": "Gravegouger",
             "text": "When Gravegouger comes into play, remove up to two target cards in a single graveyard from the game.\nWhen Gravegouger leaves play, return the removed cards to their owner's graveyard.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "86ddd9ce-bbb6-5a6c-b2eb-16459cd0b4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b063c3a-267f-4f22-be51-0a14880afc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b063c3a-267f-4f22-be51-0a14880afc24.jpg?1",
             "name": "Grotesque Hybrid",
             "text": "Whenever Grotesque Hybrid deals combat damage to a creature, destroy that creature. It can't be regenerated.\nDiscard a card from your hand: Grotesque Hybrid gains flying and protection from green and from white until end of turn.",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "5f648e9e-a131-5068-82be-9e88c0ab0bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0e53a1-11d5-4975-b698-8b5d72d241f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0e53a1-11d5-4975-b698-8b5d72d241f0.jpg?1",
             "name": "Hypnox",
             "text": "Flying\nWhen Hypnox comes into play, if you played it from your hand, remove all cards in target opponent's hand from the game.\nWhen Hypnox leaves play, return the removed cards to their owner's hand.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "0ba5cbc3-2ed7-53db-bc33-485b75072aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97431dca-54ca-47ef-ab00-943140e8e758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97431dca-54ca-47ef-ab00-943140e8e758.jpg?1",
             "name": "Ichorid",
             "text": "Haste\nAt end of turn, sacrifice Ichorid.\nAt the beginning of your upkeep, if Ichorid is in your graveyard, you may remove a black creature card in your graveyard other than Ichorid from the game. If you do, return Ichorid to play.",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "12318b18-d6b9-5e91-81ff-48b4c9296a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a29622-23a6-42c7-8e56-690613572c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a29622-23a6-42c7-8e56-690613572c94.jpg?1",
             "name": "Insidious Dreams",
             "text": "As an additional cost to play Insidious Dreams, discard X cards from your hand.\nSearch your library for X cards. Then shuffle your library and put those cards on top of it in any order.",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "06906c32-7d54-54c7-aa9a-babed68c0d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a397bb-6910-4724-833d-7f2d92723e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a397bb-6910-4724-833d-7f2d92723e3b.jpg?1",
             "name": "Laquatus's Champion",
             "text": "When Laquatus's Champion comes into play, target player loses 6 life.\nWhen Laquatus's Champion leaves play, that player gains 6 life.\no\nB: Regenerate Laquatus's Champion.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "31d67ad5-fb18-51e0-88df-c48586cc52c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c05f2a-b844-42b3-af91-65694b4211dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c05f2a-b844-42b3-af91-65694b4211dd.jpg?1",
             "name": "Last Laugh",
             "text": "Whenever a permanent other than Last Laugh is put into a graveyard from play, Last Laugh deals 1 damage to each creature and each player.\nWhen no creatures are in play, sacrifice Last Laugh.",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "0629f77d-c16f-595f-885c-b35e4612ed86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edd4ea-c587-4d93-a675-4cdec3e0b1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edd4ea-c587-4d93-a675-4cdec3e0b1ca.jpg?1",
             "name": "Mesmeric Fiend",
             "text": "When Mesmeric Fiend comes into play, target opponent reveals his or her hand and you choose a nonland card from it. Remove that card from the game.\nWhen Mesmeric Fiend leaves play, return the removed card to its owner's hand.",
             "colours": [
@@ -2339,7 +2339,7 @@
         },
         {
             "id": "f1dcaea8-e6b3-5580-9660-3736d7060e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bf3c19-f148-4542-8505-604191fd5a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bf3c19-f148-4542-8505-604191fd5a02.jpg?1",
             "name": "Mind Sludge",
             "text": "Target player discards a card from his or her hand for each swamp you control.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "ea852198-b417-5208-b049-965d625f6726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21146226-ff05-40d5-bc4e-42f2263104b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21146226-ff05-40d5-bc4e-42f2263104b1.jpg?1",
             "name": "Mortal Combat",
             "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "0d8a104e-4254-59dc-b494-5f56402faa18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b93caa-0f43-43ac-84e9-99f6bcbf9e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b93caa-0f43-43ac-84e9-99f6bcbf9e81.jpg?1",
             "name": "Mortiphobia",
             "text": "o1o\nB, Discard a card from your hand: Remove target card in a graveyard from the game.\no1o\nB, Sacrifice Mortiphobia: Remove target card in a graveyard from the game.",
             "colours": [
@@ -2435,7 +2435,7 @@
         },
         {
             "id": "a8f0ce54-9847-5e65-8fcd-3040a7418828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6189cab3-1963-4590-9cbc-7ab4a693d7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6189cab3-1963-4590-9cbc-7ab4a693d7c6.jpg?1",
             "name": "Mutilate",
             "text": "All creatures get -1/-1 until end of turn for each swamp you control.",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "dd8a801e-f880-548f-8d7a-5c9bd2d4f5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed9dc9c-b92b-4305-8c54-1a63f750f8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed9dc9c-b92b-4305-8c54-1a63f750f8d1.jpg?1",
             "name": "Nantuko Shade",
             "text": "o\nB: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "bc2ea9b7-1007-562c-bafe-341c729008a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6233d4c3-9407-41b0-92a9-5f90dfd6a584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6233d4c3-9407-41b0-92a9-5f90dfd6a584.jpg?1",
             "name": "Organ Grinder",
             "text": "oc\nT, Remove three cards in your graveyard from the game: Target player loses 3 life.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "e2ee3a3f-3025-56e7-8742-a7085d65531b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3f6cd2-0138-40e7-a975-3f7c68db0d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3f6cd2-0138-40e7-a975-3f7c68db0d93.jpg?1",
             "name": "Psychotic Haze",
             "text": "Psychotic Haze deals 1 damage to each creature and each player.\nMadness o1o\nB (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "2b3144bc-c36e-5269-886b-114b16f91893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e6c5c-4bc4-4f41-8c2c-f5b8c97c53c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e6c5c-4bc4-4f41-8c2c-f5b8c97c53c5.jpg?1",
             "name": "Putrid Imp",
             "text": "Discard a card from your hand: Putrid Imp gains flying until end of turn.\nThreshold Putrid Imp gets +1/+1 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "8f6ec1be-a0bf-566c-a1ee-b1ab090dc701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d07a96-85ba-4714-94a5-4a8125954f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d07a96-85ba-4714-94a5-4a8125954f58.jpg?1",
             "name": "Rancid Earth",
             "text": "Destroy target land.\nThreshold Instead destroy that land and Rancid Earth deals 1 damage to each creature and each player. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "abceaf8b-c9e6-5eef-b8c9-38be124bc7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63795680-5310-4c99-92c1-70e453391de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63795680-5310-4c99-92c1-70e453391de9.jpg?1",
             "name": "Restless Dreams",
             "text": "As an additional cost to play Restless Dreams, discard X cards from your hand.\nReturn X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "16409fb6-a1d0-5fe7-8169-9e975490210a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2308c0c4-7a78-4da8-8dd8-5b35b49a1896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2308c0c4-7a78-4da8-8dd8-5b35b49a1896.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn is put into a graveyard, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "a7114daf-eee0-5326-93cb-c1c1ad5cbf68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449baad3-9a4a-4f5f-9e9f-02cc97ab71e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449baad3-9a4a-4f5f-9e9f-02cc97ab71e6.jpg?1",
             "name": "Shade's Form",
             "text": "Enchanted creature has \"o\nB: This creature gets +1/+1 until end of turn.\"\nWhen enchanted creature is put into a graveyard, return that creature to play under your control.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "63254f5b-a7ee-540f-8296-8935fe0c6389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b93715-985f-4719-a3c3-044c2a150e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b93715-985f-4719-a3c3-044c2a150e96.jpg?1",
             "name": "Shambling Swarm",
             "text": "When Shambling Swarm is put into a graveyard from play, distribute three -1/-1 counters among one, two, or three target creatures. Remove those counters at end of turn.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "c5b09b6c-5252-5740-8de1-8b9b0d37f2e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9396ac77-9f53-46bd-b126-02441a0f5594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9396ac77-9f53-46bd-b126-02441a0f5594.jpg?1",
             "name": "Sickening Dreams",
             "text": "As an additional cost to play Sickening Dreams, discard X cards from your hand.\nSickening Dreams deals X damage to each creature and each player.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "989060b0-a72d-5936-a287-e94701f05e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c875bb6-55bb-41cc-8825-8011581ff001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c875bb6-55bb-41cc-8825-8011581ff001.jpg?1",
             "name": "Slithery Stalker",
             "text": "Swampwalk\nWhen Slithery Stalker comes into play, remove target green or white creature an opponent controls from the game.\nWhen Slithery Stalker leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "5766dd59-450c-518c-9dd5-dcbaaff2b734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7d91b-cfbb-4da0-97fa-3c0a15f1dbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7d91b-cfbb-4da0-97fa-3c0a15f1dbb9.jpg?1",
             "name": "Soul Scourge",
             "text": "Flying\nWhen Soul Scourge comes into play, target player loses 3 life.\nWhen Soul Scourge leaves play, that player gains 3 life.",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "48368a13-87b7-53b1-ae7f-112abcccac04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afda26e7-4fdd-45e1-bcd1-f0abf91979aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afda26e7-4fdd-45e1-bcd1-f0abf91979aa.jpg?1",
             "name": "Strength of Lunacy",
             "text": "Enchanted creature gets +2/+1 and has protection from white.\nMadness o\nB (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "05ac49fe-e971-557f-be97-387837f991ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89deafd-cb7c-4da7-ab9b-8f795554a705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89deafd-cb7c-4da7-ab9b-8f795554a705.jpg?1",
             "name": "Unhinge",
             "text": "Target player discards a card from his or her hand.\nDraw a card.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "b016c395-47e6-5a94-88af-3e554fcab6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e859c2-3457-4c4c-9b1c-0db647dcf259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e859c2-3457-4c4c-9b1c-0db647dcf259.jpg?1",
             "name": "Waste Away",
             "text": "As an additional cost to play Waste Away, discard a card from your hand.\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "52d19dcf-afe7-56ac-9b20-e5d8842ff71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4675f-ebec-483f-a111-b505629760fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4675f-ebec-483f-a111-b505629760fd.jpg?1",
             "name": "Zombie Trailblazer",
             "text": "Tap an untapped Zombie you control: Target land becomes a swamp until end of turn.\nTap an untapped Zombie you control: Target creature gains swampwalk until end of turn.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "63c421f3-b215-5f52-82b5-74300e2a5ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a28dd88-db90-4f02-8aa9-39051d2c4763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a28dd88-db90-4f02-8aa9-39051d2c4763.jpg?1",
             "name": "Accelerate",
             "text": "Target creature gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "106af149-efa9-51ae-8ae6-abdd46ac1a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecdc5-d2c7-4292-9b59-fd6bf3ba29d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecdc5-d2c7-4292-9b59-fd6bf3ba29d5.jpg?1",
             "name": "Balthor the Stout",
             "text": "All Barbarians get +1/+1.\no\nR: Target Barbarian gets +1/+0 until end of turn.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "9a1dda5d-6cc4-56f0-8778-adc95a352787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d67b5c-ab20-456e-8ff5-7521be8273b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d67b5c-ab20-456e-8ff5-7521be8273b2.jpg?1",
             "name": "Barbarian Outcast",
             "text": "When you control no swamps, sacrifice Barbarian Outcast.",
             "colours": [
@@ -3109,7 +3109,7 @@
         },
         {
             "id": "f4131788-1a62-5b26-8abf-e5a32f0348d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810f7e3-03ff-4c46-a88f-2f8144540780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810f7e3-03ff-4c46-a88f-2f8144540780.jpg?1",
             "name": "Crackling Club",
             "text": "Enchanted creature gets +1/+0.\nSacrifice Crackling Club: Crackling Club deals 1 damage to target creature.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "e2046740-daff-5234-8cbc-0b65f7807c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef809de-ff64-4832-95dd-2ebda5942df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef809de-ff64-4832-95dd-2ebda5942df8.jpg?1",
             "name": "Crazed Firecat",
             "text": "When Crazed Firecat comes into play, flip a coin until you lose a flip. Put a +1/+1 counter on Crazed Firecat for each flip you win.",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "b0ff65aa-9350-5432-9c7c-0658ecbd626d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fffeed0-a5ea-47ac-a7a4-0cc3bb1d408a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fffeed0-a5ea-47ac-a7a4-0cc3bb1d408a.jpg?1",
             "name": "Devastating Dreams",
             "text": "As an additional cost to play Devastating Dreams, discard X cards at random from your hand.\nEach player sacrifices X lands. Devastating Dreams deals X damage to each creature.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "d902e008-29eb-5815-a4da-2aa3c3ce94c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5003a6-211e-43d3-9a3c-756496357163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5003a6-211e-43d3-9a3c-756496357163.jpg?1",
             "name": "Enslaved Dwarf",
             "text": "o\nR, Sacrifice Enslaved Dwarf: Target black creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "5b6fc518-5813-5bef-ab8e-c44b1b0f21d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918e46b7-cbca-4acf-8e83-94b5fcadcc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918e46b7-cbca-4acf-8e83-94b5fcadcc49.jpg?1",
             "name": "Fiery Temper",
             "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness o\nR (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "4eb9ace4-8006-5cc9-93fd-902073549fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7fd9b7-c394-4ab3-b945-b4aab694eb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7fd9b7-c394-4ab3-b945-b4aab694eb6a.jpg?1",
             "name": "Flaming Gambit",
             "text": "Flaming Gambit deals X damage to target player. That player may choose a creature he or she controls and have Flaming Gambit deal that damage to it instead.\nFlashback o\nXo\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "8db065b8-01ed-5b51-a9d0-afd0578a7f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e550776-b806-4f66-8aab-e6a5dac6d5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e550776-b806-4f66-8aab-e6a5dac6d5cc.jpg?1",
             "name": "Flash of Defiance",
             "text": "Players can't block with green and/or white creatures this turn.\nFlashback\u2014o1o\nR, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "dffe11c6-c922-560b-a7d0-a87b5f594baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd72697-24be-42c7-a6d9-a837bdbd4662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd72697-24be-42c7-a6d9-a837bdbd4662.jpg?1",
             "name": "Grim Lavamancer",
             "text": "o\nR, oc\nT, Remove two cards in your graveyard from the game: Grim Lavamancer deals 2 damage to target creature or player.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "bd6bbd55-0507-5c2a-9435-a170a5b09698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41ac1c-2603-4234-8963-cd47bb894024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41ac1c-2603-4234-8963-cd47bb894024.jpg?1",
             "name": "Hell-Bent Raider",
             "text": "First strike, haste\nDiscard a card at random from your hand: Hell-Bent Raider gains protection from white until end of turn.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "ed777d42-0c42-52d7-a3aa-ee53b9befa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c55518-7bdf-4a42-ae30-cd6525557a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c55518-7bdf-4a42-ae30-cd6525557a59.jpg?1",
             "name": "Kamahl's Sledge",
             "text": "Kamahl's Sledge deals 4 damage to target creature.\nThreshold Instead Kamahl's Sledge deals 4 damage to that creature and 4 damage to that creature's controller. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "7e49f29b-f0b3-573a-aa0a-541853ddb78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0dcf33-8d3f-429c-8ad8-a65d07d7c790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0dcf33-8d3f-429c-8ad8-a65d07d7c790.jpg?1",
             "name": "Longhorn Firebeast",
             "text": "When Longhorn Firebeast comes into play, any opponent may have it deal 5 damage to him or her. If a player does, sacrifice Longhorn Firebeast.",
             "colours": [
@@ -3478,7 +3478,7 @@
         },
         {
             "id": "5eddb334-6cf2-50ac-b25f-d0caaf61b258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2e0f0-8a8e-4021-bd24-aff1a3212345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2e0f0-8a8e-4021-bd24-aff1a3212345.jpg?1",
             "name": "Overmaster",
             "text": "The next instant or sorcery spell you play this turn can't be countered by spells or abilities.\nDraw a card.",
             "colours": [
@@ -3510,7 +3510,7 @@
         },
         {
             "id": "988e9471-589f-595d-95b7-621de9007955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2538fa-2eb7-47ca-a1cf-e5546e26e584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2538fa-2eb7-47ca-a1cf-e5546e26e584.jpg?1",
             "name": "Pardic Arsonist",
             "text": "Threshold When Pardic Arsonist comes into play, it deals 3 damage to target creature or player. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3545,7 +3545,7 @@
         },
         {
             "id": "19ddbe76-0037-511e-900f-329a182026a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a60f33-1d1a-4c7c-9eb2-d9fc0d56b127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a60f33-1d1a-4c7c-9eb2-d9fc0d56b127.jpg?1",
             "name": "Pardic Collaborator",
             "text": "First strike\no\nB: Pardic Collaborator gets +1/+1 until end of turn.",
             "colours": [
@@ -3581,7 +3581,7 @@
         },
         {
             "id": "475599f4-d6fd-5e0c-aa8e-2d3ecc370055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487a6a7-066a-49bb-ab76-d79fc4300c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487a6a7-066a-49bb-ab76-d79fc4300c29.jpg?1",
             "name": "Pardic Lancer",
             "text": "Discard a card at random from your hand: Pardic Lancer gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "a527f2a8-656e-53fe-a0a7-e1274895af0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac6311-8516-4db2-8c1f-626f0db0d36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac6311-8516-4db2-8c1f-626f0db0d36f.jpg?1",
             "name": "Petradon",
             "text": "When Petradon comes into play, remove two target lands from the game.\nWhen Petradon leaves play, return the removed cards to play under their owners' control.\no\nR: Petradon gets +1/+0 until end of turn.",
             "colours": [
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "38c8bbf7-b63c-55eb-b6c8-31feecfbf7be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc98d09-439e-426b-8403-4a3e12167336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc98d09-439e-426b-8403-4a3e12167336.jpg?1",
             "name": "Petravark",
             "text": "When Petravark comes into play, remove target land from the game.\nWhen Petravark leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "7297032b-c487-5ec5-95d8-f6f27fb90def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfea263-6ff0-41be-9755-03bcdebfb255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfea263-6ff0-41be-9755-03bcdebfb255.jpg?1",
             "name": "Pitchstone Wall",
             "text": "(Walls can't attack.)\nWhenever you discard a card from your hand, you may sacrifice Pitchstone Wall. If you do, return the discarded card from your graveyard to your hand.",
             "colours": [
@@ -3720,7 +3720,7 @@
         },
         {
             "id": "b176c4bd-74a3-51a4-b223-930edf3e81fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e79610-8cfe-4711-bc71-8c25d68036da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e79610-8cfe-4711-bc71-8c25d68036da.jpg?1",
             "name": "Possessed Barbarian",
             "text": "First strike\nThreshold Possessed Barbarian gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target red creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "49a12b66-156a-50a6-8058-b29da5cde6f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5af4e9-a2b6-43c7-8ff4-e761fbf693a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5af4e9-a2b6-43c7-8ff4-e761fbf693a7.jpg?1",
             "name": "Pyromania",
             "text": "o1o\nR, Discard a card at random from your hand: Pyromania deals 1 damage to target creature or player.\no1o\nR, Sacrifice Pyromania: Pyromania deals 1 damage to target creature or player.",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "fa1c13c4-3989-5d83-9e27-c6b0ee423183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2562c25a-999e-4fb5-a595-f376c8abf1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2562c25a-999e-4fb5-a595-f376c8abf1ff.jpg?1",
             "name": "Radiate",
             "text": "Choose target instant or sorcery spell that targets only a single permanent or player. For each other permanent or player that spell could target, put a copy of the spell onto the stack. Each copy targets a different one of those permanents and players.",
             "colours": [
@@ -3821,7 +3821,7 @@
         },
         {
             "id": "80d91e47-765f-5895-8ed3-b62319ce17f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f1343c-77bf-4f44-8226-fdfb2c2c7015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f1343c-77bf-4f44-8226-fdfb2c2c7015.jpg?1",
             "name": "Skullscorch",
             "text": "Target player discards two cards at random from his or her hand unless that player has Skullscorch deal 4 damage to him or her.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "1b4cd2f6-e517-5379-9841-9fb78d80f289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98eb9371-aa20-4790-baf8-a1ad95de39de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98eb9371-aa20-4790-baf8-a1ad95de39de.jpg?1",
             "name": "Sonic Seizure",
             "text": "As an additional cost to play Sonic Seizure, discard a card at random from your hand.\nSonic Seizure deals 3 damage to target creature or player.",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "5c63e915-0e02-5b2e-ab25-1c6fff519046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415d0678-539f-4c19-8a6e-b43e747a97de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415d0678-539f-4c19-8a6e-b43e747a97de.jpg?1",
             "name": "Temporary Insanity",
             "text": "Untap target creature with power less than the number of cards in your graveyard and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "ff666c15-0491-520f-b264-3a2986b10362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff19c870-331d-4703-a92d-c5b1d4289338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff19c870-331d-4703-a92d-c5b1d4289338.jpg?1",
             "name": "Violent Eruption",
             "text": "Violent Eruption deals 4 damage divided as you choose among any number of target creatures and/or players.\nMadness o1o\nRo\nR (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "1abe8b04-69c4-5f90-af2c-5f3868a2c89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32987720-cc0c-416b-b79b-217d3b37542d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32987720-cc0c-416b-b79b-217d3b37542d.jpg?1",
             "name": "Acorn Harvest",
             "text": "Put two 1/1 green Squirrel creature tokens into play.\nFlashback\u2014o1o\nG, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "3bbe2a88-8983-5b7b-8aa8-ac90210289e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a21190-3c05-40fe-9310-493ed0f9e42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a21190-3c05-40fe-9310-493ed0f9e42e.jpg?1",
             "name": "Anurid Scavenger",
             "text": "Protection from black\nAt the beginning of your upkeep, sacrifice Anurid Scavenger unless you put a card from your graveyard on the bottom of your library.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "7248c346-3952-5cd8-9717-174224fe4f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b849c7-c91d-4c67-a357-f7d17f9b187a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b849c7-c91d-4c67-a357-f7d17f9b187a.jpg?1",
             "name": "Arrogant Wurm",
             "text": "Trample\nMadness o2o\nG (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "e8e569e1-993c-5c44-b2ca-1a76e0bcfb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67768a-6cd9-4163-b941-752f29c87a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67768a-6cd9-4163-b941-752f29c87a8d.jpg?1",
             "name": "Basking Rootwalla",
             "text": "o1o\nG: Basking Rootwalla gets +2/+2 until end of turn. Play this ability only once each turn.\nMadness o0 (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "9d00e2a7-604e-52a9-8417-c92a00f88f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fa0a57-e7eb-454e-9527-3db702b54935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fa0a57-e7eb-454e-9527-3db702b54935.jpg?1",
             "name": "Centaur Chieftain",
             "text": "Haste\nThreshold When Centaur Chieftain comes into play, creatures you control get +1/+1 and gain trample until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "b8dff7c3-d5be-543f-b9ea-2c4a563743c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83903c1-40fe-47a5-8bcc-2f0877c58225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83903c1-40fe-47a5-8bcc-2f0877c58225.jpg?1",
             "name": "Centaur Veteran",
             "text": "Trample\no\nG, Discard a card from your hand: Regenerate Centaur Veteran.",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "908b7e06-78e0-5495-bb55-c92cd41ab886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ac905a-839b-4fb5-8c17-7fd6c2c0c492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ac905a-839b-4fb5-8c17-7fd6c2c0c492.jpg?1",
             "name": "Dwell on the Past",
             "text": "Target player shuffles up to four target cards from his or her graveyard into his or her library.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "56dfb15c-6075-5802-ab33-75a8087c0080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3a735a-5f51-41af-99d1-92296cec7b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3a735a-5f51-41af-99d1-92296cec7b22.jpg?1",
             "name": "Far Wanderings",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.\nThreshold Instead search your library for three basic land cards and put them into play tapped. Then shuffle your library. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "f18cd46b-b364-5825-92c6-53dd633cb5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e672c6-6ddc-4dd2-b4c7-5083d7566e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e672c6-6ddc-4dd2-b4c7-5083d7566e87.jpg?1",
             "name": "Gurzigost",
             "text": "At the beginning of your upkeep, sacrifice Gurzigost unless you put two cards from your graveyard on the bottom of your library.\no\nGo\nG, Discard a card from your hand: You may have Gurzigost deal its combat damage to defending player this turn as though it weren't blocked.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "bfeb3ac2-3de7-509c-8f6d-f32aee83c139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1f72d-ef5e-4cea-a0ee-645570a36104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1f72d-ef5e-4cea-a0ee-645570a36104.jpg?1",
             "name": "Insist",
             "text": "The next creature spell you play this turn can't be countered by spells or abilities.\nDraw a card.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "70feeeae-10b1-5969-9c2c-a0098ac2a24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec74e797-390e-4ebd-a53b-098ef3edd7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec74e797-390e-4ebd-a53b-098ef3edd7d1.jpg?1",
             "name": "Invigorating Falls",
             "text": "You gain life equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "d2ca9cac-8d4d-536f-844f-c4dcae200843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b3479-18c3-4c43-b8d1-8b4a25d271a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b3479-18c3-4c43-b8d1-8b4a25d271a7.jpg?1",
             "name": "Krosan Constrictor",
             "text": "Swampwalk\noc\nT: Target black creature gets -2/-0 until end of turn.",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "30d87966-33f2-505c-a6b7-df6f3593c1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f9f54d-b8c7-407d-bc25-dad4db833208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f9f54d-b8c7-407d-bc25-dad4db833208.jpg?1",
             "name": "Krosan Restorer",
             "text": "oc\nT: Untap target land.\nThreshold oc\nT: Untap up to three target lands. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "7b115352-628b-5e26-b4d5-71b5b0ecd657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a6f1b6-e1ed-497a-b50e-1bfa257c18c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a6f1b6-e1ed-497a-b50e-1bfa257c18c0.jpg?1",
             "name": "Nantuko Blightcutter",
             "text": "Protection from black\nThreshold Nantuko Blightcutter gets +1/+1 for each black permanent your opponents control. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "4c8b8e7e-c1ac-5e51-b505-429ed98dc7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b1198-feff-437c-9d4c-94785144c98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b1198-feff-437c-9d4c-94785144c98f.jpg?1",
             "name": "Nantuko Calmer",
             "text": "o\nG, oc\nT, Sacrifice Nantuko Calmer: Destroy target enchantment.\nThreshold Nantuko Calmer gets +1/+1. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "c3db5cd9-0568-5af8-a4e1-547aa1122491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d258fe7-7906-43ca-8ebd-344aa81cb85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d258fe7-7906-43ca-8ebd-344aa81cb85b.jpg?1",
             "name": "Nantuko Cultivator",
             "text": "When Nantuko Cultivator comes into play, you may discard any number of land cards from your hand. Put that many +1/+1 counters on Nantuko Cultivator and draw that many cards.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "c3158763-e39d-5b9b-a518-6f26087f70dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea658dd-7567-4b93-88a4-08b4ffb3dad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea658dd-7567-4b93-88a4-08b4ffb3dad7.jpg?1",
             "name": "Narcissism",
             "text": "o\nG, Discard a card from your hand: Target creature gets +2/+2 until end of turn.\no\nG, Sacrifice Narcissism: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "73eb451f-925c-536a-a490-2d3bb532b839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1e794-a32e-4f91-acbb-7e60dad4cf53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1e794-a32e-4f91-acbb-7e60dad4cf53.jpg?1",
             "name": "Nostalgic Dreams",
             "text": "As an additional cost to play Nostalgic Dreams, discard X cards from your hand.\nReturn X target cards from your graveyard to your hand. Remove Nostalgic Dreams from the game.",
             "colours": [
@@ -4552,7 +4552,7 @@
         },
         {
             "id": "1bb0806a-46d6-501f-9f8e-f03fd42391c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cce010-a8e7-477b-9179-bbad38aa6438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cce010-a8e7-477b-9179-bbad38aa6438.jpg?1",
             "name": "Parallel Evolution",
             "text": "For each creature token in play, its controller puts a creature token into play that's a copy of that creature.\nFlashback o4o\nGo\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "71fabf1e-b2b7-5ec9-9a98-12ef81fb3c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e11b2-9636-48a0-8705-f5ce3bc98117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e11b2-9636-48a0-8705-f5ce3bc98117.jpg?1",
             "name": "Possessed Centaur",
             "text": "Trample\nThreshold Possessed Centaur gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target green creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "70a30893-d11b-50a7-83ef-2be0cf5837a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732bf7bb-5326-4742-8311-96ddbfe14b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732bf7bb-5326-4742-8311-96ddbfe14b38.jpg?1",
             "name": "Seton's Scout",
             "text": "Seton's Scout may block as though it had flying.\nThreshold Seton's Scout gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "53a58169-e2c5-5191-a125-87353eb951c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b934c78-258e-4b1e-9783-ec9f734e8776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b934c78-258e-4b1e-9783-ec9f734e8776.jpg?1",
             "name": "Cabal Coffers",
             "text": "o2, oc\nT: Add o\nB to your mana pool for each swamp you control.",
             "colours": [],
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "40698409-a9af-53b7-850d-4411fe01fe49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b5f0aa-1570-4064-ad20-aac7be8b2c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b5f0aa-1570-4064-ad20-aac7be8b2c9c.jpg?1",
             "name": "Tainted Field",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nB to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],
@@ -4718,7 +4718,7 @@
         },
         {
             "id": "cc9dc60e-4b34-5477-8e5d-24a5c8cfc238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b462e121-015c-49c4-838a-ab788f213322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b462e121-015c-49c4-838a-ab788f213322.jpg?1",
             "name": "Tainted Isle",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "a2684ded-4874-5516-9398-96182a6c50ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcaaabe-e1d7-4047-9960-79178af3d903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcaaabe-e1d7-4047-9960-79178af3d903.jpg?1",
             "name": "Tainted Peak",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "d352b51b-fc4e-5926-b674-aa0871efe326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20a35cc-69e5-42b8-b28c-ae5147451150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20a35cc-69e5-42b8-b28c-ae5147451150.jpg?1",
             "name": "Tainted Wood",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nG to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],

--- a/Assets/Resources/Sets/TSP.json
+++ b/Assets/Resources/Sets/TSP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "02ea741e-e664-50ea-b4c6-f461870d309a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e05e5-1340-4010-b39b-3571a5829840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e05e5-1340-4010-b39b-3571a5829840.jpg?1",
             "name": "Amrou Scout",
             "text": "{4}, {T}: Search your library for a Rebel card with converted mana cost 3 or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "1268e445-d62c-51cb-9b12-db98607e628d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc2a06d-54f7-436f-b32a-4a8daa199fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc2a06d-54f7-436f-b32a-4a8daa199fb8.jpg?1",
             "name": "Amrou Seekers",
             "text": "Amrou Seekers can't be blocked except by artifact creatures and/or white creatures.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "9c640706-0239-5838-82eb-a96b95991799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580cb5be-fa59-4eb9-8808-7d2943fb6413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580cb5be-fa59-4eb9-8808-7d2943fb6413.jpg?1",
             "name": "Angel's Grace",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "f77a31eb-1f7b-53e5-9aa2-0d0ccc9cca76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013ca9c-1d29-42f6-8665-92f98d076ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013ca9c-1d29-42f6-8665-92f98d076ff8.jpg?1",
             "name": "Benalish Cavalry",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "03068b2b-e046-5513-92fd-7aa5d52461f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a3ed1e-f07e-486d-8a44-b2fbfaffa547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a3ed1e-f07e-486d-8a44-b2fbfaffa547.jpg?1",
             "name": "Castle Raptors",
             "text": "Flying\nAs long as Castle Raptors is untapped, it gets +0/+2.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "b00e4490-e8d4-5e06-a499-06de84ef8e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b19194-87bf-432c-8d34-91dd9520cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b19194-87bf-432c-8d34-91dd9520cbd2.jpg?1",
             "name": "Cavalry Master",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nOther creatures you control with flanking have flanking. (Each instance of flanking triggers separately.)",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "eb1b5c04-f308-52ca-8b5a-b56d97395eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5624d6-2c27-4c7a-8001-73edb2512ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5624d6-2c27-4c7a-8001-73edb2512ffb.jpg?1",
             "name": "Celestial Crusader",
             "text": "Flash (You may play this spell any time you could play an instant.)\nSplit second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nFlying\nOther white creatures get +1/+1.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "8c6f6243-ffc5-5210-a777-24cc9df527ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221a5895-bc21-4f10-b5fc-a4980fde843e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221a5895-bc21-4f10-b5fc-a4980fde843e.jpg?1",
             "name": "Children of Korlis",
             "text": "Sacrifice Children of Korlis: You gain life equal to the life you've lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "4792926b-ba4f-5187-9246-1df1eb7c5301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg?1",
             "name": "Chronosavant",
             "text": "{1}{W}: Return Chronosavant from your graveyard to play tapped. Skip your next turn.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "0282a355-bff6-5569-902e-56801267b806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87003295-fd7c-489a-b724-b76eef187b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87003295-fd7c-489a-b724-b76eef187b57.jpg?1",
             "name": "Cloudchaser Kestrel",
             "text": "Flying\nWhen Cloudchaser Kestrel comes into play, destroy target enchantment.\n{W}: Target permanent becomes white until end of turn.",
             "colours": [
@@ -350,7 +350,7 @@
         },
         {
             "id": "327b2381-717a-55fc-8007-3dd570fc1924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deac6492-ce39-4137-8418-6169d3b1b632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deac6492-ce39-4137-8418-6169d3b1b632.jpg?1",
             "name": "D'Avenant Healer",
             "text": "{T}: D'Avenant Healer deals 1 damage to target attacking or blocking creature.\n{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "6303ad80-f33f-5748-9e02-af10c3ef2e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c467446b-0168-4c7d-9ab6-57ad8b664877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c467446b-0168-4c7d-9ab6-57ad8b664877.jpg?1",
             "name": "Detainment Spell",
             "text": "Enchant creature\nEnchanted creature's activated abilities can't be played.\n{1}{W}: Attach Detainment Spell to target creature.",
             "colours": [
@@ -420,7 +420,7 @@
         },
         {
             "id": "86a3bc81-54b7-527c-9b67-b44bf925e502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f781071-e9bc-49ee-ac94-23490134b909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f781071-e9bc-49ee-ac94-23490134b909.jpg?1",
             "name": "Divine Congregation",
             "text": "You gain 2 life for each creature target player controls.\nSuspend 5\u2014{1}{W} (Rather than play this card from your hand, you may pay {1}{W} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "7a8177dc-e2be-51f1-b6a8-31ef2c248ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfad8c3e-e459-477c-b602-34df2dda1efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfad8c3e-e459-477c-b602-34df2dda1efe.jpg?1",
             "name": "Duskrider Peregrine",
             "text": "Flying, protection from black\nSuspend 3\u2014{1}{W} (Rather than play this card from your hand, you may pay {1}{W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "f24b13a6-1fe2-5f87-8333-7a54ef1358ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a2daf3-4d66-43f8-beda-285d85eefb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a2daf3-4d66-43f8-beda-285d85eefb57.jpg?1",
             "name": "Errant Doomsayers",
             "text": "{T}: Tap target creature with toughness 2 or less.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "9fd2b5b0-c33f-5eb4-9f9d-eb8216d3cd22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f58e1aa-587c-4f89-9552-1128c8c2da1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f58e1aa-587c-4f89-9552-1128c8c2da1a.jpg?1",
             "name": "Evangelize",
             "text": "Buyback {2}{W}{W} (You may pay an additional {2}{W}{W} as you play this spell. If you do, put this card into your hand as it resolves.)\nGain control of target creature of an opponent's choice that he or she controls.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "75f5a742-7cda-51bd-ba35-8a8a85b7e8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ef9188-737e-4cc6-b3a5-95aafddcf665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ef9188-737e-4cc6-b3a5-95aafddcf665.jpg?1",
             "name": "Flickering Spirit",
             "text": "Flying\n{3}{W}: Remove Flickering Spirit from the game, then return it to play under its owner's control.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "f1e85810-372e-578c-941d-4b6403090214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a3622-9f24-47a3-816f-1732c0e077d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a3622-9f24-47a3-816f-1732c0e077d0.jpg?1",
             "name": "Foriysian Interceptor",
             "text": "Flash (You may play this spell any time you could play an instant.)\nDefender\nForiysian Interceptor can block an additional creature.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "b98593b7-b009-5258-8898-2e7bfdc4245d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd063dc7-a35c-44c9-9f8d-b7bb2dc95bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd063dc7-a35c-44c9-9f8d-b7bb2dc95bec.jpg?1",
             "name": "Fortify",
             "text": "Choose one Creatures you control get +2/+0 until end of turn; or creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -654,7 +654,7 @@
         },
         {
             "id": "da8b32da-1f29-5527-b2cd-ba9d7894248d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d565ec-541d-429e-ab45-58db16c2f41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d565ec-541d-429e-ab45-58db16c2f41d.jpg?1",
             "name": "Gaze of Justice",
             "text": "As an additional cost to play Gaze of Justice, tap three untapped white creatures you control.\nRemove target creature from the game.\nFlashback {5}{W} (You may play this card from your graveyard for its flashback cost and any additional costs. Then remove it from the game.)",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "65622ec4-7a56-5d54-84ce-1d77ffdbe89b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a15d9-5899-4b84-9c00-345b19df53ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a15d9-5899-4b84-9c00-345b19df53ae.jpg?1",
             "name": "Griffin Guide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\nWhen enchanted creature is put into a graveyard, put a 2/2 white Griffin creature token with flying into play.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "cc9c36dd-ae06-5596-b4a9-1ac3a77720cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36a5462-3a21-4d64-af92-b541b425cdf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36a5462-3a21-4d64-af92-b541b425cdf5.jpg?1",
             "name": "Gustcloak Cavalier",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nWhenever Gustcloak Cavalier attacks, you may tap target creature.\nWhenever Gustcloak Cavalier becomes blocked, you may untap Gustcloak Cavalier and remove it from combat.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "d99f6925-4e48-5b22-bb70-ce140dbe5240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab784-c77e-4b78-99fc-b5d7ed985d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab784-c77e-4b78-99fc-b5d7ed985d76.jpg?1",
             "name": "Icatian Crier",
             "text": "{1}{W}, {T}, Discard a card: Put two 1/1 white Citizen creature tokens into play.",
             "colours": [
@@ -790,7 +790,7 @@
         },
         {
             "id": "6df674bc-b4b1-552a-a44d-a323df294a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb30d9-a826-4f29-ae2a-6873997674a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb30d9-a826-4f29-ae2a-6873997674a7.jpg?1",
             "name": "Ivory Giant",
             "text": "When Ivory Giant comes into play, tap all nonwhite creatures.\nSuspend 5\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "fa0d2e4d-5de3-5b3d-a258-a41c86140e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29cc9e5-29b7-4e3c-a0cd-46265b0f74ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29cc9e5-29b7-4e3c-a0cd-46265b0f74ac.jpg?1",
             "name": "Jedit's Dragoons",
             "text": "Vigilance\nWhen Jedit's Dragoons comes into play, you gain 4 life.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "4a124488-10d0-5e62-9f93-01557b1a5e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdeb716-4632-4895-b771-0ebd59c868d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdeb716-4632-4895-b771-0ebd59c868d5.jpg?1",
             "name": "Knight of the Holy Nimbus",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Knight of the Holy Nimbus would be destroyed, regenerate it.\n{2}: Knight of the Holy Nimbus can't be regenerated this turn. Only any opponent may play this ability.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "876804d2-412b-51d3-bcd5-06e143bd09cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febbea40-74c7-431f-a88f-c15d4fdda89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febbea40-74c7-431f-a88f-c15d4fdda89d.jpg?1",
             "name": "Magus of the Disk",
             "text": "Magus of the Disk comes into play tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "2191f4f3-7c5a-5086-b5fd-bdf4f90ec9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785b66c-c5a4-4520-a9fa-aa199f7f56e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785b66c-c5a4-4520-a9fa-aa199f7f56e5.jpg?1",
             "name": "Mangara of Corondor",
             "text": "{T}: Remove Mangara of Corondor and target permanent from the game.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "d1cde194-b455-58cc-bb71-445e0e37cea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e072a-0630-472b-9106-5df554dff785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e072a-0630-472b-9106-5df554dff785.jpg?1",
             "name": "Momentary Blink",
             "text": "Remove target creature you control from the game, then return it to play under its owner's control.\nFlashback {3}{U} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1000,7 +1000,7 @@
         },
         {
             "id": "4e4ef91a-928b-5633-8146-1e91a06d4927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905ad286-e70b-46cd-87fd-eec13ed2d43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905ad286-e70b-46cd-87fd-eec13ed2d43b.jpg?1",
             "name": "Opal Guardian",
             "text": "When an opponent plays a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "0f005ec2-44b6-51d7-a961-6f4d84e2d536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e0d923-d94f-4f12-a025-86587b18878f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e0d923-d94f-4f12-a025-86587b18878f.jpg?1",
             "name": "Outrider en-Kor",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n{0}: The next 1 damage that would be dealt to Outrider en-Kor this turn is dealt to target creature you control instead.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "e3588be2-6477-55d8-abe9-38ba7242100d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced01039-e19f-466b-bbc6-9bcb8d3ae845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced01039-e19f-466b-bbc6-9bcb8d3ae845.jpg?1",
             "name": "Pentarch Paladin",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nAs Pentarch Paladin comes into play, choose a color.\n{W}{W}, {T}: Destroy target permanent of the chosen color.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "b56689fd-ad95-5a98-a5d5-5055b510fcf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c70894-dd4a-4cbb-b3c1-57135cc151a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c70894-dd4a-4cbb-b3c1-57135cc151a9.jpg?1",
             "name": "Pentarch Ward",
             "text": "Enchant creature\nAs Pentarch Ward comes into play, choose a color.\nWhen Pentarch Ward comes into play, draw a card.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Pentarch Ward.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "25d8fbc9-105b-5c69-8065-0fc97655102c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873fddf3-40e7-41ee-9519-98d0a5268fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873fddf3-40e7-41ee-9519-98d0a5268fd1.jpg?1",
             "name": "Plated Pegasus",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nIf a spell would deal damage to a creature or player, prevent 1 damage that spell would deal to that creature or player.",
             "colours": [
@@ -1171,7 +1171,7 @@
         },
         {
             "id": "e288597d-1db2-5a73-92d5-b9ab864f77a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d218091-d218-41ad-b666-c8ab3de7160a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d218091-d218-41ad-b666-c8ab3de7160a.jpg?1",
             "name": "Pull from Eternity",
             "text": "Put target face-up card that's removed from the game into its owner's graveyard.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "99079e5a-0996-5142-9c21-c64fb0506373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c19d42-aaaf-417c-a303-74262f82e365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c19d42-aaaf-417c-a303-74262f82e365.jpg?1",
             "name": "Pulmonic Sliver",
             "text": "All Slivers have flying and \"If this creature would be put into a graveyard, you may put it on top of its owner's library instead.\"",
             "colours": [
@@ -1237,7 +1237,7 @@
         },
         {
             "id": "6c7dea4a-943f-5ca3-b4cb-38c1407b6c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72486240-eabb-4b37-99cc-ab13413683fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72486240-eabb-4b37-99cc-ab13413683fa.jpg?1",
             "name": "Quilled Sliver",
             "text": "All Slivers have \"{T}: This creature deals 1 damage to target attacking or blocking creature.\"",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "021880ef-1f06-5da0-9542-e56c253a6e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3be9788-2360-4ff0-b7f6-0bfbefa03ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3be9788-2360-4ff0-b7f6-0bfbefa03ce0.jpg?1",
             "name": "Restore Balance",
             "text": "Restore Balance is white.\nSuspend 6\u2014{W}\nEach player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.",
             "colours": [
@@ -1303,7 +1303,7 @@
         },
         {
             "id": "22a4aad4-f46c-53fb-bae3-d44f8225ddf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185c8f-ac41-46e2-85b1-760abac914ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185c8f-ac41-46e2-85b1-760abac914ac.jpg?1",
             "name": "Return to Dust",
             "text": "Remove target artifact or enchantment from the game. If you played this spell during your main phase, you may remove up to one other target artifact or enchantment from the game.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "9847a145-529f-54d6-b0ca-db1a45d12ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9d7c1c-3bfd-4705-9bc2-5ca3f84cc32a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9d7c1c-3bfd-4705-9bc2-5ca3f84cc32a.jpg?1",
             "name": "Serra Avenger",
             "text": "You can't play Serra Avenger during your first, second, or third turns of the game.\nFlying, vigilance",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "e5c892f1-4f71-5286-a3a7-4fdfc4601e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073b8f2-b42d-40f2-b5fb-e78ffb1733ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073b8f2-b42d-40f2-b5fb-e78ffb1733ea.jpg?1",
             "name": "Sidewinder Sliver",
             "text": "All Slivers have flanking. (Whenever a creature without flanking blocks a Sliver, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "8a9170a1-f8dd-5ce0-ab13-18a1ee4a526b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ffb2e6-b1bc-41c5-9e52-294c060b1d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ffb2e6-b1bc-41c5-9e52-294c060b1d45.jpg?1",
             "name": "Spirit Loop",
             "text": "Enchant creature you control\nWhenever enchanted creature deals damage, you gain that much life.\nWhen Spirit Loop is put into a graveyard from play, return Spirit Loop to its owner's hand.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "656385b5-13f1-5f93-9120-3a3163643b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb406292-1879-4aa9-a369-082822dae1d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb406292-1879-4aa9-a369-082822dae1d7.jpg?1",
             "name": "Temporal Isolation",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature has shadow. (It can block or be blocked by only creatures with shadow.)\nPrevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "7c0bccf5-b69e-506a-a181-fca69a1d21f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d3a74-496e-462d-afa6-370dc2b8347d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d3a74-496e-462d-afa6-370dc2b8347d.jpg?1",
             "name": "Tivadar of Thorn",
             "text": "First strike, protection from red\nWhen Tivadar of Thorn comes into play, destroy target Goblin.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "371b46e7-167c-582b-ae10-d70fa7ff46b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d72a950-82ed-4e7b-9e18-b8231a2ebea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d72a950-82ed-4e7b-9e18-b8231a2ebea7.jpg?1",
             "name": "Watcher Sliver",
             "text": "All Slivers get +0/+2.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "57a4509b-1637-58ce-9be3-6e42821d1904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991a18e5-a183-4b84-b157-5a3609b3f910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991a18e5-a183-4b84-b157-5a3609b3f910.jpg?1",
             "name": "Weathered Bodyguards",
             "text": "As long as Weathered Bodyguards is untapped, all combat damage that would be dealt to you by unblocked creatures is dealt to Weathered Bodyguards instead.\nMorph {3}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "851a49ad-6f53-5980-b0ca-dcad98f8a869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2a2740-68cb-48c9-9716-081d369075e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2a2740-68cb-48c9-9716-081d369075e0.jpg?1",
             "name": "Zealot il-Vec",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Zealot il-Vec attacks and isn't blocked, you may have it deal 1 damage to target creature. If you do, prevent all combat damage Zealot il-Vec would deal this turn.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "5174f624-c725-5b74-b967-4aa531c88d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccedc4d-38c7-4bf3-9ca7-4febd6c49d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccedc4d-38c7-4bf3-9ca7-4febd6c49d3d.jpg?1",
             "name": "Ancestral Vision",
             "text": "Ancestral Vision is blue.\nSuspend 4\u2014{U} (Rather than play this card from your hand, pay {U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)\nTarget player draws three cards.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "37864ff3-3679-52bb-bc07-eafda610e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be63098-6446-4e64-85b0-9af914f5e075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be63098-6446-4e64-85b0-9af914f5e075.jpg?1",
             "name": "Bewilder",
             "text": "Target creature gets -3/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "b2d0174f-1c0b-56a1-9de0-c2c65f7c5f33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2c73-501b-46c9-bc76-134b50d35bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2c73-501b-46c9-bc76-134b50d35bb8.jpg?1",
             "name": "Brine Elemental",
             "text": "Morph {5}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Brine Elemental is turned face up, each opponent skips his or her next untap step.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "1a6dd217-e05c-510c-82ff-8cee876e643a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e175f7-f649-451b-9ee5-ad1140b2e8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e175f7-f649-451b-9ee5-ad1140b2e8a7.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "fea919f6-ddd7-5550-a268-c00ef3969c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf71574-5b1e-4483-9a8e-c3212148ce9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf71574-5b1e-4483-9a8e-c3212148ce9c.jpg?1",
             "name": "Careful Consideration",
             "text": "Target player draws four cards, then discards three cards. If you played this spell during your main phase, instead that player draws four cards, then discards two cards.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "6d11f4b3-b3f1-510b-9b8e-8a3287873275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1323d548-e2fe-47c5-8df3-f181aed537c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1323d548-e2fe-47c5-8df3-f181aed537c5.jpg?1",
             "name": "Clockspinning",
             "text": "Buyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nChoose a counter on target permanent or suspended card. Remove that counter from that permanent or card or put another of those counters on it.",
             "colours": [
@@ -1806,7 +1806,7 @@
         },
         {
             "id": "94a1e077-f870-5a9e-8940-b2e4ba42bc15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdcfa1-f499-4d95-9d79-3b3996cd75ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdcfa1-f499-4d95-9d79-3b3996cd75ed.jpg?1",
             "name": "Coral Trickster",
             "text": "Morph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Coral Trickster is turned face up, you may tap or untap target permanent.",
             "colours": [
@@ -1841,7 +1841,7 @@
         },
         {
             "id": "65ec9256-0816-5b0b-ba29-76059d467e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2266726-1832-4b7b-92e1-9bb0c43b7d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2266726-1832-4b7b-92e1-9bb0c43b7d5d.jpg?1",
             "name": "Crookclaw Transmuter",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Crookclaw Transmuter comes into play, switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "0e4b4d39-e2d1-52fc-bbc0-2932a1f1a442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e050532-e245-4eea-90a5-03e3e410dcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e050532-e245-4eea-90a5-03e3e410dcbe.jpg?1",
             "name": "Deep-Sea Kraken",
             "text": "Deep-Sea Kraken is unblockable.\nSuspend 9\u2014{2}{U}\nWhenever an opponent plays a spell, if Deep-Sea Kraken is suspended, remove a time counter from it.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "31727bcf-ef42-52a6-8cfe-0fa3eafec7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559d326-b97b-43d9-b7c9-c09e1a0e9db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559d326-b97b-43d9-b7c9-c09e1a0e9db6.jpg?1",
             "name": "Draining Whelk",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Draining Whelk comes into play, counter target spell. Put X +1/+1 counters on Draining Whelk, where X is that spell's converted mana cost.",
             "colours": [
@@ -1944,7 +1944,7 @@
         },
         {
             "id": "4d40e2b6-9c14-574e-9096-a7974e7c03ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8fc8e-3b23-4275-b19b-43aa6a307619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8fc8e-3b23-4275-b19b-43aa6a307619.jpg?1",
             "name": "Dream Stalker",
             "text": "When Dream Stalker comes into play, return a permanent you control to its owner's hand.",
             "colours": [
@@ -1978,7 +1978,7 @@
         },
         {
             "id": "43919fca-013c-5fbc-b0a4-6dc68b492714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3de909-b47e-45d7-9922-8d5e08a76ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3de909-b47e-45d7-9922-8d5e08a76ec9.jpg?1",
             "name": "Drifter il-Dal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nAt the beginning of your upkeep, sacrifice Drifter il-Dal unless you pay {U}.",
             "colours": [
@@ -2013,7 +2013,7 @@
         },
         {
             "id": "67648277-479e-5900-8f6e-eef793810bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398c26cc-cd55-42c6-a744-aaefd7018960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398c26cc-cd55-42c6-a744-aaefd7018960.jpg?1",
             "name": "Errant Ephemeron",
             "text": "Flying\nSuspend 4\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "0e789258-ef50-5703-aaff-b714374680a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de753839-cf75-48d0-98c3-5765779678c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de753839-cf75-48d0-98c3-5765779678c0.jpg?1",
             "name": "Eternity Snare",
             "text": "Enchant creature\nWhen Eternity Snare comes into play, draw a card.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "1ec2df86-8f91-5086-a13c-272b3a4d1f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20de275a-2e11-4452-8037-bc397dd53a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20de275a-2e11-4452-8037-bc397dd53a8c.jpg?1",
             "name": "Fathom Seer",
             "text": "Morph\u2014\nReturn two Islands you control to their owner's hand. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Fathom Seer is turned face up, draw two cards.",
             "colours": [
@@ -2115,7 +2115,7 @@
         },
         {
             "id": "5ea0f226-18da-5f19-8704-f57103f7a76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464923e-ae6e-4c1d-9315-0ddb86c07b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464923e-ae6e-4c1d-9315-0ddb86c07b40.jpg?1",
             "name": "Fledgling Mawcor",
             "text": "Flying\n{T}: Fledgling Mawcor deals 1 damage to target creature or player.\nMorph {U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2149,7 +2149,7 @@
         },
         {
             "id": "41ac0506-78e0-5b26-b3a1-1e7e8c3d0031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbc7ac4-c28e-4155-b3c8-60946653b9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbc7ac4-c28e-4155-b3c8-60946653b9b4.jpg?1",
             "name": "Fool's Demise",
             "text": "Enchant creature\nWhen enchanted creature is put into a graveyard, return that creature to play under your control.\nWhen Fool's Demise is put into a graveyard from play, return Fool's Demise to its owner's hand.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "3e3ca885-e392-57d4-878a-bd388582c7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f5c613-80ad-487f-995a-6a869c137798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f5c613-80ad-487f-995a-6a869c137798.jpg?1",
             "name": "Ixidron",
             "text": "As Ixidron comes into play, turn all other nontoken creatures in play face down. They're 2/2 creatures.\nIxidron's power and toughness are each equal to the number of face-down creatures in play.",
             "colours": [
@@ -2217,7 +2217,7 @@
         },
         {
             "id": "0d907c2b-fae2-5075-a989-5d53288809c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee06f-9021-4b65-9f53-9c326bf3a27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee06f-9021-4b65-9f53-9c326bf3a27f.jpg?1",
             "name": "Looter il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Looter il-Kor deals damage to an opponent, draw a card, then discard a card.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "bd518eee-f7e5-5e75-9d3a-1e2a6fb73e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31961041-a9e6-4d96-bd4a-5c5f88a79e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31961041-a9e6-4d96-bd4a-5c5f88a79e74.jpg?1",
             "name": "Magus of the Jar",
             "text": "{T}, Sacrifice Magus of the Jar: Each player removes his or her hand from the game face down and draws seven cards. At end of turn, each player discards his or her hand and returns to his or her hand each card he or she removed from the game this way.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "d8eb958d-5210-5f72-b262-7ce01e28608d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781cc80-5f57-4677-a9da-3523191cc7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781cc80-5f57-4677-a9da-3523191cc7c6.jpg?1",
             "name": "Moonlace",
             "text": "Target spell or permanent becomes colorless.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "61904af3-b273-53c9-8ea4-72f07db91375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a057e5f3-b6bd-4995-b990-714201f36989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a057e5f3-b6bd-4995-b990-714201f36989.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, and put it into your hand. Then shuffle your library.\nFlashback {5}{B} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "63c9b509-fb9b-53f1-bb92-175b92ea055b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26836ff5-b3c3-4b10-af1e-df3658781cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26836ff5-b3c3-4b10-af1e-df3658781cb2.jpg?1",
             "name": "Ophidian Eye",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -2386,7 +2386,7 @@
         },
         {
             "id": "de83949d-a2b7-55a8-871f-d409d5fe9967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c74def-83e5-4420-989d-2304bf4743ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c74def-83e5-4420-989d-2304bf4743ae.jpg?1",
             "name": "Paradox Haze",
             "text": "Enchant player\nAt the beginning of enchanted player's first upkeep each turn, that player gets an additional upkeep step after this step.",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "e9a7633f-6546-5538-8a51-62cff130d52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559ca03-4442-47c5-bd6e-84e71cfa6ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559ca03-4442-47c5-bd6e-84e71cfa6ca5.jpg?1",
             "name": "Psionic Sliver",
             "text": "All Slivers have \"{T}: This creature deals 2 damage to target creature or player and 3 damage to itself.\"",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "72f329eb-8361-5d30-b555-2c612d778bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ad6c86-8cfb-4f24-b8e8-ecbeffc949b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ad6c86-8cfb-4f24-b8e8-ecbeffc949b8.jpg?1",
             "name": "Riftwing Cloudskate",
             "text": "Flying\nWhen Riftwing Cloudskate comes into play, return target permanent to its owner's hand.\nSuspend 3\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2488,7 +2488,7 @@
         },
         {
             "id": "7f044031-d973-5ecb-8fd1-bfdb2134d4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ea578-069e-4020-a762-d108a3e14861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ea578-069e-4020-a762-d108a3e14861.jpg?1",
             "name": "Sage of Epityr",
             "text": "When Sage of Epityr comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "6cb83e1b-bef6-590c-bad5-01d7ec78dcf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313e71da-ce72-4976-8286-f4495ea56485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313e71da-ce72-4976-8286-f4495ea56485.jpg?1",
             "name": "Screeching Sliver",
             "text": "All Slivers have \"{T}: Target player puts the top card of his or her library into his or her graveyard.\"",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "52d1edc6-aa5c-5186-9c99-90eb553b3a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb725914-1b0f-4efc-808b-9fe2eaa7f17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb725914-1b0f-4efc-808b-9fe2eaa7f17d.jpg?1",
             "name": "Shadow Sliver",
             "text": "All Slivers have shadow. (They can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "68d56978-c784-5e87-bdb0-bfdfc57a6afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc6ee4-4b8a-4746-9d3f-4f66b3809670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc6ee4-4b8a-4746-9d3f-4f66b3809670.jpg?1",
             "name": "Slipstream Serpent",
             "text": "Slipstream Serpent can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice Slipstream Serpent.\nMorph {5}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "018c3064-82bd-5d59-891a-2a15f1e18576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9135ba-9b6a-4443-a1c4-882f9bfae626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9135ba-9b6a-4443-a1c4-882f9bfae626.jpg?1",
             "name": "Snapback",
             "text": "You may remove a blue card in your hand from the game rather than pay Snapback's mana cost.\nReturn target creature to its owner's hand.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "95e1b428-4e53-5f7e-bb16-10c030d0f112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95c8015-fd7d-4329-ab23-aec37a824083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95c8015-fd7d-4329-ab23-aec37a824083.jpg?1",
             "name": "Spell Burst",
             "text": "Buyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nCounter target spell with converted mana cost X.",
             "colours": [
@@ -2689,7 +2689,7 @@
         },
         {
             "id": "0af146c9-9615-5c7c-af5c-4cd1c390d986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c752a0b9-cc87-4c3e-a1e8-0162715e011a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c752a0b9-cc87-4c3e-a1e8-0162715e011a.jpg?1",
             "name": "Spiketail Drakeling",
             "text": "Flying\nSacrifice Spiketail Drakeling: Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -2723,7 +2723,7 @@
         },
         {
             "id": "2a933a10-3a99-556c-b1e2-f332bd4cbd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de52e53-8a45-4c0a-bb7d-6dc0d659a7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de52e53-8a45-4c0a-bb7d-6dc0d659a7c0.jpg?1",
             "name": "Sprite Noble",
             "text": "Flying\nOther creatures you control with flying get +0/+1.\n{T}: Other creatures you control with flying get +1/+0 until end of turn.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "737ce9c9-6e5e-56df-a12f-a5b21d05ac14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b0791-618b-4060-b4d9-3bd7a778098e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b0791-618b-4060-b4d9-3bd7a778098e.jpg?1",
             "name": "Stormcloud Djinn",
             "text": "Flying\nStormcloud Djinn can block only creatures with flying.\n{R}{R}: Stormcloud Djinn gets +2/+0 until end of turn and deals 1 damage to you.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "40c0d3b3-b4ba-578d-a15d-9c5c4765b370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0145f6-4e27-49e7-9ef6-bac6fa3de26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0145f6-4e27-49e7-9ef6-bac6fa3de26d.jpg?1",
             "name": "Teferi, Mage of Zhalfir",
             "text": "Flash (You may play this spell any time you could play an instant.)\nCreature cards you own that aren't in play have flash.\nEach opponent can play spells only any time he or she could play a sorcery.",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "22861d5d-faf1-5cd8-9fea-524ed333f5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b934ad-4858-4680-924a-53ea4f250f9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b934ad-4858-4680-924a-53ea4f250f9e.jpg?1",
             "name": "Telekinetic Sliver",
             "text": "All Slivers have \"{T}: Tap target permanent.\"",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "ad0fc2ef-85f3-5b93-87b3-60728ba590ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab2147-d496-489b-aaf0-b354e31a6b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab2147-d496-489b-aaf0-b354e31a6b45.jpg?1",
             "name": "Temporal Eddy",
             "text": "Put target creature or land on top of its owner's library.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "888818d6-af6d-5137-b855-8ecd1525fe15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d99db-de6d-4405-90ec-b144abbaa5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d99db-de6d-4405-90ec-b144abbaa5a4.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "6ed0ed0b-1932-5436-9826-4277160ced36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97ec8b-6163-41ff-9e6f-af091a7c529e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97ec8b-6163-41ff-9e6f-af091a7c529e.jpg?1",
             "name": "Tolarian Sentinel",
             "text": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "d0620205-b895-51dc-9e02-eecf2166758e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e58ff2-dea3-42b3-8c22-3e6202a7d433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e58ff2-dea3-42b3-8c22-3e6202a7d433.jpg?1",
             "name": "Trickbind",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nCounter target activated or triggered ability. If a permanent's ability is countered this way, activated abilities of that permanent can't be played this turn. (Mana abilities can't be targeted.)",
             "colours": [
@@ -2995,7 +2995,7 @@
         },
         {
             "id": "53ab8d1f-7493-54b3-83f3-49ba5b25d1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3e301a-02a5-4d92-9cdd-5ab877bf8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3e301a-02a5-4d92-9cdd-5ab877bf8ed3.jpg?1",
             "name": "Truth or Tale",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put a card from the chosen pile into your hand, then put all other cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "26bac3f2-1a63-5f55-91d8-826858d42aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458031cc-238d-45f0-9a81-b52e82286e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458031cc-238d-45f0-9a81-b52e82286e0f.jpg?1",
             "name": "Vesuvan Shapeshifter",
             "text": "As Vesuvan Shapeshifter comes into play or is turned face up, you may choose another creature in play. If you do, until Vesuvan Shapeshifter is turned face down, it becomes a copy of that creature and gains \"At the beginning of your upkeep, you may turn this creature face down.\"\nMorph {1}{U}",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "c6b24406-0dc5-5c7d-abab-76778e75b8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc9f54e-7fba-4f03-83ca-6d293dffc07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc9f54e-7fba-4f03-83ca-6d293dffc07a.jpg?1",
             "name": "Viscerid Deepwalker",
             "text": "{U}: Viscerid Deepwalker gets +1/+0 until end of turn.\nSuspend 4\u2014{U} (Rather than play this card from your hand, you may pay {U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "e72b60b4-9b4b-5297-8e0f-cddd121d2bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9765c83-fe52-43c5-9466-7318809bbfe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9765c83-fe52-43c5-9466-7318809bbfe0.jpg?1",
             "name": "Voidmage Husher",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Voidmage Husher comes into play, counter target activated ability. (Mana abilities can't be targeted.)\nWhenever you play a spell, you may return Voidmage Husher to its owner's hand.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "0c48524d-6fa8-5f56-8887-87fda8765802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db567cf-3d26-4216-932b-53ca4cfeb5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db567cf-3d26-4216-932b-53ca4cfeb5b7.jpg?1",
             "name": "Walk the Aeons",
             "text": "Buyback\u2014\nSacrifice three Islands. (You may sacrifice three Islands in addition to any other costs as you play this spell. If you do, put this card into your hand as it resolves.)\nTarget player takes an extra turn after this one.",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "4ce76a99-940a-521a-8915-a497bd337299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb43af-367c-4778-a7cc-7ee3b3103379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb43af-367c-4778-a7cc-7ee3b3103379.jpg?1",
             "name": "Wipe Away",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "8eab22db-89b5-58cc-b463-57897ed814da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b67839-622d-41c1-b9c7-1a26b021ec78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b67839-622d-41c1-b9c7-1a26b021ec78.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "886a33bd-8f85-5de0-989e-4d115584ea32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4564e9df-bfa3-48e5-a12e-f7e96a504cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4564e9df-bfa3-48e5-a12e-f7e96a504cb1.jpg?1",
             "name": "Basal Sliver",
             "text": "All Slivers have \"Sacrifice this creature: Add {B}{B} to your mana pool.\"",
             "colours": [
@@ -3261,7 +3261,7 @@
         },
         {
             "id": "e227585b-9d68-5cea-8487-cfe2dc203cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7322e2-dbea-46e1-ba29-a86a13e5d33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7322e2-dbea-46e1-ba29-a86a13e5d33e.jpg?1",
             "name": "Call to the Netherworld",
             "text": "Return target black creature card from your graveyard to your hand.\nMadness {0} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "bbe8be3a-d72f-5c99-961f-a3202cc848ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58b842a-a4c0-475d-a8b3-62d4e5bb2eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58b842a-a4c0-475d-a8b3-62d4e5bb2eaf.jpg?1",
             "name": "Corpulent Corpse",
             "text": "Fear\nSuspend 5\u2014{B} (Rather than play this card from your hand, you may pay {B} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "1437d860-9d00-55e7-9198-96674cd06636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4323aa6-a1fb-42ee-9634-3747129fde3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4323aa6-a1fb-42ee-9634-3747129fde3b.jpg?1",
             "name": "Curse of the Cabal",
             "text": "Target player sacrifices half the permanents he or she controls, rounded down.\nSuspend 2\u2014{2}{B}{B}\nAt the beginning of each player's upkeep, if Curse of the Cabal is suspended, that player may sacrifice a permanent. If he or she does, put two time counters on Curse of the Cabal.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "9a939fc9-0436-548b-86f3-b3f2aa7ce2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6bc89-492a-46a4-90dc-95ae2e2bc483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6bc89-492a-46a4-90dc-95ae2e2bc483.jpg?1",
             "name": "Cyclopean Giant",
             "text": "When Cyclopean Giant is put into a graveyard from play, target land becomes a Swamp. Remove Cyclopean Giant from the game.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "2d166f37-732a-504c-8af7-fcabaec59ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da58e0d-5877-43c4-b129-993e154b6087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da58e0d-5877-43c4-b129-993e154b6087.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "52d4eecc-584c-5301-9808-b31e217d7749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b.jpg?1",
             "name": "Deathspore Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Deathspore Thallid.\nRemove three spore counters from Deathspore Thallid: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "98686b72-8cac-59a7-bdb1-abd48c7dc5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a68a28-05fa-4c6e-896d-ddb9aea3a38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a68a28-05fa-4c6e-896d-ddb9aea3a38d.jpg?1",
             "name": "Demonic Collusion",
             "text": "Buyback\u2014\nDiscard two cards. (You may discard two cards in addition to any other costs as you play this spell. If you do, put this card into your hand as it resolves.)\nSearch your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "8ec728f7-587c-516f-8632-bceb75e39863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e304fc-0ace-459e-8d2f-376f1899639c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e304fc-0ace-459e-8d2f-376f1899639c.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to play.\nFlashback\u2014\nSacrifice three creatures. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "6e39c160-c3b1-5f20-ab43-362a0e7b7b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c07d9a-afed-4028-9fa1-ec439b60f08f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c07d9a-afed-4028-9fa1-ec439b60f08f.jpg?1",
             "name": "Drudge Reavers",
             "text": "Flash (You may play this spell any time you could play an instant.)\n{B}: Regenerate Drudge Reavers.",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "680d81f9-0a25-5bc5-9fee-2f12f1bb175c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac6faba-59f2-436f-addb-c53db2b0cc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac6faba-59f2-436f-addb-c53db2b0cc17.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you play a creature spell, put X 1/1 black Thrull creature tokens into play, where X is that spell's converted mana cost.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "75b63e4e-fc7d-54ec-ad2d-e023255bd39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc17fe31-11f1-48e0-9b0d-7c7dcda417a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc17fe31-11f1-48e0-9b0d-7c7dcda417a6.jpg?1",
             "name": "Evil Eye of Urborg",
             "text": "Non-Eye creatures you control can't attack.\nWhenever Evil Eye of Urborg becomes blocked by a creature, destroy that creature.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "f39e546c-456a-5794-9385-089b2d68a6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17146f8-d517-4941-b01e-09ecf00ec8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17146f8-d517-4941-b01e-09ecf00ec8e4.jpg?1",
             "name": "Faceless Devourer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhen Faceless Devourer comes into play, remove another target creature with shadow from the game.\nWhen Faceless Devourer leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "97694ce0-9370-5da1-a2e3-c815520fa252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2d24b0-f0d3-40f0-a51f-074f8e95e6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2d24b0-f0d3-40f0-a51f-074f8e95e6af.jpg?1",
             "name": "Fallen Ideal",
             "text": "Enchant creature\nEnchanted creature has flying and \"Sacrifice a creature: This creature gets +2/+1 until end of turn.\"\nWhen Fallen Ideal is put into a graveyard from play, return Fallen Ideal to its owner's hand.",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "442df62a-5e10-5066-a2b6-539e4db32d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2660d-b661-4266-b7e5-07bb8b72bce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2660d-b661-4266-b7e5-07bb8b72bce6.jpg?1",
             "name": "Feebleness",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets -2/-1.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "36f1288b-5f00-5703-9c23-c966dbef7103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdeb7c9-98bd-4143-87e4-1c78c0ce627e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdeb7c9-98bd-4143-87e4-1c78c0ce627e.jpg?1",
             "name": "Gorgon Recluse",
             "text": "Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.\nMadness {B}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "c05bd7b0-eff6-5a31-82dd-b67185448df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8163a9d-5a1b-4d36-b20a-b220207a3b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8163a9d-5a1b-4d36-b20a-b220207a3b94.jpg?1",
             "name": "Haunting Hymn",
             "text": "Target player discards two cards. If you played this spell during your main phase, that player discards four cards instead.",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "9c8193ed-8db5-5520-a873-7db96f795dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e7c608-d224-472b-8736-273874211f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e7c608-d224-472b-8736-273874211f24.jpg?1",
             "name": "Liege of the Pit",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature other than Liege of the Pit. If you can't, Liege of the Pit deals 7 damage to you.\nMorph {B}{B}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "dfee3094-6043-5959-866c-f06cf88bf92f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3cdfe-0289-474b-b9c4-07e8c6588ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3cdfe-0289-474b-b9c4-07e8c6588ec5.jpg?1",
             "name": "Lim-D\u00fbl the Necromancer",
             "text": "Whenever a creature an opponent controls is put into a graveyard from play, you may pay {1}{B}. If you do, return that card to play under your control. If it's a creature, it's a Zombie in addition to its other creature types.\n{1}{B}: Regenerate target Zombie.",
             "colours": [
@@ -3870,7 +3870,7 @@
         },
         {
             "id": "a7171431-f4df-5d1a-80d3-c6faa56afd67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be0ff69-d9f3-4b81-b02f-1360e4064aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be0ff69-d9f3-4b81-b02f-1360e4064aff.jpg?1",
             "name": "Living End",
             "text": "Living End is black.\nSuspend 3\u2014{2}{B}{B}\nEach player removes all creature cards in his or her graveyard from the game, then sacrifices all creatures he or she controls, then puts into play all cards he or she removed this way.",
             "colours": [
@@ -3902,7 +3902,7 @@
         },
         {
             "id": "0ebe5682-6b5e-509a-93d5-018e5cf1e56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6e8ff6-323d-4cc3-b7b6-8607bf89597e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6e8ff6-323d-4cc3-b7b6-8607bf89597e.jpg?1",
             "name": "Magus of the Mirror",
             "text": "{T}, Sacrifice Magus of the Mirror: Exchange life totals with target opponent. Play this ability only during your upkeep.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "70278633-1ed8-567a-ada2-2e7525c2f73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a39ed44-bc0c-40e2-ba53-cd586c2d5877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a39ed44-bc0c-40e2-ba53-cd586c2d5877.jpg?1",
             "name": "Mana Skimmer",
             "text": "Flying\nWhenever Mana Skimmer deals damage to a player, tap target land that player controls. That land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "4faa2d54-efe1-54d3-b182-95ff6b9a5c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54575-dc1d-491c-a4f6-41f76eba2a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54575-dc1d-491c-a4f6-41f76eba2a2d.jpg?1",
             "name": "Mindlash Sliver",
             "text": "All Slivers have \"{1}, Sacrifice this creature: Each player discards a card.\"",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "103730f9-c16a-5ef9-95af-5a53c662a6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efd28ef-77db-4e7b-a69d-5a089e016737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efd28ef-77db-4e7b-a69d-5a089e016737.jpg?1",
             "name": "Mindstab",
             "text": "Target player discards three cards.\nSuspend 4\u2014{B} (Rather than play this card from your hand, you may pay {B} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "f25efe6f-2339-5fb3-8f36-5fc118f9cd15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911d2271-8998-4193-9d1a-1768c5dfaaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911d2271-8998-4193-9d1a-1768c5dfaaad.jpg?1",
             "name": "Nether Traitor",
             "text": "Haste\nShadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever another creature is put into your graveyard from play, you may pay {B}. If you do, return Nether Traitor from your graveyard to play.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "26c91c11-a72a-5650-a58c-5f2aea51e240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e57492c-ca26-4f75-a27e-5c54967534ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e57492c-ca26-4f75-a27e-5c54967534ea.jpg?1",
             "name": "Nightshade Assassin",
             "text": "First strike\nWhen Nightshade Assassin comes into play, you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn.\nMadness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "cb91875b-a64d-5636-b5c5-ccc6b4f043f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba55f16-a37c-4caa-9417-227a06cf4061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba55f16-a37c-4caa-9417-227a06cf4061.jpg?1",
             "name": "Phthisis",
             "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5\u2014{1}{B} (Rather than play this card from your hand, you may pay {1}{B} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "fcf3e647-14e0-594f-a729-ebbb2d2f5e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936e767-0e48-4adb-93e9-790fe0cc19f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936e767-0e48-4adb-93e9-790fe0cc19f2.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper comes into play, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "19b7380e-d56f-5998-8051-f227f5557d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703d491e-b25f-44fa-8b76-b955a4e75ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703d491e-b25f-44fa-8b76-b955a4e75ba5.jpg?1",
             "name": "Plague Sliver",
             "text": "All Slivers have \"At the beginning of your upkeep, this creature deals 1 damage to you.\"",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "1465ecb2-e263-5f84-adf2-508f2e5b0a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96cea6a-fea6-4a6b-84b2-7b57237be96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96cea6a-fea6-4a6b-84b2-7b57237be96a.jpg?1",
             "name": "Premature Burial",
             "text": "Destroy target nonblack creature that came into play since your last turn ended.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "2294cf58-e15b-5ecd-9d44-6a5afdf89039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e61fbcd-b673-4d1d-bc38-a791a56a9aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e61fbcd-b673-4d1d-bc38-a791a56a9aac.jpg?1",
             "name": "Psychotic Episode",
             "text": "Target player reveals his or her hand and the top card of his or her library. You choose a card revealed this way. That player puts the chosen card on the bottom of his or her library.\nMadness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -4271,7 +4271,7 @@
         },
         {
             "id": "55343d25-ee49-5030-9052-a79d0e9c2208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9abc52-76f6-4b1f-8602-2e5abdd23b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9abc52-76f6-4b1f-8602-2e5abdd23b6b.jpg?1",
             "name": "Sangrophage",
             "text": "At the beginning of your upkeep, tap Sangrophage unless you pay 2 life.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "e2ce2b31-7fea-578b-96b8-9ea94da447ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd9cc4c-708b-41cb-9cac-fd6d8ce9922d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd9cc4c-708b-41cb-9cac-fd6d8ce9922d.jpg?1",
             "name": "Sengir Nosferatu",
             "text": "Flying\n{1}{B}, Remove Sengir Nosferatu from the game: Put a 1/2 black Bat creature token with flying into play. It has \"{1}{B}, Sacrifice this creature: Return to play under its owner's control a card named Sengir Nosferatu that's removed from the game.\"",
             "colours": [
@@ -4339,7 +4339,7 @@
         },
         {
             "id": "3e386776-43a1-5b41-a162-d05427c201f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d21e39-b1dd-476d-86dc-4317858e4f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d21e39-b1dd-476d-86dc-4317858e4f8e.jpg?1",
             "name": "Skittering Monstrosity",
             "text": "When you play a creature spell, sacrifice Skittering Monstrosity.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "233a789c-991d-5ba2-b19f-0c13bf1c8f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7927b-64ae-4448-9540-8d7bbe88c9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7927b-64ae-4448-9540-8d7bbe88c9cc.jpg?1",
             "name": "Skulking Knight",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nWhen Skulking Knight becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "6ddc333a-72dd-5ef3-960a-48b586ca6005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175d5a88-2597-4e85-aed6-7a65c0595fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175d5a88-2597-4e85-aed6-7a65c0595fb4.jpg?1",
             "name": "Smallpox",
             "text": "Each player loses 1 life, discards a card, sacrifices a creature, then sacrifices a land.",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "f9673160-b1bc-5f8a-91ea-f274d779ac36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723e552-baf5-4b6a-8af6-843fd8597f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723e552-baf5-4b6a-8af6-843fd8597f6c.jpg?1",
             "name": "Strangling Soot",
             "text": "Destroy target creature with toughness 3 or less.\nFlashback {5}{R} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "b4160f99-57e2-504b-b883-1a0411ec04cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg?1",
             "name": "Stronghold Overseer",
             "text": "Flying\nShadow (This creature can block or be blocked by only creatures with shadow.)\n{B}{B}: Creatures with shadow get +1/+0 until end of turn and creatures without shadow get -1/-0 until end of turn.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "1f42f2ba-0e71-549d-89a8-55d8a971bf95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e889c4-105b-4f4e-8a3d-ace753a24a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e889c4-105b-4f4e-8a3d-ace753a24a4e.jpg?1",
             "name": "Sudden Death",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nTarget creature gets -4/-4 until end of turn.",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "dcbcfdbe-1c68-5192-9058-ba387bc2cdd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f89f1e4-4d55-48b8-bf81-54cfd34f4aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f89f1e4-4d55-48b8-bf81-54cfd34f4aa0.jpg?1",
             "name": "Sudden Spoiling",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nCreatures target player controls become 0/2 and lose all abilities until end of turn.",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "e9eb8a20-9d35-520b-9cd2-c541b5a4a3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f61db9e-ef88-4dc8-b90c-1f8b2d7e9bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f61db9e-ef88-4dc8-b90c-1f8b2d7e9bb9.jpg?1",
             "name": "Tendrils of Corruption",
             "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "cff4e966-d6b7-5e05-a642-e3cc840b0d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6313a601-5d26-487b-a70c-2c7184b7cc91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6313a601-5d26-487b-a70c-2c7184b7cc91.jpg?1",
             "name": "Traitor's Clutch",
             "text": "Target creature gets +1/+0, becomes black, and gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)\nFlashback {1}{B} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "01649eaf-6dfe-5afc-8a59-ea50d98b1685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4903171e-76b2-437d-8965-e871e47a3482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4903171e-76b2-437d-8965-e871e47a3482.jpg?1",
             "name": "Trespasser il-Vec",
             "text": "Discard a card: Trespasser il-Vec gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "e5b8256b-3443-52dd-a30f-ea6aba0ab7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8376f6-5c26-4b87-b226-960466e16cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8376f6-5c26-4b87-b226-960466e16cb0.jpg?1",
             "name": "Urborg Syphon-Mage",
             "text": "{2}{B}, {T}, Discard a card: Each other player loses 2 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "3d5d3e3c-5cb1-5092-9a07-e20539996b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c56db1-bb2d-4383-90aa-72d00fe476b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c56db1-bb2d-4383-90aa-72d00fe476b2.jpg?1",
             "name": "Vampiric Sliver",
             "text": "All Slivers have \"Whenever a creature dealt damage by this creature this turn is put into a graveyard, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "56125128-7421-5e04-829c-75f9b515f723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f04d7-da34-41e3-9153-97891a428889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f04d7-da34-41e3-9153-97891a428889.jpg?1",
             "name": "Viscid Lemures",
             "text": "{0}: Viscid Lemures gets -1/-0 and gains swampwalk until end of turn.",
             "colours": [
@@ -4773,7 +4773,7 @@
         },
         {
             "id": "a14e7ce7-bd9f-5fd5-a833-3f30e1195d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b14f08-dd93-4a9f-a616-8f8d0b26b966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b14f08-dd93-4a9f-a616-8f8d0b26b966.jpg?1",
             "name": "Aetherflame Wall",
             "text": "Defender\n\u00c6therflame Wall can block creatures with shadow as though they didn't have shadow.\n{R}: \u00c6therflame Wall gets +1/+0 until end of turn.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "e0763cff-87db-5986-b127-5ceaa1971cf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cbad1f-4f16-4d5f-a485-5bf950565216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cbad1f-4f16-4d5f-a485-5bf950565216.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "2d64a670-b23a-5458-a018-e95fc279f6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6f45a-7219-4b59-bf0a-9e374599ae5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6f45a-7219-4b59-bf0a-9e374599ae5e.jpg?1",
             "name": "Barbed Shocker",
             "text": "Trample, haste\nWhenever Barbed Shocker deals damage to a player, that player discards all the cards in his or her hand, then draws that many cards.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "b53ef69d-6264-51c1-859c-37e97107a09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34945e1-b982-48a0-8c03-9b97c13cc73d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34945e1-b982-48a0-8c03-9b97c13cc73d.jpg?1",
             "name": "Basalt Gargoyle",
             "text": "Flying\nEcho {2}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{R}: Basalt Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "4b278b4b-1991-50db-8782-a06d9ad7005e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabf35d5-de8a-4d9d-be59-7ad7039873c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabf35d5-de8a-4d9d-be59-7ad7039873c6.jpg?1",
             "name": "Blazing Blade Askari",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n{2}: Blazing Blade Askari becomes colorless until end of turn.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "c1af5460-a744-55ce-bc04-7152bcd86874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5852f528-92aa-45cf-8436-5774691676d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5852f528-92aa-45cf-8436-5774691676d3.jpg?1",
             "name": "Bogardan Hellkite",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Bogardan Hellkite comes into play, it deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "974b397f-7ddf-5adc-95e5-8bd39953ef89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53d26b-ad3e-474f-a374-05fcdc00e49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53d26b-ad3e-474f-a374-05fcdc00e49c.jpg?1",
             "name": "Bogardan Rager",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Bogardan Rager comes into play, target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -5011,7 +5011,7 @@
         },
         {
             "id": "8b587c57-f0f8-51a4-8c43-ffe1f34bdb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705e29c5-2d9b-44ad-a04c-9a62dd74eb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705e29c5-2d9b-44ad-a04c-9a62dd74eb12.jpg?1",
             "name": "Bonesplitter Sliver",
             "text": "All Slivers get +2/+0.",
             "colours": [
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "1999a73f-7a8c-5dd9-966e-a2d4a7dee1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6bdc34-1ef6-4de3-a9a9-b5dd503e02c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6bdc34-1ef6-4de3-a9a9-b5dd503e02c0.jpg?1",
             "name": "Coal Stoker",
             "text": "When Coal Stoker comes into play, if you played it from your hand, add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "91083e40-553f-5825-a0ba-2f7f272e8e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc5f7fb-b7a6-433d-a0bb-240c7aa0a720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc5f7fb-b7a6-433d-a0bb-240c7aa0a720.jpg?1",
             "name": "Conflagrate",
             "text": "Conflagrate deals X damage divided as you choose among any number of target creatures and/or players.\nFlashback\u2014{R}{R}, Discard X cards. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "707d9c55-ec87-5b60-b076-88b31be812b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bb27c-c58a-478a-b637-eb4f7e1e0ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bb27c-c58a-478a-b637-eb4f7e1e0ab4.jpg?1",
             "name": "Empty the Warrens",
             "text": "Put two 1/1 red Goblin creature tokens into play.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -5143,7 +5143,7 @@
         },
         {
             "id": "64a551ed-fb4e-59bd-bc4c-c76c5590b20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d592bc85-41ca-48a4-b35a-4d86c8e76d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d592bc85-41ca-48a4-b35a-4d86c8e76d54.jpg?1",
             "name": "Firemaw Kavu",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Firemaw Kavu comes into play, it deals 2 damage to target creature.\nWhen Firemaw Kavu leaves play, it deals 4 damage to target creature.",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "c4db7807-4ced-5044-bc00-659e756f4241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940bfe4f-bc18-4506-b6f4-13d339fd3e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940bfe4f-bc18-4506-b6f4-13d339fd3e55.jpg?1",
             "name": "Flamecore Elemental",
             "text": "Echo {2}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "6149b305-3dd2-51ad-bbf8-d09280200982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f10fa1c-2c7b-49ba-87b6-3b652b65704d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f10fa1c-2c7b-49ba-87b6-3b652b65704d.jpg?1",
             "name": "Flowstone Channeler",
             "text": "{1}{R}, {T}, Discard a card: Target creature gets +1/-1 and gains haste until end of turn.",
             "colours": [
@@ -5246,7 +5246,7 @@
         },
         {
             "id": "dfdfa896-0923-51a0-a819-78ff2b8c0746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893bbb7-0589-4544-a488-f84f9aa1d058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893bbb7-0589-4544-a488-f84f9aa1d058.jpg?1",
             "name": "Fortune Thief",
             "text": "Damage that would reduce your life total to less than 1 reduces it to 1 instead.\nMorph {R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "9f203094-9e28-5fef-847b-5508b798ec53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1",
             "name": "Fury Sliver",
             "text": "All Slivers have double strike.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "595b2987-8c80-58ae-80d2-45df58f0203e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9098b989-072a-4e5b-8972-22c61645c5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9098b989-072a-4e5b-8972-22c61645c5bb.jpg?1",
             "name": "Ghitu Firebreathing",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\n{R}: Enchanted creature gets +1/+0 until end of turn.\n{R}: Return Ghitu Firebreathing to its owner's hand.",
             "colours": [
@@ -5349,7 +5349,7 @@
         },
         {
             "id": "5ae2e274-288f-5b5d-bfbf-b36a71b284d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45406cd-a036-45d5-a0fb-3c195d40d746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45406cd-a036-45d5-a0fb-3c195d40d746.jpg?1",
             "name": "Goblin Skycutter",
             "text": "Sacrifice Goblin Skycutter: Goblin Skycutter deals 2 damage to target creature with flying. That creature loses flying until end of turn.",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "0026ba71-f6f6-5f0e-b3b4-4b44ff1c440b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee33cb6-768e-44a0-b6f4-b8638aa84330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee33cb6-768e-44a0-b6f4-b8638aa84330.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to target creature or player.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "545dcd44-2511-5e0a-b499-87bed1688545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653ddfa0-2088-4503-a3ab-b0f1d55d8351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653ddfa0-2088-4503-a3ab-b0f1d55d8351.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Play this ability only if Greater Gargadon is suspended.",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "593dc9e6-6072-5389-b20f-274ba95c35ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62333783-6a18-4461-88ce-1c37eaf64e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62333783-6a18-4461-88ce-1c37eaf64e2b.jpg?1",
             "name": "Ground Rift",
             "text": "Target creature without flying can't block this turn.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5482,7 +5482,7 @@
         },
         {
             "id": "e5709e12-302d-5f68-a390-522a555bb7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38134389-b471-4f58-a9ae-26bf9dc1557a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38134389-b471-4f58-a9ae-26bf9dc1557a.jpg?1",
             "name": "Ib Halfheart, Goblin Tactician",
             "text": "Whenever another Goblin you control becomes blocked, sacrifice it. If you do, it deals 4 damage to each creature blocking it.\nSacrifice two Mountains: Put two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -5519,7 +5519,7 @@
         },
         {
             "id": "eca01659-a70a-5a9c-84c0-7fa69cccf4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7b7831-27a1-4c0a-8ed1-6dddf2754d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7b7831-27a1-4c0a-8ed1-6dddf2754d65.jpg?1",
             "name": "Ignite Memories",
             "text": "Target player reveals a card at random from his or her hand. Ignite Memories deals damage to that player equal to that card's converted mana cost.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "2f78f7d2-8caa-5268-a322-6e4397d17c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07e37ea-aa8d-4443-9af6-4351994bc00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07e37ea-aa8d-4443-9af6-4351994bc00c.jpg?1",
             "name": "Ironclaw Buzzardiers",
             "text": "Ironclaw Buzzardiers can't block creatures with power 2 or greater.\n{R}: Ironclaw Buzzardiers gains flying until end of turn.",
             "colours": [
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "8ae1eb71-866d-523d-81a7-d8a3a485852c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f85b2a-7836-4058-87a5-859c4311a7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f85b2a-7836-4058-87a5-859c4311a7e4.jpg?1",
             "name": "Jaya Ballard, Task Mage",
             "text": "{R}, {T}, Discard a card: Destroy target blue permanent.\n{1}{R}, {T}, Discard a card: Jaya Ballard, Task Mage deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.\n{5}{R}{R}, {T}, Discard a card: Jaya Ballard deals 6 damage to each creature and each player.",
             "colours": [
@@ -5623,7 +5623,7 @@
         },
         {
             "id": "030b4df4-93f5-54a0-a381-43c8ef563ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90723e0-fbb3-4976-9463-0373f8ed337c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90723e0-fbb3-4976-9463-0373f8ed337c.jpg?1",
             "name": "Keldon Halberdier",
             "text": "First strike\nSuspend 4\u2014{R} (Rather than play this card from your hand, you may pay {R} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "e68fdf69-2f0d-5369-8f3b-3fce3995168b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b748290-04b0-48a9-81aa-ab43182cf339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b748290-04b0-48a9-81aa-ab43182cf339.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to play Lightning Axe, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "caf69553-ddc9-5541-b501-14783b54d6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6060cada-52bf-4ef2-8a26-8ba04dded458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6060cada-52bf-4ef2-8a26-8ba04dded458.jpg?1",
             "name": "Magus of the Scroll",
             "text": "{3}, {T}: Name a card. Reveal a card at random from your hand. If it's the named card, Magus of the Scroll deals 2 damage to target creature or player.",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "424fdaf8-4466-5541-aab3-2041fdb8a852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e0bdb-b615-447a-b80d-d7244c25c56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e0bdb-b615-447a-b80d-d7244c25c56e.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal comes into play or is put into a graveyard from play, put a 1/1 red Goblin creature token into play.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "ff3749ae-8091-5bdc-8d9a-b89eb72a88bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61ea59a-1db0-4e6b-bcde-19787c76a49b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61ea59a-1db0-4e6b-bcde-19787c76a49b.jpg?1",
             "name": "Norin the Wary",
             "text": "When a player plays a spell or a creature attacks, remove Norin the Wary from the game. Return it to play under its owner's control at end of turn.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "6103db7a-270c-555a-a1a1-9de631098363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e40f99c-9608-4463-8c6f-c6e142f0d716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e40f99c-9608-4463-8c6f-c6e142f0d716.jpg?1",
             "name": "Orcish Cannonade",
             "text": "Orcish Cannonade deals 2 damage to target creature or player and 3 damage to you.\nDraw a card.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "562bde17-3432-5d4b-bdc2-df7876fce121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad47d954-dda8-412a-b69b-a213bbd2f309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad47d954-dda8-412a-b69b-a213bbd2f309.jpg?1",
             "name": "Pardic Dragon",
             "text": "Flying\n{R}: Pardic Dragon gets +1/+0 until end of turn.\nSuspend 2\u2014{R}{R}\nWhenever an opponent plays a spell, if Pardic Dragon is suspended, that player may put a time counter on Pardic Dragon.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "d9d4f283-773c-5f16-ab19-46c2a7465099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cff220-b1a6-4da6-b765-25a583b33de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cff220-b1a6-4da6-b765-25a583b33de2.jpg?1",
             "name": "Plunder",
             "text": "Destroy target artifact or land.\nSuspend 4\u2014{1}{R} (Rather than play this card from your hand, you may pay {1}{R} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "3e928c6c-cb24-5bed-8b48-a54158927e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc2151b-acec-4237-8f6f-ed97055f3bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc2151b-acec-4237-8f6f-ed97055f3bb9.jpg?1",
             "name": "Reiterate",
             "text": "Buyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "26995916-9d28-5d0f-8df8-79227f145147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dde96e-6824-4d26-9fb5-86b9f3c50959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dde96e-6824-4d26-9fb5-86b9f3c50959.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to target creature or player.\nSuspend 1\u2014{R} (Rather than play this card from your hand, you may pay {R} and remove it from the game with a time counter on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "1da18008-9b77-5fdb-ae8b-cdd38b53e5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dc8d7e-745c-46ba-842c-526f1beb89a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dc8d7e-745c-46ba-842c-526f1beb89a7.jpg?1",
             "name": "Sedge Sliver",
             "text": "All Slivers have \"This creature gets +1/+1 as long as you control a Swamp\" and \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "821767c9-7d17-54be-93b3-9c076e55563f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9429ec0-ff23-494d-ab1c-b88f3a0dee1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9429ec0-ff23-494d-ab1c-b88f3a0dee1b.jpg?1",
             "name": "Subterranean Shambler",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Subterranean Shambler comes into play or leaves play, it deals 1 damage to each creature without flying.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "7080205b-7fdf-5250-b103-7a619b13864d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2691ee-8eec-437d-9bc1-113264525fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2691ee-8eec-437d-9bc1-113264525fb8.jpg?1",
             "name": "Sudden Shock",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "3b50bf52-3caf-59f4-b94f-f099f0586bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67511e0e-be09-4f4e-9949-b9ecbdc7f536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67511e0e-be09-4f4e-9949-b9ecbdc7f536.jpg?1",
             "name": "Sulfurous Blast",
             "text": "Sulfurous Blast deals 2 damage to each creature and each player. If you played this spell during your main phase, Sulfurous Blast deals 3 damage to each creature and each player instead.",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "d7483fb7-bce1-5784-992f-443ea04577cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8aaf09-312f-4c82-9e0a-bd797e7f26c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8aaf09-312f-4c82-9e0a-bd797e7f26c3.jpg?1",
             "name": "Tectonic Fiend",
             "text": "Echo {4}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nTectonic Fiend attacks each turn if able.",
             "colours": [
@@ -6126,7 +6126,7 @@
         },
         {
             "id": "a0f096f1-1266-5855-8965-b99b17c5c386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a82da-ae5c-4f3d-8aa0-4bd3de7bf0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a82da-ae5c-4f3d-8aa0-4bd3de7bf0b6.jpg?1",
             "name": "Thick-Skinned Goblin",
             "text": "You may pay {0} rather than pay the echo cost for permanents you control.\n{R}: Thick-Skinned Goblin gains protection from red until end of turn.",
             "colours": [
@@ -6161,7 +6161,7 @@
         },
         {
             "id": "190eaf2d-ff02-54dd-8124-dc6b526059cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89fb3b-0238-4d76-a46d-7d6fa4a74620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89fb3b-0238-4d76-a46d-7d6fa4a74620.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "All Slivers have \"This creature can't be blocked except by two or more creatures.\"",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "1a8c078f-a61e-5289-932f-ccd75623f8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7ff7d2-a8f1-4ce4-acad-828ef36afe07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7ff7d2-a8f1-4ce4-acad-828ef36afe07.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from play, return Undying Rage to its owner's hand.",
             "colours": [
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "ed4e2914-e2cc-5ef4-af43-fbb7ee5ed2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fce1b3-0961-4672-845f-e1c6ce101c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fce1b3-0961-4672-845f-e1c6ce101c1b.jpg?1",
             "name": "Viashino Bladescout",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Viashino Bladescout comes into play, target creature gains first strike until end of turn.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "1e218ae5-2041-5563-9b10-6517e9a014a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebd5c57-cfc8-4a3c-b4a2-0cd64a5e3575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebd5c57-cfc8-4a3c-b4a2-0cd64a5e3575.jpg?1",
             "name": "Volcanic Awakening",
             "text": "Destroy target land.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -6296,7 +6296,7 @@
         },
         {
             "id": "c0ea7bbf-054d-50ae-ac48-fc4aafed4a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9eb9fc-0a69-480d-be17-3e80e34c453b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9eb9fc-0a69-480d-be17-3e80e34c453b.jpg?1",
             "name": "Wheel of Fate",
             "text": "Wheel of Fate is red.\nSuspend 4\u2014{1}{R} (Rather than play this card from your hand, pay {1}{R} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)\nEach player discards his or her hand, then draws seven cards.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "c87f11ec-8b68-5fe0-bcf2-386a8fc70ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3c98-ec84-4686-bc21-c8572a736e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3c98-ec84-4686-bc21-c8572a736e62.jpg?1",
             "name": "Word of Seizing",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "5554df1b-d6e4-5e50-9b05-ccadd1e02bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a6af9-1b39-41e1-bd71-210700b7608b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a6af9-1b39-41e1-bd71-210700b7608b.jpg?1",
             "name": "Aether Web",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets +1/+1, can block as though it had flying, and can block creatures with shadow as though they didn't have shadow.",
             "colours": [
@@ -6394,7 +6394,7 @@
         },
         {
             "id": "12017277-3f36-5caf-90a0-d880d7b28f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7a6ab5-8a8f-492c-8484-3089354ce8cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7a6ab5-8a8f-492c-8484-3089354ce8cf.jpg?1",
             "name": "Ashcoat Bear",
             "text": "Flash (You may play this spell any time you could play an instant.)",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "69cfd1a3-9d32-582e-9a73-69d4079bdd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3eb61f4-627b-4f42-85aa-eb676a035fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3eb61f4-627b-4f42-85aa-eb676a035fbd.jpg?1",
             "name": "Aspect of Mongoose",
             "text": "Enchant creature\nEnchanted creature can't be the target of spells or abilities.\nWhen Aspect of Mongoose is put into a graveyard from play, return Aspect of Mongoose to its owner's hand.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "b732ec9a-5ae4-5fed-b637-76db8d379138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d506b1c-f329-4e07-8926-a87b4abf16a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d506b1c-f329-4e07-8926-a87b4abf16a7.jpg?1",
             "name": "Chameleon Blur",
             "text": "Prevent all damage that creatures would deal to players this turn.",
             "colours": [
@@ -6494,7 +6494,7 @@
         },
         {
             "id": "21ab4d9a-be7e-5407-964c-405a8ab1ba2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670521c3-df02-487d-a299-49419e41889f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670521c3-df02-487d-a299-49419e41889f.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than play this card from your hand, you may pay {G} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "a0b4caef-b318-56ba-8b79-87f59b83c8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49f5835-c933-4ba7-a3c9-34f4eb01f00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49f5835-c933-4ba7-a3c9-34f4eb01f00d.jpg?1",
             "name": "Durkwood Tracker",
             "text": "{1}{G}, {T}: If Durkwood Tracker is in play, it deals damage equal to its power to target attacking creature. That creature deals damage equal to its power to Durkwood Tracker.",
             "colours": [
@@ -6562,7 +6562,7 @@
         },
         {
             "id": "629da528-b6c3-5c66-afe0-743caf9c3322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c0486a-288d-443a-bb07-62dc1dddaed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c0486a-288d-443a-bb07-62dc1dddaed7.jpg?1",
             "name": "Fungus Sliver",
             "text": "All Slivers have \"Whenever this creature is dealt damage, put a +1/+1 counter on it.\" (The damage is dealt before the counter is put on.)",
             "colours": [
@@ -6597,7 +6597,7 @@
         },
         {
             "id": "270295d3-10f7-5559-b38f-ff40495b67cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09135b0-fd57-4205-aa74-c9869946c264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09135b0-fd57-4205-aa74-c9869946c264.jpg?1",
             "name": "Gemhide Sliver",
             "text": "All Slivers have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6631,7 +6631,7 @@
         },
         {
             "id": "9c1ae99b-888d-551e-98e5-10839545454b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118253e9-f33a-455d-b785-dd9df657e7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118253e9-f33a-455d-b785-dd9df657e7cf.jpg?1",
             "name": "Glass Asp",
             "text": "Whenever Glass Asp deals combat damage to a player, that player loses 2 life at the beginning of his or her next draw step unless he or she pays {2} before that step.",
             "colours": [
@@ -6665,7 +6665,7 @@
         },
         {
             "id": "7aa3c8e1-2b60-5971-8092-aca90bc49497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dfa231-349a-4dce-bed6-c82a136fe0a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dfa231-349a-4dce-bed6-c82a136fe0a1.jpg?1",
             "name": "Greenseeker",
             "text": "{G}, {T}, Discard a card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "836e2440-49f3-58ea-b7cd-aa4476131a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561a4bb5-285a-4d52-b372-d165e442cff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561a4bb5-285a-4d52-b372-d165e442cff3.jpg?1",
             "name": "Havenwood Wurm",
             "text": "Flash (You may play this spell any time you could play an instant.)\nTrample",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "798bdc6b-6bf5-5736-a9f9-8381007be8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf4fd75-34b1-4afa-b8cd-777dfc9e6376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf4fd75-34b1-4afa-b8cd-777dfc9e6376.jpg?1",
             "name": "Herd Gnarr",
             "text": "Whenever another creature comes into play under your control, Herd Gnarr gets +2/+2 until end of turn.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "7e9e4e57-ef52-59b0-9a74-3bb4018e1450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6969-e579-4b28-a76b-5a99c7488f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6969-e579-4b28-a76b-5a99c7488f15.jpg?1",
             "name": "Hypergenesis",
             "text": "Hypergenesis is green.\nSuspend 3\u2014{1}{G}{G}\nStarting with you, each player may put an artifact, creature, enchantment, or land card from his or her hand into play. Repeat this process until no one puts a card into play.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "b4a10492-668a-50b6-a17c-35d0c7bb072b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b524bb-5a18-4dda-9c45-26ce9ff0f0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b524bb-5a18-4dda-9c45-26ce9ff0f0c1.jpg?1",
             "name": "Krosan Grip",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -6832,7 +6832,7 @@
         },
         {
             "id": "73847b9e-7f90-5abc-b282-f7ed6616d33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ba1a0-eb35-4622-a7c5-6f9eb1357e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ba1a0-eb35-4622-a7c5-6f9eb1357e23.jpg?1",
             "name": "Magus of the Candelabra",
             "text": "{X}, {T}: Untap X target lands.",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "0f6bddbb-f465-5174-ba0b-7361180500a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7b2c47-2123-45c1-993c-e7a2c9438855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7b2c47-2123-45c1-993c-e7a2c9438855.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you played this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -6899,7 +6899,7 @@
         },
         {
             "id": "246a1421-6d8b-5803-aa99-139888855829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8c52f-e608-4710-872f-8a8ae2b5c00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8c52f-e608-4710-872f-8a8ae2b5c00c.jpg?1",
             "name": "Might Sliver",
             "text": "All Slivers get +2/+2.",
             "colours": [
@@ -6933,7 +6933,7 @@
         },
         {
             "id": "32516e53-b40d-5ce1-adf1-b86724b8a337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0eb32c-89b1-40be-a77c-62c114a73ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0eb32c-89b1-40be-a77c-62c114a73ccc.jpg?1",
             "name": "Molder",
             "text": "Destroy target artifact or enchantment with converted mana cost X. It can't be regenerated. You gain X life.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "c5cc6063-9c77-5a50-9050-673f4186ebf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6841dbf6-5023-4612-bbd7-182fd35b05c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6841dbf6-5023-4612-bbd7-182fd35b05c8.jpg?1",
             "name": "Mwonvuli Acid-Moss",
             "text": "Destroy target land. Search your library for a Forest card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -6997,7 +6997,7 @@
         },
         {
             "id": "d249b9d9-6945-5d98-9ec5-93987e0308b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e75970f-b41e-406a-9c22-f5df871e70e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e75970f-b41e-406a-9c22-f5df871e70e6.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman comes into play, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than play this card from your hand, you may pay {2}{G}{G} and remove it from the game with a time counter on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "9f801cce-88d8-5255-b210-f264ce9597a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d759b5-1739-414e-9616-723625883ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d759b5-1739-414e-9616-723625883ebf.jpg?1",
             "name": "Pendelhaven Elder",
             "text": "{T}: Each 1/1 creature you control gets +1/+2 until end of turn.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "10ac706e-ccda-5576-bcd8-4b4d09939f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a989ac1-df69-45e7-98bf-564cc7c38973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a989ac1-df69-45e7-98bf-564cc7c38973.jpg?1",
             "name": "Penumbra Spider",
             "text": "Penumbra Spider can block as though it had flying.\nWhen Penumbra Spider is put into a graveyard from play, put a 2/4 black Spider creature token into play that can block as though it had flying.",
             "colours": [
@@ -7101,7 +7101,7 @@
         },
         {
             "id": "ea72815b-f422-5def-9325-232822b2ea2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94722ba-adb5-4613-b8f0-da1c34591c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94722ba-adb5-4613-b8f0-da1c34591c10.jpg?1",
             "name": "Phantom Wurm",
             "text": "Phantom Wurm comes into play with four +1/+1 counters on it.\nIf damage would be dealt to Phantom Wurm, prevent that damage. Remove a +1/+1 counter from Phantom Wurm.",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "3df09e6b-4832-5ecc-9421-ec1ea99228a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7f5c-8a10-4037-9a94-42e0559b4b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7f5c-8a10-4037-9a94-42e0559b4b72.jpg?1",
             "name": "Primal Forcemage",
             "text": "Whenever another creature comes into play under your control, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7171,7 +7171,7 @@
         },
         {
             "id": "6f215f5e-1a33-51f5-a6bf-cd86961bf5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cbbdb-3bbc-48da-b5e3-fcdbddebec81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cbbdb-3bbc-48da-b5e3-fcdbddebec81.jpg?1",
             "name": "Savage Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Savage Thallid.\nRemove three spore counters from Savage Thallid: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Regenerate target Fungus.",
             "colours": [
@@ -7205,7 +7205,7 @@
         },
         {
             "id": "f7592a49-9e9e-51bb-b39f-5fb4ca23d475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6dece3-058c-4738-a22f-8893345ddd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6dece3-058c-4738-a22f-8893345ddd1c.jpg?1",
             "name": "Scarwood Treefolk",
             "text": "Scarwood Treefolk comes into play tapped.",
             "colours": [
@@ -7239,7 +7239,7 @@
         },
         {
             "id": "c07b8315-4e9a-55ff-a2c7-bc8f8861f840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aacabde-f5ec-4519-895d-17f5e48746ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aacabde-f5ec-4519-895d-17f5e48746ee.jpg?1",
             "name": "Scryb Ranger",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying, protection from blue\nReturn a Forest you control to its owner's hand: Untap target creature. Play this ability only once each turn.",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "d39abd2d-90b9-5666-83ee-64eb9f8e2dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f739e8-b4ba-426a-a159-0e0d5a0ebb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f739e8-b4ba-426a-a159-0e0d5a0ebb6f.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card and put it into play. Then shuffle your library.\nSuspend 2\u2014{G} (Rather than play this card from your hand, you may pay {G} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "2916dd37-9c22-5ac4-a75f-f76cbd0e882c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dff1c4-6297-46f6-9c70-544c67319dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dff1c4-6297-46f6-9c70-544c67319dd0.jpg?1",
             "name": "Spectral Force",
             "text": "Trample\nWhenever Spectral Force attacks, if defending player controls no black permanents, it doesn't untap during your next untap step.",
             "colours": [
@@ -7341,7 +7341,7 @@
         },
         {
             "id": "d98202e2-7ba7-5ef2-ab10-75a978149db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf3643a-502f-4736-8063-5b567bdfbcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf3643a-502f-4736-8063-5b567bdfbcc4.jpg?1",
             "name": "Spike Tiller",
             "text": "Spike Tiller comes into play with three +1/+1 counters on it.\n{2}, Remove a +1/+1 counter from Spike Tiller: Put a +1/+1 counter on target creature.\n{2}, Remove a +1/+1 counter from Spike Tiller: Target land becomes a 2/2 creature that's still a land. Put a +1/+1 counter on it.",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "b59f5c80-4e3e-5399-8dfd-7f354595af27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da698c63-f167-4129-a650-b50c080a24b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da698c63-f167-4129-a650-b50c080a24b5.jpg?1",
             "name": "Spinneret Sliver",
             "text": "All Slivers have \"This creature can block as though it had flying.\"",
             "colours": [
@@ -7409,7 +7409,7 @@
         },
         {
             "id": "32af5e58-7aae-559d-a93d-964e6f3c8e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f834b1f-9f05-4553-a9b5-828a8348ed30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f834b1f-9f05-4553-a9b5-828a8348ed30.jpg?1",
             "name": "Sporesower Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on each Fungus you control.\nRemove three spore counters from Sporesower Thallid: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "ed6263f0-3730-5cae-bebe-7efc61da627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967363f-1e05-4484-8790-47f7be68455c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967363f-1e05-4484-8790-47f7be68455c.jpg?1",
             "name": "Sprout",
             "text": "Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "966ad5c0-ab44-5282-b4e3-53618aa6a19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg?1",
             "name": "Squall Line",
             "text": "Squall Line deals X damage to each creature with flying and each player.",
             "colours": [
@@ -7507,7 +7507,7 @@
         },
         {
             "id": "c39cd306-325e-5cfc-98d6-af14ed12017d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b300e67-04d2-4c69-b516-c5cc0a6ff2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b300e67-04d2-4c69-b516-c5cc0a6ff2e7.jpg?1",
             "name": "Stonewood Invocation",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nTarget creature gets +5/+5 until end of turn and can't be the target of spells or abilities this turn.",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "42eac7c9-3e13-5484-8ac2-d61b4b908d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5a571a-f323-473a-b5ec-f881bea82ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5a571a-f323-473a-b5ec-f881bea82ce1.jpg?1",
             "name": "Strength in Numbers",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
             "colours": [
@@ -7571,7 +7571,7 @@
         },
         {
             "id": "a1af20e1-8690-5352-b1e9-6bfd1341c61e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac526fb0-e6d0-4ee0-9888-15098c1704df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac526fb0-e6d0-4ee0-9888-15098c1704df.jpg?1",
             "name": "Thallid Germinator",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid Germinator.\nRemove three spore counters from Thallid Germinator: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "ac4ff448-52b3-5e47-b429-9f153a38ccd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee36256-022f-49b3-8914-9b1c2f4dc506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee36256-022f-49b3-8914-9b1c2f4dc506.jpg?1",
             "name": "Thallid Shell-Dweller",
             "text": "Defender\nAt the beginning of your upkeep, put a spore counter on Thallid Shell-Dweller.\nRemove three spore counters from Thallid Shell-Dweller: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "257dbe04-2cca-56b4-b3cc-5621320f3280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b0be6d-9183-4938-b7a1-ae7f04ba78a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b0be6d-9183-4938-b7a1-ae7f04ba78a0.jpg?1",
             "name": "Thelon of Havenwood",
             "text": "Each Fungus gets +1/+1 for each spore counter on it.\n{B}{G}, Remove a Fungus card in a graveyard from the game: Put a spore counter on each Fungus in play.",
             "colours": [
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "989491ed-7968-57b9-9af3-c770484b89f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95b6b0-ff20-405f-81ae-87f5cce45fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95b6b0-ff20-405f-81ae-87f5cce45fb2.jpg?1",
             "name": "Thelonite Hermit",
             "text": "All Saprolings get +1/+1.\nMorph {3}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Thelonite Hermit is turned face up, put four 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "52bb7290-aefc-56fb-bd52-4bcad8c588f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe0c8e-f361-4eac-8c2c-ca6602dad352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe0c8e-f361-4eac-8c2c-ca6602dad352.jpg?1",
             "name": "Thrill of the Hunt",
             "text": "Target creature gets +1/+2 until end of turn.\nFlashback {W} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "cbdc2caf-3750-56b7-981f-615e80983f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832b67f4-60ec-44ad-9bcc-c3d247c22705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832b67f4-60ec-44ad-9bcc-c3d247c22705.jpg?1",
             "name": "Tromp the Domains",
             "text": "Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "78b74b6e-b868-57d7-b59a-de54ecdd4d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg?1",
             "name": "Unyaro Bees",
             "text": "Flying\n{G}: Unyaro Bees gets +1/+1 until end of turn.\n{3}{G}, Sacrifice Unyaro Bees: Unyaro Bees deals 2 damage to target creature or player.",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "4483c6a8-2ec3-52ff-8fc5-47c43dbff7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd1d130-98e7-4898-9f13-2bb58fa4777b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd1d130-98e7-4898-9f13-2bb58fa4777b.jpg?1",
             "name": "Verdant Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has \"At the beginning of each upkeep, put a 1/1 green Saproling creature token into play under your control.\"",
             "colours": [
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "c5ad72cf-b4f9-5386-8680-2049bc9e0624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad370-1b7e-4926-9580-7acf919787f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad370-1b7e-4926-9580-7acf919787f2.jpg?1",
             "name": "Wormwood Dryad",
             "text": "{G}: Wormwood Dryad gains forestwalk until end of turn and it deals 1 damage to you.\n{B}: Wormwood Dryad gains swampwalk until end of turn and it deals 1 damage to you.",
             "colours": [
@@ -7880,7 +7880,7 @@
         },
         {
             "id": "050990c5-1197-5da5-9131-b91da0e474c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85402aef-3fb1-4e78-9103-e2e47e5f3c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85402aef-3fb1-4e78-9103-e2e47e5f3c65.jpg?1",
             "name": "Wurmcalling",
             "text": "Buyback {2}{G} (You may pay an additional {2}{G} as you play this spell. If you do, put this card into your hand as it resolves.)\nPut an X/X green Wurm creature token into play.",
             "colours": [
@@ -7912,7 +7912,7 @@
         },
         {
             "id": "6041bf6c-3880-5f60-9ddf-badb8cab75f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b56d65-b1ac-4aa3-aee6-433770c3dfbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b56d65-b1ac-4aa3-aee6-433770c3dfbc.jpg?1",
             "name": "Yavimaya Dryad",
             "text": "Forestwalk\nWhen Yavimaya Dryad comes into play, you may search your library for a Forest card and put it into play tapped under target player's control. If you do, shuffle your library.",
             "colours": [
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "41ca0689-29d2-5470-a1ec-6b5248459173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955028d2-33df-4295-8ee3-572e5979b04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955028d2-33df-4295-8ee3-572e5979b04c.jpg?1",
             "name": "Dementia Sliver",
             "text": "All Slivers have \"{T}: Name a card. Target opponent reveals a card at random from his or her hand. If it's the named card, that player discards it. Play this ability only during your turn.\"",
             "colours": [
@@ -7982,7 +7982,7 @@
         },
         {
             "id": "71c97040-a17b-5c32-b084-e41c9c84fede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3828efe-cbe1-473c-8dde-60ea9aaf23a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3828efe-cbe1-473c-8dde-60ea9aaf23a2.jpg?1",
             "name": "Dralnu, Lich Lord",
             "text": "If damage would be dealt to Dralnu, sacrifice that many permanents instead.\n{T}: Target instant or sorcery card in your graveyard has flashback until end of turn. Its flashback cost becomes equal to its mana cost as you play it. (You may play that card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "2009197f-fe1c-5052-a000-158ea739de84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d3f5a0d-029e-44fd-b3e6-c70176b5b4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d3f5a0d-029e-44fd-b3e6-c70176b5b4ac.jpg?1",
             "name": "Firewake Sliver",
             "text": "All Slivers have haste and \"{1}, Sacrifice this creature: Target Sliver gets +2/+2 until end of turn.\"",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "e5ee5132-3ae9-50c4-8cae-030858c8333e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64eb10d1-22c6-4848-a7f4-c6ccd2c66dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64eb10d1-22c6-4848-a7f4-c6ccd2c66dae.jpg?1",
             "name": "Ghostflame Sliver",
             "text": "All Slivers are colorless.",
             "colours": [
@@ -8093,7 +8093,7 @@
         },
         {
             "id": "dc07cf83-225e-5667-b245-43e2736cd98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7904997-a857-44f0-91d8-b78651bb4e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7904997-a857-44f0-91d8-b78651bb4e83.jpg?1",
             "name": "Harmonic Sliver",
             "text": "All Slivers have \"When this creature comes into play, destroy target artifact or enchantment.\"",
             "colours": [
@@ -8129,7 +8129,7 @@
         },
         {
             "id": "a93c28ea-df82-567b-8179-273d827caf57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd98dea-8012-49bb-84cf-dd8ed5c032cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd98dea-8012-49bb-84cf-dd8ed5c032cf.jpg?1",
             "name": "Ith, High Arcanist",
             "text": "Vigilance\n{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nSuspend 4\u2014{W}{U}",
             "colours": [
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "2577f2fd-bfe3-57c7-bf7c-ae960afc78a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444fa5a5-b5b0-4555-bd69-67c1c0cbf317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444fa5a5-b5b0-4555-bd69-67c1c0cbf317.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent plays a spell, Kaervek the Merciless deals damage to target creature or player equal to that spell's converted mana cost.",
             "colours": [
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "8aaabb76-19e5-5446-9927-ee74b0d55513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5deaec5-499d-4e19-b879-8bcd1dc35f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5deaec5-499d-4e19-b879-8bcd1dc35f3e.jpg?1",
             "name": "Mishra, Artificer Prodigy",
             "text": "Whenever you play an artifact spell, you may search your graveyard, hand, and/or library for a card with the same name as that spell and put it into play. If you search your library this way, shuffle it.",
             "colours": [
@@ -8248,7 +8248,7 @@
         },
         {
             "id": "9f057de2-6f99-55d4-b351-3087d8542821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75af1cc6-cb40-48c8-818b-91e64bdbe691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75af1cc6-cb40-48c8-818b-91e64bdbe691.jpg?1",
             "name": "Opaline Sliver",
             "text": "All Slivers have \"Whenever this creature becomes the target of a spell an opponent controls, you may draw a card.\"",
             "colours": [
@@ -8284,7 +8284,7 @@
         },
         {
             "id": "0d55af7c-79ac-59b6-ac4f-3355a3f4c014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34bb91e-138b-4491-bb2d-5df2cd272bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34bb91e-138b-4491-bb2d-5df2cd272bf0.jpg?1",
             "name": "Saffi Eriksdotter",
             "text": "Sacrifice Saffi Eriksdotter: When target creature is put into your graveyard from play this turn, return that card to play.",
             "colours": [
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "9a63a154-421b-5b10-8c12-66841bf66f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb6f85b-60e9-4191-b557-ec952b7f22fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb6f85b-60e9-4191-b557-ec952b7f22fc.jpg?1",
             "name": "Scion of the Ur-Dragon",
             "text": "Flying\n{2}: Search your library for a Dragon card and put it into your graveyard. If you do, Scion of the Ur-Dragon becomes a copy of that card until end of turn. Then shuffle your library.",
             "colours": [
@@ -8368,7 +8368,7 @@
         },
         {
             "id": "a3c8e3b0-03f2-57c8-af32-69dd18548284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c62102-0562-4b09-a05d-986aa4212f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c62102-0562-4b09-a05d-986aa4212f44.jpg?1",
             "name": "Stonebrow, Krosan Hero",
             "text": "Trample\nWhenever a creature you control with trample attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -8407,7 +8407,7 @@
         },
         {
             "id": "ec2f15d5-ff9f-5b84-baf4-fda3f1598328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d662-3740-4704-9184-c42c6a16d829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d662-3740-4704-9184-c42c6a16d829.jpg?1",
             "name": "Assembly-Worker",
             "text": "{T}: Target Assembly-Worker gets +1/+1 until end of turn.",
             "colours": [],
@@ -8438,7 +8438,7 @@
         },
         {
             "id": "f2624c24-697f-5103-bb36-93870aafc71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ae7c6-347c-4b29-b7a9-3ca3bb050396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ae7c6-347c-4b29-b7a9-3ca3bb050396.jpg?1",
             "name": "Brass Gnat",
             "text": "Flying\nBrass Gnat doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap Brass Gnat.",
             "colours": [],
@@ -8469,7 +8469,7 @@
         },
         {
             "id": "4af8162f-35b5-5ecf-9985-003443e0e0fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee874779-e654-48f0-8f2d-cc98ef150d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee874779-e654-48f0-8f2d-cc98ef150d75.jpg?1",
             "name": "Candles of Leng",
             "text": "{4}, {T}: Reveal the top card of your library. If it has the same name as a card in your graveyard, put it into your graveyard. Otherwise, draw a card.",
             "colours": [],
@@ -8497,7 +8497,7 @@
         },
         {
             "id": "22f99e59-832f-525c-af59-3f9d93c16db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7a1357-debd-49b0-9fd5-560d5b3f589e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7a1357-debd-49b0-9fd5-560d5b3f589e.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color to your mana pool.\nWhen Chromatic Star is put into a graveyard from play, draw a card.",
             "colours": [],
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "ec808989-a0ac-57bf-a51f-35f9a7993a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acd482c-9815-4ff5-99ef-fb1a014251bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acd482c-9815-4ff5-99ef-fb1a014251bb.jpg?1",
             "name": "Chronatog Totem",
             "text": "{T}: Add {U} to your mana pool.\n{1}{U}: Chronatog Totem becomes a 1/2 blue Atog artifact creature until end of turn.\n{0}: Chronatog Totem gets +3/+3 until end of turn. You skip your next turn. Play this ability only once each turn and only if Chronatog Totem is a creature.",
             "colours": [],
@@ -8555,7 +8555,7 @@
         },
         {
             "id": "04c87875-80e6-5752-beda-6335739e404e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54522c50-5333-47ac-ba3e-d87c599404c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54522c50-5333-47ac-ba3e-d87c599404c4.jpg?1",
             "name": "Clockwork Hydra",
             "text": "Clockwork Hydra comes into play with four +1/+1 counters on it.\nWhenever Clockwork Hydra attacks or blocks, remove a +1/+1 counter from it. If you do, Clockwork Hydra deals 1 damage to target creature or player.\n{T}: Put a +1/+1 counter on Clockwork Hydra.",
             "colours": [],
@@ -8586,7 +8586,7 @@
         },
         {
             "id": "ad57af82-3f4a-520d-8d34-33d6b335651d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba87d-3c8c-4f38-bdd8-51072ba6365b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba87d-3c8c-4f38-bdd8-51072ba6365b.jpg?1",
             "name": "Foriysian Totem",
             "text": "{T}: Add {R} to your mana pool.\n{4}{R}: Foriysian Totem becomes a 4/4 red Giant artifact creature with trample until end of turn.\nAs long as Foriysian Totem is a creature, it can block an additional creature.",
             "colours": [],
@@ -8616,7 +8616,7 @@
         },
         {
             "id": "cfa8f461-5bbb-5480-a9df-5913a28e3db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109f93ac-86e9-42f1-9fba-fec8bcd521b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109f93ac-86e9-42f1-9fba-fec8bcd521b0.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power comes into play, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds one mana of that color to his or her mana pool.",
             "colours": [],
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "a67859a0-c4d9-574c-bf5e-e6865db44531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685fc2f8-4cad-46a1-b9d7-d94c13990994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685fc2f8-4cad-46a1-b9d7-d94c13990994.jpg?1",
             "name": "Hivestone",
             "text": "Creatures you control are Slivers in addition to their other creature types.",
             "colours": [],
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "b32b03e6-17d7-5815-a779-c2f20b6c4a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce2c6d7-505b-490b-9c6f-b5166c9ff71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce2c6d7-505b-490b-9c6f-b5166c9ff71d.jpg?1",
             "name": "Jhoira's Timebug",
             "text": "{T}: Choose target permanent you control or suspended card you own. If that permanent or card has a time counter on it, you may remove a time counter from it or put another time counter on it.",
             "colours": [],
@@ -8703,7 +8703,7 @@
         },
         {
             "id": "8dcb9b69-a576-50c5-88a0-5b1d84c3587c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b316f198-4465-4fb5-a7a6-a92bf8eae8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b316f198-4465-4fb5-a7a6-a92bf8eae8c1.jpg?1",
             "name": "Locket of Yesterdays",
             "text": "Spells you play cost {1} less to play for each card with the same name as that spell in your graveyard.",
             "colours": [],
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "f9500c62-96f6-53d7-8449-acf13347d12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73127ee0-9a0c-48fa-9c60-b4c600ace8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73127ee0-9a0c-48fa-9c60-b4c600ace8f7.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than play this card from your hand, pay {0} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "5ae08f1b-0360-5c61-84e2-8d9a27564a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205ac7e-4d4e-4849-b3ae-1e4e0558fd96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205ac7e-4d4e-4849-b3ae-1e4e0558fd96.jpg?1",
             "name": "Paradise Plume",
             "text": "As Paradise Plume comes into play, choose a color.\nWhenever a player plays a spell of the chosen color, you may gain 1 life.\n{T}: Add one mana of the chosen color to your mana pool.",
             "colours": [],
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "941ee164-4807-5e2f-9b2f-fecefe7d19f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b9fee-88ce-4725-82a5-335d8645aca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b9fee-88ce-4725-82a5-335d8645aca2.jpg?1",
             "name": "Phyrexian Totem",
             "text": "{T}: Add {B} to your mana pool.\n{2}{B}: Phyrexian Totem becomes a 5/5 black Horror artifact creature with trample until end of turn.\nWhenever Phyrexian Totem is dealt damage, if it's a creature, sacrifice that many permanents.",
             "colours": [],
@@ -8817,7 +8817,7 @@
         },
         {
             "id": "69f00f65-e6ff-5a44-bd0f-b4604b9308c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f058a7-c3c7-4bdf-a66c-a2636a8bd9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f058a7-c3c7-4bdf-a66c-a2636a8bd9db.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8845,7 +8845,7 @@
         },
         {
             "id": "9020d538-c5d9-5827-9e44-458ffc955b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37a6cf7-f239-4bca-b4c3-a48932ef56b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37a6cf7-f239-4bca-b4c3-a48932ef56b5.jpg?1",
             "name": "Sarpadian Empires, Vol. VII",
             "text": "As Sarpadian Empires, Vol. VII comes into play, choose white Citizen, blue Camarid, black Thrull, red Goblin, or green Saproling.\n{3}, {T}: Put a 1/1 creature token of the chosen color and type into play.",
             "colours": [],
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "422d6c11-d2b9-54b4-a53d-2e1225011596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ca7425-a499-4864-b955-369ef2577849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ca7425-a499-4864-b955-369ef2577849.jpg?1",
             "name": "Stuffy Doll",
             "text": "As Stuffy Doll comes into play, choose a player.\nStuffy Doll is indestructible.\nWhenever damage is dealt to Stuffy Doll, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -8904,7 +8904,7 @@
         },
         {
             "id": "db55ae1e-e836-5aa6-aac5-00023d747048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc332da-e93f-45b1-912c-06af41b412e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc332da-e93f-45b1-912c-06af41b412e9.jpg?1",
             "name": "Thunder Totem",
             "text": "{T}: Add {W} to your mana pool.\n{1}{W}{W}: Thunder Totem becomes a 2/2 white Spirit artifact creature with flying and first strike until end of turn.",
             "colours": [],
@@ -8934,7 +8934,7 @@
         },
         {
             "id": "fad5a574-462c-57ad-aede-e9be9bbb07fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978d11e7-cfb7-41bf-bb98-deb79549a074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978d11e7-cfb7-41bf-bb98-deb79549a074.jpg?1",
             "name": "Triskelavus",
             "text": "Flying\nTriskelavus comes into play with three +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from Triskelavus: Put a 1/1 Triskelavite artifact creature token with flying into play. It has \"Sacrifice this creature: This creature deals 1 damage to target creature or player.\"",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "a620801e-351b-5c40-b20e-7de376c31c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg?1",
             "name": "Venser's Sliver",
             "text": "",
             "colours": [],
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "22e0b3e9-7437-52ba-91bf-1c0f3bc2790f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3275df49-c3f1-4310-87dd-25e3e0ee7fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3275df49-c3f1-4310-87dd-25e3e0ee7fca.jpg?1",
             "name": "Weatherseed Totem",
             "text": "{T}: Add {G} to your mana pool.\n{2}{G}{G}{G}: Weatherseed Totem becomes a 5/3 green Treefolk artifact creature with trample until end of turn.\nWhen Weatherseed Totem is put into a graveyard from play, if it was a creature, return this card to its owner's hand.",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "dfd8e69a-0cca-5091-bd98-d37cbcb334ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af09af65-0a3b-42df-b0fd-372e2158beac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af09af65-0a3b-42df-b0fd-372e2158beac.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}, {T}: Put target artifact card in your graveyard on top of your library.",
             "colours": [],
@@ -9058,7 +9058,7 @@
         },
         {
             "id": "42a6cdec-8f5c-5f33-a02d-19557a053373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cead86-b8ff-4975-90b2-3badcc452fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cead86-b8ff-4975-90b2-3badcc452fdb.jpg?1",
             "name": "Calciform Pools",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Calciform Pools.\n{1}, Remove X storage counters from Calciform Pools: Add X mana in any combination of {W} and/or {U} to your mana pool.",
             "colours": [],
@@ -9089,7 +9089,7 @@
         },
         {
             "id": "6304fa9f-6abd-58bf-91c0-e516df9accef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a83915-07b7-4912-bdf2-089b05796378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a83915-07b7-4912-bdf2-089b05796378.jpg?1",
             "name": "Dreadship Reef",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Dreadship Reef.\n{1}, Remove X storage counters from Dreadship Reef: Add X mana in any combination of {U} and/or {B} to your mana pool.",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "60e32328-b786-5483-a186-5970b31308fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad23cd0e-6871-4ba6-b5bf-cfd14f8f71b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad23cd0e-6871-4ba6-b5bf-cfd14f8f71b2.jpg?1",
             "name": "Flagstones of Trokair",
             "text": "{T}: Add {W} to your mana pool.\nWhen Flagstones of Trokair is put into a graveyard from play, you may search your library for a Plains card and put it into play tapped. If you do, shuffle your library.",
             "colours": [],
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "8b3736a1-01b2-551a-8b97-8d924518ab4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4521b3-a3b0-4a1d-a623-cc630058eee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4521b3-a3b0-4a1d-a623-cc630058eee2.jpg?1",
             "name": "Fungal Reaches",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Fungal Reaches.\n{1}, Remove X storage counters from Fungal Reaches: Add X mana in any combination of {R} and/or {G} to your mana pool.",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "3bf15b28-2abc-5ef1-9703-2a5c1c71e693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d74254-4750-4fb3-9e53-473a5f98b315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d74254-4750-4fb3-9e53-473a5f98b315.jpg?1",
             "name": "Gemstone Caverns",
             "text": "If Gemstone Caverns is in your opening hand and you're not playing first, you may begin the game with Gemstone Caverns in play with a luck counter on it. If you do, remove a card in your hand from the game.\n{T}: Add {1} to your mana pool. If Gemstone Caverns has a luck counter on it, instead add one mana of any color to your mana pool.",
             "colours": [],
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "bd45d763-43b8-5c97-977e-a03c8ba8000e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde3b332-5bc3-47bc-ba24-5437f04c21a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde3b332-5bc3-47bc-ba24-5437f04c21a0.jpg?1",
             "name": "Kher Keep",
             "text": "{T}: Add {1} to your mana pool.\n{1}{R}, {T}: Put a 0/1 red Kobold creature token named Kobolds of Kher Keep into play.",
             "colours": [],
@@ -9245,7 +9245,7 @@
         },
         {
             "id": "6aefe6ee-17ed-57e6-b574-b42182965f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d090288c-48f3-49fe-87c4-3766eb7bb240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d090288c-48f3-49fe-87c4-3766eb7bb240.jpg?1",
             "name": "Molten Slagheap",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Molten Slagheap.\n{1}, Remove X storage counters from Molten Slagheap: Add X mana in any combination of {B} and/or {R} to your mana pool.",
             "colours": [],
@@ -9276,7 +9276,7 @@
         },
         {
             "id": "10e19a9a-4e37-5f00-9fc4-cdda64fee1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adc67a6-9b05-4480-be0c-70b860075d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adc67a6-9b05-4480-be0c-70b860075d70.jpg?1",
             "name": "Saltcrusted Steppe",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Saltcrusted Steppe.\n{1}, Remove X storage counters from Saltcrusted Steppe: Add X mana in any combination of {G} and/or {W} to your mana pool.",
             "colours": [],
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "f36008e7-7255-5624-bdb2-f17172620a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bfe849-a508-4fa8-8999-909fe8ec34fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bfe849-a508-4fa8-8999-909fe8ec34fa.jpg?1",
             "name": "Swarmyard",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Regenerate target Insect, Rat, Spider, or Squirrel.",
             "colours": [],
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "8cf08475-c4e7-53fe-8e5a-1120d2eaf18d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd097ea2-0a1c-44a0-824b-d5373df513fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd097ea2-0a1c-44a0-824b-d5373df513fb.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -9363,7 +9363,7 @@
         },
         {
             "id": "6a45518e-533c-5e1f-bd45-7a8882cb63b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22d97f3-08cf-4c19-bbe2-5a36096187cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22d97f3-08cf-4c19-bbe2-5a36096187cd.jpg?1",
             "name": "Urza's Factory",
             "text": "{T}: Add {1} to your mana pool.\n{7}, {T}: Put a 2/2 Assembly-Worker artifact creature token into play.",
             "colours": [],
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "201e0fa2-e371-5fd7-af74-f5b30ff2c5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc9498-7397-4857-87fe-7c9010944ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc9498-7397-4857-87fe-7c9010944ed8.jpg?1",
             "name": "Vesuva",
             "text": "As Vesuva comes into play, you may choose a land in play. If you do, Vesuva comes into play tapped as a copy of the chosen land.",
             "colours": [],
@@ -9421,7 +9421,7 @@
         },
         {
             "id": "c94a3c6b-697e-5845-bb21-6662099fc15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9a8337-e4ca-458d-8fcd-672d8d6f1c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9a8337-e4ca-458d-8fcd-672d8d6f1c0d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "e884bd08-78b6-5aba-8472-6ff899e4de94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0aaf3-eba0-445e-b560-f889b800e6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0aaf3-eba0-445e-b560-f889b800e6b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "18ace20b-f8fb-57ed-934e-91665ff073b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d056a94a-a07d-4494-a75c-b3f6f59457b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d056a94a-a07d-4494-a75c-b3f6f59457b3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "647af4f2-4815-59a4-8254-fad8a14d97be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa21cca2-59cb-4223-b67b-1a8fc54aadd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa21cca2-59cb-4223-b67b-1a8fc54aadd8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9573,7 +9573,7 @@
         },
         {
             "id": "dc528aa4-749c-57cb-9b1b-f1fcb1ef70b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdeb2c-afb8-4850-bcdc-86283ffa3486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdeb2c-afb8-4850-bcdc-86283ffa3486.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9611,7 +9611,7 @@
         },
         {
             "id": "1ba1d4de-7a1e-5c02-bef1-6634faf3a13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08915c9-78ff-450b-a47f-0c9678d16bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08915c9-78ff-450b-a47f-0c9678d16bbd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9649,7 +9649,7 @@
         },
         {
             "id": "c238ce67-4a6a-5db9-993c-560a7a6fa4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8c7cf-6705-4ff7-8aa8-113c1400ffda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8c7cf-6705-4ff7-8aa8-113c1400ffda.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9687,7 +9687,7 @@
         },
         {
             "id": "2b4eef37-d6b1-5627-950c-09467916099b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1a989a-38d4-4225-a41f-37d54f2f42ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1a989a-38d4-4225-a41f-37d54f2f42ae.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9725,7 +9725,7 @@
         },
         {
             "id": "e412fa48-3d44-5ad3-b8b0-9bc828f77c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fecc759-61fa-4040-9b46-710512baa4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fecc759-61fa-4040-9b46-710512baa4bf.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "67294962-7f41-58bb-a996-3c401b5648d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53dbcc0-169d-4b5c-b4e5-d82716c1539d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53dbcc0-169d-4b5c-b4e5-d82716c1539d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9801,7 +9801,7 @@
         },
         {
             "id": "1414305d-ace2-52d4-a571-73b0995ff8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dc4523-075d-425e-9b53-77921d26c173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dc4523-075d-425e-9b53-77921d26c173.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9839,7 +9839,7 @@
         },
         {
             "id": "a1d25dbb-b5ab-5bbb-ac60-49fefccd738a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd634a88-c114-469a-8133-59cfc9bf3215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd634a88-c114-469a-8133-59cfc9bf3215.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9877,7 +9877,7 @@
         },
         {
             "id": "af6ec5e3-13c3-547f-99fa-5354d4fc563a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34229e7-5dc4-47b3-9ba2-609e5b3ca6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34229e7-5dc4-47b3-9ba2-609e5b3ca6c2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9915,7 +9915,7 @@
         },
         {
             "id": "3b4081b0-f088-50e5-a4ec-9ff3fff698fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c71906a-f885-49ba-a889-8baf4e74cce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c71906a-f885-49ba-a889-8baf4e74cce8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "ada0390b-d92e-595c-bfbe-d0bec68ad68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e3961c-d092-4a15-b5db-d7b5c70e4fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e3961c-d092-4a15-b5db-d7b5c70e4fc1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9991,7 +9991,7 @@
         },
         {
             "id": "62e143d3-1aa6-5305-a3a4-99df42570c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae3e69d-ec38-43e2-b4a2-3a9064835a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae3e69d-ec38-43e2-b4a2-3a9064835a97.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10029,7 +10029,7 @@
         },
         {
             "id": "c7a20c53-3a15-5d61-bbdc-9a88111c5d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bd3e1-45ef-43b7-8796-6085842278df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bd3e1-45ef-43b7-8796-6085842278df.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10067,7 +10067,7 @@
         },
         {
             "id": "f5f66768-18d6-592d-9e60-52d2496f21f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a10ed4f-2c9a-424d-bcca-730af7727854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a10ed4f-2c9a-424d-bcca-730af7727854.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10105,7 +10105,7 @@
         },
         {
             "id": "40f7153f-a960-5bf2-abd3-d2e90b5da97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b176d24-a4d6-489e-af69-4547693e7de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b176d24-a4d6-489e-af69-4547693e7de1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "c890761b-781b-56e6-a1bc-c8a709c22a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393d66f7-7dbf-4a92-912f-377f99c8f164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393d66f7-7dbf-4a92-912f-377f99c8f164.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/Assets/Resources/Sets/TSR.json
+++ b/Assets/Resources/Sets/TSR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a4ac2a93-dac1-5a51-892c-4a3c5f7d058c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2b6d3a-15e7-4305-9384-3635159cb421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2b6d3a-15e7-4305-9384-3635159cb421.jpg?1",
             "name": "Amrou Scout",
             "text": "{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "ab4a70c6-9460-526f-9337-2b914d3a5e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c3c08-a91d-48cc-8837-993614b6a32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c3c08-a91d-48cc-8837-993614b6a32e.jpg?1",
             "name": "Amrou Seekers",
             "text": "Amrou Seekers can't be blocked except by artifact creatures and/or white creatures.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "a4281380-193f-5637-9a6a-907292c33fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cdee5-134f-4008-91ce-9e7d0fdb5750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cdee5-134f-4008-91ce-9e7d0fdb5750.jpg?1",
             "name": "Angel of Salvation",
             "text": "Flash; convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nWhen Angel of Salvation enters the battlefield, prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "69f967db-b2c6-53f4-81f9-7003ba349777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e39ea-20be-4196-992c-7ed2cb8150c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e39ea-20be-4196-992c-7ed2cb8150c1.jpg?1",
             "name": "Angel's Grace",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "b2e4d90a-7411-55c9-b089-a1ea0e2ec1dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf42b4-f767-48b7-b38c-b98306909f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf42b4-f767-48b7-b38c-b98306909f06.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "50c6c9e8-05fd-5e76-8826-823d21e99c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261691c8-371d-49b6-9c9b-50ece5984aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261691c8-371d-49b6-9c9b-50ece5984aa2.jpg?1",
             "name": "Aven Riftwatcher",
             "text": "Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher enters the battlefield or leaves the battlefield, you gain 2 life.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "427fd944-0c9e-5136-ae7e-068aaf945ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fd40fa-4144-41b4-b441-a71d09a11305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fd40fa-4144-41b4-b441-a71d09a11305.jpg?1",
             "name": "Benalish Cavalry",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "6ee1404f-dc19-538d-98b6-5a78456ce8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d57fb-abe1-483b-8b94-85d39a1c31e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d57fb-abe1-483b-8b94-85d39a1c31e1.jpg?1",
             "name": "Benalish Commander",
             "text": "Benalish Commander's power and toughness are each equal to the number of Soldiers you control.\nSuspend X\u2014{X}{W}{W}. X can't be 0.\nWhenever a time counter is removed from Benalish Commander while it's exiled, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "6dfcdb99-cb24-5d0f-831b-1b23ff9be5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1b493-2dec-4816-a427-4813a00ca3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1b493-2dec-4816-a427-4813a00ca3e9.jpg?1",
             "name": "Blade of the Sixth Pride",
             "text": "",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "7dd688ae-e9ec-5417-a8d6-e76c4ed9505c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a0a78e-08cc-4eb0-8891-6c3eec5b595b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a0a78e-08cc-4eb0-8891-6c3eec5b595b.jpg?1",
             "name": "Bound in Silence",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "3dbe0551-fa87-5302-ab22-20dc5da4da5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae9641c-5792-4f72-b40c-f029af28dab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae9641c-5792-4f72-b40c-f029af28dab9.jpg?1",
             "name": "Calciderm",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nVanishing 4 (This creature enters the battlefield with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "bf705ea3-4fb4-5ac8-a294-749829fdd1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b980a75-8d2d-4d56-be76-48159ef33631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b980a75-8d2d-4d56-be76-48159ef33631.jpg?1",
             "name": "Castle Raptors",
             "text": "Flying\nAs long as Castle Raptors is untapped, it gets +0/+2.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "1b7fc8c1-2e02-58a8-8dad-d88e5df9f18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f371f5-9c2a-4a00-a4d2-e4f97ac0f3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f371f5-9c2a-4a00-a4d2-e4f97ac0f3e0.jpg?1",
             "name": "Celestial Crusader",
             "text": "Flash\nSplit second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nFlying\nOther white creatures get +1/+1.",
             "colours": [
@@ -456,7 +456,7 @@
         },
         {
             "id": "ab448847-2974-57b9-a422-41a3e7362678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6cbece-f9d8-4c40-b72b-dfdb86430ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6cbece-f9d8-4c40-b72b-dfdb86430ff2.jpg?1",
             "name": "Children of Korlis",
             "text": "Sacrifice Children of Korlis: You gain life equal to the life you've lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -492,7 +492,7 @@
         },
         {
             "id": "37ce768c-95db-5ec5-860c-237b6016b709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a9dfa5-0e94-433e-8f4a-edfa2dac4913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a9dfa5-0e94-433e-8f4a-edfa2dac4913.jpg?1",
             "name": "Crovax, Ascendant Hero",
             "text": "Other white creatures get +1/+1.\nNonwhite creatures get -1/-1.\nPay 2 life: Return Crovax, Ascendant Hero to its owner's hand.",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "d6ba87c6-662d-5b41-926d-83cb8cdd07af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321ff631-54f0-4501-852a-569790d05cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321ff631-54f0-4501-852a-569790d05cf1.jpg?1",
             "name": "Duskrider Peregrine",
             "text": "Flying, protection from black\nSuspend 3\u2014{1}{W} (Rather than cast this card from your hand, you may pay {1}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "9def36a4-a8cb-5491-8415-ef73a6a91c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb5c6e6-7251-4b80-9561-742442d8a497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb5c6e6-7251-4b80-9561-742442d8a497.jpg?1",
             "name": "Errant Doomsayers",
             "text": "{T}: Tap target creature with toughness 2 or less.",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "44589fec-d9a0-5fab-9e50-5064fe738cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af529-6ba1-4900-a6f6-7647c9632e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af529-6ba1-4900-a6f6-7647c9632e11.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "b0347377-17fa-5231-9085-1211ed5ccc65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d038ee-1648-49cf-8775-c191fca252aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d038ee-1648-49cf-8775-c191fca252aa.jpg?1",
             "name": "Griffin Guide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\nWhen enchanted creature dies, create a 2/2 white Griffin creature token with flying.",
             "colours": [
@@ -664,7 +664,7 @@
         },
         {
             "id": "12347e0d-539b-5c61-97ff-abc62b5bd835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b1b580-4a2c-41a4-a1e0-85b659b3a30e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b1b580-4a2c-41a4-a1e0-85b659b3a30e.jpg?1",
             "name": "Ivory Giant",
             "text": "When Ivory Giant enters the battlefield, tap all nonwhite creatures.\nSuspend 5\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "d219a00b-c944-59cf-8fcb-2d455be1a19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce06e910-e130-4975-92db-1399ff3d44b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce06e910-e130-4975-92db-1399ff3d44b7.jpg?1",
             "name": "Judge Unworthy",
             "text": "Choose target attacking or blocking creature. Scry 3, then reveal the top card of your library. Judge Unworthy deals damage equal to that card's converted mana cost to that creature.",
             "colours": [
@@ -730,7 +730,7 @@
         },
         {
             "id": "b97c45c1-96c0-5e50-9d70-33d4ba231701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693bec1-9bd9-4840-9d7f-954f92d968c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693bec1-9bd9-4840-9d7f-954f92d968c9.jpg?1",
             "name": "Knight of Sursi",
             "text": "Flying; flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nSuspend 3\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -765,7 +765,7 @@
         },
         {
             "id": "79232f04-8438-5dc5-8782-4e97a2d1ef4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ac76c0-54ce-41b2-9000-e21eecaf7e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ac76c0-54ce-41b2-9000-e21eecaf7e99.jpg?1",
             "name": "Knight of the Holy Nimbus",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Knight of the Holy Nimbus would be destroyed, regenerate it. (Tap it, remove it from combat, and heal all damage on it.)\n{2}: Knight of the Holy Nimbus can't be regenerated this turn. Only your opponents may activate this ability.",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "58178a9e-a648-5955-9d76-1bc276ae9491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0595c72-5b32-4d7b-8efc-7ce5c83504dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0595c72-5b32-4d7b-8efc-7ce5c83504dd.jpg?1",
             "name": "Lost Auramancers",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Lost Auramancers dies, if it had no time counters on it, you may search your library for an enchantment card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "b0163288-d504-5c2d-af33-f8ddd709f84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8b4d4-4400-46cc-bd3c-e8a781cfc6f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8b4d4-4400-46cc-bd3c-e8a781cfc6f2.jpg?1",
             "name": "Lymph Sliver",
             "text": "All Sliver creatures have absorb 1. (If a source would deal damage to a Sliver, prevent 1 of that damage.)",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "befe8230-3cd1-5b8f-90c2-4c2cebd27010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae707d5-d81d-4320-b947-6016dc188898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae707d5-d81d-4320-b947-6016dc188898.jpg?1",
             "name": "Mana Tithe",
             "text": "Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "a84da07b-deba-5175-9239-d2553253c771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5686b7-4b7b-4127-9330-9282f36bd70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5686b7-4b7b-4127-9330-9282f36bd70b.jpg?1",
             "name": "Mangara of Corondor",
             "text": "{T}: Exile Mangara of Corondor and target permanent.",
             "colours": [
@@ -939,7 +939,7 @@
         },
         {
             "id": "7564d040-a263-5117-bc4f-1e260c0ff02f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7ab3b-beca-411e-bc27-024f42c013e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7ab3b-beca-411e-bc27-024f42c013e1.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -972,7 +972,7 @@
         },
         {
             "id": "957a9e0f-a302-5e31-9801-2231ea879789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca60d13-137f-4438-bc51-7ea02ec3c515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca60d13-137f-4438-bc51-7ea02ec3c515.jpg?1",
             "name": "Mycologist",
             "text": "At the beginning of your upkeep, put a spore counter on Mycologist.\nRemove three spore counters from Mycologist: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: You gain 2 life.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "c11c6937-c843-5fd7-83f2-63c165d05459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9b2506-ead4-49ff-a733-66f3f13dbe17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9b2506-ead4-49ff-a733-66f3f13dbe17.jpg?1",
             "name": "Outrider en-Kor",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n{0}: The next 1 damage that would be dealt to Outrider en-Kor this turn is dealt to target creature you control instead.",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "1325d6d7-1423-5e4d-9126-ec6e3f4c2bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a2a28e-c241-4228-9ece-2e49d4d3733a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a2a28e-c241-4228-9ece-2e49d4d3733a.jpg?1",
             "name": "Pallid Mycoderm",
             "text": "At the beginning of your upkeep, put a spore counter on Pallid Mycoderm.\nRemove three spore counters from Pallid Mycoderm: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Each creature you control that's a Fungus or a Saproling gets +1/+1 until end of turn.",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "25f126ed-683a-503a-bddb-f860941d1c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6f333-ccb4-44ea-be59-bba6335acf99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6f333-ccb4-44ea-be59-bba6335acf99.jpg?1",
             "name": "Porphyry Nodes",
             "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Porphyry Nodes.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "1e281677-146c-5b2b-bdd0-af1dfe08e9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6db2cf-5171-4791-82b4-c9fac37902a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6db2cf-5171-4791-82b4-c9fac37902a3.jpg?1",
             "name": "Poultice Sliver",
             "text": "All Slivers have \"{2}, {T}: Regenerate target Sliver.\" (The next time that Sliver would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "fdb30248-cce1-50cb-924c-6de5b100035d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4eb560-97a7-4f5f-bf12-1f9e1be63095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4eb560-97a7-4f5f-bf12-1f9e1be63095.jpg?1",
             "name": "Pulmonic Sliver",
             "text": "All Sliver creatures have flying.\nAll Slivers have \"If this permanent would be put into a graveyard, you may put it on top of its owner's library instead.\"",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "df37c9a2-88cb-54a9-954c-792a12a5f7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea5111-5a5c-4c40-8686-8123c822843a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea5111-5a5c-4c40-8686-8123c822843a.jpg?1",
             "name": "Rebuff the Wicked",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "d2e0a4cb-267a-52f2-aa34-7b05921ea82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0febc7fe-4172-4285-9804-a62ce4506c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0febc7fe-4172-4285-9804-a62ce4506c39.jpg?1",
             "name": "Restore Balance",
             "text": "Suspend 6\u2014{W}\nEach player chooses a number of lands they control equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "abda8ff5-d47e-587a-992e-a6417245e245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efa90c9-ff9a-4a99-b991-8e4dc54bb131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efa90c9-ff9a-4a99-b991-8e4dc54bb131.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "69db7d05-d620-561c-8d1e-cd2b3710b351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4cb76-c895-4862-8099-d306b1bb06e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4cb76-c895-4862-8099-d306b1bb06e9.jpg?1",
             "name": "Riftmarked Knight",
             "text": "Protection from black; flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nSuspend 3\u2014{1}{W}{W}\nWhen the last time counter is removed from Riftmarked Knight while it's exiled, create a 2/2 black Knight creature token with flanking, protection from white, and haste.",
             "colours": [
@@ -1309,7 +1309,7 @@
         },
         {
             "id": "a20c6107-dece-506b-b12b-64fbee391c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61475a0c-f33a-43a7-937c-5a63fc8a54b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61475a0c-f33a-43a7-937c-5a63fc8a54b4.jpg?1",
             "name": "Saltblast",
             "text": "Destroy target nonwhite permanent.",
             "colours": [
@@ -1341,7 +1341,7 @@
         },
         {
             "id": "736c1262-1c86-5d74-ba33-b3dff0b7d596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb21c04-d3f7-4960-9b9b-2354e98becb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb21c04-d3f7-4960-9b9b-2354e98becb7.jpg?1",
             "name": "Saltfield Recluse",
             "text": "{T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -1377,7 +1377,7 @@
         },
         {
             "id": "361d11a9-f82e-5a34-bd59-1cd7c96c238b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5627de-fda7-4e39-a6ec-1e895bc353ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5627de-fda7-4e39-a6ec-1e895bc353ed.jpg?1",
             "name": "Serra Avenger",
             "text": "You can't cast this spell during your first, second, or third turns of the game.\nFlying, vigilance",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "1a5e96d4-fbe0-5c55-8e28-17fda73e72c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e4d9c6-416b-47fd-93a5-6c19d89b7c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e4d9c6-416b-47fd-93a5-6c19d89b7c7f.jpg?1",
             "name": "Shade of Trokair",
             "text": "{W}: Shade of Trokair gets +1/+1 until end of turn.\nSuspend 3\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -1445,7 +1445,7 @@
         },
         {
             "id": "4c768990-98de-5101-ba86-ca0141bb3236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5616e0c7-1f1d-4716-95e5-773a8e3ae5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5616e0c7-1f1d-4716-95e5-773a8e3ae5e3.jpg?1",
             "name": "Sidewinder Sliver",
             "text": "All Sliver creatures have flanking. (Whenever a creature without flanking blocks a Sliver, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -1479,7 +1479,7 @@
         },
         {
             "id": "aca3df97-9aa0-53c9-944d-c5fac59a4e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1",
             "name": "Sinew Sliver",
             "text": "All Sliver creatures get +1/+1.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "eb678cc7-ded7-5534-812c-94a65f141a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0997f0-865f-422b-b34e-485ff8178625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0997f0-865f-422b-b34e-485ff8178625.jpg?1",
             "name": "Stonecloaker",
             "text": "Flash\nFlying\nWhen Stonecloaker enters the battlefield, return a creature you control to its owner's hand.\nWhen Stonecloaker enters the battlefield, exile target card from a graveyard.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "8e2a9b5b-1313-5fd2-b8ae-88d4f047680d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3181709-42d2-4e1a-8de9-4f1d2deac232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3181709-42d2-4e1a-8de9-4f1d2deac232.jpg?1",
             "name": "Stormfront Riders",
             "text": "Flying\nWhen Stormfront Riders enters the battlefield, return two creatures you control to their owner's hand.\nWhenever Stormfront Riders or another creature is returned to your hand from the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "68ac61a4-705e-551f-a8c6-abd49f755ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ab72c3-1f76-45ff-84b4-05f403866d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ab72c3-1f76-45ff-84b4-05f403866d44.jpg?1",
             "name": "Sunlance",
             "text": "Sunlance deals 3 damage to target nonwhite creature.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "ee4361bb-f15d-56b0-a87b-7efd487c7fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72380757-6344-43e6-a4ed-bd753f2431d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72380757-6344-43e6-a4ed-bd753f2431d5.jpg?1",
             "name": "Temporal Isolation",
             "text": "Flash\nEnchant creature\nEnchanted creature has shadow. (It can block or be blocked by only creatures with shadow.)\nPrevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "9b441258-d5b6-5057-bd5f-ab08f22ad353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5395039-4f1d-4b16-a8b9-b80593dbde76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5395039-4f1d-4b16-a8b9-b80593dbde76.jpg?1",
             "name": "Watcher Sliver",
             "text": "All Sliver creatures get +0/+2.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "87dc26cd-c0bf-5707-a0d0-9bcffeec8d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d243be1-b67a-44b5-9453-a9f8583c0014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d243be1-b67a-44b5-9453-a9f8583c0014.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "3f62d380-e306-5857-bfec-a0a8512f9ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cec8dcc-8ebb-4640-a5f3-90e6e62c27e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cec8dcc-8ebb-4640-a5f3-90e6e62c27e5.jpg?1",
             "name": "Aeon Chronicler",
             "text": "Aeon Chronicler's power and toughness are each equal to the number of cards in your hand.\nSuspend X\u2014{X}{3}{U}. X can't be 0.\nWhenever a time counter is removed from Aeon Chronicler while it's exiled, draw a card.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "31cb499a-8325-555f-883a-75399d83c5ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9079c93e-3da8-442a-89d2-609a3eac83b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9079c93e-3da8-442a-89d2-609a3eac83b0.jpg?1",
             "name": "Ancestral Vision",
             "text": "Suspend 4\u2014{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "fc48f3ed-4735-5022-aace-a962fec13b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aa1ab5-0085-4043-8272-64e10f3dcf2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aa1ab5-0085-4043-8272-64e10f3dcf2a.jpg?1",
             "name": "Bewilder",
             "text": "Target creature gets -3/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "52de3cd5-22b4-5f6c-a630-826677478e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de72afaf-a4b4-431c-8831-86ddfba2403c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de72afaf-a4b4-431c-8831-86ddfba2403c.jpg?1",
             "name": "Bonded Fetch",
             "text": "Defender, haste\n{T}: Draw a card, then discard a card.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "a03796d7-a7d2-5ee8-ae80-0a7b5787e8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb038efc-2cb2-4635-a183-42b6e0b6b5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb038efc-2cb2-4635-a183-42b6e0b6b5f8.jpg?1",
             "name": "Brine Elemental",
             "text": "Morph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Brine Elemental is turned face up, each opponent skips their next untap step.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "74058b0c-593b-56e1-86b6-0d602671653f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7224b-adb9-4c31-b0bb-1c498f2922fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7224b-adb9-4c31-b0bb-1c498f2922fb.jpg?1",
             "name": "Careful Consideration",
             "text": "Target player draws four cards, then discards three cards. If you cast this spell during your main phase, instead that player draws four cards, then discards two cards.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "17decf82-4bef-51f3-9be6-175d0d0516bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9adcc82-0754-4cb7-ac28-e5624f563b7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9adcc82-0754-4cb7-ac28-e5624f563b7f.jpg?1",
             "name": "Cloudseeder",
             "text": "Flying\n{U}, {T}, Discard a card: Create a 1/1 blue Faerie creature token named Cloud Sprite. It has flying and \"Cloud Sprite can block only creatures with flying.\"",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "620f2ce9-7d95-544b-8cca-d064ef56c444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eacbc6-362e-4257-b29f-78682f4130c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eacbc6-362e-4257-b29f-78682f4130c1.jpg?1",
             "name": "Coral Trickster",
             "text": "Morph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Coral Trickster is turned face up, you may tap or untap target permanent.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "236e8e0f-3d51-5250-993b-266019076425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba5f411-668b-4344-be2f-c8f6cc3255e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba5f411-668b-4344-be2f-c8f6cc3255e8.jpg?1",
             "name": "Crookclaw Transmuter",
             "text": "Flash\nFlying\nWhen Crookclaw Transmuter enters the battlefield, switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "cb2b0a7d-4102-5086-956c-007a77fd00d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5377e2d9-a846-4533-aeaf-9144ca8765da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5377e2d9-a846-4533-aeaf-9144ca8765da.jpg?1",
             "name": "Cryptic Annelid",
             "text": "When Cryptic Annelid enters the battlefield, scry 1, then scry 2, then scry 3. (To scry X, look at the top X cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "7613c3d3-6972-579a-a332-d8e4874dd229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906d538-f1ca-4799-b91c-2e0d2934f241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906d538-f1ca-4799-b91c-2e0d2934f241.jpg?1",
             "name": "Delay",
             "text": "Counter target spell. If the spell is countered this way, exile it with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, remove a time counter from that card. When the last is removed, the player plays it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "6133c5ed-57d6-592e-8bd7-f0760c248505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eca246-591e-4ea8-8432-9f4c1f16a65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eca246-591e-4ea8-8432-9f4c1f16a65e.jpg?1",
             "name": "Draining Whelk",
             "text": "Flash\nFlying\nWhen Draining Whelk enters the battlefield, counter target spell. Put X +1/+1 counters on Draining Whelk, where X is that spell's converted mana cost.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "90a89f55-a8f5-5f88-a9f7-10ec957ef6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59b4729-74c1-4aa9-937d-27cda960f157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59b4729-74c1-4aa9-937d-27cda960f157.jpg?1",
             "name": "Dream Stalker",
             "text": "When Dream Stalker enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "2b5732f7-abd4-515a-8453-dc5b1d2159d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f244985e-7487-44db-bd69-47c781753f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f244985e-7487-44db-bd69-47c781753f2e.jpg?1",
             "name": "Dreamscape Artist",
             "text": "{2}{U}, {T}, Discard a card, Sacrifice a land: Search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "f7824b00-012c-5d70-9041-05b67ac1ba8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c45e7-f157-4b3f-a627-09b5c27473ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c45e7-f157-4b3f-a627-09b5c27473ae.jpg?1",
             "name": "Drifter il-Dal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nAt the beginning of your upkeep, sacrifice Drifter il-Dal unless you pay {U}.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "23b79e79-e54e-5177-918a-42b25b0d088a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3779a76a-0171-4714-9713-a65dc173a33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3779a76a-0171-4714-9713-a65dc173a33f.jpg?1",
             "name": "Errant Ephemeron",
             "text": "Flying\nSuspend 4\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "fe65e2a9-85b1-580f-9255-cefdb74e2b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac93762-9377-49c3-9593-6d02bfb66903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac93762-9377-49c3-9593-6d02bfb66903.jpg?1",
             "name": "Erratic Mutation",
             "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "a5d258f2-c1f1-548d-9df1-6bb5d12697d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0f831e-2eb0-499f-9502-418c04ac34a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0f831e-2eb0-499f-9502-418c04ac34a0.jpg?1",
             "name": "Fathom Seer",
             "text": "Morph\u2014\nReturn two Islands you control to their owner's hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Fathom Seer is turned face up, draw two cards.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "8254f7fd-e18b-56ab-9338-24d4b2db5c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecf2ee8-6b93-4757-89c4-f1e76509a217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecf2ee8-6b93-4757-89c4-f1e76509a217.jpg?1",
             "name": "Foresee",
             "text": "Scry 4, then draw two cards.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "5251cf54-7160-5605-b490-d826a2d0ca90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf05ed80-8abf-4c2c-97d7-a96961c35f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf05ed80-8abf-4c2c-97d7-a96961c35f35.jpg?1",
             "name": "Gossamer Phantasm",
             "text": "Flying\nWhen Gossamer Phantasm becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "00cd686b-96c5-5da4-9ffc-1044f9743a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ab190b-c96f-4b00-8e97-33a11bb2ed08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ab190b-c96f-4b00-8e97-33a11bb2ed08.jpg?1",
             "name": "Infiltrator il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSuspend 2\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "deca81b5-0489-5d1b-a6c7-a12185100580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707277a-f0ba-4f35-9274-7a38efbc11e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707277a-f0ba-4f35-9274-7a38efbc11e8.jpg?1",
             "name": "Jodah's Avenger",
             "text": "{0}: Until end of turn, Jodah's Avenger gets -1/-1 and gains your choice of double strike, protection from red, vigilance, or shadow. (A creature with shadow can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "14877986-1b4b-53b0-a75c-f1cecee688f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624feb0e-f683-4eb6-a63b-7872d0e28f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624feb0e-f683-4eb6-a63b-7872d0e28f1f.jpg?1",
             "name": "Logic Knot",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "d45794de-9c64-5941-bdb0-3af2c4950cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d891cb5-c575-4c63-b053-a2315947c3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d891cb5-c575-4c63-b053-a2315947c3e0.jpg?1",
             "name": "Looter il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Looter il-Kor deals damage to an opponent, draw a card, then discard a card.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "511d2813-62b1-53d8-9e78-b95bbe3ea5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ba1ea5-c861-4bb4-a681-fc0633268bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ba1ea5-c861-4bb4-a681-fc0633268bd9.jpg?1",
             "name": "Magus of the Future",
             "text": "Play with the top card of your library revealed.\nYou may play lands and cast spells from the top of your library.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "b7e4fc02-81a4-5a52-9a62-c5b43c9e4b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb51cd-8418-43ee-bf4f-6b959cc5b131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb51cd-8418-43ee-bf4f-6b959cc5b131.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, put it into your hand, then shuffle your library.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "6f0868d6-7470-573d-a2d4-0efa21fd7126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed4c0bb-b710-44a1-b8bc-6bd11c27b8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed4c0bb-b710-44a1-b8bc-6bd11c27b8b8.jpg?1",
             "name": "Pact of Negation",
             "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "6fb6c32a-932d-5dc4-8e06-27b25e10c45d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb19ac2-edf9-4f9a-b9ba-2a33ba96a4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb19ac2-edf9-4f9a-b9ba-2a33ba96a4d8.jpg?1",
             "name": "Piracy Charm",
             "text": "Choose one \u2014\n\u2022 Target creature gains islandwalk until end of turn. (It can't be blocked as long as defending player controls an Island.)\n\u2022 Target creature gets +2/-1 until end of turn.\n\u2022 Target player discards a card.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "1b3f6c08-8f24-5d8b-92c2-c45bb7cee66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501dea-4e0e-49b0-86b5-e8a01f77077d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501dea-4e0e-49b0-86b5-e8a01f77077d.jpg?1",
             "name": "Pongify",
             "text": "Destroy target creature. It can't be regenerated. Its controller creates a 3/3 green Ape creature token.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "70084461-4c7b-585f-a157-71c70695d64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27064d4f-aeaf-4432-964a-97dfc1db835d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27064d4f-aeaf-4432-964a-97dfc1db835d.jpg?1",
             "name": "Primal Plasma",
             "text": "As Primal Plasma enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.",
             "colours": [
@@ -2725,7 +2725,7 @@
         },
         {
             "id": "d84db383-5bf8-51ad-a618-be4e711c324b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8510381-e05c-4cc4-98aa-c9327e18ec02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8510381-e05c-4cc4-98aa-c9327e18ec02.jpg?1",
             "name": "Reality Acid",
             "text": "Enchant permanent\nVanishing 3 (This Aura enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves the battlefield, enchanted permanent's controller sacrifices it.",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "7eb4d3be-461f-5580-9551-587a396dab2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2b228d-db4d-44a3-b208-6cf7a9f57da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2b228d-db4d-44a3-b208-6cf7a9f57da6.jpg?1",
             "name": "Riftwing Cloudskate",
             "text": "Flying\nWhen Riftwing Cloudskate enters the battlefield, return target permanent to its owner's hand.\nSuspend 3\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "2a3256a3-723c-5b2e-8120-63fe40a5cc7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb9744-79cc-48d6-9e3b-f16073dde1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb9744-79cc-48d6-9e3b-f16073dde1e4.jpg?1",
             "name": "Riptide Pilferer",
             "text": "Whenever Riptide Pilferer deals combat damage to a player, that player discards a card.\nMorph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "5252bbeb-ffe3-5060-9cca-3c3cb0b06568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636ba4f-07ef-4327-8e4a-6c2d8f90b264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636ba4f-07ef-4327-8e4a-6c2d8f90b264.jpg?1",
             "name": "Sarcomite Myr",
             "text": "{2}: Sarcomite Myr gains flying until end of turn.\n{2}, Sacrifice Sarcomite Myr: Draw a card.",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "a3c3fe16-2020-5591-bbee-a69dde075e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc15d7-9e3f-4293-978e-809a6a5b9aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc15d7-9e3f-4293-978e-809a6a5b9aa0.jpg?1",
             "name": "Shaper Parasite",
             "text": "Morph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Shaper Parasite is turned face up, target creature gets +2/-2 or -2/+2 until end of turn.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "2c193ca5-3e3e-56cf-a626-623d60c50fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16dac30-52d2-4b87-90b4-4bc7f8f729ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16dac30-52d2-4b87-90b4-4bc7f8f729ee.jpg?1",
             "name": "Slipstream Serpent",
             "text": "Slipstream Serpent can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice Slipstream Serpent.\nMorph {5}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "03a8beba-3036-58d0-93a2-3c5075ed66c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367d46d1-fa7a-403d-8949-b478a1f83f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367d46d1-fa7a-403d-8949-b478a1f83f46.jpg?1",
             "name": "Snapback",
             "text": "You may exile a blue card from your hand rather than pay this spell's mana cost.\nReturn target creature to its owner's hand.",
             "colours": [
@@ -2964,7 +2964,7 @@
         },
         {
             "id": "a616deee-dacb-5c9f-b462-163606df88bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169929c-641f-41c8-a48e-1a7d0c57726b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169929c-641f-41c8-a48e-1a7d0c57726b.jpg?1",
             "name": "Spell Burst",
             "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCounter target spell with converted mana cost X.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "1c4bce9f-32f4-57ca-907b-6e610ca0df8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a696a-11fb-4573-bf95-1fec643bf418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a696a-11fb-4573-bf95-1fec643bf418.jpg?1",
             "name": "Spiketail Drakeling",
             "text": "Flying\nSacrifice Spiketail Drakeling: Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -3030,7 +3030,7 @@
         },
         {
             "id": "a6f10a22-024e-5eeb-a845-8229ad2e30e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25283518-cabb-4fa6-ab92-c989190ec9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25283518-cabb-4fa6-ab92-c989190ec9f3.jpg?1",
             "name": "Stormcloud Djinn",
             "text": "Flying\nStormcloud Djinn can block only creatures with flying.\n{R}{R}: Stormcloud Djinn gets +2/+0 until end of turn and deals 1 damage to you.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "73b344fd-1c4f-574b-bdb4-2bd290aa1adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5e4a8-ea7b-4803-a7ed-3b915708661f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5e4a8-ea7b-4803-a7ed-3b915708661f.jpg?1",
             "name": "Teferi, Mage of Zhalfir",
             "text": "Flash\nCreature cards you own that aren't on the battlefield have flash.\nEach opponent can cast spells only any time they could cast a sorcery.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "fd02428c-6f4a-5f2f-9e72-85a4d7a0b05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e1d85b-f094-40e2-8811-640076d7d546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e1d85b-f094-40e2-8811-640076d7d546.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "a4188a48-0896-5dfc-ba04-4183830ea9e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea286fe-0768-4e46-a8dd-a3522db844e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea286fe-0768-4e46-a8dd-a3522db844e1.jpg?1",
             "name": "Timebender",
             "text": "Morph {U}\nWhen Timebender is turned face up, choose one \u2014\n\u2022 Remove two time counters from target permanent or suspended card.\n\u2022 Put two time counters on target permanent with a time counter on it or suspended card.",
             "colours": [
@@ -3169,7 +3169,7 @@
         },
         {
             "id": "1a1dc6a7-50a6-5382-9750-7fc14f6a1ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6572-4748-4242-98d2-62e668a59a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6572-4748-4242-98d2-62e668a59a48.jpg?1",
             "name": "Tolarian Sentinel",
             "text": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "a80b29db-4822-50c8-b251-a49758cb2ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c211958-1ee2-4dda-9ef1-c59de599ebc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c211958-1ee2-4dda-9ef1-c59de599ebc1.jpg?1",
             "name": "Veiling Oddity",
             "text": "Suspend 4\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)\nWhen the last time counter is removed from Veiling Oddity while it's exiled, creatures can't be blocked this turn.",
             "colours": [
@@ -3238,7 +3238,7 @@
         },
         {
             "id": "ae79b5ad-2b7a-5f04-995d-e04fc18a41f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dabd1-c043-4bcf-afa8-271225a099e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dabd1-c043-4bcf-afa8-271225a099e1.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "73286290-15c5-5fc5-b084-e79b2f882d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b59d2-ad4b-4dc6-a730-0d19f2774ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b59d2-ad4b-4dc6-a730-0d19f2774ae9.jpg?1",
             "name": "Vesuvan Shapeshifter",
             "text": "As Vesuvan Shapeshifter enters the battlefield or is turned face up, you may choose another creature on the battlefield. If you do, until Vesuvan Shapeshifter is turned face down, it becomes a copy of that creature, except it has \"At the beginning of your upkeep, you may turn this creature face down.\"\nMorph {1}{U}",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "baf1ef45-615b-558a-b306-ca4d767d0671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d09ae-a995-482f-848e-7f99477bd6f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d09ae-a995-482f-848e-7f99477bd6f3.jpg?1",
             "name": "Walk the Aeons",
             "text": "Buyback\u2014\nSacrifice three Islands. (You may sacrifice three Islands in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget player takes an extra turn after this one.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "f214f070-51c3-5945-8627-84c36a4ef130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80e0723-0d0a-42df-90ac-0ba9b5c3a82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80e0723-0d0a-42df-90ac-0ba9b5c3a82d.jpg?1",
             "name": "Whip-Spine Drake",
             "text": "Flying\nMorph {2}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "af4b6f9c-aa2c-5144-9b6d-928bc2a3d4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ece0707-72f7-4a0a-8c37-9fbe0c694f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ece0707-72f7-4a0a-8c37-9fbe0c694f9b.jpg?1",
             "name": "Wipe Away",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "cfe83ab1-ea1a-5812-a644-170f6e9e1316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a1dc6-215f-4738-8ae4-7b6aa1c7d80b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a1dc6-215f-4738-8ae4-7b6aa1c7d80b.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "61c84955-5bc1-59b8-a0e6-4e9cee74cea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec1014-375c-4877-95e3-093d24c02bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec1014-375c-4877-95e3-093d24c02bc8.jpg?1",
             "name": "Big Game Hunter",
             "text": "When Big Game Hunter enters the battlefield, destroy target creature with power 4 or greater. It can't be regenerated.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "7dcf7052-00a9-5c61-ade8-1a43acfc1e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ab3455-f464-41b0-ac63-d40d27abbfb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ab3455-f464-41b0-ac63-d40d27abbfb1.jpg?1",
             "name": "Blightspeaker",
             "text": "{T}: Target player loses 1 life.\n{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "46993703-2fc7-5fa7-a93e-879311169ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8680e7c-f180-45b9-9af6-a8e93037b851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8680e7c-f180-45b9-9af6-a8e93037b851.jpg?1",
             "name": "Corpulent Corpse",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nSuspend 5\u2014{B} (Rather than cast this card from your hand, you may pay {B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "c1016f12-3c9c-54ae-bbe5-540bd3a0271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4123bab-d61e-4d69-b9ca-1fff3a11335a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4123bab-d61e-4d69-b9ca-1fff3a11335a.jpg?1",
             "name": "Cutthroat il-Dal",
             "text": "Hellbent \u2014 Cutthroat il-Dal has shadow as long as you have no cards in hand. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -3581,7 +3581,7 @@
         },
         {
             "id": "4a4a6d9b-1b72-5084-bb81-1dba685e9686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b65da-b9b3-4e15-bab5-bcbfd20dbe05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b65da-b9b3-4e15-bab5-bcbfd20dbe05.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "d34eeb2c-f76f-5b01-9ec6-9f235a853778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9366fa8-f0af-4eb4-a063-7869ca85b9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9366fa8-f0af-4eb4-a063-7869ca85b9c2.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3645,7 +3645,7 @@
         },
         {
             "id": "350f73ee-1412-5a48-915e-051b8c8f8957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e872ae-2e41-49f5-9015-e8f9fa7da987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e872ae-2e41-49f5-9015-e8f9fa7da987.jpg?1",
             "name": "Deadly Grub",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadly Grub dies, if it had no time counters on it, create a 6/1 green Insect creature token with shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "e9aa6ef5-a896-5cfe-a773-c2f30a319e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b368-6fb0-4430-807e-d124f3077361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b368-6fb0-4430-807e-d124f3077361.jpg?1",
             "name": "Deathspore Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Deathspore Thallid.\nRemove three spore counters from Deathspore Thallid: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "3db1f071-cd35-547b-81a1-2488b04ea984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfa5f3-495f-457b-ad44-bd2cf3414ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfa5f3-495f-457b-ad44-bd2cf3414ce4.jpg?1",
             "name": "Deepcavern Imp",
             "text": "Flying, haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "c7006b88-1122-5ec8-aa58-fe7ab85a3b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a548c9b-bdea-4c11-891e-e472fc63ae9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a548c9b-bdea-4c11-891e-e472fc63ae9b.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "afb6678d-517b-56ae-b732-4eaf9be995b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f6f584-9ed3-4e93-ac1a-31878a6b7118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f6f584-9ed3-4e93-ac1a-31878a6b7118.jpg?1",
             "name": "Dunerider Outlaw",
             "text": "Protection from green\nAt the beginning of each end step, if Dunerider Outlaw dealt damage to an opponent this turn, put a +1/+1 counter on it.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "98052a9b-8cfe-568b-ba17-df5181c48908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00440fc-e3e1-4a1c-b32b-f7946a76cd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00440fc-e3e1-4a1c-b32b-f7946a76cd62.jpg?1",
             "name": "Enslave",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, enchanted creature deals 1 damage to its owner.",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "02b99e1b-e604-5be0-9193-485daf8df84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4171dbd3-96d6-4e7a-afac-5b2882bf3872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4171dbd3-96d6-4e7a-afac-5b2882bf3872.jpg?1",
             "name": "Extirpate",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles their library.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "806fb112-908e-5a1a-8c54-f6dbe726338c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49d6139-fc0c-41db-be08-dfa87c685092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49d6139-fc0c-41db-be08-dfa87c685092.jpg?1",
             "name": "Faceless Devourer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhen Faceless Devourer enters the battlefield, exile another target creature with shadow.\nWhen Faceless Devourer leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "5a70d1be-bac9-5439-8ac9-6be52d704684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265960a9-bea6-4111-b9a7-b6a37194b1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265960a9-bea6-4111-b9a7-b6a37194b1c5.jpg?1",
             "name": "Feebleness",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-1.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "965fefa2-6bf6-5892-b19e-83b207ecf5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bf2a33-0eb6-4898-a0fb-f5afb47ea1aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bf2a33-0eb6-4898-a0fb-f5afb47ea1aa.jpg?1",
             "name": "Gorgon Recluse",
             "text": "Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.\nMadness {B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "5d0a96ab-715c-5312-961a-c53e27714d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c53e52-8d63-4628-bfb9-8abe4c7c7f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c53e52-8d63-4628-bfb9-8abe4c7c7f4a.jpg?1",
             "name": "Grave Scrabbler",
             "text": "Madness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nWhen Grave Scrabbler enters the battlefield, if its madness cost was paid, you may return target creature card from a graveyard to its owner's hand.",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "18d6e9ea-f0ba-5db9-a01e-6fc2bba13fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33faa287-2a12-4a94-8d42-77da2b24d86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33faa287-2a12-4a94-8d42-77da2b24d86f.jpg?1",
             "name": "Ichor Slick",
             "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "b43c05fd-204b-5aba-a97c-3dc1dbfbfcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55cf5e9-b343-4307-a379-925d94a8a003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55cf5e9-b343-4307-a379-925d94a8a003.jpg?1",
             "name": "Kor Dirge",
             "text": "All damage that would be dealt this turn to target creature you control by a source of your choice is dealt to another target creature instead.",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "6638f3e9-1c72-59e7-854b-4899af2edb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eede29-17a4-437f-a5c2-e24cccbc6a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eede29-17a4-437f-a5c2-e24cccbc6a33.jpg?1",
             "name": "Living End",
             "text": "Suspend 3\u2014{2}{B}{B}\nEach player exiles all creature cards from their graveyard, then sacrifices all creatures they control, then puts all cards they exiled this way onto the battlefield.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "b734f3af-ff7a-5974-8ef4-71755ae4720a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd816d37-7a9e-485e-9ed9-20c1c15a26dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd816d37-7a9e-485e-9ed9-20c1c15a26dd.jpg?1",
             "name": "Mass of Ghouls",
             "text": "",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "a06bbfd1-4c73-5e7d-8171-659a4c5459a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542f97fa-6295-4c87-86a8-7ff2bc8b5e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542f97fa-6295-4c87-86a8-7ff2bc8b5e81.jpg?1",
             "name": "Mindstab",
             "text": "Target player discards three cards.\nSuspend 4\u2014{B} (Rather than cast this card from your hand, you may pay {B} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "e760dce0-93f7-5512-b939-9387ca76314c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42fded-49e8-4c69-8ade-ba5e76e44b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42fded-49e8-4c69-8ade-ba5e76e44b45.jpg?1",
             "name": "Minions' Murmurs",
             "text": "You draw X cards and you lose X life, where X is the number of creatures you control.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "64706533-c1d9-5dd8-96c4-7d8dae7f0674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1706d-2faa-452b-a192-204386df29f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1706d-2faa-452b-a192-204386df29f6.jpg?1",
             "name": "Mirri the Cursed",
             "text": "Flying, first strike, haste\nWhenever Mirri the Cursed deals combat damage to a creature, put a +1/+1 counter on Mirri the Cursed.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "c5c788ef-9806-56ab-8f97-ba0b3649104d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2aaec8-43a0-4639-8190-3ce1273a2711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2aaec8-43a0-4639-8190-3ce1273a2711.jpg?1",
             "name": "Muck Drubb",
             "text": "Flash\nWhen Muck Drubb enters the battlefield, change the target of target spell that targets only a single creature to Muck Drubb.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "707912c6-1a9b-57d0-9c96-9872978f4c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3482ec-8466-4680-bfdc-e1029c0fbe89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3482ec-8466-4680-bfdc-e1029c0fbe89.jpg?1",
             "name": "Nether Traitor",
             "text": "Haste\nShadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever another creature is put into your graveyard from the battlefield, you may pay {B}. If you do, return Nether Traitor from your graveyard to the battlefield.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "62061072-2390-54c3-b0e5-974888f9e3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd610675-f8ab-47a7-a4db-c1bfb0e9d5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd610675-f8ab-47a7-a4db-c1bfb0e9d5c8.jpg?1",
             "name": "Nightshade Assassin",
             "text": "First strike\nWhen Nightshade Assassin enters the battlefield, you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "f06f5ef6-a006-52b2-adc2-5323e80c8370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e798d8e-cc01-4cd1-9325-37d1bf73e042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e798d8e-cc01-4cd1-9325-37d1bf73e042.jpg?1",
             "name": "Phthisis",
             "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5\u2014{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4387,7 +4387,7 @@
         },
         {
             "id": "50ff3c40-ad1d-54f8-a84e-60037fa25818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f731d16-d969-40a8-a002-4d40eb8f6bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f731d16-d969-40a8-a002-4d40eb8f6bac.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper enters the battlefield, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "f1fd5921-9a10-5119-89d6-17e3a283160a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42f83e3-631b-432e-8d2f-f62d3207e95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42f83e3-631b-432e-8d2f-f62d3207e95e.jpg?1",
             "name": "Premature Burial",
             "text": "Destroy target nonblack creature that entered the battlefield since your last turn ended.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "c1556856-54f1-5d52-8891-61585e66ac32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6d8c51-bff9-4eba-8c1b-2d45b7635c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6d8c51-bff9-4eba-8c1b-2d45b7635c52.jpg?1",
             "name": "Psychotic Episode",
             "text": "Target player reveals their hand and the top card of their library. You choose a card revealed this way. That player puts the chosen card on the bottom of their library.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "1641f887-b179-5922-8d19-08e81600c67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30c08c7-ff2b-40cb-93d0-18e48bf0cf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30c08c7-ff2b-40cb-93d0-18e48bf0cf4d.jpg?1",
             "name": "Rathi Trapper",
             "text": "{B}, {T}: Tap target creature.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "24f84be8-1ce4-50f6-b5bd-306b72c9c972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51ea7d3-a9d7-4b1d-bf3b-3fcfb6a49624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51ea7d3-a9d7-4b1d-bf3b-3fcfb6a49624.jpg?1",
             "name": "Ridged Kusite",
             "text": "{1}{B}, {T}, Discard a card: Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "64a9de72-5b40-53c7-b515-33f1f0c1a416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ceaa1f-4c11-4f06-aa87-2f2a0deb47e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ceaa1f-4c11-4f06-aa87-2f2a0deb47e1.jpg?1",
             "name": "Sangrophage",
             "text": "At the beginning of your upkeep, tap Sangrophage unless you pay 2 life.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "8f86689b-8e45-53a6-b9fd-b6a89914f6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc9f1e-b889-402d-a5a1-fa0d7d493246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc9f1e-b889-402d-a5a1-fa0d7d493246.jpg?1",
             "name": "Sengir Nosferatu",
             "text": "Flying\n{1}{B}, Exile Sengir Nosferatu: Create a 1/2 black Bat creature token with flying. It has \"{1}{B}, Sacrifice this creature: Return an exiled card named Sengir Nosferatu to the battlefield under its owner's control.\"",
             "colours": [
@@ -4625,7 +4625,7 @@
         },
         {
             "id": "202b09c7-a301-56de-a0b4-592a3dfe4a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6f872f-adfa-4d29-87df-9d39fb06b5be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6f872f-adfa-4d29-87df-9d39fb06b5be.jpg?1",
             "name": "Skittering Monstrosity",
             "text": "When you cast a creature spell, sacrifice Skittering Monstrosity.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "f693afa4-e933-5978-bb8c-4c40e794e5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e00341-030f-433e-b22b-aca42e0a88d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e00341-030f-433e-b22b-aca42e0a88d2.jpg?1",
             "name": "Slaughter Pact",
             "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
             "colours": [
@@ -4691,7 +4691,7 @@
         },
         {
             "id": "8a831fcc-a21a-59b4-846d-056d71a19e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28db9a4-6696-460b-a9d3-98f4a31abe75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28db9a4-6696-460b-a9d3-98f4a31abe75.jpg?1",
             "name": "Smallpox",
             "text": "Each player loses 1 life, discards a card, sacrifices a creature, then sacrifices a land.",
             "colours": [
@@ -4723,7 +4723,7 @@
         },
         {
             "id": "90eefd70-1e0c-5aad-9ea5-2dd36b5c3216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872d8f4d-6ee5-4494-9900-db62d3e4cedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872d8f4d-6ee5-4494-9900-db62d3e4cedd.jpg?1",
             "name": "Strangling Soot",
             "text": "Destroy target creature with toughness 3 or less.\nFlashback {5}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "673663cc-9c29-5c12-a9eb-e451dc7246fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d078cad-7f2b-4bef-b637-46aec9c8ed36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d078cad-7f2b-4bef-b637-46aec9c8ed36.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "05cc02fe-b0ea-54d7-9119-e6d80fe577a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87761f00-bfbc-42dc-b96d-9f4258b43a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87761f00-bfbc-42dc-b96d-9f4258b43a8b.jpg?1",
             "name": "Stronghold Rats",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Stronghold Rats deals combat damage to a player, each player discards a card.",
             "colours": [
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "07e93c10-3676-51dc-893d-e4ed7f70e7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d724faa-a988-4c08-875d-d18f48926a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d724faa-a988-4c08-875d-d18f48926a0a.jpg?1",
             "name": "Sudden Death",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget creature gets -4/-4 until end of turn.",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "3bfdae13-9373-5a55-971e-ec7070706cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73514b51-6c19-4b3c-9cf9-2cf5028d7708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73514b51-6c19-4b3c-9cf9-2cf5028d7708.jpg?1",
             "name": "Sudden Spoiling",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntil end of turn, creatures target player controls lose all abilities and have base power and toughness 0/2.",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "cefa9c1a-fe85-596f-a8f0-eaf118b7eec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c338b459-6bb8-4bc7-a6b5-945a09589c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c338b459-6bb8-4bc7-a6b5-945a09589c05.jpg?1",
             "name": "Tendrils of Corruption",
             "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "c5cf1702-6839-5a5a-ba79-25b942deacea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f02d59-0786-41c8-940b-4ef6ef01c646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f02d59-0786-41c8-940b-4ef6ef01c646.jpg?1",
             "name": "Tombstalker",
             "text": "Flying\nDelve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "9f1765ba-1ff8-5969-8372-987e874eb051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278421ff-5324-44e5-b24f-dfbf9aa9b604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278421ff-5324-44e5-b24f-dfbf9aa9b604.jpg?1",
             "name": "Trespasser il-Vec",
             "text": "Discard a card: Trespasser il-Vec gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "bf95d1eb-a9fc-52fa-8c66-02869e2c7325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7b098-82ba-4015-aaa5-df9aa0a05e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7b098-82ba-4015-aaa5-df9aa0a05e40.jpg?1",
             "name": "Urborg Syphon-Mage",
             "text": "{2}{B}, {T}, Discard a card: Each other player loses 2 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "d735ef37-aabf-5c66-aa1a-a476c20c862a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2ef91f-d113-4e8d-a164-c6e261aa9c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2ef91f-d113-4e8d-a164-c6e261aa9c12.jpg?1",
             "name": "Yixlid Jailer",
             "text": "Cards in graveyards lose all abilities.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "7296d372-3411-523d-816c-2bf346b11001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21655e-fda4-4852-a801-c5593644044a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21655e-fda4-4852-a801-c5593644044a.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "This spell can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "65992061-33ab-50a9-b46d-2d2bba5a3a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f28d4a2-6c75-44c2-93ac-e7159c1c623f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f28d4a2-6c75-44c2-93ac-e7159c1c623f.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "0a99a831-790e-5651-b88e-ea57758143cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8fe7c-fe36-4f6d-9c7f-85286b745865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8fe7c-fe36-4f6d-9c7f-85286b745865.jpg?1",
             "name": "Arc Blade",
             "text": "Arc Blade deals 2 damage to any target. Exile Arc Blade with three time counters on it.\nSuspend 3\u2014{2}{R} (Rather than cast this card from your hand, you may pay {2}{R} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "153bc79c-4b40-50f4-b55d-1913d05b076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d49201b-bd41-49b7-b00e-4ab8034a3a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d49201b-bd41-49b7-b00e-4ab8034a3a03.jpg?1",
             "name": "Basalt Gargoyle",
             "text": "Flying\nEcho {2}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{R}: Basalt Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "b6a784e7-e5e7-57d6-b827-dffd0a0ad292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65a72b-d24c-4016-befc-91018a1b62e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65a72b-d24c-4016-befc-91018a1b62e1.jpg?1",
             "name": "Battering Sliver",
             "text": "All Sliver creatures have trample.",
             "colours": [
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "fca6d0fd-2263-50a2-9f5b-d712272b0141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29672365-f059-4ff2-93c5-437b9ab01297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29672365-f059-4ff2-93c5-437b9ab01297.jpg?1",
             "name": "Bonesplitter Sliver",
             "text": "All Sliver creatures get +2/+0.",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "f5c48cee-a372-5359-bccb-66480756fad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy target land you control and target land you don't control.",
             "colours": [
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "8903a04a-9211-56f5-83e6-709334496a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy all lands.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "604eadb8-4ac3-5e18-b19e-0b501970a79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89db7256-3bd0-4c1d-9c6f-de81f7d3c1a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89db7256-3bd0-4c1d-9c6f-de81f7d3c1a2.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5358,7 +5358,7 @@
         },
         {
             "id": "2cf24e49-e843-5172-bd1e-525db488821c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f696f9-afa2-40c4-950a-e1e01c452017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f696f9-afa2-40c4-950a-e1e01c452017.jpg?1",
             "name": "Char-Rumbler",
             "text": "Double strike\n{R}: Char-Rumbler gets +1/+0 until end of turn.",
             "colours": [
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "8d186c3f-aa36-5c54-a307-58dbbf414042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59871c54-7873-4fc5-8084-55918a11e6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59871c54-7873-4fc5-8084-55918a11e6f4.jpg?1",
             "name": "Coal Stoker",
             "text": "When Coal Stoker enters the battlefield, if you cast it from your hand, add {R}{R}{R}.",
             "colours": [
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "ede13a3b-c4f9-5a6e-a2eb-91d72c504b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbbcc1a-c6cc-4671-91ab-9dcf454f62e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbbcc1a-c6cc-4671-91ab-9dcf454f62e0.jpg?1",
             "name": "Conflagrate",
             "text": "Conflagrate deals X damage divided as you choose among any number of targets.\nFlashback\u2014{R}{R}, Discard X cards. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5458,7 +5458,7 @@
         },
         {
             "id": "201fa252-7c18-58f2-babb-ddf4d7b1c948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg?1",
             "name": "Dead // Gone",
             "text": "Dead deals 2 damage to target creature.",
             "colours": [
@@ -5490,7 +5490,7 @@
         },
         {
             "id": "a7b619e0-ba58-51fc-a45c-e56454588116",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg?1",
             "name": "Dead // Gone",
             "text": "Return target creature you don't control to its owner's hand.",
             "colours": [
@@ -5522,7 +5522,7 @@
         },
         {
             "id": "0393e3b1-2aec-5d19-8988-76f0071db8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06462b57-1b0e-4c9c-9531-c14b9f2d5a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06462b57-1b0e-4c9c-9531-c14b9f2d5a3b.jpg?1",
             "name": "Empty the Warrens",
             "text": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5554,7 +5554,7 @@
         },
         {
             "id": "7e2f4033-7ca5-5257-aae8-26981de86f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2376735d-7812-4fab-baba-0d331f6e2211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2376735d-7812-4fab-baba-0d331f6e2211.jpg?1",
             "name": "Firemaw Kavu",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Firemaw Kavu enters the battlefield, it deals 2 damage to target creature.\nWhen Firemaw Kavu leaves the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "f636625b-4d83-5446-a49f-e48f1987b073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a64329-09fc-4e0d-b7d1-378635f2801a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a64329-09fc-4e0d-b7d1-378635f2801a.jpg?1",
             "name": "Fury Sliver",
             "text": "All Sliver creatures have double strike.",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "72d09917-e2cb-5336-9d88-effba8e74d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c232e5-54e2-44b7-85b1-ed039a8e5a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c232e5-54e2-44b7-85b1-ed039a8e5a73.jpg?1",
             "name": "Gathan Raiders",
             "text": "Hellbent \u2014 Gathan Raiders gets +2/+2 as long as you have no cards in hand.\nMorph\u2014\nDiscard a card. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5657,7 +5657,7 @@
         },
         {
             "id": "09db974b-82f1-5c64-8050-5ebf57633bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585bed40-9ca6-46a0-80c4-c769cd8e2b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585bed40-9ca6-46a0-80c4-c769cd8e2b20.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to any target.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5689,7 +5689,7 @@
         },
         {
             "id": "5518c3db-31de-5c1e-8855-da5ab9c82fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6d6eb2-beed-4c84-af6a-bf8ebdc62f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6d6eb2-beed-4c84-af6a-bf8ebdc62f50.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate this ability only if Greater Gargadon is suspended.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "982a830a-8ce2-599e-94d6-5359771ed4d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8215cb7b-9c8c-4d2b-adb1-c1d1d22bb54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8215cb7b-9c8c-4d2b-adb1-c1d1d22bb54e.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {C}{C}{R}. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -5757,7 +5757,7 @@
         },
         {
             "id": "ffcd0286-e1ba-504b-ab63-187affe47a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344b885-68c6-43d2-b6c1-6c89b3c94983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344b885-68c6-43d2-b6c1-6c89b3c94983.jpg?1",
             "name": "Haze of Rage",
             "text": "Buyback {2} (You may pay an additional {2} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreatures you control get +1/+0 until end of turn.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5789,7 +5789,7 @@
         },
         {
             "id": "59f5782c-ed01-5f5a-8400-39de187cb1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8f7ae-bb2b-4ecc-b020-427486315855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8f7ae-bb2b-4ecc-b020-427486315855.jpg?1",
             "name": "Henchfiend of Ukor",
             "text": "Haste\nEcho {1}{B} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{BR}: Henchfiend of Ukor gets +1/+0 until end of turn.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "52f5948e-a560-5ceb-9b9b-fd7814bb72ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f2073b-bc1f-4611-9bdf-73cb86892886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f2073b-bc1f-4611-9bdf-73cb86892886.jpg?1",
             "name": "Homing Sliver",
             "text": "Each Sliver card in each player's hand has slivercycling {3}.\nSlivercycling {3} ({3}, Discard this card: Search your library for a Sliver card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "8aed7a8f-011b-5533-bff2-2798ce6d9d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2890840e-da0b-40ba-b3c2-7e4af39922b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2890840e-da0b-40ba-b3c2-7e4af39922b3.jpg?1",
             "name": "Jaya Ballard, Task Mage",
             "text": "{R}, {T}, Discard a card: Destroy target blue permanent.\n{1}{R}, {T}, Discard a card: Jaya Ballard, Task Mage deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.\n{5}{R}{R}, {T}, Discard a card: Jaya Ballard deals 6 damage to each creature and each player.",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "4b8ce7ba-312c-5bf1-a382-c0f7890f6380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0caef-215a-4433-8a85-322e62e3590d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0caef-215a-4433-8a85-322e62e3590d.jpg?1",
             "name": "Keldon Halberdier",
             "text": "First strike\nSuspend 4\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5930,7 +5930,7 @@
         },
         {
             "id": "c773ae0c-865b-5c31-a113-9abbdaedf2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca33c171-ab9e-4908-8f97-82cd83b173c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca33c171-ab9e-4908-8f97-82cd83b173c0.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "9441b1b3-5093-5adf-8461-10d362150201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9bd75c-9606-4607-bfa6-d6acdee12820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9bd75c-9606-4607-bfa6-d6acdee12820.jpg?1",
             "name": "Magus of the Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "fad9a81b-6645-509e-91d5-7708640a2bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6d241-f68b-45c8-a79a-f6c274bd8512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6d241-f68b-45c8-a79a-f6c274bd8512.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "814c5745-ffeb-57e1-b461-7e274e0da1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c7d94f-3760-4c97-b0bf-c895f4132c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c7d94f-3760-4c97-b0bf-c895f4132c7f.jpg?1",
             "name": "Needlepeak Spider",
             "text": "Reach",
             "colours": [
@@ -6066,7 +6066,7 @@
         },
         {
             "id": "a9f30f7d-38a0-5a81-8c73-a9035d138b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afae574-aa96-4500-9882-a4b10337b6f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afae574-aa96-4500-9882-a4b10337b6f5.jpg?1",
             "name": "Orcish Cannonade",
             "text": "Orcish Cannonade deals 2 damage to any target and 3 damage to you.\nDraw a card.",
             "colours": [
@@ -6098,7 +6098,7 @@
         },
         {
             "id": "fcb5d54f-242b-52e9-b5c3-3c2d3e69d19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4612effe-8ca2-4c27-90d2-d9255acc80d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4612effe-8ca2-4c27-90d2-d9255acc80d9.jpg?1",
             "name": "Pact of the Titan",
             "text": "Create a 4/4 red Giant creature token.\nAt the beginning of your next upkeep, pay {4}{R}. If you don't, you lose the game.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "d30da3bb-5148-5429-aab5-74024536b45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16600a-c2a5-49e4-89e2-260cfaf58b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16600a-c2a5-49e4-89e2-260cfaf58b52.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to any target.",
             "colours": [
@@ -6165,7 +6165,7 @@
         },
         {
             "id": "cd023f2a-58f7-58ea-b3e4-360982d57d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59243436-b55d-44c3-962b-751eff429f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59243436-b55d-44c3-962b-751eff429f71.jpg?1",
             "name": "Reckless Wurm",
             "text": "Trample\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6199,7 +6199,7 @@
         },
         {
             "id": "dc21a4c4-7b88-58ba-80bf-7d39699fbe73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99302c41-434f-41ff-a61a-2c3681a0c135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99302c41-434f-41ff-a61a-2c3681a0c135.jpg?1",
             "name": "Reiterate",
             "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -6231,7 +6231,7 @@
         },
         {
             "id": "2c8f3c2b-ea37-5640-9359-509fe37ecb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e380151-abb6-457c-bac9-39f1a3744ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e380151-abb6-457c-bac9-39f1a3744ed0.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose any target. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that permanent or player.",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "accf4d50-a4a6-560f-81f7-e3e3dd47a23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3459a44-0c26-4ee1-ad7f-67be7cd7d80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3459a44-0c26-4ee1-ad7f-67be7cd7d80a.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to any target.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -6295,7 +6295,7 @@
         },
         {
             "id": "4a7b1e1f-aeef-55c2-931c-b54c5f9909e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dd1bc9-734b-41c6-941f-f9ed5eaa2337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dd1bc9-734b-41c6-941f-f9ed5eaa2337.jpg?1",
             "name": "Rift Elemental",
             "text": "{1}{R}, Remove a time counter from a permanent you control or suspended card you own: Rift Elemental gets +2/+0 until end of turn.",
             "colours": [
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "609b3e64-4e46-595c-a99d-bcbb04691d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg?1",
             "name": "Rough // Tumble",
             "text": "Rough deals 2 damage to each creature without flying.",
             "colours": [
@@ -6361,7 +6361,7 @@
         },
         {
             "id": "983b268c-9dcd-5381-aa23-a0542a890667",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg?1",
             "name": "Rough // Tumble",
             "text": "Tumble deals 6 damage to each creature with flying.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "d0711dcd-314e-5de9-9502-ffb15538c897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af3c6b1-9139-46a3-ad41-91aabbdda55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af3c6b1-9139-46a3-ad41-91aabbdda55f.jpg?1",
             "name": "Sedge Sliver",
             "text": "All Sliver creatures have \"This creature gets +1/+1 as long as you control a Swamp.\"\nAll Slivers have \"{B}: Regenerate this permanent.\" (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "c1adda27-7b49-57d7-bf21-e60bb43ff4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a98f0-ceb4-4e23-b2ec-1c4f4e4e22aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a98f0-ceb4-4e23-b2ec-1c4f4e4e22aa.jpg?1",
             "name": "Shivan Meteor",
             "text": "Shivan Meteor deals 13 damage to target creature.\nSuspend 2\u2014{1}{R}{R} (Rather than cast this card from your hand, you may pay {1}{R}{R} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "28c7159f-17cf-50ba-b163-ce2135e70693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21beb25-09a4-4d7f-84e3-87178e1721eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21beb25-09a4-4d7f-84e3-87178e1721eb.jpg?1",
             "name": "Shivan Sand-Mage",
             "text": "When Shivan Sand-Mage enters the battlefield, choose one \u2014\n\u2022 Remove two time counters from target permanent or suspended card.\n\u2022 Put two time counters on target permanent with a time counter on it or suspended card.\nSuspend 4\u2014{R}",
             "colours": [
@@ -6495,7 +6495,7 @@
         },
         {
             "id": "49cf85f2-d2f1-53e1-a82f-6cc880b7a930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e57335d-4066-4d73-83cd-67a215e01a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e57335d-4066-4d73-83cd-67a215e01a4e.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "Exile Simian Spirit Guide from your hand: Add {R}.",
             "colours": [
@@ -6530,7 +6530,7 @@
         },
         {
             "id": "9d70bf5e-8fc3-5c35-ac3c-6ce0d11305a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b675da-f709-4aa3-8967-c9771234f9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b675da-f709-4aa3-8967-c9771234f9d8.jpg?1",
             "name": "Skirk Shaman",
             "text": "Skirk Shaman can't be blocked except by artifact creatures and/or red creatures.",
             "colours": [
@@ -6565,7 +6565,7 @@
         },
         {
             "id": "04452308-e212-53e2-a192-9c4b367c5654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bcc2bc-75a7-4b01-856b-4e0b8703e302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bcc2bc-75a7-4b01-856b-4e0b8703e302.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "0331579e-b79b-5e1b-99a3-8de97b259fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6e88a5-0d1f-4587-b855-42ab5452ddc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6e88a5-0d1f-4587-b855-42ab5452ddc8.jpg?1",
             "name": "Storm Entity",
             "text": "Haste\nStorm Entity enters the battlefield with a +1/+1 counter on it for each other spell cast this turn.",
             "colours": [
@@ -6634,7 +6634,7 @@
         },
         {
             "id": "66cb1cca-f225-580d-9cd3-5639d84c0b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b659a3b-0f66-40f2-8e2e-f13b694e270e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b659a3b-0f66-40f2-8e2e-f13b694e270e.jpg?1",
             "name": "Sudden Shock",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to any target.",
             "colours": [
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "1ec4b7d7-557c-520f-bb27-b80f4e0650ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aed10f9-8c52-400b-a432-a0d8c6458e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aed10f9-8c52-400b-a432-a0d8c6458e87.jpg?1",
             "name": "Sulfur Elemental",
             "text": "Flash\nSplit second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nWhite creatures get +1/-1.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "511981ea-ed2e-5c9c-b76b-a6cb61b8a3f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f6dfd2-f4b1-41bc-b848-5afa30b13e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f6dfd2-f4b1-41bc-b848-5afa30b13e36.jpg?1",
             "name": "Thick-Skinned Goblin",
             "text": "You may pay {0} rather than pay the echo cost for permanents you control.\n{R}: Thick-Skinned Goblin gains protection from red until end of turn.",
             "colours": [
@@ -6735,7 +6735,7 @@
         },
         {
             "id": "217ff08f-668f-50eb-9bfe-2721a017793d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260cf43a-f3a4-48f7-9c51-5884d106ff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260cf43a-f3a4-48f7-9c51-5884d106ff56.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "30c5c4dd-1303-5d8f-a3d2-cb36fffa4649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7937e12-76d9-4030-a68c-7a93a3c852cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7937e12-76d9-4030-a68c-7a93a3c852cb.jpg?1",
             "name": "Wheel of Fate",
             "text": "Suspend 4\u2014{1}{R} (Rather than cast this card from your hand, pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player discards their hand, then draws seven cards.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "b38e4e6d-686a-5c31-8a9f-c764bf6e5f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0cd9af6-3729-4c9c-9669-a2800a693b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0cd9af6-3729-4c9c-9669-a2800a693b39.jpg?1",
             "name": "Citanul Woodreaders",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nWhen Citanul Woodreaders enters the battlefield, if it was kicked, draw two cards.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "81cba021-c140-5c36-b7a9-cba079807435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce39dd1-ca51-420f-a627-1511192d34c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce39dd1-ca51-420f-a627-1511192d34c2.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "bfdba67a-b7f6-5453-ad2b-298802f546cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c72229c-f3da-4e35-af79-14452efe581b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c72229c-f3da-4e35-af79-14452efe581b.jpg?1",
             "name": "Edge of Autumn",
             "text": "If you control four or fewer lands, search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\nCycling\u2014\nSacrifice a land. (Sacrifice a land, Discard this card: Draw a card.)",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "f88bc9b7-dc64-5a35-8f75-2e9a7a2f5f91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d21cb-f506-4ad4-89d8-ecfdaed5952f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d21cb-f506-4ad4-89d8-ecfdaed5952f.jpg?1",
             "name": "Evolution Charm",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target creature gains flying until end of turn.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "9592d98f-c8b7-5fb2-b16e-74cbdaddc184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a67e4-5deb-45d5-bd42-3078716e142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a67e4-5deb-45d5-bd42-3078716e142b.jpg?1",
             "name": "Fungus Sliver",
             "text": "All Sliver creatures have \"Whenever this creature is dealt damage, put a +1/+1 counter on it.\" (It must survive the damage to get the counter.)",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "64d0ce68-6717-5ce7-96ad-f919fc0c8e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43febc63-597d-4392-b8ea-a00841148c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43febc63-597d-4392-b8ea-a00841148c45.jpg?1",
             "name": "Gaea's Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "5004f5fd-7edb-5cab-8299-93a00eb1f3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110887a5-cbfd-431f-9208-06acc4ed2602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110887a5-cbfd-431f-9208-06acc4ed2602.jpg?1",
             "name": "Gemhide Sliver",
             "text": "All Slivers have \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "ff65f7b4-3d44-5968-ba40-0e62eb19c02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8aec78a-9fd4-4cf9-a9ec-e234f6a552e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8aec78a-9fd4-4cf9-a9ec-e234f6a552e4.jpg?1",
             "name": "Giant Dustwasp",
             "text": "Flying\nSuspend 4\u2014{1}{G} (Rather than cast this card from your hand, you may pay {1}{G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "2823e767-344a-5436-9481-4c79c39a7cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423d0c1d-1791-4c80-86d1-f87f3c6a8611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423d0c1d-1791-4c80-86d1-f87f3c6a8611.jpg?1",
             "name": "Greenseeker",
             "text": "{G}, {T}, Discard a card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "62527fbf-555e-51e8-9c43-5479e3aa2bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcb8138-0d0c-43bd-a3d3-1a57c0a19764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcb8138-0d0c-43bd-a3d3-1a57c0a19764.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "522860e8-8f0d-5447-be8f-cac2197fda25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e2f7a-8cfe-4d1b-a68d-7e6d8d10bd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e2f7a-8cfe-4d1b-a68d-7e6d8d10bd27.jpg?1",
             "name": "Heartwood Storyteller",
             "text": "Whenever a player casts a noncreature spell, each of that player's opponents may draw a card.",
             "colours": [
@@ -7170,7 +7170,7 @@
         },
         {
             "id": "dc421abb-0000-5fb0-a68b-a85efa6c7f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65757321-2f26-44dc-a4f8-31d40fbf1681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65757321-2f26-44dc-a4f8-31d40fbf1681.jpg?1",
             "name": "Hypergenesis",
             "text": "Suspend 3\u2014{1}{G}{G}\nStarting with you, each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "afb6dec8-aad7-5ea3-a339-e4a98aa15d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f189aaf0-474a-4701-9bda-e67dc057e347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f189aaf0-474a-4701-9bda-e67dc057e347.jpg?1",
             "name": "Imperiosaur",
             "text": "Spend only mana produced by basic lands to cast this spell.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "7dec7663-c11e-5c37-a434-58d23bdad977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c3439-74a9-4a53-9e8b-c1c84b60ea35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c3439-74a9-4a53-9e8b-c1c84b60ea35.jpg?1",
             "name": "Kavu Primarch",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf Kavu Primarch was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -7270,7 +7270,7 @@
         },
         {
             "id": "4a444865-60c1-5292-8ae0-a84500f036d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16e927d-0f23-4fac-9b35-3cfcb22ebc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16e927d-0f23-4fac-9b35-3cfcb22ebc26.jpg?1",
             "name": "Keen Sense",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -7304,7 +7304,7 @@
         },
         {
             "id": "da1d256d-bc07-50fb-8e7b-0536e2a4194e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253352d1-26e1-4074-94d8-f88c697e910e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253352d1-26e1-4074-94d8-f88c697e910e.jpg?1",
             "name": "Krosan Grip",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -7336,7 +7336,7 @@
         },
         {
             "id": "10299d89-bd7f-5218-93f9-642d003dce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2721724d-92ae-4c0c-88dd-628888c468bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2721724d-92ae-4c0c-88dd-628888c468bf.jpg?1",
             "name": "Life and Limb",
             "text": "All Forests and all Saprolings are 1/1 green Saproling creatures and Forest lands in addition to their other types. (They're affected by summoning sickness.)",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "f5df0b4b-c64c-5e43-8cf3-fe5fea382f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f894e7-adf7-4fe5-811a-8e2d8c8a88d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f894e7-adf7-4fe5-811a-8e2d8c8a88d6.jpg?1",
             "name": "Llanowar Mentor",
             "text": "{G}, {T}, Discard a card: Create a 1/1 green Elf Druid creature token named Llanowar Elves. It has \"{T}: Add {G}.\"",
             "colours": [
@@ -7403,7 +7403,7 @@
         },
         {
             "id": "0e4fce86-8d16-5c98-8796-62604db1e02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4246cfd0-f150-4142-8dd4-7ebeb707b6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4246cfd0-f150-4142-8dd4-7ebeb707b6f4.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "d8552f5e-4cc8-5044-815c-55d29f01a92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c72fc3-72ac-4727-9872-33dc71049894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c72fc3-72ac-4727-9872-33dc71049894.jpg?1",
             "name": "Might Sliver",
             "text": "All Sliver creatures get +2/+2.",
             "colours": [
@@ -7469,7 +7469,7 @@
         },
         {
             "id": "3a0199b2-0061-53de-b105-e090ac0b6268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab20019-d4b7-4bbb-b258-c9cc14bf2b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab20019-d4b7-4bbb-b258-c9cc14bf2b3a.jpg?1",
             "name": "Mire Boa",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n{G}: Regenerate Mire Boa. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "d2c5743b-9826-548f-a44d-7d132ab7863d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b103cb22-93b2-4206-9f80-5f966155e07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b103cb22-93b2-4206-9f80-5f966155e07e.jpg?1",
             "name": "Muraganda Petroglyphs",
             "text": "Creatures with no abilities get +2/+2.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "53bfb536-35db-5626-b0a1-6528586e5b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3370c6d-a743-49b3-b869-da65b49391d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3370c6d-a743-49b3-b869-da65b49391d9.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman enters the battlefield, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than cast this card from your hand, you may pay {2}{G}{G} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "f066f314-0895-5c11-baba-67193f5b063e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafc1724-af33-491e-b834-9a3cf30039ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafc1724-af33-491e-b834-9a3cf30039ca.jpg?1",
             "name": "Pendelhaven Elder",
             "text": "{T}: Each 1/1 creature you control gets +1/+2 until end of turn.",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "d7a9bd14-fb94-5b29-9b37-6115118086a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862a2f7-673e-44bd-b8ee-e4295da1e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862a2f7-673e-44bd-b8ee-e4295da1e0d5.jpg?1",
             "name": "Penumbra Spider",
             "text": "Reach\nWhen Penumbra Spider dies, create a 2/4 black Spider creature token with reach.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "c6cb4d62-daba-5cb5-92c9-5c0465340658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f48a57-5005-46c7-8b52-97e2f9112b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f48a57-5005-46c7-8b52-97e2f9112b85.jpg?1",
             "name": "Phantom Wurm",
             "text": "Phantom Wurm enters the battlefield with four +1/+1 counters on it.\nIf damage would be dealt to Phantom Wurm, prevent that damage. Remove a +1/+1 counter from Phantom Wurm.",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "d33437e4-b41f-5ba1-aa9e-bd71bd89cfad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503078a-c5a8-4292-a573-82d062870c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503078a-c5a8-4292-a573-82d062870c7f.jpg?1",
             "name": "Primal Forcemage",
             "text": "Whenever another creature enters the battlefield under your control, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "cc61239b-e243-59ab-84e8-5b3c35c82b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14da2f-0e35-4586-8435-de0859aad060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14da2f-0e35-4586-8435-de0859aad060.jpg?1",
             "name": "Reflex Sliver",
             "text": "All Sliver creatures have haste.",
             "colours": [
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "4970bba0-cef5-5a72-a21a-364c8788b442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c122a-d350-420f-ba7b-4523a28e48a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c122a-d350-420f-ba7b-4523a28e48a6.jpg?1",
             "name": "Scryb Ranger",
             "text": "Flash\nFlying, protection from blue\nReturn a Forest you control to its owner's hand: Untap target creature. Activate this ability only once each turn.",
             "colours": [
@@ -7778,7 +7778,7 @@
         },
         {
             "id": "4030cd50-2d9b-588e-9a30-1e8f3cab1f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5592ab-6883-4c5a-8d50-d9530d905b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5592ab-6883-4c5a-8d50-d9530d905b19.jpg?1",
             "name": "Seal of Primordium",
             "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
             "colours": [
@@ -7810,7 +7810,7 @@
         },
         {
             "id": "3fa9036f-9653-5aad-bfa5-5e9b154c9d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c65336f-f735-4c35-9278-ad97255eb5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c65336f-f735-4c35-9278-ad97255eb5bb.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -7842,7 +7842,7 @@
         },
         {
             "id": "1a67ea5b-f9fa-5758-9fb3-de6bf1b0f7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f86e30d-d9e8-48f7-8bd1-f2645f0ab3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f86e30d-d9e8-48f7-8bd1-f2645f0ab3f4.jpg?1",
             "name": "Spinneret Sliver",
             "text": "All Sliver creatures have reach.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "48341ada-6047-58ac-8b77-8c06f9ec6758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babc8043-bfed-45e3-9d04-1967534f77b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babc8043-bfed-45e3-9d04-1967534f77b2.jpg?1",
             "name": "Sporesower Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on each Fungus you control.\nRemove three spore counters from Sporesower Thallid: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -7910,7 +7910,7 @@
         },
         {
             "id": "12bea01a-1f21-5c5b-8c3f-cfac027b2495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a96041-1b20-464e-9119-93c19675ac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a96041-1b20-464e-9119-93c19675ac46.jpg?1",
             "name": "Sporoloth Ancient",
             "text": "At the beginning of your upkeep, put a spore counter on Sporoloth Ancient.\nCreatures you control have \"Remove two spore counters from this creature: Create a 1/1 green Saproling creature token.\"",
             "colours": [
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "23806dbb-4ef2-5361-82c9-94287ca6dfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d900d0-3f3a-4716-bcc7-b27a0cbbc339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d900d0-3f3a-4716-bcc7-b27a0cbbc339.jpg?1",
             "name": "Strength in Numbers",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
             "colours": [
@@ -7976,7 +7976,7 @@
         },
         {
             "id": "39d37852-bc97-5865-bc8f-45099990927d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f88ac-8a90-4057-b0e6-c15fbd02da38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f88ac-8a90-4057-b0e6-c15fbd02da38.jpg?1",
             "name": "Summoner's Pact",
             "text": "Search your library for a green creature card, reveal it, put it into your hand, then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -8008,7 +8008,7 @@
         },
         {
             "id": "48f77718-82d7-5cb8-a419-3b1e09d4c19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69daba76-96e8-4bcc-ab79-2f00189ad8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69daba76-96e8-4bcc-ab79-2f00189ad8fb.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "ac5e644e-1680-5777-a81f-fbd3852dfd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799e835b-98ad-41b2-a8a9-a7c661efd86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799e835b-98ad-41b2-a8a9-a7c661efd86f.jpg?1",
             "name": "Thallid Germinator",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid Germinator.\nRemove three spore counters from Thallid Germinator: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "df01d422-69ae-55fa-b172-83bdcf26a43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd5ff-79a2-43d9-bd69-94be175d19b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd5ff-79a2-43d9-bd69-94be175d19b4.jpg?1",
             "name": "Thallid Shell-Dweller",
             "text": "Defender\nAt the beginning of your upkeep, put a spore counter on Thallid Shell-Dweller.\nRemove three spore counters from Thallid Shell-Dweller: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "1c1529c4-d855-5331-82c5-d72dbd165a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f1b9f-9866-4ead-96cf-88babf459ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f1b9f-9866-4ead-96cf-88babf459ce2.jpg?1",
             "name": "Thelon of Havenwood",
             "text": "Each Fungus creature gets +1/+1 for each spore counter on it.\n{B}{G}, Exile a Fungus card from a graveyard: Put a spore counter on each Fungus on the battlefield.",
             "colours": [
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "1284f47b-ee7b-5a4d-99cf-1aa93212cbdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803ebda-2f6b-41e4-9ffe-b1f2888996b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803ebda-2f6b-41e4-9ffe-b1f2888996b6.jpg?1",
             "name": "Thelonite Hermit",
             "text": "All Saprolings get +1/+1.\nMorph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Thelonite Hermit is turned face up, create four 1/1 green Saproling creature tokens.",
             "colours": [
@@ -8183,7 +8183,7 @@
         },
         {
             "id": "8e939602-34ed-503c-b72e-fe2419500503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b7811-ff6c-4767-921d-e8e88913e820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b7811-ff6c-4767-921d-e8e88913e820.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach, deathtouch",
             "colours": [
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "282b112c-c49d-5a2d-8d03-ebe8ea42423b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bed96ea-f509-40eb-80b7-71a02d9ac69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bed96ea-f509-40eb-80b7-71a02d9ac69f.jpg?1",
             "name": "Thrill of the Hunt",
             "text": "Target creature gets +1/+2 until end of turn.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "a76c14f7-419a-5207-a5df-40dae7156a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef40007b-47eb-4881-9467-30ce5b9a0fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef40007b-47eb-4881-9467-30ce5b9a0fa3.jpg?1",
             "name": "Tromp the Domains",
             "text": "Domain \u2014 Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "74ca8aaa-24f7-5221-883f-1339614bc11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c401a-8c66-4054-894f-afd866b3b95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c401a-8c66-4054-894f-afd866b3b95b.jpg?1",
             "name": "Uktabi Drake",
             "text": "Flying, haste\nEcho {1}{G}{G} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -8317,7 +8317,7 @@
         },
         {
             "id": "125e9600-7283-533e-9e08-0afe2ee40d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5664e121-d3f1-4ff5-9576-ef515e22bde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5664e121-d3f1-4ff5-9576-ef515e22bde7.jpg?1",
             "name": "Utopia Mycon",
             "text": "At the beginning of your upkeep, put a spore counter on Utopia Mycon.\nRemove three spore counters from Utopia Mycon: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Add one mana of any color.",
             "colours": [
@@ -8351,7 +8351,7 @@
         },
         {
             "id": "25fae8ae-6c79-51bd-8d17-bbcca1f1df31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55dcec32-6ff2-4f47-b3e2-ab621f58d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55dcec32-6ff2-4f47-b3e2-ab621f58d498.jpg?1",
             "name": "Utopia Vow",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -8385,7 +8385,7 @@
         },
         {
             "id": "f523db25-4fff-5b66-88e2-f3af7be414f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5082a2a-e8b1-4799-ad29-a632d95ae1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5082a2a-e8b1-4799-ad29-a632d95ae1da.jpg?1",
             "name": "Virulent Sliver",
             "text": "All Sliver creatures have poisonous 1. (Whenever a Sliver deals combat damage to a player, that player gets a poison counter. A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "0678ed38-b3d3-5683-91b9-708a2266bf7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9807f9a8-a994-4fb2-ad33-3d80d9702bfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9807f9a8-a994-4fb2-ad33-3d80d9702bfe.jpg?1",
             "name": "Yavimaya Dryad",
             "text": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)\nWhen Yavimaya Dryad enters the battlefield, you may search your library for a Forest card, put it onto the battlefield tapped under target player's control, then shuffle your library.",
             "colours": [
@@ -8453,7 +8453,7 @@
         },
         {
             "id": "34c4a3c6-e434-5cce-a8b1-baeb9a17d3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11df0ed7-ae08-4a95-8b79-d6be0df9e31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11df0ed7-ae08-4a95-8b79-d6be0df9e31a.jpg?1",
             "name": "Cautery Sliver",
             "text": "All Slivers have \"{1}, Sacrifice this permanent: This permanent deals 1 damage to any target.\"\nAll Slivers have \"{1}, Sacrifice this permanent: Prevent the next 1 damage that would be dealt to target player, planeswalker, or Sliver creature this turn.\"",
             "colours": [
@@ -8489,7 +8489,7 @@
         },
         {
             "id": "e5010f70-7253-573e-b719-3822b48cfa68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0b1a4-5372-424f-99b0-8abf500d5ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0b1a4-5372-424f-99b0-8abf500d5ece.jpg?1",
             "name": "Darkheart Sliver",
             "text": "All Slivers have \"Sacrifice this permanent: You gain 3 life.\"",
             "colours": [
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "15a5a1c8-34ff-59a9-a3f0-a354751c93cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d646252-6d42-4000-bfc1-ad12f2386b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d646252-6d42-4000-bfc1-ad12f2386b99.jpg?1",
             "name": "Dormant Sliver",
             "text": "All Sliver creatures have defender.\nAll Slivers have \"When this permanent enters the battlefield, draw a card.\"",
             "colours": [
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "be81a18f-717e-556d-be81-9524470bf7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554f402-35d4-43ac-9494-9d17d2a79092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554f402-35d4-43ac-9494-9d17d2a79092.jpg?1",
             "name": "Dralnu, Lich Lord",
             "text": "If damage would be dealt to Dralnu, Lich Lord, sacrifice that many permanents instead.\n{T}: Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8600,7 +8600,7 @@
         },
         {
             "id": "d2924393-10c7-523c-a6ef-b0b42e02c915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7972f0a2-eb3f-4b67-82c8-73b0ae02722b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7972f0a2-eb3f-4b67-82c8-73b0ae02722b.jpg?1",
             "name": "Firewake Sliver",
             "text": "All Sliver creatures have haste.\nAll Slivers have \"{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn.\"",
             "colours": [
@@ -8636,7 +8636,7 @@
         },
         {
             "id": "00dc5683-b09e-5860-8ebb-ed9ad78bf9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c89645b-5e53-48c0-b4bb-9f22332c7658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c89645b-5e53-48c0-b4bb-9f22332c7658.jpg?1",
             "name": "Glittering Wish",
             "text": "You may reveal a multicolored card you own from outside the game and put it into your hand. Exile Glittering Wish.",
             "colours": [
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "b8e7b241-5837-59a7-9748-ab1b06a6ae2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cfc5db-3fc0-428e-8d4b-f6ea6caea36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cfc5db-3fc0-428e-8d4b-f6ea6caea36d.jpg?1",
             "name": "Harmonic Sliver",
             "text": "All Slivers have \"When this permanent enters the battlefield, destroy target artifact or enchantment.\"",
             "colours": [
@@ -8706,7 +8706,7 @@
         },
         {
             "id": "c9401d33-abb7-5f3b-825e-f6a796c3f283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c32735-e8e7-46a1-84ea-92806f459e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c32735-e8e7-46a1-84ea-92806f459e84.jpg?1",
             "name": "Ith, High Arcanist",
             "text": "Vigilance\n{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nSuspend 4\u2014{W}{U}",
             "colours": [
@@ -8745,7 +8745,7 @@
         },
         {
             "id": "a47b81d7-c055-518d-b024-0751e012451b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6c3c8a-aa35-46b3-8769-27b4244457b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6c3c8a-aa35-46b3-8769-27b4244457b0.jpg?1",
             "name": "Jhoira of the Ghitu",
             "text": "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend. (At the beginning of your upkeep, remove a time counter from that card. When the last is removed, cast it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "3ad9ee8d-1736-5b51-8a76-639f6349c264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a163e-7896-47bf-9b9b-dcf011402ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a163e-7896-47bf-9b9b-dcf011402ce7.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent casts a spell, Kaervek the Merciless deals damage equal to that spell's converted mana cost to any target.",
             "colours": [
@@ -8823,7 +8823,7 @@
         },
         {
             "id": "4f63f020-d857-536c-ae93-3ebd33b5d924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e57239-bbd8-49c3-acee-b7455f296c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e57239-bbd8-49c3-acee-b7455f296c9d.jpg?1",
             "name": "Necrotic Sliver",
             "text": "All Slivers have \"{3}, Sacrifice this permanent: Destroy target permanent.\"",
             "colours": [
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "09b0d812-f935-5e4b-9bae-76f25ec810c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7924e5a5-9614-4fd0-a621-80fa3103cc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7924e5a5-9614-4fd0-a621-80fa3103cc22.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -8898,7 +8898,7 @@
         },
         {
             "id": "ab724c07-1c8b-5152-a99c-587994fc4f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4176dda4-ec5c-4734-bb48-0876304aa219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4176dda4-ec5c-4734-bb48-0876304aa219.jpg?1",
             "name": "Saffi Eriksdotter",
             "text": "Sacrifice Saffi Eriksdotter: When target creature is put into your graveyard this turn, return that card to the battlefield.",
             "colours": [
@@ -8937,7 +8937,7 @@
         },
         {
             "id": "aca9b08d-da19-5413-90a6-d0d651e7ab6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87545415-2e27-4841-a3af-7653af2ba6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87545415-2e27-4841-a3af-7653af2ba6d3.jpg?1",
             "name": "Sliver Legion",
             "text": "All Sliver creatures get +1/+1 for each other Sliver on the battlefield.",
             "colours": [
@@ -8981,7 +8981,7 @@
         },
         {
             "id": "be8a04c7-c7ea-5dfc-938c-52289949f70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ee61d-0bc1-4d7b-ba68-157061aa98eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ee61d-0bc1-4d7b-ba68-157061aa98eb.jpg?1",
             "name": "Akroma's Memorial",
             "text": "Creatures you control have flying, first strike, vigilance, trample, haste, and protection from black and from red.",
             "colours": [],
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "bc85a76c-ceb2-5991-bb33-642e7d1600ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8d492-2c67-410b-b556-c157a14c4cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8d492-2c67-410b-b556-c157a14c4cec.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color.\nWhen Chromatic Star is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "a979cd0a-5cc5-57bc-8ddb-6ead3a14e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babba9f7-86e4-4e11-9fb8-acd50fbd8031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babba9f7-86e4-4e11-9fb8-acd50fbd8031.jpg?1",
             "name": "Clockwork Hydra",
             "text": "Clockwork Hydra enters the battlefield with four +1/+1 counters on it.\nWhenever Clockwork Hydra attacks or blocks, remove a +1/+1 counter from it. If you do, Clockwork Hydra deals 1 damage to any target.\n{T}: Put a +1/+1 counter on Clockwork Hydra.",
             "colours": [],
@@ -9070,7 +9070,7 @@
         },
         {
             "id": "a0c213a0-5442-5710-b82b-94e79678177d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f880de5-8fc5-4e4e-a4bb-cc3e61a7697b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f880de5-8fc5-4e4e-a4bb-cc3e61a7697b.jpg?1",
             "name": "Cloud Key",
             "text": "As Cloud Key enters the battlefield, choose artifact, creature, enchantment, instant, or sorcery.\nSpells you cast of the chosen type cost {1} less to cast.",
             "colours": [],
@@ -9098,7 +9098,7 @@
         },
         {
             "id": "2e7978b4-f18e-551e-a5c9-4a3bb9003c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fae620-8fa5-44db-8326-11cb323c626e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fae620-8fa5-44db-8326-11cb323c626e.jpg?1",
             "name": "Coalition Relic",
             "text": "{T}: Add one mana of any color.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color for each charge counter removed this way.",
             "colours": [],
@@ -9126,7 +9126,7 @@
         },
         {
             "id": "fed801f8-e157-5462-9346-8de853f4d739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e870a0-5699-4f42-b67a-8dbd24e0c9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e870a0-5699-4f42-b67a-8dbd24e0c9c2.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "cdd3ba5f-2e36-55e8-8872-0ec439dc4895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e62171-713c-49c0-8e16-b193ff181dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e62171-713c-49c0-8e16-b193ff181dcd.jpg?1",
             "name": "Hivestone",
             "text": "Creatures you control are Slivers in addition to their other creature types.",
             "colours": [],
@@ -9182,7 +9182,7 @@
         },
         {
             "id": "cdb02719-a9de-5f4c-be59-0bd8787fcd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d14746-3b57-4f8e-8155-e578cc84850d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d14746-3b57-4f8e-8155-e578cc84850d.jpg?1",
             "name": "Jhoira's Timebug",
             "text": "{T}: Choose target permanent you control or suspended card you own. If that permanent or card has a time counter on it, you may remove a time counter from it or put another time counter on it.",
             "colours": [],
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "8f8fdc46-cab4-5ef7-852c-f74ca05af17a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89ae4d-1cc2-41d8-a4de-a54b958c4429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89ae4d-1cc2-41d8-a4de-a54b958c4429.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color.",
             "colours": [],
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "a01efab0-1774-5546-b824-758f3808b223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794e97e-8b2c-4bde-8028-4348de5aec83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794e97e-8b2c-4bde-8028-4348de5aec83.jpg?1",
             "name": "Paradise Plume",
             "text": "As Paradise Plume enters the battlefield, choose a color.\nWhenever a player casts a spell of the chosen color, you may gain 1 life.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9271,7 +9271,7 @@
         },
         {
             "id": "ccc41f94-6ecd-5637-816f-b722e4607db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3be020-37a3-49ce-8604-27794175bf9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3be020-37a3-49ce-8604-27794175bf9d.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "b18302b1-1f17-5aeb-a633-55a20d2fbb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83458352-9634-4cd7-bed1-6f7743c56c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83458352-9634-4cd7-bed1-6f7743c56c1f.jpg?1",
             "name": "Sliversmith",
             "text": "{1}, {T}, Discard a card: Create a 1/1 colorless Sliver artifact creature token named Metallic Sliver.",
             "colours": [],
@@ -9330,7 +9330,7 @@
         },
         {
             "id": "da6b98e1-3191-5a95-9243-5400366434e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce427213-4ce5-478e-83d8-fe80ec446a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce427213-4ce5-478e-83d8-fe80ec446a58.jpg?1",
             "name": "Stuffy Doll",
             "text": "Indestructible\nAs Stuffy Doll enters the battlefield, choose a player.\nWhenever Stuffy Doll is dealt damage, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "10b57907-0bc0-5a8e-87dc-f784e32573fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297a2b09-562a-46d8-905d-0b32e854e9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297a2b09-562a-46d8-905d-0b32e854e9d2.jpg?1",
             "name": "Calciform Pools",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Calciform Pools.\n{1}, Remove X storage counters from Calciform Pools: Add X mana in any combination of {W} and/or {U}.",
             "colours": [],
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "e5b95d94-8c5f-5ff2-be98-83d3903b19fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18642a9e-ac45-402b-bb56-08cb6336c485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18642a9e-ac45-402b-bb56-08cb6336c485.jpg?1",
             "name": "Dreadship Reef",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Dreadship Reef.\n{1}, Remove X storage counters from Dreadship Reef: Add X mana in any combination of {U} and/or {B}.",
             "colours": [],
@@ -9423,7 +9423,7 @@
         },
         {
             "id": "efa6c108-f237-5b51-bb56-34b69755e567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3a843b-2dea-4b44-be74-c09c18b9b969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3a843b-2dea-4b44-be74-c09c18b9b969.jpg?1",
             "name": "Dryad Arbor",
             "text": "(Dryad Arbor isn't a spell, it's affected by summoning sickness, and it has \"{T}: Add {G}.\")",
             "colours": [
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "e58b388c-3114-5ad4-b97e-7a9fe37017c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acea27-88de-4d27-8da2-8f82439526a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acea27-88de-4d27-8da2-8f82439526a1.jpg?1",
             "name": "Flagstones of Trokair",
             "text": "{T}: Add {W}.\nWhen Flagstones of Trokair is put into a graveyard from the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -9491,7 +9491,7 @@
         },
         {
             "id": "03f18618-b517-5c5e-9aa6-41986f29a4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3580d6-345a-46ba-a327-0e924989d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3580d6-345a-46ba-a327-0e924989d6b1.jpg?1",
             "name": "Fungal Reaches",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Fungal Reaches.\n{1}, Remove X storage counters from Fungal Reaches: Add X mana in any combination of {R} and/or {G}.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "27178af1-4848-5ea1-a98f-4d3be5384044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f273641-c5f3-48bc-b89e-3cff52d26a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f273641-c5f3-48bc-b89e-3cff52d26a0b.jpg?1",
             "name": "Gemstone Caverns",
             "text": "If Gemstone Caverns is in your opening hand and you're not the starting player, you may begin the game with Gemstone Caverns on the battlefield with a luck counter on it. If you do, exile a card from your hand.\n{T}: Add {C}. If Gemstone Caverns has a luck counter on it, instead add one mana of any color.",
             "colours": [],
@@ -9552,7 +9552,7 @@
         },
         {
             "id": "051eb390-678f-51cf-853e-baaa435e8fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daf0fe9-d567-4749-b649-4bfc929cb238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daf0fe9-d567-4749-b649-4bfc929cb238.jpg?1",
             "name": "Kher Keep",
             "text": "{T}: Add {C}.\n{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep.",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "a98b5cf4-e166-52ed-9aa8-1c014e663921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d952491-3a33-42af-9748-d2cb9c5a2f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d952491-3a33-42af-9748-d2cb9c5a2f76.jpg?1",
             "name": "Molten Slagheap",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Molten Slagheap.\n{1}, Remove X storage counters from Molten Slagheap: Add X mana in any combination of {B} and/or {R}.",
             "colours": [],
@@ -9615,7 +9615,7 @@
         },
         {
             "id": "6374eb80-6c99-5da6-947f-9ebf4ae19dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d757f1-9398-494f-9a24-b01c5c8c6db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d757f1-9398-494f-9a24-b01c5c8c6db5.jpg?1",
             "name": "Saltcrusted Steppe",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Saltcrusted Steppe.\n{1}, Remove X storage counters from Saltcrusted Steppe: Add X mana in any combination of {G} and/or {W}.",
             "colours": [],
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "90af5491-b6cc-5229-9a41-329df3bb8412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89329f2-d386-40a7-9098-6d80beeb8843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89329f2-d386-40a7-9098-6d80beeb8843.jpg?1",
             "name": "Swarmyard",
             "text": "{T}: Add {C}.\n{T}: Regenerate target Insect, Rat, Spider, or Squirrel. (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [],
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "23387971-7b19-5a16-a4f7-477202c0e728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2564ec-f092-45d6-a519-6f18dbcdaee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2564ec-f092-45d6-a519-6f18dbcdaee6.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "f7c3bae8-fa93-5e5b-98a9-0c059508a9a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b005eef6-75f3-454f-a42b-d851bc84ac4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b005eef6-75f3-454f-a42b-d851bc84ac4e.jpg?1",
             "name": "Tolaria West",
             "text": "Tolaria West enters the battlefield tapped.\n{T}: Add {U}.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with converted mana cost 0, reveal it, put it into your hand, then shuffle your library. Transmute only as a sorcery.)",
             "colours": [],
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "70be3f1f-8a6b-50e5-9b45-acb245fa5310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1a9e38-6ffc-490f-b0be-23ba4e8204c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1a9e38-6ffc-490f-b0be-23ba4e8204c6.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],
@@ -9762,7 +9762,7 @@
         },
         {
             "id": "9887e47c-43d3-51d6-ac4a-9bdd21482446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03f17f1-b0fd-4b84-82ea-085c2f87eeda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03f17f1-b0fd-4b84-82ea-085c2f87eeda.jpg?1",
             "name": "Urza's Factory",
             "text": "{T}: Add {C}.\n{7}, {T}: Create a 2/2 colorless Assembly-Worker artifact creature token.",
             "colours": [],
@@ -9792,7 +9792,7 @@
         },
         {
             "id": "4ad0d5bb-f365-5d5f-90ff-e57be359bfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0726f70a-c1c4-4edb-86fb-9be280d9ea73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0726f70a-c1c4-4edb-86fb-9be280d9ea73.jpg?1",
             "name": "Vesuva",
             "text": "You may have Vesuva enter the battlefield tapped as a copy of any land on the battlefield.",
             "colours": [],
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "01296cbc-3a64-559b-99c0-8a5f76529855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab58d83-5930-4d28-a26c-225c7a872216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab58d83-5930-4d28-a26c-225c7a872216.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -9855,7 +9855,7 @@
         },
         {
             "id": "5922467e-bb4c-5426-a3c4-6237a89c6992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f27dd19-a475-4024-aecf-ba6142806656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f27dd19-a475-4024-aecf-ba6142806656.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield.",
             "colours": [
@@ -9887,7 +9887,7 @@
         },
         {
             "id": "f54d1ec8-92e8-5d4f-bfd8-17033f6a6ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65975f50-70b1-4d64-8d81-5ef2da479c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65975f50-70b1-4d64-8d81-5ef2da479c48.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "e43a4ba8-474e-5ebc-b4bb-3ff30c7de70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167e245-dbdc-4a4b-b475-05b23f84a98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167e245-dbdc-4a4b-b475-05b23f84a98b.jpg?1",
             "name": "Ethereal Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each enchantment you control and has first strike.",
             "colours": [
@@ -9956,7 +9956,7 @@
         },
         {
             "id": "628a2f4d-59f5-590a-804d-ee14b11b999e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6931aad2-aa2c-4069-9e5a-2566b9f3eae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6931aad2-aa2c-4069-9e5a-2566b9f3eae4.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -9990,7 +9990,7 @@
         },
         {
             "id": "6d28fed4-c9bc-56c5-8930-db8450455c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa180a-772d-4d4a-9c1b-22b3cf18e2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa180a-772d-4d4a-9c1b-22b3cf18e2b0.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "dbdf1770-6552-517e-b65d-4bd624968a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278e97cf-312d-4e9e-bc39-023f4e547121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278e97cf-312d-4e9e-bc39-023f4e547121.jpg?1",
             "name": "Lingering Souls",
             "text": "Create two 1/1 white Spirit creature tokens with flying.\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10055,7 +10055,7 @@
         },
         {
             "id": "bba42d0f-56a7-5d9a-8e74-da0c2ec21a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f71a96-94d1-4cbb-b21c-0e5075840777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f71a96-94d1-4cbb-b21c-0e5075840777.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "0d02f774-8734-538a-ad75-b87e5b4f8b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed869151-02e9-4daa-994d-ccdf9f9dc3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed869151-02e9-4daa-994d-ccdf9f9dc3c8.jpg?1",
             "name": "Palace Jailer",
             "text": "When Palace Jailer enters the battlefield, you become the monarch.\nWhen Palace Jailer enters the battlefield, exile target creature an opponent controls until an opponent becomes the monarch.",
             "colours": [
@@ -10124,7 +10124,7 @@
         },
         {
             "id": "36e7671e-ed7c-518f-a75c-5ae3eaef1f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee3e42e-120c-468a-988d-4441b6025bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee3e42e-120c-468a-988d-4441b6025bbe.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle their library.",
             "colours": [
@@ -10156,7 +10156,7 @@
         },
         {
             "id": "00338347-2db3-523f-9758-d12f2c7ef69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1266de-3a58-4579-9781-78aaf852bbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1266de-3a58-4579-9781-78aaf852bbac.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -10190,7 +10190,7 @@
         },
         {
             "id": "9b08ffa3-e171-51ee-9de1-4268a30ac66e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3584cdf0-9e46-480d-bc73-78e1180d32d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3584cdf0-9e46-480d-bc73-78e1180d32d3.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "e9bd8b51-7e14-5f45-9bec-27a1f51791e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93c1860-a27e-426c-9fbb-3bd20ead1afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93c1860-a27e-426c-9fbb-3bd20ead1afc.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn.",
             "colours": [
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "2f7ac489-c526-53e4-ae67-e25496b499df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc08ef6-61fc-4d01-a78b-df0cf99585d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc08ef6-61fc-4d01-a78b-df0cf99585d9.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
             "colours": [
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "ce232f83-94b4-5f7d-94b8-7369c7e45a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d14bf-78dd-4a51-a8df-04636d2141f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d14bf-78dd-4a51-a8df-04636d2141f3.jpg?1",
             "name": "Stonehorn Dignitary",
             "text": "When Stonehorn Dignitary enters the battlefield, target opponent skips their next combat phase.",
             "colours": [
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "4c7ff267-a6bd-56ee-9fc5-3c9734ad8c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec18fa41-6948-4d94-8dcc-31fb63fb53ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec18fa41-6948-4d94-8dcc-31fb63fb53ec.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -10361,7 +10361,7 @@
         },
         {
             "id": "b026c919-ed80-53de-9e2c-b5dcce24670b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103a725-4750-4d9e-8792-6fbbb81bba0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103a725-4750-4d9e-8792-6fbbb81bba0e.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -10398,7 +10398,7 @@
         },
         {
             "id": "7444058d-157c-5806-a997-7b80f2a54cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83fbd7f-1757-4dcf-9972-0c8f71843f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83fbd7f-1757-4dcf-9972-0c8f71843f03.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -10430,7 +10430,7 @@
         },
         {
             "id": "6e3a8477-c7e9-56b8-b5ab-51cc287ba81b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7308076-755c-4508-8920-5a6641a17a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7308076-755c-4508-8920-5a6641a17a8a.jpg?1",
             "name": "Fblthp, the Lost",
             "text": "When Fblthp, the Lost enters the battlefield, draw a card. If it entered from your library or was cast from your library, draw two cards instead.\nWhen Fblthp becomes the target of a spell, shuffle Fblthp into its owner's library.",
             "colours": [
@@ -10466,7 +10466,7 @@
         },
         {
             "id": "b75e2506-f2d5-5831-b689-5a3d5b67aa4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840b48c-7a14-481e-9d21-0c68aee16020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840b48c-7a14-481e-9d21-0c68aee16020.jpg?1",
             "name": "Laboratory Maniac",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.",
             "colours": [
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "05d9ced2-e828-5dc8-8ee6-22ed3f74e162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367f862-cd88-4e6d-8e87-693080e5c431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367f862-cd88-4e6d-8e87-693080e5c431.jpg?1",
             "name": "Master of the Pearl Trident",
             "text": "Other Merfolk creatures you control get +1/+1 and have islandwalk. (They can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -10535,7 +10535,7 @@
         },
         {
             "id": "232bccae-067d-57fd-83e5-91c3b7d8bab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea86b5bf-c38f-4168-a4dd-96859948423c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea86b5bf-c38f-4168-a4dd-96859948423c.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -10569,7 +10569,7 @@
         },
         {
             "id": "4f20ceef-1f89-56bc-8b51-d67350626d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337214ad-2976-4692-89c4-2c5001bf087f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337214ad-2976-4692-89c4-2c5001bf087f.jpg?1",
             "name": "Mystic Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Return target creature to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -10601,7 +10601,7 @@
         },
         {
             "id": "51d81354-9d18-574b-9fba-ec4dce2dc41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101b32f-2a7f-4cfa-80a4-fdae3756a7f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101b32f-2a7f-4cfa-80a4-fdae3756a7f1.jpg?1",
             "name": "Ninja of the Deep Hours",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Ninja of the Deep Hours deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -10636,7 +10636,7 @@
         },
         {
             "id": "d0ec417d-fd81-54ca-aa76-15e270acc0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad659f3-11c8-4cc0-a716-43bb3ad18a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad659f3-11c8-4cc0-a716-43bb3ad18a9c.jpg?1",
             "name": "Paradoxical Outcome",
             "text": "Return any number of target nonland, nontoken permanents you control to their owners' hands. Draw a card for each card returned to your hand this way.",
             "colours": [
@@ -10668,7 +10668,7 @@
         },
         {
             "id": "d3d4b101-fb5e-55b2-988b-2a9317e909ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af450adb-23be-4332-a54c-d647a1fd0248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af450adb-23be-4332-a54c-d647a1fd0248.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -10700,7 +10700,7 @@
         },
         {
             "id": "0d518adb-b442-5674-b1ac-37d849a109d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69001c08-2541-47e3-8343-2e5089a9b193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69001c08-2541-47e3-8343-2e5089a9b193.jpg?1",
             "name": "Remand",
             "text": "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.",
             "colours": [
@@ -10732,7 +10732,7 @@
         },
         {
             "id": "760a585c-5d9e-5029-bdbf-0d2052f25812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67954eb1-1c61-432c-9113-104909511ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67954eb1-1c61-432c-9113-104909511ad4.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -10764,7 +10764,7 @@
         },
         {
             "id": "e7256b66-5d76-514a-8a1c-0e32b72f9e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7f794-71b7-433f-9d43-863058efa134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7f794-71b7-433f-9d43-863058efa134.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "2a112a05-961c-5898-a9db-b9750dd3e63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e86d8e-8d58-41e8-8c4d-b73482bcba45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e86d8e-8d58-41e8-8c4d-b73482bcba45.jpg?1",
             "name": "Treasure Cruise",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -10833,7 +10833,7 @@
         },
         {
             "id": "35900df9-3dec-5497-ba15-9346ee2fdcf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e006682-5236-4a32-9f3d-7337b2c42b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e006682-5236-4a32-9f3d-7337b2c42b21.jpg?1",
             "name": "Trinket Mage",
             "text": "When Trinket Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "68713514-ca1d-5798-8c17-bb57790adf2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ad086b-9bf2-4086-b820-a4ff7854a674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ad086b-9bf2-4086-b820-a4ff7854a674.jpg?1",
             "name": "True-Name Nemesis",
             "text": "As True-Name Nemesis enters the battlefield, choose a player.\nTrue-Name Nemesis has protection from the chosen player.",
             "colours": [
@@ -10903,7 +10903,7 @@
         },
         {
             "id": "4f0083dc-1815-5f5e-91d9-1c95ddf2cdd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d405dc-180f-4edb-8c53-80a034ee622e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d405dc-180f-4edb-8c53-80a034ee622e.jpg?1",
             "name": "Dismember",
             "text": "({PB} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -10935,7 +10935,7 @@
         },
         {
             "id": "368f0a6f-21d8-5e93-a2f5-929aab3947dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be62041-fec2-44e0-aec9-5368d1c7f1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be62041-fec2-44e0-aec9-5368d1c7f1da.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "When Gray Merchant of Asphodel enters the battlefield, each opponent loses X life, where X is your devotion to black. You gain life equal to the life lost this way. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "72082e26-62b0-5526-9871-b79e88a0f292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361fe303-34a5-4d12-b927-dfb858699c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361fe303-34a5-4d12-b927-dfb858699c6c.jpg?1",
             "name": "Gurmag Angler",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "a29a8a5e-e6c6-575a-aae0-53d2ec297d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d222691-1eb4-407e-a94a-5a71c0f1e376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d222691-1eb4-407e-a94a-5a71c0f1e376.jpg?1",
             "name": "Harvester of Souls",
             "text": "Deathtouch\nWhenever another nontoken creature dies, you may draw a card.",
             "colours": [
@@ -11038,7 +11038,7 @@
         },
         {
             "id": "90ce16ec-6b5d-5398-b153-e552f128dd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186eea73-46c5-4532-ac94-326db7d6f0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186eea73-46c5-4532-ac94-326db7d6f0cb.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -11070,7 +11070,7 @@
         },
         {
             "id": "34c4cb9a-e9d6-599a-bf60-e84651cd3895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f0f9e-556c-40b7-bba9-a539c4c4fd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f0f9e-556c-40b7-bba9-a539c4c4fd30.jpg?1",
             "name": "Liliana's Triumph",
             "text": "Each opponent sacrifices a creature. If you control a Liliana planeswalker, each opponent also discards a card.",
             "colours": [
@@ -11102,7 +11102,7 @@
         },
         {
             "id": "4ec2fb78-2f3f-580e-891d-b2ad9a626421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daf00e8-f95b-410f-9e6f-a7fd6c2b8588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daf00e8-f95b-410f-9e6f-a7fd6c2b8588.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life.",
             "colours": [
@@ -11134,7 +11134,7 @@
         },
         {
             "id": "69c11c4c-3876-58ed-b948-811ea4341dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28de0281-0370-44df-9ee0-6e1bb9925a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28de0281-0370-44df-9ee0-6e1bb9925a92.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -11168,7 +11168,7 @@
         },
         {
             "id": "a1804535-c5e9-5ca7-9e4c-024cb373dbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c16b0-bdab-44e1-b235-47fe8d32f4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c16b0-bdab-44e1-b235-47fe8d32f4d2.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -11200,7 +11200,7 @@
         },
         {
             "id": "1ca4718a-c7b0-539e-baeb-9032c0f8d70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d007da5a-6bd9-433b-b04e-b740e61dfc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d007da5a-6bd9-433b-b04e-b740e61dfc50.jpg?1",
             "name": "Shriekmaw",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhen Shriekmaw enters the battlefield, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -11234,7 +11234,7 @@
         },
         {
             "id": "84a7bf23-0877-543f-a1bf-ac5144d6f72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd78ce3d-cf5a-4f1a-9a47-7872be8cf45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd78ce3d-cf5a-4f1a-9a47-7872be8cf45c.jpg?1",
             "name": "Stinkweed Imp",
             "text": "Flying\nWhenever Stinkweed Imp deals combat damage to a creature, destroy that creature.\nDredge 5 (If you would draw a card, you may mill five cards instead. If you do, return this card from your graveyard to your hand.)",
             "colours": [
@@ -11268,7 +11268,7 @@
         },
         {
             "id": "711a82f7-88a0-5011-a0b7-bab10ff6d96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b6fd9-d0e5-4026-895a-851a462cbf90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b6fd9-d0e5-4026-895a-851a462cbf90.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n{2}{GW}{GW}: Mill two cards, then return a nonland card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -11307,7 +11307,7 @@
         },
         {
             "id": "89c871d9-5914-54e6-a601-4582b4f87b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e76c6b-9d60-4bc8-b88d-6c9c7fade9a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e76c6b-9d60-4bc8-b88d-6c9c7fade9a6.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -11339,7 +11339,7 @@
         },
         {
             "id": "7f1b21cc-11fe-513c-8bf1-2188c4e512ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d945e64f-cbe9-4b72-aaec-0b97be1e12d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d945e64f-cbe9-4b72-aaec-0b97be1e12d2.jpg?1",
             "name": "Vampire Hexmage",
             "text": "First strike\nSacrifice Vampire Hexmage: Remove all counters from target permanent.",
             "colours": [
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "dc1a084b-57ba-509d-966e-2c5e80994250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81564970-23ad-41a3-b5e0-21bdf13f6248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81564970-23ad-41a3-b5e0-21bdf13f6248.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11411,7 +11411,7 @@
         },
         {
             "id": "8cda3f8e-2b70-5285-be0d-911a2e89fe25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8a6636-eab2-4aee-bd55-4d62c2e2e266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8a6636-eab2-4aee-bd55-4d62c2e2e266.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11447,7 +11447,7 @@
         },
         {
             "id": "e26806bb-1c3b-5262-a49d-1eeb5ca8bca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ba1276-0fe6-419f-9d91-fac9eb23cca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ba1276-0fe6-419f-9d91-fac9eb23cca4.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -11486,7 +11486,7 @@
         },
         {
             "id": "46b1c4fa-1b71-53ea-a8d3-e80a76f9309c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89888597-e9bf-431a-8664-da66f22c7ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89888597-e9bf-431a-8664-da66f22c7ea0.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -11518,7 +11518,7 @@
         },
         {
             "id": "7d64a303-98f0-57e1-b185-3f5e3131ab2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526682f2-011c-4cab-9115-ef605489ee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526682f2-011c-4cab-9115-ef605489ee01.jpg?1",
             "name": "Bedlam Reveler",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "27ba2912-7367-5c9f-891a-bf9ac68f5605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933adb-9c7a-4248-9908-f01e6a6bf12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933adb-9c7a-4248-9908-f01e6a6bf12c.jpg?1",
             "name": "Dreadhorde Arcanist",
             "text": "Trample\nWhenever Dreadhorde Arcanist attacks, you may cast target instant or sorcery card with converted mana cost less than or equal to Dreadhorde Arcanist's power from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -11588,7 +11588,7 @@
         },
         {
             "id": "dcac1e61-f5b6-5a78-b349-70e0eb7796b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f9f8b0-f0de-4dff-a8ea-857919366000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f9f8b0-f0de-4dff-a8ea-857919366000.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -11625,7 +11625,7 @@
         },
         {
             "id": "8760d0bc-f696-55eb-9a7b-73f533528abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7109a9-9eec-48fe-9081-5a0424f255ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7109a9-9eec-48fe-9081-5a0424f255ce.jpg?1",
             "name": "Exquisite Firecraft",
             "text": "Exquisite Firecraft deals 4 damage to any target.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.",
             "colours": [
@@ -11657,7 +11657,7 @@
         },
         {
             "id": "40dfb7b5-ba30-5e66-8676-ba070466e984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44130046-cd48-42d5-8083-5e4e7dd37a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44130046-cd48-42d5-8083-5e4e7dd37a7b.jpg?1",
             "name": "Feldon of the Third Path",
             "text": "{2}{R}, {T}: Create a token that's a copy of target creature card in your graveyard, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -11694,7 +11694,7 @@
         },
         {
             "id": "216bdcfd-aabc-5225-9cac-70bdc85d76cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f675f6-df29-4b90-a5e6-26d915fdc6a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f675f6-df29-4b90-a5e6-26d915fdc6a1.jpg?1",
             "name": "Goblin Engineer",
             "text": "When Goblin Engineer enters the battlefield, you may search your library for an artifact card, put it into your graveyard, then shuffle your library.\n{R}, {T}, Sacrifice an artifact: Return target artifact card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "30118563-af77-5c66-b3ff-d4326143acff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a30fe7c-3c6b-4d05-adb7-9f87df29cd3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a30fe7c-3c6b-4d05-adb7-9f87df29cd3b.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Create a token that's a copy of target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -11766,7 +11766,7 @@
         },
         {
             "id": "21485a46-03ca-50e2-b323-4821ee082c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0852af16-f650-4293-81d8-9008882ff45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0852af16-f650-4293-81d8-9008882ff45a.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player or planeswalker.",
             "colours": [
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "f147a2e5-c57e-5f65-a6dd-11c2fc4b8d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f29ab4-79f8-4bcf-ab0e-c21d3c40d63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f29ab4-79f8-4bcf-ab0e-c21d3c40d63e.jpg?1",
             "name": "Molten Rain",
             "text": "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.",
             "colours": [
@@ -11832,7 +11832,7 @@
         },
         {
             "id": "4b6ca226-a25c-57ec-80d9-6ad33a58cfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439d4ade-45c8-414b-a2fe-a57f9672bceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439d4ade-45c8-414b-a2fe-a57f9672bceb.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -11867,7 +11867,7 @@
         },
         {
             "id": "0d29223b-1883-5598-ac7d-81061dc87ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e655061a-8071-4b7b-b993-27f9ea360f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e655061a-8071-4b7b-b993-27f9ea360f7c.jpg?1",
             "name": "Past in Flames",
             "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -11899,7 +11899,7 @@
         },
         {
             "id": "3c6f070e-e66c-5545-b8ac-9e3b3b0b8d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6af20a0-ef9b-4827-a9ef-4958b9d80820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6af20a0-ef9b-4827-a9ef-4958b9d80820.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "4c1f8b7a-48ab-50cd-bc32-7ad2f95d297f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb320986-0a52-4084-a8c4-e09659432b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb320986-0a52-4084-a8c4-e09659432b22.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -11963,7 +11963,7 @@
         },
         {
             "id": "c5ec9fb9-76eb-57c4-8f33-92da9f1d2013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63195ed-5c3e-40e8-9cc2-5cbc1faf7f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63195ed-5c3e-40e8-9cc2-5cbc1faf7f7f.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -11998,7 +11998,7 @@
         },
         {
             "id": "f3f94633-6069-52b6-9275-191fddf8b260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576152c-d8c1-4412-89db-6e21295c9b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576152c-d8c1-4412-89db-6e21295c9b18.jpg?1",
             "name": "Zealous Conscripts",
             "text": "Haste\nWhen Zealous Conscripts enters the battlefield, gain control of target permanent until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -12033,7 +12033,7 @@
         },
         {
             "id": "f9d4e177-a001-5b35-86a7-e97a1514ec17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2a4717-3914-46bc-886e-1eddee94e098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2a4717-3914-46bc-886e-1eddee94e098.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "8b945171-bbc3-5c07-a0de-79022f0db0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbebd9-9faf-4a7b-8e79-b67c074eba8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbebd9-9faf-4a7b-8e79-b67c074eba8c.jpg?1",
             "name": "Beast Whisperer",
             "text": "Whenever you cast a creature spell, draw a card.",
             "colours": [
@@ -12100,7 +12100,7 @@
         },
         {
             "id": "63d5910f-336a-5c4e-83ce-cd72160d9e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1f93-ecee-4ed8-a77e-6ebc4b85328d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1f93-ecee-4ed8-a77e-6ebc4b85328d.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Beast creature token.",
             "colours": [
@@ -12132,7 +12132,7 @@
         },
         {
             "id": "572e687b-6803-57e4-b77e-52d8e823cf1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cbd578-4b3c-4de8-8418-0dd6f85972ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cbd578-4b3c-4de8-8418-0dd6f85972ae.jpg?1",
             "name": "Become Immense",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget creature gets +6/+6 until end of turn.",
             "colours": [
@@ -12164,7 +12164,7 @@
         },
         {
             "id": "6322df71-702f-5426-977a-a313f001c9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c341be76-664f-4665-a4c3-708d97605a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c341be76-664f-4665-a4c3-708d97605a16.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play lands from the top of your library.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "e87f90e1-1453-5c4d-9196-adddaf575760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d50fa57-db11-419e-b73b-666a6b25f7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d50fa57-db11-419e-b73b-666a6b25f7de.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -12234,7 +12234,7 @@
         },
         {
             "id": "4b2b072d-4c59-56de-852b-033579aa12c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584dfb52-4a6c-4a33-9ae1-12227b938f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584dfb52-4a6c-4a33-9ae1-12227b938f9a.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -12269,7 +12269,7 @@
         },
         {
             "id": "16747de0-2a87-5e65-87e6-cf2fe48a5d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c731ba3b-3c48-472b-88ec-05205690e703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c731ba3b-3c48-472b-88ec-05205690e703.jpg?1",
             "name": "Evolutionary Leap",
             "text": "{G}, Sacrifice a creature: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12301,7 +12301,7 @@
         },
         {
             "id": "b235f55d-83c4-5a51-a85b-d199289a4ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74db0dd4-3bb6-41f7-803c-a04647327dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74db0dd4-3bb6-41f7-803c-a04647327dec.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -12333,7 +12333,7 @@
         },
         {
             "id": "b1eb9a52-dca2-5f04-a466-04db8e2a1c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faca514-b7f3-4d34-a259-d03bad50611b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faca514-b7f3-4d34-a259-d03bad50611b.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -12365,7 +12365,7 @@
         },
         {
             "id": "c0b6c996-4da3-515d-b72a-76179d9c157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53760940-50e4-45d4-8297-353c9fc896e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53760940-50e4-45d4-8297-353c9fc896e9.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -12399,7 +12399,7 @@
         },
         {
             "id": "4f1da9f2-1337-51f0-9b5b-0e805cf745b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fba2e4-ea27-4ef0-9b27-bc61a7c6b0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fba2e4-ea27-4ef0-9b27-bc61a7c6b0ab.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -12434,7 +12434,7 @@
         },
         {
             "id": "14b6affd-b84f-5714-a7fa-f3edc4bb700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f882c71-dd90-4eac-9756-0bf487cba625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f882c71-dd90-4eac-9756-0bf487cba625.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -12466,7 +12466,7 @@
         },
         {
             "id": "24f65d9f-aefa-58fc-9863-605fe3891969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30267b1-a7ea-45cd-99a8-6b0e6ddbc395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30267b1-a7ea-45cd-99a8-6b0e6ddbc395.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -12500,7 +12500,7 @@
         },
         {
             "id": "e53de842-9b7e-519e-a330-f0d79822d6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a42d3fb-fc5b-4b8e-bc23-167bc21b5194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a42d3fb-fc5b-4b8e-bc23-167bc21b5194.jpg?1",
             "name": "Time of Need",
             "text": "Search your library for a legendary creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -12532,7 +12532,7 @@
         },
         {
             "id": "0c425aeb-8d8c-5fe7-9f2a-c36100fe1706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57010ba9-52be-484d-9976-7576c4ce48d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57010ba9-52be-484d-9976-7576c4ce48d0.jpg?1",
             "name": "Abrupt Decay",
             "text": "This spell can't be countered.\nDestroy target nonland permanent with converted mana cost 3 or less.",
             "colours": [
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "c9b6781a-b2b6-514b-9316-138c2e6004f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0652f9e2-ba2a-4c0a-bbfc-9b00ee5d28d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0652f9e2-ba2a-4c0a-bbfc-9b00ee5d28d4.jpg?1",
             "name": "Arcades, the Strategist",
             "text": "Flying, vigilance\nWhenever a creature with defender enters the battlefield under your control, draw a card.\nEach creature you control with defender assigns combat damage equal to its toughness rather than its power and can attack as though it didn't have defender.",
             "colours": [
@@ -12607,7 +12607,7 @@
         },
         {
             "id": "2d4acc41-7e5a-5426-8ea3-b7e9fdfbbf09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9445d57a-da77-4456-9e69-c898c4d57853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9445d57a-da77-4456-9e69-c898c4d57853.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -12644,7 +12644,7 @@
         },
         {
             "id": "541100e5-1d65-5cf0-8a8a-fe02b86a82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b8521e-8706-4480-9a47-9600a015cc96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b8521e-8706-4480-9a47-9600a015cc96.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "Sliver creatures you control have flying and haste.",
             "colours": [
@@ -12680,7 +12680,7 @@
         },
         {
             "id": "f09edfb1-ab7c-543d-bcb4-9ce8e6b1a50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc894fb3-011c-441c-8843-34d84b4115ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc894fb3-011c-441c-8843-34d84b4115ef.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -12716,7 +12716,7 @@
         },
         {
             "id": "a1e0cbef-8429-5a9c-8df8-db3cf2483b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2392b542-5ae6-4d0e-808c-734f1d06afa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2392b542-5ae6-4d0e-808c-734f1d06afa4.jpg?1",
             "name": "Dovin's Veto",
             "text": "This spell can't be countered.\nCounter target noncreature spell.",
             "colours": [
@@ -12750,7 +12750,7 @@
         },
         {
             "id": "f906e52a-6fb1-5a57-b3a3-f2c68569f46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2212c653-0daa-4c7a-86fc-493d49db210a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2212c653-0daa-4c7a-86fc-493d49db210a.jpg?1",
             "name": "Epic Experiment",
             "text": "Exile the top X cards of your library. You may cast instant and sorcery spells with converted mana cost X or less from among them without paying their mana costs. Then put all cards exiled this way that weren't cast into your graveyard.",
             "colours": [
@@ -12784,7 +12784,7 @@
         },
         {
             "id": "226b5364-6d70-53dc-86ca-297b8be7cd5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e8bb8-fa07-4858-aafb-7eab7f01ddae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e8bb8-fa07-4858-aafb-7eab7f01ddae.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "Flying\nWhenever you cast an instant or sorcery spell that targets a creature you control, exile that card instead of putting it into your graveyard as it resolves. If you do, return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -12822,7 +12822,7 @@
         },
         {
             "id": "1a946674-d53e-51bd-9ff7-12855fc607f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dba110-0319-4c64-8a96-539627e315ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dba110-0319-4c64-8a96-539627e315ad.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "Grenzo, Dungeon Warden enters the battlefield with X +1/+1 counters on it.\n{2}: Put the bottom card of your library into your graveyard. If it's a creature card with power less than or equal to Grenzo's power, put it onto the battlefield.",
             "colours": [
@@ -12861,7 +12861,7 @@
         },
         {
             "id": "9ae19325-489a-5942-8fa3-55672a94d878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcba497e-14de-4977-9e5a-0533b6b0de60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcba497e-14de-4977-9e5a-0533b6b0de60.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -12898,7 +12898,7 @@
         },
         {
             "id": "76f40a40-90a5-5581-a950-23c439a17594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bee8ea6-8903-4bed-977b-b6c2cd0126f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bee8ea6-8903-4bed-977b-b6c2cd0126f9.jpg?1",
             "name": "Lavinia, Azorius Renegade",
             "text": "Each opponent can't cast noncreature spells with converted mana cost greater than the number of lands that player controls.\nWhenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.",
             "colours": [
@@ -12937,7 +12937,7 @@
         },
         {
             "id": "c6d8fdc7-4926-56e5-9160-931c8b9f7cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767a344e-e2ab-462f-9da3-2e1ee8868a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767a344e-e2ab-462f-9da3-2e1ee8868a26.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "cf43cc52-6510-5992-8346-34c54d4c59cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf17671-5323-4c84-8215-d58dd2189cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf17671-5323-4c84-8215-d58dd2189cdd.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -13007,7 +13007,7 @@
         },
         {
             "id": "98e53ca1-e089-5779-afd6-f38fd519a3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f749c4-3a00-4a9f-b8ad-5c7c3a96e8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f749c4-3a00-4a9f-b8ad-5c7c3a96e8f0.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -13044,7 +13044,7 @@
         },
         {
             "id": "5a048c17-1d71-58fa-b28f-2cbe416d8acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cbac09-6c0c-4c5d-be20-d558815990fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cbac09-6c0c-4c5d-be20-d558815990fb.jpg?1",
             "name": "Rakdos Charm",
             "text": "Choose one \u2014\n\u2022 Exile all cards from target player's graveyard.\n\u2022 Destroy target artifact.\n\u2022 Each creature deals 1 damage to its controller.",
             "colours": [
@@ -13078,7 +13078,7 @@
         },
         {
             "id": "ef96122f-fce1-5e5a-b831-f84b3c05d755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b921da9a-b140-463f-aeee-6d16aaa5246c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b921da9a-b140-463f-aeee-6d16aaa5246c.jpg?1",
             "name": "Secret Plans",
             "text": "Face-down creatures you control get +0/+1.\nWhenever a permanent you control is turned face up, draw a card.",
             "colours": [
@@ -13112,7 +13112,7 @@
         },
         {
             "id": "b2e8eace-0609-5a5b-9275-358c41a9a18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4d684a-2de8-477c-a4d5-d7ae80d62318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4d684a-2de8-477c-a4d5-d7ae80d62318.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13150,7 +13150,7 @@
         },
         {
             "id": "27469bab-c643-5b4d-9420-3e37dfd26c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512f8d1-0d81-424a-a6e4-2a38411dc84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512f8d1-0d81-424a-a6e4-2a38411dc84b.jpg?1",
             "name": "Temur Ascendancy",
             "text": "Creatures you control have haste.\nWhenever a creature with power 4 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -13186,7 +13186,7 @@
         },
         {
             "id": "83c12f56-cfb9-578b-a3d0-b4ff1f71a6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eecfbd-00c6-435c-9d16-70db2d6872a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eecfbd-00c6-435c-9d16-70db2d6872a7.jpg?1",
             "name": "Tidehollow Sculler",
             "text": "When Tidehollow Sculler enters the battlefield, target opponent reveals their hand and you choose a nonland card from it. Exile that card.\nWhen Tidehollow Sculler leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "b26a773e-b282-59e0-880d-1be97ef8ce9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a7756e-2f01-4422-a370-3319fc5145fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a7756e-2f01-4422-a370-3319fc5145fe.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -13259,7 +13259,7 @@
         },
         {
             "id": "6468d7f6-aad6-54fe-bc3f-086240bd93cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25674e46-e15b-4fc0-9813-39b4e1c23de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25674e46-e15b-4fc0-9813-39b4e1c23de4.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "a8b43417-fd97-5e17-8762-cba6ded7e3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1f5bf0-14d8-4b47-8b94-8741d1cc8bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1f5bf0-14d8-4b47-8b94-8741d1cc8bd9.jpg?1",
             "name": "Contagion Clasp",
             "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -13315,7 +13315,7 @@
         },
         {
             "id": "368a54cf-91ef-5e0f-b2d7-9fd2fca56cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26d52d-7437-44cf-90b7-b536a5b8c94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26d52d-7437-44cf-90b7-b536a5b8c94d.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1}",
             "colours": [],
@@ -13347,7 +13347,7 @@
         },
         {
             "id": "0f558812-baad-5bb6-8a78-b185a8ee4344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b7bf9-4087-4235-a21e-33f52ae69b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b7bf9-4087-4235-a21e-33f52ae69b48.jpg?1",
             "name": "Crystal Shard",
             "text": "{3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}.",
             "colours": [],
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "13a9c202-2da7-5448-bba9-3769909e4848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27875258-47af-4105-9ded-56e03dcbd9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27875258-47af-4105-9ded-56e03dcbd9e7.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2}\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "5a79ee4d-779d-5ded-8ee4-54f6dab76946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ca366-2a43-4930-9c16-0ba72c1de3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ca366-2a43-4930-9c16-0ba72c1de3b8.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -13433,7 +13433,7 @@
         },
         {
             "id": "bf42e88c-de59-51e7-a443-d1c48d07f508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b167fef0-a3ef-4e76-bd69-51ed7501cba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b167fef0-a3ef-4e76-bd69-51ed7501cba8.jpg?1",
             "name": "Hollow One",
             "text": "This spell costs {2} less to cast for each card you've cycled or discarded this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -13464,7 +13464,7 @@
         },
         {
             "id": "72d13d43-07fc-5374-9e81-82dd9982d3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9d8fa-2427-49fb-af69-3b2688dc8a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9d8fa-2427-49fb-af69-3b2688dc8a8c.jpg?1",
             "name": "Leveler",
             "text": "When Leveler enters the battlefield, exile all cards from your library.",
             "colours": [],
@@ -13495,7 +13495,7 @@
         },
         {
             "id": "97f3cf46-3249-5046-b4cf-bacf25a5ea1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e74de1-1f1f-4886-ba33-644db34df588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e74de1-1f1f-4886-ba33-644db34df588.jpg?1",
             "name": "Manifold Key",
             "text": "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -13523,7 +13523,7 @@
         },
         {
             "id": "13050cfb-9a41-5c62-b135-e548bd131961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c88ec62-c3c9-4bb8-99f6-04c7a9d65e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c88ec62-c3c9-4bb8-99f6-04c7a9d65e45.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -13551,7 +13551,7 @@
         },
         {
             "id": "9b80359a-dec2-5f0c-a4bf-6b76346e55f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7272e1b-439b-4283-932d-e1084468c32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7272e1b-439b-4283-932d-e1084468c32b.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -13582,7 +13582,7 @@
         },
         {
             "id": "43799ab3-9790-5c4e-8bb8-53195605f242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa420ea4-93ef-44e5-ad13-c186a4451624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa420ea4-93ef-44e5-ad13-c186a4451624.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -13610,7 +13610,7 @@
         },
         {
             "id": "16d7e562-1b61-5399-85dc-a97b27606c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b54a7-30c9-4955-8e71-7437528de18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b54a7-30c9-4955-8e71-7437528de18c.jpg?1",
             "name": "Vanquisher's Banner",
             "text": "As Vanquisher's Banner enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\nWhenever you cast a creature spell of the chosen type, draw a card.",
             "colours": [],
@@ -13638,7 +13638,7 @@
         },
         {
             "id": "dd081b5e-7f60-5e89-91ee-77d1b14ce5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddf6c54-d928-42f7-b2b6-7ee58be58148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddf6c54-d928-42f7-b2b6-7ee58be58148.jpg?1",
             "name": "Ancient Den",
             "text": "{T}: Add {W}.",
             "colours": [],
@@ -13669,7 +13669,7 @@
         },
         {
             "id": "9fd37d07-d14e-58af-b4a9-031b416a9b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2216c70-91c2-43d5-9156-9b4f7828c821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2216c70-91c2-43d5-9156-9b4f7828c821.jpg?1",
             "name": "Arch of Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C}.\n{5}, {T}: Draw a card. Activate this ability only if you have the city's blessing.",
             "colours": [],
@@ -13697,7 +13697,7 @@
         },
         {
             "id": "52d4dfe4-4f5d-50cc-98df-d386a7e56c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a29ec4-ec55-4754-b832-35b39e8b23ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a29ec4-ec55-4754-b832-35b39e8b23ae.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {C}.\n{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -13727,7 +13727,7 @@
         },
         {
             "id": "6b07bb35-51f8-5865-a072-b5bcb57b4095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46ca7cb-4a04-4081-8834-6bc29e0762d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46ca7cb-4a04-4081-8834-6bc29e0762d2.jpg?1",
             "name": "Bojuka Bog",
             "text": "Bojuka Bog enters the battlefield tapped.\nWhen Bojuka Bog enters the battlefield, exile all cards from target player's graveyard.\n{T}: Add {B}.",
             "colours": [],
@@ -13757,7 +13757,7 @@
         },
         {
             "id": "d2c209e7-138b-5eb5-9574-f9ae78233b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284d3ba-0542-48d7-8305-bfb2775c3674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284d3ba-0542-48d7-8305-bfb2775c3674.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles their library.",
             "colours": [],
@@ -13785,7 +13785,7 @@
         },
         {
             "id": "9a6845c8-278f-50cf-a3bf-13bfd919de84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f83f35-c4dc-46f0-9109-9d0d0181d9c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f83f35-c4dc-46f0-9109-9d0d0181d9c8.jpg?1",
             "name": "Mystic Sanctuary",
             "text": "({T}: Add {U}.)\nMystic Sanctuary enters the battlefield tapped unless you control three or more other Islands.\nWhen Mystic Sanctuary enters the battlefield untapped, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [],
@@ -13817,7 +13817,7 @@
         },
         {
             "id": "7bf16df1-1cec-5d5c-969f-b186bbdb164f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a7ea8-aa1c-4ff9-b1f7-06452492c788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a7ea8-aa1c-4ff9-b1f7-06452492c788.jpg?1",
             "name": "Ramunap Ruins",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add {R}.\n{2}{R}{R}, {T}, Sacrifice a Desert: Ramunap Ruins deals 2 damage to each opponent.",
             "colours": [],
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "16c84ee9-fcc0-5d6c-a22e-df3ebf514f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10c264-c7f6-4ae3-b3ef-ff12bd7b64c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10c264-c7f6-4ae3-b3ef-ff12bd7b64c0.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -13879,7 +13879,7 @@
         },
         {
             "id": "9940c435-2bf3-50e8-9e9b-ce3651bfb6f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7466be25-5d41-408d-90eb-6de47ea11484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7466be25-5d41-408d-90eb-6de47ea11484.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color.",
             "colours": [],
@@ -13908,7 +13908,7 @@
         },
         {
             "id": "a1562632-0989-5122-b108-3cb73a6ac90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7a7388-3f80-41c0-a042-d6b8ef3cf291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7a7388-3f80-41c0-a042-d6b8ef3cf291.jpg?1",
             "name": "Griffin",
             "text": "",
             "colours": [
@@ -13942,7 +13942,7 @@
         },
         {
             "id": "48ab910b-8770-50e2-bd1f-1d505e07c1fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6090f44-034f-4069-a328-5c81ab774cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6090f44-034f-4069-a328-5c81ab774cea.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -13976,7 +13976,7 @@
         },
         {
             "id": "0ee365ef-02d4-580f-b535-1706b0ea5204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2144f2-d4be-419e-bfca-116cedfdf18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2144f2-d4be-419e-bfca-116cedfdf18b.jpg?1",
             "name": "Cloud Sprite",
             "text": "",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "3968de9a-3aac-5b38-8a48-51f1cdfe3f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c532e0f-8934-4ad3-bb1a-640abe946e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c532e0f-8934-4ad3-bb1a-640abe946e10.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -14044,7 +14044,7 @@
         },
         {
             "id": "362cdc6f-d7d0-5dca-884e-0a3e4e120508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31ce82f-6c4a-4986-be1e-032348504ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31ce82f-6c4a-4986-be1e-032348504ad6.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "43524a68-f7fd-5050-8aae-65dcbc86eab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e8f429-5a66-4bcd-8a1f-69f9b79c0f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e8f429-5a66-4bcd-8a1f-69f9b79c0f5b.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -14112,7 +14112,7 @@
         },
         {
             "id": "bd17bd9c-4774-5ad1-a696-b46cfe9d4041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0197284c-3c17-438b-a46d-83131d56c768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0197284c-3c17-438b-a46d-83131d56c768.jpg?1",
             "name": "Giant",
             "text": "",
             "colours": [
@@ -14146,7 +14146,7 @@
         },
         {
             "id": "8d32e4af-d168-5a47-9b9e-4512e2063e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234007e2-624f-42d0-af7f-9788f9f35fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234007e2-624f-42d0-af7f-9788f9f35fab.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -14180,7 +14180,7 @@
         },
         {
             "id": "3ef49466-2745-594c-80c3-c598fb5ef612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e8e64-7caa-4d98-8e20-0a4a20056143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e8e64-7caa-4d98-8e20-0a4a20056143.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -14214,7 +14214,7 @@
         },
         {
             "id": "f32064f0-133f-5e83-bfb8-7f7b82c1fb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e0924c-e4b7-482d-9076-1d3b8ff09e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e0924c-e4b7-482d-9076-1d3b8ff09e9b.jpg?1",
             "name": "Ape",
             "text": "",
             "colours": [
@@ -14248,7 +14248,7 @@
         },
         {
             "id": "56407688-2fea-5806-be9d-04c0eea6ae2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -14282,7 +14282,7 @@
         },
         {
             "id": "5f62e8ff-2cc2-546b-b58f-da255e8171a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcb0668-e88c-4462-b079-34f140c0277e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcb0668-e88c-4462-b079-34f140c0277e.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -14317,7 +14317,7 @@
         },
         {
             "id": "5940e002-54ac-564a-958f-4f70f7f8becb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed58cd8c-b11a-4109-b789-0eb92eaf0184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed58cd8c-b11a-4109-b789-0eb92eaf0184.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -14351,7 +14351,7 @@
         },
         {
             "id": "2fc6f9fb-404d-5f5b-b6e6-d3c435749337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72daa68-0680-431c-a616-b3693fd58813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72daa68-0680-431c-a616-b3693fd58813.jpg?1",
             "name": "Assembly-Worker",
             "text": "",
             "colours": [],
@@ -14382,7 +14382,7 @@
         },
         {
             "id": "134a8ff3-eddb-5e65-9e27-ac521c0357e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e0d67-b627-4cf7-8f56-e1f0bd75cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e0d67-b627-4cf7-8f56-e1f0bd75cd5c.jpg?1",
             "name": "Metallic Sliver",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/UDS.json
+++ b/Assets/Resources/Sets/UDS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b0e69425-f47f-5879-a526-5396994655d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4367bc78-0912-4abd-8edd-bc792558d01a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4367bc78-0912-4abd-8edd-bc792558d01a.jpg?1",
             "name": "Academy Rector",
             "text": "When Academy Rector is put into a graveyard from play, you may remove Academy Rector from the game. If you do, search your library for an enchantment card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b1246365-728a-5dd6-82cf-7e51d308ce99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151232e6-68cc-4cac-a532-9ade8e925961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151232e6-68cc-4cac-a532-9ade8e925961.jpg?1",
             "name": "Archery Training",
             "text": "At the beginning of your upkeep, you may put an arrow counter on Archery Training.\nEnchanted creature gains \"oc\nT: This creature deals X damage to target attacking or blocking creature, where X is the number of arrow counters on the Archery Training enchanting this creature.\"",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "83a63214-23b9-5485-b90a-5843f54c5307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d7f78e-d310-4305-942e-7839583bd893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d7f78e-d310-4305-942e-7839583bd893.jpg?1",
             "name": "Capashen Knight",
             "text": "First strike\no1oo\nW Capashen Knight gets +1/+0 until end of turn.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "8fc693d6-4903-500e-b1b2-23967b58405d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16665386-405e-48c9-8c69-c21b03931c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16665386-405e-48c9-8c69-c21b03931c2f.jpg?1",
             "name": "Capashen Standard",
             "text": "Enchanted creature gets +1/+1.\no2, Sacrifice Capashen Standard: Draw a card.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "dc332d75-f08f-5cc7-ba42-6578c13054ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0976a193-463a-4bcb-a951-ca73347a5572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0976a193-463a-4bcb-a951-ca73347a5572.jpg?1",
             "name": "Capashen Templar",
             "text": "oo\nW Capashen Templar gets +0/+1 until end of turn.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "4f63c818-48ba-5556-a98c-0fb5d9deaa93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcb46d3-1ddf-4e3b-9ac7-a3fee49f04c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcb46d3-1ddf-4e3b-9ac7-a3fee49f04c6.jpg?1",
             "name": "False Prophet",
             "text": "When False Prophet is put into a graveyard from play, remove all creatures from the game.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "ffbb07f0-1846-5990-b85c-1710ff1f3c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d7a33-986d-45ad-8662-7bca80d3628d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d7a33-986d-45ad-8662-7bca80d3628d.jpg?1",
             "name": "Fend Off",
             "text": "Cycling o2\nTarget creature deals no combat damage this turn.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "ed459912-5954-5f82-800c-340768be09f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb830403-0832-47f7-b4b4-4f241f1b9112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb830403-0832-47f7-b4b4-4f241f1b9112.jpg?1",
             "name": "Field Surgeon",
             "text": "Tap an untapped creature you control: Prevent the next 1 damage to target creature this turn.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "e2759759-106b-5a0c-9d89-64df82b6f8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e7ec5-6488-483f-8020-b48e1a951f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e7ec5-6488-483f-8020-b48e1a951f09.jpg?1",
             "name": "Flicker",
             "text": "Remove target nontoken permanent from the game, then return it to play under its owner's control.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "b15644b3-8da5-5938-a2e9-a62f28cfe257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6641dd2-5b9c-4089-8a71-a3a1a9c29f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6641dd2-5b9c-4089-8a71-a3a1a9c29f8b.jpg?1",
             "name": "Jasmine Seer",
             "text": "o2o\nW, oc\nT: Reveal any number of white cards in your hand. You gain 2 life for each card revealed this way.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "6fdc10fc-15e9-54a9-84cf-564cf45c4960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd97150-b405-4bb5-b5a8-fceda4a45ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd97150-b405-4bb5-b5a8-fceda4a45ebb.jpg?1",
             "name": "Mask of Law and Grace",
             "text": "Enchanted creature gains protection from black and protection from red.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "85db7ad3-6d16-538c-989a-914ec7cd69cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a342c-ad80-43e4-8b2d-1c48241c52b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a342c-ad80-43e4-8b2d-1c48241c52b1.jpg?1",
             "name": "Master Healer",
             "text": "oc\nT: Prevent the next 4 damage to target creature or player this turn.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "aa03644e-01c9-5ef7-a2b2-ef3da6014aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0071fb-afa5-47b5-b266-2b10a4f5a98a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0071fb-afa5-47b5-b266-2b10a4f5a98a.jpg?1",
             "name": "Opalescence",
             "text": "Each other global enchantment is a creature with power and toughness each equal to its converted mana cost. It's still an enchantment.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "70df1168-6ed2-533d-abb7-1da3dec72d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243e9386-2a7f-406a-9ed3-77d4bf1b50fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243e9386-2a7f-406a-9ed3-77d4bf1b50fd.jpg?1",
             "name": "Reliquary Monk",
             "text": "When Reliquary Monk is put into a graveyard from play, destroy target artifact or enchantment.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "7f2288a2-7217-5cfc-b04d-6d410cb8dea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2fe13-bbc0-42b7-bc42-3b51910ce118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2fe13-bbc0-42b7-bc42-3b51910ce118.jpg?1",
             "name": "Replenish",
             "text": "Return all enchantment cards from your graveyard to play. (Local enchantments with no permanent to enchant remain in your graveyard.)",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "4b5c5aa5-bbb6-5053-94a5-96134660d176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc6b744-92c7-4839-9b27-833bedb92bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc6b744-92c7-4839-9b27-833bedb92bba.jpg?1",
             "name": "Sanctimony",
             "text": "Whenever one of your opponents taps a mountain for mana, you may gain 1 life.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "fc02dea7-cbcc-571f-b5ac-4af283b97939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dae0cf-9696-498c-8d28-dc8c239faec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dae0cf-9696-498c-8d28-dc8c239faec7.jpg?1",
             "name": "Scent of Jasmine",
             "text": "Reveal any number of white cards in your hand. You gain 2 life for each card revealed this way.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "c3199633-3df9-5b78-8e50-b1b125b6f1cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac5162e-39ea-4f01-92eb-182fe23c1608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac5162e-39ea-4f01-92eb-182fe23c1608.jpg?1",
             "name": "Scour",
             "text": "Remove target enchantment from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "a0fac403-93a4-5014-9eba-6f4e91553686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac540c7-8b3a-4e28-96a2-d414ff613640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac540c7-8b3a-4e28-96a2-d414ff613640.jpg?1",
             "name": "Serra Advocate",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "d5767d51-547a-5c59-9484-a12de098657d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e1589a-ec4f-47a4-b758-ada7f49ffb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e1589a-ec4f-47a4-b758-ada7f49ffb8f.jpg?1",
             "name": "Solidarity",
             "text": "Creatures you control get +0/+5 until end of turn.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "ca6a3bf0-35e0-598e-a155-3d13a8e90d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bed19fa-e497-48de-8459-030e60fdc9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bed19fa-e497-48de-8459-030e60fdc9a8.jpg?1",
             "name": "Tethered Griffin",
             "text": "Flying\nWhen you control no enchantments, sacrifice Tethered Griffin.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "4ae811a8-f0b3-58f6-afc6-3f784a9e1787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d4d751-50df-4d8f-a6d9-4e76797c429a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d4d751-50df-4d8f-a6d9-4e76797c429a.jpg?1",
             "name": "Tormented Angel",
             "text": "Flying",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "ecfe3c40-785d-51b9-a0c0-475ea488f37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c648e59-c872-4e04-b45f-2729b42410af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c648e59-c872-4e04-b45f-2729b42410af.jpg?1",
             "name": "Voice of Duty",
             "text": "Flying, protection from green",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "6805405e-49e7-549a-b207-e4cfbf16a70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3d5a10-6d4b-4383-b400-7323f2b4670e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3d5a10-6d4b-4383-b400-7323f2b4670e.jpg?1",
             "name": "Voice of Reason",
             "text": "Flying, protection from blue",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "aa3cee08-9c8b-5d02-a476-a1778cc11375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f159193-fcf8-437c-b14a-06718a446a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f159193-fcf8-437c-b14a-06718a446a5c.jpg?1",
             "name": "Wall of Glare",
             "text": "(Walls can't attack.)\nWall of Glare may block any number of creatures each combat.",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "dc32ed0e-137c-5c99-9434-bf2dc1e293a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae591d2-b9d3-4bc5-bcec-5d3d79a13b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae591d2-b9d3-4bc5-bcec-5d3d79a13b41.jpg?1",
             "name": "Aura Thief",
             "text": "Flying\nWhen Aura Thief is put into a graveyard from play, you gain control of all enchantments. (You don't get to move local enchantments.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "248776ce-5d76-577a-a5a8-fba6ee8f4220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949c5a7-9656-466a-add8-1800973fefee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949c5a7-9656-466a-add8-1800973fefee.jpg?1",
             "name": "Blizzard Elemental",
             "text": "Flying\no3oo\nU Untap Blizzard Elemental.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "efaed608-df00-5b44-8b21-27dd3b1070cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6e5575-b004-417f-9366-6ba7840a79e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6e5575-b004-417f-9366-6ba7840a79e7.jpg?1",
             "name": "Brine Seer",
             "text": "o2o\nU, oc\nT: Reveal any number of blue cards in your hand. Counter target spell unless its controller pays o1 for each card revealed this way.",
             "colours": [
@@ -950,7 +950,7 @@
         },
         {
             "id": "53e68e3b-07a0-52a9-8397-928c5a92c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1",
             "name": "Bubbling Beebles",
             "text": "Bubbling Beebles is unblockable as long as defending player controls an enchantment.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "ead8866e-fa99-559b-85e3-05db07f24bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf280f4-74a1-4e6f-aec6-1852f04204e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf280f4-74a1-4e6f-aec6-1852f04204e4.jpg?1",
             "name": "Disappear",
             "text": "oo\nU Return enchanted creature and Disappear to their owners' hands.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "90f4b30a-abf7-5114-bbb6-ac5f567c9b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d8ce9-f8c8-45ad-b74c-97fba0e2982e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d8ce9-f8c8-45ad-b74c-97fba0e2982e.jpg?1",
             "name": "Donate",
             "text": "Target player gains control of target permanent you control.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "cad6361a-7aa0-565d-9e7d-87a5d4d9cc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660fb109-dd65-4410-99b9-a2a14f8ea202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660fb109-dd65-4410-99b9-a2a14f8ea202.jpg?1",
             "name": "Fatigue",
             "text": "Target player skips his or her next draw step.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "02075eb8-fb7e-5f5a-8bb0-3e378f21736c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd46bfa-ca09-422f-9891-db9399fa2d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd46bfa-ca09-422f-9891-db9399fa2d3a.jpg?1",
             "name": "Fledgling Osprey",
             "text": "Fledgling Osprey gains flying as long as it's enchanted.",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "bc0a51e2-217b-5835-bf8f-af1704db43f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f98e703-a0d3-497f-840a-aa026b02d47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f98e703-a0d3-497f-840a-aa026b02d47f.jpg?1",
             "name": "Illuminated Wings",
             "text": "Enchanted creature gains flying.\no2, Sacrifice Illuminated Wings: Draw a card.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "3a1be31b-5f4a-5609-85a5-224f5c31654b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cbc36d-3391-4086-9b81-fb1ef0b83046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cbc36d-3391-4086-9b81-fb1ef0b83046.jpg?1",
             "name": "Iridescent Drake",
             "text": "Flying\nWhen Iridescent Drake comes into play, return target enchant creature card from a graveyard to play enchanting Iridescent Drake. (You control that enchantment.)",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "5532e74f-4e11-5103-928b-4fd9c365edff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442bc3ba-00b3-4616-a5b2-55524ff8a736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442bc3ba-00b3-4616-a5b2-55524ff8a736.jpg?1",
             "name": "Kingfisher",
             "text": "Flying\nWhen Kingfisher is put into a graveyard from play, draw a card.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "eb05dd87-7c42-52ec-bb62-e33ead1e8660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ffd83-b5c9-46b4-bc5a-172ca34ddc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ffd83-b5c9-46b4-bc5a-172ca34ddc79.jpg?1",
             "name": "Mental Discipline",
             "text": "o1o\nU, Choose and discard a card from your hand: Draw a card.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "7734c4b3-e710-5a38-82d3-eb27e266b2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa941f17-1b81-4017-90ae-4466eba8da2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa941f17-1b81-4017-90ae-4466eba8da2f.jpg?1",
             "name": "Metathran Elite",
             "text": "Metathran Elite is unblockable as long as it's enchanted.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "8f2a7b23-7447-52a7-a94e-29e4004b20b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650d40d0-78ec-4b6e-8ea0-28d43ce175d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650d40d0-78ec-4b6e-8ea0-28d43ce175d5.jpg?1",
             "name": "Metathran Soldier",
             "text": "Metathran Soldier is unblockable.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "197c45bf-2cb1-5003-843e-e5c75c5f0211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95be2701-af7c-483e-8165-e8bd4b2774ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95be2701-af7c-483e-8165-e8bd4b2774ed.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -1352,7 +1352,7 @@
         },
         {
             "id": "fbc49538-3f1c-5b61-bb3a-cd35f9de88f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f9849-a4bd-4501-9473-79345c751701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f9849-a4bd-4501-9473-79345c751701.jpg?1",
             "name": "Private Research",
             "text": "At the beginning of your upkeep, you may put a page counter on Private Research.\nWhen enchanted creature is put into a graveyard, draw a card for each page counter on Private Research.",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "408d9636-1938-5a77-b7e2-d9702123db70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62019ac4-a5a1-4a8c-bfb4-96e818949bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62019ac4-a5a1-4a8c-bfb4-96e818949bbe.jpg?1",
             "name": "Quash",
             "text": "Counter target instant or sorcery spell. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "ebe7fab8-a1bd-5bc9-9136-46297176e4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee6480c-7697-47e2-893b-ca88c0ab3376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee6480c-7697-47e2-893b-ca88c0ab3376.jpg?1",
             "name": "Rayne, Academy Chancellor",
             "text": "Whenever you or a permanent you control is the target of a spell or ability controlled by one of your opponents, you may draw a card, and if Rayne, Academy Chancellor is enchanted, you may draw another card.",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "f176cf58-7abc-5696-9517-6a1c3df371a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fc979e-7758-4310-9259-659e9ced2c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fc979e-7758-4310-9259-659e9ced2c7f.jpg?1",
             "name": "Rescue",
             "text": "Return target permanent you control to its owner's hand.",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "68b0be19-4739-57d2-a026-b54cfa740d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117bf8d-23ec-4f9d-99d0-3a990c5f7075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117bf8d-23ec-4f9d-99d0-3a990c5f7075.jpg?1",
             "name": "Scent of Brine",
             "text": "Reveal any number of blue cards in your hand. Counter target spell unless its controller pays o1 for each card revealed this way.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "23ed8ac1-00ec-5491-a4ce-cccd9c3c41df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f3c70-e2c3-479e-8d22-2fd1429e9857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f3c70-e2c3-479e-8d22-2fd1429e9857.jpg?1",
             "name": "Sigil of Sleep",
             "text": "Whenever enchanted creature deals damage to a player, return target creature that player controls to its owner's hand.",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "87fed47f-c822-51ed-abe4-699b5ac69acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e7f64-e32c-4242-aae9-45d50b89ff1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e7f64-e32c-4242-aae9-45d50b89ff1f.jpg?1",
             "name": "Telepathic Spies",
             "text": "When Telepathic Spies comes into play, look at target opponent's hand.",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "87cd283a-b7d3-5eef-b2d2-7e40ee910b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bb9695-a8b0-47b4-9a03-11d559412f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bb9695-a8b0-47b4-9a03-11d559412f33.jpg?1",
             "name": "Temporal Adept",
             "text": "o\nUo\nUo\nU, oc\nT: Return target permanent to its owner's hand.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "3a20c68d-bfa5-53b3-b115-317865da6c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b23b9-4569-40ff-988f-ad1d5d3fe573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b23b9-4569-40ff-988f-ad1d5d3fe573.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying\nWhenever Thieving Magpie deals damage to one of your opponents, you draw a card.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "58ddf2a3-1810-5ebd-a8be-2e0957b29bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613694aa-b169-400d-8063-2b83d8303611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613694aa-b169-400d-8063-2b83d8303611.jpg?1",
             "name": "Treachery",
             "text": "When Treachery comes into play, untap up to five lands.\nYou control enchanted creature.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "50d8ee20-8fe0-5396-97f4-af34d38f95a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cc1f6-9897-4de4-8e94-40cbe2d962a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cc1f6-9897-4de4-8e94-40cbe2d962a2.jpg?1",
             "name": "Apprentice Necromancer",
             "text": "o\nB, oc\nT, Sacrifice Apprentice Necromancer: Return target creature card from your graveyard to play. That creature gains haste. At end of turn, sacrifice it. (The creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "7b6abdfe-6aff-5d80-949c-bfdb2b7cbca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb615b-249d-433f-a521-8310e8784b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb615b-249d-433f-a521-8310e8784b5d.jpg?1",
             "name": "Attrition",
             "text": "o\nB, Sacrifice a creature: Destroy target nonblack creature.",
             "colours": [
@@ -1758,7 +1758,7 @@
         },
         {
             "id": "9a2d2c91-3391-59a1-a7e4-930b050ba541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d4c858-5a11-485d-a514-12a6d80459f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d4c858-5a11-485d-a514-12a6d80459f0.jpg?1",
             "name": "Body Snatcher",
             "text": "When Body Snatcher comes into play, you may choose and discard a creature card from your hand. If you don't, remove Body Snatcher from the game.\nWhen Body Snatcher is put into a graveyard from play, remove Body Snatcher from the game and return target creature card from your graveyard to play.",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "d1025350-d221-5446-9d6a-e070aafa9428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca76614-78a1-4535-9162-70469d1e8a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca76614-78a1-4535-9162-70469d1e8a13.jpg?1",
             "name": "Bubbling Muck",
             "text": "Until end of turn, whenever a player taps a swamp for mana, it produces an additional o\nB.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "35f68312-c536-5df5-bf6d-582192a41bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847340fb-9251-4439-b33b-f86bff507dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847340fb-9251-4439-b33b-f86bff507dcd.jpg?1",
             "name": "Carnival of Souls",
             "text": "Whenever a creature comes into play, you lose 1 life and add o\nB to your mana pool.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "479fa3eb-332e-5ba4-a717-47fd7a349f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec7c917-b254-4643-afc2-b6387f267469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec7c917-b254-4643-afc2-b6387f267469.jpg?1",
             "name": "Chime of Night",
             "text": "When Chime of Night is put into a graveyard from play, destroy target nonblack creature.",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "234fe6d9-63c1-5185-8d9f-97a8d5bc655c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49125cfc-dbae-4543-9d2d-4cc78f45ce9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49125cfc-dbae-4543-9d2d-4cc78f45ce9a.jpg?1",
             "name": "Disease Carriers",
             "text": "When Disease Carriers is put into a graveyard from play, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "49b61440-2740-580a-8a66-06627f8c32be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a25a472-495e-4062-b66f-c37f148b494f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a25a472-495e-4062-b66f-c37f148b494f.jpg?1",
             "name": "Dying Wail",
             "text": "When enchanted creature is put into a graveyard from play, target player chooses and discards two cards from his or her hand.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "a96218d1-4648-5e55-be1b-4746b84db1a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd48dac-0a1a-49c4-8daf-11972b990454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd48dac-0a1a-49c4-8daf-11972b990454.jpg?1",
             "name": "Encroach",
             "text": "Look at target player's hand and choose a nonbasic land card from it. That player discards that card.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "473abae9-677b-5b72-8941-74a34d7c466b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fad4607-c11d-4407-b5fa-bd34f74e41b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fad4607-c11d-4407-b5fa-bd34f74e41b3.jpg?1",
             "name": "Eradicate",
             "text": "Remove target nonblack creature from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "68c91cdd-1367-5443-91de-9126593cc117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927eed13-510b-4b06-811d-91a6a069cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927eed13-510b-4b06-811d-91a6a069cb8c.jpg?1",
             "name": "Festering Wound",
             "text": "At the beginning of your upkeep, you may put an infection counter on Festering Wound.\nAt the beginning of the upkeep of enchanted creature's controller, Festering Wound deals X damage to that player, where X is the number of infection counters on Festering Wound.",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "4e4d0bdb-6401-506b-9114-fdbda54ceb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d082d8-f401-47ad-845c-77776ee647ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d082d8-f401-47ad-845c-77776ee647ba.jpg?1",
             "name": "Lurking Jackals",
             "text": "When one of your opponents has 10 life or less, if Lurking Jackals is an enchantment, it becomes a 3/2 Hound creature.",
             "colours": [
@@ -2089,7 +2089,7 @@
         },
         {
             "id": "722f00ed-823f-5a4a-9e0f-85a710f7cd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2262467-1354-4aec-84a2-21916c44b9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2262467-1354-4aec-84a2-21916c44b9ef.jpg?1",
             "name": "Nightshade Seer",
             "text": "o2o\nB, oc\nT: Reveal any number of black cards in your hand. Target creature gets -X/-X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "fa43dfc5-37d3-5c33-942a-b95eba8486e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/571058b0-7e10-4259-8db9-5c8b78c1e13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/571058b0-7e10-4259-8db9-5c8b78c1e13d.jpg?1",
             "name": "Phyrexian Monitor",
             "text": "oo\nB Regenerate Phyrexian Monitor.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "93624615-209a-57c3-8520-0b68b9440910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a02d67-5931-49ae-a28e-57aa6f9c7f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a02d67-5931-49ae-a28e-57aa6f9c7f83.jpg?1",
             "name": "Phyrexian Negator",
             "text": "Trample\nWhenever Phyrexian Negator is dealt damage, sacrifice a permanent for each 1 damage dealt to it.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "ffd0eb74-20c8-50b8-9256-3a4858c3d652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9cebd8-aa3f-4e22-8d15-d4b7bad355e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9cebd8-aa3f-4e22-8d15-d4b7bad355e4.jpg?1",
             "name": "Plague Dogs",
             "text": "When Plague Dogs is put into a graveyard from play, all creatures get -1/-1 until end of turn.\no2, Sacrifice Plague Dogs: Draw a card.",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "dc2ba3f0-9754-5d94-bc01-167deccf2e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1678d911-1456-4631-a2f4-d7de4906644b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1678d911-1456-4631-a2f4-d7de4906644b.jpg?1",
             "name": "Rapid Decay",
             "text": "Cycling o2\nRemove from the game up to three target cards in a single graveyard.",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "3312ed41-aab2-5fe7-bd5b-f84ee7ba0b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9185188-9a32-4ccd-8f33-b0c299901d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9185188-9a32-4ccd-8f33-b0c299901d81.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent chooses and discards a card from his or her hand.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "c555a96d-c96d-577f-8251-5219b508837a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582468a6-0ea9-411e-a694-13977d47c877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582468a6-0ea9-411e-a694-13977d47c877.jpg?1",
             "name": "Scent of Nightshade",
             "text": "Reveal any number of black cards in your hand. Target creature gets -X/-X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -2328,7 +2328,7 @@
         },
         {
             "id": "972d8bfe-fe9b-55f6-8ed4-2eb33858b26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cd2771-9681-4b4a-8c2c-a2ffd7361c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cd2771-9681-4b4a-8c2c-a2ffd7361c35.jpg?1",
             "name": "Skittering Horror",
             "text": "When you play a creature spell, sacrifice Skittering Horror.",
             "colours": [
@@ -2363,7 +2363,7 @@
         },
         {
             "id": "fa899bf9-0d6b-5384-bce5-8cc02fd6854f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00522c4b-4e64-4403-96b1-df41afbe255f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00522c4b-4e64-4403-96b1-df41afbe255f.jpg?1",
             "name": "Slinking Skirge",
             "text": "Flying\no2, Sacrifice Slinking Skirge: Draw a card.",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "021d9bf0-3f3c-57a4-9959-5fac926f4cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417a9db-5101-4fe1-84b7-283ca1fd42e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417a9db-5101-4fe1-84b7-283ca1fd42e5.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "c83b5d41-049f-572f-ab88-a2d9b41f7c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47793a3-9a98-4733-8d6a-2fb1a67b15c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47793a3-9a98-4733-8d6a-2fb1a67b15c9.jpg?1",
             "name": "Squirming Mass",
             "text": "Squirming Mass can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "e79ee2a5-39ce-5a86-92a2-8d8a7c3ea692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e37889-7dc0-476b-8b99-8f06881d352c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e37889-7dc0-476b-8b99-8f06881d352c.jpg?1",
             "name": "Twisted Experiment",
             "text": "Enchanted creature gets +3/-1.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "3726bacc-49c6-5846-b034-a0fc292d778c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86901bf2-7722-43f8-b879-7a30630371fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86901bf2-7722-43f8-b879-7a30630371fa.jpg?1",
             "name": "Yawgmoth's Bargain",
             "text": "Skip your draw step.\nPay 1 life: Draw a card.",
             "colours": [
@@ -2530,7 +2530,7 @@
         },
         {
             "id": "aff51fd7-2955-5b77-afc2-a7e77b86f9eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a09917-50ce-4b51-a5cf-e28e88a45762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a09917-50ce-4b51-a5cf-e28e88a45762.jpg?1",
             "name": "Aether Sting",
             "text": "Whenever one of your opponents plays a creature spell, \u00c6ther Sting deals 1 damage to that player.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "81b9f2ad-5e89-5c54-89e2-193fc3bb79ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9320f3d8-0e51-43d0-aedb-bfed771101e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9320f3d8-0e51-43d0-aedb-bfed771101e9.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "oc\nT, Sacrifice a creature: Bloodshot Cyclops deals X damage to target creature or player, where X is the sacrificed creature's power.",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "0786d784-77e8-5831-8b81-a7c689e3f11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96e7522-e0bc-4e23-8e4b-40a0c28ea986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96e7522-e0bc-4e23-8e4b-40a0c28ea986.jpg?1",
             "name": "Cinder Seer",
             "text": "o2o\nR, oc\nT: Reveal any number of red cards in your hand. Cinder Seer deals X damage to target creature or player, where X is the number of cards revealed this way.",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "d3775406-1442-5c88-8acd-5719ee100085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d68eb62-9f86-4c85-8696-46a248c744ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d68eb62-9f86-4c85-8696-46a248c744ff.jpg?1",
             "name": "Colos Yearling",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)\noo\nR Colos Yearling gets +1/+0 until end of turn.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "9b7f4929-3417-5e1f-aa57-0aaa8643c7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f37e36-c004-4b89-a668-5cd984c59019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f37e36-c004-4b89-a668-5cd984c59019.jpg?1",
             "name": "Covetous Dragon",
             "text": "Flying\nWhen you control no artifacts, sacrifice Covetous Dragon.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "3dd5a073-184c-5165-a54a-2e70e86aff56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a511f9df-b53b-4fea-87cd-9f18f6833f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a511f9df-b53b-4fea-87cd-9f18f6833f92.jpg?1",
             "name": "Flame Jet",
             "text": "Cycling o2\nFlame Jet deals 3 damage to target player.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "39ae221e-1f7d-546b-b707-6102127768f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c7635d-98b2-4505-9153-d7e9e53ea16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c7635d-98b2-4505-9153-d7e9e53ea16d.jpg?1",
             "name": "Goblin Berserker",
             "text": "First strike; haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "203a53aa-d597-5a16-a185-320c90da448b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac067eb8-427f-4bfa-b392-0bb41ac8370e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac067eb8-427f-4bfa-b392-0bb41ac8370e.jpg?1",
             "name": "Goblin Festival",
             "text": "o2: Goblin Festival deals 1 damage to target creature or player. Flip a coin. If you lose the flip, choose one of your opponents. That player gains control of Goblin Festival.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "42b8feca-0c85-5161-abc9-9b83eb732105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eab0544-9c0b-4365-86bb-bc0c3e9d87ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eab0544-9c0b-4365-86bb-bc0c3e9d87ce.jpg?1",
             "name": "Goblin Gardener",
             "text": "When Goblin Gardener is put into a graveyard from play, destroy target land.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "3d8dbeee-839a-5752-8d6d-e2efd2cba48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9.jpg?1",
             "name": "Goblin Marshal",
             "text": "Echo\nWhenever Goblin Marshal comes into play or is put into a graveyard from play, put two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "4d073f26-79a5-5637-9eeb-ca71b58b4383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124070d9-c362-4053-a405-9438b1cfac02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124070d9-c362-4053-a405-9438b1cfac02.jpg?1",
             "name": "Goblin Masons",
             "text": "When Goblin Masons is put into a graveyard from play, destroy target Wall.",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "5e342d15-15f4-5f7f-93ef-a89c524d8d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0676d39e-229f-480b-874e-ff0cb8e335d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0676d39e-229f-480b-874e-ff0cb8e335d8.jpg?1",
             "name": "Hulking Ogre",
             "text": "Hulking Ogre can't block.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "6ee50c72-eb06-5f61-9d2f-4f5e7a4f666b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39c8166-9e63-4b02-af7b-4caf14ca73ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39c8166-9e63-4b02-af7b-4caf14ca73ac.jpg?1",
             "name": "Impatience",
             "text": "At the end of each player's turn, if that player didn't play a spell that turn, Impatience deals 2 damage to him or her.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "4b5e9fad-ba3f-522a-baef-142d311eebd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f4775-29b1-4ed1-94d9-db5930a35157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f4775-29b1-4ed1-94d9-db5930a35157.jpg?1",
             "name": "Incendiary",
             "text": "At the beginning of your upkeep, you may put a fuse counter on Incendiary.\nWhen enchanted creature is put into a graveyard, Incendiary deals X damage to target creature or player, where X is the number of fuse counters on Incendiary.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "ae80cc9e-e6bc-55fe-aba5-2d238c27e72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eee4d2-fe28-418e-a81f-73a66e831b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eee4d2-fe28-418e-a81f-73a66e831b05.jpg?1",
             "name": "Keldon Champion",
             "text": "Echo; haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhen Keldon Champion comes into play, it deals 3 damage to target player.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "cedb4186-e146-5a03-96a6-7f86e2f85189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18cdf4d-42ce-4f2d-8b8f-8cf52a1b8db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18cdf4d-42ce-4f2d-8b8f-8cf52a1b8db4.jpg?1",
             "name": "Keldon Vandals",
             "text": "Echo\nWhen Keldon Vandals comes into play, destroy target artifact.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "a154e9a0-6e85-5a25-acd2-2e8e1d627cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ddc0dc-8783-4659-bbbd-db6698843b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ddc0dc-8783-4659-bbbd-db6698843b47.jpg?1",
             "name": "Landslide",
             "text": "Sacrifice any number of mountains. Landslide deals that much damage to target player.",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "9ac067eb-03a0-588e-80ff-684a6ff4b1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b21b2f4-a05d-477b-8a39-632f7ff7f5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b21b2f4-a05d-477b-8a39-632f7ff7f5f5.jpg?1",
             "name": "Mark of Fury",
             "text": "Enchanted creature gains haste. (It may attack and oc\nT the turn it comes under your control.)\nAt end of turn, return Mark of Fury to its owner's hand.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "b7ecdd90-a948-5774-b219-c7c5d41ece15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f335d43-cacb-40ad-93c1-9a861e9f66c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f335d43-cacb-40ad-93c1-9a861e9f66c7.jpg?1",
             "name": "Reckless Abandon",
             "text": "As an additional cost to play Reckless Abandon, sacrifice a creature.\nReckless Abandon deals 4 damage to target creature or player.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "887e10bf-833a-54dd-ba85-e1078e9eb99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f3c78e-16c0-4fbc-8ef4-fbf610f9d464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f3c78e-16c0-4fbc-8ef4-fbf610f9d464.jpg?1",
             "name": "Repercussion",
             "text": "Whenever a creature is dealt damage, Repercussion deals that much damage to that creature's controller.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "194117c1-4eb2-5516-bf36-886bf5758e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c030eca0-bc5f-403b-8600-1f295fc85fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c030eca0-bc5f-403b-8600-1f295fc85fee.jpg?1",
             "name": "Scent of Cinder",
             "text": "Reveal any number of red cards in your hand. Scent of Cinder deals X damage to target creature or player, where X is the number of cards revealed this way.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "03ec0b47-023e-53b9-bd9e-770dc0029d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f7251-f71a-47d2-a779-c898d94e807c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f7251-f71a-47d2-a779-c898d94e807c.jpg?1",
             "name": "Sowing Salt",
             "text": "Remove target nonbasic land from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "19e7a911-da90-52e2-b217-b17e15be9400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcce5fd-9efb-42fa-9cd6-ed45d8ee46d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcce5fd-9efb-42fa-9cd6-ed45d8ee46d7.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "d0975290-baa2-5436-9b29-eb6f78e39fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c070f12-0342-48d5-ab0e-4fc4701c3669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c070f12-0342-48d5-ab0e-4fc4701c3669.jpg?1",
             "name": "Wake of Destruction",
             "text": "Destroy target land and all lands with the same name as that land.",
             "colours": [
@@ -3331,7 +3331,7 @@
         },
         {
             "id": "ecb639d4-91da-59f4-aecd-25fcd9d1ed6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d39f746-7b82-476a-9774-3375debb47bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d39f746-7b82-476a-9774-3375debb47bd.jpg?1",
             "name": "Wild Colos",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -3366,7 +3366,7 @@
         },
         {
             "id": "e7f5f4d6-21d3-5f91-8072-0b799770283c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49651dd4-a489-42d3-b4eb-51f5353b334e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49651dd4-a489-42d3-b4eb-51f5353b334e.jpg?1",
             "name": "Ancient Silverback",
             "text": "oo\nG Regenerate Ancient Silverback.",
             "colours": [
@@ -3400,7 +3400,7 @@
         },
         {
             "id": "8d56d218-631b-51d4-9f5a-820ae43fdc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2523c403-0025-48c7-8ff1-e66ca27ee585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2523c403-0025-48c7-8ff1-e66ca27ee585.jpg?1",
             "name": "Compost",
             "text": "Whenever a black card is put into one of your opponents' graveyards, you may draw a card.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "447a015b-83af-5a07-8f31-987ec120093b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8a0e2-311a-4627-8a48-43df045c3112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8a0e2-311a-4627-8a48-43df045c3112.jpg?1",
             "name": "Elvish Lookout",
             "text": "Elvish Lookout can't be the target of spells or abilities.",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "5a4974b7-a661-5b8d-a148-364c78332949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e76333-0959-4572-a1ca-d77f76da1279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e76333-0959-4572-a1ca-d77f76da1279.jpg?1",
             "name": "Elvish Piper",
             "text": "o\nG, oc\nT: Put a creature card from your hand into play.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "1bbeaa7e-3640-58af-872a-df1a8245ee84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccba208-1e24-45bb-a556-a3eb936efb10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccba208-1e24-45bb-a556-a3eb936efb10.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "efcb920c-bd3a-56b8-a4f1-115625b12888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6006c21-28b5-4550-8b4e-ac631f39cdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6006c21-28b5-4550-8b4e-ac631f39cdf7.jpg?1",
             "name": "Gamekeeper",
             "text": "When Gamekeeper is put into a graveyard from play, you may remove Gamekeeper from the game. If you do, reveal cards from your library until you reveal a creature card. Put that card into play and put the other cards revealed this way into your graveyard.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "c95b74de-0fdf-538a-9222-80f02c2c2371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83d8765-f654-4837-9b06-739610188415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83d8765-f654-4837-9b06-739610188415.jpg?1",
             "name": "Goliath Beetle",
             "text": "Trample",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "a1abcaaa-c481-5e5a-87c9-9ccda0340a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e42dbe-3eeb-4367-bb6d-0f5c71f5da80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e42dbe-3eeb-4367-bb6d-0f5c71f5da80.jpg?1",
             "name": "Heart Warden",
             "text": "oc\nT: Add one green mana to your mana pool.\no2, Sacrifice Heart Warden: Draw a card.",
             "colours": [
@@ -3638,7 +3638,7 @@
         },
         {
             "id": "2fe8693c-e033-566f-965c-2689ffe9f6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926cefa1-3c5c-4bd6-859b-de620a3ee777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926cefa1-3c5c-4bd6-859b-de620a3ee777.jpg?1",
             "name": "Hunting Moa",
             "text": "Echo\nWhenever Hunting Moa comes into play or is put into a graveyard from play, put a +1/+1 counter on target creature.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "f57beb0a-fd89-5546-b465-6ea8527b35c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ad11c-1351-4eff-94ac-3926037d7247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ad11c-1351-4eff-94ac-3926037d7247.jpg?1",
             "name": "Ivy Seer",
             "text": "o2o\nG, oc\nT: Reveal any number of green cards in your hand. Target creature gets +X/+X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "91f94f9b-8ec1-5af2-b404-44456b9b3a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb2c6-f1a6-42c3-a7cb-3a1a46854c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb2c6-f1a6-42c3-a7cb-3a1a46854c9b.jpg?1",
             "name": "Magnify",
             "text": "All creatures get +1/+1 until end of turn.",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "8b1be586-6890-5d11-bac8-75ed7b937d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd3c78-197a-40b9-94d1-bbb1ec1e64b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd3c78-197a-40b9-94d1-bbb1ec1e64b1.jpg?1",
             "name": "Marker Beetles",
             "text": "When Marker Beetles is put into a graveyard from play, target creature gets +1/+1 until end of turn.\no2, Sacrifice Marker Beetles: Draw a card.",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "57f76675-f77b-5109-9fa3-27e30ab9d46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bd11a2-7cab-4d3f-b52b-f5bb66fbbec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bd11a2-7cab-4d3f-b52b-f5bb66fbbec6.jpg?1",
             "name": "Momentum",
             "text": "At the beginning of your upkeep, you may put a growth counter on Momentum.\nEnchanted creature gets +1/+1 for each growth counter on Momentum.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "d551fe59-bf69-5dc1-bdf6-3351c86c54e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b4d5c8-23fc-4fb8-99d6-bb64e66cc4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b4d5c8-23fc-4fb8-99d6-bb64e66cc4db.jpg?1",
             "name": "Multani's Decree",
             "text": "Destroy all enchantments. You gain 2 life for each enchantment destroyed this way.",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "6138d6f6-3d88-5ed8-a7ab-d9b5c1d32545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23c4f4-a191-4225-a3b7-dab5b1462922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23c4f4-a191-4225-a3b7-dab5b1462922.jpg?1",
             "name": "Pattern of Rebirth",
             "text": "When enchanted creature is put into a graveyard from play, that creature's controller may search his or her library for a creature card and put that card into play. If that player does, he or she then shuffles his or her library.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "bf74c9e7-f4fd-5a64-8ef4-293cd5c87eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3529f49b-7e5e-4fa8-a03d-a94877761525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3529f49b-7e5e-4fa8-a03d-a94877761525.jpg?1",
             "name": "Plated Spider",
             "text": "Plated Spider may block as though it had flying.",
             "colours": [
@@ -3908,7 +3908,7 @@
         },
         {
             "id": "d8701233-0bfd-5c61-be59-e1cc3646e23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30735c4-7f12-4db9-972b-9b7568a8ada8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30735c4-7f12-4db9-972b-9b7568a8ada8.jpg?1",
             "name": "Plow Under",
             "text": "Put two target lands on top of their owner's library.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "22badd84-bc17-5eae-a8d1-b9650f7a6733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa5cc65-f8f1-4f6f-8b4e-2fedccbda684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa5cc65-f8f1-4f6f-8b4e-2fedccbda684.jpg?1",
             "name": "Rofellos, Llanowar Emissary",
             "text": "oc\nT: Add one green mana to your mana pool for each forest you control.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "4008d0ed-68e3-5333-8598-342c8c387bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41347ba-b2e3-4d7e-8018-e6fd30243559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41347ba-b2e3-4d7e-8018-e6fd30243559.jpg?1",
             "name": "Rofellos's Gift",
             "text": "Reveal any number of green cards in your hand. Return an enchantment card from your graveyard to your hand for each card revealed this way.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "8b69c0bf-e0b5-5a67-afc5-b93999926aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b4894-b959-4d00-b631-95d26eb85a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b4894-b959-4d00-b631-95d26eb85a4e.jpg?1",
             "name": "Scent of Ivy",
             "text": "Reveal any number of green cards in your hand. Target creature gets +X/+X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "dc68a089-ecaf-58a6-8967-505405fbc441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32175c-f2e6-460b-b4bf-dd85cac3eb4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32175c-f2e6-460b-b4bf-dd85cac3eb4f.jpg?1",
             "name": "Splinter",
             "text": "Remove target artifact from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "cfa6450e-b511-53f8-9c5c-b21dd70038b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bfa6b9-c898-4bb6-a444-6cf336bfb260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bfa6b9-c898-4bb6-a444-6cf336bfb260.jpg?1",
             "name": "Taunting Elf",
             "text": "All creatures able to block Taunting Elf do so.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "b3331d09-74c0-5c20-a441-5dd4cdfe90d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d4b0d-fe3e-46f5-86df-3fbac6b900b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d4b0d-fe3e-46f5-86df-3fbac6b900b0.jpg?1",
             "name": "Thorn Elemental",
             "text": "Thorn Elemental may deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -4141,7 +4141,7 @@
         },
         {
             "id": "ebbae453-4e06-594c-85c4-2316bb244d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325d9372-01c9-4e99-a966-13c8f8566e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325d9372-01c9-4e99-a966-13c8f8566e2e.jpg?1",
             "name": "Yavimaya Elder",
             "text": "When Yavimaya Elder is put into a graveyard from play, you may search your library for up to two basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.\no2, Sacrifice Yavimaya Elder: Draw a card.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "6d593dc8-bf00-5b63-8ea7-d79fbb0dd58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e3934e-6169-416e-92bb-359e41900c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e3934e-6169-416e-92bb-359e41900c3b.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "de58f4ec-99dd-5e37-83af-42e7c8c0b353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e783b7-9bd1-4f82-bf20-5d201413f5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e783b7-9bd1-4f82-bf20-5d201413f5e8.jpg?1",
             "name": "Braidwood Cup",
             "text": "oc\nT: You gain 1 life.",
             "colours": [],
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "9b0e371e-6720-545a-a4ec-3106f601719d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc7634-8ef5-4a03-8276-7e1dae4244c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc7634-8ef5-4a03-8276-7e1dae4244c2.jpg?1",
             "name": "Braidwood Sextant",
             "text": "o2, oc\nT, Sacrifice Braidwood Sextant: Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "8db5c541-2958-50c5-99ed-d70eb0530a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5685cff-b607-4a81-aa47-6676ab1a5782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5685cff-b607-4a81-aa47-6676ab1a5782.jpg?1",
             "name": "Brass Secretary",
             "text": "o2, Sacrifice Brass Secretary: Draw a card.",
             "colours": [],
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "9ffbb6b6-5d07-5ebe-9890-952ed2e8fe80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cf74e4-31d2-4cd2-8f3a-b2141301f686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cf74e4-31d2-4cd2-8f3a-b2141301f686.jpg?1",
             "name": "Caltrops",
             "text": "Whenever a creature attacks, Caltrops deals 1 damage to it.",
             "colours": [],
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "f241a1d5-94f9-53d0-b473-b786ba51d072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc2f0d0-273d-428f-9a8a-c582f4d16394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc2f0d0-273d-428f-9a8a-c582f4d16394.jpg?1",
             "name": "Extruder",
             "text": "Echo\nSacrifice an artifact: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "59fecc9a-7a4f-5938-912a-007a71a1117e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ba320-69c9-4400-a0d7-f0f79e8d9856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ba320-69c9-4400-a0d7-f0f79e8d9856.jpg?1",
             "name": "Fodder Cannon",
             "text": "o4, oc\nT, Sacrifice a creature: Fodder Cannon deals 4 damage to target creature.",
             "colours": [],
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "eab65b38-7d18-5295-9796-15747b193fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f5a9d8-80b9-4765-adb2-10d53baaacb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f5a9d8-80b9-4765-adb2-10d53baaacb0.jpg?1",
             "name": "Junk Diver",
             "text": "Flying\nWhen Junk Diver is put into a graveyard from play, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "3657c541-d387-5cb6-a874-ee918c5d4843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f7ebfb-f955-4849-a0f5-6806ff6ae891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f7ebfb-f955-4849-a0f5-6806ff6ae891.jpg?1",
             "name": "Mantis Engine",
             "text": "o2: Mantis Engine gains flying until end of turn.\no2: Mantis Engine gains first strike until end of turn.",
             "colours": [],
@@ -4447,7 +4447,7 @@
         },
         {
             "id": "3e2b946f-0a62-58c3-aeba-68588d825d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908a2215-7231-43a4-8fec-5d1e4233c028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908a2215-7231-43a4-8fec-5d1e4233c028.jpg?1",
             "name": "Masticore",
             "text": "At the beginning of your upkeep, you may choose and discard a card from your hand. If you don't, sacrifice Masticore.\no2: Masticore deals 1 damage to target creature.\no2: Regenerate Masticore.",
             "colours": [],
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "dcd05bd8-60aa-5a11-8ac1-1f6d40d14be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050d414-71c7-4c42-a1ff-4c04068ba7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050d414-71c7-4c42-a1ff-4c04068ba7f2.jpg?1",
             "name": "Metalworker",
             "text": "oc\nT: Reveal any number of artifact cards in your hand. Add two colorless mana to your mana pool for each card revealed this way.",
             "colours": [],
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "b027e7be-84c3-543f-b1bd-8241518de3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9715c2-9036-4ae2-a5b4-1b190d50c963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9715c2-9036-4ae2-a5b4-1b190d50c963.jpg?1",
             "name": "Powder Keg",
             "text": "At the beginning of your upkeep, you may put a fuse counter on Powder Keg.\noc\nT, Sacrifice Powder Keg: Destroy each artifact and creature with converted mana cost equal to the number of fuse counters on Powder Keg.",
             "colours": [],
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "531a3146-0140-5050-9ac3-a8971c09430f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286819f-6c57-4503-898c-528786ad86e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286819f-6c57-4503-898c-528786ad86e9.jpg?1",
             "name": "Scrying Glass",
             "text": "o3, oc\nT: Choose a number greater than 0 and a color. Target opponent reveals his or her hand. If that opponent reveals exactly the chosen number of cards of the chosen color, you draw a card.",
             "colours": [],
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "758edb30-c44a-5ade-acc3-d90141b89dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77378279-024c-4c36-b5bf-6294fe5c32f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77378279-024c-4c36-b5bf-6294fe5c32f5.jpg?1",
             "name": "Storage Matrix",
             "text": "As long as Storage Matrix is untapped, instead of each player untapping the permanents he or she controls during his or her untap step, that player chooses artifacts, creatures, or lands and untaps all permanents of the chosen type he or she controls.",
             "colours": [],
@@ -4593,7 +4593,7 @@
         },
         {
             "id": "d96a4072-944e-5862-921d-f951055f91f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c9dee-fab5-4522-9821-343f84b0c8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c9dee-fab5-4522-9821-343f84b0c8ab.jpg?1",
             "name": "Thran Dynamo",
             "text": "oc\nT: Add three colorless mana to your mana pool.",
             "colours": [],
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "d1096803-ee6f-5650-8666-571616d23626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdc0d42-d96f-490f-87cb-3577dfdce807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdc0d42-d96f-490f-87cb-3577dfdce807.jpg?1",
             "name": "Thran Foundry",
             "text": "o1, oc\nT, Remove Thran Foundry from the game: Target player shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "17901676-3afc-57a9-a629-397a57555a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5778c52b-248b-4131-b5c0-12ea1986786e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5778c52b-248b-4131-b5c0-12ea1986786e.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and gains flying, first strike, and trample.",
             "colours": [],
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "83beb4d1-d3f5-545e-bf0a-66659ee25f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96c2c-b3d6-4d84-9572-fb115a795bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96c2c-b3d6-4d84-9572-fb115a795bed.jpg?1",
             "name": "Urza's Incubator",
             "text": "When Urza's Incubator comes into play, choose a creature type.\nCreature spells of the chosen type cost o2 less to play.",
             "colours": [],
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "4d8175a8-cecc-5526-92e5-c16dfd4d04ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dd5c4b-5972-43e1-ae2a-ebf275006458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dd5c4b-5972-43e1-ae2a-ebf275006458.jpg?1",
             "name": "Yavimaya Hollow",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no\nG, oc\nT: Regenerate target creature.",
             "colours": [],

--- a/Assets/Resources/Sets/UGL.json
+++ b/Assets/Resources/Sets/UGL.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b0ea3c7e-dde2-5c80-a88a-6319955ae946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b690ef-9fcb-42be-bbee-6aad516534a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b690ef-9fcb-42be-bbee-6aad516534a5.jpg?1",
             "name": "Charm School",
             "text": "When Charm School comes into play, choose a color and balance Charm School on your head.\nPrevent all damage to you of the chosen color.\nIf Charm School falls off your head, sacrifice Charm School.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "58efe678-594a-5778-839a-d444cd30acf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a114f-3349-4a62-bfad-0dc33b78a53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a114f-3349-4a62-bfad-0dc33b78a53f.jpg?1",
             "name": "The Cheese Stands Alone",
             "text": "If you control no cards in play other than The Cheese Stands Alone and have no cards in your hand, you win the game.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "926e0671-b2e8-5622-8271-521eb8cab24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbdbd92-ec36-4fe9-b75d-13f55574db5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbdbd92-ec36-4fe9-b75d-13f55574db5e.jpg?1",
             "name": "Double Dip",
             "text": "Choose another player. Gain 5 life now and an additional 5 life at the beginning of the next game with that player.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "57f770a0-a47f-5728-98fc-81c0649de4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2757b582-d995-45f9-9482-0792b0f0784d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2757b582-d995-45f9-9482-0792b0f0784d.jpg?1",
             "name": "Get a Life",
             "text": "Target player and each of his or her teammates exchange life totals.",
             "colours": [
@@ -128,7 +128,7 @@
         },
         {
             "id": "531b29bc-b32b-5abb-a265-47dbeebcbbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5979237f-ff41-4e87-b2e4-d09b81eca2dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5979237f-ff41-4e87-b2e4-d09b81eca2dc.jpg?1",
             "name": "I'm Rubber, You're Glue",
             "text": "Speak only in rhyming sentences. If you do not, sacrifice I'm Rubber, You're Glue.\nSay \"I'm rubber, you're glue. Everything bounces off me and sticks to you\": Target spell or ability, which targets only you, targets another player of your choice instead. (The new target must be legal.)",
             "colours": [
@@ -159,7 +159,7 @@
         },
         {
             "id": "8b6429db-1771-573b-8c6d-7205fdc02e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53daa7-9130-4187-9e53-1075c6ab67d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53daa7-9130-4187-9e53-1075c6ab67d0.jpg?1",
             "name": "Knight of the Hokey Pokey",
             "text": "First strike\no1o\nW, Do the Hokey Pokey (Stand up, wiggle your butt, raise your hands above your head, and shake them wildly as you rotate 360 degrees): Prevent all damage to Knight of the Hokey Pokey from any one source.",
             "colours": [
@@ -192,7 +192,7 @@
         },
         {
             "id": "10828bbb-6600-51c7-bf20-0bed42990528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39db7a3-028e-4c01-8ff9-64d2a1397379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39db7a3-028e-4c01-8ff9-64d2a1397379.jpg?1",
             "name": "Lexivore",
             "text": "If Lexivore damages any player, destroy target card in play, other than Lexivore, with the most lines of text in its text box. (If more than one card has the most lines of text, you choose which of those cards to destroy.)",
             "colours": [
@@ -225,7 +225,7 @@
         },
         {
             "id": "d9b2fd1e-4934-5e16-aa59-f84e884b5b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fb0d87-b086-4546-8f7f-786cb0b7b2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fb0d87-b086-4546-8f7f-786cb0b7b2f5.jpg?1",
             "name": "Look at Me, I'm the DCI",
             "text": "Ban one card, other than a basic land, for the remainder of the match. (For the remainder of the match, each player removes from the game all copies of that card in play or in any graveyard, hand, library, or sideboard.)",
             "colours": [
@@ -256,7 +256,7 @@
         },
         {
             "id": "82c35563-a96b-58ed-bcd2-7d5ab83d59a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1edbc-ea37-42c4-8fb9-deac011372b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1edbc-ea37-42c4-8fb9-deac011372b5.jpg?1",
             "name": "Mesa Chicken",
             "text": "Stand up, Flap your arms, Cluck like a chicken: Mesa Chicken gains flying until end of turn.",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "09bb53fb-787d-5fd4-86c4-bc18aaebb4ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747ff5d4-69cd-447e-a18d-edcf583d0539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747ff5d4-69cd-447e-a18d-edcf583d0539.jpg?1",
             "name": "Miss Demeanor",
             "text": "Flying, first strike\nDuring each other player's turn, compliment that player on his or her game play or sacrifice Miss Demeanor.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "96d9c768-dbe1-5b7c-9951-74e64700d099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba42881b-9275-4b54-a17f-dec87d21a270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba42881b-9275-4b54-a17f-dec87d21a270.jpg?1",
             "name": "Once More with Feeling",
             "text": "Remove Once More with Feeling from the game as well as all cards in play and in all graveyards. Each player shuffles his or her hand into her or his library, then draws seven cards. Each player's life total is set to 10.\nDCI ruling: This card is restricted. (You cannot play with more than one in a deck.)",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "1c401a89-735f-52cb-a781-040242bc902c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79624ebe-7110-486d-82ff-b64c662dc6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79624ebe-7110-486d-82ff-b64c662dc6de.jpg?1",
             "name": "Prismatic Wardrobe",
             "text": "Destroy target card that does not share a color with clothing worn by its controller. You cannot choose an artifact or land card.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "cc377cd4-a3e9-5f79-a7a5-d71e9b91f99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cfc18c-ed01-4016-86a2-162d7bc1bf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cfc18c-ed01-4016-86a2-162d7bc1bf33.jpg?1",
             "name": "Sex Appeal",
             "text": "Prevent up to 3 damage total to any number of creatures and/or players. If there are more players in the room of the opposite sex, prevent up to 3 additional damage total to any number of creatures and/or players.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "5cf3e6e9-e2a0-5f69-a33e-caa252ab894c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43417d07-725e-4c3d-99d2-bbbfbdeee770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43417d07-725e-4c3d-99d2-bbbfbdeee770.jpg?1",
             "name": "Bureaucracy",
             "text": "Pursuant to subsection 3.1(4) of Richard's Rules of Order, during the upkeep of each participant in this game of the Magic: The Gathering\u00ae trading card game (hereafter known as \"PLAYER\"), that PLAYER performs all actions in the sequence of previously added actions (hereafter known as \"ACTION QUEUE\"), in the order those actions were added, then adds another action to the end of the ACTION QUEUE. All actions must be simple physical or verbal actions that a player can perform while sitting in a chair, without jeopardizing the health and security of said PLAYER.\nIf any PLAYER does not perform all the prescribed actions in the correct order, sacrifice Bureaucracy and said PLAYER discards his or her complement of cards in hand (hereafter known as \"HAND\").",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "3f00c3d1-be2d-51e2-825d-d74f14b1ad6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d4fba-cf12-4ad3-bca3-6824dbc639af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d4fba-cf12-4ad3-bca3-6824dbc639af.jpg?1",
             "name": "Censorship",
             "text": "When Censorship comes into play, choose a CENSORED word.\nWhenever any CENSORED player says the chosen CENSORED word, Censorship deals 2 CENSORED damage to him or her.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "5e65f63f-b46f-54fc-9e80-5748ace9122d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70457a-34dc-48a1-8643-4a78c1e6f2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70457a-34dc-48a1-8643-4a78c1e6f2d3.jpg?1",
             "name": "Checks and Balances",
             "text": "Whenever any spell is played, counter that spell if each player, other than the caster and his or her teammates, agrees to choose and discard a card. Those players must discard those cards after agreeing.\nChecks and Balances may be played only in a game with three or more players.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "baf06116-3094-56f2-b7cb-2e65f0a231bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcefcab-8988-47e8-89bb-9b76f14c9d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcefcab-8988-47e8-89bb-9b76f14c9d8b.jpg?1",
             "name": "Chicken \u00e0 la King",
             "text": "Whenever a 6 is rolled on a six-sided die, put a +1/+1 counter on each Chicken in play. (You may roll dice only when a card instructs you to.)\nTap a Chicken you control: Roll a six-sided die.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "4826be91-6ee1-54e7-ad83-5f5e3308611e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ba052-10f7-4612-91b7-a1528c188ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ba052-10f7-4612-91b7-a1528c188ec3.jpg?1",
             "name": "Clambassadors",
             "text": "If Clambassadors damages any player, choose an artifact, creature, or land you control. That player gains control of that artifact, creature, or land.",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "0e3b5d6c-d300-5ca6-8830-e0a4ed9f2962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e1b62-df2b-48dc-9cb1-d86c9d3ab986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e1b62-df2b-48dc-9cb1-d86c9d3ab986.jpg?1",
             "name": "Clam-I-Am",
             "text": "Whenever you roll a 3 on a six-sided die, you may reroll that die.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "93ec0222-31e5-5cdd-a788-8a4259acad96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2953cd-1b7e-41aa-959f-fb7ba2964bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2953cd-1b7e-41aa-959f-fb7ba2964bfb.jpg?1",
             "name": "Clam Session",
             "text": "When Clam Session comes into play, choose a word.\nDuring your upkeep, sing at least six words of a song, one of which must be the chosen word, or sacrifice Clam Session. You cannot repeat a song.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "2e4c8a4f-d46d-523c-b29d-dbafa49d92dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad6b646-a2b2-4817-856c-580a5953d87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad6b646-a2b2-4817-856c-580a5953d87e.jpg?1",
             "name": "Common Courtesy",
             "text": "Counter any spell unless its caster asks your permission to play that spell. If you refuse permission, Sacrifice Common Courtesy and counter the spell.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "a2b7d300-e422-5348-9b0d-8288a7070d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285c125-e145-4565-a029-352ac6adf688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285c125-e145-4565-a029-352ac6adf688.jpg?1",
             "name": "Denied!",
             "text": "Play Denied only as any opponent casts target spell. Name a card, then look at all cards in that player's hand. If the named card is in the player's hand, counter target spell.",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "2126334c-064f-59ed-bcb0-72572240f53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71941f1f-b41e-4ec9-a7c6-61eccaa47b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71941f1f-b41e-4ec9-a7c6-61eccaa47b0e.jpg?1",
             "name": "Double Take",
             "text": "Choose another player. Draw two cards now and draw an additional two cards at the beginning of the next game with that player.",
             "colours": [
@@ -737,7 +737,7 @@
         },
         {
             "id": "9cd156c7-a60d-5d60-9133-08880eaf5b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2303a4e0-b8eb-4e8b-bc62-507eee52e7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2303a4e0-b8eb-4e8b-bc62-507eee52e7bc.jpg?1",
             "name": "Fowl Play",
             "text": "Enchanted creature loses all abilities and is a 1/1 creature that counts as a Chicken.",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "0cf28ac9-fb9b-55ad-b8ee-1ab210a84e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630efac8-3033-4c2d-9127-b3b2f78bb136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630efac8-3033-4c2d-9127-b3b2f78bb136.jpg?1",
             "name": "Free-for-All",
             "text": "When Free-for-All comes into play, set aside all creatures in play, face down.\nDuring each player's upkeep, that player chooses a creature card at random from those set aside in this way and puts that creature into play under his or her control.\nIf Free-for-All leaves play, put each creature still set aside this way into its owner's graveyard.",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "5ac0d90c-a367-507b-8686-c3864a8419bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60dfba09-9e75-4fb9-a163-40e3149f7785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60dfba09-9e75-4fb9-a163-40e3149f7785.jpg?1",
             "name": "Psychic Network",
             "text": "Each player reveals the top card of his or her library to all other players by continuously holding it against his or her forehead. This does not allow a player to look at his or her own card. (That card still counts as the top card of your library. Whenever you draw a card, draw that one and replace it with the next card of your library.)",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "5e615232-4d37-5396-8f68-053f8297259c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14606012-d57b-4fe7-908b-b5cfc272994b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14606012-d57b-4fe7-908b-b5cfc272994b.jpg?1",
             "name": "Sorry",
             "text": "Before playing any spell, if a copy of that spell card is in any graveyard, the spell's caster may say \"Sorry.\" If he or she does not, any other player may counter the spell by saying \"Sorry\" as it is cast.\nIf any player says \"Sorry\" at any other time, Sorry deals 2 damage to that player.",
             "colours": [
@@ -863,7 +863,7 @@
         },
         {
             "id": "33b10155-90dc-5846-9c82-af414ba6c1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f9c279-e382-4feb-9575-196e7cf5d7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f9c279-e382-4feb-9575-196e7cf5d7dc.jpg?1",
             "name": "B.F.M. (Big Furry Monster)",
             "text": "You must play both B.\nF.\nM. cards to put\nleaves play, sacrifice the other.\nB.\nF.\nM. can be blocked only by three or",
             "colours": [
@@ -901,7 +901,7 @@
         },
         {
             "id": "451ac233-9ba8-59db-8fff-6962e0b173f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c6375-2e4e-47f7-88e1-d90794e7f724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c6375-2e4e-47f7-88e1-d90794e7f724.jpg?1",
             "name": "B.F.M. (Big Furry Monster)",
             "text": "You must play both B.\nF.\nM. cards to put\nleaves play, sacrifice the other.\nB.\nF.\nM. can be blocked only by three or",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "5c176335-a5d5-5a91-9c2f-74875ae58625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3998e-b4a1-4dd1-8e12-24579ec8938b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3998e-b4a1-4dd1-8e12-24579ec8938b.jpg?1",
             "name": "Deadhead",
             "text": "Put Deadhead into play. Use this ability only if any opponent loses contact with his or her hand of cards and only if Deadhead is in your graveyard.",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "04dcf162-1039-5fcd-ac4f-562b769bca54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f90e34-3736-42ed-aade-e31247b3472d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f90e34-3736-42ed-aade-e31247b3472d.jpg?1",
             "name": "Double Cross",
             "text": "Choose another player. Look at that player's hand and choose one of those cards other than a basic land. He or she discards that card. At the beginning of the next game with the player, look at the player's hand and choose one of those cards other than a basic land. He or she discards that card.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "2a176d87-a2c5-5966-a00b-176424d5bc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae92f5-4219-4194-b152-c2b2653aef3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae92f5-4219-4194-b152-c2b2653aef3f.jpg?1",
             "name": "Handcuffs",
             "text": "Target player keeps both hands in contact with each other. If he or she does not, sacrifice Handcuffs and that player sacrifices three cards in play.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "42b47054-7009-5f19-9e0d-e39e4ad1b3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99711b5b-3cb2-4d57-ac9a-f43cc86a7ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99711b5b-3cb2-4d57-ac9a-f43cc86a7ca9.jpg?1",
             "name": "Infernal Spawn of Evil",
             "text": "Flying, first strike\no1o\nB, Reveal Infernal Spawn of Evil from your hand, Say \"It's coming\": Infernal Spawn of Evil deals 1 damage to target opponent. Use this ability only during your upkeep and only once each upkeep.",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "4b0aceba-90f8-5e0f-82b1-e759f81100ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135b61b-eb8c-44d7-8227-bd268c3ca463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135b61b-eb8c-44d7-8227-bd268c3ca463.jpg?1",
             "name": "Jumbo Imp",
             "text": "Flying\nWhen you play Jumbo Imp, roll a six-sided die. Jumbo Imp comes into play with a number of +1/+1 counters on it equal to the die roll.\nDuring your upkeep, roll a six-sided die and put on Jumbo Imp a number of +1/+1 counters equal to the die roll.\nAt the end of your turn, roll a six-sided die and remove from Jumbo Imp a number of +1/+1 counters equal to the die roll.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "7010e071-313e-55e5-9d18-bb06c71c1193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05213eec-322f-4bc7-b607-217290447f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05213eec-322f-4bc7-b607-217290447f40.jpg?1",
             "name": "Organ Harvest",
             "text": "You and your teammates may sacrifice any number of creatures. For each creature sacrificed in this way, add o\nBo\nB to your mana pool.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "161f4356-f12c-5c35-9bfc-164371af8520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd26c2a6-7b08-4de6-afbf-e34d321995ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd26c2a6-7b08-4de6-afbf-e34d321995ab.jpg?1",
             "name": "Ow",
             "text": "Whenever any creature damages a player, for each Ow card in play, that player says \"Ow\" once or Ow deals 1 damage to him or her.",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "29db17ff-dbcb-5419-8f13-bf0cf40e946c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bec883-a2e0-49a5-8cdd-2755c0963a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bec883-a2e0-49a5-8cdd-2755c0963a2d.jpg?1",
             "name": "Poultrygeist",
             "text": "Flying\nWhenever a creature is put into any graveyard from play, you may roll a six-sided die. On a 1, sacrifice Poultrygeist. Otherwise, put a +1/+1 counter on Poultrygeist.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "bd512631-b500-57e9-89d3-6c8b55472bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7105d13-798e-472b-bb00-d419886e9cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7105d13-798e-472b-bb00-d419886e9cc7.jpg?1",
             "name": "Temp of the Damned",
             "text": "When you play Temp of the Damned, roll a six-sided die. Temp of the Damned comes into play with a number of funk counters on it equal to the die roll.\nDuring your upkeep, remove a funk counter from Temp of the Damned or sacrifice Temp of the Damned.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "7bc2bb63-2081-53fd-85d0-aba4741b8004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b915b6-4436-4007-a014-415694117c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b915b6-4436-4007-a014-415694117c7e.jpg?1",
             "name": "Volrath's Motion Sensor",
             "text": "When Volrath's Motion Sensor comes into play, choose target hand controlled by an opponent. Enchanted player balances Volrath's Motion Sensor on the back of that hand.\nIf Volrath's Motion Sensor falls off the hand, sacrifice Volrath's Motion Sensor and that player loses 3 life.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "6a54b561-0bc4-5ab6-a780-4c6a2145913d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ed4800-dc0f-4681-9ae6-74bd0018e8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ed4800-dc0f-4681-9ae6-74bd0018e8dc.jpg?1",
             "name": "Burning Cinder Fury of Crimson Chaos Fire",
             "text": "Whenever any player taps a card, that player gives control of that card to an opponent at end of turn.\nIf a player does not tap any nonland cards during his or her turn, Burning Cinder Fury of Crimson Chaos Fire deals 3 damage to that player at end of turn.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "9173b925-8b75-5abc-9365-48b51651c611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640ac565-331b-47e2-b2af-a8a94a96488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640ac565-331b-47e2-b2af-a8a94a96488a.jpg?1",
             "name": "Chicken Egg",
             "text": "During your upkeep, roll a six-sided die. On a 6, sacrifice Chicken Egg and put a Giant Chicken token into play. Treat this token as a 4/4 red creature that counts as a Chicken.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "609e62c5-13bd-5a5e-8d3f-361c502b2ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8b3def-30ee-4dd2-9a25-ecf7d5663f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8b3def-30ee-4dd2-9a25-ecf7d5663f96.jpg?1",
             "name": "Double Deal",
             "text": "Choose another player. Double Deal deals 3 damage to that player now and deals an additional 3 damage to the player at the beginning of the next game with the player.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "045bb960-50d6-5478-b370-224cdce8fb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc880e76-1e92-4af1-b89f-b5a2b60b86f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc880e76-1e92-4af1-b89f-b5a2b60b86f0.jpg?1",
             "name": "Goblin Bookie",
             "text": "o\nR, oc\nT: Reflip any coin or reroll any die.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "32c9718b-f1c1-531d-8736-2f8aa72abe89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1",
             "name": "Goblin Bowling Team",
             "text": "Whenever Goblin Bowling Team damages any creature or player, roll a six-sided die. Goblin Bowling Team deals to that creature or player additional damage equal to the die roll.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "027bde8b-0fb7-5eda-9d72-19843c86998c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bc822d-a028-4162-bf23-6ff4b9f43688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bc822d-a028-4162-bf23-6ff4b9f43688.jpg?1",
             "name": "Goblin Tutor",
             "text": "Roll a six-sided die for Goblin Tutor. On a 1, Goblin Tutor has no effect. Otherwise, search your library for the indicated card, reveal that card to all players, and put it into your hand. Shuffle your library afterwards.\n2 Any Goblin Tutor\n3 Any enchantment\n4 Any artifact\n5 Any creature\n6 Any sorcery, instant, or interrupt",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "7a868b76-5093-5f49-8cea-02ce9f759f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d957abcb-ba56-42b4-9316-f30ac821ecf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d957abcb-ba56-42b4-9316-f30ac821ecf9.jpg?1",
             "name": "Hurloon Wrangler",
             "text": "Denimwalk (If defending player is wearing any clothing made of denim, this creature is unblockable.)",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "955be9e7-b1f6-58c1-9bf3-4c5e88706881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5d0ead-7798-49a2-8106-418db1d4fd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5d0ead-7798-49a2-8106-418db1d4fd69.jpg?1",
             "name": "Jalum Grifter",
             "text": "o1o\nR, oc\nT: Put Jalum Grifter and two lands you control face down in front of target opponent after revealing each card to him or her. Then, rearrange the order of the three cards as often as you wish, keeping them on the table at all times. That opponent then chooses one of those cards. If a land is chosen, destroy target card in play. Otherwise, sacrifice Jalum Grifter.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "9b3e875b-0ae4-5e73-a3e7-081c11c9e455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e978fdf7-2243-49d0-b265-a3287f19b17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e978fdf7-2243-49d0-b265-a3287f19b17d.jpg?1",
             "name": "Krazy Kow",
             "text": "During your upkeep, roll a six-sided die. On a 1, sacrifice Krazy Kow and it deals 3 damage to each creature and player.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "f2d95364-07b1-532f-87b5-122de4fab7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef5452d-b5cb-4772-a5ac-1b4c976e03a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef5452d-b5cb-4772-a5ac-1b4c976e03a5.jpg?1",
             "name": "Landfill",
             "text": "Choose a land type. Remove from play all lands of that type that you control. Drop those cards, one at a time, onto the playing area from a height of at least one foot. Destroy each card in play that is completely covered by those cards. Then return to play, tapped, all lands dropped in this way.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "ceea7467-fdd1-520e-8027-7abd3127140a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea993e57-b72f-48f8-9132-0693f2e78ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea993e57-b72f-48f8-9132-0693f2e78ce4.jpg?1",
             "name": "Ricochet",
             "text": "Whenever any spell targets a single player, each player rolls a six-sided die. That spell is redirected to the player or players with the lowest die roll. If two or more players tie for the lowest die roll, they reroll until there is no tie.",
             "colours": [
@@ -1616,7 +1616,7 @@
         },
         {
             "id": "b162a4be-1a66-523c-850a-a6efaa3ca92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea73a7ef-e9da-4d5b-aa4d-a953cbacd6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea73a7ef-e9da-4d5b-aa4d-a953cbacd6c2.jpg?1",
             "name": "Spark Fiend",
             "text": "When Spark Fiend comes into play, roll two six-sided dice. On a total of 2, 3, or 12, sacrifice Spark Fiend. On a total of 7 or 11, do not roll dice for Spark Fiend during any of your following upkeep phases. If you roll any other total, note it.\nDuring your upkeep, roll two six-sided dice. On a total of 7, sacrifice Spark Fiend. If you roll the noted total, do not roll dice for Spark Fiend during any of your following upkeep phases. On any other roll, there is no effect.",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "aa083a5e-20d4-5c98-910b-09844d94620e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2996a63-9fb6-4455-906d-13f917a8bb29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2996a63-9fb6-4455-906d-13f917a8bb29.jpg?1",
             "name": "Strategy, Schmategy",
             "text": "Roll a six-sided die for Strategy, Schmategy. On a 1, Strategy, Schmategy has no effect. Otherwise, it has one of the following effects.\n2 Destroy all artifacts.\n3 Destroy all lands.\n4 Strategy, Schmategy deals 3 damage to each creature and player.\n5 Each player discards his or her hand and draws seven cards.\n6 Roll the die two more times.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "b23bc758-25fc-5f75-8619-0e9d664c48c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616abc97-4276-4e96-bbe8-e47ba7cac075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616abc97-4276-4e96-bbe8-e47ba7cac075.jpg?1",
             "name": "The Ultimate Nightmare of Wizards of the Coast\u00ae Customer Service",
             "text": "The Ultimate Nightmare of Wizards of the Coast\u00ae Customer Service deals X damage to each of Y target creatures and Z target players.",
             "colours": [
@@ -1711,7 +1711,7 @@
         },
         {
             "id": "71377d26-db92-55c1-8c56-3375e72294cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059fc73f-7a00-4014-9e92-75765798cf2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059fc73f-7a00-4014-9e92-75765798cf2d.jpg?1",
             "name": "Cardboard Carapace",
             "text": "For each other Cardboard Carapace card you have with you, enchanted creature gets +1/+1.\nErrata: This does not count any Cardboard Carapace cards in play that you control or in your graveyard, hand, or library.",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "d69f95eb-1c76-5fd8-a098-5a4c00148019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c66e0-0ca8-447f-b8d9-b03ce7ffaf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c66e0-0ca8-447f-b8d9-b03ce7ffaf7f.jpg?1",
             "name": "Double Play",
             "text": "Choose another player. Search your library for a basic land and put that land into play. At the beginning of the next game with that player, search your library for an additional basic land and put that land into play. In both cases, shuffle your library afterwards.",
             "colours": [
@@ -1775,7 +1775,7 @@
         },
         {
             "id": "28973feb-0e45-5507-bf1c-8c745da08b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922663f0-f444-4364-a706-eb6b91ac36ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922663f0-f444-4364-a706-eb6b91ac36ef.jpg?1",
             "name": "Elvish Impersonators",
             "text": "When you play Elvish Impersonators, roll two six-sided dice one after the other. Elvish Impersonators comes into play with power equal to the first die roll and toughness equal to the second.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "9e5898b1-894e-52fa-a2ce-fc09948ef6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce65cbd-e2cf-4fbf-8424-287cd87c97f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce65cbd-e2cf-4fbf-8424-287cd87c97f1.jpg?1",
             "name": "Flock of Rabid Sheep",
             "text": "Flip X coins; an opponent calls heads or tails. For each flip you win, put a Rabid Sheep token into play. Treat these tokens as 2/2 green creatures that count as Sheep.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "2e415ee0-7861-553c-8164-a14e853c03f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59e6414-62ac-427e-8e37-690ed401b4dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59e6414-62ac-427e-8e37-690ed401b4dd.jpg?1",
             "name": "Free-Range Chicken",
             "text": "o1o\nG: Roll two six-sided dice. If both die rolls are the same, Free-Range Chicken gets +X/+X until end of turn, where X is the number rolled on each die. Otherwise, if the total rolled is equal to any other total you have rolled this turn for Free-Range Chicken, sacrifice it. (For example, if you roll two 3s, Free-Range Chicken gets +3/+3. If you roll a total of 6 for Free-Range Chicken later in that turn, sacrifice it.)",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "081165b2-452a-55f9-b6a4-1872ec20a07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea8ab0f-6898-4312-9989-915d6357515f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea8ab0f-6898-4312-9989-915d6357515f.jpg?1",
             "name": "Gerrymandering",
             "text": "Remove all lands from play and shuffle them together. Randomly deal to each player one land card for each land he or she had before. Each player puts those lands into play under his or her control, untapped.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "53d7f8b1-8ab0-5cf2-917a-40790bdfbb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c18690-cf8c-4006-a981-6258d18ba538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c18690-cf8c-4006-a981-6258d18ba538.jpg?1",
             "name": "Ghazb\u00e1n Ogress",
             "text": "When Ghazb\u00e1n Ogress comes into play, the player who has won the most Magic games that day gains control of it. If more than one player has won the same number of games, you retain control of Ghazb\u00e1n Ogress.",
             "colours": [
@@ -1936,7 +1936,7 @@
         },
         {
             "id": "cd9beb6a-1adb-59f4-b9a7-64150678d5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905accf-ea94-48fa-8dbe-b4a7dd57a277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905accf-ea94-48fa-8dbe-b4a7dd57a277.jpg?1",
             "name": "Growth Spurt",
             "text": "Roll a six-sided die. Target creature gets +X/+X until end of turn, where X is equal to the die roll.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "e0a315ed-f9db-5bf4-8cb5-d9524375dca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b05428-d9f3-42ec-bef4-286f1ad06901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b05428-d9f3-42ec-bef4-286f1ad06901.jpg?1",
             "name": "Gus",
             "text": "Gus comes into play with one +1/+1 counter on it for each game you have lost to your opponent since you last won a Magic game against him or her.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "1c1c12ac-c243-5b04-ae0c-77207d0c7500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a17ecb8-cf64-420a-9038-609bfdb4c669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a17ecb8-cf64-420a-9038-609bfdb4c669.jpg?1",
             "name": "Hungry Hungry Heifer",
             "text": "During your upkeep, remove a counter from any card you control or sacrifice Hungry Hungry Heifer.",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "88f60557-ccd8-5438-923e-e00654b4b816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573cf5e6-35ee-4eb6-990a-524ba7335797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573cf5e6-35ee-4eb6-990a-524ba7335797.jpg?1",
             "name": "Incoming!",
             "text": "Each player searches his or her library for any number of artifacts, creatures, enchantments, and lands and puts those cards into play. Each player shuffles his or her library afterwards.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "5033ea8d-6662-581c-978b-57470cfea713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91f28e0-867a-4713-955d-582201af63ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91f28e0-867a-4713-955d-582201af63ae.jpg?1",
             "name": "Mine, Mine, Mine!",
             "text": "When Mine, Mine, Mine comes into play, each player puts his or her library into his or her hand.\nEach player skips his or her discard phase and does not lose as a result of being unable to draw a card.\nEach player cannot play more than one spell each turn.\nIf Mine, Mine, Mine leaves play, each player shuffles his or her hand and graveyard into his or her library.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "62785ad6-f56f-53e0-9fd3-5e3d31bb4007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987ddd67-305a-4c95-9f1a-17eeeb058aaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987ddd67-305a-4c95-9f1a-17eeeb058aaa.jpg?1",
             "name": "Squirrel Farm",
             "text": "o1o\nG: Choose a card in your hand. Covering the artist's name, reveal the card to target player. If that player cannot name the artist, reveal the artist's name and put a Squirrel token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "28eab892-c663-5205-ac4c-64da6c777ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8369211-e7e1-45e1-a142-274f4236e230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8369211-e7e1-45e1-a142-274f4236e230.jpg?1",
             "name": "Team Spirit",
             "text": "All creatures controlled by target player and his or her teammates get +1/+1 until end of turn.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "cb3f1aa7-5242-52b6-b7dc-1f07ca99e04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43ce658-12be-4eb2-b679-0aefea348de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43ce658-12be-4eb2-b679-0aefea348de2.jpg?1",
             "name": "Timmy, Power Gamer",
             "text": "o4: Put a creature into play from your hand.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "f8175a6a-f790-5c38-94c5-f3005f3a27d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420010f-5389-4aa2-a5f8-d9631249679a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420010f-5389-4aa2-a5f8-d9631249679a.jpg?1",
             "name": "Ashnod's Coupon",
             "text": "oc\nT, Sacrifice Ashnod's Coupon: Target player gets you target drink.\nErrata: You pay any costs for the drink.",
             "colours": [],
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "9b04fa89-b946-58e9-88ee-de5cf015a3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c85d097-e87b-41ee-93c6-0e54ec41b174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c85d097-e87b-41ee-93c6-0e54ec41b174.jpg?1",
             "name": "Blacker Lotus",
             "text": "oc\nT: Tear Blacker Lotus into pieces. Add four mana of any one color to your mana pool. Play this ability as a mana source. Remove the pieces from the game afterwards.",
             "colours": [],
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "d739225a-6ed8-52be-8585-e53887edd5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21943fe2-3eeb-441a-a3ae-99866c6e76bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21943fe2-3eeb-441a-a3ae-99866c6e76bd.jpg?1",
             "name": "Bronze Calendar",
             "text": "Your spells cost o1 less to play as long as you speak in a voice other than your normal voice.\nIf you speak in your normal voice, sacrifice Bronze Calendar.",
             "colours": [],
@@ -2274,7 +2274,7 @@
         },
         {
             "id": "4013c717-93a0-5e85-8eee-8a6c1b613c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cee00a-5ab5-43c3-8017-db20d37e69c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cee00a-5ab5-43c3-8017-db20d37e69c4.jpg?1",
             "name": "Chaos Confetti",
             "text": "o4, oc\nT: Tear Chaos Confetti into pieces. Throw the pieces onto the playing area from a distance of at least five feet. Destroy each card in play that a piece touches. Remove the pieces from the game afterwards.",
             "colours": [],
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "27373004-c893-5124-a904-12b00f913072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfacc30-0acc-4b2d-bc7b-6ff72afc1077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfacc30-0acc-4b2d-bc7b-6ff72afc1077.jpg?1",
             "name": "Clay Pigeon",
             "text": "Flying\no1, Throw Clay Pigeon into the air at least two feet above your head while seated, Attempt to catch it with one hand: If you catch Clay Pigeon, prevent all damage to you from any one source and return Clay Pigeon to play, tapped. Otherwise, sacrifice it.",
             "colours": [],
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "6ab4214d-3f8e-554e-9190-a0427487e050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdb8678-3c0c-4ee3-aeff-52a4db4e09c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdb8678-3c0c-4ee3-aeff-52a4db4e09c4.jpg?1",
             "name": "Giant Fan",
             "text": "o2, oc\nT: Move target counter from one card to another. If the second card's rules text refers to any type of counters, the moved counter becomes one of those counters. Otherwise, it becomes a +1/+1 counter.",
             "colours": [],
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "37f4bd2f-1393-59f9-b76b-fb0278e04d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1834ac92-8b4e-4442-a834-acd580e1ef99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1834ac92-8b4e-4442-a834-acd580e1ef99.jpg?1",
             "name": "Jack-in-the-Mox",
             "text": "oc\nT: Roll a six-sided die for Jack-in-the-Mox. On a 1, sacrifice Jack-in-the-Mox and lose 5 life. Otherwise, Jack-in-the-Mox has one of the following effects. Treat this ability as a mana source.\n2 Add o\nW to your mana pool.\n3 Add o\nU to your mana pool.\n4 Add o\nB to your mana pool.\n5 Add o\nR to your mana pool.\n6 Add o\nG to your mana pool.",
             "colours": [],
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "f4f45a83-a98c-5c4e-970a-5e1b4aa7c7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68f012-307f-4ffb-909e-1284fb39e64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68f012-307f-4ffb-909e-1284fb39e64f.jpg?1",
             "name": "Jester's Sombrero",
             "text": "o2, oc\nT, Sacrifice Jester's Sombrero: Look through target player's sideboard and remove any three of those cards from it for the remainder of the match.",
             "colours": [],
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "d2df03d0-2696-506a-b37f-d4b9a461ddb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf208d-5fe6-4030-a19d-7505832dab3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf208d-5fe6-4030-a19d-7505832dab3b.jpg?1",
             "name": "Mirror Mirror",
             "text": "Mirror Mirror comes into play tapped.\no7, oc\nT, Sacrifice Mirror Mirror: At end of turn, exchange life totals with target player and exchange all cards in play that you control, and all cards in your hand, library, and graveyard, with that player until end of game.",
             "colours": [],
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "ad530bf0-179b-5ff8-aaaa-1d6d5b3c466c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1cb9ab-512e-4bb1-8d77-37a0b2d3e7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1cb9ab-512e-4bb1-8d77-37a0b2d3e7f8.jpg?1",
             "name": "Paper Tiger",
             "text": "Rock Lobsters cannot attack or block.",
             "colours": [],
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "568eaa81-563a-5fb8-8a6b-615b999b8a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba96c2a-9ccf-4b28-8af5-f8c221fc6823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba96c2a-9ccf-4b28-8af5-f8c221fc6823.jpg?1",
             "name": "Rock Lobster",
             "text": "Scissors Lizards cannot attack or block.",
             "colours": [],
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "a713c635-f87d-56c6-ab33-2c3b91337005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b3502d-5519-4254-b946-226edc3bd7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b3502d-5519-4254-b946-226edc3bd7e4.jpg?1",
             "name": "Scissors Lizard",
             "text": "Paper Tigers cannot attack or block.",
             "colours": [],
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "89f3c5da-de85-5f4c-9c8a-46f3d0d4527e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d1435-bde3-46f7-a35d-2a663e05fb97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d1435-bde3-46f7-a35d-2a663e05fb97.jpg?1",
             "name": "Spatula of the Ages",
             "text": "o4, oc\nT, Sacrifice Spatula of the Ages: Put into play from your hand any card from an Unglued supplement.",
             "colours": [],
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "1c6761fe-ada4-55db-9cc1-28a52d94d0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f386c088-fa37-4134-96bb-9fb784719101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f386c088-fa37-4134-96bb-9fb784719101.jpg?1",
             "name": "Urza's Contact Lenses",
             "text": "Urza's Contact Lenses comes into play tapped and does not untap during its controller's untap phase.\nAll players play with their hands face up.\nClap your hands twice: Tap or untap Urza's Contact Lenses.",
             "colours": [],
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "db24ae5c-9e2d-5036-8d1e-43c97eb117b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfe56d0-c15f-4a68-a0b8-911e13b1bc9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfe56d0-c15f-4a68-a0b8-911e13b1bc9a.jpg?1",
             "name": "Urza's Science Fair Project",
             "text": "o2: Roll a six-sided die for Urza's Science Fair Project.\n1 It gets -2/-2 until end of turn.\n2 It deals no combat damage this turn.\n3 Attacking does not cause it to tap this turn.\n4 It gains first strike until end of turn.\n5 It gains flying until end of turn.\n6 It gets +2/+2 until end of turn.",
             "colours": [],
@@ -2619,7 +2619,7 @@
         },
         {
             "id": "58f9ae77-a62a-53e4-a0db-96f7c6f87229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb382733-ff3d-43e2-9b1e-efa2f7c28173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb382733-ff3d-43e2-9b1e-efa2f7c28173.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "6e1c70a2-447a-5f18-9b4c-87a547a81ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f89f2-30a0-493a-914e-6251d2574099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f89f2-30a0-493a-914e-6251d2574099.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "d9a2e581-d292-5ec3-9424-f497a760c232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69384f97-3333-4aa7-bc4f-928ba49a2c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69384f97-3333-4aa7-bc4f-928ba49a2c80.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "18548922-7199-5e53-a68e-13e18b239be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c2e1a-181e-4275-ad09-51c9de039d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c2e1a-181e-4275-ad09-51c9de039d32.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "536d955c-bb4c-5ad2-ac79-c51c6a8c6a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed8a17-ce32-4100-8ffc-fb8af1c35142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed8a17-ce32-4100-8ffc-fb8af1c35142.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2784,7 +2784,7 @@
         },
         {
             "id": "88308b13-9d63-5450-8152-54a09e60e259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc944579-b6d8-40f7-8c46-146513960d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc944579-b6d8-40f7-8c46-146513960d61.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "01a52fbf-27cd-5ccb-993d-d60faf1c6280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159b57d-bc52-4cef-ac7a-e364e40c3d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159b57d-bc52-4cef-ac7a-e364e40c3d03.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -2852,7 +2852,7 @@
         },
         {
             "id": "6427bb52-c4c3-5918-bf64-421f8bff5978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7b5995-ee8b-40d1-b157-8df96c02cc5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7b5995-ee8b-40d1-b157-8df96c02cc5b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "9085fbb5-b423-540e-9bdb-da12104801a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd728ed-d5dc-44b3-9159-6c86cab3be0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd728ed-d5dc-44b3-9159-6c86cab3be0c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "6c328ab8-3fdf-5fbc-8179-f4780c70df80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281d2c14-2343-44c9-a589-7f4da37978a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281d2c14-2343-44c9-a589-7f4da37978a2.jpg?1",
             "name": "Sheep",
             "text": "",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "f47e3eeb-f1d4-5fd2-852e-5f08ec9bd5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf24a09-0a54-4e1d-a515-ed5ae99294be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf24a09-0a54-4e1d-a515-ed5ae99294be.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/ULG.json
+++ b/Assets/Resources/Sets/ULG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6019df9f-5c1b-568a-a3c9-97242a2317f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ba2da-6dea-44ac-8439-527222da565b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ba2da-6dea-44ac-8439-527222da565b.jpg?1",
             "name": "Angelic Curator",
             "text": "Flying, protection from artifacts",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "d6fa1aa9-32e8-5ad5-86d9-78458dc60b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb6d738-f6a8-4626-8103-68e63874eda4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb6d738-f6a8-4626-8103-68e63874eda4.jpg?1",
             "name": "Blessed Reversal",
             "text": "Gain 3 life for each creature attacking you.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "dfcbfd2b-6134-54b1-9243-eba7507364f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d590d2-cfa3-43d1-9e65-bc68b5a2a3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d590d2-cfa3-43d1-9e65-bc68b5a2a3ee.jpg?1",
             "name": "Burst of Energy",
             "text": "Untap target permanent.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "05abed58-e64f-5244-ae52-87c2cbc542ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a113f0c-8249-427b-979b-10898ec66a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a113f0c-8249-427b-979b-10898ec66a3a.jpg?1",
             "name": "Cessation",
             "text": "Enchanted creature cannot attack.\nWhen Cessation is put into a graveyard from play, return Cessation to owner's hand.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "1fa66e8a-cfda-5685-bc8d-1cdc54e21bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8e8719-8c33-429d-8b95-b7f813888850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8e8719-8c33-429d-8b95-b7f813888850.jpg?1",
             "name": "Defender of Law",
             "text": "Protection from red\nYou may play Defender of Law any time you could play an instant.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "dc6a871e-fe51-5d03-b46f-1d8644006965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b5c60-8a5e-4473-ba43-583aef50f19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b5c60-8a5e-4473-ba43-583aef50f19e.jpg?1",
             "name": "Devout Harpist",
             "text": "oc\nT: Destroy target creature enchantment.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "9490d240-7066-5d0d-a69e-09d842c0417d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c89d61-3c2e-4d70-86d6-f70eba3d327f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c89d61-3c2e-4d70-86d6-f70eba3d327f.jpg?1",
             "name": "Erase",
             "text": "Remove target enchantment from the game.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "b4eafc53-7d74-5ab3-80b6-1e05bc0e0eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31d7d1b-a219-4653-be99-a885bc9b2e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31d7d1b-a219-4653-be99-a885bc9b2e2f.jpg?1",
             "name": "Expendable Troops",
             "text": "oc\nT, Sacrifice Expendable Troops: Expendable Troops deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "71153f87-9f78-57fe-8a01-0b99a5c4af8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6478f-4ae5-4f26-baa9-b28e992f962e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6478f-4ae5-4f26-baa9-b28e992f962e.jpg?1",
             "name": "Hope and Glory",
             "text": "Untap two target creatures. Each of them gets +1/+1 until end of turn.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "4e4ccf2d-5a07-5977-bee1-92cc7ecbd0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee0ee84-6c22-4649-b621-e3fdb08bbe45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee0ee84-6c22-4649-b621-e3fdb08bbe45.jpg?1",
             "name": "Iron Will",
             "text": "Target creature gets +0/+4 until end of turn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "b7afaca8-748a-571a-9290-61c775624b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d23045-905b-44cb-9af9-cc6ad717477d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d23045-905b-44cb-9af9-cc6ad717477d.jpg?1",
             "name": "Karmic Guide",
             "text": "Flying, protection from black; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Karmic Guide comes into play, choose target creature card in your graveyard and put that creature into play.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "1d8e69c4-8af8-5c23-98eb-4e429dbe7318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5e98d3-2521-4340-8d48-98e8c2c7818d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5e98d3-2521-4340-8d48-98e8c2c7818d.jpg?1",
             "name": "Knighthood",
             "text": "All creatures you control gain first strike.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "6063f93f-a46a-5583-9fa9-e4ab6977734a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1f026b-8c7f-4051-9922-5684a6b2c06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1f026b-8c7f-4051-9922-5684a6b2c06b.jpg?1",
             "name": "Martyr's Cause",
             "text": "Sacrifice a creature: Prevent all damage to a creature or player from one source. (Treat further damage from that source normally.)",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "2d9077d1-de7c-5515-b6e2-d4034747a220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1a46ab-95cb-4c24-924f-fc2afd4fcac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1a46ab-95cb-4c24-924f-fc2afd4fcac7.jpg?1",
             "name": "Mother of Runes",
             "text": "oc\nT: Target creature you control gains protection from a color of your choice until end of turn.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "1c82c9d6-fc19-513d-833b-1c0fbb142a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9337bbe-e092-469d-8122-77f92e233306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9337bbe-e092-469d-8122-77f92e233306.jpg?1",
             "name": "Opal Avenger",
             "text": "When you have 10 life or less, if Opal Avenger is an enchantment, Opal Avenger becomes a 3/5 creature that counts as a Guardian.",
             "colours": [
@@ -503,7 +503,7 @@
         },
         {
             "id": "e0df75b6-e382-5ce4-828a-aca1a3d2566f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699cf3b-df54-4c77-ba19-3bc7598ae3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699cf3b-df54-4c77-ba19-3bc7598ae3fa.jpg?1",
             "name": "Opal Champion",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Champion is an enchantment, Opal Champion becomes a 3/3 creature with first strike that counts as a Knight.",
             "colours": [
@@ -535,7 +535,7 @@
         },
         {
             "id": "f00e02d5-c0f2-575b-8556-683085794637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d73accc-8f19-44d4-8216-c1acdbef3856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d73accc-8f19-44d4-8216-c1acdbef3856.jpg?1",
             "name": "Peace and Quiet",
             "text": "Destroy two target enchantments.",
             "colours": [
@@ -567,7 +567,7 @@
         },
         {
             "id": "11b51444-0705-5386-8618-7977ee1527b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee22cf3c-51b0-4790-ab13-985cbe900c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee22cf3c-51b0-4790-ab13-985cbe900c3b.jpg?1",
             "name": "Planar Collapse",
             "text": "During your upkeep, if there are four or more creatures in play, sacrifice Planar Collapse and destroy all creatures. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "73c30f75-46da-5087-8da5-37c75b5df4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5341da18-df05-4135-b948-7aa3e3d7a492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5341da18-df05-4135-b948-7aa3e3d7a492.jpg?1",
             "name": "Purify",
             "text": "Destroy all artifacts and enchantments.",
             "colours": [
@@ -631,7 +631,7 @@
         },
         {
             "id": "56f91cd7-27ce-584d-8bba-e51c399ed11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99509da7-3e11-4c38-804b-286ce572f36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99509da7-3e11-4c38-804b-286ce572f36e.jpg?1",
             "name": "Radiant, Archangel",
             "text": "Flying\nRadiant, Archangel counts as an Angel.\nAttacking does not cause Radiant to tap.\nRadiant gets +1/+1 for each other creature with flying in play.",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "7aee37a4-b2a4-578e-a80b-ee5f49d5f52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f39de-6ad2-410c-bc6c-75fd3c8d159b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f39de-6ad2-410c-bc6c-75fd3c8d159b.jpg?1",
             "name": "Radiant's Dragoons",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Radiant's Dragoons comes into play, gain 5 life.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "4573a62b-b39c-5514-badd-88cf0b65ef3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2718e-c6fc-4961-b094-11f25f1177ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2718e-c6fc-4961-b094-11f25f1177ff.jpg?1",
             "name": "Radiant's Judgment",
             "text": "Destroy target creature with power 4 or greater.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "c8ab1d58-7835-5c03-8e90-6c21992d0c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca280e1e-4231-48e5-be1b-965480822c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca280e1e-4231-48e5-be1b-965480822c46.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "Flying\nWhenever Sustainer of the Realm blocks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "64678420-8607-5a3d-8486-05ffa835d0f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294aa7fc-12be-4722-b288-de14a28919b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294aa7fc-12be-4722-b288-de14a28919b2.jpg?1",
             "name": "Tragic Poet",
             "text": "oc\nT, Sacrifice Tragic Poet: Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "50c0447f-f023-5a69-bcf8-b3c566dfa96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089e2bc7-0063-47bf-8f66-48bed6eb046b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089e2bc7-0063-47bf-8f66-48bed6eb046b.jpg?1",
             "name": "Anthroplasm",
             "text": "Anthroplasm comes into play with two +1/+1 counters on it.\no\nX, oc\nT: Remove all +1/+1 counters from Anthroplasm and put X +1/+1 counters on it.",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "96248a07-e29d-5b79-84cf-4c292fc641f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9936cb4d-f4e3-4fc7-869e-8f17056e57d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9936cb4d-f4e3-4fc7-869e-8f17056e57d5.jpg?1",
             "name": "Archivist",
             "text": "oc\nT: Draw a card.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "bbe6231a-daea-5e75-8637-ed76ca7f7e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6be1542-70b8-4e97-a951-100966dc46ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6be1542-70b8-4e97-a951-100966dc46ce.jpg?1",
             "name": "Aura Flux",
             "text": "Each other enchantment gains \"During your upkeep, pay o2 or sacrifice this enchantment.\"",
             "colours": [
@@ -903,7 +903,7 @@
         },
         {
             "id": "f268877a-8a96-52bc-b647-e036df401b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8656bdd4-0c45-43f9-b2dc-d11a355ff747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8656bdd4-0c45-43f9-b2dc-d11a355ff747.jpg?1",
             "name": "Bouncing Beebles",
             "text": "Bouncing Beebles is unblockable if defending player controls an artifact.",
             "colours": [
@@ -937,7 +937,7 @@
         },
         {
             "id": "c032be25-ebcf-5c2e-925d-ee50eb6e30ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e76d04a-0038-4b5b-a026-3056ee940da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e76d04a-0038-4b5b-a026-3056ee940da9.jpg?1",
             "name": "Cloud of Faeries",
             "text": "Flying\nWhen Cloud of Faeries comes into play, untap up to two lands.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "4783bc65-dd02-58d2-b3aa-9ea14158d137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899088b3-4cdf-47c0-8c52-3c9f55c086c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899088b3-4cdf-47c0-8c52-3c9f55c086c4.jpg?1",
             "name": "Delusions of Mediocrity",
             "text": "When Delusions of Mediocrity comes into play, gain 10 life.\nWhen Delusions of Mediocrity leaves play, lose 10 life.",
             "colours": [
@@ -1003,7 +1003,7 @@
         },
         {
             "id": "d56a3e48-1bd4-5e7d-a776-5f53a24d816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9a5501-f149-47d0-9d79-151a524c7c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9a5501-f149-47d0-9d79-151a524c7c54.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying\no1oo\nU Return Fleeting Image to owner's hand.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "fc1b6960-10c4-5304-9f64-344016aeb31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1904db14-6df7-424f-afa5-e3dfab31300a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1904db14-6df7-424f-afa5-e3dfab31300a.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then choose and discard two cards. Untap up to three lands.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "35da17a7-e1fd-5c14-8ca2-3adb2b0199a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e3894-5dfe-4d03-9996-eebf96c58168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e3894-5dfe-4d03-9996-eebf96c58168.jpg?1",
             "name": "Intervene",
             "text": "Counter target spell that targets a creature.",
             "colours": [
@@ -1101,7 +1101,7 @@
         },
         {
             "id": "014f08dc-5f90-56b5-a002-143b4187cb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedea953-b5f1-4ec7-bd9f-b7827f9d40fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedea953-b5f1-4ec7-bd9f-b7827f9d40fe.jpg?1",
             "name": "King Crab",
             "text": "o1o\nU, oc\nT: Put target green creature on top of owner's library.",
             "colours": [
@@ -1135,7 +1135,7 @@
         },
         {
             "id": "716b22af-d935-512e-97aa-669cb58d0400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca18a2e7-6b01-4d10-82b5-0c1cb6ba0d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca18a2e7-6b01-4d10-82b5-0c1cb6ba0d2b.jpg?1",
             "name": "Levitation",
             "text": "All creatures you control gain flying.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "aa45f70b-a8f4-5bc0-ae86-75a570599f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4956a2-9a39-4152-9c98-70e4b2acfa26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4956a2-9a39-4152-9c98-70e4b2acfa26.jpg?1",
             "name": "Miscalculation",
             "text": "Counter target spell unless its caster pays an additional o2.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "70cb4eda-6b22-528d-97d6-98071ec21284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a09767-a15d-42b0-aaa3-794a4e11037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a09767-a15d-42b0-aaa3-794a4e11037a.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "184f3e89-8188-5a22-846b-f35a6231ad46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5621db3f-a9e7-4350-9c6a-0ba04a628947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5621db3f-a9e7-4350-9c6a-0ba04a628947.jpg?1",
             "name": "Palinchron",
             "text": "Flying\nWhen Palinchron comes into play, untap up to seven lands.\no2o\nUoo\nU Return Palinchron to owner's hand.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "3b197524-7105-520a-ad66-26a49f8fd272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104638d-29aa-490c-8cfb-e08fc94efb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104638d-29aa-490c-8cfb-e08fc94efb59.jpg?1",
             "name": "Raven Familiar",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Raven Familiar comes into play, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "26b95319-6a7e-58b1-aa94-7ae3c02a5fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc1613c-a149-4f04-9950-41637d35d675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc1613c-a149-4f04-9950-41637d35d675.jpg?1",
             "name": "Rebuild",
             "text": "Return all artifacts to owners' hands.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "a7bcf387-18e2-502a-95d1-59097072f39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d1a0da-40b9-4e79-bace-b93f98ae4695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d1a0da-40b9-4e79-bace-b93f98ae4695.jpg?1",
             "name": "Second Chance",
             "text": "During your upkeep, if you have 5 life or less, sacrifice Second Chance and take an extra turn after this one.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "f20143c5-2e3f-594f-ab63-0fdf280b7082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2860a20d-e1bf-4e46-8c07-a858f616d5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2860a20d-e1bf-4e46-8c07-a858f616d5a5.jpg?1",
             "name": "Slow Motion",
             "text": "During the upkeep of enchanted creature's controller, that player pays o2 or sacrifices that creature.\nWhen Slow Motion is put into a graveyard from play, return Slow Motion to owner's hand.",
             "colours": [
@@ -1397,7 +1397,7 @@
         },
         {
             "id": "14f6f8a5-4d45-5927-ba97-3986c69f2634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0549e-2d23-4ea8-b8d1-ae21af2c9091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0549e-2d23-4ea8-b8d1-ae21af2c9091.jpg?1",
             "name": "Snap",
             "text": "Return target creature to owner's hand. Untap up to two lands.",
             "colours": [
@@ -1429,7 +1429,7 @@
         },
         {
             "id": "b1f0d7dd-a67d-57bc-88d0-224e9b1cd127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4b20a-448a-4855-9e60-19625f921a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4b20a-448a-4855-9e60-19625f921a4d.jpg?1",
             "name": "Thornwind Faeries",
             "text": "Flying\noc\nT: Thornwind Faeries deals 1 damage to target creature or player.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "5a59d111-6137-5f00-8448-81269da4900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da23b15-dfb8-4267-9b33-d7a4c035c434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da23b15-dfb8-4267-9b33-d7a4c035c434.jpg?1",
             "name": "Tinker",
             "text": "At the time you play Tinker, sacrifice an artifact.\nSearch your library for an artifact card and put that artifact into play. Shuffle your library afterward.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "fb31b360-68dd-5470-8ad0-9026fd57685a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37940486-2d7f-40d9-9c19-151b9307d374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37940486-2d7f-40d9-9c19-151b9307d374.jpg?1",
             "name": "Vigilant Drake",
             "text": "Flying\no2oo\nU Untap Vigilant Drake.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "6a27a9fb-7fdf-59a5-a170-b92418e2d8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b125d1e7-5d9b-4997-88b0-71bdfc19c6f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b125d1e7-5d9b-4997-88b0-71bdfc19c6f2.jpg?1",
             "name": "Walking Sponge",
             "text": "oc\nT: Target creature loses flying, first strike, or trample until end of turn.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "2cb02da6-5539-5c69-a785-b013c002bf5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7ebec7-7375-4362-9489-437ff9305f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7ebec7-7375-4362-9489-437ff9305f19.jpg?1",
             "name": "Weatherseed Faeries",
             "text": "Flying, protection from red",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "941c2689-8a4f-5422-ac36-ac3fcfd4de1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece050ad-788e-4451-b773-ca42c37549d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece050ad-788e-4451-b773-ca42c37549d2.jpg?1",
             "name": "Bone Shredder",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.) When Bone Shredder comes into play, destroy target nonartifact, nonblack creature.",
             "colours": [
@@ -1632,7 +1632,7 @@
         },
         {
             "id": "08a94fff-6856-5a96-909e-322104de9697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5391d8-b546-4159-955e-16bb58052311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5391d8-b546-4159-955e-16bb58052311.jpg?1",
             "name": "Brink of Madness",
             "text": "During your upkeep, if you have no cards in hand, sacrifice Brink of Madness and target opponent discards his or her hand.",
             "colours": [
@@ -1664,7 +1664,7 @@
         },
         {
             "id": "860b01b7-0eb2-5493-9ec4-a9e4dbebb259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e158d5-efb2-4f90-8898-60ede98f7d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e158d5-efb2-4f90-8898-60ede98f7d29.jpg?1",
             "name": "Engineered Plague",
             "text": "When Engineered Plague comes into play, choose a creature type.\nAll creatures of the chosen type get -1/-1.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "9a6c858b-b9eb-5f90-99da-f59f7bf0ab75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167e7f67-8d44-4134-b7b9-54ccdfb8675c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167e7f67-8d44-4134-b7b9-54ccdfb8675c.jpg?1",
             "name": "Eviscerator",
             "text": "Protection from white\nWhen Eviscerator comes into play, lose 5 life.",
             "colours": [
@@ -1731,7 +1731,7 @@
         },
         {
             "id": "9fdc16ea-a654-5e9a-adb4-e10f36668872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e9c54-134b-41da-8c3d-ec699d96778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e9c54-134b-41da-8c3d-ec699d96778a.jpg?1",
             "name": "Fog of Gnats",
             "text": "Flying\noo\nB Regenerate Fog of Gnats.",
             "colours": [
@@ -1765,7 +1765,7 @@
         },
         {
             "id": "b3a97028-9440-5168-be51-86d38f643a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521bf0c-9f43-402e-8065-d2fc02e20194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521bf0c-9f43-402e-8065-d2fc02e20194.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "8387d9f9-cb2c-5485-8b9b-ebe5e86e105b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9063cc12-a822-4488-856e-93d70ecfe37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9063cc12-a822-4488-856e-93d70ecfe37f.jpg?1",
             "name": "Lurking Skirge",
             "text": "When a creature is put into one of your opponents' graveyards, if Lurking Skirge is an enchantment, Lurking Skirge becomes a 3/2 creature with flying that counts as an Imp.",
             "colours": [
@@ -1831,7 +1831,7 @@
         },
         {
             "id": "fbe5f099-1056-594d-96bd-7b24ee679cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fc29c-0223-4b03-864f-eb9149abc921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fc29c-0223-4b03-864f-eb9149abc921.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature successfully deals damage to you, destroy it.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "56c1f135-2d5f-504d-99b7-e3e50d1ebdb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b00193a-84ae-4465-943d-01e3d5fa9aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b00193a-84ae-4465-943d-01e3d5fa9aca.jpg?1",
             "name": "Ostracize",
             "text": "Look at target opponent's hand and choose a creature card there. That player discards that card.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "89077323-e7b7-5f6f-a7f9-ee713bfc8e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2313481c-baf9-4dc7-80c7-1ebc6502dce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2313481c-baf9-4dc7-80c7-1ebc6502dce7.jpg?1",
             "name": "Phyrexian Broodlings",
             "text": "o1, Sacrifice a creature: Put a +1/+1 counter on Phyrexian Broodlings.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "9e60e1db-02c9-55ef-8a5d-1e1abaffde63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672dcca2-096b-4bcc-9b02-7180c4c0d4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672dcca2-096b-4bcc-9b02-7180c4c0d4c7.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\noc\nT, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "a7db5fee-0654-52bf-88f7-38ceab815e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d555b5e-9f8a-4b1b-a4a6-dee8e177d9e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d555b5e-9f8a-4b1b-a4a6-dee8e177d9e8.jpg?1",
             "name": "Phyrexian Defiler",
             "text": "oc\nT, Sacrifice Phyrexian Defiler: Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "57b0ab3b-1a2e-5ba8-949a-da8dc0edb111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf849a0-9b53-4a8a-87a7-dc38d97311ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf849a0-9b53-4a8a-87a7-dc38d97311ab.jpg?1",
             "name": "Phyrexian Denouncer",
             "text": "oc\nT, Sacrifice Phyrexian Denouncer: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "523360f1-ead5-51f1-b2b1-e69c9a13b194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bd530-4b11-428e-864e-e24e96051e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bd530-4b11-428e-864e-e24e96051e3e.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "oc\nT, Sacrifice Phyrexian Plaguelord: Target creature gets -4/-4 until end of turn.\nSacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "e7dcda1e-8a8a-51d1-9dc6-15b13cd340c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a2bb7-d9f0-47b5-a0d9-2adf1b33e995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a2bb7-d9f0-47b5-a0d9-2adf1b33e995.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "o1o\nB, Pay 2 life: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "0fae8f58-756b-5556-bbcf-37aaf3ad0ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07f4e55-57f9-49f6-a1a2-1c94dcbe7d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07f4e55-57f9-49f6-a1a2-1c94dcbe7d71.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "691bd3d1-c6b1-5a70-900c-260a47c2d5c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59481cb5-2cb0-4b8c-84ee-519399862d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59481cb5-2cb0-4b8c-84ee-519399862d46.jpg?1",
             "name": "Rank and File",
             "text": "When Rank and File comes into play, all green creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2170,7 +2170,7 @@
         },
         {
             "id": "8ec37c3d-8601-5f14-b73c-24516a4264db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8736f8a2-ee8d-49d2-883f-b22cbe3f3645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8736f8a2-ee8d-49d2-883f-b22cbe3f3645.jpg?1",
             "name": "Sick and Tired",
             "text": "Two target creatures each get -1/-1 until end of turn.",
             "colours": [
@@ -2202,7 +2202,7 @@
         },
         {
             "id": "64d48f06-9161-55fa-96d5-9e4f8a13b419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a001ca83-35b5-48e5-8337-92258d5affc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a001ca83-35b5-48e5-8337-92258d5affc2.jpg?1",
             "name": "Sleeper's Guile",
             "text": "Enchanted creature cannot be blocked except by artifact creatures and black creatures.\nWhen Sleeper's Guile is put into a graveyard from play, return Sleeper's Guile to owner's hand.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "031c875a-0c4b-50a0-a94f-88c38ae65773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f1bca9-5831-4e8b-8920-f28ebb3ffb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f1bca9-5831-4e8b-8920-f28ebb3ffb27.jpg?1",
             "name": "Subversion",
             "text": "During your upkeep, each of your opponents loses 1 life. Gain 1 life for each 1 life lost this way.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "64c7b80f-98a6-5432-a00d-3fa55bd98d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947b8923-d9d6-4dd8-928b-91be9105ffb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947b8923-d9d6-4dd8-928b-91be9105ffb4.jpg?1",
             "name": "Swat",
             "text": "Destroy target creature with power 2 or less.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "0a17de72-0f2d-5cd6-b0cb-fe8181927f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1d02c-5d9d-4436-af3b-fb7190c1c028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1d02c-5d9d-4436-af3b-fb7190c1c028.jpg?1",
             "name": "Tethered Skirge",
             "text": "Flying\nWhenever Tethered Skirge becomes the target of a spell or ability, lose 1 life.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "1f01fd65-6c5e-5f65-9eee-cb2882978762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f8581-411b-4403-9c3a-3cf2156f6779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f8581-411b-4403-9c3a-3cf2156f6779.jpg?1",
             "name": "Treacherous Link",
             "text": "Redirect to its controller all damage dealt to enchanted creature.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "2f8a6f9c-4a5e-5fe9-8437-4a267cfcd17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb2549-e485-44d6-9d65-7605c568909e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb2549-e485-44d6-9d65-7605c568909e.jpg?1",
             "name": "Unearth",
             "text": "Choose target creature card in your graveyard with total casting cost 3 or less and put that creature into play.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "0913e75b-c685-5093-9f49-ca0a5df365ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e71828-095b-4729-ab11-c6c39ba29aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e71828-095b-4729-ab11-c6c39ba29aab.jpg?1",
             "name": "About Face",
             "text": "Switch target creature's power and toughness until end of turn. Effects that alter the creature's power alter its toughness instead, and vice versa, this turn.",
             "colours": [
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "4a83afa7-11f9-5cda-b2a7-6b92ddbc427f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdc5330-c76b-40ca-a694-58fa4b9b7304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdc5330-c76b-40ca-a694-58fa4b9b7304.jpg?1",
             "name": "Avalanche Riders",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nAvalanche Riders is unaffected by summoning sickness.\nWhen Avalanche Riders comes into play, destroy target land.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "8889f660-ea6c-524a-b2e4-e9ed75078498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ae26a-e5a0-4478-9995-00ea6bd84c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ae26a-e5a0-4478-9995-00ea6bd84c03.jpg?1",
             "name": "Defender of Chaos",
             "text": "Protection from white\nYou may play Defender of Chaos any time you could play an instant.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "0e391573-48e3-5906-8004-2bdc16a39692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131dce1c-e9c8-437a-b7aa-36a47049d2d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131dce1c-e9c8-437a-b7aa-36a47049d2d2.jpg?1",
             "name": "Ghitu Fire-Eater",
             "text": "oc\nT, Sacrifice Ghitu Fire-Eater: Ghitu Fire-Eater deals damage equal to its power to target creature or player.",
             "colours": [
@@ -2538,7 +2538,7 @@
         },
         {
             "id": "78d6504c-7934-514e-aedc-883c63beffa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e4bc1d-6a4b-408a-8921-433249c960f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e4bc1d-6a4b-408a-8921-433249c960f9.jpg?1",
             "name": "Ghitu Slinger",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Ghitu Slinger comes into play, it deals 2 damage to target creature or player.",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "feee926e-1726-53c1-9e5b-58765f85cd07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9786c4f-f09b-46ce-966c-10efb1e5e609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9786c4f-f09b-46ce-966c-10efb1e5e609.jpg?1",
             "name": "Ghitu War Cry",
             "text": "oo\nR Target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "44fe604e-4225-5824-8917-570a23988c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc08b6-f31a-46b3-b233-f6bb2c6b1106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc08b6-f31a-46b3-b233-f6bb2c6b1106.jpg?1",
             "name": "Goblin Medics",
             "text": "Whenever Goblin Medics becomes tapped, it deals 1 damage to target creature or player.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "0dd58ee1-d018-5681-9baa-3596881c0578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171e136-1167-4329-acb2-6853d3a814e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171e136-1167-4329-acb2-6853d3a814e5.jpg?1",
             "name": "Goblin Welder",
             "text": "oc\nT: Exchange target artifact a player controls for target artifact card in that player's graveyard.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "b7db3a6b-4ab9-5ec3-90bd-bc58072d9617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9e0e7e-ada8-49f5-9dd9-f62464697675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9e0e7e-ada8-49f5-9dd9-f62464697675.jpg?1",
             "name": "Granite Grip",
             "text": "Enchanted creature gets +1/+0 for each mountain you control.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "201382ad-67ef-54b4-aa79-17600be5a168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44497303-9686-4810-bf0f-876dd9696cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44497303-9686-4810-bf0f-876dd9696cab.jpg?1",
             "name": "Impending Disaster",
             "text": "During your upkeep, if there are seven or more lands in play, sacrifice Impending Disaster and destroy all lands.",
             "colours": [
@@ -2741,7 +2741,7 @@
         },
         {
             "id": "69992aab-14a9-5567-a311-8c8f7faa18e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f7fe0-0681-4b25-807f-30ed70ec78d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f7fe0-0681-4b25-807f-30ed70ec78d5.jpg?1",
             "name": "Last-Ditch Effort",
             "text": "Sacrifice X creatures. Last-Ditch Effort deals X damage to target creature or player.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "d7f21c30-29e3-58a5-81b7-03786f8f5269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11ec278-46f5-4970-ad0b-f6718c73de6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11ec278-46f5-4970-ad0b-f6718c73de6c.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "d4b34350-924b-5cc3-82c2-c40108b9b6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95234b29-9ac8-4200-b42d-9653ba51b010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95234b29-9ac8-4200-b42d-9653ba51b010.jpg?1",
             "name": "Molten Hydra",
             "text": "o1o\nRoo\nR Put a +1/+1 counter on Molten Hydra.\noc\nT, Remove all +1/+1 counters from Molten Hydra: Molten Hydra deals 1 damage to target creature or player for each +1/+1 counter removed this way.",
             "colours": [
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "bc2988b6-7cc7-5997-b8b0-7c319bd511e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab8065-cecc-4b19-be93-7cf791a93e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab8065-cecc-4b19-be93-7cf791a93e62.jpg?1",
             "name": "Parch",
             "text": "Choose one Parch deals 2 damage to target creature or player; or Parch deals 4 damage to target blue creature.",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "5825a803-c3d1-5c71-bf33-041b9baf2096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96136626-4777-4e58-865b-c4d3f6ceb59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96136626-4777-4e58-865b-c4d3f6ceb59d.jpg?1",
             "name": "Pygmy Pyrosaur",
             "text": "Pygmy Pyrosaur cannot block.\noo\nR Pygmy Pyrosaur gets +1/+0 until end of turn.",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "287c9548-4b6f-5b22-9556-c03fbadd6d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a91a58-cc8b-47a3-8c53-43c32753a00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a91a58-cc8b-47a3-8c53-43c32753a00d.jpg?1",
             "name": "Pyromancy",
             "text": "o3, Discard a card at random: Pyromancy deals to target creature or player damage equal to the total casting cost of the discarded card.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "e262a1ba-5feb-5122-a122-28dda54b8a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e8f6a-3a1a-4c30-9348-4b31882267eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e8f6a-3a1a-4c30-9348-4b31882267eb.jpg?1",
             "name": "Rack and Ruin",
             "text": "Destroy two target artifacts.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "6cff6f01-fde3-5697-ba58-89b2064af571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b79677b-d5b9-47c7-a5f5-45446d5cddff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b79677b-d5b9-47c7-a5f5-45446d5cddff.jpg?1",
             "name": "Rivalry",
             "text": "During each player's upkeep, if that player controls more lands than any other, Rivalry deals 2 damage to him or her.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "9f2c8db1-595a-58db-85ce-8aa25aba2a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112aa0e2-7e4a-4ae8-bedb-d84b4116df5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112aa0e2-7e4a-4ae8-bedb-d84b4116df5e.jpg?1",
             "name": "Shivan Phoenix",
             "text": "Flying\nWhen Shivan Phoenix is put into a graveyard from play, return Shivan Phoenix to owner's hand.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "90756eee-c12b-552d-9afb-b09256dd5e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba91431-3fcd-4b44-ae7b-a69eb18efd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba91431-3fcd-4b44-ae7b-a69eb18efd5f.jpg?1",
             "name": "Sluggishness",
             "text": "Enchanted creature cannot block.\nWhen Sluggishness is put into a graveyard from play, return Sluggishness to owner's hand.",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "59fad638-4516-504d-b90e-a7bb7b1fdb3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc07c6-60c7-4abe-8197-7544887ec64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc07c6-60c7-4abe-8197-7544887ec64d.jpg?1",
             "name": "Viashino Bey",
             "text": "When Viashino Bey attacks, all creatures you control attack if able.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "28fd6d50-9e87-5676-8a73-b8eda4b63e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbab69d-3259-40f4-a588-ab550858a178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbab69d-3259-40f4-a588-ab550858a178.jpg?1",
             "name": "Viashino Cutthroat",
             "text": "Viashino Cutthroat is unaffected by summoning sickness.\nAt end of turn, return Viashino Cutthroat to owner's hand.",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "8ea7255d-c7bc-5e2b-8b31-8ca1d4542683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e435e-e3a1-45b0-81c3-bd47916df8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e435e-e3a1-45b0-81c3-bd47916df8ac.jpg?1",
             "name": "Viashino Heretic",
             "text": "o1o\nR, oc\nT: Destroy target artifact. Viashino Heretic deals to that artifact's controller damage equal to the artifact's total casting cost.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "6f6de059-9e8d-50da-b4cf-2dff2efa0bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd888a-ca98-44dd-a213-858c3539dc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd888a-ca98-44dd-a213-858c3539dc97.jpg?1",
             "name": "Viashino Sandscout",
             "text": "Viashino Sandscout is unaffected by summoning sickness.\nAt end of turn, return Viashino Sandscout to owner's hand.",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "1cf1811b-db81-5562-9e94-7fc2c51d5589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9686f1a8-035e-415e-9a06-933d6ce1cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9686f1a8-035e-415e-9a06-933d6ce1cd5c.jpg?1",
             "name": "Bloated Toad",
             "text": "Protection from blue\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "f14438a8-a8d4-59a8-8221-535cd8cb43de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6563f790-862c-465a-b963-7a61f2385516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6563f790-862c-465a-b963-7a61f2385516.jpg?1",
             "name": "Crop Rotation",
             "text": "At the time you play Crop Rotation, sacrifice a land.\nSearch your library for a land card and put that land into play. Shuffle your library afterward.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "af4af472-43bc-56ab-a27d-ff8f282ce900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a807f-d5d0-4787-b390-3351783a1ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a807f-d5d0-4787-b390-3351783a1ae4.jpg?1",
             "name": "Darkwatch Elves",
             "text": "Protection from black\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "09bbb964-d134-59af-b967-458555e94647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e93381f-627f-41b6-b1b6-45d712a44d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e93381f-627f-41b6-b1b6-45d712a44d8e.jpg?1",
             "name": "Defense of the Heart",
             "text": "During your upkeep, if one of your opponents controls three or more creatures, sacrifice Defense of the Heart, search your library for up to two creature cards, and put those creatures into play. Shuffle your library afterward.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "03b78dda-0a5b-5295-af5c-ef255abb7acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e94c9-61c4-4cc0-b5ce-db62bc2660ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e94c9-61c4-4cc0-b5ce-db62bc2660ee.jpg?1",
             "name": "Deranged Hermit",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Deranged Hermit comes into play, put four Squirrel tokens into play. Treat these tokens as 1/1 green creatures.\nAll Squirrels get +1/+1.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "e3b7149a-4906-5cee-a6e2-ba11722bf87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84177f-43a3-4d14-9a4c-2ca931cfe092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84177f-43a3-4d14-9a4c-2ca931cfe092.jpg?1",
             "name": "Gang of Elk",
             "text": "Whenever a creature blocks it, Gang of Elk gets +2/+2 until end of turn.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "288296dc-c79c-5678-8fd8-abb9d14e818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aafc380-cf4d-4843-b9c3-c389d9c5e942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aafc380-cf4d-4843-b9c3-c389d9c5e942.jpg?1",
             "name": "Harmonic Convergence",
             "text": "Return all enchantments to top of owners' libraries.",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "daa40298-e8cf-530d-bf61-3936ed57b882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f94da51-b4d9-4d79-9113-39f8f4a1be34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f94da51-b4d9-4d79-9113-39f8f4a1be34.jpg?1",
             "name": "Hidden Gibbons",
             "text": "When one of your opponents successfully casts an instant or interrupt spell, if Hidden Gibbons is an enchantment, Hidden Gibbons becomes a 4/4 creature that counts as an Ape.",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "5839e309-1880-5123-9e4c-8d5d60106ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70ae8e9-852e-4e47-b48d-d1847666fc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70ae8e9-852e-4e47-b48d-d1847666fc50.jpg?1",
             "name": "Lone Wolf",
             "text": "You may have Lone Wolf deal combat damage to defending player instead of to creatures blocking it.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "e549c771-a332-576d-9cad-45e4906c5953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e48b989-bb64-4c71-9921-0a230fed5b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e48b989-bb64-4c71-9921-0a230fed5b11.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -3537,7 +3537,7 @@
         },
         {
             "id": "bec05e4f-c529-5be4-8737-2529eef08b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6cc98b-b376-40af-8308-198bab00b2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6cc98b-b376-40af-8308-198bab00b2b1.jpg?1",
             "name": "Multani, Maro-Sorcerer",
             "text": "Multani, Maro-Sorcerer has power and toughness each equal to the total number of cards in all players' hands.\nMultani cannot be the target of spells or abilities.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "0ec96b74-6c92-5400-ad99-804706989be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fdecb-bca0-48ea-b5bb-d0886c7d3316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fdecb-bca0-48ea-b5bb-d0886c7d3316.jpg?1",
             "name": "Multani's Acolyte",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Multani's Acolyte comes into play, draw a card.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "7b7c2b9e-59b1-5fba-9afe-8b2475c376c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bfa984-5fe9-44ad-b13f-3276951f9f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bfa984-5fe9-44ad-b13f-3276951f9f10.jpg?1",
             "name": "Multani's Presence",
             "text": "Whenever a spell you play is countered, draw a card.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "61d0d767-692b-556f-ace6-d0d080d5861e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e256c2-38df-4012-9308-ce17dd889e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e256c2-38df-4012-9308-ce17dd889e5f.jpg?1",
             "name": "Rancor",
             "text": "Enchanted creature gains +2/+0 and trample.\nWhen Rancor is put into a graveyard from play, return Rancor to owner's hand.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "b2ead781-2b26-5ede-a643-7dfe7103a22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac77869-97bc-4976-9ee0-3d60e162b78a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac77869-97bc-4976-9ee0-3d60e162b78a.jpg?1",
             "name": "Repopulate",
             "text": "Shuffle all creature cards from target player's graveyard into that player's library.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "e9d46d46-0265-5d30-9bf8-54e71c72a3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9498a97a-0e32-4eb8-9cb4-0698ff3a7ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9498a97a-0e32-4eb8-9cb4-0698ff3a7ded.jpg?1",
             "name": "Silk Net",
             "text": "Target creature gets +1/+1 and can block creatures with flying until end of turn.",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "65cd2130-1cae-54f4-be10-442beb720b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aaea3e-a67a-4d9c-9059-e6beb05f97b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aaea3e-a67a-4d9c-9059-e6beb05f97b1.jpg?1",
             "name": "Simian Grunts",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nYou may play Simian Grunts any time you could play an instant.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "24f1a08e-81b5-5fd6-9822-1bde4ba93635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697acf5-9bc5-411d-8574-fe6185f18672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697acf5-9bc5-411d-8574-fe6185f18672.jpg?1",
             "name": "Treefolk Mystic",
             "text": "Whenever a creature blocks or is blocked by Treefolk Mystic, destroy all enchantments on that creature.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "138843eb-3a96-5ae6-9ad4-8146188c053f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74f8ae-992b-40a6-87e3-7b321dba4ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74f8ae-992b-40a6-87e3-7b321dba4ffa.jpg?1",
             "name": "Weatherseed Elf",
             "text": "oc\nT: Target creature gains forestwalk until end of turn. (If defending player controls a forest, this creature is unblockable.)",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "7db49e3a-8db8-572c-8908-8a13bbff3cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42cce45-3b6a-43e2-8329-68c30135c5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42cce45-3b6a-43e2-8329-68c30135c5c1.jpg?1",
             "name": "Weatherseed Treefolk",
             "text": "Trample\nWhen Weatherseed Treefolk is put into a graveyard from play, return Weatherseed Treefolk to owner's hand.",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "3c3f4903-ab64-501f-963f-d961a8ebb3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19116d5d-8f2d-4e85-849d-1fbaa67e8cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19116d5d-8f2d-4e85-849d-1fbaa67e8cfd.jpg?1",
             "name": "Wing Snare",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "5b18bd48-be7b-5860-bff0-c50caae466ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414a41-b50c-49b6-9c27-f3170017d9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414a41-b50c-49b6-9c27-f3170017d9b0.jpg?1",
             "name": "Yavimaya Granger",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Yavimaya Granger comes into play, you may search your library for a basic land card and put that land into play tapped. Shuffle your library afterward.",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "2a22f96e-74e5-5f41-ab12-f4b187a52844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f80036-1058-4513-8549-0557df9b5d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f80036-1058-4513-8549-0557df9b5d61.jpg?1",
             "name": "Yavimaya Scion",
             "text": "Protection from artifacts",
             "colours": [
@@ -3973,7 +3973,7 @@
         },
         {
             "id": "fc701eaa-6d6a-51df-b71e-7e86c9617b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde16069-7176-42dc-88d8-fb37b7894007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde16069-7176-42dc-88d8-fb37b7894007.jpg?1",
             "name": "Yavimaya Wurm",
             "text": "Trample",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "248ca95b-5028-56a0-9e97-09c857455092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7b248a-3c74-4592-b357-47989568298c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7b248a-3c74-4592-b357-47989568298c.jpg?1",
             "name": "Angel's Trumpet",
             "text": "Attacking does not cause creatures to tap.\nAt the end of each player's turn, tap all untapped creatures he or she controls that did not attack this turn. Angel's Trumpet deals 1 damage to that player for each creature tapped this way.",
             "colours": [],
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "24ca99ea-03fb-5e02-8920-eab75d899d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06578d72-50e9-468d-96d2-c0cbda14961a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06578d72-50e9-468d-96d2-c0cbda14961a.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden has power and toughness each equal to the total number of creatures in play.",
             "colours": [],
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "73de3536-1224-54eb-989c-9b0301531f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4913a54f-f4d0-483a-a181-716007f65658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4913a54f-f4d0-483a-a181-716007f65658.jpg?1",
             "name": "Crawlspace",
             "text": "No more than two creatures can attack you each combat.",
             "colours": [],
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "4a0fe7f5-b117-5086-b7af-d4c2638577b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87841977-75ff-49c3-b832-3f0cf48b50b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87841977-75ff-49c3-b832-3f0cf48b50b2.jpg?1",
             "name": "Damping Engine",
             "text": "A player who controls more permanents than any other cannot play lands or artifact, creature, or enchantment spells. That player may sacrifice a permanent to ignore this effect until end of turn.",
             "colours": [],
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "a7cf7d5a-661d-5417-b93c-7e85af91a448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2592c9-7e64-40c1-a9cb-c0994094a1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2592c9-7e64-40c1-a9cb-c0994094a1e0.jpg?1",
             "name": "Defense Grid",
             "text": "During each player's turn, spells played by another player cost an additional o3.",
             "colours": [],
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "2064bb5c-089c-5dc6-adf5-e885dec0cd24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc9fe1-17c8-4e1d-aeb8-c4214e881280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc9fe1-17c8-4e1d-aeb8-c4214e881280.jpg?1",
             "name": "Grim Monolith",
             "text": "Grim Monolith does not untap during your untap phase.\noc\nT: Add three colorless mana to your mana pool. Play this ability as a mana source.\no4: Untap Grim Monolith.",
             "colours": [],
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "40ce73a9-2024-5feb-a916-f87d4d4d1e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad925fb0-1d5c-44a0-8347-202a38c23107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad925fb0-1d5c-44a0-8347-202a38c23107.jpg?1",
             "name": "Iron Maiden",
             "text": "During each of your opponent's upkeeps, Iron Maiden deals 1 damage to that player for each card more than four in his or her hand.",
             "colours": [],
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "5fc70b2f-655e-5f7e-a36e-ea6a1bfce06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb38309-c02c-496c-894f-786a2f6e3d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb38309-c02c-496c-894f-786a2f6e3d1c.jpg?1",
             "name": "Jhoira's Toolbox",
             "text": "o2: Regenerate target artifact creature.",
             "colours": [],
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "d290f0dd-ff0e-5387-8f5b-d922d84a90d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15d33d6-7213-4482-a1be-ac0a73644af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15d33d6-7213-4482-a1be-ac0a73644af6.jpg?1",
             "name": "Memory Jar",
             "text": "oc\nT, Sacrifice Memory Jar: Each player sets aside his or her hand, face down, and draws seven cards. At end of turn, each player discards his or her hand and returns to his or her hand each card he or she set aside this way.",
             "colours": [],
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "2065bd1f-8ae1-52fe-a5d8-dc010774cf56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfdebbe-6432-426f-ac2a-5a9af3047813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfdebbe-6432-426f-ac2a-5a9af3047813.jpg?1",
             "name": "Quicksilver Amulet",
             "text": "o4, oc\nT: Choose a creature card in your hand and put that creature into play.",
             "colours": [],
@@ -4293,7 +4293,7 @@
         },
         {
             "id": "18fb2a65-dcab-5f21-b458-02cd735c7bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09dc9b-ed01-49de-9675-48c41f428385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09dc9b-ed01-49de-9675-48c41f428385.jpg?1",
             "name": "Ring of Gix",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\no1, oc\nT: Tap target artifact, creature, or land.",
             "colours": [],
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "2de0d9ef-5e3f-5ae4-a16d-fa62a76e3805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14aa4474-96a0-4c1d-a09d-73b9c1073b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14aa4474-96a0-4c1d-a09d-73b9c1073b00.jpg?1",
             "name": "Scrapheap",
             "text": "Whenever an artifact or enchantment is put into your graveyard from play, gain 1 life.",
             "colours": [],
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "bd8693e8-5b29-5509-ba0a-7cfb54f1e8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c3666-5ba0-4f0a-adbe-a97af0aa28d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c3666-5ba0-4f0a-adbe-a97af0aa28d1.jpg?1",
             "name": "Thran Lens",
             "text": "All permanents are colorless.",
             "colours": [],
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "ff70e14d-8c48-5516-a230-958ae4276c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5908714a-be91-4279-b87e-e2bc09dbaaba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5908714a-be91-4279-b87e-e2bc09dbaaba.jpg?1",
             "name": "Thran War Machine",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nThran War Machine attacks each turn if able.",
             "colours": [],
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "7b073425-5f56-5f68-b6d0-f87039bf5c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f005ae-fca1-4a48-84a3-4b217ac879ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f005ae-fca1-4a48-84a3-4b217ac879ce.jpg?1",
             "name": "Thran Weaponry",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nYou may choose not to untap Thran Weaponry during your untap phase.\no2, oc\nT: All creatures get +2/+2 as long as Thran Weaponry remains tapped.",
             "colours": [],
@@ -4436,7 +4436,7 @@
         },
         {
             "id": "8a94ad84-6833-5720-bd4b-8ec429ece93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6241755c-ff3d-44db-a99d-960bea54633e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6241755c-ff3d-44db-a99d-960bea54633e.jpg?1",
             "name": "Ticking Gnomes",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nSacrifice Ticking Gnomes: Ticking Gnomes deals 1 damage to target creature or player.",
             "colours": [],
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "341537dd-7c54-5a0b-86e9-485a922d2e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f0d4b-c13e-48a6-915f-b0edd2ac0ae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f0d4b-c13e-48a6-915f-b0edd2ac0ae8.jpg?1",
             "name": "Urza's Blueprints",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\noc\nT: Draw a card.",
             "colours": [],
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "903a0972-1ecf-559d-94ee-f39d7eaab352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87edc873-169a-4cd3-8a94-84b5810b5ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87edc873-169a-4cd3-8a94-84b5810b5ed8.jpg?1",
             "name": "Wheel of Torture",
             "text": "During each of your opponents' upkeeps, Wheel of Torture deals 1 damage to that player for each card fewer than three in his or her hand.",
             "colours": [],
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "6f0dc7d4-ec1a-5a6e-bc13-9d336279fc5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3ede87-b026-4781-81ab-8652664f8e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3ede87-b026-4781-81ab-8652664f8e41.jpg?1",
             "name": "Faerie Conclave",
             "text": "Faerie Conclave comes into play tapped.\noc\nT: Add one blue mana to your mana pool.\no1oo\nU Faerie Conclave becomes a 2/1 blue creature with flying until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "cc7b0d64-1895-5bab-82ab-58db87ead554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96503ed7-aa68-439f-95b0-6ac2c48e3935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96503ed7-aa68-439f-95b0-6ac2c48e3935.jpg?1",
             "name": "Forbidding Watchtower",
             "text": "Forbidding Watchtower comes into play tapped.\noc\nT: Add one white mana to your mana pool.\no1oo\nW Forbidding Watchtower becomes a 1/5 white creature until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "e6f2d060-8dcc-564d-8e94-88c8fa854290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09ecef-1e30-4206-9648-8fe5c8a71c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09ecef-1e30-4206-9648-8fe5c8a71c71.jpg?1",
             "name": "Ghitu Encampment",
             "text": "Ghitu Encampment comes into play tapped.\noc\nT: Add one red mana to your mana pool.\no1oo\nR Ghitu Encampment becomes a 2/1 red creature with first strike until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "042963f2-73d6-514a-b68e-4fdada5bc958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ffec42-57f7-4592-99ab-6284d59829a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ffec42-57f7-4592-99ab-6284d59829a1.jpg?1",
             "name": "Spawning Pool",
             "text": "Spawning Pool comes into play tapped.\noc\nT: Add one black mana to your mana pool.\no1oo\nB Spawning Pool becomes a 1/1 black creature with \"oo\nB Regenerate this creature\" until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4643,7 +4643,7 @@
         },
         {
             "id": "001f424c-6ae7-55f8-8a47-b396d77bc59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02212bd8-0c0f-4e8e-99f1-a8477476c03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02212bd8-0c0f-4e8e-99f1-a8477476c03a.jpg?1",
             "name": "Treetop Village",
             "text": "Treetop Village comes into play tapped.\noc\nT: Add one green mana to your mana pool.\no1oo\nG Treetop Village becomes a 3/3 green creature with trample until end of turn. This creature still counts as a land.",
             "colours": [],

--- a/Assets/Resources/Sets/UMA.json
+++ b/Assets/Resources/Sets/UMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "05c7bdc4-44ed-5902-83cb-e8dfec9afba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf632ef-70e3-46f2-af21-14ea7ef30237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf632ef-70e3-46f2-af21-14ea7ef30237.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all colored permanents they control.",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "288f57e6-ef6f-574d-962a-0c75610bae96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03648eff-8652-4750-a3d2-3338ce9e5a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03648eff-8652-4750-a3d2-3338ce9e5a81.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast this spell, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "c4200f49-324e-5bc7-b756-9dd0b4c84459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3909816-5cc2-4712-bc7d-534ae0b9229c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3909816-5cc2-4712-bc7d-534ae0b9229c.jpg?1",
             "name": "Eldrazi Conscription",
             "text": "Enchant creature\nEnchanted creature gets +10/+10 and has trample and annihilator 2. (Whenever it attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "6e19a078-9ed1-55de-bc16-9e1cc2c92a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -129,7 +129,7 @@
         },
         {
             "id": "351d222e-eb1d-5d2d-9fcf-941df021e2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69714257-2848-48e1-95cf-cdb6595215f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69714257-2848-48e1-95cf-cdb6595215f0.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -161,7 +161,7 @@
         },
         {
             "id": "95fd5ccb-168d-581f-aa9a-ea8e96d3cbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d47a1c7-d32b-425a-b15d-24eb35318f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d47a1c7-d32b-425a-b15d-24eb35318f6f.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -193,7 +193,7 @@
         },
         {
             "id": "7cb58593-21c9-5444-b943-234bdd0d07e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe0f77f-5092-4372-83fb-269dfb11f9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe0f77f-5092-4372-83fb-269dfb11f9b5.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -225,7 +225,7 @@
         },
         {
             "id": "ad6d1578-7ab6-58f3-ae64-8b282cd56157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda0fd38-38e6-4e9b-9c17-4d855e01b1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda0fd38-38e6-4e9b-9c17-4d855e01b1e1.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each combat if able.",
             "colours": [],
@@ -255,7 +255,7 @@
         },
         {
             "id": "02f098cf-93bc-5a4e-8d29-724d3b273cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f39f9-fbdf-4096-9bd7-a7b2481e2dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f39f9-fbdf-4096-9bd7-a7b2481e2dbd.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "First strike\nWhen Ancestor's Chosen enters the battlefield, you gain 1 life for each card in your graveyard.",
             "colours": [
@@ -290,7 +290,7 @@
         },
         {
             "id": "c23c14ab-26a1-587c-8f6a-e38b51797aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03fc1f1-31f6-4e52-87d0-e3d18ea60d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03fc1f1-31f6-4e52-87d0-e3d18ea60d3b.jpg?1",
             "name": "Angelic Renewal",
             "text": "Whenever a creature is put into your graveyard from the battlefield, you may sacrifice Angelic Renewal. If you do, return that card to the battlefield.",
             "colours": [
@@ -322,7 +322,7 @@
         },
         {
             "id": "10bcd0b5-e33a-5ec4-80f2-f8c6e596d0d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bece9c5-1a2f-44e1-b7f4-9498da558bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bece9c5-1a2f-44e1-b7f4-9498da558bc8.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "0e871107-1ee2-566b-9d00-cc26d52b342f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94507660-cf60-4fd8-a796-7a6e6f28396d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94507660-cf60-4fd8-a796-7a6e6f28396d.jpg?1",
             "name": "Conviction",
             "text": "Enchant creature\nEnchanted creature gets +1/+3.\n{W}: Return Conviction to its owner's hand.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "a35e078e-d519-513c-92d5-d6c3d486444f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec653f1-32ce-4eb5-8d18-f56a7bbabac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec653f1-32ce-4eb5-8d18-f56a7bbabac6.jpg?1",
             "name": "Dawn Charm",
             "text": "Choose one \u2014\n\u2022 Prevent all combat damage that would be dealt this turn.\n\u2022 Regenerate target creature.\n\u2022 Counter target spell that targets you.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "f0fd7a1d-33a5-5249-88c7-aeda5e5ad310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818537cd-4c95-4538-b61f-c276a6fc8864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818537cd-4c95-4538-b61f-c276a6fc8864.jpg?1",
             "name": "Daybreak Coronet",
             "text": "Enchant creature with another Aura attached to it\nEnchanted creature gets +3/+3 and has first strike, vigilance, and lifelink.",
             "colours": [
@@ -457,7 +457,7 @@
         },
         {
             "id": "f3b1addf-c375-5753-9ce7-cff99bfbd908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189e0728-94e3-43af-a341-d2bbb33b6b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189e0728-94e3-43af-a341-d2bbb33b6b32.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "e310cf84-2575-5cd0-8313-079e83311e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8e887e-bf53-44e3-b3e5-d00d8974d0b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8e887e-bf53-44e3-b3e5-d00d8974d0b3.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "c5a54f1b-a2e0-5a0c-905a-3e4b8843f683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02e3c30-e540-4d7b-a17b-3eece63743cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02e3c30-e540-4d7b-a17b-3eece63743cb.jpg?1",
             "name": "Fiend Hunter",
             "text": "When Fiend Hunter enters the battlefield, you may exile another target creature.\nWhen Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -560,7 +560,7 @@
         },
         {
             "id": "5fb3457f-dcab-543c-b0e7-77e8d589426e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d95d57f-daaf-49d2-b26f-2058c065f0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d95d57f-daaf-49d2-b26f-2058c065f0fe.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "3fd293a6-d0f0-5120-a8ff-69103aee2130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753dd235-55d3-4124-9b43-74517534bd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753dd235-55d3-4124-9b43-74517534bd87.jpg?1",
             "name": "Heliod's Pilgrim",
             "text": "When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -627,7 +627,7 @@
         },
         {
             "id": "d1ef694b-3bac-55b5-979a-100217937482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc9a63b-e7cd-404a-8d5c-0c1396e16d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc9a63b-e7cd-404a-8d5c-0c1396e16d0b.jpg?1",
             "name": "Hero of Iroas",
             "text": "Aura spells you cast cost {1} less to cast.\nHeroic \u2014 Whenever you cast a spell that targets Hero of Iroas, put a +1/+1 counter on Hero of Iroas.",
             "colours": [
@@ -662,7 +662,7 @@
         },
         {
             "id": "190b3a1d-1365-5a5a-b7aa-2e823a993c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87128a82-bcde-4def-9447-0ab8165d6b5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87128a82-bcde-4def-9447-0ab8165d6b5e.jpg?1",
             "name": "Hyena Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has first strike.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "b67b7df3-0b5b-5d10-8696-7622d5096d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ba6543-ede7-45a5-8e8d-e17d3f545d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ba6543-ede7-45a5-8e8d-e17d3f545d3f.jpg?1",
             "name": "Icatian Crier",
             "text": "{1}{W}, {T}, Discard a card: Create two 1/1 white Citizen creature tokens.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "80308f62-a223-5b5f-88e5-b59f273cf847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3170852-60a9-46bc-8183-b1a65fc3b82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3170852-60a9-46bc-8183-b1a65fc3b82b.jpg?1",
             "name": "Lotus-Eye Mystics",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Lotus-Eye Mystics enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "7dbdc989-a069-525d-bf97-b0f94f0ccf00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9195c-cd12-47b7-8ebc-5c4a77a9002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9195c-cd12-47b7-8ebc-5c4a77a9002a.jpg?1",
             "name": "Mammoth Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has vigilance.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "43334efa-a18e-505a-8ec0-a32337ff7c62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d4a6b-af72-4d44-a25f-dce8e12da727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d4a6b-af72-4d44-a25f-dce8e12da727.jpg?1",
             "name": "Martyr of Sands",
             "text": "{1}, Reveal X white cards from your hand, Sacrifice Martyr of Sands: You gain three times X life.",
             "colours": [
@@ -835,7 +835,7 @@
         },
         {
             "id": "63cf5042-0594-554b-8bff-135d69911e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3459d9-a667-4cee-9b39-844013576d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3459d9-a667-4cee-9b39-844013576d0b.jpg?1",
             "name": "Miraculous Recovery",
             "text": "Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.",
             "colours": [
@@ -867,7 +867,7 @@
         },
         {
             "id": "ce51cbe9-065e-511e-a0da-ed86299bba06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d22985-4354-4015-bd74-0ddf4f0cdf17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d22985-4354-4015-bd74-0ddf4f0cdf17.jpg?1",
             "name": "Phalanx Leader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Phalanx Leader, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "b12965cf-d3d7-582b-8a69-d6729ad40a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b300df0-c867-41e6-a1fd-fe547ed3dc51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b300df0-c867-41e6-a1fd-fe547ed3dc51.jpg?1",
             "name": "Rally the Peasants",
             "text": "Creatures you control get +2/+0 until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -935,7 +935,7 @@
         },
         {
             "id": "898b7dbd-98ed-5cd1-9249-8608a19a96e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced55b-27e2-4549-90e4-31c9718e1395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced55b-27e2-4549-90e4-31c9718e1395.jpg?1",
             "name": "Repel the Darkness",
             "text": "Tap up to two target creatures.\nDraw a card.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "1bfcefe6-3156-5d50-99d4-1977e5f7b7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a176b295-9406-4d6b-b15c-e81a72e66874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a176b295-9406-4d6b-b15c-e81a72e66874.jpg?1",
             "name": "Resurrection",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -999,7 +999,7 @@
         },
         {
             "id": "7f20e0de-35bc-5c06-b4b8-218dfead93e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcf9b52-d249-41e7-8ed1-ba9acc816f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcf9b52-d249-41e7-8ed1-ba9acc816f30.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "58bec4ad-afeb-5459-8473-ed8f3da6b25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b45bdd-829a-4fc1-ad37-17c2bd57fac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b45bdd-829a-4fc1-ad37-17c2bd57fac8.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "Flying\nAt the beginning of your upkeep, you may return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "a05977f6-93ae-5bb1-aeb5-ba7e6cebe08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810e22f-11fd-48a8-a057-2d80f3088691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810e22f-11fd-48a8-a057-2d80f3088691.jpg?1",
             "name": "Ronom Unicorn",
             "text": "Sacrifice Ronom Unicorn: Destroy target enchantment.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "c486e539-7dbb-521c-87b1-ad2f58797dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c401fabd-52fb-4c59-9c72-10ff97dda45f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c401fabd-52fb-4c59-9c72-10ff97dda45f.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
             "colours": [
@@ -1135,7 +1135,7 @@
         },
         {
             "id": "469085c4-6105-5fbb-9e6e-cc8b3596a6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64393586-42c6-4874-9473-85c63c7ed2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64393586-42c6-4874-9473-85c63c7ed2ad.jpg?1",
             "name": "Sigil of the New Dawn",
             "text": "Whenever a creature is put into your graveyard from the battlefield, you may pay {1}{W}. If you do, return that card to your hand.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "6c6d960b-a8ef-559d-9925-eef50579ed00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41a35c6-14d9-4b8f-88f1-f1442e4ef222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41a35c6-14d9-4b8f-88f1-f1442e4ef222.jpg?1",
             "name": "Skyspear Cavalry",
             "text": "Flying, double strike",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "a7e172e9-d995-5ccf-b606-3d35181a7744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3ee404-0501-41bc-b56a-ebf16f693511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3ee404-0501-41bc-b56a-ebf16f693511.jpg?1",
             "name": "Spirit Cairn",
             "text": "Whenever a player discards a card, you may pay {W}. If you do, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -1234,7 +1234,7 @@
         },
         {
             "id": "6ae222ce-482b-500e-8cdb-63aa16c208b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e53129-c49b-4bb8-a816-629fc87e58bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e53129-c49b-4bb8-a816-629fc87e58bb.jpg?1",
             "name": "Sublime Archangel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nOther creatures you control have exalted. (If a creature has multiple instances of exalted, each triggers separately.)",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "80064910-e5f0-5f59-a569-7093b9129897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820096b5-0d64-47a0-88a4-17d3f24cb165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820096b5-0d64-47a0-88a4-17d3f24cb165.jpg?1",
             "name": "Swift Reckoning",
             "text": "Spell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may cast Swift Reckoning as though it had flash.\nDestroy target tapped creature.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "7febf777-aa47-5698-9f89-366d661ef7ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51baeea2-a922-4e98-8253-f395546c30c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51baeea2-a922-4e98-8253-f395546c30c8.jpg?1",
             "name": "Tethmos High Priest",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Tethmos High Priest, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "4f43738e-c0f6-5a71-9160-f42005b8808f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1515e039-b838-40b6-b087-eb9e9d9ff008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1515e039-b838-40b6-b087-eb9e9d9ff008.jpg?1",
             "name": "Wall of Reverence",
             "text": "Defender, flying\nAt the beginning of your end step, you may gain life equal to the power of target creature you control.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "b33f129d-04dd-5bfa-baa5-24ef5ed7bbfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02599bd-c5d8-4bdc-9478-a7bad8185552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02599bd-c5d8-4bdc-9478-a7bad8185552.jpg?1",
             "name": "Wandering Champion",
             "text": "Whenever Wandering Champion deals combat damage to a player, if you control a blue or red permanent, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "06143991-52a7-5f0e-84a1-8865a064698f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b189050-522b-4b8a-b4e6-1f5158ebe519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b189050-522b-4b8a-b4e6-1f5158ebe519.jpg?1",
             "name": "Wingsteed Rider",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.",
             "colours": [
@@ -1440,7 +1440,7 @@
         },
         {
             "id": "3f8073ad-f3ae-566a-84f6-25e4b19be6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f04e69-aa5b-495c-ab17-31fc2ff7288a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f04e69-aa5b-495c-ab17-31fc2ff7288a.jpg?1",
             "name": "Aethersnipe",
             "text": "When Aethersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "36e15f96-82f0-59cc-ba1e-12b4b73f3dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc258713-6ce3-44e0-9b4b-8fa7d1d093a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc258713-6ce3-44e0-9b4b-8fa7d1d093a1.jpg?1",
             "name": "Archaeomancer",
             "text": "When Archaeomancer enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "6663837c-665b-503b-ab35-717f9e40c44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6c2-0f72-4e79-a55d-1f06dffa48c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6c2-0f72-4e79-a55d-1f06dffa48c2.jpg?1",
             "name": "Back to Basics",
             "text": "Nonbasic lands don't untap during their controllers' untap steps.",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "1696f7b9-1edd-5c89-a531-2eef2885fade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472de0e2-c15b-49c4-b2fd-74b776daac34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472de0e2-c15b-49c4-b2fd-74b776daac34.jpg?1",
             "name": "Circular Logic",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1573,7 +1573,7 @@
         },
         {
             "id": "eb0c8680-6e92-5e57-9cd8-045c52afc291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6c69-e5c4-47b0-b226-4e1d84fabfa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6c69-e5c4-47b0-b226-4e1d84fabfa7.jpg?1",
             "name": "Defy Gravity",
             "text": "Target creature gains flying until end of turn.\nFlashback {U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "d75c9e2e-3be5-5ae2-ae4e-2d11a5fec543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093610b6-3fe3-4f12-859f-569857fa341b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093610b6-3fe3-4f12-859f-569857fa341b.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Put the top card of your library into your graveyard: Add {C}.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "8adfd3be-8dfc-5995-8bbb-f0eb9d1113cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cd4184-93ce-4005-b6d1-140afa3dd429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cd4184-93ce-4005-b6d1-140afa3dd429.jpg?1",
             "name": "Dig Through Time",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nLook at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "860d21e5-e629-5928-99b5-7823b1a11fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b20c4-f69b-45ed-8c9e-50847f215e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b20c4-f69b-45ed-8c9e-50847f215e73.jpg?1",
             "name": "Disrupting Shoal",
             "text": "You may exile a blue card with converted mana cost X from your hand rather than pay this spell's mana cost.\nCounter target spell if its converted mana cost is X.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "6f448448-c1bb-5bac-880b-34fe4fe7ebaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527bc84-fa66-4763-a035-344e6458e54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527bc84-fa66-4763-a035-344e6458e54b.jpg?1",
             "name": "Dreamscape Artist",
             "text": "{2}{U}, {T}, Discard a card, Sacrifice a land: Search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "f98483bf-deca-5c73-acc4-a31b40a0f43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc0fa64-0e2e-4f7a-8516-20c06fc57351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc0fa64-0e2e-4f7a-8516-20c06fc57351.jpg?1",
             "name": "Eel Umbra",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1775,7 +1775,7 @@
         },
         {
             "id": "45bf07f3-68a6-58bc-a868-d13ef46ee63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b770973-2061-44cb-8c02-b2251d711e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b770973-2061-44cb-8c02-b2251d711e92.jpg?1",
             "name": "Flight of Fancy",
             "text": "Enchant creature\nWhen Flight of Fancy enters the battlefield, draw two cards.\nEnchanted creature has flying.",
             "colours": [
@@ -1809,7 +1809,7 @@
         },
         {
             "id": "b9bf282f-2d26-5277-afc4-a87133d9f4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b39fd6-9240-4f76-b12c-e7d9aa88f061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b39fd6-9240-4f76-b12c-e7d9aa88f061.jpg?1",
             "name": "Foil",
             "text": "You may discard an Island card and another card rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1841,7 +1841,7 @@
         },
         {
             "id": "e78298d6-463c-5dd9-85fe-7147e3bc1fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70dcc0d-aaa2-4815-be83-daafe441ceb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70dcc0d-aaa2-4815-be83-daafe441ceb4.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "6f7d304f-f335-515c-a367-3a0ab3df49ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a6d5a5-ea8a-4d13-a8a6-11587f1bde44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a6d5a5-ea8a-4d13-a8a6-11587f1bde44.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "bbb2d174-c8d5-51d3-96c7-8ea065069372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9af767-42da-46c7-a2b8-3957b2e3063f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9af767-42da-46c7-a2b8-3957b2e3063f.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "Flying\n{U}, Sacrifice Glen Elendra Archmage: Counter target noncreature spell.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "1e40e99b-977e-52e8-81eb-8618592c8913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c99c962-aa33-4e19-96b2-7a05b97d06d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c99c962-aa33-4e19-96b2-7a05b97d06d4.jpg?1",
             "name": "Iridescent Drake",
             "text": "Flying\nWhen Iridescent Drake enters the battlefield, put target Aura card from a graveyard onto the battlefield under your control attached to Iridescent Drake.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "e830232a-8c0f-548b-b0a8-0a8f27eb6c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e40878-358d-48ec-a35f-3d9867728143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e40878-358d-48ec-a35f-3d9867728143.jpg?1",
             "name": "Just the Wind",
             "text": "Return target creature to its owner's hand.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2007,7 +2007,7 @@
         },
         {
             "id": "e518a1e0-0222-553f-852d-2503aeefc28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608567fd-9f94-4058-831a-77cb6019ef02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608567fd-9f94-4058-831a-77cb6019ef02.jpg?1",
             "name": "Laboratory Maniac",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "909ec540-187d-587e-a370-0c0badf81215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa314d92-51e5-4c09-963c-761e83dc84bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa314d92-51e5-4c09-963c-761e83dc84bc.jpg?1",
             "name": "Living Lore",
             "text": "As Living Lore enters the battlefield, exile an instant or sorcery card from your graveyard.\nLiving Lore's power and toughness are each equal to the exiled card's converted mana cost.\nWhenever Living Lore deals combat damage, you may sacrifice it. If you do, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "6c97a1d1-d0d9-59fd-bb40-6dddfe9fab75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117ed81-7b5c-4e29-b958-6126d48ac5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117ed81-7b5c-4e29-b958-6126d48ac5a6.jpg?1",
             "name": "Magus of the Bazaar",
             "text": "{T}: Draw two cards, then discard three cards.",
             "colours": [
@@ -2111,7 +2111,7 @@
         },
         {
             "id": "45b505dd-9fb7-57f7-85b8-52b1045282e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855de173-6bec-457b-828e-28678b7d396e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855de173-6bec-457b-828e-28678b7d396e.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "f972585f-574c-5194-98d8-e6eb1b745e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a288d3-c769-4681-828b-9b7579d93469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a288d3-c769-4681-828b-9b7579d93469.jpg?1",
             "name": "Marang River Prowler",
             "text": "Marang River Prowler can't block and can't be blocked.\nYou may cast Marang River Prowler from your graveyard as long as you control a black or green permanent.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "2ec5246b-f0f7-514b-b504-bb3e59585a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5a2f5e-b9b3-41ee-a659-76dd763bad65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5a2f5e-b9b3-41ee-a659-76dd763bad65.jpg?1",
             "name": "Mystic Retrieval",
             "text": "Return target instant or sorcery card from your graveyard to your hand.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2213,7 +2213,7 @@
         },
         {
             "id": "d13749b6-1e41-50e8-b707-34e000b1b9a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbca952-b4e8-4833-aee3-7da8ae82906e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbca952-b4e8-4833-aee3-7da8ae82906e.jpg?1",
             "name": "Rise from the Tides",
             "text": "Create a tapped 2/2 black Zombie creature token for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "e5e1bb76-9ffa-5a39-919a-f333ed01e3d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d72a34-0f31-4fec-b5a5-4574199bc312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d72a34-0f31-4fec-b5a5-4574199bc312.jpg?1",
             "name": "Rune Snag",
             "text": "Counter target spell unless its controller pays {2} plus an additional {2} for each card named Rune Snag in each graveyard.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "8af8f805-a52c-53fa-a6e4-fa0037bc1929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712408f9-4bc2-447d-8efe-59c5d53ae364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712408f9-4bc2-447d-8efe-59c5d53ae364.jpg?1",
             "name": "Skywing Aven",
             "text": "Flying\nDiscard a card: Return Skywing Aven to its owner's hand.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "05795614-2951-5a56-9b61-1b67ff6d4ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1766d117-6ee1-4103-88e8-47b932a94d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1766d117-6ee1-4103-88e8-47b932a94d65.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "d25046d3-845e-5722-8a48-7f0521acaf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41765e-43fe-461d-baeb-ee30d13d2d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41765e-43fe-461d-baeb-ee30d13d2d93.jpg?1",
             "name": "Snapcaster Mage",
             "text": "Flash\nWhen Snapcaster Mage enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "f90184bc-6710-53b1-9d41-72f95ec62a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736f293a-10b5-43bc-8aad-cb63f00601a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736f293a-10b5-43bc-8aad-cb63f00601a6.jpg?1",
             "name": "Stitched Drake",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nFlying",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "7b2a221c-9be8-54a0-86b5-9b04e3bbb66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717e34b9-161e-4b11-afb1-f41ee8027433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717e34b9-161e-4b11-afb1-f41ee8027433.jpg?1",
             "name": "Stitcher's Apprentice",
             "text": "{1}{U}, {T}: Create a 2/2 blue Homunculus creature token, then sacrifice a creature.",
             "colours": [
@@ -2448,7 +2448,7 @@
         },
         {
             "id": "4b7d52a5-6f30-5274-bb45-eaf38193b92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4faef057-8734-442b-a213-c309c219cdee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4faef057-8734-442b-a213-c309c219cdee.jpg?1",
             "name": "Stream of Consciousness",
             "text": "Target player shuffles up to four target cards from their graveyard into their library.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "64ee7a7c-2123-5f65-93de-55d8fe0c631e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c3936-1d30-4b1b-85ae-64c2be7d37c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c3936-1d30-4b1b-85ae-64c2be7d37c0.jpg?1",
             "name": "Sultai Skullkeeper",
             "text": "When Sultai Skullkeeper enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "986f4b04-21a1-5161-8128-3c0aa302656f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74e76-c6ce-4107-8816-0be8c20d7617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74e76-c6ce-4107-8816-0be8c20d7617.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "dc3ed620-63db-5469-9459-dc6acad4fc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270b93e-8cd2-4668-982a-f4c4628da9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270b93e-8cd2-4668-982a-f4c4628da9d9.jpg?1",
             "name": "Temporal Manipulation",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "aa559b7f-090f-5970-865a-503d4317e16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73db9c10-109a-417f-81cd-489d9510cc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73db9c10-109a-417f-81cd-489d9510cc78.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "90a92698-0b3e-5db3-8df6-1d8fd8168771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff91245-57d8-4020-b260-495c938a515b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff91245-57d8-4020-b260-495c938a515b.jpg?1",
             "name": "Treasure Cruise",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "326a85f3-0571-5af8-b5a3-09f31e94f618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66b93a-11a6-4861-a775-d309b7adc461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66b93a-11a6-4861-a775-d309b7adc461.jpg?1",
             "name": "Unstable Mutation",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nAt the beginning of the upkeep of enchanted creature's controller, put a -1/-1 counter on that creature.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "ec1f67e5-1903-506e-8452-6e9e904f7031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b97772-9490-4db3-b4dd-a87d973680a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b97772-9490-4db3-b4dd-a87d973680a5.jpg?1",
             "name": "Visions of Beyond",
             "text": "Draw a card. If a graveyard has twenty or more cards in it, draw three cards instead.",
             "colours": [
@@ -2716,7 +2716,7 @@
         },
         {
             "id": "b02f4068-2594-51fd-8ebc-478a0c2e02d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdbe6b5-7f67-42f1-be8f-637c35417925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdbe6b5-7f67-42f1-be8f-637c35417925.jpg?1",
             "name": "Whirlwind Adept",
             "text": "Hexproof\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "fb905337-235a-5701-9d9d-1f5c0b0fe566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f20b88-7b48-4d3b-b836-c7aef71cd337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f20b88-7b48-4d3b-b836-c7aef71cd337.jpg?1",
             "name": "Appetite for Brains",
             "text": "Target opponent reveals their hand. You choose a card from it with converted mana cost 4 or greater and exile that card.",
             "colours": [
@@ -2783,7 +2783,7 @@
         },
         {
             "id": "968ad7ce-9bb4-53f4-a7a8-2fe621623185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d86ad3-e0a1-43da-9dc1-a9028b719c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d86ad3-e0a1-43da-9dc1-a9028b719c99.jpg?1",
             "name": "Apprentice Necromancer",
             "text": "{B}, {T}, Sacrifice Apprentice Necromancer: Return target creature card from your graveyard to the battlefield. That creature gains haste. At the beginning of the next end step, sacrifice it.",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "f993a629-cd4c-5d87-b071-40d2d3484d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547872bd-d2b3-4c24-b3fb-481e0c90c3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547872bd-d2b3-4c24-b3fb-481e0c90c3c0.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "287c6e8e-9b14-5d88-8d8b-750e43c2fb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a788fb3-fc21-47b2-b387-ceff438969af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a788fb3-fc21-47b2-b387-ceff438969af.jpg?1",
             "name": "Bloodflow Connoisseur",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "558143cf-fcd8-5bca-9270-2ed114676a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faaa657-8b02-41a9-8a99-31a223d2caa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faaa657-8b02-41a9-8a99-31a223d2caa5.jpg?1",
             "name": "Bridge from Below",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, if Bridge from Below is in your graveyard, create a 2/2 black Zombie creature token.\nWhen a creature is put into an opponent's graveyard from the battlefield, if Bridge from Below is in your graveyard, exile Bridge from Below.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "66b727f1-4e3c-542f-88a6-983f57e01623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f51145-aade-4955-b9e7-4a34074253d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f51145-aade-4955-b9e7-4a34074253d6.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards, put them into your graveyard, then shuffle your library.",
             "colours": [
@@ -2951,7 +2951,7 @@
         },
         {
             "id": "2e3becb4-5f3a-5eab-9f0a-7ca9f6da6b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36a583a-d4be-4589-a43c-a2854de062c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36a583a-d4be-4589-a43c-a2854de062c6.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "96dc1ffb-6c7d-5296-bef9-cf041b3aa19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d66d3-03e1-4a6e-bb8e-7ad32faea2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d66d3-03e1-4a6e-bb8e-7ad32faea2bc.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "c54d4fda-25f7-52b9-97e7-d2bd2fa90945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320791b-a64f-4249-9a78-7b28cfe58743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320791b-a64f-4249-9a78-7b28cfe58743.jpg?1",
             "name": "Dark Dabbling",
             "text": "Regenerate target creature. Draw a card.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, also regenerate each other creature you control.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "cb88210b-03b2-54e6-94a0-520500f34167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d0a239-4d45-4762-968a-d4b9479346d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d0a239-4d45-4762-968a-d4b9479346d9.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "d9b5061e-c871-58b4-8393-abf7f6f6b232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdbc231-5316-4abd-9d8d-d87cff2c9847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdbc231-5316-4abd-9d8d-d87cff2c9847.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "240fffcc-7fd9-5a90-b5e7-79740aea43b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66f864b-b1bb-4596-93b8-3b4bfe6b1332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66f864b-b1bb-4596-93b8-3b4bfe6b1332.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card and put that card into your graveyard. Then shuffle your library.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "1e5f68fc-6c1a-5151-8a2c-c322ff21ff02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1ef824-306c-4975-abca-19f0bd77449f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1ef824-306c-4975-abca-19f0bd77449f.jpg?1",
             "name": "Fume Spitter",
             "text": "Sacrifice Fume Spitter: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "18b42212-ca2c-55ae-bf4c-196c86caa155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e27974c-1279-486f-8e14-b326cd90cb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e27974c-1279-486f-8e14-b326cd90cb06.jpg?1",
             "name": "Ghoulcaller's Accomplice",
             "text": "{3}{B}, Exile Ghoulcaller's Accomplice from your graveyard: Create a 2/2 black Zombie creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3218,7 +3218,7 @@
         },
         {
             "id": "13c3122d-6e92-5144-9c09-578f6629434d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8f7cfd-88db-4cc1-b65f-3462332a2873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8f7cfd-88db-4cc1-b65f-3462332a2873.jpg?1",
             "name": "Ghoulsteed",
             "text": "{2}{B}, Discard two cards: Return Ghoulsteed from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "d3b69ef6-87dc-5550-ad77-be5cc5a7b317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfb37f-aa3f-46ca-9bff-01a874f8cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfb37f-aa3f-46ca-9bff-01a874f8cc59.jpg?1",
             "name": "Golgari Thug",
             "text": "When Golgari Thug dies, put target creature card from your graveyard on top of your library.\nDredge 4 (If you would draw a card, instead you may put exactly four cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "8459a876-abcf-51b1-a1c0-354343b5be88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261205d-3506-4f0a-98ce-690f40df7a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261205d-3506-4f0a-98ce-690f40df7a5a.jpg?1",
             "name": "Goryo's Vengeance",
             "text": "Return target legendary creature card from your graveyard to the battlefield. That creature gains haste. Exile it at the beginning of the next end step.\nSplice onto Arcane {2}{B} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "e06e378a-b7a6-5544-9fb7-c783634e72d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30af93c-9cb6-48a2-92c2-92506969756a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30af93c-9cb6-48a2-92c2-92506969756a.jpg?1",
             "name": "Grave Scrabbler",
             "text": "Madness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nWhen Grave Scrabbler enters the battlefield, if its madness cost was paid, you may return target creature card from a graveyard to its owner's hand.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "a6354d24-96a6-5707-a594-cd31ea93c06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51b6c19-d8f8-4249-83c8-f3c4fa12291e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51b6c19-d8f8-4249-83c8-f3c4fa12291e.jpg?1",
             "name": "Grave Strength",
             "text": "Choose target creature. Put the top three cards of your library into your graveyard, then put a +1/+1 counter on that creature for each creature card in your graveyard.",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "f02de313-bbbb-59c1-b96e-e0a42e207109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedd44eb-f381-46e1-bcb0-88416b4ce33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedd44eb-f381-46e1-bcb0-88416b4ce33d.jpg?1",
             "name": "Gurmag Angler",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "726a4073-bfed-5a2d-bbe9-ced0ada6041b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2897581c-20ec-497e-9562-2d39ceca628e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2897581c-20ec-497e-9562-2d39ceca628e.jpg?1",
             "name": "Last Gasp",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -3455,7 +3455,7 @@
         },
         {
             "id": "45450cae-f41e-553f-b9e0-d92611d7c42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e653437e-2e56-4443-aec5-5bb7d8860238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e653437e-2e56-4443-aec5-5bb7d8860238.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "77295f9a-91e2-5fe2-b573-398fd99efc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150090cc-27ac-4d18-b6e6-3ddaa40c822e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150090cc-27ac-4d18-b6e6-3ddaa40c822e.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "53f073fa-1bed-5633-a45d-884f1ccd4868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8879190f-d8ff-47ce-a5d8-6a481a67236a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8879190f-d8ff-47ce-a5d8-6a481a67236a.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "c19b8c82-3ce9-5f9a-8e4d-3fba354a0164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1f42ee-7f4e-4b2a-b60b-750662878a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1f42ee-7f4e-4b2a-b60b-750662878a5c.jpg?1",
             "name": "Moan of the Unhallowed",
             "text": "Create two 2/2 black Zombie creature tokens.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "2b1fdd97-7ae1-5665-b0e8-3a7dc36293ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737679bd-b38f-402e-a6b2-7964da0f8d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737679bd-b38f-402e-a6b2-7964da0f8d2f.jpg?1",
             "name": "Offalsnout",
             "text": "Flash\nWhen Offalsnout leaves the battlefield, exile target card from a graveyard.\nEvoke {B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -3628,7 +3628,7 @@
         },
         {
             "id": "bfd8c717-84c4-511a-8c6b-cfb40c7b0528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d0f7a-8418-455a-aa0c-02e8c9ad7820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d0f7a-8418-455a-aa0c-02e8c9ad7820.jpg?1",
             "name": "Olivia's Dragoon",
             "text": "Discard a card: Olivia's Dragoon gains flying until end of turn.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "b0f3ef8f-2387-53ff-9555-64b66f9b4a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fc99dc-bfbe-4567-b791-6b1db96471ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fc99dc-bfbe-4567-b791-6b1db96471ec.jpg?1",
             "name": "Reanimate",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "21d0b2f5-e88a-5d53-b44a-e2680c47e1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d79c616-32d7-4d20-8dd8-8f56f5c04a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d79c616-32d7-4d20-8dd8-8f56f5c04a0a.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "089b65ce-969e-54c6-af8a-f9f5966a458a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0757cb66-7aa2-41a2-8efc-f3f35b70ab9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0757cb66-7aa2-41a2-8efc-f3f35b70ab9e.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from the battlefield, you may return that card to the battlefield at the beginning of the next end step if Shirei, Shizo's Caretaker is still on the battlefield.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "c4da91ac-4832-5fb5-bc9a-bafd6714468b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5b89f-ec60-46b5-9160-9255cbb858a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5b89f-ec60-46b5-9160-9255cbb858a9.jpg?1",
             "name": "Shriekmaw",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhen Shriekmaw enters the battlefield, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "16ea9ef5-5891-54d9-bc33-1831632f704c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475690db-4934-4c2e-b869-a6499d86a9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475690db-4934-4c2e-b869-a6499d86a9c5.jpg?1",
             "name": "Slum Reaper",
             "text": "When Slum Reaper enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "2a6ea82d-d878-5650-b747-2b10f9c81749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9133b267-295d-4987-b1d6-f32a85b66081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9133b267-295d-4987-b1d6-f32a85b66081.jpg?1",
             "name": "Songs of the Damned",
             "text": "Add {B} for each creature card in your graveyard.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "3eb858d0-2c72-547f-991b-978bbe844f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb97a96-2c56-4638-b971-00cdf1eafd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb97a96-2c56-4638-b971-00cdf1eafd43.jpg?1",
             "name": "Spoils of the Vault",
             "text": "Choose a card name. Reveal cards from the top of your library until you reveal a card with that name, then put that card into your hand. Exile all other cards revealed this way, and you lose 1 life for each of the exiled cards.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "c4df64ce-5c8c-554d-ad3c-42d396653748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b7d726-c395-4af4-aa6a-e8e0c0582a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b7d726-c395-4af4-aa6a-e8e0c0582a1f.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n{2}{GW}{GW}: Put the top two cards of your library into your graveyard, then return a nonland card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "f700e7de-a926-5f46-a85f-8ad7a18b8b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f689e20a-2c24-44a3-9e1b-7717df3d1948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f689e20a-2c24-44a3-9e1b-7717df3d1948.jpg?1",
             "name": "Twins of Maurer Estate",
             "text": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "ea7083a6-6818-5b38-bf58-3a6f4ccb8401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faffb7ad-4d85-48de-80c8-dcf2ebf190fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faffb7ad-4d85-48de-80c8-dcf2ebf190fd.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "9d073f7a-8387-5a76-b5c5-81e1650b6787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6883e3c-265e-408a-b733-35b89b66dabd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6883e3c-265e-408a-b733-35b89b66dabd.jpg?1",
             "name": "Unholy Hunger",
             "text": "Destroy target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you gain 2 life.",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "be37f35f-6526-556c-96b1-f5aa4b72e5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d295ac-3c83-47db-a324-aa4907bcefdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d295ac-3c83-47db-a324-aa4907bcefdd.jpg?1",
             "name": "Akroan Crusader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Crusader, create a 1/1 red Soldier creature token with haste.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "bf799f02-b59f-53da-9826-e528dc1b42a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0768df-40c3-4b07-9274-e619cae3dd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0768df-40c3-4b07-9274-e619cae3dd2b.jpg?1",
             "name": "Anger",
             "text": "Haste\nAs long as Anger is in your graveyard and you control a Mountain, creatures you control have haste.",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "a34676b5-03b7-531c-a621-0cdde3d36f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacc2881-26b8-4199-9b7d-e12c75effe6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacc2881-26b8-4199-9b7d-e12c75effe6e.jpg?1",
             "name": "Arena Athlete",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Arena Athlete, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "ba1c1f42-2cde-5cd5-bd80-0ec5b140b3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468d5308-2a6c-440e-a8d0-1c5e084afb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468d5308-2a6c-440e-a8d0-1c5e084afb82.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "5cde3046-67c3-53ab-bc45-1fec206a4484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e987cd-94a0-4332-89c4-c7662c8dc001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e987cd-94a0-4332-89c4-c7662c8dc001.jpg?1",
             "name": "Brazen Scourge",
             "text": "Haste",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "723599f5-1cbc-5f97-b890-99c698a4f416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ffb4-3c9d-4d5c-a927-8988166c2d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ffb4-3c9d-4d5c-a927-8988166c2d94.jpg?1",
             "name": "Conflagrate",
             "text": "Conflagrate deals X damage divided as you choose among any number of targets.\nFlashback\u2014{R}{R}, Discard X cards. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "d516086b-7978-5edc-b38e-b018a1736d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3825b85d-07df-43b9-a8d8-930863262d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3825b85d-07df-43b9-a8d8-930863262d83.jpg?1",
             "name": "Desperate Ritual",
             "text": "Add {R}{R}{R}.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "ff3b25aa-8b4c-5b91-b0b1-0a8cfc16715a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0865d7-3325-489f-bbe6-b7d2a43c23af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0865d7-3325-489f-bbe6-b7d2a43c23af.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "18e975ef-e176-55bb-9d6a-fea41704a61e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2610d0e0-2824-4d40-816b-e487ac8f0e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2610d0e0-2824-4d40-816b-e487ac8f0e03.jpg?1",
             "name": "Fiery Temper",
             "text": "Fiery Temper deals 3 damage to any target.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4336,7 +4336,7 @@
         },
         {
             "id": "941b54f8-9129-5db9-952a-a69bc766e6fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d7c90a-b999-4e0b-87df-7355d6c36fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d7c90a-b999-4e0b-87df-7355d6c36fb1.jpg?1",
             "name": "Firewing Phoenix",
             "text": "Flying\n{1}{R}{R}{R}: Return Firewing Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "bd37f254-779b-5ad2-8553-0acce2085f67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5879ce5-7bc0-4688-a506-8b0796a00485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5879ce5-7bc0-4688-a506-8b0796a00485.jpg?1",
             "name": "Furnace Celebration",
             "text": "Whenever you sacrifice another permanent, you may pay {2}. If you do, Furnace Celebration deals 2 damage to any target.",
             "colours": [
@@ -4402,7 +4402,7 @@
         },
         {
             "id": "6a71b548-1ad4-5b72-9eda-7aa48d3c2c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01c9474-90a1-4c2e-bd90-471ff4fd04e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01c9474-90a1-4c2e-bd90-471ff4fd04e5.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle your library.",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "c17afd96-e446-5c03-b0f4-c7383ea5db33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea15262-c00f-4865-bb6a-37ccb2ef62bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea15262-c00f-4865-bb6a-37ccb2ef62bd.jpg?1",
             "name": "Generator Servant",
             "text": "{T}, Sacrifice Generator Servant: Add {C}{C}. If that mana is spent on a creature spell, it gains haste until end of turn.",
             "colours": [
@@ -4468,7 +4468,7 @@
         },
         {
             "id": "4bd9c738-47dd-50dc-ab6b-1d501b00370b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549b7d4-0120-44d1-8692-e5e997d26535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549b7d4-0120-44d1-8692-e5e997d26535.jpg?1",
             "name": "Hissing Iguanar",
             "text": "Whenever another creature dies, you may have Hissing Iguanar deal 1 damage to target player or planeswalker.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "01a5f51b-daa3-578a-bb2c-2718ab83240e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84b4b61-0e92-4ca2-b4e0-ae846a2a8e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84b4b61-0e92-4ca2-b4e0-ae846a2a8e37.jpg?1",
             "name": "Ingot Chewer",
             "text": "When Ingot Chewer enters the battlefield, destroy target artifact.\nEvoke {R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "be89b7de-6f2c-5ef6-80bf-abe9939a9f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c21c1f-eaa4-454d-a1c7-b41466d0a428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c21c1f-eaa4-454d-a1c7-b41466d0a428.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player or planeswalker.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "5135ad3d-0d57-5cb9-8949-53c21bdc2bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a62145-8dad-4385-9c6d-8cf8bfdad681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a62145-8dad-4385-9c6d-8cf8bfdad681.jpg?1",
             "name": "Mad Prophet",
             "text": "Haste\n{T}, Discard a card: Draw a card.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "09087083-955c-5264-a6cc-397b14c446fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c571fe-54ef-4234-98c3-5d4a7b07e7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c571fe-54ef-4234-98c3-5d4a7b07e7d2.jpg?1",
             "name": "Magmaw",
             "text": "{1}, Sacrifice a nonland permanent: Magmaw deals 1 damage to any target.",
             "colours": [
@@ -4639,7 +4639,7 @@
         },
         {
             "id": "697f11c6-6ff8-58db-b57d-eb813ac7897f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b781ed-9f16-4cef-8b97-7a3e90abfdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b781ed-9f16-4cef-8b97-7a3e90abfdb3.jpg?1",
             "name": "Malevolent Whispers",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "db56cd6e-07f9-584d-9f62-1488c60fcbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7ea3f3-900e-4dc5-ad83-1d5c5320d031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7ea3f3-900e-4dc5-ad83-1d5c5320d031.jpg?1",
             "name": "Molten Birth",
             "text": "Create two 1/1 red Elemental creature tokens, then flip a coin. If you win the flip, return Molten Birth to its owner's hand.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "2ebf32e9-b571-56b1-8a2c-ef1ae8943504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8952ef0-d81e-491e-a137-be08a74ed005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8952ef0-d81e-491e-a137-be08a74ed005.jpg?1",
             "name": "Nightbird's Clutches",
             "text": "Up to two target creatures can't block this turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "bee32ca3-ec1e-53b0-917e-9b12d01a042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75d458-4947-4075-89b6-e93936c67370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75d458-4947-4075-89b6-e93936c67370.jpg?1",
             "name": "Raid Bombardment",
             "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to the player or planeswalker that creature is attacking.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "34d0e6e1-469b-5a55-94cd-827be567270e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9275605-15a0-4db6-bd7d-66755138e8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9275605-15a0-4db6-bd7d-66755138e8d7.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "a39a2340-1074-5b3c-92bf-9e697458e5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3aa26a-ae7b-4239-948d-ce12d7f3ea41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3aa26a-ae7b-4239-948d-ce12d7f3ea41.jpg?1",
             "name": "Reckless Wurm",
             "text": "Trample\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "c5c2641b-1d94-52a1-b413-80b3a1190941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebe6be-6d36-4ed4-a23d-770faed22e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebe6be-6d36-4ed4-a23d-770faed22e15.jpg?1",
             "name": "Rolling Temblor",
             "text": "Rolling Temblor deals 2 damage to each creature without flying.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "445e02ec-8c7c-59ec-9e3d-4ae6c00ff33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2eb4e6-4ce1-4f72-9b3d-b6a44b22bd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2eb4e6-4ce1-4f72-9b3d-b6a44b22bd2e.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card: Seismic Assault deals 2 damage to any target.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "9dc957d7-98e6-503a-8b02-46f9d7d288ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee67808-abe3-4755-83a0-03681ad5f82f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee67808-abe3-4755-83a0-03681ad5f82f.jpg?1",
             "name": "Seize the Day",
             "text": "Untap target creature. After this main phase, there is an additional combat phase followed by an additional main phase.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "1996edd3-1d7d-50dd-afc4-43194b366ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11217e72-9009-40c7-a9eb-98e10b41667b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11217e72-9009-40c7-a9eb-98e10b41667b.jpg?1",
             "name": "Soul's Fire",
             "text": "Target creature you control deals damage equal to its power to any target.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "a3abaeb6-f1c8-5551-99ec-76b665e249cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e67cab-496b-4b07-a045-b332d378ae74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e67cab-496b-4b07-a045-b332d378ae74.jpg?1",
             "name": "Sparkspitter",
             "text": "{R}, {T}, Discard a card: Create a 3/1 red Elemental creature token named Spark Elemental. It has trample, haste, and \"At the beginning of the end step, sacrifice Spark Elemental.\"",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "aee03847-c6ae-50cc-84dc-de8a6c8647c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fa9fdb-1458-4e34-8d2a-dfc083a7a223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fa9fdb-1458-4e34-8d2a-dfc083a7a223.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "41a74c4a-9a7c-5520-a22d-e37f3b390a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cac6a6-ded0-47cb-88d2-8838db9cc6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cac6a6-ded0-47cb-88d2-8838db9cc6b2.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "7adf1e71-2477-51ae-8350-ea498447e8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088dab4a-0090-4509-a851-25d916b30236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088dab4a-0090-4509-a851-25d916b30236.jpg?1",
             "name": "Through the Breach",
             "text": "You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice that creature at the beginning of the next end step.\nSplice onto Arcane {2}{R}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "eeda6d19-ac51-5669-a1f5-db68f34f9a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e987d8-b80e-49cd-9e9d-068027556b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e987d8-b80e-49cd-9e9d-068027556b83.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "57217c4f-8fe0-5a4d-880d-fd79bc47da37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ebb551-6b0d-45fa-88c8-3746214094f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ebb551-6b0d-45fa-88c8-3746214094f6.jpg?1",
             "name": "Vexing Devil",
             "text": "When Vexing Devil enters the battlefield, any opponent may have it deal 4 damage to them. If a player does, sacrifice Vexing Devil.",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "1bd09932-bef3-5d14-99e5-f442cf885b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1f44d0-7fb2-40f5-93a9-1a465372dd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1f44d0-7fb2-40f5-93a9-1a465372dd82.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -5204,7 +5204,7 @@
         },
         {
             "id": "854fd314-7510-53e1-b000-c6533dae6c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bfde99-7761-48e1-851a-522f888d0f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bfde99-7761-48e1-851a-522f888d0f6c.jpg?1",
             "name": "Basking Rootwalla",
             "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "8e4d0357-51cd-5b62-8c2b-647dd3b5d095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573e1673-3ab5-4b28-9cf1-b0d43cad5ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573e1673-3ab5-4b28-9cf1-b0d43cad5ef3.jpg?1",
             "name": "Become Immense",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget creature gets +6/+6 until end of turn.",
             "colours": [
@@ -5270,7 +5270,7 @@
         },
         {
             "id": "69ff3c40-0e2e-5802-93b3-6c1bb5a688c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8ce72b-605c-4a05-93d2-64fa65308d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8ce72b-605c-4a05-93d2-64fa65308d96.jpg?1",
             "name": "Boar Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "8a554634-2838-5787-9a05-22b877068e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605038e9-2840-4c2d-bd7a-1004ae210e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605038e9-2840-4c2d-bd7a-1004ae210e2a.jpg?1",
             "name": "Boneyard Wurm",
             "text": "Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -5338,7 +5338,7 @@
         },
         {
             "id": "3edc5251-d0e7-5203-aa96-9df0417a126d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c517b-4b29-45c5-b985-32dd7af8cfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c517b-4b29-45c5-b985-32dd7af8cfcd.jpg?1",
             "name": "Brawn",
             "text": "Trample\nAs long as Brawn is in your graveyard and you control a Forest, creatures you control have trample.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "8a7da7b3-c846-5d20-86e8-29c9dafcc697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2b20b-6255-450d-a848-f7aaf0d80721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2b20b-6255-450d-a848-f7aaf0d80721.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -5404,7 +5404,7 @@
         },
         {
             "id": "8a592e82-af1e-54f9-973f-1af3cc3105ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8a8dbb-cba7-4e1d-8888-73ab6f4aff07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8a8dbb-cba7-4e1d-8888-73ab6f4aff07.jpg?1",
             "name": "Devoted Druid",
             "text": "{T}: Add {G}.\nPut a -1/-1 counter on Devoted Druid: Untap Devoted Druid.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "b4d0c6ce-70ba-5bf8-a1c3-5ce01f57f0d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4448f49-ebe8-43f1-958f-308c4c20a01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4448f49-ebe8-43f1-958f-308c4c20a01f.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "2c19611f-be1a-579e-bf93-3db9a4c0bfa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddcec63-a60a-4d73-af6d-9ac978703811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddcec63-a60a-4d73-af6d-9ac978703811.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "b9e9e29f-730e-5e04-973e-947d36e6242b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979578b-a82f-4d5e-8871-9e45401038a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979578b-a82f-4d5e-8871-9e45401038a8.jpg?1",
             "name": "Fecundity",
             "text": "Whenever a creature dies, that creature's controller may draw a card.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "97225938-59cd-5236-87be-4964c479f310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f3323-f702-46a6-92db-33ec0afd75d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f3323-f702-46a6-92db-33ec0afd75d2.jpg?1",
             "name": "Golgari Brownscale",
             "text": "When Golgari Brownscale is put into your hand from your graveyard, you gain 2 life.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "14d619ef-fdb3-59af-b738-e8bd2925a203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a065808-643e-4123-a1ae-f65d62223106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a065808-643e-4123-a1ae-f65d62223106.jpg?1",
             "name": "Golgari Grave-Troll",
             "text": "Golgari Grave-Troll enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.\n{1}, Remove a +1/+1 counter from Golgari Grave-Troll: Regenerate Golgari Grave-Troll.\nDredge 6",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "b5adb818-66c7-5102-ba6d-025f4054eba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625498e-82e5-49e2-a7fa-f4ea0bb838db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625498e-82e5-49e2-a7fa-f4ea0bb838db.jpg?1",
             "name": "Groundskeeper",
             "text": "{1}{G}: Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -5645,7 +5645,7 @@
         },
         {
             "id": "c72c603d-be2a-5c5c-9264-1ab4162cd844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f3f0ce-e8f5-4020-b8db-23a6aa7f7cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f3f0ce-e8f5-4020-b8db-23a6aa7f7cb5.jpg?1",
             "name": "Hero of Leina Tower",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Hero of Leina Tower, you may pay {X}. If you do, put X +1/+1 counters on Hero of Leina Tower.",
             "colours": [
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "ae47d0f1-0d81-50bf-8448-2ab82430d448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfbd094-1d59-4539-80e1-595227d3e64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfbd094-1d59-4539-80e1-595227d3e64d.jpg?1",
             "name": "Hooting Mandrills",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTrample",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "c21b66c5-7970-545e-b4c8-ce27206df230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102d20e6-5179-44b7-9abd-f1defc15ca6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102d20e6-5179-44b7-9abd-f1defc15ca6a.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "1966a9ed-117e-5b7f-b18b-1afb6a539711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7447c11-05a1-44e4-831a-0bacf97d447d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7447c11-05a1-44e4-831a-0bacf97d447d.jpg?1",
             "name": "Life from the Loam",
             "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "b2988a9f-a8db-5b9b-9b82-01ce3c9ad250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d816cd-9ca6-4118-893e-5c6b167d9d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d816cd-9ca6-4118-893e-5c6b167d9d81.jpg?1",
             "name": "Miming Slime",
             "text": "Create an X/X green Ooze creature token, where X is the greatest power among creatures you control.",
             "colours": [
@@ -5812,7 +5812,7 @@
         },
         {
             "id": "a3d63b73-9913-5336-8e89-691b96ba2022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff782973-e33c-4edd-bbd7-5c8dc8d59554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff782973-e33c-4edd-bbd7-5c8dc8d59554.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U}.",
             "colours": [
@@ -5849,7 +5849,7 @@
         },
         {
             "id": "ffb684ad-65e9-5764-8d4d-4099045fe640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472cd09-0b0a-49c9-ab10-ec5b73ddb74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472cd09-0b0a-49c9-ab10-ec5b73ddb74b.jpg?1",
             "name": "Nourishing Shoal",
             "text": "You may exile a green card with converted mana cost X from your hand rather than pay this spell's mana cost.\nYou gain X life.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "fd59c754-190d-58e8-8780-3fe785aa16f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e34219-9fd9-4f11-a244-670fb75ef938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e34219-9fd9-4f11-a244-670fb75ef938.jpg?1",
             "name": "Pattern of Rebirth",
             "text": "Enchant creature\nWhen enchanted creature dies, that creature's controller may search their library for a creature card, put that card onto the battlefield, then shuffle their library.",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "78f649d5-04fd-56e8-a856-e86b0ad7327e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ce98d-0a19-42c5-9ef9-32408da1d2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ce98d-0a19-42c5-9ef9-32408da1d2a1.jpg?1",
             "name": "Penumbra Wurm",
             "text": "Trample\nWhen Penumbra Wurm dies, create a 6/6 black Wurm creature token with trample.",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "0fff9d28-bfd3-5715-b7da-407e462e2eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb1b036-0856-4cfb-ace5-2731f13696bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb1b036-0856-4cfb-ace5-2731f13696bd.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control.",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "8162d0c9-afc4-5489-8fc0-fc44c48e899a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88143d08-081f-4463-aef8-aedd47f86898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88143d08-081f-4463-aef8-aedd47f86898.jpg?1",
             "name": "Pulse of Murasa",
             "text": "Return target creature or land card from a graveyard to its owner's hand. You gain 6 life.",
             "colours": [
@@ -6015,7 +6015,7 @@
         },
         {
             "id": "b774db59-0d0a-559f-acb7-5ddac02fdef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702caa-c9eb-4538-83ff-3b015c6b1349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702caa-c9eb-4538-83ff-3b015c6b1349.jpg?1",
             "name": "Satyr Wayfinder",
             "text": "When Satyr Wayfinder enters the battlefield, reveal the top four cards of your library. You may put a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "f74555b2-a470-58d7-a8ec-a72a1d823484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467d9e99-5624-44ac-ab33-c4ebb338e6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467d9e99-5624-44ac-ab33-c4ebb338e6bf.jpg?1",
             "name": "Shed Weakness",
             "text": "Target creature gets +2/+2 until end of turn. You may remove a -1/-1 counter from it.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "41f6cc9e-8d4d-57a5-a1a3-b4081cfd2c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3071a8b-05b1-490c-89f6-4bf97c02833b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3071a8b-05b1-490c-89f6-4bf97c02833b.jpg?1",
             "name": "Snake Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals damage to an opponent, you may draw a card.\"\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "7b9d48a9-1d5a-5d4e-b0ee-d0b0f1a0647d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef12c5a-deb9-48dd-9805-cba89aab51c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef12c5a-deb9-48dd-9805-cba89aab51c1.jpg?1",
             "name": "Spider Spawning",
             "text": "Create a 1/2 green Spider creature token with reach for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "0b50dbd7-3be3-542a-9ca5-c775462352ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762b8d61-53c9-41e1-aaa7-098b91d9b938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762b8d61-53c9-41e1-aaa7-098b91d9b938.jpg?1",
             "name": "Spider Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has reach.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "a5add884-ef64-5ac3-b1c5-babe29b83140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c754202d-adc9-4d02-b1b3-ec253f7e637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c754202d-adc9-4d02-b1b3-ec253f7e637a.jpg?1",
             "name": "Staunch-Hearted Warrior",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Staunch-Hearted Warrior, put two +1/+1 counters on Staunch-Hearted Warrior.",
             "colours": [
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "a9753e87-ca95-5608-a14f-c78febe6a2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9596be71-290a-4955-aa34-dcffa9422664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9596be71-290a-4955-aa34-dcffa9422664.jpg?1",
             "name": "Stingerfling Spider",
             "text": "Reach\nWhen Stingerfling Spider enters the battlefield, you may destroy target creature with flying.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "2bd00f57-00c1-5230-891a-97ca8ad5fc88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e56220-81c3-4440-9f97-8616d630a8ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e56220-81c3-4440-9f97-8616d630a8ee.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "f16058af-5b85-52ce-a8bb-9bee1b2b9625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb41317e-9263-49a1-92d4-323613677e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb41317e-9263-49a1-92d4-323613677e34.jpg?1",
             "name": "Travel Preparations",
             "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "c1343e4e-1624-557d-9890-c1858da8fd06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b205bc3-379a-4790-90a0-c589bbbb1803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b205bc3-379a-4790-90a0-c589bbbb1803.jpg?1",
             "name": "Vengevine",
             "text": "Haste\nWhenever you cast a spell, if it's the second creature spell you cast this turn, you may return Vengevine from your graveyard to the battlefield.",
             "colours": [
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "c2046137-fea4-5c85-bafe-8b43e64ca334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878d18d-aff7-4b49-b849-9dab0e4949ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878d18d-aff7-4b49-b849-9dab0e4949ca.jpg?1",
             "name": "Verdant Eidolon",
             "text": "{G}, Sacrifice Verdant Eidolon: Add three mana of any one color.\nWhenever you cast a multicolored spell, you may return Verdant Eidolon from your graveyard to your hand.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "1af10f7f-863f-5be1-b484-650441b8eedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab879034-2400-4451-9ba2-0325f61db537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab879034-2400-4451-9ba2-0325f61db537.jpg?1",
             "name": "Walker of the Grove",
             "text": "When Walker of the Grove leaves the battlefield, create a 4/4 green Elemental creature token.\nEvoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "525fe1e2-24a6-5c6a-b755-a33c350ce4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833dff5c-63b4-413c-9956-67c84d036c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833dff5c-63b4-413c-9956-67c84d036c2e.jpg?1",
             "name": "Wickerbough Elder",
             "text": "Wickerbough Elder enters the battlefield with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from Wickerbough Elder: Destroy target artifact or enchantment.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "2316b6f1-0dd9-5d03-b607-ebe979b39aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bacc50a-71d7-4660-be1d-4db10c9b8fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bacc50a-71d7-4660-be1d-4db10c9b8fa8.jpg?1",
             "name": "Wild Hunger",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "e0a684ea-0208-5c86-a6be-d22624202ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5be4ab-f85a-4272-ac08-99cb0105eb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5be4ab-f85a-4272-ac08-99cb0105eb11.jpg?1",
             "name": "Wild Mongrel",
             "text": "Discard a card: Wild Mongrel gets +1/+1 and becomes the color of your choice until end of turn.",
             "colours": [
@@ -6522,7 +6522,7 @@
         },
         {
             "id": "46a6376b-c24a-5f98-afd0-f849a2cf19ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da88d23-8650-4b55-a3f9-e964427660ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da88d23-8650-4b55-a3f9-e964427660ed.jpg?1",
             "name": "Woodfall Primus",
             "text": "Trample\nWhen Woodfall Primus enters the battlefield, destroy target noncreature permanent.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6557,7 +6557,7 @@
         },
         {
             "id": "640b2371-ce93-532d-bf62-1b6ebe1a52fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07809b2-dabe-4242-84c3-fd640d7d5998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07809b2-dabe-4242-84c3-fd640d7d5998.jpg?1",
             "name": "Angel of Despair",
             "text": "Flying\nWhen Angel of Despair enters the battlefield, destroy target permanent.",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "97ad6c01-de59-55eb-8563-19a09d2406d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a97c6e7-affd-455a-925c-332ca6b7a6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a97c6e7-affd-455a-925c-332ca6b7a6a5.jpg?1",
             "name": "Blast of Genius",
             "text": "Choose any target. Draw three cards, then discard a card. Blast of Genius deals damage equal to the discarded card's converted mana cost to that permanent or player.",
             "colours": [
@@ -6627,7 +6627,7 @@
         },
         {
             "id": "6afa4733-2b47-5d62-a0e7-990fe7eaaadf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f864e-a10f-47f4-94c5-4571b5c11b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f864e-a10f-47f4-94c5-4571b5c11b3b.jpg?1",
             "name": "Countersquall",
             "text": "Counter target noncreature spell. Its controller loses 2 life.",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "36cf32c6-a7c0-5503-b86a-5c09eef6b35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40cfba1-08b5-4241-bd36-8ae18e584557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40cfba1-08b5-4241-bd36-8ae18e584557.jpg?1",
             "name": "Gaddock Teeg",
             "text": "Noncreature spells with converted mana cost 4 or greater can't be cast.\nNoncreature spells with {X} in their mana costs can't be cast.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "792ff109-54e9-5632-99c0-a4e7fd6fafc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc84b7cf-5c68-4bb1-a1dc-2a5fae3baf04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc84b7cf-5c68-4bb1-a1dc-2a5fae3baf04.jpg?1",
             "name": "Garna, the Bloodflame",
             "text": "Flash\nWhen Garna, the Bloodflame enters the battlefield, return to your hand all creature cards in your graveyard that were put there from anywhere this turn.\nOther creatures you control have haste.",
             "colours": [
@@ -6739,7 +6739,7 @@
         },
         {
             "id": "4b91eff4-78cd-521a-9677-7bf1519c056d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d467e61-bbec-4cea-bd5d-f10555910c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d467e61-bbec-4cea-bd5d-f10555910c9d.jpg?1",
             "name": "Golgari Charm",
             "text": "Choose one \u2014\n\u2022 All creatures get -1/-1 until end of turn.\n\u2022 Destroy target enchantment.\n\u2022 Regenerate each creature you control.",
             "colours": [
@@ -6773,7 +6773,7 @@
         },
         {
             "id": "18a18737-9ed0-57c7-abef-b7e5931b0fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedfc5b7-9242-4680-b284-debc8b5a9bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedfc5b7-9242-4680-b284-debc8b5a9bc7.jpg?1",
             "name": "Leovold, Emissary of Trest",
             "text": "Each opponent can't draw more than one card each turn.\nWhenever you or a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "9d1f8b72-55eb-59ea-a6ce-b80e4cfc190a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8862c680-01ed-4794-bc75-47dd840778a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8862c680-01ed-4794-bc75-47dd840778a6.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "dd4aedd4-041a-5709-81a1-c056b93cba1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30ea59f-c582-4044-b639-dce6fc429b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30ea59f-c582-4044-b639-dce6fc429b72.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "8e4b760c-eb07-5955-b11d-c62bb226724c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a6c902-4705-4210-8e5e-08d6a6f67573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a6c902-4705-4210-8e5e-08d6a6f67573.jpg?1",
             "name": "Reviving Vapors",
             "text": "Reveal the top three cards of your library and put one of them into your hand. You gain life equal to that card's converted mana cost. Put all other cards revealed this way into your graveyard.",
             "colours": [
@@ -6918,7 +6918,7 @@
         },
         {
             "id": "27202f35-7b76-5765-92ad-07316931284c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1",
             "name": "Sigarda, Host of Herons",
             "text": "Flying, hexproof\nSpells and abilities your opponents control can't cause you to sacrifice permanents.",
             "colours": [
@@ -6956,7 +6956,7 @@
         },
         {
             "id": "232052c5-7830-565f-8ed2-911ecec5bb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68ea02-66d3-4cca-ba0c-96f4340f683c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68ea02-66d3-4cca-ba0c-96f4340f683c.jpg?1",
             "name": "Sovereigns of Lost Alara",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may search your library for an Aura card that could enchant that creature, put it onto the battlefield attached to that creature, then shuffle your library.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "a5bd3247-8398-5dfc-95af-740dc3db4c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d74ebd-9674-4bcc-b51e-d46e7b5cbc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d74ebd-9674-4bcc-b51e-d46e7b5cbc72.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -7026,7 +7026,7 @@
         },
         {
             "id": "51b35d51-f1b7-5992-8b3d-45be79f35bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03bb160-8113-409a-a130-2b3fdc476e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03bb160-8113-409a-a130-2b3fdc476e6a.jpg?1",
             "name": "Vengeful Rebirth",
             "text": "Return target card from your graveyard to your hand. If you return a nonland card to your hand this way, Vengeful Rebirth deals damage equal to that card's converted mana cost to any target.\nExile Vengeful Rebirth.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "7a3290dc-13ae-528a-99c8-abfd89780e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989f8049-c4d2-4729-b35f-7bd7d8cbcb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989f8049-c4d2-4729-b35f-7bd7d8cbcb06.jpg?1",
             "name": "Warleader's Helix",
             "text": "Warleader's Helix deals 4 damage to any target and you gain 4 life.",
             "colours": [
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "c666b510-d1a7-50ee-8a46-bad607033de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bdd5f-2aad-48ba-a4b1-f2b2365a1a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bdd5f-2aad-48ba-a4b1-f2b2365a1a53.jpg?1",
             "name": "Beckon Apparition",
             "text": "Exile target card from a graveyard. Create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "ac605089-50a9-59d6-9493-09ca8b8d91d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7158f78-daf3-46ff-aa5f-f8cff3a24ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7158f78-daf3-46ff-aa5f-f8cff3a24ed5.jpg?1",
             "name": "Canker Abomination",
             "text": "As Canker Abomination enters the battlefield, choose an opponent. Canker Abomination enters the battlefield with a -1/-1 counter on it for each creature that player controls.",
             "colours": [
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "df43a385-7afb-5430-8dec-b29a22d430c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6822ef8f-ff27-410d-934f-c87baef03266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6822ef8f-ff27-410d-934f-c87baef03266.jpg?1",
             "name": "Dimir Guildmage",
             "text": "{3}{U}: Target player draws a card. Activate this ability only any time you could cast a sorcery.\n{3}{B}: Target player discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "98f16881-6ce2-5699-b969-9f876e12c015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82505754-a22f-4ae9-8efd-75eff17cbed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82505754-a22f-4ae9-8efd-75eff17cbed6.jpg?1",
             "name": "Double Cleave",
             "text": "Target creature gains double strike until end of turn.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "51c74350-fc33-5e1f-ac63-3fb0c1995978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168dd99-f4a9-4fe9-89d4-fc0effeb8f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168dd99-f4a9-4fe9-89d4-fc0effeb8f89.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "f59b125b-b38d-5714-be8f-8626c554f1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a844d537-df73-422d-a154-f1c6b92d0469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a844d537-df73-422d-a154-f1c6b92d0469.jpg?1",
             "name": "Kitchen Finks",
             "text": "When Kitchen Finks enters the battlefield, you gain 2 life.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "e5c3f012-940e-577d-892e-5b21f31f0d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadf575-2076-4f0c-b66e-994898adf375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadf575-2076-4f0c-b66e-994898adf375.jpg?1",
             "name": "Murderous Redcap",
             "text": "When Murderous Redcap enters the battlefield, it deals damage equal to its power to any target.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "0ad5ef2c-b933-56ae-ba7c-1f494ec05220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6c9c6-53db-4f6f-a20b-16dcbae42d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6c9c6-53db-4f6f-a20b-16dcbae42d0c.jpg?1",
             "name": "Plumeveil",
             "text": "Flash\nDefender, flying",
             "colours": [
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "de704d4e-47d2-5745-9b0c-b96e62d5fa9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aed1803-7936-4329-bb8a-7cdb0de23633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aed1803-7936-4329-bb8a-7cdb0de23633.jpg?1",
             "name": "Rakdos Shred-Freak",
             "text": "Haste",
             "colours": [
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "4c5ef25c-53de-5f05-9325-090222a2de27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d049f233-7fcb-49cb-897b-a12d57692fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d049f233-7fcb-49cb-897b-a12d57692fe0.jpg?1",
             "name": "Safehold Elite",
             "text": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7456,7 +7456,7 @@
         },
         {
             "id": "44d0bbe2-c409-5a4f-a1c2-b950b1cf6b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013b28-7a90-4b4e-a91c-7d864105d28b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013b28-7a90-4b4e-a91c-7d864105d28b.jpg?1",
             "name": "Scuzzback Marauders",
             "text": "Trample\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7493,7 +7493,7 @@
         },
         {
             "id": "34d5061e-59a3-58dc-9932-64067e374841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a99c3c-0041-49c0-9d81-e8ec731ba072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a99c3c-0041-49c0-9d81-e8ec731ba072.jpg?1",
             "name": "Shielding Plax",
             "text": "Enchant creature\nWhen Shielding Plax enters the battlefield, draw a card.\nEnchanted creature can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -7529,7 +7529,7 @@
         },
         {
             "id": "8dd6574f-3031-57f1-bdaf-c69fda823c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4bbea-7e3f-4de0-bb01-dfd67f21c254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4bbea-7e3f-4de0-bb01-dfd67f21c254.jpg?1",
             "name": "Slippery Bogle",
             "text": "Hexproof",
             "colours": [
@@ -7565,7 +7565,7 @@
         },
         {
             "id": "b04386d5-c992-5e9f-b418-b9cd0d2cbb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d3bf1-5f8b-431c-bb4e-a6874c69817a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d3bf1-5f8b-431c-bb4e-a6874c69817a.jpg?1",
             "name": "Turn to Mist",
             "text": "Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -7599,7 +7599,7 @@
         },
         {
             "id": "6a586d99-dede-56e6-ab57-34c25ba565cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg?1",
             "name": "Fire // Ice",
             "text": "Fire deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "b4464e15-7786-5518-9df7-09c31a628921",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "e5b26e01-2d32-5503-9651-a1d815af7dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ba6c14-9393-4420-adfe-6b2ef85d2ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ba6c14-9393-4420-adfe-6b2ef85d2ce9.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion dies, add {C}{C}{C}.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "e9796f2a-22ff-53a2-b41e-6fee4768f8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e2b69e-b06b-46a5-ac57-a6a180eeecc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e2b69e-b06b-46a5-ac57-a6a180eeecc7.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "7e39cdd0-0624-5bc7-b752-c9e8f2d2424c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09a887-958c-4a63-81d6-f5ec484223c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09a887-958c-4a63-81d6-f5ec484223c2.jpg?1",
             "name": "Heap Doll",
             "text": "Sacrifice Heap Doll: Exile target card from a graveyard.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "a835418d-2ba7-5304-988e-71b4848166a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdf9706-acdb-48fc-89db-93bc50b3b9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdf9706-acdb-48fc-89db-93bc50b3b9ad.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "1d084470-4c85-5466-81a0-67876d29e5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53712a0-e11d-4b83-aebc-8e97244f085b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53712a0-e11d-4b83-aebc-8e97244f085b.jpg?1",
             "name": "Myr Servitor",
             "text": "At the beginning of your upkeep, if Myr Servitor is on the battlefield, each player returns all cards named Myr Servitor from their graveyard to the battlefield.",
             "colours": [],
@@ -7814,7 +7814,7 @@
         },
         {
             "id": "f6098975-d2e2-57a2-a3d2-2f62e9e84948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6b8ca-2e72-4f19-b73b-08b3f9fe6966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6b8ca-2e72-4f19-b73b-08b3f9fe6966.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Discard a card: Regenerate Patchwork Gnomes.",
             "colours": [],
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "769a75f5-6864-595e-95e8-44bea5e1fd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c66c54b-b2d1-494d-ae10-a950c184a52f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c66c54b-b2d1-494d-ae10-a950c184a52f.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -7873,7 +7873,7 @@
         },
         {
             "id": "dc9c1e74-3c51-5ab0-b931-c8b015ede11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b03143-9e85-4061-88e6-ad621f75ec3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b03143-9e85-4061-88e6-ad621f75ec3b.jpg?1",
             "name": "Platinum Emperion",
             "text": "Your life total can't change.",
             "colours": [],
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "42a65f78-afde-51f3-92d1-748e871b0813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618fb0b-099c-47f6-b16f-49854bc5be6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618fb0b-099c-47f6-b16f-49854bc5be6b.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "07218191-e151-59b7-8bab-09bcbbfdc601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ec86a5-7d2f-4413-919e-b4f7c70457df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ec86a5-7d2f-4413-919e-b4f7c70457df.jpg?1",
             "name": "Vessel of Endless Rest",
             "text": "When Vessel of Endless Rest enters the battlefield, put target card from a graveyard on the bottom of its owner's library.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -7960,7 +7960,7 @@
         },
         {
             "id": "15da53d9-25f2-5190-a0ea-137ac7894c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3d4b4b-cf31-4f89-8140-9650edb03c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3d4b4b-cf31-4f89-8140-9650edb03c7b.jpg?1",
             "name": "Ancient Tomb",
             "text": "{T}: Add {C}{C}. Ancient Tomb deals 2 damage to you.",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "43619dcf-341f-5068-ad7a-6d88e5e6267b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976cb2-3123-4935-adcc-70e3db51d381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976cb2-3123-4935-adcc-70e3db51d381.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "ca22ca6d-05ca-5e57-92c4-b712c4b512c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c830a99-595b-4aed-9f6b-85a78917f498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c830a99-595b-4aed-9f6b-85a78917f498.jpg?1",
             "name": "Celestial Colonnade",
             "text": "Celestial Colonnade enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{3}{W}{U}: Until end of turn, Celestial Colonnade becomes a 4/4 white and blue Elemental creature with flying and vigilance. It's still a land.",
             "colours": [],
@@ -8047,7 +8047,7 @@
         },
         {
             "id": "9aba2219-da83-5b31-8794-1ba3753c5ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250441b-8255-4ae1-b064-a75eb24faaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250441b-8255-4ae1-b064-a75eb24faaf3.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{1}{U}{B}: Creeping Tar Pit becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land.",
             "colours": [],
@@ -8078,7 +8078,7 @@
         },
         {
             "id": "50810b90-8e77-57eb-8798-d9c908ed478c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58329049-2141-498a-8b73-653610c05ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58329049-2141-498a-8b73-653610c05ea6.jpg?1",
             "name": "Dakmor Salvage",
             "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B}.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "37eb9619-1516-5cba-a071-d20f18b26183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00d16f9-ea27-4aa3-a134-4e04f934d020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00d16f9-ea27-4aa3-a134-4e04f934d020.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "3766f227-a7fe-59af-ba71-7bb665db749e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12cfe8-76cf-4709-bdc4-62c059f4eebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12cfe8-76cf-4709-bdc4-62c059f4eebd.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "{T}: Add {C}.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "29f4a8f8-a2c0-5640-9356-3f1317af98ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93d3a9f-abc2-4f63-a74d-e5936609386f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93d3a9f-abc2-4f63-a74d-e5936609386f.jpg?1",
             "name": "Flagstones of Trokair",
             "text": "{T}: Add {W}.\nWhen Flagstones of Trokair is put into a graveyard from the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8202,7 +8202,7 @@
         },
         {
             "id": "dd033e0e-1cce-5300-bf1e-07ae98bcc8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52214e1-404a-405a-b08e-20e13c087338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52214e1-404a-405a-b08e-20e13c087338.jpg?1",
             "name": "Karakas",
             "text": "{T}: Add {W}.\n{T}: Return target legendary creature to its owner's hand.",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "e63f1d57-8d68-5791-b838-4d4a66f7cc59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409fcd0c-8449-4623-8bf0-cd7ca0937a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409fcd0c-8449-4623-8bf0-cd7ca0937a4a.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "Lavaclaw Reaches enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with \"{X}: This creature gets +X/+0 until end of turn.\" It's still a land.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "d197487a-6c2b-55ee-8622-a8a1aa5a93e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297e677f-5092-49bb-a63b-ac3269a4c016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297e677f-5092-49bb-a63b-ac3269a4c016.jpg?1",
             "name": "Mage-Ring Network",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Mage-Ring Network.\n{T}, Remove any number of storage counters from Mage-Ring Network: Add {C} for each storage counter removed this way.",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "137b369b-b78d-5347-81e1-d806b0b0e7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724acbe2-4c82-4360-a738-38cc6aa0c4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724acbe2-4c82-4360-a738-38cc6aa0c4a4.jpg?1",
             "name": "Mistveil Plains",
             "text": "({T}: Add {W}.)\nMistveil Plains enters the battlefield tapped.\n{W}, {T}: Put target card from your graveyard on the bottom of your library. Activate this ability only if you control two or more white permanents.",
             "colours": [],
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "b93a3774-3e7a-580f-88f0-dd2ce224dc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25dc997-219f-44e9-9003-384f75a606a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25dc997-219f-44e9-9003-384f75a606a3.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -8357,7 +8357,7 @@
         },
         {
             "id": "f57b2f15-1214-5b41-a1e9-e09862f203d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e6b8fc-6627-47ab-bfd1-7300e13debec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e6b8fc-6627-47ab-bfd1-7300e13debec.jpg?1",
             "name": "Raging Ravine",
             "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
             "colours": [],
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "eb9a8de1-47d8-5385-8fb2-1950aef8ea98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e32c53-cd0c-4c57-8cf6-23fc8fcde054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e32c53-cd0c-4c57-8cf6-23fc8fcde054.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "7a437379-273b-58bb-a254-c03da014bb97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f40dfc-a35d-4094-9805-0de8b7f61cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f40dfc-a35d-4094-9805-0de8b7f61cb0.jpg?1",
             "name": "Stirring Wildwood",
             "text": "Stirring Wildwood enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{1}{G}{W}: Until end of turn, Stirring Wildwood becomes a 3/4 green and white Elemental creature with reach. It's still a land.",
             "colours": [],
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "d8593a17-bff5-5f7a-aa84-11ad45918c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d3fa52-93ee-40a8-a4ce-41b91ff20eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d3fa52-93ee-40a8-a4ce-41b91ff20eb8.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "de6d979d-9764-52ce-8b9a-ee14a5a35afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492bd-b32f-4692-917c-7771986b5bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492bd-b32f-4692-917c-7771986b5bf7.jpg?1",
             "name": "Thespian's Stage",
             "text": "{T}: Add {C}.\n{2}, {T}: Thespian's Stage becomes a copy of target land, except it has this ability.",
             "colours": [],
@@ -8503,7 +8503,7 @@
         },
         {
             "id": "62c12ea6-7049-5a8f-b784-33b48ade7f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e17705-739e-409f-a6fd-7bab22120b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e17705-739e-409f-a6fd-7bab22120b22.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "55f6b605-5c55-5f16-a501-fbed2ee04a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165164e7-5693-4d65-b789-8ed8a222365b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165164e7-5693-4d65-b789-8ed8a222365b.jpg?1",
             "name": "Citizen",
             "text": "",
             "colours": [
@@ -8567,7 +8567,7 @@
         },
         {
             "id": "8dea83bc-b672-56ea-8f6b-024476b90279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31830977-e096-4736-bb30-1d70008d7488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31830977-e096-4736-bb30-1d70008d7488.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8601,7 +8601,7 @@
         },
         {
             "id": "028e4800-4d6a-5e34-b063-954a0d39ee48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd81e9a-69b5-4764-91a7-8b6cdddcaa40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd81e9a-69b5-4764-91a7-8b6cdddcaa40.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "b4bc4560-c20a-5637-970f-0d2ecc9d5a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c6ef29-b879-4813-87b0-0e3ba2b5cb29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c6ef29-b879-4813-87b0-0e3ba2b5cb29.jpg?1",
             "name": "Homunculus",
             "text": "",
             "colours": [
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "84534351-3a79-50ce-abe2-5b5776bf4768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67457137-64f2-413d-b62e-658b3f1b1043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67457137-64f2-413d-b62e-658b3f1b1043.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -8704,7 +8704,7 @@
         },
         {
             "id": "417106fb-eca9-5ef6-86fc-861cf8bea2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105e687e-7196-4010-a6b7-cfa42d998fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105e687e-7196-4010-a6b7-cfa42d998fa4.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -8740,7 +8740,7 @@
         },
         {
             "id": "e4816192-d5de-577f-86fa-cd160534d09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31107acf-5969-42ff-a805-9152f439b7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31107acf-5969-42ff-a805-9152f439b7fa.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8774,7 +8774,7 @@
         },
         {
             "id": "3de757dd-9448-59ac-9d97-e96adc6ba66a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e8ff7-3cb7-4ef9-a480-76d664924cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e8ff7-3cb7-4ef9-a480-76d664924cff.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8808,7 +8808,7 @@
         },
         {
             "id": "354f77e0-4448-53cb-8715-b2493678684f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae1c136-7319-45d1-882a-3d838b344773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae1c136-7319-45d1-882a-3d838b344773.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "4d3d1d6f-5817-57d6-8568-7b234f094c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7cb791-ac35-4c69-aa85-23e14b821c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7cb791-ac35-4c69-aa85-23e14b821c6a.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8876,7 +8876,7 @@
         },
         {
             "id": "de4fe0ae-18d6-56f5-9ac4-c2a79ae54657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b8e44-b435-4e05-b94c-02c4dda11943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b8e44-b435-4e05-b94c-02c4dda11943.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "1b592ced-e93e-54d3-81d4-e95251bfe81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1270173-72fc-489a-beef-85e2d8096bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1270173-72fc-489a-beef-85e2d8096bd7.jpg?1",
             "name": "Spark Elemental",
             "text": "",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "99e687c5-4402-51fc-99fb-335ec554881e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea0857b-0f9e-4a87-83d7-85723e33f26c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea0857b-0f9e-4a87-83d7-85723e33f26c.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "75e2af1c-33af-5f39-9787-2d242a91e882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d299e48d-fb74-49a1-b94a-29975056378a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d299e48d-fb74-49a1-b94a-29975056378a.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9012,7 +9012,7 @@
         },
         {
             "id": "ad252f9f-adf3-5412-be42-f4c12577a351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ede910-a0cb-4cf1-82f4-69fce0076c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ede910-a0cb-4cf1-82f4-69fce0076c4d.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -9046,7 +9046,7 @@
         },
         {
             "id": "c024f57b-b8ec-55a7-937f-db99918c2a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a306c6-57e9-4c99-b2a9-ee27a557d69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a306c6-57e9-4c99-b2a9-ee27a557d69b.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/UND.json
+++ b/Assets/Resources/Sets/UND.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e1b54271-89ea-5b05-ad7f-50a537c9e865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25ff6aa-a01d-49f2-926f-8f5457143b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25ff6aa-a01d-49f2-926f-8f5457143b5c.jpg?1",
             "name": "Adorable Kitten",
             "text": "When this creature enters the battlefield,\nroll a six-sided die. You gain life equal to the result.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "1ac5559b-5589-5dcc-8f5d-2d3ecb3b9e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da3387-454c-4c09-b78f-6fcc36c426ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da3387-454c-4c09-b78f-6fcc36c426ce.jpg?1",
             "name": "AWOL",
             "text": "Exile target attacking creature. Then remove it from the game. Then put it into the absolutely-removed-from-the-freaking-game-forever zone.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "79ff343f-b8fc-5cb2-9df3-76c4cb0f0173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa7c80e-86bf-4156-8370-d40f864c3704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa7c80e-86bf-4156-8370-d40f864c3704.jpg?1",
             "name": "Emcee",
             "text": "Whenever another creature enters the battlefield, you may stand up and say in a deep, booming voice, \"Presenting . . . \" and that creature's name. If you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "289af0ca-e261-5f02-8af0-ba257954bc7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abce5940-e84f-4f9f-89a9-13da1cd7fd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abce5940-e84f-4f9f-89a9-13da1cd7fd43.jpg?1",
             "name": "Flavor Judge",
             "text": "{T}: Choose target spell or ability that targets a permanent you control. Then ask a person outside the game if the story of what will happen makes sense. If they say no, sacrifice Flavor Judge and counter that spell or ability.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "7463f2a8-b9ba-534f-a315-f8aff14b0286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c3e8b-d9c6-46cd-9f39-86db077fb89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c3e8b-d9c6-46cd-9f39-86db077fb89d.jpg?1",
             "name": "Frankie Peanuts",
             "text": "At the beginning of your upkeep, you may ask target player a yes-or-no question. If you do, that player answers the question truthfully and abides by that answer if able until end of turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "9e7dff50-8d34-5bda-a914-6ca08f3591e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40eb8f1-7dec-47cd-99dd-b6147ad5593d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40eb8f1-7dec-47cd-99dd-b6147ad5593d.jpg?1",
             "name": "GO TO JAIL",
             "text": "When GO TO JAIL enters the battlefield, exile target creature an opponent controls until GO TO JAIL leaves the battlefield.\nAt the beginning of the upkeep of the exiled card's owner, that player rolls two six-sided dice. If they roll doubles, sacrifice GO TO JAIL.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "cd88f21d-3c1a-5ab6-90fd-4c11592e9989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8d36-92e3-43b5-b9ce-79cb8d2bfd76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8d36-92e3-43b5-b9ce-79cb8d2bfd76.jpg?1",
             "name": "Humming-",
             "text": "Flying\nWhenever you attack with two or more creatures,\nAugment {3}{W} ({3}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "23036e2e-4a3c-506c-a4e6-3f26562ddf29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d81b09-aa21-4206-bdc5-21819e36d9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d81b09-aa21-4206-bdc5-21819e36d9b3.jpg?1",
             "name": "Knight of the Hokey Pokey",
             "text": "First strike\n{1}{W}, Do the Hokey Pokey: Prevent all damage a source of your choice would deal to Knight of the Hokey Pokey this turn. (To do the Hokey Pokey, choose an arm, a leg, or your whole self and put it in. Put it out. Put it in. Shake it all about. You do the Hokey Pokey Turn yourself around.)",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "76e70d5f-abd8-5cb4-8dd4-32da5fab6f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaee15d7-db3d-4aa2-ab04-b883ff41d12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaee15d7-db3d-4aa2-ab04-b883ff41d12a.jpg?1",
             "name": "Look at Me, I'm R&D",
             "text": "As Look at Me, I'm R&D comes into play, choose a number and a second number one higher or one lower than that number.\nAll instances of the first chosen number on permanents, spells, and cards in any zone are the second chosen number.",
             "colours": [
@@ -302,7 +302,7 @@
         },
         {
             "id": "e048657a-fbb6-52d7-ae57-ddc578ba8ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa69802-c392-4004-9d58-ad1fc42de0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa69802-c392-4004-9d58-ad1fc42de0bd.jpg?1",
             "name": "Look at Me, I'm the DCI",
             "text": "Ban a card other than a basic land card for the rest of the match. (All cards with that name in any zone or sideboard are removed from the match.)",
             "colours": [
@@ -333,7 +333,7 @@
         },
         {
             "id": "461281bf-52c7-5cd3-bc88-2faaf6a53104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b0cbc6-fe14-484a-a5ab-ea04d7b9e487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b0cbc6-fe14-484a-a5ab-ea04d7b9e487.jpg?1",
             "name": "Old Guard",
             "text": "{W}, {T}: Tap target creature without reminder text. (Reminder text is any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "4b7faffc-7f75-56ad-8b7d-e44f02ffdce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d2083-2022-4d49-90ab-ec52e584842c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d2083-2022-4d49-90ab-ec52e584842c.jpg?1",
             "name": "Ordinary Pony",
             "text": "When this creature enters the battlefield,\nyou may exile target non-Horse creature you control that wasn't put onto the battlefield with this ability this turn, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "b23e355d-5190-5db8-ad5a-5ff9d0fe9bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc13f28-6d2e-4589-b475-3c18d0eea2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc13f28-6d2e-4589-b475-3c18d0eea2de.jpg?1",
             "name": "Staying Power",
             "text": "\"Until end of turn\" and \"this turn\" effects don't end.",
             "colours": [
@@ -434,7 +434,7 @@
         },
         {
             "id": "ebed16ae-db40-50db-b83f-a202f5661acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef766e71-d67a-4656-90c0-3628bcca640b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef766e71-d67a-4656-90c0-3628bcca640b.jpg?1",
             "name": "Strutting Turkey",
             "text": "When this creature enters the battlefield,\nexile target creature card with converted mana cost 2 or less from your graveyard. If it has augment, combine it with a host you control. Otherwise, put it onto the battlefield.",
             "colours": [
@@ -469,7 +469,7 @@
         },
         {
             "id": "08e4b1bc-e247-5850-9aee-d0415c22d6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0b109c-eaf3-49ab-a61c-853e8ca239fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0b109c-eaf3-49ab-a61c-853e8ca239fc.jpg?1",
             "name": "Syr Cadian, Knight Owl",
             "text": "Knightlifelink (Damage dealt by Knights you control also causes you to gain that much life.)\n{W}: Syr Cadian, Knight Owl gains vigilance until end of turn. Activate this ability only from sunrise to sunset.\n{B}: Syr Cadian, Knight Owl gains flying until end of turn. Activate this ability only from sunset to sunrise.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "119a7726-0291-5067-b85d-5fafa28ca0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1572109-df70-4335-aac2-1670fe99be54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1572109-df70-4335-aac2-1670fe99be54.jpg?1",
             "name": "Alexander Clamilton",
             "text": "Whenever you cast a wordy spell, scry 2. (A spell is wordy if it has four or more lines of rules text.)\n{1}{R}, {T}: Choose target creature you don't control. Reveal the top card of your library. Alexander Clamilton gets +X/+0 until end of turn, where X is the number of lines of rules text of the revealed card. Alexander Clamilton fights that creature.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "44c3aebc-584a-5590-b3dc-296f645482a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da4dcb0-285e-4948-8155-4b536bce202d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da4dcb0-285e-4948-8155-4b536bce202d.jpg?1",
             "name": "Avatar of Me",
             "text": "This spell costs {1} more to cast for each ten years you've been alive.\nAvatar of Me's power is equal to your height in feet and its toughness is equal to your American shoe size. Round to the nearest \u00bd.\nAvatar of Me is the color of your eyes.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "25463956-7fc1-5781-88cb-abba28a59ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41ecd9-8875-4765-a9a9-372f948b5ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41ecd9-8875-4765-a9a9-372f948b5ad7.jpg?1",
             "name": "B.O.B. (Bevy of Beebles)",
             "text": "As B.\nO.\nB. enters the battlefield, create four 1/1 blue Beeble creature tokens.\nThe number of loyalty counters on B.\nO.\nB. is equal to the number of Beebles you control. (Create or sacrifice Beebles whenever B.\nO.\nB. gains or loses loyalty.)\n+1: Up to X target Beebles can't be blocked this turn, where X is the number of cards in your hand.\n\u22121: Draw a card.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "306494e3-f2d7-5efb-9cd6-cff7fc2b7172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fa790-e131-4871-841b-ad8ee2a0a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fa790-e131-4871-841b-ad8ee2a0a716.jpg?1",
             "name": "Carnivorous Death-Parrot",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Carnivorous Death-Parrot unless you say its flavor text.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "f006f1c0-36b1-5f98-a8d6-499cecb11f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebafd1c7-c248-494c-b9b7-3521c6c4352c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebafd1c7-c248-494c-b9b7-3521c6c4352c.jpg?1",
             "name": "Cheatyface",
             "text": "If Cheatyface is in your hand, you may sneak Cheatyface onto the battlefield. If an opponent catches you right away, that player may exile Cheatyface.\nFlying",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "c6c4bfd9-bcec-5267-867c-d93b66d3e8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbd4ef-3bf4-4f22-9069-2a11c9619a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbd4ef-3bf4-4f22-9069-2a11c9619a43.jpg?1",
             "name": "Chicken \u00e0 la King",
             "text": "Whenever a 6 is rolled on a six-sided die, put a +1/+1 counter on each Bird. (You may roll dice only when instructed to.)\nTap an untapped Bird you control: Roll a six-sided die. (Like now.)",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "6bfe9a93-7ff8-58e1-a68c-389f94605b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cb220-47c4-438d-bc24-abd68ed4273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cb220-47c4-438d-bc24-abd68ed4273c.jpg?1",
             "name": "Common Courtesy",
             "text": "Whenever a player casts a spell without asking your permission while casting it, counter that spell.\nWhen a player asks you permission to cast a spell and you refuse, counter that spell and sacrifice Common Courtesy.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "efd1829b-27f5-58b8-b9a5-89494535da8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fc7a61-226c-426a-9b99-21d87aca2f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fc7a61-226c-426a-9b99-21d87aca2f6f.jpg?1",
             "name": "Johnny, Combo Player",
             "text": "{4}: Search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "87b82b46-4ebb-5be2-b5a0-518e7e6fb429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111f985b-d33e-4ecd-93d4-1be4a730463b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111f985b-d33e-4ecd-93d4-1be4a730463b.jpg?1",
             "name": "Magic Word",
             "text": "Enchant creature\nAs Magic Word enters the battlefield, choose a word.\nWhisper the chosen word: Tap enchanted creature.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "7c903143-4f2e-5bfd-84c6-02ac9631e746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece674d3-6c39-4489-b097-a7e875bc6655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece674d3-6c39-4489-b097-a7e875bc6655.jpg?1",
             "name": "Mer Man",
             "text": "When this creature enters the battlefield,\nyou may draw a card.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "6bbadd17-5f08-5055-9c25-9a7bf4c61356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616a3755-f08c-4b8f-954b-7e3f3a8fa71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616a3755-f08c-4b8f-954b-7e3f3a8fa71f.jpg?1",
             "name": "Richard Garfield, Ph.D.",
             "text": "You may play cards as though they were other cards of your choice with the same mana cost. You can't choose the same card twice. (Mana cost includes color.)",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "865c8147-f27b-5318-bd97-8488bbcd6e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4b5dfe-9947-42fb-859d-291a608a7309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4b5dfe-9947-42fb-859d-291a608a7309.jpg?1",
             "name": "Rings a Bell",
             "text": "As Rings a Bell enters the battlefield, choose a word with four or more letters.\nAfter you say the chosen word for the first time each turn, an opponent may ring or imitate a bell within five seconds. When no opponent does, draw a card.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "416c0488-d0c1-52e6-a644-5dd5680743fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ef21-ef1c-4524-9d06-1792840cbe2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ef21-ef1c-4524-9d06-1792840cbe2e.jpg?1",
             "name": "Time Out",
             "text": "Roll a six-sided die. Put target nonland permanent into its owner's library just beneath the top X cards of that library, where X is the result.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "dc550dcd-1405-5691-a5c3-c98e9128ccd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf253a-eca6-405d-8216-a362854b4ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf253a-eca6-405d-8216-a362854b4ae1.jpg?1",
             "name": "Topsy Turvy",
             "text": "The phases of each player's turn are reversed. (The phases are, in reverse order, ending, postcombat main, combat, precombat main, and beginning.)\nAs long as there are more than two players in the game, the turn order is reversed.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "f1c3600a-ed9a-5f92-b96d-b2ddbda582d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d09f247-99c6-4038-9cd1-7c4ccc3d7005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d09f247-99c6-4038-9cd1-7c4ccc3d7005.jpg?1",
             "name": "Wall of Fortune",
             "text": "Defender\nYou may tap an untapped Wall you control to have any player reroll a die that player rolled.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "6888bc2d-33b9-56da-b17a-c683032dc171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c37a83-3d5e-4019-b180-88e2bc106dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c37a83-3d5e-4019-b180-88e2bc106dd0.jpg?1",
             "name": "Acornelia, Fashionable Filcher",
             "text": "Whenever you cast a spell with a squirrel in its art, you get  (an acorn counter).\nWhenever a Squirrel you control enters the battlefield or dies, you get .\n{2}{B}, Pay X : Target creature gets -X/-X until end of turn.\n{G}, Pay X : Target creature gets +X/+X until end of turn.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "7aab776d-ebfe-5665-8c9d-fec741ec7929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14ebf7a-c616-4a89-904b-75c5602c54de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14ebf7a-c616-4a89-904b-75c5602c54de.jpg?1",
             "name": "Bat-",
             "text": "Flying\nAt the beginning of each end step, if an opponent lost 3 or more life this turn,\nAugment {1}{B} ({1}{B}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -1080,7 +1080,7 @@
         },
         {
             "id": "e2fc4ff6-5816-50b8-b04a-4a9e3dd42ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5718db-e67d-468a-95ba-11a08fcf9fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5718db-e67d-468a-95ba-11a08fcf9fea.jpg?1",
             "name": "Booster Tutor",
             "text": "Open a sealed Magic booster pack, reveal the cards, and put one of them into your hand. (Remove that card from your deck before beginning a new game.)",
             "colours": [
@@ -1111,7 +1111,7 @@
         },
         {
             "id": "e2b0c02e-a519-58eb-8653-dc1e6deee027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17596a17-b062-41e9-a8c6-76fb67e36e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17596a17-b062-41e9-a8c6-76fb67e36e48.jpg?1",
             "name": "Dirty Rat",
             "text": "When this creature enters the battlefield,\ntarget opponent discards a card.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "c0a3fb00-3846-53d2-a0a1-6d70af42f85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318bc78c-65ef-4d1b-a710-cdf08636b572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318bc78c-65ef-4d1b-a710-cdf08636b572.jpg?1",
             "name": "Duh",
             "text": "Destroy target creature with reminder text. (Reminder text is any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "371fdc8c-2d58-5898-b5a9-118a8ee67320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696f3a6-88c3-4aab-9c1f-05b5e36094fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696f3a6-88c3-4aab-9c1f-05b5e36094fa.jpg?1",
             "name": "Enter the Dungeon",
             "text": "Players play a Magic subgame under the table, starting at 5 life and using their libraries as their decks. The winner searches their library for two cards, puts those cards into their hand, then shuffles their library.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "4795e57f-dfd1-5a77-a580-9b28c2c4d0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293106ab-da9b-4932-8227-96b7e55e7d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293106ab-da9b-4932-8227-96b7e55e7d26.jpg?1",
             "name": "Hoisted Hireling",
             "text": "Hoisted Hireling has flying as long as it's being held above the battlefield.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "b996f0e6-1e5f-5e5c-a9c9-fe3786268491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c28a60a-8b2b-45f5-b46e-c0c50218b239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c28a60a-8b2b-45f5-b46e-c0c50218b239.jpg?1",
             "name": "Infernal Spawn of Evil",
             "text": "Flying, first strike\n{1}{B}, Reveal Infernal Spawn of Evil from your hand, Say \"It's coming\": Infernal Spawn of Evil deals 1 damage to target opponent or planeswalker. Activate this ability only during your upkeep and only once each turn.",
             "colours": [
@@ -1274,7 +1274,7 @@
         },
         {
             "id": "31e0ff52-217d-5955-bc9a-6991594cc041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2c80d5-960b-4624-9b3e-96943d7b4144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2c80d5-960b-4624-9b3e-96943d7b4144.jpg?1",
             "name": "Infernal Spawn of Infernal Spawn of Evil",
             "text": "Flying, first strike, trample\nOnce each turn, while you're searching your library, you may pay {1}{B}, reveal Infernal Spawn of Infernal Spawn of Evil from your library and say \"I'm coming, too\" If you do, Infernal Spawn of Infernal Spawn of Evil deals 2 damage to a player of your choice.",
             "colours": [
@@ -1308,7 +1308,7 @@
         },
         {
             "id": "d3a41575-6a96-51c6-8836-ad9a49dbd9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3b1317-f024-4e34-89ad-538fc148cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3b1317-f024-4e34-89ad-538fc148cd5c.jpg?1",
             "name": "Infernius Spawnington III, Esq.",
             "text": "Flying, first strike, trample, haste\nThis spell costs {3} less to cast for each card you've revealed this turn.\nWhen Infernius Spawnington III, Esq. enters the battlefield, you may say \"I'm here.\" If you do, it deals 3 damage to target player.",
             "colours": [
@@ -1343,7 +1343,7 @@
         },
         {
             "id": "46d0c4d8-6c32-5b3c-8326-d56254f90818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1150ef5-b529-4ad2-ba27-dd0fcffd8888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1150ef5-b529-4ad2-ba27-dd0fcffd8888.jpg?1",
             "name": "Inhumaniac",
             "text": "At the beginning of your upkeep, roll a six-sided die. On a 3 or 4, put a +1/+1 counter on Inhumaniac. On a 5 or higher, put two +1/+1 counters on it. On a 1, remove all +1/+1 counters from Inhumaniac.",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "9d2c59ac-f3fc-5718-8421-4f26dd5cdc3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d761c0b3-ae18-49a2-b1b7-f820b645a258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d761c0b3-ae18-49a2-b1b7-f820b645a258.jpg?1",
             "name": "Jumbo Imp",
             "text": "Flying\nAs Jumbo Imp enters the battlefield, roll a six-sided die. Jumbo Imp enters the battlefield with a number of +1/+1 counters on it equal to the result.\nAt the beginning of your upkeep, roll a six-sided die and put a number of +1/+1 counters on Jumbo Imp equal to the result.\nAt the beginning of your end step, roll a six-sided die and remove a number of +1/+1 counters from Jumbo Imp equal to the result.",
             "colours": [
@@ -1409,7 +1409,7 @@
         },
         {
             "id": "6764410c-2100-5058-9b2c-87f60b49c77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7317f1f-dff3-4d38-98be-2b4907bdd523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7317f1f-dff3-4d38-98be-2b4907bdd523.jpg?1",
             "name": "Poultrygeist",
             "text": "Flying\nWhenever a creature dies, you may roll a six-sided die. If you roll a 1, sacrifice Poultrygeist. Otherwise, put a +1/+1 counter on Poultrygeist.",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "289fcb55-c34a-5422-80cc-5b0bad05dd5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80cfcad-c82b-461d-8002-a8e1acddacf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80cfcad-c82b-461d-8002-a8e1acddacf2.jpg?1",
             "name": "Skull Saucer",
             "text": "Flying\nWhen Skull Saucer enters the battlefield, destroy target creature and put your head on the table. Sacrifice Skull Saucer when your head stops touching the table.",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "fe2fd969-cb4b-5ac1-969d-8649142529db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98469f4c-40b6-4ca8-886f-6d1879641641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98469f4c-40b6-4ca8-886f-6d1879641641.jpg?1",
             "name": "Snickering Squirrel",
             "text": "You may tap Snickering Squirrel to increase the result of a die any player rolled by 1.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "467b454e-6b5a-5b38-86e1-2ed53987c68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67248450-7135-43ed-a1ec-d8a2da556066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67248450-7135-43ed-a1ec-d8a2da556066.jpg?1",
             "name": "Stinging Scorpion",
             "text": "When this creature enters the battlefield,\ntarget creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "82448769-bbfe-5f3b-be44-c4b11f719060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c244e904-89ab-4486-a467-16e86f179fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c244e904-89ab-4486-a467-16e86f179fcc.jpg?1",
             "name": "Abstract Iguanart",
             "text": "Whenever you cast a spell, note the first letter of its artist's name. If that letter wasn't already noted, put a +1/+1 counter on Abstract Iguanart.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "547ee5c2-42ad-5ad6-81e2-770a6da73d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a784dde5-cfce-464f-a134-8894ba3faf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a784dde5-cfce-464f-a134-8894ba3faf5b.jpg?1",
             "name": "Blast from the Past",
             "text": "Madness {R}, cycling {1}{R}, kicker {2}{R}, flashback {3}{R}, buyback {4}{R}\nBlast from the Past deals 2 damage to any target. If this spell was kicked, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "fbb867e7-afb4-5af1-9d27-8d71947284db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747788b4-42ab-4e3e-bdbe-eb5040432db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747788b4-42ab-4e3e-bdbe-eb5040432db1.jpg?1",
             "name": "Boomstacker",
             "text": "As Boomstacker enters the battlefield and whenever it attacks, stack two dice on top of it. (All dice must be stacked vertically, one on top of another.)\nBoomstacker gets +1/+1 for each die in its stack.\nBoomstacker attacks each combat if able.\nWhen the stack falls, sacrifice Boomstacker.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "0f8c3b4a-a1a4-588a-8e3f-341340e99042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487de7fb-51b5-48bf-89cc-a0539ac1b994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487de7fb-51b5-48bf-89cc-a0539ac1b994.jpg?1",
             "name": "Common Iguana",
             "text": "When this creature enters the battlefield,\nyou may discard a card. If you do, draw a card.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "fcce5e54-4313-5631-98e0-b95f3039fb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0520e8-794e-403e-855c-2cb4ba79189d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0520e8-794e-403e-855c-2cb4ba79189d.jpg?1",
             "name": "Goblin Haberdasher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nOther creatures you control wearing hats in their art have menace.",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "cf3476d9-292b-5377-ba72-9be334cad74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103d84da-2a1b-48b1-973f-5a995218d0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103d84da-2a1b-48b1-973f-5a995218d0e0.jpg?1",
             "name": "Goblin S.W.A.T. Team",
             "text": "Say \"Goblin S.W.A.T. Team\": Put a +1/+1 counter on Goblin S.W.A.T. Team unless an opponent swats the table within five seconds. Activate this ability only once each turn.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "376ad6ae-ac1d-5014-932c-c236e780a02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba2055e-c668-4fe5-9c2b-0ef17557548c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba2055e-c668-4fe5-9c2b-0ef17557548c.jpg?1",
             "name": "Goblin Tutor",
             "text": "Roll a six-sided die. If you roll a 1, Goblin Tutor has no effect. Otherwise, search your library for the indicated card, reveal it, put it into your hand, then shuffle your library.\n2 \u2014 A card named Goblin Tutor\n3 \u2014 An enchantment\n4 \u2014 An artifact\n5 \u2014 A creature\n6 \u2014 An instant or sorcery",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "a06bc59c-e61c-50db-b60c-63d0966f7f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9330f67-0f79-4374-804c-5ca30841b8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9330f67-0f79-4374-804c-5ca30841b8bb.jpg?1",
             "name": "Infinity Elemental",
             "text": "(This creature has INFINITE POWER.)",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "f31460f6-91d6-5cb4-b9ef-b3074bfd8351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33292b84-331d-490f-b96e-43341b367df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33292b84-331d-490f-b96e-43341b367df0.jpg?1",
             "name": "Painiac",
             "text": "At the beginning of your upkeep, roll a six-sided die. Painiac gets +X/+0 until end of turn, where X is the result.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "438dd605-f6d8-51f7-aef3-0b2bd1f44f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706e573e-3e3b-4684-b51c-8b583fddc549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706e573e-3e3b-4684-b51c-8b583fddc549.jpg?1",
             "name": "Six-y Beast",
             "text": "As Six-y Beast enters the battlefield, you secretly put six or fewer +1/+1 counters on it, then an opponent guesses the number of counters. If that player guesses right, sacrifice Six-y Beast after it enters the battlefield.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "952ba4d4-ef21-587f-b104-a4645d81c066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57a6d9d-f0e9-4c5a-bacf-7a6c30d65b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57a6d9d-f0e9-4c5a-bacf-7a6c30d65b08.jpg?1",
             "name": "Stet, Draconic Proofreader",
             "text": "Flying\nWhenever Stet, Draconic Proofreader attacks, you may exile a card from your graveyard. When you do, Stet, Draconic Proofreader deals 4 damage to any target whose name begins with the same letter as the exiled card.\n{W}: Delete the first letter of target permanent or player's name until end of turn.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "74955d47-80c6-5ffa-a18a-7acc518b2c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6159df84-64a3-4252-99d8-30971b07cec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6159df84-64a3-4252-99d8-30971b07cec5.jpg?1",
             "name": "Strategy, Schmategy",
             "text": "Roll a six-sided die. Strategy, Schmategy has the indicated effect.\n1 \u2014 Do nothing.\n2 \u2014 Destroy all artifacts.\n3 \u2014 Destroy all lands.\n4 \u2014 Strategy, Schmategy deals 3 damage to each creature and each player.\n5 \u2014 Each player discards their hand and draws seven cards.\n6 \u2014 Repeat this process two more times.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "aed5ad42-e52f-5bb9-b21e-a2d1c6adb24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b0255d-0dde-4a0c-b5fd-70ac4b72133e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b0255d-0dde-4a0c-b5fd-70ac4b72133e.jpg?1",
             "name": "Super-Duper Death Ray",
             "text": "Trample (This spell can deal excess damage to its target's controller.)\nSuper-Duper Death Ray deals 4 damage to target creature.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "87874c83-6b86-5b71-ae64-f02d102bb4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d85779-89f6-4f4e-b34a-d44a6d15ce06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d85779-89f6-4f4e-b34a-d44a6d15ce06.jpg?1",
             "name": "Yet Another Aether Vortex",
             "text": "All creatures have haste.\nPlayers play with the top card of their libraries revealed.\nNoninstant, nonsorcery cards on top of a library are on the battlefield under their owner's control in addition to being in that library.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "5d7b2689-007c-5f3c-9eae-b5d2f10823c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf4a081-3532-45e5-be72-1ff2fb88bb08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf4a081-3532-45e5-be72-1ff2fb88bb08.jpg?1",
             "name": "B-I-N-G-O",
             "text": "Trample\nWhenever a player casts a spell, put a chip counter on its converted mana cost.\nB-I-N-G-O gets +9/+9 for each set of three numbers in a row with chip counters on them.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "44e9c9c0-88e9-532d-bac8-82d4ded43547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159e36d-8e4c-4ac8-8b1f-1111ba73ac12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159e36d-8e4c-4ac8-8b1f-1111ba73ac12.jpg?1",
             "name": "Elvish Impersonators",
             "text": "As Elvish Impersonators enters the battlefield, roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "12c5ee36-0d50-5cca-8bbb-25e73b570bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70124c3-7188-418f-bc7d-fb6294d79a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70124c3-7188-418f-bc7d-fb6294d79a56.jpg?1",
             "name": "Free-Range Chicken",
             "text": "{1}{G}: Roll two six-sided dice. If both results are the same, Free-Range Chicken gets +X/+X until end of turn, where X is that result. If the total of those results is equal to any other total you have rolled this turn for this ability, sacrifice it. (For example, if you roll two 3s, it gets +3/+3. If you roll a 4 and a 2 for this ability later that turn, sacrifice it.)",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "e91458f8-6495-55c7-82f0-498956cde217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8052788-65d6-4809-a338-68ff40ef5b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8052788-65d6-4809-a338-68ff40ef5b0f.jpg?1",
             "name": "Growth Spurt",
             "text": "Roll a six-sided die. Target creature gets +X/+X until end of turn, where X is the result.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "816efcf3-d1f2-524d-a1b5-aefa2654c09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd59e69-0dfe-4161-8e95-41be9ae07716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd59e69-0dfe-4161-8e95-41be9ae07716.jpg?1",
             "name": "Half-Squirrel, Half-",
             "text": "Whenever a nontoken creature enters the battlefield,\nAugment {G} ({G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "4b710611-4598-5bee-9499-78cdfb4a15c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933630cb-e812-436e-a35e-8247557f72a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933630cb-e812-436e-a35e-8247557f72a3.jpg?1",
             "name": "Mother Kangaroo",
             "text": "When this creature enters the battlefield,\nroll a six-sided die. Put a number of +1/+1 counters on this creature equal to the result.",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "17ccd14d-a756-5f95-a80d-6b423ae525b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccae52dd-3ffd-4974-8915-61f816d29a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccae52dd-3ffd-4974-8915-61f816d29a64.jpg?1",
             "name": "Old Fogey",
             "text": "Phasing, cumulative upkeep {1}, echo, fading 3, bands with other Dinosaurs, protection from Homarids, snow-covered plainswalk, flanking, rampage 2",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "f8a6d3ab-7cd8-5877-85be-cdd6a20b6259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f42b1a-5404-496a-b6e4-98794a4d8bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f42b1a-5404-496a-b6e4-98794a4d8bee.jpg?1",
             "name": "Pippa, Duchess of Dice",
             "text": "{2}{G}, {T}: Roll a six-sided die. It becomes a green Die creature token with power and toughness each equal to its result.\n{2}{U}, {T}: Reroll any die. (Activate this ability only any time it makes sense.)",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "df55aede-0f2c-5ff0-ac6e-91d52cb23a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349a387-1803-49c6-975c-49fe1491521a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349a387-1803-49c6-975c-49fe1491521a.jpg?1",
             "name": "Slaying Mantis",
             "text": "Just a second (As long as this spell is on the stack, players can't move cards on the battlefield.)\nSlaying Mantis enters the battlefield by being thrown from a distance of at least three feet.\nWhen Slaying Mantis enters the battlefield, it fights each creature an opponent controls that it touched as it entered.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "a7b21be3-20fa-507b-9743-c61ec81564b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479c30a3-9358-4db0-ac99-6da5018a3830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479c30a3-9358-4db0-ac99-6da5018a3830.jpg?1",
             "name": "Spirit of the Season",
             "text": "When Spirit of the Season enters the battlefield, it gains haste if it's summer. Put a +1/+1 counter on it if it's autumn. You gain 5 life if it's winter. If it's spring, search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "03113fed-fb42-5e9b-bfa3-d56bcc915541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc67b0f2-c36d-4ad8-b2ec-08934568526b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc67b0f2-c36d-4ad8-b2ec-08934568526b.jpg?1",
             "name": "Squirrel Farm",
             "text": "{1}{G}: Reveal a card in your hand, covering the artist credit. Target opponent guesses the artist. If they guess wrong, create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "faf9bb72-f54c-5a66-80dc-e92a82b9184e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e21568-5474-4406-ad54-9e9330e5ff5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e21568-5474-4406-ad54-9e9330e5ff5c.jpg?1",
             "name": "Surgeon General Commander",
             "text": "Whenever you augment, enchant, or mutate a creature you control, draw a card.\n{T}: Add {W}, {U}, {B}, {R}, or {G}.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "1414742d-55f5-5401-a792-a747eb9b9c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa57822-8bca-4cdd-916f-261dae494228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa57822-8bca-4cdd-916f-261dae494228.jpg?1",
             "name": "Timmy, Power Gamer",
             "text": "{4}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "dfe8a94f-0182-5d76-abd8-a89eed68437f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af3038-5106-42e3-b9ed-29db209de4d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af3038-5106-42e3-b9ed-29db209de4d1.jpg?1",
             "name": "Wild Crocodile",
             "text": "When this creature enters the battlefield,\nsearch your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2487,7 +2487,7 @@
         },
         {
             "id": "6eba118a-91ac-5734-a776-0fba67684a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "Who\no\nXo\nW\nInstant\nTarget player gains X life.\n//\nWhat\no2o\nR\nInstant\nDestroy target artifact.\n//\nWhen\no2o\nU\nInstant\nCounter target creature spell.\n//\nWhere\no3o\nB\nInstant\nDestroy target land.\n//\nWhy\no1o\nG\nInstant\nDestroy target enchantment.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "035da06a-c4fe-54c2-946d-66cd0481fa12",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "823b9f86-5d85-55bf-96a3-bab429a852aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "e1b00e53-7b48-5bc6-842a-66839f08ca7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "5b138950-4f9a-56e0-a614-5d1627471b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "a0fdab50-c217-55ab-bf24-f13eafc88e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bc518c-6752-4a2a-92c0-ed95029dc2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bc518c-6752-4a2a-92c0-ed95029dc2ca.jpg?1",
             "name": "Bronze Calendar",
             "text": "Spells you cast cost {1} less to cast.\nYou must speak in a voice other than your normal voice.\nWhen you speak in your normal voice, sacrifice Bronze Calendar.",
             "colours": [],
@@ -2689,7 +2689,7 @@
         },
         {
             "id": "9d95e3d3-88ad-5458-977b-32abe0ebb8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889b42c8-f009-4a75-b4bf-812fbbd87626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889b42c8-f009-4a75-b4bf-812fbbd87626.jpg?1",
             "name": "Entirely Normal Armchair",
             "text": "During your turn, if Entirely Normal Armchair is in your hand, you may hide it on the battlefield.\n{0}: Return Entirely Normal Armchair to its owner's hand. Only any opponent may activate this ability and only if they see Entirely Normal Armchair.\n{2}, Sacrifice Entirely Normal Armchair: Destroy target attacking creature.",
             "colours": [],
@@ -2716,7 +2716,7 @@
         },
         {
             "id": "76370db3-0da9-5295-b51e-3e99a54e2cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30889-d245-4f20-938a-1295ddbcfac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30889-d245-4f20-938a-1295ddbcfac6.jpg?1",
             "name": "Jack-in-the-Mox",
             "text": "{T}: Roll a six-sided die. This ability has the indicated effect.\n1 \u2014 Sacrifice Jack-in-the-Mox and you lose 5 life.\n2 \u2014 Add {W}.\n3 \u2014 Add {U}.\n4 \u2014 Add {B}.\n5 \u2014 Add {R}.\n6 \u2014 Add {G}.",
             "colours": [],
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "6d9047dc-3e2c-56fa-b55d-8091eea05b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f267de8-2849-4abd-834e-11bbd82dccf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f267de8-2849-4abd-834e-11bbd82dccf5.jpg?1",
             "name": "Krark's Other Thumb",
             "text": "If you would roll a die, instead roll two of those dice and ignore one of those results.",
             "colours": [],
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "d56d93bc-1586-5d79-b536-970d4e64084b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8041ade-5522-4f81-950c-7a610a28da00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8041ade-5522-4f81-950c-7a610a28da00.jpg?1",
             "name": "Paper Tiger",
             "text": "Creatures named Rock Lobster can't attack or block.",
             "colours": [],
@@ -2808,7 +2808,7 @@
         },
         {
             "id": "0e9565c3-ded7-5fa8-94cc-88f7e609f08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab83fbe-c8b7-448c-81b6-b2e46b9f5f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab83fbe-c8b7-448c-81b6-b2e46b9f5f95.jpg?1",
             "name": "Pointy Finger of Doom",
             "text": "{3}, {T}: Spin Pointy Finger of Doom in the middle of the table so that it rotates completely at least once, then destroy the closest permanent the finger points to.",
             "colours": [],
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "276de3e0-5f7f-54ac-a491-4f50ca5c2ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e216977-d414-4e04-aca9-765ea8ea298c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e216977-d414-4e04-aca9-765ea8ea298c.jpg?1",
             "name": "Rock Lobster",
             "text": "Creatures named Scissors Lizard can't attack or block.",
             "colours": [],
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "a1059b69-5c1a-5fd0-a056-264ad09cadf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ec736-67af-443a-a91a-dfd1b2151030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ec736-67af-443a-a91a-dfd1b2151030.jpg?1",
             "name": "Scissors Lizard",
             "text": "Creatures named Paper Tiger can't attack or block.",
             "colours": [],
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "36b595c1-f6f0-5042-a812-27cfbc50a400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf451d4b-0884-4ab5-8d85-312d9db82e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf451d4b-0884-4ab5-8d85-312d9db82e76.jpg?1",
             "name": "Sword of Dungeons & Dragons",
             "text": "Equipped creature gets +2/+2 and has protection from Rogues and from Clerics.\nWhenever equipped creature deals combat damage to a player, create a 4/4 gold Dragon creature token with flying and roll a d20 (a twenty-sided die). If you roll a 20, repeat this process.\nEquip {2}",
             "colours": [],
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "e8fc008f-3f26-55d5-845a-c6f823d6e724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242e7c36-8f1a-4614-86c2-07d97cf516fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242e7c36-8f1a-4614-86c2-07d97cf516fc.jpg?1",
             "name": "Water Gun Balloon Game",
             "text": "As Water Gun Balloon Game enters the battlefield, each player puts a pop counter on \"0.\"\nWhenever a player casts a spell, move that player's pop counter up one.\nWhenever a player's pop counter hits \"5,\" that player creates a 5/5 pink Giant Teddy Bear creature token and resets all pop counters to \"0.\"",
             "colours": [],
@@ -2951,7 +2951,7 @@
         },
         {
             "id": "dc0309c2-c4e7-5abc-9cfd-ca0287f73b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c362ea-16e2-4c13-bed2-735c8c09d975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c362ea-16e2-4c13-bed2-735c8c09d975.jpg?1",
             "name": "Underdome",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to pay silver-bordered costs.",
             "colours": [],
@@ -2978,7 +2978,7 @@
         },
         {
             "id": "df3a4387-62c5-5fcc-a675-1c5e04d6103b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116a7806-1513-44b9-ae95-cbedb7e96b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116a7806-1513-44b9-ae95-cbedb7e96b89.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -3013,7 +3013,7 @@
         },
         {
             "id": "19c6f196-f59b-5e2c-b412-a03c4795427e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296cffa-be1f-49af-aaca-3166e7043de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296cffa-be1f-49af-aaca-3166e7043de0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "fd1d49da-582f-5633-81db-d2d8f76559fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5258f33-02c6-4b45-b4de-4429b4508924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5258f33-02c6-4b45-b4de-4429b4508924.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "9f97a994-46a4-5cf8-a8ac-aad1ed82a819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad5cbb-b64e-4e18-9aa0-ac076d4b2448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad5cbb-b64e-4e18-9aa0-ac076d4b2448.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "9e9f8fa6-9754-5105-97d9-aa156b2e3c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e269461e-638f-433b-979b-820f87fb431a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e269461e-638f-433b-979b-820f87fb431a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "81ac82de-a2a6-5e60-946f-56ff32de6c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4996-ed4e-4818-a9ec-f5d8ee84ad26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4996-ed4e-4818-a9ec-f5d8ee84ad26.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "675635e6-2801-552c-a45b-7aeaf20150e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee851c64-4bf9-4dde-b73e-41366828a1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee851c64-4bf9-4dde-b73e-41366828a1dc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -3226,7 +3226,7 @@
         },
         {
             "id": "6e450b23-72fb-5d1e-a68f-8fd4d0a6b119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737ac24f-a47b-486c-89df-3e3eaf495ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737ac24f-a47b-486c-89df-3e3eaf495ff5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "2fd26ecb-9919-5468-a775-2ec526a2db0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f283c-8aae-44ab-b245-c239feb23c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f283c-8aae-44ab-b245-c239feb23c16.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -3297,7 +3297,7 @@
         },
         {
             "id": "32bf6053-6ffb-5ab6-9b8d-0db1d38fa4e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a035fe-8847-4678-84f7-01bac77ae011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a035fe-8847-4678-84f7-01bac77ae011.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "fadc5bb5-e83e-5b93-96e6-7310294ea7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa4d4-106b-4fec-86ac-b81b71a8f432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa4d4-106b-4fec-86ac-b81b71a8f432.jpg?1",
             "name": "Beeble",
             "text": "",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "5ba1754c-e73f-53bd-887c-702d23c189b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f874f9-7ac2-4d1a-97e3-722db719cd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f874f9-7ac2-4d1a-97e3-722db719cd1c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "43508041-6dab-5759-858c-a3123188292d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c6d816-d9b2-4b11-b0e1-ab00be74cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c6d816-d9b2-4b11-b0e1-ab00be74cbda.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -3435,7 +3435,7 @@
         },
         {
             "id": "26d669dc-4e1b-5d56-bdad-22f9202d8b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819b8c9-73a3-4e8e-ad7a-95cffabf873a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819b8c9-73a3-4e8e-ad7a-95cffabf873a.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [],
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "6101c4b1-4dbe-5e69-99c7-ce9f45cb9390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628c542b-7579-4070-9143-6f1f7221468f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628c542b-7579-4070-9143-6f1f7221468f.jpg?1",
             "name": "Giant Teddy Bear",
             "text": "",
             "colours": [],
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "1cd42be8-2df1-5c7f-9721-8c1bac440e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fb396f-3ae1-4705-bf94-3e1b0556e910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fb396f-3ae1-4705-bf94-3e1b0556e910.jpg?1",
             "name": "Acorn Stash",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/UNF.json
+++ b/Assets/Resources/Sets/UNF.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f1bcd64f-bc78-5e47-9b21-ca6bc3e91f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a72769-f691-48c1-939f-54df244fb209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a72769-f691-48c1-939f-54df244fb209.jpg?1",
             "name": "Standard Procedure",
             "text": "",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "3550ba55-cde8-5974-8db1-725c35e36fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f4abd-089e-4015-a207-8a62616668b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f4abd-089e-4015-a207-8a62616668b1.jpg?1",
             "name": "Aerialephant",
             "text": "Flying\nWhen Aerialephant enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "b3421e63-70cc-5444-918d-fac19f50c6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e3ec6e-1375-4647-9d15-37ff4697da5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e3ec6e-1375-4647-9d15-37ff4697da5c.jpg?1",
             "name": "Assembled Ensemble",
             "text": "",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "e10470f4-b511-5b67-a426-6b1569586150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c045f20-353f-4e65-a770-dd4e2a7668c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c045f20-353f-4e65-a770-dd4e2a7668c8.jpg?1",
             "name": "Bar Entry",
             "text": "",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "a919f7dd-3486-5f09-9b44-b5a54379042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e86e72f-4c12-443a-adf7-f733945a6317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e86e72f-4c12-443a-adf7-f733945a6317.jpg?1",
             "name": "_____ Bird Gets the Worm",
             "text": "",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "6850b21a-cdb7-5ef5-a471-b87a77f44f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859428e7-0795-423b-b16f-fdb4335de2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859428e7-0795-423b-b16f-fdb4335de2b8.jpg?1",
             "name": "Clowning Around",
             "text": "Create two 1/1 white Clown Robot artifact creature tokens, then roll a six-sided die. If the result is equal to or less than the number of Robots you control, create a 1/1 white Clown Robot artifact creature token.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "40fc8103-5143-5434-a0e8-7ba4d1ced6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c733e915-aead-4f82-92d0-37eabbfd0017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c733e915-aead-4f82-92d0-37eabbfd0017.jpg?1",
             "name": "Complaints Clerk",
             "text": "When Complaints Clerk enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nWhenever you roll a 1, create a 1/1 white Clown Robot artifact creature token.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "010aaf42-d474-5b0c-8902-7767a8dd69f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c47667-1ae3-464b-9c5f-732a08a53707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c47667-1ae3-464b-9c5f-732a08a53707.jpg?1",
             "name": "Far Out",
             "text": "",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "614227a6-39a0-5fa7-badd-50ff7b53bf8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2149da9d-35ad-4f32-8072-fb515100b2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2149da9d-35ad-4f32-8072-fb515100b2fd.jpg?1",
             "name": "Form of the Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "7a74649f-f518-57dc-b73b-a9e1d6105be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bb8e82-bc4d-4140-a53b-df8844d63b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bb8e82-bc4d-4140-a53b-df8844d63b01.jpg?1",
             "name": "Get Your Head in the Game",
             "text": "",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "852b5a6b-cd9a-593f-a668-c8e7d047d9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937d151e-8912-4377-8afc-dc5c742c8a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937d151e-8912-4377-8afc-dc5c742c8a92.jpg?1",
             "name": "Gobsmacked",
             "text": "",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "410b7a27-110f-53c3-81bd-5358e7cfc94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc2b6b4-399d-411a-a057-8dd1fff0d3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc2b6b4-399d-411a-a057-8dd1fff0d3b7.jpg?1",
             "name": "A Good Day to Pie",
             "text": "Tap up to two target creatures.\nWhenever you put a name sticker on a creature, you may return A Good Day to Pie from your graveyard to your hand.",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "64e959fa-ca41-5549-bf30-45d27fdd642c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0111a98-4720-4ad8-80b0-929d08a99b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0111a98-4720-4ad8-80b0-929d08a99b04.jpg?1",
             "name": "Hat Trick",
             "text": "",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "48911cfb-8743-5aa5-b65c-5a434c469865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a8cbef-e95c-4bc0-9043-8a18e02385cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a8cbef-e95c-4bc0-9043-8a18e02385cb.jpg?1",
             "name": "Impounding Lot-Bot",
             "text": "",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "cd93e0a8-3aa2-553c-8c9c-ecaee1ce95e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca01d8c3-0b5d-4fcc-92e7-1e28956f4297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca01d8c3-0b5d-4fcc-92e7-1e28956f4297.jpg?1",
             "name": "Jetpack Janitor",
             "text": "",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "ed8b0c8a-92ad-5baf-b88b-1c8837baa6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191da6ec-22a5-4eab-a016-01cd588cce9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191da6ec-22a5-4eab-a016-01cd588cce9f.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "04755679-cee3-5adb-9c27-92675e945b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caddc44-35c1-4171-a4a1-060df29d4da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caddc44-35c1-4171-a4a1-060df29d4da9.jpg?1",
             "name": "Knight in _____ Armor",
             "text": "",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "66b61d03-6df8-57da-9db0-c57c6f4487d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f9f520-5e0a-4114-b778-6019f89d2a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f9f520-5e0a-4114-b778-6019f89d2a16.jpg?1",
             "name": "Leading Performance",
             "text": "",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "9df4b531-0e21-58a8-ad14-a3ad9a94dbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c4a63-2561-4c52-908f-7d1c08e1d9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c4a63-2561-4c52-908f-7d1c08e1d9a7.jpg?1",
             "name": "Main Event Horizon",
             "text": "",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "a6aca6f9-ac7a-540f-a1cb-dc6435154f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9745205-8bbf-4bea-a360-7662de05e47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9745205-8bbf-4bea-a360-7662de05e47b.jpg?1",
             "name": "Now You See Me . . .",
             "text": "",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "42940319-7c4f-5c22-8d12-8bc3b52e0ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711784fe-e36b-44ac-bbcc-c29921e231f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711784fe-e36b-44ac-bbcc-c29921e231f3.jpg?1",
             "name": "Park Bleater",
             "text": "Whenever another creature you own enters the battlefield, you get {Ticket}.\n{W}, {T}: You may put a sticker on a creature you own that entered the battlefield this turn.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "17807ed2-b35d-5979-8f56-c0676d25d485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff504c0-ace6-4bbb-a2b9-3518ba31f0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff504c0-ace6-4bbb-a2b9-3518ba31f0e7.jpg?1",
             "name": "Park Re-Entry",
             "text": "",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "cf022b7d-6b88-5fa2-a506-1fca06dbbbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f0d7ac-8145-46e3-a594-dd2668e30c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f0d7ac-8145-46e3-a594-dd2668e30c0c.jpg?1",
             "name": "Pin Collection",
             "text": "When Pin Collection enters the battlefield, you may put an ability sticker with ticket cost X or less on it without paying that sticker's ticket cost.\nEquipped creature gets +1/+1 and has all abilities of ability stickers on Pin Collection.\nEquip {2}",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "ac57aa92-06b4-532e-bc25-44f6ae6f59da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541f80d-f4f2-4a2a-8e17-1d6835e24469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541f80d-f4f2-4a2a-8e17-1d6835e24469.jpg?1",
             "name": "Ride Guide",
             "text": "When Ride Guide enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "44bbd6e4-30d9-5e9c-a8aa-8069d9130ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8febd2c-2f6a-47c6-bebc-6f80e175ee95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8febd2c-2f6a-47c6-bebc-6f80e175ee95.jpg?1",
             "name": "Robo-Pi\u00f1ata",
             "text": "When Robo-Pi\u00f1ata dies, choose one \u2014\n\u2022 You get {Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "2200a828-2ef1-5452-9246-fc3e716c0ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8ae57-74d4-4484-aead-56fe125f26f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8ae57-74d4-4484-aead-56fe125f26f8.jpg?1",
             "name": "Sanguine Sipper",
             "text": "Sanguine Sipper has lifelink as long as you control a stickered permanent.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "dc148059-19ae-52af-967d-d97545f83ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a97764c-0d47-4cca-8a02-2b9aade662e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a97764c-0d47-4cca-8a02-2b9aade662e1.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -973,7 +973,7 @@
         },
         {
             "id": "ec9d3b45-86f8-5ecb-a885-f6f1ad4259fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25090e-dd32-4267-a661-da3083d1737a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25090e-dd32-4267-a661-da3083d1737a.jpg?1",
             "name": "Starlight Spectacular",
             "text": "Parade \u2014 At the beginning of combat on your turn, choose creatures you control one at a time until each creature you control has been chosen. Each of those creatures gets +1/+1 until end of turn for each creature chosen before it. (Places everyone The first creature in line gets +0/+0.)",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "47e100cb-9a6b-59fd-b018-8200ac61dc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dcfb90-8720-4a85-ab5b-169668871bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dcfb90-8720-4a85-ab5b-169668871bb2.jpg?1",
             "name": "Surprise Party",
             "text": "",
             "colours": [
@@ -1041,7 +1041,7 @@
         },
         {
             "id": "1533dc94-889d-5715-bfe3-4d37eceebc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105f7d98-5288-4867-b081-c0541e5d75cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105f7d98-5288-4867-b081-c0541e5d75cc.jpg?1",
             "name": "Sword-Swallowing Seraph",
             "text": "Flying, vigilance\nWhen Sword-Swallowing Seraph enters the battlefield, you may put a name sticker on a nonland permanent you own.\n{1}{W}, {T}: Put a +1/+1 counter on another target creature with a name sticker on it. Activate only as a sorcery.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "aa293451-6533-5f51-b894-23fd4223c0e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77912a6f-774e-4bd5-8632-8fb90c9af82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77912a6f-774e-4bd5-8632-8fb90c9af82d.jpg?1",
             "name": "T.A.P.P.E.R.",
             "text": "",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "87a61251-6069-5dd9-be34-2260db24e103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490fa81f-3557-4f01-ba2d-0da10fb68a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490fa81f-3557-4f01-ba2d-0da10fb68a20.jpg?1",
             "name": "Trapeze Artist",
             "text": "",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "bc205d7d-1fe2-54cd-9ed6-6b4affb2e975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af548aa-802f-4057-8afb-225cdf19d98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af548aa-802f-4057-8afb-225cdf19d98b.jpg?1",
             "name": "Animate Object",
             "text": "",
             "colours": [
@@ -1187,7 +1187,7 @@
         },
         {
             "id": "fd6ccb9a-813f-5575-a732-2f139e89aa9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4995ce0-c588-4df5-b6e0-b4f99b861334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4995ce0-c588-4df5-b6e0-b4f99b861334.jpg?1",
             "name": "Astroquarium",
             "text": "",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "3234f7d6-e163-518c-a9e7-67340cc29ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b2911-5b22-4847-a570-c16ce719d9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b2911-5b22-4847-a570-c16ce719d9b4.jpg?1",
             "name": "Baaallerina",
             "text": "Flying\nWhen Baaallerina enters the battlefield, you may put a name sticker on a nonland permanent you own.\n{2}{U}: Another target creature with a name sticker on it gains flying until end of turn.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "60e7c3a1-fa46-5b86-816d-b7098968ff89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c3fae-9d73-42bd-88cb-0f7571059c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c3fae-9d73-42bd-88cb-0f7571059c12.jpg?1",
             "name": "Bag Check",
             "text": "",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "1afb572f-b28f-5c28-8051-998859e9170d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03511d64-3c8d-40a1-8ce2-afb46922df1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03511d64-3c8d-40a1-8ce2-afb46922df1d.jpg?1",
             "name": "Bamboozling Beeble",
             "text": "Protection from Robots\n{1}, {T}: The next time target player would roll one or more dice this turn, instead they roll that many dice plus one and you choose one of those rolls to ignore.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "4f8bbb5c-b19a-5d72-bb0f-0c8275347801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3293a-35f4-4ae3-8d88-ae4dbfb38012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3293a-35f4-4ae3-8d88-ae4dbfb38012.jpg?1",
             "name": "Bioluminary",
             "text": "Whenever Bioluminary deals combat damage to a player, you get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "4d8502fc-41f6-5016-bb76-b31a8c1a412f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0d1cc-222c-4203-8bf7-a6941d2970ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0d1cc-222c-4203-8bf7-a6941d2970ff.jpg?1",
             "name": "Blufferfish",
             "text": "",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "3eb78409-5a2e-5ce0-b91d-7e52883ff5cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefcc37a-d3d6-472e-86a5-7197c69c7217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefcc37a-d3d6-472e-86a5-7197c69c7217.jpg?1",
             "name": "Boing!",
             "text": "Return target creature to its owner's hand, then roll a six-sided die. If the result is 3 or less, scry a number of cards equal to the result.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "2eadd5ad-3791-5268-a5dd-278e234e869e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233a7a72-74b8-43de-8638-ea2f2edecb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233a7a72-74b8-43de-8638-ea2f2edecb87.jpg?1",
             "name": "Busted!",
             "text": "",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "af8effe6-fd0e-591d-894e-bc7c96f0f087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b93fc-3490-4598-95a3-302481e8679d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b93fc-3490-4598-95a3-302481e8679d.jpg?1",
             "name": "Command Performance",
             "text": "Choose two \u2014\n\u2022 Open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\n\u2022 Roll to visit your Attractions.\n\u2022 You get {Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "2163d995-017d-5f3a-8bbd-f463a7537bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28693e54-c171-4c14-bfa3-bed417779cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28693e54-c171-4c14-bfa3-bed417779cd4.jpg?1",
             "name": "Croakid Amphibonaut",
             "text": "Croakid Amphibonaut has flying as long as you control a stickered permanent.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "50964302-8f53-523d-9209-dcbe08058890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de388bf5-373e-4f3a-a7ab-cfa121f15964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de388bf5-373e-4f3a-a7ab-cfa121f15964.jpg?1",
             "name": "Decisions, Decisions",
             "text": "",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "da0d5876-9c0d-5e46-8f29-321f006bf442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c28cebf-f849-4353-9dd1-c62f05c15d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c28cebf-f849-4353-9dd1-c62f05c15d0f.jpg?1",
             "name": "Exchange of Words",
             "text": "When Exchange of Words enters the battlefield, choose two target creatures. For as long as Exchange of Words remains on the battlefield, exchange the text boxes of those creatures.",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "2f38f665-b018-55d7-9968-b61122c2f749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c974d9a-40a6-4072-90b2-01c3b3461a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c974d9a-40a6-4072-90b2-01c3b3461a75.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "49f39c5a-7ac1-50bc-acba-fe448931b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba6fc40-1289-4b29-88f9-28de94585b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba6fc40-1289-4b29-88f9-28de94585b46.jpg?1",
             "name": "Focused Funambulist",
             "text": "",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "5880d58d-db5f-5b3c-936b-d9d60877bf9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03dfb51-c0df-4cb7-8e42-57d52cec4e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03dfb51-c0df-4cb7-8e42-57d52cec4e89.jpg?1",
             "name": "Glitterflitter",
             "text": "Flying\nWhen Glitterflitter enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -1723,7 +1723,7 @@
         },
         {
             "id": "f64812bf-fe37-5031-911e-006fb44189ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e47aa-563d-4501-bbb3-2442b4ca037d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e47aa-563d-4501-bbb3-2442b4ca037d.jpg?1",
             "name": "How Is This a Par Three?!",
             "text": "",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "e486d4d0-e66f-5e1b-8ee4-76d5e1b8c982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a10b13c-ad97-49a7-9026-dcbd3599ce4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a10b13c-ad97-49a7-9026-dcbd3599ce4c.jpg?1",
             "name": "Make a _____ Splash",
             "text": "",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "d0456cb1-7118-5b3d-9b6b-b08fd285b88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f080ab50-c78c-4a27-a7e5-abfbd93f4e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f080ab50-c78c-4a27-a7e5-abfbd93f4e41.jpg?1",
             "name": "Mobile Clone",
             "text": "",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "09e173b5-4e1c-5dfd-a3c1-ba86b7b0c412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e042a9-0321-4092-8512-ee1d93f3a5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e042a9-0321-4092-8512-ee1d93f3a5f4.jpg?1",
             "name": "Monitor Monitor",
             "text": "When Monitor Monitor enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nOnce each turn, you may pay {1} to reroll one or more dice you rolled.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "ccf4948b-8623-5908-b703-e0515a1b2688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1d2b1d-d264-4a8e-9c33-c35f5d1e80bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1d2b1d-d264-4a8e-9c33-c35f5d1e80bc.jpg?1",
             "name": "Motion Sickness",
             "text": "Enchant creature\nWhen Motion Sickness enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhenever you visit an Attraction, you may attach Motion Sickness to target tapped creature.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "25fdda67-861a-557a-85b7-0e50f7fca581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c590e5-be42-4acc-80ef-b27def8d896b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c590e5-be42-4acc-80ef-b27def8d896b.jpg?1",
             "name": "Octo Opus",
             "text": "",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "30c79851-753c-5865-9583-6a74de69f16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66e33a-3a11-494f-9c23-8e410f7cdae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66e33a-3a11-494f-9c23-8e410f7cdae4.jpg?1",
             "name": "Phone a Friend",
             "text": "",
             "colours": [
@@ -1966,7 +1966,7 @@
         },
         {
             "id": "dba17347-1500-5e99-b814-87b65ddcd3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba43188f-ac49-4c6a-b53c-9170fe047aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba43188f-ac49-4c6a-b53c-9170fe047aa5.jpg?1",
             "name": "Plate Spinning",
             "text": "",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "8a0bab82-5e06-5a44-a84e-c8fdccecc399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffd0fd2-2e53-41a8-8824-7ae4ba1a886f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffd0fd2-2e53-41a8-8824-7ae4ba1a886f.jpg?1",
             "name": "Prize Wall",
             "text": "Defender\n{U}, {T}: You get {Ticket}.\n{4}{U}, {T}: You may put a sticker on a nonland permanent you own. Activate only as a sorcery.",
             "colours": [
@@ -2036,7 +2036,7 @@
         },
         {
             "id": "0e68e360-2c80-5387-9797-3ca6fe3d3522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d43a529-5005-463f-98f7-8931d955b07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d43a529-5005-463f-98f7-8931d955b07e.jpg?1",
             "name": "Seasoned Buttoneer",
             "text": "When Seasoned Buttoneer enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "2a353a31-523b-54bc-b70a-76a2eb804b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450c264f-008b-4360-b0ee-f0448ca8fedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450c264f-008b-4360-b0ee-f0448ca8fedc.jpg?1",
             "name": "Super-Duper Lost",
             "text": "",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "8509bd35-99d6-5d16-8f61-6db10519dbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456149a1-0f15-466a-8d07-803efb5721d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456149a1-0f15-466a-8d07-803efb5721d5.jpg?1",
             "name": "Treacherous Trapezist",
             "text": "",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "b19b4372-736d-5f27-9bdf-122977c6c5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacc52b-9e52-42d3-a152-0c96ff55ab44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacc52b-9e52-42d3-a152-0c96ff55ab44.jpg?1",
             "name": "_____ _____ _____ Trespasser",
             "text": "When this creature enters the battlefield, you may put a name sticker on it.\n{3}{U}: This creature gets +1/+0 until end of turn for each name sticker on it. It can't be blocked this turn.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "f0da1cd3-7601-56ba-86b4-b14dacf6057c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402a29c1-1270-4a2a-8099-4c489e3c1adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402a29c1-1270-4a2a-8099-4c489e3c1adf.jpg?1",
             "name": "Unlawful Entry",
             "text": "Target creature gets +1/+0 and gains flying until end of turn.\nWhenever you put an art sticker on a creature, you may return Unlawful Entry from your graveyard to your hand.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "d4f547c7-a7d4-5f97-8e7b-9e8c1d30924a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdc091b-c528-4058-ae10-d9b209d5cee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdc091b-c528-4058-ae10-d9b209d5cee8.jpg?1",
             "name": "Vedalken Squirrel-Whacker",
             "text": "As Vedalken Squirrel-Whacker enters the battlefield, roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result.\nIf you would roll one or more six-sided dice, instead roll them and you may exchange one result with Vedalken Squirrel-Whacker's base power or base toughness.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "67d49392-426f-526d-a294-99e9b9a9887b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0df840-e050-42b9-8f81-6682fe16d377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0df840-e050-42b9-8f81-6682fe16d377.jpg?1",
             "name": "Wizards of the _____",
             "text": "",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "1716cd04-e660-5de9-bb7f-cfdce17e9b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f7b63b-44b1-4119-a4bf-c10fe3429d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f7b63b-44b1-4119-a4bf-c10fe3429d91.jpg?1",
             "name": "Animate Graveyard",
             "text": "",
             "colours": [
@@ -2327,7 +2327,7 @@
         },
         {
             "id": "fb70000e-2b0e-5d93-bd78-b9dacae67b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840dd63f-55c7-4bf3-b748-b157721054ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840dd63f-55c7-4bf3-b748-b157721054ad.jpg?1",
             "name": "Attempted Murder",
             "text": "Choose target creature. Roll X six-sided dice. For each even result, put two -1/-1 counters on that creature. For each odd result, create a 1/2 blue Bird creature token with flying named Storm Crow.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "841c9620-f9c3-5511-a13a-1effb040cb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed3fc60-9079-486b-a05e-00f926a99b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed3fc60-9079-486b-a05e-00f926a99b4e.jpg?1",
             "name": "Black Hole",
             "text": "",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "e9cef9eb-dc21-5065-a811-ca534c8a5143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e6ce64-0907-4db2-a0b6-4f79ba76616b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e6ce64-0907-4db2-a0b6-4f79ba76616b.jpg?1",
             "name": "Carnival Carnivore",
             "text": "Deathtouch\nWhen Carnival Carnivore enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "7b48a425-1eea-579d-84b3-72e34b90067f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850c354-6737-4b72-a5bf-fd99f866259a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850c354-6737-4b72-a5bf-fd99f866259a.jpg?1",
             "name": "Deadbeat Attendant",
             "text": "When Deadbeat Attendant enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "799302a9-ff50-5631-97db-b0bb287c5e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2658ceab-8d96-44d2-b443-ef671deca928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2658ceab-8d96-44d2-b443-ef671deca928.jpg?1",
             "name": "Discourtesy Clerk",
             "text": "When Discourtesy Clerk enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nAt the beginning of your end step, if you control three or more Attractions, you draw a card and you lose 1 life.",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "046d1a6e-2e7d-5e97-95d2-728e521141df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a467916f-f0dd-4211-a96f-4a01fbad6f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a467916f-f0dd-4211-a96f-4a01fbad6f4e.jpg?1",
             "name": "Disemvowel",
             "text": "",
             "colours": [
@@ -2541,7 +2541,7 @@
         },
         {
             "id": "0c16b404-8032-5292-a046-d1555ff5f4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5df2dd-0a16-4f3c-9352-91bd87b955b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5df2dd-0a16-4f3c-9352-91bd87b955b4.jpg?1",
             "name": "Dissatisfied Customer",
             "text": "Flying, haste\nWhen Dissatisfied Customer enters the battlefield, roll a six-sided die. If the result is 3 or less, you lose that much life.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "0e936c9e-82af-59bd-8107-ee59b9f70fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad23c10-3180-456f-b781-84d3893a6815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad23c10-3180-456f-b781-84d3893a6815.jpg?1",
             "name": "Down for Repairs",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Destroy up to one target Attraction that player controls. (It's put into their junkyard.)",
             "colours": [
@@ -2612,7 +2612,7 @@
         },
         {
             "id": "fd3001f0-efb3-56f6-977e-f7822165bfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b584e-4646-4301-b1de-44717336e590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b584e-4646-4301-b1de-44717336e590.jpg?1",
             "name": "Exit Through the Grift Shop",
             "text": "",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "698369c8-ecf3-51d0-af7f-4b04f25c9f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf4ab1-f558-41fb-a7b5-3e543a307e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf4ab1-f558-41fb-a7b5-3e543a307e1c.jpg?1",
             "name": "Gray Merchant of Alphabet",
             "text": "",
             "colours": [
@@ -2683,7 +2683,7 @@
         },
         {
             "id": "eb55ed1a-341c-594b-859b-74c195efd992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35fa37b-5119-49b1-a51b-bb359ee272be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35fa37b-5119-49b1-a51b-bb359ee272be.jpg?1",
             "name": "Haberthrasher",
             "text": "",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "9d80181f-e1a7-5c12-a950-3f9d4dc1cf03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b0c89-e811-426c-b185-6d51946c4235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b0c89-e811-426c-b185-6d51946c4235.jpg?1",
             "name": "Knife and Death",
             "text": "",
             "colours": [
@@ -2755,7 +2755,7 @@
         },
         {
             "id": "84765d33-4468-5d52-ae4a-307f62737e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b746c03f-85bf-429f-ba93-cd5d6a6999fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b746c03f-85bf-429f-ba93-cd5d6a6999fb.jpg?1",
             "name": "Last Voyage of the _____",
             "text": "",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "45080400-cacf-5ae0-a069-4c4e7a1eeafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fede7f75-0dff-4f3e-816d-e52b43e8b33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fede7f75-0dff-4f3e-816d-e52b43e8b33b.jpg?1",
             "name": "\"Lifetime\" Pass Holder",
             "text": "\"Lifetime\" Pass Holder enters the battlefield tapped.\nWhen \"Lifetime\" Pass Holder dies, open an Attraction.\nWhenever you roll to visit your Attractions, if you roll a 6, you may return \"Lifetime\" Pass Holder from your graveyard to the battlefield.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "3fdd8ae2-023d-5e1c-9aab-5521735fb86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ddf4-e86f-406e-a31b-47aede5a97c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ddf4-e86f-406e-a31b-47aede5a97c6.jpg?1",
             "name": "Line Cutter",
             "text": "",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "66aaea5d-dfdf-5872-9fd0-c70d134b55a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ccea2d-5cde-4c30-a498-66199cbc90a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ccea2d-5cde-4c30-a498-66199cbc90a2.jpg?1",
             "name": "Night Shift of the Living Dead",
             "text": "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.\nWhenever you roll a 6, create a 2/2 black Zombie Employee creature token.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "dc2645f8-31f2-5396-a3ef-d720393c27e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d19cd-e51d-4cee-97ca-1aa646d5bf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d19cd-e51d-4cee-97ca-1aa646d5bf30.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -2939,7 +2939,7 @@
         },
         {
             "id": "36d1fe5f-94de-5081-9624-8704042b53c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eb480e-c7e7-4177-83b7-ebd4334b15f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eb480e-c7e7-4177-83b7-ebd4334b15f0.jpg?1",
             "name": "Photo Op",
             "text": "",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "21bd4331-b49e-5782-b85c-248872ca1182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1219a1c-21da-468e-8aa2-085ba2d9db6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1219a1c-21da-468e-8aa2-085ba2d9db6d.jpg?1",
             "name": "Questionable Cuisine",
             "text": "",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "5a232b48-ebfc-5219-bf4d-e78a26cbb0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78c8da1-7220-4fbf-b672-547af59d2490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78c8da1-7220-4fbf-b672-547af59d2490.jpg?1",
             "name": "Quick Fixer",
             "text": "",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "8db18424-b8b3-55c4-bb5a-291fcee41282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c41ae26-23be-4ebe-9ca2-b972ca2b8f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c41ae26-23be-4ebe-9ca2-b972ca2b8f91.jpg?1",
             "name": "Rat in the Hat",
             "text": "",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "99ed7914-775c-5ad6-a87e-a622cb1b320d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e053a-1287-4f4d-b1c2-daf0819c9230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e053a-1287-4f4d-b1c2-daf0819c9230.jpg?1",
             "name": "A Real Handful",
             "text": "",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "79833cec-eeb0-546a-abd3-3e33413800bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e6a7bc-a35a-4e68-99a0-be264553b5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e6a7bc-a35a-4e68-99a0-be264553b5de.jpg?1",
             "name": "Saw in Half",
             "text": "Destroy target creature. If that creature dies this way, its controller creates two tokens that are copies of that creature, except their base power is half that creature's power and their base toughness is half that creature's toughness. Round up each time.",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "e226b6f5-6319-5df3-af1e-672db3d30c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31950e19-83ca-45d4-8ca1-e109b875fd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31950e19-83ca-45d4-8ca1-e109b875fd67.jpg?1",
             "name": "Scampire",
             "text": "When Scampire enters the battlefield, you get {Ticket}, then you may put a sticker on a creature card in your graveyard.\n{3}{B}: Return target creature card with a sticker on it from your graveyard to the battlefield. That creature gains haste. Exile it at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "f5c82f29-e7ac-5256-ad8a-7f097d345524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc479ea0-7c38-49ae-9dc6-1c85183fe6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc479ea0-7c38-49ae-9dc6-1c85183fe6c8.jpg?1",
             "name": "Scared Stiff",
             "text": "Scared Stiff has menace as long you control a stickered permanent.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "befe1198-35d3-5c94-a4b1-49a4b8869a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443a18c0-0e72-4dd5-ba5e-8e2a486ae0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443a18c0-0e72-4dd5-ba5e-8e2a486ae0a7.jpg?1",
             "name": "Scooch",
             "text": "",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "acccc971-d158-596e-aff3-1c4ea82b70c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0902a-1bc7-4231-8530-2b0fe28a6030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0902a-1bc7-4231-8530-2b0fe28a6030.jpg?1",
             "name": "Six-Sided Die",
             "text": "Choose target creature. Roll a six-sided die.\n1 \u2014 It has base toughness 1 until end of turn.\n2 \u2014 Put two -1/-1 counters on it.\n3 \u2014 Six-Sided Die deals 3 damage to it and you gain 3 life.\n4 \u2014 It gets -4/-4 until end of turn.\n5 \u2014 Destroy it.\n6 \u2014 Exile it.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "0005fe8b-170d-5381-baaf-3d6bd58042f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d07a8e-2880-40bd-a80b-c8d938a3761b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d07a8e-2880-40bd-a80b-c8d938a3761b.jpg?1",
             "name": "Soul Swindler",
             "text": "As long as you've visited an Attraction this turn, Soul Swindler has indestructible. (Damage and effects that say \"destroy\" don't destroy it.)\nWhen Soul Swindler enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "9344f47d-b912-5c61-8a83-0022a0ee6121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea143b9-140a-4e73-9c23-79327df1ccfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea143b9-140a-4e73-9c23-79327df1ccfa.jpg?1",
             "name": "Step Right Up",
             "text": "Open two Attractions. (Put the top two cards of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "5e5afbea-e855-5504-a824-441af557e2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d009df3-4a15-4614-b365-ac42755b386f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d009df3-4a15-4614-b365-ac42755b386f.jpg?1",
             "name": "Wolf in _____ Clothing",
             "text": "",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "a4c8e8be-33fa-5ef2-9f74-e58679a07f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc45cb-0bf5-423d-adeb-112b24c4d57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc45cb-0bf5-423d-adeb-112b24c4d57f.jpg?1",
             "name": "Xenosquirrels",
             "text": "Xenosquirrels enters the battlefield with two +1/+1 counters on it.\nAfter you roll a die, you may remove a +1/+1 counter from Xenosquirrels. If you do, increase or decrease the result by 1.",
             "colours": [
@@ -3441,7 +3441,7 @@
         },
         {
             "id": "98cb2d85-6133-5780-ab3e-e2353b980da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c775a7d1-a1f7-460b-b1f4-888006058e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c775a7d1-a1f7-460b-b1f4-888006058e15.jpg?1",
             "name": "Aardwolf's Advantage",
             "text": "",
             "colours": [
@@ -3475,7 +3475,7 @@
         },
         {
             "id": "9c56d5bb-fde4-5486-865c-3df6f1d81f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9a9810-ad37-4575-8773-de428174af8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9a9810-ad37-4575-8773-de428174af8d.jpg?1",
             "name": "Amped Up",
             "text": "",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "d2801d98-cc43-5ce7-a921-dd9ecd60ac51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ece617-f845-47e9-8fee-8533db5c7a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ece617-f845-47e9-8fee-8533db5c7a2f.jpg?1",
             "name": "Art Appreciation",
             "text": "",
             "colours": [
@@ -3543,7 +3543,7 @@
         },
         {
             "id": "ad17c807-d5d9-5377-88ac-229bab2abc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb567441-1880-4b34-9c48-6d2c45062eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb567441-1880-4b34-9c48-6d2c45062eb0.jpg?1",
             "name": "_____ Balls of Fire",
             "text": "",
             "colours": [
@@ -3577,7 +3577,7 @@
         },
         {
             "id": "c538171e-c8f0-513c-ae97-33d734fb603b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68808b7-b22f-47c6-b654-16d95fc9169b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68808b7-b22f-47c6-b654-16d95fc9169b.jpg?1",
             "name": "Big Winner",
             "text": "",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "17b9bdc9-ff74-5109-aeed-a0b728227d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c29dab-5cd4-4158-9a12-f14004e08484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c29dab-5cd4-4158-9a12-f14004e08484.jpg?1",
             "name": "Carnival Barker",
             "text": "",
             "colours": [
@@ -3652,7 +3652,7 @@
         },
         {
             "id": "4c9cd78b-257e-56cb-a9cd-8e95ba47c2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21045d6-638e-4267-b353-c2c11db8d965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21045d6-638e-4267-b353-c2c11db8d965.jpg?1",
             "name": "Circuits Act",
             "text": "Roll three six-sided dice. For each different result, create a 1/1 white Clown Robot artifact creature token.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "d1d1df68-eae4-5701-a2c2-9fdff7e21860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e71131-9591-4773-9c6a-1dc381d0e1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e71131-9591-4773-9c6a-1dc381d0e1ab.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "cc8b4ad6-a9df-5150-92d2-1f883afebeb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c5c1e-1d48-481d-b3b3-97e9cc8416f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c5c1e-1d48-481d-b3b3-97e9cc8416f3.jpg?1",
             "name": "Don't Try This at Home",
             "text": "",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "7958b797-2eb7-5872-9c77-3053f068225a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19d1e98-f667-4a3b-9e78-a416118aec52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19d1e98-f667-4a3b-9e78-a416118aec52.jpg?1",
             "name": "Eelectrocute",
             "text": "Eelectrocute deals 2 damage to any target.\nYou may cast Eelectrocute from your graveyard as long as you've rolled a 6 this turn. If you cast Eelectrocute this way and it would be put into your graveyard, exile it instead.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "2149c489-5ddc-5aeb-bda6-b53c24e4562c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5819e3f3-da49-4003-88ce-f3b7bb495787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5819e3f3-da49-4003-88ce-f3b7bb495787.jpg?1",
             "name": "_____ Goblin",
             "text": "",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "22718764-ec13-50f4-b019-aaf94df0ee0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a42d2c-8ef3-4789-a0c9-eacdc9005fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a42d2c-8ef3-4789-a0c9-eacdc9005fc2.jpg?1",
             "name": "Goblin Airbrusher",
             "text": "Whenever you place a sticker, create a Treasure token. If it's an art sticker, instead create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "a5c0136c-1f93-50b4-99d0-0170938ece07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f4263e-4630-4e22-b3b5-d2abf829567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f4263e-4630-4e22-b3b5-d2abf829567d.jpg?1",
             "name": "Goblin Blastronauts",
             "text": "",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "b8369e15-cd47-56f6-a6af-508b22dcab61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90bd23d-0f0f-41d7-ba12-776f012714f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90bd23d-0f0f-41d7-ba12-776f012714f7.jpg?1",
             "name": "Goblin Cruciverbalist",
             "text": "",
             "colours": [
@@ -3944,7 +3944,7 @@
         },
         {
             "id": "1c566088-6d40-5e0a-93cb-30200ec633a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cff141a-6202-436c-ac91-bc3a357aa25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cff141a-6202-436c-ac91-bc3a357aa25e.jpg?1",
             "name": "Goblin Girder Gang",
             "text": "",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "1fe57a4e-0f93-5dea-83d0-c3c33558bf6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6342b-0b9e-4379-b433-70bbaeb04c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6342b-0b9e-4379-b433-70bbaeb04c19.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "73ad2c9d-d56b-569a-a206-f670ca6d2846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81503e0b-02cb-4441-9fd6-2c3dced877a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81503e0b-02cb-4441-9fd6-2c3dced877a2.jpg?1",
             "name": "Juggletron",
             "text": "",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "b1f2b6e5-6a24-5bd3-a88f-dba1e1bdbcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8994e99-2a63-4b2f-906f-373065aa3319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8994e99-2a63-4b2f-906f-373065aa3319.jpg?1",
             "name": "Minotaur de Force",
             "text": "Haste\nWhen Minotaur de Force enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "2ddd44cc-66f6-5ff2-a400-9711f69a9709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc051b2-9119-4a12-a8eb-8369954442be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc051b2-9119-4a12-a8eb-8369954442be.jpg?1",
             "name": "Non-Human Cannonball",
             "text": "When Non-Human Cannonball dies, roll a six-sided die. If the result is 4 or less, Non-Human Cannonball deals that much damage to you.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "fc67e003-fae4-5b85-9ffc-69190efb5c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "1b032576-c900-5132-b9a2-c8a6c09b5e43",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "33bab751-55e2-527e-8fe3-465771a0641d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96e3f29-bb0d-49d0-9649-19c3c9b9f40d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96e3f29-bb0d-49d0-9649-19c3c9b9f40d.jpg?1",
             "name": "One-Clown Band",
             "text": "{2}{R}: Target Robot gets +2/+0 until end of turn.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "d72b09c5-7683-5ed7-b4bf-c730c500fc91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1725526f-9a18-4cbd-83cf-16334aa56e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1725526f-9a18-4cbd-83cf-16334aa56e76.jpg?1",
             "name": "Opening Ceremony",
             "text": "",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "aed8fe33-181e-5d35-9869-5a4e114bb133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26243a5b-c489-4691-b1aa-347f7e0d2080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26243a5b-c489-4691-b1aa-347f7e0d2080.jpg?1",
             "name": "Priority Boarding",
             "text": "",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "ee781801-d76d-5aad-a32c-30a4ec308e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e10062a-4406-478d-a594-0be78a982c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e10062a-4406-478d-a594-0be78a982c76.jpg?1",
             "name": "Proficient Pyrodancer",
             "text": "When Proficient Pyrodancer enters the battlefield, you may put an art sticker on a nonland permanent you own.\n{2}{R}: Another target creature with an art sticker on it gets +2/+0 and gains menace until end of turn.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "f19f246b-2c59-5504-b3ca-f1961b3ac89b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18961324-dbfb-4491-af66-ba8ccfbc94f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18961324-dbfb-4491-af66-ba8ccfbc94f4.jpg?1",
             "name": "Rad Rascal",
             "text": "When Rad Rascal enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "1fa705f7-0cc2-5df2-b038-fa86f46a7770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66425c96-9fa9-4ba5-8198-619ae4632ed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66425c96-9fa9-4ba5-8198-619ae4632ed6.jpg?1",
             "name": "Rock Star",
             "text": "",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "c247681c-7cc1-51aa-a8e4-bdcc166b4a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128cc33-05e3-4b2b-8b24-7f574d3f0d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128cc33-05e3-4b2b-8b24-7f574d3f0d53.jpg?1",
             "name": "Slight Malfunction",
             "text": "",
             "colours": [
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "ec76f3dc-e73d-53b7-843d-8eeb8605b26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8c30b-15e5-44c4-8fe0-431e905f4f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8c30b-15e5-44c4-8fe0-431e905f4f42.jpg?1",
             "name": "Ticking Mime Bomb",
             "text": "",
             "colours": [
@@ -4504,7 +4504,7 @@
         },
         {
             "id": "7dd133c6-9dfb-5676-8f75-dbe63cdea545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cafb84c-6e35-488c-a219-c6bbdb3ac565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cafb84c-6e35-488c-a219-c6bbdb3ac565.jpg?1",
             "name": "Trigger Happy",
             "text": "",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "8070623c-6079-5985-a951-000c9a7cb241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd42cab5-3285-48bf-a8f2-f57a474565ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd42cab5-3285-48bf-a8f2-f57a474565ad.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "174fef55-6406-52df-88e9-4ad48a90a563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7338aa7e-09d0-485c-a223-9395ed9704e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7338aa7e-09d0-485c-a223-9395ed9704e3.jpg?1",
             "name": "Wee Champion",
             "text": "Whenever you place a sticker, Wee Champion gets +1/+1 until end of turn. If it's an art sticker, instead put a +1/+1 counter on Wee Champion.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "71cd8dc7-011a-5a99-96d8-6afa20498d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6eb108-d865-4f9f-8fd5-d10495c036a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6eb108-d865-4f9f-8fd5-d10495c036a3.jpg?1",
             "name": "Well Done",
             "text": "",
             "colours": [
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "501fdd3b-98c5-56bf-8ded-666a2928802c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782e572-0cea-47a3-9ce9-3c431fbd44f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782e572-0cea-47a3-9ce9-3c431fbd44f8.jpg?1",
             "name": "Alpha Guard",
             "text": "",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "017c5c8d-7481-5819-8fbc-6b049008c448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cc109-0f43-4957-a4a8-6313b851edae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cc109-0f43-4957-a4a8-6313b851edae.jpg?1",
             "name": "Atomwheel Acrobats",
             "text": "Whenever you roll a 1 or 2, put that many +1/+1 counters on Atomwheel Acrobats.\n{2}{G}: Roll a six-sided die.",
             "colours": [
@@ -4729,7 +4729,7 @@
         },
         {
             "id": "b6027e03-b09e-54be-a70d-6b9b9db21e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8de9fc5-9d0b-456b-8ce4-90e6d76f3838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8de9fc5-9d0b-456b-8ce4-90e6d76f3838.jpg?1",
             "name": "Blorbian Buddy",
             "text": "Trample\n{G}, {T}: You get {Ticket} (a ticket counter).",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "8c869c02-eb1c-5af1-bfa2-74ca8066ead4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eecbc0a-237d-433f-9edf-7420819f1301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eecbc0a-237d-433f-9edf-7420819f1301.jpg?1",
             "name": "Centaur of Attention",
             "text": "When Centaur of Attention enters the battlefield, roll five six-sided dice and store those results on it.\nAt the beginning of combat on your turn, you may reroll any number of Centaur of Attention's stored results.\nCentaur of Attention gets +X/+X, where X is the greatest number of stored results on it of the same value.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "1d29926e-d8a0-55d1-8628-96648271daeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68cf6bc-3b4f-4765-87a7-f4b390d08bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68cf6bc-3b4f-4765-87a7-f4b390d08bca.jpg?1",
             "name": "Chicken Troupe",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Chicken Troupe enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "e3b2d231-0f49-5353-8f40-85388e54ebbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7254a-68fd-4841-9f88-ebf54d5e9731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7254a-68fd-4841-9f88-ebf54d5e9731.jpg?1",
             "name": "Clandestine Chameleon",
             "text": "When Clandestine Chameleon enters the battlefield, you get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own.\nClandestine Chameleon has all abilities of ability stickers on other permanents you own and cards in your graveyard.",
             "colours": [
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "1ae02284-ebbd-59e1-9d02-b82c967f3bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0f726-fc72-42ac-b350-3c2813abefa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0f726-fc72-42ac-b350-3c2813abefa4.jpg?1",
             "name": "Coming Attraction",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -4911,7 +4911,7 @@
         },
         {
             "id": "20e39b5e-4d46-5c45-8032-3b4f6edaa5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba0d7c-1e1e-4378-b25b-a531d1937779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba0d7c-1e1e-4378-b25b-a531d1937779.jpg?1",
             "name": "Done for the Day",
             "text": "At the beginning of your end step, if you control an Employee, a Performer, or a Robot, you may get {Ticket} or create a Treasure token. If you control all three, you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -4945,7 +4945,7 @@
         },
         {
             "id": "131d2bb8-f0fe-5d53-9927-28419f767ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b759c27-9fb6-4c23-adc1-f6d3f3a0eb52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b759c27-9fb6-4c23-adc1-f6d3f3a0eb52.jpg?1",
             "name": "Embiggen",
             "text": "Until end of turn, target non-Brushwagg creature gets +1/+1 for each supertype, card type, and subtype it has.",
             "colours": [
@@ -4979,7 +4979,7 @@
         },
         {
             "id": "fe7f1ac6-7ad2-50fe-ae82-02535983d2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dcd89f-a626-4dcb-ae73-7b8605747099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dcd89f-a626-4dcb-ae73-7b8605747099.jpg?1",
             "name": "Fight the _____ Fight",
             "text": "",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "c4451d8c-f954-5f2a-b6e3-0f684f991a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadd9acf-3c42-4be4-bb45-551736535cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadd9acf-3c42-4be4-bb45-551736535cb7.jpg?1",
             "name": "Finishing Move",
             "text": "You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "36251069-e2e2-521d-b180-f2d45f842b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9975e-a363-4874-b357-ed3e0183a7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9975e-a363-4874-b357-ed3e0183a7a2.jpg?1",
             "name": "Grabby Tabby",
             "text": "Grabby Tabby has vigilance as long as you control a stickered permanent.",
             "colours": [
@@ -5086,7 +5086,7 @@
         },
         {
             "id": "ffc6c69e-cb16-5bda-b806-8399b5c19ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80225482-6566-41fb-ade7-d9646426a4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80225482-6566-41fb-ade7-d9646426a4be.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "8ae6c9ec-5e9f-5339-8728-dd3dec25af68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d270c5-9619-41a3-849f-d0d836bb1b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d270c5-9619-41a3-849f-d0d836bb1b2e.jpg?1",
             "name": "Icing Manipulator",
             "text": "",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "33a6fb25-6783-580f-a590-225e91d0bac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ba21ae-9b76-426b-9d79-52373ca0ca20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ba21ae-9b76-426b-9d79-52373ca0ca20.jpg?1",
             "name": "An Incident Has Occurred",
             "text": "",
             "colours": [
@@ -5198,7 +5198,7 @@
         },
         {
             "id": "4c8d5dc8-0638-5d1a-8534-fe51bbc0d750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b423097-a056-4673-bd7e-ca94a41a7aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b423097-a056-4673-bd7e-ca94a41a7aee.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "1679a94b-fae5-5d55-b95b-27381304ba0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c0ac1f-8e40-427e-832c-4d1c6d2ce41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c0ac1f-8e40-427e-832c-4d1c6d2ce41c.jpg?1",
             "name": "Killer Cosplay",
             "text": "",
             "colours": [
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "6c625c6d-6a31-51db-8467-b3b80f01ee40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbb63c-ffc7-4183-a5e2-b55b035dc033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbb63c-ffc7-4183-a5e2-b55b035dc033.jpg?1",
             "name": "Lineprancers",
             "text": "When Lineprancers enters the battlefield, you get {Ticket}{Ticket}, then you may put a power and toughness sticker on a creature you own.\n{3}{G}: Target creature you don't control blocks target creature you control with a power and toughness sticker on it other than Lineprancers this turn if able.",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "457f2652-0563-58cc-9fd3-fcd857b5fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4764da-c508-4a7e-aabc-771f22a32c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4764da-c508-4a7e-aabc-771f22a32c23.jpg?1",
             "name": "Mistakes Were Made",
             "text": "",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "5c13469e-09fc-5220-bbf4-c5e97969c5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db23c3-7ff6-4b86-a6a6-7c1d9c810e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db23c3-7ff6-4b86-a6a6-7c1d9c810e6e.jpg?1",
             "name": "_____-o-saurus",
             "text": "",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "909602a5-f336-5afe-a85d-a46b88698687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567665f3-4227-4f3c-bfbe-4e9576f32b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567665f3-4227-4f3c-bfbe-4e9576f32b50.jpg?1",
             "name": "Pair o' Dice Lost",
             "text": "Roll two six-sided dice. Return any number of cards with total mana value X or less from your graveyard to your hand, where X is the total of those results. Exile Pair o' Dice Lost.",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "c140c331-0cb7-5517-98ba-6ab71e367bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb72280-0544-450a-afc6-afec159e6c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb72280-0544-450a-afc6-afec159e6c1f.jpg?1",
             "name": "Petting Zookeeper",
             "text": "Reach\nWhen Petting Zookeeper enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "c0acfd21-0ec0-51f0-8930-4165601a548d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1898d1-af70-4386-bd81-b1804dc0a801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1898d1-af70-4386-bd81-b1804dc0a801.jpg?1",
             "name": "Pie-Eating Contest",
             "text": "",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "08aab601-961f-5ba3-a382-5eca12296cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77594270-42ca-4578-96b6-9a3af18e44de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77594270-42ca-4578-96b6-9a3af18e44de.jpg?1",
             "name": "Plot Armor",
             "text": "",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "e6b11987-382d-5984-9c1c-4d1d984eb777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95cc18-128e-45ca-9255-49b15307f271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95cc18-128e-45ca-9255-49b15307f271.jpg?1",
             "name": "Resolute Veggiesaur",
             "text": "Trample\nWhenever you roll your third die each turn, put a +1/+1 counter on Resolute Veggiesaur.",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "fec1abfa-93ee-55cb-8483-0d5939876411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65e8d13-10b1-4d0b-813f-c45058560e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65e8d13-10b1-4d0b-813f-c45058560e5c.jpg?1",
             "name": "Sole Performer",
             "text": "",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "2ed1684d-9bcc-5974-90c1-4857f40e311f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ceb595-33cd-4b5c-8a23-83b1cd5709d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ceb595-33cd-4b5c-8a23-83b1cd5709d0.jpg?1",
             "name": "Spelling Bee",
             "text": "",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "0c5c324d-f5c9-553a-8710-e547af4b6f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ba935d-43b9-4661-8d2c-9e6b457c5b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ba935d-43b9-4661-8d2c-9e6b457c5b68.jpg?1",
             "name": "Squirrel Squatters",
             "text": "When Squirrel Squatters enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nWhenever Squirrel Squatters attacks, create a 1/1 green Squirrel creature token that's tapped and attacking for each Attraction you've visited this turn.",
             "colours": [
@@ -5671,7 +5671,7 @@
         },
         {
             "id": "d204880a-c468-5656-a808-4e71eaa4bb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd16fe9d-9f31-4fe8-941e-f5728cd394a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd16fe9d-9f31-4fe8-941e-f5728cd394a9.jpg?1",
             "name": "Stiltstrider",
             "text": "Reach\nWhen Stiltstrider enters the battlefield, you get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "656d7f3f-3583-51ef-b8a3-043a676ec5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658d1a66-27dc-45fa-9b2a-91b012b1a86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658d1a66-27dc-45fa-9b2a-91b012b1a86f.jpg?1",
             "name": "Tchotchke Elemental",
             "text": "",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "c53df4b5-2efb-5d2c-9960-71cb696e419f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db51cafc-7177-4644-b149-4bef3b73fea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db51cafc-7177-4644-b149-4bef3b73fea8.jpg?1",
             "name": "Tug of War",
             "text": "",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "ed41c6a5-32c5-5aa8-80b6-de1d6fbbe895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78514029-667b-4102-bfea-e154a341be3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78514029-667b-4102-bfea-e154a341be3c.jpg?1",
             "name": "Vegetation Abomination",
             "text": "Deathtouch\n{T}, Sacrifice Vegetation Abomination: Roll a six-sided die. You gain life equal to the result.",
             "colours": [
@@ -5817,7 +5817,7 @@
         },
         {
             "id": "3b5709b6-f83e-5108-a32c-5fce6cbfe591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49600fe1-8c1f-4940-bb1e-7e28131d6d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49600fe1-8c1f-4940-bb1e-7e28131d6d5f.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -5861,7 +5861,7 @@
         },
         {
             "id": "94e50d17-6109-50b6-9db2-9904891dd6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770aa4e1-a28c-45a4-ab8c-185ccaeb86d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770aa4e1-a28c-45a4-ab8c-185ccaeb86d5.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "9551b2bb-e58f-5b0e-b052-63a64f4263aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68832214-2943-4253-8884-ffa490e84087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68832214-2943-4253-8884-ffa490e84087.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -5947,7 +5947,7 @@
         },
         {
             "id": "b524f7d4-6db3-5547-997d-1e3ac8bf413e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e8bdd9-24a3-42f0-8b0c-dbc05be8fc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e8bdd9-24a3-42f0-8b0c-dbc05be8fc20.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "14e2b540-0a24-509f-8abc-8d3468de5920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc9331-0f35-4921-bb27-58a22d3980a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc9331-0f35-4921-bb27-58a22d3980a7.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -6034,7 +6034,7 @@
         },
         {
             "id": "61ec1a4c-6b0f-51fc-b01d-557eac0d69b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76fa8d4-923d-4afc-ba47-ba10fc0fe46e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76fa8d4-923d-4afc-ba47-ba10fc0fe46e.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "0: Roll a six-sided die.\n1 or 2 \u2014 +2, then create two 1/1 green Squirrel creature tokens. They gain haste until end of turn.\n3 \u2014 \u22121, then return a card with mana value 2 or less from your graveyard to your hand.\n4 or 5 \u2014 Comet, Stellar Pup deals damage equal to the number of loyalty counters on him to a creature or player, then \u22122.\n6 \u2014 +1, and you may activate Comet, Stellar Pup's loyalty ability two more times this turn.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "89dade5c-73c7-57ef-a54a-e9b027674256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6607b2ac-e196-4586-b7a5-7c68621084c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6607b2ac-e196-4586-b7a5-7c68621084c4.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -6119,7 +6119,7 @@
         },
         {
             "id": "ed04d25b-43be-512d-920b-b807adba68fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d196ad09-a3b3-445b-8ae4-fa231758c350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d196ad09-a3b3-445b-8ae4-fa231758c350.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "88689b73-0063-541a-8ef9-f18662796523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93330c2-b79b-4211-87ca-6ebc45b70dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93330c2-b79b-4211-87ca-6ebc45b70dd9.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "a043db54-4f32-5bfe-bfbd-8698d24c4ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f5873d-2c62-4f46-b3be-056f6c25fe22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f5873d-2c62-4f46-b3be-056f6c25fe22.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "8e9241da-e406-569c-9244-bc2554b8eb82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f2ba13-cd72-4f7a-8443-8e3962f2ac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f2ba13-cd72-4f7a-8443-8e3962f2ac46.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "bc04dea7-8cd0-53d5-ab2e-cfb577d00ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c2e47d-f537-4108-b548-37b294482af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c2e47d-f537-4108-b548-37b294482af6.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "35c8df48-7d48-5d77-8f59-ebcfb92aa9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b43168-44fb-439f-80e7-cb2539ca511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b43168-44fb-439f-80e7-cb2539ca511f.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "83501f61-e0e6-5c6c-a0ce-8332dbb2810a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b8ff8-13e4-46e7-b028-d055e4548f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b8ff8-13e4-46e7-b028-d055e4548f6a.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -6421,7 +6421,7 @@
         },
         {
             "id": "3fbe2dee-27dd-5c53-8ec9-8903da5d9fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e57baea-00ee-49dc-80ce-a8c11a67a6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e57baea-00ee-49dc-80ce-a8c11a67a6db.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -6464,7 +6464,7 @@
         },
         {
             "id": "59a3f406-c3f3-5000-8865-265dc583a922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da5dd8-1e56-4c0a-a18f-f094a1cfe2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da5dd8-1e56-4c0a-a18f-f094a1cfe2c9.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -6508,7 +6508,7 @@
         },
         {
             "id": "bcbbd0c1-dc44-520c-a977-51e40319a577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7999a76-35b0-43de-8d13-8fc0d447a9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7999a76-35b0-43de-8d13-8fc0d447a9d1.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -6551,7 +6551,7 @@
         },
         {
             "id": "c739441d-479d-554f-a215-ae5c52f91285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ddb2e7-6bc6-43ce-aeec-175a0ce17ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ddb2e7-6bc6-43ce-aeec-175a0ce17ed5.jpg?1",
             "name": "Space Beleren",
             "text": "Space sculptor (Space Beleren divides the battlefield into alpha, beta, and gamma sectors. If a creature isn't assigned to a sector, its controller assigns it to one. Opponents assign first.)\n+1: Creatures in each sector can be blocked this turn only by creatures in the same sector.\n\u22121: Put a +1/+1 counter on each creature in the sector of your choice.\n\u22125: Destroy all creatures in the sector of your choice.",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "923b092f-13a0-557b-a253-626921cde862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26177224-3c0e-4081-8468-3cd9981ddb0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26177224-3c0e-4081-8468-3cd9981ddb0a.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "a0002a16-a233-532a-a15d-5567b7db6fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a92336-2ed7-4496-9476-9fe3368bbdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a92336-2ed7-4496-9476-9fe3368bbdfd.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -6679,7 +6679,7 @@
         },
         {
             "id": "46e0434c-0f6e-5857-bf4f-e51f8ccf4a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6f092-08b9-4c67-836a-28006ea3b2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6f092-08b9-4c67-836a-28006ea3b2df.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -6723,7 +6723,7 @@
         },
         {
             "id": "4d3a781a-4dbf-5ac1-a6df-a0fde2317923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903168f6-c195-47af-bdf7-b5748108d2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903168f6-c195-47af-bdf7-b5748108d2a8.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "56aad74f-2df6-5a89-8c2c-c732db25f790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e53c1d-56cf-4d3f-8150-df307c5a3ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e53c1d-56cf-4d3f-8150-df307c5a3ae4.jpg?1",
             "name": "Autograph Book",
             "text": "",
             "colours": [],
@@ -6797,7 +6797,7 @@
         },
         {
             "id": "3bf6015d-785a-5465-b7f9-b9678e1a3b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da67aec2-18ff-426a-a074-25cd34b01f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da67aec2-18ff-426a-a074-25cd34b01f9c.jpg?1",
             "name": "Blue Ribbon",
             "text": "",
             "colours": [],
@@ -6829,7 +6829,7 @@
         },
         {
             "id": "a4bdf296-541a-5c9c-88bf-f748c3a161d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa7b481-9332-4140-9a46-11e4e384d8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa7b481-9332-4140-9a46-11e4e384d8f1.jpg?1",
             "name": "Celebr-8000",
             "text": "At the beginning of combat on your turn, roll two six-sided dice. For each result of 1, Celebr-8000 gets +1/+1 until end of turn. For each other result, it gains the indicated ability until end of turn. If you rolled doubles, it also gains double strike until end of turn.\n\u2022 2 \u2014 menace \u2022 5 \u2014 flying\n\u2022 3 \u2014 vigilance \u2022 6 \u2014 indestructible\n\u2022 4 \u2014 lifelink",
             "colours": [],
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "8d4c3e95-957b-543e-a7f9-5c8822539be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6667e4f-f0f6-4416-940a-d03bed75f5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6667e4f-f0f6-4416-940a-d03bed75f5a7.jpg?1",
             "name": "Clown Car",
             "text": "When Clown Car enters the battlefield, roll X six-sided dice. For each odd result, create a 1/1 white Clown Robot artifact creature token. For each even result, put a +1/+1 counter on Clown Car.\nCrew 2",
             "colours": [],
@@ -6895,7 +6895,7 @@
         },
         {
             "id": "865b60bf-be0a-5547-967b-a756bb2345b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72beb4e7-7044-4b10-b585-ee35760827b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72beb4e7-7044-4b10-b585-ee35760827b1.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "f184b4a3-1b46-51c1-b95e-f89f52062c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c97bdec-d085-4929-927b-ba0d81a2987d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c97bdec-d085-4929-927b-ba0d81a2987d.jpg?1",
             "name": "Draconian Gate-Bot",
             "text": "When Draconian Gate-Bot enters the battlefield, choose one \u2014\n\u2022 Open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\n\u2022 Destroy target Attraction. (It's put into its owner's junkyard.)",
             "colours": [],
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "9b129c7f-82eb-5e9e-9265-e4a9cf8d1989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a5413-290b-484b-b754-06ec7f1a62ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a5413-290b-484b-b754-06ec7f1a62ac.jpg?1",
             "name": "Greatest Show in the Multiverse",
             "text": "",
             "colours": [],
@@ -6998,7 +6998,7 @@
         },
         {
             "id": "51e2eb66-504a-5f13-96ac-1a659f81bb13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f895a-5c2e-4530-9a09-835d2b02ccae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f895a-5c2e-4530-9a09-835d2b02ccae.jpg?1",
             "name": "Park Map",
             "text": "",
             "colours": [],
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "e19a5f35-6104-53f6-8d11-ddabbaf47cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97957307-f8ec-412f-a720-9b03b93fac56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97957307-f8ec-412f-a720-9b03b93fac56.jpg?1",
             "name": "_____ _____ Rocketship",
             "text": "",
             "colours": [],
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "2373c2da-2ac0-56fe-abeb-03f7a0bb4a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c468d-7faa-43f9-8221-1640c76403b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c468d-7faa-43f9-8221-1640c76403b9.jpg?1",
             "name": "Souvenir T-Shirt",
             "text": "",
             "colours": [],
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "162b2bcb-0d62-5250-a02e-4cb1fea81dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b654514f-b1a0-4d96-8d05-55e2cf386518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b654514f-b1a0-4d96-8d05-55e2cf386518.jpg?1",
             "name": "Strength-Testing Hammer",
             "text": "Whenever equipped creature attacks, roll a six-sided die. That creature gets +X/+0 until end of turn, where X is the result. Then if it has the greatest power or is tied for greatest power among creatures on the battlefield, draw a card.\nEquip {3}",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "81be2535-ab40-56f4-a0ca-682d845614b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6086ebe1-a8d4-4fd4-8d68-487553ce1405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6086ebe1-a8d4-4fd4-8d68-487553ce1405.jpg?1",
             "name": "Ticket Turbotubes",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: You get {Ticket} (a ticket counter).",
             "colours": [],
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "fd3d60f6-3795-5b50-8ded-19a088f7daeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4906051-0f74-4a0c-9508-2fa52d98b618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4906051-0f74-4a0c-9508-2fa52d98b618.jpg?1",
             "name": "Ticketomaton",
             "text": "When Ticketomaton enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -7187,7 +7187,7 @@
         },
         {
             "id": "74563ac6-2a0c-56ee-9e07-6579f7c7e638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7db6e16-357c-4872-8b23-338953ffefb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7db6e16-357c-4872-8b23-338953ffefb4.jpg?1",
             "name": "Wicker Picker",
             "text": "Creature spells you cast have sticker kicker {1}. (You may pay an additional {1} as you cast a creature spell. If you do, you get {Ticket}, then you may put a sticker on it.)",
             "colours": [],
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "181276bc-57d5-52dc-bd15-172d53fe3bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c98d7-a5c4-41ce-9179-0f06ae72b7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c98d7-a5c4-41ce-9179-0f06ae72b7f4.jpg?1",
             "name": "The Big Top",
             "text": "",
             "colours": [],
@@ -7251,7 +7251,7 @@
         },
         {
             "id": "a8312c09-290f-5e07-9219-04a1fbc2a108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da785d1b-6b90-4b65-9efb-d7f329405318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da785d1b-6b90-4b65-9efb-d7f329405318.jpg?1",
             "name": "Nearby Planet",
             "text": "",
             "colours": [],
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "5d646a97-f63e-5573-b5ca-a7ce9b1d2f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c47a99-965c-4bde-935a-10f28cf5ccba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c47a99-965c-4bde-935a-10f28cf5ccba.jpg?1",
             "name": "Urza's Fun House",
             "text": "",
             "colours": [],
@@ -7319,7 +7319,7 @@
         },
         {
             "id": "2ec0d664-e1f7-5a49-a76d-93ba96dc3414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9eaed8-e956-4fb2-a23d-3d442cd2fa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9eaed8-e956-4fb2-a23d-3d442cd2fa5c.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7353,7 +7353,7 @@
         },
         {
             "id": "9d7b7368-4040-50fb-a141-3cc0abba5885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7412ea3f-646c-41bd-be94-cf2a2c0cee14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7412ea3f-646c-41bd-be94-cf2a2c0cee14.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "c5a60901-f11e-50ad-b4f6-d39c730f048f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a7de59-f3d4-4092-b23d-0e519a108ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a7de59-f3d4-4092-b23d-0e519a108ced.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7421,7 +7421,7 @@
         },
         {
             "id": "60dc836f-deb5-5274-9045-b749e67d44b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb8928-8178-439b-803e-35f5681b8ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb8928-8178-439b-803e-35f5681b8ff4.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "7ae44751-89eb-52d6-8a3e-c1622601e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5985a9-2f9c-45b9-ac59-f29e7197b301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5985a9-2f9c-45b9-ac59-f29e7197b301.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "e0840ffa-6136-5461-9033-60405c545a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8c158f-52be-4cb4-a0bd-1f6419a12da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8c158f-52be-4cb4-a0bd-1f6419a12da0.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "711b8fc4-49c1-528c-a666-29e6a3637a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756164bc-6d3a-4d0f-96b6-fd0ae9a5371e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756164bc-6d3a-4d0f-96b6-fd0ae9a5371e.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "7c74bcbc-e603-597f-a885-01573be8816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a818c-125a-48ac-9e3a-9502c69b9386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a818c-125a-48ac-9e3a-9502c69b9386.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7591,7 +7591,7 @@
         },
         {
             "id": "5a2b4057-bf9b-5598-ba95-f7beda0bcfe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdefffa-14bb-4a2b-9e75-13e29eaa6677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdefffa-14bb-4a2b-9e75-13e29eaa6677.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7627,7 +7627,7 @@
         },
         {
             "id": "68e00e79-c8f6-5126-90aa-91de7fc2cd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e52d857-b673-427a-84b7-fd8a65650aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e52d857-b673-427a-84b7-fd8a65650aec.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "0a31971c-02b5-59f8-8a90-db63e0b6f32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ccdc1b-ad12-4d2d-bb9e-0b0d50b9a644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ccdc1b-ad12-4d2d-bb9e-0b0d50b9a644.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7699,7 +7699,7 @@
         },
         {
             "id": "546fe317-78e7-5060-9675-ad4829434999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7254a788-ea08-4daa-b8db-c8f0c3c84a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7254a788-ea08-4daa-b8db-c8f0c3c84a2e.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7735,7 +7735,7 @@
         },
         {
             "id": "ab15c6a7-163d-5260-b5cd-7d9d8c59f730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fa2347-5967-4736-ad11-d8299a331907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fa2347-5967-4736-ad11-d8299a331907.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7771,7 +7771,7 @@
         },
         {
             "id": "12603d87-e49f-5f98-9e9c-e3434fda33e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb790c6-8195-488c-b64d-83faf8699304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb790c6-8195-488c-b64d-83faf8699304.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "fb0955d8-e21b-5b5f-8e78-06e9de258e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eed5075-0632-4af1-8a16-9b959317e154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eed5075-0632-4af1-8a16-9b959317e154.jpg?1",
             "name": "Centrifuge",
             "text": "Visit \u2014 Each player draws a card from the library of the player to their right. You create three Treasure tokens.",
             "colours": [],
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "33f8140d-9719-583e-986c-48c312489e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb4473-6c19-44ba-ba57-b2a9646d80d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb4473-6c19-44ba-ba57-b2a9646d80d7.jpg?1",
             "name": "Centrifuge",
             "text": "Visit \u2014 Each player draws a card from the library of the player to their right. You create three Treasure tokens.",
             "colours": [],
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "6d4afa3b-1a98-5f40-bf66-b3cda32d0c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cd6f28-11b0-4d69-bc2c-9050c2478b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cd6f28-11b0-4d69-bc2c-9050c2478b1d.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -7905,7 +7905,7 @@
         },
         {
             "id": "5d5e166d-1e78-5d73-9592-75a98116d3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e23dec-67c1-446a-b599-2a8ea8f7c716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e23dec-67c1-446a-b599-2a8ea8f7c716.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "f40e19bd-c1c8-5382-a6bf-bac579a55f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e8c2a-62bd-4c12-b2c2-287b8ef68b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e8c2a-62bd-4c12-b2c2-287b8ef68b53.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "8646bb99-19a6-5973-b4cb-c131e02aa6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0accf374-76ed-4829-9fb2-87d6a411b0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0accf374-76ed-4829-9fb2-87d6a411b0dc.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -8007,7 +8007,7 @@
         },
         {
             "id": "83045a4c-76df-585e-9103-add474594f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ab8948-1080-487b-b0a0-c5d11935141f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ab8948-1080-487b-b0a0-c5d11935141f.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "2c58f345-548e-5522-8989-3fb34eca721b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443739b2-22da-4ac8-907e-71a3b6c49a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443739b2-22da-4ac8-907e-71a3b6c49a3f.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "5fdfd43b-f222-5e43-81bc-b8683c57d105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6289bc9-e77f-4764-bae8-96d4569ac737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6289bc9-e77f-4764-bae8-96d4569ac737.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8109,7 +8109,7 @@
         },
         {
             "id": "e070e404-6b94-522a-bf23-bfb89fccfdc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514e6039-2722-4350-a8e0-b2964d6c100d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514e6039-2722-4350-a8e0-b2964d6c100d.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8143,7 +8143,7 @@
         },
         {
             "id": "16a26793-623d-5ad8-ac1a-668433e4e0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81dd9df-0eeb-42fd-8dd0-fd7f154954e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81dd9df-0eeb-42fd-8dd0-fd7f154954e0.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "f7d2fed7-12cb-5984-bd20-634fa7102c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f89ff2-6da0-40ea-998c-cb6893c5d0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f89ff2-6da0-40ea-998c-cb6893c5d0fa.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8215,7 +8215,7 @@
         },
         {
             "id": "294b48e4-0e48-566e-935c-6abb0eb15759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9e5578-266c-45d2-86b8-0ff32fa9f80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9e5578-266c-45d2-86b8-0ff32fa9f80a.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "e36e200a-67a7-5e91-8e36-6dad44aaf61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610d3b7-1066-4dbf-af12-55e2d9a984b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610d3b7-1066-4dbf-af12-55e2d9a984b5.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8287,7 +8287,7 @@
         },
         {
             "id": "0ac328d7-8ec7-58da-b90d-a0edc49c60c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd3e471-c342-4590-ac8e-1064ba2c6beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd3e471-c342-4590-ac8e-1064ba2c6beb.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "68e9d157-392d-52a0-992b-790e68377488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64539d25-b2af-4a12-b8ee-03d24a91b07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64539d25-b2af-4a12-b8ee-03d24a91b07e.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "856e40e1-798c-5208-8e2e-3e93625add8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174517f4-efdc-4932-bc6a-53703dfa6875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174517f4-efdc-4932-bc6a-53703dfa6875.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8393,7 +8393,7 @@
         },
         {
             "id": "231855ea-dcff-5893-97c7-9bf3607d848e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866f977-5641-4c20-8c06-e4c9cfd2e065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866f977-5641-4c20-8c06-e4c9cfd2e065.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "694ad33d-51b4-500e-8492-8f6fcd729788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52860ef5-e884-4c15-afa1-2ea21c67e608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52860ef5-e884-4c15-afa1-2ea21c67e608.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "ec1edc15-02f6-5d4d-9a2b-164717953f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb2b98a-0f88-41f5-b87c-8622cd8939e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb2b98a-0f88-41f5-b87c-8622cd8939e5.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "224a2af2-aea7-5e34-a7fa-78a942fa79ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d11e43-6942-408a-a585-7f431b154f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d11e43-6942-408a-a585-7f431b154f65.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "10e77ea4-606b-5bfe-88d2-09c5185ae1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ff30a-d56b-455a-8d15-10c23da8ec82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ff30a-d56b-455a-8d15-10c23da8ec82.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8563,7 +8563,7 @@
         },
         {
             "id": "a60c8057-5984-5e3b-9191-33a8a37d9043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c553b00c-1b5a-4a4c-a4eb-e7b573c9cb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c553b00c-1b5a-4a4c-a4eb-e7b573c9cb33.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8597,7 +8597,7 @@
         },
         {
             "id": "df740b54-43b3-5a49-8c96-ca25496441c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac24e8e-69de-4e3e-8f3c-b4436c65bc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac24e8e-69de-4e3e-8f3c-b4436c65bc28.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8631,7 +8631,7 @@
         },
         {
             "id": "f2f120c0-af49-5fe1-8277-4ad1230c2029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738cd8d-f88b-431e-b66f-dc32e39a9606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738cd8d-f88b-431e-b66f-dc32e39a9606.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8667,7 +8667,7 @@
         },
         {
             "id": "47524c89-e456-5b4d-bd97-1bb1d5431712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e070e-bc22-416a-a424-2ac285704b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e070e-bc22-416a-a424-2ac285704b8f.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8703,7 +8703,7 @@
         },
         {
             "id": "5cedef9d-c3fc-50b5-b38e-c9eb79e2b519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99613047-706f-450d-90bf-d66a11293ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99613047-706f-450d-90bf-d66a11293ec6.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "499c0e3c-ed18-51a5-b766-0a9fefa6c33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4573d1a0-f4b0-43f2-a7fb-8af6b1c4ecde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4573d1a0-f4b0-43f2-a7fb-8af6b1c4ecde.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8775,7 +8775,7 @@
         },
         {
             "id": "2392debf-dd0b-5978-9977-6ccd41c24f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cb926f-22c1-450b-82cd-bb3c861b80a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cb926f-22c1-450b-82cd-bb3c861b80a3.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "e745a6c3-f2ea-585b-bedb-4a6ce88e1d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0aedb2-de98-4abc-9d4e-7f682ee9a26b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0aedb2-de98-4abc-9d4e-7f682ee9a26b.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8847,7 +8847,7 @@
         },
         {
             "id": "6cb33b2c-793c-549d-9ef6-fb3db3c74935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91562ab3-1153-48d9-9f8e-4c79155548f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91562ab3-1153-48d9-9f8e-4c79155548f2.jpg?1",
             "name": "Ferris Wheel",
             "text": "",
             "colours": [],
@@ -8877,7 +8877,7 @@
         },
         {
             "id": "aa64e910-4054-5cc8-ab75-da887cc5c078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9456ca6-a721-4b61-8afb-19d811f21a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9456ca6-a721-4b61-8afb-19d811f21a3c.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "9231a1a7-ab40-5a05-9212-37488d32d370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c57f5f-2a7c-4d85-a06a-0692a8b71989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c57f5f-2a7c-4d85-a06a-0692a8b71989.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "24a7236d-e8d8-59f9-aebb-ed4cba16b559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1a5df-2279-49f3-a658-865565d6464d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1a5df-2279-49f3-a658-865565d6464d.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "edbdb8f1-3798-5651-ad70-633fcb83953c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2c9aa0-1f1b-481b-acd2-718a1813c91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2c9aa0-1f1b-481b-acd2-718a1813c91a.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -9013,7 +9013,7 @@
         },
         {
             "id": "16eb73fe-58bb-5b18-a398-0032c295c8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde28457-2a4d-44e0-9d03-31173d411c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde28457-2a4d-44e0-9d03-31173d411c34.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9049,7 +9049,7 @@
         },
         {
             "id": "6a8368aa-c6d0-55b3-a36f-e4b498d6204c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e68a801-fe89-46a7-b097-2ba79214482b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e68a801-fe89-46a7-b097-2ba79214482b.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "491fc62d-b041-5d00-b950-6f821b5e873f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eece7-f94f-4988-a5ba-11cab94152d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eece7-f94f-4988-a5ba-11cab94152d2.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "eec9ff00-2699-5b9d-a61d-560828761608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74018663-1f57-44ed-8c98-97bd96e8100d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74018663-1f57-44ed-8c98-97bd96e8100d.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9157,7 +9157,7 @@
         },
         {
             "id": "ccab4343-4545-5959-9030-79850b72e8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68ac1c8-d802-4854-b2bf-4686efa62a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68ac1c8-d802-4854-b2bf-4686efa62a97.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "3de997f1-fbdc-5dc5-8e03-e4e6b9459900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533f3be9-82a1-45a4-bd91-f34eab32ade4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533f3be9-82a1-45a4-bd91-f34eab32ade4.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "9b65868e-db7d-5666-97e4-a414691db4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ad0d58-b1f6-4549-b0b3-f655b006dbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ad0d58-b1f6-4549-b0b3-f655b006dbb4.jpg?1",
             "name": "Gallery of Legends",
             "text": "Visit \u2014 Exile cards from the top of your library until you exile a nonland card, then choose a legendary creature card name with the same mana value as that card. Create a token that's a copy of the card with the chosen name. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -9261,7 +9261,7 @@
         },
         {
             "id": "faff9920-c495-5d8b-9d3a-9fe857cb37f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ec3a9-e706-46f9-bf90-ba9aacd2d6cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ec3a9-e706-46f9-bf90-ba9aacd2d6cd.jpg?1",
             "name": "Gallery of Legends",
             "text": "Visit \u2014 Exile cards from the top of your library until you exile a nonland card, then choose a legendary creature card name with the same mana value as that card. Create a token that's a copy of the card with the chosen name. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "bc0ba63e-d5a9-5678-ab4c-a6cc1de79289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723e0-4e14-4910-905c-0292b84a0272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723e0-4e14-4910-905c-0292b84a0272.jpg?1",
             "name": "Gift Shop",
             "text": "Visit \u2014 Choose one that hasn't been chosen.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Create a 2/2 pink Teddy Bear creature token.\n\u2022 Create two Food tokens.\n\u2022 You get {Ticket}{Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -9325,7 +9325,7 @@
         },
         {
             "id": "4b6af18c-88a3-53d0-b9bd-a7b9b7ab3d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc33291-a597-4c70-8072-aa7251e57e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc33291-a597-4c70-8072-aa7251e57e78.jpg?1",
             "name": "Gift Shop",
             "text": "Visit \u2014 Choose one that hasn't been chosen.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Create a 2/2 pink Teddy Bear creature token.\n\u2022 Create two Food tokens.\n\u2022 You get {Ticket}{Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "bc703cc3-9908-575e-8278-904b1f7343d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdf92c4-1645-4e48-8294-8b10f62dd45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdf92c4-1645-4e48-8294-8b10f62dd45a.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9391,7 +9391,7 @@
         },
         {
             "id": "42c07e79-04e2-5124-a877-b3611310d0f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb74882-b66b-4397-9b17-1d114472b655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb74882-b66b-4397-9b17-1d114472b655.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "22829dc5-4570-5ae9-bcfd-10c216d92937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c02968-b930-4be8-ab6e-6a388704b1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c02968-b930-4be8-ab6e-6a388704b1f1.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "b5118311-f41e-5b3a-b5c1-3ccf94bb5b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7347a-30a3-48cf-9257-48cf240e0178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7347a-30a3-48cf-9257-48cf240e0178.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "bcd4142e-8ba4-561b-83dc-3a85560d5923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c887a-9879-4f62-8058-ece831d6fb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c887a-9879-4f62-8058-ece831d6fb65.jpg?1",
             "name": "Hall of Mirrors",
             "text": "Visit \u2014 Choose target creature you control. Each other creature you control becomes a copy of that creature until end of turn, except it isn't legendary if the chosen creature is legendary.",
             "colours": [],
@@ -9525,7 +9525,7 @@
         },
         {
             "id": "f794f050-20ba-56bf-a9dd-cc0b44f35b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1ce311-3a27-432b-8d77-1548c50afa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1ce311-3a27-432b-8d77-1548c50afa52.jpg?1",
             "name": "Hall of Mirrors",
             "text": "",
             "colours": [],
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "33195709-1778-5b09-baee-e77804063d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8d4551-3adc-4ce4-bcea-1a555208de8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8d4551-3adc-4ce4-bcea-1a555208de8b.jpg?1",
             "name": "Haunted House",
             "text": "Visit \u2014 Return target creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of your next end step.",
             "colours": [],
@@ -9589,7 +9589,7 @@
         },
         {
             "id": "e6ccf367-39b4-582c-b877-f5cb7791b63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a651c53-b345-482b-b732-f0a5098068c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a651c53-b345-482b-b732-f0a5098068c3.jpg?1",
             "name": "Haunted House",
             "text": "Visit \u2014 Return target creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of your next end step.",
             "colours": [],
@@ -9621,7 +9621,7 @@
         },
         {
             "id": "0def53d4-b985-5b7b-8ba1-4941eaf78fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015dc10f-d1cb-41ed-a32e-3382540109b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015dc10f-d1cb-41ed-a32e-3382540109b0.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9655,7 +9655,7 @@
         },
         {
             "id": "308354c4-c2db-51fe-93c4-c751b814f1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb7aed1-99e8-494c-9bc5-c483d0577f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb7aed1-99e8-494c-9bc5-c483d0577f91.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "c4ded5fd-48de-57db-9cd0-c2dce72d25dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9591b2-7cbc-48e4-82c7-103ca6cef37d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9591b2-7cbc-48e4-82c7-103ca6cef37d.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9723,7 +9723,7 @@
         },
         {
             "id": "4daef6ac-4778-5fa2-b099-873970ff56ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64218e2c-0e5b-48f1-8eea-698c20fbb017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64218e2c-0e5b-48f1-8eea-698c20fbb017.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9757,7 +9757,7 @@
         },
         {
             "id": "1dd8501e-6284-56ef-94b8-a0eae3e78b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451731e1-ac14-426c-a853-d502d10394a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451731e1-ac14-426c-a853-d502d10394a0.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9793,7 +9793,7 @@
         },
         {
             "id": "3253bc2c-c3bf-5a03-969c-66720a9c1c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7df12a-6284-441c-8bc0-abd1c01dca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7df12a-6284-441c-8bc0-abd1c01dca4f.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9829,7 +9829,7 @@
         },
         {
             "id": "642d6838-f55a-5021-ba9b-e2504337679b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008d7d1f-8635-41d5-9921-11d8043a6206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008d7d1f-8635-41d5-9921-11d8043a6206.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9865,7 +9865,7 @@
         },
         {
             "id": "c8224252-c34f-54f1-a78e-e869732e77c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f999ad-05df-4c95-bcce-e3d8c0827c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f999ad-05df-4c95-bcce-e3d8c0827c3e.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9901,7 +9901,7 @@
         },
         {
             "id": "71317b27-024e-5ab9-b529-b68542557cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edec11-0d16-4228-af1b-92c0cafb8a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edec11-0d16-4228-af1b-92c0cafb8a3a.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9937,7 +9937,7 @@
         },
         {
             "id": "89ad761a-dbd8-5077-8cf4-f1404668567c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d386c2a-df7e-4839-b81d-99e2b9e364df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d386c2a-df7e-4839-b81d-99e2b9e364df.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9973,7 +9973,7 @@
         },
         {
             "id": "83aac216-2240-58fe-b260-0ca155451e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b29fde-e065-4edf-96e7-88318b61c260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b29fde-e065-4edf-96e7-88318b61c260.jpg?1",
             "name": "Log Flume",
             "text": "Visit \u2014 Choose up to four creatures you control. Those creatures jump in a log until end of turn. (Creatures in a log together can't be blocked unless they're all blocked. If a spell or ability you control targets one of them, it targets all of them.)",
             "colours": [],
@@ -10005,7 +10005,7 @@
         },
         {
             "id": "3a33411e-6ebe-567d-80a1-033222a77da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7090cb0-70ec-4966-88bd-4e4bf7efb142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7090cb0-70ec-4966-88bd-4e4bf7efb142.jpg?1",
             "name": "Log Flume",
             "text": "Visit \u2014 Choose up to four creatures you control. Those creatures jump in a log until end of turn. (Creatures in a log together can't be blocked unless they're all blocked. If a spell or ability you control targets one of them, it targets all of them.)",
             "colours": [],
@@ -10037,7 +10037,7 @@
         },
         {
             "id": "9d7c7012-4c99-5960-972c-0d5f302088be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb35be9-4fe3-4db7-81d6-d66f5e399d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb35be9-4fe3-4db7-81d6-d66f5e399d03.jpg?1",
             "name": "Memory Test",
             "text": "When Memory Test enters the battlefield, target opponent exiles cards from the bottom of their library until they exile five nonland cards, then turns those nonland cards face down.\nVisit \u2014 Name the exiled face-down cards, then look at them. If you named them correctly, turn them face up, then claim the prize\nPrize \u2014 Create three 1/1 red Balloon creature tokens with flying, then sacrifice Memory Test and open an Attraction.",
             "colours": [],
@@ -10069,7 +10069,7 @@
         },
         {
             "id": "40ff777d-b64a-53c5-8954-9737ef41fe45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd511185-f55b-49f2-a1ab-31683ae827e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd511185-f55b-49f2-a1ab-31683ae827e0.jpg?1",
             "name": "Memory Test",
             "text": "When Memory Test enters the battlefield, target opponent exiles cards from the bottom of their library until they exile five nonland cards, then turns those cards face down.\nVisit \u2014 Name the exiled nonland cards, then look at the exiled cards. If you named them correctly, claim the prize\nPrize \u2014 Create three 1/1 red Balloon creature tokens with flying, then sacrifice Memory Test and open an Attraction.",
             "colours": [],
@@ -10101,7 +10101,7 @@
         },
         {
             "id": "e9748ccc-1be2-58c1-a8f6-da48cfa2f5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df9d6db-5b97-464b-a880-364fa33567e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df9d6db-5b97-464b-a880-364fa33567e8.jpg?1",
             "name": "Merry-Go-Round",
             "text": "Visit \u2014 Creatures you control with power 2 or less gain horsemanship until end of turn. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [],
@@ -10133,7 +10133,7 @@
         },
         {
             "id": "c80df02a-3c60-509b-aa08-dfb13f5f22c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d4e4af-0587-40ea-86f1-992c80240adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d4e4af-0587-40ea-86f1-992c80240adb.jpg?1",
             "name": "Merry-Go-Round",
             "text": "Visit \u2014 Creatures you control with power 2 or less gain horsemanship until end of turn. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [],
@@ -10165,7 +10165,7 @@
         },
         {
             "id": "a44f55e6-b355-586f-ace5-1975fa7cb5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1f5d3f-7702-4446-a672-d149053abcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1f5d3f-7702-4446-a672-d149053abcc5.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10201,7 +10201,7 @@
         },
         {
             "id": "8a3be1c9-0449-5aae-a57e-f4b60ce03d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfdd446-3618-44dd-9521-2e223c8ccae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfdd446-3618-44dd-9521-2e223c8ccae3.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10237,7 +10237,7 @@
         },
         {
             "id": "5852292d-7737-56d3-8017-ba4e793ec751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334d1755-a875-42eb-91f8-a7a90ecce367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334d1755-a875-42eb-91f8-a7a90ecce367.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10273,7 +10273,7 @@
         },
         {
             "id": "8f2151da-472c-55ee-b8ed-148e21620d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa86716-5f94-4943-8dc3-56d760e2eff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa86716-5f94-4943-8dc3-56d760e2eff6.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "d8e984ad-44d2-5c29-8bc8-a5a64d9517dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f97ddf7-c394-48c2-95e5-751df20befea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f97ddf7-c394-48c2-95e5-751df20befea.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10345,7 +10345,7 @@
         },
         {
             "id": "f874e68c-c336-59f5-88c8-9faa1766e332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18088e7-9bad-40d1-af40-d9a65847d1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18088e7-9bad-40d1-af40-d9a65847d1cd.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "5d0ec2a8-3eb9-5219-a6df-86864b4c6aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a60cc-4561-4f96-9df1-9cbe9545f1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a60cc-4561-4f96-9df1-9cbe9545f1dc.jpg?1",
             "name": "Push Your Luck",
             "text": "Visit \u2014 Reveal cards from the top of your library until you decide to stop. If the total mana value of the cards revealed this way is 7 or less, create a 2/2 pink Teddy Bear creature token. If the total is exactly 7, claim the prize Shuffle the revealed cards into your library.\nPrize \u2014 Put five +1/+1 counters on a Teddy Bear you control. It gains haste. Sacrifice Push Your Luck and open an Attraction.",
             "colours": [],
@@ -10413,7 +10413,7 @@
         },
         {
             "id": "2b3b89f8-2b58-530c-963b-2f9ef81cbf4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05269f3c-b549-401a-8f7f-c5993fc211c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05269f3c-b549-401a-8f7f-c5993fc211c9.jpg?1",
             "name": "Push Your Luck",
             "text": "Visit \u2014 Reveal cards from the top of your library until you decide to stop. If the total mana value of the cards revealed this way is 7 or less, create a 2/2 pink Teddy Bear creature token. If the total is exactly 7, claim the prize Shuffle the revealed cards into your library.\nPrize \u2014 Put five +1/+1 counters on a Teddy Bear you control. It gains haste. Sacrifice Push Your Luck and open an Attraction.",
             "colours": [],
@@ -10445,7 +10445,7 @@
         },
         {
             "id": "2b979faa-ee43-5557-8e67-bebb94767086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff3a7a-d9b7-494f-991d-db1d0ff2de56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff3a7a-d9b7-494f-991d-db1d0ff2de56.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10479,7 +10479,7 @@
         },
         {
             "id": "87202a84-5468-508f-b69c-6ad696cb4dac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5636b2c4-ca50-4435-807d-13d74bd15d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5636b2c4-ca50-4435-807d-13d74bd15d7c.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10513,7 +10513,7 @@
         },
         {
             "id": "05a6ddce-1e31-54b6-b9e4-8f1b5ff85475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea3a2df-d327-4d0b-b711-53347a9ff0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea3a2df-d327-4d0b-b711-53347a9ff0b5.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10547,7 +10547,7 @@
         },
         {
             "id": "fb88c9c2-43ce-5c5d-ad11-1dba4b64ccd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a66ff6a-5194-4139-9323-e23b99a42742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a66ff6a-5194-4139-9323-e23b99a42742.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "c162e47b-7a2e-5f93-9efe-382216e07a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69b2b85-77d5-4e11-9858-c2403e49219a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69b2b85-77d5-4e11-9858-c2403e49219a.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a humanoid animal or alien,\" \"food,\" or \"horns or tusks\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10617,7 +10617,7 @@
         },
         {
             "id": "7b8b533d-22d4-51a2-9765-cda7c7a8e348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d95e12-b648-4a2c-b1d0-931b99949a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d95e12-b648-4a2c-b1d0-931b99949a8f.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"an elf or goblin,\" \"a tail,\" or \"a flying creature or flying vehicle\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "22a8be36-e6a8-5c99-9480-eae00caf7971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7106f347-677f-4a2a-87ab-705389b2be7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7106f347-677f-4a2a-87ab-705389b2be7e.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a creature wearing a hat,\" \"a book or scroll,\" or \"teeth\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "d1b8ae8a-7ead-5dd2-9035-b8439596a2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0080c6-a4fc-481c-b7bd-90692deb1873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0080c6-a4fc-481c-b7bd-90692deb1873.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a weapon,\" \"five or more creatures,\" or \"words or numbers\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "ae60f689-d4b5-54ed-9212-0d4319393ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e559da14-5e2e-4312-85dd-b1e652d8a7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e559da14-5e2e-4312-85dd-b1e652d8a7b2.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a vampire or zombie,\" \"fire, lightning, or an explosion,\" or \"a metallic creature\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10761,7 +10761,7 @@
         },
         {
             "id": "1f889edd-6cec-51bd-a391-43e73ea51fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1d6397-930d-4eac-b500-144b23d28811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1d6397-930d-4eac-b500-144b23d28811.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a four-legged creature,\" \"a liquid other than water,\" or \"a door\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10797,7 +10797,7 @@
         },
         {
             "id": "172b4299-0dfb-5c0a-a3c6-cf930cd7ad63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ceb59c-fdd7-43f8-8824-fff5e0154271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ceb59c-fdd7-43f8-8824-fff5e0154271.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10833,7 +10833,7 @@
         },
         {
             "id": "1f2059cd-a192-5171-b451-b32162aa31fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810dc84-dd78-4f49-bc75-92887fd7f653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810dc84-dd78-4f49-bc75-92887fd7f653.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10869,7 +10869,7 @@
         },
         {
             "id": "63b82a42-c685-5188-b45c-bbb94d5451ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06396eac-94d2-4f25-a9b0-7c90cbc0f79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06396eac-94d2-4f25-a9b0-7c90cbc0f79d.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10905,7 +10905,7 @@
         },
         {
             "id": "aad9e5af-92fe-56a3-9557-f6c3ab66e570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f0bac-098f-4d88-9b8e-82d12ad25dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f0bac-098f-4d88-9b8e-82d12ad25dfa.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "71cd756e-81ae-504e-82f9-1b2f28d4fb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ecd2b9-4a23-44fa-93e2-210225d3da47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ecd2b9-4a23-44fa-93e2-210225d3da47.jpg?1",
             "name": "Spinny Ride",
             "text": "",
             "colours": [],
@@ -10977,7 +10977,7 @@
         },
         {
             "id": "d18720fd-85a2-5314-9457-40226fcda381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f6b339-06cf-4608-8f66-25c20bdc1230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f6b339-06cf-4608-8f66-25c20bdc1230.jpg?1",
             "name": "Spinny Ride",
             "text": "",
             "colours": [],
@@ -11013,7 +11013,7 @@
         },
         {
             "id": "0cedb0b4-dc5d-546f-9b41-f9f22e88edac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de665505-0896-46c6-a6b5-d3b57a9a01e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de665505-0896-46c6-a6b5-d3b57a9a01e4.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11049,7 +11049,7 @@
         },
         {
             "id": "c1bd72cb-3b32-5d11-a5d3-a8aaf959cafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ead87da-b031-41b0-8904-f9069d85ca57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ead87da-b031-41b0-8904-f9069d85ca57.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11085,7 +11085,7 @@
         },
         {
             "id": "e2229c8d-73fc-5723-87c7-2e3a2d65b4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b16dc-8c0c-4747-9512-e679f69a9c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b16dc-8c0c-4747-9512-e679f69a9c38.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11121,7 +11121,7 @@
         },
         {
             "id": "24c7b304-7621-5771-8a21-6e4d58709554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcaaa3a8-ced5-43ec-94fe-12e662d8261e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcaaa3a8-ced5-43ec-94fe-12e662d8261e.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11157,7 +11157,7 @@
         },
         {
             "id": "bbb40e89-9c26-5cdc-870a-6cd7d1b3018f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ad144-9846-4097-bb51-c473c55b2f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ad144-9846-4097-bb51-c473c55b2f74.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11193,7 +11193,7 @@
         },
         {
             "id": "150443bd-317f-59f2-b5c8-8c3250f0a50d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04423fcd-fdfe-477a-9d92-eda91dc16f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04423fcd-fdfe-477a-9d92-eda91dc16f85.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11229,7 +11229,7 @@
         },
         {
             "id": "5708bba7-499b-502b-bbb3-1efafa55e820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42aeb2e-26ca-49b1-8e4d-1454c3783a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42aeb2e-26ca-49b1-8e4d-1454c3783a84.jpg?1",
             "name": "Storybook Ride",
             "text": "Visit \u2014 Exile the top X cards of your library, where X is the number of Attractions you've visited this turn (including this one). You may play those cards. At the beginning of the next end step, put them on the bottom of your library in any order.",
             "colours": [],
@@ -11261,7 +11261,7 @@
         },
         {
             "id": "0b6608cc-0251-50fc-8d64-cbdd6c1893f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070cf701-53ae-463f-b6ce-47b489557e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070cf701-53ae-463f-b6ce-47b489557e8a.jpg?1",
             "name": "Storybook Ride",
             "text": "Visit \u2014 Exile the top X cards of your library, where X is the number of Attractions you've visited this turn (including this one). You may play those cards. At the beginning of the next end step, put them on the bottom of your library in any order.",
             "colours": [],
@@ -11293,7 +11293,7 @@
         },
         {
             "id": "c45015b0-c454-59e1-8a4d-72e450ff782c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0319b2d1-1d63-4f3f-a1da-10ec64d74f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0319b2d1-1d63-4f3f-a1da-10ec64d74f03.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the fastest,\" \"the scariest,\" or \"the weakest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11329,7 +11329,7 @@
         },
         {
             "id": "b7fed820-e91c-5fb1-b05d-9f3e2d58e55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65ff7de-ed00-41cf-8320-74f98c87212e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65ff7de-ed00-41cf-8320-74f98c87212e.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the cutest,\" \"the loudest,\" or \"the strongest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11365,7 +11365,7 @@
         },
         {
             "id": "737ebc52-5254-5347-b642-e3d9d99c0985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d298f389-4c97-413c-ac83-9c928cb5c3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d298f389-4c97-413c-ac83-9c928cb5c3e4.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the quietest,\" \"the slowest,\" or \"the ugliest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11401,7 +11401,7 @@
         },
         {
             "id": "7644248f-e034-51eb-9ff7-09143c3e4ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f21a33a-ef9d-495d-a475-7042cbd9f6f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f21a33a-ef9d-495d-a475-7042cbd9f6f5.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the cleanest,\" \"the hungriest,\" or \"the strangest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11437,7 +11437,7 @@
         },
         {
             "id": "fea3ff94-81cb-502d-b4fe-b3ac68d513a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801ff015-e322-4a85-a060-326a74bed703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801ff015-e322-4a85-a060-326a74bed703.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the friendliest,\" \"the smartest,\" or \"the wildest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11473,7 +11473,7 @@
         },
         {
             "id": "3c0d032d-2419-54da-b5b1-fb41765e07f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25f5c7-2352-4d21-a48f-11dddc310a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25f5c7-2352-4d21-a48f-11dddc310a1b.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the funniest,\" \"the smelliest,\" or \"the sturdiest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11509,7 +11509,7 @@
         },
         {
             "id": "d49f5c18-29eb-51d6-ab39-f03d40f1cd48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782b5d-57a9-4595-8f35-18d1881263f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782b5d-57a9-4595-8f35-18d1881263f8.jpg?1",
             "name": "Swinging Ship",
             "text": "Visit \u2014 After the first combat phase this turn, there's an additional combat phase. At the beginning of that combat, untap all creatures that attacked this turn.",
             "colours": [],
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "b11a3957-a90c-598c-b229-430c25388062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a7dfaa-f2dc-4975-a4c2-25537a4874fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a7dfaa-f2dc-4975-a4c2-25537a4874fc.jpg?1",
             "name": "Swinging Ship",
             "text": "Visit \u2014 After the first combat phase this turn, there's an additional combat phase. At the beginning of that combat, untap all creatures that attacked this turn.",
             "colours": [],
@@ -11573,7 +11573,7 @@
         },
         {
             "id": "567e8cd7-d565-5751-836d-73ab9ec5e564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07c39f7-5c3e-40f6-b584-458b65282a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07c39f7-5c3e-40f6-b584-458b65282a7e.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11607,7 +11607,7 @@
         },
         {
             "id": "cc44b702-ebe3-5e51-ba15-df0e0dbb6bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba10e7e-f2fc-4b30-88e9-cfc850b852ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba10e7e-f2fc-4b30-88e9-cfc850b852ab.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11641,7 +11641,7 @@
         },
         {
             "id": "4e9c1b9d-097e-568e-910a-d86b95a2e783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4da5c2-17e8-4fa1-a8b2-d8ec4ff585d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4da5c2-17e8-4fa1-a8b2-d8ec4ff585d8.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11675,7 +11675,7 @@
         },
         {
             "id": "f2aa5ffc-0616-50be-89eb-866a4dc56697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e371d860-aaf1-4a81-b607-f5494921e55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e371d860-aaf1-4a81-b607-f5494921e55f.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "a7331c28-312c-58db-a19d-7c93ee65a198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6083e23-9050-4221-b1c9-06a83f0ce53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6083e23-9050-4221-b1c9-06a83f0ce53b.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses white card, land card, or planeswalker card, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11745,7 +11745,7 @@
         },
         {
             "id": "8ee08441-de0e-5f99-857d-e1f67bb9e24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2900cf-4d92-4192-b4f2-2445a06f120f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2900cf-4d92-4192-b4f2-2445a06f120f.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses blue card, enchantment card, or creature type, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11781,7 +11781,7 @@
         },
         {
             "id": "5f2e36c5-f263-56a4-90cb-92ac11727677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0543f27-d2ec-44bc-b9e3-1044d292a3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0543f27-d2ec-44bc-b9e3-1044d292a3e6.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses black card, artifact card, or expansion, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11817,7 +11817,7 @@
         },
         {
             "id": "78729f10-9d52-5a4c-b5c7-ad1eaa34aa52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52057f7-a78a-4edc-8e95-edaea6376e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52057f7-a78a-4edc-8e95-edaea6376e76.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses red card, sorcery card, or legendary card, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11853,7 +11853,7 @@
         },
         {
             "id": "dc124f98-9a17-5470-961e-1c1450bae776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecd115-48a8-48d3-8eff-0ec4ddb2174c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecd115-48a8-48d3-8eff-0ec4ddb2174c.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses green card, instant card, or named mechanic, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11889,7 +11889,7 @@
         },
         {
             "id": "1bf7cc09-7e22-5fd0-b7be-64d528427930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b20bcc6-69ed-432d-ab10-c7bceb7cdfb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b20bcc6-69ed-432d-ab10-c7bceb7cdfb9.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses colorless card, creature card, or plane, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11925,7 +11925,7 @@
         },
         {
             "id": "a39390f6-dcc6-5479-8350-2ae08499cb1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f902fef-5905-4e72-b838-22acdb01ccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f902fef-5905-4e72-b838-22acdb01ccc8.jpg?1",
             "name": "Tunnel of Love",
             "text": "Visit \u2014 Choose an opponent. They choose a creature they control, then you choose a creature you control. You may exile the chosen creatures. If you do, return them to the battlefield under their owners' control at the beginning of the next end step. Otherwise, the chosen creatures fight each other.",
             "colours": [],
@@ -11957,7 +11957,7 @@
         },
         {
             "id": "6fe445b9-0278-5053-83e5-74789cd6e734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45997b5-880e-4df0-8001-8118972c2fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45997b5-880e-4df0-8001-8118972c2fcc.jpg?1",
             "name": "Tunnel of Love",
             "text": "Visit \u2014 Choose an opponent. They choose a creature they control, then you choose a creature you control. You may exile the chosen creatures. If you do, return them to the battlefield under their owners' control at the beginning of the next end step. Otherwise, the chosen creatures fight each other.",
             "colours": [],
@@ -11989,7 +11989,7 @@
         },
         {
             "id": "0d9b97a5-28b7-5d0e-9afa-2163ef59ef27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c453d1ea-9a42-4ccb-9391-eec122025647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c453d1ea-9a42-4ccb-9391-eec122025647.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12027,7 +12027,7 @@
         },
         {
             "id": "1a2d1b98-6ea4-5966-b739-6fbea2c1e7ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d018af9-dd14-46fa-8fd5-226defc9698f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d018af9-dd14-46fa-8fd5-226defc9698f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "6c684672-510b-5d83-87c1-8eca4d5d6095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a6375e-9477-4871-8a15-02439f3f6f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a6375e-9477-4871-8a15-02439f3f6f34.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12103,7 +12103,7 @@
         },
         {
             "id": "a41722c4-e480-5c1f-ad94-4702c21052a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6da8eb-31b0-48c1-9ad9-552827967f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6da8eb-31b0-48c1-9ad9-552827967f91.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12141,7 +12141,7 @@
         },
         {
             "id": "1367a94a-915c-5977-a4ac-3a7da20f98e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dda1113-352c-471a-a7e0-a9a3cb3f19c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dda1113-352c-471a-a7e0-a9a3cb3f19c5.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "8084b2e3-90ed-5726-816b-9508411718cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82283c22-9b64-4f41-a5bb-aeb737eee5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82283c22-9b64-4f41-a5bb-aeb737eee5c9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12217,7 +12217,7 @@
         },
         {
             "id": "a0fe6618-f01f-5941-a29a-e53da509d614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15303b22-ddf0-488d-b07e-a118f35ef00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15303b22-ddf0-488d-b07e-a118f35ef00f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12255,7 +12255,7 @@
         },
         {
             "id": "8d25fc09-4ea7-5670-9ea0-46de68c6e4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c850b9-d014-4cd1-8ffd-361ed4fe1e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c850b9-d014-4cd1-8ffd-361ed4fe1e6d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12293,7 +12293,7 @@
         },
         {
             "id": "0db9b62c-e6ce-5cfe-8b8b-c01a45566afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1170a5-e5bb-4b86-8718-f75eec679b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1170a5-e5bb-4b86-8718-f75eec679b4e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12331,7 +12331,7 @@
         },
         {
             "id": "ea8041e2-5bfb-5ea0-9bd9-c5383c7619a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1488e6b-f677-44c5-8ff3-6a2f9bdb28c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1488e6b-f677-44c5-8ff3-6a2f9bdb28c2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12369,7 +12369,7 @@
         },
         {
             "id": "e42e9ada-2430-5d8b-a36b-12f674219958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef89827b-39b0-4dbb-9516-ee2e47012938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef89827b-39b0-4dbb-9516-ee2e47012938.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "6a7a313a-570b-520a-8797-0b93c3d44c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9cf49-3c2b-4f18-8bd3-2cf82095fc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9cf49-3c2b-4f18-8bd3-2cf82095fc70.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -12451,7 +12451,7 @@
         },
         {
             "id": "fab3abcf-0aa2-5e83-92c3-8f4b36e127eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8beaf424-5974-4007-a396-08355f802283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8beaf424-5974-4007-a396-08355f802283.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12492,7 +12492,7 @@
         },
         {
             "id": "587973aa-8546-544a-9563-7b50029704e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20db599-f382-4a9b-ad55-4660b7219ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20db599-f382-4a9b-ad55-4660b7219ece.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12533,7 +12533,7 @@
         },
         {
             "id": "d28f6ced-770d-5114-bf3b-bbb4568fa9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee1213-f65b-4df9-a891-5a2863254c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee1213-f65b-4df9-a891-5a2863254c60.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -12574,7 +12574,7 @@
         },
         {
             "id": "b27e6eec-3628-5353-9e75-853485c957b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4a844-0f75-4f5c-8c05-45614641184f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4a844-0f75-4f5c-8c05-45614641184f.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12615,7 +12615,7 @@
         },
         {
             "id": "96aaebd2-451d-59c6-b4a0-334f89a511eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae98fcd-434c-4e58-b891-2a733adac7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae98fcd-434c-4e58-b891-2a733adac7f6.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -12660,7 +12660,7 @@
         },
         {
             "id": "03c64bd2-e1f9-5451-bc06-aee5f1db8612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14234b9-a2c8-41b7-9ee0-9a13ae318bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14234b9-a2c8-41b7-9ee0-9a13ae318bdb.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12701,7 +12701,7 @@
         },
         {
             "id": "f162de1d-b0e1-5368-bb67-6ada96f67c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f50fbc-96a0-44e7-b13d-69856d9dbb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f50fbc-96a0-44e7-b13d-69856d9dbb96.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -12742,7 +12742,7 @@
         },
         {
             "id": "e24f64c4-24ab-52d2-b540-76b29c6d954a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b28211-bfc2-458a-a65e-1e70d85c206c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b28211-bfc2-458a-a65e-1e70d85c206c.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -12786,7 +12786,7 @@
         },
         {
             "id": "dc4642b8-a8e8-58aa-9e98-fb5c8173d93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a9752-ae60-42e2-b5ed-74a30070d06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a9752-ae60-42e2-b5ed-74a30070d06e.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -12829,7 +12829,7 @@
         },
         {
             "id": "8466f5d3-b178-5ce7-98ec-4aad1ef1f689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d23de-0d40-4dad-be40-e7724e63168a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d23de-0d40-4dad-be40-e7724e63168a.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -12872,7 +12872,7 @@
         },
         {
             "id": "71e8d356-a9ac-5dd3-8053-fb67dfb1c5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69145398-96b2-453c-9bb1-93cd33fb54c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69145398-96b2-453c-9bb1-93cd33fb54c7.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -12916,7 +12916,7 @@
         },
         {
             "id": "3daaaf34-a86c-515f-a987-f58f23e26c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c3064-0e03-44f9-93e7-9031de1c4116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c3064-0e03-44f9-93e7-9031de1c4116.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -12959,7 +12959,7 @@
         },
         {
             "id": "4037d420-5653-523f-a6fb-94cb188cac02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171a969e-3d5e-4110-a770-4183c2a2710d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171a969e-3d5e-4110-a770-4183c2a2710d.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -13002,7 +13002,7 @@
         },
         {
             "id": "5a7329b2-2c3c-5d4b-a952-2e4a4971cf2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2c9ae3-ba1b-4582-b6c3-1fa38791f3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2c9ae3-ba1b-4582-b6c3-1fa38791f3a9.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -13045,7 +13045,7 @@
         },
         {
             "id": "e3245608-7f9f-5912-a0ab-dfb7af759206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18eb4f1-74fd-4df1-b087-83ebe86d2dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18eb4f1-74fd-4df1-b087-83ebe86d2dc2.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -13088,7 +13088,7 @@
         },
         {
             "id": "539c7e15-0af6-5028-b96d-828487eeffb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a2d471-25e9-4fb0-88fd-bb0698724a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a2d471-25e9-4fb0-88fd-bb0698724a42.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -13131,7 +13131,7 @@
         },
         {
             "id": "074edce7-8033-5c25-b4cb-774a3492721a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee0bbf-312a-493c-a8d0-13b8dae8ba71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee0bbf-312a-493c-a8d0-13b8dae8ba71.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -13174,7 +13174,7 @@
         },
         {
             "id": "7edd2b9e-9a8b-552f-b7bf-415469878166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14360131-4108-4968-874f-935f920e0837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14360131-4108-4968-874f-935f920e0837.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -13217,7 +13217,7 @@
         },
         {
             "id": "1fb81dd4-14b2-5616-82fa-59e7fb14cc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad95fc-7f3e-49f9-82e2-3d3673ec27a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad95fc-7f3e-49f9-82e2-3d3673ec27a3.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -13260,7 +13260,7 @@
         },
         {
             "id": "1c06c501-6c2d-5f07-bfba-5b8db5620111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774c25d1-7e31-4e67-8601-a3b4c9320223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774c25d1-7e31-4e67-8601-a3b4c9320223.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -13304,7 +13304,7 @@
         },
         {
             "id": "50bb65d4-f9f8-545d-a9f6-e0d6742ac709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2dd07-89db-40a4-b7b3-158c15a66861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2dd07-89db-40a4-b7b3-158c15a66861.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -13347,7 +13347,7 @@
         },
         {
             "id": "977c0613-340b-5e96-ad96-d73d5a10c36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd71020-beb5-4682-91f3-cb71bbddc796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd71020-beb5-4682-91f3-cb71bbddc796.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -13391,7 +13391,7 @@
         },
         {
             "id": "19666dfe-03fd-5438-b623-2ca1a41d0bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a29c058-aeff-4f77-954f-1e1a4ea92c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a29c058-aeff-4f77-954f-1e1a4ea92c83.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -13434,7 +13434,7 @@
         },
         {
             "id": "217c0d00-0fcf-52df-8aa3-e4b9f91bf9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db161073-7fb1-465c-8878-e2584ac27458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db161073-7fb1-465c-8878-e2584ac27458.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -13477,7 +13477,7 @@
         },
         {
             "id": "a87d5fce-fb68-52b5-ab31-2ecbb9f81f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbcd448-23fc-4e8d-985d-df2801f5c78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbcd448-23fc-4e8d-985d-df2801f5c78c.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -13520,7 +13520,7 @@
         },
         {
             "id": "569ddd6d-a96d-5225-b1ed-4aa1550c799a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01af935e-f8ca-4315-9e2b-a6f06787ff25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01af935e-f8ca-4315-9e2b-a6f06787ff25.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -13564,7 +13564,7 @@
         },
         {
             "id": "2ab3682e-d325-56ee-b64f-7ea5c3b4b3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7d2436-0ba3-4827-ae9a-aa75735ba3ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7d2436-0ba3-4827-ae9a-aa75735ba3ff.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -13608,7 +13608,7 @@
         },
         {
             "id": "b2133b14-fb18-53d7-8a50-d4852e4b9119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36ba173-e4a1-42df-baa6-fc2e854fa3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36ba173-e4a1-42df-baa6-fc2e854fa3fe.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -13645,7 +13645,7 @@
         },
         {
             "id": "157260cb-ba4d-5c5f-940a-7c495e4ec834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cac4ebc-fdc3-4dd4-b988-9a924ee3c781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cac4ebc-fdc3-4dd4-b988-9a924ee3c781.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "",
             "colours": [
@@ -13687,7 +13687,7 @@
         },
         {
             "id": "e652bab7-775e-5ec0-9707-2641e9d4217d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec649bac-f332-4e66-91d2-1ff0e041f8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec649bac-f332-4e66-91d2-1ff0e041f8b0.jpg?1",
             "name": "Space Beleren",
             "text": "",
             "colours": [
@@ -13729,7 +13729,7 @@
         },
         {
             "id": "cbfdc1b0-39c9-516f-8f03-70affcbe8506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029eaaa9-e45e-4c50-a03d-ad67e3dfcc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029eaaa9-e45e-4c50-a03d-ad67e3dfcc3e.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U}.)\nAs Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13765,7 +13765,7 @@
         },
         {
             "id": "4f83f35e-ff54-55d1-a006-6e004d98e3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81706879-ec5d-4b17-b4bc-5f7cb37557a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81706879-ec5d-4b17-b4bc-5f7cb37557a5.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B}.)\nAs Watery Grave enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13801,7 +13801,7 @@
         },
         {
             "id": "de0be7e3-b0c1-5d35-8784-957f80616ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1cebcb-0e3f-4dce-81ff-44bc8c0b9ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1cebcb-0e3f-4dce-81ff-44bc8c0b9ad7.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R}.)\nAs Blood Crypt enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13837,7 +13837,7 @@
         },
         {
             "id": "d79eaece-b4b3-5252-b236-fc5d833b10c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dd057e-1f38-4a5f-819c-f3af9134fecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dd057e-1f38-4a5f-819c-f3af9134fecf.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G}.)\nAs Stomping Ground enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13873,7 +13873,7 @@
         },
         {
             "id": "22d7ef95-42b3-5cdf-8882-c070a4982dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43609973-6c01-4f03-9e08-a347364dfa76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43609973-6c01-4f03-9e08-a347364dfa76.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W}.)\nAs Temple Garden enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13909,7 +13909,7 @@
         },
         {
             "id": "4e6acd3c-9f6e-566a-9261-e11cff0e2837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e739c7e-cc16-4557-836f-fdec53a7ed8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e739c7e-cc16-4557-836f-fdec53a7ed8c.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B}.)\nAs Godless Shrine enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "73751bd4-20f9-595d-8078-2d1da506605b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af478684-ea34-4275-ab45-a9512aaa0758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af478684-ea34-4275-ab45-a9512aaa0758.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R}.)\nAs Steam Vents enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13981,7 +13981,7 @@
         },
         {
             "id": "f16c3aad-8391-5384-8b67-1f657753e122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5de5eb-442d-48de-bb5a-e316ea44520d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5de5eb-442d-48de-bb5a-e316ea44520d.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G}.)\nAs Overgrown Tomb enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -14017,7 +14017,7 @@
         },
         {
             "id": "a43a8e7e-2cb9-5ddb-b76f-0caad2177b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3142a41-8718-4955-9fec-18f3d4875493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3142a41-8718-4955-9fec-18f3d4875493.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W}.)\nAs Sacred Foundry enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -14053,7 +14053,7 @@
         },
         {
             "id": "186fb101-5401-5627-9404-12aae0432571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830eb270-f7aa-4694-8fe1-7c19e148a39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830eb270-f7aa-4694-8fe1-7c19e148a39f.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U}.)\nAs Breeding Pool enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -14089,7 +14089,7 @@
         },
         {
             "id": "f88ba09a-35e0-5209-9cef-f511261c8303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18450a2a-c9b6-4746-a1a5-14e4db552037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18450a2a-c9b6-4746-a1a5-14e4db552037.jpg?1",
             "name": "Standard Procedure",
             "text": "",
             "colours": [],
@@ -14118,7 +14118,7 @@
         },
         {
             "id": "cd074a47-cb37-52f1-8168-dfec328b7391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57516816-4adb-4567-a26d-e08d0513c6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57516816-4adb-4567-a26d-e08d0513c6f7.jpg?1",
             "name": "Aerialephant",
             "text": "",
             "colours": [
@@ -14154,7 +14154,7 @@
         },
         {
             "id": "0ace18be-2c82-5bd9-893b-2a5fbd1eac64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f5a08-f3a5-4632-a050-d9bdaae57dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f5a08-f3a5-4632-a050-d9bdaae57dce.jpg?1",
             "name": "Assembled Ensemble",
             "text": "",
             "colours": [
@@ -14192,7 +14192,7 @@
         },
         {
             "id": "02fe27e2-7238-5812-a24c-39c05756206d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0828457-8ac6-4fb6-afc9-d103bb5b8408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0828457-8ac6-4fb6-afc9-d103bb5b8408.jpg?1",
             "name": "Bar Entry",
             "text": "",
             "colours": [
@@ -14225,7 +14225,7 @@
         },
         {
             "id": "4712ca63-64d5-539b-9d8e-61a84e78f25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10200c-b525-4751-9f4b-15e0055de9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10200c-b525-4751-9f4b-15e0055de9e2.jpg?1",
             "name": "_____ Bird Gets the Worm",
             "text": "",
             "colours": [
@@ -14261,7 +14261,7 @@
         },
         {
             "id": "49d8a4c9-a608-5da6-acb9-5e1cba7e7c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcf4209-373b-4665-93c2-56496ece5b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcf4209-373b-4665-93c2-56496ece5b61.jpg?1",
             "name": "Clowning Around",
             "text": "",
             "colours": [
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "b7288919-78d4-5f64-a867-2078e25cc32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74e4feb-f3d5-4122-866c-421f4f24b829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74e4feb-f3d5-4122-866c-421f4f24b829.jpg?1",
             "name": "Complaints Clerk",
             "text": "",
             "colours": [
@@ -14330,7 +14330,7 @@
         },
         {
             "id": "3d4476e6-3718-5733-a0df-a6664e445d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412833b3-e1f7-4378-8e1b-5805cc6f7998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412833b3-e1f7-4378-8e1b-5805cc6f7998.jpg?1",
             "name": "Far Out",
             "text": "",
             "colours": [
@@ -14363,7 +14363,7 @@
         },
         {
             "id": "00a587d6-64e2-55c5-9a40-fb6401596632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658bd8ee-831f-4b42-a866-2f21a3fb6c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658bd8ee-831f-4b42-a866-2f21a3fb6c61.jpg?1",
             "name": "Form of the Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -14396,7 +14396,7 @@
         },
         {
             "id": "a610013a-b287-5b88-a502-bc3553d5143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d2a66-a548-4739-aabe-6d68fee89b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d2a66-a548-4739-aabe-6d68fee89b6d.jpg?1",
             "name": "Get Your Head in the Game",
             "text": "",
             "colours": [
@@ -14429,7 +14429,7 @@
         },
         {
             "id": "c444abc3-9d52-5f07-9a69-d2f2084881ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a2c71-838c-457f-b928-e00dccca9527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a2c71-838c-457f-b928-e00dccca9527.jpg?1",
             "name": "Gobsmacked",
             "text": "",
             "colours": [
@@ -14464,7 +14464,7 @@
         },
         {
             "id": "571af159-f894-523f-897c-647c1bda8aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76647500-477c-4ecc-a4b3-e7fd17c7d1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76647500-477c-4ecc-a4b3-e7fd17c7d1ee.jpg?1",
             "name": "A Good Day to Pie",
             "text": "",
             "colours": [
@@ -14497,7 +14497,7 @@
         },
         {
             "id": "720a103a-e3df-5b6e-8243-9868df71148f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0f9df8-2883-4673-bfad-b62f79b09198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0f9df8-2883-4673-bfad-b62f79b09198.jpg?1",
             "name": "Hat Trick",
             "text": "",
             "colours": [
@@ -14530,7 +14530,7 @@
         },
         {
             "id": "7c176478-eeee-5400-93fa-8952d91861b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29852adf-bbec-40ae-8c47-38126a12a426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29852adf-bbec-40ae-8c47-38126a12a426.jpg?1",
             "name": "Impounding Lot-Bot",
             "text": "",
             "colours": [
@@ -14566,7 +14566,7 @@
         },
         {
             "id": "83c96965-bb1f-5f87-af59-c5b3a453655e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363b47ed-7b70-40d2-bde7-bb6ac3f8d0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363b47ed-7b70-40d2-bde7-bb6ac3f8d0f6.jpg?1",
             "name": "Jetpack Janitor",
             "text": "",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "d34af78d-71ff-553c-8492-2141de3fc6d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98665cc0-efb1-4079-95cc-8dca6148c320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98665cc0-efb1-4079-95cc-8dca6148c320.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -14642,7 +14642,7 @@
         },
         {
             "id": "e3930ac3-0af8-5177-8c89-35be18c3ddb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87264d92-761f-435b-a907-3ef6c0c9a91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87264d92-761f-435b-a907-3ef6c0c9a91a.jpg?1",
             "name": "Knight in _____ Armor",
             "text": "",
             "colours": [
@@ -14679,7 +14679,7 @@
         },
         {
             "id": "3048b477-c877-5b7a-bd49-29da31565700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb77639-c7cd-428d-8a98-09b70bf1330b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb77639-c7cd-428d-8a98-09b70bf1330b.jpg?1",
             "name": "Leading Performance",
             "text": "",
             "colours": [
@@ -14712,7 +14712,7 @@
         },
         {
             "id": "0131e5c9-7ff1-5df7-8473-fb08bfb4cf6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cbbeba-d236-4635-8f07-df2500c0ef68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cbbeba-d236-4635-8f07-df2500c0ef68.jpg?1",
             "name": "Main Event Horizon",
             "text": "",
             "colours": [
@@ -14745,7 +14745,7 @@
         },
         {
             "id": "6a57098f-3676-5cf2-80e0-bf5e0cf7b276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57be0f52-1a11-479e-8242-29539fce76e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57be0f52-1a11-479e-8242-29539fce76e6.jpg?1",
             "name": "Now You See Me . . .",
             "text": "",
             "colours": [
@@ -14778,7 +14778,7 @@
         },
         {
             "id": "097f2b69-0e57-5031-b1b9-c69375bd45a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c155fd-bab7-4f86-b10c-6c9f1f43b330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c155fd-bab7-4f86-b10c-6c9f1f43b330.jpg?1",
             "name": "Park Bleater",
             "text": "",
             "colours": [
@@ -14814,7 +14814,7 @@
         },
         {
             "id": "d8df4ce4-5f8a-532d-8f4f-80288178b4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765a4d36-200b-4401-811f-03244656ff6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765a4d36-200b-4401-811f-03244656ff6f.jpg?1",
             "name": "Park Re-Entry",
             "text": "",
             "colours": [
@@ -14847,7 +14847,7 @@
         },
         {
             "id": "9ec25025-af44-596a-85c8-b36f37ed9ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ce7df4-3aec-4f2b-a0f4-fd100a9d7660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ce7df4-3aec-4f2b-a0f4-fd100a9d7660.jpg?1",
             "name": "Pin Collection",
             "text": "",
             "colours": [
@@ -14882,7 +14882,7 @@
         },
         {
             "id": "e1f5dd14-89da-562c-af9a-3ccc3b0c8d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe85619-4936-4782-b3d6-8fa77514bb43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe85619-4936-4782-b3d6-8fa77514bb43.jpg?1",
             "name": "Ride Guide",
             "text": "",
             "colours": [
@@ -14918,7 +14918,7 @@
         },
         {
             "id": "80ca86c8-8661-55bb-a400-bd1a39cb2323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeafb4a7-2766-4452-8442-1386d4c4dd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeafb4a7-2766-4452-8442-1386d4c4dd44.jpg?1",
             "name": "Robo-Pi\u00f1ata",
             "text": "",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "4f4f6d13-c429-57f4-a4bc-8749a8437713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648ddac-8c5f-425f-a8c9-8c37a5a7a02a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648ddac-8c5f-425f-a8c9-8c37a5a7a02a.jpg?1",
             "name": "Sanguine Sipper",
             "text": "",
             "colours": [
@@ -14991,7 +14991,7 @@
         },
         {
             "id": "22418cae-fffa-53b5-8f66-d998c349da61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec35de35-bbb3-479f-8e0e-4d937b86d8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec35de35-bbb3-479f-8e0e-4d937b86d8fe.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -15031,7 +15031,7 @@
         },
         {
             "id": "59c4d0a7-70a5-5ffd-b964-27e80328602a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c7d4d8-bfc3-41a1-ad27-5c8d0c69f551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c7d4d8-bfc3-41a1-ad27-5c8d0c69f551.jpg?1",
             "name": "Starlight Spectacular",
             "text": "",
             "colours": [
@@ -15064,7 +15064,7 @@
         },
         {
             "id": "de870f0f-9497-5ab7-88b5-2588dca7dab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f1c0d9-f302-487e-857b-555a326924c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f1c0d9-f302-487e-857b-555a326924c6.jpg?1",
             "name": "Surprise Party",
             "text": "",
             "colours": [
@@ -15097,7 +15097,7 @@
         },
         {
             "id": "6e9e2b0e-755f-5b51-8204-b42df94eb44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef91852-4dea-4d2a-b1a1-8d0c8366830c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef91852-4dea-4d2a-b1a1-8d0c8366830c.jpg?1",
             "name": "Sword-Swallowing Seraph",
             "text": "",
             "colours": [
@@ -15133,7 +15133,7 @@
         },
         {
             "id": "c1d20817-ee3d-5f7d-a3a6-9f510cfb6893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266bec4a-c2a3-4793-a409-fbcf432c7ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266bec4a-c2a3-4793-a409-fbcf432c7ffb.jpg?1",
             "name": "T.A.P.P.E.R.",
             "text": "",
             "colours": [
@@ -15170,7 +15170,7 @@
         },
         {
             "id": "202fa79b-e8ec-5c9c-943f-1a9a92c2d817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df25d01-5d82-453a-b50f-337c38d8806d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df25d01-5d82-453a-b50f-337c38d8806d.jpg?1",
             "name": "Trapeze Artist",
             "text": "",
             "colours": [
@@ -15206,7 +15206,7 @@
         },
         {
             "id": "6a6935e0-91f7-5390-a072-6a36015f5db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87342791-ae77-40e3-9b38-dce94dbeffe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87342791-ae77-40e3-9b38-dce94dbeffe9.jpg?1",
             "name": "Animate Object",
             "text": "",
             "colours": [
@@ -15239,7 +15239,7 @@
         },
         {
             "id": "fb6e23f4-c208-5b3e-9526-4d4028ed767e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c5e1f-6615-48da-beaa-abaf1d11a72c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c5e1f-6615-48da-beaa-abaf1d11a72c.jpg?1",
             "name": "Astroquarium",
             "text": "",
             "colours": [
@@ -15272,7 +15272,7 @@
         },
         {
             "id": "27ba853f-d47f-5123-ae1b-58a191f0ad8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc1c903-9194-4155-a469-2a6fbe7508a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc1c903-9194-4155-a469-2a6fbe7508a1.jpg?1",
             "name": "Baaallerina",
             "text": "",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "dc5fa71e-e1c5-59d6-985f-1f43677bf5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f0d12-8f97-42f0-b305-37563310b09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f0d12-8f97-42f0-b305-37563310b09e.jpg?1",
             "name": "Bag Check",
             "text": "",
             "colours": [
@@ -15341,7 +15341,7 @@
         },
         {
             "id": "b6c8e7a4-c93f-5a0f-9af0-95d4e0e3be5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9bca30a-51bd-4ba5-8a5d-cd6413da6ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9bca30a-51bd-4ba5-8a5d-cd6413da6ba1.jpg?1",
             "name": "Bamboozling Beeble",
             "text": "",
             "colours": [
@@ -15376,7 +15376,7 @@
         },
         {
             "id": "92844214-7f34-5db9-b4b2-946f3a3078fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a1b1ac-55fd-489d-b110-4a394ed46d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a1b1ac-55fd-489d-b110-4a394ed46d16.jpg?1",
             "name": "Bioluminary",
             "text": "",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "b212c5b5-4428-57fc-825b-f771838c8a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71876c-7cf9-4bbe-843f-bd1c488d7060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71876c-7cf9-4bbe-843f-bd1c488d7060.jpg?1",
             "name": "Blufferfish",
             "text": "",
             "colours": [
@@ -15447,7 +15447,7 @@
         },
         {
             "id": "9220a851-c043-5447-a52c-b17e699bd512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324cb7ad-a4be-413f-a69e-90363c52feac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324cb7ad-a4be-413f-a69e-90363c52feac.jpg?1",
             "name": "Boing!",
             "text": "",
             "colours": [
@@ -15480,7 +15480,7 @@
         },
         {
             "id": "b0c0ea34-bfa9-5fd9-93da-862aa11a81a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d55929c-d08e-42d3-89b2-07bca9d0f05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d55929c-d08e-42d3-89b2-07bca9d0f05c.jpg?1",
             "name": "Busted!",
             "text": "",
             "colours": [
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "0b8d1f56-de4d-5084-bd00-0e45f5eda9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811e7fca-c9e8-4ee7-bffa-6e0b84b167b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811e7fca-c9e8-4ee7-bffa-6e0b84b167b7.jpg?1",
             "name": "Command Performance",
             "text": "",
             "colours": [
@@ -15546,7 +15546,7 @@
         },
         {
             "id": "d6b6f5ef-25c0-579a-9f28-34fba7115476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e01dec-1ab1-404f-9758-e82a313a3d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e01dec-1ab1-404f-9758-e82a313a3d50.jpg?1",
             "name": "Croakid Amphibonaut",
             "text": "",
             "colours": [
@@ -15582,7 +15582,7 @@
         },
         {
             "id": "33c77d8b-b2dc-5787-9eb8-98a13753b4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f27012d-f284-4b66-90e3-0ef2c256186c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f27012d-f284-4b66-90e3-0ef2c256186c.jpg?1",
             "name": "Decisions, Decisions",
             "text": "",
             "colours": [
@@ -15615,7 +15615,7 @@
         },
         {
             "id": "dcb13be8-f6ef-5ca0-9af0-2eeb8cc16166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698fbc7-63de-449c-a668-8828e47aff8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698fbc7-63de-449c-a668-8828e47aff8a.jpg?1",
             "name": "Exchange of Words",
             "text": "",
             "colours": [
@@ -15648,7 +15648,7 @@
         },
         {
             "id": "6aa3b847-02ff-5bab-9356-3368e4cb8c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e868b8-9c6b-402f-aec9-ce18eb877705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e868b8-9c6b-402f-aec9-ce18eb877705.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -15688,7 +15688,7 @@
         },
         {
             "id": "6507a50f-dc7f-5566-ad6b-a02c735b3f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c74b3-43b0-4a97-8470-6ee5749ec892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c74b3-43b0-4a97-8470-6ee5749ec892.jpg?1",
             "name": "Focused Funambulist",
             "text": "",
             "colours": [
@@ -15724,7 +15724,7 @@
         },
         {
             "id": "69aad17d-d7e2-5e6b-89e1-5891e26e358f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89074aca-a093-46f2-9d63-0f992c198e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89074aca-a093-46f2-9d63-0f992c198e85.jpg?1",
             "name": "Glitterflitter",
             "text": "",
             "colours": [
@@ -15760,7 +15760,7 @@
         },
         {
             "id": "4dc174c4-a302-51ef-8c13-819acf02a1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32311d5a-6604-469b-b616-bd96d1ddc31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32311d5a-6604-469b-b616-bd96d1ddc31b.jpg?1",
             "name": "How Is This a Par Three?!",
             "text": "",
             "colours": [
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "97614c00-9f7d-5e48-9160-3c004b2a055f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff28845-1da7-4116-a7e9-d0392ce992b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff28845-1da7-4116-a7e9-d0392ce992b5.jpg?1",
             "name": "Make a _____ Splash",
             "text": "",
             "colours": [
@@ -15826,7 +15826,7 @@
         },
         {
             "id": "831e0fc1-b268-5471-a27c-d77dcc887af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7956f-938e-4478-9638-1167221d3bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7956f-938e-4478-9638-1167221d3bd2.jpg?1",
             "name": "Mobile Clone",
             "text": "",
             "colours": [
@@ -15859,7 +15859,7 @@
         },
         {
             "id": "8f46808a-e4c5-599a-b21a-5ad20308684d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13156d62-e0b4-4449-8691-9110b1938cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13156d62-e0b4-4449-8691-9110b1938cb2.jpg?1",
             "name": "Monitor Monitor",
             "text": "",
             "colours": [
@@ -15895,7 +15895,7 @@
         },
         {
             "id": "15e44a4d-056d-5945-b937-5f89dd896f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173423de-2fea-454f-b9a4-2da16f5966f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173423de-2fea-454f-b9a4-2da16f5966f5.jpg?1",
             "name": "Motion Sickness",
             "text": "",
             "colours": [
@@ -15930,7 +15930,7 @@
         },
         {
             "id": "e23a4c70-6f03-5f5c-b4ad-8be8d2d0e3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffb2105-d640-42c8-b723-9aaf42748585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffb2105-d640-42c8-b723-9aaf42748585.jpg?1",
             "name": "Octo Opus",
             "text": "",
             "colours": [
@@ -15963,7 +15963,7 @@
         },
         {
             "id": "2cc225a4-af84-5dda-890f-0b46e2ee8c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28e7d40-58f3-4b16-9edb-230c01bcc562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28e7d40-58f3-4b16-9edb-230c01bcc562.jpg?1",
             "name": "Phone a Friend",
             "text": "",
             "colours": [
@@ -15996,7 +15996,7 @@
         },
         {
             "id": "b8905b28-6c4f-53ac-9162-e3589afcb8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaf7c50-fce6-48ba-9d44-cda9b6054f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaf7c50-fce6-48ba-9d44-cda9b6054f4b.jpg?1",
             "name": "Plate Spinning",
             "text": "",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "16cf5f0b-1a4b-5fee-ac42-ecf6b52d0cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb5662-e7ab-4670-898d-93f1f11aacd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb5662-e7ab-4670-898d-93f1f11aacd2.jpg?1",
             "name": "Prize Wall",
             "text": "",
             "colours": [
@@ -16064,7 +16064,7 @@
         },
         {
             "id": "254fb38a-0307-5129-8c3a-781df4edd653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3268a25-4e65-4064-983f-99671b052211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3268a25-4e65-4064-983f-99671b052211.jpg?1",
             "name": "Seasoned Buttoneer",
             "text": "",
             "colours": [
@@ -16100,7 +16100,7 @@
         },
         {
             "id": "d9392826-9a2d-5a49-8eb9-b90207fb55e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0487a865-87a9-4226-a1d3-4d120b30dbc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0487a865-87a9-4226-a1d3-4d120b30dbc2.jpg?1",
             "name": "Super-Duper Lost",
             "text": "",
             "colours": [
@@ -16133,7 +16133,7 @@
         },
         {
             "id": "e0616b92-cb29-5fb2-b368-7919f232998e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd8fb4b-691b-4e26-80c6-e7178d3b26f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd8fb4b-691b-4e26-80c6-e7178d3b26f2.jpg?1",
             "name": "Treacherous Trapezist",
             "text": "",
             "colours": [
@@ -16169,7 +16169,7 @@
         },
         {
             "id": "9bd24db7-89e6-563e-b230-341a4f3777e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e39c752-7f04-4a6a-8917-1177ae807273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e39c752-7f04-4a6a-8917-1177ae807273.jpg?1",
             "name": "_____ _____ _____ Trespasser",
             "text": "",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "00262af8-7af0-5099-bcb2-6c81c2ffbcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fbc62e-2dd1-4b87-af05-d994c605db8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fbc62e-2dd1-4b87-af05-d994c605db8d.jpg?1",
             "name": "Unlawful Entry",
             "text": "",
             "colours": [
@@ -16239,7 +16239,7 @@
         },
         {
             "id": "912f6082-d276-5821-9abd-21238a3be6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c1355f-da17-4035-96b8-28f7fd22e9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c1355f-da17-4035-96b8-28f7fd22e9ee.jpg?1",
             "name": "Vedalken Squirrel-Whacker",
             "text": "",
             "colours": [
@@ -16275,7 +16275,7 @@
         },
         {
             "id": "c9f5f07b-3646-5f2e-ae29-5f8798a4e239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4544507e-fd90-43de-ade3-baa8a40f732b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4544507e-fd90-43de-ade3-baa8a40f732b.jpg?1",
             "name": "Wizards of the _____",
             "text": "",
             "colours": [
@@ -16312,7 +16312,7 @@
         },
         {
             "id": "541439b6-7387-557c-b73b-ab6517bcf28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4711607a-ad57-4f11-87b6-6d69ca1d010e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4711607a-ad57-4f11-87b6-6d69ca1d010e.jpg?1",
             "name": "Animate Graveyard",
             "text": "",
             "colours": [
@@ -16347,7 +16347,7 @@
         },
         {
             "id": "228eb0ff-0b52-51b1-9429-7619e1efb1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c97d3c-420b-4050-b1e2-19eff7afa790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c97d3c-420b-4050-b1e2-19eff7afa790.jpg?1",
             "name": "Attempted Murder",
             "text": "",
             "colours": [
@@ -16380,7 +16380,7 @@
         },
         {
             "id": "bc6cc1a9-60c4-54ad-9fd7-5f6ef5f727d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cdfebc-fb99-497e-9202-feca5125744b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cdfebc-fb99-497e-9202-feca5125744b.jpg?1",
             "name": "Black Hole",
             "text": "",
             "colours": [
@@ -16413,7 +16413,7 @@
         },
         {
             "id": "d3b49366-5b0f-524a-9503-0b0f4e9fde33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c973bce5-77d7-43f7-a559-25acb80d876a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c973bce5-77d7-43f7-a559-25acb80d876a.jpg?1",
             "name": "Carnival Carnivore",
             "text": "",
             "colours": [
@@ -16450,7 +16450,7 @@
         },
         {
             "id": "03b12284-5db4-5fc2-9050-7f3a4bc4ff35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a6b0c3-a8e2-4de6-a676-d7357ee929fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a6b0c3-a8e2-4de6-a676-d7357ee929fe.jpg?1",
             "name": "Deadbeat Attendant",
             "text": "",
             "colours": [
@@ -16486,7 +16486,7 @@
         },
         {
             "id": "9551f35e-c5af-5bbc-b13a-3f959911771d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdfeed7-90f7-4520-8c82-cbd468aed0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdfeed7-90f7-4520-8c82-cbd468aed0ae.jpg?1",
             "name": "Discourtesy Clerk",
             "text": "",
             "colours": [
@@ -16522,7 +16522,7 @@
         },
         {
             "id": "4d6deac2-e863-51c5-97f6-408301dd4982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151f67eb-a55d-4149-8f93-39ab7379b887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151f67eb-a55d-4149-8f93-39ab7379b887.jpg?1",
             "name": "Disemvowel",
             "text": "",
             "colours": [
@@ -16555,7 +16555,7 @@
         },
         {
             "id": "a861ef6e-1747-50fc-be1e-5bb3e156198c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01ae3f1-6809-4282-9e23-12e60f100297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01ae3f1-6809-4282-9e23-12e60f100297.jpg?1",
             "name": "Dissatisfied Customer",
             "text": "",
             "colours": [
@@ -16591,7 +16591,7 @@
         },
         {
             "id": "19510adf-ab2a-570e-9751-dc7c39c90038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5bd289-6069-4d99-83cd-d1dda24bc224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5bd289-6069-4d99-83cd-d1dda24bc224.jpg?1",
             "name": "Down for Repairs",
             "text": "",
             "colours": [
@@ -16624,7 +16624,7 @@
         },
         {
             "id": "9fa1e647-6a01-5f22-9895-55614b0eea0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b352f4df-b2a0-4fe9-8c96-c53208f08379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b352f4df-b2a0-4fe9-8c96-c53208f08379.jpg?1",
             "name": "Exit Through the Grift Shop",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "82b4a062-e2a3-5919-af74-f48afd2fdadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318a63-ee98-4668-b4a7-ff09a65b2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318a63-ee98-4668-b4a7-ff09a65b2d50.jpg?1",
             "name": "Gray Merchant of Alphabet",
             "text": "",
             "colours": [
@@ -16693,7 +16693,7 @@
         },
         {
             "id": "b3fa5d11-8772-5b5c-be28-42ee6f6de483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab83f9-e415-4e72-aa81-cc401f0e7933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab83f9-e415-4e72-aa81-cc401f0e7933.jpg?1",
             "name": "Haberthrasher",
             "text": "",
             "colours": [
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "6639a8de-9e62-5575-9b96-b43278181ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae675f5d-b6b2-49da-9eae-b686bedcf340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae675f5d-b6b2-49da-9eae-b686bedcf340.jpg?1",
             "name": "Knife and Death",
             "text": "",
             "colours": [
@@ -16763,7 +16763,7 @@
         },
         {
             "id": "9efd3e36-d28a-5024-935c-26a480de9b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e394ce-1857-45ac-9950-1cc912692315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e394ce-1857-45ac-9950-1cc912692315.jpg?1",
             "name": "Last Voyage of the _____",
             "text": "",
             "colours": [
@@ -16796,7 +16796,7 @@
         },
         {
             "id": "ff00f069-23e7-5fad-b76c-8225e6d00c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42293306-aaea-4542-8df4-8138234bf556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42293306-aaea-4542-8df4-8138234bf556.jpg?1",
             "name": "\"Lifetime\" Pass Holder",
             "text": "",
             "colours": [
@@ -16832,7 +16832,7 @@
         },
         {
             "id": "3565cd31-fd7c-5fbe-be84-3b109af61bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bf283-3e03-4b85-9250-441c98b78c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bf283-3e03-4b85-9250-441c98b78c7e.jpg?1",
             "name": "Line Cutter",
             "text": "",
             "colours": [
@@ -16869,7 +16869,7 @@
         },
         {
             "id": "3fa18453-ad97-5c27-bdfe-a863b3b733af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9b37f-20e5-4bda-a23b-950a313486e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9b37f-20e5-4bda-a23b-950a313486e8.jpg?1",
             "name": "Night Shift of the Living Dead",
             "text": "",
             "colours": [
@@ -16902,7 +16902,7 @@
         },
         {
             "id": "5ece4f7f-f77b-58c4-b385-b74bce7f11e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b1f051-4fe6-4dab-a5b4-758a51f83d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b1f051-4fe6-4dab-a5b4-758a51f83d72.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -16942,7 +16942,7 @@
         },
         {
             "id": "b96ff6a5-35cf-540e-9d50-a4459e40b055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb2a46-8b4e-4793-9414-228d6baa7040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb2a46-8b4e-4793-9414-228d6baa7040.jpg?1",
             "name": "Photo Op",
             "text": "",
             "colours": [
@@ -16975,7 +16975,7 @@
         },
         {
             "id": "ba265357-7c86-5543-92fb-4e56ae6c28db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103fa2de-6c5d-419b-8261-ad027cd229b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103fa2de-6c5d-419b-8261-ad027cd229b9.jpg?1",
             "name": "Questionable Cuisine",
             "text": "",
             "colours": [
@@ -17008,7 +17008,7 @@
         },
         {
             "id": "3e4a937b-0802-5f4d-afc3-af5b575c415a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16477afb-7e82-4c84-95a7-e3619e9f7492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16477afb-7e82-4c84-95a7-e3619e9f7492.jpg?1",
             "name": "Quick Fixer",
             "text": "",
             "colours": [
@@ -17044,7 +17044,7 @@
         },
         {
             "id": "be53ef19-36c2-531c-9360-ac5a1a316fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae99e189-4912-4a71-922e-bfced7689abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae99e189-4912-4a71-922e-bfced7689abd.jpg?1",
             "name": "Rat in the Hat",
             "text": "",
             "colours": [
@@ -17080,7 +17080,7 @@
         },
         {
             "id": "39970b89-3132-509a-9fd8-5cddc22f98ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc45d25-b74e-4a59-a00d-0db53651386c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc45d25-b74e-4a59-a00d-0db53651386c.jpg?1",
             "name": "A Real Handful",
             "text": "",
             "colours": [
@@ -17117,7 +17117,7 @@
         },
         {
             "id": "14465672-2d11-5ebc-9edd-63e85404175f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d727549-842c-4105-b6e0-b25c945359df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d727549-842c-4105-b6e0-b25c945359df.jpg?1",
             "name": "Saw in Half",
             "text": "",
             "colours": [
@@ -17150,7 +17150,7 @@
         },
         {
             "id": "9d86dd97-c48d-5a3c-94d2-b09b41942d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689edb7-bc20-46bc-82e5-119f7ca04356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689edb7-bc20-46bc-82e5-119f7ca04356.jpg?1",
             "name": "Scampire",
             "text": "",
             "colours": [
@@ -17186,7 +17186,7 @@
         },
         {
             "id": "85899917-1c50-5d1c-ad1f-8740d8103989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b2f6d6-01ad-431f-835e-62fe0670fe8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b2f6d6-01ad-431f-835e-62fe0670fe8f.jpg?1",
             "name": "Scared Stiff",
             "text": "",
             "colours": [
@@ -17223,7 +17223,7 @@
         },
         {
             "id": "12f4f5e2-88b1-5bda-9f5b-3dbb52cc4692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af7d064-f448-412c-a105-b3accaec8628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af7d064-f448-412c-a105-b3accaec8628.jpg?1",
             "name": "Scooch",
             "text": "",
             "colours": [
@@ -17256,7 +17256,7 @@
         },
         {
             "id": "0727e514-b98b-5b2d-9445-ce815db59157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb77893-d196-458e-b37f-b2d79975a7f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb77893-d196-458e-b37f-b2d79975a7f1.jpg?1",
             "name": "Six-Sided Die",
             "text": "",
             "colours": [
@@ -17289,7 +17289,7 @@
         },
         {
             "id": "029a3a20-831d-521c-a793-df2d6d280e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe6c89-1036-4daf-8c77-25a31e1d0aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe6c89-1036-4daf-8c77-25a31e1d0aba.jpg?1",
             "name": "Soul Swindler",
             "text": "",
             "colours": [
@@ -17325,7 +17325,7 @@
         },
         {
             "id": "c4ace71c-57bd-570c-a69f-66abda358af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb4e22f-2ae8-47cf-a160-431a42c2cf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb4e22f-2ae8-47cf-a160-431a42c2cf1b.jpg?1",
             "name": "Step Right Up",
             "text": "",
             "colours": [
@@ -17358,7 +17358,7 @@
         },
         {
             "id": "a1df1f04-f146-598e-ba1b-924299e12883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98be4570-f223-4413-8d5e-dff0e667cdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98be4570-f223-4413-8d5e-dff0e667cdd6.jpg?1",
             "name": "Wolf in _____ Clothing",
             "text": "",
             "colours": [
@@ -17394,7 +17394,7 @@
         },
         {
             "id": "6e7df926-10a2-55e9-b2fc-08df85f0de81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd13e204-3e5b-4491-b9b0-49d2ab728473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd13e204-3e5b-4491-b9b0-49d2ab728473.jpg?1",
             "name": "Xenosquirrels",
             "text": "",
             "colours": [
@@ -17430,7 +17430,7 @@
         },
         {
             "id": "c7d55066-27ac-5ff0-bf00-23fb7022f5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d8efe5-3356-4dbe-a05f-c87c9b4264a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d8efe5-3356-4dbe-a05f-c87c9b4264a8.jpg?1",
             "name": "Aardwolf's Advantage",
             "text": "",
             "colours": [
@@ -17463,7 +17463,7 @@
         },
         {
             "id": "715d3a8f-5f72-5af9-9ad6-29df925ce3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4a5918-2d31-4e07-a7ae-3322a3cebce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4a5918-2d31-4e07-a7ae-3322a3cebce0.jpg?1",
             "name": "Amped Up",
             "text": "",
             "colours": [
@@ -17496,7 +17496,7 @@
         },
         {
             "id": "7f568b52-ef2e-55a3-85d8-02068a76da81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998684bf-4a99-4d46-a6af-76ce7189bd22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998684bf-4a99-4d46-a6af-76ce7189bd22.jpg?1",
             "name": "Art Appreciation",
             "text": "",
             "colours": [
@@ -17529,7 +17529,7 @@
         },
         {
             "id": "10cb1b14-24cb-5a61-b58c-4754c9460069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41134e27-8d2c-4db2-8c0d-d2f3484ec3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41134e27-8d2c-4db2-8c0d-d2f3484ec3f1.jpg?1",
             "name": "_____ Balls of Fire",
             "text": "",
             "colours": [
@@ -17562,7 +17562,7 @@
         },
         {
             "id": "cf52a1b5-7515-5e58-9e19-25d2189d9cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ad6c1-355a-4a99-8a7d-c754cea81fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ad6c1-355a-4a99-8a7d-c754cea81fb4.jpg?1",
             "name": "Big Winner",
             "text": "",
             "colours": [
@@ -17599,7 +17599,7 @@
         },
         {
             "id": "9b4efed2-9d20-5731-bc92-5f72e1acc324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c16c3d1-cc8c-45b5-88df-03166eb4e373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c16c3d1-cc8c-45b5-88df-03166eb4e373.jpg?1",
             "name": "Carnival Barker",
             "text": "",
             "colours": [
@@ -17635,7 +17635,7 @@
         },
         {
             "id": "59991f44-c682-5b25-bd32-933a306e7a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96b2ddc-9da9-4375-b044-f2c9a53c2e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96b2ddc-9da9-4375-b044-f2c9a53c2e1e.jpg?1",
             "name": "Circuits Act",
             "text": "",
             "colours": [
@@ -17668,7 +17668,7 @@
         },
         {
             "id": "3574c497-dc4d-5fd8-9aab-cfa75b1efb94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0d1c7-4036-425e-8445-c3448c40ded2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0d1c7-4036-425e-8445-c3448c40ded2.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -17708,7 +17708,7 @@
         },
         {
             "id": "2eaee88a-aaee-5770-9662-dca33d604f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cdf65e-bdb9-41f4-9834-8fc335efa7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cdf65e-bdb9-41f4-9834-8fc335efa7a7.jpg?1",
             "name": "Don't Try This at Home",
             "text": "",
             "colours": [
@@ -17741,7 +17741,7 @@
         },
         {
             "id": "cb399ebd-c1df-586b-8ec1-5311a7af526a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd8fc49-1218-408d-af29-8f4fd77cf8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd8fc49-1218-408d-af29-8f4fd77cf8a9.jpg?1",
             "name": "Eelectrocute",
             "text": "",
             "colours": [
@@ -17774,7 +17774,7 @@
         },
         {
             "id": "b349cc63-1757-59eb-a1b8-e0e2cfdf4900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f80bd8-7ce2-449d-b06c-d3e353b54daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f80bd8-7ce2-449d-b06c-d3e353b54daa.jpg?1",
             "name": "_____ Goblin",
             "text": "",
             "colours": [
@@ -17810,7 +17810,7 @@
         },
         {
             "id": "d53f434e-eadd-54c2-b43f-b1e02bc780ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4702fcd-49ac-49f1-b0b9-db38efa6ce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4702fcd-49ac-49f1-b0b9-db38efa6ce8b.jpg?1",
             "name": "Goblin Airbrusher",
             "text": "",
             "colours": [
@@ -17846,7 +17846,7 @@
         },
         {
             "id": "0c1ba9f3-a6f6-5d6c-bab5-a1894fdcd70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fee86e-3916-436a-8e18-85cdd5215f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fee86e-3916-436a-8e18-85cdd5215f7e.jpg?1",
             "name": "Goblin Blastronauts",
             "text": "",
             "colours": [
@@ -17882,7 +17882,7 @@
         },
         {
             "id": "0ca70b42-e9a1-51ae-905a-e4bb71d96c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e808958-2a5d-4d1f-90a1-d32e5f477c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e808958-2a5d-4d1f-90a1-d32e5f477c5e.jpg?1",
             "name": "Goblin Cruciverbalist",
             "text": "",
             "colours": [
@@ -17919,7 +17919,7 @@
         },
         {
             "id": "353598c3-b41f-54db-8ccf-0d3def527283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a43acea-4768-4411-9653-a711770011d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a43acea-4768-4411-9653-a711770011d2.jpg?1",
             "name": "Goblin Girder Gang",
             "text": "",
             "colours": [
@@ -17955,7 +17955,7 @@
         },
         {
             "id": "e5f34607-41de-5e76-bd43-bcaef4a9915f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdaf330-5600-4baa-a56c-7f912218c4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdaf330-5600-4baa-a56c-7f912218c4db.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -17995,7 +17995,7 @@
         },
         {
             "id": "6c3f02d7-edbe-52dd-87f8-a0f172437dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7b0fa-163d-4e38-9f0b-a5ca00b3329c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7b0fa-163d-4e38-9f0b-a5ca00b3329c.jpg?1",
             "name": "Juggletron",
             "text": "",
             "colours": [
@@ -18032,7 +18032,7 @@
         },
         {
             "id": "6dc7e35e-6f49-5901-b5ab-ff3dfd00fe08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaa8a1a-512b-413d-a83f-668c3e07c127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaa8a1a-512b-413d-a83f-668c3e07c127.jpg?1",
             "name": "Minotaur de Force",
             "text": "",
             "colours": [
@@ -18068,7 +18068,7 @@
         },
         {
             "id": "1cdbe66a-4458-5cd1-8e7c-c00f352f1de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bb149-2e50-462e-8b83-5c8339bb3aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bb149-2e50-462e-8b83-5c8339bb3aff.jpg?1",
             "name": "Non-Human Cannonball",
             "text": "",
             "colours": [
@@ -18105,7 +18105,7 @@
         },
         {
             "id": "85a8e127-fae1-547c-82fb-0185a64aad2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -18142,7 +18142,7 @@
         },
         {
             "id": "b70593a5-4091-5d28-87f6-293a019efbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -18177,7 +18177,7 @@
         },
         {
             "id": "2517ac9e-13e1-5dc7-8453-dac60ee86ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240c08c-4dca-4271-88d1-715432714bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240c08c-4dca-4271-88d1-715432714bb1.jpg?1",
             "name": "One-Clown Band",
             "text": "",
             "colours": [
@@ -18215,7 +18215,7 @@
         },
         {
             "id": "b7502f9b-f561-5ecb-9326-0351abe2f610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7876202-d04f-49b3-9561-c98bc8e7513c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7876202-d04f-49b3-9561-c98bc8e7513c.jpg?1",
             "name": "Opening Ceremony",
             "text": "",
             "colours": [
@@ -18252,7 +18252,7 @@
         },
         {
             "id": "f17f1c0b-f622-58d2-bde0-c787263e0cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209203c1-348d-4d3a-bbd4-5a8219505515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209203c1-348d-4d3a-bbd4-5a8219505515.jpg?1",
             "name": "Priority Boarding",
             "text": "",
             "colours": [
@@ -18285,7 +18285,7 @@
         },
         {
             "id": "66a94768-6f96-5692-bf50-02173cfacabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5262fc99-3f9a-4452-9248-e1705d6f2202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5262fc99-3f9a-4452-9248-e1705d6f2202.jpg?1",
             "name": "Proficient Pyrodancer",
             "text": "",
             "colours": [
@@ -18321,7 +18321,7 @@
         },
         {
             "id": "dda685a2-6459-54c5-86f8-8e6be29ea9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194c217b-5ade-4e93-9e05-48359fe4619f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194c217b-5ade-4e93-9e05-48359fe4619f.jpg?1",
             "name": "Rad Rascal",
             "text": "",
             "colours": [
@@ -18357,7 +18357,7 @@
         },
         {
             "id": "fea77332-1f60-5679-8b33-caaf18668129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae55cd76-5959-457c-9c19-747e3183d8c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae55cd76-5959-457c-9c19-747e3183d8c0.jpg?1",
             "name": "Rock Star",
             "text": "",
             "colours": [
@@ -18393,7 +18393,7 @@
         },
         {
             "id": "ae8d543f-8349-550c-a0b6-12aed87e5aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ea8772-4060-4f9f-86ac-6e6a6088f372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ea8772-4060-4f9f-86ac-6e6a6088f372.jpg?1",
             "name": "Slight Malfunction",
             "text": "",
             "colours": [
@@ -18426,7 +18426,7 @@
         },
         {
             "id": "e94cfea2-7e3f-5e6f-b425-ddb55ea6ab3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cd8b8b-b800-44f6-a395-0ba032c09646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cd8b8b-b800-44f6-a395-0ba032c09646.jpg?1",
             "name": "Ticking Mime Bomb",
             "text": "",
             "colours": [
@@ -18464,7 +18464,7 @@
         },
         {
             "id": "58bb8ea0-b322-53b7-bc3e-df379c7f3fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb346c6-4732-4e35-b6e4-7b2a50b65d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb346c6-4732-4e35-b6e4-7b2a50b65d44.jpg?1",
             "name": "Trigger Happy",
             "text": "",
             "colours": [
@@ -18497,7 +18497,7 @@
         },
         {
             "id": "d512fc07-9942-5b58-aa10-081421c95b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bfa5cf-87b5-43a6-a5c7-24a41e287545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bfa5cf-87b5-43a6-a5c7-24a41e287545.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -18541,7 +18541,7 @@
         },
         {
             "id": "ac619c9d-1e15-54df-86ca-2717c247e949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59e34b6-352e-4a0f-b251-66af1ca5101c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59e34b6-352e-4a0f-b251-66af1ca5101c.jpg?1",
             "name": "Wee Champion",
             "text": "",
             "colours": [
@@ -18578,7 +18578,7 @@
         },
         {
             "id": "eff31d4e-2b5f-5ceb-85d0-726d84ba9e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23c1ade-c751-4071-beb5-9f47d6f8b557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23c1ade-c751-4071-beb5-9f47d6f8b557.jpg?1",
             "name": "Well Done",
             "text": "",
             "colours": [
@@ -18611,7 +18611,7 @@
         },
         {
             "id": "92c90bf4-b890-5610-83d4-976ae38df7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fcdd26-669b-4f0f-a932-708abfc1711c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fcdd26-669b-4f0f-a932-708abfc1711c.jpg?1",
             "name": "Alpha Guard",
             "text": "",
             "colours": [
@@ -18647,7 +18647,7 @@
         },
         {
             "id": "ff0b6274-640e-5237-9230-7460b5109b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdc8c7-9bb2-49f3-a633-6e009fa8586f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdc8c7-9bb2-49f3-a633-6e009fa8586f.jpg?1",
             "name": "Atomwheel Acrobats",
             "text": "",
             "colours": [
@@ -18683,7 +18683,7 @@
         },
         {
             "id": "45c0128b-fa43-59f7-a2f7-4d30e8c90c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53899f04-d0b5-464c-bac9-c3e9490ed127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53899f04-d0b5-464c-bac9-c3e9490ed127.jpg?1",
             "name": "Blorbian Buddy",
             "text": "",
             "colours": [
@@ -18719,7 +18719,7 @@
         },
         {
             "id": "8669679d-ccf3-5523-8b06-4971e610606f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71057f4e-8730-4f88-a2bc-ccf920465762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71057f4e-8730-4f88-a2bc-ccf920465762.jpg?1",
             "name": "Centaur of Attention",
             "text": "",
             "colours": [
@@ -18755,7 +18755,7 @@
         },
         {
             "id": "ec11022d-09f2-5c4b-92e3-88f906575e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddeb24e8-5caa-4a18-bdfa-47334286a920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddeb24e8-5caa-4a18-bdfa-47334286a920.jpg?1",
             "name": "Chicken Troupe",
             "text": "",
             "colours": [
@@ -18791,7 +18791,7 @@
         },
         {
             "id": "20f9abd2-7732-589e-8b1f-5ec12c5d4f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70fe267-d1d4-43f1-a95e-7fc275bde243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70fe267-d1d4-43f1-a95e-7fc275bde243.jpg?1",
             "name": "Clandestine Chameleon",
             "text": "",
             "colours": [
@@ -18827,7 +18827,7 @@
         },
         {
             "id": "5c64ecfa-ddd2-5cc2-9f47-a3569cef700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4e96bf-e6b8-48bf-af10-d4857c724153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4e96bf-e6b8-48bf-af10-d4857c724153.jpg?1",
             "name": "Coming Attraction",
             "text": "",
             "colours": [
@@ -18860,7 +18860,7 @@
         },
         {
             "id": "2fb85c08-6d25-5f80-9328-7503551bfaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84ff6c-0380-4dec-879d-610876b2f57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84ff6c-0380-4dec-879d-610876b2f57d.jpg?1",
             "name": "Done for the Day",
             "text": "",
             "colours": [
@@ -18893,7 +18893,7 @@
         },
         {
             "id": "affce140-4236-5d55-bc55-d7bb1a3fb52c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f31b7e-fb62-4bec-b726-4da344d2ab82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f31b7e-fb62-4bec-b726-4da344d2ab82.jpg?1",
             "name": "Embiggen",
             "text": "",
             "colours": [
@@ -18926,7 +18926,7 @@
         },
         {
             "id": "b51e4d00-6083-5ba0-8c3a-ab576085b162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0646993-4387-4df5-8ba0-a2ed630e8077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0646993-4387-4df5-8ba0-a2ed630e8077.jpg?1",
             "name": "Fight the _____ Fight",
             "text": "",
             "colours": [
@@ -18961,7 +18961,7 @@
         },
         {
             "id": "fc8aead9-f101-51f4-bb79-a79567a82ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64724b2-8e31-4145-a4c2-79a1fbfa936b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64724b2-8e31-4145-a4c2-79a1fbfa936b.jpg?1",
             "name": "Finishing Move",
             "text": "",
             "colours": [
@@ -18994,7 +18994,7 @@
         },
         {
             "id": "3c3f4a9d-55d9-55e8-868c-8be520115bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774107d-f5d3-4aa8-8f55-b4b109a8c0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774107d-f5d3-4aa8-8f55-b4b109a8c0df.jpg?1",
             "name": "Grabby Tabby",
             "text": "",
             "colours": [
@@ -19030,7 +19030,7 @@
         },
         {
             "id": "c439ca4c-2be3-5874-a9df-442026c2692b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad70398-6522-4e77-905c-32519a896bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad70398-6522-4e77-905c-32519a896bd8.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -19070,7 +19070,7 @@
         },
         {
             "id": "59863087-7126-58c1-8588-38ad92782790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a92b80-f944-40c5-b789-213afd1436ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a92b80-f944-40c5-b789-213afd1436ef.jpg?1",
             "name": "Icing Manipulator",
             "text": "",
             "colours": [
@@ -19106,7 +19106,7 @@
         },
         {
             "id": "b3fc7a07-96ef-5f54-bd9f-6a0d1ba7d281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9cb34-7ba1-4bce-a2a3-cc65cbbdbe5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9cb34-7ba1-4bce-a2a3-cc65cbbdbe5c.jpg?1",
             "name": "An Incident Has Occurred",
             "text": "",
             "colours": [
@@ -19139,7 +19139,7 @@
         },
         {
             "id": "7b398373-b253-50d0-8ddc-dfeb08b7acb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58f01de-aede-489f-866a-720b67f0e138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58f01de-aede-489f-866a-720b67f0e138.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -19179,7 +19179,7 @@
         },
         {
             "id": "d54994d1-dc7e-5438-87ff-55960da663a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da27712-70f0-49e6-9ecc-da92199afe9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da27712-70f0-49e6-9ecc-da92199afe9c.jpg?1",
             "name": "Killer Cosplay",
             "text": "",
             "colours": [
@@ -19214,7 +19214,7 @@
         },
         {
             "id": "e0368369-8879-538c-94b4-25829c0e3900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900f91be-10dc-4f4a-b6a6-013b372b982b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900f91be-10dc-4f4a-b6a6-013b372b982b.jpg?1",
             "name": "Lineprancers",
             "text": "",
             "colours": [
@@ -19250,7 +19250,7 @@
         },
         {
             "id": "1b6791f0-850f-56f5-99d3-fc0b69ca4557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca0f438-d0f9-40ae-959c-90971c878b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca0f438-d0f9-40ae-959c-90971c878b0d.jpg?1",
             "name": "Mistakes Were Made",
             "text": "",
             "colours": [
@@ -19283,7 +19283,7 @@
         },
         {
             "id": "b90e95e8-d202-54f4-8bf7-f4095b318efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8783af-3904-4f2f-bad2-9f5c36fb0639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8783af-3904-4f2f-bad2-9f5c36fb0639.jpg?1",
             "name": "_____-o-saurus",
             "text": "",
             "colours": [
@@ -19319,7 +19319,7 @@
         },
         {
             "id": "d82e916f-37f3-5e2f-96c4-d76cb652e564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a4342b-823f-4f60-bba9-f83dfb050397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a4342b-823f-4f60-bba9-f83dfb050397.jpg?1",
             "name": "Pair o' Dice Lost",
             "text": "",
             "colours": [
@@ -19352,7 +19352,7 @@
         },
         {
             "id": "da2df91d-b4dd-5639-9342-166e4d960909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e8bda-77d3-4031-9fcd-c5c4838fd88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e8bda-77d3-4031-9fcd-c5c4838fd88c.jpg?1",
             "name": "Petting Zookeeper",
             "text": "",
             "colours": [
@@ -19388,7 +19388,7 @@
         },
         {
             "id": "467b9f20-aa7e-54ad-90ac-fd084257ec9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afccff1-a590-435d-821e-3e0e1a9738b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afccff1-a590-435d-821e-3e0e1a9738b9.jpg?1",
             "name": "Pie-Eating Contest",
             "text": "",
             "colours": [
@@ -19421,7 +19421,7 @@
         },
         {
             "id": "e736f0f4-25a2-50bd-877e-4d8353791df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a967f75-f189-4cfc-abc5-6633583790ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a967f75-f189-4cfc-abc5-6633583790ed.jpg?1",
             "name": "Plot Armor",
             "text": "",
             "colours": [
@@ -19456,7 +19456,7 @@
         },
         {
             "id": "7fbe9beb-9857-5be1-a7b5-16b0ec50932f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb297-ec1b-41fa-a2f8-884c42475809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb297-ec1b-41fa-a2f8-884c42475809.jpg?1",
             "name": "Resolute Veggiesaur",
             "text": "",
             "colours": [
@@ -19492,7 +19492,7 @@
         },
         {
             "id": "d0fbb6f9-7a15-5825-9a73-45ab1bbca948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24649a26-822e-456f-8f28-8e1d002fdd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24649a26-822e-456f-8f28-8e1d002fdd81.jpg?1",
             "name": "Sole Performer",
             "text": "",
             "colours": [
@@ -19528,7 +19528,7 @@
         },
         {
             "id": "f7f7f6e5-6533-5d18-a227-47d50010924a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf848f3-4716-4b1b-b469-ae6bb112d15c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf848f3-4716-4b1b-b469-ae6bb112d15c.jpg?1",
             "name": "Spelling Bee",
             "text": "",
             "colours": [
@@ -19564,7 +19564,7 @@
         },
         {
             "id": "f13d6134-b435-57a7-8ea8-5f9b568fc8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff9491e-ea18-4b80-ae27-8ce8a8eca9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff9491e-ea18-4b80-ae27-8ce8a8eca9cb.jpg?1",
             "name": "Squirrel Squatters",
             "text": "",
             "colours": [
@@ -19599,7 +19599,7 @@
         },
         {
             "id": "1f5d759d-e562-5010-a0de-70a5dc71a8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202595c2-958c-416c-8d01-a7d4136628cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202595c2-958c-416c-8d01-a7d4136628cf.jpg?1",
             "name": "Stiltstrider",
             "text": "",
             "colours": [
@@ -19635,7 +19635,7 @@
         },
         {
             "id": "d65d371b-76c6-5cf8-b093-dd902dff09c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d27927c-30b7-42e9-8a71-e16f60381d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d27927c-30b7-42e9-8a71-e16f60381d54.jpg?1",
             "name": "Tchotchke Elemental",
             "text": "",
             "colours": [
@@ -19670,7 +19670,7 @@
         },
         {
             "id": "e5830ea3-1013-59a8-a798-cf03d099a1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2743c817-fbe3-436d-96ab-00cd69c23423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2743c817-fbe3-436d-96ab-00cd69c23423.jpg?1",
             "name": "Tug of War",
             "text": "",
             "colours": [
@@ -19703,7 +19703,7 @@
         },
         {
             "id": "073edb94-4c9d-5c93-b4fd-9a66ce79dae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65d1ab8-ab8e-44db-b6fe-0d1a19835935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65d1ab8-ab8e-44db-b6fe-0d1a19835935.jpg?1",
             "name": "Vegetation Abomination",
             "text": "",
             "colours": [
@@ -19741,7 +19741,7 @@
         },
         {
             "id": "ed86e8ba-35b6-5b66-beb1-58d0775301d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707be12-b255-47ea-a938-f4b03a1e9247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707be12-b255-47ea-a938-f4b03a1e9247.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -19784,7 +19784,7 @@
         },
         {
             "id": "17984c5d-bc4c-5a44-baed-bb6b0103d76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2624ed75-81ea-49aa-8acb-36d0084a9312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2624ed75-81ea-49aa-8acb-36d0084a9312.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -19826,7 +19826,7 @@
         },
         {
             "id": "a6321f1b-3988-58dd-b148-f02b05b4fc3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b0f07-999f-437a-af88-5d3f391afe12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b0f07-999f-437a-af88-5d3f391afe12.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -19868,7 +19868,7 @@
         },
         {
             "id": "37f3af28-3c8a-5609-8f51-697ad401b9f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d354e-0485-4469-9781-fe03c78c624a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d354e-0485-4469-9781-fe03c78c624a.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -19911,7 +19911,7 @@
         },
         {
             "id": "8871f80f-547b-50fc-873b-da676b39c38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f415ac7-24e7-4cbf-a0ed-5086aa6e7cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f415ac7-24e7-4cbf-a0ed-5086aa6e7cea.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -19953,7 +19953,7 @@
         },
         {
             "id": "866a6a1c-dd1f-5c75-99bd-c66ce302a8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e571-402b-4caa-afd8-562dff0ef341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e571-402b-4caa-afd8-562dff0ef341.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "",
             "colours": [
@@ -19994,7 +19994,7 @@
         },
         {
             "id": "1429a0bf-8f48-5c98-a434-2ee76868a7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227984-b6d5-417f-a00e-6d6ec1fd9cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227984-b6d5-417f-a00e-6d6ec1fd9cfc.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -20036,7 +20036,7 @@
         },
         {
             "id": "e115851a-0a98-52bc-86c4-d25859ec5121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c0d46-7a88-40d0-9652-712c60bb3a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c0d46-7a88-40d0-9652-712c60bb3a03.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -20078,7 +20078,7 @@
         },
         {
             "id": "e0049a60-f8a1-5c4a-b869-12c58702953b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ebcd89-7dc2-4a38-83f2-edccd319c8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ebcd89-7dc2-4a38-83f2-edccd319c8fb.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -20120,7 +20120,7 @@
         },
         {
             "id": "47caf335-9de6-5e03-ba13-5e79b9685ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fda05f-01c6-487f-b264-949271114316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fda05f-01c6-487f-b264-949271114316.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -20162,7 +20162,7 @@
         },
         {
             "id": "8fc1e197-2527-5579-8bb3-fd73ad6ee5db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd970a38-6575-4302-a308-fce3688bb795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd970a38-6575-4302-a308-fce3688bb795.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -20204,7 +20204,7 @@
         },
         {
             "id": "6121f9c0-a100-5814-bd96-8d68c84a6a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90b69a-aad6-4dcf-b060-52cef300f48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90b69a-aad6-4dcf-b060-52cef300f48d.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -20246,7 +20246,7 @@
         },
         {
             "id": "a6744f05-1770-57a5-ac5f-014230d4f866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fdf560-a106-4991-bb0b-2811db33ee1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fdf560-a106-4991-bb0b-2811db33ee1e.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -20288,7 +20288,7 @@
         },
         {
             "id": "f4f99e08-9069-5786-9a4b-fab50fa0e3a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f43d58-b64c-4726-a1a9-8d71d2da4507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f43d58-b64c-4726-a1a9-8d71d2da4507.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -20331,7 +20331,7 @@
         },
         {
             "id": "6d68a633-e7bf-5bd6-925a-75cd68f8667d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b92f4b-570a-431c-a6e3-4974e9316e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b92f4b-570a-431c-a6e3-4974e9316e9e.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -20373,7 +20373,7 @@
         },
         {
             "id": "e819aa75-7344-5683-a920-8ec5d2eafbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed669650-8776-4aef-b9a7-21ce32e77a44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed669650-8776-4aef-b9a7-21ce32e77a44.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -20416,7 +20416,7 @@
         },
         {
             "id": "972377f6-7647-5d50-b9a9-4984dfd71055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4228a057-e617-428b-b119-35659d10aeba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4228a057-e617-428b-b119-35659d10aeba.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -20458,7 +20458,7 @@
         },
         {
             "id": "533e84f0-05f5-50c9-856d-f9db6dfd787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b5ebec-503c-4fcc-b73b-b7c1fbed425b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b5ebec-503c-4fcc-b73b-b7c1fbed425b.jpg?1",
             "name": "Space Beleren",
             "text": "",
             "colours": [
@@ -20499,7 +20499,7 @@
         },
         {
             "id": "f08c42fe-e742-5173-8180-5acbe4d6c892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200905c-ed18-45aa-8a24-3e1ef688bc6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200905c-ed18-45aa-8a24-3e1ef688bc6f.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -20541,7 +20541,7 @@
         },
         {
             "id": "7bb97baa-a027-5990-9e2e-ffed24ef8857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d732d0c-9b77-477a-b867-a0086753ed1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d732d0c-9b77-477a-b867-a0086753ed1e.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -20583,7 +20583,7 @@
         },
         {
             "id": "05f06df8-52d5-5f4a-8317-e0e3540c11ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8663120-01f9-49cb-aeb7-8eac274b3a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8663120-01f9-49cb-aeb7-8eac274b3a62.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -20626,7 +20626,7 @@
         },
         {
             "id": "b8e767e2-70bb-5ab6-97f6-ffc709878076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af667ba8-10ac-4ba9-bb12-0ce356ecba2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af667ba8-10ac-4ba9-bb12-0ce356ecba2a.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -20669,7 +20669,7 @@
         },
         {
             "id": "044684bb-d5fd-5d0e-8228-d18837f34480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4087522-a795-4bb4-91e5-506dbcf07cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4087522-a795-4bb4-91e5-506dbcf07cae.jpg?1",
             "name": "Autograph Book",
             "text": "",
             "colours": [],
@@ -20698,7 +20698,7 @@
         },
         {
             "id": "a7c90807-b6a2-59a4-bbf7-125b5eb96745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506ec976-0347-4a62-b895-3fa443d99577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506ec976-0347-4a62-b895-3fa443d99577.jpg?1",
             "name": "Blue Ribbon",
             "text": "",
             "colours": [],
@@ -20729,7 +20729,7 @@
         },
         {
             "id": "d5302c51-4e56-5d5e-859d-bb6fc4160509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce90e68-1765-4c78-90ab-7435517349e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce90e68-1765-4c78-90ab-7435517349e4.jpg?1",
             "name": "Celebr-8000",
             "text": "",
             "colours": [],
@@ -20762,7 +20762,7 @@
         },
         {
             "id": "41d0be0f-8d87-544d-b878-485e01a8a4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd9541-3b1c-4af1-ad23-92c1b1bd01e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd9541-3b1c-4af1-ad23-92c1b1bd01e2.jpg?1",
             "name": "Clown Car",
             "text": "",
             "colours": [],
@@ -20793,7 +20793,7 @@
         },
         {
             "id": "a3f969df-dabf-54cf-b484-3e5c84bbb6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ec39e-7790-4621-b095-69bbc4ba1b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ec39e-7790-4621-b095-69bbc4ba1b3c.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -20829,7 +20829,7 @@
         },
         {
             "id": "ab20d313-8d98-568e-ae8f-0ac77311fdd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862780d6-3f3b-440b-bef1-3c24c1be4486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862780d6-3f3b-440b-bef1-3c24c1be4486.jpg?1",
             "name": "Draconian Gate-Bot",
             "text": "",
             "colours": [],
@@ -20861,7 +20861,7 @@
         },
         {
             "id": "3401a84f-333f-5f39-b7b2-ac7368c6879c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ae2b25-93f9-4111-b377-68c300e425a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ae2b25-93f9-4111-b377-68c300e425a3.jpg?1",
             "name": "Greatest Show in the Multiverse",
             "text": "",
             "colours": [],
@@ -20893,7 +20893,7 @@
         },
         {
             "id": "fb4f919d-3a66-5efb-bca4-ed6c48440ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d881c16e-978c-4ecb-9009-d4ff30932647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d881c16e-978c-4ecb-9009-d4ff30932647.jpg?1",
             "name": "Park Map",
             "text": "",
             "colours": [],
@@ -20922,7 +20922,7 @@
         },
         {
             "id": "2bfd08ab-5d03-5ddf-83b0-ab3c95094569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2d7cbc-3d21-4191-923f-08e603c818f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2d7cbc-3d21-4191-923f-08e603c818f0.jpg?1",
             "name": "_____ _____ Rocketship",
             "text": "",
             "colours": [],
@@ -20953,7 +20953,7 @@
         },
         {
             "id": "f9aa7c14-999f-5437-9435-b7ee2a776bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f39645-0448-4355-98cc-e47295f19681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f39645-0448-4355-98cc-e47295f19681.jpg?1",
             "name": "Souvenir T-Shirt",
             "text": "",
             "colours": [],
@@ -20984,7 +20984,7 @@
         },
         {
             "id": "49475d00-a70b-51e9-94b5-ad1cc2ba3fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce70c02-01e4-4a3d-8670-4b6b1456e050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce70c02-01e4-4a3d-8670-4b6b1456e050.jpg?1",
             "name": "Strength-Testing Hammer",
             "text": "",
             "colours": [],
@@ -21015,7 +21015,7 @@
         },
         {
             "id": "e32bbd82-eee6-5d8b-97ee-4cb6b846fd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de8b26f-1afb-4a87-9766-3b7961d81987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de8b26f-1afb-4a87-9766-3b7961d81987.jpg?1",
             "name": "Ticket Turbotubes",
             "text": "",
             "colours": [],
@@ -21044,7 +21044,7 @@
         },
         {
             "id": "00f0c6fa-8a42-5d3e-a0e2-215e86d7af9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ac22a3-9ac6-48aa-86f1-0b7e8836ad1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ac22a3-9ac6-48aa-86f1-0b7e8836ad1c.jpg?1",
             "name": "Ticketomaton",
             "text": "",
             "colours": [],
@@ -21076,7 +21076,7 @@
         },
         {
             "id": "5b5e05ad-833b-5967-abaf-02da41a9da67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2c656-2b4a-4541-8934-29d0db93f794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2c656-2b4a-4541-8934-29d0db93f794.jpg?1",
             "name": "Wicker Picker",
             "text": "",
             "colours": [],
@@ -21109,7 +21109,7 @@
         },
         {
             "id": "a085d24d-fd9b-514f-86cf-41100da28870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6017b7d-7444-4946-a760-95cf30966b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6017b7d-7444-4946-a760-95cf30966b45.jpg?1",
             "name": "The Big Top",
             "text": "",
             "colours": [],
@@ -21138,7 +21138,7 @@
         },
         {
             "id": "db8ce153-3463-5b42-bf5c-56c7c04f40e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cb79f6-a274-4595-a579-3865d73b8dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cb79f6-a274-4595-a579-3865d73b8dec.jpg?1",
             "name": "Nearby Planet",
             "text": "",
             "colours": [],
@@ -21173,7 +21173,7 @@
         },
         {
             "id": "36a529c8-6cc8-5a49-9bf9-ca27959dfc86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559be6bc-cce8-43b1-b8a5-1795e727f1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559be6bc-cce8-43b1-b8a5-1795e727f1c2.jpg?1",
             "name": "Urza's Fun House",
             "text": "",
             "colours": [],
@@ -21204,7 +21204,7 @@
         },
         {
             "id": "ffbf9e65-bc44-5a8f-ad29-054c7b8211e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4af7f5-c89c-4e61-9d4b-b9e467ca55b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4af7f5-c89c-4e61-9d4b-b9e467ca55b4.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -21241,7 +21241,7 @@
         },
         {
             "id": "8245f416-1346-5e63-b629-d1da37b0ffac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e083ce-0f15-4ff0-8af1-747565f2d0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e083ce-0f15-4ff0-8af1-747565f2d0d8.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21278,7 +21278,7 @@
         },
         {
             "id": "627786cd-b6b9-5e17-985d-a38d21afe12e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c4bbf1-2e52-4b43-ad35-9272b48d36a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c4bbf1-2e52-4b43-ad35-9272b48d36a8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21315,7 +21315,7 @@
         },
         {
             "id": "8d86d944-12fd-5d37-ae41-ceeb37c429f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e998ce9-4853-44d1-a01a-e2d493718ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e998ce9-4853-44d1-a01a-e2d493718ceb.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21352,7 +21352,7 @@
         },
         {
             "id": "c40f5914-fedc-5248-b62e-55591430cde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46df0e0-648d-4dc9-a2c7-ac96125ba77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46df0e0-648d-4dc9-a2c7-ac96125ba77c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -21389,7 +21389,7 @@
         },
         {
             "id": "c3b5bfbc-a3c9-595c-9235-f32c9d63b5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb3077-484d-42d4-a54b-5fade5335420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb3077-484d-42d4-a54b-5fade5335420.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -21426,7 +21426,7 @@
         },
         {
             "id": "31acf70d-12bf-562f-a1d7-b3fabbd0d895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670e5e4-721b-422a-b10e-09bb742cbc4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670e5e4-721b-422a-b10e-09bb742cbc4b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21463,7 +21463,7 @@
         },
         {
             "id": "200ed23d-7d2c-5df6-84eb-8b690d9ce3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d49fc14-e848-4c44-a03c-6dfb83efed80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d49fc14-e848-4c44-a03c-6dfb83efed80.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21500,7 +21500,7 @@
         },
         {
             "id": "ee5dd420-745c-5003-95c1-baa7249ca4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc7313-8b12-4ce1-9016-59b4e3c78ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc7313-8b12-4ce1-9016-59b4e3c78ff1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21537,7 +21537,7 @@
         },
         {
             "id": "27a17bfc-8a53-521c-866e-9c34d07cbdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ec5e4-3b44-4359-9ab8-4e25e2a9ec86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ec5e4-3b44-4359-9ab8-4e25e2a9ec86.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -21574,7 +21574,7 @@
         },
         {
             "id": "e65f6303-91e6-5448-9eb3-9225a4b61f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b58b-3d12-4385-b634-7ee7bc1c2964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b58b-3d12-4385-b634-7ee7bc1c2964.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21614,7 +21614,7 @@
         },
         {
             "id": "2dd642b8-fabe-5597-ad91-46805e392f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371aeeb3-9c17-44d9-a191-fde80da1e37e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371aeeb3-9c17-44d9-a191-fde80da1e37e.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -21654,7 +21654,7 @@
         },
         {
             "id": "616ba59a-d535-570e-bae7-93017fdd63e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a5124-b0dc-4bc7-8b30-46a85bbe7d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a5124-b0dc-4bc7-8b30-46a85bbe7d38.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21694,7 +21694,7 @@
         },
         {
             "id": "dd47a366-74ea-5f38-9e23-c7f4eb657802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242f9727-5fd6-4f6e-9447-58731e5aff20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242f9727-5fd6-4f6e-9447-58731e5aff20.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21734,7 +21734,7 @@
         },
         {
             "id": "e9694fbc-86c7-5ff6-8e70-717c69a53f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66deec5a-f459-4c91-8de2-c24d83dfebf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66deec5a-f459-4c91-8de2-c24d83dfebf5.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -21774,7 +21774,7 @@
         },
         {
             "id": "e6f64c87-a612-54d3-b063-a96d45cd6ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f380fcd-dbd8-4d30-a332-7627d51b237f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f380fcd-dbd8-4d30-a332-7627d51b237f.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21814,7 +21814,7 @@
         },
         {
             "id": "d953c865-24db-5735-8552-95906bcf613a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9bb6a5-76e8-4490-895b-287d7db11449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9bb6a5-76e8-4490-895b-287d7db11449.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -21858,7 +21858,7 @@
         },
         {
             "id": "4f448fc0-e57d-5634-9b36-28b4040b9319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0d0f9a-9018-45fb-9e14-023e2268ad35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0d0f9a-9018-45fb-9e14-023e2268ad35.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21898,7 +21898,7 @@
         },
         {
             "id": "7e36537b-9309-5666-b547-5027d657ed2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f83eab-98ae-47c2-a4ca-3b2137feaa64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f83eab-98ae-47c2-a4ca-3b2137feaa64.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -21938,7 +21938,7 @@
         },
         {
             "id": "fd898be6-92fb-5537-b36b-fc68de26959c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8862a56-028b-462a-b789-e01f1abacceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8862a56-028b-462a-b789-e01f1abacceb.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -21981,7 +21981,7 @@
         },
         {
             "id": "5197f4de-fd5f-5686-bed4-d768512b4c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627e21e6-b2fb-41d6-b8f2-ef7f8360a3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627e21e6-b2fb-41d6-b8f2-ef7f8360a3ce.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -22023,7 +22023,7 @@
         },
         {
             "id": "f064ff0b-40b8-5680-b9c7-c5ee43398d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ffb0ab-d7bf-4136-9aa7-0a4965581a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ffb0ab-d7bf-4136-9aa7-0a4965581a75.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -22065,7 +22065,7 @@
         },
         {
             "id": "267e0705-f5d9-5133-a25a-8c5eefe7f63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32494237-9d3f-4624-8762-2641fffc2115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32494237-9d3f-4624-8762-2641fffc2115.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -22108,7 +22108,7 @@
         },
         {
             "id": "62ce5141-7f33-558f-9b29-a8b2ebf40cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3866b64b-2d6d-4708-9a7d-be2be2f1d59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3866b64b-2d6d-4708-9a7d-be2be2f1d59d.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -22150,7 +22150,7 @@
         },
         {
             "id": "6277d1f3-b8ea-57d7-9e0f-64cc1b36f57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b5a57-21d3-4504-8b53-3d583ba3f438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b5a57-21d3-4504-8b53-3d583ba3f438.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -22192,7 +22192,7 @@
         },
         {
             "id": "ed8b5a6e-9908-5b9a-93a6-6b479be79804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445fb505-05c6-4a15-89db-7dcbb1d83c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445fb505-05c6-4a15-89db-7dcbb1d83c91.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -22234,7 +22234,7 @@
         },
         {
             "id": "3d7c32fe-3c8f-5bbc-856c-25a8d3ce9af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d781ac53-88fa-451c-a747-ba178c251c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d781ac53-88fa-451c-a747-ba178c251c3c.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -22276,7 +22276,7 @@
         },
         {
             "id": "71a199b1-adf7-5955-8ea8-d225c4463fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e43e41e-782a-4d28-bb45-0a1265bf9732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e43e41e-782a-4d28-bb45-0a1265bf9732.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -22318,7 +22318,7 @@
         },
         {
             "id": "6a07f6f5-972c-5b02-8129-267cf3345db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0909366b-b578-4829-afd3-6b4d6ef474a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0909366b-b578-4829-afd3-6b4d6ef474a4.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -22360,7 +22360,7 @@
         },
         {
             "id": "d0815555-07a2-511f-9349-5dae327a51de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816683ec-cfd2-4a66-bb9d-a13c1ad60d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816683ec-cfd2-4a66-bb9d-a13c1ad60d1e.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -22402,7 +22402,7 @@
         },
         {
             "id": "f44e7474-d776-5c6b-bcda-4f8e4f889bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e56f12-2097-413d-9a79-8476067900b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e56f12-2097-413d-9a79-8476067900b7.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -22444,7 +22444,7 @@
         },
         {
             "id": "3c686e35-bb9e-5bc8-80aa-a812fd911f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1107d-f478-48dc-b721-6eb1f6bc1b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1107d-f478-48dc-b721-6eb1f6bc1b22.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -22487,7 +22487,7 @@
         },
         {
             "id": "a4806bed-7118-548f-9939-a24474295710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ba4d49-d7fa-43f4-b5c4-8da0619ef553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ba4d49-d7fa-43f4-b5c4-8da0619ef553.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -22529,7 +22529,7 @@
         },
         {
             "id": "8e11627c-1803-533a-8ef5-4c41f1787790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b392d1a2-6feb-47de-8f89-657f275c520d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b392d1a2-6feb-47de-8f89-657f275c520d.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -22572,7 +22572,7 @@
         },
         {
             "id": "71c436b3-8f11-50eb-9acb-1ffaa869e165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa261-9737-4228-9767-b9d36a2c3c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa261-9737-4228-9767-b9d36a2c3c30.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -22614,7 +22614,7 @@
         },
         {
             "id": "8d528e2a-fbe7-54f5-a74b-6d022a8ab663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9969b4-cb64-4275-b7fd-93565dadaaf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9969b4-cb64-4275-b7fd-93565dadaaf7.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -22656,7 +22656,7 @@
         },
         {
             "id": "52e3c730-5df8-522b-89fe-a824bb6b164c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e140a98a-ad97-40c9-a666-9d5055f7edd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e140a98a-ad97-40c9-a666-9d5055f7edd4.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -22698,7 +22698,7 @@
         },
         {
             "id": "8e04ca20-5f25-5dab-81e3-0ec2eb9b2ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47975755-d7a2-4c04-a493-efe422096d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47975755-d7a2-4c04-a493-efe422096d3d.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -22741,7 +22741,7 @@
         },
         {
             "id": "23342a95-59cb-5dcb-9f0d-609c541936b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6b5393-8c49-4736-a7fd-0b4a4a2f1676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6b5393-8c49-4736-a7fd-0b4a4a2f1676.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -22784,7 +22784,7 @@
         },
         {
             "id": "a00211bf-2903-580d-b5d1-b27393056899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf0a5a5-cb0b-4cfa-8c5b-f1bcd1004979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf0a5a5-cb0b-4cfa-8c5b-f1bcd1004979.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -22820,7 +22820,7 @@
         },
         {
             "id": "8721bab6-6dab-5d37-a6aa-4fdcfc642f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360668f0-c76c-4fb3-94ce-dfab9969f6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360668f0-c76c-4fb3-94ce-dfab9969f6d3.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "0: Roll a six-sided die.\n1 or 2 \u2014 +2, then create two 1/1 green Squirrel creature tokens. They gain haste until end of turn.\n3 \u2014 \u22121, then return a card with mana value 2 or less from your graveyard to your hand.\n4 or 5 \u2014 Comet, Stellar Pup deals damage equal to the number of loyalty counters on him to a creature or player, then \u22122.\n6 \u2014 +1, and you may activate Comet, Stellar Pup's loyalty ability two more times this turn.",
             "colours": [
@@ -22861,7 +22861,7 @@
         },
         {
             "id": "c44d9054-ebce-5661-8fbb-372ff5965315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b416fd-27cc-4d22-9d44-345b46b1cdcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b416fd-27cc-4d22-9d44-345b46b1cdcb.jpg?1",
             "name": "Space Beleren",
             "text": "Space sculptor (Space Beleren divides the battlefield into alpha, beta, and gamma sectors. If a creature isn't assigned to a sector, its controller assigns it to one. Opponents assign first.)\n+1: Creatures in each sector can be blocked this turn only by creatures in the same sector.\n\u22121: Put a +1/+1 counter on each creature in the sector of your choice.\n\u22125: Destroy all creatures in the sector of your choice.",
             "colours": [
@@ -22902,7 +22902,7 @@
         },
         {
             "id": "3373ff29-c605-5f94-8dcf-93f8acad1794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a4070-18e8-4f5e-bf64-a191ddf3210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a4070-18e8-4f5e-bf64-a191ddf3210e.jpg?1",
             "name": "Hallowed Fountain",
             "text": "",
             "colours": [],
@@ -22937,7 +22937,7 @@
         },
         {
             "id": "0608ab2f-66a6-55c0-9117-bd831ebf6f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3721bac-4e1c-438e-b0a2-a557dd530077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3721bac-4e1c-438e-b0a2-a557dd530077.jpg?1",
             "name": "Watery Grave",
             "text": "",
             "colours": [],
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "214279fa-3cdc-5742-add8-8ba08358a6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737d6df-a20d-46ac-a340-b119c7791f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737d6df-a20d-46ac-a340-b119c7791f1b.jpg?1",
             "name": "Blood Crypt",
             "text": "",
             "colours": [],
@@ -23007,7 +23007,7 @@
         },
         {
             "id": "c16ba014-104d-5541-8a0c-2c9877b7e1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982711bc-cdfa-467a-9675-0b719963045c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982711bc-cdfa-467a-9675-0b719963045c.jpg?1",
             "name": "Stomping Ground",
             "text": "",
             "colours": [],
@@ -23042,7 +23042,7 @@
         },
         {
             "id": "522bb6e5-f23f-556b-8e8f-d8b59b66ff27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a0d368-993a-473d-9da9-9ed50fc5670e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a0d368-993a-473d-9da9-9ed50fc5670e.jpg?1",
             "name": "Temple Garden",
             "text": "",
             "colours": [],
@@ -23077,7 +23077,7 @@
         },
         {
             "id": "7f8d9790-246a-5a1b-9dcd-fad03fd564ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1296cc-59aa-412d-9115-99fdc9ada754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1296cc-59aa-412d-9115-99fdc9ada754.jpg?1",
             "name": "Godless Shrine",
             "text": "",
             "colours": [],
@@ -23112,7 +23112,7 @@
         },
         {
             "id": "0d6d1e13-6ac4-5751-a5af-d7e5c489e262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be874189-b715-4e7c-85d7-e887328b9d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be874189-b715-4e7c-85d7-e887328b9d3f.jpg?1",
             "name": "Steam Vents",
             "text": "",
             "colours": [],
@@ -23147,7 +23147,7 @@
         },
         {
             "id": "48a2455b-b2bd-5622-911b-ae521a2dd03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315a5f0-d473-4566-9420-7f214b0c76e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315a5f0-d473-4566-9420-7f214b0c76e2.jpg?1",
             "name": "Overgrown Tomb",
             "text": "",
             "colours": [],
@@ -23182,7 +23182,7 @@
         },
         {
             "id": "53db2c0b-64a5-579e-9ec4-a25e22ab5f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b86558b-655f-482f-9d81-09efc917f8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b86558b-655f-482f-9d81-09efc917f8fc.jpg?1",
             "name": "Sacred Foundry",
             "text": "",
             "colours": [],
@@ -23217,7 +23217,7 @@
         },
         {
             "id": "2c6ebc86-ae39-56b8-9ac8-491a731a5e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ded082-0e6e-4aed-90cc-1bc4aea77dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ded082-0e6e-4aed-90cc-1bc4aea77dfa.jpg?1",
             "name": "Breeding Pool",
             "text": "",
             "colours": [],
@@ -23252,7 +23252,7 @@
         },
         {
             "id": "cd0e3312-700b-5b29-b240-c40eb58fbe5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb587e1-1243-4422-8ee3-198bd247b42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb587e1-1243-4422-8ee3-198bd247b42c.jpg?1",
             "name": "Water Gun Balloon Game",
             "text": "",
             "colours": [],
@@ -23279,7 +23279,7 @@
         },
         {
             "id": "6b70f468-ac73-5e14-a0ba-c5388b439dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16b4228-ed85-4d31-8760-88539b9a3cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16b4228-ed85-4d31-8760-88539b9a3cf9.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -23314,7 +23314,7 @@
         },
         {
             "id": "9af30052-def7-5631-9fee-735a6b6caf7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d001ca-285e-4033-9d97-0a1db3a8ec7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d001ca-285e-4033-9d97-0a1db3a8ec7b.jpg?1",
             "name": "Clown Robot",
             "text": "",
             "colours": [],
@@ -23347,7 +23347,7 @@
         },
         {
             "id": "837671c9-3c78-59ae-b945-ecac938d9140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd324b-8325-40f3-8a02-b84102cc63ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd324b-8325-40f3-8a02-b84102cc63ab.jpg?1",
             "name": "Clown Robot",
             "text": "",
             "colours": [],
@@ -23380,7 +23380,7 @@
         },
         {
             "id": "94942e99-5e62-58a6-862b-587f46220b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg?1",
             "name": "Contortionist // Contortionist",
             "text": "",
             "colours": [
@@ -23416,7 +23416,7 @@
         },
         {
             "id": "5467878f-d200-5dd7-b420-668c87ef6c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg?1",
             "name": "Contortionist // Contortionist",
             "text": "",
             "colours": [
@@ -23452,7 +23452,7 @@
         },
         {
             "id": "5776a0a9-6827-5e8b-8ea8-669d8c096a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c73960-1dd9-4f11-81b3-2ae4d3a5e283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c73960-1dd9-4f11-81b3-2ae4d3a5e283.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -23487,7 +23487,7 @@
         },
         {
             "id": "9f7c2c23-0bc1-5b68-9daf-de6355875618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d7d1d3-8989-4c54-9029-c1298c6ff8ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d7d1d3-8989-4c54-9029-c1298c6ff8ca.jpg?1",
             "name": "Zombie Employee",
             "text": "",
             "colours": [
@@ -23523,7 +23523,7 @@
         },
         {
             "id": "aeaa0582-78d4-5bbb-848d-472aa3bbb01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2c0f-7ed8-4d72-8f94-33ad615bf21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2c0f-7ed8-4d72-8f94-33ad615bf21d.jpg?1",
             "name": "Balloon",
             "text": "",
             "colours": [
@@ -23558,7 +23558,7 @@
         },
         {
             "id": "2f870f14-6517-5fcc-8656-66db0fedf25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4170e0-c899-481a-8076-cae9f3effc37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4170e0-c899-481a-8076-cae9f3effc37.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -23593,7 +23593,7 @@
         },
         {
             "id": "a51bf167-c9c0-5a66-af04-b9bc7cc36cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aef57de-7b99-47f3-af44-3c0bc546bbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aef57de-7b99-47f3-af44-3c0bc546bbac.jpg?1",
             "name": "Teddy Bear",
             "text": "",
             "colours": [],
@@ -23625,7 +23625,7 @@
         },
         {
             "id": "4fafd1b0-4281-54a5-b3c1-7811a0200625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01136e91-1ad3-4e01-8f7e-2718c3a9da27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01136e91-1ad3-4e01-8f7e-2718c3a9da27.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -23656,7 +23656,7 @@
         },
         {
             "id": "2066c068-0bfe-5cf9-bde5-b2726bd59211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95643f5-16f8-4ea6-8328-b3c227d87d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95643f5-16f8-4ea6-8328-b3c227d87d83.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -23687,7 +23687,7 @@
         },
         {
             "id": "7daecc09-9012-5a81-86c2-3f6a831f41a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef2b17-e7cd-49e3-a84d-cc4653b1ca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef2b17-e7cd-49e3-a84d-cc4653b1ca8b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -23718,7 +23718,7 @@
         },
         {
             "id": "0650b215-3a3d-5d23-97d4-6e2256fd6840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab1ec58-5299-4604-8feb-212a6c5e7ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab1ec58-5299-4604-8feb-212a6c5e7ffd.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -23749,7 +23749,7 @@
         },
         {
             "id": "a963dd53-b432-5cd6-9a12-d8d54734cad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52942a5c-0552-4a9b-9c0f-7a9ffd04d0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52942a5c-0552-4a9b-9c0f-7a9ffd04d0af.jpg?1",
             "name": "Ticket Bucket-Bot",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/UNH.json
+++ b/Assets/Resources/Sets/UNH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "554eefda-6c6f-5ad4-9007-cd102ce74c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0076e3-e538-4f4f-87fb-467851a8d8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0076e3-e538-4f4f-87fb-467851a8d8dd.jpg?1",
             "name": "Atinlay Igpay",
             "text": "Oubleday ikestray\nEneverwhay Atinlay Igpay's ontrollercay eaksspay ay onnay-Igpay-Atinlay ordway, acrificesay Atinlay Igpay.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "8b38766f-c20d-54cd-91a6-2ea3d79a2b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf3447a-ec7d-47d7-bf6b-e2bbe0ac58df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf3447a-ec7d-47d7-bf6b-e2bbe0ac58df.jpg?1",
             "name": "AWOL",
             "text": "Remove target attacking creature from the game. Then remove it from the removed-from-game zone and put it into the absolutely-removed-from-the-freaking-game-forever zone.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "2192d5e3-3f36-5abc-bf3c-4cf7d1f3782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c94a52-fc1e-4f5d-a95c-47e6d6c8bef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c94a52-fc1e-4f5d-a95c-47e6d6c8bef9.jpg?1",
             "name": "AWOL",
             "text": "",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "adb9e553-de2c-5a80-9960-72b8c147c5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9701ab2-acb5-431a-a442-8df33bcb75a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9701ab2-acb5-431a-a442-8df33bcb75a3.jpg?1",
             "name": "Bosom Buddy",
             "text": "Whenever you play a spell, you may gain \u00bd life for each word in that spell's name.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "85253fe3-1543-5bcf-b997-b151ebcc19df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e0273-133f-4326-91d4-a1281b388d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e0273-133f-4326-91d4-a1281b388d2c.jpg?1",
             "name": "Cardpecker",
             "text": "Flying\nGotcha Whenever an opponent touches the table with his or her hand, you may say \"Gotcha\" If you do, return Cardpecker from your graveyard to your hand.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "07f98b20-42d1-5aff-80bd-9fdab39e7991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42bbacc-b9ad-42fe-b726-e2dccf030bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42bbacc-b9ad-42fe-b726-e2dccf030bb8.jpg?1",
             "name": "Cardpecker",
             "text": "",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "1a24d642-1fd8-5a04-a91f-49f37e6341b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c3f0ea-d4b5-428c-abd2-93e09998d63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c3f0ea-d4b5-428c-abd2-93e09998d63c.jpg?1",
             "name": "Cheap Ass",
             "text": "Spells you play cost  less to play.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "3ec510aa-e378-5256-9eb2-081f70e2ab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbdb5ed-2d8a-4c95-b0fd-f19ff82e1302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbdb5ed-2d8a-4c95-b0fd-f19ff82e1302.jpg?1",
             "name": "Circle of Protection: Art",
             "text": "As Circle of Protection: Art comes into play, choose an artist.\n{1}{W}: The next time a source of your choice by the chosen artist would deal damage to you this turn, prevent that damage.\n{1}{W}: Return Circle of Protection: Art to its owner's hand.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "67bee778-91ce-5744-98b8-cacaa427144a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de4c754-dfff-4c0b-93c6-3725ad1efbb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de4c754-dfff-4c0b-93c6-3725ad1efbb0.jpg?1",
             "name": "Collector Protector",
             "text": "{W}, Give an opponent a nonland card you own from outside the game: Prevent the next 1 damage that would be dealt to you or Collector Protector this turn.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "d35fa7b5-5779-5c37-ac82-010fee4eabf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa9cd0-2152-4c01-a5d7-d257ae109d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa9cd0-2152-4c01-a5d7-d257ae109d0f.jpg?1",
             "name": "Drawn Together",
             "text": "As Drawn Together comes into play, choose an artist.\nCreatures by the chosen artist get +2/+2.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "6cc3cf14-b0f9-5291-94ef-0a6dc727f46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcef9e39-c9e9-401a-b389-962877b3d763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcef9e39-c9e9-401a-b389-962877b3d763.jpg?1",
             "name": "Emcee",
             "text": "Whenever another creature comes into play, you may stand up and say in a deep, booming voice \"Presenting . . . \" and that creature's name. If you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "1dc4b98e-0bbd-5458-a24a-af22437bfb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9109252-2630-4550-a815-98a6c3725591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9109252-2630-4550-a815-98a6c3725591.jpg?1",
             "name": "Emcee",
             "text": "",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "c98bf90b-e3b8-5a16-a797-73391ca6e4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3d2a7-3c62-4aaa-bfa4-5a97af6c276a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3d2a7-3c62-4aaa-bfa4-5a97af6c276a.jpg?1",
             "name": "Erase (Not the Urza's Legacy One)",
             "text": "If you control two or more white permanents that share an artist, you may play Erase (Not the Urza's Legacy One) without paying its mana cost.\nRemove target enchantment from the game.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "9fa2ce28-ac2d-5c19-9c51-544c74ef8249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d2f904-3d68-4192-aa8d-9521b9747fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d2f904-3d68-4192-aa8d-9521b9747fbd.jpg?1",
             "name": "Fascist Art Director",
             "text": "{W}{W}: Fascist Art Director gains protection from the artist of your choice until end of turn..",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "49b1a86c-d918-5cbb-99e6-aad5ec3c4115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8affab3-be32-4b9b-b4d1-8d2d7299580b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8affab3-be32-4b9b-b4d1-8d2d7299580b.jpg?1",
             "name": "First Come, First Served",
             "text": "The attacking or blocking creature with the lowest collector number has first strike. If two or more creatures are tied, they all have first strike.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "43b5cc22-b384-5df1-af20-2a93fd35b259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b884afa-705c-432c-9783-22df4dd658b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b884afa-705c-432c-9783-22df4dd658b2.jpg?1",
             "name": "Frankie Peanuts",
             "text": "At the beginning of your upkeep, you may ask target player a yes-or-no question. If you do, that player answers the question truthfully and abides by that answer if able until end of turn.",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "8d464e9a-7e15-5119-b1bd-3d26408ae177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a209e1-9171-4433-ad04-07cd849ad71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a209e1-9171-4433-ad04-07cd849ad71f.jpg?1",
             "name": "Head to Head",
             "text": "You and target opponent play Seven Questions about the top card of that player's library. (That player looks at the card, then you ask up to six yes-or-no questions about the card that he or she answers truthfully. You guess the card's name\u2014that's question seven\u2014and the player reveals the card.) If you win, prevent all damage that would be dealt this turn by a source of your choice.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "3564dd96-651d-5c4a-836a-80ba477392e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1a661c-7acd-44cb-ae18-35a1f1e860e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1a661c-7acd-44cb-ae18-35a1f1e860e9.jpg?1",
             "name": "Ladies' Knight",
             "text": "Flying\nSpells that players wearing at least one item of women's clothing play cost {1} less to play. (Women's clothing is designed to be worn exclusively by women.)",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "07c3fd84-835e-5423-91d9-cea624914bd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f17b85-a866-48e8-aae0-55330109550e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f17b85-a866-48e8-aae0-55330109550e.jpg?1",
             "name": "Little Girl",
             "text": "",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "ebd770e7-728d-58c3-a0de-910ed6f20d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f9c8f9-dbb4-408f-835a-4b6c6abfdc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f9c8f9-dbb4-408f-835a-4b6c6abfdc74.jpg?1",
             "name": "Look at Me, I'm R&D",
             "text": "As Look at Me, I'm R&D comes into play, choose a number and a second number one higher or one lower than that number.\nAll instances of the first chosen number on permanents, spells, and cards in any zone are the second chosen number.",
             "colours": [
@@ -685,7 +685,7 @@
         },
         {
             "id": "65b12a17-d12e-545b-8127-0742a69cb864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a45371-46b2-416c-a850-021fbf32ed51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a45371-46b2-416c-a850-021fbf32ed51.jpg?1",
             "name": "Man of Measure",
             "text": "As long as you're shorter than an opponent, Man of Measure has first strike and gets +0/+1.\nAs long as you're taller than an opponent, Man of Measure gets +1/+0.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "8f9c24a0-71ea-593d-ac6d-d59e5cd4a0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba47805c-c8f2-4bcd-bf14-b3fa950039b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba47805c-c8f2-4bcd-bf14-b3fa950039b6.jpg?1",
             "name": "Save Life",
             "text": "Choose one Target player gains 2\u00bd life; or prevent the next 2\u00bd damage that would be dealt to target creature this turn.\nGotcha Whenever an opponent says \"Save\" or \"Life,\" you may say \"Gotcha\" If you do, return Save Life from your graveyard to your hand.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "7a173e9b-6866-543d-b699-804a25cb6185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba002c-d955-46d1-ae40-3467c863f42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba002c-d955-46d1-ae40-3467c863f42b.jpg?1",
             "name": "Standing Army",
             "text": "As long as you're standing, Standing Army has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "c159a184-6f03-5d80-839e-6d28b77afc07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3790b-9fc9-4788-bebc-a978d39d09e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3790b-9fc9-4788-bebc-a978d39d09e9.jpg?1",
             "name": "Standing Army",
             "text": "",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "336e4e45-83e4-52f4-b2e4-6aecc5c48a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924127a5-a364-489a-804f-a4f4174064ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924127a5-a364-489a-804f-a4f4174064ae.jpg?1",
             "name": "Staying Power",
             "text": "As long as Staying Power is in play, \"until end of turn\" and \"this turn\" effects don't end.",
             "colours": [
@@ -856,7 +856,7 @@
         },
         {
             "id": "ad2111fc-ab40-51ce-914f-ebc2037f1785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e15af-194e-4456-8b5e-c66e8e1bbe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e15af-194e-4456-8b5e-c66e8e1bbe27.jpg?1",
             "name": "Wordmail",
             "text": "Enchanted creature gets +1/+1 for each word in its name.",
             "colours": [
@@ -890,7 +890,7 @@
         },
         {
             "id": "26ff1d87-2638-5eff-90d6-3a7f46c64104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa90ab6-2686-4462-8725-5d4370c05437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa90ab6-2686-4462-8725-5d4370c05437.jpg?1",
             "name": "_____",
             "text": "{1}: This card's name becomes the name of your choice. Play this ability anywhere, anytime.",
             "colours": [
@@ -924,7 +924,7 @@
         },
         {
             "id": "c007ca64-8d5c-5896-8979-757d511efdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f834c86-cd38-40bf-9aad-b4098895de86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f834c86-cd38-40bf-9aad-b4098895de86.jpg?1",
             "name": "Ambiguity",
             "text": "Whenever a player plays a spell that counters a spell that has been played or a player plays a spell that comes into play with counters, that player may counter the next spell played or put an additional counter on a permanent that has already been played, but not countered.",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "3be6dd71-e336-530b-97d0-09b4a7087993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3ba2a4-3784-4bb5-8a60-7bae80e97eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3ba2a4-3784-4bb5-8a60-7bae80e97eba.jpg?1",
             "name": "Artful Looter",
             "text": "{T}: Draw a card, then discard a card.\nWhenever a permanent comes into play that shares an artist with another permanent you control, untap Artful Looter.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "514bda78-8855-52e7-8458-e2bebef4f953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d07cd08-42db-4fff-bd63-c1da48966cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d07cd08-42db-4fff-bd63-c1da48966cba.jpg?1",
             "name": "Avatar of Me",
             "text": "Avatar of Me costs {1} more to play for each ten years you've been alive.\nAvatar of Me's power is equal to your height in feet and its toughness is equal to your American shoe size. Round to the nearest \u00bd.\nAvatar of Me's color is the color of your eyes.",
             "colours": [
@@ -1025,7 +1025,7 @@
         },
         {
             "id": "2bcc40fd-90bb-5c97-934a-dfb183b584aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdacb38-8f75-4d4f-bcb1-d2641f4d817f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdacb38-8f75-4d4f-bcb1-d2641f4d817f.jpg?1",
             "name": "Brushstroke Paintermage",
             "text": "{T}: Target permanent's artist becomes the artist of your choice until end of turn.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "4daeb65d-5db6-5569-b583-cf03d283a860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7262a7-f48c-411b-8a0e-c5bd8f646145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7262a7-f48c-411b-8a0e-c5bd8f646145.jpg?1",
             "name": "Bursting Beebles",
             "text": "Bursting Beebles is unblockable as long as defending player controls two or more nonland permanents that share an artist.",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "01f94d75-d4ff-579a-9bdf-1d4fa695a5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db678d7f-4d9a-450a-be92-b6aeaf06d120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db678d7f-4d9a-450a-be92-b6aeaf06d120.jpg?1",
             "name": "Carnivorous Death-Parrot",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Carnivorous Death-Parrot unless you say its flavor text.",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "a4f6b074-48d6-57eb-92a1-becb2fb7ab8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab857e73-ac20-4013-bc34-ed675de84c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab857e73-ac20-4013-bc34-ed675de84c7c.jpg?1",
             "name": "Cheatyface",
             "text": "You may sneak Cheatyface into play at any time without paying for it, but if an opponent catches you right away, that player may remove Cheatyface from the game.\nFlying",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "d3b0603d-8754-52e0-8073-9c8c19ae1573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c9c9f-a622-4bc3-b9be-38ed70b5c0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c9c9f-a622-4bc3-b9be-38ed70b5c0f1.jpg?1",
             "name": "Double Header",
             "text": "Flying\nWhen Double Header comes into play, you may return target permanent with a two-word name to its owner's hand.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "4b74400c-d115-5f39-b4ec-8c183fbb1800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409cb48a-572a-40df-ae1a-a43feab6bdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409cb48a-572a-40df-ae1a-a43feab6bdfd.jpg?1",
             "name": "Flaccify",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "efceb742-ec4b-5a32-8119-0741f0da3fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf8efc4-ac10-4195-b389-181732c12ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf8efc4-ac10-4195-b389-181732c12ada.jpg?1",
             "name": "Framed!",
             "text": "Tap or untap all permanents by the artist of your choice.",
             "colours": [
@@ -1260,7 +1260,7 @@
         },
         {
             "id": "804bba8a-8977-586d-bb02-d8c9d906a372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec1ebe-805d-41f5-a131-cc4113ffab44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec1ebe-805d-41f5-a131-cc4113ffab44.jpg?1",
             "name": "Greater Morphling",
             "text": "{2}: Greater Morphling gains your choice of banding, bushido 1, double strike, fear, flying, first strike, haste, landwalk of your choice, protection from a color of your choice, provoke, rampage 1, shadow, or trample until end of turn.\n{2}: Greater Morphling becomes the colors of your choice until end of turn.\n{2}: Greater Morphling's type becomes the creature type of your choice until end of turn.\n{2}: Greater Morphling's expansion symbol becomes the symbol of your choice until end of turn.\n{2}: Greater Morphling's artist becomes the artist of your choice until end of turn.\n{2}: Greater Morphling gets +2/-2 or -2/+2 until end of turn.\n{2}: Untap Greater Morphling.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "a4b54a66-5c16-5cba-9db6-6e5847c7e675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31ed653-86ca-4962-8030-c8cba979129b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31ed653-86ca-4962-8030-c8cba979129b.jpg?1",
             "name": "Greater Morphling",
             "text": "",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "f1d410f6-c040-5ed5-87a6-e059120c17e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff24f82-afd6-48be-ba99-2f9e8a3d0231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff24f82-afd6-48be-ba99-2f9e8a3d0231.jpg?1",
             "name": "Johnny, Combo Player",
             "text": "{4}: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "947fd259-f614-561f-b804-4edfb28fb9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a2f131-e0d1-4583-929f-c009aee8bc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a2f131-e0d1-4583-929f-c009aee8bc20.jpg?1",
             "name": "Loose Lips",
             "text": "As Loose Lips comes into play, choose a sentence with eight or fewer words.\nEnchanted creature has flying.\nWhenever enchanted creature deals damage to an opponent, you draw two cards unless that player says the chosen sentence.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "0e4187ea-d33e-5c02-b80e-d07b86aeab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651626f5-aca6-4653-aa27-36c919566cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651626f5-aca6-4653-aa27-36c919566cb0.jpg?1",
             "name": "Magical Hacker",
             "text": "{U}: Change the text of target spell or permanent by replacing all instances of + with -, and vice versa, until end of turn.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "fa9a2a88-26d8-5ef1-811d-7750b2cf141b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039b1f3-6bcd-4578-af5b-e13fb2036ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039b1f3-6bcd-4578-af5b-e13fb2036ef2.jpg?1",
             "name": "Mise",
             "text": "Name a nonland card, then reveal the top card of your library. If that card is the named card, draw three cards.",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "37d2f0bb-30b7-50d5-933f-9d2790f4e70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0697ef17-6aa5-4fe0-96ae-9aa0f4c92f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0697ef17-6aa5-4fe0-96ae-9aa0f4c92f21.jpg?1",
             "name": "Moniker Mage",
             "text": "{U}, Say your middle name: Moniker Mage can't be the target of spells or abilities this turn.\n{U}, Say an opponent's middle name: Moniker Mage gains flying until end of turn.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "0d66dcad-93dd-5ebf-9b31-0bf6c818b32e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9307a6-7eb1-4e20-afd4-8a723db89048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9307a6-7eb1-4e20-afd4-8a723db89048.jpg?1",
             "name": "Mouth to Mouth",
             "text": "You and target opponent have a breath-holding contest. If you win, you gain control of target creature that player controls.",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "7e7eed44-a71d-5793-aa27-2b2cec44e3e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c790e6-340f-42c2-af88-e458b7b9690c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c790e6-340f-42c2-af88-e458b7b9690c.jpg?1",
             "name": "Now I Know My ABC's",
             "text": "At the beginning of your upkeep, if you control permanents with names that include all twenty-six letters of the English alphabet, you win the game.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "7dc969b0-e98d-599a-84e4-9f362fdc0431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e31d8-8d4f-4335-9191-1369302632d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e31d8-8d4f-4335-9191-1369302632d5.jpg?1",
             "name": "Number Crunch",
             "text": "Return target permanent to its owner's hand.\nGotcha Whenever an opponent says a number, you may say \"Gotcha\" If you do, return Number Crunch from your graveyard to your hand.",
             "colours": [
@@ -1599,7 +1599,7 @@
         },
         {
             "id": "a6fde033-e523-5b53-949c-b65330d9a17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ec2c53-2958-46d0-8322-b673cf0b79d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ec2c53-2958-46d0-8322-b673cf0b79d4.jpg?1",
             "name": "Question Elemental?",
             "text": "Flying\nAre you aware that when you say something that isn't a question, the player who first points out this fact gains control of Question Elemental?",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "12b2dc5c-5225-54a1-a346-96f689f76ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e92e32-1b13-4f31-a2ce-b3d9308a5de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e92e32-1b13-4f31-a2ce-b3d9308a5de2.jpg?1",
             "name": "Question Elemental?",
             "text": "",
             "colours": [
@@ -1669,7 +1669,7 @@
         },
         {
             "id": "4c70c1a7-b2be-5b92-b042-cfc579789b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b8afa9-9e9d-4552-8709-4ba4af79ead3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b8afa9-9e9d-4552-8709-4ba4af79ead3.jpg?1",
             "name": "Richard Garfield, Ph.D.",
             "text": "You may play cards as though they were other Magic cards of your choice with the same mana cost. (Mana cost includes color.) You can't choose the same card twice.",
             "colours": [
@@ -1707,7 +1707,7 @@
         },
         {
             "id": "7341ef82-468e-56d5-bd7a-92e9fd2f3447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493f3c04-2e12-44b3-957e-50c7861c4667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493f3c04-2e12-44b3-957e-50c7861c4667.jpg?1",
             "name": "Richard Garfield, Ph.D.",
             "text": "",
             "colours": [
@@ -1745,7 +1745,7 @@
         },
         {
             "id": "1ee7e64c-2286-53a7-bada-882fb6625816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090e83c2-375d-4470-a559-c37e8e7cefca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090e83c2-375d-4470-a559-c37e8e7cefca.jpg?1",
             "name": "Smart Ass",
             "text": "Whenever Smart Ass attacks, name a card. Defending player may reveal his or her hand and show you that the named card isn't there. If that player doesn't, Smart Ass is unblockable this turn.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "84b26f71-9a6c-5dcb-9156-ad937a2c6f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d323f0-334f-49d1-b338-24c4b854a112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d323f0-334f-49d1-b338-24c4b854a112.jpg?1",
             "name": "Spell Counter",
             "text": "Counter target spell.\nGotcha Whenever an opponent says \"Spell\" or \"Counter,\" you may say \"Gotcha\" If you do, return Spell Counter from your graveyard to your hand.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "796d0cc7-0a15-586f-8991-70f127c91c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdca743d-f861-4aec-b9cb-b7490dd3425a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdca743d-f861-4aec-b9cb-b7490dd3425a.jpg?1",
             "name": "Topsy Turvy",
             "text": "The phases of each player's turn are reversed. (The phases are, in reverse order, end, postcombat main, combat, precombat main, and beginning.)\nIf there are more than two players in the game, the turn order is reversed.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "f6c59f6c-e339-5b96-bd21-5165c7af6996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0464a507-20e5-42d5-8aca-12504a869f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0464a507-20e5-42d5-8aca-12504a869f21.jpg?1",
             "name": "Aesthetic Consultation",
             "text": "Name an artist. Remove the top six cards of your library from the game, then reveal cards from the top of your library until you reveal a card by the named artist. Put that card in your hand, then remove all the other cards revealed this way from the game.",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "f23e7343-5497-561e-8ee7-d91028bfb4fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee7b1f-e300-411a-957d-5253300c36cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee7b1f-e300-411a-957d-5253300c36cf.jpg?1",
             "name": "Aesthetic Consultation",
             "text": "",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "8f8877be-d091-59e9-9a80-dd286dd8d249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b41832-f549-42e3-871e-e3a03372dbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b41832-f549-42e3-871e-e3a03372dbba.jpg?1",
             "name": "Bad Ass",
             "text": "{1}{B}, Growl: Regenerate Bad Ass.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "adfad74d-14de-57e1-acd3-eb1b28ab5703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee08949-7cd4-4099-a109-de041a201529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee08949-7cd4-4099-a109-de041a201529.jpg?1",
             "name": "Bad Ass",
             "text": "",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "ac49d5ac-a6f1-55c3-85b7-a50a28bc7439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53556e90-1da6-4721-8ab4-da98de52a1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53556e90-1da6-4721-8ab4-da98de52a1a5.jpg?1",
             "name": "Bloodletter",
             "text": "When the names of three or more nonland permanents begin with the same letter, sacrifice Bloodletter. If you do, it deals 2 damage to each creature and each player.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "c998c1bf-21a3-5e30-ba60-274b81eef7e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a5b25e-c5af-417e-8675-162ab18ac2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a5b25e-c5af-417e-8675-162ab18ac2b1.jpg?1",
             "name": "Booster Tutor",
             "text": "Open a sealed Magic booster pack, reveal the cards, and put one of those cards into your hand. (Remove that card from your deck before beginning a new game.)",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "0b0e286b-c781-51ed-9bc0-57d3fbd81192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5b9b30-4950-4c9c-9ce8-6d271bb7aa01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5b9b30-4950-4c9c-9ce8-6d271bb7aa01.jpg?1",
             "name": "Duh",
             "text": "Destroy target creature with reminder text. (Reminder text is any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -2080,7 +2080,7 @@
         },
         {
             "id": "145d3b9d-728a-5f62-a12c-7ae850a2163c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f85f32-5bc3-46c1-82a5-7a8d8f03effb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f85f32-5bc3-46c1-82a5-7a8d8f03effb.jpg?1",
             "name": "Enter the Dungeon",
             "text": "Players play a Magic subgame under the table starting at 5 life, using their libraries as their decks. After the subgame ends, the winner searches his or her library for two cards, puts those cards into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "0d069999-b557-5825-a7ce-d9ab49ace9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0276e9da-73fc-4d27-bbf1-726a37f5d5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0276e9da-73fc-4d27-bbf1-726a37f5d5a0.jpg?1",
             "name": "Eye to Eye",
             "text": "You and target creature's controller have a staring contest. If you win, destroy that creature.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "ba1a92b3-9469-5537-a0cb-b2dcc1e2bad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b458a3a2-b047-4edb-a621-87aee8be3a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b458a3a2-b047-4edb-a621-87aee8be3a3c.jpg?1",
             "name": "The Fallen Apart",
             "text": "The Fallen Apart comes into play with two arms and two legs.\nWhenever damage is dealt to The Fallen Apart, remove an arm or a leg from it.\nThe Fallen Apart can't attack if it has no legs and can't block if it has no arms.",
             "colours": [
@@ -2178,7 +2178,7 @@
         },
         {
             "id": "30cf8e74-542f-55cf-9ac3-93dbf4a98ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bc23dc-ae0e-499b-824a-7eb0e20a3282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bc23dc-ae0e-499b-824a-7eb0e20a3282.jpg?1",
             "name": "Farewell to Arms",
             "text": "As Farewell to Arms comes into play, choose a hand attached to an opponent's arm.\nWhen the chosen hand isn't behind its owner's back, sacrifice Farewell to Arms. If you do, that player discards his or her hand . . . of cards. (The lawyers wouldn't let us do it the other way.)",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "e58eb760-9dbf-5c40-8035-fc275d6632a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b61c3a-5e76-4529-9878-603e49c82743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b61c3a-5e76-4529-9878-603e49c82743.jpg?1",
             "name": "Farewell to Arms",
             "text": "",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "bb8ccd04-58fa-59cb-a9cc-0dcfcabb3e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033e627-9c4f-4b36-adfc-1afe97174c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033e627-9c4f-4b36-adfc-1afe97174c98.jpg?1",
             "name": "Infernal Spawn of Infernal Spawn of Evil",
             "text": "Flying, first strike, trample\nIf you say \"I'm coming, too\" as you search your library, you may pay {1}{B} and reveal Infernal Spawn of Infernal Spawn of Evil from your library to have it deal 2 damage to a player of your choice. Do this no more than once each turn.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "19fcfece-84d4-557b-af79-882a839ed42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd5a66-101d-4f88-b1ba-e2368203d408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd5a66-101d-4f88-b1ba-e2368203d408.jpg?1",
             "name": "Kill! Destroy!",
             "text": "Destroy target nonblack creature.\nGotcha Whenever an opponent says \"Kill\" or \"Destroy,\" you may say \"Gotcha\" If you do, return Kill Destroy from your graveyard to your hand.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "1ee1a3ba-3d5b-5d1d-90fd-a9fb38cc7c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6c3e15-ecae-4719-9b00-eb088223632b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6c3e15-ecae-4719-9b00-eb088223632b.jpg?1",
             "name": "Mother of Goons",
             "text": "Whenever a creature an opponent controls is put into a graveyard from play, sacrifice Mother of Goons unless you insult that creature.",
             "colours": [
@@ -2346,7 +2346,7 @@
         },
         {
             "id": "c6d1fec2-4c34-5649-9c9a-44c7b18f109f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead51a23-db13-4424-9191-dc992c510921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead51a23-db13-4424-9191-dc992c510921.jpg?1",
             "name": "Necro-Impotence",
             "text": "Skip your untap step.\nAt the beginning of your upkeep, you may pay X life. If you do, untap X permanents.\nPay \u00bd life: Remove the top card of your library from the game face down. Put that card into your hand at end of turn.",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "d3bf7199-c41b-5734-9e6e-da97cb765a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acfbc21-ffd7-4253-9f79-a1a3217f243a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acfbc21-ffd7-4253-9f79-a1a3217f243a.jpg?1",
             "name": "Persecute Artist",
             "text": "Choose an artist other than Rebecca Guay. Target player reveals his or her hand and discards all nonland cards by the chosen artist.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "496e4bba-7a8b-5cbe-850e-000ece9457e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340903b7-992c-43c2-9ee5-a1d76819fccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340903b7-992c-43c2-9ee5-a1d76819fccf.jpg?1",
             "name": "Phyrexian Librarian",
             "text": "Flying, trample\nAt the beginning of your upkeep, remove the top card of your library from the game face up and balance it on your body.\nWhen a balanced card falls or touches another balanced card, sacrifice Phyrexian Librarian.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "9ab8c558-1d79-5cf8-8af4-2834a67b1d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24f8edd-0998-4a59-b5b1-9e494626b166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24f8edd-0998-4a59-b5b1-9e494626b166.jpg?1",
             "name": "Stop That",
             "text": "Target player discards a card.\nGotcha Whenever an opponent audibly flicks the cards in his or her hand, you may say \"Gotcha\" If you do, return Stop That from your graveyard to your hand.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "1d13662c-0644-5a9f-a627-201787f14b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef1259-c415-46f5-be9f-dfd6cd76d2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef1259-c415-46f5-be9f-dfd6cd76d2c3.jpg?1",
             "name": "Tainted Monkey",
             "text": "{T}: Choose a word. Target player puts the top card of his or her library into his or her graveyard. If that card has the chosen word in its text box, that player loses 3 life.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "32f6b2ba-fb0f-5756-acf0-d2b9d70b4f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333be977-050e-4885-b631-70fd043ebeca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333be977-050e-4885-b631-70fd043ebeca.jpg?1",
             "name": "Vile Bile",
             "text": "Whenever a player's skin or fingernail touches Vile Bile, that player loses 2 life.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "7bf84120-1695-5d1d-b2f2-f8b46d964b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1d16-4781-4f65-bbe8-79fad472396c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1d16-4781-4f65-bbe8-79fad472396c.jpg?1",
             "name": "Wet Willie of the Damned",
             "text": "Wet Willie of the Damned deals 2\u00bd damage to target creature or player and you gain 2\u00bd life.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "0c2ae7ad-2b55-57fa-93e2-3ee03522aec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62d1ce8-9c41-41f8-9f96-d8b6177b85a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62d1ce8-9c41-41f8-9f96-d8b6177b85a4.jpg?1",
             "name": "When Fluffy Bunnies Attack",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of times the letter of your choice appears in that creature's name.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "c2b35326-de65-5e10-8401-aa65df7ae9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21960405-d7a4-4b10-9fde-3cb0d2456f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21960405-d7a4-4b10-9fde-3cb0d2456f07.jpg?1",
             "name": "When Fluffy Bunnies Attack",
             "text": "",
             "colours": [
@@ -2643,7 +2643,7 @@
         },
         {
             "id": "7d5f49fe-d272-512e-aaeb-a5c4a19e791b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a5e4c9-8452-4fdc-a5f0-5fd168e18050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a5e4c9-8452-4fdc-a5f0-5fd168e18050.jpg?1",
             "name": "Working Stiff",
             "text": "As Working Stiff comes into play, straighten your arms.\nWhen you bend an elbow, sacrifice Working Stiff.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "1ec478d7-5c64-5b7f-a8d0-d449d8146ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963fb55a-7cf6-4984-844f-afbcdb4db551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963fb55a-7cf6-4984-844f-afbcdb4db551.jpg?1",
             "name": "Zombie Fanboy",
             "text": "As Zombie Fanboy comes into play, choose an artist.\nWhenever a permanent by the chosen artist is put into a graveyard, put two +1/+1 counters on Zombie Fanboy.",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "f6dd9fe8-41cc-586a-bc71-da987c247f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead203-b976-46d7-81c7-86ada091a4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead203-b976-46d7-81c7-86ada091a4ec.jpg?1",
             "name": "Zzzyxas's Abyss",
             "text": "At the beginning of your upkeep, destroy all nonland permanents with the first name alphabetically among nonland permanents in play.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "cc3d0c4f-0d31-5e4a-9dcf-cd6a0e0faaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13248b-5abb-4246-b639-1a8a6681a157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13248b-5abb-4246-b639-1a8a6681a157.jpg?1",
             "name": "Assquatch",
             "text": "Each other Donkey gets +1\u00bd/+1\u00bd.\nWhenever another Donkey comes into play, untap target creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "f1857a68-aec8-5a33-9d2f-969151456e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca23782-80d3-4656-afba-f8440c813253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca23782-80d3-4656-afba-f8440c813253.jpg?1",
             "name": "Blast from the Past",
             "text": "Madness {R}, cycling {1}{R}, kicker {2}{R}, flashback {3}{R}, buyback {4}{R}\nBlast from the Past deals 2 damage to target creature or player.\nIf the kicker cost was paid, put a 1/1 red Goblin creature token into play.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "9954df08-0479-5921-ac9d-dbe08360924c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa30bf92-5281-4b74-8d2a-dc7b0467cb0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa30bf92-5281-4b74-8d2a-dc7b0467cb0a.jpg?1",
             "name": "Blast from the Past",
             "text": "",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "f193238a-07a8-53b6-8383-e30e95353891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg?1",
             "name": "Curse of the Fire Penguin // Curse of the Fire Penguin Creature",
             "text": "Curse of the Fire Penquin consumes and confuses enchanted creature.\n-----\nCreature Penguin\nTrample\nWhen this creature is put into a graveyard from play, return Curse of the Fire Penguin from your graveyard to play.\n6/5",
             "colours": [
@@ -2878,7 +2878,7 @@
         },
         {
             "id": "4b0c2060-5ce5-563b-8b1f-50eb87da82fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg?1",
             "name": "Curse of the Fire Penguin // Curse of the Fire Penguin Creature",
             "text": "",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "8586b7eb-8e8c-5fd6-a4d5-56c7f539e11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de905517-983d-4996-a680-3a5cf91bfe11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de905517-983d-4996-a680-3a5cf91bfe11.jpg?1",
             "name": "Deal Damage",
             "text": "Deal Damage deals 4 damage to target creature or player.\nGotcha Whenever an opponent says \"Deal\" or \"Damage,\" you may say \"Gotcha\" If you do, return Deal Damage from your graveyard to your hand.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "c51658d2-0e04-5f90-88b8-42f9fce34081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd769b2-8823-4c1e-b92f-c1bccc0b6026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd769b2-8823-4c1e-b92f-c1bccc0b6026.jpg?1",
             "name": "Dumb Ass",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, target opponent chooses whether Dumb Ass attacks this turn.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "8d957851-68b0-5e8b-b9bd-05fc922b3c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c93900-1af7-4c6b-a844-055bb7e27ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c93900-1af7-4c6b-a844-055bb7e27ddb.jpg?1",
             "name": "Face to Face",
             "text": "You and target opponent play a best two-out-of-three Rock, Paper, Scissors match. If you win, Face to Face deals 5 damage to that opponent.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "554bb8ac-7ba6-5d2e-95e3-7b983968da5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08bd24-5710-4548-8966-9c5e81744680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08bd24-5710-4548-8966-9c5e81744680.jpg?1",
             "name": "Frazzled Editor",
             "text": "Protection from wordy (Something is wordy if it has four or more lines of text in its text box.)",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "0be4d642-c2c9-588b-9097-74a71799ca78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae110a-d76f-4433-bb1b-ccb311656af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae110a-d76f-4433-bb1b-ccb311656af5.jpg?1",
             "name": "Frazzled Editor",
             "text": "",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "983fb8de-44e1-549b-a064-2bffefee4e2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b3f29a-b3a3-4dad-94ea-28999286bccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b3f29a-b3a3-4dad-94ea-28999286bccc.jpg?1",
             "name": "Goblin Mime",
             "text": "When you speak, sacrifice Goblin Mime.",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "13942218-34d0-5aaa-87e1-56a99cfe9f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca4db3-9ef0-4d0b-a03b-2e8437a72ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca4db3-9ef0-4d0b-a03b-2e8437a72ba7.jpg?1",
             "name": "Goblin Mime",
             "text": "",
             "colours": [
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "f99158b2-bb24-54c8-b7f8-09fed4b2cafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219d9bf5-2145-4805-8128-eda990c97739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219d9bf5-2145-4805-8128-eda990c97739.jpg?1",
             "name": "Goblin Secret Agent",
             "text": "First strike\nAt the beginning of your upkeep, reveal a card from your hand at random.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "d07efcc9-5d11-5ccf-926e-1d30a1374acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91848051-4c72-44be-b779-53dbb528e265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91848051-4c72-44be-b779-53dbb528e265.jpg?1",
             "name": "Goblin S.W.A.T. Team",
             "text": "Say \"Goblin S.W.A.T. Team\": Put a +1/+1 counter on Goblin S.W.A.T. Team unless an opponent swats the table within five seconds. Play this ability only once each turn.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "4b8c33aa-f928-5cea-8f75-5f0295917940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2c83a1-b06a-4a3c-b025-f58b04caec3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2c83a1-b06a-4a3c-b025-f58b04caec3e.jpg?1",
             "name": "Mana Flair",
             "text": "Add {R} to your mana pool for each nonland permanent by the artist of your choice.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "b0fa8f64-aca1-56d8-9d04-f6798c006545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729238ee-b3ea-4c1d-852c-2dc9a2c58356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729238ee-b3ea-4c1d-852c-2dc9a2c58356.jpg?1",
             "name": "Mons's Goblin Waiters",
             "text": "Sacrifice a creature or land: Add {HR} to your mana pool.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "a2d66ef7-36e7-5eb5-b29f-5f3290910ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae733007-3089-43fc-a14d-7c1919554923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae733007-3089-43fc-a14d-7c1919554923.jpg?1",
             "name": "Mons's Goblin Waiters",
             "text": "",
             "colours": [
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "70214e8f-a289-5b0e-bbbd-f24ddfb4406d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864cddb-7b2e-434c-8cb6-4e44b802add6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864cddb-7b2e-434c-8cb6-4e44b802add6.jpg?1",
             "name": "Orcish Paratroopers",
             "text": "When Orcish Paratroopers comes into play, flip it from a height of at least one foot. Sacrifice Orcish Paratroopers unless it lands face up after turning over completely.",
             "colours": [
@@ -3364,7 +3364,7 @@
         },
         {
             "id": "17611604-e27e-5e8d-b978-fcb43b61e4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b90711-1bf8-446c-9431-df693b8d8d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b90711-1bf8-446c-9431-df693b8d8d79.jpg?1",
             "name": "Punctuate",
             "text": "Punctuate deals damage to target creature equal to half the number of punctuation marks in that creature's text box. (The punctuation marks are  ? , ; : - ( ) / \" ' & .)",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "9c7408c2-114b-59a2-8849-ee1b984c60a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af443b8c-203f-46f0-9233-60f962e5baa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af443b8c-203f-46f0-9233-60f962e5baa6.jpg?1",
             "name": "Pygmy Giant",
             "text": "{R}, {T}, Sacrifice a creature: Pygmy Giant deals X damage to target creature, where X is a number in the sacrificed creature's text box.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "04c7d285-fb9b-516b-8f06-f7a7affa1090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f65a9d6-12d8-472c-b9d4-cc2460aa58ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f65a9d6-12d8-472c-b9d4-cc2460aa58ae.jpg?1",
             "name": "Red-Hot Hottie",
             "text": "Whenever Red-Hot Hottie deals damage to a creature, put a third-degree-burn counter on that creature. It has \"At the end of each turn, sacrifice this creature unless you scream \u2018\nAaah' at the top of your lungs.\"",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "8ac89a6b-fc06-51e1-b3b1-93b11ef08148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e405361f-70df-459d-9385-2210fbe7e115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e405361f-70df-459d-9385-2210fbe7e115.jpg?1",
             "name": "Rocket-Powered Turbo Slug",
             "text": "Super haste (This may attack the turn before you play it. (You may put this card into play from your hand, tapped and attacking, during your declare attackers step. If you do, you lose the game at the end of your next turn unless you pay this card's mana cost during that turn.))",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "1da7da62-ea34-5984-9772-da780474bfc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbebbb-7ea4-4140-933f-186cad08697d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbebbb-7ea4-4140-933f-186cad08697d.jpg?1",
             "name": "Saut\u00e9",
             "text": "Saut\u00e9 deals 3\u00bd damage to target creature or player.",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "dac26ae4-c0a0-5177-8a4a-9ee3a09cd1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0379c99c-94b1-4c48-b62d-7accb594ef1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0379c99c-94b1-4c48-b62d-7accb594ef1a.jpg?1",
             "name": "Six-y Beast",
             "text": "As Six-y Beast comes into play, you secretly put six or fewer +1/+1 counters on it, then an opponent guesses the number of counters. If that player guesses right, sacrifice Six-y Beast.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "6d579da2-4247-5a7a-806e-013cf129a5ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec8666-9417-49df-9261-38bfb550088d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec8666-9417-49df-9261-38bfb550088d.jpg?1",
             "name": "Touch and Go",
             "text": "Destroy target land.\nGotcha Whenever an opponent touches his or her face, you may say \"Gotcha\" If you do, return Touch and Go from your graveyard to your hand.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "eac799a5-4307-586c-bc17-8815759967dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed3d84-b68f-4eec-95f4-3e3366cecdfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed3d84-b68f-4eec-95f4-3e3366cecdfc.jpg?1",
             "name": "Touch and Go",
             "text": "",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "e930979d-cf3b-56e9-bc5d-668141c6f960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e731ba8c-e909-4053-84ae-0793a7319540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e731ba8c-e909-4053-84ae-0793a7319540.jpg?1",
             "name": "Yet Another Aether Vortex",
             "text": "All creatures have haste.\nPlayers play with the top card of their libraries revealed.\nNoninstant, nonsorcery cards on top of a library are in play under their owner's control in addition to being in that library.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "eaa1c01b-5fd5-5e4c-bc60-22fa3981280b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4dabd2-2d1c-44e6-80a7-67e0af9bf468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4dabd2-2d1c-44e6-80a7-67e0af9bf468.jpg?1",
             "name": "B-I-N-G-O",
             "text": "Trample\nWhenever a player plays a spell, put a chip counter on its converted mana cost.\nB-I-N-G-O gets +9/+9 for each set of three numbers in a row with chip counters on them.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "60a40d90-f608-5af5-ac1a-d362bb69bf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac8bde-7a3e-4d14-91f4-f4325c93f6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac8bde-7a3e-4d14-91f4-f4325c93f6a8.jpg?1",
             "name": "Creature Guy",
             "text": "Gotcha Whenever an opponent says \"Creature\" or \"Guy,\" you may say \"Gotcha\" If you do, return Creature Guy from your graveyard to your hand.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "63dc8842-2995-5d9d-b964-bc88eb31ebf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6301ea0-cf66-49ba-87c5-dde566ce5d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6301ea0-cf66-49ba-87c5-dde566ce5d01.jpg?1",
             "name": "Elvish House Party",
             "text": "Elvish House Party's power and toughness are each equal to the current hour, using the twelve-hour system.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "8dde27d8-3f18-5ced-aa86-0320eae48bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc72766-06a0-4874-92c4-9debfaa97e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc72766-06a0-4874-92c4-9debfaa97e05.jpg?1",
             "name": "Fat Ass",
             "text": "Fat Ass gets +2/+2 and has trample as long as you're eating. (Food is in your mouth and you're chewing, licking, sucking, or swallowing it.)",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "7e662f20-688b-5c04-9cde-151e827336f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2241203c-1219-4e75-9973-7e1a44885341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2241203c-1219-4e75-9973-7e1a44885341.jpg?1",
             "name": "Form of the Squirrel",
             "text": "As Form of the Squirrel comes into play, put a 1/1 green Squirrel creature token into play. You lose the game when it leaves play.\nCreatures can't attack you.\nYou can't be the target of spells or abilities.\nYou can't play spells.",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "554b089b-81f6-5b36-bf15-09ef880ab54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d42015-6cab-485f-9266-428db0b2b773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d42015-6cab-485f-9266-428db0b2b773.jpg?1",
             "name": "Fraction Jackson",
             "text": "{G}, {T}: Return target card with a \u00bd on it from your graveyard to your hand.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "4fa66c26-64f5-5edb-bcea-4f52acc9e25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7626ff-814f-4d9f-9595-ac7fa5334d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7626ff-814f-4d9f-9595-ac7fa5334d4b.jpg?1",
             "name": "Gluetius Maximus",
             "text": "As Gluetius Maximus comes into play, an opponent chooses one of your fingers. (Thumbs are fingers, too.)\nWhen the chosen finger isn't touching Gluetius Maximus, sacrifice Gluetius Maximus.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "9e39ec1d-b46e-5710-966a-ede9c21b3f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949269fa-5d90-4ed5-b148-ee06de227e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949269fa-5d90-4ed5-b148-ee06de227e99.jpg?1",
             "name": "Granny's Payback",
             "text": "You gain life equal to your age.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "5dea3392-4565-5205-a819-5f4a89535cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92ab617-2b06-4030-a15b-5a6db3e5b1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92ab617-2b06-4030-a15b-5a6db3e5b1fb.jpg?1",
             "name": "Graphic Violence",
             "text": "All creatures by the artist of your choice get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "b5c0b902-aee5-5c93-9094-5d173f6ce40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8100f78-0dd1-4750-8a8a-d4fda30d8432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8100f78-0dd1-4750-8a8a-d4fda30d8432.jpg?1",
             "name": "Keeper of the Sacred Word",
             "text": "As Keeper of the Sacred Word comes into play, choose a word.\nWhenever an opponent says the chosen word, Keeper of the Sacred Word gets +3/+3 until end of turn.",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "815303cb-a016-5e46-ab2e-8d0c65f19a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c5b9d-ee0a-4d36-a099-00483882fb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c5b9d-ee0a-4d36-a099-00483882fb24.jpg?1",
             "name": "Keeper of the Sacred Word",
             "text": "",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "d80e6345-3a46-5e60-b455-218b0376cf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a457d88-268c-4be0-bfd7-e57dd1ac364c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a457d88-268c-4be0-bfd7-e57dd1ac364c.jpg?1",
             "name": "Land Aid '04",
             "text": "Search your library for a basic land card, put that card into play tapped, then shuffle your library. If you sang a song the whole time you were searching and shuffling, you may untap that land.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "aec9aca7-ae93-5d6a-9070-4f6829af218c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e8440d-fce1-4a02-8029-f20a7617ae4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e8440d-fce1-4a02-8029-f20a7617ae4f.jpg?1",
             "name": "Laughing Hyena",
             "text": "Gotcha Whenever an opponent laughs, you may say \"Gotcha\" If you do, return Laughing Hyena from your graveyard to your hand.",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "f3567523-c62d-5903-aee8-7bdfcfc5d993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0712ff-c689-42fa-9384-f36d1f75c1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0712ff-c689-42fa-9384-f36d1f75c1dd.jpg?1",
             "name": "Laughing Hyena",
             "text": "",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "c19500d4-f826-560f-bc0e-54736000bbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7c17f-b5fc-4c58-945b-4972bce4614e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7c17f-b5fc-4c58-945b-4972bce4614e.jpg?1",
             "name": "Monkey Monkey Monkey",
             "text": "As Monkey Monkey Monkey comes into play, choose a letter.\nMonkey Monkey Monkey gets +1/+1 for each nonland permanent whose name begins with the chosen letter.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "03b10384-1d5a-5d9f-8894-71b2e90b668b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08588205-11d8-4f0c-9ed0-e9b5ed66de4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08588205-11d8-4f0c-9ed0-e9b5ed66de4b.jpg?1",
             "name": "Monkey Monkey Monkey",
             "text": "",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "28f686f8-2d71-50f4-97af-291e80bff8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8f650-9e47-4649-a8e2-8c6ff4e72d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8f650-9e47-4649-a8e2-8c6ff4e72d9e.jpg?1",
             "name": "Name Dropping",
             "text": "Gotcha Whenever an opponent says a word that's in the name of a card in your graveyard, you may say \"Gotcha\" If you do, return that card to your hand.",
             "colours": [
@@ -4241,7 +4241,7 @@
         },
         {
             "id": "9d36443d-3ee5-598d-9b12-8cce6eafe6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ce51c4-16ea-48e8-a976-402b15450b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ce51c4-16ea-48e8-a976-402b15450b88.jpg?1",
             "name": "Old Fogey",
             "text": "Phasing, cumulative upkeep {1}, echo, fading 3, bands with other Dinosaurs, protection from Homarids, snow-covered plainswalk, flanking, rampage 2",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "17ad0580-e193-5bf1-9df1-1db70c3532c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac29717c-c586-4adb-94a3-f41096cce110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac29717c-c586-4adb-94a3-f41096cce110.jpg?1",
             "name": "Old Fogey",
             "text": "",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "5c7be4e4-0955-5318-92eb-aa7e912e1739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f3f52-cb9b-4b2a-bb02-6175897ae76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f3f52-cb9b-4b2a-bb02-6175897ae76e.jpg?1",
             "name": "Our Market Research Shows That Players Like Really Long Card Names So We Made this Card to Have the Absolute Longest Card Name Ever Elemental",
             "text": "Art rampage 2 (Whenever this becomes blocked by a creature, it gets +2/+2 for each creature in the blocker's art beyond the first.)",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "28d66e76-f2e5-5d35-9b50-856cb1f91f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7c0b-8104-47c9-9fb2-6cb50259fae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7c0b-8104-47c9-9fb2-6cb50259fae2.jpg?1",
             "name": "Remodel",
             "text": "If you control two or more green permanents that share an artist, you may play Remodel without paying its mana cost.\nRemove target artifact from the game.",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "7b490f42-d2ac-54d8-bdce-d303860b728d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa1912-cced-491a-867d-7f21acaf1e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa1912-cced-491a-867d-7f21acaf1e3b.jpg?1",
             "name": "Shoe Tree",
             "text": "Shoe Tree comes into play with up to two shoe counters on it. Use your shoes as counters.\nShoe Tree gets +1/+1 for each shoe counter on it.",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "17d43be4-2c93-566d-8682-a48cf07dfb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c08e26f-70c6-481e-b68b-3fad145a07e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c08e26f-70c6-481e-b68b-3fad145a07e7.jpg?1",
             "name": "Shoe Tree",
             "text": "",
             "colours": [
@@ -4447,7 +4447,7 @@
         },
         {
             "id": "d251d501-54af-5760-8354-2ec1bbe7a58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8512b3c-9a44-4c15-8217-0f13898846cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8512b3c-9a44-4c15-8217-0f13898846cd.jpg?1",
             "name": "Side to Side",
             "text": "You and target opponent arm-wrestle. If you win, put a 3/3 green Ape creature token into play.",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "a68f090a-346a-5fbd-b6bd-e92b5cbe6c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a2e16-f729-44ec-969f-d7011c623907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a2e16-f729-44ec-969f-d7011c623907.jpg?1",
             "name": "S.N.O.T.",
             "text": "As S.N.O.T. comes into play, you may stick it onto another creature named S.N.O.T. in play. If you do, all those creatures form a single creature.\nS.N.O.T.'s power and toughness are equal to the square of the number of S.N.O.T.s stuck together. (One is a 1/1, two are a 4/4, three are a 9/9, and four are a 16/16.)",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "9363f07d-c6ea-5b72-994b-1a17886e73fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1768bb4-1626-47c8-a96f-374895c816e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1768bb4-1626-47c8-a96f-374895c816e3.jpg?1",
             "name": "Stone-Cold Basilisk",
             "text": "Whenever Stone-Cold Basilisk blocks or becomes blocked by a creature with fewer letters in its name, destroy that creature at end of combat. (Punctuation and spaces aren't letters.)\nWhenever an opponent reads Stone-Cold Basilisk, that player is turned to stone until end of turn. Stoned players can't attack, block, or play spells or abilities.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "bfabaf8a-9752-56d1-aa8e-06fed5992f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb07d9b-947d-475f-b4fd-2590b95a7f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb07d9b-947d-475f-b4fd-2590b95a7f91.jpg?1",
             "name": "Supersize",
             "text": "Target creature gets +3\u00bd/+3\u00bd until end of turn.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "5d4c2950-a099-5f15-8707-a697920fd127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9480a100-19a0-4964-b5d0-27ff9987497e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9480a100-19a0-4964-b5d0-27ff9987497e.jpg?1",
             "name": "Symbol Status",
             "text": "Put a 1/1 colorless Expansion-Symbol creature token into play for each different expansion symbol among permanents you control.",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "0aaddebf-a1e4-5479-8bd3-d7bf45775719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6d8520-0a7c-489c-8ae9-aed07c7df6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6d8520-0a7c-489c-8ae9-aed07c7df6df.jpg?1",
             "name": "Uktabi Kong",
             "text": "Trample\nWhen Uktabi Kong comes into play, destroy all artifacts.\nTap two untapped Apes you control: Put a 1/1 green Ape creature token into play.",
             "colours": [
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "6869d699-5f2b-5a41-886c-4e74b52ca763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f2c8f5-8e11-4639-b7de-00e4a2cbabee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f2c8f5-8e11-4639-b7de-00e4a2cbabee.jpg?1",
             "name": "\"Ach! Hans, Run!\"",
             "text": "At the beginning of your upkeep, you may say \"Ach Hans, run It's the . . .\" and name a creature card. If you do, search your library for the named card, put it into play, then shuffle your library. That creature has haste. Remove it from the game at end of turn.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "78983557-74fa-5d93-aeef-a2fc779fc555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf33d6-e00d-4d60-9c7f-c56c3b1f84c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf33d6-e00d-4d60-9c7f-c56c3b1f84c0.jpg?1",
             "name": "Ass Whuppin'",
             "text": "Destroy target silver-bordered permanent in any game you can see from your seat.",
             "colours": [
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "ad3415fb-aef6-572e-b411-241cccffba10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c86f1b5-d95d-4f44-8078-4572101997b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c86f1b5-d95d-4f44-8078-4572101997b4.jpg?1",
             "name": "Meddling Kids",
             "text": "As Meddling Kids comes into play, choose a word with four or more letters.\nNonland cards with the chosen word in their text box can't be played.",
             "colours": [
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "bad12d87-1010-5d75-a69a-5e73a2b80923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09274a32-c764-4239-bab0-675ddcb57c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09274a32-c764-4239-bab0-675ddcb57c13.jpg?1",
             "name": "Rare-B-Gone",
             "text": "Each player sacrifices all rare permanents, then reveals his or her hand and discards all rare cards.",
             "colours": [
@@ -4784,7 +4784,7 @@
         },
         {
             "id": "0e0cfbbd-51d0-5490-b74e-a84a7d219233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "Who\no\nXo\nW\nInstant\nTarget player gains X life.\n-----\nWhat\no2o\nR\nInstant\nDestroy target artifact.\n-----\nWhen\no2o\nU\nInstant\nCounter target creature spell.\n-----\nWhere\no3o\nB\nInstant\nDestroy target land.\n-----\nWhy\no1o\nG\nInstant\nDestroy target enchantment.",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "57e1525f-e346-599d-915d-c4c754688859",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "56b368a2-e1db-5aa6-ad4c-c034b9b52294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4892,7 +4892,7 @@
         },
         {
             "id": "26e6e262-4217-50f6-941a-029ec09776c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "64cffe98-fd90-5f01-a600-5a5c82d61508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "64c50f5b-49a7-55ef-85e7-791182d08d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fe1662-7927-4909-8d25-6924e6fc27eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fe1662-7927-4909-8d25-6924e6fc27eb.jpg?1",
             "name": "Gleemax",
             "text": "You choose all targets for all spells and abilities.",
             "colours": [],
@@ -4995,7 +4995,7 @@
         },
         {
             "id": "ab7ef8c2-d943-5ccd-bd40-cf7233e747bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2b9db1-c091-4ccc-b7b6-061de7132a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2b9db1-c091-4ccc-b7b6-061de7132a18.jpg?1",
             "name": "Gleemax",
             "text": "",
             "colours": [],
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "6bbcf1ee-80c1-5450-9fd3-66b3796516be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ed7580-1b92-446b-b074-99517116fb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ed7580-1b92-446b-b074-99517116fb6a.jpg?1",
             "name": "Letter Bomb",
             "text": "When Letter Bomb comes into play, sign it and shuffle it into target player's library. That player reveals each card he or she draws until Letter Bomb is drawn. When that player draws Letter Bomb, it deals 19\u00bd damage to him or her.",
             "colours": [],
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "f288f1bb-8219-539e-9f5d-5b78fa7bdaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cec1cd-c122-4508-a302-517f174a2b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cec1cd-c122-4508-a302-517f174a2b3c.jpg?1",
             "name": "Letter Bomb",
             "text": "",
             "colours": [],
@@ -5084,7 +5084,7 @@
         },
         {
             "id": "72e71ac7-a2cb-51b1-a269-33db181c7458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd58d98d-9597-4d5a-be06-6747a5ba8406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd58d98d-9597-4d5a-be06-6747a5ba8406.jpg?1",
             "name": "Mana Screw",
             "text": "{1}: Flip a coin. If you win the flip, add {2} to your mana pool. Play this ability only any time you could play an instant.",
             "colours": [],
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "d6dbcfbf-49bb-5127-b034-b35aa3366d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebad46e-a069-49d4-9bb3-1a07434bc61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebad46e-a069-49d4-9bb3-1a07434bc61d.jpg?1",
             "name": "Mana Screw",
             "text": "",
             "colours": [],
@@ -5142,7 +5142,7 @@
         },
         {
             "id": "efd0c48a-9b80-57a5-9cfb-d8b1d83a9124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8241a53-8b88-474e-a46c-44b3d1f3b0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8241a53-8b88-474e-a46c-44b3d1f3b0df.jpg?1",
             "name": "Mox Lotus",
             "text": "{T}: Add {\u221e} to your mana pool.\n{100}: Add one mana of any color to your mana pool.\nYou don't lose life due to mana burn.",
             "colours": [],
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "eefeb967-3d6e-5f94-b0d4-fb64131390f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7f1b-ef9d-4fb4-93e4-d03702375d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7f1b-ef9d-4fb4-93e4-d03702375d0c.jpg?1",
             "name": "Mox Lotus",
             "text": "",
             "colours": [],
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "c4cb342f-6313-5f5c-9b02-33a2d04225a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56ccbd2-c17d-4625-bc11-181d36a84936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56ccbd2-c17d-4625-bc11-181d36a84936.jpg?1",
             "name": "My First Tome",
             "text": "{1}, {T}: Say the flavor text on a card in your hand. Target opponent guesses that card's name. You may reveal that card. If you do and your opponent guessed wrong, draw a card.",
             "colours": [],
@@ -5229,7 +5229,7 @@
         },
         {
             "id": "159f3c3d-4d3a-577b-880b-e6605ba5c466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334316ea-f0a0-4616-9aed-4bed3b9cef60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334316ea-f0a0-4616-9aed-4bed3b9cef60.jpg?1",
             "name": "My First Tome",
             "text": "",
             "colours": [],
@@ -5258,7 +5258,7 @@
         },
         {
             "id": "f2c70238-fbee-5ae3-8e76-03c0ae7c6358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5695a3e9-e30f-4569-ae0f-a395230f653c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5695a3e9-e30f-4569-ae0f-a395230f653c.jpg?1",
             "name": "Pointy Finger of Doom",
             "text": "{3}, {T}: Spin Pointy Finger of Doom in the middle of the table so that it rotates completely at least once, then destroy the closest permanent the finger points to.",
             "colours": [],
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "65f95291-f457-5f81-bd1a-48037f58b1a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe7ff52-aa0e-4a97-8a36-b67518a020d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe7ff52-aa0e-4a97-8a36-b67518a020d7.jpg?1",
             "name": "Rod of Spanking",
             "text": "{2}, {T}: Rod of Spanking deals 1 damage to target player. Then untap Rod of Spanking unless that player says \"Thank you, sir. May I have another?\"",
             "colours": [],
@@ -5314,7 +5314,7 @@
         },
         {
             "id": "e73e32af-f050-5548-ad84-09aa916723a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b5f1eb-172b-40e5-92dd-ff1f5889001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b5f1eb-172b-40e5-92dd-ff1f5889001f.jpg?1",
             "name": "Time Machine",
             "text": "{T}: Remove Time Machine and target nontoken creature you own from the game. Return both cards to play at the beginning of your upkeep on your turn X of the next game you play with the same opponent, where X is the removed creature's converted mana cost.",
             "colours": [],
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "2bab65ff-98f7-59e3-b3d5-52c8c135e4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583f4691-d3cb-41f0-b718-75d022d81ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583f4691-d3cb-41f0-b718-75d022d81ef1.jpg?1",
             "name": "Time Machine",
             "text": "",
             "colours": [],
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "97c25505-4bb9-53eb-b503-28243ad5a68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046cd853-0cde-4d44-9111-962d6670710b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046cd853-0cde-4d44-9111-962d6670710b.jpg?1",
             "name": "Togglodyte",
             "text": "Togglodyte comes into play turned on.\nWhenever a player plays a spell, toggle Togglodyte's ON/OFF switch.\nAs long as Togglodyte is turned off, it can't attack or block, and all damage it would deal is prevented.",
             "colours": [],
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "ef0afc95-9a48-5844-af20-84f575d55bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f000911c-5a4a-4498-bb69-6f6e13f45447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f000911c-5a4a-4498-bb69-6f6e13f45447.jpg?1",
             "name": "Toy Boat",
             "text": "Cumulative upkeep\u2014\nSay \"Toy Boat\" quickly. (At the beginning of your upkeep, put an age counter on Toy Boat, then sacrifice it unless you say \"Toy Boat\" once for each age counter on it\u2014without pausing between or fumbling it.)",
             "colours": [],
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "a329e1d6-0928-5448-b141-0a7829db59b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17722a-3509-45ac-ae5c-c230482c69e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17722a-3509-45ac-ae5c-c230482c69e4.jpg?1",
             "name": "Urza's Hot Tub",
             "text": "{2}, Discard a card: Search your library for a card that shares a complete word in its name with the discarded card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "f0c4fd7e-2bbd-5f11-ac15-15df682746c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ffee-28ec-4aa4-8433-a009273a4ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ffee-28ec-4aa4-8433-a009273a4ada.jpg?1",
             "name": "Water Gun Balloon Game",
             "text": "As Water Gun Balloon Game comes into play, each player puts a pop counter on a 0.\nWhenever a player plays a spell, move that player's pop counter up 1.\nWhenever a player's pop counter hits 5, that player puts a 5/5 pink Giant Teddy Bear creature token into play and resets all pop counters to 0.",
             "colours": [],
@@ -5490,7 +5490,7 @@
         },
         {
             "id": "f607394f-c428-5f9e-93a3-d02a9c164860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1be145-cf42-4a9a-8d0a-d7174d96834e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1be145-cf42-4a9a-8d0a-d7174d96834e.jpg?1",
             "name": "World-Bottling Kit",
             "text": "{5}, Sacrifice World-Bottling Kit: Choose a Magic set. Remove from the game all permanents with that set's expansion symbol except for basic lands.",
             "colours": [],
@@ -5518,7 +5518,7 @@
         },
         {
             "id": "edd0b105-e224-5d40-a242-9a8cad9b347b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fe2e7-bd1b-4c11-a098-6c8abfbdf06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fe2e7-bd1b-4c11-a098-6c8abfbdf06e.jpg?1",
             "name": "City of Ass",
             "text": "City of Ass comes into play tapped.\n{T}: Add one and one-half mana of any one color to your mana pool.",
             "colours": [],
@@ -5546,7 +5546,7 @@
         },
         {
             "id": "6f93a382-f512-5ff5-97a5-303eda1d253f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdc6a9-0a44-43ef-b065-02ef5d6110dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdc6a9-0a44-43ef-b065-02ef5d6110dc.jpg?1",
             "name": "R&D's Secret Lair",
             "text": "Play cards as written. Ignore all errata.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "f97e44ef-a6bb-54cb-89ea-06250cabe74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dba1c-a702-43c0-8fca-e47bbad4a00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dba1c-a702-43c0-8fca-e47bbad4a00f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "09d44003-974a-577a-8f9b-b3a67645340e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4eaecf-dd4c-45ab-9b50-2abe987d35d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4eaecf-dd4c-45ab-9b50-2abe987d35d4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "a7604ebc-44fd-5d44-9046-14ae16bea8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8365ab45-6d78-47ad-a6ed-282069b0fabc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8365ab45-6d78-47ad-a6ed-282069b0fabc.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "a5ab2362-b495-50ec-a45c-5b221fe8ca0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42232ea6-e31d-46a6-9f94-b2ad2416d79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42232ea6-e31d-46a6-9f94-b2ad2416d79b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "afc52162-e37d-5645-ac1b-06b814d61c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e71532-3f79-4fec-974f-b0e85c7fe701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e71532-3f79-4fec-974f-b0e85c7fe701.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "bcab8547-3756-5c5f-a121-06a02620660e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45af7f55-9a69-43dd-969f-65411711b13e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45af7f55-9a69-43dd-969f-65411711b13e.jpg?1",
             "name": "Super Secret Tech",
             "text": "All premium spells cost {1} less to play.\nAll premium creatures get +1/+1.",
             "colours": [],

--- a/Assets/Resources/Sets/USG.json
+++ b/Assets/Resources/Sets/USG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "0877107a-de72-5913-94be-921cf3d06e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d1839-7180-4b4c-8ddb-7df24573f740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d1839-7180-4b4c-8ddb-7df24573f740.jpg?1",
             "name": "Absolute Grace",
             "text": "All creatures gain protection from black.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "a3e5dfab-d380-5f5c-9187-21e48478f4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d1f05b-f165-47c7-8a78-3b60ee3298ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d1f05b-f165-47c7-8a78-3b60ee3298ca.jpg?1",
             "name": "Absolute Law",
             "text": "All creatures gain protection from red.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "6554e6ed-2935-508f-9ef8-819f9504ee7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bf221-a1bf-41ab-9b7e-e5a64c385642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bf221-a1bf-41ab-9b7e-e5a64c385642.jpg?1",
             "name": "Angelic Chorus",
             "text": "Whenever a creature comes into play under your control, gain life equal to that creature's toughness.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "78e7ede1-4bca-54a0-b7a3-d4d92e71fe8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a4378-8b14-484c-b285-09cc4c4e1b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a4378-8b14-484c-b285-09cc4c4e1b3c.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -131,7 +131,7 @@
         },
         {
             "id": "15225852-6e33-50d2-9680-076be2fddc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d454961-1ab3-442b-935d-68c25b56aea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d454961-1ab3-442b-935d-68c25b56aea0.jpg?1",
             "name": "Brilliant Halo",
             "text": "Enchanted creature gets +1/+2.\nWhen Brilliant Halo is put into a graveyard from play, return Brilliant Halo to owner's hand.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "c2c7753d-377f-5118-9fec-e2769650c9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294d21dc-5c76-4449-936f-9b7541d37c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294d21dc-5c76-4449-936f-9b7541d37c86.jpg?1",
             "name": "Catastrophe",
             "text": "Destroy all lands or all creatures. Creatures destroyed this way cannot regenerate this turn.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "319db9c4-68ce-57af-a423-8b86f67475a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cdb977-7d5b-4050-bb01-181f6b363de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cdb977-7d5b-4050-bb01-181f6b363de7.jpg?1",
             "name": "Clear",
             "text": "Destroy target enchantment.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -226,7 +226,7 @@
         },
         {
             "id": "3f93aa82-6782-56d4-b0e9-eafdf47e564f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7923b-eb1c-49ce-8250-a1ea6efbb56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7923b-eb1c-49ce-8250-a1ea6efbb56e.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature in play.",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "0b318ff3-6f2d-5546-b267-41324a30f1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd76db0-1a67-4965-81a5-1d8d86b63971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd76db0-1a67-4965-81a5-1d8d86b63971.jpg?1",
             "name": "Defensive Formation",
             "text": "Instead of the attacking player, you choose how creatures attacking you deal combat damage.",
             "colours": [
@@ -288,7 +288,7 @@
         },
         {
             "id": "fe4c8619-363e-53d2-8192-7ba15250ddd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa36d2-0a60-40a5-a182-a63e1e65b2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa36d2-0a60-40a5-a182-a63e1e65b2bd.jpg?1",
             "name": "Disciple of Grace",
             "text": "Protection from black\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -322,7 +322,7 @@
         },
         {
             "id": "4938ae25-c4ae-5fd7-9dbc-f161d28b8273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5c8701-a294-4474-9747-129f972cfb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5c8701-a294-4474-9747-129f972cfb18.jpg?1",
             "name": "Disciple of Law",
             "text": "Protection from red\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "7818642c-3c98-58ce-8f6a-891ad9e6ef31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da67d77-1cbd-4f0e-a109-87fb4c84bcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da67d77-1cbd-4f0e-a109-87fb4c84bcca.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "6b084b10-1b73-507d-9780-4605918958d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ee95c-3ce8-4b8c-a1a7-1caa5b8a3cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ee95c-3ce8-4b8c-a1a7-1caa5b8a3cc9.jpg?1",
             "name": "Elite Archers",
             "text": "oc\nT: Elite Archers deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "2def9013-b377-5074-b998-de5b0902c2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51ff6a-ba1b-4015-8d0b-df1a1bb5a0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51ff6a-ba1b-4015-8d0b-df1a1bb5a0c1.jpg?1",
             "name": "Faith Healer",
             "text": "Sacrifice an enchantment: Gain life equal to the sacrificed enchantment's total casting cost.",
             "colours": [
@@ -456,7 +456,7 @@
         },
         {
             "id": "c1a4fea5-67e6-5618-b3fe-c2798584f192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f867c5-0727-4408-b479-b81518daa0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f867c5-0727-4408-b479-b81518daa0ec.jpg?1",
             "name": "Glorious Anthem",
             "text": "All creatures you control get +1/+1.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "968c5f2a-6ece-5edd-86d3-a73b10c6d6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89146f6a-583f-4ed1-8b43-75e9a55892c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89146f6a-583f-4ed1-8b43-75e9a55892c6.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent up to 3 damage to a creature or player.",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "92f0964a-56b3-57be-b64f-eb18be6fa708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a2b882-d616-495e-99f6-196031235f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a2b882-d616-495e-99f6-196031235f93.jpg?1",
             "name": "Herald of Serra",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nAttacking does not cause Herald of Serra to tap.",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "9c685cbb-7c94-58d1-b7d5-3413a3970561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01383c7f-685f-4e77-a143-8418fe1fe436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01383c7f-685f-4e77-a143-8418fe1fe436.jpg?1",
             "name": "Humble",
             "text": "Target creature loses all abilities and is a 0/1 creature until end of turn.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "cfd49ee3-f257-5f32-af6f-a2b7b1217487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a5c67-f76a-4021-959e-3e084a06b80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a5c67-f76a-4021-959e-3e084a06b80f.jpg?1",
             "name": "Intrepid Hero",
             "text": "oc\nT: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "ab3035d2-bd8e-5c61-8f11-9d3e069d1a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285a867b-f82e-49cb-a59c-31a25129baf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285a867b-f82e-49cb-a59c-31a25129baf9.jpg?1",
             "name": "Monk Idealist",
             "text": "When Monk Idealist comes into play, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "f81d6df2-afe7-50de-ac49-397aca7ea3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7fe9f1-f3c0-43e4-aa30-d0bdab4ae94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7fe9f1-f3c0-43e4-aa30-d0bdab4ae94d.jpg?1",
             "name": "Monk Realist",
             "text": "When Monk Realist comes into play, destroy target enchantment.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "8203a88f-d8dd-5819-a336-1b3d1027c3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839b4c10-f68f-4321-82ee-5ec257f63866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839b4c10-f68f-4321-82ee-5ec257f63866.jpg?1",
             "name": "Opal Acrolith",
             "text": "Whenever one of your opponents successfully casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 creature that counts as a Guardian.\no0: Opal Acrolith becomes an enchantment.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "900a8aef-53c3-5d5a-b95a-f7d3323f6a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75fca33-fa06-4385-866c-5d463ae6aaf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75fca33-fa06-4385-866c-5d463ae6aaf6.jpg?1",
             "name": "Opal Archangel",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Archangel is an enchantment, Opal Archangel becomes a 5/5 creature with flying that counts as an Angel. Attacking does not cause Opal Archangel to tap.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "1dab404f-c664-533d-a026-b498cc163fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8a2e24-c959-40a2-883d-c0114589cfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8a2e24-c959-40a2-883d-c0114589cfe7.jpg?1",
             "name": "Opal Caryatid",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Caryatid is an enchantment, Opal Caryatid becomes a 2/2 creature that counts as a Soldier.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "a0777214-14a6-5185-bc73-6dfdc54cb65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a67943-8f07-445b-a84c-893879dae7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a67943-8f07-445b-a84c-893879dae7ca.jpg?1",
             "name": "Opal Gargoyle",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Gargoyle is an enchantment, Opal Gargoyle becomes a 2/2 creature with flying that counts as a Gargoyle.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "437bde50-69ca-57ee-9b0c-6b85e5cb1ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379f1f01-88c6-4cc2-9049-078aa6980582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379f1f01-88c6-4cc2-9049-078aa6980582.jpg?1",
             "name": "Opal Titan",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Titan is an enchantment, Opal Titan becomes a 4/4 creature with protection from each of that spell's colors and that counts as a Giant.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "a56a316f-6d97-5185-9f24-260453e70ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81638f-a74c-47fc-825a-ae778c524f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81638f-a74c-47fc-825a-ae778c524f66.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature cannot attack or block.",
             "colours": [
@@ -874,7 +874,7 @@
         },
         {
             "id": "a5ec6088-49cf-5e38-92bf-87e8eb2176dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0447f9e1-792b-4200-9ef3-7cd95c326b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0447f9e1-792b-4200-9ef3-7cd95c326b88.jpg?1",
             "name": "Pariah",
             "text": "Redirect to enchanted creature all damage dealt to you.",
             "colours": [
@@ -907,7 +907,7 @@
         },
         {
             "id": "29e29f67-a7c1-56cc-aa42-90db57b1b147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7a2719-7910-4601-be88-7b3c249199d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7a2719-7910-4601-be88-7b3c249199d3.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy target creature. That creature's owner gains 4 life.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "fa3130bb-eadb-57da-a3cb-b9687f610545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62a5287-25ec-4e13-9e39-1c87a4052c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62a5287-25ec-4e13-9e39-1c87a4052c4d.jpg?1",
             "name": "Pegasus Charger",
             "text": "Flying, first strike",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "1ae2d48c-2c34-5004-8116-d90de1c1539b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cacdff-aa83-4644-b2f0-ce8c89dddfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cacdff-aa83-4644-b2f0-ce8c89dddfbf.jpg?1",
             "name": "Planar Birth",
             "text": "Put all basic lands from all graveyards into play under their owners' control, tapped.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "cd9ed8e9-3778-5e5c-907e-db5f41dbc215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849adb29-61ad-4307-98b9-61e33aec6500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849adb29-61ad-4307-98b9-61e33aec6500.jpg?1",
             "name": "Presence of the Master",
             "text": "Whenever a player plays an enchantment spell, counter it.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "85adb37b-23a3-5f06-aa67-9c8fffc083cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a7756d-df25-4969-96ad-b006df09788b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a7756d-df25-4969-96ad-b006df09788b.jpg?1",
             "name": "Redeem",
             "text": "Prevent all damage to one or two creatures. (Treat further damage normally.)",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "9ee9e793-286f-51ae-9adf-1ba3358a5a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556d334e-3ac9-45b0-98d2-aff49ada0f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556d334e-3ac9-45b0-98d2-aff49ada0f75.jpg?1",
             "name": "Remembrance",
             "text": "Whenever a nontoken creature you control is put into a graveyard, you may search your library for a copy of that creature card. If you do, reveal the card, put it into your hand, and shuffle your library afterward.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "4f774317-47ed-569b-a3a9-8ba1efef2048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18cce33-92be-4189-9f99-cb47bd617fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18cce33-92be-4189-9f99-cb47bd617fd2.jpg?1",
             "name": "Rune of Protection: Artifacts",
             "text": "oo\nW Prevent all damage to you from an artifact source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "7373b297-b5e8-50c1-8559-84671f299d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f69050b-c54d-43f2-8348-2801c365dc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f69050b-c54d-43f2-8348-2801c365dc4c.jpg?1",
             "name": "Rune of Protection: Black",
             "text": "oo\nW Prevent all damage to you from a black source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "65224cc1-e06e-58cb-ace8-4448b2cc3135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4ed3a-1851-49b1-baac-fdc8c00b6b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4ed3a-1851-49b1-baac-fdc8c00b6b71.jpg?1",
             "name": "Rune of Protection: Blue",
             "text": "oo\nW Prevent all damage to you from a blue source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "b79fe89c-87fc-5f6c-8c28-0fee8f69f389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905712b2-3177-4935-bca1-6990439b8d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905712b2-3177-4935-bca1-6990439b8d78.jpg?1",
             "name": "Rune of Protection: Green",
             "text": "oo\nW Prevent all damage to you from a green source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "30613811-490f-514a-97fd-8c05d03c9200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e874700-8002-41e7-8861-b4ce29ba6d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e874700-8002-41e7-8861-b4ce29ba6d9e.jpg?1",
             "name": "Rune of Protection: Lands",
             "text": "oo\nW Prevent all damage to you from a land source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "311b1aa7-6712-500e-95ca-96fcddd112c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2916023b-cf67-443f-9ac7-f03313f9d3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2916023b-cf67-443f-9ac7-f03313f9d3b7.jpg?1",
             "name": "Rune of Protection: Red",
             "text": "oo\nW Prevent all damage to you from a red source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "ff1e78ba-14b9-5d48-a65f-e6f2c025cec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6408417e-aca3-43f3-9eea-fed5a402d8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6408417e-aca3-43f3-9eea-fed5a402d8ab.jpg?1",
             "name": "Rune of Protection: White",
             "text": "oo\nW Prevent all damage to you from a white source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "a1c23714-77ea-52d9-81d8-7cc9e522da60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a64b98-9002-48fe-a3e5-4449050c87e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a64b98-9002-48fe-a3e5-4449050c87e1.jpg?1",
             "name": "Sanctum Custodian",
             "text": "oc\nT: Prevent up to 2 damage to a creature or player.",
             "colours": [
@@ -1346,7 +1346,7 @@
         },
         {
             "id": "4e4458f4-d290-5e30-8ba0-3012879d3bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09137f-0f4c-4389-a915-0ce02c833d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09137f-0f4c-4389-a915-0ce02c833d94.jpg?1",
             "name": "Sanctum Guardian",
             "text": "Sacrifice Sanctum Guardian: Prevent all damage to a creature or player from one source. (Treat further damage from that source normally.)",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "4c9e92b1-4680-5cb2-9cc9-0a4129a934f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de20845-06b7-4542-8d61-4b97309669f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de20845-06b7-4542-8d61-4b97309669f9.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -1414,7 +1414,7 @@
         },
         {
             "id": "c50e5fb2-38a5-5793-bb0a-aafc94aa07b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b0976-78e8-4fbe-8607-2e55d8761d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b0976-78e8-4fbe-8607-2e55d8761d3e.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar has power and toughness each equal to your life total.\nWhen Serra Avatar is put into a graveyard, shuffle Serra Avatar into owner's library.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "d4f555c4-ce8e-5d06-b4f5-fe3a378156d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b311542-599f-4d2f-a871-18d5b0b7bbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b311542-599f-4d2f-a871-18d5b0b7bbe5.jpg?1",
             "name": "Serra Zealot",
             "text": "First strike",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "486e58b0-eacd-5d62-be2c-b7e1edeb5063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145c3ebd-7a67-4606-8427-f3b91ab26b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145c3ebd-7a67-4606-8427-f3b91ab26b84.jpg?1",
             "name": "Serra's Embrace",
             "text": "Enchanted creature gets +2/+2 and gains flying. Attacking does not cause enchanted creature to tap.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "a3429529-36b4-5181-81b8-9d80bce987d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8205a-608e-4274-a32c-802a7ce52d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8205a-608e-4274-a32c-802a7ce52d9c.jpg?1",
             "name": "Serra's Hymn",
             "text": "During your upkeep, you may put a verse counter on Serra's Hymn.\nSacrifice Serra's Hymn: Prevent up to X damage total to any number of creatures and/or players, where X is the number of verse counters on Serra's Hymn.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "0bc4a894-51a7-5004-bc6e-0112ab8fe8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84be3ef-a820-41e3-b66a-09303dad32dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84be3ef-a820-41e3-b66a-09303dad32dd.jpg?1",
             "name": "Serra's Liturgy",
             "text": "During your upkeep, you may put a verse counter on Serra's Liturgy.\no\nW, Sacrifice Serra's Liturgy: Destroy up to X target artifacts and/or enchantments, where X is the number of verse counters on Serra's Liturgy.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "560c0cb7-bb46-5c05-8ac2-bf29adbcbd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa7158a-5c00-4969-a116-c40cefdf4591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa7158a-5c00-4969-a116-c40cefdf4591.jpg?1",
             "name": "Shimmering Barrier",
             "text": "(Walls cannot attack.)\nFirst strike\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "e1268655-8af1-560a-89f6-ca0baa465813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e90087-3738-40df-929b-d2f880264b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e90087-3738-40df-929b-d2f880264b55.jpg?1",
             "name": "Silent Attendant",
             "text": "oc\nT: Gain 1 life.",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "6c303455-0866-5a94-8a22-6321b91c5fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d306f-3f4e-4c21-9461-caa3daf4fc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d306f-3f4e-4c21-9461-caa3daf4fc50.jpg?1",
             "name": "Songstitcher",
             "text": "o1oo\nW Target attacking creature with flying deals no combat damage this turn.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "9264da26-6a04-5967-8da8-df26321f4d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6ef073-1c83-47a4-b19d-86fb8bed5db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6ef073-1c83-47a4-b19d-86fb8bed5db9.jpg?1",
             "name": "Soul Sculptor",
             "text": "o1o\nW, oc\nT: Target creature becomes an enchantment and loses all abilities until a player successfully casts a creature spell.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "cdff691c-dfbc-5dbb-93cc-17b165375a99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8eb3b-3ebf-426c-8dc8-138ec9b7c671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8eb3b-3ebf-426c-8dc8-138ec9b7c671.jpg?1",
             "name": "Voice of Grace",
             "text": "Flying, protection from black",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "77b674b3-7ced-53be-acec-da313902212a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daec52a4-02da-4bff-aff4-5247baed1326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daec52a4-02da-4bff-aff4-5247baed1326.jpg?1",
             "name": "Voice of Law",
             "text": "Flying, protection from red",
             "colours": [
@@ -1776,7 +1776,7 @@
         },
         {
             "id": "808a887b-a30c-546e-9b8b-d96ed08af690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867a33ee-0340-413a-8243-9d6bc2d944e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867a33ee-0340-413a-8243-9d6bc2d944e2.jpg?1",
             "name": "Waylay",
             "text": "Put three Knight tokens into play. Treat these tokens as 2/2 white creatures. Remove them from the game at end of turn.",
             "colours": [
@@ -1807,7 +1807,7 @@
         },
         {
             "id": "f3434b7c-8235-53bd-b14b-4bc90b781bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908781a0-1ba4-4027-bd9d-13f9faf08686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908781a0-1ba4-4027-bd9d-13f9faf08686.jpg?1",
             "name": "Worship",
             "text": "Damage that would reduce your life total to less than 1 instead reduces it to 1 if you control a creature.",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "e0bc810a-7ef4-5eb0-b0a9-426234abfc30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca58c8e-9f40-4ed8-a3ed-a01fe67c600d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca58c8e-9f40-4ed8-a3ed-a01fe67c600d.jpg?1",
             "name": "Academy Researchers",
             "text": "When Academy Researchers comes into play, you may choose an enchant creature card in your hand and put that enchantment into play on Academy Researchers.",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "3501d513-9a59-5c4a-b08a-b0883a802e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c73ff-be92-41ca-93a7-76f9823adb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c73ff-be92-41ca-93a7-76f9823adb38.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "82e15fcf-83ac-5759-9d59-4442112e3eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a88e8-aab0-488a-a0b8-fa3feedbf278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a88e8-aab0-488a-a0b8-fa3feedbf278.jpg?1",
             "name": "Arcane Laboratory",
             "text": "Each player cannot play more than one spell each turn.",
             "colours": [
@@ -1934,7 +1934,7 @@
         },
         {
             "id": "e19c4b0e-5b73-52cc-b934-05fcf25b9160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6723528-8b2c-4beb-a465-800300faf158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6723528-8b2c-4beb-a465-800300faf158.jpg?1",
             "name": "Attunement",
             "text": "Return Attunement to owner's hand: Draw three cards, then choose and discard four cards.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "4345caef-856a-528e-a987-a74949e911dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab4cd7e-b56f-4408-a0e9-c07e040cc38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab4cd7e-b56f-4408-a0e9-c07e040cc38f.jpg?1",
             "name": "Back to Basics",
             "text": "Nonbasic lands do not untap during their controllers' untap phases.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "08eb29cb-8772-5049-a2ac-a91cd1038c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec79e35f-9e78-462d-8b71-4f044e2eff90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec79e35f-9e78-462d-8b71-4f044e2eff90.jpg?1",
             "name": "Barrin, Master Wizard",
             "text": "Barrin, Master Wizard counts as a Wizard.\no2, Sacrifice a permanent: Return target creature to owner's hand.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "7b88f854-6899-555b-aa38-d55b488d810f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bdef28-0e27-4c8d-a04c-5413519dcb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bdef28-0e27-4c8d-a04c-5413519dcb4e.jpg?1",
             "name": "Catalog",
             "text": "Draw two cards, then choose and discard a card.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "6601ed6d-0f66-506d-a093-d98c750f857e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54251c-5a2e-48e4-9790-a64dcc44eb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54251c-5a2e-48e4-9790-a64dcc44eb8e.jpg?1",
             "name": "Cloak of Mists",
             "text": "Enchanted creature is unblockable.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "69edc2e8-2e4d-53c3-9fcc-21006e0f0ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cba6d4a-58d0-42d6-b49b-65c72b86007f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cba6d4a-58d0-42d6-b49b-65c72b86007f.jpg?1",
             "name": "Confiscate",
             "text": "You control enchanted permanent.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "0d601243-32e1-5b91-8b07-2df5d8397aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837d82a9-aef8-4079-a485-05ada1b66322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837d82a9-aef8-4079-a485-05ada1b66322.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "751892b9-4b94-548c-8273-2d75678e1f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ee9af3-d61c-4964-88a6-6e8ad6a6a29a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ee9af3-d61c-4964-88a6-6e8ad6a6a29a.jpg?1",
             "name": "Curfew",
             "text": "Each player chooses a creature he or she controls and returns it to owner's hand.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "e5447f28-af35-59b9-9144-75af131c619e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee43681d-e0f7-422b-a363-0d630f68d363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee43681d-e0f7-422b-a363-0d630f68d363.jpg?1",
             "name": "Disruptive Student",
             "text": "oc\nT: Counter target spell unless its caster pays an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "c2c06954-3427-59b0-9905-9334b922f864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a8d857-184d-4339-88f4-261378e5bd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a8d857-184d-4339-88f4-261378e5bd3c.jpg?1",
             "name": "Douse",
             "text": "o1oo\nU Counter target red spell. Play this ability as an interrupt.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "cdefb4cb-26db-5189-ad28-94f9bfb06bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d0eda-91b8-48f2-a988-016bcc7ab35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d0eda-91b8-48f2-a988-016bcc7ab35e.jpg?1",
             "name": "Drifting Djinn",
             "text": "Flying\nDuring your upkeep, pay o1o\nU or sacrifice Drifting Djinn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "dfa65a6d-5257-5f07-830f-7244b5aa7d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254aa8d0-f0f5-4fb2-a6ba-07453d71e229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254aa8d0-f0f5-4fb2-a6ba-07453d71e229.jpg?1",
             "name": "Enchantment Alteration",
             "text": "Move target enchantment from one creature to another or from one land to another. (The enchantment's new target must be legal.)",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "410401a0-17d7-55c5-bd6a-49b684babb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff5770-b207-41e1-97b7-b9347c72b407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff5770-b207-41e1-97b7-b9347c72b407.jpg?1",
             "name": "Energy Field",
             "text": "Prevent all damage dealt to you from sources you do not control.\nWhen a card is put into your graveyard, sacrifice Energy Field.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "86a3b896-fcce-5dac-8d6e-d7c31e2587f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666efc89-b566-4b2b-a0e2-52f1dedc9e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666efc89-b566-4b2b-a0e2-52f1dedc9e10.jpg?1",
             "name": "Exhaustion",
             "text": "Creatures and lands target opponent controls do not untap during his or her next untap phase.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "b8829fdc-b778-5d07-8878-3ef5f14700c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade0d30-5a57-439e-95e8-5f865880031f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade0d30-5a57-439e-95e8-5f865880031f.jpg?1",
             "name": "Fog Bank",
             "text": "(Walls cannot attack.)\nFlying\nFog Bank does not deal or receive combat damage.",
             "colours": [
@@ -2417,7 +2417,7 @@
         },
         {
             "id": "9e74408d-4424-5200-bf64-1fd6e806ad56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de3fdae-cc2c-4a14-b15b-4fe1a983dfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de3fdae-cc2c-4a14-b15b-4fe1a983dfbf.jpg?1",
             "name": "Gilded Drake",
             "text": "Flying\nWhen Gilded Drake comes into play, exchange control of Gilded Drake for target creature one of your opponents controls or sacrifice Gilded Drake.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "94b34059-d245-53b9-a05f-4ea01dd12de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a2acf1-dad8-4f93-a34e-891e5178a48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a2acf1-dad8-4f93-a34e-891e5178a48f.jpg?1",
             "name": "Great Whale",
             "text": "When Great Whale comes into play, untap up to seven lands.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "8644488d-9b25-5fea-b0d6-2950f0bd0bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321888a-a450-4c15-9461-255cfaa05367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321888a-a450-4c15-9461-255cfaa05367.jpg?1",
             "name": "Hermetic Study",
             "text": "Enchanted creature gains \"oc\nT: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "0b27990e-b7b8-541f-aaee-72ac94dd7247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7444c-fabb-4437-8db9-a1008ea09415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7444c-fabb-4437-8db9-a1008ea09415.jpg?1",
             "name": "Hibernation",
             "text": "Return all green permanents to owners' hands.",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "d4c423f4-6931-5d0b-ae19-9eacaca04398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33646b-a0e3-4344-873e-6711743bc85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33646b-a0e3-4344-873e-6711743bc85c.jpg?1",
             "name": "Horseshoe Crab",
             "text": "oo\nU Untap Horseshoe Crab.",
             "colours": [
@@ -2580,7 +2580,7 @@
         },
         {
             "id": "0b920694-8042-57c6-9eab-d3a40e736ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa19ecb-146e-4109-b4ef-74675b35d8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa19ecb-146e-4109-b4ef-74675b35d8c4.jpg?1",
             "name": "Imaginary Pet",
             "text": "During your upkeep, if you have a card in hand, return Imaginary Pet to owner's hand.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "f463403b-72ac-5024-9b59-4a600f11650e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f78667-b3ab-44af-89df-9e9332dc5485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f78667-b3ab-44af-89df-9e9332dc5485.jpg?1",
             "name": "Launch",
             "text": "Enchanted creature gains flying.\nWhen Launch is put into a graveyard from play, return Launch to owner's hand.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "52b2249e-cf39-52ff-9140-c6c5e5672510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef319154-c5fc-4432-a860-a05508c132d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef319154-c5fc-4432-a860-a05508c132d4.jpg?1",
             "name": "Lilting Refrain",
             "text": "During your upkeep, you may put a verse counter on Lilting Refrain.\nSacrifice Lilting Refrain: Counter target spell unless its caster pays an additional o\nX, where X is the number of verse counters on Lilting Refrain. Play this ability as an interrupt.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "6e403ebb-41a0-52e2-8f8a-fd4da5d3d425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b4a82-a1d5-4dcc-9264-96005fdf53f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b4a82-a1d5-4dcc-9264-96005fdf53f5.jpg?1",
             "name": "Lingering Mirage",
             "text": "Enchanted land is an island.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "108c8a91-7f86-5dcd-ad4e-f2611488b9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4d5c-aacf-4bd8-849d-80a357a7804d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4d5c-aacf-4bd8-849d-80a357a7804d.jpg?1",
             "name": "Morphling",
             "text": "oo\nU Untap Morphling.\noo\nU Morphling gains flying until end of turn.\noo\nU Morphling cannot be the target of spells or abilities until end of turn.\no1: Morphling gets +1/-1 until end of turn.\no1: Morphling gets -1/+1 until end of turn.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "c903cfbd-457c-5b56-b206-a3396620124a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b6708-5ed4-4085-b9b7-d359b2d5b26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b6708-5ed4-4085-b9b7-d359b2d5b26f.jpg?1",
             "name": "Pendrell Drake",
             "text": "Flying\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "1fdf2f0d-8d96-51f3-bd17-4d7fe065632c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34847e03-c529-415e-9d49-fd4647ca8892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34847e03-c529-415e-9d49-fd4647ca8892.jpg?1",
             "name": "Pendrell Flux",
             "text": "Enchanted creature gains \"During your upkeep, pay this creature's casting cost or sacrifice it.\"",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "7c2e27a2-19e8-526e-aef0-dd77171cf550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951863f-1c16-4d09-ba9a-f57dc3d81a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951863f-1c16-4d09-ba9a-f57dc3d81a20.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake comes into play, untap up to five lands.",
             "colours": [
@@ -2842,7 +2842,7 @@
         },
         {
             "id": "bf831162-0891-5194-9751-398023530227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662cf693-18c4-4169-bcce-09862778f60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662cf693-18c4-4169-bcce-09862778f60c.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless its caster pays an additional o\nX. If he or she does not, tap all mana-producing lands that player controls and remove all mana from his or her mana pool.",
             "colours": [
@@ -2873,7 +2873,7 @@
         },
         {
             "id": "06045f16-c79b-5203-ae4a-020ef2800995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d0296c-c0f5-491e-9e61-be8f5af2e631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d0296c-c0f5-491e-9e61-be8f5af2e631.jpg?1",
             "name": "Power Taint",
             "text": "During the upkeep of enchanted enchantment's controller, that player pays o2 or loses 2 life.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "9266bb89-4577-5d7c-8905-8bd4c7a5ff98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95479839-779e-4dbe-8989-ccf26cc488fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95479839-779e-4dbe-8989-ccf26cc488fe.jpg?1",
             "name": "Recantation",
             "text": "During your upkeep, you may put a verse counter on Recantation.\no\nU, Sacrifice Recantation: Return up to X target permanents to owner's hand, where X is the number of verse counters on Recantation.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "68874a15-7ef6-5af6-bc13-e728159bdc2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dde1dc-8eee-4a66-87d9-fdfb42270744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dde1dc-8eee-4a66-87d9-fdfb42270744.jpg?1",
             "name": "Rescind",
             "text": "Return target permanent to owner's hand.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "3397625f-b5d1-57cc-8e55-d4e694e1a4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51c4fb-fb29-4b1c-b78e-1fadf94fc9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51c4fb-fb29-4b1c-b78e-1fadf94fc9a5.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -2999,7 +2999,7 @@
         },
         {
             "id": "5efd3495-be53-59a6-8deb-7ae97b553993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ce3960-abf1-4f28-8434-ab3b27d3b7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ce3960-abf1-4f28-8434-ab3b27d3b7cb.jpg?1",
             "name": "Sandbar Merfolk",
             "text": "Cycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "a67ee534-bbec-5a8d-995f-dd330b5620e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b430ec-28e1-4b2c-bea8-3bfd3a0e8cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b430ec-28e1-4b2c-bea8-3bfd3a0e8cf8.jpg?1",
             "name": "Sandbar Serpent",
             "text": "Cycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "0bdf25e0-3f7f-5178-8ca2-c39349c25eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b851c17-55ed-4671-b471-dc7b34944432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b851c17-55ed-4671-b471-dc7b34944432.jpg?1",
             "name": "Show and Tell",
             "text": "Each player may choose an artifact, creature, enchantment, or land card in his or her hand and put that permanent into play.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "6be84a72-dbad-526e-aef6-2dbb6ae8ffec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35aa7a8-5579-46b7-83ef-f5ecc2b31847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35aa7a8-5579-46b7-83ef-f5ecc2b31847.jpg?1",
             "name": "Somnophore",
             "text": "Flying\nWhenever Somnophore successfully deals damage to a player, tap target creature that player controls. That creature does not untap during its controller's untap phase as long as Somnophore remains in play.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "a5bef70a-40fd-5b77-bf94-7128a5545e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66b2aa6-e891-4ae5-b6c9-1537b797c3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66b2aa6-e891-4ae5-b6c9-1537b797c3ab.jpg?1",
             "name": "Spire Owl",
             "text": "Flying\nWhen Spire Owl comes into play, look at the top four cards of your library and put them back in any order.",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "88be0ba4-1d02-5aee-b85d-781a83832f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7042fdc8-e2dd-4f9a-97b9-00d95c9eae74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7042fdc8-e2dd-4f9a-97b9-00d95c9eae74.jpg?1",
             "name": "Stern Proctor",
             "text": "When Stern Proctor comes into play, return target artifact or enchantment to owner's hand.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "632e1e0f-161e-569d-b558-36c3d8a5e809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e977755-8ea4-4a8b-90c4-dd175321e05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e977755-8ea4-4a8b-90c4-dd175321e05d.jpg?1",
             "name": "Stroke of Genius",
             "text": "Target player draws X cards.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "e23abbd6-74ae-58d1-a168-caf2baef2cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9dd7c6-36b6-4fe2-b3d3-f62a6e10a428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9dd7c6-36b6-4fe2-b3d3-f62a6e10a428.jpg?1",
             "name": "Sunder",
             "text": "Return all lands to owners' hands.",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "9134f723-3bd7-599b-bab8-7c641447d0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51729f36-0a0c-47fb-a3bf-22afc78df7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51729f36-0a0c-47fb-a3bf-22afc78df7a4.jpg?1",
             "name": "Telepathy",
             "text": "Each of your opponents plays with his or her hand revealed.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "19763626-a349-5578-a256-7243ff7c22ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d62dbd-63db-4ac9-950f-9852627f23f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d62dbd-63db-4ac9-950f-9852627f23f2.jpg?1",
             "name": "Time Spiral",
             "text": "Remove Time Spiral from the game. Each player shuffles his or her graveyard and hand into his or her library, then draws seven cards. You untap up to six lands.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "716dc38a-7e2b-564b-859f-3849a3785dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c29399d-0a59-4dcb-9bd4-f31eea3f39f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c29399d-0a59-4dcb-9bd4-f31eea3f39f9.jpg?1",
             "name": "Tolarian Winds",
             "text": "Discard your hand, then draw that many cards.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "b95d681a-4979-5656-9a81-468d5090a36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52000066-a8cd-418f-98d2-30354b959b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52000066-a8cd-418f-98d2-30354b959b32.jpg?1",
             "name": "Turnabout",
             "text": "Tap or untap all artifacts, creatures, or lands target player controls.",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "ea9dfdff-101c-599e-b907-585ea24dd0f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bd3fac-44b6-4078-a096-8d47b01ea979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bd3fac-44b6-4078-a096-8d47b01ea979.jpg?1",
             "name": "Veil of Birds",
             "text": "When one of your opponents successfully casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 creature with flying that counts as a Bird.",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "e459bb41-28e7-5ed3-8eb2-1468d7978d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ea09f-5017-423c-84ad-c332329992b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ea09f-5017-423c-84ad-c332329992b3.jpg?1",
             "name": "Veiled Apparition",
             "text": "When one of your opponents successfully casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 creature with flying and \"During your upkeep, pay o1o\nU or sacrifice Veiled Apparition\" and that counts as an Illusion.",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "f39bf22a-af4f-5b13-afd2-fe8c8fdbfd03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be15ae1-5262-40ba-937c-217a33d131da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be15ae1-5262-40ba-937c-217a33d131da.jpg?1",
             "name": "Veiled Crocodile",
             "text": "When a player has no cards in hand, if Veiled Crocodile is an enchantment, Veiled Crocodile becomes a 4/4 creature that counts as a Crocodile.",
             "colours": [
@@ -3475,7 +3475,7 @@
         },
         {
             "id": "6c2f806a-491c-5f06-9f4f-a79380ac06cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de458a9d-6c09-42bb-b470-c2691e95345a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de458a9d-6c09-42bb-b470-c2691e95345a.jpg?1",
             "name": "Veiled Sentry",
             "text": "When one of your opponents successfully casts a spell, if Veiled Sentry is an enchantment, Veiled Sentry becomes a creature with power and toughness each equal to the total casting cost of that spell and that counts as an Illusion.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "8ccbb092-d32f-586f-87a8-1882daa02aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193fd6-3156-48ff-90fa-71328ee7adf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193fd6-3156-48ff-90fa-71328ee7adf5.jpg?1",
             "name": "Veiled Serpent",
             "text": "When one of your opponents successfully casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 creature that cannot attack unless defending player controls an island and that counts as a Serpent.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3537,7 +3537,7 @@
         },
         {
             "id": "a5049f97-d198-5431-b250-7baba73ba782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aef4608-5ba8-4636-b5e7-cac57c5c0608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aef4608-5ba8-4636-b5e7-cac57c5c0608.jpg?1",
             "name": "Windfall",
             "text": "Each player discards his or her hand and draws cards equal to the greatest number a player discarded this way.",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "be7be1e8-37ab-5cc6-bcc0-aba052d1c687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49805401-9bd9-48a3-9b99-0120a8bb1fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49805401-9bd9-48a3-9b99-0120a8bb1fb5.jpg?1",
             "name": "Wizard Mentor",
             "text": "oc\nT: Return Wizard Mentor and target creature you control to owner's hand.",
             "colours": [
@@ -3602,7 +3602,7 @@
         },
         {
             "id": "b155724c-b46f-59f8-9f78-95a11ad69d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0317fff-dbad-4c47-a191-0369d81cdda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0317fff-dbad-4c47-a191-0369d81cdda2.jpg?1",
             "name": "Zephid",
             "text": "Flying\nZephid cannot be the target of spells or abilities.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "0fa60212-e879-5d8a-be75-e498df18199a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3312de-c153-4e75-8f8c-b7762b30d492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3312de-c153-4e75-8f8c-b7762b30d492.jpg?1",
             "name": "Zephid's Embrace",
             "text": "Enchanted creature gets +2/+2, gains flying, and cannot be the target of spells or abilities.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "837f42c8-475f-5f55-82f3-6615a14e16f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94396d26-cede-4a61-b30a-50aecc730407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94396d26-cede-4a61-b30a-50aecc730407.jpg?1",
             "name": "Abyssal Horror",
             "text": "Flying\nWhen Abyssal Horror comes into play, target player chooses and discards two cards.",
             "colours": [
@@ -3701,7 +3701,7 @@
         },
         {
             "id": "8f6463c4-3cb5-5b22-98fd-a59b6009f09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92cb48d-315b-4877-b615-ffdf275c4d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92cb48d-315b-4877-b615-ffdf275c4d61.jpg?1",
             "name": "Befoul",
             "text": "Destroy target land or nonblack creature. A creature destroyed this way cannot be regenerated this turn.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "5b05e2d2-f936-5e51-8dd7-ade6645768aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1e5f5-a164-4359-bae1-e5dfd4801688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1e5f5-a164-4359-bae1-e5dfd4801688.jpg?1",
             "name": "Bereavement",
             "text": "Whenever a green creature is put into a graveyard from play, its controller chooses and discards a card.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "56af8b6e-3923-50b1-9c2b-a21a5ac66f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e692dea-750b-40b2-9440-8b570e67c23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e692dea-750b-40b2-9440-8b570e67c23e.jpg?1",
             "name": "Blood Vassal",
             "text": "Sacrifice Blood Vassal: Add o\nBo\nB to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "97e2036e-7243-5fb1-bd2b-bda4447fd86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3739188b-f2b3-4ab0-8e5c-b3a1d2a1ad09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3739188b-f2b3-4ab0-8e5c-b3a1d2a1ad09.jpg?1",
             "name": "Bog Raiders",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "6c4d593d-4219-5f3d-952f-98547a642597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a8e6f-4c3b-4d92-bd05-9bbb0150d653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a8e6f-4c3b-4d92-bd05-9bbb0150d653.jpg?1",
             "name": "Bog Raiders",
             "text": "",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "adb3fea6-94fe-5c9a-b812-930af88df493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eada28cb-92bf-47e0-b09d-4709be32dbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eada28cb-92bf-47e0-b09d-4709be32dbe6.jpg?1",
             "name": "Breach",
             "text": "Target creature gets +2/+0 until end of turn. That creature cannot be blocked except by artifact creatures and black creatures this turn.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "51ef3c33-31ff-5954-bdbc-ec98d7b6f876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae410ae8-1e72-4727-96df-c7c195063fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae410ae8-1e72-4727-96df-c7c195063fb5.jpg?1",
             "name": "Cackling Fiend",
             "text": "When Cackling Fiend comes into play, each of your opponents chooses and discards a card.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "9a0b0c2b-ccd8-55c4-b165-7f3b857cfb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d4f4d7-a35b-45ea-ba51-ee65b3ff98d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d4f4d7-a35b-45ea-ba51-ee65b3ff98d4.jpg?1",
             "name": "Carrion Beetles",
             "text": "o2o\nB, oc\nT: Remove from the game up to three target cards in one graveyard.",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "d27995ec-6c25-591c-aeb1-486138828c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86067dfe-65c3-4c96-bccd-b3915d6663f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86067dfe-65c3-4c96-bccd-b3915d6663f9.jpg?1",
             "name": "Contamination",
             "text": "During your upkeep, sacrifice a creature or sacrifice Contamination.\nWhenever a land is tapped for mana, it produces o\nB instead of its normal type and amount.",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "8c34e61d-9fe9-54b6-ab92-6c065137c4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e1c65c-ced6-484d-b3b4-db913c6bf84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e1c65c-ced6-484d-b3b4-db913c6bf84b.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals 1 damage to target creature or player for each swamp you control. When Corrupt successfully deals damage to a creature or player, gain life equal to that damage.",
             "colours": [
@@ -4025,7 +4025,7 @@
         },
         {
             "id": "9d2f441a-eb42-571a-8ced-f2e8d0a67e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816272de-f134-45fa-ac1f-70d35d30c7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816272de-f134-45fa-ac1f-70d35d30c7e1.jpg?1",
             "name": "Crazed Skirge",
             "text": "Flying\nCrazed Skirge is unaffected by summoning sickness.",
             "colours": [
@@ -4059,7 +4059,7 @@
         },
         {
             "id": "53d3c6db-6cdd-5007-b9e5-50922ccd996d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a538c1-8539-4955-ae3e-27312ce9e800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a538c1-8539-4955-ae3e-27312ce9e800.jpg?1",
             "name": "Dark Hatchling",
             "text": "Flying\nWhen Dark Hatchling comes into play, destroy target nonblack creature. That creature cannot be regenerated this turn.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "2eb8f803-c6d3-55d5-9b97-fc2e40a76ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e9d0d-e1a3-4e0a-bf39-e9aaf4d36d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e9d0d-e1a3-4e0a-bf39-e9aaf4d36d67.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "ddd1581d-b73b-5743-bdeb-826631bfec74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad98ca8-d358-450a-8439-5abf57197b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad98ca8-d358-450a-8439-5abf57197b83.jpg?1",
             "name": "Darkest Hour",
             "text": "All creatures are black.",
             "colours": [
@@ -4154,7 +4154,7 @@
         },
         {
             "id": "2815bf7f-60a6-5f22-aeaa-3d76d31c674a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef400a6a-628a-40d6-80dc-feabe40d6ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef400a6a-628a-40d6-80dc-feabe40d6ce1.jpg?1",
             "name": "Despondency",
             "text": "Enchanted creature gets -2/-0.\nWhen Despondency is put into a graveyard from play, return Despondency to owner's hand.",
             "colours": [
@@ -4187,7 +4187,7 @@
         },
         {
             "id": "48628f4c-2d03-503e-9788-86170c54cd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb1e0c9-9041-44cd-9e96-87cf14c67068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb1e0c9-9041-44cd-9e96-87cf14c67068.jpg?1",
             "name": "Diabolic Servitude",
             "text": "When Diabolic Servitude comes into play, choose target creature card in your graveyard and put that creature into play.\nWhen the chosen creature is put into a graveyard, remove the creature from the game and return Diabolic Servitude to owner's hand.\nWhen Diabolic Servitude leaves play, remove the chosen creature from the game.",
             "colours": [
@@ -4220,7 +4220,7 @@
         },
         {
             "id": "2ffa7609-03b7-58eb-a04b-2ca6298b813b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d6bc-693b-4c2b-9c3b-b0db241ebb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d6bc-693b-4c2b-9c3b-b0db241ebb42.jpg?1",
             "name": "Diabolic Servitude",
             "text": "",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "393102a3-6dc6-593b-b0d1-0015ed5657d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48e753c-ba11-4aa3-9a73-584f8a7538f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48e753c-ba11-4aa3-9a73-584f8a7538f5.jpg?1",
             "name": "Discordant Dirge",
             "text": "During your upkeep, you may put a verse counter on Discordant Dirge.\no\nB, Sacrifice Discordant Dirge: Look at target opponent's hand and choose up to X of those cards, where X is the number of verse counters on Discordant Dirge. That player discards those cards.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "4a35f58f-536a-5935-9d83-cf1571c9ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367f49-0f4a-4b7f-8104-851893fbcd8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367f49-0f4a-4b7f-8104-851893fbcd8a.jpg?1",
             "name": "Duress",
             "text": "Look at target opponent's hand and choose a noncreature, nonland card there. That player discards that card.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "ef2b477a-e621-5dc9-9f61-0290c9fe0015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f042a8c7-f07b-42bd-8251-c588d890683c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f042a8c7-f07b-42bd-8251-c588d890683c.jpg?1",
             "name": "Eastern Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target green creature.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "edc118a2-8775-5be3-8419-78fe870735a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88b23ce-ce19-47da-b9f2-055a4d6bdc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88b23ce-ce19-47da-b9f2-055a4d6bdc79.jpg?1",
             "name": "Exhume",
             "text": "Each player chooses a creature card in his or her graveyard and puts that creature into play.",
             "colours": [
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "c206713e-69db-5c66-9013-208bdfce8197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0576ffe8-a7b9-479b-8ea0-418b430b1aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0576ffe8-a7b9-479b-8ea0-418b430b1aa1.jpg?1",
             "name": "Expunge",
             "text": "Destroy target nonartifact, nonblack creature. That creature cannot be regenerated this turn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "38d75d88-4aaa-5147-b919-4ad802d588dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dc6a91-ca13-45da-ba65-8fbb16c159c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dc6a91-ca13-45da-ba65-8fbb16c159c0.jpg?1",
             "name": "Flesh Reaver",
             "text": "Whenever Flesh Reaver successfully deals damage to a creature or opponent, Flesh Reaver deals an equal amount of damage to you.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "bc683913-87d1-5c4b-bb47-fa8c090fd65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e84fa4f-617d-4449-8141-783a9ce017c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e84fa4f-617d-4449-8141-783a9ce017c1.jpg?1",
             "name": "Hollow Dogs",
             "text": "Whenever Hollow Dogs attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "d6c1c3e0-a5e9-5570-8aad-03a07dbec48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826230ad-6b2b-42a0-9d6f-ed07d3554efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826230ad-6b2b-42a0-9d6f-ed07d3554efd.jpg?1",
             "name": "Ill-Gotten Gains",
             "text": "Remove Ill-Gotten Gains from the game. All players discard their hands, then each player puts up to three cards from his or her graveyard into his or her hand.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "8cd4d6a8-3dda-56c2-a01d-34bcd5531b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525f63ae-e002-4d47-bea5-b24dc89d4d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525f63ae-e002-4d47-bea5-b24dc89d4d06.jpg?1",
             "name": "Looming Shade",
             "text": "oo\nB Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "0d81db79-a661-5b42-a66a-195ebe7bc876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e94ab55-4390-4b3d-8e7f-a95996e2c5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e94ab55-4390-4b3d-8e7f-a95996e2c5b7.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -4582,7 +4582,7 @@
         },
         {
             "id": "34925eae-837c-5c2a-b992-9c64522a1be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ef7201-4443-4a77-b9e1-6f1f39e8f993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ef7201-4443-4a77-b9e1-6f1f39e8f993.jpg?1",
             "name": "Lurking Evil",
             "text": "Pay half your life, rounded up: Lurking Evil becomes a 4/4 creature with flying that counts as a Horror.",
             "colours": [
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "1e2ca1de-7bcc-5ed6-a2f9-5c46fdbb0f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a288616-5350-43eb-b718-5bfeb5be4ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a288616-5350-43eb-b718-5bfeb5be4ed4.jpg?1",
             "name": "Mana Leech",
             "text": "You may choose not to untap Mana Leech during your untap phase.\noc\nT: Tap target land. As long as Mana Leech remains tapped, that land does not untap during its controller's untap phase.",
             "colours": [
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "dc0be188-e00e-5d3c-a2c4-10dd4fb36f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9b2b0-65aa-42a1-b9f8-563b194ca5b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9b2b0-65aa-42a1-b9f8-563b194ca5b1.jpg?1",
             "name": "No Rest for the Wicked",
             "text": "Sacrifice No Rest for the Wicked: Return to your hand all creature cards put into your graveyard from play this turn.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "267b7e36-cf52-5bec-96ab-eb97d18f9e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a4bce-15db-43a7-9514-5e657b618aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a4bce-15db-43a7-9514-5e657b618aac.jpg?1",
             "name": "No Rest for the Wicked",
             "text": "",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "502843ec-cd41-548c-96cd-1ea005fbc6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838e751-b206-4052-9263-a67b8fea05cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838e751-b206-4052-9263-a67b8fea05cc.jpg?1",
             "name": "Oppression",
             "text": "Whenever a player successfully casts a spell, that player chooses and discards a card.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "ba46b93c-6dde-5b45-ab01-a3911bcad93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e858d-d8d2-4626-9343-070cf86949ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e858d-d8d2-4626-9343-070cf86949ab.jpg?1",
             "name": "Order of Yawgmoth",
             "text": "Order of Yawgmoth cannot be blocked except by artifact creatures and black creatures.\nWhenever Order of Yawgmoth successfully deals damage to a player, that player chooses and discards a card.",
             "colours": [
@@ -4778,7 +4778,7 @@
         },
         {
             "id": "9293a064-5a24-51d5-85da-80a40d721b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bd3995-3013-468e-b586-0c5720a0bde6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bd3995-3013-468e-b586-0c5720a0bde6.jpg?1",
             "name": "Parasitic Bond",
             "text": "During the upkeep of enchanted creature's controller, Parasitic Bond deals 2 damage to that player.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "4092dc2b-0d39-50ef-adaa-ed126b3a4dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8e2be6-124d-412e-be34-aa4495a83e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8e2be6-124d-412e-be34-aa4495a83e02.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Look at target player's hand. That player discards all cards of the chosen color.",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "6a826a50-2b19-538c-80e6-0d6d2d8f55e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f5630-647f-4789-8506-e7fafcbdd671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f5630-647f-4789-8506-e7fafcbdd671.jpg?1",
             "name": "Pestilence",
             "text": "At the end of each turn, if no creatures are in play, sacrifice Pestilence.\noo\nB Pestilence deals 1 damage to each creature and player.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "dfb1b4aa-159e-5a1d-a0c2-42dacddeb32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4843ba92-fde2-4b46-8fdb-e0f8aca96959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4843ba92-fde2-4b46-8fdb-e0f8aca96959.jpg?1",
             "name": "Phyrexian Ghoul",
             "text": "Sacrifice a creature: Phyrexian Ghoul gets +2/+2 until end of turn.",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "371f63e0-fbd7-5cfb-aa47-95ea3b6de3ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035c718-ac11-4c97-a9bb-0cd88dc71904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035c718-ac11-4c97-a9bb-0cd88dc71904.jpg?1",
             "name": "Planar Void",
             "text": "Whenever a card is put into a graveyard, remove that card from the game.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "dfb10134-93ac-5796-892f-71cbcb6f5e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64166899-fcc6-4000-9994-643f5a4cd214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64166899-fcc6-4000-9994-643f5a4cd214.jpg?1",
             "name": "Priest of Gix",
             "text": "When Priest of Gix comes into play, add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "75631035-0337-51f4-b255-91ed1515ead6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf07d5a-6618-48e2-a9f0-669b75bb6e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf07d5a-6618-48e2-a9f0-669b75bb6e85.jpg?1",
             "name": "Rain of Filth",
             "text": "Each land you control gains \"Sacrifice this land: Add o\nB to your mana pool\" until end of turn.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "f78bbc38-eb16-51bc-a3b8-d835ad1b38be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b6e655-e05e-44b5-9c7f-9dbbc66e6e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b6e655-e05e-44b5-9c7f-9dbbc66e6e28.jpg?1",
             "name": "Ravenous Skirge",
             "text": "Flying\nWhenever Ravenous Skirge attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "8e0882dd-fffa-5bb1-821d-5236d4a16192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b14c6-78a0-4e82-924e-781719c8defb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b14c6-78a0-4e82-924e-781719c8defb.jpg?1",
             "name": "Reclusive Wight",
             "text": "During your upkeep, if you control any other nonland permanents, sacrifice Reclusive Wight.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "280b1d7e-7cc8-54ba-ac78-3d65add7da71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569408b3-43c8-4cb1-a70f-15ab2aeaf8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569408b3-43c8-4cb1-a70f-15ab2aeaf8ed.jpg?1",
             "name": "Reprocess",
             "text": "Sacrifice any number of artifacts, creatures, and/or lands and draw a card for each one sacrificed this way.",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "5cc0bf33-9422-5a7a-994a-83f619b8dff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c33fbb0-f49d-4b4d-804d-84b03e0daf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c33fbb0-f49d-4b4d-804d-84b03e0daf4d.jpg?1",
             "name": "Sanguine Guard",
             "text": "First strike\no1oo\nB Regenerate Sanguine Guard.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "f7b80490-6e3c-512b-8e76-ac167ea34dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1beb5d-0ef2-4013-932b-5e4a5d0af559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1beb5d-0ef2-4013-932b-5e4a5d0af559.jpg?1",
             "name": "Sicken",
             "text": "Enchanted creature gets -1/-1.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -5172,7 +5172,7 @@
         },
         {
             "id": "e9a00d47-f9aa-571b-a8a6-a481594c4fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935ee538-3ea1-4a80-bb8f-01d562f63b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935ee538-3ea1-4a80-bb8f-01d562f63b5d.jpg?1",
             "name": "Skirge Familiar",
             "text": "Flying\nChoose and discard a card: Add o\nB to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "78b15046-b2f2-53e1-b236-5eb8a577b7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aba9d5-5f96-4aba-8248-74398b8bfe9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aba9d5-5f96-4aba-8248-74398b8bfe9d.jpg?1",
             "name": "Skittering Skirge",
             "text": "Flying\nWhen you successfully cast a creature spell, sacrifice Skittering Skirge.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "621ab515-d5c4-516d-97ba-85fc6f06b31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b2c4bd-2397-4ebd-b4fb-3b3e9c6c7dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b2c4bd-2397-4ebd-b4fb-3b3e9c6c7dec.jpg?1",
             "name": "Sleeper Agent",
             "text": "When Sleeper Agent comes into play, target opponent gains control of it.\nDuring your upkeep, Sleeper Agent deals 2 damage to you.",
             "colours": [
@@ -5274,7 +5274,7 @@
         },
         {
             "id": "164e8514-8eed-59e8-b974-317f8ff53846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a14524b-e690-4f77-b43e-416d5ec3cbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a14524b-e690-4f77-b43e-416d5ec3cbb9.jpg?1",
             "name": "Spined Fluke",
             "text": "When Spined Fluke comes into play, sacrifice a creature.\noo\nB Regenerate Spined Fluke.",
             "colours": [
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "2a71c849-3e4d-5f72-a01c-d18e3090a689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd33a1-1603-4368-9c32-e4c9fd6ecd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd33a1-1603-4368-9c32-e4c9fd6ecd08.jpg?1",
             "name": "Tainted Aether",
             "text": "Whenever a creature comes into play, its controller sacrifices a creature or land.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "0e4ed857-d91d-5230-a271-763faed937ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72779ce-bcd3-41dc-8b3f-bfb9a1b137d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72779ce-bcd3-41dc-8b3f-bfb9a1b137d8.jpg?1",
             "name": "Unnerve",
             "text": "Each of your opponents chooses and discards two cards.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "e46c896c-0b26-5fa2-b4f4-3b6fa80b800d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f42c561-1762-43c4-a539-0cf9a5ce7f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f42c561-1762-43c4-a539-0cf9a5ce7f4f.jpg?1",
             "name": "Unworthy Dead",
             "text": "oo\nB Regenerate Unworthy Dead.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "e8ae330e-b788-5433-b6d3-65379a857981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf88542-e5af-430e-9d48-03a216d7526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf88542-e5af-430e-9d48-03a216d7526f.jpg?1",
             "name": "Unworthy Dead",
             "text": "",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "f2f6cfd1-7b18-54aa-9aa3-25b485469e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889be765-5716-4549-b544-0a49d3962e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889be765-5716-4549-b544-0a49d3962e16.jpg?1",
             "name": "Vampiric Embrace",
             "text": "Enchanted creature gets +2/+2 and gains flying.\nWhenever a creature successfully dealt damage by enchanted creature this turn is put into a graveyard, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "e7e96d85-0b0e-5d5a-9d8c-2ecedecd9ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5623194-0cd9-4f3f-bab1-133d6b1e94fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5623194-0cd9-4f3f-bab1-133d6b1e94fe.jpg?1",
             "name": "Vebulid",
             "text": "Vebulid comes into play with one +1/+1 counter on it.\nDuring your upkeep, you may put a +1/+1 counter on Vebulid.\nWhen Vebulid attacks or blocks, destroy it at end of combat.",
             "colours": [
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "3d9e9717-f6bd-5e9a-bd0a-2a52eae5ba7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caafe7da-0167-4c53-bbad-172f900d137b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caafe7da-0167-4c53-bbad-172f900d137b.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, put the two chosen creatures into play tapped.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "32454058-1407-504c-8ef0-f19f5b1e669d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be44b37-2383-4bf4-ba30-d8d4e2cb8939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be44b37-2383-4bf4-ba30-d8d4e2cb8939.jpg?1",
             "name": "Vile Requiem",
             "text": "During your upkeep, you may put a verse counter on Vile Requiem.\no1o\nB, Sacrifice Vile Requiem: Destroy up to X target nonblack creatures, where X is the number of verse counters on Vile Requiem. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "ec36983c-abb6-5088-9215-6f1a255d53a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bcfe0f-2397-488b-8f02-dae1f6cd5824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bcfe0f-2397-488b-8f02-dae1f6cd5824.jpg?1",
             "name": "Western Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target white creature.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "0662924f-f773-5faa-ba65-c253712a6c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef749290-58e2-4b40-a141-5fe294f9b995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef749290-58e2-4b40-a141-5fe294f9b995.jpg?1",
             "name": "Witch Engine",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)\noc\nT: Add o\nBo\nBo\nBo\nB to your mana pool. Target opponent gains control of Witch Engine. (Play this ability as an instant.)",
             "colours": [
@@ -5639,7 +5639,7 @@
         },
         {
             "id": "177f9c6b-1fc4-5ecb-9ac3-dfa0ab6c4d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16be4b-4540-476a-b3ac-7442507ed314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16be4b-4540-476a-b3ac-7442507ed314.jpg?1",
             "name": "Yawgmoth's Edict",
             "text": "Whenever one of your opponents successfully casts a white spell, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "78cc0f77-ee21-5941-b708-7902aec2ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e3c3a-d351-4d91-8884-312d4b6f540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e3c3a-d351-4d91-8884-312d4b6f540d.jpg?1",
             "name": "Yawgmoth's Will",
             "text": "Until end of turn, you may play cards in your graveyard as though they were in your hand. Cards put into your graveyard this turn are removed from the game instead.",
             "colours": [
@@ -5701,7 +5701,7 @@
         },
         {
             "id": "3acc697f-2874-5482-9455-f7689d8b5192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790157c9-b1ed-4da5-9d50-e99e0dd807b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790157c9-b1ed-4da5-9d50-e99e0dd807b7.jpg?1",
             "name": "Acidic Soil",
             "text": "Acidic Soil deals 1 damage to each player for each land he or she controls.",
             "colours": [
@@ -5732,7 +5732,7 @@
         },
         {
             "id": "54300b17-1d80-59fb-9059-bb49e10db1c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9db511-089e-413f-8005-ccb05ec3b06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9db511-089e-413f-8005-ccb05ec3b06e.jpg?1",
             "name": "Antagonism",
             "text": "During each player's discard phase, Antagonism deals 2 damage to that player unless one of his or her opponents was successfully dealt damage that turn.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "189e8cb5-b33a-5315-aefb-9afd64bcad17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c81ade7-0074-4447-ba2c-b16fa0f09ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c81ade7-0074-4447-ba2c-b16fa0f09ccb.jpg?1",
             "name": "Arc Lightning",
             "text": "Arc Lightning deals 3 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -5794,7 +5794,7 @@
         },
         {
             "id": "d35fa5e6-ebb5-53ef-bd11-43dd028fcb07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e97dc9-8df3-4912-8564-7bdb2ac6564b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e97dc9-8df3-4912-8564-7bdb2ac6564b.jpg?1",
             "name": "Bedlam",
             "text": "Creatures cannot block.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "7000de85-0e60-553a-b83d-629815db86c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafbd034-c8a0-4798-a680-555c13bdd251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafbd034-c8a0-4798-a680-555c13bdd251.jpg?1",
             "name": "Brand",
             "text": "Gain control of all permanents you own.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -5856,7 +5856,7 @@
         },
         {
             "id": "38c67e41-eeb2-51d2-ab5c-e2b965ea7b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba422-4837-400c-a913-b56d87b49e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba422-4837-400c-a913-b56d87b49e26.jpg?1",
             "name": "Bravado",
             "text": "Enchanted creature gets +1/+1 for each other creature you control.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "5a24cd50-ab91-5953-8cd8-43616d23d804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2041b95-ec5b-4512-b012-f875ca686669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2041b95-ec5b-4512-b012-f875ca686669.jpg?1",
             "name": "Bulwark",
             "text": "During your upkeep, Bulwark deals 1 damage to target opponent for each card in your hand greater than the number of cards in that player's hand.",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "41fd2081-37fe-5c5e-b295-68117d8b0cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2382e525-1750-484a-bf95-dbb42bbb30ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2382e525-1750-484a-bf95-dbb42bbb30ae.jpg?1",
             "name": "Crater Hellion",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Crater Hellion comes into play, it deals 4 damage to each other creature.",
             "colours": [
@@ -5954,7 +5954,7 @@
         },
         {
             "id": "58992e6b-8834-5811-8347-87215248be24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479645b3-54af-4fbf-928e-2224540fe892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479645b3-54af-4fbf-928e-2224540fe892.jpg?1",
             "name": "Destructive Urge",
             "text": "Whenever enchanted creature successfully deals combat damage to a player, that player sacrifices a land.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "ef35f3bf-b281-5344-b9a0-c9912f387bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5ec10-dfea-4e6d-8996-553a4a0eb8a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5ec10-dfea-4e6d-8996-553a4a0eb8a4.jpg?1",
             "name": "Disorder",
             "text": "Disorder deals 2 damage to each white creature and each player who controls a white creature.",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "546fc0ff-1625-57ca-aca9-f33b45f8d26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65de0b43-64df-44dc-850c-25f48d6ab53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65de0b43-64df-44dc-850c-25f48d6ab53b.jpg?1",
             "name": "Dromosaur",
             "text": "Whenever Dromosaur blocks or becomes blocked, it gets +2/-2 until end of turn.",
             "colours": [
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "09371731-330d-5ad9-9523-116c67d142b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c3d04f-4010-4db3-9e4e-afa8116b263d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c3d04f-4010-4db3-9e4e-afa8116b263d.jpg?1",
             "name": "Electryte",
             "text": "Whenever Electryte successfully deals combat damage to defending player, Electryte deals damage equal to its power to each blocking creature.",
             "colours": [
@@ -6085,7 +6085,7 @@
         },
         {
             "id": "3f51e600-ae3d-52ea-8604-82f0ea9c4752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e279126c-0512-4ee6-ad83-6fdfc7ae46c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e279126c-0512-4ee6-ad83-6fdfc7ae46c5.jpg?1",
             "name": "Falter",
             "text": "Creatures without flying cannot block this turn.",
             "colours": [
@@ -6116,7 +6116,7 @@
         },
         {
             "id": "a8650772-0910-5fe0-a23d-30b3faaa562c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4fd0e-9f84-4628-92a7-858ad8064531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4fd0e-9f84-4628-92a7-858ad8064531.jpg?1",
             "name": "Fault Line",
             "text": "Fault Line deals X damage to each creature without flying and each player.",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "68586634-e0f8-55d6-9626-d1d21a502deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41deea2-c12f-40cd-8fc4-47227c762f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41deea2-c12f-40cd-8fc4-47227c762f42.jpg?1",
             "name": "Fiery Mantle",
             "text": "When Fiery Mantle is put into a graveyard from play, return Fiery Mantle to owner's hand.\noo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "6a5bd8ed-6e07-5319-be2a-40d612cfec34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e38af-a2e5-4d52-870e-1b6e0cb33cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e38af-a2e5-4d52-870e-1b6e0cb33cef.jpg?1",
             "name": "Fire Ants",
             "text": "oc\nT: Fire Ants deals 1 damage to each other creature without flying.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "6563615c-5a8e-551f-9e97-fffbba5d62b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e32a3d-c477-419a-97c2-851974c6b89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e32a3d-c477-419a-97c2-851974c6b89e.jpg?1",
             "name": "Fire Ants",
             "text": "",
             "colours": [
@@ -6250,7 +6250,7 @@
         },
         {
             "id": "c2efae71-ca4d-5810-ba66-a2ddeb5ff708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0f160-7339-4d98-8a8c-f08889ee52f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0f160-7339-4d98-8a8c-f08889ee52f5.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, then discard a card at random. Shuffle your library afterward.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "1430634c-9d38-59de-9d76-b22e03c46d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60081115-16bc-4924-b76d-7cfc0ad2287c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60081115-16bc-4924-b76d-7cfc0ad2287c.jpg?1",
             "name": "Goblin Cadets",
             "text": "Whenever Goblin Cadets blocks or becomes blocked, target opponent gains control of it. (This removes Goblin Cadets from combat.)",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "1d0c45f3-76bd-5fe7-bb87-808b4ff9963a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b848caa-aad8-4060-8f86-304a8556de2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b848caa-aad8-4060-8f86-304a8556de2d.jpg?1",
             "name": "Goblin Lackey",
             "text": "Whenever Goblin Lackey successfully deals damage to a player, you may choose a Goblin card in your hand and put that Goblin into play.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "b1e61696-b770-564c-96a6-04a938147be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e2e5d-ad06-4378-9afb-ffb174e6a5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e2e5d-ad06-4378-9afb-ffb174e6a5b4.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron comes into play, you may search your library for a Goblin card. If you do, reveal that card, put it into your hand, and shuffle your library afterward.",
             "colours": [
@@ -6380,7 +6380,7 @@
         },
         {
             "id": "507c6ee3-22ea-5baa-8929-584c63c17c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9813857-5527-4499-af86-758a5971e21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9813857-5527-4499-af86-758a5971e21a.jpg?1",
             "name": "Goblin Offensive",
             "text": "Put X Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "c1f89a22-c3fe-5827-b8a8-b2db316ce0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fcd8d3-f159-49a1-8dd9-582ae4a0adc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fcd8d3-f159-49a1-8dd9-582ae4a0adc3.jpg?1",
             "name": "Goblin Patrol",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "822b4466-8aa7-57e5-be08-e769a35ae8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150a460-8a81-4097-8100-ccb8a9bb1bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150a460-8a81-4097-8100-ccb8a9bb1bd7.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider cannot block.",
             "colours": [
@@ -6478,7 +6478,7 @@
         },
         {
             "id": "47a1c480-ace1-5c1d-be45-49008e093e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d02a81f-2dac-41f7-a818-811baa238021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d02a81f-2dac-41f7-a818-811baa238021.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "Mountainwalk (If defending player controls a mountain, this creature is unblockable.)",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "b780a517-7b6f-5d13-868d-4da959ca3421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d0fc9e-fb6b-4a00-b422-32565f7ce454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d0fc9e-fb6b-4a00-b422-32565f7ce454.jpg?1",
             "name": "Goblin War Buggy",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nGoblin War Buggy is unaffected by summoning sickness.",
             "colours": [
@@ -6545,7 +6545,7 @@
         },
         {
             "id": "c518d2d4-e605-5cd5-ab0b-b20ce0184ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6246f17-6034-4423-82c5-1aea8d71f94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6246f17-6034-4423-82c5-1aea8d71f94e.jpg?1",
             "name": "Guma",
             "text": "Protection from blue",
             "colours": [
@@ -6578,7 +6578,7 @@
         },
         {
             "id": "4e9ff8d3-fb68-5b4b-9b73-a9e1cbe15a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0db04c-5101-4a43-9109-3964ac66bdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0db04c-5101-4a43-9109-3964ac66bdab.jpg?1",
             "name": "Headlong Rush",
             "text": "All attacking creatures gain first strike until end of turn.",
             "colours": [
@@ -6609,7 +6609,7 @@
         },
         {
             "id": "6915b519-2478-5406-8051-891dc72cfe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27f90e-d156-439c-b5e5-6d53bd510fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27f90e-d156-439c-b5e5-6d53bd510fe7.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "1c13f61d-eb94-53b4-aded-8e96ca47e621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49304f24-a961-4d1e-b85c-af6e3d8d5edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49304f24-a961-4d1e-b85c-af6e3d8d5edc.jpg?1",
             "name": "Jagged Lightning",
             "text": "Jagged Lightning deals 3 damage to target creature and 3 damage to another target creature.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "1ded5362-7c2c-5394-8f77-8f09f7dd5adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa1186-51fa-419a-9cd0-42403d1dd4a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa1186-51fa-419a-9cd0-42403d1dd4a7.jpg?1",
             "name": "Lay Waste",
             "text": "Destroy target land.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "77b04e79-9681-5224-befd-308bfc8f4ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fc7bc-657f-43a3-9558-f516fa545a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fc7bc-657f-43a3-9558-f516fa545a09.jpg?1",
             "name": "Lightning Dragon",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\noo\nR Lightning Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -6735,7 +6735,7 @@
         },
         {
             "id": "b71d3b61-ed39-55ca-ab0b-ff588cc2015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7a967a-35a0-4e5c-a32b-123a9cfdb79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7a967a-35a0-4e5c-a32b-123a9cfdb79e.jpg?1",
             "name": "Meltdown",
             "text": "Destroy each artifact with total casting cost X or less.",
             "colours": [
@@ -6766,7 +6766,7 @@
         },
         {
             "id": "0220a4d8-a928-574d-9a4b-35000e8ad647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecbdbc-dcfb-42ee-956c-a508db6eaafa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecbdbc-dcfb-42ee-956c-a508db6eaafa.jpg?1",
             "name": "Okk",
             "text": "Okk cannot attack unless a creature with greater power also attacks.\nOkk cannot block unless a creature with greater power also blocks.",
             "colours": [
@@ -6799,7 +6799,7 @@
         },
         {
             "id": "2ecad6eb-fa98-5603-b39c-36c6d0e23399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5a69fa-71ff-4e4f-9406-7cfebccb3384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5a69fa-71ff-4e4f-9406-7cfebccb3384.jpg?1",
             "name": "Outmaneuver",
             "text": "X target blocked creatures deal combat damage to defending player instead of to blocking creatures this turn.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "2e510040-c925-5feb-8d4c-28f889c8c8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4792293a-e11d-4c5e-bbd9-6f09e69ee617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4792293a-e11d-4c5e-bbd9-6f09e69ee617.jpg?1",
             "name": "Rain of Salt",
             "text": "Destroy two target lands.",
             "colours": [
@@ -6861,7 +6861,7 @@
         },
         {
             "id": "fe06399b-0d63-5b85-a29f-afc6c0f7629c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d51b3c-24e9-41b6-b7cd-c70329e498ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d51b3c-24e9-41b6-b7cd-c70329e498ca.jpg?1",
             "name": "Raze",
             "text": "At the time you play Raze, sacrifice a land.\nDestroy target land.",
             "colours": [
@@ -6892,7 +6892,7 @@
         },
         {
             "id": "e090a96b-a250-5092-9d26-5e9197fbc982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614782c2-a38a-4b3e-9716-7f5c09c4ad43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614782c2-a38a-4b3e-9716-7f5c09c4ad43.jpg?1",
             "name": "Reflexes",
             "text": "Enchanted creature gains first strike.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "821bb7d2-2478-5e83-8d1d-fc24e784d8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fbf63d-7106-47d5-97c3-4596d8239925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fbf63d-7106-47d5-97c3-4596d8239925.jpg?1",
             "name": "Retromancer",
             "text": "Whenever Retromancer is the target of a spell or ability, Retromancer deals 3 damage to that spell or ability's controller.",
             "colours": [
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "249a1bd3-02b8-54bf-b657-ac8a517484d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf267c2-c3d5-48ba-93af-dd0af133add3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf267c2-c3d5-48ba-93af-dd0af133add3.jpg?1",
             "name": "Rumbling Crescendo",
             "text": "During your upkeep, you may put a verse counter on Rumbling Crescendo.\no\nR, Sacrifice Rumbling Crescendo: Destroy up to X target lands, where X is the number of verse counters on Rumbling Crescendo.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "8de6121a-8fe5-5f9f-814d-1498d062b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff97d4b-301f-4ade-a6df-2667dff566c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff97d4b-301f-4ade-a6df-2667dff566c2.jpg?1",
             "name": "Scald",
             "text": "Whenever a player taps an island for mana, Scald deals 1 damage to that player.",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "73172f84-7bc2-544f-b4b8-3e644b579d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4175d6e4-98fc-46f6-b549-c13e9f647eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4175d6e4-98fc-46f6-b549-c13e9f647eef.jpg?1",
             "name": "Scoria Wurm",
             "text": "During your upkeep, flip a coin. If you lose the flip, return Scoria Wurm to owner's hand.",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "9355b7a1-552d-584e-9ff5-f836cb20e5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f070430-59d6-462f-9f04-306ffc2ae01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f070430-59d6-462f-9f04-306ffc2ae01b.jpg?1",
             "name": "Scrap",
             "text": "Destroy target artifact.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -7085,7 +7085,7 @@
         },
         {
             "id": "3670d004-4fdc-533d-ac41-d6e38ab73fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f30e-277f-4d8d-ad75-567545a78d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f30e-277f-4d8d-ad75-567545a78d97.jpg?1",
             "name": "Shivan Hellkite",
             "text": "Flying\no1oo\nR Shivan Hellkite deals 1 damage to target creature or player.",
             "colours": [
@@ -7118,7 +7118,7 @@
         },
         {
             "id": "b6a84751-9d94-5d96-b2aa-34e282a6b7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc45153-3cb1-43bc-b694-06f6a74b3eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc45153-3cb1-43bc-b694-06f6a74b3eb7.jpg?1",
             "name": "Shivan Raptor",
             "text": "First strike; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nShivan Raptor is unaffected by summoning sickness.",
             "colours": [
@@ -7151,7 +7151,7 @@
         },
         {
             "id": "cc243b32-e4c7-54bf-bfe4-41c96b40d1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9ba1a3-1de4-4771-b76a-89354bc799d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9ba1a3-1de4-4771-b76a-89354bc799d3.jpg?1",
             "name": "Shiv's Embrace",
             "text": "Enchanted creature gets +2/+2 and gains flying.\noo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "e2e7e36e-7bc4-5054-bedb-1662302121a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428999-a83d-40a5-9753-dfefdf705a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428999-a83d-40a5-9753-dfefdf705a9e.jpg?1",
             "name": "Shower of Sparks",
             "text": "Shower of Sparks deals 1 damage to target creature and 1 damage to target player.",
             "colours": [
@@ -7215,7 +7215,7 @@
         },
         {
             "id": "973848a0-46a2-5854-b5ce-ae822753ed87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07dc95d-82a8-4a58-8ea2-d4513bd7316d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07dc95d-82a8-4a58-8ea2-d4513bd7316d.jpg?1",
             "name": "Sneak Attack",
             "text": "oo\nR Choose a creature card from your hand and put that creature into play. The creature is unaffected by summoning sickness. At end of turn, sacrifice the creature.",
             "colours": [
@@ -7246,7 +7246,7 @@
         },
         {
             "id": "30104f29-8e79-52d4-bcb9-53a5a8fae824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144a1b4e-d960-4c3a-810b-11a0c78635ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144a1b4e-d960-4c3a-810b-11a0c78635ad.jpg?1",
             "name": "Steam Blast",
             "text": "Steam Blast deals 2 damage to each creature and player.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "37eef8e7-c32e-536c-b217-83840bf80444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e133997f-1620-4fe9-8275-057edc998fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e133997f-1620-4fe9-8275-057edc998fba.jpg?1",
             "name": "Sulfuric Vapors",
             "text": "Whenever a red spell deals damage, it instead deals that amount of damage plus 1.",
             "colours": [
@@ -7308,7 +7308,7 @@
         },
         {
             "id": "bbb20d03-831b-56ef-a1c9-3bde08a9ee07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98afd54f-2f86-4694-a688-ce3dcefccdbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98afd54f-2f86-4694-a688-ce3dcefccdbc.jpg?1",
             "name": "Thundering Giant",
             "text": "Thundering Giant is unaffected by summoning sickness.",
             "colours": [
@@ -7341,7 +7341,7 @@
         },
         {
             "id": "8b4d3821-f95b-5ef6-bfec-8722521da984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba8cdf0-492a-4e64-9143-4ccb29ba1d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba8cdf0-492a-4e64-9143-4ccb29ba1d56.jpg?1",
             "name": "Torch Song",
             "text": "During your upkeep, you may put a verse counter on Torch Song.\no2o\nR, Sacrifice Torch Song: Torch Song deals X damage to target creature or player, where X is the number of verse counters on Torch Song.",
             "colours": [
@@ -7372,7 +7372,7 @@
         },
         {
             "id": "90d22cd6-fea2-537b-97aa-1e696d0bbf32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ba659c-7e0f-4d8b-b91c-3c0725102ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ba659c-7e0f-4d8b-b91c-3c0725102ba2.jpg?1",
             "name": "Viashino Outrider",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -7405,7 +7405,7 @@
         },
         {
             "id": "aa480225-6f03-5f0f-85af-41af75e515aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bf72e0-0b0c-4b29-8709-9dcd460508cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bf72e0-0b0c-4b29-8709-9dcd460508cb.jpg?1",
             "name": "Viashino Runner",
             "text": "Viashino Runner cannot be blocked by only one creature.",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "63f5c7c7-6c9f-5de4-aec9-c799c9e078ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0790607f-51b7-40ff-80f9-4f7f5cd2d63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0790607f-51b7-40ff-80f9-4f7f5cd2d63c.jpg?1",
             "name": "Viashino Sandswimmer",
             "text": "oo\nR Flip a coin. If you win the flip, return Viashino Sandswimmer to owner's hand. Otherwise, sacrifice Viashino Sandswimmer.",
             "colours": [
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "75b3290a-1aff-5b8a-ae16-09699d8f39a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def316ed-b080-4d1d-b946-d7a86ebb8ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def316ed-b080-4d1d-b946-d7a86ebb8ad9.jpg?1",
             "name": "Viashino Weaponsmith",
             "text": "Whenever a creature blocks it, Viashino Weaponsmith gets +2/+2 until end of turn.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "acde0081-4dab-5fbf-bcdc-66244b140f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bbb1f6-f3c4-4e11-bb71-91ea31797d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bbb1f6-f3c4-4e11-bb71-91ea31797d1e.jpg?1",
             "name": "Vug Lizard",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nMountainwalk (If defending player controls a mountain, this creature is unblockable.)",
             "colours": [
@@ -7537,7 +7537,7 @@
         },
         {
             "id": "dbe0e385-6624-5458-bd70-22eaa9eab7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d50972-4549-40cd-9c33-4b341333803f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d50972-4549-40cd-9c33-4b341333803f.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands, then Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "95bb8ed4-ad8f-50dc-8ae3-45b0842268f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d051fa-bd3a-4c94-ae41-34d89a7bb77d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d051fa-bd3a-4c94-ae41-34d89a7bb77d.jpg?1",
             "name": "Abundance",
             "text": "Instead of drawing a card, you may choose land or nonland and reveal cards from your library until you reveal a card of the chosen kind. Put that card into your hand and put all other revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -7599,7 +7599,7 @@
         },
         {
             "id": "4d0725a0-0569-537a-a129-7e6669146c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a38f-5a60-46da-af1c-440e4bf7fe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a38f-5a60-46da-af1c-440e4bf7fe9e.jpg?1",
             "name": "Acridian",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "be365d5c-ba26-5a9f-90af-82076e86d9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a3c112-f0c1-4d30-8df6-63fc01356a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a3c112-f0c1-4d30-8df6-63fc01356a4f.jpg?1",
             "name": "Albino Troll",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\no1oo\nG Regenerate Albino Troll.",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "afa60ef9-3d7c-5cb5-ada9-a6ff21465fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be798fd-18c9-45b0-8207-7e5e01c83f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be798fd-18c9-45b0-8207-7e5e01c83f49.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "ccce7178-51cc-503e-8b6f-e636b545e359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453e7cb4-bc37-4932-85b7-3a4e160b73dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453e7cb4-bc37-4932-85b7-3a4e160b73dc.jpg?1",
             "name": "Argothian Elder",
             "text": "oc\nT: Untap two target lands.",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "34cc8c8d-8d09-54ea-a15b-e9b51243f3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ababc1a-515e-4e20-8819-19d84d9b0af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ababc1a-515e-4e20-8819-19d84d9b0af5.jpg?1",
             "name": "Argothian Enchantress",
             "text": "Argothian Enchantress cannot be the target of spells or abilities.\nWhenever you successfully cast an enchantment spell, draw a card.",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "381b8004-aae1-56d8-9366-0b7a82827110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe5e4ec-9c0e-4b1a-b3c6-e9631cf214eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe5e4ec-9c0e-4b1a-b3c6-e9631cf214eb.jpg?1",
             "name": "Argothian Swine",
             "text": "Trample",
             "colours": [
@@ -7799,7 +7799,7 @@
         },
         {
             "id": "2f0d8fcd-bd7a-5f48-b882-acc7eeae22ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93294349-75ae-4a6b-896d-b403a5d69e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93294349-75ae-4a6b-896d-b403a5d69e98.jpg?1",
             "name": "Argothian Wurm",
             "text": "Trample\nWhen Argothian Wurm comes into play, any player may sacrifice a land to put Argothian Wurm on top of owner's library.",
             "colours": [
@@ -7832,7 +7832,7 @@
         },
         {
             "id": "6cea9f1d-3527-5ccb-b0ed-4e3f009769b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f3776-74f4-4626-833b-e1b0921d3cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f3776-74f4-4626-833b-e1b0921d3cbc.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchanted creature gets +X/+X, where X is the number of forests you control.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "1ffd825a-9c8c-580a-a3d7-f5aa2e628189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f824502c-d712-41af-ba44-33e8294c3735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f824502c-d712-41af-ba44-33e8294c3735.jpg?1",
             "name": "Blanchwood Treefolk",
             "text": "",
             "colours": [
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "b9447280-d6a4-51d7-b80d-a4dee792ce4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1f8259-1825-4a46-8026-75adc4480322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1f8259-1825-4a46-8026-75adc4480322.jpg?1",
             "name": "Bull Hippo",
             "text": "Islandwalk (If defending player controls an island, this creature is unblockable.)",
             "colours": [
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "96024a32-b94f-5141-97c0-632526346726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93abb48a-85f2-432d-8602-0a1d17fbb409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93abb48a-85f2-432d-8602-0a1d17fbb409.jpg?1",
             "name": "Carpet of Flowers",
             "text": "During your main phase, you may add up to X mana of one color to your mana pool, where X is the number of islands target opponent controls.",
             "colours": [
@@ -7962,7 +7962,7 @@
         },
         {
             "id": "804db7d6-e913-5073-b7d3-d1842d7e348e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c782eb28-0cdd-4c3d-9d89-8b23c29cddd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c782eb28-0cdd-4c3d-9d89-8b23c29cddd4.jpg?1",
             "name": "Cave Tiger",
             "text": "Whenever a creature blocks it, Cave Tiger gets +1/+1 until end of turn.",
             "colours": [
@@ -7995,7 +7995,7 @@
         },
         {
             "id": "6f076468-3a7f-52d8-bc94-3cf6e12e33b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a836d9bd-a4cb-4676-935c-5fb7b793a42f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a836d9bd-a4cb-4676-935c-5fb7b793a42f.jpg?1",
             "name": "Child of Gaea",
             "text": "Trample\nDuring your upkeep, pay o\nGo\nG or sacrifice Child of Gaea.\no1oo\nG Regenerate Child of Gaea.",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "3548cc81-7b69-5839-bd13-5f72bb784783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac987-7906-4159-a007-ed409baea9d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac987-7906-4159-a007-ed409baea9d7.jpg?1",
             "name": "Citanul Centaurs",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nCitanul Centaurs cannot be the target of spells or abilities.",
             "colours": [
@@ -8061,7 +8061,7 @@
         },
         {
             "id": "400258a2-a267-5b5e-aab5-b56fc023ef41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905506cc-f77e-4214-8eb3-6f141997336c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905506cc-f77e-4214-8eb3-6f141997336c.jpg?1",
             "name": "Citanul Hierophants",
             "text": "Each creature you control gains \"oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.\"",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "49f86319-a5ab-5f4f-a158-1e409c44cd83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b659c1c-cc0b-40f0-87b4-aeddb44dfac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b659c1c-cc0b-40f0-87b4-aeddb44dfac5.jpg?1",
             "name": "Cradle Guard",
             "text": "Trample; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "52414b56-e9a1-58fd-a31f-a6bec52b3c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f182a85b-a119-46e2-8b8b-48b6758d9c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f182a85b-a119-46e2-8b8b-48b6758d9c39.jpg?1",
             "name": "Crosswinds",
             "text": "All creatures with flying get -2/-0.",
             "colours": [
@@ -8159,7 +8159,7 @@
         },
         {
             "id": "1aefc8da-4126-50b0-b4fd-5e8fb4edc174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb2b07e-3d50-4b85-be2a-c99e9c8ebf25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb2b07e-3d50-4b85-be2a-c99e9c8ebf25.jpg?1",
             "name": "Elvish Herder",
             "text": "oo\nG Target creature gains trample until end of turn.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "be1742ec-66e5-5e2f-a2e1-425db2c2867c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c63ea60-4ce0-4dc7-bda6-7f623b0f9e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c63ea60-4ce0-4dc7-bda6-7f623b0f9e2a.jpg?1",
             "name": "Elvish Lyrist",
             "text": "o\nG, oc\nT, Sacrifice Elvish Lyrist: Destroy target enchantment.",
             "colours": [
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "201ad28f-170a-5324-af6b-1d388bb93b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53772435-e20e-4b9e-a2f1-c1c6a4dcac79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53772435-e20e-4b9e-a2f1-c1c6a4dcac79.jpg?1",
             "name": "Endless Wurm",
             "text": "Trample\nDuring your upkeep, sacrifice an enchantment or sacrifice Endless Wurm.",
             "colours": [
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "9dfcc18d-1b2f-5447-8908-0c9836dede1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f09e451-0246-45a2-8bfd-07d3c65ddfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f09e451-0246-45a2-8bfd-07d3c65ddfe6.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land each turn.",
             "colours": [
@@ -8289,7 +8289,7 @@
         },
         {
             "id": "2a663452-6e4e-5c9e-a9b9-a8088b9aa2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c93c11-448c-402d-ac55-8d5ab4c83d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c93c11-448c-402d-ac55-8d5ab4c83d7b.jpg?1",
             "name": "Fecundity",
             "text": "Whenever a creature is put into a graveyard from play, that creature's controller may draw a card.",
             "colours": [
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "6b0608ff-6d32-550a-b6bd-4b246a8976df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091dda35-59e5-456d-8804-61513a610aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091dda35-59e5-456d-8804-61513a610aed.jpg?1",
             "name": "Fertile Ground",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional one mana of any color.",
             "colours": [
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "38c2096e-4d81-5df8-bd42-74945b0c2bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54d5240-8afc-4c61-aaf6-a78d2b92e5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54d5240-8afc-4c61-aaf6-a78d2b92e5c9.jpg?1",
             "name": "Fortitude",
             "text": "When Fortitude is put into a graveyard from play, return Fortitude to owner's hand.\nSacrifice a forest: Regenerate enchanted creature.",
             "colours": [
@@ -8386,7 +8386,7 @@
         },
         {
             "id": "08ac289e-06f1-5529-8361-4817a8b7f3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b55e37-fcad-4d50-89d4-5d88269fee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b55e37-fcad-4d50-89d4-5d88269fee66.jpg?1",
             "name": "Gaea's Bounty",
             "text": "Search your library for up to two forest cards, reveal them, and put them into your hand. Shuffle your library afterward.",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "3e7ad39c-60ad-571c-8a79-ba23cd6f769f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce99456-d7cc-480f-b283-0ba063c89e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce99456-d7cc-480f-b283-0ba063c89e0a.jpg?1",
             "name": "Gaea's Embrace",
             "text": "Enchanted creature gets +3/+3 and gains trample.\noo\nG Regenerate enchanted creature.",
             "colours": [
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "28e1d200-df07-51c9-9824-035866768a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c7e2b0-2df0-4cde-8565-762c93e6c14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c7e2b0-2df0-4cde-8565-762c93e6c14f.jpg?1",
             "name": "Gorilla Warrior",
             "text": "",
             "colours": [
@@ -8484,7 +8484,7 @@
         },
         {
             "id": "544e3686-87a6-5701-ac85-a2dd0ae30343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12befd35-2dc6-4852-a153-75b553042643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12befd35-2dc6-4852-a153-75b553042643.jpg?1",
             "name": "Greater Good",
             "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then choose and discard three cards.",
             "colours": [
@@ -8515,7 +8515,7 @@
         },
         {
             "id": "a6ea320a-0fa9-55af-afcd-171b0c75739a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c3222e-ac18-4f57-9c9e-50deb0a69db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c3222e-ac18-4f57-9c9e-50deb0a69db3.jpg?1",
             "name": "Greener Pastures",
             "text": "During each player's upkeep, if that player controls more lands than any other, the player puts a Saproling token into play under his or her control. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "0a049d8e-2de6-5ac0-a7e0-1a04f40a1aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/842e8c4c-32f3-4ec3-b636-1d7dc9f0023e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/842e8c4c-32f3-4ec3-b636-1d7dc9f0023e.jpg?1",
             "name": "Hawkeater Moth",
             "text": "Flying\nHawkeater Moth cannot be the target of spells or abilities.",
             "colours": [
@@ -8579,7 +8579,7 @@
         },
         {
             "id": "be3c8678-5514-52c3-91ab-b32c8dc8fbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f4f257-c04e-489f-8ffd-814bf075e7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f4f257-c04e-489f-8ffd-814bf075e7d1.jpg?1",
             "name": "Hidden Ancients",
             "text": "When one of your opponents successfully casts an enchantment spell, if Hidden Ancients is an enchantment, Hidden Ancients becomes a 5/5 creature that counts as a Treefolk.",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "c4136601-e02f-5b03-8fe7-665fc5f74da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab16fbb-1542-4ba6-9a06-30806176572c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab16fbb-1542-4ba6-9a06-30806176572c.jpg?1",
             "name": "Hidden Guerrillas",
             "text": "When one of your opponents successfully casts an artifact spell, if Hidden Guerrillas is an enchantment, Hidden Guerrillas becomes a 5/3 creature with trample and that counts as a Soldier.",
             "colours": [
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "c30d8300-6276-5a11-b87f-e63b8107323e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f07992-1f81-440a-a80a-164c44d0a471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f07992-1f81-440a-a80a-164c44d0a471.jpg?1",
             "name": "Hidden Herd",
             "text": "When one of your opponents plays a nonbasic land, if Hidden Herd is an enchantment, Hidden Herd becomes a 3/3 creature that counts as a Beast.",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "c9770b23-09fe-5d11-ba7a-f9bbf8b2b27f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ee86-a576-4f40-b165-be5b4558507d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ee86-a576-4f40-b165-be5b4558507d.jpg?1",
             "name": "Hidden Predators",
             "text": "When one of your opponents controls a creature with power 4 or greater, if Hidden Predators is an enchantment, Hidden Predators becomes a 4/4 creature that counts as a Beast.",
             "colours": [
@@ -8703,7 +8703,7 @@
         },
         {
             "id": "aada2e92-ef12-5c06-ad07-b9d76b6d046b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2640cb-7d0b-40e5-9624-02c64b2f9830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2640cb-7d0b-40e5-9624-02c64b2f9830.jpg?1",
             "name": "Hidden Spider",
             "text": "When one of your opponents successfully casts a creature with flying, if Hidden Spider is an enchantment, Hidden Spider becomes a 3/5 creature that can block creatures with flying and that counts as a Spider.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "727bb8d9-b75f-5b6a-af0c-5b360d45272e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0501e115-ef61-4db5-bdb3-36dc4334431c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0501e115-ef61-4db5-bdb3-36dc4334431c.jpg?1",
             "name": "Hidden Stag",
             "text": "Whenever one of your opponents plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 creature that counts as a Beast.\nWhenever you play a land, if Hidden Stag is a creature, Hidden Stag becomes an enchantment.",
             "colours": [
@@ -8765,7 +8765,7 @@
         },
         {
             "id": "49a26953-b4c4-5f63-882e-45ef102bde31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f01c95-ce9e-4b45-9d15-a5d37100a5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f01c95-ce9e-4b45-9d15-a5d37100a5d8.jpg?1",
             "name": "Hush",
             "text": "Destroy all enchantments.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -8796,7 +8796,7 @@
         },
         {
             "id": "a740c17f-886d-5267-b63e-348c2473887f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec5d627-b3d7-4e11-81c7-bf4cef5409a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec5d627-b3d7-4e11-81c7-bf4cef5409a6.jpg?1",
             "name": "Lull",
             "text": "Creatures deal no combat damage this turn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -8827,7 +8827,7 @@
         },
         {
             "id": "389296c3-06b4-5c28-ab75-eed7419098a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40a7f65-10fe-4ce5-ad1c-be53a635d7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40a7f65-10fe-4ce5-ad1c-be53a635d7a9.jpg?1",
             "name": "Midsummer Revel",
             "text": "During your upkeep, you may put a verse counter on Midsummer Revel.\no\nG, Sacrifice Midsummer Revel: Put X Beast tokens into play, where X is the number of verse counters on Midsummer Revel. Treat these tokens as 3/3 green creatures.",
             "colours": [
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "6dabf774-49f7-5008-992a-abe230f65633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ac6e5-3e46-4290-9683-51d6f54e4edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ac6e5-3e46-4290-9683-51d6f54e4edf.jpg?1",
             "name": "Pouncing Jaguar",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "e64a0425-720d-507e-b756-92ef70bad14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965c33c3-0c68-4516-b8b0-5a0552ed44b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965c33c3-0c68-4516-b8b0-5a0552ed44b6.jpg?1",
             "name": "Priest of Titania",
             "text": "oc\nT: Add o\nG to your mana pool for each Elf in play. Play this ability as a mana source.",
             "colours": [
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "cb566109-bbb3-5ed0-b95e-4825e896d4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3709a3-7a1b-4644-b1d5-e1ffef549f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3709a3-7a1b-4644-b1d5-e1ffef549f94.jpg?1",
             "name": "Rejuvenate",
             "text": "Gain 6 life.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -8956,7 +8956,7 @@
         },
         {
             "id": "6d649980-aca3-5124-a677-aaec8f217381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e3814-5b9f-40da-8205-263fc49294da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e3814-5b9f-40da-8205-263fc49294da.jpg?1",
             "name": "Retaliation",
             "text": "Each creature you control gains \"Whenever a creature blocks it, this creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -8987,7 +8987,7 @@
         },
         {
             "id": "84eb9284-83ee-56c0-9675-23ebbeb70ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839d969b-b1f7-4978-b00c-db0766161f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839d969b-b1f7-4978-b00c-db0766161f63.jpg?1",
             "name": "Sporogenesis",
             "text": "During your upkeep, you may put a fungus counter on target nontoken creature.\nWhenever a creature with a fungus counter on it is put into a graveyard, put a Saproling token into play for each of those fungus counters. Treat these tokens as 1/1 green creatures.\nWhen Sporogenesis leaves play, remove all fungus counters from all creatures.",
             "colours": [
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "df88fc8e-312a-55bb-952f-4802c96f5e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cfc00e-180c-4277-8911-43afa691b9d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cfc00e-180c-4277-8911-43afa691b9d7.jpg?1",
             "name": "Spreading Algae",
             "text": "Play Spreading Algae only on a swamp.\nWhen enchanted land becomes tapped, destroy that land.\nWhen Spreading Algae is put into a graveyard from play, return Spreading Algae to owner's hand.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "72f94d6b-b3dd-5360-a25f-e4cfc996ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d35e2c5-1871-4749-aefa-4a7a69645c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d35e2c5-1871-4749-aefa-4a7a69645c03.jpg?1",
             "name": "Symbiosis",
             "text": "Two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "c80f8654-182a-5053-bf8e-fecb61927a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d64591-8552-4e94-b932-7a23922513a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d64591-8552-4e94-b932-7a23922513a1.jpg?1",
             "name": "Titania's Boon",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "4b7563c3-9203-55dc-adf3-f59f2b757322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9450340-2c29-4573-8da2-0d3cae9759c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9450340-2c29-4573-8da2-0d3cae9759c1.jpg?1",
             "name": "Titania's Chosen",
             "text": "Whenever a player successfully casts a green spell, put a +1/+1 counter on Titania's Chosen.",
             "colours": [
@@ -9147,7 +9147,7 @@
         },
         {
             "id": "562eff23-da8d-593a-9301-750c20220e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec5ee47-c2ef-442d-b1e7-323a8dba6627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec5ee47-c2ef-442d-b1e7-323a8dba6627.jpg?1",
             "name": "Treefolk Seedlings",
             "text": "Treefolk Seedlings has toughness equal to the number of forests you control.",
             "colours": [
@@ -9180,7 +9180,7 @@
         },
         {
             "id": "a25ba444-db50-58f4-b892-735894a84d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f1a343-250b-4a30-a3b5-296282a70446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f1a343-250b-4a30-a3b5-296282a70446.jpg?1",
             "name": "Treetop Rangers",
             "text": "Treetop Rangers cannot be blocked except by creatures with flying.",
             "colours": [
@@ -9214,7 +9214,7 @@
         },
         {
             "id": "8b3fa1c1-2213-5cf5-a1f6-0bda9871c652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ae1348-c063-4ec8-9d8c-3d19a6421800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ae1348-c063-4ec8-9d8c-3d19a6421800.jpg?1",
             "name": "Venomous Fangs",
             "text": "Whenever enchanted creature successfully deals damage to a creature, destroy that creature.",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "41ea46f1-d86c-5776-8ecf-ae6e7526ef36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a49c80-02ee-4d5a-83cb-53ac3e7870e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a49c80-02ee-4d5a-83cb-53ac3e7870e7.jpg?1",
             "name": "Vernal Bloom",
             "text": "Whenever a forest is tapped for mana, it produces an additional o\nG.",
             "colours": [
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "f352aae5-98fe-5d1c-8ca1-77724f1ff6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392b4acf-4548-47dd-be58-bdf4ca4ece7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392b4acf-4548-47dd-be58-bdf4ca4ece7e.jpg?1",
             "name": "War Dance",
             "text": "During your upkeep, you may put a verse counter on War Dance.\nSacrifice War Dance: Target creature gets +X/+X until end of turn, where X is the number of verse counters on War Dance.",
             "colours": [
@@ -9309,7 +9309,7 @@
         },
         {
             "id": "8b760662-8e29-52e5-937f-bef25579c81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8101bab4-ef93-451a-a24f-e1456c82837c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8101bab4-ef93-451a-a24f-e1456c82837c.jpg?1",
             "name": "Whirlwind",
             "text": "Destroy all creatures with flying.",
             "colours": [
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "ce47414f-fd26-53a2-ab66-275606f77584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7811e2-8bff-44a9-96bf-8e302c3cade9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7811e2-8bff-44a9-96bf-8e302c3cade9.jpg?1",
             "name": "Wild Dogs",
             "text": "During your upkeep, if a player has more life than any other, that player gains control of Wild Dogs.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "307bc8f4-aa73-54ae-8854-ab7fe0201edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed75dc43-172c-4302-8807-23bfdd65baf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed75dc43-172c-4302-8807-23bfdd65baf4.jpg?1",
             "name": "Winding Wurm",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -9406,7 +9406,7 @@
         },
         {
             "id": "6573b089-3eba-5f2d-96a4-bac36d486392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951b225-f11e-41bd-ab6e-e1fda957dff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951b225-f11e-41bd-ab6e-e1fda957dff3.jpg?1",
             "name": "Barrin's Codex",
             "text": "During your upkeep, you may put a page counter on Barrin's Codex.\no4, oc\nT, Sacrifice Barrin's Codex: Draw X cards, where X is the number of page counters on Barrin's Codex.",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "9180f96a-119e-5a3f-b64d-10d99a97c9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28def495-1806-40ec-b170-ca727c914f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28def495-1806-40ec-b170-ca727c914f30.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion is put into a graveyard from play, add three colorless mana to your mana pool.",
             "colours": [],
@@ -9463,7 +9463,7 @@
         },
         {
             "id": "f334e38b-3c54-5dba-8905-7e0c7e608243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c228b-8339-49d1-af0c-05e7d7ba4c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c228b-8339-49d1-af0c-05e7d7ba4c9d.jpg?1",
             "name": "Chimeric Staff",
             "text": "oo\nX Chimeric Staff is an artifact creature with power and toughness each equal to X until end of turn.",
             "colours": [],
@@ -9490,7 +9490,7 @@
         },
         {
             "id": "615b0cea-4ff1-5b2c-93e3-fe632a716d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf71fab2-d936-40f0-bda2-b0630948e1fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf71fab2-d936-40f0-bda2-b0630948e1fa.jpg?1",
             "name": "Citanul Flute",
             "text": "o\nX, oc\nT: Search your library for a creature card with total casting cost no greater than X. Reveal that card and put it into your hand. Shuffle your library afterward.",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "780fcb27-61ea-5c16-abe1-15d192f8e8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78372366-8c4c-46ac-bd7c-a735c2b24b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78372366-8c4c-46ac-bd7c-a735c2b24b5d.jpg?1",
             "name": "Claws of Gix",
             "text": "o1, Sacrifice a permanent: Gain 1 life.",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "bad13c3d-2502-5761-a0c0-5b638211abe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e326b7-6f6a-4249-a315-c5f017931c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e326b7-6f6a-4249-a315-c5f017931c73.jpg?1",
             "name": "Copper Gnomes",
             "text": "o4, Sacrifice Copper Gnomes: Choose an artifact card in your hand and put that artifact into play.",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "30456b17-9b92-5c2e-a3c5-c677438a6a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d03d54-7aa4-4586-bb4b-8a5d269fe289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d03d54-7aa4-4586-bb4b-8a5d269fe289.jpg?1",
             "name": "Crystal Chimes",
             "text": "o3, oc\nT, Sacrifice Crystal Chimes: Return all enchantment cards from your graveyard to your hand.",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "afa13967-41f0-5d6e-b04e-0a6bf2c67aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff72806a-ae41-44f5-ad74-56c3338ebfcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff72806a-ae41-44f5-ad74-56c3338ebfcb.jpg?1",
             "name": "Dragon Blood",
             "text": "o3, oc\nT: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -9628,7 +9628,7 @@
         },
         {
             "id": "27c65442-445a-5aa9-ac49-4185654f4672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4630c3-bf8e-46ac-be68-f454c4ca1047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4630c3-bf8e-46ac-be68-f454c4ca1047.jpg?1",
             "name": "Endoskeleton",
             "text": "You may choose not to untap Endoskeleton during your untap phase.\no2, oc\nT: Target creature gets +0/+3 as long as Endoskeleton remains tapped.",
             "colours": [],
@@ -9655,7 +9655,7 @@
         },
         {
             "id": "a918ac63-684d-5bd0-a960-18b7122dd317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92078408-e0e4-443e-b0fd-aac0ac651f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92078408-e0e4-443e-b0fd-aac0ac651f46.jpg?1",
             "name": "Fluctuator",
             "text": "Cycling costs you up to o2 less to play.",
             "colours": [],
@@ -9682,7 +9682,7 @@
         },
         {
             "id": "c45ab4bf-0791-597d-b5ab-bbae0c8524ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8424e6-4a92-4be3-b69e-49ac9a736f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8424e6-4a92-4be3-b69e-49ac9a736f94.jpg?1",
             "name": "Grafted Skullcap",
             "text": "During your draw phase, draw an additional card.\nAt the end of each of your turns, discard your hand.",
             "colours": [],
@@ -9709,7 +9709,7 @@
         },
         {
             "id": "a310c646-e697-54cd-960e-494357ccc32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4717b6c3-9fba-454f-9d02-e8c2869c4450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4717b6c3-9fba-454f-9d02-e8c2869c4450.jpg?1",
             "name": "Hopping Automaton",
             "text": "o0: Hopping Automaton gets -1/-1 and gains flying until end of turn.",
             "colours": [],
@@ -9739,7 +9739,7 @@
         },
         {
             "id": "57eb2889-d0f8-5ab5-9705-6b23ef180ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a0988-2900-426c-9413-8f1778d99678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a0988-2900-426c-9413-8f1778d99678.jpg?1",
             "name": "Karn, Silver Golem",
             "text": "Whenever Karn, Silver Golem blocks or becomes blocked, it gets -4/+4 until end of turn.\no1: Target noncreature artifact is an artifact creature with power and toughness each equal to its casting cost until end of turn. (That artifact retains its abilities.)",
             "colours": [],
@@ -9771,7 +9771,7 @@
         },
         {
             "id": "9e977384-5e05-572a-ae9e-43d23471e570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee82f-36b2-48a9-930a-8e23cb2742fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee82f-36b2-48a9-930a-8e23cb2742fc.jpg?1",
             "name": "Lifeline",
             "text": "Whenever a creature is put into a graveyard and a creature is in play, return that creature from your graveyard to play at end of turn.",
             "colours": [],
@@ -9798,7 +9798,7 @@
         },
         {
             "id": "956a3936-6003-5938-8e5a-3402adbad65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d17e0a-5407-4fde-8eb0-8f580eab5565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d17e0a-5407-4fde-8eb0-8f580eab5565.jpg?1",
             "name": "Lotus Blossom",
             "text": "During your upkeep, you may put a petal counter on Lotus Blossom.\noc\nT, Sacrifice Lotus Blossom: Add X mana of one color to your mana pool, where X is the number of petal counters on Lotus Blossom. Play this ability as a mana source.",
             "colours": [],
@@ -9825,7 +9825,7 @@
         },
         {
             "id": "204bd054-0ef6-5332-bbba-17c048bae9bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71f153d-2d07-4a8a-b725-747bb96afe00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71f153d-2d07-4a8a-b725-747bb96afe00.jpg?1",
             "name": "Metrognome",
             "text": "When a spell or ability one of your opponents controls causes you to discard Metrognome, put four Gnome tokens into play. Treat these tokens as 1/1 artifact creatures.\no4, oc\nT: Put a Gnome token into play. Treat this token as a 1/1 artifact creature.",
             "colours": [],
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "b919d4a3-998d-5c32-a86a-3ec5b6630349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62507f-465d-45e9-96bf-06671d19e79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62507f-465d-45e9-96bf-06671d19e79e.jpg?1",
             "name": "Mishra's Helix",
             "text": "o\nX, oc\nT: Tap X lands.",
             "colours": [],
@@ -9879,7 +9879,7 @@
         },
         {
             "id": "1d02db4a-12c1-53cd-8162-bd23a99b0ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f642246-5b2a-46a6-9236-524a297d7608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f642246-5b2a-46a6-9236-524a297d7608.jpg?1",
             "name": "Mobile Fort",
             "text": "Mobile Fort counts as a Wall. (Walls cannot attack.)\no3: Mobile Fort gets +3/-1 until end of turn and can attack this turn as though it were not a Wall. Play this ability only once each turn.",
             "colours": [],
@@ -9909,7 +9909,7 @@
         },
         {
             "id": "42c00b33-1fda-5684-9da9-53613e053474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18506777-cd69-42f6-99c9-cde9b0958868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18506777-cd69-42f6-99c9-cde9b0958868.jpg?1",
             "name": "Noetic Scales",
             "text": "During each player's upkeep, return to owner's hand each creature that player controls with power greater than the number of cards in his or her hand.",
             "colours": [],
@@ -9936,7 +9936,7 @@
         },
         {
             "id": "831af3cb-ab43-5b94-9561-e28ff38617ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0ba37a-ce52-4c01-89aa-25e90cda04ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0ba37a-ce52-4c01-89aa-25e90cda04ba.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "Phyrexian Colossus does not untap during your untap phase.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus cannot be blocked by fewer than three creatures.",
             "colours": [],
@@ -9967,7 +9967,7 @@
         },
         {
             "id": "017935cd-fac7-52a6-8752-0a3b20336e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6875ce99-badd-44da-8e5d-509600efa1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6875ce99-badd-44da-8e5d-509600efa1d0.jpg?1",
             "name": "Phyrexian Processor",
             "text": "When Phyrexian Processor comes into play, pay any amount of life.\no4, oc\nT: Put a Minion token into play. Treat this token as a black creature with power and toughness each equal to the amount of life paid at the time Phyrexian Processor came into play.",
             "colours": [],
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "edbd86e1-581d-55ec-92ee-966a59a85ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2003c1-356b-4714-9a2a-4e12f782321e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2003c1-356b-4714-9a2a-4e12f782321e.jpg?1",
             "name": "Pit Trap",
             "text": "o2, oc\nT, Sacrifice Pit Trap: Destroy target attacking creature without flying. That creature cannot be regenerated this turn.",
             "colours": [],
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "8317e2cc-8c3b-5f46-a442-e50ccb00d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef8128a-e0f5-43d6-b7bd-3f2003d83eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef8128a-e0f5-43d6-b7bd-3f2003d83eab.jpg?1",
             "name": "Purging Scythe",
             "text": "During your upkeep, Purging Scythe deals 2 damage to the creature with the lowest toughness. If two or more creatures are tied for the lowest toughness, you decide to which creature Purging Scythe deals damage.",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "3ea9b8c9-06b8-5612-8066-feed09b4a787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a37ab2d-094f-431e-878f-93aef0360413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a37ab2d-094f-431e-878f-93aef0360413.jpg?1",
             "name": "Smokestack",
             "text": "During your upkeep, you may put a soot counter on Smokestack.\nDuring each player's upkeep, that player sacrifices a permanent for each soot counter on Smokestack.",
             "colours": [],
@@ -10075,7 +10075,7 @@
         },
         {
             "id": "aafe78b9-ee71-5c17-b486-41a334a4720b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5c2555-c707-4814-933a-c275b9ebc0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5c2555-c707-4814-933a-c275b9ebc0a3.jpg?1",
             "name": "Temporal Aperture",
             "text": "o5, oc\nT: Shuffle your library and reveal the top card. Until end of turn, as long as that card remains on top of your library, you may play the card as though it were in your hand without paying its casting cost. (If the spell has o\nX in its casting cost, X is 0.)",
             "colours": [],
@@ -10102,7 +10102,7 @@
         },
         {
             "id": "1d82bdaf-7b47-5ec8-b790-0505515f3740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c310f-b50d-4993-9add-9f585f6172af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c310f-b50d-4993-9add-9f585f6172af.jpg?1",
             "name": "Thran Turbine",
             "text": "During your upkeep, you may add up to two colorless mana to your mana pool. This mana cannot be spent to play spells.",
             "colours": [],
@@ -10129,7 +10129,7 @@
         },
         {
             "id": "06640751-e51c-5fcb-b704-671f212a133d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a6db88-a11d-49b4-8692-28b24d23f3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a6db88-a11d-49b4-8692-28b24d23f3c7.jpg?1",
             "name": "Umbilicus",
             "text": "During each player's upkeep, that player pays 2 life or returns a permanent he or she controls to owner's hand.",
             "colours": [],
@@ -10156,7 +10156,7 @@
         },
         {
             "id": "5d4f63fe-cd95-584a-8cba-c2cdca8ca42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901d78-e8fb-4adf-bafe-99a567a375c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901d78-e8fb-4adf-bafe-99a567a375c1.jpg?1",
             "name": "Urza's Armor",
             "text": "Whenever a source deals damage to you, that damage is reduced by 1.",
             "colours": [],
@@ -10183,7 +10183,7 @@
         },
         {
             "id": "28e105a4-4c5b-53b9-b5c6-2bacf6525210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4baf7-4693-4c55-af04-2fa5d901d701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4baf7-4693-4c55-af04-2fa5d901d701.jpg?1",
             "name": "Voltaic Key",
             "text": "o1, oc\nT: Untap target artifact.",
             "colours": [],
@@ -10210,7 +10210,7 @@
         },
         {
             "id": "46990671-7961-597f-8d28-4397bde4d088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3f88b3-9796-4d4d-af8b-543f0d280e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3f88b3-9796-4d4d-af8b-543f0d280e77.jpg?1",
             "name": "Wall of Junk",
             "text": "Whenever Wall of Junk blocks, return it to owner's hand at end of combat.",
             "colours": [],
@@ -10240,7 +10240,7 @@
         },
         {
             "id": "11056bc1-5339-58a3-b279-33f10be9f713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627805a0-535f-4cba-8176-a4de290b9c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627805a0-535f-4cba-8176-a4de290b9c15.jpg?1",
             "name": "Whetstone",
             "text": "o3: Each player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -10267,7 +10267,7 @@
         },
         {
             "id": "2ec7c905-3180-5130-8eb6-c893b4ef4262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6333d686-58ec-4360-8929-9f7302f9a09c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6333d686-58ec-4360-8929-9f7302f9a09c.jpg?1",
             "name": "Wirecat",
             "text": "Wirecat cannot attack or block if an enchantment is in play.",
             "colours": [],
@@ -10297,7 +10297,7 @@
         },
         {
             "id": "90c12fc9-1c39-53b8-8f5a-26bc9461fb65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2224d7ef-2e2f-47dd-a4a0-e36b3170b124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2224d7ef-2e2f-47dd-a4a0-e36b3170b124.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone comes into play tapped.\noc\nT: Add two colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "d94ac6e6-74ff-5f78-9b68-6bc50d7c2e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71d910-6c50-4894-8092-d39cbb7a83b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71d910-6c50-4894-8092-d39cbb7a83b4.jpg?1",
             "name": "Blasted Landscape",
             "text": "oc\nT: Add one colorless mana to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "7cded439-dfb5-523f-be91-10c6ac3ce48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f669f7-0b36-4c82-8e32-15314ec0c0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f669f7-0b36-4c82-8e32-15314ec0c0c4.jpg?1",
             "name": "Drifting Meadow",
             "text": "Drifting Meadow comes into play tapped.\noc\nT: Add o\nW to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10380,7 +10380,7 @@
         },
         {
             "id": "aca602fa-8308-5f6f-8f45-9367ffcdc4d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1",
             "name": "Gaea's Cradle",
             "text": "oc\nT: Add o\nG to your mana pool for each creature you control.",
             "colours": [],
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "a103086b-802c-5f24-bb32-dfc97bbb90fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f915cf0-6273-4896-bf24-fb0ec17b6096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f915cf0-6273-4896-bf24-fb0ec17b6096.jpg?1",
             "name": "Phyrexian Tower",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice a creature: Add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -10442,7 +10442,7 @@
         },
         {
             "id": "2d6a1039-b936-5aa0-83f7-396278d81e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe2c562-ac25-4395-a9f0-8b246c7954b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe2c562-ac25-4395-a9f0-8b246c7954b6.jpg?1",
             "name": "Polluted Mire",
             "text": "Polluted Mire comes into play tapped.\noc\nT: Add o\nB to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10471,7 +10471,7 @@
         },
         {
             "id": "25e97ed8-9118-5011-a81e-38f9f92d182e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48d55ff-10d0-4d9b-9202-02ebb2137953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48d55ff-10d0-4d9b-9202-02ebb2137953.jpg?1",
             "name": "Remote Isle",
             "text": "Remote Isle comes into play tapped.\noc\nT: Add o\nU to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10500,7 +10500,7 @@
         },
         {
             "id": "23cf163e-bcef-5613-bcbb-864e2e77825b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a18130-dbaa-4657-a885-3a96a985935a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a18130-dbaa-4657-a885-3a96a985935a.jpg?1",
             "name": "Serra's Sanctum",
             "text": "oc\nT: Add o\nW to your mana pool for each enchantment you control.",
             "colours": [],
@@ -10531,7 +10531,7 @@
         },
         {
             "id": "76548380-18b5-57da-b7f7-e9084bbe336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531eb8c-af8a-45c6-9058-3337c44e609f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531eb8c-af8a-45c6-9058-3337c44e609f.jpg?1",
             "name": "Shivan Gorge",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2o\nR, oc\nT: Shivan Gorge deals 1 damage to each of your opponents.",
             "colours": [],
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "b5aea189-5877-522e-824c-65c2cf2d35c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d01a6a7-c006-4fce-a546-8138baef421b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d01a6a7-c006-4fce-a546-8138baef421b.jpg?1",
             "name": "Slippery Karst",
             "text": "Slippery Karst comes into play tapped.\noc\nT: Add o\nG to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "bd7c9e76-51ca-584b-9a82-16b9f257754a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9940ce4-09d7-4e89-b456-e3126a83cfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9940ce4-09d7-4e89-b456-e3126a83cfe1.jpg?1",
             "name": "Smoldering Crater",
             "text": "Smoldering Crater comes into play tapped.\noc\nT: Add o\nR to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10620,7 +10620,7 @@
         },
         {
             "id": "3dbd84e5-7ef4-5e48-8e46-f23940758db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2d6c41-7d82-4062-a783-37d88536279c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2d6c41-7d82-4062-a783-37d88536279c.jpg?1",
             "name": "Thran Quarry",
             "text": "At the end of each turn, if you control no creatures, sacrifice Thran Quarry.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10647,7 +10647,7 @@
         },
         {
             "id": "5a757133-8ef9-5ffa-afe9-4ff0f5ebd548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7ac9a5-340f-4509-826c-7b9416d47887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7ac9a5-340f-4509-826c-7b9416d47887.jpg?1",
             "name": "Tolarian Academy",
             "text": "oc\nT: Add o\nU to your mana pool for each artifact you control.",
             "colours": [],
@@ -10678,7 +10678,7 @@
         },
         {
             "id": "566fb554-5412-50b2-8563-20e3b88a3443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e35567-05df-4a3f-8c29-d8327abc2e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e35567-05df-4a3f-8c29-d8327abc2e8d.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10715,7 +10715,7 @@
         },
         {
             "id": "57bd34f7-317e-517c-8143-51c9cd3b3cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34ef351-2864-42f6-8943-75bb6fffc9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34ef351-2864-42f6-8943-75bb6fffc9f7.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10752,7 +10752,7 @@
         },
         {
             "id": "8b1cdc8a-763a-59ed-9443-cdf2ebd270cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54db7822-ebed-4c7c-8ede-469d72fd694a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54db7822-ebed-4c7c-8ede-469d72fd694a.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10789,7 +10789,7 @@
         },
         {
             "id": "51ed2a66-b091-5e69-a513-8574bad7d25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f87b5c-78b4-443c-ad92-f37bb62d0bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f87b5c-78b4-443c-ad92-f37bb62d0bbe.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10826,7 +10826,7 @@
         },
         {
             "id": "0679ec70-fd3f-52ff-8e7c-14f685353db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4ce9ff-c295-475b-b9fa-88ed65a84f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4ce9ff-c295-475b-b9fa-88ed65a84f35.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10863,7 +10863,7 @@
         },
         {
             "id": "a5780572-29d8-52b7-a551-bdf30160cbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf69bc5-8ee3-4b17-a3b1-51e35dd2d0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf69bc5-8ee3-4b17-a3b1-51e35dd2d0dc.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10900,7 +10900,7 @@
         },
         {
             "id": "19254d0b-971b-508e-92bd-9a4608da2d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92724530-9c7a-44ab-9381-ee56bfccb641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92724530-9c7a-44ab-9381-ee56bfccb641.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "5bbd9f9e-fa99-5c25-b86f-10fe7c49ae90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43297ca7-846c-4bc4-a347-997279bc73d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43297ca7-846c-4bc4-a347-997279bc73d6.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10974,7 +10974,7 @@
         },
         {
             "id": "fa45a692-879d-567d-8477-c2e5ef4cf3ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04dac6d-a7c2-44ee-b735-bd4eade06e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04dac6d-a7c2-44ee-b735-bd4eade06e4e.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11011,7 +11011,7 @@
         },
         {
             "id": "70c732bd-81ac-5bcb-ae41-d86af16484eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a97cc92-6894-4c6f-8c8d-bfc9fdd4f974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a97cc92-6894-4c6f-8c8d-bfc9fdd4f974.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11048,7 +11048,7 @@
         },
         {
             "id": "9e16e053-eb3d-527d-8acb-f3679a96db8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d1102-0ad5-40df-9ca2-26448321d3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d1102-0ad5-40df-9ca2-26448321d3d1.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11085,7 +11085,7 @@
         },
         {
             "id": "61696d33-7e28-5d01-9599-383c5c5af12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f24df7-65c6-4488-967a-e847bdec7db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f24df7-65c6-4488-967a-e847bdec7db0.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11122,7 +11122,7 @@
         },
         {
             "id": "165a01bb-4136-55d8-b375-256394a508af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d34a2f-09ed-4fb4-891a-890f450699bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d34a2f-09ed-4fb4-891a-890f450699bd.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11159,7 +11159,7 @@
         },
         {
             "id": "9f273661-1a4f-5190-abf3-b0958635198f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be7e4b30-7f45-4109-b5ed-9223a9422d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be7e4b30-7f45-4109-b5ed-9223a9422d95.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11196,7 +11196,7 @@
         },
         {
             "id": "ed88aee7-f619-5b56-a563-522922c7fdb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d811021-40b1-43b1-88f1-04d711c2ab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d811021-40b1-43b1-88f1-04d711c2ab57.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11233,7 +11233,7 @@
         },
         {
             "id": "41f55faa-3e44-50b3-8315-a64c260ca79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b39c91-e367-487d-9820-893870df23b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b39c91-e367-487d-9820-893870df23b1.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "facd71a4-bd47-5062-9bb4-ecf7b020cd70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38c68a5-86eb-4fb2-8a43-4a7d63195462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38c68a5-86eb-4fb2-8a43-4a7d63195462.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11307,7 +11307,7 @@
         },
         {
             "id": "dfbc3eca-eab8-5025-a8d7-d79510256346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c151d945-7da0-4ab8-b0db-e41d10c0eb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c151d945-7da0-4ab8-b0db-e41d10c0eb91.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "85413a85-8717-567f-9136-84a4c5d1c148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8990632-f055-4583-ae85-5ac742549b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8990632-f055-4583-ae85-5ac742549b61.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11381,7 +11381,7 @@
         },
         {
             "id": "4366df09-610d-5509-bb9d-93fb2d06cbe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b43815e-8b8a-4745-bdf3-f72c8d60c48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b43815e-8b8a-4745-bdf3-f72c8d60c48c.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/Assets/Resources/Sets/UST.json
+++ b/Assets/Resources/Sets/UST.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "954658ae-c7f7-55b0-b96d-33db85205302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2729cce6-f380-4c94-ac64-3a2487da6130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2729cce6-f380-4c94-ac64-3a2487da6130.jpg?1",
             "name": "Adorable Kitten",
             "text": "When this creature enters the battlefield, roll a six-sided die. You gain life equal to the result.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "756ec740-7f4c-5447-8f18-8332010d7f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7290b56-22c2-4905-8add-0550a12db082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7290b56-22c2-4905-8add-0550a12db082.jpg?1",
             "name": "Aerial Toastmaster",
             "text": "Flying\n{3}{W}, Sacrifice another artifact: Aerial Toastmaster assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "cc53cc02-6a60-5314-b3bb-36c31518f0f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426dc98-daae-4785-8384-d2b2dc2bbaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426dc98-daae-4785-8384-d2b2dc2bbaad.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -114,7 +114,7 @@
         },
         {
             "id": "22dc8b2a-f053-5a83-a1f0-f14c41715dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd9d460-733f-44e5-a174-98b5636dc13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd9d460-733f-44e5-a174-98b5636dc13c.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -152,7 +152,7 @@
         },
         {
             "id": "76a3d519-7687-52d5-a91b-ef9de2845264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b77675-cf32-477f-8fdb-cbfa99c6de17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b77675-cf32-477f-8fdb-cbfa99c6de17.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -190,7 +190,7 @@
         },
         {
             "id": "52f5fb21-1e01-52e5-a19a-df0363b9b97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4f6-91e2-40fd-8fef-bb4deca39b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4f6-91e2-40fd-8fef-bb4deca39b15.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "e370fd66-6838-5b25-8aa1-2f94fc25aa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6921466-edac-40fc-8f5e-d8b2e766d1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6921466-edac-40fc-8f5e-d8b2e766d1dd.jpg?1",
             "name": "By Gnome Means",
             "text": "{1}{W}, Remove a counter from a permanent you control: Create a 1/1 colorless Gnome artifact creature token.\n{1}{W}, Sacrifice an artifact: Choose any kind of counter a printed card refers to, then put one of that counter on target permanent.",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "6d3f1dcd-4d69-5d17-a214-d3d0b1c56931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94393ae5-5cae-4818-aed4-3a6b7c3eba76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94393ae5-5cae-4818-aed4-3a6b7c3eba76.jpg?1",
             "name": "Chivalrous Chevalier",
             "text": "Flying\nWhen Chivalrous Chevalier enters the battlefield, return a creature you control to its owner's hand unless you compliment an opponent.",
             "colours": [
@@ -296,7 +296,7 @@
         },
         {
             "id": "0bc59408-6985-5be3-8024-b129a12f3e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f4e8c-6519-4b35-b7b5-54a4c4e32c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f4e8c-6519-4b35-b7b5-54a4c4e32c18.jpg?1",
             "name": "Do-It-Yourself Seraph",
             "text": "Flying\nWhenever Do-It-Yourself Seraph attacks, you may search your library for an artifact card, exile it, then shuffle your library.\nDo-It-Yourself Seraph has the text box of each card exiled with Do-It-Yourself Seraph in addition to its own.",
             "colours": [
@@ -332,7 +332,7 @@
         },
         {
             "id": "ed181229-d92a-5f9f-b905-bc3266b30b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587ddc67-99ac-490d-93e1-e90a72b55ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587ddc67-99ac-490d-93e1-e90a72b55ade.jpg?1",
             "name": "Gimme Five",
             "text": "You gain 1 life for each person who high-fives you in the next thirty seconds. Each player in a silver-bordered game who high-fives you gains 1 life. (Offer high fives. Don't hit people.)",
             "colours": [
@@ -364,7 +364,7 @@
         },
         {
             "id": "24506898-4d8f-5714-8493-057e09d70fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b86826-307b-499b-92a4-a2de0839dc47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b86826-307b-499b-92a4-a2de0839dc47.jpg?1",
             "name": "GO TO JAIL",
             "text": "When GO TO JAIL enters the battlefield, exile target creature an opponent controls until GO TO JAIL leaves the battlefield.\nAt the beginning of the upkeep of the exiled card's owner, that player rolls two six-sided dice. If he or she rolls doubles, sacrifice GO TO JAIL.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "182a17b1-06b5-58f1-9c82-22b15be3ac7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0053e1-96c7-40cd-84b2-b213195199c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0053e1-96c7-40cd-84b2-b213195199c9.jpg?1",
             "name": "Half-Kitten, Half-",
             "text": "Whenever you're dealt damage,\nAugment {2}{W} ({2}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "523ff187-2970-5b7e-8397-a33a7e0cdd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e1f7bd-972a-4e76-93eb-8c8acfa6ec43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e1f7bd-972a-4e76-93eb-8c8acfa6ec43.jpg?1",
             "name": "Humming-",
             "text": "Flying\nWhenever you attack with two or more creatures,\nAugment {3}{W} ({3}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -464,7 +464,7 @@
         },
         {
             "id": "dc28f942-cf45-5c7b-8152-2428d6814d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d84953b-c59c-45f8-aedd-e68bff7c7ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d84953b-c59c-45f8-aedd-e68bff7c7ce3.jpg?1",
             "name": "Jackknight",
             "text": "Whenever another artifact enters the battlefield under your control, put a +1/+1 counter on Jackknight. If that artifact is a Contraption, Jackknight gains lifelink until end of turn.",
             "colours": [
@@ -500,7 +500,7 @@
         },
         {
             "id": "84983ebf-3ea9-50a7-8b6d-2e75111beeab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c98931-cad7-4cea-97eb-f5e233ab2b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c98931-cad7-4cea-97eb-f5e233ab2b36.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from black borders (Nothing with a black border can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "034884b5-f125-57e3-9676-5365f644096a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa78eb3f-cf10-4827-ab37-53383596c7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa78eb3f-cf10-4827-ab37-53383596c7f4.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from even collector numbers (Nothing with an even collector number can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "7d8d2bf3-3bcd-5776-98d6-a862c6240320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b50cba-faa4-4847-90af-6fc20f62843e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b50cba-faa4-4847-90af-6fc20f62843e.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from loose lips (Nothing with an open mouth in its artwork can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "af9b8c51-3ae2-5de8-b8a4-d511c6ab0bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e3bd17-9928-4e7e-8f68-051aae75725e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e3bd17-9928-4e7e-8f68-051aae75725e.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from odd collector numbers (Nothing with an odd collector number can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "d35ab476-cf46-5c01-8fdb-f33f3caf0acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06b6fb8-27fc-4d5b-92b2-1a6a5005a262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06b6fb8-27fc-4d5b-92b2-1a6a5005a262.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from two-word names (Nothing with exactly two words in its name can block, target, deal damage to, or attach to this creature. Hyphenated words are one word.)",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "d36fe96d-cde0-5dc8-a429-68db67e3f84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d81180a-71c8-403f-90c0-48daf81e43a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d81180a-71c8-403f-90c0-48daf81e43a1.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from watermarks (Nothing with a watermark can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "31f945ff-0831-5da9-b9e5-3005e30931dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012cae92-bb03-48bc-9e34-01be54405f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012cae92-bb03-48bc-9e34-01be54405f74.jpg?1",
             "name": "Knight of the Widget",
             "text": "Vigilance\nKnight of the Widget's power and toughness are each equal to the number of Order of the Widget watermarks among permanents you control.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "2826798a-ea8a-568f-a996-1ff9925039ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6e37a1-0dfd-4b8a-83d1-8f6d99123516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6e37a1-0dfd-4b8a-83d1-8f6d99123516.jpg?1",
             "name": "Midlife Upgrade",
             "text": "As an additional cost to cast Midlife Upgrade, sacrifice X Contraptions.\nAssemble X plus one Contraptions. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "a67a5b16-afc8-5bf7-9ab1-95bdc2aea6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d5f87-1c8b-414a-a91e-4805f5bdca54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d5f87-1c8b-414a-a91e-4805f5bdca54.jpg?1",
             "name": "Oddly Uneven",
             "text": "Choose one \u2014\n\u2022 Destroy each creature with an odd number of words in its name. (Hyphenated words are one word.)\n\u2022 Destroy each creature with an even number of words in its name.",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "8412fbe8-b471-5d69-b310-e7c08055458b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06081fa-857f-40b3-8041-257d5c5457bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06081fa-857f-40b3-8041-257d5c5457bd.jpg?1",
             "name": "Old Guard",
             "text": "{W}, {T}: Tap target creature without reminder text. (Reminder text is still any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "e63d96af-f9ec-5b35-adcb-2e7c729a68ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d79ba7e-82a8-44ec-b72d-3cdd81126bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d79ba7e-82a8-44ec-b72d-3cdd81126bfa.jpg?1",
             "name": "Ordinary Pony",
             "text": "When this creature enters the battlefield, you may exile target non-Horse creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -924,7 +924,7 @@
         },
         {
             "id": "c2c51a25-5213-5f5a-a54e-b8f131ce00ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c56df0-3f4d-489d-90c2-e9574f50929a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c56df0-3f4d-489d-90c2-e9574f50929a.jpg?1",
             "name": "Rhino-",
             "text": "Whenever this creature blocks,\nAugment {3}{W} ({3}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "babdcaec-c896-5923-8700-b6866cae96e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcd4ec-d3bc-4aeb-824d-dc79543f8700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcd4ec-d3bc-4aeb-824d-dc79543f8700.jpg?1",
             "name": "Riveting Rigger",
             "text": "When Riveting Rigger enters the battlefield, you may sacrifice another artifact. If you do, put two +1/+1 counters on Riveting Rigger and it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "99cb1a66-a4d8-55c5-b48a-5a8ee5e96724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02c575-5685-44f5-8b47-89d888529d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02c575-5685-44f5-8b47-89d888529d1b.jpg?1",
             "name": "Rules Lawyer",
             "text": "State-based actions don't apply to you or other permanents you control. (You don't lose the game due to having 0 or less life or drawing from an empty library. Your creatures aren't destroyed due to damage or deathtouch and aren't put into a graveyard due to having 0 or less toughness. Your planeswalkers aren't put into a graveyard if they have 0 loyalty. You don't put a legendary permanent into a graveyard if you control two with the same name. Counters aren't removed from your permanents due to game rules. Permanents you control attached or combined illegally remain on the battlefield. For complete rules and regulations, see rule 704.)",
             "colours": [
@@ -1030,7 +1030,7 @@
         },
         {
             "id": "00ff33b2-92ea-56b0-9c2c-bba965f10d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc709f-c046-48c4-99a0-e9a3a7e79d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc709f-c046-48c4-99a0-e9a3a7e79d66.jpg?1",
             "name": "Sacrifice Play",
             "text": "A person outside the game chooses an attacking or blocking creature target opponent controls. That player sacrifices that creature.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "da98f418-01c3-53bf-945e-e46c1c1664a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483ab3dd-f2d5-49c8-b380-562236709561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483ab3dd-f2d5-49c8-b380-562236709561.jpg?1",
             "name": "Shaggy Camel",
             "text": "When this creature enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "f96777ac-7ccd-5f30-a8af-3ab4160c296c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f79554-5e9f-45aa-94ed-e765ee933fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f79554-5e9f-45aa-94ed-e765ee933fd3.jpg?1",
             "name": "Side Quest",
             "text": "Target player in a silver-bordered game you can see from your seat gains control of target creature you control until your next turn. At the beginning of your next upkeep, put two +1/+1 counters on that creature. (A creature is on the battlefield of only the game its controller is playing.)",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "20ca9e1a-49ec-5314-ae01-486ba6ac0ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf598741-c252-4388-979f-ad7392c8bf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf598741-c252-4388-979f-ad7392c8bf36.jpg?1",
             "name": "Success!",
             "text": "Target creature gets +2/+2 until end of turn. If it's a host or has augment, it gains lifelink until end of turn.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "7c1d01e1-a15a-56d1-b581-c2e044145be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942dd271-396c-4c79-9f67-20f2a494eb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942dd271-396c-4c79-9f67-20f2a494eb74.jpg?1",
             "name": "Teacher's Pet",
             "text": "{2}{W}, Sacrifice Teacher's Pet: Search your library for a card with augment, combine it with target host you control, then shuffle your library.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "fbd411f8-c55b-5ca4-b335-f58b765d5a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add4f168-c69e-4045-9725-47208ef69935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add4f168-c69e-4045-9725-47208ef69935.jpg?1",
             "name": "Animate Library",
             "text": "Enchant your library\nEnchanted library is an artifact creature on the battlefield with power and toughness each equal to the number of cards in it. It's still a library.\nIf enchanted library would leave the battlefield, exile Animate Library instead.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "e3aeb4ee-5957-5105-84a8-374ecca2210b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1a368e-51da-454d-a474-ff14fd2e7b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1a368e-51da-454d-a474-ff14fd2e7b76.jpg?1",
             "name": "Blurry Beeble",
             "text": "Blurry (This creature can be blocked only if defending player was wearing glasses as it was cast.)\nWhenever Blurry Beeble deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "f920476e-7599-5c0d-9c17-3bba4a818298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac8dd95-4a5a-496d-95ce-c3356fce7df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac8dd95-4a5a-496d-95ce-c3356fce7df4.jpg?1",
             "name": "Chipper Chopper",
             "text": "Flying\nWhen Chipper Chopper enters the battlefield, you may sacrifice another artifact. If you do, put two +1/+1 counters on Chipper Chopper and it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "41b478a6-af0f-54e2-b2fe-bafae034c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e34f0b-f94b-49fb-a667-8c11dd9d59d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e34f0b-f94b-49fb-a667-8c11dd9d59d4.jpg?1",
             "name": "Clocknapper",
             "text": "When Clocknapper enters the battlefield, choose beginning phase, precombat main phase, combat phase, postcombat main phase, or ending phase. Steal that phase from target player during his or her next turn. (That phase occurs as though it's your turn instead.)",
             "colours": [
@@ -1339,7 +1339,7 @@
         },
         {
             "id": "3bde8afb-51bf-5e03-a483-1283df80a9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c2219-a372-435e-9857-3ed949971d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c2219-a372-435e-9857-3ed949971d8e.jpg?1",
             "name": "Crafty Octopus",
             "text": "When this creature enters the battlefield, this creature assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "97456cfa-ab54-57f5-bf80-2501c451b592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e0713c-8358-46fc-9618-66a986d681cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e0713c-8358-46fc-9618-66a986d681cb.jpg?1",
             "name": "Crow Storm",
             "text": "Create a 1/2 blue Bird creature token with flying named Storm Crow.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "6fd036b4-a60c-5da7-88be-6013c48eff5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f829be-d4f5-4231-a45d-1869222e5e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f829be-d4f5-4231-a45d-1869222e5e24.jpg?1",
             "name": "Defective Detective",
             "text": "Defective Detective can't be blocked.\nWhen Defective Detective enters the battlefield, a person outside the game looks at target opponent's hand and chooses a card from it. That player reveals that card.",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "03cd6ff2-32aa-5d40-9786-98da22f78e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2655be-7c53-4350-86ee-6c0053809b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2655be-7c53-4350-86ee-6c0053809b59.jpg?1",
             "name": "Five-Finger Discount",
             "text": "Put target nonland permanent into your hand. You may spend mana as though it were mana of any color the next time you cast that card.",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "c54954bb-9be7-5ce8-a5df-112bdae3d34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b913bbbd-a4c5-4e90-98ff-74be2c907d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b913bbbd-a4c5-4e90-98ff-74be2c907d87.jpg?1",
             "name": "Graveyard Busybody",
             "text": "All graveyards are also your graveyards.\nGraveyard Busybody's power and toughness are each equal to the number of cards with flavor text in your graveyards.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "226f144d-9118-50bc-84e3-cd16fa73f253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e36f79-4621-4f0c-be98-90c2efb2ace7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e36f79-4621-4f0c-be98-90c2efb2ace7.jpg?1",
             "name": "Half-Shark, Half-",
             "text": "At the beginning of your upkeep,\nAugment {5}{U} ({5}{U}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "abd7114a-f29d-55a8-a0fe-5445918731c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba905b6e-9568-4aa6-a281-248c79af87ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba905b6e-9568-4aa6-a281-248c79af87ec.jpg?1",
             "name": "Incite Insight",
             "text": "Assemble X Contraptions. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "5098ca81-9795-5132-aa82-4f0747d45772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c28ba7-2270-4a59-bc0a-528e2a97970f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c28ba7-2270-4a59-bc0a-528e2a97970f.jpg?1",
             "name": "Kindly Cognician",
             "text": "Spells you cast that refer to artifacts or Contraptions in their rules text cost {1} less to cast.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "30fee560-d62e-5b24-b452-d8d020a52121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a81eb1b-e97b-46a7-aa5f-dcb5d20f2e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a81eb1b-e97b-46a7-aa5f-dcb5d20f2e22.jpg?1",
             "name": "Magic Word",
             "text": "Enchant creature\nAs Magic Word enters the battlefield, choose a word.\nWhisper the chosen word: Tap enchanted creature.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "f99d335e-1390-5136-90a3-b76404e92b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e99b47-acda-4888-8b2e-0852ba3b931c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e99b47-acda-4888-8b2e-0852ba3b931c.jpg?1",
             "name": "Mer Man",
             "text": "When this creature enters the battlefield, you may draw a card.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "41b44da1-718f-53c9-b158-118352c6c2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b111425a-adaa-4938-88a1-6fdd0bcecc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b111425a-adaa-4938-88a1-6fdd0bcecc39.jpg?1",
             "name": "More or Less",
             "text": "Add or subtract 1 or one from a number or number word on target spell or permanent until end of turn.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "a59dc1fd-eb01-50bf-808e-afc03f7f59ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c121f3-01cb-4e1c-a8a7-6841de28645b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c121f3-01cb-4e1c-a8a7-6841de28645b.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1753,7 +1753,7 @@
         },
         {
             "id": "ff48fde3-2d7b-52d3-8617-46fb8b497a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b946b9bd-501c-4d3c-80f2-aac31aadd083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b946b9bd-501c-4d3c-80f2-aac31aadd083.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "73ac067e-181b-54c6-8890-23b113e63daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73115807-ab27-4c13-928b-dbd6ba990da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73115807-ab27-4c13-928b-dbd6ba990da3.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "aaddf260-62f4-527b-9c6e-9ce695032360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bffb474-4f90-47ec-ae45-833ea825049e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bffb474-4f90-47ec-ae45-833ea825049e.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "798ef64d-8db8-510a-b17a-f3d290ea6a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752537c6-ee47-46c5-a6c7-cbf16e3a1dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752537c6-ee47-46c5-a6c7-cbf16e3a1dcf.jpg?1",
             "name": "Numbing Jellyfish",
             "text": "When this creature enters the battlefield, roll a six-sided die. Target player puts the top X cards of his or her library into his or her graveyard, where X is the result.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "5565f6fc-3534-5fb2-abbc-a1a41f9cd767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6237d7-454b-4b1b-b732-1adda35d746d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6237d7-454b-4b1b-b732-1adda35d746d.jpg?1",
             "name": "S.N.E.A.K. Dispatcher",
             "text": "{2}{U}, {T}: Look at the top card of target player's library. If it has an Agents of S.\nN.\nE.\nA.\nK. watermark, you may reveal it and put it into your hand. Otherwise, put it on the top or bottom of its owner's library.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "9183e564-93ae-571f-840f-8a3d9de2a086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd90f0f-9009-4002-86ae-3353843735c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd90f0f-9009-4002-86ae-3353843735c7.jpg?1",
             "name": "Socketed Sprocketer",
             "text": "{T}: Uninstall all results from Socketed Sprocketer, then roll a six-sided die. Install the result on Socketed Sprocketer. (Put the die on this card.)\nYou may uninstall a result from Socketed Sprocketer to use it for a die you rolled.\nUninstall a 6 from Socketed Sprocketer: Draw a card.",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "f807cf5d-18ac-5e37-95e9-62517bafa9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631bd92-2046-468d-8b10-d583a318ed24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631bd92-2046-468d-8b10-d583a318ed24.jpg?1",
             "name": "Spell Suck",
             "text": "Counter target spell, then assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "912536e1-4ccb-5100-8904-061745b3c805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84a9db-8130-489b-9f76-e3ecd35a0fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84a9db-8130-489b-9f76-e3ecd35a0fd8.jpg?1",
             "name": "Spy Eye",
             "text": "Flying\nWhenever Spy Eye deals combat damage to a player, you may draw a card from that player's library.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "2319b140-7959-5526-a0a3-a7771a95dbe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e1f2c-da19-45aa-9f48-997a0d62587e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e1f2c-da19-45aa-9f48-997a0d62587e.jpg?1",
             "name": "Suspicious Nanny",
             "text": "Whenever Suspicious Nanny deals combat damage to a player, it reassembles target Contraption that player controls. (Gain control of it and move it onto one of your sprockets.)",
             "colours": [
@@ -2077,7 +2077,7 @@
         },
         {
             "id": "608164c0-27b3-566d-be98-5bf1a8679464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bb1492-99de-4606-b2fd-6bbe1961611f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bb1492-99de-4606-b2fd-6bbe1961611f.jpg?1",
             "name": "Time Out",
             "text": "Roll a six-sided die. Put target nonland permanent into its owner's library just beneath the top X cards of that library, where X is the result.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "97f655a9-8b81-5953-89d0-d2953719a20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a650610-20e2-4f16-b59c-2ea7779f6e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a650610-20e2-4f16-b59c-2ea7779f6e47.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Switch target creature's power and toughness until end of turn.\n\u2022 Target creature can't be blocked this turn.\n\u2022 Draw a card. If that card's art is by Wayne England, you may reveal it and draw another card.\n\u2022 Assemble a Contraption.",
             "colours": [
@@ -2147,7 +2147,7 @@
         },
         {
             "id": "7d4c7d8b-0be9-55db-93f4-22a78866defe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a90b2b6-d96e-4c13-83be-849d2ec1d845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a90b2b6-d96e-4c13-83be-849d2ec1d845.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Untap two target permanents.\n\u2022 Tap each permanent target player controls with exactly one word in its name.\n\u2022 Discard all the cards in your hand, then draw that many cards.\n\u2022 Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "a30c83fa-5268-5b8c-bcdb-49b6a4c5f588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfc9416-06d6-40af-8b3d-62371b3da7c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfc9416-06d6-40af-8b3d-62371b3da7c5.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Draw a card from an opponent's library.\n\u2022 Copy target instant or sorcery spell. You may choose new targets for the copy.\n\u2022 Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.\n\u2022 Create a 1/1 colorless Gnome artifact creature token.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "1db7ffa8-b78c-5f80-ad78-199be5b7afe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12272ce6-ab1f-4576-9e50-21d324263c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12272ce6-ab1f-4576-9e50-21d324263c44.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Return target permanent to its controller's hand.\n\u2022 Draw two cards, then discard a card.\n\u2022 Change the target of target spell with a single target.\n\u2022 Turn over target nontoken creature.",
             "colours": [
@@ -2261,7 +2261,7 @@
         },
         {
             "id": "b8551573-9c09-5dc2-a440-d260fcbe6fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e84dd2-01f9-4fad-8a24-cc86424d09a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e84dd2-01f9-4fad-8a24-cc86424d09a2.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Counter target black-bordered spell.\n\u2022 Return target creature to its owner's hand.\n\u2022 Untap each permanent you control with a watermark.\n\u2022 Roll two six-sided dice. Target player puts the top X cards of his or her library into his or her graveyard, where X is the total of those results.",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "3ad5d66e-8406-5a35-bcee-ae747a88a917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41e6c51-d96a-436f-94c5-5d1e19c5e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41e6c51-d96a-436f-94c5-5d1e19c5e0d5.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Scry 3.\n\u2022 Create a 2/2 black Rogue creature token with menace.\n\u2022 Add or subtract 1 or one from a number or number word on target spell or permanent until end of turn.\n\u2022 Return all artifacts target player controls to their owner's hand.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "b1eee0bb-f848-5487-b62b-249331d1843d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766cfce-6edd-4e89-aa78-f30182120804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766cfce-6edd-4e89-aa78-f30182120804.jpg?1",
             "name": "Wall of Fortune",
             "text": "Defender\nYou may tap an untapped Wall you control to have any player reroll a die that player rolled.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "26e1bb24-a541-5fcc-907c-c60dbdde87a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30980d4-b12e-4504-b257-c920b073fd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30980d4-b12e-4504-b257-c920b073fd91.jpg?1",
             "name": "Big Boa Constrictor",
             "text": "When this creature enters the battlefield, roll a six-sided die. Target opponent loses life equal to the result.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "dc79e8a5-1f5d-5f90-ab0e-f99a38e789dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8a98f2-c777-4dc0-ab68-2b1df7ce1ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8a98f2-c777-4dc0-ab68-2b1df7ce1ddd.jpg?1",
             "name": "capital offense",
             "text": "target creature gets -x/-x until end of turn, where x is the number of times a capital letter appears in its rules text. (ignore reminder text and flavor text.)",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "53ad8c80-413e-56df-809e-4766b48979d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bba0ec-d2d4-45e8-84f5-7c6baf40afcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bba0ec-d2d4-45e8-84f5-7c6baf40afcb.jpg?1",
             "name": "Dirty Rat",
             "text": "When this creature enters the battlefield, target opponent discards a card.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "465e104b-a40b-59a2-ac8f-95e8141bd2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a2f09c-60b8-4020-a4f6-f3d51600b234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a2f09c-60b8-4020-a4f6-f3d51600b234.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "f27167b1-cdae-5fce-8b94-a394e52ef392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36cc317-c78f-4941-9a45-541c11efd7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36cc317-c78f-4941-9a45-541c11efd7af.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "d2f3cbdc-f8f5-53dd-8a62-f499f4e09a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6c930e-a20a-436a-96c4-531c7a4961d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6c930e-a20a-436a-96c4-531c7a4961d7.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "5365f877-084f-5411-8bc1-d42c939d8da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23561cc-007c-483a-ae08-9e87ef7774c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23561cc-007c-483a-ae08-9e87ef7774c7.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "f2151178-8cb0-5ef3-96c3-2058cf90ff84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b7148-e98f-40a4-95e3-ffdd2daa324b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b7148-e98f-40a4-95e3-ffdd2daa324b.jpg?1",
             "name": "Finders, Keepers",
             "text": "Destroy target creature, then assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "f4352e65-e2e4-5e66-957b-db8c5a7115f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380d297c-674a-4d0f-964d-7405db81b27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380d297c-674a-4d0f-964d-7405db81b27a.jpg?1",
             "name": "Hangman",
             "text": "As Hangman enters the battlefield, secretly note a word with six to eight letters.\n{1}: Target player who doesn't control Hangman guesses the noted word or an unguessed letter in that word. If he or she guesses wrong, put a +1/+1 counter on Hangman. Any player may activate this ability.\nWhen a player guesses the noted word or all of its letters, sacrifice Hangman.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "c40542a6-bd62-55c8-aef7-d19e87e0fa70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329d79a-08d8-4228-9ca2-97747eec2c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329d79a-08d8-4228-9ca2-97747eec2c44.jpg?1",
             "name": "Hazmat Suit (Used)",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace.\nWhenever a player's skin or fingernail touches enchanted creature, that player loses 2 life.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "6ae5c235-65fe-59c4-a541-46cb2bef04c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc122cf-a4bf-42e0-884a-f655c68a46e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc122cf-a4bf-42e0-884a-f655c68a46e5.jpg?1",
             "name": "Hoisted Hireling",
             "text": "Hoisted Hireling has flying as long as it's being held above the battlefield.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "4396b0bc-50d5-5633-89ed-c57b8add5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9acc1ce-964e-425c-88a6-fe641d3f1f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9acc1ce-964e-425c-88a6-fe641d3f1f5b.jpg?1",
             "name": "Inhumaniac",
             "text": "At the beginning of your upkeep, roll a six-sided die. On a 3 or 4, put a +1/+1 counter on Inhumaniac. On a 5 or higher, put two +1/+1 counters on it. On a 1, remove all +1/+1 counters from Inhumaniac.",
             "colours": [
@@ -2797,7 +2797,7 @@
         },
         {
             "id": "a60385a2-ac0a-56d6-9843-5b930665f69d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0b8b2-0202-4e68-970d-cd006f63de61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0b8b2-0202-4e68-970d-cd006f63de61.jpg?1",
             "name": "Masterful Ninja",
             "text": "Haste\nReveal Masterful Ninja from your hand: Masterful Ninja is on the battlefield and in your hand until end of turn.\n{1}{B}: Masterful Ninja gets +1/+1 until end of turn.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "d4f5c755-5bdd-5c28-8fbe-1d892e451203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c50dc-2bd6-47e3-9ca5-49e38898e774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c50dc-2bd6-47e3-9ca5-49e38898e774.jpg?1",
             "name": "Ninja",
             "text": "You may activate Ninja's augment ability any time you could cast an instant.\nWhenever this creature deals combat damage to a player,\nAugment {2}{B} ({2}{B}, Reveal this card from your hand: Combine it with target host. Augment only as\u2014oh, nevermind.)",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "659950fb-d7c4-5603-bd1f-f9238ce7a8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c576ec-bb05-446b-8b0b-20d4246831ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c576ec-bb05-446b-8b0b-20d4246831ee.jpg?1",
             "name": "Old-Fashioned Vampire",
             "text": "Flying\nOld-Fashioned Vampire gets +2/+2 and has deathtouch as long as it's dark outdoors.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "66f4d0a0-1d04-52e2-83a0-dea5a9c9daa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5279543-3678-40f2-9bea-0a75c2044017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5279543-3678-40f2-9bea-0a75c2044017.jpg?1",
             "name": "Over My Dead Bodies",
             "text": "Creature cards in graveyards can attack and block as though they were on the battlefield, can block or be blocked only by creature cards in graveyards, are Zombies in addition to their other types, and have undeathtouch. (If they would deal damage to a creature card, exile that creature card instead.)\nCreature cards in your graveyard have haste.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "ef10a4ba-ce01-578f-b207-28bdf590f578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3492b7-325b-40f4-b84f-cd1ba1d0256e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3492b7-325b-40f4-b84f-cd1ba1d0256e.jpg?1",
             "name": "Overt Operative",
             "text": "Menace\nWhenever Overt Operative deals combat damage to a player, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "bdd8e35c-88e2-5b09-b630-468450d8c28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3587b9-e727-4f37-b4d6-1baa7316262f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3587b9-e727-4f37-b4d6-1baa7316262f.jpg?1",
             "name": "\"Rumors of My Death . . .\"",
             "text": "{3}{B}, Exile a permanent you control with a League of Dastardly Doom watermark: Return a permanent card with a League of Dastardly Doom watermark from your graveyard to the battlefield.",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "1d0d7e55-b402-5890-8f7b-cb36fdb8903e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246e2a7b-c7dd-4b30-9d7a-60a02b605a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246e2a7b-c7dd-4b30-9d7a-60a02b605a04.jpg?1",
             "name": "Skull Saucer",
             "text": "Flying\nWhen Skull Saucer enters the battlefield, destroy target creature and put your head on the table. Sacrifice Skull Saucer when your head stops touching the table.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "3ac81113-4804-5887-8c9e-1a4a49d07627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d37a3fc-d652-4c87-892e-bf8b8dc71e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d37a3fc-d652-4c87-892e-bf8b8dc71e35.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, that player reveals his or her hand. You choose a card from it with the longest name. That player discards that card.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "b5360a7b-8995-52e6-96df-7101985c0179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4df93-078e-4266-82f2-cf4fc5945ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4df93-078e-4266-82f2-cf4fc5945ce3.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, you may destroy target creature facing left in its art. (Creatures without faces don't face anywhere.)",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "a0f484a6-1f64-5f0b-b9a0-bf0463c7cfd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94008ffb-f0fe-4e83-bf73-d8ade4104d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94008ffb-f0fe-4e83-bf73-d8ade4104d86.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, that player loses a finger until Sly Spy leaves the battlefield. (The finger is chosen by its owner and can't roll dice or touch cards.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "bdb4b8fd-d187-50f2-a50c-5974389c82c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596ee7af-cc78-41b5-93c5-945189d5e46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596ee7af-cc78-41b5-93c5-945189d5e46c.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, you may destroy target creature facing right in its art. (Creatures without faces don't face anywhere.)",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "1fbd80e9-6547-5131-9ad5-5a1eefa3b7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc2eae1-8e24-4bef-aa03-a3e428f291a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc2eae1-8e24-4bef-aa03-a3e428f291a1.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, that player reveals the top card of his or her library. Put that card into your hand and you lose life equal to its converted mana cost.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "fbb23fa9-744e-5577-a43a-def19d3ae121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaf902f-4139-4a54-a519-a60aea84e669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaf902f-4139-4a54-a519-a60aea84e669.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, roll a six-sided die. That player loses life equal to the result.",
             "colours": [
@@ -3281,7 +3281,7 @@
         },
         {
             "id": "05850043-d6a5-57d8-8a15-2ef8a80ed7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca78c52-f1b5-4c3a-aa7e-99b54332c332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca78c52-f1b5-4c3a-aa7e-99b54332c332.jpg?1",
             "name": "Snickering Squirrel",
             "text": "You may tap Snickering Squirrel to increase the result of a die any player rolled by 1.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "14bb21f3-5ab7-5c46-b861-fd4aaa53c7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e90b22-6f43-4e9a-a236-f33191768813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e90b22-6f43-4e9a-a236-f33191768813.jpg?1",
             "name": "Spike, Tournament Grinder",
             "text": "({PB} can be paid with either {B} or 2 life.)\n{PB}{PB}{PB}{PB}: Choose a card you own from outside the game that has been banned or restricted in a Constructed format, reveal that card, and put it into your hand.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "e4be2b4a-3f4c-577e-8fe3-f81d0b93e0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f735f1-2528-424d-8454-e94746a2b58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f735f1-2528-424d-8454-e94746a2b58f.jpg?1",
             "name": "Squirrel-Powered Scheme",
             "text": "Increase the result of each die you roll by 2.",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "bc8f8e2b-8041-56f1-bb57-51a2821226e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a393ca-3bb1-4da2-9ece-6421b3814091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a393ca-3bb1-4da2-9ece-6421b3814091.jpg?1",
             "name": "Steady-Handed Mook",
             "text": "Deathtouch\nWhen Steady-Handed Mook enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "6f3366da-545b-50c5-8584-a39f5907634d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b719a4-3ac5-4e45-baa6-4c058e764129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b719a4-3ac5-4e45-baa6-4c058e764129.jpg?1",
             "name": "Stinging Scorpion",
             "text": "When this creature enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "b2b04baa-4ef7-5f6e-9136-c92475d9258b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c349f19b-1f9e-4541-943a-a6933d01ad73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c349f19b-1f9e-4541-943a-a6933d01ad73.jpg?1",
             "name": "Subcontract",
             "text": "A person outside the game looks at target opponent's hand and chooses a nonland card from it. That player discards that card.",
             "colours": [
@@ -3488,7 +3488,7 @@
         },
         {
             "id": "d7238442-60d2-5ec4-9701-d3d40563336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66d5bb-a0cc-48fa-9d98-4195debc188a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66d5bb-a0cc-48fa-9d98-4195debc188a.jpg?1",
             "name": "Summon the Pack",
             "text": "Open a sealed Magic booster pack, reveal the cards, and put all creature cards revealed this way onto the battlefield under your control. They're Zombies in addition to their other types. (Remove those cards from your deck before beginning a new game.)",
             "colours": [
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "930d1fc3-3d81-5167-b923-27e73a3cefe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2d319-f03b-4a39-a177-07161e72c416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2d319-f03b-4a39-a177-07161e72c416.jpg?1",
             "name": "Zombified",
             "text": "{4}{B}: Combine Zombified from your graveyard with target host.\n{2}{B}, Exile a creature card from your graveyard:\nAugment {4}{B} ({4}{B}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "4f0aa84a-6efd-539a-9d55-49038d7c3c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec4563d-1a83-402c-b209-0e1f740a6523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec4563d-1a83-402c-b209-0e1f740a6523.jpg?1",
             "name": "The Big Idea",
             "text": "{2}{BR}{BR}, {T}: Roll a six-sided die. Create a number of 1/1 red Brainiac creature tokens equal to the result.\nTap three untapped Brainiacs you control: The next time you would roll a six-sided die, instead roll two six-sided dice and use the total of those results.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "f1b1928a-393d-56b8-9058-80a1c145a518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6964c3d5-4bb7-46b1-a057-878af73f2e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6964c3d5-4bb7-46b1-a057-878af73f2e5f.jpg?1",
             "name": "Box of Free-Range Goblins",
             "text": "Roll a six-sided die. Create a number of 1/1 red Goblin creature tokens equal to the result.",
             "colours": [
@@ -3624,7 +3624,7 @@
         },
         {
             "id": "a543eae4-ed87-5870-88e9-08be0262aa1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4930b9d5-939f-4463-9f9a-235aa3a4f8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4930b9d5-939f-4463-9f9a-235aa3a4f8c4.jpg?1",
             "name": "Bumbling Pangolin",
             "text": "When this creature enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "d918bf8f-7fea-5f5a-9045-7fe6b999bc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2225f-4bac-4579-b8ee-9ded9af3294b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2225f-4bac-4579-b8ee-9ded9af3294b.jpg?1",
             "name": "Common Iguana",
             "text": "When this creature enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "60795102-0cdf-5589-bb5c-e6bd63f66382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb8115-3a47-4d7e-a3ed-b2e81ca27255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb8115-3a47-4d7e-a3ed-b2e81ca27255.jpg?1",
             "name": "The Countdown Is at One",
             "text": "Players play a Magic subgame, starting at 1 life and using their libraries as their decks. For the rest of the main game, if a source would deal damage to a player who didn't win the subgame, it deals double that damage to that player instead.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "edce57dc-8189-5028-a653-cf809165812e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f49ff5d-292d-432a-8548-aed8cb0d98ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f49ff5d-292d-432a-8548-aed8cb0d98ea.jpg?1",
             "name": "Feisty Stegosaurus",
             "text": "When this creature enters the battlefield, roll a six-sided die. This creature deals damage equal to the result to target creature an opponent controls.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "81ebd535-68de-5439-abfd-48af42da922b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33c84b-3807-430e-8315-5de2d7f6fa32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33c84b-3807-430e-8315-5de2d7f6fa32.jpg?1",
             "name": "Garbage Elemental",
             "text": "Frenzy 2 (Whenever this creature attacks and isn't blocked, it gets +2/+0 until end of turn.)\nGarbage Elemental can't be blocked by wordy creatures. (A creature is wordy if it has four or more lines of rules text.)",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "26c99733-b1cb-53ed-9a03-f38b2dbe1fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427b338-42d0-44cc-9594-9e50ccbdd809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427b338-42d0-44cc-9594-9e50ccbdd809.jpg?1",
             "name": "Garbage Elemental",
             "text": "When Garbage Elemental enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3846,7 +3846,7 @@
         },
         {
             "id": "566dc68c-78c6-51e1-98ad-5e3044556281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5579dfb-4e63-4e7b-80c5-56949518c71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5579dfb-4e63-4e7b-80c5-56949518c71e.jpg?1",
             "name": "Garbage Elemental",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhen Garbage Elemental enters the battlefield, roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "c8647f26-3414-5b12-80fa-b2304fbf5e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1a004-4d80-481b-8f3f-30cc362556bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1a004-4d80-481b-8f3f-30cc362556bc.jpg?1",
             "name": "Garbage Elemental",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nWhen Garbage Elemental enters the battlefield, roll a six-sided die. Garbage Elemental deals damage equal to the result to target opponent.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "37ae4a82-7e9f-5556-b787-fcc1a2b61535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8ae74c-6aba-4ea7-8afd-ce319ef6b047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8ae74c-6aba-4ea7-8afd-ce319ef6b047.jpg?1",
             "name": "Garbage Elemental",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\nEach creature you control with any kind of counter on it has art menace. (They can't be blocked except by creatures with two or more visible figures in their art.)",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "96073680-2173-5fe9-bc04-ad71974bc3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de96731b-d4b1-4c6c-8413-f9e00030d11d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de96731b-d4b1-4c6c-8413-f9e00030d11d.jpg?1",
             "name": "Garbage Elemental",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)\nBattalion \u2014 Whenever Garbage Elemental and at least two other creatures attack, target creature can't block this turn.",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "a12af461-73dd-5ebc-b972-cc8af1806090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e94470-ca77-4b4d-929c-9f694a74260f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e94470-ca77-4b4d-929c-9f694a74260f.jpg?1",
             "name": "Goblin Haberdasher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nOther creatures you control wearing hats in their art have menace.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "db0b93f4-7897-599d-9f52-963726310815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e6915b-2077-45aa-93e7-29b5f14beb51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e6915b-2077-45aa-93e7-29b5f14beb51.jpg?1",
             "name": "Half-Orc, Half-",
             "text": "Trample\nAt the beginning of each end step, if an opponent was dealt damage this turn,\nAugment {1}{R}{R} ({1}{R}{R}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "16c3e901-50e1-5729-ba33-a5c86f35b53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d58edc-0881-4bfb-aa47-143741cd66e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d58edc-0881-4bfb-aa47-143741cd66e7.jpg?1",
             "name": "Hammer Helper",
             "text": "Gain control of target creature until end of turn. Untap that creature and roll a six-sided die. Until end of turn, it gains haste and gets +X/+0, where X is the result.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "effc4f77-f9f7-5b56-9089-4b7bd997c2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e613e-817c-42c4-8124-407a85f633b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e613e-817c-42c4-8124-407a85f633b3.jpg?1",
             "name": "Hammer Jammer",
             "text": "As Hammer Jammer enters the battlefield, roll a six-sided die. Hammer Jammer enters the battlefield with a number of +1/+1 counters on it equal to the result.\nWhenever you roll a die, remove all +1/+1 counters from Hammer Jammer, then put a number of +1/+1 counters on it equal to the result.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "cb36062f-9856-5748-9c87-06e6398d34af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591d888-b9c4-4c42-a9ef-abf6c06b10c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591d888-b9c4-4c42-a9ef-abf6c06b10c8.jpg?1",
             "name": "Hammerfest Boomtacular",
             "text": "Whenever you cast a spell with a Goblin Explosioneers watermark, Hammerfest Boomtacular deals 2 damage to target creature or player.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "8598b3c0-d145-527d-9680-157a757b4c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13295f5-c3ce-4392-885c-f21d5fbeaaa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13295f5-c3ce-4392-885c-f21d5fbeaaa3.jpg?1",
             "name": "Infinity Elemental",
             "text": "(This creature has INFINITE POWER.)",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "99443a6d-fc62-5b82-86c3-46efdb1a6cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1131b87-8e59-47e7-a760-848a455c82b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1131b87-8e59-47e7-a760-848a455c82b0.jpg?1",
             "name": "It That Gets Left Hanging",
             "text": "When It That Gets Left Hanging enters the battlefield, ask a person outside the game to high-five you. If he or she won't, It That Gets Left Hanging gains haste until end of turn.",
             "colours": [
@@ -4244,7 +4244,7 @@
         },
         {
             "id": "0db1962d-eb28-51c3-b80a-1588ea7902eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b9e63f-4cf5-454d-a368-d5cce2529272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b9e63f-4cf5-454d-a368-d5cce2529272.jpg?1",
             "name": "Just Desserts",
             "text": "Just Desserts deals \u03c0 damage to target creature. (\u03c0 is the ratio of a circle's circumference to its diameter. (It's a smidgen more than 3.))",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "f3b33da7-ae27-580c-b295-617073a960ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01dc452-5938-499b-a70f-7f40323faf76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01dc452-5938-499b-a70f-7f40323faf76.jpg?1",
             "name": "Painiac",
             "text": "At the beginning of your upkeep, roll a six-sided die. Painiac gets +X/+0 until end of turn, where X is the result.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "58ae59e9-b61a-5a25-a612-841861f0ff7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f3203-e79c-47af-8c3d-b37c0537de34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f3203-e79c-47af-8c3d-b37c0537de34.jpg?1",
             "name": "Party Crasher",
             "text": "Haste\nYou can attack with Party Crasher once each combat during each opponent's turn.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "5bb30094-f210-5e4c-9ed0-290fdb91b28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9110d5b8-1fe3-44f8-8159-e0e72ce55152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9110d5b8-1fe3-44f8-8159-e0e72ce55152.jpg?1",
             "name": "Steamflogger Boss",
             "text": "Other Riggers you control get +1/+0 and have haste.\nIf a Rigger you control would assemble a Contraption, it assembles two Contraptions instead.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "6a4a5cf2-2f63-5628-83ce-b9f1a8191d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d536048-86fd-4ea0-bd1c-5a82c76d58b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d536048-86fd-4ea0-bd1c-5a82c76d58b7.jpg?1",
             "name": "Steamflogger of the Month",
             "text": "When Steamflogger of the Month enters the battlefield, it assembles a Contraption for each Contraption you control. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "6d9deada-cc3f-56b3-a45d-6ac737b90231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a67262-a5f9-4830-97df-ecaaff2badc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a67262-a5f9-4830-97df-ecaaff2badc1.jpg?1",
             "name": "Steamflogger Temp",
             "text": "{6}, {T}: Steamflogger Temp assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4450,7 +4450,7 @@
         },
         {
             "id": "783b5979-5eb3-5845-9055-3f10213d165f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c690d386-bd4f-4251-a475-0b016e2f29ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c690d386-bd4f-4251-a475-0b016e2f29ee.jpg?1",
             "name": "Steamfloggery",
             "text": "Roll a six-sided die. Assemble a number of Contraptions equal to the result. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4482,7 +4482,7 @@
         },
         {
             "id": "7bf2f89f-f8c3-5054-8e01-2b75d29f3d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3400a39f-9dd1-4e86-b29a-3cb9758b60be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3400a39f-9dd1-4e86-b29a-3cb9758b60be.jpg?1",
             "name": "Super-Duper Death Ray",
             "text": "Trample (This spell can deal excess damage to its target's controller.)\nSuper-Duper Death Ray deals 4 damage to target creature.",
             "colours": [
@@ -4514,7 +4514,7 @@
         },
         {
             "id": "00c24f80-3f6a-5d77-a9d1-aa60a8a02126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3093a4-e115-4d88-b7c0-33dee8a11142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3093a4-e115-4d88-b7c0-33dee8a11142.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "fe56ec01-d6ba-5bc6-ad93-0952ca57bc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807812cc-74a2-4609-9555-7e0a2463090e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807812cc-74a2-4609-9555-7e0a2463090e.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "743ce4b2-2519-531b-9143-07fcc28bea3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b552dd-1e0d-41e6-a79b-5a6c1ff28851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b552dd-1e0d-41e6-a79b-5a6c1ff28851.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "e33a8081-f53b-59d3-bc73-214ebf1aa37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a2cdb5-18a8-4fb2-8eb8-920c95beeea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a2cdb5-18a8-4fb2-8eb8-920c95beeea9.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "07a32c1c-5a51-5b02-aaed-ad8680b7184b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c6dd7-84eb-42ff-a950-705bc0d1811e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c6dd7-84eb-42ff-a950-705bc0d1811e.jpg?1",
             "name": "Three-Headed Goblin",
             "text": "Triple strike (This creature deals first-strike, regular, and last-strike combat damage.)",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "18612437-5231-58bf-99e6-23a476d2f5c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4cf5c-ac9e-45d4-ae4e-ce0162e9f5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4cf5c-ac9e-45d4-ae4e-ce0162e9f5bb.jpg?1",
             "name": "Work a Double",
             "text": "Assemble two Contraptions. (Put the top card of your Contraption deck face up onto one of your sprockets. Then repeat this process.)",
             "colours": [
@@ -4737,7 +4737,7 @@
         },
         {
             "id": "7ea3da71-f604-5027-87b8-ccfcf1f12715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4fcdd5-8f7b-48b1-8841-afc3f8f35853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4fcdd5-8f7b-48b1-8841-afc3f8f35853.jpg?1",
             "name": "Wrench-Rigger",
             "text": "When Wrench-Rigger enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "aae145bd-e85a-5894-810a-38ff701a3583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17892f5-5c4a-4149-8d5e-ba9df013866e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17892f5-5c4a-4149-8d5e-ba9df013866e.jpg?1",
             "name": "As Luck Would Have It",
             "text": "Hexproof\nWhenever you roll a die, put a number of luck counters on As Luck Would Have It equal to the result. Then if there are 100 or more luck counters on As Luck Would Have It, you win the game. (Count both rolls if you reroll a die.)",
             "colours": [
@@ -4804,7 +4804,7 @@
         },
         {
             "id": "b046ad64-d571-58c7-9a52-9a8c329c733b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed069c-410f-4b30-afd1-8d04742068e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed069c-410f-4b30-afd1-8d04742068e7.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "4321861b-d291-56ca-8b9d-60acce7dad5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7693877c-958f-4c67-93d5-7db8f2dd87e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7693877c-958f-4c67-93d5-7db8f2dd87e7.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "9e0be1f6-28ca-5e43-bbb1-be3beb9a5e7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90b6269-7406-40c9-8d4c-3448698a1fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90b6269-7406-40c9-8d4c-3448698a1fdd.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "3bf39565-9497-56cf-9402-55af84737849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7191d7-2c2c-470e-a2b6-eeb8f3031cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7191d7-2c2c-470e-a2b6-eeb8f3031cc2.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "c63940a8-1aae-5d5a-9073-6d9f6f1df4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b60a89-cf45-4e90-a84f-d4674b926bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b60a89-cf45-4e90-a84f-d4674b926bf7.jpg?1",
             "name": "Chittering Doom",
             "text": "Whenever you roll a 4 or higher on a die, create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "64630a98-501d-5875-9041-f0e053469782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1590cf0a-42bf-4ffd-a83e-eec516a71590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1590cf0a-42bf-4ffd-a83e-eec516a71590.jpg?1",
             "name": "Clever Combo",
             "text": "Search your library for a host card or a card with augment, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "7ac3f4e3-1d05-5496-8d80-e73b15899da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae93229-be0f-4721-85ee-bfccf4e28971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae93229-be0f-4721-85ee-bfccf4e28971.jpg?1",
             "name": "Druid of the Sacred Beaker",
             "text": "{T}: Add {G} to your mana pool for each Crossbreed Labs watermark among permanents you control.",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "516a0044-d46e-5fe3-b852-0426eb4deea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07ec8f9-ffa9-43e9-bd75-babf3f8ed322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07ec8f9-ffa9-43e9-bd75-babf3f8ed322.jpg?1",
             "name": "Eager Beaver",
             "text": "When this creature enters the battlefield, you may untap target permanent.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "9c4b45d1-3dd8-5131-8b41-5de9338b6686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bbf567-bdb4-4f88-906c-eb1503c02d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bbf567-bdb4-4f88-906c-eb1503c02d9f.jpg?1",
             "name": "Earl of Squirrel",
             "text": "Squirrellink (Damage dealt by this creature also causes you to create that many 1/1 green Squirrel creature tokens.)\nCreature tokens you control are Squirrels in addition to their other creature types.\nOther Squirrels you control get +1/+1.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "49660a09-f460-529d-bd33-4411270453b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5fb06-7371-421e-bab6-e0a5c3123948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5fb06-7371-421e-bab6-e0a5c3123948.jpg?1",
             "name": "First Pick",
             "text": "Destroy target artifact or enchantment. Assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "0a2c9ff3-a32b-56fa-bdab-c274d1371aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f8801-4dff-4192-a783-2b5dfda24784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f8801-4dff-4192-a783-2b5dfda24784.jpg?1",
             "name": "Ground Pounder",
             "text": "{3}{G}: Roll a six-sided die. Ground Pounder gets +X/+X until end of turn, where X is the result.\nWhenever you roll a 5 or higher on a die, Ground Pounder gains trample until end of turn.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "420d3f64-2707-5e6c-a97b-5b45323dbaaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7793b65-d752-4563-85b4-e7666a51f2be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7793b65-d752-4563-85b4-e7666a51f2be.jpg?1",
             "name": "Half-Squirrel, Half-",
             "text": "Whenever a nontoken creature enters the battlefield,\nAugment {G} ({G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "2be0d342-f38a-5cc5-b576-9cc28c4373b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760e482c-8725-410e-9d9f-c377649fe8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760e482c-8725-410e-9d9f-c377649fe8bb.jpg?1",
             "name": "Hydradoodle",
             "text": "As Hydradoodle enters the battlefield, roll X six-sided dice. Hydradoodle enters the battlefield with a number of +1/+1 counters on it equal to the total of those results.\nReach, trample",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "b6872a2f-9721-53c8-976c-5f7cfe5d33b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be3e867a-208d-4a23-b8a8-a48866889a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be3e867a-208d-4a23-b8a8-a48866889a8d.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose Flavorful or Bland.\n\u2022 Flavorful \u2014 Whenever a creature with flavor text enters the battlefield under your control, draw a card.\n\u2022 Bland \u2014 Whenever a creature without flavor text enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "c021e39d-5a9c-5295-9003-82f55124e871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80545e3d-aff4-4501-a173-b7fa02ef816c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80545e3d-aff4-4501-a173-b7fa02ef816c.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose an artist.\nWhenever a creature with art by the chosen artist enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5341,7 +5341,7 @@
         },
         {
             "id": "888b40fa-c8e1-5bd9-9cbb-3e4b2919b6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91144259-d0a1-4e49-9f9b-9be7e36361d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91144259-d0a1-4e49-9f9b-9be7e36361d9.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose white-bordered or silver-bordered.\nWhenever a creature with the chosen border enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5379,7 +5379,7 @@
         },
         {
             "id": "811f8d16-fca4-528d-8147-7e2b393021e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0d8fc5-5841-403f-96db-2259048ff424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0d8fc5-5841-403f-96db-2259048ff424.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose a rarity.\nWhenever a creature with the chosen rarity enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "1cb355f1-5c65-57ba-b27f-eed9042df257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962272f8-7cea-4766-9980-da99a503ca6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962272f8-7cea-4766-9980-da99a503ca6d.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose odd or even.\nWhenever a creature with a collector number of the chosen value enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5455,7 +5455,7 @@
         },
         {
             "id": "8b8c821a-730a-5bf1-ab33-beb3e9faf961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b25c91-892d-48d6-b42e-045d16d35316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b25c91-892d-48d6-b42e-045d16d35316.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose a number.\nWhenever a creature with exactly the chosen number of words in its name enters the battlefield under your control, draw a card. (Hyphenated words are one word.)",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "974f7094-2f06-5176-9655-a714c1821090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199304-1b6e-417f-9855-82c38454dff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199304-1b6e-417f-9855-82c38454dff9.jpg?1",
             "name": "Joyride Rigger",
             "text": "When Joyride Rigger enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "f0da11d9-7208-5b0e-bdb9-da36e4de3f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569f48f9-db8c-458d-b1c8-fed5fd844bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569f48f9-db8c-458d-b1c8-fed5fd844bfd.jpg?1",
             "name": "Monkey-",
             "text": "Whenever a nontoken creature you control dies,\nAugment {2}{G} ({2}{G}, Reveal this card from your hand: Combine it with target  host. Augment only as a sorcery.)",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "cbccee7d-41cc-5d50-8f2b-e0b75796ebd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e96d8-2c6d-43c6-b9c9-512fdb98a30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e96d8-2c6d-43c6-b9c9-512fdb98a30d.jpg?1",
             "name": "Mother Kangaroo",
             "text": "When this creature enters the battlefield, roll a six-sided die. Put a number of +1/+1 counters on this creature equal to the result.",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "0c282577-878e-556b-8e66-da30eee4d55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9fdfa-c361-465e-9639-097d441a3f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9fdfa-c361-465e-9639-097d441a3f74.jpg?1",
             "name": "Multi-Headed",
             "text": "At the beginning of each end step, if you rolled a die this turn,\nAugment {4}{G} ({4}{G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "58dc68f1-d9c9-5522-967b-06f78f2086c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabefc4a-4d5a-41bc-a791-38aa8ab0f9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabefc4a-4d5a-41bc-a791-38aa8ab0f9e6.jpg?1",
             "name": "Really Epic Punch",
             "text": "Target creature you control gets +2/+2 if it's a host or has augment. Then it fights target creature you don't control.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "510a91d7-956a-59ca-a4f2-f31b00c1163f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88375ad9-50cb-4529-982b-82f9653c69f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88375ad9-50cb-4529-982b-82f9653c69f6.jpg?1",
             "name": "Selfie Preservation",
             "text": "Search your library for a basic land card and reveal it. If there's a tree in its art, put it onto the battlefield tapped. Otherwise, put it into your hand. Then shuffle your library.",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "4b87b880-b312-50d2-89bd-c4ec84787a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a6611-db7e-48a5-8eb1-2886f8d3665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a6611-db7e-48a5-8eb1-2886f8d3665a.jpg?1",
             "name": "Serpentine",
             "text": "Whenever a land enters the battlefield under your control,\nAugment {2}{G} ({2}{G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "bbd1208c-3f93-5b45-8cd9-d62eef774160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad58131-2bfe-4796-ab7d-44364a0d0acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad58131-2bfe-4796-ab7d-44364a0d0acc.jpg?1",
             "name": "Shellephant",
             "text": "{0}: Choose one. You may activate this ability while Shellephant is in any zone.\n\u2022 Shellephant has base power and toughness 1/4.\n\u2022 Shellephant has base power and toughness 3/3.",
             "colours": [
@@ -5766,7 +5766,7 @@
         },
         {
             "id": "924205fb-c267-5f31-8098-de87130fbbda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87be87-258e-4a84-8f43-fcaa55e8ad3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87be87-258e-4a84-8f43-fcaa55e8ad3a.jpg?1",
             "name": "Slaying Mantis",
             "text": "Just a second (As long as this spell is on the stack, players can't move cards on the battlefield.)\nSlaying Mantis enters the battlefield by being thrown from a distance of at least three feet.\nWhen Slaying Mantis enters the battlefield, it fights each creature an opponent controls that it touched as it entered.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "2269ca43-c339-531e-996d-aaebcea94f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89757c05-72af-4bfe-a4c0-abc5d1155b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89757c05-72af-4bfe-a4c0-abc5d1155b61.jpg?1",
             "name": "Squirrel Dealer",
             "text": "When Squirrel Dealer enters the battlefield, ask a person outside the game \"Do you like Squirrels?\" If he or she does, create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "0ac96bc0-227b-5b79-83e9-da34801305fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea9d1a-d7ee-47ac-b010-ec0b0afc7886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea9d1a-d7ee-47ac-b010-ec0b0afc7886.jpg?1",
             "name": "Steamflogger Service Rep",
             "text": "Whenever another Goblin enters the battlefield under your control, you may pay {1}. If you do, Steamflogger Service Rep assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "d12d5e09-f6af-599f-adf4-ab9cdbda19a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332188f4-ff05-4a07-9200-ad03bd650c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332188f4-ff05-4a07-9200-ad03bd650c3f.jpg?1",
             "name": "Wild Crocodile",
             "text": "When this creature enters the battlefield, search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "3e17f557-889d-56b0-bb0c-d0b67df0a11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958c27db-68fa-47e9-a9c3-82f0c92e86c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958c27db-68fa-47e9-a9c3-82f0c92e86c1.jpg?1",
             "name": "Willing Test Subject",
             "text": "Reach\nWhenever you roll a 4 or higher on a die, put a +1/+1 counter on Willing Test Subject.\n{6}: Roll a six-sided die.",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "dab95af3-dea5-513c-8360-5746571d798e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d31d5c-6d4d-4bd8-b69c-b44c5b7f089f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d31d5c-6d4d-4bd8-b69c-b44c5b7f089f.jpg?1",
             "name": "Baron Von Count",
             "text": "Baron Von Count enters the battlefield with a doom counter on \"5.\"\nWhenever you cast a spell with the indicated numeral in its mana cost, text box, power, or toughness, move the doom counter one numeral to the left.\nWhen the doom counter moves from \"1,\" destroy target player and put that doom counter on \"5.\"",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "32f7b856-2faf-511d-ae54-57ee6810dc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd5cc29-3490-4e35-b7ef-5cd07eb43bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd5cc29-3490-4e35-b7ef-5cd07eb43bf7.jpg?1",
             "name": "Better Than One",
             "text": "A person outside the game becomes your teammate. (Choose any number of cards in your hand, on top of your library, or on the battlefield under your control. Those cards become your teammate's hand, library, and permanents, respectively.)",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "e71ac09d-c496-5bea-a6cb-4964d073a4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa775e1e-2322-4981-bf14-4f24a3be983e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa775e1e-2322-4981-bf14-4f24a3be983e.jpg?1",
             "name": "Cramped Bunker",
             "text": "At the beginning of each opponent's upkeep, that player moves a permanent he or she controls to touch Cramped Bunker and no other permanents. If he or she can't, destroy each permanent that player controls that isn't touching Cramped Bunker, then sacrifice it.",
             "colours": [
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "5d7f1428-e62c-5f0c-8881-dc77b991c020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a8222-7760-41bb-b524-9036a036bc8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a8222-7760-41bb-b524-9036a036bc8b.jpg?1",
             "name": "Dr. Julius Jumblemorph",
             "text": "Dr. Julius Jumblemorph is every creature type (even if this card isn't on the battlefield).\nWhenever a host enters the battlefield under your control, you may search your library and/or graveyard for a card with augment and combine it with that host. If you search your library this way, shuffle it.",
             "colours": [
@@ -6087,7 +6087,7 @@
         },
         {
             "id": "2410be48-8227-573c-9eb0-a54f4c579b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1e38a2-d817-4f19-aabf-02dc72c78259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1e38a2-d817-4f19-aabf-02dc72c78259.jpg?1",
             "name": "The Grand Calcutron",
             "text": "When The Grand Calcutron enters the battlefield, each player's hand becomes a program (an ordered row of revealed cards).\nPlayers can only play the first card of their program.\nIf a card would be put into a player's hand from anywhere, that player reveals it and places it anywhere within his or her program instead.\nAt the beginning of each player's end step, if that player's program has fewer than five cards, he or she draws cards equal to the difference.",
             "colours": [
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "16ed97b8-7055-57d9-b475-6ac4e88debfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ca9cf7-d6ca-4403-84be-719480eb4b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ca9cf7-d6ca-4403-84be-719480eb4b7d.jpg?1",
             "name": "Grusilda, Monster Masher",
             "text": "Combined, enchanted, and equipped creatures you control have menace.\n{3}{B}{R}, {T}: Put two target creature cards from graveyards onto the battlefield combined into one creature under your control. (Its power is equal to their total power, its toughness is equal to their total toughness, and it has their names, mana costs, types, text boxes, etc.)",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "813b4e71-91d5-5c42-9745-73b5c45f9ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f3b4c8-76c2-4f50-87bc-4e863796309c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f3b4c8-76c2-4f50-87bc-4e863796309c.jpg?1",
             "name": "Hot Fix",
             "text": "You have ten seconds to look at and rearrange the cards in your library. At the end of those ten seconds, if you're touching one or more of those cards, shuffle your library.",
             "colours": [
@@ -6196,7 +6196,7 @@
         },
         {
             "id": "c3222fca-ddf1-5ffb-a4d8-416c0c92df69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5135b251-002b-453d-a4f8-0455617ebb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5135b251-002b-453d-a4f8-0455617ebb81.jpg?1",
             "name": "Ol' Buzzbark",
             "text": "When Ol' Buzzbark enters the battlefield, roll X six-sided dice onto the battlefield from a height of at least X inches. For each die, put a number of +1/+1 counters equal to the result on each creature you control that die is touching. For each die, Ol' Buzzbark deals damage equal to the result to each creature an opponent controls that die is touching.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "bf82c445-7258-540e-bee7-45e34a05dd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54d145-a570-49cc-bbb0-8c12c168ec23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54d145-a570-49cc-bbb0-8c12c168ec23.jpg?1",
             "name": "Phoebe, Head of S.N.E.A.K.",
             "text": "Phoebe, Head of S.N.E.A.K. can't be blocked by creatures with flavor text.\n{2}{U}{B}: Phoebe permanently steals target creature's text box. (That creature loses all rules text, flavor text, and watermarks. This creature gains them.)",
             "colours": [
@@ -6274,7 +6274,7 @@
         },
         {
             "id": "7028db1f-7465-52b4-ad97-0be076abc0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4581455-5fa1-4c96-96b3-e9e9654f5a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4581455-5fa1-4c96-96b3-e9e9654f5a28.jpg?1",
             "name": "Urza, Academy Headmaster",
             "text": "+1: Head to Ask\nUrza.com and click +1.\n-1: Head to Ask\nUrza.com and click -1.\n-6: Head to Ask\nUrza.com and click -6.",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "55cd11df-cb7c-54a8-977d-c570bb837c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77f6e64-2470-4c6a-a92b-328e4edc3ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77f6e64-2470-4c6a-a92b-328e4edc3ea9.jpg?1",
             "name": "X",
             "text": "As long as X is in X's owner's opponent's hand, X's owner may cast X and activate X's abilities. That opponent can't cast X and plays with his or her hand revealed.\n{U}{B}, {T}: Put X into target opponent's hand.\n{3}{U}{B}: You may play a card in the same hand as X without paying its mana cost.",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "5ed3f632-7c42-56d4-a666-8e4e9b765e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ccdda-07a0-445b-b146-51c1e3a05421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ccdda-07a0-445b-b146-51c1e3a05421.jpg?1",
             "name": "Mary O'Kill",
             "text": "{1}{BR}: Switch a Killbot or Mary O'Kill in your hand with one on the battlefield. (If a creature is tapped, the switched creature is tapped. The same is true for untapped, attacking, blocking, enchanted, equipped, and targeted. Any counters on a creature are on the switched creature instead.)",
             "colours": [
@@ -6396,7 +6396,7 @@
         },
         {
             "id": "fb0afb51-4eff-5dd1-8d51-7dcc1d17ac9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b8287-7af4-4c5b-8d76-7f865bd602c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b8287-7af4-4c5b-8d76-7f865bd602c0.jpg?1",
             "name": "Angelic Rocket",
             "text": "Flying\nWhen this creature enters the battlefield, you may destroy target nonland permanent.",
             "colours": [],
@@ -6429,7 +6429,7 @@
         },
         {
             "id": "f9be4361-4287-5c4a-b578-5cc459c1983b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480e3b96-f7fa-4dcc-a956-6b48d55097c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480e3b96-f7fa-4dcc-a956-6b48d55097c9.jpg?1",
             "name": "Border Guardian",
             "text": "Whenever you cast a silver-bordered spell, put a +1/+1 counter on Border Guardian.\nWhenever you cast a black-bordered spell, Border Guardian can't be blocked this turn.\nWhenever you cast a white-bordered spell, Border Guardian gains double strike until end of turn.",
             "colours": [],
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "bedcb479-3d5c-53ca-8f86-de86c10f5e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e18540e-6a64-4f0e-89d4-bd67c41194c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e18540e-6a64-4f0e-89d4-bd67c41194c6.jpg?1",
             "name": "Buzzing Whack-a-Doodle",
             "text": "As Buzzing Whack-a-Doodle enters the battlefield, you and an opponent each secretly choose Whack or Doodle. Then those choices are revealed. If the choices match, Buzzing Whack-a-Doodle has that ability. Otherwise, it has Buzz.\n\u2022 Whack \u2014 {T}: Target player loses 2 life.\n\u2022 Doodle \u2014 {T}: You gain 3 life.\n\u2022 Buzz \u2014 {2}, {T}: Draw a card.",
             "colours": [],
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "8b0dbdd8-85b3-5e68-b2ad-042c1db4a428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5765e68-20ee-43dc-a0d5-8e777719de44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5765e68-20ee-43dc-a0d5-8e777719de44.jpg?1",
             "name": "Clock of DOOOOOOOOOOOOM!",
             "text": "{4}, {T}: Move the CRANK counter to your Contraption deck's next sprocket and crank any number of that sprocket's Contraptions.",
             "colours": [],
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "83bbb7c8-c217-5f00-809d-4d3b50fcb387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af687c72-e5b9-4074-a3aa-1bf04fa06ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af687c72-e5b9-4074-a3aa-1bf04fa06ce9.jpg?1",
             "name": "Cogmentor",
             "text": "Flying\n{4}: Reassemble target Contraption you control. (Move it onto another one of your sprockets.)",
             "colours": [],
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "28bba9dd-9985-539b-ad4c-db4148a7d736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2253a4-5ebe-488c-9715-15917408006f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2253a4-5ebe-488c-9715-15917408006f.jpg?1",
             "name": "Contraption Cannon",
             "text": "{2}, Sacrifice Contraption Cannon: It deals damage to target creature or player equal to the number of Contraptions you control.",
             "colours": [],
@@ -6576,7 +6576,7 @@
         },
         {
             "id": "ccfcf2be-6464-5bfd-8884-c462f40fa542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2b7e0-1f6c-4c17-9648-2d74d7789442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2b7e0-1f6c-4c17-9648-2d74d7789442.jpg?1",
             "name": "Curious Killbot",
             "text": "",
             "colours": [],
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "3fa6926c-99e5-52c7-8fab-9882d8d91fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa7a8ac-65ed-4f16-9f31-08183f97da74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa7a8ac-65ed-4f16-9f31-08183f97da74.jpg?1",
             "name": "Delighted Killbot",
             "text": "",
             "colours": [],
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "5b9d346d-5f61-5527-afa8-4452b2b1da00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62acc75-484e-4945-bcd0-cba5e098ef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62acc75-484e-4945-bcd0-cba5e098ef4e.jpg?1",
             "name": "Despondent Killbot",
             "text": "",
             "colours": [],
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "015dee75-9066-5317-bdb2-26f100813869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205fb956-6e2a-4b5f-bae3-eb547a8838aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205fb956-6e2a-4b5f-bae3-eb547a8838aa.jpg?1",
             "name": "Enraged Killbot",
             "text": "",
             "colours": [],
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "7e54fdde-3f95-55cd-82f0-2fd3acd2929c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef04b83-c11a-498f-ab5e-5f05a97b7c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef04b83-c11a-498f-ab5e-5f05a97b7c98.jpg?1",
             "name": "Entirely Normal Armchair",
             "text": "During your turn, if Entirely Normal Armchair is in your hand, you may hide it on the battlefield.\n{0}: Return Entirely Normal Armchair to its owner's hand. Only any opponent may activate this ability and only if he or she sees Entirely Normal Armchair.\n{2}, Sacrifice Entirely Normal Armchair: Destroy target attacking creature.",
             "colours": [],
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "41ec313a-aac3-5002-99aa-19142e517e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09bef24-a186-4697-bd33-446fe6e25376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09bef24-a186-4697-bd33-446fe6e25376.jpg?1",
             "name": "Everythingamajig",
             "text": "{2}, {T}: Move a counter from one permanent onto another. If the second permanent refers to any kind of counter, the moved counter becomes one of those counters. Otherwise, it becomes a +1/+1 counter.\n{3}, {T}: Put a +1/+1 counter on target creature.\n{4}, {T}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "a00fa005-74d6-57e3-a1cf-5e99b300472d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ab7126-4191-4632-be2b-3e972a96bc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ab7126-4191-4632-be2b-3e972a96bc30.jpg?1",
             "name": "Everythingamajig",
             "text": "{2}, {T}: Draw a card. Activate this ability only if you have no cards in hand.\n{8}, {T}: You gain 10 life.\n{4}, {T}, Sacrifice Everythingamajig: You may put a silver-bordered permanent card from your hand onto the battlefield.",
             "colours": [],
@@ -6796,7 +6796,7 @@
         },
         {
             "id": "a28b87b7-10d4-5822-872d-d01788d7a126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8a3f9b-8ddd-4bce-95ea-f6ecfe2a5502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8a3f9b-8ddd-4bce-95ea-f6ecfe2a5502.jpg?1",
             "name": "Everythingamajig",
             "text": "{1}: Flip a coin. If you win the flip, add {C}{C} to your mana pool. Activate this ability only any time you could cast an instant.\n{3}, {T}: Target player discards a card. Activate this ability only during your turn.\n{X}: Everythingamajig becomes an X/X Construct artifact creature until end of turn.",
             "colours": [],
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "ed53807e-68c2-537f-b32a-ae43b6ba986e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6870324-16c9-4cb7-8889-8ec49d59f89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6870324-16c9-4cb7-8889-8ec49d59f89f.jpg?1",
             "name": "Everythingamajig",
             "text": "{T}: Add one mana of any color to your mana pool.\n{1}, {T}: Say the flavor text on a card in your hand. Target opponent guesses that card's name. You may reveal that card. If you do and your opponent guessed wrong, draw a card.\n{8}, {T}: Everythingamajig deals 12 damage to target creature.",
             "colours": [],
@@ -6864,7 +6864,7 @@
         },
         {
             "id": "643f38ad-8865-5bb6-9d68-094f0f3d6f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca90bc5e-e448-47b7-a011-c19ac23c5eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca90bc5e-e448-47b7-a011-c19ac23c5eaa.jpg?1",
             "name": "Everythingamajig",
             "text": "Sacrifice a land: You gain 2 life.\nSacrifice a creature: Add {C}{C} to your mana pool.\n{2}, Discard a card: Search your library for a card that shares a complete word in its name with the name of the discarded card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -6898,7 +6898,7 @@
         },
         {
             "id": "c86d15cd-efb3-5ee6-9406-48e7206bf536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c6b55b-2dbb-4740-af86-3fe0e4aa03f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c6b55b-2dbb-4740-af86-3fe0e4aa03f8.jpg?1",
             "name": "Everythingamajig",
             "text": "{1}, {T}: Scry 2.\n{1}, {T}, Pay 1 life: Create a 0/1 white Goat creature token.\n{7}, {T}, Sacrifice Everythingamajig: Choose target player. At the beginning of the next end step, exchange life totals with that player, exchange control of all permanents you and that player control, and exchange cards in your hands, cards in your libraries, and cards in your graveyards.",
             "colours": [],
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "1fa7b14f-85c5-54da-8be9-c75fa7d6a8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c110c56-cf58-4c04-a567-c55928f5d640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c110c56-cf58-4c04-a567-c55928f5d640.jpg?1",
             "name": "Gnome-Made Engine",
             "text": "When this creature enters the battlefield, create a 1/1 colorless Gnome artifact creature token.",
             "colours": [],
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "1685d45c-fd26-5956-a376-3530bd163295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9ae44-6da4-44f4-8b24-679d84e122de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9ae44-6da4-44f4-8b24-679d84e122de.jpg?1",
             "name": "Handy Dandy Clone Machine",
             "text": "{2}, {T}: Create a 2/2 colorless Homunculus creature token. It must be represented by a unique hand and two fingers at all times, or it ceases to exist.",
             "colours": [],
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "929b7895-fe9d-5cd0-97c2-a4d65a7f4918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf4f4ac-f793-4996-8f29-252398c26eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf4f4ac-f793-4996-8f29-252398c26eef.jpg?1",
             "name": "Kindslaver",
             "text": "{5}, {T}, Sacrifice Kindslaver: A person outside the game controls target player during that player's next turn. Neither player may advise that person until the end of that turn.",
             "colours": [],
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "ff9c81a2-c11a-5b2d-bb3b-660fc1075bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6eab86-ca0c-4fd6-9839-dda15ba2b1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6eab86-ca0c-4fd6-9839-dda15ba2b1ac.jpg?1",
             "name": "Krark's Other Thumb",
             "text": "If you would roll a die, instead roll two of those dice and ignore one of those results.",
             "colours": [],
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "a3cc1648-60d5-5e76-8225-725be3621261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eae1cf-f7e8-4281-a50c-fc4b728d23dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eae1cf-f7e8-4281-a50c-fc4b728d23dd.jpg?1",
             "name": "Labro Bot",
             "text": "When this creature enters the battlefield, return target host card or card with augment from your graveyard to your hand.",
             "colours": [],
@@ -7086,7 +7086,7 @@
         },
         {
             "id": "d3206d6a-f8a3-545b-9d05-2b5a98b2f304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7bc6c4-3755-4ae8-8dc2-69ac2d0a6d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7bc6c4-3755-4ae8-8dc2-69ac2d0a6d92.jpg?1",
             "name": "Lobe Lobber",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target player. Roll a six-sided die. On a 5 or higher, untap it.\"\nEquip {2}",
             "colours": [],
@@ -7116,7 +7116,7 @@
         },
         {
             "id": "766a5629-5547-5d24-be7f-464f72076bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b605c5-c2fa-452d-a062-8ca67c1d5243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b605c5-c2fa-452d-a062-8ca67c1d5243.jpg?1",
             "name": "Mad Science Fair Project",
             "text": "{T}: Roll a six-sided die. On a 3 or lower,\ntarget player adds o\nC to his or her mana\npool. Otherwise, that player adds one\nmana of any color he or she chooses to\nhis or her mana pool.",
             "colours": [],
@@ -7144,7 +7144,7 @@
         },
         {
             "id": "3df98040-f11f-54ad-aa7a-deee6ca5c42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1498cb2-9f95-4c24-924b-a9a98e54f24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1498cb2-9f95-4c24-924b-a9a98e54f24c.jpg?1",
             "name": "Modular Monstrosity",
             "text": "Whenever an opponent casts a spell, you have five seconds to choose a keyword you haven't chosen for a card named Modular Monstrosity today that's been printed on a creature card. If you do, Modular Monstrosity gains that ability. Otherwise, Modular Monstrosity loses all keyword abilities.",
             "colours": [],
@@ -7175,7 +7175,7 @@
         },
         {
             "id": "06f71902-56fd-51a3-a3b2-a088ef29ae0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18ab484-e12b-4e3f-9e72-16f9031f35f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18ab484-e12b-4e3f-9e72-16f9031f35f7.jpg?1",
             "name": "Proper Laboratory Attire",
             "text": "Equipped creature gets +2/+1 and has protection from die rolls. (Nothing that lets a player roll a die can block, target, deal damage to, or attach to equipped creature.)\nEquip {2}",
             "colours": [],
@@ -7205,7 +7205,7 @@
         },
         {
             "id": "ebccee55-b816-5fff-9510-328ddff04897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d54442-caca-412d-a716-032eaa587944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d54442-caca-412d-a716-032eaa587944.jpg?1",
             "name": "Robo-",
             "text": "At the beginning of each end step, if an artifact entered the battlefield under your control this turn,\nAugment {2} ({2}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [],
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "6a1fb044-0572-57d8-868c-77e04d145498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc5106-5dba-4eae-a102-771a4e893b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc5106-5dba-4eae-a102-771a4e893b23.jpg?1",
             "name": "Split Screen",
             "text": "When Split Screen enters the battlefield, shuffle your library and deal it into four libraries. If anything refers to your library, choose one of your libraries for it.\nPlay with your libraries' top cards revealed.\nWhen Split Screen leaves the battlefield, shuffle your libraries together.",
             "colours": [],
@@ -7264,7 +7264,7 @@
         },
         {
             "id": "879425e1-c3ab-5243-98e1-0d58e1b2b7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e57af4-b126-41e1-979a-7bce8f75217e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e57af4-b126-41e1-979a-7bce8f75217e.jpg?1",
             "name": "Staff of the Letter Magus",
             "text": "As Staff of the Letter Magus enters the battlefield, choose a consonant other than N, R, S, or T.\nWhenever a player casts a spell, you gain 1 life for each time the chosen letter appears in that spell's name.",
             "colours": [],
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "478f9b1b-c6c9-53e7-bd83-f314cdfd02ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e832a07d-b417-47fa-8a29-c31f590c2e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e832a07d-b417-47fa-8a29-c31f590c2e59.jpg?1",
             "name": "Stamp of Approval",
             "text": "As Stamp of Approval enters the battlefield, choose a watermark.\nCreatures you control with the chosen watermark get +1/+1.",
             "colours": [],
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "43e72702-16d2-5d21-83d2-c6916eed4586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be251636-acbe-4bbc-97f6-de583d0769b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be251636-acbe-4bbc-97f6-de583d0769b6.jpg?1",
             "name": "Steam-Powered",
             "text": "{5}:\nAugment {4} ({4}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [],
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "7c3079ba-5aa7-5d16-8274-9c67583e0a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feacac-9496-44bf-ad58-0fd5f3b5675a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feacac-9496-44bf-ad58-0fd5f3b5675a.jpg?1",
             "name": "Steel Squirrel",
             "text": "Whenever you roll a 5 or higher on a die, Steel Squirrel gets +X/+X until end of turn, where X is the result.\n{6}: Roll a six-sided die.",
             "colours": [],
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "5eaf4df7-8267-5519-85e3-3ef8a9e6dda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacce818-96b4-4b6f-97c4-74a22c8d9afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacce818-96b4-4b6f-97c4-74a22c8d9afb.jpg?1",
             "name": "Sword of Dungeons & Dragons",
             "text": "Equipped creature gets +2/+2 and has protection from Rogues and from Clerics.\nWhenever equipped creature deals combat damage to a player, create a 4/4 gold Dragon creature token with flying and roll a d20 (a twenty-sided die). If you roll a 20, repeat this process.\nEquip {2}",
             "colours": [],
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "bb56ba44-24e5-5913-9d7c-bbdc95500198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffcbb9f-a605-4f7f-a005-b237b4f60052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffcbb9f-a605-4f7f-a005-b237b4f60052.jpg?1",
             "name": "Voracious Vacuum",
             "text": "When this creature enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "d72d3515-636e-5520-b150-44b701ade2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4306c2-1b92-4ccc-8d92-9f27f1505113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4306c2-1b92-4ccc-8d92-9f27f1505113.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "0aad334d-ac52-54b1-a044-1dd3641a6569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728c905-41b9-438f-a9f4-4a1192c93c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728c905-41b9-438f-a9f4-4a1192c93c42.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "46b2b144-ab4a-551d-aa0b-32c8ee0878af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d836021-9289-4ab2-be85-6362670cb9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d836021-9289-4ab2-be85-6362670cb9de.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "3f457b52-53a4-53b1-b4d4-6578b0e67c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c658-0a3f-4079-b565-a491061090f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c658-0a3f-4079-b565-a491061090f0.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7577,7 +7577,7 @@
         },
         {
             "id": "145bf970-b532-5526-ab50-fe049e0f8027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba52527-191f-4b6e-a524-f2a7a01813bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba52527-191f-4b6e-a524-f2a7a01813bf.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "87f219e3-b93c-5faf-93cf-915b067a803b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf98bb09-c479-4dba-b542-ac5475fac697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf98bb09-c479-4dba-b542-ac5475fac697.jpg?1",
             "name": "Watermarket",
             "text": "{T}: Add {C}{C} to your mana pool. Spend this mana only to cast spells with watermarks.",
             "colours": [],
@@ -7638,7 +7638,7 @@
         },
         {
             "id": "2fd75397-ee58-50b9-a64a-57e4db28adef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ca02a0-5acf-4d89-847b-bad0d7560682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ca02a0-5acf-4d89-847b-bad0d7560682.jpg?1",
             "name": "Accessories to Murder",
             "text": "Whenever you crank Accessories to Murder, target creature gets +X/+0 until end of turn, where X is the number of creatures you control.",
             "colours": [],
@@ -7668,7 +7668,7 @@
         },
         {
             "id": "c2d67c95-c5b1-5620-b9ff-b6cff0c612d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd1fe5-1b80-45eb-921d-8d1a90816754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd1fe5-1b80-45eb-921d-8d1a90816754.jpg?1",
             "name": "Applied Aeronautics",
             "text": "Whenever you crank Applied Aeronautics, until end of turn, target creature gets +1/+0, gains flying, and becomes an artifact in addition to its other types.",
             "colours": [],
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "16060451-518c-5fd0-91ec-1ae43b64556c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8277ff56-067f-49dc-8f83-b9fe7b37990f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8277ff56-067f-49dc-8f83-b9fe7b37990f.jpg?1",
             "name": "Arms Depot",
             "text": "Whenever you crank Arms Depot, put two +1/+1 counters on target creature.",
             "colours": [],
@@ -7728,7 +7728,7 @@
         },
         {
             "id": "29550cc9-1610-5b56-b448-4132ea2ae42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dcdef4-7898-4620-a176-fcabd3f1fa4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dcdef4-7898-4620-a176-fcabd3f1fa4f.jpg?1",
             "name": "Auto-Key",
             "text": "Whenever you crank Auto-Key, until end of turn, target creature becomes an artifact in addition to its other types and gains \"{T}: You gain 3 life.\"",
             "colours": [],
@@ -7758,7 +7758,7 @@
         },
         {
             "id": "87a61aff-e72d-5c38-aa15-7c25ce164c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4927de5-69a4-4461-9ebe-b243e9cf00c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4927de5-69a4-4461-9ebe-b243e9cf00c4.jpg?1",
             "name": "Bee-Bee Gun",
             "text": "Whenever you crank Bee-Bee Gun, until end of turn, target creature gains \"{2}: This creature fights another target creature.\"",
             "colours": [],
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "3aa71e3b-14da-5449-97a1-f0f3231f57ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fb2587-6661-4596-9fcb-15f97aeedd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fb2587-6661-4596-9fcb-15f97aeedd37.jpg?1",
             "name": "Boomflinger",
             "text": "Whenever you crank Boomflinger, roll two six-sided dice. Boomflinger deals damage to target player equal to the difference between those results.",
             "colours": [],
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "e480472e-b538-5637-815e-324aee4519b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bac075-aa1f-4c8a-9d82-8b6c1ff9b97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bac075-aa1f-4c8a-9d82-8b6c1ff9b97a.jpg?1",
             "name": "Buzz Buggy",
             "text": "Whenever you crank Buzz Buggy, target creature gets +2/+0 and gains trample until end of turn.",
             "colours": [],
@@ -7848,7 +7848,7 @@
         },
         {
             "id": "cb854504-ccae-5539-aced-dafcf11ee47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0242175-3e91-4a6e-bcaf-036ff75cef49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0242175-3e91-4a6e-bcaf-036ff75cef49.jpg?1",
             "name": "Deadly Poison Sampler",
             "text": "Whenever you crank Deadly Poison Sampler, until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, destroy target creature that player controls.\"",
             "colours": [],
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "507db51a-c0ba-5a3a-a347-e76ffec014a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782d7294-14e6-4773-af8e-40b39f4f701a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782d7294-14e6-4773-af8e-40b39f4f701a.jpg?1",
             "name": "Dictation Quillograph",
             "text": "Whenever you crank Dictation Quillograph, until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, you may draw a card. If you do, discard a card.\"",
             "colours": [],
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "b20c429b-7b1a-570b-9eed-1b490b257d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eced6323-cfb6-4429-badb-2c249c6c69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eced6323-cfb6-4429-badb-2c249c6c69f4.jpg?1",
             "name": "Dispatch Dispensary",
             "text": "Whenever you crank Dispatch Dispensary, create a 2/2 black Rogue creature token with menace.",
             "colours": [],
@@ -7938,7 +7938,7 @@
         },
         {
             "id": "aeed39b2-face-596c-94ee-89349bef09f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fcd1f0-0ed3-46f9-a12a-fc0e9f99e97f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fcd1f0-0ed3-46f9-a12a-fc0e9f99e97f.jpg?1",
             "name": "Division Table",
             "text": "Whenever you crank Division Table, target player loses 2 life.",
             "colours": [],
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "6c743c36-1d66-5898-87ce-d32a1e9594c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003732e-efa5-42c7-8656-90fb4c9fc1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003732e-efa5-42c7-8656-90fb4c9fc1e5.jpg?1",
             "name": "Dogsnail Engine",
             "text": "Whenever you crank Dogsnail Engine, target player gains life equal to the greatest power among creatures you control.",
             "colours": [],
@@ -7998,7 +7998,7 @@
         },
         {
             "id": "4c3fa1b3-a232-522f-8361-92e87d9d78d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c91e63-284e-4403-af01-0cfe6af914c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c91e63-284e-4403-af01-0cfe6af914c1.jpg?1",
             "name": "Dual Doomsuits",
             "text": "Whenever you crank Dual Doomsuits, each time a source you control would deal damage this turn, it deals double that damage instead.",
             "colours": [],
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "9c8d1bc7-dc63-52d6-944c-95b5146542bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b586c92c-ebd7-473c-ae55-2628a9eac390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b586c92c-ebd7-473c-ae55-2628a9eac390.jpg?1",
             "name": "Duplication Device",
             "text": "Whenever you crank Duplication Device, until end of turn, target creature becomes a copy of any creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [],
@@ -8058,7 +8058,7 @@
         },
         {
             "id": "6c42dedb-801c-5cfd-bf39-2ee063ee27c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ea8a49-9644-4de9-8633-a38431a29c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ea8a49-9644-4de9-8633-a38431a29c0b.jpg?1",
             "name": "Faerie Aerie",
             "text": "Whenever you crank Faerie Aerie, create two 1/1 blue Faerie Spy creature tokens with flying, haste, and \"Whenever this creature deals combat damage to a player, draw a card.\" Exile them at the beginning of the next end step.",
             "colours": [],
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "3007fc64-4a95-50f3-a770-40d9bc1b8846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd63e12-3851-441b-9cd6-566c08940031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd63e12-3851-441b-9cd6-566c08940031.jpg?1",
             "name": "Genetic Recombinator",
             "text": "Whenever you crank Genetic Recombinator, up to two target creatures each get +2/+2 until end of turn.",
             "colours": [],
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "b89cdbf0-eb80-5171-afe0-71dafb3c2406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190dd17-adf3-4174-ab4b-cc49698b7901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190dd17-adf3-4174-ab4b-cc49698b7901.jpg?1",
             "name": "Gift Horse",
             "text": "Whenever you crank Gift Horse, roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results.",
             "colours": [],
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "c6a2001a-6e11-5e37-b2a0-f9e4227f6048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291989b2-d87f-4e5a-a159-4d564d1c2c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291989b2-d87f-4e5a-a159-4d564d1c2c6a.jpg?1",
             "name": "Gnomeball Machine",
             "text": "Whenever you crank Gnomeball Machine, create two 1/1 colorless Gnome artifact creature tokens.",
             "colours": [],
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "b19037b9-7c48-5ae9-b472-21746ee959ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368a5ae-5642-4e90-9e73-9f0283067c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368a5ae-5642-4e90-9e73-9f0283067c15.jpg?1",
             "name": "Goblin Slingshot",
             "text": "Whenever you crank Goblin Slingshot, creatures you control get +2/+0 and gain trample until end of turn.",
             "colours": [],
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "621e290d-7bdb-50bd-91a2-8352888dbd9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9968bad-07fb-4fc5-8ce7-78936c4e6c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9968bad-07fb-4fc5-8ce7-78936c4e6c28.jpg?1",
             "name": "Guest List",
             "text": "Whenever you crank Guest List, target creature gets -X/-X until end of turn, where X is the number of creature cards in its controller's graveyard.",
             "colours": [],
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "860d6591-3593-5636-b00e-532627c0670b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc6c38-18e7-44b1-91d0-dfa1acdb4106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc6c38-18e7-44b1-91d0-dfa1acdb4106.jpg?1",
             "name": "Hard Hat Area",
             "text": "Whenever you crank Hard Hat Area, roll two six-sided dice. Hard Hat Area assembles a number of Contraptions equal to the difference between those results. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [],
@@ -8268,7 +8268,7 @@
         },
         {
             "id": "1542d7a4-0064-5dba-8447-aa129654aa2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c3fc99-227b-402e-9b33-07bbec9a7699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c3fc99-227b-402e-9b33-07bbec9a7699.jpg?1",
             "name": "Head Banger",
             "text": "Whenever you crank Head Banger, target creature must be blocked this turn if able.",
             "colours": [],
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "8fcfec31-465d-58d0-89b6-4590a62ac3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d193e9-8bcd-452e-a7d8-37b519b6c2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d193e9-8bcd-452e-a7d8-37b519b6c2b5.jpg?1",
             "name": "Hypnotic Swirly Disc",
             "text": "Whenever you crank Hypnotic Swirly Disc, target player puts the top X cards of his or her library into his or her graveyard, where X is the number of creatures you control.",
             "colours": [],
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "d63ddb6f-51e2-5255-b84a-9bc827f972ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60b15f8-95e8-43b2-a21e-26cb7e686745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60b15f8-95e8-43b2-a21e-26cb7e686745.jpg?1",
             "name": "Inflation Station",
             "text": "Whenever you crank Inflation Station, target creature gets +3/+3 until end of turn.",
             "colours": [],
@@ -8358,7 +8358,7 @@
         },
         {
             "id": "6b2cab30-6c96-51cc-995d-a0b5fa77c08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0741c7b2-0e1e-42ed-aa97-5b3ba123d44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0741c7b2-0e1e-42ed-aa97-5b3ba123d44f.jpg?1",
             "name": "Insufferable Syphon",
             "text": "Whenever you crank Insufferable Syphon, target player discards a card.",
             "colours": [],
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "e7402580-71aa-5b21-b809-f399e9bdd8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe920f24-720b-4b92-bac4-651b8faae90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe920f24-720b-4b92-bac4-651b8faae90e.jpg?1",
             "name": "Jamming Device",
             "text": "Whenever you crank Jamming Device, creatures target player controls get -1/-1 until end of turn.",
             "colours": [],
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "96b7e568-01cb-5fe8-92d8-536e9b0991e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7bc397-eb40-4647-a06c-d3f427eb8c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7bc397-eb40-4647-a06c-d3f427eb8c3a.jpg?1",
             "name": "Lackey Recycler",
             "text": "Whenever you crank Lackey Recycler, put target creature card from your graveyard on top of your library.",
             "colours": [],
@@ -8448,7 +8448,7 @@
         },
         {
             "id": "f302de50-f886-5f29-aa2e-c670eed6f2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ad93ba-dd05-4a29-ac36-2b9b4474309a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ad93ba-dd05-4a29-ac36-2b9b4474309a.jpg?1",
             "name": "Mandatory Friendship Shackles",
             "text": "Whenever you crank Mandatory Friendship Shackles, target creature gets -1/-1 until end of turn.",
             "colours": [],
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "b663a55f-352d-58a8-962a-3c90d7ce5a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b8f6cd-04d1-4c99-9fac-e606b08e750a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b8f6cd-04d1-4c99-9fac-e606b08e750a.jpg?1",
             "name": "Neural Network",
             "text": "Whenever you crank Neural Network, gain control of target creature an opponent controls with power less than or equal to the number of creature cards in its controller's graveyard until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [],
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "c4e4c21a-70e7-5084-a5c8-7f9a921164e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488398b3-8b85-4017-87db-f7b683eef3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488398b3-8b85-4017-87db-f7b683eef3d6.jpg?1",
             "name": "Oaken Power Suit",
             "text": "Whenever you crank Oaken Power Suit, target creature gets +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [],
@@ -8538,7 +8538,7 @@
         },
         {
             "id": "6a7258b0-e50a-51ab-bd17-02de8ba7bf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505f1be-4d9f-4536-a3f7-c6e6e19d5678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505f1be-4d9f-4536-a3f7-c6e6e19d5678.jpg?1",
             "name": "Optical Optimizer",
             "text": "Whenever you crank Optical Optimizer, until end of turn, target creature becomes an artifact in addition to its other types and gains \"{T}: Draw a card.\"",
             "colours": [],
@@ -8568,7 +8568,7 @@
         },
         {
             "id": "2f832189-3171-5586-9ed9-1dced0a91a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1430162-6df1-4b24-b533-559ac2f97a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1430162-6df1-4b24-b533-559ac2f97a09.jpg?1",
             "name": "Pet Project",
             "text": "Whenever you crank Pet Project, put target creature card from an opponent's graveyard onto the battlefield under your control.",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "0b443b5c-7202-5ea6-b26d-74e7ed30c698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eccf9ee-3909-49d4-b489-fe0798d1a3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eccf9ee-3909-49d4-b489-fe0798d1a3a1.jpg?1",
             "name": "Quick-Stick Lick Trick",
             "text": "Whenever you crank Quick-Stick Lick Trick, target creature gets +1/+1 and gains lifelink until end of turn.",
             "colours": [],
@@ -8628,7 +8628,7 @@
         },
         {
             "id": "af7f2d13-21cc-58f3-89be-a9fd2ae8e9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337af8e8-940f-4afd-bd0c-330de63f79c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337af8e8-940f-4afd-bd0c-330de63f79c9.jpg?1",
             "name": "Rapid Prototyper",
             "text": "Whenever you crank Rapid Prototyper, create an X/X colorless Construct artifact creature token, where X is the number of artifacts you control.",
             "colours": [],
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "2c86ec97-956c-5bc6-9291-c44fe1f67eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1028aa-0a08-4851-a108-93c3c72ebe99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1028aa-0a08-4851-a108-93c3c72ebe99.jpg?1",
             "name": "Record Store",
             "text": "Whenever you crank Record Store, look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8688,7 +8688,7 @@
         },
         {
             "id": "7941df9f-8511-5d68-b6a7-489cade3e704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3b81f-7393-4f85-8b1c-59d560778ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3b81f-7393-4f85-8b1c-59d560778ca1.jpg?1",
             "name": "Refibrillator",
             "text": "Whenever you crank Refibrillator, return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "09618c19-c87e-51e2-959c-8b176156c9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8d38a8-e835-4314-80eb-6a574756431d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8d38a8-e835-4314-80eb-6a574756431d.jpg?1",
             "name": "Sap Sucker",
             "text": "Whenever you crank Sap Sucker, add {G} to your mana pool. Until end of turn, this mana doesn't empty from your mana pool as steps and phases end.",
             "colours": [],
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "3dfaad31-d6a0-57f5-807e-dc4084caffbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2420ee20-c7f1-42e8-b8c5-efc0206887aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2420ee20-c7f1-42e8-b8c5-efc0206887aa.jpg?1",
             "name": "Sundering Fork",
             "text": "Whenever you crank Sundering Fork, destroy target artifact.",
             "colours": [],
@@ -8780,7 +8780,7 @@
         },
         {
             "id": "ca7fc729-c29b-5d8f-953c-170a7a8d9817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52882b9b-fbf2-405e-9eee-ddb434874070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52882b9b-fbf2-405e-9eee-ddb434874070.jpg?1",
             "name": "Targeting Rocket",
             "text": "Whenever you crank Targeting Rocket, target creature blocks this turn if able.",
             "colours": [],
@@ -8810,7 +8810,7 @@
         },
         {
             "id": "ca8f36b8-9208-5976-9145-0ba042c3f963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40dafec-1243-413c-84db-c07a8cf6d628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40dafec-1243-413c-84db-c07a8cf6d628.jpg?1",
             "name": "Thud-for-Duds",
             "text": "Whenever you crank Thud-for-Duds, roll two six-sided dice. Thud-for-Duds deals damage to target creature equal to the difference between those results.",
             "colours": [],
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "863a254b-6422-5ae3-bc92-40c5ac8dc543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f6ce-1c39-453a-8edf-5461a9db8b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f6ce-1c39-453a-8edf-5461a9db8b8f.jpg?1",
             "name": "Top-Secret Tunnel",
             "text": "Whenever you crank Top-Secret Tunnel, target creature can't be blocked this turn.",
             "colours": [],
@@ -8870,7 +8870,7 @@
         },
         {
             "id": "182275a2-be91-5a7a-93d1-b80c7fcd8560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d2f8f3-7bd0-4775-806b-1583da4814a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d2f8f3-7bd0-4775-806b-1583da4814a5.jpg?1",
             "name": "Tread Mill",
             "text": "Whenever you crank Tread Mill, until end of turn, target creature gets +1/+2, gains vigilance, and becomes an artifact in addition to its other types.",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "83e0fc96-aa7c-59a4-863c-62a685c4c973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be96ad59-cec0-4b82-877d-7ffa2755cebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be96ad59-cec0-4b82-877d-7ffa2755cebf.jpg?1",
             "name": "Turbo-Thwacking Auto-Hammer",
             "text": "Whenever you crank Turbo-Thwacking Auto-Hammer, target creature gains double strike until end of turn.",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "1c617718-b025-5d5e-8cbb-bbf652af6165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce1145-ca48-4fee-a11d-df88c20bd852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce1145-ca48-4fee-a11d-df88c20bd852.jpg?1",
             "name": "Twiddlestick Charger",
             "text": "Whenever you crank Twiddlestick Charger, tap or untap target creature.",
             "colours": [],
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "198eb6ac-6e8e-56ad-92e4-58e7ae5992b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11519144-1f4c-4f11-9a36-4456d45098a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11519144-1f4c-4f11-9a36-4456d45098a1.jpg?1",
             "name": "Widget Contraption",
             "text": "Whenever you crank Widget Contraption, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [],
@@ -8990,7 +8990,7 @@
         },
         {
             "id": "c7f233d4-0770-5b10-9836-b4034047a9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c8b8e-2e28-4f10-b04f-9b313c60c0bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c8b8e-2e28-4f10-b04f-9b313c60c0bb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9024,7 +9024,7 @@
         },
         {
             "id": "f25771fd-0ee8-5499-95cb-aa8093c0c45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b2118-b22c-4ef5-bac7-836db4b8b9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b2118-b22c-4ef5-bac7-836db4b8b9ee.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9058,7 +9058,7 @@
         },
         {
             "id": "d0a61ccf-d4ca-5640-9e36-562088817708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108b0fb-420a-422d-ae85-9a99c0f73169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108b0fb-420a-422d-ae85-9a99c0f73169.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "203688a0-57b3-5560-9fd3-3cc193667827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1a862-00fc-4e79-a83a-289fef81503a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1a862-00fc-4e79-a83a-289fef81503a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9126,7 +9126,7 @@
         },
         {
             "id": "2e38aa40-48bd-5a1b-bce7-a53f5ae2911d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8772631-d4a1-440d-ac89-ac6659bdc073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8772631-d4a1-440d-ac89-ac6659bdc073.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "8e1f827f-baa9-50b9-a165-2e33175d4b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg?1",
             "name": "Angel // Angel",
             "text": "",
             "colours": [
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "b6f3e90f-2ddf-5067-ad65-4150865fcad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg?1",
             "name": "Angel // Angel",
             "text": "",
             "colours": [
@@ -9225,7 +9225,7 @@
         },
         {
             "id": "49f34b52-a64a-5352-a362-1a7bfea5baab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b44a88-85e8-4f82-8968-cf1352f0fb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b44a88-85e8-4f82-8968-cf1352f0fb87.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "c6704eb3-dc05-5ba4-8138-e578e5d6ce3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg?1",
             "name": "Spirit // Spirit",
             "text": "",
             "colours": [
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "105fb6c8-1ec4-5eca-a024-1603b2a8fe84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg?1",
             "name": "Spirit // Spirit",
             "text": "",
             "colours": [
@@ -9324,7 +9324,7 @@
         },
         {
             "id": "00599669-2f9c-5f4d-ae77-64b2840ce3bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008e47a-a8c4-4f4f-8628-ac4b8f978dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008e47a-a8c4-4f4f-8628-ac4b8f978dd0.jpg?1",
             "name": "Faerie Spy",
             "text": "",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "583a9407-fae0-5b72-8017-c49e5c4701dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80165be4-c6c8-4b22-b259-c64eb4b7fc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80165be4-c6c8-4b22-b259-c64eb4b7fc95.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "d8fcf9ab-0a1e-5bb9-9095-d9f21ecef810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg?1",
             "name": "Thopter // Thopter",
             "text": "",
             "colours": [
@@ -9428,7 +9428,7 @@
         },
         {
             "id": "01a2b9ed-170e-51d9-8cd0-50582b393393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg?1",
             "name": "Thopter // Thopter",
             "text": "",
             "colours": [
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "0289045f-4003-52c1-a805-9c3759130054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633d7b-6d61-4b1a-8d65-6e1f3d5ffba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633d7b-6d61-4b1a-8d65-6e1f3d5ffba7.jpg?1",
             "name": "Rogue",
             "text": "",
             "colours": [
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "d1fed647-a495-51e4-904b-85946036fbc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg?1",
             "name": "Vampire // Vampire",
             "text": "",
             "colours": [
@@ -9527,7 +9527,7 @@
         },
         {
             "id": "3d8ead38-b452-5999-8d82-2247cf92c602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg?1",
             "name": "Vampire // Vampire",
             "text": "",
             "colours": [
@@ -9558,7 +9558,7 @@
         },
         {
             "id": "510ddecb-189f-5951-82a0-f2704fc079b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg?1",
             "name": "Zombie // Zombie",
             "text": "",
             "colours": [
@@ -9592,7 +9592,7 @@
         },
         {
             "id": "64a647cc-efa5-5c52-87d1-9a4cfedf52ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg?1",
             "name": "Zombie // Zombie",
             "text": "",
             "colours": [
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "3cee8fbc-9a87-5ec9-906c-4ddcb978f6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1a8115-127d-4268-a4d0-95360862e5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1a8115-127d-4268-a4d0-95360862e5fb.jpg?1",
             "name": "Brainiac",
             "text": "",
             "colours": [
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "a0fc88f2-fde4-581d-9bca-111e01888e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -9691,7 +9691,7 @@
         },
         {
             "id": "b26bd125-c227-5c1b-a00e-660af80a3ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -9722,7 +9722,7 @@
         },
         {
             "id": "2774cdb5-a6d6-5f29-9092-aa29913f1562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be4b0d5-b3f8-4a5d-8a38-eb0e1886f655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be4b0d5-b3f8-4a5d-8a38-eb0e1886f655.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9756,7 +9756,7 @@
         },
         {
             "id": "aaa77154-0683-5efd-b433-401a3a156f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg?1",
             "name": "Beast // Beast",
             "text": "",
             "colours": [
@@ -9790,7 +9790,7 @@
         },
         {
             "id": "47b64de2-bcbb-5a99-8364-a292f7d6daef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg?1",
             "name": "Beast // Beast",
             "text": "",
             "colours": [
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "f2df0021-b3ad-540b-9f9d-794fd2e208bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg?1",
             "name": "Saproling // Saproling",
             "text": "",
             "colours": [
@@ -9855,7 +9855,7 @@
         },
         {
             "id": "d2a392d6-599f-5ceb-ab99-90d47f0e4685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg?1",
             "name": "Saproling // Saproling",
             "text": "",
             "colours": [
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "635c3b86-6abb-5d76-8cb9-edf324c55576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53500f0f-ef65-4534-a8db-80ce73030bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53500f0f-ef65-4534-a8db-80ce73030bc1.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -9920,7 +9920,7 @@
         },
         {
             "id": "8fa3153c-0257-5bab-b1af-b95f1a77c905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c65dfd-69be-4345-92e9-51a35a486f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c65dfd-69be-4345-92e9-51a35a486f21.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [],
@@ -9950,7 +9950,7 @@
         },
         {
             "id": "65af3978-a2ad-5607-8c7b-1d7c82292fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "f01363ef-2fbd-56b2-80b1-017ccfa6f907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "0ed8e23f-eae3-5f95-abed-b1bea07d2503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg?1",
             "name": "Clue // Clue",
             "text": "",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "a8f45998-a850-5176-b877-8f771ef980ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg?1",
             "name": "Clue // Clue",
             "text": "",
             "colours": [],
@@ -10076,7 +10076,7 @@
         },
         {
             "id": "d223b599-3253-5f87-8e98-1dfe083fa7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1935902c-d84f-496a-b9f1-f96d1f5e2b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1935902c-d84f-496a-b9f1-f96d1f5e2b84.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -10107,7 +10107,7 @@
         },
         {
             "id": "32d8fbf9-e5f4-5d90-8f0c-01b7fa813113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf33cc3-254f-4c5c-be22-3a2d96f29b80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf33cc3-254f-4c5c-be22-3a2d96f29b80.jpg?1",
             "name": "Gnome",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/VIS.json
+++ b/Assets/Resources/Sets/VIS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9521f4ad-1d27-50cc-87c3-af89ddae109a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368144bf-d415-48ab-a957-9d7ac1ceb353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368144bf-d415-48ab-a957-9d7ac1ceb353.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking does not cause Archangel to tap.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "39341424-6f21-57db-bf0f-a7a2890315ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7afcaa-9df8-4dd6-89ad-bc2e15f1ec4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7afcaa-9df8-4dd6-89ad-bc2e15f1ec4b.jpg?1",
             "name": "Daraja Griffin",
             "text": "Flying\nSacrifice Daraja Griffin: Destroy target black creature.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "9cc92819-c954-5cc9-a884-dfadffba12b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53783312-3551-4361-ab02-c9651ce2a926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53783312-3551-4361-ab02-c9651ce2a926.jpg?1",
             "name": "Equipoise",
             "text": "During your upkeep, for each land target player controls in excess of the number of lands you control, target land he or she controls phases out. Repeat this process for artifacts and then for creatures.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "1b87b003-7b5e-549c-9a38-d0bccdbd73cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa84e4ad-738a-4d23-a84c-06c39ff4200b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa84e4ad-738a-4d23-a84c-06c39ff4200b.jpg?1",
             "name": "Eye of Singularity",
             "text": "When Eye of Singularity comes into play, bury all permanents with the same name except basic lands.\nWhenever any permanent other than a basic land comes into play, bury any permanent already in play with the same name.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "1908536e-4c6d-596a-9605-758a28c1e362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dc0244-319c-4e15-9083-8d21ad0364d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dc0244-319c-4e15-9083-8d21ad0364d8.jpg?1",
             "name": "Freewind Falcon",
             "text": "Flying, protection from red",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "57d17fcb-7fb1-5822-ac39-ae3ef9a19242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9917a29-c6b4-4e0a-a301-21868bd27e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9917a29-c6b4-4e0a-a301-21868bd27e17.jpg?1",
             "name": "Gossamer Chains",
             "text": "Return Gossamer Chains to owner's hand: Target unblocked creature deals no combat damage this turn.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "77821b34-9612-5dc2-895f-670875fefef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559d301-98bd-40a9-abf4-1079d7283214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559d301-98bd-40a9-abf4-1079d7283214.jpg?1",
             "name": "Honorable Passage",
             "text": "Prevent all damage to you or target creature from any one source. If that source is red, Honorable Passage deals to the source's controller an amount of damage equal to the amount of damage prevented.",
             "colours": [
@@ -229,7 +229,7 @@
         },
         {
             "id": "596fd214-760b-5f48-b49b-9bda84d6a54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a8980f-07ab-49b7-b83d-f394952ced57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a8980f-07ab-49b7-b83d-f394952ced57.jpg?1",
             "name": "Hope Charm",
             "text": "Choose one Target creature gains first strike until end of turn; or target player gains 2 life; or destroy target local enchantment.",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "dffad234-9995-5ac5-836d-3902f927bcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0350470b-feea-4e15-bdf0-850b71dbeea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0350470b-feea-4e15-bdf0-850b71dbeea6.jpg?1",
             "name": "Infantry Veteran",
             "text": "oc\nT: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "0bdd505c-9816-59eb-8000-c42a5288f6f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc681f5-9fff-48b6-98d9-e85c85e582a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc681f5-9fff-48b6-98d9-e85c85e582a3.jpg?1",
             "name": "Jamuraan Lion",
             "text": "o\nW, oc\nT: Target creature cannot block this turn.",
             "colours": [
@@ -327,7 +327,7 @@
         },
         {
             "id": "8d2cb294-bd42-5e31-a94c-a10fbc0107b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa80ae-bb17-4e52-a269-efe75cf4c041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa80ae-bb17-4e52-a269-efe75cf4c041.jpg?1",
             "name": "Knight of Valor",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1oo\nW Each creature without flanking blocking Knight of Valor gets -1/-1 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "4d9d55f2-f9ac-530a-99af-4e3a0a75b068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee185d-f5ae-4b1d-90a4-840182f87ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee185d-f5ae-4b1d-90a4-840182f87ab8.jpg?1",
             "name": "Longbow Archer",
             "text": "First strike\nLongbow Archer can block creatures with flying.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "de966bfd-c5fe-537f-aad2-01d99589775a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fecb31-790a-4454-918e-5aeb253021f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fecb31-790a-4454-918e-5aeb253021f0.jpg?1",
             "name": "Miraculous Recovery",
             "text": "Put target creature card from your graveyard into play and put a +1/+1 counter on that creature. Treat the creature as though it were just played.",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "8c84425c-f028-5678-9d03-5bd2e46a2e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bbcaa9-edbf-48ad-bcd2-65e8fb9bb938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bbcaa9-edbf-48ad-bcd2-65e8fb9bb938.jpg?1",
             "name": "Parapet",
             "text": "You may choose to play Parapet as an instant; if you do, bury it at end of turn.\nAll creatures you control get +0/+1.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "f759753b-1626-5d32-9817-54fc863f2600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21da279d-a723-4902-bf84-dfe2c569d4c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21da279d-a723-4902-bf84-dfe2c569d4c8.jpg?1",
             "name": "Peace Talks",
             "text": "During this turn and the next one, players cannot declare an attack and cannot play spells or abilities that target any permanent or player.",
             "colours": [
@@ -489,7 +489,7 @@
         },
         {
             "id": "52d8f995-f7a2-5b45-ac3b-1bf735ce3d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0459667-b7da-43bd-b981-0e515432d147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0459667-b7da-43bd-b981-0e515432d147.jpg?1",
             "name": "Relic Ward",
             "text": "You may choose to play Relic Ward as an instant; if you do, bury it at end of turn.\nEnchanted artifact cannot be the target of spells or effects.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "fb5916ca-8777-5803-86af-cda8557dd3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0b7162-4422-4dfb-a6ca-8d89fa74e6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0b7162-4422-4dfb-a6ca-8d89fa74e6dc.jpg?1",
             "name": "Remedy",
             "text": "Prevent up to 5 damage total to any number of creatures and/or players.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "eb3cb1a0-f1eb-57a8-9775-3ebbe3c4d211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21250bdb-9431-41b3-9fef-d66a4d3f6ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21250bdb-9431-41b3-9fef-d66a4d3f6ecd.jpg?1",
             "name": "Resistance Fighter",
             "text": "Sacrifice Resistance Fighter: Target creature deals no combat damage this turn.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "96b754e0-34c2-5f27-8e6c-5c229466c82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860b8633-1bfc-426a-8666-5e6a584d4525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860b8633-1bfc-426a-8666-5e6a584d4525.jpg?1",
             "name": "Retribution of the Meek",
             "text": "Bury all creatures with power 4 or greater.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "c788644f-8f8f-5e8c-95c3-000ca51eb84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed82843-2853-42d3-bcf6-b831032b7a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed82843-2853-42d3-bcf6-b831032b7a69.jpg?1",
             "name": "Righteous Aura",
             "text": "o\nW, Pay 2 life: Prevent all damage to you from any one source.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "2b2209bc-459a-5c73-a501-2f53d551514b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f1fb74-bc08-4c3b-9fbe-da6973aaeaa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f1fb74-bc08-4c3b-9fbe-da6973aaeaa2.jpg?1",
             "name": "Sun Clasp",
             "text": "Enchanted creature gets +1/+3.\noo\nW Return enchanted creature to owner's hand.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "435411cd-9ff9-5d0d-ba57-ac6f0435de86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177d5bf-db48-4bbf-bbd4-ee6313031920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177d5bf-db48-4bbf-bbd4-ee6313031920.jpg?1",
             "name": "Teferi's Honor Guard",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no\nUoo\nU Phase out",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "12c17218-27cb-5f8d-bec7-8071c9bc1558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae08938-e563-4322-b2eb-db81913ea730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae08938-e563-4322-b2eb-db81913ea730.jpg?1",
             "name": "Tithe",
             "text": "Search your library for a plains card. If you control fewer lands than target opponent, you may search your library for an additional plains card. Reveal those cards to all players and put them into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "7440af79-cc9e-5646-a2d2-f0fceb3938fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7babd273-3e20-4cf9-bf21-c602eb729fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7babd273-3e20-4cf9-bf21-c602eb729fc5.jpg?1",
             "name": "Warrior's Honor",
             "text": "All creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "98036d65-0f7e-5c97-b629-6345e19aff9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed802f-6e54-4fed-a71e-6d404c2c664b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed802f-6e54-4fed-a71e-6d404c2c664b.jpg?1",
             "name": "Zhalfirin Crusader",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1oo\nW Redirect 1 damage from Zhalfirin Crusader to target creature or player.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "ea020bf4-0b8b-543c-ac4b-f2ed6940eb67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9b5c75-882e-4fe4-827f-584080e91485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9b5c75-882e-4fe4-827f-584080e91485.jpg?1",
             "name": "Betrayal",
             "text": "Play only on a creature an opponent controls.\nIf enchanted creature becomes tapped, draw a card.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "ab1f8fbd-a04f-5422-aeb0-1c089780e43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaefa77-6e4a-4724-a443-fa6b45803db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaefa77-6e4a-4724-a443-fa6b45803db5.jpg?1",
             "name": "Breezekeeper",
             "text": "Flying, phasing",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "cba1477f-ad31-5304-ab78-d31bfff73f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ada02f-04e9-4269-b04a-97a7eaac2c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ada02f-04e9-4269-b04a-97a7eaac2c46.jpg?1",
             "name": "Chronatog",
             "text": "Skip your next turn: Chronatog gets +3/+3 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "594cd2f3-17ac-5bd2-9f29-f617e1133abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2a5146-cf2e-40c0-b498-06e611343196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2a5146-cf2e-40c0-b498-06e611343196.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "48f031f2-7db6-5786-92ab-680408204e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2a1779-af08-4a9a-aba4-e6892ce2332c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2a1779-af08-4a9a-aba4-e6892ce2332c.jpg?1",
             "name": "Desertion",
             "text": "Counter target spell. If that spell is an artifact or summon spell, put that card into play under your control as though it were just played.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "9396c7a9-8ef0-5cca-85b3-b4091d30987c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd292a0-ec08-4250-8d75-0802e985d6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd292a0-ec08-4250-8d75-0802e985d6e6.jpg?1",
             "name": "Dream Tides",
             "text": "Creatures do not untap during their controllers' untap phase.\nEach nongreen creature's controller may pay an additional o2 during his or her upkeep to untap that creature.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "f2d35836-03d8-554a-bec8-00f086300e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49db9f58-380f-496e-9d3d-6776d30fb564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49db9f58-380f-496e-9d3d-6776d30fb564.jpg?1",
             "name": "Flooded Shoreline",
             "text": "o\nUo\nU, Return two islands you control to owner's hand: Return target creature to owner's hand.",
             "colours": [
@@ -1038,7 +1038,7 @@
         },
         {
             "id": "3fc3f63c-fad2-5814-943f-74ebc3a9a0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54c51de-bfac-4198-a7c4-37b4db74e525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54c51de-bfac-4198-a7c4-37b4db74e525.jpg?1",
             "name": "Foreshadow",
             "text": "Name a card. Put the top card from target opponent's library into his or her graveyard. If that card is the one named, draw a card.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "ae66cd65-91a4-5df7-8fab-d3cd97122fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d710a97-062f-4773-b6c6-8aeddeb3b6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d710a97-062f-4773-b6c6-8aeddeb3b6e8.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library. Shuffle your library afterwards.",
             "colours": [
@@ -1100,7 +1100,7 @@
         },
         {
             "id": "63dc205b-7055-5a17-a5bc-cdf2f444750d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5247d0b0-660e-4f27-8e76-62effbe12221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5247d0b0-660e-4f27-8e76-62effbe12221.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "e05325ad-1a4c-554a-a477-17704414cfe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37924cbc-fb9d-4906-9ad2-9b6d4ccfff0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37924cbc-fb9d-4906-9ad2-9b6d4ccfff0f.jpg?1",
             "name": "Knight of the Mists",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nWhen Knight of the Mists comes into play, pay o\nU or bury target Knight.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "c002fdda-f978-5370-90a6-c8ffbe8d17a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbf9bf9-75cd-4b25-a3a1-43b7e029700b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbf9bf9-75cd-4b25-a3a1-43b7e029700b.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War comes into play, return target creature to owner's hand.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "63e49727-62e6-51bb-b999-138f0296e751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb640d-5c54-4d0a-b8c2-e22fe04f96c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb640d-5c54-4d0a-b8c2-e22fe04f96c2.jpg?1",
             "name": "Mystic Veil",
             "text": "You may choose to play Mystic Veil as an instant; if you do, bury it at end of turn.\nEnchanted creature cannot be the target of spells or effects.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "16a69039-088e-591e-a346-0add4e998194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f0988-4194-4481-a6b7-27753261174a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f0988-4194-4481-a6b7-27753261174a.jpg?1",
             "name": "Ovinomancer",
             "text": "When Ovinomancer comes into play, return three basic lands you control to owner's hand or bury Ovinomancer.\noc\nT, Return Ovinomancer to owner's hand: Bury target creature and put a Sheep token into play under the control of the creature's controller. Treat this token as a 0/1 green creature.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "15260d66-27d5-5ae8-bf8d-df2f6e779f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5e806-3cf2-4241-b45d-a05d2b715efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5e806-3cf2-4241-b45d-a05d2b715efd.jpg?1",
             "name": "Prosperity",
             "text": "Each player draws X cards.",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "0dc321b6-9db8-5e65-a623-5dbd1fded5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6f03a6-3665-40e4-ae68-640913972770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6f03a6-3665-40e4-ae68-640913972770.jpg?1",
             "name": "Rainbow Efreet",
             "text": "Flying\no\nUo\nU: Phase out",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "2de59638-bb8c-5910-a744-72f5655aae9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5704f-5856-4422-9d82-14558dbe1434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5704f-5856-4422-9d82-14558dbe1434.jpg?1",
             "name": "Shimmering Efreet",
             "text": "Flying, phasing\nWhen Shimmering Efreet phases in, target creature phases out.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "3c7053bb-2cdf-5822-9dca-3f3203082e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63971a64-c5f3-4d1f-ae0d-489d7d5b18f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63971a64-c5f3-4d1f-ae0d-489d7d5b18f0.jpg?1",
             "name": "Shrieking Drake",
             "text": "Flying\nWhen Shrieking Drake comes into play, return a creature you control to owner's hand.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "a12ff333-e1cf-56a2-8801-3abba7358599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba3e4ea-2241-4f1e-a46b-70f512fe729e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba3e4ea-2241-4f1e-a46b-70f512fe729e.jpg?1",
             "name": "Teferi's Realm",
             "text": "At the beginning of each player's upkeep, that player chooses artifacts, creatures, lands, or global enchantments. All cards of that type phase out.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "82923bcc-eb48-53db-9250-b76b37ba564c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2b253-7023-44d1-963b-eae98d48f498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2b253-7023-44d1-963b-eae98d48f498.jpg?1",
             "name": "Three Wishes",
             "text": "Take the top three cards from your library, look at them, and set them aside face down. You may play those cards as though they were in your hand. At the beginning of your next turn, bury any of those cards not played.",
             "colours": [
@@ -1459,7 +1459,7 @@
         },
         {
             "id": "103d28fd-3b69-5604-b103-3a05120d8f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b348a-0301-4d45-a2c1-d78802c445ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b348a-0301-4d45-a2c1-d78802c445ba.jpg?1",
             "name": "Time and Tide",
             "text": "All creatures that are phased out phase in and all creatures with phasing phase out.",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "36fb7bd8-11d3-5345-88a9-3b24bb8c5c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bef942e-9d17-4d40-a4c9-8be715e73a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bef942e-9d17-4d40-a4c9-8be715e73a08.jpg?1",
             "name": "Undo",
             "text": "Return two target creatures to owner's hand.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "7063d8c9-6ab4-5b0c-ba46-03292ced0c45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1fb805-1382-458c-b98d-4491f13833b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1fb805-1382-458c-b98d-4491f13833b6.jpg?1",
             "name": "Vanishing",
             "text": "o\nUoo\nU Enchanted creature phases out.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "a7842c17-9736-5c4c-874b-e2b23338100f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b384d3-3adf-493a-8b89-bfe68fd1c3e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b384d3-3adf-493a-8b89-bfe68fd1c3e2.jpg?1",
             "name": "Vision Charm",
             "text": "Choose one Target artifact phases out; or put the top four cards from target player's library into his or her graveyard; or all lands of one type are basic lands of your choice until end of turn.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "c255557c-5a2a-5346-97d4-2356dc3372ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6946a75e-e9d1-4a56-86d1-dd81f7b1b125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6946a75e-e9d1-4a56-86d1-dd81f7b1b125.jpg?1",
             "name": "Waterspout Djinn",
             "text": "Flying\nDuring your upkeep, return an untapped island you control to owner's hand or bury Waterspout Djinn.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "2e5ee823-dd12-5532-a554-873173032738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369a5df5-fc36-476c-84f4-ec4bdeb4f9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369a5df5-fc36-476c-84f4-ec4bdeb4f9d2.jpg?1",
             "name": "Aku Djinn",
             "text": "Trample\nDuring your upkeep, each opponent puts a +1/+1 counter on each creature he or she controls.",
             "colours": [
@@ -1651,7 +1651,7 @@
         },
         {
             "id": "a0a27a80-13ac-56a5-a20b-072788d38c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe012fd0-9ff0-4436-a890-3ab436e42201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe012fd0-9ff0-4436-a890-3ab436e42201.jpg?1",
             "name": "Blanket of Night",
             "text": "Each mana-producing land is a swamp in addition to its normal land type.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "5852d611-1733-5f66-99c2-418237a61da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b6150e-7d0c-4361-b99b-79de96dfc53a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b6150e-7d0c-4361-b99b-79de96dfc53a.jpg?1",
             "name": "Brood of Cockroaches",
             "text": "If Brood of Cockroaches is put into your graveyard from play, pay 1 life and return Brood of Cockroaches to your hand at end of turn.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "14b6a11e-c2ad-5608-97d6-75e2039454fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b07d33-f5f5-45cc-b2ac-360eaf2d4146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b07d33-f5f5-45cc-b2ac-360eaf2d4146.jpg?1",
             "name": "Coercion",
             "text": "Look at target opponent's hand. Choose a card from that player's hand. That player discards that card.",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "7b1f90c2-ca96-5898-aa4a-a55dda440362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736455f6-c1b3-4a5a-a91f-a0cd3986ed53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736455f6-c1b3-4a5a-a91f-a0cd3986ed53.jpg?1",
             "name": "Crypt Rats",
             "text": "oo\nX Crypt Rats deals X damage to each creature and player. Spend only black mana in this way.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "830d997b-1a35-5550-b250-87eb5908aa74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2cf44-cc20-4a37-81ae-930f8c6d0896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2cf44-cc20-4a37-81ae-930f8c6d0896.jpg?1",
             "name": "Dark Privilege",
             "text": "Enchanted creature gets +1/+1.\nSacrifice a creature: Regenerate enchanted creature.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "328ed91f-3fc6-50bf-ba72-2b1ec5baaea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e939d8f-6989-4884-989b-9cba566c9963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e939d8f-6989-4884-989b-9cba566c9963.jpg?1",
             "name": "Death Watch",
             "text": "If enchanted creature is put into any graveyard, that creature's controller loses an amount of life equal to its power and you gain an amount of life equal to its toughness.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "aff631a1-31b2-55ce-8099-b93b0a72ebc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b186460-d2af-4912-ba19-95b2cb5f1639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b186460-d2af-4912-ba19-95b2cb5f1639.jpg?1",
             "name": "Desolation",
             "text": "At the end of each turn, each player who tapped a land for mana during that turn sacrifices a land. If a plains is sacrificed in this way, Desolation deals 2 damage to that plains' controller.",
             "colours": [
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "08c56700-abfd-505b-8d85-8b2eb7c4c3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1",
             "name": "Fallen Askari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nFallen Askari cannot block.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "820519f8-4f8a-5cf6-bd81-e1e8751f512d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5327e6d-db4e-4b44-a00e-b764e80b8946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5327e6d-db4e-4b44-a00e-b764e80b8946.jpg?1",
             "name": "Forbidden Ritual",
             "text": "Sacrifice a card in play: Target opponent loses 2 life unless he or she sacrifices a permanent or chooses and discards a card.\nYou may repeat this process as many times as you choose.",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "57f26343-1699-5b5e-a60d-b85c5e7268d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d7240-2014-4838-bace-80666192a73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d7240-2014-4838-bace-80666192a73e.jpg?1",
             "name": "Funeral Charm",
             "text": "Choose one Target player chooses and discards a card; or target creature gets +2/-1 until end of turn; or target creature gains swampwalk until end of turn. (If defending player controls any swamps, that creature is unblockable.)",
             "colours": [
@@ -1972,7 +1972,7 @@
         },
         {
             "id": "4b90524f-9476-5dc4-b868-aded4ba15135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf85ac9-f5d8-4a36-aa6c-3a31427a0348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf85ac9-f5d8-4a36-aa6c-3a31427a0348.jpg?1",
             "name": "Infernal Harvest",
             "text": "Return X swamps you control to owner's hand: Infernal Harvest deals X damage, divided any way you choose, among any number of target creatures.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "3013a4fd-2cf9-504b-a31a-d53fe896d73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d385b9e5-e13d-4098-ba74-ea55bde164d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d385b9e5-e13d-4098-ba74-ea55bde164d9.jpg?1",
             "name": "Kaervek's Spite",
             "text": "Sacrifice all permanents, Discard your hand: Target player loses 5 life.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "c7896b11-1cb7-5702-bb03-765517477212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a6257-dd77-4bb6-81cb-c8e7862350f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a6257-dd77-4bb6-81cb-c8e7862350f3.jpg?1",
             "name": "Necromancy",
             "text": "You may choose to play Necromancy as an instant; if you do, bury it at end of turn.\nWhen you play Necromancy, choose target creature card in any graveyard. When Necromancy comes into play, put that creature into play as though it were just played and Necromancy becomes a creature enchantment that targets the creature. If Necromancy leaves play, bury the creature.",
             "colours": [
@@ -2065,7 +2065,7 @@
         },
         {
             "id": "cc295880-7079-52e4-b746-08072d4d6200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70cd5fa-ae66-4ea4-90d2-28af2aa34dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70cd5fa-ae66-4ea4-90d2-28af2aa34dd4.jpg?1",
             "name": "Necrosavant",
             "text": "o3o\nBo\nB, Sacrifice a creature: Put Necrosavant into play. Use this ability only during your upkeep and only if Necrosavant is in your graveyard.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "a72b65e8-7e44-5054-9620-7939c80df11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba3e342-88b7-4692-a3f7-a3f56c0cf6b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba3e342-88b7-4692-a3f7-a3f56c0cf6b5.jpg?1",
             "name": "Nekrataal",
             "text": "First strike\nWhen Nekrataal comes into play, bury target nonartifact, nonblack creature.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "97bf6d52-23b6-5a8e-9a98-03d4ceb6f30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f93fd-4f2c-4dce-a774-4483031ed532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f93fd-4f2c-4dce-a774-4483031ed532.jpg?1",
             "name": "Pillar Tombs of Aku",
             "text": "During each player's upkeep, that player sacrifices a creature, or that player loses 5 life and you bury Pillar Tombs of Aku.",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "5de1e656-d388-5dfd-9dea-b80fabc5037a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e99969-6c21-4de6-ba57-44ef7f9c8c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e99969-6c21-4de6-ba57-44ef7f9c8c47.jpg?1",
             "name": "Python",
             "text": "",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "76147635-8968-58fb-8737-319ca94058e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7178c6-f989-437d-83e3-04b9817f2c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7178c6-f989-437d-83e3-04b9817f2c54.jpg?1",
             "name": "Suq'Ata Assassin",
             "text": "Suq'Ata Assassin cannot be blocked except by artifact or black creatures.\nIf Suq'Ata Assassin attacks and is not blocked, defending player gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -2233,7 +2233,7 @@
         },
         {
             "id": "3968ea21-63f1-5a59-8b8b-39a93125bc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1283190-094e-4a9f-bf67-f9fd05778744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1283190-094e-4a9f-bf67-f9fd05778744.jpg?1",
             "name": "Tar Pit Warrior",
             "text": "If Tar Pit Warrior is the target of a spell or effect, bury Tar Pit Warrior.",
             "colours": [
@@ -2267,7 +2267,7 @@
         },
         {
             "id": "aaa5ea10-44b3-5a6e-b6e3-611db3f113aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78405864-fc83-47ab-9238-8e0464a700ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78405864-fc83-47ab-9238-8e0464a700ec.jpg?1",
             "name": "Urborg Mindsucker",
             "text": "o\nB, Sacrifice Urborg Mindsucker: Target opponent discards a card at random. Play this ability as a sorcery.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "ae335858-71fd-5db2-9fa0-7cfee7b8c2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a07cba3-2e8d-48ec-a6f8-4d2edfcd833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a07cba3-2e8d-48ec-a6f8-4d2edfcd833d.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Pay 2 life: Search your library for any one card. Shuffle your library, then put that card on top of your library.",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "4572168f-22bf-5885-97bb-3994e6bb5162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dff2817-1813-410f-aca7-96e8f9f4ce81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dff2817-1813-410f-aca7-96e8f9f4ce81.jpg?1",
             "name": "Vampirism",
             "text": "Draw a card at the beginning of the upkeep of the turn after Vampirism comes into play.\nEnchanted creature gets +1/+1 for each other creature you control. All other creatures you control get -1/-1.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "2775346b-ea42-5667-a281-9e444eb20a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52420b80-7f34-4426-ac97-a6e15167c7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52420b80-7f34-4426-ac97-a6e15167c7a9.jpg?1",
             "name": "Wake of Vultures",
             "text": "Flying\no1o\nB, Sacrifice a creature: Regenerate",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "f908c457-bfe0-5d3c-b601-22a69cc92573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee32f8ba-3547-4913-a555-d43ee2978ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee32f8ba-3547-4913-a555-d43ee2978ba9.jpg?1",
             "name": "Wicked Reward",
             "text": "Sacrifice a creature: Target creature gets +4/+2 until end of turn.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "ee36ff8c-616c-52bb-a6f8-82674c35ad9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253db28a-3873-4364-80d7-a8164000ea9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253db28a-3873-4364-80d7-a8164000ea9e.jpg?1",
             "name": "Bogardan Phoenix",
             "text": "Flying\nIf Bogardan Phoenix is put into any graveyard from play and has no death counter on it, return Bogardan Phoenix to play and put a death counter on it.\nIf Bogardan Phoenix is put into any graveyard from play and has a death counter on it, remove it from the game.",
             "colours": [
@@ -2461,7 +2461,7 @@
         },
         {
             "id": "8afb52ff-7593-5c24-89f2-ecc0550cf328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d33bb-41bf-440d-939b-67ab5aacb092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d33bb-41bf-440d-939b-67ab5aacb092.jpg?1",
             "name": "Dwarven Vigilantes",
             "text": "If Dwarven Vigilantes attacks and is not blocked, you may choose to have it deal no combat damage this turn. If you do, Dwarven Vigilantes deals an amount of damage equal to its power to target creature.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "54237c5c-0076-5c04-be7b-a89824301c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb625ba-3718-4988-962c-bf2e11eb4c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb625ba-3718-4988-962c-bf2e11eb4c16.jpg?1",
             "name": "Elkin Lair",
             "text": "During each player's upkeep, that player chooses a card at random from his or her hand and sets it aside face up. The player may play that card as though it were in his or her hand. If the player does not play the card by end of turn, bury that card.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "59e8e854-17ba-52cf-a307-649c9ace1c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eb5b2c-1f02-48a6-a287-88eb189d6780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eb5b2c-1f02-48a6-a287-88eb189d6780.jpg?1",
             "name": "Fireblast",
             "text": "You may sacrifice two mountains instead of paying Fireblast's casting cost. Fireblast deals 4 damage to target creature or player.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "6cb2bcc2-c43e-51ce-87e3-52b7fb88833f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee791d5-1d48-40e8-b65f-b6aa889f3467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee791d5-1d48-40e8-b65f-b6aa889f3467.jpg?1",
             "name": "Goblin Recruiter",
             "text": "When Goblin Recruiter comes into play, search your library for any number of Goblin cards. Reveal those cards to all players. Shuffle your library, then put the cards on top of your library in any order.",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "3d008cad-0c68-5f2b-b137-e4ae06edd593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49980982-d534-4204-bc15-3e6c4ffa1a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49980982-d534-4204-bc15-3e6c4ffa1a53.jpg?1",
             "name": "Goblin Swine-Rider",
             "text": "If Goblin Swine-Rider is blocked, it deals 2 damage to each attacking creature and 2 damage to each blocking creature.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "a42820b3-6398-5f87-8bcb-2bbb38dcdde1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa9ac66-51b7-4aec-92dc-0f0656b0f7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa9ac66-51b7-4aec-92dc-0f0656b0f7fe.jpg?1",
             "name": "Hearth Charm",
             "text": "Choose one Destroy target artifact creature; or all attacking creatures get +1/+0 until end of turn; or target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -2655,7 +2655,7 @@
         },
         {
             "id": "e3508fc4-a266-5449-bb05-26b2969efcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dd0810-4528-4a88-add8-923bb2057821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dd0810-4528-4a88-add8-923bb2057821.jpg?1",
             "name": "Heat Wave",
             "text": "Cumulative upkeep o\nR\nBlue creatures cannot block creatures you control. Nonblue creatures cannot block creatures you control unless their controller pays an additional 1 life for each blocking creature.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "022f81be-fa1f-5095-ad74-7196f1fde644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ee5ea8-7023-4dde-ab51-d3ba234d74b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ee5ea8-7023-4dde-ab51-d3ba234d74b9.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops cannot block.",
             "colours": [
@@ -2719,7 +2719,7 @@
         },
         {
             "id": "09fcf745-f682-5a9e-a177-11d03875365d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11b6df4-449f-44ea-a4fa-f079bcd26a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11b6df4-449f-44ea-a4fa-f079bcd26a54.jpg?1",
             "name": "Keeper of Kookus",
             "text": "oo\nR Protection from red until end of turn.",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "b7e0b2c8-309c-502b-8a08-2e17527752b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb90922-99d2-4b36-9039-bb806fd01756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb90922-99d2-4b36-9039-bb806fd01756.jpg?1",
             "name": "Kookus",
             "text": "Trample\nDuring your upkeep, if you do not control at least one Keeper of Kookus, Kookus deals 3 damage to you and attacks this turn if able.\noo\nR +1/+0 until end of turn.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "182adfa1-d909-5750-bb75-c00e328c8438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfc2ad-a1a4-4f65-a239-f11383aaafe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfc2ad-a1a4-4f65-a239-f11383aaafe1.jpg?1",
             "name": "Lightning Cloud",
             "text": "oo\nR Lightning Cloud deals 1 damage to target creature or player. Use this ability only when a red spell is successfully cast and only once for each such spell.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "b10d8d8b-24a1-5b21-aeaa-487f3dcf0a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e428d56a-9445-4e86-b281-656e2d251e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e428d56a-9445-4e86-b281-656e2d251e0b.jpg?1",
             "name": "Mob Mentality",
             "text": "Enchanted creature gains trample.\nIf all non-Wall creatures you control attack, enchanted creature gets +*/+0 until end of turn, where * is equal to the number of attacking creatures.",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "85f79ee7-8094-5dcc-90bb-e70d44b849fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f072d6-7489-4eb0-8c53-1fa42ad806a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f072d6-7489-4eb0-8c53-1fa42ad806a4.jpg?1",
             "name": "Ogre Enforcer",
             "text": "Ogre Enforcer cannot be destroyed by lethal damage unless a single source deals enough damage to destroy it.",
             "colours": [
@@ -2882,7 +2882,7 @@
         },
         {
             "id": "8c559f70-e997-5e1a-8e41-b7b2a885c981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c284ce-33b8-4fb2-9dd9-4c477bedc774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c284ce-33b8-4fb2-9dd9-4c477bedc774.jpg?1",
             "name": "Raging Gorilla",
             "text": "If Raging Gorilla blocks or is blocked, it gets +2/-2 until end of turn.",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "a5e93a13-9051-5123-bc1f-fd49047d6cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747161ea-cb65-4960-84dd-a05bfe5f3ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747161ea-cb65-4960-84dd-a05bfe5f3ba0.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You may declare an additional attack during your main phase this turn.",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "f46e9488-71e8-5d67-b200-79845274c209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e01717a-d6ed-42c1-9a9a-f3f4a3d73bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e01717a-d6ed-42c1-9a9a-f3f4a3d73bca.jpg?1",
             "name": "Rock Slide",
             "text": "Rock Slide deals X damage, divided any way you choose, among any number of target attacking or blocking creatures without flying.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "16163a60-493f-5b3f-8a96-57380f026659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d4bd6f-b019-4594-aa41-138fa58ba529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d4bd6f-b019-4594-aa41-138fa58ba529.jpg?1",
             "name": "Solfatara",
             "text": "Target player cannot play any land cards this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3008,7 +3008,7 @@
         },
         {
             "id": "c8c40958-e0fe-53bf-8384-819c7ef58408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4497a1d7-6604-4f2d-9484-1f1d77a6228f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4497a1d7-6604-4f2d-9484-1f1d77a6228f.jpg?1",
             "name": "Song of Blood",
             "text": "Put the top four cards from your library into your graveyard. For each creature card put into your graveyard in this way, all creatures that attack this turn get +1/+0 until end of turn.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "81e18cc2-0eec-568f-8c66-b1b9a1bb2b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6ef97-587f-4f7b-98a2-e3cc8b39df8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6ef97-587f-4f7b-98a2-e3cc8b39df8b.jpg?1",
             "name": "Spitting Drake",
             "text": "Flying\noo\nR +1/+0 until end of turn. You cannot spend more than o\nR in this way each turn.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "0fe48ca4-3828-56bb-8b55-8e4a03db8346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2884d8df-7fd5-4247-9da5-38c31333ff5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2884d8df-7fd5-4247-9da5-38c31333ff5d.jpg?1",
             "name": "Suq'Ata Lancer",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nSuq'Ata Lancer is unaffected by summoning sickness.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "e753a88f-9b93-5389-ac04-ad3f54d49e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33730a07-754c-4606-bfac-d73454af9567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33730a07-754c-4606-bfac-d73454af9567.jpg?1",
             "name": "Talruum Champion",
             "text": "First strike\nWhenever Talruum Champion blocks or is blocked by any creature, that creature loses first strike until end of turn.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "709dead3-b2c1-59b0-8e04-45c065565b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2cb9a7-5063-4b31-9782-8bfd784bca0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2cb9a7-5063-4b31-9782-8bfd784bca0a.jpg?1",
             "name": "Talruum Piper",
             "text": "All creatures with flying able to block Talruum Piper do so.",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "47a247e4-f90a-52a3-b9e5-8de35eae814a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d64665-c1e0-40ab-a358-247f82966379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d64665-c1e0-40ab-a358-247f82966379.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "9057619b-ada3-5983-8973-644ea7b37239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01770e13-ebd4-4c83-9e72-99374239a63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01770e13-ebd4-4c83-9e72-99374239a63d.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "Viashino Sandstalker is unaffected by summoning sickness.\nAt the end of any turn, return Viashino Sandstalker to owner's hand.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "31a36f4c-a39c-541e-a116-9e925403c6f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7f5f41-ed30-412b-b51e-37d26e9e6455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7f5f41-ed30-412b-b51e-37d26e9e6455.jpg?1",
             "name": "Bull Elephant",
             "text": "When Bull Elephant comes into play, return two forests you control to owner's hand or bury Bull Elephant.",
             "colours": [
@@ -3270,7 +3270,7 @@
         },
         {
             "id": "7cf19545-be13-5449-ae80-f2265fd5c80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be499b81-bb2d-4f1d-9deb-c8bfcdca8e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be499b81-bb2d-4f1d-9deb-c8bfcdca8e13.jpg?1",
             "name": "City of Solitude",
             "text": "Each player may play spells and abilities only during his or her turn.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "a2ceb8bd-95db-5b09-99b2-308e856b42fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e7691f-c771-4451-ac54-3532ca10d48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e7691f-c771-4451-ac54-3532ca10d48f.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, land, or enchantment.",
             "colours": [
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "6210d1fb-6297-57d0-9b9f-f4135f2ee93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c1f5a7-0d28-43ab-9b66-937e963f42cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c1f5a7-0d28-43ab-9b66-937e963f42cd.jpg?1",
             "name": "Elephant Grass",
             "text": "Cumulative upkeep o1\nBlack creatures cannot attack you. Nonblack creatures cannot attack you unless their controller pays an additional o2 for each attacking creature.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "f1334e4a-3c78-552b-bfe9-b71499983976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fa078f-c74a-42b2-af97-7ca2c29dc316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fa078f-c74a-42b2-af97-7ca2c29dc316.jpg?1",
             "name": "Elven Cache",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "3eab4e06-2f0d-5d69-84f5-f976976f7751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c9199b-61b3-4794-878b-f065058f50f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c9199b-61b3-4794-878b-f065058f50f3.jpg?1",
             "name": "Emerald Charm",
             "text": "Choose one Untap target permanent; or destroy target global enchantment; or target creature loses flying until end of turn.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "66b26b5b-81f2-5466-aa05-b616b1285c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dec7cf-2865-4642-9022-d3006fd7ac30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dec7cf-2865-4642-9022-d3006fd7ac30.jpg?1",
             "name": "Feral Instinct",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "5be8b1dc-0246-51f9-8ef0-5f31e671104a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f602a6-3d35-49a3-b5cb-d754e03a9573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f602a6-3d35-49a3-b5cb-d754e03a9573.jpg?1",
             "name": "Giant Caterpillar",
             "text": "o\nG, Sacrifice Giant Caterpillar: Put a Butterfly token into play at end of turn. Treat this token as a 1/1 green creature with flying.",
             "colours": [
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "291b09fa-bf95-526f-b813-b6c8e5206894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b34ce8-1eb2-44eb-813a-09d0308e27a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b34ce8-1eb2-44eb-813a-09d0308e27a0.jpg?1",
             "name": "Katabatic Winds",
             "text": "Phasing\nCreatures with flying cannot attack, block, or use any ability that includes oc\nT in the activation cost.",
             "colours": [
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "239aa1bc-8a76-52ac-9f86-07e4d7b2b2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38149d49-8661-427c-9338-93c11a2a8093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38149d49-8661-427c-9338-93c11a2a8093.jpg?1",
             "name": "King Cheetah",
             "text": "You may choose to play King Cheetah whenever you could play an instant.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "81314d38-9a73-5b00-a79e-4aadeee5b4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f14bbe-2436-4a5a-8e2a-8066b740b715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f14bbe-2436-4a5a-8e2a-8066b740b715.jpg?1",
             "name": "Kyscu Drake",
             "text": "Flying\noo\nG +0/+1 until end of turn. You cannot spend more than o\nG in this way each turn.\nSacrifice Kyscu Drake and Spitting Drake: Search your library for Viashivan Dragon and put it into play. Shuffle your library afterwards.",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "83dc9f95-60d6-523a-9c2b-1ea8acda6853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0c356-a81d-41d4-a8b7-8c159146a8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0c356-a81d-41d4-a8b7-8c159146a8b8.jpg?1",
             "name": "Lichenthrope",
             "text": "For each 1 damage dealt to Lichenthrope, put a -1/-1 counter on it instead.\nDuring your upkeep, remove one of these -1/-1 counters from Lichenthrope.",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "4b598341-8cca-5462-8548-0d6bb596c626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808830ff-496a-41dc-8b64-334ddaca9435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808830ff-496a-41dc-8b64-334ddaca9435.jpg?1",
             "name": "Mortal Wound",
             "text": "If damage is dealt to enchanted creature, destroy it.",
             "colours": [
@@ -3653,7 +3653,7 @@
         },
         {
             "id": "d776abc3-5ae4-5e0e-b863-2479cabd9f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0845f0b0-9413-4ddd-861d-9607636bebc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0845f0b0-9413-4ddd-861d-9607636bebc6.jpg?1",
             "name": "Natural Order",
             "text": "Sacrifice a green creature: Search your library for a green creature card and put it into play as though it were just played. Shuffle your library afterwards.",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "c2956731-a9c0-5c9e-a9c5-b67a7d93e865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c9bc99-28e3-4d64-8383-2b92011104ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c9bc99-28e3-4d64-8383-2b92011104ed.jpg?1",
             "name": "Panther Warriors",
             "text": "",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "535e217b-2408-5e44-b991-7a0e6850b6bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca5319a-5c26-487f-ba87-d317633122ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca5319a-5c26-487f-ba87-d317633122ba.jpg?1",
             "name": "Quirion Druid",
             "text": "o\nG, oc\nT: Target land becomes a 2/2 green creature permanently. That land still counts as a land.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "9b771df0-92de-5869-bbaf-7ef3f59366b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56efe72c-6d7f-44f6-ac74-01af9305c4b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56efe72c-6d7f-44f6-ac74-01af9305c4b6.jpg?1",
             "name": "Quirion Ranger",
             "text": "Return a forest you control to owner's hand: Untap target creature. Use this ability only once each turn.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "93e9c02c-5735-5a73-8dd6-34edd95ee424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9d5aaf-b7e8-4676-aec8-7d29a0169a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9d5aaf-b7e8-4676-aec8-7d29a0169a2c.jpg?1",
             "name": "River Boa",
             "text": "Islandwalk (If defending player controls an island, this creature is unblockable.)\noo\nG Regenerate",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "d6659200-4fb7-5515-b2f2-494fd9f38dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07144d84-f7f3-4101-805d-07cce8342a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07144d84-f7f3-4101-805d-07cce8342a64.jpg?1",
             "name": "Rowen",
             "text": "During your draw phase, reveal the first card you draw to all players. If that card is a basic land, draw a card.",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "c45bc8ff-d347-5b8f-bbf5-259d1634b8f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1818812-4cb8-4fe1-98c0-b40086b4991c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1818812-4cb8-4fe1-98c0-b40086b4991c.jpg?1",
             "name": "Spider Climb",
             "text": "You may choose to play Spider Climb as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +0/+3 and can block creatures with flying.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "a867e33f-ad96-540e-aeb6-2473ae075ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb5f524-fad6-4a63-b20f-3348a844fefa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb5f524-fad6-4a63-b20f-3348a844fefa.jpg?1",
             "name": "Stampeding Wildebeests",
             "text": "Trample\nDuring your upkeep, return a green creature you control to owner's hand.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "a9704fe2-d06b-534a-ba68-becddf99bd34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d78f4e-d95d-49bc-9971-06a68a4e35fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d78f4e-d95d-49bc-9971-06a68a4e35fd.jpg?1",
             "name": "Summer Bloom",
             "text": "You may play up to three additional lands this turn.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "04eec290-7289-563e-a320-a697121e0c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c7d58-43cc-4ebd-87f1-2016fbff56dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c7d58-43cc-4ebd-87f1-2016fbff56dd.jpg?1",
             "name": "Uktabi Orangutan",
             "text": "When Uktabi Orangutan comes into play, destroy target artifact.",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "45bf83d9-9a8a-5c14-8df9-081eceb9490e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2510b8-52d6-4d2e-89a5-31b27b732dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2510b8-52d6-4d2e-89a5-31b27b732dd8.jpg?1",
             "name": "Warthog",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -4014,7 +4014,7 @@
         },
         {
             "id": "00bd1866-4cad-590c-a545-9d63d79763d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8324f44-c7f5-41ee-bc8d-16822bd8942f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8324f44-c7f5-41ee-bc8d-16822bd8942f.jpg?1",
             "name": "Wind Shear",
             "text": "All attacking creatures with flying get -2/-2 and lose flying until end of turn.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "89ce82ca-9f26-5471-a1a3-555aa12b791b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e129be5-e2c5-4f69-b8e8-539ac2085c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e129be5-e2c5-4f69-b8e8-539ac2085c7a.jpg?1",
             "name": "Army Ants",
             "text": "oc\nT, Sacrifice a land: Destroy target land.",
             "colours": [
@@ -4080,7 +4080,7 @@
         },
         {
             "id": "f280d496-70fe-5cbc-959b-bbf9851012a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87ace53-d77c-4df5-b200-4be2ac2b7fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87ace53-d77c-4df5-b200-4be2ac2b7fdb.jpg?1",
             "name": "Breathstealer's Crypt",
             "text": "Whenever any player draws a card, he or she reveals that card. If the card is a creature card, that player pays 3 life or discards the card.",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "a08cb2c2-e4ce-5fd1-a6f1-03c4a53cd584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176122b2-f60f-4150-8c0c-757c8f8914d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176122b2-f60f-4150-8c0c-757c8f8914d2.jpg?1",
             "name": "Corrosion",
             "text": "Cumulative upkeep o1\nDuring your upkeep, put a rust counter on each artifact target opponent controls. If the number of rust counters on an artifact equals or exceeds that artifact's casting cost, bury the artifact.\nIf Corrosion leaves play, remove all rust counters from the game.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "d9b51885-a54d-59ed-b84a-835c96c035f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ba72c7-7957-4d02-b41e-c0132fe1f2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ba72c7-7957-4d02-b41e-c0132fe1f2e6.jpg?1",
             "name": "Femeref Enchantress",
             "text": "Whenever an enchantment is put into any graveyard from play, draw a card.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "87a7a841-d8b1-54c7-b705-bf7fb131b638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def23574-4a41-4323-84d9-49f58b2ca322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def23574-4a41-4323-84d9-49f58b2ca322.jpg?1",
             "name": "Firestorm Hellkite",
             "text": "Flying, trample\nCumulative upkeep o\nUo\nR",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "a1d23d44-e9ee-576f-88f8-e15b558346b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96d184-0ef8-40f7-98bc-bd4c53c57072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96d184-0ef8-40f7-98bc-bd4c53c57072.jpg?1",
             "name": "Guiding Spirit",
             "text": "Flying\noc\nT: If the top card of target player's graveyard is a creature card, put that card on the top of that player's library.",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "52169eee-7ff8-590c-9ad1-9a0279d5fac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e320ca-848b-4743-93f1-ec04ef1ce402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e320ca-848b-4743-93f1-ec04ef1ce402.jpg?1",
             "name": "Mundungu",
             "text": "oc\nT: Counter target spell unless that spell's caster pays an additional o1 and 1 life. Play this ability as an interrupt.",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "b68fb713-b09e-518b-bbd1-84fb700219a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f6220-6ead-46b4-8663-57609ef5a12e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f6220-6ead-46b4-8663-57609ef5a12e.jpg?1",
             "name": "Pygmy Hippo",
             "text": "If Pygmy Hippo attacks and is not blocked, you may choose to have it deal no combat damage this turn. If you do, defending player draws all mana from his or her lands and then his or her mana pool is emptied. After combat, add an equal amount of colorless mana to your mana pool.",
             "colours": [
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "1a008e97-4fe2-5d5d-b696-5e2c190c644a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcacb8e-1aff-4807-b70c-a17d6703d279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcacb8e-1aff-4807-b70c-a17d6703d279.jpg?1",
             "name": "Righteous War",
             "text": "All white creatures you control gain protection from black.\nAll black creatures you control gain protection from white.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "08c2dd2e-ee9c-5e9b-9214-e551b9e1569f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3bff610-783a-46b7-bd15-061da41027bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3bff610-783a-46b7-bd15-061da41027bb.jpg?1",
             "name": "Scalebane's Elite",
             "text": "Protection from black",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "28f34393-8b2b-5724-998a-bc3712c7fdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9239-82e0-4696-ad99-10796042d1f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9239-82e0-4696-ad99-10796042d1f8.jpg?1",
             "name": "Simoon",
             "text": "Simoon deals 1 damage to each creature target opponent controls.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "fb296a80-7f79-5338-8871-71f5f31064d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcddbea7-3025-47b1-a597-2d2b2711fb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcddbea7-3025-47b1-a597-2d2b2711fb81.jpg?1",
             "name": "Squandered Resources",
             "text": "Sacrifice a land: Add to your mana pool one mana of any type the sacrificed land could produce. Play this ability as a mana source.",
             "colours": [
@@ -4459,7 +4459,7 @@
         },
         {
             "id": "e83fb428-dee4-5557-920f-a01dc147dbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a15e970-e605-425a-b4ec-391d9cacde38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a15e970-e605-425a-b4ec-391d9cacde38.jpg?1",
             "name": "Suleiman's Legacy",
             "text": "When Suleiman's Legacy comes into play, bury all Djinns and Efreets.\nWhenever a Djinn or Efreet comes into play, bury it.",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "02760c06-1979-502a-ae7d-1c8417c5d351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa5262-d0d9-4b4a-8027-00393568b3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa5262-d0d9-4b4a-8027-00393568b3df.jpg?1",
             "name": "Tempest Drake",
             "text": "Flying\nAttacking does not cause Tempest Drake to tap.",
             "colours": [
@@ -4527,7 +4527,7 @@
         },
         {
             "id": "d51d0a4f-b525-5ed8-b086-fea3435614ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172ef0b-ca9e-47cf-8ec6-2d8cb18f2283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172ef0b-ca9e-47cf-8ec6-2d8cb18f2283.jpg?1",
             "name": "Viashivan Dragon",
             "text": "Flying\noo\nR +1/+0 until end of turn\noo\nG +0/+1 until end of turn",
             "colours": [
@@ -4562,7 +4562,7 @@
         },
         {
             "id": "d818d5cf-5ecc-503c-a447-afcbffd5c2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff965dd-54b4-4f21-a52f-81c0dd1e691e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff965dd-54b4-4f21-a52f-81c0dd1e691e.jpg?1",
             "name": "Anvil of Bogardan",
             "text": "Each player skips his or her discard phase.\nDuring each player's draw phase, that player draws an additional card and then chooses and discards a card.",
             "colours": [],
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "7f6db842-a120-5d6c-ac5c-5720e25a8342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c9655-e51c-4b63-96cf-7f3fba3ec75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c9655-e51c-4b63-96cf-7f3fba3ec75c.jpg?1",
             "name": "Brass-Talon Chimera",
             "text": "First strike\nBrass-Talon Chimera counts as a Chimera.\nSacrifice Brass-Talon Chimera: Put a +2/+2 counter on target Chimera and that Chimera gains first strike permanently.",
             "colours": [],
@@ -4619,7 +4619,7 @@
         },
         {
             "id": "fdbf6686-ea5d-54f6-90a9-aab45136a34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548ff852-274d-4068-818d-58a883e74a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548ff852-274d-4068-818d-58a883e74a5f.jpg?1",
             "name": "Diamond Kaleidoscope",
             "text": "o3, oc\nT: Put a Prism token into play. Treat this token as a 0/1 artifact creature.\nSacrifice a Prism token: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "8e0cde13-8752-5dd2-82f7-263f3c7cb8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098e329-adc8-42dd-b779-d00d9ccc3dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098e329-adc8-42dd-b779-d00d9ccc3dbd.jpg?1",
             "name": "Dragon Mask",
             "text": "o3, oc\nT: Target creature you control gets +2/+2 until end of turn. At end of turn, if that creature is in play, return it to owner's hand.",
             "colours": [],
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "123276f7-e53d-52df-9e94-6e403387d388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bba882-39b8-42db-9a01-54c6712b8019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bba882-39b8-42db-9a01-54c6712b8019.jpg?1",
             "name": "Helm of Awakening",
             "text": "All spells cost one generic mana less to play.",
             "colours": [],
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "7e2f05bc-d6c7-5a11-a4c9-0460f83064f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5899a575-a97d-4850-b55c-22ad6900ba20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5899a575-a97d-4850-b55c-22ad6900ba20.jpg?1",
             "name": "Iron-Heart Chimera",
             "text": "Attacking does not cause Iron-Heart Chimera to tap.\nIron-Heart Chimera counts as a Chimera.\nSacrifice Iron-Heart Chimera: Put a +2/+2 counter on target Chimera and attacking any turn does not cause that Chimera to tap.",
             "colours": [],
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "deced70d-88f5-57c3-9261-3bbcb1db2338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5fa8208-7d65-4f8f-b07e-f5c3a66e1143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5fa8208-7d65-4f8f-b07e-f5c3a66e1143.jpg?1",
             "name": "Juju Bubble",
             "text": "Cumulative upkeep o1\nIf you play a card, bury Juju Bubble.\no2: Gain 1 life.",
             "colours": [],
@@ -4757,7 +4757,7 @@
         },
         {
             "id": "41f736ce-b9dc-5b77-a90d-0dbbd474f010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89b377-80d2-42a0-b84e-a455a72ed9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89b377-80d2-42a0-b84e-a455a72ed9fe.jpg?1",
             "name": "Lead-Belly Chimera",
             "text": "Trample\nLead-Belly Chimera counts as a Chimera.\nSacrifice Lead-Belly Chimera: Put a +2/+2 counter on target Chimera and that Chimera gains trample permanently.",
             "colours": [],
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "7bc72aab-9a88-541f-aebc-122fd96796db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aecc3df-7ce6-419c-b3d6-60fc28bfe941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aecc3df-7ce6-419c-b3d6-60fc28bfe941.jpg?1",
             "name": "Magma Mine",
             "text": "o4: Put a pressure counter on Magma Mine.\noc\nT, Sacrifice Magam Mine: For each pressure counter on it, Magma Mine deals 1 damage to target creature or player.",
             "colours": [],
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "0e965f8f-5614-5c15-92f6-272fa1743ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92378d6f-89ee-49dc-8964-0e9c55daeffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92378d6f-89ee-49dc-8964-0e9c55daeffc.jpg?1",
             "name": "Matopi Golem",
             "text": "o1: Regenerate and put a -1/-1 counter on Matopi Golem.",
             "colours": [],
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "aa043981-5fef-5f14-82ad-1c30aab44123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a75dc8-1c24-4063-8944-d7e71b4a5755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a75dc8-1c24-4063-8944-d7e71b4a5755.jpg?1",
             "name": "Phyrexian Marauder",
             "text": "Phryexian Marauder comes into play with X +1/+1 counters on it.\nPhyrexian Marauder cannot block.\nPhyrexian Marauder cannot attack unless you pay o1 for each +1/+1 counter on it.",
             "colours": [],
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "e9d5ac33-9f8a-5f91-8791-2fd4c9c5a397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a3979-2947-4692-8b2f-d4c07c534777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a3979-2947-4692-8b2f-d4c07c534777.jpg?1",
             "name": "Phyrexian Walker",
             "text": "",
             "colours": [],
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "8204bfb2-1f7a-5c43-8722-b118333f68c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782ee95-bde4-41f4-a947-b073cc4c1e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782ee95-bde4-41f4-a947-b073cc4c1e7c.jpg?1",
             "name": "Sands of Time",
             "text": "Each player skips his or her untap phase.\nAt the beginning of each player's turn, untap each tapped artifact, creature, and land he or she controls and tap each untapped artifact, creature, and land he or she controls.",
             "colours": [],
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "8533cee9-8658-5dd4-a014-bd14476585b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08becd3-ca5e-4150-8d28-52436a3eaffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08becd3-ca5e-4150-8d28-52436a3eaffd.jpg?1",
             "name": "Sisay's Ring",
             "text": "oc\nT: Add two colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "7cbfbf98-b945-5a4c-8996-0c47a740c6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfda9a16-9cdb-494a-b662-ac24e3b89d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfda9a16-9cdb-494a-b662-ac24e3b89d0c.jpg?1",
             "name": "Snake Basket",
             "text": "o\nX, Sacrifice Snake Basket: Put X Cobra tokens into play. Treat these tokens as 1/1 green creatures. Play this ability as a sorcery.",
             "colours": [],
@@ -4987,7 +4987,7 @@
         },
         {
             "id": "3f380b0e-5b5d-58fc-95ac-6b9fc7738758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1377dab4-b814-46cc-a097-24a3cf8d0f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1377dab4-b814-46cc-a097-24a3cf8d0f8f.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "During each player's draw phase, that player counts the cards in his or her hand, puts those cards on the bottom of his or her library, and then draws that number of cards.",
             "colours": [],
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "c76fc460-be81-516a-b995-ef6b73432ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3375dcc6-9399-48eb-9aa4-7b40c3686cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3375dcc6-9399-48eb-9aa4-7b40c3686cc5.jpg?1",
             "name": "Tin-Wing Chimera",
             "text": "Flying\nTin-Wing Chimera counts as a Chimera.\nSacrifice Tin-Wing Chimera: Put a +2/+2 counter on target Chimera and that Chimera gains flying permanently.",
             "colours": [],
@@ -5044,7 +5044,7 @@
         },
         {
             "id": "84d78730-ff1f-58fe-983a-b39d508e99f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1d7d4d-bed7-4d28-a304-ad33f42e9831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1d7d4d-bed7-4d28-a304-ad33f42e9831.jpg?1",
             "name": "Triangle of War",
             "text": "o2, Sacrifice Triangle of War: Choose target creature you control and target creature an opponent controls. Each creature deals an amount of damage equal to its power to the other.",
             "colours": [],
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "eec8acf4-dffe-5f62-872e-845ba4476f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1c856f-6d29-4bfc-976e-7875d60abd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1c856f-6d29-4bfc-976e-7875d60abd52.jpg?1",
             "name": "Wand of Denial",
             "text": "oc\nT: Look at the top card of target player's library. If that card is a nonland card, you may pay 2 life to put it into that player's graveyard.",
             "colours": [],
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "a34be966-4999-587f-a2d1-eebca467e9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7c4619-e5af-4aa0-bd3f-6bf0e1fdc1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7c4619-e5af-4aa0-bd3f-6bf0e1fdc1fc.jpg?1",
             "name": "Coral Atoll",
             "text": "Coral Atoll comes into play tapped.\nWhen Coral Atoll comes into play, return an untapped island you control to owner's hand or bury Coral Atoll.\noc\nT: Add o\nU and one colorless mana to your mana pool.",
             "colours": [],
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "747ba60f-83e5-52de-a40b-8171c7990307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa92be7-883f-42bd-8623-00eb2df28a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa92be7-883f-42bd-8623-00eb2df28a98.jpg?1",
             "name": "Dormant Volcano",
             "text": "Dormant Volcano comes into play tapped.\nWhen Dormant Volcano comes into play, return an untapped mountain you control to owner's hand or bury Dormant Volcano.\noc\nT: Add o\nR and one colorless mana to your mana pool.",
             "colours": [],
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "5ea90fc5-d383-500c-85c1-82598ba7af8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f2eaf7-7f08-446b-892f-5a844f74808f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f2eaf7-7f08-446b-892f-5a844f74808f.jpg?1",
             "name": "Everglades",
             "text": "Everglades comes into play tapped.\nWhen Everglades comes into play, return an untapped swamp you control to owner's hand or bury Everglades.\noc\nT: Add o\nB and one colorless mana to your mana pool.",
             "colours": [],
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "64ffafa8-43ad-5253-9917-777c096741ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705d8194-3ad0-41b7-ae32-9c0cd8cd46b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705d8194-3ad0-41b7-ae32-9c0cd8cd46b9.jpg?1",
             "name": "Griffin Canyon",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Untap target Griffin. That Griffin gets +1/+1 until end of turn.",
             "colours": [],
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "dafe0924-2c94-5608-872a-5fca5463aab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3146db-2f86-4728-9af1-ff651f871652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3146db-2f86-4728-9af1-ff651f871652.jpg?1",
             "name": "Jungle Basin",
             "text": "Jungle Basin comes into play tapped.\nWhen Jungle Basin comes into play, return an untapped forest you control to owner's hand or bury Jungle Basin.\noc\nT: Add o\nG and one colorless mana to your mana pool.",
             "colours": [],
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "f1bc5bdc-e4e1-570f-8b06-ba26be43e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786815c-53ec-483e-ad56-382778a57b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786815c-53ec-483e-ad56-382778a57b1a.jpg?1",
             "name": "Karoo",
             "text": "Karoo comes into play tapped.\nWhen Karoo comes into play, return an untapped plains you control to owner's hand or bury Karoo.\noc\nT: Add o\nW and one colorless mana to your mana pool.",
             "colours": [],
@@ -5270,7 +5270,7 @@
         },
         {
             "id": "9ea5b7eb-b25d-59b2-93ed-0ecfb78f8ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11370658-8d80-4d2f-afa5-ec6df6dee369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11370658-8d80-4d2f-afa5-ec6df6dee369.jpg?1",
             "name": "Quicksand",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "9460969e-62f1-528e-b9ef-2d9aa7b2cc06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e8830-5e62-4945-8b73-60f0628d38e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e8830-5e62-4945-8b73-60f0628d38e7.jpg?1",
             "name": "Undiscovered Paradise",
             "text": "oc\nT: Add one mana of any color to your mana pool. At the beginning of your next untap phase, return Undiscovered Paradise to owner's hand.",
             "colours": [],

--- a/Assets/Resources/Sets/VOW.json
+++ b/Assets/Resources/Sets/VOW.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "14bf8abf-b718-5cc7-8b5d-847f9ee85eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd091f3e-5fcc-4d12-b0c3-3b6340ab01d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd091f3e-5fcc-4d12-b0c3-3b6340ab01d8.jpg?1",
             "name": "Adamant Will",
             "text": "Target creature gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "a5c04d16-e1c3-5913-a33e-01f4b3f468f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d81b88-c19b-4148-89ba-ae8fb53843e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d81b88-c19b-4148-89ba-ae8fb53843e1.jpg?1",
             "name": "Angelic Quartermaster",
             "text": "Flying\nWhen Angelic Quartermaster enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "a8b84b37-8b72-5ecc-b849-cf688a8cee34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2004a20c-e434-4691-8ef2-740846ce6a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2004a20c-e434-4691-8ef2-740846ce6a51.jpg?1",
             "name": "Arm the Cathars",
             "text": "Until end of turn, target creature gets +3/+3, up to one other target creature gets +2/+2, and up to one other target creature gets +1/+1. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "2d08d62a-ee1b-50f2-8fb2-f83727a5309d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e5dbbe-ca99-41a5-901d-511b9f3ccea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e5dbbe-ca99-41a5-901d-511b9f3ccea6.jpg?1",
             "name": "Bride's Gown",
             "text": "Equipped creature gets +2/+0. It gets an additional +0/+2 and has first strike as long as an Equipment named Groom's Finery is attached to a creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "d914e85e-b153-533d-a4b5-f70c10202a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46764e49-64da-4a94-b61c-75e006b2c5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46764e49-64da-4a94-b61c-75e006b2c5a9.jpg?1",
             "name": "By Invitation Only",
             "text": "Choose a number between 0 and 13. Each player sacrifices that many creatures.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "fa771e07-a925-5ec9-a16d-9ef441b049f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00731eb-69fe-42f3-9919-66a4cdec00f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00731eb-69fe-42f3-9919-66a4cdec00f7.jpg?1",
             "name": "Cemetery Protector",
             "text": "Flash\nWhen Cemetery Protector enters the battlefield, exile a card from a graveyard.\nWhenever you play a land or cast a spell, if it shares a card type with the exiled card, create a 1/1 white Human creature token.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "61d350d7-95fc-5445-a82e-219097f6fc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13031fb6-9d5a-4add-9a86-28b2a9373fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13031fb6-9d5a-4add-9a86-28b2a9373fd2.jpg?1",
             "name": "Circle of Confinement",
             "text": "When Circle of Confinement enters the battlefield, exile target creature an opponent controls with mana value 3 or less until Circle of Confinement leaves the battlefield.\nWhenever an opponent casts a Vampire spell with the same name as a card exiled with Circle of Confinement, you gain 2 life.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "4a5f9032-3bff-56db-9e4d-7326016c69e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d27617-2d3d-44a1-b93f-0694253b6774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d27617-2d3d-44a1-b93f-0694253b6774.jpg?1",
             "name": "Dawnhart Geist",
             "text": "Whenever you cast an enchantment spell, you gain 2 life.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "97e74168-5f9b-518e-85a0-2dd9bb52370c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1",
             "name": "Distracting Geist // Clever Distraction",
             "text": "Whenever Distracting Geist attacks, tap target creature defending player controls.\nDisturb {4}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "18cbb350-9bb3-5969-964a-9efe9d087668",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1",
             "name": "Distracting Geist // Clever Distraction",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, tap target creature defending player controls.\"\nIf Clever Distraction would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "e4184bf3-7c33-5f05-a696-5f3a5e2ad13a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1",
             "name": "Drogskol Infantry // Drogskol Armaments",
             "text": "Disturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "b0ebe8e4-82d9-5be8-8d6a-0088c3fac447",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1",
             "name": "Drogskol Infantry // Drogskol Armaments",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nIf Drogskol Armaments would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "dfcdd07b-b150-5927-b5ca-6fbe991fdc19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg?1",
             "name": "Estwald Shieldbasher",
             "text": "Whenever Estwald Shieldbasher attacks, you may pay {1}. If you do, it gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "6a1b4bce-5776-5334-bfb5-b158a515c944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Defender, flying, vigilance\nAt the beginning of your upkeep, if Faithbound Judge has two or fewer judgment counters on it, put a judgment counter on it.\nAs long as Faithbound Judge has three or more judgment counters on it, it can attack as though it didn't have defender.\nDisturb {5}{W}{W}",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "6e392c3f-a94f-5ca6-afe1-8fedb0f9cd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Enchant player\nAt the beginning of your upkeep, put a judgment counter on Sinner's Judgment. Then if there are three or more judgment counters on it, enchanted player loses the game.\nIf Sinner's Judgment would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "c42a3140-dcd1-5633-a4f1-72b440a88c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597b163-5c6b-4f64-b1f1-5f1fa2e23e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597b163-5c6b-4f64-b1f1-5f1fa2e23e5d.jpg?1",
             "name": "Fierce Retribution",
             "text": "Cleave {5}{W} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDestroy target [attacking] creature.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "987ff12a-2ee6-59f7-aeaa-40fad8a37664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9d80f7-9742-4437-a9f4-6717a678f935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9d80f7-9742-4437-a9f4-6717a678f935.jpg?1",
             "name": "Fleeting Spirit",
             "text": "{W}, Exile three cards from your graveyard: Fleeting Spirit gains first strike until end of turn.\nDiscard a card: Exile Fleeting Spirit. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "5162ad3b-5227-5609-9762-d1705ebcef98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5317077b-370e-41a9-9162-c713362fd7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5317077b-370e-41a9-9162-c713362fd7f4.jpg?1",
             "name": "Gryff Rider",
             "text": "Flying\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "6dd42308-7a20-516f-8646-bc25447ff89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792d5b41-27f3-455b-890e-a1771944fc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792d5b41-27f3-455b-890e-a1771944fc7d.jpg?1",
             "name": "Gryffwing Cavalry",
             "text": "Flying\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever Gryffwing Cavalry attacks, you may pay {1}{W}. If you do, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -659,7 +659,7 @@
         },
         {
             "id": "78a14e65-6f6c-5c7e-85b8-a9205c4943a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674c0a50-9c37-4c29-84d8-eb3e34f34d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674c0a50-9c37-4c29-84d8-eb3e34f34d37.jpg?1",
             "name": "Hallowed Haunting",
             "text": "As long as you control seven or more enchantments, creatures you control have flying and vigilance.\nWhenever you cast an enchantment spell, create a white Spirit Cleric creature token with \"This creature's power and toughness are each equal to the number of Spirits you control.\"",
             "colours": [
@@ -693,7 +693,7 @@
         },
         {
             "id": "3d0d3865-3d1b-5a71-abd2-8b2b769c2978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e6933-5c64-4fcd-bb7f-740767a149cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e6933-5c64-4fcd-bb7f-740767a149cb.jpg?1",
             "name": "Heron of Hope",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\n{1}{W}: Heron of Hope gains lifelink until end of turn.",
             "colours": [
@@ -727,7 +727,7 @@
         },
         {
             "id": "d1cd26ed-0d4d-5eb8-a715-606bd3e70924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bacf4a-4e99-4008-97e4-3a82dddd4e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bacf4a-4e99-4008-97e4-3a82dddd4e45.jpg?1",
             "name": "Heron-Blessed Geist",
             "text": "Flying\n{3}{W}, Exile Heron-Blessed Geist from your graveyard: Create two 1/1 white Spirit creature tokens with flying. Activate only if you control an enchantment and only as a sorcery.",
             "colours": [
@@ -761,7 +761,7 @@
         },
         {
             "id": "db3d471a-d3c1-5d22-8dfa-afefec86683d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b3fd1-952a-4bc6-9b31-bd9bd13072f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b3fd1-952a-4bc6-9b31-bd9bd13072f5.jpg?1",
             "name": "Hopeful Initiate",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\n{2}{W}, Remove two +1/+1 counters from among creatures you control: Destroy target artifact or enchantment.",
             "colours": [
@@ -798,7 +798,7 @@
         },
         {
             "id": "9307c39d-121b-56bd-8ae2-da2e099f6706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Flying, lifelink, protection from Vampires\nKatilda, Dawnhart Martyr's power and toughness are each equal to the number of permanents you control that are Spirits and/or enchantments.\nDisturb {3}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "d49fed4c-f5c3-5d7d-bfa2-eab6af267bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Enchant creature\nEnchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, where X is the number of permanents you control that are Spirits and/or enchantments.\nIf Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "fb1eaab6-b533-57f3-81cb-6ec1c134d349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1",
             "name": "Kindly Ancestor // Ancestor's Embrace",
             "text": "Lifelink\nDisturb {1}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -909,7 +909,7 @@
         },
         {
             "id": "cb8ba0c5-cbc6-511a-ad4b-58593847f7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1",
             "name": "Kindly Ancestor // Ancestor's Embrace",
             "text": "Enchant creature\nEnchanted creature has lifelink.\nIf Ancestor's Embrace would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "f1c071f1-e4de-5dd6-91d7-9bd3dba1aea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd59300-7b5c-4263-a7fd-775c9fcb05ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd59300-7b5c-4263-a7fd-775c9fcb05ad.jpg?1",
             "name": "Lantern Flare",
             "text": "Cleave {X}{R}{W} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nLantern Flare deals X damage to target creature or planeswalker and you gain X life. [\nX is the number of creatures you control.]",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "f93cbf50-4f1f-588e-ae8b-3552682826cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b3ff40-3185-4369-985e-17613bb6ad22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b3ff40-3185-4369-985e-17613bb6ad22.jpg?1",
             "name": "Militia Rallier",
             "text": "Militia Rallier can't attack alone.\nWhenever Militia Rallier attacks, untap target creature.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "a1652f7f-740a-50ad-9d9e-a6880ccf3746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c68dbd-e61b-49a7-aa17-da6b26c9fd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c68dbd-e61b-49a7-aa17-da6b26c9fd29.jpg?1",
             "name": "Nebelgast Beguiler",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "30789e1d-e3bf-5568-bb62-6326cce7c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e109ea-8b86-4432-b15e-5a6201caf2aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e109ea-8b86-4432-b15e-5a6201caf2aa.jpg?1",
             "name": "Nurturing Presence",
             "text": "Enchant creature\nEnchanted creature has \"Whenever a creature enters the battlefield under your control, this creature gets +1/+1 until end of turn.\"\nWhen Nurturing Presence enters the battlefield, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "40dcfa13-9706-515f-bcb6-b2c612196987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a659bf-9d85-4011-980e-c3a8dc4513e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a659bf-9d85-4011-980e-c3a8dc4513e9.jpg?1",
             "name": "Ollenbock Escort",
             "text": "Vigilance\nSacrifice Ollenbock Escort: Target creature you control with a +1/+1 counter on it gains lifelink and indestructible until end of turn.",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "3e3d9a1b-2646-573b-ad28-0aa85de390f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg?1",
             "name": "Panicked Bystander // Cackling Culprit",
             "text": "Whenever Panicked Bystander or another creature you control dies, you gain 1 life.\nAt the beginning of your end step, if you gained 3 or more life this turn, transform Panicked Bystander.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "52db4391-758b-5e5a-aa1d-e13f761a1581",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg?1",
             "name": "Panicked Bystander // Cackling Culprit",
             "text": "Whenever Cackling Culprit or another creature you control dies, you gain 1 life.\n{1}{B}: Cackling Culprit gains deathtouch until end of turn.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "fcb1c91d-7a0f-551b-a518-ad66e473cf8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9845cdf2-e5ba-44a0-8136-72a1eb03a6a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9845cdf2-e5ba-44a0-8136-72a1eb03a6a1.jpg?1",
             "name": "Parish-Blade Trainee",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhen Parish-Blade Trainee dies, put its counters on target creature you control.",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "bb981eec-21a1-5fe0-b41b-0de7adc9c8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cc4e2b-1497-4788-afb4-9e42b7683b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cc4e2b-1497-4788-afb4-9e42b7683b5a.jpg?1",
             "name": "Piercing Light",
             "text": "Piercing Light deals 2 damage to target attacking or blocking creature. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "b63ce99e-f42c-5e8c-b634-89cbff3a14cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1",
             "name": "Radiant Grace // Radiant Restraints",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has vigilance.\nWhen enchanted creature dies, return Radiant Grace to the battlefield transformed under your control attached to target opponent.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "4f075837-246d-5fcd-a76b-a179a894d809",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1",
             "name": "Radiant Grace // Radiant Restraints",
             "text": "Enchant player\nCreatures enchanted player controls enter the battlefield tapped.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "02fb6859-ca30-53b5-b26a-229c1033372f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ae747-350f-4253-b903-8c6892d78c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ae747-350f-4253-b903-8c6892d78c83.jpg?1",
             "name": "Resistance Squad",
             "text": "When Resistance Squad enters the battlefield, if you control another Human, draw a card.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "0e6ce937-f727-54e5-b7ff-fe3b87d4ccf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880e071a-6d6c-41c4-b2eb-c9e6626d0c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880e071a-6d6c-41c4-b2eb-c9e6626d0c7f.jpg?1",
             "name": "Sanctify",
             "text": "Destroy target artifact or enchantment. You gain 3 life.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "d1775172-1134-50d1-843c-391b1f3b035c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77e83b-1846-4c42-bea0-2e304429fbe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77e83b-1846-4c42-bea0-2e304429fbe0.jpg?1",
             "name": "Savior of Ollenbock",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever Savior of Ollenbock trains, exile up to one other target creature from the battlefield or creature card from a graveyard.\nWhen Savior of Ollenbock leaves the battlefield, put the exiled cards onto the battlefield under their owners' control.",
             "colours": [
@@ -1429,7 +1429,7 @@
         },
         {
             "id": "3f6b4d4c-510a-5b40-a846-8d383f012436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118995a6-8471-47ac-9404-700ce7fc46f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118995a6-8471-47ac-9404-700ce7fc46f6.jpg?1",
             "name": "Sigarda's Imprisonment",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{4}{W}: Exile enchanted creature. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "650105c0-7aef-534f-bed5-02bb3bbbeb5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27f647a-d48e-4f53-ae5b-64c76f4fc745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27f647a-d48e-4f53-ae5b-64c76f4fc745.jpg?1",
             "name": "Sigarda's Summons",
             "text": "Creatures you control with +1/+1 counters on them have base power and toughness 4/4, have flying, and are Angels in addition to their other types.",
             "colours": [
@@ -1498,7 +1498,7 @@
         },
         {
             "id": "3eff7573-2a10-5d85-a9b0-eb8ce885244b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ca69c-916d-4af3-82a4-5f6fb614d6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ca69c-916d-4af3-82a4-5f6fb614d6a4.jpg?1",
             "name": "Supernatural Rescue",
             "text": "This spell has flash as long as you control a Spirit.\nWhen you cast this spell, tap up to two target creatures you don't control.\nEnchant creature you control\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -1532,7 +1532,7 @@
         },
         {
             "id": "f9925a8a-584e-511d-b4bf-393028652722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f8b8fb-1cd8-450e-a1fe-892e7a323479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f8b8fb-1cd8-450e-a1fe-892e7a323479.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1572,7 +1572,7 @@
         },
         {
             "id": "ca1b0d95-6fb0-5cd6-bea0-5e96a52220fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e672a05c-5f1a-4aa6-9398-e33df01c7c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e672a05c-5f1a-4aa6-9398-e33df01c7c96.jpg?1",
             "name": "Traveling Minister",
             "text": "{T}: Target creature gets +1/+0 until end of turn. You gain 1 life. Activate only as a sorcery.",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "213640ae-9ca7-541d-854f-84fcde7c7353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg?1",
             "name": "Twinblade Geist // Twinblade Invocation",
             "text": "Double strike\nDisturb {2}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "6e603d28-cbc7-502a-84ac-5da0c2adba21",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg?1",
             "name": "Twinblade Geist // Twinblade Invocation",
             "text": "Enchant creature\nEnchanted creature has double strike.\nIf Twinblade Invocation would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "1254b99c-2cbe-545c-a1d9-5e9a54714b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4c04a4-e68b-4d3d-89c8-29cdaaac36b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4c04a4-e68b-4d3d-89c8-29cdaaac36b2.jpg?1",
             "name": "Unholy Officiant",
             "text": "Vigilance\n{4}{W}: Put a +1/+1 counter on Unholy Officiant.",
             "colours": [
@@ -1713,7 +1713,7 @@
         },
         {
             "id": "d7f22aa8-46bd-56c9-8ceb-bc452fdcd189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6b9a3b-8a19-4094-8dbb-08a0a9ca04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6b9a3b-8a19-4094-8dbb-08a0a9ca04a0.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1745,7 +1745,7 @@
         },
         {
             "id": "6eda450d-f85d-5e1f-9416-2b09e952a26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f6f03b-5a4e-4532-9c9e-24c75df2769f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f6f03b-5a4e-4532-9c9e-24c75df2769f.jpg?1",
             "name": "Vampire Slayer",
             "text": "Whenever Vampire Slayer deals damage to a Vampire, destroy that creature.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "ae9863df-f515-5a40-84bb-9622b3d880aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16c0871-3f40-4d5a-9d21-e7f944b64a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16c0871-3f40-4d5a-9d21-e7f944b64a65.jpg?1",
             "name": "Voice of the Blessed",
             "text": "Whenever you gain life, put a +1/+1 counter on Voice of the Blessed.\nAs long as Voice of the Blessed has four or more +1/+1 counters on it, it has flying and vigilance.\nAs long as Voice of the Blessed has ten or more +1/+1 counters on it, it has indestructible.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "c85dc20f-82b3-539d-9171-f0cc9bb55376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "At the beginning of your end step, put an invitation counter on Wedding Announcement. If you attacked with two or more creatures this turn, draw a card. Otherwise, create a 1/1 white Human creature token. Then if Wedding Announcement has three or more invitation counters on it, transform it.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "eb9aa9d0-6ad9-55ff-9836-71132ca0d6f5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "32c0afdf-82b5-5dde-92a6-f53365eee360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f69cea-823c-482b-a605-8138b3d950e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f69cea-823c-482b-a605-8138b3d950e6.jpg?1",
             "name": "Welcoming Vampire",
             "text": "Flying\nWhenever one or more other creatures with power 2 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "e38824d5-483c-5aa7-909a-cee8100bbcce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbf9d4f-6027-40b8-81c1-7f001a9119dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbf9d4f-6027-40b8-81c1-7f001a9119dd.jpg?1",
             "name": "Alchemist's Retrieval",
             "text": "Cleave {1}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nReturn target nonland permanent [you control] to its owner's hand.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "cec10798-3fdb-526c-948f-5bea71c99f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1",
             "name": "Binding Geist // Spectral Binding",
             "text": "Whenever Binding Geist attacks, target creature an opponent controls gets -2/-0 until end of turn.\nDisturb {1}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "a649aee7-e7ee-565c-8ba6-235b922b8468",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1",
             "name": "Binding Geist // Spectral Binding",
             "text": "Enchant creature\nEnchanted creature gets -2/-0.\nIf Spectral Binding would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "c8389e50-b89b-518d-9935-b735b83d3d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg?1",
             "name": "A-Binding Geist // A-Spectral Binding",
             "text": "",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "f389f93b-6ccb-51ab-948d-3f2b6e31df0f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg?1",
             "name": "A-Binding Geist // A-Spectral Binding",
             "text": "",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "abdd3364-cd0c-5411-8f07-dbaed5c3044e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg?1",
             "name": "Biolume Egg // Biolume Serpent",
             "text": "Defender\nWhen Biolume Egg enters the battlefield, scry 2.\nWhen you sacrifice Biolume Egg, return it to the battlefield transformed under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "10f3bd54-535e-5347-8a55-ebd86e49cfad",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg?1",
             "name": "Biolume Egg // Biolume Serpent",
             "text": "Sacrifice two Islands: Biolume Serpent can't be blocked this turn.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "14a942aa-929a-5c37-b5a1-ab02b1302c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg?1",
             "name": "Cemetery Illuminator",
             "text": "Flying\nWhenever Cemetery Illuminator enters the battlefield or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with Cemetery Illuminator.",
             "colours": [
@@ -2192,7 +2192,7 @@
         },
         {
             "id": "a9a7ba6d-5533-54d3-8583-600153df7674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60222e91-a688-4113-a8c2-ab08f52bb6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60222e91-a688-4113-a8c2-ab08f52bb6e1.jpg?1",
             "name": "Chill of the Grave",
             "text": "This spell costs {1} less to cast if you control a Zombie.\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "b32f35e1-56b2-5a26-bb82-49f42533aa5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2d3ba4-07c7-46bd-8241-0fa41105b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2d3ba4-07c7-46bd-8241-0fa41105b771.jpg?1",
             "name": "Cobbled Lancer",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\n{3}{U}, Exile Cobbled Lancer from your graveyard: Draw a card.",
             "colours": [
@@ -2259,7 +2259,7 @@
         },
         {
             "id": "e4856bec-930c-5543-831a-461702793087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72382e-920b-4695-a91c-4980c8c37a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72382e-920b-4695-a91c-4980c8c37a12.jpg?1",
             "name": "A-Cobbled Lancer",
             "text": "",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "5fa7a08e-b7f8-5b3e-9649-97bb95d5ab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg?1",
             "name": "Consuming Tide",
             "text": "Each player chooses a nonland permanent they control. Return all nonland permanents not chosen this way to their owners' hands. Then you draw a card for each opponent who has more cards in their hand than you.",
             "colours": [
@@ -2327,7 +2327,7 @@
         },
         {
             "id": "9b778fb4-f81b-57ff-aed0-6e492588bdd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42cbad81-152a-435f-9289-f4b6483a059b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42cbad81-152a-435f-9289-f4b6483a059b.jpg?1",
             "name": "Cradle of Safety",
             "text": "Flash\nEnchant creature you control\nWhen Cradle of Safety enters the battlefield, enchanted creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "bb3f9a24-4fbb-5aa9-a1de-335c08a10e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf2c686-efb0-46c7-b34e-c77987914b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf2c686-efb0-46c7-b34e-c77987914b96.jpg?1",
             "name": "Cruel Witness",
             "text": "Flying\nWhenever you cast a noncreature spell, look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "4496523f-c57e-5006-b87c-875462038114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b5fdf4-3884-436f-8066-bc7593e72b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b5fdf4-3884-436f-8066-bc7593e72b02.jpg?1",
             "name": "Diver Skaab",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Diver Skaab exploits a creature, target creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "5e65540b-92d2-5f16-8673-4c3cf96f5ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16345278-7565-406b-a958-835081082bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16345278-7565-406b-a958-835081082bc8.jpg?1",
             "name": "Dreadlight Monstrosity",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\n{3}{U}{U}: Dreadlight Monstrosity can't be blocked this turn. Activate only if you own a card in exile.",
             "colours": [
@@ -2465,7 +2465,7 @@
         },
         {
             "id": "c52ff1dc-4236-525a-ac81-cee87c3219c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b81d90b-708a-48c9-a478-e3b0a3d7e982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b81d90b-708a-48c9-a478-e3b0a3d7e982.jpg?1",
             "name": "Dreamshackle Geist",
             "text": "Flying\nAt the beginning of combat on your turn, choose up to one \u2014\n\u2022 Tap target creature.\n\u2022 Target creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "15a4f57c-8671-5f93-915d-1d250cb9a0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb3ee1-54f6-4523-9bec-435fade6332f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb3ee1-54f6-4523-9bec-435fade6332f.jpg?1",
             "name": "A-Dreamshackle Geist",
             "text": "",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "e2fd18de-def4-55ec-82cf-27399fc668f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81704d2-d555-4894-b36c-6b65d1ebe681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81704d2-d555-4894-b36c-6b65d1ebe681.jpg?1",
             "name": "Fear of Death",
             "text": "Enchant creature\nWhen Fear of Death enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "82a71dd9-14f6-5377-955c-4a93cdaf0f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302b5da-cac5-4ce7-ad38-2ff4e410891b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302b5da-cac5-4ce7-ad38-2ff4e410891b.jpg?1",
             "name": "Geistlight Snare",
             "text": "This spell costs {1} less to cast if you control a Spirit. It also costs {1} less to cast if you control an enchantment.\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "e7e5109b-9668-52a0-9175-e0d9f4df9772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69890076-9cc4-434f-8618-63b00fdf4515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69890076-9cc4-434f-8618-63b00fdf4515.jpg?1",
             "name": "Geralf, Visionary Stitcher",
             "text": "Zombies you control have flying.\n{U}, {T}, Sacrifice another nontoken creature: Create an X/X blue Zombie creature token, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "c8df5dc9-75a2-5e40-b096-2f8db9973ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg?1",
             "name": "Gutter Skulker // Gutter Shortcut",
             "text": "Gutter Skulker can't be blocked as long as it's attacking alone.\nDisturb {3}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "0846117c-935a-5c96-bfb5-158a54002e45",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg?1",
             "name": "Gutter Skulker // Gutter Shortcut",
             "text": "Enchant creature\nEnchanted creature can't be blocked as long as it's attacking alone.\nIf Gutter Shortcut would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "cdec08c7-6dcd-5217-8137-97bee73a4c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg?1",
             "name": "A-Gutter Skulker // A-Gutter Shortcut",
             "text": "",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "32ee944d-d97e-593a-9534-e8619f1bf9cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg?1",
             "name": "A-Gutter Skulker // A-Gutter Shortcut",
             "text": "",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "5eb40487-e9cd-5694-822e-bab8820f50e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b546bcf-2e86-42af-bf32-81c7fd36ef8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b546bcf-2e86-42af-bf32-81c7fd36ef8c.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "e8e02df6-89b5-55a1-8579-c3151cd19013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43799d-c83c-4774-bd39-3d94d6c8360e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43799d-c83c-4774-bd39-3d94d6c8360e.jpg?1",
             "name": "A-Hullbreaker Horror",
             "text": "",
             "colours": [
@@ -2846,7 +2846,7 @@
         },
         {
             "id": "d5d0f3bc-7caa-5775-ad07-af8fb716c065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe4ee8e-579d-4bfa-8c19-bfdb1c0b7177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe4ee8e-579d-4bfa-8c19-bfdb1c0b7177.jpg?1",
             "name": "Inspired Idea",
             "text": "Cleave {3}{U}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDraw three cards. [\nYour maximum hand size is reduced by three for the rest of the game.]",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "34e30c28-282b-5510-bf00-a2dbc571e5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "{T}: Draw a card, then exile a card from your hand face down. You may look at that card for as long as it remains exiled. You may pay {4}{U}{U}. If you do, transform Jacob Hauken, Inspector.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "5133fd60-dd96-5e8e-a31b-f1222e1e499b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "At the beginning of your upkeep, exile the top card of your library face down. You may look at that card for as long as it remains exiled.\nOnce during each of your turns, you may play a land or cast a spell from among the cards exiled with this permanent without paying its mana cost.",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "f4f0b664-c2e7-5dfe-991a-c115627f8f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg?1",
             "name": "Lantern Bearer // Lanterns' Lift",
             "text": "Flying\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "6c2e3128-4d0c-5819-8527-03ecdb14cf8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg?1",
             "name": "Lantern Bearer // Lanterns' Lift",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nIf Lanterns' Lift would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "655e68e4-4683-581f-aa7d-f2ae3007fa8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg?1",
             "name": "A-Lantern Bearer // A-Lanterns' Lift",
             "text": "",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "4d5b6c73-5522-5fa3-a418-6f6b4166da37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg?1",
             "name": "A-Lantern Bearer // A-Lanterns' Lift",
             "text": "",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "3c209370-48f6-5351-a493-cd8f9af15567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66511c-355f-4e8a-96fc-3afc7a315231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66511c-355f-4e8a-96fc-3afc7a315231.jpg?1",
             "name": "Lunar Rejection",
             "text": "Cleave {3}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nReturn target [\nWolf or Werewolf] creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "57a2fdb2-8f63-5652-a756-5aaae838fccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "You may have Mirrorhall Mimic enter the battlefield as a copy of any creature on the battlefield, except it's a Spirit in addition to its other types.\nDisturb {3}{U}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "07823919-e0b7-5f5e-a2a7-f1b8128dac06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "Enchant creature\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except it's a Spirit in addition to its other types.\nIf Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "d12f2d2e-bbc5-5888-b58c-ff309fded097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1",
             "name": "Mischievous Catgeist // Catlike Curiosity",
             "text": "Whenever Mischievous Catgeist deals combat damage to a player, draw a card.\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "a17ef2ec-2875-5bad-b748-ccf43a3c5645",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1",
             "name": "Mischievous Catgeist // Catlike Curiosity",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, draw a card.\"\nIf Catlike Curiosity would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "c93e7487-7800-5299-86a3-e16b92e0aeaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg?1",
             "name": "A-Mischievous Catgeist // A-Catlike Curiosity",
             "text": "",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "6561d6dd-1052-5930-b7b9-189fe8bd4abb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg?1",
             "name": "A-Mischievous Catgeist // A-Catlike Curiosity",
             "text": "",
             "colours": [
@@ -3331,7 +3331,7 @@
         },
         {
             "id": "eee0e4ed-17c8-5d1d-8dde-277007a572dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b674053-1f0f-436d-b106-f91f41cf3959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b674053-1f0f-436d-b106-f91f41cf3959.jpg?1",
             "name": "Necroduality",
             "text": "Whenever a nontoken Zombie enters the battlefield under your control, create a token that's a copy of that creature.",
             "colours": [
@@ -3365,7 +3365,7 @@
         },
         {
             "id": "308006ca-fe84-589b-9364-f725b19e7fd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd63d-6c25-47a6-a76c-ac53bf12949c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd63d-6c25-47a6-a76c-ac53bf12949c.jpg?1",
             "name": "Overcharged Amalgam",
             "text": "Flash\nFlying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Overcharged Amalgam exploits a creature, counter target spell, activated ability, or triggered ability.",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "d33dde45-88f9-5298-a885-5bfb5c51ebd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg?1",
             "name": "Patchwork Crawler",
             "text": "{2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter on Patchwork Crawler.\nPatchwork Crawler has all activated abilities of all creature cards exiled with it.",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "1e0305c7-7664-59fc-8a1a-ddb2ca3cacfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc22c2a-535a-46b5-817c-da5850abd669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc22c2a-535a-46b5-817c-da5850abd669.jpg?1",
             "name": "Repository Skaab",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Repository Skaab exploits a creature, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -3473,7 +3473,7 @@
         },
         {
             "id": "a1a7f6f7-d879-5f0d-afac-9f87e5b266bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5c6675-6e0f-427d-9399-a6e7fc6215f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5c6675-6e0f-427d-9399-a6e7fc6215f1.jpg?1",
             "name": "Scattered Thoughts",
             "text": "Look at the top four cards of your library. Put two of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "5c4bed81-1276-5ae6-85c8-611031583d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9faf98-11bb-4407-aec9-d0d43dbaba34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9faf98-11bb-4407-aec9-d0d43dbaba34.jpg?1",
             "name": "Screaming Swarm",
             "text": "Flying\nWhenever you attack with one or more creatures, target player mills that many cards. (To mill a card, a player puts the top card of their library into their graveyard.)\n{2}{U}: Put Screaming Swarm from your graveyard into your library second from the top.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "f789d77c-f8f8-5058-8723-3172559a69c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8805db2-5a26-43cf-9b74-f882c283e5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8805db2-5a26-43cf-9b74-f882c283e5e4.jpg?1",
             "name": "Selhoff Entomber",
             "text": "{T}, Discard a creature card: Draw a card.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "05de4376-3bf6-5d14-b72b-c7a3b76b2c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8214b1c-29f8-4986-89ac-2d7fc929edf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8214b1c-29f8-4986-89ac-2d7fc929edf3.jpg?1",
             "name": "Serpentine Ambush",
             "text": "Until end of turn, target creature becomes a blue Serpent with base power and toughness 5/5.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "9fad1682-6718-52b4-bda3-92fca004f539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73168804-3c22-4fcb-907a-2f08999c0cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73168804-3c22-4fcb-907a-2f08999c0cea.jpg?1",
             "name": "Skywarp Skaab",
             "text": "Flying\nWhen Skywarp Skaab enters the battlefield, you may exile two creature cards from your graveyard. If you do, draw a card.",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "885bcad2-125d-5733-9eec-0c09785a2a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg?1",
             "name": "Soulcipher Board // Cipherbound Spirit",
             "text": "Soulcipher Board enters the battlefield with three omen counters on it.\n{1}{U}, {T}: Look at the top two cards of your library. Put one of them into your graveyard.\nWhenever a creature card is put into your graveyard from anywhere, remove an omen counter from Soulcipher Board. Then if it has no omen counters on it, transform it.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "5255c8f6-07bf-5be1-860c-7855402da55a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg?1",
             "name": "Soulcipher Board // Cipherbound Spirit",
             "text": "Flying\nCipherbound Spirit can block only creatures with flying.\n{3}{U}: Draw two cards, then discard a card.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "28d9ca66-722e-537d-b035-4b59ba02d2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fb1426-5a6f-48dd-938b-c64b1a28ee59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fb1426-5a6f-48dd-938b-c64b1a28ee59.jpg?1",
             "name": "Steelclad Spirit",
             "text": "Defender\nWhenever an enchantment enters the battlefield under your control, Steelclad Spirit can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "64f7152e-00fb-5ff0-9a7e-c35bbfbe343b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1debb8c-d5e0-49e5-ab27-2d50e6f9d8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1debb8c-d5e0-49e5-ab27-2d50e6f9d8d2.jpg?1",
             "name": "Stitched Assistant",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Stitched Assistant exploits a creature, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -3775,7 +3775,7 @@
         },
         {
             "id": "0b275505-8ac9-556d-a667-2f73adb8e1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753d235-24d6-47a9-aed8-b3e13211c222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753d235-24d6-47a9-aed8-b3e13211c222.jpg?1",
             "name": "A-Stitched Assistant",
             "text": "",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "c31d5b4c-c831-5921-a70a-2ef479f115c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd5c860-9d27-40d9-af38-aaf40bd52423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd5c860-9d27-40d9-af38-aaf40bd52423.jpg?1",
             "name": "Stormchaser Drake",
             "text": "Flying\nWhenever Stormchaser Drake becomes the target of a spell you control, draw a card.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "6b3066fc-d7df-5981-9ea2-3eadd12b6f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08375017-4432-4296-9799-966db145ed7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08375017-4432-4296-9799-966db145ed7c.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays {X}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "fc7f19b4-e73e-5e01-9d6d-08531d50eb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a2d31-ac2c-45aa-8369-6c2d6fbba4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a2d31-ac2c-45aa-8369-6c2d6fbba4e4.jpg?1",
             "name": "Syphon Essence",
             "text": "Counter target creature or planeswalker spell. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "1a7c0af7-5017-5e54-8fb3-3a51b67eda15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea179e9-9c0d-46c1-9ee8-60be68e1f79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea179e9-9c0d-46c1-9ee8-60be68e1f79c.jpg?1",
             "name": "Thirst for Discovery",
             "text": "Draw three cards. Then discard two cards unless you discard a basic land card.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "8129a5b3-52c2-5deb-ae3f-75875d595116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb3ce5d-330d-427e-a053-8cc4eeb2941b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb3ce5d-330d-427e-a053-8cc4eeb2941b.jpg?1",
             "name": "Wanderlight Spirit",
             "text": "Flying\nWanderlight Spirit can block only creatures with flying.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "c6bb7348-fc09-5d73-acea-0b64c4e15b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43411ade-be80-4535-8baa-7055e78496df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43411ade-be80-4535-8baa-7055e78496df.jpg?1",
             "name": "Wash Away",
             "text": "Cleave {1}{U}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nCounter target spell [that wasn't cast from its owner's hand].",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "c1cdfd9d-b1c2-52fc-bc44-88276c38418d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg?1",
             "name": "Whispering Wizard",
             "text": "Whenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "dc7e6a62-5dc0-5582-9c48-9e0158f48d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg?1",
             "name": "Winged Portent",
             "text": "Cleave {4}{G}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDraw a card for each creature [with flying] you control.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "53ddb642-d650-54d2-9b14-64a39ff62146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b3683f-a68b-458c-8f70-bba0f8779b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b3683f-a68b-458c-8f70-bba0f8779b8a.jpg?1",
             "name": "Witness the Future",
             "text": "Target player shuffles up to four target cards from their graveyard into their library. You look at the top four cards of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "7c6ba013-373b-5141-a963-5a16c72897b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3991f0-76b8-4f77-9d67-0e2b11fda750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3991f0-76b8-4f77-9d67-0e2b11fda750.jpg?1",
             "name": "Wretched Throng",
             "text": "When Wretched Throng dies, you may search your library for a card named Wretched Throng, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "0b713075-53e4-59ed-b585-400e75679d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1174e8e1-2e8e-4070-9871-7d5d93e0dd56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1174e8e1-2e8e-4070-9871-7d5d93e0dd56.jpg?1",
             "name": "Aim for the Head",
             "text": "Choose one \u2014\n\u2022 Exile target Zombie.\n\u2022 Target opponent exiles two cards from their hand.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "a61230dd-d509-516e-8ace-c5939a92303a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf81c9d-ddb2-470e-8a4a-590049713e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf81c9d-ddb2-470e-8a4a-590049713e95.jpg?1",
             "name": "Archghoul of Thraben",
             "text": "Whenever Archghoul of Thraben or another Zombie you control dies, look at the top card of your library. If it's a Zombie card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "98aac3c0-23fb-5872-b82c-b3908ee654ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65755-f104-4de9-bcc9-0a4a7bc66b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65755-f104-4de9-bcc9-0a4a7bc66b51.jpg?1",
             "name": "Bleed Dry",
             "text": "Target creature gets -13/-13 until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "6e7bc76d-4bcc-57e2-b625-4f56684d643e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd03651e-ada0-41dc-8722-0eba476943e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd03651e-ada0-41dc-8722-0eba476943e3.jpg?1",
             "name": "Blood Fountain",
             "text": "When Blood Fountain enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{3}{B}, {T}, Sacrifice Blood Fountain: Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "38547fe6-0676-5be5-8c48-57c6d052139c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12c378-1103-4a50-88fa-cf5a2deef463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12c378-1103-4a50-88fa-cf5a2deef463.jpg?1",
             "name": "Bloodcrazed Socialite",
             "text": "Menace\nWhen Bloodcrazed Socialite enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "1103220c-b98b-5987-b760-64424fa28ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "{1}{B}, Discard a card: Bloodsworn Squire gains indestructible until end of turn. Tap it. Then if there are four or more creature cards in your graveyard, transform Bloodsworn Squire. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4347,7 +4347,7 @@
         },
         {
             "id": "aba94310-12d5-54b4-b137-95cd59e85421",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "Bloodsworn Knight's power and toughness are each equal to the number of creature cards in your graveyard.\n{1}{B}, Discard a card: Bloodsworn Knight gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "a8693cfe-ddb9-5150-b636-4ae02f2fa9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4889c58b-8b84-42af-a56c-e886655aa997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4889c58b-8b84-42af-a56c-e886655aa997.jpg?1",
             "name": "Bloodvial Purveyor",
             "text": "Flying, trample\nWhenever an opponent casts a spell, that player creates a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "b38955ff-c2ad-51ce-a373-b5469ba41537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1",
             "name": "Catapult Fodder // Catapult Captain",
             "text": "At the beginning of combat on your turn, if you control three or more creatures that each have toughness greater than their power, transform Catapult Fodder.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "a3dac4c9-f667-5714-b913-5799233e9cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1",
             "name": "Catapult Fodder // Catapult Captain",
             "text": "{2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "ef1d3238-cdaa-58bb-a0cd-d20280b3a31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg?1",
             "name": "Cemetery Desecrator",
             "text": "Menace\nWhen Cemetery Desecrator enters the battlefield or dies, exile another card from a graveyard. When you do, choose one \u2014\n\u2022 Remove X counters from target permanent, where X is the mana value of the exiled card.\n\u2022 Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card.",
             "colours": [
@@ -4524,7 +4524,7 @@
         },
         {
             "id": "5581d890-0e6b-5cd5-8a4f-23050383719e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Defender\n{2}{B}: Transform Concealing Curtains. Activate only as a sorcery.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "572749c9-631b-5ce0-ae98-9c0c1a5f87b1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Menace\nWhen this creature transforms into Revealing Eye, target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "eb12ccd9-5866-562b-b59d-735d3bf72b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a8dc7-1ee9-4731-bd72-3d02f4e7c6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a8dc7-1ee9-4731-bd72-3d02f4e7c6c4.jpg?1",
             "name": "Courier Bat",
             "text": "Flying\nWhen Courier Bat enters the battlefield, if you gained life this turn, return up to one target creature card from your graveyard to your hand.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "e7ae62d5-9917-5178-b8c4-b17e4117125a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c3741e-cf04-4aa2-a6a9-ce19f043b22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c3741e-cf04-4aa2-a6a9-ce19f043b22c.jpg?1",
             "name": "Demonic Bargain",
             "text": "Exile the top thirteen cards of your library, then search your library for a card. Put that card into your hand, then shuffle.",
             "colours": [
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "7a03e1a8-7680-5e02-88bf-f6809bb8cca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg?1",
             "name": "Desperate Farmer // Depraved Harvester",
             "text": "Lifelink\nWhen another creature you control dies, transform Desperate Farmer.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "c1ea4a6b-af19-58d1-ae22-22992ea40c69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg?1",
             "name": "Desperate Farmer // Depraved Harvester",
             "text": "Lifelink",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "9b3ec6e9-70c4-5cdf-a071-e3e0e28d1405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg?1",
             "name": "Diregraf Scavenger",
             "text": "Deathtouch\nWhen Diregraf Scavenger enters the battlefield, exile up to one target card from a graveyard. If a creature card was exiled this way, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "55da5515-9b60-5aec-bfa3-a76670dd7266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0cf16-81ea-45e3-99cc-4424d59bb44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0cf16-81ea-45e3-99cc-4424d59bb44b.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -4804,7 +4804,7 @@
         },
         {
             "id": "88b75259-2ee2-52ae-b383-b7e57c579435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad4c472-b8ce-4ae0-a6f0-726ea74722c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad4c472-b8ce-4ae0-a6f0-726ea74722c5.jpg?1",
             "name": "Dread Fugue",
             "text": "Cleave {2}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nTarget player reveals their hand. You choose a nonland card from it [with mana value 2 or less]. That player discards that card.",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "9b3578eb-25fa-523f-a38d-30f41b16023c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269199ea-2106-4299-ade0-10cce1320434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269199ea-2106-4299-ade0-10cce1320434.jpg?1",
             "name": "Dreadfeast Demon",
             "text": "Flying\nAt the beginning of your end step, sacrifice a non-Demon creature. If you do, create a token that's a copy of Dreadfeast Demon.",
             "colours": [
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "22334416-a411-5af4-af66-a1232b005320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea16cd-801e-478a-b924-5431582b70d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea16cd-801e-478a-b924-5431582b70d1.jpg?1",
             "name": "Dying to Serve",
             "text": "Whenever you discard one or more cards, create a tapped 2/2 black Zombie creature token. This ability triggers only once each turn.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "2a45ef19-08f5-5b6b-93cb-18f8e3d67b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ff9de6-f9ae-4b1c-9fd1-4ba9663922af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ff9de6-f9ae-4b1c-9fd1-4ba9663922af.jpg?1",
             "name": "Edgar's Awakening",
             "text": "Return target creature card from your graveyard to the battlefield.\nWhen you discard Edgar's Awakening, you may pay {B}. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "bca2c03d-5d5e-5b9d-b414-f687455726d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451559d0-b62d-4757-8eb5-f6b0e240899c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451559d0-b62d-4757-8eb5-f6b0e240899c.jpg?1",
             "name": "Falkenrath Forebear",
             "text": "Flying\nFalkenrath Forebear can't block.\nWhenever Falkenrath Forebear deals combat damage to a player, create a Blood token.\n{B}, Sacrifice two Blood tokens: Return Falkenrath Forebear from your graveyard to the battlefield.",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "72479027-b2cf-5bb5-8475-bd07e6366826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347849-6c07-42c0-bee4-74f93d7ad511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347849-6c07-42c0-bee4-74f93d7ad511.jpg?1",
             "name": "Fell Stinger",
             "text": "Deathtouch\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Fell Stinger exploits a creature, target player draws two cards and loses 2 life.",
             "colours": [
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "b1b4d68e-1e42-5c8f-b6b4-5877f5fdb3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a864375f-99c3-4c68-9440-bc25ff6d0dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a864375f-99c3-4c68-9440-bc25ff6d0dc0.jpg?1",
             "name": "Gift of Fangs",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Vampire. Otherwise, it gets -2/-2.",
             "colours": [
@@ -5046,7 +5046,7 @@
         },
         {
             "id": "e4479e63-3cbd-54a9-8476-03a1e71af2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c07288-1c71-4e71-bdf5-910eb583a1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c07288-1c71-4e71-bdf5-910eb583a1d8.jpg?1",
             "name": "Gluttonous Guest",
             "text": "When Gluttonous Guest enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Blood token, you gain 1 life.",
             "colours": [
@@ -5082,7 +5082,7 @@
         },
         {
             "id": "da1ed74f-99d9-5e28-ab1d-e1226763090e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg?1",
             "name": "Graf Reaver",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Graf Reaver exploits a creature, destroy target planeswalker.\nAt the beginning of your upkeep, Graf Reaver deals 1 damage to you.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "1a8e5fd7-a95b-5aeb-a4b7-9c604bb51b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cdf2ab-3acd-49bd-8273-84c1cfc92883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cdf2ab-3acd-49bd-8273-84c1cfc92883.jpg?1",
             "name": "Grisly Ritual",
             "text": "Destroy target creature or planeswalker. Create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "a930e1e8-91a7-5ebe-954d-535ba756b7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bc65cf-4444-4db3-9bb3-a7d91e560470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bc65cf-4444-4db3-9bb3-a7d91e560470.jpg?1",
             "name": "Groom's Finery",
             "text": "Equipped creature gets +2/+0. It gets an additional +0/+2 and has deathtouch as long as an Equipment named Bride's Gown is attached to a creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "0d693c10-4709-5adc-ad33-86e061ccbb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24018e8-b8f1-44a5-9355-8b79f363569d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24018e8-b8f1-44a5-9355-8b79f363569d.jpg?1",
             "name": "Headless Rider",
             "text": "Whenever Headless Rider or another nontoken Zombie you control dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "ba2ee893-217a-510d-bbcb-bf08ea32ad5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen \u2014\n\u2022 Each player sacrifices a creature.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Transform Henrika Domnathi.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "a0ee90ad-676b-523c-9a6c-871b4713eece",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying, deathtouch, lifelink\n{1}{B}{B}: Each creature you control with flying, deathtouch, and/or lifelink gets +1/+0 until end of turn.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "ef7568a3-95d1-5bc5-8b05-e2f28a9cb01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b0751e-3a7e-4568-8c64-7429d6829687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b0751e-3a7e-4568-8c64-7429d6829687.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "604145b4-defd-5570-acd1-0c61a8c839a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "At the beginning of your upkeep, any opponent may sacrifice a creature. If no one does, transform Innocent Traveler.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "6f1a9d11-690a-5328-9115-d14a8006e42f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "Flying\nMalicious Invader gets +2/+0 as long as an opponent controls a Human.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "3501c7e8-fe9e-5ef5-94f1-1fa389bf8501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c4e00d-128a-4ddb-9e1b-3ee93121b262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c4e00d-128a-4ddb-9e1b-3ee93121b262.jpg?1",
             "name": "Mindleech Ghoul",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Mindleech Ghoul exploits a creature, each opponent exiles a card from their hand.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "91ec91fc-b315-5ed4-8382-e91dd940d3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0713adf7-1770-4d5b-80f7-d6cbd24f7890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0713adf7-1770-4d5b-80f7-d6cbd24f7890.jpg?1",
             "name": "Parasitic Grasp",
             "text": "Cleave {1}{B}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nParasitic Grasp deals 3 damage to target [\nHuman] creature. You gain 3 life.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "f5bf25c1-ff47-5538-b759-9bcdfbdf434f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5449a-d63b-4b22-9432-8f0365c3c4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5449a-d63b-4b22-9432-8f0365c3c4d9.jpg?1",
             "name": "Path of Peril",
             "text": "Cleave {4}{W}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDestroy all creatures [with mana value 2 or less].",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "21a1cc6d-7d02-54b2-86e6-7004471ce967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7baf973-3202-4fea-8861-a4a5ec228640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7baf973-3202-4fea-8861-a4a5ec228640.jpg?1",
             "name": "Persistent Specimen",
             "text": "{2}{B}: Return Persistent Specimen from your graveyard to the battlefield tapped.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "00ef2ebb-0d40-56d8-b21c-7aa78282e0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076deb63-f7e2-498f-a66a-8a190370a3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076deb63-f7e2-498f-a66a-8a190370a3b3.jpg?1",
             "name": "Pointed Discussion",
             "text": "You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "8886cdac-18a2-562f-bc5d-d29d7390e0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg?1",
             "name": "Ragged Recluse // Odious Witch",
             "text": "At the beginning of your end step, if you discarded a card this turn, transform Ragged Recluse.",
             "colours": [
@@ -5607,7 +5607,7 @@
         },
         {
             "id": "87c5dc77-4f67-57ea-a201-8a9a89b1b507",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg?1",
             "name": "Ragged Recluse // Odious Witch",
             "text": "Whenever Odious Witch attacks, defending player loses 1 life and you gain 1 life.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "b05823b8-4e22-57d9-93db-0548c81b9327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nSacrifice two Blood tokens: Transform Restless Bloodseeker. Activate only as a sorcery.",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "40cdfae0-8dc6-5ebb-a545-1b7d6e7be767",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{4}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "86dfd633-57eb-588a-9e30-25dd601a8188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eafefd0-3a9e-400e-8c75-0825aeb2ded1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eafefd0-3a9e-400e-8c75-0825aeb2ded1.jpg?1",
             "name": "Rot-Tide Gargantua",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Rot-Tide Gargantua exploits a creature, each opponent sacrifices a creature.",
             "colours": [
@@ -5749,7 +5749,7 @@
         },
         {
             "id": "354f11cd-b8f1-5245-87b9-20dc70a320aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497b94b9-c5d7-4e94-87c2-ca1342588d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497b94b9-c5d7-4e94-87c2-ca1342588d79.jpg?1",
             "name": "Skulking Killer",
             "text": "When Skulking Killer enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn if that opponent controls no other creatures.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "a3a10243-2d04-5d53-9494-debf602e0c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7ff5f4-a7cc-41a1-a22b-8cf67ad18707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7ff5f4-a7cc-41a1-a22b-8cf67ad18707.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "0e997854-f8e6-5ca0-98a1-fee654b79e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e64f38-b1f3-47cd-8cfb-a4861369aca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e64f38-b1f3-47cd-8cfb-a4861369aca3.jpg?1",
             "name": "Toxrill, the Corrosive",
             "text": "At the beginning of each end step, put a slime counter on each creature you don't control.\nCreatures you don't control get -1/-1 for each slime counter on them.\nWhenever a creature you don't control with a slime counter on it dies, create a 1/1 black Slug creature token.\n{U}{B}, Sacrifice a Slug: Draw a card.",
             "colours": [
@@ -5866,7 +5866,7 @@
         },
         {
             "id": "0644169c-b392-5eb4-961c-8ba2b689afd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b8582-8887-4652-82e2-f9b11ee21545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b8582-8887-4652-82e2-f9b11ee21545.jpg?1",
             "name": "Undead Butler",
             "text": "When Undead Butler enters the battlefield, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen Undead Butler dies, you may exile it. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5900,7 +5900,7 @@
         },
         {
             "id": "92334bd0-e0d9-5b6f-8954-d32de1187092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb38041-043a-4b18-9d9a-f1283684e8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb38041-043a-4b18-9d9a-f1283684e8f1.jpg?1",
             "name": "Undying Malice",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "3f372b80-b237-59b4-aed6-4f0cf1d6dcf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec541b-1799-4c0e-a3fb-c008cf2eb911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec541b-1799-4c0e-a3fb-c008cf2eb911.jpg?1",
             "name": "Unhallowed Phalanx",
             "text": "Unhallowed Phalanx enters the battlefield tapped.",
             "colours": [
@@ -5967,7 +5967,7 @@
         },
         {
             "id": "004d27a9-3296-5633-b826-5ded7b49da6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf8cc-4259-48cc-8e7f-1580bb010d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf8cc-4259-48cc-8e7f-1580bb010d3f.jpg?1",
             "name": "Vampire's Kiss",
             "text": "Target player loses 2 life and you gain 2 life. Create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "cb5067fe-fe6e-5253-af3e-5a032903ec24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "2dd36e10-21c2-5b6f-944c-3eb8e012204d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "3cf0fd6a-177e-5703-8ffe-0cf4152c1d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddfdd10-2a99-4376-abee-f868b0d5e7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddfdd10-2a99-4376-abee-f868b0d5e7c1.jpg?1",
             "name": "Wedding Security",
             "text": "Whenever Wedding Security attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter on Wedding Security and draw a card.",
             "colours": [
@@ -6112,7 +6112,7 @@
         },
         {
             "id": "4913a0dc-3870-5ef3-86fc-1637bf544cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e47d11-cb21-402b-a39e-588a94cc57b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e47d11-cb21-402b-a39e-588a94cc57b4.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "aef55052-2ab7-50fc-8e80-dc5c2f412693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fbf5d3-4677-4bf0-891f-57d6dcddaff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fbf5d3-4677-4bf0-891f-57d6dcddaff7.jpg?1",
             "name": "Alchemist's Gambit",
             "text": "Cleave {4}{U}{U}{R} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nTake an extra turn after this one. During that turn, damage can't be prevented. At the beginning of that turn's end step, you lose the game.\nExile Alchemist's Gambit.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "89fd1d7f-ba05-5525-bb4f-e076c9f3db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "When you attack with exactly two creatures, transform Alluring Suitor.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "472e2e3a-9ffe-5243-989d-d55da189e594",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "Trample\nWhen this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't lose this mana as steps and phases end.\n{R}{R}: Deadly Dancer and another target creature each get +1/+0 until end of turn.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "6c1b624f-dfee-576d-b9d0-0a768394db0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dee47ab-d603-4346-97f4-a25dc3f47765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dee47ab-d603-4346-97f4-a25dc3f47765.jpg?1",
             "name": "Ancestral Anger",
             "text": "Target creature gains trample and gets +X/+0 until end of turn, where X is 1 plus the number of cards named Ancestral Anger in your graveyard.\nDraw a card.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "c65601dc-fd33-5276-bce9-8a5e4d42a082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg?1",
             "name": "Ballista Watcher // Ballista Wielder",
             "text": "{2}{R}, {T}: Ballista Watcher deals 1 damage to any target.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "bfb803bf-5e79-5f9d-9a41-3fb570464ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg?1",
             "name": "Ballista Watcher // Ballista Wielder",
             "text": "{2}{R}: Ballista Wielder deals 1 damage to any target. A creature dealt damage this way can't block this turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "ddd19e6f-c7f0-574d-8dfd-fe9a9833f849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb844c4-f41c-4411-a80a-c19e1d97b272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb844c4-f41c-4411-a80a-c19e1d97b272.jpg?1",
             "name": "Belligerent Guest",
             "text": "Trample\nWhenever Belligerent Guest deals combat damage to a player, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "c690ef52-de76-5024-92ac-4472a1b82ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85e0477-9176-4a3e-badc-f1c1c734e59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85e0477-9176-4a3e-badc-f1c1c734e59c.jpg?1",
             "name": "Blood Hypnotist",
             "text": "Blood Hypnotist can't block.\nWhenever you sacrifice one or more Blood tokens, target creature can't block this turn. This ability triggers only once each turn.",
             "colours": [
@@ -6425,7 +6425,7 @@
         },
         {
             "id": "be3fa911-012c-562e-8d2a-f3f001f27c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3a4927-f06c-424d-92a9-b40cf8e3e209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3a4927-f06c-424d-92a9-b40cf8e3e209.jpg?1",
             "name": "Blood Petal Celebrant",
             "text": "Blood Petal Celebrant has first strike as long as it's attacking.\nWhen Blood Petal Celebrant dies, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6461,7 +6461,7 @@
         },
         {
             "id": "2d6226fa-c463-50b4-827c-a8e49087252e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8970a5d6-dcab-415a-851b-20e228ef7d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8970a5d6-dcab-415a-851b-20e228ef7d16.jpg?1",
             "name": "Bloody Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "95ea1b20-717a-5dc8-9297-dc40c7d81272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457086c4-1b4e-4f79-8f2a-10b16174c8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457086c4-1b4e-4f79-8f2a-10b16174c8bb.jpg?1",
             "name": "Cemetery Gatekeeper",
             "text": "First strike\nWhen Cemetery Gatekeeper enters the battlefield, exile a card from a graveyard.\nWhenever a player plays a land or casts a spell, if it shares a card type with the exiled card, Cemetery Gatekeeper deals 2 damage to that player.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "29ce18c1-48d3-5692-ba14-c5cf79e3adc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681f7c73-92c6-47ba-af56-3ff032ac12da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681f7c73-92c6-47ba-af56-3ff032ac12da.jpg?1",
             "name": "Chandra, Dressed to Kill",
             "text": "+1: Add {R}. Chandra, Dressed to Kill deals 1 damage to up to one target player or planeswalker.\n+1: Exile the top card of your library. If it's red, you may cast it this turn.\n\u22127: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"",
             "colours": [
@@ -6567,7 +6567,7 @@
         },
         {
             "id": "16387216-cc90-5a18-b26b-37a1c6f56d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ca5ce5-94e7-43a1-8f2b-f0a4532f617a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ca5ce5-94e7-43a1-8f2b-f0a4532f617a.jpg?1",
             "name": "Change of Fortune",
             "text": "Discard your hand, then draw a card for each card you've discarded this turn.",
             "colours": [
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "700eed52-28b3-5cf3-9494-a49373422fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg?1",
             "name": "Creepy Puppeteer",
             "text": "Haste\nWhenever Creepy Puppeteer attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn.",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "e2235fda-df7e-550b-b03b-a11c1101e942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg?1",
             "name": "Curse of Hospitality",
             "text": "Enchant player\nCreatures attacking enchanted player have trample.\nWhenever a creature deals combat damage to enchanted player, that player exiles the top card of their library. Until end of turn, that creature's controller may play that card and they may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "eb030e56-9f8c-584b-aac2-1e6a3ff8deec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8697a861-0f67-4ed3-bed8-f264fc78565e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8697a861-0f67-4ed3-bed8-f264fc78565e.jpg?1",
             "name": "Daybreak Combatants",
             "text": "Haste\nWhen Daybreak Combatants enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "7ab1bf93-b5cc-5f9e-a896-99382bcebdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11d234-c6e4-45b2-a3c2-dcacc77cc084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11d234-c6e4-45b2-a3c2-dcacc77cc084.jpg?1",
             "name": "Dominating Vampire",
             "text": "When Dominating Vampire enters the battlefield, gain control of target creature with mana value less than or equal to the number of Vampires you control until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -6747,7 +6747,7 @@
         },
         {
             "id": "946a1e75-2eb8-532f-8dfc-603a4b011c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec748e6-7245-4a71-aeee-cefed8346948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec748e6-7245-4a71-aeee-cefed8346948.jpg?1",
             "name": "End the Festivities",
             "text": "End the Festivities deals 1 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -6779,7 +6779,7 @@
         },
         {
             "id": "3c113ba5-1f73-51bc-b0fd-ab2123864444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3c5778-4760-4a8c-8d8d-693e29a0a74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3c5778-4760-4a8c-8d8d-693e29a0a74b.jpg?1",
             "name": "Falkenrath Celebrants",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Falkenrath Celebrants enters the battlefield, create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6815,7 +6815,7 @@
         },
         {
             "id": "6456e418-60c9-5e12-bd03-570fd3d139a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg?1",
             "name": "Fearful Villager // Fearsome Werewolf",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "d6fa3986-5abf-55c9-af99-cfa2d5c1a0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg?1",
             "name": "Fearful Villager // Fearsome Werewolf",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "c5aa8f3c-e5e7-5ffd-af28-26e565e7aec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1771a8f-7bea-4bb0-9949-566ee6613b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1771a8f-7bea-4bb0-9949-566ee6613b93.jpg?1",
             "name": "Flame-Blessed Bolt",
             "text": "Flame-Blessed Bolt deals 2 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "a42f5e8d-5f63-578c-b05f-6edf4bf1e675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7912206-6de3-4085-b5f6-a2e90ea55b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7912206-6de3-4085-b5f6-a2e90ea55b90.jpg?1",
             "name": "Frenzied Devils",
             "text": "Haste\nWhenever you cast a noncreature spell, Frenzied Devils gets +2/+2 until end of turn.",
             "colours": [
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "d8ce6762-a988-5769-9c58-436ce12e5eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e491a1-b195-45bb-bf06-345eaee30b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e491a1-b195-45bb-bf06-345eaee30b81.jpg?1",
             "name": "Honeymoon Hearse",
             "text": "Trample\nTap two untapped creatures you control: Honeymoon Hearse becomes an artifact creature until end of turn.",
             "colours": [
@@ -6984,7 +6984,7 @@
         },
         {
             "id": "149459e2-da3e-52e9-8d28-b30e24d1560f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804e0e1d-9c9c-46e6-8533-88e18a91ceff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804e0e1d-9c9c-46e6-8533-88e18a91ceff.jpg?1",
             "name": "Hungry Ridgewolf",
             "text": "As long as you control another Wolf or Werewolf, Hungry Ridgewolf gets +1/+0 and has trample.",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "61de9b66-8c4a-50cd-96c0-30a8495b2f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever Ill-Tempered Loner is dealt damage, it deals that much damage to any target.\n{1}{R}: Ill-Tempered Loner gets +2/+0 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7055,7 +7055,7 @@
         },
         {
             "id": "efe7daf2-bd75-5878-91d5-5e1f79b0cdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever a permanent you control is dealt damage, Howlpack Avenger deals that much damage to any target.\n{1}{R}: Howlpack Avenger gets +2/+0 until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "633e6d81-c183-5083-8a19-062bcb334f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a96286-0dda-4761-a1c5-241288c36275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a96286-0dda-4761-a1c5-241288c36275.jpg?1",
             "name": "Into the Night",
             "text": "It becomes night. Discard any number of cards, then draw that many cards plus one.",
             "colours": [
@@ -7123,7 +7123,7 @@
         },
         {
             "id": "b1a92756-3c7f-5254-81b1-c1f8326ba433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ad78a-b02a-44dc-afe6-7f95781a5062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ad78a-b02a-44dc-afe6-7f95781a5062.jpg?1",
             "name": "Kessig Flamebreather",
             "text": "Whenever you cast a noncreature spell, Kessig Flamebreather deals 1 damage to each opponent.",
             "colours": [
@@ -7158,7 +7158,7 @@
         },
         {
             "id": "28481847-407b-5e4c-9959-1da3052dea4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg?1",
             "name": "Kessig Wolfrider",
             "text": "Menace\n{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "bd47c307-d725-53c7-890c-21998545cd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e0c0dc-2d35-4e5a-81da-dd5f35b8e579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e0c0dc-2d35-4e5a-81da-dd5f35b8e579.jpg?1",
             "name": "Lacerate Flesh",
             "text": "Lacerate Flesh deals 4 damage to target creature. Create a number of Blood tokens equal to the amount of excess damage dealt to that creature this way. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "66b34f01-ba41-5a2f-94ac-861774f41496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg?1",
             "name": "Lambholt Raconteur // Lambholt Ravager",
             "text": "Whenever you cast a noncreature spell, Lambholt Raconteur deals 1 damage to each opponent.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7262,7 +7262,7 @@
         },
         {
             "id": "6f53fdf0-bd73-5ca3-adf2-a1b7583c7a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg?1",
             "name": "Lambholt Raconteur // Lambholt Ravager",
             "text": "Whenever you cast a noncreature spell, Lambholt Ravager deals 2 damage to each opponent.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7296,7 +7296,7 @@
         },
         {
             "id": "aca7acf6-b459-5c4b-b209-6c73327e0f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7211e4c3-e940-41da-88e4-4630eab447a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7211e4c3-e940-41da-88e4-4630eab447a6.jpg?1",
             "name": "Lightning Wolf",
             "text": "{1}{R}: Lightning Wolf gains first strike until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "236a6a7e-ebd5-5925-83df-f72a4a4227b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f133d6-35c3-49b7-85f6-d6cfa6bac3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f133d6-35c3-49b7-85f6-d6cfa6bac3d9.jpg?1",
             "name": "Magma Pummeler",
             "text": "Magma Pummeler enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Magma Pummeler while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from it. When one or more counters are removed from Magma Pummeler this way, it deals that much damage to any target.",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "dbd85237-3c8f-53b4-9c32-8544fffca303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59170-aa80-45e1-ad0d-ce4818e78d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59170-aa80-45e1-ad0d-ce4818e78d2a.jpg?1",
             "name": "Manaform Hellkite",
             "text": "Flying\nWhenever you cast a noncreature spell, create an X/X red Dragon Illusion creature token with flying and haste, where X is the amount of mana spent to cast that spell. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "04aa7896-01c3-5c48-8f86-190543d1b814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d3840c-db27-4512-bfe3-92249094e5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d3840c-db27-4512-bfe3-92249094e5b4.jpg?1",
             "name": "Markov Retribution",
             "text": "Choose one or both \u2014\n\u2022 Creatures you control get +1/+0 until end of turn.\n\u2022 Target Vampire you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "60e5b8f2-0571-5400-87f5-e72ef992d284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9702fa3-9323-4e2f-92c9-6c31df198af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9702fa3-9323-4e2f-92c9-6c31df198af2.jpg?1",
             "name": "Olivia's Attendants",
             "text": "Menace\nWhenever Olivia's Attendants deals damage, create that many Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{2}{R}: Olivia's Attendants deals 1 damage to any target.",
             "colours": [
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "fc6d2574-1687-5666-b206-4a2264c05cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80255777-de00-4ffa-a8a0-f522bf4198fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80255777-de00-4ffa-a8a0-f522bf4198fb.jpg?1",
             "name": "Pyre Spawn",
             "text": "When Pyre Spawn dies, it deals 3 damage to any target.",
             "colours": [
@@ -7502,7 +7502,7 @@
         },
         {
             "id": "c87b343b-9f7a-517b-804a-8da7ebb82fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6943c07f-ab0d-4f5a-bbe9-c0a83dc98546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6943c07f-ab0d-4f5a-bbe9-c0a83dc98546.jpg?1",
             "name": "Reckless Impulse",
             "text": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "38de3cd7-6efc-5fdb-8f13-b08d9652023c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51332c31-41df-4379-aa63-6a734a4df618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51332c31-41df-4379-aa63-6a734a4df618.jpg?1",
             "name": "Rending Flame",
             "text": "Rending Flame deals 5 damage to target creature or planeswalker. If that permanent is a Spirit, Rending Flame also deals 2 damage to that permanent's controller.",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "50246049-844e-588e-9502-f71d5c9bc04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9615f0-376f-4ac0-b269-5f497f2b5223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9615f0-376f-4ac0-b269-5f497f2b5223.jpg?1",
             "name": "Runebound Wolf",
             "text": "{3}{R}, {T}: Runebound Wolf deals damage equal to the number of Wolves and Werewolves you control to target opponent.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "3e534d1d-666c-506b-afc9-2858b79cc650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fafd4-443f-4e16-972e-86c16f22670a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fafd4-443f-4e16-972e-86c16f22670a.jpg?1",
             "name": "Sanguine Statuette",
             "text": "When Sanguine Statuette enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Blood token, you may have Sanguine Statuette become a 3/3 Vampire artifact creature with haste until end of turn.",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "b54d0d16-fede-562d-9283-f01161b25e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df71a8c1-25af-4e6a-9197-11b96b959b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df71a8c1-25af-4e6a-9197-11b96b959b46.jpg?1",
             "name": "Stensia Uprising",
             "text": "At the beginning of your end step, create a 1/1 red Human creature token. Then if you control exactly thirteen permanents, you may sacrifice Stensia Uprising. When you do, it deals 7 damage to any target.",
             "colours": [
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "506b9bd7-dc44-51ff-aba7-494fa02406c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d872736-fafb-44e8-a809-48c5436c665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d872736-fafb-44e8-a809-48c5436c665a.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "d2a50c74-2e25-5dd4-a046-ac3cf959d6ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d2d886-13a2-44f1-966a-ec674622fd01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d2d886-13a2-44f1-966a-ec674622fd01.jpg?1",
             "name": "Vampires' Vengeance",
             "text": "Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "68e6cc61-908e-5116-b3d9-5ba20af355d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Volatile Arsonist attacks, it deals 1 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "d9c387d6-ee18-50dc-8a6e-791c87687e04",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Dire-Strain Anarchist attacks, it deals 2 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "a17db2a7-04dd-5592-9284-aa035c4babb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae154e64-f626-45fb-bd52-840c1c27b2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae154e64-f626-45fb-bd52-840c1c27b2d3.jpg?1",
             "name": "Voldaren Epicure",
             "text": "When Voldaren Epicure enters the battlefield, it deals 1 damage to each opponent. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "5581eb36-c490-5f1b-a5ee-821ccd292ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg?1",
             "name": "Voltaic Visionary // Volt-Charged Berserker",
             "text": "{T}: Voltaic Visionary deals 2 damage to you. Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\nWhen you play a card exiled with Voltaic Visionary, transform Voltaic Visionary.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "61d7ebca-daf3-5718-8512-c6322154545e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg?1",
             "name": "Voltaic Visionary // Volt-Charged Berserker",
             "text": "Volt-Charged Berserker can't block.",
             "colours": [
@@ -7911,7 +7911,7 @@
         },
         {
             "id": "2383c721-d8f7-5918-b741-2ed2d490b82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg?1",
             "name": "Weary Prisoner // Wrathful Jailbreaker",
             "text": "Defender\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "3a59a116-8a25-524c-bf2a-b617609c069a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg?1",
             "name": "Weary Prisoner // Wrathful Jailbreaker",
             "text": "Wrathful Jailbreaker attacks each combat if able.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7980,7 +7980,7 @@
         },
         {
             "id": "77ea7682-28fc-5d69-bcdf-c55991c4d831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03f0790-cdc9-4bb4-ae54-2c248435b0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03f0790-cdc9-4bb4-ae54-2c248435b0a4.jpg?1",
             "name": "Apprentice Sharpshooter",
             "text": "Reach\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "f52ca772-48a8-543d-8def-bd285edef3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c5b67-5de9-41da-b57f-7ce771457a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c5b67-5de9-41da-b57f-7ce771457a3e.jpg?1",
             "name": "Ascendant Packleader",
             "text": "Ascendant Packleader enters the battlefield with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.\nWhenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on Ascendant Packleader.",
             "colours": [
@@ -8051,7 +8051,7 @@
         },
         {
             "id": "0c258f5e-d050-526a-b5f7-e768ba0b0493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nAt the beginning of combat on your turn, put two +1/+1 counters on another target creature you control.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "53987de7-c8c2-5f85-9df3-918be109e63a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nOther permanents you control have hexproof.\nAt the beginning of combat on your turn, put two +1/+1 counters on each creature you control.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8124,7 +8124,7 @@
         },
         {
             "id": "650a0d57-8cdb-5361-b0b0-607ed2e454ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3017ae1-9744-493b-a1a2-fb2a60f7e7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3017ae1-9744-493b-a1a2-fb2a60f7e7e4.jpg?1",
             "name": "Bramble Armor",
             "text": "When Bramble Armor enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "5635a80b-ad76-59fa-b87e-f73c37fc5b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f16f137-4ceb-469c-a381-e575d58f456b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f16f137-4ceb-469c-a381-e575d58f456b.jpg?1",
             "name": "Bramble Wurm",
             "text": "Reach, trample\nWhen Bramble Wurm enters the battlefield, you gain 5 life.\n{2}{G}, Exile Bramble Wurm from your graveyard: You gain 5 life.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "788b53d3-eb73-504c-910a-8e420ea9d71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a41cfc-f329-4e69-a785-835f69c7d2ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a41cfc-f329-4e69-a785-835f69c7d2ba.jpg?1",
             "name": "Cartographer's Survey",
             "text": "Look at the top seven cards of your library. Put up to two land cards from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8224,7 +8224,7 @@
         },
         {
             "id": "21b4acda-d7c7-5d55-84eb-165d5848efed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b124ccc4-76e3-41a4-92b2-8f1d06ea9cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b124ccc4-76e3-41a4-92b2-8f1d06ea9cb8.jpg?1",
             "name": "Cemetery Prowler",
             "text": "Vigilance\nWhenever Cemetery Prowler enters the battlefield or attacks, exile a card from a graveyard.\nSpells you cast cost {1} less to cast for each card type they share with cards exiled with Cemetery Prowler.",
             "colours": [
@@ -8260,7 +8260,7 @@
         },
         {
             "id": "7e95c7b9-72d1-5a48-8115-8549a22f4ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d86c79-d2c7-4900-9474-4d4bc4c74d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d86c79-d2c7-4900-9474-4d4bc4c74d44.jpg?1",
             "name": "Cloaked Cadet",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever one or more +1/+1 counters are put on one or more Humans you control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "27d6a371-221d-5fcd-9b76-4d8f2da44ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab55dae-5393-4356-9f81-66d6ea5d23c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab55dae-5393-4356-9f81-66d6ea5d23c0.jpg?1",
             "name": "Crawling Infestation",
             "text": "At the beginning of your upkeep, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nWhenever one or more creature cards are put into your graveyard from anywhere during your turn, create a 1/1 green Insect creature token. This ability triggers only once each turn.",
             "colours": [
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "099c7f47-2bec-548c-ac12-fbba2dfb7329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae67d98-5167-442b-8586-0b2bcb0c56eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae67d98-5167-442b-8586-0b2bcb0c56eb.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "84c1cd81-238d-548c-a2ca-29bf1225be3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dffe04-c431-440d-a8da-33c74b4bb683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dffe04-c431-440d-a8da-33c74b4bb683.jpg?1",
             "name": "Cultivator Colossus",
             "text": "Trample\nCultivator Colossus's power and toughness are each equal to the number of lands you control.\nWhen Cultivator Colossus enters the battlefield, you may put a land card from your hand onto the battlefield tapped. If you do, draw a card and repeat this process.",
             "colours": [
@@ -8396,7 +8396,7 @@
         },
         {
             "id": "9f0ff1f1-5678-5d3d-bd0f-fb3296e216ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb669c-155e-4002-ba55-7e901760c0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb669c-155e-4002-ba55-7e901760c0e8.jpg?1",
             "name": "Dawnhart Disciple",
             "text": "Whenever another Human enters the battlefield under your control, Dawnhart Disciple gets +1/+1 until end of turn.",
             "colours": [
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "34a499a5-8f9b-51b7-9d32-d70b031e5141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14c947-2452-4fd6-8f1a-391cf5898100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14c947-2452-4fd6-8f1a-391cf5898100.jpg?1",
             "name": "Dig Up",
             "text": "Cleave {1}{B}{B}{G} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nSearch your library for a basic land card, [reveal it,] put it into your hand, then shuffle.",
             "colours": [
@@ -8466,7 +8466,7 @@
         },
         {
             "id": "a77d8d1f-5a4e-5d42-a3d2-0d7e94fd29a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1",
             "name": "Dormant Grove // Gnarled Grovestrider",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if that creature has toughness 6 or greater, transform Dormant Grove.",
             "colours": [
@@ -8498,7 +8498,7 @@
         },
         {
             "id": "3acea3f9-570b-58ec-8571-1eefc1179948",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1",
             "name": "Dormant Grove // Gnarled Grovestrider",
             "text": "Vigilance\nOther creatures you control have vigilance.",
             "colours": [
@@ -8532,7 +8532,7 @@
         },
         {
             "id": "1d6d0b88-686d-545e-82b9-9ec279d3b1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc54df-773d-4f46-b241-e1f42af8ab95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc54df-773d-4f46-b241-e1f42af8ab95.jpg?1",
             "name": "Flourishing Hunter",
             "text": "When Flourishing Hunter enters the battlefield, you gain life equal to the greatest toughness among other creatures you control.",
             "colours": [
@@ -8567,7 +8567,7 @@
         },
         {
             "id": "13fb1f5c-8c22-5fc5-b37b-f20cfd29b3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2caf73e-c3eb-4fa8-996a-d3d18b2ffaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2caf73e-c3eb-4fa8-996a-d3d18b2ffaeb.jpg?1",
             "name": "Glorious Sunrise",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Target land gains \"{T}: Add {G}{G}{G}\" until end of turn.\n\u2022 Draw a card if you control a creature with power 3 or greater.\n\u2022 You gain 3 life.",
             "colours": [
@@ -8601,7 +8601,7 @@
         },
         {
             "id": "8194b518-6805-5741-9799-8206da90eeb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31e108b-8cb5-4f30-b68b-274aa7ac2a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31e108b-8cb5-4f30-b68b-274aa7ac2a81.jpg?1",
             "name": "Hamlet Vanguard",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nHamlet Vanguard enters the battlefield with two +1/+1 counters on it for each other nontoken Human you control.",
             "colours": [
@@ -8638,7 +8638,7 @@
         },
         {
             "id": "7c407209-94fe-583c-8766-148918aeddee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg?1",
             "name": "Hiveheart Shaman",
             "text": "Whenever Hiveheart Shaman attacks, you may search your library for a basic land card that doesn't share a land type with a land you control, put that card onto the battlefield, then shuffle.\n{5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is the number of basic land types among lands you control. Activate only as a sorcery.",
             "colours": [
@@ -8675,7 +8675,7 @@
         },
         {
             "id": "ca51a502-3104-5113-b0d5-89cb32a9a47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg?1",
             "name": "Hookhand Mariner // Riphook Raider",
             "text": "Daybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "caf12634-b122-5591-be5f-d7053ac0d177",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg?1",
             "name": "Hookhand Mariner // Riphook Raider",
             "text": "Riphook Raider can't be blocked by creatures with power 2 or less.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8744,7 +8744,7 @@
         },
         {
             "id": "b4f26a07-bffa-5964-be4d-ec6dee6e94ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50b6a5-2e58-4de3-b0e1-0b33536f69a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50b6a5-2e58-4de3-b0e1-0b33536f69a6.jpg?1",
             "name": "Howling Moon",
             "text": "At the beginning of combat on your turn, target Wolf or Werewolf you control gets +2/+2 until end of turn.\nWhenever an opponent casts their second spell each turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "5bbed948-58ea-5b2d-a0cb-d26e8dbdaa53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "This spell can't be countered.\n{1}{G}, {T}: You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap Howlpack Piper. Activate only as a sorcery.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "c832bca2-a4a8-5313-b477-f772f84116cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "Whenever this creature enters the battlefield or transforms into Wildsong Howler, look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "dd994999-af50-5a3a-a264-791611b5e2a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg?1",
             "name": "Infestation Expert // Infested Werewolf",
             "text": "Whenever Infestation Expert enters the battlefield or attacks, create a 1/1 green Insect creature token.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "90140ae8-3a0b-5eb9-baae-877f5b0b0ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg?1",
             "name": "Infestation Expert // Infested Werewolf",
             "text": "Whenever Infested Werewolf enters the battlefield or attacks, create two 1/1 green Insect creature tokens.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "1550f0fb-898e-5b37-a712-4893bff5dc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141f7948-3140-40f2-95dd-ab6c79f2a821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141f7948-3140-40f2-95dd-ab6c79f2a821.jpg?1",
             "name": "Laid to Rest",
             "text": "Whenever a Human you control dies, draw a card.\nWhenever a creature you control with a +1/+1 counter on it dies, you gain 2 life.",
             "colours": [
@@ -8952,7 +8952,7 @@
         },
         {
             "id": "b26c3968-8ef2-5d67-bbe2-e10b05932811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd50b-4825-4d85-b0f9-e2a51d2a7df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd50b-4825-4d85-b0f9-e2a51d2a7df1.jpg?1",
             "name": "Massive Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "19baed50-2ba4-5e20-8739-132cfaa80b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ea27-63d1-4b80-beae-8e016373d004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ea27-63d1-4b80-beae-8e016373d004.jpg?1",
             "name": "Moldgraf Millipede",
             "text": "When Moldgraf Millipede enters the battlefield, mill three cards, then put a +1/+1 counter on Moldgraf Millipede for each creature card in your graveyard. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -9019,7 +9019,7 @@
         },
         {
             "id": "818b734b-3945-5eec-abdc-8dcc451ec7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950dd57e-b2e1-4a27-a212-86fbfdbf914d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950dd57e-b2e1-4a27-a212-86fbfdbf914d.jpg?1",
             "name": "Mulch",
             "text": "Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "e85f838b-73dd-5cb4-a30b-4bb141d19c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d757af-86fd-4f99-a09a-0f3898ed95f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d757af-86fd-4f99-a09a-0f3898ed95f6.jpg?1",
             "name": "Nature's Embrace",
             "text": "Enchant creature or land\nAs long as enchanted permanent is a creature, it gets +2/+2.\nAs long as enchanted permanent is a land, it has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "1f7357fb-a6c9-5843-82f4-49fff92a6039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg?1",
             "name": "Oakshade Stalker // Moonlit Ambusher",
             "text": "You may cast this spell as though it had flash if you pay {2} more to cast it.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "3d152b12-ef5e-5d56-932c-131ee28444f2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg?1",
             "name": "Oakshade Stalker // Moonlit Ambusher",
             "text": "Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9155,7 +9155,7 @@
         },
         {
             "id": "3162ecd0-58d0-58f1-8323-66ad231724cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43d9686-a5e4-413b-8a34-3430788dd1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43d9686-a5e4-413b-8a34-3430788dd1b9.jpg?1",
             "name": "Packsong Pup",
             "text": "At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1 counter on Packsong Pup.\nWhen Packsong Pup dies, you gain life equal to its power.",
             "colours": [
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "dfe75531-ab21-5b00-9723-b52ff7cbfc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10edf37a-ee35-491d-b83a-39035f7df65a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10edf37a-ee35-491d-b83a-39035f7df65a.jpg?1",
             "name": "Reclusive Taxidermist",
             "text": "Reclusive Taxidermist gets +3/+2 as long as there are four or more creature cards in your graveyard.\n{T}: Add one mana of any color.",
             "colours": [
@@ -9226,7 +9226,7 @@
         },
         {
             "id": "96468dd8-30b0-5bb8-8073-b7284fda0832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e997f78-22a2-4b66-ac10-1adc9a72ce3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e997f78-22a2-4b66-ac10-1adc9a72ce3b.jpg?1",
             "name": "Retrieve",
             "text": "Return up to one target creature card and up to one target noncreature permanent card from your graveyard to your hand. Exile Retrieve.",
             "colours": [
@@ -9258,7 +9258,7 @@
         },
         {
             "id": "970c975f-c86b-5c80-9880-35376302e8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf35971-f1c4-4ccb-af5c-fd396391bb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf35971-f1c4-4ccb-af5c-fd396391bb4b.jpg?1",
             "name": "Rural Recruit",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhen Rural Recruit enters the battlefield, create a 3/1 green Boar creature token.",
             "colours": [
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "33c3c063-4165-55a8-8857-a8082792c470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225773f9-1843-4ee0-8564-8e4a5dfef775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225773f9-1843-4ee0-8564-8e4a5dfef775.jpg?1",
             "name": "Sawblade Slinger",
             "text": "When Sawblade Slinger enters the battlefield, choose up to one \u2014\n\u2022 Destroy target artifact an opponent controls.\n\u2022 Sawblade Slinger fights target Zombie an opponent controls.",
             "colours": [
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "6431653f-0507-5d20-a43a-f7d7925682f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd4c2-0e9f-440c-8e4c-80db351a5eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd4c2-0e9f-440c-8e4c-80db351a5eba.jpg?1",
             "name": "Sheltering Boughs",
             "text": "Enchant creature\nWhen Sheltering Boughs enters the battlefield, draw a card.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "c5b38839-3c61-5c8f-874d-55c809b090be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd271d7-a3c8-4448-b8e2-bcef5d7e9118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd271d7-a3c8-4448-b8e2-bcef5d7e9118.jpg?1",
             "name": "Snarling Wolf",
             "text": "{1}{G}: Snarling Wolf gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -9396,7 +9396,7 @@
         },
         {
             "id": "b83263c3-9a3a-5aa5-b2a9-98cf89f2f915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e95ec-b630-4492-be1d-f66aa19889e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e95ec-b630-4492-be1d-f66aa19889e5.jpg?1",
             "name": "Spiked Ripsaw",
             "text": "Equipped creature gets +3/+3.\nWhenever equipped creature attacks, you may sacrifice a Forest. If you do, that creature gains trample until end of turn.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "51f25f18-3e1a-52d5-b31b-3b690437521d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4ca85-4d2d-4d1e-86ca-aa25edfcda61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4ca85-4d2d-4d1e-86ca-aa25edfcda61.jpg?1",
             "name": "Splendid Reclamation",
             "text": "Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "d5ccb8a8-3a20-53d4-930e-f23ebce0110e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628dbc4c-3640-44a9-8439-873103989409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628dbc4c-3640-44a9-8439-873103989409.jpg?1",
             "name": "Spore Crawler",
             "text": "When Spore Crawler dies, draw a card.",
             "colours": [
@@ -9498,7 +9498,7 @@
         },
         {
             "id": "db74dbfb-37e3-5932-8295-6232d337c52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb04879-9348-4d4f-9a23-c82fd99d04c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb04879-9348-4d4f-9a23-c82fd99d04c6.jpg?1",
             "name": "Sporeback Wolf",
             "text": "As long as it's your turn, Sporeback Wolf gets +0/+2.",
             "colours": [
@@ -9532,7 +9532,7 @@
         },
         {
             "id": "6aaeb0b6-21f3-5c61-99e6-590317b5073f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfca481-cf2d-435d-b4b6-07b1fe2a8e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfca481-cf2d-435d-b4b6-07b1fe2a8e5d.jpg?1",
             "name": "Toxic Scorpion",
             "text": "Deathtouch\nWhen Toxic Scorpion enters the battlefield, another target creature you control gains deathtouch until end of turn.",
             "colours": [
@@ -9566,7 +9566,7 @@
         },
         {
             "id": "44fd016f-d15e-5474-87db-95a1ee90ace8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\n{5}{G}{G}: Transform Ulvenwald Oddity.",
             "colours": [
@@ -9602,7 +9602,7 @@
         },
         {
             "id": "bdd375d9-25d2-521f-b786-02c6c96993b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\nOther creatures you control get +1/+1 and have trample and haste.",
             "colours": [
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "f8d22816-d97c-543f-9f93-fa022abf7468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg?1",
             "name": "Weaver of Blossoms // Blossom-Clad Werewolf",
             "text": "{T}: Add one mana of any color.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "1a176191-f3d7-569d-b2d5-1186ae046499",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg?1",
             "name": "Weaver of Blossoms // Blossom-Clad Werewolf",
             "text": "{T}: Add two mana of any one color.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9708,7 +9708,7 @@
         },
         {
             "id": "c3b69e46-0755-5e42-a01e-4d69a63730d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d021207-76be-4bc9-bb71-df991a04d8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d021207-76be-4bc9-bb71-df991a04d8d8.jpg?1",
             "name": "Witch's Web",
             "text": "Target creature gets +3/+3 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "fc6599bc-b222-5c3c-b36b-b33cdee3c8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9cd00-7ffd-44e1-aa0f-c94489ff4a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9cd00-7ffd-44e1-aa0f-c94489ff4a0f.jpg?1",
             "name": "Wolf Strike",
             "text": "Target creature you control gets +2/+0 until end of turn if it's night. Then it deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -9772,7 +9772,7 @@
         },
         {
             "id": "65fae7fe-fab7-59c9-abf4-fc4036693c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg?1",
             "name": "Wolfkin Outcast // Wedding Crasher",
             "text": "This spell costs {2} less to cast if you control a Wolf or Werewolf.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "5ac82e55-ddc7-5bd1-926f-85378736add2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg?1",
             "name": "Wolfkin Outcast // Wedding Crasher",
             "text": "Whenever Wedding Crasher or another Wolf or Werewolf you control dies, draw a card.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "952af4aa-f3fa-5a89-99d8-82a1f4595fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22264087-bac4-4746-b6ce-0d44cce163e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22264087-bac4-4746-b6ce-0d44cce163e6.jpg?1",
             "name": "Ancient Lumberknot",
             "text": "Each creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -9877,7 +9877,7 @@
         },
         {
             "id": "55b3a42b-f56f-5c50-98b6-89a197280528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfac4ab-97f1-448c-8554-42ed03eb5656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfac4ab-97f1-448c-8554-42ed03eb5656.jpg?1",
             "name": "Anje, Maid of Dishonor",
             "text": "Whenever Anje, Maid of Dishonor and/or one or more other Vampires enter the battlefield under your control, create a Blood token. This ability triggers only once each turn. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{2}, Sacrifice another creature or a Blood token: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -9917,7 +9917,7 @@
         },
         {
             "id": "c22f1a85-9583-539b-8520-17acc9de1b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0192cf7-3391-4720-b9c8-72dec5dde01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0192cf7-3391-4720-b9c8-72dec5dde01e.jpg?1",
             "name": "Bloodtithe Harvester",
             "text": "When Bloodtithe Harvester enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{T}, Sacrifice Bloodtithe Harvester: Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.",
             "colours": [
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "37087751-cd5c-5ee0-8a7f-1d4d34af8422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1",
             "name": "Brine Comber // Brinebound Gift",
             "text": "Whenever Brine Comber enters the battlefield or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nDisturb {W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -9991,7 +9991,7 @@
         },
         {
             "id": "0cdcfe6c-6cac-50c1-8db5-15d452115b42",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1",
             "name": "Brine Comber // Brinebound Gift",
             "text": "Enchant creature\nWhenever Brinebound Gift enters the battlefield or enchanted creature becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nIf Brinebound Gift would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -10027,7 +10027,7 @@
         },
         {
             "id": "2f2c79aa-6787-5a10-9678-48adf998db6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg?1",
             "name": "A-Brine Comber // A-Brinebound Gift",
             "text": "",
             "colours": [
@@ -10062,7 +10062,7 @@
         },
         {
             "id": "1f96a408-f0e2-5bcd-9839-ae98a82dac33",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg?1",
             "name": "A-Brine Comber // A-Brinebound Gift",
             "text": "",
             "colours": [
@@ -10097,7 +10097,7 @@
         },
         {
             "id": "6e98a6dc-d955-5f25-a440-9cc3ac675142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg?1",
             "name": "Child of the Pack // Savage Packmate",
             "text": "{2}{R}{G}: Create a 2/2 green Wolf creature token.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -10134,7 +10134,7 @@
         },
         {
             "id": "bcabc25f-9f4c-5128-8277-e0b17167f435",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg?1",
             "name": "Child of the Pack // Savage Packmate",
             "text": "Trample\nOther creatures you control get +1/+0.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -10170,7 +10170,7 @@
         },
         {
             "id": "e3427911-19b6-5cc5-ad0c-2b229ef5395c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Flying\nWhen Dorothea, Vengeful Victim attacks or blocks, sacrifice it at end of combat.\nDisturb {1}{W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -10210,7 +10210,7 @@
         },
         {
             "id": "1bdb25c4-34ef-5145-be01-40e5ec13b2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat.\"\nIf Dorothea's Retribution would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -10248,7 +10248,7 @@
         },
         {
             "id": "ea57a618-f931-5d14-83a7-c77a6ae9a153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg?1",
             "name": "A-Dorothea, Vengeful Victim // A-Dorothea's Retribution",
             "text": "",
             "colours": [
@@ -10285,7 +10285,7 @@
         },
         {
             "id": "d254f73c-f13b-53e1-8a38-2df98913cc07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg?1",
             "name": "A-Dorothea, Vengeful Victim // A-Dorothea's Retribution",
             "text": "",
             "colours": [
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "c63aa2d2-7882-57da-8498-63ea294c91e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "Other Vampires you control get +1/+1.\nWhen Edgar, Charmed Groom dies, return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -10362,7 +10362,7 @@
         },
         {
             "id": "b37ee2b4-ab96-5aa9-b474-135e9a26da46",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "At the beginning of your upkeep, create a 1/1 white and black Vampire creature token with lifelink and put a bloodline counter on Edgar Markov's Coffin. Then if there are three or more bloodline counters on it, remove those counters and transform it.",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "5ccc35ed-ca34-5ef2-8c2c-ccbb167701a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764077-df2d-4ac7-b507-2c8e08386d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764077-df2d-4ac7-b507-2c8e08386d49.jpg?1",
             "name": "Eruth, Tormented Prophet",
             "text": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
             "colours": [
@@ -10443,7 +10443,7 @@
         },
         {
             "id": "67386448-09e2-5714-8fde-2c7587b7e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaba76b-9cec-4c2b-b0eb-8f44201f6422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaba76b-9cec-4c2b-b0eb-8f44201f6422.jpg?1",
             "name": "Grolnok, the Omnivore",
             "text": "Whenever a Frog you control attacks, mill three cards.\nWhenever a permanent card is put into your graveyard from your library, exile it with a croak counter on it.\nYou may play lands and cast spells from among cards you own in exile with croak counters on them.",
             "colours": [
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "452ec549-794e-5100-923d-0e0f8287078b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608fa232-f5fe-4c58-9efe-fb780f454b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608fa232-f5fe-4c58-9efe-fb780f454b19.jpg?1",
             "name": "Halana and Alena, Partners",
             "text": "First strike, reach\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is Halana and Alena's power. That creature gains haste until end of turn.",
             "colours": [
@@ -10524,7 +10524,7 @@
         },
         {
             "id": "704756a0-a6b7-51d9-8de7-18acad07f3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a208c-ee2b-4672-a43b-f4a708585b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a208c-ee2b-4672-a43b-f4a708585b1a.jpg?1",
             "name": "Kaya, Geist Hunter",
             "text": "+1: Creatures you control gain deathtouch until end of turn. Put a +1/+1 counter on up to one target creature token you control.\n\u22122: Until end of turn, if one or more tokens would be created under your control, twice that many of those tokens are created instead.\n\u22126: Exile all cards from all graveyards, then create a 1/1 white Spirit creature token with flying for each card exiled this way.",
             "colours": [
@@ -10564,7 +10564,7 @@
         },
         {
             "id": "106117c2-52ae-5627-8a85-a033b8cea8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95d34a-0b13-4533-9efc-08381c81e6cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95d34a-0b13-4533-9efc-08381c81e6cd.jpg?1",
             "name": "Markov Purifier",
             "text": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay {2}. If you do, draw a card.",
             "colours": [
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "a350d5a1-8e20-5833-b033-bbfc2ad12694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f45bc0-36ed-44ec-9bc8-31ea7c7fafdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f45bc0-36ed-44ec-9bc8-31ea7c7fafdb.jpg?1",
             "name": "Markov Waltzer",
             "text": "Flying, haste\nAt the beginning of combat on your turn, up to two target creatures you control each get +1/+0 until end of turn.",
             "colours": [
@@ -10641,7 +10641,7 @@
         },
         {
             "id": "2e8bf7bd-75a9-509e-b03d-5b11404071ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a79f5f-a65a-4b43-b58c-cdfa09cc7855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a79f5f-a65a-4b43-b58c-cdfa09cc7855.jpg?1",
             "name": "Odric, Blood-Cursed",
             "text": "When Odric, Blood-Cursed enters the battlefield, create X Blood tokens, where X is the number of abilities from among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance found among creatures you control. (Count each ability only once.)",
             "colours": [
@@ -10682,7 +10682,7 @@
         },
         {
             "id": "352ecef4-837f-519e-8ca6-5b1c95c6e307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b8023-2ef1-4b7b-9e48-4f774fee14e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b8023-2ef1-4b7b-9e48-4f774fee14e0.jpg?1",
             "name": "Old Rutstein",
             "text": "When Old Rutstein enters the battlefield or at the beginning of your upkeep, mill a card. If a land card is milled this way, create a Treasure token. If a creature card is milled this way, create a 1/1 green Insect creature token. If a noncreature, nonland card is milled this way, create a Blood token.",
             "colours": [
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "91153fb8-a021-5b44-b41b-4362b9af9290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301dacc9-ef92-4515-b907-a70d6c3fd73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301dacc9-ef92-4515-b907-a70d6c3fd73e.jpg?1",
             "name": "Olivia, Crimson Bride",
             "text": "Flying, haste\nWhenever Olivia, Crimson Bride attacks, return target creature card from your graveyard to the battlefield tapped and attacking. It gains \"When you don't control a legendary Vampire, exile this creature.\"",
             "colours": [
@@ -10765,7 +10765,7 @@
         },
         {
             "id": "fdd66690-4700-564b-a569-4189ee585d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhen Runo Stromkirk enters the battlefield, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo Stromkirk.",
             "colours": [
@@ -10807,7 +10807,7 @@
         },
         {
             "id": "b4fb1a2d-73aa-5aa0-8afa-ef8743eb705c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhenever Krothuss, Lord of the Deep attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "4d54f1c9-d5f7-58f0-a4e4-181603d98cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34228fdd-e466-488e-84b2-4c595e758688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34228fdd-e466-488e-84b2-4c595e758688.jpg?1",
             "name": "Sigardian Paladin",
             "text": "As long as you've put one or more +1/+1 counters on a creature this turn, Sigardian Paladin has trample and lifelink.\n{1}{G}{W}: Target creature you control with a +1/+1 counter on it gains trample and lifelink until end of turn.",
             "colours": [
@@ -10886,7 +10886,7 @@
         },
         {
             "id": "cbb79b64-9b16-52bf-bf1d-e518166558cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220003ce-cf2e-4595-91f4-c3462407d293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220003ce-cf2e-4595-91f4-c3462407d293.jpg?1",
             "name": "A-Sigardian Paladin",
             "text": "",
             "colours": [
@@ -10922,7 +10922,7 @@
         },
         {
             "id": "dede4788-d6aa-5f8d-8818-37487674f903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268fd7e7-0105-4c39-a3ea-77ed32214ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268fd7e7-0105-4c39-a3ea-77ed32214ff3.jpg?1",
             "name": "Skull Skaab",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -10958,7 +10958,7 @@
         },
         {
             "id": "1bb0a9ca-0533-553d-9ba7-c7ab51b07b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302dfa1-7302-4b3c-a894-b780b5474d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302dfa1-7302-4b3c-a894-b780b5474d8f.jpg?1",
             "name": "A-Skull Skaab",
             "text": "",
             "colours": [
@@ -10993,7 +10993,7 @@
         },
         {
             "id": "9440068d-09f4-5593-8fec-f3565a0167b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd111dc9-b8de-4e92-a63d-75a961b2db3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd111dc9-b8de-4e92-a63d-75a961b2db3b.jpg?1",
             "name": "Torens, Fist of the Angels",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
             "colours": [
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "e64b8341-3315-5eab-b20d-b1b3d2e14144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad9ae64-6526-4747-9b0c-77d113f58c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad9ae64-6526-4747-9b0c-77d113f58c33.jpg?1",
             "name": "Vilespawn Spider",
             "text": "Reach\nAt the beginning of your upkeep, mill a card. (Put the top card of your library into your graveyard.)\n{2}{G}{U}, {T}, Sacrifice Vilespawn Spider: Create a 1/1 green Insect creature token for each creature card in your graveyard. Activate only as a sorcery.",
             "colours": [
@@ -11071,7 +11071,7 @@
         },
         {
             "id": "d0a45a32-ac9a-5051-a12d-cc37588d3f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a1096-6313-4245-be18-1588c219b842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a1096-6313-4245-be18-1588c219b842.jpg?1",
             "name": "Wandering Mind",
             "text": "Flying\nWhen Wandering Mind enters the battlefield, look at the top six cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11107,7 +11107,7 @@
         },
         {
             "id": "d416771c-1334-575c-b20f-92eb070155b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87845cc2-bf5d-491d-bfa2-b33b034557a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87845cc2-bf5d-491d-bfa2-b33b034557a4.jpg?1",
             "name": "Blood Servitor",
             "text": "When Blood Servitor enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -11138,7 +11138,7 @@
         },
         {
             "id": "8d5dcadd-d8ac-5cb8-91ae-1196dbd9b799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02cf94c-94d3-4c4c-a7ae-b4d48ef5b14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02cf94c-94d3-4c4c-a7ae-b4d48ef5b14e.jpg?1",
             "name": "Boarded Window",
             "text": "Creatures attacking you get -1/-0.\nAt the beginning of each end step, if you were dealt 4 or more damage this turn, exile Boarded Window.",
             "colours": [],
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "90ac6fd9-1d9f-50e5-a5f6-5a175a9c8c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccb4b1e-ef8f-4c5f-8b5b-6148455442f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccb4b1e-ef8f-4c5f-8b5b-6148455442f7.jpg?1",
             "name": "Ceremonial Knife",
             "text": "Equipped creature gets +1/+0 and has \"Whenever this creature deals combat damage, create a Blood token.\" (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11196,7 +11196,7 @@
         },
         {
             "id": "66b52eff-8cf5-5054-a4f0-c828fcca3cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396abc9e-a738-430d-85cc-448ace2548f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396abc9e-a738-430d-85cc-448ace2548f9.jpg?1",
             "name": "Dollhouse of Horrors",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a token that's a copy of the exiled card, except it's a 0/0 Construct artifact in addition to its other types and it has \"This creature gets +1/+1 for each Construct you control.\" It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -11226,7 +11226,7 @@
         },
         {
             "id": "22d2d2b0-3299-5d32-94f5-f88717e0c2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1",
             "name": "Foreboding Statue // Forsaken Thresher",
             "text": "{T}: Add one mana of any color. Put an omen counter on Foreboding Statue.\nAt the beginning of your end step, if there are three or more omen counters on Foreboding Statue, untap it, then transform it.",
             "colours": [],
@@ -11257,7 +11257,7 @@
         },
         {
             "id": "ff0531ad-76ee-576b-993c-a460bf5cb307",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1",
             "name": "Foreboding Statue // Forsaken Thresher",
             "text": "At the beginning of your precombat main phase, add one mana of any color.",
             "colours": [],
@@ -11288,7 +11288,7 @@
         },
         {
             "id": "e2d366ce-a5af-5485-949a-88a0d37e9d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3390e4d-9137-40ff-b998-bdb19c90b7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3390e4d-9137-40ff-b998-bdb19c90b7d5.jpg?1",
             "name": "Honored Heirloom",
             "text": "{T}: Add one mana of any color.\n{2}, {T}: Exile target card from a graveyard.",
             "colours": [],
@@ -11316,7 +11316,7 @@
         },
         {
             "id": "10a4e7eb-5884-51b4-ad19-98e30d63e3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a606e5-7a90-4a89-b51a-7f4e68705f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a606e5-7a90-4a89-b51a-7f4e68705f97.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -11349,7 +11349,7 @@
         },
         {
             "id": "5aae641c-323f-5cd1-b2b3-1928bccd2f68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2303f11-2c82-44d5-893a-8e71dece7746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2303f11-2c82-44d5-893a-8e71dece7746.jpg?1",
             "name": "Lantern of the Lost",
             "text": "When Lantern of the Lost enters the battlefield, exile target card from a graveyard.\n{1}, {T}, Exile Lantern of the Lost: Exile all cards from all graveyards, then draw a card.",
             "colours": [],
@@ -11377,7 +11377,7 @@
         },
         {
             "id": "1f458628-afd9-5384-94db-5dd8b859ec79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc22ff6-4081-47ce-bc8a-e063f5f4d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc22ff6-4081-47ce-bc8a-e063f5f4d044.jpg?1",
             "name": "Wedding Invitation",
             "text": "When Wedding Invitation enters the battlefield, draw a card.\n{T}, Sacrifice Wedding Invitation: Target creature can't be blocked this turn. If it's a Vampire, it also gains lifelink until end of turn.",
             "colours": [],
@@ -11405,7 +11405,7 @@
         },
         {
             "id": "133121cd-0e80-54b9-b6a8-bc36b7bb8120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5523659-98a8-4ae2-9ec7-d77e7352c374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5523659-98a8-4ae2-9ec7-d77e7352c374.jpg?1",
             "name": "Deathcap Glade",
             "text": "Deathcap Glade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "936c3617-8070-5cc1-8bb0-2306a3203272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb604455-c411-414d-a2ef-e7567ee86a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb604455-c411-414d-a2ef-e7567ee86a4d.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "Dreamroot Cascade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -11471,7 +11471,7 @@
         },
         {
             "id": "57984d21-ccfe-58a9-a4be-d0f147cbf031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80fe230-745d-42ae-a1f5-a8cc950783d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80fe230-745d-42ae-a1f5-a8cc950783d0.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11499,7 +11499,7 @@
         },
         {
             "id": "818f2a99-e932-5b0f-a1e2-71b5824714e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad44c9aa-eb8f-4200-8dfe-2af728d80083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad44c9aa-eb8f-4200-8dfe-2af728d80083.jpg?1",
             "name": "Shattered Sanctum",
             "text": "Shattered Sanctum enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "b196578a-9cde-527b-9644-6669ba33666a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1dee-b3d7-472b-aa0b-2f9b46a96da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1dee-b3d7-472b-aa0b-2f9b46a96da5.jpg?1",
             "name": "Stormcarved Coast",
             "text": "Stormcarved Coast enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -11565,7 +11565,7 @@
         },
         {
             "id": "b8e239ec-1de4-5dd5-a9dd-25205ff8ddf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3fddd7-ede4-41c7-a645-a6af298a3d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3fddd7-ede4-41c7-a645-a6af298a3d35.jpg?1",
             "name": "Sundown Pass",
             "text": "Sundown Pass enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "23df94c4-ae72-5f0f-bc7a-a450bb55b08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2577e5fd-903a-44ce-989a-d53d56511ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2577e5fd-903a-44ce-989a-d53d56511ad3.jpg?1",
             "name": "Voldaren Estate",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -11629,7 +11629,7 @@
         },
         {
             "id": "e16e3fb9-90d1-5c27-928d-86327b9ade5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabdaa1-6227-48e4-82d5-63a1771320b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabdaa1-6227-48e4-82d5-63a1771320b2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11667,7 +11667,7 @@
         },
         {
             "id": "fb839df4-8322-5cc3-88f4-4af553ffeaf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b069f97-735a-4d85-8504-b5a863bd659b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b069f97-735a-4d85-8504-b5a863bd659b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11705,7 +11705,7 @@
         },
         {
             "id": "2c5b1ab7-eed5-5d00-86ae-6d337c8cf1e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ddd3aa-593c-4adb-b591-33c15d02131c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ddd3aa-593c-4adb-b591-33c15d02131c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11743,7 +11743,7 @@
         },
         {
             "id": "93c0f594-ddb5-5074-aa9f-d503f371e222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54591ec7-94a1-470c-927a-788b6a514444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54591ec7-94a1-470c-927a-788b6a514444.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11781,7 +11781,7 @@
         },
         {
             "id": "f8b44690-c734-50e6-913e-70f259c1692f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abfe418-15f8-46ce-9b39-fd5a38b25d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abfe418-15f8-46ce-9b39-fd5a38b25d12.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11819,7 +11819,7 @@
         },
         {
             "id": "348e609b-c281-5904-bcab-0382db8d738e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55a405-bf5b-4158-ba9a-239627ac9701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55a405-bf5b-4158-ba9a-239627ac9701.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11857,7 +11857,7 @@
         },
         {
             "id": "c689a37a-09b2-51dd-9e83-0753057a85e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4448b6-0dbe-427c-b145-8ac915fc0dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4448b6-0dbe-427c-b145-8ac915fc0dfc.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11895,7 +11895,7 @@
         },
         {
             "id": "fc857222-27c3-5a92-ad80-0fb9bc11c5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f72e53-52bb-4cf4-9b8b-34ed0c5f7c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f72e53-52bb-4cf4-9b8b-34ed0c5f7c3c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11933,7 +11933,7 @@
         },
         {
             "id": "b60bb2b8-c393-5ef7-be3b-bd9b671fdaa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c83b60-3d49-4fdc-a6b7-06d1a0c4a126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c83b60-3d49-4fdc-a6b7-06d1a0c4a126.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11971,7 +11971,7 @@
         },
         {
             "id": "fb9495c4-3db2-5642-9098-79bb4dcdeffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8760175-e9bb-4ef9-87ca-591d1edd5163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8760175-e9bb-4ef9-87ca-591d1edd5163.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12009,7 +12009,7 @@
         },
         {
             "id": "1ad90d63-7713-50bf-b415-441c3be54aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112394a6-7819-43b4-adad-f6900aff2936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112394a6-7819-43b4-adad-f6900aff2936.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "484d9c02-f7e0-5bd0-930d-1bca26f74b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7129a358-4628-4426-ae3b-e3d9288a6355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7129a358-4628-4426-ae3b-e3d9288a6355.jpg?1",
             "name": "Chandra, Dressed to Kill",
             "text": "+1: Add {R}. Chandra, Dressed to Kill deals 1 damage to up to one target player or planeswalker.\n+1: Exile the top card of your library. If it's red, you may cast it this turn.\n\u22127: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"",
             "colours": [
@@ -12087,7 +12087,7 @@
         },
         {
             "id": "9faaf785-17cb-550c-a26e-cae9b2196137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86c212a-180d-4fd5-94d0-c0c946683f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86c212a-180d-4fd5-94d0-c0c946683f00.jpg?1",
             "name": "Kaya, Geist Hunter",
             "text": "+1: Creatures you control gain deathtouch until end of turn. Put a +1/+1 counter on up to one target creature token you control.\n\u22122: Until end of turn, if one or more tokens would be created under your control, twice that many of those tokens are created instead.\n\u22126: Exile all cards from all graveyards, then create a 1/1 white Spirit creature token with flying for each card exiled this way.",
             "colours": [
@@ -12127,7 +12127,7 @@
         },
         {
             "id": "21d1e73a-6ec8-5035-a18f-036bd5a8f583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619474c0-2978-4152-9943-292707d99fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619474c0-2978-4152-9943-292707d99fb3.jpg?1",
             "name": "Deathcap Glade",
             "text": "Deathcap Glade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -12160,7 +12160,7 @@
         },
         {
             "id": "e1cc31bd-38c8-5895-9474-251d32257b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2997c3b1-0255-41be-9189-03da53838f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2997c3b1-0255-41be-9189-03da53838f63.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "Dreamroot Cascade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -12193,7 +12193,7 @@
         },
         {
             "id": "8f4d203b-1a51-5e75-aaef-aea05a69a7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9885da74-30bd-461d-98ca-0dc72d817dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9885da74-30bd-461d-98ca-0dc72d817dbd.jpg?1",
             "name": "Shattered Sanctum",
             "text": "Shattered Sanctum enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -12226,7 +12226,7 @@
         },
         {
             "id": "bd4f754d-5a13-5fd0-b3bf-4075de170e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e589848-2c25-43e8-a940-7769f7936815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e589848-2c25-43e8-a940-7769f7936815.jpg?1",
             "name": "Stormcarved Coast",
             "text": "Stormcarved Coast enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -12259,7 +12259,7 @@
         },
         {
             "id": "87231134-2a0d-56bc-b298-e8dce04c5dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e7d34-f250-4a61-a95b-75450d134eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e7d34-f250-4a61-a95b-75450d134eec.jpg?1",
             "name": "Sundown Pass",
             "text": "Sundown Pass enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "ff990e4e-49c6-5634-afc2-79f5850205ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722b6cc7-16f2-43cd-bac6-42f5e7962d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722b6cc7-16f2-43cd-bac6-42f5e7962d99.jpg?1",
             "name": "Unholy Officiant",
             "text": "Vigilance\n{4}{W}: Put a +1/+1 counter on Unholy Officiant.",
             "colours": [
@@ -12329,7 +12329,7 @@
         },
         {
             "id": "4f83e3eb-a7d9-5538-bf3a-1f840e374002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd60ee8d-fb50-41df-89a8-aed5a53d755f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd60ee8d-fb50-41df-89a8-aed5a53d755f.jpg?1",
             "name": "Welcoming Vampire",
             "text": "Flying\nWhenever one or more other creatures with power 2 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -12365,7 +12365,7 @@
         },
         {
             "id": "cfdf065a-49b9-5b61-a4ba-ec1cb6868b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df22639-7e98-43a1-801e-cbf882558c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df22639-7e98-43a1-801e-cbf882558c53.jpg?1",
             "name": "Bloodcrazed Socialite",
             "text": "Menace\nWhen Bloodcrazed Socialite enters the battlefield, create a Blood token.\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.",
             "colours": [
@@ -12401,7 +12401,7 @@
         },
         {
             "id": "15cc7f06-9268-5a93-ad85-7c16fd7c5637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "{1}{B}, Discard a card: Bloodsworn Squire gains indestructible until end of turn. Tap it. Then if there are four or more creature cards in your graveyard, transform Bloodsworn Squire.",
             "colours": [
@@ -12438,7 +12438,7 @@
         },
         {
             "id": "3f3cec04-1f92-5cd9-af78-e913c19ff5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "Bloodsworn Knight's power and toughness are each equal to the number of creature cards in your graveyard.\n{1}{B}, Discard a card: Bloodsworn Knight gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -12475,7 +12475,7 @@
         },
         {
             "id": "84736eb4-e66c-5a3a-942a-af8f349abd09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e1e62-9862-4e14-b6fd-071f025cb867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e1e62-9862-4e14-b6fd-071f025cb867.jpg?1",
             "name": "Bloodvial Purveyor",
             "text": "Flying, trample\nWhenever an opponent casts a spell, that player creates a Blood token.\nWhenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.",
             "colours": [
@@ -12511,7 +12511,7 @@
         },
         {
             "id": "ee6f8412-2871-5eef-8ce9-107dee84b1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a99150a-4ab0-4cac-8c25-eece703f8d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a99150a-4ab0-4cac-8c25-eece703f8d58.jpg?1",
             "name": "Falkenrath Forebear",
             "text": "Flying\nFalkenrath Forebear can't block.\nWhenever Falkenrath Forebear deals combat damage to a player, create a Blood token.\n{B}, Sacrifice two Blood tokens: Return Falkenrath Forebear from your graveyard to the battlefield.",
             "colours": [
@@ -12548,7 +12548,7 @@
         },
         {
             "id": "2c077d2b-2a09-5f91-af83-cbee00263872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6abfce-ffe0-4506-89f9-41c2820b188f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6abfce-ffe0-4506-89f9-41c2820b188f.jpg?1",
             "name": "Gluttonous Guest",
             "text": "When Gluttonous Guest enters the battlefield, create a Blood token.\nWhenever you sacrifice a Blood token, you gain 1 life.",
             "colours": [
@@ -12584,7 +12584,7 @@
         },
         {
             "id": "d8b431d0-7574-5fd5-bb26-cdd7aaa6614c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen \u2014\n\u2022 Each player sacrifices a creature.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Transform Henrika Domnathi.",
             "colours": [
@@ -12623,7 +12623,7 @@
         },
         {
             "id": "4300fc34-0c2c-52d4-9852-a66ad482c948",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying, deathtouch, lifelink\n{1}{B}{B}: Each creature you control with flying, deathtouch, and/or lifelink gets +1/+0 until end of turn.",
             "colours": [
@@ -12662,7 +12662,7 @@
         },
         {
             "id": "97651114-3e16-5eea-ad20-5161f20eaedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "At the beginning of your upkeep, any opponent may sacrifice a creature. If no one does, transform Innocent Traveler.",
             "colours": [
@@ -12699,7 +12699,7 @@
         },
         {
             "id": "80dbd4ff-833c-547b-8c0a-21019a750923",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "Flying\nMalicious Invader gets +2/+0 as long as an opponent controls a Human.",
             "colours": [
@@ -12736,7 +12736,7 @@
         },
         {
             "id": "13eefcb1-327a-5e5e-b88e-31357d353edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token.\nSacrifice two Blood tokens: Transform Restless Bloodseeker. Activate only as a sorcery.",
             "colours": [
@@ -12772,7 +12772,7 @@
         },
         {
             "id": "1be26724-e3e4-5d2c-b0e0-49f6f62a5ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token.\n{4}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -12808,7 +12808,7 @@
         },
         {
             "id": "d63b0080-6db0-57e0-9c1f-b10351c01e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c491af90-b224-4795-adb4-d7ea4c8464ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c491af90-b224-4795-adb4-d7ea4c8464ce.jpg?1",
             "name": "Skulking Killer",
             "text": "When Skulking Killer enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn if that opponent controls no other creatures.",
             "colours": [
@@ -12845,7 +12845,7 @@
         },
         {
             "id": "a2afd3c1-bb5d-5365-a0e7-524f56e31258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51089813-8ad5-4ee0-af75-cfba870b675c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51089813-8ad5-4ee0-af75-cfba870b675c.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -12885,7 +12885,7 @@
         },
         {
             "id": "79f546ad-9452-5880-b095-9496480a9561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token.\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.",
             "colours": [
@@ -12923,7 +12923,7 @@
         },
         {
             "id": "b2cd6db0-34b7-561d-9736-7b5d783c9d06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
             "colours": [
@@ -12961,7 +12961,7 @@
         },
         {
             "id": "8f1e1ddd-5e33-53ab-82ea-60af16ca409b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b1a617-96bf-4960-bffe-dddf3a3c1868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b1a617-96bf-4960-bffe-dddf3a3c1868.jpg?1",
             "name": "Wedding Security",
             "text": "Whenever Wedding Security attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter on Wedding Security and draw a card.",
             "colours": [
@@ -12998,7 +12998,7 @@
         },
         {
             "id": "ebe14f13-8b52-5e82-be80-0cd8b88c5ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "When you attack with exactly two creatures, transform Alluring Suitor.",
             "colours": [
@@ -13034,7 +13034,7 @@
         },
         {
             "id": "5a46d2f6-b2a5-5831-8e0f-f08ee41840f5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "Trample\nWhen this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't lose this mana as steps and phases end.\n{R}{R}: Deadly Dancer and another target creature each get +1/+0 until end of turn.",
             "colours": [
@@ -13070,7 +13070,7 @@
         },
         {
             "id": "de39a6bb-db84-517b-9763-d409d1a2148e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924b1c15-811a-4d11-a481-f904002a6740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924b1c15-811a-4d11-a481-f904002a6740.jpg?1",
             "name": "Belligerent Guest",
             "text": "Trample\nWhenever Belligerent Guest deals combat damage to a player, create a Blood token.",
             "colours": [
@@ -13106,7 +13106,7 @@
         },
         {
             "id": "941e05b3-c8f3-5734-80f0-10f20e361660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a5fafe-951f-44c5-8de9-7d2261525c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a5fafe-951f-44c5-8de9-7d2261525c05.jpg?1",
             "name": "Blood Hypnotist",
             "text": "Blood Hypnotist can't block.\nWhenever you sacrifice one or more Blood tokens, target creature can't block this turn. This ability triggers only once each turn.",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "21cd6820-cc15-5df9-8366-61091582d1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592609d-48f5-4762-b95c-b2eaa2ea4d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592609d-48f5-4762-b95c-b2eaa2ea4d51.jpg?1",
             "name": "Blood Petal Celebrant",
             "text": "Blood Petal Celebrant has first strike as long as it's attacking.\nWhen Blood Petal Celebrant dies, create a Blood token.",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "93996e31-8379-5920-a2e4-d87a8e6b7bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63141c56-f0dd-4bb3-808d-6b7031253cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63141c56-f0dd-4bb3-808d-6b7031253cad.jpg?1",
             "name": "Cemetery Gatekeeper",
             "text": "First strike\nWhen Cemetery Gatekeeper enters the battlefield, exile a card from a graveyard.\nWhenever a player plays a land or casts a spell, if it shares a card type with the exiled card, Cemetery Gatekeeper deals 2 damage to that player.",
             "colours": [
@@ -13214,7 +13214,7 @@
         },
         {
             "id": "717d62eb-661c-534f-ac86-1ab16d38acb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213112df-439b-454e-ade4-90e4176411c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213112df-439b-454e-ade4-90e4176411c5.jpg?1",
             "name": "Dominating Vampire",
             "text": "When Dominating Vampire enters the battlefield, gain control of target creature with mana value less than or equal to the number of Vampires you control until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "81a77ee7-1ea7-54b9-ad32-2c71adcffdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aacc8fa-9440-494b-a3d9-7b1678c5a9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aacc8fa-9440-494b-a3d9-7b1678c5a9f6.jpg?1",
             "name": "Falkenrath Celebrants",
             "text": "Menace\nWhen Falkenrath Celebrants enters the battlefield, create two Blood tokens.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "1aff0233-7bc0-5011-90bc-61cdebe091b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b68fbf-7fc7-4fd5-9bdf-f3ef846d4c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b68fbf-7fc7-4fd5-9bdf-f3ef846d4c22.jpg?1",
             "name": "Olivia's Attendants",
             "text": "Menace\nWhenever Olivia's Attendants deals damage, create that many Blood tokens.\n{2}{R}: Olivia's Attendants deals 1 damage to any target.",
             "colours": [
@@ -13323,7 +13323,7 @@
         },
         {
             "id": "1897deef-cd1e-5cf1-a273-e8d248b4dfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feda6bb3-ee22-489c-bcfd-52ef04841024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feda6bb3-ee22-489c-bcfd-52ef04841024.jpg?1",
             "name": "Voldaren Epicure",
             "text": "When Voldaren Epicure enters the battlefield, it deals 1 damage to each opponent. Create a Blood token.",
             "colours": [
@@ -13359,7 +13359,7 @@
         },
         {
             "id": "1af69051-3251-5faa-9bc9-0720f597a9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dd1ee6-a9da-4c89-a3b8-b293ac28467f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dd1ee6-a9da-4c89-a3b8-b293ac28467f.jpg?1",
             "name": "Anje, Maid of Dishonor",
             "text": "Whenever Anje, Maid of Dishonor and/or one or more other Vampires enter the battlefield under your control, create a Blood token. This ability triggers only once each turn.\n{2}, Sacrifice another creature or a Blood token: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -13399,7 +13399,7 @@
         },
         {
             "id": "e7b2d8f5-1204-5e49-b800-33d67f1ba0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01182501-2b50-4b87-835a-fea3c5e6e330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01182501-2b50-4b87-835a-fea3c5e6e330.jpg?1",
             "name": "Bloodtithe Harvester",
             "text": "When Bloodtithe Harvester enters the battlefield, create a Blood token.\n{T}, Sacrifice Bloodtithe Harvester: Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.",
             "colours": [
@@ -13437,7 +13437,7 @@
         },
         {
             "id": "daf26d55-b1a4-5576-83c9-7da3a5717a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "Other Vampires you control get +1/+1.\nWhen Edgar, Charmed Groom dies, return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -13479,7 +13479,7 @@
         },
         {
             "id": "7534be9b-15c3-5805-bb78-a78cf90b735e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "At the beginning of your upkeep, create a 1/1 white and black Vampire creature token with lifelink and put a bloodline counter on Edgar Markov's Coffin. Then if there are three or more bloodline counters on it, remove those counters and transform it.",
             "colours": [
@@ -13518,7 +13518,7 @@
         },
         {
             "id": "ee0f5b0c-a7c1-51a4-8716-74a9b314cc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533673f3-5e18-4630-bd71-001774d698a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533673f3-5e18-4630-bd71-001774d698a8.jpg?1",
             "name": "Markov Purifier",
             "text": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay {2}. If you do, draw a card.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "d49dcfee-8b89-5490-bcf3-64c6b91ed76f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd545edd-699a-4ee9-8d8e-1e875cf4f2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd545edd-699a-4ee9-8d8e-1e875cf4f2af.jpg?1",
             "name": "Markov Waltzer",
             "text": "Flying, haste\nAt the beginning of combat on your turn, up to two target creatures you control each get +1/+0 until end of turn.",
             "colours": [
@@ -13595,7 +13595,7 @@
         },
         {
             "id": "4d598151-676b-5214-b1d1-943f1e956f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8335a9-2880-4e12-8d93-b75a297272dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8335a9-2880-4e12-8d93-b75a297272dc.jpg?1",
             "name": "Odric, Blood-Cursed",
             "text": "When Odric, Blood-Cursed enters the battlefield, create X Blood tokens, where X is the number of abilities from among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance found among creatures you control. (Count each ability only once.)",
             "colours": [
@@ -13636,7 +13636,7 @@
         },
         {
             "id": "aa33985d-3379-50ec-b905-116aaeaa91f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7964ed78-c0c2-4555-bc25-b0eac14d0b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7964ed78-c0c2-4555-bc25-b0eac14d0b34.jpg?1",
             "name": "Olivia, Crimson Bride",
             "text": "Flying, haste\nWhenever Olivia, Crimson Bride attacks, return target creature card from your graveyard to the battlefield tapped and attacking. It gains \"When you don't control a legendary Vampire, exile this creature.\"",
             "colours": [
@@ -13678,7 +13678,7 @@
         },
         {
             "id": "9921e75c-6b47-5620-81e1-b30449e93d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhen Runo Stromkirk enters the battlefield, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo Stromkirk.",
             "colours": [
@@ -13720,7 +13720,7 @@
         },
         {
             "id": "c22c43cb-00ee-529b-bf38-d4c9ad10afed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhenever Krothuss, Lord of the Deep attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
             "colours": [
@@ -13762,7 +13762,7 @@
         },
         {
             "id": "c2a95d60-9dfb-5714-9ea6-3dbaa9c8662f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Flying, lifelink, protection from Vampires\nKatilda, Dawnhart Martyr's power and toughness are each equal to the number of permanents you control that are Spirits and/or enchantments.\nDisturb {3}{W}{W}",
             "colours": [
@@ -13801,7 +13801,7 @@
         },
         {
             "id": "6221d122-1fb9-5ec9-8860-972f4626544e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Enchant creature\nEnchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, where X is the number of permanents you control that are Spirits and/or enchantments.\nIf Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -13839,7 +13839,7 @@
         },
         {
             "id": "28a78ede-a937-57c9-98be-e604b6686f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7cbfc-e655-4f82-8bde-fbc95461361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7cbfc-e655-4f82-8bde-fbc95461361e.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -13879,7 +13879,7 @@
         },
         {
             "id": "bd8bf43c-646d-5095-8247-b61b9541fd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d474-5620-4c5f-95a4-8a128825df83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d474-5620-4c5f-95a4-8a128825df83.jpg?1",
             "name": "Geralf, Visionary Stitcher",
             "text": "Zombies you control have flying.\n{U}, {T}, Sacrifice another nontoken creature: Create an X/X blue Zombie creature token, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -13918,7 +13918,7 @@
         },
         {
             "id": "98ce28b2-0189-59cd-bb09-3ce45c32b78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "{T}: Draw a card, then exile a card from your hand face down. You may look at that card for as long as it remains exiled. You may pay {4}{U}{U}. If you do, transform Jacob Hauken, Inspector.",
             "colours": [
@@ -13958,7 +13958,7 @@
         },
         {
             "id": "83638ea8-ad03-52a9-95ec-22222ad372d7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "At the beginning of your upkeep, exile the top card of your library face down. You may look at that card for as long as it remains exiled.\nOnce during each of your turns, you may play a land or cast a spell from among the cards exiled with this permanent without paying its mana cost.",
             "colours": [
@@ -13995,7 +13995,7 @@
         },
         {
             "id": "43b3b820-fdf9-539a-a864-3a7cc3e0e994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78808d46-a3a7-4598-bddf-a302977808fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78808d46-a3a7-4598-bddf-a302977808fb.jpg?1",
             "name": "Toxrill, the Corrosive",
             "text": "At the beginning of each end step, put a slime counter on each creature you don't control.\nCreatures you don't control get -1/-1 for each slime counter on them.\nWhenever a creature you don't control with a slime counter on it dies, create a 1/1 black Slug creature token.\n{U}{B}, Sacrifice a Slug: Draw a card.",
             "colours": [
@@ -14035,7 +14035,7 @@
         },
         {
             "id": "d0470c18-986f-5934-89d2-51eb4982941a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Flying\nWhen Dorothea, Vengeful Victim attacks or blocks, sacrifice it at end of combat.\nDisturb {1}{W}{U}",
             "colours": [
@@ -14075,7 +14075,7 @@
         },
         {
             "id": "64d86c8b-2e9b-5d93-a076-2bf245a3f0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat.\"\nIf Dorothea's Retribution would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14113,7 +14113,7 @@
         },
         {
             "id": "e980d553-1710-5482-a6e3-409ed546de24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2481acb-9738-4069-b772-99fdbacc3857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2481acb-9738-4069-b772-99fdbacc3857.jpg?1",
             "name": "Eruth, Tormented Prophet",
             "text": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
             "colours": [
@@ -14155,7 +14155,7 @@
         },
         {
             "id": "16cebdd2-ff4f-5d24-875f-ca9f5017133a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51e8d9-a837-4b53-8943-220c0e1d4c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51e8d9-a837-4b53-8943-220c0e1d4c3c.jpg?1",
             "name": "Grolnok, the Omnivore",
             "text": "Whenever a Frog you control attacks, mill three cards.\nWhenever a permanent card is put into your graveyard from your library, exile it with a croak counter on it.\nYou may play lands and cast spells from among cards you own in exile with croak counters on them.",
             "colours": [
@@ -14195,7 +14195,7 @@
         },
         {
             "id": "20b42d7c-78b4-5ee4-8e7c-59885861e6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87684bef-8ef9-4709-a50e-fa5ff2f67acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87684bef-8ef9-4709-a50e-fa5ff2f67acc.jpg?1",
             "name": "Halana and Alena, Partners",
             "text": "First strike, reach\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is Halana and Alena's power. That creature gains haste until end of turn.",
             "colours": [
@@ -14236,7 +14236,7 @@
         },
         {
             "id": "4d6fc84f-0ade-5dcb-9d57-1ea119bc39f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90930e16-4a77-4ce6-bab4-e099184d1b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90930e16-4a77-4ce6-bab4-e099184d1b54.jpg?1",
             "name": "Old Rutstein",
             "text": "When Old Rutstein enters the battlefield or at the beginning of your upkeep, mill a card. If a land card is milled this way, create a Treasure token. If a creature card is milled this way, create a 1/1 green Insect creature token. If a noncreature, nonland card is milled this way, create a Blood token.",
             "colours": [
@@ -14277,7 +14277,7 @@
         },
         {
             "id": "00bd4df8-ff81-52a2-bdb7-a5e104eca541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhen Runo Stromkirk enters the battlefield, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo Stromkirk.",
             "colours": [
@@ -14319,7 +14319,7 @@
         },
         {
             "id": "0b199ffa-90e3-5e65-8f71-c1c42e3b4038",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhenever Krothuss, Lord of the Deep attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
             "colours": [
@@ -14361,7 +14361,7 @@
         },
         {
             "id": "ba8cfcd9-77c4-5b67-a1ea-23f0a03a4e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8fa32-f5fb-441a-8c53-28cd44723672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8fa32-f5fb-441a-8c53-28cd44723672.jpg?1",
             "name": "Torens, Fist of the Angels",
             "text": "Training\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
             "colours": [
@@ -14403,7 +14403,7 @@
         },
         {
             "id": "b90a5274-07f5-5268-9435-ffdb5e36dee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cb7bbb-9216-43b7-abd8-387f6c7864e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cb7bbb-9216-43b7-abd8-387f6c7864e6.jpg?1",
             "name": "Circle of Confinement",
             "text": "When Circle of Confinement enters the battlefield, exile target creature an opponent controls with mana value 3 or less until Circle of Confinement leaves the battlefield.\nWhenever an opponent casts a Vampire spell with the same name as a card exiled with Circle of Confinement, you gain 2 life.",
             "colours": [
@@ -14437,7 +14437,7 @@
         },
         {
             "id": "ccd21ae8-ca0b-529c-8dd4-006e4834b09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2d232-484c-4ec2-814b-e1018277a1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2d232-484c-4ec2-814b-e1018277a1ff.jpg?1",
             "name": "Savior of Ollenbock",
             "text": "Training\nWhenever Savior of Ollenbock trains, exile up to one other target creature from the battlefield or creature card from a graveyard.\nWhen Savior of Ollenbock leaves the battlefield, put the exiled cards onto the battlefield under their owners' control.",
             "colours": [
@@ -14475,7 +14475,7 @@
         },
         {
             "id": "5d36fe9d-6ce1-5d7c-8f15-c0d3968ee4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1830002a-b512-4e51-b3fa-0137d2b4c749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1830002a-b512-4e51-b3fa-0137d2b4c749.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -14515,7 +14515,7 @@
         },
         {
             "id": "624bdbbd-f73e-5e13-ae98-a7d1064ecb13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "{T}: Draw a card, then exile a card from your hand face down. You may look at that card for as long as it remains exiled. You may pay {4}{U}{U}. If you do, transform Jacob Hauken, Inspector.",
             "colours": [
@@ -14555,7 +14555,7 @@
         },
         {
             "id": "e6b11575-ba94-552a-a6ee-051294080edd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "At the beginning of your upkeep, exile the top card of your library face down. You may look at that card for as long as it remains exiled.\nOnce during each of your turns, you may play a land or cast a spell from among the cards exiled with this permanent without paying its mana cost.",
             "colours": [
@@ -14592,7 +14592,7 @@
         },
         {
             "id": "54a94fc6-7197-5f1f-8fec-62e11d441c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ed095e-6b77-4262-a2fa-d04dde96f9e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ed095e-6b77-4262-a2fa-d04dde96f9e4.jpg?1",
             "name": "Thirst for Discovery",
             "text": "Draw three cards. Then discard two cards unless you discard a basic land card.",
             "colours": [
@@ -14626,7 +14626,7 @@
         },
         {
             "id": "ea7f0224-cd76-5d73-9c40-067aa598e8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d43ab9-772d-4f4d-8536-3ea60e8f9f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d43ab9-772d-4f4d-8536-3ea60e8f9f82.jpg?1",
             "name": "Falkenrath Forebear",
             "text": "Flying\nFalkenrath Forebear can't block.\nWhenever Falkenrath Forebear deals combat damage to a player, create a Blood token.\n{B}, Sacrifice two Blood tokens: Return Falkenrath Forebear from your graveyard to the battlefield.",
             "colours": [
@@ -14663,7 +14663,7 @@
         },
         {
             "id": "d0a03e2c-3f7f-5a87-91c7-64c19784be7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen \u2014\n\u2022 Each player sacrifices a creature.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Transform Henrika Domnathi.",
             "colours": [
@@ -14702,7 +14702,7 @@
         },
         {
             "id": "357a2aaa-7be5-511a-b03e-1918d184b113",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying, deathtouch, lifelink\n{1}{B}{B}: Each creature you control with flying, deathtouch, and/or lifelink gets +1/+0 until end of turn.",
             "colours": [
@@ -14741,7 +14741,7 @@
         },
         {
             "id": "8e6cbd54-3006-5363-bf36-c5e63420d5e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "At the beginning of your upkeep, any opponent may sacrifice a creature. If no one does, transform Innocent Traveler.",
             "colours": [
@@ -14778,7 +14778,7 @@
         },
         {
             "id": "35444858-85c9-5242-b62a-aa57f8501e99",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "Flying\nMalicious Invader gets +2/+0 as long as an opponent controls a Human.",
             "colours": [
@@ -14815,7 +14815,7 @@
         },
         {
             "id": "87209059-8177-59b0-93a9-8b4e9b958dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260d784d-0213-44da-8f78-58968a185012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260d784d-0213-44da-8f78-58968a185012.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -14855,7 +14855,7 @@
         },
         {
             "id": "ee52dc1d-3c5b-5fba-ae84-e2017c039deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token.\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "409a24b6-f398-586f-a09c-881b79f3b9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
             "colours": [
@@ -14931,7 +14931,7 @@
         },
         {
             "id": "572b89e6-31e5-516b-ad8a-3a43416daa1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4ba693-0323-415d-ad91-c083fbbab7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4ba693-0323-415d-ad91-c083fbbab7f7.jpg?1",
             "name": "Vampires' Vengeance",
             "text": "Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token.",
             "colours": [
@@ -14965,7 +14965,7 @@
         },
         {
             "id": "a0c430bc-2fc8-56d3-b0d5-68bed8692cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626eacad-6ea5-410a-9a3f-af97b5e52ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626eacad-6ea5-410a-9a3f-af97b5e52ff0.jpg?1",
             "name": "Reclusive Taxidermist",
             "text": "Reclusive Taxidermist gets +3/+2 as long as there are four or more creature cards in your graveyard.\n{T}: Add one mana of any color.",
             "colours": [
@@ -15002,7 +15002,7 @@
         },
         {
             "id": "7c24d5e5-d467-522e-a26a-01c0207d698a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "Other Vampires you control get +1/+1.\nWhen Edgar, Charmed Groom dies, return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -15044,7 +15044,7 @@
         },
         {
             "id": "8d59cb71-e741-57c3-a4fc-87265611cd08",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "At the beginning of your upkeep, create a 1/1 white and black Vampire creature token with lifelink and put a bloodline counter on Edgar Markov's Coffin. Then if there are three or more bloodline counters on it, remove those counters and transform it.",
             "colours": [
@@ -15083,7 +15083,7 @@
         },
         {
             "id": "17c01956-5f85-550e-ade9-e5400b63133d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecbb622-f33b-4192-9b42-8872b35cc409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecbb622-f33b-4192-9b42-8872b35cc409.jpg?1",
             "name": "Eruth, Tormented Prophet",
             "text": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
             "colours": [
@@ -15125,7 +15125,7 @@
         },
         {
             "id": "d9d355f6-a4b8-5189-9d2a-6a074bf216cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5552d3-6860-42e5-8a13-1d36dce77322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5552d3-6860-42e5-8a13-1d36dce77322.jpg?1",
             "name": "Olivia, Crimson Bride",
             "text": "Flying, haste\nWhenever Olivia, Crimson Bride attacks, return target creature card from your graveyard to the battlefield tapped and attacking. It gains \"When you don't control a legendary Vampire, exile this creature.\"",
             "colours": [
@@ -15167,7 +15167,7 @@
         },
         {
             "id": "8e3de8cf-3769-5484-aefa-c99724ea361f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3448-34fd-4de6-a6b4-f6d636eead8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3448-34fd-4de6-a6b4-f6d636eead8c.jpg?1",
             "name": "Torens, Fist of the Angels",
             "text": "Training\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
             "colours": [
@@ -15209,7 +15209,7 @@
         },
         {
             "id": "3471dadd-e2d0-51c2-af46-2ae3e51e3315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8191ff1-458f-4295-b253-c4748c933e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8191ff1-458f-4295-b253-c4748c933e92.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -15242,7 +15242,7 @@
         },
         {
             "id": "12c9e400-8d82-555d-a159-d4f27b0f3a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab11a4db-5504-4f52-9c2f-eae05a0a8415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab11a4db-5504-4f52-9c2f-eae05a0a8415.jpg?1",
             "name": "By Invitation Only",
             "text": "Choose a number between 0 and 13. Each player sacrifices that many creatures.",
             "colours": [
@@ -15276,7 +15276,7 @@
         },
         {
             "id": "8f4a1f81-f769-5281-9f68-5bebe4d2761e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa2f823-d66d-42b0-ab3c-180b9a927cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa2f823-d66d-42b0-ab3c-180b9a927cb1.jpg?1",
             "name": "Cemetery Protector",
             "text": "Flash\nWhen Cemetery Protector enters the battlefield, exile a card from a graveyard.\nWhenever you play a land or cast a spell, if it shares a card type with the exiled card, create a 1/1 white Human creature token.",
             "colours": [
@@ -15313,7 +15313,7 @@
         },
         {
             "id": "785b309d-36ec-5781-9e60-0de69260e536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Defender, flying, vigilance\nAt the beginning of your upkeep, if Faithbound Judge has two or fewer judgment counters on it, put a judgment counter on it.\nAs long as Faithbound Judge has three or more judgment counters on it, it can attack as though it didn't have defender.\nDisturb {5}{W}{W}",
             "colours": [
@@ -15350,7 +15350,7 @@
         },
         {
             "id": "00f8f397-9d44-5d5e-ba25-a57a2533e153",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Enchant player\nAt the beginning of your upkeep, put a judgment counter on Sinner's Judgment. Then if there are three or more judgment counters on it, enchanted player loses the game.\nIf Sinner's Judgment would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -15387,7 +15387,7 @@
         },
         {
             "id": "16a2a122-b88a-5ee1-a590-047293f1167e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0904640-40e8-45bf-ac9c-94b1dd0bab8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0904640-40e8-45bf-ac9c-94b1dd0bab8f.jpg?1",
             "name": "Hallowed Haunting",
             "text": "As long as you control seven or more enchantments, creatures you control have flying and vigilance.\nWhenever you cast an enchantment spell, create a white Spirit Cleric creature token with \"This creature's power and toughness are each equal to the number of Spirits you control.\"",
             "colours": [
@@ -15421,7 +15421,7 @@
         },
         {
             "id": "65e4f746-2aed-57cc-aaf0-8aadf9de885b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169b4aa8-9597-4b57-a957-abee147fdde4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169b4aa8-9597-4b57-a957-abee147fdde4.jpg?1",
             "name": "Hopeful Initiate",
             "text": "Training\n{2}{W}, Remove two +1/+1 counters from among creatures you control: Destroy target artifact or enchantment.",
             "colours": [
@@ -15458,7 +15458,7 @@
         },
         {
             "id": "9ba6f39a-f4c9-5dc4-a7ff-8c0331b7e9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95751a49-398b-4d95-9475-2bdfed9b791b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95751a49-398b-4d95-9475-2bdfed9b791b.jpg?1",
             "name": "Lantern Flare",
             "text": "Cleave {X}{R}{W}\nLantern Flare deals X damage to target creature or planeswalker and you gain X life. [\nX is the number of creatures you control.]",
             "colours": [
@@ -15493,7 +15493,7 @@
         },
         {
             "id": "054a8bbb-d342-5ec8-94ab-34e96510d8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec42176-cf5b-44b7-801a-2550a065692b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec42176-cf5b-44b7-801a-2550a065692b.jpg?1",
             "name": "Savior of Ollenbock",
             "text": "Training\nWhenever Savior of Ollenbock trains, exile up to one other target creature from the battlefield or creature card from a graveyard.\nWhen Savior of Ollenbock leaves the battlefield, put the exiled cards onto the battlefield under their owners' control.",
             "colours": [
@@ -15531,7 +15531,7 @@
         },
         {
             "id": "87a4c580-fc93-53ca-8f1e-3dd1867fdadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da14fe94-9a64-4e98-a827-0f4588a6d832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da14fe94-9a64-4e98-a827-0f4588a6d832.jpg?1",
             "name": "Sigarda's Summons",
             "text": "Creatures you control with +1/+1 counters on them have base power and toughness 4/4, have flying, and are Angels in addition to their other types.",
             "colours": [
@@ -15566,7 +15566,7 @@
         },
         {
             "id": "056611f3-819e-557f-8859-05493a334bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008aac8-0e84-49ae-8905-68db2b2900ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008aac8-0e84-49ae-8905-68db2b2900ef.jpg?1",
             "name": "Voice of the Blessed",
             "text": "Whenever you gain life, put a +1/+1 counter on Voice of the Blessed.\nAs long as Voice of the Blessed has four or more +1/+1 counters on it, it has flying and vigilance.\nAs long as Voice of the Blessed has ten or more +1/+1 counters on it, it has indestructible.",
             "colours": [
@@ -15603,7 +15603,7 @@
         },
         {
             "id": "f938c276-7eba-528c-9100-e8895351b60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "At the beginning of your end step, put an invitation counter on Wedding Announcement. If you attacked with two or more creatures this turn, draw a card. Otherwise, create a 1/1 white Human creature token. Then if Wedding Announcement has three or more invitation counters on it, transform it.",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "3f840a21-aa97-53a2-b814-dd66783da008",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -15671,7 +15671,7 @@
         },
         {
             "id": "e49685a1-10fe-52a1-ba6a-9f58b22977fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c330f8-7461-48d3-9743-25e66d153538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c330f8-7461-48d3-9743-25e66d153538.jpg?1",
             "name": "Cemetery Illuminator",
             "text": "Flying\nWhenever Cemetery Illuminator enters the battlefield or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with Cemetery Illuminator.",
             "colours": [
@@ -15707,7 +15707,7 @@
         },
         {
             "id": "96345e66-4003-5a49-bab8-0ab000b73274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc518e53-1fd5-4eeb-a8b7-6db871cc16d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc518e53-1fd5-4eeb-a8b7-6db871cc16d6.jpg?1",
             "name": "Consuming Tide",
             "text": "Each player chooses a nonland permanent they control. Return all nonland permanents not chosen this way to their owners' hands. Then you draw a card for each opponent who has more cards in their hand than you.",
             "colours": [
@@ -15741,7 +15741,7 @@
         },
         {
             "id": "f9fa5087-17db-53e7-9dad-d33eaf877156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e591ed36-2a6f-493d-b57d-43a18608e811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e591ed36-2a6f-493d-b57d-43a18608e811.jpg?1",
             "name": "Dreamshackle Geist",
             "text": "Flying\nAt the beginning of combat on your turn, choose up to one \u2014\n\u2022 Tap target creature.\n\u2022 Target creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -15777,7 +15777,7 @@
         },
         {
             "id": "bad5044a-7574-5733-b87b-f2002336acb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e073047-fba8-41bd-b260-1eefb084fc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e073047-fba8-41bd-b260-1eefb084fc80.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -15814,7 +15814,7 @@
         },
         {
             "id": "e6f9a2f1-71d5-5228-ac5b-3c9e13ed1c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c531001-3401-428e-a064-880bddc8c246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c531001-3401-428e-a064-880bddc8c246.jpg?1",
             "name": "Inspired Idea",
             "text": "Cleave {3}{U}{U}\nDraw three cards. [\nYour maximum hand size is reduced by three for the rest of the game.]",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "1c650e33-eafd-5c9d-87a9-0c092cb6675f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "You may have Mirrorhall Mimic enter the battlefield as a copy of any creature on the battlefield, except it's a Spirit in addition to its other types.\nDisturb {3}{U}{U}",
             "colours": [
@@ -15884,7 +15884,7 @@
         },
         {
             "id": "f08a630f-f7ad-53a9-9506-9c68f6ed44ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "Enchant creature\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except it's a Spirit in addition to its other types.\nIf Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -15920,7 +15920,7 @@
         },
         {
             "id": "0b08e33f-9db1-523e-8609-7b8b79f5ce53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400ca655-68ed-4714-96e9-55df00a325b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400ca655-68ed-4714-96e9-55df00a325b3.jpg?1",
             "name": "Necroduality",
             "text": "Whenever a nontoken Zombie enters the battlefield under your control, create a token that's a copy of that creature.",
             "colours": [
@@ -15954,7 +15954,7 @@
         },
         {
             "id": "8f78e14d-9f8f-5004-acff-f208cd9aebe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8d93bf-8836-469e-a28c-39633959a212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8d93bf-8836-469e-a28c-39633959a212.jpg?1",
             "name": "Overcharged Amalgam",
             "text": "Flash\nFlying, exploit\nWhen Overcharged Amalgam exploits a creature, counter target spell, activated ability, or triggered ability.",
             "colours": [
@@ -15991,7 +15991,7 @@
         },
         {
             "id": "52b28b5c-3739-5123-8d7e-4aa3cdcfd57c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5afa6a-c1e2-4cb1-a04c-67c9cf605c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5afa6a-c1e2-4cb1-a04c-67c9cf605c20.jpg?1",
             "name": "Patchwork Crawler",
             "text": "{2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter on Patchwork Crawler.\nPatchwork Crawler has all activated abilities of all creature cards exiled with it.",
             "colours": [
@@ -16028,7 +16028,7 @@
         },
         {
             "id": "86e51219-2498-54e5-a1d4-698767c93f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b369e3-5057-49ff-b87e-1126571334f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b369e3-5057-49ff-b87e-1126571334f5.jpg?1",
             "name": "Winged Portent",
             "text": "Cleave {4}{G}{U}\nDraw a card for each creature [with flying] you control.",
             "colours": [
@@ -16063,7 +16063,7 @@
         },
         {
             "id": "bfed5962-f578-5d7f-bfd0-f0b97d150b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dcf3c1-8b2c-4b2a-8ba7-9c65ae1e04d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dcf3c1-8b2c-4b2a-8ba7-9c65ae1e04d5.jpg?1",
             "name": "Cemetery Desecrator",
             "text": "Menace\nWhen Cemetery Desecrator enters the battlefield or dies, exile another card from a graveyard. When you do, choose one \u2014\n\u2022 Remove X counters from target permanent, where X is the mana value of the exiled card.\n\u2022 Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card.",
             "colours": [
@@ -16099,7 +16099,7 @@
         },
         {
             "id": "50a99452-fbe4-5ff4-a0fe-615a608c2d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Defender\n{2}{B}: Transform Concealing Curtains. Activate only as a sorcery.",
             "colours": [
@@ -16135,7 +16135,7 @@
         },
         {
             "id": "33f0df49-b381-56d9-a044-94818ae7bf73",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Menace\nWhen this creature transforms into Revealing Eye, target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "2d1ae06c-bca2-51e1-9337-34c174173257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5603d9-085c-48ac-b78b-5d95f412e577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5603d9-085c-48ac-b78b-5d95f412e577.jpg?1",
             "name": "Demonic Bargain",
             "text": "Exile the top thirteen cards of your library, then search your library for a card. Put that card into your hand, then shuffle.",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "36eb71fb-aefc-52c1-b1c3-eb8698d5a5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46089fef-1b9a-4796-b1fd-8c11494631aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46089fef-1b9a-4796-b1fd-8c11494631aa.jpg?1",
             "name": "Dreadfeast Demon",
             "text": "Flying\nAt the beginning of your end step, sacrifice a non-Demon creature. If you do, create a token that's a copy of Dreadfeast Demon.",
             "colours": [
@@ -16242,7 +16242,7 @@
         },
         {
             "id": "9dd83e5c-b5ec-57ea-8a61-fbec63294afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e70a-c00c-4c9e-8a52-e69a94103594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e70a-c00c-4c9e-8a52-e69a94103594.jpg?1",
             "name": "Dying to Serve",
             "text": "Whenever you discard one or more cards, create a tapped 2/2 black Zombie creature token. This ability triggers only once each turn.",
             "colours": [
@@ -16276,7 +16276,7 @@
         },
         {
             "id": "f7525000-ee9a-51f0-af08-8dcd2853f35c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c1efe-b1c9-4830-a1cc-d897913e10c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c1efe-b1c9-4830-a1cc-d897913e10c5.jpg?1",
             "name": "Graf Reaver",
             "text": "Exploit\nWhen Graf Reaver exploits a creature, destroy target planeswalker.\nAt the beginning of your upkeep, Graf Reaver deals 1 damage to you.",
             "colours": [
@@ -16313,7 +16313,7 @@
         },
         {
             "id": "d7912f5b-9d62-5f44-b268-a1726597e1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544d7162-b78f-4a70-86e7-83cec7062039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544d7162-b78f-4a70-86e7-83cec7062039.jpg?1",
             "name": "Headless Rider",
             "text": "Whenever Headless Rider or another nontoken Zombie you control dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -16349,7 +16349,7 @@
         },
         {
             "id": "1563b119-92ac-5848-9a4f-d1f0604a74c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061be997-1519-41b6-9933-eb625db88eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061be997-1519-41b6-9933-eb625db88eb2.jpg?1",
             "name": "Path of Peril",
             "text": "Cleave {4}{W}{B}\nDestroy all creatures [with mana value 2 or less].",
             "colours": [
@@ -16384,7 +16384,7 @@
         },
         {
             "id": "3be56dff-efb4-5330-95a7-0793f5eb26fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab8938-57c9-4e08-b808-09eb02b040a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab8938-57c9-4e08-b808-09eb02b040a0.jpg?1",
             "name": "Alchemist's Gambit",
             "text": "Cleave {4}{U}{U}{R}\nTake an extra turn after this one. During that turn, damage can't be prevented. [\nAt the beginning of that turn's end step, you lose the game.]\nExile Alchemist's Gambit.",
             "colours": [
@@ -16419,7 +16419,7 @@
         },
         {
             "id": "d0fe8fea-a9ad-5dc1-8f89-22b7857ef213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e09ecd-a8fc-45a6-a997-49b0fc5c88b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e09ecd-a8fc-45a6-a997-49b0fc5c88b9.jpg?1",
             "name": "Change of Fortune",
             "text": "Discard your hand, then draw a card for each card you've discarded this turn.",
             "colours": [
@@ -16453,7 +16453,7 @@
         },
         {
             "id": "fc735da2-4296-549c-92c4-a08a4b7ad87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0694ead-c2cb-4c0d-a7f7-959b641f2294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0694ead-c2cb-4c0d-a7f7-959b641f2294.jpg?1",
             "name": "Creepy Puppeteer",
             "text": "Haste\nWhenever Creepy Puppeteer attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn.",
             "colours": [
@@ -16490,7 +16490,7 @@
         },
         {
             "id": "fcd07d75-2988-59a5-8549-7a1a12e6556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583344df-41ac-4950-ae63-275df9b0a9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583344df-41ac-4950-ae63-275df9b0a9e9.jpg?1",
             "name": "Curse of Hospitality",
             "text": "Enchant player\nCreatures attacking enchanted player have trample.\nWhenever a creature deals combat damage to enchanted player, that player exiles the top card of their library. Until end of turn, that creature's controller may play that card and they may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -16527,7 +16527,7 @@
         },
         {
             "id": "54a57b92-6047-5701-9f58-a92350b564e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever Ill-Tempered Loner is dealt damage, it deals that much damage to any target.\n{1}{R}: Ill-Tempered Loner gets +2/+0 until end of turn.\nDaybound",
             "colours": [
@@ -16564,7 +16564,7 @@
         },
         {
             "id": "518d2a7b-c827-55f6-b9ca-86e790360432",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever a permanent you control is dealt damage, Howlpack Avenger deals that much damage to any target.\n{1}{R}: Howlpack Avenger gets +2/+0 until end of turn.\nNightbound",
             "colours": [
@@ -16600,7 +16600,7 @@
         },
         {
             "id": "a762ef7d-e6bb-561e-985f-c3944855809b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d54673a-2147-474c-9bcb-ef89dbe54456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d54673a-2147-474c-9bcb-ef89dbe54456.jpg?1",
             "name": "Kessig Wolfrider",
             "text": "Menace\n{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.",
             "colours": [
@@ -16637,7 +16637,7 @@
         },
         {
             "id": "6772a6c0-ca0f-5156-aed9-d90934e10341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8f0f2-3694-4f82-9e45-0130248875ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8f0f2-3694-4f82-9e45-0130248875ea.jpg?1",
             "name": "Manaform Hellkite",
             "text": "Flying\nWhenever you cast a noncreature spell, create an X/X red Dragon Illusion creature token with flying and haste, where X is the amount of mana spent to cast that spell. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -16673,7 +16673,7 @@
         },
         {
             "id": "3b2c0e46-214c-5796-9345-34a13492d806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832a58cd-804d-4c1a-b24e-478357873b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832a58cd-804d-4c1a-b24e-478357873b93.jpg?1",
             "name": "Stensia Uprising",
             "text": "At the beginning of your end step, create a 1/1 red Human creature token. Then if you control exactly thirteen permanents, you may sacrifice Stensia Uprising. When you do, it deals 7 damage to any target.",
             "colours": [
@@ -16707,7 +16707,7 @@
         },
         {
             "id": "21fd3c99-610d-5cac-aea2-ff9eca2fbb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Volatile Arsonist attacks, it deals 1 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nDaybound",
             "colours": [
@@ -16744,7 +16744,7 @@
         },
         {
             "id": "61909d09-c1cb-5d9a-a0d5-5b82ba2542d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Dire-Strain Anarchist attacks, it deals 2 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nNightbound",
             "colours": [
@@ -16780,7 +16780,7 @@
         },
         {
             "id": "f70622e6-fbd1-5bc4-9620-5fe66507e456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af47752-f5d9-471a-a10b-1ba06d58e0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af47752-f5d9-471a-a10b-1ba06d58e0e5.jpg?1",
             "name": "Ascendant Packleader",
             "text": "Ascendant Packleader enters the battlefield with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.\nWhenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on Ascendant Packleader.",
             "colours": [
@@ -16816,7 +16816,7 @@
         },
         {
             "id": "ae38fd25-5a29-5807-adf5-43430dab1e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nAt the beginning of combat on your turn, put two +1/+1 counters on another target creature you control.\nDaybound",
             "colours": [
@@ -16853,7 +16853,7 @@
         },
         {
             "id": "401ddfef-7260-50a3-b91c-1bb5a370724d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nOther permanents you control have hexproof.\nAt the beginning of combat on your turn, put two +1/+1 counters on each creature you control.\nNightbound",
             "colours": [
@@ -16889,7 +16889,7 @@
         },
         {
             "id": "1b97a54c-8862-5958-a341-719de68ae2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352dcf9-fcdf-45c2-a581-87c5ec965618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352dcf9-fcdf-45c2-a581-87c5ec965618.jpg?1",
             "name": "Cemetery Prowler",
             "text": "Vigilance\nWhenever Cemetery Prowler enters the battlefield or attacks, exile a card from a graveyard.\nSpells you cast cost {1} less to cast for each card type they share with cards exiled with Cemetery Prowler.",
             "colours": [
@@ -16925,7 +16925,7 @@
         },
         {
             "id": "0078d827-6c03-5684-900e-7094ab5be190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d752b67-93ea-4f76-ad80-09787427398e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d752b67-93ea-4f76-ad80-09787427398e.jpg?1",
             "name": "Cultivator Colossus",
             "text": "Trample\nCultivator Colossus's power and toughness are each equal to the number of lands you control.\nWhen Cultivator Colossus enters the battlefield, you may put a land card from your hand onto the battlefield tapped. If you do, draw a card and repeat this process.",
             "colours": [
@@ -16962,7 +16962,7 @@
         },
         {
             "id": "c3df45d8-8056-53c8-a21b-ee478e51613d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078d0194-0137-45cd-977a-eefae67f9bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078d0194-0137-45cd-977a-eefae67f9bca.jpg?1",
             "name": "Dig Up",
             "text": "Cleave {1}{B}{B}{G}\nSearch your library for a basic land card, [reveal it,] put it into your hand, then shuffle.",
             "colours": [
@@ -16997,7 +16997,7 @@
         },
         {
             "id": "b4ed3060-d345-5590-a541-71c59bf2f5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bd18f-29f0-422e-a28e-4fc7ce21b9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bd18f-29f0-422e-a28e-4fc7ce21b9c9.jpg?1",
             "name": "Glorious Sunrise",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Target land gains \"{T}: Add {G}{G}{G}\" until end of turn.\n\u2022 Draw a card if you control a creature with power 3 or greater.\n\u2022 You gain 3 life.",
             "colours": [
@@ -17031,7 +17031,7 @@
         },
         {
             "id": "9a8a0436-3421-538d-bc50-134dc26db515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf4689-53a6-434d-9795-97f9c3777fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf4689-53a6-434d-9795-97f9c3777fac.jpg?1",
             "name": "Hamlet Vanguard",
             "text": "Ward {2}\nHamlet Vanguard enters the battlefield with two +1/+1 counters on it for each other nontoken Human you control.",
             "colours": [
@@ -17068,7 +17068,7 @@
         },
         {
             "id": "d9bededa-e940-54ad-a145-4200c799b05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c150b7b-5a78-4f84-bff7-d5000e266a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c150b7b-5a78-4f84-bff7-d5000e266a55.jpg?1",
             "name": "Hiveheart Shaman",
             "text": "Whenever Hiveheart Shaman attacks, you may search your library for a basic land card that doesn't share a land type with a land you control, put that card onto the battlefield, then shuffle.\n{5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is the number of basic land types among lands you control. Activate only as a sorcery.",
             "colours": [
@@ -17105,7 +17105,7 @@
         },
         {
             "id": "43ef64b8-5f67-5a64-a2a6-1da63b4b24b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c9612e-3acd-4eb7-b34c-c300084625d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c9612e-3acd-4eb7-b34c-c300084625d4.jpg?1",
             "name": "Howling Moon",
             "text": "At the beginning of combat on your turn, target Wolf or Werewolf you control gets +2/+2 until end of turn.\nWhenever an opponent casts their second spell each turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -17139,7 +17139,7 @@
         },
         {
             "id": "5e01b051-8739-581a-b3a2-db6b41264ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "This spell can't be countered.\n{1}{G}, {T}: You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap Howlpack Piper. Activate only as a sorcery.\nDaybound",
             "colours": [
@@ -17176,7 +17176,7 @@
         },
         {
             "id": "5986dc93-8cba-5956-b466-ea1ae210c3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "Whenever this creature enters the battlefield or transforms into Wildsong Howler, look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nNightbound",
             "colours": [
@@ -17212,7 +17212,7 @@
         },
         {
             "id": "5f7271d9-fb0d-54d7-b85b-20125dc6061f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfdaf0-6507-4c46-afe1-b4281a645cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfdaf0-6507-4c46-afe1-b4281a645cbf.jpg?1",
             "name": "Splendid Reclamation",
             "text": "Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -17246,7 +17246,7 @@
         },
         {
             "id": "6573a18e-3268-5e84-a6c1-99bfd9292626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\n{5}{G}{G}: Transform Ulvenwald Oddity.",
             "colours": [
@@ -17282,7 +17282,7 @@
         },
         {
             "id": "ca42e483-f4c4-5c2b-8ab8-ee046b8639f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\nOther creatures you control get +1/+1 and have trample and haste.",
             "colours": [
@@ -17319,7 +17319,7 @@
         },
         {
             "id": "d4267ba5-d1e3-5536-ad2e-0ce92a22406e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d2885-82f1-424d-ba95-c4dd15b6639d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d2885-82f1-424d-ba95-c4dd15b6639d.jpg?1",
             "name": "Dollhouse of Horrors",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a token that's a copy of the exiled card, except it's a 0/0 Construct artifact in addition to its other types and it has \"This creature gets +1/+1 for each Construct you control.\" It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -17349,7 +17349,7 @@
         },
         {
             "id": "fe0e7e78-b0e3-5c39-83b5-d6dd93fbe87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f35a26f-f31e-497c-a604-0157f81a3540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f35a26f-f31e-497c-a604-0157f81a3540.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -17382,7 +17382,7 @@
         },
         {
             "id": "6ee89f05-b140-58e1-9b16-3db99917aae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2437225-d6a9-4cc6-9b3b-148f9300e6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2437225-d6a9-4cc6-9b3b-148f9300e6b1.jpg?1",
             "name": "Voldaren Estate",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control.",
             "colours": [],
@@ -17413,7 +17413,7 @@
         },
         {
             "id": "5257fea9-ca8e-5453-a019-5b229ecc9239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ddb0be-d62d-46fa-b753-36dfab935e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ddb0be-d62d-46fa-b753-36dfab935e8a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17451,7 +17451,7 @@
         },
         {
             "id": "018bd152-3bca-588a-bc3a-52c16c2c997b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82b281f-d3c7-4eb8-9a10-b4808ca6cfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82b281f-d3c7-4eb8-9a10-b4808ca6cfcd.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17489,7 +17489,7 @@
         },
         {
             "id": "ead3d5ae-4314-52b7-93e1-c91aee7340c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87de91-aa10-4ed8-83a2-261b4f57e7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87de91-aa10-4ed8-83a2-261b4f57e7db.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17527,7 +17527,7 @@
         },
         {
             "id": "449c0c6a-ba8f-5afe-8be5-fd2a9e8166c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86fbf78-57ec-4a0f-9fb6-e4bf13861563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86fbf78-57ec-4a0f-9fb6-e4bf13861563.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17565,7 +17565,7 @@
         },
         {
             "id": "d1ff8036-c078-5ac1-9fc7-76ffa3966252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6380e-b1b6-4a5a-a8d9-7cdf8eab3557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6380e-b1b6-4a5a-a8d9-7cdf8eab3557.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17603,7 +17603,7 @@
         },
         {
             "id": "6a305874-0e44-519e-84c4-02e2baeae9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9524-0958-4ce5-b521-ce38dd54a9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9524-0958-4ce5-b521-ce38dd54a9d1.jpg?1",
             "name": "Voldaren Estate",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control.",
             "colours": [],
@@ -17633,7 +17633,7 @@
         },
         {
             "id": "54d3d08b-8bba-5e26-96e3-b788e166aded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06242f90-5709-482c-8d45-a60a4dc9e8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06242f90-5709-482c-8d45-a60a4dc9e8bc.jpg?1",
             "name": "Sigarda's Summons",
             "text": "Creatures you control with +1/+1 counters on them have base power and toughness 4/4, have flying, and are Angels in addition to their other types.",
             "colours": [
@@ -17667,7 +17667,7 @@
         },
         {
             "id": "ac0df35a-9418-5a66-97af-c402ecc6b807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a081700-a29a-40ff-a198-00d32f0ea11d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a081700-a29a-40ff-a198-00d32f0ea11d.jpg?1",
             "name": "Geistlight Snare",
             "text": "This spell costs {1} less to cast if you control a Spirit. It also costs {1} less to cast if you control an enchantment.\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -17700,7 +17700,7 @@
         },
         {
             "id": "6650c7e1-fdce-59d5-b8ee-d16b674397f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53e7eb0-7468-41b7-aba8-f4977703f867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53e7eb0-7468-41b7-aba8-f4977703f867.jpg?1",
             "name": "Fell Stinger",
             "text": "Deathtouch\nExploit\nWhen Fell Stinger exploits a creature, target player draws two cards and loses 2 life.",
             "colours": [
@@ -17736,7 +17736,7 @@
         },
         {
             "id": "809ad170-defa-5f44-ab96-c6ba861330a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acfc15c-048a-4e16-94f5-935f0e9ba068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acfc15c-048a-4e16-94f5-935f0e9ba068.jpg?1",
             "name": "Dominating Vampire",
             "text": "When Dominating Vampire enters the battlefield, gain control of target creature with mana value less than or equal to the number of Vampires you control until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -17772,7 +17772,7 @@
         },
         {
             "id": "3a40c646-c09c-51ea-8208-521b33e5a2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80897666-ade2-4f70-9c4d-235753b44a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80897666-ade2-4f70-9c4d-235753b44a23.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17809,7 +17809,7 @@
         },
         {
             "id": "9f91350e-c7e4-566f-b353-da466d46573d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fddf4cb-0680-4bc7-8bb3-cb15268aff46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fddf4cb-0680-4bc7-8bb3-cb15268aff46.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17846,7 +17846,7 @@
         },
         {
             "id": "65077995-4af9-543a-bc34-acc9e50c7dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91afb4f0-70ef-4539-9081-dc130c7c63f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91afb4f0-70ef-4539-9081-dc130c7c63f5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17883,7 +17883,7 @@
         },
         {
             "id": "d0b64708-7286-50cb-a74c-fe318a1ba482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117716bf-43c8-4534-92da-d7948d4b5628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117716bf-43c8-4534-92da-d7948d4b5628.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17920,7 +17920,7 @@
         },
         {
             "id": "fc187bf4-9fe2-5f99-ae9e-13380a8a0d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7279281-42d5-4226-b841-f1f4deff919b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7279281-42d5-4226-b841-f1f4deff919b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17957,7 +17957,7 @@
         },
         {
             "id": "6d9ac173-1396-5fa3-baeb-88b5214d5dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d13a93a-a43d-4cf5-8300-8341f3b7f1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d13a93a-a43d-4cf5-8300-8341f3b7f1b1.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -17992,7 +17992,7 @@
         },
         {
             "id": "5457bab4-6167-50ce-8933-ff06f7c8c92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -18027,7 +18027,7 @@
         },
         {
             "id": "f0bc8e29-4b4f-5c21-8209-32a86ffdb49c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61e7f44-c112-4501-8850-0565fc857397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61e7f44-c112-4501-8850-0565fc857397.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -18062,7 +18062,7 @@
         },
         {
             "id": "0ef3b09e-ec53-5e89-a255-38ce73adb6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bae5-d768-45ab-aba8-94c4f9fabc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bae5-d768-45ab-aba8-94c4f9fabc79.jpg?1",
             "name": "Spirit Cleric",
             "text": "",
             "colours": [
@@ -18098,7 +18098,7 @@
         },
         {
             "id": "d3d7ce7b-5ea0-5653-ad6c-0de20e759e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539f4b60-667b-469d-9191-eacaad5c0db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539f4b60-667b-469d-9191-eacaad5c0db1.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -18133,7 +18133,7 @@
         },
         {
             "id": "5c80ec44-74e2-5bfc-824f-275b73753026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2ae34f-4558-46e0-95c5-e00d813fa355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2ae34f-4558-46e0-95c5-e00d813fa355.jpg?1",
             "name": "Slug",
             "text": "",
             "colours": [
@@ -18168,7 +18168,7 @@
         },
         {
             "id": "fe9ee815-6717-5dbc-9c88-30054c02cd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd12ac1-d1b2-4e22-9a17-8f3964294e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd12ac1-d1b2-4e22-9a17-8f3964294e35.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -18203,7 +18203,7 @@
         },
         {
             "id": "e032730f-4759-505f-a38f-bbe44fd7f41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e21cd-079d-493f-ab8d-e62f16ec1581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e21cd-079d-493f-ab8d-e62f16ec1581.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -18238,7 +18238,7 @@
         },
         {
             "id": "a819ecc0-e17d-5a7d-b7b4-2e9c098bfa1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ca01e-d2ff-45ce-bf6f-9f756808c8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ca01e-d2ff-45ce-bf6f-9f756808c8fb.jpg?1",
             "name": "Dragon Illusion",
             "text": "",
             "colours": [
@@ -18274,7 +18274,7 @@
         },
         {
             "id": "332b3d4e-183f-5f93-89bb-adfef34a51a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c8ff82-b598-4ccc-83a7-99f1e53b64d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c8ff82-b598-4ccc-83a7-99f1e53b64d3.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -18309,7 +18309,7 @@
         },
         {
             "id": "31e17edf-e40c-531d-ae1b-6340f8dc2709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -18344,7 +18344,7 @@
         },
         {
             "id": "d35b3ce0-91d2-5be9-bd34-84fc7c10f305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975c4329-418a-4ada-82fa-9286fb61d61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975c4329-418a-4ada-82fa-9286fb61d61a.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -18379,7 +18379,7 @@
         },
         {
             "id": "15cdbf33-de46-5228-bcdc-08295c9a6038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ac66f8-4bb2-42bd-9a18-7da9c3839c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ac66f8-4bb2-42bd-9a18-7da9c3839c8b.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -18414,7 +18414,7 @@
         },
         {
             "id": "d089be24-e720-50f4-8ac7-d9a928910659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -18449,7 +18449,7 @@
         },
         {
             "id": "3fc32629-0485-5851-b51b-cb8f20600499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -18487,7 +18487,7 @@
         },
         {
             "id": "5846af2a-b320-5784-9096-f6b26e1f157f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee78d3-c65f-4454-bd3c-1c55388422f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee78d3-c65f-4454-bd3c-1c55388422f5.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -18524,7 +18524,7 @@
         },
         {
             "id": "57469ddb-d4b7-5e59-9df7-199251b58fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f374bc-cd29-469f-808a-6a6c004ee8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f374bc-cd29-469f-808a-6a6c004ee8aa.jpg?1",
             "name": "Blood",
             "text": "",
             "colours": [],
@@ -18555,7 +18555,7 @@
         },
         {
             "id": "4b0b11fb-6382-5e5d-bbab-e77c1ed5cab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a89fdcf-0672-4241-834f-5db2c861694d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a89fdcf-0672-4241-834f-5db2c861694d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -18586,7 +18586,7 @@
         },
         {
             "id": "2a0c52f6-dc87-5d78-bccc-2682d94072e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2942a8-68e8-4f73-956f-f19c690fa512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2942a8-68e8-4f73-956f-f19c690fa512.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -18614,7 +18614,7 @@
         },
         {
             "id": "d1e6d9db-2420-5250-a2f4-c0688e0c5ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01783a68-4f61-43ff-94ef-eb0eae654cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01783a68-4f61-43ff-94ef-eb0eae654cb7.jpg?1",
             "name": "Chandra, Dressed to Kill Emblem",
             "text": "",
             "colours": [],
@@ -18642,7 +18642,7 @@
         },
         {
             "id": "deef0d85-4dee-5cc5-a53c-205ef82254c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],
@@ -18669,7 +18669,7 @@
         },
         {
             "id": "c7d1ebd5-fe83-58d1-83ed-b35e8773fc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/WAR.json
+++ b/Assets/Resources/Sets/WAR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "0a679f46-9f50-5ac1-a6bf-c802c67fc0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec0c0fb-1a4f-45f4-85b7-346a6d3ce2c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec0c0fb-1a4f-45f4-85b7-346a6d3ce2c5.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "Activated abilities of artifacts your opponents control can't be activated.\n+1: Until your next turn, up to one target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost.\n\u22122: You may choose an artifact card you own from outside the game or in exile, reveal that card, and put it into your hand.",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "ba2d7f48-9846-5343-ae02-913b7e6a18d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b572739-0a10-4af0-9014-dd81b67b3dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b572739-0a10-4af0-9014-dd81b67b3dbb.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "",
             "colours": [],
@@ -72,7 +72,7 @@
         },
         {
             "id": "52b531a3-d0eb-58ee-af14-c69f6a05b327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b003521-3da3-41bf-9765-36630653f902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b003521-3da3-41bf-9765-36630653f902.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "Colorless spells you cast cost {2} less to cast.\n+1: Exile the top card of your library face down and look at it. Create a 2/2 colorless Spirit creature token. When that token leaves the battlefield, put the exiled card into your hand.\n\u22123: Destroy target permanent that's one or more colors.",
             "colours": [],
@@ -106,7 +106,7 @@
         },
         {
             "id": "2ab585b3-9529-55b0-8c89-782578877fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7f23ba-1a98-416a-ac97-3f15ed000c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7f23ba-1a98-416a-ac97-3f15ed000c60.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "",
             "colours": [],
@@ -140,7 +140,7 @@
         },
         {
             "id": "e796a3c2-b34f-5b13-888b-45ff0c94ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9957ecca-5ea0-446f-bfd3-46c2aaa42f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9957ecca-5ea0-446f-bfd3-46c2aaa42f08.jpg?1",
             "name": "Ugin's Conjurant",
             "text": "Ugin's Conjurant enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Ugin's Conjurant while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from Ugin's Conjurant.",
             "colours": [],
@@ -171,7 +171,7 @@
         },
         {
             "id": "d451691b-6cc7-5ea7-968b-2abae1beb622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3656310-093d-4724-a399-7f7010843b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3656310-093d-4724-a399-7f7010843b1f.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "470332c9-e7d4-5b11-b0ca-4c9f877f8e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8e970-b90c-4829-8970-0a3364027bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8e970-b90c-4829-8970-0a3364027bbb.jpg?1",
             "name": "Battlefield Promotion",
             "text": "Put a +1/+1 counter on target creature. That creature gains first strike until end of turn. You gain 2 life.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "50f8a302-b981-5940-823c-e5892ef630ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7c78bb-9f2a-47a4-adc4-b497bb38f46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7c78bb-9f2a-47a4-adc4-b497bb38f46f.jpg?1",
             "name": "Bond of Discipline",
             "text": "Tap all creatures your opponents control. Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -270,7 +270,7 @@
         },
         {
             "id": "4b60a0b8-ddee-5a88-a578-22fb009c117e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11510817-edb3-40d4-bd27-6161fedadd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11510817-edb3-40d4-bd27-6161fedadd11.jpg?1",
             "name": "Bulwark Giant",
             "text": "When Bulwark Giant enters the battlefield, you gain 5 life.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "4bae03de-a6cb-59a5-a470-b5a57c0e2f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357513b9-0505-4b67-9a29-36a705a175b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357513b9-0505-4b67-9a29-36a705a175b1.jpg?1",
             "name": "Charmed Stray",
             "text": "Lifelink\nWhen Charmed Stray enters the battlefield, put a +1/+1 counter on each other creature you control named Charmed Stray.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "fe669d77-6304-5ff9-a9cd-e0e2d23b8b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc183a40-7e15-40b1-9faa-b243401b3d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc183a40-7e15-40b1-9faa-b243401b3d10.jpg?1",
             "name": "Defiant Strike",
             "text": "Target creature gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "2cfc2f2d-d3a3-5875-b24a-102bd414bae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbb58a-1b00-4883-9b45-da7ded7317e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbb58a-1b00-4883-9b45-da7ded7317e3.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "01013cab-be73-532f-b6bf-0f24d0c3792f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d6d488-01df-4d61-92ff-9881838b4018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d6d488-01df-4d61-92ff-9881838b4018.jpg?1",
             "name": "Enforcer Griffin",
             "text": "Flying",
             "colours": [
@@ -437,7 +437,7 @@
         },
         {
             "id": "981628d3-14b8-55fe-b9b8-d6d2afd78bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccacb84-2b8e-40b8-8d53-d1b97bb2971f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccacb84-2b8e-40b8-8d53-d1b97bb2971f.jpg?1",
             "name": "Finale of Glory",
             "text": "Create X 2/2 white Soldier creature tokens with vigilance. If X is 10 or more, also create X 4/4 white Angel creature tokens with flying and vigilance.",
             "colours": [
@@ -469,7 +469,7 @@
         },
         {
             "id": "d6e42c74-0bb6-5036-a6a9-3746d7ed223c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d51c5e-26cb-4276-a676-fabfef866248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d51c5e-26cb-4276-a676-fabfef866248.jpg?1",
             "name": "Gideon Blackblade",
             "text": "As long as it's your turn, Gideon Blackblade is a 4/4 Human Soldier creature with indestructible that's still a planeswalker.\nPrevent all damage that would be dealt to Gideon Blackblade during your turn.\n+1: Up to one other target creature you control gains your choice of vigilance, lifelink, or indestructible until end of turn.\n\u22126: Exile target nonland permanent.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "2a56dbcf-d091-56cc-ac20-1f8ce7c7ec4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9581ba4-8b7a-410c-9a7d-d4a976880435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9581ba4-8b7a-410c-9a7d-d4a976880435.jpg?1",
             "name": "Gideon Blackblade",
             "text": "",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "5ec4ceb6-405c-559b-986e-fb76bfea5b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849c79ad-8bfc-4512-ab41-f213b6b285ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849c79ad-8bfc-4512-ab41-f213b6b285ab.jpg?1",
             "name": "Gideon's Sacrifice",
             "text": "Choose a creature or planeswalker you control. All damage that would be dealt this turn to you and permanents you control is dealt to the chosen permanent instead (if it's still on the battlefield).",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "a9183560-ed4a-5744-bcc0-2ca2b20d1487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6610c6a-717f-406e-a49d-b6e548880946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6610c6a-717f-406e-a49d-b6e548880946.jpg?1",
             "name": "Gideon's Triumph",
             "text": "Target opponent sacrifices a creature that attacked or blocked this turn. If you control a Gideon planeswalker, that player sacrifices two of those creatures instead.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "3712322d-1c14-5840-b9ce-c6e5949842ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70f155-2336-421c-8a9d-69772d2b51a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70f155-2336-421c-8a9d-69772d2b51a8.jpg?1",
             "name": "God-Eternal Oketra",
             "text": "Double strike\nWhenever you cast a creature spell, create a 4/4 black Zombie Warrior creature token with vigilance.\nWhen God-Eternal Oketra dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "7f3c0e8a-b5d1-53d9-bfd3-6c66968599f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcb1f9d-105d-48c6-bd66-d7e8839de9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcb1f9d-105d-48c6-bd66-d7e8839de9e1.jpg?1",
             "name": "Grateful Apparition",
             "text": "Flying\nWhenever Grateful Apparition deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "fb88ffcc-0821-5a08-80e7-3caeef0fc6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11d6f9-0b80-4b19-ab96-23f80b66b409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11d6f9-0b80-4b19-ab96-23f80b66b409.jpg?1",
             "name": "Ignite the Beacon",
             "text": "Search your library for up to two planeswalker cards, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "19f9723e-e36d-5df8-82ab-27f3a1e19453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb16895-6542-405e-9793-154ffc439f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb16895-6542-405e-9793-154ffc439f23.jpg?1",
             "name": "Ironclad Krovod",
             "text": "",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "44dcd2cf-ffac-5df5-9538-06a3ec158573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d39238-e21d-4345-84c8-648ef3a66703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d39238-e21d-4345-84c8-648ef3a66703.jpg?1",
             "name": "Law-Rune Enforcer",
             "text": "{1}, {T}: Tap target creature with converted mana cost 2 or greater.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "242791b2-926a-5865-b28f-66143021c5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57f873b-5fb2-4638-b66c-f6d1aec156ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57f873b-5fb2-4638-b66c-f6d1aec156ba.jpg?1",
             "name": "Loxodon Sergeant",
             "text": "Vigilance\nWhen Loxodon Sergeant enters the battlefield, other creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "d0192592-1b1a-5ee7-b5c8-291a71431618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82293d58-d3b4-4cf6-8a16-32ae3e509696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82293d58-d3b4-4cf6-8a16-32ae3e509696.jpg?1",
             "name": "Makeshift Battalion",
             "text": "Whenever Makeshift Battalion and at least two other creatures attack, put a +1/+1 counter on Makeshift Battalion.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "e306e8bc-7b20-5f95-b625-53a41a654b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbc8ca-a574-461e-92ea-c6010daa8230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbc8ca-a574-461e-92ea-c6010daa8230.jpg?1",
             "name": "Martyr for the Cause",
             "text": "When Martyr for the Cause dies, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "8e4d50a9-f385-570b-a73a-d7883284d42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ba80e-3aca-423e-a0b7-19c2d4b44dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ba80e-3aca-423e-a0b7-19c2d4b44dbf.jpg?1",
             "name": "Parhelion II",
             "text": "Flying, first strike, vigilance\nWhenever Parhelion II attacks, create two 4/4 white Angel creature tokens with flying and vigilance that are attacking.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "a9705de7-bdc9-5859-a738-d0d85c136684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9383956f-90bc-40e4-ae5c-503e98e21832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9383956f-90bc-40e4-ae5c-503e98e21832.jpg?1",
             "name": "Pouncing Lynx",
             "text": "As long as it's your turn, Pouncing Lynx has first strike.",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "35d1b37b-b29e-5bb7-b0b6-282284664c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476e8e5-2377-464b-b2d5-a3cd66ee2e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476e8e5-2377-464b-b2d5-a3cd66ee2e45.jpg?1",
             "name": "Prison Realm",
             "text": "When Prison Realm enters the battlefield, exile target creature or planeswalker an opponent controls until Prison Realm leaves the battlefield.\nWhen Prison Realm enters the battlefield, scry 1.",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "8681699e-1abb-5f39-a615-777eb2670653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f043642d-35fe-4ea9-a1d3-78ddfdddeaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f043642d-35fe-4ea9-a1d3-78ddfdddeaf4.jpg?1",
             "name": "Rally of Wings",
             "text": "Untap all creatures you control. Creatures you control with flying get +2/+2 until end of turn.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "6880451e-b6bb-5284-9974-fefd56bb0cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f83824-43c6-4101-88fd-9109958b23e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f83824-43c6-4101-88fd-9109958b23e2.jpg?1",
             "name": "Ravnica at War",
             "text": "Exile all multicolored permanents.",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "c203b669-c6e0-517c-a032-bde4aa972d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcacc28-aacf-4d40-b8cc-f8c028380340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcacc28-aacf-4d40-b8cc-f8c028380340.jpg?1",
             "name": "Rising Populace",
             "text": "Whenever another creature or planeswalker you control dies, put a +1/+1 counter on Rising Populace.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "9bf42aa4-962f-5269-aa17-af5866e0818b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e7c6a-e628-4327-a16f-2062c5a662df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e7c6a-e628-4327-a16f-2062c5a662df.jpg?1",
             "name": "Single Combat",
             "text": "Each player chooses a creature or planeswalker they control, then sacrifices the rest. Players can't cast creature or planeswalker spells until the end of your next turn.",
             "colours": [
@@ -1118,7 +1118,7 @@
         },
         {
             "id": "150f54d6-43b9-5b9a-9c1c-300b4d989f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211c0e1-b314-495f-9c43-9a0e95c9efb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211c0e1-b314-495f-9c43-9a0e95c9efb9.jpg?1",
             "name": "Sunblade Angel",
             "text": "Flying, first strike, vigilance, lifelink",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "5991b55d-ae2e-5ffc-8afd-5930507ddd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a974571c-d8d5-4860-9077-2023e5f32a24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a974571c-d8d5-4860-9077-2023e5f32a24.jpg?1",
             "name": "Teyo, the Shieldmage",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\n\u22122: Create a 0/3 white Wall creature token with defender.",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "2f4942dd-d6d7-5b79-8dd9-91c9cd0daf1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc3498-b837-4444-b388-2d11c883a08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc3498-b837-4444-b388-2d11c883a08a.jpg?1",
             "name": "Teyo, the Shieldmage",
             "text": "",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "5de7f2c0-626c-5c8e-8e25-705f9806c0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfffe235-98b1-43db-9461-1b2da5f0690e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfffe235-98b1-43db-9461-1b2da5f0690e.jpg?1",
             "name": "Teyo's Lightshield",
             "text": "When Teyo's Lightshield enters the battlefield, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "097cd96b-1043-5905-a227-1fa2e91cc59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346387c-2f13-472b-b5b1-968b490eb38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346387c-2f13-472b-b5b1-968b490eb38f.jpg?1",
             "name": "Tomik, Distinguished Advokist",
             "text": "Flying\nLands on the battlefield and land cards in graveyards can't be the targets of spells or abilities your opponents control.\nYour opponents can't play land cards from graveyards.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "b7e80a1e-1cd4-5bbb-aac2-03b95d44d624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2829fa40-92e4-4017-aacd-9d9feae04aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2829fa40-92e4-4017-aacd-9d9feae04aa2.jpg?1",
             "name": "Topple the Statue",
             "text": "Tap target permanent. If it's an artifact, destroy it.\nDraw a card.",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "349613bc-3594-564e-b95d-1ecaa92e6cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bbcaf5-80e9-43f2-b470-de6cbed6a95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bbcaf5-80e9-43f2-b470-de6cbed6a95a.jpg?1",
             "name": "Trusted Pegasus",
             "text": "Flying\nWhenever Trusted Pegasus attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "c1e62a67-65b3-5c9b-8045-94ae5bdbbfb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f0e463-9eed-4348-af7c-fde5f0d8188c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f0e463-9eed-4348-af7c-fde5f0d8188c.jpg?1",
             "name": "The Wanderer",
             "text": "Prevent all noncombat damage that would be dealt to you and other permanents you control.\n\u22122: Exile target creature with power 4 or greater.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "fc82e07b-fa39-56ec-8b31-3e5837753347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28037c63-67ec-4a57-9a8c-3ba88127a258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28037c63-67ec-4a57-9a8c-3ba88127a258.jpg?1",
             "name": "The Wanderer",
             "text": "",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "248cb87f-8fa4-5e2d-8ae9-fdb7ca09cb23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e1d63e-9692-4988-bda2-7c2c9b42217b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e1d63e-9692-4988-bda2-7c2c9b42217b.jpg?1",
             "name": "Wanderer's Strike",
             "text": "Exile target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "2e95c376-f7f2-5453-9092-3e9d9045ffa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ff7868-eeb9-4292-a2f4-cac18f9ba270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ff7868-eeb9-4292-a2f4-cac18f9ba270.jpg?1",
             "name": "War Screecher",
             "text": "Flying\n{5}{W}, {T}: Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "7b4e809a-ca53-5a72-a89a-81e2c665ebfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd5b0a1-104d-4e0f-82de-65487fbf01ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd5b0a1-104d-4e0f-82de-65487fbf01ff.jpg?1",
             "name": "Ashiok's Skulker",
             "text": "{3}{U}: Ashiok's Skulker can't be blocked this turn.",
             "colours": [
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "0aca5931-a2f4-5710-9087-ca9fdf1fea16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fbfe6-69bb-452a-be3c-b9c625e23193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fbfe6-69bb-452a-be3c-b9c625e23193.jpg?1",
             "name": "Augur of Bolas",
             "text": "When Augur of Bolas enters the battlefield, look at the top three cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1572,7 +1572,7 @@
         },
         {
             "id": "10d6434f-4d3e-5497-ab53-92018c1c8efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe479484-a827-4d3c-8e35-e905e4f6664a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe479484-a827-4d3c-8e35-e905e4f6664a.jpg?1",
             "name": "Aven Eternal",
             "text": "Flying\nWhen Aven Eternal enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "f578a3e3-fb93-53f3-bfa8-9ce139ac0643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648629af-e911-49e1-b564-c98f339b84a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648629af-e911-49e1-b564-c98f339b84a1.jpg?1",
             "name": "Bond of Insight",
             "text": "Each player puts the top four cards of their library into their graveyard. Return up to two instant and/or sorcery cards from your graveyard to your hand. Exile Bond of Insight.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "fac498b3-76a0-5fdb-8533-247b33457aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cef326-339c-49e5-9905-21a1603a46ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cef326-339c-49e5-9905-21a1603a46ae.jpg?1",
             "name": "Callous Dismissal",
             "text": "Return target nonland permanent to its owner's hand.\nAmass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "6be49a63-db65-5954-a5da-68bc29ede7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209d70a2-c8c1-4072-ab1f-57804b55a09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209d70a2-c8c1-4072-ab1f-57804b55a09a.jpg?1",
             "name": "Commence the Endgame",
             "text": "This spell can't be countered.\nDraw two cards, then amass X, where X is the number of cards in your hand. (Put X +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "ae99fe47-f3b6-54b9-a206-1081e18779cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e30deb6-9e1f-4545-ae30-c30ba6c7b3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e30deb6-9e1f-4545-ae30-c30ba6c7b3a0.jpg?1",
             "name": "Contentious Plan",
             "text": "Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nDraw a card.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "46bd1799-9a0a-5fd1-93d6-708a585dc71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c70f23-0ca9-425e-a53a-6c09921c0075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c70f23-0ca9-425e-a53a-6c09921c0075.jpg?1",
             "name": "Crush Dissent",
             "text": "Counter target spell unless its controller pays {2}.\nAmass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "cadda636-34e1-5556-a9fb-ac9f76ead093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03188bc3-0ef1-40cd-9c3c-4bb4d806fb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03188bc3-0ef1-40cd-9c3c-4bb4d806fb92.jpg?1",
             "name": "Erratic Visionary",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "6526da20-d411-520b-863d-64604f79b30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aacfc9-1d45-4250-9abc-698d8941699f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aacfc9-1d45-4250-9abc-698d8941699f.jpg?1",
             "name": "Eternal Skylord",
             "text": "When Eternal Skylord enters the battlefield, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have flying.",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "ccefb41c-79d7-5103-866b-6ec1116a0719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52558748-6893-4c72-a9e2-e87d31796b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52558748-6893-4c72-a9e2-e87d31796b59.jpg?1",
             "name": "Fblthp, the Lost",
             "text": "When Fblthp, the Lost enters the battlefield, draw a card. If it entered from your library or was cast from your library, draw two cards instead.\nWhen Fblthp becomes the target of a spell, shuffle Fblthp into its owner's library.",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "aaa8f0c2-5bd4-567a-96fc-36a6bbae6e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6630c34a-1a97-4e31-9d2c-1150b0aa903e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6630c34a-1a97-4e31-9d2c-1150b0aa903e.jpg?1",
             "name": "Finale of Revelation",
             "text": "Draw X cards. If X is 10 or more, instead shuffle your graveyard into your library, draw X cards, untap up to five lands, and you have no maximum hand size for the rest of the game.\nExile Finale of Revelation.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "62322fa3-842a-5665-a121-a21340b70710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202e82-e159-482f-9224-292cb533171c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202e82-e159-482f-9224-292cb533171c.jpg?1",
             "name": "Flux Channeler",
             "text": "Whenever you cast a noncreature spell, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "14bde121-71a2-5ea9-8145-6022b329c24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14060f-9167-4e28-a053-77689e066e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14060f-9167-4e28-a053-77689e066e30.jpg?1",
             "name": "God-Eternal Kefnet",
             "text": "Flying\nYou may reveal the first card you draw each turn as you draw it. Whenever you reveal an instant or sorcery card this way, copy that card and you may cast the copy. That copy costs {2} less to cast.\nWhen God-Eternal Kefnet dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -1978,7 +1978,7 @@
         },
         {
             "id": "de19d916-8688-5083-9608-5f09f09be8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb7d73-4482-4930-8497-cffd169b57e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb7d73-4482-4930-8497-cffd169b57e2.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.\n+1: Target player puts the top two cards of their library into their graveyard. Draw a card.\n\u22128: Draw seven cards. Then if your library has no cards in it, you win the game.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "6c88eb11-319a-5061-befd-1073c165e603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50eb8cf-dc8d-4c7e-bff7-db9254ff8a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50eb8cf-dc8d-4c7e-bff7-db9254ff8a90.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "a1d983f9-e380-5457-bb91-a5fdd8426a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4924f177-5ee2-4d3f-9603-4b9aef4dac09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4924f177-5ee2-4d3f-9603-4b9aef4dac09.jpg?1",
             "name": "Jace's Triumph",
             "text": "Draw two cards. If you control a Jace planeswalker, draw three cards instead.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "0fe56d65-a3e6-559c-8c89-068f4694d32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77d9454-a78c-4063-ad66-46b2f5a030aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77d9454-a78c-4063-ad66-46b2f5a030aa.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "Spells your opponents cast that target a creature or planeswalker you control cost {2} more to cast.\n\u22122: Create a 2/2 blue Wizard creature token. Draw a card, then discard a card.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "a2a8ab63-1d7a-5c6c-aef5-2ff698b4e4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac128e-5784-467c-85ed-e46c6ab25547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac128e-5784-467c-85ed-e46c6ab25547.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "9197605c-a8cd-59f3-9ec4-8ee58a904e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9771412-695a-4e89-b146-0e3a7336d319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9771412-695a-4e89-b146-0e3a7336d319.jpg?1",
             "name": "Kasmina's Transmutation",
             "text": "Enchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "0d49a203-86df-536e-abdd-38193187f5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd61fb0-a82b-4f46-8043-c6b89764720b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd61fb0-a82b-4f46-8043-c6b89764720b.jpg?1",
             "name": "Kiora's Dambreaker",
             "text": "When Kiora's Dambreaker enters the battlefield, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "bd1e3301-e099-5695-928f-76c8b06db444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03b5405-6016-405b-a504-a454731b9276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03b5405-6016-405b-a504-a454731b9276.jpg?1",
             "name": "Lazotep Plating",
             "text": "Amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nYou and permanents you control gain hexproof until end of turn. (You and they can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "557e146d-0f14-54b2-8cb8-f202621c56c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f244233-f2e8-48f8-9106-e7cd186efd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f244233-f2e8-48f8-9106-e7cd186efd51.jpg?1",
             "name": "Naga Eternal",
             "text": "",
             "colours": [
@@ -2297,7 +2297,7 @@
         },
         {
             "id": "4fa9e9f5-c36f-507e-abbb-0c90f4fd8772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c39f9b4-02b9-4d44-b8d6-4fd02ebbb0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c39f9b4-02b9-4d44-b8d6-4fd02ebbb0c5.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "Each opponent can't draw more than one card each turn.\n\u22122: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "ee637963-2d06-5ab7-9678-a3428c4ce419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078151b-74b7-426a-9ee5-d83799ca2b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078151b-74b7-426a-9ee5-d83799ca2b85.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -2373,7 +2373,7 @@
         },
         {
             "id": "bc654c56-bae4-5998-9c1d-ec43537eed6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63754036-d51e-47bb-925b-564d9dc922ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63754036-d51e-47bb-925b-564d9dc922ff.jpg?1",
             "name": "Narset's Reversal",
             "text": "Copy target instant or sorcery spell, then return it to its owner's hand. You may choose new targets for the copy.",
             "colours": [
@@ -2405,7 +2405,7 @@
         },
         {
             "id": "61fa7145-af2b-59a2-92dd-48d19be60152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9888a1-6f35-4802-b8fb-902017736d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9888a1-6f35-4802-b8fb-902017736d4a.jpg?1",
             "name": "No Escape",
             "text": "Counter target creature or planeswalker spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.\nScry 1.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "0abe85a1-668c-50cd-a669-1453d00c2f33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258e242-91c6-4b30-86ec-7759705aa97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258e242-91c6-4b30-86ec-7759705aa97c.jpg?1",
             "name": "Relentless Advance",
             "text": "Amass 3. (Put three +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "1c659d00-2878-587f-9347-64a900ca1440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ba9fa2-bfd2-4dc7-b96d-d22a8886a6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ba9fa2-bfd2-4dc7-b96d-d22a8886a6ae.jpg?1",
             "name": "Rescuer Sphinx",
             "text": "Flying\nAs Rescuer Sphinx enters the battlefield, you may return a nonland permanent you control to its owner's hand. If you do, Rescuer Sphinx enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "05444e76-0331-53d6-a734-12eaee10b5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2f3dee-1768-4562-9333-a50b9ee7570f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2f3dee-1768-4562-9333-a50b9ee7570f.jpg?1",
             "name": "Silent Submersible",
             "text": "Whenever Silent Submersible deals combat damage to a player or planeswalker, draw a card.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "1c74cb7d-39f3-527a-b3d1-9dea4a7287ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98902dd9-f21c-4419-8205-4b9d6592bf28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98902dd9-f21c-4419-8205-4b9d6592bf28.jpg?1",
             "name": "Sky Theater Strix",
             "text": "Flying\nWhenever you cast a noncreature spell, Sky Theater Strix gets +1/+0 until end of turn.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "2411ffb6-b1ef-52c5-865e-c87e30460d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8a103c-b776-4501-9441-a45b90391045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8a103c-b776-4501-9441-a45b90391045.jpg?1",
             "name": "Spark Double",
             "text": "You may have Spark Double enter the battlefield as a copy of a creature or planeswalker you control, except it enters with an additional +1/+1 counter on it if it's a creature, it enters with an additional loyalty counter on it if it's a planeswalker, and it isn't legendary if that permanent is legendary.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "93487570-31c1-5213-91a0-fdce2928e9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e42dad-5958-443f-a196-12b3f3e44213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e42dad-5958-443f-a196-12b3f3e44213.jpg?1",
             "name": "Spellkeeper Weird",
             "text": "{2}, {T}, Sacrifice Spellkeeper Weird: Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "4a99f85f-5d1f-5870-b5a0-2eccb277f384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfd4f5-7fe1-4a22-9a85-bd9b75b16380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfd4f5-7fe1-4a22-9a85-bd9b75b16380.jpg?1",
             "name": "Stealth Mission",
             "text": "Put two +1/+1 counters on target creature you control. That creature can't be blocked this turn.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "b42398ff-b92c-5eec-8fb2-7e0e5e40ec3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce338cf3-46dc-4c87-8df5-af27097c7dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce338cf3-46dc-4c87-8df5-af27097c7dd4.jpg?1",
             "name": "Tamiyo's Epiphany",
             "text": "Scry 4, then draw two cards.",
             "colours": [
@@ -2703,7 +2703,7 @@
         },
         {
             "id": "eb459f4b-50c6-5a93-a773-1f88d168d971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c878bdc0-d697-4a2f-bba5-758b27f4247a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c878bdc0-d697-4a2f-bba5-758b27f4247a.jpg?1",
             "name": "Teferi's Time Twist",
             "text": "Exile target permanent you control. Return that card to the battlefield under its owner's control at the beginning of the next end step. If it enters the battlefield as a creature, it enters with an additional +1/+1 counter on it.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "f5014458-218e-5625-bbbc-f1895a9509e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a9bc4-1b15-4a91-9376-730d2f5b3336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a9bc4-1b15-4a91-9376-730d2f5b3336.jpg?1",
             "name": "Thunder Drake",
             "text": "Flying\nWhenever you cast your second spell each turn, put a +1/+1 counter on Thunder Drake.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "08f8bb29-6091-50d2-afab-6b80087ce067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffef78-f776-42d3-ab40-3347c8e5c88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffef78-f776-42d3-ab40-3347c8e5c88b.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "7610bd8e-d995-51a9-a46a-6e295f9488a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96613089-3508-429a-9f90-23168d56bbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96613089-3508-429a-9f90-23168d56bbe7.jpg?1",
             "name": "Wall of Runes",
             "text": "Defender\nWhen Wall of Runes enters the battlefield, scry 1.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "d11acd0d-21cc-5dbb-bbe8-2603146a20ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bc010-f1af-42a2-9009-2039cf3d8f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bc010-f1af-42a2-9009-2039cf3d8f0a.jpg?1",
             "name": "Aid the Fallen",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return target planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "fc0f3291-22a4-58e5-b03e-b971c5403c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e03567-c95a-40b8-a75a-971076093f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e03567-c95a-40b8-a75a-971076093f57.jpg?1",
             "name": "Banehound",
             "text": "Lifelink, haste",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "bed79a7b-995f-5103-8b6f-d626053b4203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82422c-8ac8-4fbb-b9b9-d0aa23dded61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82422c-8ac8-4fbb-b9b9-d0aa23dded61.jpg?1",
             "name": "Bleeding Edge",
             "text": "Up to one target creature gets -2/-2 until end of turn. Amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "4ae50b85-70ab-5cc3-b836-dd273375f5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2124603-d20e-40eb-97f0-a66323397ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2124603-d20e-40eb-97f0-a66323397ac2.jpg?1",
             "name": "Bolas's Citadel",
             "text": "You may look at the top card of your library any time.\nYou may play the top card of your library. If you cast a spell this way, pay life equal to its converted mana cost rather than pay its mana cost.\n{T}, Sacrifice ten nonland permanents: Each opponent loses 10 life.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "56a30d0f-fb9d-554f-bbab-61c863e41169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6482fb9-f874-4e33-aa74-7a0da4c9760c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6482fb9-f874-4e33-aa74-7a0da4c9760c.jpg?1",
             "name": "Bond of Revival",
             "text": "Return target creature card from your graveyard to the battlefield. It gains haste until your next turn.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "5f61c1b9-63ad-5a82-9438-360edd6eea85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3594f726-cdbb-4b7d-bcfe-17d5f8cd5228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3594f726-cdbb-4b7d-bcfe-17d5f8cd5228.jpg?1",
             "name": "Charity Extractor",
             "text": "Lifelink",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "b132e71e-617c-5a0d-acef-c27efce402ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ec307-45e0-4853-85fe-9ce859b188c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ec307-45e0-4853-85fe-9ce859b188c2.jpg?1",
             "name": "Command the Dreadhorde",
             "text": "Choose any number of target creature and/or planeswalker cards in graveyards. Command the Dreadhorde deals damage to you equal to the total converted mana cost of those cards. Put them onto the battlefield under your control.",
             "colours": [
@@ -3068,7 +3068,7 @@
         },
         {
             "id": "450bcf93-03fd-59f8-a8ed-1ac506f2786c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a44f0-1db8-406a-b7d9-f883f947f7bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a44f0-1db8-406a-b7d9-f883f947f7bd.jpg?1",
             "name": "Davriel, Rogue Shadowmage",
             "text": "At the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, Davriel, Rogue Shadowmage deals 2 damage to them.\n\u22121: Target player discards a card.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "e514382a-9f86-5af0-bcdd-623eb2da60ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce03906-fef8-4636-945c-95b857cbeab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce03906-fef8-4636-945c-95b857cbeab0.jpg?1",
             "name": "Davriel, Rogue Shadowmage",
             "text": "",
             "colours": [
@@ -3144,7 +3144,7 @@
         },
         {
             "id": "1fb4ee52-0ee4-5117-bf54-538f17eb9822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8fe63-37a7-478d-b9ba-33a0f6519cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8fe63-37a7-478d-b9ba-33a0f6519cf1.jpg?1",
             "name": "Davriel's Shadowfugue",
             "text": "Target player discards two cards and loses 2 life.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "b7c73fc0-f175-57df-9b59-01dfd2ec8e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aa7104-7acc-4827-b763-ac053c99baab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aa7104-7acc-4827-b763-ac053c99baab.jpg?1",
             "name": "Deliver Unto Evil",
             "text": "Choose up to four target cards in your graveyard. If you control a Bolas planeswalker, return those cards to your hand. Otherwise, an opponent chooses two of them. Leave the chosen cards in your graveyard and put the rest into your hand.\nExile Deliver Unto Evil.",
             "colours": [
@@ -3208,7 +3208,7 @@
         },
         {
             "id": "5589028d-25c2-556b-9aa5-dff384ae6200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c6e42d-991d-4e6b-a900-38480931f79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c6e42d-991d-4e6b-a900-38480931f79e.jpg?1",
             "name": "Dreadhorde Invasion",
             "text": "At the beginning of your upkeep, you lose 1 life and amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nWhenever a Zombie token you control with power 6 or greater attacks, it gains lifelink until end of turn.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "0736085a-62ee-58bf-aa23-fef2afef4e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327cfac-a4a4-445e-9d04-51c1ca142140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327cfac-a4a4-445e-9d04-51c1ca142140.jpg?1",
             "name": "Dreadmalkin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{2}{B}, Sacrifice another creature or planeswalker: Put two +1/+1 counters on Dreadmalkin.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "73e28193-a44b-5c38-bb10-82e832bec6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16eb5a6b-5e69-497c-a0c9-4165ad0f5d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16eb5a6b-5e69-497c-a0c9-4165ad0f5d0b.jpg?1",
             "name": "Duskmantle Operative",
             "text": "Duskmantle Operative can't be blocked by creatures with power 4 or greater.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "be75eb27-bb09-589b-8115-102852c8baf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b16625-7faf-4de6-abf7-d397988e32fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b16625-7faf-4de6-abf7-d397988e32fb.jpg?1",
             "name": "The Elderspell",
             "text": "Destroy any number of target planeswalkers. Choose a planeswalker you control. Put two loyalty counters on it for each planeswalker destroyed this way.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "71b101c1-e8cf-5f25-93b3-534bb11f285b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7789188e-5caa-4500-b3e4-bb95f7657903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7789188e-5caa-4500-b3e4-bb95f7657903.jpg?1",
             "name": "Eternal Taskmaster",
             "text": "Eternal Taskmaster enters the battlefield tapped.\nWhenever Eternal Taskmaster attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "3e448b1f-26b7-54e4-b0e2-ba9555b19d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c60177-8b71-4e24-87e7-395d5e4f93ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c60177-8b71-4e24-87e7-395d5e4f93ff.jpg?1",
             "name": "Finale of Eternity",
             "text": "Destroy up to three target creatures with toughness X or less. If X is 10 or more, return all creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "7877d2ca-9220-5e0d-840e-68c6b5975b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714a135-e2b9-43a7-a2a2-fa5a2e0ac61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714a135-e2b9-43a7-a2a2-fa5a2e0ac61a.jpg?1",
             "name": "God-Eternal Bontu",
             "text": "Menace\nWhen God-Eternal Bontu enters the battlefield, sacrifice any number of other permanents, then draw that many cards.\nWhen God-Eternal Bontu dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "d2b2455f-2026-5384-875b-8958d85207a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae9cb7-a3af-4224-89a5-a72f4d09dacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae9cb7-a3af-4224-89a5-a72f4d09dacf.jpg?1",
             "name": "Herald of the Dreadhorde",
             "text": "When Herald of the Dreadhorde dies, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "315620f5-2920-574f-b428-feafdf9e885b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f3be88-24e2-433f-9138-f0cb59d09a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f3be88-24e2-433f-9138-f0cb59d09a0f.jpg?1",
             "name": "Kaya's Ghostform",
             "text": "Enchant creature or planeswalker you control\nWhen enchanted permanent dies or is put into exile, return that card to the battlefield under your control.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "793a2190-c40b-5ee8-8736-d03a778e1e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be6f22-e9e8-462a-956b-e1c78bbadacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be6f22-e9e8-462a-956b-e1c78bbadacc.jpg?1",
             "name": "Lazotep Behemoth",
             "text": "",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "17a987be-195f-58a4-8e0f-a8d1979d0337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594bbe43-a8aa-42aa-bc49-cb4f3bc05cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594bbe43-a8aa-42aa-bc49-cb4f3bc05cad.jpg?1",
             "name": "Lazotep Reaver",
             "text": "When Lazotep Reaver enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "8f8ae2ff-0bcc-575d-bb3e-4f26b0bc7b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75ebba8-34ca-47a0-bf13-8318ad73b343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75ebba8-34ca-47a0-bf13-8318ad73b343.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "09683aa4-d39d-518d-8e22-d13c129f3ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e3667-33be-415f-8f10-1c42a78d7637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e3667-33be-415f-8f10-1c42a78d7637.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "88b9bd21-a393-5aa8-bc37-3c2a4ec676d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84803db8-fdb0-462b-92f6-33d591593d2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84803db8-fdb0-462b-92f6-33d591593d2d.jpg?1",
             "name": "Liliana's Triumph",
             "text": "Each opponent sacrifices a creature. If you control a Liliana planeswalker, each opponent also discards a card.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "0092adb5-ab0a-5315-baa0-c389c994f52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8ec9e1-2c8e-496d-9111-4d453b75b578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8ec9e1-2c8e-496d-9111-4d453b75b578.jpg?1",
             "name": "Massacre Girl",
             "text": "Menace\nWhen Massacre Girl enters the battlefield, each other creature gets -1/-1 until end of turn. Whenever a creature dies this turn, each creature other than Massacre Girl gets -1/-1 until end of turn.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "745de871-6f1e-5f41-95ca-069289359d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14916e2d-73af-4747-a927-d2d4cb3e32db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14916e2d-73af-4747-a927-d2d4cb3e32db.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "Whenever an opponent draws a card, Ob Nixilis, the Hate-Twisted deals 1 damage to that player.\n\u22122: Destroy target creature. Its controller draws two cards.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "9ee15cd2-7dc1-5db7-b6d6-81aed4a84db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b67ca03-f759-4d7c-8527-7a569e7bfad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b67ca03-f759-4d7c-8527-7a569e7bfad1.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "4310b589-7fd2-597e-bdd4-1be54c5af6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db72a8-57f7-4f17-9f09-cae90ef50304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db72a8-57f7-4f17-9f09-cae90ef50304.jpg?1",
             "name": "Ob Nixilis's Cruelty",
             "text": "Target creature gets -5/-5 until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "0cc0f683-bb90-56ca-a34a-4f47eeba1bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd68e918-5089-46c9-8836-b05a3da3c7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd68e918-5089-46c9-8836-b05a3da3c7a3.jpg?1",
             "name": "Price of Betrayal",
             "text": "Remove up to five counters from target artifact, creature, planeswalker, or opponent.",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "a370d47d-42a3-546f-b2bc-743d0cef6035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1c3148-7a6f-4963-af0b-18d9a156bf22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1c3148-7a6f-4963-af0b-18d9a156bf22.jpg?1",
             "name": "Shriekdiver",
             "text": "Flying\n{1}: Shriekdiver gains haste until end of turn.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "49c8722b-11e4-5007-a871-a88e56ea1bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eecfc2-452d-461c-a37c-8aa10183e5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eecfc2-452d-461c-a37c-8aa10183e5a0.jpg?1",
             "name": "Sorin's Thirst",
             "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "89ba71fa-c8c6-55f3-a1df-138cbd5a4319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013a138-f8e2-4a67-91e8-759288d985a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013a138-f8e2-4a67-91e8-759288d985a7.jpg?1",
             "name": "Spark Harvest",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "50350615-04ba-5d26-aaff-578314d2d25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922537f0-4caf-481c-b431-826f0c44e5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922537f0-4caf-481c-b431-826f0c44e5c5.jpg?1",
             "name": "Spark Reaper",
             "text": "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card.",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "79e7cdeb-5d82-53e4-888b-afd2173658cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c305ccb-62f5-496a-a205-e818e34ead82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c305ccb-62f5-496a-a205-e818e34ead82.jpg?1",
             "name": "Tithebearer Giant",
             "text": "When Tithebearer Giant enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "cb61867b-e6af-5d15-aed9-5200e89ea040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471c2a5-aa2c-47e2-8238-1eb366c8adc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471c2a5-aa2c-47e2-8238-1eb366c8adc9.jpg?1",
             "name": "Toll of the Invasion",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nAmass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "1d18dedb-2446-5b68-965c-fc5a7ec53c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c260c5c-e796-4f81-9e15-0c5be75106b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c260c5c-e796-4f81-9e15-0c5be75106b9.jpg?1",
             "name": "Unlikely Aid",
             "text": "Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and  effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "349a59bc-cc3e-5402-b2a5-6e30442befe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf21a4-616d-48a5-a104-180c24491761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf21a4-616d-48a5-a104-180c24491761.jpg?1",
             "name": "Vampire Opportunist",
             "text": "{6}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "077ea8a8-24b7-575b-9c34-ba7f54fb5099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2444c7dc-7aa1-4476-8660-19d26607306d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2444c7dc-7aa1-4476-8660-19d26607306d.jpg?1",
             "name": "Vizier of the Scorpion",
             "text": "When Vizier of the Scorpion enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have deathtouch.",
             "colours": [
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "ce6a2697-5f3a-5857-ab1b-ac015d9f32f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89fa379-7fae-4fbf-8e31-0ef3645353c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89fa379-7fae-4fbf-8e31-0ef3645353c5.jpg?1",
             "name": "Vraska's Finisher",
             "text": "When Vraska's Finisher enters the battlefield, destroy target creature or planeswalker an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "40d6739e-7d71-559a-8756-35d42dcac450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dea2466-5c7f-40ce-b749-100ae89d2c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dea2466-5c7f-40ce-b749-100ae89d2c90.jpg?1",
             "name": "Ahn-Crop Invader",
             "text": "As long as it's your turn, Ahn-Crop Invader has first strike.\n{1}, Sacrifice another creature: Ahn-Crop Invader gets +2/+0 until end of turn.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "19827ebf-3b49-5021-ac7f-f6c125a3bdd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d49637b-2255-4f16-8f24-140145966bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d49637b-2255-4f16-8f24-140145966bfa.jpg?1",
             "name": "Blindblast",
             "text": "Blindblast deals 1 damage to target creature. That creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "5af182ba-dc7c-5177-961e-bcc07ee1f180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b35408-3728-4e1b-9f58-b0775df914d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b35408-3728-4e1b-9f58-b0775df914d6.jpg?1",
             "name": "Bolt Bend",
             "text": "This spell costs {3} less to cast if you control a creature with power 4 or greater.\nChange the target of target spell or ability with a single target.",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "cb422986-4248-54ca-8a3a-d5e842ecd0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae644e9d-9bc4-4ccd-aef4-3d0559948aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae644e9d-9bc4-4ccd-aef4-3d0559948aa6.jpg?1",
             "name": "Bond of Passion",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Bond of Passion deals 2 damage to any other target.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "42909c0b-ed28-5e9f-abe2-d8abc284f7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5b095-13c9-4673-bf0c-553de455e521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5b095-13c9-4673-bf0c-553de455e521.jpg?1",
             "name": "Burning Prophet",
             "text": "Whenever you cast a noncreature spell, Burning Prophet gets +1/+0 until end of turn, then scry 1.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "e2b23487-2a53-5b2d-a4f7-ca6a487fc388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f18df2-5910-4c5d-8b04-6fe5d04e8150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f18df2-5910-4c5d-8b04-6fe5d04e8150.jpg?1",
             "name": "Chainwhip Cyclops",
             "text": "{3}{R}: Target creature can't block this turn.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "638fe5e4-2dbe-5aee-9f9a-f7b47ee3275a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21a7b23-8827-49f2-ade4-75a602d17743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21a7b23-8827-49f2-ade4-75a602d17743.jpg?1",
             "name": "Chandra, Fire Artisan",
             "text": "Whenever one or more loyalty counters are removed from Chandra, Fire Artisan, she deals that much damage to target opponent or planeswalker.\n+1: Exile the top card of your library. You may play it this turn.\n\u22127: Exile the top seven cards of your library. You may play them this turn.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "29741223-18c8-5ad7-b1fc-0b9a68dbd768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b129f92-e6c4-4967-bd0c-02ff85f09636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b129f92-e6c4-4967-bd0c-02ff85f09636.jpg?1",
             "name": "Chandra, Fire Artisan",
             "text": "",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "4c926dd3-a5d5-5fa3-80b0-c0f61110ea7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c482f51-9222-4e9e-a9fd-bb14a0afe156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c482f51-9222-4e9e-a9fd-bb14a0afe156.jpg?1",
             "name": "Chandra's Pyrohelix",
             "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -4516,7 +4516,7 @@
         },
         {
             "id": "176681b6-28dd-5e3c-b5dc-02e8b9117371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f43c17-7022-4052-86b8-90b74382b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f43c17-7022-4052-86b8-90b74382b7bf.jpg?1",
             "name": "Chandra's Triumph",
             "text": "Chandra's Triumph deals 3 damage to target creature or planeswalker an opponent controls. Chandra's Triumph deals 5 damage to that permanent instead if you control a Chandra planeswalker.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "eb8d5ba3-3eb1-5a20-8451-2d52fb4d3353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0966a6-f378-4975-88ae-23b600d578bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0966a6-f378-4975-88ae-23b600d578bf.jpg?1",
             "name": "Cyclops Electromancer",
             "text": "When Cyclops Electromancer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "483cf41b-2659-5bee-a737-5f70b394bdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00211dd-6dd7-40d9-80f3-f909f6d112db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00211dd-6dd7-40d9-80f3-f909f6d112db.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "f92874f5-a27c-5f8e-951b-5b21af4ab78b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88205574-bf2b-46e7-aac7-4b8ea217f94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88205574-bf2b-46e7-aac7-4b8ea217f94c.jpg?1",
             "name": "Devouring Hellion",
             "text": "As Devouring Hellion enters the battlefield, you may sacrifice any number of creatures and/or planeswalkers. If you do, it enters with twice that many +1/+1 counters on it.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "f9c065dc-1677-52a6-891c-0130e443c624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97b3cf-924e-4f77-bb82-0bf19592389f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97b3cf-924e-4f77-bb82-0bf19592389f.jpg?1",
             "name": "Dreadhorde Arcanist",
             "text": "Trample\nWhenever Dreadhorde Arcanist attacks, you may cast target instant or sorcery card with converted mana cost less than or equal to Dreadhorde Arcanist's power from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "7db415c9-fd0a-509b-a5a8-44da6b18e496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82017bf6-352f-4e81-8fd5-c1b0daf05b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82017bf6-352f-4e81-8fd5-c1b0daf05b01.jpg?1",
             "name": "Dreadhorde Twins",
             "text": "When Dreadhorde Twins enters the battlefield, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have trample.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "6f6fdec6-cbe0-594b-bd8f-582ff3a14aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b2dda-e1b7-4a46-83cc-5cdc17554836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b2dda-e1b7-4a46-83cc-5cdc17554836.jpg?1",
             "name": "Finale of Promise",
             "text": "You may cast up to one target instant card and/or up to one target sorcery card from your graveyard each with converted mana cost X or less without paying their mana costs. If a card cast this way would be put into your graveyard this turn, exile it instead. If X is 10 or more, copy each of those spells twice. You may choose new targets for the copies.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "249cf960-24ec-5fca-9a48-fe636c2e51ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41acc81-7c22-4b59-97b8-54473623db6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41acc81-7c22-4b59-97b8-54473623db6f.jpg?1",
             "name": "Goblin Assailant",
             "text": "",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "fd401566-339d-5cb8-aa09-7a4b47f60c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880047fd-d258-40fb-bcd5-37cb26678dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880047fd-d258-40fb-bcd5-37cb26678dfe.jpg?1",
             "name": "Goblin Assault Team",
             "text": "Haste\nWhen Goblin Assault Team dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "c062dba2-9085-5a97-803d-5529a4b11a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b6ec9d-3861-48bf-a198-dc7efba5d89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b6ec9d-3861-48bf-a198-dc7efba5d89c.jpg?1",
             "name": "Grim Initiate",
             "text": "First strike\nWhen Grim Initiate dies, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4857,7 +4857,7 @@
         },
         {
             "id": "da9c6cbe-b7c9-502d-a3d9-9b26b30b5279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db219ea-2ed1-4a86-955c-d61ecedbc019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db219ea-2ed1-4a86-955c-d61ecedbc019.jpg?1",
             "name": "Heartfire",
             "text": "As an additional cost to cast this spell, sacrifice a creature or planeswalker.\nHeartfire deals 4 damage to any target.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "39c545fc-99ba-5d4b-b11a-346639422041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75844d13-74f5-4008-9bc6-2f6d04f378aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75844d13-74f5-4008-9bc6-2f6d04f378aa.jpg?1",
             "name": "Honor the God-Pharaoh",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards. Amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "055930a7-4004-551d-82f0-60686ba51ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0109b60-09aa-4a03-92e7-0c651d976d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0109b60-09aa-4a03-92e7-0c651d976d51.jpg?1",
             "name": "Ilharg, the Raze-Boar",
             "text": "Trample\nWhenever Ilharg, the Raze-Boar attacks, you may put a creature card from your hand onto the battlefield tapped and attacking. Return that creature to your hand at the beginning of the next end step.\nWhen Ilharg, the Raze-Boar dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "f689a73c-545b-59a0-b9cd-389445c8a848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e408b-f052-451c-9bf9-ac6f98753a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e408b-f052-451c-9bf9-ac6f98753a9d.jpg?1",
             "name": "Invading Manticore",
             "text": "When Invading Manticore enters the battlefield, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "79c77484-155c-5e8f-88b5-ba8912ab5b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129dc8a8-9fbc-4300-b559-243395dc6ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129dc8a8-9fbc-4300-b559-243395dc6ed5.jpg?1",
             "name": "Jaya, Venerated Firemage",
             "text": "If another red source you control would deal damage to a permanent or player, it deals that much damage plus 1 to that permanent or player instead.\n\u22122: Jaya, Venerated Firemage deals 2 damage to any target.",
             "colours": [
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "2896c920-1b81-526a-b211-a931ba0f4a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd5ff8-0591-4e58-aae1-4f441750518d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd5ff8-0591-4e58-aae1-4f441750518d.jpg?1",
             "name": "Jaya, Venerated Firemage",
             "text": "",
             "colours": [
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "41d8d564-27fa-5ea0-8131-b51d2d26a39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66f169-5cf9-4d7c-a5ab-c64fc4801358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66f169-5cf9-4d7c-a5ab-c64fc4801358.jpg?1",
             "name": "Jaya's Greeting",
             "text": "Jaya's Greeting deals 3 damage to target creature. Scry 1.",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "df73e10a-6b0b-5b2e-9ed9-2a9d3bcb936e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ed04d3-cfa1-4778-aea6-b4c2c29e6e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ed04d3-cfa1-4778-aea6-b4c2c29e6e0a.jpg?1",
             "name": "Krenko, Tin Street Kingpin",
             "text": "Whenever Krenko, Tin Street Kingpin attacks, put a +1/+1 counter on it, then create a number of 1/1 red Goblin creature tokens equal to Krenko's power.",
             "colours": [
@@ -5137,7 +5137,7 @@
         },
         {
             "id": "69ce976f-1371-5256-9f61-1b0345f9137f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5643253b-0996-45a8-9488-5bcc9192f867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5643253b-0996-45a8-9488-5bcc9192f867.jpg?1",
             "name": "Mizzium Tank",
             "text": "Trample\nWhenever you cast a noncreature spell, Mizzium Tank becomes an artifact creature and gets +1/+1 until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "9b55ced1-064b-593d-a8bb-c1317291b08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14331e-8da5-4455-ac69-e510684e989c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14331e-8da5-4455-ac69-e510684e989c.jpg?1",
             "name": "Nahiri's Stoneblades",
             "text": "Up to two target creatures each get +2/+0 until end of turn.",
             "colours": [
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "f7cb76de-5710-5b2c-b6e1-5abf4d88b55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c90d5d-7b3b-48d2-85f6-d6a2a452c0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c90d5d-7b3b-48d2-85f6-d6a2a452c0e9.jpg?1",
             "name": "Neheb, Dreadhorde Champion",
             "text": "Trample\nWhenever Neheb, Dreadhorde Champion deals combat damage to a player or planeswalker, you may discard any number of cards. If you do, draw that many cards and add that much {R}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "38d1637f-7c7e-555d-b059-a740f3350962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae38aa2d-6c0e-409a-bfc7-ed4281457670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae38aa2d-6c0e-409a-bfc7-ed4281457670.jpg?1",
             "name": "Raging Kronch",
             "text": "Raging Kronch can't attack alone.",
             "colours": [
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "6f16a789-102e-553d-a5ed-3fbe5d3fdf93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bda699-2b5d-4f5b-bee5-792b99d2b64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bda699-2b5d-4f5b-bee5-792b99d2b64a.jpg?1",
             "name": "Samut's Sprint",
             "text": "Target creature gets +2/+1 and gains haste until end of turn. Scry 1.",
             "colours": [
@@ -5307,7 +5307,7 @@
         },
         {
             "id": "b822babc-a8a1-575b-9cf2-ef7478b554be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb96971-5bf1-4ae3-98f4-7cd7a614bf97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb96971-5bf1-4ae3-98f4-7cd7a614bf97.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "Whenever a creature attacks you or a planeswalker you control, each Dragon you control deals 1 damage to that creature.\n+1: Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.\n\u22123: Create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "865eecad-2284-53a7-afe3-703310a6f5ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df04f130-e9ea-4f5f-82d0-63d3f74d8234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df04f130-e9ea-4f5f-82d0-63d3f74d8234.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "ad2365f6-b11b-5ba1-b1c8-9d80b95e04ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b6f26-c66b-4048-9503-af0a886ef14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b6f26-c66b-4048-9503-af0a886ef14f.jpg?1",
             "name": "Sarkhan's Catharsis",
             "text": "Sarkhan's Catharsis deals 5 damage to target player or planeswalker.",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "173caa83-8aef-5c07-aa0c-7b78d428ef63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91551f85-4630-43a0-af72-8332d2ff0752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91551f85-4630-43a0-af72-8332d2ff0752.jpg?1",
             "name": "Spellgorger Weird",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.",
             "colours": [
@@ -5449,7 +5449,7 @@
         },
         {
             "id": "c28a0e0b-6f52-5249-99d1-9222bb3e9e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a24dc-8bc3-4528-8780-57fb108fdfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a24dc-8bc3-4528-8780-57fb108fdfbf.jpg?1",
             "name": "Tibalt, Rakish Instigator",
             "text": "Your opponents can't gain life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "a3935d99-8f12-5a3f-8e30-2ce727dc7943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68718639-a767-4f4e-b7bf-1fbb65e6cae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68718639-a767-4f4e-b7bf-1fbb65e6cae5.jpg?1",
             "name": "Tibalt, Rakish Instigator",
             "text": "",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "22532515-400f-5649-8969-05cfbc008ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2985520d-dfce-414e-a4ac-61695be67406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2985520d-dfce-414e-a4ac-61695be67406.jpg?1",
             "name": "Tibalt's Rager",
             "text": "When Tibalt's Rager dies, it deals 1 damage to any target.\n{1}{R}: Tibalt's Rager gets +2/+0 until end of turn.",
             "colours": [
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "33f4cc82-7b2f-5462-a355-41007862577e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f624f-c5eb-4150-b36e-6147b440ff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f624f-c5eb-4150-b36e-6147b440ff56.jpg?1",
             "name": "Turret Ogre",
             "text": "Reach\nWhen Turret Ogre enters the battlefield, if you control another creature with power 4 or greater, Turret Ogre deals 2 damage to each opponent.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "ff209b2c-1d8c-5749-8659-43ddf24a3320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5f86f-44a8-4735-909a-770586d33a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5f86f-44a8-4735-909a-770586d33a15.jpg?1",
             "name": "Arboreal Grazer",
             "text": "Reach\nWhen Arboreal Grazer enters the battlefield, you may put a land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -5628,7 +5628,7 @@
         },
         {
             "id": "9c2c42d5-6cf3-5298-a7e9-9b14d6503d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5391d2f1-e8d3-4d39-98cf-367888e10534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5391d2f1-e8d3-4d39-98cf-367888e10534.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "Each creature you control that's a Wolf or a Werewolf enters the battlefield with an additional +1/+1 counter on it.\n\u22122: Create a 2/2 green Wolf creature token.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "1804176d-2d08-5cea-b77e-4b442ff376b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43261927-7655-474b-ac61-dfef9e63f428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43261927-7655-474b-ac61-dfef9e63f428.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "67df542e-fb46-5268-a7ae-c73ec7bc357a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747223a5-c669-4d0e-a062-265eb47710cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747223a5-c669-4d0e-a062-265eb47710cd.jpg?1",
             "name": "Arlinn's Wolf",
             "text": "Arlinn's Wolf can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "6739063b-938e-5bfb-ae02-9a10a9cdac1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42b2fb4-8016-462c-8764-2639adec931f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42b2fb4-8016-462c-8764-2639adec931f.jpg?1",
             "name": "Awakening of Vitu-Ghazi",
             "text": "Put nine +1/+1 counters on target land you control. It becomes a legendary 0/0 Elemental creature with haste named Vitu-Ghazi. It's still a land.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "c3116d5f-3040-51b0-9780-5cd11be0283e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1d8aa1-d742-477c-819a-0113912d5011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1d8aa1-d742-477c-819a-0113912d5011.jpg?1",
             "name": "Band Together",
             "text": "Up to two target creatures you control each deal damage equal to their power to another target creature.",
             "colours": [
@@ -5802,7 +5802,7 @@
         },
         {
             "id": "30aa01b9-f697-56ee-92fc-0502fb15bf8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c9129-254d-4d1d-9d95-112292bd6bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c9129-254d-4d1d-9d95-112292bd6bcc.jpg?1",
             "name": "Bloom Hulk",
             "text": "When Bloom Hulk enters the battlefield, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "9e7999e1-62ba-5968-8c1a-f19d39fa35e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901fdc-8672-44f5-ade5-7c4e0b5c5d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901fdc-8672-44f5-ade5-7c4e0b5c5d81.jpg?1",
             "name": "Bond of Flourishing",
             "text": "Look at the top three cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in any order. You gain 3 life.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "6b9bb917-3152-537a-94d6-6addecbb7495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf020acb-e0c6-43b4-8324-0f2ec68b73d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf020acb-e0c6-43b4-8324-0f2ec68b73d6.jpg?1",
             "name": "Centaur Nurturer",
             "text": "When Centaur Nurturer enters the battlefield, you gain 3 life.\n{T}: Add one mana of any color.",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "e476bc1e-6a4a-5f49-8d58-0daa0500edf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d778a-ef16-437f-9a9d-204cf061919b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d778a-ef16-437f-9a9d-204cf061919b.jpg?1",
             "name": "Challenger Troll",
             "text": "Each creature you control with power 4 or greater can't be blocked by more than one creature.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "e63d7d93-9b27-5d7f-8743-a852299595a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a22083-9ef9-4ff7-8502-3a77e69299df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a22083-9ef9-4ff7-8502-3a77e69299df.jpg?1",
             "name": "Courage in Crisis",
             "text": "Put a +1/+1 counter on target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "2634269a-6457-5157-a2d0-27415ee848d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4042db8-6032-49a2-bc96-ad15f55db6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4042db8-6032-49a2-bc96-ad15f55db6c3.jpg?1",
             "name": "Evolution Sage",
             "text": "Whenever a land enters the battlefield under your control, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6005,7 +6005,7 @@
         },
         {
             "id": "76f9f095-f516-5dfd-899e-75ba4a662630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985453e7-997e-4d77-a338-cc0290791ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985453e7-997e-4d77-a338-cc0290791ebe.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with converted mana cost X or less and put it onto the battlefield. If you search your library this way, shuffle it. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "2e3c42d4-d1d8-590e-a2a4-4fafe2c592e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb319a7-564c-4748-82cf-c26ab110c32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb319a7-564c-4748-82cf-c26ab110c32c.jpg?1",
             "name": "Forced Landing",
             "text": "Put target creature with flying on the bottom of its owner's library.",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "a503cb41-a414-576e-97c4-40d64a3a91c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec9e8b-4bd8-4caf-a559-6514b7ab4ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec9e8b-4bd8-4caf-a559-6514b7ab4ca4.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6101,7 +6101,7 @@
         },
         {
             "id": "56788492-50a1-54f5-b6ef-85e18365290a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb444f0-69cc-47c8-8cd6-1f9edad5d903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb444f0-69cc-47c8-8cd6-1f9edad5d903.jpg?1",
             "name": "God-Eternal Rhonas",
             "text": "Deathtouch\nWhen God-Eternal Rhonas enters the battlefield, double the power of each other creature you control until end of turn. Those creatures gain vigilance until end of turn.\nWhen God-Eternal Rhonas dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -6138,7 +6138,7 @@
         },
         {
             "id": "f3db8dfc-2fb4-539f-aca5-2d61eca652c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0d47d-b13c-4d48-881f-8aaa347ef209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0d47d-b13c-4d48-881f-8aaa347ef209.jpg?1",
             "name": "Jiang Yanggu, Wildcrafter",
             "text": "Each creature you control with a +1/+1 counter on it has \"{T}: Add one mana of any color.\"\n\u22121: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -6176,7 +6176,7 @@
         },
         {
             "id": "4c49c839-b070-573a-a231-4484998c7490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a66171-1143-4d23-81c3-ae8bb0ef63ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a66171-1143-4d23-81c3-ae8bb0ef63ad.jpg?1",
             "name": "Jiang Yanggu, Wildcrafter",
             "text": "",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "6f2d2422-ae83-5836-a3de-3f309753ba05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b88fe9-2450-47ee-ac1e-bbbccbf5684f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b88fe9-2450-47ee-ac1e-bbbccbf5684f.jpg?1",
             "name": "Kraul Stinger",
             "text": "Deathtouch",
             "colours": [
@@ -6249,7 +6249,7 @@
         },
         {
             "id": "d8798669-f034-5a9a-a481-7b559a4baef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41d22a-ee37-4d69-a9ca-98c91315b9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41d22a-ee37-4d69-a9ca-98c91315b9e6.jpg?1",
             "name": "Kronch Wrangler",
             "text": "Trample\nWhenever a creature with power 4 or greater enters the battlefield under your control, put a +1/+1 counter on Kronch Wrangler.",
             "colours": [
@@ -6284,7 +6284,7 @@
         },
         {
             "id": "aeffa888-35eb-5855-b3d6-a211cbd2c86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41a191c-c42e-42ec-89bd-cc1bc215ffbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41a191c-c42e-42ec-89bd-cc1bc215ffbc.jpg?1",
             "name": "Mowu, Loyal Companion",
             "text": "Trample, vigilance\nIf one or more +1/+1 counters would be put on Mowu, Loyal Companion, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "1ae82207-e017-5539-ac71-5ecdb5d1b7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c521da-677e-43b9-b5fe-c84dc64e66ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c521da-677e-43b9-b5fe-c84dc64e66ec.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen New Horizons enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "ffccf80c-e56f-5bc2-9838-d77166da4eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857bbe4-5619-4733-a0c7-69700f2ef4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857bbe4-5619-4733-a0c7-69700f2ef4f3.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "Whenever you tap a Forest for mana, add an additional {G}.\n+1: Put three +1/+1 counters on up to one target noncreature land you control. Untap it. It becomes a 0/0 Elemental creature with vigilance and haste that's still a land.\n\u22128: You get an emblem with \"Lands you control have indestructible.\" Search your library for any number of Forest cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6392,7 +6392,7 @@
         },
         {
             "id": "8ca09437-8a78-5065-8bec-3cc36eab7939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d63632-c019-4f34-926a-42f829a4665c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d63632-c019-4f34-926a-42f829a4665c.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "",
             "colours": [
@@ -6430,7 +6430,7 @@
         },
         {
             "id": "65b241eb-8093-580e-aac6-7b47e993795f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7946b256-ae79-4b99-8bf4-0d627baf9044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7946b256-ae79-4b99-8bf4-0d627baf9044.jpg?1",
             "name": "Nissa's Triumph",
             "text": "Search your library for up to two basic Forest cards. If you control a Nissa planeswalker, instead search your library for up to three land cards. Reveal those cards, put them into your hand, then shuffle your library.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "462a3159-19c3-5506-992f-e264e634bcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed8d9e7-cdad-450d-8329-fa653d387a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed8d9e7-cdad-450d-8329-fa653d387a63.jpg?1",
             "name": "Paradise Druid",
             "text": "Paradise Druid has hexproof as long as it's untapped.(It can't be the target of spells or abilities your opponents control.)\n{T}: Add one mana of any color.",
             "colours": [
@@ -6497,7 +6497,7 @@
         },
         {
             "id": "d9737859-bb86-5455-abe2-8f6159d7e0e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11016840-56b6-4759-bde6-3dc0e339e87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11016840-56b6-4759-bde6-3dc0e339e87e.jpg?1",
             "name": "Planewide Celebration",
             "text": "Choose four. You may choose the same mode more than once.\n\u2022 Create a 2/2 Citizen creature token that's all colors.\n\u2022 Return target permanent card from your graveyard to your hand.\n\u2022 Proliferate.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "633f54dd-6b69-5eb6-b1fe-6a144a207a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0f478c-54f8-4087-ad52-d089e2049dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0f478c-54f8-4087-ad52-d089e2049dda.jpg?1",
             "name": "Pollenbright Druid",
             "text": "When Pollenbright Druid enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "caa87172-dc22-5c72-be26-7046068aae01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0e8298-adac-4922-8824-a1fafa089f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0e8298-adac-4922-8824-a1fafa089f72.jpg?1",
             "name": "Primordial Wurm",
             "text": "",
             "colours": [
@@ -6598,7 +6598,7 @@
         },
         {
             "id": "ed015dda-2818-5ea2-a4ad-2eb3d498c00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085e3129-591b-46ec-ac8b-cff428927c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085e3129-591b-46ec-ac8b-cff428927c01.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "b4d70fe7-e3f2-55f5-9f92-a1820bb6e270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a0fcc5-57d3-43ab-9e3d-0e015792239a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a0fcc5-57d3-43ab-9e3d-0e015792239a.jpg?1",
             "name": "Snarespinner",
             "text": "Reach\nWhenever Snarespinner blocks a creature with flying, Snarespinner gets +2/+0 until end of turn.",
             "colours": [
@@ -6664,7 +6664,7 @@
         },
         {
             "id": "211a1eee-e2d2-5f01-8f15-35c6d5d2ca52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af6a1b5-a561-4d92-b429-de13b2ccaf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af6a1b5-a561-4d92-b429-de13b2ccaf81.jpg?1",
             "name": "Steady Aim",
             "text": "Untap target creature. It gets +1/+4 and gains reach until end of turn.",
             "colours": [
@@ -6696,7 +6696,7 @@
         },
         {
             "id": "7370a76b-f407-5105-9d7c-f0dec075fe09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b3b12e-bef7-409e-86b3-9e90640e598c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b3b12e-bef7-409e-86b3-9e90640e598c.jpg?1",
             "name": "Storm the Citadel",
             "text": "Until end of turn, creatures you control get +2/+2 and gain \"Whenever this creature deals combat damage to a player or planeswalker, destroy target artifact or enchantment defending player controls.\"",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "31d92cfc-8aee-5596-be49-f7d73201575a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9888d9a4-ad72-43f6-8031-1031877171a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9888d9a4-ad72-43f6-8031-1031877171a9.jpg?1",
             "name": "Thundering Ceratok",
             "text": "Trample\nWhen Thundering Ceratok enters the battlefield, other creatures you control gain trample until end of turn.",
             "colours": [
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "f4f7168b-127e-57f3-af5c-9f5320dbcb83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3986d7-9b3d-4082-8d72-ce59c9fcd5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3986d7-9b3d-4082-8d72-ce59c9fcd5d5.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "You may cast creature spells as though they had flash.\n+1: Until your next turn, up to one target creature gains vigilance and reach.\n\u22122: Look at the top three cards of your library. Exile one face down and put the rest on the bottom of your library in any order. For as long as it remains exiled, you may look at that card and you may cast it if it's a creature card.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "b0aada96-91d4-51ab-93ca-0f952d2cd3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4422e69e-a7db-4582-b37d-59519b6871f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4422e69e-a7db-4582-b37d-59519b6871f9.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "93ef91a8-df9c-5705-b1f0-df3abe2e2b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc846f-5b78-4d54-8d29-642ad7a852bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc846f-5b78-4d54-8d29-642ad7a852bc.jpg?1",
             "name": "Vivien's Arkbow",
             "text": "{X}, {T}, Discard a card: Look at the top X cards of your library. You may put a creature card with converted mana cost X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "e249f978-c9bf-5895-a844-7b6cd601fc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f2571b-6756-462c-9e71-3121fa458160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f2571b-6756-462c-9e71-3121fa458160.jpg?1",
             "name": "Vivien's Grizzly",
             "text": "{3}{G}: Look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, put it on the bottom of your library.",
             "colours": [
@@ -6907,7 +6907,7 @@
         },
         {
             "id": "083a4a7d-220e-586f-a7c8-4647bf258c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5341b9-06e4-4360-a75d-f405d468276e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5341b9-06e4-4360-a75d-f405d468276e.jpg?1",
             "name": "Wardscale Crocodile",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6941,7 +6941,7 @@
         },
         {
             "id": "d52aebee-9ea7-5bf6-897f-e34c45e5edb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc78151-8cb0-4521-9674-fb0c67e24a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc78151-8cb0-4521-9674-fb0c67e24a17.jpg?1",
             "name": "Ajani, the Greathearted",
             "text": "Creatures you control have vigilance.\n+1: You gain 3 life.\n\u22122: Put a +1/+1 counter on each creature you control and a loyalty counter on each other planeswalker you control.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "c73d1680-63cd-501a-b828-b163428e57a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee535c3-4ccd-4eb1-85e9-d28bf6dc0710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee535c3-4ccd-4eb1-85e9-d28bf6dc0710.jpg?1",
             "name": "Ajani, the Greathearted",
             "text": "",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "4e17b405-08e8-5d22-88ce-3e8e37ad27cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a39379-7313-463a-9a02-e5157b9557f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a39379-7313-463a-9a02-e5157b9557f4.jpg?1",
             "name": "Angrath's Rampage",
             "text": "Choose one \u2014\n\u2022 Target player sacrifices an artifact.\n\u2022 Target player sacrifices a creature.\n\u2022 Target player sacrifices a planeswalker.",
             "colours": [
@@ -7055,7 +7055,7 @@
         },
         {
             "id": "73b21bac-d5fd-5361-9f93-25515b696afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01a161-49a1-407c-8410-6933bc8f7b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01a161-49a1-407c-8410-6933bc8f7b6a.jpg?1",
             "name": "Bioessence Hydra",
             "text": "Trample\nBioessence Hydra enters the battlefield with a +1/+1 counter on it for each loyalty counter on planeswalkers you control.\nWhenever one or more loyalty counters are put on planeswalkers you control, put that many +1/+1 counters on Bioessence Hydra.",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "51c2c882-b31c-5d30-b647-6ae98db12925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc5e50-c6f7-41ec-815a-5667eefded78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc5e50-c6f7-41ec-815a-5667eefded78.jpg?1",
             "name": "Casualties of War",
             "text": "Choose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature.\n\u2022 Destroy target enchantment.\n\u2022 Destroy target land.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "1ee550f8-ee51-5a89-b121-5af6c7d73d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ead6ac-b1c5-4852-8413-7fa43c6cfc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ead6ac-b1c5-4852-8413-7fa43c6cfc57.jpg?1",
             "name": "Cruel Celebrant",
             "text": "Whenever Cruel Celebrant or another creature or planeswalker you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "b61d5f96-30c1-5bcd-ac30-84960831339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d615557-aea8-4057-9fbd-d62dd98edc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d615557-aea8-4057-9fbd-d62dd98edc13.jpg?1",
             "name": "Deathsprout",
             "text": "Destroy target creature. Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7196,7 +7196,7 @@
         },
         {
             "id": "2105a674-59b9-57c5-b7fd-18ccbf2cdf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b17dfc-b916-4134-ba77-501cff435e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b17dfc-b916-4134-ba77-501cff435e7e.jpg?1",
             "name": "Despark",
             "text": "Exile target permanent with converted mana cost 4 or greater.",
             "colours": [
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "cf65b0d5-04d2-53f5-a0e8-bb0b07e9f7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1af9881-e35b-4be2-8716-ea7c6664e22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1af9881-e35b-4be2-8716-ea7c6664e22c.jpg?1",
             "name": "Domri, Anarch of Bolas",
             "text": "Creatures you control get +1/+0.\n+1: Add {R} or {G}. Creature spells you cast this turn can't be countered.\n\u22122: Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7270,7 +7270,7 @@
         },
         {
             "id": "c4f2db39-0198-53ed-a8f0-e527cfa18852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ec2a4-e6b1-42a4-9a20-3b55eda4377f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ec2a4-e6b1-42a4-9a20-3b55eda4377f.jpg?1",
             "name": "Domri, Anarch of Bolas",
             "text": "",
             "colours": [
@@ -7310,7 +7310,7 @@
         },
         {
             "id": "e0e05e4f-a336-5625-b3a9-5c86e15dd8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dcae59-e9be-45a8-8ed8-5b47309bb716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dcae59-e9be-45a8-8ed8-5b47309bb716.jpg?1",
             "name": "Domri's Ambush",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "830832c9-2b37-56b6-8200-f1415923f139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6b5054-2224-4f68-9d82-3ed17c5dacc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6b5054-2224-4f68-9d82-3ed17c5dacc4.jpg?1",
             "name": "Dovin's Veto",
             "text": "This spell can't be countered.\nCounter target noncreature spell.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "d5233d3e-5fd2-5731-9a1e-d392629c539e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457bc402-4c31-465c-95e1-694f686e257e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457bc402-4c31-465c-95e1-694f686e257e.jpg?1",
             "name": "Dreadhorde Butcher",
             "text": "Haste\nWhenever Dreadhorde Butcher deals combat damage to a player or planeswalker, put a +1/+1 counter on Dreadhorde Butcher.\nWhen Dreadhorde Butcher dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "3602f881-3a52-5449-abc0-e4dbb76294dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e40b14-48a2-4b9e-b767-e914cab04b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e40b14-48a2-4b9e-b767-e914cab04b30.jpg?1",
             "name": "Elite Guardmage",
             "text": "Flying\nWhen Elite Guardmage enters the battlefield, you gain 3 life and draw a card.",
             "colours": [
@@ -7452,7 +7452,7 @@
         },
         {
             "id": "be4eef08-4518-53f7-8d86-e380aaabe591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7070-2266-4c93-8c89-084e12ba7a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7070-2266-4c93-8c89-084e12ba7a4e.jpg?1",
             "name": "Enter the God-Eternals",
             "text": "Enter the God-Eternals deals 4 damage to target creature and you gain life equal to the damage dealt this way. Target player puts the top four cards of their library into their graveyard. Amass 4. (Put four +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "9c936b88-a365-576d-b074-e8a8d9b1f6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a2d2c6-8eaa-4760-b620-921b807baa2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a2d2c6-8eaa-4760-b620-921b807baa2e.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "Flying\nWhenever you cast an instant or sorcery spell that targets a creature you control, exile that card instead of putting it into your graveyard as it resolves. If you do, return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "4dd2b6e8-4999-5c70-b9b1-6b89c1245ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4604b4-df53-485c-a604-4d823b33d8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4604b4-df53-485c-a604-4d823b33d8ba.jpg?1",
             "name": "Gleaming Overseer",
             "text": "When Gleaming Overseer enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have hexproof and menace.",
             "colours": [
@@ -7561,7 +7561,7 @@
         },
         {
             "id": "63289f00-b5b2-5c16-ada5-fe6e05be49a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af569235-f5cb-4e3e-ba77-c1c429ed0a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af569235-f5cb-4e3e-ba77-c1c429ed0a60.jpg?1",
             "name": "Heartwarming Redemption",
             "text": "Discard all the cards in your hand, then draw that many cards plus one. You gain life equal to the number of cards in your hand.",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "f1c4e98d-80f7-5ddc-a3c2-0f70eba20150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba680ad0-6134-46e0-8fcb-532b2052eca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba680ad0-6134-46e0-8fcb-532b2052eca7.jpg?1",
             "name": "Huatli's Raptor",
             "text": "Vigilance\nWhen Huatli's Raptor enters the battlefield, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "fea4fd6f-cd52-59d1-ba38-2b418edb5954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a587eb67-c2df-486c-9c48-dfeac540efe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a587eb67-c2df-486c-9c48-dfeac540efe8.jpg?1",
             "name": "Invade the City",
             "text": "Amass X, where X is the number of instant and sorcery cards in your graveyard. (Put X +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "b47b3aee-0384-574b-a750-1ef2704e1251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b4e8f-d48e-4bb0-883d-29f978033f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b4e8f-d48e-4bb0-883d-29f978033f65.jpg?1",
             "name": "Leyline Prowler",
             "text": "Deathtouch, lifelink\n{T}: Add one mana of any color.",
             "colours": [
@@ -7702,7 +7702,7 @@
         },
         {
             "id": "2378f517-597d-56f0-bf47-b26c54c17577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d92676-a994-4031-834c-6cf7c43bd170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d92676-a994-4031-834c-6cf7c43bd170.jpg?1",
             "name": "Living Twister",
             "text": "{1}{R}, Discard a land card: Living Twister deals 2 damage to any target.\n{G}: Return a tapped land you control to its owner's hand.",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "489b4151-9369-5706-9de2-10327e6b6f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17416926-168b-49b3-9231-acbb8f8a1d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17416926-168b-49b3-9231-acbb8f8a1d13.jpg?1",
             "name": "Mayhem Devil",
             "text": "Whenever a player sacrifices a permanent, Mayhem Devil deals 1 damage to any target.",
             "colours": [
@@ -7774,7 +7774,7 @@
         },
         {
             "id": "3b1a9e81-b53d-5d0c-a248-7e4a3a2d8fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf211eb-837b-4c02-b02e-8d9e62f1abb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf211eb-837b-4c02-b02e-8d9e62f1abb1.jpg?1",
             "name": "Merfolk Skydiver",
             "text": "Flying\nWhen Merfolk Skydiver enters the battlefield, put a +1/+1 counter on target creature you control.\n{3}{G}{U}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "01e31b26-7b7f-5c89-9099-ba2df6f2d343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8f67e-4f2f-4a1f-b190-7c3f39e477e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8f67e-4f2f-4a1f-b190-7c3f39e477e4.jpg?1",
             "name": "Neoform",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield with an additional +1/+1 counter on it, then shuffle your library.",
             "colours": [
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "ad06d0fe-1d5c-5d62-9134-e97294333d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b68dea-a7be-4f99-8a50-4c8cf0e0f7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b68dea-a7be-4f99-8a50-4c8cf0e0f7a9.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "Nicol Bolas, Dragon-God has all loyalty abilities of all other planeswalkers on the battlefield.\n+1: You draw a card. Each opponent exiles a card from their hand or a permanent they control.\n\u22123: Destroy target creature or planeswalker.\n\u22128: Each opponent who doesn't control a legendary creature or planeswalker loses the game.",
             "colours": [
@@ -7887,7 +7887,7 @@
         },
         {
             "id": "4e13c7ce-6811-5d13-9675-3baafa9d3910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5770e-533d-479f-b469-1fbef08614c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5770e-533d-479f-b469-1fbef08614c1.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "eb76191d-5004-5735-a618-663b3411898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a2609d-b535-400b-81d9-72989a33c70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a2609d-b535-400b-81d9-72989a33c70f.jpg?1",
             "name": "Niv-Mizzet Reborn",
             "text": "Flying\nWhen Niv-Mizzet Reborn enters the battlefield, reveal the top ten cards of your library. For each color pair, choose a card that's exactly those colors from among them. Put the chosen cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7974,7 +7974,7 @@
         },
         {
             "id": "d14b23fb-7a3c-5d0a-84d6-9993338710e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faba010d-5b1b-4562-91d6-ec55303c4dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faba010d-5b1b-4562-91d6-ec55303c4dcd.jpg?1",
             "name": "Oath of Kaya",
             "text": "When Oath of Kaya enters the battlefield, it deals 3 damage to any target and you gain 3 life.\nWhenever an opponent attacks a planeswalker you control with one or more creatures, Oath of Kaya deals 2 damage to that player and you gain 2 life.",
             "colours": [
@@ -8010,7 +8010,7 @@
         },
         {
             "id": "3041ff06-b062-5b9e-84a4-4ef50f01b298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9b3518-7fcd-49e2-a4c4-e5daa8be6c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9b3518-7fcd-49e2-a4c4-e5daa8be6c21.jpg?1",
             "name": "Pledge of Unity",
             "text": "Put a +1/+1 counter on each creature you control. You gain 1 life for each creature you control.",
             "colours": [
@@ -8044,7 +8044,7 @@
         },
         {
             "id": "d26a1c5d-25a3-56fd-9559-bc3a0e910e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ce3bf-152d-45ca-87ae-ad46c921328b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ce3bf-152d-45ca-87ae-ad46c921328b.jpg?1",
             "name": "Ral, Storm Conduit",
             "text": "Whenever you cast or copy an instant or sorcery spell, Ral, Storm Conduit deals 1 damage to target opponent or planeswalker.\n+2: Scry 1.\n\u22122: When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -8084,7 +8084,7 @@
         },
         {
             "id": "8d0fcede-8da7-567e-87eb-ec87154550e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad09cd7-52c3-4c13-919c-e113b6dc3419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad09cd7-52c3-4c13-919c-e113b6dc3419.jpg?1",
             "name": "Ral, Storm Conduit",
             "text": "",
             "colours": [
@@ -8124,7 +8124,7 @@
         },
         {
             "id": "0ebc529b-6c1e-5d96-8f98-fda74777f386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3dd3e-50d2-4729-9caa-b2cd984f4c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3dd3e-50d2-4729-9caa-b2cd984f4c97.jpg?1",
             "name": "Ral's Outburst",
             "text": "Ral's Outburst deals 3 damage to any target. Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "057bb70b-58de-5f49-8e50-1f45f548f519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de14b4fd-fb4e-4986-9123-69ae68b5050a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de14b4fd-fb4e-4986-9123-69ae68b5050a.jpg?1",
             "name": "Roalesk, Apex Hybrid",
             "text": "Flying, trample\nWhen Roalesk, Apex Hybrid enters the battlefield, put two +1/+1 counters on another target creature you control.\nWhen Roalesk dies, proliferate, then proliferate again. (Choose any number of permanents and/or players, then give each another counter of each kind already there. Then do it again.)",
             "colours": [
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "fc24aaad-c086-589a-b869-f38c18b35193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b47017-d982-4d4c-94fc-f265a5b7f36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b47017-d982-4d4c-94fc-f265a5b7f36a.jpg?1",
             "name": "Role Reversal",
             "text": "Exchange control of two target permanents that share a permanent type.",
             "colours": [
@@ -8231,7 +8231,7 @@
         },
         {
             "id": "d3fcf363-1b10-595d-b906-a4d75dfdc6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf8df62-eca1-4a45-84af-fd7c88245a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf8df62-eca1-4a45-84af-fd7c88245a42.jpg?1",
             "name": "Rubblebelt Rioters",
             "text": "Haste\nWhenever Rubblebelt Rioters attacks, it gets +X/+0 until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -8268,7 +8268,7 @@
         },
         {
             "id": "8d5e4d8d-581d-5ae0-b40c-2ba55337c619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb72ba0f-ab3a-41e6-906d-a84039efa0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb72ba0f-ab3a-41e6-906d-a84039efa0af.jpg?1",
             "name": "Solar Blaze",
             "text": "Each creature deals damage to itself equal to its power.",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "aa4ef53e-b4fb-5baa-9b1f-ca98b5e9a108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354fe9bd-4ec8-409c-8ce5-b29393f3d169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354fe9bd-4ec8-409c-8ce5-b29393f3d169.jpg?1",
             "name": "Sorin, Vengeful Bloodlord",
             "text": "As long as it's your turn, creatures and planeswalkers you control have lifelink.\n+2: Sorin, Vengeful Bloodlord deals 1 damage to target player or planeswalker.\n\u2212X: Return target creature card with converted mana cost X from your graveyard to the battlefield. That creature is a Vampire in addition to its other types.",
             "colours": [
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "8657ec09-9371-5ae5-b003-c47f9559760d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a29e375-081c-43ac-aeb5-9d71d65c5ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a29e375-081c-43ac-aeb5-9d71d65c5ddd.jpg?1",
             "name": "Sorin, Vengeful Bloodlord",
             "text": "",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "da466d68-ad03-578d-a86a-75d84007ba0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb66ccd-a930-4757-832c-c4b0259741e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb66ccd-a930-4757-832c-c4b0259741e2.jpg?1",
             "name": "Soul Diviner",
             "text": "{T}, Remove a counter from an artifact, creature, land, or planeswalker you control: Draw a card.",
             "colours": [
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "62891624-ecec-50f4-92ce-bb0b3593f595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c906bd-f443-4f4b-b40b-9218e71f1196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c906bd-f443-4f4b-b40b-9218e71f1196.jpg?1",
             "name": "Storrev, Devkarin Lich",
             "text": "Trample\nWhenever Storrev, Devkarin Lich deals combat damage to a player or planeswalker, return to your hand target creature or planeswalker card in your graveyard that wasn't put there this combat.",
             "colours": [
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "f5d4e818-4fe5-557f-8967-e41be29a8edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76776b24-a2e1-4590-88e7-8a421baf2fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76776b24-a2e1-4590-88e7-8a421baf2fc4.jpg?1",
             "name": "Tamiyo, Collector of Tales",
             "text": "Spells and abilities your opponents control can't cause you to discard cards or sacrifice permanents.\n+1: Choose a nonland card name, then reveal the top four cards of your library. Put all cards with the chosen name from among them into your hand and the rest into your graveyard.\n\u22123: Return target card from your graveyard to your hand.",
             "colours": [
@@ -8499,7 +8499,7 @@
         },
         {
             "id": "1340ff21-3a0c-5889-ad60-a3830ca8d6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ad78c6-8af3-4efa-b47a-29a646ea412a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ad78c6-8af3-4efa-b47a-29a646ea412a.jpg?1",
             "name": "Tamiyo, Collector of Tales",
             "text": "",
             "colours": [
@@ -8539,7 +8539,7 @@
         },
         {
             "id": "643aea97-faaa-5cf2-8f7d-4b07d5c45e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb76266-ae50-4bbc-8f96-d98f309b02d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb76266-ae50-4bbc-8f96-d98f309b02d3.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "Each opponent can cast spells only any time they could cast a sorcery.\n+1: Until your next turn, you may cast sorcery spells as though they had flash.\n\u22123: Return up to one target artifact, creature, or enchantment to its owner's hand. Draw a card.",
             "colours": [
@@ -8579,7 +8579,7 @@
         },
         {
             "id": "2547a2ff-267b-5f64-aadd-623ca9e3f6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01091bfd-e9b8-4a9b-89a9-56da625a5d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01091bfd-e9b8-4a9b-89a9-56da625a5d18.jpg?1",
             "name": "A-Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -8616,7 +8616,7 @@
         },
         {
             "id": "6ba6c3fb-480a-5c58-b481-476b89b433b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb4cc4-b79a-4ac8-ba33-ceeb55012022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb4cc4-b79a-4ac8-ba33-ceeb55012022.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "9f44df25-b9b4-58bd-9394-e55752aead75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f3090b-917b-4122-b522-27c30dca8e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f3090b-917b-4122-b522-27c30dca8e69.jpg?1",
             "name": "Tenth District Legionnaire",
             "text": "Haste\nWhenever you cast a spell that targets Tenth District Legionnaire, put a +1/+1 counter on Tenth District Legionnaire, then scry 1.",
             "colours": [
@@ -8693,7 +8693,7 @@
         },
         {
             "id": "52a150fe-a4b9-5e4c-9dad-55e5e6dd7ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c59475-6f15-48d2-b105-f49901f20d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c59475-6f15-48d2-b105-f49901f20d44.jpg?1",
             "name": "Time Wipe",
             "text": "Return a creature you control to its owner's hand, then destroy all creatures.",
             "colours": [
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "6200a999-c695-5023-813f-fb1f031775fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fce047-49f1-40ae-8410-6501cb0f8201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fce047-49f1-40ae-8410-6501cb0f8201.jpg?1",
             "name": "Tolsimir, Friend to Wolves",
             "text": "When Tolsimir, Friend to Wolves enters the battlefield, create Voja, Friend to Elves, a legendary 3/3 green and white Wolf creature token.\nWhenever a Wolf enters the battlefield under your control, you gain 3 life and that creature fights up to one target creature you don't control.",
             "colours": [
@@ -8766,7 +8766,7 @@
         },
         {
             "id": "ec637ce6-77cf-588b-b6a2-128f375565a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e2708c-2824-4925-b529-d625deb77924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e2708c-2824-4925-b529-d625deb77924.jpg?1",
             "name": "Tyrant's Scorn",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with converted mana cost 3 or less.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -8800,7 +8800,7 @@
         },
         {
             "id": "45f14f0b-c356-5cb0-9292-2f3adb722418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97715d22-f432-4f67-b4ea-47b8fe6edca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97715d22-f432-4f67-b4ea-47b8fe6edca5.jpg?1",
             "name": "Widespread Brutality",
             "text": "Amass 2, then the Army you amassed deals damage equal to its power to each non-Army creature. (To amass 2, put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -8834,7 +8834,7 @@
         },
         {
             "id": "438ea174-d61e-5373-802b-aefeb468d6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3a4cb5-945e-4caf-8a18-1ef977879fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3a4cb5-945e-4caf-8a18-1ef977879fe8.jpg?1",
             "name": "Angrath, Captain of Chaos",
             "text": "Creatures you control have menace.\n\u22122: Amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "4c4668a9-c195-5e3e-b4ec-577d8a487403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98da7c-e61b-4921-9b27-eed3ce41221d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98da7c-e61b-4921-9b27-eed3ce41221d.jpg?1",
             "name": "Angrath, Captain of Chaos",
             "text": "",
             "colours": [
@@ -8914,7 +8914,7 @@
         },
         {
             "id": "77b1743c-77f0-500a-bd82-3edb82b71ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2df3258-c053-48a8-974f-d80899b2cd93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2df3258-c053-48a8-974f-d80899b2cd93.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "Spells and abilities your opponents control can't cause their controller to search their library.\n\u22121: Target player puts the top four cards of their library into their graveyard. Then exile each opponent's graveyard.",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "bff5937c-ea19-54d0-8729-4441da6add14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df061ce-dd56-4a11-a932-f16d69f47d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df061ce-dd56-4a11-a932-f16d69f47d3b.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "",
             "colours": [
@@ -8994,7 +8994,7 @@
         },
         {
             "id": "79ad285b-2485-50ff-aad2-a1320cff715b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ff745-919b-4688-9e9e-ab7835b3b891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ff745-919b-4688-9e9e-ab7835b3b891.jpg?1",
             "name": "Dovin, Hand of Control",
             "text": "Artifact, instant, and sorcery spells your opponents cast cost {1} more to cast.\n\u22121: Until your next turn, prevent all damage that would be dealt to and dealt by target permanent an opponent controls.",
             "colours": [
@@ -9034,7 +9034,7 @@
         },
         {
             "id": "eed57490-6091-5655-bfba-aba1862e70ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c347f3-157e-45ca-95a8-bdf300b0811b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c347f3-157e-45ca-95a8-bdf300b0811b.jpg?1",
             "name": "Dovin, Hand of Control",
             "text": "",
             "colours": [
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "00d36b0f-e866-54df-b4aa-447ba0f681e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d709742c-82a2-457e-9991-85e98d78029d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d709742c-82a2-457e-9991-85e98d78029d.jpg?1",
             "name": "Huatli, the Sun's Heart",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n\u22123: You gain life equal to the greatest toughness among creatures you control.",
             "colours": [
@@ -9114,7 +9114,7 @@
         },
         {
             "id": "d7f9064a-1e5e-545e-9d53-08412f26e7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7c88ec-0537-4d94-81d1-e1ba877d2cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7c88ec-0537-4d94-81d1-e1ba877d2cdb.jpg?1",
             "name": "Huatli, the Sun's Heart",
             "text": "",
             "colours": [
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "d5220486-1689-5ada-8838-7999645b000b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b575d3-f3f9-4ff4-8e5c-da7c2ec69882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b575d3-f3f9-4ff4-8e5c-da7c2ec69882.jpg?1",
             "name": "Kaya, Bane of the Dead",
             "text": "Your opponents and permanents your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.\n\u22123: Exile target creature.",
             "colours": [
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "31f5245d-0d8e-5240-bcfa-a5a3b3aaaf2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981850b2-3013-4f12-ab13-6410431585f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981850b2-3013-4f12-ab13-6410431585f2.jpg?1",
             "name": "Kaya, Bane of the Dead",
             "text": "",
             "colours": [
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "7220bde9-27de-5afd-bda5-dc94bec60ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b1a6-a75f-47b0-b215-de9708b6d773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b1a6-a75f-47b0-b215-de9708b6d773.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "Whenever a creature with power 4 or greater enters the battlefield under your control, draw a card.\n\u22121: Untap target permanent.",
             "colours": [
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "c7405131-4417-5d62-ab10-020f44cb5118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2b1975-183b-4989-aa1f-a653ec732abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2b1975-183b-4989-aa1f-a653ec732abf.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "",
             "colours": [
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "6c4f3a22-7a6a-53c1-9bdc-bbf5210b654e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8806605c-0cb7-4360-96e4-afb424ccad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8806605c-0cb7-4360-96e4-afb424ccad90.jpg?1",
             "name": "Nahiri, Storm of Stone",
             "text": "As long as it's your turn, creatures you control have first strike and equip abilities you activate cost {1} less to activate.\n\u2212X: Nahiri, Storm of Stone deals X damage to target tapped creature.",
             "colours": [
@@ -9354,7 +9354,7 @@
         },
         {
             "id": "00c40864-6487-5497-af84-da7ceac90570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f17544a-7bcd-4315-8e14-bea8317ee13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f17544a-7bcd-4315-8e14-bea8317ee13a.jpg?1",
             "name": "Nahiri, Storm of Stone",
             "text": "",
             "colours": [
@@ -9394,7 +9394,7 @@
         },
         {
             "id": "9db8bfe0-8f19-5575-b36d-0d822c8b1929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a10b543-d5d4-42a8-9ee8-dada59a2ad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a10b543-d5d4-42a8-9ee8-dada59a2ad7e.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "Whenever you cast a noncreature spell, create a 1/1 colorless Servo artifact creature token.\n\u22122: Target artifact you control becomes a copy of another target artifact or creature you control until end of turn, except it's an artifact in addition to its other types.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "2238f49a-461c-51de-b858-9e6f616e7372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555b4e-c682-46d2-a99e-1bd1656155d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555b4e-c682-46d2-a99e-1bd1656155d7.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "",
             "colours": [
@@ -9474,7 +9474,7 @@
         },
         {
             "id": "9a4bc4b2-4b62-513d-a25d-e941c2d3e00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0457e3f-56c1-401b-8e08-f04b95c55e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0457e3f-56c1-401b-8e08-f04b95c55e2d.jpg?1",
             "name": "Samut, Tyrant Smasher",
             "text": "Creatures you control have haste.\n\u22121: Target creature gets +2/+1 and gains haste until end of turn. Scry 1.",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "554bee2e-bd0c-5b8d-a3e4-bf538e99a391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197c8c75-3b53-49ab-adb5-32937b49e834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197c8c75-3b53-49ab-adb5-32937b49e834.jpg?1",
             "name": "Samut, Tyrant Smasher",
             "text": "",
             "colours": [
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "a0c99852-b08e-5f09-9f48-317f2253df15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ee2974-07e9-4506-903c-457cb7327dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ee2974-07e9-4506-903c-457cb7327dd8.jpg?1",
             "name": "Vraska, Swarm's Eminence",
             "text": "Whenever a creature you control with deathtouch deals damage to a player or planeswalker, put a +1/+1 counter on that creature.\n\u22122: Create a 1/1 black Assassin creature token with deathtouch and \"Whenever this creature deals damage to a planeswalker, destroy that planeswalker.\"",
             "colours": [
@@ -9594,7 +9594,7 @@
         },
         {
             "id": "bfbf2df1-007f-500a-bfe5-1310ad1bad5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1523eed-d417-44bc-90fc-f67ecb3dc2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1523eed-d417-44bc-90fc-f67ecb3dc2c4.jpg?1",
             "name": "Vraska, Swarm's Eminence",
             "text": "",
             "colours": [
@@ -9634,7 +9634,7 @@
         },
         {
             "id": "49cb18a1-3ebd-5f6c-b0c3-e4434cd5aa38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0ebb6b-d35a-47db-8071-7fef2a46c17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0ebb6b-d35a-47db-8071-7fef2a46c17b.jpg?1",
             "name": "Firemind Vessel",
             "text": "Firemind Vessel enters the battlefield tapped.\n{T}: Add two mana of different colors.",
             "colours": [],
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "8a6db6ec-f645-510c-9cfb-e52827ad748f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dce06ba-c1e1-45ec-82a7-fc10b0fa8870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dce06ba-c1e1-45ec-82a7-fc10b0fa8870.jpg?1",
             "name": "God-Pharaoh's Statue",
             "text": "Spells your opponents cast cost {2} more to cast.\nAt the beginning of your end step, each opponent loses 1 life.",
             "colours": [],
@@ -9692,7 +9692,7 @@
         },
         {
             "id": "7246a4e8-0537-5016-b07a-433c59c2c285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7faf99e-f61f-46cb-a275-2e12c41f1e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7faf99e-f61f-46cb-a275-2e12c41f1e31.jpg?1",
             "name": "Guild Globe",
             "text": "When Guild Globe enters the battlefield, draw a card.\n{2}, {T}, Sacrifice Guild Globe: Add two mana of different colors.",
             "colours": [],
@@ -9720,7 +9720,7 @@
         },
         {
             "id": "7c489a49-7bb9-5573-a464-00e33fc95e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2c66e-402c-4d5c-b987-402679aa914b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2c66e-402c-4d5c-b987-402679aa914b.jpg?1",
             "name": "Iron Bully",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Iron Bully enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -9751,7 +9751,7 @@
         },
         {
             "id": "0cd9f299-f255-5114-9297-da3fa19f29f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17315a12-a7f8-45ba-ac3b-a62c789e75d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17315a12-a7f8-45ba-ac3b-a62c789e75d0.jpg?1",
             "name": "Mana Geode",
             "text": "When Mana Geode enters the battlefield, scry 1.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9779,7 +9779,7 @@
         },
         {
             "id": "a3aca765-02a0-51c7-8cc5-f5687723a88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40475e96-0283-445f-97fb-1da008707399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40475e96-0283-445f-97fb-1da008707399.jpg?1",
             "name": "Prismite",
             "text": "{2}: Add one mana of any color.",
             "colours": [],
@@ -9810,7 +9810,7 @@
         },
         {
             "id": "104f39bb-55d3-56d4-82d4-f6b1c34975f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba77c07-5d23-4a1a-90a0-b8293848d637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba77c07-5d23-4a1a-90a0-b8293848d637.jpg?1",
             "name": "Saheeli's Silverwing",
             "text": "Flying\nWhen Saheeli's Silverwing enters the battlefield, look at the top card of target opponent's library.",
             "colours": [],
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "c5571152-b10a-5f16-8c80-11bf0122910a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6bc7d5-e8f6-4103-920c-9f7ec5cd6c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6bc7d5-e8f6-4103-920c-9f7ec5cd6c28.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -9869,7 +9869,7 @@
         },
         {
             "id": "b632cecc-63a2-5589-b49d-8b17dad0493f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95f6e7-b806-47fe-a071-6c38b3176d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95f6e7-b806-47fe-a071-6c38b3176d94.jpg?1",
             "name": "Emergence Zone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Emergence Zone: You may cast spells this turn as though they had flash.",
             "colours": [],
@@ -9897,7 +9897,7 @@
         },
         {
             "id": "867dc5ee-8945-5d55-8ddc-28adf77d7c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d69cf2-8643-4926-857e-febbd54d870f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d69cf2-8643-4926-857e-febbd54d870f.jpg?1",
             "name": "Gateway Plaza",
             "text": "Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9927,7 +9927,7 @@
         },
         {
             "id": "cd13979a-8623-5460-b4a4-b9eb503a0682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d8e2a-e1dd-4867-8e8c-e48b9450b350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d8e2a-e1dd-4867-8e8c-e48b9450b350.jpg?1",
             "name": "Interplanar Beacon",
             "text": "Whenever you cast a planeswalker spell, you gain 1 life.\n{T}: Add {C}.\n{1}, {T}: Add two mana of different colors. Spend this mana only to cast planeswalker spells.",
             "colours": [],
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "be235975-8cc2-5d04-9413-cb24078a10c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d895af-7e8c-419f-bc5d-5596083fbfb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d895af-7e8c-419f-bc5d-5596083fbfb6.jpg?1",
             "name": "Karn's Bastion",
             "text": "{T}: Add {C}.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "9e0bac4f-5eb9-5bdb-ba4c-fb3ef2495485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214792e9-a172-4547-b148-b9b368cb3432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214792e9-a172-4547-b148-b9b368cb3432.jpg?1",
             "name": "Mobilized District",
             "text": "{T}: Add {C}.\n{4}: Mobilized District becomes a 3/3 Citizen creature with vigilance until end of turn. It's still a land. This ability costs {1} less to activate for each legendary creature and planeswalker you control.",
             "colours": [],
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "f752014a-4084-5cf0-8ad8-ef1abbc42ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92ef517-2417-43a2-8b1a-0673d1531c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92ef517-2417-43a2-8b1a-0673d1531c65.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "84f7df64-3236-5564-af46-d92f8bf3d82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84144d57-f0b6-4011-aee8-c626c21998c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84144d57-f0b6-4011-aee8-c626c21998c4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "6398dfb7-92c3-514e-9dcd-56eb5cf61407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ae52e-9ea7-4e9d-a9c9-c819cc768cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ae52e-9ea7-4e9d-a9c9-c819cc768cd6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10122,7 +10122,7 @@
         },
         {
             "id": "00ec69b3-2ee6-505c-a5aa-190713ce2342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7014b9fc-a906-4ffd-a482-22ba8dbe3b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7014b9fc-a906-4ffd-a482-22ba8dbe3b4a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "ffc37bdd-e379-5cad-851a-b18eeee2d857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb7b85-8c0f-4311-85f3-11bcb45ba0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb7b85-8c0f-4311-85f3-11bcb45ba0b6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10196,7 +10196,7 @@
         },
         {
             "id": "b641bd1b-2b9d-5354-9c63-d47ed4aa3741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e28a0-a10f-4324-b008-09564e85573e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e28a0-a10f-4324-b008-09564e85573e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10233,7 +10233,7 @@
         },
         {
             "id": "29c0a93a-31d3-5e34-a3e1-dfe16c7979c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eeb424-235d-4346-9355-57914e740ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eeb424-235d-4346-9355-57914e740ec6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "3cef4025-fecf-5c80-aa2d-e01726d40852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211b98e5-8ec2-4108-bacd-97e854a85b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211b98e5-8ec2-4108-bacd-97e854a85b6f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10307,7 +10307,7 @@
         },
         {
             "id": "e604ae3d-dde1-50d6-b3f2-b05995c79cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04559991-3278-469f-b2be-07c3b27ad5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04559991-3278-469f-b2be-07c3b27ad5a5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10344,7 +10344,7 @@
         },
         {
             "id": "9a3c07b1-7f17-582c-a32f-711c63fd7023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489fdba7-5c25-4cf3-a1e0-3e0fda6c6ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489fdba7-5c25-4cf3-a1e0-3e0fda6c6ee6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "8a7eda3c-35ce-58d2-8a46-51f5a0fae7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7878e1-28a5-4527-ba61-ed6c6b855309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7878e1-28a5-4527-ba61-ed6c6b855309.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "27ecba1a-6dd3-5611-9054-5be611b73349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef001a8-adb5-4125-aa1a-f5e3f8ca898b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef001a8-adb5-4125-aa1a-f5e3f8ca898b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10455,7 +10455,7 @@
         },
         {
             "id": "3ff03579-4891-5929-8e6d-516c9e18fffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d61651-349e-40d0-a7c4-c9561e190405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d61651-349e-40d0-a7c4-c9561e190405.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10492,7 +10492,7 @@
         },
         {
             "id": "ffc29ec9-5994-5857-8963-37987b5ff2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ef8358-9812-4d40-9532-d667513d7701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ef8358-9812-4d40-9532-d667513d7701.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10529,7 +10529,7 @@
         },
         {
             "id": "02ef4428-b7c7-55b2-84ed-e07e26d44bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120879f-df13-4583-b260-0fc298518f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120879f-df13-4583-b260-0fc298518f16.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "afa65aca-d3c0-5ec5-a3ab-ae8e45d858c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7331d-98b8-420f-a346-3f3521c3b258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7331d-98b8-420f-a346-3f3521c3b258.jpg?1",
             "name": "Gideon, the Oathsworn",
             "text": "Whenever you attack with two or more non-Gideon creatures, put a +1/+1 counter on each of those creatures.\n+2: Until end of turn, Gideon, the Oathsworn becomes a 5/5 white Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn. (He can't attack if he was cast this turn.)\n\u22129: Exile Gideon, the Oathsworn and each creature your opponents control.",
             "colours": [
@@ -10601,7 +10601,7 @@
         },
         {
             "id": "c26eea1c-45b8-5669-aedd-3478617f4c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce134a-25ef-4f8d-a385-7c29fc5707dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce134a-25ef-4f8d-a385-7c29fc5707dc.jpg?1",
             "name": "Desperate Lunge",
             "text": "Target creature gets +2/+2 and gains flying until end of turn. You gain 2 life.",
             "colours": [
@@ -10632,7 +10632,7 @@
         },
         {
             "id": "bf37df13-6eb3-59f9-ae91-63063737742b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52de8fc6-6d9b-402e-a6c8-4c39b0c92f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52de8fc6-6d9b-402e-a6c8-4c39b0c92f07.jpg?1",
             "name": "Gideon's Battle Cry",
             "text": "Put a +1/+1 counter on each creature you control. You may search your library and/or graveyard for a card named Gideon, the Oathsworn, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "4bfb89dd-6d4a-5da5-ab7d-ed387781606f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a64d2e-8b89-4642-84c2-b01dfe11312e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a64d2e-8b89-4642-84c2-b01dfe11312e.jpg?1",
             "name": "Gideon's Company",
             "text": "Whenever you gain life, put two +1/+1 counters on Gideon's Company.\n{3}{W}: Put a loyalty counter on target Gideon planeswalker.",
             "colours": [
@@ -10697,7 +10697,7 @@
         },
         {
             "id": "eab81823-e710-52b2-88b3-be3dfcf88da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbadf8cf-02bf-45f6-b3c1-a684d9bc5228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbadf8cf-02bf-45f6-b3c1-a684d9bc5228.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "fc9d6f40-8ae4-59ce-a184-4224a864f17d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a857fb-159f-40c4-8988-da91d8521a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a857fb-159f-40c4-8988-da91d8521a60.jpg?1",
             "name": "Jace, Arcane Strategist",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on target creature you control.\n+1: Draw a card.\n\u22127: Creatures you control can't be blocked this turn.",
             "colours": [
@@ -10764,7 +10764,7 @@
         },
         {
             "id": "c1a0a165-01c5-538d-bcde-8169054bb06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a304200f-86d5-4eed-a775-cc24e72872ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a304200f-86d5-4eed-a775-cc24e72872ac.jpg?1",
             "name": "Guildpact Informant",
             "text": "Flying\nWhenever Guildpact Informant deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -10798,7 +10798,7 @@
         },
         {
             "id": "3ad0900e-596e-5b9a-8503-7180b6a3cd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d35a34-01b7-41e1-8491-a6589175d027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d35a34-01b7-41e1-8491-a6589175d027.jpg?1",
             "name": "Jace's Projection",
             "text": "Whenever you draw a card, put a +1/+1 counter on Jace's Projection.\n{3}{U}: Put a loyalty counter on target Jace planeswalker.",
             "colours": [
@@ -10832,7 +10832,7 @@
         },
         {
             "id": "aa0a67a1-cb52-5d46-bbfe-e56546c90a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e8d2c7-cd6e-48bf-9d54-73f3d6cff0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e8d2c7-cd6e-48bf-9d54-73f3d6cff0aa.jpg?1",
             "name": "Jace's Ruse",
             "text": "Return up to two target creatures to their owner's hand. You may search your library and/or graveyard for a card named Jace, Arcane Strategist, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10863,7 +10863,7 @@
         },
         {
             "id": "16eff56b-1261-51ce-86db-a59a9e8cd28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989d6851-2a5d-4d8f-a7b8-724818236c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989d6851-2a5d-4d8f-a7b8-724818236c47.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10895,7 +10895,7 @@
         },
         {
             "id": "e381bfa0-b8d7-52ff-a6fe-1bc22133edda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1eea2-961f-445d-b035-6baed454f289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1eea2-961f-445d-b035-6baed454f289.jpg?1",
             "name": "Tezzeret, Master of the Bridge",
             "text": "Creature and planeswalker spells you cast have affinity for artifacts.\n+2: Tezzeret, Master of the Bridge deals X damage to each opponent, where X is the number of artifacts you control. You gain X life.\n\u22123: Return target artifact card from your graveyard to your hand.\n\u22128: Exile the top ten cards of your library. Put all artifact cards from among them onto the battlefield.",
             "colours": [
@@ -10932,7 +10932,7 @@
         },
         {
             "id": "fd5fe8a4-bb00-5884-9468-86d63c58d1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d7514-35a9-446b-be0d-a5b6b4001291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d7514-35a9-446b-be0d-a5b6b4001291.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -10962,7 +10962,7 @@
         },
         {
             "id": "80298dd1-6460-5e53-8390-f1a1c6ee1e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b81e0-5525-4be3-96db-807146fdc5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b81e0-5525-4be3-96db-807146fdc5b3.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -10996,7 +10996,7 @@
         },
         {
             "id": "6250feea-3f95-5c08-955f-323be591443c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11c711-93fe-45ca-b393-3851148defc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11c711-93fe-45ca-b393-3851148defc4.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -11030,7 +11030,7 @@
         },
         {
             "id": "24eb5aaf-70f4-5d91-8762-0c027557b192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae8c31-70cb-44e1-a105-f4d29f1f9356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae8c31-70cb-44e1-a105-f4d29f1f9356.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -11064,7 +11064,7 @@
         },
         {
             "id": "9b47488c-320d-5b91-b7be-fd6a32c343a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0b95ce-4821-4955-a27c-93471240f54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0b95ce-4821-4955-a27c-93471240f54b.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -11098,7 +11098,7 @@
         },
         {
             "id": "20d740ce-f9b0-580c-9f23-ec1b0c6ea42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e997ac-5a4a-4555-9b37-06c25a5db356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e997ac-5a4a-4555-9b37-06c25a5db356.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "87201137-39ed-586a-985a-90821d3de996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "3e61718a-ebb5-5b67-929d-1eafdafd1388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b7c63-8430-4ca4-baee-dc958d5bd22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b7c63-8430-4ca4-baee-dc958d5bd22f.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -11201,7 +11201,7 @@
         },
         {
             "id": "a915e4c4-e12a-5e5f-ae47-f04e31c547c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3f2ad9-d362-4602-8e49-b44c0659c112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3f2ad9-d362-4602-8e49-b44c0659c112.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -11236,7 +11236,7 @@
         },
         {
             "id": "b58e80b0-3835-5eda-8aa0-b600a9a7cc6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12742d1f-eb2e-4262-88e2-403c9ae6c431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12742d1f-eb2e-4262-88e2-403c9ae6c431.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -11271,7 +11271,7 @@
         },
         {
             "id": "69d5ed6f-fcf2-5d44-896b-4c2b2df9407c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06aa97-1611-4af6-8bad-32051927fcfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06aa97-1611-4af6-8bad-32051927fcfd.jpg?1",
             "name": "Zombie Warrior",
             "text": "",
             "colours": [
@@ -11306,7 +11306,7 @@
         },
         {
             "id": "85006970-f095-5f8f-8888-cd32c5fa6bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dc3d65-1729-4541-9dc3-bd673e9bdc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dc3d65-1729-4541-9dc3-bd673e9bdc5d.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -11340,7 +11340,7 @@
         },
         {
             "id": "f1a101af-6b87-576d-b9a1-e62aa9729e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a195b254-bc3c-4259-9219-5a9e085d7947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a195b254-bc3c-4259-9219-5a9e085d7947.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "4dc37821-5a65-5c3c-9fe6-d8cd57b5c540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0861b13-6cf8-4078-9178-e223a4041a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0861b13-6cf8-4078-9178-e223a4041a8b.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -11408,7 +11408,7 @@
         },
         {
             "id": "d5bb1bad-8652-591d-a221-e91004d64993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f3219-3e98-4354-abcd-db22c3253105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f3219-3e98-4354-abcd-db22c3253105.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -11442,7 +11442,7 @@
         },
         {
             "id": "f383fb18-f9c7-5ae5-a5b3-6145bc1ff24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ba875-f77b-404f-8b75-4ba6f81da410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ba875-f77b-404f-8b75-4ba6f81da410.jpg?1",
             "name": "Citizen",
             "text": "",
             "colours": [
@@ -11484,7 +11484,7 @@
         },
         {
             "id": "39d9e3f7-e989-5ddb-bdc6-db7b3f17463b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39475e91-1e71-4546-ae4a-47ea66e47536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39475e91-1e71-4546-ae4a-47ea66e47536.jpg?1",
             "name": "Voja, Friend to Elves",
             "text": "",
             "colours": [
@@ -11522,7 +11522,7 @@
         },
         {
             "id": "a74ffa4e-54c6-5945-bfc4-8890cd279b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761507d5-d36a-4123-a074-95d7f6ffb4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761507d5-d36a-4123-a074-95d7f6ffb4c5.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "7f8a2b3a-365f-5825-8d10-4ce16e3cd201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b191fe-7a92-4d08-91a4-036699d08bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b191fe-7a92-4d08-91a4-036699d08bc4.jpg?1",
             "name": "Nissa, Who Shakes the World Emblem",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/WHO.json
+++ b/Assets/Resources/Sets/WHO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9d7695d0-cfcd-5923-8f16-0513ec31b047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c5bd2b-cf68-4e5e-819d-53917a6c5275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c5bd2b-cf68-4e5e-819d-53917a6c5275.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -52,7 +52,7 @@
         },
         {
             "id": "91f13aee-1fea-522f-ba42-20c14b400f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84ea0fd-efc7-4614-9f8f-41a3c71fceaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84ea0fd-efc7-4614-9f8f-41a3c71fceaa.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -98,7 +98,7 @@
         },
         {
             "id": "10bc8c49-2239-58ec-92a8-9ccb9298331f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1499f49-793b-4265-9ad0-883a431941ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1499f49-793b-4265-9ad0-883a431941ab.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "845adf01-30b9-59f5-940b-2200b70f713d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc4ec90-1650-4b98-9350-66341394cf0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc4ec90-1650-4b98-9350-66341394cf0b.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -190,7 +190,7 @@
         },
         {
             "id": "397dcc00-a00c-5bb0-80a0-35bafe2dae4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa8d034-f98c-4e27-b6af-850eadf59941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa8d034-f98c-4e27-b6af-850eadf59941.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "71bb3a62-bf3e-5f3b-b334-7e68d27b72de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba76f68-e647-4786-903c-92dbd3cef05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba76f68-e647-4786-903c-92dbd3cef05d.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "87ba4c05-0385-584d-a6c0-44ce59fec23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b09a4f-bb62-4766-8115-cae4d5cc4c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b09a4f-bb62-4766-8115-cae4d5cc4c12.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "7efb45e4-cfa8-51aa-8e02-8f13e8d549ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfae7d1-c09b-47e0-92d8-49b21402207d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfae7d1-c09b-47e0-92d8-49b21402207d.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "f662c683-4f09-5969-8cf2-9400e7be82f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1ee042-6713-4e9e-9901-9b94d99d33f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1ee042-6713-4e9e-9901-9b94d99d33f1.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -398,7 +398,7 @@
         },
         {
             "id": "4ec26b49-a6e1-53d5-a186-dabfab42a03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f91092-b679-46c1-9f0c-3b286ee1d02f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f91092-b679-46c1-9f0c-3b286ee1d02f.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "d52e93d3-4e3b-58a6-b87b-afb838b1e14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda3aa2-5fac-4188-bdad-dc369a089d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda3aa2-5fac-4188-bdad-dc369a089d00.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "1e7cdeab-8cf8-50d9-a611-c5fbc81b36bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03868f8d-1f1b-4892-abb0-be2b00fc2ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03868f8d-1f1b-4892-abb0-be2b00fc2ba7.jpg?1",
             "name": "Atraxi Warden",
             "text": "",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "cd2d7494-b120-5586-b052-d76caca08d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f39d4c-af2d-486d-9408-b987474f8352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f39d4c-af2d-486d-9408-b987474f8352.jpg?1",
             "name": "Banish to Another Universe",
             "text": "",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "f2521d48-6edd-5af8-836c-f6b8ce04c110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bdd33-549d-4690-917c-ea48decffbbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bdd33-549d-4690-917c-ea48decffbbb.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -588,7 +588,7 @@
         },
         {
             "id": "0b41e207-bfed-51e0-98c7-1c355c71bec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b260c0a-b9dc-4a4f-83ee-5a7fbd9b3f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b260c0a-b9dc-4a4f-83ee-5a7fbd9b3f67.jpg?1",
             "name": "The Caves of Androzani",
             "text": "",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "c2f4a7a9-cbd2-5f94-8b95-ae1f20327e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559e77be-42a2-47cf-a2cf-057b37384cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559e77be-42a2-47cf-a2cf-057b37384cb4.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "8b3787ae-4e73-5c7b-ab15-74cdb00554fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d9672-58a7-4ec8-a20d-7054d76fde37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d9672-58a7-4ec8-a20d-7054d76fde37.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "3607ba30-c979-5339-9844-390b7b5bebca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab0052-7f0c-4b56-847f-20552666a271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab0052-7f0c-4b56-847f-20552666a271.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -732,7 +732,7 @@
         },
         {
             "id": "f1889911-bdea-5069-9ccc-6199059f3918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4b912c-07d4-42a1-8f3b-d5f34cca087f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4b912c-07d4-42a1-8f3b-d5f34cca087f.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "1aa57ee1-1c18-5cea-96c5-71ba653f68a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe50fc-6c6c-43e7-ad0e-8f13a254da2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe50fc-6c6c-43e7-ad0e-8f13a254da2a.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -804,7 +804,7 @@
         },
         {
             "id": "b551ecb5-b178-50c2-81c6-6d34aba900a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5da4-0d8e-4db1-b827-ddfeb5ce0f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5da4-0d8e-4db1-b827-ddfeb5ce0f1d.jpg?1",
             "name": "The Girl in the Fireplace",
             "text": "",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "3034ca97-3b46-571c-86ba-139a9bc6cca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bce4bde-33af-4c91-903f-c46218664353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bce4bde-33af-4c91-903f-c46218664353.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "971a4715-46c2-59b3-9703-59edca1a09a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c73220-363e-44d7-b406-436246c02a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c73220-363e-44d7-b406-436246c02a75.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "f5ccdd28-1d48-5f18-8656-674c2c3e05f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513d33fb-becc-4804-806a-764d08fc7b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513d33fb-becc-4804-806a-764d08fc7b7d.jpg?1",
             "name": "The Night of the Doctor",
             "text": "",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "5f9a321d-cce3-534e-86bd-3378eec528e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1642e04-d39a-46dc-8157-549c225c992f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1642e04-d39a-46dc-8157-549c225c992f.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "37ddbd3f-7409-5415-b3cb-59b6b46cca38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f81beb-4565-4cfe-80a2-456f3d44f461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f81beb-4565-4cfe-80a2-456f3d44f461.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "31687180-43c2-5eda-98d8-313686d0e576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc3ebd-34e1-421c-87b4-0be905954289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc3ebd-34e1-421c-87b4-0be905954289.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "7ba8c775-f6dc-5195-8f9e-a9aefed6ea12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361769b3-7e10-4e0f-b623-c00e2144463d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361769b3-7e10-4e0f-b623-c00e2144463d.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "a9e22411-55f6-559a-858a-f37a3cf79d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b68ed3-0d26-4334-8d0c-2d28ced8ee4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b68ed3-0d26-4334-8d0c-2d28ced8ee4c.jpg?1",
             "name": "Trial of a Time Lord",
             "text": "",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "3837f4b6-83e7-5dd4-af64-271b9f3414d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0662fee0-a6bc-4a1c-8a0f-6e7efc6b8a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0662fee0-a6bc-4a1c-8a0f-6e7efc6b8a21.jpg?1",
             "name": "The War Games",
             "text": "",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "fdf7019b-53a0-5a4a-9040-9e5fd95d94aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc4ce53-7805-4448-bc20-f5bf85fdefa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc4ce53-7805-4448-bc20-f5bf85fdefa3.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "82292f40-e2de-57a7-ac0a-802eb5b17a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10918b68-b442-4895-b8a6-57f65274a39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10918b68-b442-4895-b8a6-57f65274a39e.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "37c414e4-79e3-5089-a62b-a2137ff3da3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f290a17-699e-420d-8322-3e28300a0d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f290a17-699e-420d-8322-3e28300a0d2e.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "6fa1ea60-10a3-57a1-9cde-32ecc32cc715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6c639c-0b8a-4369-b7d0-57aa1f83279a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6c639c-0b8a-4369-b7d0-57aa1f83279a.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -1343,7 +1343,7 @@
         },
         {
             "id": "47a1c0fb-a889-5976-a94d-00ae435f0aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b20b07-2983-4b5e-9351-b8d7a5bcd72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b20b07-2983-4b5e-9351-b8d7a5bcd72a.jpg?1",
             "name": "An Unearthly Child",
             "text": "",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "95fb3704-6701-5c6b-9e4f-b05566bd959e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc35b82-a233-4460-968e-d90980fb2074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc35b82-a233-4460-968e-d90980fb2074.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "dacf01c0-9684-55e9-bc08-fb6de61ba4a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15927163-f203-4d45-b78f-70eafb941bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15927163-f203-4d45-b78f-70eafb941bfd.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "12e69b0a-bdbc-54cf-a694-5fcab53d6f64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ce5aa7-70cb-4ab2-9a25-4363aa2b370f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ce5aa7-70cb-4ab2-9a25-4363aa2b370f.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "0115b361-604d-5e3f-a0e3-0464eeacd4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e0a50-304c-4b3f-b5f7-1ca1213c0282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e0a50-304c-4b3f-b5f7-1ca1213c0282.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "726aed83-c456-5f46-b0f3-32af922f9f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31cf95-6e1d-4786-ae92-e1eebdb1da13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31cf95-6e1d-4786-ae92-e1eebdb1da13.jpg?1",
             "name": "Don't Blink",
             "text": "",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "d6fefffc-d6b7-5125-90f8-7d8e661456a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c90a9-697a-4bff-a738-0cebfb238bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c90a9-697a-4bff-a738-0cebfb238bff.jpg?1",
             "name": "The Eleventh Hour",
             "text": "",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "ade5c3bc-0e55-5e9b-8213-7622ad5b3622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c1ebc5-6775-47f3-be43-e59b281eba55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c1ebc5-6775-47f3-be43-e59b281eba55.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "4147ea73-7091-5d15-bb87-9732b6c827d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baea4cd3-cc62-4138-ac2e-5c96c70bbcce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baea4cd3-cc62-4138-ac2e-5c96c70bbcce.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -1681,7 +1681,7 @@
         },
         {
             "id": "0abb16eb-77d7-5275-930f-7d7a8dada1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512e9bd2-77b9-4c1c-8d30-e6249dbd930e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512e9bd2-77b9-4c1c-8d30-e6249dbd930e.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "50ea2745-f009-5c51-a2ee-8379fee0e852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3474c4-9466-46fc-8327-50950d75e79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3474c4-9466-46fc-8327-50950d75e79f.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "50d901b8-93d3-566a-97cf-9a1191262b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b0a2a9-ba95-4330-a8ab-9cb530eb4257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b0a2a9-ba95-4330-a8ab-9cb530eb4257.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "dda3992c-f23b-558a-b015-46c9b465d74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e46695-7bd3-448c-a5ea-6d544943ec5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e46695-7bd3-448c-a5ea-6d544943ec5f.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "8e74cc47-2aa9-5870-8286-4c4c4ae0aabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9f97c9-825b-43dc-96a5-807d1a15fdce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9f97c9-825b-43dc-96a5-807d1a15fdce.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -1881,7 +1881,7 @@
         },
         {
             "id": "06b3fb7d-5569-5bb7-945a-30d5c00776d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aa8dbd-ae18-4d62-a721-94afcb12bf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aa8dbd-ae18-4d62-a721-94afcb12bf27.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "0f045bf3-7c9e-5859-8232-c10662921538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5c463-6b5c-49c9-84c9-666aa8c19fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5c463-6b5c-49c9-84c9-666aa8c19fbf.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -1958,7 +1958,7 @@
         },
         {
             "id": "08552412-cca5-5ffa-9c84-21bd39ac98a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed41499-759d-4a3b-aabb-c462d5831956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed41499-759d-4a3b-aabb-c462d5831956.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "8b14a0f6-c32d-53c0-8652-94273a1d38da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceba3080-4e10-46b3-887c-e2d45581962b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceba3080-4e10-46b3-887c-e2d45581962b.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "fc451067-fefd-5e40-87f4-d331676d2639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6deb8b33-723d-4927-934c-5d049125d235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6deb8b33-723d-4927-934c-5d049125d235.jpg?1",
             "name": "Renegade Silent",
             "text": "",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "89f69343-a889-5338-9202-b2196798f647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3ea66-555c-490d-b34f-12c267bc4e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3ea66-555c-490d-b34f-12c267bc4e9b.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "f4e25f3a-4912-521e-acac-c183ebe6b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dca4c3-efd6-4b6b-ac49-5a916135a592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dca4c3-efd6-4b6b-ac49-5a916135a592.jpg?1",
             "name": "Star Whale",
             "text": "",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "5bd3b8bd-d965-5af1-bbf0-b117dc29fb34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3574926-dd5a-4997-b9e2-7b051bc59c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3574926-dd5a-4997-b9e2-7b051bc59c57.jpg?1",
             "name": "Start the TARDIS",
             "text": "",
             "colours": [
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "0afa3289-1551-5be3-b661-a130c7cd7fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001c639-8bd0-426f-89cb-4ca61f3cc054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001c639-8bd0-426f-89cb-4ca61f3cc054.jpg?1",
             "name": "Surge of Brilliance",
             "text": "",
             "colours": [
@@ -2213,7 +2213,7 @@
         },
         {
             "id": "0f81e2ce-7d82-5fb5-a314-eec32e6d5e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c592af4-5470-4311-af05-761e5a9c46be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c592af4-5470-4311-af05-761e5a9c46be.jpg?1",
             "name": "Time Beetle",
             "text": "",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "cc5956a1-dd9d-5a8a-87f6-f9944c46fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeba907-5dc7-4dbb-b5a4-c86e8151f2ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeba907-5dc7-4dbb-b5a4-c86e8151f2ec.jpg?1",
             "name": "Time Lord Regeneration",
             "text": "",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "6dc44610-e521-5488-8067-03014b0231ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6570c23-f135-4e81-9a4c-934c298a51ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6570c23-f135-4e81-9a4c-934c298a51ad.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "57edcefc-f5a2-5b18-9d1a-2f97a583c826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "0af22e84-fc91-5aa4-bd5b-642499164d47",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "74cbfeee-1233-5e2b-9b96-fb7291fbf157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55412d31-fba2-46fd-b1a1-d47fb41c4b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55412d31-fba2-46fd-b1a1-d47fb41c4b8d.jpg?1",
             "name": "Wibbly-wobbly, Timey-wimey",
             "text": "",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "b2cd3d8b-6284-5641-b8dd-e482f5fe67e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b5538b-4561-4929-8e1c-9763e75cad0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b5538b-4561-4929-8e1c-9763e75cad0e.jpg?1",
             "name": "Zygon Infiltrator",
             "text": "",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "e8f7a181-3ee5-5d8f-8fbf-141407daec36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77763c-b50c-4787-b352-68af16e4c741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77763c-b50c-4787-b352-68af16e4c741.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "2ffa5566-3934-5dab-a0da-919fda8adf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76573f9d-f0f2-47b8-88e7-17d58d0d20d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76573f9d-f0f2-47b8-88e7-17d58d0d20d3.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "750d7ebb-0f67-57b8-bd22-a9797def63cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c55c73-eed0-433c-b1a4-c2edae06a77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c55c73-eed0-433c-b1a4-c2edae06a77f.jpg?1",
             "name": "Death in Heaven",
             "text": "",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "2456a8b5-6547-5c07-987e-26ef5df3deaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e86622-6f30-41b2-87d0-d345110e2387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e86622-6f30-41b2-87d0-d345110e2387.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -2612,7 +2612,7 @@
         },
         {
             "id": "b5a3b520-41c2-5646-8b10-f64d3714293a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da54bbfd-48d8-4b1f-9336-e45be7e0b0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da54bbfd-48d8-4b1f-9336-e45be7e0b0e5.jpg?1",
             "name": "Exterminate!",
             "text": "",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "59218706-6ecd-5fee-883d-b53b71b810c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce10eb6-9718-4739-a796-da33d823a463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce10eb6-9718-4739-a796-da33d823a463.jpg?1",
             "name": "Genesis of the Daleks",
             "text": "",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "ba37142f-1df5-5d4d-b4a6-4a7b0d9908ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f6265-c0c8-4f51-bea8-408caf0a58d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f6265-c0c8-4f51-bea8-408caf0a58d8.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "004badc6-e7a8-5173-94c6-7ec2d4722c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05bca9-a756-4492-b085-221daa384a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05bca9-a756-4492-b085-221daa384a93.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "dcf12813-8ec4-5bc6-be53-40aea8e16f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381de078-6eac-462c-b6d9-095779279d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381de078-6eac-462c-b6d9-095779279d42.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "142b0cc6-cc11-5418-9a2a-4f0266166d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2765f-4016-4e41-9db4-5ad463faceab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2765f-4016-4e41-9db4-5ad463faceab.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "d1932cee-1d5f-5aa1-8f71-4f83fef914c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ec946-036b-480a-bab6-c4102e5c31db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ec946-036b-480a-bab6-c4102e5c31db.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "748e2651-e95f-5da1-94f6-08be6668aed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a2faa-91e3-4e89-ba8d-2cbf7ac005c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a2faa-91e3-4e89-ba8d-2cbf7ac005c0.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "a331d3d4-3ff5-54e0-9941-2a1dcb17d2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74185710-3877-4080-b1d2-014fabbc7186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74185710-3877-4080-b1d2-014fabbc7186.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -2952,7 +2952,7 @@
         },
         {
             "id": "80dd3856-f141-5ef1-985a-0d4761d97a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "91fe54b6-8cd1-5924-b2b0-2f60244cc98f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "7a61cb6e-4d43-55e4-8b29-0da85dbe6e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b5c60e-f2f5-40d7-8713-edc3ecedb5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b5c60e-f2f5-40d7-8713-edc3ecedb5e0.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "d9cf21d7-fe90-549c-af07-c5d1a35afadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc53534-f362-4871-a594-9855a4923cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc53534-f362-4871-a594-9855a4923cd0.jpg?1",
             "name": "Day of the Moon",
             "text": "",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "5c706f9d-de09-5551-8d73-4236219de2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cedaa9-f08a-4d7b-8314-1d0a09a657bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cedaa9-f08a-4d7b-8314-1d0a09a657bd.jpg?1",
             "name": "Decaying Time Loop",
             "text": "",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "83450fa2-1694-5d4d-8035-34188d5bafd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875c7337-78af-4e13-89e5-3255ba2d4053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875c7337-78af-4e13-89e5-3255ba2d4053.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "1d62e349-5c7f-514b-bb4a-118ced504b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ffec6a-fbba-46cc-becb-4ee5ef8c4971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ffec6a-fbba-46cc-becb-4ee5ef8c4971.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "f1622b69-bdd2-5734-a538-64d6d2a0f0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ae18ff-e9df-4712-a0d0-a02621740b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ae18ff-e9df-4712-a0d0-a02621740b5a.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "1234be43-ed79-54aa-848c-8ba367fbff3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11454c82-3f1d-4456-8857-0dcb01d34298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11454c82-3f1d-4456-8857-0dcb01d34298.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "7a5054f8-b6ee-5f47-bb51-f8adbaf0a674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc8ecfd-7388-4725-8c58-bed2cc61400f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc8ecfd-7388-4725-8c58-bed2cc61400f.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "f78e9fdf-bc2b-51f4-9fa8-606e6dbdd89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026611f8-ae07-464f-afe5-6e94bcfac05e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026611f8-ae07-464f-afe5-6e94bcfac05e.jpg?1",
             "name": "The Flux",
             "text": "",
             "colours": [
@@ -3352,7 +3352,7 @@
         },
         {
             "id": "bd7b55f3-12c2-50df-8080-2d6e5bbca5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cc159d-74f7-41fe-a866-c18d96219794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cc159d-74f7-41fe-a866-c18d96219794.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "c954bda2-3aff-584f-a2f6-1a55b8f1c3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a3cb61-b760-4cd4-838c-b26310103719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a3cb61-b760-4cd4-838c-b26310103719.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "bc0e3fe3-08d2-5f26-8068-5afe265c7acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a74a-a4d5-4b9f-8c62-74cdfcc67825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a74a-a4d5-4b9f-8c62-74cdfcc67825.jpg?1",
             "name": "Iraxxa, Empress of Mars",
             "text": "",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "3045627c-fd1b-5be2-9bb9-fcd8ec121373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63837f16-8157-43c7-8da0-88441ac62f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63837f16-8157-43c7-8da0-88441ac62f04.jpg?1",
             "name": "Memory Worm",
             "text": "",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "d9b06a17-7b41-5791-9362-5b7a9c4a092a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65015afb-cfdb-4373-a0db-0ca5e95c49a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65015afb-cfdb-4373-a0db-0ca5e95c49a1.jpg?1",
             "name": "The Parting of the Ways",
             "text": "",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "64a2146b-1d3c-5356-aca4-d82a8c3448a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de4341-d10a-47c6-8a60-9dfa491f1d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de4341-d10a-47c6-8a60-9dfa491f1d02.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -3572,7 +3572,7 @@
         },
         {
             "id": "fb2caba6-dab7-51a5-a806-aa3e41485483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5bcf60-f956-4e0d-beb7-a7f5c1c83692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5bcf60-f956-4e0d-beb7-a7f5c1c83692.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "df14933e-ffa4-561a-8d9b-2e7a47de6be9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42684d97-fce6-4a96-9c64-20e2cb382dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42684d97-fce6-4a96-9c64-20e2cb382dca.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -3652,7 +3652,7 @@
         },
         {
             "id": "b2701af9-6b59-5866-a5bb-d8e61b0bb6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145daf0b-55a3-45a9-b653-e6e4a461d629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145daf0b-55a3-45a9-b653-e6e4a461d629.jpg?1",
             "name": "Sibylline Soothsayer",
             "text": "",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "0714ba2a-6e7e-57c2-b427-922a2818e043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb70fa62-fea1-4e91-a8a1-64b43b777091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb70fa62-fea1-4e91-a8a1-64b43b777091.jpg?1",
             "name": "Sontaran General",
             "text": "",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "3881d44d-b962-517c-bf8a-1200213167c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff2141a-a3ed-4ad0-9338-560502b1c85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff2141a-a3ed-4ad0-9338-560502b1c85c.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "11c63657-d34e-59ba-a1bc-901376718b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f001a0-8393-4977-84bb-cde39740606c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f001a0-8393-4977-84bb-cde39740606c.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "1fd504a0-5d23-5962-b465-2b6d33aedc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4d9b25-02ea-4ce3-a35f-7f427a74f591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4d9b25-02ea-4ce3-a35f-7f427a74f591.jpg?1",
             "name": "City of Death",
             "text": "",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "812911df-e114-5069-b2b5-d0acbf0c47f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43319645-53b0-41f6-be90-9690e86e12d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43319645-53b0-41f6-be90-9690e86e12d3.jpg?1",
             "name": "Displaced Dinosaurs",
             "text": "",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "619f1e25-0543-5dd8-b0b3-b2727f3171df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada5e97f-c079-445c-8071-1c2a6dd00001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada5e97f-c079-445c-8071-1c2a6dd00001.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "996d025b-572d-5c19-84ea-59cd4be596d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93391c14-a22c-4223-a980-5f98350c6a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93391c14-a22c-4223-a980-5f98350c6a99.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -3953,7 +3953,7 @@
         },
         {
             "id": "23eab821-f82c-518d-89f7-d48a1cae00b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15f1891-4f80-4c68-8421-8e16ff8d6a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15f1891-4f80-4c68-8421-8e16ff8d6a6d.jpg?1",
             "name": "Fugitive of the Judoon",
             "text": "",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "cfc5c533-b26d-5ee5-9321-b779c431b29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467d66e-1a81-40d6-945a-f2c679d214d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467d66e-1a81-40d6-945a-f2c679d214d1.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "6cc454c0-cfb5-5541-bf7e-675ba9849f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cececf-8547-4355-972b-7ffbafcda1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cececf-8547-4355-972b-7ffbafcda1c2.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "10367b9f-2b3e-5e0a-b9cc-0c5948e225b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "71340907-c46a-5913-b200-c8b94570fc27",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "f6ab7e9f-28db-558b-85c5-2e9fb44d5cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4e5b5-70c8-4488-9e7d-7d68fe8219d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4e5b5-70c8-4488-9e7d-7d68fe8219d7.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -4188,7 +4188,7 @@
         },
         {
             "id": "8474cb69-577c-56f8-be28-49d82825b2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcb0cb-0df9-4a45-beab-08dc39cf6b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcb0cb-0df9-4a45-beab-08dc39cf6b3b.jpg?1",
             "name": "The Sea Devils",
             "text": "",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "95d7240c-2b11-53e5-87ef-d94bc799c848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b94f939-5f3b-4b55-8514-b7d296509ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b94f939-5f3b-4b55-8514-b7d296509ac1.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "d5d92453-e001-5ab9-bff8-0585c1bb139e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40ec4f-37e7-4e6d-b47b-8b13ea2c9157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40ec4f-37e7-4e6d-b47b-8b13ea2c9157.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -4302,7 +4302,7 @@
         },
         {
             "id": "b5566e98-c6b4-55cc-bced-b54469ac1daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05e23b-419f-4023-9ad4-1227bb1b53be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05e23b-419f-4023-9ad4-1227bb1b53be.jpg?1",
             "name": "Thijarian Witness",
             "text": "",
             "colours": [
@@ -4339,7 +4339,7 @@
         },
         {
             "id": "daa89de4-3acc-569a-828f-c1cc111bc1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf952d23-291d-42fa-8f2a-e4002a04b95f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf952d23-291d-42fa-8f2a-e4002a04b95f.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "b52f0857-9580-50b8-89e8-61777d302780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc19e32-4f78-492f-8586-54ad4ae6fcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc19e32-4f78-492f-8586-54ad4ae6fcec.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "44c96465-c93b-5ce6-8ef3-dafc7743158f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6218badd-d352-4e6d-9c84-f1e3f2f84695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6218badd-d352-4e6d-9c84-f1e3f2f84695.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "5b258614-c529-5650-820d-0c7be58228a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1178ac-35b9-4086-8ad4-6c629d976ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1178ac-35b9-4086-8ad4-6c629d976ce2.jpg?1",
             "name": "Bigger on the Inside",
             "text": "",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "3979b72e-2f7c-5bc7-8389-e59fe478eb1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032adfbd-3898-410c-acf0-79b88f924520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032adfbd-3898-410c-acf0-79b88f924520.jpg?1",
             "name": "Blink",
             "text": "",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "ef81d167-9608-5a88-b3a0-dfbf38fb3a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3913111c-6a77-4536-bbb4-0ac5bf18fe53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3913111c-6a77-4536-bbb4-0ac5bf18fe53.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "50259ff1-5c04-5a18-b848-23c0e46f6d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e399b70-d793-4833-8317-557fa98a611c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e399b70-d793-4833-8317-557fa98a611c.jpg?1",
             "name": "The Curse of Fenric",
             "text": "",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "cd652568-6481-527f-b7ad-c51238b6f90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab0df1-d53f-4208-9ff9-d015aac20141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab0df1-d53f-4208-9ff9-d015aac20141.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "01ce6836-0f32-54d3-8fd2-a83b342c3629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96e1793-cf1c-452d-9443-b0aad4475d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96e1793-cf1c-452d-9443-b0aad4475d50.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "87424e00-3915-568e-8ec7-af1a796d785a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9767f42c-df04-4426-929a-87e51aa2b8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9767f42c-df04-4426-929a-87e51aa2b8a5.jpg?1",
             "name": "The Day of the Doctor",
             "text": "",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "55b5c4eb-a009-58da-9b95-f9cbe7236709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816242c4-54ec-4f49-8f77-b3dbf1576247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816242c4-54ec-4f49-8f77-b3dbf1576247.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "1e054b6d-d4f5-5fd4-8963-bff427672204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21aafe-c093-40db-830e-da4c87055254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21aafe-c093-40db-830e-da4c87055254.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -4837,7 +4837,7 @@
         },
         {
             "id": "c15037dc-c621-510c-8a30-54756aee587c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf6fd-ced3-4c37-8adb-9a75c6d6d5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf6fd-ced3-4c37-8adb-9a75c6d6d5cc.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "88f87268-3d13-5ebd-9b5a-4bdd15df76cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590849a7-9abc-4757-8e13-f680d3b1dceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590849a7-9abc-4757-8e13-f680d3b1dceb.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "1910ae62-1cef-5a76-8963-a91bb37cb01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b207088-b63c-4d9f-9a42-377736855101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b207088-b63c-4d9f-9a42-377736855101.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "8b2f2a3b-ae06-5ad1-9dfc-e56d4a4efe99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f548f4b-77b9-47bb-b262-a851fdf0124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f548f4b-77b9-47bb-b262-a851fdf0124f.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "dd4920cd-d411-515c-84c9-bf5d3e35641a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4d7db-56b1-4110-b4e4-11748201caf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4d7db-56b1-4110-b4e4-11748201caf9.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "0de89a00-936c-5a23-9528-cb6130760f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d85d8c7-07b2-4577-8c62-7a34dca73ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d85d8c7-07b2-4577-8c62-7a34dca73ad8.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -5106,7 +5106,7 @@
         },
         {
             "id": "2d3eec1d-71b5-53bc-971c-6af9adfdb14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea8bd29-80a4-463f-b3bd-e15f4bd5f5ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea8bd29-80a4-463f-b3bd-e15f4bd5f5ce.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "7bec4bef-6974-521c-b3d3-7f0d2608b266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -5186,7 +5186,7 @@
         },
         {
             "id": "b2cc771f-7836-5527-b2fb-97a9f7cf7e71",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "f1ebe024-a571-5726-81b8-ea3b1924905d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1f865e-759e-4303-81b5-74a558d270ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1f865e-759e-4303-81b5-74a558d270ec.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "98053eb2-3381-5476-98c9-b7e6f32a371c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a798feb4-561b-4bb9-bdc9-771325faec57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a798feb4-561b-4bb9-bdc9-771325faec57.jpg?1",
             "name": "Great Intelligence's Plan",
             "text": "",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "e5797504-39cc-501a-b924-f7174faf4738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14692f-f1c3-4d7f-8baf-3248621e36fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14692f-f1c3-4d7f-8baf-3248621e36fb.jpg?1",
             "name": "Heaven Sent",
             "text": "",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "255b83dc-2618-5ce7-be21-7cb525140d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0018c07-73dc-4762-ad55-78b18f885877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0018c07-73dc-4762-ad55-78b18f885877.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "a0f888ef-f97c-5d3f-8bba-9b3f910e80d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebd099-ce57-4053-8f25-d18b3d47fac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebd099-ce57-4053-8f25-d18b3d47fac4.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "2b9eac38-9be2-5a6d-8d73-c908fef66c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abedc7b1-b6a4-48ab-a336-c0b8edb426a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abedc7b1-b6a4-48ab-a336-c0b8edb426a2.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "bb29c428-4263-5353-a9ce-233f7fd895d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab1e87e-e778-46fb-9f6d-563463447159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab1e87e-e778-46fb-9f6d-563463447159.jpg?1",
             "name": "Judoon Enforcers",
             "text": "",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "bfbb4441-5b1e-574f-a680-1b709d85912d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c2b4d-5627-4264-943f-9be029c0ee92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c2b4d-5627-4264-943f-9be029c0ee92.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -5549,7 +5549,7 @@
         },
         {
             "id": "ef0b5f80-c8d5-5979-9962-0c167f0a643f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ed521-eff6-4bdd-939d-8304b26ad256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ed521-eff6-4bdd-939d-8304b26ad256.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "9d29ea37-79ed-5456-bde9-0276a21cc60d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd60763-8954-4502-99ef-f4f38bf7671b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd60763-8954-4502-99ef-f4f38bf7671b.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -5628,7 +5628,7 @@
         },
         {
             "id": "e9dab452-6e51-54ca-bb3a-d6fd7d8d8b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94849571-928a-4c6d-9868-58f606941679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94849571-928a-4c6d-9868-58f606941679.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -5671,7 +5671,7 @@
         },
         {
             "id": "ad74deda-2c54-5298-90af-d83964ae22fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85edffb-37ce-45ca-b8d2-ddbbbee3b571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85edffb-37ce-45ca-b8d2-ddbbbee3b571.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -5716,7 +5716,7 @@
         },
         {
             "id": "d17541d1-d6ce-58a5-b453-eff4b46c3c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efb5dd0-abc4-4741-9d90-d8d93b03cf21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efb5dd0-abc4-4741-9d90-d8d93b03cf21.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "115ac423-6328-563b-ae29-11c9992591b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772306d4-63d1-4d90-8c1b-4e4d6edb9aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772306d4-63d1-4d90-8c1b-4e4d6edb9aab.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -5806,7 +5806,7 @@
         },
         {
             "id": "a99a7fb9-2077-526d-8ee0-9cdbe2222386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f734ca0-91bc-4496-9bd7-2d09415e850f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f734ca0-91bc-4496-9bd7-2d09415e850f.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "905b45a6-fc6e-5906-aa8f-da25b13cfb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfbf6bf-c0e1-48a1-9223-73099fe470aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfbf6bf-c0e1-48a1-9223-73099fe470aa.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "717aea21-f13f-5cd3-b38e-1930fe148565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74785b3b-44df-4555-a036-082572b7f4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74785b3b-44df-4555-a036-082572b7f4e7.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -5942,7 +5942,7 @@
         },
         {
             "id": "5323bf11-29c3-5e54-b53d-d6860ee3e2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b44c52-b3a3-4954-adcc-53b79921ea24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b44c52-b3a3-4954-adcc-53b79921ea24.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "18710f57-cf0b-5587-9c02-e6014b8040c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564120cb-dbe5-4a28-947c-d79ad3123152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564120cb-dbe5-4a28-947c-d79ad3123152.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -6030,7 +6030,7 @@
         },
         {
             "id": "1de6265f-5c91-5d4c-9fbc-47652c4f66ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7c35e0-b304-4b24-a8a1-5ccc4bb2aad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7c35e0-b304-4b24-a8a1-5ccc4bb2aad0.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -6068,7 +6068,7 @@
         },
         {
             "id": "be068f89-ae05-56a8-ac38-e854a7aa5630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1efb084-d2a0-44c4-a89d-6445156bb298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1efb084-d2a0-44c4-a89d-6445156bb298.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "c9921b30-46c8-5cac-9c4e-1d11fbc17852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51a010d-641c-413f-8f91-0c8ff3b2085c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51a010d-641c-413f-8f91-0c8ff3b2085c.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -6157,7 +6157,7 @@
         },
         {
             "id": "7d720df5-dcfe-5467-8c09-bbe4aac5af4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95452998-7196-4a9b-b8a3-93cb3ec24f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95452998-7196-4a9b-b8a3-93cb3ec24f93.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "72b69aca-ca1e-569b-992e-ff1e1b43df66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33354a5-d99a-46dd-8715-34dbc5f0ec3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33354a5-d99a-46dd-8715-34dbc5f0ec3b.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -6238,7 +6238,7 @@
         },
         {
             "id": "a082edcd-f75c-557c-afe9-d7f1ed1d1b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568c2687-4381-4954-9cab-f669d1fe6306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568c2687-4381-4954-9cab-f669d1fe6306.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -6284,7 +6284,7 @@
         },
         {
             "id": "a85ccad7-1f6b-505b-8d35-b76a828ef1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f40e07-f565-4b9e-87a5-5b28b4e9fb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f40e07-f565-4b9e-87a5-5b28b4e9fb0b.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -6327,7 +6327,7 @@
         },
         {
             "id": "480b85ce-223e-5d48-887a-dd183888f667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd6bfb3-1338-4ee6-9281-30a7428200d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd6bfb3-1338-4ee6-9281-30a7428200d2.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "a45490c0-0295-5e76-8ff8-6e1f754a894c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c045ccb2-28d1-4bbe-9feb-3e86988fd24d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c045ccb2-28d1-4bbe-9feb-3e86988fd24d.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -6419,7 +6419,7 @@
         },
         {
             "id": "66718e9c-6227-5d46-81a7-2b506a0cf6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4801775-70e2-4cda-959c-27f9aa623767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4801775-70e2-4cda-959c-27f9aa623767.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "5f6f7741-a29b-5d13-a79a-6c430236c52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d27ceaf-f4cf-489b-b305-552a9d065584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d27ceaf-f4cf-489b-b305-552a9d065584.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "11117d33-3a7e-51a2-b96d-a558162c2f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2934f5e5-2274-4de7-a8c7-ca034f1fec29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2934f5e5-2274-4de7-a8c7-ca034f1fec29.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "0a1f1e1a-ff99-55f0-8a73-ecb64070f984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8771cc-1042-47b1-b4fa-459c3eeece04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8771cc-1042-47b1-b4fa-459c3eeece04.jpg?1",
             "name": "Truth or Consequences",
             "text": "",
             "colours": [
@@ -6585,7 +6585,7 @@
         },
         {
             "id": "620caa98-ebdb-5638-b9d8-ebf7a2f26f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2400d681-05ef-43b1-b720-c15ca4226c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2400d681-05ef-43b1-b720-c15ca4226c27.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -6631,7 +6631,7 @@
         },
         {
             "id": "497b45b3-0b1d-599b-acec-22c38e49e138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63218a4-afaf-4ad8-9ca4-4f9af87877b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63218a4-afaf-4ad8-9ca4-4f9af87877b9.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -6676,7 +6676,7 @@
         },
         {
             "id": "fec33c7d-adf9-5a0f-b358-def9a6b4eb7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b117d388-ac94-4e20-84f0-f4d242121d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b117d388-ac94-4e20-84f0-f4d242121d7f.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "9e61d464-ea19-5190-84d5-7a13a46ac2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a51472c-b61f-4d31-8753-a9ec90d12889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a51472c-b61f-4d31-8753-a9ec90d12889.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -6765,7 +6765,7 @@
         },
         {
             "id": "ba5f5c5d-82ee-5a94-9cde-b0179ec14cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd7b66-28f1-407b-bd60-6bcc577288cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd7b66-28f1-407b-bd60-6bcc577288cb.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -6809,7 +6809,7 @@
         },
         {
             "id": "d88f6609-8119-54c9-97ed-5a7fef871ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e7d2ca-3fa9-4cb2-adc2-dae4e161f186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e7d2ca-3fa9-4cb2-adc2-dae4e161f186.jpg?1",
             "name": "Wreck and Rebuild",
             "text": "",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "dd0a86e7-e194-5050-aedf-862a871c415e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1132b6-9db6-440c-9e0a-fae6c157e8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1132b6-9db6-440c-9e0a-fae6c157e8a3.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -6881,7 +6881,7 @@
         },
         {
             "id": "53cb982c-b5f4-581e-aec9-d64524cb9dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb585d-2b49-44a0-93d0-98dc8e0727c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb585d-2b49-44a0-93d0-98dc8e0727c2.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -6917,7 +6917,7 @@
         },
         {
             "id": "cbdf4991-cf78-52fa-940c-ea5fe304c8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa6d0-dc2d-4903-bbba-6cf83be2b187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa6d0-dc2d-4903-bbba-6cf83be2b187.jpg?1",
             "name": "Clockwork Droid",
             "text": "",
             "colours": [],
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "c2e5393f-8e25-5574-a1df-9613c246d13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2e0de7-e29d-432e-8782-766c0c31c05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2e0de7-e29d-432e-8782-766c0c31c05d.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -6982,7 +6982,7 @@
         },
         {
             "id": "9929467d-00dd-5303-801a-5e4e9f2c7d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566ae475-48cd-42d0-8d96-168529b2180d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566ae475-48cd-42d0-8d96-168529b2180d.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -7017,7 +7017,7 @@
         },
         {
             "id": "33941334-1369-5643-8525-ff87c523dca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db625a36-5b87-4ddd-8c9e-0969ff8e6488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db625a36-5b87-4ddd-8c9e-0969ff8e6488.jpg?1",
             "name": "Cybermat",
             "text": "",
             "colours": [],
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "9c6725a6-283e-5899-8c4f-85cadae733f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce660ef-0c6f-413d-8ddd-b755a19ab731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce660ef-0c6f-413d-8ddd-b755a19ab731.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -7085,7 +7085,7 @@
         },
         {
             "id": "d9265bb2-bed2-50b8-a518-b3c8dd297cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9d006-7179-4d59-88ef-34b4d4b2e2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9d006-7179-4d59-88ef-34b4d4b2e2fc.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -7119,7 +7119,7 @@
         },
         {
             "id": "65f93992-9dbc-565b-a025-560dc44fd8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e646af0-1a7a-4e2c-83ba-78e748737846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e646af0-1a7a-4e2c-83ba-78e748737846.jpg?1",
             "name": "Laser Screwdriver",
             "text": "",
             "colours": [],
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "741652c3-c6c0-5805-8654-fdf21a010be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8dcf01-8e2c-439c-81c4-650dd01ecb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8dcf01-8e2c-439c-81c4-650dd01ecb65.jpg?1",
             "name": "Midnight Crusader Shuttle",
             "text": "",
             "colours": [],
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "e7a9bcb9-e0d8-5dbe-b158-236594e79e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f233e7db-321f-4ab1-ae49-e45eae188f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f233e7db-321f-4ab1-ae49-e45eae188f3f.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -7215,7 +7215,7 @@
         },
         {
             "id": "4855f17d-2d72-5ffe-951c-7326982870ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae12c61-0125-4810-b0e4-139c27b1b08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae12c61-0125-4810-b0e4-139c27b1b08b.jpg?1",
             "name": "Psychic Paper",
             "text": "",
             "colours": [],
@@ -7247,7 +7247,7 @@
         },
         {
             "id": "d434bc7b-a0f7-5561-9540-1b9bc0c11c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96476a30-72b0-4f91-9d2d-85fc196f89c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96476a30-72b0-4f91-9d2d-85fc196f89c5.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -7279,7 +7279,7 @@
         },
         {
             "id": "d1b20507-16c2-50e9-a03c-7b2c52811b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a06389-7e2b-49f1-a4d2-bb8ea580057a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a06389-7e2b-49f1-a4d2-bb8ea580057a.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -7311,7 +7311,7 @@
         },
         {
             "id": "8d87cd62-b99c-55c2-ab17-6ad81d0f7a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131027a-9776-41fa-8a5f-d9ef80e0dc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131027a-9776-41fa-8a5f-d9ef80e0dc2e.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "e51f0c25-2676-5dde-a93a-6d032ed9cb95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57896797-af41-42f7-90fb-0319b9592ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57896797-af41-42f7-90fb-0319b9592ff3.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -7379,7 +7379,7 @@
         },
         {
             "id": "f576aed3-fd07-5bb2-8403-3321b7d88e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a55d514-b670-4fe2-825b-9ba955977cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a55d514-b670-4fe2-825b-9ba955977cac.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "3eafd064-26ad-5367-b956-9df24a87e8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059b1d8-3bfb-40c9-9344-addda43509ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059b1d8-3bfb-40c9-9344-addda43509ab.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -7447,7 +7447,7 @@
         },
         {
             "id": "cbd79cea-9782-5689-94b7-6af390a11639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d990f5-a7b7-4482-95e6-b03a397192e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d990f5-a7b7-4482-95e6-b03a397192e2.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "2878f5a6-5948-557a-9fca-dce84477d470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e843c57-fae3-4127-94e7-cad8c8bb9486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e843c57-fae3-4127-94e7-cad8c8bb9486.jpg?1",
             "name": "Ominous Cemetery",
             "text": "",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "1282eb59-b73c-5ff6-81aa-4d41f111a76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64444549-1198-4465-91d5-02a7903691dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64444549-1198-4465-91d5-02a7903691dc.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "68432632-d503-5ebd-96aa-97152c3408b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d180a882-84d9-4e38-8aed-1fc6ecd1df72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d180a882-84d9-4e38-8aed-1fc6ecd1df72.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "fa5b7ee1-7b63-5c14-a9a0-42c442a966e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1838aa-591f-4694-b772-beaab94587c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1838aa-591f-4694-b772-beaab94587c3.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -7637,7 +7637,7 @@
         },
         {
             "id": "aa00fb56-4d2d-512a-8693-bafddc9b5ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f14a4-7b8d-4e1d-a48d-4920130b8e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f14a4-7b8d-4e1d-a48d-4920130b8e23.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "c74f7497-f307-5486-9861-b2e53034c902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea9e80-0d3a-4b75-8f29-56e88d6fe66a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea9e80-0d3a-4b75-8f29-56e88d6fe66a.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -7729,7 +7729,7 @@
         },
         {
             "id": "a4d8b55a-7761-5685-a768-d6bcae2809b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e79f4fc-c56b-49b7-82cb-138f6e3bcefa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e79f4fc-c56b-49b7-82cb-138f6e3bcefa.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -7775,7 +7775,7 @@
         },
         {
             "id": "400f0f2b-5d12-56b1-85ee-2a2c421af71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4d8ef3-2b26-4376-a00e-ccd58e3ea2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4d8ef3-2b26-4376-a00e-ccd58e3ea2eb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "314c360b-6d1b-52f9-91aa-c843bb4106ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaea970-a19c-400a-a8cb-5d30f9cc2672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaea970-a19c-400a-a8cb-5d30f9cc2672.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "5be2515d-c1f8-5991-9fa6-a7c4d24311db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98e0fb-5f07-40c8-9958-84379bcdc35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98e0fb-5f07-40c8-9958-84379bcdc35c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7889,7 +7889,7 @@
         },
         {
             "id": "d4c75420-bcb3-5593-a8a3-e340bd55504b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b2aae2-a0b4-4c52-8a43-a4155527bae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b2aae2-a0b4-4c52-8a43-a4155527bae9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "eb75cae2-e4a8-54dd-9b2f-fcb6fee3cda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5788684f-1339-4cb4-863a-a9883ccab79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5788684f-1339-4cb4-863a-a9883ccab79b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -7965,7 +7965,7 @@
         },
         {
             "id": "47e88022-28fe-51fe-80a1-57b34268de9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5d8a2c-b98a-4dae-8b89-4a2435fa7103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5d8a2c-b98a-4dae-8b89-4a2435fa7103.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "6300fa51-8df9-5a70-9fa9-bf2ea711352c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c34fe0-77ec-4ba3-a214-00d0eb42ebae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c34fe0-77ec-4ba3-a214-00d0eb42ebae.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "bbec3756-04a7-5d84-822f-f73f17e89616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f1fe4e-8da1-4879-8129-bd8a440a45be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f1fe4e-8da1-4879-8129-bd8a440a45be.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8079,7 +8079,7 @@
         },
         {
             "id": "3b4999ec-8f2b-5670-a047-22484d107f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c95d38-c135-4059-9379-051b2dd33f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c95d38-c135-4059-9379-051b2dd33f9c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "13fa4399-8e16-578b-8974-5dbc0babf0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3f35e-451e-4de6-a4f7-249287566964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3f35e-451e-4de6-a4f7-249287566964.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8155,7 +8155,7 @@
         },
         {
             "id": "a875ad4a-06bc-5815-a30f-40afb5b90da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f2bd7a-4d14-43ef-b04a-3383aeae615c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f2bd7a-4d14-43ef-b04a-3383aeae615c.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -8193,7 +8193,7 @@
         },
         {
             "id": "decd2674-7136-5a0f-b462-7cd141a82b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c922516-7a2d-41a6-b546-4e73c5ccdb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c922516-7a2d-41a6-b546-4e73c5ccdb0b.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "8a0e3f10-9a7a-5551-976c-ed61c87c7be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bae9eca-8cc9-490b-a9b5-ba2a083bcb08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bae9eca-8cc9-490b-a9b5-ba2a083bcb08.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "e383532d-d317-5982-a750-ce1eb7d5554d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0c372-bc10-49f6-9fd4-a482790846e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0c372-bc10-49f6-9fd4-a482790846e4.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -8301,7 +8301,7 @@
         },
         {
             "id": "fa6d924d-8945-5de9-9621-13e75e37a3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b5c4d1-4271-4e89-9947-95ca9ff1d63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b5c4d1-4271-4e89-9947-95ca9ff1d63d.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -8335,7 +8335,7 @@
         },
         {
             "id": "48e05954-29f7-556b-a71b-906041f3f0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516678c-37ce-4958-a149-aff03ef1dfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516678c-37ce-4958-a149-aff03ef1dfd6.jpg?1",
             "name": "Return to Dust",
             "text": "",
             "colours": [
@@ -8369,7 +8369,7 @@
         },
         {
             "id": "c9c2eaa3-ab5b-51d9-bb5d-8acd02600b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc8dea8-a6af-4bba-affa-92aca36a8413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc8dea8-a6af-4bba-affa-92aca36a8413.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "61f9041c-a7e9-5fc5-a5ac-f5ba89320a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8fd9a7-d1bd-43bd-a136-49dc26621e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8fd9a7-d1bd-43bd-a136-49dc26621e4d.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "a2f1d4a2-bd45-53ec-9bd4-42e69967e5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfcd573-dc06-4b2a-9a9a-7e35267ac800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfcd573-dc06-4b2a-9a9a-7e35267ac800.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "9a02c104-991c-5260-bdef-922c8a3d1f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01aeee52-1fb0-4eeb-8fd8-455fdd91db15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01aeee52-1fb0-4eeb-8fd8-455fdd91db15.jpg?1",
             "name": "Clockspinning",
             "text": "",
             "colours": [
@@ -8509,7 +8509,7 @@
         },
         {
             "id": "89e9586b-4ede-59f6-a8cc-de02e6f422ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5798d2-52d2-4294-8cc4-7cd8f380da92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5798d2-52d2-4294-8cc4-7cd8f380da92.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -8545,7 +8545,7 @@
         },
         {
             "id": "fdeb0622-f3d4-5c3c-b697-326c4c22c773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262285ab-3a6f-4932-b53b-8ab20bcad955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262285ab-3a6f-4932-b53b-8ab20bcad955.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -8579,7 +8579,7 @@
         },
         {
             "id": "aed2dc95-6a43-5598-bbbe-2e7a7610432c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3757f89-56fe-4234-bb8e-a2f3ae645a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3757f89-56fe-4234-bb8e-a2f3ae645a06.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "14d3fbb1-59f8-518d-8d1e-99f3266bb38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16023fe1-f5e7-4ec0-aef2-c34c131b8ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16023fe1-f5e7-4ec0-aef2-c34c131b8ff3.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "f4e62bc5-157e-57aa-95b4-43ddd46dffb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988111df-e398-4e87-aaf9-5872f36710de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988111df-e398-4e87-aaf9-5872f36710de.jpg?1",
             "name": "Think Twice",
             "text": "",
             "colours": [
@@ -8681,7 +8681,7 @@
         },
         {
             "id": "3b7e933a-1d2e-5252-86f9-36d77bb13c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ca70f4-2fb2-4e0b-b1d6-c9220766807f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ca70f4-2fb2-4e0b-b1d6-c9220766807f.jpg?1",
             "name": "Feed the Swarm",
             "text": "",
             "colours": [
@@ -8715,7 +8715,7 @@
         },
         {
             "id": "e24184f7-be08-5132-9cb9-91187f87f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760660d0-06f2-49ea-afbf-647d7f1ea151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760660d0-06f2-49ea-afbf-647d7f1ea151.jpg?1",
             "name": "Snuff Out",
             "text": "",
             "colours": [
@@ -8749,7 +8749,7 @@
         },
         {
             "id": "45f562f2-7452-558e-91b1-849aec609292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d7dcdd-bec4-4795-b04f-63430228e48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d7dcdd-bec4-4795-b04f-63430228e48c.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -8785,7 +8785,7 @@
         },
         {
             "id": "729786e1-134a-5cae-a278-1faeea103be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e5d93b-2f1f-43ed-b8ff-ee00d98eb46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e5d93b-2f1f-43ed-b8ff-ee00d98eb46c.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -8821,7 +8821,7 @@
         },
         {
             "id": "f86c009c-393e-56da-8038-8c5644518a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff37491-f496-4810-80a4-d13470434994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff37491-f496-4810-80a4-d13470434994.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "b3fcfb5e-e2d4-5b22-9e8f-e8d6aa2466ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb9aadf-a50e-4542-82e8-6d8cbc2ea350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb9aadf-a50e-4542-82e8-6d8cbc2ea350.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -8893,7 +8893,7 @@
         },
         {
             "id": "4643dc08-ada4-590b-8ddf-66d77b01deec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74881c8f-f21d-4901-90cf-2ae8d0f46c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74881c8f-f21d-4901-90cf-2ae8d0f46c3d.jpg?1",
             "name": "Throes of Chaos",
             "text": "",
             "colours": [
@@ -8927,7 +8927,7 @@
         },
         {
             "id": "5d4caee9-9c1f-5e20-b4eb-e7b38535b3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df0ecf-9161-4515-8511-fb042b9562ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df0ecf-9161-4515-8511-fb042b9562ae.jpg?1",
             "name": "Beast Within",
             "text": "",
             "colours": [
@@ -8961,7 +8961,7 @@
         },
         {
             "id": "4095ce76-4aa7-5a56-aeff-d8d3e5ea5c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd374915-323c-4d98-9b59-94d405c1dde8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd374915-323c-4d98-9b59-94d405c1dde8.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -8997,7 +8997,7 @@
         },
         {
             "id": "6384c4da-ec41-5029-b74e-1eafb59f68df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6396ba2-ea82-4ca8-9848-08751a1bf45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6396ba2-ea82-4ca8-9848-08751a1bf45a.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "bba7e759-5e05-5e08-969d-e6097296b6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25768b76-c6d7-4b0b-8427-d0a80633aa39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25768b76-c6d7-4b0b-8427-d0a80633aa39.jpg?1",
             "name": "Explore",
             "text": "",
             "colours": [
@@ -9065,7 +9065,7 @@
         },
         {
             "id": "b1a2c4f8-6e67-5b2d-b012-62de7ac31cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befd2137-bd91-4209-bdec-219cf53b7be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befd2137-bd91-4209-bdec-219cf53b7be7.jpg?1",
             "name": "Farseek",
             "text": "",
             "colours": [
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "5c5d4284-1c9f-5a56-849a-575c12c88251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11d822-51c7-41dd-8f78-718d884019e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11d822-51c7-41dd-8f78-718d884019e8.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -9135,7 +9135,7 @@
         },
         {
             "id": "f1a3f175-c2d9-56d8-90f9-7f94aa9263a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857818d8-454b-4c2c-8cf2-7aa9c2898b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857818d8-454b-4c2c-8cf2-7aa9c2898b18.jpg?1",
             "name": "Search for Tomorrow",
             "text": "",
             "colours": [
@@ -9169,7 +9169,7 @@
         },
         {
             "id": "12504f7c-221b-5cea-920e-440d52d0c3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc20bfa9-6d55-49f4-a86a-8fb3b433ee29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc20bfa9-6d55-49f4-a86a-8fb3b433ee29.jpg?1",
             "name": "Three Visits",
             "text": "",
             "colours": [
@@ -9203,7 +9203,7 @@
         },
         {
             "id": "9593fd56-7e99-50ea-a1a8-f1878424b227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1e9cd6-7be2-4c9a-a94f-3ea7e69e49db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1e9cd6-7be2-4c9a-a94f-3ea7e69e49db.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -9241,7 +9241,7 @@
         },
         {
             "id": "14125cf2-d3b5-5c66-ba58-ae6a04cfe0fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac9e381-dbb8-478b-b385-9f09f0325e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac9e381-dbb8-478b-b385-9f09f0325e87.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -9277,7 +9277,7 @@
         },
         {
             "id": "57e462ae-a87f-5ef7-936d-6aac8be9721c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e5358a-23b6-4dac-893e-48f4481609ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e5358a-23b6-4dac-893e-48f4481609ab.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -9315,7 +9315,7 @@
         },
         {
             "id": "6781d9ff-2fd2-5ff7-bd04-96bd7eee5a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d58eb-b95a-48d9-a174-e2d72a29c167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d58eb-b95a-48d9-a174-e2d72a29c167.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -9345,7 +9345,7 @@
         },
         {
             "id": "cf67df45-bf86-5ea4-8a29-6a321f4ec7e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331338ed-5b1e-4cc0-8a3f-ea43539b9346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331338ed-5b1e-4cc0-8a3f-ea43539b9346.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "40fbd46c-01c7-5bf7-9a56-91c835349da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84f5c57-0589-4eac-bad7-775122c767c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84f5c57-0589-4eac-bad7-775122c767c1.jpg?1",
             "name": "Hero's Blade",
             "text": "",
             "colours": [],
@@ -9407,7 +9407,7 @@
         },
         {
             "id": "36d2a82b-42b5-52a1-a6df-ada0b448d5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4503b65f-416e-49af-88c8-0871bca2c050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4503b65f-416e-49af-88c8-0871bca2c050.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -9441,7 +9441,7 @@
         },
         {
             "id": "76cc05b6-2333-56de-8544-b86543197e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb10b3-6856-4355-94a7-a14c516887d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb10b3-6856-4355-94a7-a14c516887d5.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -9473,7 +9473,7 @@
         },
         {
             "id": "72d0be83-a544-5b6e-9318-74aecbf0bff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8db7a-009a-4141-bba7-b5fdfaf8d245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8db7a-009a-4141-bba7-b5fdfaf8d245.jpg?1",
             "name": "Mind Stone",
             "text": "",
             "colours": [],
@@ -9503,7 +9503,7 @@
         },
         {
             "id": "4611290b-ebd7-5d68-ba79-8767aeb24a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f44a54b-512e-45ef-80ee-7982d2eaf762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f44a54b-512e-45ef-80ee-7982d2eaf762.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -9533,7 +9533,7 @@
         },
         {
             "id": "6935c0a7-c050-5fb8-9dba-68da7387a8f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd72802-8eab-4700-9bd2-d3997c17438f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd72802-8eab-4700-9bd2-d3997c17438f.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -9568,7 +9568,7 @@
         },
         {
             "id": "f6a8ef03-0cc5-59bf-90fa-551699879d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cde405f-ac69-45f4-af7f-c4d892a7a42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cde405f-ac69-45f4-af7f-c4d892a7a42d.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "e6cbca04-4378-5736-adc6-7d65f7e2fa73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6104a32-95ba-4003-bd02-12c567631990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6104a32-95ba-4003-bd02-12c567631990.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -9634,7 +9634,7 @@
         },
         {
             "id": "abfb7498-c0c8-5ae8-9e6a-709503ba3fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f45b45-86ca-48cb-adb1-1d01c197ece4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f45b45-86ca-48cb-adb1-1d01c197ece4.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -9667,7 +9667,7 @@
         },
         {
             "id": "dccee3ab-5136-5f96-bc77-31569e73772c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827edf4f-2442-4c9d-8aac-3dead3af3146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827edf4f-2442-4c9d-8aac-3dead3af3146.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -9700,7 +9700,7 @@
         },
         {
             "id": "c1046482-5e5d-5fa2-9eac-9b74faedda5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d55e1f0-26ce-4ad2-b175-4c64a9638431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d55e1f0-26ce-4ad2-b175-4c64a9638431.jpg?1",
             "name": "Talisman of Impulse",
             "text": "",
             "colours": [],
@@ -9733,7 +9733,7 @@
         },
         {
             "id": "f57ddf89-273a-52fc-831e-51d183e8d4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e2fad-0aab-4ead-9b25-509c83ad4a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e2fad-0aab-4ead-9b25-509c83ad4a93.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "3cf6ddf9-e917-5a41-b6ea-a5ff2fe66e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f67117-3d40-466d-9ea8-f75e1ad10b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f67117-3d40-466d-9ea8-f75e1ad10b45.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "c32055bc-2f4f-5616-b3ed-5181ab8dd0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a395b259-1f3f-43ab-9636-d1c218661c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a395b259-1f3f-43ab-9636-d1c218661c15.jpg?1",
             "name": "Talisman of Unity",
             "text": "",
             "colours": [],
@@ -9832,7 +9832,7 @@
         },
         {
             "id": "e54ed6d0-6f1f-5602-b302-52cf3baf3392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84506a3f-46ee-4482-9f7d-0409c2699ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84506a3f-46ee-4482-9f7d-0409c2699ae4.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -9862,7 +9862,7 @@
         },
         {
             "id": "a955e6af-57e5-54e5-bf7e-e25494abee0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3660a-4141-46fe-b34b-3aeb45589cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3660a-4141-46fe-b34b-3aeb45589cac.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "",
             "colours": [],
@@ -9892,7 +9892,7 @@
         },
         {
             "id": "75a2b2b2-d1a6-56b6-bb58-eb92245a44f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fec728-2bf5-40a5-b3d7-02f366271c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fec728-2bf5-40a5-b3d7-02f366271c0c.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "d5a59d79-8a09-5b29-bc8e-7ee42f03d5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b93de5-52e6-4a30-88e9-e636f18dccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b93de5-52e6-4a30-88e9-e636f18dccc8.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -9960,7 +9960,7 @@
         },
         {
             "id": "b8d4990e-1ce9-5ffe-8c6e-1f3e7d87fa0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221cd894-19e2-433b-a624-f6838fadd6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221cd894-19e2-433b-a624-f6838fadd6fd.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -9998,7 +9998,7 @@
         },
         {
             "id": "c08a3102-f5a2-572c-bd4b-be1196fd94ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d71183-509f-40b8-85af-8f118cad5c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d71183-509f-40b8-85af-8f118cad5c13.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "23d60cda-40e2-5d8f-80ea-4ce9d322c2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33320e-8dcb-40e2-a356-038f2eea77d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33320e-8dcb-40e2-a356-038f2eea77d7.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "7110460e-c256-5349-846f-3b86a0e9ff33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d3cd1f-3971-45ae-83c5-f7c2b3f5758a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d3cd1f-3971-45ae-83c5-f7c2b3f5758a.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -10106,7 +10106,7 @@
         },
         {
             "id": "8fc7a497-9211-5a33-b5e9-a28972a49923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811d6e5d-c8a3-41ae-910e-e0f194f42292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811d6e5d-c8a3-41ae-910e-e0f194f42292.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "a05717ef-8c3d-5001-9398-2cf1071db042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd4f68-f006-4ad5-9bf8-8757e498736a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd4f68-f006-4ad5-9bf8-8757e498736a.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10178,7 +10178,7 @@
         },
         {
             "id": "7866f4e4-ed56-5a43-9870-9852547ae358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b82ac1b-c2d8-45f0-851a-97b0cdcff0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b82ac1b-c2d8-45f0-851a-97b0cdcff0ee.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10214,7 +10214,7 @@
         },
         {
             "id": "e4e89e65-534f-5585-9118-6844088c7f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e819e5-573c-49d3-87d7-9abd60532e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e819e5-573c-49d3-87d7-9abd60532e71.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "1428325f-c9d6-58e2-9687-a6af598a1e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a6531-7cf7-4c74-9050-65fe4b273744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a6531-7cf7-4c74-9050-65fe4b273744.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -10285,7 +10285,7 @@
         },
         {
             "id": "016ec506-f301-5975-9905-7225a36cc174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb7fadc-dcd8-473a-9b12-d9c8f0a19f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb7fadc-dcd8-473a-9b12-d9c8f0a19f79.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "",
             "colours": [],
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "1955620d-103d-579c-96bc-86425c8775f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8036733-de99-4f33-a7a2-b1dde43606f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8036733-de99-4f33-a7a2-b1dde43606f1.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -10354,7 +10354,7 @@
         },
         {
             "id": "3c476cd0-9333-5d19-8148-9e46ca2022a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed66e849-8fc9-46a1-9b8a-6845b5bc0734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed66e849-8fc9-46a1-9b8a-6845b5bc0734.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -10389,7 +10389,7 @@
         },
         {
             "id": "fa0dfbb9-0f79-5dbe-b64c-642f46963d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7223-20ce-4802-93f5-be41dcce1c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7223-20ce-4802-93f5-be41dcce1c15.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -10424,7 +10424,7 @@
         },
         {
             "id": "e4ac3e48-9581-5e78-bbd0-d8da5bb049d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787c5c8e-7274-4d74-8a8d-728b28ec0b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787c5c8e-7274-4d74-8a8d-728b28ec0b71.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -10459,7 +10459,7 @@
         },
         {
             "id": "fab6b6f1-77aa-5297-ad37-d6a35eae2fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8c7416-c0af-419d-892a-ee989585bf79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8c7416-c0af-419d-892a-ee989585bf79.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -10494,7 +10494,7 @@
         },
         {
             "id": "a466e821-6f0e-5189-8f52-c2d6f3c36b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f3d434-bab7-48c2-961d-347735d61d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f3d434-bab7-48c2-961d-347735d61d38.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -10529,7 +10529,7 @@
         },
         {
             "id": "f94aee4a-c458-5be2-9581-a5d8f610123b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7387895f-8697-4755-8abb-7f81af4a2717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7387895f-8697-4755-8abb-7f81af4a2717.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -10559,7 +10559,7 @@
         },
         {
             "id": "1ea782bf-2c57-5141-84fd-c686a2f27d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bc648d-def5-4442-9cfe-0f93fee631f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bc648d-def5-4442-9cfe-0f93fee631f4.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "04897a44-6088-5b8c-989f-506094356328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4830469e-2323-4e00-9c97-8fa8a5a03580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4830469e-2323-4e00-9c97-8fa8a5a03580.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -10629,7 +10629,7 @@
         },
         {
             "id": "dc2b01e3-ba97-524f-a0be-f05b1a143126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf68138-63c1-4201-998c-eb412463f664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf68138-63c1-4201-998c-eb412463f664.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -10664,7 +10664,7 @@
         },
         {
             "id": "b389833b-a8b9-5150-bd2b-3a48ff00bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724c72-8e0e-4380-82ba-1f9ec8e45f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724c72-8e0e-4380-82ba-1f9ec8e45f01.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -10699,7 +10699,7 @@
         },
         {
             "id": "a983e412-308d-51a6-8922-a0b9ae153b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58be08-7988-4ea5-8338-019a03171d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58be08-7988-4ea5-8338-019a03171d16.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -10734,7 +10734,7 @@
         },
         {
             "id": "c8501d12-a1e0-5591-be14-db3fc8213fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadb4128-62f4-47ea-8435-e06dfdb8e964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadb4128-62f4-47ea-8435-e06dfdb8e964.jpg?1",
             "name": "Frontier Bivouac",
             "text": "",
             "colours": [],
@@ -10768,7 +10768,7 @@
         },
         {
             "id": "e010a134-c131-53d1-b7eb-21b3f1e3a176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1d2c3d-e6ec-4130-8765-346adbb79d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1d2c3d-e6ec-4130-8765-346adbb79d31.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -10803,7 +10803,7 @@
         },
         {
             "id": "88d7e892-9c6b-5765-a181-699341387bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ddcd8b-a9b1-479f-85c6-5bd8b9ac4f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ddcd8b-a9b1-479f-85c6-5bd8b9ac4f2d.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "17678747-c8a8-530a-a2ed-8fa2cc56d2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066326c9-c1d7-4eca-84fe-fdd95b659ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066326c9-c1d7-4eca-84fe-fdd95b659ac1.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "619fb78b-f2ea-57f8-9eef-277675d6f726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e28187-fece-4f78-b8fe-43ee6df4d338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e28187-fece-4f78-b8fe-43ee6df4d338.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -10908,7 +10908,7 @@
         },
         {
             "id": "3dc5c8b5-e7e1-5449-a605-0f0af55f9438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b62353-e170-4c29-bda1-7cd8441c01c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b62353-e170-4c29-bda1-7cd8441c01c2.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -10943,7 +10943,7 @@
         },
         {
             "id": "236d5bf0-df73-55b5-ae15-51c111513a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf2baad-0160-419d-bba5-f4f35596aa61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf2baad-0160-419d-bba5-f4f35596aa61.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -10978,7 +10978,7 @@
         },
         {
             "id": "66a26d7e-9eff-512d-985b-d451b1854d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1422a65-5bda-4d75-8682-8c7351b3dba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1422a65-5bda-4d75-8682-8c7351b3dba6.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -11016,7 +11016,7 @@
         },
         {
             "id": "f696b6f7-f5c9-5f05-aa33-a6620280dd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59735c0d-5793-478a-b40c-f8d13413f67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59735c0d-5793-478a-b40c-f8d13413f67b.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -11051,7 +11051,7 @@
         },
         {
             "id": "81361ff9-80b2-595f-9ade-680ee6a794c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcfd8e-e069-4489-8498-2c7b742bf4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcfd8e-e069-4489-8498-2c7b742bf4fe.jpg?1",
             "name": "Myriad Landscape",
             "text": "",
             "colours": [],
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "41302153-e089-56ca-9519-c028a9c86eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698de613-bd07-49b8-bbc3-d89d26565593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698de613-bd07-49b8-bbc3-d89d26565593.jpg?1",
             "name": "Mystic Monastery",
             "text": "",
             "colours": [],
@@ -11115,7 +11115,7 @@
         },
         {
             "id": "cd4bf199-6ddc-5402-8c39-f2fadf0e6983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7790ee3-87dc-497f-87ea-9554ca67600d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7790ee3-87dc-497f-87ea-9554ca67600d.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -11150,7 +11150,7 @@
         },
         {
             "id": "391da408-7607-59db-9fab-4deacbfedd40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c6f93e-e03f-4749-8b30-9375c79f10f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c6f93e-e03f-4749-8b30-9375c79f10f4.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -11180,7 +11180,7 @@
         },
         {
             "id": "d9b5646c-6379-5791-947f-b2ab561e962c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df58d745-2f08-447f-a7db-41765731e36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df58d745-2f08-447f-a7db-41765731e36c.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -11215,7 +11215,7 @@
         },
         {
             "id": "63250dba-b376-5cdd-b22c-b1abcb1440ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32fcfa0-50df-4815-ad8f-0e0db32c307b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32fcfa0-50df-4815-ad8f-0e0db32c307b.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "e7f4fff3-43b8-57ef-b771-eda2508697a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afb2f16-4364-439e-a5ce-6598b351cb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afb2f16-4364-439e-a5ce-6598b351cb4c.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -11283,7 +11283,7 @@
         },
         {
             "id": "e6c4b3a4-5f07-569c-adda-fe24726663ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebb072-492c-4ec0-8b1d-f8ea48221647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebb072-492c-4ec0-8b1d-f8ea48221647.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -11318,7 +11318,7 @@
         },
         {
             "id": "8f909000-4f61-5d96-a532-850b57c75a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ea91-d31f-4862-8ec0-6e24ef40545c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ea91-d31f-4862-8ec0-6e24ef40545c.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -11353,7 +11353,7 @@
         },
         {
             "id": "1ad7b737-9b07-5226-97f2-18853dd23af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f3b1cb-e436-40f9-904c-f5696aa6f383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f3b1cb-e436-40f9-904c-f5696aa6f383.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -11383,7 +11383,7 @@
         },
         {
             "id": "6b09ce6c-994a-5eea-bc69-a9265df3f380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72232b23-d59b-4bf4-aa55-b8f5ab691504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72232b23-d59b-4bf4-aa55-b8f5ab691504.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -11418,7 +11418,7 @@
         },
         {
             "id": "d823ddb2-b369-5022-b018-cbaa5c718701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12f441a-4d58-4ea5-90b8-f4e32db391a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12f441a-4d58-4ea5-90b8-f4e32db391a1.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -11456,7 +11456,7 @@
         },
         {
             "id": "9390adb9-a07f-5a4b-a505-29555e222a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88308a2d-5d93-4bc3-a5db-e895a0db76e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88308a2d-5d93-4bc3-a5db-e895a0db76e2.jpg?1",
             "name": "Seaside Citadel",
             "text": "",
             "colours": [],
@@ -11490,7 +11490,7 @@
         },
         {
             "id": "740da7c2-6d05-5620-bab0-2cb0f8729ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e7104-debd-474c-a602-3226dae5a553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e7104-debd-474c-a602-3226dae5a553.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -11525,7 +11525,7 @@
         },
         {
             "id": "68a5017d-be04-5edc-93de-5ab46f3e5395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e230ab-9cae-43e2-b4dd-54fd2baea76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e230ab-9cae-43e2-b4dd-54fd2baea76f.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -11563,7 +11563,7 @@
         },
         {
             "id": "86fe02ab-3978-5eba-a76b-6bacba06ea26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0dfc2d-5d13-4051-b24c-108b566b5e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0dfc2d-5d13-4051-b24c-108b566b5e23.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "5ac0ca93-a550-504c-b395-9c5b717aa110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9761639c-8b54-4ef2-83cf-d45f9da33388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9761639c-8b54-4ef2-83cf-d45f9da33388.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "d01c1d12-01d2-5ec0-bdc4-be261e48e7a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b65ecb-ace2-4247-a654-1e704d24319a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b65ecb-ace2-4247-a654-1e704d24319a.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -11671,7 +11671,7 @@
         },
         {
             "id": "7f5236ab-1f11-5429-bdd4-c7bcb20a2b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe029f-e173-4a16-bdb4-394847b4e50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe029f-e173-4a16-bdb4-394847b4e50b.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -11706,7 +11706,7 @@
         },
         {
             "id": "76ffdba8-c1c6-59f7-913f-8f3fcf0fed09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da58ad9-3584-4881-9c98-f60cd09fc519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da58ad9-3584-4881-9c98-f60cd09fc519.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -11741,7 +11741,7 @@
         },
         {
             "id": "53eeb9aa-3ecf-51b7-a8b8-4d588b7ef688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8b5b0b-a8bc-4244-b457-44ccb92ede5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8b5b0b-a8bc-4244-b457-44ccb92ede5c.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -11776,7 +11776,7 @@
         },
         {
             "id": "0d89e104-847f-5d79-9f43-fb48ebcce2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4a9124-a692-4086-8f22-574fdcd81ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4a9124-a692-4086-8f22-574fdcd81ae2.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -11811,7 +11811,7 @@
         },
         {
             "id": "96c75b0b-95fd-5682-a36e-a4315e610213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4247c058-7f27-4195-b847-db883a430e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4247c058-7f27-4195-b847-db883a430e6a.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -11849,7 +11849,7 @@
         },
         {
             "id": "2136cf4e-c1fa-5a1c-b733-68ea9da1003c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1511f21-d9ae-4949-859a-3246a01c1166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1511f21-d9ae-4949-859a-3246a01c1166.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -11884,7 +11884,7 @@
         },
         {
             "id": "094e6db2-3b6b-5d0e-af43-da5977a41bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfbb9b-f2b8-42ed-89ba-c0d894e1e8d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfbb9b-f2b8-42ed-89ba-c0d894e1e8d4.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -11919,7 +11919,7 @@
         },
         {
             "id": "a90ffa3f-2e23-5cc3-8cae-451547161469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345eb1f-3a44-432c-8bee-39099e1947e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345eb1f-3a44-432c-8bee-39099e1947e6.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -11954,7 +11954,7 @@
         },
         {
             "id": "f29b6cf0-4032-5e62-92eb-9462aceeea51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7df0f35-81a1-439f-a9b0-0c3afd4bce68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7df0f35-81a1-439f-a9b0-0c3afd4bce68.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -11989,7 +11989,7 @@
         },
         {
             "id": "dd406f3b-6b2a-5074-bf4c-bf56093b810b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fabb0-9f83-49a3-9da3-d2b1d89fdb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fabb0-9f83-49a3-9da3-d2b1d89fdb61.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -12024,7 +12024,7 @@
         },
         {
             "id": "584f478a-8258-529b-8711-4f861e00f6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f1a8ce-a7c2-4e74-a4f2-22c914e998c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f1a8ce-a7c2-4e74-a4f2-22c914e998c4.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -12059,7 +12059,7 @@
         },
         {
             "id": "38f48830-eb5b-54d4-ae83-9e580c68afa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a47d5-e96b-4e90-8e63-a0e9376f2359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a47d5-e96b-4e90-8e63-a0e9376f2359.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -12094,7 +12094,7 @@
         },
         {
             "id": "4bcd57db-d281-5f0b-8cdd-426bc7c17794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca70d08-1468-407d-80e6-a58c6655b4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca70d08-1468-407d-80e6-a58c6655b4f0.jpg?1",
             "name": "Temple of the False God",
             "text": "",
             "colours": [],
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "11ac6a0c-4b4c-50c9-8ab2-4a6fa9b39d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e7e74-07ac-4aed-b58f-f4b045730cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e7e74-07ac-4aed-b58f-f4b045730cfe.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -12159,7 +12159,7 @@
         },
         {
             "id": "cbf2fbde-eb4e-58b0-a39e-c7a71fc086e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa85babf-6764-4cf7-9108-ec15cda6ada5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa85babf-6764-4cf7-9108-ec15cda6ada5.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -12189,7 +12189,7 @@
         },
         {
             "id": "80787ac9-822d-51b3-b0a3-aa35ea1cf23f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3d9d-e269-4a83-9b2d-cfe34f5f0f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3d9d-e269-4a83-9b2d-cfe34f5f0f78.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -12221,7 +12221,7 @@
         },
         {
             "id": "b15e50f2-d578-5780-9e51-02876e3a46ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb29495-5cc8-4f78-adb5-a7302bb9743b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb29495-5cc8-4f78-adb5-a7302bb9743b.jpg?1",
             "name": "Thriving Bluff",
             "text": "",
             "colours": [],
@@ -12253,7 +12253,7 @@
         },
         {
             "id": "ea5efbc5-bcb3-5ff4-a372-fe34b6546323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ccec9-7377-4038-b23b-58a714e797b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ccec9-7377-4038-b23b-58a714e797b9.jpg?1",
             "name": "Thriving Grove",
             "text": "",
             "colours": [],
@@ -12285,7 +12285,7 @@
         },
         {
             "id": "4330b00d-9c1c-5ccb-abc7-a76aa69f59c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d230b-43ac-4980-80b8-ae7b9aa63e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d230b-43ac-4980-80b8-ae7b9aa63e6d.jpg?1",
             "name": "Thriving Heath",
             "text": "",
             "colours": [],
@@ -12317,7 +12317,7 @@
         },
         {
             "id": "2a094dea-0474-5a82-b28c-a079bda2bd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352b106e-46de-4087-9533-a9f4b5536220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352b106e-46de-4087-9533-a9f4b5536220.jpg?1",
             "name": "Thriving Isle",
             "text": "",
             "colours": [],
@@ -12349,7 +12349,7 @@
         },
         {
             "id": "eaae9724-05ff-514a-b5ed-31f96c9175ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3a27-cd9a-4344-8879-1ed81932aaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3a27-cd9a-4344-8879-1ed81932aaec.jpg?1",
             "name": "Thriving Moor",
             "text": "",
             "colours": [],
@@ -12381,7 +12381,7 @@
         },
         {
             "id": "deb0ad53-6570-55fd-91ee-2b03cf251fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44297b-fd89-4d95-a502-cdd98fd4fbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44297b-fd89-4d95-a502-cdd98fd4fbc3.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -12416,7 +12416,7 @@
         },
         {
             "id": "2d421cc3-d9be-5700-bb60-06d8a2ca9ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f90fe-f5f1-47bb-8601-f3f18735b647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f90fe-f5f1-47bb-8601-f3f18735b647.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -12448,7 +12448,7 @@
         },
         {
             "id": "097a63b0-c766-584f-84e0-80bb634d9927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46931098-ae3c-409a-8789-7071205e11ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46931098-ae3c-409a-8789-7071205e11ee.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -12483,7 +12483,7 @@
         },
         {
             "id": "07ea979c-255c-5405-ba4e-0939ebfffac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c0b868-a688-4ccb-97b7-58fd424a7864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c0b868-a688-4ccb-97b7-58fd424a7864.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -12520,7 +12520,7 @@
         },
         {
             "id": "6548eb60-64c0-53e3-a3b6-ded5062c66ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1974b3-59dd-40ed-8d82-61d2b1b7fad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1974b3-59dd-40ed-8d82-61d2b1b7fad5.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -12558,7 +12558,7 @@
         },
         {
             "id": "74234a23-77fa-5284-be19-d58aeed8c8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540398df-27db-4103-bc28-92fd3aa9cbcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540398df-27db-4103-bc28-92fd3aa9cbcd.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -12598,7 +12598,7 @@
         },
         {
             "id": "a788871c-e1d7-55ee-9429-ea8467e9425c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd853b51-906f-49ef-a21e-5716317af8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd853b51-906f-49ef-a21e-5716317af8fc.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -12639,7 +12639,7 @@
         },
         {
             "id": "4df7c60b-67b3-543d-8527-b048aa21020b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c9f47c-be91-4d77-a76e-2963a6d75864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c9f47c-be91-4d77-a76e-2963a6d75864.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -12675,7 +12675,7 @@
         },
         {
             "id": "258b27ed-9328-5e85-b5d1-2e3db6362761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6932a-5714-4e9e-9229-ea182a175779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6932a-5714-4e9e-9229-ea182a175779.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -12711,7 +12711,7 @@
         },
         {
             "id": "379c8989-8d72-5b6e-80df-6c9585e009e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9558e30-7ea9-4841-a742-5d7941c0241f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9558e30-7ea9-4841-a742-5d7941c0241f.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -12747,7 +12747,7 @@
         },
         {
             "id": "73b50c71-b86c-516b-8d5c-71ac83c48281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8a2f7f-477d-441c-9677-1346c8622fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8a2f7f-477d-441c-9677-1346c8622fff.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -12783,7 +12783,7 @@
         },
         {
             "id": "99b99294-c8f4-57c7-a97c-40ca810dbef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafd4914-71e9-436e-acd7-9e2d17769044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafd4914-71e9-436e-acd7-9e2d17769044.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -12819,7 +12819,7 @@
         },
         {
             "id": "3d1b551e-c075-5d1d-9b76-3fa0654d1709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d52ef49-528c-4859-8b8f-9eae12d6d7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d52ef49-528c-4859-8b8f-9eae12d6d7ca.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -12860,7 +12860,7 @@
         },
         {
             "id": "e6315b72-c7fa-5ff3-9817-dd4433b2ac23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697a5e9-4229-4bf9-9161-c3b768df5bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697a5e9-4229-4bf9-9161-c3b768df5bd3.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -12901,7 +12901,7 @@
         },
         {
             "id": "0699b22e-8175-51b9-80d7-d4ece2f77fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6974ba-658c-4747-9a25-68670142c487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6974ba-658c-4747-9a25-68670142c487.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -12939,7 +12939,7 @@
         },
         {
             "id": "f83a0070-0361-5bc3-aa94-8fc89fea8407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeb6a54-3d0a-4a64-a9e4-acd683e42761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeb6a54-3d0a-4a64-a9e4-acd683e42761.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -12979,7 +12979,7 @@
         },
         {
             "id": "1c9b693b-e215-5f19-968f-b17e5d74cb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f9086a-40e0-4dd0-ba2c-338015bd4d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f9086a-40e0-4dd0-ba2c-338015bd4d73.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -13020,7 +13020,7 @@
         },
         {
             "id": "1340ef0d-480b-5503-863d-1500cc8a1102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57508c8-22f6-45ca-abd7-4cdd775ff4b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57508c8-22f6-45ca-abd7-4cdd775ff4b6.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -13062,7 +13062,7 @@
         },
         {
             "id": "35b8f1b7-8644-5367-91ad-42f90dffb2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb3b95-9540-45f4-8600-bedaff98e624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb3b95-9540-45f4-8600-bedaff98e624.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "fe50a530-6c57-5fd9-a06c-191e5fe25198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b6f28a-bca5-4f5c-8102-085316088a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b6f28a-bca5-4f5c-8102-085316088a11.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -13145,7 +13145,7 @@
         },
         {
             "id": "a6b7e616-54dc-5796-be52-c86a5fd5af2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc2d77-ec3c-408f-9259-0c511790fa34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc2d77-ec3c-408f-9259-0c511790fa34.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "ec9973ee-ea26-5950-a797-3f348c501666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39de636c-87e7-4de7-98de-41b285bc9c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39de636c-87e7-4de7-98de-41b285bc9c52.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -13222,7 +13222,7 @@
         },
         {
             "id": "601fb6ec-1938-51d6-83cd-fe76ed5bf8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1974e2c-1ce5-41a0-8b52-1950d7cca0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1974e2c-1ce5-41a0-8b52-1950d7cca0d5.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -13263,7 +13263,7 @@
         },
         {
             "id": "8da7d10f-cbae-512b-ad36-81743effc98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27c960e-864d-4dbf-861b-a862039579a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27c960e-864d-4dbf-861b-a862039579a8.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -13299,7 +13299,7 @@
         },
         {
             "id": "2b09b81f-4acd-561c-8793-03909512e88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2697012c-81a6-48e7-96cd-e6745078e0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2697012c-81a6-48e7-96cd-e6745078e0d9.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -13339,7 +13339,7 @@
         },
         {
             "id": "f4fff64a-f755-5e63-bae9-b11b00e10769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d19d6-0fe0-4534-898e-706336c95af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d19d6-0fe0-4534-898e-706336c95af7.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "924903b9-abd0-5d38-b3cc-ba044caaa8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a779222-d591-4f08-9383-b29895e8d2b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a779222-d591-4f08-9383-b29895e8d2b6.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -13413,7 +13413,7 @@
         },
         {
             "id": "45f98d44-de9d-53ed-bc6a-0963c9519877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a12bf-0078-446e-9471-01d43ec099d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a12bf-0078-446e-9471-01d43ec099d1.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -13455,7 +13455,7 @@
         },
         {
             "id": "70da4325-3bcb-5ef8-a4f4-eb66851877bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a5990-f61e-4533-a598-1839b209f2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a5990-f61e-4533-a598-1839b209f2f3.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -13495,7 +13495,7 @@
         },
         {
             "id": "54a8b5d5-5f07-545b-9fb4-6c42e7d14ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d36ecf-5508-4fe6-9ad4-72df934b5c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d36ecf-5508-4fe6-9ad4-72df934b5c40.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -13531,7 +13531,7 @@
         },
         {
             "id": "b983d026-4a82-5d25-88fb-1b0686867b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebb1d26-13d1-4907-95d6-8766b233fc73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebb1d26-13d1-4907-95d6-8766b233fc73.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -13570,7 +13570,7 @@
         },
         {
             "id": "4368275b-5d84-5d8e-827e-beaf1335299e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c6b33d-c1c7-442b-91ac-d7ef56ce8fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c6b33d-c1c7-442b-91ac-d7ef56ce8fdd.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -13610,7 +13610,7 @@
         },
         {
             "id": "52ea3d20-2aca-5f0a-baa4-5a86e4163d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2c9623-6b4c-457e-9235-a39a84b49b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2c9623-6b4c-457e-9235-a39a84b49b7b.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -13646,7 +13646,7 @@
         },
         {
             "id": "1a84f306-5fb8-59e0-a9b1-e7f4f4543a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb58f17-5d98-4b17-b635-3e27e94a3673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb58f17-5d98-4b17-b635-3e27e94a3673.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -13690,7 +13690,7 @@
         },
         {
             "id": "1dc39f2f-0d20-57e7-af59-2a3a29663d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e23c4f-06bf-4f34-8221-408ce90ec672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e23c4f-06bf-4f34-8221-408ce90ec672.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -13731,7 +13731,7 @@
         },
         {
             "id": "59fa9768-a43e-50bb-9e19-d9fca54c3337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f2135a-75a5-497f-ab71-b440c56d17cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f2135a-75a5-497f-ab71-b440c56d17cf.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -13767,7 +13767,7 @@
         },
         {
             "id": "ec208732-17bb-5291-aecc-c10cf8465894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5043369d-966c-49c4-a249-92c700ecd28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5043369d-966c-49c4-a249-92c700ecd28a.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -13808,7 +13808,7 @@
         },
         {
             "id": "72466cfa-6d8d-5378-9854-02ebf1f2d5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834219e4-ccae-4fd9-bc75-b82fdbd7f47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834219e4-ccae-4fd9-bc75-b82fdbd7f47e.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "87207a2b-fe4d-50c3-9d16-bee213ae8859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986a1243-712d-4139-b9a1-27f935c9439b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986a1243-712d-4139-b9a1-27f935c9439b.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -13891,7 +13891,7 @@
         },
         {
             "id": "8ec6a77d-ff36-5c4f-878c-543b04fc321c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497f3315-13d2-41be-bf3a-a75de57a5e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497f3315-13d2-41be-bf3a-a75de57a5e08.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "a7f49d4f-2078-5edc-805d-d959304b47f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67e7988-fbed-43f3-a25c-2b422b3d6594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67e7988-fbed-43f3-a25c-2b422b3d6594.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -13963,7 +13963,7 @@
         },
         {
             "id": "b2cb1eca-40f0-5178-a19b-3636dd72f3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7513ebd-272b-4e50-be9f-0ff84b50444a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7513ebd-272b-4e50-be9f-0ff84b50444a.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -13999,7 +13999,7 @@
         },
         {
             "id": "a6956ae6-e876-511b-9dbe-c87485b7ff52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb77dfb-c072-4557-ace7-3166ae72fb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb77dfb-c072-4557-ace7-3166ae72fb38.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -14038,7 +14038,7 @@
         },
         {
             "id": "31843d6a-7d0e-5724-bdc2-1be7e6171d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d38653a-c170-4cda-8ded-860537e54bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d38653a-c170-4cda-8ded-860537e54bae.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -14074,7 +14074,7 @@
         },
         {
             "id": "637c9b2f-b5b9-5fac-a16e-51d59622f28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4f9b2d-f7b3-4ea4-b4b4-2f0734ae295f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4f9b2d-f7b3-4ea4-b4b4-2f0734ae295f.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -14110,7 +14110,7 @@
         },
         {
             "id": "9d817228-8450-5ff3-8b87-2b34f1464167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69807079-995f-4b15-a9f1-cad3eb66c526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69807079-995f-4b15-a9f1-cad3eb66c526.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -14149,7 +14149,7 @@
         },
         {
             "id": "9f8e4525-8cb7-5470-996d-255bc5629e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25b6dcd-12aa-449d-b734-d1dc4b053df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25b6dcd-12aa-449d-b734-d1dc4b053df4.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -14185,7 +14185,7 @@
         },
         {
             "id": "e7964257-b3a4-5f93-9797-ae6b058669d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7db07e-9332-488a-a9ae-b90d6180098e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7db07e-9332-488a-a9ae-b90d6180098e.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -14224,7 +14224,7 @@
         },
         {
             "id": "f2aef294-3fa3-5046-84de-30a541afd526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65da12f9-8fcb-4f58-b123-adcff8e6ea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65da12f9-8fcb-4f58-b123-adcff8e6ea20.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -14264,7 +14264,7 @@
         },
         {
             "id": "c06366cf-3732-5d5d-b298-cdfe87761f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d4b61-136b-41b8-8de3-9a1b40f90216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d4b61-136b-41b8-8de3-9a1b40f90216.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -14304,7 +14304,7 @@
         },
         {
             "id": "f98b090e-9ad3-5ca7-9847-7c264203ff89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e04f552-c6a8-4c3d-898b-7cf1523f9440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e04f552-c6a8-4c3d-898b-7cf1523f9440.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -14344,7 +14344,7 @@
         },
         {
             "id": "26d17299-7174-5982-9f54-3ebf318b07ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08448af-6f7d-4587-be37-de360fe6199c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08448af-6f7d-4587-be37-de360fe6199c.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -14384,7 +14384,7 @@
         },
         {
             "id": "43a871d5-8d90-5157-96f3-64762855743f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d085c152-d492-4ff6-9c98-d7db658a36c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d085c152-d492-4ff6-9c98-d7db658a36c7.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -14420,7 +14420,7 @@
         },
         {
             "id": "6e1933ea-2545-5ff6-bc41-4d8aae7d3e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9fe657-e9c8-4b74-bda5-ee03b909c97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9fe657-e9c8-4b74-bda5-ee03b909c97b.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -14460,7 +14460,7 @@
         },
         {
             "id": "5fc8df13-6c96-5d00-8a2b-7660069ec8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d749a92e-7bb4-44b2-9849-98414a416208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d749a92e-7bb4-44b2-9849-98414a416208.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -14496,7 +14496,7 @@
         },
         {
             "id": "beb3c121-f856-504c-863c-122eef2e62cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d53c12-2e7c-4b71-b2b5-3abfbd26b4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d53c12-2e7c-4b71-b2b5-3abfbd26b4b9.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -14532,7 +14532,7 @@
         },
         {
             "id": "fc58a20f-23b0-546a-b313-4218c7f87e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21f29c1-545f-4ab5-bb8c-3ea7bf453188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21f29c1-545f-4ab5-bb8c-3ea7bf453188.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -14570,7 +14570,7 @@
         },
         {
             "id": "ff79b368-5b95-5edb-b9b8-799d6fb4f75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727e54-94d4-4606-91a3-2d11b463a9f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727e54-94d4-4606-91a3-2d11b463a9f4.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -14606,7 +14606,7 @@
         },
         {
             "id": "597f8351-68a8-54b0-a68d-d26a2f03653a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f84d1c2-c96b-4cd8-9fa7-34c8f5b4bec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f84d1c2-c96b-4cd8-9fa7-34c8f5b4bec0.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -14642,7 +14642,7 @@
         },
         {
             "id": "e7853e73-7de5-5617-b24c-86d2aa036bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3618e0-3cbc-409b-9d08-a75a2c840496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3618e0-3cbc-409b-9d08-a75a2c840496.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -14678,7 +14678,7 @@
         },
         {
             "id": "01de6d7e-816a-5343-89af-437527660785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94727f3-4d5f-44aa-b66a-30a670ac07ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94727f3-4d5f-44aa-b66a-30a670ac07ed.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -14718,7 +14718,7 @@
         },
         {
             "id": "d7744796-8e38-58ca-b80b-3824e69298fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942e0d0-399b-48e6-be18-1687232f75a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942e0d0-399b-48e6-be18-1687232f75a0.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -14758,7 +14758,7 @@
         },
         {
             "id": "3ee53c5a-64a6-5c3d-b543-b9f9f034f932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff3fbe7-1c11-4cce-a43b-b6b4cb4d1594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff3fbe7-1c11-4cce-a43b-b6b4cb4d1594.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "2c0123c3-271d-572d-ad1d-bf899f3c3c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f325e7-2585-4c7a-a6cf-91f8cd91f22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f325e7-2585-4c7a-a6cf-91f8cd91f22c.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -14839,7 +14839,7 @@
         },
         {
             "id": "203f1fdb-7385-529e-b4b6-32e4b72ed05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce6d329-9c3a-4fb0-bf1e-9b72346ca3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce6d329-9c3a-4fb0-bf1e-9b72346ca3ad.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -14880,7 +14880,7 @@
         },
         {
             "id": "725c3cc1-9f0b-56c9-9185-d5de33164dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a4c23c-fbf0-4edd-8503-37d4f87d680a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a4c23c-fbf0-4edd-8503-37d4f87d680a.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -14916,7 +14916,7 @@
         },
         {
             "id": "21a5dd63-ffc6-5b96-8950-5cb295ef8109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a3e73e-9c81-4102-8163-4158e6e2f602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a3e73e-9c81-4102-8163-4158e6e2f602.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -14956,7 +14956,7 @@
         },
         {
             "id": "0bbde221-de7e-5062-a3ad-77ecd68b505d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d33a0-8e3f-40e4-a36d-db0e5001fa1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d33a0-8e3f-40e4-a36d-db0e5001fa1c.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -14997,7 +14997,7 @@
         },
         {
             "id": "7c565e99-ab6f-52ba-8414-757bc6bf287d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d31cc1f-a53e-45bb-9568-082c09a6ea28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d31cc1f-a53e-45bb-9568-082c09a6ea28.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -15038,7 +15038,7 @@
         },
         {
             "id": "549b267c-ace3-58f3-adbc-c749664afa69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d666c6e-dfa3-4e15-9841-675c596df906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d666c6e-dfa3-4e15-9841-675c596df906.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -15079,7 +15079,7 @@
         },
         {
             "id": "35308b0a-b890-56b9-b215-9e02a4dd3c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7a8297-5612-4f87-9d14-e8c1ee4c1d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7a8297-5612-4f87-9d14-e8c1ee4c1d0e.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -15117,7 +15117,7 @@
         },
         {
             "id": "cd9e2907-5974-585a-bb91-4cf7f13903cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7c1b5-5d40-4ac5-b4bc-42fb726693f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7c1b5-5d40-4ac5-b4bc-42fb726693f4.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -15157,7 +15157,7 @@
         },
         {
             "id": "15fa4942-0c25-544a-82ae-02780787c95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd85a71e-e090-4071-bc07-a05abd802782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd85a71e-e090-4071-bc07-a05abd802782.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -15202,7 +15202,7 @@
         },
         {
             "id": "31e78ebf-bf1e-5185-9d01-8a95104ff419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d579c01-7d65-4492-88dc-00aff3be6ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d579c01-7d65-4492-88dc-00aff3be6ab3.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "a2b77583-00a7-5693-8157-b0956783f185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32903c6-1230-436c-9913-6abf3a97f10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32903c6-1230-436c-9913-6abf3a97f10e.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -15289,7 +15289,7 @@
         },
         {
             "id": "ea5a2595-37d9-5e37-b15a-f35d34a58483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be38267-fa28-49c8-b8df-d08df4106d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be38267-fa28-49c8-b8df-d08df4106d95.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -15334,7 +15334,7 @@
         },
         {
             "id": "4bacd7b4-ff25-5b27-83d1-4856abcce34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf41cbb6-1d43-4197-b3c6-a5a70f96f135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf41cbb6-1d43-4197-b3c6-a5a70f96f135.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -15377,7 +15377,7 @@
         },
         {
             "id": "a94d60f2-17c0-51e2-9a27-c68434e070c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc16ca7-7ece-4889-a6e6-a79563847b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc16ca7-7ece-4889-a6e6-a79563847b88.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -15420,7 +15420,7 @@
         },
         {
             "id": "0429f742-83b2-5401-9e92-ccf95b9eebf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bcb234-012b-47f1-ad8c-2223d12fe1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bcb234-012b-47f1-ad8c-2223d12fe1f2.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -15469,7 +15469,7 @@
         },
         {
             "id": "6342aab5-213b-5d84-9923-2fb70968abc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391e1747-69b0-47e0-9210-317f5febca59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391e1747-69b0-47e0-9210-317f5febca59.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -15509,7 +15509,7 @@
         },
         {
             "id": "b794afa4-d0cc-5e97-b07a-22c64b9025ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4f9d74-c6ed-45f5-96b3-69b918ec9462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4f9d74-c6ed-45f5-96b3-69b918ec9462.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -15552,7 +15552,7 @@
         },
         {
             "id": "aa03d352-7546-5bf5-83d7-18c8a0ccc71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46827983-517e-45bb-b27e-b9766185f7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46827983-517e-45bb-b27e-b9766185f7ed.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -15598,7 +15598,7 @@
         },
         {
             "id": "bcc769bc-4e5a-5912-9e77-ac9670ee4f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe6a5a0-3c1f-4e97-9bc6-aa74daeec7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe6a5a0-3c1f-4e97-9bc6-aa74daeec7a0.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -15644,7 +15644,7 @@
         },
         {
             "id": "11179ff2-5aa5-5695-9ca6-c9fed8d7bd37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7495b342-7397-4957-afa6-00529a6e86b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7495b342-7397-4957-afa6-00529a6e86b7.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -15689,7 +15689,7 @@
         },
         {
             "id": "ac719064-3847-5d7d-a4c3-4a5eaa932a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aedb9b-5dd6-4e93-a470-e57e24e1f6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aedb9b-5dd6-4e93-a470-e57e24e1f6de.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -15735,7 +15735,7 @@
         },
         {
             "id": "dc9aaad1-2103-5a07-a782-91ada382e846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9ec14-87a1-4ac1-a778-c1e962bca4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9ec14-87a1-4ac1-a778-c1e962bca4c4.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -15781,7 +15781,7 @@
         },
         {
             "id": "6e2cb859-8676-51ce-b486-931465a93c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e22e8-7e88-4786-b349-e4472c1086fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e22e8-7e88-4786-b349-e4472c1086fd.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "ae379ee8-debb-51f4-be50-bde5f78723ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f08ba37-15dd-4ad8-a35a-4f5cf776139d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f08ba37-15dd-4ad8-a35a-4f5cf776139d.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -15868,7 +15868,7 @@
         },
         {
             "id": "3b273a91-9346-5358-945c-1f3167644932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a07db6-db90-4584-9d73-64e56c05601a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a07db6-db90-4584-9d73-64e56c05601a.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -15913,7 +15913,7 @@
         },
         {
             "id": "dcc9ab07-16dd-52c6-a91c-81f9847006ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e364cf-afb5-41b1-8f56-2e70ca51a64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e364cf-afb5-41b1-8f56-2e70ca51a64b.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -15953,7 +15953,7 @@
         },
         {
             "id": "188bb547-69fb-593e-b6a2-2f45441a99b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013fe4db-615c-433f-a1cf-b5144cd877a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013fe4db-615c-433f-a1cf-b5144cd877a3.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -15996,7 +15996,7 @@
         },
         {
             "id": "d278b1e5-eff5-5c59-8238-b9b96490212b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f821-7239-4aa0-97bc-3c187c7eb9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f821-7239-4aa0-97bc-3c187c7eb9b5.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -16039,7 +16039,7 @@
         },
         {
             "id": "ae46cd7a-a005-571e-bd83-d9fc329504da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c430ce-b6c4-4b05-9439-07b4fbfdfe62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c430ce-b6c4-4b05-9439-07b4fbfdfe62.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -16082,7 +16082,7 @@
         },
         {
             "id": "7095d691-1552-56b1-b6be-0530164d28cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bce6c7-4864-406d-a693-d47cc8026425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bce6c7-4864-406d-a693-d47cc8026425.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -16127,7 +16127,7 @@
         },
         {
             "id": "0041da35-5459-5726-9203-789822885bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98048265-cdab-4a21-89f9-3403babf34e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98048265-cdab-4a21-89f9-3403babf34e6.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -16165,7 +16165,7 @@
         },
         {
             "id": "bdbd483c-0c8d-58d0-a978-28a08606b823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e306f3-65b3-420d-a50c-fa5cf74677ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e306f3-65b3-420d-a50c-fa5cf74677ad.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "99085d59-f02b-572b-8a12-326da02c51a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2861f7-1b2c-436a-848f-02f1142e6e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2861f7-1b2c-436a-848f-02f1142e6e2e.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -16249,7 +16249,7 @@
         },
         {
             "id": "fa2f139a-01e3-539f-8213-2c788a877579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867721ef-0329-4711-968e-62eb95c14df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867721ef-0329-4711-968e-62eb95c14df5.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -16294,7 +16294,7 @@
         },
         {
             "id": "3acdd9d3-075c-5178-aa63-95002cf5ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdf1881-b1a5-4422-b722-2eb03e1bcc4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdf1881-b1a5-4422-b722-2eb03e1bcc4e.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -16339,7 +16339,7 @@
         },
         {
             "id": "1949022f-b8b5-5578-83d4-366bbd14a802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee2b585-a26b-4a1a-9fa4-79b54505be3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee2b585-a26b-4a1a-9fa4-79b54505be3c.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -16384,7 +16384,7 @@
         },
         {
             "id": "fe2ccca1-a6a6-5829-bdc1-fd68c10311ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d86fee-e217-42b9-82c1-238e48297cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d86fee-e217-42b9-82c1-238e48297cff.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -16429,7 +16429,7 @@
         },
         {
             "id": "34a5de36-283b-55e9-9888-d1c389b7e10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfab366-8c79-42ec-89b1-c987ed9e9846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfab366-8c79-42ec-89b1-c987ed9e9846.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -16474,7 +16474,7 @@
         },
         {
             "id": "f48d09f6-0a2d-5acd-aacc-79f8b78abcc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c1232e-0104-4295-a1de-3eebe2ac6a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c1232e-0104-4295-a1de-3eebe2ac6a5f.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -16521,7 +16521,7 @@
         },
         {
             "id": "12fca8fa-648e-5c02-b90b-2cd94499d2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d57465e-24de-48dd-a748-91885710c88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d57465e-24de-48dd-a748-91885710c88f.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -16567,7 +16567,7 @@
         },
         {
             "id": "4aa9c671-d9a0-5514-8944-803b7ce3a9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f6be27-73e9-4978-b972-0a531e4bf3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f6be27-73e9-4978-b972-0a531e4bf3db.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -16612,7 +16612,7 @@
         },
         {
             "id": "e2048660-decc-57c6-b9e4-9ea43d8ca17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7047e7-d1fd-4b2c-b548-5c9c7590ab0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7047e7-d1fd-4b2c-b548-5c9c7590ab0b.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -16655,7 +16655,7 @@
         },
         {
             "id": "819d1717-2f1e-5288-ac7e-33c902fa7d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df450d9a-a556-4d2c-bce0-0aabe1eef8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df450d9a-a556-4d2c-bce0-0aabe1eef8cd.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -16693,7 +16693,7 @@
         },
         {
             "id": "cda8d298-7f0d-534d-9b22-1d033ee827a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6b98f9-5317-4fd9-944e-c1fd5e7f6d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6b98f9-5317-4fd9-944e-c1fd5e7f6d3f.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -16739,7 +16739,7 @@
         },
         {
             "id": "bb22e50c-9f1c-5633-9484-b2fc5b6ede67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035109e7-56e9-4ce4-a81c-404dec8c0690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035109e7-56e9-4ce4-a81c-404dec8c0690.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -16782,7 +16782,7 @@
         },
         {
             "id": "63dca8e2-f4be-58e9-8c05-1e0168f7fd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5ecb3c-5da8-41fc-9196-0d67b4234de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5ecb3c-5da8-41fc-9196-0d67b4234de3.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -16820,7 +16820,7 @@
         },
         {
             "id": "72fa9d08-5a6b-5544-9de4-811429246dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80447e9-a359-49cf-82fa-9ee36ed730d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80447e9-a359-49cf-82fa-9ee36ed730d3.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -16863,7 +16863,7 @@
         },
         {
             "id": "dec8aa79-7faa-5b75-ac42-1ff7c43c9193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c071154-145f-4a37-9869-dea71ac2f997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c071154-145f-4a37-9869-dea71ac2f997.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -16909,7 +16909,7 @@
         },
         {
             "id": "1dff694b-e5d3-53a3-870f-d0caafbc4063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c96909-1150-4126-a21d-7842670bbaf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c96909-1150-4126-a21d-7842670bbaf8.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -16952,7 +16952,7 @@
         },
         {
             "id": "89b6bcc7-a513-5635-820f-1243d90d5502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c642d-3c32-4a16-8da5-fd1505e571d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c642d-3c32-4a16-8da5-fd1505e571d1.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -16998,7 +16998,7 @@
         },
         {
             "id": "a1c7ed1b-b6ae-5f77-83a2-31b85252af15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129ea0f5-67f6-4364-b8db-ee582b3e23fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129ea0f5-67f6-4364-b8db-ee582b3e23fd.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -17044,7 +17044,7 @@
         },
         {
             "id": "fe8a6635-a0ce-53d6-bbaa-a36765dbec03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9410dc-7f2b-432b-8025-ec26f77446d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9410dc-7f2b-432b-8025-ec26f77446d7.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -17087,7 +17087,7 @@
         },
         {
             "id": "3432a3a2-e3dc-5f79-96f9-34ca82ec9dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf34ac5c-85fb-4a75-8bf9-ba68c7a1059d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf34ac5c-85fb-4a75-8bf9-ba68c7a1059d.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -17128,7 +17128,7 @@
         },
         {
             "id": "6473ce86-9815-5d18-8049-7bcf2e901ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f6f6ce-410d-4c84-8a57-cf9f41016441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f6f6ce-410d-4c84-8a57-cf9f41016441.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -17175,7 +17175,7 @@
         },
         {
             "id": "21cf766f-12a3-535a-bfc4-b0f3166542ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757f142-b3fd-45a5-ab99-c82f956bc3a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757f142-b3fd-45a5-ab99-c82f956bc3a3.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -17221,7 +17221,7 @@
         },
         {
             "id": "be61e9c2-20bf-59b8-bfae-3a5f64a7fc28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43174baf-eb78-41a4-834c-61cdb50eb452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43174baf-eb78-41a4-834c-61cdb50eb452.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -17268,7 +17268,7 @@
         },
         {
             "id": "f6112f63-64fd-5524-8be0-6742aa81e675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501152a4-776e-4c08-a573-f482d5bb29fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501152a4-776e-4c08-a573-f482d5bb29fb.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -17314,7 +17314,7 @@
         },
         {
             "id": "434138b2-559d-52ff-b872-b2b895faaccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddf0067-2453-44b3-8ea7-248a8bb1268f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddf0067-2453-44b3-8ea7-248a8bb1268f.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -17359,7 +17359,7 @@
         },
         {
             "id": "b84b08da-0c4f-58a8-a34f-fc087c731aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7072dba-30a0-46b1-ad77-2a1a3995ffcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7072dba-30a0-46b1-ad77-2a1a3995ffcd.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -17403,7 +17403,7 @@
         },
         {
             "id": "54f4f71b-9c4d-5648-b700-7f284f5de6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcb7f51-be3f-4e32-ae8c-d19ecc219b10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcb7f51-be3f-4e32-ae8c-d19ecc219b10.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -17448,7 +17448,7 @@
         },
         {
             "id": "66561544-acbf-5385-b308-6bf07f1c9b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60a02f-741a-4304-852e-f446e43bb46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60a02f-741a-4304-852e-f446e43bb46f.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -17492,7 +17492,7 @@
         },
         {
             "id": "4cad2899-b846-5b83-add8-6ac466f0c24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a9bbe6-d1fc-49a7-8abe-fbf629d545d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a9bbe6-d1fc-49a7-8abe-fbf629d545d5.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -17528,7 +17528,7 @@
         },
         {
             "id": "a89de3af-7c56-5aa8-9c77-27cb0f786685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82b7f05-a73e-4db3-85cf-4fb2be77073f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82b7f05-a73e-4db3-85cf-4fb2be77073f.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -17564,7 +17564,7 @@
         },
         {
             "id": "b12f19d2-b8ef-5745-b05f-0b9807ee716a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50e018-2536-457b-b1b0-8f8cb27529cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50e018-2536-457b-b1b0-8f8cb27529cc.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -17596,7 +17596,7 @@
         },
         {
             "id": "e4b6b5fd-95c4-5f5a-a355-327335966c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c952d35-e18d-44b3-9c7e-9d09bc58a774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c952d35-e18d-44b3-9c7e-9d09bc58a774.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -17631,7 +17631,7 @@
         },
         {
             "id": "6730fd40-38ab-5d67-b3d3-bb75e374cfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c6fe5d-3964-440a-93ee-0e193263a5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c6fe5d-3964-440a-93ee-0e193263a5b6.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -17665,7 +17665,7 @@
         },
         {
             "id": "b7e845e7-20bc-5c11-b1c3-42627d03c3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683237b7-b3a9-4e34-abb4-ee0293385397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683237b7-b3a9-4e34-abb4-ee0293385397.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -17699,7 +17699,7 @@
         },
         {
             "id": "c229f841-175f-55b3-bce1-5140b0038deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c73ab0-79ed-44cd-90bf-b0debdc04fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c73ab0-79ed-44cd-90bf-b0debdc04fad.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -17731,7 +17731,7 @@
         },
         {
             "id": "304936d9-a5f3-556e-8432-297ad27fae1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c07ff4-7579-44f2-b7ec-2b51c0ac34f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c07ff4-7579-44f2-b7ec-2b51c0ac34f4.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -17763,7 +17763,7 @@
         },
         {
             "id": "7f9fcd82-cc84-57d0-80ef-d641e6bd0cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8e2bc9-8fa7-4112-ad66-3e5b7fa69793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8e2bc9-8fa7-4112-ad66-3e5b7fa69793.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -17797,7 +17797,7 @@
         },
         {
             "id": "6eb787ac-45dd-50b2-89b3-3a9cc161b2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93bea89-4ade-459d-a0e0-2a35fdf043af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93bea89-4ade-459d-a0e0-2a35fdf043af.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -17833,7 +17833,7 @@
         },
         {
             "id": "bf544e3b-73a3-5646-a91e-09c6a3b3c570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c48ce9d-4158-421a-9a4f-50159188ef1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c48ce9d-4158-421a-9a4f-50159188ef1f.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -17871,7 +17871,7 @@
         },
         {
             "id": "8899ac0b-2438-507f-8e8b-acbbf2a6d015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7912ef76-6a99-4018-9fd1-4dff5ad92285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7912ef76-6a99-4018-9fd1-4dff5ad92285.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -17907,7 +17907,7 @@
         },
         {
             "id": "15e7a2dd-2589-54e8-b16b-aeaa169ad47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a91ea06-154c-4d55-b0b3-9c49dbafddc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a91ea06-154c-4d55-b0b3-9c49dbafddc7.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -17943,7 +17943,7 @@
         },
         {
             "id": "3e49d23e-ad4b-523e-9ea4-d9711aecf356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116e94fb-c9cc-4ebe-a64b-51e88f938a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116e94fb-c9cc-4ebe-a64b-51e88f938a58.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -17979,7 +17979,7 @@
         },
         {
             "id": "ee70da02-f9f1-5292-9fcc-5b3d6363f65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99645e5-4125-4f23-8911-0a027a0ac9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99645e5-4125-4f23-8911-0a027a0ac9fe.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -18015,7 +18015,7 @@
         },
         {
             "id": "8381fd0c-f174-535b-911f-050f4f7d051d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef29d1d1-10a1-4aa3-9e20-342396b8e126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef29d1d1-10a1-4aa3-9e20-342396b8e126.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -18051,7 +18051,7 @@
         },
         {
             "id": "91b5e3f1-553b-5a5a-b67b-0599741711d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba9e2-9b21-49da-bd53-9364517f2c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba9e2-9b21-49da-bd53-9364517f2c95.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -18087,7 +18087,7 @@
         },
         {
             "id": "44058c68-eea4-5098-8036-b4d29f40d049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4057379b-f886-486f-830a-e8f2f42afe6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4057379b-f886-486f-830a-e8f2f42afe6a.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -18123,7 +18123,7 @@
         },
         {
             "id": "3992500d-b29a-5f72-9a77-abf0aa1d6dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37d8206-22a1-436c-bb1a-62cdd9f8a266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37d8206-22a1-436c-bb1a-62cdd9f8a266.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -18159,7 +18159,7 @@
         },
         {
             "id": "3ee8bc93-84bc-5cfd-94d6-43ef9c8e0a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550ed1d8-916a-4a5b-9672-1b0756620e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550ed1d8-916a-4a5b-9672-1b0756620e4a.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -18195,7 +18195,7 @@
         },
         {
             "id": "6c4cd391-60e8-5263-aedc-e205605ba455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a31283-7174-4b7e-9f29-b04bef0b9309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a31283-7174-4b7e-9f29-b04bef0b9309.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -18231,7 +18231,7 @@
         },
         {
             "id": "b5b1b778-e2b9-5a4f-98e9-a31e8392cffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c649c4-b9e9-4aa5-8b82-a8e1f9f998e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c649c4-b9e9-4aa5-8b82-a8e1f9f998e0.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -18267,7 +18267,7 @@
         },
         {
             "id": "bc0bda20-4719-5b02-ac27-c4c17cbd282e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c79de71-98f9-4807-8b01-915b5ad393e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c79de71-98f9-4807-8b01-915b5ad393e6.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -18303,7 +18303,7 @@
         },
         {
             "id": "3977c330-4f16-5138-819e-20db693ea5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6477d-d1f5-4890-a1ba-abdbd8094b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6477d-d1f5-4890-a1ba-abdbd8094b23.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -18341,7 +18341,7 @@
         },
         {
             "id": "0d0c28bc-362b-5a51-927e-b93af5d91fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce230228-caed-4f1a-8197-507056d6e417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce230228-caed-4f1a-8197-507056d6e417.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -18379,7 +18379,7 @@
         },
         {
             "id": "77be96bc-bfa0-568a-9293-799dfedbdaf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ef8f63-1224-495e-ae0b-7789c2b94e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ef8f63-1224-495e-ae0b-7789c2b94e3a.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -18413,7 +18413,7 @@
         },
         {
             "id": "e97dda3d-a485-5ea8-b252-c3b9787a972a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b2c09d-d317-4f0e-a544-71ee80524201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b2c09d-d317-4f0e-a544-71ee80524201.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -18448,7 +18448,7 @@
         },
         {
             "id": "4a8386b9-3122-5e5b-ba21-e48cfa0da3e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bcda96-890c-4f27-b85d-7d0c7e56e641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bcda96-890c-4f27-b85d-7d0c7e56e641.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -18486,7 +18486,7 @@
         },
         {
             "id": "dea98583-83da-523e-8891-5ff3a66b03b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f25c02e-9d38-4c4c-8b00-183052fb2307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f25c02e-9d38-4c4c-8b00-183052fb2307.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -18524,7 +18524,7 @@
         },
         {
             "id": "abfb48ff-b5c3-5708-bfd3-064ad5997354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d8924a-3792-4c47-8b2c-72e8358266d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d8924a-3792-4c47-8b2c-72e8358266d5.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -18559,7 +18559,7 @@
         },
         {
             "id": "4679ae78-6f8b-58bc-8b42-95f7fdd58850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7651beb-c2d7-4547-9fe5-ac27f711aaa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7651beb-c2d7-4547-9fe5-ac27f711aaa2.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -18594,7 +18594,7 @@
         },
         {
             "id": "96d4a284-6b56-5466-accf-6b4608cd38e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aa5ec4-d5ea-41a0-acdc-703f03491d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aa5ec4-d5ea-41a0-acdc-703f03491d10.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -18632,7 +18632,7 @@
         },
         {
             "id": "8113e3ec-2829-52b9-b291-f76733b1618d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec64c304-3233-4004-90e4-a9592ea633da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec64c304-3233-4004-90e4-a9592ea633da.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -18667,7 +18667,7 @@
         },
         {
             "id": "f478b510-7c7d-5d59-9f5c-c36d65ee422c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a631d41c-e4a6-4fc1-8ea7-9b9a5b5509b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a631d41c-e4a6-4fc1-8ea7-9b9a5b5509b4.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -18702,7 +18702,7 @@
         },
         {
             "id": "f75f4935-00a3-5481-8d78-d6ac831ae583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03fd757-9997-497c-a572-b8744dd94681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03fd757-9997-497c-a572-b8744dd94681.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -18737,7 +18737,7 @@
         },
         {
             "id": "f0b03496-7882-5df0-bd4d-0bfad98d60eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a44a44-491a-4184-8db6-5e914f017c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a44a44-491a-4184-8db6-5e914f017c3a.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -18772,7 +18772,7 @@
         },
         {
             "id": "8ff395ef-db97-5f71-825a-6fe5ebd17ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80569a69-7a6b-41f4-a9c4-d970dae1bd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80569a69-7a6b-41f4-a9c4-d970dae1bd51.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -18807,7 +18807,7 @@
         },
         {
             "id": "b41b663e-171e-5bfc-9926-ad787bbf0b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad53306-7abf-46bb-a0d7-a87df7b40c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad53306-7abf-46bb-a0d7-a87df7b40c1b.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -18842,7 +18842,7 @@
         },
         {
             "id": "8a4852e3-4ea6-51f3-9cc4-6da0ee1adeb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fd96c-fb06-44d1-b8e3-f06ecdaa484c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fd96c-fb06-44d1-b8e3-f06ecdaa484c.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -18877,7 +18877,7 @@
         },
         {
             "id": "e8da3b28-a20c-59a9-ba95-fcd0122f1e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d06112-9d7d-4d1b-8b2d-b948b13035d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d06112-9d7d-4d1b-8b2d-b948b13035d6.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -18909,7 +18909,7 @@
         },
         {
             "id": "e7892e37-e97e-5738-917a-c0725972e89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fad548-ce37-43a5-98b1-e15ff04daa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fad548-ce37-43a5-98b1-e15ff04daa30.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -18947,7 +18947,7 @@
         },
         {
             "id": "01aa2274-8671-51fb-b4ff-bfdec3a44df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63161520-b60d-4cea-91c3-a1b83ce8e292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63161520-b60d-4cea-91c3-a1b83ce8e292.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -18982,7 +18982,7 @@
         },
         {
             "id": "1fd82ed2-0fd0-567a-b84b-a18a9c33e29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a3f9b0-9f83-45b7-9697-3fe19f31a79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a3f9b0-9f83-45b7-9697-3fe19f31a79e.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -19017,7 +19017,7 @@
         },
         {
             "id": "51b8cdcd-c97b-577f-a3a2-c6ddb1f819e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56b25f-1b83-4a11-8b88-c32dc1eb0cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56b25f-1b83-4a11-8b88-c32dc1eb0cd5.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -19052,7 +19052,7 @@
         },
         {
             "id": "b31d34d7-8080-5648-8b82-b603514c1d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2829b-6f48-418b-a4ca-000d3241c5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2829b-6f48-418b-a4ca-000d3241c5ca.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -19087,7 +19087,7 @@
         },
         {
             "id": "4519d410-e1bd-5b5f-97a5-5b37684acbb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82f79d0-5eeb-4247-8625-91c770555409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82f79d0-5eeb-4247-8625-91c770555409.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -19122,7 +19122,7 @@
         },
         {
             "id": "3b465a24-6574-5ae1-940a-006385014f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df66186f-b287-4d5c-9d8a-b1683f947846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df66186f-b287-4d5c-9d8a-b1683f947846.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -19157,7 +19157,7 @@
         },
         {
             "id": "f99ea2f0-a313-5e8e-9759-0888654eb89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59cd65b-f86f-4b13-b89e-000768c80cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59cd65b-f86f-4b13-b89e-000768c80cfe.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -19192,7 +19192,7 @@
         },
         {
             "id": "69b53f6e-8eaa-5646-be4d-1e8e264d5d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8483fc-a4f8-4c61-8913-6d1b634b14c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8483fc-a4f8-4c61-8913-6d1b634b14c2.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -19227,7 +19227,7 @@
         },
         {
             "id": "93341cf1-3557-5686-9ea7-247c376d7b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014281b4-172c-4c4e-b859-4ca9ba110cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014281b4-172c-4c4e-b859-4ca9ba110cce.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -19262,7 +19262,7 @@
         },
         {
             "id": "40a8fc04-6298-555a-9025-f06817ba8c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05da6e31-2aa1-4ed2-94f8-c611252f2242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05da6e31-2aa1-4ed2-94f8-c611252f2242.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -19300,7 +19300,7 @@
         },
         {
             "id": "958f228a-90f0-535b-b592-8efcd8a5aac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ccf65-7f40-420c-b55d-4d4d0fe187c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ccf65-7f40-420c-b55d-4d4d0fe187c1.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -19335,7 +19335,7 @@
         },
         {
             "id": "6c311f87-46ef-5e50-b93b-906d2de623e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93434d1f-ff3c-45d6-8162-982244839f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93434d1f-ff3c-45d6-8162-982244839f53.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -19370,7 +19370,7 @@
         },
         {
             "id": "bad195d8-0d7c-5f6a-9e13-7d669a64e73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d81e162-1c69-4b5f-b68a-1fbb10443db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d81e162-1c69-4b5f-b68a-1fbb10443db3.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -19405,7 +19405,7 @@
         },
         {
             "id": "ede1dcd3-83aa-5c67-95a5-cbac543d1ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88e1616-e480-46c3-9aa7-dad032dde577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88e1616-e480-46c3-9aa7-dad032dde577.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -19443,7 +19443,7 @@
         },
         {
             "id": "6e676e1f-f4a8-56de-8042-7c2a9b590268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ac15ec-0d93-43a1-8e18-97df3c0dcdf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ac15ec-0d93-43a1-8e18-97df3c0dcdf6.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -19478,7 +19478,7 @@
         },
         {
             "id": "5e1211ff-7ceb-5ee2-bc90-7f39e81dcb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc5afd8-0607-4f35-80e8-764643607f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc5afd8-0607-4f35-80e8-764643607f88.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -19513,7 +19513,7 @@
         },
         {
             "id": "28251081-3951-5cfc-b70e-4657a7d8c8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9acaf17-b6bf-44b1-9062-8593668b47a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9acaf17-b6bf-44b1-9062-8593668b47a2.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -19548,7 +19548,7 @@
         },
         {
             "id": "49abd9e5-ec57-538b-993f-0889be1330e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebe189-c508-4174-b7d6-80cd01956057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebe189-c508-4174-b7d6-80cd01956057.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -19586,7 +19586,7 @@
         },
         {
             "id": "d9c260eb-e889-522a-8275-3ca90a457132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57bb0a6-56f5-4f55-b7c0-0d1323f1e435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57bb0a6-56f5-4f55-b7c0-0d1323f1e435.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -19621,7 +19621,7 @@
         },
         {
             "id": "f60efff3-205a-523a-8596-56adf755b24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b506dd0-460c-4023-a6f7-e61345fe0ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b506dd0-460c-4023-a6f7-e61345fe0ebe.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -19659,7 +19659,7 @@
         },
         {
             "id": "1a35af6c-0398-53c0-9451-6f82cabeadb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e7eb01-4ecc-4260-bcc2-6230c0e42586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e7eb01-4ecc-4260-bcc2-6230c0e42586.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -19694,7 +19694,7 @@
         },
         {
             "id": "ed27c57f-3c58-5b7f-ab8c-a3e625e48604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eac1a3-afc7-43ff-86f1-dce4fb1bc1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eac1a3-afc7-43ff-86f1-dce4fb1bc1e3.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -19729,7 +19729,7 @@
         },
         {
             "id": "fc9b154d-fe4e-5a31-9652-8fd47e3040bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e070da-8b2b-4ddc-9b14-91790d7cb955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e070da-8b2b-4ddc-9b14-91790d7cb955.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -19767,7 +19767,7 @@
         },
         {
             "id": "cdc260ba-9b38-5e67-915c-fa643c203a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7f70a-31c6-4094-914f-ecb8109a0cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7f70a-31c6-4094-914f-ecb8109a0cfa.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -19802,7 +19802,7 @@
         },
         {
             "id": "31ad4aca-b90d-5526-b7b3-84574932080c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1974c2-f125-450f-86d4-d235a382ee2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1974c2-f125-450f-86d4-d235a382ee2f.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -19837,7 +19837,7 @@
         },
         {
             "id": "39950cc4-80b6-527e-bd5d-b7743a700ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686dd8f1-9c21-45b9-8db0-4b0da9505f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686dd8f1-9c21-45b9-8db0-4b0da9505f2a.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -19872,7 +19872,7 @@
         },
         {
             "id": "ec3625d1-3b80-54dc-9c8a-3292f9f4c9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af441250-94d9-4bf6-96e2-c79c76214f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af441250-94d9-4bf6-96e2-c79c76214f47.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -19907,7 +19907,7 @@
         },
         {
             "id": "0db37645-f244-5aa8-bd22-79667627a8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227746a8-8816-4488-ab3e-20566a42970b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227746a8-8816-4488-ab3e-20566a42970b.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -19945,7 +19945,7 @@
         },
         {
             "id": "2f20ad55-b060-5c82-add6-8a1650574a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b9443b-60d6-4afb-b365-432184b4d79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b9443b-60d6-4afb-b365-432184b4d79a.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -19980,7 +19980,7 @@
         },
         {
             "id": "59d67f61-8903-5779-b9c9-944c2d246c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3f19c8-ae36-4538-884f-89c75fbd6180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3f19c8-ae36-4538-884f-89c75fbd6180.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -20015,7 +20015,7 @@
         },
         {
             "id": "c31afb2b-bcf0-5e88-bb57-ad7c58b90acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c055c1-a81a-4d6e-9776-95fd0d4b0f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c055c1-a81a-4d6e-9776-95fd0d4b0f0c.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -20050,7 +20050,7 @@
         },
         {
             "id": "8d390203-57c9-503e-a1da-34bc336f28af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c473c770-9cd9-4151-b055-9875d5f13932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c473c770-9cd9-4151-b055-9875d5f13932.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -20085,7 +20085,7 @@
         },
         {
             "id": "ddfcdc57-75b3-564f-bba6-cac6474bafde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803b87ea-8927-4056-92a2-3e47e55b698d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803b87ea-8927-4056-92a2-3e47e55b698d.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -20120,7 +20120,7 @@
         },
         {
             "id": "39d70d95-58fb-58d5-af45-90291554b5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68772d59-d3ca-4872-b2f8-311b17b936aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68772d59-d3ca-4872-b2f8-311b17b936aa.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -20155,7 +20155,7 @@
         },
         {
             "id": "8e48ac48-3590-5a96-80db-09d11b76a270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30e4141-57d8-4096-986d-4e7f4854655c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30e4141-57d8-4096-986d-4e7f4854655c.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -20190,7 +20190,7 @@
         },
         {
             "id": "b26b230a-b5f8-5600-bfc0-d0693d1411c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd04e0f-8016-44aa-bb74-d275695ff811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd04e0f-8016-44aa-bb74-d275695ff811.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -20225,7 +20225,7 @@
         },
         {
             "id": "e543b30a-16b9-5100-a826-6dca729d9ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490e699-a796-42c9-87d1-90673644a379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490e699-a796-42c9-87d1-90673644a379.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -20257,7 +20257,7 @@
         },
         {
             "id": "2c12835e-afbd-533b-a915-3a0253b9c1a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25a6cfd-61a0-454e-910b-5adfdad839c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25a6cfd-61a0-454e-910b-5adfdad839c2.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -20292,7 +20292,7 @@
         },
         {
             "id": "7d43b30a-d112-5f27-b20c-b808fa96ac35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7975a1d1-191e-4870-a2dc-6d852d7c2984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7975a1d1-191e-4870-a2dc-6d852d7c2984.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -20324,7 +20324,7 @@
         },
         {
             "id": "c90050c4-ad16-5ff8-84cb-0a47d98dc65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069e7426-07c1-4a48-8e70-894905c10f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069e7426-07c1-4a48-8e70-894905c10f0d.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -20359,7 +20359,7 @@
         },
         {
             "id": "c4ea1528-346c-53f5-a0d4-b40adcd77b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f305be6-c51d-423d-8283-39e3ffc2d790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f305be6-c51d-423d-8283-39e3ffc2d790.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -20401,7 +20401,7 @@
         },
         {
             "id": "fd679f3b-f90d-51e9-b5b3-952704c3cd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59b2b4-34d8-4add-a187-61677c7a3b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59b2b4-34d8-4add-a187-61677c7a3b0d.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -20444,7 +20444,7 @@
         },
         {
             "id": "1f7c38df-ae27-58de-b44a-85d843ee0d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51905ce-9146-46e4-8d7f-643843d48edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51905ce-9146-46e4-8d7f-643843d48edb.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -20488,7 +20488,7 @@
         },
         {
             "id": "8aa00a47-210c-5fe9-9f78-e2ada7f3e6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34eebf0-36be-4632-8687-cbe35eedcc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34eebf0-36be-4632-8687-cbe35eedcc13.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -20527,7 +20527,7 @@
         },
         {
             "id": "3a42e0c7-e101-5d42-886d-057b0e271875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f884ca5-76b7-4eb8-857e-d347f3e70b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f884ca5-76b7-4eb8-857e-d347f3e70b1c.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -20570,7 +20570,7 @@
         },
         {
             "id": "108d4f21-52cb-5ef5-9c8c-44cc4e5395d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a8776-e1bd-47c0-bdb9-cb120424e76d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a8776-e1bd-47c0-bdb9-cb120424e76d.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -20619,7 +20619,7 @@
         },
         {
             "id": "b9d606df-af8b-5708-b7a2-8b2374e156e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc49c0-1a6f-4569-a0eb-1a11dbb56ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc49c0-1a6f-4569-a0eb-1a11dbb56ea6.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -20664,7 +20664,7 @@
         },
         {
             "id": "be33cee0-d263-5403-a752-a5679856425a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b13f4ef-c140-4401-a2d2-c80af2514539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b13f4ef-c140-4401-a2d2-c80af2514539.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -20709,7 +20709,7 @@
         },
         {
             "id": "54034287-361c-5e3d-9b43-70623b53f250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7815e26-b547-47a9-90e3-d1242407b9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7815e26-b547-47a9-90e3-d1242407b9ce.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -20754,7 +20754,7 @@
         },
         {
             "id": "2d770e4d-c64b-528a-834c-bb30cb60a530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b202ad-3aca-4d50-a235-caf5ddcf99ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b202ad-3aca-4d50-a235-caf5ddcf99ee.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -20799,7 +20799,7 @@
         },
         {
             "id": "f0486636-5fef-55c4-9219-8ffd62a7c57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb40a56-80bd-4566-a005-2b385865b1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb40a56-80bd-4566-a005-2b385865b1dd.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -20844,7 +20844,7 @@
         },
         {
             "id": "4311caa5-a886-542e-a01a-b7f7ce99133f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106cb2c6-d282-4ff0-86b2-3c680973ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106cb2c6-d282-4ff0-86b2-3c680973ebe1.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -20891,7 +20891,7 @@
         },
         {
             "id": "a05e0525-cc9f-5dbc-9cdc-512ed0a25942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1705e68d-4649-4c51-b34a-2e18498b72f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1705e68d-4649-4c51-b34a-2e18498b72f2.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -20937,7 +20937,7 @@
         },
         {
             "id": "93d24e7c-d671-5c8e-9796-7eb70d3b7020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf2d71d-f662-470d-bd99-68e69ea516d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf2d71d-f662-470d-bd99-68e69ea516d5.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -20982,7 +20982,7 @@
         },
         {
             "id": "bc8e7ec5-ade7-5b21-8e76-db1d91ff0765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf93dd13-03f4-481c-9ad0-4808a4d679b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf93dd13-03f4-481c-9ad0-4808a4d679b2.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -21026,7 +21026,7 @@
         },
         {
             "id": "d062485b-d840-52ee-bd54-50ff693a5db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c4675f-1fcc-49ea-a43f-8540140689c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c4675f-1fcc-49ea-a43f-8540140689c8.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -21061,7 +21061,7 @@
         },
         {
             "id": "445698b3-85b3-5acf-b3a2-60a3640f3868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb150502-96ed-44c0-ae03-2fe0a3cbb0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb150502-96ed-44c0-ae03-2fe0a3cbb0e9.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -21095,7 +21095,7 @@
         },
         {
             "id": "3faac8a8-e74d-5877-bd63-8d3bcdbdf2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b487e0b-7824-475c-ae58-d7852789e213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b487e0b-7824-475c-ae58-d7852789e213.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -21141,7 +21141,7 @@
         },
         {
             "id": "53c5a3b9-a1fc-5ed7-9ea2-f860bf1049e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a040be4-4ffb-49f6-82fe-24140aa6be19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a040be4-4ffb-49f6-82fe-24140aa6be19.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -21186,7 +21186,7 @@
         },
         {
             "id": "0b59aee3-3ca1-5339-87d5-accf42fb9a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdf625-d257-48b8-8714-f49d99135706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdf625-d257-48b8-8714-f49d99135706.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -21232,7 +21232,7 @@
         },
         {
             "id": "cd916af2-120b-552a-b521-7f7fa3388662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eca0143-5ba3-484d-b177-b31e1a1c90b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eca0143-5ba3-484d-b177-b31e1a1c90b6.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -21277,7 +21277,7 @@
         },
         {
             "id": "1d166839-8c5f-5e73-a65e-832b46d082a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc91319-2905-44a2-a339-5ff518e0bd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc91319-2905-44a2-a339-5ff518e0bd02.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -21323,7 +21323,7 @@
         },
         {
             "id": "bd18bd1b-6edd-5a4a-a534-9a14102a80f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ef0850-a822-43b7-88fa-a3756c1b7675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ef0850-a822-43b7-88fa-a3756c1b7675.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -21368,7 +21368,7 @@
         },
         {
             "id": "0e3f2f87-ebf2-5040-89be-0700f4aa0146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10414d81-177d-43f4-9381-0d10ac51507f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10414d81-177d-43f4-9381-0d10ac51507f.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -21415,7 +21415,7 @@
         },
         {
             "id": "7cc0cc00-41fa-5c25-8f95-b24097fedf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10611b-38a0-4947-a36b-f5503584d59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10611b-38a0-4947-a36b-f5503584d59e.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -21461,7 +21461,7 @@
         },
         {
             "id": "7375d156-a91c-5307-9f8e-36995f1db164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf1e0f5-0358-4a90-bc00-967c5967ff8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf1e0f5-0358-4a90-bc00-967c5967ff8f.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -21507,7 +21507,7 @@
         },
         {
             "id": "60557799-4162-57f3-ac76-22aefa7a2723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90007d91-554e-4613-8be1-4506fd4773bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90007d91-554e-4613-8be1-4506fd4773bb.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -21552,7 +21552,7 @@
         },
         {
             "id": "ba8f9e6a-e0ea-5e6e-8002-f54f12c29194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0566c86-b433-4c9a-b8b3-96ff6183ddb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0566c86-b433-4c9a-b8b3-96ff6183ddb5.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -21598,7 +21598,7 @@
         },
         {
             "id": "8e9b5c06-cb99-58d6-9822-922b69e4d221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c934f0d6-b67a-4554-9061-720064a13d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c934f0d6-b67a-4554-9061-720064a13d99.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -21643,7 +21643,7 @@
         },
         {
             "id": "f51cf188-81a7-57fd-935f-f497c0f5fca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec9e2a0-8eff-494c-b4a3-8bf60a1dedc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec9e2a0-8eff-494c-b4a3-8bf60a1dedc8.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -21689,7 +21689,7 @@
         },
         {
             "id": "fdd44187-0300-5af1-9c59-afad5c5955f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9499f326-3ebe-4544-8dc3-30b7e16d1d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9499f326-3ebe-4544-8dc3-30b7e16d1d89.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -21734,7 +21734,7 @@
         },
         {
             "id": "8b3275a3-cb63-5026-a7f4-bf423fc62b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449500a1-c143-469a-a1dd-3e0c278fa28b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449500a1-c143-469a-a1dd-3e0c278fa28b.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -21780,7 +21780,7 @@
         },
         {
             "id": "f4feadc1-3a2e-5599-b955-00513fa12e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd796f8-4d34-4a92-b4e2-40bfbe741846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd796f8-4d34-4a92-b4e2-40bfbe741846.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -21825,7 +21825,7 @@
         },
         {
             "id": "5fb2da3e-5aa2-563c-aec2-c9b9014f29db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1040a5-4a3b-4821-9c29-e9347f2e47d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1040a5-4a3b-4821-9c29-e9347f2e47d6.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -21871,7 +21871,7 @@
         },
         {
             "id": "e58d4937-d6fb-54c1-9028-b487a4579f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe06db4-5e06-4504-b8a7-03021a695730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe06db4-5e06-4504-b8a7-03021a695730.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -21916,7 +21916,7 @@
         },
         {
             "id": "74e469da-8c09-5563-bd42-c2dbd05a3aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d6e52-e6ba-4268-99ad-e22345866a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d6e52-e6ba-4268-99ad-e22345866a51.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -21963,7 +21963,7 @@
         },
         {
             "id": "5a401fd9-02d6-59b9-9cf8-65f4d386ede1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520b89b6-53f5-4cad-b842-9dcc0a46224e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520b89b6-53f5-4cad-b842-9dcc0a46224e.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -22009,7 +22009,7 @@
         },
         {
             "id": "f5c46be1-7e6b-5e4e-bb34-51cd7dbe2efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fbb90d-0338-4673-8c2c-65a500662b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fbb90d-0338-4673-8c2c-65a500662b01.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -22055,7 +22055,7 @@
         },
         {
             "id": "7d8d18d0-c520-52d0-b211-033755419d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20991b-bab8-4fc7-8d66-fca55ff341db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20991b-bab8-4fc7-8d66-fca55ff341db.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -22100,7 +22100,7 @@
         },
         {
             "id": "3fb6af06-725c-5db8-9e3d-22200602aed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08239a3-ed5a-4345-8772-6bcbed164d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08239a3-ed5a-4345-8772-6bcbed164d7b.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -22146,7 +22146,7 @@
         },
         {
             "id": "dcee069f-496b-50a5-ba50-952cfa966498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0ca0-9b2d-4c27-9ecd-0b2a7661952e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0ca0-9b2d-4c27-9ecd-0b2a7661952e.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -22191,7 +22191,7 @@
         },
         {
             "id": "a4072135-41e9-54e1-8905-4a853e6cf9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d71fe21-04ac-473c-9b93-1b4e129b8155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d71fe21-04ac-473c-9b93-1b4e129b8155.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -22238,7 +22238,7 @@
         },
         {
             "id": "4f3671e6-6faa-533a-9ba9-f05f5bf09e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25da713c-55c0-4842-b199-5659028cda74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25da713c-55c0-4842-b199-5659028cda74.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -22284,7 +22284,7 @@
         },
         {
             "id": "d7563ec5-9258-5552-a697-1f68f6ce6a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b828e-eaf6-4599-925a-64e59201de6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b828e-eaf6-4599-925a-64e59201de6e.jpg?1",
             "name": "Past in Flames",
             "text": "",
             "colours": [
@@ -22315,7 +22315,7 @@
         },
         {
             "id": "a14698b3-9a83-51ec-8e37-9127fc209716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0615cc-860a-4fed-9e9c-4377ba8ed22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0615cc-860a-4fed-9e9c-4377ba8ed22a.jpg?1",
             "name": "Amy's Home",
             "text": "",
             "colours": [],
@@ -22344,7 +22344,7 @@
         },
         {
             "id": "82e9fcb7-2e78-5cf3-aff0-c4aed5dc8e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc61f60-2f9d-4f67-8390-62873b4b8ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc61f60-2f9d-4f67-8390-62873b4b8ddb.jpg?1",
             "name": "Antarctic Research Base",
             "text": "",
             "colours": [],
@@ -22373,7 +22373,7 @@
         },
         {
             "id": "a4030564-a0b0-5672-b741-b08a58fdec83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855978a6-c81c-4e5e-a34f-41a54fef0c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855978a6-c81c-4e5e-a34f-41a54fef0c10.jpg?1",
             "name": "Aplan Mortarium",
             "text": "",
             "colours": [],
@@ -22402,7 +22402,7 @@
         },
         {
             "id": "09a19712-f09f-50a9-be4e-1c19e4a113da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a068875e-9294-403d-a6db-15092b6c42d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a068875e-9294-403d-a6db-15092b6c42d3.jpg?1",
             "name": "Bad Wolf Bay",
             "text": "",
             "colours": [],
@@ -22431,7 +22431,7 @@
         },
         {
             "id": "6bbcf9e2-3e41-5879-9608-7498f895873f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb62bd5-79e5-4af0-aafd-c1bd53765c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb62bd5-79e5-4af0-aafd-c1bd53765c67.jpg?1",
             "name": "Besieged Viking Village",
             "text": "",
             "colours": [],
@@ -22460,7 +22460,7 @@
         },
         {
             "id": "635eb13f-9918-56df-8f2e-afc012ee1f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e3ec5a-4bd5-452f-873a-3801253754dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e3ec5a-4bd5-452f-873a-3801253754dd.jpg?1",
             "name": "Bowie Base One",
             "text": "",
             "colours": [],
@@ -22489,7 +22489,7 @@
         },
         {
             "id": "38be451d-cfa3-52e5-81e8-1e20077ec531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddc6d0-50cc-4914-a6f2-00fb93d4402a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddc6d0-50cc-4914-a6f2-00fb93d4402a.jpg?1",
             "name": "Caught in a Parallel Universe",
             "text": "",
             "colours": [],
@@ -22516,7 +22516,7 @@
         },
         {
             "id": "e62e352e-aaf8-50a3-9174-6be4483a2b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74560139-0870-4184-887b-72d67c57b6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74560139-0870-4184-887b-72d67c57b6ed.jpg?1",
             "name": "The Cave of Skulls",
             "text": "",
             "colours": [],
@@ -22545,7 +22545,7 @@
         },
         {
             "id": "b7d109e1-cd35-5004-ab04-2bbd909b2b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6bd680-18c6-46d9-b747-825fb0fee6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6bd680-18c6-46d9-b747-825fb0fee6dd.jpg?1",
             "name": "The Cheetah Planet",
             "text": "",
             "colours": [],
@@ -22574,7 +22574,7 @@
         },
         {
             "id": "78630b32-b5c9-581b-9918-10c854642c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f82f5b7-b4b9-489a-bbd7-98faaa566515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f82f5b7-b4b9-489a-bbd7-98faaa566515.jpg?1",
             "name": "City of the Daleks",
             "text": "",
             "colours": [],
@@ -22603,7 +22603,7 @@
         },
         {
             "id": "bafa58fe-881e-5f87-bc9a-0924d8edc785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e09673-c7f0-4377-abbd-b1ea4922d4b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e09673-c7f0-4377-abbd-b1ea4922d4b3.jpg?1",
             "name": "Coal Hill School",
             "text": "",
             "colours": [],
@@ -22632,7 +22632,7 @@
         },
         {
             "id": "a739436b-6338-5d81-8bdc-3884a67d46c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd9d2c-f1d3-4dbf-8101-e4fab9f42e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd9d2c-f1d3-4dbf-8101-e4fab9f42e40.jpg?1",
             "name": "Dalek Intensive Care",
             "text": "",
             "colours": [],
@@ -22661,7 +22661,7 @@
         },
         {
             "id": "6a4b9a52-0d62-5d43-83bf-8103321dd0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6193ea-4906-4097-8e30-431220f9e35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6193ea-4906-4097-8e30-431220f9e35c.jpg?1",
             "name": "The Dining Car",
             "text": "",
             "colours": [],
@@ -22690,7 +22690,7 @@
         },
         {
             "id": "22418a5b-2b8f-5e3e-8ff3-70a963211917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c583ab-ad15-436b-9151-8b4d212cbeda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c583ab-ad15-436b-9151-8b4d212cbeda.jpg?1",
             "name": "The Doctor's Childhood Barn",
             "text": "",
             "colours": [],
@@ -22719,7 +22719,7 @@
         },
         {
             "id": "98454da5-96a9-59dc-9c7d-829781d33130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2456bb33-6380-4b4d-bf23-7b071fc22be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2456bb33-6380-4b4d-bf23-7b071fc22be2.jpg?1",
             "name": "The Doctor's Tomb",
             "text": "",
             "colours": [],
@@ -22748,7 +22748,7 @@
         },
         {
             "id": "7df1c7d2-8342-5be5-ba5f-9687544d85d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdb7dca-017a-49a7-b8de-4a8ccf7ac679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdb7dca-017a-49a7-b8de-4a8ccf7ac679.jpg?1",
             "name": "The Drum, Mining Facility",
             "text": "",
             "colours": [],
@@ -22777,7 +22777,7 @@
         },
         {
             "id": "47604611-0a78-5ea8-b0ef-21531a47ce40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05478f9-3a9a-4887-a8e7-63550eaa6030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05478f9-3a9a-4887-a8e7-63550eaa6030.jpg?1",
             "name": "Fixed Point in Time",
             "text": "",
             "colours": [],
@@ -22804,7 +22804,7 @@
         },
         {
             "id": "d51dbcf4-ba7c-5d5e-be6e-68964c1f4d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb753c00-303d-49f3-ad98-b7772cc4a274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb753c00-303d-49f3-ad98-b7772cc4a274.jpg?1",
             "name": "Gardens of Tranquil Repose",
             "text": "",
             "colours": [],
@@ -22833,7 +22833,7 @@
         },
         {
             "id": "f84f5164-6029-57cc-a7db-78c3de3e9a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b164271-6438-4135-b7a9-8573c3921052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b164271-6438-4135-b7a9-8573c3921052.jpg?1",
             "name": "Hotel of Fears",
             "text": "",
             "colours": [],
@@ -22862,7 +22862,7 @@
         },
         {
             "id": "5abd4084-405d-5312-ba65-82fc5461cc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5def75a-f511-42e8-a652-7de4abfbd968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5def75a-f511-42e8-a652-7de4abfbd968.jpg?1",
             "name": "Human-Time Lord Meta-Crisis",
             "text": "",
             "colours": [],
@@ -22889,7 +22889,7 @@
         },
         {
             "id": "464da0d0-dfdf-5efd-a504-7e224c248b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c46b6c1-0c84-4bd3-b317-9b8191ad937e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c46b6c1-0c84-4bd3-b317-9b8191ad937e.jpg?1",
             "name": "Kerblam! Warehouse",
             "text": "",
             "colours": [],
@@ -22918,7 +22918,7 @@
         },
         {
             "id": "813a5a51-d2bb-52c7-8af0-3c39994a090d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45091d2b-d872-4beb-af87-7675aaf0c2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45091d2b-d872-4beb-af87-7675aaf0c2c8.jpg?1",
             "name": "Lake Silencio",
             "text": "",
             "colours": [],
@@ -22947,7 +22947,7 @@
         },
         {
             "id": "3cb4628c-99d6-5758-a937-1ebbadbf099a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cd9db0-b417-42e8-b3be-00fdc9330014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cd9db0-b417-42e8-b3be-00fdc9330014.jpg?1",
             "name": "The Lux Foundation Library",
             "text": "",
             "colours": [],
@@ -22976,7 +22976,7 @@
         },
         {
             "id": "24e5c16d-4607-5cb3-bdfc-908d6c2a3a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c343b9dd-edce-46ee-bdd6-f240cf061d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c343b9dd-edce-46ee-bdd6-f240cf061d59.jpg?1",
             "name": "The Matrix of Time",
             "text": "",
             "colours": [],
@@ -23005,7 +23005,7 @@
         },
         {
             "id": "97833a41-cc53-514a-94d7-d67156193e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6728e1-12f0-40a7-90f9-520f3572b190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6728e1-12f0-40a7-90f9-520f3572b190.jpg?1",
             "name": "Mondassian Colony Ship",
             "text": "",
             "colours": [],
@@ -23034,7 +23034,7 @@
         },
         {
             "id": "70f88220-9341-5bf2-915e-a3aa7f18b8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715df92-e504-4844-9d74-6f4965fd32ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715df92-e504-4844-9d74-6f4965fd32ee.jpg?1",
             "name": "The Moonbase",
             "text": "",
             "colours": [],
@@ -23063,7 +23063,7 @@
         },
         {
             "id": "d0695847-8740-5850-83b8-ebc114c2d96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185dfce-d3ad-4509-b356-f6750d7c6a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185dfce-d3ad-4509-b356-f6750d7c6a09.jpg?1",
             "name": "New New York",
             "text": "",
             "colours": [],
@@ -23092,7 +23092,7 @@
         },
         {
             "id": "4be7f5b0-0dca-5626-beab-f5aee3d6b68f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6489955c-1571-41dd-9419-5c071a8b3e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6489955c-1571-41dd-9419-5c071a8b3e30.jpg?1",
             "name": "North Pole Research Base",
             "text": "",
             "colours": [],
@@ -23121,7 +23121,7 @@
         },
         {
             "id": "f2d459d3-7028-5c73-ba35-7e322cedb434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c9e68-4d5f-4e7f-894b-56dec4081fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c9e68-4d5f-4e7f-894b-56dec4081fc7.jpg?1",
             "name": "Ood Sphere",
             "text": "",
             "colours": [],
@@ -23150,7 +23150,7 @@
         },
         {
             "id": "b9083c96-30db-5cfe-96f6-6cda111e4613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549ee7a-276b-45eb-a2c7-f74c85dc6a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549ee7a-276b-45eb-a2c7-f74c85dc6a0d.jpg?1",
             "name": "Pompeii",
             "text": "",
             "colours": [],
@@ -23179,7 +23179,7 @@
         },
         {
             "id": "534af165-6b05-5c7d-b0c4-5a9a583c9882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291478b8-a8f6-4449-8cd8-9d70484d3398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291478b8-a8f6-4449-8cd8-9d70484d3398.jpg?1",
             "name": "Prime Minister's Cabinet Room",
             "text": "",
             "colours": [],
@@ -23208,7 +23208,7 @@
         },
         {
             "id": "4857443f-7980-5838-9163-a1c6449cfb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec22c6-4986-45aa-9b6b-8517bbbaed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec22c6-4986-45aa-9b6b-8517bbbaed4e.jpg?1",
             "name": "The Pyramid of Mars",
             "text": "",
             "colours": [],
@@ -23237,7 +23237,7 @@
         },
         {
             "id": "edaa95c4-4a8c-58bb-9182-4721a7e13b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30f88bd-426a-48fb-a921-c7c5831120bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30f88bd-426a-48fb-a921-c7c5831120bd.jpg?1",
             "name": "Singing Towers of Darillium",
             "text": "",
             "colours": [],
@@ -23266,7 +23266,7 @@
         },
         {
             "id": "a200ec7c-6c36-5bd2-b3f4-6b96c30aa760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84933e48-8b10-4ccf-a7e8-140fbb9c0c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84933e48-8b10-4ccf-a7e8-140fbb9c0c9b.jpg?1",
             "name": "Spectrox Mines",
             "text": "",
             "colours": [],
@@ -23295,7 +23295,7 @@
         },
         {
             "id": "6570ab5c-4582-5b8a-8072-11340f966e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665c85f-f564-47fe-a123-4e5a70e179d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665c85f-f564-47fe-a123-4e5a70e179d9.jpg?1",
             "name": "Stormcage Containment Facility",
             "text": "",
             "colours": [],
@@ -23324,7 +23324,7 @@
         },
         {
             "id": "b80c362d-3cba-5db1-9eee-81219c7071d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2d8456-6e3c-42ee-8bd4-215db5fbda98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2d8456-6e3c-42ee-8bd4-215db5fbda98.jpg?1",
             "name": "TARDIS Bay",
             "text": "",
             "colours": [],
@@ -23353,7 +23353,7 @@
         },
         {
             "id": "6b313e3f-3c83-55f2-a984-eea562169f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75481e04-ab27-4fdd-b789-4a53ffc92430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75481e04-ab27-4fdd-b789-4a53ffc92430.jpg?1",
             "name": "Temple of Atropos",
             "text": "",
             "colours": [],
@@ -23382,7 +23382,7 @@
         },
         {
             "id": "64f6f47e-3881-5342-9503-e9889d206d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40732207-291c-4cea-be87-dd4dbb8b6259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40732207-291c-4cea-be87-dd4dbb8b6259.jpg?1",
             "name": "Two Streams Facility",
             "text": "",
             "colours": [],
@@ -23411,7 +23411,7 @@
         },
         {
             "id": "08873df2-d77b-52bb-adae-3056bcf45bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7ec46f-1499-4c75-8568-d9266a3d1e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7ec46f-1499-4c75-8568-d9266a3d1e69.jpg?1",
             "name": "UNIT Headquarters",
             "text": "",
             "colours": [],
@@ -23440,7 +23440,7 @@
         },
         {
             "id": "18ff2672-ceda-531f-9608-f7632e79d300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c04ad-a8b5-453a-aff4-dce743b1c693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c04ad-a8b5-453a-aff4-dce743b1c693.jpg?1",
             "name": "Unleash the Flux",
             "text": "",
             "colours": [],
@@ -23467,7 +23467,7 @@
         },
         {
             "id": "cce86856-3691-56b1-924f-90b22e98d89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb0761-820f-43b6-bedc-e6103faf45ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb0761-820f-43b6-bedc-e6103faf45ea.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -23515,7 +23515,7 @@
         },
         {
             "id": "085184f5-6b60-5886-9f2e-c9daf7440124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fa1d9-adcb-43b4-bfce-42d9e7530ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fa1d9-adcb-43b4-bfce-42d9e7530ac6.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -23561,7 +23561,7 @@
         },
         {
             "id": "e4ef2794-38b9-5642-8540-f9c37a63e296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef59ead-4854-47ee-b31a-74acccb59728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef59ead-4854-47ee-b31a-74acccb59728.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -23607,7 +23607,7 @@
         },
         {
             "id": "47adf329-3c8e-5af4-801a-c361a3e647f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d087c16-33f5-44a3-b036-cc6322c7e578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d087c16-33f5-44a3-b036-cc6322c7e578.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -23653,7 +23653,7 @@
         },
         {
             "id": "25116c7a-8a6c-5c49-b86d-81119d66aaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac4cfec-1e78-4877-95a4-43a0a41cc75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac4cfec-1e78-4877-95a4-43a0a41cc75c.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -23694,7 +23694,7 @@
         },
         {
             "id": "3ecdf34a-dd1a-5da8-8142-d3ad1f57a59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d676054-fdd0-44a8-b723-0aac048e6e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d676054-fdd0-44a8-b723-0aac048e6e28.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -23736,7 +23736,7 @@
         },
         {
             "id": "0ed1379f-9731-56af-804c-9766222e270c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959d587-d723-42ce-9339-b50c307d2882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959d587-d723-42ce-9339-b50c307d2882.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -23778,7 +23778,7 @@
         },
         {
             "id": "410bdc3c-5730-5a53-afa9-6c29f11b5a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b81c472-ebf3-4451-9716-242a7962b598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b81c472-ebf3-4451-9716-242a7962b598.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -23824,7 +23824,7 @@
         },
         {
             "id": "1b923193-d70f-5428-b366-14e1602e2051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9eee5f-29c0-4f2f-996c-1ba23a55ec81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9eee5f-29c0-4f2f-996c-1ba23a55ec81.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -23860,7 +23860,7 @@
         },
         {
             "id": "059ac58a-a6c9-50fb-92c4-5503c3e9f92c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b98e0b0-ff76-4e71-a266-82e1f1c00e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b98e0b0-ff76-4e71-a266-82e1f1c00e54.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -23897,7 +23897,7 @@
         },
         {
             "id": "a4713ba5-7741-54ef-aad6-8a876978383b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fde7632-c2ac-45e4-a135-9bdfa135c77d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fde7632-c2ac-45e4-a135-9bdfa135c77d.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -23936,7 +23936,7 @@
         },
         {
             "id": "b1247395-590c-5974-9c25-0f08db81f824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2ef5dc-77e4-40b9-b724-868c99c28cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2ef5dc-77e4-40b9-b724-868c99c28cee.jpg?1",
             "name": "Atraxi Warden",
             "text": "",
             "colours": [
@@ -23972,7 +23972,7 @@
         },
         {
             "id": "6acee774-1cae-5bd6-9ec2-8e62b4c86d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bf2b8-f318-4ec2-b040-00820d8f7832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bf2b8-f318-4ec2-b040-00820d8f7832.jpg?1",
             "name": "Banish to Another Universe",
             "text": "",
             "colours": [
@@ -24005,7 +24005,7 @@
         },
         {
             "id": "64ba0a74-752f-5780-aac3-3d9fbe22b311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f1fd2-ada7-40b7-99bf-73f0e38d71db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f1fd2-ada7-40b7-99bf-73f0e38d71db.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -24045,7 +24045,7 @@
         },
         {
             "id": "7d6fc082-289c-58a9-b3ef-d1486f9f6c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0bda4e-c7f3-4585-980b-d9e2ed9ff64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0bda4e-c7f3-4585-980b-d9e2ed9ff64b.jpg?1",
             "name": "The Caves of Androzani",
             "text": "",
             "colours": [
@@ -24080,7 +24080,7 @@
         },
         {
             "id": "84c7ea05-20e4-5076-96e0-b52e0a2be160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae92a01-7bba-4f11-a88d-b34e18363da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae92a01-7bba-4f11-a88d-b34e18363da1.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -24115,7 +24115,7 @@
         },
         {
             "id": "9d8cc000-91b8-5656-93dc-cf6eb65a6d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee59476-d94d-4c2a-be2c-831c1e89c4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee59476-d94d-4c2a-be2c-831c1e89c4f3.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -24150,7 +24150,7 @@
         },
         {
             "id": "009dc028-259b-5110-b61c-2ce1297e9835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4b08d-1882-4c8c-abb5-f0e9e5e9292d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4b08d-1882-4c8c-abb5-f0e9e5e9292d.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -24185,7 +24185,7 @@
         },
         {
             "id": "a7e94205-125b-5877-9698-677239e2a8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136bd8c3-a54f-40cd-96c9-5023a67e7fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136bd8c3-a54f-40cd-96c9-5023a67e7fd6.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -24220,7 +24220,7 @@
         },
         {
             "id": "1b66b35a-bcf0-5da8-a231-7d173c15ec39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853506d3-200c-4829-9032-168e45f120bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853506d3-200c-4829-9032-168e45f120bf.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -24255,7 +24255,7 @@
         },
         {
             "id": "bd5dea71-7d9a-5646-a596-a866d2f4136c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da19a75-e018-4cde-b2b5-1f7b19e8e41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da19a75-e018-4cde-b2b5-1f7b19e8e41f.jpg?1",
             "name": "The Girl in the Fireplace",
             "text": "",
             "colours": [
@@ -24290,7 +24290,7 @@
         },
         {
             "id": "542feaa5-aa01-5ba3-ab6e-a9a762b1d17d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5347feac-78cb-4444-9516-574f7c5526c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5347feac-78cb-4444-9516-574f7c5526c7.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -24330,7 +24330,7 @@
         },
         {
             "id": "5bee9cc2-8be3-5cfc-bc20-531c010ada72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f11d2-f450-4a89-9b3d-20df669e255c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f11d2-f450-4a89-9b3d-20df669e255c.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -24370,7 +24370,7 @@
         },
         {
             "id": "b8675248-77e4-593a-8a03-1ce0147edb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82931c7d-4e6a-44f4-a487-ecfbd287e778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82931c7d-4e6a-44f4-a487-ecfbd287e778.jpg?1",
             "name": "The Night of the Doctor",
             "text": "",
             "colours": [
@@ -24405,7 +24405,7 @@
         },
         {
             "id": "b5299c80-b455-500f-82fa-16623d800059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecb2f79-5e9a-4c38-950e-57be6dfe79d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecb2f79-5e9a-4c38-950e-57be6dfe79d9.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -24442,7 +24442,7 @@
         },
         {
             "id": "871e6b19-a6f1-51fd-8455-339f9d4c60c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc386fc-eb04-4d5b-b83e-c383112b4815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc386fc-eb04-4d5b-b83e-c383112b4815.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -24481,7 +24481,7 @@
         },
         {
             "id": "20b2c6d8-9e33-51fd-882c-2f80bf5167e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c2114b-257c-4151-968f-74cb42d1c350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c2114b-257c-4151-968f-74cb42d1c350.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -24521,7 +24521,7 @@
         },
         {
             "id": "99b8077d-a803-523a-87c1-34621e3c68c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbdd3fe-7e86-408f-a787-e9dec27343ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbdd3fe-7e86-408f-a787-e9dec27343ae.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -24560,7 +24560,7 @@
         },
         {
             "id": "963cbf45-2012-5a22-9b50-3f75aabd888c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139dab8d-88f5-4a59-9db1-9b8b81c78822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139dab8d-88f5-4a59-9db1-9b8b81c78822.jpg?1",
             "name": "Trial of a Time Lord",
             "text": "",
             "colours": [
@@ -24595,7 +24595,7 @@
         },
         {
             "id": "55df0c16-192f-5579-8abe-6b806c204d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20d978b-f854-4225-a420-b013889b0783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20d978b-f854-4225-a420-b013889b0783.jpg?1",
             "name": "The War Games",
             "text": "",
             "colours": [
@@ -24630,7 +24630,7 @@
         },
         {
             "id": "86fec126-6494-5e53-82a6-fa5dc22e6695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cdfa73-4e56-4364-82eb-744a1680911d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cdfa73-4e56-4364-82eb-744a1680911d.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -24665,7 +24665,7 @@
         },
         {
             "id": "325d7109-ba59-59a0-804a-1c0dba66c64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b0534e-b59a-4b90-88f1-de45917556da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b0534e-b59a-4b90-88f1-de45917556da.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -24705,7 +24705,7 @@
         },
         {
             "id": "4a09684d-2be5-5447-8b5a-09f5e0ff1390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f3de2b-c0ec-4448-9a49-8f41732494b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f3de2b-c0ec-4448-9a49-8f41732494b7.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -24745,7 +24745,7 @@
         },
         {
             "id": "58e74769-ed94-5a94-a709-bf531534174f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc08a16-d2ef-44d2-ae6b-7ff9ce27ef00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc08a16-d2ef-44d2-ae6b-7ff9ce27ef00.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -24780,7 +24780,7 @@
         },
         {
             "id": "eb217b37-6017-5b03-acf7-9c209fb702e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6d87d6-e89c-4b84-b1d0-2aad21cb1c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6d87d6-e89c-4b84-b1d0-2aad21cb1c47.jpg?1",
             "name": "An Unearthly Child",
             "text": "",
             "colours": [
@@ -24815,7 +24815,7 @@
         },
         {
             "id": "f336f3b2-b389-5454-b0aa-346f4873aadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aa293d-6354-4285-b692-9f846aef9f5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aa293d-6354-4285-b692-9f846aef9f5c.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -24854,7 +24854,7 @@
         },
         {
             "id": "c1708300-53cb-579e-a5d6-3a1f4353708c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a3912f-0e03-4c87-884e-955f84dbea6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a3912f-0e03-4c87-884e-955f84dbea6d.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -24891,7 +24891,7 @@
         },
         {
             "id": "241c8c9f-9fbb-59d9-be23-3271090863de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6573c-13cb-4ad9-a9d0-6f3029440246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6573c-13cb-4ad9-a9d0-6f3029440246.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -24926,7 +24926,7 @@
         },
         {
             "id": "b6aca4b0-0359-56d5-98f3-fc066c3dfd28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d45933-35e0-4562-b9a8-27aede3294d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d45933-35e0-4562-b9a8-27aede3294d1.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -24967,7 +24967,7 @@
         },
         {
             "id": "e1596c2c-f3dc-57c3-85e7-61a247b11e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92aed2-9f40-4507-bd91-fd1b4d405c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92aed2-9f40-4507-bd91-fd1b4d405c91.jpg?1",
             "name": "Don't Blink",
             "text": "",
             "colours": [
@@ -25000,7 +25000,7 @@
         },
         {
             "id": "bf5c6743-88c9-5a44-b945-b16431de0949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed22dc33-d3c0-454e-aa41-29b653742964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed22dc33-d3c0-454e-aa41-29b653742964.jpg?1",
             "name": "The Eleventh Hour",
             "text": "",
             "colours": [
@@ -25035,7 +25035,7 @@
         },
         {
             "id": "c5fdd5f4-ce3a-5998-95ba-c4a733b49fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b79758-1d7c-484c-9b23-8e8fa3a9c560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b79758-1d7c-484c-9b23-8e8fa3a9c560.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -25074,7 +25074,7 @@
         },
         {
             "id": "9f2e8c9a-04f3-56c2-9405-b67e301e11c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0541308b-0ff0-4c88-8d11-4bd324047b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0541308b-0ff0-4c88-8d11-4bd324047b06.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -25109,7 +25109,7 @@
         },
         {
             "id": "625cd890-5ccc-5555-9189-4bc846f1dd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b017dead-b202-400d-ab08-e0081ac0f39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b017dead-b202-400d-ab08-e0081ac0f39f.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -25147,7 +25147,7 @@
         },
         {
             "id": "e99f8774-225b-5f67-bf87-7fb48adaa515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ac277c-c581-4552-9363-0b43c37d402a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ac277c-c581-4552-9363-0b43c37d402a.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -25186,7 +25186,7 @@
         },
         {
             "id": "f2d6e28a-56df-5968-97d4-cfbd40712c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a217740c-1793-4832-b3ef-dd87ef9aec0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a217740c-1793-4832-b3ef-dd87ef9aec0a.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -25221,7 +25221,7 @@
         },
         {
             "id": "da1cbab2-303c-54d8-ab0f-8fc2bbe25838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca07223-8057-4687-be8f-730d952d6a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca07223-8057-4687-be8f-730d952d6a58.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -25264,7 +25264,7 @@
         },
         {
             "id": "632c218f-f7ea-5477-9ff1-b7fe09b1db04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028f347-24e8-4e14-bce5-3d88134a6bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028f347-24e8-4e14-bce5-3d88134a6bec.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -25304,7 +25304,7 @@
         },
         {
             "id": "e90b543f-ed09-5c1e-8095-3a19c389e54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d113fcac-095b-43c5-94e9-299592cf7aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d113fcac-095b-43c5-94e9-299592cf7aa1.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -25339,7 +25339,7 @@
         },
         {
             "id": "4f80fd48-83dc-5035-b82a-041e7d5222e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e360c6e-da94-4384-aad7-85f300c9c332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e360c6e-da94-4384-aad7-85f300c9c332.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -25379,7 +25379,7 @@
         },
         {
             "id": "5c3db9e7-1210-5a00-9e14-c2e357fe447c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e908f2-5717-48e6-80a0-508029b4a016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e908f2-5717-48e6-80a0-508029b4a016.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -25419,7 +25419,7 @@
         },
         {
             "id": "6dd41c86-ed05-5171-b27c-92e075a17532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530a366-d59f-466f-a3fc-d858a5854564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530a366-d59f-466f-a3fc-d858a5854564.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -25454,7 +25454,7 @@
         },
         {
             "id": "9aed667f-8672-53ac-8981-0fbd54dbef95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984a09f-91e5-4566-9f8e-e8e12e4dcb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984a09f-91e5-4566-9f8e-e8e12e4dcb5b.jpg?1",
             "name": "Renegade Silent",
             "text": "",
             "colours": [
@@ -25490,7 +25490,7 @@
         },
         {
             "id": "5c42beeb-ea5e-55a0-8017-7223732d65ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9744f-bfc7-4597-9928-1b1029c24ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9744f-bfc7-4597-9928-1b1029c24ff4.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -25525,7 +25525,7 @@
         },
         {
             "id": "f1892b7f-f9ce-508b-a35f-133bf3028b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c0b0e-4f10-4a34-855c-423839b4b828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c0b0e-4f10-4a34-855c-423839b4b828.jpg?1",
             "name": "Star Whale",
             "text": "",
             "colours": [
@@ -25561,7 +25561,7 @@
         },
         {
             "id": "a2ed44e1-a091-50f2-b0ac-3c3275580275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87455d11-f5e7-45fc-b79c-ddd5f4e78d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87455d11-f5e7-45fc-b79c-ddd5f4e78d53.jpg?1",
             "name": "Start the TARDIS",
             "text": "",
             "colours": [
@@ -25594,7 +25594,7 @@
         },
         {
             "id": "d07a8375-5c52-5260-a659-e58c1338efb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e202cf6-d7a0-47a8-94fc-0345ea53c21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e202cf6-d7a0-47a8-94fc-0345ea53c21b.jpg?1",
             "name": "Surge of Brilliance",
             "text": "",
             "colours": [
@@ -25627,7 +25627,7 @@
         },
         {
             "id": "8d149d8b-d8bc-58da-a9a9-27ff814b889b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a8197-55c2-4abd-9979-b62014240796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a8197-55c2-4abd-9979-b62014240796.jpg?1",
             "name": "Time Beetle",
             "text": "",
             "colours": [
@@ -25663,7 +25663,7 @@
         },
         {
             "id": "8176bd36-ea10-5e02-8308-24eadee680bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47559f8-d634-48b9-828a-d16485eb9ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47559f8-d634-48b9-828a-d16485eb9ea0.jpg?1",
             "name": "Time Lord Regeneration",
             "text": "",
             "colours": [
@@ -25696,7 +25696,7 @@
         },
         {
             "id": "50ccd68b-51e5-58c4-9fa8-76cefad9bae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad33b-aad4-438b-8063-003c98d53df7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad33b-aad4-438b-8063-003c98d53df7.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -25731,7 +25731,7 @@
         },
         {
             "id": "fc11911e-c839-50cf-b958-70453603e3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -25764,7 +25764,7 @@
         },
         {
             "id": "5d883850-1d97-5a59-8cb0-2bf9ee3f5be0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -25799,7 +25799,7 @@
         },
         {
             "id": "665b2044-386c-5f16-952d-454565d63a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2355e847-f147-421a-8fc3-7e244b4a70ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2355e847-f147-421a-8fc3-7e244b4a70ee.jpg?1",
             "name": "Wibbly-wobbly, Timey-wimey",
             "text": "",
             "colours": [
@@ -25832,7 +25832,7 @@
         },
         {
             "id": "f828e0f3-b308-5742-9346-0080511dc8a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4fc3c3-6fc5-4e9b-8fe2-91d3889c9558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4fc3c3-6fc5-4e9b-8fe2-91d3889c9558.jpg?1",
             "name": "Zygon Infiltrator",
             "text": "",
             "colours": [
@@ -25869,7 +25869,7 @@
         },
         {
             "id": "f8e7c8c9-f395-5c5e-b89b-349bf4dfa2ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5333c5-b0c8-4ce1-8ee5-cd2f7b54d5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5333c5-b0c8-4ce1-8ee5-cd2f7b54d5fb.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -25907,7 +25907,7 @@
         },
         {
             "id": "0d8f3901-57cb-5ccd-a85c-e260a20d2914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a5f1c9-8164-43c6-96f1-894d6981a2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a5f1c9-8164-43c6-96f1-894d6981a2ea.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -25945,7 +25945,7 @@
         },
         {
             "id": "277d8e11-3bd4-595c-9715-69298a9583cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bedb9c9-8ed5-4aad-b594-722041a7e393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bedb9c9-8ed5-4aad-b594-722041a7e393.jpg?1",
             "name": "Death in Heaven",
             "text": "",
             "colours": [
@@ -25980,7 +25980,7 @@
         },
         {
             "id": "e263f5fc-72ea-5609-829d-c7f02f7b41fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e6ec7f-4b98-43c2-bdf8-c662263cda51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e6ec7f-4b98-43c2-bdf8-c662263cda51.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -26015,7 +26015,7 @@
         },
         {
             "id": "dfcc1cfe-24f4-5606-a1e3-7a45e3b9c265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53f2c88-0719-4a4e-849f-239358cb3518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53f2c88-0719-4a4e-849f-239358cb3518.jpg?1",
             "name": "Exterminate!",
             "text": "",
             "colours": [
@@ -26048,7 +26048,7 @@
         },
         {
             "id": "d46006ed-cc63-56e9-98ac-383d0abfd2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59cf715-271c-4f65-9f53-56b822f46ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59cf715-271c-4f65-9f53-56b822f46ea5.jpg?1",
             "name": "Genesis of the Daleks",
             "text": "",
             "colours": [
@@ -26083,7 +26083,7 @@
         },
         {
             "id": "eae9decb-7f85-57b6-9d1d-2a985447bdf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686d1c6-bebe-45ac-b82e-78cf420b5e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686d1c6-bebe-45ac-b82e-78cf420b5e33.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -26118,7 +26118,7 @@
         },
         {
             "id": "2adfdcad-2730-54fa-9616-921a91a80b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e904743-37b7-462e-80c5-963fc94528b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e904743-37b7-462e-80c5-963fc94528b5.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -26156,7 +26156,7 @@
         },
         {
             "id": "a2fe40a9-238c-5ac5-8f0e-2844bdc9bd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574546c1-c023-4250-990a-010fc630934b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574546c1-c023-4250-990a-010fc630934b.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -26191,7 +26191,7 @@
         },
         {
             "id": "1c91b71c-52cb-592e-bff8-73a30dd8c596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4defc65-1473-4e4f-8b39-9d7e004170d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4defc65-1473-4e4f-8b39-9d7e004170d3.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -26229,7 +26229,7 @@
         },
         {
             "id": "3c3c7d0b-3e69-5fe0-9b66-70548864ef53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0879d8-fa00-47b2-9c94-298e51bf7d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0879d8-fa00-47b2-9c94-298e51bf7d99.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -26268,7 +26268,7 @@
         },
         {
             "id": "9665dee8-cfc0-5597-955f-75581129fd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f90c5f-d45d-49ec-a597-fde8b4c27331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f90c5f-d45d-49ec-a597-fde8b4c27331.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -26307,7 +26307,7 @@
         },
         {
             "id": "e2f12d83-c224-5706-afbe-8580cb9498a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a7ecf0-70db-4619-981e-f67bf9c9d2d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a7ecf0-70db-4619-981e-f67bf9c9d2d2.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -26346,7 +26346,7 @@
         },
         {
             "id": "a4e0d81e-48ac-53aa-85bb-b3a9b7f599f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -26379,7 +26379,7 @@
         },
         {
             "id": "f056591c-dd6e-5a32-b4b7-a6ee73c9168e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -26412,7 +26412,7 @@
         },
         {
             "id": "1e7d2e89-6afb-5bd3-b31b-aef29cf843fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bf6c2-c7c2-48f5-a1a5-0aac4a08e567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bf6c2-c7c2-48f5-a1a5-0aac4a08e567.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -26451,7 +26451,7 @@
         },
         {
             "id": "9af17119-f546-5bc5-98a8-37a0f28e6c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0b79b-874b-4ae2-b60e-ee6cb6753e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0b79b-874b-4ae2-b60e-ee6cb6753e6d.jpg?1",
             "name": "Day of the Moon",
             "text": "",
             "colours": [
@@ -26486,7 +26486,7 @@
         },
         {
             "id": "083bcb03-a7b8-58d5-86b0-b3613ff153e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d63dfcc-49c2-49df-8542-649f659ccf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d63dfcc-49c2-49df-8542-649f659ccf0d.jpg?1",
             "name": "Decaying Time Loop",
             "text": "",
             "colours": [
@@ -26519,7 +26519,7 @@
         },
         {
             "id": "dfeac889-07fa-5ce6-a0b1-38040a0f5716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6753b6-3c7d-447b-b76c-dd1ae5da8fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6753b6-3c7d-447b-b76c-dd1ae5da8fbc.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -26554,7 +26554,7 @@
         },
         {
             "id": "118538d9-a080-57a1-88ea-99ace54271c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73c605b-7173-419f-843d-566ad9cc85ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73c605b-7173-419f-843d-566ad9cc85ef.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -26593,7 +26593,7 @@
         },
         {
             "id": "b59da021-3271-5a88-944a-e830ebc84fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a5ecf-74e5-4c70-99e1-c06ffeb71c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a5ecf-74e5-4c70-99e1-c06ffeb71c19.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -26628,7 +26628,7 @@
         },
         {
             "id": "b8aa4a76-dacb-51c5-b85c-ab860e112d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d44c31-b19b-45f2-a8c0-d0cc9276f9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d44c31-b19b-45f2-a8c0-d0cc9276f9b3.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -26663,7 +26663,7 @@
         },
         {
             "id": "90a7cbd2-f325-5c93-a840-977c845c4b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef18b36-7dad-4861-84bd-d6de7e192a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef18b36-7dad-4861-84bd-d6de7e192a7a.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -26700,7 +26700,7 @@
         },
         {
             "id": "92cd319b-1a4e-5eb0-9640-8df48cc9bd7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fc939e-bc5f-4150-8b4d-bb3e92ecde5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fc939e-bc5f-4150-8b4d-bb3e92ecde5e.jpg?1",
             "name": "The Flux",
             "text": "",
             "colours": [
@@ -26735,7 +26735,7 @@
         },
         {
             "id": "c789c13e-b615-507a-bb79-0be213d11af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4cde0cf-e422-4b51-9a5e-6324079974cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4cde0cf-e422-4b51-9a5e-6324079974cb.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -26770,7 +26770,7 @@
         },
         {
             "id": "1636c235-9220-51eb-9232-d6a7875c7663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703dcd8a-a4a6-47c8-bb05-f336ff92b6ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703dcd8a-a4a6-47c8-bb05-f336ff92b6ca.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -26805,7 +26805,7 @@
         },
         {
             "id": "4444174b-51ea-53fc-8a48-3043ef8c0631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10053fd4-b38a-49d0-aa3a-3ee3367102e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10053fd4-b38a-49d0-aa3a-3ee3367102e2.jpg?1",
             "name": "Iraxxa, Empress of Mars",
             "text": "",
             "colours": [
@@ -26843,7 +26843,7 @@
         },
         {
             "id": "24fa27de-5f37-5b68-ab4d-1b868f33fb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f405f-a6f4-4a94-abd3-4a3bdfdaaeb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f405f-a6f4-4a94-abd3-4a3bdfdaaeb0.jpg?1",
             "name": "Memory Worm",
             "text": "",
             "colours": [
@@ -26879,7 +26879,7 @@
         },
         {
             "id": "be025435-a7d3-5751-96fb-221c1635bd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6892f67c-055e-490a-9c77-894f44c3762f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6892f67c-055e-490a-9c77-894f44c3762f.jpg?1",
             "name": "The Parting of the Ways",
             "text": "",
             "colours": [
@@ -26914,7 +26914,7 @@
         },
         {
             "id": "eb51cae4-9025-5353-991c-364f3f7e039c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec322d-f229-489f-8982-5be22ac4e020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec322d-f229-489f-8982-5be22ac4e020.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -26949,7 +26949,7 @@
         },
         {
             "id": "0263cfd7-74a5-5af2-8b9d-5d49c6f5400d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758982ce-9283-465f-ba10-e1a3d5f5c1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758982ce-9283-465f-ba10-e1a3d5f5c1c3.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -26988,7 +26988,7 @@
         },
         {
             "id": "ea9cc9b6-e13f-50db-bd58-1e619a836da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c8271-f814-4d00-b719-984120dd18b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c8271-f814-4d00-b719-984120dd18b5.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -27027,7 +27027,7 @@
         },
         {
             "id": "e7919782-60cc-53e8-bae4-e8c38e63734b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a217b61-e2ec-4852-ae4e-f4c40dcc2851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a217b61-e2ec-4852-ae4e-f4c40dcc2851.jpg?1",
             "name": "Sibylline Soothsayer",
             "text": "",
             "colours": [
@@ -27063,7 +27063,7 @@
         },
         {
             "id": "0e3d1995-b8ca-57c7-bee9-b1674e0ba40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010e983d-e84c-4fb1-82c1-fab0885934f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010e983d-e84c-4fb1-82c1-fab0885934f7.jpg?1",
             "name": "Sontaran General",
             "text": "",
             "colours": [
@@ -27099,7 +27099,7 @@
         },
         {
             "id": "8bf81549-0111-54e8-9bde-78ba7ab03f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48636d77-a335-4c46-9019-d8b84462b645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48636d77-a335-4c46-9019-d8b84462b645.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -27136,7 +27136,7 @@
         },
         {
             "id": "e54d02a3-5115-5884-b1a4-25d04ead9b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af646ff7-b3ee-4e95-9fce-7d48d4987e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af646ff7-b3ee-4e95-9fce-7d48d4987e4e.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -27176,7 +27176,7 @@
         },
         {
             "id": "6c6f0b59-3fdd-5f2c-82ed-6d4bf6db8b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02242155-5612-4be7-b4db-c94f3ff34383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02242155-5612-4be7-b4db-c94f3ff34383.jpg?1",
             "name": "City of Death",
             "text": "",
             "colours": [
@@ -27211,7 +27211,7 @@
         },
         {
             "id": "d3d3c07e-7b62-5742-8153-4f892384cd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f46c447-23e6-4d6d-88d0-f5322734bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f46c447-23e6-4d6d-88d0-f5322734bc82.jpg?1",
             "name": "Displaced Dinosaurs",
             "text": "",
             "colours": [
@@ -27246,7 +27246,7 @@
         },
         {
             "id": "093c3129-ad19-52fb-b2a2-64cf00cf8621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18385ef8-2af8-47bc-8863-046dc5b4e8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18385ef8-2af8-47bc-8863-046dc5b4e8df.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -27281,7 +27281,7 @@
         },
         {
             "id": "4e1a869e-657e-59ee-b8ef-388adee47d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923ce269-f8a6-4d4b-adbf-463241a001b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923ce269-f8a6-4d4b-adbf-463241a001b0.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -27320,7 +27320,7 @@
         },
         {
             "id": "1ca114e6-17c8-5aa5-8323-68c4b25c7823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836ff17-553c-4545-a132-2e2d6eeeb66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836ff17-553c-4545-a132-2e2d6eeeb66e.jpg?1",
             "name": "Fugitive of the Judoon",
             "text": "",
             "colours": [
@@ -27355,7 +27355,7 @@
         },
         {
             "id": "6facfd27-7058-5533-9f86-0684f9598b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3a420-bfbf-4197-8dcb-d7af5784dd8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3a420-bfbf-4197-8dcb-d7af5784dd8e.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -27395,7 +27395,7 @@
         },
         {
             "id": "e2bdfa2c-a49a-5a0d-a488-d6f3437223ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098150bc-a865-48d0-95c2-39c2bee9bbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098150bc-a865-48d0-95c2-39c2bee9bbb4.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -27435,7 +27435,7 @@
         },
         {
             "id": "99968926-9f09-5c58-8951-1e00ca13a209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -27474,7 +27474,7 @@
         },
         {
             "id": "e42a5190-a109-52d6-9270-33beef0be9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -27509,7 +27509,7 @@
         },
         {
             "id": "b3e23464-fc86-55ca-9271-901f5973fbdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a43e73f-2d9e-41f3-89bc-fd9991753955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a43e73f-2d9e-41f3-89bc-fd9991753955.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -27549,7 +27549,7 @@
         },
         {
             "id": "b9c7392c-e716-550c-ba33-c5326c4c89a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdb8d0d-cdae-4a4d-a6fc-6a8fafb3e892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdb8d0d-cdae-4a4d-a6fc-6a8fafb3e892.jpg?1",
             "name": "The Sea Devils",
             "text": "",
             "colours": [
@@ -27584,7 +27584,7 @@
         },
         {
             "id": "03fb3375-a82e-5d25-af26-657bce84ff6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d537988-13ab-4b36-8bbd-0d7abf796f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d537988-13ab-4b36-8bbd-0d7abf796f26.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -27621,7 +27621,7 @@
         },
         {
             "id": "ea30b6c1-408f-5b95-9d76-6f69335ed7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181c4373-5576-4acd-9c56-26df29e7d021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181c4373-5576-4acd-9c56-26df29e7d021.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -27660,7 +27660,7 @@
         },
         {
             "id": "ac7383de-68b0-5c23-9161-2eb4336b4832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c0c32-f770-4012-ae3e-33b1808b3dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c0c32-f770-4012-ae3e-33b1808b3dc4.jpg?1",
             "name": "Thijarian Witness",
             "text": "",
             "colours": [
@@ -27696,7 +27696,7 @@
         },
         {
             "id": "2670ba2f-1d46-5943-a7bf-92aee870a58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a202892-3bbc-454f-83c6-51451c8e6215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a202892-3bbc-454f-83c6-51451c8e6215.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -27740,7 +27740,7 @@
         },
         {
             "id": "3e80d212-d64a-5684-bafd-2d446e5559fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d0f5ba-babd-4e05-89bf-acda8570a876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d0f5ba-babd-4e05-89bf-acda8570a876.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -27784,7 +27784,7 @@
         },
         {
             "id": "eb4e4888-57f2-50fd-8aea-d7c151ead975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa958e1-c3f4-41a2-8c32-92f8b36bd108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa958e1-c3f4-41a2-8c32-92f8b36bd108.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -27825,7 +27825,7 @@
         },
         {
             "id": "361b2fcc-e3f3-595d-8d18-fce978f3ffb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb9935-ecbc-4bbd-af56-05de3652973f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb9935-ecbc-4bbd-af56-05de3652973f.jpg?1",
             "name": "Bigger on the Inside",
             "text": "",
             "colours": [
@@ -27862,7 +27862,7 @@
         },
         {
             "id": "24fd08ea-f07a-5fa4-bea9-8bd5c56582b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73a2404-9400-4628-a799-23b48026f27d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73a2404-9400-4628-a799-23b48026f27d.jpg?1",
             "name": "Blink",
             "text": "",
             "colours": [
@@ -27899,7 +27899,7 @@
         },
         {
             "id": "75384a8f-8b46-543e-b632-c0216b618d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d0f99-ecc8-41ad-8cd5-d52da07c41a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d0f99-ecc8-41ad-8cd5-d52da07c41a4.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -27943,7 +27943,7 @@
         },
         {
             "id": "eff6a0e0-a6a3-5128-85bd-96216c6d8804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8129a46-ba17-454c-801f-81eb07d61bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8129a46-ba17-454c-801f-81eb07d61bdf.jpg?1",
             "name": "The Curse of Fenric",
             "text": "",
             "colours": [
@@ -27980,7 +27980,7 @@
         },
         {
             "id": "8d9610e1-f552-578e-8791-d6deda22e086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e965848-fadb-4522-95f1-5e330a72e871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e965848-fadb-4522-95f1-5e330a72e871.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -28022,7 +28022,7 @@
         },
         {
             "id": "dd9b73f2-c932-554e-adab-0e796df85dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18bf54-88b0-46a4-a2c7-fded41e524cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18bf54-88b0-46a4-a2c7-fded41e524cb.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -28064,7 +28064,7 @@
         },
         {
             "id": "950f63e9-e786-58ac-ada3-7ae7f1c78512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf289cf8-c792-4198-9310-02a7a02c248f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf289cf8-c792-4198-9310-02a7a02c248f.jpg?1",
             "name": "The Day of the Doctor",
             "text": "",
             "colours": [
@@ -28101,7 +28101,7 @@
         },
         {
             "id": "a743437c-789a-5d33-9f2a-982c04202ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab556a2-eed3-4b75-af34-ad1ee147558e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab556a2-eed3-4b75-af34-ad1ee147558e.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -28140,7 +28140,7 @@
         },
         {
             "id": "d3add04c-610f-5eee-ba60-d9a0fa8af6f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d669c14-a549-4d17-bd1a-ddd5e9a1a4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d669c14-a549-4d17-bd1a-ddd5e9a1a4c6.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -28182,7 +28182,7 @@
         },
         {
             "id": "ae63afa9-34d5-5b78-9388-b10ecd630daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99bf3d7-732c-4e1b-972a-efd49d2b3725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99bf3d7-732c-4e1b-972a-efd49d2b3725.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -28227,7 +28227,7 @@
         },
         {
             "id": "70cad508-b4a6-54c9-9240-4ec450592570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb88d0-d1a0-48e5-8e7a-c0fd0b7ef691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb88d0-d1a0-48e5-8e7a-c0fd0b7ef691.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -28272,7 +28272,7 @@
         },
         {
             "id": "e000482f-1eff-571c-a12d-08ad42a0f687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7194b-36dd-418b-948f-09669f3b2479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7194b-36dd-418b-948f-09669f3b2479.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -28316,7 +28316,7 @@
         },
         {
             "id": "526c0c84-0f3a-581f-914a-0e6f1aec18eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a20c3-b2cf-489b-8cfd-65ae3f935a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a20c3-b2cf-489b-8cfd-65ae3f935a78.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -28361,7 +28361,7 @@
         },
         {
             "id": "f6e8c4f3-ebac-509d-9397-bd90afa2d1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0af9cc9-ee39-4b0c-a7b0-c067cdd60f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0af9cc9-ee39-4b0c-a7b0-c067cdd60f30.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -28406,7 +28406,7 @@
         },
         {
             "id": "b351ede1-7884-50cb-82c6-07a4b69a5503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cd33c6-e593-4606-9e03-ae4c17073f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cd33c6-e593-4606-9e03-ae4c17073f30.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -28445,7 +28445,7 @@
         },
         {
             "id": "90966d74-d4cd-53b8-a191-f77cf96aaa4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8ed973-a94d-46b1-8584-12d553d170e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8ed973-a94d-46b1-8584-12d553d170e6.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -28489,7 +28489,7 @@
         },
         {
             "id": "51577b19-b686-55a5-ba74-51d55447bc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -28523,7 +28523,7 @@
         },
         {
             "id": "a9705d33-3e85-5a6a-81f2-82c17b87adb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -28557,7 +28557,7 @@
         },
         {
             "id": "2935af5a-6f2d-586e-a493-38e7874e8194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eab11a2-9df7-42e9-a762-e5003f7927e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eab11a2-9df7-42e9-a762-e5003f7927e4.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -28596,7 +28596,7 @@
         },
         {
             "id": "1186f779-afef-5996-838a-c07eb988ff83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280c4d2c-6832-4ba5-958a-0527ba3cbc71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280c4d2c-6832-4ba5-958a-0527ba3cbc71.jpg?1",
             "name": "Great Intelligence's Plan",
             "text": "",
             "colours": [
@@ -28631,7 +28631,7 @@
         },
         {
             "id": "c908fa25-797e-5c48-8272-5696a8524f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47239168-df82-4b54-8400-7a4b6e9cc40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47239168-df82-4b54-8400-7a4b6e9cc40f.jpg?1",
             "name": "Heaven Sent",
             "text": "",
             "colours": [
@@ -28668,7 +28668,7 @@
         },
         {
             "id": "b310671a-8310-5d46-a728-4981c26a7799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3cbf0d-c0ed-44ab-afe0-3d51635e2073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3cbf0d-c0ed-44ab-afe0-3d51635e2073.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -28710,7 +28710,7 @@
         },
         {
             "id": "7a232529-d600-5be1-8c5c-b3b88c985b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e792d96-bba9-4fa2-a57e-3ba9485e238f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e792d96-bba9-4fa2-a57e-3ba9485e238f.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -28752,7 +28752,7 @@
         },
         {
             "id": "edc3a456-9244-54db-9059-f34ecb4b739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41604c3f-9568-4bb4-813b-80d8f2be7530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41604c3f-9568-4bb4-813b-80d8f2be7530.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -28794,7 +28794,7 @@
         },
         {
             "id": "34681833-149e-5ea8-9148-6960f86d28d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d08f5f4-db1a-4d59-abe5-5a509fbfa32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d08f5f4-db1a-4d59-abe5-5a509fbfa32c.jpg?1",
             "name": "Judoon Enforcers",
             "text": "",
             "colours": [
@@ -28833,7 +28833,7 @@
         },
         {
             "id": "b18ff8e0-7891-5e59-af73-eef8b56374ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab585eec-db82-4d4e-a4a1-d8d21e5a9146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab585eec-db82-4d4e-a4a1-d8d21e5a9146.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -28877,7 +28877,7 @@
         },
         {
             "id": "545fb8a3-f477-5be8-8789-d1fc6ce1e492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fbaf77-8afa-41c7-804b-ba7b740fffe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fbaf77-8afa-41c7-804b-ba7b740fffe8.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -28914,7 +28914,7 @@
         },
         {
             "id": "cb53e262-6617-50ae-936e-c6b1420f3288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12481875-102f-414c-9c28-9e2e7e5edb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12481875-102f-414c-9c28-9e2e7e5edb28.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -28954,7 +28954,7 @@
         },
         {
             "id": "bea5833b-193b-59c2-87c8-f49d7f716656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf3fc0-c6da-4662-94b1-ac114e0d5123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf3fc0-c6da-4662-94b1-ac114e0d5123.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -28996,7 +28996,7 @@
         },
         {
             "id": "009c238b-e596-5caf-8f52-c70e8aca6535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a24e966-df2c-467b-a62d-243782eb37ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a24e966-df2c-467b-a62d-243782eb37ca.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -29040,7 +29040,7 @@
         },
         {
             "id": "52b6c2c9-36e4-57fc-a153-342fba647fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc8cc351-831f-47c0-ad1f-f8ca031204de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc8cc351-831f-47c0-ad1f-f8ca031204de.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -29084,7 +29084,7 @@
         },
         {
             "id": "b0c4fcd2-4183-5c57-a543-7c7afc4306dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830ce411-9f63-4aa3-8846-df48520e35e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830ce411-9f63-4aa3-8846-df48520e35e2.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -29128,7 +29128,7 @@
         },
         {
             "id": "2ba90430-8767-5c8e-9600-294bbc6698e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69741c34-d433-4c0b-8c21-a9e122758070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69741c34-d433-4c0b-8c21-a9e122758070.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -29172,7 +29172,7 @@
         },
         {
             "id": "b390f93f-e046-514b-b47e-c06a50f6ee4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aee3c03-9d03-4088-8557-6bf5dcb7acc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aee3c03-9d03-4088-8557-6bf5dcb7acc4.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -29216,7 +29216,7 @@
         },
         {
             "id": "534829f2-2760-52bf-85a6-48f67858e990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717bfcc5-32f8-4944-8aa1-a2cd178354ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717bfcc5-32f8-4944-8aa1-a2cd178354ec.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -29261,7 +29261,7 @@
         },
         {
             "id": "695cdceb-e904-550a-ab9e-26aab1ddc2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f85a38e-eb8c-4af3-bd74-758b1c46ff92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f85a38e-eb8c-4af3-bd74-758b1c46ff92.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -29305,7 +29305,7 @@
         },
         {
             "id": "7ac2bb6b-5551-5716-8a28-baa3e000dd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46782d62-52d2-414d-a55e-c48bc2ae93c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46782d62-52d2-414d-a55e-c48bc2ae93c4.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -29347,7 +29347,7 @@
         },
         {
             "id": "1b73cd5e-0bd9-5ada-9b0f-869ae47e928f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d38ec3-5028-42ac-97c3-af2aa04314ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d38ec3-5028-42ac-97c3-af2aa04314ae.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -29384,7 +29384,7 @@
         },
         {
             "id": "5809fb11-9f6b-5d14-8153-3b3d0dea5eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841e20fb-8607-481d-b690-c70a0e0f2daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841e20fb-8607-481d-b690-c70a0e0f2daa.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -29429,7 +29429,7 @@
         },
         {
             "id": "ce050c5d-1e7b-5f84-8a46-4fca188de099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7bb09-7c22-4d39-9aab-b0016ee2d5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7bb09-7c22-4d39-9aab-b0016ee2d5ab.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -29471,7 +29471,7 @@
         },
         {
             "id": "526170ed-7a63-5341-968a-3f21a0dcc00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e479d60-0da2-48b8-b7e3-16505506004a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e479d60-0da2-48b8-b7e3-16505506004a.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -29508,7 +29508,7 @@
         },
         {
             "id": "2425a276-ad7d-5986-aab1-4009356ce375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e085b17-e3a8-49eb-adff-6c748ca5a611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e085b17-e3a8-49eb-adff-6c748ca5a611.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -29550,7 +29550,7 @@
         },
         {
             "id": "16d8447e-95e7-5efa-8658-d9fc9c84b2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052b234-d8e5-4da9-8c68-77e76ece2285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052b234-d8e5-4da9-8c68-77e76ece2285.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -29595,7 +29595,7 @@
         },
         {
             "id": "b7a9222f-7390-583b-90c4-5d3709ab49e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db451876-fa9d-4cfd-9105-c6ceb562fa4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db451876-fa9d-4cfd-9105-c6ceb562fa4d.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -29637,7 +29637,7 @@
         },
         {
             "id": "e8942658-62b9-5c5e-8a0e-d3f089a0643e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce1351f-3643-4d7e-99a8-9c1a31abe970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce1351f-3643-4d7e-99a8-9c1a31abe970.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -29682,7 +29682,7 @@
         },
         {
             "id": "2526171a-9f2d-5f4b-bbcd-9133c341f09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947207ae-24a1-4c85-a5fc-d650a5deafe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947207ae-24a1-4c85-a5fc-d650a5deafe0.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -29727,7 +29727,7 @@
         },
         {
             "id": "8c816aee-db03-5ee5-b4c2-bf7f67d3c4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5aabb06-d4e5-40b5-84a8-4f74d4763567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5aabb06-d4e5-40b5-84a8-4f74d4763567.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -29769,7 +29769,7 @@
         },
         {
             "id": "fce87a06-ff62-5638-91fc-c5719318786f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c12a66b-3a89-49a5-8a2f-7d260f4d68d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c12a66b-3a89-49a5-8a2f-7d260f4d68d4.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -29809,7 +29809,7 @@
         },
         {
             "id": "12b33414-e37d-5eff-823c-9d10946ef103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769fa42b-65ad-4231-863e-1c7923726975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769fa42b-65ad-4231-863e-1c7923726975.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -29854,7 +29854,7 @@
         },
         {
             "id": "51b3b435-a5f8-51fb-9356-78f846d37af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec190b44-7761-4eb1-8b24-8142c25add4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec190b44-7761-4eb1-8b24-8142c25add4b.jpg?1",
             "name": "Truth or Consequences",
             "text": "",
             "colours": [
@@ -29889,7 +29889,7 @@
         },
         {
             "id": "8e97f9d1-ef3a-5f91-9be0-9c37a29c43db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ae7218-e99f-49ef-87be-2462101a1c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ae7218-e99f-49ef-87be-2462101a1c31.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -29934,7 +29934,7 @@
         },
         {
             "id": "51a671fa-9106-5a39-a7b2-6069ec0d5478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4bf74-1ca1-48ea-9f82-511c3c2eb04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4bf74-1ca1-48ea-9f82-511c3c2eb04a.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -29978,7 +29978,7 @@
         },
         {
             "id": "472e530e-5796-5ad1-806c-6c088fa2c30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce4479c-157e-4821-bdf3-053a9f483d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce4479c-157e-4821-bdf3-053a9f483d9e.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -30021,7 +30021,7 @@
         },
         {
             "id": "b5aface2-1ce0-5a0d-b9e2-d2b47927b11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178d195b-fa8b-429a-b4b3-86d2a2be24b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178d195b-fa8b-429a-b4b3-86d2a2be24b9.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -30065,7 +30065,7 @@
         },
         {
             "id": "c98bca32-1e92-520d-8011-72a8fdffcea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20e4595-ebf0-475f-937c-b78d8beb1e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20e4595-ebf0-475f-937c-b78d8beb1e01.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -30108,7 +30108,7 @@
         },
         {
             "id": "f4aab596-2db9-5c63-96c3-ba0e2adde39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bbe175-5b19-4c7e-b5bc-85fe25b63004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bbe175-5b19-4c7e-b5bc-85fe25b63004.jpg?1",
             "name": "Wreck and Rebuild",
             "text": "",
             "colours": [
@@ -30143,7 +30143,7 @@
         },
         {
             "id": "9d4801a6-ca6a-583c-bfe1-e3aaaa4909e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aa1467-f359-4b69-bbe8-6d59a87378b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aa1467-f359-4b69-bbe8-6d59a87378b8.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -30178,7 +30178,7 @@
         },
         {
             "id": "b8912a59-8185-5e53-a5ef-d8539a43beae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000a902-9f18-4823-9d85-d1d12d03ad4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000a902-9f18-4823-9d85-d1d12d03ad4a.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -30213,7 +30213,7 @@
         },
         {
             "id": "e3af39e9-5ee1-554a-86d9-418c7a7b0b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe714c2-5358-4ba8-b990-5bb5f5757a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe714c2-5358-4ba8-b990-5bb5f5757a57.jpg?1",
             "name": "Clockwork Droid",
             "text": "",
             "colours": [],
@@ -30245,7 +30245,7 @@
         },
         {
             "id": "d4f90445-8401-570e-9abb-93a8c115486a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64077b-2c50-4511-8424-684c97c2a3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64077b-2c50-4511-8424-684c97c2a3f9.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -30276,7 +30276,7 @@
         },
         {
             "id": "9e2ff142-4988-5a98-a7fd-42a91492943a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe32187-ce41-48b8-9bb9-ddca2ca0bab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe32187-ce41-48b8-9bb9-ddca2ca0bab6.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -30310,7 +30310,7 @@
         },
         {
             "id": "90c8e4bc-4a81-5c1b-bbaa-fb0369f86c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04debb05-5303-4b0a-8224-d00f3512639e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04debb05-5303-4b0a-8224-d00f3512639e.jpg?1",
             "name": "Cybermat",
             "text": "",
             "colours": [],
@@ -30342,7 +30342,7 @@
         },
         {
             "id": "ce38ee77-809a-55b2-bf23-f774fda0bed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf58737-3e09-4c09-85d8-bdf2364db30c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf58737-3e09-4c09-85d8-bdf2364db30c.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -30376,7 +30376,7 @@
         },
         {
             "id": "3e4589ad-c71a-53a8-86a0-af373d978e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41185e7-d6e2-49a9-aac8-597e5aab197a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41185e7-d6e2-49a9-aac8-597e5aab197a.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -30409,7 +30409,7 @@
         },
         {
             "id": "395b6143-b981-5213-91c8-64114254d2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431a6798-2a82-44b8-bd2e-3e3a425d3473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431a6798-2a82-44b8-bd2e-3e3a425d3473.jpg?1",
             "name": "Laser Screwdriver",
             "text": "",
             "colours": [],
@@ -30438,7 +30438,7 @@
         },
         {
             "id": "3a28d68a-d0eb-5a15-91cb-e1638f1e9970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13c9eac-7b53-4b90-94b9-890fa8c522dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13c9eac-7b53-4b90-94b9-890fa8c522dc.jpg?1",
             "name": "Midnight Crusader Shuttle",
             "text": "",
             "colours": [],
@@ -30469,7 +30469,7 @@
         },
         {
             "id": "2a21aaf0-c818-5101-8889-c1f418475740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7209964-432a-4318-b9f3-c341bda7256c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7209964-432a-4318-b9f3-c341bda7256c.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -30502,7 +30502,7 @@
         },
         {
             "id": "1d93a02d-1bc5-55d8-a5b6-ac1b438deb5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0aea96-932a-498b-8520-e9b88c788e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0aea96-932a-498b-8520-e9b88c788e3a.jpg?1",
             "name": "Psychic Paper",
             "text": "",
             "colours": [],
@@ -30533,7 +30533,7 @@
         },
         {
             "id": "36ed2049-af0f-521b-a062-bb25d97d4be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98833afa-fc8a-4c1b-b670-b772bde076bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98833afa-fc8a-4c1b-b670-b772bde076bb.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -30564,7 +30564,7 @@
         },
         {
             "id": "3414b895-39d6-5f9f-a1fe-ffd3159a76bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151084cd-49cb-4361-85c1-f0485f3f52dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151084cd-49cb-4361-85c1-f0485f3f52dd.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -30595,7 +30595,7 @@
         },
         {
             "id": "2d15bad9-e73d-5ada-9160-4be6ad69846a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81fb890-3165-43fe-b2c8-876c8fb0431b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81fb890-3165-43fe-b2c8-876c8fb0431b.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30628,7 +30628,7 @@
         },
         {
             "id": "2ca3bc12-f9c7-5a62-8fa2-c17d1de4e240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64912428-5156-4167-b890-a30e2e594a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64912428-5156-4167-b890-a30e2e594a35.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30661,7 +30661,7 @@
         },
         {
             "id": "98cf9b51-3fca-5c20-89a2-b0aef23f0617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0476000-798e-4a19-a241-bb1e43a7b5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0476000-798e-4a19-a241-bb1e43a7b5fe.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30694,7 +30694,7 @@
         },
         {
             "id": "b0ecaec4-0c26-5ac8-9a97-ed5008ef18c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69ef4-a95b-48c8-9720-18e2d862e926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69ef4-a95b-48c8-9720-18e2d862e926.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -30727,7 +30727,7 @@
         },
         {
             "id": "c52a4ad0-ce68-5652-b646-d8865b064a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a316539-e2eb-4321-a73c-075dafb01cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a316539-e2eb-4321-a73c-075dafb01cc9.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -30760,7 +30760,7 @@
         },
         {
             "id": "892bdc76-0a7c-5369-b865-ba9a7112603d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742df7f-cf92-4749-8c33-d88e5987b4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742df7f-cf92-4749-8c33-d88e5987b4c6.jpg?1",
             "name": "Ominous Cemetery",
             "text": "",
             "colours": [],
@@ -30789,7 +30789,7 @@
         },
         {
             "id": "424e6e78-b458-5b70-83b1-a83aa87cbcb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0b3429-e42f-4eb7-acd5-8fddf100f0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0b3429-e42f-4eb7-acd5-8fddf100f0c4.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -30824,7 +30824,7 @@
         },
         {
             "id": "db550dba-6c16-5574-a9d4-f940d240dace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf098980-26e4-4df1-bca3-439b405c3ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf098980-26e4-4df1-bca3-439b405c3ae7.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -30865,7 +30865,7 @@
         },
         {
             "id": "7e4c698c-f756-5060-bc07-6f1c94e26c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de768e49-acd0-4575-8800-db15c71dc719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de768e49-acd0-4575-8800-db15c71dc719.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -30902,7 +30902,7 @@
         },
         {
             "id": "10dec3d1-e766-5830-a519-1b5c69672c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b2f41-4ee6-4eb7-a01f-155a3752d150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b2f41-4ee6-4eb7-a01f-155a3752d150.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -30937,7 +30937,7 @@
         },
         {
             "id": "6626e117-3f73-5711-8629-2199c4cd81d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad46a46-4221-4e0e-8b46-49f517c231c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad46a46-4221-4e0e-8b46-49f517c231c1.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -30972,7 +30972,7 @@
         },
         {
             "id": "77db5f6a-2361-5657-8de7-c15a7a8bd109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bc66ca-5909-49cf-bf5b-1dd6c209c03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bc66ca-5909-49cf-bf5b-1dd6c209c03b.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -31007,7 +31007,7 @@
         },
         {
             "id": "62cabb9e-2c00-5432-ac74-c9cd5cdba4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6f35c8-d25c-4d06-b80c-c2e2744cdaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6f35c8-d25c-4d06-b80c-c2e2744cdaec.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -31040,7 +31040,7 @@
         },
         {
             "id": "cb6a2e4b-de36-5d19-9a25-196fb91bf933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a1bb38-5cb4-4188-995d-8ee73071abee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a1bb38-5cb4-4188-995d-8ee73071abee.jpg?1",
             "name": "Return to Dust",
             "text": "",
             "colours": [
@@ -31073,7 +31073,7 @@
         },
         {
             "id": "b117cc2b-9096-5e1f-a1f0-3a2c42c243af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d09581-e8da-4169-82d1-14389b53c375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d09581-e8da-4169-82d1-14389b53c375.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -31106,7 +31106,7 @@
         },
         {
             "id": "ecc866ed-0e78-5933-9764-4ebf8fb04262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79d396b-cd84-4088-8996-d33b19841286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79d396b-cd84-4088-8996-d33b19841286.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -31141,7 +31141,7 @@
         },
         {
             "id": "c5cc39d1-afbf-5ae6-86d8-298c8c4cf316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2833c9d0-ed79-4413-922d-41be9f522a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2833c9d0-ed79-4413-922d-41be9f522a49.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -31176,7 +31176,7 @@
         },
         {
             "id": "68e1ec40-2db5-5d84-858f-45525b20bf9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7939bd65-b5b2-4a11-90f2-234a146280ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7939bd65-b5b2-4a11-90f2-234a146280ff.jpg?1",
             "name": "Clockspinning",
             "text": "",
             "colours": [
@@ -31209,7 +31209,7 @@
         },
         {
             "id": "157cfa18-74b9-50be-9892-206a325a5459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed2c7dc-0727-4b38-9623-14f943f93feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed2c7dc-0727-4b38-9623-14f943f93feb.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -31244,7 +31244,7 @@
         },
         {
             "id": "fdea3a25-63aa-58b4-ad7c-baddd72b6d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d4ee7-d188-47e0-b1be-8add6e229356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d4ee7-d188-47e0-b1be-8add6e229356.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -31277,7 +31277,7 @@
         },
         {
             "id": "4e9d5e10-a85c-54ce-bf63-a7a2cb2204bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f076fa76-5aef-4fa6-894c-f57e1926177a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f076fa76-5aef-4fa6-894c-f57e1926177a.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -31310,7 +31310,7 @@
         },
         {
             "id": "65f51606-0d40-5100-985d-9fc992fbe80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3308ce8-df83-4f8e-b493-39f95b2d0237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3308ce8-df83-4f8e-b493-39f95b2d0237.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -31343,7 +31343,7 @@
         },
         {
             "id": "7728af0b-f119-535b-a71a-a6d6fe0599e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b90a2cc-a87d-4024-bc31-66ef00e04a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b90a2cc-a87d-4024-bc31-66ef00e04a90.jpg?1",
             "name": "Think Twice",
             "text": "",
             "colours": [
@@ -31376,7 +31376,7 @@
         },
         {
             "id": "25e0f6f8-a37c-5586-88e9-e806599c530c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0ce1dd-befa-428b-b7e9-2c71e328f8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0ce1dd-befa-428b-b7e9-2c71e328f8b1.jpg?1",
             "name": "Feed the Swarm",
             "text": "",
             "colours": [
@@ -31409,7 +31409,7 @@
         },
         {
             "id": "0145b249-f2b1-5d54-8b9d-867f205e9b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d70f4ea-49fb-46f0-b917-5607d944515c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d70f4ea-49fb-46f0-b917-5607d944515c.jpg?1",
             "name": "Snuff Out",
             "text": "",
             "colours": [
@@ -31442,7 +31442,7 @@
         },
         {
             "id": "9a2a0683-8300-52c6-9c46-43d499ea8d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758383e-e70f-477b-a70b-09b2d25a6a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758383e-e70f-477b-a70b-09b2d25a6a92.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -31477,7 +31477,7 @@
         },
         {
             "id": "82f768aa-584f-5d23-a7f4-5217339532cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14e29c-a4f6-4491-a318-bf0cff4ae91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14e29c-a4f6-4491-a318-bf0cff4ae91c.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -31512,7 +31512,7 @@
         },
         {
             "id": "9a49e1ca-c163-5dbb-af4a-ec8c93d639ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ca8c7c-6c67-4d8d-abd2-0b4135a7072e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ca8c7c-6c67-4d8d-abd2-0b4135a7072e.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -31547,7 +31547,7 @@
         },
         {
             "id": "6c48b689-2184-5a67-9a15-49595625adfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a325c-a0c2-4c9f-9162-063fc6071c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a325c-a0c2-4c9f-9162-063fc6071c22.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -31582,7 +31582,7 @@
         },
         {
             "id": "819e2511-e6a3-5d6e-9da3-8f34c08de2b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e05245-54bf-4162-82ca-bc436b45e55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e05245-54bf-4162-82ca-bc436b45e55b.jpg?1",
             "name": "Throes of Chaos",
             "text": "",
             "colours": [
@@ -31615,7 +31615,7 @@
         },
         {
             "id": "e1a57cc7-ab09-5e20-8fed-8e8a8d72dd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072db20-b134-47bd-9b5b-a19a131ee738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072db20-b134-47bd-9b5b-a19a131ee738.jpg?1",
             "name": "Beast Within",
             "text": "",
             "colours": [
@@ -31648,7 +31648,7 @@
         },
         {
             "id": "06049f0d-404e-5120-af45-59a5dd288523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e6f8f9-c17c-4f96-9283-a8a4d27b4746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e6f8f9-c17c-4f96-9283-a8a4d27b4746.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -31683,7 +31683,7 @@
         },
         {
             "id": "b4df6209-d09c-596d-bacb-c196fa844c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3889ea3-b7e0-446e-a8af-be284198a758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3889ea3-b7e0-446e-a8af-be284198a758.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -31716,7 +31716,7 @@
         },
         {
             "id": "662c5c2b-4d18-5849-a012-23bc540270ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f8f2a4-ddfb-48b5-9ecb-73cf03a65f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f8f2a4-ddfb-48b5-9ecb-73cf03a65f8d.jpg?1",
             "name": "Explore",
             "text": "",
             "colours": [
@@ -31749,7 +31749,7 @@
         },
         {
             "id": "e3111845-03e8-5d76-8699-170a6e9ec16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df75b100-b02c-41de-9292-798750e7c89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df75b100-b02c-41de-9292-798750e7c89f.jpg?1",
             "name": "Farseek",
             "text": "",
             "colours": [
@@ -31782,7 +31782,7 @@
         },
         {
             "id": "6abf4d32-e920-567f-a54f-6eb34a6aa649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3c402f-3133-40f2-bfda-613e2d936044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3c402f-3133-40f2-bfda-613e2d936044.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -31817,7 +31817,7 @@
         },
         {
             "id": "e69f745b-476d-5301-83ff-459d00c4f709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b145c299-311a-4a76-944e-7d8aabb6857c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b145c299-311a-4a76-944e-7d8aabb6857c.jpg?1",
             "name": "Search for Tomorrow",
             "text": "",
             "colours": [
@@ -31850,7 +31850,7 @@
         },
         {
             "id": "5d214df8-fdb8-5fb6-bd14-b3ba01cc822f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a515b75-0adf-4f33-a33a-2ddf524b14d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a515b75-0adf-4f33-a33a-2ddf524b14d9.jpg?1",
             "name": "Three Visits",
             "text": "",
             "colours": [
@@ -31883,7 +31883,7 @@
         },
         {
             "id": "d1c28bcc-b189-5298-9d25-4347eb889ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3373a8a7-69a3-4011-a3dc-4e7c252dcd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3373a8a7-69a3-4011-a3dc-4e7c252dcd92.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -31920,7 +31920,7 @@
         },
         {
             "id": "ac638550-1cf8-5428-b463-d6055cb3e844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db3b871-55fa-4a6a-8bae-b54ee642d039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db3b871-55fa-4a6a-8bae-b54ee642d039.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -31955,7 +31955,7 @@
         },
         {
             "id": "fee16a4a-ccba-548c-bbc9-83db79bbfe9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdde5ea-4a4f-4ca7-8326-92e83506518a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdde5ea-4a4f-4ca7-8326-92e83506518a.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -31992,7 +31992,7 @@
         },
         {
             "id": "cd7d2432-c6a6-500b-a4d9-c700df5f155d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc52210-9de3-4392-9a11-87a67f56b92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc52210-9de3-4392-9a11-87a67f56b92a.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -32021,7 +32021,7 @@
         },
         {
             "id": "050ea007-3100-51bf-9a8b-19de08cf1c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7b3575-4942-4ce3-a6de-87c9c4568927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7b3575-4942-4ce3-a6de-87c9c4568927.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -32050,7 +32050,7 @@
         },
         {
             "id": "85110529-9f73-547b-8790-350a0537378e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99c9918-b7fb-4366-b15f-4645ea45928b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99c9918-b7fb-4366-b15f-4645ea45928b.jpg?1",
             "name": "Hero's Blade",
             "text": "",
             "colours": [],
@@ -32081,7 +32081,7 @@
         },
         {
             "id": "34a3bb1f-4020-5038-8501-0df05cf9e21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc631ce-4b0d-49da-a5ad-6f419678abb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc631ce-4b0d-49da-a5ad-6f419678abb4.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -32114,7 +32114,7 @@
         },
         {
             "id": "4e6f8602-7d44-5191-b4a1-a582cd3cacb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49404d84-bcd2-4893-906f-13c8a3b0d25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49404d84-bcd2-4893-906f-13c8a3b0d25b.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -32145,7 +32145,7 @@
         },
         {
             "id": "984464b0-0e87-59d5-8d22-c07018140ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3817d9a-0e1c-4eed-9593-78d481d3001b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3817d9a-0e1c-4eed-9593-78d481d3001b.jpg?1",
             "name": "Mind Stone",
             "text": "",
             "colours": [],
@@ -32174,7 +32174,7 @@
         },
         {
             "id": "5806536c-179c-5e58-864d-c1190a7039be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8262-4636-4a2c-a0c8-de741cf45aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8262-4636-4a2c-a0c8-de741cf45aed.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -32203,7 +32203,7 @@
         },
         {
             "id": "bf446c5f-05f5-5644-8767-4534d68dc383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea91e4d-c355-49ae-82e0-6dbd387714c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea91e4d-c355-49ae-82e0-6dbd387714c3.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -32237,7 +32237,7 @@
         },
         {
             "id": "d4cf4001-f010-5b4c-ac2e-939b60fb0954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb81c294-f7cb-4351-96c5-d867c677ba15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb81c294-f7cb-4351-96c5-d867c677ba15.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -32269,7 +32269,7 @@
         },
         {
             "id": "5564510a-7281-5f76-b740-5bb297f1f299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43aa0a-d063-48af-b6d1-a89dbd803c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43aa0a-d063-48af-b6d1-a89dbd803c83.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -32301,7 +32301,7 @@
         },
         {
             "id": "33ad92bd-b638-51bc-b8e7-c48a7f2279b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fc32b4-d58d-4f9a-9af8-af145dd4c4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fc32b4-d58d-4f9a-9af8-af145dd4c4a8.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -32333,7 +32333,7 @@
         },
         {
             "id": "6017edec-bca1-5c8c-b341-6dc19e4569ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e195d8cd-8c26-460d-85fc-964931a89b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e195d8cd-8c26-460d-85fc-964931a89b0b.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -32365,7 +32365,7 @@
         },
         {
             "id": "831d3854-e604-5ebe-9282-84fdce7df47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6acffe-89ac-4426-8a7a-048d1f298362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6acffe-89ac-4426-8a7a-048d1f298362.jpg?1",
             "name": "Talisman of Impulse",
             "text": "",
             "colours": [],
@@ -32397,7 +32397,7 @@
         },
         {
             "id": "5bacfa30-0b59-5b4e-a59d-9acf91e49bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eee538-03b1-4faa-af73-5897b9f41a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eee538-03b1-4faa-af73-5897b9f41a5d.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -32429,7 +32429,7 @@
         },
         {
             "id": "eb8d8be8-6a4f-557a-885c-5375fb209de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a7fd9-0c09-4d61-8440-b9a82b71930a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a7fd9-0c09-4d61-8440-b9a82b71930a.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -32461,7 +32461,7 @@
         },
         {
             "id": "e13362f4-6a1e-5d1e-b16f-4c2d94bd060f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ecf6f5-b29a-4fd4-9fc4-e4947ff7c681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ecf6f5-b29a-4fd4-9fc4-e4947ff7c681.jpg?1",
             "name": "Talisman of Unity",
             "text": "",
             "colours": [],
@@ -32493,7 +32493,7 @@
         },
         {
             "id": "1c5c5647-3acb-5902-a5c5-054a43aaf880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf7e43-d0ba-4340-8d48-d775c7b36ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf7e43-d0ba-4340-8d48-d775c7b36ab3.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -32522,7 +32522,7 @@
         },
         {
             "id": "10a0eccb-6989-5d2b-8e18-915a4de8ff2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ba5e0-9e25-4b9c-a992-2e818d9377bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ba5e0-9e25-4b9c-a992-2e818d9377bd.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "",
             "colours": [],
@@ -32551,7 +32551,7 @@
         },
         {
             "id": "c80d1a36-f2ba-50b0-b467-6e068b1b49e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494938cf-03a9-403a-bfd6-25ad9647b2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494938cf-03a9-403a-bfd6-25ad9647b2e6.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -32580,7 +32580,7 @@
         },
         {
             "id": "190f95cb-24b4-5abc-a7ff-eb3552faaf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46f1b58-1948-47b0-94ba-18932691a4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46f1b58-1948-47b0-94ba-18932691a4b7.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -32617,7 +32617,7 @@
         },
         {
             "id": "b8396e38-f472-5dab-a3ee-1a482912d7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d87fff-92c9-45eb-aebb-ed522a3e9e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d87fff-92c9-45eb-aebb-ed522a3e9e0a.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -32654,7 +32654,7 @@
         },
         {
             "id": "a55b639f-9146-5099-9722-64b8fd2c63f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b8a70b-94cd-431e-a0ac-1c1c04181df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b8a70b-94cd-431e-a0ac-1c1c04181df1.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -32688,7 +32688,7 @@
         },
         {
             "id": "24047e9d-5cf8-5f3c-a68b-82ff270e68f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af9770-ecd5-47a1-9414-e6b53f959790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af9770-ecd5-47a1-9414-e6b53f959790.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -32722,7 +32722,7 @@
         },
         {
             "id": "0b5845dd-6604-5031-adf6-373c2c7fa415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb1bb0b-4533-4c11-a9ee-f80438d031ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb1bb0b-4533-4c11-a9ee-f80438d031ba.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -32759,7 +32759,7 @@
         },
         {
             "id": "2a60c795-b818-5ca6-9471-6316d5daaaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b81040-cbce-4833-bc13-89aa707dcda7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b81040-cbce-4833-bc13-89aa707dcda7.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32794,7 +32794,7 @@
         },
         {
             "id": "3d746924-163a-566b-ad6c-ce6747dbffa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a60c53-4ba2-48cf-8b5f-08b80dbb960c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a60c53-4ba2-48cf-8b5f-08b80dbb960c.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32829,7 +32829,7 @@
         },
         {
             "id": "14253164-b9e3-5069-9fa2-b2a76337f5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef33ca3-9f5d-4e4a-a416-1dd3d1272e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef33ca3-9f5d-4e4a-a416-1dd3d1272e35.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32864,7 +32864,7 @@
         },
         {
             "id": "33a3057d-67f9-5df6-87c7-90ad1d0acad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cc78a-7bb0-4fa2-a63a-f8526ec5472b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cc78a-7bb0-4fa2-a63a-f8526ec5472b.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32899,7 +32899,7 @@
         },
         {
             "id": "246de69d-1dae-5c22-b332-86fe18820123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2d6d-82ab-4e0a-8b0d-cc3c128b22b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2d6d-82ab-4e0a-8b0d-cc3c128b22b5.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -32933,7 +32933,7 @@
         },
         {
             "id": "b9aaadc5-7ad7-5b05-837e-c1753156c9d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda76016-58d1-4867-a55c-0f670ea4500b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda76016-58d1-4867-a55c-0f670ea4500b.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "",
             "colours": [],
@@ -32966,7 +32966,7 @@
         },
         {
             "id": "9ecacc1d-f494-57e4-abd8-fba1d9881b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6916a-d487-4998-9d1b-15d34f1a56bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6916a-d487-4998-9d1b-15d34f1a56bb.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -33000,7 +33000,7 @@
         },
         {
             "id": "91aab8db-ec58-5e02-9e86-47b7d3f403e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98967b8d-d2ee-4131-b614-44cc3e403917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98967b8d-d2ee-4131-b614-44cc3e403917.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -33034,7 +33034,7 @@
         },
         {
             "id": "f1e65d28-b8d3-5f0f-b5c2-2263954e39f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6680767-a84a-4a98-9075-596adfc5dc88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6680767-a84a-4a98-9075-596adfc5dc88.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -33068,7 +33068,7 @@
         },
         {
             "id": "bec7d13b-7344-5f86-ba7b-650b2615bd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4970a2-4f9d-46a1-a80d-c0764eed3023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4970a2-4f9d-46a1-a80d-c0764eed3023.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -33102,7 +33102,7 @@
         },
         {
             "id": "25a9310f-6b09-5b9d-8c03-5a1a947f6932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3279f8e-c508-428d-ab5e-f25d635d8444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3279f8e-c508-428d-ab5e-f25d635d8444.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -33136,7 +33136,7 @@
         },
         {
             "id": "68885dbb-c6bc-590d-9e9e-8db6b27e4432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5043715-8ad3-44cc-a694-400b67db269d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5043715-8ad3-44cc-a694-400b67db269d.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -33170,7 +33170,7 @@
         },
         {
             "id": "fd654771-7cac-545e-a8a5-0fe5f870d4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aa2331-4bd0-482d-8009-d5dd820f5725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aa2331-4bd0-482d-8009-d5dd820f5725.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -33199,7 +33199,7 @@
         },
         {
             "id": "b08321bb-d1dc-54c6-bd7d-ef53ade3f491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d78fb5e-35e9-4759-b783-bf13bae271fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d78fb5e-35e9-4759-b783-bf13bae271fa.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -33230,7 +33230,7 @@
         },
         {
             "id": "0316309c-49bd-5099-b6fc-5d020dca34ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f00c7f-8fe9-4570-886a-e43f6206efbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f00c7f-8fe9-4570-886a-e43f6206efbf.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -33267,7 +33267,7 @@
         },
         {
             "id": "dfbb5316-5cbe-5312-beb2-2c05b213f00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b51d3e-a870-4e96-9396-7d47ae4f2961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b51d3e-a870-4e96-9396-7d47ae4f2961.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -33301,7 +33301,7 @@
         },
         {
             "id": "c14b0ae4-9e78-5b76-9790-31fa31480cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecc8eb-6e28-49b6-b2db-6c9fadb084f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecc8eb-6e28-49b6-b2db-6c9fadb084f8.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -33335,7 +33335,7 @@
         },
         {
             "id": "451039b2-4476-5516-a3be-c3a5d5d0ce5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd50305e-3c7b-4ef5-a093-da7bbdbd6249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd50305e-3c7b-4ef5-a093-da7bbdbd6249.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -33369,7 +33369,7 @@
         },
         {
             "id": "3d5e1b82-1f9a-5760-a02b-b198b341bb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24442f-b01e-4af8-8039-49373ebc4016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24442f-b01e-4af8-8039-49373ebc4016.jpg?1",
             "name": "Frontier Bivouac",
             "text": "",
             "colours": [],
@@ -33402,7 +33402,7 @@
         },
         {
             "id": "e495d9da-4352-5efe-abdf-27e0d9d4abeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51446e-b198-4495-9cbc-296a8e7bf2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51446e-b198-4495-9cbc-296a8e7bf2fc.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -33436,7 +33436,7 @@
         },
         {
             "id": "68bc0a1b-762e-525e-b2be-92312aa988bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c091056b-25bd-4014-b19b-ceae26a293a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c091056b-25bd-4014-b19b-ceae26a293a8.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -33470,7 +33470,7 @@
         },
         {
             "id": "dcad56c0-1d03-52f2-9133-b17ba5f69075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10831dd5-d048-4751-94bb-560a1f03277d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10831dd5-d048-4751-94bb-560a1f03277d.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -33504,7 +33504,7 @@
         },
         {
             "id": "76bb3b6e-98b9-53c2-880d-280bae3630e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9759472-1f44-4c2b-9afb-8507f3168840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9759472-1f44-4c2b-9afb-8507f3168840.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -33538,7 +33538,7 @@
         },
         {
             "id": "b51e8c32-ae2a-585e-966d-892b8be8a664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298d6db-daf6-4aed-91f9-076debdf9533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298d6db-daf6-4aed-91f9-076debdf9533.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -33572,7 +33572,7 @@
         },
         {
             "id": "9114a647-9d45-5788-9d12-5c027b7ae875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb64334-a911-49c3-934a-7d77f4fb4f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb64334-a911-49c3-934a-7d77f4fb4f5b.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -33606,7 +33606,7 @@
         },
         {
             "id": "c62de117-4541-5943-8899-f2705290567d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873ea903-cbbc-48b8-8a67-fe612996deab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873ea903-cbbc-48b8-8a67-fe612996deab.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -33643,7 +33643,7 @@
         },
         {
             "id": "ae1f57f1-0895-57cf-bf18-20a6ca42b6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d94b75-22e5-4696-bfde-11777e2aee2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d94b75-22e5-4696-bfde-11777e2aee2f.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -33677,7 +33677,7 @@
         },
         {
             "id": "caa6382c-a8ee-5b67-9230-1a65268a94ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375e1986-678a-4a51-b2a7-61b1f936fe39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375e1986-678a-4a51-b2a7-61b1f936fe39.jpg?1",
             "name": "Myriad Landscape",
             "text": "",
             "colours": [],
@@ -33706,7 +33706,7 @@
         },
         {
             "id": "bb57af21-d243-592a-9e6a-c3c573ebd159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51faff0a-1006-4bc5-adb6-4ff3d7f07326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51faff0a-1006-4bc5-adb6-4ff3d7f07326.jpg?1",
             "name": "Mystic Monastery",
             "text": "",
             "colours": [],
@@ -33739,7 +33739,7 @@
         },
         {
             "id": "c97638b8-289a-55b1-9bfc-0fed06fce55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef2c66-853d-4b49-9a88-42c6c9b0d47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef2c66-853d-4b49-9a88-42c6c9b0d47b.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -33773,7 +33773,7 @@
         },
         {
             "id": "770564c0-1e82-532d-8cbf-8f4dfc8da3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afc4565-923f-4ad4-a9e9-5113a53386c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afc4565-923f-4ad4-a9e9-5113a53386c5.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -33802,7 +33802,7 @@
         },
         {
             "id": "3656fe4d-8bfe-57e1-badd-6e42938b769e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fcd68-1b41-47a1-bb31-7bf91f80168f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fcd68-1b41-47a1-bb31-7bf91f80168f.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -33836,7 +33836,7 @@
         },
         {
             "id": "e3831ca0-6df1-5ce0-bbf2-ee07c6f0003b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d35c1c-dbc3-4787-a7e5-9c1a02f95222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d35c1c-dbc3-4787-a7e5-9c1a02f95222.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -33873,7 +33873,7 @@
         },
         {
             "id": "fc1e3294-eb39-5c19-96f4-54e6623fe841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add0acb4-9f98-46d7-9c4b-7945dc1b05d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add0acb4-9f98-46d7-9c4b-7945dc1b05d1.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -33902,7 +33902,7 @@
         },
         {
             "id": "49457a5d-8cca-54c3-b074-91fc578f2f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56002ea-7c0d-4d7b-9887-477340370b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56002ea-7c0d-4d7b-9887-477340370b16.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -33936,7 +33936,7 @@
         },
         {
             "id": "e0660bf9-6453-54f9-a13a-af2ad23d2747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a6e6e-90b6-4fd7-a3df-a669327ca24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a6e6e-90b6-4fd7-a3df-a669327ca24c.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -33970,7 +33970,7 @@
         },
         {
             "id": "41180796-455b-5bf5-ace8-237681868908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c55a2e4-a041-4190-ae69-645347cb3b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c55a2e4-a041-4190-ae69-645347cb3b58.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -33999,7 +33999,7 @@
         },
         {
             "id": "fdcc0a59-a9aa-5eb7-9d7f-f92a278277ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e244138-e378-4bff-98be-03693a87b9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e244138-e378-4bff-98be-03693a87b9af.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -34033,7 +34033,7 @@
         },
         {
             "id": "e2315f15-87a4-5de8-a5a3-947304034a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f0a4f-6eec-47ef-ae66-38d99c5bf402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f0a4f-6eec-47ef-ae66-38d99c5bf402.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -34070,7 +34070,7 @@
         },
         {
             "id": "7d66d225-ca10-5420-8054-063b6db13cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f6558d-ee71-4d37-9354-8bd36a0aacc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f6558d-ee71-4d37-9354-8bd36a0aacc9.jpg?1",
             "name": "Seaside Citadel",
             "text": "",
             "colours": [],
@@ -34103,7 +34103,7 @@
         },
         {
             "id": "7a467680-2360-50cd-b94f-cd9f58908480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cbf21e-2789-4d1b-ac91-3539f809f68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cbf21e-2789-4d1b-ac91-3539f809f68f.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -34137,7 +34137,7 @@
         },
         {
             "id": "4916e3ab-6f37-52ed-97b6-7eedbf0f513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daab81ac-9adc-4b82-b2e5-16f0f13475b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daab81ac-9adc-4b82-b2e5-16f0f13475b7.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -34174,7 +34174,7 @@
         },
         {
             "id": "b58366da-8437-5569-8ee7-41e2afa538d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fca63-a979-40d1-9c5e-54f667c5c1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fca63-a979-40d1-9c5e-54f667c5c1f5.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -34208,7 +34208,7 @@
         },
         {
             "id": "51b33d23-9c9e-5a98-873c-b5b6336adddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3c66d4-c12f-4cc1-863d-4b48c64a812d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3c66d4-c12f-4cc1-863d-4b48c64a812d.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -34242,7 +34242,7 @@
         },
         {
             "id": "fe9f8a1a-dcab-545a-b208-e26937eb3cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c89e444-8292-4784-bfe8-8a8ea7d8cdcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c89e444-8292-4784-bfe8-8a8ea7d8cdcd.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -34279,7 +34279,7 @@
         },
         {
             "id": "4e6d1c0b-12f4-5cc9-9f8b-9e406e4103e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a4c8d-fdc1-4140-bc2e-eabc4c91d1c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a4c8d-fdc1-4140-bc2e-eabc4c91d1c1.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -34313,7 +34313,7 @@
         },
         {
             "id": "2e5c84fb-e904-5087-8364-4c7caeb711b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2510ee-9454-4792-8209-ab62d0bc02bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2510ee-9454-4792-8209-ab62d0bc02bb.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -34347,7 +34347,7 @@
         },
         {
             "id": "ce0ec101-d6e5-5575-82b6-797c5c01e98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a983e29-cb13-4000-b09d-c325152eb481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a983e29-cb13-4000-b09d-c325152eb481.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -34381,7 +34381,7 @@
         },
         {
             "id": "edc9095b-937d-5fe8-87d1-00e9bacfe3f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302e3173-f035-4d26-9aa6-7c4351739cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302e3173-f035-4d26-9aa6-7c4351739cf2.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -34415,7 +34415,7 @@
         },
         {
             "id": "7fe06800-acd3-5b92-b22a-b3a2189850de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576525b-ab90-4e06-8d70-95dd27eb5588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576525b-ab90-4e06-8d70-95dd27eb5588.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -34452,7 +34452,7 @@
         },
         {
             "id": "bc5c4ae5-2077-588a-ab6b-6111a590457d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03148778-0471-47a6-a43f-232dbf52b0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03148778-0471-47a6-a43f-232dbf52b0e2.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -34486,7 +34486,7 @@
         },
         {
             "id": "88b26d20-4359-54aa-9ae7-c9d7fe0c7694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22e560-353c-45aa-bfc7-ad56dab01445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22e560-353c-45aa-bfc7-ad56dab01445.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -34520,7 +34520,7 @@
         },
         {
             "id": "a31d9c36-4db6-5c41-be7e-63014a4cbb39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108131c-9a63-4217-bcaa-ea994260b517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108131c-9a63-4217-bcaa-ea994260b517.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -34554,7 +34554,7 @@
         },
         {
             "id": "f1749655-cf27-50a4-9b3d-e9cbebd7d8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879164f3-2434-4393-8901-7e51c9c9472f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879164f3-2434-4393-8901-7e51c9c9472f.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -34588,7 +34588,7 @@
         },
         {
             "id": "e3918349-ac37-55e0-8370-efa157aa84ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee649-5464-45b4-8fa6-05333c577420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee649-5464-45b4-8fa6-05333c577420.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -34622,7 +34622,7 @@
         },
         {
             "id": "b1ef436d-6e96-5b32-b894-54855029f115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee03d883-7693-408e-9bc2-1db4cbcf005e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee03d883-7693-408e-9bc2-1db4cbcf005e.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -34656,7 +34656,7 @@
         },
         {
             "id": "83d1a97c-d00d-5b03-9149-4c2d8ed638c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cf35a-d9ce-4f14-8a9c-7f4ec4613a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cf35a-d9ce-4f14-8a9c-7f4ec4613a22.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -34690,7 +34690,7 @@
         },
         {
             "id": "e5b21aea-a627-5454-84c6-200fc0118967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b63bd2-38ad-4a41-9a08-0580bdfb30fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b63bd2-38ad-4a41-9a08-0580bdfb30fd.jpg?1",
             "name": "Temple of the False God",
             "text": "",
             "colours": [],
@@ -34719,7 +34719,7 @@
         },
         {
             "id": "5a6830ee-bc5a-572f-b7d9-4deea6393a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd210e96-7499-431b-aac2-2412ada82431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd210e96-7499-431b-aac2-2412ada82431.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -34753,7 +34753,7 @@
         },
         {
             "id": "d52a6d03-f550-564e-a7e2-74c9c201c621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537f1fa1-1ae6-4ec1-ba87-4d64f9d3b12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537f1fa1-1ae6-4ec1-ba87-4d64f9d3b12b.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -34782,7 +34782,7 @@
         },
         {
             "id": "f6d38a0d-41c6-5cd2-b108-82a97d7ec402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc82744-f5da-438c-9ecf-1c286d9d78d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc82744-f5da-438c-9ecf-1c286d9d78d3.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -34813,7 +34813,7 @@
         },
         {
             "id": "ce02bc5a-917e-5a0f-9f67-742d07a4109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754e057-2ce2-4c19-a04f-35e646a32817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754e057-2ce2-4c19-a04f-35e646a32817.jpg?1",
             "name": "Thriving Bluff",
             "text": "",
             "colours": [],
@@ -34844,7 +34844,7 @@
         },
         {
             "id": "b819fd62-6023-520c-af46-c91827b07b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e65150-4990-48b2-88c9-affdc5333e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e65150-4990-48b2-88c9-affdc5333e8b.jpg?1",
             "name": "Thriving Grove",
             "text": "",
             "colours": [],
@@ -34875,7 +34875,7 @@
         },
         {
             "id": "c2879176-085e-5bf2-9eac-4ccb3d1dc79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bea150-fc4b-4ee9-9563-d52abd9ca848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bea150-fc4b-4ee9-9563-d52abd9ca848.jpg?1",
             "name": "Thriving Heath",
             "text": "",
             "colours": [],
@@ -34906,7 +34906,7 @@
         },
         {
             "id": "09555fa1-ac6e-5792-8f0e-81aa09e5ce3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1ad2a-7e0a-4e1d-9a43-98e76c52cd7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1ad2a-7e0a-4e1d-9a43-98e76c52cd7a.jpg?1",
             "name": "Thriving Isle",
             "text": "",
             "colours": [],
@@ -34937,7 +34937,7 @@
         },
         {
             "id": "5248a83c-1e52-5fd3-91ce-a82f0566d2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceadb155-d6dc-4b02-9ce8-bf1452cf655d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceadb155-d6dc-4b02-9ce8-bf1452cf655d.jpg?1",
             "name": "Thriving Moor",
             "text": "",
             "colours": [],
@@ -34968,7 +34968,7 @@
         },
         {
             "id": "7df78c1c-ba7e-549e-94c2-95ef108d9b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185e41a-bad8-4732-9396-a412bce67a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185e41a-bad8-4732-9396-a412bce67a73.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -35002,7 +35002,7 @@
         },
         {
             "id": "f27df5d6-1ffc-523c-a777-25ada9eca1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf2cbe-fb56-424f-b1f8-ef80bdf0ae77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf2cbe-fb56-424f-b1f8-ef80bdf0ae77.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -35033,7 +35033,7 @@
         },
         {
             "id": "e8ee3dfd-5734-562d-8e96-3f2c620b6152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ca4c3e-9d81-4897-bece-fec88d3a58e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ca4c3e-9d81-4897-bece-fec88d3a58e7.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -35067,7 +35067,7 @@
         },
         {
             "id": "910509c6-7a6a-561d-a311-20a655561a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f7d709-74bb-4085-bf69-bdab4c1ae26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f7d709-74bb-4085-bf69-bdab4c1ae26d.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -35103,7 +35103,7 @@
         },
         {
             "id": "fa50e9be-81c2-5a53-9b68-47947f2a75d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333c352-9edd-425e-80d8-7d61c76da298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333c352-9edd-425e-80d8-7d61c76da298.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -35140,7 +35140,7 @@
         },
         {
             "id": "e5e2ec3a-e943-5ff9-b2f2-aa2e23e98982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c48102-e213-4188-a2a7-5a9adae3f693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c48102-e213-4188-a2a7-5a9adae3f693.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -35179,7 +35179,7 @@
         },
         {
             "id": "8dfb33ef-e879-5ffb-a18b-b21258eb84c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653b9e87-9230-4f96-bf60-d6be6b150e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653b9e87-9230-4f96-bf60-d6be6b150e7a.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -35219,7 +35219,7 @@
         },
         {
             "id": "5748324e-aa24-52fc-a6c7-4938c87ef0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cca38da-6278-4ebe-8b62-a457876a2669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cca38da-6278-4ebe-8b62-a457876a2669.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -35254,7 +35254,7 @@
         },
         {
             "id": "dcd929c6-3826-539a-92e7-006a70519317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de3ee91-b361-45ae-8a8a-cdb5eb9e4f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de3ee91-b361-45ae-8a8a-cdb5eb9e4f11.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -35289,7 +35289,7 @@
         },
         {
             "id": "f5b1b77e-19d8-5fd9-a528-f92f8d863253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2e371e-7f5b-4fb5-9c6c-49443ef19703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2e371e-7f5b-4fb5-9c6c-49443ef19703.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -35324,7 +35324,7 @@
         },
         {
             "id": "ddbb35ac-4e23-59e5-900d-4805e02a9cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c825df-8fa8-4c07-a9b7-cafbb6508c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c825df-8fa8-4c07-a9b7-cafbb6508c3c.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -35359,7 +35359,7 @@
         },
         {
             "id": "cf5c336a-b400-5210-83e0-7221fc7d9724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fd8cdb-4608-4bfa-b100-51b964439179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fd8cdb-4608-4bfa-b100-51b964439179.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -35394,7 +35394,7 @@
         },
         {
             "id": "e23310f7-1e90-5e36-8e3c-3d18d3e9355e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3b424b-8695-40e7-bb50-933c9c62f4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3b424b-8695-40e7-bb50-933c9c62f4cf.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -35434,7 +35434,7 @@
         },
         {
             "id": "527e8bcd-f648-5225-a2a4-2267ddaac1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa35c60-3d9d-4022-97c3-4eeff398c895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa35c60-3d9d-4022-97c3-4eeff398c895.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -35474,7 +35474,7 @@
         },
         {
             "id": "a5788234-60a8-5196-87d7-a79e19e3a363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0777c9e1-0c21-44a1-93ce-bbac00e4cff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0777c9e1-0c21-44a1-93ce-bbac00e4cff3.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -35511,7 +35511,7 @@
         },
         {
             "id": "55dd12de-a230-5928-9125-9b16fd8c926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abda47c-a50e-4354-a044-4186c1d22f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abda47c-a50e-4354-a044-4186c1d22f89.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -35550,7 +35550,7 @@
         },
         {
             "id": "83647813-09f2-53cb-9841-0fb67f702e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a7d6e5-9372-46cc-be26-03f66a21d539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a7d6e5-9372-46cc-be26-03f66a21d539.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -35590,7 +35590,7 @@
         },
         {
             "id": "5aa23ff5-f53b-5c43-ac03-094f6558b828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832a6eb-72c9-4480-a173-20588e688b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832a6eb-72c9-4480-a173-20588e688b11.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -35631,7 +35631,7 @@
         },
         {
             "id": "da170d24-a691-53f0-a819-4a30a6da773d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a86e0-413c-45a0-a4c0-d85fe74361c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a86e0-413c-45a0-a4c0-d85fe74361c1.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -35673,7 +35673,7 @@
         },
         {
             "id": "e174bf4b-3b6b-54fa-8889-ab4973f0b654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbda79c-5d9a-4b66-b7a9-556b296d71fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbda79c-5d9a-4b66-b7a9-556b296d71fd.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -35712,7 +35712,7 @@
         },
         {
             "id": "9d6a0ecd-d23d-5816-a89d-5d5034cabfb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be35975-fac5-448d-a18e-7b05dcc57f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be35975-fac5-448d-a18e-7b05dcc57f02.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -35747,7 +35747,7 @@
         },
         {
             "id": "f2080843-b480-5aee-a8c2-e1baa437f557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2488d86-a7ea-4c00-bc0a-7ebafc6e165f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2488d86-a7ea-4c00-bc0a-7ebafc6e165f.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -35787,7 +35787,7 @@
         },
         {
             "id": "0d73347f-ad5c-522c-ada8-20460181b9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176a1504-262b-48f5-92a8-9e29cb397366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176a1504-262b-48f5-92a8-9e29cb397366.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -35827,7 +35827,7 @@
         },
         {
             "id": "d672fa55-dc78-53c0-9de5-a5796c3796d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c61ba76-14fa-4a57-b2a8-3b701ba1df30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c61ba76-14fa-4a57-b2a8-3b701ba1df30.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -35862,7 +35862,7 @@
         },
         {
             "id": "62d8f92b-8e8e-502a-aa53-d80a3d085f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44771a2-899e-4259-af49-4993f8a5865b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44771a2-899e-4259-af49-4993f8a5865b.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -35901,7 +35901,7 @@
         },
         {
             "id": "f8635a28-98f5-56db-bcef-1e9efa7b3b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0a7b62-ac10-4f71-91e3-870853e43b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0a7b62-ac10-4f71-91e3-870853e43b1c.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -35938,7 +35938,7 @@
         },
         {
             "id": "0779716b-f728-5665-90f1-7fcafb1427d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed19c7cb-41cc-499f-ae76-fa08262f0834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed19c7cb-41cc-499f-ae76-fa08262f0834.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -35973,7 +35973,7 @@
         },
         {
             "id": "12de237a-6fe8-582f-a542-654fcaf350f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93c9838-e041-4ca4-9a39-49df328e3dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93c9838-e041-4ca4-9a39-49df328e3dd1.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -36014,7 +36014,7 @@
         },
         {
             "id": "8b658c18-6ef1-5958-999a-d02bfc22fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00932f-96eb-414f-a8f5-c4f627fdba98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00932f-96eb-414f-a8f5-c4f627fdba98.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -36053,7 +36053,7 @@
         },
         {
             "id": "71faa59b-31f8-555d-ac56-780ca02f6b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5e0f58-5cc1-4cf5-9bb7-da45a6e0bd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5e0f58-5cc1-4cf5-9bb7-da45a6e0bd0e.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -36088,7 +36088,7 @@
         },
         {
             "id": "fbd246eb-a514-5978-b723-fcb0df42bc0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b37617e-bba7-4d85-8092-9b43be7fec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b37617e-bba7-4d85-8092-9b43be7fec40.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -36126,7 +36126,7 @@
         },
         {
             "id": "4c5cdba4-105e-5c99-94d5-4cf0e3ea27cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e77feb-1a6a-4183-bcae-3e3d4d4566d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e77feb-1a6a-4183-bcae-3e3d4d4566d4.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -36165,7 +36165,7 @@
         },
         {
             "id": "118043dd-0754-5b87-b1c8-497e9be28832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78332c23-4d73-4aec-b3fc-2d6340a03f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78332c23-4d73-4aec-b3fc-2d6340a03f1c.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -36200,7 +36200,7 @@
         },
         {
             "id": "6372ae20-fdd8-5e72-b4cd-e28d8258a440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f151285-08a7-4148-950e-82ccb36502bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f151285-08a7-4148-950e-82ccb36502bf.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -36243,7 +36243,7 @@
         },
         {
             "id": "6d90869c-4c2e-5c07-b7f1-67df42f5f6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6335929d-6de3-4278-9f4b-883453ad1dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6335929d-6de3-4278-9f4b-883453ad1dc6.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -36283,7 +36283,7 @@
         },
         {
             "id": "65ca1316-7d08-5260-89c9-c2a4016829a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69086404-c405-4d08-a6d4-7daaa1d2f11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69086404-c405-4d08-a6d4-7daaa1d2f11c.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -36318,7 +36318,7 @@
         },
         {
             "id": "4309d7c6-3632-5216-8160-654386d67bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42832b1c-e38e-4d06-809c-31a7250566ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42832b1c-e38e-4d06-809c-31a7250566ad.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -36358,7 +36358,7 @@
         },
         {
             "id": "b29c9281-9d80-57a3-9c64-2404b384168c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b212e7d-2ea1-4ba7-a060-c67d44e259a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b212e7d-2ea1-4ba7-a060-c67d44e259a7.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -36398,7 +36398,7 @@
         },
         {
             "id": "1b1529b2-b4e6-58b6-aabd-fdef9131465b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ce4ff5-7b9e-4ef8-9a7e-9d148983b04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ce4ff5-7b9e-4ef8-9a7e-9d148983b04e.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -36439,7 +36439,7 @@
         },
         {
             "id": "4305c4de-832f-5386-a2f2-1174ad5c0636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cddd4ff-0c56-41b5-a865-5d3f55141ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cddd4ff-0c56-41b5-a865-5d3f55141ae3.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -36474,7 +36474,7 @@
         },
         {
             "id": "0b8fc043-5bcd-5f60-8f93-fcd6c005adcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b101a18-cb20-4511-96bc-03d32bfe1a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b101a18-cb20-4511-96bc-03d32bfe1a03.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -36509,7 +36509,7 @@
         },
         {
             "id": "e6b4d18f-31e2-521c-ae80-d0a4ecfaa203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c512b-adc8-4ce2-80e5-28a3b827d40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c512b-adc8-4ce2-80e5-28a3b827d40f.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -36544,7 +36544,7 @@
         },
         {
             "id": "2311bcd9-8759-582a-8545-0dbf8a51e01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0829742d-7268-46a3-a8f3-172559b1315f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0829742d-7268-46a3-a8f3-172559b1315f.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -36582,7 +36582,7 @@
         },
         {
             "id": "8c49c218-8c3d-5069-b6db-7c948ac7b661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70606b58-b72e-46b4-931e-5e2490a83b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70606b58-b72e-46b4-931e-5e2490a83b29.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -36617,7 +36617,7 @@
         },
         {
             "id": "0fe916df-29c8-5444-a257-072631740462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecb70ba-2b35-4032-9d2c-ce64099b9719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecb70ba-2b35-4032-9d2c-ce64099b9719.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -36652,7 +36652,7 @@
         },
         {
             "id": "10411783-1b13-577b-b9be-1d74ee483140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fb923e-bf9a-46e6-827a-035b3c360edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fb923e-bf9a-46e6-827a-035b3c360edf.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -36690,7 +36690,7 @@
         },
         {
             "id": "e686f379-50f2-55c8-bfa6-3c3671e6a558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf950d-bf1b-4ee6-9ffe-326473d7c704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf950d-bf1b-4ee6-9ffe-326473d7c704.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -36725,7 +36725,7 @@
         },
         {
             "id": "5de3c0d5-5b87-5022-83af-10eb31d20694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abacd86-9e99-4a9a-863c-260596201039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abacd86-9e99-4a9a-863c-260596201039.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -36763,7 +36763,7 @@
         },
         {
             "id": "341f8754-c5cd-5aeb-af39-aef4dd58c32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab01ba9-0f4a-49b9-b7dc-0db1b48e7420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab01ba9-0f4a-49b9-b7dc-0db1b48e7420.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -36802,7 +36802,7 @@
         },
         {
             "id": "a1167081-6848-5839-866f-01bc8c58ff97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb9f82-bccd-4444-8439-b6c872a17589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb9f82-bccd-4444-8439-b6c872a17589.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -36841,7 +36841,7 @@
         },
         {
             "id": "bfe95642-3aeb-557f-be5a-3ecce4176d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff8d9c3-143b-4558-81bc-82845bc45342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff8d9c3-143b-4558-81bc-82845bc45342.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -36880,7 +36880,7 @@
         },
         {
             "id": "77c279ca-fa98-5e30-9ec1-7abf117511ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51591756-3a27-4b2b-9ee4-cf2e24656246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51591756-3a27-4b2b-9ee4-cf2e24656246.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -36919,7 +36919,7 @@
         },
         {
             "id": "0faf45c6-d4c2-564b-a867-6c97f23a342d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08f8c11-7f61-4856-bc45-5f3d91750093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08f8c11-7f61-4856-bc45-5f3d91750093.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -36954,7 +36954,7 @@
         },
         {
             "id": "da1de919-89a7-5097-8451-66095ed3b346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804d844b-9aae-46fe-8146-3b1b08c4cb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804d844b-9aae-46fe-8146-3b1b08c4cb50.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -36993,7 +36993,7 @@
         },
         {
             "id": "6e39ea1a-f12d-56b9-a253-26cf197d0efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e1fe57-63db-4fe0-8ecc-877f808555b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e1fe57-63db-4fe0-8ecc-877f808555b8.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -37028,7 +37028,7 @@
         },
         {
             "id": "e2959175-e879-5fd8-8e1f-2e1d809c9d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d5e7c-4f8f-4802-8da4-50a369a5b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d5e7c-4f8f-4802-8da4-50a369a5b31f.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -37063,7 +37063,7 @@
         },
         {
             "id": "60148b85-80d8-56ca-8eae-10c7faa94eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d476b1-1096-49ce-9acf-53b1c5e94df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d476b1-1096-49ce-9acf-53b1c5e94df6.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -37100,7 +37100,7 @@
         },
         {
             "id": "0f57f719-0a73-52e4-959d-3461697ea104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b846507-2573-4435-8a12-706e42b4cdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b846507-2573-4435-8a12-706e42b4cdd2.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -37135,7 +37135,7 @@
         },
         {
             "id": "dafb95b2-c2cd-524d-b5b9-c7d9c01e615c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d239db59-d011-472f-bb65-97ed8da0dcc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d239db59-d011-472f-bb65-97ed8da0dcc3.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -37170,7 +37170,7 @@
         },
         {
             "id": "3a8cdb29-4d8f-5d04-b981-3c200a8ba289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2cb24-311f-4411-8f17-c481caf132c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2cb24-311f-4411-8f17-c481caf132c2.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -37205,7 +37205,7 @@
         },
         {
             "id": "39bb292c-efe7-54dc-8daa-1b7d694be9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6d214-87e8-4b39-ae22-8f0a69c9933c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6d214-87e8-4b39-ae22-8f0a69c9933c.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -37244,7 +37244,7 @@
         },
         {
             "id": "34670d37-d584-514b-9f12-2e5b1e79e8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976ceca5-3222-46d0-ba8e-205781b17466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976ceca5-3222-46d0-ba8e-205781b17466.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -37283,7 +37283,7 @@
         },
         {
             "id": "ed11893d-e191-574d-8bf2-2a6d35ca1e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed24e12a-e08b-4c0e-abe3-4d108d5ece79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed24e12a-e08b-4c0e-abe3-4d108d5ece79.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -37320,7 +37320,7 @@
         },
         {
             "id": "64a5b1e9-bd9a-59e3-b11e-4fcaaa8dc5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1aefd-fb8a-42a7-b59f-b05c05cef8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1aefd-fb8a-42a7-b59f-b05c05cef8f8.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -37362,7 +37362,7 @@
         },
         {
             "id": "5b0ce0ce-e4f6-574a-a9ef-86e5cc992113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8cc91a-dedf-4a35-b0e7-31a3fedbe2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8cc91a-dedf-4a35-b0e7-31a3fedbe2d3.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -37402,7 +37402,7 @@
         },
         {
             "id": "974623d8-2ca6-58b9-bfba-21fda8a79d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ec96e9-5326-4726-bb94-c3b5c6aaccb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ec96e9-5326-4726-bb94-c3b5c6aaccb6.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -37437,7 +37437,7 @@
         },
         {
             "id": "419833a4-647b-503e-a02f-196d7306fdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b952c053-0c26-4690-86d2-1b28e664e7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b952c053-0c26-4690-86d2-1b28e664e7a6.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -37476,7 +37476,7 @@
         },
         {
             "id": "a2ab23e2-41b5-5826-931f-b17c6d3ab93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0410cb-e202-4bad-a6a5-e3e58e574157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0410cb-e202-4bad-a6a5-e3e58e574157.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -37516,7 +37516,7 @@
         },
         {
             "id": "ab8eaac5-8a48-53cd-9908-7aa1f04ab953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215f5c44-c1e0-4a2e-a950-7d26426f002e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215f5c44-c1e0-4a2e-a950-7d26426f002e.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -37556,7 +37556,7 @@
         },
         {
             "id": "8b9c47a2-bb8e-5f76-bd1a-35ce1c255b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a41b0c-36ca-4e93-9ae4-0632bd483e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a41b0c-36ca-4e93-9ae4-0632bd483e6f.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -37596,7 +37596,7 @@
         },
         {
             "id": "f91bb568-b246-595e-8a3d-30ee047d723d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc4062-61d8-4e51-a500-bea82279568b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc4062-61d8-4e51-a500-bea82279568b.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -37633,7 +37633,7 @@
         },
         {
             "id": "bb5f1706-b1b0-5d36-8b0b-f6759ee0a755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca13436-2e25-4853-be97-cff5675b41f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca13436-2e25-4853-be97-cff5675b41f8.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -37672,7 +37672,7 @@
         },
         {
             "id": "347d967d-59e5-5371-8c15-028680fc9bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bf944a-8fad-4107-a9c5-5d98fd1a07df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bf944a-8fad-4107-a9c5-5d98fd1a07df.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -37716,7 +37716,7 @@
         },
         {
             "id": "f09c9b98-6c3b-5211-bd14-b5f06e86cd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91390e37-3239-4caf-b194-5bee36d1b67a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91390e37-3239-4caf-b194-5bee36d1b67a.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -37760,7 +37760,7 @@
         },
         {
             "id": "837f520a-de77-5d42-91e8-9935d525fc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae56274-d001-48ca-9312-a1aa744cf643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae56274-d001-48ca-9312-a1aa744cf643.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -37801,7 +37801,7 @@
         },
         {
             "id": "bd53b3db-9c49-5e2f-b70d-ed46e1cd2b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4a0b3-89b2-4db5-a8c5-a5d8d1c1ed1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4a0b3-89b2-4db5-a8c5-a5d8d1c1ed1d.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -37845,7 +37845,7 @@
         },
         {
             "id": "d237b6c2-c936-5c7c-9231-e66fba45a4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa858045-c3cf-457b-b7f9-a0b4fa70f2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa858045-c3cf-457b-b7f9-a0b4fa70f2df.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -37887,7 +37887,7 @@
         },
         {
             "id": "21427448-94e8-5c71-85fc-5e2a8218b319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6a050-7486-4210-93cf-3ce7cc957a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6a050-7486-4210-93cf-3ce7cc957a1c.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -37929,7 +37929,7 @@
         },
         {
             "id": "7ca8c7e1-1bfb-5799-a8b0-4a83a4b999bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24057902-f0a7-4ca9-bbe0-cd74b68dbd8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24057902-f0a7-4ca9-bbe0-cd74b68dbd8d.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -37977,7 +37977,7 @@
         },
         {
             "id": "11a6f40a-7e9f-5d16-9bdb-f1522d9de673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8bfda3-ea87-470d-94eb-0951b7f4ab1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8bfda3-ea87-470d-94eb-0951b7f4ab1c.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -38016,7 +38016,7 @@
         },
         {
             "id": "a3943a6c-d9dd-5a1f-8c03-b990e7435afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0cfc0e-6a38-4fa2-8e4b-64a893591fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0cfc0e-6a38-4fa2-8e4b-64a893591fec.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -38058,7 +38058,7 @@
         },
         {
             "id": "dd7f9395-a353-5ece-b1f5-8d2f5949767f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b80dd3-589f-493d-ae3c-a663b520da79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b80dd3-589f-493d-ae3c-a663b520da79.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -38103,7 +38103,7 @@
         },
         {
             "id": "c25cd7d8-0c6e-5fc8-91d1-00ef9c2a908e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d3891a-25e8-47ff-a516-4f3b8ce7fe24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d3891a-25e8-47ff-a516-4f3b8ce7fe24.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -38148,7 +38148,7 @@
         },
         {
             "id": "85d9bfa2-ec83-5eb6-9aa0-0f5ca512199d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc5252a-77d7-419a-8d78-161e106352ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc5252a-77d7-419a-8d78-161e106352ee.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -38192,7 +38192,7 @@
         },
         {
             "id": "e587e5eb-6820-5875-9e2e-43f6125cd1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038279a1-76fd-4bf0-8ebb-d06db9747a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038279a1-76fd-4bf0-8ebb-d06db9747a64.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -38237,7 +38237,7 @@
         },
         {
             "id": "0245ed25-66b3-56e1-8f64-d5af3299ec81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0902ee20-bb26-4eca-ac34-e0cb3909a32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0902ee20-bb26-4eca-ac34-e0cb3909a32e.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -38282,7 +38282,7 @@
         },
         {
             "id": "b755f788-9968-50b0-a354-413eb3984431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae754d-33a2-4a07-8b10-fe4dda9af745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae754d-33a2-4a07-8b10-fe4dda9af745.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -38328,7 +38328,7 @@
         },
         {
             "id": "9bc7384e-38a6-53d1-a482-2d0ebd157809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2136c09b-f27d-40f1-b3fd-44a399d1d021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2136c09b-f27d-40f1-b3fd-44a399d1d021.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -38367,7 +38367,7 @@
         },
         {
             "id": "6b1ef8bc-276f-590d-910d-d0fb21515c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7f02c6-384a-41ba-ba9c-e0f0984ec2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7f02c6-384a-41ba-ba9c-e0f0984ec2a1.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -38411,7 +38411,7 @@
         },
         {
             "id": "390ca56d-111f-5c91-bc49-67357da7fdcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dc4f0d-88f1-4434-a36e-ac9aae7b295c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dc4f0d-88f1-4434-a36e-ac9aae7b295c.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -38450,7 +38450,7 @@
         },
         {
             "id": "1a6bc687-8ef7-552b-970e-6727b4b3101c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476ec84a-4618-4ead-85cb-c6c2e426fd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476ec84a-4618-4ead-85cb-c6c2e426fd91.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -38492,7 +38492,7 @@
         },
         {
             "id": "7a81d223-87bd-5584-b932-c71c6eb92617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bc3ef-7a2e-4d5f-8c6a-a1a4409b1ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bc3ef-7a2e-4d5f-8c6a-a1a4409b1ea2.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -38534,7 +38534,7 @@
         },
         {
             "id": "72d85e5e-fb7e-5cc0-ba36-dbcbb3c346dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e4a50-b844-4306-af1d-a986050def36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e4a50-b844-4306-af1d-a986050def36.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -38576,7 +38576,7 @@
         },
         {
             "id": "0b64d023-91b4-5ba3-a5a9-62d96ae789d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf13c77b-8b5b-45c3-9a1e-e8fb13640e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf13c77b-8b5b-45c3-9a1e-e8fb13640e8d.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -38620,7 +38620,7 @@
         },
         {
             "id": "56446903-6b89-5cf8-a2d2-ea254fe4a37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964a050-bed3-4e2e-b44b-e93561c4c643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964a050-bed3-4e2e-b44b-e93561c4c643.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -38657,7 +38657,7 @@
         },
         {
             "id": "f0adb48f-2f0d-5654-99f8-18433953f455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321f0fa-0df0-4388-86a0-456f7ab721de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321f0fa-0df0-4388-86a0-456f7ab721de.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -38697,7 +38697,7 @@
         },
         {
             "id": "25c745a7-d790-5ccb-b40a-c2737648937d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a73bf1-cf14-4a36-97ff-868212e0bfb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a73bf1-cf14-4a36-97ff-868212e0bfb8.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -38739,7 +38739,7 @@
         },
         {
             "id": "35fee6cf-7329-5843-8c11-22f7e807b4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225fd1e5-cd42-4c33-bfcd-9287289d2098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225fd1e5-cd42-4c33-bfcd-9287289d2098.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -38783,7 +38783,7 @@
         },
         {
             "id": "7572c1d5-1319-5622-833e-5ac9dd0e39fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db03b22-a9ad-43e9-875f-66e9bdc9cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db03b22-a9ad-43e9-875f-66e9bdc9cd90.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -38827,7 +38827,7 @@
         },
         {
             "id": "460bda83-cfcc-5561-900d-88a9bc6bd27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b4f8d-44bb-40ac-a2e0-bd28690887de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b4f8d-44bb-40ac-a2e0-bd28690887de.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -38871,7 +38871,7 @@
         },
         {
             "id": "a827cde2-508d-52e7-b6ed-8d411072f205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df77bd5-9880-4813-b85e-fe157a7bea9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df77bd5-9880-4813-b85e-fe157a7bea9e.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -38915,7 +38915,7 @@
         },
         {
             "id": "4cc3dd2c-7b1d-5b1f-bbcb-fcdb0796f190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2859f7ca-6b21-4c08-8860-12d9cd82d00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2859f7ca-6b21-4c08-8860-12d9cd82d00a.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -38959,7 +38959,7 @@
         },
         {
             "id": "658e63fe-1714-5324-8fd5-6f98d2e754d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f72af9-7b86-4c52-a7fe-9db2afcbcd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f72af9-7b86-4c52-a7fe-9db2afcbcd14.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -39005,7 +39005,7 @@
         },
         {
             "id": "962b2e17-dd2d-5f6a-b402-496172acc177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3e0b24-2bf1-451b-9f02-e3704949ae7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3e0b24-2bf1-451b-9f02-e3704949ae7d.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -39050,7 +39050,7 @@
         },
         {
             "id": "43295484-e091-504e-be3d-9d56c5bf2baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6439d491-1be8-4f70-8385-4da79ae4aef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6439d491-1be8-4f70-8385-4da79ae4aef7.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -39094,7 +39094,7 @@
         },
         {
             "id": "a726d769-b6e5-590f-be6c-ee5cbd8765d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b23c9f1-1474-4df1-b1a2-b98eae2248ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b23c9f1-1474-4df1-b1a2-b98eae2248ad.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -39136,7 +39136,7 @@
         },
         {
             "id": "43938db2-fc23-5661-b771-639a800fe58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0245b04-c2a6-43dd-b9d2-5150d0ebb24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0245b04-c2a6-43dd-b9d2-5150d0ebb24c.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -39173,7 +39173,7 @@
         },
         {
             "id": "f5b0ad2d-af13-5d7e-a405-6329a6cb3801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2666846e-fde4-4b28-97c6-a0296771081d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2666846e-fde4-4b28-97c6-a0296771081d.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -39218,7 +39218,7 @@
         },
         {
             "id": "a111cc37-1191-5330-a517-ef5e6a9bbdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dc2162-3350-4fd4-995a-b2080f8fb94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dc2162-3350-4fd4-995a-b2080f8fb94e.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -39260,7 +39260,7 @@
         },
         {
             "id": "9a3740e3-1b8a-57ec-8cc1-03bd3f6b0a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bac5d4-b83e-457e-bdf1-da7dbaf8ded4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bac5d4-b83e-457e-bdf1-da7dbaf8ded4.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -39297,7 +39297,7 @@
         },
         {
             "id": "980737f6-c3ff-5878-a628-6238b6dc5e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209b79d-02a4-40d5-9301-98cf97ac095a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209b79d-02a4-40d5-9301-98cf97ac095a.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -39339,7 +39339,7 @@
         },
         {
             "id": "075bb03b-5c0c-57c5-bff2-5dac5046543f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb7f9-232b-4c1e-9c27-d9d8f7fd3752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb7f9-232b-4c1e-9c27-d9d8f7fd3752.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -39384,7 +39384,7 @@
         },
         {
             "id": "b8d3e966-2eb5-5505-85c2-f50a4f3a67b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26393e65-d137-4c36-ba39-6da7e32b16d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26393e65-d137-4c36-ba39-6da7e32b16d0.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -39426,7 +39426,7 @@
         },
         {
             "id": "40ac61b3-4e77-5055-8c2e-3b0711b3dbf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d19bf30-4e95-470b-a81b-a6595816eeed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d19bf30-4e95-470b-a81b-a6595816eeed.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -39471,7 +39471,7 @@
         },
         {
             "id": "15628c88-0911-5ef5-87d4-92bf624b9d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae21ef3-9e4a-43da-83f3-4b4cd30bc2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae21ef3-9e4a-43da-83f3-4b4cd30bc2cd.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -39516,7 +39516,7 @@
         },
         {
             "id": "f5de9c0a-e834-5680-a109-b6e9ad103dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e411f4-d1b9-415f-8769-01b274a1b17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e411f4-d1b9-415f-8769-01b274a1b17e.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -39558,7 +39558,7 @@
         },
         {
             "id": "6929276e-2cd9-50d1-bc83-62eedae72eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a24ee3-2e35-4918-ab6d-5ee839cab23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a24ee3-2e35-4918-ab6d-5ee839cab23d.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -39598,7 +39598,7 @@
         },
         {
             "id": "00f2cd58-c460-57af-a941-b7e8dd5ce937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7d3ae-e15a-4e5c-8c9e-f90aa334b0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7d3ae-e15a-4e5c-8c9e-f90aa334b0cd.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -39644,7 +39644,7 @@
         },
         {
             "id": "40cdf738-a80e-58ed-b4a9-84a9f5b6d9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee72f96-0989-42ca-a60a-7f88ce7440c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee72f96-0989-42ca-a60a-7f88ce7440c2.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -39689,7 +39689,7 @@
         },
         {
             "id": "6129fe0e-e952-5b75-b5f5-8cb46cc58b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801fedfb-f5bb-44c2-9956-b14ca2adc3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801fedfb-f5bb-44c2-9956-b14ca2adc3ed.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -39735,7 +39735,7 @@
         },
         {
             "id": "71ed2476-1fa2-5134-ac27-8f0bb074f699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc9f5cb-700b-4b99-bca4-3c7d03cc180a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc9f5cb-700b-4b99-bca4-3c7d03cc180a.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -39780,7 +39780,7 @@
         },
         {
             "id": "f390a0de-00c6-5daf-95d2-1172b8a0a13a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d154b5ec-9fd0-4627-bcf8-7993f1ab5b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d154b5ec-9fd0-4627-bcf8-7993f1ab5b6b.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -39824,7 +39824,7 @@
         },
         {
             "id": "c7e76f2a-74fa-5fad-b3a0-5ccdfb0c2b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78130eb5-fa5d-4007-9b6b-714732bf97c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78130eb5-fa5d-4007-9b6b-714732bf97c5.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -39867,7 +39867,7 @@
         },
         {
             "id": "bb4a6fe5-6b23-5183-bf7e-d8b0dd31f222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33148ef-e7f7-4e34-8f0a-7c209feb572c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33148ef-e7f7-4e34-8f0a-7c209feb572c.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -39911,7 +39911,7 @@
         },
         {
             "id": "d6e75c59-affb-5070-89f5-af428a379240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9430043-f452-4bb6-bff3-d6f91420b756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9430043-f452-4bb6-bff3-d6f91420b756.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -39954,7 +39954,7 @@
         },
         {
             "id": "5c9d305d-af50-5dc2-9bd0-24c95f6fcdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a6cc57-6b6b-4e7e-8488-181c0999df60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a6cc57-6b6b-4e7e-8488-181c0999df60.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -39989,7 +39989,7 @@
         },
         {
             "id": "49be8185-c349-51e6-8e64-466a8c03be44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39166adc-6b0e-4549-965b-a8dded70c54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39166adc-6b0e-4549-965b-a8dded70c54c.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -40024,7 +40024,7 @@
         },
         {
             "id": "a3c03f2f-6e44-5f06-91f3-ef7b43d0fcf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33f4765-f5cc-4c94-afa7-32fd841c07ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33f4765-f5cc-4c94-afa7-32fd841c07ca.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -40055,7 +40055,7 @@
         },
         {
             "id": "2126b1cd-a876-5648-a117-42e4cce43cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdf8ea-e3a7-4121-805a-417361c8d58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdf8ea-e3a7-4121-805a-417361c8d58d.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -40089,7 +40089,7 @@
         },
         {
             "id": "1e7ed733-a4c4-5f83-aa99-ccee3fcfedd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96b99e-07e1-41b6-b9ce-dca3f75ecfa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96b99e-07e1-41b6-b9ce-dca3f75ecfa1.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -40122,7 +40122,7 @@
         },
         {
             "id": "c7498bc7-3ae6-5ee8-a710-9a299bdf2fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc1dec-87a1-413d-afa9-2d4d1b0479b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc1dec-87a1-413d-afa9-2d4d1b0479b0.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -40155,7 +40155,7 @@
         },
         {
             "id": "cea05c21-f79d-5ac6-9747-6a1787b9d5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8baa1c-7dd4-46b0-824f-405b44829caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8baa1c-7dd4-46b0-824f-405b44829caa.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -40186,7 +40186,7 @@
         },
         {
             "id": "5e626544-7ecf-5318-95c5-933fc62b1289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e251c4-72bd-42b5-91ed-b0d4ea312fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e251c4-72bd-42b5-91ed-b0d4ea312fae.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -40217,7 +40217,7 @@
         },
         {
             "id": "ba6b312c-a1be-5f63-8145-e26b5f7168e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e03370a-05a7-4f84-aadd-9eba459e2696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e03370a-05a7-4f84-aadd-9eba459e2696.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -40250,7 +40250,7 @@
         },
         {
             "id": "907adc2f-2ac9-5252-b8c3-6ec4deb8a39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f517d29-aa30-4890-ba4e-b572ac873bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f517d29-aa30-4890-ba4e-b572ac873bb4.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -40285,7 +40285,7 @@
         },
         {
             "id": "0b5bd532-26f4-5ae8-981d-a0ed20ee56e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e329faf-f122-44d8-bd7d-decf296404e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e329faf-f122-44d8-bd7d-decf296404e9.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -40322,7 +40322,7 @@
         },
         {
             "id": "685c712b-ab6a-528a-be08-3f6022e555cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b2e80f-7dd9-4d0f-a3b7-ea2dbbd7ada2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b2e80f-7dd9-4d0f-a3b7-ea2dbbd7ada2.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -40357,7 +40357,7 @@
         },
         {
             "id": "fb2cb877-d854-5e75-b94f-741429601ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1df61a7-f87b-48bc-9ea0-0b7799cbd4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1df61a7-f87b-48bc-9ea0-0b7799cbd4ae.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -40392,7 +40392,7 @@
         },
         {
             "id": "5679fe0e-1bcd-5082-86fd-2442b00cf7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39ad9da-f71a-48a5-b5d3-e6e0bfb7402e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39ad9da-f71a-48a5-b5d3-e6e0bfb7402e.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -40427,7 +40427,7 @@
         },
         {
             "id": "b3994c69-d1b2-53aa-8f8a-76e461a8024d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcac03a0-c4e3-4761-93f1-d4a64c0d46f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcac03a0-c4e3-4761-93f1-d4a64c0d46f8.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -40462,7 +40462,7 @@
         },
         {
             "id": "93176330-4188-5d0d-9437-3aa232d08de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8107bd96-3570-458e-b76c-73af227f9955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8107bd96-3570-458e-b76c-73af227f9955.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -40497,7 +40497,7 @@
         },
         {
             "id": "a5fe2048-d427-58ce-a243-28362a9415ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c678c4-7b36-42a9-88d3-1b4c5dadae36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c678c4-7b36-42a9-88d3-1b4c5dadae36.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -40532,7 +40532,7 @@
         },
         {
             "id": "58849d31-6d97-5c18-8bf6-b35ced7fb7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4070bf-315a-4fe4-826d-7507ea4b2d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4070bf-315a-4fe4-826d-7507ea4b2d12.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -40567,7 +40567,7 @@
         },
         {
             "id": "41b06296-ecdb-575a-8450-64f7bc988b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb016ec-ceff-4145-8118-8902e96aba57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb016ec-ceff-4145-8118-8902e96aba57.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -40602,7 +40602,7 @@
         },
         {
             "id": "7ffa9a2e-0078-530f-85fc-6ded93f77c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed48a-d2d2-46bc-82c1-487e6fa66f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed48a-d2d2-46bc-82c1-487e6fa66f53.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -40637,7 +40637,7 @@
         },
         {
             "id": "53d49e01-782d-5aca-9cfb-a2953bfa9c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d4da83-beaf-448f-8877-9a17236cb8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d4da83-beaf-448f-8877-9a17236cb8f6.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -40672,7 +40672,7 @@
         },
         {
             "id": "abfbf57d-3256-5701-ac1e-3e4d41d8ae00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68a5679-87a1-4d35-b5ef-59c1803e43aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68a5679-87a1-4d35-b5ef-59c1803e43aa.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -40707,7 +40707,7 @@
         },
         {
             "id": "52affaaf-6849-5c23-ad59-ba3417ba0257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77ce389-1610-4122-b1a5-bbbfa7b80a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77ce389-1610-4122-b1a5-bbbfa7b80a74.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -40742,7 +40742,7 @@
         },
         {
             "id": "49c04e73-35ca-5d17-9400-56e413cb34b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c69c743-59bd-4cac-b8e7-f3424677ac57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c69c743-59bd-4cac-b8e7-f3424677ac57.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -40779,7 +40779,7 @@
         },
         {
             "id": "ce124ada-e5ed-5947-ab71-c28f762558bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac538d7-ec0c-4fca-ac97-39f14e02152e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac538d7-ec0c-4fca-ac97-39f14e02152e.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -40816,7 +40816,7 @@
         },
         {
             "id": "16d62079-8847-58cf-a032-43566bc79f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f585e6-4435-437a-98f0-b9159211067c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f585e6-4435-437a-98f0-b9159211067c.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -40849,7 +40849,7 @@
         },
         {
             "id": "9b151253-c311-5b50-a4ff-626e63be886d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464305af-870c-46b0-9962-b69b6cd5b12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464305af-870c-46b0-9962-b69b6cd5b12d.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -40883,7 +40883,7 @@
         },
         {
             "id": "b4db40dd-f1f1-50d2-9c48-76aca8b0cd1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519b3bb3-5179-4b2e-ac8f-6e594e0d09d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519b3bb3-5179-4b2e-ac8f-6e594e0d09d5.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -40920,7 +40920,7 @@
         },
         {
             "id": "538c9830-fcfb-596e-81b3-dd109c89ac23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0be6643-50dc-4916-a284-fafef1127421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0be6643-50dc-4916-a284-fafef1127421.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -40957,7 +40957,7 @@
         },
         {
             "id": "f7088618-1553-5031-bd9e-557e1df0642f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f191dfbe-31bf-4a5f-8307-4e63a9ef89b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f191dfbe-31bf-4a5f-8307-4e63a9ef89b9.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -40991,7 +40991,7 @@
         },
         {
             "id": "6fa92d5a-05c6-5e5c-917b-4dc4800cb09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40227b-8a9a-402d-bb3d-ae92b84b6951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40227b-8a9a-402d-bb3d-ae92b84b6951.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -41025,7 +41025,7 @@
         },
         {
             "id": "e0b9e822-8270-59cb-a5d4-423c3186d739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447821-caed-44f4-995f-3d120c892626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447821-caed-44f4-995f-3d120c892626.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -41062,7 +41062,7 @@
         },
         {
             "id": "979bfc0f-8106-5b86-a9f6-0f1a2b3427b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42bc75-42df-4dd0-b18d-eec5213562db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42bc75-42df-4dd0-b18d-eec5213562db.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -41096,7 +41096,7 @@
         },
         {
             "id": "754a5d42-9392-5176-95d1-d8e3ad2dc0f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88d373-04a2-4877-a01a-468f8075e4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88d373-04a2-4877-a01a-468f8075e4d9.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -41130,7 +41130,7 @@
         },
         {
             "id": "a8a6a607-8cc7-5e9b-b720-910126eb9ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311ce87a-5a0f-4fa2-884c-813b71d109c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311ce87a-5a0f-4fa2-884c-813b71d109c3.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -41164,7 +41164,7 @@
         },
         {
             "id": "41aa9419-5440-5c61-9598-900084635f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09143c06-e17a-4fed-b4b1-c90773f7a32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09143c06-e17a-4fed-b4b1-c90773f7a32d.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -41198,7 +41198,7 @@
         },
         {
             "id": "a4f8ed85-9c24-581d-81a3-85a3576861d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d3a41-fe2b-459d-998b-c38a8177ba83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d3a41-fe2b-459d-998b-c38a8177ba83.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -41232,7 +41232,7 @@
         },
         {
             "id": "59c066f3-44dc-5a91-8b83-893bb3f06c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a8b62-4247-4f98-9340-ec897556e993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a8b62-4247-4f98-9340-ec897556e993.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -41266,7 +41266,7 @@
         },
         {
             "id": "b7a530ec-f048-5cf9-87eb-44764e632ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8096a898-6f78-459b-ac0a-d2fbaf50a118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8096a898-6f78-459b-ac0a-d2fbaf50a118.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -41300,7 +41300,7 @@
         },
         {
             "id": "d1dcd098-27e7-5d6f-b7f9-48f072b151a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad795109-0aaf-452c-80b4-243e8501572d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad795109-0aaf-452c-80b4-243e8501572d.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -41331,7 +41331,7 @@
         },
         {
             "id": "ade751c0-5d50-5833-a068-3d046f3db88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092fb6c6-ae24-422e-8085-3e699eb9aed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092fb6c6-ae24-422e-8085-3e699eb9aed8.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -41368,7 +41368,7 @@
         },
         {
             "id": "e49c9e42-97da-5b08-a8f6-206904c4bf5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3bd973-04c8-4890-b44b-031e46f2372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3bd973-04c8-4890-b44b-031e46f2372c.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -41402,7 +41402,7 @@
         },
         {
             "id": "d06404a4-8788-5c56-9aa7-6cd2828d9805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d947c-e4c7-409b-886e-affb1c68264d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d947c-e4c7-409b-886e-affb1c68264d.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -41436,7 +41436,7 @@
         },
         {
             "id": "d1282c34-1a3c-57a7-ad8e-e3caa2844256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90cfebc-4a26-43fa-be37-26318d5449f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90cfebc-4a26-43fa-be37-26318d5449f1.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -41470,7 +41470,7 @@
         },
         {
             "id": "460932e9-3369-57eb-8fb9-6e6cad6b2a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0c27-95f1-4425-8cc4-c287b1317119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0c27-95f1-4425-8cc4-c287b1317119.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -41504,7 +41504,7 @@
         },
         {
             "id": "81777356-aa97-5e28-80ac-46f08c007760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1799d0-0b50-480a-8f30-5936b211f904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1799d0-0b50-480a-8f30-5936b211f904.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -41538,7 +41538,7 @@
         },
         {
             "id": "6211fff2-5e5b-5558-a232-39fd6614598c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2258e2-0f03-4280-8a83-d592949d778c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2258e2-0f03-4280-8a83-d592949d778c.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -41572,7 +41572,7 @@
         },
         {
             "id": "a649050f-e5fb-5f0a-9e1d-1bec725dfe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f367f4-7389-438f-8abe-43ccb824c968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f367f4-7389-438f-8abe-43ccb824c968.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -41606,7 +41606,7 @@
         },
         {
             "id": "5f0830db-81af-5a20-929c-a7a5365b6a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96354af0-e074-4057-8224-667e7294795a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96354af0-e074-4057-8224-667e7294795a.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -41640,7 +41640,7 @@
         },
         {
             "id": "dbbacbfb-568d-51ad-b838-36a78f94ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ae31a-3109-4f55-9f2d-cccb3af5d123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ae31a-3109-4f55-9f2d-cccb3af5d123.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -41674,7 +41674,7 @@
         },
         {
             "id": "ca64a498-0013-55ce-b8d2-5a35f7037453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794ba355-7bee-4808-8161-3584e3505bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794ba355-7bee-4808-8161-3584e3505bf1.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -41711,7 +41711,7 @@
         },
         {
             "id": "532bc546-9d30-5b03-abac-3c649234b090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce1760-2325-4af1-ad70-5cf5a0781c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce1760-2325-4af1-ad70-5cf5a0781c8e.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -41745,7 +41745,7 @@
         },
         {
             "id": "edd3011d-c9c2-58f0-b648-543e5fe1ed20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f831e9ac-e10a-40bd-a7f6-4be90cc313b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f831e9ac-e10a-40bd-a7f6-4be90cc313b3.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -41779,7 +41779,7 @@
         },
         {
             "id": "fe5d456d-ff6d-5b9d-8de2-b6023f074d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c9c3c0-039e-47b7-9b88-b1114d110a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c9c3c0-039e-47b7-9b88-b1114d110a12.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -41813,7 +41813,7 @@
         },
         {
             "id": "e07bdbd0-e05e-5604-aade-1ed8cae53fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bdc124-52a8-4993-aaa5-35190e78d08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bdc124-52a8-4993-aaa5-35190e78d08b.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -41850,7 +41850,7 @@
         },
         {
             "id": "55b7aed5-45d1-57f5-91f8-f9b9a9c9379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83200ef-069f-4344-93b0-23c2eff16027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83200ef-069f-4344-93b0-23c2eff16027.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -41884,7 +41884,7 @@
         },
         {
             "id": "ae13dd1b-c4d1-5314-888f-3854ec711fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34dbf00-1f3b-4946-ae43-2c8e339d4e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34dbf00-1f3b-4946-ae43-2c8e339d4e5b.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -41918,7 +41918,7 @@
         },
         {
             "id": "5c45a43a-ae2b-55f8-b873-e6c1b6630a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c0e91b-1377-465c-a00e-4e788bbbddc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c0e91b-1377-465c-a00e-4e788bbbddc6.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -41952,7 +41952,7 @@
         },
         {
             "id": "feb1539a-f63d-56f0-ad18-11fe5116df8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffb5a5e-050e-4f2e-a671-461c9de521cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffb5a5e-050e-4f2e-a671-461c9de521cf.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -41989,7 +41989,7 @@
         },
         {
             "id": "b29f0b97-cd60-5b72-ba20-512804e228ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4328db-edfd-40c3-8b13-b97dbcdff3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4328db-edfd-40c3-8b13-b97dbcdff3c8.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -42023,7 +42023,7 @@
         },
         {
             "id": "eba20585-d4ad-52c1-9bbe-38ce4745b0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec84099-b8b4-4a3b-88f9-37fd02e848de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec84099-b8b4-4a3b-88f9-37fd02e848de.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -42060,7 +42060,7 @@
         },
         {
             "id": "f32febb4-6fef-5ef7-84ac-99d58cbad372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054022c8-0273-4853-b353-3b792e8063b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054022c8-0273-4853-b353-3b792e8063b3.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -42094,7 +42094,7 @@
         },
         {
             "id": "0f8cfb8a-55dd-5f99-8082-4bd4c63b1a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c0c7aa-d060-4ad7-8a6a-fcfe5f8e010e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c0c7aa-d060-4ad7-8a6a-fcfe5f8e010e.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -42128,7 +42128,7 @@
         },
         {
             "id": "82a92042-8182-5ce3-b99d-59e327284572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc8ec97-5a84-4111-8f7e-fc9687532080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc8ec97-5a84-4111-8f7e-fc9687532080.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -42165,7 +42165,7 @@
         },
         {
             "id": "7aa7495d-4dec-57c6-966c-20629a10e7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a366b83d-ce0a-4916-a9da-73bb6aa4f101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a366b83d-ce0a-4916-a9da-73bb6aa4f101.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -42199,7 +42199,7 @@
         },
         {
             "id": "934cbedf-8da9-5ca2-9794-72e48db5bb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5b4e01-313c-4560-bc29-64f3169eab91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5b4e01-313c-4560-bc29-64f3169eab91.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -42233,7 +42233,7 @@
         },
         {
             "id": "6b71a06f-9224-5a28-b555-c13c48a2b0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70ac99-1c83-4155-9854-5e666e8f8b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70ac99-1c83-4155-9854-5e666e8f8b09.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -42267,7 +42267,7 @@
         },
         {
             "id": "1207dcf5-9433-592b-b354-ab14b1426610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e711b70e-4b8c-4cd7-8ad6-e543e3301a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e711b70e-4b8c-4cd7-8ad6-e543e3301a65.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -42301,7 +42301,7 @@
         },
         {
             "id": "1d732491-ff55-589d-bcca-6e6051a4f6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb058da2-150c-435c-ba4b-2c668b588c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb058da2-150c-435c-ba4b-2c668b588c5a.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -42338,7 +42338,7 @@
         },
         {
             "id": "8685acd6-d905-543f-9655-4eccb130febe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f94647-cd6c-4ac7-87fb-e5a6e646fe09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f94647-cd6c-4ac7-87fb-e5a6e646fe09.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -42372,7 +42372,7 @@
         },
         {
             "id": "1df87f93-d0a5-5312-984f-adb13fc40e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71051848-3983-462a-8189-aff8c56f163f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71051848-3983-462a-8189-aff8c56f163f.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -42406,7 +42406,7 @@
         },
         {
             "id": "fbf9e855-0f2b-544c-8b76-29aaca31b8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cd8dc-9ea0-48d6-8723-0cfd43eca60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cd8dc-9ea0-48d6-8723-0cfd43eca60d.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -42440,7 +42440,7 @@
         },
         {
             "id": "b9aab5d9-4d47-509d-97b0-5a529f128efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6632dc47-5fe4-4527-9c31-9f81c27c8840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6632dc47-5fe4-4527-9c31-9f81c27c8840.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -42474,7 +42474,7 @@
         },
         {
             "id": "af0e33ac-143f-5e24-9d22-ad595355896b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b683c2a-edf4-49d7-8de8-f9f33b2d4d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b683c2a-edf4-49d7-8de8-f9f33b2d4d5a.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -42508,7 +42508,7 @@
         },
         {
             "id": "52b6db86-e617-5a80-9fb7-f1c6f42ddfd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d09204-e1f0-438a-9c74-b703fef96e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d09204-e1f0-438a-9c74-b703fef96e4a.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -42542,7 +42542,7 @@
         },
         {
             "id": "c432fc39-9ce8-5405-83f3-c9ea861af38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f65fd-645a-4869-8852-2a1183aa0c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f65fd-645a-4869-8852-2a1183aa0c04.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -42576,7 +42576,7 @@
         },
         {
             "id": "86da52b4-15ff-5900-84eb-56cffc289d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2255311-0e94-4d29-b5ee-78a7fa530fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2255311-0e94-4d29-b5ee-78a7fa530fc1.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -42610,7 +42610,7 @@
         },
         {
             "id": "6f56137d-b400-54ab-aacd-c45d61704ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90b10f7-474d-4947-aec9-ac4196a84a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90b10f7-474d-4947-aec9-ac4196a84a35.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -42641,7 +42641,7 @@
         },
         {
             "id": "d37db091-c0af-5280-9bc9-2f9599142e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707d0e5-41b6-4c8b-9ef1-dc7ac0084ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707d0e5-41b6-4c8b-9ef1-dc7ac0084ddb.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -42675,7 +42675,7 @@
         },
         {
             "id": "2483d66b-fe70-56da-84c4-8cdfd9d118d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb05a447-fe4f-4eec-81ef-2dcd171ef3c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb05a447-fe4f-4eec-81ef-2dcd171ef3c1.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -42706,7 +42706,7 @@
         },
         {
             "id": "3cc39a79-34aa-523c-a8fa-526188103423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f5b07-0507-4dfd-b5b6-6a032e76e4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f5b07-0507-4dfd-b5b6-6a032e76e4fd.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -42740,7 +42740,7 @@
         },
         {
             "id": "de207c52-cef8-59a0-834a-6436450f0a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ca7fac-d0df-4d96-887f-16be6c995476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ca7fac-d0df-4d96-887f-16be6c995476.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -42781,7 +42781,7 @@
         },
         {
             "id": "f1a18c25-78df-5986-9ab1-7579c86ee7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba416ffc-dea7-4272-b391-c66540031366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba416ffc-dea7-4272-b391-c66540031366.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -42823,7 +42823,7 @@
         },
         {
             "id": "ec43d1a8-1794-5d8b-865f-eea39097c001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ab508a-db3d-42d1-885a-d49fa751dc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ab508a-db3d-42d1-885a-d49fa751dc18.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -42866,7 +42866,7 @@
         },
         {
             "id": "aac50a26-8bb2-5c0f-aa73-11cbdd7f8ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cc9021-db64-439a-8c6c-4ed36a8cd9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cc9021-db64-439a-8c6c-4ed36a8cd9c0.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -42904,7 +42904,7 @@
         },
         {
             "id": "cd4f81e5-04e7-510b-be60-34012dc08ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59e33ae-598c-44d3-89bc-b773ceade7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59e33ae-598c-44d3-89bc-b773ceade7c7.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -42946,7 +42946,7 @@
         },
         {
             "id": "26d54a9a-bee2-5a8e-845c-aed0c060990d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6356a904-0510-4652-b054-b116c0708f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6356a904-0510-4652-b054-b116c0708f58.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -42994,7 +42994,7 @@
         },
         {
             "id": "7e5c0723-15fb-5b04-b04b-300ad02e4b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdba5b9-235c-411b-b031-7f6ff5368158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdba5b9-235c-411b-b031-7f6ff5368158.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -43038,7 +43038,7 @@
         },
         {
             "id": "48baa900-8f48-5155-bc1b-e56b96e3d68d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee2efd-a295-411c-8291-18f5ea13a387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee2efd-a295-411c-8291-18f5ea13a387.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -43082,7 +43082,7 @@
         },
         {
             "id": "26675346-5dc5-50a3-8559-baf2fef95e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d458bd-ac12-4980-85d5-81cfb2a105e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d458bd-ac12-4980-85d5-81cfb2a105e9.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -43126,7 +43126,7 @@
         },
         {
             "id": "b7ab1fdc-86e9-57a4-aad5-f7e683c9823c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f0ce15-bf8a-4212-b196-a1b601222ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f0ce15-bf8a-4212-b196-a1b601222ab6.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -43170,7 +43170,7 @@
         },
         {
             "id": "613688d9-7d38-5ed2-96cd-3d6463af3223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198c8bec-d484-42cb-8950-221138e17960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198c8bec-d484-42cb-8950-221138e17960.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -43214,7 +43214,7 @@
         },
         {
             "id": "c912907a-6b21-582e-b426-5df0984c39b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77d817b-b4af-451b-9c5b-8df59b1b4d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77d817b-b4af-451b-9c5b-8df59b1b4d81.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -43260,7 +43260,7 @@
         },
         {
             "id": "e92a6f94-b580-5c61-8377-802d6ced4070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d064ea-85c8-4daa-8ee2-ccde9bb84115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d064ea-85c8-4daa-8ee2-ccde9bb84115.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -43305,7 +43305,7 @@
         },
         {
             "id": "a34ab002-f665-538e-ae97-590453128f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a42c16-ce18-47f5-8b57-00740b1fa0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a42c16-ce18-47f5-8b57-00740b1fa0c1.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -43349,7 +43349,7 @@
         },
         {
             "id": "25e860d0-2545-53be-af71-1224999047c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b95a3-efdd-4437-8a22-2f19b44cf9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b95a3-efdd-4437-8a22-2f19b44cf9a7.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -43392,7 +43392,7 @@
         },
         {
             "id": "69a4d675-d68a-5265-aefb-edd32f10faea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fad0f5-37ed-456b-bc17-7a7739f5c01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fad0f5-37ed-456b-bc17-7a7739f5c01b.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -43426,7 +43426,7 @@
         },
         {
             "id": "c0f10bd2-511f-5c2d-a1a3-3fd6d422d4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694373e5-91f4-4092-a05d-ab721a9d633a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694373e5-91f4-4092-a05d-ab721a9d633a.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -43459,7 +43459,7 @@
         },
         {
             "id": "da0aa706-4e37-5b80-bd96-2c393ebae574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4462460-caf0-4795-a60a-72fa877fd9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4462460-caf0-4795-a60a-72fa877fd9b8.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -43504,7 +43504,7 @@
         },
         {
             "id": "9b5ec2d9-2761-5488-adf7-6a61b0bc6ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ceb335-50fa-406b-a681-b4afae6a531b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ceb335-50fa-406b-a681-b4afae6a531b.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -43549,7 +43549,7 @@
         },
         {
             "id": "a384d205-cd24-5831-81be-71bc539a936d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d25476-cab1-4035-843f-19da73c4dac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d25476-cab1-4035-843f-19da73c4dac7.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -43594,7 +43594,7 @@
         },
         {
             "id": "524b1c44-1e58-5f85-a116-c3d5c1ec63d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0292a859-79b4-46ae-b2fe-293dae5cba7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0292a859-79b4-46ae-b2fe-293dae5cba7a.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -43640,7 +43640,7 @@
         },
         {
             "id": "e1e7d62e-6919-5d5d-a857-59a7fdfb4cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a035cc61-591f-4742-a4ec-0d07e5b4e74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a035cc61-591f-4742-a4ec-0d07e5b4e74e.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -43685,7 +43685,7 @@
         },
         {
             "id": "6531091b-6f62-549e-abdd-d4bfc8c9a6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be3c60-cd96-49d2-bc4f-8072c981e456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be3c60-cd96-49d2-bc4f-8072c981e456.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -43730,7 +43730,7 @@
         },
         {
             "id": "310ce04c-7aee-58fc-892e-7e76be942dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce91239-0003-4e77-91af-a00eab10e98c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce91239-0003-4e77-91af-a00eab10e98c.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -43775,7 +43775,7 @@
         },
         {
             "id": "fd4ee443-045b-5936-b0c2-26583b78af45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b8e37e-85ac-4682-b2d9-3fdec751f9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b8e37e-85ac-4682-b2d9-3fdec751f9bc.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -43820,7 +43820,7 @@
         },
         {
             "id": "c2b580ea-550c-5df5-8867-2acd40e225eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f0779c-7d8f-438a-949f-fde3e0bac7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f0779c-7d8f-438a-949f-fde3e0bac7a2.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -43865,7 +43865,7 @@
         },
         {
             "id": "78c24e6f-c5a8-5641-bc78-1509e4548d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503b89a5-d8cc-47c7-87f7-0c4a72508447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503b89a5-d8cc-47c7-87f7-0c4a72508447.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -43911,7 +43911,7 @@
         },
         {
             "id": "b5b6ad28-b8eb-5694-8523-096083dc84a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e2ffe-3d90-4e8f-bf62-c5c382dfffc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e2ffe-3d90-4e8f-bf62-c5c382dfffc5.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -43956,7 +43956,7 @@
         },
         {
             "id": "01f17da9-5d96-52cf-838a-dd2b13c93deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba997437-76f0-4a96-9628-31b283bc292d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba997437-76f0-4a96-9628-31b283bc292d.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -44001,7 +44001,7 @@
         },
         {
             "id": "882be6aa-fac2-52b8-9b47-a0980d475a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698cc758-f0bc-4e09-9845-baa460bb1364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698cc758-f0bc-4e09-9845-baa460bb1364.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -44047,7 +44047,7 @@
         },
         {
             "id": "4912ba49-ee69-5cc2-be16-cacf6cf9b3bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a95b348-a12e-4ed6-9e95-00bc8ef03982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a95b348-a12e-4ed6-9e95-00bc8ef03982.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44084,7 +44084,7 @@
         },
         {
             "id": "acb82f79-c4e5-5194-9027-18972bb4a04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2da8374-7e37-49cd-affa-14cfafd12822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2da8374-7e37-49cd-affa-14cfafd12822.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44121,7 +44121,7 @@
         },
         {
             "id": "5cb9febb-4523-5d55-ada8-ba7e88e8d58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96b4124-ebc2-443c-981d-9869b5a3fcf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96b4124-ebc2-443c-981d-9869b5a3fcf3.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -44158,7 +44158,7 @@
         },
         {
             "id": "5ee757a0-a87b-51f0-97e4-9127e4a322d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda6712-1730-48a0-b86d-2e7765e3db74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda6712-1730-48a0-b86d-2e7765e3db74.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -44195,7 +44195,7 @@
         },
         {
             "id": "8ae2713d-882a-5db3-969b-739c753bcc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dec693-a086-4a6b-8af9-a67ee093719a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dec693-a086-4a6b-8af9-a67ee093719a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -44232,7 +44232,7 @@
         },
         {
             "id": "7c1715e8-85fc-5bf1-9a58-f3b6188384b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df93f14-494f-4051-8a55-8d23eb2fc012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df93f14-494f-4051-8a55-8d23eb2fc012.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -44269,7 +44269,7 @@
         },
         {
             "id": "95afeb32-a382-579b-9df6-2232d7b2a53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4038773a-2fa6-47c3-8064-fb49da90816c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4038773a-2fa6-47c3-8064-fb49da90816c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -44306,7 +44306,7 @@
         },
         {
             "id": "64677110-701f-5f26-a68a-189337480b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b8829d-7ac3-4563-8c3e-959c660dbe32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b8829d-7ac3-4563-8c3e-959c660dbe32.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -44343,7 +44343,7 @@
         },
         {
             "id": "325ed4ef-fe13-5cfa-b1a8-b211aec496a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8d9bd-b8c0-4628-bb19-6867336df7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8d9bd-b8c0-4628-bb19-6867336df7a8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -44380,7 +44380,7 @@
         },
         {
             "id": "fcd17bcf-4bc8-553a-8673-93f2f855122a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0230af7-0edf-4f76-af57-44cd4ebad552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0230af7-0edf-4f76-af57-44cd4ebad552.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -44417,7 +44417,7 @@
         },
         {
             "id": "8244ce5a-599a-573d-a0ad-5a6d96e2ddf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd96dce-0cc4-4417-bec1-863b2c44f844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd96dce-0cc4-4417-bec1-863b2c44f844.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -44445,7 +44445,7 @@
         },
         {
             "id": "df497901-ee26-5687-8569-c236ec3346b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92520769-1e59-45d0-bfe9-cbaf80a4591e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92520769-1e59-45d0-bfe9-cbaf80a4591e.jpg?1",
             "name": "Alien",
             "text": "",
             "colours": [
@@ -44480,7 +44480,7 @@
         },
         {
             "id": "b367754a-d8af-568a-8b47-3719214c2ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68243f3e-c311-47cf-b1f4-583625919a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68243f3e-c311-47cf-b1f4-583625919a2c.jpg?1",
             "name": "Alien Rhino",
             "text": "",
             "colours": [
@@ -44516,7 +44516,7 @@
         },
         {
             "id": "18bca77f-d2a0-501b-a469-d8475badfa6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e29c393-6d89-481d-8f33-19c61c46621a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e29c393-6d89-481d-8f33-19c61c46621a.jpg?1",
             "name": "Horse",
             "text": "",
             "colours": [
@@ -44551,7 +44551,7 @@
         },
         {
             "id": "fc618d70-fe8c-5bf4-9437-bf88e1f700af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ed2bb3-93b9-43a3-8b4a-97dc746f3d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ed2bb3-93b9-43a3-8b4a-97dc746f3d2b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -44586,7 +44586,7 @@
         },
         {
             "id": "e60475cd-0dbe-5a46-b363-d2cd6b6f3f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abaff2e5-32b2-404b-a4a9-2612062f6499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abaff2e5-32b2-404b-a4a9-2612062f6499.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -44621,7 +44621,7 @@
         },
         {
             "id": "ae65b9f8-8811-55d8-b44f-7eb7939047d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1bb221-bf45-4ce2-b38e-b121859235ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1bb221-bf45-4ce2-b38e-b121859235ad.jpg?1",
             "name": "Human Noble",
             "text": "",
             "colours": [
@@ -44657,7 +44657,7 @@
         },
         {
             "id": "3459327e-38e0-52c6-a20d-8c866d674693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2a3ff-a2f6-40c1-a246-0041c6145fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2a3ff-a2f6-40c1-a246-0041c6145fc0.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -44692,7 +44692,7 @@
         },
         {
             "id": "1dcfdfd8-836b-5bfd-9dd7-0b9f5809cbac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41567b9a-80cf-44fc-9c82-5a5f95014428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41567b9a-80cf-44fc-9c82-5a5f95014428.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -44727,7 +44727,7 @@
         },
         {
             "id": "0efae50b-9876-5264-bd35-1504d8e5f345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297fc694-08f6-4477-b898-60ec641a0757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297fc694-08f6-4477-b898-60ec641a0757.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -44762,7 +44762,7 @@
         },
         {
             "id": "8edcf37f-13f9-578d-9ccf-d137455f0d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65e872a-ba16-4df2-9214-60019fd6456a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65e872a-ba16-4df2-9214-60019fd6456a.jpg?1",
             "name": "Alien Angel",
             "text": "",
             "colours": [
@@ -44799,7 +44799,7 @@
         },
         {
             "id": "128d056e-eddd-5133-9652-b9e059c22d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f176f6ec-1ff8-4cd4-b7a6-b95830532f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f176f6ec-1ff8-4cd4-b7a6-b95830532f6a.jpg?1",
             "name": "Dalek",
             "text": "",
             "colours": [
@@ -44835,7 +44835,7 @@
         },
         {
             "id": "16528ba1-8ff5-5249-9cc0-7aa74d1e08e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b8e1c-ea36-4b5a-91a0-a15d109cc25a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b8e1c-ea36-4b5a-91a0-a15d109cc25a.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -44871,7 +44871,7 @@
         },
         {
             "id": "670f1571-ba7b-58bb-847f-525055b82c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6155e7ce-3e8c-4bb3-941d-dac686d4eb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6155e7ce-3e8c-4bb3-941d-dac686d4eb57.jpg?1",
             "name": "Alien Warrior",
             "text": "",
             "colours": [
@@ -44907,7 +44907,7 @@
         },
         {
             "id": "834e89d7-fa9d-5f99-9226-e87ff3b652fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c1206-c36f-4fb4-9014-e8a822c97085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c1206-c36f-4fb4-9014-e8a822c97085.jpg?1",
             "name": "Mark of the Rani",
             "text": "",
             "colours": [
@@ -44942,7 +44942,7 @@
         },
         {
             "id": "40c852ca-959e-5bc7-9e71-a4b2ee1468bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45133d-ce37-42b4-b068-fbcc8be0e907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45133d-ce37-42b4-b068-fbcc8be0e907.jpg?1",
             "name": "Alien Salamander",
             "text": "",
             "colours": [
@@ -44978,7 +44978,7 @@
         },
         {
             "id": "8f74eb21-8ace-5fc6-9aa1-9eac3d061ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf1eac-279f-4264-93f6-9058a6a83d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf1eac-279f-4264-93f6-9058a6a83d0a.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -45013,7 +45013,7 @@
         },
         {
             "id": "733c6587-68fd-5dcb-9823-933a18a13dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa61fa5-f0ca-4933-ac57-9db95f891889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa61fa5-f0ca-4933-ac57-9db95f891889.jpg?1",
             "name": "Mutant",
             "text": "",
             "colours": [
@@ -45048,7 +45048,7 @@
         },
         {
             "id": "ab863556-b4e5-5b95-9cde-267027545314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609bcaff-c903-40ce-9b3e-bb7b07bb9125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609bcaff-c903-40ce-9b3e-bb7b07bb9125.jpg?1",
             "name": "Alien Insect",
             "text": "",
             "colours": [
@@ -45086,7 +45086,7 @@
         },
         {
             "id": "1eedd8ec-5ea2-52c5-887c-337040311ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890d9d05-3be1-467c-9b6f-a2fd9f907657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890d9d05-3be1-467c-9b6f-a2fd9f907657.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -45123,7 +45123,7 @@
         },
         {
             "id": "4070e76d-b950-57a8-8b4c-0a6327b221eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008f776f-c7ce-47ed-bc04-2ab9f9bcd8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008f776f-c7ce-47ed-bc04-2ab9f9bcd8ae.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -45154,7 +45154,7 @@
         },
         {
             "id": "e6488883-6375-5415-8ec0-aec7307d6feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de94d6e-2c7c-46d8-897d-4f0e56cc583b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de94d6e-2c7c-46d8-897d-4f0e56cc583b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -45185,7 +45185,7 @@
         },
         {
             "id": "e3caf8d3-4c7a-5aa7-9154-e701ded8b984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5cf37-da4d-481f-a7d6-975a05798201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5cf37-da4d-481f-a7d6-975a05798201.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -45216,7 +45216,7 @@
         },
         {
             "id": "f632859f-fb8c-5d4b-a02e-14c7ce32d46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc273b8-05bb-4c8f-92b1-c178d4bbadb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc273b8-05bb-4c8f-92b1-c178d4bbadb0.jpg?1",
             "name": "Cyberman",
             "text": "",
             "colours": [],
@@ -45247,7 +45247,7 @@
         },
         {
             "id": "ff16f71d-c50b-5929-86bc-bb7467c399ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a8ba9-6a3c-4f3b-876e-ec47a08dbb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a8ba9-6a3c-4f3b-876e-ec47a08dbb8a.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -45278,7 +45278,7 @@
         },
         {
             "id": "95cccd10-bb21-5afa-a2c3-8b6d68f48f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a31a8f-5576-4ab7-bc3b-778a252d4c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a31a8f-5576-4ab7-bc3b-778a252d4c10.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -45309,7 +45309,7 @@
         },
         {
             "id": "94866a37-6db0-5be1-9d44-fb38145a6979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1660fd-ef35-4b95-b901-af3dda687f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1660fd-ef35-4b95-b901-af3dda687f08.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -45340,7 +45340,7 @@
         },
         {
             "id": "5c61ec07-6ebc-51ec-bd6c-f909ec6ebbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38144274-f5c9-4276-b63e-a3c32aec971e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38144274-f5c9-4276-b63e-a3c32aec971e.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45371,7 +45371,7 @@
         },
         {
             "id": "1bd4264f-22b6-5b3d-9ffe-05d33718dfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ce40c-0744-4976-9855-b7a7b08fdac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ce40c-0744-4976-9855-b7a7b08fdac4.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45402,7 +45402,7 @@
         },
         {
             "id": "55ca5784-6689-582a-a7e8-06a663f42fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64159e56-a781-416d-a071-41a7b0c8263b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64159e56-a781-416d-a071-41a7b0c8263b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45433,7 +45433,7 @@
         },
         {
             "id": "91c7ddb5-749c-5fcd-acbe-aa3ab3417f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77825935-2f71-4bd1-8ec7-9e8be26853c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77825935-2f71-4bd1-8ec7-9e8be26853c0.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45464,7 +45464,7 @@
         },
         {
             "id": "1378472c-7518-5091-af60-d40f3c7f664b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d0482-c747-4eca-947b-9af1a2cc9b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d0482-c747-4eca-947b-9af1a2cc9b29.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -45501,7 +45501,7 @@
         },
         {
             "id": "553b5e02-de02-59fb-9901-28d367ab1c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d9dfbb-1bd8-4e7b-9945-498fde093d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d9dfbb-1bd8-4e7b-9945-498fde093d6c.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -45528,7 +45528,7 @@
         },
         {
             "id": "b7e1f480-5560-5f11-8f61-3c9b1cc963fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce150eb-7d3d-4882-8e1a-2eafe9d9b356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce150eb-7d3d-4882-8e1a-2eafe9d9b356.jpg?1",
             "name": "Alien",
             "text": "",
             "colours": [
@@ -45562,7 +45562,7 @@
         },
         {
             "id": "bc5e5622-5b3f-5857-b5ef-204dd83e196b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28cb34f-04c3-4cb8-9d4c-90c98b11bfe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28cb34f-04c3-4cb8-9d4c-90c98b11bfe3.jpg?1",
             "name": "Alien Rhino",
             "text": "",
             "colours": [
@@ -45597,7 +45597,7 @@
         },
         {
             "id": "ed01af5a-fc62-57b3-bf96-e73e9829883b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea25527-2c98-4c6b-ac1c-cabf69fda851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea25527-2c98-4c6b-ac1c-cabf69fda851.jpg?1",
             "name": "Horse",
             "text": "",
             "colours": [
@@ -45631,7 +45631,7 @@
         },
         {
             "id": "824e4285-56ea-5d9f-9db2-48a34f3fddd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe939f-c680-403f-a5be-0f0cca020ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe939f-c680-403f-a5be-0f0cca020ef2.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -45665,7 +45665,7 @@
         },
         {
             "id": "08e6cdff-da21-5a62-b87d-d80eaa6703dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b58706-9140-4908-b613-702e607b7d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b58706-9140-4908-b613-702e607b7d8b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -45699,7 +45699,7 @@
         },
         {
             "id": "1407fe64-0a46-5d5f-85d3-6ab80374df0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207efdc-c416-4918-80d9-8b18905eaa90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207efdc-c416-4918-80d9-8b18905eaa90.jpg?1",
             "name": "Human Noble",
             "text": "",
             "colours": [
@@ -45734,7 +45734,7 @@
         },
         {
             "id": "03c72458-0406-598c-953f-8f204503744c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c10957-0b04-4a7b-879f-76d70f023818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c10957-0b04-4a7b-879f-76d70f023818.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -45768,7 +45768,7 @@
         },
         {
             "id": "c0907e3c-e290-5768-b885-6bc88459ecdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b566e0d-5680-4b06-8360-b722beedef2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b566e0d-5680-4b06-8360-b722beedef2e.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -45802,7 +45802,7 @@
         },
         {
             "id": "a1b995bd-aec0-5b7f-8db9-65b77d465558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779b2dbe-70d9-4690-b05e-e828197f3afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779b2dbe-70d9-4690-b05e-e828197f3afa.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -45836,7 +45836,7 @@
         },
         {
             "id": "07ba385a-72ad-50a1-935c-9e1717f565b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d928b9e7-2b21-4fd3-bb33-d69c0e91b415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d928b9e7-2b21-4fd3-bb33-d69c0e91b415.jpg?1",
             "name": "Alien Angel",
             "text": "",
             "colours": [
@@ -45872,7 +45872,7 @@
         },
         {
             "id": "f50201d6-3e20-541a-89c9-b44ceaf4c0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde90b3-cd39-4ac5-b326-9ecc3d7d0d04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde90b3-cd39-4ac5-b326-9ecc3d7d0d04.jpg?1",
             "name": "Dalek",
             "text": "",
             "colours": [
@@ -45907,7 +45907,7 @@
         },
         {
             "id": "1f5fc2a7-0ac2-5e82-b473-688241c0a5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578a760b-26c7-4cbb-892a-7d8f2a92ece3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578a760b-26c7-4cbb-892a-7d8f2a92ece3.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -45942,7 +45942,7 @@
         },
         {
             "id": "64f5b6ae-4946-576c-bdf9-545659758984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba581b6-1866-4f5c-9785-98a14ec84ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba581b6-1866-4f5c-9785-98a14ec84ebc.jpg?1",
             "name": "Alien Warrior",
             "text": "",
             "colours": [
@@ -45977,7 +45977,7 @@
         },
         {
             "id": "503c446b-a8f5-5791-a42e-4dd984bed366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da780e8b-55a9-4fbe-b37f-b7b9043f9cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da780e8b-55a9-4fbe-b37f-b7b9043f9cdf.jpg?1",
             "name": "Mark of the Rani",
             "text": "",
             "colours": [
@@ -46011,7 +46011,7 @@
         },
         {
             "id": "a0b261b5-37b1-5fe4-85e5-c8f2bd31be21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f247c-edb7-438a-b004-be3d4fcd3d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f247c-edb7-438a-b004-be3d4fcd3d3f.jpg?1",
             "name": "Alien Salamander",
             "text": "",
             "colours": [
@@ -46046,7 +46046,7 @@
         },
         {
             "id": "5ba0df90-4985-53bf-9118-fbd40384d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0375ff38-d2db-4866-a979-3fe94b286405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0375ff38-d2db-4866-a979-3fe94b286405.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -46080,7 +46080,7 @@
         },
         {
             "id": "3f5e883a-baaf-58ec-9f48-a8e8af76dbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4fa4c-b68c-406c-80af-97257518a884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4fa4c-b68c-406c-80af-97257518a884.jpg?1",
             "name": "Mutant",
             "text": "",
             "colours": [
@@ -46114,7 +46114,7 @@
         },
         {
             "id": "8febb223-d127-5c7e-8584-2b9bef54942e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832e03c-111a-409e-a88c-6edbb528a239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832e03c-111a-409e-a88c-6edbb528a239.jpg?1",
             "name": "Alien Insect",
             "text": "",
             "colours": [
@@ -46151,7 +46151,7 @@
         },
         {
             "id": "1d186e0e-3028-52e1-8537-d1c52575e57c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406b2d4-d227-4b03-801f-38230161c708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406b2d4-d227-4b03-801f-38230161c708.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -46187,7 +46187,7 @@
         },
         {
             "id": "16b5f074-63da-51a6-bc86-5da72774d0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad1e6e0-c2e6-4a03-9ee0-a3643801e7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad1e6e0-c2e6-4a03-9ee0-a3643801e7c8.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -46217,7 +46217,7 @@
         },
         {
             "id": "33138258-8135-5875-ba96-57a1cebaf1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa00d7c-359c-4c80-9d71-f9e39e87829b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa00d7c-359c-4c80-9d71-f9e39e87829b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -46247,7 +46247,7 @@
         },
         {
             "id": "915356b7-202a-5619-b003-e613d245d5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145be5c-62f5-43ef-8dea-3a1e85ad9b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145be5c-62f5-43ef-8dea-3a1e85ad9b72.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -46277,7 +46277,7 @@
         },
         {
             "id": "52622c86-375f-5342-963b-e5cdac14f354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392db1d2-9d75-4d19-88e0-9b0ffdc88541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392db1d2-9d75-4d19-88e0-9b0ffdc88541.jpg?1",
             "name": "Cyberman",
             "text": "",
             "colours": [],
@@ -46307,7 +46307,7 @@
         },
         {
             "id": "b9848bcd-fba3-5290-bfcc-15b590061511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7db322-83fb-49ae-bb03-509d516adc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7db322-83fb-49ae-bb03-509d516adc12.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -46337,7 +46337,7 @@
         },
         {
             "id": "fbe51736-4f09-5854-ab11-d7e15b141a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36bd92-5cec-46a5-9ab3-ce4c81574770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36bd92-5cec-46a5-9ab3-ce4c81574770.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -46367,7 +46367,7 @@
         },
         {
             "id": "e5a3f019-74a1-5996-91b2-3e8750cf0841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be99852d-54f7-42bd-b2a2-e123302650eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be99852d-54f7-42bd-b2a2-e123302650eb.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -46397,7 +46397,7 @@
         },
         {
             "id": "fb19c769-de84-5f88-ae6c-fdbb80a5cf48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4656467d-947e-43cd-81cb-19ebd504d156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4656467d-947e-43cd-81cb-19ebd504d156.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46427,7 +46427,7 @@
         },
         {
             "id": "feaa3126-d549-54f5-b99c-222e4b3606f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7db254-48c7-4870-b060-70050908abff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7db254-48c7-4870-b060-70050908abff.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46457,7 +46457,7 @@
         },
         {
             "id": "3a44cd3e-fe02-5af3-b1e6-281027660e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1e7e9c-cd70-40a6-a0cd-8dbd5db23d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1e7e9c-cd70-40a6-a0cd-8dbd5db23d06.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46487,7 +46487,7 @@
         },
         {
             "id": "4f5f8c15-0464-5138-a9b6-07a65429f4f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31e197-a322-4310-95a9-67f806f904a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31e197-a322-4310-95a9-67f806f904a6.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46517,7 +46517,7 @@
         },
         {
             "id": "0a02e8fd-b70d-544d-a438-64d5f72cbba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c9567-4e2a-4537-b391-5ce509f34382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c9567-4e2a-4537-b391-5ce509f34382.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/WOE.json
+++ b/Assets/Resources/Sets/WOE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ba7f1dad-ad9d-5634-b868-8c8e15c74bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1",
             "name": "Archon of the Wild Rose",
             "text": "Flying\nOther creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "3b1e5466-13eb-5d70-9226-3b0b800dbd38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71768e7-4ef7-4fb2-838b-eb3a7f662d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71768e7-4ef7-4fb2-838b-eb3a7f662d38.jpg?1",
             "name": "Archon's Glory",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTarget creature gets +2/+2 until end of turn. If this spell was bargained, that creature also gains flying and lifelink until end of turn.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "5a54f9fa-82a6-59ad-8af3-94dd74790e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b041949-6fb6-40a6-9329-f209be537219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b041949-6fb6-40a6-9329-f209be537219.jpg?1",
             "name": "Armory Mice",
             "text": "Celebration \u2014 Armory Mice gets +0/+2 as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "03c147e7-aaf5-52ac-9a9f-264bacd6f797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg?1",
             "name": "Besotted Knight // Betroth the Beast",
             "text": "",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "cd7cb0c4-f317-5f0e-9b2d-e5ac83dfb0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg?1",
             "name": "Besotted Knight // Betroth the Beast",
             "text": "Create a Royal Role token attached to target creature you control. (Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f47f48fd-5552-5ba4-8139-b25c3f8570cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7094fc0-1d26-429c-9b49-37718c4a5c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7094fc0-1d26-429c-9b49-37718c4a5c80.jpg?1",
             "name": "Break the Spell",
             "text": "Destroy target enchantment. If a permanent you controlled or a token was destroyed this way, draw a card.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "d2864645-8c0f-5442-b971-504bc426181d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994f4473-dfc9-45cd-8528-945db3aa6a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994f4473-dfc9-45cd-8528-945db3aa6a9a.jpg?1",
             "name": "Charmed Clothier",
             "text": "Flying\nWhen Charmed Clothier enters the battlefield, create a Royal Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "f923a228-3c44-5ac9-8ddb-b11d62fcb667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg?1",
             "name": "Cheeky House-Mouse // Squeak By",
             "text": "",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "8ab58188-e111-52ce-942d-0a73a47c6fef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg?1",
             "name": "Cheeky House-Mouse // Squeak By",
             "text": "Target creature you control gets +1/+1 until end of turn. It can't be blocked by creatures with power 3 or greater this turn.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "fd9017a3-a53c-5ac1-b779-fb3c9cec9725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb8758-09c5-4e19-ada1-904e36ece1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb8758-09c5-4e19-ada1-904e36ece1fc.jpg?1",
             "name": "Cooped Up",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "463e9b43-02c0-5264-be3f-6b95bf162edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2d5a71-d6e1-4c96-9a53-0e370047a56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2d5a71-d6e1-4c96-9a53-0e370047a56e.jpg?1",
             "name": "Cursed Courtier",
             "text": "Lifelink\nWhen Cursed Courtier enters the battlefield, create a Cursed Role token attached to it. (Enchanted creature is 1/1.)",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "9250b35b-016d-5e5c-9a6a-e1e79ead10e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584774b5-640f-45e0-810b-f5faf119645b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584774b5-640f-45e0-810b-f5faf119645b.jpg?1",
             "name": "Discerning Financier",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{2}{W}: Choose another player. That player gains control of target Treasure you control. You draw a card.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "ff83ed32-caa5-5e76-aec7-3154b06fe07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e40377-990f-41ea-8dd2-62a998dcd128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e40377-990f-41ea-8dd2-62a998dcd128.jpg?1",
             "name": "Dutiful Griffin",
             "text": "Flying\n{2}{W}, Sacrifice two enchantments: Return Dutiful Griffin from your graveyard to your hand.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "64210b86-3837-5114-b73d-cabffab30b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a74545-75c8-4a6b-bee1-ac5665d9bcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a74545-75c8-4a6b-bee1-ac5665d9bcf0.jpg?1",
             "name": "Eerie Interference",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn by creatures.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "1cf78934-5d8e-5d69-9a4d-d05f188b2f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1094eef0-6c57-4bfa-a584-f708b87354fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1094eef0-6c57-4bfa-a584-f708b87354fb.jpg?1",
             "name": "Expel the Interlopers",
             "text": "Choose a number between 0 and 10. Destroy all creatures with power greater than or equal to the chosen number.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "8eb00e55-c619-5986-9c35-35c164a3d7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dec431-a20e-4c1c-9855-904779756509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dec431-a20e-4c1c-9855-904779756509.jpg?1",
             "name": "Frostbridge Guard",
             "text": "{2}{W}, {T}: Tap target creature.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "a488b25b-4576-5ed4-a801-574f8210b27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053d330-d0a2-4468-afba-42bf165b8fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053d330-d0a2-4468-afba-42bf165b8fbf.jpg?1",
             "name": "Gallant Pie-Wielder",
             "text": "First strike\nCelebration \u2014 Gallant Pie-Wielder has double strike as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "67d666a3-1b95-57d3-b1d4-50d8bc63a9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c5c395-ee8b-47fd-ac52-256354c19cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c5c395-ee8b-47fd-ac52-256354c19cdf.jpg?1",
             "name": "Glass Casket",
             "text": "When Glass Casket enters the battlefield, exile target creature an opponent controls with mana value 3 or less until Glass Casket leaves the battlefield.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "6ea683dc-eacb-5080-a215-18ab8440aa17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382fd32-b1f5-4ec7-9d42-fc2915ed3bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382fd32-b1f5-4ec7-9d42-fc2915ed3bc9.jpg?1",
             "name": "Hopeful Vigil",
             "text": "When Hopeful Vigil enters the battlefield, create a 2/2 white Knight creature token with vigilance.\nWhen Hopeful Vigil is put into a graveyard from the battlefield, scry 2.\n{2}{W}: Sacrifice Hopeful Vigil.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "3cab7d98-fa65-5def-95ea-063a6a46223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc727a6-f875-49b1-b7a4-67f22fbc3d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc727a6-f875-49b1-b7a4-67f22fbc3d50.jpg?1",
             "name": "Kellan's Lightblades",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nKellan's Lightblades deals 3 damage to target attacking or blocking creature. If this spell was bargained, destroy that creature instead.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "30aa1b7d-3a65-5799-95a6-ef4cf3aa3026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f33617-ad19-4d42-ab94-6f21a7fb3dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f33617-ad19-4d42-ab94-6f21a7fb3dd4.jpg?1",
             "name": "Knight of Doves",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "03fcd050-09df-5444-a3fa-26aa4663d120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f257fd6-24a4-4cc1-89e0-99cf5d821e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f257fd6-24a4-4cc1-89e0-99cf5d821e3a.jpg?1",
             "name": "Moment of Valor",
             "text": "Choose one \u2014\n\u2022 Untap target creature. It gets +1/+0 and gains indestructible until end of turn.\n\u2022 Destroy target creature with power 4 or greater.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "0fcec908-a1cf-59f7-9547-8b91beb02908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092c48bd-b648-4c9e-aa99-cac3c407911d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092c48bd-b648-4c9e-aa99-cac3c407911d.jpg?1",
             "name": "Moonshaker Cavalry",
             "text": "Flying\nWhen Moonshaker Cavalry enters the battlefield, creatures you control gain flying and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "e04e83e1-f258-5983-8e19-e78873c45bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4aceba-f386-457c-bc68-6382eda46754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4aceba-f386-457c-bc68-6382eda46754.jpg?1",
             "name": "Plunge into Winter",
             "text": "Tap up to one target creature. Scry 1, then draw a card.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "6b7b537f-6330-5d27-a9ec-102fee17a362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad7bd06-22e4-40f8-bda9-bcdbb2d8f632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad7bd06-22e4-40f8-bda9-bcdbb2d8f632.jpg?1",
             "name": "The Princess Takes Flight",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile up to one target creature.\nII \u2014 Target creature you control gets +2/+2 and gains flying until end of turn.\nIII \u2014 Return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "97567c04-351a-58bf-a4b0-c8e7bbf6512a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cc9653-80ef-4606-a0ec-6d4228fdb118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cc9653-80ef-4606-a0ec-6d4228fdb118.jpg?1",
             "name": "Protective Parents",
             "text": "When Protective Parents dies, create a Young Hero Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "d70bc68c-ab73-5bf9-a2e1-e5e7dd4b0288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg?1",
             "name": "Regal Bunnicorn",
             "text": "Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "8962d1c7-43c7-5036-b5d3-83c8c86733b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5209c13-9591-48eb-8d6c-112b3bdd429a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5209c13-9591-48eb-8d6c-112b3bdd429a.jpg?1",
             "name": "Return Triumphant",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Create a Young Hero Role token attached to it. (Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\" If you put another Role on the creature later, put this one into the graveyard.)",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "5bd4ee6a-a6e1-5eff-a6f9-51da71d59541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60acc0b7-6842-44aa-a7cc-c5d315d90287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60acc0b7-6842-44aa-a7cc-c5d315d90287.jpg?1",
             "name": "Rimefur Reindeer",
             "text": "Whenever an enchantment enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "bc59a5bc-2a1e-5bdd-a7a1-322e7fc6911e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg?1",
             "name": "Savior of the Sleeping",
             "text": "Vigilance\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Savior of the Sleeping.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "b518c769-3b5e-5878-b7f3-d54950f6517d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f41ae2-ebc6-439f-95af-c34818a3f4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f41ae2-ebc6-439f-95af-c34818a3f4e6.jpg?1",
             "name": "Slumbering Keepguard",
             "text": "Whenever an enchantment enters the battlefield under your control, scry 1.\n{2}{W}: Slumbering Keepguard gets +1/+1 until end of turn for each enchantment you control.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "d49e32ee-a399-59be-87e3-9b4a0d8319b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155693c-def0-4290-b662-ab9932e07fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155693c-def0-4290-b662-ab9932e07fe5.jpg?1",
             "name": "Solitary Sanctuary",
             "text": "When Solitary Sanctuary enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "31c5bab0-394a-5f46-abe5-36e8c3da1c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ceac5b5-05eb-4f00-9477-3db490be24dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ceac5b5-05eb-4f00-9477-3db490be24dd.jpg?1",
             "name": "Spellbook Vendor",
             "text": "Vigilance\nAt the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "43ae2fba-6d21-5ea9-8681-9c86a3445ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0214ebc6-c59f-4170-8dd2-ce07caa6e6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0214ebc6-c59f-4170-8dd2-ce07caa6e6ad.jpg?1",
             "name": "Stockpiling Celebrant",
             "text": "When Stockpiling Celebrant enters the battlefield, you may return another target nonland permanent you control to its owner's hand. If you do, scry 2.",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "3f0293de-14f8-5256-acf2-788e35944c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289ba7ec-e30e-436f-b8d4-c88b65ecd137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289ba7ec-e30e-436f-b8d4-c88b65ecd137.jpg?1",
             "name": "Stroke of Midnight",
             "text": "Destroy target nonland permanent. Its controller creates a 1/1 white Human creature token.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "0dca050f-64cb-5f0a-a515-f431d95f7249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg?1",
             "name": "A Tale for the Ages",
             "text": "Enchanted creatures you control get +2/+2.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "110832cc-0948-5a98-b4bc-2540e3c37f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2ba371-854c-4529-b72b-e4a1887e33ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2ba371-854c-4529-b72b-e4a1887e33ab.jpg?1",
             "name": "Three Blind Mice",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI \u2014 Create a 1/1 white Mouse creature token.\nII, III \u2014 Create a token that's a copy of target token you control.\nIV \u2014 Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "297649c5-7508-5579-91d8-1190f3838516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01334fed-781e-4864-83fd-d37f787a778b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01334fed-781e-4864-83fd-d37f787a778b.jpg?1",
             "name": "Tuinvale Guide",
             "text": "Flying\nCelebration \u2014 Tuinvale Guide gets +1/+0 and has lifelink as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "b3f6794e-4f70-5fba-973d-ea93851ba61a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66fbaeb-1624-43b3-83e2-a37ce7588a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66fbaeb-1624-43b3-83e2-a37ce7588a5a.jpg?1",
             "name": "Unassuming Sage",
             "text": "When Unassuming Sage enters the battlefield, you may pay {2}. If you do, create a Sorcerer Role token attached to it. (Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "20b7b28c-4498-5b96-afb1-6f044fe373b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control. Untap those creatures.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "71767870-dbd5-54fe-97aa-e56816c5162f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "315030cd-5e10-5e29-a154-4e15ae5601df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg?1",
             "name": "Werefox Bodyguard",
             "text": "Flash\nWhen Werefox Bodyguard enters the battlefield, exile up to one other target non-Fox creature until Werefox Bodyguard leaves the battlefield.\n{1}{W}, Sacrifice Werefox Bodyguard: You gain 2 life.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "69fa5e30-fdb9-53bf-837f-ea3972e658fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg?1",
             "name": "Aquatic Alchemist // Bubble Up",
             "text": "Whenever you cast your first instant or sorcery spell each turn, Aquatic Alchemist gets +2/+0 until end of turn.",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "7300ecbb-91a2-5ee3-a7e4-cea6d87dc020",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg?1",
             "name": "Aquatic Alchemist // Bubble Up",
             "text": "Put target instant or sorcery card from your graveyard on top of your library. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1512,7 +1512,7 @@
         },
         {
             "id": "49a4a855-8bd0-5597-9898-e0c96a4ede96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2979104f-7570-487c-8024-131d7ee3ab91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2979104f-7570-487c-8024-131d7ee3ab91.jpg?1",
             "name": "Archive Dragon",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Archive Dragon enters the battlefield, scry 2.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "cbc25ae8-c4b9-5dbb-9a9b-a3207adaaa1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b96a97-0d7d-4e05-9e2f-0b99a039b655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b96a97-0d7d-4e05-9e2f-0b99a039b655.jpg?1",
             "name": "Asinine Antics",
             "text": "You may cast Asinine Antics as though it had flash if you pay {2} more to cast it.\nFor each creature your opponents control, create a Cursed Role token attached to that creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
             "colours": [
@@ -1581,7 +1581,7 @@
         },
         {
             "id": "fa124a29-a69e-59de-af95-93cdddc067bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg?1",
             "name": "Beluna's Gatekeeper // Entry Denied",
             "text": "",
             "colours": [
@@ -1616,7 +1616,7 @@
         },
         {
             "id": "beb603e9-2e1d-5865-aafe-75ec96448938",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg?1",
             "name": "Beluna's Gatekeeper // Entry Denied",
             "text": "Return target creature you don't control with mana value 3 or less to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "330f1f04-b727-5267-bfa4-931126480bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e3c71-e21d-4e77-b1b6-09769f9cd3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e3c71-e21d-4e77-b1b6-09769f9cd3d6.jpg?1",
             "name": "Bitter Chill",
             "text": "Enchant creature\nWhen Bitter Chill enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhen Bitter Chill is put into a graveyard from the battlefield, you may pay {1}. If you do, scry 1, then draw a card.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "bf8c4aa4-6c05-55dc-a8be-c0b0f3778650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67bd5ef-305b-4bf7-990b-3014778b14a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67bd5ef-305b-4bf7-990b-3014778b14a0.jpg?1",
             "name": "Chancellor of Tales",
             "text": "Flying\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "032bb6cd-99dd-569f-b863-2dd7ece33617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d604f-b187-4122-bd4b-67634654b6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d604f-b187-4122-bd4b-67634654b6f1.jpg?1",
             "name": "Diminisher Witch",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen Diminisher Witch enters the battlefield, if it was bargained, create a Cursed Role token attached to target creature an opponent controls. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "36df8846-a152-5c7d-a5a4-97209a55dc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588c6217-c460-417e-98bf-de5475780baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588c6217-c460-417e-98bf-de5475780baf.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with mana value 4 or greater.",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "62756386-775d-53eb-93d1-37a1121945bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69fb480-a9fc-4f09-ac4e-3ce52c485ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69fb480-a9fc-4f09-ac4e-3ce52c485ea9.jpg?1",
             "name": "Extraordinary Journey",
             "text": "When Extraordinary Journey enters the battlefield, exile up to X target creatures. For each of those cards, its owner may play it for as long as it remains exiled.\nWhenever one or more nontoken creatures enter the battlefield, if one or more of them entered from exile or was cast from exile, you draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "62ade95b-4f77-5c77-96f9-bf5c350c7a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg?1",
             "name": "Farsight Ritual",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nLook at the top four cards of your library. If this spell was bargained, look at the top eight cards of your library instead. Put two of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "0026b37c-bc3a-5a1e-a6d5-429840baf32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8bb9c7-2c4b-48a1-806e-742addb72b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8bb9c7-2c4b-48a1-806e-742addb72b4b.jpg?1",
             "name": "Freeze in Place",
             "text": "Tap target creature an opponent controls and put three stun counters on it. Scry 2. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "a9bc2b67-27db-5b10-a0a9-02f3ab65e571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af07c47f-8b4e-43cb-b469-2efb82aa5590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af07c47f-8b4e-43cb-b469-2efb82aa5590.jpg?1",
             "name": "Gadwick's First Duel",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a Cursed Role token attached to up to one target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)\nII \u2014 Scry 2.\nIII \u2014 When you cast your next instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "3378d03b-838c-5fce-bd6f-d162f06e1ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg?1",
             "name": "Galvanic Giant // Storm Reading",
             "text": "Whenever you cast a spell with mana value 5 or greater, tap target creature an opponent controls and put a stun counter on it.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "88494e55-ec96-50fc-9c28-47057efa0da8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg?1",
             "name": "Galvanic Giant // Storm Reading",
             "text": "Draw four cards, then discard two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "a64e3d37-4934-51f5-b48d-bad9f3951535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "Flash\nWard {2}\nHorned Loch-Whale enters the battlefield tapped unless it's your turn.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "183b20c9-2733-5d22-9498-e105a672a276",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "The owner of target attacking creature you don't control puts it on the top or bottom of their library.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "7069b991-8751-5132-bd10-33ccd1071049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ffafda-c852-497a-8156-4f759cdf3693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ffafda-c852-497a-8156-4f759cdf3693.jpg?1",
             "name": "Ice Out",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {1} less to cast if it's bargained.\nCounter target spell.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "51b15a14-517d-56c7-afff-c61107c7c0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859419d3-cd15-4362-98b3-a7ff98e29692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859419d3-cd15-4362-98b3-a7ff98e29692.jpg?1",
             "name": "Icewrought Sentry",
             "text": "Vigilance\nWhenever Icewrought Sentry attacks, you may pay {1}{U}. When you do, tap target creature an opponent controls.\nWhenever you tap an untapped creature an opponent controls, Icewrought Sentry gets +2/+1 until end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "236c7bcb-fc0b-5664-a1ac-db263a5e717d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf224968-b676-40dd-83c1-a9ee2ceba574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf224968-b676-40dd-83c1-a9ee2ceba574.jpg?1",
             "name": "Ingenious Prodigy",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nIngenious Prodigy enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, if Ingenious Prodigy has one or more +1/+1 counters on it, you may remove a +1/+1 counter from it. If you do, draw a card.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "4e70427f-be31-5535-bdbd-50c928649078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969b13bb-6411-41f9-b6b4-af4ffca62e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969b13bb-6411-41f9-b6b4-af4ffca62e17.jpg?1",
             "name": "Into the Fae Court",
             "text": "Draw three cards. Create a 1/1 blue Faerie creature token with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "9bf0b366-1471-5484-8016-fe1e5e66ccaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31408397-36f5-479f-b822-fa97411b7872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31408397-36f5-479f-b822-fa97411b7872.jpg?1",
             "name": "Johann's Stopgap",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {2} less to cast if it's bargained.\nReturn target nonland permanent to its owner's hand. Draw a card.",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "6c9b9f4d-7df2-525b-8fa9-bae5aaae48e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169afcaf-7ebf-4590-9e51-2a1a5eb3ac76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169afcaf-7ebf-4590-9e51-2a1a5eb3ac76.jpg?1",
             "name": "Living Lectern",
             "text": "{1}, Sacrifice Living Lectern: Draw a card. Create a Sorcerer Role token attached to up to one other target creature you control. Activate only as a sorcery. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "d60d7ee8-c2aa-5b62-997c-87313b264ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f6a79c-aa2f-47d2-a929-1606a61f9341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f6a79c-aa2f-47d2-a929-1606a61f9341.jpg?1",
             "name": "Merfolk Coralsmith",
             "text": "{1}: Merfolk Coralsmith gets +1/-1 until end of turn.\nWhen Merfolk Coralsmith dies, scry 2.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "cfb11b8e-e343-5461-ae59-9520a7a2f3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6c7a43-c3d1-450e-834a-54e1b9def1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6c7a43-c3d1-450e-834a-54e1b9def1cd.jpg?1",
             "name": "Misleading Motes",
             "text": "Target creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "f0f5b133-4ea2-5cb0-8bf3-5861b34146d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e595014d-4ff4-4561-b7f2-a9bd56300b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e595014d-4ff4-4561-b7f2-a9bd56300b01.jpg?1",
             "name": "Mocking Sprite",
             "text": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -2365,7 +2365,7 @@
         },
         {
             "id": "6a89f54b-9895-5d2c-93e6-ef9cbbca9e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1",
             "name": "Obyra's Attendants // Desperate Parry",
             "text": "Flying",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "584734e9-6a31-54e7-96e9-17c8dca59e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1",
             "name": "Obyra's Attendants // Desperate Parry",
             "text": "Target creature gets -4/-0 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "fe7def44-a9a8-5dd1-8ee9-9d5f839ab3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg?1",
             "name": "Picklock Prankster // Free the Fae",
             "text": "Flying, vigilance",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "687b6cf1-2e49-5655-a440-077a7df5b2ca",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg?1",
             "name": "Picklock Prankster // Free the Fae",
             "text": "Mill four cards. Then put an instant, sorcery, or Faerie card from among the milled cards into your hand.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "fb16e675-35b8-551e-9989-e281caa5e5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78e2bca-bc93-464a-8911-8361abff2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78e2bca-bc93-464a-8911-8361abff2ac6.jpg?1",
             "name": "Quick Study",
             "text": "Draw two cards.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "b7cf0005-fc24-5821-8cec-e57e57519f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31051436-68f2-457e-8293-2b10ccf7684e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31051436-68f2-457e-8293-2b10ccf7684e.jpg?1",
             "name": "Sleep-Cursed Faerie",
             "text": "Flying, ward {2}\nSleep-Cursed Faerie enters the battlefield tapped with three stun counters on it. (If it would become untapped, remove a stun counter from it instead.)\n{1}{U}: Untap Sleep-Cursed Faerie.",
             "colours": [
@@ -2572,7 +2572,7 @@
         },
         {
             "id": "848a81e7-d20e-51e8-a6d9-c74227fa2acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dea5c0-ada3-488a-9f2b-f895b92c762f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dea5c0-ada3-488a-9f2b-f895b92c762f.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "4eca08d5-3d00-5ded-a92b-2fde310f2dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa37390-5c32-46ae-89d1-c094c9aa01e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa37390-5c32-46ae-89d1-c094c9aa01e5.jpg?1",
             "name": "Snaremaster Sprite",
             "text": "Flying\nWhen Snaremaster Sprite enters the battlefield, you may pay {2}. When you do, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "1490c515-b0b0-534f-8507-c87497b31520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24447e36-a42f-40a9-ad44-e904b6f9b276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24447e36-a42f-40a9-ad44-e904b6f9b276.jpg?1",
             "name": "Spell Stutter",
             "text": "Counter target spell unless its controller pays {2} plus an additional {1} for each Faerie you control.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "3443fcc0-19d5-5769-a1d4-8ed770839970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ebd7f0-a54d-43a8-a5ee-9d6835308794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ebd7f0-a54d-43a8-a5ee-9d6835308794.jpg?1",
             "name": "Splashy Spellcaster",
             "text": "Whenever you cast an instant or sorcery spell, create a Sorcerer Role token attached to up to one other target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -2708,7 +2708,7 @@
         },
         {
             "id": "0d432b92-a349-53ed-997e-6b98c8dc2994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff065dbf-77e3-45a8-bcca-aff9eaeb151f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff065dbf-77e3-45a8-bcca-aff9eaeb151f.jpg?1",
             "name": "Stormkeld Prowler",
             "text": "Whenever you cast a spell with mana value 5 or greater, put two +1/+1 counters on Stormkeld Prowler.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "6b0d550e-ea7f-5ec1-8285-879a8c6a5ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg?1",
             "name": "Succumb to the Cold",
             "text": "Tap one or two target creatures an opponent controls. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "309d02a7-77d9-57be-9b42-5ccddadec7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg?1",
             "name": "Talion's Messenger",
             "text": "Flying\nWhenever you attack with one or more Faeries, draw a card, then discard a card. When you discard a card this way, put a +1/+1 counter on target Faerie you control.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "9a4f5738-fffd-5684-ac32-aaeb3af5c828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40be735-0780-459b-8dd2-a298575beaab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40be735-0780-459b-8dd2-a298575beaab.jpg?1",
             "name": "Tenacious Tomeseeker",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen Tenacious Tomeseeker enters the battlefield, if it was bargained, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2847,7 +2847,7 @@
         },
         {
             "id": "1b5049e6-c899-519d-a3d8-cfd181c9531e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg?1",
             "name": "Vantress Transmuter // Croaking Curse",
             "text": "",
             "colours": [
@@ -2882,7 +2882,7 @@
         },
         {
             "id": "967749a3-058f-578c-b584-61f59bbe637a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg?1",
             "name": "Vantress Transmuter // Croaking Curse",
             "text": "Tap target creature. Create a Cursed Role token attached to it. (Enchanted creature is 1/1.)",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "3462dd3d-467f-551a-8db3-094ed01eea08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "If a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "2f3a4fd7-9caa-5d20-ae97-3e31c367a6be",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "Copy target activated or triggered ability you control. You may choose new targets for the copy.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "292858b5-e333-55e9-afe3-d45461bda602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea4993c-d1ba-4b33-955b-e0874fd2132f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea4993c-d1ba-4b33-955b-e0874fd2132f.jpg?1",
             "name": "Water Wings",
             "text": "Until end of turn, target creature you control has base power and toughness 4/4 and gains flying and hexproof. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "dbdbc120-09cd-59ac-9d1d-1ad7d011ba25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg?1",
             "name": "Ashiok, Wicked Manipulator",
             "text": "If you would pay life while your library has at least that many cards in it, exile that many cards from the top of your library instead.\n+1: Look at the top two cards of your library. Exile one of them and put the other into your hand.\n\u22122: Create two 1/1 black Nightmare creature tokens with \"At the beginning of combat on your turn, if a card was put into exile this turn, put a +1/+1 counter on this creature.\"\n\u22127: Target player exiles the top X cards of their library, where X is the total mana value of cards you own in exile.",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "9322bef7-e0cb-5aa8-8606-5eca401ec387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83957fe0-6500-420c-9b7a-2448a1c1d3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83957fe0-6500-420c-9b7a-2448a1c1d3b3.jpg?1",
             "name": "Ashiok's Reaper",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "fb832eaf-4e3c-524c-a674-0fb64ff980fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660845b5-96fa-4484-822b-aa0508801306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660845b5-96fa-4484-822b-aa0508801306.jpg?1",
             "name": "Back for Seconds",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nReturn up to two target creature cards from your graveyard to your hand. If this spell was bargained, you may put one of those cards with mana value 4 or less onto the battlefield instead of putting it into your hand.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "054405f6-e8f5-5ea5-9dc0-7e0ab52a3386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67da5ad8-4de2-4bd4-8b95-f2657e1fdee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67da5ad8-4de2-4bd4-8b95-f2657e1fdee5.jpg?1",
             "name": "Barrow Naughty",
             "text": "Flying\nBarrow Naughty has lifelink as long as you control another Faerie.\n{2}{B}: Barrow Naughty gets +1/+0 until end of turn.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "e430ff2e-182f-5aaa-a0b2-8c6b9d2291a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg?1",
             "name": "Beseech the Mirror",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nSearch your library for a card, exile it face down, then shuffle. If this spell was bargained, you may cast the exiled card without paying its mana cost if that spell's mana value is 4 or less. Put the exiled card into your hand if it wasn't cast this way.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "a46f57ac-821b-5466-a580-1f99be187dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190d97bc-dbef-496d-9bd1-b785bdf8a964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190d97bc-dbef-496d-9bd1-b785bdf8a964.jpg?1",
             "name": "Candy Grapple",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTarget creature gets -3/-3 until end of turn. If this spell was bargained, that creature gets -5/-5 until end of turn instead.",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "473adc97-07a9-56f2-81f2-9b3ca0f92fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg?1",
             "name": "Conceited Witch // Price of Beauty",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "f78d2a67-e333-5fdb-bc2a-68e7f025edd1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg?1",
             "name": "Conceited Witch // Price of Beauty",
             "text": "Create a Wicked Role token attached to target creature you control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "f936ed70-13e4-51e0-be57-d7492ecd9076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd1963-fe71-42c1-8ad7-53fd80145ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd1963-fe71-42c1-8ad7-53fd80145ca6.jpg?1",
             "name": "Dream Spoilers",
             "text": "Flying\nWhenever you cast a spell during an opponent's turn, up to one target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "c45f42b7-cdc6-5b94-a6b6-01cfdbcec7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf36da-bbad-4d6e-a530-502d47a2dd23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf36da-bbad-4d6e-a530-502d47a2dd23.jpg?1",
             "name": "Ego Drain",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. If you don't control a Faerie, exile a card from your hand.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "f5efba23-55ca-54cf-967e-2ee555e46185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg?1",
             "name": "The End",
             "text": "This spell costs {2} less to cast if your life total is 5 or less.\nExile target creature or planeswalker. Search its controller's graveyard, hand, and library for any number of cards with the same name as that permanent and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "b2c9b409-afbf-5adc-8b52-323aed61b483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfed2acf-9ac8-447b-94f5-7db3a713c991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfed2acf-9ac8-447b-94f5-7db3a713c991.jpg?1",
             "name": "Eriette's Whisper",
             "text": "Target opponent discards two cards. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "73d2ebf9-308f-512f-9fdd-d201bf533ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ca2ec5-442d-4909-be28-93c50fbc5f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ca2ec5-442d-4909-be28-93c50fbc5f7a.jpg?1",
             "name": "Faerie Dreamthief",
             "text": "Flying\nWhen Faerie Dreamthief enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{2}{B}, Exile Faerie Dreamthief from your graveyard: You draw a card and you lose 1 life.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "614f9fad-2b6f-5170-ab8f-6a5d8d112690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdcaf24-4352-47cf-a043-899be47ab1bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdcaf24-4352-47cf-a043-899be47ab1bb.jpg?1",
             "name": "Faerie Fencing",
             "text": "Target creature gets -X/-X until end of turn. That creature gets an additional -3/-3 until end of turn if you controlled a Faerie as you cast this spell.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "1de97d22-eb9a-547a-9b62-45db51f8b291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd18a5-e06a-4cb5-b78e-de18ec641321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd18a5-e06a-4cb5-b78e-de18ec641321.jpg?1",
             "name": "Feed the Cauldron",
             "text": "Destroy target creature with mana value 3 or less. If it's your turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "1ec2e1b0-8f30-5065-9608-6310f5b926f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg?1",
             "name": "Fell Horseman // Deathly Ride",
             "text": "When Fell Horseman dies, put it on the bottom of its owner's library.",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "bbaccea0-bebf-5cf4-b843-0fa5392f0c64",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg?1",
             "name": "Fell Horseman // Deathly Ride",
             "text": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "c6aeb737-eee3-59bc-8c92-d9d34649a184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Lifelink\nWhen Gumdrop Poisoner enters the battlefield, up to one target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "17a51d13-a713-5ec8-aa0c-2e23705ab335",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "9e610d96-1b0e-53d6-8b0a-8c3e4047dc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fc77e7-154d-4433-93b3-1a1dee34791b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fc77e7-154d-4433-93b3-1a1dee34791b.jpg?1",
             "name": "High Fae Negotiator",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nFlying\nWhen High Fae Negotiator enters the battlefield, if it was bargained, each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "10e84fc4-3212-52c0-bb7f-26ee0b90fadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg?1",
             "name": "Hopeless Nightmare",
             "text": "When Hopeless Nightmare enters the battlefield, each opponent discards a card and loses 2 life.\nWhen Hopeless Nightmare is put into a graveyard from the battlefield, scry 2.\n{2}{B}: Sacrifice Hopeless Nightmare.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "232167d7-3f62-5823-99c6-f26f04023d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg?1",
             "name": "Lich-Knights' Conquest",
             "text": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -3769,7 +3769,7 @@
         },
         {
             "id": "857768d3-3e69-5026-a984-28780427d9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729877be-4894-4ef5-9e60-de8a8fb2bdc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729877be-4894-4ef5-9e60-de8a8fb2bdc0.jpg?1",
             "name": "Lord Skitter, Sewer King",
             "text": "Whenever another Rat enters the battlefield under your control, exile up to one target card from an opponent's graveyard.\nAt the beginning of combat on your turn, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "060fcbf9-b8fa-5f4a-9047-b39c77253327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg?1",
             "name": "Lord Skitter's Blessing",
             "text": "When Lord Skitter's Blessing enters the battlefield, create a Wicked Role token attached to target creature you control. (Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)\nAt the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you draw an additional card.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "c7942950-5c26-5983-82d2-264afcaa3eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b31d2b-ef66-4e16-a75e-4e27eb5ebfe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b31d2b-ef66-4e16-a75e-4e27eb5ebfe9.jpg?1",
             "name": "Lord Skitter's Butcher",
             "text": "When Lord Skitter's Butcher enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 black Rat creature token with \"This creature can't block.\"\n\u2022 You may sacrifice another creature. If you do, scry 2, then draw a card.\n\u2022 Creatures you control gain menace until end of turn.",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "cfd45651-7e0e-5c12-85f7-8a761295c657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902f154-6fe8-4b97-aa67-4d4696abf887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902f154-6fe8-4b97-aa67-4d4696abf887.jpg?1",
             "name": "Mintstrosity",
             "text": "When Mintstrosity dies, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "b40c1cf4-5b32-5981-8403-0e32e918e775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a2b68-efe6-4027-846d-db7b19d9eef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a2b68-efe6-4027-846d-db7b19d9eef6.jpg?1",
             "name": "Not Dead After All",
             "text": "Until end of turn, target creature you control gains \"When this creature dies, return it to the battlefield tapped under its owner's control, then create a Wicked Role token attached to it.\" (Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "f188abe9-2e40-5c76-9cca-fafe0a028207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9bdcf-160a-48c9-9750-778c910b805d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9bdcf-160a-48c9-9750-778c910b805d.jpg?1",
             "name": "Rankle's Prank",
             "text": "Choose one or more \u2014\n\u2022 Each player discards two cards.\n\u2022 Each player loses 4 life.\n\u2022 Each player sacrifices two creatures.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "d91e7aa5-7d44-557f-8da7-ba8bb2e2f229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c42755-bf91-4c75-95c6-d2a60ba3492a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c42755-bf91-4c75-95c6-d2a60ba3492a.jpg?1",
             "name": "Rat Out",
             "text": "Up to one target creature gets -1/-1 until end of turn. You create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "6e7d199f-0902-5730-b007-2bd54d0676a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be6786e-0569-42dd-b03c-82da7b32a14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be6786e-0569-42dd-b03c-82da7b32a14f.jpg?1",
             "name": "Rowan's Grim Search",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nIf this spell was bargained, look at the top four cards of your library, then put up to two of them back on top of your library in any order and the rest into your graveyard.\nYou draw two cards and you lose 2 life.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "04241ce3-be46-57f2-99a1-2f2531b519a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg?1",
             "name": "Scream Puff",
             "text": "Deathtouch\nWhenever Scream Puff deals combat damage to a player, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -4075,7 +4075,7 @@
         },
         {
             "id": "83ff0b76-7daa-5f24-a1a1-ead8cec399dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc79f0f7-0a09-4a74-b2b9-cc1ce608d89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc79f0f7-0a09-4a74-b2b9-cc1ce608d89f.jpg?1",
             "name": "Shatter the Oath",
             "text": "Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "ce4d1b50-e968-542b-99f6-65e1bfa5c909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg?1",
             "name": "Specter of Mortality",
             "text": "Flying\nWhen Specter of Mortality enters the battlefield, you may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "002cd42a-3ee0-55e2-98da-b5616a767b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1",
             "name": "Spiteful Hexmage",
             "text": "When Spiteful Hexmage enters the battlefield, create a Cursed Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "99a22cf3-81b4-5e6f-90a7-db9af68ff7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b7dd9-6a1d-4c71-873b-782a0a2e7d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b7dd9-6a1d-4c71-873b-782a0a2e7d1d.jpg?1",
             "name": "Stingblade Assassin",
             "text": "Flash\nFlying\nWhen Stingblade Assassin enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "1eef5617-e8fd-569b-a6dc-79763444433e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a638c9ba-45d6-4b50-a8ab-ef580a0a5d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a638c9ba-45d6-4b50-a8ab-ef580a0a5d8e.jpg?1",
             "name": "Sugar Rush",
             "text": "Target creature gets +3/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "a05e7e4f-3000-5b88-a74a-c5b8bd57eeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bdb984-06f8-4bca-a943-17fe5db97682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bdb984-06f8-4bca-a943-17fe5db97682.jpg?1",
             "name": "Sweettooth Witch",
             "text": "When Sweettooth Witch enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}, Sacrifice a Food: Target player loses 2 life.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "dbc04033-fb53-5127-bbd1-eb782cb7df4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f858d83d-a13e-4ffa-a91d-d695e5e5d71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f858d83d-a13e-4ffa-a91d-d695e5e5d71a.jpg?1",
             "name": "Taken by Nightmares",
             "text": "Exile target creature. If you control an enchantment, scry 2.",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "69bc34db-458c-500d-a7b7-463bd4da0b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg?1",
             "name": "Tangled Colony",
             "text": "Tangled Colony can't block.\nWhen Tangled Colony dies, create X 1/1 black Rat creature tokens with \"This creature can't block,\" where X is the amount of damage dealt to it this turn.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "0f2e7013-3540-55cf-8aff-ae639158afde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3ddf7-582d-4923-be30-8428e52237e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3ddf7-582d-4923-be30-8428e52237e4.jpg?1",
             "name": "Twisted Sewer-Witch",
             "text": "When Twisted Sewer-Witch enters the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\" Then for each Rat you control, create a Wicked Role token attached to that Rat. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "a49ddadf-ae35-55d3-a47e-3a5d232d795b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -4419,7 +4419,7 @@
         },
         {
             "id": "6b30127f-aca1-52a2-89f9-d0a4e886078a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "Target creature gets -3/-3 until end of turn. You gain 2 life.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "881b67b1-34db-51a2-be24-a390b5f10cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059be65-3c73-49bb-a3b6-c346ce2f9fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059be65-3c73-49bb-a3b6-c346ce2f9fa4.jpg?1",
             "name": "Voracious Vermin",
             "text": "When Voracious Vermin enters the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\"\nWhenever another creature you control dies, put a +1/+1 counter on Voracious Vermin.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "fc1f83e6-d4cb-54c2-87e1-a9137d61accd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d500ad81-9659-4a00-8f99-8be7c23587e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d500ad81-9659-4a00-8f99-8be7c23587e8.jpg?1",
             "name": "Warehouse Tabby",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\"\n{1}{B}: Warehouse Tabby gains deathtouch until end of turn.",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "ad13e55f-f8d8-5b59-b8f2-d747c251d24f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ec4b8-0012-48c4-9ccb-0f062df0c250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ec4b8-0012-48c4-9ccb-0f062df0c250.jpg?1",
             "name": "Wicked Visitor",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, each opponent loses 1 life.",
             "colours": [
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "11dca0c0-72f0-5fd7-b965-3756bbae5f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ca4926-b5ac-405a-8b58-f8db6df400ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ca4926-b5ac-405a-8b58-f8db6df400ff.jpg?1",
             "name": "The Witch's Vanity",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target creature an opponent controls with mana value 2 or less.\nII \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nIII \u2014 Create a Wicked Role token attached to target creature you control.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "afa8ec60-f18b-5aa6-b10d-b375c75c1f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6658398a-46a5-4f41-9b1b-4a47f2822cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6658398a-46a5-4f41-9b1b-4a47f2822cf8.jpg?1",
             "name": "Belligerent of the Ball",
             "text": "Celebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4626,7 +4626,7 @@
         },
         {
             "id": "0d99bc2d-e2cc-59f5-baca-d9f447b14fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg?1",
             "name": "Bellowing Bruiser // Beat a Path",
             "text": "Haste",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "e370b8b0-fdbb-573a-84c0-b5d3c4b1579d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg?1",
             "name": "Bellowing Bruiser // Beat a Path",
             "text": "Up to two target creatures can't block this turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "cce1a4da-add2-562c-b96f-6f7c5981fb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ecd59-9166-473c-bafc-cb3c54c21388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ecd59-9166-473c-bafc-cb3c54c21388.jpg?1",
             "name": "Bespoke Battlegarb",
             "text": "Equipped creature gets +2/+0.\nCelebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, attach Bespoke Battlegarb to up to one target creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "0cb6ae90-3bf5-572e-bcc6-275325b621f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdcbb1d-702e-4832-8eed-7ed3deffefe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdcbb1d-702e-4832-8eed-7ed3deffefe3.jpg?1",
             "name": "Boundary Lands Ranger",
             "text": "At the beginning of combat on your turn, if you control a creature with power 4 or greater, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "d0410196-5daa-5bbe-8d9c-efa5ca3207d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1",
             "name": "Charming Scoundrel",
             "text": "Haste\nWhen Charming Scoundrel enters the battlefield, choose one \u2014\n\u2022 Discard a card, then draw a card.\n\u2022 Create a Treasure token.\n\u2022 Create a Wicked Role token attached to target creature you control.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "0052ff0c-2279-5fdc-9864-3636f6279644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4d40a-7657-4ff8-9fc2-915b99432275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4d40a-7657-4ff8-9fc2-915b99432275.jpg?1",
             "name": "Cut In",
             "text": "Cut In deals 4 damage to target creature.\nCreate a Young Hero Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "321cc413-a881-54b0-bb50-28a78c97fdb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acda9d02-00fc-49e2-a9f3-176e9c0a8c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acda9d02-00fc-49e2-a9f3-176e9c0a8c5f.jpg?1",
             "name": "Edgewall Pack",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Edgewall Pack enters the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "f0865396-489a-5188-a2e8-6cfe85888b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7130b8-3168-421f-912a-46ed5b769807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7130b8-3168-421f-912a-46ed5b769807.jpg?1",
             "name": "Embereth Veteran",
             "text": "{1}, Sacrifice Embereth Veteran: Create a Young Hero Role token attached to another target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "1875d390-9464-53e5-a44f-f978b0ce3a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a67b2-fbb0-4be4-9edd-93946a583f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a67b2-fbb0-4be4-9edd-93946a583f23.jpg?1",
             "name": "Flick a Coin",
             "text": "Flick a Coin deals 1 damage to any target. You create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nDraw a card.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "0f4a972f-0bac-537c-ae12-d2269be741bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg?1",
             "name": "Food Fight",
             "text": "Artifacts you control have \"{2}, Sacrifice this artifact: It deals damage to any target equal to 1 plus the number of permanents named Food Fight you control.\"",
             "colours": [
@@ -4967,7 +4967,7 @@
         },
         {
             "id": "b4cc9cb6-c48f-5309-9839-654ce17cbc73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd85f5a-258b-4ced-bf9e-3abe7fe72395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd85f5a-258b-4ced-bf9e-3abe7fe72395.jpg?1",
             "name": "Frantic Firebolt",
             "text": "Frantic Firebolt deals X damage to target creature, where X is 2 plus the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "9480c67b-1459-5e64-8111-1793fa24660b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fc64a-9734-44a6-8869-ab03512f1a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fc64a-9734-44a6-8869-ab03512f1a99.jpg?1",
             "name": "Gnawing Crescendo",
             "text": "Creatures you control get +2/+0 until end of turn. Whenever a nontoken creature you control dies this turn, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "33dec57b-a287-53f3-980c-6448b7b92356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg?1",
             "name": "Goddric, Cloaked Reveler",
             "text": "Haste\nCelebration \u2014 As long as two or more nonland permanents entered the battlefield under your control this turn, Goddric, Cloaked Reveler is a Dragon with base power and toughness 4/4, flying, and \"{R}: Dragons you control get +1/+0 until end of turn.\" (It loses all other creature types.)",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "60ba491d-cf8d-53b7-8ab0-8a9b2dc0b7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg?1",
             "name": "Grabby Giant // That's Mine",
             "text": "Reach\n{2}{R}, Sacrifice an artifact or land: Draw a card.",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "160a82ef-eb39-5c24-a477-ee5d3f579b90",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg?1",
             "name": "Grabby Giant // That's Mine",
             "text": "Create a Treasure token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "581fdb53-ba90-5171-9f0f-96faafdf687c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e75228-16af-42b0-8441-ed253a660cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e75228-16af-42b0-8441-ed253a660cc9.jpg?1",
             "name": "Grand Ball Guest",
             "text": "Celebration \u2014 Grand Ball Guest gets +1/+1 and has trample as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "f068b094-4af5-5c57-beb5-802f956d9c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db79785-4f55-445f-93f2-14c6e4606fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db79785-4f55-445f-93f2-14c6e4606fc5.jpg?1",
             "name": "Harried Spearguard",
             "text": "Haste\nWhen Harried Spearguard dies, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -5208,7 +5208,7 @@
         },
         {
             "id": "6b340d2e-ac98-5ab8-b08f-3a1095eeecd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg?1",
             "name": "Hearth Elemental // Stoke Genius",
             "text": "This spell costs {X} less to cast, where X is the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "32acb6a2-9f95-504a-b2cf-98c5154cb1db",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg?1",
             "name": "Hearth Elemental // Stoke Genius",
             "text": "Discard your hand, then draw two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "9e7d8455-d673-5293-a53c-53d3132e6800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b44833-0482-4b47-a594-4050bb87f1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b44833-0482-4b47-a594-4050bb87f1a5.jpg?1",
             "name": "Imodane, the Pyrohammer",
             "text": "Whenever an instant or sorcery spell you control that targets only a single creature deals damage to that creature, Imodane deals that much damage to each opponent.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "6e415046-796c-5657-be6e-fd0578cca4f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6d05e-e566-4a85-bcf8-9d0fbea3dd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6d05e-e566-4a85-bcf8-9d0fbea3dd14.jpg?1",
             "name": "Kindled Heroism",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "16f85be5-e384-51c9-8a33-c205e6671906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a811b2cb-ffc7-4100-ac3e-bc4125842bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a811b2cb-ffc7-4100-ac3e-bc4125842bb2.jpg?1",
             "name": "Korvold and the Noble Thief",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nIII \u2014 Exile the top three cards of target opponent's library. You may play those cards this turn.",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "8c675f35-61c4-5e02-9159-4b8a6bfd0883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058b9b-e919-45eb-9da0-690f62aa252e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058b9b-e919-45eb-9da0-690f62aa252e.jpg?1",
             "name": "Merry Bards",
             "text": "When Merry Bards enters the battlefield, you may pay {1}. When you do, create a Young Hero Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "254befee-8635-5ad1-8f6f-df3f8b55410d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg?1",
             "name": "Minecart Daredevil // Ride the Rails",
             "text": "",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "6f30b8b7-1ea7-5ab9-be83-0ca7c20fd6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg?1",
             "name": "Minecart Daredevil // Ride the Rails",
             "text": "Target creature gets +2/+1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5485,7 +5485,7 @@
         },
         {
             "id": "fe8379d6-22f2-54c5-b187-f68de50e0094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg?1",
             "name": "Monstrous Rage",
             "text": "Target creature gets +2/+0 until end of turn. Create a Monster Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)",
             "colours": [
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "ec59fc72-c9a8-53b5-81ab-615bd3799810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg?1",
             "name": "Raging Battle Mouse",
             "text": "The second spell you cast each turn costs {1} less to cast.\nCelebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -5553,7 +5553,7 @@
         },
         {
             "id": "b7ef9f57-e717-58af-bc96-93ea3b3cd0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg?1",
             "name": "Ratcatcher Trainee // Pest Problem",
             "text": "As long as it's your turn, Ratcatcher Trainee has first strike.",
             "colours": [
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "725f44a8-8011-5d6b-be7d-4d349ca015da",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg?1",
             "name": "Ratcatcher Trainee // Pest Problem",
             "text": "Create two 1/1 black Rat creature tokens with \"This creature can't block.\" (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "a599aaac-0e13-58fe-9f68-abcb4e2e3b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg?1",
             "name": "Realm-Scorcher Hellkite",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nFlying, haste\nWhen Realm-Scorcher Hellkite enters the battlefield, if it was bargained, add four mana in any combination of colors.\n{1}{R}: Realm-Scorcher Hellkite deals 1 damage to any target.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "449e0ab5-a806-590c-aa53-10970d2661b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96bcd5f0-da79-47ab-83cf-976198b458d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96bcd5f0-da79-47ab-83cf-976198b458d1.jpg?1",
             "name": "Redcap Gutter-Dweller",
             "text": "Menace\nWhen Redcap Gutter-Dweller enters the battlefield, create two 1/1 black Rat creature tokens with \"This creature can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on Redcap Gutter-Dweller and exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "bfa0cb20-a3f4-5a1e-b169-e56235ad51d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda6bdeb-a0d6-46ca-ba8c-317ee0096416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda6bdeb-a0d6-46ca-ba8c-317ee0096416.jpg?1",
             "name": "Redcap Thief",
             "text": "When Redcap Thief enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "93b2bc6b-6202-5fcd-9611-024bbb53649f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg?1",
             "name": "Rotisserie Elemental",
             "text": "Menace\nWhenever Rotisserie Elemental deals combat damage to a player, put a skewer counter on Rotisserie Elemental. Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the number of skewer counters on Rotisserie Elemental. You may play those cards this turn.",
             "colours": [
@@ -5766,7 +5766,7 @@
         },
         {
             "id": "23ac2f89-0bd2-5baf-bf29-cb440ebc4a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e50ca-d27b-45db-91fa-7fef3cad16d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e50ca-d27b-45db-91fa-7fef3cad16d0.jpg?1",
             "name": "Skewer Slinger",
             "text": "Reach\nWhenever Skewer Slinger blocks or becomes blocked by a creature, Skewer Slinger deals 1 damage to that creature.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "7af6f656-46d9-5bb6-89a2-ad72e82f3785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg?1",
             "name": "Song of Totentanz",
             "text": "Create X 1/1 black Rat creature tokens with \"This creature can't block.\" Creatures you control gain haste until end of turn.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "1b60be20-2689-5060-bcbd-df7d5bc83bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb22f79c-3075-439d-a072-ceaabe35d76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb22f79c-3075-439d-a072-ceaabe35d76f.jpg?1",
             "name": "Stonesplitter Bolt",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nStonesplitter Bolt deals X damage to target creature or planeswalker. If this spell was bargained, it deals twice X damage to that permanent instead.",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "a47d71c0-601c-5e6c-9577-bcdba578c7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f505b4-d61c-4da8-ab45-37125260d556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f505b4-d61c-4da8-ab45-37125260d556.jpg?1",
             "name": "Tattered Ratter",
             "text": "Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "1ff5912e-ded1-5227-8387-a2f64e21c778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6027c-813f-46df-95b4-e2e305a67620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6027c-813f-46df-95b4-e2e305a67620.jpg?1",
             "name": "Torch the Tower",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTorch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained, instead it deals 3 damage to that permanent and you scry 1.\nIf a permanent dealt damage by Torch the Tower would die this turn, exile it instead.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "12c1f4ec-ec8d-50a0-9980-e91915084ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382d6085-79b9-48f7-8949-9f44dde2c753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382d6085-79b9-48f7-8949-9f44dde2c753.jpg?1",
             "name": "Twisted Fealty",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\nCreate a Wicked Role token attached to up to one target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -5968,7 +5968,7 @@
         },
         {
             "id": "1c0671d8-3030-5577-9ac5-3cfea3a70866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg?1",
             "name": "Two-Headed Hunter // Twice the Rage",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "3a553b11-2640-5b61-b786-0255ebb21253",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg?1",
             "name": "Two-Headed Hunter // Twice the Rage",
             "text": "Target creature gains double strike until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "53d8a613-cc08-546f-aee8-e0facc3c9b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc275f8-f060-4c15-9b8f-63cf3857eaa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc275f8-f060-4c15-9b8f-63cf3857eaa7.jpg?1",
             "name": "Unruly Catapult",
             "text": "Defender\n{T}: Unruly Catapult deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Unruly Catapult.",
             "colours": [
@@ -6071,7 +6071,7 @@
         },
         {
             "id": "08d36f7b-44ac-590d-86e6-01cf565f007c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library. You may play those cards this turn.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "b9f3c067-23f0-5a09-9829-2c566a7c03cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Embereth Blaze deals 2 damage to any target. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "172d4bb3-56bd-5250-a439-28597a587986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0685afcb-06f6-4d18-b8c2-510764558dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0685afcb-06f6-4d18-b8c2-510764558dc1.jpg?1",
             "name": "Witch's Mark",
             "text": "You may discard a card. If you do, draw two cards.\nCreate a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "0bff791f-b7a1-5e4d-a554-c4bd794eb29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649025a7-79d1-4d7c-b1db-d46bcf5a1ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649025a7-79d1-4d7c-b1db-d46bcf5a1ae2.jpg?1",
             "name": "Witchstalker Frenzy",
             "text": "This spell costs {1} less to cast for each creature that attacked this turn.\nWitchstalker Frenzy deals 5 damage to target creature.",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "d4cf54ae-f7b8-5192-874c-eed2f9ce5175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92652c41-1239-4299-a486-11fe1a96e912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92652c41-1239-4299-a486-11fe1a96e912.jpg?1",
             "name": "Agatha's Champion",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTrample\nWhen Agatha's Champion enters the battlefield, if it was bargained, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6240,7 +6240,7 @@
         },
         {
             "id": "17163145-7124-548c-a245-450295c0e330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg?1",
             "name": "Beanstalk Wurm // Plant Beans",
             "text": "Reach",
             "colours": [
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "f9eafba8-3c7f-518f-86fe-b669701cd7dd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg?1",
             "name": "Beanstalk Wurm // Plant Beans",
             "text": "You may play an additional land this turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "1681479c-c3a3-50d9-8caf-2f55cdf5ea89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9b8e5-1ed8-4be0-aad5-041a599c6841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9b8e5-1ed8-4be0-aad5-041a599c6841.jpg?1",
             "name": "Bestial Bloodline",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\n{4}{G}: Return Bestial Bloodline from your graveyard to your hand.",
             "colours": [
@@ -6343,7 +6343,7 @@
         },
         {
             "id": "5d4db9b0-dcd7-5cd4-9cca-1240e4de5009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg?1",
             "name": "Blossoming Tortoise",
             "text": "Whenever Blossoming Tortoise enters the battlefield or attacks, mill three cards, then return a land card from your graveyard to the battlefield tapped.\nActivated abilities of lands you control cost {1} less to activate.\nLand creatures you control get +1/+1.",
             "colours": [
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "15f61e7d-bd56-59d7-a6ac-c234330cc241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "{T}: Add {G}.\n{1}{G}, {T}, Discard a card: Return Bramble Familiar to its owner's hand.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "95d8eabe-b154-5305-92e2-fc21780b1e06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "Mill seven cards. Then put a creature, enchantment, or land card from among the milled cards onto the battlefield.",
             "colours": [
@@ -6452,7 +6452,7 @@
         },
         {
             "id": "aed9dab7-f56b-5fee-8141-1d33b7d26e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b9e86-d108-42e5-b642-c5e07ab16c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b9e86-d108-42e5-b642-c5e07ab16c37.jpg?1",
             "name": "Brave the Wilds",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nIf this spell was bargained, target land you control becomes a 3/3 Elemental creature with haste that's still a land.\nSearch your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6484,7 +6484,7 @@
         },
         {
             "id": "e8cd13be-ecee-5480-99b4-521b9775f0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5224eec3-2941-4d16-a713-099e34e93eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5224eec3-2941-4d16-a713-099e34e93eee.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "e4274ade-59c2-58db-b1a0-d9319843c58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89148458-1fd6-48ef-a2d9-7b434c9723ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89148458-1fd6-48ef-a2d9-7b434c9723ec.jpg?1",
             "name": "Curse of the Werefox",
             "text": "Create a Monster Role token attached to target creature you control. When you do, that creature fights up to one target creature you don't control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample. Creatures that fight each deal damage equal to their power to the other.)",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "3dd84e7a-b1bd-5db2-9102-74a9f1143b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg?1",
             "name": "Elvish Archivist",
             "text": "Whenever one or more artifacts enter the battlefield under your control, put two +1/+1 counters on Elvish Archivist. This ability triggers only once each turn.\nWhenever one or more enchantments enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -6585,7 +6585,7 @@
         },
         {
             "id": "c24ab91f-6d03-5647-8f3b-1fdb92652960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg?1",
             "name": "Feral Encounter",
             "text": "Look at the top five cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card this turn. At the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.",
             "colours": [
@@ -6619,7 +6619,7 @@
         },
         {
             "id": "9381787d-1762-503f-8855-268713f1639e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg?1",
             "name": "Ferocious Werefox // Guard Change",
             "text": "Trample",
             "colours": [
@@ -6655,7 +6655,7 @@
         },
         {
             "id": "8b948fec-cc6e-5b93-a78c-0057d95a6d43",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg?1",
             "name": "Ferocious Werefox // Guard Change",
             "text": "Create a Monster Role token attached to target creature you control. (Enchanted creature gets +1/+1 and has trample.)",
             "colours": [
@@ -6689,7 +6689,7 @@
         },
         {
             "id": "6ee711a1-c74f-56b8-80e6-479a2f09f5f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83edf626-ed34-417f-818d-597ecf439167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83edf626-ed34-417f-818d-597ecf439167.jpg?1",
             "name": "Graceful Takedown",
             "text": "Any number of target enchanted creatures you control and up to one other target creature you control each deal damage equal to their power to target creature you don't control.",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "daeb92c6-cce4-550b-bdda-0feacf2c5977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8760ab9-ac76-4e2e-b82f-0ee2a6dc5634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8760ab9-ac76-4e2e-b82f-0ee2a6dc5634.jpg?1",
             "name": "Gruff Triplets",
             "text": "Trample\nWhen Gruff Triplets enters the battlefield, if it isn't a token, create two tokens that are copies of it.\nWhen Gruff Triplets dies, put a number of +1/+1 counters equal to its power on each creature you control named Gruff Triplets.",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "e3cd81af-936a-5bce-b92c-d043779d2b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ec5544-c138-44bb-a807-5798313c9a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ec5544-c138-44bb-a807-5798313c9a50.jpg?1",
             "name": "Hamlet Glutton",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {2} less to cast if it's bargained.\nTrample\nWhen Hamlet Glutton enters the battlefield, you gain 3 life.",
             "colours": [
@@ -6792,7 +6792,7 @@
         },
         {
             "id": "cf6b1023-c7e6-5f9c-af52-9001b0aaedb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg?1",
             "name": "Hollow Scavenger // Bakery Raid",
             "text": "{1}, Sacrifice a Food: Hollow Scavenger gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "dfcaffd3-3139-5b66-9d9f-5663ff72e562",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg?1",
             "name": "Hollow Scavenger // Bakery Raid",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "63bab65c-d73b-56db-ac53-80198875cf93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86311523-d0eb-4db3-b586-8349de9c2d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86311523-d0eb-4db3-b586-8349de9c2d37.jpg?1",
             "name": "Howling Galefang",
             "text": "Vigilance\nHowling Galefang has haste as long as you own a card in exile that has an Adventure.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "e45ccc75-08ab-5206-84af-ba8b37c32328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg?1",
             "name": "The Huntsman's Redemption",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 3/3 green Beast creature token.\nII \u2014 You may sacrifice a creature. If you do, search your library for a creature or basic land card, reveal it, put it into your hand, then shuffle.\nIII \u2014 Up to two target creatures each get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -6928,7 +6928,7 @@
         },
         {
             "id": "612b753d-3d0c-5a4b-9023-3e156fb7fcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2785f716-274c-495c-b4e3-71a72e22f856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2785f716-274c-495c-b4e3-71a72e22f856.jpg?1",
             "name": "Leaping Ambush",
             "text": "Target creature gets +1/+3 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "a0e30175-fbfa-529e-96cd-c8da356c2bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f53bed-7075-4303-aa9e-fcca0a266e19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f53bed-7075-4303-aa9e-fcca0a266e19.jpg?1",
             "name": "Night of the Sweets' Revenge",
             "text": "When Night of the Sweets' Revenge enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nFoods you control have \"{T}: Add {G}.\"\n{5}{G}{G}, Sacrifice Night of the Sweets' Revenge: Creatures you control get +X/+X until end of turn, where X is the number of Foods you control. Activate only as a sorcery.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "e90f6fbf-d5af-59b2-81b4-e57fc83f45ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c81440-66eb-4443-a83f-e2f15cb68a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c81440-66eb-4443-a83f-e2f15cb68a3e.jpg?1",
             "name": "Redtooth Genealogist",
             "text": "When Redtooth Genealogist enters the battlefield, create a Royal Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "aa1769ac-7e79-5db6-9ac5-8780205ea0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55271960-b9bd-4bea-93ca-3321bf30be78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55271960-b9bd-4bea-93ca-3321bf30be78.jpg?1",
             "name": "Redtooth Vanguard",
             "text": "Trample\nWhenever an enchantment enters the battlefield under your control, you may pay {2}. If you do, return Redtooth Vanguard from your graveyard to your hand.",
             "colours": [
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "68dc84af-8f5c-541e-82db-00ada25a0943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597d9ea-d9b2-4009-8e7c-02caa3585bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597d9ea-d9b2-4009-8e7c-02caa3585bc5.jpg?1",
             "name": "Return from the Wilds",
             "text": "Choose two \u2014\n\u2022 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n\u2022 Create a 1/1 white Human creature token.\n\u2022 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "112025db-dec3-557d-8054-f346ae95cee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e87db5a-1a70-42df-83a2-c0f71fe8533a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e87db5a-1a70-42df-83a2-c0f71fe8533a.jpg?1",
             "name": "Rootrider Faun",
             "text": "{T}: Add {G}.\n{1}, {T}: Add one mana of any color.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "1a0d8560-021d-5213-a4b9-ffff114607da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6516b8f-ecfb-401e-ba8e-bf561aa2be64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6516b8f-ecfb-401e-ba8e-bf561aa2be64.jpg?1",
             "name": "Royal Treatment",
             "text": "Target creature you control gains hexproof until end of turn. Create a Royal Role token attached to that creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -7161,7 +7161,7 @@
         },
         {
             "id": "c10d2d6d-6c6d-565d-ba62-c36ac6d48f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg?1",
             "name": "Sentinel of Lost Lore",
             "text": "When Sentinel of Lost Lore enters the battlefield, choose one or more \u2014\n\u2022 Return target card you own in exile that has an Adventure to your hand.\n\u2022 Put target card you don't own in exile that has an Adventure on the bottom of its owner's library.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -7198,7 +7198,7 @@
         },
         {
             "id": "50aaf7b1-e52d-5bd2-b795-cde0f09ee22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08da5c6-ebe7-4166-99d5-2aca5b0b529f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08da5c6-ebe7-4166-99d5-2aca5b0b529f.jpg?1",
             "name": "Skybeast Tracker",
             "text": "Reach\nWhenever you cast a spell with mana value 5 or greater, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "65c19016-ca91-5e0d-9552-fe0022f61d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9fd720b-e9c2-4e82-917e-bab6c544afb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9fd720b-e9c2-4e82-917e-bab6c544afb0.jpg?1",
             "name": "Spider Food",
             "text": "Destroy up to one target artifact, enchantment, or creature with flying. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "ed4a0fc3-840d-59b1-895a-5618a6f47ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg?1",
             "name": "Stormkeld Vanguard // Bear Down",
             "text": "Stormkeld Vanguard can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -7300,7 +7300,7 @@
         },
         {
             "id": "8754f01b-8b1f-5a8a-a566-5b9cadb7d6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg?1",
             "name": "Stormkeld Vanguard // Bear Down",
             "text": "Destroy target artifact or enchantment. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -7334,7 +7334,7 @@
         },
         {
             "id": "c91131a8-b1dc-5aac-8aa4-43c9e6cc0865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc5c32d-be0a-4a5f-a8c7-9767a895bc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc5c32d-be0a-4a5f-a8c7-9767a895bc76.jpg?1",
             "name": "Tanglespan Lookout",
             "text": "Whenever an Aura enters the battlefield under your control, draw a card.",
             "colours": [
@@ -7370,7 +7370,7 @@
         },
         {
             "id": "49be0d1e-699e-52ae-aa6f-b4324aa47fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2515d53d-7a50-4da3-980d-91d91fea2020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2515d53d-7a50-4da3-980d-91d91fea2020.jpg?1",
             "name": "Territorial Witchstalker",
             "text": "Defender\nAt the beginning of combat on your turn, if you control a creature with power 4 or greater, Territorial Witchstalker gets +1/+0 until end of turn and can attack this turn as though it didn't have defender.",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "38259300-9897-5d05-8dbe-43d3604f408d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98f51ec-8eae-434a-ab62-85bdb6586fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98f51ec-8eae-434a-ab62-85bdb6586fa2.jpg?1",
             "name": "Thunderous Debut",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nLook at the top twenty cards of your library. You may reveal up to two creature cards from among them. If this spell was bargained, put the revealed cards onto the battlefield. Otherwise, put the revealed cards into your hand. Then shuffle.",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "283ebd75-0109-54be-8710-c98bc0d728e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46917de3-5e98-4dd6-8950-fc10338515df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46917de3-5e98-4dd6-8950-fc10338515df.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -7470,7 +7470,7 @@
         },
         {
             "id": "c3f2a632-4f05-5bc3-b802-c94984146f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a6349a-beff-4abd-b005-86d27c1e2957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a6349a-beff-4abd-b005-86d27c1e2957.jpg?1",
             "name": "Toadstool Admirer",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\n{3}{G}: Put a +1/+1 counter on Toadstool Admirer.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "a6c05b85-21b7-5981-82b7-3b3d0ce4397e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa37f85-5336-4372-97a2-9c8b00798c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa37f85-5336-4372-97a2-9c8b00798c7a.jpg?1",
             "name": "Tough Cookie",
             "text": "When Tough Cookie enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}{G}: Target noncreature artifact you control becomes a 4/4 artifact creature until end of turn.\n{2}, {T}, Sacrifice Tough Cookie: You gain 3 life.",
             "colours": [
@@ -7540,7 +7540,7 @@
         },
         {
             "id": "e7a1c142-6fd2-5074-9103-19ad8dbc1b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7b2fc0-d3f6-4c4d-a163-986a372e5b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7b2fc0-d3f6-4c4d-a163-986a372e5b12.jpg?1",
             "name": "Troublemaker Ouphe",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen Troublemaker Ouphe enters the battlefield, if it was bargained, exile target artifact or enchantment an opponent controls.",
             "colours": [
@@ -7574,7 +7574,7 @@
         },
         {
             "id": "f62e346d-027a-5bd5-b6a8-62413c3b1ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg?1",
             "name": "Up the Beanstalk",
             "text": "When Up the Beanstalk enters the battlefield and whenever you cast a spell with mana value 5 or greater, draw a card.",
             "colours": [
@@ -7606,7 +7606,7 @@
         },
         {
             "id": "d0b8b82b-f467-52f1-aaa2-a6c29de1575f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg?1",
             "name": "Verdant Outrider",
             "text": "{1}{G}: Verdant Outrider can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -7641,7 +7641,7 @@
         },
         {
             "id": "ca4fa4fd-af26-548d-9610-afa82adbbe08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "If you tap a basic land for mana, it produces three times as much of that mana instead.",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "8915762e-e344-50cd-ac88-2a70fe32faaf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "Return target creature or land card from your graveyard to your hand. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "1fb17e72-43a0-58b4-828b-89170d1c0ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e629a31-2e06-4f95-9628-34670dcf68b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e629a31-2e06-4f95-9628-34670dcf68b9.jpg?1",
             "name": "Welcome to Sweettooth",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human creature token.\nII \u2014 Create a Food token.\nIII \u2014 Put X +1/+1 counters on target creature you control, where X is one plus the number of Foods you control.",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "a1e8a6cd-14fe-5973-b970-91dd6807d2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c48f07-63b7-4a60-8da6-ce77405abf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c48f07-63b7-4a60-8da6-ce77405abf1e.jpg?1",
             "name": "Agatha of the Vile Cauldron",
             "text": "Activated abilities of creatures you control cost {X} less to activate, where X is Agatha of the Vile Cauldron's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "fb1ece4b-1170-563f-9268-78c0990ec9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb58bb-8ff3-4e34-b3d1-d83b5bd8c178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb58bb-8ff3-4e34-b3d1-d83b5bd8c178.jpg?1",
             "name": "The Apprentice's Folly",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Choose target nontoken creature you control that doesn't have the same name as a token you control. Create a token that's a copy of it, except it isn't legendary, is a Reflection in addition to its other types, and has haste.\nIII \u2014 Sacrifice all Reflections you control.",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "e69e533d-5229-5ece-b011-d8b5329f3c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51e6610-25b6-4d8e-92d7-c50a2ff844ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51e6610-25b6-4d8e-92d7-c50a2ff844ff.jpg?1",
             "name": "Ash, Party Crasher",
             "text": "Haste\nCelebration \u2014 Whenever Ash, Party Crasher attacks, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Ash.",
             "colours": [
@@ -7861,7 +7861,7 @@
         },
         {
             "id": "8968ffde-f692-5e49-b491-bbd2251667ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecead4cd-47ae-4c42-b15c-1b29b5caba18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecead4cd-47ae-4c42-b15c-1b29b5caba18.jpg?1",
             "name": "Eriette of the Charmed Apple",
             "text": "Each creature that's enchanted by an Aura you control can't attack you or planeswalkers you control.\nAt the beginning of your end step, each opponent loses X life and you gain X life, where X is the number of Auras you control.",
             "colours": [
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "2dc4f472-a88d-5d84-a5b8-28825225b8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd585-c5ea-46f8-8e11-f33c067f2f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd585-c5ea-46f8-8e11-f33c067f2f8e.jpg?1",
             "name": "Faunsbane Troll",
             "text": "When Faunsbane Troll enters the battlefield, create a Monster Role token attached to it. (Enchanted creature gets +1/+1 and has trample.)\n{1}, Sacrifice an Aura attached to Faunsbane Troll: Faunsbane Troll fights target creature you don't control. If that creature would die this turn, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "d6807e37-228b-5dfb-b1b9-7b60fc938e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55c370-d396-4c73-8ee2-83dc4c124005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55c370-d396-4c73-8ee2-83dc4c124005.jpg?1",
             "name": "The Goose Mother",
             "text": "Flying\nThe Goose Mother enters the battlefield with X +1/+1 counters on it.\nWhen The Goose Mother enters the battlefield, create half X Food tokens, rounded up.\nWhenever The Goose Mother attacks, you may sacrifice a Food. If you do, draw a card.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "3d6c03e9-1530-5d2a-b96f-35ab4a98522c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd365e-34d1-4224-b925-119000311934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd365e-34d1-4224-b925-119000311934.jpg?1",
             "name": "Greta, Sweettooth Scourge",
             "text": "When Greta, Sweettooth Scourge enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{G}, Sacrifice a Food: Put a +1/+1 counter on target creature. Activate only as a sorcery.\n{1}{B}, Sacrifice a Food: You draw a card and you lose 1 life.",
             "colours": [
@@ -8020,7 +8020,7 @@
         },
         {
             "id": "86809f1b-60a5-5e27-8042-a356783105bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9231fd-053d-4b84-a7a8-86063465bc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9231fd-053d-4b84-a7a8-86063465bc49.jpg?1",
             "name": "Hylda of the Icy Crown",
             "text": "Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do, choose one \u2014\n\u2022 Create a 4/4 white and blue Elemental creature token.\n\u2022 Put a +1/+1 counter on each creature you control.\n\u2022 Scry 2, then draw a card.",
             "colours": [
@@ -8061,7 +8061,7 @@
         },
         {
             "id": "82e31be5-24c3-5267-a55e-171136daeef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a762d-19ed-451d-a3a9-b3e7eea40f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a762d-19ed-451d-a3a9-b3e7eea40f67.jpg?1",
             "name": "Johann, Apprentice Sorcerer",
             "text": "You may look at the top card of your library any time.\nOnce each turn, you may cast an instant or sorcery spell from the top of your library. (You still pay its costs. Timing rules still apply.)",
             "colours": [
@@ -8100,7 +8100,7 @@
         },
         {
             "id": "0211fc43-5065-54ec-8fbf-59ddc1b9b993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2957472a-825e-4904-b7e8-62bef1cb432d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2957472a-825e-4904-b7e8-62bef1cb432d.jpg?1",
             "name": "Likeness Looter",
             "text": "Flying\n{T}: Draw a card, then discard a card.\n{X}: Likeness Looter becomes a copy of target creature card in your graveyard with mana value X, except it has flying and this ability. Activate only as a sorcery.",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "4874fad0-0a3b-5d82-bc31-e81cff47ba00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f925ab-ade7-4da8-a791-185e098d18f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f925ab-ade7-4da8-a791-185e098d18f2.jpg?1",
             "name": "Neva, Stalked by Nightmares",
             "text": "Menace\nWhen Neva, Stalked by Nightmares enters the battlefield, return target creature or enchantment card from your graveyard to your hand.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Neva, then scry 1.",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "a26a043a-87b0-5adf-9ce1-223ddadd24aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ce03ee-279b-4955-98e3-9ce1990f8b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ce03ee-279b-4955-98e3-9ce1990f8b7b.jpg?1",
             "name": "Obyra, Dreaming Duelist",
             "text": "Flash\nFlying\nWhenever another Faerie enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -8217,7 +8217,7 @@
         },
         {
             "id": "a5025e25-31e0-5dd1-bc02-b422c8348387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee179ab-a15b-4bd6-b7f8-1e1abeeb31b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee179ab-a15b-4bd6-b7f8-1e1abeeb31b7.jpg?1",
             "name": "Rowan, Scion of War",
             "text": "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
             "colours": [
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "b581278d-b7dc-56d4-a0a1-c050aadef29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb5786b-6825-4ebf-a1e1-80011340adbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb5786b-6825-4ebf-a1e1-80011340adbb.jpg?1",
             "name": "Ruby, Daring Tracker",
             "text": "Haste\nWhenever Ruby, Daring Tracker attacks while you control a creature with power 4 or greater, Ruby gets +2/+2 until end of turn.\n{T}: Add {R} or {G}.",
             "colours": [
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "773b348f-4203-50b7-857a-26773a0a11b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600bc36a-3ef0-459c-9a93-94ec45b8c3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600bc36a-3ef0-459c-9a93-94ec45b8c3d9.jpg?1",
             "name": "Sharae of Numbing Depths",
             "text": "When Sharae of Numbing Depths enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you tap one or more untapped creatures your opponents control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "53cfa3a2-180e-547f-a962-d57aa21c8f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85050609-baf0-430a-ab33-83a6ea6d4741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85050609-baf0-430a-ab33-83a6ea6d4741.jpg?1",
             "name": "Syr Armont, the Redeemer",
             "text": "When Syr Armont, the Redeemer enters the battlefield, create a Monster Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)\nEnchanted creatures you control get +1/+1.",
             "colours": [
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "2d2bb8d6-0baf-5ddb-a5f9-2122dad998f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6b452-c796-45c6-b4d1-0ae3d675e38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6b452-c796-45c6-b4d1-0ae3d675e38e.jpg?1",
             "name": "Talion, the Kindly Lord",
             "text": "Flying\nAs Talion, the Kindly Lord enters the battlefield, choose a number between 1 and 10.\nWhenever an opponent casts a spell with mana value, power, or toughness equal to the chosen number, that player loses 2 life and you draw a card.",
             "colours": [
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "9240b281-0ade-5aca-b6ab-acbd02c7a5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422d6db-fe5b-4a89-951a-fbd7985a29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422d6db-fe5b-4a89-951a-fbd7985a29fc.jpg?1",
             "name": "Totentanz, Swarm Piper",
             "text": "Whenever Totentanz, Swarm Piper or another nontoken creature you control dies, create a 1/1 black Rat creature token with \"This creature can't block.\"\n{1}{B}: Target attacking Rat you control gains deathtouch until end of turn.",
             "colours": [
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "3522035a-1bc3-5c00-a73b-12a5e918ea75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadd2a1a-93a0-4257-897d-1aaee279449f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadd2a1a-93a0-4257-897d-1aaee279449f.jpg?1",
             "name": "Troyan, Gutsy Explorer",
             "text": "{T}: Add {G}{U}. Spend this mana only to cast spells with mana value 5 or greater or spells with {X} in their mana costs.\n{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "278c3136-f379-58ba-91e3-11b28941de1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162088ea-5f99-4244-9427-2fdfb2168fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162088ea-5f99-4244-9427-2fdfb2168fc3.jpg?1",
             "name": "Will, Scion of Peace",
             "text": "Vigilance\n{T}: Spells you cast this turn that are white and/or blue cost {X} less to cast, where X is the amount of life you gained this turn. Activate only as a sorcery.",
             "colours": [
@@ -8536,7 +8536,7 @@
         },
         {
             "id": "455c5c51-a66a-5ca5-a531-f80f5b41ee02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635d461-254a-434e-8e5d-dea61dd8ca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635d461-254a-434e-8e5d-dea61dd8ca4f.jpg?1",
             "name": "Yenna, Redtooth Regent",
             "text": "{2}, {T}: Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, Redtooth Regent, then scry 2. Activate only as a sorcery.",
             "colours": [
@@ -8577,7 +8577,7 @@
         },
         {
             "id": "ac11ebbb-d5c6-5214-8a17-e2924415430a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Trample\nPermanent spells you cast that have an Adventure cost {1} less to cast.",
             "colours": [
@@ -8620,7 +8620,7 @@
         },
         {
             "id": "669150c9-9a54-5f3d-bdda-180d0a5ac4e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Mill seven cards. Then put all cards that have an Adventure from among the milled cards into your hand.",
             "colours": [
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "c76d53fd-2435-54c7-a66e-db7bceb3b39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg?1",
             "name": "Callous Sell-Sword // Burn Together",
             "text": "Callous Sell-Sword enters the battlefield with a +1/+1 counter on it for each creature that died under your control this turn.",
             "colours": [
@@ -8696,7 +8696,7 @@
         },
         {
             "id": "8f9c2348-0888-57bf-930e-5bb704ab6d62",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg?1",
             "name": "Callous Sell-Sword // Burn Together",
             "text": "Target creature you control deals damage equal to its power to any other target. Then sacrifice it.",
             "colours": [
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "cd098713-dace-57c3-94d9-4031d688961a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Cruel Somnophage's power and toughness are each equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "faaa6da4-1e7d-5664-a40a-f5147e18aeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "c1760b74-0fb5-53b2-995c-f34110eb3c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Flying, trample\nWhenever Decadent Dragon attacks, create a Treasure token.",
             "colours": [
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "375be560-1c58-51f0-aab7-5784ddeea1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Exile the top two cards of target opponent's library face down. You may look at and play those cards for as long as they remain exiled.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "6373326c-e354-569a-bb1b-f9226aec3988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Menace, trample\nAt the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. If you don't, tap Devouring Sugarmaw.",
             "colours": [
@@ -8916,7 +8916,7 @@
         },
         {
             "id": "c9dcce7e-3adf-586a-961c-f5a07d5c20a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Create a 1/1 white Human creature token and a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8953,7 +8953,7 @@
         },
         {
             "id": "fc7af2c3-0f96-51f9-94b9-cf73bd60a076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nCreatures with power less than Elusive Otter's power can't block it.",
             "colours": [
@@ -8990,7 +8990,7 @@
         },
         {
             "id": "34033da4-c22f-5e08-a431-5221c8fee107",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Distribute X +1/+1 counters among any number of target creatures you control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9027,7 +9027,7 @@
         },
         {
             "id": "54578bf7-e702-59fd-b873-74540d60102c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg?1",
             "name": "Frolicking Familiar // Blow Off Steam",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Frolicking Familiar gets +1/+1 until end of turn.",
             "colours": [
@@ -9063,7 +9063,7 @@
         },
         {
             "id": "31bd771d-a1b9-5625-bb14-f9518406564d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg?1",
             "name": "Frolicking Familiar // Blow Off Steam",
             "text": "Blow Off Steam deals 1 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9098,7 +9098,7 @@
         },
         {
             "id": "408eb47f-db3b-5e15-800c-fae23e244dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg?1",
             "name": "Gingerbread Hunter // Puny Snack",
             "text": "When Gingerbread Hunter enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "46ce4c69-a894-56f4-8620-54425ec91517",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg?1",
             "name": "Gingerbread Hunter // Puny Snack",
             "text": "Target creature gets -2/-2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9168,7 +9168,7 @@
         },
         {
             "id": "cc1074d9-5095-591f-bdd5-7f8bc811effd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Instant and sorcery spells you control have lifelink.",
             "colours": [
@@ -9206,7 +9206,7 @@
         },
         {
             "id": "347af62e-7577-5d46-95f7-76496ae4d02a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Heartflame Slash deals 3 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "d07c6d79-289a-5a83-a221-13eff0e629ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg?1",
             "name": "Imodane's Recruiter // Train Troops",
             "text": "When Imodane's Recruiter enters the battlefield, creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "f358ec5c-ad0d-5b68-8d2f-edc92b13022d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg?1",
             "name": "Imodane's Recruiter // Train Troops",
             "text": "Create two 2/2 white Knight creature tokens with vigilance. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "4f5c190b-aab1-58fc-86f4-df0e92b69453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan, the Fae-Blooded.",
             "colours": [
@@ -9355,7 +9355,7 @@
         },
         {
             "id": "c5eb6c3f-d8b0-5483-82e8-5c62cbba92c7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "e7195a14-e92e-5e5d-b52f-f0206a47e710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "Trample\nWhen Mosswood Dreadknight dies, you may cast it from your graveyard as an Adventure until the end of your next turn.",
             "colours": [
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "0df7cfd8-230d-5028-846b-111e110383fe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "8f56053c-db00-5913-8a17-63ec7a8931f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg?1",
             "name": "Picnic Ruiner // Stolen Goodies",
             "text": "Whenever Picnic Ruiner attacks while you control a creature with power 4 or greater, Picnic Ruiner gains double strike until end of turn.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "6f95e294-707b-5eb4-a603-84a0e954cd16",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg?1",
             "name": "Picnic Ruiner // Stolen Goodies",
             "text": "Distribute three +1/+1 counters among any number of target creatures you control.",
             "colours": [
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "d93b450c-bd76-58ab-ade3-f9b2de06e25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Creature tokens you control get +1/+1.",
             "colours": [
@@ -9576,7 +9576,7 @@
         },
         {
             "id": "ceadedae-2096-50bc-be0c-759bdc0f9060",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Target creature you control gains vigilance and gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "78b47c1b-d6ab-59ed-a378-296d1debfb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on Questing Druid.",
             "colours": [
@@ -9651,7 +9651,7 @@
         },
         {
             "id": "976f9483-014b-54f4-a961-94e209b8c50b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Exile the top two cards of your library. Until your next end step, you may play those cards.",
             "colours": [
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "09ec3da9-2c92-5e8f-affc-b3f24fa77e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Whenever an opponent casts a spell with mana value 3 or less, Scalding Viper deals 1 damage to that player.",
             "colours": [
@@ -9726,7 +9726,7 @@
         },
         {
             "id": "44d639ca-0422-5578-87e5-ae8304bd4055",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Return target nonland permanent to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "e47fea04-1518-54ff-887e-c22523863586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg?1",
             "name": "Shrouded Shepherd // Cleave Shadows",
             "text": "When Shrouded Shepherd enters the battlefield, target creature you control gets +2/+2 until end of turn.",
             "colours": [
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "0e26f681-97bf-50b0-a321-f02cdfd9a53a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg?1",
             "name": "Shrouded Shepherd // Cleave Shadows",
             "text": "Creatures your opponents control get -1/-1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9834,7 +9834,7 @@
         },
         {
             "id": "fa765318-c9ca-50c2-ac97-b7220928b383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg?1",
             "name": "Spellscorn Coven // Take It Back",
             "text": "Flying\nWhen Spellscorn Coven enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "7a749949-b0a4-57ec-85a2-224ff28b606f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg?1",
             "name": "Spellscorn Coven // Take It Back",
             "text": "Return target spell to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9905,7 +9905,7 @@
         },
         {
             "id": "622420ae-fa6a-5c03-befc-871d0da983fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg?1",
             "name": "Tempest Hart // Scan the Clouds",
             "text": "Trample\nWhenever you cast a spell with mana value 5 or greater, put a +1/+1 counter on Tempest Hart.",
             "colours": [
@@ -9941,7 +9941,7 @@
         },
         {
             "id": "e2b3bb4d-ca56-55bf-a3cb-8b65c05e1e94",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg?1",
             "name": "Tempest Hart // Scan the Clouds",
             "text": "Draw two cards, then discard two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9976,7 +9976,7 @@
         },
         {
             "id": "d215b905-d954-5ef7-a197-43f6ddc9f59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg?1",
             "name": "Threadbind Clique // Rip the Seams",
             "text": "Flying",
             "colours": [
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "25741935-6add-5aa2-8ea8-711d53325531",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg?1",
             "name": "Threadbind Clique // Rip the Seams",
             "text": "Destroy target tapped creature. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -10046,7 +10046,7 @@
         },
         {
             "id": "ceae5d60-9d6b-5afd-a5e8-8a304fe1410a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Flying, vigilance, ward {1}",
             "colours": [
@@ -10084,7 +10084,7 @@
         },
         {
             "id": "39a65d01-1e88-58ca-80c0-4cffc621edbf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "e32cb62e-af7a-5404-b90b-77a4a4367ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg?1",
             "name": "Woodland Acolyte // Mend the Wilds",
             "text": "When Woodland Acolyte enters the battlefield, draw a card.",
             "colours": [
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "09d6a819-f481-55b9-b715-3e4a87885f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg?1",
             "name": "Woodland Acolyte // Mend the Wilds",
             "text": "Put target permanent card from your graveyard on top of your library. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "aaf24b85-b4ac-55c3-81c9-c46632d23e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019b51b0-e5c6-4208-922b-7736686dddcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019b51b0-e5c6-4208-922b-7736686dddcd.jpg?1",
             "name": "Agatha's Soul Cauldron",
             "text": "You may spend mana as though it were mana of any color to activate abilities of creatures you control.\nCreatures you control with +1/+1 counters on them have all activated abilities of all creature cards exiled with Agatha's Soul Cauldron.\n{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -10224,7 +10224,7 @@
         },
         {
             "id": "0761cdc2-eb74-5a58-896b-32d548e955c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a860925-d912-49e5-9ddc-41ab26916bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a860925-d912-49e5-9ddc-41ab26916bb3.jpg?1",
             "name": "Candy Trail",
             "text": "When Candy Trail enters the battlefield, scry 2.\n{2}, {T}, Sacrifice Candy Trail: You gain 3 life and draw a card.",
             "colours": [],
@@ -10255,7 +10255,7 @@
         },
         {
             "id": "0366cae7-b50f-5838-bdcb-0e41b3eaffc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a4f27-8cd6-437d-8c05-8aedbc7ddc4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a4f27-8cd6-437d-8c05-8aedbc7ddc4b.jpg?1",
             "name": "Collector's Vault",
             "text": "{2}, {T}: Draw a card, then discard a card. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -10283,7 +10283,7 @@
         },
         {
             "id": "ea042ab2-ddf3-55d7-a559-3a93b6baa8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b61711f-8982-4ff0-86ba-01e0125cd705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b61711f-8982-4ff0-86ba-01e0125cd705.jpg?1",
             "name": "Eriette's Tempting Apple",
             "text": "When Eriette's Tempting Apple enters the battlefield, gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n{2}, {T}, Sacrifice Eriette's Tempting Apple: You gain 3 life.\n{2}, {T}, Sacrifice Eriette's Tempting Apple: Target opponent loses 3 life.",
             "colours": [],
@@ -10315,7 +10315,7 @@
         },
         {
             "id": "8532e156-9ec1-5319-ae8f-8fc896c60aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4578a-7dc6-4da3-93ee-913b10be5740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4578a-7dc6-4da3-93ee-913b10be5740.jpg?1",
             "name": "Gingerbrute",
             "text": "Haste\n{1}: Gingerbrute can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice Gingerbrute: You gain 3 life.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "1e06bf77-0b18-5191-8e75-d7e4eee69ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4a6c0-f00e-45a7-9c88-899460007020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4a6c0-f00e-45a7-9c88-899460007020.jpg?1",
             "name": "Hylda's Crown of Winter",
             "text": "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.\n{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control.",
             "colours": [],
@@ -10379,7 +10379,7 @@
         },
         {
             "id": "43105e5e-803f-5c31-af4d-c476edd23f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8051c5ec-54a6-45a8-8945-fb93c5feaa39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8051c5ec-54a6-45a8-8945-fb93c5feaa39.jpg?1",
             "name": "The Irencrag",
             "text": "{T}: Add {C}.\nWhenever a legendary creature enters the battlefield under your control, you may have The Irencrag become a legendary Equipment artifact named Everflame, Heroes' Legacy. If you do, it gains equip {3} and \"Equipped creature gets +3/+3\" and loses all other abilities.",
             "colours": [],
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "e288d02f-ff28-5594-8e88-6b0d2fb6bc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fae351c-b918-4648-a361-d5239ae63156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fae351c-b918-4648-a361-d5239ae63156.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -10439,7 +10439,7 @@
         },
         {
             "id": "f6b8b3c4-32c2-5e38-985a-c928881ea340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc08461-bec6-4a18-b782-da4c92abb789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc08461-bec6-4a18-b782-da4c92abb789.jpg?1",
             "name": "Scarecrow Guide",
             "text": "Reach\n{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "28d77d9e-ec33-5aa2-abbd-4fb5f40879d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571173-29e7-4915-af5f-05f13b463061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571173-29e7-4915-af5f-05f13b463061.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "When Soul-Guide Lantern enters the battlefield, exile target card from a graveyard.\n{T}, Sacrifice Soul-Guide Lantern: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice Soul-Guide Lantern: Draw a card.",
             "colours": [],
@@ -10498,7 +10498,7 @@
         },
         {
             "id": "40b7bb97-33de-5d4b-ae77-6d413b70839d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdba12-1369-41ae-b0e9-c405c0f0a2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdba12-1369-41ae-b0e9-c405c0f0a2e5.jpg?1",
             "name": "Syr Ginger, the Meal Ender",
             "text": "Syr Ginger, the Meal Ender has trample, hexproof, and haste as long as an opponent controls a planeswalker.\nWhenever another artifact you control is put into a graveyard from the battlefield, put a +1/+1 counter on Syr Ginger and scry 1.\n{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power.",
             "colours": [],
@@ -10534,7 +10534,7 @@
         },
         {
             "id": "eea49276-523d-5a62-ad19-f626e1b7bf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a508e040-d1e5-46aa-8404-1adc18f0f8bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a508e040-d1e5-46aa-8404-1adc18f0f8bd.jpg?1",
             "name": "Three Bowls of Porridge",
             "text": "{2}, {T}: Choose one that hasn't been chosen \u2014\n\u2022 Three Bowls of Porridge deals 2 damage to target creature.\n\u2022 Tap target creature.\n\u2022 Sacrifice Three Bowls of Porridge. You gain 3 life.",
             "colours": [],
@@ -10564,7 +10564,7 @@
         },
         {
             "id": "98a570c5-3136-574a-bc75-8dc530f9417a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6f9d3d-600d-43f3-a915-612e5d53aaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6f9d3d-600d-43f3-a915-612e5d53aaa1.jpg?1",
             "name": "Crystal Grotto",
             "text": "When Crystal Grotto enters the battlefield, scry 1.\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -10592,7 +10592,7 @@
         },
         {
             "id": "39ec1aad-886d-5f16-a10d-b8d282336677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec435e54-628a-43bd-8804-cbc37e375bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec435e54-628a-43bd-8804-cbc37e375bce.jpg?1",
             "name": "Edgewall Inn",
             "text": "Edgewall Inn enters the battlefield tapped.\nAs Edgewall Inn enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.\n{3}, {T}, Sacrifice Edgewall Inn: Return target card that has an Adventure from your graveyard to your hand.",
             "colours": [],
@@ -10620,7 +10620,7 @@
         },
         {
             "id": "6e8581ed-33f1-5129-a2e4-0fe8eff02079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f9c819-719a-461b-8e7e-a26c88e8099b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f9c819-719a-461b-8e7e-a26c88e8099b.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10648,7 +10648,7 @@
         },
         {
             "id": "2bf07df7-22e8-57a4-843f-1fbcbb2896f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85e0aed-bfb2-4aa8-a754-849c4d9a6a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85e0aed-bfb2-4aa8-a754-849c4d9a6a58.jpg?1",
             "name": "Restless Bivouac",
             "text": "Restless Bivouac enters the battlefield tapped.\n{T}: Add {R} or {W}.\n{1}{R}{W}: Restless Bivouac becomes a 2/2 red and white Ox creature until end of turn. It's still a land.\nWhenever Restless Bivouac attacks, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -10681,7 +10681,7 @@
         },
         {
             "id": "85be7c0e-6f6d-5f29-9ddd-2c4e4fa4c0f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787eadf3-5005-4ae5-820f-4012a4d4e1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787eadf3-5005-4ae5-820f-4012a4d4e1a5.jpg?1",
             "name": "Restless Cottage",
             "text": "Restless Cottage enters the battlefield tapped.\n{T}: Add {B} or {G}.\n{2}{B}{G}: Restless Cottage becomes a 4/4 black and green Horror creature until end of turn. It's still a land.\nWhenever Restless Cottage attacks, create a Food token and exile up to one target card from a graveyard.",
             "colours": [],
@@ -10714,7 +10714,7 @@
         },
         {
             "id": "bac3e0a1-5d81-53cc-9814-2a8d704fd664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675213bb-28d7-460c-a4f3-950f5b9090af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675213bb-28d7-460c-a4f3-950f5b9090af.jpg?1",
             "name": "Restless Fortress",
             "text": "Restless Fortress enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{2}{W}{B}: Restless Fortress becomes a 1/4 white and black Nightmare creature until end of turn. It's still a land.\nWhenever Restless Fortress attacks, defending player loses 2 life and you gain 2 life.",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "63928c50-c1a2-5db7-a404-a2b2f641d37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66386fe8-9d3c-47f7-9cd3-4cd30051535f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66386fe8-9d3c-47f7-9cd3-4cd30051535f.jpg?1",
             "name": "Restless Spire",
             "text": "Restless Spire enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{U}{R}: Until end of turn, Restless Spire becomes a 2/1 blue and red Elemental creature with \"As long as it's your turn, this creature has first strike.\" It's still a land.\nWhenever Restless Spire attacks, scry 1.",
             "colours": [],
@@ -10780,7 +10780,7 @@
         },
         {
             "id": "a29e9f42-dfb6-5701-a964-c1d87572f276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3161d-3f69-4b06-ab73-c31fc0c1520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3161d-3f69-4b06-ab73-c31fc0c1520c.jpg?1",
             "name": "Restless Vinestalk",
             "text": "Restless Vinestalk enters the battlefield tapped.\n{T}: Add {G} or {U}.\n{3}{G}{U}: Until end of turn, Restless Vinestalk becomes a 5/5 green and blue Plant creature with trample. It's still a land.\nWhenever Restless Vinestalk attacks, up to one other target creature has base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -10813,7 +10813,7 @@
         },
         {
             "id": "65ab0fa3-4cec-5857-93cf-8c7192a7e56c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd4d57-8c51-4fcf-8a9f-5d6a61c33e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd4d57-8c51-4fcf-8a9f-5d6a61c33e3d.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10850,7 +10850,7 @@
         },
         {
             "id": "5c12baf8-10b5-5e4e-87fe-6859dd6ba5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4b4da4-83f6-4280-880b-b6033308f2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4b4da4-83f6-4280-880b-b6033308f2a2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10887,7 +10887,7 @@
         },
         {
             "id": "bff6310e-be44-5140-984f-5b296851fbdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee68f2cb-851b-4196-ac58-844d72628e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee68f2cb-851b-4196-ac58-844d72628e6a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10924,7 +10924,7 @@
         },
         {
             "id": "713663b4-62fb-5e9b-9aed-9e5d8d452020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8822db23-34dc-452a-92bc-a3ceee4db375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8822db23-34dc-452a-92bc-a3ceee4db375.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10961,7 +10961,7 @@
         },
         {
             "id": "01d3c9dd-c727-5999-9808-4915028ee395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd6d8fb-780c-446c-a8bf-93386b22fe95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd6d8fb-780c-446c-a8bf-93386b22fe95.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10998,7 +10998,7 @@
         },
         {
             "id": "ff9bd747-5b27-57a5-9fd1-831349822771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed1af19-e075-4e6f-9394-d258143e15a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed1af19-e075-4e6f-9394-d258143e15a4.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "ce2a4840-e3d3-5372-8063-ba8a1e3e4e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fbcf9-3a04-47f6-8927-886c2a454499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fbcf9-3a04-47f6-8927-886c2a454499.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "6fc01ceb-dcc3-58b9-9522-716c81c74ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6245d2f8-8ef0-4d2a-9abb-99839dc3abf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6245d2f8-8ef0-4d2a-9abb-99839dc3abf0.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "6a308810-b7d9-5c75-93ab-7dc8077719e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9798d6-34b3-4438-992d-d3616a7c8536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9798d6-34b3-4438-992d-d3616a7c8536.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11146,7 +11146,7 @@
         },
         {
             "id": "dac84a33-a870-5c5c-acea-d9d4658e7a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a801ba-ebf7-4b9e-98c2-db50448845b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a801ba-ebf7-4b9e-98c2-db50448845b7.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11183,7 +11183,7 @@
         },
         {
             "id": "2b932496-65bf-58ed-9cdc-fc4ae97c8bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0de4ea5-77e6-474e-99f9-36192bbd37d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0de4ea5-77e6-474e-99f9-36192bbd37d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11220,7 +11220,7 @@
         },
         {
             "id": "bc728528-08ee-54d0-a461-5b2c9c61359f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8996cd43-5ecd-4a05-a5a9-e49326befaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8996cd43-5ecd-4a05-a5a9-e49326befaa1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11257,7 +11257,7 @@
         },
         {
             "id": "d520b320-f920-5580-a9f4-50a1cf00b45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e747bba-b521-4f81-9d9a-3e85747cefe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e747bba-b521-4f81-9d9a-3e85747cefe9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11294,7 +11294,7 @@
         },
         {
             "id": "ce43ab42-734a-5b98-ae8b-b29ba26293cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c99f1b-f304-42d5-bbea-32283b01d43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c99f1b-f304-42d5-bbea-32283b01d43b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11331,7 +11331,7 @@
         },
         {
             "id": "fb64325c-6a8f-5fca-8469-48be32a5ad36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd51a22-3e0d-4826-aab7-0adbfce4478a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd51a22-3e0d-4826-aab7-0adbfce4478a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11368,7 +11368,7 @@
         },
         {
             "id": "c7b3238e-5112-5143-adfd-8a2987b15ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control. Untap those creatures.",
             "colours": [
@@ -11402,7 +11402,7 @@
         },
         {
             "id": "f4e52ae1-d067-5d00-80b5-8a80914bc1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "42af1bcf-279a-5b74-810f-cd104f3b912a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "Flash\nWard {2}\nHorned Loch-Whale enters the battlefield tapped unless it's your turn.",
             "colours": [
@@ -11474,7 +11474,7 @@
         },
         {
             "id": "a166c05a-d3d2-54bd-b6dd-d7bd955914fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "The owner of target attacking creature you don't control puts it on the top or bottom of their library.",
             "colours": [
@@ -11510,7 +11510,7 @@
         },
         {
             "id": "0b108d51-ff44-5460-8fd8-1341fbe2dfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "If a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -11544,7 +11544,7 @@
         },
         {
             "id": "d638567a-c71e-5cab-b4af-f4fe7dab540f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "Copy target activated or triggered ability you control. You may choose new targets for the copy.",
             "colours": [
@@ -11580,7 +11580,7 @@
         },
         {
             "id": "6ec9325c-7265-51c1-b138-ba03f8b6c63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Lifelink\nWhen Gumdrop Poisoner enters the battlefield, up to one target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -11617,7 +11617,7 @@
         },
         {
             "id": "9cd1e51a-a52b-56bf-9d7f-805a629ebff2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -11653,7 +11653,7 @@
         },
         {
             "id": "dc47fdb9-28d6-5449-b678-9880d3394817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -11687,7 +11687,7 @@
         },
         {
             "id": "64068d9f-2621-520f-8765-89378210c79d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "Target creature gets -3/-3 until end of turn. You gain 2 life.",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "299cb4dc-d21d-568a-bfaa-2862841e5b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library. You may play those cards this turn.",
             "colours": [
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "32714b92-87df-551c-a7c3-dd0d96c0fb67",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Embereth Blaze deals 2 damage to any target. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -11793,7 +11793,7 @@
         },
         {
             "id": "3255f414-6bb0-5f27-ba1a-4aeba15b7cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "{T}: Add {G}.\n{1}{G}, {T}, Discard a card: Return Bramble Familiar to its owner's hand.",
             "colours": [
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "c3ec02b6-41ca-5ad5-805f-887b76856c41",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "Mill seven cards. Then put a creature, enchantment, or land card from among the milled cards onto the battlefield.",
             "colours": [
@@ -11866,7 +11866,7 @@
         },
         {
             "id": "43d5b7cd-7ec0-5e3f-90b8-e1d095f002d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "If you tap a basic land for mana, it produces three times as much of that mana instead.",
             "colours": [
@@ -11900,7 +11900,7 @@
         },
         {
             "id": "e3d5fbfb-5dfa-5c1a-a68c-457254486d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "Return target creature or land card from your graveyard to your hand. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -11936,7 +11936,7 @@
         },
         {
             "id": "95a861ba-0aaf-57cf-818d-b10f264e203b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Trample\nPermanent spells you cast that have an Adventure cost {1} less to cast.",
             "colours": [
@@ -11979,7 +11979,7 @@
         },
         {
             "id": "3754c023-d52b-5c66-9e17-ad104976ea40",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Mill seven cards. Then put all cards that have an Adventure from among the milled cards into your hand.",
             "colours": [
@@ -12019,7 +12019,7 @@
         },
         {
             "id": "d7bbc2cc-7b08-5ef9-a3e3-321784c6ed43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Cruel Somnophage's power and toughness are each equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -12056,7 +12056,7 @@
         },
         {
             "id": "94d3f9d8-f311-546f-8f43-8afa6efbf529",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12093,7 +12093,7 @@
         },
         {
             "id": "a12d6f01-42a9-56a4-992a-d081c300e361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Flying, trample\nWhenever Decadent Dragon attacks, create a Treasure token.",
             "colours": [
@@ -12130,7 +12130,7 @@
         },
         {
             "id": "5c26ef96-3d35-5452-a6ad-cc7f0fbd4351",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Exile the top two cards of target opponent's library face down. You may look at and play those cards for as long as they remain exiled.",
             "colours": [
@@ -12167,7 +12167,7 @@
         },
         {
             "id": "e0fd1c17-c6a3-5683-805e-a4b16e57b394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Menace, trample\nAt the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. If you don't, tap Devouring Sugarmaw.",
             "colours": [
@@ -12204,7 +12204,7 @@
         },
         {
             "id": "db09c0ac-a86b-5c9e-99dd-8f13ebd4db7f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Create a 1/1 white Human creature token and a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12241,7 +12241,7 @@
         },
         {
             "id": "d1de0b55-99df-59aa-b441-aa25fbf7e9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nCreatures with power less than Elusive Otter's power can't block it.",
             "colours": [
@@ -12278,7 +12278,7 @@
         },
         {
             "id": "fe2f90a1-4630-5579-b77b-2c4e4ba74539",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Distribute X +1/+1 counters among any number of target creatures you control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12315,7 +12315,7 @@
         },
         {
             "id": "9efa7fb0-cd2b-590e-85d5-38d658441cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Instant and sorcery spells you control have lifelink.",
             "colours": [
@@ -12353,7 +12353,7 @@
         },
         {
             "id": "4e8aaec5-5033-5851-91b8-102b6515357a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Heartflame Slash deals 3 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12390,7 +12390,7 @@
         },
         {
             "id": "d700fc99-a622-5dad-a6e9-1651ce9e015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan, the Fae-Blooded.",
             "colours": [
@@ -12431,7 +12431,7 @@
         },
         {
             "id": "4835d6e4-92b2-5c22-afd5-5333c5069191",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -12469,7 +12469,7 @@
         },
         {
             "id": "a0f5895a-ca32-52f9-b41e-b728f593e5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "Trample\nWhen Mosswood Dreadknight dies, you may cast it from your graveyard as an Adventure until the end of your next turn.",
             "colours": [
@@ -12507,7 +12507,7 @@
         },
         {
             "id": "ac55df2b-83ba-5d84-9018-7ca59cdeb2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "263b5c17-9b90-508e-b013-3e8516733571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Creature tokens you control get +1/+1.",
             "colours": [
@@ -12581,7 +12581,7 @@
         },
         {
             "id": "d5fe9923-a01a-53d1-93a1-264f75688331",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Target creature you control gains vigilance and gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -12618,7 +12618,7 @@
         },
         {
             "id": "ec45edae-ddb7-514c-ae97-edfa6a854c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on Questing Druid.",
             "colours": [
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "e2dc501c-0081-5975-980f-db6e1e543b18",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Exile the top two cards of your library. Until your next end step, you may play those cards.",
             "colours": [
@@ -12693,7 +12693,7 @@
         },
         {
             "id": "ccd1a2cc-2130-5492-8f35-3a335bfa43fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Whenever an opponent casts a spell with mana value 3 or less, Scalding Viper deals 1 damage to that player.",
             "colours": [
@@ -12731,7 +12731,7 @@
         },
         {
             "id": "c4810281-3086-5699-8dc0-b92329bc5feb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Return target nonland permanent to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12768,7 +12768,7 @@
         },
         {
             "id": "5905a2fa-322b-55f2-af9e-e7441b9f5a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Flying, vigilance, ward {1}",
             "colours": [
@@ -12806,7 +12806,7 @@
         },
         {
             "id": "592923ad-e978-51b0-9499-7404c310bda1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -12843,7 +12843,7 @@
         },
         {
             "id": "ea89690e-34ce-5610-9432-8dd06eb27795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f57de-21af-4c25-8a21-df3a75157939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f57de-21af-4c25-8a21-df3a75157939.jpg?1",
             "name": "Ashiok, Wicked Manipulator",
             "text": "If you would pay life while your library has at least that many cards in it, exile that many cards from the top of your library instead.\n+1: Look at the top two cards of your library. Exile one of them and put the other into your hand.\n\u22122: Create two 1/1 black Nightmare creature tokens with \"At the beginning of combat on your turn, if a card was put into exile this turn, put a +1/+1 counter on this creature.\"\n\u22127: Target player exiles the top X cards of their library, where X is the total mana value of cards you own in exile.",
             "colours": [
@@ -12881,7 +12881,7 @@
         },
         {
             "id": "6d54b2a5-3a9c-5d31-8231-73c35eb7fb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan, the Fae-Blooded.",
             "colours": [
@@ -12922,7 +12922,7 @@
         },
         {
             "id": "4629025b-2f8f-5f29-a6ec-f5e1dd4cdee2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -12960,7 +12960,7 @@
         },
         {
             "id": "09ef2fd3-aab8-549e-976e-8d927ae9fcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487a2cc0-ddbf-46b9-90ed-9455347724d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487a2cc0-ddbf-46b9-90ed-9455347724d5.jpg?1",
             "name": "Eriette of the Charmed Apple",
             "text": "Each creature that's enchanted by an Aura you control can't attack you or planeswalkers you control.\nAt the beginning of your end step, each opponent loses X life and you gain X life, where X is the number of Auras you control.",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "c8cc5d4f-508c-599e-8399-8fe3e2c48ca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e29e9-e870-4433-ad63-0ff918a3e41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e29e9-e870-4433-ad63-0ff918a3e41a.jpg?1",
             "name": "Rowan, Scion of War",
             "text": "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
             "colours": [
@@ -13042,7 +13042,7 @@
         },
         {
             "id": "180dd859-f481-5105-9d17-b68c26606546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1f05ef-7607-4a63-a710-18d0061ec982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1f05ef-7607-4a63-a710-18d0061ec982.jpg?1",
             "name": "Talion, the Kindly Lord",
             "text": "Flying\nAs Talion, the Kindly Lord enters the battlefield, choose a number between 1 and 10.\nWhenever an opponent casts a spell with mana value, power, or toughness equal to the chosen number, that player loses 2 life and you draw a card.",
             "colours": [
@@ -13083,7 +13083,7 @@
         },
         {
             "id": "7fdd72f5-c8bf-5429-a281-1439c4cd92a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e3db-19ae-4f89-80ec-bf0ad561be39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e3db-19ae-4f89-80ec-bf0ad561be39.jpg?1",
             "name": "Will, Scion of Peace",
             "text": "Vigilance\n{T}: Spells you cast this turn that are white and/or blue cost {X} less to cast, where X is the amount of life you gained this turn. Activate only as a sorcery.",
             "colours": [
@@ -13124,7 +13124,7 @@
         },
         {
             "id": "bec04914-0e09-5b2f-9dd4-298562302175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901796b2-c567-41e2-a87b-6147a966c9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901796b2-c567-41e2-a87b-6147a966c9a8.jpg?1",
             "name": "Restless Bivouac",
             "text": "Restless Bivouac enters the battlefield tapped.\n{T}: Add {R} or {W}.\n{1}{R}{W}: Restless Bivouac becomes a 2/2 red and white Ox creature until end of turn. It's still a land.\nWhenever Restless Bivouac attacks, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -13157,7 +13157,7 @@
         },
         {
             "id": "e1f13f95-cda1-5ce2-8474-588109638cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb97ff-9356-4be7-8991-091f950c0b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb97ff-9356-4be7-8991-091f950c0b63.jpg?1",
             "name": "Restless Cottage",
             "text": "Restless Cottage enters the battlefield tapped.\n{T}: Add {B} or {G}.\n{2}{B}{G}: Restless Cottage becomes a 4/4 black and green Horror creature until end of turn. It's still a land.\nWhenever Restless Cottage attacks, create a Food token and exile up to one target card from a graveyard.",
             "colours": [],
@@ -13190,7 +13190,7 @@
         },
         {
             "id": "1e724296-d370-5b52-8307-00c6acc5ab89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8034589b-3b57-49be-b0fd-a306f915d864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8034589b-3b57-49be-b0fd-a306f915d864.jpg?1",
             "name": "Restless Fortress",
             "text": "Restless Fortress enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{2}{W}{B}: Restless Fortress becomes a 1/4 white and black Nightmare creature until end of turn. It's still a land.\nWhenever Restless Fortress attacks, defending player loses 2 life and you gain 2 life.",
             "colours": [],
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "4b97a0b2-e2de-5c4e-ad86-285db5afc279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc42bb4f-475e-4c76-bcbd-a9d8cf03117c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc42bb4f-475e-4c76-bcbd-a9d8cf03117c.jpg?1",
             "name": "Restless Spire",
             "text": "Restless Spire enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{U}{R}: Until end of turn, Restless Spire becomes a 2/1 blue and red Elemental creature with \"As long as it's your turn, this creature has first strike.\" It's still a land.\nWhenever Restless Spire attacks, scry 1.",
             "colours": [],
@@ -13256,7 +13256,7 @@
         },
         {
             "id": "3d90e022-6dae-58f0-ab02-6ea1a758b83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a710643a-b9dd-49bf-a375-d9986b05ed7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a710643a-b9dd-49bf-a375-d9986b05ed7a.jpg?1",
             "name": "Restless Vinestalk",
             "text": "Restless Vinestalk enters the battlefield tapped.\n{T}: Add {G} or {U}.\n{3}{G}{U}: Until end of turn, Restless Vinestalk becomes a 5/5 green and blue Plant creature with trample. It's still a land.\nWhenever Restless Vinestalk attacks, up to one other target creature has base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -13289,7 +13289,7 @@
         },
         {
             "id": "0a5e7e8d-82d3-51dc-9e42-f929b7efb4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2aed-3514-4db9-8da0-329620b12f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2aed-3514-4db9-8da0-329620b12f63.jpg?1",
             "name": "Food Coma",
             "text": "When Food Coma enters the battlefield, exile target creature an opponent controls until Food Coma leaves the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -13321,7 +13321,7 @@
         },
         {
             "id": "59b3a982-1cf5-5469-b9b6-0c4c39f59c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg?1",
             "name": "Lady of Laughter",
             "text": "Flying\nCelebration \u2014\u00a0\nAt the beginning of your end step, if two or more nonland permanents entered the battlefield under your control this turn, draw a card.",
             "colours": [
@@ -13358,7 +13358,7 @@
         },
         {
             "id": "b9e304cd-0698-5616-bff0-00fd8b69e1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671c2a0-51e8-4d5e-8409-87abd6c0a8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671c2a0-51e8-4d5e-8409-87abd6c0a8ab.jpg?1",
             "name": "Pests of Honor",
             "text": "Celebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Pests of Honor.",
             "colours": [
@@ -13392,7 +13392,7 @@
         },
         {
             "id": "70a53330-bd36-5136-9701-a2751844797b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg?1",
             "name": "Faerie Slumber Party",
             "text": "Return all creatures to their owners' hands. For each opponent who controlled a creature returned this way, you create two 1/1 blue Faerie creature tokens with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "2b4a9a76-7da2-5d54-bc9b-7dff7f7ca056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg?1",
             "name": "Rowdy Research",
             "text": "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",
             "colours": [
@@ -13458,7 +13458,7 @@
         },
         {
             "id": "2c11c746-7882-5244-b784-16713e4a5a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f4cf85-2120-4897-aecd-4ee4b02d6f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f4cf85-2120-4897-aecd-4ee4b02d6f9b.jpg?1",
             "name": "Storyteller Pixie",
             "text": "Flying\nWhenever you cast an Adventure spell, draw a card.",
             "colours": [
@@ -13493,7 +13493,7 @@
         },
         {
             "id": "d98f370d-ea20-54e2-ba04-04397ccad43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aaf5db-9418-4b97-97da-736c674905d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aaf5db-9418-4b97-97da-736c674905d4.jpg?1",
             "name": "Experimental Confectioner",
             "text": "When Experimental Confectioner enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever you sacrifice a Food, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -13528,7 +13528,7 @@
         },
         {
             "id": "a97bc16f-1983-5e89-a171-e8bd8c115185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cb3c6d-560d-40ca-b5c0-27322863cead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cb3c6d-560d-40ca-b5c0-27322863cead.jpg?1",
             "name": "Malevolent Witchkite",
             "text": "Flying\nWhen Malevolent Witchkite enters the battlefield, sacrifice any number of artifacts, enchantments, and/or tokens, then draw that many cards.",
             "colours": [
@@ -13565,7 +13565,7 @@
         },
         {
             "id": "547c1f98-7f93-5743-b524-43a7c4ebbb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c77d6f-de14-423c-bf55-0fb289171004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c77d6f-de14-423c-bf55-0fb289171004.jpg?1",
             "name": "Old Flitterfang",
             "text": "Flying\nAt the beginning of each end step, if a creature died this turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets +2/+2 until end of turn.",
             "colours": [
@@ -13602,7 +13602,7 @@
         },
         {
             "id": "cd9565bc-6c28-536d-b8e8-dd4ab031b7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a154dadc-be5b-4ad6-9946-bdc54c251bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a154dadc-be5b-4ad6-9946-bdc54c251bff.jpg?1",
             "name": "Become Brutes",
             "text": "One or two target creatures each gain haste until end of turn. For each of those creatures, create a Monster Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)",
             "colours": [
@@ -13634,7 +13634,7 @@
         },
         {
             "id": "2d2dc7fe-461a-5624-905b-216b43f63644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddc6f47-202d-4764-abc1-ee453a8917c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddc6f47-202d-4764-abc1-ee453a8917c2.jpg?1",
             "name": "Charging Hooligan",
             "text": "Whenever Charging Hooligan attacks, it gets +1/+0 until end of turn for each attacking creature. If a Rat is attacking, Charging Hooligan gains trample until end of turn.",
             "colours": [
@@ -13669,7 +13669,7 @@
         },
         {
             "id": "e1a431ee-d95b-521b-9429-63885fab45a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg?1",
             "name": "Ogre Chitterlord",
             "text": "Menace\nWhenever Ogre Chitterlord enters the battlefield or attacks, create two 1/1 black Rat creature tokens with \"This creature can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn.",
             "colours": [
@@ -13706,7 +13706,7 @@
         },
         {
             "id": "6141fd5d-4051-530e-850c-e35a82c990a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg?1",
             "name": "Intrepid Trufflesnout // Go Hog Wild",
             "text": "Whenever Intrepid Trufflesnout attacks alone, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -13740,7 +13740,7 @@
         },
         {
             "id": "cdabd5c7-4a86-5f76-aa43-22e00c9b2334",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg?1",
             "name": "Intrepid Trufflesnout // Go Hog Wild",
             "text": "Target creature gets +2/+2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -13774,7 +13774,7 @@
         },
         {
             "id": "f5c9b1a7-3c21-51e5-a15b-0278d9f748e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015282d-bcd4-44ab-ae26-41e4e3b23fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015282d-bcd4-44ab-ae26-41e4e3b23fc0.jpg?1",
             "name": "Provisions Merchant",
             "text": "When Provisions Merchant enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever Provisions Merchant attacks, you may sacrifice a Food. If you do, attacking creatures get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -13809,7 +13809,7 @@
         },
         {
             "id": "ea9f1a7d-7337-5e9c-8d77-a77106469b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg?1",
             "name": "Wildwood Mentor",
             "text": "Whenever a token enters the battlefield under your control, put a +1/+1 counter on Wildwood Mentor.\nWhenever Wildwood Mentor attacks, another target attacking creature gets +X/+X until end of turn, where X is Wildwood Mentor's power.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "48acb8d7-95ec-5563-b5d3-ce00aaf0a8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2b19f1-2f92-458d-a658-25481c57dea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2b19f1-2f92-458d-a658-25481c57dea0.jpg?1",
             "name": "Archon of the Wild Rose",
             "text": "Flying\nOther creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.",
             "colours": [
@@ -13881,7 +13881,7 @@
         },
         {
             "id": "798bf4f2-da0a-5c23-89ec-dce521f4f123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5907a-2d70-46a9-b9f9-0ae7bcf35d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5907a-2d70-46a9-b9f9-0ae7bcf35d48.jpg?1",
             "name": "Expel the Interlopers",
             "text": "Choose a number between 0 and 10. Destroy all creatures with power greater than or equal to the chosen number.",
             "colours": [
@@ -13916,7 +13916,7 @@
         },
         {
             "id": "94243eb5-2846-5f29-aa58-7214f7df5f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e06198-b96a-4b52-ba86-3df8278c0785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e06198-b96a-4b52-ba86-3df8278c0785.jpg?1",
             "name": "Moonshaker Cavalry",
             "text": "Flying\nWhen Moonshaker Cavalry enters the battlefield, creatures you control gain flying and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -13953,7 +13953,7 @@
         },
         {
             "id": "c50b0d4d-2aa0-5f60-a2c5-d1df319bdf3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e650b3f-30a7-4943-8829-055e8aa7b9cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e650b3f-30a7-4943-8829-055e8aa7b9cd.jpg?1",
             "name": "Regal Bunnicorn",
             "text": "Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control.",
             "colours": [
@@ -13990,7 +13990,7 @@
         },
         {
             "id": "d6f73032-235c-511a-80b7-d27bc94c711f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6973853c-2e95-4b5b-9008-4b06ffc8a078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6973853c-2e95-4b5b-9008-4b06ffc8a078.jpg?1",
             "name": "Spellbook Vendor",
             "text": "Vigilance\nAt the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control.",
             "colours": [
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "e50f1073-3afe-5729-8ea3-fbad1383d921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc7d7d8-0965-4097-98ee-e89cfa05fd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc7d7d8-0965-4097-98ee-e89cfa05fd05.jpg?1",
             "name": "A Tale for the Ages",
             "text": "Enchanted creatures you control get +2/+2.",
             "colours": [
@@ -14061,7 +14061,7 @@
         },
         {
             "id": "a2049cae-c3f4-5d14-a7e2-2a53d3edd67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eff52-c141-4587-857b-e71050899bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eff52-c141-4587-857b-e71050899bdb.jpg?1",
             "name": "Werefox Bodyguard",
             "text": "Flash\nWhen Werefox Bodyguard enters the battlefield, exile up to one other target non-Fox creature until Werefox Bodyguard leaves the battlefield.\n{1}{W}, Sacrifice Werefox Bodyguard: You gain 2 life.",
             "colours": [
@@ -14099,7 +14099,7 @@
         },
         {
             "id": "583daff2-3348-5037-a272-fb0ff0a988e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba9c281-a6e0-4af9-a217-e6aee7a38ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba9c281-a6e0-4af9-a217-e6aee7a38ff0.jpg?1",
             "name": "Asinine Antics",
             "text": "You may cast Asinine Antics as though it had flash if you pay {2} more to cast it.\nFor each creature your opponents control, create a Cursed Role token attached to that creature.",
             "colours": [
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "d077ae38-7c95-5e4a-8261-5b67ac41bd98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd423cc-7a86-4b15-b591-85940faa323e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd423cc-7a86-4b15-b591-85940faa323e.jpg?1",
             "name": "Extraordinary Journey",
             "text": "When Extraordinary Journey enters the battlefield, exile up to X target creatures. For each of those cards, its owner may play it for as long as it remains exiled.\nWhenever one or more nontoken creatures enter the battlefield, if one or more of them entered from exile or was cast from exile, you draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -14167,7 +14167,7 @@
         },
         {
             "id": "ccf2da29-aaa3-515a-b8f4-905b12dcf01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f484b9-486f-4aff-8b23-d8e555b476d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f484b9-486f-4aff-8b23-d8e555b476d3.jpg?1",
             "name": "Farsight Ritual",
             "text": "Bargain\nLook at the top four cards of your library. If this spell was bargained, look at the top eight cards of your library instead. Put two of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14201,7 +14201,7 @@
         },
         {
             "id": "16f8fcf7-24a1-51a4-a9dc-de0ea79625c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bf6c34-429b-4213-856b-e8189276f2db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bf6c34-429b-4213-856b-e8189276f2db.jpg?1",
             "name": "Ingenious Prodigy",
             "text": "Skulk\nIngenious Prodigy enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, if Ingenious Prodigy has one or more +1/+1 counters on it, you may remove a +1/+1 counter from it. If you do, draw a card.",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "0022d876-c3a5-57cb-b1f0-944eaf73e1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb94d9f-d679-4eb2-97d4-b519d8a166b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb94d9f-d679-4eb2-97d4-b519d8a166b0.jpg?1",
             "name": "Sleep-Cursed Faerie",
             "text": "Flying, ward {2}\nSleep-Cursed Faerie enters the battlefield tapped with three stun counters on it.\n{1}{U}: Untap Sleep-Cursed Faerie.",
             "colours": [
@@ -14275,7 +14275,7 @@
         },
         {
             "id": "252e222a-d9a4-53f3-b4d2-9566f6403f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54e69e4-c6c9-4735-ab86-c437eba8d4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54e69e4-c6c9-4735-ab86-c437eba8d4e2.jpg?1",
             "name": "Talion's Messenger",
             "text": "Flying\nWhenever you attack with one or more Faeries, draw a card, then discard a card. When you discard a card this way, put a +1/+1 counter on target Faerie you control.",
             "colours": [
@@ -14312,7 +14312,7 @@
         },
         {
             "id": "ee499002-5e27-5b5a-9c2c-fe0d644bda78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3d7fa-2b43-4b9e-85eb-ef96537942fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3d7fa-2b43-4b9e-85eb-ef96537942fb.jpg?1",
             "name": "Beseech the Mirror",
             "text": "Bargain\nSearch your library for a card, exile it face down, then shuffle. If this spell was bargained, you may cast the exiled card without paying its mana cost if that spell's mana value is 4 or less. Put the exiled card into your hand if it wasn't cast this way.",
             "colours": [
@@ -14346,7 +14346,7 @@
         },
         {
             "id": "1a409bd0-d391-5f08-b888-f59b457f0745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79220c46-01df-41c1-877e-577f9ce78593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79220c46-01df-41c1-877e-577f9ce78593.jpg?1",
             "name": "The End",
             "text": "This spell costs {2} less to cast if your life total is 5 or less.\nExile target creature or planeswalker. Search its controller's graveyard, hand, and library for any number of cards with the same name as that permanent and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -14380,7 +14380,7 @@
         },
         {
             "id": "cb66f2dd-2d3e-5c75-a1f4-d0185ff42c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee2cc6-955c-43fb-b359-9d0e261c6925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee2cc6-955c-43fb-b359-9d0e261c6925.jpg?1",
             "name": "Lich-Knights' Conquest",
             "text": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "98186e5f-6889-5f41-a531-664a56aa6a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728520b3-fd90-46e4-ad51-3121a2557e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728520b3-fd90-46e4-ad51-3121a2557e86.jpg?1",
             "name": "Lord Skitter, Sewer King",
             "text": "Whenever another Rat enters the battlefield under your control, exile up to one target card from an opponent's graveyard.\nAt the beginning of combat on your turn, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -14454,7 +14454,7 @@
         },
         {
             "id": "4215208e-0067-5ba5-819e-d7db269bfbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c78dde-4059-4e8d-9feb-f03653773787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c78dde-4059-4e8d-9feb-f03653773787.jpg?1",
             "name": "Lord Skitter's Blessing",
             "text": "When Lord Skitter's Blessing enters the battlefield, create a Wicked Role token attached to target creature you control.\nAt the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you draw an additional card.",
             "colours": [
@@ -14488,7 +14488,7 @@
         },
         {
             "id": "8fa4be54-8007-575c-a019-6f69874c15a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342061c-6992-47d2-b862-db310d389b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342061c-6992-47d2-b862-db310d389b3d.jpg?1",
             "name": "Rankle's Prank",
             "text": "Choose one or more \u2014\n\u2022 Each player discards two cards.\n\u2022 Each player loses 4 life.\n\u2022 Each player sacrifices two creatures.",
             "colours": [
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "2eba4813-73b8-576a-80ff-c646b63ba04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3026523f-65a0-49a4-a46e-bb91a8988ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3026523f-65a0-49a4-a46e-bb91a8988ea4.jpg?1",
             "name": "Specter of Mortality",
             "text": "Flying\nWhen Specter of Mortality enters the battlefield, you may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "eba0a8cf-566a-5100-b431-0d7a01aac12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d527d48d-d6f7-4587-955e-de23b80ce0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d527d48d-d6f7-4587-955e-de23b80ce0d6.jpg?1",
             "name": "Spiteful Hexmage",
             "text": "When Spiteful Hexmage enters the battlefield, create a Cursed Role token attached to target creature you control.",
             "colours": [
@@ -14595,7 +14595,7 @@
         },
         {
             "id": "329d2c6f-2e7f-5f25-81c5-7c70ec336ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ba866b-eda5-45c0-8878-235abadc0a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ba866b-eda5-45c0-8878-235abadc0a3c.jpg?1",
             "name": "Tangled Colony",
             "text": "Tangled Colony can't block.\nWhen Tangled Colony dies, create X 1/1 black Rat creature tokens with \"This creature can't block,\" where X is the amount of damage dealt to it this turn.",
             "colours": [
@@ -14631,7 +14631,7 @@
         },
         {
             "id": "29ab8f3e-480a-523e-8301-5dab2f655190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f94c92-cf88-4770-8ab8-874cd6634510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f94c92-cf88-4770-8ab8-874cd6634510.jpg?1",
             "name": "Charming Scoundrel",
             "text": "Haste\nWhen Charming Scoundrel enters the battlefield, choose one \u2014\n\u2022 Discard a card, then draw a card.\n\u2022 Create a Treasure token.\n\u2022 Create a Wicked Role token attached to target creature you control.",
             "colours": [
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "00851b83-9fe6-575f-b838-d7444e6a5279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef34fc2-8d37-484d-9adf-e3bb70283f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef34fc2-8d37-484d-9adf-e3bb70283f33.jpg?1",
             "name": "Food Fight",
             "text": "Artifacts you control have \"{2}, Sacrifice this artifact: It deals damage to any target equal to 1 plus the number of permanents named Food Fight you control.\"",
             "colours": [
@@ -14702,7 +14702,7 @@
         },
         {
             "id": "12ac820b-f2c2-5ce7-a9cc-d1d78b6ca107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb884762-5468-43be-870a-96328f8172c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb884762-5468-43be-870a-96328f8172c2.jpg?1",
             "name": "Goddric, Cloaked Reveler",
             "text": "Haste\nCelebration \u2014 As long as two or more nonland permanents entered the battlefield under your control this turn, Goddric, Cloaked Reveler is a Dragon with base power and toughness 4/4, flying, and \"{R}: Dragons you control get +1/+0 until end of turn.\"",
             "colours": [
@@ -14741,7 +14741,7 @@
         },
         {
             "id": "6961cc28-b9b4-5386-b5de-f9d6de7e7c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77bf3c05-4cbb-4525-9724-2d04cb2084f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77bf3c05-4cbb-4525-9724-2d04cb2084f3.jpg?1",
             "name": "Imodane, the Pyrohammer",
             "text": "Whenever an instant or sorcery spell you control that targets only a single creature deals damage to that creature, Imodane deals that much damage to each opponent.",
             "colours": [
@@ -14780,7 +14780,7 @@
         },
         {
             "id": "682e1bc2-8c5f-579f-8a6e-1f7cf80a4826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cabc6-f3a6-4992-acfc-1bed6bc5f05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cabc6-f3a6-4992-acfc-1bed6bc5f05d.jpg?1",
             "name": "Raging Battle Mouse",
             "text": "The second spell you cast each turn costs {1} less to cast.\nCelebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -14816,7 +14816,7 @@
         },
         {
             "id": "fd0550d7-baf8-590a-bc50-f1ab049c22b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2d38fe-7fa5-4b29-b3e2-dd20d5afd127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2d38fe-7fa5-4b29-b3e2-dd20d5afd127.jpg?1",
             "name": "Realm-Scorcher Hellkite",
             "text": "Bargain\nFlying, haste\nWhen Realm-Scorcher Hellkite enters the battlefield, if it was bargained, add four mana in any combination of colors.\n{1}{R}: Realm-Scorcher Hellkite deals 1 damage to any target.",
             "colours": [
@@ -14852,7 +14852,7 @@
         },
         {
             "id": "e86cd4cc-590f-5e0c-bec2-2a3ace590741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb9275-07f2-46b1-a64b-2971390a35de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb9275-07f2-46b1-a64b-2971390a35de.jpg?1",
             "name": "Redcap Gutter-Dweller",
             "text": "Menace\nWhen Redcap Gutter-Dweller enters the battlefield, create two 1/1 black Rat creature tokens with \"This creature can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on Redcap Gutter-Dweller and exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -14889,7 +14889,7 @@
         },
         {
             "id": "9c1b40b5-7e2f-59f3-8208-3ad0bcacc082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a55780-cb3b-429a-b0a8-ac616f85582f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a55780-cb3b-429a-b0a8-ac616f85582f.jpg?1",
             "name": "Rotisserie Elemental",
             "text": "Menace\nWhenever Rotisserie Elemental deals combat damage to a player, put a skewer counter on Rotisserie Elemental. Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the number of skewer counters on Rotisserie Elemental. You may play those cards this turn.",
             "colours": [
@@ -14925,7 +14925,7 @@
         },
         {
             "id": "41745161-4031-50f8-8171-96a2cdef93b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c2f106-0df8-4d4f-a6ef-7946fe8e47c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c2f106-0df8-4d4f-a6ef-7946fe8e47c4.jpg?1",
             "name": "Song of Totentanz",
             "text": "Create X 1/1 black Rat creature tokens with \"This creature can't block.\" Creatures you control gain haste until end of turn.",
             "colours": [
@@ -14959,7 +14959,7 @@
         },
         {
             "id": "77f469b2-0eda-5930-80c5-8c8913d9c9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79593c3a-00d9-4d24-a49c-753520a1ce30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79593c3a-00d9-4d24-a49c-753520a1ce30.jpg?1",
             "name": "Blossoming Tortoise",
             "text": "Whenever Blossoming Tortoise enters the battlefield or attacks, mill three cards, then return a land card from your graveyard to the battlefield tapped.\nActivated abilities of lands you control cost {1} less to activate.\nLand creatures you control get +1/+1.",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "7295be11-284c-5235-9fb4-967f016f82e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7678157-e18e-45bd-a28e-7594a49bf2d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7678157-e18e-45bd-a28e-7594a49bf2d7.jpg?1",
             "name": "Elvish Archivist",
             "text": "Whenever one or more artifacts enter the battlefield under your control, put two +1/+1 counters on Elvish Archivist. This ability triggers only once each turn.\nWhenever one or more enchantments enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -15032,7 +15032,7 @@
         },
         {
             "id": "a3858001-977a-55c7-90c3-b94b817b1391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794c5066-724b-4f94-aa6e-7b0690dd706e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794c5066-724b-4f94-aa6e-7b0690dd706e.jpg?1",
             "name": "Feral Encounter",
             "text": "Look at the top five cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card this turn. At the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.",
             "colours": [
@@ -15066,7 +15066,7 @@
         },
         {
             "id": "e5e23350-edf6-557e-93be-bf7c3d5de6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7bd4-c12d-48a7-b39f-36033636e5c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7bd4-c12d-48a7-b39f-36033636e5c7.jpg?1",
             "name": "Gruff Triplets",
             "text": "Trample\nWhen Gruff Triplets enters the battlefield, if it isn't a token, create two tokens that are copies of it.\nWhen Gruff Triplets dies, put a number of +1/+1 counters equal to its power on each creature you control named Gruff Triplets.",
             "colours": [
@@ -15103,7 +15103,7 @@
         },
         {
             "id": "fffbfc17-a457-565d-a1ed-aefe5810c86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8556d3c-9290-4600-afa5-5928d74e3c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8556d3c-9290-4600-afa5-5928d74e3c96.jpg?1",
             "name": "Sentinel of Lost Lore",
             "text": "When Sentinel of Lost Lore enters the battlefield, choose one or more \u2014\n\u2022 Return target card you own in exile that has an Adventure to your hand.\n\u2022 Put target card you don't own in exile that has an Adventure on the bottom of its owner's library.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "b9658d09-b766-50c0-b94b-8c3c5b838755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742aa20-4b18-4296-9693-c2c5a8ba6c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742aa20-4b18-4296-9693-c2c5a8ba6c04.jpg?1",
             "name": "Thunderous Debut",
             "text": "Bargain\nLook at the top twenty cards of your library. You may reveal up to two creature cards from among them. If this spell was bargained, put the revealed cards onto the battlefield. Otherwise, put the revealed cards into your hand. Then shuffle.",
             "colours": [
@@ -15174,7 +15174,7 @@
         },
         {
             "id": "b8ac45f9-eded-5424-a747-6b15290fbdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f6c96-698d-4f5c-81ec-91176bd2e6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f6c96-698d-4f5c-81ec-91176bd2e6e8.jpg?1",
             "name": "Agatha of the Vile Cauldron",
             "text": "Activated abilities of creatures you control cost {X} less to activate, where X is Agatha of the Vile Cauldron's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.",
             "colours": [
@@ -15215,7 +15215,7 @@
         },
         {
             "id": "21f2e03c-458d-554d-8c3d-7673fb4c535e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf2ce6a-f2ee-42a4-a026-b1d0c18a3ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf2ce6a-f2ee-42a4-a026-b1d0c18a3ed4.jpg?1",
             "name": "Faunsbane Troll",
             "text": "When Faunsbane Troll enters the battlefield, create a Monster Role token attached to it.\n{1}, Sacrifice an Aura attached to Faunsbane Troll: Faunsbane Troll fights target creature you don't control. If that creature would die this turn, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -15253,7 +15253,7 @@
         },
         {
             "id": "cb7f0b43-5a9a-566d-96d2-0ae388d419a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1024d5f1-69f4-4a09-ba83-6fcc249217fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1024d5f1-69f4-4a09-ba83-6fcc249217fa.jpg?1",
             "name": "The Goose Mother",
             "text": "Flying\nThe Goose Mother enters the battlefield with X +1/+1 counters on it.\nWhen The Goose Mother enters the battlefield, create half X Food tokens, rounded up.\nWhenever The Goose Mother attacks, you may sacrifice a Food. If you do, draw a card.",
             "colours": [
@@ -15294,7 +15294,7 @@
         },
         {
             "id": "d5616af1-36f0-5dae-ad13-073a50895c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f5f043-0b59-40ba-bdab-1706adf44075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f5f043-0b59-40ba-bdab-1706adf44075.jpg?1",
             "name": "Hylda of the Icy Crown",
             "text": "Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do, choose one \u2014\n\u2022 Create a 4/4 white and blue Elemental creature token.\n\u2022 Put a +1/+1 counter on each creature you control.\n\u2022 Scry 2, then draw a card.",
             "colours": [
@@ -15335,7 +15335,7 @@
         },
         {
             "id": "bfe0e975-ca97-515f-8fe2-66ac484fecd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51232f-ee63-4929-adab-042101c97b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51232f-ee63-4929-adab-042101c97b23.jpg?1",
             "name": "Likeness Looter",
             "text": "Flying\n{T}: Draw a card, then discard a card.\n{X}: Likeness Looter becomes a copy of target creature card in your graveyard with mana value X, except it has flying and this ability. Activate only as a sorcery.",
             "colours": [
@@ -15374,7 +15374,7 @@
         },
         {
             "id": "1d453913-e73b-5c22-8180-650e683ef7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02f04f7-a345-4aa9-933c-1969f0cdd5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02f04f7-a345-4aa9-933c-1969f0cdd5c6.jpg?1",
             "name": "Yenna, Redtooth Regent",
             "text": "{2}, {T}: Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, Redtooth Regent, then scry 2. Activate only as a sorcery.",
             "colours": [
@@ -15415,7 +15415,7 @@
         },
         {
             "id": "2e211814-80eb-5ab1-86dc-51a377a159c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec5fc59-73d8-4735-88f1-3dbd1f15a546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec5fc59-73d8-4735-88f1-3dbd1f15a546.jpg?1",
             "name": "Agatha's Soul Cauldron",
             "text": "You may spend mana as though it were mana of any color to activate abilities of creatures you control.\nCreatures you control with +1/+1 counters on them have all activated abilities of all creature cards exiled with Agatha's Soul Cauldron.\n{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -15447,7 +15447,7 @@
         },
         {
             "id": "ab96d9fe-5fea-5f8e-b97b-293de0253edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141f900-a87b-40ce-8439-02c000aafa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141f900-a87b-40ce-8439-02c000aafa30.jpg?1",
             "name": "Hylda's Crown of Winter",
             "text": "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.\n{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control.",
             "colours": [],
@@ -15479,7 +15479,7 @@
         },
         {
             "id": "81f2c321-536e-5156-bab8-ea0a1c8ec8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c50432-28af-40e8-ae98-d4f33a5a936e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c50432-28af-40e8-ae98-d4f33a5a936e.jpg?1",
             "name": "The Irencrag",
             "text": "{T}: Add {C}.\nWhenever a legendary creature enters the battlefield under your control, you may have The Irencrag become a legendary Equipment artifact named Everflame, Heroes' Legacy. If you do, it gains equip {3} and \"Equipped creature gets +3/+3\" and loses all other abilities.",
             "colours": [],
@@ -15511,7 +15511,7 @@
         },
         {
             "id": "30586399-0435-5a87-922a-de165a64feee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522e43f3-4f9a-4f40-a5f5-d84277172040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522e43f3-4f9a-4f40-a5f5-d84277172040.jpg?1",
             "name": "Syr Ginger, the Meal Ender",
             "text": "Syr Ginger, the Meal Ender has trample, hexproof, and haste as long as an opponent controls a planeswalker.\nWhenever another artifact you control is put into a graveyard from the battlefield, put a +1/+1 counter on Syr Ginger and scry 1.\n{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power.",
             "colours": [],
@@ -15547,7 +15547,7 @@
         },
         {
             "id": "3155d297-4e02-5323-bdd3-b107f7d1b47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ba4b10-5667-414c-a692-166a19b7d748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ba4b10-5667-414c-a692-166a19b7d748.jpg?1",
             "name": "Lady of Laughter",
             "text": "Flying\nCelebration \u2014\u00a0\nAt the beginning of your end step, if two or more nonland permanents entered the battlefield under your control this turn, draw a card.",
             "colours": [
@@ -15584,7 +15584,7 @@
         },
         {
             "id": "e30a3e2f-5afb-521f-9765-64d721a5d32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d1945f-6462-4ec3-a966-3a8dafc0f5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d1945f-6462-4ec3-a966-3a8dafc0f5d8.jpg?1",
             "name": "Faerie Slumber Party",
             "text": "Return all creatures to their owners' hands. For each opponent who controlled a creature returned this way, you create two 1/1 blue Faerie creature tokens with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -15618,7 +15618,7 @@
         },
         {
             "id": "2aa5adcd-257a-5012-803a-cce5b8cb7730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee6723-9b90-4d39-9cbb-9d3765a4fcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee6723-9b90-4d39-9cbb-9d3765a4fcb0.jpg?1",
             "name": "Malevolent Witchkite",
             "text": "Flying\nWhen Malevolent Witchkite enters the battlefield, sacrifice any number of artifacts, enchantments, and/or tokens, then draw that many cards.",
             "colours": [
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "073cfe6f-5684-53c8-a961-fb59d9b5b862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8d687a-8935-4907-909f-4cadac6cdf67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8d687a-8935-4907-909f-4cadac6cdf67.jpg?1",
             "name": "Ogre Chitterlord",
             "text": "Menace\nWhenever Ogre Chitterlord enters the battlefield or attacks, create two 1/1 black Rat creature tokens with \"This creature can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn.",
             "colours": [
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "c162db73-73e6-5646-82c3-314cccbe70da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7b456e-e56d-45dd-88b3-1ac58a9bfb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7b456e-e56d-45dd-88b3-1ac58a9bfb5f.jpg?1",
             "name": "Wildwood Mentor",
             "text": "Whenever a token enters the battlefield under your control, put a +1/+1 counter on Wildwood Mentor.\nWhenever Wildwood Mentor attacks, another target attacking creature gets +X/+X until end of turn, where X is Wildwood Mentor's power.",
             "colours": [
@@ -15728,7 +15728,7 @@
         },
         {
             "id": "68a4071d-c149-5137-8a5f-696b9a1ae762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73014a95-5251-4404-b3a3-037fb5ca3327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73014a95-5251-4404-b3a3-037fb5ca3327.jpg?1",
             "name": "Stroke of Midnight",
             "text": "Destroy target nonland permanent. Its controller creates a 1/1 white Human creature token.",
             "colours": [
@@ -15762,7 +15762,7 @@
         },
         {
             "id": "0972ac2b-b2f9-5966-ac3b-1215246cb487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c81647-6586-4c9c-93fc-9d5ee40b377b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c81647-6586-4c9c-93fc-9d5ee40b377b.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -15796,7 +15796,7 @@
         },
         {
             "id": "73dc1a50-648a-5f9b-93b3-8ba14291b874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373f235b-ce93-48b0-8e36-71f5bc5efcc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373f235b-ce93-48b0-8e36-71f5bc5efcc2.jpg?1",
             "name": "Faerie Dreamthief",
             "text": "Flying\nWhen Faerie Dreamthief enters the battlefield, surveil 1.\n{2}{B}, Exile Faerie Dreamthief from your graveyard: You draw a card and you lose 1 life.",
             "colours": [
@@ -15833,7 +15833,7 @@
         },
         {
             "id": "9e71ec2e-e579-5ddb-994e-8d957c59fbaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603675e-84df-4dd2-b45b-47349341f64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603675e-84df-4dd2-b45b-47349341f64c.jpg?1",
             "name": "Torch the Tower",
             "text": "Bargain\nTorch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained, instead it deals 3 damage to that permanent and you scry 1.\nIf a permanent dealt damage by Torch the Tower would die this turn, exile it instead.",
             "colours": [
@@ -15867,7 +15867,7 @@
         },
         {
             "id": "69d23eb9-bc04-5366-94e6-9da048ff2886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca603dc-8a2d-484d-8b95-25dfa39369fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca603dc-8a2d-484d-8b95-25dfa39369fd.jpg?1",
             "name": "Tanglespan Lookout",
             "text": "Whenever an Aura enters the battlefield under your control, draw a card.",
             "colours": [
@@ -15903,7 +15903,7 @@
         },
         {
             "id": "9e160b1e-06ad-58c9-a6bc-55bae755f3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ffe314-b66b-48d8-b94d-36c8bb5861e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ffe314-b66b-48d8-b94d-36c8bb5861e4.jpg?1",
             "name": "Lich-Knights' Conquest",
             "text": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -15937,7 +15937,7 @@
         },
         {
             "id": "b4604969-4a00-521b-bcf3-2257fe3a44c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaac375-57ce-432b-b718-b547367faec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaac375-57ce-432b-b718-b547367faec7.jpg?1",
             "name": "Expel the Interlopers",
             "text": "Choose a number between 0 and 10. Destroy all creatures with power greater than or equal to the chosen number.",
             "colours": [
@@ -15971,7 +15971,7 @@
         },
         {
             "id": "3b0fa459-5153-5fea-8dff-cb16c1c932dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16006,7 +16006,7 @@
         },
         {
             "id": "b10c0494-4000-52fd-b93c-6af7da4e71d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -16041,7 +16041,7 @@
         },
         {
             "id": "8e024fa2-e2fc-5eb3-a2ff-295d496c0d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16076,7 +16076,7 @@
         },
         {
             "id": "27f0061d-f29b-5058-8d71-7d99ee87b052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80435c8-9a41-47cb-be84-784a278adcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80435c8-9a41-47cb-be84-784a278adcae.jpg?1",
             "name": "Mouse",
             "text": "",
             "colours": [
@@ -16111,7 +16111,7 @@
         },
         {
             "id": "ebe161d9-962f-584c-b10b-5a87dfdd24a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg?1",
             "name": "Faerie",
             "text": "",
             "colours": [
@@ -16146,7 +16146,7 @@
         },
         {
             "id": "2a779ede-71be-5f0c-8ccf-c434f2892afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858428ee-3a9c-4dfc-84c2-751e59df2ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858428ee-3a9c-4dfc-84c2-751e59df2ed7.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -16181,7 +16181,7 @@
         },
         {
             "id": "2ff9f472-d654-56b6-bba6-cb501a09ad5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -16216,7 +16216,7 @@
         },
         {
             "id": "5bcd3bc9-e9c5-52ca-964f-12d045535a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d33cf3-c803-4e90-9d4b-fa34136b600e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d33cf3-c803-4e90-9d4b-fa34136b600e.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -16251,7 +16251,7 @@
         },
         {
             "id": "d2cce550-6244-5702-a711-1464205e0709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff615495-a230-484e-a858-ead84f880bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff615495-a230-484e-a858-ead84f880bdd.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16288,7 +16288,7 @@
         },
         {
             "id": "2c699539-fec1-5ef0-b8a8-7c9bf3c4216d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4f83dd-94c0-4594-8e72-611eb76fa4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4f83dd-94c0-4594-8e72-611eb76fa4e2.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16319,7 +16319,7 @@
         },
         {
             "id": "da4e6e00-e477-5fba-9f49-993015cbbdab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaec411-0590-4662-ac88-11bb0008d69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaec411-0590-4662-ac88-11bb0008d69c.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16350,7 +16350,7 @@
         },
         {
             "id": "f24d9414-a9cc-50f6-aac6-16e596b7c671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a40362-be01-4a16-9c98-0761fffb2560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a40362-be01-4a16-9c98-0761fffb2560.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16381,7 +16381,7 @@
         },
         {
             "id": "fb8bf330-86de-566c-ae38-09bbc290c33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67727b7-819c-4e96-aa8e-1e01ecaf9f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67727b7-819c-4e96-aa8e-1e01ecaf9f33.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16412,7 +16412,7 @@
         },
         {
             "id": "8fb72ba2-7332-5577-b7bd-d75df4c727c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbf189-a79b-4dca-8b29-33aef6306b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbf189-a79b-4dca-8b29-33aef6306b5a.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -16443,7 +16443,7 @@
         },
         {
             "id": "246f948c-eea9-5f6a-8d19-f8c11c51de94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg?1",
             "name": "Monster // Sorcerer",
             "text": "",
             "colours": [],
@@ -16475,7 +16475,7 @@
         },
         {
             "id": "dd6f5274-9bb4-5acc-9855-55815f497831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg?1",
             "name": "Monster // Sorcerer",
             "text": "",
             "colours": [],
@@ -16507,7 +16507,7 @@
         },
         {
             "id": "4c23fc6d-6c85-5c7b-9176-eeee951c3b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg?1",
             "name": "Royal // Young Hero",
             "text": "",
             "colours": [],
@@ -16539,7 +16539,7 @@
         },
         {
             "id": "1498b1ca-31fb-50bd-b106-b9298eaece80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg?1",
             "name": "Royal // Young Hero",
             "text": "",
             "colours": [],
@@ -16571,7 +16571,7 @@
         },
         {
             "id": "be188b68-76b3-5695-88ae-97d7383f3679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg?1",
             "name": "Wicked // Cursed",
             "text": "",
             "colours": [],
@@ -16603,7 +16603,7 @@
         },
         {
             "id": "a8e38737-ad9f-538b-a910-3dbdea354ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg?1",
             "name": "Wicked // Cursed",
             "text": "",
             "colours": [],
@@ -16635,7 +16635,7 @@
         },
         {
             "id": "cf472819-5911-5d3a-bafb-4bbd7994dda4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf4c7fb-7859-4c11-8552-6817f5119d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf4c7fb-7859-4c11-8552-6817f5119d2e.jpg?1",
             "name": "On an Adventure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/WTH.json
+++ b/Assets/Resources/Sets/WTH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a34bafca-4ebb-585e-b3a7-abe39cfb6718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125a355d-bfcf-4125-aa6c-35e7dea6f63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125a355d-bfcf-4125-aa6c-35e7dea6f63e.jpg?1",
             "name": "Abeyance",
             "text": "Until end of turn, target player cannot play instants, interrupts, sorceries, or abilities requiring an activation cost.\nDraw a card.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "4da40510-af07-5549-8acb-a1eca56bb4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fcc23-ac09-4ada-b194-424739c9c734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fcc23-ac09-4ada-b194-424739c9c734.jpg?1",
             "name": "Alabaster Dragon",
             "text": "Flying\nIf Alabaster Dragon is put into any graveyard from play, shuffle Alabaster Dragon into its owner's library.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "d01447aa-5007-5b4d-8ecb-b1cfc81fa638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97382dd8-2754-4ca3-8ba8-d655acaf22ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97382dd8-2754-4ca3-8ba8-d655acaf22ac.jpg?1",
             "name": "Alms",
             "text": "o1, Remove the top card in your graveyard from the game: Prevent 1 damage to any creature.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "31ef5ac7-0db5-52f0-b632-4a8632b44aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dddde7d-8565-45a7-a1db-f2dea2a6a3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dddde7d-8565-45a7-a1db-f2dea2a6a3ba.jpg?1",
             "name": "Angelic Renewal",
             "text": "If any creatures are put into your graveyard from play, you may bury Angelic Renewal and put one of those creatures into play.",
             "colours": [
@@ -130,7 +130,7 @@
         },
         {
             "id": "b2ed0166-a592-5ea6-8839-441c57b4050b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb212ca5-bbb5-4c83-9a7b-9d5ab451e032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb212ca5-bbb5-4c83-9a7b-9d5ab451e032.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking does not cause Ardent Militia to tap.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "d4cfbe5a-0264-5e4a-813e-e5307af7b99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f23295-ad0a-4e2d-ae04-1a9c065e575d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f23295-ad0a-4e2d-ae04-1a9c065e575d.jpg?1",
             "name": "Argivian Find",
             "text": "Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "99bcf6d4-186b-5637-8a16-8025909fd977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6c366-b8c7-4f66-b8e1-82dc69c0081c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6c366-b8c7-4f66-b8e1-82dc69c0081c.jpg?1",
             "name": "Aura of Silence",
             "text": "Artifact and enchantment spells cost target opponent an additional o2 to play.\nSacrifice Aura of Silence: Destroy target artifact or enchantment.",
             "colours": [
@@ -226,7 +226,7 @@
         },
         {
             "id": "c7a963e8-bd55-5f5a-83ed-aa4ff18f674b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8472303-b8ee-402b-a9ea-49abe2e01152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8472303-b8ee-402b-a9ea-49abe2e01152.jpg?1",
             "name": "Benalish Infantry",
             "text": "Banding",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "d5ae66df-17a6-5c8a-873b-357ef1304345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c184bb-6c7d-4118-a111-ef27171cfee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c184bb-6c7d-4118-a111-ef27171cfee6.jpg?1",
             "name": "Benalish Knight",
             "text": "First strike\nYou may play Benalish Knight whenever you could play an instant.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "82b73ff1-318a-5dc9-bccc-1abb9ad39873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac1992-6212-4f05-af16-c892dfc40643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac1992-6212-4f05-af16-c892dfc40643.jpg?1",
             "name": "Benalish Missionary",
             "text": "o1o\nW, oc\nT: Target blocked creature deals no combat damage this turn.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "7c67a640-ea4d-5514-8937-3fc7a1a1d872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19ed33b-42d4-4a5d-a763-cfb43348769c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19ed33b-42d4-4a5d-a763-cfb43348769c.jpg?1",
             "name": "Debt of Loyalty",
             "text": "Regenerate target creature. Gain control of that creature.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "9635dd0b-1ae2-56ab-9f6c-fb5e4101ad0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee3a23a-6ecf-439c-8637-e096fa8c1a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee3a23a-6ecf-439c-8637-e096fa8c1a80.jpg?1",
             "name": "Duskrider Falcon",
             "text": "Flying, protection from black",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "f7336763-42f1-529a-8f07-2f0ce6e0c062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5518a79f-bcae-417a-b01b-b6ff572be0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5518a79f-bcae-417a-b01b-b6ff572be0be.jpg?1",
             "name": "Empyrial Armor",
             "text": "Enchanted creature gets +X/+X, where X is equal to the number of cards in your hand.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "586ee364-c862-509b-bd79-9362a3be0e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d11b6ef-3a24-4709-a62f-c5e062a6cee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d11b6ef-3a24-4709-a62f-c5e062a6cee1.jpg?1",
             "name": "Foriysian Brigade",
             "text": "Foriysian Brigade may block two creatures each combat. (All blocking assignments must still be legal.)",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "95d7e590-35b1-5c5e-b5da-186f9d191ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81defa5-edb4-4f1f-b13c-7cfb34511138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81defa5-edb4-4f1f-b13c-7cfb34511138.jpg?1",
             "name": "Gerrard's Wisdom",
             "text": "For each card in your hand, gain 2 life.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "de12a3f2-fe70-5e05-999f-840c86d53fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e8ec37-abe8-45a9-a1a0-6d4e37c74c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e8ec37-abe8-45a9-a1a0-6d4e37c74c45.jpg?1",
             "name": "Guided Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "ad85dabf-d7b2-5940-a4dc-760f924c47a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfe3eed-e415-4b28-8b4d-e50a19235683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfe3eed-e415-4b28-8b4d-e50a19235683.jpg?1",
             "name": "Heavy Ballista",
             "text": "oc\nT: Heavy Ballista deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "52a0e66b-de11-553d-94ec-2915171a876b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2298faae-370e-4b87-bf32-d20c2282a928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2298faae-370e-4b87-bf32-d20c2282a928.jpg?1",
             "name": "Inner Sanctum",
             "text": "Cumulative upkeep\u20142 life\nAll damage dealt to creatures you control is reduced to 0.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "9ff1796b-8d42-5699-8092-3d1aa2df7424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395e7882-0429-46aa-8e38-be707067c588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395e7882-0429-46aa-8e38-be707067c588.jpg?1",
             "name": "Kithkin Armor",
             "text": "Enchanted creature cannot be blocked by creatures with power 3 or greater.\nSacrifice Kithkin Armor: Prevent all damage to enchanted creature from one source.",
             "colours": [
@@ -619,7 +619,7 @@
         },
         {
             "id": "d71ccc8d-65f0-5d70-8475-5f5022f44cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97ff43-c0b6-4f67-ad09-5ba8710c681a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97ff43-c0b6-4f67-ad09-5ba8710c681a.jpg?1",
             "name": "Master of Arms",
             "text": "First strike\no1oo\nW Tap target creature blocking Master of Arms.",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "2392ab36-0423-568a-a798-eb048d573dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec71a29-19db-4747-8276-7fd4d563d4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec71a29-19db-4747-8276-7fd4d563d4df.jpg?1",
             "name": "Mistmoon Griffin",
             "text": "Flying\nIf Mistmoon Griffin is put into any graveyard from play, remove Mistmoon Griffin from the game, then put the top creature card from your graveyard into play.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "13f662e5-3f79-5ebe-a0f4-b8385fa28352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a5683-5f2f-4933-9fc3-5f7773f72f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a5683-5f2f-4933-9fc3-5f7773f72f93.jpg?1",
             "name": "Peacekeeper",
             "text": "During your upkeep, pay o1o\nW or bury Peacekeeper.\nCreatures cannot attack.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "1309151d-a711-55a3-a1fa-81fb94f71a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c642dd2-1a3e-4b08-917e-6e8aed358b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c642dd2-1a3e-4b08-917e-6e8aed358b72.jpg?1",
             "name": "Revered Unicorn",
             "text": "Cumulative upkeep o1\nIf Revered Unicorn leaves play, its controller gains life equal to Revered Unicorn's last paid cumulative upkeep.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "ff0d24fd-6ca7-5393-b8e5-4ec785eb10c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca975ab-b3ee-4584-9f92-860b4c2369f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca975ab-b3ee-4584-9f92-860b4c2369f3.jpg?1",
             "name": "Serenity",
             "text": "During your upkeep, bury all artifacts and enchantments.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "7c6f354e-91ee-571c-aa41-557f575add9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794cca9-3df0-4864-8a98-4de71a2bcf17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794cca9-3df0-4864-8a98-4de71a2bcf17.jpg?1",
             "name": "Serra's Blessing",
             "text": "Attacking does not cause creatures you control to tap.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "15ab3ce8-fb2f-5606-a01f-409153ce215a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a39ba-5fbf-46c3-8dc7-3058ac6d24e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a39ba-5fbf-46c3-8dc7-3058ac6d24e8.jpg?1",
             "name": "Soul Shepherd",
             "text": "o\nW, Remove a creature card in your graveyard from the game: Gain 1 life.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "3988b97f-c1f0-550b-b84f-fe6d607ac434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3c94a1-8455-4521-a0d5-ee2982527b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3c94a1-8455-4521-a0d5-ee2982527b89.jpg?1",
             "name": "Southern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target red permanent.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "38fef905-c0ed-559b-a003-692d02489716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24333832-2a87-4810-9443-ec993468d103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24333832-2a87-4810-9443-ec993468d103.jpg?1",
             "name": "Tariff",
             "text": "Each player chooses a creature with the highest total casting cost he or she controls, then pays an amount of mana equal to that creature's total casting cost or buries the creature.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "0109faa4-6e05-5c3f-b2fc-d8d71fa9e42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5344911f-25e8-45ce-87b9-607e42db0139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5344911f-25e8-45ce-87b9-607e42db0139.jpg?1",
             "name": "Volunteer Reserves",
             "text": "Banding\nCumulative upkeep o1",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "91f2ff1a-5634-5995-aba0-c57029cbcbac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81264d-0e03-44ac-8ff5-049b9aaebcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81264d-0e03-44ac-8ff5-049b9aaebcca.jpg?1",
             "name": "Abduction",
             "text": "When Abduction comes into play, untap enchanted creature.\nGain control of enchanted creature.\nIf enchanted creature is put into any graveyard, put that creature into play under its owner's control.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "1e41e6e3-df48-516d-844f-35e38beefa7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbad9449-d09c-4fd0-b2ad-2aa3a29e03bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbad9449-d09c-4fd0-b2ad-2aa3a29e03bf.jpg?1",
             "name": "Abjure",
             "text": "Sacrifice a blue permanent: Counter target spell.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "938f41e0-5bb6-5567-8134-4730e2113bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b90d72-00ac-4423-8cdf-e1471c6cd0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b90d72-00ac-4423-8cdf-e1471c6cd0ae.jpg?1",
             "name": "Ancestral Knowledge",
             "text": "Cumulative upkeep o1\nWhen Ancestral Knowledge comes into play, look at the top ten cards of your library, then remove any number of them from the game and put the rest back on top of your library in any order.\nIf Ancestral Knowledge leaves play, shuffle your library.",
             "colours": [
@@ -1042,7 +1042,7 @@
         },
         {
             "id": "def7fe6b-c4ef-592b-ac8d-bd5795cd929d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3a6fe-e234-4c3f-96fc-3eb5eb22c0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3a6fe-e234-4c3f-96fc-3eb5eb22c0b8.jpg?1",
             "name": "Apathy",
             "text": "Enchanted creature does not untap during its controller's untap phase.\nDuring the upkeep of enchanted creature's controller, that player may discard a card at random to untap that creature.",
             "colours": [
@@ -1075,7 +1075,7 @@
         },
         {
             "id": "14c50c6f-57e8-52d8-b24c-3822dcb99129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1a9d35-1b2a-44a2-9bbc-8529a7487905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1a9d35-1b2a-44a2-9bbc-8529a7487905.jpg?1",
             "name": "Argivian Restoration",
             "text": "Put target artifact card from your graveyard into play.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "6b72ec90-56a5-55bb-9871-ef2ddeafec3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993986c-e8f1-41b1-86e6-c72021c53b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993986c-e8f1-41b1-86e6-c72021c53b87.jpg?1",
             "name": "Avizoa",
             "text": "Flying\nSkip your next untap phase: Avizoa gets +2/+2 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -1139,7 +1139,7 @@
         },
         {
             "id": "e67a6a41-b468-5fc4-bcc6-254f9e1b00ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c857a151-45fe-43af-a9be-a93d26f220f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c857a151-45fe-43af-a9be-a93d26f220f3.jpg?1",
             "name": "Cloud Djinn",
             "text": "Flying\nCloud Djinn can block only creatures with flying.",
             "colours": [
@@ -1172,7 +1172,7 @@
         },
         {
             "id": "658271cb-eed8-585b-bc1d-341da9d7e71d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cc89b0-9acf-452b-ac1a-bc7e90eb32fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cc89b0-9acf-452b-ac1a-bc7e90eb32fc.jpg?1",
             "name": "Disrupt",
             "text": "Counter target instant, interrupt, or sorcery spell unless its caster pays an additional o1.\nDraw a card.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "08368163-1cc6-5144-a323-760f28b0b218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354c9de7-0cdf-4302-9d1a-ae17eca13053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354c9de7-0cdf-4302-9d1a-ae17eca13053.jpg?1",
             "name": "Ertai's Familiar",
             "text": "Phasing\nIf Ertai's Familiar leaves play, put the top three cards of your library into your graveyard.\noo\nU Ertai's Familiar cannot phase out until the beginning of your next upkeep.",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "96281193-2feb-5cd7-8efd-44b8e9a2cfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b28e4-a367-4a38-866d-c3768bd9b7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b28e4-a367-4a38-866d-c3768bd9b7ad.jpg?1",
             "name": "Flux",
             "text": "Each player chooses and discards any number of cards, then draws that many cards.\nDraw a card.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "9664a030-e660-576a-b8d7-d171fbdc1a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b454d0-7dc7-419f-aefa-f20f37444658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b454d0-7dc7-419f-aefa-f20f37444658.jpg?1",
             "name": "Fog Elemental",
             "text": "Flying\nIf Fog Elemental attacks or blocks, bury it at end of combat.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "ca7d4f1b-f412-5c29-b5b8-f56e1f15a57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77802038-0d86-4911-97ed-e6bd2ed55e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77802038-0d86-4911-97ed-e6bd2ed55e23.jpg?1",
             "name": "Mana Chains",
             "text": "Enchanted creature gains \"Cumulative upkeep o1.\"",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "4ba4cf27-05e8-5d13-91ea-13790ed58868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f74884-9b82-419d-9e97-c947a6b7d09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f74884-9b82-419d-9e97-c947a6b7d09f.jpg?1",
             "name": "Manta Ray",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)\nManta Ray cannot be blocked except by blue creatures.",
             "colours": [
@@ -1366,7 +1366,7 @@
         },
         {
             "id": "a49f8695-0e31-5d7a-b30b-4dd49a5b3618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebacbf23-4b69-481c-aaf7-5de7b4a6db6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebacbf23-4b69-481c-aaf7-5de7b4a6db6f.jpg?1",
             "name": "Merfolk Traders",
             "text": "When Merfolk Traders comes into play, draw a card, then choose and discard a card.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "ffe20b98-92b7-5be9-917d-d6286f720a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd221f30-1773-4e05-a40f-022a9306ef89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd221f30-1773-4e05-a40f-022a9306ef89.jpg?1",
             "name": "Noble Benefactor",
             "text": "If Noble Benefactor is put into any graveyard from play, each player may search his or her library for any one card and put that card into his or her hand. Each player who searches his or her library shuffles it afterwards.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "bfaa812c-1286-580c-bd2e-57992a1c763f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0a010-76a7-460f-bb4e-a152c10c3bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0a010-76a7-460f-bb4e-a152c10c3bb7.jpg?1",
             "name": "Ophidian",
             "text": "o0: Draw a card. Ophidian deals no combat damage this turn. Use this ability only if Ophidian is attacking and unblocked and only once each turn.",
             "colours": [
@@ -1466,7 +1466,7 @@
         },
         {
             "id": "3cfa89e5-a4c4-5235-b1bd-a8e8636f6f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64a17a8-091d-4029-908e-31d6a050b479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64a17a8-091d-4029-908e-31d6a050b479.jpg?1",
             "name": "Paradigm Shift",
             "text": "Remove all cards in your library from the game. Shuffle your graveyard into your library.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "d827080e-55a3-5186-b342-09dcca532573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b902b972-3a93-4e4e-aa77-02ada81e6b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b902b972-3a93-4e4e-aa77-02ada81e6b95.jpg?1",
             "name": "Pendrell Mists",
             "text": "Each creature gains \"During your upkeep, pay o1 or bury this creature.\"",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "abb1ad2b-f7b9-53df-8391-1bbcd2dd9329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414c9f8-ee46-4368-a8dc-0767c645a9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414c9f8-ee46-4368-a8dc-0767c645a9c1.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "f914572b-2a31-577b-846d-e939c68467eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0db4c6c-aa51-487b-a591-78d93c67c775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0db4c6c-aa51-487b-a591-78d93c67c775.jpg?1",
             "name": "Phantom Wings",
             "text": "Enchanted creature gains flying.\nSacrifice Phantom Wings: Return enchanted creature to owner's hand.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "5577e714-42f2-59e4-9ada-18b75ecdb0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2a419-7122-4eeb-bb64-738a647cfd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2a419-7122-4eeb-bb64-738a647cfd82.jpg?1",
             "name": "Psychic Vortex",
             "text": "Cumulative upkeep\u2014\nDraw a card\nAt the end of each of your turns, sacrifice a land and discard your hand.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "7355c802-5add-5dbd-b679-db6178e81299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f8480-8ae7-4b5f-abdf-1bd46066049e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f8480-8ae7-4b5f-abdf-1bd46066049e.jpg?1",
             "name": "Relearn",
             "text": "Return target instant, interrupt, or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "982a4c3e-2103-5e40-9855-d1994b3f3b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee2d6a1-8b1e-47e5-9720-5683ac458250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee2d6a1-8b1e-47e5-9720-5683ac458250.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl comes into play, look at the top four cards of your library and put them back in any order.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "61131cb1-5215-538c-83fe-89af1702b43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf39b80-d972-4f79-902f-cc613c32e446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf39b80-d972-4f79-902f-cc613c32e446.jpg?1",
             "name": "Teferi's Veil",
             "text": "Whenever any creature you control attacks, it phases out at end of combat.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "0a89058b-218d-52c0-a48d-046df9fd15db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bbdbd8-1517-4bfd-926b-465a32724082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bbdbd8-1517-4bfd-926b-465a32724082.jpg?1",
             "name": "Timid Drake",
             "text": "Flying\nIf any other creature comes into play, return Timid Drake to owner's hand.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "5e5dc6fa-2521-50e8-8167-9e0fc697bd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04bba8a-48ee-4981-adc2-4f82c0f2c1bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04bba8a-48ee-4981-adc2-4f82c0f2c1bd.jpg?1",
             "name": "Tolarian Drake",
             "text": "Flying, phasing",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "6f75126e-8a34-5924-bf28-c83e6be1e02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29dd04a-b3aa-48b6-beef-3314344b84a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29dd04a-b3aa-48b6-beef-3314344b84a6.jpg?1",
             "name": "Tolarian Entrancer",
             "text": "Whenever Tolarian Entrancer is blocked by any creature, gain control of that creature at end of combat.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "050a8d8f-eb5a-531d-acd6-9a7f85e8a1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236a857-c4ca-4de2-a4a2-e0914d16b54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236a857-c4ca-4de2-a4a2-e0914d16b54b.jpg?1",
             "name": "Tolarian Serpent",
             "text": "During your upkeep, put the top seven cards of your library into your graveyard.",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "0d3c1110-b288-5533-b828-84f7b08ce0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0e28b-9fd6-4763-8d6b-952b530358ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0e28b-9fd6-4763-8d6b-952b530358ab.jpg?1",
             "name": "Vodalian Illusionist",
             "text": "o\nUo\nU, oc\nT: Target creature phases out.",
             "colours": [
@@ -1888,7 +1888,7 @@
         },
         {
             "id": "0e3b0422-09bd-5129-a8f7-faead877b250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1734df5a-7d3a-46c7-a0ad-adbbd1be958f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1734df5a-7d3a-46c7-a0ad-adbbd1be958f.jpg?1",
             "name": "Abyssal Gatekeeper",
             "text": "If Abyssal Gatekeeper is put into any graveyard from play, each player chooses and buries a creature he or she controls.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "57159e63-3a03-5417-b7af-862236f69780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be277367-a58e-429e-af1b-58163becf861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be277367-a58e-429e-af1b-58163becf861.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand. Choose two of those cards and put them on top of his or her library in any order.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "4b07f526-213c-55f3-a74d-798d3c5af503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7055007-83dd-40fe-b2a1-4b3132f636db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7055007-83dd-40fe-b2a1-4b3132f636db.jpg?1",
             "name": "Barrow Ghoul",
             "text": "During your upkeep, remove the top creature card in your graveyard from the game or bury Barrow Ghoul.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "d5e5cfbd-067a-53d5-b9fa-8184307233de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207bb4cd-4525-47e0-b412-0d0e29717d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207bb4cd-4525-47e0-b412-0d0e29717d44.jpg?1",
             "name": "Bone Dancer",
             "text": "o0: Put the top creature card of defending player's graveyard into play under your control. Bone Dancer deals no combat damage this turn. Use this ability only if Bone Dancer is attacking and unblocked and only once each turn.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "b28a4df3-b461-5bbb-94d4-be602b806f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b92eb5-72b0-46b4-8b16-8a7a7ac80f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b92eb5-72b0-46b4-8b16-8a7a7ac80f56.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards and put them into your graveyard. Shuffle your library afterwards.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "b7d9ee60-5f59-5173-b3d5-61b32d0debaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dae8e49-c2b6-4965-9249-49f93449d271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dae8e49-c2b6-4965-9249-49f93449d271.jpg?1",
             "name": "Circling Vultures",
             "text": "Flying\nDuring your upkeep, remove the top creature card in your graveyard from the game or bury Circling Vultures.\nIf Circling Vultures is in your hand, you may discard it. Play this ability as an instant.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "1448ea45-5468-595e-bcd9-277ce69e2c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502bfb38-4a37-4053-af20-d5606ffc67c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502bfb38-4a37-4053-af20-d5606ffc67c8.jpg?1",
             "name": "Coils of the Medusa",
             "text": "Enchanted creature gets +1/-1.\nSacrifice Coils of the Medusa: Destroy all non-Wall creatures blocking enchanted creature.",
             "colours": [
@@ -2115,7 +2115,7 @@
         },
         {
             "id": "ce95ba02-a79d-5681-bfd4-137d00af93b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c6d87-9383-450b-bba5-33435b6b0d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c6d87-9383-450b-bba5-33435b6b0d08.jpg?1",
             "name": "Doomsday",
             "text": "Pay half your life, rounded up: Put your graveyard on top of your library, then remove all but five cards of your library from the game. Put the rest on top of your library in any order.",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "4e3a342c-c428-5665-995c-6818cb1de51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dc7c2-6198-4526-b79a-f3d8ee7a157a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dc7c2-6198-4526-b79a-f3d8ee7a157a.jpg?1",
             "name": "Fatal Blow",
             "text": "Bury target creature that was damaged this turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "9ba47561-fc9f-581b-ac68-28e7425c4721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d688bda-fee2-496d-9793-794c2568b54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d688bda-fee2-496d-9793-794c2568b54e.jpg?1",
             "name": "Festering Evil",
             "text": "During your upkeep, Festering Evil deals 1 damage to each creature and player.\no\nBo\nB, Sacrifice Festering Evil: Festering Evil deals 3 damage to each creature and player.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "872f9571-d64a-586b-ad06-c19209445258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fdf2a-d6d2-42da-8f41-0f67dd0bf4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fdf2a-d6d2-42da-8f41-0f67dd0bf4d2.jpg?1",
             "name": "Fledgling Djinn",
             "text": "Flying\nDuring your upkeep, Fledgling Djinn deals 1 damage to you.",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "2b6db985-e24d-5225-854e-4416197485f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df86192-6374-42ac-94bc-95e2e8284bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df86192-6374-42ac-94bc-95e2e8284bd6.jpg?1",
             "name": "Gallowbraid",
             "text": "Trample\nCumulative upkeep\u20141 life",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "614477fa-8978-5e32-b407-2d8175ecaf07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b83ba-8ba8-4b98-8a13-a037ba7805e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b83ba-8ba8-4b98-8a13-a037ba7805e9.jpg?1",
             "name": "Haunting Misery",
             "text": "Remove X creature cards in your graveyard from the game: Haunting Misery deals X damage to target player.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "ef202c6a-1e37-5218-8eb6-a4f9a475a80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885dc4c5-2ade-4497-b579-0307c67ac783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885dc4c5-2ade-4497-b579-0307c67ac783.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play, choose and discard a creature card or bury Hidden Horror.",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "03665df8-906c-5b6a-a8f0-f19e1e975e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569739b2-f212-4cc9-84db-1be17b3f90fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569739b2-f212-4cc9-84db-1be17b3f90fb.jpg?1",
             "name": "Infernal Tribute",
             "text": "o2, Sacrifice a card in play: Draw a card.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "a00fb642-7230-5389-a413-b27d30821b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054254ee-29cf-48d7-afbf-cb6de83e513e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054254ee-29cf-48d7-afbf-cb6de83e513e.jpg?1",
             "name": "Mischievous Poltergeist",
             "text": "Flying\nPay 1 life: Regenerate",
             "colours": [
@@ -2405,7 +2405,7 @@
         },
         {
             "id": "42abe983-7dde-5c0b-a569-b243474b64d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5006ad3-16ca-4be3-8d56-d4fe4e9e0a44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5006ad3-16ca-4be3-8d56-d4fe4e9e0a44.jpg?1",
             "name": "Morinfen",
             "text": "Flying\nCumulative upkeep\u20141 life",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "a402ecbd-a723-5d06-924b-101e6d7637a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb19c519-c09a-44a0-8d4b-ab6c15dabdef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb19c519-c09a-44a0-8d4b-ab6c15dabdef.jpg?1",
             "name": "Necratog",
             "text": "Remove the top creature card in your graveyard from the game: +2/+2 until end of turn",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "60fa0ea7-eef9-5ae6-b910-1ad6c60a45fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3b7cd1-051c-43a8-b5f0-72a9d704efbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3b7cd1-051c-43a8-b5f0-72a9d704efbc.jpg?1",
             "name": "Odylic Wraith",
             "text": "Swampwalk\nIf Odylic Wraith damages any player, that player chooses and discards a card.",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "54316737-1c30-5b6c-abbf-4ee7ca57d95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae869780-27e8-4a6d-9ac6-cdab617725e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae869780-27e8-4a6d-9ac6-cdab617725e2.jpg?1",
             "name": "Razortooth Rats",
             "text": "Razortooth Rats cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "f48edb58-edca-5c0c-b85e-26e7eb330afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfdec24-e689-4cca-a546-a8f5d0929f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfdec24-e689-4cca-a546-a8f5d0929f8d.jpg?1",
             "name": "Shadow Rider",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "574ba43c-5ac9-5002-8e61-c7eca7329d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117df45d-4500-459b-96b5-ca41952580c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117df45d-4500-459b-96b5-ca41952580c1.jpg?1",
             "name": "Shattered Crypt",
             "text": "Return X target creature cards from your graveyard to your hand and lose X life.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "436bb0c8-3f93-5192-a24b-2da71fbbb50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e64a8e-84b1-416c-9fa7-8b10130dc9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e64a8e-84b1-416c-9fa7-8b10130dc9e9.jpg?1",
             "name": "Spinning Darkness",
             "text": "You may remove the top three black cards in your graveyard from the game instead of paying Spinning Darkness's casting cost. Spinning Darkness deals 3 damage to target nonblack creature. Gain 3 life.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "fd0934f1-a1e5-5e8e-b7f5-e6b6a46dcd03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ef62f-e119-470b-b212-9beb48469095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ef62f-e119-470b-b212-9beb48469095.jpg?1",
             "name": "Strands of Night",
             "text": "o\nBo\nB, Pay 2 life, Sacrifice a swamp: Put target creature card from your graveyard into play.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "be0a030c-acb0-59cc-ac05-44d991ad5b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d73ddb-bd3c-4625-9f75-ba2079553915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d73ddb-bd3c-4625-9f75-ba2079553915.jpg?1",
             "name": "Tendrils of Despair",
             "text": "Sacrifice a creature: Target opponent chooses and discards two cards.",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "c0c3ab4c-92ab-54f2-b2fe-f2fa92796f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f322ff-0b04-41ce-90cd-9896f941e703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f322ff-0b04-41ce-90cd-9896f941e703.jpg?1",
             "name": "Urborg Justice",
             "text": "Target opponent chooses and buries a number of creatures he or she controls equal to the number of creatures put into your graveyard from play so far this turn.",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "edcea703-7050-526e-a82e-a815c61053a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33e3d5-c608-4ba8-8614-0b9d0385af64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33e3d5-c608-4ba8-8614-0b9d0385af64.jpg?1",
             "name": "Urborg Stalker",
             "text": "During each player's upkeep, if that player controls any nonblack permanents other than lands, Urborg Stalker deals 1 damage to that player.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "4ed32200-2e0b-55ce-868c-3bc05872ee07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40ab3e7-9abb-4acc-9932-de03b533722f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40ab3e7-9abb-4acc-9932-de03b533722f.jpg?1",
             "name": "Wave of Terror",
             "text": "Cumulative upkeep o1\nAt the end of your upkeep, bury each creature with casting cost equal to Wave of Terror's last paid cumulative upkeep.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e5afce68-8fdf-587f-9248-4a47ba8b7d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec786b1-6097-4e97-99b0-571d6e3e73e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec786b1-6097-4e97-99b0-571d6e3e73e7.jpg?1",
             "name": "Zombie Scavengers",
             "text": "Remove the top creature card in your graveyard from the game: Regenerate",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "98c1c36c-2b6c-59c9-8ee0-3c80d00216d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6642d-393d-49a5-8c49-c1f62524ea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6642d-393d-49a5-8c49-c1f62524ea20.jpg?1",
             "name": "Aether Flash",
             "text": "Whenever any creature comes into play, \u00c6ther Flash deals 2 damage to that creature.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "abb64ff2-883a-5b53-8bf7-4b60ac4f203a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e517aa4-d8ba-4a49-bf9f-172bf029fa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e517aa4-d8ba-4a49-bf9f-172bf029fa52.jpg?1",
             "name": "Betrothed of Fire",
             "text": "Sacrifice an untapped creature: Enchanted creature gets +2/+0 until end of turn.\nSacrifice enchanted creature: All creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "170e747a-b397-5cd9-aa8f-d0ca6159add9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c642fd9-38f7-4029-ab93-e1dc5636c1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c642fd9-38f7-4029-ab93-e1dc5636c1ad.jpg?1",
             "name": "Bloodrock Cyclops",
             "text": "Bloodrock Cyclops attacks each turn if able.",
             "colours": [
@@ -2922,7 +2922,7 @@
         },
         {
             "id": "a68e07a9-611d-561b-9276-82ea3e445993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ff9650-d25f-4c6b-b96e-794b50af3f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ff9650-d25f-4c6b-b96e-794b50af3f14.jpg?1",
             "name": "Bogardan Firefiend",
             "text": "If Bogardan Firefiend is put into any graveyard from play, it deals 2 damage to target creature.",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "2ed6b5e1-9f19-52be-b88a-bb3e68ee30b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcb85b6-ab5a-40db-aaae-555315f32877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcb85b6-ab5a-40db-aaae-555315f32877.jpg?1",
             "name": "Boiling Blood",
             "text": "Target creature attacks this turn if able.\nDraw a card.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "189fe929-6902-5a86-9305-aaa1a9748dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de97c939-2c44-4c43-9d66-1087bcee692b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de97c939-2c44-4c43-9d66-1087bcee692b.jpg?1",
             "name": "Cinder Giant",
             "text": "During your upkeep, Cinder Giant deals 2 damage to each other creature you control.",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "6423f5fa-e9e1-5ee1-9ea4-657300b9b732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1e429c-2e66-4363-b50a-b12b72efa060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1e429c-2e66-4363-b50a-b12b72efa060.jpg?1",
             "name": "Cinder Wall",
             "text": "If Cinder Wall blocks, destroy it at end of combat.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "6f37c6a4-cf9f-5fd0-b814-c9c284bca1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5713f17a-9a57-41f8-b492-ced876e1a37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5713f17a-9a57-41f8-b492-ced876e1a37f.jpg?1",
             "name": "Cone of Flame",
             "text": "Choose three target creatures and/or players. Cone of Flame deals 1 damage to the first, 2 damage to the second, and 3 damage to the third.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "5cfcc217-2569-5a86-a1df-32586d34e1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4245160-274e-4c39-9bcd-c64e9a44dfdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4245160-274e-4c39-9bcd-c64e9a44dfdb.jpg?1",
             "name": "Desperate Gambit",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, double the damage dealt by a source you control. Otherwise, prevent all damage from that source.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "cfd71fd1-94db-542a-9d25-049dbea3522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc734e9-fb09-4094-94b6-76c0458649e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc734e9-fb09-4094-94b6-76c0458649e9.jpg?1",
             "name": "Dwarven Berserker",
             "text": "If Dwarven Berserker is blocked, it gets +3/+0 and gains trample until end of turn.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "eca5c951-cf73-5436-8950-f2a8944623c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68aa29-9f38-48a2-b00a-39aef9d91f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68aa29-9f38-48a2-b00a-39aef9d91f6d.jpg?1",
             "name": "Dwarven Thaumaturgist",
             "text": "oc\nT: Switch power and toughness of target creature until end of turn. Effects that alter that creature's power alter its toughness instead, and vice versa, until end of turn.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "16782e9c-3488-52f2-9c8e-7cdfe837dab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4df70ea-2b6b-4e25-a564-655989ef16fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4df70ea-2b6b-4e25-a564-655989ef16fa.jpg?1",
             "name": "Fervor",
             "text": "All creatures you control are unaffected by summoning sickness.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "2b566230-e0c5-59b9-aea9-50cec43cb0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee194b4-f18f-4ebd-b42f-c7dfef42f22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee194b4-f18f-4ebd-b42f-c7dfef42f22e.jpg?1",
             "name": "Fire Whip",
             "text": "Play only on a creature you control.\nTap enchanted creature: Enchanted creature deals 1 damage to target creature or player.\nSacrifice Fire Whip: Fire Whip deals 1 damage to target creature or player.",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "261392bb-cbee-5cfb-93ed-3804ab6aa8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e674aa8a-668a-4345-95ee-73a0b87bbcb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e674aa8a-668a-4345-95ee-73a0b87bbcb1.jpg?1",
             "name": "Firestorm",
             "text": "Choose and discard X cards: Firestorm deals X damage to each of X target creatures and/or players.",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "02cae858-ed56-5a28-aec0-8bad52b0b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7b9ec-90cf-4d23-af5e-48394398ff06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7b9ec-90cf-4d23-af5e-48394398ff06.jpg?1",
             "name": "Fit of Rage",
             "text": "Target creature gets +3/+3 and gains first strike until end of turn.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "0ca7e0b3-4a30-5465-8922-be853faf7d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8a436-9fd0-409f-a020-0f9f41602d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8a436-9fd0-409f-a020-0f9f41602d50.jpg?1",
             "name": "Goblin Bomb",
             "text": "During your upkeep, you may choose to flip a coin. Target opponent calls heads or tails while the coin is in the air. If the flip ends up in your favor, put a fuse counter on Goblin Bomb. Otherwise, remove a fuse counter from Goblin Bomb.\nRemove 5 fuse counters from Goblin Bomb, Sacrifice Goblin Bomb: Goblin Bomb deals 20 damage to target player.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "5cf66c5f-c128-5ed9-95dc-4c1adb9dc5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73db23-727f-4d63-97d7-2ca542276722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73db23-727f-4d63-97d7-2ca542276722.jpg?1",
             "name": "Goblin Grenadiers",
             "text": "Sacrifice Goblin Grenadiers: Destroy target creature and target land. Use this ability only if Goblin Grenadiers is attacking and unblocked.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "042a6374-aa12-5645-8e24-31de0b9feaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad3b81-f706-4b33-b1ec-7600182a5232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad3b81-f706-4b33-b1ec-7600182a5232.jpg?1",
             "name": "Goblin Vandal",
             "text": "oo\nR Destroy target artifact defending player controls. Goblin Vandal deals no combat damage this turn. Use this ability only if Goblin Vandal is attacking and unblocked and only once each turn.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "a5920156-d27e-523f-b12c-e2b05c1c15c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e30d025-1df9-4a08-b686-037e9cbf23a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e30d025-1df9-4a08-b686-037e9cbf23a6.jpg?1",
             "name": "Heart of Bogardan",
             "text": "Cumulative upkeep o2\nIf Heart of Bogardan's cumulative upkeep cost is not paid, Heart of Bogardan deals damage equal to its last paid cumulative upkeep to target player and each creature he or she controls.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "2823d21f-a786-5748-8e6e-6751b1a13f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baf2a6c-57ec-4b38-8b08-4b3f800dbe99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baf2a6c-57ec-4b38-8b08-4b3f800dbe99.jpg?1",
             "name": "Heat Stroke",
             "text": "At the end of each combat, destroy all creatures that blocked or were blocked this turn.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "8779e0f7-447c-544e-aeff-d7bc8bc22613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a359c9-1889-426d-acaf-074cfd9f274d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a359c9-1889-426d-acaf-074cfd9f274d.jpg?1",
             "name": "Hurloon Shaman",
             "text": "If Hurloon Shaman is put into any graveyard from play, each player chooses and buries a land he or she controls.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "cb9e1229-b847-520a-b152-a0283b16b129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896dcaf0-3e52-4189-990f-cabab40ffbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896dcaf0-3e52-4189-990f-cabab40ffbd1.jpg?1",
             "name": "Lava Hounds",
             "text": "Lava Hounds is unaffected by summoning sickness.\nWhen Lava Hounds comes into play, it deals 4 damage to you.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "f3425340-944d-58af-bc7c-25c65f7c7db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fcd58e-e5e2-45f4-9edd-300a871ae5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fcd58e-e5e2-45f4-9edd-300a871ae5f5.jpg?1",
             "name": "Lava Storm",
             "text": "Lava Storm deals 2 damage to each attacking creature or 2 damage to each blocking creature.",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "3476c2fe-8c17-5e75-9064-17455588cd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59329155-a423-4e8d-a7d4-c99555ff5ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59329155-a423-4e8d-a7d4-c99555ff5ed1.jpg?1",
             "name": "Maraxus of Keld",
             "text": "Maraxus of Keld has power and toughness each equal to the total number of untapped artifacts, creatures, and lands you control.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "ec037601-f72d-58df-aa90-0cadf9134a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54764f6-6f65-405c-ba30-1e485ce3fe21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54764f6-6f65-405c-ba30-1e485ce3fe21.jpg?1",
             "name": "Orcish Settlers",
             "text": "o\nXo\nXo\nR, oc\nT, Sacrifice Orcish Settlers: Destroy X target lands.",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "bea821a3-217c-579c-98f5-1177451cde04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25857884-6bb7-4a8e-a08b-fa610af8a5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25857884-6bb7-4a8e-a08b-fa610af8a5c3.jpg?1",
             "name": "Roc Hatchling",
             "text": "When Roc Hatchling comes into play, put four shell counters on it.\nDuring your upkeep, remove a shell counter from Roc Hatchling.\nAs long as Roc Hatchling has no shell counters on it, it gets +3/+2 and gains flying.",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "3e837f1d-302b-5c66-83df-6fcab88b04e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a237580-f7f6-4d6b-a342-0d11fc0b5a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a237580-f7f6-4d6b-a342-0d11fc0b5a59.jpg?1",
             "name": "Sawtooth Ogre",
             "text": "If Sawtooth Ogre blocks or is blocked by any creature, Sawtooth Ogre deals 1 damage to that creature at end of combat.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "ac58d030-0d6a-5958-8444-f15a9108ba28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a4b641-2eb3-482b-91a1-236ebe2a7a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a4b641-2eb3-482b-91a1-236ebe2a7a41.jpg?1",
             "name": "Thunderbolt",
             "text": "Thunderbolt deals 3 damage to target player or 4 damage to target creature with flying.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "b080e8ee-cc70-5a2c-8676-ff57ef3377cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e936e5cb-0a8e-4348-afea-e5f96b19fe23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e936e5cb-0a8e-4348-afea-e5f96b19fe23.jpg?1",
             "name": "Thundermare",
             "text": "Thundermare is unaffected by summoning sickness.\nWhen Thundermare comes into play, tap all other creatures.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "7b434d33-dbe8-5eee-bb33-0cbb016bec7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72ac67-e4fb-49a1-b1e5-cd2e414bec28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72ac67-e4fb-49a1-b1e5-cd2e414bec28.jpg?1",
             "name": "Aboroth",
             "text": "Cumulative upkeep\u2014\nPut a -1/-1 counter on Aboroth",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "98c7bec5-a6c6-597d-be24-6e552460d250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb56a2-5138-4c31-aa4b-0824a1a24573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb56a2-5138-4c31-aa4b-0824a1a24573.jpg?1",
             "name": "Arctic Wolves",
             "text": "Cumulative upkeep o2\nWhen Arctic Wolves comes into play, draw a card.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "075d1e34-518b-54b7-ad4d-a08f9abb46d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f263eb80-f8f2-4b32-8e8b-a297de9f3666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f263eb80-f8f2-4b32-8e8b-a297de9f3666.jpg?1",
             "name": "Barishi",
             "text": "If Barishi is put into any graveyard from play, remove Barishi from the game, then shuffle all creature cards from your graveyard into your library.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "0c962d17-9aa2-5210-8781-93ed4ca1a36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f944ad9-c9ce-47b2-80fa-d0f7fcf0fd5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f944ad9-c9ce-47b2-80fa-d0f7fcf0fd5d.jpg?1",
             "name": "Blossoming Wreath",
             "text": "Gain life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "e8be34cf-01a1-55b0-8112-439b3a2e5939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68100ac2-9677-4eb5-93dc-54e49b15985d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68100ac2-9677-4eb5-93dc-54e49b15985d.jpg?1",
             "name": "Briar Shield",
             "text": "Enchanted creature gets +1/+1.\nSacrifice Briar Shield: Enchanted creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "a2d98280-535b-566d-92e1-c9787606011c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742bc7c-7f0d-4dff-b229-f16d54fe1347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742bc7c-7f0d-4dff-b229-f16d54fe1347.jpg?1",
             "name": "Call of the Wild",
             "text": "o2o\nGoo\nG Reveal the top card of your library to all players. If that card is a creature card, put it into play. Otherwise, bury it.",
             "colours": [
@@ -3961,7 +3961,7 @@
         },
         {
             "id": "de881043-1730-5a73-be0a-6a083181a800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4a7ee-f6f0-454a-9074-5988fdee1f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4a7ee-f6f0-454a-9074-5988fdee1f34.jpg?1",
             "name": "Choking Vines",
             "text": "Play only when blockers are declared.\nX target attacking creatures are considered blocked. Choking Vines deals 1 damage to each of those creatures.",
             "colours": [
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "e85519f2-5178-5e1f-bb48-50d6251db50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a2035-59cb-426e-b2ae-45d8d6ce0bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a2035-59cb-426e-b2ae-45d8d6ce0bb8.jpg?1",
             "name": "Dense Foliage",
             "text": "Creatures cannot be the target of spells.",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "98cc0e35-202e-58cb-a9d4-b088fdf4d4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4ced80-926a-4e4d-8ebd-d4fe7374a6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4ced80-926a-4e4d-8ebd-d4fe7374a6ad.jpg?1",
             "name": "Downdraft",
             "text": "oo\nG Target creature loses flying until end of turn.\nSacrifice Downdraft: Downdraft deals 2 damage to each creature with flying.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "ecd4eaa6-5a47-5e9d-bced-85d87e645fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba02b6f-6010-47a4-8670-406391a52a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba02b6f-6010-47a4-8670-406391a52a68.jpg?1",
             "name": "Fallow Wurm",
             "text": "When Fallow Wurm comes into play, choose and discard a land card or bury Fallow Wurm.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "9fca5531-df5d-5d87-9f02-0ca6a6e42ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f993f517-999f-4ee6-8ffb-946bffdcf7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f993f517-999f-4ee6-8ffb-946bffdcf7fe.jpg?1",
             "name": "Familiar Ground",
             "text": "Each creature you control cannot be blocked by more than one creature.",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "94b9e41a-582d-5685-aefa-e82820af9a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4336bfd1-27a4-414d-b6fe-f186a0563dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4336bfd1-27a4-414d-b6fe-f186a0563dc0.jpg?1",
             "name": "Fungus Elemental",
             "text": "o\nG, Sacrifice a forest: Put a +2/+2 counter on Fungus Elemental. Use this ability only if Fungus Elemental came into play this turn.",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "b167e1e6-88fe-5a68-ac22-b192a946cde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee83d511-57e0-40fb-a4db-62f6c2c39888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee83d511-57e0-40fb-a4db-62f6c2c39888.jpg?1",
             "name": "Gaea's Blessing",
             "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nIf Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "5f805b73-8047-5015-abf5-c24793b1075f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21139d-edfc-4140-aa43-d4165331d7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21139d-edfc-4140-aa43-d4165331d7f3.jpg?1",
             "name": "Harvest Wurm",
             "text": "When Harvest Wurm comes into play, return any basic land card from your graveyard to your hand or bury Harvest Wurm.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "496b01f4-c990-56e7-9b81-c9f6719f3179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff4512b-8244-4e38-bffb-0062a97d9531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff4512b-8244-4e38-bffb-0062a97d9531.jpg?1",
             "name": "Liege of the Hollows",
             "text": "If Liege of the Hollows is put into any graveyard from play, each player may pay any amount of mana to put that number of Squirrel tokens into play under his or her control. Treat those tokens as 1/1 green creatures.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "58cea5cf-4885-51aa-b587-d901e2cb3277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d9bd0-7ce9-4a1e-a8b2-5c1dbb014917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d9bd0-7ce9-4a1e-a8b2-5c1dbb014917.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "Tap a creature you control: +1/+1 until end of turn",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "c5b8f6f4-334d-55d2-9f36-218ef1408c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffad279c-762a-42cf-ac20-f4e48734c194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffad279c-762a-42cf-ac20-f4e48734c194.jpg?1",
             "name": "Llanowar Druid",
             "text": "oc\nT, Sacrifice Llanowar Druid: Untap all forests.",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "47340e8c-4688-549e-b19c-5e41a2055d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37ea4b-66e2-4ad5-ae7f-d02fd59131bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37ea4b-66e2-4ad5-ae7f-d02fd59131bd.jpg?1",
             "name": "Llanowar Sentinel",
             "text": "When Llanowar Sentinel comes into play, you may pay o1o\nG to search your library for a Llanowar Sentinel card. Put that card into play. Shuffle your library afterwards.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "497a2d54-28fc-58db-9828-553bea9546a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f65-93a1-4913-87e7-a17ebfcc7780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f65-93a1-4913-87e7-a17ebfcc7780.jpg?1",
             "name": "Mwonvuli Ooze",
             "text": "Cumulative upkeep o2\nMwonvuli Ooze has power and toughness each equal to 1 plus its last paid cumulative upkeep.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "43a0c776-1f6d-56d8-b852-4dcffd7febfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b09c44-d463-45a9-9fa2-89407c21200b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b09c44-d463-45a9-9fa2-89407c21200b.jpg?1",
             "name": "Nature's Kiss",
             "text": "o1, Remove the top card in your graveyard from the game: Enchanted creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "23f1b8eb-f404-5b7d-9592-13ce9371e1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df9fb85-f7fa-4617-87bd-4d457c830f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df9fb85-f7fa-4617-87bd-4d457c830f46.jpg?1",
             "name": "Nature's Resurgence",
             "text": "Each player draws a number of cards equal to the number of creature cards in his or her graveyard.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "b8c62645-ed74-5dbe-bea3-3782018191ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0274e162-33e4-4604-a6ea-51fc1a5c6a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0274e162-33e4-4604-a6ea-51fc1a5c6a04.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "b3b97f21-9389-52f3-8cc2-1db9fc614dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b622b2f-84ad-4203-97fa-35af09e1c370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b622b2f-84ad-4203-97fa-35af09e1c370.jpg?1",
             "name": "Rogue Elephant",
             "text": "When Rogue Elephant comes into play, sacrifice a forest or bury Rogue Elephant.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "693a86d8-4a1d-5aa0-8249-4f311de5bc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf54365-56ae-485d-b931-784a4cf9d8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf54365-56ae-485d-b931-784a4cf9d8f2.jpg?1",
             "name": "Striped Bears",
             "text": "When Striped Bears comes into play, draw a card.",
             "colours": [
@@ -4545,7 +4545,7 @@
         },
         {
             "id": "95c55fb2-352b-5763-b32b-cddebe7d5be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432a6908-0ee3-45c5-9089-b7f8cf1184bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432a6908-0ee3-45c5-9089-b7f8cf1184bb.jpg?1",
             "name": "Sylvan Hierophant",
             "text": "If Sylvan Hierophant is put into any graveyard from play, remove Sylvan Hierophant from the game, then return a creature card from your graveyard to your hand.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "b0f9f86e-d17b-55a2-859c-40e6f3ae48bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a145f2-b59d-4728-922c-9bc228451432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a145f2-b59d-4728-922c-9bc228451432.jpg?1",
             "name": "Tranquil Grove",
             "text": "o1o\nGoo\nG Destroy all other enchantments.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "e9176a11-d1f9-5f1a-b4aa-3d8ca8f8a07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678a224-d314-4108-8a39-de0c1b635b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678a224-d314-4108-8a39-de0c1b635b5c.jpg?1",
             "name": "Uktabi Efreet",
             "text": "Cumulative upkeep o\nG",
             "colours": [
@@ -4643,7 +4643,7 @@
         },
         {
             "id": "f68ce1ee-36fb-5e69-a3e4-73cd738ff806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdac36f2-99ce-4d48-90fa-aa7439778ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdac36f2-99ce-4d48-90fa-aa7439778ffc.jpg?1",
             "name": "Veteran Explorer",
             "text": "If Veteran Explorer is put into any graveyard from play, each player may search his or her library for up to two basic land cards and put those lands into play. Each player shuffles his or her library afterwards.",
             "colours": [
@@ -4678,7 +4678,7 @@
         },
         {
             "id": "6a2a8be8-9616-50cd-996b-7676f7138f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ee4997-4b1a-4e03-88ac-63b451bb7b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ee4997-4b1a-4e03-88ac-63b451bb7b38.jpg?1",
             "name": "Vitalize",
             "text": "Untap all creatures you control.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "05004c1f-d03c-5ca0-9b0e-9a7fc77c4264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca9c239-84ff-4527-aa23-bdb11856744c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca9c239-84ff-4527-aa23-bdb11856744c.jpg?1",
             "name": "Bubble Matrix",
             "text": "All damage dealt to creatures is reduced to 0.",
             "colours": [],
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "7f3ac419-e560-55e4-9cdd-8fa60e8a652f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884bede-df28-42e8-9ac9-ae03118b1985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884bede-df28-42e8-9ac9-ae03118b1985.jpg?1",
             "name": "B\u00f6sium Strip",
             "text": "o3, oc\nT: Until end of turn, if at any time the top card in your graveyard is an instant, interrupt, or sorcery card, you may play that card as though it were in your hand. If you do so, remove the card from the game.",
             "colours": [],
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "9507a71b-0049-58cc-a0dc-b73d0f6a990b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96857c-b38e-4614-9838-cacd3700e3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96857c-b38e-4614-9838-cacd3700e3ee.jpg?1",
             "name": "Chimeric Sphere",
             "text": "o2: Until end of turn, Chimeric Sphere is a 2/1 artifact creature with flying.\no2: Until end of turn, Chimeric Sphere is a 3/2 artifact creature without flying.",
             "colours": [],
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "479ed27e-56a8-5694-b066-fae719a1e3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065b4358-5dee-4f13-bff9-8254bdb92069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065b4358-5dee-4f13-bff9-8254bdb92069.jpg?1",
             "name": "Dingus Staff",
             "text": "Whenever a creature is put into any graveyard from play, Dingus Staff deals 2 damage to that creature's controller.",
             "colours": [],
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "0ba745fa-3873-518a-af55-1b60ea880024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51a496-1ca6-4286-bdbe-990d43196a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51a496-1ca6-4286-bdbe-990d43196a25.jpg?1",
             "name": "Jabari's Banner",
             "text": "o1, oc\nT: Target creature gains flanking until end of turn. (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [],
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "6371d8ed-ce7d-5056-85dc-99d0c97825e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a427b-9869-4059-aeeb-d9b97b324e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a427b-9869-4059-aeeb-d9b97b324e4e.jpg?1",
             "name": "Jangling Automaton",
             "text": "If Jangling Automaton attacks, untap all creatures defending player controls.",
             "colours": [],
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "621b819d-2d49-5c52-b70a-f389de18a844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c72ec90-dacc-496f-a7f5-f18bfce5eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c72ec90-dacc-496f-a7f5-f18bfce5eb3e.jpg?1",
             "name": "Mana Web",
             "text": "Whenever any land target opponent controls is tapped for mana, tap all lands he or she controls that can produce any type of mana that land can produce.",
             "colours": [],
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "aa06fbe5-fca7-5098-bee0-1cd431c2352a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162e81d3-6cd4-4cb8-8ed8-cfbd8d34ca71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162e81d3-6cd4-4cb8-8ed8-cfbd8d34ca71.jpg?1",
             "name": "Mind Stone",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source.\no1, oc\nT, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "8453c949-7d44-50cf-8fe8-8940d1ba746a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc45f2cb-c256-4a0f-879a-c7db5b1a0b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc45f2cb-c256-4a0f-879a-c7db5b1a0b94.jpg?1",
             "name": "Null Rod",
             "text": "Players cannot play any artifact abilities requiring an activation cost.",
             "colours": [],
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "e44019e8-6d96-50b3-badc-c5d63b328267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98bca31-8c05-430b-b5d7-331bdc55710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98bca31-8c05-430b-b5d7-331bdc55710a.jpg?1",
             "name": "Phyrexian Furnace",
             "text": "oc\nT: Remove the bottom card of target player's graveyard from the game.\no1, Sacrifice Phyrexian Furnace: Remove target card in any graveyard from the game and draw a card.",
             "colours": [],
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "39f6986c-f779-552a-bd52-84f2e3209c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c449126c-ac01-4a90-b967-8c3ad112091b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c449126c-ac01-4a90-b967-8c3ad112091b.jpg?1",
             "name": "Serrated Biskelion",
             "text": "oc\nT: Put a -1/-1 counter on Serrated Biskelion and a -1/-1 counter on target creature.",
             "colours": [],
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "90adb877-f20e-5221-adf5-1f0a02dfa14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa927e0-5a65-4ac1-8eca-c000bb8080e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa927e0-5a65-4ac1-8eca-c000bb8080e7.jpg?1",
             "name": "Steel Golem",
             "text": "You cannot play summon or artifact creature spells.",
             "colours": [],
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "80049fdd-a93b-517b-91d4-2606f11ccd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d62479-92ac-43e2-a3d3-b41dfe0fbb20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d62479-92ac-43e2-a3d3-b41dfe0fbb20.jpg?1",
             "name": "Straw Golem",
             "text": "If any opponent successfully casts a summon or artifact creature spell, bury Straw Golem.",
             "colours": [],
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "23bb3494-e1ce-566b-8aa2-c88374761c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c9691b-bee8-4251-8275-5f6ba14a8ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c9691b-bee8-4251-8275-5f6ba14a8ecd.jpg?1",
             "name": "Thran Forge",
             "text": "o2: Until end of turn, target nonartifact creature gets +1/+0 and is an artifact creature.",
             "colours": [],
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "ee5a608e-8e75-581f-8c23-aca781d81546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63db7360-fe6e-430f-bfee-a2f80bcb6fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63db7360-fe6e-430f-bfee-a2f80bcb6fec.jpg?1",
             "name": "Thran Tome",
             "text": "o5, oc\nT: Reveal the top three cards of your library to target opponent. Bury one of those cards of that opponent's choice. Draw the remaining cards.",
             "colours": [],
@@ -5126,7 +5126,7 @@
         },
         {
             "id": "062a76f1-f489-5a9b-8c65-1635145c8f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923afe8a-e82c-4b93-bb42-8f5073acae13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923afe8a-e82c-4b93-bb42-8f5073acae13.jpg?1",
             "name": "Touchstone",
             "text": "oc\nT: Tap target artifact you do not control.",
             "colours": [],
@@ -5153,7 +5153,7 @@
         },
         {
             "id": "0bf9ea17-d141-5652-818a-76c25483b4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5184b967-f474-4c9b-9a20-65ddb0d6e4f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5184b967-f474-4c9b-9a20-65ddb0d6e4f8.jpg?1",
             "name": "Well of Knowledge",
             "text": "Any player may pay o2 during his or her draw phase to draw a card. Players may use this ability as many times as they choose.",
             "colours": [],
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "ec5174db-aab9-546d-8967-2f05162ccd4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8becb285-cd91-4de0-af59-ddaa7d8c5366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8becb285-cd91-4de0-af59-ddaa7d8c5366.jpg?1",
             "name": "Xanthic Statue",
             "text": "o5: Until end of turn, Xanthic Statue is an 8/8 artifact creature with trample.",
             "colours": [],
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "38d0f073-95d5-514d-8fe8-21e04aaecfd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09507f7f-c58f-4f57-b878-b39811a5b619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09507f7f-c58f-4f57-b878-b39811a5b619.jpg?1",
             "name": "Gemstone Mine",
             "text": "When Gemstone Mine comes into play, put three mining counters on it.\noc\nT, Remove a mining counter from Gemstone Mine: Add one mana of any color to your mana pool. If there are no mining counters on Gemstone Mine, bury it.",
             "colours": [],
@@ -5234,7 +5234,7 @@
         },
         {
             "id": "344ab473-e5d3-57ed-9ec4-96d91abcc680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5cd12a-2a07-44a8-8eac-de00d26fe9e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5cd12a-2a07-44a8-8eac-de00d26fe9e3.jpg?1",
             "name": "Lotus Vale",
             "text": "When Lotus Vale comes into play, sacrifice two untapped lands or bury Lotus Vale.\noc\nT: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "9733a606-9856-5077-a0fa-27d52dad1d80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4e843-937c-47fb-8768-0f42c5cb4e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4e843-937c-47fb-8768-0f42c5cb4e4f.jpg?1",
             "name": "Scorched Ruins",
             "text": "When Scorched Ruins comes into play, sacrifice two untapped lands or bury Scorched Ruins.\noc\nT: Add four colorless mana to your mana pool.",
             "colours": [],
@@ -5288,7 +5288,7 @@
         },
         {
             "id": "675ce267-e99d-523e-8722-402debaa9717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26672a8-f4ff-4c64-bb3e-f5072bbc9e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26672a8-f4ff-4c64-bb3e-f5072bbc9e3e.jpg?1",
             "name": "Winding Canyons",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Until end of turn, you may play creature cards whenever you could play instants.",
             "colours": [],

--- a/Assets/Resources/Sets/WWK.json
+++ b/Assets/Resources/Sets/WWK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c4c30137-bb7f-5d54-b9bd-d98e7ed1c161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feddbd0-3d29-4428-b70d-107c1e26930d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feddbd0-3d29-4428-b70d-107c1e26930d.jpg?1",
             "name": "Admonition Angel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may exile target nonland permanent other than Admonition Angel.\nWhen Admonition Angel leaves the battlefield, return all cards exiled with it to the battlefield under their owners' control.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "fece374b-77c5-5d4a-8700-4f0b235d553d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f038f0-6f50-4f89-855c-6bbd68d84436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f038f0-6f50-4f89-855c-6bbd68d84436.jpg?1",
             "name": "Apex Hawks",
             "text": "Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nFlying\nApex Hawks enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "87f62994-3bf2-5b27-b92a-04fbb03eae85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7dfcf6-c41b-48d6-a3b4-4b4a7bed82eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7dfcf6-c41b-48d6-a3b4-4b4a7bed82eb.jpg?1",
             "name": "Archon of Redemption",
             "text": "Flying\nWhenever Archon of Redemption or another creature with flying enters the battlefield under your control, you may gain life equal to that creature's power.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "1ce74470-c2cf-58d9-9d27-02ca5256b821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f540b83-67fd-4630-a461-69bc84b88ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f540b83-67fd-4630-a461-69bc84b88ed3.jpg?1",
             "name": "Battle Hurda",
             "text": "First strike",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "2dfb1f15-09ae-5f52-8a4d-d5cad1e2a75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1739550d-3bd8-421b-b2a9-95dd3bff2ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1739550d-3bd8-421b-b2a9-95dd3bff2ce2.jpg?1",
             "name": "Fledgling Griffin",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Fledgling Griffin gains flying until end of turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "b2cc6529-70c3-517b-ba23-d407fa51ed63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20b710-6d09-4080-acd5-e88ad98460a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20b710-6d09-4080-acd5-e88ad98460a9.jpg?1",
             "name": "Guardian Zendikon",
             "text": "Enchant land\nEnchanted land is a 2/6 white Wall creature with defender. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "67d48853-391c-56d7-8f35-f9867b4ce4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22700453-e1aa-43d1-9b51-cda8a37fc00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22700453-e1aa-43d1-9b51-cda8a37fc00d.jpg?1",
             "name": "Hada Freeblade",
             "text": "Whenever Hada Freeblade or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Hada Freeblade.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "49e7b289-44dc-5299-bd97-77d711e99aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2c308c-e681-4eba-8b62-bcc95f1e8548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2c308c-e681-4eba-8b62-bcc95f1e8548.jpg?1",
             "name": "Iona's Judgment",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "463b2a37-ef0a-5c44-8ecf-323b1c758b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27e2eb4-d48b-43c3-bd19-e1748f310c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27e2eb4-d48b-43c3-bd19-e1748f310c54.jpg?1",
             "name": "Join the Ranks",
             "text": "Put two 1/1 white Soldier Ally creature tokens onto the battlefield.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "563c0af6-d47f-5c11-90f0-1700491329b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e2315e-41d9-4e46-bee4-c8f92e91e2a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e2315e-41d9-4e46-bee4-c8f92e91e2a9.jpg?1",
             "name": "Kitesail Apprentice",
             "text": "As long as Kitesail Apprentice is equipped, it gets +1/+1 and has flying.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "ce60a1d7-443d-5acb-9b15-8f1b91e8a062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3b88ad-9d65-4873-8527-8f420570aad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3b88ad-9d65-4873-8527-8f420570aad3.jpg?1",
             "name": "Kor Firewalker",
             "text": "Protection from red\nWhenever a player casts a red spell, you may gain 1 life.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "b95ddf82-4726-59ba-8aca-fa8da7bbc151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d0234f-d712-4ac3-bd3b-10f9c530e167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d0234f-d712-4ac3-bd3b-10f9c530e167.jpg?1",
             "name": "Lightkeeper of Emeria",
             "text": "Multikicker {W} (You may pay an additional {W} any number of times as you cast this spell.)\nFlying\nWhen Lightkeeper of Emeria enters the battlefield, you gain 2 life for each time it was kicked.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "0a320645-87c5-581f-9501-5b6007d06b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbb5f-6cb4-4971-b159-ee5f875ba260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbb5f-6cb4-4971-b159-ee5f875ba260.jpg?1",
             "name": "Loam Lion",
             "text": "Loam Lion gets +1/+2 as long as you control a Forest.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "d385f53b-ef4c-5310-9107-9b8f04b8d2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0c439a-25e4-4ff7-8080-b3be59d5dbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0c439a-25e4-4ff7-8080-b3be59d5dbe6.jpg?1",
             "name": "Marsh Threader",
             "text": "Swampwalk",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "ead550f5-f1b8-56ec-9a16-09aca2e17501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38b1b7a-2f20-4a82-b143-7aeafc686dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38b1b7a-2f20-4a82-b143-7aeafc686dee.jpg?1",
             "name": "Marshal's Anthem",
             "text": "Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nCreatures you control get +1/+1.\nWhen Marshal's Anthem enters the battlefield, return up to X target creature cards from your graveyard to the battlefield, where X is the number of times Marshal's Anthem was kicked.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "3061388d-03aa-5c2f-8548-dc58c75292dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e532309-5cf9-4d12-b673-f9baad30b800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e532309-5cf9-4d12-b673-f9baad30b800.jpg?1",
             "name": "Perimeter Captain",
             "text": "Defender\nWhenever a creature you control with defender blocks, you may gain 2 life.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "c790eafd-cf9f-5f61-8fd5-a0da4cebf935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdceb36-fd36-4315-8ebe-9b8fc3777428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdceb36-fd36-4315-8ebe-9b8fc3777428.jpg?1",
             "name": "Refraction Trap",
             "text": "If an opponent cast a red instant or sorcery spell this turn, you may pay {W} rather than pay Refraction Trap's mana cost.\nPrevent the next 3 damage that a source of your choice would deal to you and/or permanents you control this turn. If damage is prevented this way, Refraction Trap deals that much damage to target creature or player.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "3325f013-5260-535a-8e69-bea31aa34e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eb8537-42c9-41d5-be0a-1186bc8dee0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eb8537-42c9-41d5-be0a-1186bc8dee0b.jpg?1",
             "name": "Rest for the Weary",
             "text": "Target player gains 4 life.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that player gains 8 life instead.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "d79a1cd0-8507-596b-9b3e-6dce56ba1c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b60f10-0997-46ec-8914-f5cdde76cf75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b60f10-0997-46ec-8914-f5cdde76cf75.jpg?1",
             "name": "Ruin Ghost",
             "text": "{W}, {T}: Exile target land you control, then return it to the battlefield under your control.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "42a128a8-aa5d-5aac-aaf1-cb2fc7702368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19557351-b65f-4b04-b971-66abdc07000a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19557351-b65f-4b04-b971-66abdc07000a.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.\n{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "15857090-ea13-5df0-a6b9-d9275e69c068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5212f4-f04c-4ca3-b254-654bb263829b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5212f4-f04c-4ca3-b254-654bb263829b.jpg?1",
             "name": "Talus Paladin",
             "text": "Whenever Talus Paladin or another Ally enters the battlefield under your control, you may have Allies you control gain lifelink until end of turn, and you may put a +1/+1 counter on Talus Paladin.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "a94c032a-10d1-5fa8-bd98-2bb7f878cbab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bad0759-4132-42b5-9a26-0fcf321a60e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bad0759-4132-42b5-9a26-0fcf321a60e0.jpg?1",
             "name": "Terra Eternal",
             "text": "All lands are indestructible.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "b82489f2-47cb-5f71-9cf9-010919a7bba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f220b-f860-4ebb-a424-22598bdd6fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f220b-f860-4ebb-a424-22598bdd6fae.jpg?1",
             "name": "Veteran's Reflexes",
             "text": "Target creature gets +1/+1 until end of turn. Untap that creature.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "7eacf37b-0921-567b-9f8e-e6bfafaa098b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f31a77-a4a9-4783-8885-c44552379ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f31a77-a4a9-4783-8885-c44552379ae6.jpg?1",
             "name": "Aether Tradewinds",
             "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
             "colours": [
@@ -815,7 +815,7 @@
         },
         {
             "id": "88cca0ba-0e63-5e49-8bf6-2b13d1f5cdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec0c914-1188-45c9-a68c-c3b915dbebf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec0c914-1188-45c9-a68c-c3b915dbebf7.jpg?1",
             "name": "Calcite Snapper",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may switch Calcite Snapper's power and toughness until end of turn.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "19ec5137-4148-50be-8166-dfc4d2106c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f178d0cc-5dd1-41ab-a2e8-218ece6f2a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f178d0cc-5dd1-41ab-a2e8-218ece6f2a86.jpg?1",
             "name": "Dispel",
             "text": "Counter target instant spell.",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "3e1d7823-11e2-5968-8941-33777109e6d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af0ef2e-4273-432a-8d03-3480165f1be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af0ef2e-4273-432a-8d03-3480165f1be7.jpg?1",
             "name": "Enclave Elite",
             "text": "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\nIslandwalk\nEnclave Elite enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "16775cf9-7bbe-5a45-80f8-e312a8eea9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a792b-ad04-4892-92d9-0f6abe3759e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a792b-ad04-4892-92d9-0f6abe3759e8.jpg?1",
             "name": "Goliath Sphinx",
             "text": "Flying",
             "colours": [
@@ -950,7 +950,7 @@
         },
         {
             "id": "1a49b151-d274-5559-a87e-333f2d7ad587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147dce7-b2dd-426a-9ff7-843d50bb8b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147dce7-b2dd-426a-9ff7-843d50bb8b01.jpg?1",
             "name": "Halimar Excavator",
             "text": "Whenever Halimar Excavator or another Ally enters the battlefield under your control, target player puts the top X cards of his or her library into his or her graveyard, where X is the number of Allies you control.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "2c5db1e7-9779-5f61-9384-1c1715616093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022f07c5-c644-41cd-9434-a57068f73ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022f07c5-c644-41cd-9434-a57068f73ab2.jpg?1",
             "name": "Horizon Drake",
             "text": "Flying, protection from lands",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "635f9f1e-4ea0-50d4-8f8b-0dd6b0d609b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e606072-a3aa-4300-ba90-ec92a721fa76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e606072-a3aa-4300-ba90-ec92a721fa76.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n-1: Return target creature to its owner's hand.\n-12: Exile all cards from target player's library, then that player shuffles his or her hand into his or her library.",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "805e5277-8346-5fa8-833b-dad4566b3881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587f91f6-b46e-4dd5-a86d-1048054dd3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587f91f6-b46e-4dd5-a86d-1048054dd3c0.jpg?1",
             "name": "Jwari Shapeshifter",
             "text": "You may have Jwari Shapeshifter enter the battlefield as a copy of any Ally creature on the battlefield.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "a9ea12f6-adfc-5abe-a8be-e71429d02d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1907b1e9-ae1e-43fb-9033-3c4322277fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1907b1e9-ae1e-43fb-9033-3c4322277fff.jpg?1",
             "name": "Mysteries of the Deep",
             "text": "Draw two cards.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, draw three cards instead.",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "4436145d-3ba0-5e4b-972f-c2e5e760b6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b6dc43-62d3-4572-a2e1-b0e67dcc21c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b6dc43-62d3-4572-a2e1-b0e67dcc21c7.jpg?1",
             "name": "Permafrost Trap",
             "text": "If an opponent had a green creature enter the battlefield under his or her control this turn, you may pay {U} rather than pay Permafrost Trap's mana cost.\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "0dbb20da-58bf-5e7b-95e7-e0f8d8a26f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77983bbf-6761-4126-82b4-bdcdd6b8e1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77983bbf-6761-4126-82b4-bdcdd6b8e1dc.jpg?1",
             "name": "Quest for Ula's Temple",
             "text": "At the beginning of your upkeep, you may look at the top card of your library. If it's a creature card, you may reveal it and put a quest counter on Quest for Ula's Temple.\nAt the beginning of each end step, if there are three or more quest counters on Quest for Ula's Temple, you may put a Kraken, Leviathan, Octopus, or Serpent creature card from your hand onto the battlefield.",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "32b473f1-e135-5f81-9020-29856aa7771b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae04d82-56f5-4c72-b1c1-40c7d9640b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae04d82-56f5-4c72-b1c1-40c7d9640b7c.jpg?1",
             "name": "Sejiri Merfolk",
             "text": "As long as you control a Plains, Sejiri Merfolk has first strike and lifelink. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "091c88e3-0ea6-5d37-b3f7-7fa01e86da5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555063cc-99ad-4014-b17b-c4c6b40d2e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555063cc-99ad-4014-b17b-c4c6b40d2e81.jpg?1",
             "name": "Selective Memory",
             "text": "Search your library for any number of nonland cards and exile them. Then shuffle your library.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "b4d21b75-a035-5d04-8919-e7c57b789a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b748d8b-898f-4b55-bc33-f5bbbc823c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b748d8b-898f-4b55-bc33-f5bbbc823c45.jpg?1",
             "name": "Spell Contortion",
             "text": "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\nCounter target spell unless its controller pays {2}. Draw a card for each time Spell Contortion was kicked.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "922727f0-34db-5fa7-9b27-2623b1a0764f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ec4dc0-09ae-437d-a7d6-cb27c2cb7590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ec4dc0-09ae-437d-a7d6-cb27c2cb7590.jpg?1",
             "name": "Surrakar Banisher",
             "text": "When Surrakar Banisher enters the battlefield, you may return target tapped creature to its owner's hand.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "6141938d-9bf0-5fa3-bc2f-0b6a7d439b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcbeab-7a1e-4dcf-99bf-98f42c2b6a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcbeab-7a1e-4dcf-99bf-98f42c2b6a6f.jpg?1",
             "name": "Thada Adel, Acquisitor",
             "text": "Islandwalk\nWhenever Thada Adel, Acquisitor deals combat damage to a player, search that player's library for an artifact card and exile it. Then that player shuffles his or her library. Until end of turn, you may play that card.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "8433ff54-3ce4-5fcc-8c7c-928c89e82fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23e758d-c9a4-4f8e-b366-634f8c451b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23e758d-c9a4-4f8e-b366-634f8c451b61.jpg?1",
             "name": "Tideforce Elemental",
             "text": "{U}, {T}: You may tap or untap another target creature.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may untap Tideforce Elemental.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "ebbb1e8b-94e6-522e-8e7b-bcf356600a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce73b174-2448-4914-bca3-70564191da16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce73b174-2448-4914-bca3-70564191da16.jpg?1",
             "name": "Treasure Hunt",
             "text": "Reveal cards from the top of your library until you reveal a nonland card, then put all cards revealed this way into your hand.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "19f79314-cc01-5541-8cf9-a24d18397a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267f18b9-efe7-4ff4-9932-7fbb3cfe5436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267f18b9-efe7-4ff4-9932-7fbb3cfe5436.jpg?1",
             "name": "Twitch",
             "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "5253de9f-cfad-58b5-af74-0fdee0562579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09358e-099a-4115-807e-48ceb024d186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09358e-099a-4115-807e-48ceb024d186.jpg?1",
             "name": "Vapor Snare",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, sacrifice Vapor Snare unless you return a land you control to its owner's hand.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "cf855559-65a3-5997-a64a-f3ca349095ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6fb960-58cb-42db-975f-fd9329e852fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6fb960-58cb-42db-975f-fd9329e852fd.jpg?1",
             "name": "Voyager Drake",
             "text": "Multikicker {U} (You may pay an additional {U} any number of times as you cast this spell.)\nFlying\nWhen Voyager Drake enters the battlefield, up to X target creatures gain flying until end of turn, where X is the number of times Voyager Drake was kicked.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "a9ca4c7d-f227-59d6-9281-c8bc2cedbd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaae63e-6269-4aca-aa45-956f6bf4e112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaae63e-6269-4aca-aa45-956f6bf4e112.jpg?1",
             "name": "Wind Zendikon",
             "text": "Enchant land\nEnchanted land is a 2/2 blue Elemental creature with flying. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "727c5cb9-f943-5885-9a79-7ee8a32d7a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee68b52-6377-419b-b772-2af1e57cbe5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee68b52-6377-419b-b772-2af1e57cbe5d.jpg?1",
             "name": "Abyssal Persecutor",
             "text": "Flying, trample\nYou can't win the game and your opponents can't lose the game.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "acf25960-685d-5797-b77b-21f49337993a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c592ef76-d612-4cfe-b906-0e63c44d36f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c592ef76-d612-4cfe-b906-0e63c44d36f8.jpg?1",
             "name": "Agadeem Occultist",
             "text": "{T}: Put target creature card from an opponent's graveyard onto the battlefield under your control if its converted mana cost is less than or equal to the number of Allies you control.",
             "colours": [
@@ -1629,7 +1629,7 @@
         },
         {
             "id": "82e5f4e3-23ef-530f-96cb-d2be70d008da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b247681-1cf6-42a0-ad44-76261c690596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b247681-1cf6-42a0-ad44-76261c690596.jpg?1",
             "name": "Anowon, the Ruin Sage",
             "text": "At the beginning of your upkeep, each player sacrifices a non-Vampire creature.",
             "colours": [
@@ -1666,7 +1666,7 @@
         },
         {
             "id": "477b2c97-c304-51bc-b704-7ea6a67611af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5445e2-1fa8-4c66-b441-892a76675810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5445e2-1fa8-4c66-b441-892a76675810.jpg?1",
             "name": "Bloodhusk Ritualist",
             "text": "Multikicker {B} (You may pay an additional {B} any number of times as you cast this spell.)\nWhen Bloodhusk Ritualist enters the battlefield, target opponent discards a card for each time it was kicked.",
             "colours": [
@@ -1701,7 +1701,7 @@
         },
         {
             "id": "9f5eaa1a-3bcc-5ba2-b1d4-780a2c907726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e0aa67-0ea9-4c50-8297-369ab486fd0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e0aa67-0ea9-4c50-8297-369ab486fd0f.jpg?1",
             "name": "Bojuka Brigand",
             "text": "Bojuka Brigand can't block.\nWhenever Bojuka Brigand or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Bojuka Brigand.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "c02a7b76-81e5-518c-b044-c60b5fd0f3ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c841c3e-e0d1-49d7-bcec-3c45f73c13c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c841c3e-e0d1-49d7-bcec-3c45f73c13c5.jpg?1",
             "name": "Brink of Disaster",
             "text": "Enchant creature or land\nWhen enchanted permanent becomes tapped, destroy it.",
             "colours": [
@@ -1771,7 +1771,7 @@
         },
         {
             "id": "6e272c6a-d49b-5e74-aa59-905a6d1bc571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73131341-0fde-4eca-aefa-ce69c933af07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73131341-0fde-4eca-aefa-ce69c933af07.jpg?1",
             "name": "Butcher of Malakir",
             "text": "Flying\nWhenever Butcher of Malakir or another creature you control is put into a graveyard from the battlefield, each opponent sacrifices a creature.",
             "colours": [
@@ -1806,7 +1806,7 @@
         },
         {
             "id": "b6b88afc-be90-56ee-ac0c-f345e0c1e46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80076580-23f1-4008-ab91-9dad8c806cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80076580-23f1-4008-ab91-9dad8c806cfa.jpg?1",
             "name": "Caustic Crawler",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "1e1bdd58-94c1-5098-91f5-92ba9ea44a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce7d93d-3998-4486-b277-e4f91f6e3feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce7d93d-3998-4486-b277-e4f91f6e3feb.jpg?1",
             "name": "Corrupted Zendikon",
             "text": "Enchant land\nEnchanted land is a 3/3 black Ooze creature. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "3c8755d7-9029-5e21-9de7-f72603fac77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad16a3b8-e99e-47ed-92ce-ef42310f9f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad16a3b8-e99e-47ed-92ce-ef42310f9f46.jpg?1",
             "name": "Dead Reckoning",
             "text": "You may put target creature card from your graveyard on top of your library. If you do, Dead Reckoning deals damage equal to that card's power to target creature.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "6d14524d-c088-5505-9403-7d7e8cf90070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e040c3-bf42-4a5b-aeb3-5dc9921151e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e040c3-bf42-4a5b-aeb3-5dc9921151e5.jpg?1",
             "name": "Death's Shadow",
             "text": "Death's Shadow gets -X/-X, where X is your life total.",
             "colours": [
@@ -1940,7 +1940,7 @@
         },
         {
             "id": "484f855b-033a-5ef6-a1a6-882a1f97cb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4e933b-de65-4089-877f-c598004b8e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4e933b-de65-4089-877f-c598004b8e7e.jpg?1",
             "name": "Jagwasp Swarm",
             "text": "Flying",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "85a85d88-54d0-54b6-a1ae-3a46e65bcf2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1efd1dd-903c-47a0-b746-5571a3ea1755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1efd1dd-903c-47a0-b746-5571a3ea1755.jpg?1",
             "name": "Kalastria Highborn",
             "text": "Whenever Kalastria Highborn or another Vampire you control is put into a graveyard from the battlefield, you may pay {B}. If you do, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2009,7 +2009,7 @@
         },
         {
             "id": "f2cec1fb-02f3-5202-bf3e-26f299bd22d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6976c2-f2a0-4993-a428-9469ada5ca37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6976c2-f2a0-4993-a428-9469ada5ca37.jpg?1",
             "name": "Mire's Toll",
             "text": "Target player reveals a number of cards from his or her hand equal to the number of Swamps you control. You choose one of them. That player discards that card.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "20bd9b73-8f79-5da7-bbab-f10773cca8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a9f5cb-3139-4c6e-a2d4-69e1659b8db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a9f5cb-3139-4c6e-a2d4-69e1659b8db2.jpg?1",
             "name": "Nemesis Trap",
             "text": "If a white creature is attacking, you may pay {B}{B} rather than pay Nemesis Trap's mana cost.\nExile target attacking creature. Put a creature token that's a copy of that creature onto the battlefield. Exile it at the beginning of the next end step.",
             "colours": [
@@ -2075,7 +2075,7 @@
         },
         {
             "id": "01e5971c-1fe4-5b35-b923-40c2421fbce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4604a63c-ebe0-420f-968e-3ffc7641ce22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4604a63c-ebe0-420f-968e-3ffc7641ce22.jpg?1",
             "name": "Pulse Tracker",
             "text": "Whenever Pulse Tracker attacks, each opponent loses 1 life.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "947249c6-668d-570b-9baa-7812135ce749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f0220f-6120-433a-b37f-f655f25322c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f0220f-6120-433a-b37f-f655f25322c5.jpg?1",
             "name": "Quag Vampires",
             "text": "Multikicker {1}{B} (You may pay an additional {1}{B} any number of times as you cast this spell.)\nSwampwalk\nQuag Vampires enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "505682ec-c30d-5d46-9b4d-801f86a92836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c604a567-71dd-47d9-ae5d-b87b4db98df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c604a567-71dd-47d9-ae5d-b87b4db98df4.jpg?1",
             "name": "Quest for the Nihil Stone",
             "text": "Whenever an opponent discards a card, you may put a quest counter on Quest for the Nihil Stone.\nAt the beginning of each opponent's upkeep, if that player has no cards in hand and Quest for the Nihil Stone has two or more quest counters on it, you may have that player lose 5 life.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "ee8912c0-6f63-5b01-b388-d49591413f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da2dc92-0352-4757-8249-67f08a2464d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da2dc92-0352-4757-8249-67f08a2464d1.jpg?1",
             "name": "Ruthless Cullblade",
             "text": "Ruthless Cullblade gets +2/+1 as long as an opponent has 10 or less life.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "95798fc2-76ed-531b-93cd-e5dd9607ab19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4170ddd3-53bd-4ec7-82c0-4fb48f400aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4170ddd3-53bd-4ec7-82c0-4fb48f400aa5.jpg?1",
             "name": "Scrib Nibblers",
             "text": "{T}: Exile the top card of target player's library. If it's a land card, you gain 1 life.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may untap Scrib Nibblers.",
             "colours": [
@@ -2246,7 +2246,7 @@
         },
         {
             "id": "dcfc85a9-b87a-5636-9057-00a2c3279b34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d87345-9f89-4b65-ae9c-a0f46b1e9f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d87345-9f89-4b65-ae9c-a0f46b1e9f31.jpg?1",
             "name": "Shoreline Salvager",
             "text": "Whenever Shoreline Salvager deals combat damage to a player, if you control an Island, you may draw a card.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "d0db8e8d-9257-5516-81b5-9bcc241c6424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b4deea-c077-46ab-898f-41b3907ecf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b4deea-c077-46ab-898f-41b3907ecf33.jpg?1",
             "name": "Smother",
             "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "418fe18d-007a-52fa-a490-05d56e1efa6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beaaa66-0dae-4631-895d-06570834ba7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beaaa66-0dae-4631-895d-06570834ba7c.jpg?1",
             "name": "Tomb Hex",
             "text": "Target creature gets -2/-2 until end of turn.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that creature gets -4/-4 until end of turn instead.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "71191575-3405-5c75-a88d-0cd03b9631ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b388d4d9-62b6-4174-897e-f933a4badcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b388d4d9-62b6-4174-897e-f933a4badcf9.jpg?1",
             "name": "Urge to Feed",
             "text": "Target creature gets -3/-3 until end of turn. You may tap any number of untapped Vampire creatures you control. If you do, put a +1/+1 counter on each of those Vampires.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "a2bc3620-557a-54ac-8bb4-95d6bc2d3289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031950b6-110f-4e20-b31b-afe5ffdd6086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031950b6-110f-4e20-b31b-afe5ffdd6086.jpg?1",
             "name": "Akoum Battlesinger",
             "text": "Haste\nWhenever Akoum Battlesinger or another Ally enters the battlefield under your control, you may have Ally creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -2412,7 +2412,7 @@
         },
         {
             "id": "f2db73e3-7236-578c-b4e2-22be6c058ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ef13-a363-4cab-b69d-39093a621a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ef13-a363-4cab-b69d-39093a621a5c.jpg?1",
             "name": "Bazaar Trader",
             "text": "{T}: Target player gains control of target artifact, creature, or land you control.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "300aa07c-f72e-5798-8362-7388c6210073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed55a4d-d99c-44ae-a5b9-fd9d1b8477f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed55a4d-d99c-44ae-a5b9-fd9d1b8477f9.jpg?1",
             "name": "Bull Rush",
             "text": "Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -2478,7 +2478,7 @@
         },
         {
             "id": "4dc05df0-59cd-548f-8e19-8fb45afb0556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614b9df9-c959-4bdb-91c0-75ae60b724e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614b9df9-c959-4bdb-91c0-75ae60b724e4.jpg?1",
             "name": "Chain Reaction",
             "text": "Chain Reaction deals X damage to each creature, where X is the number of creatures on the battlefield.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "c36228aa-9493-51e2-98e8-94129972a06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85fb3ef-be24-4ea4-9f0e-0bb73f8baf90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85fb3ef-be24-4ea4-9f0e-0bb73f8baf90.jpg?1",
             "name": "Claws of Valakut",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 for each Mountain you control and has first strike.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "25ee4245-abf4-5f69-8ab8-3ba17a94be86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8b2c8-7afe-4299-b59b-8cd2cdc8d4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8b2c8-7afe-4299-b59b-8cd2cdc8d4cb.jpg?1",
             "name": "Comet Storm",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature or player, then choose another target creature or player for each time Comet Storm was kicked. Comet Storm deals X damage to each of them.",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "89b7bd38-deda-521e-905d-395baf25f356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e73e-f6ac-46b7-9029-ef389a9ebe9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e73e-f6ac-46b7-9029-ef389a9ebe9f.jpg?1",
             "name": "Cosi's Ravager",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have Cosi's Ravager deal 1 damage to target player.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "ae09c2b7-9db0-56e4-8366-0fc962575d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf140fa-a901-41a5-a10f-f97ccef72fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf140fa-a901-41a5-a10f-f97ccef72fcc.jpg?1",
             "name": "Crusher Zendikon",
             "text": "Enchant land\nEnchanted land is a 4/2 red Beast creature with trample. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "dcd44266-8b92-51fa-bc94-d4fd256c5646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699842c1-6507-48ee-b98b-3774d1f07c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699842c1-6507-48ee-b98b-3774d1f07c76.jpg?1",
             "name": "Cunning Sparkmage",
             "text": "Haste\n{T}: Cunning Sparkmage deals 1 damage to target creature or player.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "e4e660fe-c091-5bcf-8eec-f70c63e9ae0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd079fe-83fc-4a9d-8185-dfe620b9d1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd079fe-83fc-4a9d-8185-dfe620b9d1e0.jpg?1",
             "name": "Deathforge Shaman",
             "text": "Multikicker {R} (You may pay an additional {R} any number of times as you cast this spell.)\nWhen Deathforge Shaman enters the battlefield, it deals damage to target player equal to twice the number of times it was kicked.",
             "colours": [
@@ -2714,7 +2714,7 @@
         },
         {
             "id": "069e72dc-2034-5d75-85bc-17a25df7cfd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2297a4e-3c19-4748-9150-efbd2513066a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2297a4e-3c19-4748-9150-efbd2513066a.jpg?1",
             "name": "Dragonmaster Outcast",
             "text": "At the beginning of your upkeep, if you control six or more lands, put a 5/5 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "2ff93cf7-154f-5417-9449-f471cfdfd735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79787dd-6d2f-4773-aefe-16a4eb93d3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79787dd-6d2f-4773-aefe-16a4eb93d3cc.jpg?1",
             "name": "Goblin Roughrider",
             "text": "",
             "colours": [
@@ -2784,7 +2784,7 @@
         },
         {
             "id": "408f0958-083a-58cf-9442-7f58e59be34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9275cb0a-e777-40f8-934a-a3f6e6071ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9275cb0a-e777-40f8-934a-a3f6e6071ec6.jpg?1",
             "name": "Grotag Thrasher",
             "text": "Whenever Grotag Thrasher attacks, target creature can't block this turn.",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "a0b9ffa0-87a2-517b-987d-dbad9acb2968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09154170-70f5-45ca-8903-027ad04bc98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09154170-70f5-45ca-8903-027ad04bc98b.jpg?1",
             "name": "Kazuul, Tyrant of the Cliffs",
             "text": "Whenever a creature an opponent controls attacks, if you're the defending player, put a 3/3 red Ogre creature token onto the battlefield unless that creature's controller pays {3}.",
             "colours": [
@@ -2855,7 +2855,7 @@
         },
         {
             "id": "561a92ad-a6d7-5dcf-8c22-c70ad136865a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b32069-a707-4a4b-8379-c097d829bb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b32069-a707-4a4b-8379-c097d829bb90.jpg?1",
             "name": "Mordant Dragon",
             "text": "Flying\n{1}{R}: Mordant Dragon gets +1/+0 until end of turn.\nWhenever Mordant Dragon deals combat damage to a player, you may have it deal that much damage to target creature that player controls.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "2601ec8c-460b-5381-8bb6-d43cd1a4fcad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23adb09-d216-47f5-a7d4-cb6a2ce48ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23adb09-d216-47f5-a7d4-cb6a2ce48ada.jpg?1",
             "name": "Quest for the Goblin Lord",
             "text": "Whenever a Goblin enters the battlefield under your control, you may put a quest counter on Quest for the Goblin Lord.\nAs long as Quest for the Goblin Lord has five or more quest counters on it, creatures you control get +2/+0.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "579cc858-d51e-5eba-87bd-f9cbf20b87e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d782375-9192-4ed0-bd79-f3404e5a1b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d782375-9192-4ed0-bd79-f3404e5a1b01.jpg?1",
             "name": "Ricochet Trap",
             "text": "If an opponent cast a blue spell this turn, you may pay {R} rather than pay Ricochet Trap's mana cost.\nChange the target of target spell with a single target.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "59879d00-2a5d-5838-81f2-482250c1bca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d3a425-01d1-4001-92f9-8e297dd862b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d3a425-01d1-4001-92f9-8e297dd862b7.jpg?1",
             "name": "Roiling Terrain",
             "text": "Destroy target land, then Roiling Terrain deals damage to that land's controller equal to the number of land cards in that player's graveyard.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "93266b71-9edc-5bb4-a88e-497cb03b8666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fd58c6-5bca-4160-bc1e-63b9cb3996ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fd58c6-5bca-4160-bc1e-63b9cb3996ab.jpg?1",
             "name": "Rumbling Aftershocks",
             "text": "Whenever you cast a kicked spell, you may have Rumbling Aftershocks deal damage to target creature or player equal to the number of times that spell was kicked.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "4ca819cb-a58e-5578-a4d6-3a492ba2122c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301f13dd-39b8-4a93-9c05-3dc4fa1f1c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301f13dd-39b8-4a93-9c05-3dc4fa1f1c75.jpg?1",
             "name": "Searing Blaze",
             "text": "Searing Blaze deals 1 damage to target player and 1 damage to target creature that player controls.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, Searing Blaze deals 3 damage to that player and 3 damage to that creature instead.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "64667284-43e9-508d-9c6c-8f1b66e25318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153c1465-9cbc-424b-8147-79e95fd45b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153c1465-9cbc-424b-8147-79e95fd45b3d.jpg?1",
             "name": "Skitter of Lizards",
             "text": "Multikicker {1}{R} (You may pay an additional {1}{R} any number of times as you cast this spell.)\nHaste\nSkitter of Lizards enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "fc56bb51-4437-55e4-9304-a7b731b830fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71790058-3362-421f-b248-a3b2095100eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71790058-3362-421f-b248-a3b2095100eb.jpg?1",
             "name": "Slavering Nulls",
             "text": "Whenever Slavering Nulls deals combat damage to a player, if you control a Swamp, you may have that player discard a card.",
             "colours": [
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "efed22a5-d50d-52fe-95ba-f523004c0900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dee4b3-f3c1-4ef5-8dfa-fa10c860be1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dee4b3-f3c1-4ef5-8dfa-fa10c860be1e.jpg?1",
             "name": "Stone Idol Trap",
             "text": "Stone Idol Trap costs {1} less to cast for each attacking creature.\nPut a 6/12 colorless Construct artifact creature token with trample onto the battlefield. Exile it at the beginning of your next end step.",
             "colours": [
@@ -3154,7 +3154,7 @@
         },
         {
             "id": "3d56d4b1-0a60-5ef2-852e-0f2b1dcdae6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a84a2a-6384-497a-8ee2-de0fa74fcc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a84a2a-6384-497a-8ee2-de0fa74fcc80.jpg?1",
             "name": "Tuktuk Scrapper",
             "text": "Whenever Tuktuk Scrapper or another Ally enters the battlefield under your control, you may destroy target artifact. If that artifact is put into a graveyard this way, Tuktuk Scrapper deals damage to that artifact's controller equal to the number of Allies you control.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "bfd63672-033f-58da-a8ba-25d17da6611b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32a4ed-6b43-4473-91ec-08cd5414f2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32a4ed-6b43-4473-91ec-08cd5414f2f0.jpg?1",
             "name": "Arbor Elf",
             "text": "{T}: Untap target Forest.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "0d9a4b4e-f301-55d8-bed3-83101ff81652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde073e0-f329-4ab0-8e31-a48929e017ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde073e0-f329-4ab0-8e31-a48929e017ce.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, put a 0/1 green Plant creature token onto the battlefield for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "24ea3143-811a-5c31-a2e9-a4a2b755086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434b99c2-26f5-4d45-8453-77d9dedb7892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434b99c2-26f5-4d45-8453-77d9dedb7892.jpg?1",
             "name": "Bestial Menace",
             "text": "Put a 1/1 green Snake creature token, a 2/2 green Wolf creature token, and a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "1f5ccff6-eb58-5b7e-bc9c-1f4fa871882c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc34db-60be-4017-adfa-6bdfacec793f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc34db-60be-4017-adfa-6bdfacec793f.jpg?1",
             "name": "Canopy Cover",
             "text": "Enchant creature\nEnchanted creature can't be blocked except by creatures with flying or reach.\nEnchanted creature can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -3325,7 +3325,7 @@
         },
         {
             "id": "f91c219b-93e5-5ba0-b179-4c22f2714d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f81e8a-e309-4bac-81de-326756cd8901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f81e8a-e309-4bac-81de-326756cd8901.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -3357,7 +3357,7 @@
         },
         {
             "id": "abd9d3a2-2327-59ef-9c37-648cdb4d5198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215115fa-50a6-42c0-b3c6-8d18e7f65174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215115fa-50a6-42c0-b3c6-8d18e7f65174.jpg?1",
             "name": "Feral Contest",
             "text": "Put a +1/+1 counter on target creature you control. Another target creature blocks it this turn if able.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "e817e712-7d3d-5e57-98e2-2cd5196cafbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68716387-c5ec-4967-be5f-723783722c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68716387-c5ec-4967-be5f-723783722c64.jpg?1",
             "name": "Gnarlid Pack",
             "text": "Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nGnarlid Pack enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "12ae2f53-26ce-5228-97ac-be02dbd126c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2324d0b-ac63-45e5-ba27-a643c61538c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2324d0b-ac63-45e5-ba27-a643c61538c7.jpg?1",
             "name": "Grappler Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "b96ad4bc-052c-507e-a91d-490c52b783b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed04a5a7-f7d0-4dd8-9c23-6a767814316a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed04a5a7-f7d0-4dd8-9c23-6a767814316a.jpg?1",
             "name": "Graypelt Hunter",
             "text": "Trample\nWhenever Graypelt Hunter or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Graypelt Hunter.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "a76cc52c-09f2-5de0-937b-66a6e9f46722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca76e9a-672f-49eb-86c6-00fac60d3065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca76e9a-672f-49eb-86c6-00fac60d3065.jpg?1",
             "name": "Groundswell",
             "text": "Target creature gets +2/+2 until end of turn.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "7eee1d89-a46a-5475-9d67-f6a29bdf1ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a538cf-2291-49aa-8429-17d97d454479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a538cf-2291-49aa-8429-17d97d454479.jpg?1",
             "name": "Harabaz Druid",
             "text": "{T}: Add X mana of any one color to your mana pool, where X is the number of Allies you control.",
             "colours": [
@@ -3561,7 +3561,7 @@
         },
         {
             "id": "3a015537-2f9b-5d23-b442-f6d25858320b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650200df-4408-4d2c-97b0-ef4cd744196c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650200df-4408-4d2c-97b0-ef4cd744196c.jpg?1",
             "name": "Joraga Warcaller",
             "text": "Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nJoraga Warcaller enters the battlefield with a +1/+1 counter on it for each time it was kicked.\nOther Elf creatures you control get +1/+1 for each +1/+1 counter on Joraga Warcaller.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "2c07c923-6fde-51e8-b648-9f79be5c8d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f97b4c-42c7-4986-a150-0b8de11f0537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f97b4c-42c7-4986-a150-0b8de11f0537.jpg?1",
             "name": "Leatherback Baloth",
             "text": "",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "d88d537a-0d75-5188-842d-d094d7c3b4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae5a91-ac54-4222-832e-d7a740a3f7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae5a91-ac54-4222-832e-d7a740a3f7cb.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "44c91697-cae7-5a67-afb1-b8fc84279608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694579c6-f739-45df-8adf-b0c540a904a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694579c6-f739-45df-8adf-b0c540a904a1.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "Green mana doesn't empty from your mana pool as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each green mana in your mana pool.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "dbc247d7-e679-59cf-9b11-fd2796790adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b7ad82-1115-4f80-886a-3f59f568423f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b7ad82-1115-4f80-886a-3f59f568423f.jpg?1",
             "name": "Quest for Renewal",
             "text": "Whenever a creature you control becomes tapped, you may put a quest counter on Quest for Renewal.\nAs long as there are four or more quest counters on Quest for Renewal, untap all creatures you control during each other player's untap step.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "8062ba17-35e0-54d9-a46e-78596af1edc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def592b9-9d8b-4e2d-9b52-e1bc9f4bd019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def592b9-9d8b-4e2d-9b52-e1bc9f4bd019.jpg?1",
             "name": "Slingbow Trap",
             "text": "If a black creature with flying is attacking, you may pay {G} rather than pay Slingbow Trap's mana cost.\nDestroy target attacking creature with flying.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "ea80be9e-9a97-5d46-b867-bfa900b7be25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8860c3d5-8b93-4c52-b374-8814fb8546bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8860c3d5-8b93-4c52-b374-8814fb8546bd.jpg?1",
             "name": "Snapping Creeper",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Snapping Creeper gains vigilance until end of turn.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "d5b7afe2-88b9-54d2-a99f-afeddb3d4a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a06885-08e9-4f5a-8752-fa0945ad7701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a06885-08e9-4f5a-8752-fa0945ad7701.jpg?1",
             "name": "Strength of the Tajuru",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature, then choose another target creature for each time Strength of the Tajuru was kicked. Put X +1/+1 counters on each of them.",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "89fa8aae-95d9-5b86-be42-038a8fd6c19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367e7821-44f1-4064-a9a3-d9852c7c235c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367e7821-44f1-4064-a9a3-d9852c7c235c.jpg?1",
             "name": "Summit Apes",
             "text": "As long as you control a Mountain, Summit Apes can't be blocked except by two or more creatures.",
             "colours": [
@@ -3864,7 +3864,7 @@
         },
         {
             "id": "36ea67df-8a41-5f75-a16c-faf2ace90d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d2f62-8a4a-4e8d-93e1-5dc802684106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d2f62-8a4a-4e8d-93e1-5dc802684106.jpg?1",
             "name": "Terastodon",
             "text": "When Terastodon enters the battlefield, you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller puts a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "b66534df-b4ce-5e44-acb8-ce124a431e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cc40e7-fb31-4540-81a1-d0c0f514c8a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cc40e7-fb31-4540-81a1-d0c0f514c8a8.jpg?1",
             "name": "Vastwood Animist",
             "text": "{T}: Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "02e663ec-66c3-5edf-9896-d57ec3ba6d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bca11e1-3c75-4dba-b4a2-c77595cc3022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bca11e1-3c75-4dba-b4a2-c77595cc3022.jpg?1",
             "name": "Vastwood Zendikon",
             "text": "Enchant land\nEnchanted land is a 6/4 green Elemental creature. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "c890f85d-335d-5c49-ba4a-4affad67a2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffbd5e-113a-4f24-baa1-b65a5082d893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffbd5e-113a-4f24-baa1-b65a5082d893.jpg?1",
             "name": "Wolfbriar Elemental",
             "text": "Multikicker {G} (You may pay an additional {G} any number of times as you cast this spell.)\nWhen Wolfbriar Elemental enters the battlefield, put a 2/2 green Wolf creature token onto the battlefield for each time it was kicked.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "64fed9e8-3721-51ab-bcf6-18258e3bf0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64733f34-2eb4-4df5-8656-57bdb8b3a983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64733f34-2eb4-4df5-8656-57bdb8b3a983.jpg?1",
             "name": "Novablast Wurm",
             "text": "Whenever Novablast Wurm attacks, destroy all other creatures.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "7496f155-c591-5d89-a472-ae84a0bfd2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb989b-aff4-4232-9ae1-c4f73dacf728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb989b-aff4-4232-9ae1-c4f73dacf728.jpg?1",
             "name": "Wrexial, the Risen Deep",
             "text": "Islandwalk, swampwalk\nWhenever Wrexial, the Risen Deep deals combat damage to a player, you may cast target instant or sorcery card from that player's graveyard without paying its mana cost. If that card would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "635685a0-fcc4-5ff0-af0c-bf4e291923bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997bc933-ac30-477b-a4e1-5333b796a99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997bc933-ac30-477b-a4e1-5333b796a99d.jpg?1",
             "name": "Amulet of Vigor",
             "text": "Whenever a permanent enters the battlefield tapped and under your control, untap it.",
             "colours": [],
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "91ae3442-e707-5660-b335-c2400f368890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cdba1b-7a80-435f-9cff-b9365f62e311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cdba1b-7a80-435f-9cff-b9365f62e311.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -4134,7 +4134,7 @@
         },
         {
             "id": "1c703d17-aefe-5649-a734-503085588a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdcc0c3-4029-4fc3-a486-5d7f45c910bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdcc0c3-4029-4fc3-a486-5d7f45c910bd.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {1} to your mana pool for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "71f55e12-dcfa-549e-8185-80a56589709c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c6bc5-701d-4ae8-bb52-c2e2c6956946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c6bc5-701d-4ae8-bb52-c2e2c6956946.jpg?1",
             "name": "Hammer of Ruin",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, you may destroy target Equipment that player controls.\nEquip {2}",
             "colours": [],
@@ -4192,7 +4192,7 @@
         },
         {
             "id": "42a6d085-c6ff-5acc-ac39-9ce91dde25ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a36448-ca96-4c10-baf9-89c248c3510b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a36448-ca96-4c10-baf9-89c248c3510b.jpg?1",
             "name": "Hedron Rover",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Hedron Rover gets +2/+2 until end of turn.",
             "colours": [],
@@ -4223,7 +4223,7 @@
         },
         {
             "id": "57203bca-ca54-51d4-a984-14f746f7ea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217a05a7-557f-4879-8fd1-d6c003f1751e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217a05a7-557f-4879-8fd1-d6c003f1751e.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "5415f22d-07de-57dd-9021-7d4c58ee8bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0ee6a-852a-4f1e-8f03-40b6d505bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0ee6a-852a-4f1e-8f03-40b6d505bc82.jpg?1",
             "name": "Lodestone Golem",
             "text": "Nonartifact spells cost {1} more to cast.",
             "colours": [],
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "a1ef8321-927d-5ba5-8750-03ee1bb5f663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2a474b-5eac-4e0d-b65c-5610385f2011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2a474b-5eac-4e0d-b65c-5610385f2011.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "91fdedee-6ca6-5b8a-8ce3-81d29a1ee9a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41526ad7-730d-44ad-bd19-e1b8a2717cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41526ad7-730d-44ad-bd19-e1b8a2717cf7.jpg?1",
             "name": "Razor Boomerang",
             "text": "Equipped creature has \"{T}, Unattach Razor Boomerang: Razor Boomerang deals 1 damage to target creature or player. Return Razor Boomerang to its owner's hand.\"\nEquip {2}",
             "colours": [],
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "063a462e-88e8-55c6-b4ca-b8d71efb682c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314cb009-bd0e-40eb-98ea-c6dea8d83dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314cb009-bd0e-40eb-98ea-c6dea8d83dcf.jpg?1",
             "name": "Seer's Sundial",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "af90513a-7686-5cc0-b0de-d14f8236650b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53515042-e729-4a7c-ac3b-36ef70dbbe8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53515042-e729-4a7c-ac3b-36ef70dbbe8d.jpg?1",
             "name": "Walking Atlas",
             "text": "{T}: You may put a land card from your hand onto the battlefield.",
             "colours": [],
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "58a8d275-ea92-5816-aca1-013ced94efdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c38b3-7397-4dac-9859-acd9cd451c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c38b3-7397-4dac-9859-acd9cd451c32.jpg?1",
             "name": "Bojuka Bog",
             "text": "Bojuka Bog enters the battlefield tapped.\nWhen Bojuka Bog enters the battlefield, exile all cards from target player's graveyard.\n{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "f98a936a-0cf7-54fb-9c67-4c6d0162b8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929259-2903-4f6f-9b06-42048fd55c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929259-2903-4f6f-9b06-42048fd55c6a.jpg?1",
             "name": "Celestial Colonnade",
             "text": "Celestial Colonnade enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.\n{3}{W}{U}: Until end of turn, Celestial Colonnade becomes a 4/4 white and blue Elemental creature with flying and vigilance. It's still a land.",
             "colours": [],
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "54e22f20-4cd2-5253-b7a8-5d5ab9861042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f427f0b-034c-4821-8758-e395c0042d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f427f0b-034c-4821-8758-e395c0042d8a.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.\n{1}{U}{B}: Until end of turn, Creeping Tar Pit becomes a 3/2 blue and black Elemental creature and is unblockable. It's still a land.",
             "colours": [],
@@ -4496,7 +4496,7 @@
         },
         {
             "id": "ca787441-7dcf-556f-a8bc-2e701bb6b9eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6814d15f-e7a5-4a73-9adc-88a1a4dec6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6814d15f-e7a5-4a73-9adc-88a1a4dec6cc.jpg?1",
             "name": "Dread Statuary",
             "text": "{T}: Add {1} to your mana pool.\n{4}: Dread Statuary becomes a 4/2 Golem artifact creature until end of turn. It's still a land.",
             "colours": [],
@@ -4524,7 +4524,7 @@
         },
         {
             "id": "820ca3a0-e631-5d0e-8e44-94b45d801f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b21941-1b7d-4fde-8b1d-7edbd5e5b796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b21941-1b7d-4fde-8b1d-7edbd5e5b796.jpg?1",
             "name": "Eye of Ugin",
             "text": "Colorless Eldrazi spells you cast cost {2} less to cast.\n{7}, {T}: Search your library for a colorless creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "51c0557d-5573-5a0c-bd81-7351b5c2501a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5651e5e-2314-4e3d-a2c8-2579239314e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5651e5e-2314-4e3d-a2c8-2579239314e1.jpg?1",
             "name": "Halimar Depths",
             "text": "Halimar Depths enters the battlefield tapped.\nWhen Halimar Depths enters the battlefield, look at the top three cards of your library, then put them back in any order.\n{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "d4f445fd-d8d9-53ef-97c7-b877ef3a86d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc6a5e6-0b73-4488-8954-4b168ce7106d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc6a5e6-0b73-4488-8954-4b168ce7106d.jpg?1",
             "name": "Khalni Garden",
             "text": "Khalni Garden enters the battlefield tapped.\nWhen Khalni Garden enters the battlefield, put a 0/1 green Plant creature token onto the battlefield.\n{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -4614,7 +4614,7 @@
         },
         {
             "id": "f5926324-ddb6-5a8b-80d0-53b429c6ee3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7066095-f05a-4f2e-ab9c-47c498608ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7066095-f05a-4f2e-ab9c-47c498608ccb.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "Lavaclaw Reaches enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.\n{1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with \"{X}: This creature gets +X/+0 until end of turn.\" It's still a land.",
             "colours": [],
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "f2a41d81-9a31-5127-b985-13437554d792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e396df7-9931-43f6-b009-27cf93c4a3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e396df7-9931-43f6-b009-27cf93c4a3e5.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "52c21e6b-ff2d-58c6-a167-4b8af9713a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b6fb5-4d38-4734-b46f-923322cff24e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b6fb5-4d38-4734-b46f-923322cff24e.jpg?1",
             "name": "Raging Ravine",
             "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
             "colours": [],
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "10b798c5-8e88-5f0e-b424-9461fb5e5fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668f5732-da88-4d42-9186-70cfef81f689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668f5732-da88-4d42-9186-70cfef81f689.jpg?1",
             "name": "Sejiri Steppe",
             "text": "Sejiri Steppe enters the battlefield tapped.\nWhen Sejiri Steppe enters the battlefield, target creature you control gains protection from the color of your choice until end of turn.\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "57eac5b2-0467-598e-91f1-efe463250775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1b05db-4475-49cd-99a3-5e5640c6da9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1b05db-4475-49cd-99a3-5e5640c6da9b.jpg?1",
             "name": "Smoldering Spires",
             "text": "Smoldering Spires enters the battlefield tapped.\nWhen Smoldering Spires enters the battlefield, target creature can't block this turn.\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -4764,7 +4764,7 @@
         },
         {
             "id": "1033c9a0-83f3-58f6-9e0b-51effa86d0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556d10b-83cc-4736-b269-4ce65aae2837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556d10b-83cc-4736-b269-4ce65aae2837.jpg?1",
             "name": "Stirring Wildwood",
             "text": "Stirring Wildwood enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.\n{1}{G}{W}: Until end of turn, Stirring Wildwood becomes a 3/4 green and white Elemental creature with reach. It's still a land.",
             "colours": [],
@@ -4795,7 +4795,7 @@
         },
         {
             "id": "73944cb3-28db-5ca6-87c8-f47c8cdab8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcf5c0f-9d18-406d-a930-c179a781264f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcf5c0f-9d18-406d-a930-c179a781264f.jpg?1",
             "name": "Tectonic Edge",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Tectonic Edge: Destroy target nonbasic land. Activate this ability only if an opponent controls four or more lands.",
             "colours": [],
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "eb5ad563-b821-5096-9ed9-c46714b21a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05abf2df-833f-4172-af74-6533b022dfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05abf2df-833f-4172-af74-6533b022dfa9.jpg?1",
             "name": "Soldier Ally",
             "text": "",
             "colours": [
@@ -4858,7 +4858,7 @@
         },
         {
             "id": "921f2257-6e27-5e00-945a-dc599f4711b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87835c7-4739-45c9-a15a-889aa6b6b7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87835c7-4739-45c9-a15a-889aa6b6b7ab.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -4892,7 +4892,7 @@
         },
         {
             "id": "8de388a3-945c-5afd-b555-fa73ef6fd938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99c10f3-9f11-42f1-9007-c0320a1929e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99c10f3-9f11-42f1-9007-c0320a1929e0.jpg?1",
             "name": "Ogre",
             "text": "",
             "colours": [
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "873837b0-d1e4-5a5a-b08a-7864eb2d9c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5a05d3-7824-4570-b32d-91fe2dced952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5a05d3-7824-4570-b32d-91fe2dced952.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "539e2a1f-f221-56c1-ade0-73473e15bab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1424e8d-1f96-44af-9382-c337b6695ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1424e8d-1f96-44af-9382-c337b6695ddf.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "79943663-ab50-529b-8619-f4a7f0ceef51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6b47f-5c2a-4771-90ee-4aa8c1eda0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6b47f-5c2a-4771-90ee-4aa8c1eda0be.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/XLN.json
+++ b/Assets/Resources/Sets/XLN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4f651d96-55d5-5cbc-9bb8-863c8c58d8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c950d7-b4f6-4902-8c9a-98f2933f9fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c950d7-b4f6-4902-8c9a-98f2933f9fa5.jpg?1",
             "name": "Adanto Vanguard",
             "text": "As long as Adanto Vanguard is attacking, it gets +2/+0.\nPay 4 life: Adanto Vanguard gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b36c8384-bcfd-53c7-ac7d-3816f17a0955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8eb264-dadb-440c-af85-273e755f1db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8eb264-dadb-440c-af85-273e755f1db6.jpg?1",
             "name": "Ashes of the Abhorrent",
             "text": "Players can't cast spells from graveyards or activate abilities of cards in graveyards.\nWhenever a creature dies, you gain 1 life.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "0bd4b1f5-c131-5b41-9c21-63f63af87cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d72a8-8acf-42c6-8adf-cbaecb4a985a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d72a8-8acf-42c6-8adf-cbaecb4a985a.jpg?1",
             "name": "Axis of Mortality",
             "text": "At the beginning of your upkeep, you may have two target players exchange life totals.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d63b8b73-3331-5631-8a25-24203d155911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e3b6c5-fd30-4d45-a122-ce60d5707357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e3b6c5-fd30-4d45-a122-ce60d5707357.jpg?1",
             "name": "Bellowing Aegisaur",
             "text": "Enrage \u2014 Whenever Bellowing Aegisaur is dealt damage, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "92eeae92-0e05-55ce-a55f-b52b9fe808fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg?1",
             "name": "Bishop of Rebirth",
             "text": "Vigilance\nWhenever Bishop of Rebirth attacks, you may return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "cef747aa-5ca6-5786-906b-d509d87a689f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d954677c-2de6-440a-90d0-bab2e0c8b4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d954677c-2de6-440a-90d0-bab2e0c8b4af.jpg?1",
             "name": "Bishop's Soldier",
             "text": "Lifelink",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "e22acc4f-714f-5575-ad53-7a84d621707c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3340ffb9-9513-4551-ad64-821600596b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3340ffb9-9513-4551-ad64-821600596b2e.jpg?1",
             "name": "Bright Reprisal",
             "text": "Destroy target attacking creature.\nDraw a card.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "8854c02f-90aa-5bb9-a9fd-739d9370594d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3979b88-ac58-420a-8c03-37ea5d93d0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3979b88-ac58-420a-8c03-37ea5d93d0f1.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "02dcd43f-da36-5c2e-930a-2471cdd8197e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa524bb-0ce7-4c30-93c3-ae15c3b05e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa524bb-0ce7-4c30-93c3-ae15c3b05e92.jpg?1",
             "name": "Duskborne Skymarcher",
             "text": "Flying\n{W}, {T}: Target attacking Vampire gets +1/+1 until end of turn.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "d7582621-fda1-5ea5-9f16-7ac80668ec67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0636cd47-d2a3-4320-97bf-40db805fca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0636cd47-d2a3-4320-97bf-40db805fca51.jpg?1",
             "name": "Emissary of Sunrise",
             "text": "First strike\nWhen Emissary of Sunrise enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "8b728334-f043-53a2-989b-8ad755661d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe64569-c1b6-4bd4-a742-6ee46ea5181c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe64569-c1b6-4bd4-a742-6ee46ea5181c.jpg?1",
             "name": "Encampment Keeper",
             "text": "First strike\n{7}{W}, {T}, Sacrifice Encampment Keeper: Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "0b467201-d5e5-5a19-b34f-8817c866d919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf87f95-1c77-455a-8feb-57bfd4d159c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf87f95-1c77-455a-8feb-57bfd4d159c9.jpg?1",
             "name": "Glorifier of Dusk",
             "text": "Pay 2 life: Glorifier of Dusk gains flying until end of turn.\nPay 2 life: Glorifier of Dusk gains vigilance until end of turn.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "a82602e3-c4dc-539d-97e9-a4302376cf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8309f684-5912-4191-9f64-d573f1cc84c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8309f684-5912-4191-9f64-d573f1cc84c9.jpg?1",
             "name": "Goring Ceratops",
             "text": "Double strike\nWhenever Goring Ceratops attacks, other creatures you control gain double strike until end of turn.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "b59e8868-dbb2-56b5-85dd-f54aad1c24d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d08f90b-9b98-4237-9826-578fb812d412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d08f90b-9b98-4237-9826-578fb812d412.jpg?1",
             "name": "Imperial Aerosaur",
             "text": "Flying\nWhen Imperial Aerosaur enters the battlefield, another target creature you control gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "4d66feca-bd10-5e9f-9052-a2604c586ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed3784a-2dc0-4626-aa6a-268c1e2ac83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed3784a-2dc0-4626-aa6a-268c1e2ac83c.jpg?1",
             "name": "Imperial Lancer",
             "text": "Imperial Lancer has double strike as long as you control a Dinosaur.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "db3cce92-d51d-567f-9ffd-168500808198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b8f1da-c8ea-41d5-b1ad-b714c22d3683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b8f1da-c8ea-41d5-b1ad-b714c22d3683.jpg?1",
             "name": "Inspiring Cleric",
             "text": "When Inspiring Cleric enters the battlefield, you gain 4 life.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "7b3bae10-6ecf-5c23-8685-7cc9e966c68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c8c31-ceb8-4a2c-beb6-0ff5f7b6ae07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c8c31-ceb8-4a2c-beb6-0ff5f7b6ae07.jpg?1",
             "name": "Ixalan's Binding",
             "text": "When Ixalan's Binding enters the battlefield, exile target nonland permanent an opponent controls until Ixalan's Binding leaves the battlefield.\nYour opponents can't cast spells with the same name as the exiled card.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "940e35dd-6988-5847-829d-649440171da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625211d4-c89c-4aee-a0b0-4bfabd3509ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625211d4-c89c-4aee-a0b0-4bfabd3509ad.jpg?1",
             "name": "Kinjalli's Caller",
             "text": "Dinosaur spells you cast cost {1} less to cast.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "ee041a1a-d11b-5af7-99bb-3ecd8c0380d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9e0b0f-651a-44e6-8fb0-e46bfda0ada9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9e0b0f-651a-44e6-8fb0-e46bfda0ada9.jpg?1",
             "name": "Kinjalli's Sunwing",
             "text": "Flying\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "01bdcc3a-29e3-5972-af02-726fee266cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30590d7-59c7-4a1a-a8e5-3cc13f69bd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30590d7-59c7-4a1a-a8e5-3cc13f69bd41.jpg?1",
             "name": "Legion Conquistador",
             "text": "When Legion Conquistador enters the battlefield, you may search your library for any number of cards named Legion Conquistador, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "f360e708-8fe7-53b8-8c1f-a67793bb1c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bea20-c196-4da8-bc3e-36f8d50dcc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bea20-c196-4da8-bc3e-36f8d50dcc17.jpg?1",
             "name": "Legion's Judgment",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "b6db5d31-1ddf-5752-9d3e-24dac3911669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg?1",
             "name": "Legion's Landing // Adanto, the First Fort",
             "text": "When Legion's Landing enters the battlefield, create a 1/1 white Vampire creature token with lifelink.\nWhen you attack with three or more creatures, transform Legion's Landing.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "aa4d38d2-0eb8-5dd8-86ca-0fe28f6472f8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg?1",
             "name": "Legion's Landing // Adanto, the First Fort",
             "text": "(Transforms from Legion's Landing.)\n{T}: Add {W} to your mana pool.\n{2}{W}, {T}: Create a 1/1 white Vampire creature token with lifelink.",
             "colours": [],
@@ -782,7 +782,7 @@
         },
         {
             "id": "f5f63f44-6008-5ca8-ac18-a9a524710e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcff1c6-0db6-4ff6-b4af-d7048b426368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcff1c6-0db6-4ff6-b4af-d7048b426368.jpg?1",
             "name": "Looming Altisaur",
             "text": "",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "2dcd3003-17c8-5ae2-b033-5ad923f64f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7294e40-11b3-4d5c-82d0-c8ec6bd3a6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7294e40-11b3-4d5c-82d0-c8ec6bd3a6c9.jpg?1",
             "name": "Mavren Fein, Dusk Apostle",
             "text": "Whenever one or more nontoken Vampires you control attack, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "11b4d963-7125-59ee-846c-8bb094766819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0385d5-d0f4-40b8-af28-6557ffdfb625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0385d5-d0f4-40b8-af28-6557ffdfb625.jpg?1",
             "name": "Paladin of the Bloodstained",
             "text": "When Paladin of the Bloodstained enters the battlefield, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "ffcbd82f-db34-574b-9835-7c3b44b7edc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670b9645-ce34-41eb-a527-4af3e13c3a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670b9645-ce34-41eb-a527-4af3e13c3a54.jpg?1",
             "name": "Pious Interdiction",
             "text": "Enchant creature\nWhen Pious Interdiction enters the battlefield, you gain 2 life.\nEnchanted creature can't attack or block.",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "ee82a5a2-b844-5ca2-a73b-5d52e62f5b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051dc73e-f04a-4901-b0ed-3b33c33ac72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051dc73e-f04a-4901-b0ed-3b33c33ac72f.jpg?1",
             "name": "Priest of the Wakening Sun",
             "text": "At the beginning of your upkeep, you may reveal a Dinosaur card from your hand. If you do, you gain 2 life.\n{3}{W}{W}, Sacrifice Priest of the Wakening Sun: Search your library for a Dinosaur card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "d9b7dbb5-b807-5306-addf-ad17833f2a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f00a04-1336-4830-a6c2-514848afefd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f00a04-1336-4830-a6c2-514848afefd2.jpg?1",
             "name": "Pterodon Knight",
             "text": "Pterodon Knight has flying as long as you control a Dinosaur.",
             "colours": [
@@ -992,7 +992,7 @@
         },
         {
             "id": "96d9f72f-e4bf-5b81-9d6d-87f0f17e643a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06c0007-299e-4d71-99c3-f905d942759d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06c0007-299e-4d71-99c3-f905d942759d.jpg?1",
             "name": "Queen's Commission",
             "text": "Create two 1/1 white Vampire creature tokens with lifelink.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "b596de8a-9c3c-5aae-a67b-f916dcc135d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a5efb-fde9-4bba-be80-d073eba2ad8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a5efb-fde9-4bba-be80-d073eba2ad8d.jpg?1",
             "name": "Rallying Roar",
             "text": "Creatures you control get +1/+1 until end of turn. Untap them.",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "9bcda218-9eda-5dc6-b41d-5aec21bffab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d37fc42-0a7c-46b3-9270-333d370e479f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d37fc42-0a7c-46b3-9270-333d370e479f.jpg?1",
             "name": "Raptor Companion",
             "text": "",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "39434f90-0a00-5813-99d4-441e7be7c954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691c0acb-1882-482f-9513-e7d010cc1d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691c0acb-1882-482f-9513-e7d010cc1d15.jpg?1",
             "name": "Ritual of Rejuvenation",
             "text": "You gain 4 life.\nDraw a card.",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "f19625c8-a237-598d-947b-5b294459fa56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fae153-d86a-42b5-9c1c-6dbd56118ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fae153-d86a-42b5-9c1c-6dbd56118ecb.jpg?1",
             "name": "Sanguine Sacrament",
             "text": "You gain twice X life. Put Sanguine Sacrament on the bottom of its owner's library.",
             "colours": [
@@ -1154,7 +1154,7 @@
         },
         {
             "id": "76b5f757-ce53-595b-8958-293fb5bb8cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg?1",
             "name": "Settle the Wreckage",
             "text": "Exile all attacking creatures target player controls. That player may search his or her library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -1186,7 +1186,7 @@
         },
         {
             "id": "c956fc7f-ea47-54c6-b589-d93431936df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c945c7-6c31-4c4f-9203-3dc2aef50820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c945c7-6c31-4c4f-9203-3dc2aef50820.jpg?1",
             "name": "Sheltering Light",
             "text": "Target creature gains indestructible until end of turn. Scry 1. (Damage and effects that say \"destroy\" don't destroy the creature.)",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "be5a1016-18b1-5864-b86b-b95c3009393a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e900d0d-6f35-4e5d-9365-6ade227d218d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e900d0d-6f35-4e5d-9365-6ade227d218d.jpg?1",
             "name": "Shining Aerosaur",
             "text": "Flying",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "5bfba646-3546-5e17-a736-f327c311f55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e788e2-12e9-4041-8210-753aaef2576c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e788e2-12e9-4041-8210-753aaef2576c.jpg?1",
             "name": "Skyblade of the Legion",
             "text": "Flying",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "db1c1c78-e40a-57be-86fa-066a2bea81b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97d474e-83b6-4969-81b4-51f5315057d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97d474e-83b6-4969-81b4-51f5315057d7.jpg?1",
             "name": "Slash of Talons",
             "text": "Slash of Talons deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "456de4f4-1459-59ab-b107-758adcf98947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197934d5-726c-4cd3-a934-3d6449a5a56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197934d5-726c-4cd3-a934-3d6449a5a56e.jpg?1",
             "name": "Steadfast Armasaur",
             "text": "Vigilance\n{1}{W}, {T}: Steadfast Armasaur deals damage equal to its toughness to target creature blocking or blocked by it.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "086cc976-0eaf-5c65-9bcd-d0ae33a1b18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d87b3-bf42-47ed-961d-d0e86d3e1d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d87b3-bf42-47ed-961d-d0e86d3e1d90.jpg?1",
             "name": "Sunrise Seeker",
             "text": "Vigilance\nWhen Sunrise Seeker enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "ce34a8c8-2368-5711-a949-4efe2244fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5a237a-31e7-43ee-8d47-3eb12dd1a60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5a237a-31e7-43ee-8d47-3eb12dd1a60c.jpg?1",
             "name": "Territorial Hammerskull",
             "text": "Whenever Territorial Hammerskull attacks, tap target creature an opponent controls.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "394717f7-84dd-5f57-a670-e25588faccea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fc3501-e7bd-4589-98c5-4476258842ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fc3501-e7bd-4589-98c5-4476258842ea.jpg?1",
             "name": "Tocatli Honor Guard",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "497f02db-ae3f-506a-a59f-dcf5b7b52c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c507f6-c178-40be-bca7-3bd5adb1c5b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c507f6-c178-40be-bca7-3bd5adb1c5b1.jpg?1",
             "name": "Vampire's Zeal",
             "text": "Target creature gets +2/+2 until end of turn. If it's a Vampire, it gains first strike until end of turn.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "cb7f6021-e86e-5e60-919d-ead37a7c7694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7434abe4-87eb-4709-a26d-4e23154b4d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7434abe4-87eb-4709-a26d-4e23154b4d31.jpg?1",
             "name": "Wakening Sun's Avatar",
             "text": "When Wakening Sun's Avatar enters the battlefield, if you cast it from your hand, destroy all non-Dinosaur creatures.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "690d6a1f-6b49-5308-ac80-5bf2ecd48518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc9ba0a-2840-48cb-8cf4-ef2a5f273849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc9ba0a-2840-48cb-8cf4-ef2a5f273849.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "b60ea5bc-3ad8-55d2-a184-791ab33a244f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3edaaf-cf63-4e17-94ae-9d9991d9fb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3edaaf-cf63-4e17-94ae-9d9991d9fb5f.jpg?1",
             "name": "Arcane Adaptation",
             "text": "As Arcane Adaptation enters the battlefield, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "19981a7f-e2b3-5e8f-97c2-0d4494972146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6e5ad6-ffe2-4588-b357-c415c33fbc11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6e5ad6-ffe2-4588-b357-c415c33fbc11.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "cefd1be9-025f-524c-8950-7645d9cb3f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98291778-2ec2-47e2-ac99-5f8cfbb3cf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98291778-2ec2-47e2-ac99-5f8cfbb3cf24.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked with a creature this turn.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "8fb184ab-2ef0-5edd-a75f-f6bfcdf92b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cb012c-947c-4281-8619-1384acf6df54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cb012c-947c-4281-8619-1384acf6df54.jpg?1",
             "name": "Daring Saboteur",
             "text": "{2}{U}: Daring Saboteur can't be blocked this turn.\nWhenever Daring Saboteur deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "7a109ac9-3555-52b3-ab4c-0f801d9cf3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba70d58-69fd-4675-85d2-90bc2595c01c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba70d58-69fd-4675-85d2-90bc2595c01c.jpg?1",
             "name": "Deadeye Quartermaster",
             "text": "When Deadeye Quartermaster enters the battlefield, you may search your library for an Equipment or Vehicle card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "4663572d-e950-551d-a7a9-8ccd7e03d11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bec3b7-5dfc-4b48-ae8f-5bf49470d030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bec3b7-5dfc-4b48-ae8f-5bf49470d030.jpg?1",
             "name": "Deeproot Waters",
             "text": "Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token with hexproof. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1756,7 +1756,7 @@
         },
         {
             "id": "a3f8cfd2-6d26-5988-9d7b-575533967dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63420437-76a9-40cf-aedc-0ca1e73fcc0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63420437-76a9-40cf-aedc-0ca1e73fcc0b.jpg?1",
             "name": "Depths of Desire",
             "text": "Return target creature to its owner's hand. Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "6238baf3-cb3e-5ade-bfea-6698fea93ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33e493e-1aef-43b3-9716-52158b002430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33e493e-1aef-43b3-9716-52158b002430.jpg?1",
             "name": "Dive Down",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "ae050434-1875-5e46-9b2a-56b0a92ec329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548c92c8-1ae1-48b4-8cbe-aa18f59c1efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548c92c8-1ae1-48b4-8cbe-aa18f59c1efb.jpg?1",
             "name": "Dreamcaller Siren",
             "text": "Flash\nFlying\nDreamcaller Siren can block only creatures with flying.\nWhen Dreamcaller Siren enters the battlefield, if you control another Pirate, tap up to two target nonland permanents.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "a20eff8c-6ced-515a-9e23-a766b7e738e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15732049-7e56-432f-881f-215e45b7a70e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15732049-7e56-432f-881f-215e45b7a70e.jpg?1",
             "name": "Entrancing Melody",
             "text": "Gain control of target creature with converted mana cost X.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "611a7959-b28d-578c-9a7b-a8b360d4cf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfe8174-4e75-4e8f-b59c-f80a98492b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfe8174-4e75-4e8f-b59c-f80a98492b5f.jpg?1",
             "name": "Favorable Winds",
             "text": "Creatures you control with flying get +1/+1.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "8446098a-8754-5bcd-81e0-87ce8e8b0c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edbde38-1653-4eb5-b196-8881375781cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edbde38-1653-4eb5-b196-8881375781cb.jpg?1",
             "name": "Fleet Swallower",
             "text": "Whenever Fleet Swallower attacks, target player puts the top half of his or her library, rounded up, into his or her graveyard.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "8c461a8d-6c72-5a2f-b938-17171eb7d2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2c338-f5e9-4596-9435-c6aa965ae541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2c338-f5e9-4596-9435-c6aa965ae541.jpg?1",
             "name": "Headwater Sentries",
             "text": "",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "7d3b0a5d-9da1-538b-a7de-64d868e51662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168cbca9-0124-478b-8dd7-0bd9dc711c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168cbca9-0124-478b-8dd7-0bd9dc711c6d.jpg?1",
             "name": "Herald of Secret Streams",
             "text": "Creatures you control with +1/+1 counters on them can't be blocked.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "a046cc01-aef9-504c-9238-76eb83cec9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f56f2-88fd-44ba-ad02-56ea3391f173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f56f2-88fd-44ba-ad02-56ea3391f173.jpg?1",
             "name": "Jace, Cunning Castaway",
             "text": "+1: Whenever one or more creatures you control deal combat damage to a player this turn, draw a card, then discard a card.\n\u22122: Create a 2/2 blue Illusion creature token with \"When this creature becomes the target of a spell, sacrifice it.\"\n\u22125: Create two tokens that are copies of Jace, Cunning Castaway, except they're not legendary.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "02e7db1a-dccf-5f0e-b145-abc06cf6bfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34561f87-09d9-4f23-8a05-907fe1303e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34561f87-09d9-4f23-8a05-907fe1303e70.jpg?1",
             "name": "Kopala, Warden of Waves",
             "text": "Spells your opponents cast that target a Merfolk you control cost {2} more to cast.\nAbilities your opponents activate that target a Merfolk you control cost {2} more to activate.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "11dd43a3-dc7b-50a6-9b2a-99b360d99e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5751a3c-7695-4c47-9cbd-92fd5b1b7ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5751a3c-7695-4c47-9cbd-92fd5b1b7ec9.jpg?1",
             "name": "Lookout's Dispersal",
             "text": "Lookout's Dispersal costs {1} less to cast if you control a Pirate.\nCounter target spell unless its controller pays {4}.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "03a9fcdc-cd3e-525e-b21b-e3c6abf09669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb082e5e-770a-4c5a-8976-ee394ab73c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb082e5e-770a-4c5a-8976-ee394ab73c86.jpg?1",
             "name": "Navigator's Ruin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked with a creature this turn, target opponent puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "cf3ea1fd-a327-5bc1-a1af-182db284ace1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c00f8bf-0088-44ad-b40b-26a2951a2428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c00f8bf-0088-44ad-b40b-26a2951a2428.jpg?1",
             "name": "One With the Wind",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "b9837f4b-8b26-5f7c-ba7d-16c495493672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c3aa9f-5cb0-4c8d-a050-42938398071b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c3aa9f-5cb0-4c8d-a050-42938398071b.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "11aa5157-c7b1-5080-991b-d238b23d346c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg?1",
             "name": "Overflowing Insight",
             "text": "Target player draws seven cards.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "f3dc9db0-c51d-59e7-af34-037f55c6874c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6623e-2784-4bc9-9d8c-3eee9c78c350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6623e-2784-4bc9-9d8c-3eee9c78c350.jpg?1",
             "name": "Perilous Voyage",
             "text": "Return target nonland permanent you don't control to its owner's hand. If its converted mana cost was 2 or less, scry 2.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "8e1caa33-dd20-54ee-a901-731181fc2151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d97373-9b55-4eb7-99b6-8912f09bd0bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d97373-9b55-4eb7-99b6-8912f09bd0bb.jpg?1",
             "name": "Pirate's Prize",
             "text": "Draw two cards. Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "932244b0-3108-5e88-824e-8d7a72242094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fed2d67-fc51-45e8-825b-fe7565e8a65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fed2d67-fc51-45e8-825b-fe7565e8a65d.jpg?1",
             "name": "Prosperous Pirates",
             "text": "When Prosperous Pirates enters the battlefield, create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "c1b52e32-8ccd-59c3-adcf-a88babea37d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32ffc-dc1d-4bb2-926f-51d110392b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32ffc-dc1d-4bb2-926f-51d110392b06.jpg?1",
             "name": "River Sneak",
             "text": "River Sneak can't be blocked.\nWhenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "d75fea1a-dbae-5e2a-8fa9-5054c70d8558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda8ef30-bbfa-4857-9750-0dd0def8b13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda8ef30-bbfa-4857-9750-0dd0def8b13f.jpg?1",
             "name": "River's Rebuke",
             "text": "Return all nonland permanents target player controls to their owner's hand.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "01e71d23-71b2-5713-9d09-6ab8d88085d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed573c6-2b95-4052-8b43-106cbaacb721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed573c6-2b95-4052-8b43-106cbaacb721.jpg?1",
             "name": "Run Aground",
             "text": "Put target artifact or creature on top of its owner's library.",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "b66f420a-39f6-5701-a0e7-dff8d9724c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f15157-6017-4b05-8c74-b3f8728d764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f15157-6017-4b05-8c74-b3f8728d764b.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "934fb7c2-a194-5a67-b87c-0fea6f280dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may put it into your graveyard. Then if you have seven or more cards in your graveyard, you may transform Search for Azcanta.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "83013969-fdab-58c7-8649-5640b6bdb57e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "(Transforms from Search for Azcanta.)\n{T}: Add {U} to your mana pool.\n{2}{U}, {T}: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [],
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "c2da5b80-3ff9-5a15-a0d1-e436e049edb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02955471-5ffc-4c7b-83fe-a69816415ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02955471-5ffc-4c7b-83fe-a69816415ca1.jpg?1",
             "name": "Shaper Apprentice",
             "text": "Shaper Apprentice has flying as long as you control another Merfolk.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "da3320be-8678-5127-810c-910e34ce7cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891cbde7-0dff-4877-b373-03f9f4332002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891cbde7-0dff-4877-b373-03f9f4332002.jpg?1",
             "name": "Shipwreck Looter",
             "text": "Raid \u2014 When Shipwreck Looter enters the battlefield, if you attacked with a creature this turn, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "569d86aa-f607-5aee-bf7c-0843bc2490c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d1145-8640-44e1-8079-45832fa2556d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d1145-8640-44e1-8079-45832fa2556d.jpg?1",
             "name": "Shore Keeper",
             "text": "{7}{U}, {T}, Sacrifice Shore Keeper: Draw three cards.",
             "colours": [
@@ -2661,7 +2661,7 @@
         },
         {
             "id": "0d3b852b-b340-59fa-a471-49d6647e9b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1",
             "name": "Siren Lookout",
             "text": "Flying\nWhen Siren Lookout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "4c508df8-5c1b-5d35-9469-3399189b3c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f7375c-2d9b-4738-b539-00e1949980e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f7375c-2d9b-4738-b539-00e1949980e7.jpg?1",
             "name": "Siren Stormtamer",
             "text": "Flying\n{U}, Sacrifice Siren Stormtamer: Counter target spell or ability that targets you or a creature you control.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "bb1c6f33-b999-5437-93d5-8fd9a3cec52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f389872-d1f4-4828-a527-e820a6f2ac21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f389872-d1f4-4828-a527-e820a6f2ac21.jpg?1",
             "name": "Siren's Ruse",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "789f2a24-d67a-5892-8d84-d09480b18c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf4dfc0-c58b-4535-b660-54ceaa6e0217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf4dfc0-c58b-4535-b660-54ceaa6e0217.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "b93b0988-491c-5ab5-b03f-7b6450169ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e619ada-e9ce-4758-afd8-8def853877eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e619ada-e9ce-4758-afd8-8def853877eb.jpg?1",
             "name": "Spell Swindle",
             "text": "Counter target spell. Create X colorless Treasure artifact tokens, where X is that spell's converted mana cost. They have \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "e5275fef-0f05-554f-94c3-486833cce0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1acd5-bee4-48fe-951d-7936e20f0a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1acd5-bee4-48fe-951d-7936e20f0a71.jpg?1",
             "name": "Storm Fleet Aerialist",
             "text": "Flying\nRaid \u2014 Storm Fleet Aerialist enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.",
             "colours": [
@@ -2863,7 +2863,7 @@
         },
         {
             "id": "4e7a3596-414d-5ab0-82ab-e118ddf45c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c33ef4-60bb-4f95-92a5-7abedaac6767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c33ef4-60bb-4f95-92a5-7abedaac6767.jpg?1",
             "name": "Storm Fleet Spy",
             "text": "Raid \u2014 When Storm Fleet Spy enters the battlefield, if you attacked with a creature this turn, draw a card.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "ccedda2f-9dd9-5ce2-bd9b-8a8a75548ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9532b735-8390-4379-ae43-2bd00d281dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9532b735-8390-4379-ae43-2bd00d281dd6.jpg?1",
             "name": "Storm Sculptor",
             "text": "Storm Sculptor can't be blocked.\nWhen Storm Sculptor enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -2933,7 +2933,7 @@
         },
         {
             "id": "08a12f6a-5b63-56d4-a217-94dbe97cda70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d0f22d-0448-4039-b6f3-75d12e10f48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d0f22d-0448-4039-b6f3-75d12e10f48c.jpg?1",
             "name": "Tempest Caller",
             "text": "When Tempest Caller enters the battlefield, tap all creatures target opponent controls.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "c300ad97-90ac-599d-93ca-5f6c15051636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d973568-d7b0-443f-a09d-44f6b02da5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d973568-d7b0-443f-a09d-44f6b02da5d4.jpg?1",
             "name": "Watertrap Weaver",
             "text": "When Watertrap Weaver enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "4103e89b-43fb-531c-a0e3-112b372e42f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613a8ab1-9c5e-4b56-aa51-daeb8c1983b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613a8ab1-9c5e-4b56-aa51-daeb8c1983b9.jpg?1",
             "name": "Wind Strider",
             "text": "Flash\nFlying",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "6b6a0625-b380-5bca-8e2a-bedc4c4959a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae5e75-0048-41fd-8bbb-89607ab96d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae5e75-0048-41fd-8bbb-89607ab96d6e.jpg?1",
             "name": "Anointed Deacon",
             "text": "At the beginning of combat on your turn, you may have target Vampire get +2/+0 until end of turn.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "c1ba207f-a6c3-5076-b6f3-aa8cd8d2759e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg?1",
             "name": "Arguel's Blood Fast // Temple of Aclazotz",
             "text": "{1}{B}, Pay 2 life: Draw a card.\nAt the beginning of your upkeep, if you have 5 or less life, you may transform Arguel's Blood Fast.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "56e48acf-d6bd-56c6-a030-bb02221a2c85",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg?1",
             "name": "Arguel's Blood Fast // Temple of Aclazotz",
             "text": "(Transforms from Arguel's Blood Fast.)\n{T}: Add {B} to your mana pool.\n{T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [],
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "8fd928b1-21a9-5fca-9881-64b2640392f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373131be-bd66-49f5-80fa-836ced03fedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373131be-bd66-49f5-80fa-836ced03fedf.jpg?1",
             "name": "Bishop of the Bloodstained",
             "text": "When Bishop of the Bloodstained enters the battlefield, target opponent loses 1 life for each Vampire you control.",
             "colours": [
@@ -3174,7 +3174,7 @@
         },
         {
             "id": "4ed26f1c-5dd2-505b-bc8e-9d966d256c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bcabe2d-82d2-4c1b-8f28-21dc29c9dbf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bcabe2d-82d2-4c1b-8f28-21dc29c9dbf2.jpg?1",
             "name": "Blight Keeper",
             "text": "Flying\n{7}{B}, {T}, Sacrifice Blight Keeper: Target opponent loses 4 life and you gain 4 life.",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "b866547c-c1ae-55b7-976b-5293ff76c127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2160e9-14a0-4c75-b7b0-fb09051ddb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2160e9-14a0-4c75-b7b0-fb09051ddb32.jpg?1",
             "name": "Bloodcrazed Paladin",
             "text": "Flash\nBloodcrazed Paladin enters the battlefield with a +1/+1 counter on it for each creature that died this turn.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "f9600ec0-367d-593e-b815-1ea190879740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35989b1e-9bad-4f8d-a559-bf14d1342aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35989b1e-9bad-4f8d-a559-bf14d1342aa3.jpg?1",
             "name": "Boneyard Parley",
             "text": "Exile up to five target creature cards from graveyards. An opponent separates those cards into two piles. Put all cards from the pile of your choice onto the battlefield under your control and the rest into their owners' graveyards.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "aa9384ea-83df-5d58-8a08-09d3491c1236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20feb-b1ed-4d80-bef9-f3cc44ffb7b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20feb-b1ed-4d80-bef9-f3cc44ffb7b0.jpg?1",
             "name": "Contract Killing",
             "text": "Destroy target creature. Create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "39b61b96-9a8e-5376-b6f4-0fdc8b7ea736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f1f41e-98fc-4f6b-b287-c8899dff8ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f1f41e-98fc-4f6b-b287-c8899dff8ab0.jpg?1",
             "name": "Costly Plunder",
             "text": "As an additional cost to cast Costly Plunder, sacrifice an artifact or creature.\nDraw two cards.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "295f770c-2bae-501f-89d4-920fe9b39535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053c4cf0-992b-4f76-b8d1-cd67f894172c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053c4cf0-992b-4f76-b8d1-cd67f894172c.jpg?1",
             "name": "Dark Nourishment",
             "text": "Dark Nourishment deals 3 damage to target creature or player. You gain 3 life.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "08faf10b-bba4-5271-9af4-b461a69e0619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d219fb0a-49a3-4711-9b37-a0c1b36f68d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d219fb0a-49a3-4711-9b37-a0c1b36f68d0.jpg?1",
             "name": "Deadeye Tormentor",
             "text": "Raid \u2014 When Deadeye Tormentor enters the battlefield, if you attacked with a creature this turn, target opponent discards a card.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "4720323c-a728-5763-88ff-64f9d8e15b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848902db-7a10-4754-b50a-57a9e845705a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848902db-7a10-4754-b50a-57a9e845705a.jpg?1",
             "name": "Deadeye Tracker",
             "text": "{1}{B}, {T}: Exile two target cards from an opponent's graveyard. Deadeye Tracker explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "30ee39c2-2cc5-5c5b-883d-8f33e03f749c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc1cd9-22ff-4263-856b-0aaa990a3893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc1cd9-22ff-4263-856b-0aaa990a3893.jpg?1",
             "name": "Deathless Ancient",
             "text": "Flying\nTap three untapped Vampires you control: Return Deathless Ancient from your graveyard to your hand.",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "f7b8f3a7-b8e2-5daf-a160-5fd52f5d9e12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a92dde-7a84-40fb-a11e-54c7d3057126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a92dde-7a84-40fb-a11e-54c7d3057126.jpg?1",
             "name": "Desperate Castaways",
             "text": "Desperate Castaways can't attack unless you control an artifact.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "bc5e3b38-e46c-5e49-850a-7117d270b968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd719e-fa21-42bb-968b-ccc0cd3829c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd719e-fa21-42bb-968b-ccc0cd3829c6.jpg?1",
             "name": "Dire Fleet Hoarder",
             "text": "When Dire Fleet Hoarder dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "70582ea8-1f08-5b19-8bff-68e152401222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e3f7ee-98d0-45bd-97ae-3dc8050085a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e3f7ee-98d0-45bd-97ae-3dc8050085a1.jpg?1",
             "name": "Dire Fleet Interloper",
             "text": "Menace\nWhen Dire Fleet Interloper enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "5e674510-d098-55c5-aa76-221448b8c8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bd7ccc-aa71-4a3f-a86e-936cb3b2cce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bd7ccc-aa71-4a3f-a86e-936cb3b2cce3.jpg?1",
             "name": "Dire Fleet Ravager",
             "text": "Menace, deathtouch\nWhen Dire Fleet Ravager enters the battlefield, each player loses a third of his or her life, rounded up.",
             "colours": [
@@ -3618,7 +3618,7 @@
         },
         {
             "id": "7f0f58cb-d8ab-51a5-b355-c4fc39d85baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006cbb74-7447-45fb-b44b-bac31832b392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006cbb74-7447-45fb-b44b-bac31832b392.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3650,7 +3650,7 @@
         },
         {
             "id": "cc7ec1e8-068e-5e9d-b13a-1946e56f187f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd7467-ff8c-4a92-ae55-6894213d6c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd7467-ff8c-4a92-ae55-6894213d6c0b.jpg?1",
             "name": "Fathom Fleet Captain",
             "text": "Menace\nWhenever Fathom Fleet Captain attacks, if you control another nontoken Pirate, you may pay {2}. If you do, create a 2/2 black Pirate creature token with menace.",
             "colours": [
@@ -3685,7 +3685,7 @@
         },
         {
             "id": "d32bd811-ae7b-5752-96c9-9c48b74b28cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83500ed-8c46-488e-bd8e-197bedb8f4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83500ed-8c46-488e-bd8e-197bedb8f4bd.jpg?1",
             "name": "Fathom Fleet Cutthroat",
             "text": "When Fathom Fleet Cutthroat enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3720,7 +3720,7 @@
         },
         {
             "id": "dab650ac-404d-5a00-90f1-7c1c75ecbab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055934f-1567-4207-aaad-d32d0fe1cdba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055934f-1567-4207-aaad-d32d0fe1cdba.jpg?1",
             "name": "Grim Captain's Call",
             "text": "Return a Pirate card from your graveyard to your hand, then do the same for Vampire, Dinosaur, and Merfolk.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "45f2320a-e322-5c83-9c7d-bc6023ec3486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e791ce-1380-4de0-b314-246ea6dfc3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e791ce-1380-4de0-b314-246ea6dfc3cc.jpg?1",
             "name": "Heartless Pillage",
             "text": "Target opponent discards two cards.\nRaid \u2014 If you attacked with a creature this turn, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3784,7 +3784,7 @@
         },
         {
             "id": "5a6be60b-a93a-543f-bfb8-7db8933f8132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62fd592-4910-417d-a500-e7029f3d119f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62fd592-4910-417d-a500-e7029f3d119f.jpg?1",
             "name": "Kitesail Freebooter",
             "text": "Flying\nWhen Kitesail Freebooter enters the battlefield, target opponent reveals his or her hand. You choose a noncreature, nonland card from it. Exile that card until Kitesail Freebooter leaves the battlefield.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "2ae2d538-5d6a-5f4a-b4c8-4623464f13e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdbaa34-1ee5-4a2a-bdb3-2f04809a5b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdbaa34-1ee5-4a2a-bdb3-2f04809a5b42.jpg?1",
             "name": "Lurking Chupacabra",
             "text": "Whenever a creature you control explores, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -3854,7 +3854,7 @@
         },
         {
             "id": "bede4658-97a1-504c-b119-ddff8482f15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8ae9-c6ea-4fab-ac9e-b25c62c540c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8ae9-c6ea-4fab-ac9e-b25c62c540c6.jpg?1",
             "name": "March of the Drowned",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return two target Pirate cards from your graveyard to your hand.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "54747a6a-adfe-5e36-9984-0bd5cfd0165d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fec80c-81d5-4d3b-bc07-6fc6c2513ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fec80c-81d5-4d3b-bc07-6fc6c2513ef8.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "d8ecbf8c-42e2-53f0-a161-dc9e177dccc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3562f65a-bd69-47e4-9d9d-ab5c2c6ceb35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3562f65a-bd69-47e4-9d9d-ab5c2c6ceb35.jpg?1",
             "name": "Queen's Agent",
             "text": "Lifelink\nWhen Queen's Agent enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3955,7 +3955,7 @@
         },
         {
             "id": "ac19f1bb-da8c-579d-83f3-32e1348e0878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ca2e6-f920-4529-88d2-d984bdb7490a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ca2e6-f920-4529-88d2-d984bdb7490a.jpg?1",
             "name": "Queen's Bay Soldier",
             "text": "",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "f45399ac-4cd4-5af5-a360-f94e1edd35de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd81dd41-a982-46d2-a572-432580be73c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd81dd41-a982-46d2-a572-432580be73c5.jpg?1",
             "name": "Raiders' Wake",
             "text": "Whenever an opponent discards a card, that player loses 2 life.\nRaid \u2014 At the beginning of your end step, if you attacked with a creature this turn, target opponent discards a card.",
             "colours": [
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "b2c955c0-7f0b-5748-ab5d-98af82d8c682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b0e035-8716-469d-99ae-a530cd96ef09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b0e035-8716-469d-99ae-a530cd96ef09.jpg?1",
             "name": "Revel in Riches",
             "text": "Whenever a creature an opponent controls dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nAt the beginning of your upkeep, if you control ten or more Treasures, you win the game.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "d0732a5c-d4da-5b05-a6a3-fc19aa5a6556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457ba695-3637-40de-a8a8-e3a43a71674f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457ba695-3637-40de-a8a8-e3a43a71674f.jpg?1",
             "name": "Ruin Raider",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked with a creature this turn, reveal the top card of your library and put that card into your hand. You lose life equal to the card's converted mana cost.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "1a58a484-ca1a-5fe3-b68c-11432d7f618f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce91e38-4601-4354-ad1b-2c5c1c70da17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce91e38-4601-4354-ad1b-2c5c1c70da17.jpg?1",
             "name": "Ruthless Knave",
             "text": "{2}{B}, Sacrifice a creature: Create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nSacrifice three Treasures: Draw a card.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "09173e5f-5cde-5dcb-b5e4-6d33c92786d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72150779-0bb6-4d20-a898-cda93a66e7cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72150779-0bb6-4d20-a898-cda93a66e7cd.jpg?1",
             "name": "Sanctum Seeker",
             "text": "Whenever a Vampire you control attacks, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "04032b71-8d05-5e61-ad5a-ba561d022389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37a6802-7a1d-4d37-bd65-f3e3e5127aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37a6802-7a1d-4d37-bd65-f3e3e5127aca.jpg?1",
             "name": "Seekers' Squire",
             "text": "When Seekers' Squire enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -4194,7 +4194,7 @@
         },
         {
             "id": "9f832092-9f4d-51f8-b710-f369bd512ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0722fbdf-c092-4e80-913f-29390177cdcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0722fbdf-c092-4e80-913f-29390177cdcb.jpg?1",
             "name": "Skittering Heartstopper",
             "text": "{B}: Skittering Heartstopper gains deathtouch until end of turn.",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "5b116bf1-6032-5b42-9865-779c77d12fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30343b-1637-490f-810e-d614219789e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30343b-1637-490f-810e-d614219789e3.jpg?1",
             "name": "Skulduggery",
             "text": "Until end of turn, target creature you control gets +1/+1 and target creature an opponent controls gets -1/-1.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "8b7254f9-54a6-5f1c-8fcf-118f46a2283c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b41d7-30fa-43ab-8f8d-c1de68a19add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b41d7-30fa-43ab-8f8d-c1de68a19add.jpg?1",
             "name": "Skymarch Bloodletter",
             "text": "Flying\nWhen Skymarch Bloodletter enters the battlefield, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "73233dad-3486-5d57-93a6-9f0e9eeb3575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8a160c-5e89-4347-8e88-3541b6d221e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8a160c-5e89-4347-8e88-3541b6d221e0.jpg?1",
             "name": "Spreading Rot",
             "text": "Destroy target land. Its controller loses 2 life.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "a20cb5f6-ef4d-564a-b014-ebc0f80d977d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25750098-02a1-48e4-917d-187c41e111b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25750098-02a1-48e4-917d-187c41e111b6.jpg?1",
             "name": "Sword-Point Diplomacy",
             "text": "Reveal the top three cards of your library. For each of those cards, put that card into your hand unless any opponent pays 3 life. Then exile the rest.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "a3ea6836-cb9d-5b79-a3d2-9774a62363bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e599ed0b-4b3b-4341-b6ac-7fdfdc6799a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e599ed0b-4b3b-4341-b6ac-7fdfdc6799a3.jpg?1",
             "name": "Vanquish the Weak",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "d5d2900a-15d7-5d94-b2a1-1fcd14ed2996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4b6ced-e8d3-47e9-bd27-3e0cb644afe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4b6ced-e8d3-47e9-bd27-3e0cb644afe4.jpg?1",
             "name": "Vicious Conquistador",
             "text": "Whenever Vicious Conquistador attacks, each opponent loses 1 life.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "0c2dcc7c-e499-5049-b7a7-d8057dc47c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg?1",
             "name": "Vraska's Contempt",
             "text": "Exile target creature or planeswalker. You gain 2 life.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "a2bcb4aa-0f5f-588d-9dac-c15eac9b71dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ac6a-318f-44fb-bb64-7ae172c4aca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ac6a-318f-44fb-bb64-7ae172c4aca3.jpg?1",
             "name": "Walk the Plank",
             "text": "Destroy target non-Merfolk creature.",
             "colours": [
@@ -4490,7 +4490,7 @@
         },
         {
             "id": "fa3c4031-f1fa-5cda-8946-e265ba2ff71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6704e4c9-3b5e-4ba5-a5bc-6d684e2983e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6704e4c9-3b5e-4ba5-a5bc-6d684e2983e9.jpg?1",
             "name": "Wanted Scoundrels",
             "text": "When Wanted Scoundrels dies, target opponent creates two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "764a3368-0ca0-50ce-8ca9-c449082f1a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfc9e0-14e8-43ce-8fca-773b7f2387dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfc9e0-14e8-43ce-8fca-773b7f2387dc.jpg?1",
             "name": "Angrath's Marauders",
             "text": "If a source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "a7dcc141-1112-55ee-b7a6-74cbd4a8c4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ad54a-73f8-4b97-b890-2be9a178bc42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ad54a-73f8-4b97-b890-2be9a178bc42.jpg?1",
             "name": "Bonded Horncrest",
             "text": "Bonded Horncrest can't attack or block alone.",
             "colours": [
@@ -4594,7 +4594,7 @@
         },
         {
             "id": "818933f6-0665-53aa-8cdc-a8576e5fb90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca29a73-9606-4422-9187-67e00dcd52aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca29a73-9606-4422-9187-67e00dcd52aa.jpg?1",
             "name": "Brazen Buccaneers",
             "text": "Haste\nWhen Brazen Buccaneers enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "3f0a0a83-b889-5aa3-bafb-6994ca7a91ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146c0cab-5f6b-425d-9f50-33d8da266235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146c0cab-5f6b-425d-9f50-33d8da266235.jpg?1",
             "name": "Burning Sun's Avatar",
             "text": "When Burning Sun's Avatar enters the battlefield, it deals 3 damage to target opponent and 3 damage to up to one target creature.",
             "colours": [
@@ -4664,7 +4664,7 @@
         },
         {
             "id": "168ba29e-f991-59b9-958c-f172da872a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab86a8a-7a0a-473e-9a97-da2fe0ab866c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab86a8a-7a0a-473e-9a97-da2fe0ab866c.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "Haste\nWhenever Captain Lannery Storm attacks, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nWhenever you sacrifice a Treasure, Captain Lannery Storm gets +1/+0 until end of turn.",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "03c080ad-4643-53d6-ad5e-8c6ca6f172e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76e66c1-dbe2-4346-b4b3-20e8386e7d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76e66c1-dbe2-4346-b4b3-20e8386e7d76.jpg?1",
             "name": "Captivating Crew",
             "text": "{3}{R}: Gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "9b94c686-6364-5424-ba67-8c4782d0576f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5222448-95d1-4b63-ab76-d5060febcf38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5222448-95d1-4b63-ab76-d5060febcf38.jpg?1",
             "name": "Charging Monstrosaur",
             "text": "Trample, haste",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "cba2630b-a44a-5157-ad36-9dd3492b7bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48aa427-b2d5-4562-bd69-e98913d53fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48aa427-b2d5-4562-bd69-e98913d53fb1.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4802,7 +4802,7 @@
         },
         {
             "id": "af759d90-8794-57cf-946e-e9a75cef5c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31bda74-8455-45ab-8142-65fbde2f39c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31bda74-8455-45ab-8142-65fbde2f39c3.jpg?1",
             "name": "Dinosaur Stampede",
             "text": "Attacking creatures get +2/+0 until end of turn. Dinosaurs you control gain trample until end of turn.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "103eafc3-ee91-541f-8426-2508fc273daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb504d2-d3de-4b09-9007-3d403fc9a216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb504d2-d3de-4b09-9007-3d403fc9a216.jpg?1",
             "name": "Dual Shot",
             "text": "Dual Shot deals 1 damage to each of up to two target creatures.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "a038d27b-2492-5223-a927-f5445d31fcd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52280963-ba5b-4735-b5cb-67866f8624c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52280963-ba5b-4735-b5cb-67866f8624c9.jpg?1",
             "name": "Fathom Fleet Firebrand",
             "text": "{1}{R}: Fathom Fleet Firebrand gets +1/+0 until end of turn.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "39c19f81-70a0-5f08-84d9-b3ab1d45212d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d21c9-4b6c-4797-845f-7bca79c2b76b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d21c9-4b6c-4797-845f-7bca79c2b76b.jpg?1",
             "name": "Fiery Cannonade",
             "text": "Fiery Cannonade deals 2 damage to each non-Pirate creature.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "92480b66-f8f0-575a-b1f9-6e707fed6b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54135905-9b15-4bf9-8f4d-4ea7a0c75b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54135905-9b15-4bf9-8f4d-4ea7a0c75b77.jpg?1",
             "name": "Fire Shrine Keeper",
             "text": "Menace\n{7}{R}, {T}, Sacrifice Fire Shrine Keeper: It deals 3 damage to each of up to two target creatures.",
             "colours": [
@@ -4967,7 +4967,7 @@
         },
         {
             "id": "b5817d4c-5af6-524c-9d63-47f40c904d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f083c3-d7b0-4d3d-8551-af52c7883d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f083c3-d7b0-4d3d-8551-af52c7883d83.jpg?1",
             "name": "Firecannon Blast",
             "text": "Firecannon Blast deals 3 damage to target creature.\nRaid \u2014 Firecannon Blast deals 6 damage to that creature instead if you attacked with a creature this turn.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "385aba97-41fc-5b0a-b918-e7fd29e10cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c3a1c9-ffa2-4990-aa4b-db9d688f1ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c3a1c9-ffa2-4990-aa4b-db9d688f1ed4.jpg?1",
             "name": "Frenzied Raptor",
             "text": "",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "17b9d20d-2782-5f5b-a7d0-695d81e3e13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66973e90-0c8b-4438-bc22-6e78930c194d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66973e90-0c8b-4438-bc22-6e78930c194d.jpg?1",
             "name": "Headstrong Brute",
             "text": "Headstrong Brute can't block.\nHeadstrong Brute has menace as long as you control another Pirate.",
             "colours": [
@@ -5068,7 +5068,7 @@
         },
         {
             "id": "623ef364-5281-59a1-bd07-d862f65f8529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519c5660-4daf-4404-b808-66d1c840ab70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519c5660-4daf-4404-b808-66d1c840ab70.jpg?1",
             "name": "Hijack",
             "text": "Gain control of target artifact or creature until end of turn. Untap it. It gains haste until end of turn.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "ae7e8264-759e-5b87-adc5-bd8de1181384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f55dee-7e39-4183-8e74-844d9c299bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f55dee-7e39-4183-8e74-844d9c299bf5.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to target creature or player.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "c171b9ab-2716-5ff9-861a-a6b703eb5e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4a34ce-94d5-4e4d-97cc-1326cf5241f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4a34ce-94d5-4e4d-97cc-1326cf5241f5.jpg?1",
             "name": "Lightning-Rig Crew",
             "text": "{T}: Lightning-Rig Crew deals 1 damage to each opponent.\nWhenever you cast a Pirate spell, untap Lightning-Rig Crew.",
             "colours": [
@@ -5167,7 +5167,7 @@
         },
         {
             "id": "168069b8-68bc-5ee1-ae76-7ddeef22fe98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65689442-e679-4844-91a8-f6a39a7c1f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65689442-e679-4844-91a8-f6a39a7c1f9b.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to target creature or player.",
             "colours": [
@@ -5199,7 +5199,7 @@
         },
         {
             "id": "e96b1a6b-58b3-5394-8613-8069a59135e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576d3845-f45a-4db0-9f7c-845cedb64c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576d3845-f45a-4db0-9f7c-845cedb64c49.jpg?1",
             "name": "Nest Robber",
             "text": "Haste",
             "colours": [
@@ -5233,7 +5233,7 @@
         },
         {
             "id": "f2624362-a4e6-512d-8a8b-f2405bb070db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c334e6f3-1378-4429-b4f1-fa8ed7ab7123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c334e6f3-1378-4429-b4f1-fa8ed7ab7123.jpg?1",
             "name": "Otepec Huntmaster",
             "text": "Dinosaur spells you cast cost {1} less to cast.\n{T}: Target Dinosaur gains haste until end of turn.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "98e6a6ec-5068-5db7-a4ae-3e8618fd2192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d3c658-1927-4af3-9077-88c4a669c730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d3c658-1927-4af3-9077-88c4a669c730.jpg?1",
             "name": "Rampaging Ferocidon",
             "text": "Menace\nPlayers can't gain life.\nWhenever another creature enters the battlefield, Rampaging Ferocidon deals 1 damage to that creature's controller.",
             "colours": [
@@ -5302,7 +5302,7 @@
         },
         {
             "id": "a8cc4ab7-29e5-5455-b4ca-b2584347bc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093e88d-fd3c-43d3-a025-9ebb9f02a84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093e88d-fd3c-43d3-a025-9ebb9f02a84f.jpg?1",
             "name": "Raptor Hatchling",
             "text": "Enrage \u2014 Whenever Raptor Hatchling is dealt damage, create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "6f240a9b-e1af-5d71-a159-625bfde06d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90a2d6-8292-4ff1-91d0-b30ae9775f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90a2d6-8292-4ff1-91d0-b30ae9775f12.jpg?1",
             "name": "Repeating Barrage",
             "text": "Repeating Barrage deals 3 damage to target creature or player.\nRaid \u2014 {3}{R}{R}: Return Repeating Barrage from your graveyard to your hand. Activate this ability only if you attacked with a creature this turn.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "fdcd8856-159d-555e-b8d8-2ac2d354fd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9983ce-8ca6-450a-9cac-5396ba8e1690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9983ce-8ca6-450a-9cac-5396ba8e1690.jpg?1",
             "name": "Rigging Runner",
             "text": "First strike\nRaid \u2014 Rigging Runner enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "0da19f41-11d4-5136-9889-acf39ea483db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80925750-6c90-42d1-9525-27f1f0313398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80925750-6c90-42d1-9525-27f1f0313398.jpg?1",
             "name": "Rile",
             "text": "Rile deals 1 damage to target creature you control. That creature gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "37b9996f-e867-50f2-89e2-f2dd92cb4117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb3821a-ecc8-478d-93de-57200476868c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb3821a-ecc8-478d-93de-57200476868c.jpg?1",
             "name": "Rowdy Crew",
             "text": "Trample\nWhen Rowdy Crew enters the battlefield, draw three cards, then discard two cards at random. If two cards that share a card type are discarded this way, put two +1/+1 counters on Rowdy Crew.",
             "colours": [
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "b6007468-4947-582a-ae70-2f81b1b12948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8342ad27-f2cd-47c3-bc30-6fae8523f250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8342ad27-f2cd-47c3-bc30-6fae8523f250.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "b1c28fb2-de80-514a-8567-ddab9d1d3f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021f57dc-80f3-4ede-99d5-4a44aade44e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021f57dc-80f3-4ede-99d5-4a44aade44e2.jpg?1",
             "name": "Star of Extinction",
             "text": "Destroy target land. Star of Extinction deals 20 damage to each creature and each planeswalker.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "e9e6a68d-c39b-50f8-9562-06c3e7dd3fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ecb6d-f794-468b-8399-60a50aaa13ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ecb6d-f794-468b-8399-60a50aaa13ac.jpg?1",
             "name": "Storm Fleet Arsonist",
             "text": "Raid \u2014 When Storm Fleet Arsonist enters the battlefield, if you attacked with a creature this turn, target opponent sacrifices a permanent.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "6b8ff733-8514-5c82-8185-d7b9de8d2690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5f5e45-2abb-43e1-aecb-97f0390282a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5f5e45-2abb-43e1-aecb-97f0390282a7.jpg?1",
             "name": "Storm Fleet Pyromancer",
             "text": "Raid \u2014 When Storm Fleet Pyromancer enters the battlefield, if you attacked with a creature this turn, Storm Fleet Pyromancer deals 2 damage to target creature or player.",
             "colours": [
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "1e0724ee-6c9d-53a3-8682-fa24e7c7e0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab793e-0e17-4940-9cab-a30d62df5c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab793e-0e17-4940-9cab-a30d62df5c20.jpg?1",
             "name": "Sun-Crowned Hunters",
             "text": "Enrage \u2014 Whenever Sun-Crowned Hunters is dealt damage, it deals 3 damage to target opponent.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "f4562e59-1f33-5ed8-b8c6-5ae9aa7372fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52480-8faf-4418-af70-fd999096e3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52480-8faf-4418-af70-fd999096e3bb.jpg?1",
             "name": "Sunbird's Invocation",
             "text": "Whenever you cast a spell from your hand, reveal the top X cards of your library, where X is that spell's converted mana cost. You may cast a card revealed this way with converted mana cost X or less without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5674,7 +5674,7 @@
         },
         {
             "id": "cb0ef290-9cef-537b-b27a-b90835a61944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5370060a-653b-453d-8daf-bef46f9bb4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5370060a-653b-453d-8daf-bef46f9bb4d5.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5706,7 +5706,7 @@
         },
         {
             "id": "a5a0c5a6-36cf-5460-a8fc-668ecf87c3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ed59b1-968b-4297-9e98-42d940f9478c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ed59b1-968b-4297-9e98-42d940f9478c.jpg?1",
             "name": "Swashbuckling",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "0d64ba46-c3ce-5c81-8a92-8dd55dd283e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a03b859-811c-45ff-8d8a-9e87e4bbf113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a03b859-811c-45ff-8d8a-9e87e4bbf113.jpg?1",
             "name": "Thrash of Raptors",
             "text": "As long as you control another Dinosaur, Thrash of Raptors gets +2/+0 and has trample.",
             "colours": [
@@ -5774,7 +5774,7 @@
         },
         {
             "id": "b7bb6933-e350-5809-ae71-8968e123650c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25c2f33-1707-4ff3-a22e-58f51936b733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25c2f33-1707-4ff3-a22e-58f51936b733.jpg?1",
             "name": "Tilonalli's Knight",
             "text": "Whenever Tilonalli's Knight attacks, if you control a Dinosaur, Tilonalli's Knight gets +1/+1 until end of turn.",
             "colours": [
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "a185ec34-e362-504d-a4ba-34ea9bd440d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab2765d-cfc4-4381-8cce-adce5aaf05ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab2765d-cfc4-4381-8cce-adce5aaf05ad.jpg?1",
             "name": "Tilonalli's Skinshifter",
             "text": "Haste\nWhenever Tilonalli's Skinshifter attacks, it becomes a copy of another target nonlegendary attacking creature until end of turn.",
             "colours": [
@@ -5844,7 +5844,7 @@
         },
         {
             "id": "7371ea25-f0b1-58ff-ab1c-4fa1a6576cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2df914-bb56-449e-9ef8-8b1012a76f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2df914-bb56-449e-9ef8-8b1012a76f64.jpg?1",
             "name": "Trove of Temptation",
             "text": "Each opponent must attack you or a planeswalker you control with at least one creature each combat if able.\nAt the beginning of your end step, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "c94f8b97-d6bf-5faa-969d-8207e9861e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b274-0499-4cb6-a2e4-f5e18ad7fd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b274-0499-4cb6-a2e4-f5e18ad7fd2d.jpg?1",
             "name": "Unfriendly Fire",
             "text": "Unfriendly Fire deals 4 damage to target creature or player.",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "5638a279-f2e0-5fc6-bc07-daf5e1dd7980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg?1",
             "name": "Vance's Blasting Cannons // Spitfire Bastion",
             "text": "At the beginning of your upkeep, exile the top card of your library. If it's a nonland card, you may cast that card this turn.\nWhenever you cast your third spell in a turn, you may transform Vance's Blasting Cannons.",
             "colours": [
@@ -5942,7 +5942,7 @@
         },
         {
             "id": "6eb85348-da9f-5443-939f-46e3471e1f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg?1",
             "name": "Vance's Blasting Cannons // Spitfire Bastion",
             "text": "(Transforms from Vance's Blasting Cannons.)\n{T}: Add {R} to your mana pool.\n{2}{R}, {T}: Spitfire Bastion deals 3 damage to target creature or player.",
             "colours": [],
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "964a97b7-c581-5fcc-bb6c-e734ec61b89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175b24c-c256-45a8-b24a-6b83e42d5efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175b24c-c256-45a8-b24a-6b83e42d5efa.jpg?1",
             "name": "Wily Goblin",
             "text": "When Wily Goblin enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "432af4a6-b941-5d5a-8d16-bd53e7c422df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39421ce8-86d5-4739-b6fd-78d63c0bb258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39421ce8-86d5-4739-b6fd-78d63c0bb258.jpg?1",
             "name": "Ancient Brontodon",
             "text": "",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "248ce605-8f10-5ff0-b648-8dc9d46d95f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e214e0d-bd3d-467b-83fb-d8a232e166e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e214e0d-bd3d-467b-83fb-d8a232e166e4.jpg?1",
             "name": "Atzocan Archer",
             "text": "Reach\nWhen Atzocan Archer enters the battlefield, you may have it fight another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "ec120f6c-0344-5b2b-9b23-b29cd6781e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae7d501-72a1-43c2-9f72-d768ac5e9320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae7d501-72a1-43c2-9f72-d768ac5e9320.jpg?1",
             "name": "Blinding Fog",
             "text": "Prevent all damage that would be dealt to creatures this turn. Creatures you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "401c2610-840a-541f-8402-0119cba7b751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a3645f-2b71-4816-a1f2-6cd4e987882f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a3645f-2b71-4816-a1f2-6cd4e987882f.jpg?1",
             "name": "Blossom Dryad",
             "text": "{T}: Untap target land.",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "a3f8c02e-733e-5753-80de-6d31e71adb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg?1",
             "name": "Carnage Tyrant",
             "text": "Carnage Tyrant can't be countered.\nTrample, hexproof",
             "colours": [
@@ -6178,7 +6178,7 @@
         },
         {
             "id": "29d5afaf-6c80-5505-9a34-e8d79b5b9522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac5b70-47db-4cdb-91e7-e5c18c42e516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac5b70-47db-4cdb-91e7-e5c18c42e516.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -6212,7 +6212,7 @@
         },
         {
             "id": "5a8a8323-29fe-5dbf-84ae-4cfa26fb54bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b9a07-6631-477a-8c77-3b04f211439d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b9a07-6631-477a-8c77-3b04f211439d.jpg?1",
             "name": "Commune with Dinosaurs",
             "text": "Look at the top five cards of your library. You may reveal a Dinosaur or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "31774bdb-5b35-5bb1-8e01-8904e15f87a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b52d17-7efb-4c6e-9e6a-4763d1ef1daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b52d17-7efb-4c6e-9e6a-4763d1ef1daa.jpg?1",
             "name": "Crash the Ramparts",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -6276,7 +6276,7 @@
         },
         {
             "id": "7d16e6f3-da9a-504f-a2a4-60d84353f123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66b0e45-e585-44f3-8d2b-e887330ba138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66b0e45-e585-44f3-8d2b-e887330ba138.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -6308,7 +6308,7 @@
         },
         {
             "id": "c240c240-508c-5e1b-afc6-b53b2daaa4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e9d8a4-dfc2-4451-a15f-98592b817155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e9d8a4-dfc2-4451-a15f-98592b817155.jpg?1",
             "name": "Deathgorge Scavenger",
             "text": "Whenever Deathgorge Scavenger enters the battlefield or attacks, you may exile target card from a graveyard. If a creature card is exiled this way, you gain 2 life. If a noncreature card is exiled this way, Deathgorge Scavenger gets +1/+1 until end of turn.",
             "colours": [
@@ -6342,7 +6342,7 @@
         },
         {
             "id": "e924db67-ed0d-51c1-9508-d4805e8e2f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg?1",
             "name": "Deeproot Champion",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Deeproot Champion.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "60e8849a-67ec-5a12-ba3b-d77476f3a4da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a1963-ec46-4ed3-9be1-e4cc09687922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a1963-ec46-4ed3-9be1-e4cc09687922.jpg?1",
             "name": "Deeproot Warrior",
             "text": "Whenever Deeproot Warrior becomes blocked, it gets +1/+1 until end of turn.",
             "colours": [
@@ -6412,7 +6412,7 @@
         },
         {
             "id": "167788bd-e9dc-5f93-94ac-342780d4b14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdf2fc-d948-4c64-a34e-2f90eab83212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdf2fc-d948-4c64-a34e-2f90eab83212.jpg?1",
             "name": "Drover of the Mighty",
             "text": "Drover of the Mighty gets +2/+2 as long as you control a Dinosaur.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "50fad4bc-9ddc-5dc7-ab8f-67dc38a7e50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e396762-fe76-4b2d-b571-373ab2c240ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e396762-fe76-4b2d-b571-373ab2c240ad.jpg?1",
             "name": "Emergent Growth",
             "text": "Target creature gets +5/+5 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -6479,7 +6479,7 @@
         },
         {
             "id": "d5760eae-5650-52c7-bbd8-aa88874ace9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c22b9-bdb7-4933-a58a-c53d040ae3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c22b9-bdb7-4933-a58a-c53d040ae3bb.jpg?1",
             "name": "Emperor's Vanguard",
             "text": "Whenever Emperor's Vanguard deals combat damage to a player, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "05691d13-a1f7-5e33-bd5f-1f050dc3ab7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cbd690-4d6e-49a7-bded-e6ecee2c76b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cbd690-4d6e-49a7-bded-e6ecee2c76b6.jpg?1",
             "name": "Grazing Whiptail",
             "text": "Reach",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "d8d96736-acc9-58e2-81a5-0360b35521de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "When Growing Rites of Itlimoc enters the battlefield, look at the top four cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nAt the beginning of your end step, if you control four or more creatures, transform Growing Rites of Itlimoc.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "fb418740-d772-5e20-8b7d-ec446e905436",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "(Transforms from Growing Rites of Itlimoc.)\n{T}: Add {G} to your mana pool.\n{T}: Add {G} to your mana pool for each creature you control.",
             "colours": [],
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "2c7a21dc-e154-599c-b9e0-a7f0fa61ab66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22b55f6-681f-45da-bc57-a0cf7b8f671d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22b55f6-681f-45da-bc57-a0cf7b8f671d.jpg?1",
             "name": "Ixalli's Diviner",
             "text": "When Ixalli's Diviner enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "392b0aed-b2c3-5814-84ac-90407020aca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b98537-abf4-46cb-853f-9561811ab439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b98537-abf4-46cb-853f-9561811ab439.jpg?1",
             "name": "Ixalli's Keeper",
             "text": "{7}{G}, {T}, Sacrifice Ixalli's Keeper: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "149e1f90-ba8e-5378-820e-f45d7094cc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca83e48-6e32-477f-8714-6103e77c06df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca83e48-6e32-477f-8714-6103e77c06df.jpg?1",
             "name": "Jade Guardian",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhen Jade Guardian enters the battlefield, put a +1/+1 counter on target Merfolk you control.",
             "colours": [
@@ -6719,7 +6719,7 @@
         },
         {
             "id": "4646e507-01e1-5a48-9803-8d783444c8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0e3547-d8cb-4b68-a396-8c8fbc3b2b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0e3547-d8cb-4b68-a396-8c8fbc3b2b1c.jpg?1",
             "name": "Jungle Delver",
             "text": "{3}{G}: Put a +1/+1 counter on Jungle Delver.",
             "colours": [
@@ -6754,7 +6754,7 @@
         },
         {
             "id": "fc712a61-0a5f-5aa1-8bf8-e5b4d3fc17af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e96ddf-ac9e-4cc5-8c9a-afee421d99a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e96ddf-ac9e-4cc5-8c9a-afee421d99a6.jpg?1",
             "name": "Kumena's Speaker",
             "text": "Kumena's Speaker gets +1/+1 as long as you control another Merfolk or an Island.",
             "colours": [
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "41a24ddd-aef5-5331-96bb-96d086cc73d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6f0d4a-4827-47b6-8af6-803949c195f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6f0d4a-4827-47b6-8af6-803949c195f8.jpg?1",
             "name": "Merfolk Branchwalker",
             "text": "When Merfolk Branchwalker enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6824,7 +6824,7 @@
         },
         {
             "id": "757cbe1a-1a6d-5d98-a864-9cc4d5c1d07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b12c75-1248-4c81-90cf-28e341a885cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b12c75-1248-4c81-90cf-28e341a885cf.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen New Horizons enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -6858,7 +6858,7 @@
         },
         {
             "id": "4ba1a9cd-fe26-55ca-8f81-fab8de96e6e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06458882-94c8-4d92-a21c-955e9d70f0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06458882-94c8-4d92-a21c-955e9d70f0d4.jpg?1",
             "name": "Old-Growth Dryads",
             "text": "When Old-Growth Dryads enters the battlefield, each opponent may search his or her library for a basic land card, put it onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -6892,7 +6892,7 @@
         },
         {
             "id": "eacb92f6-8aeb-5cda-ac80-6c03278036eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b96cba6-33d7-4e1d-88f7-da3da681540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b96cba6-33d7-4e1d-88f7-da3da681540d.jpg?1",
             "name": "Pounce",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "8f06808b-3839-56d1-9c78-06e82f31e7b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e91efc6-0e6a-4a9e-a486-adf53e53d3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e91efc6-0e6a-4a9e-a486-adf53e53d3f1.jpg?1",
             "name": "Ranging Raptors",
             "text": "Enrage \u2014 Whenever Ranging Raptors is dealt damage, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "733f822c-c115-5f2d-9ba0-752af5b49e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b204b-774a-47bc-aead-c78db90f3be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b204b-774a-47bc-aead-c78db90f3be2.jpg?1",
             "name": "Ravenous Daggertooth",
             "text": "Enrage \u2014 Whenever Ravenous Daggertooth is dealt damage, you gain 2 life.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "34fdb84e-cdff-51c5-9d75-55822f34d05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5368c6-87e0-4f83-aaf7-f4af96d2bf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5368c6-87e0-4f83-aaf7-f4af96d2bf30.jpg?1",
             "name": "Ripjaw Raptor",
             "text": "Enrage \u2014 Whenever Ripjaw Raptor is dealt damage, draw a card.",
             "colours": [
@@ -7026,7 +7026,7 @@
         },
         {
             "id": "20f5cec2-0ca0-5f51-9cd8-7d1f2b8a0203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e355a98d-093d-4ab2-84f2-f560d08f1fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e355a98d-093d-4ab2-84f2-f560d08f1fca.jpg?1",
             "name": "River Heralds' Boon",
             "text": "Put a +1/+1 counter on target creature and a +1/+1 counter on up to one target Merfolk.",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "72e2f4cb-d13d-530b-88b6-c60680673076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb862587-8821-43c7-ad08-2b7d2b82cc71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb862587-8821-43c7-ad08-2b7d2b82cc71.jpg?1",
             "name": "Savage Stomp",
             "text": "Savage Stomp costs {2} less to cast if it targets a Dinosaur you control.\nPut a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "e7147fa7-b9fc-5ed7-afb7-1adde49cf17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930240dc-9c8c-4857-b6ce-85f1689c60e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930240dc-9c8c-4857-b6ce-85f1689c60e5.jpg?1",
             "name": "Shapers' Sanctuary",
             "text": "Whenever a creature you control becomes the target of a spell or ability an opponent controls, you may draw a card.",
             "colours": [
@@ -7122,7 +7122,7 @@
         },
         {
             "id": "ab7b5872-3f9f-57d7-b452-2f558e7a1eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433634b9-b26c-4935-a4f1-735373415548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433634b9-b26c-4935-a4f1-735373415548.jpg?1",
             "name": "Slice in Twain",
             "text": "Destroy target artifact or enchantment.\nDraw a card.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "83684508-ade0-5aa4-bda5-6620ce580260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af1eadf-f7ea-40be-a0cc-b79e4161db34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af1eadf-f7ea-40be-a0cc-b79e4161db34.jpg?1",
             "name": "Snapping Sailback",
             "text": "Flash\nEnrage \u2014 Whenever Snapping Sailback is dealt damage, put a +1/+1 counter on it. (It must survive the damage to get the counter.)",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "fbf4d717-0b5a-5fef-9abd-3f5b712f48ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a3b5f2-0b0b-42e0-a15b-4bb2fce05927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a3b5f2-0b0b-42e0-a15b-4bb2fce05927.jpg?1",
             "name": "Spike-Tailed Ceratops",
             "text": "Spike-Tailed Ceratops can block an additional creature each combat.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "42a762a8-1232-5788-aa61-cd203cdc3bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35711da6-aac4-4c2a-b324-aebeaa843adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35711da6-aac4-4c2a-b324-aebeaa843adc.jpg?1",
             "name": "Thundering Spineback",
             "text": "Other Dinosaurs you control get +1/+1.\n{5}{G}: Create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -7256,7 +7256,7 @@
         },
         {
             "id": "1e55b8dd-b8bd-5f55-b82f-03d8c93c49b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af52383b-545e-4b64-93f9-317ba6dcf5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af52383b-545e-4b64-93f9-317ba6dcf5a8.jpg?1",
             "name": "Tishana's Wayfinder",
             "text": "When Tishana's Wayfinder enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "341b5188-d08a-58af-8a84-b35d60e8ea39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993f4343-8f0a-4c50-b6fd-49f1f11d96f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993f4343-8f0a-4c50-b6fd-49f1f11d96f0.jpg?1",
             "name": "Verdant Rebirth",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to its owner's hand.\"\nDraw a card.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "0fe25e23-b31b-5891-affe-93fd80cbf1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb5b6a-dc74-4e3e-9de1-5b379abdf2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb5b6a-dc74-4e3e-9de1-5b379abdf2b4.jpg?1",
             "name": "Verdant Sun's Avatar",
             "text": "Whenever Verdant Sun's Avatar or another creature enters the battlefield under your control, you gain life equal to that creature's toughness.",
             "colours": [
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "35aaa0c0-2dc6-5bbe-8b9b-7b88461409ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a27502-f6f4-4c12-af0e-eab00d942ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a27502-f6f4-4c12-af0e-eab00d942ada.jpg?1",
             "name": "Vineshaper Mystic",
             "text": "When Vineshaper Mystic enters the battlefield, put a +1/+1 counter on each of up to two target Merfolk you control.",
             "colours": [
@@ -7393,7 +7393,7 @@
         },
         {
             "id": "af929716-6b4f-5196-8b81-6e53c44e39bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46c4db-e12e-4c79-a17f-2166ed78e9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46c4db-e12e-4c79-a17f-2166ed78e9bc.jpg?1",
             "name": "Waker of the Wilds",
             "text": "{X}{G}{G}: Put X +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -7428,7 +7428,7 @@
         },
         {
             "id": "8476beb7-65b1-5fbb-b769-17d9e07f5874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e4c0f8-d5f0-4224-9974-190606911480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e4c0f8-d5f0-4224-9974-190606911480.jpg?1",
             "name": "Wildgrowth Walker",
             "text": "Whenever a creature you control explores, put a +1/+1 counter on Wildgrowth Walker and you gain 3 life.",
             "colours": [
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "6830aa31-aaa5-5aee-9eeb-03d98363373d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854c2ec-0e53-4ac7-b417-554a9331c5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854c2ec-0e53-4ac7-b417-554a9331c5e0.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "Other Pirates you control get +1/+1.\nAt the beginning of your end step, gain control of target nonland permanent controlled by a player who was dealt combat damage by three or more Pirates this turn.",
             "colours": [
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "b15730bd-8df3-5af8-b5dc-db3bca67eb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bab75a-2c1f-4ff1-a26e-134e52f61d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bab75a-2c1f-4ff1-a26e-134e52f61d39.jpg?1",
             "name": "Belligerent Brontodon",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "84b86c18-6b24-5e2b-92db-24474e12db94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7226de1-0e05-4baf-8c2f-54297fee43c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7226de1-0e05-4baf-8c2f-54297fee43c1.jpg?1",
             "name": "Call to the Feast",
             "text": "Create three 1/1 white Vampire creature tokens with lifelink.",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "6329d8a3-0c7e-59c0-baa2-cd47f463f7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a7a1a4-aec2-467d-91a1-1a2605718c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a7a1a4-aec2-467d-91a1-1a2605718c7c.jpg?1",
             "name": "Deadeye Plunderers",
             "text": "Deadeye Plunderers gets +1/+1 for each artifact you control.\n{2}{U}{B}: Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "77b849ce-1fd1-5bb5-a215-dda3064153a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200f8a3-d60b-470a-a558-0c3555d1f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200f8a3-d60b-470a-a558-0c3555d1f10b.jpg?1",
             "name": "Dire Fleet Captain",
             "text": "Whenever Dire Fleet Captain attacks, it gets +1/+1 until end of turn for each other attacking Pirate.",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "56822088-92d6-5604-8471-42526b8d56f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e500-342d-476d-975c-817512e6e3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e500-342d-476d-975c-817512e6e3d6.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "Trample, vigilance, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "3bc83f75-d0e0-5ddd-b568-899ab9c0b5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc67a0-05d9-463e-9794-30a7e951c240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc67a0-05d9-463e-9794-30a7e951c240.jpg?1",
             "name": "Hostage Taker",
             "text": "When Hostage Taker enters the battlefield, exile target artifact or creature until Hostage Taker leaves the battlefield. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -7725,7 +7725,7 @@
         },
         {
             "id": "06367b6f-a30f-5acc-9035-9b979af7785d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc61ba-e91a-4b30-841c-cae8dd288b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc61ba-e91a-4b30-841c-cae8dd288b40.jpg?1",
             "name": "Huatli, Warrior Poet",
             "text": "+2: You gain life equal to the greatest power among creatures you control.\n0: Create a 3/3 green Dinosaur creature token with trample.\n\u2212X: Huatli, Warrior Poet deals X damage divided as you choose among any number of target creatures. Creatures dealt damage this way can't block this turn.",
             "colours": [
@@ -7763,7 +7763,7 @@
         },
         {
             "id": "72ca1334-aeb4-551e-805a-472b7ad87f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c41fee8-7b03-4dc8-babb-f8c8369a74c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c41fee8-7b03-4dc8-babb-f8c8369a74c2.jpg?1",
             "name": "Marauding Looter",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked with a creature this turn, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "41625e33-4623-5670-8b9b-e0aede92a844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a79137-9589-4c24-9bea-31041fd3c9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a79137-9589-4c24-9bea-31041fd3c9ae.jpg?1",
             "name": "Raging Swordtooth",
             "text": "Trample\nWhen Raging Swordtooth enters the battlefield, it deals 1 damage to each other creature.",
             "colours": [
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "4ae5eeef-531c-50ae-9bef-fef68d4af19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a322c5-aa4c-4a99-a3ca-48c1353104f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a322c5-aa4c-4a99-a3ca-48c1353104f0.jpg?1",
             "name": "Regisaur Alpha",
             "text": "Other Dinosaurs you control have haste.\nWhen Regisaur Alpha enters the battlefield, create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -7872,7 +7872,7 @@
         },
         {
             "id": "3a5a725c-f9af-5c6e-bdef-12c83f926383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa682fb-f5b6-41c1-9428-6043b0b76744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa682fb-f5b6-41c1-9428-6043b0b76744.jpg?1",
             "name": "Shapers of Nature",
             "text": "{3}{G}: Put a +1/+1 counter on target creature.\n{2}{U}, Remove a +1/+1 counter from a creature you control: Draw a card.",
             "colours": [
@@ -7909,7 +7909,7 @@
         },
         {
             "id": "a331fe91-c60d-56cf-855b-c56802cad40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167ed739-2953-47af-841f-bc1a092b3aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167ed739-2953-47af-841f-bc1a092b3aa6.jpg?1",
             "name": "Sky Terror",
             "text": "Flying, menace",
             "colours": [
@@ -7945,7 +7945,7 @@
         },
         {
             "id": "0c06b325-e60c-5d95-a5fd-0600ab4307bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c5cfbe-3972-4d2e-a37f-e96cca33bb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c5cfbe-3972-4d2e-a37f-e96cca33bb33.jpg?1",
             "name": "Tishana, Voice of Thunder",
             "text": "Tishana, Voice of Thunder's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhen Tishana enters the battlefield, draw a card for each creature you control.",
             "colours": [
@@ -7984,7 +7984,7 @@
         },
         {
             "id": "eba10c93-0d30-5d89-aaa7-7e9f1aafcff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fd4101-d531-43aa-9cb6-79e36a8121d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fd4101-d531-43aa-9cb6-79e36a8121d8.jpg?1",
             "name": "Vona, Butcher of Magan",
             "text": "Vigilance, lifelink\n{T}, Pay 7 life: Destroy target nonland permanent. Activate this ability only during your turn.",
             "colours": [
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "a40640ef-45fb-510c-9d10-142dfd91db31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b7272-33a6-46e9-b0aa-4757aee54b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b7272-33a6-46e9-b0aa-4757aee54b3a.jpg?1",
             "name": "Vraska, Relic Seeker",
             "text": "+2: Create a 2/2 black Pirate creature token with menace.\n\u22123: Destroy target artifact, creature, or enchantment. Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\n\u221210: Target player's life total becomes 1.",
             "colours": [
@@ -8061,7 +8061,7 @@
         },
         {
             "id": "dcc549f3-63b6-5b8c-8159-3e5e7ba62e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2ff4f0-0dd1-4551-826b-68e8ff1e5860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2ff4f0-0dd1-4551-826b-68e8ff1e5860.jpg?1",
             "name": "Cobbled Wings",
             "text": "Equipped creature has flying.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8091,7 +8091,7 @@
         },
         {
             "id": "7e5f352a-6a66-59e7-bf17-d93e2fb3e0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg?1",
             "name": "Conqueror's Galleon // Conqueror's Foothold",
             "text": "When Conqueror's Galleon attacks, exile it at end of combat, then return it to the battlefield transformed under your control.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8121,7 +8121,7 @@
         },
         {
             "id": "c1713a78-e74a-5049-bd68-205f6702400f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg?1",
             "name": "Conqueror's Galleon // Conqueror's Foothold",
             "text": "(Transforms from Conqueror's Galleon.)\n{T}: Add {C} to your mana pool.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}: Draw a card.\n{6}, {T}: Return target card from your graveyard to your hand.",
             "colours": [],
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "040b2583-1896-585a-9a56-681e7597c304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg?1",
             "name": "Dowsing Dagger // Lost Vale",
             "text": "When Dowsing Dagger enters the battlefield, target opponent creates two 0/2 green Plant creature tokens with defender.\nEquipped creature gets +2/+1.\nWhenever equipped creature deals combat damage to a player, you may transform Dowsing Dagger.\nEquip {2}",
             "colours": [],
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "4194a0e5-6575-56a0-a841-569172c330ca",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg?1",
             "name": "Dowsing Dagger // Lost Vale",
             "text": "(Transforms from Dowsing Dagger.)\n{T}: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "95da6cee-80c2-51ca-b771-1d559ae6f47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec26144-9acf-43b7-8614-1a2952df613d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec26144-9acf-43b7-8614-1a2952df613d.jpg?1",
             "name": "Dusk Legion Dreadnought",
             "text": "Vigilance\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8237,7 +8237,7 @@
         },
         {
             "id": "68b553dc-f3e7-5deb-a7b5-b35d3f6ec38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9170f0-d332-42ba-98c7-7e99922fa3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9170f0-d332-42ba-98c7-7e99922fa3fb.jpg?1",
             "name": "Elaborate Firecannon",
             "text": "Elaborate Firecannon doesn't untap during your untap step.\n{4}, {T}: Elaborate Firecannon deals 2 damage to target creature or player.\nAt the beginning of your upkeep, you may discard a card. If you do, untap Elaborate Firecannon.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "507ba3af-28ae-5ecf-b742-0f2a7834761a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774bdb6-7a02-43c9-9e6f-75d0b09570ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774bdb6-7a02-43c9-9e6f-75d0b09570ca.jpg?1",
             "name": "Fell Flagship",
             "text": "Pirates you control get +1/+0.\nWhenever Fell Flagship deals combat damage to a player, that player discards a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "effa2c58-9606-5bb3-8975-f20990cbed1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cc1a59-76bf-4721-b4a7-ef746f3d3990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cc1a59-76bf-4721-b4a7-ef746f3d3990.jpg?1",
             "name": "Gilded Sentinel",
             "text": "",
             "colours": [],
@@ -8326,7 +8326,7 @@
         },
         {
             "id": "c9435bb9-b73b-53b3-8d3c-15f94b6f0cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8be52c-25ce-49da-8435-58797550f058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8be52c-25ce-49da-8435-58797550f058.jpg?1",
             "name": "Hierophant's Chalice",
             "text": "When Hierophant's Chalice enters the battlefield, target opponent loses 1 life and you gain 1 life.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -8354,7 +8354,7 @@
         },
         {
             "id": "ef746800-e68e-56db-a035-c0c483bddb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888facd-e462-4794-a774-d765d1a1edfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888facd-e462-4794-a774-d765d1a1edfd.jpg?1",
             "name": "Pillar of Origins",
             "text": "As Pillar of Origins enters the battlefield, choose a creature type.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "ce58d2f6-def0-5ad1-8008-63f3d41da164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7e871-19cf-486d-bacb-1499fe066974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7e871-19cf-486d-bacb-1499fe066974.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When Pirate's Cutlass enters the battlefield, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8412,7 +8412,7 @@
         },
         {
             "id": "b05dcfd1-37a5-5ea9-850f-acfb1837b43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg?1",
             "name": "Primal Amulet // Primal Wellspring",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, put a charge counter on Primal Amulet. Then if there are four or more charge counters on it, you may remove those counters and transform it.",
             "colours": [],
@@ -8440,7 +8440,7 @@
         },
         {
             "id": "f7642222-7218-5fe6-9d78-7d436c5bdaef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg?1",
             "name": "Primal Amulet // Primal Wellspring",
             "text": "(Transforms from Primal Amulet.)\n{T}: Add one mana of any color to your mana pool. When that mana is spent to cast an instant or sorcery spell, copy that spell and you may choose new targets for the copy.",
             "colours": [],
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "f89d8a19-1028-504a-bc94-4ea487b8ca14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad45720e-2870-414d-8119-8e48c5600d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad45720e-2870-414d-8119-8e48c5600d3b.jpg?1",
             "name": "Prying Blade",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature deals combat damage to a player, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8498,7 +8498,7 @@
         },
         {
             "id": "240de12c-ca10-5fac-b63e-b1af94b59ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8097eb-518a-4b8e-8d6a-a139d4ddcc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8097eb-518a-4b8e-8d6a-a139d4ddcc8f.jpg?1",
             "name": "Sentinel Totem",
             "text": "When Sentinel Totem enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}, Exile Sentinel Totem: Exile all cards from all graveyards.",
             "colours": [],
@@ -8526,7 +8526,7 @@
         },
         {
             "id": "47414e80-bd37-53f1-bb5b-f41ca48e3a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ab3ed-32cd-4168-9763-96884491aaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ab3ed-32cd-4168-9763-96884491aaa1.jpg?1",
             "name": "Shadowed Caravel",
             "text": "Whenever a creature you control explores, put a +1/+1 counter on Shadowed Caravel.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "695546f1-c67b-50d0-bcb3-efeaac1fbe19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767e2bfb-bcf5-442c-b092-bdb1f4f13561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767e2bfb-bcf5-442c-b092-bdb1f4f13561.jpg?1",
             "name": "Sleek Schooner",
             "text": "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8586,7 +8586,7 @@
         },
         {
             "id": "3438d2d9-4e87-573a-bc3f-28e703fe47ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85506a24-8d60-475c-9f43-65994caca7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85506a24-8d60-475c-9f43-65994caca7d4.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "4a0f0d48-4079-5ce7-94cb-507eacc11cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg?1",
             "name": "Thaumatic Compass // Spires of Orazca",
             "text": "{3}, {T}: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nAt the beginning of your end step, if you control seven or more lands, transform Thaumatic Compass.",
             "colours": [],
@@ -8642,7 +8642,7 @@
         },
         {
             "id": "fd15aeb4-ad00-5e72-9e4f-395c0573ee84",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg?1",
             "name": "Thaumatic Compass // Spires of Orazca",
             "text": "(Transforms from Thaumatic Compass.)\n{T}: Add {C} to your mana pool.\n{T}: Untap target attacking creature an opponent controls and remove it from combat.",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "27c48a7a-d2a2-5459-b13c-461fcea64473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "{1}, {T}: Scry 1. Put a landmark counter on Treasure Map. Then if there are three or more landmark counters on it, remove those counters, transform Treasure Map, and create three colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "9df98469-8e7f-5e59-aae6-255b850cef43",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "(Transforms from Treasure Map.)\n{T}: Add {C} to your mana pool.\n{T}, Sacrifice a Treasure: Draw a card.",
             "colours": [],
@@ -8726,7 +8726,7 @@
         },
         {
             "id": "713e12ef-815d-5f68-b151-52962f16e9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7a85f-3a30-4ece-9bbb-61f3c4b796b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7a85f-3a30-4ece-9bbb-61f3c4b796b8.jpg?1",
             "name": "Vanquisher's Banner",
             "text": "As Vanquisher's Banner enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\nWhenever you cast a creature spell of the chosen type, draw a card.",
             "colours": [],
@@ -8754,7 +8754,7 @@
         },
         {
             "id": "d0dfae9c-f5d0-5717-adb1-00cecf309902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91570836-9e36-4774-8d5d-7cbcee0012ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91570836-9e36-4774-8d5d-7cbcee0012ba.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -8785,7 +8785,7 @@
         },
         {
             "id": "3ace6f06-fa88-53d2-95b4-58f4f9a997ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef728f1-5153-47d6-8f9c-dfd473ee0750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef728f1-5153-47d6-8f9c-dfd473ee0750.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "b72dcc93-14d6-5510-9b30-a0e22ef0432f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72afb21-7bb0-4fd8-a529-ada92a654f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72afb21-7bb0-4fd8-a529-ada92a654f61.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches his or her library for a basic land card, puts it onto the battlefield, then shuffles his or her library.",
             "colours": [],
@@ -8844,7 +8844,7 @@
         },
         {
             "id": "3f3c4617-31d6-5fc1-aaf3-e3e66edb604c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef133d9-26d2-4a1e-8d6a-829f1067c169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef133d9-26d2-4a1e-8d6a-829f1067c169.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "a31b60ce-aa8e-573b-847f-ffde6e50df54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f59e19-9ac1-4f86-893e-5b3364122fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f59e19-9ac1-4f86-893e-5b3364122fc6.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "fbd740b8-0149-5cb5-8218-b64aa3d2471d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f234312-00e8-49f7-a489-f4c316b0a81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f234312-00e8-49f7-a489-f4c316b0a81a.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -8937,7 +8937,7 @@
         },
         {
             "id": "ec6ee728-9eb9-5bab-a0be-869e83620e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765732-6fe3-4594-bff5-6ce47a79f45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765732-6fe3-4594-bff5-6ce47a79f45a.jpg?1",
             "name": "Unclaimed Territory",
             "text": "As Unclaimed Territory enters the battlefield, choose a creature type.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "ee3c5db5-0fce-563f-8efd-0491b5e37ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517315dc-591f-4af4-a319-542ad9a2e4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517315dc-591f-4af4-a319-542ad9a2e4b8.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8993,7 +8993,7 @@
         },
         {
             "id": "6daa541d-46eb-52c8-85b6-43f1eedc9a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff6ee0-01f4-432f-916b-ed771904d64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff6ee0-01f4-432f-916b-ed771904d64c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "d3936e64-10b3-5448-8a6d-648b94ab5a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed39f11e-a7c4-4a35-aed6-7cd7590723b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed39f11e-a7c4-4a35-aed6-7cd7590723b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9069,7 +9069,7 @@
         },
         {
             "id": "6eccbfe4-8f9d-55db-b10e-c3bc34ed256e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39965b8e-0ddc-4c9d-9eb1-7536ec4a8723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39965b8e-0ddc-4c9d-9eb1-7536ec4a8723.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9107,7 +9107,7 @@
         },
         {
             "id": "5efc6e9a-33bb-5b05-a07f-72299b732116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9fda9-50b0-4ce4-b351-cd2b5e6409c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9fda9-50b0-4ce4-b351-cd2b5e6409c8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9145,7 +9145,7 @@
         },
         {
             "id": "f649b2c2-02d4-5908-a466-5e32eb9c6d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c840af-9a13-4716-8458-09071239cc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c840af-9a13-4716-8458-09071239cc26.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "528061fa-3f03-5935-9803-71e4f02be1b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1bec1a-72cd-4a1f-8386-a228fbbdc04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1bec1a-72cd-4a1f-8386-a228fbbdc04d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9221,7 +9221,7 @@
         },
         {
             "id": "59cd28fb-41f1-5b7c-a934-a7aa185ad4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb839476-63ba-4e17-b97d-4bc282a85648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb839476-63ba-4e17-b97d-4bc282a85648.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "aa89b479-e374-5711-a8a8-8a57bb5a38a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc35243-3801-4c02-a8df-2ccf6ea71a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc35243-3801-4c02-a8df-2ccf6ea71a17.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9297,7 +9297,7 @@
         },
         {
             "id": "8815c804-1d8c-5546-9948-9a93a713ae99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db69a637-5770-4eea-9b04-c00e6f90a12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db69a637-5770-4eea-9b04-c00e6f90a12a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "f8e11f1c-b59a-5bb6-9563-5e0f33d44912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74c620-a445-46a4-a1aa-b5b8ef657f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74c620-a445-46a4-a1aa-b5b8ef657f18.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "d273eb35-8069-5d43-8bcf-a919e8e81dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af26e12-8518-4b15-afcd-c44faaebb574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af26e12-8518-4b15-afcd-c44faaebb574.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9411,7 +9411,7 @@
         },
         {
             "id": "e2ca5787-2346-53a2-9dc3-0465d3c55109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf4e561-d430-432e-8c65-a5a12616f552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf4e561-d430-432e-8c65-a5a12616f552.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9449,7 +9449,7 @@
         },
         {
             "id": "5fa4c8b8-7930-5953-9842-be734844d078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c96b83-d0b3-4da9-bb2d-249cc18b55e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c96b83-d0b3-4da9-bb2d-249cc18b55e9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "ea302b64-2c4c-5213-bc3b-8b4d3980de18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a456b1c-de58-4ba2-ac39-9e0b3e2a9b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a456b1c-de58-4ba2-ac39-9e0b3e2a9b51.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9525,7 +9525,7 @@
         },
         {
             "id": "9d2470e9-3428-56d4-a808-6414253abfc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96328602-bf67-42a5-8cca-1fcea5656b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96328602-bf67-42a5-8cca-1fcea5656b8a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "c5bba943-c38e-572d-839c-cf4da257371f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df190cfa-ebb6-48e8-9980-950a26d0f2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df190cfa-ebb6-48e8-9980-950a26d0f2d8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "8f941e15-8ba1-5408-8727-cebb522b7c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eef5e5c-27be-45f2-a9c8-4e0a65c984d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eef5e5c-27be-45f2-a9c8-4e0a65c984d4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "057df7fb-238d-55b1-93dd-ec76548a0fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab82f8e3-6f48-4974-bb5c-39feddc51344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab82f8e3-6f48-4974-bb5c-39feddc51344.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9677,7 +9677,7 @@
         },
         {
             "id": "a510d2df-c04f-5177-afb0-8790f887139a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398ee871-7b30-4e8c-b0d0-b85e0a37d3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398ee871-7b30-4e8c-b0d0-b85e0a37d3b1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9715,7 +9715,7 @@
         },
         {
             "id": "6ad57a1f-4f19-521a-98dc-c44348286625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676702c-523a-4e57-9cb3-171405cab782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676702c-523a-4e57-9cb3-171405cab782.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9753,7 +9753,7 @@
         },
         {
             "id": "76dd0fa9-8795-5466-838f-fc861716a176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b274f6-833f-430f-ac1a-d1d1d5b03e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b274f6-833f-430f-ac1a-d1d1d5b03e71.jpg?1",
             "name": "Jace, Ingenious Mind-Mage",
             "text": "+1: Draw a card.\n+1: Untap all creatures you control.\n\u22129: Gain control of up to three target creatures.",
             "colours": [
@@ -9788,7 +9788,7 @@
         },
         {
             "id": "d84de62a-0d45-5f6a-ae93-90773792acc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a26ba9-84b8-4f54-918c-f75d4cacad0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a26ba9-84b8-4f54-918c-f75d4cacad0b.jpg?1",
             "name": "Castaway's Despair",
             "text": "Enchant creature\nWhen Castaway's Despair enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "635a1ad4-597b-526c-bf58-267ee1911fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7344ffb-aada-4be1-bc82-2ed96e6cb5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7344ffb-aada-4be1-bc82-2ed96e6cb5bf.jpg?1",
             "name": "Grasping Current",
             "text": "Return up to two target creatures to their owner's hand.\nSearch your library and/or graveyard for a card named Jace, Ingenious Mind-Mage, reveal it, and put it into your hand. If you searched your library this way, shuffle it.",
             "colours": [
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "204dd11f-849b-5417-bc11-ca930aadc417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9131361b-ec1e-4390-82c9-b9b9f77792a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9131361b-ec1e-4390-82c9-b9b9f77792a8.jpg?1",
             "name": "Jace's Sentinel",
             "text": "As long as you control a Jace planeswalker, Jace's Sentinel gets +1/+0 and can't be blocked.",
             "colours": [
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "326f44f0-908e-55e8-b50e-ada49aec93f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740bb19c-0c91-4fc1-9b3c-be84425a3523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740bb19c-0c91-4fc1-9b3c-be84425a3523.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "35f59e7e-7606-5170-94e2-0e212ce2ba96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5a6f7b-149d-46d3-9814-d38a302db17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5a6f7b-149d-46d3-9814-d38a302db17c.jpg?1",
             "name": "Huatli, Dinosaur Knight",
             "text": "+2: Put two +1/+1 counters on up to one target Dinosaur you control.\n\u22123: Target Dinosaur you control deals damage equal to its power to target creature you don't control.\n\u22127: Dinosaurs you control get +4/+4 until end of turn.",
             "colours": [
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "27bf07d4-e1db-5580-a75b-73aba922dbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d88e6c-4aa8-4175-9f5d-a4c0182cdf74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d88e6c-4aa8-4175-9f5d-a4c0182cdf74.jpg?1",
             "name": "Huatli's Snubhorn",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "545e5adb-a937-58d6-b324-103a1d4db753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19440e2-855f-4f60-a443-b99500394611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19440e2-855f-4f60-a443-b99500394611.jpg?1",
             "name": "Huatli's Spurring",
             "text": "Target creature gets +2/+0 until end of turn. If you control a Huatli planeswalker, that creature gets +4/+0 until end of turn instead.",
             "colours": [
@@ -10017,7 +10017,7 @@
         },
         {
             "id": "3e1d0bc3-ecab-504e-ba83-9177c1256e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f06ac1f-0bae-4aaa-9ff4-28c806828c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f06ac1f-0bae-4aaa-9ff4-28c806828c40.jpg?1",
             "name": "Sun-Blessed Mount",
             "text": "When Sun-Blessed Mount enters the battlefield, you may search your library and/or graveyard for a card named Huatli, Dinosaur Knight, reveal it, then put it into your hand. If you searched your library this way, shuffle it.",
             "colours": [
@@ -10052,7 +10052,7 @@
         },
         {
             "id": "80ce0f76-4542-5111-94c1-8953ca7b0129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06da82de-fd37-4c8f-a37d-61da66db567e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06da82de-fd37-4c8f-a37d-61da66db567e.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "625decf2-a1bc-53b6-b601-342906413033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09293ae7-0629-417b-9eda-9bd3f6d8e118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09293ae7-0629-417b-9eda-9bd3f6d8e118.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "945c18bc-34dc-553c-bdd6-663d53ac09de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b3030-5495-404b-938c-8c4a387a1341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b3030-5495-404b-938c-8c4a387a1341.jpg?1",
             "name": "Ixalan Checklist",
             "text": "",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "e25abbdd-fc0e-57b2-857d-e493e78d42d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10729a5-061a-4daf-91d6-0f6ce813a992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10729a5-061a-4daf-91d6-0f6ce813a992.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -10177,7 +10177,7 @@
         },
         {
             "id": "08f919c7-a885-5483-b26c-e2b2e0c4b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90317f5e-d121-4c00-86cc-5bbee953f600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90317f5e-d121-4c00-86cc-5bbee953f600.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -10211,7 +10211,7 @@
         },
         {
             "id": "4b906342-8344-55ed-aa84-af278b7b0d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7fc721-6b5b-4920-86fa-0fbfd90adaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7fc721-6b5b-4920-86fa-0fbfd90adaf5.jpg?1",
             "name": "Pirate",
             "text": "",
             "colours": [
@@ -10245,7 +10245,7 @@
         },
         {
             "id": "3123b918-b1a5-522b-bad1-174bedb81e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccee594-e1e6-4a82-bc17-93bcdeb36198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccee594-e1e6-4a82-bc17-93bcdeb36198.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -10279,7 +10279,7 @@
         },
         {
             "id": "f0127dde-c191-5bef-82b7-4cca8adc9585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d1d93-22d0-43f9-8691-6790876185a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d1d93-22d0-43f9-8691-6790876185a0.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -10313,7 +10313,7 @@
         },
         {
             "id": "340d30ce-7bbd-51b7-8a0d-503e2b47035f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720f3e68-84c0-462e-a0d1-90236ccc494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720f3e68-84c0-462e-a0d1-90236ccc494a.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10343,7 +10343,7 @@
         },
         {
             "id": "de25c8dd-8190-559a-86fa-adaf7192f463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e89101-f1cf-4bbd-a1d5-c5d48512e0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e89101-f1cf-4bbd-a1d5-c5d48512e0dd.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10373,7 +10373,7 @@
         },
         {
             "id": "a04220a7-422e-5d17-9350-b42b214e2f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f06ec6-634d-454b-a46a-dfefe4600d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f06ec6-634d-454b-a46a-dfefe4600d27.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10403,7 +10403,7 @@
         },
         {
             "id": "d71e6c2f-7c07-58e3-af7b-9b966f5c0403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe8bced-9524-47f6-a600-bf4ddc072698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe8bced-9524-47f6-a600-bf4ddc072698.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/Assets/Resources/Sets/ZEN.json
+++ b/Assets/Resources/Sets/ZEN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4416fff6-179b-5a46-aec1-701bcb513da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f7752-e981-4046-ae9b-90b20db6b23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f7752-e981-4046-ae9b-90b20db6b23a.jpg?1",
             "name": "Armament Master",
             "text": "Other Kor creatures you control get +2/+2 for each Equipment attached to Armament Master.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "a1bd1a36-4928-5800-b745-6fd83339fdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94d5ae2-4d37-4c5f-b490-e578297d87c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94d5ae2-4d37-4c5f-b490-e578297d87c2.jpg?1",
             "name": "Arrow Volley Trap",
             "text": "If four or more creatures are attacking, you may pay {1}{W} rather than pay Arrow Volley Trap's mana cost.\nArrow Volley Trap deals 5 damage divided as you choose among any number of target attacking creatures.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "60a9af82-1964-5eb5-ae56-a576ee5f4708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f657723-dd5d-4786-9d9b-ac7ed279615a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f657723-dd5d-4786-9d9b-ac7ed279615a.jpg?1",
             "name": "Bold Defense",
             "text": "Kicker {3}{W} (You may pay an additional {3}{W} as you cast this spell.)\nCreatures you control get +1/+1 until end of turn. If Bold Defense was kicked, instead creatures you control get +2/+2 and gain first strike until end of turn.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "9ef4080d-f1e5-5d65-9ea9-c9b78e4b9ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14c492d-3fd7-4b2a-910e-bfcb33752eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14c492d-3fd7-4b2a-910e-bfcb33752eba.jpg?1",
             "name": "Brave the Elements",
             "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "c0a79fc8-72eb-5f13-8544-1e667f92e852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf3a3d-292d-40b9-b28c-34ad33a76bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf3a3d-292d-40b9-b28c-34ad33a76bb4.jpg?1",
             "name": "Caravan Hurda",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "37b6cdd5-516f-5729-82d4-652faf8d3f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4599c159-386e-4b13-a386-185924333fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4599c159-386e-4b13-a386-185924333fc5.jpg?1",
             "name": "Celestial Mantle",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nWhenever enchanted creature deals combat damage to a player, double its controller's life total.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "b0e3daff-3476-5f5a-836c-08d00982b689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743b625-e937-4cac-8701-9e2dd709a9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743b625-e937-4cac-8701-9e2dd709a9a4.jpg?1",
             "name": "Cliff Threader",
             "text": "Mountainwalk",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "6ab11d68-e0aa-5148-814a-df7e1ec12c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af1844a-601a-48c1-bf96-921d2d2e2aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af1844a-601a-48c1-bf96-921d2d2e2aa1.jpg?1",
             "name": "Conqueror's Pledge",
             "text": "Kicker {6} (You may pay an additional {6} as you cast this spell.)\nPut six 1/1 white Kor Soldier creature tokens onto the battlefield. If Conqueror's Pledge was kicked, put twelve of those tokens onto the battlefield instead.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "cecca0fd-b83e-5510-be01-cd3c70857216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa98fca-972b-46c2-bdec-6ace35c988d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa98fca-972b-46c2-bdec-6ace35c988d5.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "11075751-ae22-5d00-9c03-6db8fc3bebaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e31e43-84d3-429e-9e81-60b325989c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e31e43-84d3-429e-9e81-60b325989c93.jpg?1",
             "name": "Devout Lightcaster",
             "text": "Protection from black\nWhen Devout Lightcaster enters the battlefield, exile target black permanent.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "63f93f13-17fb-5bec-ad85-5eaa4e046eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b386d39-ba41-42f8-ba05-f9ed602ee23f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b386d39-ba41-42f8-ba05-f9ed602ee23f.jpg?1",
             "name": "Emeria Angel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a 1/1 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "c017f486-8cb7-521f-88ff-99bf3f71946c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3c93e6-af75-4d7e-86b0-8a38425f51a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3c93e6-af75-4d7e-86b0-8a38425f51a1.jpg?1",
             "name": "Felidar Sovereign",
             "text": "Vigilance, lifelink\nAt the beginning of your upkeep, if you have 40 or more life, you win the game.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "a1688c15-a96b-56ba-bc25-752e5e33f25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62458cfe-7231-4e09-b398-9c4d9330d08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62458cfe-7231-4e09-b398-9c4d9330d08e.jpg?1",
             "name": "Iona, Shield of Emeria",
             "text": "Flying\nAs Iona, Shield of Emeria enters the battlefield, choose a color.\nYour opponents can't cast spells of the chosen color.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "7d8659c5-4d50-5d72-8a86-655f5f4c2f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfe585-8a55-4b27-89e0-dfb6946fe1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfe585-8a55-4b27-89e0-dfb6946fe1f3.jpg?1",
             "name": "Journey to Nowhere",
             "text": "When Journey to Nowhere enters the battlefield, exile target creature.\nWhen Journey to Nowhere leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "c8f53013-c530-5e16-9dab-18268035a4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f05d96-42d5-4e1d-a9c6-229a3f42dda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f05d96-42d5-4e1d-a9c6-229a3f42dda9.jpg?1",
             "name": "Kabira Evangel",
             "text": "Whenever Kabira Evangel or another Ally enters the battlefield under your control, you may choose a color. If you do, Allies you control gain protection from the chosen color until end of turn.",
             "colours": [
@@ -512,7 +512,7 @@
         },
         {
             "id": "a15a2a06-e862-5bca-913e-f1ab9ddf15dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642bdbf-c03f-4c48-a5c8-c9201a08b834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642bdbf-c03f-4c48-a5c8-c9201a08b834.jpg?1",
             "name": "Kazandu Blademaster",
             "text": "First strike, vigilance\nWhenever Kazandu Blademaster or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Kazandu Blademaster.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "f1febd5b-1483-5880-bcf1-1aa109a84192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae3eb8-b570-4129-9d4e-b7afa8fc4840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae3eb8-b570-4129-9d4e-b7afa8fc4840.jpg?1",
             "name": "Kor Aeronaut",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nFlying\nWhen Kor Aeronaut enters the battlefield, if it was kicked, target creature gains flying until end of turn.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "1f9b78ff-2754-5e14-98fb-f16b5368f313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6063b7ee-94ae-4a5b-9902-6aa0335af593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6063b7ee-94ae-4a5b-9902-6aa0335af593.jpg?1",
             "name": "Kor Cartographer",
             "text": "When Kor Cartographer enters the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "f76070c3-1083-5d94-9690-d5044453c457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1af74-ba3b-4528-9490-99edd54e9fe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1af74-ba3b-4528-9490-99edd54e9fe1.jpg?1",
             "name": "Kor Duelist",
             "text": "As long as Kor Duelist is equipped, it has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "ffafc190-b3d3-5306-b625-07c47da6fa7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3199-c202-4b71-8a36-53547e70c39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3199-c202-4b71-8a36-53547e70c39b.jpg?1",
             "name": "Kor Hookmaster",
             "text": "When Kor Hookmaster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "1ede19f5-c7fd-5afe-974d-6d657e428a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1",
             "name": "Kor Outfitter",
             "text": "When Kor Outfitter enters the battlefield, you may attach target Equipment you control to target creature you control.",
             "colours": [
@@ -723,7 +723,7 @@
         },
         {
             "id": "575d1ff0-8bab-5bc9-b050-5d5ca3e5962e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038b04fe-d77a-4192-a084-654ef39aa9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038b04fe-d77a-4192-a084-654ef39aa9ff.jpg?1",
             "name": "Kor Sanctifiers",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nWhen Kor Sanctifiers enters the battlefield, if it was kicked, destroy target artifact or enchantment.",
             "colours": [
@@ -758,7 +758,7 @@
         },
         {
             "id": "dc15067d-f356-5f77-b3ee-11ed6e185c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2e9465-f5ba-4c7b-9f03-d40dc8394acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2e9465-f5ba-4c7b-9f03-d40dc8394acd.jpg?1",
             "name": "Kor Skyfisher",
             "text": "Flying\nWhen Kor Skyfisher enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -793,7 +793,7 @@
         },
         {
             "id": "51dc3de7-007b-5dbd-a507-e844ab1572c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245357c6-b4cd-40f3-b7c2-413eee767239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245357c6-b4cd-40f3-b7c2-413eee767239.jpg?1",
             "name": "Landbind Ritual",
             "text": "You gain 2 life for each Plains you control.",
             "colours": [
@@ -825,7 +825,7 @@
         },
         {
             "id": "b08e425e-dc91-58fe-a97d-3bd6c1564932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f3a20f-a788-4d8b-946b-d9c1c983a85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f3a20f-a788-4d8b-946b-d9c1c983a85a.jpg?1",
             "name": "Luminarch Ascension",
             "text": "At the beginning of each opponent's end step, if you didn't lose life this turn, you may put a quest counter on Luminarch Ascension. (Damage causes loss of life.)\n{1}{W}: Put a 4/4 white Angel creature token with flying onto the battlefield. Activate this ability only if Luminarch Ascension has four or more quest counters on it.",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "42d9a2ae-71f6-5e32-94c6-5bce1a4f50ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76e9555-966c-4fc3-9ef4-a0154ccb8329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76e9555-966c-4fc3-9ef4-a0154ccb8329.jpg?1",
             "name": "Makindi Shieldmate",
             "text": "Defender\nWhenever Makindi Shieldmate or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Makindi Shieldmate.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "22dd680e-60ef-501f-baa8-95cd8ca38a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9942a2-11d2-403b-89c6-35c23ac9e9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9942a2-11d2-403b-89c6-35c23ac9e9da.jpg?1",
             "name": "Narrow Escape",
             "text": "Return target permanent you control to its owner's hand. You gain 4 life.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "6db50e08-9248-5ff0-adfa-ec0a94f3a1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae4042-8806-437c-8fc1-2d6996ff38c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae4042-8806-437c-8fc1-2d6996ff38c6.jpg?1",
             "name": "Nimbus Wings",
             "text": "Enchant creature\nEnchanted creature gets +1/+2 and has flying.",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "8609392b-23d9-5898-a0ce-9d6c7eed0f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae1e55c-bdf2-4327-9f97-032c2c3c7d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae1e55c-bdf2-4327-9f97-032c2c3c7d0c.jpg?1",
             "name": "Noble Vestige",
             "text": "Flying\n{T}: Prevent the next 1 damage that would be dealt to target player this turn.",
             "colours": [
@@ -993,7 +993,7 @@
         },
         {
             "id": "0debb9fa-8bf8-561d-9e96-4f06a2f455e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced43447-fefc-482a-b8fa-33b9616aa532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced43447-fefc-482a-b8fa-33b9616aa532.jpg?1",
             "name": "Ondu Cleric",
             "text": "Whenever Ondu Cleric or another Ally enters the battlefield under your control, you may gain life equal to the number of Allies you control.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "1d61021d-ddb0-53ae-af93-0354392d4130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70a8ff1-f0cf-4aef-ad90-06902f98d434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70a8ff1-f0cf-4aef-ad90-06902f98d434.jpg?1",
             "name": "Pillarfield Ox",
             "text": "",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "b6a0e349-8be2-539e-9f1f-de41e36f8a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2823d9a5-dd2f-4e6a-8e3d-554c4204aa32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2823d9a5-dd2f-4e6a-8e3d-554c4204aa32.jpg?1",
             "name": "Pitfall Trap",
             "text": "If exactly one creature is attacking, you may pay {W} rather than pay Pitfall Trap's mana cost.\nDestroy target attacking creature without flying.",
             "colours": [
@@ -1097,7 +1097,7 @@
         },
         {
             "id": "fc63c39f-5837-5592-8e98-173b1661c7ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d6b8bb-ec11-4ded-a7fc-fa4ea0bb96cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d6b8bb-ec11-4ded-a7fc-fa4ea0bb96cc.jpg?1",
             "name": "Quest for the Holy Relic",
             "text": "Whenever you cast a creature spell, you may put a quest counter on Quest for the Holy Relic.\nRemove five quest counters from Quest for the Holy Relic and sacrifice it: Search your library for an Equipment card, put it onto the battlefield, and attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "0a3e9b59-1225-584c-9234-dab90567c2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff23b1c2-7b99-4504-8944-ada264725524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff23b1c2-7b99-4504-8944-ada264725524.jpg?1",
             "name": "Shepherd of the Lost",
             "text": "Flying, first strike, vigilance",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "10619cab-8862-56b5-95b1-c95a6cda0447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58a26f8-a2c9-48e5-8662-7cbd43c00411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58a26f8-a2c9-48e5-8662-7cbd43c00411.jpg?1",
             "name": "Shieldmate's Blessing",
             "text": "Prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "9d9afb7d-18b4-5b67-bea1-cb376a13117f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aaec1c-8084-4468-82e7-2e4cc5ebe244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aaec1c-8084-4468-82e7-2e4cc5ebe244.jpg?1",
             "name": "Steppe Lynx",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Steppe Lynx gets +2/+2 until end of turn.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "46769dfe-05a9-55d4-b43e-7b3e7f1bc789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0811c4c-9e91-4785-b3d2-e4221c5d92d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0811c4c-9e91-4785-b3d2-e4221c5d92d8.jpg?1",
             "name": "Sunspring Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Sunspring Expedition.\nRemove three quest counters from Sunspring Expedition and sacrifice it: You gain 8 life.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "cceed302-397a-519c-a5d6-dd5c32cc7ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b0fd3-ae3e-41eb-b31b-d941b84b6c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b0fd3-ae3e-41eb-b31b-d941b84b6c64.jpg?1",
             "name": "Windborne Charge",
             "text": "Two target creatures you control each get +2/+2 and gain flying until end of turn.",
             "colours": [
@@ -1293,7 +1293,7 @@
         },
         {
             "id": "7c905265-8d75-51b9-8e0d-8fcd41901f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134ff41d-1645-4d3a-94b6-e13a30dedb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134ff41d-1645-4d3a-94b6-e13a30dedb8e.jpg?1",
             "name": "World Queller",
             "text": "At the beginning of your upkeep, you may choose a card type. If you do, each player sacrifices a permanent of that type.",
             "colours": [
@@ -1327,7 +1327,7 @@
         },
         {
             "id": "9b20cf14-1fad-5f6e-99bd-ffe632e2fe47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a4657b-98de-4f4c-b921-46d15a8e6f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a4657b-98de-4f4c-b921-46d15a8e6f5a.jpg?1",
             "name": "Aether Figment",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\n\u00c6ther Figment is unblockable.\nIf \u00c6ther Figment was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "72fbb71e-5bbd-52ee-8f79-59d5a95e5172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bb2ca9-32b8-442d-b6a0-d624a87f5af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bb2ca9-32b8-442d-b6a0-d624a87f5af8.jpg?1",
             "name": "Archive Trap",
             "text": "If an opponent searched his or her library this turn, you may pay {0} rather than pay Archive Trap's mana cost.\nTarget opponent puts the top thirteen cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "b6fd66a3-b9b4-5e34-91fa-99f9e55671b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe803d-88d7-4ad2-b3d8-c41c123d8bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe803d-88d7-4ad2-b3d8-c41c123d8bf3.jpg?1",
             "name": "Archmage Ascension",
             "text": "At the beginning of each end step, if you drew two or more cards this turn, you may put a quest counter on Archmage Ascension.\nAs long as Archmage Ascension has six or more quest counters on it, if you would draw a card, you may instead search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "b51ee243-29cd-5c8e-8cc2-8e5e18e147ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5aabef2-982b-42c9-9804-08ce4d8910cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5aabef2-982b-42c9-9804-08ce4d8910cd.jpg?1",
             "name": "Caller of Gales",
             "text": "{1}{U}, {T}: Target creature gains flying until end of turn.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "9d4b826c-50b9-5cc2-b3c7-e217b17ccbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e557f54-3d9d-4610-a0d0-5874feacc76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e557f54-3d9d-4610-a0d0-5874feacc76e.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "2c746c3c-8295-56b3-8e9b-a20efda5157e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb7372-481a-44a6-937d-21430ee02ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb7372-481a-44a6-937d-21430ee02ff9.jpg?1",
             "name": "Cosi's Trickster",
             "text": "Whenever an opponent shuffles his or her library, you may put a +1/+1 counter on Cosi's Trickster.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "ad04c7c8-7818-5372-83a5-b9383e293f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119d2661-ba22-4901-b89a-a0a8ec25d004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119d2661-ba22-4901-b89a-a0a8ec25d004.jpg?1",
             "name": "Gomazoa",
             "text": "Defender, flying\n{T}: Put Gomazoa and each creature it's blocking on top of their owners' libraries, then those players shuffle their libraries.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "f40e3484-5bc4-56c7-b392-a96f55a0282d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa1946-4f97-4c52-b5f2-b80571230616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa1946-4f97-4c52-b5f2-b80571230616.jpg?1",
             "name": "Hedron Crab",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "7e36ced8-b2bf-5a1f-b3c9-af76f385c831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba9972-dd8b-407b-9374-a8f0ed1a96db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba9972-dd8b-407b-9374-a8f0ed1a96db.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If Into the Roil was kicked, draw a card.",
             "colours": [
@@ -1629,7 +1629,7 @@
         },
         {
             "id": "82c2fdfb-c6f6-591a-9c85-8913e559a5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acdba29-3a09-42d4-bce2-ce615c36bb3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acdba29-3a09-42d4-bce2-ce615c36bb3c.jpg?1",
             "name": "Ior Ruin Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Ior Ruin Expedition.\nRemove three quest counters from Ior Ruin Expedition and sacrifice it: Draw two cards.",
             "colours": [
@@ -1661,7 +1661,7 @@
         },
         {
             "id": "262f8bab-bac7-5a91-8cfc-6d4ec12c3e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d100a3-93f2-428c-8f54-8807e71f2638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d100a3-93f2-428c-8f54-8807e71f2638.jpg?1",
             "name": "Kraken Hatchling",
             "text": "",
             "colours": [
@@ -1695,7 +1695,7 @@
         },
         {
             "id": "c3799994-26df-5192-80d1-891d46021dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351aa3f2-864a-4921-a01c-8712560087bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351aa3f2-864a-4921-a01c-8712560087bb.jpg?1",
             "name": "Lethargy Trap",
             "text": "If three or more creatures are attacking, you may pay {U} rather than pay Lethargy Trap's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "705e5baa-a916-5879-af79-6a3df2b8782d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107a4e2b-e463-46f3-a431-66ea954ef487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107a4e2b-e463-46f3-a431-66ea954ef487.jpg?1",
             "name": "Living Tsunami",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Living Tsunami unless you return a land you control to its owner's hand.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "bd329887-2a1d-58c2-94ef-7299c769ff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf68e-e78e-4709-9c7a-c6e8cbb1f56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf68e-e78e-4709-9c7a-c6e8cbb1f56f.jpg?1",
             "name": "Lorthos, the Tidemaker",
             "text": "Whenever Lorthos, the Tidemaker attacks, you may pay {8}. If you do, tap up to eight target permanents. Those permanents don't untap during their controllers' next untap steps.",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "d8e819e1-53e6-514f-b189-66caac711079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34de3df-3236-4281-a043-7583c76d89cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34de3df-3236-4281-a043-7583c76d89cc.jpg?1",
             "name": "Lullmage Mentor",
             "text": "Whenever a spell or ability you control counters a spell, you may put a 1/1 blue Merfolk creature token onto the battlefield.\nTap seven untapped Merfolk you control: Counter target spell.",
             "colours": [
@@ -1834,7 +1834,7 @@
         },
         {
             "id": "5df2bf8e-06ed-54cf-b3ca-f8c19e5b3854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5d069-45a0-46ea-b3ec-4e75f0531382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5d069-45a0-46ea-b3ec-4e75f0531382.jpg?1",
             "name": "Merfolk Seastalkers",
             "text": "Islandwalk\n{2}{U}: Tap target creature without flying.",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "0f3598e3-7512-5be9-8f45-deea1c66024c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ab86f3-aa75-40ce-a71e-90d40dad4bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ab86f3-aa75-40ce-a71e-90d40dad4bdc.jpg?1",
             "name": "Merfolk Wayfinder",
             "text": "Flying\nWhen Merfolk Wayfinder enters the battlefield, reveal the top three cards of your library. Put all Island cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "a9cf898e-2d22-5df8-b0aa-985caf1ee918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f51140b-6254-431a-8810-94307bfdfbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f51140b-6254-431a-8810-94307bfdfbbe.jpg?1",
             "name": "Mindbreak Trap",
             "text": "If an opponent cast three or more spells this turn, you may pay {0} rather than pay Mindbreak Trap's mana cost.\nExile any number of target spells.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "0d643615-3bfd-59ff-8ba8-16f9fd449ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af35801-9280-4ec1-9399-e34501919a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af35801-9280-4ec1-9399-e34501919a8f.jpg?1",
             "name": "Paralyzing Grasp",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1972,7 +1972,7 @@
         },
         {
             "id": "8defd487-1060-59ca-ba4f-243a2eadb391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de22b67-968e-49e1-ae96-6dd0ee75cd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de22b67-968e-49e1-ae96-6dd0ee75cd54.jpg?1",
             "name": "Quest for Ancient Secrets",
             "text": "Whenever a card is put into your graveyard from anywhere, you may put a quest counter on Quest for Ancient Secrets.\nRemove five quest counters from Quest for Ancient Secrets and sacrifice it: Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "ca3077e0-a8b0-546a-8bfc-6e6cb0fd4a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b059c5-6812-42eb-a010-87fb9e0bb2b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b059c5-6812-42eb-a010-87fb9e0bb2b9.jpg?1",
             "name": "Reckless Scholar",
             "text": "{T}: Target player draws a card, then discards a card.",
             "colours": [
@@ -2039,7 +2039,7 @@
         },
         {
             "id": "64a013a1-6586-5461-b241-f68063e6af5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4530fe45-8a3d-48e9-a7a5-abf8fb1485e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4530fe45-8a3d-48e9-a7a5-abf8fb1485e3.jpg?1",
             "name": "Rite of Replication",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nPut a token onto the battlefield that's a copy of target creature. If Rite of Replication was kicked, put five of those tokens onto the battlefield instead.",
             "colours": [
@@ -2071,7 +2071,7 @@
         },
         {
             "id": "acb9994e-eaaa-565e-944b-6defc6149211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66139c73-8e14-433d-bcb6-ae3e518bcdfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66139c73-8e14-433d-bcb6-ae3e518bcdfb.jpg?1",
             "name": "Roil Elemental",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may gain control of target creature for as long as you control Roil Elemental.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "62f2579c-6993-515a-bb59-ba204c17ac27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd723c8-4b3d-4fbb-a825-79934279382d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd723c8-4b3d-4fbb-a825-79934279382d.jpg?1",
             "name": "Sea Gate Loremaster",
             "text": "{T}: Draw a card for each Ally you control.",
             "colours": [
@@ -2141,7 +2141,7 @@
         },
         {
             "id": "5b7a3834-b00d-5414-aa8a-038df96ef271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690efc8-de2b-4476-87da-d8ed9572dc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690efc8-de2b-4476-87da-d8ed9572dc84.jpg?1",
             "name": "Seascape Aerialist",
             "text": "Whenever Seascape Aerialist or another Ally enters the battlefield under your control, you may have Ally creatures you control gain flying until end of turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "51e9c4b3-86c6-53de-9b35-ebd154079c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a98047-8e6d-416c-b11d-cc4c2a56b624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a98047-8e6d-416c-b11d-cc4c2a56b624.jpg?1",
             "name": "Shoal Serpent",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, Shoal Serpent loses defender until end of turn.",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "0c805d6a-51c7-534f-835e-2c40622126a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb5850-df1e-4d8a-af7a-15cab080fb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb5850-df1e-4d8a-af7a-15cab080fb8f.jpg?1",
             "name": "Sky Ruin Drake",
             "text": "Flying",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "2eeadebc-9233-558c-b8bd-9e64b5e6f154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d3901-e4a6-45ab-a7b5-c65d91e1875e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d3901-e4a6-45ab-a7b5-c65d91e1875e.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "cc0adef2-9607-53c5-b7ad-d0b8e1111822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d13a9c-8757-46f4-be83-eb9917a5bbe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d13a9c-8757-46f4-be83-eb9917a5bbe3.jpg?1",
             "name": "Sphinx of Jwar Isle",
             "text": "Flying, shroud\nYou may look at the top card of your library. (You may do this at any time.)",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "68962dda-3ca9-58ed-9d77-f81e32025a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b61b6-bf80-4326-a646-a1985e0b50d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b61b6-bf80-4326-a646-a1985e0b50d7.jpg?1",
             "name": "Sphinx of Lost Truths",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nFlying\nWhen Sphinx of Lost Truths enters the battlefield, draw three cards. Then if it wasn't kicked, discard three cards.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "98516940-e05f-5fc5-8b86-a433e36cdc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37454c1c-4098-4ac2-884e-3f65f1384bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37454c1c-4098-4ac2-884e-3f65f1384bdb.jpg?1",
             "name": "Spreading Seas",
             "text": "Enchant land\nWhen Spreading Seas enters the battlefield, draw a card.\nEnchanted land is an Island.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "a4f1e3ae-44fb-5d94-8b7d-b3437f5332f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82afba-df51-4bd9-853c-d3ef323095a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82afba-df51-4bd9-853c-d3ef323095a6.jpg?1",
             "name": "Summoner's Bane",
             "text": "Counter target creature spell. Put a 2/2 blue Illusion creature token onto the battlefield.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "a3dcd016-a41d-505d-9487-27431f461cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d173dda8-de9f-4148-b5be-85d1a4c4faf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d173dda8-de9f-4148-b5be-85d1a4c4faf6.jpg?1",
             "name": "Tempest Owl",
             "text": "Kicker {4}{U} (You may pay an additional {4}{U} as you cast this spell.)\nFlying\nWhen Tempest Owl enters the battlefield, if it was kicked, tap up to three target permanents.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "4b0e2dca-2a85-54ba-8bef-4a23c272932c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9dfda7-c034-478e-a52a-e4a272c7d160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9dfda7-c034-478e-a52a-e4a272c7d160.jpg?1",
             "name": "Trapfinder's Trick",
             "text": "Target player reveals his or her hand and discards all Trap cards.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "5024ce88-2bf2-59bb-a26f-c88d3296a6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbc98ab-9f8a-41ed-b368-22f1f4ae594b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbc98ab-9f8a-41ed-b368-22f1f4ae594b.jpg?1",
             "name": "Trapmaker's Snare",
             "text": "Search your library for a Trap card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -2509,7 +2509,7 @@
         },
         {
             "id": "03733223-ccbf-586e-872c-b8acc9a3531a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6049cc80-1faa-48bf-897e-fefe5a8e7ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6049cc80-1faa-48bf-897e-fefe5a8e7ab2.jpg?1",
             "name": "Umara Raptor",
             "text": "Flying\nWhenever Umara Raptor or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Umara Raptor.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "372a1334-2f19-5467-8edc-7c9c4ebe3903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357931d0-8ba6-4857-9db9-7f42d81514a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357931d0-8ba6-4857-9db9-7f42d81514a5.jpg?1",
             "name": "Welkin Tern",
             "text": "Flying\nWelkin Tern can block only creatures with flying.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "5a549456-2e8d-5951-923d-5d6dbb06fb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80e6ae-13e0-46f7-baef-5fa7dfcedcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80e6ae-13e0-46f7-baef-5fa7dfcedcec.jpg?1",
             "name": "Whiplash Trap",
             "text": "If an opponent had two or more creatures enter the battlefield under his or her control this turn, you may pay {U} rather than pay Whiplash Trap's mana cost.\nReturn two target creatures to their owners' hands.",
             "colours": [
@@ -2612,7 +2612,7 @@
         },
         {
             "id": "67be7cbb-9009-5edd-949d-f8da3f685d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18b11f0-19cc-4169-84e0-fbb038a5c848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18b11f0-19cc-4169-84e0-fbb038a5c848.jpg?1",
             "name": "Windrider Eel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, Windrider Eel gets +2/+2 until end of turn.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "eca011d2-7116-5ff5-94b3-46bd3591530c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4598ec-cf36-4a51-9f67-b91c146c3c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4598ec-cf36-4a51-9f67-b91c146c3c4f.jpg?1",
             "name": "Bala Ged Thief",
             "text": "Whenever Bala Ged Thief or another Ally enters the battlefield under your control, target player reveals a number of cards from his or her hand equal to the number of Allies you control. You choose one of them. That player discards that card.",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "851aaead-54bc-5977-87ad-d47fcd21a502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abc9e8-9ecf-4665-9ea5-ee18ab83c148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abc9e8-9ecf-4665-9ea5-ee18ab83c148.jpg?1",
             "name": "Blood Seeker",
             "text": "Whenever a creature enters the battlefield under an opponent's control, you may have that player lose 1 life.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "1a5c7633-14e2-521f-8d6c-2cb7eccd4154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76487d3-1d52-4c31-917e-eb929907218d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76487d3-1d52-4c31-917e-eb929907218d.jpg?1",
             "name": "Blood Tribute",
             "text": "Kicker\u2014\nTap an untapped Vampire you control. (You may tap a Vampire you control in addition to any other costs as you cast this spell.)\nTarget opponent loses half his or her life, rounded up. If Blood Tribute was kicked, you gain life equal to the life lost this way.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "8132184d-a780-5c7d-8a72-2ce4a71eaf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa213dbb-c52a-4084-92aa-d0b5d97a97d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa213dbb-c52a-4084-92aa-d0b5d97a97d9.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "43c48749-6978-59eb-8560-0fd120092e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63870c81-63bf-4a9a-aeb5-74c6eaded9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63870c81-63bf-4a9a-aeb5-74c6eaded9f1.jpg?1",
             "name": "Bloodghast",
             "text": "Bloodghast can't block.\nBloodghast has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may return Bloodghast from your graveyard to the battlefield.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "98a3b428-6a9a-54c4-a07f-925a702c3650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0830c00-02fa-4fc8-907c-19d4b7f9cd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0830c00-02fa-4fc8-907c-19d4b7f9cd6e.jpg?1",
             "name": "Bog Tatters",
             "text": "Swampwalk",
             "colours": [
@@ -2850,7 +2850,7 @@
         },
         {
             "id": "9e09f095-86c0-5a54-815f-454f3d45125f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9920e91d-58c1-4c1a-a177-43423db96842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9920e91d-58c1-4c1a-a177-43423db96842.jpg?1",
             "name": "Crypt Ripper",
             "text": "Haste\n{B}: Crypt Ripper gets +1/+1 until end of turn.",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "ce36b15e-d83a-587a-9c9b-495dd25ea5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05e478-8712-41de-94af-ecb90432e562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05e478-8712-41de-94af-ecb90432e562.jpg?1",
             "name": "Desecrated Earth",
             "text": "Destroy target land. Its controller discards a card.",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "15269cf5-9eb9-5b7d-8c79-42154e8ece24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3842ad2-a449-4963-8c96-276554125757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3842ad2-a449-4963-8c96-276554125757.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2948,7 +2948,7 @@
         },
         {
             "id": "562835c6-dc41-52e4-a315-63ea1878d05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7dd5e2-b2a5-46ab-a67c-499451706505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7dd5e2-b2a5-46ab-a67c-499451706505.jpg?1",
             "name": "Feast of Blood",
             "text": "Cast Feast of Blood only if you control two or more Vampires.\nDestroy target creature. You gain 4 life.",
             "colours": [
@@ -2980,7 +2980,7 @@
         },
         {
             "id": "c68fbb19-ed45-578e-863f-072a69142c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db3698-a45c-4eaf-87e6-30502c0c10f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db3698-a45c-4eaf-87e6-30502c0c10f4.jpg?1",
             "name": "Gatekeeper of Malakir",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen Gatekeeper of Malakir enters the battlefield, if it was kicked, target player sacrifices a creature.",
             "colours": [
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "3da693a5-1291-5806-8fab-4a8ef90094a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27221df-ec7a-4c51-b3a8-34b65b236b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27221df-ec7a-4c51-b3a8-34b65b236b49.jpg?1",
             "name": "Giant Scorpion",
             "text": "Deathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "64d244b3-2175-5373-bd4d-01a25628b346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeec3f1-1f12-4237-95ec-54bbc9a901f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeec3f1-1f12-4237-95ec-54bbc9a901f9.jpg?1",
             "name": "Grim Discovery",
             "text": "Choose one or both \u2014 Return target creature card from your graveyard to your hand; and/or return target land card from your graveyard to your hand.",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "6f293180-2355-5196-a006-af2344b7d783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6ee73e-fe6e-4698-b92e-606d5d10e5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6ee73e-fe6e-4698-b92e-606d5d10e5e0.jpg?1",
             "name": "Guul Draz Specter",
             "text": "Flying\nGuul Draz Specter gets +3/+3 as long as an opponent has no cards in hand.\nWhenever Guul Draz Specter deals combat damage to a player, that player discards a card.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "518f8f85-d008-57fc-bed2-541f35b3abf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c92575-1c97-48bf-801b-22f34040cf9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c92575-1c97-48bf-801b-22f34040cf9a.jpg?1",
             "name": "Guul Draz Vampire",
             "text": "As long as an opponent has 10 or less life, Guul Draz Vampire gets +2/+1 and has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3150,7 +3150,7 @@
         },
         {
             "id": "10db3566-d1d1-5e42-985c-6858149a2906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394a7a2-8f1a-4f07-843a-77db62de49bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394a7a2-8f1a-4f07-843a-77db62de49bd.jpg?1",
             "name": "Hagra Crocodile",
             "text": "Hagra Crocodile can't block.\nLandfall \u2014 Whenever a land enters the battlefield under your control, Hagra Crocodile gets +2/+2 until end of turn.",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "d890d460-3d2d-56bd-b72f-368c1b738a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303e7e2-cb22-4dea-889f-d03e2494ed0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303e7e2-cb22-4dea-889f-d03e2494ed0f.jpg?1",
             "name": "Hagra Diabolist",
             "text": "Whenever Hagra Diabolist or another Ally enters the battlefield under your control, you may have target player lose life equal to the number of Allies you control.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "319ee0df-a9d8-5be8-967d-66f72be6638f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96344c-4b1f-42a6-bbf2-dc5cf11cdb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96344c-4b1f-42a6-bbf2-dc5cf11cdb02.jpg?1",
             "name": "Halo Hunter",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhen Halo Hunter enters the battlefield, destroy target Angel.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "7d756a17-8fc8-5ae5-87c4-534689e5a396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20016d-2b5a-445e-a59b-5305e76f549c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20016d-2b5a-445e-a59b-5305e76f549c.jpg?1",
             "name": "Heartstabber Mosquito",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nFlying\nWhen Heartstabber Mosquito enters the battlefield, if it was kicked, destroy target creature.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "8eb76067-15bd-5c40-955a-4e461dac77b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a09ee1-99d9-432f-a4e2-a1377edef9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a09ee1-99d9-432f-a4e2-a1377edef9d2.jpg?1",
             "name": "Hideous End",
             "text": "Destroy target nonblack creature. Its controller loses 2 life.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "ff5aec29-8757-5ff5-bf8b-b65e5a011641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859aab70-8192-414c-839b-dd0fbcbd8bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859aab70-8192-414c-839b-dd0fbcbd8bf1.jpg?1",
             "name": "Kalitas, Bloodchief of Ghet",
             "text": "{B}{B}{B}, {T}: Destroy target creature. If that creature is put into a graveyard this way, put a black Vampire creature token onto the battlefield. Its power is equal to that creature's power and its toughness is equal to that creature's toughness.",
             "colours": [
@@ -3357,7 +3357,7 @@
         },
         {
             "id": "ed863689-41bd-5741-a5ed-2c6f8e232370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865ac36f-4c61-468b-a2ed-ed2d1bbbf4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865ac36f-4c61-468b-a2ed-ed2d1bbbf4e3.jpg?1",
             "name": "Malakir Bloodwitch",
             "text": "Flying, protection from white\nWhen Malakir Bloodwitch enters the battlefield, each opponent loses life equal to the number of Vampires you control. You gain life equal to the life lost this way.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "e56e89b3-a055-5153-aab1-153a1e20627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28476d0d-60ea-4d08-890c-0e6502ee3d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28476d0d-60ea-4d08-890c-0e6502ee3d2a.jpg?1",
             "name": "Marsh Casualties",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nCreatures target player controls get -1/-1 until end of turn. If Marsh Casualties was kicked, those creatures get -2/-2 until end of turn instead.",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "dec042e7-9ccf-5a82-9059-f41f7bd8701d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaedf6d-171b-4845-8815-debbe06b5b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaedf6d-171b-4845-8815-debbe06b5b66.jpg?1",
             "name": "Mind Sludge",
             "text": "Target player discards a card for each Swamp you control.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "418bdc38-4e11-5150-ba0b-3ff2cce8d6d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d43b60-5bbc-4f9d-a96b-8d886b0c6dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d43b60-5bbc-4f9d-a96b-8d886b0c6dbd.jpg?1",
             "name": "Mindless Null",
             "text": "Mindless Null can't block unless you control a Vampire.",
             "colours": [
@@ -3490,7 +3490,7 @@
         },
         {
             "id": "dc1e1c2f-2b07-5777-a64e-b4d6e464e993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63238d-a022-4ea1-a83d-0b2260d56a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63238d-a022-4ea1-a83d-0b2260d56a17.jpg?1",
             "name": "Mire Blight",
             "text": "Enchant creature\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "a3f55b21-f817-54c2-80b7-3cb9d6af1bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dee4c4e-9505-43e5-88af-db5f9e56a749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dee4c4e-9505-43e5-88af-db5f9e56a749.jpg?1",
             "name": "Needlebite Trap",
             "text": "If an opponent gained life this turn, you may pay {B} rather than pay Needlebite Trap's mana cost.\nTarget player loses 5 life and you gain 5 life.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "ffa55b75-5138-5eff-94d3-c8dd1c4c2d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504d12-a3ef-4588-a52d-734c20f6ac58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504d12-a3ef-4588-a52d-734c20f6ac58.jpg?1",
             "name": "Nimana Sell-Sword",
             "text": "Whenever Nimana Sell-Sword or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Nimana Sell-Sword.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "e792373d-60be-58cc-9894-29f82539f13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824a001-3f0e-4ac5-8406-e58f4288f2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824a001-3f0e-4ac5-8406-e58f4288f2f2.jpg?1",
             "name": "Ob Nixilis, the Fallen",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have target player lose 3 life. If you do, put three +1/+1 counters on Ob Nixilis, the Fallen.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "3c15b10c-d09c-5c93-be42-98ff3515262a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b3d28-fe57-4d6a-a5d2-cc7cc44973d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b3d28-fe57-4d6a-a5d2-cc7cc44973d9.jpg?1",
             "name": "Quest for the Gravelord",
             "text": "Whenever a creature is put into a graveyard from the battlefield, you may put a quest counter on Quest for the Gravelord.\nRemove three quest counters from Quest for the Gravelord and sacrifice it: Put a 5/5 black Zombie Giant creature token onto the battlefield.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "d0d5d824-55cd-5124-8548-680a2a5b2396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4540013-11f9-4a8b-ad54-61f467f04756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4540013-11f9-4a8b-ad54-61f467f04756.jpg?1",
             "name": "Ravenous Trap",
             "text": "If an opponent had three or more cards put into his or her graveyard from anywhere this turn, you may pay {0} rather than pay Ravenous Trap's mana cost.\nExile all cards from target player's graveyard.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "c997beef-77e0-5e95-828e-89e5fd90e0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d82fd7-6af1-4a97-9d51-486a41224b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d82fd7-6af1-4a97-9d51-486a41224b35.jpg?1",
             "name": "Sadistic Sacrament",
             "text": "Kicker {7} (You may pay an additional {7} as you cast this spell.)\nSearch target player's library for up to three cards, exile them, then that player shuffles his or her library. If Sadistic Sacrament was kicked, instead search that player's library for up to fifteen cards, exile them, then that player shuffles his or her library.",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "37b090ca-a6b0-5411-939c-b57e9eefd5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29606aca-f23f-4dfe-b685-2065193109c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29606aca-f23f-4dfe-b685-2065193109c8.jpg?1",
             "name": "Sorin Markov",
             "text": "+2: Sorin Markov deals 2 damage to target creature or player and you gain 2 life.\n-3: Target opponent's life total becomes 10.\n-7: You control target player's next turn.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "22b41c42-6a08-5efd-9959-b125f48535cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902d03cd-2df7-4f87-ab99-fd52f0df6339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902d03cd-2df7-4f87-ab99-fd52f0df6339.jpg?1",
             "name": "Soul Stair Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Soul Stair Expedition.\nRemove three quest counters from Soul Stair Expedition and sacrifice it: Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "bff3824b-c13c-5f41-ac17-dad318306a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a1af-14f2-4e22-bd27-9207e837d5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a1af-14f2-4e22-bd27-9207e837d5fb.jpg?1",
             "name": "Surrakar Marauder",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Surrakar Marauder gains intimidate until end of turn. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "18e2f84b-be65-55c1-ae66-982daf4643c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d2c4d1-6205-404a-b03d-995b90a3a33a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d2c4d1-6205-404a-b03d-995b90a3a33a.jpg?1",
             "name": "Vampire Hexmage",
             "text": "First strike\nSacrifice Vampire Hexmage: Remove all counters from target permanent.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "cfafaf14-9b3f-52cd-ab32-68c568f0761f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114eca6c-76de-4b87-8174-78e2d17ad0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114eca6c-76de-4b87-8174-78e2d17ad0e3.jpg?1",
             "name": "Vampire Lacerator",
             "text": "At the beginning of your upkeep, you lose 1 life unless an opponent has 10 or less life.",
             "colours": [
@@ -3900,7 +3900,7 @@
         },
         {
             "id": "2cbc21ec-00db-5f68-b682-c56ef783a4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f19fe3-7a17-4c45-adfa-590f73dfebfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f19fe3-7a17-4c45-adfa-590f73dfebfa.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying\nDeathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "454ef2b6-366e-56b5-8b87-1a199897fcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6460a752-e5a7-4fd0-9ae5-e0773b86f19b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6460a752-e5a7-4fd0-9ae5-e0773b86f19b.jpg?1",
             "name": "Vampire's Bite",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nTarget creature gets +3/+0 until end of turn. If Vampire's Bite was kicked, that creature gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "89b3a880-fef6-51d7-be6b-12b952c24ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1558dfaf-15ed-4220-9051-bf0bf442b2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1558dfaf-15ed-4220-9051-bf0bf442b2e9.jpg?1",
             "name": "Bladetusk Boar",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "55a6022a-92ae-5622-bd55-fdb95344a75b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc16614-5cf8-444d-a5ae-cac25018af68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc16614-5cf8-444d-a5ae-cac25018af68.jpg?1",
             "name": "Burst Lightning",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to target creature or player. If Burst Lightning was kicked, it deals 4 damage to that creature or player instead.",
             "colours": [
@@ -4033,7 +4033,7 @@
         },
         {
             "id": "10c0dcdc-3bce-5942-ab79-10e10e5a92a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da8995-77da-4ec4-94a5-5e7932a3c969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da8995-77da-4ec4-94a5-5e7932a3c969.jpg?1",
             "name": "Chandra Ablaze",
             "text": "+1: Discard a card. If a red card is discarded this way, Chandra Ablaze deals 4 damage to target creature or player.\n-2: Each player discards his or her hand, then draws three cards.\n-7: Cast any number of red instant and/or sorcery cards from your graveyard without paying their mana costs.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "99b909d6-de41-56a1-96eb-b5bf13109952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0df49a-b60b-4987-aa99-36791a30f453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0df49a-b60b-4987-aa99-36791a30f453.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "a48639fd-0a31-580a-9e48-c75a8e6c480a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9830b9e9-950c-4763-9396-8194d08bf8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9830b9e9-950c-4763-9396-8194d08bf8df.jpg?1",
             "name": "Electropotence",
             "text": "Whenever a creature enters the battlefield under your control, you may pay {2}{R}. If you do, that creature deals damage equal to its power to target creature or player.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "c5eda3cf-a072-5c50-b49f-f7a9a07e6d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a583f30-a3e0-4c4f-81b3-01452edaf22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a583f30-a3e0-4c4f-81b3-01452edaf22c.jpg?1",
             "name": "Elemental Appeal",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nPut a 7/1 red Elemental creature token with trample and haste onto the battlefield. Exile it at the beginning of the next end step. If Elemental Appeal was kicked, that creature gets +7/+0 until end of turn.",
             "colours": [
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "2cd9f97d-6781-524a-b25b-eaed4ffbc33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aec169-4c62-4d53-a19c-68baa20c8e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aec169-4c62-4d53-a19c-68baa20c8e59.jpg?1",
             "name": "Geyser Glider",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Geyser Glider gains flying until end of turn.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "4a55c4da-0316-50c0-b00e-d037f2f9484e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4085a5bf-a71b-4c73-9b39-0dcc328fe11b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4085a5bf-a71b-4c73-9b39-0dcc328fe11b.jpg?1",
             "name": "Goblin Bushwhacker",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nWhen Goblin Bushwhacker enters the battlefield, if it was kicked, creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "06551013-d5a8-5323-b5e4-002d0e652211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e2a777-0705-4a37-937d-c6e020ebc0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e2a777-0705-4a37-937d-c6e020ebc0f0.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of his or her library. If it's a land card, that player puts it into his or her hand.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "94893096-8a64-5adf-9a35-5e1a250fa1ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95d1f3-7ec1-4279-ade7-3f339f2f33da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95d1f3-7ec1-4279-ade7-3f339f2f33da.jpg?1",
             "name": "Goblin Ruinblaster",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nHaste\nWhen Goblin Ruinblaster enters the battlefield, if it was kicked, destroy target nonbasic land.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "456eda3b-035d-59e8-8cd7-64786203513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daeaa2e-68e5-4f49-9220-58c0c9b1a3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daeaa2e-68e5-4f49-9220-58c0c9b1a3d0.jpg?1",
             "name": "Goblin Shortcutter",
             "text": "When Goblin Shortcutter enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4340,7 +4340,7 @@
         },
         {
             "id": "3e3f994e-07ec-5324-8960-851648933eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4388e57e-0c87-4d66-a862-58261d76c5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4388e57e-0c87-4d66-a862-58261d76c5ac.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "96fc59f6-41ce-5b8f-b94e-d1bb8f7d79ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f975874-24a6-4a14-bc5c-898c3d8e90e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f975874-24a6-4a14-bc5c-898c3d8e90e5.jpg?1",
             "name": "Hellfire Mongrel",
             "text": "At the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Hellfire Mongrel deals 2 damage to him or her.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "d36bfe91-c837-5760-b0d2-7017a2898a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70c645d-d170-4a91-a6bb-0175ec900e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70c645d-d170-4a91-a6bb-0175ec900e93.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "fde65f15-3bbb-5c0e-9f13-7090ac2de76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c22bf3-2ba6-4d8f-a2b8-a5d5e26f1316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c22bf3-2ba6-4d8f-a2b8-a5d5e26f1316.jpg?1",
             "name": "Highland Berserker",
             "text": "Whenever Highland Berserker or another Ally enters the battlefield under your control, you may have Ally creatures you control gain first strike until end of turn.",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "0e2760d0-000a-5457-83a1-38177453278f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a81ac38-c477-4797-ab91-cb7804cb727b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a81ac38-c477-4797-ab91-cb7804cb727b.jpg?1",
             "name": "Inferno Trap",
             "text": "If you've been dealt damage by two or more creatures this turn, you may pay {R} rather than pay Inferno Trap's mana cost.\nInferno Trap deals 4 damage to target creature.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "39ca5513-6ceb-5f79-9e11-798c5c94ac8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da42df13-eded-48e2-ad1a-ff74d718ce3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da42df13-eded-48e2-ad1a-ff74d718ce3c.jpg?1",
             "name": "Kazuul Warlord",
             "text": "Whenever Kazuul Warlord or another Ally enters the battlefield under your control, you may put a +1/+1 counter on each Ally creature you control.",
             "colours": [
@@ -4549,7 +4549,7 @@
         },
         {
             "id": "520acc7e-c78a-56d3-8e5e-e48c59d6d391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d411e1-5488-4818-95a4-9f637efb9be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d411e1-5488-4818-95a4-9f637efb9be6.jpg?1",
             "name": "Lavaball Trap",
             "text": "If an opponent had two or more lands enter the battlefield under his or her control this turn, you may pay {3}{R}{R} rather than pay Lavaball Trap's mana cost.\nDestroy two target lands. Lavaball Trap deals 4 damage to each creature.",
             "colours": [
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "2229270a-0c82-526e-9f2a-ddd656ea9aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee526306-6959-421c-9969-3c19b666d6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee526306-6959-421c-9969-3c19b666d6da.jpg?1",
             "name": "Magma Rift",
             "text": "As an additional cost to cast Magma Rift, sacrifice a land.\nMagma Rift deals 5 damage to target creature.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "5be9ecd2-8855-5d47-8b23-0f220380a5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a0a019-239d-428e-85a2-e19cae8f4b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a0a019-239d-428e-85a2-e19cae8f4b58.jpg?1",
             "name": "Mark of Mutiny",
             "text": "Gain control of target creature until end of turn. Put a +1/+1 counter on it and untap it. That creature gains haste until end of turn.",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "06a1ac15-dd8b-5d90-951c-2afc1716a814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebc7622-e7a7-419c-abb4-d9d339e6cdb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebc7622-e7a7-419c-abb4-d9d339e6cdb0.jpg?1",
             "name": "Molten Ravager",
             "text": "{R}: Molten Ravager gets +1/+0 until end of turn.",
             "colours": [
@@ -4681,7 +4681,7 @@
         },
         {
             "id": "a5a0169f-924e-5325-ac27-305bf317e210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60daf59f-ffba-403b-8028-787ff33f2d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60daf59f-ffba-403b-8028-787ff33f2d6c.jpg?1",
             "name": "Murasa Pyromancer",
             "text": "Whenever Murasa Pyromancer or another Ally enters the battlefield under your control, you may have Murasa Pyromancer deal damage to target creature equal to the number of Allies you control.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "b35dd7e8-5334-5f09-8bc4-822b90eb0659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbf7e23-5610-45d7-a273-923433d10934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbf7e23-5610-45d7-a273-923433d10934.jpg?1",
             "name": "Obsidian Fireheart",
             "text": "{1}{R}{R}: Put a blaze counter on target land without a blaze counter on it. As long as that land has a blaze counter on it, it has \"At the beginning of your upkeep, this land deals 1 damage to you.\" (The land continues to burn after Obsidian Fireheart has left the battlefield.)",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "42d19a53-3dce-5e2b-8760-048260b6b002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8b5c0c-acda-411e-9f17-6d9292628a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8b5c0c-acda-411e-9f17-6d9292628a56.jpg?1",
             "name": "Plated Geopede",
             "text": "First strike\nLandfall \u2014 Whenever a land enters the battlefield under your control, Plated Geopede gets +2/+2 until end of turn.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "ebd24dcd-4197-5edd-8aef-794149bb1908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e76f1c-5a07-455a-a3df-4c45b5b25b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e76f1c-5a07-455a-a3df-4c45b5b25b82.jpg?1",
             "name": "Punishing Fire",
             "text": "Punishing Fire deals 2 damage to target creature or player.\nWhenever an opponent gains life, you may pay {R}. If you do, return Punishing Fire from your graveyard to your hand.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "8b3e65c4-7fc8-5c8d-966e-5b061ab71544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288d624e-d72e-4a4b-bb74-5a8b0b2e3cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288d624e-d72e-4a4b-bb74-5a8b0b2e3cb0.jpg?1",
             "name": "Pyromancer Ascension",
             "text": "Whenever you cast an instant or sorcery spell that has the same name as a card in your graveyard, you may put a quest counter on Pyromancer Ascension.\nWhenever you cast an instant or sorcery spell while Pyromancer Ascension has two or more quest counters on it, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "03fcb278-4971-58a7-860b-9999263c347b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ac5a-21b9-4abe-b8be-86b9056ad70d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ac5a-21b9-4abe-b8be-86b9056ad70d.jpg?1",
             "name": "Quest for Pure Flame",
             "text": "Whenever a source you control deals damage to an opponent, you may put a quest counter on Quest for Pure Flame.\nRemove four quest counters from Quest for Pure Flame and sacrifice it: If any source you control would deal damage to a creature or player this turn, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "0a4e7c21-cbdd-5e42-9dd7-97ab7b836d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e800a3fe-bb1a-45f1-8c81-5ec88ff8647b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e800a3fe-bb1a-45f1-8c81-5ec88ff8647b.jpg?1",
             "name": "Ruinous Minotaur",
             "text": "Whenever Ruinous Minotaur deals damage to an opponent, sacrifice a land.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "aff3807b-9aa9-5c0b-b45a-2c6dc6f3bb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ceff22-0270-4c9d-9ae2-f40a7047335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ceff22-0270-4c9d-9ae2-f40a7047335b.jpg?1",
             "name": "Runeflare Trap",
             "text": "If an opponent drew three or more cards this turn, you may pay {R} rather than pay Runeflare Trap's mana cost.\nRuneflare Trap deals damage to target player equal to the number of cards in that player's hand.",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "347ba0f7-f96c-5e15-b3ae-3ee1efe1c419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20365082-6102-4e3b-8791-c9b66846270d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20365082-6102-4e3b-8791-c9b66846270d.jpg?1",
             "name": "Seismic Shudder",
             "text": "Seismic Shudder deals 1 damage to each creature without flying.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "2e26814d-3aaa-5940-b5c4-21d224b0878f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfbb4dd-56a2-4a94-9b15-b3ef8b2f1d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfbb4dd-56a2-4a94-9b15-b3ef8b2f1d0b.jpg?1",
             "name": "Shatterskull Giant",
             "text": "",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "2f962346-439b-55c0-ad4d-3f3ed0323145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93b0eda-693e-4a17-be1d-1df162702146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93b0eda-693e-4a17-be1d-1df162702146.jpg?1",
             "name": "Slaughter Cry",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "6bc3fee4-beb8-531d-811c-e2518ef920f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c8fe2a-3203-4545-bb25-b1f107b13cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c8fe2a-3203-4545-bb25-b1f107b13cca.jpg?1",
             "name": "Spire Barrage",
             "text": "Spire Barrage deals damage to target creature or player equal to the number of Mountains you control.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "caf46460-0d3f-51b5-9bce-e06146ca1848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4648820-9e87-4c67-8d97-cd7603f2e484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4648820-9e87-4c67-8d97-cd7603f2e484.jpg?1",
             "name": "Torch Slinger",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nWhen Torch Slinger enters the battlefield, if it was kicked, it deals 2 damage to target creature.",
             "colours": [
@@ -5116,7 +5116,7 @@
         },
         {
             "id": "b4da9dbf-87f5-5a31-88ca-b4d948dd452d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f37982-d2ae-4ff1-b5da-3936733f8108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f37982-d2ae-4ff1-b5da-3936733f8108.jpg?1",
             "name": "Tuktuk Grunts",
             "text": "Haste\nWhenever Tuktuk Grunts or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Tuktuk Grunts.",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "3fca9d9c-0bb6-5b33-bb4d-30ff51edb2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41c658e-68ec-4b55-bc5b-fd9fe8dbbdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41c658e-68ec-4b55-bc5b-fd9fe8dbbdb3.jpg?1",
             "name": "Unstable Footing",
             "text": "Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nDamage can't be prevented this turn. If Unstable Footing was kicked, it deals 5 damage to target player.",
             "colours": [
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "6cc06280-1fe3-5694-8a98-b5399a502c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98637219-40d8-414c-939d-e2c90b909725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98637219-40d8-414c-939d-e2c90b909725.jpg?1",
             "name": "Warren Instigator",
             "text": "Double strike\nWhenever Warren Instigator deals damage to an opponent, you may put a Goblin creature card from your hand onto the battlefield.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "d2525841-d3a3-55ea-99bf-ea8d2f2dfda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12d2c01-0ef2-40e6-8c7d-8512e2c8c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12d2c01-0ef2-40e6-8c7d-8512e2c8c074.jpg?1",
             "name": "Zektar Shrine Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Zektar Shrine Expedition.\nRemove three quest counters from Zektar Shrine Expedition and sacrifice it: Put a 7/1 red Elemental creature token with trample and haste onto the battlefield. Exile it at the beginning of the next end step.",
             "colours": [
@@ -5251,7 +5251,7 @@
         },
         {
             "id": "f0b54fe8-5dcb-51b6-96b4-1e2ffd7a1fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00ac173-ea82-4364-812c-13173a700dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00ac173-ea82-4364-812c-13173a700dd0.jpg?1",
             "name": "Baloth Cage Trap",
             "text": "If an opponent had an artifact enter the battlefield under his or her control this turn, you may pay {1}{G} rather than pay Baloth Cage Trap's mana cost.\nPut a 4/4 green Beast creature token onto the battlefield.",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "2d0cec7f-9ae5-544f-9d6a-9e654bce9709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223dc6a-2bee-4be9-86d5-f0a17a24c33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223dc6a-2bee-4be9-86d5-f0a17a24c33e.jpg?1",
             "name": "Baloth Woodcrasher",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Baloth Woodcrasher gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "aea4101d-57fc-518d-88a7-b8603003db79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46465b5f-26fa-4a07-9dc9-55486edee31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46465b5f-26fa-4a07-9dc9-55486edee31a.jpg?1",
             "name": "Beast Hunt",
             "text": "Reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -5351,7 +5351,7 @@
         },
         {
             "id": "4edccf17-3d7f-5511-8f98-b58e87a589c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d7ea78-d539-4c34-8bb3-941353e3da46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d7ea78-d539-4c34-8bb3-941353e3da46.jpg?1",
             "name": "Beastmaster Ascension",
             "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "a2427f58-0390-5a0b-adee-d996df761321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e2966-c163-4e02-a315-4fe66e482884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e2966-c163-4e02-a315-4fe66e482884.jpg?1",
             "name": "Cobra Trap",
             "text": "If a noncreature permanent under your control was destroyed this turn by a spell or ability an opponent controlled, you may pay {G} rather than pay Cobra Trap's mana cost.\nPut four 1/1 green Snake creature tokens onto the battlefield.",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "a6ecaed9-7834-5fa9-a333-795c9dce4c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a418a-2386-49b9-b48d-67a52448e65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a418a-2386-49b9-b48d-67a52448e65c.jpg?1",
             "name": "Frontier Guide",
             "text": "{3}{G}, {T}: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "16c04080-954d-5902-8b70-a91cd191bc59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa476306-9d6b-45ed-9e6c-fd4aee6592e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa476306-9d6b-45ed-9e6c-fd4aee6592e7.jpg?1",
             "name": "Gigantiform",
             "text": "Kicker {4}\nEnchant creature\nEnchanted creature is 8/8 and has trample.\nWhen Gigantiform enters the battlefield, if it was kicked, you may search your library for a card named Gigantiform, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "5ce32715-8dee-5c47-986a-88d00e87c506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b5290-a613-496f-bd23-8fd109549f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b5290-a613-496f-bd23-8fd109549f31.jpg?1",
             "name": "Grazing Gladehart",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may gain 2 life.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "fdb17ac5-bbfd-5596-90ed-2fede299ce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747099f7-ce5b-4366-a8a4-f3d80100f66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747099f7-ce5b-4366-a8a4-f3d80100f66e.jpg?1",
             "name": "Greenweaver Druid",
             "text": "{T}: Add {G}{G} to your mana pool.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "62454305-aa7f-5dce-9048-7b8af6ed09db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e309c1fc-3a7c-4624-8b48-9b152c2590ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e309c1fc-3a7c-4624-8b48-9b152c2590ae.jpg?1",
             "name": "Harrow",
             "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "eb256b35-474b-5b47-b693-738d7c12a988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5a5f-d851-4ceb-96e7-9ba216062072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5a5f-d851-4ceb-96e7-9ba216062072.jpg?1",
             "name": "Joraga Bard",
             "text": "Whenever Joraga Bard or another Ally enters the battlefield under your control, you may have Ally creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "0e4db2dc-36a6-5164-a5f7-d6e2efc3fbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797d8cd6-fc6b-4560-9c6f-1a867dfce85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797d8cd6-fc6b-4560-9c6f-1a867dfce85a.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5656,7 +5656,7 @@
         },
         {
             "id": "3280ccbd-c1eb-533a-aefb-ce9b7a3d48aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19adde22-e5eb-4815-beb6-c520b3274cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19adde22-e5eb-4815-beb6-c520b3274cc9.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may add one mana of any color to your mana pool.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "09a6d117-8ccc-545c-b55c-9b071ef93391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903cb570-d769-4d7f-afbe-90ebad96657c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903cb570-d769-4d7f-afbe-90ebad96657c.jpg?1",
             "name": "Mold Shambler",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Mold Shambler enters the battlefield, if it was kicked, destroy target noncreature permanent.",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "a77415ec-938c-5709-869b-bd084b3f7a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4c26ab-0f7b-4163-b9e4-a415b91352a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4c26ab-0f7b-4163-b9e4-a415b91352a6.jpg?1",
             "name": "Nissa Revane",
             "text": "+1: Search your library for a card named Nissa's Chosen and put it onto the battlefield. Then shuffle your library.\n+1: You gain 2 life for each Elf you control.\n-7: Search your library for any number of Elf creature cards and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "b783a1fb-3395-5d73-91a9-521c54c09dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a740584f-2ec2-46a9-9344-eac220759e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a740584f-2ec2-46a9-9344-eac220759e85.jpg?1",
             "name": "Nissa's Chosen",
             "text": "If Nissa's Chosen would be put into a graveyard from the battlefield, put it on the bottom of its owner's library instead.",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "043bf4ea-aa82-5ce5-9b29-02e90e77c58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89a173-0b2f-4a6a-b706-9aed8dbcabec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89a173-0b2f-4a6a-b706-9aed8dbcabec.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play the top card of your library if it's a land card.",
             "colours": [
@@ -5831,7 +5831,7 @@
         },
         {
             "id": "4d94e393-6c33-5e66-b321-edcaec2af36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a69043-23f5-478e-bf9b-f170e326c0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a69043-23f5-478e-bf9b-f170e326c0e0.jpg?1",
             "name": "Oran-Rief Recluse",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nReach (This creature can block creatures with flying.)\nWhen Oran-Rief Recluse enters the battlefield, if it was kicked, destroy target creature with flying.",
             "colours": [
@@ -5865,7 +5865,7 @@
         },
         {
             "id": "5bfba302-4f2d-5e43-8265-add2a66caa98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d598220-bddd-48a4-8c80-eb149c6292a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d598220-bddd-48a4-8c80-eb149c6292a3.jpg?1",
             "name": "Oran-Rief Survivalist",
             "text": "Whenever Oran-Rief Survivalist or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Oran-Rief Survivalist.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "56b6d7e6-3cbc-57b2-9d4c-829775b3bf05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f8adaa-2852-4e9c-b91d-ce80a21859c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f8adaa-2852-4e9c-b91d-ce80a21859c9.jpg?1",
             "name": "Predatory Urge",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to target creature. That creature deals damage equal to its power to this creature.\"",
             "colours": [
@@ -5935,7 +5935,7 @@
         },
         {
             "id": "3af7a402-0d79-57b3-ab7b-04b920fda645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b0c6a9-a7c0-4518-8580-653712062265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b0c6a9-a7c0-4518-8580-653712062265.jpg?1",
             "name": "Primal Bellow",
             "text": "Target creature gets +1/+1 until end of turn for each Forest you control.",
             "colours": [
@@ -5967,7 +5967,7 @@
         },
         {
             "id": "72d2c199-508a-566e-a058-bb604d7817ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12a160-9c05-4f66-bd80-035ea52f415b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12a160-9c05-4f66-bd80-035ea52f415b.jpg?1",
             "name": "Quest for the Gemblades",
             "text": "Whenever a creature you control deals combat damage to a creature, you may put a quest counter on Quest for the Gemblades.\nRemove a quest counter from Quest for the Gemblades and sacrifice it: Put four +1/+1 counters on target creature.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "d576014d-7c81-57af-92cd-341a31d7d20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ae703d-b133-4749-9d38-216abe6c6647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ae703d-b133-4749-9d38-216abe6c6647.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a 4/4 green Beast creature token onto the battlefield.",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "064c94a9-8f62-5cf4-8d81-d658fd0b36d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c924b2-3b10-4bb0-b51d-122bfdd298aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c924b2-3b10-4bb0-b51d-122bfdd298aa.jpg?1",
             "name": "Relic Crush",
             "text": "Destroy target artifact or enchantment and up to one other target artifact or enchantment.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "6b63e705-de6f-5047-9426-063030bbda3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a81be06-b685-461b-80a8-2f23139106e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a81be06-b685-461b-80a8-2f23139106e7.jpg?1",
             "name": "River Boa",
             "text": "Islandwalk\n{G}: Regenerate River Boa.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "0cc480f5-6079-54fd-bdb9-c1ceb2610457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8547e0-2928-4edc-a15a-a613cb4d1eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8547e0-2928-4edc-a15a-a613cb4d1eac.jpg?1",
             "name": "Savage Silhouette",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\"",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "10253e7c-a2a8-5e2d-bf40-4647a6a98687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e2fcc6-96d3-45f5-b4dd-e049d9ec6cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e2fcc6-96d3-45f5-b4dd-e049d9ec6cec.jpg?1",
             "name": "Scute Mob",
             "text": "At the beginning of your upkeep, if you control five or more lands, put four +1/+1 counters on Scute Mob.",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "2b6a41e5-b51f-58eb-bbc5-cb03ac955867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d289043-edb5-4a7e-801b-4881709edb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d289043-edb5-4a7e-801b-4881709edb32.jpg?1",
             "name": "Scythe Tiger",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nWhen Scythe Tiger enters the battlefield, sacrifice it unless you sacrifice a land.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "85c406f8-807c-5aa4-8a2b-f78f5abb180b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ce4a96-9cb2-4032-9291-7fa0849aeab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ce4a96-9cb2-4032-9291-7fa0849aeab9.jpg?1",
             "name": "Summoning Trap",
             "text": "If a creature spell you cast this turn was countered by a spell or ability an opponent controlled, you may pay {0} rather than pay Summoning Trap's mana cost.\nLook at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "c447c078-c72f-5295-b4e6-a890b2a1f8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46dbeb-f9b3-4e0f-a61f-52a91da6f087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46dbeb-f9b3-4e0f-a61f-52a91da6f087.jpg?1",
             "name": "Tajuru Archer",
             "text": "Whenever Tajuru Archer or another Ally enters the battlefield under your control, you may have Tajuru Archer deal damage to target creature with flying equal to the number of Allies you control.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "4964680f-1ef2-5443-90b2-49c418cb6d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e15b-7460-4d61-a209-6de27e4df6bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e15b-7460-4d61-a209-6de27e4df6bb.jpg?1",
             "name": "Tanglesap",
             "text": "Prevent all combat damage that would be dealt this turn by creatures without trample.",
             "colours": [
@@ -6303,7 +6303,7 @@
         },
         {
             "id": "6fe4ea5f-b07c-5acc-b57a-9ca8aff0101e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab062f4-e4b1-4129-9027-d0ca1a723273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab062f4-e4b1-4129-9027-d0ca1a723273.jpg?1",
             "name": "Terra Stomper",
             "text": "Terra Stomper can't be countered.\nTrample",
             "colours": [
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "e248f976-b5af-5464-868b-0ab6a8e792ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45033b8a-f3a8-4a23-b6b0-e011e3e7a4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45033b8a-f3a8-4a23-b6b0-e011e3e7a4c1.jpg?1",
             "name": "Territorial Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Territorial Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "e7a1666e-7fee-5d76-9347-e30d7bcf4335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fc3bc-eb3b-4504-93a3-8943d07b23f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fc3bc-eb3b-4504-93a3-8943d07b23f8.jpg?1",
             "name": "Timbermaw Larva",
             "text": "Whenever Timbermaw Larva attacks, it gets +1/+1 until end of turn for each Forest you control.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "2dba9d5e-9dfd-5dd3-aa15-1ddf81b897b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b774563a-d2d4-4bdf-ad82-dd9e1fa953ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b774563a-d2d4-4bdf-ad82-dd9e1fa953ba.jpg?1",
             "name": "Turntimber Basilisk",
             "text": "Deathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target creature block Turntimber Basilisk this turn if able.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "f0628638-ae53-5e9c-a1ff-3586524f774a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24bba56-3256-489b-82a2-22748388e110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24bba56-3256-489b-82a2-22748388e110.jpg?1",
             "name": "Turntimber Ranger",
             "text": "Whenever Turntimber Ranger or another Ally enters the battlefield under your control, you may put a 2/2 green Wolf creature token onto the battlefield. If you do, put a +1/+1 counter on Turntimber Ranger.",
             "colours": [
@@ -6476,7 +6476,7 @@
         },
         {
             "id": "310e58c0-0895-573f-a89c-72a85fd18f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5daf96-ceae-4c9a-95cd-f6d706e9b1fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5daf96-ceae-4c9a-95cd-f6d706e9b1fa.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -6510,7 +6510,7 @@
         },
         {
             "id": "56f22031-170c-54b5-a297-610e388ddb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bd8b10-de86-4bb6-b49f-6ccb5297c81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bd8b10-de86-4bb6-b49f-6ccb5297c81c.jpg?1",
             "name": "Vines of Vastwood",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nTarget creature can't be the target of spells or abilities your opponents control this turn. If Vines of Vastwood was kicked, that creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6542,7 +6542,7 @@
         },
         {
             "id": "b2b0789a-bbeb-5a12-ba9b-dc7325b17206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb7fb-8618-4595-84b4-20881b824b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb7fb-8618-4595-84b4-20881b824b3e.jpg?1",
             "name": "Zendikar Farguide",
             "text": "Forestwalk",
             "colours": [
@@ -6576,7 +6576,7 @@
         },
         {
             "id": "63af049c-be3d-50a7-8ccc-ad9e50b1bb40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa395f2-656e-4bf3-bd9b-6240bd3e2774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa395f2-656e-4bf3-bd9b-6240bd3e2774.jpg?1",
             "name": "Adventuring Gear",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "f5c15e35-854f-5e2b-aa05-57478411ed95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b42e5-0e60-4148-907e-456d9f3043be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b42e5-0e60-4148-907e-456d9f3043be.jpg?1",
             "name": "Blade of the Bloodchief",
             "text": "Whenever a creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature. If equipped creature is a Vampire, put two +1/+1 counters on it instead.\nEquip {1}",
             "colours": [],
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "4cbcc725-b6d8-55a0-b130-63618b13a351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9d1ff2-9ce3-4737-af1d-9fc82e4dffe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9d1ff2-9ce3-4737-af1d-9fc82e4dffe6.jpg?1",
             "name": "Blazing Torch",
             "text": "Equipped creature can't be blocked by Vampires or Zombies.\nEquipped creature has \"{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to target creature or player.\"\nEquip {1}",
             "colours": [],
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "65950970-fea4-5aa0-9f80-e409f43f2e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52688a03-26a4-40ff-8a99-a268113a9802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52688a03-26a4-40ff-8a99-a268113a9802.jpg?1",
             "name": "Carnage Altar",
             "text": "{3}, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -6694,7 +6694,7 @@
         },
         {
             "id": "94ae28a6-7456-5e6d-859a-85d69ed3468f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4169-8c49-41f4-9e01-20de06ca4ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4169-8c49-41f4-9e01-20de06ca4ad9.jpg?1",
             "name": "Eldrazi Monument",
             "text": "Creatures you control get +1/+1, have flying, and are indestructible.\nAt the beginning of your upkeep, sacrifice a creature. If you can't, sacrifice Eldrazi Monument.",
             "colours": [],
@@ -6722,7 +6722,7 @@
         },
         {
             "id": "fe4ae6e4-0c9a-5fba-a09e-5dcda5580293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9222e18-41b3-423f-8715-305a0d8fd410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9222e18-41b3-423f-8715-305a0d8fd410.jpg?1",
             "name": "Eternity Vessel",
             "text": "Eternity Vessel enters the battlefield with X charge counters on it, where X is your life total.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have your life total become the number of charge counters on Eternity Vessel.",
             "colours": [],
@@ -6750,7 +6750,7 @@
         },
         {
             "id": "cba1eb11-a729-58b3-b63e-07277901ff1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55bee97-593f-441f-b96c-a998d5212a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55bee97-593f-441f-b96c-a998d5212a55.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -6778,7 +6778,7 @@
         },
         {
             "id": "e134ea22-7904-553f-852d-b40ef0f5b05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3a9cdb-4842-44b3-8143-0fda31692600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3a9cdb-4842-44b3-8143-0fda31692600.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "dbe29b6d-b206-5f4b-885a-59631866866f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c29a90-639b-479d-b822-d5fb54b1d690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c29a90-639b-479d-b822-d5fb54b1d690.jpg?1",
             "name": "Grappling Hook",
             "text": "Equipped creature has double strike.\nWhenever equipped creature attacks, you may have target creature block it this turn if able.\nEquip {4}",
             "colours": [],
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "7ba36c44-42a1-5c70-a324-ca29a685b90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6422e062-0ce1-4239-8c2d-06449627a55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6422e062-0ce1-4239-8c2d-06449627a55a.jpg?1",
             "name": "Hedron Scrabbler",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Hedron Scrabbler gets +1/+1 until end of turn.",
             "colours": [],
@@ -6869,7 +6869,7 @@
         },
         {
             "id": "6459301e-638e-56dc-9dd4-8b98be4f9baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f6b2b-8d98-4609-b991-a69523b5a07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f6b2b-8d98-4609-b991-a69523b5a07d.jpg?1",
             "name": "Khalni Gem",
             "text": "When Khalni Gem enters the battlefield, return two lands you control to their owner's hand.\n{T}: Add two mana of any one color to your mana pool.",
             "colours": [],
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "0d5851a3-5c32-5881-a28e-945f2b87a1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f75f13e-43e6-4118-83a3-0446c2089d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f75f13e-43e6-4118-83a3-0446c2089d84.jpg?1",
             "name": "Spidersilk Net",
             "text": "Equipped creature gets +0/+2 and has reach. (It can block creatures with flying.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "bf84e585-ad01-5519-8988-6f56b10486f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg?1",
             "name": "Stonework Puma",
             "text": "",
             "colours": [],
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "7e001275-440c-5997-9884-8bdb11891e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb5a30-016a-465f-bdf0-e2df2d1bef8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb5a30-016a-465f-bdf0-e2df2d1bef8c.jpg?1",
             "name": "Trailblazer's Boots",
             "text": "Equipped creature has nonbasic landwalk. (It's unblockable as long as defending player controls a nonbasic land.)\nEquip {2}",
             "colours": [],
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "75df09b9-7388-5764-82d0-8ef129af92c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c9838e-aa72-49fc-bae2-f880bcbc9313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c9838e-aa72-49fc-bae2-f880bcbc9313.jpg?1",
             "name": "Trusty Machete",
             "text": "Equipped creature gets +2/+1.\nEquip {2}",
             "colours": [],
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "3dcda88c-02b1-5e2e-b7d0-189309941ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed95b4a-1452-4337-a4b2-e67e624d33df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed95b4a-1452-4337-a4b2-e67e624d33df.jpg?1",
             "name": "Akoum Refuge",
             "text": "Akoum Refuge enters the battlefield tapped.\nWhen Akoum Refuge enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "ac7a549d-deb4-56c5-8941-4da1ba8a3293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c8d2fa-54a7-46e8-980c-905258497c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c8d2fa-54a7-46e8-980c-905258497c90.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "e354d5d9-606c-50d4-a21d-006e15bd9d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672869d6-5314-422e-92f6-6a328fe0c6f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672869d6-5314-422e-92f6-6a328fe0c6f6.jpg?1",
             "name": "Crypt of Agadeem",
             "text": "Crypt of Agadeem enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\n{2}, {T}: Add {B} to your mana pool for each black creature card in your graveyard.",
             "colours": [],
@@ -7108,7 +7108,7 @@
         },
         {
             "id": "7ecf25a1-e4b4-50a2-ae3d-af8f48523342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf6016e-71e7-4339-80f9-78e9aa44c54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf6016e-71e7-4339-80f9-78e9aa44c54b.jpg?1",
             "name": "Emeria, the Sky Ruin",
             "text": "Emeria, the Sky Ruin enters the battlefield tapped.\nAt the beginning of your upkeep, if you control seven or more Plains, you may return target creature card from your graveyard to the battlefield.\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -7138,7 +7138,7 @@
         },
         {
             "id": "15e3500a-a85d-56d0-aec1-bc1170424e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46324e3-52e7-4b21-a9a0-a3aae9f7dd5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46324e3-52e7-4b21-a9a0-a3aae9f7dd5b.jpg?1",
             "name": "Graypelt Refuge",
             "text": "Graypelt Refuge enters the battlefield tapped.\nWhen Graypelt Refuge enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7169,7 +7169,7 @@
         },
         {
             "id": "dc786df5-cda6-5049-962c-c3b6ef0927cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd9463f-d029-459d-a933-432b7bbd7a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd9463f-d029-459d-a933-432b7bbd7a41.jpg?1",
             "name": "Jwar Isle Refuge",
             "text": "Jwar Isle Refuge enters the battlefield tapped.\nWhen Jwar Isle Refuge enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7200,7 +7200,7 @@
         },
         {
             "id": "44d00f1a-7e11-56cc-a734-7e8b10b52f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776decb-cdb5-4f41-8a3a-c0cece18eb35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776decb-cdb5-4f41-8a3a-c0cece18eb35.jpg?1",
             "name": "Kabira Crossroads",
             "text": "Kabira Crossroads enters the battlefield tapped.\nWhen Kabira Crossroads enters the battlefield, you gain 2 life.\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "1b44835a-134b-5ff1-a225-303b9c2f2aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af66f9c-c90b-45e0-a54c-a76e7e1b9dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af66f9c-c90b-45e0-a54c-a76e7e1b9dff.jpg?1",
             "name": "Kazandu Refuge",
             "text": "Kazandu Refuge enters the battlefield tapped.\nWhen Kazandu Refuge enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "a7ffab36-f986-588c-a56f-bf5db806010a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c84cf70-4164-47ea-8da1-c0ca1ac132e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c84cf70-4164-47ea-8da1-c0ca1ac132e1.jpg?1",
             "name": "Magosi, the Waterveil",
             "text": "Magosi, the Waterveil enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\n{U}, {T}: Put an eon counter on Magosi, the Waterveil. Skip your next turn.\n{T}, Remove an eon counter from Magosi, the Waterveil and return it to its owner's hand: Take an extra turn after this one.",
             "colours": [],
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "7c6b5635-469e-5116-a091-d8c585578814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45026d57-0324-4312-8b86-2e7d4f581ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45026d57-0324-4312-8b86-2e7d4f581ee9.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7319,7 +7319,7 @@
         },
         {
             "id": "613e3626-6735-549f-a37f-f8dfaf1fd61d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a5cc2c-0fbf-4a5f-b175-6e0ffd0d0787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a5cc2c-0fbf-4a5f-b175-6e0ffd0d0787.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7347,7 +7347,7 @@
         },
         {
             "id": "f190ea49-c050-54f6-9a0b-eae644fe4bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcc3bab-46f8-4ed2-abdb-7a117ad07d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcc3bab-46f8-4ed2-abdb-7a117ad07d03.jpg?1",
             "name": "Oran-Rief, the Vastwood",
             "text": "Oran-Rief, the Vastwood enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{T}: Put a +1/+1 counter on each green creature that entered the battlefield this turn.",
             "colours": [],
@@ -7377,7 +7377,7 @@
         },
         {
             "id": "5610381e-bf89-5766-b301-7629354768a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea077cff-b5c9-4a40-8e66-8810c37be5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea077cff-b5c9-4a40-8e66-8810c37be5cb.jpg?1",
             "name": "Piranha Marsh",
             "text": "Piranha Marsh enters the battlefield tapped.\nWhen Piranha Marsh enters the battlefield, target player loses 1 life.\n{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "2776db51-8343-5762-8f56-9b15be46e3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327cf118-cc92-4073-85d0-94d2a0a6989a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327cf118-cc92-4073-85d0-94d2a0a6989a.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "abec0112-bfdc-5f4a-ad78-a87d1ee08fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd8cb0d-d651-44e7-ae14-4035b0f1aa77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd8cb0d-d651-44e7-ae14-4035b0f1aa77.jpg?1",
             "name": "Sejiri Refuge",
             "text": "Sejiri Refuge enters the battlefield tapped.\nWhen Sejiri Refuge enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7466,7 +7466,7 @@
         },
         {
             "id": "ee55ee6f-8389-521e-9587-006f60135bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf0de91-765a-49e3-bd8a-94f266b3bdd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf0de91-765a-49e3-bd8a-94f266b3bdd8.jpg?1",
             "name": "Soaring Seacliff",
             "text": "Soaring Seacliff enters the battlefield tapped.\nWhen Soaring Seacliff enters the battlefield, target creature gains flying until end of turn.\n{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -7496,7 +7496,7 @@
         },
         {
             "id": "cf46ecb1-6ad2-5ed0-8b85-ebdb914a5fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56aca36-bb51-45e3-9ef9-9f9f2aa1e088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56aca36-bb51-45e3-9ef9-9f9f2aa1e088.jpg?1",
             "name": "Teetering Peaks",
             "text": "Teetering Peaks enters the battlefield tapped.\nWhen Teetering Peaks enters the battlefield, target creature gets +2/+0 until end of turn.\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -7526,7 +7526,7 @@
         },
         {
             "id": "062922a9-8dfb-532f-9f96-c75f972c15de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc92d6ef-a578-4320-b5c8-3da192eea1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc92d6ef-a578-4320-b5c8-3da192eea1f3.jpg?1",
             "name": "Turntimber Grove",
             "text": "Turntimber Grove enters the battlefield tapped.\nWhen Turntimber Grove enters the battlefield, target creature gets +1/+1 until end of turn.\n{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "ea154084-9fef-5195-a0ee-34f46314ca6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bce60d-2cb0-4772-9f5c-122a7ed426a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bce60d-2cb0-4772-9f5c-122a7ed426a0.jpg?1",
             "name": "Valakut, the Molten Pinnacle",
             "text": "Valakut, the Molten Pinnacle enters the battlefield tapped.\nWhenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have Valakut, the Molten Pinnacle deal 3 damage to target creature or player.\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "f2bcbbfd-d681-59be-b020-5468029b46de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd2723-2851-4f1a-b2d0-dfcb526472c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd2723-2851-4f1a-b2d0-dfcb526472c3.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "15ffebe7-d12a-5c01-91a3-02a8becb6f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b6d-ff35-4b1f-974b-f39569e6b3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b6d-ff35-4b1f-974b-f39569e6b3c7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "9667babc-eadb-53ce-a476-8c18f881ab23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51afc6cd-1a39-4160-a265-d92610db1d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51afc6cd-1a39-4160-a265-d92610db1d44.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7697,7 +7697,7 @@
         },
         {
             "id": "bb0061d9-5f98-59d3-8adb-47a6cc12c3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b362e9b-8d25-405e-b70e-f3c9533627a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b362e9b-8d25-405e-b70e-f3c9533627a7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7739,7 +7739,7 @@
         },
         {
             "id": "735b8fcb-0a0f-50c8-abb3-453e46a62de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e53e2e-0703-45d3-ab91-78f5241c32bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e53e2e-0703-45d3-ab91-78f5241c32bb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "bf04c6b3-f7e4-5116-a50f-1b698d292cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36446ad6-8bf0-4e4e-bbab-379c22dbf4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36446ad6-8bf0-4e4e-bbab-379c22dbf4f6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "c54b1457-7f32-537d-ad11-d51768510784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4da90d5-d793-4412-acc3-e0c2a5c10e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4da90d5-d793-4412-acc3-e0c2a5c10e18.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7863,7 +7863,7 @@
         },
         {
             "id": "df458f48-668f-5f23-bfb2-816aac2e234d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9646663-ba93-446b-ad83-71503924e7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9646663-ba93-446b-ad83-71503924e7f8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7905,7 +7905,7 @@
         },
         {
             "id": "b649e837-05ce-5dc5-b179-37f3f612db55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a087d3-54b1-4000-89d1-0c428659158c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a087d3-54b1-4000-89d1-0c428659158c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "aed5fe79-ddec-5bf7-93b3-63a042faf863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd86f2a-bd28-4731-838d-78e67be8b49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd86f2a-bd28-4731-838d-78e67be8b49e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "76a8c558-a2bc-56fc-b3e7-de053e39a6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ec37bf-80bd-4f51-a79e-9c20e4048a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ec37bf-80bd-4f51-a79e-9c20e4048a00.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8029,7 +8029,7 @@
         },
         {
             "id": "1801bcf6-b3e2-5e0e-aad9-aaaf12393787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b4cbcc-c394-4be3-8072-8893b48c866d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b4cbcc-c394-4be3-8072-8893b48c866d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "bd892174-c6c2-59c6-9373-5b401943eee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3c4a0-892d-4e74-bb21-00786705766e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3c4a0-892d-4e74-bb21-00786705766e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "671e0285-dd5b-5eed-b5c5-b2534d73e8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f905b-4ce0-4071-a721-7e51be14d114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f905b-4ce0-4071-a721-7e51be14d114.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "5263fe25-8015-5201-8443-bfba346cede5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a50ced-f89d-4636-a681-8c1de18ee712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a50ced-f89d-4636-a681-8c1de18ee712.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "1570300a-543b-5f6f-80f4-d8363a3bf809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3a90f-23c4-4c54-8825-32cb17977b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3a90f-23c4-4c54-8825-32cb17977b48.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8237,7 +8237,7 @@
         },
         {
             "id": "1018c35b-0e4c-5e57-b4fb-d06d1bbf57cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f8662-8294-4924-a4c0-e26b709ea4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f8662-8294-4924-a4c0-e26b709ea4a6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8278,7 +8278,7 @@
         },
         {
             "id": "025fb02d-5479-55f1-af9e-3cd5c02f20d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd6becc-f06a-4fd3-8305-70604b92a187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd6becc-f06a-4fd3-8305-70604b92a187.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "2086b5e7-6f55-5dcb-9de5-2de7a9a66f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3e999-c75b-4be3-ae7f-ac5430b760b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3e999-c75b-4be3-ae7f-ac5430b760b6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8361,7 +8361,7 @@
         },
         {
             "id": "be1b0ff1-b113-5fa2-ae1e-7c3c0c3b4826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847cac15-b404-4e0f-964e-7aee41c93346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847cac15-b404-4e0f-964e-7aee41c93346.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "8f213ece-b3fc-5013-91cf-2967feff1732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485df5c7-5653-4bb2-ae0b-8ec83359f192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485df5c7-5653-4bb2-ae0b-8ec83359f192.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "0a0f53ed-2640-5848-936d-50de61cb5c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095fed4-0a2a-4092-b923-8f46c8ea22d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095fed4-0a2a-4092-b923-8f46c8ea22d8.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "69ec3d81-1e22-5c88-83fd-34944bfb1d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d5f86d-19c3-4a9a-956f-8c52cec5ba83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d5f86d-19c3-4a9a-956f-8c52cec5ba83.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8527,7 +8527,7 @@
         },
         {
             "id": "fb083deb-30ea-5ff4-8aa8-cee8531cd7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9e2d99-a3ad-4bfb-a781-a8a9454085c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9e2d99-a3ad-4bfb-a781-a8a9454085c9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8569,7 +8569,7 @@
         },
         {
             "id": "512e7ce6-124b-5c2b-abed-43796e7a0e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80906a47-ef4b-4e59-889c-946d40a79d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80906a47-ef4b-4e59-889c-946d40a79d94.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "ffa3a1b1-a69b-5098-a9a6-9dae5ac7f661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232ee129-0db1-4a03-9eda-4692a8495b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232ee129-0db1-4a03-9eda-4692a8495b53.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8652,7 +8652,7 @@
         },
         {
             "id": "4168bae9-8e35-5c8d-b23b-b37f2f1e4046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f570888-effb-44ff-a250-a7726a0b01f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f570888-effb-44ff-a250-a7726a0b01f4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8693,7 +8693,7 @@
         },
         {
             "id": "2eee4910-9ccf-504d-8464-fced3f661831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de70f1-6fb1-4191-b66f-491c794f9c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de70f1-6fb1-4191-b66f-491c794f9c05.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8735,7 +8735,7 @@
         },
         {
             "id": "36ed46db-8731-5f03-988c-8502737fc99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45651533-0c76-476a-bfaf-1b5ec74427cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45651533-0c76-476a-bfaf-1b5ec74427cd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "b1d2a944-d6b5-5fe1-9431-962f7ed1b080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bacab3-25fb-4a0c-81b3-7e9e22899c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bacab3-25fb-4a0c-81b3-7e9e22899c2c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "3701118e-8443-56ca-bfce-325ea86a37be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0571374-26b4-403c-b6da-4fd8b930cda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0571374-26b4-403c-b6da-4fd8b930cda6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "3ff0e334-7b61-57ee-b312-cacadd08716c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a298c5d-9937-4df6-a544-7b3bcfe84885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a298c5d-9937-4df6-a544-7b3bcfe84885.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8901,7 +8901,7 @@
         },
         {
             "id": "70532549-6396-5ce0-878e-20a2fd58a9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf03952-6d9d-4e57-acb5-44c855f3ad69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf03952-6d9d-4e57-acb5-44c855f3ad69.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "8b2b4813-187c-53d1-8ee6-d9109ce4c427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ca4b9f-4ee6-4ad8-a95f-326ada9de3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ca4b9f-4ee6-4ad8-a95f-326ada9de3cd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "d86dc958-7b41-55e3-856c-a74c55852ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d6876e-7d83-44bd-b721-5070f4087325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d6876e-7d83-44bd-b721-5070f4087325.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9025,7 +9025,7 @@
         },
         {
             "id": "7c0ffc88-34ff-5436-bfe7-ac9f1dd62888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6744c441-42b3-48b2-af06-1e27ec776d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6744c441-42b3-48b2-af06-1e27ec776d97.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9067,7 +9067,7 @@
         },
         {
             "id": "e24c5554-22b3-54c0-84c6-387bfb179a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfbcefd-8b2d-4b9e-a11a-18274c3a8dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfbcefd-8b2d-4b9e-a11a-18274c3a8dd2.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "59cea094-ebc9-5afa-bdf3-f0cc832a2136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c21f91-6679-4adb-baf2-b06cf505150c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c21f91-6679-4adb-baf2-b06cf505150c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9150,7 +9150,7 @@
         },
         {
             "id": "ec4af441-2ff2-5259-8df8-b69caf0a9464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1908f8d2-95df-44e3-8943-568c596cd8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1908f8d2-95df-44e3-8943-568c596cd8aa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "41d883ae-9018-5218-887e-502b03a2b89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341b05e6-93bb-4071-b8c6-1644f56e026d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341b05e6-93bb-4071-b8c6-1644f56e026d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9233,7 +9233,7 @@
         },
         {
             "id": "55e52247-87e9-52a6-86f4-f33b0ae82226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30f54e8-eba3-4412-a805-3a834922c260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30f54e8-eba3-4412-a805-3a834922c260.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "4ce057df-27f1-57f6-8a11-13d1641775e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc37484-b58b-4a42-9281-b4272dc7c872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc37484-b58b-4a42-9281-b4272dc7c872.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9308,7 +9308,7 @@
         },
         {
             "id": "00bc234b-f9c2-54ce-9033-84fbf420cc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbb3c16-a7ef-4b83-b1a9-637a905229d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbb3c16-a7ef-4b83-b1a9-637a905229d7.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "4ee8e1b3-61d9-5633-9585-e53d127a3a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9623e74-3b94-4842-903f-ed52931bdf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9623e74-3b94-4842-903f-ed52931bdf6a.jpg?1",
             "name": "Kor Soldier",
             "text": "",
             "colours": [
@@ -9377,7 +9377,7 @@
         },
         {
             "id": "29dab46f-15d2-516d-b549-663a56422696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dcbf662-7263-414a-b64b-ccf9aab20faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dcbf662-7263-414a-b64b-ccf9aab20faa.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -9411,7 +9411,7 @@
         },
         {
             "id": "b13404ba-d911-5474-b6a9-75f61d5734c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b292b-2da6-4601-9f93-5eb273ce3a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b292b-2da6-4601-9f93-5eb273ce3a50.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -9445,7 +9445,7 @@
         },
         {
             "id": "34a7d9ba-1821-58bc-bac4-cb9f6d73ffe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969eff58-d91e-49e2-a1e1-8f32b4598810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969eff58-d91e-49e2-a1e1-8f32b4598810.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "6bb07111-9fd4-5c6f-b130-96531e843c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1999ff2f-5797-496e-9917-ad19507ecec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1999ff2f-5797-496e-9917-ad19507ecec9.jpg?1",
             "name": "Zombie Giant",
             "text": "",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "c58cd9b2-decb-5789-81db-7de4f7db8e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e12780-9c25-4cb0-b1ff-a36ca50b19d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e12780-9c25-4cb0-b1ff-a36ca50b19d8.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -9548,7 +9548,7 @@
         },
         {
             "id": "8dc57fdf-8072-5f4d-9969-046050d5eb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e455-053d-4a86-93b2-2436b554b638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e455-053d-4a86-93b2-2436b554b638.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "b00a6f47-fe8c-53f5-a49d-d175f4325e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6a142-f065-4a74-9a73-8105be29bc94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6a142-f065-4a74-9a73-8105be29bc94.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -9616,7 +9616,7 @@
         },
         {
             "id": "4a62fd92-1384-56e3-a5cc-d6e2d8dda434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9e4b4-c0fb-4627-92cf-69544e0c875d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9e4b4-c0fb-4627-92cf-69544e0c875d.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [

--- a/Assets/Resources/Sets/ZNR.json
+++ b/Assets/Resources/Sets/ZNR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f85cb2cb-34b1-5d26-bffc-eb86ebe23fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340df0d4-9848-4372-9f45-a73a8e94058a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340df0d4-9848-4372-9f45-a73a8e94058a.jpg?1",
             "name": "Allied Assault",
             "text": "Up to two target creatures each get +X/+X until end of turn, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "014e7ff4-baf3-5f8f-998c-85de7c9716e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897074a-0ac4-4d1a-9aac-e77830cc5c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897074a-0ac4-4d1a-9aac-e77830cc5c78.jpg?1",
             "name": "Angel of Destiny",
             "text": "Flying, double strike\nWhenever a creature you control deals combat damage to a player, you and that player each gain that much life.\nAt the beginning of your end step, if you have at least 15 life more than your starting life total, each player Angel of Destiny attacked this turn loses the game.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "85c9c43d-4296-5c4a-bbda-c04fd26da05f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06cc03f-da73-4ba5-96c9-618b497a7ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06cc03f-da73-4ba5-96c9-618b497a7ea3.jpg?1",
             "name": "Angelheart Protector",
             "text": "When Angelheart Protector enters the battlefield, target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "e6456927-05f5-5682-a76d-f9df6caaedef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228c1650-da3c-4099-91b6-18e3873c9cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228c1650-da3c-4099-91b6-18e3873c9cdb.jpg?1",
             "name": "Archon of Emeria",
             "text": "Flying\nEach player can't cast more than one spell each turn.\nNonbasic lands your opponents control enter the battlefield tapped.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "6c096234-980f-5483-a18c-da4c6e0a9bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc61e4-46e3-473b-90f8-27e71e1088e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc61e4-46e3-473b-90f8-27e71e1088e8.jpg?1",
             "name": "Archpriest of Iona",
             "text": "Archpriest of Iona's power is equal to the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "84ad24f9-d124-5e3b-a0fb-f85e8531aa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca80b5a-3943-41ca-8cd1-8e3db1b2a1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca80b5a-3943-41ca-8cd1-8e3db1b2a1c8.jpg?1",
             "name": "Attended Healer",
             "text": "Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.\n{2}{W}: Another target Cleric gains lifelink until end of turn.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "36309bf0-11e4-5489-a624-fdcf6f121523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b3938e-ebd7-4668-be3a-422c02ff5b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b3938e-ebd7-4668-be3a-422c02ff5b08.jpg?1",
             "name": "Canyon Jerboa",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "b8c9b683-4aeb-5860-99f8-2700d3f53344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f334767-4353-4379-a934-fa67075db439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f334767-4353-4379-a934-fa67075db439.jpg?1",
             "name": "Cliffhaven Sell-Sword",
             "text": "",
             "colours": [
@@ -287,7 +287,7 @@
         },
         {
             "id": "97d5cdbb-7d5b-5a3b-87d1-5641926daa39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a4d17-68e6-4133-99fd-e501e24e6c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a4d17-68e6-4133-99fd-e501e24e6c6b.jpg?1",
             "name": "Dauntless Unity",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nCreatures you control get +1/+1 until end of turn. If this spell was kicked, those creatures get +2/+1 until end of turn instead.",
             "colours": [
@@ -319,7 +319,7 @@
         },
         {
             "id": "48bfb87c-c329-5505-a81f-8a53bc0ba6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c37ba56-e22c-4b10-821a-2827c5cd81ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c37ba56-e22c-4b10-821a-2827c5cd81ad.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -351,7 +351,7 @@
         },
         {
             "id": "8c89d234-8842-5627-9433-4bd110339eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6490370e-fff5-4f17-b715-74ff8df5bc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6490370e-fff5-4f17-b715-74ff8df5bc7c.jpg?1",
             "name": "Emeria Captain",
             "text": "Flying, vigilance\nWhen Emeria Captain enters the battlefield, put a +1/+1 counter on it for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "d1222c93-0aee-5d60-970a-7342b6f8cba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "Create two 4/4 white Angel Warrior creature tokens with flying. Non-Angel creatures you control gain indestructible until your next turn.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -420,7 +420,7 @@
         },
         {
             "id": "dde525a3-231d-58c4-a49d-4d6b6d811f19",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "As Emeria, Shattered Skyclave enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.\n\n\nSorcery\n{4}{W}{W}{W}",
             "colours": [],
@@ -452,7 +452,7 @@
         },
         {
             "id": "f3cdc8d5-012a-5c61-9f3c-59e8beaf2f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a00a88-de0e-4012-9ad8-ccb187dff7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a00a88-de0e-4012-9ad8-ccb187dff7df.jpg?1",
             "name": "Expedition Healer",
             "text": "Vigilance\nExpedition Healer has lifelink as long as you control another Cleric.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "2d9d9030-0291-5539-b6dc-bd3fc621b9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949bb9a-b4e8-4992-a12d-8e31953aff0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949bb9a-b4e8-4992-a12d-8e31953aff0d.jpg?1",
             "name": "Farsight Adept",
             "text": "When Farsight Adept enters the battlefield, you and target opponent each draw a card.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "f4712ff2-22fe-54d1-bac8-7ef326cedb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d73eb7-4e76-48d4-90fa-fa972dc0fccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d73eb7-4e76-48d4-90fa-fa972dc0fccb.jpg?1",
             "name": "Fearless Fledgling",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Fearless Fledgling. It gains flying until end of turn.",
             "colours": [
@@ -558,7 +558,7 @@
         },
         {
             "id": "07a07a01-4daf-5b6c-aeba-13353f593f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45340647-4d3e-4be1-b0e6-e40cc56a438b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45340647-4d3e-4be1-b0e6-e40cc56a438b.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "e4d9e639-6f3d-5a34-bd14-900f31efe30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47120e3c-73aa-468d-96b7-47aead342e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47120e3c-73aa-468d-96b7-47aead342e31.jpg?1",
             "name": "Journey to Oblivion",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nWhen Journey to Oblivion enters the battlefield, exile target nonland permanent an opponent controls until Journey to Oblivion leaves the battlefield.",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "1bd6493e-af7c-5efa-a243-accb8a5ee6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c81719-f820-4674-9cfb-cd5eaf0c1f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c81719-f820-4674-9cfb-cd5eaf0c1f0d.jpg?1",
             "name": "Kabira Outrider",
             "text": "When Kabira Outrider enters the battlefield, target creature gets +1/+1 until end of turn for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -659,7 +659,7 @@
         },
         {
             "id": "c3f3ff5b-5c29-5b6c-a794-69efe192f2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1",
             "name": "Kabira Takedown // Kabira Plateau",
             "text": "Kabira Takedown deals damage equal to the number of creatures you control to target creature or planeswalker.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "320fbcfe-e6f5-5e22-84b3-1b58565ff4d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1",
             "name": "Kabira Takedown // Kabira Plateau",
             "text": "Kabira Plateau enters the battlefield tapped.\n{T}: Add {W}.\n\n\nInstant\n{1}{W}",
             "colours": [],
@@ -721,7 +721,7 @@
         },
         {
             "id": "c2725771-c75b-5e1c-91e4-116d78df7ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16626f84-00d3-4ec9-b62c-19fff380cd3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16626f84-00d3-4ec9-b62c-19fff380cd3a.jpg?1",
             "name": "Kitesail Cleric",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nFlying\nWhen Kitesail Cleric enters the battlefield, if it was kicked, tap up to two target creatures.",
             "colours": [
@@ -756,7 +756,7 @@
         },
         {
             "id": "39bd3a4c-1ea9-5e88-9dc4-99ad8b3ca5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6049-5599-47eb-ae58-a8eb96927ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6049-5599-47eb-ae58-a8eb96927ece.jpg?1",
             "name": "Kor Blademaster",
             "text": "Double strike\nEquipped Warriors you control have double strike.",
             "colours": [
@@ -791,7 +791,7 @@
         },
         {
             "id": "c794e071-41dc-5738-b9c9-2b0f34f17697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c37e46-a961-4739-8893-f783013e2be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c37e46-a961-4739-8893-f783013e2be6.jpg?1",
             "name": "Kor Celebrant",
             "text": "Whenever Kor Celebrant or another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -826,7 +826,7 @@
         },
         {
             "id": "d23b96b7-fc82-59dc-a7e4-35d79e06e487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda5609a-ab22-4f03-988b-8056c97fdc9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda5609a-ab22-4f03-988b-8056c97fdc9e.jpg?1",
             "name": "Legion Angel",
             "text": "Flying\nWhen Legion Angel enters the battlefield, you may reveal a card you own named Legion Angel from outside the game and put it into your hand.",
             "colours": [
@@ -863,7 +863,7 @@
         },
         {
             "id": "c05a79d5-f08f-5a11-a2d9-5b058b81f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe964e7e-e2c5-4263-889d-0a531eb51442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe964e7e-e2c5-4263-889d-0a531eb51442.jpg?1",
             "name": "Luminarch Aspirant",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -900,7 +900,7 @@
         },
         {
             "id": "3d0deee6-d05f-5b94-a925-81b00ae53e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d164a-bce2-4474-abe0-b735eb6c9442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d164a-bce2-4474-abe0-b735eb6c9442.jpg?1",
             "name": "Makindi Ox",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "3a1ffbe7-7f31-5df5-9697-830124b8d3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg?1",
             "name": "Makindi Stampede // Makindi Mesas",
             "text": "Creatures you control get +2/+2 until end of turn.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -968,7 +968,7 @@
         },
         {
             "id": "8301bdda-54b5-5c36-a3b7-2a85e0870250",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg?1",
             "name": "Makindi Stampede // Makindi Mesas",
             "text": "Makindi Mesas enters the battlefield tapped.\n{T}: Add {W}.\n\n\nSorcery\n{3}{W}{W}",
             "colours": [],
@@ -998,7 +998,7 @@
         },
         {
             "id": "a3a20ff0-f502-5bb4-8f5a-bc9b03bbfca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2608-0d44-442c-97a1-12ac94b7abac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2608-0d44-442c-97a1-12ac94b7abac.jpg?1",
             "name": "Maul of the Skyclaves",
             "text": "When Maul of the Skyclaves enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+2 and has flying and first strike.\nEquip {2}{W}{W}",
             "colours": [
@@ -1034,7 +1034,7 @@
         },
         {
             "id": "828859ab-c060-5586-bfbb-09abcbfeceeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65af09b-656f-4d81-b95d-b4f902e56bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65af09b-656f-4d81-b95d-b4f902e56bb7.jpg?1",
             "name": "Mesa Lynx",
             "text": "As long as it's not your turn, Mesa Lynx gets +0/+2.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "088e395b-423a-55ae-9c25-ee6fe8b33953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421eac28-d6f2-44f2-b7ca-eb73fbf23887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421eac28-d6f2-44f2-b7ca-eb73fbf23887.jpg?1",
             "name": "Nahiri's Binding",
             "text": "Enchant creature or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "8c2835f3-d8fc-5755-8194-89bf5f2ffeff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Destroy all nonland permanents.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "df15adcf-2c3a-559b-a40d-b135b7a1ebd5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Ondu Skyruins enters the battlefield tapped.\n{T}: Add {W}.\n\n\nSorcery\n{6}{W}{W}",
             "colours": [],
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "a425cc1c-256c-5630-9579-0077a07628b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67930e10-4de8-4d40-af27-4a38d35ab16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67930e10-4de8-4d40-af27-4a38d35ab16f.jpg?1",
             "name": "Paired Tactician",
             "text": "Whenever Paired Tactician and at least one other Warrior attack, put a +1/+1 counter on Paired Tactician.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "10303416-af27-5575-ba24-c3d99647ab57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b448f4-aa0c-42c7-a771-e8dd20e0520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b448f4-aa0c-42c7-a771-e8dd20e0520c.jpg?1",
             "name": "Practiced Tactics",
             "text": "Choose target attacking or blocking creature. Practiced Tactics deals damage to that creature equal to twice the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -1235,7 +1235,7 @@
         },
         {
             "id": "d3d993ba-345e-5028-b5bb-732b90fd5de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe82bbf-9b92-4684-a42d-fbc50c4c5903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe82bbf-9b92-4684-a42d-fbc50c4c5903.jpg?1",
             "name": "Pressure Point",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "335f6fe2-0924-52cc-8d92-53ed579212c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d1c11a-a32c-449c-95c6-450dce6c26d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d1c11a-a32c-449c-95c6-450dce6c26d2.jpg?1",
             "name": "Prowling Felidar",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Prowling Felidar.",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "1c69a680-efd1-569c-a28b-d73b22626358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b82476-4320-4719-9785-af8d68503234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b82476-4320-4719-9785-af8d68503234.jpg?1",
             "name": "Resolute Strike",
             "text": "Target creature gets +2/+2 until end of turn. If it's a Warrior, you may attach an Equipment you control to it.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "74a178c0-e75b-5935-8565-0e2427277b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4634e-1487-4b66-8f70-bcb4b1fa6e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4634e-1487-4b66-8f70-bcb4b1fa6e77.jpg?1",
             "name": "Sea Gate Banneret",
             "text": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1371,7 +1371,7 @@
         },
         {
             "id": "c1b2f597-ae58-5fac-93af-e1e95af87e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1",
             "name": "Sejiri Shelter // Sejiri Glacier",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "8371d026-41cc-5f24-af86-ffe3f57a967a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1",
             "name": "Sejiri Shelter // Sejiri Glacier",
             "text": "Sejiri Glacier enters the battlefield tapped.\n{T}: Add {W}.\n\n\nInstant\n{1}{W}",
             "colours": [],
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "540b1682-b4e1-553c-8470-6fb0f21cf8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70baa3-5232-4e10-80b4-a9ead6ed6ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70baa3-5232-4e10-80b4-a9ead6ed6ec3.jpg?1",
             "name": "Shepherd of Heroes",
             "text": "Flying\nWhen Shepherd of Heroes enters the battlefield, you gain 2 life for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "ef368548-311c-53fd-9941-f1ad13636f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83cfbaa-7890-4f6f-878b-4edb45677371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83cfbaa-7890-4f6f-878b-4edb45677371.jpg?1",
             "name": "Skyclave Apparition",
             "text": "When Skyclave Apparition enters the battlefield, exile up to one target nonland, nontoken permanent you don't control with converted mana cost 4 or less.\nWhen Skyclave Apparition leaves the battlefield, the exiled card's owner creates an X/X blue Illusion creature token, where X is the converted mana cost of the exiled card.",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "2026fabc-fe54-5c55-9fbd-917d79a0b52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg?1",
             "name": "Skyclave Cleric // Skyclave Basilica",
             "text": "When Skyclave Cleric enters the battlefield, you gain 2 life.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "8406e4c9-605b-5473-956f-7d2094c68424",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg?1",
             "name": "Skyclave Cleric // Skyclave Basilica",
             "text": "Skyclave Basilica enters the battlefield tapped.\n{T}: Add {W}.\n\n\nCleric\n{1}{W}",
             "colours": [],
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "04921058-5ce3-5d02-874a-a54783625da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce186d-c9cd-41e9-bac2-ad9d36c4939f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce186d-c9cd-41e9-bac2-ad9d36c4939f.jpg?1",
             "name": "Squad Commander",
             "text": "When Squad Commander enters the battlefield, create a 1/1 white Kor Warrior creature token for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "0ac29ad3-b84d-5624-95c3-ca9fb50e70d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c103163-31b7-4d25-aa2c-02ca082ee1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c103163-31b7-4d25-aa2c-02ca082ee1bf.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "d8728257-a03b-51bf-80ab-02248d503743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299d60b9-0ba7-40ee-b9d0-ee8f1ea288c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299d60b9-0ba7-40ee-b9d0-ee8f1ea288c9.jpg?1",
             "name": "Tazeem Raptor",
             "text": "Flying\nWhen Tazeem Raptor enters the battlefield, you may return a land you control to its owner's hand.",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "48b84b4d-c550-590b-b220-f47ce8966729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b79138-5728-4541-9ea5-dce1a5ae7e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b79138-5728-4541-9ea5-dce1a5ae7e6a.jpg?1",
             "name": "Tazri, Beacon of Unity",
             "text": "This spell costs {1} less to cast for each creature in your party.\n{2\nU}{2\nB}{2\nR}{2\nG}: Look at the top six cards of your library. You may reveal up to two Cleric, Rogue, Warrior, Wizard, and/or Ally cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "0ad2c31c-7e2c-5126-8f61-a17c2d69bd37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db99b872-77c7-4471-9c44-a36d4ff5d33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db99b872-77c7-4471-9c44-a36d4ff5d33f.jpg?1",
             "name": "Anticognition",
             "text": "Counter target creature or planeswalker spell unless its controller pays {2}. If an opponent has eight or more cards in their graveyard, instead counter that spell, then scry 2.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "ce100595-c59e-51cd-b03e-28e2d65feab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg?1",
             "name": "Beyeen Veil // Beyeen Coast",
             "text": "Creatures your opponents control get -2/-0 until end of turn.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "a4ceb7d1-c98f-53bd-b891-d1e8dec60bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg?1",
             "name": "Beyeen Veil // Beyeen Coast",
             "text": "Beyeen Coast enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{1}{U}",
             "colours": [],
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "27f9c8b6-64ce-5d30-b323-7bfd2ade82bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfba7a0-d5ca-4197-9e58-21f28345f1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfba7a0-d5ca-4197-9e58-21f28345f1a6.jpg?1",
             "name": "Bubble Snare",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nEnchant creature\nWhen Bubble Snare enters the battlefield, if it was kicked, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "6c9b84c4-fd63-5f89-9c64-af20e01c76b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13105c88-2926-40ad-bc7a-09d515aa36c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13105c88-2926-40ad-bc7a-09d515aa36c6.jpg?1",
             "name": "Cascade Seer",
             "text": "When Cascade Seer enters the battlefield, scry X, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "5108f3bc-571f-5de3-8646-b996c113464a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a6804-1e3c-428c-af5e-1d56ba11c108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a6804-1e3c-428c-af5e-1d56ba11c108.jpg?1",
             "name": "Charix, the Raging Isle",
             "text": "Spells your opponents cast that target Charix, the Raging Isle cost {2} more to cast.\n{3}: Charix gets +X/-X until end of turn, where X is the number of Islands you control.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "4855d940-293b-524b-9898-52c345920698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f9adfd-a940-4d62-894b-84f17c693a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f9adfd-a940-4d62-894b-84f17c693a10.jpg?1",
             "name": "Chilling Trap",
             "text": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "d2353848-c3dd-50bb-abf5-270bab0faa59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ea262c-ea32-4aca-b96b-58f556a8dffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ea262c-ea32-4aca-b96b-58f556a8dffc.jpg?1",
             "name": "Cleric of Chill Depths",
             "text": "Whenever Cleric of Chill Depths blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "a3d0ecc7-23b3-5a48-bab3-262a11f9728b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c108d-3902-4c2e-919c-a5449cd2dc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c108d-3902-4c2e-919c-a5449cd2dc3c.jpg?1",
             "name": "Concerted Defense",
             "text": "Counter target noncreature spell unless its controller pays {1} plus an additional {1} for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "7dc7049e-192f-5bbc-bfd0-ee452c17e48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e37936-913e-4b16-a5a8-8aed733d702d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e37936-913e-4b16-a5a8-8aed733d702d.jpg?1",
             "name": "Confounding Conundrum",
             "text": "When Confounding Conundrum enters the battlefield, draw a card.\nWhenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under their control this turn, they return a land they control to its owner's hand.",
             "colours": [
@@ -2052,7 +2052,7 @@
         },
         {
             "id": "597f2b12-15ee-5f2f-88fa-9f99fb245b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b54524-8345-4b47-913f-d883a1cbe3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b54524-8345-4b47-913f-d883a1cbe3a1.jpg?1",
             "name": "Coralhelm Chronicler",
             "text": "Whenever you cast a kicked spell, draw a card, then discard a card.\nWhen Coralhelm Chronicler enters the battlefield, look at the top five cards of your library. You may reveal a card with a kicker ability from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2089,7 +2089,7 @@
         },
         {
             "id": "5adbe097-fdd3-590f-b67d-349b195046d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217f0a9-5af5-45cc-8cf7-8878d4f66dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217f0a9-5af5-45cc-8cf7-8878d4f66dd8.jpg?1",
             "name": "Cunning Geysermage",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nWhen Cunning Geysermage enters the battlefield, if it was kicked, return up to one other target creature to its owner's hand.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "ecc2d863-0dd4-58d8-af5a-234bdb63085f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41c0dd0-fef2-4f3c-8f3c-9c9c521b5442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41c0dd0-fef2-4f3c-8f3c-9c9c521b5442.jpg?1",
             "name": "Deliberate",
             "text": "Scry 2, then draw a card.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "f9806f43-a79c-5b21-9f2d-242cadc49f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f6e94-fb5f-4861-a465-f11766303676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f6e94-fb5f-4861-a465-f11766303676.jpg?1",
             "name": "Expedition Diviner",
             "text": "Flying\nAs long as you control another Wizard, Expedition Diviner has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "3b8905a0-c91d-5e42-9c8e-2ba51cb21759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c3a2f-678b-4e70-a53f-258457d88d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c3a2f-678b-4e70-a53f-258457d88d29.jpg?1",
             "name": "Field Research",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nDraw two cards. If this spell was kicked, draw three cards instead.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "89d1d1d2-f69b-54df-b18d-f4ace7c72acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381d84d6-7b34-44cb-a697-54b835ba1281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381d84d6-7b34-44cb-a697-54b835ba1281.jpg?1",
             "name": "Glacial Grasp",
             "text": "Tap target creature. Its controller mills two cards. That creature doesn't untap during its controller's next untap step. (They put the top two cards of their library into their graveyard.)\nDraw a card.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "992af866-53ec-5530-bd0a-bd94d4be939e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "You may have Glasspool Mimic enter the battlefield as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -2292,7 +2292,7 @@
         },
         {
             "id": "5632d048-68aa-5867-aea0-d4b21284dc82",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "Glasspool Shore enters the battlefield tapped.\n{T}: Add {U}.\n\n\nRogue\n{2}{U}",
             "colours": [],
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "2c48aa0e-796b-5d48-9add-625b25250d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281cdb1c-21ae-4430-8e0f-c993f52ba891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281cdb1c-21ae-4430-8e0f-c993f52ba891.jpg?1",
             "name": "Inscription of Insight",
             "text": "Kicker {2}{U}{U}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Return up to two target creatures to their owners' hands.\n\u2022 Scry 2, then draw two cards.\n\u2022 Target player creates an X/X blue Illusion creature token, where X is the number of cards in their hand.",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "dd604910-0e81-5d56-b022-e08f21de0879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899540b0-c17a-4a73-912c-9b8925203de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899540b0-c17a-4a73-912c-9b8925203de1.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "19914d4f-3f02-5050-a11e-c1c72acda20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ed348-e4ed-4b6a-b9d9-03539a6fb42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ed348-e4ed-4b6a-b9d9-03539a6fb42a.jpg?1",
             "name": "Jace, Mirror Mage",
             "text": "Kicker {2}\nWhen Jace, Mirror Mage enters the battlefield, if Jace was kicked, create a token that's a copy of Jace, Mirror Mage, except it's not legendary and its starting loyalty is 1.\n+1: Scry 2.\n0: Draw a card and reveal it. Remove a number of loyalty counters equal to that card's converted mana cost from Jace, Mirror Mage.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "688d303d-a159-567e-9a5e-d7e43401d9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg?1",
             "name": "Jwari Disruption // Jwari Ruins",
             "text": "Counter target spell unless its controller pays {1}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "d998ffd8-ff81-5e94-b6b7-49fc35e5c8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg?1",
             "name": "Jwari Disruption // Jwari Ruins",
             "text": "Jwari Ruins enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{1}{U}",
             "colours": [],
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "01d1ef65-cbcd-5b28-85c8-0edeca7ed330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05ed233-9b53-4c67-ab1c-0217386c9fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05ed233-9b53-4c67-ab1c-0217386c9fe4.jpg?1",
             "name": "Living Tempest",
             "text": "Flash\nFlying",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "b253e3c4-9bda-5698-9c3b-b25ac231d15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9944393-348f-4f0e-a0c7-9adcc5a30749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9944393-348f-4f0e-a0c7-9adcc5a30749.jpg?1",
             "name": "Lullmage's Domination",
             "text": "This spell costs {3} less to cast if it targets a creature whose controller has eight or more cards in their graveyard.\nGain control of target creature with converted mana cost X.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "53df80cc-d023-58b6-96ba-a22494041997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a79733-702c-4611-b073-71db7f1158b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a79733-702c-4611-b073-71db7f1158b2.jpg?1",
             "name": "Maddening Cacophony",
             "text": "Kicker {3}{U}\nEach opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "074f2c80-fced-5d43-aab8-f8fcb056e390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaf92a-3d9d-4c52-acff-cf960ec55e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaf92a-3d9d-4c52-acff-cf960ec55e47.jpg?1",
             "name": "Master of Winds",
             "text": "Flying\nWhen Master of Winds enters the battlefield, draw two cards, then discard a card.\nWhenever you cast an instant, sorcery, or Wizard spell, you may have Master of Winds's base power and toughness become 4/1 or 1/4 until end of turn.",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "d3eb610b-27a0-51e5-bc80-0f45fa16263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a96105-8448-44cb-b60a-36648a1bdbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a96105-8448-44cb-b60a-36648a1bdbac.jpg?1",
             "name": "A-Master of Winds",
             "text": "",
             "colours": [
@@ -2663,7 +2663,7 @@
         },
         {
             "id": "1d011237-4e72-52a2-abbe-7ea805d1af4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb0d55a-9d6a-443d-aa82-5cea93188fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb0d55a-9d6a-443d-aa82-5cea93188fd2.jpg?1",
             "name": "Merfolk Falconer",
             "text": "Flying\nWhenever you cast a kicked spell, scry 2.",
             "colours": [
@@ -2698,7 +2698,7 @@
         },
         {
             "id": "41c8ddc1-bb00-510b-86e5-012961dbb51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112077b8-1514-4320-a70f-b23f3c7ce18a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112077b8-1514-4320-a70f-b23f3c7ce18a.jpg?1",
             "name": "Merfolk Windrobber",
             "text": "Flying\nWhenever Merfolk Windrobber deals combat damage to a player, that player mills a card. (They put the top card of their library into their graveyard.)\nSacrifice Merfolk Windrobber: Draw a card. Activate this ability only if an opponent has eight or more cards in their graveyard.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "6bf9586f-5404-5ae5-be10-57973407f4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c7477-d453-4fa4-acf4-3835ab9eb55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c7477-d453-4fa4-acf4-3835ab9eb55a.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "3f65c9b3-fedc-58e5-854b-1bb5c5c77977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee1a550-b7e7-48e0-bd96-a41986dbd879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee1a550-b7e7-48e0-bd96-a41986dbd879.jpg?1",
             "name": "Nimble Trapfinder",
             "text": "Nimble Trapfinder can't be blocked if you had another Cleric, Rogue, Warrior, or Wizard enter the battlefield under your control this turn.\nAt the beginning of combat on your turn, if you have a full party, creatures you control gain \"Whenever this creature deals combat damage to a player, draw a card\" until end of turn.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "e6bc516d-a9dd-54cd-85ed-747de0ea5729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6455009-030c-4a33-a60b-80863d8f8aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6455009-030c-4a33-a60b-80863d8f8aaf.jpg?1",
             "name": "Risen Riptide",
             "text": "Whenever you cast a kicked spell, Risen Riptide has base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "749d1824-be3b-52d4-8855-45e96ea4e41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1240d4-dbd0-483b-934a-5f7c505fad42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1240d4-dbd0-483b-934a-5f7c505fad42.jpg?1",
             "name": "Roost of Drakes",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nWhen Roost of Drakes enters the battlefield, if it was kicked, create a 2/2 blue Drake creature token with flying.\nWhenever you cast a kicked spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "4289ce68-7cf8-5fa3-b2c2-84d0132b8151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ce273-c938-42d2-83b2-c4f5f4000b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ce273-c938-42d2-83b2-c4f5f4000b0b.jpg?1",
             "name": "Ruin Crab",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, each opponent mills three cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "302d4e22-af48-562b-86f3-182b142969f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "Draw cards equal to the number of cards in your hand plus one. You have no maximum hand size for the rest of the game.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "56eadd50-8594-5dab-be75-36e74035e68d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "As Sea Gate, Reborn enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.\n\n\nSorcery\n{4}{U}{U}{U}",
             "colours": [],
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "413aadac-d2ed-5f73-9331-051e0d7605ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e14e677-9bfa-4bcc-9772-8e7758d7538a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e14e677-9bfa-4bcc-9772-8e7758d7538a.jpg?1",
             "name": "Sea Gate Stormcaller",
             "text": "Kicker {4}{U}\nWhen Sea Gate Stormcaller enters the battlefield, copy the next instant or sorcery spell with converted mana cost 2 or less you cast this turn when you cast it. If Sea Gate Stormcaller was kicked, copy that spell twice instead. You may choose new targets for the copies.",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "25e05e59-8afb-57b9-99f8-fda315e99265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e9696-6c76-4241-97fc-f166fe2420ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e9696-6c76-4241-97fc-f166fe2420ce.jpg?1",
             "name": "Seafloor Stalker",
             "text": "{4}{U}: Seafloor Stalker gets +1/+0 until end of turn and can't be blocked this turn. This ability costs {1} less to activate for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "3d361e8a-1863-5b13-b914-3cdc7b13c87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3daede39-8eef-4272-a483-312dbd2dd30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3daede39-8eef-4272-a483-312dbd2dd30f.jpg?1",
             "name": "Shell Shield",
             "text": "Kicker {1} (You may pay an additional {1} as you cast this spell.)\nTarget creature you control gets +0/+3 until end of turn. If this spell was kicked, that creature also gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -3074,7 +3074,7 @@
         },
         {
             "id": "3f332ab3-f2d6-5a61-bca7-38992453fb48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg?1",
             "name": "Silundi Vision // Silundi Isle",
             "text": "Look at the top six cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "659aebc2-277a-54f3-a533-9380fb1daa6d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg?1",
             "name": "Silundi Vision // Silundi Isle",
             "text": "Silundi Isle enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{2}{U}",
             "colours": [],
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "54cbe878-7ebd-5235-986b-60ed7b3d13d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff05312-787e-4e5e-a0d5-8f3fb576fc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff05312-787e-4e5e-a0d5-8f3fb576fc49.jpg?1",
             "name": "Skyclave Plunder",
             "text": "Look at the top X cards of your library, where X is three plus the number of creatures in your party. Put three of those cards into your hand and the rest on the bottom of your library in a random order. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "d5e8d92b-251f-56fb-9ee1-6fa5ba8cffd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ed049-7b5b-47d9-96af-f737631a221f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ed049-7b5b-47d9-96af-f737631a221f.jpg?1",
             "name": "Skyclave Squid",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Squid can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "cce4bb9b-3192-528e-bfb7-8f0cd2f9e1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0505053c-8a9c-43ed-b44a-b52c56ba4f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0505053c-8a9c-43ed-b44a-b52c56ba4f77.jpg?1",
             "name": "Sure-Footed Infiltrator",
             "text": "Tap another untapped Rogue you control: Sure-Footed Infiltrator can't be blocked this turn.\nWhenever Sure-Footed Infiltrator deals combat damage to a player, draw a card.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "9c7cc6d6-eb38-55fd-b24e-c50ba1e1d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f222fb7-375d-4ee2-9ff6-bd71f63ab31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f222fb7-375d-4ee2-9ff6-bd71f63ab31a.jpg?1",
             "name": "Tazeem Roilmage",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nWhen Tazeem Roilmage enters the battlefield, if it was kicked, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "4ab19108-6acb-5e15-944e-36cd6f5aa94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff84ea71-e477-44f7-a3f8-77fef708efeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff84ea71-e477-44f7-a3f8-77fef708efeb.jpg?1",
             "name": "Thieving Skydiver",
             "text": "Kicker {X}. X can't be 0. (You may pay an additional {X} as you cast this spell.)\nFlying\nWhen Thieving Skydiver enters the battlefield, if it was kicked, gain control of target artifact with converted mana cost X or less. If that artifact is an Equipment, attach it to Thieving Skydiver.",
             "colours": [
@@ -3311,7 +3311,7 @@
         },
         {
             "id": "8b9b0a75-561a-5a7a-88e9-1f559165eff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg?1",
             "name": "Umara Wizard // Umara Skyfalls",
             "text": "Whenever you cast an instant, sorcery, or Wizard spell, Umara Wizard gains flying until end of turn.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "076d18b9-3a90-5a31-b29e-c16edf07e786",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg?1",
             "name": "Umara Wizard // Umara Skyfalls",
             "text": "Umara Skyfalls enters the battlefield tapped.\n{T}: Add {U}.\n\n\nWizard\n{4}{U}",
             "colours": [],
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "6a52b40c-620d-5376-bac3-20c1ce872aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790a86d-db91-4a87-aa3a-3f9fc4d4b662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790a86d-db91-4a87-aa3a-3f9fc4d4b662.jpg?1",
             "name": "Windrider Wizard",
             "text": "Flying\nWhenever you cast an instant, sorcery, or Wizard spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "3f49533b-0ff4-5094-8e54-ced99b051aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4c7268-60c6-4038-8ce9-d9d51bed4577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4c7268-60c6-4038-8ce9-d9d51bed4577.jpg?1",
             "name": "Zulaport Duelist",
             "text": "Flash\nWhen Zulaport Duelist enters the battlefield, up to one target creature gets -2/-0 until end of turn. Its controller mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "16b73777-ebad-5771-b1c7-0726eeda9f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281336c7-ca7c-4c91-bdfb-d253a965cb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281336c7-ca7c-4c91-bdfb-d253a965cb7c.jpg?1",
             "name": "Acquisitions Expert",
             "text": "When Acquisitions Expert enters the battlefield, target opponent reveals a number of cards from their hand equal to the number of creatures in your party. You choose one of those cards. That player discards that card. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "12c64bd4-83e3-53f4-b037-a7306121cdb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "Return from your graveyard to the battlefield any number of target creature cards that each have a different converted mana cost X or less.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "d5ea3ded-5799-5625-8a3c-bad72e6aeb39",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "As Agadeem, the Undercrypt enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.\n\n\nSorcery\n{X}{B}{B}{B}",
             "colours": [],
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "963e7d0a-f4e0-55d2-ba98-4bf4e131f961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg?1",
             "name": "Blackbloom Rogue // Blackbloom Bog",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nBlackbloom Rogue gets +3/+0 as long as an opponent has eight or more cards in their graveyard.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "e709a2b9-c819-52c1-b2e6-54f9736580fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg?1",
             "name": "Blackbloom Rogue // Blackbloom Bog",
             "text": "Blackbloom Bog enters the battlefield tapped.\n{T}: Add {B}.\n\n\nRogue\n{2}{B}",
             "colours": [],
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "aa9b8a27-4336-5f5f-ade7-c80655a5e9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb88075-14f8-4ac9-b947-5ca1d30938f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb88075-14f8-4ac9-b947-5ca1d30938f1.jpg?1",
             "name": "Blood Beckoning",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nReturn target creature card from your graveyard to your hand. If this spell was kicked, instead return two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "c0f42223-7bd2-5d6c-a26f-1cf9b0d4c793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14d32d-fe53-4370-8298-fab528ff12db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14d32d-fe53-4370-8298-fab528ff12db.jpg?1",
             "name": "Blood Price",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order. You lose 2 life.",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "d947d9cd-f855-5496-b5de-88006b49865f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8447-6b1c-4651-a734-a8fea2cbf7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8447-6b1c-4651-a734-a8fea2cbf7b2.jpg?1",
             "name": "Bloodchief's Thirst",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nDestroy target creature or planeswalker with converted mana cost 2 or less. If this spell was kicked, instead destroy target creature or planeswalker.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "5c56c095-1c7c-5fd4-bb7f-4308e3479dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afbc5d3-318f-4545-88d6-fc81e5466238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afbc5d3-318f-4545-88d6-fc81e5466238.jpg?1",
             "name": "Coveted Prize",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nSearch your library for a card, put it into your hand, then shuffle your library. If you have a full party, you may cast a spell with converted mana cost 4 or less from your hand without paying its mana cost.",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "0ab082c4-ede2-5cd6-88ab-2fa066e7c43e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007a5c8c-ed0b-4844-9393-a3d25d4ffa1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007a5c8c-ed0b-4844-9393-a3d25d4ffa1d.jpg?1",
             "name": "Deadly Alliance",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "8104eec8-4d71-537c-aa04-86cf85f40876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f5197-e42b-45e0-8170-1b0a8a5beebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f5197-e42b-45e0-8170-1b0a8a5beebd.jpg?1",
             "name": "Demon's Disciple",
             "text": "When Demon's Disciple enters the battlefield, each player sacrifices a creature or planeswalker.",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "3ad614e1-4de8-575f-866c-8fe3456a2280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd4154e-7681-444b-a0f2-33e887791ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd4154e-7681-444b-a0f2-33e887791ba7.jpg?1",
             "name": "Drana, the Last Bloodchief",
             "text": "Flying\nWhenever Drana, the Last Bloodchief attacks, defending player chooses a nonlegendary creature card in your graveyard. You return that card to the battlefield with a +1/+1 counter on it. The creature is a Vampire in addition to its other types.",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "f28c3b12-31c7-5286-b461-60757029d43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59224f9a-deb2-4dd4-b2d4-967232c14254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59224f9a-deb2-4dd4-b2d4-967232c14254.jpg?1",
             "name": "Drana's Silencer",
             "text": "When Drana's Silencer enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "9db2791b-bf23-526c-aac5-bdbb84f23f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339736a8-a00f-4e21-8d92-38486f73dba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339736a8-a00f-4e21-8d92-38486f73dba9.jpg?1",
             "name": "Dreadwurm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Dreadwurm gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3922,7 +3922,7 @@
         },
         {
             "id": "07c2e89c-093b-532d-a898-a7a0d235e9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2966b1f0-3d30-4d92-87e5-f39ceacefbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2966b1f0-3d30-4d92-87e5-f39ceacefbd2.jpg?1",
             "name": "Expedition Skulker",
             "text": "Expedition Skulker has deathtouch as long as you control another Rogue.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "c2c689ac-4752-5d10-8ec4-8c359e5df42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b2eba7-862a-4efd-9f65-065fb2070855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b2eba7-862a-4efd-9f65-065fb2070855.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's converted mana cost.",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "77262c37-53a5-51d0-9e01-09bde26b66cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f272ac54-fea8-4044-83e2-f8fdc10f467d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f272ac54-fea8-4044-83e2-f8fdc10f467d.jpg?1",
             "name": "Ghastly Gloomhunter",
             "text": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nFlying, lifelink\nIf Ghastly Gloomhunter was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "6c99a42f-c90e-5397-bb85-5ffd43ad02ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b996743e-7f48-49d8-948b-ceb75bddf215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b996743e-7f48-49d8-948b-ceb75bddf215.jpg?1",
             "name": "Guul Draz Mucklord",
             "text": "When Guul Draz Mucklord dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "9c1b3814-fb66-57f1-8d30-abc3a51cfebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f971b71a-af69-43a7-b06c-e80eaaaf4a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f971b71a-af69-43a7-b06c-e80eaaaf4a5f.jpg?1",
             "name": "Hagra Constrictor",
             "text": "Hagra Constrictor enters the battlefield with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has menace. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "73110484-d3a9-5ffc-a829-08b05dad2d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcad1-00d2-4e26-8230-82f0768bdd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcad1-00d2-4e26-8230-82f0768bdd67.jpg?1",
             "name": "A-Hagra Constrictor",
             "text": "",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "bd6c333d-346c-5178-a15d-917f86ac3e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c04c734-354d-4925-8161-7052110951df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c04c734-354d-4925-8161-7052110951df.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "This spell costs {1} less to cast if an opponent controls no basic lands.\nDestroy target creature.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "c3dbece1-31b6-5e2b-89eb-5a31c5473ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c04c734-354d-4925-8161-7052110951df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c04c734-354d-4925-8161-7052110951df.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "Hagra Broodpit enters the battlefield tapped.\n{T}: Add {B}.\n\n\nInstant\n{2}{B}{B}",
             "colours": [],
@@ -4191,7 +4191,7 @@
         },
         {
             "id": "ddfe362c-16a1-5ddf-be15-5b235c8f13b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c40082-516e-4381-a4cc-e61c5a9a6cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c40082-516e-4381-a4cc-e61c5a9a6cac.jpg?1",
             "name": "Highborn Vampire",
             "text": "",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "f5b4df8e-eafe-5af7-bfe8-ad1468f80a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93612079-0b8d-489d-9ae1-3593414a8cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93612079-0b8d-489d-9ae1-3593414a8cee.jpg?1",
             "name": "Inscription of Ruin",
             "text": "Kicker {2}{B}{B}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Target opponent discards two cards.\n\u2022 Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u2022 Destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "3adcbcc9-a9cf-50f3-95ab-0d52cd96e1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b36d12e-9a68-4d3d-92e8-9840cd5320bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b36d12e-9a68-4d3d-92e8-9840cd5320bc.jpg?1",
             "name": "Lithoform Blight",
             "text": "Enchant land\nWhen Lithoform Blight enters the battlefield, draw a card.\nEnchanted land loses all land types and abilities and has \"{T}: Add {C}\" and \"{T}, Pay 1 life: Add one mana of any color.\"",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "3dc126c9-19a2-57cf-bef7-947fbf0c47e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14ea81-d303-47db-90b4-7d10588f7ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14ea81-d303-47db-90b4-7d10588f7ea6.jpg?1",
             "name": "Malakir Blood-Priest",
             "text": "When Malakir Blood-Priest enters the battlefield, each opponent loses X life and you gain X life, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "08321af6-5548-53c6-88c0-99537f2bf5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1",
             "name": "Malakir Rebirth // Malakir Mire",
             "text": "Choose target creature. You lose 2 life. Until end of turn, that creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "08438b77-41e3-5bdf-bbe4-5c76a95f04d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1",
             "name": "Malakir Rebirth // Malakir Mire",
             "text": "Malakir Mire enters the battlefield tapped.\n{T}: Add {B}.\n\n\nInstant\n{B}",
             "colours": [],
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "349b037f-2ce1-54ec-b06a-1c3fc3a03061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730ddbcd-0814-4e22-85e9-78b0878324b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730ddbcd-0814-4e22-85e9-78b0878324b6.jpg?1",
             "name": "Marauding Blight-Priest",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "4173674f-b2b7-52b7-8a7c-11059b323eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b6e18-bcd8-43b7-870d-6c7e5c06f99b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b6e18-bcd8-43b7-870d-6c7e5c06f99b.jpg?1",
             "name": "Mind Carver",
             "text": "When Mind Carver enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0. It gets +3/+1 instead as long as an opponent has eight or more cards in their graveyard.\nEquip {2}{B}",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "88d932a2-296a-5d1e-bf2f-10cd6564e0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0683d586-a54b-425a-a24d-2efb2342f150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0683d586-a54b-425a-a24d-2efb2342f150.jpg?1",
             "name": "Mind Drain",
             "text": "Target opponent discards two cards, mills a card, and loses 1 life. You gain 1 life. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "f5bf1c79-b32b-5150-ae9b-1978698aa01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb348f07-1d48-4877-8a56-60655d64a3f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb348f07-1d48-4877-8a56-60655d64a3f7.jpg?1",
             "name": "Nighthawk Scavenger",
             "text": "Flying, deathtouch, lifelink\nNighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards. (Cards in graveyards have only the characteristics of their front face.)",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "eb67e9ad-a112-50b3-a1ab-0c895e396def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea080141-6262-4595-8058-b2969b3f016b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea080141-6262-4595-8058-b2969b3f016b.jpg?1",
             "name": "Nimana Skitter-Sneak",
             "text": "As long as an opponent has eight or more cards in their graveyard, Nimana Skitter-Sneak gets +1/+0 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "81acbee0-ea7f-5c24-8a14-e3f41985b8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72eaa0f-cbec-45a1-b390-cbbedf5a02f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72eaa0f-cbec-45a1-b390-cbbedf5a02f2.jpg?1",
             "name": "Nimana Skydancer",
             "text": "Flash\nFlying\nWhen Nimana Skydancer enters the battlefield, target opponent mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "b85990b9-479d-5492-925d-7f3ff241b50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086fc7fb-efcf-4676-8455-39b63edaec6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086fc7fb-efcf-4676-8455-39b63edaec6a.jpg?1",
             "name": "Nullpriest of Oblivion",
             "text": "Kicker {3}{B}\nMenace, lifelink\nWhen Nullpriest of Oblivion enters the battlefield, if it was kicked, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "b25066a0-c638-5051-8968-b1f25f833e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf65512-8228-48f4-ba7b-d861b66d28c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf65512-8228-48f4-ba7b-d861b66d28c9.jpg?1",
             "name": "Oblivion's Hunger",
             "text": "Target creature you control gains indestructible until end of turn. Draw a card if that creature has a +1/+1 counter on it. (Damage and effects that say \"destroy\" don't destroy the creature.)",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "75ba9201-7ad8-589e-a46a-67cf08e4a694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg?1",
             "name": "Pelakka Predation // Pelakka Caverns",
             "text": "Target opponent reveals their hand. You choose a card from it with converted mana cost 3 or greater. That player discards that card.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "956cb1d0-2beb-51f9-8f33-38cb28280d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg?1",
             "name": "Pelakka Predation // Pelakka Caverns",
             "text": "Pelakka Caverns enters the battlefield tapped.\n{T}: Add {B}.\n\n\nSorcery\n{2}{B}",
             "colours": [],
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "e10af705-d59c-5abd-afdd-c130a4ee50b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043926fe-d25f-40b4-b556-181503434e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043926fe-d25f-40b4-b556-181503434e68.jpg?1",
             "name": "Scion of the Swarm",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on Scion of the Swarm.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "294dd93b-a5d4-5969-b6f7-0936f6c6426f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7bcc-3ff8-40b0-8264-0cd678d6ff31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7bcc-3ff8-40b0-8264-0cd678d6ff31.jpg?1",
             "name": "Scourge of the Skyclaves",
             "text": "Kicker {4}{B}\nWhen you cast this spell, if it was kicked, each player loses half their life, rounded up.\nScourge of the Skyclaves's power and toughness are each equal to 20 minus the highest life total among players.",
             "colours": [
@@ -4801,7 +4801,7 @@
         },
         {
             "id": "95ff4a99-0080-5977-8b4f-5dcd15ba63b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093e0b1e-2cd9-4743-9c0e-b8f3fbc41798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093e0b1e-2cd9-4743-9c0e-b8f3fbc41798.jpg?1",
             "name": "Shadow Stinger",
             "text": "Tap another untapped Rogue you control: Shadow Stinger gains deathtouch until end of turn.\nWhenever Shadow Stinger deals combat damage to a player, that player mills three cards. (They put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "c520e095-d4d6-56dc-b770-0ddeb29a38b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52470883-b44d-415b-9324-8074e66f79ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52470883-b44d-415b-9324-8074e66f79ae.jpg?1",
             "name": "Shadows' Verdict",
             "text": "Exile all creatures and planeswalkers with converted mana cost 3 or less from the battlefield and all creature and planeswalker cards with converted mana cost 3 or less from all graveyards.",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "4d56da12-590e-5994-b4ce-1a1927a380c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bbc0e7-48ce-41e2-a014-1f2eb0427550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bbc0e7-48ce-41e2-a014-1f2eb0427550.jpg?1",
             "name": "Skyclave Shade",
             "text": "Kicker {2}{B}\nSkyclave Shade can't block.\nIf Skyclave Shade was kicked, it enters the battlefield with two +1/+1 counters on it.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if Skyclave Shade is in your graveyard and it's your turn, you may cast it from your graveyard this turn.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "6c9b17b7-87a7-5e41-9f83-e7831bf97c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27fcfc5-a1a9-4b21-8240-2ed6346c64e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27fcfc5-a1a9-4b21-8240-2ed6346c64e1.jpg?1",
             "name": "Skyclave Shadowcat",
             "text": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Skyclave Shadowcat.\nWhenever a creature you control with a +1/+1 counter on it dies, draw a card.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "8c964741-16ec-54eb-8fc7-1ddccd9adf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fd304-d8e4-4ba4-ab0e-2ebeebea8fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fd304-d8e4-4ba4-ab0e-2ebeebea8fdd.jpg?1",
             "name": "A-Skyclave Shadowcat",
             "text": "",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "672fcb99-8a44-551e-b079-eef0c3c5f024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fb07b-0f70-403b-be8b-b5217f12e671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fb07b-0f70-403b-be8b-b5217f12e671.jpg?1",
             "name": "Soul Shatter",
             "text": "Each opponent sacrifices a creature or planeswalker with the highest converted mana cost among creatures and planeswalkers they control.",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "7c0bc355-f965-5ace-b176-c572e1ec2612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3f531a-ce45-4cba-be24-6db749e38abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3f531a-ce45-4cba-be24-6db749e38abd.jpg?1",
             "name": "Subtle Strike",
             "text": "Choose one or both \u2014\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "8f1eecc2-d5c5-5284-ba45-740b1c155bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331bf97d-f447-4c68-bfc7-2bb593106d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331bf97d-f447-4c68-bfc7-2bb593106d66.jpg?1",
             "name": "Taborax, Hope's Demise",
             "text": "Flying\nTaborax, Hope's Demise has lifelink as long as it has five or more +1/+1 counters on it.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on Taborax. If that creature was a Cleric, you may draw a card. If you do, you lose 1 life.",
             "colours": [
@@ -5080,7 +5080,7 @@
         },
         {
             "id": "8571832c-1faa-501b-8f7c-20ea14b7bf53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd037e51-9088-4145-8289-00a86fb72ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd037e51-9088-4145-8289-00a86fb72ca1.jpg?1",
             "name": "Thwart the Grave",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nReturn target creature card and up to one target Cleric, Rogue, Warrior, or Wizard creature card from your graveyard to the battlefield.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "2caff408-bba3-5572-9091-cecf1f128b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15852d4-2c79-4841-bb65-6661d88fdfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15852d4-2c79-4841-bb65-6661d88fdfab.jpg?1",
             "name": "Vanquish the Weak",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "c097250b-2e07-5484-8507-5e9f075b244e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg?1",
             "name": "Zof Consumption // Zof Bloodbog",
             "text": "Each opponent loses 4 life and you gain 4 life.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "ca78ebc5-2b25-5141-8fcf-efbc71fb333b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg?1",
             "name": "Zof Consumption // Zof Bloodbog",
             "text": "Zof Bloodbog enters the battlefield tapped.\n{T}: Add {B}.\n\n\nSorcery\n{4}{B}{B}",
             "colours": [],
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "3408090b-fa31-545e-8714-a4b850deb21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5ad1c8-3d70-43ed-9539-2aa6289c5c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5ad1c8-3d70-43ed-9539-2aa6289c5c4a.jpg?1",
             "name": "Akoum Hellhound",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Akoum Hellhound gets +2/+2 until end of turn.",
             "colours": [
@@ -5243,7 +5243,7 @@
         },
         {
             "id": "d57817ff-61f3-52df-b3dd-f7209909467c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg?1",
             "name": "Akoum Warrior // Akoum Teeth",
             "text": "Trample\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "09d8b7ad-bd05-5db3-9a4e-5417a42073d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg?1",
             "name": "Akoum Warrior // Akoum Teeth",
             "text": "Akoum Teeth enters the battlefield tapped.\n{T}: Add {R}.\n\n\nWarrior\n{5}{R}",
             "colours": [],
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "d1a1ad66-98f2-52b0-80d9-cc1ab0eaf49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8685c8e-935f-49f2-acf2-8e3c41c5b330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8685c8e-935f-49f2-acf2-8e3c41c5b330.jpg?1",
             "name": "Ardent Electromancer",
             "text": "When Ardent Electromancer enters the battlefield, add {R} for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "24f6a2c0-f421-58b1-8e2a-f902af60ffd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516cf97-805f-4a21-a4c6-2d6e55865336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516cf97-805f-4a21-a4c6-2d6e55865336.jpg?1",
             "name": "Cinderclasm",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nCinderclasm deals 1 damage to each creature. If it was kicked, it deals 2 damage to each creature instead.",
             "colours": [
@@ -5375,7 +5375,7 @@
         },
         {
             "id": "577e0ed1-a830-51d7-869c-09332f00f05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492d77e5-acc6-41b8-8930-f39d69234919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492d77e5-acc6-41b8-8930-f39d69234919.jpg?1",
             "name": "Cleansing Wildfire",
             "text": "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle their library.\nDraw a card.",
             "colours": [
@@ -5407,7 +5407,7 @@
         },
         {
             "id": "60a47f13-ed69-5cfd-a0a4-2015793bfc88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30084dc1-f501-4b7c-972d-1a3b9137083a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30084dc1-f501-4b7c-972d-1a3b9137083a.jpg?1",
             "name": "Expedition Champion",
             "text": "Expedition Champion gets +2/+0 as long as you control another Warrior.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "de599aa8-838e-5e2a-b9b3-b46ba844d7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca657846-f352-4ac4-b2b3-d0ced6607163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca657846-f352-4ac4-b2b3-d0ced6607163.jpg?1",
             "name": "Fireblade Charger",
             "text": "As long as Fireblade Charger is equipped, it has haste.\nWhen Fireblade Charger dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -5477,7 +5477,7 @@
         },
         {
             "id": "283ce812-3533-5846-8445-5ffccecd2ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa10a18-5059-46ab-9983-0ea78b507331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa10a18-5059-46ab-9983-0ea78b507331.jpg?1",
             "name": "Fissure Wizard",
             "text": "When Fissure Wizard enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "fdbb5212-a128-5df1-b366-c37544d24b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83962b-445a-4b44-ad8a-fada2c0a15b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83962b-445a-4b44-ad8a-fada2c0a15b8.jpg?1",
             "name": "Goma Fada Vanguard",
             "text": "Whenever Goma Fada Vanguard attacks, target creature an opponent controls with power less than or equal to the number of Warriors you control can't block this turn.",
             "colours": [
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "5b32081e-f78d-5f3b-80a4-c4f5c8a9967f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7762d48f-9088-4856-a0b0-cbf62540caf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7762d48f-9088-4856-a0b0-cbf62540caf5.jpg?1",
             "name": "A-Goma Fada Vanguard",
             "text": "",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "789a9e29-9514-5da2-a1e8-d483e95f4979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b310b01-f9cb-48ce-8af3-5957d3abf098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b310b01-f9cb-48ce-8af3-5957d3abf098.jpg?1",
             "name": "Grotag Bug-Catcher",
             "text": "Trample\nWhenever Grotag Bug-Catcher attacks, it gets +1/+0 until end of turn for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "16f880fa-f909-5a7f-892c-182972cffc78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0568341b-f972-407f-92ce-1b7c9ef742f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0568341b-f972-407f-92ce-1b7c9ef742f6.jpg?1",
             "name": "Grotag Night-Runner",
             "text": "Whenever Grotag Night-Runner deals combat damage to a player, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -5651,7 +5651,7 @@
         },
         {
             "id": "fcf5d326-0db8-5e9b-bf16-5e7f5ca2d03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f62bdc-50a0-41a0-ac37-9b0eeb21b6aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f62bdc-50a0-41a0-ac37-9b0eeb21b6aa.jpg?1",
             "name": "Inordinate Rage",
             "text": "Target creature gets +3/+2 until end of turn. Scry 1.",
             "colours": [
@@ -5683,7 +5683,7 @@
         },
         {
             "id": "dd45841b-24e5-56a8-8ac1-ac93b2837915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0885acdc-9b4c-4e28-8785-9e721a27e81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0885acdc-9b4c-4e28-8785-9e721a27e81e.jpg?1",
             "name": "Kargan Intimidator",
             "text": "Cowards can't block Warriors.\n{1}: Choose one that hasn't been chosen this turn \u2014\n\u2022 Kargan Intimidator gets +1/+1 until end of turn.\n\u2022 Target creature becomes a Coward until end of turn.\n\u2022 Target Warrior gains trample until end of turn.",
             "colours": [
@@ -5720,7 +5720,7 @@
         },
         {
             "id": "f28398a2-36d3-54b7-aa01-5cc5422f8f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d4bac-9433-4956-9126-358432c22818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d4bac-9433-4956-9126-358432c22818.jpg?1",
             "name": "A-Kargan Intimidator",
             "text": "",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "8c9a078d-7a7a-5b9c-a195-163136d901ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg?1",
             "name": "Kazuul's Fury // Kazuul's Cliffs",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nKazuul's Fury deals damage equal to the sacrificed creature's power to any target.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "56ce8024-a3fd-51bf-a4fe-b1709b3a8a35",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg?1",
             "name": "Kazuul's Fury // Kazuul's Cliffs",
             "text": "Kazuul's Cliffs enters the battlefield tapped.\n{T}: Add {R}.\n\n\nInstant\n{2}{R}",
             "colours": [],
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "091650a7-76ef-5250-8b67-5215b9242619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847ae75b-1c0f-4d0a-9933-9a302c88dc27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847ae75b-1c0f-4d0a-9933-9a302c88dc27.jpg?1",
             "name": "Leyline Tyrant",
             "text": "Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "5b5ec259-c82f-51b4-8b13-e0e7d7cf2522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8be6570-5b5f-4ffc-a5e5-67d7c41c8caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8be6570-5b5f-4ffc-a5e5-67d7c41c8caa.jpg?1",
             "name": "Magmatic Channeler",
             "text": "As long as there are four or more instant and/or sorcery cards in your graveyard, Magmatic Channeler gets +3/+1.\n{T}, Discard a card: Exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "ac49d8fe-0353-530d-9c30-6c7870b9cf0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1beef2-788b-469b-883b-cf1cca04eeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1beef2-788b-469b-883b-cf1cca04eeff.jpg?1",
             "name": "Molten Blast",
             "text": "Choose one \u2014\n\u2022 Molten Blast deals 2 damage to target creature or planeswalker.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "9ab4ff1f-158e-5f25-aaea-3a442ed95890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5eacd7-aaa7-4720-9794-52e7b098c82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5eacd7-aaa7-4720-9794-52e7b098c82c.jpg?1",
             "name": "Moraug, Fury of Akoum",
             "text": "Each creature you control gets +1/+0 for each time it has attacked this turn.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if it's your main phase, there's an additional combat phase after this phase. At the beginning of that combat, untap all creatures you control.",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "605aebe3-8782-5efd-b7aa-459ea8b93fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb4bc1-6ef9-4015-9f5f-36f51dbac87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb4bc1-6ef9-4015-9f5f-36f51dbac87e.jpg?1",
             "name": "Nahiri's Lithoforming",
             "text": "Sacrifice X lands. For each land sacrificed this way, draw a card. You may play X additional lands this turn. Lands you control enter the battlefield tapped this turn.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "96b800e9-dee2-54b7-8bf4-f665a5daf33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5929c89b-8c61-47f5-a8ec-b64bf41e9d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5929c89b-8c61-47f5-a8ec-b64bf41e9d5b.jpg?1",
             "name": "Pyroclastic Hellion",
             "text": "When Pyroclastic Hellion enters the battlefield, you may return a land you control to its owner's hand. When you do, Pyroclastic Hellion deals 2 damage to each opponent.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "c42e4832-443e-5dae-9e1c-ae10e465cb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540205c-eee8-4db3-8757-710de874b313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540205c-eee8-4db3-8757-710de874b313.jpg?1",
             "name": "Relic Robber",
             "text": "Haste\nWhenever Relic Robber deals combat damage to a player, that player creates a 0/1 colorless Goblin Construct artifact creature token with \"This creature can't block\" and \"At the beginning of your upkeep, this creature deals 1 damage to you.\"",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "340af055-57af-5efe-8e5f-d2e9767471ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e105c546-ce4f-49c7-97ba-ea5fbe70df82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e105c546-ce4f-49c7-97ba-ea5fbe70df82.jpg?1",
             "name": "Rockslide Sorcerer",
             "text": "Whenever you cast an instant, sorcery, or Wizard spell, Rockslide Sorcerer deals 1 damage to any target.",
             "colours": [
@@ -6100,7 +6100,7 @@
         },
         {
             "id": "ac99bc36-28c2-59a7-af7b-152085ec4218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e350e531-1ce1-48dc-b458-c2ace44cad1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e350e531-1ce1-48dc-b458-c2ace44cad1e.jpg?1",
             "name": "A-Rockslide Sorcerer",
             "text": "",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "dbd65728-bba8-536e-a908-5dfa56068dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86572747-8faa-4242-b059-07d11e6be1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86572747-8faa-4242-b059-07d11e6be1cd.jpg?1",
             "name": "Roil Eruption",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nRoil Eruption deals 3 damage to any target. If this spell was kicked, it deals 5 damage instead.",
             "colours": [
@@ -6168,7 +6168,7 @@
         },
         {
             "id": "82ddb9b0-1fd3-5969-8eff-1b4b24db10d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b057eb7-8439-4d26-89df-c345ab2773e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b057eb7-8439-4d26-89df-c345ab2773e1.jpg?1",
             "name": "Roiling Vortex",
             "text": "At the beginning of each player's upkeep, Roiling Vortex deals 1 damage to them.\nWhenever a player casts a spell, if no mana was spent to cast that spell, Roiling Vortex deals 5 damage to that player.\n{R}: Your opponents can't gain life this turn.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "7638da7d-57bd-5d59-bd6c-7bbe2ed788ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3280f0d0-de0d-4f87-a6ef-c941cb7c9784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3280f0d0-de0d-4f87-a6ef-c941cb7c9784.jpg?1",
             "name": "Scavenged Blade",
             "text": "When Scavenged Blade enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {2}{R} ({2}{R}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6236,7 +6236,7 @@
         },
         {
             "id": "bf594864-1a37-5968-8130-20aa03bad92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec9d3eb-4729-49a9-8146-7388ff2629df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec9d3eb-4729-49a9-8146-7388ff2629df.jpg?1",
             "name": "Scorch Rider",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nWhen Scorch Rider enters the battlefield, if it was kicked, it gains haste until end of turn.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "076636d3-9d74-50c0-83fa-5988d64c9f98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6d6bc3-2162-4c2b-a5de-25103e706e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6d6bc3-2162-4c2b-a5de-25103e706e37.jpg?1",
             "name": "Shatterskull Charger",
             "text": "Kicker {2}\nTrample, haste\nIf Shatterskull Charger was kicked, it enters the battlefield with a +1/+1 counter on it.\nAt the beginning of your end step, if Shatterskull Charger doesn't have a +1/+1 counter on it, return it to its owner's hand.",
             "colours": [
@@ -6308,7 +6308,7 @@
         },
         {
             "id": "5af95a50-ea56-5626-9e06-f720399f9368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d311f5f-ad68-48d4-aa5d-66916034ddb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d311f5f-ad68-48d4-aa5d-66916034ddb9.jpg?1",
             "name": "Shatterskull Minotaur",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nHaste",
             "colours": [
@@ -6343,7 +6343,7 @@
         },
         {
             "id": "8475caa4-359c-55b2-8de3-900c40a48468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "Shatterskull Smashing deals X damage divided as you choose among up to two target creatures and/or planeswalkers. If X is 6 or more, Shatterskull Smashing deals twice X damage divided as you choose among them instead.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "5f636702-105c-5538-a3c6-b74a18bf2c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "As Shatterskull, the Hammer Pass enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.\n\n\nSorcery\n{X}{R}{R}",
             "colours": [],
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "b0ab98ac-cbcb-5967-bd9c-9a979f5b7948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf5843a-a01f-4d1c-b8fe-c586d5160f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf5843a-a01f-4d1c-b8fe-c586d5160f6e.jpg?1",
             "name": "Sizzling Barrage",
             "text": "Sizzling Barrage deals 4 damage to target creature that blocked this turn.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "ab2c2f19-8620-5785-9687-76b3838ebc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9103c9-084f-4ad2-8b7b-ca52be97619d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9103c9-084f-4ad2-8b7b-ca52be97619d.jpg?1",
             "name": "Skyclave Geopede",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Geopede gets +2/+2 until end of turn.",
             "colours": [
@@ -6477,7 +6477,7 @@
         },
         {
             "id": "37d01d0d-f2a5-5c8f-b4ec-c52dddf2a5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c9e8c-7808-49d0-82c1-72d5b835f51c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c9e8c-7808-49d0-82c1-72d5b835f51c.jpg?1",
             "name": "Sneaking Guide",
             "text": "{2}, {T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "00810124-9bb5-5981-8385-941cb2783a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg?1",
             "name": "Song-Mad Treachery // Song-Mad Ruins",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6544,7 +6544,7 @@
         },
         {
             "id": "214bc31f-aba3-56b9-b2dc-028759edf38e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg?1",
             "name": "Song-Mad Treachery // Song-Mad Ruins",
             "text": "Song-Mad Ruins enters the battlefield tapped.\n{T}: Add {R}.\n\n\nSorcery\n{3}{R}{R}",
             "colours": [],
@@ -6574,7 +6574,7 @@
         },
         {
             "id": "b00297e5-063f-59fc-b284-5ef2dce4aff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1",
             "name": "Spikefield Hazard // Spikefield Cave",
             "text": "Spikefield Hazard deals 1 damage to any target. If a permanent dealt damage this way would die this turn, exile it instead.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "d0566eb7-d5b9-57d5-80be-195dbd71595c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1",
             "name": "Spikefield Hazard // Spikefield Cave",
             "text": "Spikefield Cave enters the battlefield tapped.\n{T}: Add {R}.\n\n\nInstant\n{R}",
             "colours": [],
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "e7d3cac3-b017-5e22-b6f5-e984ae9cb716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f26493-812f-4c14-91c4-d2ab549a7b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f26493-812f-4c14-91c4-d2ab549a7b8a.jpg?1",
             "name": "Spitfire Lagac",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Spitfire Lagac deals 1 damage to each opponent.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "aa44fa15-47cc-511d-94d0-486de9a9e616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87f4637-1ad3-4d61-98ff-98c0b0be46a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87f4637-1ad3-4d61-98ff-98c0b0be46a1.jpg?1",
             "name": "Synchronized Spellcraft",
             "text": "Synchronized Spellcraft deals 4 damage to target creature and X damage to that creature's controller, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "a1d75fca-fee5-5e09-af9a-8dc1373fc0b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad57c2f3-d9cb-4165-bb39-897b5b12689e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad57c2f3-d9cb-4165-bb39-897b5b12689e.jpg?1",
             "name": "Teeterpeak Ambusher",
             "text": "{2}{R}: Teeterpeak Ambusher gets +2/+0 until end of turn.",
             "colours": [
@@ -6739,7 +6739,7 @@
         },
         {
             "id": "6f7f647e-6e17-529e-aaa3-790c76349d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc671707-4708-44d8-8ec8-d5332599adf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc671707-4708-44d8-8ec8-d5332599adf9.jpg?1",
             "name": "Thundering Rebuke",
             "text": "Thundering Rebuke deals 4 damage to target creature or planeswalker.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "957a05e6-c042-57eb-aaa4-6d32c6c46587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e6de80-3516-426b-8a1b-bda45f8c0cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e6de80-3516-426b-8a1b-bda45f8c0cac.jpg?1",
             "name": "Thundering Sparkmage",
             "text": "When Thundering Sparkmage enters the battlefield, it deals X damage to target creature or planeswalker, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -6806,7 +6806,7 @@
         },
         {
             "id": "f26366bd-0e31-5f33-b023-03f125bf710c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da46103-a14c-4aa2-92fc-fd758335caf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da46103-a14c-4aa2-92fc-fd758335caf4.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "eb3df8ba-df7d-577b-a2a0-927e023b7b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eedf9d-e26c-405c-aee5-1b3493dc5e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eedf9d-e26c-405c-aee5-1b3493dc5e9b.jpg?1",
             "name": "Tuktuk Rubblefort",
             "text": "Defender, reach\nCreatures you control have haste.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "f3a5ac3a-7540-536a-8cfb-a9eb2ef6791c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6906,7 +6906,7 @@
         },
         {
             "id": "833aa414-f3da-5e3a-8abf-f312610f1820",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Valakut Stoneforge enters the battlefield tapped.\n{T}: Add {R}.\n\n\nInstant\n{2}{R}",
             "colours": [],
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "fe94459b-9c97-5302-9cde-1a2fdaf11e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cb7bf6-9c7c-4e62-a678-7b75862e2f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cb7bf6-9c7c-4e62-a678-7b75862e2f64.jpg?1",
             "name": "Valakut Exploration",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, exile the top card of your library. You may play that card for as long as it remains exiled.\nAt the beginning of your end step, if there are cards exiled with Valakut Exploration, put them into their owner's graveyard, then Valakut Exploration deals that much damage to each opponent.",
             "colours": [
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "a7160591-6b7c-5f1c-bf98-820b3c7b01da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00f8ab0-61cd-4721-b974-a2516da77d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00f8ab0-61cd-4721-b974-a2516da77d39.jpg?1",
             "name": "Wayward Guide-Beast",
             "text": "Trample, haste\nWhenever Wayward Guide-Beast deals combat damage to a player, return a land you control to its owner's hand.",
             "colours": [
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "68d76993-3cf0-5f43-9ae6-4fba76e99119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50f988-da46-4b9b-9cc5-78497df2df8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50f988-da46-4b9b-9cc5-78497df2df8b.jpg?1",
             "name": "Adventure Awaits",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, draw a card.",
             "colours": [
@@ -7040,7 +7040,7 @@
         },
         {
             "id": "d9464359-036d-515d-9bd1-8888f97e722c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe08e59-fdc4-436f-b05c-6ad386c46310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe08e59-fdc4-436f-b05c-6ad386c46310.jpg?1",
             "name": "Ancient Greenwarden",
             "text": "Reach\nYou may play lands from your graveyard.\nIf a land entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -7076,7 +7076,7 @@
         },
         {
             "id": "4f0e2df4-7c35-5fab-a10f-b1314ce2b456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74943390-d25f-47cb-90bb-cbf70c87f4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74943390-d25f-47cb-90bb-cbf70c87f4a2.jpg?1",
             "name": "Ashaya, Soul of the Wild",
             "text": "Ashaya, Soul of the Wild's power and toughness are each equal to the number of lands you control.\nNontoken creatures you control are Forest lands in addition to their other types. (They're still affected by summoning sickness.)",
             "colours": [
@@ -7114,7 +7114,7 @@
         },
         {
             "id": "5fc410b3-69aa-5409-aad0-bfa838811d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg?1",
             "name": "Bala Ged Recovery // Bala Ged Sanctuary",
             "text": "Return target card from your graveyard to your hand.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "5a27401e-98b0-5056-9f43-265ebdb570aa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg?1",
             "name": "Bala Ged Recovery // Bala Ged Sanctuary",
             "text": "Bala Ged Sanctuary enters the battlefield tapped.\n{T}: Add {G}.\n\n\nSorcery\n{2}{G}",
             "colours": [],
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "7b8674e8-659b-5ca6-98b1-2db2734a037e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fc2dfd-85b0-4add-be18-b39549235921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fc2dfd-85b0-4add-be18-b39549235921.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "5cbec624-a214-5810-900e-ec2069421337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b04160c-89a7-4dcd-b05d-5dc846824d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b04160c-89a7-4dcd-b05d-5dc846824d64.jpg?1",
             "name": "Canopy Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Canopy Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "542ddbd7-39b1-56ea-b2a3-4b446ed8ec2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab62382d-2dc9-4a60-b031-c845ebad0357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab62382d-2dc9-4a60-b031-c845ebad0357.jpg?1",
             "name": "Cragplate Baloth",
             "text": "Kicker {2}{G}\nThis spell can't be countered.\nHexproof, haste\nIf Cragplate Baloth was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -7280,7 +7280,7 @@
         },
         {
             "id": "cac64ccf-e714-5154-9f02-3058c8e6e327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b1b4a2-52a7-4fcd-aa96-f7d9e459657b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b1b4a2-52a7-4fcd-aa96-f7d9e459657b.jpg?1",
             "name": "Dauntless Survivor",
             "text": "When Dauntless Survivor enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -7315,7 +7315,7 @@
         },
         {
             "id": "7fa3bb33-527a-5dc1-b214-fef991a64fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327289d-eed8-44b1-8495-7172e2b49d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327289d-eed8-44b1-8495-7172e2b49d5f.jpg?1",
             "name": "Gnarlid Colony",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nIf Gnarlid Colony was kicked, it enters the battlefield with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -7349,7 +7349,7 @@
         },
         {
             "id": "ec61c6b8-292b-59bc-a16b-755c284e1cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f644a6-9621-429e-a0a0-4c74d0ecff2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f644a6-9621-429e-a0a0-4c74d0ecff2e.jpg?1",
             "name": "A-Gnarlid Colony",
             "text": "",
             "colours": [
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "07ad0849-a384-579a-b01a-0ecdba840ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2e01e-a143-4b62-8b01-d253fb35c590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2e01e-a143-4b62-8b01-d253fb35c590.jpg?1",
             "name": "Inscription of Abundance",
             "text": "Kicker {2}{G}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player gains X life, where X is the greatest power among creatures they control.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "2bb54e1c-50f3-5f27-8f74-b6a03ab76648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ef641-b08c-42d0-94a5-3054fa7fcebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ef641-b08c-42d0-94a5-3054fa7fcebc.jpg?1",
             "name": "Iridescent Hornbeetle",
             "text": "At the beginning of your end step, create a 1/1 green Insect creature token for each +1/+1 counter you've put on creatures under your control this turn.",
             "colours": [
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "734e5608-3cbc-5bbc-bb43-548b8bd5da3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538103da-aa42-436b-8d1a-8f774d005c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538103da-aa42-436b-8d1a-8f774d005c9a.jpg?1",
             "name": "A-Iridescent Hornbeetle",
             "text": "",
             "colours": [
@@ -7483,7 +7483,7 @@
         },
         {
             "id": "a28fc05a-fbdc-58ea-ae1a-107218664cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea2c17-382a-45e4-ac34-88bf8ba47169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea2c17-382a-45e4-ac34-88bf8ba47169.jpg?1",
             "name": "Joraga Visionary",
             "text": "When Joraga Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -7518,7 +7518,7 @@
         },
         {
             "id": "7116797b-4b94-550c-ba99-3c0d002a4b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Kazandu Mammoth gets +2/+2 until end of turn.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -7554,7 +7554,7 @@
         },
         {
             "id": "7c3af9ec-7098-5de6-b37e-02b0868628a4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Kazandu Valley enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElephant\n{1}{G}{G}",
             "colours": [],
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "0d2dd7a9-908d-575e-b391-3033aae3da6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d3f4a-ef83-454e-b8a1-1fc5d5f44be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d3f4a-ef83-454e-b8a1-1fc5d5f44be8.jpg?1",
             "name": "Kazandu Nectarpot",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "3630473b-9aaf-59f0-9075-3da04b90b44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afdfe5aa-8b15-4a89-a22a-03baf6afa4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afdfe5aa-8b15-4a89-a22a-03baf6afa4e7.jpg?1",
             "name": "Kazandu Stomper",
             "text": "Trample\nWhen Kazandu Stomper enters the battlefield, return up to two lands you control to their owner's hand.",
             "colours": [
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "70e2e9da-30ca-5b38-9738-01c84cf51dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg?1",
             "name": "Khalni Ambush // Khalni Territory",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "27426996-767f-545a-808b-1272003b645f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg?1",
             "name": "Khalni Ambush // Khalni Territory",
             "text": "Khalni Territory enters the battlefield tapped.\n{T}: Add {G}.\n\n\nInstant\n{2}{G}",
             "colours": [],
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "85245ba1-faf6-5b7c-925c-5d9056cf20d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b759f0-901f-4be3-93fa-224609b08d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b759f0-901f-4be3-93fa-224609b08d48.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "416ccd41-0cfc-5235-9bc4-a1233a6a12bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42914fd9-e56e-4c3e-a445-fdfa45a45178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42914fd9-e56e-4c3e-a445-fdfa45a45178.jpg?1",
             "name": "Might of Murasa",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nTarget creature gets +3/+3 until end of turn. If this spell was kicked, that creature gets +5/+5 until end of turn instead.",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "9c0927bd-cea6-55ef-a7d6-ca9322b1773a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe1c5b2-4356-41ae-ab7e-ad9fc835a911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe1c5b2-4356-41ae-ab7e-ad9fc835a911.jpg?1",
             "name": "Murasa Brute",
             "text": "",
             "colours": [
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "24c268af-4642-5f2b-bf97-48bd9cb0b591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53472b7-53da-4833-b7f9-204706dfb721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53472b7-53da-4833-b7f9-204706dfb721.jpg?1",
             "name": "Murasa Sproutling",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Murasa Sproutling enters the battlefield, if it was kicked, return target card with a kicker ability from your graveyard to your hand.",
             "colours": [
@@ -7856,7 +7856,7 @@
         },
         {
             "id": "2ea8424b-129c-5b24-a638-ae36bbc03474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd37ea0e-ff72-4522-aa5b-d46bff832a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd37ea0e-ff72-4522-aa5b-d46bff832a34.jpg?1",
             "name": "Nissa's Zendikon",
             "text": "Enchant land\nEnchanted land is a 4/4 Elemental creature with reach and haste. It's still a land.\nWhen enchanted land dies, return that card to its owner's hand.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "6ed2eb75-a324-515e-9ee4-6a3a10d1efbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2ad967-dd77-4c3a-b53c-2929ecf7750f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2ad967-dd77-4c3a-b53c-2929ecf7750f.jpg?1",
             "name": "Oran-Rief Ooze",
             "text": "When Oran-Rief Ooze enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Oran-Rief Ooze attacks, put a +1/+1 counter on each attacking creature with a +1/+1 counter on it.",
             "colours": [
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "27fc283e-887b-5c06-a6b0-b37a975252d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52abea40-2736-49a8-a372-16b7b93d510a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52abea40-2736-49a8-a372-16b7b93d510a.jpg?1",
             "name": "A-Oran-Rief Ooze",
             "text": "",
             "colours": [
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "6f1d3541-b056-5b97-9ffa-fe283eb53e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe3fab-6d13-4603-8a21-8a3c2a0d9e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe3fab-6d13-4603-8a21-8a3c2a0d9e08.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -7991,7 +7991,7 @@
         },
         {
             "id": "efa6966e-1b65-59fc-bd2f-1075b3052577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805faf2e-97dc-4b77-bc02-a4cae980f041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805faf2e-97dc-4b77-bc02-a4cae980f041.jpg?1",
             "name": "Reclaim the Wastes",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nSearch your library for a basic land card, reveal it, put it into your hand, then shuffle your library. If this spell was kicked, search your library for two basic land cards instead of one.",
             "colours": [
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "7ef6cffb-335a-5831-8319-20b6a020f1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa259096-b24f-414c-af59-301bed4b4627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa259096-b24f-414c-af59-301bed4b4627.jpg?1",
             "name": "Roiling Regrowth",
             "text": "Sacrifice a land. Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "fc03eaaa-bdfa-5121-9ffd-9e1d250382df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e781d6ad-950e-49bf-9645-e2354086ae49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e781d6ad-950e-49bf-9645-e2354086ae49.jpg?1",
             "name": "Scale the Heights",
             "text": "Put a +1/+1 counter on up to one target creature. You gain 2 life. You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -8089,7 +8089,7 @@
         },
         {
             "id": "7930cea5-8e5a-521d-92ad-0ac5e89b604c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f42823-8a48-4b81-a037-664ba1c69f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f42823-8a48-4b81-a037-664ba1c69f29.jpg?1",
             "name": "Scute Swarm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 1/1 green Insect creature token. If you control six or more lands, create a token that's a copy of Scute Swarm instead.",
             "colours": [
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "60fc1701-a723-58f0-96de-c21c9e0c98bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965a54b-8b22-418c-9a0d-bf154932f2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965a54b-8b22-418c-9a0d-bf154932f2e2.jpg?1",
             "name": "Skyclave Pick-Axe",
             "text": "When Skyclave Pick-Axe enters the battlefield, attach it to target creature you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {2}{G}",
             "colours": [
@@ -8161,7 +8161,7 @@
         },
         {
             "id": "e0d350f2-2e72-583d-8123-dd28a4a32928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d822730-6d81-4dbc-a3c3-ce96d29a1078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d822730-6d81-4dbc-a3c3-ce96d29a1078.jpg?1",
             "name": "Springmantle Cleric",
             "text": "Springmantle Cleric enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "0e34b99a-5e5d-5187-b9eb-5d6cf4030641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090b3da4-c942-480e-9997-bb9c20e8d62d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090b3da4-c942-480e-9997-bb9c20e8d62d.jpg?1",
             "name": "Strength of Solidarity",
             "text": "Choose target creature you control. Put a +1/+1 counter on it for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -8228,7 +8228,7 @@
         },
         {
             "id": "6a084be6-b0db-5521-afbd-c772afa72c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7e4f99-ece4-473e-b712-40e4c53558e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7e4f99-ece4-473e-b712-40e4c53558e8.jpg?1",
             "name": "Swarm Shambler",
             "text": "Swarm Shambler enters the battlefield with a +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.\n{1}, {T}: Put a +1/+1 counter on Swarm Shambler.",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "b5d84c08-0d16-5520-a819-1e11dff1cca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d6020-6767-406c-bf28-6b3e9ae72f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d6020-6767-406c-bf28-6b3e9ae72f50.jpg?1",
             "name": "Tajuru Blightblade",
             "text": "Deathtouch",
             "colours": [
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "cbcc15f4-7db2-5e22-866c-362f916e11ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a045dd0f-953a-4022-8f29-0758f2b6ccaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a045dd0f-953a-4022-8f29-0758f2b6ccaa.jpg?1",
             "name": "Tajuru Paragon",
             "text": "Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.\nKicker {3}\nWhen Tajuru Paragon enters the battlefield, if it was kicked, reveal the top six cards of your library. You may put a card that shares a creature type with it from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "38f41bd1-411e-551a-a05c-4bea756120d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1894cf9-7d53-4b7e-aaae-8db42bdd8e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1894cf9-7d53-4b7e-aaae-8db42bdd8e49.jpg?1",
             "name": "Tajuru Snarecaster",
             "text": "Reach",
             "colours": [
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "9b9ee2cb-4f20-573a-86d4-fe43209a310f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg?1",
             "name": "Tangled Florahedron // Tangled Vale",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "6f56a117-5df1-50b0-be53-c18842f847f3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg?1",
             "name": "Tangled Florahedron // Tangled Vale",
             "text": "Tangled Vale enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElemental\n{1}{G}",
             "colours": [],
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "737c795d-701c-544c-9779-3a05489ff2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f8996-bf72-4e55-944f-5b8202b6068c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f8996-bf72-4e55-944f-5b8202b6068c.jpg?1",
             "name": "Taunting Arbormage",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nWhen Taunting Arbormage enters the battlefield, if it was kicked, all creatures able to block target creature this turn do so.",
             "colours": [
@@ -8470,7 +8470,7 @@
         },
         {
             "id": "5447072f-af3d-5a7f-a8d6-207329848d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e0f725c-8d1f-47ff-ad81-a5007199a5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e0f725c-8d1f-47ff-ad81-a5007199a5e2.jpg?1",
             "name": "Territorial Scythecat",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Territorial Scythecat.",
             "colours": [
@@ -8506,7 +8506,7 @@
         },
         {
             "id": "4a4817f5-7f77-56f0-86a9-57d859ae87ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b6922-2584-43e1-98d4-e722e7c9393c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b6922-2584-43e1-98d4-e722e7c9393c.jpg?1",
             "name": "Turntimber Ascetic",
             "text": "When Turntimber Ascetic enters the battlefield, you gain 3 life.",
             "colours": [
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "01d98db6-acc5-5fed-ad07-050bf80c26ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. If that card has converted mana cost 3 or less, it enters with three additional +1/+1 counters on it. Put the rest on the bottom of your library in a random order.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "b37eea80-116a-5b82-86c6-51962f4eb7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "As Turntimber, Serpentine Wood enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.\n\n\nSorcery\n{4}{G}{G}{G}",
             "colours": [],
@@ -8607,7 +8607,7 @@
         },
         {
             "id": "fd9fea99-a02c-5357-bc14-f8c9575d1d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg?1",
             "name": "Vastwood Fortification // Vastwood Thicket",
             "text": "Put a +1/+1 counter on target creature.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -8639,7 +8639,7 @@
         },
         {
             "id": "e4bff9ce-8ce4-5e04-8884-fb433696f4b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg?1",
             "name": "Vastwood Fortification // Vastwood Thicket",
             "text": "Vastwood Thicket enters the battlefield tapped.\n{T}: Add {G}.\n\n\nInstant\n{G}",
             "colours": [],
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "a918645b-4f30-5005-9f13-d51aab298868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6974363c-0d0d-4270-a25e-ab84b0c03f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6974363c-0d0d-4270-a25e-ab84b0c03f4e.jpg?1",
             "name": "Vastwood Surge",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nSearch your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library. If this spell was kicked, put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -8701,7 +8701,7 @@
         },
         {
             "id": "40045e21-d8ed-5a18-ace0-ac1216ef5405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e524ddf0-9a2f-4c1c-ae72-4b5b48f55645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e524ddf0-9a2f-4c1c-ae72-4b5b48f55645.jpg?1",
             "name": "Veteran Adventurer",
             "text": "Veteran Adventurer is also a Cleric, Rogue, Warrior, and Wizard.\nThis spell costs {1} less to cast for each creature in your party.\nVigilance",
             "colours": [
@@ -8735,7 +8735,7 @@
         },
         {
             "id": "aadf7487-1cdd-5271-a3e2-a83b7bf1b7ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6f9984-dec7-4a1f-91d6-1e85b5df5e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6f9984-dec7-4a1f-91d6-1e85b5df5e4c.jpg?1",
             "name": "Vine Gecko",
             "text": "The first kicked spell you cast each turn costs {1} less to cast.\nWhenever you cast a kicked spell, put a +1/+1 counter on Vine Gecko.",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "92640531-043c-5de7-9455-298c8715cf7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e42511-f653-4a6f-a5d4-50e21dfc8077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e42511-f653-4a6f-a5d4-50e21dfc8077.jpg?1",
             "name": "Akiri, Fearless Voyager",
             "text": "Whenever you attack a player with one or more equipped creatures, draw a card.\n{W}: You may unattach an Equipment from a creature you control. If you do, tap that creature and it gains indestructible until end of turn.",
             "colours": [
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "74e7d5ff-5e9e-56e0-ba85-6e74861f81cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc448f6-a7fe-47c4-ac7c-385a77326469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc448f6-a7fe-47c4-ac7c-385a77326469.jpg?1",
             "name": "Brushfire Elemental",
             "text": "Haste\nBrushfire Elemental can't be blocked by creatures with power 2 or less.\nLandfall \u2014 Whenever a land enters the battlefield under your control, Brushfire Elemental gets +2/+2 until end of turn.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "14fdfbef-e73e-5a01-bc5c-8fffc2693d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953db280-6999-4b91-bc40-c6e7f7dd13ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953db280-6999-4b91-bc40-c6e7f7dd13ef.jpg?1",
             "name": "Cleric of Life's Bond",
             "text": "Whenever another Cleric enters the battlefield under your control, you gain 1 life.\nWhenever you gain life for the first time each turn, put a +1/+1 counter on Cleric of Life's Bond.",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "b7a2baeb-e50b-584e-8225-9797048ebaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd227384-e0e3-40ce-98bb-8b7cf1900ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd227384-e0e3-40ce-98bb-8b7cf1900ad7.jpg?1",
             "name": "Grakmaw, Skyclave Ravager",
             "text": "Grakmaw, Skyclave Ravager enters the battlefield with three +1/+1 counters on it.\nWhenever another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on Grakmaw.\nWhen Grakmaw dies, create an X/X black and green Hydra creature token, where X is the number of +1/+1 counters on Grakmaw.",
             "colours": [
@@ -8927,7 +8927,7 @@
         },
         {
             "id": "f3434acf-7796-572c-a889-487c84cf7948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f921dca-ce93-42d1-87b1-149973558467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f921dca-ce93-42d1-87b1-149973558467.jpg?1",
             "name": "Kargan Warleader",
             "text": "Other Warriors you control get +1/+1.",
             "colours": [
@@ -8966,7 +8966,7 @@
         },
         {
             "id": "dbc5f0ea-7bed-5d69-a639-a2ee6c8aa78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d44c40-cdd0-42d5-a250-e7d95ae926c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d44c40-cdd0-42d5-a250-e7d95ae926c0.jpg?1",
             "name": "A-Kargan Warleader",
             "text": "",
             "colours": [
@@ -9002,7 +9002,7 @@
         },
         {
             "id": "866edde7-ea78-5b96-aed9-e7d3c5f980aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6bc333-79c0-4de8-9874-80f2254f9ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6bc333-79c0-4de8-9874-80f2254f9ad2.jpg?1",
             "name": "Kaza, Roil Chaser",
             "text": "Flying, haste\n{T}: The next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of Wizards you control as this ability resolves.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "39ef7d4c-e9ec-507b-8c3b-aadb90a43490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b66956-82e1-402f-9088-2201bdc0d4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b66956-82e1-402f-9088-2201bdc0d4b8.jpg?1",
             "name": "Linvala, Shield of Sea Gate",
             "text": "Flying\nAt the beginning of combat on your turn, if you have a full party, choose target nonland permanent an opponent controls. Until your next turn, it can't attack or block, and its activated abilities can't be activated.\nSacrifice Linvala: Choose hexproof or indestructible. Creatures you control gain that ability until end of turn.",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "f05ab4a8-f4ec-5406-969e-9951be880fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31a81e8-df0e-4540-93c1-c30c31ea9be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31a81e8-df0e-4540-93c1-c30c31ea9be9.jpg?1",
             "name": "Lullmage's Familiar",
             "text": "{T}: Add {G} or {U}.\nWhenever you cast a kicked spell, you gain 2 life.",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "b292a2a1-fee9-5725-82d3-09ccb7d519ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a445dc-3aea-4281-a145-0ab3a28ec6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a445dc-3aea-4281-a145-0ab3a28ec6c6.jpg?1",
             "name": "Moss-Pit Skeleton",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nIf Moss-Pit Skeleton was kicked, it enters the battlefield with three +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on a creature you control, if Moss-Pit Skeleton is in your graveyard, you may put Moss-Pit Skeleton on top of your library.",
             "colours": [
@@ -9157,7 +9157,7 @@
         },
         {
             "id": "7750b55c-d734-5d12-86f4-f86fafde4a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd748df0-b7af-4438-b567-5fabe0731438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd748df0-b7af-4438-b567-5fabe0731438.jpg?1",
             "name": "A-Moss-Pit Skeleton",
             "text": "",
             "colours": [
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "903377a4-e1aa-57f9-a479-e6a9e9f21368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b3b78-9bdc-449b-82a9-c2fc3dd7f120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b3b78-9bdc-449b-82a9-c2fc3dd7f120.jpg?1",
             "name": "Murasa Rootgrazer",
             "text": "Vigilance\n{T}: You may put a basic land card from your hand onto the battlefield.\n{T}: Return target basic land you control to its owner's hand.",
             "colours": [
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "42158c39-091a-5392-9379-823e17cf011c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408be425-b8a6-4c03-b2a6-7ff7bd6555e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408be425-b8a6-4c03-b2a6-7ff7bd6555e0.jpg?1",
             "name": "Nahiri, Heir of the Ancients",
             "text": "+1: Create a 1/1 white Kor Warrior creature token. You may attach an Equipment you control to it.\n\u22122: Look at the top six cards of your library. You may reveal a Warrior or Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Nahiri, Heir of the Ancients deals damage to target creature or planeswalker equal to twice the number of Equipment you control.",
             "colours": [
@@ -9269,7 +9269,7 @@
         },
         {
             "id": "97555cf3-7fe0-5f54-b580-112bbb3437b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e33233-fc29-489b-bcf4-fa7d771db0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e33233-fc29-489b-bcf4-fa7d771db0cc.jpg?1",
             "name": "A-Nahiri, Heir of the Ancients",
             "text": "",
             "colours": [
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "143d09da-3fe5-588d-a004-1e1a6dd69ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d69f943-d474-47c0-bc6b-1b247a5dd6f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d69f943-d474-47c0-bc6b-1b247a5dd6f3.jpg?1",
             "name": "Nissa of Shadowed Boughs",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a loyalty counter on Nissa of Shadowed Boughs.\n+1: Untap target land you control. You may have it become a 3/3 Elemental creature with haste and menace until end of turn. It's still a land.\n\u22125: You may put a creature card with converted mana cost less than or equal to the number of lands you control onto the battlefield from your hand or graveyard with two +1/+1 counters on it.",
             "colours": [
@@ -9346,7 +9346,7 @@
         },
         {
             "id": "815c6d28-81bb-5c0d-99cb-e0dd7bced29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4fb50c-a81f-44d3-93c5-fa9a0b37f617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4fb50c-a81f-44d3-93c5-fa9a0b37f617.jpg?1",
             "name": "Omnath, Locus of Creation",
             "text": "When Omnath, Locus of Creation enters the battlefield, draw a card.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, Omnath deals 4 damage to each opponent and each planeswalker you don't control.",
             "colours": [
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "9d995a92-bc5c-5dcf-87ee-cb1d85cd113b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f5fbd5-b045-4da7-a996-54f163b35b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f5fbd5-b045-4da7-a996-54f163b35b8d.jpg?1",
             "name": "A-Omnath, Locus of Creation",
             "text": "",
             "colours": [
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "c17b8231-1fbd-5c52-8653-ed1b31b361fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336c8bf-fcad-41f9-9041-80b8aa3cd79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336c8bf-fcad-41f9-9041-80b8aa3cd79a.jpg?1",
             "name": "Orah, Skyclave Hierophant",
             "text": "Lifelink\nWhenever Orah, Skyclave Hierophant or another Cleric you control dies, return target Cleric card with lesser converted mana cost from your graveyard to the battlefield.",
             "colours": [
@@ -9473,7 +9473,7 @@
         },
         {
             "id": "20fcd345-f48e-5cc7-9902-be2f723bd386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af88c9-70ca-484c-bddf-b705e0ea7bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af88c9-70ca-484c-bddf-b705e0ea7bc7.jpg?1",
             "name": "Phylath, World Sculptor",
             "text": "When Phylath, World Sculptor enters the battlefield, create a 0/1 green Plant creature token for each basic land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, put four +1/+1 counters on target Plant you control.",
             "colours": [
@@ -9513,7 +9513,7 @@
         },
         {
             "id": "cde3abea-d57f-5aeb-8305-38b61335d21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c4a2f5-b942-4c94-b28c-e04d0609cfb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c4a2f5-b942-4c94-b28c-e04d0609cfb3.jpg?1",
             "name": "A-Phylath, World Sculptor",
             "text": "",
             "colours": [
@@ -9550,7 +9550,7 @@
         },
         {
             "id": "da12cbef-13f4-5e21-a381-f03bebe067c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af484140-57d6-4505-9960-5e7b0306cc9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af484140-57d6-4505-9960-5e7b0306cc9b.jpg?1",
             "name": "Ravager's Mace",
             "text": "When Ravager's Mace enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0 for each creature in your party and has menace. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nEquip {2}{B}{R}",
             "colours": [
@@ -9586,7 +9586,7 @@
         },
         {
             "id": "f11616b0-805e-5201-843b-cc806c9ab304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d73c9c4-8955-499f-8f87-6500b35b4977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d73c9c4-8955-499f-8f87-6500b35b4977.jpg?1",
             "name": "Soaring Thought-Thief",
             "text": "Flash\nFlying\nAs long as an opponent has eight or more cards in their graveyard, Rogues you control get +1/+0.\nWhenever one or more Rogues you control attack, each opponent mills two cards.",
             "colours": [
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "985471ec-473a-5032-a104-395da40a8589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3b1ef0-a653-4adb-8112-82d4822446b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3b1ef0-a653-4adb-8112-82d4822446b4.jpg?1",
             "name": "Spoils of Adventure",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nYou gain 3 life and draw three cards.",
             "colours": [
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "49f713e2-972a-5a50-a250-ccc04220bd08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb979cfc-3e5b-42c9-b78d-584c274ed912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb979cfc-3e5b-42c9-b78d-584c274ed912.jpg?1",
             "name": "Umara Mystic",
             "text": "Flying\nWhenever you cast an instant, sorcery, or Wizard spell, Umara Mystic gets +2/+0 until end of turn.",
             "colours": [
@@ -9694,7 +9694,7 @@
         },
         {
             "id": "4acf2687-ac7d-57cf-adf3-9c18a94a2753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559ebc64-3412-413f-8ef3-f058a0d60f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559ebc64-3412-413f-8ef3-f058a0d60f33.jpg?1",
             "name": "A-Umara Mystic",
             "text": "",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "d49a3cb8-6f6f-5339-bd4e-8cf85e03294f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752a2aa9-40ed-4c64-b945-bc6fec606b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752a2aa9-40ed-4c64-b945-bc6fec606b7b.jpg?1",
             "name": "Verazol, the Split Current",
             "text": "Verazol, the Split Current enters the battlefield with a +1/+1 counter on it for each mana spent to cast it.\nWhenever you cast a kicked spell, you may remove two +1/+1 counters from Verazol. If you do, copy that spell. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -9770,7 +9770,7 @@
         },
         {
             "id": "ca63f098-759e-5d62-b5ee-0db862f41f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12878fbd-dbe5-44bc-9f34-38fd374ec10a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12878fbd-dbe5-44bc-9f34-38fd374ec10a.jpg?1",
             "name": "Yasharn, Implacable Earth",
             "text": "When Yasharn enters the battlefield, search your library for a basic Forest card and a basic Plains card, reveal those cards, put them into your hand, then shuffle your library.\nPlayers can't pay life or sacrifice nonland permanents to cast spells or activate abilities.",
             "colours": [
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "525b57a0-036f-51af-bb73-dd1eb6bd8203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81448c-f87b-4ca1-b951-b359216ab1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81448c-f87b-4ca1-b951-b359216ab1d0.jpg?1",
             "name": "Zagras, Thief of Heartbeats",
             "text": "This spell costs {1} less to cast for each creature in your party.\nFlying, deathtouch, haste\nOther creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "eb9d9c5a-3939-5f33-8781-2389f1383e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfe4fbe-277f-410c-9eee-f7617f4cb850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfe4fbe-277f-410c-9eee-f7617f4cb850.jpg?1",
             "name": "Zareth San, the Trickster",
             "text": "Flash\n{2}{U}{B}, Return an unblocked attacking Rogue you control to its owner's hand: Put Zareth San, the Trickster from your hand onto the battlefield tapped and attacking.\nWhenever Zareth San deals combat damage to a player, you may put target permanent card from that player's graveyard onto the battlefield under your control.",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "b8c785d9-9996-565a-bf1b-f3a3a8e77d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eebf8f67-49d0-42de-a5cc-ad13d19d2c55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eebf8f67-49d0-42de-a5cc-ad13d19d2c55.jpg?1",
             "name": "Cliffhaven Kitesail",
             "text": "When Cliffhaven Kitesail enters the battlefield, attach it to target creature you control.\nEquipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9923,7 +9923,7 @@
         },
         {
             "id": "8c8728b6-c369-5d10-896e-3ec0967bbe1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33568871-dab0-4c09-b9f0-0ae78a46a06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33568871-dab0-4c09-b9f0-0ae78a46a06d.jpg?1",
             "name": "Forsaken Monument",
             "text": "Colorless creatures you control get +2/+2.\nWhenever you tap a permanent for {C}, add an additional {C}.\nWhenever you cast a colorless spell, you gain 2 life.",
             "colours": [],
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "798c7a62-d5cc-51a9-9a7c-c63cdd8f79f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6683416a-5820-4cd0-b28a-60a53239e9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6683416a-5820-4cd0-b28a-60a53239e9ef.jpg?1",
             "name": "Lithoform Engine",
             "text": "{2}, {T}: Copy target activated or triggered ability you control. You may choose new targets for the copy.\n{3}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}, {T}: Copy target permanent spell you control. (The copy becomes a token.)",
             "colours": [],
@@ -9987,7 +9987,7 @@
         },
         {
             "id": "266b4838-deb2-5cdc-88b1-ab16712a30f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1de4-9aba-4145-804d-2072f258af3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1de4-9aba-4145-804d-2072f258af3b.jpg?1",
             "name": "Myriad Construct",
             "text": "Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.",
             "colours": [],
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "d4c8282d-60bf-57bd-9dbc-66e0dc501a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab97a84-fe8c-4986-afd8-3abdcc029f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab97a84-fe8c-4986-afd8-3abdcc029f7f.jpg?1",
             "name": "Relic Amulet",
             "text": "Whenever you cast an instant, sorcery, or Wizard spell, put a charge counter on Relic Amulet.\n{2}, {T}, Remove all charge counters from Relic Amulet: It deals that much damage to target creature.",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "923ad797-50a9-5272-a6b2-058a6b024db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8705e3-0e44-45c9-bcdf-c24507b038fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8705e3-0e44-45c9-bcdf-c24507b038fe.jpg?1",
             "name": "Relic Axe",
             "text": "When Relic Axe enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1. If it's a Warrior, it gets +2/+1 instead.\nEquip {2}",
             "colours": [],
@@ -10078,7 +10078,7 @@
         },
         {
             "id": "530eb0dc-e169-55c1-b844-d300b6516ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b59c75b-d8f8-4f95-9030-ed73c67d988e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b59c75b-d8f8-4f95-9030-ed73c67d988e.jpg?1",
             "name": "Relic Golem",
             "text": "Relic Golem can't attack or block unless an opponent has eight or more cards in their graveyard.\n{2}, {T}: Target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [],
@@ -10109,7 +10109,7 @@
         },
         {
             "id": "427d0306-238a-52d4-b0bd-87973432683e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9ae607-e0bc-4415-ad58-65944848bbe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9ae607-e0bc-4415-ad58-65944848bbe9.jpg?1",
             "name": "Relic Vial",
             "text": "{2}, {T}, Sacrifice a creature: Draw a card.\nAs long as you control a Cleric, Relic Vial has \"Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\"",
             "colours": [],
@@ -10137,7 +10137,7 @@
         },
         {
             "id": "75d703db-274d-5239-82a6-fba47a3fa69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04fd8e8-ee8d-4cb7-87ab-955303c46ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04fd8e8-ee8d-4cb7-87ab-955303c46ece.jpg?1",
             "name": "Sea Gate Colossus",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [],
@@ -10169,7 +10169,7 @@
         },
         {
             "id": "ba20b3d8-eb35-592d-b0d0-afdeb0145108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20259dff-4984-4d0b-aa49-34f3aaf31e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20259dff-4984-4d0b-aa49-34f3aaf31e3a.jpg?1",
             "name": "Skyclave Relic",
             "text": "Kicker {3}\nIndestructible\nWhen Skyclave Relic enters the battlefield, if it was kicked, create two tapped tokens that are copies of Skyclave Relic.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -10199,7 +10199,7 @@
         },
         {
             "id": "c80ad8a0-aaf0-5d4d-8579-a94c7f5f20af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8809a-77cd-4090-8a89-12121a8da676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8809a-77cd-4090-8a89-12121a8da676.jpg?1",
             "name": "Skyclave Sentinel",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nFlying, defender\nIf Skyclave Sentinel was kicked, it enters the battlefield with two +1/+1 counters on it.\nAs long as Skyclave Sentinel has a +1/+1 counter on it, it can attack as though it didn't have defender.",
             "colours": [],
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "e51c3a28-5719-5f1f-856a-ccdadf9411e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53baf25-1782-427b-a9dd-fc9b8dc6444f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53baf25-1782-427b-a9dd-fc9b8dc6444f.jpg?1",
             "name": "Spare Supplies",
             "text": "Spare Supplies enters the battlefield tapped.\nWhen Spare Supplies enters the battlefield, draw a card.\n{2}, {T}, Sacrifice Spare Supplies: Draw a card.",
             "colours": [],
@@ -10258,7 +10258,7 @@
         },
         {
             "id": "51c154c6-a67b-56bb-9713-c2b10b936e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29e17ba-d584-4296-9f43-17467edaa25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29e17ba-d584-4296-9f43-17467edaa25f.jpg?1",
             "name": "Stonework Packbeast",
             "text": "Stonework Packbeast is also a Cleric, Rogue, Warrior, and Wizard.\n{2}: Add one mana of any color.",
             "colours": [],
@@ -10289,7 +10289,7 @@
         },
         {
             "id": "4c3776b8-e3fb-5dd9-9a6b-8bdcc6943fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5c781d-cd89-4671-8fbe-fae82c33357b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5c781d-cd89-4671-8fbe-fae82c33357b.jpg?1",
             "name": "Utility Knife",
             "text": "When Utility Knife enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "ffa1ae56-535f-51de-8455-2cd52335abee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc85412e-333d-4e7d-8c85-40618cf1b6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc85412e-333d-4e7d-8c85-40618cf1b6c2.jpg?1",
             "name": "Base Camp",
             "text": "Base Camp enters the battlefield tapped.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Cleric, Rogue, Warrior, or Wizard spell or to activate an ability of a Cleric, Rogue, Warrior, or Wizard.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "cd9ac675-aeaa-55cc-b33a-4b00a580ec5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56f7e2a-150c-4daa-811c-a0347ff850bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56f7e2a-150c-4daa-811c-a0347ff850bf.jpg?1",
             "name": "A-Base Camp",
             "text": "",
             "colours": [],
@@ -10374,7 +10374,7 @@
         },
         {
             "id": "6072997d-fb42-5bc9-b7ee-b82f00165c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10407,7 +10407,7 @@
         },
         {
             "id": "239da818-3951-5513-bb3c-e3deedae10d2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -10440,7 +10440,7 @@
         },
         {
             "id": "14a82225-1e50-5ba9-b4fe-c1b23d9b869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -10473,7 +10473,7 @@
         },
         {
             "id": "79ef228a-7fb6-5043-9f0f-ac02a09ce92c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10506,7 +10506,7 @@
         },
         {
             "id": "4aecc7ae-e72d-53f4-b7d6-b07099cb28f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "386b656e-9795-5656-a79a-98c8a3e7398c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -10572,7 +10572,7 @@
         },
         {
             "id": "85d7e791-1aa2-50d9-ad8b-d9bed3f500aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -10605,7 +10605,7 @@
         },
         {
             "id": "dc222dc4-d430-5485-8b44-fd75d8608aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -10638,7 +10638,7 @@
         },
         {
             "id": "95c20144-a11c-5b20-b5b9-206c907eb9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0e025-7a75-4641-a51a-27df9dcde05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0e025-7a75-4641-a51a-27df9dcde05f.jpg?1",
             "name": "Crawling Barrens",
             "text": "{T}: Add {C}.\n{4}: Put two +1/+1 counters on Crawling Barrens. Then you may have it become a 0/0 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -10668,7 +10668,7 @@
         },
         {
             "id": "94b0d788-b3e1-5d16-9417-6eb676a10368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10702,7 +10702,7 @@
         },
         {
             "id": "47632a4c-8baa-59af-8669-8e692748eaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -10736,7 +10736,7 @@
         },
         {
             "id": "b444c54f-a0fe-5c23-b89a-5ff49adab445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -10769,7 +10769,7 @@
         },
         {
             "id": "1cb8e283-5796-548c-af19-c44d9ac863e0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "a1119869-e9b5-5e0e-af8f-da00eea52b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a0563e-c83b-40df-abf6-51c83bf6792d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a0563e-c83b-40df-abf6-51c83bf6792d.jpg?1",
             "name": "Throne of Makindi",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a charge counter on Throne of Makindi.\n{T}, Remove a charge counter from Throne of Makindi: Add two mana of any one color. Spend this mana only to cast kicked spells.",
             "colours": [],
@@ -10832,7 +10832,7 @@
         },
         {
             "id": "5c4273d7-d8c6-5bbb-bbe2-365d45378d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591fd15-78d9-4089-a075-031ab2affd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591fd15-78d9-4089-a075-031ab2affd2d.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10870,7 +10870,7 @@
         },
         {
             "id": "e94465e5-39c4-56f3-b6bd-294805b2db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665190e-ea2a-498e-9c4f-f0bc514bd80c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665190e-ea2a-498e-9c4f-f0bc514bd80c.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10908,7 +10908,7 @@
         },
         {
             "id": "341e8922-05d7-59aa-84bf-a387dd34f79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d918248-85ff-4fea-ac91-aa5466dd2829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d918248-85ff-4fea-ac91-aa5466dd2829.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10946,7 +10946,7 @@
         },
         {
             "id": "945fd1a5-d0e9-5f85-be86-654dcc7f1d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea783b-adaa-47be-9918-ca2f161c5d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea783b-adaa-47be-9918-ca2f161c5d9e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10984,7 +10984,7 @@
         },
         {
             "id": "1e2b8e90-5158-5992-a792-a492b8b8c9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb695ab9-72dc-4b07-b42d-e2109a5254b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb695ab9-72dc-4b07-b42d-e2109a5254b6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11022,7 +11022,7 @@
         },
         {
             "id": "e6c1b9fa-bd00-5c5d-bd24-b1bb81d15929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba4b3ad-1aef-44d3-889a-aedd9e070975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba4b3ad-1aef-44d3-889a-aedd9e070975.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11060,7 +11060,7 @@
         },
         {
             "id": "4b6c32d3-1277-56a3-8da0-dbf098b48c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a58ce4-e07f-4c9c-98ae-3173d6d63cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a58ce4-e07f-4c9c-98ae-3173d6d63cc5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11098,7 +11098,7 @@
         },
         {
             "id": "7c91ca01-5bcc-5639-839a-1421d18ab3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26142ae3-5aa1-4b9b-989a-21c0e4e5089d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26142ae3-5aa1-4b9b-989a-21c0e4e5089d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11136,7 +11136,7 @@
         },
         {
             "id": "ea273c8a-4b17-5fe1-8594-51f8dba92e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418335b2-398f-499e-92ad-8d21a5a5b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418335b2-398f-499e-92ad-8d21a5a5b69f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11174,7 +11174,7 @@
         },
         {
             "id": "9fbe0e9c-dad4-53da-90da-1b58ab725311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96297bcc-8480-4b14-8612-1c395d481bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96297bcc-8480-4b14-8612-1c395d481bce.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11212,7 +11212,7 @@
         },
         {
             "id": "63fcd42f-12bd-5a19-895c-bd6ca55894cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aefd4-074a-47b8-88a3-32fb90b09dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aefd4-074a-47b8-88a3-32fb90b09dee.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11250,7 +11250,7 @@
         },
         {
             "id": "6c7d678a-b7a8-51d5-bbed-e67594bd3def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89b3c3a-3dba-47b3-9620-d4dd754a59e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89b3c3a-3dba-47b3-9620-d4dd754a59e6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11288,7 +11288,7 @@
         },
         {
             "id": "37a9e1bd-4217-51cc-bc44-38c19db3ea40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d949485e-5188-49f4-9d30-5e135532d445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d949485e-5188-49f4-9d30-5e135532d445.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11326,7 +11326,7 @@
         },
         {
             "id": "dbbfcc96-b9f2-508e-8cc5-22f6616fabef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a9654-ce17-4378-b52b-fb6efbbf042f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a9654-ce17-4378-b52b-fb6efbbf042f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "0ed86207-9b2f-558a-9172-1932bae2f143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef9b74-481b-424b-8e33-f0b910f66370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef9b74-481b-424b-8e33-f0b910f66370.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11402,7 +11402,7 @@
         },
         {
             "id": "1e6cfbf9-83b7-5999-a544-d2b78b9f1a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961bb827-f13a-417d-8284-5cd2aac3d034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961bb827-f13a-417d-8284-5cd2aac3d034.jpg?1",
             "name": "Jace, Mirror Mage",
             "text": "Kicker {2}\nWhen Jace, Mirror Mage enters the battlefield, if Jace was kicked, create a token that's a copy of Jace, Mirror Mage, except it's not legendary and its starting loyalty is 1.\n+1: Scry 2.\n0: Draw a card and reveal it. Remove a number of loyalty counters equal to that card's converted mana cost from Jace, Mirror Mage.",
             "colours": [
@@ -11440,7 +11440,7 @@
         },
         {
             "id": "57c09509-89f1-5318-9a1c-9c61e198dc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90ad3d-8d88-470b-897e-2f64376f7f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90ad3d-8d88-470b-897e-2f64376f7f43.jpg?1",
             "name": "Nahiri, Heir of the Ancients",
             "text": "+1: Create a 1/1 white Kor Warrior creature token. You may attach an Equipment you control to it.\n\u22122: Look at the top six cards of your library. You may reveal a Warrior or Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Nahiri, Heir of the Ancients deals damage to target creature or planeswalker equal to twice the number of Equipment you control.",
             "colours": [
@@ -11480,7 +11480,7 @@
         },
         {
             "id": "e4e1b07e-02b1-5171-b2b0-e0887cfc4f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabac59d-8319-417e-9cd5-e4ee59b2e5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabac59d-8319-417e-9cd5-e4ee59b2e5f2.jpg?1",
             "name": "Nissa of Shadowed Boughs",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a loyalty counter on Nissa of Shadowed Boughs.\n+1: Untap target land you control. You may have it become a 3/3 Elemental creature with haste and menace until end of turn. It's still a land.\n\u22125: You may put a creature card with converted mana cost less than or equal to the number of lands you control onto the battlefield from your hand or graveyard with two +1/+1 counters on it.",
             "colours": [
@@ -11520,7 +11520,7 @@
         },
         {
             "id": "18691760-a467-52fe-ba32-ab6051585479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "0c44b423-d106-5fa9-9f4d-d69ad70ceef7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11586,7 +11586,7 @@
         },
         {
             "id": "7e47679e-24a0-57dc-970f-b29efb7d55ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11619,7 +11619,7 @@
         },
         {
             "id": "7236f50c-3d65-5b7e-9aee-62e521bc6959",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "a7f50521-110a-5572-ba96-5fe748b56d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -11685,7 +11685,7 @@
         },
         {
             "id": "f31fdd39-6824-5bf5-b6a1-f8333aeae539",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -11718,7 +11718,7 @@
         },
         {
             "id": "b6e0a606-671c-55d5-b312-132a3d86098e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11751,7 +11751,7 @@
         },
         {
             "id": "3f4e0b67-3ab9-591b-9675-6fdd2f34d033",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11784,7 +11784,7 @@
         },
         {
             "id": "c4f04cbb-7139-5e80-9d6b-3e29ac3cde84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11818,7 +11818,7 @@
         },
         {
             "id": "2b18cf5f-bdc1-575c-8c1e-fe95d24b15e3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11852,7 +11852,7 @@
         },
         {
             "id": "4cd78a0c-794d-5014-93cf-b032d5a8aba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "",
             "colours": [],
@@ -11885,7 +11885,7 @@
         },
         {
             "id": "6ac8128d-c1f8-57c5-a5ae-47706e062d06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "",
             "colours": [],
@@ -11918,7 +11918,7 @@
         },
         {
             "id": "3d3b5b44-e3ec-5ca4-a24a-3468369483e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11951,7 +11951,7 @@
         },
         {
             "id": "e3a27a1c-52cb-5e6c-9dad-464d23d7c307",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11984,7 +11984,7 @@
         },
         {
             "id": "9e6e6056-0ecf-5b8e-880c-aae2e3869816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0250dc8-9d4c-428a-9e34-9e3577be4745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0250dc8-9d4c-428a-9e34-9e3577be4745.jpg?1",
             "name": "Canyon Jerboa",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -12020,7 +12020,7 @@
         },
         {
             "id": "0a9f5ef2-5d55-5ab7-8752-df29072c5cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8024d-a300-43cb-9dde-6b4cb1fa19f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8024d-a300-43cb-9dde-6b4cb1fa19f7.jpg?1",
             "name": "Fearless Fledgling",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Fearless Fledgling. It gains flying until end of turn.",
             "colours": [
@@ -12056,7 +12056,7 @@
         },
         {
             "id": "da647a9b-fda1-5d5d-a903-2e32b542c71f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c32d-457d-4fef-bba2-33a07bf23125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c32d-457d-4fef-bba2-33a07bf23125.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -12090,7 +12090,7 @@
         },
         {
             "id": "8cbd59e2-0c20-59c6-9c35-04d88f06191c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97b691-f9f5-4fb4-8e44-8ffe32d13d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97b691-f9f5-4fb4-8e44-8ffe32d13d03.jpg?1",
             "name": "Makindi Ox",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -12126,7 +12126,7 @@
         },
         {
             "id": "bdd0a49a-e7d3-51f7-8f46-4d299fdf71e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8df0aed-dd2b-4f1e-8dfe-aec07462b1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8df0aed-dd2b-4f1e-8dfe-aec07462b1e1.jpg?1",
             "name": "Prowling Felidar",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Prowling Felidar.",
             "colours": [
@@ -12163,7 +12163,7 @@
         },
         {
             "id": "68c703c8-ef41-5b91-932a-fb7a6b7900d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc72e9f-2cda-47b9-84fd-4eed88312404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc72e9f-2cda-47b9-84fd-4eed88312404.jpg?1",
             "name": "Ruin Crab",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, each opponent mills three cards.",
             "colours": [
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "f185ff3c-caa7-5e84-ab16-17fdce789518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04833fcc-cef7-4152-8191-c552288c83e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04833fcc-cef7-4152-8191-c552288c83e4.jpg?1",
             "name": "Skyclave Squid",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Squid can attack this turn as though it didn't have defender.",
             "colours": [
@@ -12235,7 +12235,7 @@
         },
         {
             "id": "fc96e0dd-630f-57f0-be8c-ad79beee374f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60c9b15-c824-4203-bdda-ff9c041f9e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60c9b15-c824-4203-bdda-ff9c041f9e2f.jpg?1",
             "name": "Dreadwurm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Dreadwurm gains indestructible until end of turn.",
             "colours": [
@@ -12272,7 +12272,7 @@
         },
         {
             "id": "496e4c41-1e58-5927-8d55-7b8791997e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05347539-de61-4a37-929f-c909e65033f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05347539-de61-4a37-929f-c909e65033f5.jpg?1",
             "name": "Skyclave Shade",
             "text": "Kicker {2}{B}\nSkyclave Shade can't block.\nIf Skyclave Shade was kicked, it enters the battlefield with two +1/+1 counters on it.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if Skyclave Shade is in your graveyard and it's your turn, you may cast it from your graveyard this turn.",
             "colours": [
@@ -12308,7 +12308,7 @@
         },
         {
             "id": "444f35a4-be3b-5ea2-a958-c20cc759dc7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5757230-08b8-4808-af61-d343f9748fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5757230-08b8-4808-af61-d343f9748fb1.jpg?1",
             "name": "Akoum Hellhound",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Akoum Hellhound gets +2/+2 until end of turn.",
             "colours": [
@@ -12345,7 +12345,7 @@
         },
         {
             "id": "623bc456-243e-5679-9d7e-b626e599066d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecfbd48-7da0-4b44-b9a2-d31412f65eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecfbd48-7da0-4b44-b9a2-d31412f65eb1.jpg?1",
             "name": "Moraug, Fury of Akoum",
             "text": "Each creature you control gets +1/+0 for each time it has attacked this turn.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if it's your main phase, there's an additional combat phase after this phase. At the beginning of that combat, untap all creatures you control.",
             "colours": [
@@ -12384,7 +12384,7 @@
         },
         {
             "id": "077cb5b9-40cf-552b-b410-b5ac8879c6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490f3d74-6144-4cbc-80ed-37cfcdbd159a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490f3d74-6144-4cbc-80ed-37cfcdbd159a.jpg?1",
             "name": "Skyclave Geopede",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Geopede gets +2/+2 until end of turn.",
             "colours": [
@@ -12420,7 +12420,7 @@
         },
         {
             "id": "4f7e5b3e-3329-53eb-ae26-c63447c4976b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6008794-a7ca-4a3e-b88b-e5dbb9e0f39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6008794-a7ca-4a3e-b88b-e5dbb9e0f39b.jpg?1",
             "name": "Spitfire Lagac",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Spitfire Lagac deals 1 damage to each opponent.",
             "colours": [
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "3b1f8dd0-4735-5d1b-96c0-9c3c073c6b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954cc66-ab80-4457-b0da-61d80e80e25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954cc66-ab80-4457-b0da-61d80e80e25e.jpg?1",
             "name": "Valakut Exploration",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, exile the top card of your library. You may play that card for as long as it remains exiled.\nAt the beginning of your end step, if there are cards exiled with Valakut Exploration, put them into their owner's graveyard, then Valakut Exploration deals that much damage to each opponent.",
             "colours": [
@@ -12490,7 +12490,7 @@
         },
         {
             "id": "9908c952-3bc1-5e4e-a015-442cafece95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52e90d3-d356-4b23-8f5c-a4004b20394c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52e90d3-d356-4b23-8f5c-a4004b20394c.jpg?1",
             "name": "Canopy Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Canopy Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -12526,7 +12526,7 @@
         },
         {
             "id": "8c33b1af-2d15-5a7f-a62b-89ab070c8a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Kazandu Mammoth gets +2/+2 until end of turn.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -12562,7 +12562,7 @@
         },
         {
             "id": "d8b73b4b-41a3-5b69-91cb-9d52225b5bef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Kazandu Valley enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElephant\n{1}{G}{G}",
             "colours": [],
@@ -12594,7 +12594,7 @@
         },
         {
             "id": "ecdb729a-a9b0-5f88-9a51-abd95dcdd3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796b5899-97e5-4682-aac8-51378f0c904e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796b5899-97e5-4682-aac8-51378f0c904e.jpg?1",
             "name": "Kazandu Nectarpot",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -12630,7 +12630,7 @@
         },
         {
             "id": "5e255230-447d-5262-9006-d600e9c661a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151bdf3a-4445-43b1-8cea-2737c13d9dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151bdf3a-4445-43b1-8cea-2737c13d9dee.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color.",
             "colours": [
@@ -12666,7 +12666,7 @@
         },
         {
             "id": "c7a49031-605d-576e-a0bc-a35cf25b2661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b2cb5-b9a8-417d-b5ae-0a7d03ff93f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b2cb5-b9a8-417d-b5ae-0a7d03ff93f0.jpg?1",
             "name": "Scute Swarm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 1/1 green Insect creature token. If you control six or more lands, create a token that's a copy of Scute Swarm instead.",
             "colours": [
@@ -12702,7 +12702,7 @@
         },
         {
             "id": "85b6f1f4-58e0-5d5f-a16a-1354c04035b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d6d8a4-c51d-4b4a-86e7-df9e9c7a171d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d6d8a4-c51d-4b4a-86e7-df9e9c7a171d.jpg?1",
             "name": "Skyclave Pick-Axe",
             "text": "When Skyclave Pick-Axe enters the battlefield, attach it to target creature you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {2}{G}",
             "colours": [
@@ -12738,7 +12738,7 @@
         },
         {
             "id": "d72578e7-d99c-56f3-a87d-fcbd91c8d6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4aba-3391-4259-9a5f-a163a45d943c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4aba-3391-4259-9a5f-a163a45d943c.jpg?1",
             "name": "Territorial Scythecat",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Territorial Scythecat.",
             "colours": [
@@ -12774,7 +12774,7 @@
         },
         {
             "id": "7542bc87-0494-5749-8a55-7f0ba5a2eb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0954df-07f0-430d-90ee-d1fe40af546f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0954df-07f0-430d-90ee-d1fe40af546f.jpg?1",
             "name": "Brushfire Elemental",
             "text": "Haste\nBrushfire Elemental can't be blocked by creatures with power 2 or less.\nLandfall \u2014 Whenever a land enters the battlefield under your control, Brushfire Elemental gets +2/+2 until end of turn.",
             "colours": [
@@ -12812,7 +12812,7 @@
         },
         {
             "id": "1c47b784-e283-5122-b128-ed6f4414d8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5bc5d7-c0f8-4632-adb7-dd3b75a3d87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5bc5d7-c0f8-4632-adb7-dd3b75a3d87d.jpg?1",
             "name": "Omnath, Locus of Creation",
             "text": "When Omnath, Locus of Creation enters the battlefield, draw a card.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, Omnath deals 4 damage to each opponent and each planeswalker you don't control.",
             "colours": [
@@ -12856,7 +12856,7 @@
         },
         {
             "id": "58217603-1efd-5bde-b9c8-06a8abf949e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344a3cd-43e0-4333-83ec-081f0e39530a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344a3cd-43e0-4333-83ec-081f0e39530a.jpg?1",
             "name": "Phylath, World Sculptor",
             "text": "When Phylath, World Sculptor enters the battlefield, create a 0/1 green Plant creature token for each basic land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, put four +1/+1 counters on target Plant you control.",
             "colours": [
@@ -12896,7 +12896,7 @@
         },
         {
             "id": "55474870-ba85-59e7-a2e2-5e707c4271a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f3282-b88e-4843-9569-af20940559b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f3282-b88e-4843-9569-af20940559b0.jpg?1",
             "name": "Angel of Destiny",
             "text": "Flying, double strike\nWhenever a creature you control deals combat damage to a player, you and that player each gain that much life.\nAt the beginning of your end step, if you have at least 15 life more than your starting life total, each player Angel of Destiny attacked this turn loses the game.",
             "colours": [
@@ -12933,7 +12933,7 @@
         },
         {
             "id": "a65f4408-2069-5fb4-9237-bf0b226f24ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ed3d8-d176-44c8-ba54-f2536ceeb497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ed3d8-d176-44c8-ba54-f2536ceeb497.jpg?1",
             "name": "Archon of Emeria",
             "text": "Flying\nEach player can't cast more than one spell each turn.\nNonbasic lands your opponents control enter the battlefield tapped.",
             "colours": [
@@ -12969,7 +12969,7 @@
         },
         {
             "id": "6b5deeb0-9f8d-5aa5-9787-38bc93caad76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23d588e-f7d8-4a11-9bf5-77b9f6faffd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23d588e-f7d8-4a11-9bf5-77b9f6faffd4.jpg?1",
             "name": "Archpriest of Iona",
             "text": "Archpriest of Iona's power is equal to the number of creatures in your party.\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -13006,7 +13006,7 @@
         },
         {
             "id": "6d82730a-9c18-5030-9aa7-bb1eb590556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "Create two 4/4 white Angel Warrior creature tokens with flying. Non-Angel creatures you control gain indestructible until your next turn.",
             "colours": [
@@ -13040,7 +13040,7 @@
         },
         {
             "id": "b31428a0-3a18-54aa-82db-a4fa8e155e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "As Emeria, Shattered Skyclave enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -13072,7 +13072,7 @@
         },
         {
             "id": "4799dad8-1bb9-51f4-b968-c5c093823bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc4014f-f9aa-4a46-b772-474e56ed72c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc4014f-f9aa-4a46-b772-474e56ed72c3.jpg?1",
             "name": "Legion Angel",
             "text": "Flying\nWhen Legion Angel enters the battlefield, you may reveal a card you own named Legion Angel from outside the game and put it into your hand.",
             "colours": [
@@ -13109,7 +13109,7 @@
         },
         {
             "id": "27a31b08-41a6-548a-af5d-96b7eb16a7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9427d-068f-487c-9263-b40366a164bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9427d-068f-487c-9263-b40366a164bc.jpg?1",
             "name": "Luminarch Aspirant",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -13146,7 +13146,7 @@
         },
         {
             "id": "701020e7-6acb-5c66-8f2d-4c42f8604248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9da1e4-4554-42eb-aed5-9d068c39e727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9da1e4-4554-42eb-aed5-9d068c39e727.jpg?1",
             "name": "Maul of the Skyclaves",
             "text": "When Maul of the Skyclaves enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+2 and has flying and first strike.\nEquip {2}{W}{W}",
             "colours": [
@@ -13182,7 +13182,7 @@
         },
         {
             "id": "96218570-8362-55f7-93ad-1f518cadd468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -13216,7 +13216,7 @@
         },
         {
             "id": "1e8f76b3-01b2-50ea-971a-df9ee31605ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Ondu Skyruins enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -13248,7 +13248,7 @@
         },
         {
             "id": "44d43cf5-d486-5171-bce5-e03eb43bcaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4b938f-a600-4d10-8030-ed60cf6ade56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4b938f-a600-4d10-8030-ed60cf6ade56.jpg?1",
             "name": "Skyclave Apparition",
             "text": "When Skyclave Apparition enters the battlefield, exile up to one target nonland, nontoken permanent you don't control with converted mana cost 4 or less.\nWhen Skyclave Apparition leaves the battlefield, the exiled card's owner creates an X/X blue Illusion creature token, where X is the converted mana cost of the exiled card.",
             "colours": [
@@ -13285,7 +13285,7 @@
         },
         {
             "id": "74a69a2e-1c59-5582-a99c-ef86babe1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c56de4d-cb23-45f8-864d-3e7d640d62b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c56de4d-cb23-45f8-864d-3e7d640d62b0.jpg?1",
             "name": "Squad Commander",
             "text": "When Squad Commander enters the battlefield, create a 1/1 white Kor Warrior creature token for each creature in your party.\nAt the beginning of combat on your turn, if you have a full party, creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -13322,7 +13322,7 @@
         },
         {
             "id": "a12b36d9-1284-59d1-85ef-eb4e61df4985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c1ab6-a67e-4258-8156-de21ccb2277d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c1ab6-a67e-4258-8156-de21ccb2277d.jpg?1",
             "name": "Tazri, Beacon of Unity",
             "text": "This spell costs {1} less to cast for each creature in your party.\n{2\nU}{2\nB}{2\nR}{2\nG}: Look at the top six cards of your library. You may reveal up to two Cleric, Rogue, Warrior, Wizard, and/or Ally cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13365,7 +13365,7 @@
         },
         {
             "id": "0fac0334-e2ab-5d86-8da3-9a3c81d496b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97982bcc-e1b1-4d21-b208-a6587613b8a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97982bcc-e1b1-4d21-b208-a6587613b8a1.jpg?1",
             "name": "Charix, the Raging Isle",
             "text": "Spells your opponents cast that target Charix, the Raging Isle cost {2} more to cast.\n{3}: Charix gets +X/-X until end of turn, where X is the number of Islands you control.",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "ac9cfb31-2793-5db2-baa2-95e3a37c6332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c18e39-5173-48f1-8690-5a261b872758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c18e39-5173-48f1-8690-5a261b872758.jpg?1",
             "name": "Confounding Conundrum",
             "text": "When Confounding Conundrum enters the battlefield, draw a card.\nWhenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under their control this turn, they return a land they control to its owner's hand.",
             "colours": [
@@ -13439,7 +13439,7 @@
         },
         {
             "id": "709dd8e1-acfb-5b59-ab59-0a0f1ff99a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937f3ea1-7966-4fd1-8ec7-bdca6edabdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937f3ea1-7966-4fd1-8ec7-bdca6edabdd0.jpg?1",
             "name": "Coralhelm Chronicler",
             "text": "Whenever you cast a kicked spell, draw a card, then discard a card.\nWhen Coralhelm Chronicler enters the battlefield, look at the top five cards of your library. You may reveal a card with a kicker ability from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13476,7 +13476,7 @@
         },
         {
             "id": "71caa444-42a9-57d1-8e3c-7c4dd2d957f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "You may have Glasspool Mimic enter the battlefield as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.",
             "colours": [
@@ -13513,7 +13513,7 @@
         },
         {
             "id": "3e09ab49-3a49-5ae8-8098-9903bfbf08df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "Glasspool Shore enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -13545,7 +13545,7 @@
         },
         {
             "id": "cf8f334c-a03f-507b-b094-21828459be93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea9e50b-f76e-4797-8e52-1e30ccfdb284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea9e50b-f76e-4797-8e52-1e30ccfdb284.jpg?1",
             "name": "Inscription of Insight",
             "text": "Kicker {2}{U}{U}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Return up to two target creatures to their owners' hands.\n\u2022 Scry 2, then draw two cards.\n\u2022 Target player creates an X/X blue Illusion creature token, where X is the number of cards in their hand.",
             "colours": [
@@ -13579,7 +13579,7 @@
         },
         {
             "id": "51077a97-d423-5916-8e21-ea9b74627404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62da66b8-c16a-4fa3-bd7f-bbf89591c5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62da66b8-c16a-4fa3-bd7f-bbf89591c5d8.jpg?1",
             "name": "Maddening Cacophony",
             "text": "Kicker {3}{U}\nEach opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.",
             "colours": [
@@ -13613,7 +13613,7 @@
         },
         {
             "id": "d0cca18d-5ea1-56f2-a4c0-eef5b44c0f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63663faa-3ccb-4299-b393-347eefaf3c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63663faa-3ccb-4299-b393-347eefaf3c7b.jpg?1",
             "name": "Master of Winds",
             "text": "Flying\nWhen Master of Winds enters the battlefield, draw two cards, then discard a card.\nWhenever you cast an instant, sorcery, or Wizard spell, you may have Master of Winds's base power and toughness become 4/1 or 1/4 until end of turn.",
             "colours": [
@@ -13650,7 +13650,7 @@
         },
         {
             "id": "0c5b0732-dd62-5b88-88f7-ffc5f2bef530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdc085a-8d97-45fe-86bf-2f4783ebf65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdc085a-8d97-45fe-86bf-2f4783ebf65e.jpg?1",
             "name": "Nimble Trapfinder",
             "text": "Nimble Trapfinder can't be blocked if you had another Cleric, Rogue, Warrior, or Wizard enter the battlefield under your control this turn.\nAt the beginning of combat on your turn, if you have a full party, creatures you control gain \"Whenever this creature deals combat damage to a player, draw a card\" until end of turn.",
             "colours": [
@@ -13687,7 +13687,7 @@
         },
         {
             "id": "445127ae-b2dd-5346-b98d-f894a11dcba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "Draw cards equal to the number of cards in your hand plus one. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -13721,7 +13721,7 @@
         },
         {
             "id": "53f9fe28-58ce-5aae-9f75-0f966247eb60",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "As Sea Gate, Reborn enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -13753,7 +13753,7 @@
         },
         {
             "id": "a83f7191-b210-53af-82ff-1d5cf763d999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b79895-30ac-4bb4-bbe3-033a0dfcf1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b79895-30ac-4bb4-bbe3-033a0dfcf1d6.jpg?1",
             "name": "Sea Gate Stormcaller",
             "text": "Kicker {4}{U}\nWhen Sea Gate Stormcaller enters the battlefield, copy the next instant or sorcery spell with converted mana cost 2 or less you cast this turn when you cast it. If Sea Gate Stormcaller was kicked, copy that spell twice instead. You may choose new targets for the copies.",
             "colours": [
@@ -13790,7 +13790,7 @@
         },
         {
             "id": "4ba1ec71-e57e-53c0-ba57-d4fc3cbf09b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3eb41-2351-4dca-becb-7ecb1fcfa14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3eb41-2351-4dca-becb-7ecb1fcfa14b.jpg?1",
             "name": "Thieving Skydiver",
             "text": "Kicker {X}. X can't be 0.\nFlying\nWhen Thieving Skydiver enters the battlefield, if it was kicked, gain control of target artifact with converted mana cost X or less. If that artifact is an Equipment, attach it to Thieving Skydiver.",
             "colours": [
@@ -13827,7 +13827,7 @@
         },
         {
             "id": "349defa8-44a5-5ff4-8c1b-a5c82e216e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "Return from your graveyard to the battlefield any number of target creature cards that each have a different converted mana cost X or less.",
             "colours": [
@@ -13861,7 +13861,7 @@
         },
         {
             "id": "8deee4f4-b892-5ac8-bbd1-2dcca27e1571",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "As Agadeem, the Undercrypt enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -13893,7 +13893,7 @@
         },
         {
             "id": "5971056b-bc98-5b6c-ab80-3dd260bbc37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c86ad5-5384-4a62-971c-05abc995da91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c86ad5-5384-4a62-971c-05abc995da91.jpg?1",
             "name": "Coveted Prize",
             "text": "This spell costs {1} less to cast for each creature in your party.\nSearch your library for a card, put it into your hand, then shuffle your library. If you have a full party, you may cast a spell with converted mana cost 4 or less from your hand without paying its mana cost.",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "c7333229-7fcc-53df-aeec-7f6107204d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927297f6-5480-441f-ae05-a4064f493eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927297f6-5480-441f-ae05-a4064f493eed.jpg?1",
             "name": "Drana, the Last Bloodchief",
             "text": "Flying\nWhenever Drana, the Last Bloodchief attacks, defending player chooses a nonlegendary creature card in your graveyard. You return that card to the battlefield with a +1/+1 counter on it. The creature is a Vampire in addition to its other types.",
             "colours": [
@@ -13966,7 +13966,7 @@
         },
         {
             "id": "ee07b2ff-7520-5e0f-952d-675a7ec95965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "This spell costs {1} less to cast if an opponent controls no basic lands.\nDestroy target creature.",
             "colours": [
@@ -14000,7 +14000,7 @@
         },
         {
             "id": "30489ca2-a650-5638-995e-ebd5f7c1014f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "Hagra Broodpit enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -14032,7 +14032,7 @@
         },
         {
             "id": "4329adcd-a317-5e28-8edd-5d703f8deb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267c7c9-dc93-445a-92e0-8cda9742e4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267c7c9-dc93-445a-92e0-8cda9742e4cb.jpg?1",
             "name": "Inscription of Ruin",
             "text": "Kicker {2}{B}{B}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Target opponent discards two cards.\n\u2022 Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u2022 Destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -14066,7 +14066,7 @@
         },
         {
             "id": "39ec1458-b7bc-5bd7-b09c-93948b242f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9522009-4fc9-439a-95ea-5800842c5ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9522009-4fc9-439a-95ea-5800842c5ee2.jpg?1",
             "name": "Nighthawk Scavenger",
             "text": "Flying, deathtouch, lifelink\nNighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards.",
             "colours": [
@@ -14103,7 +14103,7 @@
         },
         {
             "id": "5da824a6-be1e-5a67-b2e8-fa1c967a8ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774af92-db1a-4541-bf5c-0c34bf543aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774af92-db1a-4541-bf5c-0c34bf543aca.jpg?1",
             "name": "Nullpriest of Oblivion",
             "text": "Kicker {3}{B}\nMenace, lifelink\nWhen Nullpriest of Oblivion enters the battlefield, if it was kicked, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -14140,7 +14140,7 @@
         },
         {
             "id": "2fd9b7cd-42f0-5556-99e5-9ce26b817686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fec4b5-2a9c-4448-9fef-045d0e6725c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fec4b5-2a9c-4448-9fef-045d0e6725c2.jpg?1",
             "name": "Scourge of the Skyclaves",
             "text": "Kicker {4}{B}\nWhen you cast this spell, if it was kicked, each player loses half their life, rounded up.\nScourge of the Skyclaves's power and toughness are each equal to 20 minus the highest life total among players.",
             "colours": [
@@ -14176,7 +14176,7 @@
         },
         {
             "id": "e37d7af7-414f-5622-a0a5-bfc9fe93badc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c1e4ca-4528-4637-9452-cc3e5da75456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c1e4ca-4528-4637-9452-cc3e5da75456.jpg?1",
             "name": "Shadows' Verdict",
             "text": "Exile all creatures and planeswalkers with converted mana cost 3 or less from the battlefield and all creature and planeswalker cards with converted mana cost 3 or less from all graveyards.",
             "colours": [
@@ -14210,7 +14210,7 @@
         },
         {
             "id": "7c6131c9-759a-5dc3-bb99-d1e71af4dfa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e40b3f9-8eed-41b1-afe1-eaf61a618407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e40b3f9-8eed-41b1-afe1-eaf61a618407.jpg?1",
             "name": "Soul Shatter",
             "text": "Each opponent sacrifices a creature or planeswalker with the highest converted mana cost among creatures and planeswalkers they control.",
             "colours": [
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "a975e75a-c8dd-51ca-bcd8-d3d0765c2d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d014ddb-c545-4f59-aa8e-e324399722e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d014ddb-c545-4f59-aa8e-e324399722e8.jpg?1",
             "name": "Taborax, Hope's Demise",
             "text": "Flying\nTaborax, Hope's Demise has lifelink as long as it has five or more +1/+1 counters on it.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on Taborax. If that creature was a Cleric, you may draw a card. If you do, you lose 1 life.",
             "colours": [
@@ -14283,7 +14283,7 @@
         },
         {
             "id": "f9de2b29-56a5-5f1f-8f76-18d58d9deba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18442d4e-931f-4a41-b8c1-51ab3ea696df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18442d4e-931f-4a41-b8c1-51ab3ea696df.jpg?1",
             "name": "Kargan Intimidator",
             "text": "Cowards can't block Warriors.\n{1}: Choose one that hasn't been chosen this turn \u2014\n\u2022 Kargan Intimidator gets +1/+1 until end of turn.\n\u2022 Target creature becomes a Coward until end of turn.\n\u2022 Target Warrior gains trample until end of turn.",
             "colours": [
@@ -14320,7 +14320,7 @@
         },
         {
             "id": "c9d574cb-f1c3-5d4c-9984-0b60f3c29541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633ebe69-493b-486a-a5b3-5a12418623f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633ebe69-493b-486a-a5b3-5a12418623f9.jpg?1",
             "name": "Leyline Tyrant",
             "text": "Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.",
             "colours": [
@@ -14356,7 +14356,7 @@
         },
         {
             "id": "2b236209-66a2-5db0-90e3-8c47ea9ba571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c3023-1429-4aa1-b822-85ab1badf086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c3023-1429-4aa1-b822-85ab1badf086.jpg?1",
             "name": "Magmatic Channeler",
             "text": "As long as there are four or more instant and/or sorcery cards in your graveyard, Magmatic Channeler gets +3/+1.\n{T}, Discard a card: Exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -14393,7 +14393,7 @@
         },
         {
             "id": "7ef69894-b07c-5918-942d-17a0af788ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2af06c-4c00-49ec-b13b-32be5bc6869a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2af06c-4c00-49ec-b13b-32be5bc6869a.jpg?1",
             "name": "Nahiri's Lithoforming",
             "text": "Sacrifice X lands. For each land sacrificed this way, draw a card. You may play X additional lands this turn. Lands you control enter the battlefield tapped this turn.",
             "colours": [
@@ -14427,7 +14427,7 @@
         },
         {
             "id": "0fc56dc7-6902-5902-8e97-5f4a99da7e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6a537-fa85-44ab-a853-7a32812a4b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6a537-fa85-44ab-a853-7a32812a4b32.jpg?1",
             "name": "Relic Robber",
             "text": "Haste\nWhenever Relic Robber deals combat damage to a player, that player creates a 0/1 colorless Goblin Construct artifact creature token with \"This creature can't block\" and \"At the beginning of your upkeep, this creature deals 1 damage to you.\"",
             "colours": [
@@ -14464,7 +14464,7 @@
         },
         {
             "id": "012ccd43-697b-5fd8-8c60-37430012599c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64940bb-c92f-4c2f-aef6-927cdc070b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64940bb-c92f-4c2f-aef6-927cdc070b13.jpg?1",
             "name": "Roiling Vortex",
             "text": "At the beginning of each player's upkeep, Roiling Vortex deals 1 damage to them.\nWhenever a player casts a spell, if no mana was spent to cast that spell, Roiling Vortex deals 5 damage to that player.\n{R}: Your opponents can't gain life this turn.",
             "colours": [
@@ -14498,7 +14498,7 @@
         },
         {
             "id": "af333115-4484-5fbd-8a40-303d96fdaf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f194ce88-3206-4263-9ae9-01a4c2f4467e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f194ce88-3206-4263-9ae9-01a4c2f4467e.jpg?1",
             "name": "Shatterskull Charger",
             "text": "Kicker {2}\nTrample, haste\nIf Shatterskull Charger was kicked, it enters the battlefield with a +1/+1 counter on it.\nAt the beginning of your end step, if Shatterskull Charger doesn't have a +1/+1 counter on it, return it to its owner's hand.",
             "colours": [
@@ -14535,7 +14535,7 @@
         },
         {
             "id": "903bfc0b-3ad5-51cc-9a7c-ee6ed13790fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "Shatterskull Smashing deals X damage divided as you choose among up to two target creatures and/or planeswalkers. If X is 6 or more, Shatterskull Smashing deals twice X damage divided as you choose among them instead.",
             "colours": [
@@ -14569,7 +14569,7 @@
         },
         {
             "id": "bb2109b7-8ecf-558e-829f-cc2b455634ab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "As Shatterskull, the Hammer Pass enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -14601,7 +14601,7 @@
         },
         {
             "id": "90a8dcab-fe91-579e-bb10-55c67f9c5f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.",
             "colours": [
@@ -14635,7 +14635,7 @@
         },
         {
             "id": "518f1b89-f077-5315-a6b6-c7ae28f50035",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Valakut Stoneforge enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -14667,7 +14667,7 @@
         },
         {
             "id": "3ddc34dc-2364-53da-a9a2-b7c813eb4639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebfe94fc-7a98-4f53-8fd0-f5fd016b1873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebfe94fc-7a98-4f53-8fd0-f5fd016b1873.jpg?1",
             "name": "Wayward Guide-Beast",
             "text": "Trample, haste\nWhenever Wayward Guide-Beast deals combat damage to a player, return a land you control to its owner's hand.",
             "colours": [
@@ -14703,7 +14703,7 @@
         },
         {
             "id": "f0e55194-46e6-518c-8bbd-5deb749e92d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a058aa-f620-4a1f-af32-6e6be2cb3e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a058aa-f620-4a1f-af32-6e6be2cb3e4b.jpg?1",
             "name": "Ancient Greenwarden",
             "text": "Reach\nYou may play lands from your graveyard.\nIf a land entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -14739,7 +14739,7 @@
         },
         {
             "id": "ce1ad15d-07a3-5bb5-bde7-6f85e8d9bf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a883f-55e2-43f5-90a9-34494c14c0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a883f-55e2-43f5-90a9-34494c14c0c4.jpg?1",
             "name": "Ashaya, Soul of the Wild",
             "text": "Ashaya, Soul of the Wild's power and toughness are each equal to the number of lands you control.\nNontoken creatures you control are Forest lands in addition to their other types.",
             "colours": [
@@ -14777,7 +14777,7 @@
         },
         {
             "id": "b3991ddc-d928-58e8-a7f6-8800c600f2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227be7a0-de77-48ae-9a07-91d671985168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227be7a0-de77-48ae-9a07-91d671985168.jpg?1",
             "name": "Cragplate Baloth",
             "text": "Kicker {2}{G}\nThis spell can't be countered.\nHexproof, haste\nIf Cragplate Baloth was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -14813,7 +14813,7 @@
         },
         {
             "id": "d040c0c1-9ca5-5b9f-9493-075135381989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14c74a8-be66-4268-93fa-b32765fd82e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14c74a8-be66-4268-93fa-b32765fd82e2.jpg?1",
             "name": "Inscription of Abundance",
             "text": "Kicker {2}{G}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player gains X life, where X is the greatest power among creatures they control.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -14847,7 +14847,7 @@
         },
         {
             "id": "7e716f38-634c-5605-aeb2-aa695dea2417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f4293f-94ba-4702-9515-fd06df806169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f4293f-94ba-4702-9515-fd06df806169.jpg?1",
             "name": "Oran-Rief Ooze",
             "text": "When Oran-Rief Ooze enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Oran-Rief Ooze attacks, put a +1/+1 counter on each attacking creature with a +1/+1 counter on it.",
             "colours": [
@@ -14883,7 +14883,7 @@
         },
         {
             "id": "18a79249-3563-557f-91de-b93dd8d618e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e0cde7-ec96-4428-b368-572154c97f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e0cde7-ec96-4428-b368-572154c97f1c.jpg?1",
             "name": "Swarm Shambler",
             "text": "Swarm Shambler enters the battlefield with a +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.\n{1}, {T}: Put a +1/+1 counter on Swarm Shambler.",
             "colours": [
@@ -14920,7 +14920,7 @@
         },
         {
             "id": "a448a7e2-6861-505b-ad5d-ba613aa70051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a2ec1-23c1-4826-94b8-3df24172d764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a2ec1-23c1-4826-94b8-3df24172d764.jpg?1",
             "name": "Tajuru Paragon",
             "text": "Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.\nKicker {3}\nWhen Tajuru Paragon enters the battlefield, if it was kicked, reveal the top six cards of your library. You may put a card that shares a creature type with it from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14956,7 +14956,7 @@
         },
         {
             "id": "f6aeb170-0112-5224-8df5-274ce7558327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. If that card has converted mana cost 3 or less, it enters with three additional +1/+1 counters on it. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14990,7 +14990,7 @@
         },
         {
             "id": "3bdeba6f-fa4d-5d1d-b169-6840a87e279e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "As Turntimber, Serpentine Wood enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -15022,7 +15022,7 @@
         },
         {
             "id": "fb7f1969-d094-5d75-ad52-fa42dde3ddff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b24f6-7def-4e2c-9e7b-a347dd3cdcee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b24f6-7def-4e2c-9e7b-a347dd3cdcee.jpg?1",
             "name": "Akiri, Fearless Voyager",
             "text": "Whenever you attack a player with one or more equipped creatures, draw a card.\n{W}: You may unattach an Equipment from a creature you control. If you do, tap that creature and it gains indestructible until end of turn.",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "94bd2963-670a-5f0d-9cbd-020cf360c39b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25975f58-a6b7-4cbc-bdc5-d0eedeb3ef1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25975f58-a6b7-4cbc-bdc5-d0eedeb3ef1b.jpg?1",
             "name": "Grakmaw, Skyclave Ravager",
             "text": "Grakmaw, Skyclave Ravager enters the battlefield with three +1/+1 counters on it.\nWhenever another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on Grakmaw.\nWhen Grakmaw dies, create an X/X black and green Hydra creature token, where X is the number of +1/+1 counters on Grakmaw.",
             "colours": [
@@ -15104,7 +15104,7 @@
         },
         {
             "id": "f31ced07-f01b-5bd9-9cad-2a7a27e988d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9f9c0a-1ea6-44ac-b0af-6a6a32359494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9f9c0a-1ea6-44ac-b0af-6a6a32359494.jpg?1",
             "name": "Kaza, Roil Chaser",
             "text": "Flying, haste\n{T}: The next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of Wizards you control as this ability resolves.",
             "colours": [
@@ -15145,7 +15145,7 @@
         },
         {
             "id": "fbe1c556-c85d-5da0-bfa5-1660855f0280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15500025-e5ba-4f02-b875-bfa1b1a76875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15500025-e5ba-4f02-b875-bfa1b1a76875.jpg?1",
             "name": "Linvala, Shield of Sea Gate",
             "text": "Flying\nAt the beginning of combat on your turn, if you have a full party, choose target nonland permanent an opponent controls. Until your next turn, it can't attack or block, and its activated abilities can't be activated.\nSacrifice Linvala: Choose hexproof or indestructible. Creatures you control gain that ability until end of turn.",
             "colours": [
@@ -15186,7 +15186,7 @@
         },
         {
             "id": "7bab8861-40c1-5895-91d7-504b0eaaeae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a323ac2-b7c0-4eae-8c12-253ec1f81317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a323ac2-b7c0-4eae-8c12-253ec1f81317.jpg?1",
             "name": "Orah, Skyclave Hierophant",
             "text": "Lifelink\nWhenever Orah, Skyclave Hierophant or another Cleric you control dies, return target Cleric card with lesser converted mana cost from your graveyard to the battlefield.",
             "colours": [
@@ -15228,7 +15228,7 @@
         },
         {
             "id": "901e82f0-e2f1-5011-9e6e-acbf265b3412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0584fc6c-88c6-46b5-8cc5-42d4a6f7e2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0584fc6c-88c6-46b5-8cc5-42d4a6f7e2f4.jpg?1",
             "name": "Verazol, the Split Current",
             "text": "Verazol, the Split Current enters the battlefield with a +1/+1 counter on it for each mana spent to cast it.\nWhenever you cast a kicked spell, you may remove two +1/+1 counters from Verazol. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -15268,7 +15268,7 @@
         },
         {
             "id": "a4c05416-faac-5c33-9282-b0e2540fec93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59fa96-9bf1-41e2-b687-87704d2ec3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59fa96-9bf1-41e2-b687-87704d2ec3a7.jpg?1",
             "name": "Yasharn, Implacable Earth",
             "text": "When Yasharn enters the battlefield, search your library for a basic Forest card and a basic Plains card, reveal those cards, put them into your hand, then shuffle your library.\nPlayers can't pay life or sacrifice nonland permanents to cast spells or activate abilities.",
             "colours": [
@@ -15309,7 +15309,7 @@
         },
         {
             "id": "01a77bd3-365b-5053-a9a0-a72effcd9976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1158d64-50fa-41ac-9967-c95237fc207a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1158d64-50fa-41ac-9967-c95237fc207a.jpg?1",
             "name": "Zagras, Thief of Heartbeats",
             "text": "This spell costs {1} less to cast for each creature in your party.\nFlying, deathtouch, haste\nOther creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -15350,7 +15350,7 @@
         },
         {
             "id": "b7c4d629-4cdd-573d-a19a-363ad7f095dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f0b9a-d8a2-4b34-a23e-61cd6630ce3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f0b9a-d8a2-4b34-a23e-61cd6630ce3d.jpg?1",
             "name": "Zareth San, the Trickster",
             "text": "Flash\n{2}{U}{B}, Return an unblocked attacking Rogue you control to its owner's hand: Put Zareth San, the Trickster from your hand onto the battlefield tapped and attacking.\nWhenever Zareth San deals combat damage to a player, you may put target permanent card from that player's graveyard onto the battlefield under your control.",
             "colours": [
@@ -15391,7 +15391,7 @@
         },
         {
             "id": "bece5558-8292-58ec-b2e5-9705ee174c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8f362c-f035-48b3-8e74-ef23240b44f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8f362c-f035-48b3-8e74-ef23240b44f7.jpg?1",
             "name": "Forsaken Monument",
             "text": "Colorless creatures you control get +2/+2.\nWhenever you tap a permanent for {C}, add an additional {C}.\nWhenever you cast a colorless spell, you gain 2 life.",
             "colours": [],
@@ -15423,7 +15423,7 @@
         },
         {
             "id": "3d0db380-3fa9-5ed1-8106-535eba2c266d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b02012-56b1-4386-936b-139480162e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b02012-56b1-4386-936b-139480162e8f.jpg?1",
             "name": "Lithoform Engine",
             "text": "{2}, {T}: Copy target activated or triggered ability you control. You may choose new targets for the copy.\n{3}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}, {T}: Copy target permanent spell you control.",
             "colours": [],
@@ -15455,7 +15455,7 @@
         },
         {
             "id": "82e28780-671f-5813-8d68-0a32d45a79f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11e4bb6-8ab3-4402-b474-0fb8cbccd802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11e4bb6-8ab3-4402-b474-0fb8cbccd802.jpg?1",
             "name": "Myriad Construct",
             "text": "Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.",
             "colours": [],
@@ -15488,7 +15488,7 @@
         },
         {
             "id": "190b0d86-3791-5333-a7c6-e8e7a676345e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2fb74a-d235-4ba6-bd7e-d439478dce44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2fb74a-d235-4ba6-bd7e-d439478dce44.jpg?1",
             "name": "Skyclave Relic",
             "text": "Kicker {3}\nIndestructible\nWhen Skyclave Relic enters the battlefield, if it was kicked, create two tapped tokens that are copies of Skyclave Relic.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -15518,7 +15518,7 @@
         },
         {
             "id": "35b3e481-2f8c-595f-ac85-b56d1b20111e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9078dbd-65c5-4b02-ac21-c3d2da05b8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9078dbd-65c5-4b02-ac21-c3d2da05b8ec.jpg?1",
             "name": "Crawling Barrens",
             "text": "{T}: Add {C}.\n{4}: Put two +1/+1 counters on Crawling Barrens. Then you may have it become a 0/0 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -15548,7 +15548,7 @@
         },
         {
             "id": "0728d7e5-314a-5480-bea1-928524185260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2731e9-ea63-4615-9ca4-8759fb15881e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2731e9-ea63-4615-9ca4-8759fb15881e.jpg?1",
             "name": "Throne of Makindi",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a charge counter on Throne of Makindi.\n{T}, Remove a charge counter from Throne of Makindi: Add two mana of any one color. Spend this mana only to cast kicked spells.",
             "colours": [],
@@ -15578,7 +15578,7 @@
         },
         {
             "id": "45260a6a-bb6a-521c-98c3-cd6643ac4f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae92e656-6c9d-48c3-a238-5a11c2c62ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae92e656-6c9d-48c3-a238-5a11c2c62ec8.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15616,7 +15616,7 @@
         },
         {
             "id": "bc649741-e3df-531f-b52c-b3634cb80c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589a324f-4466-4d4a-8cfb-806a041d7c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589a324f-4466-4d4a-8cfb-806a041d7c1f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15654,7 +15654,7 @@
         },
         {
             "id": "8148c863-ee4b-5204-b115-3f172931e08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1967d4a8-6cc4-4a4d-9d24-93257de35e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1967d4a8-6cc4-4a4d-9d24-93257de35e6d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "6c9650e9-4b6c-5954-94eb-dc6c0418a760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6a38dd-e8f5-420f-9576-66937c71286b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6a38dd-e8f5-420f-9576-66937c71286b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15730,7 +15730,7 @@
         },
         {
             "id": "2f8a3f3d-3b11-5f26-b766-0b0bbda0a5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90e88b-60a3-4d1d-bb8c-14633e5005a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90e88b-60a3-4d1d-bb8c-14633e5005a5.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15768,7 +15768,7 @@
         },
         {
             "id": "fce0a486-fb7e-5e33-bea2-573c4e6529be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc715da-970a-4525-a752-a3b7a0f1e87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc715da-970a-4525-a752-a3b7a0f1e87b.jpg?1",
             "name": "Orah, Skyclave Hierophant",
             "text": "",
             "colours": [
@@ -15809,7 +15809,7 @@
         },
         {
             "id": "b335008d-c678-52cd-8f87-7fc71832365b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e23886b-8200-427d-99af-068a0133795d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e23886b-8200-427d-99af-068a0133795d.jpg?1",
             "name": "Charix, the Raging Isle",
             "text": "",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "3f492516-7767-5ed7-a1d4-e3f7c06aee2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c2c3d7-3437-44b8-8d39-d3abe02af50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c2c3d7-3437-44b8-8d39-d3abe02af50e.jpg?1",
             "name": "Into the Roil",
             "text": "",
             "colours": [
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "3f9a0369-5fe7-5aee-85fe-3cfaacd275af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7be5c0a-b538-4bc5-89c7-f5a81de7ccc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7be5c0a-b538-4bc5-89c7-f5a81de7ccc3.jpg?1",
             "name": "Bloodchief's Thirst",
             "text": "",
             "colours": [
@@ -15916,7 +15916,7 @@
         },
         {
             "id": "97577e9e-69a9-5a8b-9c24-a72703790046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c02ec-f21e-405b-8267-7f7ff089904a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c02ec-f21e-405b-8267-7f7ff089904a.jpg?1",
             "name": "Roil Eruption",
             "text": "",
             "colours": [
@@ -15950,7 +15950,7 @@
         },
         {
             "id": "deb51cbd-b890-5b2d-9d6f-7b896e16c6fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa531b2-ccd5-489b-9edf-4cab01aca7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa531b2-ccd5-489b-9edf-4cab01aca7fd.jpg?1",
             "name": "Roiling Regrowth",
             "text": "",
             "colours": [
@@ -15984,7 +15984,7 @@
         },
         {
             "id": "46407d93-df48-5161-95fe-f24086746663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1409-4e7c-445e-ae6b-b3133faf1f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1409-4e7c-445e-ae6b-b3133faf1f73.jpg?1",
             "name": "Kargan Warleader",
             "text": "",
             "colours": [
@@ -16023,7 +16023,7 @@
         },
         {
             "id": "d640859a-29e8-5cff-a0c0-5816ae2813b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91098481-46c2-49bf-8123-e9cab2f22b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91098481-46c2-49bf-8123-e9cab2f22b84.jpg?1",
             "name": "Angel Warrior",
             "text": "",
             "colours": [
@@ -16059,7 +16059,7 @@
         },
         {
             "id": "11584d9e-92a2-5ed4-acd9-df46cbe26f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f458f39-27b6-4121-bda9-1a0d1b42f5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f458f39-27b6-4121-bda9-1a0d1b42f5fb.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16094,7 +16094,7 @@
         },
         {
             "id": "e20db866-4106-56e6-b6e6-898d17870875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c91781-acf9-4cff-be1a-85148ad2a683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c91781-acf9-4cff-be1a-85148ad2a683.jpg?1",
             "name": "Cat Beast",
             "text": "",
             "colours": [
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "04bfbf2c-20cb-5e2a-b32d-118d9e12c9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13412797-f831-49fe-adf3-369cdfacdbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13412797-f831-49fe-adf3-369cdfacdbd5.jpg?1",
             "name": "Kor Warrior",
             "text": "",
             "colours": [
@@ -16166,7 +16166,7 @@
         },
         {
             "id": "f21130a4-98f8-5e32-875a-b0ffe39d1d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1659d2ee-1831-4ba1-a08d-03af31c9a043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1659d2ee-1831-4ba1-a08d-03af31c9a043.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "e06431b6-e469-59ea-ae40-070e3c7d224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300635e-7771-4676-a5a5-29a9d8f49f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300635e-7771-4676-a5a5-29a9d8f49f1a.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -16236,7 +16236,7 @@
         },
         {
             "id": "c260fa03-ae9a-5bda-8c06-aab126a23edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84da9c36-5d9c-4e29-b6cc-c5c10e490f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84da9c36-5d9c-4e29-b6cc-c5c10e490f2e.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16271,7 +16271,7 @@
         },
         {
             "id": "eca9a6c2-1883-5ba3-9e0f-4317701db374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03d87f5-0ac6-45ca-a54b-6a36132a8eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03d87f5-0ac6-45ca-a54b-6a36132a8eae.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -16306,7 +16306,7 @@
         },
         {
             "id": "d3514110-ce8f-5d62-9991-f498505241b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ad0395-190d-4779-81b7-2832dc257828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ad0395-190d-4779-81b7-2832dc257828.jpg?1",
             "name": "Hydra",
             "text": "",
             "colours": [
@@ -16343,7 +16343,7 @@
         },
         {
             "id": "5f94537e-fc38-5705-9ad7-753043780a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462c167-e6cf-46f8-9b77-2a88815e3b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462c167-e6cf-46f8-9b77-2a88815e3b82.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -16375,7 +16375,7 @@
         },
         {
             "id": "c7db9aee-80eb-537f-8b1c-e643957e87b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24a63e2-c2b3-43f8-a15a-68886bec7d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24a63e2-c2b3-43f8-a15a-68886bec7d60.jpg?1",
             "name": "Goblin Construct",
             "text": "",
             "colours": [],
@@ -16408,7 +16408,7 @@
         },
         {
             "id": "61aa5086-680f-5638-801a-69b49c0fe160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f62ebf-1600-4eaa-a998-3fd7d1ea2f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f62ebf-1600-4eaa-a998-3fd7d1ea2f65.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/10E.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/10E.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5f8287b1-5bb6-5f4c-ad17-316a40d5bb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5cd03c-4227-4551-aa4b-7d119f0468b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5cd03c-4227-4551-aa4b-7d119f0468b5.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Ancestor's Chosen comes into play, you gain 1 life for each card in your graveyard.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "b7c19924-b4bf-56fc-aa73-f586e940bd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82072a1d-c1ab-4b4f-875f-d0591447e0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82072a1d-c1ab-4b4f-875f-d0591447e0a4.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "57aaebc1-850c-503d-9f6e-bb8d00d8bf7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7980d4-da43-4d6d-ad16-14b8a34ae91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7980d4-da43-4d6d-ad16-14b8a34ae91d.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "8fd4e2eb-3eb4-50ea-856b-ef638fa47f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0157252-6949-4f03-a15c-c168512123a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0157252-6949-4f03-a15c-c168512123a8.jpg?1",
             "name": "Angel of Mercy",
             "text": "",
             "colours": [
@@ -146,7 +146,7 @@
         },
         {
             "id": "55bd38ca-dc73-5c06-8f80-a6ddd2f44382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285aa3f-bcfb-4fc3-8441-85a56c72a3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285aa3f-bcfb-4fc3-8441-85a56c72a3e4.jpg?1",
             "name": "Angelic Blessing",
             "text": "Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "c5655330-5131-5f40-9d3e-0549d88c6e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7f007-2fe3-47c2-aaa3-b8d084053bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7f007-2fe3-47c2-aaa3-b8d084053bae.jpg?1",
             "name": "Angelic Blessing",
             "text": "",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "3b77bb52-4181-57f5-b3cd-f3a15b95aa29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835ff5d-e03d-4a93-98bb-704eaa1e2b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835ff5d-e03d-4a93-98bb-704eaa1e2b64.jpg?1",
             "name": "Angelic Chorus",
             "text": "Whenever a creature comes into play under your control, you gain life equal to its toughness.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "fadda48c-6226-5ac5-a2b9-e9170d2017cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa1f42f-1729-46ea-99c6-015d66c627d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa1f42f-1729-46ea-99c6-015d66c627d4.jpg?1",
             "name": "Angelic Wall",
             "text": "Defender, flying (This creature can't attack, and it can block creatures with flying.)",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "60b93108-8790-591b-844e-c3d311698767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e26cb-c77a-4ba1-ba3d-e649bfab3d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e26cb-c77a-4ba1-ba3d-e649bfab3d24.jpg?1",
             "name": "Angelic Wall",
             "text": "",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "fac6ad26-f8c2-51bd-9f6a-a1b0940b4cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae635d18-5d22-494c-8bc7-5d52f3021cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae635d18-5d22-494c-8bc7-5d52f3021cbb.jpg?1",
             "name": "Aura of Silence",
             "text": "Artifact and enchantment spells your opponents play cost {2} more to play.\nSacrifice Aura of Silence: Destroy target artifact or enchantment.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "8ac972b5-9f6e-5cc8-91c3-b9a40a98232e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407110e9-19af-4ff5-97b2-c03225031a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407110e9-19af-4ff5-97b2-c03225031a73.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "6adaf14d-43e3-521a-adf1-960c808e5b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671cbd0e-b9d8-403a-ad12-f2ddb275b08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671cbd0e-b9d8-403a-ad12-f2ddb275b08a.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "a69b404f-144a-5317-b10e-7d9dce135b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d17394-b9c4-43f6-9a6d-2c7c7ecb1d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d17394-b9c4-43f6-9a6d-2c7c7ecb1d74.jpg?1",
             "name": "Ballista Squad",
             "text": "{X}{W}, {T}: Ballista Squad deals X damage to target attacking or blocking creature.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "6d268c95-c176-5766-9a46-c14f739aba1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c17e3b-4d7f-4472-afe1-8e9358b82f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c17e3b-4d7f-4472-afe1-8e9358b82f2c.jpg?1",
             "name": "Bandage",
             "text": "Prevent the next 1 damage that would be dealt to target creature or player this turn.\nDraw a card.",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "56f4935b-f6c5-59b9-88bf-9bcce20247ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9b5da-d3fa-4d70-a71a-a2342dbfd527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9b5da-d3fa-4d70-a71a-a2342dbfd527.jpg?1",
             "name": "Beacon of Immortality",
             "text": "Double target player's life total. Shuffle Beacon of Immortality into its owner's library.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "62365fbb-af07-5c2a-976d-e3092bdfc317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ae60d0-20d3-452c-9953-e229567c06f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ae60d0-20d3-452c-9953-e229567c06f5.jpg?1",
             "name": "Benalish Knight",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "0d2a4e1d-cc12-5675-8044-9a7bc7d60050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccebfdd-85cb-4549-93a4-c0dcd667ee04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccebfdd-85cb-4549-93a4-c0dcd667ee04.jpg?1",
             "name": "Benalish Knight",
             "text": "",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "81daea6a-2735-5a46-a2da-b65a2ad5738f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe04dfe7-6376-4c12-9404-0e1ae0942917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe04dfe7-6376-4c12-9404-0e1ae0942917.jpg?1",
             "name": "Cho-Manno, Revolutionary",
             "text": "Prevent all damage that would be dealt to Cho-Manno, Revolutionary.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "7fef665c-36a1-5f7a-9299-cf8938708710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9edff0-58a8-405d-9f2e-39f8269bbcb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9edff0-58a8-405d-9f2e-39f8269bbcb2.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -658,7 +658,7 @@
         },
         {
             "id": "2f9c211e-1869-5b3f-94ea-f73b7910a5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197c672-dfa1-4d1e-97ea-af916864d23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197c672-dfa1-4d1e-97ea-af916864d23c.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -690,7 +690,7 @@
         },
         {
             "id": "668c64a2-cecb-5f48-af16-d7a64814d3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e22d287-274e-4222-9ed7-3e609a84ac07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e22d287-274e-4222-9ed7-3e609a84ac07.jpg?1",
             "name": "Field Marshal",
             "text": "Other Soldier creatures get +1/+1 and have first strike. (They deal combat damage before creatures without first strike.)",
             "colours": [
@@ -726,7 +726,7 @@
         },
         {
             "id": "6d6a31d5-a80b-5f31-9b46-2c2083a95581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac20a92-9650-4cb1-bf7a-752a5db31b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac20a92-9650-4cb1-bf7a-752a5db31b39.jpg?1",
             "name": "Field Marshal",
             "text": "",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "d68306e2-9877-5987-84b3-12b8234c8eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd81534-79cb-4fde-bfa5-11c510ac6e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd81534-79cb-4fde-bfa5-11c510ac6e11.jpg?1",
             "name": "Ghost Warden",
             "text": "{T}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "546eac7c-1424-597d-ac13-bf8558e88fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbc588-019e-416a-938c-4ccbe7121335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbc588-019e-416a-938c-4ccbe7121335.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -828,7 +828,7 @@
         },
         {
             "id": "c19bcfc2-fc10-5040-8239-1c193098df47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a49daec-5f0f-497b-a88e-fa62bf48ca23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a49daec-5f0f-497b-a88e-fa62bf48ca23.jpg?1",
             "name": "Hail of Arrows",
             "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
             "colours": [
@@ -860,7 +860,7 @@
         },
         {
             "id": "36fcaa1e-64e3-56e3-950c-907db167e41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa4b29-ce6b-4579-bee6-06a9ccfda55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa4b29-ce6b-4579-bee6-06a9ccfda55c.jpg?1",
             "name": "Heart of Light",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nPrevent all damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "08548840-8e62-5fed-b432-f2a5a0cb5f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f599cc6e-1ecb-407c-98fc-06e903f8b72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f599cc6e-1ecb-407c-98fc-06e903f8b72f.jpg?1",
             "name": "Heart of Light",
             "text": "",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "60f49caf-3583-5f85-b4b3-08dca73a8628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79b3153-8874-458d-8e7e-cf97c6c1887c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79b3153-8874-458d-8e7e-cf97c6c1887c.jpg?1",
             "name": "High Ground",
             "text": "Each creature you control can block an additional creature.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "02e23fa1-b2f0-528c-b331-12a0c27bc5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3895c0c-0db8-4962-b386-57887fb60701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3895c0c-0db8-4962-b386-57887fb60701.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "4e4cbdec-e2d4-5f31-98a3-f2ef052c849d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21264cb-d915-4431-92fd-b0aa32a715fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21264cb-d915-4431-92fd-b0aa32a715fc.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "79996e77-112f-51e8-980c-0ec82f2d7754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b957dd74-d6c0-4da1-a7e8-86459f23d090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b957dd74-d6c0-4da1-a7e8-86459f23d090.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "9bee1901-1125-5635-9e22-3b4f37989c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a5add-87af-447d-9fd7-c4aeec3685fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a5add-87af-447d-9fd7-c4aeec3685fb.jpg?1",
             "name": "Honor Guard",
             "text": "{W}: Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "cb865391-5b14-58ce-aa99-b36b83e6377f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f8c040-b6da-42f4-9140-7cd5eceb51c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f8c040-b6da-42f4-9140-7cd5eceb51c7.jpg?1",
             "name": "Icatian Priest",
             "text": "{1}{W}{W}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "bb6e511d-3e7f-5dd3-b40c-dbeb09c734f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d742a-52a1-45c8-961a-85b6ff120c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d742a-52a1-45c8-961a-85b6ff120c44.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "{T}: All combat damage that would be dealt to you by unblocked creatures this turn is dealt to Kjeldoran Royal Guard instead.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "73e8c198-4ba4-5f42-9781-167150eae4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bf030b-4e20-49b0-837f-935f96b5d1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bf030b-4e20-49b0-837f-935f96b5d1fe.jpg?1",
             "name": "Loxodon Mystic",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -1204,7 +1204,7 @@
         },
         {
             "id": "3f809288-0eaa-5f55-8144-483ed8ea810c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf02b5fa-8589-462e-90f5-552c8f28a22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf02b5fa-8589-462e-90f5-552c8f28a22f.jpg?1",
             "name": "Loyal Sentry",
             "text": "When Loyal Sentry blocks a creature, destroy that creature and Loyal Sentry.",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "efe6103c-6a3e-5ed0-a689-81a2efe4273b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc636-439f-4ce0-8189-5d00b0cf6b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc636-439f-4ce0-8189-5d00b0cf6b1a.jpg?1",
             "name": "Luminesce",
             "text": "Prevent all damage that black sources and red sources would deal this turn.",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "7f1bea50-20c0-51b3-8b2a-ac60f5d31133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccc50a9-2cd0-4ee0-b4c9-a181b6b0cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccc50a9-2cd0-4ee0-b4c9-a181b6b0cc7f.jpg?1",
             "name": "Mobilization",
             "text": "Soldier creatures have vigilance. (Attacking doesn't cause them to tap.)\n{2}{W}: Put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "1afcbee1-1310-5144-86ea-e7bf0fb34d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8afceba-d9f6-4a98-8dbd-f6922492a296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8afceba-d9f6-4a98-8dbd-f6922492a296.jpg?1",
             "name": "Mobilization",
             "text": "",
             "colours": [
@@ -1337,7 +1337,7 @@
         },
         {
             "id": "5d53a06b-68a0-5d1a-a1a5-a676f16c23dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468f109-8020-4a74-8ffd-bba771362f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468f109-8020-4a74-8ffd-bba771362f76.jpg?1",
             "name": "Nomad Mythmaker",
             "text": "{W}, {T}: Put target Aura card in a graveyard into play attached to a creature you control. (You control that Aura.)",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "ac19e0e0-6d8e-55ad-a7a9-68fd6032eaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11417661-a53f-4392-abb3-b415fd939311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11417661-a53f-4392-abb3-b415fd939311.jpg?1",
             "name": "Nomad Mythmaker",
             "text": "",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "26fc6830-a092-5e24-9b58-97f4c38f3e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686352f6-d8e7-4d31-83bd-3d087c103e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686352f6-d8e7-4d31-83bd-3d087c103e75.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature can't attack or block.",
             "colours": [
@@ -1446,7 +1446,7 @@
         },
         {
             "id": "b1e43df0-d501-5297-9cb4-c84d2a76945d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84817323-785e-4f8c-b0ce-6b9e36bebaf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84817323-785e-4f8c-b0ce-6b9e36bebaf1.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "214dbfe9-0f16-5b6b-be30-8771192a89ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1a8e1-35f4-4b4a-aa68-21b5219527a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1a8e1-35f4-4b4a-aa68-21b5219527a9.jpg?1",
             "name": "Paladin en-Vec",
             "text": "First strike, protection from black, protection from red (This creature deals combat damage before creatures without first strike. It can't be blocked, targeted, dealt damage, or enchanted by anything black or red.)",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "08a671f0-ea90-531e-bbeb-c00793a57672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1db895-5e14-48c7-b464-4e36be432579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1db895-5e14-48c7-b464-4e36be432579.jpg?1",
             "name": "Paladin en-Vec",
             "text": "",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "7dff9ddf-213e-593d-a007-a72cf6ff925e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3f7e4f-57d1-4b8b-85d7-ef62ceccce93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3f7e4f-57d1-4b8b-85d7-ef62ceccce93.jpg?1",
             "name": "Pariah",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nAll damage that would be dealt to you is dealt to enchanted creature instead.",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "9f315280-5d52-5dea-a679-a2d97386907e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c110365-493f-4995-b919-59d0f4e2092c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c110365-493f-4995-b919-59d0f4e2092c.jpg?1",
             "name": "Pariah",
             "text": "",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "39b50224-8305-56dd-9849-09deecb07d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3dd79-ac4c-4ffc-9442-1efa0082f60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3dd79-ac4c-4ffc-9442-1efa0082f60f.jpg?1",
             "name": "Reviving Dose",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "6028cab2-0478-584b-a880-8174a88eb188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81ef83-41c2-46dc-aff9-41bb3a32637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81ef83-41c2-46dc-aff9-41bb3a32637a.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nAt the beginning of your upkeep, you may return target creature card from your graveyard to play.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "341f9c8d-a838-58f9-933b-094c8d889a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9349fdc-3d9c-4fa9-88b6-a7bc782bfd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9349fdc-3d9c-4fa9-88b6-a7bc782bfd44.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "9a14261a-b567-5429-a5ca-a913e15d8bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda6c9d5-113f-44f1-bfaf-c40001ba9f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda6c9d5-113f-44f1-bfaf-c40001ba9f60.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "eee00aa2-c730-5ff1-84a9-51d95a9fe180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529ebe9-c809-4c84-9096-1fa05388b660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529ebe9-c809-4c84-9096-1fa05388b660.jpg?1",
             "name": "Rule of Law",
             "text": "Each player can't play more than one spell each turn.",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "a2be2e9b-5211-53e6-ac6a-abd65dbcac1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621f9a58-0bc8-40dd-aef1-43618274d6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621f9a58-0bc8-40dd-aef1-43618274d6fe.jpg?1",
             "name": "Samite Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "be665b02-1cf2-50c6-8861-85da921bc853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b2f11-7420-4fa7-98f0-4f4be2093355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b2f11-7420-4fa7-98f0-4f4be2093355.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance (This creature can't be blocked except by creatures with flying or reach, and attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "b2f56602-e85a-588f-a4be-40b6e56f44f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354aa649-0261-4fb3-ac83-babc0e957be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354aa649-0261-4fb3-ac83-babc0e957be2.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "fe9187fa-cd14-5618-9a62-bcf18b523d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba6c4f3-59cf-4eb8-97fb-c9138005e19c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba6c4f3-59cf-4eb8-97fb-c9138005e19c.jpg?1",
             "name": "Serra's Embrace",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+2 and has flying and vigilance. (It can't be blocked except by creatures with flying or reach, and attacking doesn't cause it to tap.)",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "dc219ada-64b4-5846-9840-e49986109aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288d296-a8d5-43b5-b281-ba7063407724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288d296-a8d5-43b5-b281-ba7063407724.jpg?1",
             "name": "Serra's Embrace",
             "text": "",
             "colours": [
@@ -1968,7 +1968,7 @@
         },
         {
             "id": "db398a18-0d81-50ba-bc86-a7de52a1be7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cda455-34dc-45b6-aafc-825c1c42b67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cda455-34dc-45b6-aafc-825c1c42b67b.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "Flying, first strike (This creature can't be blocked except by creatures with flying or reach, and it deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "db62961f-51de-569a-bfd8-b3f82abf1b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9989475-fba5-4043-98bd-a4eb106eb487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9989475-fba5-4043-98bd-a4eb106eb487.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "66993685-84dd-5143-9454-8a4028d10a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa4af5-f0cb-4512-bef5-2e46a43aa27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa4af5-f0cb-4512-bef5-2e46a43aa27b.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying, vigilance (This creature can't be blocked except by creatures with flying or reach, and attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "5e670818-f7b1-52a6-bc6f-c9eccb8ce3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae3b1f4-54d3-40b5-8696-1d0e1989e931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae3b1f4-54d3-40b5-8696-1d0e1989e931.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "261c0ce9-13d9-58e2-922b-d4068ff4d743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fd8f5-6e12-4675-99bb-b493af6a9e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fd8f5-6e12-4675-99bb-b493af6a9e52.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "Flying, double strike (This creature can't be blocked except by creatures with flying or reach, and it deals both first-strike and regular combat damage.)",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "0bd58de8-5807-55d0-a5ad-ebe42f2f1ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bfcc61-80fe-4d21-8219-d31420a28989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bfcc61-80fe-4d21-8219-d31420a28989.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "bcc70712-566e-5a6f-8d73-f1ab87c57454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe5fe13-b57d-4514-89e6-79909474f7e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe5fe13-b57d-4514-89e6-79909474f7e8.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature comes into play, you gain 1 life.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "a563f008-ed9f-5fc4-b6aa-1e68d63cb814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d0e011-b0e3-461d-bbf2-bb1ca77b94bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d0e011-b0e3-461d-bbf2-bb1ca77b94bd.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "0da4a2a0-4d13-5c8a-bdff-12b67070798e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc4de07-4a46-41d6-81b8-4d6299b88ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc4de07-4a46-41d6-81b8-4d6299b88ee7.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "ae68e914-6896-5ee8-af5f-8ea88f5e0200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e436d-5c46-4a39-b773-99548befb9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e436d-5c46-4a39-b773-99548befb9fa.jpg?1",
             "name": "Spirit Weaver",
             "text": "{2}: Target green or blue creature gets +0/+1 until end of turn.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "ecf2b08e-7eca-5f13-a9f7-7a915ee259f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d2139e-76ea-49e2-ac43-6d9cc51ca09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d2139e-76ea-49e2-ac43-6d9cc51ca09f.jpg?1",
             "name": "Starlight Invoker",
             "text": "{7}{W}: You gain 5 life.",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "c81dca90-b0cf-5ce8-965c-8dbe5a55cc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a5c12b-c947-4a71-b54f-e310150858a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a5c12b-c947-4a71-b54f-e310150858a3.jpg?1",
             "name": "Steadfast Guard",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "c3b8083a-bbe4-524f-8e90-8b8a493152db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07631735-2024-4e7a-b8b3-b7743f4e4a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07631735-2024-4e7a-b8b3-b7743f4e4a86.jpg?1",
             "name": "Steadfast Guard",
             "text": "",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "b5bdfa8c-00ab-5b6a-b97a-ee77ffcbc4e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6194fab1-c185-4df5-8900-37d28ffae545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6194fab1-c185-4df5-8900-37d28ffae545.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "6b754dda-9a6c-5762-ae67-8069101eb4d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4886566-af41-4d14-8ae1-ce2952db8e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4886566-af41-4d14-8ae1-ce2952db8e42.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "f286fe97-e2ad-5a5a-8e7f-0caa9dc898b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d4bbec-c20b-437f-88e2-d609fd7c6003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d4bbec-c20b-437f-88e2-d609fd7c6003.jpg?1",
             "name": "Suntail Hawk",
             "text": "",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "f44e0c48-1740-5e18-859f-4e4615f3a3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1475f999-5a85-4177-aa30-15c51cf69812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1475f999-5a85-4177-aa30-15c51cf69812.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -2566,7 +2566,7 @@
         },
         {
             "id": "cfa41bcc-edea-53e6-8aec-e7f9d5d23089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0282b59e-78ef-412d-bb76-fb337f32a213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0282b59e-78ef-412d-bb76-fb337f32a213.jpg?1",
             "name": "Treasure Hunter",
             "text": "When Treasure Hunter comes into play, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "46743f03-e0a4-5976-8d42-c3b698384b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a9c5c4-47d1-4b87-8cbd-2212ee6c5887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a9c5c4-47d1-4b87-8cbd-2212ee6c5887.jpg?1",
             "name": "True Believer",
             "text": "You have shroud. (You can't be the target of spells or abilities.)",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "c84cfe08-d681-58e9-a003-1447f3b6d0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e41e3-919c-4bd3-9eea-adc0291f5f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e41e3-919c-4bd3-9eea-adc0291f5f8a.jpg?1",
             "name": "True Believer",
             "text": "",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "94cb0244-f6ae-50c5-ba26-fd3f861c3bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f573db-f4f8-4311-ba47-234e5171da3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f573db-f4f8-4311-ba47-234e5171da3d.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2707,7 +2707,7 @@
         },
         {
             "id": "ede09d78-f4b5-59eb-8356-dd125323f74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eec9aa-3058-4746-9a7d-0e880b0ce3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eec9aa-3058-4746-9a7d-0e880b0ce3ad.jpg?1",
             "name": "Tundra Wolves",
             "text": "",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "8732b0a8-0c4e-5179-9855-d139dbad85c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36501d5-4f45-4191-b8ec-6ab435b61bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36501d5-4f45-4191-b8ec-6ab435b61bc1.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "814b54df-221c-5fdb-a516-0fbd438b57a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4673ac-4305-4fb2-9ba2-1c72f04574c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4673ac-4305-4fb2-9ba2-1c72f04574c3.jpg?1",
             "name": "Voice of All",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nAs Voice of All comes into play, choose a color.\nVoice of All has protection from the chosen color. (It can't be blocked, targeted, dealt damage, or enchanted by anything of the chosen color.)",
             "colours": [
@@ -2813,7 +2813,7 @@
         },
         {
             "id": "3c6b79b0-1a84-5584-83c6-954430868f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db289ae0-b36a-43de-9e1b-56aaf6bf6ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db289ae0-b36a-43de-9e1b-56aaf6bf6ad8.jpg?1",
             "name": "Voice of All",
             "text": "",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "fefca4a6-440f-56be-ba90-b8587c55d347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6938602-d531-4ff1-abb3-c7982864c2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6938602-d531-4ff1-abb3-c7982864c2e0.jpg?1",
             "name": "Wall of Swords",
             "text": "Defender, flying (This creature can't attack, and it can block creatures with flying.)",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "4ffc3780-0054-5128-b97e-b19d06b483c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14792249-fadc-48a6-a4df-2034c576688f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14792249-fadc-48a6-a4df-2034c576688f.jpg?1",
             "name": "Wall of Swords",
             "text": "",
             "colours": [
@@ -2918,7 +2918,7 @@
         },
         {
             "id": "2bf3fff9-15c9-5cda-9a04-d0ea22180c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09117d06-79e6-4f86-ba92-d1f8fe165147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09117d06-79e6-4f86-ba92-d1f8fe165147.jpg?1",
             "name": "Warrior's Honor",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "75e792c1-d5d9-5712-9462-230fa196f861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ecf12-b750-4a95-85c8-8612d2a77a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ecf12-b750-4a95-85c8-8612d2a77a0a.jpg?1",
             "name": "Wild Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "9e583bce-5201-59f8-aa5c-f85c55824f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed40871-63a9-4ae2-8df8-8229e12fa252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed40871-63a9-4ae2-8df8-8229e12fa252.jpg?1",
             "name": "Wild Griffin",
             "text": "",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "556e35e6-ad67-51c6-8580-eda71597a507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b6d10c-89eb-42a9-beda-129dbc5c79af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b6d10c-89eb-42a9-beda-129dbc5c79af.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCreatures can't attack you unless their controller pays {2} for each creature he or she controls that's attacking you.",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "9e49c166-9728-5259-b3e9-758b3c1357c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd367-9f6c-42d2-ab67-54d6e3b61d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd367-9f6c-42d2-ab67-54d6e3b61d7b.jpg?1",
             "name": "Windborn Muse",
             "text": "",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "3c0d065a-4aa4-55f4-bc11-bd326d23e5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b969f680-b176-4bfa-a160-714de8e03c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b969f680-b176-4bfa-a160-714de8e03c25.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "f4937944-9439-5887-85e0-fc3705243da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb437-9c76-4b87-99ba-1e24047dc3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb437-9c76-4b87-99ba-1e24047dc3a6.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "bfed2fdd-d029-545f-88f7-5ab45446cf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b0f2a2-464d-41c1-a78a-49a4c1f0db69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b0f2a2-464d-41c1-a78a-49a4c1f0db69.jpg?1",
             "name": "Youthful Knight",
             "text": "",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "b8a68840-4044-52c0-a14e-0a1c630ba42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62ca800-ec24-476e-b56f-834eef9622a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62ca800-ec24-476e-b56f-834eef9622a9.jpg?1",
             "name": "Academy Researchers",
             "text": "When Academy Researchers comes into play, you may put an Aura card from your hand into play attached to Academy Researchers.",
             "colours": [
@@ -3229,7 +3229,7 @@
         },
         {
             "id": "76ddd7f5-1a84-55d5-98f5-4883c217e0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2326dd-78c9-46bb-a459-306602939a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2326dd-78c9-46bb-a459-306602939a41.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "76d4f437-02e5-5f1c-a1d3-eddb55e8725d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0720105-eb26-42a0-a12e-1f05e8af0f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0720105-eb26-42a0-a12e-1f05e8af0f3d.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "29723d8d-34c9-5009-8b79-2c679e35f674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b261067f-b5de-41cc-ba9e-6ef4c061e170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b261067f-b5de-41cc-ba9e-6ef4c061e170.jpg?1",
             "name": "Ambassador Laquatus",
             "text": "{3}: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -3336,7 +3336,7 @@
         },
         {
             "id": "6f08f7f6-ecfb-584f-ae7a-c6e4d9c4da35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed53483-4bec-491b-9ae6-afc6faf122a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed53483-4bec-491b-9ae6-afc6faf122a2.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "aeb1b742-645c-5dab-ba9b-35d51649e074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55552a2b-1861-4235-a60d-ccabb4839d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55552a2b-1861-4235-a60d-ccabb4839d54.jpg?1",
             "name": "Aura Graft",
             "text": "Gain control of target Aura that's attached to a permanent. Attach it to another permanent it can enchant.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "758df5d5-992f-5d30-b6bc-87cb1a0788ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2cd91-84a7-4d05-9a0c-55440491be1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2cd91-84a7-4d05-9a0c-55440491be1e.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "e4b4684b-8e14-5fcf-9286-497b7afd5b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21991934-378a-49e0-8678-0c444f8f94ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21991934-378a-49e0-8678-0c444f8f94ee.jpg?1",
             "name": "Aven Fisher",
             "text": "",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "d833c453-58c5-5ff6-91b2-f526ca5f808a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67d7ae-3117-433f-ad82-44a4f015fecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67d7ae-3117-433f-ad82-44a4f015fecf.jpg?1",
             "name": "Aven Windreader",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{1}{U}: Target player reveals the top card of his or her library.",
             "colours": [
@@ -3513,7 +3513,7 @@
         },
         {
             "id": "e11ae348-44d1-5d45-bc5c-99a44d2acd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c0a27-eefc-46f6-88ad-ab0846e802ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c0a27-eefc-46f6-88ad-ab0846e802ef.jpg?1",
             "name": "Aven Windreader",
             "text": "",
             "colours": [
@@ -3550,7 +3550,7 @@
         },
         {
             "id": "1aac00c8-3b6e-5bdd-9fde-6cfcbc7837c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4095675-1e3f-4d3c-b565-5c434d2e5cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4095675-1e3f-4d3c-b565-5c434d2e5cc0.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "cdc96814-2f52-5314-80ab-0cff2dcc5054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850d1d5-f506-4e50-9d51-408f987bbbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850d1d5-f506-4e50-9d51-408f987bbbbd.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -3614,7 +3614,7 @@
         },
         {
             "id": "9af574e4-dc6e-5246-8fe7-fee6c4c77a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c5272d-df5b-4c21-9bff-4d6245b8d2a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c5272d-df5b-4c21-9bff-4d6245b8d2a6.jpg?1",
             "name": "Cephalid Constable",
             "text": "Whenever Cephalid Constable deals combat damage to a player, return up to that many target permanents that player controls to their owners' hands.",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "8dfc67e9-8323-5d1f-9e25-9f9394abd5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782f78b-ff4d-4567-8606-d4f0ebb0a304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782f78b-ff4d-4567-8606-d4f0ebb0a304.jpg?1",
             "name": "Clone",
             "text": "As Clone comes into play, you may choose a creature in play. If you do, Clone comes into play as a copy of that creature.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "596a7bd4-895b-5e7c-8124-373fd709444d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc3025-704f-476b-bcb3-74b905755dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc3025-704f-476b-bcb3-74b905755dc9.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "4fed8c53-5ff9-51ce-a7a8-2fc629bf3d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa91c8a-0838-4c12-8f7a-c038ff6d6e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa91c8a-0838-4c12-8f7a-c038ff6d6e69.jpg?1",
             "name": "Cloud Elemental",
             "text": "",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "fdbec3b3-f6f2-5149-a70a-4f9d2622a87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feacf831-a6e4-456b-b8f2-d7ec554281a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feacf831-a6e4-456b-b8f2-d7ec554281a1.jpg?1",
             "name": "Cloud Sprite",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCloud Sprite can block only creatures with flying.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "ba5acf09-98cc-5052-b65e-c5145e92fc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0bf2fd-0341-461b-b19b-c79016f0d890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0bf2fd-0341-461b-b19b-c79016f0d890.jpg?1",
             "name": "Cloud Sprite",
             "text": "",
             "colours": [
@@ -3823,7 +3823,7 @@
         },
         {
             "id": "eb5c94c7-5494-5669-9c54-6f3672d65683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1224718a-e1a7-473d-ac9d-497e624376cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1224718a-e1a7-473d-ac9d-497e624376cd.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "Draw two cards.",
             "colours": [
@@ -3855,7 +3855,7 @@
         },
         {
             "id": "8d5f87fd-7a87-572b-bdce-303effec6b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186271c-2b03-4e0c-b922-27e23787d865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186271c-2b03-4e0c-b922-27e23787d865.jpg?1",
             "name": "Crafty Pathmage",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "5a50a7e8-2ed1-5e8a-8867-c96f1186bd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414ad73-146e-47a6-926a-ec148194bb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414ad73-146e-47a6-926a-ec148194bb50.jpg?1",
             "name": "Dehydration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "2bbaf3d6-9fbc-5ab8-93d3-d26e2ddec999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404659c-7354-419c-b6bb-7f2fe21af958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404659c-7354-419c-b6bb-7f2fe21af958.jpg?1",
             "name": "Dehydration",
             "text": "",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "a9a74d88-7663-5419-a74c-5a28e8642b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf37153-ec4c-4c2f-89f7-450f0a157311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf37153-ec4c-4c2f-89f7-450f0a157311.jpg?1",
             "name": "Deluge",
             "text": "Tap all creatures without flying.",
             "colours": [
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "f4ee3e9e-21da-5a63-8278-3efa59da7df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7e928-511c-4a31-b1fb-8c28bd41182a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7e928-511c-4a31-b1fb-8c28bd41182a.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep comes into play, return each other creature you control to its owner's hand.",
             "colours": [
@@ -4026,7 +4026,7 @@
         },
         {
             "id": "e2066f75-65de-5254-82f2-8e1f969bf31b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bee0d51-f4a1-4a3a-9ccd-540c3afe62d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bee0d51-f4a1-4a3a-9ccd-540c3afe62d0.jpg?1",
             "name": "Discombobulate",
             "text": "Counter target spell. Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "6f9ae90a-5638-5b88-a3d7-ccea4372eb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ebb96f-185b-4aa5-ad4b-9c02ce44d387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ebb96f-185b-4aa5-ad4b-9c02ce44d387.jpg?1",
             "name": "Dreamborn Muse",
             "text": "At the beginning of each player's upkeep, that player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards in his or her hand.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "100f46ae-e457-5491-b5d1-66cd9284304c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978fa0a-a52b-4464-afe3-d9f7bc202e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978fa0a-a52b-4464-afe3-d9f7bc202e63.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "f90fe5cb-ee47-51f2-8a8c-3ced26f1b446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e5fd8-2542-4fc9-a806-d9af287dd734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e5fd8-2542-4fc9-a806-d9af287dd734.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -4156,7 +4156,7 @@
         },
         {
             "id": "5d45d146-5a42-502e-affb-71f3e81cf7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95534175-0bf8-4460-8182-117dc1487dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95534175-0bf8-4460-8182-117dc1487dcb.jpg?1",
             "name": "Fog Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Fog Elemental attacks or blocks, sacrifice it at end of combat.",
             "colours": [
@@ -4191,7 +4191,7 @@
         },
         {
             "id": "6c515488-2a63-5b1e-84a4-987b5fa993af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5c785-a51d-4c43-8cda-57005ae566a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5c785-a51d-4c43-8cda-57005ae566a8.jpg?1",
             "name": "Fog Elemental",
             "text": "",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "4492a8f1-a2bf-581a-9ee0-e488f9241c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7be532-d353-4961-94bf-db3265515753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7be532-d353-4961-94bf-db3265515753.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "4405f887-4eb7-5e3e-874d-1bfe79ec0ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32862f4-53ed-41c7-b90f-5df2c01dd447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32862f4-53ed-41c7-b90f-5df2c01dd447.jpg?1",
             "name": "Horseshoe Crab",
             "text": "{U}: Untap Horseshoe Crab.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "5ac794d2-4c66-5332-afb1-54b24bc11823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a42c38-6129-4e6e-9e27-e2c812ce6f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a42c38-6129-4e6e-9e27-e2c812ce6f45.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "Return all artifacts target player owns to his or her hand.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "cb8e5b8f-706a-5b09-884e-ed32ceeec0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a03ba5a-ac27-4fce-9eaf-b029ab26f9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a03ba5a-ac27-4fce-9eaf-b029ab26f9e1.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "404d6f98-eefb-5dea-8e81-aed2b5956437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a79bb42-a4c4-46c6-a5ed-43bbf028a7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a79bb42-a4c4-46c6-a5ed-43bbf028a7f0.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "206c4a07-1442-5fee-acd8-7a8a00da57a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95fb2c-3d6b-4b12-8bf3-f869dd2c2a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95fb2c-3d6b-4b12-8bf3-f869dd2c2a17.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "60961bae-4655-5a6b-843d-f6180c2c310d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17edd1-e9ed-4fd5-a304-f9a34983d138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17edd1-e9ed-4fd5-a304-f9a34983d138.jpg?1",
             "name": "March of the Machines",
             "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
             "colours": [
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "82306a22-03b6-5cbd-ba72-0002755c4217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94aadbd-625c-4bfc-8e31-00a680094332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94aadbd-625c-4bfc-8e31-00a680094332.jpg?1",
             "name": "March of the Machines",
             "text": "",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "46a7e3a9-4e93-5d73-b35e-6ad63cc195cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e4e99d-5834-4f6c-b915-4f95edc1337f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e4e99d-5834-4f6c-b915-4f95edc1337f.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "7cf5654d-d547-50ce-838a-75ff6045fd0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a5bfa-9a50-4610-acd7-19fc0a53f798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a5bfa-9a50-4610-acd7-19fc0a53f798.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"islandwalk.\" This effect doesn't end at end of turn.)",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "b00ad339-0cc1-59d4-b8a4-c827b6512b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb5c0f0-fa65-4868-b0da-e4e7b4c9a2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb5c0f0-fa65-4868-b0da-e4e7b4c9a2f3.jpg?1",
             "name": "Mind Bend",
             "text": "",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "284ed7cc-8917-5005-bfa9-e7c61b1fb85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869a6c06-eae5-418e-9a5c-26598a929416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869a6c06-eae5-418e-9a5c-26598a929416.jpg?1",
             "name": "Peek",
             "text": "Look at target player's hand.\nDraw a card.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "b4f659b7-bef9-527b-95e8-55cc9c444ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e957fab3-7a79-4b8f-813a-daaabb0ccbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e957fab3-7a79-4b8f-813a-daaabb0ccbea.jpg?1",
             "name": "Persuasion",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nYou control enchanted creature.",
             "colours": [
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "022ee2d2-d02b-580e-a549-ed9555ef9153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab3611c-b0ab-48ea-8c64-e7c500e95fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab3611c-b0ab-48ea-8c64-e7c500e95fc5.jpg?1",
             "name": "Persuasion",
             "text": "",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "8d5006e3-45cb-5d9f-896d-83a22d86d53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ea51c-1ef0-49ed-93de-52f8f6a9d595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ea51c-1ef0-49ed-93de-52f8f6a9d595.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "5a1f3fc3-e970-5408-94ef-e7c78e57000b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ae2f8-1e19-495a-86a9-8391e1e14ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ae2f8-1e19-495a-86a9-8391e1e14ac5.jpg?1",
             "name": "Plagiarize",
             "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "c7f34f83-c800-5987-8520-5ae1705871d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0814958-2fec-443e-b27e-cd2416ccbf95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0814958-2fec-443e-b27e-cd2416ccbf95.jpg?1",
             "name": "Puppeteer",
             "text": "{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "4fa9bf42-9170-594e-bbf9-42111adea313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49a8b0d-f130-4a16-a79c-607618cc40bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49a8b0d-f130-4a16-a79c-607618cc40bd.jpg?1",
             "name": "Reminisce",
             "text": "Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "f37b2caa-03c5-51ec-a02a-c2e5311a9fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35673701-684c-4ba6-99f5-74364bc6fec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35673701-684c-4ba6-99f5-74364bc6fec2.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "9626b37d-3a04-5cd6-a636-943981354e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9948fcc3-6e95-4b39-accd-a4083fff1244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9948fcc3-6e95-4b39-accd-a4083fff1244.jpg?1",
             "name": "Robe of Mirrors",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "23aabc91-9146-5367-9cce-4fe955861abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110b92c8-6bc3-4b2d-b71d-d04db8c3b465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110b92c8-6bc3-4b2d-b71d-d04db8c3b465.jpg?1",
             "name": "Robe of Mirrors",
             "text": "",
             "colours": [
@@ -4937,7 +4937,7 @@
         },
         {
             "id": "f1eba89f-dd82-5843-80a9-e9b2cd3a6037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da47bd4-58b6-4ef3-bd42-caf947e38645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da47bd4-58b6-4ef3-bd42-caf947e38645.jpg?1",
             "name": "Rootwater Commando",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "f76ee94d-b1a1-5c9f-bdc8-4bf659844cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c1cfde-c08e-4fda-8b3c-7e7a0121f87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c1cfde-c08e-4fda-8b3c-7e7a0121f87b.jpg?1",
             "name": "Rootwater Commando",
             "text": "",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "fc96da15-9362-585a-b555-f7a7e5480e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09179261-aa02-4144-9028-3b8d6420a860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09179261-aa02-4144-9028-3b8d6420a860.jpg?1",
             "name": "Rootwater Matriarch",
             "text": "{T}: Gain control of target creature as long as that creature is enchanted.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "cdf65c48-2ac8-522a-bbcf-2f8165187a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed89567-cb18-4e51-a978-eac81d112aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed89567-cb18-4e51-a978-eac81d112aa1.jpg?1",
             "name": "Sage Owl",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Sage Owl comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "67adcf6f-bf56-5ca8-a3fb-a1045b4fba41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d6c0f1-7479-4f15-8d85-e8dfface190d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d6c0f1-7479-4f15-8d85-e8dfface190d.jpg?1",
             "name": "Sage Owl",
             "text": "",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "d5124438-a5d4-5b3b-88af-d179f4b9c9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ca697-bdf4-41df-973d-22a0ce89ad35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ca697-bdf4-41df-973d-22a0ce89ad35.jpg?1",
             "name": "Scalpelexis",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Scalpelexis deals combat damage to a player, that player removes the top four cards of his or her library from the game. If two or more of those cards have the same name, repeat this process.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "f4670242-6ae0-5ec4-872d-391386bb026b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d19d71-3ae2-4c48-aa7e-406b2c188b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d19d71-3ae2-4c48-aa7e-406b2c188b99.jpg?1",
             "name": "Scalpelexis",
             "text": "",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "9db6f50d-3242-5cbc-9f71-45477f4967df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3809b4c6-79b4-4a06-8fc9-beabc278cbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3809b4c6-79b4-4a06-8fc9-beabc278cbf8.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an Island.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "a122a3b0-b686-5b96-a02c-926423c65b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c9aa9f-acd5-4908-9e11-1a152363ef42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c9aa9f-acd5-4908-9e11-1a152363ef42.jpg?1",
             "name": "Shimmering Wings",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\n{U}: Return Shimmering Wings to its owner's hand.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "41b6098d-f7d9-5a37-9734-01dff7ce4912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2c0439-aed2-4ed5-b38a-d2b321811ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2c0439-aed2-4ed5-b38a-d2b321811ccc.jpg?1",
             "name": "Shimmering Wings",
             "text": "",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "39adc884-8e24-572d-ad54-74561b1cb139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917a5c02-89b1-4d06-8d65-8db8c9c485a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917a5c02-89b1-4d06-8d65-8db8c9c485a9.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -5317,7 +5317,7 @@
         },
         {
             "id": "18db55ad-e62f-5c76-a6b8-743378d6ea38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e0e4-d077-46a5-850c-68399fd16da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e0e4-d077-46a5-850c-68399fd16da6.jpg?1",
             "name": "Sky Weaver",
             "text": "{2}: Target white or black creature gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -5353,7 +5353,7 @@
         },
         {
             "id": "e451cc8a-2bbe-5850-adc4-fb1b738bcef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58d58cf-3023-43cd-8aec-61e32510471a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58d58cf-3023-43cd-8aec-61e32510471a.jpg?1",
             "name": "Sky Weaver",
             "text": "",
             "colours": [
@@ -5389,7 +5389,7 @@
         },
         {
             "id": "381e8d26-d8ca-5755-ba19-5fba857a7920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b2ad93-8287-4b87-88ed-c627bd54fd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b2ad93-8287-4b87-88ed-c627bd54fd49.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "c0b0e7a5-4252-57f5-8ed0-399d08c0523f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fdfc2-782c-4a3f-8761-ace19c479b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fdfc2-782c-4a3f-8761-ace19c479b07.jpg?1",
             "name": "Snapping Drake",
             "text": "",
             "colours": [
@@ -5459,7 +5459,7 @@
         },
         {
             "id": "e0d42d12-40a7-54d5-b688-84841a8bc72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0586e0-5e93-4742-a5ae-893edd49117d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0586e0-5e93-4742-a5ae-893edd49117d.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nSacrifice Spiketail Hatchling: Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -5494,7 +5494,7 @@
         },
         {
             "id": "c31c9d06-507b-59fa-a1bc-402d38a5d9a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4905c-9227-4f0f-a41a-d7509740c1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4905c-9227-4f0f-a41a-d7509740c1ce.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "",
             "colours": [
@@ -5529,7 +5529,7 @@
         },
         {
             "id": "0d3888b4-3eb2-5cb5-b7de-0c8a3257f0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f136c6af-fda0-4c4a-a67b-f431e4e51385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f136c6af-fda0-4c4a-a67b-f431e4e51385.jpg?1",
             "name": "Sunken Hope",
             "text": "At the beginning of each player's upkeep, that player returns a creature he or she controls to its owner's hand.",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "976585bc-fe72-56aa-b841-c4331d81655f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158b0bb5-04c0-41aa-ac39-43bb0f274fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158b0bb5-04c0-41aa-ac39-43bb0f274fd7.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -5593,7 +5593,7 @@
         },
         {
             "id": "27745694-8868-5240-aa72-cdb326bd1e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caf69d0-58bd-4cd1-9108-56e6cbf882e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caf69d0-58bd-4cd1-9108-56e6cbf882e4.jpg?1",
             "name": "Telling Time",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "3c265fdb-4a70-5ee7-ba8e-a67eac8d7b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96395d53-5eaa-4d17-a473-f685ad925eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96395d53-5eaa-4d17-a473-f685ad925eaf.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "2081f76c-b206-5d08-a191-fcb60723b9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270ec8a0-71c0-45dc-b79b-6272216eceb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270ec8a0-71c0-45dc-b79b-6272216eceb3.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "9add78c6-3207-5f67-aa15-618adb14497b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39195bf4-896a-4a58-a7de-b9110216333b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39195bf4-896a-4a58-a7de-b9110216333b.jpg?1",
             "name": "Tidings",
             "text": "Draw four cards.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "81bcb781-c127-5def-8c17-ffcc2f09849a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521d1b29-c25b-443b-ae5f-07c11786947e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521d1b29-c25b-443b-ae5f-07c11786947e.jpg?1",
             "name": "Time Stop",
             "text": "End the turn. (Remove all spells and abilities on the stack from the game, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "4b375581-c43d-5bd1-b990-a0fa496b8262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433ca5fe-2b38-4b37-98eb-4f2860990f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433ca5fe-2b38-4b37-98eb-4f2860990f87.jpg?1",
             "name": "Time Stop",
             "text": "",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "5ef80896-673a-548a-9eaa-05db2cbb07a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c878780-f666-44ab-a60e-c9985f628fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c878780-f666-44ab-a60e-c9985f628fc3.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "e5b81af3-5518-57ab-b42b-ab62e3732c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4e697d-8fef-4db9-ac8c-c5e940a9ab07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4e697d-8fef-4db9-ac8c-c5e940a9ab07.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "0ead5084-cdde-5f7e-a60b-1a0b9f64a995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d65aee-242e-4255-b2a7-5a3a3b464b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d65aee-242e-4255-b2a7-5a3a3b464b48.jpg?1",
             "name": "Twincast",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "7b259873-da0b-5e3c-982e-986bf2504820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881386b4-fc85-49f7-b2a5-3b41f6a6c920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881386b4-fc85-49f7-b2a5-3b41f6a6c920.jpg?1",
             "name": "Twitch",
             "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "7248b1c8-b57b-5382-9c5f-4366ed1c254c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe16e3c-9cf5-4b5a-8ec9-8a2d60f3fcc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe16e3c-9cf5-4b5a-8ec9-8a2d60f3fcc9.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "0d2b2057-eb16-5435-aea9-61b3038ae9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea34a540-486b-42dc-993c-93698988d024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea34a540-486b-42dc-993c-93698988d024.jpg?1",
             "name": "Vedalken Mastermind",
             "text": "{U}, {T}: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "48792ac1-73cf-5a28-bf61-949b5950d881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40595366-8601-40e0-a070-fc218723270d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40595366-8601-40e0-a070-fc218723270d.jpg?1",
             "name": "Wall of Air",
             "text": "Defender, flying (This creature can't attack, and it can block creatures with flying.)",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "c7e4eda9-dc2e-5243-8a1d-7097e3b2b319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ce111-91c4-4ae2-91ed-6c69a91fb2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ce111-91c4-4ae2-91ed-6c69a91fb2bb.jpg?1",
             "name": "Wall of Air",
             "text": "",
             "colours": [
@@ -6058,7 +6058,7 @@
         },
         {
             "id": "9acf4d13-d68f-5fec-93b4-caf0a14725a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f18447-2853-469b-b3b3-20d6bcafa6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f18447-2853-469b-b3b3-20d6bcafa6e7.jpg?1",
             "name": "Afflict",
             "text": "Target creature gets -1/-1 until end of turn.\nDraw a card.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "4429ce97-b78e-5bc4-bd34-a38b26794bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bac7a8-d3bb-4032-b30b-db7328e4d2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bac7a8-d3bb-4032-b30b-db7328e4d2fc.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand and choose two cards from it. Put them on top of that player's library in any order.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "bba43f4e-a9eb-5c89-8389-5935a1fbd8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82419eea-a397-41df-b526-f3bea857bbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82419eea-a397-41df-b526-f3bea857bbbd.jpg?1",
             "name": "Ascendant Evincar",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nOther black creatures get +1/+1.\nNonblack creatures get -1/-1.",
             "colours": [
@@ -6161,7 +6161,7 @@
         },
         {
             "id": "c206ab94-4325-5766-91d6-62b8f50aeac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1244ad-5b5f-41e8-bb0e-9cc854e663fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1244ad-5b5f-41e8-bb0e-9cc854e663fb.jpg?1",
             "name": "Ascendant Evincar",
             "text": "",
             "colours": [
@@ -6200,7 +6200,7 @@
         },
         {
             "id": "c6f3da33-27e8-51e4-9859-ef7cb3cdbe61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79599f4-7038-4b8f-9a44-e58b650f21a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79599f4-7038-4b8f-9a44-e58b650f21a7.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -6232,7 +6232,7 @@
         },
         {
             "id": "efdd5367-9393-54c1-a6b8-c7810ee87ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee97c64-39ab-4967-a7e4-3fc5e793d534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee97c64-39ab-4967-a7e4-3fc5e793d534.jpg?1",
             "name": "Beacon of Unrest",
             "text": "Put target artifact or creature card in a graveyard into play under your control. Shuffle Beacon of Unrest into its owner's library.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "ac084dab-6ac0-55fa-94b7-e009fede9012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b39f2d-96f2-4cac-9f6d-a061dbef749b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b39f2d-96f2-4cac-9f6d-a061dbef749b.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -6299,7 +6299,7 @@
         },
         {
             "id": "efaa7c3d-c5e0-5346-b3b2-c6a3d132c27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151643af-a8b7-4291-9ba1-839091eb342f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151643af-a8b7-4291-9ba1-839091eb342f.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "26180f1b-41a1-5fa5-9f6b-39ee08a1a203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8117171-08a7-44f6-9c14-12e8b96c7632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8117171-08a7-44f6-9c14-12e8b96c7632.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "2562f5f1-4de2-5834-a9ff-99092380d910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b6552-367e-4b0b-9095-42322843b1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b6552-367e-4b0b-9095-42322843b1b2.jpg?1",
             "name": "Contaminated Bond",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "9c0311e8-03c1-527d-9d90-6fa2dba2aae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f5ba76-b6dd-46cb-8b5f-415da19986e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f5ba76-b6dd-46cb-8b5f-415da19986e0.jpg?1",
             "name": "Contaminated Bond",
             "text": "",
             "colours": [
@@ -6436,7 +6436,7 @@
         },
         {
             "id": "e77dbe8c-5878-5881-b5f3-8203af673278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d9c1d-a984-4971-810c-e493d0a55e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d9c1d-a984-4971-810c-e493d0a55e5c.jpg?1",
             "name": "Cruel Edict",
             "text": "Target opponent sacrifices a creature.",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "7069fe50-d855-59ea-b445-e8068cda7559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9271cc-6525-4a44-af24-915f0ba5afa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9271cc-6525-4a44-af24-915f0ba5afa9.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -6500,7 +6500,7 @@
         },
         {
             "id": "e9435188-40bd-54c7-938f-798459b038ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb98f0e-5fa0-497e-9061-85cf0b3a3eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb98f0e-5fa0-497e-9061-85cf0b3a3eff.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -6532,7 +6532,7 @@
         },
         {
             "id": "77ce01d6-3609-519e-a0d4-6ad6770c45e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb7ade-ebbb-49fb-b64f-fa247f9a9af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb7ade-ebbb-49fb-b64f-fa247f9a9af6.jpg?1",
             "name": "Distress",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "49f64f3e-f0ff-5d4c-a730-5ea919857d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ff8ca-068d-4115-9139-df00b63e2912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ff8ca-068d-4115-9139-df00b63e2912.jpg?1",
             "name": "Doomed Necromancer",
             "text": "{B}, {T}, Sacrifice Doomed Necromancer: Return target creature card from your graveyard to play.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "fea2ad06-355d-5a9a-822d-66275d89cad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd5c07e-4ece-4c8b-93c8-6abd7dd3a39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd5c07e-4ece-4c8b-93c8-6abd7dd3a39a.jpg?1",
             "name": "Dross Crocodile",
             "text": "",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "2d080e75-7e1b-5f75-9c8f-18d02a4710dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e71542-b9c1-4431-bfef-da629a3edc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e71542-b9c1-4431-bfef-da629a3edc57.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "d9902515-6292-5a4a-9bde-a7616ad5f0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9038925-7acf-42b7-abec-c8eec9f591b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9038925-7acf-42b7-abec-c8eec9f591b6.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "42022e6f-e123-54a6-84df-ec826b13f5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f264f6-832c-42fe-8642-00ee0f009c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f264f6-832c-42fe-8642-00ee0f009c08.jpg?1",
             "name": "Dusk Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "b75509f6-c893-54a7-a51e-757066a0b4da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bcb6ac-b27f-4da3-9f68-40b3c59cda88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bcb6ac-b27f-4da3-9f68-40b3c59cda88.jpg?1",
             "name": "Dusk Imp",
             "text": "",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "d38298f2-29e8-57b0-b978-140aa2171cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af61c18-a7ac-42c8-a942-d2f546c1ef57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af61c18-a7ac-42c8-a942-d2f546c1ef57.jpg?1",
             "name": "Essence Drain",
             "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "b159e707-915c-5940-bd70-7f0416cc8def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa57eb-e307-4104-a291-c6cbfa235816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa57eb-e307-4104-a291-c6cbfa235816.jpg?1",
             "name": "Fear",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -6842,7 +6842,7 @@
         },
         {
             "id": "f49300ef-efa0-5b82-ace3-f2f06795fbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4136b-ad5b-4234-a476-90e1dcae00c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4136b-ad5b-4234-a476-90e1dcae00c6.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -6877,7 +6877,7 @@
         },
         {
             "id": "004adf9a-b59a-5d56-9093-df73b9929bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce1a3a3-f0b8-4088-85f6-8cbdd1f29e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce1a3a3-f0b8-4088-85f6-8cbdd1f29e65.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "f180c680-0dc9-5132-a713-65fdc4eefa75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd23186-6796-4430-86c5-f0d5337bbc91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd23186-6796-4430-86c5-f0d5337bbc91.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control is put into a graveyard from play, each other player sacrifices a creature.",
             "colours": [
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "1430ebef-2e40-57ce-8801-2f94b05d027e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d460b79-f1a5-41c4-a5b3-61f703fd97df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d460b79-f1a5-41c4-a5b3-61f703fd97df.jpg?1",
             "name": "Graveborn Muse",
             "text": "At the beginning of your upkeep, you draw X cards and you lose X life, where X is the number of Zombies you control.",
             "colours": [
@@ -6979,7 +6979,7 @@
         },
         {
             "id": "71fd9f58-2931-5c3c-957c-d98f2ab02862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57d35a-ca0b-4f93-867c-d0a9fb5108f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57d35a-ca0b-4f93-867c-d0a9fb5108f1.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7013,7 +7013,7 @@
         },
         {
             "id": "4c1a672a-3089-563f-a852-9580a425dbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b3c413-96ca-42c5-b263-f2da195c1854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b3c413-96ca-42c5-b263-f2da195c1854.jpg?1",
             "name": "Hate Weaver",
             "text": "{2}: Target blue or red creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7048,7 +7048,7 @@
         },
         {
             "id": "6b7fba1d-4937-5867-8a77-863ec30d432e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ab3037-7e62-46a7-800e-8bfa7d33f237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ab3037-7e62-46a7-800e-8bfa7d33f237.jpg?1",
             "name": "Head Games",
             "text": "Target opponent puts the cards from his or her hand on top of his or her library. Search that player's library for that many cards. The player puts those cards into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "6d030b32-0534-55c9-9c40-00bb59d4e164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac9d57-a724-4ad1-b6a7-805381c21bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac9d57-a724-4ad1-b6a7-805381c21bb3.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play, sacrifice it unless you discard a creature card.",
             "colours": [
@@ -7114,7 +7114,7 @@
         },
         {
             "id": "f58e52e4-ab1c-5ccf-a751-5d174e5138a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4d095-664e-4704-b922-f868d0d454d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4d095-664e-4704-b922-f868d0d454d3.jpg?1",
             "name": "Highway Robber",
             "text": "When Highway Robber comes into play, you gain 2 life and target opponent loses 2 life.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "c620a95f-984f-5234-b8f3-a2e359972e85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08978a4-1c3a-4abf-9991-fe36220e1f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08978a4-1c3a-4abf-9991-fe36220e1f4f.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
             "colours": [
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "f39b4446-0ca6-5446-8507-4b1ba37bb3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110f97e-d9a2-4575-be70-8b13dc85d418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110f97e-d9a2-4575-be70-8b13dc85d418.jpg?1",
             "name": "Hypnotic Specter",
             "text": "",
             "colours": [
@@ -7219,7 +7219,7 @@
         },
         {
             "id": "ec5227b0-8cbd-5cad-a27e-32a798a3ae0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d665187f-a8d3-40b6-bfaf-cf25d84484b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d665187f-a8d3-40b6-bfaf-cf25d84484b4.jpg?1",
             "name": "Knight of Dusk",
             "text": "{B}{B}: Destroy target creature blocking Knight of Dusk.",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "8830d071-858a-534c-ba8f-376dcc56d74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba629ab-a322-4a7c-b6e5-477ca1b709bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba629ab-a322-4a7c-b6e5-477ca1b709bf.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "50c75c75-4a07-5620-9798-5632fadf09e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea363c-ec09-4d79-aaf9-f8ff2e2a34c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea363c-ec09-4d79-aaf9-f8ff2e2a34c0.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample (This creature can't be blocked except by creatures with flying or reach. If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nAt the beginning of your upkeep, sacrifice a creature other than Lord of the Pit. If you can't, Lord of the Pit deals 7 damage to you.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "ad67ee3e-ce9d-5fd4-845b-a1673f717f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6293b9d-5454-4fb2-8351-b545b3187430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6293b9d-5454-4fb2-8351-b545b3187430.jpg?1",
             "name": "Lord of the Pit",
             "text": "",
             "colours": [
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "6022d604-c21f-599e-b65e-ff895bc51005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e773b-5feb-407f-a162-f35d6e693cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e773b-5feb-407f-a162-f35d6e693cca.jpg?1",
             "name": "Lord of the Undead",
             "text": "Other Zombie creatures get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "93ee4f89-0cd1-50a1-9525-401e2fccd32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5e3ea-fcca-42c2-b3af-bfcd3a81dfff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5e3ea-fcca-42c2-b3af-bfcd3a81dfff.jpg?1",
             "name": "Mass of Ghouls",
             "text": "",
             "colours": [
@@ -7427,7 +7427,7 @@
         },
         {
             "id": "0c960d75-fd2e-5a5a-ba78-58e10530fea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13604ba3-b238-4a63-80f7-9dc2d5d04ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13604ba3-b238-4a63-80f7-9dc2d5d04ded.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -7459,7 +7459,7 @@
         },
         {
             "id": "952369f6-d553-558f-8385-5c219c66653b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4239c4e8-41f3-47fd-bd01-fa0b28976e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4239c4e8-41f3-47fd-bd01-fa0b28976e29.jpg?1",
             "name": "Midnight Ritual",
             "text": "Remove X target creature cards in your graveyard from the game. For each creature card removed this way, put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -7491,7 +7491,7 @@
         },
         {
             "id": "9ba7d620-4e3f-554d-b245-7ad70b63a746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77cb309-1fb2-451e-a96d-b02b8c99932c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77cb309-1fb2-451e-a96d-b02b8c99932c.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "3616d597-cbda-5839-9478-85b8e18d0011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d9cfce-1507-4cdf-9d58-6ebaf44e72e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d9cfce-1507-4cdf-9d58-6ebaf44e72e3.jpg?1",
             "name": "Mortal Combat",
             "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
             "colours": [
@@ -7555,7 +7555,7 @@
         },
         {
             "id": "889dbfab-bcc2-5a94-ba57-01d229c6dccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad89ad-03ee-4227-b2a6-5d5002eecead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad89ad-03ee-4227-b2a6-5d5002eecead.jpg?1",
             "name": "Mortivore",
             "text": "Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\n{B}: Regenerate Mortivore. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "4cd3a77f-82ac-5204-8f60-b04234d2db30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c213d-9262-4cba-8bde-161baf8cc0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c213d-9262-4cba-8bde-161baf8cc0c0.jpg?1",
             "name": "Mortivore",
             "text": "",
             "colours": [
@@ -7625,7 +7625,7 @@
         },
         {
             "id": "60122d6f-448b-5df8-ac2a-8f5a1e841278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8f8f83-65bb-4da3-8263-e58162ebb24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8f8f83-65bb-4da3-8263-e58162ebb24b.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -7660,7 +7660,7 @@
         },
         {
             "id": "f560811b-3c5d-5929-8b17-e9ae8730cec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca42df8-a9a2-4391-8dec-7097f788c250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca42df8-a9a2-4391-8dec-7097f788c250.jpg?1",
             "name": "Nekrataal",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Nekrataal comes into play, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "37f0071d-09b9-5fdc-a5de-52061a01cb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24721dc-7473-4a7b-b42e-8ddcf027c7e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24721dc-7473-4a7b-b42e-8ddcf027c7e2.jpg?1",
             "name": "Nekrataal",
             "text": "",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "5bd291f0-560a-5046-bd07-a91bd3004f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88111e2b-84ff-48bf-9a64-b4e9022b6dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88111e2b-84ff-48bf-9a64-b4e9022b6dae.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -7768,7 +7768,7 @@
         },
         {
             "id": "d6fff2c5-c356-543e-9708-3a25de95244a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0001a4-18f9-460c-b26f-476ce55e6294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0001a4-18f9-460c-b26f-476ce55e6294.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "8d4f5d80-16ea-52cc-8201-93a46b803efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cfd454-5bc3-456c-9ca2-151af99f69ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cfd454-5bc3-456c-9ca2-151af99f69ce.jpg?1",
             "name": "No Rest for the Wicked",
             "text": "Sacrifice No Rest for the Wicked: Return to your hand all creature cards that were put into your graveyard from play this turn.",
             "colours": [
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "274c6a91-31d3-5adb-8707-3edca2cb62b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902c9b72-170c-4c25-a966-a55d689daae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902c9b72-170c-4c25-a966-a55d689daae8.jpg?1",
             "name": "Phage the Untouchable",
             "text": "When Phage the Untouchable comes into play, if you didn't play it from your hand, you lose the game.\nWhenever Phage deals combat damage to a creature, destroy that creature. It can't be regenerated.\nWhenever Phage deals combat damage to a player, that player loses the game.",
             "colours": [
@@ -7873,7 +7873,7 @@
         },
         {
             "id": "f9be8a22-a0cb-54e3-adbd-97fc4a5a3b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a85419a-7ebb-4fe1-891f-b5295e18878f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a85419a-7ebb-4fe1-891f-b5295e18878f.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager comes into play, you draw a card and you lose 1 life.",
             "colours": [
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "a29c83ec-1698-5321-b89f-06b782674335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5d3dac-98df-433f-a417-bcb9c91722fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5d3dac-98df-433f-a417-bcb9c91722fb.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -7943,7 +7943,7 @@
         },
         {
             "id": "65b16f51-24dc-5039-9d54-4a00c387fc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcc163a-6041-45a0-befb-b1174cfd6da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcc163a-6041-45a0-befb-b1174cfd6da4.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "0af7633e-8851-5afa-8611-fb3272f05fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327d38a9-e631-4f5e-a7c3-b99794a40954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327d38a9-e631-4f5e-a7c3-b99794a40954.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -8010,7 +8010,7 @@
         },
         {
             "id": "fd50dffd-b4d8-5956-9fec-b454fd1fef06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5811f4ee-f352-4b41-8f56-da0cb7f3f11b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5811f4ee-f352-4b41-8f56-da0cb7f3f11b.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy target land.",
             "colours": [
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "f4cf6831-f6af-51c9-af91-1246830ae0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8b556-6e18-46ee-80f8-cbd922e37432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8b556-6e18-46ee-80f8-cbd922e37432.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "aa1053c3-4b45-5742-beb6-36d9316b204f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864efca-d7c8-4ec7-8cda-ba89f9df7722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864efca-d7c8-4ec7-8cda-ba89f9df7722.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "70eb81fd-23fb-521a-9ac3-fae8f0ca5bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa876b-d6d4-4108-83e5-c06e9a786bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa876b-d6d4-4108-83e5-c06e9a786bcd.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature in play named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "23e48622-2895-5385-99a4-892c93a5d3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1d6b5-ee32-4d62-848d-884da6376c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1d6b5-ee32-4d62-848d-884da6376c63.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -8177,7 +8177,7 @@
         },
         {
             "id": "8c2f219b-5122-52b2-940c-988c5818d788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cbf71-1199-4457-9b09-f66e7cb294d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cbf71-1199-4457-9b09-f66e7cb294d5.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "74fa21a6-66f3-5395-a95f-19e9f0b1d24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1570397-0efa-4b31-a7fd-bdf4dcf690a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1570397-0efa-4b31-a7fd-bdf4dcf690a1.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever a creature dealt damage by Sengir Vampire this turn is put into a graveyard, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "47fe8296-36c6-5338-b239-9fa0cceba156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf0027a-4a1f-4403-bd7d-bc56ad5746cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf0027a-4a1f-4403-bd7d-bc56ad5746cb.jpg?1",
             "name": "Sengir Vampire",
             "text": "",
             "colours": [
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "e9cf9c31-aa62-53f4-bff2-71cd5e2f4004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82633f38-5af1-429e-8c9d-db536af85309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82633f38-5af1-429e-8c9d-db536af85309.jpg?1",
             "name": "Severed Legion",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "285ed705-6771-5dc8-8076-c252fe984278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34919e82-fded-4652-beaa-a2b2927e9dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34919e82-fded-4652-beaa-a2b2927e9dea.jpg?1",
             "name": "Severed Legion",
             "text": "",
             "colours": [
@@ -8351,7 +8351,7 @@
         },
         {
             "id": "d1797b46-68c8-57b9-913e-cca4feb3dae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60096938-d520-424a-afe4-0c5ee8b90aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60096938-d520-424a-afe4-0c5ee8b90aa1.jpg?1",
             "name": "Sleeper Agent",
             "text": "When Sleeper Agent comes into play, target opponent gains control of it.\nAt the beginning of your upkeep, Sleeper Agent deals 2 damage to you.",
             "colours": [
@@ -8386,7 +8386,7 @@
         },
         {
             "id": "65e0dbca-81ed-538d-8f71-d5ddc5a927b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a8d6d-8cd0-4dfe-9894-77eb60620884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a8d6d-8cd0-4dfe-9894-77eb60620884.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "e24e5e4e-722f-56ff-9555-9b76303fc6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0221a713-2fdc-4ff0-abe3-1d340d272232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0221a713-2fdc-4ff0-abe3-1d340d272232.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -8454,7 +8454,7 @@
         },
         {
             "id": "4c9c5ea9-5bca-5301-a0a2-2680fe75b04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509a386-0c11-425c-9946-ab4add1abfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509a386-0c11-425c-9946-ab4add1abfee.jpg?1",
             "name": "Stronghold Discipline",
             "text": "Each player loses 1 life for each creature he or she controls.",
             "colours": [
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "5fab2f5f-3737-5e5b-b572-26abb094331b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ccc3b-a6bd-4dc8-b7ba-99172d612106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ccc3b-a6bd-4dc8-b7ba-99172d612106.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8518,7 +8518,7 @@
         },
         {
             "id": "01d6c876-b6e6-5534-8bef-42862a9cd839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6fe257-b1bd-4eaf-9941-e8819f3bc89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6fe257-b1bd-4eaf-9941-e8819f3bc89a.jpg?1",
             "name": "Thrull Surgeon",
             "text": "{1}{B}, Sacrifice Thrull Surgeon: Look at target player's hand and choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -8552,7 +8552,7 @@
         },
         {
             "id": "86b465df-0605-555c-aaa4-303f7e32d4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e212d55-c98d-4df6-ab5a-389f38099070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e212d55-c98d-4df6-ab5a-389f38099070.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -8584,7 +8584,7 @@
         },
         {
             "id": "53d6532f-43a4-5c01-891c-3ff67a49d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc48d8-7ff9-46d4-921a-03e63ca41a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc48d8-7ff9-46d4-921a-03e63ca41a66.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "27d4596d-3c6c-5d6e-a978-424044a468d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb681091-331f-40d7-bc32-56899f3e6885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb681091-331f-40d7-bc32-56899f3e6885.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "4c9c45db-116c-59e0-a708-d471e38c6361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114f37e0-0a00-4ab0-840c-8f02cea101b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114f37e0-0a00-4ab0-840c-8f02cea101b3.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{B}: Vampire Bats gets +1/+0 until end of turn. Play this ability no more than twice each turn.",
             "colours": [
@@ -8689,7 +8689,7 @@
         },
         {
             "id": "e65aae37-20bc-5499-aee4-c1f30832f7b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff7fed-93ab-4e80-8548-744a7da9be0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff7fed-93ab-4e80-8548-744a7da9be0d.jpg?1",
             "name": "Vampire Bats",
             "text": "",
             "colours": [
@@ -8724,7 +8724,7 @@
         },
         {
             "id": "5119e249-f9be-56b3-9deb-72d7cba52ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdd01bd-ab41-4005-8807-46db0cfc4da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdd01bd-ab41-4005-8807-46db0cfc4da4.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "08099cff-a271-54f1-942e-2fe7101c7bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f084952-991b-459f-b347-e7d2f2f04b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f084952-991b-459f-b347-e7d2f2f04b31.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "",
             "colours": [
@@ -8794,7 +8794,7 @@
         },
         {
             "id": "f6226c44-1f81-530a-9dda-8a63b412c727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41764237-fa31-4b27-92ff-712a42d350b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41764237-fa31-4b27-92ff-712a42d350b9.jpg?1",
             "name": "Arcane Teachings",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+2 and has \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -8829,7 +8829,7 @@
         },
         {
             "id": "66cdbfaf-8bc2-5313-9c5c-7d422d2e4b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0942b-3a63-43e8-806e-2471fdebf72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0942b-3a63-43e8-806e-2471fdebf72e.jpg?1",
             "name": "Arcane Teachings",
             "text": "",
             "colours": [
@@ -8864,7 +8864,7 @@
         },
         {
             "id": "5543c576-ef2b-59ac-878b-3aff199f27de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830b73b-1def-4d34-902d-966ecdbc7717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830b73b-1def-4d34-902d-966ecdbc7717.jpg?1",
             "name": "Beacon of Destruction",
             "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
             "colours": [
@@ -8896,7 +8896,7 @@
         },
         {
             "id": "e54f8939-0853-5b0b-81b0-a29391bfb9e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213035f9-40f5-4b4e-88b3-e262ad684294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213035f9-40f5-4b4e-88b3-e262ad684294.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -8928,7 +8928,7 @@
         },
         {
             "id": "9ae3a282-1852-5b73-8c60-eabca0956349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4050c0a3-a318-4283-ae72-8fffcf8d45e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4050c0a3-a318-4283-ae72-8fffcf8d45e9.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "{R}, Sacrifice Bloodfire Colossus: Bloodfire Colossus deals 6 damage to each creature and each player.",
             "colours": [
@@ -8962,7 +8962,7 @@
         },
         {
             "id": "9370dddd-ba64-53f9-8890-f391ee305326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a830f8-b508-431e-aadc-36330dcfe5db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a830f8-b508-431e-aadc-36330dcfe5db.jpg?1",
             "name": "Bloodrock Cyclops",
             "text": "Bloodrock Cyclops attacks each turn if able.",
             "colours": [
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "c676dcc1-ff7c-51eb-a878-7e1bb3ee6ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9be02-935e-4428-863b-95e84c88834a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9be02-935e-4428-863b-95e84c88834a.jpg?1",
             "name": "Bogardan Firefiend",
             "text": "When Bogardan Firefiend is put into a graveyard from play, it deals 2 damage to target creature.",
             "colours": [
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "cdc0805a-73b1-5d98-bff3-4e06e6a1f036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec5e56a-5bab-4965-9035-128c3f1ae175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec5e56a-5bab-4965-9035-128c3f1ae175.jpg?1",
             "name": "Cone of Flame",
             "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
             "colours": [
@@ -9063,7 +9063,7 @@
         },
         {
             "id": "ab4f32a2-6671-5724-8ce9-6b721a5f2417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf386439-0f68-454f-993b-d55dcc989d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf386439-0f68-454f-993b-d55dcc989d81.jpg?1",
             "name": "Cryoclasm",
             "text": "Destroy target Plains or Island. Cryoclasm deals 3 damage to that land's controller.",
             "colours": [
@@ -9095,7 +9095,7 @@
         },
         {
             "id": "8e171679-0214-5448-9188-883cfa365c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558503-5124-44cb-8343-6dec0130f8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558503-5124-44cb-8343-6dec0130f8f7.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -9127,7 +9127,7 @@
         },
         {
             "id": "890a9b49-9cea-500c-80c2-220e38b661fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da84a3e-a8b2-4cb4-b9c9-1b5c2dca8c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da84a3e-a8b2-4cb4-b9c9-1b5c2dca8c67.jpg?1",
             "name": "Dragon Roost",
             "text": "{5}{R}{R}: Put a 5/5 red Dragon creature token with flying into play. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "6bb35d3c-20f6-5e0e-aea9-cffbef432373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8785edc4-2ec5-4eb3-a130-1277088ebf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8785edc4-2ec5-4eb3-a130-1277088ebf83.jpg?1",
             "name": "Dragon Roost",
             "text": "",
             "colours": [
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "91ea7dc6-6498-5ecf-853f-0090ae00fbfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913e4d2-3502-41f3-871e-59b3b13df58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913e4d2-3502-41f3-871e-59b3b13df58a.jpg?1",
             "name": "Duct Crawler",
             "text": "{1}{R}: Target creature can't block Duct Crawler this turn.",
             "colours": [
@@ -9227,7 +9227,7 @@
         },
         {
             "id": "4bdb6002-18d3-5a09-a94c-da7796980b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf4360-ba2f-464f-86f0-1620532e6a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf4360-ba2f-464f-86f0-1620532e6a0a.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -9261,7 +9261,7 @@
         },
         {
             "id": "02aa05a4-ff94-5bda-8ad7-24f00bd19ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c623048-8c87-46d8-bf77-9fe1b38f494f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c623048-8c87-46d8-bf77-9fe1b38f494f.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -9296,7 +9296,7 @@
         },
         {
             "id": "bf599cd8-8095-5725-bcca-244b9e69f5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261b73f8-1d48-40d1-8273-d2a8854cace8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261b73f8-1d48-40d1-8273-d2a8854cace8.jpg?1",
             "name": "Firebreathing",
             "text": "",
             "colours": [
@@ -9331,7 +9331,7 @@
         },
         {
             "id": "e43188e9-33c7-5df9-b611-c2d2ddd3d78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fab4a7e-ef8a-4f38-b659-5598a2ead833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fab4a7e-ef8a-4f38-b659-5598a2ead833.jpg?1",
             "name": "Fists of the Anvil",
             "text": "Target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -9363,7 +9363,7 @@
         },
         {
             "id": "75578928-5ef3-5c91-87d8-e16191a1764e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dad8247-1970-4dfb-aad5-d683160ab1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dad8247-1970-4dfb-aad5-d683160ab1b9.jpg?1",
             "name": "Flamewave Invoker",
             "text": "{7}{R}: Flamewave Invoker deals 5 damage to target player.",
             "colours": [
@@ -9398,7 +9398,7 @@
         },
         {
             "id": "7e457744-dd60-5fd0-ae58-1718ef65c1a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074121e8-aecc-469f-b181-8e6a9e918826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074121e8-aecc-469f-b181-8e6a9e918826.jpg?1",
             "name": "Flowstone Slide",
             "text": "All creatures get +X/-X until end of turn.",
             "colours": [
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "9932f234-b27f-55df-96be-18b6583ba3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef98-b6d5-406f-956b-7107550889d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef98-b6d5-406f-956b-7107550889d8.jpg?1",
             "name": "Furnace of Rath",
             "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -9462,7 +9462,7 @@
         },
         {
             "id": "b9abc758-c583-5d39-b761-9e83496927aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c00aa95-3ef3-4639-bda2-6593515f68ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c00aa95-3ef3-4639-bda2-6593515f68ae.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "60d613d8-fd21-5d63-b920-75c0d3e12121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f71c4d-9390-4cf4-b307-0c73ac9ce023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f71c4d-9390-4cf4-b307-0c73ac9ce023.jpg?1",
             "name": "Furnace Whelp",
             "text": "",
             "colours": [
@@ -9532,7 +9532,7 @@
         },
         {
             "id": "ad3f67e9-ab12-5242-a9c8-4a7c3c004934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa052041-14db-4a3f-86ad-683c1f162cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa052041-14db-4a3f-86ad-683c1f162cd7.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "Whenever Goblin Elite Infantry blocks or becomes blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -9567,7 +9567,7 @@
         },
         {
             "id": "9075708d-9c83-519c-aa81-465d35078747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b266935-25ea-49c5-a1da-57c22a4362fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b266935-25ea-49c5-a1da-57c22a4362fd.jpg?1",
             "name": "Goblin King",
             "text": "Other Goblin creatures get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -9602,7 +9602,7 @@
         },
         {
             "id": "e8650f78-41cc-562b-b18a-b20207d716e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696ca38e-3035-492f-8f1b-258f60b8788c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696ca38e-3035-492f-8f1b-258f60b8788c.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "f8084160-8edf-58fa-b453-81daf28278d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e990aa-5124-4e9d-ab4e-178bcda12abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e990aa-5124-4e9d-ab4e-178bcda12abd.jpg?1",
             "name": "Goblin Lore",
             "text": "Draw four cards, then discard three cards at random.",
             "colours": [
@@ -9669,7 +9669,7 @@
         },
         {
             "id": "c0258169-1e97-55b4-8513-427baf8fe898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae72d6-f2a2-4345-822d-6a7c2409a237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae72d6-f2a2-4345-822d-6a7c2409a237.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -9704,7 +9704,7 @@
         },
         {
             "id": "bc3a62a0-3be0-553f-bf42-a10e954c815f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbd596b-56c2-475c-93e4-c72f9f29281b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbd596b-56c2-475c-93e4-c72f9f29281b.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "edc4b78a-6130-5fd4-b5ff-c46850e2b957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa7444-25c4-4524-931a-f65446d132f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa7444-25c4-4524-931a-f65446d132f6.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "",
             "colours": [
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "8d805d91-280e-5c7e-81d2-2676b9ee93b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf3bac0-6e63-4bd3-bbd6-547f46c2d126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf3bac0-6e63-4bd3-bbd6-547f46c2d126.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nWhen a spell or ability an opponent controls causes you to discard Guerrilla Tactics, Guerrilla Tactics deals 4 damage to target creature or player.",
             "colours": [
@@ -9808,7 +9808,7 @@
         },
         {
             "id": "39f4ab79-50be-53cd-b422-354d0b320126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c2be6a-9ca6-4d3a-8dd0-db4ea40799f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c2be6a-9ca6-4d3a-8dd0-db4ea40799f8.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -9842,7 +9842,7 @@
         },
         {
             "id": "67a83049-b3fc-5438-9d37-581ae6f2bcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723fb62e-735a-4ca6-9d38-f1c3944fe69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723fb62e-735a-4ca6-9d38-f1c3944fe69a.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
             "colours": [
@@ -9874,7 +9874,7 @@
         },
         {
             "id": "2b887770-1bb2-5ded-9340-1f703007efc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b9336-5aa3-4992-b04b-4786150c6074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b9336-5aa3-4992-b04b-4786150c6074.jpg?1",
             "name": "Kamahl, Pit Fighter",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Kamahl, Pit Fighter deals 3 damage to target creature or player.",
             "colours": [
@@ -9912,7 +9912,7 @@
         },
         {
             "id": "d44d44ca-fa5a-59e7-8790-f9b107f6c2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea44c0c-722f-4b91-bc56-54f61e4d7df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea44c0c-722f-4b91-bc56-54f61e4d7df9.jpg?1",
             "name": "Kamahl, Pit Fighter",
             "text": "",
             "colours": [
@@ -9950,7 +9950,7 @@
         },
         {
             "id": "4b135a97-07ad-5cb0-a130-c5900ea1791a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28a286-3ea0-4760-bcc4-c7e8299c298e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28a286-3ea0-4760-bcc4-c7e8299c298e.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "3f736237-5bba-5b24-8fc5-ad279eec8c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74adb3f7-2453-4133-a08b-4a2b1dc714b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74adb3f7-2453-4133-a08b-4a2b1dc714b9.jpg?1",
             "name": "Lavaborn Muse",
             "text": "At the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Lavaborn Muse deals 3 damage to him or her.",
             "colours": [
@@ -10016,7 +10016,7 @@
         },
         {
             "id": "0c77c055-2d74-5328-b3b1-eb4f9e1ad63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a557c16-2b58-45c4-9e97-cf6047a83d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a557c16-2b58-45c4-9e97-cf6047a83d17.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -10051,7 +10051,7 @@
         },
         {
             "id": "265e33a7-c32f-5177-8b16-8998931bc8a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9358c3-d4a6-4c62-8484-0a12b79db178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9358c3-d4a6-4c62-8484-0a12b79db178.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "85245362-de1a-59fd-9f9a-d6a0c9522592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009b1aff-a8c7-4032-ab29-a77c94c5af59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009b1aff-a8c7-4032-ab29-a77c94c5af59.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to that player.",
             "colours": [
@@ -10118,7 +10118,7 @@
         },
         {
             "id": "767ee0a4-a8fa-5bce-a948-0a067fa4ba89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185949ab-55d0-439f-b25b-1f525e3eddf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185949ab-55d0-439f-b25b-1f525e3eddf7.jpg?1",
             "name": "Mogg Fanatic",
             "text": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
             "colours": [
@@ -10152,7 +10152,7 @@
         },
         {
             "id": "06af24c4-9cbe-5c8f-9c22-63273cf74ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fca10-0eb8-4f70-80bb-dd9aee50a018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fca10-0eb8-4f70-80bb-dd9aee50a018.jpg?1",
             "name": "Orcish Artillery",
             "text": "{T}: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -10187,7 +10187,7 @@
         },
         {
             "id": "8b63019c-7755-502c-b599-b264b0b12c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6023c95-8cd8-4f12-960a-6557fbefd628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6023c95-8cd8-4f12-960a-6557fbefd628.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "518754bb-441f-5f22-a106-377017a55ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e7131-db26-448d-afda-f48337a026f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e7131-db26-448d-afda-f48337a026f0.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "6fd7afbb-7725-5f7a-91fe-cb578229971a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cec628-5f6a-4b42-9044-3f9a80cac3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cec628-5f6a-4b42-9044-3f9a80cac3e6.jpg?1",
             "name": "Rage Weaver",
             "text": "{2}: Target black or green creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "9e0f4c70-6db0-5798-8307-caf4f98f17f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f171f5f3-6457-4a1b-84ef-f532748f804b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f171f5f3-6457-4a1b-84ef-f532748f804b.jpg?1",
             "name": "Rage Weaver",
             "text": "",
             "colours": [
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "b91e7385-f4a8-5d1b-ac43-23857284e185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181ed588-5b9e-4160-967c-ed927b7e0048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181ed588-5b9e-4160-967c-ed927b7e0048.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -10362,7 +10362,7 @@
         },
         {
             "id": "5cfbcc15-d710-51d0-b0e8-90e66649839e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594f850f-dab1-40e0-828c-c200bbac060f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594f850f-dab1-40e0-828c-c200bbac060f.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -10398,7 +10398,7 @@
         },
         {
             "id": "cb833dcb-2d9b-528d-bf47-889102212f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00c810c-7d92-484b-9bed-deae5f29582b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00c810c-7d92-484b-9bed-deae5f29582b.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -10430,7 +10430,7 @@
         },
         {
             "id": "c371ba25-9ad2-5650-af82-98c534ec327a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dc08b0-491f-470c-b920-2ca961d0d569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dc08b0-491f-470c-b920-2ca961d0d569.jpg?1",
             "name": "Rock Badger",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -10466,7 +10466,7 @@
         },
         {
             "id": "90b87b65-7385-596e-bbea-64fe7dd67ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bef28-eb1d-4f43-bc76-304e027ba453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bef28-eb1d-4f43-bc76-304e027ba453.jpg?1",
             "name": "Rock Badger",
             "text": "",
             "colours": [
@@ -10502,7 +10502,7 @@
         },
         {
             "id": "3c25757c-4c47-5685-a14d-dcabb08fc79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406f7fef-00f0-4ca5-ada4-c4a760e68467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406f7fef-00f0-4ca5-ada4-c4a760e68467.jpg?1",
             "name": "Scoria Wurm",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, return Scoria Wurm to its owner's hand.",
             "colours": [
@@ -10536,7 +10536,7 @@
         },
         {
             "id": "ceb02498-5932-532d-80f3-0f2d892aaed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14363cc7-ef76-41ad-9307-8ab3ed469a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14363cc7-ef76-41ad-9307-8ab3ed469a23.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "855f7c1e-d582-5ae3-8f58-00a5c0d77c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a1aa93-26d1-40b0-82d8-414f56a36337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a1aa93-26d1-40b0-82d8-414f56a36337.jpg?1",
             "name": "Shatterstorm",
             "text": "Destroy all artifacts. They can't be regenerated.",
             "colours": [
@@ -10600,7 +10600,7 @@
         },
         {
             "id": "5f06ccaf-7381-55e6-acb8-99c923d6a3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdd2db-1a4b-48dd-94cf-bd719ff40da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdd2db-1a4b-48dd-94cf-bd719ff40da9.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -10635,7 +10635,7 @@
         },
         {
             "id": "1102852c-8ade-5273-b9a3-4acb8ad97060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bfdf43-8d4c-4415-bf19-34aa481cd91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bfdf43-8d4c-4415-bf19-34aa481cd91c.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -10670,7 +10670,7 @@
         },
         {
             "id": "25634111-8644-5d96-9e23-3b00c2ea0ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03993ba0-cdf1-4170-ab4e-7d1378aede12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03993ba0-cdf1-4170-ab4e-7d1378aede12.jpg?1",
             "name": "Shivan Hellkite",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{1}{R}: Shivan Hellkite deals 1 damage to target creature or player.",
             "colours": [
@@ -10705,7 +10705,7 @@
         },
         {
             "id": "12458b60-30cf-5ce8-aa7d-89c8a75575e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9de5450-030e-4347-a852-1380527b3219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9de5450-030e-4347-a852-1380527b3219.jpg?1",
             "name": "Shivan Hellkite",
             "text": "",
             "colours": [
@@ -10740,7 +10740,7 @@
         },
         {
             "id": "da226026-1ef7-5663-bc44-a1218f8a0b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ad39a-4088-4530-8f3c-d34e7cc99fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ad39a-4088-4530-8f3c-d34e7cc99fae.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "8b56bd26-7d38-50f1-b4ce-5b6989081b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e54b10e-5307-4138-8f80-28406170f2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e54b10e-5307-4138-8f80-28406170f2c6.jpg?1",
             "name": "Shunt",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -10804,7 +10804,7 @@
         },
         {
             "id": "d899942a-ee50-5305-ab9c-5000f9bb3708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a232d-7289-48c2-9160-54c1c4154721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a232d-7289-48c2-9160-54c1c4154721.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander comes into play, put three 1/1 red Goblin creature tokens into play.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "e732ba9a-fdfa-50a3-80a4-d91af06d575e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c39852-efd3-4a25-b33b-3c13dad96e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c39852-efd3-4a25-b33b-3c13dad96e7d.jpg?1",
             "name": "Smash",
             "text": "Destroy target artifact.\nDraw a card.",
             "colours": [
@@ -10870,7 +10870,7 @@
         },
         {
             "id": "9a6b8e1e-1dc7-5807-bafd-bcd4fa1c6401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4e1b9-d93e-443e-91a4-69d4c9dac517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4e1b9-d93e-443e-91a4-69d4c9dac517.jpg?1",
             "name": "Soulblast",
             "text": "As an additional cost to play Soulblast, sacrifice all creatures you control.\nSoulblast deals damage to target creature or player equal to the total power of the sacrificed creatures.",
             "colours": [
@@ -10902,7 +10902,7 @@
         },
         {
             "id": "4798151f-368c-5c06-910b-f0f63c2ec88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7dfad-aca9-498d-bd1c-5503b411ca5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7dfad-aca9-498d-bd1c-5503b411ca5f.jpg?1",
             "name": "Spark Elemental",
             "text": "Trample, haste (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player. This creature can attack and {T} as soon as it comes under your control.)\nAt end of turn, sacrifice Spark Elemental.",
             "colours": [
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "e35dd1c6-3d00-5d23-898f-aa07be8e98aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90624323-97aa-4ce7-8003-40773a0bc58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90624323-97aa-4ce7-8003-40773a0bc58b.jpg?1",
             "name": "Spark Elemental",
             "text": "",
             "colours": [
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "799c2ab7-18cb-5be5-92f3-079e27487073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475294e2-792c-400b-b5ff-d4bf9e70718e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475294e2-792c-400b-b5ff-d4bf9e70718e.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals damage equal to the number of Mountains you control to target creature.",
             "colours": [
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "99be8d57-8eeb-5208-aa32-0a303e000795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92bcec-ddfa-41bf-97e4-983d850fe32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92bcec-ddfa-41bf-97e4-983d850fe32e.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -11040,7 +11040,7 @@
         },
         {
             "id": "b1dd04ef-45b8-5aa8-9564-6cd209a8402f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e2c82-cdb8-4745-9af6-804717c541d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e2c82-cdb8-4745-9af6-804717c541d7.jpg?1",
             "name": "Stun",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "55492210-8ce6-553c-bdb7-573d824ca3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6560bb7-28d4-4b5c-bdfa-986a5c114349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6560bb7-28d4-4b5c-bdfa-986a5c114349.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -11104,7 +11104,7 @@
         },
         {
             "id": "de76ac44-6732-54a1-94a0-e87866b58aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d467d4-f7d2-403c-9b70-1b054b2c82bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d467d4-f7d2-403c-9b70-1b054b2c82bc.jpg?1",
             "name": "Threaten",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -11137,7 +11137,7 @@
         },
         {
             "id": "e691cb00-dabd-51ec-a678-6227dddb7b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adaaa1f-4a56-4f41-9d91-7b6dfdafd4dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adaaa1f-4a56-4f41-9d91-7b6dfdafd4dd.jpg?1",
             "name": "Threaten",
             "text": "",
             "colours": [
@@ -11170,7 +11170,7 @@
         },
         {
             "id": "e3f6afc6-060e-52e1-b537-3dc8039ca113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6b8f09-f021-4ac8-900f-daeac527477e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6b8f09-f021-4ac8-900f-daeac527477e.jpg?1",
             "name": "Thundering Giant",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -11205,7 +11205,7 @@
         },
         {
             "id": "a778b5ec-ca7e-5e11-92e0-c1a99b8599cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3640ff-3935-4904-881a-a87abd444023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3640ff-3935-4904-881a-a87abd444023.jpg?1",
             "name": "Thundering Giant",
             "text": "",
             "colours": [
@@ -11240,7 +11240,7 @@
         },
         {
             "id": "c2e79d18-b72d-5219-8418-d0e1f71887c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9c85a-ba8e-40d4-ab09-1a22a7462030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9c85a-ba8e-40d4-ab09-1a22a7462030.jpg?1",
             "name": "Uncontrollable Anger",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -11275,7 +11275,7 @@
         },
         {
             "id": "61a544c2-1700-500c-b93f-bc292114df3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a70926-a99b-4e73-9c2a-8120b085abd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a70926-a99b-4e73-9c2a-8120b085abd0.jpg?1",
             "name": "Uncontrollable Anger",
             "text": "",
             "colours": [
@@ -11310,7 +11310,7 @@
         },
         {
             "id": "f7aa8817-24f8-5dbb-a726-353611565ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa862a0-388d-43b8-973f-3a00ebf53952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa862a0-388d-43b8-973f-3a00ebf53952.jpg?1",
             "name": "Viashino Runner",
             "text": "Viashino Runner can't be blocked except by two or more creatures.",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "1c1fe501-7af9-5df6-9b1e-7187f5445d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102f139d-1baf-4ca6-a940-70b7efdc29f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102f139d-1baf-4ca6-a940-70b7efdc29f2.jpg?1",
             "name": "Viashino Sandscout",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAt end of turn, return Viashino Sandscout to its owner's hand. (Return it only if it's in play.)",
             "colours": [
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "1b122375-8e96-5a83-969a-2d772eceba4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237da964-df20-4bb1-bb87-c3a9582b54ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237da964-df20-4bb1-bb87-c3a9582b54ab.jpg?1",
             "name": "Viashino Sandscout",
             "text": "",
             "colours": [
@@ -11416,7 +11416,7 @@
         },
         {
             "id": "d2a33bcc-4679-54e9-90ad-1387ff8716e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e461bb-5d51-4f9c-a753-9fb090f564e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e461bb-5d51-4f9c-a753-9fb090f564e8.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "16342dc0-7314-5c08-a076-eeeb1956b7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f56b2c-f4e4-42ea-a31a-bd929d2d2ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f56b2c-f4e4-42ea-a31a-bd929d2d2ebc.jpg?1",
             "name": "Wall of Fire",
             "text": "",
             "colours": [
@@ -11486,7 +11486,7 @@
         },
         {
             "id": "56abb591-a158-5945-8dd6-97664f1c82cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0df0a08-7f62-4b8a-a37d-c778c07076c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0df0a08-7f62-4b8a-a37d-c778c07076c6.jpg?1",
             "name": "Warp World",
             "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way into play, then puts all enchantment cards revealed this way into play, then puts all cards revealed this way that weren't put into play on the bottom of his or her library in any order.",
             "colours": [
@@ -11518,7 +11518,7 @@
         },
         {
             "id": "38513fa0-ea83-5642-8ecd-4f0b3daa6768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46184f97-d5c9-4a98-9fd9-e19057ce9b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46184f97-d5c9-4a98-9fd9-e19057ce9b7e.jpg?1",
             "name": "Abundance",
             "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -11550,7 +11550,7 @@
         },
         {
             "id": "0dea6b2e-25bc-5c31-aa1b-a7690af6b853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf92ae01-9d1e-4b41-b068-096648daadf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf92ae01-9d1e-4b41-b068-096648daadf6.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -11582,7 +11582,7 @@
         },
         {
             "id": "b1c3860c-0def-5059-b183-d76ba9a1c93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca570876-23b2-4915-a5b9-20f1fa976fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca570876-23b2-4915-a5b9-20f1fa976fab.jpg?1",
             "name": "Avatar of Might",
             "text": "If an opponent controls at least four more creatures than you, Avatar of Might costs {6} less to play.\nTrample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -11617,7 +11617,7 @@
         },
         {
             "id": "a5e37da8-d36c-5bcb-945d-7be448ddc7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb29ae78-39ba-4249-a95f-a7c64330bc0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb29ae78-39ba-4249-a95f-a7c64330bc0a.jpg?1",
             "name": "Avatar of Might",
             "text": "",
             "colours": [
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "28e56ac7-6a09-5118-9ade-6755b051bc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44060205-8a5c-4f6d-8190-e65d5250935a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44060205-8a5c-4f6d-8190-e65d5250935a.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -11687,7 +11687,7 @@
         },
         {
             "id": "22578321-9dba-5729-ade5-69c7b61f77fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68996f6d-0f19-4ec1-9616-be8af06ae86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68996f6d-0f19-4ec1-9616-be8af06ae86b.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -11722,7 +11722,7 @@
         },
         {
             "id": "dd3828b6-8e14-5f19-97f6-7ffdd9ffc91b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd07ac98-f705-485e-8336-86f7cafd9055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd07ac98-f705-485e-8336-86f7cafd9055.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "062e0ec2-391d-5394-a5d6-04dbc467751f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b462ff-a130-4c0f-97e9-b096511d7abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b462ff-a130-4c0f-97e9-b096511d7abb.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -11792,7 +11792,7 @@
         },
         {
             "id": "34f1354b-31a3-5ff2-8ee3-70df534c7b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d403b-9b86-46f6-8a82-a69c754984e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d403b-9b86-46f6-8a82-a69c754984e0.jpg?1",
             "name": "Canopy Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -11827,7 +11827,7 @@
         },
         {
             "id": "68c5cace-080c-55d1-a55a-6c2190479941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb86063-6a79-491c-9949-ca458aaed03e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb86063-6a79-491c-9949-ca458aaed03e.jpg?1",
             "name": "Canopy Spider",
             "text": "",
             "colours": [
@@ -11862,7 +11862,7 @@
         },
         {
             "id": "0b5e3059-787a-555f-9bb3-38db93233ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d01445-ada9-452e-a6c0-d9dff59755f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d01445-ada9-452e-a6c0-d9dff59755f9.jpg?1",
             "name": "Civic Wayfinder",
             "text": "When Civic Wayfinder comes into play, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -11898,7 +11898,7 @@
         },
         {
             "id": "889c7527-2776-59b2-bebe-9b138ceebaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760d616-b73a-4c7f-8a38-5606a9a321e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760d616-b73a-4c7f-8a38-5606a9a321e3.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -11930,7 +11930,7 @@
         },
         {
             "id": "93c6c384-3214-5eee-ab55-c3bbcfae5472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6b8e11-b799-4235-bd8f-c4b55946c769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6b8e11-b799-4235-bd8f-c4b55946c769.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -11964,7 +11964,7 @@
         },
         {
             "id": "613639f1-7372-5b5c-9109-bef041108023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68d2204-e771-427a-a840-98f6150f648c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68d2204-e771-427a-a840-98f6150f648c.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -11996,7 +11996,7 @@
         },
         {
             "id": "9f55a614-586a-53dd-881a-d4a9648f2ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4bf2a88-2771-4ea8-b448-35642e034965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4bf2a88-2771-4ea8-b448-35642e034965.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders can't be blocked except by Walls and/or creatures with flying.",
             "colours": [
@@ -12030,7 +12030,7 @@
         },
         {
             "id": "d24cf9a8-91e1-55ae-8f2c-023c8a2a14eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777633d7-e31c-4ea3-a085-2858d6ee6040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777633d7-e31c-4ea3-a085-2858d6ee6040.jpg?1",
             "name": "Elvish Berserker",
             "text": "Whenever Elvish Berserker becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "85f9f23a-a3ec-527f-aec2-1f0afaba0235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42a3fd-21ae-49cf-b11d-3700835f2f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42a3fd-21ae-49cf-b11d-3700835f2f96.jpg?1",
             "name": "Elvish Champion",
             "text": "Other Elf creatures get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -12100,7 +12100,7 @@
         },
         {
             "id": "8ea7f1a9-a15e-5775-af3e-1a56a1e0b098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3495d3-fcf8-411f-995f-4cd32967f5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3495d3-fcf8-411f-995f-4cd32967f5cd.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -12135,7 +12135,7 @@
         },
         {
             "id": "c3808d11-6614-57a9-b4bf-d276aa88f5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5535cb2-8cda-4eb7-b201-6528c686815c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5535cb2-8cda-4eb7-b201-6528c686815c.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: You may put a creature card from your hand into play.",
             "colours": [
@@ -12170,7 +12170,7 @@
         },
         {
             "id": "1ebad7f2-d761-56b8-81ae-1e0225968026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f698125f-3961-4295-8dcf-3227ec9f4694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f698125f-3961-4295-8dcf-3227ec9f4694.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -12204,7 +12204,7 @@
         },
         {
             "id": "312306e1-001c-50b8-9a24-249bd40cfae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61df49d2-1324-460b-8c72-6b6fe8b03c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61df49d2-1324-460b-8c72-6b6fe8b03c15.jpg?1",
             "name": "Femeref Archers",
             "text": "{T}: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "373a5b22-c165-5533-aa12-893f13cc06d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a60271-edfc-4bb1-83d5-4d6fa0403b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a60271-edfc-4bb1-83d5-4d6fa0403b19.jpg?1",
             "name": "Gaea's Herald",
             "text": "Creature spells can't be countered.",
             "colours": [
@@ -12273,7 +12273,7 @@
         },
         {
             "id": "d15347ac-1e85-5d2a-9979-eef3f15c7376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4db271b-b7f2-4a12-b606-2215bab4ac17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4db271b-b7f2-4a12-b606-2215bab4ac17.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -12305,7 +12305,7 @@
         },
         {
             "id": "033917bc-01f6-5202-93af-d56bde440b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fefe43-144a-4f47-80ce-c627efed9ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fefe43-144a-4f47-80ce-c627efed9ac6.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "e9397b67-e88c-5f8b-9839-b8887bb9c1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d83722-f7c7-445e-ae45-748021f17bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d83722-f7c7-445e-ae45-748021f17bec.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -12375,7 +12375,7 @@
         },
         {
             "id": "b49d7ef1-e841-5647-8590-4857eca7e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409f9b88-f03e-40b6-9883-68c14c37c0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409f9b88-f03e-40b6-9883-68c14c37c0de.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -12409,7 +12409,7 @@
         },
         {
             "id": "6e2980cb-0c4a-521b-a99f-072533de225e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f752fb0c-31c4-4338-91c5-f2471c38d345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f752fb0c-31c4-4338-91c5-f2471c38d345.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play.",
             "colours": [
@@ -12443,7 +12443,7 @@
         },
         {
             "id": "aa1c3b14-8a65-55ba-b741-68eef451a922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371d83e8-f514-433c-bc6a-e0eeef3fab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371d83e8-f514-433c-bc6a-e0eeef3fab2a.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -12475,7 +12475,7 @@
         },
         {
             "id": "2f39f144-a02a-5017-a45a-4a3cfc2c7a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61751365-3acf-4eb8-b1f9-358ebccccf94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61751365-3acf-4eb8-b1f9-358ebccccf94.jpg?1",
             "name": "Joiner Adept",
             "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -12510,7 +12510,7 @@
         },
         {
             "id": "f83c4766-5cf2-5ccb-943c-3c938b78c7b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa1bf2d-a4b4-44f6-9126-195c602605e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa1bf2d-a4b4-44f6-9126-195c602605e0.jpg?1",
             "name": "Karplusan Strider",
             "text": "Karplusan Strider can't be the target of blue or black spells.",
             "colours": [
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "0bd38891-1832-51a7-a311-efd7a4442f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b343c2ba-e646-4614-aace-9f8772974069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b343c2ba-e646-4614-aace-9f8772974069.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber comes into play, draw a card.",
             "colours": [
@@ -12578,7 +12578,7 @@
         },
         {
             "id": "51106f17-5dd1-5853-b45b-453d83b9d979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7fe6e-aa5a-4be6-a730-5cfff4fb89e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7fe6e-aa5a-4be6-a730-5cfff4fb89e3.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -12613,7 +12613,7 @@
         },
         {
             "id": "fdfd9504-cf9b-5fec-81ba-fd23f2e509d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda18561-4767-4f8e-bc6d-9117d1a480b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda18561-4767-4f8e-bc6d-9117d1a480b1.jpg?1",
             "name": "Llanowar Sentinel",
             "text": "When Llanowar Sentinel comes into play, you may pay {1}{G}. If you do, search your library for a card named Llanowar Sentinel and put that card into play. Then shuffle your library.",
             "colours": [
@@ -12647,7 +12647,7 @@
         },
         {
             "id": "9ecee142-54dd-5a05-8e0d-702467b0ded5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e36efa-266f-48f1-b352-862920487f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e36efa-266f-48f1-b352-862920487f58.jpg?1",
             "name": "Lure",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nAll creatures able to block enchanted creature do so.",
             "colours": [
@@ -12682,7 +12682,7 @@
         },
         {
             "id": "7bd0f6ac-3239-57c5-89a1-f2edc86a4be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07260aa-96f4-440f-b448-72482a5643b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07260aa-96f4-440f-b448-72482a5643b1.jpg?1",
             "name": "Lure",
             "text": "",
             "colours": [
@@ -12717,7 +12717,7 @@
         },
         {
             "id": "c879e36f-630c-573d-a6a6-25737805752f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73957035-c02f-4de6-9258-ef339565bd1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73957035-c02f-4de6-9258-ef339565bd1d.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -12749,7 +12749,7 @@
         },
         {
             "id": "126a046f-002e-50d8-ad2b-45973a624639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd09923-4a4b-4ac6-a487-6e00d17183cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd09923-4a4b-4ac6-a487-6e00d17183cb.jpg?1",
             "name": "Might Weaver",
             "text": "{2}: Target red or white creature gains trample until end of turn. (If it would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -12785,7 +12785,7 @@
         },
         {
             "id": "de602e4a-da36-5b49-a2ed-388bcdbfb54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8cb591-e1e5-42d5-abdb-12a6fa39683a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8cb591-e1e5-42d5-abdb-12a6fa39683a.jpg?1",
             "name": "Might Weaver",
             "text": "",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "21edc41a-e830-58d0-80b5-85eabe32d0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4a6ac2-bec1-4d01-8d7c-e8fd43bd9e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4a6ac2-bec1-4d01-8d7c-e8fd43bd9e4d.jpg?1",
             "name": "Mirri, Cat Warrior",
             "text": "First strike, forestwalk, vigilance (This creature deals combat damage before creatures without first strike, it's unblockable as long as defending player controls a Forest, and attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -12859,7 +12859,7 @@
         },
         {
             "id": "410efb52-131f-5288-8bc5-a9c4a1e7bef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a39caf-85af-466e-bf07-16ff4cc0d5c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a39caf-85af-466e-bf07-16ff4cc0d5c2.jpg?1",
             "name": "Mirri, Cat Warrior",
             "text": "",
             "colours": [
@@ -12897,7 +12897,7 @@
         },
         {
             "id": "52c9439c-c1b8-565e-bd8f-9e3203d7a051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b879e83-07f7-4d9f-a144-04d81d9f700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b879e83-07f7-4d9f-a144-04d81d9f700e.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -12934,7 +12934,7 @@
         },
         {
             "id": "7887f1e9-6c2f-5d54-bf8d-8ebbb956fd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8701858c-38ac-4c50-aa8f-84abb445eb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8701858c-38ac-4c50-aa8f-84abb445eb96.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "a3cc9902-7bc8-577c-8c06-477ef8a82bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983874b1-3179-4ac6-a4f3-efa133331c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983874b1-3179-4ac6-a4f3-efa133331c6f.jpg?1",
             "name": "Natural Spring",
             "text": "Target player gains 8 life.",
             "colours": [
@@ -13003,7 +13003,7 @@
         },
         {
             "id": "33bdbf35-7ded-53cd-b02c-48d1bb62ed04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4e513-a8a7-4338-99de-b9303813d086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4e513-a8a7-4338-99de-b9303813d086.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -13035,7 +13035,7 @@
         },
         {
             "id": "f4cf6ecc-c308-5d3f-8358-ab273f375a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d39834-a8d4-4ac4-b64b-dab1e9d472ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d39834-a8d4-4ac4-b64b-dab1e9d472ac.jpg?1",
             "name": "Overgrowth",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nWhenever enchanted land is tapped for mana, its controller adds {G}{G} to his or her mana pool.",
             "colours": [
@@ -13070,7 +13070,7 @@
         },
         {
             "id": "f82185b9-c5c6-50f3-a681-0241e7d52503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1dc69-4a91-4788-8f35-9a9bc7170250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1dc69-4a91-4788-8f35-9a9bc7170250.jpg?1",
             "name": "Overgrowth",
             "text": "",
             "colours": [
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "60c34bbe-d318-57e8-9226-c6f4af90c0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bea6a3-a8eb-42c5-9224-89cdac7e8523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bea6a3-a8eb-42c5-9224-89cdac7e8523.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (If a creature you control would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -13138,7 +13138,7 @@
         },
         {
             "id": "f92a05a7-c0b3-5136-92c2-a8b6b6531bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec07b33-5d11-4bab-a01a-f6531e0b8a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec07b33-5d11-4bab-a01a-f6531e0b8a2a.jpg?1",
             "name": "Overrun",
             "text": "",
             "colours": [
@@ -13171,7 +13171,7 @@
         },
         {
             "id": "a840ae9a-5214-52fe-83de-73559845536b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484372-325a-4bef-ae86-a7f61816fd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484372-325a-4bef-ae86-a7f61816fd65.jpg?1",
             "name": "Pincher Beetles",
             "text": "Shroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "4e83393d-bb3f-5e39-8730-45202587ad47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20daa230-e72a-447a-a824-21f4433dbf97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20daa230-e72a-447a-a824-21f4433dbf97.jpg?1",
             "name": "Pincher Beetles",
             "text": "",
             "colours": [
@@ -13241,7 +13241,7 @@
         },
         {
             "id": "1ee00edc-c888-5ad2-b591-e1810ca7ce59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3b738-703d-465c-bc76-2b66f1e0aff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3b738-703d-465c-bc76-2b66f1e0aff2.jpg?1",
             "name": "Primal Rage",
             "text": "Creatures you control have trample. (If a creature you control would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -13274,7 +13274,7 @@
         },
         {
             "id": "93043613-bd0a-5937-a129-3c089a63ca8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0b1fb-9c4b-4f54-9f98-13832c1beec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0b1fb-9c4b-4f54-9f98-13832c1beec2.jpg?1",
             "name": "Primal Rage",
             "text": "",
             "colours": [
@@ -13307,7 +13307,7 @@
         },
         {
             "id": "2c6cd5b8-2f45-5ce2-9e60-6b381d8c88c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dead95f5-2e72-4591-be1e-bce6726e1c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dead95f5-2e72-4591-be1e-bce6726e1c5e.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you play a white, blue, black, or red spell, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -13341,7 +13341,7 @@
         },
         {
             "id": "a3bf2c4d-066f-5397-81c6-a18f25d7e7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee662f0a-f874-464c-8206-d4ff427daf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee662f0a-f874-464c-8206-d4ff427daf2b.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -13373,7 +13373,7 @@
         },
         {
             "id": "4dd68de9-3c96-5c4f-b829-3c5c2c485c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb6ca3-0d7f-45ba-99d2-283d517f1463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb6ca3-0d7f-45ba-99d2-283d517f1463.jpg?1",
             "name": "Recollect",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "1fcd5586-bd5b-5fe1-8875-c167a6137d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b848c69-0f64-4631-84b9-6597c359f3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b848c69-0f64-4631-84b9-6597c359f3ba.jpg?1",
             "name": "Regeneration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{G}: Regenerate enchanted creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -13440,7 +13440,7 @@
         },
         {
             "id": "222c5769-1eff-5539-a79e-33d1db864d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c46536d-05a3-43d6-8ae3-549a49b332e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c46536d-05a3-43d6-8ae3-549a49b332e4.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -13475,7 +13475,7 @@
         },
         {
             "id": "1cc6e0b9-e297-5ea0-9e51-d6fbd4fe512c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa50126-f6ec-4917-ac45-4b1f8f23ca09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa50126-f6ec-4917-ac45-4b1f8f23ca09.jpg?1",
             "name": "Rhox",
             "text": "You may have Rhox deal its combat damage to defending player as though it weren't blocked.\n{2}{G}: Regenerate Rhox. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -13511,7 +13511,7 @@
         },
         {
             "id": "3e72aae2-58f2-5c9f-9450-cbbb7e2c0111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1292402-312b-422c-abad-f59ba0715f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1292402-312b-422c-abad-f59ba0715f87.jpg?1",
             "name": "Rhox",
             "text": "",
             "colours": [
@@ -13547,7 +13547,7 @@
         },
         {
             "id": "5e52c0be-d4fa-5f73-8d06-1080da4d0942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727c757a-2ae5-45fd-9832-646a355a5710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727c757a-2ae5-45fd-9832-646a355a5710.jpg?1",
             "name": "Root Maze",
             "text": "Artifacts and lands come into play tapped.",
             "colours": [
@@ -13579,7 +13579,7 @@
         },
         {
             "id": "01248698-729b-5a69-ba8c-f1686a181abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed6122e-670f-4b02-a774-2c230f369147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed6122e-670f-4b02-a774-2c230f369147.jpg?1",
             "name": "Rootwalla",
             "text": "{1}{G}: Rootwalla gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -13613,7 +13613,7 @@
         },
         {
             "id": "e737e5cd-43e1-5a29-a977-fbb673c6367c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed23582-3260-44c6-9884-904d294442ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed23582-3260-44c6-9884-904d294442ad.jpg?1",
             "name": "Rushwood Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -13648,7 +13648,7 @@
         },
         {
             "id": "307db1e5-c643-578c-9e1d-718dd92694d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f61a381-7945-4535-b707-5ebd050d7fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f61a381-7945-4535-b707-5ebd050d7fc5.jpg?1",
             "name": "Rushwood Dryad",
             "text": "",
             "colours": [
@@ -13683,7 +13683,7 @@
         },
         {
             "id": "23d4bb2e-1ed1-5f22-8b08-bbdc15dcb31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a78413-17e3-4652-91b4-708aa66a50ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a78413-17e3-4652-91b4-708aa66a50ca.jpg?1",
             "name": "Scion of the Wild",
             "text": "Scion of the Wild's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -13717,7 +13717,7 @@
         },
         {
             "id": "204da544-dd71-552f-9bbd-bdb2cfa01964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3927cd85-9ee9-4f3c-b92e-8c860136283b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3927cd85-9ee9-4f3c-b92e-8c860136283b.jpg?1",
             "name": "Seedborn Muse",
             "text": "Untap all permanents you control during each other player's untap step.",
             "colours": [
@@ -13751,7 +13751,7 @@
         },
         {
             "id": "971aa202-f2c4-5c25-a3d0-15156ed0384c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2fd9e5-1986-4998-b08c-80897b9b27e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2fd9e5-1986-4998-b08c-80897b9b27e7.jpg?1",
             "name": "Skyshroud Ranger",
             "text": "{T}: You may put a land card from your hand into play. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -13786,7 +13786,7 @@
         },
         {
             "id": "40c181b0-a2d6-54de-ab55-3a09b0b3750b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e855e965-e01c-4203-bc5b-84646e99ac11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e855e965-e01c-4203-bc5b-84646e99ac11.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -13820,7 +13820,7 @@
         },
         {
             "id": "c63ab08b-7b43-5a3e-bbb8-e69d324b7b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8741d0e8-2e4c-49f1-96ad-d3903d29a6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8741d0e8-2e4c-49f1-96ad-d3903d29a6fd.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be blocked by more than one creature.",
             "colours": [
@@ -13854,7 +13854,7 @@
         },
         {
             "id": "20eaaca9-d27f-5521-a9f3-a6b1fcfab114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0912be9-afa5-4ca9-940a-682df7f993fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0912be9-afa5-4ca9-940a-682df7f993fd.jpg?1",
             "name": "Stampeding Wildebeests",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nAt the beginning of your upkeep, return a green creature you control to its owner's hand.",
             "colours": [
@@ -13890,7 +13890,7 @@
         },
         {
             "id": "b240df99-f98a-5450-a3e2-cc0946bb1caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b34009-9398-476d-85b1-ad2f397199c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b34009-9398-476d-85b1-ad2f397199c0.jpg?1",
             "name": "Stampeding Wildebeests",
             "text": "",
             "colours": [
@@ -13926,7 +13926,7 @@
         },
         {
             "id": "e553a0fb-cc04-551c-b0f7-f047cf0c2d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ca1865-a7cb-4107-b2dc-0ead1cd7e6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ca1865-a7cb-4107-b2dc-0ead1cd7e6e7.jpg?1",
             "name": "Sylvan Basilisk",
             "text": "Whenever Sylvan Basilisk becomes blocked by a creature, destroy that creature.",
             "colours": [
@@ -13960,7 +13960,7 @@
         },
         {
             "id": "52d9f396-b080-5da2-b904-302c6f319f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa5aac-d4b6-47c8-b148-3077e2077e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa5aac-d4b6-47c8-b148-3077e2077e53.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -13992,7 +13992,7 @@
         },
         {
             "id": "ec55586c-f4ae-5085-a6f0-20200af2ba76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1e75e1-a827-46c1-896f-cd8fbdf79fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1e75e1-a827-46c1-896f-cd8fbdf79fa8.jpg?1",
             "name": "Tangle Spider",
             "text": "Flash (You may play this spell any time you could play an instant.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "8b39d0fc-ddef-5d5a-95fc-975bee2fbe06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e250967-ce3f-49e1-abdd-e9d356cadae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e250967-ce3f-49e1-abdd-e9d356cadae8.jpg?1",
             "name": "Tangle Spider",
             "text": "",
             "colours": [
@@ -14062,7 +14062,7 @@
         },
         {
             "id": "75f33095-04ee-5cfc-b58a-863fc8819ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84185d8-c058-4fe7-b46e-f5ca90e70f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84185d8-c058-4fe7-b46e-f5ca90e70f12.jpg?1",
             "name": "Treetop Bracers",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 and can't be blocked except by creatures with flying.",
             "colours": [
@@ -14097,7 +14097,7 @@
         },
         {
             "id": "4c708bbf-9168-5fa5-a02e-5ce3bcc6158b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72741f22-ee30-4478-8706-d0b64b5e7e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72741f22-ee30-4478-8706-d0b64b5e7e3c.jpg?1",
             "name": "Treetop Bracers",
             "text": "",
             "colours": [
@@ -14132,7 +14132,7 @@
         },
         {
             "id": "154824ca-2444-5562-927f-cedddab5a8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d447186e-62a7-4767-bb85-6439fd795350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d447186e-62a7-4767-bb85-6439fd795350.jpg?1",
             "name": "Troll Ascetic",
             "text": "Troll Ascetic can't be the target of spells or abilities your opponents control.\n{1}{G}: Regenerate Troll Ascetic. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -14168,7 +14168,7 @@
         },
         {
             "id": "ba1b342b-9a40-5bdb-9a64-e392b752bd76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1bfa-eb85-4f64-bd11-8af53bf4c3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1bfa-eb85-4f64-bd11-8af53bf4c3d4.jpg?1",
             "name": "Troll Ascetic",
             "text": "",
             "colours": [
@@ -14204,7 +14204,7 @@
         },
         {
             "id": "51bf24e5-bfa3-5262-b6c7-b7b6b6d09b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c47cac-679f-4b48-977f-2fa149a6c3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c47cac-679f-4b48-977f-2fa149a6c3c3.jpg?1",
             "name": "Upwelling",
             "text": "Mana pools don't empty at the end of phases or turns. (This effect stops mana burn.)",
             "colours": [
@@ -14237,7 +14237,7 @@
         },
         {
             "id": "5c0bbc6b-9f29-5d67-9065-22a1d99ad7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec2a66-0725-4933-8651-e2ba41a8f434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec2a66-0725-4933-8651-e2ba41a8f434.jpg?1",
             "name": "Upwelling",
             "text": "",
             "colours": [
@@ -14270,7 +14270,7 @@
         },
         {
             "id": "c6eedc08-9b48-52b9-a9ec-bb0347fd3987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd3ac60-aae0-45e6-8592-32be316d2f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd3ac60-aae0-45e6-8592-32be316d2f14.jpg?1",
             "name": "Verdant Force",
             "text": "At the beginning of each upkeep, put a 1/1 green Saproling creature token into play under your control.",
             "colours": [
@@ -14304,7 +14304,7 @@
         },
         {
             "id": "abb362ed-d21a-5b20-929a-9caca69b3dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82082bf-5b15-4835-93ad-2263f0b0a62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82082bf-5b15-4835-93ad-2263f0b0a62c.jpg?1",
             "name": "Viridian Shaman",
             "text": "When Viridian Shaman comes into play, destroy target artifact.",
             "colours": [
@@ -14339,7 +14339,7 @@
         },
         {
             "id": "564d110e-2a39-5fcb-967a-bacf3a432799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864e25e-f940-47e5-9439-ab721049c690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864e25e-f940-47e5-9439-ab721049c690.jpg?1",
             "name": "Wall of Wood",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -14374,7 +14374,7 @@
         },
         {
             "id": "a6778999-a426-51ea-82d1-749bf98619be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f529ea-3dd2-4e74-8b64-b31905a4544d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f529ea-3dd2-4e74-8b64-b31905a4544d.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -14409,7 +14409,7 @@
         },
         {
             "id": "14878086-100b-5658-a753-571278cbb546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60e2daa-3740-40f0-a333-8b7f4c2da34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60e2daa-3740-40f0-a333-8b7f4c2da34a.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "da0a5791-2fc2-53e4-bc8b-c4d8cd026ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d12cd-a517-4604-97ac-b93d1a94a757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d12cd-a517-4604-97ac-b93d1a94a757.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player plays a white spell, you may gain 1 life.",
             "colours": [],
@@ -14472,7 +14472,7 @@
         },
         {
             "id": "8402d391-a810-5c04-af77-d3fb01dbacca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7cc984-1378-4b01-8115-d3c5b4f68a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7cc984-1378-4b01-8115-d3c5b4f68a2a.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: You gain 3 life.",
             "colours": [],
@@ -14503,7 +14503,7 @@
         },
         {
             "id": "da8f1e81-fc1f-57f4-b4ec-0c5445a299e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca0425d-f41c-4ba5-ac06-9ce5bab2a4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca0425d-f41c-4ba5-ac06-9ce5bab2a4b9.jpg?1",
             "name": "Chimeric Staff",
             "text": "{X}: Chimeric Staff becomes an X/X Construct artifact creature until end of turn.",
             "colours": [],
@@ -14531,7 +14531,7 @@
         },
         {
             "id": "3785490a-01f5-511d-b471-60b1209b3d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3233db3e-ec30-4be5-867d-81855652a8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3233db3e-ec30-4be5-867d-81855652a8b0.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color to your mana pool.\nWhen Chromatic Star is put into a graveyard from play, draw a card.",
             "colours": [],
@@ -14559,7 +14559,7 @@
         },
         {
             "id": "b0a0f3ea-f483-53e3-ae41-bdb409141fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e0dff-d9f0-4222-a308-e86581c440cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e0dff-d9f0-4222-a308-e86581c440cc.jpg?1",
             "name": "Citanul Flute",
             "text": "{X}, {T}: Search your library for a creature card with converted mana cost X or less, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -14587,7 +14587,7 @@
         },
         {
             "id": "515fce14-605b-5768-b743-e8497b583d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2602f046-5e79-4a8a-a5b1-b7c3cbb307fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2602f046-5e79-4a8a-a5b1-b7c3cbb307fc.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if a Goblin Warrior, a Goblin Scout, and a Zombie Goblin are in play, each gets +2/+2.)",
             "colours": [],
@@ -14616,7 +14616,7 @@
         },
         {
             "id": "ffe80735-543f-53c2-9e48-ee66c78d7393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e098d9e-3e1f-4421-aa41-6f0dc095eb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e098d9e-3e1f-4421-aa41-6f0dc095eb96.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -14645,7 +14645,7 @@
         },
         {
             "id": "827e7d75-66de-5aee-bae3-517306eb4536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd164011-7a8e-44a2-8599-0a1c0878b5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd164011-7a8e-44a2-8599-0a1c0878b5b5.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nColossus of Sardia doesn't untap during your untap step.\n{9}: Untap Colossus of Sardia. Play this ability only during your upkeep.",
             "colours": [],
@@ -14677,7 +14677,7 @@
         },
         {
             "id": "725ab389-a7a2-5869-929b-c8e1098b547d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a80eae-6a58-4833-80fa-2c22d531b9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a80eae-6a58-4833-80fa-2c22d531b9d1.jpg?1",
             "name": "Colossus of Sardia",
             "text": "",
             "colours": [],
@@ -14709,7 +14709,7 @@
         },
         {
             "id": "7db42d14-4950-5478-b87c-fbbd93889801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd4637-737d-4913-80e3-ab4bf3428680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd4637-737d-4913-80e3-ab4bf3428680.jpg?1",
             "name": "Composite Golem",
             "text": "Sacrifice Composite Golem: Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [],
@@ -14746,7 +14746,7 @@
         },
         {
             "id": "80baae17-693b-5662-aad7-071f3b031fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc887b1-299e-49f2-94ab-7c3fb24b1432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc887b1-299e-49f2-94ab-7c3fb24b1432.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play land cards from your graveyard.",
             "colours": [],
@@ -14774,7 +14774,7 @@
         },
         {
             "id": "bbea1480-68f2-51fb-8ac9-e7c7485f39fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edba12b8-1418-4122-8e8a-ebbdb654e801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edba12b8-1418-4122-8e8a-ebbdb654e801.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player plays a black spell, you may gain 1 life.",
             "colours": [],
@@ -14802,7 +14802,7 @@
         },
         {
             "id": "49383392-e722-56a9-afd0-c531ecb05310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d946df5-f206-4241-bb55-97db67dc793c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d946df5-f206-4241-bb55-97db67dc793c.jpg?1",
             "name": "Doubling Cube",
             "text": "{3}, {T}: Double the amount of each type of mana in your mana pool.",
             "colours": [],
@@ -14830,7 +14830,7 @@
         },
         {
             "id": "3a76f884-3f71-5dbd-8ac8-6bb24e72704d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963237e-cb33-4833-a725-4196cfdd87ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963237e-cb33-4833-a725-4196cfdd87ef.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player plays a red spell, you may gain 1 life.",
             "colours": [],
@@ -14858,7 +14858,7 @@
         },
         {
             "id": "01e48603-fbf2-5178-92d2-3d6c9944f4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8515a993-0f9d-4ac8-8452-889f23d9d9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8515a993-0f9d-4ac8-8452-889f23d9d9a9.jpg?1",
             "name": "Fountain of Youth",
             "text": "{2}, {T}: You gain 1 life.",
             "colours": [],
@@ -14886,7 +14886,7 @@
         },
         {
             "id": "2c7b2887-e138-547b-804a-c02ce8c51de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4141e02a-d42c-4272-833d-98e2614ab371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4141e02a-d42c-4272-833d-98e2614ab371.jpg?1",
             "name": "The Hive",
             "text": "{5}, {T}: Put a 1/1 Insect artifact creature token with flying named Wasp into play. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -14915,7 +14915,7 @@
         },
         {
             "id": "0a8f1091-c245-5569-b121-ffd0a50008b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec7d032-72df-49ad-9f59-41bf468ba850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec7d032-72df-49ad-9f59-41bf468ba850.jpg?1",
             "name": "The Hive",
             "text": "",
             "colours": [],
@@ -14944,7 +14944,7 @@
         },
         {
             "id": "03b06cf7-aa45-504c-b4af-ceefce384f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe62264-058d-4337-a793-a66eb42551f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe62264-058d-4337-a793-a66eb42551f7.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -14972,7 +14972,7 @@
         },
         {
             "id": "eef8487a-450f-5e19-b9f1-2886839d02ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c67344c-2066-4e19-88a2-52b272d7d216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c67344c-2066-4e19-88a2-52b272d7d216.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -15000,7 +15000,7 @@
         },
         {
             "id": "2443b453-cb6e-5981-b7ff-3bb6ecb06c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4736f-e19e-4e7b-9846-4d0806e46ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4736f-e19e-4e7b-9846-4d0806e46ce9.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -15028,7 +15028,7 @@
         },
         {
             "id": "c397d44d-ce30-511a-af0a-3c6a7f977df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ac76c-34c0-4d3b-868b-aa395edb221e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ac76c-34c0-4d3b-868b-aa395edb221e.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -15059,7 +15059,7 @@
         },
         {
             "id": "8dfa8b47-af66-51df-9472-16c2bc4cf8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56df2ec-a0e3-4b45-bb44-a8ea8c03eac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56df2ec-a0e3-4b45-bb44-a8ea8c03eac3.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player plays a blue spell, you may gain 1 life.",
             "colours": [],
@@ -15087,7 +15087,7 @@
         },
         {
             "id": "4afd939d-f7b3-5807-bcc9-c2d7d4ac3ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2ef7bf-6e5b-40a0-8b25-478323b64bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2ef7bf-6e5b-40a0-8b25-478323b64bdc.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Remove target permanent from the game.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -15123,7 +15123,7 @@
         },
         {
             "id": "178922c9-620a-5eaa-8391-8216ec579232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cceb7b-7166-491f-b471-8e0bc42f611e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cceb7b-7166-491f-b471-8e0bc42f611e.jpg?1",
             "name": "Leonin Scimitar",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15154,7 +15154,7 @@
         },
         {
             "id": "16b6100b-950e-567e-a815-603b78f526e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e786d55b-42e5-431d-aa27-d68c2a2ebcea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e786d55b-42e5-431d-aa27-d68c2a2ebcea.jpg?1",
             "name": "Leonin Scimitar",
             "text": "",
             "colours": [],
@@ -15185,7 +15185,7 @@
         },
         {
             "id": "8c265b98-5ca4-529e-a238-72d5de968dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f3f215-389b-4d86-8393-65e5af4ab981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f3f215-389b-4d86-8393-65e5af4ab981.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0 and has lifelink and trample. (When it deals damage, you gain that much life. If it would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15216,7 +15216,7 @@
         },
         {
             "id": "39afdeca-0f97-5d0a-ac7f-af0ae4d75b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8820a0-b07c-4595-b391-28b47cf48d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8820a0-b07c-4595-b391-28b47cf48d9d.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "",
             "colours": [],
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "ea9feb69-1c09-5d99-a920-54760fd7fd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86111211-b3d9-42eb-bab7-ee2cf9acda5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86111211-b3d9-42eb-bab7-ee2cf9acda5d.jpg?1",
             "name": "Mantis Engine",
             "text": "{2}: Mantis Engine gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)\n{2}: Mantis Engine gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -15279,7 +15279,7 @@
         },
         {
             "id": "bc899285-8adc-5280-92fd-dcf278c76da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e023e4-7fb2-4452-894a-39b6e889deac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e023e4-7fb2-4452-894a-39b6e889deac.jpg?1",
             "name": "Mantis Engine",
             "text": "",
             "colours": [],
@@ -15311,7 +15311,7 @@
         },
         {
             "id": "afdc12d3-7a55-5b55-b85c-12195718c79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a00d0ea-f08c-446a-8537-80a1df6702ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a00d0ea-f08c-446a-8537-80a1df6702ad.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -15339,7 +15339,7 @@
         },
         {
             "id": "d089fdc1-4d21-58e8-b9c8-23d8b3191fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52284689-f2e0-442d-80d0-9e766759e2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52284689-f2e0-442d-80d0-9e766759e2bc.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -15367,7 +15367,7 @@
         },
         {
             "id": "18bacc5a-3ca0-5b72-bacb-ea98e6036c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d784214-dc69-42d4-b897-995ca5751e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d784214-dc69-42d4-b897-995ca5751e13.jpg?1",
             "name": "Ornithopter",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -15399,7 +15399,7 @@
         },
         {
             "id": "4b7ee21b-ccb2-5590-98d7-146bbe0ba10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acf7453-1229-4758-bb17-8afc7dffa9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acf7453-1229-4758-bb17-8afc7dffa9a0.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -15431,7 +15431,7 @@
         },
         {
             "id": "31ecdb2e-eec0-56fb-9a12-7af9069f3673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70e601-ec60-434e-af9e-eb0bf2a580e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70e601-ec60-434e-af9e-eb0bf2a580e2.jpg?1",
             "name": "Phyrexian Vault",
             "text": "{2}, {T}, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -15459,7 +15459,7 @@
         },
         {
             "id": "cae5ac32-6265-5615-a060-21fb1a2dea5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d8adbf-37b8-4d69-b25a-57ebd777b53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d8adbf-37b8-4d69-b25a-57ebd777b53d.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle comes into play, name a card.\nActivated abilities of sources with the chosen name can't be played unless they're mana abilities.",
             "colours": [],
@@ -15487,7 +15487,7 @@
         },
         {
             "id": "c5075bc5-ad52-5c59-b764-22bfc4b1c39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698f66ac-dae6-4b42-ae6f-d468b69b25be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698f66ac-dae6-4b42-ae6f-d468b69b25be.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -15519,7 +15519,7 @@
         },
         {
             "id": "47432616-5812-59fd-b90e-88dadd613161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f259e4e8-d50e-41ef-86d2-0046f55089a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f259e4e8-d50e-41ef-86d2-0046f55089a6.jpg?1",
             "name": "Platinum Angel",
             "text": "",
             "colours": [],
@@ -15551,7 +15551,7 @@
         },
         {
             "id": "41e69f7f-cf4a-5f5e-a5ce-5ef73900a9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e539af0-4390-482e-8bc9-25909d782b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e539af0-4390-482e-8bc9-25909d782b70.jpg?1",
             "name": "Razormane Masticore",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nAt the beginning of your upkeep, sacrifice Razormane Masticore unless you discard a card.\nAt the beginning of your draw step, you may have Razormane Masticore deal 3 damage to target creature.",
             "colours": [],
@@ -15583,7 +15583,7 @@
         },
         {
             "id": "0720c621-c070-5870-b4d7-40d2cae2cb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1d6b0-a13a-4bb2-ba07-1a7742953b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1d6b0-a13a-4bb2-ba07-1a7742953b15.jpg?1",
             "name": "Razormane Masticore",
             "text": "",
             "colours": [],
@@ -15615,7 +15615,7 @@
         },
         {
             "id": "b6b8b11d-0406-54e5-aed1-46d1588262e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1f1431-b324-4915-89e8-2697cf755441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1f1431-b324-4915-89e8-2697cf755441.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -15643,7 +15643,7 @@
         },
         {
             "id": "98becc43-123e-5e33-90f0-59318c221f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41368983-14f8-4efa-bb60-b0a7ceb3d021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41368983-14f8-4efa-bb60-b0a7ceb3d021.jpg?1",
             "name": "Sculpting Steel",
             "text": "As Sculpting Steel comes into play, you may choose an artifact in play. If you do, Sculpting Steel comes into play as a copy of that artifact.",
             "colours": [],
@@ -15671,7 +15671,7 @@
         },
         {
             "id": "06058b88-09c6-5475-a4b3-a72df2a7bea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1adade15-5675-495b-a536-e531c4306d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1adade15-5675-495b-a536-e531c4306d3e.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -15699,7 +15699,7 @@
         },
         {
             "id": "a4bd6d9a-942d-53a3-8607-2354f86cc810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d9b1ae-755d-49e4-b012-db95019491c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d9b1ae-755d-49e4-b012-db95019491c6.jpg?1",
             "name": "Steel Golem",
             "text": "You can't play creature spells.",
             "colours": [],
@@ -15730,7 +15730,7 @@
         },
         {
             "id": "6c08e1af-bbb8-5a03-b680-e00e45c68ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172980e-5464-4a9a-8919-9da86261d0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172980e-5464-4a9a-8919-9da86261d0c4.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable and has shroud. (It can't be the target of spells or abilities.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15761,7 +15761,7 @@
         },
         {
             "id": "d44c9385-588c-50e2-a3fc-2ff233f41086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a8c29d-a950-4c17-9e67-394cfe431c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a8c29d-a950-4c17-9e67-394cfe431c09.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "",
             "colours": [],
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "a1629073-cd64-5aa4-aca6-4d4e64dff8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfc32a-479b-4517-b7d5-808774516bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfc32a-479b-4517-b7d5-808774516bb6.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player plays a green spell, you may gain 1 life.",
             "colours": [],
@@ -15820,7 +15820,7 @@
         },
         {
             "id": "11727081-4070-56db-8162-b970dd7f94bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cf014-7ac9-428b-9ce9-8ba5ebfdd252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cf014-7ac9-428b-9ce9-8ba5ebfdd252.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "dec9c4f1-455e-56de-aad4-9a1d18cf5588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0df1e5f-8cef-4e13-babf-4254a85ac46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0df1e5f-8cef-4e13-babf-4254a85ac46b.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "ca560ce6-8093-51e9-9b7f-2c11756d6516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afcfca-c065-4a33-95b1-ec2b08bcb493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afcfca-c065-4a33-95b1-ec2b08bcb493.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -15913,7 +15913,7 @@
         },
         {
             "id": "a807430a-5a37-550c-989f-72d125d7b0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac3c4e31-673e-4148-bd2e-de569906ce7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac3c4e31-673e-4148-bd2e-de569906ce7d.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -15944,7 +15944,7 @@
         },
         {
             "id": "0f95923c-e501-52ed-9666-5e73c531c642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69df4707-09c5-48e7-9681-0cf7960aeeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69df4707-09c5-48e7-9681-0cf7960aeeb1.jpg?1",
             "name": "Faerie Conclave",
             "text": "Faerie Conclave comes into play tapped.\n{T}: Add {U} to your mana pool.\n{1}{U}: Faerie Conclave becomes a 2/1 blue Faerie creature with flying until end of turn. It's still a land. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -15975,7 +15975,7 @@
         },
         {
             "id": "5b975ab5-c9d5-5fd3-a425-27842542683a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e8460b-cf14-40cc-8adc-c8650c6a02d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e8460b-cf14-40cc-8adc-c8650c6a02d1.jpg?1",
             "name": "Faerie Conclave",
             "text": "",
             "colours": [],
@@ -16006,7 +16006,7 @@
         },
         {
             "id": "b3de8302-e27e-5553-9ed6-f6a6f5fad14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb8c9c-3108-4a06-8ad9-a0dbe3cc5c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb8c9c-3108-4a06-8ad9-a0dbe3cc5c02.jpg?1",
             "name": "Forbidding Watchtower",
             "text": "Forbidding Watchtower comes into play tapped.\n{T}: Add {W} to your mana pool.\n{1}{W}: Forbidding Watchtower becomes a 1/5 white Soldier creature until end of turn. It's still a land.",
             "colours": [],
@@ -16036,7 +16036,7 @@
         },
         {
             "id": "e04a8147-589b-5b9d-8101-50073d47eb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4f58d5-1dc0-4824-a554-56adc1700d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4f58d5-1dc0-4824-a554-56adc1700d33.jpg?1",
             "name": "Ghitu Encampment",
             "text": "Ghitu Encampment comes into play tapped.\n{T}: Add {R} to your mana pool.\n{1}{R}: Ghitu Encampment becomes a 2/1 red Warrior creature with first strike until end of turn. It's still a land. (It deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -16067,7 +16067,7 @@
         },
         {
             "id": "d1b05ebd-7023-5236-bf3b-470476c6f59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f39841d-b8f0-4265-a3bf-73901b24f2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f39841d-b8f0-4265-a3bf-73901b24f2eb.jpg?1",
             "name": "Ghitu Encampment",
             "text": "",
             "colours": [],
@@ -16098,7 +16098,7 @@
         },
         {
             "id": "0bcc33de-dce2-556f-9bdc-080f7ae67529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56ad1cb-c1b9-4856-8d46-55012aee4d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56ad1cb-c1b9-4856-8d46-55012aee4d47.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -16129,7 +16129,7 @@
         },
         {
             "id": "15139516-eb75-5f45-b35f-3372217cfc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9d9e2d-6176-4593-b34a-c892a7b34695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9d9e2d-6176-4593-b34a-c892a7b34695.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -16160,7 +16160,7 @@
         },
         {
             "id": "6c4d1103-3acd-5828-9bf7-77a0b1d405a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8042ec-5306-4851-9854-f05ed7e1acf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8042ec-5306-4851-9854-f05ed7e1acf6.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -16188,7 +16188,7 @@
         },
         {
             "id": "ff703e3a-4ea3-59d6-99e5-02c4db74f035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62ea973-7799-4179-9d36-60e2287feae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62ea973-7799-4179-9d36-60e2287feae7.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -16219,7 +16219,7 @@
         },
         {
             "id": "0f3d794f-2e02-5fa8-b9a7-8ffa74f9615d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b49ff-2020-4203-b93e-4b3306afc337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b49ff-2020-4203-b93e-4b3306afc337.jpg?1",
             "name": "Spawning Pool",
             "text": "Spawning Pool comes into play tapped.\n{T}: Add {B} to your mana pool.\n{1}{B}: Spawning Pool becomes a 1/1 black Skeleton creature with \"{B}: Regenerate this creature\" until end of turn. It's still a land. (If it regenerates, the next time it would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [],
@@ -16250,7 +16250,7 @@
         },
         {
             "id": "85e3e30b-c47d-5606-a6fd-0b4a9931de79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495bec8c-20d1-4133-92eb-a1e405026e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495bec8c-20d1-4133-92eb-a1e405026e4f.jpg?1",
             "name": "Spawning Pool",
             "text": "",
             "colours": [],
@@ -16281,7 +16281,7 @@
         },
         {
             "id": "5ff7b860-8e0f-51a3-a2db-9819417afd06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f2426-5a56-4dca-a059-65aa7266ac83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f2426-5a56-4dca-a059-65aa7266ac83.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -16312,7 +16312,7 @@
         },
         {
             "id": "2137fcba-c774-53da-b051-321a3fcf8f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6858542c-b8f9-449b-b7da-65c96a67636a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6858542c-b8f9-449b-b7da-65c96a67636a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -16340,7 +16340,7 @@
         },
         {
             "id": "4e82f56f-3533-50af-9d10-b723005d5b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de15f8fd-499c-4fa0-9a10-425f81c61579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de15f8fd-499c-4fa0-9a10-425f81c61579.jpg?1",
             "name": "Treetop Village",
             "text": "Treetop Village comes into play tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [],
@@ -16371,7 +16371,7 @@
         },
         {
             "id": "4ed247e0-386b-5166-9c99-875d6f82f681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1773793a-31af-4a22-a4ac-90e4c3dc5090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1773793a-31af-4a22-a4ac-90e4c3dc5090.jpg?1",
             "name": "Treetop Village",
             "text": "",
             "colours": [],
@@ -16402,7 +16402,7 @@
         },
         {
             "id": "0cc99e92-fbb3-52d1-909c-ee619996e795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298bf7-2514-43d4-a285-1386d6ba0835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298bf7-2514-43d4-a285-1386d6ba0835.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -16433,7 +16433,7 @@
         },
         {
             "id": "a139944e-bae3-523b-a29c-4aa3c544e532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1d58ea-39f2-4bdb-a960-b610c39e35e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1d58ea-39f2-4bdb-a960-b610c39e35e3.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -16464,7 +16464,7 @@
         },
         {
             "id": "c4823642-08dd-5c10-ae26-ef8d52cf3a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfd53b2-3991-4a57-81b5-46618aecce4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfd53b2-3991-4a57-81b5-46618aecce4a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16502,7 +16502,7 @@
         },
         {
             "id": "3d407269-4586-51e3-9da6-298d65aff831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95e9696-6e9d-462a-a40e-117df77e3909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95e9696-6e9d-462a-a40e-117df77e3909.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16540,7 +16540,7 @@
         },
         {
             "id": "053c8559-8ab8-5a1a-9444-6140b41470c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2db9b8-648f-4c7f-bd58-1069a1417a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2db9b8-648f-4c7f-bd58-1069a1417a22.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16578,7 +16578,7 @@
         },
         {
             "id": "77977762-e1e1-507b-8d59-e9ed6671a926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b68c00-59ed-410f-87fe-b411f07662e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b68c00-59ed-410f-87fe-b411f07662e3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -16616,7 +16616,7 @@
         },
         {
             "id": "2e21d91d-3970-503f-b36a-e2b0e37fb3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74648fc-587c-4d20-9432-58465bd7dca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74648fc-587c-4d20-9432-58465bd7dca9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16654,7 +16654,7 @@
         },
         {
             "id": "a494d14e-b4c3-5467-8af5-bad8b41da09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5328db-c55a-488d-b085-fcfa7be184ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5328db-c55a-488d-b085-fcfa7be184ca.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16692,7 +16692,7 @@
         },
         {
             "id": "6c88ef33-31c8-545f-96dc-de46d68bdbc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eebf59-25ec-448f-b7a6-df9a1ecad3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eebf59-25ec-448f-b7a6-df9a1ecad3a2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "31bd4e75-e2c5-5252-a7ff-4eb2a99a4a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d3de4f-dfef-4c04-a297-4fd90884087e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d3de4f-dfef-4c04-a297-4fd90884087e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -16768,7 +16768,7 @@
         },
         {
             "id": "ec72e59f-bc37-50fd-a1b5-3afac5a402b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6497c73-4bbb-4923-8151-8234c98ca6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6497c73-4bbb-4923-8151-8234c98ca6d4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16806,7 +16806,7 @@
         },
         {
             "id": "4b3673bc-4f31-5877-9710-44d875dcca8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72aa721-c20c-4306-aca9-dbf2e36d5ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72aa721-c20c-4306-aca9-dbf2e36d5ba7.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16844,7 +16844,7 @@
         },
         {
             "id": "3e951ede-39fc-58c6-8a89-e2c320902ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eaedaf2-a9a3-44c6-84c1-4cc2da1da459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eaedaf2-a9a3-44c6-84c1-4cc2da1da459.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16882,7 +16882,7 @@
         },
         {
             "id": "eedae11d-cb7c-5b59-bcdd-419e3d6311a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eed3360-1634-4e60-b24d-4128c4896994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eed3360-1634-4e60-b24d-4128c4896994.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -16920,7 +16920,7 @@
         },
         {
             "id": "c1f98960-ef31-5ec9-af8d-d6d56169047b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aae748-27d8-48f8-beb2-8e0192d7cc5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aae748-27d8-48f8-beb2-8e0192d7cc5c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -16958,7 +16958,7 @@
         },
         {
             "id": "3e12f3ab-96ab-5d5a-8bed-92b37ffee9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253c7d53-e34b-493b-8d46-da946245bebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253c7d53-e34b-493b-8d46-da946245bebb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -16996,7 +16996,7 @@
         },
         {
             "id": "87d6bcfb-0e75-59f7-be6c-30aa7c344ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c1e97b-4d7a-4a76-8999-5c76b4bae9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c1e97b-4d7a-4a76-8999-5c76b4bae9cb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17034,7 +17034,7 @@
         },
         {
             "id": "47e1bdab-e112-526d-bd9f-7f1cffef7187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91df0ada-4828-41ca-9000-5132fcb29e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91df0ada-4828-41ca-9000-5132fcb29e6b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17072,7 +17072,7 @@
         },
         {
             "id": "4a17c998-1a44-5537-b675-b19522d43bee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99d5685-538d-4e6a-809b-3ebeab634363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99d5685-538d-4e6a-809b-3ebeab634363.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17110,7 +17110,7 @@
         },
         {
             "id": "06ac124d-5c6e-542e-bf11-552ec9cc19cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e30de-fc01-4512-b218-a1411cb50789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e30de-fc01-4512-b218-a1411cb50789.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17148,7 +17148,7 @@
         },
         {
             "id": "0f0aa930-854b-59fb-bd76-69d987356f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc29dea-b48c-4363-8f17-da0413a49a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc29dea-b48c-4363-8f17-da0413a49a92.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17186,7 +17186,7 @@
         },
         {
             "id": "4d710f8c-6249-5877-9799-edf65d0c3e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d4cf1d-6101-40e7-8e0a-a6ad5bd5d3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d4cf1d-6101-40e7-8e0a-a6ad5bd5d3fc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17224,7 +17224,7 @@
         },
         {
             "id": "5aea21ce-bd08-5cd4-87f1-991f8f708d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ae31d1-9a6e-43f3-9b04-bd15699f73d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ae31d1-9a6e-43f3-9b04-bd15699f73d6.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -17258,7 +17258,7 @@
         },
         {
             "id": "63ac47ed-3457-5af8-9a33-1bb5dcb9ca9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73e348-5bf1-4465-978b-3f31408bade9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73e348-5bf1-4465-978b-3f31408bade9.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17292,7 +17292,7 @@
         },
         {
             "id": "7decf258-eb10-50da-83f7-c7eba74adbfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b3b90-74c3-479b-b3e6-3f1cd8f1da04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b3b90-74c3-479b-b3e6-3f1cd8f1da04.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -17326,7 +17326,7 @@
         },
         {
             "id": "8b44e4ca-fb3a-5ef1-a607-6ed5b98cb216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9577d3c-ee19-4b53-adac-b304287a066f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9577d3c-ee19-4b53-adac-b304287a066f.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -17360,7 +17360,7 @@
         },
         {
             "id": "e5f8bf25-2f3e-59c6-a59e-313184ee43db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698d48fa-d6c1-44b9-8aa2-bb03e0e53788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698d48fa-d6c1-44b9-8aa2-bb03e0e53788.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -17394,7 +17394,7 @@
         },
         {
             "id": "ce98066c-a3a1-51a2-bffc-12c38ef45905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b81b5-5c84-45d4-832a-20c038372bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b81b5-5c84-45d4-832a-20c038372bc6.jpg?1",
             "name": "Wasp",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/2X2.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/2X2.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5169592e-dd93-535a-b5af-51c9aaccbf36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249db4d4-2542-47ee-a216-e13ffbc2319c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249db4d4-2542-47ee-a216-e13ffbc2319c.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -40,7 +40,7 @@
         },
         {
             "id": "14e24424-15a0-5b28-817f-de8c72748469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27cf7b7-7982-46bd-a559-7789c0e74bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27cf7b7-7982-46bd-a559-7789c0e74bae.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -76,7 +76,7 @@
         },
         {
             "id": "664e694d-acf8-5937-b1ca-9ce8ce48762c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464a820-65de-44f2-9895-46a35e8621a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464a820-65de-44f2-9895-46a35e8621a0.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -112,7 +112,7 @@
         },
         {
             "id": "18468b64-37ef-5e4d-b95a-781265b533a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db62ac2c-0d24-4d6f-a6ca-cca4371a3bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db62ac2c-0d24-4d6f-a6ca-cca4371a3bd7.jpg?1",
             "name": "Abzan Falconer",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "454b109d-f148-5f55-a5a0-7316e013e8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1778cf9a-2703-41e9-86d7-ec21af8cf61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1778cf9a-2703-41e9-86d7-ec21af8cf61d.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "ab1619d5-df3c-5434-b900-36561e62468f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fb9f7-ec03-4831-96d4-a26c89b91830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fb9f7-ec03-4831-96d4-a26c89b91830.jpg?1",
             "name": "Anointer of Valor",
             "text": "Flying\nWhenever a creature attacks, you may pay {3}. When you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "ab9fb17d-4491-50bc-adac-c230a3d6d262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4e3a08-05a6-4730-8b4a-a8cb440dc299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4e3a08-05a6-4730-8b4a-a8cb440dc299.jpg?1",
             "name": "Battlefield Promotion",
             "text": "Put a +1/+1 counter on target creature. That creature gains first strike until end of turn. You gain 2 life.",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "045cb387-99c2-5790-9a7a-b8a01736babc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a73bd5a-eb22-41dc-84ff-93d23d84afae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a73bd5a-eb22-41dc-84ff-93d23d84afae.jpg?1",
             "name": "Divine Visitation",
             "text": "If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "270cb060-9fcf-5a5a-b87e-6ec5a0e278b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5642cdda-789f-4125-a9ff-7c445bb51950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5642cdda-789f-4125-a9ff-7c445bb51950.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "eefc87b8-59ea-53e9-9a44-7ba5e4fefd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f594562-7e9f-47e6-a033-fb70e3cf1e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f594562-7e9f-47e6-a033-fb70e3cf1e10.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "106f7578-028f-5c49-bef6-03f9d65a77bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cccf30-2025-49bb-9b1e-240bbef03f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cccf30-2025-49bb-9b1e-240bbef03f27.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "c98f1fae-d2bd-5f29-87a3-30bc0035f4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8181eee-c03b-40db-aea1-24a4b34a4785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8181eee-c03b-40db-aea1-24a4b34a4785.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nScry 1.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "96dd18dd-d401-53eb-8c56-9de750ce403c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc0f1f-191a-4141-965f-8d159bf54732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc0f1f-191a-4141-965f-8d159bf54732.jpg?1",
             "name": "Hyena Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has first strike.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "4ffc473c-aaa2-5352-8050-1b833b142e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f20ca6-1a92-4be5-a84a-e7f8f0b7f648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f20ca6-1a92-4be5-a84a-e7f8f0b7f648.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, create a 2/2 white Knight creature token with vigilance.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "848c6273-60e1-5c8f-af31-8ca166021e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cca37a-7efd-4b01-bf96-15d0a032524d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cca37a-7efd-4b01-bf96-15d0a032524d.jpg?1",
             "name": "Last Breath",
             "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "408cfbb3-8d24-50a9-a369-ae442e6a2327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f827b-ebc3-45a4-8d12-c71a14478038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f827b-ebc3-45a4-8d12-c71a14478038.jpg?1",
             "name": "Leonin Arbiter",
             "text": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "colours": [
@@ -562,7 +562,7 @@
         },
         {
             "id": "73ae97f7-f6a2-587c-9851-3feaa23da4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c78b83-49d4-48c6-8aef-497541431c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c78b83-49d4-48c6-8aef-497541431c77.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "4bc2ee77-513b-54b8-9abc-a80b264ec274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3535f-bf13-442a-b632-590a69cf0ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3535f-bf13-442a-b632-590a69cf0ca4.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -638,7 +638,7 @@
         },
         {
             "id": "75ffdc56-66cf-5e20-b595-980b67ae88d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe9413b-5702-4998-aed7-d3a1102a8d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe9413b-5702-4998-aed7-d3a1102a8d7e.jpg?1",
             "name": "Militia Bugler",
             "text": "Vigilance\nWhen Militia Bugler enters the battlefield, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "12b2f9db-f0ca-59b2-bf98-86ea712572d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa0d1c6-9110-4956-97eb-e18c457bb130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa0d1c6-9110-4956-97eb-e18c457bb130.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "e0b86afa-e1d3-5f75-87bf-acadd64c31a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c8e27f-a7eb-4247-bd3d-2d0b02ead334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c8e27f-a7eb-4247-bd3d-2d0b02ead334.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "60efa78e-67d7-51e6-b779-a8f7747c366b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15afcabf-58a8-4650-a6cf-b7f2f01d0671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15afcabf-58a8-4650-a6cf-b7f2f01d0671.jpg?1",
             "name": "Myth Realized",
             "text": "Whenever you cast a noncreature spell, put a lore counter on Myth Realized.\n{2}{W}: Put a lore counter on Myth Realized.\n{W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\"",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "b53abfb4-efc9-5944-a4c8-dd55fe4f7981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90460227-6f34-4403-b2ef-d79f95f44790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90460227-6f34-4403-b2ef-d79f95f44790.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -807,7 +807,7 @@
         },
         {
             "id": "8ac21c9e-852a-5d0c-acea-1d61ac6522dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f4c1d-dbe7-4d9f-9974-b2d1a2989ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f4c1d-dbe7-4d9f-9974-b2d1a2989ddf.jpg?1",
             "name": "Relief Captain",
             "text": "When Relief Captain enters the battlefield, support 3. (Put a +1/+1 counter on each of up to three other target creatures.)",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "03cbecab-7fc0-5187-b351-e7d77d5e73cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f7f491-0733-42fa-ad8b-594252e74703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f7f491-0733-42fa-ad8b-594252e74703.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "a10359d9-8f11-52b2-80f2-20cfe661d138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b4dcd6-b1b6-4f1c-9264-e58bdc87399b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b4dcd6-b1b6-4f1c-9264-e58bdc87399b.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "18f8c5aa-4e9b-5cf3-8b36-0ef27a7efcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d5ed22-c0af-47dd-b6e8-49b51e354c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d5ed22-c0af-47dd-b6e8-49b51e354c7d.jpg?1",
             "name": "Scale Blessing",
             "text": "Bolster 1, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "44eaca88-b941-59d5-8690-b8f0b2f1b0e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e3cb28-d318-4d5d-b5bf-1ea7c6249a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e3cb28-d318-4d5d-b5bf-1ea7c6249a89.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "304fd640-ef4c-5beb-a245-6788cc19e274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d308c11-cc8d-4fa6-bbe1-357b164733ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d308c11-cc8d-4fa6-bbe1-357b164733ad.jpg?1",
             "name": "Sensor Splicer",
             "text": "When Sensor Splicer enters the battlefield, create a 3/3 colorless Phyrexian Golem artifact creature token.\nGolem creatures you control have vigilance.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "a9c4148b-46e6-59c9-b057-20a6e1ec1703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca74453c-278e-4a6c-aa37-e5654e16b08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca74453c-278e-4a6c-aa37-e5654e16b08b.jpg?1",
             "name": "Settle Beyond Reality",
             "text": "Choose one or both \u2014\n\u2022 Exile target creature you don't control.\n\u2022 Exile target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "8a0ce690-5a0d-5944-8388-ad7a95cb1d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a4bbe-2af0-4d4a-95d4-d52c5937c747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a4bbe-2af0-4d4a-95d4-d52c5937c747.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "90dea43d-b2bb-574d-8c93-6d14d35dbd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa1cb-1e35-44f2-a143-98c0f107f5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa1cb-1e35-44f2-a143-98c0f107f5ca.jpg?1",
             "name": "Teferi's Protection",
             "text": "Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)\nExile Teferi's Protection.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "1f645031-97ad-5817-ae0a-308830becc9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6504e634-d8cd-41bc-978d-769431bd896d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6504e634-d8cd-41bc-978d-769431bd896d.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "e1c7ee58-705e-5aa5-abab-30996d76ca83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09656d96-c366-49ec-b687-cad903de1385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09656d96-c366-49ec-b687-cad903de1385.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, put it into your hand, then shuffle. Activate only if an opponent controls more lands than you.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "d1f899e8-c964-5315-aba6-f53fdc3fa73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0234e0-6cdd-46b8-91b5-1b8ba7db3014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0234e0-6cdd-46b8-91b5-1b8ba7db3014.jpg?1",
             "name": "Wingsteed Rider",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "ccc80965-40fe-59e4-b560-03e2895c2e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044b2bfc-a5cc-4505-831d-5e1e3a6fdb3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044b2bfc-a5cc-4505-831d-5e1e3a6fdb3c.jpg?1",
             "name": "Advanced Stitchwing",
             "text": "Flying\n{2}{U}, Discard two cards: Return Advanced Stitchwing from your graveyard to the battlefield tapped.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "a19ee1ad-4a32-532a-8958-467b2ce8ca5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc9b5ee-4d6d-42ea-8b13-b8a7059781c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc9b5ee-4d6d-42ea-8b13-b8a7059781c9.jpg?1",
             "name": "Aethersnipe",
             "text": "When Aethersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "5d93f138-840a-5a80-a5f3-25041d0b4255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c468b523-84fc-4657-adef-acc1eec6ef2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c468b523-84fc-4657-adef-acc1eec6ef2e.jpg?1",
             "name": "As Foretold",
             "text": "At the beginning of your upkeep, put a time counter on As Foretold.\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast with mana value X or less, where X is the number of time counters on As Foretold.",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "082cc8cb-ded1-5397-b29b-6cc36064a3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078dfbe-ebdf-4ea8-aed7-cb2c986e7656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078dfbe-ebdf-4ea8-aed7-cb2c986e7656.jpg?1",
             "name": "Aven Initiate",
             "text": "Flying\nEmbalm {6}{U} ({6}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "d8b5a1f0-1d2c-5ab2-b265-85c2a20e7efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7497f2c-62a9-45c4-b2dc-c95818fa2fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7497f2c-62a9-45c4-b2dc-c95818fa2fa6.jpg?1",
             "name": "Body Double",
             "text": "You may have Body Double enter the battlefield as a copy of any creature card in a graveyard.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "7800d47e-4539-53a3-9e19-56d698b56e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22075f41-3aeb-406d-99b6-88ddae992d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22075f41-3aeb-406d-99b6-88ddae992d0b.jpg?1",
             "name": "Breakthrough",
             "text": "Draw four cards, then choose X cards in your hand and discard the rest.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "277c8dc8-72eb-56de-a949-299496d44bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cd21f5-94fd-4609-9e6a-d052aa81fe57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cd21f5-94fd-4609-9e6a-d052aa81fe57.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "1c66d6f7-adef-57d5-a4e2-90082a650327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bd60fc-2777-44bc-b314-a792e8e48360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bd60fc-2777-44bc-b314-a792e8e48360.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "240c726c-980a-5500-b9dc-f35686b07efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90296536-a56d-482e-8548-132a99894bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90296536-a56d-482e-8548-132a99894bde.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1538,7 +1538,7 @@
         },
         {
             "id": "79aebf18-2171-57b1-a4af-237b53d5f01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2784c1e-1066-411f-96ea-287d60e0c115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2784c1e-1066-411f-96ea-287d60e0c115.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Mill a card: Add {C}.",
             "colours": [
@@ -1573,7 +1573,7 @@
         },
         {
             "id": "5b137eaa-691a-5b01-89de-e96e8efca820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a885848-005f-4387-8982-40052b924076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a885848-005f-4387-8982-40052b924076.jpg?1",
             "name": "Disciple of the Ring",
             "text": "{1}, Exile an instant or sorcery card from your graveyard: Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Disciple of the Ring gets +1/+1 until end of turn.\n\u2022 Tap target creature.\n\u2022 Untap target creature.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "03c0bd60-d242-5159-a266-bf24f7b861bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5e940b-e247-4ee3-939b-679e4f8ea771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5e940b-e247-4ee3-939b-679e4f8ea771.jpg?1",
             "name": "Domestication",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your end step, if enchanted creature's power is 4 or greater, sacrifice Domestication.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "51191ce8-62b2-5816-a2ca-02e43f4155c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ab47ce-a6dd-4839-ab41-053c5c5de768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ab47ce-a6dd-4839-ab41-053c5c5de768.jpg?1",
             "name": "Eel Umbra",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "aacab549-f97f-5a6c-be60-566b3982f131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f39b4-f428-483f-999a-6ebee7659c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f39b4-f428-483f-999a-6ebee7659c5a.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1711,7 +1711,7 @@
         },
         {
             "id": "03e8a3a3-b9c7-5aed-ab0d-7ea7fc9c8ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1825a719-1b2a-4af9-9cd2-7cb497cd0317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1825a719-1b2a-4af9-9cd2-7cb497cd0317.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "a5b7204f-89b6-5770-a907-b43b104b276b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc950b6c-0346-4939-b36b-9f10a75f7a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc950b6c-0346-4939-b36b-9f10a75f7a32.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle.",
             "colours": [
@@ -1781,7 +1781,7 @@
         },
         {
             "id": "402dfc22-1b73-5806-94c7-6609c9a788c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a264f107-f9dd-4599-a134-62db6a242a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a264f107-f9dd-4599-a134-62db6a242a8b.jpg?1",
             "name": "Ingenious Skaab",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{U}: Ingenious Skaab gets +1/-1 until end of turn.",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "86b1ee64-b517-5661-8504-b5feea1a4104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fd9091-2d22-411f-955a-24c32293cdca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fd9091-2d22-411f-955a-24c32293cdca.jpg?1",
             "name": "Jeskai Elder",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jeskai Elder deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "0d475c1e-1f6b-5fac-8a1c-67f96a1aa4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938ef232-1bf5-4290-abd9-3da653cf2e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938ef232-1bf5-4290-abd9-3da653cf2e85.jpg?1",
             "name": "Kasmina's Transmutation",
             "text": "Enchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "7ffaeeaf-f4cb-52fa-8412-adef854a20c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cdb22d-90e6-49c4-9ad7-3249d9196ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cdb22d-90e6-49c4-9ad7-3249d9196ca9.jpg?1",
             "name": "Kederekt Leviathan",
             "text": "When Kederekt Leviathan enters the battlefield, return all other nonland permanents to their owners' hands.\nUnearth {6}{U} ({6}{U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "f3d710c2-7652-5e12-904e-62294638bc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e74b52-1137-4da5-bf2d-294daa8e65f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e74b52-1137-4da5-bf2d-294daa8e65f2.jpg?1",
             "name": "Makeshift Mauler",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.",
             "colours": [
@@ -1956,7 +1956,7 @@
         },
         {
             "id": "d8b9d0ec-bb20-5457-95c7-c00f2519434e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c429c40-2389-41e5-8681-4bb274e25eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c429c40-2389-41e5-8681-4bb274e25eba.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "d26a9f27-ab78-52a2-82cc-06ef6051903f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179236d9-6fe2-4db6-bdfb-f851e8d531a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179236d9-6fe2-4db6-bdfb-f851e8d531a2.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "ba7e5fd2-3fc2-53ec-8bd9-bb8d91f9c656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a2dd0d-8034-47f7-801d-c893f32f0708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a2dd0d-8034-47f7-801d-c893f32f0708.jpg?1",
             "name": "Mistfire Adept",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, target creature gains flying until end of turn.",
             "colours": [
@@ -2058,7 +2058,7 @@
         },
         {
             "id": "09744103-92f7-59c6-af8d-82bb1a3b21af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fed1e5-fcbd-4597-91b5-ba809571573b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fed1e5-fcbd-4597-91b5-ba809571573b.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "6846624b-41a7-5c7e-a6db-27a21590fab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a17b5-422c-4add-adbf-63e4492121e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a17b5-422c-4add-adbf-63e4492121e8.jpg?1",
             "name": "Nephalia Smuggler",
             "text": "{3}{U}, {T}: Exile another target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "121383d1-774e-55f0-9e7b-ee7c212f45b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5013fde-4714-4bea-b368-5b14684a05fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5013fde-4714-4bea-b368-5b14684a05fc.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "2f82a48a-ce96-5c2a-83e3-66de8fdb7556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b8a9db-d126-4038-abb1-74dcc5b36136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b8a9db-d126-4038-abb1-74dcc5b36136.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "3ee7784a-5e81-5ddd-9e18-573d6b9b1df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca9530f-ecec-4f12-bc5a-9e211b97be70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca9530f-ecec-4f12-bc5a-9e211b97be70.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "562d303a-6406-51ff-b9f8-6014306013ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afee6b3-55a4-44e5-b08c-85e0c813cd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afee6b3-55a4-44e5-b08c-85e0c813cd09.jpg?1",
             "name": "Thought Scour",
             "text": "Target player mills two cards.\nDraw a card.",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "752586b8-e40d-59df-914a-848fe4bb379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e19416-aa6c-46f1-b247-a94da5d1a13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e19416-aa6c-46f1-b247-a94da5d1a13a.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -2309,7 +2309,7 @@
         },
         {
             "id": "8b44ffe2-ec1a-5ff1-a6a7-e06e775d5463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc468f97-08f7-4103-898f-b14fa61b99bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc468f97-08f7-4103-898f-b14fa61b99bc.jpg?1",
             "name": "Wash Out",
             "text": "Return all permanents of the color of your choice to their owners' hands.",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "8773f2b1-421c-5247-8bf7-9b508227cc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b4ce37-f102-4f2b-9651-9d0a9d231d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b4ce37-f102-4f2b-9651-9d0a9d231d6d.jpg?1",
             "name": "Balustrade Spy",
             "text": "Flying\nWhen Balustrade Spy enters the battlefield, target player reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "a85eb72e-2a35-5c0e-88c9-2c7ebd285291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9640cbf-b016-410e-9eff-e8924883517b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9640cbf-b016-410e-9eff-e8924883517b.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
             "colours": [
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "0bd8fca0-eae7-538f-999e-97b3a79d77d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693dd112-d04a-4404-8fce-74f7e5497312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693dd112-d04a-4404-8fce-74f7e5497312.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "b60b7042-8547-5444-b445-f656cbc43dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f198b57-8bfe-4d13-9a16-10990707b455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f198b57-8bfe-4d13-9a16-10990707b455.jpg?1",
             "name": "Bloodflow Connoisseur",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "b1f7be4f-4c74-5ea4-a601-d6b95be0d6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06b2ab-2161-41fa-abe6-c4a4d848efd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06b2ab-2161-41fa-abe6-c4a4d848efd3.jpg?1",
             "name": "Carrier Thrall",
             "text": "When Carrier Thrall dies, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "d1daaab5-3a27-5b2d-82dc-a0e24a82cc15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c0aac5-b9f1-4446-bfea-3e1dd1cf1f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c0aac5-b9f1-4446-bfea-3e1dd1cf1f2f.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "809b83dd-5d48-55f4-be35-15e4c44364ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d96bc-6c19-4dec-9e9d-c6ea50a30cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d96bc-6c19-4dec-9e9d-c6ea50a30cbc.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "65d36a91-2510-5fe5-bc88-4945c32c98ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738c356-734a-4930-acd3-31dead241bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738c356-734a-4930-acd3-31dead241bea.jpg?1",
             "name": "Eyeblight's Ending",
             "text": "Destroy target non-Elf creature.",
             "colours": [
@@ -2619,7 +2619,7 @@
         },
         {
             "id": "f3693e7b-b851-5fb4-b354-b4ec49dbd404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e966c-80ce-4942-a993-21b960aa28ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e966c-80ce-4942-a993-21b960aa28ab.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "5ad31db2-d416-5581-852b-ef7d37807301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e62471-07bf-48af-8868-b8a72032a50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e62471-07bf-48af-8868-b8a72032a50b.jpg?1",
             "name": "Graveblade Marauder",
             "text": "Deathtouch\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "ddf5cd53-89a6-517e-9d70-3de592d82cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951ff2ed-9af0-4551-929a-ba6679fc2e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951ff2ed-9af0-4551-929a-ba6679fc2e15.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "62abe9c7-9a6f-53a9-9d91-2767279cb5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71a6bd3-7478-4c3a-8ae0-98352ce28492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71a6bd3-7478-4c3a-8ae0-98352ce28492.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "92af8dce-f610-5093-9956-c20c82b23052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f38740-20fd-4097-90f8-f0c2c2ff7281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f38740-20fd-4097-90f8-f0c2c2ff7281.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "7a05291f-d4ec-597f-8685-db41838d38c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ae5085-0d0d-4d7d-80a3-614315a07de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ae5085-0d0d-4d7d-80a3-614315a07de5.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "f1b64874-2cfa-5b4e-ad9a-36a726648ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da81fa-0bd1-4415-b112-3fa4438efe4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da81fa-0bd1-4415-b112-3fa4438efe4b.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "5895b511-6ee6-5a66-824c-deb05faccb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc3557d-49c6-49cd-a540-1b24897f4e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc3557d-49c6-49cd-a540-1b24897f4e86.jpg?1",
             "name": "Necrotic Ooze",
             "text": "As long as Necrotic Ooze is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
             "colours": [
@@ -2901,7 +2901,7 @@
         },
         {
             "id": "dcbf81c3-6368-53d7-a9bb-31f1c53de9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c727f49-833a-4b79-9946-bfbc6b06999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c727f49-833a-4b79-9946-bfbc6b06999c.jpg?1",
             "name": "Ob Nixilis, Unshackled",
             "text": "Flying, trample\nWhenever an opponent searches their library, that player sacrifices a creature and loses 10 life.\nWhenever another creature dies, put a +1/+1 counter on Ob Nixilis, Unshackled.",
             "colours": [
@@ -2939,7 +2939,7 @@
         },
         {
             "id": "f2422c6c-40c8-50bb-85b8-8d26ac634f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd79780e-ddad-4ef4-a94d-ab191d118882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd79780e-ddad-4ef4-a94d-ab191d118882.jpg?1",
             "name": "Oona's Prowler",
             "text": "Flying\nDiscard a card: Oona's Prowler gets -2/-0 until end of turn. Any player may activate this ability.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "b4fbbf1f-7998-59c9-88d5-43862c145441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416845ec-7efd-464a-a0cb-7e9170ccdd38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416845ec-7efd-464a-a0cb-7e9170ccdd38.jpg?1",
             "name": "Scion of Darkness",
             "text": "Trample\nWhenever Scion of Darkness deals combat damage to a player, you may put target creature card from that player's graveyard onto the battlefield under your control.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "4c374ed7-073b-5ae1-8dd5-280656a802af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30573211-ba4d-41c7-a3cd-283aaf04dffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30573211-ba4d-41c7-a3cd-283aaf04dffb.jpg?1",
             "name": "Seekers' Squire",
             "text": "When Seekers' Squire enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "5da2f2db-9f4d-50b6-867c-c9049df4cf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7496304-2ab2-497b-bb3a-b3c91ee1ff60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7496304-2ab2-497b-bb3a-b3c91ee1ff60.jpg?1",
             "name": "Severed Strands",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nYou gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.",
             "colours": [
@@ -3077,7 +3077,7 @@
         },
         {
             "id": "9dbeb506-143e-590a-8c6e-9ed6274f0c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7ba1de-48f9-423b-867a-22bd3f6c06c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7ba1de-48f9-423b-867a-22bd3f6c06c2.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "A deck can have any number of cards named Shadowborn Apostle.\n{B}, Sacrifice six creatures named Shadowborn Apostle: Search your library for a Demon creature card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "fc383342-50dd-523d-8ccd-f144668e9603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8a04f1-9a7b-41d6-8447-4baa639fe183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8a04f1-9a7b-41d6-8447-4baa639fe183.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "258573e8-0557-51d5-8ec5-e8d763f7d346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca107d96-0351-49a9-9f65-b055c1514d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca107d96-0351-49a9-9f65-b055c1514d7b.jpg?1",
             "name": "Skinrender",
             "text": "When Skinrender enters the battlefield, put three -1/-1 counters on target creature.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "8f7eb70f-5869-5105-8bb9-f63d17bbeefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95efd3d-ee88-4908-908a-830595f03c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95efd3d-ee88-4908-908a-830595f03c5d.jpg?1",
             "name": "Strands of Undeath",
             "text": "Enchant creature\nWhen Strands of Undeath enters the battlefield, target player discards two cards.\n{B}: Regenerate enchanted creature.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "b99b0ae4-3eb9-592e-a878-81a2a41f30c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a0278b-3198-4c8d-b20c-f42e8b1569f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a0278b-3198-4c8d-b20c-f42e8b1569f4.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "5a566f46-524b-5bf7-a6f9-a13b9b949cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15d76ac-1c23-4503-8225-375ac2bf2fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15d76ac-1c23-4503-8225-375ac2bf2fb6.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "3223a730-6a67-5368-90c1-764428cbf8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7023aa24-ef49-4973-8978-7d0d3af719d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7023aa24-ef49-4973-8978-7d0d3af719d3.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "eec5f5e7-f2c9-5648-b947-a558f12563d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f73271-b70f-40ae-be64-f8de7805923a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f73271-b70f-40ae-be64-f8de7805923a.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "84c900ca-58cf-515f-a634-72ef6d3eae89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f0f05-fe4e-4827-bedf-a54352f95967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f0f05-fe4e-4827-bedf-a54352f95967.jpg?1",
             "name": "Vampire Sovereign",
             "text": "Flying\nWhen Vampire Sovereign enters the battlefield, target opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "5f245a93-c908-5d26-9cd3-7ddb7cf28558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9947ed-de58-4172-91df-82a93584e6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9947ed-de58-4172-91df-82a93584e6fe.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "85b3ac40-66de-5d30-bf39-6b2838d35e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4f8f35-5860-4416-b7bb-9ba56540a28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4f8f35-5860-4416-b7bb-9ba56540a28c.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "97a99557-e25c-50df-bf0a-a8e0d68c5df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd94f624-9b35-4468-829f-106366f61c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd94f624-9b35-4468-829f-106366f61c1a.jpg?1",
             "name": "Abbot of Keral Keep",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Abbot of Keral Keep enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "7599dbf5-3ea2-5b62-9984-d884f89133d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5067fda-fbee-4e44-aba7-8ab2c0e396f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5067fda-fbee-4e44-aba7-8ab2c0e396f7.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "9194275c-7e27-5c6c-996b-46e3d590e0d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92088c2-74c2-4e63-8a54-83d39f9d6ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92088c2-74c2-4e63-8a54-83d39f9d6ad6.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "81346358-4be1-5df4-ae9f-299f7945021e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb3f1cb-7180-4c5f-8e04-58bb9bf45733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb3f1cb-7180-4c5f-8e04-58bb9bf45733.jpg?1",
             "name": "Backdraft Hellkite",
             "text": "Flying\nWhenever Backdraft Hellkite attacks, each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
             "colours": [
@@ -3605,7 +3605,7 @@
         },
         {
             "id": "9b8cdf43-bfcb-5b40-a742-d514d308576f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9333564-2792-470e-be73-61f2445e018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9333564-2792-470e-be73-61f2445e018f.jpg?1",
             "name": "Bedlam Reveler",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "e1e14986-bc75-5125-a086-03859d69b16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c20d8d5-a54a-4d81-9211-e82a10abdde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c20d8d5-a54a-4d81-9211-e82a10abdde2.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -3677,7 +3677,7 @@
         },
         {
             "id": "e0e02b7b-d92f-58ca-a7a8-ce3113b6e2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35664f-b99d-46b6-988e-8f2814b0a854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35664f-b99d-46b6-988e-8f2814b0a854.jpg?1",
             "name": "Dark-Dweller Oracle",
             "text": "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -3712,7 +3712,7 @@
         },
         {
             "id": "1104bdaa-8841-5b80-8300-0e8d0fcd33b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2e3efb-75cb-430f-b9f4-cb58f3aeb91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2e3efb-75cb-430f-b9f4-cb58f3aeb91b.jpg?1",
             "name": "Dockside Extortionist",
             "text": "When Dockside Extortionist enters the battlefield, create X Treasure tokens, where X is the number of artifacts and enchantments your opponents control. (Treasure tokens are artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "fe296d6e-1e5c-50b5-8cc6-80f1bbc3e752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11f5d27-37f3-430a-833c-84e249b5e744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11f5d27-37f3-430a-833c-84e249b5e744.jpg?1",
             "name": "Dreamshaper Shaman",
             "text": "At the beginning of your end step, you may pay {2}{R} and sacrifice a nonland permanent. If you do, reveal cards from the top of your library until you reveal a nonland permanent card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "616f6b4a-666c-5cc7-a4ff-a166af81e0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed3229f-40ab-420d-a41a-57f1ff8ab7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed3229f-40ab-420d-a41a-57f1ff8ab7ad.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3818,7 +3818,7 @@
         },
         {
             "id": "77777a46-0684-5acb-ba26-e898569ec29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf20cfd7-81f4-423c-a662-c4b6676edfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf20cfd7-81f4-423c-a662-c4b6676edfdd.jpg?1",
             "name": "Goblin Banneret",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\n{1}{R}: Goblin Banneret gets +2/+0 until end of turn.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "60eeee2d-49f9-5de4-9180-56c086ab7bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf6bf0-4821-41eb-bacc-32e9a2d47845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf6bf0-4821-41eb-bacc-32e9a2d47845.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate only if Greater Gargadon is suspended.",
             "colours": [
@@ -3889,7 +3889,7 @@
         },
         {
             "id": "c18e049c-e1ff-5519-976b-20aca86db00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abd74bb-01b8-4382-90d4-0ffc43e5295d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abd74bb-01b8-4382-90d4-0ffc43e5295d.jpg?1",
             "name": "Hero of the Games",
             "text": "Whenever you cast a spell that targets Hero of the Games, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -3924,7 +3924,7 @@
         },
         {
             "id": "8b04bee0-d2c7-5ccb-884f-0fb55ba2c123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2268cf4b-de6d-4447-86e8-f8298728a3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2268cf4b-de6d-4447-86e8-f8298728a3bd.jpg?1",
             "name": "Hissing Iguanar",
             "text": "Whenever another creature dies, you may have Hissing Iguanar deal 1 damage to target player or planeswalker.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "6382f369-33d0-52b0-8d4d-e61f20b1f88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da0851-c349-4b2c-bedf-21e3c2d35922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da0851-c349-4b2c-bedf-21e3c2d35922.jpg?1",
             "name": "Kruin Striker",
             "text": "Whenever another creature enters the battlefield under your control, Kruin Striker gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -3993,7 +3993,7 @@
         },
         {
             "id": "1cb91328-2cbc-52cd-9f99-472efdff0c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee955ad-6eed-4d5a-bcda-94339f155555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee955ad-6eed-4d5a-bcda-94339f155555.jpg?1",
             "name": "Labyrinth Champion",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Labyrinth Champion, Labyrinth Champion deals 2 damage to any target.",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "7314bb47-d3b6-5e5b-b57b-d1281138782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802c39df-4b92-4acc-92f9-bebd3d405471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802c39df-4b92-4acc-92f9-bebd3d405471.jpg?1",
             "name": "Lava Coil",
             "text": "Lava Coil deals 4 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "0aa4288b-47ee-5d3b-8b81-5479779a8b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ba16f-c8fb-42fe-aabf-87089cb214a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ba16f-c8fb-42fe-aabf-87089cb214a7.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "009c492a-c0e1-5dba-9caa-68e52d73e556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b9b6-7727-45e9-931f-28f7facf8692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b9b6-7727-45e9-931f-28f7facf8692.jpg?1",
             "name": "Living Lightning",
             "text": "When Living Lightning dies, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "dc75b85f-50d6-57cf-a214-9ac437f9969d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b9d59d-bac9-4092-901e-2b861c186868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b9d59d-bac9-4092-901e-2b861c186868.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "e66ecb7f-0f26-56d2-85b0-80726bf8e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097e866-9d24-43b6-bafb-b6da05b47a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097e866-9d24-43b6-bafb-b6da05b47a30.jpg?1",
             "name": "Pirate's Pillage",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "ca0ce0af-be75-5d96-bd41-a2dd408c7b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd318d3-3d84-4f3f-a48f-6a242474a4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd318d3-3d84-4f3f-a48f-6a242474a4a2.jpg?1",
             "name": "Purphoros's Emissary",
             "text": "Bestow {6}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nMenace (This creature can't be blocked except by two or more creatures.)\nEnchanted creature gets +3/+3 and has menace.",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "06cca63d-8700-554f-8e23-4ed96002dc10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccd0ada-92b2-48f3-b5ae-96346fc138b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccd0ada-92b2-48f3-b5ae-96346fc138b6.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to any target.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "0aa6573b-ce1b-5f4e-a74e-31f3b2ad9952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427f615-8430-426e-a669-f9fe12033ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427f615-8430-426e-a669-f9fe12033ac4.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "11423f8a-5277-5205-9243-8435e4cd6029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10b4edf-5f0e-4edd-88f9-2e3e7d9cad0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10b4edf-5f0e-4edd-88f9-2e3e7d9cad0a.jpg?1",
             "name": "Sparkmage's Gambit",
             "text": "Sparkmage's Gambit deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "6f8522de-9967-523d-9568-d0dab4547541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56976d52-053d-49e9-94c0-f21dc13029ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56976d52-053d-49e9-94c0-f21dc13029ac.jpg?1",
             "name": "Staggershock",
             "text": "Staggershock deals 2 damage to any target.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4367,7 +4367,7 @@
         },
         {
             "id": "04247e47-a8e3-5b62-9db1-ac8e7a6422dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189836c8-3ffb-4734-8d3e-6a21a28335be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189836c8-3ffb-4734-8d3e-6a21a28335be.jpg?1",
             "name": "Storm Fleet Pyromancer",
             "text": "Raid \u2014 When Storm Fleet Pyromancer enters the battlefield, if you attacked this turn, Storm Fleet Pyromancer deals 2 damage to any target.",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "f60afd3f-8430-5cab-a14c-0d6d9938b38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c10004-eaef-4b19-828f-a0f9bde82984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c10004-eaef-4b19-828f-a0f9bde82984.jpg?1",
             "name": "Surreal Memoir",
             "text": "Return an instant card at random from your graveyard to your hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "d774774d-3a8d-5e73-998b-3a45f826e35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1bfbe-7cfd-4b11-be95-0df327a83c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1bfbe-7cfd-4b11-be95-0df327a83c12.jpg?1",
             "name": "Titan's Strength",
             "text": "Target creature gets +3/+1 until end of turn. Scry 1.",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "f53a1067-05da-5fd2-92f4-efe86b05b3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa7c17-55e7-44e4-a965-182f63f32c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa7c17-55e7-44e4-a965-182f63f32c72.jpg?1",
             "name": "Twinflame",
             "text": "Strive \u2014 This spell costs {2}{R} more to cast for each target beyond the first.\nChoose any number of target creatures you control. For each of them, create a token that's a copy of that creature, except it has haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "d3634815-6ba9-5e9b-8c22-65cdc7ef2c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10759-e862-4b69-8b58-474df2cdae29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10759-e862-4b69-8b58-474df2cdae29.jpg?1",
             "name": "Warrior's Oath",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -4535,7 +4535,7 @@
         },
         {
             "id": "9cfe5dd7-0f94-557d-a175-1f1b9e723cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219577e6-758a-4135-9a8d-f95df964137a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219577e6-758a-4135-9a8d-f95df964137a.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "88a0e731-383e-5584-ae5b-eb678fbe3221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afa0ee5-a0b8-472e-9991-09402ddb5de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afa0ee5-a0b8-472e-9991-09402ddb5de3.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "This spell can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "9fd1b083-24e8-5a8c-9f34-129a2880f115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df71162-7e8f-47c5-aff4-59d82d8c674d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df71162-7e8f-47c5-aff4-59d82d8c674d.jpg?1",
             "name": "Ambuscade",
             "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "b069cf46-c38a-5976-87e8-bb3b3054d1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6108741c-30de-4390-8482-3f293bdce4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6108741c-30de-4390-8482-3f293bdce4bd.jpg?1",
             "name": "Annoyed Altisaur",
             "text": "Reach, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -4676,7 +4676,7 @@
         },
         {
             "id": "0c74ec73-d9e5-5237-817a-61bfa0d107d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782fbd4-36fe-4da7-a73f-20d533de8960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782fbd4-36fe-4da7-a73f-20d533de8960.jpg?1",
             "name": "Arachnus Spinner",
             "text": "Reach\nTap an untapped Spider you control: Search your graveyard and/or library for a card named Arachnus Web and put it onto the battlefield attached to target creature. If you search your library this way, shuffle.",
             "colours": [
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "c56a87e7-ece2-5828-b1ee-077262c7623a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec348d8d-6b49-4a40-a668-fc6dd2af4f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec348d8d-6b49-4a40-a668-fc6dd2af4f0d.jpg?1",
             "name": "Arachnus Web",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the end step, if enchanted creature's power is 4 or greater, destroy Arachnus Web.",
             "colours": [
@@ -4744,7 +4744,7 @@
         },
         {
             "id": "cb3ccd46-b5a2-5bb3-9f00-723bb7d7c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8e93a0-33fd-4a1b-82b9-4b4a99fbb75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8e93a0-33fd-4a1b-82b9-4b4a99fbb75b.jpg?1",
             "name": "Biogenic Upgrade",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.",
             "colours": [
@@ -4776,7 +4776,7 @@
         },
         {
             "id": "2edc1e09-a9d3-5e9f-a792-c33874cd0dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06fc1f-d8f6-43b0-a795-d759fcdf8272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06fc1f-d8f6-43b0-a795-d759fcdf8272.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "686f99a9-e30d-50a7-8631-8df3a2943f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a005933-e206-4b14-9a0f-755fae6c5a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a005933-e206-4b14-9a0f-755fae6c5a2a.jpg?1",
             "name": "Brindle Shoat",
             "text": "When Brindle Shoat dies, create a 3/3 green Boar creature token.",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "09d273e2-eac8-5fd6-9a3f-e7a10ff3e1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d190aac9-9ac8-4b54-9f51-d7d1561dc743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d190aac9-9ac8-4b54-9f51-d7d1561dc743.jpg?1",
             "name": "Centaur Battlemaster",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Centaur Battlemaster, put three +1/+1 counters on Centaur Battlemaster.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "e7791969-b9ec-55a5-8405-354f6d5a0d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a26f51-5bff-4f06-abaa-6fbb56a8b5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a26f51-5bff-4f06-abaa-6fbb56a8b5b6.jpg?1",
             "name": "Concordant Crossroads",
             "text": "All creatures have haste.",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "0b443bdf-c4ef-566d-a41a-b4c29a551788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02191caa-60f9-4604-8c90-ecfc6aee8c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02191caa-60f9-4604-8c90-ecfc6aee8c09.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach, deathtouch",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "bddc210c-24cc-503e-9e66-15b6ed3fe2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab94f16-778d-4437-a1b9-2f67cd214cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab94f16-778d-4437-a1b9-2f67cd214cc0.jpg?1",
             "name": "Devoted Druid",
             "text": "{T}: Add {G}.\nPut a -1/-1 counter on Devoted Druid: Untap Devoted Druid.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "6882945a-2bca-5f00-b11a-25b2feeeea8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10403c-b15b-4884-9984-25b3ac976305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10403c-b15b-4884-9984-25b3ac976305.jpg?1",
             "name": "Elvish Rejuvenator",
             "text": "When Elvish Rejuvenator enters the battlefield, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "f785d5bd-82b8-5ea1-a5ca-f4ec3bd3e2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d7fa2c-4dbc-4e9e-9448-5bf8bbee95d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d7fa2c-4dbc-4e9e-9448-5bf8bbee95d6.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "1c746510-9f4d-519c-b7b1-78bbb968687d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589d8494-58c0-4584-a878-37d498621992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589d8494-58c0-4584-a878-37d498621992.jpg?1",
             "name": "Experiment One",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nRemove two +1/+1 counters from Experiment One: Regenerate Experiment One.",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "615356e0-c8c5-5b4c-a581-fa1f49748d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb912458-e016-4ea2-a2ea-40ac1a57f8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb912458-e016-4ea2-a2ea-40ac1a57f8fb.jpg?1",
             "name": "Food Chain",
             "text": "Exile a creature you control: Add X mana of any one color, where X is 1 plus the exiled creature's mana value. Spend this mana only to cast creature spells.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "c1a788dd-63d5-59fc-8469-97cf5b2b2912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3009640-23b1-49ce-a51b-982a48602c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3009640-23b1-49ce-a51b-982a48602c1d.jpg?1",
             "name": "Gnarlback Rhino",
             "text": "Trample\nWhenever you cast a spell that targets Gnarlback Rhino, draw a card.",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "e8a4663f-be8e-5bde-84a3-e282cb5367ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c874c79e-18e5-4c33-8580-1269e6b0fc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c874c79e-18e5-4c33-8580-1269e6b0fc55.jpg?1",
             "name": "Grapple with the Past",
             "text": "Mill three cards, then you may return a creature or land card from your graveyard to your hand.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "60bd2419-35d8-505a-b8ba-d8a9f5c76d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70291c7b-a86f-4466-8502-c28765a89b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70291c7b-a86f-4466-8502-c28765a89b2a.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with mana value X or less, put it onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "57654daf-636d-52e2-ba4e-c76adbdcc73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf31b01-0836-4366-948d-879999832abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf31b01-0836-4366-948d-879999832abe.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "70ead3ec-c748-5a23-b4b4-287cdcd52eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa77ae-f685-48ee-85dc-ba6084cd30ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa77ae-f685-48ee-85dc-ba6084cd30ba.jpg?1",
             "name": "Impervious Greatwurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
             "colours": [
@@ -5301,7 +5301,7 @@
         },
         {
             "id": "bad80f8c-587c-5808-9691-65fad3a9e1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c7c36-2b15-463b-a023-683972303a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c7c36-2b15-463b-a023-683972303a0a.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "abcf2177-565b-5158-8f1b-44dab5e3fa08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373a4e3e-6244-43e8-80ac-f5508db9ce57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373a4e3e-6244-43e8-80ac-f5508db9ce57.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -5371,7 +5371,7 @@
         },
         {
             "id": "5f98cebb-739a-5499-8166-35c201cc6f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89572b1f-f65a-4bd4-b52a-4e84eb373e90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89572b1f-f65a-4bd4-b52a-4e84eb373e90.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "2474ba0f-ec16-5eff-b91a-74802ce45f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6b411-4a31-4bfc-8dd6-e19f553bb29b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6b411-4a31-4bfc-8dd6-e19f553bb29b.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "9c595888-9b05-59e6-94e6-4a4cbcba5057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d320f16c-798a-4dbe-875e-6abe7a9b9e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d320f16c-798a-4dbe-875e-6abe7a9b9e6b.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "4b7d7d05-8008-5e47-9efa-d99ca8e8ff4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e20241b-515f-420f-9012-2f693f333187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e20241b-515f-420f-9012-2f693f333187.jpg?1",
             "name": "Spider Spawning",
             "text": "Create a 1/2 green Spider creature token with reach for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "cf483dd0-d391-55e4-a7c3-9fd418a7ef61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ac9fc-b8b3-43f1-8579-62171ca976cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ac9fc-b8b3-43f1-8579-62171ca976cf.jpg?1",
             "name": "Splinterfright",
             "text": "Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, mill two cards.",
             "colours": [
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "800500ea-5caf-5819-9c08-46717f0a1e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7383f71d-3f51-4632-9ea0-27d47fa2fa50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7383f71d-3f51-4632-9ea0-27d47fa2fa50.jpg?1",
             "name": "Summer Bloom",
             "text": "You may play up to three additional lands this turn.",
             "colours": [
@@ -5579,7 +5579,7 @@
         },
         {
             "id": "cb60ef12-1e96-5db8-95eb-b56f0bdd9cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c8bdb1-fa35-462e-ac3f-6953fe7f3476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c8bdb1-fa35-462e-ac3f-6953fe7f3476.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "2ccfe811-1018-5d19-a8de-a164bb12f888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66284816-1fd8-4489-b006-a9e605d8d144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66284816-1fd8-4489-b006-a9e605d8d144.jpg?1",
             "name": "Travel Preparations",
             "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "bb538a48-6c0f-5ec5-8547-158703bb3df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4eab4-a2e6-4cb0-b32a-700aac59fc40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4eab4-a2e6-4cb0-b32a-700aac59fc40.jpg?1",
             "name": "Tuskguard Captain",
             "text": "Outlast {G} ({G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5679,7 +5679,7 @@
         },
         {
             "id": "a5436142-3e72-5f61-942d-dd2171dece58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576807eb-47fa-4f08-8982-1c0b3526fdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576807eb-47fa-4f08-8982-1c0b3526fdd2.jpg?1",
             "name": "Webweaver Changeling",
             "text": "Changeling (This card is every creature type.)\nReach\nWhen Webweaver Changeling enters the battlefield, if there are three or more creature cards in your graveyard, you gain 5 life.",
             "colours": [
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "766398ed-e584-502c-92ea-7c7acef54899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b722d9-be9d-463c-929e-78f7156af9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b722d9-be9d-463c-929e-78f7156af9c6.jpg?1",
             "name": "Abzan Ascendancy",
             "text": "When Abzan Ascendancy enters the battlefield, put a +1/+1 counter on each creature you control.\nWhenever a nontoken creature you control dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "db8ad183-ae1e-5b9e-9fe5-10ad4afa6d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1757a916-60d3-4f6b-8759-32a1645dadd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1757a916-60d3-4f6b-8759-32a1645dadd2.jpg?1",
             "name": "Abzan Charm",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power 3 or greater.\n\u2022 You draw two cards and you lose 2 life.\n\u2022 Distribute two +1/+1 counters among one or two target creatures.",
             "colours": [
@@ -5787,7 +5787,7 @@
         },
         {
             "id": "edf002e8-0ba2-54d9-9e3f-f71b82e43126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df59b2e4-21a6-4cf1-80bd-f92f8ea99f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df59b2e4-21a6-4cf1-80bd-f92f8ea99f2c.jpg?1",
             "name": "Aethermage's Touch",
             "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -5821,7 +5821,7 @@
         },
         {
             "id": "da4b11e5-7ab9-573b-bd32-c564fbc973bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890a23e-1da0-432b-8dc8-85b92dee9ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890a23e-1da0-432b-8dc8-85b92dee9ba1.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5855,7 +5855,7 @@
         },
         {
             "id": "1adf84c0-bba8-5f75-8452-aa024ab8d741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc010302-e715-4946-89eb-a214e0b836ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc010302-e715-4946-89eb-a214e0b836ba.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "+1: Draw a card, then put a card from your hand on top of your library.\n\u22121: Exile another target permanent you own, then return it to the battlefield under your control.\n\u22126: Choose left or right. Each player gains control of all nonland permanents other than Aminatou, the Fateshifter controlled by the next player in the chosen direction.\nAminatou, the Fateshifter can be your commander.",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "ea8e188e-1002-54b4-a361-89a68dc36670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16de91dc-5d82-43ec-84ad-67bae644795a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16de91dc-5d82-43ec-84ad-67bae644795a.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "9592bbd9-2a3b-59ce-abdd-2affa993270a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da57d0-1ae3-4f05-a52d-eb76ad56cae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da57d0-1ae3-4f05-a52d-eb76ad56cae7.jpg?1",
             "name": "Animar, Soul of Elements",
             "text": "Protection from white and from black\nWhenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.\nCreature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "3f4a027a-549f-5320-8cf9-a68baea07056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb83da3-5a8e-4349-bbcc-dcbd3b70264b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb83da3-5a8e-4349-bbcc-dcbd3b70264b.jpg?1",
             "name": "Arjun, the Shifting Flame",
             "text": "Flying\nWhenever you cast a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
             "colours": [
@@ -6016,7 +6016,7 @@
         },
         {
             "id": "440f367d-36a3-53c1-8c62-f1584a08e64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2054d9-d10f-4127-aece-71c3f0ef547c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2054d9-d10f-4127-aece-71c3f0ef547c.jpg?1",
             "name": "Ashen Rider",
             "text": "Flying\nWhen Ashen Rider enters the battlefield or dies, exile target permanent.",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "13da7e17-9db5-5d43-914c-bb3589687019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac7744-ba18-4fc5-8a6f-840dad28f6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac7744-ba18-4fc5-8a6f-840dad28f6c0.jpg?1",
             "name": "Ashenmoor Liege",
             "text": "Other black creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\nWhenever Ashenmoor Liege becomes the target of a spell or ability an opponent controls, that player loses 4 life.",
             "colours": [
@@ -6093,7 +6093,7 @@
         },
         {
             "id": "054b4133-063e-5a25-8402-255af93975c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb63464-d06b-4626-a57a-1e393ef04a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb63464-d06b-4626-a57a-1e393ef04a58.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "df88e587-7c9b-569d-845e-840440fcda39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b152e-c94e-4c10-9f0d-d960e878a430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b152e-c94e-4c10-9f0d-d960e878a430.jpg?1",
             "name": "Atarka's Command",
             "text": "Choose two \u2014\n\u2022 Your opponents can't gain life this turn.\n\u2022 Atarka's Command deals 3 damage to each opponent.\n\u2022 You may put a land card from your hand onto the battlefield.\n\u2022 Creatures you control get +1/+1 and gain reach until end of turn.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "16979287-4b12-5381-a27f-d7f61fede09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b18981-c0be-455c-baa4-d3f45c55b4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b18981-c0be-455c-baa4-d3f45c55b4e3.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "{2}, {T}: Create a 0/1 green Egg creature token with defender.\nWhenever an Egg you control dies, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "bf8d8a2e-0178-5e79-8371-3ad08a2394f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d7413b-2ad3-4e8f-8728-5649f938d06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d7413b-2ad3-4e8f-8728-5649f938d06e.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -6243,7 +6243,7 @@
         },
         {
             "id": "cdf091f2-2591-5bb5-bbc9-eccd7f3b8e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722682f-952c-4829-b4ef-e52300b7950e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722682f-952c-4829-b4ef-e52300b7950e.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia, the Warleader attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "ca9d39c4-ff74-5e8b-8596-981be4e8a5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed13445-c9a0-4f17-aa69-af353679e6a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed13445-c9a0-4f17-aa69-af353679e6a7.jpg?1",
             "name": "Balefire Liege",
             "text": "Other red creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nWhenever you cast a red spell, Balefire Liege deals 3 damage to target player or planeswalker.\nWhenever you cast a white spell, you gain 3 life.",
             "colours": [
@@ -6322,7 +6322,7 @@
         },
         {
             "id": "c7bb9c77-4273-585f-aef2-7443b5bda0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7906b1e8-3049-4f4e-b1fd-b2547e7079f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7906b1e8-3049-4f4e-b1fd-b2547e7079f0.jpg?1",
             "name": "Bant Charm",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Put target creature on the bottom of its owner's library.\n\u2022 Counter target instant spell.",
             "colours": [
@@ -6358,7 +6358,7 @@
         },
         {
             "id": "edfaf8d8-7378-52a0-b1e0-f0fc21ab62d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28194ca7-3b2a-49b8-8f03-56a2c97859d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28194ca7-3b2a-49b8-8f03-56a2c97859d9.jpg?1",
             "name": "Bear's Companion",
             "text": "When Bear's Companion enters the battlefield, create a 4/4 green Bear creature token.",
             "colours": [
@@ -6397,7 +6397,7 @@
         },
         {
             "id": "f836ca2c-95f5-566a-80d3-ab919c52c7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85603-0ac6-4587-9724-e35ac06ffab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85603-0ac6-4587-9724-e35ac06ffab9.jpg?1",
             "name": "Blazing Hellhound",
             "text": "{1}, Sacrifice another creature: Blazing Hellhound deals 1 damage to any target.",
             "colours": [
@@ -6434,7 +6434,7 @@
         },
         {
             "id": "ecc36e5a-1b3b-5f9e-84f1-80598894fdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f12f6f-9383-47e6-a44f-2834ad130e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f12f6f-9383-47e6-a44f-2834ad130e51.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "0800124b-c0c6-58e9-b451-a2adde40b0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab31-1455-4b31-ba81-c346e608c34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab31-1455-4b31-ba81-c346e608c34e.jpg?1",
             "name": "Bloodwater Entity",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bloodwater Entity enters the battlefield, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "0e749a78-6ba3-5ffe-95c4-da5e30745a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f28e081-7994-468d-8505-9981b90c001c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f28e081-7994-468d-8505-9981b90c001c.jpg?1",
             "name": "Boartusk Liege",
             "text": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "4a69374a-ff97-52d0-a4a4-3fcaea282176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e038250-f8a9-4bce-baa6-7c2502929b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e038250-f8a9-4bce-baa6-7c2502929b59.jpg?1",
             "name": "Bounty of the Luxa",
             "text": "At the beginning of your precombat main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U}.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "cd288c55-34cf-541a-86a1-6713483626c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3399260-a81a-475c-9b87-1efb1a13f8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3399260-a81a-475c-9b87-1efb1a13f8d6.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -6619,7 +6619,7 @@
         },
         {
             "id": "d640fb11-ab4e-5aa2-9257-82a293890663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba327a5e-bd57-4e24-b4b4-062202df30e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba327a5e-bd57-4e24-b4b4-062202df30e1.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G}.",
             "colours": [
@@ -6658,7 +6658,7 @@
         },
         {
             "id": "1cbddcd6-adbc-5183-a415-a56f8e29ac0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf31f32f-bbca-4e70-93ca-f74c20202939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf31f32f-bbca-4e70-93ca-f74c20202939.jpg?1",
             "name": "Call to the Feast",
             "text": "Create three 1/1 white Vampire creature tokens with lifelink.",
             "colours": [
@@ -6692,7 +6692,7 @@
         },
         {
             "id": "91b58274-a3ee-54e0-b35f-eb5fec6cdad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17906962-d89f-42ae-b019-22974490513c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17906962-d89f-42ae-b019-22974490513c.jpg?1",
             "name": "Cartel Aristocrat",
             "text": "Sacrifice another creature: Cartel Aristocrat gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -6729,7 +6729,7 @@
         },
         {
             "id": "1143ffe6-7afe-5fb1-a9fa-3ffa865e4013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2373625-af3c-4c2a-a1d1-5288c446955d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2373625-af3c-4c2a-a1d1-5288c446955d.jpg?1",
             "name": "Child of Alara",
             "text": "Trample\nWhen Child of Alara dies, destroy all nonland permanents. They can't be regenerated.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "2a65de33-2d38-548e-916c-387580276d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a60ba3-208c-41c9-a40a-46d3586acdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a60ba3-208c-41c9-a40a-46d3586acdfd.jpg?1",
             "name": "Chronicler of Heroes",
             "text": "When Chronicler of Heroes enters the battlefield, draw a card if you control a creature with a +1/+1 counter on it.",
             "colours": [
@@ -6812,7 +6812,7 @@
         },
         {
             "id": "f41b1e0f-d579-587a-acf4-69ce54096b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffec325d-63d9-4f01-8bfd-ae6618b3e891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffec325d-63d9-4f01-8bfd-ae6618b3e891.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "9fd8035f-05be-5380-b664-0e9b389ac442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2d72f6-bde3-49fb-976e-2d0c4dce60e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2d72f6-bde3-49fb-976e-2d0c4dce60e3.jpg?1",
             "name": "Conclave Mentor",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.\nWhen Conclave Mentor dies, you gain life equal to its power.",
             "colours": [
@@ -6889,7 +6889,7 @@
         },
         {
             "id": "5c536660-2262-5fcd-8ce2-90bd2fc3a2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66e5673-e34b-46e8-a0e4-55f3ee20f99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66e5673-e34b-46e8-a0e4-55f3ee20f99a.jpg?1",
             "name": "Crackling Doom",
             "text": "Crackling Doom deals 2 damage to each opponent. Each opponent sacrifices a creature with the greatest power among creatures that player controls.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "209dc644-814e-5b63-988e-4ccaea3e8e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4e9ea4-5b86-4eb1-965c-ae67be24f4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4e9ea4-5b86-4eb1-965c-ae67be24f4ea.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may create a 1/1 black and green Worm creature token.",
             "colours": [
@@ -6963,7 +6963,7 @@
         },
         {
             "id": "9afbdd7b-d5e3-5055-9834-7143c7853ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ad8e0-575b-43cc-95fd-53ddd14e65c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ad8e0-575b-43cc-95fd-53ddd14e65c2.jpg?1",
             "name": "Dack's Duplicate",
             "text": "You may have Dack's Duplicate enter the battlefield as a copy of any creature on the battlefield, except it has haste and dethrone. (Whenever it attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "6f6d44c6-60a0-5ee8-97b0-56cb8c2e0e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ccd70-4b94-4287-977e-6262731c58d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ccd70-4b94-4287-977e-6262731c58d1.jpg?1",
             "name": "Dauntless Escort",
             "text": "Sacrifice Dauntless Escort: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -7040,7 +7040,7 @@
         },
         {
             "id": "29debff3-e25e-5940-b194-3ff4db7ae422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d5f2f-7e54-4538-9f0a-eed464a74016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d5f2f-7e54-4538-9f0a-eed464a74016.jpg?1",
             "name": "Deathbringer Liege",
             "text": "Other white creatures you control get +1/+1.\nOther black creatures you control get +1/+1.\nWhenever you cast a white spell, you may tap target creature.\nWhenever you cast a black spell, you may destroy target creature if it's tapped.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "7cb55053-0e06-5bd3-a2f2-8c994da4abef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ad8e7f-cda0-4529-94fc-dd3709158a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ad8e7f-cda0-4529-94fc-dd3709158a94.jpg?1",
             "name": "Doran, the Siege Tower",
             "text": "Each creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "ced75dfe-2ce8-5f5e-9656-ff0460d1c527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4262e71a-b1fa-4b54-b623-34f4a7ccd500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4262e71a-b1fa-4b54-b623-34f4a7ccd500.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "This spell can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -7163,7 +7163,7 @@
         },
         {
             "id": "6402195b-902d-5b07-90cc-abb6d5c2eb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee837b8-c280-4a5b-acdf-71247ab096f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee837b8-c280-4a5b-acdf-71247ab096f5.jpg?1",
             "name": "Dragonlord Silumgar",
             "text": "Flying, deathtouch\nWhen Dragonlord Silumgar enters the battlefield, gain control of target creature or planeswalker for as long as you control Dragonlord Silumgar.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "db657bdc-b52a-538b-8306-1665475fa4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a865b-617d-40bf-900f-4aeca3602600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a865b-617d-40bf-900f-4aeca3602600.jpg?1",
             "name": "Dreg Mangler",
             "text": "Haste\nScavenge {3}{B}{G} ({3}{B}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "a83eb15b-23ca-5512-8283-4385696c56de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0ae1f-75cf-4bb0-8651-fbf14fa59f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0ae1f-75cf-4bb0-8651-fbf14fa59f81.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying, double strike, lifelink\nWhenever you gain life, draw a card.",
             "colours": [
@@ -7279,7 +7279,7 @@
         },
         {
             "id": "c2fc46db-5daa-597e-9346-8562aedfe6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1437f747-51b7-4fe1-bd98-282a27c3470f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1437f747-51b7-4fe1-bd98-282a27c3470f.jpg?1",
             "name": "Dromoka's Command",
             "text": "Choose two \u2014\n\u2022 Prevent all damage target instant or sorcery spell would deal this turn.\n\u2022 Target player sacrifices an enchantment.\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7315,7 +7315,7 @@
         },
         {
             "id": "477fefc7-8c5d-5e82-a0ff-d550125274e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e34147-588b-4fe5-88dd-2dfda567681d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e34147-588b-4fe5-88dd-2dfda567681d.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "87b77345-9411-51ce-9ba0-f5ffb01d076a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0728027-a1ec-4814-87c4-10c3baced0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0728027-a1ec-4814-87c4-10c3baced0e0.jpg?1",
             "name": "Elsha of the Infinite",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nYou may look at the top card of your library any time.\nYou may cast noncreature spells from the top of your library. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "8ec07169-8188-5c0a-978c-09c48d6e5bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908d523-1911-4a49-9e3f-ea1b719a8f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908d523-1911-4a49-9e3f-ea1b719a8f0b.jpg?1",
             "name": "Empyrial Archangel",
             "text": "Flying\nShroud (This creature can't be the target of spells or abilities.)\nAll damage that would be dealt to you is dealt to Empyrial Archangel instead.",
             "colours": [
@@ -7440,7 +7440,7 @@
         },
         {
             "id": "aedf1c7e-9352-5347-b0e3-521fb6f61386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769e3f-d27d-4aff-8da0-f03c10b8650b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769e3f-d27d-4aff-8da0-f03c10b8650b.jpg?1",
             "name": "Extract from Darkness",
             "text": "Each player mills two cards. Then you put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "0f327954-9e82-50d6-95d5-5f6388e443e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf721b0-2b5a-4085-b50c-89cbe7420673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf721b0-2b5a-4085-b50c-89cbe7420673.jpg?1",
             "name": "Ezuri, Claw of Progress",
             "text": "Whenever a creature with power 2 or less enters the battlefield under your control, you get an experience counter.\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is the number of experience counters you have.",
             "colours": [
@@ -7516,7 +7516,7 @@
         },
         {
             "id": "8c71ba45-4ce8-5a79-a04e-0173c5283a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144668d6-cab6-45e6-8498-ab7cd927f9df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144668d6-cab6-45e6-8498-ab7cd927f9df.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.",
             "colours": [
@@ -7554,7 +7554,7 @@
         },
         {
             "id": "c488933c-1aee-5ed1-9c16-53acf427dc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d779966-4bd4-4315-8b45-d3a4492f2bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d779966-4bd4-4315-8b45-d3a4492f2bb2.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a Kithkin Spirit with base power and toughness 2/2.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "0f75e5f5-ff7d-5f10-bdfc-483edb46d7e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df03ac18-1ab4-4264-9821-3f92333c3ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df03ac18-1ab4-4264-9821-3f92333c3ed8.jpg?1",
             "name": "Fireblade Artist",
             "text": "Haste\nAt the beginning of your upkeep, you may sacrifice a creature. When you do, Fireblade Artist deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "8009ba0e-a15b-503a-b204-9b880602ca4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5edf4f-5695-42fc-9e57-c4faef60fbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5edf4f-5695-42fc-9e57-c4faef60fbc3.jpg?1",
             "name": "Firesong and Sunspeaker",
             "text": "Red instant and sorcery spells you control have lifelink.\nWhenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "95488514-0f79-5dd6-b4a3-18a0b387ba50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2be0e99-cf43-423f-974f-02e3313b3aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2be0e99-cf43-423f-974f-02e3313b3aa9.jpg?1",
             "name": "Ghave, Guru of Spores",
             "text": "Ghave, Guru of Spores enters the battlefield with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from a creature you control: Create a 1/1 green Saproling creature token.\n{1}, Sacrifice a creature: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "84f66fd6-48b1-5152-b153-b92b896268d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374d2d74-1209-4822-b370-ab8b049d4ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374d2d74-1209-4822-b370-ab8b049d4ce0.jpg?1",
             "name": "Glen Elendra Liege",
             "text": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "f27bb4fd-15bd-5d09-b9cc-777424f1ad13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54a2256-673d-4d93-9e1d-7790bf254881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54a2256-673d-4d93-9e1d-7790bf254881.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player mills ten cards.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "3f876a96-078e-53f1-9b52-c8df6e39605a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e48e-e0a4-4a45-8d82-2ab56fee7246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e48e-e0a4-4a45-8d82-2ab56fee7246.jpg?1",
             "name": "Gloryscale Viashino",
             "text": "Whenever you cast a multicolored spell, Gloryscale Viashino gets +3/+3 until end of turn.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "824412bd-6770-57ad-b3fe-c78814530ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f56d8-3ea1-4750-b88d-c5a7837681b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f56d8-3ea1-4750-b88d-c5a7837681b5.jpg?1",
             "name": "Glowspore Shaman",
             "text": "When Glowspore Shaman enters the battlefield, mill three cards. You may put a land card from your graveyard on top of your library.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "d9f634fb-ddd4-5284-9959-a9dfda961e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43748ea-1d65-4ee8-9c66-221412a284c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43748ea-1d65-4ee8-9c66-221412a284c0.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -7907,7 +7907,7 @@
         },
         {
             "id": "e8d96510-39bf-577f-a1b1-4e8a062b127e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce33033-f673-451e-bb8e-cd3e2309e4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce33033-f673-451e-bb8e-cd3e2309e4b4.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -7947,7 +7947,7 @@
         },
         {
             "id": "2c0274f7-731d-5afb-9eda-25a86e66c58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c61bd1-4bf5-4c38-835d-2249f8e8d5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c61bd1-4bf5-4c38-835d-2249f8e8d5d4.jpg?1",
             "name": "Ground Assault",
             "text": "Ground Assault deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "2dd0140b-602c-5362-abf6-3dd2f08cd96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66c8ada-82a6-46d9-acd0-b4ff9e1e12bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66c8ada-82a6-46d9-acd0-b4ff9e1e12bd.jpg?1",
             "name": "Guided Passage",
             "text": "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle.",
             "colours": [
@@ -8019,7 +8019,7 @@
         },
         {
             "id": "df571be4-e69a-5459-9b6f-26a93cd57031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99869b4-0bb6-444a-bdc4-5916371c9d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99869b4-0bb6-444a-bdc4-5916371c9d29.jpg?1",
             "name": "Hellkite Overlord",
             "text": "Flying, trample, haste\n{R}: Hellkite Overlord gets +1/+0 until end of turn.\n{B}{G}: Regenerate Hellkite Overlord.",
             "colours": [
@@ -8059,7 +8059,7 @@
         },
         {
             "id": "63f35266-c63d-5fb0-9c7f-d51a2a80c7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5817ce-a8ba-4007-b8ca-6d39a421a9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5817ce-a8ba-4007-b8ca-6d39a421a9bc.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste.",
             "colours": [
@@ -8093,7 +8093,7 @@
         },
         {
             "id": "b02a234d-3024-53a9-a993-81d1a0c3ab81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1481378-25c3-4f8d-93bc-0a433f467dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1481378-25c3-4f8d-93bc-0a433f467dca.jpg?1",
             "name": "Hostage Taker",
             "text": "When Hostage Taker enters the battlefield, exile another target creature or artifact until Hostage Taker leaves the battlefield. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -8132,7 +8132,7 @@
         },
         {
             "id": "0d9bd644-be84-58da-865c-f0a39ecefd8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65010991-2097-4769-be96-f24b4bf9276f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65010991-2097-4769-be96-f24b4bf9276f.jpg?1",
             "name": "Hydroid Krasis",
             "text": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nHydroid Krasis enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "c534f0cf-dbc5-5918-a1d2-b21ad4762fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35517572-b5d4-4dbf-b090-4e4c4b040a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35517572-b5d4-4dbf-b090-4e4c4b040a0d.jpg?1",
             "name": "Intet, the Dreamer",
             "text": "Flying\nWhenever Intet, the Dreamer deals combat damage to a player, you may pay {2}{U}. If you do, exile the top card of your library face down. You may look at that card for as long as it remains exiled. You may play that card without paying its mana cost for as long as Intet remains on the battlefield.",
             "colours": [
@@ -8214,7 +8214,7 @@
         },
         {
             "id": "31d045e8-a7e9-509e-ace5-a19a0c20cfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4b8a7-4153-4694-9aae-f61d3124c785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4b8a7-4153-4694-9aae-f61d3124c785.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Izzet Charm deals 2 damage to target creature.\n\u2022 Draw two cards, then discard two cards.",
             "colours": [
@@ -8248,7 +8248,7 @@
         },
         {
             "id": "cffb93bf-c1db-5ee3-9320-78ebd4125109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8399fc-4cba-44c5-888e-2cfc0f6739f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8399fc-4cba-44c5-888e-2cfc0f6739f6.jpg?1",
             "name": "Jeskai Ascendancy",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn. Untap those creatures.\nWhenever you cast a noncreature spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -8286,7 +8286,7 @@
         },
         {
             "id": "9de32ef4-9a20-5bf8-b469-b7c4506fa8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c0fcdb-a312-4976-bcfb-73930c0a556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c0fcdb-a312-4976-bcfb-73930c0a556c.jpg?1",
             "name": "Jeskai Charm",
             "text": "Choose one \u2014\n\u2022 Put target creature on top of its owner's library.\n\u2022 Jeskai Charm deals 4 damage to target opponent or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "6b063fe6-b14b-5699-8908-90f0679cbeb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c18cb4-96b1-4af2-912e-974e22877ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c18cb4-96b1-4af2-912e-974e22877ede.jpg?1",
             "name": "Jodah, Archmage Eternal",
             "text": "Flying\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "f6238e61-70de-5c8f-9381-7d19f797ad76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4fc28d1-61d5-4a78-8fbb-6566128486ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4fc28d1-61d5-4a78-8fbb-6566128486ce.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -8408,7 +8408,7 @@
         },
         {
             "id": "ce143ef3-0096-5b2d-80a0-93ea338b279a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6631f-f3a6-4d3c-8618-4b4ab4e82483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6631f-f3a6-4d3c-8618-4b4ab4e82483.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -8451,7 +8451,7 @@
         },
         {
             "id": "88fad682-8a9e-53ef-ab82-8a6ef5b789d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b8259d-0bfa-4327-ac91-157c0b9e7dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b8259d-0bfa-4327-ac91-157c0b9e7dfb.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent casts a spell, Kaervek the Merciless deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -8492,7 +8492,7 @@
         },
         {
             "id": "9aa56a84-2427-5d92-95b3-9c7308a41de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e47d49-e5b5-487b-a1ec-373dbf89b2ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e47d49-e5b5-487b-a1ec-373dbf89b2ec.jpg?1",
             "name": "Kambal, Consul of Allocation",
             "text": "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "f119390e-0e74-5172-91f2-1360a641b20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6200ac79-b166-43d0-9a0b-5b547625ed57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6200ac79-b166-43d0-9a0b-5b547625ed57.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -8576,7 +8576,7 @@
         },
         {
             "id": "230f89d4-9778-5de6-a3b7-2b85b8ebe8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dab027-a475-481b-b012-b6a76e21e494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dab027-a475-481b-b012-b6a76e21e494.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to any target.",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "7e9a04e4-0081-567b-88e4-5faf03c6dd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e903a1d8-2127-4a32-9223-8ff6574c503f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e903a1d8-2127-4a32-9223-8ff6574c503f.jpg?1",
             "name": "Lavalanche",
             "text": "Lavalanche deals X damage to target player or planeswalker and each creature that player or that planeswalker's controller controls.",
             "colours": [
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "e5d7577b-6386-5694-b8fd-ea45212466f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07478486-b065-4173-837e-cd3335a0567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07478486-b065-4173-837e-cd3335a0567d.jpg?1",
             "name": "League Guildmage",
             "text": "{3}{U}, {T}: Draw a card.\n{X}{R}, {T}: Copy target instant or sorcery spell you control with mana value X. You may choose new targets for the copy.",
             "colours": [
@@ -8688,7 +8688,7 @@
         },
         {
             "id": "f4ca29b1-6047-59cc-927f-2d02c5deba0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f950f-b818-4150-af71-b53a502ca0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f950f-b818-4150-af71-b53a502ca0d5.jpg?1",
             "name": "Legion's Initiative",
             "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
             "colours": [
@@ -8724,7 +8724,7 @@
         },
         {
             "id": "ca1f16f9-50f5-5d59-aa31-30df5e641ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f25737-a195-4763-bc23-b3c4d38b9e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f25737-a195-4763-bc23-b3c4d38b9e58.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -8758,7 +8758,7 @@
         },
         {
             "id": "10020527-fbad-500a-9996-219202ed797b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696cb81d-bc00-4603-b340-c0b2e55c0959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696cb81d-bc00-4603-b340-c0b2e55c0959.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -8796,7 +8796,7 @@
         },
         {
             "id": "fff1d7a3-6507-56f3-b036-49b78ea65a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc138550-a797-4a57-91b3-626aac1b1edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc138550-a797-4a57-91b3-626aac1b1edd.jpg?1",
             "name": "Lotleth Troll",
             "text": "Trample\nDiscard a creature card: Put a +1/+1 counter on Lotleth Troll.\n{B}: Regenerate Lotleth Troll.",
             "colours": [
@@ -8833,7 +8833,7 @@
         },
         {
             "id": "3240ee59-b746-5bd3-b4af-1eaed503143d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3e1033-428a-4263-8813-fdb8bb4b6425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3e1033-428a-4263-8813-fdb8bb4b6425.jpg?1",
             "name": "Lyev Skyknight",
             "text": "Flying\nWhen Lyev Skyknight enters the battlefield, detain target nonland permanent an opponent controls. (Until your next turn, that permanent can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -8870,7 +8870,7 @@
         },
         {
             "id": "8a9c820c-1959-58af-92c9-1da98df43a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be662808-e452-407d-b142-bf6f30990b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be662808-e452-407d-b142-bf6f30990b5a.jpg?1",
             "name": "Magister Sphinx",
             "text": "Flying\nWhen Magister Sphinx enters the battlefield, target player's life total becomes 10.",
             "colours": [
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "0f906c25-1f97-55a6-a815-ef9316b7582a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3242a9f0-2ba3-4852-ac8f-366772ac1c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3242a9f0-2ba3-4852-ac8f-366772ac1c62.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "Dethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nOther creatures you control have dethrone.\nWhenever a creature you control with a +1/+1 counter on it dies, return that card to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -8955,7 +8955,7 @@
         },
         {
             "id": "e8fdb3b6-7a50-5d90-92fc-03d33377bdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf662e7-e63f-40c2-b163-1ebce47d8696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf662e7-e63f-40c2-b163-1ebce47d8696.jpg?1",
             "name": "Martial Glory",
             "text": "Target creature gets +3/+0 until end of turn.\nTarget creature gets +0/+3 until end of turn.",
             "colours": [
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "bd6a5ddb-00ff-54de-8690-b69aca0a001f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a57b0e38-8931-4715-ac13-b3af30b27895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a57b0e38-8931-4715-ac13-b3af30b27895.jpg?1",
             "name": "Master Biomancer",
             "text": "Each other creature you control enters the battlefield with a number of additional +1/+1 counters on it equal to Master Biomancer's power and as a Mutant in addition to its other types.",
             "colours": [
@@ -9028,7 +9028,7 @@
         },
         {
             "id": "78f3c2c9-9c74-5214-b12c-ffd43c9cc488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25266b22-3cee-4ac8-91e8-5a23fbaa457a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25266b22-3cee-4ac8-91e8-5a23fbaa457a.jpg?1",
             "name": "Master of Cruelties",
             "text": "First strike, deathtouch\nMaster of Cruelties can only attack alone.\nWhenever Master of Cruelties attacks a player and isn't blocked, that player's life total becomes 1. Master of Cruelties assigns no combat damage this combat.",
             "colours": [
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "7f183d7f-165f-5274-9763-203dbb4a8501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921b65b1-18bf-4b02-a35d-7eaee1846611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921b65b1-18bf-4b02-a35d-7eaee1846611.jpg?1",
             "name": "Mathas, Fiend Seeker",
             "text": "Menace\nAt the beginning of your end step, put a bounty counter on target creature an opponent controls. For as long as that creature has a bounty counter on it, it has \"When this creature dies, each opponent draws a card and gains 2 life.\"",
             "colours": [
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "367c0744-3fbb-56b8-a807-a89c4d55d5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53170fe-7f18-47ef-b501-1ed398306419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53170fe-7f18-47ef-b501-1ed398306419.jpg?1",
             "name": "Mayael's Aria",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
             "colours": [
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "f4367933-5ba2-54f8-b7b3-fbaa1a140aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173413-0431-4b70-a509-f1bc11a59225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173413-0431-4b70-a509-f1bc11a59225.jpg?1",
             "name": "The Mimeoplasm",
             "text": "As The Mimeoplasm enters the battlefield, you may exile two creature cards from graveyards. If you do, it enters the battlefield as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
             "colours": [
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "53a8ae14-ce42-5bab-bc80-93c1f43388fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6dd439-78f6-480b-bdc3-1cb3481bcaf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6dd439-78f6-480b-bdc3-1cb3481bcaf1.jpg?1",
             "name": "Mindwrack Liege",
             "text": "Other blue creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\n{UR}{UR}{UR}{UR}: You may put a blue or red creature card from your hand onto the battlefield.",
             "colours": [
@@ -9227,7 +9227,7 @@
         },
         {
             "id": "f680c970-f39f-5494-8356-8190aa54c438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0119777-70da-4cba-8104-a7e78604d515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0119777-70da-4cba-8104-a7e78604d515.jpg?1",
             "name": "Mistmeadow Witch",
             "text": "{2}{W}{U}: Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -9264,7 +9264,7 @@
         },
         {
             "id": "f0710344-ccac-5f9b-8466-81c8e784a50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069bf085-3f70-4c85-8e90-609d1d182e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069bf085-3f70-4c85-8e90-609d1d182e29.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "88a33a30-2171-5877-89dd-9a030cbd5dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4125bb0-b104-438e-a6a2-97f9d141243c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4125bb0-b104-438e-a6a2-97f9d141243c.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -9349,7 +9349,7 @@
         },
         {
             "id": "0e6b2d26-9230-57aa-bd90-7508b502a47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16677645-f635-4183-8afc-056520b94122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16677645-f635-4183-8afc-056520b94122.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "6cac882b-57d3-5b6b-a3c9-56dcd5401f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597ca22d-2f08-47b3-9d93-c4d685cefb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597ca22d-2f08-47b3-9d93-c4d685cefb5f.jpg?1",
             "name": "Nicol Bolas, God-Pharaoh",
             "text": "+2: Target opponent exiles cards from the top of their library until they exile a nonland card. Until end of turn, you may cast that card without paying its mana cost.\n+1: Each opponent exiles two cards from their hand.\n\u22124: Nicol Bolas, God-Pharaoh deals 7 damage to target opponent, creature an opponent controls, or planeswalker an opponent controls.\n\u221212: Exile each nonland permanent your opponents control.",
             "colours": [
@@ -9429,7 +9429,7 @@
         },
         {
             "id": "b2829fde-5c82-54e6-a1db-408b5092147a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e36323c-75d0-475e-a5a7-9a1567ff2b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e36323c-75d0-475e-a5a7-9a1567ff2b62.jpg?1",
             "name": "Orzhov Pontiff",
             "text": "Haunt (When this creature dies, exile it haunting target creature.)\nWhen Orzhov Pontiff enters the battlefield or the creature it haunts dies, choose one \u2014\n\u2022 Creatures you control get +1/+1 until end of turn.\n\u2022 Creatures you don't control get -1/-1 until end of turn.",
             "colours": [
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "f90d8c75-6641-54ba-bbfa-7a779f78be0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd85ec-13b3-4d63-b144-5baa39ad6524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd85ec-13b3-4d63-b144-5baa39ad6524.jpg?1",
             "name": "Phyrexian Tyranny",
             "text": "Whenever a player draws a card, that player loses 2 life unless they pay {2}.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "8b753ca1-31af-535c-b588-43e48056f0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9655bbe4-062f-4278-ad05-a326a64c5b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9655bbe4-062f-4278-ad05-a326a64c5b69.jpg?1",
             "name": "Privileged Position",
             "text": "Other permanents you control have hexproof.",
             "colours": [
@@ -9541,7 +9541,7 @@
         },
         {
             "id": "74792188-b94b-51b4-a25d-e64364d1380e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844c9fa7-8751-49be-827a-7fb6986bae59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844c9fa7-8751-49be-827a-7fb6986bae59.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -9579,7 +9579,7 @@
         },
         {
             "id": "ce80dae4-630a-53cd-befe-578317fccb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b79c31-597f-484b-a684-f1520cae314a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b79c31-597f-484b-a684-f1520cae314a.jpg?1",
             "name": "Prophetic Bolt",
             "text": "Prophetic Bolt deals 4 damage to any target. Look at the top four cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "1ba3b058-453b-50f7-84f3-8aee80307397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145d817-9c84-4acd-977c-fe00325568fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145d817-9c84-4acd-977c-fe00325568fd.jpg?1",
             "name": "Psychic Symbiont",
             "text": "Flying\nWhen Psychic Symbiont enters the battlefield, target opponent discards a card and you draw a card.",
             "colours": [
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "add8069c-43a8-5e34-863e-b9faea2cbf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103646d-b363-4896-a48f-0527d746587e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103646d-b363-4896-a48f-0527d746587e.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "94cea151-fddc-5d37-bb90-8a3bb17c40b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12259d86-f610-47c7-bb81-0da9bb6a2795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12259d86-f610-47c7-bb81-0da9bb6a2795.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "c51b5d01-8534-5e59-b4de-aefbfbab2425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff9aa6-bc5e-476d-9dd1-1318ed521b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff9aa6-bc5e-476d-9dd1-1318ed521b6f.jpg?1",
             "name": "River Hoopoe",
             "text": "Flying\n{3}{G}{U}: You gain 2 life and draw a card.",
             "colours": [
@@ -9768,7 +9768,7 @@
         },
         {
             "id": "2f8ecb6e-ebc2-5bb3-884d-41dc84cf55b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e2d6c2-a233-4e37-94c9-673a4a957e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e2d6c2-a233-4e37-94c9-673a4a957e0c.jpg?1",
             "name": "Roon of the Hidden Realm",
             "text": "Vigilance, trample\n{2}, {T}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "868a0110-e985-5a81-bf74-14561019a8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa828bdc-221e-4e81-9e71-6f288690ddcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa828bdc-221e-4e81-9e71-6f288690ddcd.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each combat if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "63561c08-6118-5a19-9ca8-31d1eeb81b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68aa496d-15c0-4da0-b3c9-4bb7e57d9a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68aa496d-15c0-4da0-b3c9-4bb7e57d9a31.jpg?1",
             "name": "Scab-Clan Giant",
             "text": "When Scab-Clan Giant enters the battlefield, it fights target creature an opponent controls chosen at random.",
             "colours": [
@@ -9889,7 +9889,7 @@
         },
         {
             "id": "217679f7-38ee-59f9-85d8-5b13e662eef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0fe75-cfaf-483e-8412-9ffb5d96ae25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0fe75-cfaf-483e-8412-9ffb5d96ae25.jpg?1",
             "name": "Sedraxis Specter",
             "text": "Flying\nWhenever Sedraxis Specter deals combat damage to a player, that player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -9927,7 +9927,7 @@
         },
         {
             "id": "428d724c-0a3b-52a2-827c-3f3d1199a1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e787a7-3721-4ba7-b643-a103488cfc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e787a7-3721-4ba7-b643-a103488cfc8a.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -9971,7 +9971,7 @@
         },
         {
             "id": "1c3e0174-606f-58ca-9f10-a4c5337fa0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a30e27-4c52-4191-8541-e25732a2dd42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a30e27-4c52-4191-8541-e25732a2dd42.jpg?1",
             "name": "Shattergang Brothers",
             "text": "{2}{B}, Sacrifice a creature: Each other player sacrifices a creature.\n{2}{R}, Sacrifice an artifact: Each other player sacrifices an artifact.\n{2}{G}, Sacrifice an enchantment: Each other player sacrifices an enchantment.",
             "colours": [
@@ -10014,7 +10014,7 @@
         },
         {
             "id": "88ca9de5-3496-58d7-a21a-327922f1724d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f08fd3-9c0a-476a-9894-1938179824c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f08fd3-9c0a-476a-9894-1938179824c6.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "e3fc013b-c7f7-5c56-8cee-02542be2de50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd0bf11-4e43-43f1-82e3-755beed0ede0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd0bf11-4e43-43f1-82e3-755beed0ede0.jpg?1",
             "name": "Skullbriar, the Walking Grave",
             "text": "Haste\nWhenever Skullbriar, the Walking Grave deals combat damage to a player, put a +1/+1 counter on it.\nCounters remain on Skullbriar as it moves to any zone other than a player's hand or library.",
             "colours": [
@@ -10098,7 +10098,7 @@
         },
         {
             "id": "232142c2-9d13-5fec-b7ce-fbb4cc4cd680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b05cf1-1bc2-43e1-b383-9cbb69517389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b05cf1-1bc2-43e1-b383-9cbb69517389.jpg?1",
             "name": "Sprouting Thrinax",
             "text": "When Sprouting Thrinax dies, create three 1/1 green Saproling creature tokens.",
             "colours": [
@@ -10136,7 +10136,7 @@
         },
         {
             "id": "953ed7de-42df-5f99-8dbf-c191d3912057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcc4f4b-a1bd-4581-858f-bbd3ff6a9d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcc4f4b-a1bd-4581-858f-bbd3ff6a9d7a.jpg?1",
             "name": "Sultai Soothsayer",
             "text": "When Sultai Soothsayer enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -10175,7 +10175,7 @@
         },
         {
             "id": "45c509a6-eee6-5a69-b2e5-1b6be733d4ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b5fe42-929c-406d-9377-40b49f9d2e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b5fe42-929c-406d-9377-40b49f9d2e2c.jpg?1",
             "name": "Supreme Verdict",
             "text": "This spell can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -10212,7 +10212,7 @@
         },
         {
             "id": "aa29ca23-6ae3-5d07-8863-970cf54b0eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b588dc15-68e6-4cbb-9345-a921c10f862d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b588dc15-68e6-4cbb-9345-a921c10f862d.jpg?1",
             "name": "Tariel, Reckoner of Souls",
             "text": "Flying, vigilance\n{T}: Choose a creature card at random from target opponent's graveyard. Put that card onto the battlefield under your control.",
             "colours": [
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "c2ada85b-56d0-5c51-affc-8bea5572dcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8caa7115-1b26-4615-842f-671b24dc96d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8caa7115-1b26-4615-842f-671b24dc96d8.jpg?1",
             "name": "Teneb, the Harvester",
             "text": "Flying\nWhenever Teneb, the Harvester deals combat damage to a player, you may pay {2}{B}. If you do, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -10296,7 +10296,7 @@
         },
         {
             "id": "ea001a1e-07b9-516c-b7d2-a1b48ecb2001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0c8d75-fb20-49f2-9a03-35411f06c1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0c8d75-fb20-49f2-9a03-35411f06c1a7.jpg?1",
             "name": "Tenth District Legionnaire",
             "text": "Haste\nWhenever you cast a spell that targets Tenth District Legionnaire, put a +1/+1 counter on Tenth District Legionnaire, then scry 1.",
             "colours": [
@@ -10333,7 +10333,7 @@
         },
         {
             "id": "98a5d7fe-1c33-5723-9f51-22940d66ff96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cba6180-a15e-4f7f-8843-e48e69e758a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cba6180-a15e-4f7f-8843-e48e69e758a0.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -10369,7 +10369,7 @@
         },
         {
             "id": "1651bede-be68-5bf2-93c6-0a7dc6659cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a21a0c-fe3d-456b-a905-8d962c0b1e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a21a0c-fe3d-456b-a905-8d962c0b1e3c.jpg?1",
             "name": "Thistledown Liege",
             "text": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
             "colours": [
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "d5fba822-6308-5bb9-b1a1-d8dd73c8eb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e22fb-7afc-43bc-b309-e36ee48d6b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e22fb-7afc-43bc-b309-e36ee48d6b03.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -10445,7 +10445,7 @@
         },
         {
             "id": "84f02141-3ce5-5e45-9827-b9ab247396c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7334eb-66c1-4410-966c-4e76c1b9e9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7334eb-66c1-4410-966c-4e76c1b9e9a7.jpg?1",
             "name": "Thraximundar",
             "text": "Haste\nWhenever Thraximundar attacks, defending player sacrifices a creature.\nWhenever a player sacrifices a creature, you may put a +1/+1 counter on Thraximundar.",
             "colours": [
@@ -10488,7 +10488,7 @@
         },
         {
             "id": "17173ae0-3c40-5642-a65c-65caf449240b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aef108-6aaf-465d-b3f6-5ac1499f44a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aef108-6aaf-465d-b3f6-5ac1499f44a3.jpg?1",
             "name": "Tower Gargoyle",
             "text": "Flying",
             "colours": [
@@ -10527,7 +10527,7 @@
         },
         {
             "id": "4c5e4a6c-ce15-5734-a4db-c40ef64e55bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002fe870-eae5-42cc-a44c-32906f60719e.jpg?1",
             "name": "Ulasht, the Hate Seed",
             "text": "Ulasht, the Hate Seed enters the battlefield with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one \u2014\n\u2022 Ulasht deals 1 damage to target creature.\n\u2022 Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "f0ad0151-5127-5f0e-a9e3-c1c8b4462cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca984fdb-aaca-4d8f-af2f-72387122607b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca984fdb-aaca-4d8f-af2f-72387122607b.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "Hexproof\nUril, the Miststalker gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -10610,7 +10610,7 @@
         },
         {
             "id": "85dc658b-3746-50fa-8518-74c8c9c104eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1caccc8-4f33-4ae3-a09a-b41b9c4663a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1caccc8-4f33-4ae3-a09a-b41b9c4663a1.jpg?1",
             "name": "Varina, Lich Queen",
             "text": "Whenever you attack with one or more Zombies, draw that many cards, then discard that many cards. You gain that much life.\n{2}, Exile two cards from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "b8640965-bab9-5d78-aa46-240541fcf42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c4bd2-b84a-4dbd-9452-90c9734d78fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c4bd2-b84a-4dbd-9452-90c9734d78fb.jpg?1",
             "name": "Villainous Wealth",
             "text": "Target opponent exiles the top X cards of their library. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "90d59752-59f4-5119-99c9-75503e3e1915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07790bd5-0d27-490e-b1ae-3b866882461e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07790bd5-0d27-490e-b1ae-3b866882461e.jpg?1",
             "name": "Wasitora, Nekoru Queen",
             "text": "Flying, trample\nWhenever Wasitora, Nekoru Queen deals combat damage to a player, that player sacrifices a creature. If the player can't, you create a 3/3 black, red, and green Cat Dragon creature token with flying.",
             "colours": [
@@ -10734,7 +10734,7 @@
         },
         {
             "id": "be162e18-8e5c-56ac-9b5d-25b1508779ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4928cb86-6971-458b-ad74-1b39c0e1c177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4928cb86-6971-458b-ad74-1b39c0e1c177.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -10773,7 +10773,7 @@
         },
         {
             "id": "1690f261-906c-5c48-a264-8f30b472c4cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400862ac-f229-4f73-949c-779f6bfa868b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400862ac-f229-4f73-949c-779f6bfa868b.jpg?1",
             "name": "Winged Coatl",
             "text": "Flash\nFlying, deathtouch",
             "colours": [
@@ -10809,7 +10809,7 @@
         },
         {
             "id": "3f2cdb30-dd78-5ea8-96e4-4efd56396e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd498cc-a609-4457-9325-6888d59ca36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd498cc-a609-4457-9325-6888d59ca36f.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -10851,7 +10851,7 @@
         },
         {
             "id": "5b2886f1-1614-52a1-a141-c5e019aa0425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb0160a-dfdc-4b1f-865e-ef905aee65d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb0160a-dfdc-4b1f-865e-ef905aee65d5.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -10894,7 +10894,7 @@
         },
         {
             "id": "22b2e747-6d2b-503a-bc8e-0d28b82340e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e8d2fd-b132-4807-9410-8edeffa519ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e8d2fd-b132-4807-9410-8edeffa519ed.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with mana value equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -10925,7 +10925,7 @@
         },
         {
             "id": "ad2def85-d307-5fee-bf98-93ecf0f22739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1939833-05e5-4cbd-b766-7837e72e5929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1939833-05e5-4cbd-b766-7837e72e5929.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -10958,7 +10958,7 @@
         },
         {
             "id": "a749c48d-3833-5709-9912-9bdb9ae78610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c1112-4cfc-4af9-85a9-4431886f19bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c1112-4cfc-4af9-85a9-4431886f19bb.jpg?1",
             "name": "Civic Saber",
             "text": "Equipped creature gets +1/+0 for each of its colors.\nEquip {1}",
             "colours": [],
@@ -10988,7 +10988,7 @@
         },
         {
             "id": "2296faa9-091f-511c-90e2-c9d36f73ad6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2548ad2-3c62-4ed1-899c-1002b46cdd8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2548ad2-3c62-4ed1-899c-1002b46cdd8f.jpg?1",
             "name": "Coldsteel Heart",
             "text": "Coldsteel Heart enters the battlefield tapped.\nAs Coldsteel Heart enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -11018,7 +11018,7 @@
         },
         {
             "id": "a41f61e6-266d-59a5-984b-c7faec99f333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f5399a-26c6-4ecd-9715-f6440f6958f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f5399a-26c6-4ecd-9715-f6440f6958f1.jpg?1",
             "name": "Conqueror's Flail",
             "text": "Equipped creature gets +1/+1 for each color among permanents you control.\nAs long as Conqueror's Flail is attached to a creature, your opponents can't cast spells during your turn.\nEquip {2}",
             "colours": [],
@@ -11050,7 +11050,7 @@
         },
         {
             "id": "bb3f2dc8-8e08-5152-a6a0-44a194246b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4893ef-f983-418b-b7a4-5f073c844545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4893ef-f983-418b-b7a4-5f073c844545.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "f3e783a3-ea19-56d8-bd09-651a74de57c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f99fb1e-99a6-4c83-98eb-7bff23996a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f99fb1e-99a6-4c83-98eb-7bff23996a7f.jpg?1",
             "name": "Darksteel Plate",
             "text": "Indestructible\nEquipped creature has indestructible.\nEquip {2}",
             "colours": [],
@@ -11113,7 +11113,7 @@
         },
         {
             "id": "e08cd29d-f912-5faf-a57d-256882b9e0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2312a56-088f-42f9-9bd2-7b0b94935236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2312a56-088f-42f9-9bd2-7b0b94935236.jpg?1",
             "name": "Dragon Arch",
             "text": "{2}, {T}: You may put a multicolored creature card from your hand onto the battlefield.",
             "colours": [],
@@ -11141,7 +11141,7 @@
         },
         {
             "id": "c264a1a7-1e3e-5598-a758-f54a02f7d023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f918-df2e-4663-b622-f731b0e01b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f918-df2e-4663-b622-f731b0e01b6d.jpg?1",
             "name": "Firemind Vessel",
             "text": "Firemind Vessel enters the battlefield tapped.\n{T}: Add two mana of different colors.",
             "colours": [],
@@ -11169,7 +11169,7 @@
         },
         {
             "id": "88d3346f-68f7-58e0-97c4-f6b1dd2797b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac4633-066b-4897-b484-2ec654c7eaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac4633-066b-4897-b484-2ec654c7eaa1.jpg?1",
             "name": "Livewire Lash",
             "text": "Equipped creature gets +2/+0 and has \"Whenever this creature becomes the target of a spell, this creature deals 2 damage to any target.\"\nEquip {2}",
             "colours": [],
@@ -11199,7 +11199,7 @@
         },
         {
             "id": "35caa9dd-fb92-5df1-85a1-18aa98e3b97a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a31d52-a407-4ded-bfca-cc812f11afa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a31d52-a407-4ded-bfca-cc812f11afa0.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -11230,7 +11230,7 @@
         },
         {
             "id": "4802bb6c-137d-5854-b02d-91c47ae4d569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787b1cc8-42b4-4d3e-9b8a-a252de297b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787b1cc8-42b4-4d3e-9b8a-a252de297b1a.jpg?1",
             "name": "Nim Deathmantle",
             "text": "Equipped creature gets +2/+2, has intimidate, and is a black Zombie. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever a nontoken creature is put into your graveyard from the battlefield, you may pay {4}. If you do, return that card to the battlefield and attach Nim Deathmantle to it.\nEquip {4}",
             "colours": [],
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "2b914ffc-6103-5dac-a4ca-e4436d9242ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998d0cc8-ca2a-41c3-ab65-d05c26ab8278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998d0cc8-ca2a-41c3-ab65-d05c26ab8278.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -11293,7 +11293,7 @@
         },
         {
             "id": "55121999-d723-5c41-b01c-06d3183fe849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9f93c-50a8-41a9-be98-d1900bf1c12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9f93c-50a8-41a9-be98-d1900bf1c12f.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "33ea1b54-cdcc-52a8-8a80-d79bbd1478fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776899f8-e977-42b7-8b54-6f726a349e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776899f8-e977-42b7-8b54-6f726a349e3c.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -11355,7 +11355,7 @@
         },
         {
             "id": "ebe68561-0858-5fa1-9582-f894682e1727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30879758-841c-46a9-a0b6-179ac163f0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30879758-841c-46a9-a0b6-179ac163f0ac.jpg?1",
             "name": "Planar Bridge",
             "text": "{8}, {T}: Search your library for a permanent card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "1a871666-a17b-51c4-9f96-8202311eaeb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5142b7a-e580-4737-a4aa-2590f6610ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5142b7a-e580-4737-a4aa-2590f6610ceb.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -11418,7 +11418,7 @@
         },
         {
             "id": "149416da-a41f-5b30-8cba-ec3693d68de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14adc0af-de61-4872-916c-3cf480dece46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14adc0af-de61-4872-916c-3cf480dece46.jpg?1",
             "name": "Thrumming Stone",
             "text": "Spells you cast have ripple 4. (Whenever you cast a spell, you may reveal the top four cards of your library. You may cast spells with the same name as that spell from among the revealed cards without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [],
@@ -11450,7 +11450,7 @@
         },
         {
             "id": "2416fd04-9d07-525f-ac38-7f277baf0fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93621a8-d0f4-436e-9e4f-cccc0447eae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93621a8-d0f4-436e-9e4f-cccc0447eae8.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -11478,7 +11478,7 @@
         },
         {
             "id": "b8e14f08-2817-51eb-b6c4-18c9f4a7e5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44067327-6fe3-4222-b591-6d14d0e360d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44067327-6fe3-4222-b591-6d14d0e360d7.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may cast spells as though they had flash.",
             "colours": [],
@@ -11509,7 +11509,7 @@
         },
         {
             "id": "eaaafb79-49c0-5c10-996d-7e1e0647cf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7084fc02-8941-4a4f-805d-3c1625cf1d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7084fc02-8941-4a4f-805d-3c1625cf1d58.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U}.",
             "colours": [],
@@ -11542,7 +11542,7 @@
         },
         {
             "id": "79aed9ca-85af-5a55-9d1f-23deb80d0b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26abe8c-4f06-448d-9e0e-8214592cb885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26abe8c-4f06-448d-9e0e-8214592cb885.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W}.",
             "colours": [],
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "01603f03-a5ea-53d0-9d9e-14770b97be39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e697ea72-e10e-4fed-be8f-8c6455cc3fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e697ea72-e10e-4fed-be8f-8c6455cc3fc8.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -11606,7 +11606,7 @@
         },
         {
             "id": "167ffae5-73d5-5e65-8028-950e4abfbb45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed4a63d-632a-4a3a-b35f-f8e155237d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed4a63d-632a-4a3a-b35f-f8e155237d27.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -11637,7 +11637,7 @@
         },
         {
             "id": "5d279ecc-ddd4-5aa4-9d65-02fb3cdaa639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b7b90-80d4-4cad-af7c-a0b36c590ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b7b90-80d4-4cad-af7c-a0b36c590ca0.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B}.",
             "colours": [],
@@ -11670,7 +11670,7 @@
         },
         {
             "id": "3a7c814b-dcc2-5984-86c3-461b7217a97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db644c-1acf-477d-9c20-f72221f1108a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db644c-1acf-477d-9c20-f72221f1108a.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color.\nWhenever you tap Forbidden Orchard for mana, target opponent creates a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -11701,7 +11701,7 @@
         },
         {
             "id": "272c4bdb-e8d7-5263-8f96-1d49639116a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b093d-a483-4c7d-81b5-9c70c866bbb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b093d-a483-4c7d-81b5-9c70c866bbb1.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G}.",
             "colours": [],
@@ -11734,7 +11734,7 @@
         },
         {
             "id": "d73fac11-44c0-5750-9df7-2a3befa5c76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294b7e06-4758-4590-b1f0-b7f97537218f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294b7e06-4758-4590-b1f0-b7f97537218f.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G}.",
             "colours": [],
@@ -11767,7 +11767,7 @@
         },
         {
             "id": "1eb2ee1e-c0b6-5050-a90f-63daea2bdebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb746aeb-7595-4b45-8ffc-90f220308960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb746aeb-7595-4b45-8ffc-90f220308960.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R}.",
             "colours": [],
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "bb91fb3e-627a-5d88-b22f-f95cfbe2948c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d7237b-6749-4d39-bc69-5185d01e24d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d7237b-6749-4d39-bc69-5185d01e24d4.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -11833,7 +11833,7 @@
         },
         {
             "id": "501a4114-ee5d-55ff-8af1-13e9489ce8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66bacf-ad9a-40c3-a2b7-464be8d4dd24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66bacf-ad9a-40c3-a2b7-464be8d4dd24.jpg?1",
             "name": "Pillar of the Paruns",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a multicolored spell.",
             "colours": [],
@@ -11863,7 +11863,7 @@
         },
         {
             "id": "a3027e70-2e3e-5ded-be51-416c582b4826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c4a77-a458-4493-a35e-6bbb6d88087f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c4a77-a458-4493-a35e-6bbb6d88087f.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R}.",
             "colours": [],
@@ -11896,7 +11896,7 @@
         },
         {
             "id": "1f16e387-647d-5a2c-9570-933171722241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8af7e5a-806b-4264-9010-f497b40a7fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8af7e5a-806b-4264-9010-f497b40a7fb4.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W}.",
             "colours": [],
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "9c18876f-d6cb-5875-833a-e1d63aabaea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511cf93-3443-4e35-8425-a1e2d24a6157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511cf93-3443-4e35-8425-a1e2d24a6157.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U}.",
             "colours": [],
@@ -11962,7 +11962,7 @@
         },
         {
             "id": "bbc08c11-694c-509e-819e-3f515b14c2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309a6684-ecb3-491c-899a-3aa15a51130b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309a6684-ecb3-491c-899a-3aa15a51130b.jpg?1",
             "name": "Cryptic Spires",
             "text": "As you create your deck, circle two of the colors below.\nCryptic Spires enters the battlefield tapped.\n{T}: Add one mana of either of the circled colors.",
             "colours": [],
@@ -11989,7 +11989,7 @@
         },
         {
             "id": "d0d78dd8-cbe2-5387-8433-5ce7e4ef0d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8638c18-f5ea-4e36-9c48-ec1446d0f7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8638c18-f5ea-4e36-9c48-ec1446d0f7a6.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -12029,7 +12029,7 @@
         },
         {
             "id": "691697d5-b4b5-5515-8388-74f1bd72c290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169fcff7-58f2-420b-a5f1-642ad38709b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169fcff7-58f2-420b-a5f1-642ad38709b3.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "f58d9aa7-9a43-5556-ae17-9636e6c7ef15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765fd969-d3da-426a-8bf2-d4e1bb7ae878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765fd969-d3da-426a-8bf2-d4e1bb7ae878.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -12107,7 +12107,7 @@
         },
         {
             "id": "c83d9fb9-922a-50cd-ac0b-59627916983d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b4b6cd-6d0f-4060-b51f-61f481000d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b4b6cd-6d0f-4060-b51f-61f481000d51.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -12143,7 +12143,7 @@
         },
         {
             "id": "1458a72a-e137-5813-8a82-70cb454e3ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc085e9-bbb2-463a-b35c-bee13008a2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc085e9-bbb2-463a-b35c-bee13008a2c6.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "60b71ed3-0e96-57c4-a06a-d816e986cb83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3331a24-e4c0-45ca-9b72-ae14d5cd94eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3331a24-e4c0-45ca-9b72-ae14d5cd94eb.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.",
             "colours": [
@@ -12219,7 +12219,7 @@
         },
         {
             "id": "e129055d-563d-55e5-a33b-9f683dc37d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a595d04e-4cdb-49d1-a323-7b6d1e3ccbe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a595d04e-4cdb-49d1-a323-7b6d1e3ccbe9.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -12255,7 +12255,7 @@
         },
         {
             "id": "757e6ffc-f1ec-5ad2-995d-fd09e392b906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b974f99-28d0-4cd5-87a7-3f9661ddd1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b974f99-28d0-4cd5-87a7-3f9661ddd1b4.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "3ba26d10-99b3-53a3-a36b-ec14a4113a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb79bb-657d-469d-b3f2-381a82891ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb79bb-657d-469d-b3f2-381a82891ccc.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -12329,7 +12329,7 @@
         },
         {
             "id": "c599bdd0-d7fb-5996-8651-4362bc68242b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca736b62-9b02-49bf-8abd-5de6c4bf0ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca736b62-9b02-49bf-8abd-5de6c4bf0ab0.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -12364,7 +12364,7 @@
         },
         {
             "id": "b3fe4fff-90b6-5631-b7db-66c921c33cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08707-1599-4b3f-9be1-363dfe4ecdbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08707-1599-4b3f-9be1-363dfe4ecdbe.jpg?1",
             "name": "Teferi's Protection",
             "text": "Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)\nExile Teferi's Protection.",
             "colours": [
@@ -12399,7 +12399,7 @@
         },
         {
             "id": "9da8789e-40e1-5175-b66f-5278b4e2d840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c9e989-b3fd-43ca-b2a5-d051f3b504b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c9e989-b3fd-43ca-b2a5-d051f3b504b3.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -12435,7 +12435,7 @@
         },
         {
             "id": "106eb1f8-1452-55cd-8bfb-7db43bc5a3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4397224-5e64-4615-8c53-e6672655f2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4397224-5e64-4615-8c53-e6672655f2ad.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -12472,7 +12472,7 @@
         },
         {
             "id": "e6f88c32-1836-5add-8995-9b18d6f7b34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5396b405-6fa0-43d7-a8f6-f64154e95e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5396b405-6fa0-43d7-a8f6-f64154e95e98.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -12507,7 +12507,7 @@
         },
         {
             "id": "d863befe-facd-5a0e-92ae-5468fb4e4f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb51da3a-9058-4817-ae69-d1d02a81b207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb51da3a-9058-4817-ae69-d1d02a81b207.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle.",
             "colours": [
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "a5f55cca-b38c-5e82-bb37-6c2488db16a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456a2f03-8304-4512-804c-76653e30f436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456a2f03-8304-4512-804c-76653e30f436.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value.",
             "colours": [
@@ -12577,7 +12577,7 @@
         },
         {
             "id": "252d5437-fa8e-547f-b4ed-9bde68d37920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99074b05-f252-4626-a96a-6bc286e8d03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99074b05-f252-4626-a96a-6bc286e8d03a.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -12613,7 +12613,7 @@
         },
         {
             "id": "0afff012-e2bd-549d-aa18-ad6f78190cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c8f1c8-2b57-41a3-abeb-77ac7de62fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c8f1c8-2b57-41a3-abeb-77ac7de62fa1.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -12647,7 +12647,7 @@
         },
         {
             "id": "e8d67cfe-48a0-5a71-90a3-140a59d41ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370142f-441b-4e70-bef9-f79e6a877ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370142f-441b-4e70-bef9-f79e6a877ee9.jpg?1",
             "name": "Thought Scour",
             "text": "Target player mills two cards.\nDraw a card.",
             "colours": [
@@ -12681,7 +12681,7 @@
         },
         {
             "id": "b0f2b7f2-459e-5912-93c5-c6e9825ea7f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5587191b-b56a-452d-8a18-1622df83c267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5587191b-b56a-452d-8a18-1622df83c267.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -12717,7 +12717,7 @@
         },
         {
             "id": "7d23e27f-35e5-5324-975c-61e7d854fe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca972d7-fcf8-4ac4-a98b-fffb2fbb4dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca972d7-fcf8-4ac4-a98b-fffb2fbb4dbc.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -12752,7 +12752,7 @@
         },
         {
             "id": "cc50fdf0-d575-5706-8437-8cbf0eb2de6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0163dd21-9f9f-4656-b0b2-7774be0b6ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0163dd21-9f9f-4656-b0b2-7774be0b6ada.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -12787,7 +12787,7 @@
         },
         {
             "id": "05adc052-5d16-5435-a6d4-8e264523673d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599cf02f-47a1-47b4-b67e-8f27fa65c151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599cf02f-47a1-47b4-b67e-8f27fa65c151.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals their hand. You choose a nonland card from it with mana value 3 or less. That player discards that card.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "c2dae913-4061-5f8d-b60c-592c92273005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b359c884-dfbe-4c16-9c83-f9f906db1f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b359c884-dfbe-4c16-9c83-f9f906db1f40.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles.",
             "colours": [
@@ -12856,7 +12856,7 @@
         },
         {
             "id": "4d71fd80-e9df-5945-b64f-cad92328c43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656127b7-21c4-40ce-8fff-5cc3d38398f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656127b7-21c4-40ce-8fff-5cc3d38398f8.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -12890,7 +12890,7 @@
         },
         {
             "id": "edd650f2-9ce5-50eb-b5d5-70c92d7df9bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedcbd3b-7e30-44cf-b9b7-1bb32c11ef67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedcbd3b-7e30-44cf-b9b7-1bb32c11ef67.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -12925,7 +12925,7 @@
         },
         {
             "id": "207d4c0c-f0ef-5e5f-b116-200995f2a3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ba4278-c63e-49b4-bf60-16dfe5c70a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ba4278-c63e-49b4-bf60-16dfe5c70a0b.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -12960,7 +12960,7 @@
         },
         {
             "id": "110e193d-f86b-59f0-a979-fd0615c7576e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fdac35-d709-4078-8205-ad7c79b6644c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fdac35-d709-4078-8205-ad7c79b6644c.jpg?1",
             "name": "Dockside Extortionist",
             "text": "When Dockside Extortionist enters the battlefield, create X Treasure tokens, where X is the number of artifacts and enchantments your opponents control.",
             "colours": [
@@ -12998,7 +12998,7 @@
         },
         {
             "id": "190a854f-6657-59fb-a551-4bf99e4a5905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c8390f-4072-454f-8dc4-174919187a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c8390f-4072-454f-8dc4-174919187a47.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -13032,7 +13032,7 @@
         },
         {
             "id": "6185a1cb-a43f-5ee4-b0ee-7b9b6753f81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9899a8-f5b0-427f-ac87-09fc8afe0f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9899a8-f5b0-427f-ac87-09fc8afe0f23.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "c05a844d-dfe2-5c45-8eff-83ab3d895682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da7322-924c-4018-a38a-89f4ea85d435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da7322-924c-4018-a38a-89f4ea85d435.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -13107,7 +13107,7 @@
         },
         {
             "id": "4d9a74ef-c1e0-518d-955e-1c59da57e8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f10099a-d256-44ec-a7a3-c93b27741d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f10099a-d256-44ec-a7a3-c93b27741d06.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -13144,7 +13144,7 @@
         },
         {
             "id": "a7c8a3fc-9af8-57b0-92f3-6fe75c775509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e99bd-04dc-4bf9-87df-86a810135dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e99bd-04dc-4bf9-87df-86a810135dfe.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "This spell can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -13182,7 +13182,7 @@
         },
         {
             "id": "d9856433-aecc-5b5b-84bf-55b919ce5a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200693d6-7164-4b24-8cff-c1f3e407fea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200693d6-7164-4b24-8cff-c1f3e407fea9.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -13220,7 +13220,7 @@
         },
         {
             "id": "9af7a005-4ba6-5c12-bcb1-a43776649f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e276fb-3af7-444e-b132-1fe9f2e1fd2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e276fb-3af7-444e-b132-1fe9f2e1fd2a.jpg?1",
             "name": "Concordant Crossroads",
             "text": "All creatures have haste.",
             "colours": [
@@ -13257,7 +13257,7 @@
         },
         {
             "id": "8c28db13-d9da-54c2-823d-d99cfe7dd00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf722227-5b90-47e3-9f56-5ba43114c14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf722227-5b90-47e3-9f56-5ba43114c14e.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -13294,7 +13294,7 @@
         },
         {
             "id": "c098afe1-1b41-5f8e-994b-ae4b2121c038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b635f1c-1e65-4aec-af23-e75e49665014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b635f1c-1e65-4aec-af23-e75e49665014.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -13329,7 +13329,7 @@
         },
         {
             "id": "03c7a115-6f8c-5257-aa68-208b2d75a32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dce077-4ecd-406a-9052-05d5485ffa6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dce077-4ecd-406a-9052-05d5485ffa6f.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -13367,7 +13367,7 @@
         },
         {
             "id": "c695ef98-6a16-51c2-a998-308adfcd080a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bbf009-0798-4d8b-b375-6d6fde975c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bbf009-0798-4d8b-b375-6d6fde975c34.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13401,7 +13401,7 @@
         },
         {
             "id": "5a55e755-8812-5599-bcb8-c97d1cb3b950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f4ff8-efd2-4d22-8491-54bd6e73006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f4ff8-efd2-4d22-8491-54bd6e73006c.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "f114e89e-fafa-5eb9-b750-efa6b0391d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6031e3f0-0181-4785-9016-574823985a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6031e3f0-0181-4785-9016-574823985a69.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -13477,7 +13477,7 @@
         },
         {
             "id": "02255d52-a851-59b4-9177-0fabc9eb6f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78efee5c-970c-4f9b-9a6b-96ef3e79caaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78efee5c-970c-4f9b-9a6b-96ef3e79caaa.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G}.",
             "colours": [
@@ -13516,7 +13516,7 @@
         },
         {
             "id": "b2c7dd2e-903f-51ab-8cbe-c6523b4e44ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033e6145-cf40-4fa8-98a4-ed8b5e8a66ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033e6145-cf40-4fa8-98a4-ed8b5e8a66ab.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -13556,7 +13556,7 @@
         },
         {
             "id": "5d573f4f-1a13-59f4-b39c-be30eacb45f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a6236c-0148-48de-be63-6ddbb34f9a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a6236c-0148-48de-be63-6ddbb34f9a2a.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "This spell can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "dcf68e3a-76b9-514a-b01e-490f5f375d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d129496d-3ae0-4e61-9e20-6259c0754b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d129496d-3ae0-4e61-9e20-6259c0754b9e.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "3095c89b-909d-5203-849e-0f4d9a12c2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d6f1ff-7514-4fed-80e9-fd912e21bd26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d6f1ff-7514-4fed-80e9-fd912e21bd26.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player mills ten cards.",
             "colours": [
@@ -13677,7 +13677,7 @@
         },
         {
             "id": "ab0fd9eb-fb14-58e1-b39a-07973bb9d859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0143eb00-b054-4741-8423-66eed0362a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0143eb00-b054-4741-8423-66eed0362a30.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -13719,7 +13719,7 @@
         },
         {
             "id": "86ab57f0-4d43-55e9-8b58-78d9ec3151b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356110b1-9cfe-420c-963a-c12469786e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356110b1-9cfe-420c-963a-c12469786e40.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -13759,7 +13759,7 @@
         },
         {
             "id": "e5524868-2e11-56d1-8ab6-04fe70ece2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8bdd10-0bdc-4339-bd84-b540606438d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8bdd10-0bdc-4339-bd84-b540606438d6.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to any target.",
             "colours": [
@@ -13796,7 +13796,7 @@
         },
         {
             "id": "cdc3a0d2-3c56-50c5-84c1-39d3d985c8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9975663-3038-4c72-b29c-65635dbe36bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9975663-3038-4c72-b29c-65635dbe36bb.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "Dethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nOther creatures you control have dethrone.\nWhenever a creature you control with a +1/+1 counter on it dies, return that card to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -13840,7 +13840,7 @@
         },
         {
             "id": "2f85b076-20ba-55d2-b174-6f8061bcb90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32086e-47a1-4088-a36b-85025daee5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32086e-47a1-4088-a36b-85025daee5fe.jpg?1",
             "name": "The Mimeoplasm",
             "text": "As The Mimeoplasm enters the battlefield, you may exile two creature cards from graveyards. If you do, it enters the battlefield as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "931b2a2d-20ec-563d-9f58-d63e7be14e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7d02a-7b83-4444-ac65-1661637183ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7d02a-7b83-4444-ac65-1661637183ee.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "4b701105-1e43-58b4-a45f-5703a0d9dd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dd7473-9baa-4410-aeab-3373f3a5ffb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dd7473-9baa-4410-aeab-3373f3a5ffb9.jpg?1",
             "name": "Privileged Position",
             "text": "Other permanents you control have hexproof.",
             "colours": [
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "530f4531-fd66-5f04-947f-db8fd7adfcc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035fa74-7e0d-4bcc-8bd7-4ae0c33db317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035fa74-7e0d-4bcc-8bd7-4ae0c33db317.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -14003,7 +14003,7 @@
         },
         {
             "id": "9d5b6d08-f88d-597e-938d-4373f78a7564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a2deb-034c-4ed8-83cd-b71c2ca36cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a2deb-034c-4ed8-83cd-b71c2ca36cea.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -14047,7 +14047,7 @@
         },
         {
             "id": "38fdf18d-942a-5676-bb42-0aec7803a369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b760cc-800a-48a3-97d9-316e1eeafd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b760cc-800a-48a3-97d9-316e1eeafd4c.jpg?1",
             "name": "Supreme Verdict",
             "text": "This spell can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -14084,7 +14084,7 @@
         },
         {
             "id": "f6d65518-322a-5cf1-a08c-fb9b71fd306f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f3c523-09dc-4f2a-9bd9-7614e061de28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f3c523-09dc-4f2a-9bd9-7614e061de28.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -14120,7 +14120,7 @@
         },
         {
             "id": "c495d485-7a34-5061-a2df-ac27c700a813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec17fa3c-9033-4eab-a236-3f0068595536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec17fa3c-9033-4eab-a236-3f0068595536.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -14157,7 +14157,7 @@
         },
         {
             "id": "5e506e06-9d1a-572f-b440-516be17b177b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e26409-430b-419b-8cd2-1bce007f12d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e26409-430b-419b-8cd2-1bce007f12d6.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with mana value equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -14188,7 +14188,7 @@
         },
         {
             "id": "07025bd9-6da4-53f4-b67e-f87429dcf3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66202ab-cd10-4116-8e22-05b45a45fa85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66202ab-cd10-4116-8e22-05b45a45fa85.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -14221,7 +14221,7 @@
         },
         {
             "id": "05bb86bb-98b7-5338-900f-c630a865b43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dccb71b-a25a-4ef8-b2ab-716fd38dcc0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dccb71b-a25a-4ef8-b2ab-716fd38dcc0b.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -14252,7 +14252,7 @@
         },
         {
             "id": "ce333667-b107-5333-9dad-f18b707f623b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a941b1f6-9f18-4c9e-993f-bf8f52bd6f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a941b1f6-9f18-4c9e-993f-bf8f52bd6f53.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -14283,7 +14283,7 @@
         },
         {
             "id": "fc1d7d9a-4de1-50dc-af70-aa308b22a3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c801e-b429-45d3-896e-289ec0497db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c801e-b429-45d3-896e-289ec0497db0.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -14314,7 +14314,7 @@
         },
         {
             "id": "1d49a1c0-f25f-53e4-b7b8-4442eed8837d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043de2ce-9ee9-414f-9385-6e5260173988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043de2ce-9ee9-414f-9385-6e5260173988.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -14345,7 +14345,7 @@
         },
         {
             "id": "b0e65a6a-e443-5c3f-90ea-404004cf6d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e997845-be0e-4130-8d07-5d2963ce8a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e997845-be0e-4130-8d07-5d2963ce8a5e.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -14376,7 +14376,7 @@
         },
         {
             "id": "cd5a990a-e06b-55ee-9c0b-c9b0c54490a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696792c7-245a-437e-b495-477b177773ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696792c7-245a-437e-b495-477b177773ba.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -14407,7 +14407,7 @@
         },
         {
             "id": "ecc44e22-b39e-5528-8f84-10a443bec6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91adeef-c1d5-4b14-9d79-ddd0dc035786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91adeef-c1d5-4b14-9d79-ddd0dc035786.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may cast spells as though they had flash.",
             "colours": [],
@@ -14438,7 +14438,7 @@
         },
         {
             "id": "93d56685-b571-5240-90d1-0addb9919628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a944c2-0711-4e0c-9cd5-cfd5ad5f8266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a944c2-0711-4e0c-9cd5-cfd5ad5f8266.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U}.",
             "colours": [],
@@ -14471,7 +14471,7 @@
         },
         {
             "id": "c4b7c3cf-5421-594a-ae49-d5fce862cec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cdfa12-e933-4c64-b7d5-c856a6a054ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cdfa12-e933-4c64-b7d5-c856a6a054ff.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W}.",
             "colours": [],
@@ -14504,7 +14504,7 @@
         },
         {
             "id": "749ccb78-b54f-520e-ab79-80d56cb90b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4222863c-c851-4ef7-b29f-7111b05bb843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4222863c-c851-4ef7-b29f-7111b05bb843.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -14535,7 +14535,7 @@
         },
         {
             "id": "06546c18-ffe5-5148-82f3-5f3049ee1e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869ec7dc-dbf5-4ed4-a368-328da384ecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869ec7dc-dbf5-4ed4-a368-328da384ecae.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -14566,7 +14566,7 @@
         },
         {
             "id": "febaa4c7-ff25-5d3a-a365-3412a7216b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7761b314-844a-4ade-a584-f37712cd2293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7761b314-844a-4ade-a584-f37712cd2293.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B}.",
             "colours": [],
@@ -14599,7 +14599,7 @@
         },
         {
             "id": "6e1332bf-be25-5940-9cc4-7129b2aa5d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dd80b6-28ff-488a-bc39-fb661da52e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dd80b6-28ff-488a-bc39-fb661da52e30.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color.\nWhenever you tap Forbidden Orchard for mana, target opponent creates a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -14630,7 +14630,7 @@
         },
         {
             "id": "4e3efb88-566e-5c3d-af4d-59816b4679c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6729320-d557-4860-80e4-32afcf6aad34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6729320-d557-4860-80e4-32afcf6aad34.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G}.",
             "colours": [],
@@ -14663,7 +14663,7 @@
         },
         {
             "id": "dfe56f31-eb1a-5f3f-a2eb-c11a86137b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380f74f-aa76-42dc-9596-92d651e1c1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380f74f-aa76-42dc-9596-92d651e1c1f6.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G}.",
             "colours": [],
@@ -14696,7 +14696,7 @@
         },
         {
             "id": "ad642426-341d-52cd-a155-744be7a8fdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891067e9-dd89-4f0e-9ef8-694a831962aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891067e9-dd89-4f0e-9ef8-694a831962aa.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R}.",
             "colours": [],
@@ -14729,7 +14729,7 @@
         },
         {
             "id": "7909a9a9-ba17-5e1c-b923-99a0a15b7364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ee89c5-5504-4b9b-b70e-4b48e4c66c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ee89c5-5504-4b9b-b70e-4b48e4c66c76.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -14762,7 +14762,7 @@
         },
         {
             "id": "5c169133-2453-5415-b397-4ba9233ef7a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197d420-fc69-4672-90f0-2264f35d1c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197d420-fc69-4672-90f0-2264f35d1c61.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R}.",
             "colours": [],
@@ -14795,7 +14795,7 @@
         },
         {
             "id": "1e1887ca-10b3-569a-87e7-fbdef5b988dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41907913-2308-4d76-b737-216088ce0d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41907913-2308-4d76-b737-216088ce0d57.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W}.",
             "colours": [],
@@ -14828,7 +14828,7 @@
         },
         {
             "id": "7eac1a36-d22d-5a9e-b293-e3468fb97d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e1b11-1796-4fec-bb1c-111b0f9768f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e1b11-1796-4fec-bb1c-111b0f9768f7.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U}.",
             "colours": [],
@@ -14861,7 +14861,7 @@
         },
         {
             "id": "1ec929f1-c791-5dfe-b3a3-1b29a165ea72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c632e1-faa8-40f9-a5b7-8773644516fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c632e1-faa8-40f9-a5b7-8773644516fa.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -14896,7 +14896,7 @@
         },
         {
             "id": "bc7929be-9502-5450-92bf-f154bf326456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4358e0-9dad-48dd-aad0-d4a3ab4766c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4358e0-9dad-48dd-aad0-d4a3ab4766c7.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -14931,7 +14931,7 @@
         },
         {
             "id": "1e2054ca-3739-5e40-be61-38d01bba937c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942c0703-f745-40bb-b894-8a64e854cd64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942c0703-f745-40bb-b894-8a64e854cd64.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -14966,7 +14966,7 @@
         },
         {
             "id": "11f9b6b3-d54f-5b63-8b3b-eb0bae59608d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68a7e08-6af2-4eab-afd4-7eb9db431e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68a7e08-6af2-4eab-afd4-7eb9db431e9c.jpg?1",
             "name": "Divine Visitation",
             "text": "If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.",
             "colours": [
@@ -14999,7 +14999,7 @@
         },
         {
             "id": "f3fe7174-21b1-54e4-ba62-7315e7184662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ac0230-151f-4079-9963-42b123e4b3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ac0230-151f-4079-9963-42b123e4b3fe.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.",
             "colours": [
@@ -15038,7 +15038,7 @@
         },
         {
             "id": "6c1ee181-714f-5420-89aa-4b26e0e7f7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f882a1-a34a-4319-bb75-c11a1193e8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f882a1-a34a-4319-bb75-c11a1193e8e8.jpg?1",
             "name": "Leonin Arbiter",
             "text": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "colours": [
@@ -15074,7 +15074,7 @@
         },
         {
             "id": "fe5f6fe7-fc59-58fd-bfed-582bc82b3688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc0779-8c92-404d-b959-db9f4bd63947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc0779-8c92-404d-b959-db9f4bd63947.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -15112,7 +15112,7 @@
         },
         {
             "id": "e7bf29be-534e-53f8-ad96-f04f8d61d0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8208ec-5049-4f9b-a5ea-89097cb1d141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8208ec-5049-4f9b-a5ea-89097cb1d141.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "9cd71216-938a-515a-b524-7d4eae442f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38befc96-938e-4b7f-97da-ed67ccd8900b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38befc96-938e-4b7f-97da-ed67ccd8900b.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -15183,7 +15183,7 @@
         },
         {
             "id": "2c871ee7-04bf-53a2-b818-1776bf6bdb9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8ab20-e402-48d9-8a39-7cf09d333374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8ab20-e402-48d9-8a39-7cf09d333374.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -15218,7 +15218,7 @@
         },
         {
             "id": "e171d406-a546-57a4-a8a5-1711aa6a8213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3b9aac-c5d5-4284-9c7c-67b23748fa45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3b9aac-c5d5-4284-9c7c-67b23748fa45.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -15252,7 +15252,7 @@
         },
         {
             "id": "be0745d1-0a66-53e3-9ec2-19c321916c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1802943c-07cc-48bb-a861-f18cb5f2b0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1802943c-07cc-48bb-a861-f18cb5f2b0ae.jpg?1",
             "name": "Teferi's Protection",
             "text": "Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)\nExile Teferi's Protection.",
             "colours": [
@@ -15286,7 +15286,7 @@
         },
         {
             "id": "2d1df6ec-03be-5af2-9fe2-8ac9b3168e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ac8a0-9f1a-4ece-a1b3-b175bb1e8486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ac8a0-9f1a-4ece-a1b3-b175bb1e8486.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, put it into your hand, then shuffle. Activate only if an opponent controls more lands than you.",
             "colours": [
@@ -15324,7 +15324,7 @@
         },
         {
             "id": "3a11e7bd-85a0-5f2d-a9e2-422c99ac05b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebda0fb2-ba10-46e0-ab9d-5a2736553b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebda0fb2-ba10-46e0-ab9d-5a2736553b5d.jpg?1",
             "name": "As Foretold",
             "text": "At the beginning of your upkeep, put a time counter on As Foretold.\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast with mana value X or less, where X is the number of time counters on As Foretold.",
             "colours": [
@@ -15357,7 +15357,7 @@
         },
         {
             "id": "bf3e52bb-4017-5760-8db6-838ee858421d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fddeced-9d04-4b4c-bf3f-e9add96f4f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fddeced-9d04-4b4c-bf3f-e9add96f4f5a.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -15393,7 +15393,7 @@
         },
         {
             "id": "6514ab17-e04a-555c-aaab-9fb79c1ff5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc1a7bc-03fe-43ae-97b2-f0a63bae7c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc1a7bc-03fe-43ae-97b2-f0a63bae7c74.jpg?1",
             "name": "Disciple of the Ring",
             "text": "{1}, Exile an instant or sorcery card from your graveyard: Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Disciple of the Ring gets +1/+1 until end of turn.\n\u2022 Tap target creature.\n\u2022 Untap target creature.",
             "colours": [
@@ -15429,7 +15429,7 @@
         },
         {
             "id": "3ccbf5e8-fc80-5256-956b-6da4542397ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d840284-ce56-4e4f-822f-8b237a261d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d840284-ce56-4e4f-822f-8b237a261d1e.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -15463,7 +15463,7 @@
         },
         {
             "id": "541a2ae4-d3a0-5d30-8dce-9e8c17c3dc64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a69886-8fc7-4f0e-b43e-afa4fc1a0ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a69886-8fc7-4f0e-b43e-afa4fc1a0ec5.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle.",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "46d6c1ec-09d5-598a-b2ff-dc0a3b8d72d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b178b9-c71b-4f4b-ac0d-ae2a16a19410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b178b9-c71b-4f4b-ac0d-ae2a16a19410.jpg?1",
             "name": "Kederekt Leviathan",
             "text": "When Kederekt Leviathan enters the battlefield, return all other nonland permanents to their owners' hands.\nUnearth {6}{U} ({6}{U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -15532,7 +15532,7 @@
         },
         {
             "id": "2d80ee0b-285b-5a76-88b4-e80660c58c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc7d280-31be-48b8-aa1e-8de676ca01ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc7d280-31be-48b8-aa1e-8de676ca01ba.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value.",
             "colours": [
@@ -15566,7 +15566,7 @@
         },
         {
             "id": "57b7d10a-f859-587a-8563-3bf5832354bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eac20be-9c39-4808-a8bc-d89fe7991dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eac20be-9c39-4808-a8bc-d89fe7991dd7.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -15599,7 +15599,7 @@
         },
         {
             "id": "3b3e5976-cd07-5f58-a3f5-082002336e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aaaffa-4518-466b-9157-7cd41ac28fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aaaffa-4518-466b-9157-7cd41ac28fcf.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "dcac458a-9e3c-5856-9584-f94777a60449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68409196-abd1-4ac5-87d0-72cb1e4a68fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68409196-abd1-4ac5-87d0-72cb1e4a68fd.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -15675,7 +15675,7 @@
         },
         {
             "id": "e58c9de1-7a3e-5cda-9450-f3cba35de613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0b3575-c7bd-411d-9aa4-3a986b7876a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0b3575-c7bd-411d-9aa4-3a986b7876a9.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
             "colours": [
@@ -15711,7 +15711,7 @@
         },
         {
             "id": "f19a8eab-60fa-5ff2-88e2-35c9fbbdfde0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c7ad21-2f01-4f9c-8631-7d7e17169ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c7ad21-2f01-4f9c-8631-7d7e17169ce4.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -15745,7 +15745,7 @@
         },
         {
             "id": "d67721f8-6719-54d0-ade6-70131c927ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6e96a0-5c2d-44f4-9191-48a6bd27536e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6e96a0-5c2d-44f4-9191-48a6bd27536e.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -15780,7 +15780,7 @@
         },
         {
             "id": "0ee631d7-2b00-56c9-ab26-87394e91cdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef9e68-0d77-4b56-b03c-b520f4af4c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef9e68-0d77-4b56-b03c-b520f4af4c01.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -15814,7 +15814,7 @@
         },
         {
             "id": "f93cadb6-5cd4-5b3b-a374-c44c57cd1c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50269303-0bd9-474e-bd16-e0d13a5cbb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50269303-0bd9-474e-bd16-e0d13a5cbb74.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -15853,7 +15853,7 @@
         },
         {
             "id": "de1692f6-ee16-51c5-b275-dfa2cb878753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870c962b-2c0d-4b17-b951-1a73f17c65f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870c962b-2c0d-4b17-b951-1a73f17c65f7.jpg?1",
             "name": "Necrotic Ooze",
             "text": "As long as Necrotic Ooze is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
             "colours": [
@@ -15888,7 +15888,7 @@
         },
         {
             "id": "33172601-a444-5d49-814c-f997a51755e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971631cc-f2e1-4eaf-8c23-71707489bdfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971631cc-f2e1-4eaf-8c23-71707489bdfc.jpg?1",
             "name": "Ob Nixilis, Unshackled",
             "text": "Flying, trample\nWhenever an opponent searches their library, that player sacrifices a creature and loses 10 life.\nWhenever another creature dies, put a +1/+1 counter on Ob Nixilis, Unshackled.",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "8a5b964f-b146-5894-8ef5-8c3a32191392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961ec8de-1029-489c-a8a3-283b5f2bf77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961ec8de-1029-489c-a8a3-283b5f2bf77c.jpg?1",
             "name": "Oona's Prowler",
             "text": "Flying\nDiscard a card: Oona's Prowler gets -2/-0 until end of turn. Any player may activate this ability.",
             "colours": [
@@ -15961,7 +15961,7 @@
         },
         {
             "id": "05491552-acdc-5d47-90dd-c5c85ce3a643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67fec89d-a66b-460f-b8dd-96e8c97d8d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67fec89d-a66b-460f-b8dd-96e8c97d8d50.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "dd3ecd49-b135-5288-a845-cf7c9e93bf0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c810eb-1402-428b-850a-72d81f880d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c810eb-1402-428b-850a-72d81f880d8f.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -16033,7 +16033,7 @@
         },
         {
             "id": "cc206399-12a6-5c5c-be68-c7b550b6ea19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355dcac7-120b-4c52-b077-bf36c41c579d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355dcac7-120b-4c52-b077-bf36c41c579d.jpg?1",
             "name": "Abbot of Keral Keep",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Abbot of Keral Keep enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -16069,7 +16069,7 @@
         },
         {
             "id": "b27447f4-6fe2-58c2-8ce4-5b03b8e4965a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9136885-785f-4b71-a834-d0eb1d2a042a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9136885-785f-4b71-a834-d0eb1d2a042a.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -16109,7 +16109,7 @@
         },
         {
             "id": "83074ae3-ef6d-59d8-9b0e-d8139d1377a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1702e178-f67c-4fe8-9dc9-99247f5b9f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1702e178-f67c-4fe8-9dc9-99247f5b9f96.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "e2cdbfd9-096f-5fdc-8418-ef3bafe2034d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d606c86-ea7a-49c8-9afb-778265063113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d606c86-ea7a-49c8-9afb-778265063113.jpg?1",
             "name": "Backdraft Hellkite",
             "text": "Flying\nWhenever Backdraft Hellkite attacks, each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
             "colours": [
@@ -16178,7 +16178,7 @@
         },
         {
             "id": "09ac00a3-bf04-555e-afa3-0d25c2e56112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61828058-6ad2-4788-adfd-a898e25974a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61828058-6ad2-4788-adfd-a898e25974a3.jpg?1",
             "name": "Bedlam Reveler",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -16214,7 +16214,7 @@
         },
         {
             "id": "b16456b6-9571-50de-bcb1-78b382b4fab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eebe1a2-5723-4c61-bdb8-4167c244bf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eebe1a2-5723-4c61-bdb8-4167c244bf6a.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -16248,7 +16248,7 @@
         },
         {
             "id": "3db882c7-a3ab-53b7-9e00-652609755b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eea863e-ebc0-4c8e-b464-80b7dbabe30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eea863e-ebc0-4c8e-b464-80b7dbabe30b.jpg?1",
             "name": "Dockside Extortionist",
             "text": "When Dockside Extortionist enters the battlefield, create X Treasure tokens, where X is the number of artifacts and enchantments your opponents control.",
             "colours": [
@@ -16285,7 +16285,7 @@
         },
         {
             "id": "075ae136-f694-5b73-976f-db1fa3e21405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc93bbd-db0d-47d2-a079-186a78224136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc93bbd-db0d-47d2-a079-186a78224136.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate only if Greater Gargadon is suspended.",
             "colours": [
@@ -16320,7 +16320,7 @@
         },
         {
             "id": "11fc95b1-f4aa-5afe-ae7d-3bc918e49b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab0dc75-e883-4428-b65a-bbbc582b3c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab0dc75-e883-4428-b65a-bbbc582b3c97.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -16357,7 +16357,7 @@
         },
         {
             "id": "aefa405d-c42a-5944-aefe-feac51ff9c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af570ca5-4123-4043-a2fc-8b3a7bdfdf38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af570ca5-4123-4043-a2fc-8b3a7bdfdf38.jpg?1",
             "name": "Twinflame",
             "text": "Strive \u2014 This spell costs {2}{R} more to cast for each target beyond the first.\nChoose any number of target creatures you control. For each of them, create a token that's a copy of that creature, except it has haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -16390,7 +16390,7 @@
         },
         {
             "id": "4459cfd5-d632-5298-8452-1dd22b5b6540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2af40-f20b-4f78-8ef5-ed33e6f0b835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2af40-f20b-4f78-8ef5-ed33e6f0b835.jpg?1",
             "name": "Warrior's Oath",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -16423,7 +16423,7 @@
         },
         {
             "id": "fab78aec-1c4b-525c-a166-bcfec63fc359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51661771-f654-418a-8ef9-11b651fce97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51661771-f654-418a-8ef9-11b651fce97c.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "This spell can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -16460,7 +16460,7 @@
         },
         {
             "id": "2ac6ca11-7b22-5b34-af27-81ec8947fa01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acde10-c524-428e-b406-23d6644295d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acde10-c524-428e-b406-23d6644295d5.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -16497,7 +16497,7 @@
         },
         {
             "id": "fb66c0b4-b14a-55a9-86ee-88225d3c7e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e99da13-fecb-4468-8786-146be83052c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e99da13-fecb-4468-8786-146be83052c0.jpg?1",
             "name": "Concordant Crossroads",
             "text": "All creatures have haste.",
             "colours": [
@@ -16533,7 +16533,7 @@
         },
         {
             "id": "cb276905-3228-50d7-97ff-3ae871fcc596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df9df79-981f-4b45-afd0-00d2e97c958b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df9df79-981f-4b45-afd0-00d2e97c958b.jpg?1",
             "name": "Food Chain",
             "text": "Exile a creature you control: Add X mana of any one color, where X is 1 plus the exiled creature's mana value. Spend this mana only to cast creature spells.",
             "colours": [
@@ -16566,7 +16566,7 @@
         },
         {
             "id": "30da076a-8487-5a2b-899a-bb126c88af08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586fdc7a-add9-4ed6-88f6-188061647c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586fdc7a-add9-4ed6-88f6-188061647c31.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with mana value X or less, put it onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -16599,7 +16599,7 @@
         },
         {
             "id": "fac07cac-d394-5de6-b433-35f6c56d1d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a4076-d5cf-494f-bf78-cbe8a689681e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a4076-d5cf-494f-bf78-cbe8a689681e.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -16633,7 +16633,7 @@
         },
         {
             "id": "1fdd7f64-cb77-59e3-97f8-363e8a2a3c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a70b17-281a-4f36-ba5e-c2f0d02af848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a70b17-281a-4f36-ba5e-c2f0d02af848.jpg?1",
             "name": "Impervious Greatwurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
             "colours": [
@@ -16668,7 +16668,7 @@
         },
         {
             "id": "bbcb921f-d3a9-5601-a955-cb7a687573cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fdbc1-4180-493c-8e99-5bee56647080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fdbc1-4180-493c-8e99-5bee56647080.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -16705,7 +16705,7 @@
         },
         {
             "id": "13cfd2af-2eb6-59f5-8eda-c6ab26840812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235415e7-c900-418c-8848-c70db24e03fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235415e7-c900-418c-8848-c70db24e03fd.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -16743,7 +16743,7 @@
         },
         {
             "id": "2c984d9b-c6dd-5383-b70e-49154205cf04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbd6337-784c-4400-ac42-32150bd7fcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbd6337-784c-4400-ac42-32150bd7fcc6.jpg?1",
             "name": "Splinterfright",
             "text": "Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, mill two cards.",
             "colours": [
@@ -16778,7 +16778,7 @@
         },
         {
             "id": "166a9f6c-7e93-54ce-b393-32dc9fd8ac16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df01c9a-5d2c-4391-99a3-f10e404b7133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df01c9a-5d2c-4391-99a3-f10e404b7133.jpg?1",
             "name": "Abzan Ascendancy",
             "text": "When Abzan Ascendancy enters the battlefield, put a +1/+1 counter on each creature you control.\nWhenever a nontoken creature you control dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -16815,7 +16815,7 @@
         },
         {
             "id": "2dea8d12-124b-557f-b170-d4e6ec2a0384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6a8db-d855-47c4-867f-349a3260010b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6a8db-d855-47c4-867f-349a3260010b.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "+1: Draw a card, then put a card from your hand on top of your library.\n\u22121: Exile another target permanent you own, then return it to the battlefield under your control.\n\u22126: Choose left or right. Each player gains control of all nonland permanents other than Aminatou, the Fateshifter controlled by the next player in the chosen direction.\nAminatou, the Fateshifter can be your commander.",
             "colours": [
@@ -16856,7 +16856,7 @@
         },
         {
             "id": "ad3e0cf2-4dbe-5205-b5f6-bd36f01d6968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7b04-cfab-44d9-929a-3c106b29471a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7b04-cfab-44d9-929a-3c106b29471a.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -16891,7 +16891,7 @@
         },
         {
             "id": "39b254ab-6bad-5da2-b5c3-228959111547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924e9db3-3f7b-4e07-b523-5ec236f99681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924e9db3-3f7b-4e07-b523-5ec236f99681.jpg?1",
             "name": "Animar, Soul of Elements",
             "text": "Protection from white and from black\nWhenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.\nCreature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.",
             "colours": [
@@ -16932,7 +16932,7 @@
         },
         {
             "id": "a1188f89-4fa6-592b-9179-6099ef9c9d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffd3512-2328-41c7-9c37-7eeda8fa127f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffd3512-2328-41c7-9c37-7eeda8fa127f.jpg?1",
             "name": "Arjun, the Shifting Flame",
             "text": "Flying\nWhenever you cast a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "ae03bbc8-8c9e-550a-ad99-f2739fc97ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f961e5d-2fd6-4d13-90fa-b8da36ab3785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f961e5d-2fd6-4d13-90fa-b8da36ab3785.jpg?1",
             "name": "Ashen Rider",
             "text": "Flying\nWhen Ashen Rider enters the battlefield or dies, exile target permanent.",
             "colours": [
@@ -17009,7 +17009,7 @@
         },
         {
             "id": "bbdc21d3-0a62-58f0-9958-09c9fd6bc612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235b41c7-1e22-42e8-9ea1-a3610576dc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235b41c7-1e22-42e8-9ea1-a3610576dc3a.jpg?1",
             "name": "Ashenmoor Liege",
             "text": "Other black creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\nWhenever Ashenmoor Liege becomes the target of a spell or ability an opponent controls, that player loses 4 life.",
             "colours": [
@@ -17047,7 +17047,7 @@
         },
         {
             "id": "ec1c0bd6-635c-5d5c-911d-eab33d2f103f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885c728-67a9-4f8c-943d-1dca22b9d8f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885c728-67a9-4f8c-943d-1dca22b9d8f9.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -17083,7 +17083,7 @@
         },
         {
             "id": "7748d310-ff93-5929-a040-c9d0965e0096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ff7b-04c7-415a-835b-ae9886f172df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ff7b-04c7-415a-835b-ae9886f172df.jpg?1",
             "name": "Atarka's Command",
             "text": "Choose two \u2014\n\u2022 Your opponents can't gain life this turn.\n\u2022 Atarka's Command deals 3 damage to each opponent.\n\u2022 You may put a land card from your hand onto the battlefield.\n\u2022 Creatures you control get +1/+1 and gain reach until end of turn.",
             "colours": [
@@ -17118,7 +17118,7 @@
         },
         {
             "id": "8023c394-3f9d-5bb7-97e3-f7cf234b7348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5ac70-cc49-4520-8076-3df237fe7cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5ac70-cc49-4520-8076-3df237fe7cd8.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "{2}, {T}: Create a 0/1 green Egg creature token with defender.\nWhenever an Egg you control dies, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -17160,7 +17160,7 @@
         },
         {
             "id": "cff5c1bf-758b-5f4d-9c1d-12e46b1f02be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd984e2c-7145-4300-8358-ac72e2d16e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd984e2c-7145-4300-8358-ac72e2d16e75.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia, the Warleader attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -17199,7 +17199,7 @@
         },
         {
             "id": "d63b0cf5-ecb2-52ad-8c58-1b36dacbf3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a8e3de-f953-4ce5-9864-03cfa9e902b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a8e3de-f953-4ce5-9864-03cfa9e902b0.jpg?1",
             "name": "Balefire Liege",
             "text": "Other red creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nWhenever you cast a red spell, Balefire Liege deals 3 damage to target player or planeswalker.\nWhenever you cast a white spell, you gain 3 life.",
             "colours": [
@@ -17237,7 +17237,7 @@
         },
         {
             "id": "75063531-5110-5b7a-a2ad-9b190db52f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8da744-99ef-4f67-82f6-c84a594a4a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8da744-99ef-4f67-82f6-c84a594a4a5f.jpg?1",
             "name": "Boartusk Liege",
             "text": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
             "colours": [
@@ -17275,7 +17275,7 @@
         },
         {
             "id": "e4f9d90c-a6eb-51f4-9930-06520951164e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a1e2a-37db-4575-ad63-3de7e664ab33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a1e2a-37db-4575-ad63-3de7e664ab33.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -17311,7 +17311,7 @@
         },
         {
             "id": "4adbb05b-913a-5113-995b-561245adab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee37f07d-e420-431e-98be-4a68e0416a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee37f07d-e420-431e-98be-4a68e0416a1d.jpg?1",
             "name": "Child of Alara",
             "text": "Trample\nWhen Child of Alara dies, destroy all nonland permanents. They can't be regenerated.",
             "colours": [
@@ -17356,7 +17356,7 @@
         },
         {
             "id": "59e9564a-c603-5134-a07e-422eca0ab87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f5a635-1ebc-4345-84ab-5d6964a32778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f5a635-1ebc-4345-84ab-5d6964a32778.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may create a 1/1 black and green Worm creature token.",
             "colours": [
@@ -17393,7 +17393,7 @@
         },
         {
             "id": "036b8e20-524b-5293-8265-254bed81e798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121ea9e6-aebd-4053-9104-339a47a1430a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121ea9e6-aebd-4053-9104-339a47a1430a.jpg?1",
             "name": "Dack's Duplicate",
             "text": "You may have Dack's Duplicate enter the battlefield as a copy of any creature on the battlefield, except it has haste and dethrone. (Whenever it attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)",
             "colours": [
@@ -17430,7 +17430,7 @@
         },
         {
             "id": "597cb97c-154d-5173-a5c7-168fbf0a842a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85973-b1de-4e7b-816b-fcc0f241a884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85973-b1de-4e7b-816b-fcc0f241a884.jpg?1",
             "name": "Dauntless Escort",
             "text": "Sacrifice Dauntless Escort: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -17468,7 +17468,7 @@
         },
         {
             "id": "b419c566-fef7-5f6f-bddf-8d91a40f98b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227c96a-14e1-479b-8e78-6d335394ad10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227c96a-14e1-479b-8e78-6d335394ad10.jpg?1",
             "name": "Deathbringer Liege",
             "text": "Other white creatures you control get +1/+1.\nOther black creatures you control get +1/+1.\nWhenever you cast a white spell, you may tap target creature.\nWhenever you cast a black spell, you may destroy target creature if it's tapped.",
             "colours": [
@@ -17505,7 +17505,7 @@
         },
         {
             "id": "b907a771-c0ca-5e00-97b5-dd88a4b85d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e221061-7317-4cac-a909-610533c06b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e221061-7317-4cac-a909-610533c06b68.jpg?1",
             "name": "Doran, the Siege Tower",
             "text": "Each creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -17547,7 +17547,7 @@
         },
         {
             "id": "64b3d3c5-1bf5-5b40-a585-4398fb1b4074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22562492-f77e-4505-81cd-84e473822cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22562492-f77e-4505-81cd-84e473822cdb.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "This spell can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -17588,7 +17588,7 @@
         },
         {
             "id": "48999ab4-8e2a-5706-8fb9-20e2ae27d77e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7633a9c0-ab4b-4955-888c-3581de297830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7633a9c0-ab4b-4955-888c-3581de297830.jpg?1",
             "name": "Dragonlord Silumgar",
             "text": "Flying, deathtouch\nWhen Dragonlord Silumgar enters the battlefield, gain control of target creature or planeswalker for as long as you control Dragonlord Silumgar.",
             "colours": [
@@ -17628,7 +17628,7 @@
         },
         {
             "id": "5d6b4182-f4ed-5493-a7ca-3879030db617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43fffd6-51a1-4a9c-b4f1-86354382aa63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43fffd6-51a1-4a9c-b4f1-86354382aa63.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying, double strike, lifelink\nWhenever you gain life, draw a card.",
             "colours": [
@@ -17665,7 +17665,7 @@
         },
         {
             "id": "bfcf0a50-e2ae-5a22-ad6d-6a290b820a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d0d2a-4984-47f9-b791-4055c8298ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d0d2a-4984-47f9-b791-4055c8298ac1.jpg?1",
             "name": "Dromoka's Command",
             "text": "Choose two \u2014\n\u2022 Prevent all damage target instant or sorcery spell would deal this turn.\n\u2022 Target player sacrifices an enchantment.\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -17700,7 +17700,7 @@
         },
         {
             "id": "54030e70-d578-53a0-9c35-ff2f46b0e476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f80199-16f9-4190-af96-f07ac9a22363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f80199-16f9-4190-af96-f07ac9a22363.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -17741,7 +17741,7 @@
         },
         {
             "id": "a9eb10f2-947f-5327-b715-e664a9f1d8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1b606-cda9-4394-85af-d6e513699b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1b606-cda9-4394-85af-d6e513699b91.jpg?1",
             "name": "Elsha of the Infinite",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nYou may look at the top card of your library any time.\nYou may cast noncreature spells from the top of your library. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -17783,7 +17783,7 @@
         },
         {
             "id": "c8a00807-bb42-594a-9a79-4e7985d8db9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9487b5a-8280-4854-9d3b-3b030e99eb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9487b5a-8280-4854-9d3b-3b030e99eb0c.jpg?1",
             "name": "Empyrial Archangel",
             "text": "Flying\nShroud (This creature can't be the target of spells or abilities.)\nAll damage that would be dealt to you is dealt to Empyrial Archangel instead.",
             "colours": [
@@ -17822,7 +17822,7 @@
         },
         {
             "id": "6502f553-422b-5588-8576-4e2c69ac1f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f766a3-ec88-46ee-bf07-b6997cd0f95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f766a3-ec88-46ee-bf07-b6997cd0f95a.jpg?1",
             "name": "Ezuri, Claw of Progress",
             "text": "Whenever a creature with power 2 or less enters the battlefield under your control, you get an experience counter.\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is the number of experience counters you have.",
             "colours": [
@@ -17863,7 +17863,7 @@
         },
         {
             "id": "d2956b35-e5c9-5352-bd49-f9deaf2fde30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e4b67-8082-43de-9a1c-11e0b1983788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e4b67-8082-43de-9a1c-11e0b1983788.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.",
             "colours": [
@@ -17900,7 +17900,7 @@
         },
         {
             "id": "f5892f2f-6551-5610-9272-2a9abc142e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b761b353-1c72-49f9-8c77-3b47ff5c3c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b761b353-1c72-49f9-8c77-3b47ff5c3c4f.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a Kithkin Spirit with base power and toughness 2/2.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
             "colours": [
@@ -17937,7 +17937,7 @@
         },
         {
             "id": "bc41a9c7-755b-5235-9125-cfbc5c51ee01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f4325-32be-41be-99f3-bd7c27226918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f4325-32be-41be-99f3-bd7c27226918.jpg?1",
             "name": "Firesong and Sunspeaker",
             "text": "Red instant and sorcery spells you control have lifelink.\nWhenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.",
             "colours": [
@@ -17977,7 +17977,7 @@
         },
         {
             "id": "10caf812-a1c9-54cc-8ae4-7c64cf3c77cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4df5e-14b3-42ed-89dd-d87450cc78f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4df5e-14b3-42ed-89dd-d87450cc78f2.jpg?1",
             "name": "Ghave, Guru of Spores",
             "text": "Ghave, Guru of Spores enters the battlefield with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from a creature you control: Create a 1/1 green Saproling creature token.\n{1}, Sacrifice a creature: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -18019,7 +18019,7 @@
         },
         {
             "id": "a4e81dcf-0ea1-5b33-b073-056bbac6a52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3486e0-f64b-4b27-9d9a-3f5968f73454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3486e0-f64b-4b27-9d9a-3f5968f73454.jpg?1",
             "name": "Glen Elendra Liege",
             "text": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
             "colours": [
@@ -18057,7 +18057,7 @@
         },
         {
             "id": "f5241c77-8d09-5c78-8572-de45aca9569e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cd3942-f385-493c-b667-e35af7f60b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cd3942-f385-493c-b667-e35af7f60b83.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player mills ten cards.",
             "colours": [
@@ -18093,7 +18093,7 @@
         },
         {
             "id": "02f406d8-b1d5-5be6-9b90-263bc8414ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ecdb6c-7456-4941-b51f-5600ec337479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ecdb6c-7456-4941-b51f-5600ec337479.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -18134,7 +18134,7 @@
         },
         {
             "id": "89d6aacc-feab-5f23-8957-3d4ddc42df2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ade84c1-80b5-446b-9547-d09d3bf4264a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ade84c1-80b5-446b-9547-d09d3bf4264a.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -18173,7 +18173,7 @@
         },
         {
             "id": "9cf61818-b9c9-5d87-9903-72d7aaed24d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800411e2-3fd0-4f5b-9751-5f5609f904e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800411e2-3fd0-4f5b-9751-5f5609f904e5.jpg?1",
             "name": "Guided Passage",
             "text": "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle.",
             "colours": [
@@ -18210,7 +18210,7 @@
         },
         {
             "id": "116db879-ae86-5c15-9e13-b1fda9a60c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ee7d-dd79-4d77-8873-c44f820ca5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ee7d-dd79-4d77-8873-c44f820ca5b0.jpg?1",
             "name": "Hellkite Overlord",
             "text": "Flying, trample, haste\n{R}: Hellkite Overlord gets +1/+0 until end of turn.\n{B}{G}: Regenerate Hellkite Overlord.",
             "colours": [
@@ -18249,7 +18249,7 @@
         },
         {
             "id": "1e1f7031-0a13-5b09-931e-46e0d2f3130b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f66a7-beb2-483b-a155-eed85f878843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f66a7-beb2-483b-a155-eed85f878843.jpg?1",
             "name": "Hostage Taker",
             "text": "When Hostage Taker enters the battlefield, exile another target creature or artifact until Hostage Taker leaves the battlefield. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -18287,7 +18287,7 @@
         },
         {
             "id": "4d313756-01b5-54f3-8342-fd880bc568a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b004684e-bd98-42fc-b90c-9a13a48dd120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b004684e-bd98-42fc-b90c-9a13a48dd120.jpg?1",
             "name": "Hydroid Krasis",
             "text": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nHydroid Krasis enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -18326,7 +18326,7 @@
         },
         {
             "id": "fa75d027-5cdf-5a50-895e-2a4d7cd5fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb99af-853b-4773-877a-ab5efcff9828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb99af-853b-4773-877a-ab5efcff9828.jpg?1",
             "name": "Intet, the Dreamer",
             "text": "Flying\nWhenever Intet, the Dreamer deals combat damage to a player, you may pay {2}{U}. If you do, exile the top card of your library face down. You may look at that card for as long as it remains exiled. You may play that card without paying its mana cost for as long as Intet remains on the battlefield.",
             "colours": [
@@ -18367,7 +18367,7 @@
         },
         {
             "id": "b18e7855-762c-5545-88b6-af93a23b4120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65868ea1-4e80-4871-a93f-66582690869a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65868ea1-4e80-4871-a93f-66582690869a.jpg?1",
             "name": "Jeskai Ascendancy",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn. Untap those creatures.\nWhenever you cast a noncreature spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -18404,7 +18404,7 @@
         },
         {
             "id": "c7b92ec3-357b-58b2-a101-5270a201bcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06cb72-ccbc-4efe-9457-dd76f503fa34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06cb72-ccbc-4efe-9457-dd76f503fa34.jpg?1",
             "name": "Jodah, Archmage Eternal",
             "text": "Flying\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -18448,7 +18448,7 @@
         },
         {
             "id": "aefae7a1-17bd-5ccb-827c-0d5bb8f940d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c8784d-22b9-485b-8f35-d33664db45b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c8784d-22b9-485b-8f35-d33664db45b5.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -18488,7 +18488,7 @@
         },
         {
             "id": "0bbbca26-562b-5724-88fd-aae0f889a13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576a670d-4efd-498b-8c53-eda6e18868a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576a670d-4efd-498b-8c53-eda6e18868a4.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -18530,7 +18530,7 @@
         },
         {
             "id": "7a9ca742-9b06-549f-b975-fc91971dcb38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298d3b70-f858-4138-97e4-1442a5b6afb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298d3b70-f858-4138-97e4-1442a5b6afb6.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent casts a spell, Kaervek the Merciless deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -18570,7 +18570,7 @@
         },
         {
             "id": "b29d06ea-07cc-5623-b6f4-8d8448d23b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67852fca-37a5-414e-bc1f-5256e46483d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67852fca-37a5-414e-bc1f-5256e46483d1.jpg?1",
             "name": "Kambal, Consul of Allocation",
             "text": "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -18610,7 +18610,7 @@
         },
         {
             "id": "41aa892e-1a1f-5ca3-830e-c502988b5257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee1fba-ad5b-41ca-a29f-ecc8cf1edeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee1fba-ad5b-41ca-a29f-ecc8cf1edeff.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -18652,7 +18652,7 @@
         },
         {
             "id": "8f77344a-a55f-5147-9424-2784877afc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f190f-7e46-4877-a47e-ae1b28e40a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f190f-7e46-4877-a47e-ae1b28e40a42.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to any target.",
             "colours": [
@@ -18688,7 +18688,7 @@
         },
         {
             "id": "119afbfb-8425-5915-8530-3d0cbb9e8720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864f0611-042a-4f71-b92f-ce70c69bc79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864f0611-042a-4f71-b92f-ce70c69bc79f.jpg?1",
             "name": "Lavalanche",
             "text": "Lavalanche deals X damage to target player or planeswalker and each creature that player or that planeswalker's controller controls.",
             "colours": [
@@ -18725,7 +18725,7 @@
         },
         {
             "id": "c5e749f6-ad3e-59d8-890a-78ae253e96cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257cd42e-c808-41b5-9878-e0c4386eb0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257cd42e-c808-41b5-9878-e0c4386eb0c1.jpg?1",
             "name": "Legion's Initiative",
             "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
             "colours": [
@@ -18760,7 +18760,7 @@
         },
         {
             "id": "5e9b2e4b-da3a-5692-83b8-d4def2f7f958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1721464-f9e5-434a-b8e6-9c8157199264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1721464-f9e5-434a-b8e6-9c8157199264.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -18797,7 +18797,7 @@
         },
         {
             "id": "503b9284-2472-5683-9188-0f193e7b7b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f26682-24c8-4990-9ceb-629fdac20036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f26682-24c8-4990-9ceb-629fdac20036.jpg?1",
             "name": "Magister Sphinx",
             "text": "Flying\nWhen Magister Sphinx enters the battlefield, target player's life total becomes 10.",
             "colours": [
@@ -18837,7 +18837,7 @@
         },
         {
             "id": "8f1a847d-eb05-5a3d-85f9-2cb84d23b7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47617780-620d-409a-944c-bc7035826b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47617780-620d-409a-944c-bc7035826b38.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "Dethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nOther creatures you control have dethrone.\nWhenever a creature you control with a +1/+1 counter on it dies, return that card to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -18880,7 +18880,7 @@
         },
         {
             "id": "f07fd5e2-c604-5663-9db9-53fd4f1c4562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dda584b-0cb4-452e-963a-d6e6bac0e402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dda584b-0cb4-452e-963a-d6e6bac0e402.jpg?1",
             "name": "Master Biomancer",
             "text": "Each other creature you control enters the battlefield with a number of additional +1/+1 counters on it equal to Master Biomancer's power and as a Mutant in addition to its other types.",
             "colours": [
@@ -18918,7 +18918,7 @@
         },
         {
             "id": "48166bf7-9683-549e-b854-084e0c33e7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b95dab-4c26-4eb9-ba2c-bec968fdaea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b95dab-4c26-4eb9-ba2c-bec968fdaea9.jpg?1",
             "name": "Master of Cruelties",
             "text": "First strike, deathtouch\nMaster of Cruelties can only attack alone.\nWhenever Master of Cruelties attacks a player and isn't blocked, that player's life total becomes 1. Master of Cruelties assigns no combat damage this combat.",
             "colours": [
@@ -18955,7 +18955,7 @@
         },
         {
             "id": "918f209e-9d65-5484-af4c-c9700c224188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238bb7a7-cf3a-432a-8c40-d745d7e7cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238bb7a7-cf3a-432a-8c40-d745d7e7cf9f.jpg?1",
             "name": "Mathas, Fiend Seeker",
             "text": "Menace\nAt the beginning of your end step, put a bounty counter on target creature an opponent controls. For as long as that creature has a bounty counter on it, it has \"When this creature dies, each opponent draws a card and gains 2 life.\"",
             "colours": [
@@ -18996,7 +18996,7 @@
         },
         {
             "id": "903174cf-1d38-57c1-bf25-3ffb32bcba28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a705820-8a40-4724-9448-d6b219d76c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a705820-8a40-4724-9448-d6b219d76c76.jpg?1",
             "name": "Mayael's Aria",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
             "colours": [
@@ -19033,7 +19033,7 @@
         },
         {
             "id": "21903cfa-038b-5309-8532-e020827b537e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4916b0ed-a0cd-4b32-9505-140f98301ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4916b0ed-a0cd-4b32-9505-140f98301ed5.jpg?1",
             "name": "The Mimeoplasm",
             "text": "As The Mimeoplasm enters the battlefield, you may exile two creature cards from graveyards. If you do, it enters the battlefield as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
             "colours": [
@@ -19075,7 +19075,7 @@
         },
         {
             "id": "8e2338ee-3362-580d-a142-e63c10014267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9395a0-922c-4062-a917-796786000f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9395a0-922c-4062-a917-796786000f2b.jpg?1",
             "name": "Mindwrack Liege",
             "text": "Other blue creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\n{UR}{UR}{UR}{UR}: You may put a blue or red creature card from your hand onto the battlefield.",
             "colours": [
@@ -19112,7 +19112,7 @@
         },
         {
             "id": "efcf0ac3-db08-5b58-8a27-1e6bc5f965cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2dd0e-b321-4f1a-b7d8-30920e134b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2dd0e-b321-4f1a-b7d8-30920e134b62.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -19152,7 +19152,7 @@
         },
         {
             "id": "0b97605d-495c-50eb-8ff2-8f2ac657cfbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a81b1b-92c1-4ee8-affe-6e1c027c7393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a81b1b-92c1-4ee8-affe-6e1c027c7393.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -19195,7 +19195,7 @@
         },
         {
             "id": "6f3644a8-017b-5761-b3a9-51a530551866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcfb7a-2a7c-4ae8-8719-8d1b37d07819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcfb7a-2a7c-4ae8-8719-8d1b37d07819.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -19232,7 +19232,7 @@
         },
         {
             "id": "62278030-0f17-5cad-bdb7-9607a15bc898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b49a2e-02ac-4b50-b283-dd2c782cd0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b49a2e-02ac-4b50-b283-dd2c782cd0d1.jpg?1",
             "name": "Nicol Bolas, God-Pharaoh",
             "text": "+2: Target opponent exiles cards from the top of their library until they exile a nonland card. Until end of turn, you may cast that card without paying its mana cost.\n+1: Each opponent exiles two cards from their hand.\n\u22124: Nicol Bolas, God-Pharaoh deals 7 damage to target opponent, creature an opponent controls, or planeswalker an opponent controls.\n\u221212: Exile each nonland permanent your opponents control.",
             "colours": [
@@ -19273,7 +19273,7 @@
         },
         {
             "id": "97d3a50c-b774-55bb-8ea0-b19f2301ca05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ceea14-c018-456d-83cd-07f4e3bc5817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ceea14-c018-456d-83cd-07f4e3bc5817.jpg?1",
             "name": "Phyrexian Tyranny",
             "text": "Whenever a player draws a card, that player loses 2 life unless they pay {2}.",
             "colours": [
@@ -19310,7 +19310,7 @@
         },
         {
             "id": "4b170fa3-a277-5bcd-a41b-46b4cba0ee06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5656b93-8dcd-4c46-95b4-d5a311d17096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5656b93-8dcd-4c46-95b4-d5a311d17096.jpg?1",
             "name": "Privileged Position",
             "text": "Other permanents you control have hexproof.",
             "colours": [
@@ -19346,7 +19346,7 @@
         },
         {
             "id": "f2055ae6-9a39-54e7-a7ca-14a9298b7a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc296a-6479-42ca-b0a8-c14b3ded1cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc296a-6479-42ca-b0a8-c14b3ded1cec.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -19383,7 +19383,7 @@
         },
         {
             "id": "9234754c-ba5f-527b-ae94-5f5dfef61ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d892-9b9e-450f-84b7-612655af23be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d892-9b9e-450f-84b7-612655af23be.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -19425,7 +19425,7 @@
         },
         {
             "id": "36fffe0a-d02a-59be-862b-86db1d5302c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0579dea8-3963-403c-b89d-204e007ce3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0579dea8-3963-403c-b89d-204e007ce3ed.jpg?1",
             "name": "Roon of the Hidden Realm",
             "text": "Vigilance, trample\n{2}, {T}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -19467,7 +19467,7 @@
         },
         {
             "id": "09e7d56a-6cb1-5798-932d-ae64be678832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a0966f-622c-47d6-a383-f1db19dfb01c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a0966f-622c-47d6-a383-f1db19dfb01c.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each combat if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "cff96abd-04fa-5495-b264-49ae5a9f1f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3600e910-784e-4b69-86dc-801a1b27288c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3600e910-784e-4b69-86dc-801a1b27288c.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -19550,7 +19550,7 @@
         },
         {
             "id": "6ca991f2-3a02-5f42-9fd0-f475fbf84b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ebe9d-27fd-4b5d-acde-d7648063fd0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ebe9d-27fd-4b5d-acde-d7648063fd0c.jpg?1",
             "name": "Shattergang Brothers",
             "text": "{2}{B}, Sacrifice a creature: Each other player sacrifices a creature.\n{2}{R}, Sacrifice an artifact: Each other player sacrifices an artifact.\n{2}{G}, Sacrifice an enchantment: Each other player sacrifices an enchantment.",
             "colours": [
@@ -19592,7 +19592,7 @@
         },
         {
             "id": "ac0432f1-765f-5949-805a-3b736eec5aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c5c9cc-16ae-4274-a52b-9947332ff5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c5c9cc-16ae-4274-a52b-9947332ff5a1.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -19634,7 +19634,7 @@
         },
         {
             "id": "b14243ae-8344-5f7b-b312-51f0bbecf92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3159553d-ab09-4970-8c68-613a9cd56a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3159553d-ab09-4970-8c68-613a9cd56a2d.jpg?1",
             "name": "Skullbriar, the Walking Grave",
             "text": "Haste\nWhenever Skullbriar, the Walking Grave deals combat damage to a player, put a +1/+1 counter on it.\nCounters remain on Skullbriar as it moves to any zone other than a player's hand or library.",
             "colours": [
@@ -19674,7 +19674,7 @@
         },
         {
             "id": "4ea05d00-fdf8-5564-9a41-26e92908c84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24c37e1-8d3f-4a76-8ea4-242d322794ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24c37e1-8d3f-4a76-8ea4-242d322794ec.jpg?1",
             "name": "Supreme Verdict",
             "text": "This spell can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -19710,7 +19710,7 @@
         },
         {
             "id": "6d5baecf-d65e-5816-91d1-3bd0662d0fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2753-385e-493a-9f6d-14aa0f392b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2753-385e-493a-9f6d-14aa0f392b69.jpg?1",
             "name": "Tariel, Reckoner of Souls",
             "text": "Flying, vigilance\n{T}: Choose a creature card at random from target opponent's graveyard. Put that card onto the battlefield under your control.",
             "colours": [
@@ -19751,7 +19751,7 @@
         },
         {
             "id": "979f8c43-e711-5f8c-9d89-9b79c0441092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1994667d-19b7-493b-9961-d823d0c92b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1994667d-19b7-493b-9961-d823d0c92b86.jpg?1",
             "name": "Teneb, the Harvester",
             "text": "Flying\nWhenever Teneb, the Harvester deals combat damage to a player, you may pay {2}{B}. If you do, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -19792,7 +19792,7 @@
         },
         {
             "id": "77b3818b-2517-53da-bae0-d671ac6211b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe277b7-e346-4c18-9fcf-1c8469354fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe277b7-e346-4c18-9fcf-1c8469354fed.jpg?1",
             "name": "Thistledown Liege",
             "text": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
             "colours": [
@@ -19830,7 +19830,7 @@
         },
         {
             "id": "107017dd-f69e-52f7-ac8c-902105f61a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da9c9a-1778-4eea-ad40-2475fe6fabc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da9c9a-1778-4eea-ad40-2475fe6fabc2.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -19866,7 +19866,7 @@
         },
         {
             "id": "f87b9e1c-27ac-50d9-b1c4-3ddcea7f8655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04638352-cb8c-477e-979a-46b4fc69ac98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04638352-cb8c-477e-979a-46b4fc69ac98.jpg?1",
             "name": "Thraximundar",
             "text": "Haste\nWhenever Thraximundar attacks, defending player sacrifices a creature.\nWhenever a player sacrifices a creature, you may put a +1/+1 counter on Thraximundar.",
             "colours": [
@@ -19908,7 +19908,7 @@
         },
         {
             "id": "ae6c1a29-ce51-54c1-b530-47c0b749246b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb8a87-85d9-48ae-b0b3-84b9420ae082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb8a87-85d9-48ae-b0b3-84b9420ae082.jpg?1",
             "name": "Ulasht, the Hate Seed",
             "text": "Ulasht, the Hate Seed enters the battlefield with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one \u2014\n\u2022 Ulasht deals 1 damage to target creature.\n\u2022 Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -19948,7 +19948,7 @@
         },
         {
             "id": "3b8e04d0-9d7e-5ee7-ad53-694023101337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c140c-2ac4-40e8-b02c-a64032303666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c140c-2ac4-40e8-b02c-a64032303666.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "Hexproof\nUril, the Miststalker gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -19989,7 +19989,7 @@
         },
         {
             "id": "699a83aa-6a4b-5ce4-8186-4b66de1794ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b16b28-f628-4d38-b3f8-c9021e322734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b16b28-f628-4d38-b3f8-c9021e322734.jpg?1",
             "name": "Varina, Lich Queen",
             "text": "Whenever you attack with one or more Zombies, draw that many cards, then discard that many cards. You gain that much life.\n{2}, Exile two cards from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -20031,7 +20031,7 @@
         },
         {
             "id": "c814a428-9c00-5b4e-ac6f-e571b8b2e45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8663bcef-df55-4765-b8a6-7afd1e09c32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8663bcef-df55-4765-b8a6-7afd1e09c32d.jpg?1",
             "name": "Villainous Wealth",
             "text": "Target opponent exiles the top X cards of their library. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -20068,7 +20068,7 @@
         },
         {
             "id": "35c13264-d2c6-5b8b-8f5b-4a63e6a0fc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1605dc-7204-4684-ade3-66e727f4deb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1605dc-7204-4684-ade3-66e727f4deb5.jpg?1",
             "name": "Wasitora, Nekoru Queen",
             "text": "Flying, trample\nWhenever Wasitora, Nekoru Queen deals combat damage to a player, that player sacrifices a creature. If the player can't, you create a 3/3 black, red, and green Cat Dragon creature token with flying.",
             "colours": [
@@ -20110,7 +20110,7 @@
         },
         {
             "id": "f73ba1db-743f-5438-80b1-c77d43e2b37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed350949-34b3-485d-99bb-d084006b4dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed350949-34b3-485d-99bb-d084006b4dcd.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -20148,7 +20148,7 @@
         },
         {
             "id": "5cdc6abc-175b-55ab-9b4a-e70ec7449b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4282ddd-3e5b-4d4c-b1b7-a48401a3521f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4282ddd-3e5b-4d4c-b1b7-a48401a3521f.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -20189,7 +20189,7 @@
         },
         {
             "id": "b1f2ab94-5d64-556d-af8a-61251f2543f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb1b3d5-6bd8-42f4-ba36-d345fe4e78ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb1b3d5-6bd8-42f4-ba36-d345fe4e78ab.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -20231,7 +20231,7 @@
         },
         {
             "id": "29e82994-8a43-5d5b-8277-743cc9d66a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f4f24-f62b-4f52-8168-62b5b9971162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f4f24-f62b-4f52-8168-62b5b9971162.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with mana value equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -20261,7 +20261,7 @@
         },
         {
             "id": "d9981ce3-76d7-564b-b626-a0382dd5b342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5205e059-97c5-4cad-ac36-22db3a050784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5205e059-97c5-4cad-ac36-22db3a050784.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -20293,7 +20293,7 @@
         },
         {
             "id": "c5ac491d-1c5a-52fb-ab99-4514906a1fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428dfa7-da5f-4aaa-9e7b-0e8b236bd15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428dfa7-da5f-4aaa-9e7b-0e8b236bd15b.jpg?1",
             "name": "Conqueror's Flail",
             "text": "Equipped creature gets +1/+1 for each color among permanents you control.\nAs long as Conqueror's Flail is attached to a creature, your opponents can't cast spells during your turn.\nEquip {2}",
             "colours": [],
@@ -20324,7 +20324,7 @@
         },
         {
             "id": "98615fc0-1101-58bc-a965-acce17421f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ca51fb-46f9-42c1-8e2f-442c9425adfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ca51fb-46f9-42c1-8e2f-442c9425adfb.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -20354,7 +20354,7 @@
         },
         {
             "id": "d37afbc9-53d8-567a-85c7-0acb76272318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6251c38d-ad22-4372-b086-5df52cdb153e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6251c38d-ad22-4372-b086-5df52cdb153e.jpg?1",
             "name": "Darksteel Plate",
             "text": "Indestructible\nEquipped creature has indestructible.\nEquip {2}",
             "colours": [],
@@ -20385,7 +20385,7 @@
         },
         {
             "id": "91ed750f-7471-5c90-aade-698d967c043a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e44bec-fce8-42e0-9734-8e6dea8b7e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e44bec-fce8-42e0-9734-8e6dea8b7e04.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -20415,7 +20415,7 @@
         },
         {
             "id": "9c9eb7ef-5c09-5ebe-bffa-6c80c293f184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f60690-7625-4c4a-8354-69a30f5fc1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f60690-7625-4c4a-8354-69a30f5fc1a3.jpg?1",
             "name": "Nim Deathmantle",
             "text": "Equipped creature gets +2/+2, has intimidate, and is a black Zombie. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever a nontoken creature is put into your graveyard from the battlefield, you may pay {4}. If you do, return that card to the battlefield and attach Nim Deathmantle to it.\nEquip {4}",
             "colours": [],
@@ -20446,7 +20446,7 @@
         },
         {
             "id": "0a33c097-4e38-574b-876c-5cabbebc1c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d68b906-8d37-4952-82e7-faba4effcf22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d68b906-8d37-4952-82e7-faba4effcf22.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -20476,7 +20476,7 @@
         },
         {
             "id": "3d441e97-6b78-5345-b635-84e28fda8303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49141090-f3b0-4748-a7ee-800093fcf29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49141090-f3b0-4748-a7ee-800093fcf29d.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -20506,7 +20506,7 @@
         },
         {
             "id": "dcd510d1-6d97-5314-8f9a-d3199126d251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45560d90-fe3a-443e-91f2-2b55ce0255c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45560d90-fe3a-443e-91f2-2b55ce0255c6.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -20536,7 +20536,7 @@
         },
         {
             "id": "24edfa10-056a-54f8-a06c-69ade91f50d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847ffd9-7986-4402-b4bc-ecf3dfd2a2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847ffd9-7986-4402-b4bc-ecf3dfd2a2f2.jpg?1",
             "name": "Planar Bridge",
             "text": "{8}, {T}: Search your library for a permanent card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -20567,7 +20567,7 @@
         },
         {
             "id": "157e7c91-47f3-507f-955e-49a86483c89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef87d80-5a31-4233-a6f2-7c26a9388107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef87d80-5a31-4233-a6f2-7c26a9388107.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -20597,7 +20597,7 @@
         },
         {
             "id": "b086bf93-01c5-5bc2-8ea3-79eb8efa9641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e79372-5ad3-4dea-9dcc-cf20f3b267c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e79372-5ad3-4dea-9dcc-cf20f3b267c7.jpg?1",
             "name": "Thrumming Stone",
             "text": "Spells you cast have ripple 4. (Whenever you cast a spell, you may reveal the top four cards of your library. You may cast spells with the same name as that spell from among the revealed cards without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [],
@@ -20628,7 +20628,7 @@
         },
         {
             "id": "b91b37f6-7ae2-56e7-93bc-c600dd711a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60306d4-3705-4bcc-84da-4787a65737b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60306d4-3705-4bcc-84da-4787a65737b7.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may cast spells as though they had flash.",
             "colours": [],
@@ -20658,7 +20658,7 @@
         },
         {
             "id": "f59890f1-d5da-5d4d-99ed-7fd1a65de3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f31ea61-cc66-4dc2-a38c-04e3f8418cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f31ea61-cc66-4dc2-a38c-04e3f8418cb8.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -20688,7 +20688,7 @@
         },
         {
             "id": "9cab59d9-723d-573a-99a7-cf3b05ec1907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35a4a4d-4b78-4c61-91bd-80c09c82895d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35a4a4d-4b78-4c61-91bd-80c09c82895d.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -20718,7 +20718,7 @@
         },
         {
             "id": "57bfa77a-a7d6-5069-98a3-bfb52ddca33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3e78b-4ca4-444a-9661-c0df4e36226e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3e78b-4ca4-444a-9661-c0df4e36226e.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color.\nWhenever you tap Forbidden Orchard for mana, target opponent creates a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -20748,7 +20748,7 @@
         },
         {
             "id": "65627b0c-6ee7-5aba-aa82-a2121a0757a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02221d76-922a-4ad4-8d40-c279b5a446b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02221d76-922a-4ad4-8d40-c279b5a446b9.jpg?1",
             "name": "Pillar of the Paruns",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a multicolored spell.",
             "colours": [],
@@ -20777,7 +20777,7 @@
         },
         {
             "id": "001e28fe-5bc1-57ef-9814-adc1195a297b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e2a410-fca6-4d3d-9b6b-519a968e5e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e2a410-fca6-4d3d-9b6b-519a968e5e86.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Mill two cards, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -20816,7 +20816,7 @@
         },
         {
             "id": "4aee00b4-2e77-597c-b90b-ffdba349b303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b1203f-1f4c-4d02-a79f-1f6486904ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b1203f-1f4c-4d02-a79f-1f6486904ea6.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -20857,7 +20857,7 @@
         },
         {
             "id": "a9e37c90-1112-53ea-a442-27897a256f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f6aed-e18e-4c8e-8e58-b1ed43ad54e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f6aed-e18e-4c8e-8e58-b1ed43ad54e7.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from spells that are one or more colors, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -20892,7 +20892,7 @@
         },
         {
             "id": "6d4e18c2-1652-5291-99db-e0c592132359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2f9d5b-8a88-443d-8046-2b2a77fd1d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2f9d5b-8a88-443d-8046-2b2a77fd1d64.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -20927,7 +20927,7 @@
         },
         {
             "id": "9c11a355-fd21-5a81-a8a4-0ccb2f34aabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00afe028-fef9-49dd-a062-085fafa8586d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00afe028-fef9-49dd-a062-085fafa8586d.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -20962,7 +20962,7 @@
         },
         {
             "id": "618274eb-37b7-5009-bc6a-5c60e8c4f233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1b6cf0-24b0-43b0-ab95-8bf73710c8ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1b6cf0-24b0-43b0-ab95-8bf73710c8ee.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, put it into your hand, then shuffle. Activate only if an opponent controls more lands than you.",
             "colours": [
@@ -21000,7 +21000,7 @@
         },
         {
             "id": "99a96354-f726-5420-9325-c665661bbfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ed050-ed2a-4043-b12b-5d29fb506eb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ed050-ed2a-4043-b12b-5d29fb506eb3.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -21036,7 +21036,7 @@
         },
         {
             "id": "7cba0b1c-2752-57f2-bdee-e0f45123aa54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b1462-dd9c-42af-8ba0-e840f8a651e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b1462-dd9c-42af-8ba0-e840f8a651e2.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -21068,7 +21068,7 @@
         },
         {
             "id": "833fee32-d935-51e4-b378-8fa466620a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c672ee51-0e77-463f-8586-191b413c44dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c672ee51-0e77-463f-8586-191b413c44dd.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -21099,7 +21099,7 @@
         },
         {
             "id": "4ad6b1d3-c030-52bd-a568-6134cd2ea3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31434b32-b741-4a4d-813e-7006fe7ffa3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31434b32-b741-4a4d-813e-7006fe7ffa3c.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -21134,7 +21134,7 @@
         },
         {
             "id": "03462caa-c066-5f44-8af9-5932944e808b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12feaabf-7b3e-4cef-8d45-1b9bbe2baaf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12feaabf-7b3e-4cef-8d45-1b9bbe2baaf6.jpg?1",
             "name": "Aven Initiate",
             "text": "",
             "colours": [
@@ -21171,7 +21171,7 @@
         },
         {
             "id": "06558f31-bce8-5504-9058-d836968bab2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73ee667-09a1-40b9-85e8-902d9c06adcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73ee667-09a1-40b9-85e8-902d9c06adcf.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -21206,7 +21206,7 @@
         },
         {
             "id": "e4440487-4f32-5ed9-b485-0e34a2258f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9d16af-2b50-426f-98d2-992d97a4a150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9d16af-2b50-426f-98d2-992d97a4a150.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -21241,7 +21241,7 @@
         },
         {
             "id": "d9361551-ef54-562f-b97a-0d2500ac5588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17763402-d0bc-44d8-8655-ceca164cae9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17763402-d0bc-44d8-8655-ceca164cae9d.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -21276,7 +21276,7 @@
         },
         {
             "id": "5bb80cf6-edae-5967-8e02-a2692efe9268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebb3b03-943e-4b5a-be04-f59316b81333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebb3b03-943e-4b5a-be04-f59316b81333.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -21311,7 +21311,7 @@
         },
         {
             "id": "5e95d749-81f3-5294-a405-b4b65a32eb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287a7057-ce44-4082-a3da-8c09b8a88fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287a7057-ce44-4082-a3da-8c09b8a88fba.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -21346,7 +21346,7 @@
         },
         {
             "id": "7c0e0855-217e-56a4-9a75-5409a158aec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a4bb3-7f76-4f8a-8af6-439b09b3ee0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a4bb3-7f76-4f8a-8af6-439b09b3ee0f.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -21381,7 +21381,7 @@
         },
         {
             "id": "367b2213-a86a-5fdb-90f7-8c93a74cb3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55998d0d-b169-4e1b-a9e2-a2ea75b4bbf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55998d0d-b169-4e1b-a9e2-a2ea75b4bbf0.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -21417,7 +21417,7 @@
         },
         {
             "id": "64241dfe-167b-5c4a-ba03-c0bb9a4996b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31603503-fd3a-4c57-90ad-4175bb2c8150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31603503-fd3a-4c57-90ad-4175bb2c8150.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -21452,7 +21452,7 @@
         },
         {
             "id": "27b9adf3-cfb3-5551-adad-757e7f00201c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462bb611-5a02-441c-ae8a-911b75436864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462bb611-5a02-441c-ae8a-911b75436864.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -21487,7 +21487,7 @@
         },
         {
             "id": "18eef80e-48c6-500e-98cf-3ed4c3601b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169a2e1-ed39-41cf-9a36-3c2b59499819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169a2e1-ed39-41cf-9a36-3c2b59499819.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -21522,7 +21522,7 @@
         },
         {
             "id": "c8599875-0389-5953-be39-61a5a7b5bb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a911fad-7af3-4bc4-bafc-cac2d5f18f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a911fad-7af3-4bc4-bafc-cac2d5f18f22.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -21557,7 +21557,7 @@
         },
         {
             "id": "9db7edf6-2139-5df7-8e94-5906ee38136d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b545a43-8837-49a1-83d8-7c548d5237d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b545a43-8837-49a1-83d8-7c548d5237d2.jpg?1",
             "name": "Egg",
             "text": "",
             "colours": [
@@ -21592,7 +21592,7 @@
         },
         {
             "id": "b04a8173-24b6-577f-a150-cd7e51791c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c9bcf4-4e8c-467c-8c72-4a9cd0556e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c9bcf4-4e8c-467c-8c72-4a9cd0556e93.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -21627,7 +21627,7 @@
         },
         {
             "id": "23cf1fd4-4cb8-52d1-89ca-401b60ff3ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74900ca-7f0d-460c-86b0-b515c8b44e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74900ca-7f0d-460c-86b0-b515c8b44e67.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -21662,7 +21662,7 @@
         },
         {
             "id": "77468071-de65-572f-80bc-88e11a77392f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e883aa-5f73-4c45-9253-1350c24222e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e883aa-5f73-4c45-9253-1350c24222e4.jpg?1",
             "name": "Cat Dragon",
             "text": "",
             "colours": [
@@ -21702,7 +21702,7 @@
         },
         {
             "id": "d1b963a7-1ccd-5e24-91d9-fe750f54a7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b71ab8-7f94-4cd9-9a15-0c2291e17b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b71ab8-7f94-4cd9-9a15-0c2291e17b47.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -21739,7 +21739,7 @@
         },
         {
             "id": "5450889c-b58f-5974-955c-b5f0d88d1338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83842dfb-e5ea-41dc-91b1-b1dd53e5ecca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83842dfb-e5ea-41dc-91b1-b1dd53e5ecca.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -21772,7 +21772,7 @@
         },
         {
             "id": "ba3bda5a-b0c8-5931-818b-0126c810dc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649d42c1-a465-435e-8b67-e901ab9ad8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649d42c1-a465-435e-8b67-e901ab9ad8ab.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -21803,7 +21803,7 @@
         },
         {
             "id": "2d0f1dda-5182-553c-97d2-57710d02a3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88493c-293b-4b89-8571-712dcf110df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88493c-293b-4b89-8571-712dcf110df5.jpg?1",
             "name": "Liliana, the Last Hope Emblem",
             "text": "",
             "colours": [],
@@ -21833,7 +21833,7 @@
         },
         {
             "id": "695a65fa-4180-5482-aed8-1c9f84226998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35578c3f-e818-4887-83c4-dc3a89e28ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35578c3f-e818-4887-83c4-dc3a89e28ed4.jpg?1",
             "name": "Wrenn and Six Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/2XM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/2XM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fc5dff7e-489f-5a42-bf3f-926985aaef4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c6662-4dde-40a2-97e0-0318478c0367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c6662-4dde-40a2-97e0-0318478c0367.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "6b31b436-0e4c-56aa-b8f4-73a46abb0f33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef65e86-3759-465d-862b-29516eed46e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef65e86-3759-465d-862b-29516eed46e6.jpg?1",
             "name": "Alabaster Mage",
             "text": "{1}{W}: Target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "8b18a63d-e741-5c34-a2b5-8b119bb77ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ca85e4-f1ca-47ff-bb67-eb0d66d35cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ca85e4-f1ca-47ff-bb67-eb0d66d35cc8.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "813198d6-f2c4-5ac3-b0a0-4ed4d866fd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccfe469-3fa7-4672-ae15-8f25971e7c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccfe469-3fa7-4672-ae15-8f25971e7c56.jpg?1",
             "name": "Angel of the Dawn",
             "text": "Flying\nWhen Angel of the Dawn enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "e5fa76e0-e10e-5eec-b6ac-8bb6549dd233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c34447-b0f4-4fcc-b557-23c92850b31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c34447-b0f4-4fcc-b557-23c92850b31b.jpg?1",
             "name": "Archangel of Thune",
             "text": "Flying, lifelink\nWhenever you gain life, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "84a4a758-4ca1-5c52-a9f2-a0cbbccfbb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb996b-1da6-41a3-8d9a-a45c2353c401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb996b-1da6-41a3-8d9a-a45c2353c401.jpg?1",
             "name": "Auriok Salvagers",
             "text": "{1}{W}: Return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "d806b135-3258-509b-adb0-52b2ac0d154c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d36e87ca-71e1-43d2-841f-b01a58fe27f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d36e87ca-71e1-43d2-841f-b01a58fe27f0.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "2818f287-8403-5217-9a59-c11af2ab77e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0519776-3d86-4f7d-9c3b-71c1dfbf7e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0519776-3d86-4f7d-9c3b-71c1dfbf7e12.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "5b9dacb4-c5a1-5950-8951-e3239a9b4983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277bc4e5-f43a-4f1e-a7e9-11796e78fcdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277bc4e5-f43a-4f1e-a7e9-11796e78fcdf.jpg?1",
             "name": "Blade Splicer",
             "text": "When Blade Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolems you control have first strike.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "ce463b18-101c-5bd3-a425-aa2e169a0e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4032a7-600c-4b30-a012-fe3cde1be9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4032a7-600c-4b30-a012-fe3cde1be9c9.jpg?1",
             "name": "Boon Reflection",
             "text": "If you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "1455b16b-e445-5117-99ce-be8bb0d68154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa187c9-90b3-4770-963a-8a9f932430ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa187c9-90b3-4770-963a-8a9f932430ef.jpg?1",
             "name": "Council's Judgment",
             "text": "Will of the council \u2014 Starting with you, each player votes for a nonland permanent you don't control. Exile each permanent with the most votes or tied for most votes.",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "8a3a1659-5731-59fc-9cbf-3647cc569356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c53df6a-618d-40d4-a390-44b2e3202d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c53df6a-618d-40d4-a390-44b2e3202d7d.jpg?1",
             "name": "Crib Swap",
             "text": "Changeling (This card is every creature type.)\nExile target creature. Its controller creates a 1/1 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "25dc1ae0-9511-5dac-9ea4-08625c9e0386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81e6aaa-aea4-4187-a4ca-fbbea0d10c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81e6aaa-aea4-4187-a4ca-fbbea0d10c7d.jpg?1",
             "name": "Crusader of Odric",
             "text": "Crusader of Odric's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "6fe16551-19f8-575f-a071-8404a937fe36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8e0f8-fdb9-4f24-a3e3-439f6cc3ebdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8e0f8-fdb9-4f24-a3e3-439f6cc3ebdc.jpg?1",
             "name": "Ethersworn Canonist",
             "text": "Each player who has cast a nonartifact spell this turn can't cast additional nonartifact spells.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "2ce1ba66-f602-542e-9b66-e802f5b894fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f198c0-5819-42fc-89f5-cad46cf8d5d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f198c0-5819-42fc-89f5-cad46cf8d5d1.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "9189b384-fcf2-5a45-912b-411c467e45c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0ed8ee-d6ea-469c-a575-6643d3995f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0ed8ee-d6ea-469c-a575-6643d3995f54.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -557,7 +557,7 @@
         },
         {
             "id": "f46dd0cf-3666-59fe-8e48-4e826bef54d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4974169a-f454-4b8a-9301-18498c73c5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4974169a-f454-4b8a-9301-18498c73c5ab.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "63b8f929-b55c-555e-a683-be61fd52086e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2fd5ac-963b-49ea-bd72-d0958ef8eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2fd5ac-963b-49ea-bd72-d0958ef8eb3e.jpg?1",
             "name": "Glint-Sleeve Artisan",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "b270b745-70c2-5ad7-9189-91a4f1b19230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e92cf6-8382-44b5-9f14-c91e572685b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e92cf6-8382-44b5-9f14-c91e572685b9.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, create a 2/2 white Cat creature token for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -661,7 +661,7 @@
         },
         {
             "id": "0d30a492-1f46-5774-a281-1cec988739b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bba319-5f66-4085-9f2a-ab71f727ab64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bba319-5f66-4085-9f2a-ab71f727ab64.jpg?1",
             "name": "Land Tax",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -693,7 +693,7 @@
         },
         {
             "id": "1f5ef27d-0cc6-51e1-9b79-e925bc088f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14397b59-ff0d-4838-92c3-9728bf6b0af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14397b59-ff0d-4838-92c3-9728bf6b0af5.jpg?1",
             "name": "Leonin Abunas",
             "text": "Artifacts you control have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "7cebda51-4ad7-5f5c-adec-335b52076f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32e82fc-6613-462b-b11f-523db195f435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32e82fc-6613-462b-b11f-523db195f435.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolems you control get +1/+1.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "1db31e0b-65b6-5ab8-8cfe-e963ff1d2ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783c15b7-6a7f-471e-b9f7-8c38115e66c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783c15b7-6a7f-471e-b9f7-8c38115e66c0.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, create a 1/1 colorless Myr artifact creature token.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "f6a99f9c-e810-58d3-94cd-00a1153c20bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c5a822-0f5e-4b5f-b969-b27324e4543f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c5a822-0f5e-4b5f-b969-b27324e4543f.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control. (Auras with nothing to enchant remain in graveyards.)",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "fff91993-bbbd-5738-b1ca-b2bd68e80257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d36855-c38a-4bba-a642-cff3f81e057e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d36855-c38a-4bba-a642-cff3f81e057e.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle their library.",
             "colours": [
@@ -863,7 +863,7 @@
         },
         {
             "id": "ad3ece0b-6b3d-59d3-8dc8-ca436a778ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abcc2e6-82e7-4cc5-8956-05dd617e3e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abcc2e6-82e7-4cc5-8956-05dd617e3e7d.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -898,7 +898,7 @@
         },
         {
             "id": "c6d225e3-34cd-55e9-947c-74b5662faf72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ca034-9cea-4b84-98ba-76c24f038edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ca034-9cea-4b84-98ba-76c24f038edb.jpg?1",
             "name": "Remember the Fallen",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "3793cd8b-d540-5c40-ae28-af79ca778138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd4fc26-8351-4371-948b-f43346c3e771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd4fc26-8351-4371-948b-f43346c3e771.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "de4b9359-a582-5fc8-86b1-80b65ed47d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0714cb-21e5-4922-b971-ebcb9e3c9196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0714cb-21e5-4922-b971-ebcb9e3c9196.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle enters the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "ec2e6c4d-8988-5eca-8eec-656530723297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86322472-52e5-4af4-8a41-1ccc3ff6fd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86322472-52e5-4af4-8a41-1ccc3ff6fd92.jpg?1",
             "name": "Sanctum Spirit",
             "text": "Lifelink\nDiscard a historic card: Sanctum Spirit gains indestructible until end of turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "bb5cedfe-72ac-5788-b453-75ddfa96c44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3473d0-b46f-41f5-ac1e-ba217f7747d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3473d0-b46f-41f5-ac1e-ba217f7747d4.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.\n{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "a2ff821b-379c-518d-89e7-71eac84d91c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efda05d-01ea-4478-b075-00a31d7037f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efda05d-01ea-4478-b075-00a31d7037f8.jpg?1",
             "name": "Stonehewer Giant",
             "text": "Vigilance\n{1}{W}, {T}: Search your library for an Equipment card and put it onto the battlefield. Attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "2791dcb2-9a4d-52d8-af3b-a08aafd3097a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6843952d-e633-4992-99d5-4ef8b87494c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6843952d-e633-4992-99d5-4ef8b87494c8.jpg?1",
             "name": "Strength of Arms",
             "text": "Target creature gets +2/+2 until end of turn. If you control an Equipment, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -1135,7 +1135,7 @@
         },
         {
             "id": "d56abffa-6fe8-582b-b4fe-10e026f17ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956cc7b5-b120-4a98-9509-03047d8acd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956cc7b5-b120-4a98-9509-03047d8acd4a.jpg?1",
             "name": "Tempered Steel",
             "text": "Artifact creatures you control get +2/+2.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "4e8564ab-9cc4-5ae4-a5c8-24a5baa2e650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39749-ad6f-4160-99eb-c677eee7f1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39749-ad6f-4160-99eb-c677eee7f1b2.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "3e84d54f-06f7-5574-827e-34f583938c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab74e12a-ad7c-4563-aa06-632654bac91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab74e12a-ad7c-4563-aa06-632654bac91d.jpg?1",
             "name": "Topple the Statue",
             "text": "Tap target permanent. If it's an artifact, destroy it.\nDraw a card.",
             "colours": [
@@ -1234,7 +1234,7 @@
         },
         {
             "id": "52992fb2-ba08-587e-8751-56e7a9e92126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7428ad-4bd4-401d-a45c-3900bb05a3f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7428ad-4bd4-401d-a45c-3900bb05a3f7.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "8834baf0-51b8-5cf9-8be4-9e72464b5869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72729e-d2fa-4bbb-8524-8c88acb30850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72729e-d2fa-4bbb-8524-8c88acb30850.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "33ee3d00-153e-5d6e-a439-1b0ca9d3ad70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e6656-36a3-4635-9f33-9f8901afd397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e6656-36a3-4635-9f33-9f8901afd397.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "378986fb-5bee-5f86-99f7-980ab62189c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13026a8-7e3c-45b2-9838-080f14ae4b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13026a8-7e3c-45b2-9838-080f14ae4b29.jpg?1",
             "name": "Apprentice Wizard",
             "text": "{U}, {T}: Add {C}{C}{C}.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "3110237b-e998-5a6a-9767-f6bcc0b177ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ecf811-2efc-4fa6-9af8-ef09f559ec1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ecf811-2efc-4fa6-9af8-ef09f559ec1a.jpg?1",
             "name": "Arcum Dagsson",
             "text": "{T}: Target artifact creature's controller sacrifices it. That player may search their library for a noncreature artifact card, put it onto the battlefield, then shuffle their library.",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "acfb4e43-bcdd-5c7b-b995-7c823680e98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14b3a6-5490-4a50-9449-542e23f1d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14b3a6-5490-4a50-9449-542e23f1d6b1.jpg?1",
             "name": "Argivian Restoration",
             "text": "Return target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "99eb6e1c-b52b-5103-9669-95dcc19cad34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593dfb2f-ede0-413a-b037-46ae5c3769e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593dfb2f-ede0-413a-b037-46ae5c3769e4.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from their hand onto the battlefield.",
             "colours": [
@@ -1473,7 +1473,7 @@
         },
         {
             "id": "64329194-cb04-530b-9763-6c331596a1ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb0421-b7af-44cd-a7f6-7daaa3dcaa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb0421-b7af-44cd-a7f6-7daaa3dcaa38.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "11c2194f-054b-56ac-8819-c5c46065ed70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afaeec0-9ea3-4aec-9876-8e005e787d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afaeec0-9ea3-4aec-9876-8e005e787d71.jpg?1",
             "name": "Cloudreader Sphinx",
             "text": "Flying\nWhen Cloudreader Sphinx enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "be568e91-35ed-5769-b349-59be469888e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3f6598-18a7-472d-8d05-715203379089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3f6598-18a7-472d-8d05-715203379089.jpg?1",
             "name": "Corridor Monitor",
             "text": "When Corridor Monitor enters the battlefield, untap target artifact or creature you control.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "1017ece8-fc06-528b-b6ca-f204d3acf75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08e5ed-f47b-4d8e-8b8b-41675dccef8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08e5ed-f47b-4d8e-8b8b-41675dccef8b.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "dd401668-4d04-5eac-8dca-9c57958be642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b26dc-de39-4510-9fcf-6cb43372f543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b26dc-de39-4510-9fcf-6cb43372f543.jpg?1",
             "name": "Deepglow Skate",
             "text": "When Deepglow Skate enters the battlefield, double the number of each kind of counter on any number of target permanents.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "39c42a35-6390-58b7-80d7-5f4b94d4f925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7269b26a-058c-4a5c-aadf-733ea60f3de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7269b26a-058c-4a5c-aadf-733ea60f3de0.jpg?1",
             "name": "Esperzoa",
             "text": "Flying\nAt the beginning of your upkeep, return an artifact you control to its owner's hand.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "d0b03af8-ea61-54c6-919a-efcc6401c488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b14d57-a856-49d4-931f-ff5a0407b135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b14d57-a856-49d4-931f-ff5a0407b135.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist enters the battlefield, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "65ba05d3-76c2-54e1-bfcb-c12c6fead81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60b291-0a88-4e8e-bef8-76cdfd6c8183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60b291-0a88-4e8e-bef8-76cdfd6c8183.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "21b834ec-8da1-57ad-93d6-ac10545e3aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89be5f5-75d4-42a0-81e9-5da5bf868e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89be5f5-75d4-42a0-81e9-5da5bf868e73.jpg?1",
             "name": "Frogify",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1. (It loses all other card types and creature types.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "30e8e88d-4f8b-584f-ad32-b1ddea0bf3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce909d-a53e-4711-a9fd-b110433d460f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce909d-a53e-4711-a9fd-b110433d460f.jpg?1",
             "name": "Grand Architect",
             "text": "Other blue creatures you control get +1/+1.\n{U}: Target artifact creature becomes blue until end of turn.\nTap an untapped blue creature you control: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -1818,7 +1818,7 @@
         },
         {
             "id": "dfffa641-f6a3-5897-97a2-daa32b334f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebaedfd-3f65-4867-bb59-df548a6eb113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebaedfd-3f65-4867-bb59-df548a6eb113.jpg?1",
             "name": "Hinder",
             "text": "Counter target spell. If that spell is countered this way, put that card on the top or bottom of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "5ab32b55-afe5-54d1-817c-baa2c59c95ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7a6dfb-a8f8-4899-b2db-c48d542dfd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7a6dfb-a8f8-4899-b2db-c48d542dfd55.jpg?1",
             "name": "Inkwell Leviathan",
             "text": "Islandwalk, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "896a92b1-ed29-5daf-bf89-2502224f8f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8817585-0d32-4d56-9142-0d29512e86a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8817585-0d32-4d56-9142-0d29512e86a9.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
             "colours": [
@@ -1923,7 +1923,7 @@
         },
         {
             "id": "b26d0f16-0f6d-576e-a716-9c1df0a8ad21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c860286-9807-4ab5-b66f-e8696e9e6ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c860286-9807-4ab5-b66f-e8696e9e6ac9.jpg?1",
             "name": "Master of Etherium",
             "text": "Master of Etherium's power and toughness are each equal to the number of artifacts you control.\nOther artifact creatures you control get +1/+1.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "98f85a2a-c64c-5a72-aae6-7c7b4125ba0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb74f-9e62-41f7-b48a-b4249aab5752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb74f-9e62-41f7-b48a-b4249aab5752.jpg?1",
             "name": "Master Transmuter",
             "text": "{U}, {T}, Return an artifact you control to its owner's hand: You may put an artifact card from your hand onto the battlefield.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "a4bb8e88-27fa-54c0-881c-d3fa9d3aca69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34785944-7b51-48a9-855c-3e656cd78251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34785944-7b51-48a9-855c-3e656cd78251.jpg?1",
             "name": "Metallic Rebuke",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "c97c9388-6244-51b2-9932-0638ecaf844f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70017989-aaf1-4a70-98aa-e447d6ce793a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70017989-aaf1-4a70-98aa-e447d6ce793a.jpg?1",
             "name": "Parasitic Strix",
             "text": "Flying\nWhen Parasitic Strix enters the battlefield, if you control a black permanent, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "0381e84a-634b-5b34-a4f5-bc314306344a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6afeb07-ed44-4e15-99b6-436f8365326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6afeb07-ed44-4e15-99b6-436f8365326f.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "({PU} can be paid with either {U} or 2 life.)\nYou may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [
@@ -2100,7 +2100,7 @@
         },
         {
             "id": "454d01cf-80b6-51ca-9131-507bf63c84c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7a6db-e0a3-45f7-9ef7-e4fd5490adb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7a6db-e0a3-45f7-9ef7-e4fd5490adb7.jpg?1",
             "name": "Pongify",
             "text": "Destroy target creature. It can't be regenerated. Its controller creates a 3/3 green Ape creature token.",
             "colours": [
@@ -2132,7 +2132,7 @@
         },
         {
             "id": "2a197a04-5cde-591e-a501-e0b73004d3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbced19d-7035-4284-93b3-cf2d4bcf9734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbced19d-7035-4284-93b3-cf2d4bcf9734.jpg?1",
             "name": "Relic Runner",
             "text": "Relic Runner can't be blocked if you've cast a historic spell this turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "0f088f6b-cffb-526e-8527-d91ccb4e5487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8a8f14-bced-4388-b263-5e70431b191f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8a8f14-bced-4388-b263-5e70431b191f.jpg?1",
             "name": "Reshape",
             "text": "As an additional cost to cast this spell, sacrifice an artifact.\nSearch your library for an artifact card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "8af6d0c1-e49b-52db-b045-2c135359dbb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aab84-5e71-496f-8c46-ecd31fb97d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aab84-5e71-496f-8c46-ecd31fb97d27.jpg?1",
             "name": "Riddlesmith",
             "text": "Whenever you cast an artifact spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "a0324058-3078-5296-841c-81873f5a01cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca07a9-5c24-490f-8871-b125cb337e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca07a9-5c24-490f-8871-b125cb337e2c.jpg?1",
             "name": "Rush of Knowledge",
             "text": "Draw cards equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "1722767a-6005-56eb-9964-73d98dbcc917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19284d8-4404-4032-8dee-3c7af2819045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19284d8-4404-4032-8dee-3c7af2819045.jpg?1",
             "name": "Sentinel of the Pearl Trident",
             "text": "Flash\nWhen Sentinel of the Pearl Trident enters the battlefield, you may exile target historic permanent you control. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "9bf3c968-6c02-5b2d-bbab-1651e6da17ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb01cf8-9bca-4446-9e56-62777c6dfbe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb01cf8-9bca-4446-9e56-62777c6dfbe8.jpg?1",
             "name": "Serra Sphinx",
             "text": "Flying, vigilance",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "54f3cb18-1e58-5707-9e5a-b8d53c790e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9fb948-86fb-497b-98bf-1f69eac9901e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9fb948-86fb-497b-98bf-1f69eac9901e.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "5e8f6143-a14d-5009-a0d9-f5ecab44b8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227437d-1fc7-4a00-ace5-80795adc51d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c227437d-1fc7-4a00-ace5-80795adc51d3.jpg?1",
             "name": "Steel Sabotage",
             "text": "Choose one \u2014\n\u2022 Counter target artifact spell.\n\u2022 Return target artifact to its owner's hand.",
             "colours": [
@@ -2399,7 +2399,7 @@
         },
         {
             "id": "ef59ce4d-ec3e-5e68-9000-8b4f75829533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46afb6e7-b2d9-436e-9532-0d09099de158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46afb6e7-b2d9-436e-9532-0d09099de158.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -2431,7 +2431,7 @@
         },
         {
             "id": "1a864ea8-6684-598e-9b30-1e96eecf6a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169e197-5ef4-454d-a31f-fcadedb74cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169e197-5ef4-454d-a31f-fcadedb74cfc.jpg?1",
             "name": "Thought Reflection",
             "text": "If you would draw a card, draw two cards instead.",
             "colours": [
@@ -2463,7 +2463,7 @@
         },
         {
             "id": "d64e95e6-ffd9-5ad8-a74f-5e91217a1726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea2fcd-f090-4545-a055-30d7980ad66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea2fcd-f090-4545-a055-30d7980ad66f.jpg?1",
             "name": "Treasure Mage",
             "text": "When Treasure Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "16ee5f83-d6aa-5b2a-982e-9e9485b59c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b9d11-0aab-4300-90b6-c8b56de36ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b9d11-0aab-4300-90b6-c8b56de36ec3.jpg?1",
             "name": "Vedalken Infuser",
             "text": "At the beginning of your upkeep, you may put a charge counter on target artifact.",
             "colours": [
@@ -2533,7 +2533,7 @@
         },
         {
             "id": "98ca597f-1cac-57d1-94ce-6ea7ee4314cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7796b82-5a7c-406e-be71-1f37abdbc44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7796b82-5a7c-406e-be71-1f37abdbc44f.jpg?1",
             "name": "Well of Ideas",
             "text": "When Well of Ideas enters the battlefield, draw two cards.\nAt the beginning of each other player's draw step, that player draws an additional card.\nAt the beginning of your draw step, draw two additional cards.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "c19def09-b6ae-5761-a786-e7b694d4eac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f2c53e-ff58-4aa8-89a6-4f45628cc571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f2c53e-ff58-4aa8-89a6-4f45628cc571.jpg?1",
             "name": "Ad Nauseam",
             "text": "Reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost. You may repeat this process any number of times.",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "ba2bb3ae-9ad2-5079-ae3d-8fa73fd19530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd199b-1855-4208-8bf7-8930e91ab139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd199b-1855-4208-8bf7-8930e91ab139.jpg?1",
             "name": "Beacon of Unrest",
             "text": "Put target artifact or creature card from a graveyard onto the battlefield under your control. Shuffle Beacon of Unrest into its owner's library.",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "d4996eed-a712-5d8e-83da-86be83bb6799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7de3d27-f3e0-4aea-a737-6577de1bd1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7de3d27-f3e0-4aea-a737-6577de1bd1c5.jpg?1",
             "name": "Bone Picker",
             "text": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -2663,7 +2663,7 @@
         },
         {
             "id": "cf32347b-17d0-5087-94a1-273d8c86ab0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480fecdd-5978-47e6-9c25-7a04cdf616db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480fecdd-5978-47e6-9c25-7a04cdf616db.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "fe55f2e4-177b-52ec-a481-2c88e03f98bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598405fd-02d2-4bf8-b241-7a2ae6338913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598405fd-02d2-4bf8-b241-7a2ae6338913.jpg?1",
             "name": "Costly Plunder",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "300725c7-140d-589d-a14f-d40f9ec5b63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d88239-43dc-46b8-8d46-626e2f8f1070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d88239-43dc-46b8-8d46-626e2f8f1070.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "8fdd86ea-8d26-59a9-94cf-2517155ba347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526ff6e-c079-4ad4-ac8d-5e26ecacf50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526ff6e-c079-4ad4-ac8d-5e26ecacf50d.jpg?1",
             "name": "Death's Shadow",
             "text": "Death's Shadow gets -X/-X, where X is your life total.",
             "colours": [
@@ -2798,7 +2798,7 @@
         },
         {
             "id": "b5d03323-b50b-5e86-9f5e-0d73d458cdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f113f11-9b87-4219-a106-9f6595d85b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f113f11-9b87-4219-a106-9f6595d85b81.jpg?1",
             "name": "Defiant Salvager",
             "text": "Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "799f3747-8263-528b-8c64-6c59cd0b1a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f86b94-2a86-4120-97cd-ec2c89d106cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f86b94-2a86-4120-97cd-ec2c89d106cb.jpg?1",
             "name": "Dire Fleet Hoarder",
             "text": "When Dire Fleet Hoarder dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "9fb379dd-cbef-52c3-9741-244a10721410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b70c101-d8b0-4acb-ad65-59bf9860708a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b70c101-d8b0-4acb-ad65-59bf9860708a.jpg?1",
             "name": "Disciple of Bolas",
             "text": "When Disciple of Bolas enters the battlefield, sacrifice another creature. You gain X life and draw X cards, where X is that creature's power.",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "23ab39a0-1531-586d-b0e6-d47e23a2ba7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c539843-4e3f-47a7-92e1-412eaaa2d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c539843-4e3f-47a7-92e1-412eaaa2d9c5.jpg?1",
             "name": "Disciple of the Vault",
             "text": "Whenever an artifact is put into a graveyard from the battlefield, you may have target opponent lose 1 life.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "12cdef28-6759-5d88-ae03-c5b2fd573c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494cb6d-1a99-40b6-96cc-0dc2ddec102f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494cb6d-1a99-40b6-96cc-0dc2ddec102f.jpg?1",
             "name": "Divest",
             "text": "Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "9f6e5403-76a5-5d25-92e4-9d7c2eb6672c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a21acd-100a-4a25-932b-f36943728ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a21acd-100a-4a25-932b-f36943728ac9.jpg?1",
             "name": "Doomed Necromancer",
             "text": "{B}, {T}, Sacrifice Doomed Necromancer: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "978a7807-5f69-5550-8334-1cc4d1ff9ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa9e00-e73e-4a6e-9607-77533aac4be4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa9e00-e73e-4a6e-9607-77533aac4be4.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "3f28ec5b-6bcb-5579-9725-f842d63cc236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46f4e7-ec58-4542-94b3-785bc46d26ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46f4e7-ec58-4542-94b3-785bc46d26ea.jpg?1",
             "name": "Driver of the Dead",
             "text": "When Driver of the Dead dies, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "fd47f6ea-033d-55be-b781-e168589e6f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e8a62-5b8c-432a-bb8f-c09048c51e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e8a62-5b8c-432a-bb8f-c09048c51e0b.jpg?1",
             "name": "Drown in Sorrow",
             "text": "All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "be690a68-9c47-5750-ba05-0ce332bf962a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ea333-96e1-4ad8-8947-21d6bc3a9f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ea333-96e1-4ad8-8947-21d6bc3a9f91.jpg?1",
             "name": "Executioner's Capsule",
             "text": "{1}{B}, {T}, Sacrifice Executioner's Capsule: Destroy target nonblack creature.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "ff508c3b-070d-5977-8bd8-ff2ef435e779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9d8fe4-fd9b-4923-92bf-7dd6b8fa02e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9d8fe4-fd9b-4923-92bf-7dd6b8fa02e7.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt \u2014 Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "b6d215d2-014f-5af7-93fd-ce6f7f768d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d56a4-fc94-43d8-9d65-361b66172a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d56a4-fc94-43d8-9d65-361b66172a5f.jpg?1",
             "name": "Geth, Lord of the Vault",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\n{X}{B}: Put target artifact or creature card with converted mana cost X from an opponent's graveyard onto the battlefield under your control tapped. Then that player mills X cards.",
             "colours": [
@@ -3207,7 +3207,7 @@
         },
         {
             "id": "b9de76f5-7fad-5ffc-98d1-baa9136289f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f9a946-f961-4e19-a30a-6e1a95683340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f9a946-f961-4e19-a30a-6e1a95683340.jpg?1",
             "name": "Glaze Fiend",
             "text": "Flying\nWhenever another artifact enters the battlefield under your control, Glaze Fiend gets +2/+2 until end of turn.",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "4bee3b6a-545b-56b6-bfdd-a38fccaf9fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b705cd6-da20-4f0a-bb94-2acd1cecd64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b705cd6-da20-4f0a-bb94-2acd1cecd64c.jpg?1",
             "name": "Heartless Pillage",
             "text": "Target opponent discards two cards.\nRaid \u2014 If you attacked this turn, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "2e0d8eb7-87e2-5cd8-b0fe-9cd3a6f85c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954157a-0c05-4788-8a0f-6093ebbb38c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954157a-0c05-4788-8a0f-6093ebbb38c3.jpg?1",
             "name": "Magus of the Abyss",
             "text": "At the beginning of each player's upkeep, destroy target nonartifact creature that player controls of their choice. It can't be regenerated.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "1122ebd6-9c5f-5bf4-8bde-1d30702ff5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c41068-59d8-4ef4-aae4-a93b0a9ee19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c41068-59d8-4ef4-aae4-a93b0a9ee19e.jpg?1",
             "name": "Magus of the Will",
             "text": "{2}{B}, {T}, Exile Magus of the Will: Until end of turn, you may play lands and cast spells from your graveyard. If a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -3344,7 +3344,7 @@
         },
         {
             "id": "0c74d47e-d5b8-52bd-bdcf-ae56a8975889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6fd09e-55af-41dd-a0c0-ba1064737c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6fd09e-55af-41dd-a0c0-ba1064737c90.jpg?1",
             "name": "Morkrut Banshee",
             "text": "Morbid \u2014 When Morkrut Banshee enters the battlefield, if a creature died this turn, target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "1db1f518-6fa5-5d8a-9575-f3c658e64cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4800a7d-c229-4ced-97ff-0e58645d58d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4800a7d-c229-4ced-97ff-0e58645d58d6.jpg?1",
             "name": "Oubliette",
             "text": "When Oubliette enters the battlefield, target creature phases out until Oubliette leaves the battlefield. Tap that creature as it phases in this way. (Auras and Equipment phase out with it. While permanents are phased out, they're treated as though they don't exist.)",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "bfe87b9c-6c97-52d5-8674-fee71b6a8728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3ba73e-58aa-417e-bd52-d7f93c80adc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3ba73e-58aa-417e-bd52-d7f93c80adc6.jpg?1",
             "name": "Ovalchase Daredevil",
             "text": "Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "9a4ad5b4-97fd-5228-9ef9-491ccdb60ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79301fd4-2f00-4ff5-993f-a6af2440064b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79301fd4-2f00-4ff5-993f-a6af2440064b.jpg?1",
             "name": "Painsmith",
             "text": "Whenever you cast an artifact spell, you may have target creature get +2/+0 and gain deathtouch until end of turn.",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "96c5334f-c9e6-5835-af66-356198506bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0fae06-1a93-43ac-a349-f3719e60076e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0fae06-1a93-43ac-a349-f3719e60076e.jpg?1",
             "name": "Ravenous Trap",
             "text": "If an opponent had three or more cards put into their graveyard from anywhere this turn, you may pay {0} rather than pay this spell's mana cost.\nExile all cards from target player's graveyard.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "58851415-e7e1-56ce-a0ff-b1a71c1f0215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7175febd-ae8e-4945-91ab-b6c67c40f04b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7175febd-ae8e-4945-91ab-b6c67c40f04b.jpg?1",
             "name": "Salvage Titan",
             "text": "You may sacrifice three artifacts rather than pay this spell's mana cost.\nExile three artifact cards from your graveyard: Return Salvage Titan from your graveyard to your hand.",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "21d935e0-d088-5d70-9f70-682e544335ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047fd05e-7545-4148-b3d7-eccf72ae43fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047fd05e-7545-4148-b3d7-eccf72ae43fb.jpg?1",
             "name": "Silumgar Scavenger",
             "text": "Flying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhenever another creature you control dies, put a +1/+1 counter on Silumgar Scavenger. It gains haste until end of turn if it exploited that creature.",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "f2d8f179-3470-5d1a-bf76-8d1dad6d4472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dd19e9-23ff-4854-bbce-ce0a00a7b5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dd19e9-23ff-4854-bbce-ce0a00a7b5b4.jpg?1",
             "name": "Skirsdag High Priest",
             "text": "Morbid \u2014 {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token with flying. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "0ee7621b-b728-5ef0-9536-e2887896acf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab61c7e-e00a-413b-a0b5-7718b479582f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab61c7e-e00a-413b-a0b5-7718b479582f.jpg?1",
             "name": "Skithiryx, the Blight Dragon",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{B}: Skithiryx, the Blight Dragon gains haste until end of turn.\n{B}{B}: Regenerate Skithiryx.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "5e1b0e13-eae6-5db2-ada3-a9e27dae94a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bff1b7-838f-48de-96bd-0c79e59ff827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bff1b7-838f-48de-96bd-0c79e59ff827.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "8e8097bd-ccd9-5f97-b9c2-0c8ee324accc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281a308-ab6b-47b6-bec7-632c9aaecede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281a308-ab6b-47b6-bec7-632c9aaecede.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -3723,7 +3723,7 @@
         },
         {
             "id": "d5783732-6927-5fed-b498-ce1b9a5402ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fa18f-d50a-4d3f-929e-91f29141b1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fa18f-d50a-4d3f-929e-91f29141b1df.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "9164a450-c787-55e3-aca3-563d74e502c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffae38ec-7712-4701-b072-9f962ec9c259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffae38ec-7712-4701-b072-9f962ec9c259.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "3a40176d-a4f1-5eba-aee6-c81ee38f9ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec2e55-fa60-4ee1-b9c0-e6b84939697b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec2e55-fa60-4ee1-b9c0-e6b84939697b.jpg?1",
             "name": "Vampire Hexmage",
             "text": "First strike\nSacrifice Vampire Hexmage: Remove all counters from target permanent.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "d94a1cb3-e3fe-5f86-885a-c93b84bee2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14a82c-877a-445f-8910-33aaa6fe3d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14a82c-877a-445f-8910-33aaa6fe3d15.jpg?1",
             "name": "Wound Reflection",
             "text": "At the beginning of each end step, each opponent loses life equal to the life they lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "01df4e32-7fe4-5b8d-9460-0f08fa29153e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da9431-7e52-44f5-bc18-2f2d8a4ca81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da9431-7e52-44f5-bc18-2f2d8a4ca81e.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -3891,7 +3891,7 @@
         },
         {
             "id": "7d666343-4f91-59c3-8700-0d1e584d5626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81848391-ed73-498a-a650-4041fb9a46bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81848391-ed73-498a-a650-4041fb9a46bc.jpg?1",
             "name": "Balduvian Rage",
             "text": "Target attacking creature gets +X/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "a9a7eb21-f400-5865-bfdf-e2924f0c1a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25920434-8254-4fbf-8ef1-6d0e2cd8ee39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25920434-8254-4fbf-8ef1-6d0e2cd8ee39.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "ba1ffdda-f3c0-5a66-9415-1cc106f471d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff02fcd-241e-4a3e-a0d0-5adc90e7d0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff02fcd-241e-4a3e-a0d0-5adc90e7d0db.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "774de3b7-06ad-517d-b5fa-1210429183a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d072e9ca-aae7-45dc-8025-3ce590bae63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d072e9ca-aae7-45dc-8025-3ce590bae63f.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "9bb62efe-c223-544b-948d-c61fc300c265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779a130b-1d23-4a20-9914-dbdc2268ae3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779a130b-1d23-4a20-9914-dbdc2268ae3b.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -4059,7 +4059,7 @@
         },
         {
             "id": "27054272-c862-52d6-b02b-a7ec77abe5a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fa0577-f02a-4d24-835b-fef8d849b37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fa0577-f02a-4d24-835b-fef8d849b37a.jpg?1",
             "name": "Brimstone Volley",
             "text": "Brimstone Volley deals 3 damage to any target.\nMorbid \u2014 Brimstone Volley deals 5 damage instead if a creature died this turn.",
             "colours": [
@@ -4091,7 +4091,7 @@
         },
         {
             "id": "6ebb5610-cd01-5d2c-985d-6449df3f42a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fa6f3-29e8-4788-bfcd-59576187c399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fa6f3-29e8-4788-bfcd-59576187c399.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "7a010b19-992a-5245-8928-3c21eaf65699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b13d612-f5d4-4423-99bc-359c47a8aa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b13d612-f5d4-4423-99bc-359c47a8aa99.jpg?1",
             "name": "Cragganwick Cremator",
             "text": "When Cragganwick Cremator enters the battlefield, discard a card at random. If you discard a creature card this way, Cragganwick Cremator deals damage equal to that card's power to target player or planeswalker.",
             "colours": [
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "0e33df1d-af7a-5abc-ab7e-112886d35b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86862339-a5a5-45c4-bba5-981cff4f45f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86862339-a5a5-45c4-bba5-981cff4f45f5.jpg?1",
             "name": "Dismantle",
             "text": "Destroy target artifact. If that artifact had counters on it, put that many +1/+1 counters or charge counters on an artifact you control.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "731c31d1-16f7-5746-afab-4b0fc430e94a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4814b8-9aea-4e44-aec1-d585473f5d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4814b8-9aea-4e44-aec1-d585473f5d1c.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4225,7 +4225,7 @@
         },
         {
             "id": "250c00e4-d094-5cb5-a75d-6bc692365df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cb1e-314a-4894-82df-f9812825f52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cb1e-314a-4894-82df-f9812825f52e.jpg?1",
             "name": "Galvanic Blast",
             "text": "Galvanic Blast deals 2 damage to any target.\nMetalcraft \u2014 Galvanic Blast deals 4 damage instead if you control three or more artifacts.",
             "colours": [
@@ -4257,7 +4257,7 @@
         },
         {
             "id": "233a0bd8-0ef6-563e-b92e-72bf523f212e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f44f3ea-504e-4745-9716-cbe28ed7873d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f44f3ea-504e-4745-9716-cbe28ed7873d.jpg?1",
             "name": "Goblin Gaveleer",
             "text": "Trample\nGoblin Gaveleer gets +2/+0 for each Equipment attached to it.",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "1609c919-63d6-5487-9589-871b9753a26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f5411-1940-410f-96ce-6f92513f753a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f5411-1940-410f-96ce-6f92513f753a.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "605e26ed-436d-5390-8728-be5a79f8dd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d1368-fbbe-48f8-9b44-d51946529322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d1368-fbbe-48f8-9b44-d51946529322.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card and put it onto the battlefield. If you do, shuffle your library.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -4366,7 +4366,7 @@
         },
         {
             "id": "a1236691-5f91-5325-b948-1479aee35971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2a0d71-15a2-4061-b5f2-434755094aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2a0d71-15a2-4061-b5f2-434755094aa4.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -4401,7 +4401,7 @@
         },
         {
             "id": "5d162141-f2d7-5db4-bd8d-c5dbb5081299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86956f26-3761-4841-a9b5-f8205bf01f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86956f26-3761-4841-a9b5-f8205bf01f19.jpg?1",
             "name": "Heat Shimmer",
             "text": "Create a token that's a copy of target creature, except it has haste and \"At the beginning of the end step, exile this permanent.\"",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "60eb5e26-d3a0-55c4-bfbf-833f8d12e53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d915eebf-1617-4339-b8b0-72b313c6dab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d915eebf-1617-4339-b8b0-72b313c6dab2.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4468,7 +4468,7 @@
         },
         {
             "id": "e76d33d1-f706-5e85-9fda-61d85d64f9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f02fc34-a2f6-456a-a8e5-da5a7327f954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f02fc34-a2f6-456a-a8e5-da5a7327f954.jpg?1",
             "name": "Ion Storm",
             "text": "{1}{R}, Remove a +1/+1 counter or a charge counter from a permanent you control: Ion Storm deals 2 damage to any target.",
             "colours": [
@@ -4500,7 +4500,7 @@
         },
         {
             "id": "a516eb59-43e3-5f48-aa3f-8c39a6f91ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7377e5a7-b479-48cc-8fbb-01af87c62566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7377e5a7-b479-48cc-8fbb-01af87c62566.jpg?1",
             "name": "Kazuul's Toll Collector",
             "text": "{0}: Attach target Equipment you control to Kazuul's Toll Collector. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4535,7 +4535,7 @@
         },
         {
             "id": "66785d2f-458b-5826-b4c9-3b286399ce51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226e1d72-4ed0-4db6-ac0a-f4631db986a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226e1d72-4ed0-4db6-ac0a-f4631db986a9.jpg?1",
             "name": "Kuldotha Flamefiend",
             "text": "When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "141bcc9a-d1da-5871-87de-5c978c1376cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91344085-92ef-4212-b59f-848ab57cd3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91344085-92ef-4212-b59f-848ab57cd3e0.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -4601,7 +4601,7 @@
         },
         {
             "id": "317f8bcf-a711-5925-b886-6bd387a6109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd079929-fa58-4484-91b7-31305b87ee43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd079929-fa58-4484-91b7-31305b87ee43.jpg?1",
             "name": "Mana Echoes",
             "text": "Whenever a creature enters the battlefield, you may add an amount of {C} equal to the number of creatures you control that share a creature type with it.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "42c19824-f54c-5b31-994a-d028100c8965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ac010e-bcd9-4e40-91f5-3f6058dca104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ac010e-bcd9-4e40-91f5-3f6058dca104.jpg?1",
             "name": "Orcish Vandal",
             "text": "{T}, Sacrifice an artifact: Orcish Vandal deals 2 damage to any target.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "f902d349-a20d-5f9b-9178-62ed74c2658e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f195c52-4018-4d57-9c62-5f0a10f7336c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f195c52-4018-4d57-9c62-5f0a10f7336c.jpg?1",
             "name": "Pyrewild Shaman",
             "text": "Bloodrush \u2014 {1}{R}, Discard Pyrewild Shaman: Target attacking creature gets +3/+1 until end of turn.\nWhenever one or more creatures you control deal combat damage to a player, if Pyrewild Shaman is in your graveyard, you may pay {3}. If you do, return Pyrewild Shaman to your hand.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "586fe151-5038-52d9-9b5d-0a6a819924cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b767e176-1df5-4adc-bf6b-418d71b4dbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b767e176-1df5-4adc-bf6b-418d71b4dbbe.jpg?1",
             "name": "Rage Reflection",
             "text": "Creatures you control have double strike.",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "5d153af6-b6f1-5d81-a706-bb9793b72543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca026be-d204-4ec2-a349-aac5fc3a05ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca026be-d204-4ec2-a349-aac5fc3a05ec.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "676ae5dd-0fd7-5b98-993d-baf33f358acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d6da8-9cfe-4c1b-90c9-477a743f6d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d6da8-9cfe-4c1b-90c9-477a743f6d62.jpg?1",
             "name": "Ravenous Intruder",
             "text": "Sacrifice an artifact: Ravenous Intruder gets +2/+2 until end of turn.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "979add19-bcdc-505d-835a-d2f44859f8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ab37d4-6ba3-404a-8162-f207874738ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ab37d4-6ba3-404a-8162-f207874738ea.jpg?1",
             "name": "Rolling Earthquake",
             "text": "Rolling Earthquake deals X damage to each creature without horsemanship and each player.",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "21aeac7a-0b3a-5ff6-8612-b4820e69ebb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec0d9-42b4-4aff-8d55-0721c8911de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec0d9-42b4-4aff-8d55-0721c8911de3.jpg?1",
             "name": "Salivating Gremlins",
             "text": "Whenever an artifact enters the battlefield under your control, Salivating Gremlins gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -4869,7 +4869,7 @@
         },
         {
             "id": "1f6ee190-467f-5c8c-a398-5db71afae59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9535cdfe-d505-4ee5-bec0-cfd7aa4b2a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9535cdfe-d505-4ee5-bec0-cfd7aa4b2a23.jpg?1",
             "name": "Skinbrand Goblin",
             "text": "Bloodrush \u2014 {R}, Discard Skinbrand Goblin: Target attacking creature gets +2/+1 until end of turn.",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "3556c2f3-d271-566e-8289-25f0838081da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9709ea-5962-4590-8b14-5213b14f9229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9709ea-5962-4590-8b14-5213b14f9229.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "db7d9ebb-b55b-5377-8e26-73c18f91ef0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88258dee-b5c0-4472-86d6-cc534c32fe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88258dee-b5c0-4472-86d6-cc534c32fe27.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "ecba687d-a132-5ee0-91de-e905d56fe8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aa7ba-4b35-42e5-bdcd-e7b3360fd01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aa7ba-4b35-42e5-bdcd-e7b3360fd01f.jpg?1",
             "name": "Thopter Engineer",
             "text": "When Thopter Engineer enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\nArtifact creatures you control have haste.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "49b67cf1-bee5-581d-ac3b-55b585768d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75993427-fb8d-41cc-9016-323e804a5eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75993427-fb8d-41cc-9016-323e804a5eb7.jpg?1",
             "name": "Trash for Treasure",
             "text": "As an additional cost to cast this spell, sacrifice an artifact.\nReturn target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -5037,7 +5037,7 @@
         },
         {
             "id": "8a787bb5-3d1e-5ed4-a07b-99801816b176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17f5403-7692-41ca-a3c9-b81c31bddc00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17f5403-7692-41ca-a3c9-b81c31bddc00.jpg?1",
             "name": "Tuktuk the Explorer",
             "text": "Haste\nWhen Tuktuk the Explorer dies, create Tuktuk the Returned, a legendary 5/5 colorless Goblin Golem artifact creature token.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "0708b9c5-c6f0-5af3-a198-3e56599387dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19330317-0c5e-44fc-bb87-89b3f6dd3704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19330317-0c5e-44fc-bb87-89b3f6dd3704.jpg?1",
             "name": "Weapon Surge",
             "text": "Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "2984adaa-c321-55f3-b781-edd229d1bb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726039a0-6c0d-48ef-9b42-99de5d4e41d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726039a0-6c0d-48ef-9b42-99de5d4e41d2.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5137,7 +5137,7 @@
         },
         {
             "id": "cb687b79-d8db-53d9-a746-1bf4522b38f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609d255-a15a-482a-95f2-1b9ef1076652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609d255-a15a-482a-95f2-1b9ef1076652.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "88902e1d-6eec-5628-9302-06eea232ddb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0c3878-3097-4451-9ec0-7f45a0f72323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0c3878-3097-4451-9ec0-7f45a0f72323.jpg?1",
             "name": "Awakening Zone",
             "text": "At the beginning of your upkeep, you may create a 0/1 colorless Eldrazi Spawn creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "91d54e8c-8cca-5d5f-a502-0ca2f2dacd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9281d7-9c11-4dc8-9035-902fa3a69ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9281d7-9c11-4dc8-9035-902fa3a69ebf.jpg?1",
             "name": "Bloodbriar",
             "text": "Whenever you sacrifice another permanent, put a +1/+1 counter on Bloodbriar.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "24d15f70-4fdc-530c-83f0-5b51a9b20415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bc8355-3a02-44a5-b06f-8be24d7cbcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bc8355-3a02-44a5-b06f-8be24d7cbcbe.jpg?1",
             "name": "Bloodspore Thrinax",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nEach other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on Bloodspore Thrinax.",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "9e87e9d8-3743-52b9-bed8-def79d101434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb2e0d6-3181-4d3d-a3b4-3896288b2e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb2e0d6-3181-4d3d-a3b4-3896288b2e0e.jpg?1",
             "name": "Champion of Lambholt",
             "text": "Creatures with power less than Champion of Lambholt's power can't block creatures you control.\nWhenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.",
             "colours": [
@@ -5307,7 +5307,7 @@
         },
         {
             "id": "e608f676-4694-5f10-aeda-0e96981c1111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7e1991-9ffa-4a57-b8eb-ebe542a47f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7e1991-9ffa-4a57-b8eb-ebe542a47f09.jpg?1",
             "name": "Chatter of the Squirrel",
             "text": "Create a 1/1 green Squirrel creature token.\nFlashback {1}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "674fafea-14d6-52d9-b95b-72edffc2f168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac257a9-39bf-4185-9d2e-f80f0848a96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac257a9-39bf-4185-9d2e-f80f0848a96a.jpg?1",
             "name": "Chord of Calling",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5373,7 +5373,7 @@
         },
         {
             "id": "4442bb99-e7c6-56ad-a9fe-8d511db557db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ff66fc-bd38-4607-b394-8c4e09affec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ff66fc-bd38-4607-b394-8c4e09affec8.jpg?1",
             "name": "Clear Shot",
             "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "33931625-ebe6-5f7e-b7df-a33b1d84456c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a5372-b25a-4559-96b8-2d8d54199a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a5372-b25a-4559-96b8-2d8d54199a38.jpg?1",
             "name": "Conclave Naturalists",
             "text": "When Conclave Naturalists enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "d3ac0d6c-7128-500b-acec-0c0d33b0afe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4249cc64-f75b-4c76-a41a-5b25873c74bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4249cc64-f75b-4c76-a41a-5b25873c74bc.jpg?1",
             "name": "Crop Rotation",
             "text": "As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a land card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "91106490-58bc-5b8d-8d58-fa7432ff25ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa22a85-1c92-48f3-921a-867a73a6bbf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa22a85-1c92-48f3-921a-867a73a6bbf7.jpg?1",
             "name": "Crushing Vines",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "2a568f10-e248-5727-881e-49c7b8d7855a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def88ab5-1b82-46f5-a136-ee1addff4214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def88ab5-1b82-46f5-a136-ee1addff4214.jpg?1",
             "name": "Death-Hood Cobra",
             "text": "{1}{G}: Death-Hood Cobra gains reach until end of turn.\n{1}{G}: Death-Hood Cobra gains deathtouch until end of turn.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "07daf4eb-fba7-560e-b70b-56ee686724e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676d164-c76e-402b-a649-6ded3f549b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676d164-c76e-402b-a649-6ded3f549b6e.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "7e07a173-7cbd-52b8-a878-beee64adf53a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f865601c-fddf-42fe-acd0-c9075fa84783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f865601c-fddf-42fe-acd0-c9075fa84783.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G}.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "4e92beed-d6d1-51a6-920a-5452f584a229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e699f-5f2c-4487-8a40-42be6f561631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e699f-5f2c-4487-8a40-42be6f561631.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "76a56b00-4e84-589b-9d43-5ca5be70cb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4c6535-afea-4704-b35c-badeb04c4f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4c6535-afea-4704-b35c-badeb04c4f4c.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "abc0b650-e749-5e87-9815-912e339ae903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ddd38-397c-4119-8d55-50c7407883f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ddd38-397c-4119-8d55-50c7407883f9.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "02ba2b6f-23cd-5db0-b31f-1b701cd5c995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5c2be0-76ab-4873-a1fc-9ff65a9347c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5c2be0-76ab-4873-a1fc-9ff65a9347c7.jpg?1",
             "name": "Gelatinous Genesis",
             "text": "Create X X/X green Ooze creature tokens.",
             "colours": [
@@ -5741,7 +5741,7 @@
         },
         {
             "id": "30466a4c-5a4c-5df9-8c6c-2191cb8a6919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046aff0b-fa01-4a2d-a030-021a7ad01e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046aff0b-fa01-4a2d-a030-021a7ad01e60.jpg?1",
             "name": "Greater Good",
             "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then discard three cards.",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "efbcbb0e-ab0a-5eba-b612-7ff9eeed8212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb1e59-b858-42cf-93f8-8a3badb3eaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb1e59-b858-42cf-93f8-8a3badb3eaad.jpg?1",
             "name": "Heartbeat of Spring",
             "text": "Whenever a player taps a land for mana, that player adds one mana of any type that land produced.",
             "colours": [
@@ -5805,7 +5805,7 @@
         },
         {
             "id": "ce99b731-c030-539f-9871-05d58f01ea7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0899da3-7beb-4161-81a3-e2d694e5b8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0899da3-7beb-4161-81a3-e2d694e5b8a5.jpg?1",
             "name": "Invigorate",
             "text": "If you control a Forest, rather than pay this spell's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "3c7c2c6e-2dbd-5ad6-9143-80be150b3988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8614f43-21c3-47cd-894a-8cc952bc561a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8614f43-21c3-47cd-894a-8cc952bc561a.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "85e0c859-c7ca-558c-909e-1db920aac789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dea9d0-9f93-460d-bf69-ae1c1172a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dea9d0-9f93-460d-bf69-ae1c1172a95e.jpg?1",
             "name": "Liege of the Tangle",
             "text": "Trample\nWhenever Liege of the Tangle deals combat damage to a player, you may choose any number of target lands you control and put an awakening counter on each of them. Each of those lands is an 8/8 green Elemental creature for as long as it has an awakening counter on it. They're still lands.",
             "colours": [
@@ -5906,7 +5906,7 @@
         },
         {
             "id": "85e82f91-01a1-5584-b0fd-d8b88f848aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e0d739-990f-4ba5-b456-165c033014cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e0d739-990f-4ba5-b456-165c033014cf.jpg?1",
             "name": "Mana Reflection",
             "text": "If you tap a permanent for mana, it produces twice as much of that mana instead.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "3aefff7a-e5dd-5d90-a971-6b0bf4311a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9900f47d-e1ec-411d-92f3-aed8e01ee535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9900f47d-e1ec-411d-92f3-aed8e01ee535.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "df4a0c0d-9e09-5de4-a16a-274509fa3cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400382a4-aea2-4827-b06a-1b0b3745908b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400382a4-aea2-4827-b06a-1b0b3745908b.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U}.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "d7a0488f-df8d-55e3-a1ec-1d3809e9a8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e378a-f033-44ca-8295-855382cc838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e378a-f033-44ca-8295-855382cc838d.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -6044,7 +6044,7 @@
         },
         {
             "id": "19b5842b-7936-5cb9-a4f2-44aaa20c93e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5945a80f-b604-4b15-a016-e2dfddeb95ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5945a80f-b604-4b15-a016-e2dfddeb95ba.jpg?1",
             "name": "Shamanic Revelation",
             "text": "Draw a card for each creature you control.\nFerocious \u2014 You gain 4 life for each creature you control with power 4 or greater.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "f87f0d3c-6707-5db0-ac85-f4012a22c33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88f730-2817-4f15-b785-c0dccbb6bf11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88f730-2817-4f15-b785-c0dccbb6bf11.jpg?1",
             "name": "Skullmulcher",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nWhen Skullmulcher enters the battlefield, draw a card for each creature it devoured.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "0734b636-4790-5269-9470-fc498f4aac25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e1ecf4-bf72-4ae9-9993-9b9a6ca80da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e1ecf4-bf72-4ae9-9993-9b9a6ca80da7.jpg?1",
             "name": "Sylvan Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nFlashback {2}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "692a1ec9-9d61-5265-b83a-7fad214a3df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cf30a6-8071-4628-8846-20a2cf4e622e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cf30a6-8071-4628-8846-20a2cf4e622e.jpg?1",
             "name": "Terastodon",
             "text": "When Terastodon enters the battlefield, you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -6176,7 +6176,7 @@
         },
         {
             "id": "3ad3a656-ecd2-52eb-a1c5-666937ff5dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8459b-4dea-4dc9-8b95-a3748472f699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8459b-4dea-4dc9-8b95-a3748472f699.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "bc6bb700-3c01-5a8b-97ac-713223927330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1614bad6-07db-4a7c-8336-3ac3db393689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1614bad6-07db-4a7c-8336-3ac3db393689.jpg?1",
             "name": "Ulvenwald Mysteries",
             "text": "Whenever a nontoken creature you control dies, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -6242,7 +6242,7 @@
         },
         {
             "id": "ef7389f9-e6da-566e-91dd-b9518994bbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5631668d-75f2-4d2d-b644-90c073c7be21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5631668d-75f2-4d2d-b644-90c073c7be21.jpg?1",
             "name": "Vengevine",
             "text": "Haste\nWhenever you cast a spell, if it's the second creature spell you cast this turn, you may return Vengevine from your graveyard to the battlefield.",
             "colours": [
@@ -6276,7 +6276,7 @@
         },
         {
             "id": "557a214b-8127-57e7-9646-1fdfb2c358be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6c19cc-6469-4958-a547-1d0fe97c70e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6c19cc-6469-4958-a547-1d0fe97c70e8.jpg?1",
             "name": "Veteran Explorer",
             "text": "When Veteran Explorer dies, each player may search their library for up to two basic land cards and put them onto the battlefield. Then each player who searched their library this way shuffles it.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "f3293bdc-2484-5c8a-9244-7228b9c59a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf17d8a-c7ee-4909-bc80-4138dcfe7e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf17d8a-c7ee-4909-bc80-4138dcfe7e67.jpg?1",
             "name": "Whisperer of the Wilds",
             "text": "{T}: Add {G}.\nFerocious \u2014 {T}: Add {G}{G}. Activate this ability only if you control a creature with power 4 or greater.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "80b32090-d254-5f78-8a15-1ee0fd99bbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021bc8f5-3992-4d6a-9806-ed43c89e99f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021bc8f5-3992-4d6a-9806-ed43c89e99f2.jpg?1",
             "name": "Woodland Champion",
             "text": "Whenever one or more tokens enter the battlefield under your control, put that many +1/+1 counters on Woodland Champion.",
             "colours": [
@@ -6382,7 +6382,7 @@
         },
         {
             "id": "3afd5bc6-d872-5502-b230-067159472137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881607c8-bfe7-4903-861f-b51a5a332c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881607c8-bfe7-4903-861f-b51a5a332c17.jpg?1",
             "name": "Arixmethes, Slumbering Isle",
             "text": "Arixmethes, Slumbering Isle enters the battlefield tapped with five slumber counters on it.\nAs long as Arixmethes has a slumber counter on it, it's a land. (It's not a creature.)\nWhenever you cast a spell, you may remove a slumber counter from Arixmethes.\n{T}: Add {G}{U}.",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "09472571-34c7-5636-963c-a8ff6aa96f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d33d52-3d28-4635-b985-51e126289259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d33d52-3d28-4635-b985-51e126289259.jpg?1",
             "name": "Atraxa, Praetors' Voice",
             "text": "Flying, vigilance, deathtouch, lifelink\nAt the beginning of your end step, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "7accc40a-e84c-5858-a415-1d2f5b96e823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b799b2-bb4e-482f-9afd-5aab90090710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b799b2-bb4e-482f-9afd-5aab90090710.jpg?1",
             "name": "Baleful Strix",
             "text": "Flying, deathtouch\nWhen Baleful Strix enters the battlefield, draw a card.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "35fbfa3d-44fc-51aa-8b32-26ebd75c1f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f700-7311-46a4-ad9b-4e743a345785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f700-7311-46a4-ad9b-4e743a345785.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "0d9d021f-9e3e-5da4-b190-6420f756b3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff27a-eb58-4a95-b2df-4a341cf9bef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff27a-eb58-4a95-b2df-4a341cf9bef6.jpg?1",
             "name": "Brudiclad, Telchor Engineer",
             "text": "Creature tokens you control have haste.\nAt the beginning of combat on your turn, create a 2/1 blue Myr artifact creature token. Then you may choose a token you control. If you do, each other token you control becomes a copy of that token.",
             "colours": [
@@ -6586,7 +6586,7 @@
         },
         {
             "id": "6642095b-d59f-570e-8f11-6f6a3df31173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6346a-5154-4c93-9a24-8b1936683517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6346a-5154-4c93-9a24-8b1936683517.jpg?1",
             "name": "Deathreap Ritual",
             "text": "Morbid \u2014 At the beginning of each end step, if a creature died this turn, you may draw a card.",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "11b1543b-aa11-55d6-a2b4-4de19a4fc186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ac7f19-bf6f-4a87-ad39-6eb2553d2202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ac7f19-bf6f-4a87-ad39-6eb2553d2202.jpg?1",
             "name": "Falkenrath Aristocrat",
             "text": "Flying, haste\nSacrifice a creature: Falkenrath Aristocrat gains indestructible until end of turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.",
             "colours": [
@@ -6657,7 +6657,7 @@
         },
         {
             "id": "c82ab013-45a3-55ca-a31b-02038d282af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420d1ea2-23f9-4650-993e-de99eedaa587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420d1ea2-23f9-4650-993e-de99eedaa587.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -6694,7 +6694,7 @@
         },
         {
             "id": "c788ba7a-7a54-5ff3-83d8-fa084b69e632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6554820-e501-44d4-9141-7c83f81d3fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6554820-e501-44d4-9141-7c83f81d3fd7.jpg?1",
             "name": "Geist of Saint Traft",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Geist of Saint Traft attacks, create a 4/4 white Angel creature token with flying that's tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "c33e7882-ed2a-5702-aa77-cf89c36bf6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aae3f29-dde8-4880-b675-75468d53b3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aae3f29-dde8-4880-b675-75468d53b3f4.jpg?1",
             "name": "Ghor-Clan Rampager",
             "text": "Trample\nBloodrush \u2014 {R}{G}, Discard Ghor-Clan Rampager: Target attacking creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "061279d5-1f12-5c32-a56e-4dd5993dd981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a8c38-c968-4337-88b3-b0b03b249a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a8c38-c968-4337-88b3-b0b03b249a4b.jpg?1",
             "name": "Glassdust Hulk",
             "text": "Whenever another artifact enters the battlefield under your control, Glassdust Hulk gets +1/+1 until end of turn and can't be blocked this turn.\nCycling {WU} ({WU}, Discard this card: Draw a card.)",
             "colours": [
@@ -6806,7 +6806,7 @@
         },
         {
             "id": "839a69a1-7a89-5043-aaa6-d47ecb7118cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16352af7-c001-41e8-8052-cd98997aebbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16352af7-c001-41e8-8052-cd98997aebbb.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "0c702ed0-d1f2-59ff-a994-baa643e7c559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9119c90-716b-4884-9b1e-471f262c2639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9119c90-716b-4884-9b1e-471f262c2639.jpg?1",
             "name": "Hidden Stockpile",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.\n{1}, Sacrifice a creature: Scry 1.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "f3a09b1f-8a6e-5224-8f8b-c5f0c4a3ac7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8f0789-aa08-4ce5-8ed1-6544de1e3ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8f0789-aa08-4ce5-8ed1-6544de1e3ed4.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Izzet Charm deals 2 damage to target creature.\n\u2022 Draw two cards, then discard two cards.",
             "colours": [
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "d57c1a70-972f-51ef-ab7f-5133763c4490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f77d23d-6257-4dae-b585-29f45f13f2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f77d23d-6257-4dae-b585-29f45f13f2e2.jpg?1",
             "name": "Jhoira, Weatherlight Captain",
             "text": "Whenever you cast a historic spell, draw a card. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "62514af8-a9a4-59c5-bf13-4b3252e1d9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc9eaf-c8d9-4da2-8fd8-8d423a02a3a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc9eaf-c8d9-4da2-8fd8-8d423a02a3a8.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -6995,7 +6995,7 @@
         },
         {
             "id": "10ca5b9b-5c29-5e9e-a0ad-5292540574c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfb85e8-278b-48a4-970e-e65bad1c4c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfb85e8-278b-48a4-970e-e65bad1c4c47.jpg?1",
             "name": "Karrthus, Tyrant of Jund",
             "text": "Flying, haste\nWhen Karrthus, Tyrant of Jund enters the battlefield, gain control of all Dragons, then untap all Dragons.\nOther Dragon creatures you control have haste.",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "d4240a95-d89b-5a5a-ad51-82f0f30896d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e514b13d-2d22-4d9e-a501-b0667f02edac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e514b13d-2d22-4d9e-a501-b0667f02edac.jpg?1",
             "name": "Maelstrom Nexus",
             "text": "The first spell you cast each turn has cascade. (When you cast your first spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -7075,7 +7075,7 @@
         },
         {
             "id": "50d5a4ca-6a62-5a2b-8e68-742b7f6aa916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ab73f-2759-43b6-9ae8-ca33a55ebf80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ab73f-2759-43b6-9ae8-ca33a55ebf80.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -7109,7 +7109,7 @@
         },
         {
             "id": "e2c60f1d-ead4-5f06-a25d-50176c0b2dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf9070e-14be-4ce5-a19a-6addc79359c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf9070e-14be-4ce5-a19a-6addc79359c1.jpg?1",
             "name": "Manamorphose",
             "text": "Add two mana in any combination of colors.\nDraw a card.",
             "colours": [
@@ -7143,7 +7143,7 @@
         },
         {
             "id": "eaaf9cc5-6175-59da-b661-8f77e79a5fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fb8520-1bc4-40e7-a4cc-2933ed7e0c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fb8520-1bc4-40e7-a4cc-2933ed7e0c00.jpg?1",
             "name": "Mazirek, Kraul Death Priest",
             "text": "Flying\nWhenever a player sacrifices another permanent, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -7182,7 +7182,7 @@
         },
         {
             "id": "5a7b685a-0e13-5937-9f13-f65d82270728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de734753-e102-489b-9160-b3f3d10be4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de734753-e102-489b-9160-b3f3d10be4f1.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage enters the battlefield, choose a nonland card name.\nSpells with the chosen name can't be cast.",
             "colours": [
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "7f467453-1dde-516c-862e-3a9f2d11a407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f160f304-64a2-4211-afa6-65acb5b686f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f160f304-64a2-4211-afa6-65acb5b686f7.jpg?1",
             "name": "Merciless Eviction",
             "text": "Choose one \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all planeswalkers.",
             "colours": [
@@ -7255,7 +7255,7 @@
         },
         {
             "id": "a72b71ee-33ae-520d-9d31-0176ad5cfc62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acba72e1-3f7f-4e5c-af3f-dfe37b5d61f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acba72e1-3f7f-4e5c-af3f-dfe37b5d61f9.jpg?1",
             "name": "Progenitor Mimic",
             "text": "You may have Progenitor Mimic enter the battlefield as a copy of any creature on the battlefield, except it has \"At the beginning of your upkeep, if this creature isn't a token, create a token that's a copy of this creature.\"",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "5997ef7e-9611-529d-8a06-0e76783cccde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91dadcb-31e9-43b0-b425-c9311af3e9d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91dadcb-31e9-43b0-b425-c9311af3e9d7.jpg?1",
             "name": "Rhys the Redeemed",
             "text": "{2}{RW}, {T}: Create a 1/1 green and white Elf Warrior creature token.\n{4}{RW}{RW}, {T}: For each creature token you control, create a token that's a copy of that creature.",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "a8d8e790-8c57-5104-9915-6f69a00d335b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dd138f-391a-4956-bc2a-fe186429c71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dd138f-391a-4956-bc2a-fe186429c71a.jpg?1",
             "name": "Riku of Two Reflections",
             "text": "Whenever you cast an instant or sorcery spell, you may pay {U}{R}. If you do, copy that spell. You may choose new targets for the copy.\nWhenever another nontoken creature enters the battlefield under your control, you may pay {G}{U}. If you do, create a token that's a copy of that creature.",
             "colours": [
@@ -7371,7 +7371,7 @@
         },
         {
             "id": "b583e7e0-216a-5e7d-b9c6-2576514dc810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0ef33b-d2bf-4d8b-a7ba-604a37ca5c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0ef33b-d2bf-4d8b-a7ba-604a37ca5c14.jpg?1",
             "name": "Savageborn Hydra",
             "text": "Double strike\nSavageborn Hydra enters the battlefield with X +1/+1 counters on it.\n{1}{RG}: Put a +1/+1 counter on Savageborn Hydra. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "eed81bd3-096f-5757-9516-0c86485953d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ee141-0ea6-45d6-a682-96a37d703394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ee141-0ea6-45d6-a682-96a37d703394.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "678c131a-6ec4-54e7-856b-8dfa8fa0729f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209ed4c-207f-4e37-8c92-255f8b8eb3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209ed4c-207f-4e37-8c92-255f8b8eb3d1.jpg?1",
             "name": "Selesnya Guildmage",
             "text": "{3}{G}: Create a 1/1 green Saproling creature token.\n{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "5cb2c20c-9865-54ce-a3d3-d1b59e0a02ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac5292-9817-4f5d-b3fa-611f9ba44443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac5292-9817-4f5d-b3fa-611f9ba44443.jpg?1",
             "name": "Sen Triplets",
             "text": "At the beginning of your upkeep, choose target opponent. This turn, that player can't cast spells or activate abilities and plays with their hand revealed. You may play lands and cast spells from that player's hand this turn.",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "a04ced15-50bb-5d34-b5f0-6273369485f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af80ef38-ab95-476f-b0dd-b5ef3e9bceab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af80ef38-ab95-476f-b0dd-b5ef3e9bceab.jpg?1",
             "name": "Sharuum the Hegemon",
             "text": "Flying\nWhen Sharuum the Hegemon enters the battlefield, you may return target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -7565,7 +7565,7 @@
         },
         {
             "id": "9d6f4f0c-ba84-5904-b356-0b162b1c34c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad955c4d-248b-4468-a975-abad97cf84a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad955c4d-248b-4468-a975-abad97cf84a4.jpg?1",
             "name": "Sphinx Summoner",
             "text": "Flying\nWhen Sphinx Summoner enters the battlefield, you may search your library for an artifact creature card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "174fbff1-7570-5087-86d0-d6a4c700d583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a89a8f-b3a7-4c38-80fb-b5484ddbf8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a89a8f-b3a7-4c38-80fb-b5484ddbf8ec.jpg?1",
             "name": "Swiftblade Vindicator",
             "text": "Double strike, vigilance, trample",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "2931f6e6-8913-5504-9db1-eb4c2cf2138c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8dcd5e-d4d0-49ae-a591-78d80322105d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8dcd5e-d4d0-49ae-a591-78d80322105d.jpg?1",
             "name": "Thopter Foundry",
             "text": "{1}, Sacrifice a nontoken artifact: Create a 1/1 blue Thopter artifact creature token with flying. You gain 1 life.",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "10c4baba-dbe2-55b6-80f2-8d907d7cb209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8b424-0cec-490e-a571-bd051f952adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8b424-0cec-490e-a571-bd051f952adf.jpg?1",
             "name": "Time Sieve",
             "text": "{T}, Sacrifice five artifacts: Take an extra turn after this one.",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "c31ad170-9dc1-5c1f-a20e-cf8d44857023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402c2c37-9439-4393-b9d7-d7abe8045d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402c2c37-9439-4393-b9d7-d7abe8045d4d.jpg?1",
             "name": "Unlicensed Disintegration",
             "text": "Destroy target creature. If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller.",
             "colours": [
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "4852ed44-c6b6-568d-9581-a3b85b951c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0acfb7-c2d9-4b94-9ac6-9374856abad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0acfb7-c2d9-4b94-9ac6-9374856abad1.jpg?1",
             "name": "Vexing Shusher",
             "text": "This spell can't be countered.\n{RG}: Target spell can't be countered.",
             "colours": [
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "a637874c-282a-5d6f-8ba0-1160880a7949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5f9d21-4cc9-4b7e-9f55-322dcf91c1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5f9d21-4cc9-4b7e-9f55-322dcf91c1b7.jpg?1",
             "name": "Vish Kal, Blood Arbiter",
             "text": "Flying, lifelink\nSacrifice a creature: Put X +1/+1 counters on Vish Kal, Blood Arbiter, where X is the sacrificed creature's power.\nRemove all +1/+1 counters from Vish Kal: Target creature gets -1/-1 until end of turn for each +1/+1 counter removed this way.",
             "colours": [
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "6d0eb160-0cef-55cb-b18a-03f04b35767c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d1e843-71c9-4a65-bc36-d23858ef5ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d1e843-71c9-4a65-bc36-d23858ef5ead.jpg?1",
             "name": "Voice of Resurgence",
             "text": "Whenever an opponent casts a spell during your turn or when Voice of Resurgence dies, create a green and white Elemental creature token with \"This creature's power and toughness are each equal to the number of creatures you control.\"",
             "colours": [
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "d86e7f2e-67d1-5dcb-83ab-2ebb91055cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaa5ed4-041d-47d6-a4e0-baf8910430ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaa5ed4-041d-47d6-a4e0-baf8910430ed.jpg?1",
             "name": "Weapons Trainer",
             "text": "Other creatures you control get +1/+0 as long as you control an Equipment.",
             "colours": [
@@ -7892,7 +7892,7 @@
         },
         {
             "id": "0098d837-df32-5b07-9c7a-6b6d48d790d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac29eb6-2770-4723-942b-b393c2abc02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac29eb6-2770-4723-942b-b393c2abc02b.jpg?1",
             "name": "Yavimaya's Embrace",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets +2/+2 and has trample.",
             "colours": [
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "da3b4163-ec84-50ef-b17e-6f7d2f0b9b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa453daf-6ceb-4e45-bfb3-f6f45835ac11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa453daf-6ceb-4e45-bfb3-f6f45835ac11.jpg?1",
             "name": "Accomplished Automaton",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "a7f26cad-b758-5e0d-9cc4-9cc183f6c891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba16bfb3-dbd3-4b3a-b155-08b613268d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba16bfb3-dbd3-4b3a-b155-08b613268d57.jpg?1",
             "name": "Adaptive Automaton",
             "text": "As Adaptive Automaton enters the battlefield, choose a creature type.\nAdaptive Automaton is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "60d2a6aa-1fd3-5dae-b02e-99961460bcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79de5e7-1545-420c-bfe1-ee2444fca85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79de5e7-1545-420c-bfe1-ee2444fca85b.jpg?1",
             "name": "Basalt Monolith",
             "text": "Basalt Monolith doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{3}: Untap Basalt Monolith.",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "85ddf0ff-ce28-58a9-a22d-4c8ad0b4ae6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f3f0d-0609-46f0-a7b6-d933c4131f5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f3f0d-0609-46f0-a7b6-d933c4131f5c.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "691af5ad-c30b-5ce5-bd68-7f93a29bcf3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f16fdf-a3f5-462d-a64a-789d893b6ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f16fdf-a3f5-462d-a64a-789d893b6ef5.jpg?1",
             "name": "Batterskull",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return Batterskull to its owner's hand.\nEquip {5}",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "fa62fc90-4b85-582b-a775-2d1a8d900ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18adbda4-8d36-47cd-afbc-c785aaa8ed80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18adbda4-8d36-47cd-afbc-c785aaa8ed80.jpg?1",
             "name": "Blightsteel Colossus",
             "text": "Trample, infect, indestructible\nIf Blightsteel Colossus would be put into a graveyard from anywhere, reveal Blightsteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -8114,7 +8114,7 @@
         },
         {
             "id": "778fea48-fe4a-5131-9be9-c8bda0504501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90055174-ad09-4a0b-b65a-10ad80727d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90055174-ad09-4a0b-b65a-10ad80727d8e.jpg?1",
             "name": "Bosh, Iron Golem",
             "text": "Trample\n{3}{R}, Sacrifice an artifact: Bosh, Iron Golem deals damage equal to the sacrificed artifact's converted mana cost to any target.",
             "colours": [],
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "f9cdadf4-ad28-535d-9df8-b5c182814f37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ddba34-e627-4f4c-b78c-ea0c48a22537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ddba34-e627-4f4c-b78c-ea0c48a22537.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion dies, add {C}{C}{C}.",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "dc8cac42-15a4-52c7-b64f-c34a57afb550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf306f7f-b231-4343-807c-083df8b90c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf306f7f-b231-4343-807c-083df8b90c87.jpg?1",
             "name": "Chief of the Foundry",
             "text": "Other artifact creatures you control get +1/+1.",
             "colours": [],
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "14fb295b-1ba9-5a7c-9104-b32fb972d20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117fded3-1157-41a3-b37a-e76dcd1b5447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117fded3-1157-41a3-b37a-e76dcd1b5447.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color.\nWhen Chromatic Star is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "0788dfb0-f4d8-54c0-b158-ee2a644521b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340cbf7-5bbe-45b9-a4bf-d1caa500ff93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340cbf7-5bbe-45b9-a4bf-d1caa500ff93.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint \u2014 When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors.",
             "colours": [],
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "ddf5e2cb-2693-59a2-b861-5b4d670ad803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627ec9-f75c-4a9d-8a4f-1f632a67e17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627ec9-f75c-4a9d-8a4f-1f632a67e17b.jpg?1",
             "name": "Clone Shell",
             "text": "Imprint \u2014 When Clone Shell enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library in any order.\nWhen Clone Shell dies, turn the exiled card face up. If it's a creature card, put it onto the battlefield under your control.",
             "colours": [],
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "b80d3cf8-7ff6-55f7-8ded-7d6bd6211965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfde3f-f7d3-4902-b3cd-23f3fa53eff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfde3f-f7d3-4902-b3cd-23f3fa53eff4.jpg?1",
             "name": "Cogwork Assembler",
             "text": "{7}: Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "35620027-44d5-5da0-a3a9-50a4af80b136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3435fd09-a7a2-475e-a690-3c2011b70024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3435fd09-a7a2-475e-a690-3c2011b70024.jpg?1",
             "name": "Conjurer's Closet",
             "text": "At the beginning of your end step, you may exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [],
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "54c73f76-e8f9-54b7-925b-687016197c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572083a6-e105-43d8-ae72-e1701611f729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572083a6-e105-43d8-ae72-e1701611f729.jpg?1",
             "name": "Coretapper",
             "text": "{T}: Put a charge counter on target artifact.\nSacrifice Coretapper: Put two charge counters on target artifact.",
             "colours": [],
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "dc6d9b79-787c-5992-8e46-8938ce05fe4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1375f17-bc25-4a65-98b7-4785bbdbe974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1375f17-bc25-4a65-98b7-4785bbdbe974.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1}",
             "colours": [],
@@ -8422,7 +8422,7 @@
         },
         {
             "id": "ce0b2121-f514-565b-9418-e51a660222ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dc8c2a-928d-465e-8f76-82a90cc66854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dc8c2a-928d-465e-8f76-82a90cc66854.jpg?1",
             "name": "Culling Dais",
             "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
             "colours": [],
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "69953bd8-5cfb-5fd5-b2c9-ca5aedbe4ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6bfe57-872d-4f69-bff5-a3f2584d6e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6bfe57-872d-4f69-bff5-a3f2584d6e0a.jpg?1",
             "name": "Darksteel Axe",
             "text": "Indestructible\nEquipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "704eb2ef-caaa-5bbd-8684-b9b0fb66da62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421089c4-c8d3-48c5-b313-fb1741546271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421089c4-c8d3-48c5-b313-fb1741546271.jpg?1",
             "name": "Darksteel Forge",
             "text": "Artifacts you control have indestructible.",
             "colours": [],
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "80492ffe-a7c0-5ac8-83b3-526a2755cfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b39497c-79fc-437b-9d63-86d906c0455a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b39497c-79fc-437b-9d63-86d906c0455a.jpg?1",
             "name": "Duplicant",
             "text": "Imprint \u2014 When Duplicant enters the battlefield, you may exile target nontoken creature.\nAs long as a card exiled with Duplicant is a creature card, Duplicant has the power, toughness, and creature types of the last creature card exiled with Duplicant. It's still a Shapeshifter.",
             "colours": [],
@@ -8539,7 +8539,7 @@
         },
         {
             "id": "3ec0fd78-b9f4-5d02-b7ed-0421433ba1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b23ca61-157b-4616-bbf4-0c1298ddbbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b23ca61-157b-4616-bbf4-0c1298ddbbb4.jpg?1",
             "name": "Eager Construct",
             "text": "When Eager Construct enters the battlefield, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [],
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "9dc6a71f-2fe8-518e-8291-96cc9fb78d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a39fc25-f9f0-44ab-a94c-9720f8722620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a39fc25-f9f0-44ab-a94c-9720f8722620.jpg?1",
             "name": "Endless Atlas",
             "text": "{2}, {T}: Draw a card. Activate this ability only if you control three or more lands with the same name.",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "1d556750-351d-5c20-8c1f-21978ec8a743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420bf1e9-f2ec-4dff-b540-e64de71e58be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420bf1e9-f2ec-4dff-b540-e64de71e58be.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "fb734f32-6678-59bb-845a-548878d43aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf825a56-4870-463a-a2ef-eec86be891db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf825a56-4870-463a-a2ef-eec86be891db.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "982635ea-d722-5275-804f-ecbe774da065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd8112f-21e0-4272-9f0d-14d1ef989779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd8112f-21e0-4272-9f0d-14d1ef989779.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "8debbb01-9749-50f4-b280-4304e0f3cd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551c0a45-9515-4e51-84e5-79703832a661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551c0a45-9515-4e51-84e5-79703832a661.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "1fd37b49-dbe2-50b4-98ae-c79a5a61fcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b394f9-644d-426e-801b-110774092018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b394f9-644d-426e-801b-110774092018.jpg?1",
             "name": "Flayer Husk",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nEquip {2}",
             "colours": [],
@@ -8742,7 +8742,7 @@
         },
         {
             "id": "b108243c-71f0-52f6-a877-ac14227a3e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410c7922-5d99-4b94-bcdb-4f02ca175e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410c7922-5d99-4b94-bcdb-4f02ca175e65.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen Gleaming Barrier dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "417210e8-94db-540d-b12f-9ee358d2c973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ef4e1-52a5-4e73-9f71-5f12c96c8caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ef4e1-52a5-4e73-9f71-5f12c96c8caf.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -8804,7 +8804,7 @@
         },
         {
             "id": "032c606c-4222-5720-89bd-fde520bffaeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198804-a247-46b9-be6e-71bbb5840401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198804-a247-46b9-be6e-71bbb5840401.jpg?1",
             "name": "Golem-Skin Gauntlets",
             "text": "Equipped creature gets +1/+0 for each Equipment attached to it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8834,7 +8834,7 @@
         },
         {
             "id": "3ec7d1d5-5ef0-525b-92f8-ff98915c185c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbce79af-968a-481b-8cd7-a323c083851d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbce79af-968a-481b-8cd7-a323c083851d.jpg?1",
             "name": "Hammer of Nazahn",
             "text": "Whenever Hammer of Nazahn or another Equipment enters the battlefield under your control, you may attach that Equipment to target creature you control.\nEquipped creature gets +2/+0 and has indestructible.\nEquip {4}",
             "colours": [],
@@ -8866,7 +8866,7 @@
         },
         {
             "id": "3ce20325-2172-5e88-93f3-154ac6da6bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce84c30-5d59-4f0d-af44-96b993f3902f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce84c30-5d59-4f0d-af44-96b993f3902f.jpg?1",
             "name": "Ichor Wellspring",
             "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -8894,7 +8894,7 @@
         },
         {
             "id": "d88f923f-d7e0-5b46-92b9-f3c050a75e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545521f8-ab61-4f18-b290-16cd2c2d505e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545521f8-ab61-4f18-b290-16cd2c2d505e.jpg?1",
             "name": "Iron Bully",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Iron Bully enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "f1ae6bce-ce12-5406-9a67-fb6313c9cf75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60370058-da94-444b-aafd-23202296070b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60370058-da94-444b-aafd-23202296070b.jpg?1",
             "name": "Iron League Steed",
             "text": "Haste\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -8956,7 +8956,7 @@
         },
         {
             "id": "64220263-9879-58c2-b910-92cde60b2f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa24fe0-e275-4307-b26c-2a656068a451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa24fe0-e275-4307-b26c-2a656068a451.jpg?1",
             "name": "Isochron Scepter",
             "text": "Imprint \u2014 When Isochron Scepter enters the battlefield, you may exile an instant card with converted mana cost 2 or less from your hand.\n{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its mana cost.",
             "colours": [],
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "81c8ec18-70d3-5f0e-9135-39f87bfaee7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b89a074-9aca-4f7f-953a-b401199be1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b89a074-9aca-4f7f-953a-b401199be1cb.jpg?1",
             "name": "Jhoira's Familiar",
             "text": "Flying\nHistoric spells you cast cost {1} less to cast. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -9015,7 +9015,7 @@
         },
         {
             "id": "ea258112-1b50-5139-9e15-5783e1bc8007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c768267f-5ad2-4f4d-bbc7-6639325401c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c768267f-5ad2-4f4d-bbc7-6639325401c7.jpg?1",
             "name": "Kuldotha Forgemaster",
             "text": "{T}, Sacrifice three artifacts: Search your library for an artifact card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -9046,7 +9046,7 @@
         },
         {
             "id": "c29d9ba2-2197-54f8-b1f1-ffcd16718e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cec97f-0a2b-4543-a02e-d5e42d337790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cec97f-0a2b-4543-a02e-d5e42d337790.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -9078,7 +9078,7 @@
         },
         {
             "id": "b42db7ea-3105-5fb5-94d9-1160398bca7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b7fee-100b-444e-9f13-45b36fd10295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b7fee-100b-444e-9f13-45b36fd10295.jpg?1",
             "name": "Lux Cannon",
             "text": "{T}: Put a charge counter on Lux Cannon.\n{T}, Remove three charge counters from Lux Cannon: Destroy target permanent.",
             "colours": [],
@@ -9106,7 +9106,7 @@
         },
         {
             "id": "75449cdc-2490-58f6-9a82-af9ebc80b325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c879b-c566-431e-a8fa-6104c39b6d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c879b-c566-431e-a8fa-6104c39b6d7c.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -9134,7 +9134,7 @@
         },
         {
             "id": "583bf60c-cbde-52b0-8051-977206ef497b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d960186-4559-4af0-bd22-63baa15f8939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d960186-4559-4af0-bd22-63baa15f8939.jpg?1",
             "name": "Mana Crypt",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -9164,7 +9164,7 @@
         },
         {
             "id": "4d2599ca-cd0b-5dd9-bc91-365329ec1c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af244fed-ea12-4d8c-b090-91c5de62edb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af244fed-ea12-4d8c-b090-91c5de62edb8.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "You may have Masterwork of Ingenuity enter the battlefield as a copy of any Equipment on the battlefield.",
             "colours": [],
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "42df2acc-f685-5202-8463-c0b5bed6176d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fbdbb-f2ae-4823-9d2a-4c505332aa5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fbdbb-f2ae-4823-9d2a-4c505332aa5b.jpg?1",
             "name": "Mesmeric Orb",
             "text": "Whenever a permanent becomes untapped, that permanent's controller mills a card. (They put the top card of their library into their graveyard.)",
             "colours": [],
@@ -9222,7 +9222,7 @@
         },
         {
             "id": "a221382a-91ed-54f2-ad78-df53ae7ea881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3e1c7a-5672-4f76-9e04-a18cf0089fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3e1c7a-5672-4f76-9e04-a18cf0089fa7.jpg?1",
             "name": "Metalspinner's Puzzleknot",
             "text": "When Metalspinner's Puzzleknot enters the battlefield, you draw a card and you lose 1 life.\n{2}{B}, Sacrifice Metalspinner's Puzzleknot: You draw a card and you lose 1 life.",
             "colours": [],
@@ -9252,7 +9252,7 @@
         },
         {
             "id": "265a1471-d133-50b5-8bb8-bd0fdc241e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbbf9b-8fee-4c32-a513-02dac6ac8a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbbf9b-8fee-4c32-a513-02dac6ac8a39.jpg?1",
             "name": "Mishra's Bauble",
             "text": "{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "71b15a22-9e76-585f-b10c-10394291d5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56001a36-126b-4c08-af98-a6cc4d84210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56001a36-126b-4c08-af98-a6cc4d84210e.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -9312,7 +9312,7 @@
         },
         {
             "id": "930aeec3-c68e-5705-9bb1-9ed156fc3b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31837c7c-267a-4483-8712-406bfa7c4fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31837c7c-267a-4483-8712-406bfa7c4fde.jpg?1",
             "name": "Myr Battlesphere",
             "text": "When Myr Battlesphere enters the battlefield, create four 1/1 colorless Myr artifact creature tokens.\nWhenever Myr Battlesphere attacks, you may tap X untapped Myr you control. If you do, Myr Battlesphere gets +X/+0 until end of turn and deals X damage to the player or planeswalker it's attacking.",
             "colours": [],
@@ -9344,7 +9344,7 @@
         },
         {
             "id": "57ed239a-8f63-5329-966b-ea6662d74aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0149d4-0731-474a-a1c3-28c25e486c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0149d4-0731-474a-a1c3-28c25e486c14.jpg?1",
             "name": "Myr Retriever",
             "text": "When Myr Retriever dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "141bb905-a5a4-5fd9-9f8b-265e27db498b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08db5b31-6b5a-4b99-b103-d628afaea2ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08db5b31-6b5a-4b99-b103-d628afaea2ba.jpg?1",
             "name": "O-Naginata",
             "text": "O-Naginata can be attached only to a creature with power 3 or greater.\nEquipped creature gets +3/+0 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "dd5f2903-9362-59f5-9ab3-d19844a59568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbbeaf1-92ac-4ea4-8733-2da6af870542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbbeaf1-92ac-4ea4-8733-2da6af870542.jpg?1",
             "name": "Oblivion Stone",
             "text": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice Oblivion Stone: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "9224bce6-f8cc-5767-ae7c-69f42ddedf92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9bd97-f256-4dcd-b2a7-3239d443a0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9bd97-f256-4dcd-b2a7-3239d443a0af.jpg?1",
             "name": "Peace Strider",
             "text": "When Peace Strider enters the battlefield, you gain 3 life.",
             "colours": [],
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "25c91158-c5dc-52eb-aa37-5adb70e0c8fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2862c5-afa8-4e38-a312-483300f8b194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2862c5-afa8-4e38-a312-483300f8b194.jpg?1",
             "name": "Pentad Prism",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\nRemove a charge counter from Pentad Prism: Add one mana of any color.",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "0354c49b-7f88-5be8-a025-b8b10f9bf201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6982a82c-dd32-40d2-8dd2-ec92d0fc6c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6982a82c-dd32-40d2-8dd2-ec92d0fc6c2d.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, choose a nonland card name.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -9524,7 +9524,7 @@
         },
         {
             "id": "eec2052e-3f30-5fdf-b40c-4665968af48d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088c801d-381f-403b-aeb7-fbbfafee99bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088c801d-381f-403b-aeb7-fbbfafee99bf.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "{R}, Sacrifice Pyrite Spellbomb: It deals 2 damage to any target.\n{1}, Sacrifice Pyrite Spellbomb: Draw a card.",
             "colours": [],
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "27d81532-dae5-5508-a1b9-5ba09fc033e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd85da-9aba-46ea-9c10-617bec99a2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd85da-9aba-46ea-9c10-617bec99a2f5.jpg?1",
             "name": "Ratchet Bomb",
             "text": "{T}: Put a charge counter on Ratchet Bomb.\n{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "59a501d5-fa17-57f4-8111-4225b2ceb9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2847c7-2d48-48ca-8cc3-3c9a154ed69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2847c7-2d48-48ca-8cc3-3c9a154ed69d.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "df7765c9-6518-546a-b0fe-8622c7727cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54dc9-3b27-4e90-a423-3aeeb4cedb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54dc9-3b27-4e90-a423-3aeeb4cedb06.jpg?1",
             "name": "Sculpting Steel",
             "text": "You may have Sculpting Steel enter the battlefield as a copy of any artifact on the battlefield.",
             "colours": [],
@@ -9641,7 +9641,7 @@
         },
         {
             "id": "71b80e77-4126-5457-a7a1-5e6ae2257163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f449cc-461e-4e89-8cd2-83e539bb40f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f449cc-461e-4e89-8cd2-83e539bb40f4.jpg?1",
             "name": "Sickleslicer",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +2/+2.\nEquip {4}",
             "colours": [],
@@ -9671,7 +9671,7 @@
         },
         {
             "id": "6cf3c6ef-d08b-5969-8b24-4b4a4353513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c65e0ff-7dab-4090-8a99-f42d486728c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c65e0ff-7dab-4090-8a99-f42d486728c9.jpg?1",
             "name": "Skinwing",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +2/+2 and has flying.\nEquip {6}",
             "colours": [],
@@ -9701,7 +9701,7 @@
         },
         {
             "id": "d206ab68-7c2b-51b0-8833-7fe3f151cb45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9bf341-0060-467d-99b3-a5bc7f2270b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9bf341-0060-467d-99b3-a5bc7f2270b8.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "d0d48f5e-de5b-5205-85ea-9f3dac0d4545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cab5f-c05e-4688-b300-33ab0dd98598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31cab5f-c05e-4688-b300-33ab0dd98598.jpg?1",
             "name": "Sphinx of the Guildpact",
             "text": "Sphinx of the Guildpact is all colors.\nFlying\nHexproof from monocolored (This creature can't be the target of monocolored spells or abilities your opponents control.)",
             "colours": [
@@ -9778,7 +9778,7 @@
         },
         {
             "id": "feacfa10-caa2-52b7-bd29-76a98aa1ec69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b3869b-6da1-4b01-a2e7-2018d478b6e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b3869b-6da1-4b01-a2e7-2018d478b6e5.jpg?1",
             "name": "Springleaf Drum",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color.",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "2d78d695-a9ad-5002-9414-f39efad828ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ebb5d3-72b1-411d-8c90-83dac5b37898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ebb5d3-72b1-411d-8c90-83dac5b37898.jpg?1",
             "name": "Sundering Titan",
             "text": "When Sundering Titan enters the battlefield or leaves the battlefield, choose a land of each basic land type, then destroy those lands.",
             "colours": [],
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "2d3a8682-39c0-525d-b226-30018f76bc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3945c488-6966-4c7d-a0b7-487a2c1837aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3945c488-6966-4c7d-a0b7-487a2c1837aa.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "56800ad4-ba77-5f28-918d-4577ca9d3000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743fc231-2ab3-42f1-9dd3-af42241229aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743fc231-2ab3-42f1-9dd3-af42241229aa.jpg?1",
             "name": "Surge Node",
             "text": "Surge Node enters the battlefield with six charge counters on it.\n{1}, {T}, Remove a charge counter from Surge Node: Put a charge counter on target artifact.",
             "colours": [],
@@ -9898,7 +9898,7 @@
         },
         {
             "id": "16cfc604-974b-5de4-8180-6151288a80c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffe5f80-a2ac-41b8-8fce-fd3485643557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffe5f80-a2ac-41b8-8fce-fd3485643557.jpg?1",
             "name": "Sword of Body and Mind",
             "text": "Equipped creature gets +2/+2 and has protection from green and from blue.\nWhenever equipped creature deals combat damage to a player, you create a 2/2 green Wolf creature token and that player mills ten cards.\nEquip {2}",
             "colours": [],
@@ -9930,7 +9930,7 @@
         },
         {
             "id": "274b6fe3-662a-5dbb-a09b-53e1dc3aa548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7710eb5-c56a-437b-8847-2a829c404d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7710eb5-c56a-437b-8847-2a829c404d47.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -9962,7 +9962,7 @@
         },
         {
             "id": "6ff43bd3-30f1-5c32-aa04-4d7ba6670548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2626d4c9-fcef-4057-a154-7d987a4a4b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2626d4c9-fcef-4057-a154-7d987a4a4b84.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to any target and you draw a card.\nEquip {2}",
             "colours": [],
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "409e346d-62b1-5cbf-8f9f-478a54062926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378c8bf-85ed-4d28-aec9-4925d12bca4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378c8bf-85ed-4d28-aec9-4925d12bca4a.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -10026,7 +10026,7 @@
         },
         {
             "id": "6711036a-bb62-568c-b2da-e88a225c9116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0c2773-3205-4ac4-b31c-c54fb06fdd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0c2773-3205-4ac4-b31c-c54fb06fdd7c.jpg?1",
             "name": "Sword of the Meek",
             "text": "Equipped creature gets +1/+2.\nEquip {2}\nWhenever a 1/1 creature enters the battlefield under your control, you may return Sword of the Meek from your graveyard to the battlefield, then attach it to that creature.",
             "colours": [],
@@ -10056,7 +10056,7 @@
         },
         {
             "id": "5a8da3e2-b78a-595a-9c58-3d7a7cdbc601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e6f50b-4b18-4aab-a7b0-869f25bc4c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e6f50b-4b18-4aab-a7b0-869f25bc4c40.jpg?1",
             "name": "Sword of War and Peace",
             "text": "Equipped creature gets +2/+2 and has protection from red and from white.\nWhenever equipped creature deals combat damage to a player, Sword of War and Peace deals damage to that player equal to the number of cards in their hand and you gain 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "88661a0e-b6c6-561c-bfd9-adbb61d39072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5719f8b-0a65-4f0c-bde0-74c5e107b64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5719f8b-0a65-4f0c-bde0-74c5e107b64d.jpg?1",
             "name": "Throne of Geth",
             "text": "{T}, Sacrifice an artifact: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "8c5fd7a3-3e6a-5789-a908-3306e550944c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2808aa-1f30-42c3-a2d1-c9eb91828e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2808aa-1f30-42c3-a2d1-c9eb91828e66.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with converted mana cost 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "93463363-2e20-58ca-9c8a-b208799d8bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316caa4e-a53a-460b-978c-5f0fba7bc549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316caa4e-a53a-460b-978c-5f0fba7bc549.jpg?1",
             "name": "Trinisphere",
             "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to cast costs three mana to cast. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to cast costs {2}{B} to cast instead.)",
             "colours": [],
@@ -10175,7 +10175,7 @@
         },
         {
             "id": "0400ff81-cc28-5bbb-92a2-745010492627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74baa632-d046-401a-9172-1ab6284240bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74baa632-d046-401a-9172-1ab6284240bc.jpg?1",
             "name": "Tumble Magnet",
             "text": "Tumble Magnet enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Tumble Magnet: Tap target artifact or creature.",
             "colours": [],
@@ -10203,7 +10203,7 @@
         },
         {
             "id": "6fd054e8-fe75-5fa1-b0d8-1ce62ebcf522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7318db50-1b78-4cc0-954b-9798af26a633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7318db50-1b78-4cc0-954b-9798af26a633.jpg?1",
             "name": "Vulshok Gauntlets",
             "text": "Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10233,7 +10233,7 @@
         },
         {
             "id": "718b099b-ef4e-5bcf-87ca-49f49065e7a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5272436e-74f0-44c4-a291-ea8ebc3f1525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5272436e-74f0-44c4-a291-ea8ebc3f1525.jpg?1",
             "name": "Walking Ballista",
             "text": "Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to any target.",
             "colours": [],
@@ -10264,7 +10264,7 @@
         },
         {
             "id": "76b12bd0-da1e-5175-8da3-83f72014a0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275ec0c4-1c59-4818-9999-b2389d17c2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275ec0c4-1c59-4818-9999-b2389d17c2e7.jpg?1",
             "name": "Welding Jar",
             "text": "Sacrifice Welding Jar: Regenerate target artifact.",
             "colours": [],
@@ -10292,7 +10292,7 @@
         },
         {
             "id": "b5a86869-617b-56ed-a91e-b37f52abc98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d275f04-cc60-4e3f-95cc-3d02bc916b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d275f04-cc60-4e3f-95cc-3d02bc916b82.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Engine dies, create a 3/3 colorless Wurm artifact creature token with deathtouch and a 3/3 colorless Wurm artifact creature token with lifelink.",
             "colours": [],
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "1544787e-b20c-59fc-a454-72e4e71bc536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95b7645-154f-4904-bf71-db7eb24d4df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95b7645-154f-4904-bf71-db7eb24d4df2.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Put target artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "e8f3c2a6-ae83-5953-87f8-1e3d894b9b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4dd417-43fd-4dee-aaf2-80d425bd0191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4dd417-43fd-4dee-aaf2-80d425bd0191.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [],
@@ -10388,7 +10388,7 @@
         },
         {
             "id": "ebe2c3bb-5098-5206-ac5b-b7539defe17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac535c1-9ef3-45b5-8959-7e79589d47ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac535c1-9ef3-45b5-8959-7e79589d47ad.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {C}.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -10416,7 +10416,7 @@
         },
         {
             "id": "39a9a454-dce0-5647-ab69-d8f054dbf6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65afdc-a994-44cb-83f9-6e7f0f3ab2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65afdc-a994-44cb-83f9-6e7f0f3ab2f1.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -10444,7 +10444,7 @@
         },
         {
             "id": "bf8eda89-5ce5-5fa8-b454-088fea96da5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e912b4-492f-415b-b0ad-d9f90c6139c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e912b4-492f-415b-b0ad-d9f90c6139c6.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {C}.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R}.",
             "colours": [],
@@ -10475,7 +10475,7 @@
         },
         {
             "id": "51332a7a-56b3-5924-84e1-7f744cac6f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb17a0-5a13-4d02-b7fb-f99531bc8ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb17a0-5a13-4d02-b7fb-f99531bc8ca5.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -10506,7 +10506,7 @@
         },
         {
             "id": "0d6c5c1e-a053-591c-b8e4-98c045059f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd582037-8682-4738-b459-177a9d6e03b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd582037-8682-4738-b459-177a9d6e03b6.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Indestructible\n{T}: Add {C}.",
             "colours": [],
@@ -10535,7 +10535,7 @@
         },
         {
             "id": "501b356b-5d45-575f-ba70-3354e7bc830f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713d95ae-4217-4544-9e00-06854fd0c6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713d95ae-4217-4544-9e00-06854fd0c6c7.jpg?1",
             "name": "Fetid Heath",
             "text": "{T}: Add {C}.\n{WB}, {T}: Add {W}{W}, {W}{B}, or {B}{B}.",
             "colours": [],
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "cf5886aa-ff48-5e8a-b454-70ad553b7ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927d645-ca43-4b8e-9932-7e70acca7aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927d645-ca43-4b8e-9932-7e70acca7aa6.jpg?1",
             "name": "Fire-Lit Thicket",
             "text": "{T}: Add {C}.\n{RG}, {T}: Add {R}{R}, {R}{G}, or {G}{G}.",
             "colours": [],
@@ -10597,7 +10597,7 @@
         },
         {
             "id": "23fd13c0-630c-5031-b473-beb6782d5e2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45d763d-75f5-4d96-ae7c-9eb869d4dead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45d763d-75f5-4d96-ae7c-9eb869d4dead.jpg?1",
             "name": "Flooded Grove",
             "text": "{T}: Add {C}.\n{GW}, {T}: Add {G}{G}, {G}{U}, or {U}{U}.",
             "colours": [],
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "f507d50a-89ad-5f4e-8572-bbea500c41e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a639687-d9e3-46a8-bc9f-6ca3912c46ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a639687-d9e3-46a8-bc9f-6ca3912c46ab.jpg?1",
             "name": "Glimmervoid",
             "text": "At the beginning of the end step, if you control no artifacts, sacrifice Glimmervoid.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -10656,7 +10656,7 @@
         },
         {
             "id": "2b4ff631-a40f-5691-abcb-7c4d9eb61ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0127d42f-bf40-48f4-a3a0-1a1c4039f432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0127d42f-bf40-48f4-a3a0-1a1c4039f432.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {C}.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R}.",
             "colours": [],
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "1eb37f49-43b5-5904-9ab8-4e4bc7ac0938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c99e02f-52e7-4a42-87dc-966034be79c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c99e02f-52e7-4a42-87dc-966034be79c7.jpg?1",
             "name": "High Market",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: You gain 1 life.",
             "colours": [],
@@ -10715,7 +10715,7 @@
         },
         {
             "id": "03bc2366-034a-5f22-9ded-35f8727b8e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78114f25-f40a-4e2e-bf89-29ea9b3500e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78114f25-f40a-4e2e-bf89-29ea9b3500e2.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -10743,7 +10743,7 @@
         },
         {
             "id": "93cfe998-5cd6-57fe-8d93-654c1bbbda66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b6fe0c-7bbe-433f-8400-4be4ce0e3f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b6fe0c-7bbe-433f-8400-4be4ce0e3f15.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -10771,7 +10771,7 @@
         },
         {
             "id": "19deb0b2-2876-5afd-b32e-764bb83b5835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe71ae5-5553-4b41-89e0-fd767f9bf430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe71ae5-5553-4b41-89e0-fd767f9bf430.jpg?1",
             "name": "Mystic Gate",
             "text": "{T}: Add {C}.\n{WU}, {T}: Add {W}{W}, {W}{U}, or {U}{U}.",
             "colours": [],
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "5e3242ed-f501-5c83-8e33-d72ffe7a133b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd301-7d04-480d-94ed-52537d944c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd301-7d04-480d-94ed-52537d944c6f.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {C}.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W}.",
             "colours": [],
@@ -10833,7 +10833,7 @@
         },
         {
             "id": "b23e0292-97f4-51c9-a03f-62873d2861a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9181d30d-4f8e-421f-89b8-149ed8000fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9181d30d-4f8e-421f-89b8-149ed8000fb2.jpg?1",
             "name": "Sunken Ruins",
             "text": "{T}: Add {C}.\n{UB}, {T}: Add {U}{U}, {U}{B}, or {B}{B}.",
             "colours": [],
@@ -10864,7 +10864,7 @@
         },
         {
             "id": "eb2bbc76-d24d-54cf-a6fa-e114d45109dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a926d-7788-4668-8bd8-7572dbf5f5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a926d-7788-4668-8bd8-7572dbf5f5eb.jpg?1",
             "name": "Thespian's Stage",
             "text": "{T}: Add {C}.\n{2}, {T}: Thespian's Stage becomes a copy of target land, except it has this ability.",
             "colours": [],
@@ -10892,7 +10892,7 @@
         },
         {
             "id": "0de72cc6-eca4-55e1-9ff3-68b8aefeb152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c59bee-0369-4a34-832f-fe3829a391b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c59bee-0369-4a34-832f-fe3829a391b3.jpg?1",
             "name": "Twilight Mire",
             "text": "{T}: Add {C}.\n{BG}, {T}: Add {B}{B}, {B}{G}, or {G}{G}.",
             "colours": [],
@@ -10923,7 +10923,7 @@
         },
         {
             "id": "44aa5a93-15bb-5c79-8f05-332d9bbd7ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dea8f6-bd32-44a3-bec4-93a5607819df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dea8f6-bd32-44a3-bec4-93a5607819df.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -10956,7 +10956,7 @@
         },
         {
             "id": "fc4c79d8-5237-5051-9a6f-6e4ce2e84ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54445d1f-5426-47e9-9e02-0274cea7174f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54445d1f-5426-47e9-9e02-0274cea7174f.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -10989,7 +10989,7 @@
         },
         {
             "id": "779b1b57-193b-539b-87f0-7b7efe1fbc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e369f3f-354b-42bf-9b2f-286912730c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e369f3f-354b-42bf-9b2f-286912730c6c.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -11022,7 +11022,7 @@
         },
         {
             "id": "923a3506-93a4-58ef-9ffd-46645b2e02c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b591ec-0231-4b91-a132-eb3aedfdf8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b591ec-0231-4b91-a132-eb3aedfdf8fa.jpg?1",
             "name": "Wooded Bastion",
             "text": "{T}: Add {C}.\n{RW}, {T}: Add {G}{G}, {G}{W}, or {W}{W}.",
             "colours": [],
@@ -11053,7 +11053,7 @@
         },
         {
             "id": "511dc2ac-7185-5b74-99d4-1cb44a61ba02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d1a254-01a8-4590-8878-690c5bfb4a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d1a254-01a8-4590-8878-690c5bfb4a95.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -11087,7 +11087,7 @@
         },
         {
             "id": "516dd7a4-fad8-5eed-bcdb-c05088762303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec386bc3-137b-49b5-8380-8daff470f0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec386bc3-137b-49b5-8380-8daff470f0bc.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
             "colours": [
@@ -11125,7 +11125,7 @@
         },
         {
             "id": "9bf9c63a-0fe5-5bb2-9cef-32cc94c3aa29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db149aaa-3da9-48c4-92cc-b3d804285290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db149aaa-3da9-48c4-92cc-b3d804285290.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -11163,7 +11163,7 @@
         },
         {
             "id": "0df712a3-ef9f-5873-8693-50229c2bcf9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32301593-f16a-4a46-8a4e-eecedd2a9013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32301593-f16a-4a46-8a4e-eecedd2a9013.jpg?1",
             "name": "Council's Judgment",
             "text": "Will of the council \u2014 Starting with you, each player votes for a nonland permanent you don't control. Exile each permanent with the most votes or tied for most votes.",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "bfbb2163-e383-5446-b171-e99916050a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb49805c-8546-463d-b78c-f4ea109851b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb49805c-8546-463d-b78c-f4ea109851b4.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.\n{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
             "colours": [
@@ -11234,7 +11234,7 @@
         },
         {
             "id": "baa76f04-4212-5aa5-a5cc-9b0810add79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd595e2f-65e4-46e8-9d28-f94ac308b275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd595e2f-65e4-46e8-9d28-f94ac308b275.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -11268,7 +11268,7 @@
         },
         {
             "id": "00217f81-e16f-5f98-afd3-43160585826a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9baef6e-a086-41d4-a20e-486f01d72406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9baef6e-a086-41d4-a20e-486f01d72406.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -11302,7 +11302,7 @@
         },
         {
             "id": "9b764b1d-5130-5084-bba8-e5c866fd9c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec136ce7-bad4-4ebb-ab00-b86de3d209a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec136ce7-bad4-4ebb-ab00-b86de3d209a7.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -11336,7 +11336,7 @@
         },
         {
             "id": "1ca5702b-74db-514d-be83-d0ea017c17a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacaf5ec-6745-4584-9175-36c98742958f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacaf5ec-6745-4584-9175-36c98742958f.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "({PU} can be paid with either {U} or 2 life.)\nYou may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "65e2b37a-2b3a-5aaf-b1b1-0e699e3fcf63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c821158-f71a-48f9-b6b4-b0e605f22bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c821158-f71a-48f9-b6b4-b0e605f22bec.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -11411,7 +11411,7 @@
         },
         {
             "id": "1ead4754-36eb-5463-bf63-c1fe672bc3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a50516-a20f-4e6e-b4f2-0049b673f942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a50516-a20f-4e6e-b4f2-0049b673f942.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt \u2014 Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -11445,7 +11445,7 @@
         },
         {
             "id": "88400e06-e77c-55b6-bb5f-6809663e6824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702503-8f2d-46c8-abdb-6edd6c431d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702503-8f2d-46c8-abdb-6edd6c431d19.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -11479,7 +11479,7 @@
         },
         {
             "id": "8df896f3-ae43-5c65-9504-270cd5093aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73731e45-51bb-4188-a54d-fdaa4bdfaf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73731e45-51bb-4188-a54d-fdaa4bdfaf1f.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -11513,7 +11513,7 @@
         },
         {
             "id": "d765f102-5ce7-5add-9841-55ade11b3c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35575d0-0b10-4d1b-b5a2-a9f36f9eada4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35575d0-0b10-4d1b-b5a2-a9f36f9eada4.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -11547,7 +11547,7 @@
         },
         {
             "id": "eac74bc2-9497-501f-b44f-ac876eecc7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2058c-3f20-4566-b366-93a2cbbe682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2058c-3f20-4566-b366-93a2cbbe682f.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
             "colours": [
@@ -11584,7 +11584,7 @@
         },
         {
             "id": "c2d44d80-704b-5776-9629-738d1f1519c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c11ba-533d-48c9-821c-3fec846bca97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c11ba-533d-48c9-821c-3fec846bca97.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -11618,7 +11618,7 @@
         },
         {
             "id": "4b41a542-1730-55fc-a409-e8fb5c116a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187abedf-c2eb-453b-bea0-a10afa399e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187abedf-c2eb-453b-bea0-a10afa399e03.jpg?1",
             "name": "Crop Rotation",
             "text": "As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a land card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "f2bfda59-3560-55a7-80a1-9d19f1a1d163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c9c856-af15-40b1-a799-1c2066df2099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c9c856-af15-40b1-a799-1c2066df2099.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "08b103c0-7f31-539a-a600-2cc4665fee55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3fc61c-c26e-47f3-a1eb-f6f10f8469e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3fc61c-c26e-47f3-a1eb-f6f10f8469e2.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -11720,7 +11720,7 @@
         },
         {
             "id": "9533d949-e6d4-571f-a3fa-1c347f49045b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8008977f-b164-4ab7-a38a-25b382c6a16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8008977f-b164-4ab7-a38a-25b382c6a16f.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U}.",
             "colours": [
@@ -11759,7 +11759,7 @@
         },
         {
             "id": "f9924588-6741-531a-a72b-16e1248234e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac080ef-8f40-43a2-8440-b457b6074b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac080ef-8f40-43a2-8440-b457b6074b69.jpg?1",
             "name": "Atraxa, Praetors' Voice",
             "text": "Flying, vigilance, deathtouch, lifelink\nAt the beginning of your end step, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "4e23d3ea-bebe-5755-ba29-0cf04ff82400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f670f9-c5b7-4eb0-a7d0-d16513fadf74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f670f9-c5b7-4eb0-a7d0-d16513fadf74.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -11848,7 +11848,7 @@
         },
         {
             "id": "1c249118-08ce-5abf-a60d-455530c1836e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9847f3-5a4c-4b49-8e25-e444d1446bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9847f3-5a4c-4b49-8e25-e444d1446bf9.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage enters the battlefield, choose a nonland card name.\nSpells with the chosen name can't be cast.",
             "colours": [
@@ -11887,7 +11887,7 @@
         },
         {
             "id": "7bea19d9-e5a5-5275-b9d7-befe61f93f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc5ac8-b944-4b71-b022-c78183eb92c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc5ac8-b944-4b71-b022-c78183eb92c3.jpg?1",
             "name": "Batterskull",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Germ creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return Batterskull to its owner's hand.\nEquip {5}",
             "colours": [],
@@ -11919,7 +11919,7 @@
         },
         {
             "id": "d847642f-62a2-5541-abf1-b72620b53ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccd5597-2d4e-4f3e-94b7-46783486853a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccd5597-2d4e-4f3e-94b7-46783486853a.jpg?1",
             "name": "Blightsteel Colossus",
             "text": "Trample, infect, indestructible\nIf Blightsteel Colossus would be put into a graveyard from anywhere, reveal Blightsteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -11953,7 +11953,7 @@
         },
         {
             "id": "f0e5c86a-d541-5b77-957d-f63feb0d3d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e94d334-e043-42f2-ba5c-be497d82f2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e94d334-e043-42f2-ba5c-be497d82f2c8.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint \u2014 When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors.",
             "colours": [],
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "33641834-53ff-5ec2-b40a-479fcc151c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc6178b-16e7-4089-974f-7048b9632fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc6178b-16e7-4089-974f-7048b9632fc2.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "010ca5c3-0ec0-5ee7-a012-dfdd964bdee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70eab734-875b-4b76-901b-3ac7d2133ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70eab734-875b-4b76-901b-3ac7d2133ad9.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -12045,7 +12045,7 @@
         },
         {
             "id": "0fa179ca-39f2-5ba7-ae24-ccf5214f2da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cd274-ed83-475a-9b4f-adb9c780a6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cd274-ed83-475a-9b4f-adb9c780a6f4.jpg?1",
             "name": "Mana Crypt",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -12075,7 +12075,7 @@
         },
         {
             "id": "a225fb12-0b43-5711-9e39-02b901af1362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547e3aa5-d88a-4418-ab9d-dd65385f031b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547e3aa5-d88a-4418-ab9d-dd65385f031b.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -12107,7 +12107,7 @@
         },
         {
             "id": "4ee41bec-e81d-529f-b7f3-042faae33c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc0b4eb-8ee9-4213-8194-02e7d63428d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc0b4eb-8ee9-4213-8194-02e7d63428d3.jpg?1",
             "name": "Sword of Body and Mind",
             "text": "Equipped creature gets +2/+2 and has protection from green and from blue.\nWhenever equipped creature deals combat damage to a player, you create a 2/2 green Wolf creature token and that player mills ten cards.\nEquip {2}",
             "colours": [],
@@ -12139,7 +12139,7 @@
         },
         {
             "id": "52e3658b-6edc-52f8-90b9-0f6b8d783bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a469d00-1416-48dd-ad91-eb6f3fb4b42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a469d00-1416-48dd-ad91-eb6f3fb4b42b.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -12171,7 +12171,7 @@
         },
         {
             "id": "2ca04fb4-adc0-5263-8f1a-1912dbd8aa9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22cd80dd-1c57-423c-81e2-9a956901565f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22cd80dd-1c57-423c-81e2-9a956901565f.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to any target and you draw a card.\nEquip {2}",
             "colours": [],
@@ -12203,7 +12203,7 @@
         },
         {
             "id": "208bcf9f-fa26-5fcf-a506-5bed62581b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a195efe-8c4f-479d-bd0f-563ee4bb49a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a195efe-8c4f-479d-bd0f-563ee4bb49a1.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -12235,7 +12235,7 @@
         },
         {
             "id": "aa7a756d-49c3-5731-9493-c13742cd0c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c0681d-97da-4363-b75a-079c209e7e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c0681d-97da-4363-b75a-079c209e7e4a.jpg?1",
             "name": "Sword of War and Peace",
             "text": "Equipped creature gets +2/+2 and has protection from red and from white.\nWhenever equipped creature deals combat damage to a player, Sword of War and Peace deals damage to that player equal to the number of cards in their hand and you gain 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -12267,7 +12267,7 @@
         },
         {
             "id": "df0b5465-c327-5f52-b79b-819662ff0ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097accb-28ad-4b22-b615-103c74e07708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097accb-28ad-4b22-b615-103c74e07708.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Engine dies, create a 3/3 colorless Wurm artifact creature token with deathtouch and a 3/3 colorless Wurm artifact creature token with lifelink.",
             "colours": [],
@@ -12301,7 +12301,7 @@
         },
         {
             "id": "a6d54fb2-c2e7-592f-8551-fb8c64307a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e55604-56da-44b5-aa78-f5de76ce9d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e55604-56da-44b5-aa78-f5de76ce9d20.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Put target artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "6ae82cdd-ac8a-5183-8701-a216e731f126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e0452-5304-41fa-9e3a-a3fa5a571315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e0452-5304-41fa-9e3a-a3fa5a571315.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -12368,7 +12368,7 @@
         },
         {
             "id": "2a6bca5f-d886-567e-9a3d-cef2aa16fd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936335d7-1c4a-4fcd-80ff-cd4d4fcab8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936335d7-1c4a-4fcd-80ff-cd4d4fcab8c4.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -12401,7 +12401,7 @@
         },
         {
             "id": "8edeacf8-e29f-5c33-b588-b9cb1c6d14f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75672e0-fa2d-43c5-9381-e17f2fd6d3bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75672e0-fa2d-43c5-9381-e17f2fd6d3bc.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -12434,7 +12434,7 @@
         },
         {
             "id": "1da4d114-3355-50e7-8388-76d48f31e63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3db531-3f21-49a2-8aeb-d98b7db94397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3db531-3f21-49a2-8aeb-d98b7db94397.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12470,7 +12470,7 @@
         },
         {
             "id": "1154d51e-0f8c-5c98-b251-bb83f81f9f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f015fe9-c7fa-4503-b0cc-c0e7f098882f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f015fe9-c7fa-4503-b0cc-c0e7f098882f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12506,7 +12506,7 @@
         },
         {
             "id": "538f6fe0-2b63-594c-8fe2-06b82f0c03c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91595b00-6233-48be-a012-1e87bd704aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91595b00-6233-48be-a012-1e87bd704aca.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "b9377685-a89e-5ceb-8e58-bead1fbcb1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a51829-8319-4271-93b2-a7a635b30e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a51829-8319-4271-93b2-a7a635b30e80.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12578,7 +12578,7 @@
         },
         {
             "id": "93073301-4800-52f2-826d-35ef994e8528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5eef83-a3d4-44c7-a6cb-7f6803825b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5eef83-a3d4-44c7-a6cb-7f6803825b9e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12614,7 +12614,7 @@
         },
         {
             "id": "8fbb7d04-6299-5c69-bcf8-cd4a2cf572e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cb941f-e3cf-45d2-9989-2a0a454d5497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cb941f-e3cf-45d2-9989-2a0a454d5497.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12650,7 +12650,7 @@
         },
         {
             "id": "90a56b45-8298-5f31-b548-ad330d1f449c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6418bc71-de29-410c-baf3-f63f5615eee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6418bc71-de29-410c-baf3-f63f5615eee2.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12686,7 +12686,7 @@
         },
         {
             "id": "0fe1aeaa-6ab6-5ed0-b65e-d731b9ff23f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8584b531-6dfa-43b2-99ba-b614b147f9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8584b531-6dfa-43b2-99ba-b614b147f9a8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "cd828bea-b68d-5a81-b4b1-cc103c35713a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146b803f-0455-497b-8362-03da2547070d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146b803f-0455-497b-8362-03da2547070d.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12758,7 +12758,7 @@
         },
         {
             "id": "f4f409bb-98a9-5ac2-85a9-7ac9debd4152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10cf58b-e01e-413e-979b-c6fe9e93100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10cf58b-e01e-413e-979b-c6fe9e93100b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12794,7 +12794,7 @@
         },
         {
             "id": "cd131db0-d77b-5048-9f45-69e660389e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91be77a-bd5b-485f-b5ca-0e6148c236ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91be77a-bd5b-485f-b5ca-0e6148c236ca.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -12827,7 +12827,7 @@
         },
         {
             "id": "bcd861de-1206-5df9-a2c5-e6a3464b37b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef345fc-e64e-4053-b643-2f8648a5473a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef345fc-e64e-4053-b643-2f8648a5473a.jpg?1",
             "name": "Chord of Calling",
             "text": "",
             "colours": [
@@ -12860,7 +12860,7 @@
         },
         {
             "id": "4346b802-ff21-513e-8ba9-1bce9bc0d26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e3f3c1-866c-4214-82e0-dcca2d1aba1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e3f3c1-866c-4214-82e0-dcca2d1aba1e.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -12892,7 +12892,7 @@
         },
         {
             "id": "1d4754fb-6636-50bc-b84b-273f1dc27277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798cef87-237b-4e4a-b7ed-78d15c720391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798cef87-237b-4e4a-b7ed-78d15c720391.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -12923,7 +12923,7 @@
         },
         {
             "id": "20ed6cbc-ff63-5be7-acee-c6e34d490685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0335da-631f-46b8-bfa1-b2f210c91f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0335da-631f-46b8-bfa1-b2f210c91f5f.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -12958,7 +12958,7 @@
         },
         {
             "id": "d3de374f-d4ac-50db-a857-b28760fec851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f859b55c-0b49-4190-b1fa-94f97a59b57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f859b55c-0b49-4190-b1fa-94f97a59b57c.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -12993,7 +12993,7 @@
         },
         {
             "id": "697e7dfa-754d-5a54-8f27-63f88029538f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3683cc6-70e0-4d33-9fed-6a56ba8b6e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3683cc6-70e0-4d33-9fed-6a56ba8b6e9b.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -13029,7 +13029,7 @@
         },
         {
             "id": "427f8834-cc43-5c81-95ce-cb56615b806b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa14443-d02e-41db-942a-498857e6b83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa14443-d02e-41db-942a-498857e6b83c.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -13064,7 +13064,7 @@
         },
         {
             "id": "cd183a9e-8db1-5261-8f81-f27c0de1c01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483c8cd6-288c-49d7-ac28-642132f85259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483c8cd6-288c-49d7-ac28-642132f85259.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "b5b44ebe-3809-5952-95e8-ab372abbcddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8b4fc-238f-4c1f-ad98-a1769fd44eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8b4fc-238f-4c1f-ad98-a1769fd44eab.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [
@@ -13136,7 +13136,7 @@
         },
         {
             "id": "068c9dc1-ab3c-5fe7-af14-6005ebb4b874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3c99d1-ebd3-4eb4-ba04-941819394567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3c99d1-ebd3-4eb4-ba04-941819394567.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -13171,7 +13171,7 @@
         },
         {
             "id": "93b079d9-286b-5abd-a242-41344559f6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc467e-b345-446c-b9b7-5f164e6651a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc467e-b345-446c-b9b7-5f164e6651a4.jpg?1",
             "name": "Germ",
             "text": "",
             "colours": [
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "ffabd0a6-5006-5c9a-8718-531071d99107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb248ba0-2ee7-4994-be57-2bcc8df29680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb248ba0-2ee7-4994-be57-2bcc8df29680.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -13243,7 +13243,7 @@
         },
         {
             "id": "ce8711c2-89a5-5c92-b3ab-36d351e9ac92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2d434d-5d9b-4475-b421-6d004c988997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2d434d-5d9b-4475-b421-6d004c988997.jpg?1",
             "name": "Ape",
             "text": "",
             "colours": [
@@ -13278,7 +13278,7 @@
         },
         {
             "id": "2f121db8-67ac-5db9-b8e2-9c630b2ace68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d270aeed-b15f-46f9-97ba-ccce562caefa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d270aeed-b15f-46f9-97ba-ccce562caefa.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -13313,7 +13313,7 @@
         },
         {
             "id": "8a91a134-801f-57c0-b095-73380ee4edba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e49e47-d658-4378-9e83-7946f7346ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e49e47-d658-4378-9e83-7946f7346ede.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -13348,7 +13348,7 @@
         },
         {
             "id": "3df270fb-2842-5181-aeb3-6a653e0691bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e76d6-d8d5-410b-9b00-088c039b668f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e76d6-d8d5-410b-9b00-088c039b668f.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -13383,7 +13383,7 @@
         },
         {
             "id": "e4b71c7b-3c28-599f-a717-8da11efef5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d05bfc-c447-474a-9ec9-9f4772821bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d05bfc-c447-474a-9ec9-9f4772821bfb.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -13418,7 +13418,7 @@
         },
         {
             "id": "35397384-bc4d-5df0-a6e7-a22d246a9ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95483574-95b7-42a3-b700-616189163b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95483574-95b7-42a3-b700-616189163b0a.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "b414d100-00cf-51eb-84fc-f0e4d50fb8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa846cf5-c618-4304-bb92-5df936ebca9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa846cf5-c618-4304-bb92-5df936ebca9b.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -13488,7 +13488,7 @@
         },
         {
             "id": "b484e108-19d6-592c-97c1-a25761a1d38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371056-43dd-41ab-8d05-b16a8bdc8d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371056-43dd-41ab-8d05-b16a8bdc8d28.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -13523,7 +13523,7 @@
         },
         {
             "id": "12178f65-27ca-5393-b766-89bb2bd13cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676704a-419e-4a00-a052-bca2ad34ecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8676704a-419e-4a00-a052-bca2ad34ecae.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -13560,7 +13560,7 @@
         },
         {
             "id": "d76f682c-a7c1-53dc-88d1-9a1237a3d1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8caa61-e294-4501-b357-a44abd77d09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8caa61-e294-4501-b357-a44abd77d09a.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "37292e23-13f4-5108-bac2-2e75f92f6a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dfd9b9-8214-4e20-b1c9-48c9f7276883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dfd9b9-8214-4e20-b1c9-48c9f7276883.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -13629,7 +13629,7 @@
         },
         {
             "id": "fc308b6a-24aa-5500-b6b8-98e72a4cfce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7becaa04-f142-4163-9286-00018b95c4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7becaa04-f142-4163-9286-00018b95c4ca.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -13661,7 +13661,7 @@
         },
         {
             "id": "37c45f60-9cdb-5706-8070-48d24b7ece38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -13693,7 +13693,7 @@
         },
         {
             "id": "dcad146d-8118-5810-ae0a-252f4adf69ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e32b9-431c-43d9-a0df-d73f4ff4fbc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e32b9-431c-43d9-a0df-d73f4ff4fbc2.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "dfdf8ee7-220c-53dd-b7b7-74c65fb75df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75602e25-a0ab-430e-b610-5e12c1cab3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75602e25-a0ab-430e-b610-5e12c1cab3d8.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -13757,7 +13757,7 @@
         },
         {
             "id": "adf54ee8-8ed7-51d9-909c-ba875c4f64e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791f5fa0-f972-455e-9802-ff299853607f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791f5fa0-f972-455e-9802-ff299853607f.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -13788,7 +13788,7 @@
         },
         {
             "id": "ced7b783-d646-567a-a951-6a1ad02808b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7822b-f155-4f3f-b835-ec64f3a71307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7822b-f155-4f3f-b835-ec64f3a71307.jpg?1",
             "name": "Tuktuk the Returned",
             "text": "",
             "colours": [],
@@ -13821,7 +13821,7 @@
         },
         {
             "id": "27b9da7b-7621-59be-a477-1137f41b7a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68e816f-f9ac-435b-ad0b-ceedbe72447a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68e816f-f9ac-435b-ad0b-ceedbe72447a.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -13853,7 +13853,7 @@
         },
         {
             "id": "8639ed93-ad63-5cd8-ac84-9cb0e6b91869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee0db9-ac89-4ab6-ac2e-8a7527d9ecbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee0db9-ac89-4ab6-ac2e-8a7527d9ecbd.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -13885,7 +13885,7 @@
         },
         {
             "id": "70911aa0-1297-5263-b92c-2348ab09b87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6870a2af-80e1-4813-a332-2b1bd789f1c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6870a2af-80e1-4813-a332-2b1bd789f1c1.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/4ED.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/4ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c10487df-6778-58a4-ae45-29f4d7682d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c931a4-297a-4f7f-8f71-6bdcbe4e94b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c931a4-297a-4f7f-8f71-6bdcbe4e94b7.jpg?1",
             "name": "Alabaster Potion",
             "text": "Give target player X life, or prevent X damage to any creature or player.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "bfb86ce8-1503-562b-a219-07fe40d22572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27de9b02-1810-41ee-aa90-5d89b6e1bf87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27de9b02-1810-41ee-aa90-5d89b6e1bf87.jpg?1",
             "name": "Amrou Kithkin",
             "text": "No creature with power greater than 2 may be assigned to block Kithkin.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "0c7d298c-2472-5925-9e43-9be7602b3171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26d1c4d-af95-4b40-83a5-b51f8b2506db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26d1c4d-af95-4b40-83a5-b51f8b2506db.jpg?1",
             "name": "Angry Mob",
             "text": "Trample\nDuring your turn, Angry Mob has power and toughness each equal to 2 plus the total number of swamps opponents control. During other turns, Angry Mob has power and toughness 2/2.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "0fda6d00-c69d-5fdf-bceb-f6c492003600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ee58e5-f493-4e27-9639-5599a9573387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ee58e5-f493-4e27-9639-5599a9573387.jpg?1",
             "name": "Animate Wall",
             "text": "Target wall can now attack.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "78ca99cd-de79-5473-bd30-e0ae3445f90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0794bc35-a8e1-4268-87b2-af5483ca6e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0794bc35-a8e1-4268-87b2-af5483ca6e5e.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -165,7 +165,7 @@
         },
         {
             "id": "63249fc5-9772-5ab6-aae1-6e9310dab473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3e219d-8e5e-44c7-97b3-2d489e2808b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3e219d-8e5e-44c7-97b3-2d489e2808b9.jpg?1",
             "name": "Balance",
             "text": "Each player sacrifices enough lands to equalize the number of lands all players control. The player who controls the fewest lands cannot sacrifice any in this way. All players then equalize cards in hand and then creatures in play in the same way.",
             "colours": [
@@ -196,7 +196,7 @@
         },
         {
             "id": "364f7d3d-2910-51f4-bf79-916ae5b18413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd204832-5f3b-4213-9c06-b89a296a9d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd204832-5f3b-4213-9c06-b89a296a9d47.jpg?1",
             "name": "Benalish Hero",
             "text": "Banding",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "5dda15e5-5bc9-5d67-b249-780e1fa3c843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218b1327-5f76-4ee2-a93d-d2ba412043c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218b1327-5f76-4ee2-a93d-d2ba412043c2.jpg?1",
             "name": "Black Ward",
             "text": "Target creature gains protection from black. The protection granted by Black Ward does not destroy Black Ward.",
             "colours": [
@@ -263,7 +263,7 @@
         },
         {
             "id": "9521e85c-e633-57f1-9bd6-4a7b80c53503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea35ac3-071d-4a42-9a7a-9104fe63bddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea35ac3-071d-4a42-9a7a-9104fe63bddc.jpg?1",
             "name": "Blessing",
             "text": "oo\nW Target creature Blessing enchants gets +1/+1 until end of turn.",
             "colours": [
@@ -296,7 +296,7 @@
         },
         {
             "id": "6ab3c740-65d0-5b6d-802d-3e5c78c44b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de62c833-c66b-442e-99ed-99ccd8eca024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de62c833-c66b-442e-99ed-99ccd8eca024.jpg?1",
             "name": "Blue Ward",
             "text": "Target creature gains protection from blue. The protection granted by Blue Ward does not destroy Blue Ward.",
             "colours": [
@@ -329,7 +329,7 @@
         },
         {
             "id": "4c5d42b7-096d-52c1-b07e-8940da5887f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c6d853-dc3a-4eed-894a-b58bf6e56dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c6d853-dc3a-4eed-894a-b58bf6e56dc8.jpg?1",
             "name": "Brainwash",
             "text": "Target creature cannot attack unless its controller pays an additional o3.",
             "colours": [
@@ -362,7 +362,7 @@
         },
         {
             "id": "89d5a4eb-73ca-5d85-9887-5d856ee92753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ee86b-222b-4d7a-9c5b-ea10e1d73756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ee86b-222b-4d7a-9c5b-ea10e1d73756.jpg?1",
             "name": "Castle",
             "text": "Untapped creatures you control get +0/+2 when not attacking.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "87ad7a17-0deb-58e6-8992-917d2dc93faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfddcee-704f-4189-8cb0-6025fe98d7e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfddcee-704f-4189-8cb0-6025fe98d7e9.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "o2: Prevent all damage against you from one artifact source. If a source deals damage to you more than once in a turn, you may pay o2 each time to prevent the damage.",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "8e452bb5-e4c0-5ce5-b2bb-3a80304a5c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9971cbae-3f08-48c6-955a-76ce8ed41c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9971cbae-3f08-48c6-955a-76ce8ed41c6c.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage against you from one black source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "2fbb52d9-cfa7-5d17-b4cd-8327dffe99bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7cdfd5-bef9-4f33-b81a-2a395c9bba29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7cdfd5-bef9-4f33-b81a-2a395c9bba29.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage against you from one blue source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "62a82db6-c716-5ef3-9cfb-f0e8cb44e18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192c50c5-ef98-47bd-9cab-cb3feaf6080b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192c50c5-ef98-47bd-9cab-cb3feaf6080b.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage against you from one green source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "ce1ab841-a843-5cd2-b1e2-325caa3060ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3575259-b019-47d0-a6d3-3fe4963294ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3575259-b019-47d0-a6d3-3fe4963294ae.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage against you from one red source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "24941298-728b-532c-812a-af9da26c54d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e1e153-cf5c-429a-9680-53b7c89dbd88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e1e153-cf5c-429a-9680-53b7c89dbd88.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage against you from one white source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "c4624be3-f634-59ef-9f8b-eb98722c1eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df33281-bebc-4c2a-97ce-528a67574670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df33281-bebc-4c2a-97ce-528a67574670.jpg?1",
             "name": "Conversion",
             "text": "All mountains become basic plains. During your upkeep, pay o\nWo\nW or destroy Conversion.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "ff21a76c-2d99-58b5-8314-79b04833e098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5428ef-847d-4ac1-b9a9-31afe155650f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5428ef-847d-4ac1-b9a9-31afe155650f.jpg?1",
             "name": "Crusade",
             "text": "All white creatures get +1/+1.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "1a99cbfa-5512-521c-94dc-301837eaed40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c54ffe-2479-4178-a5dc-dca7b564efce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c54ffe-2479-4178-a5dc-dca7b564efce.jpg?1",
             "name": "Death Ward",
             "text": "Regenerate target creature.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "d4dd8e58-7b6a-503a-81ad-cffeceb43fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a915f261-2cdc-499c-9163-da5b628b0127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a915f261-2cdc-499c-9163-da5b628b0127.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target enchantment or artifact.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "2baa2816-21d2-56d2-9fef-352e3475e1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59605bf-27d8-47ca-805e-527aab6ddf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59605bf-27d8-47ca-805e-527aab6ddf70.jpg?1",
             "name": "Divine Transformation",
             "text": "Target creature gets +3/+3.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "c32d2c8c-1ae2-520b-a72c-db35b04a6756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188d0d4-cd7c-4314-ae65-cb49e4674241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188d0d4-cd7c-4314-ae65-cb49e4674241.jpg?1",
             "name": "Elder Land Wurm",
             "text": "Trample\nCannot attack until assigned as a blocker.",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "4119e22a-fac6-581c-a7e5-22367e4ede6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc41bca-73fc-42da-b639-b73a8de8a9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc41bca-73fc-42da-b639-b73a8de8a9c6.jpg?1",
             "name": "Eye for an Eye",
             "text": "You may cast Eye for an Eye only when a creature, spell, or effect deals damage to you. Eye for an Eye deals an equal amount of damage to the controller of that creature, spell, or effect. If another spell or effect reduces the amount of damage you receive, it does not reduce the damage dealt by Eye for an Eye.",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "526661d6-c7f2-5260-9795-d837f306219c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f89968f-0182-4639-96fd-0dc94b6ad926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f89968f-0182-4639-96fd-0dc94b6ad926.jpg?1",
             "name": "Fortified Area",
             "text": "All walls you control gain banding and get +1/+0.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "de3c157c-a2e1-5c4a-a5ad-2b18cc56ecb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7548dc7-11dc-4611-85a5-71bdb48d8a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7548dc7-11dc-4611-85a5-71bdb48d8a62.jpg?1",
             "name": "Green Ward",
             "text": "Target creature gains protection from green. The protection granted by Green Ward does not destroy Green Ward.",
             "colours": [
@@ -865,7 +865,7 @@
         },
         {
             "id": "c9d0c5f4-59d8-5878-9631-eeaac714d27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd08b3b-196e-43a5-9318-9dae9edc6d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd08b3b-196e-43a5-9318-9dae9edc6d12.jpg?1",
             "name": "Healing Salve",
             "text": "Give target player 3 life, or prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "e131ef26-266c-5e65-a3a0-cbff91f83e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9dba-f621-4700-8a36-bf326e04cbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9dba-f621-4700-8a36-bf326e04cbac.jpg?1",
             "name": "Holy Armor",
             "text": "Target creature gets +0/+2.\noo\nW Target creature Holy Armor enchants gets +0/+1 until end of turn.",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "a91a7d35-965f-5847-a0ef-76a6558b74a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9f19-66d1-44e5-9aed-955e6bfd9902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9f19-66d1-44e5-9aed-955e6bfd9902.jpg?1",
             "name": "Holy Strength",
             "text": "Target creature gets +1/+2.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "cb3108b4-0dab-5bc9-ae3a-b9197960c963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0eff4d1-4ce6-48b1-84ae-a95bd1d04d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0eff4d1-4ce6-48b1-84ae-a95bd1d04d16.jpg?1",
             "name": "Island Sanctuary",
             "text": "During your draw phase, you may draw one less card from your library. If you do so, until start of your next turn the only creatures that can attack you are those with flying or islandwalk.",
             "colours": [
@@ -993,7 +993,7 @@
         },
         {
             "id": "86e48276-2df9-55db-8de1-695a5aa884ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acd8dd7-f561-487f-abae-4ad910db9d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acd8dd7-f561-487f-abae-4ad910db9d27.jpg?1",
             "name": "Karma",
             "text": "During each player's upkeep, Karma deals 1 damage to that player for each swamp he or she controls.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "715acb28-4809-5877-b14a-42c93ae6fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2381234-cf5a-4baf-89f9-cdec15557cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2381234-cf5a-4baf-89f9-cdec15557cf4.jpg?1",
             "name": "Kismet",
             "text": "All of target player's creatures, lands, and artifacts come into play tapped.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "304ce4d5-b1af-53a2-bcdd-578a8dd6bbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1301e203-7d9a-4735-8db3-7882ad70d343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1301e203-7d9a-4735-8db3-7882ad70d343.jpg?1",
             "name": "Land Tax",
             "text": "During your upkeep, if an opponent controls more land than you, you may search your library and remove up to three basic land cards and put them into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "5da5d6cc-806d-57c9-a491-11cdd76ae321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c0faf1-0c16-441a-97fd-6d4e91c894a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c0faf1-0c16-441a-97fd-6d4e91c894a5.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Flying, banding",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "66fed355-a8b8-5dca-87cf-07159d22ad95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52cdfe3-fca1-420c-b5c0-2366ea58345b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52cdfe3-fca1-420c-b5c0-2366ea58345b.jpg?1",
             "name": "Morale",
             "text": "All attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "81bed4a3-b841-5f88-9cbc-c1bd4b3b2959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e97dce-6bef-480d-939e-d35cfbf6b989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e97dce-6bef-480d-939e-d35cfbf6b989.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target black permanent.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "3220c226-8e9b-5dab-806f-c0b6d886d746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da915d3c-8d43-44c2-9052-08c1cd2afa7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da915d3c-8d43-44c2-9052-08c1cd2afa7b.jpg?1",
             "name": "Osai Vultures",
             "text": "Flying\nAt the end of any turn in which a creature is put into the graveyard from play, put a carrion counter on Vultures.\no0: Remove two carrion counters to give Vultures +1/+1 until end of turn.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "8534ea4c-c654-5c03-a625-3fb1a7035c62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acc78fc-1eab-47aa-993d-6781b2d2408a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acc78fc-1eab-47aa-993d-6781b2d2408a.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "157b620d-3e30-5552-99e4-faa23d55eb41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b107c80-0c9a-46cd-8f00-26c37f080ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b107c80-0c9a-46cd-8f00-26c37f080ce7.jpg?1",
             "name": "Personal Incarnation",
             "text": "Owner may redirect any or all damage done to Personal Incarnation to self instead. If Personal Incarnation is put into the graveyard from play, owner loses half his or her remaining life, rounding up the loss. Effects that redirect or prevent damage cannot be used to counter this loss of life.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "b171c92d-f1e0-5299-a080-5cb0fb916df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4942a9f-6b8f-438b-a2ea-366228038ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4942a9f-6b8f-438b-a2ea-366228038ed8.jpg?1",
             "name": "Piety",
             "text": "All blocking creatures get +0/+3 until end of turn.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "b9b7d0bf-b500-56b0-a26c-573f6bbbf584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015cc1ad-8b9f-484c-aa7d-d44f7bc914d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015cc1ad-8b9f-484c-aa7d-d44f7bc914d2.jpg?1",
             "name": "Pikemen",
             "text": "Banding, first strike",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "2e75c100-be1e-53af-bad9-cccd6580ae40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5736fcc7-fa95-4ef4-b821-392ec00e03bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5736fcc7-fa95-4ef4-b821-392ec00e03bf.jpg?1",
             "name": "Purelace",
             "text": "Change the color of target spell or target permanent to white. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "c693bef0-8717-54a4-b06a-a13a47500f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e8ec0-f36a-46a6-b7b1-e983e90a091a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543e8ec0-f36a-46a6-b7b1-e983e90a091a.jpg?1",
             "name": "Red Ward",
             "text": "Target creature gains protection from red. The protection granted by Red Ward does not destroy Red Ward.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "caad38ad-d173-5b71-9649-495a77219e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd458c66-0183-4bad-a651-6fe52a6d14c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd458c66-0183-4bad-a651-6fe52a6d14c4.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage dealt to you so far this turn by one source is retroactively added to your life total instead of subtracted. Further damage this turn is treated normally.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "97a3e95c-681f-5127-91d4-87a894290f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fccc7f2-b317-40c4-9b55-658d67dca843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fccc7f2-b317-40c4-9b55-658d67dca843.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "694043fd-331e-5b17-9cda-b78ccc2bcedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b354858f-d25b-4264-8a0b-fecc3a58db6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b354858f-d25b-4264-8a0b-fecc3a58db6d.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "441235a0-79b8-5e5c-95d2-99a24e7dc808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ee9127-d007-48e8-b797-88ef72bc7c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ee9127-d007-48e8-b797-88ef72bc7c8b.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "4bffee75-885e-5012-8c46-92b9ace8b664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052825f-d9fc-4820-b8c4-dbc204730b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052825f-d9fc-4820-b8c4-dbc204730b7c.jpg?1",
             "name": "Seeker",
             "text": "Target creature cannot be blocked except by white creatures and artifact creatures.",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "ebb16e0f-415a-55e0-92b1-1af287fbf624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8072d00a-82ff-4406-bdf8-1af20cd3a170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8072d00a-82ff-4406-bdf8-1af20cd3a170.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nAttacking does not cause Serra Angel to tap.",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "f165113f-c7c2-513c-b7e7-876f870f0be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58838b77-3bac-41b7-8055-5737c07df12e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58838b77-3bac-41b7-8055-5737c07df12e.jpg?1",
             "name": "Spirit Link",
             "text": "Gain 1 life for every 1 damage target creature deals. You may gain more life than the toughness or the total life of the creature or player damaged by the creature Spirit Link enchants.",
             "colours": [
@@ -1641,7 +1641,7 @@
         },
         {
             "id": "008f142f-f9c0-507b-802f-5f2d4b715cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd501ae-5814-4336-a45b-2b88cb85d29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd501ae-5814-4336-a45b-2b88cb85d29e.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Remove target creature from the game. The creature's controller gains life equal to its power.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "873beb7b-4710-563a-8870-60a31aaa01e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8527ac-27c3-4e2d-b46c-bfd6a1e1f778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8527ac-27c3-4e2d-b46c-bfd6a1e1f778.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "4f6347e9-f5e1-5121-8070-b710082ec50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fed0e6-0e56-4987-b0dd-b294156c0233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fed0e6-0e56-4987-b0dd-b294156c0233.jpg?1",
             "name": "Visions",
             "text": "Look at the top five cards of any library. You may then shuffle that library.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "dbfe8903-1451-5f01-ad75-637c202ff8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ffa85c-61c4-49b7-8946-ab353355a11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ffa85c-61c4-49b7-8946-ab353355a11c.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "b4e8acaf-c2f4-5f54-806b-260a771050b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8f8a10-6984-46a7-a641-5f712dab5c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8f8a10-6984-46a7-a641-5f712dab5c57.jpg?1",
             "name": "White Knight",
             "text": "Protection from black, first strike",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "1728d672-b2c4-5606-b88f-527af949c897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c467f-0e33-43e8-b108-0ea00d6adcc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c467f-0e33-43e8-b108-0ea00d6adcc2.jpg?1",
             "name": "White Ward",
             "text": "Target creature gains protection from white. The protection granted by White Ward does not destroy White Ward.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "eaaabf41-5f10-55b1-a76d-fb81bbf33095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4566f6a3-4d25-4df0-84be-fe4201138955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4566f6a3-4d25-4df0-84be-fe4201138955.jpg?1",
             "name": "Wrath of God",
             "text": "Bury all creatures.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "31100617-7483-5f16-aa37-92e99b633cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cfaefb-764c-4c56-bdb3-5f0375168597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cfaefb-764c-4c56-bdb3-5f0375168597.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "aa664d4b-c72e-566e-98a0-52998f79a2a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea613c48-258b-499d-975b-f56fbef3c665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea613c48-258b-499d-975b-f56fbef3c665.jpg?1",
             "name": "Animate Artifact",
             "text": "Target artifact becomes an artifact creature with power and toughness each equal to its casting cost; target retains all its original abilities. Animate Artifact does not affect artifact creatures.",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "889e912b-8543-5857-b0e2-c9a05005a706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ef569e-91e7-45f5-83b0-5a820242c628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ef569e-91e7-45f5-83b0-5a820242c628.jpg?1",
             "name": "Apprentice Wizard",
             "text": "o\nU, oc\nT: Add o3 to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "bd6b2e65-5f83-5607-bc9d-c8fd647713df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad34094d-a7ec-4b04-a288-4d4f1a07fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad34094d-a7ec-4b04-a288-4d4f1a07fc6b.jpg?1",
             "name": "Backfire",
             "text": "Backfire deals 1 damage to target creature's controller for each 1 damage dealt to you by that creature.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "bca136d4-afd7-5e1a-ace5-b4b3da26ee54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988f7b31-24b2-45c2-89e4-ff6bd9e0c8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988f7b31-24b2-45c2-89e4-ff6bd9e0c8c7.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Counter target red spell or destroy target red permanent.",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "e23005af-b7ab-5f6a-828c-a9b6aa5466c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb371e5-424e-42dd-9966-732c22e8ece8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb371e5-424e-42dd-9966-732c22e8ece8.jpg?1",
             "name": "Control Magic",
             "text": "Gain control of target creature.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "30b90630-2945-5fc0-ac1d-643a19086498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8493631-6c9c-40a8-b7de-ecf26ba6bf7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8493631-6c9c-40a8-b7de-ecf26ba6bf7d.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "7b977d05-008c-55db-b2c6-23857a00ca23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5ee5-a033-4a58-bdcb-ef54e6c8b7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5ee5-a033-4a58-bdcb-ef54e6c8b7a9.jpg?1",
             "name": "Creature Bond",
             "text": "If target creature is put into the graveyard, Creature Bond deals damage equal to the creature's toughness to that creature's controller.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "5c4cbeda-2857-5c9a-bd7b-439dcd06bd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3009237-fb96-497f-9a6e-b93b8115528a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3009237-fb96-497f-9a6e-b93b8115528a.jpg?1",
             "name": "Drain Power",
             "text": "Target player must draw all mana from his or her available lands; then, all mana in target player's mana pool drains into your mana pool.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "32d77666-3967-53cc-88a1-139e59890664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfa8400-1820-4108-a7f3-6ae8a1897f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfa8400-1820-4108-a7f3-6ae8a1897f0c.jpg?1",
             "name": "Energy Flux",
             "text": "During each player's upkeep, destroy all artifacts that player controls. The player may pay an additional o2 for each artifact he or she wishes to prevent Energy Flux from destroying.",
             "colours": [
@@ -2190,7 +2190,7 @@
         },
         {
             "id": "78258377-db37-5add-bcd3-559f1b682bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67692d-9df6-4841-a36b-26c28110b63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67692d-9df6-4841-a36b-26c28110b63b.jpg?1",
             "name": "Energy Tap",
             "text": "Tap target creature you control. Add an amount of colorless mana equal to that creature's casting cost to your mana pool.",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "3839846f-6f88-552d-898f-f94acaae94d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc539ff-03f5-4bec-877a-061fb5d40de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc539ff-03f5-4bec-877a-061fb5d40de9.jpg?1",
             "name": "Erosion",
             "text": "During his or her upkeep, target land's controller pays o1 or 1 life, or target land is destroyed. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "411bf62f-97f1-5314-ac49-d9dc181feb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5a60e6-be5f-454e-a354-ab736839f092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5a60e6-be5f-454e-a354-ab736839f092.jpg?1",
             "name": "Feedback",
             "text": "Feedback deals 1 damage to controller of target enchantment during that player's upkeep.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "13a6bf82-5df9-57bc-9d9d-eb0185a99c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867cb70-f615-4583-bf0b-fb1016209785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867cb70-f615-4583-bf0b-fb1016209785.jpg?1",
             "name": "Flight",
             "text": "Target creature gains flying.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "21bfef60-f117-5315-8bdc-cac8f56223a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba099785-bfa0-4224-be19-0dcded94fba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba099785-bfa0-4224-be19-0dcded94fba5.jpg?1",
             "name": "Flood",
             "text": "o\nUoo\nU Tap target creature without flying.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "69d84cff-149f-5662-b284-a240a29a8560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdd00f0-c6aa-4e8b-a035-fb3403711741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdd00f0-c6aa-4e8b-a035-fb3403711741.jpg?1",
             "name": "Gaseous Form",
             "text": "Target creature neither deals nor receives damage during combat.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "84b5c061-b24e-59df-8aa6-c25986d31d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af0b9ce-0a9c-4619-95c1-bbbfffa7fcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af0b9ce-0a9c-4619-95c1-bbbfffa7fcec.jpg?1",
             "name": "Ghost Ship",
             "text": "Flying\no\nUo\nUoo\nU Regenerate",
             "colours": [
@@ -2417,7 +2417,7 @@
         },
         {
             "id": "fff0c807-b6b2-5b93-9dbf-ad46e7a3ecfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512addb-5888-49f3-985b-53cc11831e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512addb-5888-49f3-985b-53cc11831e5e.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gets +0/+3 while untapped.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "58a4a35b-fd77-5adc-af1c-6cc5e2013c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee569a6-20b0-4d37-91d6-db18de4b90c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee569a6-20b0-4d37-91d6-db18de4b90c6.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "All artifacts in play owned by target player are returned to that player's hand.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "05f3511e-c68f-5425-b867-1649f29597a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f18188-70fa-433e-a114-2f1dd49388ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f18188-70fa-433e-a114-2f1dd49388ed.jpg?1",
             "name": "Island Fish Jasconius",
             "text": "Does not untap during your untap phase.\nCannot attack if defending player controls no islands. If at any time you control no islands, bury Island Fish Jasconius.\no\nUo\nUoo\nU Untap Island Fish. Use this ability only during your upkeep.",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "df0b2514-c626-5ba9-bb06-07818dd9531a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b994bf9-5b3d-42c7-b4c6-f1029d78dd80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b994bf9-5b3d-42c7-b4c6-f1029d78dd80.jpg?1",
             "name": "Jump",
             "text": "Target creature gains flying until end of turn.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "ab15e752-dccf-59f1-aae2-2708c2b3a6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc98990-7fb0-4f69-a80d-38443966b3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc98990-7fb0-4f69-a80d-38443966b3ae.jpg?1",
             "name": "Leviathan",
             "text": "Trample\nComes into play tapped and does not untap during your untap phase.\nDuring your upkeep, you may sacrifice two islands to untap Leviathan.\nLeviathan cannot attack unless you sacrifice two islands during your attack.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "cf86aa45-01a0-51c7-b62f-c294cb6f43d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd3bd-d29b-4481-990b-f320e60c4f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd3bd-d29b-4481-990b-f320e60c4f91.jpg?1",
             "name": "Lifetap",
             "text": "Gain 1 life each time a forest controlled by target opponent becomes tapped.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "1d9ce2bb-72b6-51fe-91d5-d31d5ad3e4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846572ce-c8fd-402c-9212-8288336c75e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846572ce-c8fd-402c-9212-8288336c75e8.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk gain islandwalk and get +1/+1.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "d037bac0-70db-5035-9e9e-6eb1dba019f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c57f8a-6592-49b4-acb1-9b30500d1e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c57f8a-6592-49b4-acb1-9b30500d1e8c.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of target spell or target permanent by replacing all occurrences of one basic land type with another. For example, you may change \"swampwalk\" to \"plainswalk.\"",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "58d8e5bc-20c5-5cf2-8cd6-a28fd074d270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71935f14-d7ca-4406-9263-b2c7f5f5b94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71935f14-d7ca-4406-9263-b2c7f5f5b94f.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "85b0a8ed-b812-576c-969d-d87dcb7e1a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84fdcc-5463-45e9-9421-1d554ecdb8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84fdcc-5463-45e9-9421-1d554ecdb8ae.jpg?1",
             "name": "Mana Short",
             "text": "Mana Short empties target player's mana pool and taps that player's lands.",
             "colours": [
@@ -2737,7 +2737,7 @@
         },
         {
             "id": "1e8077ab-1ed7-5c5a-8364-76fb373352d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93661c9f-b529-4d82-b68d-3ce050f77e0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93661c9f-b529-4d82-b68d-3ce050f77e0d.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "75195773-b284-5799-931d-d633e1d095d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae30614-f558-4627-8e08-bf8a30ecd5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae30614-f558-4627-8e08-bf8a30ecd5b9.jpg?1",
             "name": "Mind Bomb",
             "text": "Mind Bomb deals 3 damage to each player. All players may discard up to three cards of their choice from their hands. Each card a player discards in this manner prevents 1 damage to that player from Mind Bomb.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "6a6a9a01-b8cb-5f48-9ff6-07fc90157329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc15dcf-6f78-4968-8af9-c115dfa10e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc15dcf-6f78-4968-8af9-c115dfa10e4c.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nDuring your upkeep, pay o\nU or destroy Phantasmal Forces.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "b6a2eaf4-af4c-5bd2-808a-6f5c1bfeff81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b3b65-e1f9-4a0d-95a6-42c2c4a358e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b3b65-e1f9-4a0d-95a6-42c2c4a358e5.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Target land becomes any basic land type of your choice.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "3d80c003-4148-5285-a194-dd3a6e26b719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa120ce-63a6-4d5e-9801-123d5e05646e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa120ce-63a6-4d5e-9801-123d5e05646e.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "fd5470b3-a07c-57e8-9680-e8ad08b9438f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7f104a-fb06-41a4-abd9-38f2c6017bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7f104a-fb06-41a4-abd9-38f2c6017bbf.jpg?1",
             "name": "Pirate Ship",
             "text": "Cannot attack if defending player controls no islands. If at any time you control no islands, bury Pirate Ship.\noc\nT: Pirate Ship deals 1 damage to target creature or player.",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "e8ed3095-6b41-5fc8-8d30-a802ac0247e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f235d7-8f6b-4d17-bc36-6f2cb6d5deec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f235d7-8f6b-4d17-bc36-6f2cb6d5deec.jpg?1",
             "name": "Power Leak",
             "text": "During the upkeep of target enchantment's controller, Power Leak deals 2 damage to him or her. That player may pay o1 for each damage he or she wishes to prevent from Power Leak.",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "0a1d403b-77f7-5b83-98c7-8055239872a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c51ab-c8b1-47be-8169-7f842712771c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c51ab-c8b1-47be-8169-7f842712771c.jpg?1",
             "name": "Power Sink",
             "text": "Counter a target spell if its caster does not pay o\nX. Target spell's caster must draw and pay all available mana from lands and mana pool until o\nX is paid; he or she may also pay mana from other sources if desired.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "a98e7244-2c9a-5264-a9ae-378799d27a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4e1161-5008-427f-a88e-5497a8eb84cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4e1161-5008-427f-a88e-5497a8eb84cd.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "32450317-bc7d-5776-92df-4bd54dbecaff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6641a587-c066-4f0a-a951-b91d3f749eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6641a587-c066-4f0a-a951-b91d3f749eb2.jpg?1",
             "name": "Psionic Entity",
             "text": "oc\nT: Psionic Entity deals 2 damage to target creature or player and 3 damage to itself.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "d085bd0a-507e-5d31-86ff-42b5b314c6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138db623-393d-485a-8fa8-f1b1b933fce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138db623-393d-485a-8fa8-f1b1b933fce5.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever target land becomes tapped, Psychic Venom deals 2 damage to that land's controller.",
             "colours": [
@@ -3098,7 +3098,7 @@
         },
         {
             "id": "c2d2b235-bb56-5ba1-a648-d6276ba2362b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05eee3dd-e17f-4154-8f8d-29c5421cd89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05eee3dd-e17f-4154-8f8d-29c5421cd89d.jpg?1",
             "name": "Relic Bind",
             "text": "When target artifact opponent controls becomes tapped, you may give 1 life or have Relic Bind deal 1 damage to target player.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "4aefa1eb-4f0c-5fa7-b6bc-b8b67b836da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e474391c-9ff0-4db4-9352-3fc07eeb4b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e474391c-9ff0-4db4-9352-3fc07eeb4b51.jpg?1",
             "name": "Sea Serpent",
             "text": "Cannot attack if defending player controls no islands. If at any time you control no islands, bury Sea Serpent.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "12361900-7922-56b5-9ee9-ae83b66d7a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e6e890-d1d0-4a9b-a453-5b51974a9dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e6e890-d1d0-4a9b-a453-5b51974a9dff.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "bbb9dfb4-db10-5335-8d79-d1c2b3362ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6906d0-4963-4f4b-aa29-ad98e9944107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6906d0-4963-4f4b-aa29-ad98e9944107.jpg?1",
             "name": "Sindbad",
             "text": "oc\nT: Draw a card. If it is not a land, discard it.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "b59d5f75-ae4e-5d11-bdcf-7e37016f13e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51832cfb-0a2e-4674-bb36-38027a71ac6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51832cfb-0a2e-4674-bb36-38027a71ac6d.jpg?1",
             "name": "Siren's Call",
             "text": "All of target opponent's creatures that can attack must do so. At end of turn, destroy any non-wall creatures that did not attack. Play only during opponent's turn, before opponent's attack. Siren's Call does not affect creatures brought under opponent's control this turn.",
             "colours": [
@@ -3261,7 +3261,7 @@
         },
         {
             "id": "332d5630-6183-575d-9060-b2c2ba13d033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd21dc3d-c9e6-4592-a655-1a20ee13ae73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd21dc3d-c9e6-4592-a655-1a20ee13ae73.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of target spell or target permanent by replacing all occurrences of one color word with another. For example, you may change \"Counters black spells\" to \"Counters blue spells.\" Sleight of Mind cannot change mana symbols.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "55db956d-b27d-5dd3-a0f1-b6ab637d9d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008df307-f010-47bc-8548-65a1c7b1c4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008df307-f010-47bc-8548-65a1c7b1c4b8.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell. X is the casting cost of the target spell.",
             "colours": [
@@ -3323,7 +3323,7 @@
         },
         {
             "id": "496c5077-f081-5def-b6a1-a027c449cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d29fed-248d-4547-9455-3d69b1f2787d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d29fed-248d-4547-9455-3d69b1f2787d.jpg?1",
             "name": "Stasis",
             "text": "Players do not get an untap phase. During your upkeep, pay o\nU or destroy Stasis.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "9f9c0d2c-83b4-5f9b-b7a6-756f8463bf01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd9ee1d-d1c5-4725-98fc-f6cff3a79512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd9ee1d-d1c5-4725-98fc-f6cff3a79512.jpg?1",
             "name": "Steal Artifact",
             "text": "Gain control of target artifact.",
             "colours": [
@@ -3387,7 +3387,7 @@
         },
         {
             "id": "7d568435-0a0e-558f-9b3e-96ad0e57f590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f89b4-cf98-4354-a2f4-3f63fe2dd99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f89b4-cf98-4354-a2f4-3f63fe2dd99e.jpg?1",
             "name": "Sunken City",
             "text": "All blue creatures get +1/+1. During your upkeep, pay o\nUo\nU or destroy Sunken City.",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "925a1d65-e640-504b-9622-cf9e81b7ff5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185674a4-db97-444d-b0e9-7dcfc245ce4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185674a4-db97-444d-b0e9-7dcfc245ce4b.jpg?1",
             "name": "Thoughtlace",
             "text": "Change the color of target spell or target permanent to blue. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "745922b8-822e-59e7-b983-ed17481a0005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957fa561-d090-435d-a0da-f405edb7e591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957fa561-d090-435d-a0da-f405edb7e591.jpg?1",
             "name": "Time Elemental",
             "text": "o2o\nUo\nU, oc\nT: Return target permanent to owner's hand. You cannot use this ability on permanents with enchantment cards played on them. If Time Elemental blocks or attacks, destroy it at end of combat. In this case, Time Elemental deals 5 damage to its controller.",
             "colours": [
@@ -3482,7 +3482,7 @@
         },
         {
             "id": "889a81ba-af08-5072-8289-e2d53354bdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db401643-6114-4254-8e40-ea7605e5ed82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db401643-6114-4254-8e40-ea7605e5ed82.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target land, artifact, or creature.",
             "colours": [
@@ -3513,7 +3513,7 @@
         },
         {
             "id": "617b2901-a4f9-5fb2-b42f-6256e43c19a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841ae3a3-30b5-4f0c-ad2f-af3d5e0da2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841ae3a3-30b5-4f0c-ad2f-af3d5e0da2e9.jpg?1",
             "name": "Unstable Mutation",
             "text": "Target creature gets +3/+3. During each of its controller's upkeeps, put a -1/-1 counter on the creature. These counters remain even if Unstable Mutation is removed.",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "733e9767-9853-507d-8cf5-77800cec0617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338948aa-463d-4af4-a0d6-64132512334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338948aa-463d-4af4-a0d6-64132512334c.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to owner's hand.",
             "colours": [
@@ -3577,7 +3577,7 @@
         },
         {
             "id": "ead3dd46-7f9d-5db1-bdb6-027e69734ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5828713a-edb3-4b11-b1f9-8f1bfc3c103f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5828713a-edb3-4b11-b1f9-8f1bfc3c103f.jpg?1",
             "name": "Volcanic Eruption",
             "text": "Destroy X target mountains. Volcanic Eruption deals 1 damage to each creature and player for each mountain put into the graveyard in this way.",
             "colours": [
@@ -3608,7 +3608,7 @@
         },
         {
             "id": "de5fe448-40c6-509f-9d3b-09303c6a719c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239435c8-3380-4556-9618-09fc0e40b69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239435c8-3380-4556-9618-09fc0e40b69d.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "f24fc8c9-1f57-55d6-a246-61ba0cddb097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78028eda-61b0-408c-b3fc-adc968d39b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78028eda-61b0-408c-b3fc-adc968d39b47.jpg?1",
             "name": "Wall of Water",
             "text": "oo\nU +1/+0 until end of turn",
             "colours": [
@@ -3674,7 +3674,7 @@
         },
         {
             "id": "ec426a99-e659-5117-9e5c-06bd1c55eb33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadea972-714e-4f6d-8fb7-a59c0ac1e028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadea972-714e-4f6d-8fb7-a59c0ac1e028.jpg?1",
             "name": "Water Elemental",
             "text": "",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "44b88c17-34d1-5dee-b32e-3e6a4b4b8e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ee0fd-9eb3-4d81-9972-9e7f4c4d64e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032ee0fd-9eb3-4d81-9972-9e7f4c4d64e4.jpg?1",
             "name": "Zephyr Falcon",
             "text": "Flying\nAttacking does not cause Zephyr Falcon to tap.",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "80592cff-0521-5d10-9939-0e0888a659cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a363bc91-8278-448e-9d5c-564e4b51eb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a363bc91-8278-448e-9d5c-564e4b51eb62.jpg?1",
             "name": "Abomination",
             "text": "At the end of combat, destroy all green and white creatures blocking or blocked by Abomination.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "44844f70-8247-5b78-aa78-8255735a3bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1dc456-1f64-4f24-a646-84c57e641b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1dc456-1f64-4f24-a646-84c57e641b3b.jpg?1",
             "name": "Animate Dead",
             "text": "Take target creature from any graveyard and put it directly into play under your control with -1/-0. Treat this creature as though it were just summoned. If Animate Dead is removed, bury the creature in its owner's graveyard.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "aa3a29d9-1fa7-5e83-a1c1-f9c443a38b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f40650-9dd5-473d-a660-448672d475a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f40650-9dd5-473d-a660-448672d475a5.jpg?1",
             "name": "Ashes to Ashes",
             "text": "Ashes to Ashes removes two target non-artifact creatures from the game and deals 5 damage to you.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "13b2b052-d557-5f16-9501-0648b2b7e958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca216e2-27a5-40e1-bb61-0ddcd8ee02ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca216e2-27a5-40e1-bb61-0ddcd8ee02ae.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures get +1/+1.",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "de61e097-e684-5d0e-921c-c1d5d81b7cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47716cf4-f35c-4613-9686-4e00b5063408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47716cf4-f35c-4613-9686-4e00b5063408.jpg?1",
             "name": "Black Knight",
             "text": "Protection from white, first strike",
             "colours": [
@@ -3902,7 +3902,7 @@
         },
         {
             "id": "53251e4f-db9c-5b32-b8b2-55de7f1fd6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59365350-d149-4c0d-a08f-eabdfb7cce3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59365350-d149-4c0d-a08f-eabdfb7cce3d.jpg?1",
             "name": "Blight",
             "text": "If target land becomes tapped, destroy it at end of turn.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "2a48b903-2e45-5028-8969-b5f8a3eb9846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50c3053-3cf3-40d3-bc9e-2fc292f11c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50c3053-3cf3-40d3-bc9e-2fc292f11c34.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "1ca5c1fe-e999-51eb-8fc5-9f0389f3763b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf82ad6-b32e-41ea-abea-22b8eef69e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf82ad6-b32e-41ea-abea-22b8eef69e67.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "cbf26c87-78b7-5636-81f8-a759e16942c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5de329d-fb08-4c4a-883f-1d77dc64470d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5de329d-fb08-4c4a-883f-1d77dc64470d.jpg?1",
             "name": "Carrion Ants",
             "text": "o1: +1/+1 until end of turn",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "0b8f7989-e7d0-5713-9071-34e4bb306bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e975cc-e89d-4ac3-b9dc-dad202dacc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e975cc-e89d-4ac3-b9dc-dad202dacc14.jpg?1",
             "name": "Cosmic Horror",
             "text": "First strike\nDuring your upkeep, pay o3o\nBo\nBo\nB or destroy Cosmic Horror. If you destroy Cosmic Horror in this way, it deals 7 damage to you.",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "d8b75815-5fd6-5062-a340-7f0a5b26ba34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d9fb0a-1087-43cd-9e14-24c1685a2057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d9fb0a-1087-43cd-9e14-24c1685a2057.jpg?1",
             "name": "Cursed Land",
             "text": "Cursed Land deals 1 damage to target land's controller during his or her upkeep.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "642ed5f4-fb4c-5e9c-b5a4-1424cdaf39b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201b51b-da03-4207-805c-134e527c42e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201b51b-da03-4207-805c-134e527c42e1.jpg?1",
             "name": "Cyclopean Mummy",
             "text": "If Mummy is put into the graveyard from play, remove it from the game.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "b8a5d2d9-1285-50fc-9084-3c7bc8a32735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3477f601-5374-4316-a74e-b5e198af482b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3477f601-5374-4316-a74e-b5e198af482b.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "e3da185b-8c34-5678-a953-baa45094cb15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2ae05-29ec-4005-8d78-280a190601c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2ae05-29ec-4005-8d78-280a190601c4.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Counter target green spell. Play this ability as an interrupt.",
             "colours": [
@@ -4195,7 +4195,7 @@
         },
         {
             "id": "4a8a9241-829f-5368-9645-ef3a26ac11db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e37fb-383d-432c-8ac3-1332096567db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e37fb-383d-432c-8ac3-1332096567db.jpg?1",
             "name": "Deathlace",
             "text": "Change the color of target spell or target permanent to black. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "e8d97363-a6e0-50e8-863b-6b3e6289ebfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d10677-36f0-4339-a2c3-213e8ee1c51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d10677-36f0-4339-a2c3-213e8ee1c51d.jpg?1",
             "name": "Drain Life",
             "text": "Drain Life deals 1 damage to a target creature or player for each o\nB you pay in addition to the casting cost. You then gain 1 life for each 1 damage dealt. You cannot gain more life than the toughness of the creature or the total life of the player Drain Life damages.",
             "colours": [
@@ -4257,7 +4257,7 @@
         },
         {
             "id": "88b1acea-74c9-5597-a72e-9c65504832a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d223d3-72c1-4240-9323-84484167c5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d223d3-72c1-4240-9323-84484167c5e0.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -4290,7 +4290,7 @@
         },
         {
             "id": "9a20c486-2374-5a16-a051-356122e226dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371bd2-89ad-487e-8f27-37a6e75ca0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf371bd2-89ad-487e-8f27-37a6e75ca0f5.jpg?1",
             "name": "El-Hajj\u00e2j",
             "text": "Gain 1 life for every 1 damage El-Hajj\u00e2j deals. You cannot gain more life in this way than the toughness of the creature or the total life of the player that El-Hajj\u00e2j damages.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "fa1bb5f6-1cc6-53cb-832c-99fbea177298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320906ee-791a-41c0-9b28-9a287cdb3340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320906ee-791a-41c0-9b28-9a287cdb3340.jpg?1",
             "name": "El-Hajj\u00e2j",
             "text": "",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "b4a8e92a-c848-591f-9240-dfd1bf68679f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472c83ff-66aa-485b-9ca7-aef8731de20a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472c83ff-66aa-485b-9ca7-aef8731de20a.jpg?1",
             "name": "Erg Raiders",
             "text": "If you do not attack with Erg Raiders during your turn, it deals 2 damage to you at end of turn. Erg Raiders deals no damage to you the turn it comes into play on your side.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "709985a4-8f48-5dd7-bd2e-05587d046947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbca45f-7b08-408b-9445-e3f2b9563f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbca45f-7b08-408b-9445-e3f2b9563f1b.jpg?1",
             "name": "Evil Presence",
             "text": "Target land becomes a basic swamp.",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "06ffff78-cb07-5016-bbe0-445798c13aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126c1b02-01bd-4b70-9293-a89173b4cd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126c1b02-01bd-4b70-9293-a89173b4cd32.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked except by black creatures and artifact creatures.",
             "colours": [
@@ -4462,7 +4462,7 @@
         },
         {
             "id": "d6486f4f-10cc-5eaf-b087-a372a45518e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95547c2a-c01b-45ed-b775-f33c157b17a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95547c2a-c01b-45ed-b775-f33c157b17a5.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "23b8bb5e-ee8d-5d64-8036-b17caeb8bb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a8573d-0e2d-4a7f-a47f-7e1bc472d4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a8573d-0e2d-4a7f-a47f-7e1bc472d4fa.jpg?1",
             "name": "Gloom",
             "text": "White spells cost an additional o3 to cast. White enchantments with activation costs require an additional o3 to use.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "bd2cec1a-9948-5d49-a58a-76b8bc45a364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb0c62-1c53-464e-a2df-59285f2d593d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb0c62-1c53-464e-a2df-59285f2d593d.jpg?1",
             "name": "Greed",
             "text": "oo\nB Pay 2 life to draw a card. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "776d361e-8a02-580a-b8b0-1a9c3fee23d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba7b1e-90a0-419e-bcba-a6b19beacf29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba7b1e-90a0-419e-bcba-a6b19beacf29.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "65448da2-b6b0-5aba-9077-a298475b19b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5900350-be08-4904-8f1b-cc180ed08485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5900350-be08-4904-8f1b-cc180ed08485.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nAn opponent damaged by Specter discards a card at random from his or her hand. Ignore this effect if opponent has no cards in hand.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "04261def-edd3-5afb-baa5-63d0abf61eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398a2b0f-0b91-408c-8083-3bc89873b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398a2b0f-0b91-408c-8083-3bc89873b69f.jpg?1",
             "name": "Jun\u00fan Efreet",
             "text": "Flying\nDuring your upkeep, pay o\nBo\nB or bury Jun\u00fan Efreet.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "7a95a968-3b71-5b6e-be4c-31b53504ddb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9691e76c-770d-4721-b758-805574227de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9691e76c-770d-4721-b758-805574227de1.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nDuring your upkeep, sacrifice a creature. If you cannot sacrifice a creature, Lord of the Pit deals 7 damage to you. You cannot sacrifice Lord of the Pit to itself.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "db8f1035-781d-5861-be92-e0a6841aef12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b875b1-e534-4ed8-9ebd-8f4d5a066e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b875b1-e534-4ed8-9ebd-8f4d5a066e7d.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "71cbf3a7-3f16-526e-a829-ce3fd10447e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c65bf9-cbab-45ee-9c6e-f8ee832dbe61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c65bf9-cbab-45ee-9c6e-f8ee832dbe61.jpg?1",
             "name": "Marsh Gas",
             "text": "All creatures get -2/-0 until end of turn.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "ad44c9a4-b7f0-5bff-a5cd-dcd576d7c084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb6765c-a052-46dc-a589-200b8ba8c99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb6765c-a052-46dc-a589-200b8ba8c99f.jpg?1",
             "name": "Mind Twist",
             "text": "Target player discards X cards at random from his or her hand. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "1a75e115-7cfd-5d69-accc-4a2037683656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7731dc37-2eac-4e60-bb0f-6230205a5323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7731dc37-2eac-4e60-bb0f-6230205a5323.jpg?1",
             "name": "Murk Dwellers",
             "text": "When attacking and not blocked, Murk Dwellers gets +2/+0 until end of turn.",
             "colours": [
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "65e20f1c-de88-50f4-9562-7e260221611f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d9e96-0c7f-45c5-b6d0-6444ef84bab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d9e96-0c7f-45c5-b6d0-6444ef84bab1.jpg?1",
             "name": "Nether Shadow",
             "text": "At the end of your upkeep, if Shadow is in your graveyard with at least three creature cards above it, you may return it to play. Shadow can attack the turn it comes into play.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "a25221d0-6a12-5709-b239-69b3aefac69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db11b832-7584-4e4b-8d02-b03fe76dcbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db11b832-7584-4e4b-8d02-b03fe76dcbc3.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare has power and toughness each equal to the number of swamps its controller controls.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "8ce49d4c-7501-5754-8ba6-ba3e45dd6002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bcad9a-b69c-434a-8d48-6b727bd8e382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bcad9a-b69c-434a-8d48-6b727bd8e382.jpg?1",
             "name": "Paralyze",
             "text": "Target creature does not untap during its controller's untap phase. That player may pay an additional o4 during his or her upkeep to untap it. Tap target creatures when Paralyze comes into play.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "5533725e-a850-5e7f-af9f-07d2ee18fb89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90886a02-4c1f-48ea-8563-6d80c97d9f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90886a02-4c1f-48ea-8563-6d80c97d9f58.jpg?1",
             "name": "Pestilence",
             "text": "At the end of any turn, if there are no creatures in play, bury Pestilence.\noo\nB Pestilence deals 1 damage to all creatures and players.",
             "colours": [
@@ -4947,7 +4947,7 @@
         },
         {
             "id": "a3c70845-cd5f-52bd-8d34-b8d30139637b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a53418c-3720-4aa3-a525-6bc82c363844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a53418c-3720-4aa3-a525-6bc82c363844.jpg?1",
             "name": "Pit Scorpion",
             "text": "If Pit Scorpion damages a player, he or she gets a poison counter. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "d1c4db3e-d5b4-5d63-be9f-1a0563461260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901591cb-a7e9-47c1-96ff-3de7b39b1055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901591cb-a7e9-47c1-96ff-3de7b39b1055.jpg?1",
             "name": "Plague Rats",
             "text": "Plague Rats has power and toughness each equal to the number of Plague Rats in play, no matter who controls them. For example, if there are two Plague Rats in play, each has power and toughness 2/2.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "f80ac040-e936-5c1f-8c13-19e27ff240f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a02f9-81f7-412b-8e98-d7be3eb73eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a02f9-81f7-412b-8e98-d7be3eb73eca.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at target opponent's hand. If that player has any creature cards in hand, he or she discards one of them at random. Use this ability only during your turn.",
             "colours": [
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "a1d2b18a-ae77-54a8-a5ac-59e8a90ce144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2096e54e-1a55-4fd7-8415-a6f2fdb2a536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2096e54e-1a55-4fd7-8415-a6f2fdb2a536.jpg?1",
             "name": "Raise Dead",
             "text": "Take target creature from your graveyard and put it into your hand.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "c3f261bd-308f-5684-8b1c-2467763d52ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d51bdf-f118-4a1e-9060-bdf3c78697f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d51bdf-f118-4a1e-9060-bdf3c78697f2.jpg?1",
             "name": "Royal Assassin",
             "text": "oc\nT: Destroy target tapped creature.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "5c84f582-7aa0-550c-b947-b69c7ec1807a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd55d32-e969-4d12-b101-a35db8a53921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd55d32-e969-4d12-b101-a35db8a53921.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "8ddc4675-a7cd-5ac3-8951-1cdde968c9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0baaa9-c42b-413a-b10d-95689e4ddb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0baaa9-c42b-413a-b10d-95689e4ddb50.jpg?1",
             "name": "Scavenging Ghoul",
             "text": "At the end of each turn, put a corpse counter on Scavenging Ghoul for each creature put into the graveyard during that turn.\no0: Remove a corpse counter from Scavenging Ghoul to regenerate it.",
             "colours": [
@@ -5178,7 +5178,7 @@
         },
         {
             "id": "b98a33cc-3cb9-5e91-b391-0012430de104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e29882a-c194-48b8-ba18-439b0bda395e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e29882a-c194-48b8-ba18-439b0bda395e.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nPut a +1/+1 counter on Sengir Vampire each time a creature is put into the graveyard the same turn Sengir Vampire damaged it.",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "53e7692f-fb0e-527f-936c-7f2e6af0aae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c23232c-a264-4df9-824b-4111a5c6524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c23232c-a264-4df9-824b-4111a5c6524c.jpg?1",
             "name": "Simulacrum",
             "text": "All damage done to you so far this turn is instead retroactively applied to a target creature you control. Further damage this turn is treated normally.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "3a6b1975-3a04-5c11-801a-3be205ee324d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4855db6-570c-4845-9074-a9df7611307a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4855db6-570c-4845-9074-a9df7611307a.jpg?1",
             "name": "Sorceress Queen",
             "text": "oc\nT: Target creature other than Sorceress Queen becomes 0/2 until end of turn.",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "d3a00043-d96c-58d7-b8c3-33d4791ed1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df0c902-3fe1-4de7-9777-7ddb563b6cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df0c902-3fe1-4de7-9777-7ddb563b6cec.jpg?1",
             "name": "Spirit Shackle",
             "text": "Put a -0/-2 counter on target creature every time it becomes tapped. These counters remain even if Spirit Shackle is removed.",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "1e7f5837-86ac-5d6c-9720-55a43703ba01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5d44d-977d-4d0d-8242-17c8ffa7247c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5d44d-977d-4d0d-8242-17c8ffa7247c.jpg?1",
             "name": "Terror",
             "text": "Bury target non-black, non-artifact creature.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "5e7ca5b8-31ee-525a-8c25-198b1dfbb784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf5aa58-f68b-4197-9697-1e6653760853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf5aa58-f68b-4197-9697-1e6653760853.jpg?1",
             "name": "Uncle Istvan",
             "text": "All damage done to Uncle Istvan by creatures is reduced to 0.",
             "colours": [
@@ -5373,7 +5373,7 @@
         },
         {
             "id": "84d19be4-a4d8-5047-82f8-2f25ef51cca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c3c85-1462-406c-8e3b-c25deda9c4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c3c85-1462-406c-8e3b-c25deda9c4e6.jpg?1",
             "name": "Unholy Strength",
             "text": "Target creature gets +2/+1.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "01cc31a8-e1da-5dde-bec1-b656a32cc866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2aed701-5164-4c63-9539-3d2406970f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2aed701-5164-4c63-9539-3d2406970f46.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying\noo\nB +1/+0 until end of turn. You cannot spend more than o\nBo\nB in this way each turn.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "c33226f0-f6c4-5ada-bdf2-d32373a48fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce3251-017f-4834-9935-0985c56cccb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce3251-017f-4834-9935-0985c56cccb7.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "f516d4a9-a726-58e6-b6ca-16c6d29330ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc2fcd5-e7a5-4a66-b385-82726ee6e3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc2fcd5-e7a5-4a66-b385-82726ee6e3cc.jpg?1",
             "name": "Warp Artifact",
             "text": "Warp Artifact deals 1 damage to target artifact's controller during his or her upkeep.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "1b323990-6633-5521-8e35-71375ad7c5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d4cd1-7cc6-44ee-872e-68e5bcc608fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d4cd1-7cc6-44ee-872e-68e5bcc608fb.jpg?1",
             "name": "Weakness",
             "text": "Target creature gets -2/-1.",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "275f938f-c895-517c-9bd7-cae92f7c6a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef317-8105-4917-ba3c-93de3eebd944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef317-8105-4917-ba3c-93de3eebd944.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying\noo\nB Regenerate",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "41916568-555a-59ff-b4de-e21ea15281a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715472e1-585b-4379-b335-8f3b5e572d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715472e1-585b-4379-b335-8f3b5e572d83.jpg?1",
             "name": "Word of Binding",
             "text": "Tap X target creatures.",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "6fed95cb-c1f3-5576-85fd-1a5bb721f237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c546db-0871-4a13-8654-c26ae9f9b50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c546db-0871-4a13-8654-c26ae9f9b50a.jpg?1",
             "name": "Xenic Poltergeist",
             "text": "oc\nT: Target non-creature artifact becomes an artifact creature with power and toughness each equal to its casting cost. Target retains all original abilities. This change lasts until your next upkeep.",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "99c0cef6-1881-5050-b8e9-4a41dcbfb741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86753ae-c8da-47d7-b97a-3c75f83ee929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86753ae-c8da-47d7-b97a-3c75f83ee929.jpg?1",
             "name": "Zombie Master",
             "text": "All zombies gain swampwalk and\n\"oo\nB Regenerate.\"",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "b472c43a-64d0-5ca8-aedd-1fecc4a31604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92191f72-e3d7-4679-97a2-f0c2d19d7738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92191f72-e3d7-4679-97a2-f0c2d19d7738.jpg?1",
             "name": "Ali Baba",
             "text": "oo\nR Tap target wall.",
             "colours": [
@@ -5703,7 +5703,7 @@
         },
         {
             "id": "20a644ac-87e2-5124-bf47-82e2e617771b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bccf9a0-8d93-4b5e-ada0-1f19f260e5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bccf9a0-8d93-4b5e-ada0-1f19f260e5a8.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample\nBall Lightning can attack the turn it comes into play. At the end of any turn, bury Ball Lightning.",
             "colours": [
@@ -5736,7 +5736,7 @@
         },
         {
             "id": "366ff2f6-17cc-53c0-8a0b-2d1a513e5727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81a99a-0380-456f-8e81-753add511dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81a99a-0380-456f-8e81-753add511dbe.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "a6c1ddbe-1675-5feb-8c57-7524f8a61de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426e477f-2873-4115-9527-a50a97769dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426e477f-2873-4115-9527-a50a97769dd1.jpg?1",
             "name": "Blood Lust",
             "text": "Target creature gets +4/-4 until end of turn. If this reduces creature's toughness to less than 1, creature's toughness becomes 1.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "86032e38-18f3-55b4-ba84-6edad18f7033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66674f3a-e882-44f1-addc-d74605150c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66674f3a-e882-44f1-addc-d74605150c39.jpg?1",
             "name": "Brothers of Fire",
             "text": "1o\nRoo\nR Brothers of Fire deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "9c4f6677-c11c-50e4-8399-27d98dac9c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946f1a83-6fcc-45b0-91fc-9c75504a16f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946f1a83-6fcc-45b0-91fc-9c75504a16f3.jpg?1",
             "name": "Burrowing",
             "text": "Target creature gains mountainwalk.",
             "colours": [
@@ -5868,7 +5868,7 @@
         },
         {
             "id": "2a89fd09-e5b6-545c-a811-409be073a5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9ff47-b98c-4ab6-a4bc-8914360c3f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9ff47-b98c-4ab6-a4bc-8914360c3f6d.jpg?1",
             "name": "Cave People",
             "text": "When attacking, Cave People gets +1/-2 until end of turn.\n1o\nRo\nR, oc\nT: Target creature gains mountainwalk until end of turn.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "d887cc5e-1334-5473-9dd4-f993e5e9ecdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476180df-8b88-4ead-b6c5-6ccb3e8a2cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476180df-8b88-4ead-b6c5-6ccb3e8a2cfd.jpg?1",
             "name": "Chaoslace",
             "text": "Change the color of target spell or target permanent to red. Costs to cast, tap, maintain, or use a special ability of target remain unchanged.",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "48cec9ab-481b-52ff-9ef3-a6f08e1c23a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8fc5c-368f-4b25-a33e-a32855037c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8fc5c-368f-4b25-a33e-a32855037c4b.jpg?1",
             "name": "Crimson Manticore",
             "text": "Flying\no\nR, oc\nT: Manticore deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -5965,7 +5965,7 @@
         },
         {
             "id": "24ca8b51-803f-5ce4-811b-528e84f43318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e23d23-92ca-4d74-88e8-e1137d7faaf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e23d23-92ca-4d74-88e8-e1137d7faaf1.jpg?1",
             "name": "Detonate",
             "text": "Bury target artifact. Detonate deals X damage to the artifact's controller, where X is the casting cost of the artifact.",
             "colours": [
@@ -5996,7 +5996,7 @@
         },
         {
             "id": "a9b0d5aa-3322-5892-b99f-2c67534a7a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f41f868-454e-4075-9ef4-bcf3754d421c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f41f868-454e-4075-9ef4-bcf3754d421c.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate deals X damage to target creature or player. The target cannot regenerate until end of turn. If the target receives lethal damage this turn, remove it from the game entirely.",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "3baef929-6dea-5506-a1cb-5994493745a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ff6e6-b914-4787-bb90-ea77a3550d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ff6e6-b914-4787-bb90-ea77a3550d23.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\noo\nR +1/+0 until end of turn. If you spend more than o\nRo\nRo\nR in this way during one turn, destroy Dragon Whelp at end of turn.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "852e2a66-1ad6-5d80-b593-d561b85c0378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3616f381-ca10-4945-b95e-96dfefa3c303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3616f381-ca10-4945-b95e-96dfefa3c303.jpg?1",
             "name": "Dwarven Warriors",
             "text": "oc\nT: Target creature with power no greater than 2 becomes unblockable until end of turn. Other effects may later be used to increase the creature's power beyond 2.",
             "colours": [
@@ -6094,7 +6094,7 @@
         },
         {
             "id": "d22ec98f-620f-59b3-8d39-4f55827b198b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a859fd-28a3-470f-adf4-c6431ced27e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a859fd-28a3-470f-adf4-c6431ced27e1.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "544a97b7-763c-5a44-9aca-cabdabf753cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ec03ce-a8a3-42c3-a895-21cce1657411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ec03ce-a8a3-42c3-a895-21cce1657411.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each player and each creature without flying.",
             "colours": [
@@ -6158,7 +6158,7 @@
         },
         {
             "id": "e9aaf530-a67f-5010-bc40-87efd71e96fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d574075-9909-444a-817f-d6ad419aa62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d574075-9909-444a-817f-d6ad419aa62c.jpg?1",
             "name": "Eternal Warrior",
             "text": "Attacking does not cause target creature to tap.",
             "colours": [
@@ -6191,7 +6191,7 @@
         },
         {
             "id": "03c06c2f-77af-59d1-86b5-0bf492f9a4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0261cd0f-e763-49b5-96ed-5e5767a3d8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0261cd0f-e763-49b5-96ed-5e5767a3d8d7.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "903f2b9a-0b13-54f2-be60-06391544c58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe078d7-cdde-44bb-942e-417123ebeccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe078d7-cdde-44bb-942e-417123ebeccb.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage, divided evenly (round down) among any number of target creatures and/or players. Pay an additional o1 for each target beyond the first.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "d09ed90f-6c42-5372-bdda-0dc4c83fdedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294892cb-3927-4bf0-97ca-f37bdd0b9de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294892cb-3927-4bf0-97ca-f37bdd0b9de5.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Target creature Firebreathing enchants gets +1/+0 until end of turn.",
             "colours": [
@@ -6288,7 +6288,7 @@
         },
         {
             "id": "e8c52da2-9dfc-5caa-bb4a-bfb8b4f994c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7601b15a-53d8-499f-837b-abf369d1e3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7601b15a-53d8-499f-837b-abf369d1e3f4.jpg?1",
             "name": "Fissure",
             "text": "Bury target land or creature.",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "1949c2c5-fe6b-5535-b79a-c3936cdbb083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0de18a-1dad-49f1-8127-09aa07b69eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0de18a-1dad-49f1-8127-09aa07b69eb0.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "1ddce5f9-8efc-5136-8c80-eec949fbe20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1aebd61-311c-4269-aa75-5c004639178d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1aebd61-311c-4269-aa75-5c004639178d.jpg?1",
             "name": "Giant Strength",
             "text": "Target creature gets +2/+2.",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "02046592-7755-5f65-8e24-ea7110dca7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866df71c-856c-451d-a11b-c2086c265868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866df71c-856c-451d-a11b-c2086c265868.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "oo\nR Flying until end of turn",
             "colours": [
@@ -6417,7 +6417,7 @@
         },
         {
             "id": "2d03c702-bc5a-599b-a976-8c47708043f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dd4aef-6d15-4d74-96cf-1cc51812b541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dd4aef-6d15-4d74-96cf-1cc51812b541.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins gain mountainwalk and get +1/+1.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "05bc686b-4f13-50a8-9357-d973bec32e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f4f0c1-a43e-4282-b20e-91c711c57521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f4f0c1-a43e-4282-b20e-91c711c57521.jpg?1",
             "name": "Goblin Rock Sled",
             "text": "Trample\nCannot attack if defending player controls no mountains. Rock Sled does not untap during your untap phase if it attacked during your last turn.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "3cffdb63-be36-501e-829c-7f17e8c09d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2cc0-799f-4eb8-b338-ed7543f469e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2cc0-799f-4eb8-b338-ed7543f469e7.jpg?1",
             "name": "Gray Ogre",
             "text": "",
             "colours": [
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "1523626c-d2bf-5b2c-bf53-99f1e4941640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac25236-c2f2-48df-8dbb-d4f9ce790cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac25236-c2f2-48df-8dbb-d4f9ce790cfb.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "a0c74804-2327-5038-9bdc-a8a81c78cd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c27de-e788-4ad7-b1e3-030e7ef00471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c27de-e788-4ad7-b1e3-030e7ef00471.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "3e5fa9a0-1603-5d16-b92a-9381318fad1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0ab2b-04bf-4cba-8efa-3d1d0ab4f50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0ab2b-04bf-4cba-8efa-3d1d0ab4f50d.jpg?1",
             "name": "Hurr Jackal",
             "text": "oc\nT: Target creature cannot regenerate this turn.",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "1b576374-2daf-5152-8679-57ac46e2ea16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dbfdc1-a598-4c72-9b0d-91207bd067ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dbfdc1-a598-4c72-9b0d-91207bd067ab.jpg?1",
             "name": "Immolation",
             "text": "Target creature gets +2/-2.",
             "colours": [
@@ -6648,7 +6648,7 @@
         },
         {
             "id": "b810484a-09b4-5236-8e05-49af16261376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db90782-fa89-4470-bec5-27614e88a0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db90782-fa89-4470-bec5-27614e88a0a9.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to all players and all creatures.",
             "colours": [
@@ -6679,7 +6679,7 @@
         },
         {
             "id": "9f3d38e3-b063-5e0c-b2d6-45d0b481ea0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d882105f-2de0-46ae-b673-01508c016cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d882105f-2de0-46ae-b673-01508c016cc6.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Cannot be assigned to block any creature with power greater than 1.",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "a488205f-4022-53f6-ac38-6c11f66e7980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a32db7-e1a8-47d8-a708-987bcbf0636e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a32db7-e1a8-47d8-a708-987bcbf0636e.jpg?1",
             "name": "Keldon Warlord",
             "text": "Keldon Warlord has power and toughness each equal to the number of non-wall creatures you control, including Warlord. For example, if you control two other non-wall creatures, Warlord is 3/3. If one of those creatures leaves play, Warlord immediately becomes 2/2.",
             "colours": [
@@ -6746,7 +6746,7 @@
         },
         {
             "id": "61aa652c-e307-5b1c-9332-9025ebbcb504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9521375e-0bc1-45ef-b513-6d332a25f9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9521375e-0bc1-45ef-b513-6d332a25f9d2.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "3de4a6ef-8236-5d9a-acab-e6c2a8b8e57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993a14d5-a33d-426e-ab49-c3226a6fcdca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993a14d5-a33d-426e-ab49-c3226a6fcdca.jpg?1",
             "name": "Magnetic Mountain",
             "text": "Blue creatures do not untap during their controllers' untap phase. During his or her upkeep, a player may pay an additional o4 to untap a blue creature he or she controls.",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "596277e0-8429-566a-a802-6864f58b5cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01f27b7-f1d0-4fb6-b743-ca7a810ef85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01f27b7-f1d0-4fb6-b743-ca7a810ef85c.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to any player whose coin comes up tails. Repeat this process until both players' coins come up heads at the same time.",
             "colours": [
@@ -6839,7 +6839,7 @@
         },
         {
             "id": "2180d8d3-87ca-50ab-b289-da08d035c68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7169e26-e700-4e71-b959-4592a03f3c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7169e26-e700-4e71-b959-4592a03f3c9f.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever a player taps a land for mana, it produces one additional mana of the same type.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "ef702226-9086-546c-b41f-c8fbd1486001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4f505-bc05-44ac-9190-60101f813c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4f505-bc05-44ac-9190-60101f813c65.jpg?1",
             "name": "Manabarbs",
             "text": "Each time any land is tapped for mana, Manabarbs deals 1 damage to that land's controller.",
             "colours": [
@@ -6901,7 +6901,7 @@
         },
         {
             "id": "56f25954-dca7-57cc-a247-1d35d35e3b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f31c715-9ab8-4578-989f-141099b6750c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f31c715-9ab8-4578-989f-141099b6750c.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "d777db02-4e5e-51d0-954a-41d64e657ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19281eb4-f5b6-4b27-8c65-7e56d2a8ab77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19281eb4-f5b6-4b27-8c65-7e56d2a8ab77.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -6968,7 +6968,7 @@
         },
         {
             "id": "6b2b6763-754b-5524-9f28-9a83499fb8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc0d8b-2d4b-4c3b-a9af-b5fae35e6ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc0d8b-2d4b-4c3b-a9af-b5fae35e6ec5.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "All attacking creatures you control get +1/+0.",
             "colours": [
@@ -6999,7 +6999,7 @@
         },
         {
             "id": "d8c085d5-026d-517b-a37d-55dea1ab8230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5717af-a1a3-45cb-8b05-7543eed5532a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5717af-a1a3-45cb-8b05-7543eed5532a.jpg?1",
             "name": "Power Surge",
             "text": "During each player's upkeep, Power Surge deals that player 1 damage for each land he or she controls that was untapped at the beginning of the turn, before the untap phase.",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "bb06a258-4d15-5546-a000-46da0bff46c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e32142d-b161-4497-a6cd-ba4c67e16a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e32142d-b161-4497-a6cd-ba4c67e16a6f.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -7061,7 +7061,7 @@
         },
         {
             "id": "4f7097d5-d451-51b0-8e21-6aca031bb56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54246c9-5e5c-484e-a546-ae1f9fd020f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54246c9-5e5c-484e-a546-ae1f9fd020f3.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Counter target blue spell or destroy target blue permanent.",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "e32a177c-282e-5040-8708-b6fd6887c7be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd44196-aa28-4143-872d-592c6fc175a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd44196-aa28-4143-872d-592c6fc175a9.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -7123,7 +7123,7 @@
         },
         {
             "id": "56cccad5-d100-5871-96d0-29b9b46670d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70846483-9c23-42c4-9f9f-1fc5cda17c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70846483-9c23-42c4-9f9f-1fc5cda17c77.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\noo\nR +1/+0 until end of turn",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "92241b85-ecc8-5e6b-8947-9fbe447494e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ab53c-133a-4211-8499-aea00ed3ee1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ab53c-133a-4211-8499-aea00ed3ee1d.jpg?1",
             "name": "Sisters of the Flame",
             "text": "oc\nT: Add o\nR to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7190,7 +7190,7 @@
         },
         {
             "id": "2c3300df-f3ed-5813-ba1c-dfe4861ae53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2069f9b-578a-45da-bd52-3c208465be88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2069f9b-578a-45da-bd52-3c208465be88.jpg?1",
             "name": "Smoke",
             "text": "No player may untap more than one creature during his or her untap phase.",
             "colours": [
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "c1617b76-fd89-5848-9f40-24076765a760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265de55e-63d2-4a5d-9078-858da70f2a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265de55e-63d2-4a5d-9078-858da70f2a08.jpg?1",
             "name": "Stone Giant",
             "text": "oc\nT: Target creature you control, which must have toughness less than Stone Giant's power, gains flying until end of turn. Destroy that creature at end of turn. Other effects may later be used to increase the creature's toughness beyond Stone Giant's power.",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "a762daa9-d0ce-5c5a-8583-45cdb93e576e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9029bfb-fcff-4f80-a423-c2cfdc881c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9029bfb-fcff-4f80-a423-c2cfdc881c61.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "1fd6bd7b-a754-5d97-89e3-e84336d848f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea6dfe-64d6-451a-bd34-31546996e711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea6dfe-64d6-451a-bd34-31546996e711.jpg?1",
             "name": "Tempest Efreet",
             "text": "oc\nT: Choose a card at random from target opponent's hand and put it in yours. Bury Tempest Efreet in opponent's graveyard. The change in ownership is permanent. Play this ability as an interrupt. Before you choose the card to be switched, the opponent may prevent effect by paying 10 life or conceding game; if this is done, bury Tempest Efreet. Effects that prevent or redirect damage cannot be used to counter this loss of life. Remove Tempest Efreet from your deck before playing if not playing for ante.",
             "colours": [
@@ -7318,7 +7318,7 @@
         },
         {
             "id": "9cf35445-ebca-5a9e-986a-bb19c52d0e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b58ca62-6532-45e5-ad51-84a388d5cc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b58ca62-6532-45e5-ad51-84a388d5cc4d.jpg?1",
             "name": "The Brute",
             "text": "Target creature gets +1/+0.\no\nRo\nRoo\nR Regenerate target creature The Brute enchants.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "a589dfa9-65a3-5a1a-aed0-664008418566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9483f5d0-c627-43ed-bfaa-1559855c8a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9483f5d0-c627-43ed-bfaa-1559855c8a6d.jpg?1",
             "name": "Tunnel",
             "text": "Bury target wall.",
             "colours": [
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "f88714c2-9f4c-5460-b006-74a21ac477e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dea433-2dee-4faf-a868-6af664c6af4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dea433-2dee-4faf-a868-6af664c6af4a.jpg?1",
             "name": "Uthden Troll",
             "text": "oo\nR Regenerate",
             "colours": [
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "1db8254a-7ecc-5e8a-a8d7-282861bd9eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25b81fb-1d0f-4c0c-8d54-fbf9c1d54578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25b81fb-1d0f-4c0c-8d54-fbf9c1d54578.jpg?1",
             "name": "Wall of Dust",
             "text": "No creature blocked by Wall of Dust may attack during its controller's next turn.",
             "colours": [
@@ -7448,7 +7448,7 @@
         },
         {
             "id": "fdad627b-0a88-5fd3-b6a6-d75723dc4e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7753b-0f01-42f3-9a5b-fe1ac6e7441d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7753b-0f01-42f3-9a5b-fe1ac6e7441d.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "1785ef81-a71d-5d33-b369-2a8be862e93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b68e0-ec8b-4dad-91ee-dc1da5db6251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b68e0-ec8b-4dad-91ee-dc1da5db6251.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "eeeda5b7-2aea-5f8e-b343-30b7e1662820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77071f4c-d00b-4c79-a2e6-6be0720af36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77071f4c-d00b-4c79-a2e6-6be0720af36b.jpg?1",
             "name": "Winds of Change",
             "text": "All players shuffle their hands into their libraries and then draw the same number of cards they originally held.",
             "colours": [
@@ -7545,7 +7545,7 @@
         },
         {
             "id": "1e359442-c4a8-5e87-99ce-bdf1ad86b223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e780b8-8002-47d4-9d0c-bd65a40ea34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e780b8-8002-47d4-9d0c-bd65a40ea34e.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Increase target creature's power and toughness by half the number of forests you control, rounding down for power and up for toughness.",
             "colours": [
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "818b2a46-5e03-5d18-bbe4-3680f69e100c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8852e36-204c-4b3a-a4f8-33a98548fa7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8852e36-204c-4b3a-a4f8-33a98548fa7b.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7611,7 +7611,7 @@
         },
         {
             "id": "fe18c835-f5bd-5cd9-bfbd-facf3aa8a4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f449835-5e20-4244-b7f4-c22838910076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f449835-5e20-4244-b7f4-c22838910076.jpg?1",
             "name": "Carnivorous Plant",
             "text": "",
             "colours": [
@@ -7645,7 +7645,7 @@
         },
         {
             "id": "6172d215-b718-5306-b2f9-6cbda5bfbed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42eb95f-638d-410c-a830-a414fb2494ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42eb95f-638d-410c-a830-a414fb2494ec.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, you may add colorless mana to your mana pool at a cost of 1 life per one mana. Play these additions as interrupts. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -7676,7 +7676,7 @@
         },
         {
             "id": "63221d10-e8b3-5678-8d05-9cf88b6e69bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406dfe1-68e9-4757-9487-0b556c97d07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406dfe1-68e9-4757-9487-0b556c97d07a.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nAt the end of combat, destroy all non-wall creatures blocking or blocked by Cockatrice.",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "8347af1e-8f64-5003-a74d-3e112ab50221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e9cf07-a335-4725-a124-0e983721f2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e9cf07-a335-4725-a124-0e983721f2f8.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "dc01e332-3ffa-58f2-aac8-b5534a4e5dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86873be9-21eb-496c-b278-4c9847563b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86873be9-21eb-496c-b278-4c9847563b0f.jpg?1",
             "name": "Crumble",
             "text": "Bury target artifact. Artifact's controller gains life equal to the artifact's casting cost.",
             "colours": [
@@ -7773,7 +7773,7 @@
         },
         {
             "id": "42d9e334-770f-5878-ad41-460d569d69b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5603ce3f-3b39-4433-8ccf-44b44dc99de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5603ce3f-3b39-4433-8ccf-44b44dc99de5.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy target permanent.",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "b59f1588-a572-5e87-b41e-ce835af8fb27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85ab895-d2b9-47f5-91f0-07b0cb43fc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85ab895-d2b9-47f5-91f0-07b0cb43fc7c.jpg?1",
             "name": "Durkwood Boars",
             "text": "",
             "colours": [
@@ -7837,7 +7837,7 @@
         },
         {
             "id": "0c31dde3-6e50-5bd4-8b08-41e843cdb9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906095f6-25c7-4f61-8513-9d75e32aab02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906095f6-25c7-4f61-8513-9d75e32aab02.jpg?1",
             "name": "Elven Riders",
             "text": "Cannot be blocked except by walls and by creatures with flying.",
             "colours": [
@@ -7870,7 +7870,7 @@
         },
         {
             "id": "e3ee0a16-8ef5-551c-a369-0360b22458fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd21750-856f-4017-a728-dcbf3f506f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd21750-856f-4017-a728-dcbf3f506f20.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "9d893010-24f6-5e6d-8750-d41ef1886c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1959de7-e945-438c-a90a-158e21c4d5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1959de7-e945-438c-a90a-158e21c4d5bf.jpg?1",
             "name": "Fog",
             "text": "No creatures deal damage in combat this turn.",
             "colours": [
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "6c02fd04-850f-5acc-ab8a-934a4b623827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef1a44-faf8-42bd-aaff-778f65d18ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef1a44-faf8-42bd-aaff-778f65d18ae9.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nDuring your upkeep, pay o\nGo\nGo\nGo\nG or Force of Nature deals 8 damage to you.",
             "colours": [
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "84582d5d-c586-509e-9429-619e0dedf845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9ff903-176f-45e7-82fd-e9705c1c719f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9ff903-176f-45e7-82fd-e9705c1c719f.jpg?1",
             "name": "Fungusaur",
             "text": "At the end of any turn in which Fungusaur receives damage but does not leave play, put a +1/+1 counter on it.",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "db1bf520-c2b9-5155-94ea-f6c70de74315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9e1c1b-bc7c-41b8-a983-b1c60f558547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9e1c1b-bc7c-41b8-a983-b1c60f558547.jpg?1",
             "name": "Gaea's Liege",
             "text": "Gaea's Liege has power and toughness each equal to the number of forests you control; when Gaea's Liege attacks, these are instead equal to the number of forests defending player controls.\noc\nT: Target land becomes a basic forest until Gaea's Liege leaves play.",
             "colours": [
@@ -8035,7 +8035,7 @@
         },
         {
             "id": "e07288af-ec8e-51b8-94fd-ad033a6cd826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ce96a5-76f1-48ca-854d-a37fb6a023a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ce96a5-76f1-48ca-854d-a37fb6a023a0.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "9eb550a6-e91d-5e0d-b4ac-4dc671734230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd711db-661d-4e2c-b817-0905e26ed929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd711db-661d-4e2c-b817-0905e26ed929.jpg?1",
             "name": "Giant Spider",
             "text": "Can block creatures with flying.",
             "colours": [
@@ -8099,7 +8099,7 @@
         },
         {
             "id": "febce88c-aa1d-59ef-805c-744d594a5e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc72de-2093-477b-b39e-696339d2fdbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc72de-2093-477b-b39e-696339d2fdbc.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -8132,7 +8132,7 @@
         },
         {
             "id": "3f7c68d1-5c91-50b7-a16c-5477d58f93d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8457f271-4075-4694-a1c0-280aff910953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8457f271-4075-4694-a1c0-280aff910953.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each player and each creature with flying.",
             "colours": [
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "64ede1f4-bdc5-5f76-bae0-cb5e98f8e089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eeb4671-e6f6-4f64-83f8-8c2a56defa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eeb4671-e6f6-4f64-83f8-8c2a56defa1b.jpg?1",
             "name": "Instill Energy",
             "text": "Target creature can attack the turn it comes into play on your side.\no0: During your turn, untap target creature Instill Energy enchants. Use this ability only once each turn.",
             "colours": [
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "99111c10-232d-5ce1-8e3a-6718f046c28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c93c85-5263-4770-b937-704e57912478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c93c85-5263-4770-b937-704e57912478.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "93be0163-917c-59bc-b807-4fdb6ac38448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e748b0-4041-4266-a777-e1b8a5533e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e748b0-4041-4266-a777-e1b8a5533e80.jpg?1",
             "name": "Killer Bees",
             "text": "Flying\noo\nG +1/+1 until end of turn",
             "colours": [
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "9d88bc5a-d4e2-5f49-bb0d-3d6d0f6ffe42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1d97c-5bfa-4791-9004-5f2464908c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1d97c-5bfa-4791-9004-5f2464908c30.jpg?1",
             "name": "Land Leeches",
             "text": "First strike",
             "colours": [
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "3cf09a0d-c914-5b16-8727-6581f54438dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925adfb2-cfe3-4847-9db0-20bbe4e7baf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925adfb2-cfe3-4847-9db0-20bbe4e7baf1.jpg?1",
             "name": "Ley Druid",
             "text": "oc\nT: Untap target land. Play this ability as an interrupt.",
             "colours": [
@@ -8329,7 +8329,7 @@
         },
         {
             "id": "7637745d-bb0e-570f-a58a-9609efe77b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ca1cc3-e588-4ef7-b846-d5dba3c875a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ca1cc3-e588-4ef7-b846-d5dba3c875a0.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Counter target black spell. Play this ability as an interrupt.",
             "colours": [
@@ -8360,7 +8360,7 @@
         },
         {
             "id": "10d8629f-b498-522c-9795-fcfc706f520f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf312acb-2fa6-440a-964b-424ad8abc331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf312acb-2fa6-440a-964b-424ad8abc331.jpg?1",
             "name": "Lifelace",
             "text": "Change the color of target spell or target permanent to green. Costs to cast, tap, maintain or use a special ability of target remain unchanged.",
             "colours": [
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "f9e5006c-e47f-5b78-b62f-c71b4498dcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbe717c-313c-4a8c-85a5-d23d3796ff26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbe717c-313c-4a8c-85a5-d23d3796ff26.jpg?1",
             "name": "Living Artifact",
             "text": "Put a vitality counter on Living Artifact for each damage dealt to you.\no0: During your upkeep, remove a vitality counter to gain 1 life. Remove only one vitality counter during each of your upkeeps.",
             "colours": [
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "6c1c0cac-4c17-50e3-bce6-635e7bfbfb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d5c0df-3db4-4e2d-9688-223383e02b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d5c0df-3db4-4e2d-9688-223383e02b02.jpg?1",
             "name": "Living Lands",
             "text": "All forests become 1/1 creatures. The forests still count as lands but cannot be tapped for mana the turn they come into play.",
             "colours": [
@@ -8455,7 +8455,7 @@
         },
         {
             "id": "09cc2670-1901-5b23-bbab-da36c88f08e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d972d7-5ed9-49c1-8d27-ec162771284d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d972d7-5ed9-49c1-8d27-ec162771284d.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -8489,7 +8489,7 @@
         },
         {
             "id": "6b39ce77-4196-5f6e-be22-cc0d913c6138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abc17aa-8f6b-4156-b148-fc049e1d316a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abc17aa-8f6b-4156-b148-fc049e1d316a.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. Lure does not prevent a creature from blocking more than one creature if blocker has that ability. If blocker is forced to block more creatures than it is allowed to, defender chooses which of these creatures to block, but must block as many creatures as allowed.",
             "colours": [
@@ -8522,7 +8522,7 @@
         },
         {
             "id": "a4eb9c13-da44-51c2-b368-c64f968b8253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16524bd2-0d88-451c-a394-7d5fe204dfc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16524bd2-0d88-451c-a394-7d5fe204dfc6.jpg?1",
             "name": "Marsh Viper",
             "text": "If Marsh Viper damages a player, he or she gets two poison counters. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -8555,7 +8555,7 @@
         },
         {
             "id": "442e341f-c708-5e41-81fc-d2293525e41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db4a4ef-20a8-415f-8d7d-a6740b482f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db4a4ef-20a8-415f-8d7d-a6740b482f73.jpg?1",
             "name": "Nafs Asp",
             "text": "If Nafs Asp damages a player, it also deals 1 damage to that player during his or her next draw phase. Before then, the player may pay o1 to prevent this damage.",
             "colours": [
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "eee47855-0069-50a7-bde6-6e290611af04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2338aeec-63f6-4cc1-833e-77d44994a7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2338aeec-63f6-4cc1-833e-77d44994a7ca.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nG, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "47605cff-ef74-5f15-82f0-7536226647bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504e4e18-a70c-47d6-8331-2ca3c6210a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504e4e18-a70c-47d6-8331-2ca3c6210a98.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying until end of turn.",
             "colours": [
@@ -8655,7 +8655,7 @@
         },
         {
             "id": "82fd3e6e-9c58-575e-8afe-5f6132d07ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c01d57-2bd4-433e-bea7-1acc70d14be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c01d57-2bd4-433e-bea7-1acc70d14be3.jpg?1",
             "name": "Rebirth",
             "text": "Each player may be healed to 20 life. Any player choosing to be healed antes an additional card from the top of his or her library. Remove Rebirth from your deck before playing if not playing for ante.",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "6b3c3eec-a1ed-599e-be6a-377bd5fec9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5697b2e7-25c5-4ae0-a9ac-48cbc6a94c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5697b2e7-25c5-4ae0-a9ac-48cbc6a94c15.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate target creature Regeneration enchants.",
             "colours": [
@@ -8719,7 +8719,7 @@
         },
         {
             "id": "5897b27a-ee2e-5406-80f8-81c23fa7fffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9af432-3997-426a-b532-52333c3c50c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9af432-3997-426a-b532-52333c3c50c4.jpg?1",
             "name": "Sandstorm",
             "text": "Sandstorm deals 1 damage to all attacking creatures.",
             "colours": [
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "7b1c38d3-9b88-5d52-a838-a52827c35de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281e8da8-1383-460e-b74e-ad56f1b6d007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281e8da8-1383-460e-b74e-ad56f1b6d007.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "8663248b-ff73-55e3-b7cd-656dd990052d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8f8c01-6f1c-4902-a7fd-c9cf04b28461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8f8c01-6f1c-4902-a7fd-c9cf04b28461.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk",
             "colours": [
@@ -8817,7 +8817,7 @@
         },
         {
             "id": "41b937d0-1ea2-5800-a768-bafc348bb02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367627-9be3-4e80-a214-0b3f0f2ab867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367627-9be3-4e80-a214-0b3f0f2ab867.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -8848,7 +8848,7 @@
         },
         {
             "id": "9d98ca8e-fad6-5e50-b07d-e47f521ae401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a9682c-ecca-4caa-9e5a-17874167082b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a9682c-ecca-4caa-9e5a-17874167082b.jpg?1",
             "name": "Sylvan Library",
             "text": "You may draw two extra cards during your draw phase. If you do so, put two of the cards drawn this turn back on top of your library (in any order) or pay 4 life per card not replaced. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "ee0ba41b-b6c6-5e6f-a436-1f93b6c1447e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63c16a5-588e-4ef1-9e79-4d36127cd84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63c16a5-588e-4ef1-9e79-4d36127cd84b.jpg?1",
             "name": "Thicket Basilisk",
             "text": "At the end of combat, destroy all non-wall creatures blocking or blocked by Basilisk.",
             "colours": [
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "03c7c775-6dbd-5ed3-b193-1d8e1bf8f6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f84fc8-69b4-4756-9634-4d6c17ec88a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f84fc8-69b4-4756-9634-4d6c17ec88a1.jpg?1",
             "name": "Timber Wolves",
             "text": "Banding",
             "colours": [
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "68c2c3e7-9bcb-5bd0-bae4-29a4fa029f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19dd44e3-d62c-405d-a620-7dc871eef81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19dd44e3-d62c-405d-a620-7dc871eef81c.jpg?1",
             "name": "Titania's Song",
             "text": "All non-creature artifacts lose all their usual abilities and become artifact creatures with toughness and power each equal to their casting costs. If Titania's Song leaves play, artifacts return to normal just before the untap phase of the next turn.",
             "colours": [
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "e688964c-36e7-57f0-8687-d23d9013859a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c8b995-f3d9-435a-8360-4047a619b23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c8b995-f3d9-435a-8360-4047a619b23b.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "2f0db0e1-9281-52a8-83ac-a67bcc07c15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227c2abc-d484-4198-863c-3266a83249c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227c2abc-d484-4198-863c-3266a83249c6.jpg?1",
             "name": "Tsunami",
             "text": "Destroy all islands.",
             "colours": [
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "f242671b-4311-5d13-9988-4461921c5363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2d276d-7a73-4a8f-9803-a37301bc2905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2d276d-7a73-4a8f-9803-a37301bc2905.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for any one basic land and put it directly into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards.",
             "colours": [
@@ -9069,7 +9069,7 @@
         },
         {
             "id": "c92f6f81-4c19-50b8-95e6-060e36414992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a314a0-14cb-4df1-8f2f-653455f13b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a314a0-14cb-4df1-8f2f-653455f13b09.jpg?1",
             "name": "Venom",
             "text": "At the end of combat, destroy all non-wall creatures blocking or blocked by target creature.",
             "colours": [
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "b0a16233-46aa-53d2-9d6c-0dbcf392f810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e30d22-da86-49a1-a319-22e8a909d443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e30d22-da86-49a1-a319-22e8a909d443.jpg?1",
             "name": "Verduran Enchantress",
             "text": "o0: Draw a card when you successfully cast an enchantment. Use this effect only once for each enchantment cast.",
             "colours": [
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "92dbfcf0-5a79-5720-b447-a3b24501cc3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd66c7c-19fb-4daa-996e-70107d732732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd66c7c-19fb-4daa-996e-70107d732732.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerate",
             "colours": [
@@ -9170,7 +9170,7 @@
         },
         {
             "id": "68277e91-0f3e-55ef-944f-1939d3668934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d702bd22-6079-4f4c-9540-42cf2a29f4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d702bd22-6079-4f4c-9540-42cf2a29f4a3.jpg?1",
             "name": "Wall of Ice",
             "text": "",
             "colours": [
@@ -9203,7 +9203,7 @@
         },
         {
             "id": "dd43b149-4801-51be-80d1-0f321f11d013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f236da-8391-487b-88d4-a45342bfff62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f236da-8391-487b-88d4-a45342bfff62.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -9236,7 +9236,7 @@
         },
         {
             "id": "f126eeab-e06b-5762-8bb2-65bfec2ee334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4144ca4-4817-4bb9-929b-613fc609bdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4144ca4-4817-4bb9-929b-613fc609bdb5.jpg?1",
             "name": "Wanderlust",
             "text": "Wanderlust deals 1 damage to target creature's controller during that player's upkeep.",
             "colours": [
@@ -9269,7 +9269,7 @@
         },
         {
             "id": "13663ef2-561b-5248-866a-80383456220d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2137757c-161c-4a3b-9a99-0fd23aa0c847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2137757c-161c-4a3b-9a99-0fd23aa0c847.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -9302,7 +9302,7 @@
         },
         {
             "id": "a9412b4d-28f4-5e4e-8507-b973bfcfe08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0547a390-ceee-4b8a-9d0e-36d8778ec693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0547a390-ceee-4b8a-9d0e-36d8778ec693.jpg?1",
             "name": "Web",
             "text": "Target creature gets +0/+2 and can block creatures with flying.",
             "colours": [
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "b8dc8dc2-b139-5de8-813a-2ab78f890253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4724e-f22e-4156-97fd-1adfccc47be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4724e-f22e-4156-97fd-1adfccc47be3.jpg?1",
             "name": "Whirling Dervish",
             "text": "Protection from black\nPut a +1/+1 counter on Whirling Dervish at the end of each turn in which it damages opponent.",
             "colours": [
@@ -9369,7 +9369,7 @@
         },
         {
             "id": "3bb1cbac-8ce6-5176-94a4-d8e87e06ef4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aea57a2-2753-4014-9724-2701455a6be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aea57a2-2753-4014-9724-2701455a6be8.jpg?1",
             "name": "Wild Growth",
             "text": "Wild Growth adds o\nG to your mana pool each time target land is tapped for mana.",
             "colours": [
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "042dae66-ae89-53eb-8790-8eb5d823807f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4f72de-51e9-45c2-853b-1b6668416417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4f72de-51e9-45c2-853b-1b6668416417.jpg?1",
             "name": "Winter Blast",
             "text": "Tap X target creatures. Winter Blast deals 2 damage to each of these target creatures with flying.",
             "colours": [
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "cc63d251-fe83-5dda-9343-7dba3945d8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e7cf40-c136-4fcb-a947-558b713b39f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e7cf40-c136-4fcb-a947-558b713b39f6.jpg?1",
             "name": "Aladdin's Lamp",
             "text": "o\nX, oc\nT: Instead of drawing a card from the top of your library, draw X cards but choose only one to put into your hand. Shuffle the leftover cards and put them at the bottom of your library. X cannot be 0.",
             "colours": [],
@@ -9460,7 +9460,7 @@
         },
         {
             "id": "c5cdb316-9a13-522c-9a64-d0f85d07242a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9907bbb-12aa-4826-9a65-b2ddda5fc1e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9907bbb-12aa-4826-9a65-b2ddda5fc1e2.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "89bac005-ab4b-5649-b7cf-55ceff772bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc1716d-5817-49f4-a9db-c162e6ceacbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc1716d-5817-49f4-a9db-c162e6ceacbf.jpg?1",
             "name": "Amulet of Kroog",
             "text": "o2, oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "62cd8c67-c3a0-5d80-a529-b6a7c62afa34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44135b17-69e7-4002-a6e0-d76f4c0c423b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44135b17-69e7-4002-a6e0-d76f4c0c423b.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Each time a player puts a land into play, Ankh of Mishra deals 2 damage to that player.",
             "colours": [],
@@ -9541,7 +9541,7 @@
         },
         {
             "id": "5dfdf761-aad1-5b58-a778-f0b70c15e669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fe10-0f6e-4b7f-98fc-3a21c399c38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fe10-0f6e-4b7f-98fc-3a21c399c38a.jpg?1",
             "name": "Armageddon Clock",
             "text": "During your upkeep, put one doom counter on Armageddon Clock. At the end of your upkeep, Armageddon Clock deals X damage to each player, where X is the number of doom counters on Armageddon Clock. During any upkeep, any player may pay o4 to remove a doom counter from Armageddon Clock.",
             "colours": [],
@@ -9568,7 +9568,7 @@
         },
         {
             "id": "6669a1b7-9f0d-5566-b060-a3c800b04456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc11285-0891-4cc3-a056-b698911166c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc11285-0891-4cc3-a056-b698911166c7.jpg?1",
             "name": "Ashnod's Battle Gear",
             "text": "o2, oc\nT: Target creature you control gets +2/-2 as long as Ashnod's Battle Gear remains tapped. You may choose not to untap Ashnod's Battle Gear during your untap phase.",
             "colours": [],
@@ -9595,7 +9595,7 @@
         },
         {
             "id": "e3de83b1-2db6-5f01-9f17-cb3a15afbb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5ea1c-0ea7-4b84-b886-ebd346f4e154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5ea1c-0ea7-4b84-b886-ebd346f4e154.jpg?1",
             "name": "Battering Ram",
             "text": "Banding when attacking\nAt the end of combat, destroy all walls blocking Battering Ram.",
             "colours": [],
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "a980f71b-b609-505a-af25-7552c1c00a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81f7a0f-183f-438b-b252-738d8d30c245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81f7a0f-183f-438b-b252-738d8d30c245.jpg?1",
             "name": "Black Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Black Mana Battery.\noc\nT: Add o\nB to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Black Mana Battery, add o\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -9654,7 +9654,7 @@
         },
         {
             "id": "87e77d24-e808-5a21-8a2d-3f774260959e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196b83a1-2a25-498d-83b8-8faacd79909d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196b83a1-2a25-498d-83b8-8faacd79909d.jpg?1",
             "name": "Black Vise",
             "text": "At the end of target opponent's upkeep, Black Vise deals that player 1 damage for each card in his or her hand in excess of four.",
             "colours": [],
@@ -9681,7 +9681,7 @@
         },
         {
             "id": "89cea107-1f39-5599-994f-1c447cf5e57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2cb84e-c079-486e-87ad-d188fe38bc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2cb84e-c079-486e-87ad-d188fe38bc76.jpg?1",
             "name": "Blue Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Blue Mana Battery.\noc\nT: Add o\nU to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Blue Mana Battery, add o\nU to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -9710,7 +9710,7 @@
         },
         {
             "id": "15ff78aa-b460-57fa-8a99-107f071deef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1924860-4532-40c2-b0e8-28584d22ccb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1924860-4532-40c2-b0e8-28584d22ccb5.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o1: Sacrifice Bottle of Suleiman. Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Bottle of Suleiman deals 5 damage to you. Otherwise, put a Djinn token into play. Treat this token as a 5/5 artifact creature with flying.",
             "colours": [],
@@ -9737,7 +9737,7 @@
         },
         {
             "id": "9c087263-1411-5023-b533-562527d88b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab18c6d-2705-473e-b404-75660ff28736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab18c6d-2705-473e-b404-75660ff28736.jpg?1",
             "name": "Brass Man",
             "text": "Brass Man does not untap during your untap phase.\no1: Untap Brass Man. Use this ability only during your upkeep.",
             "colours": [],
@@ -9767,7 +9767,7 @@
         },
         {
             "id": "f05a01b1-71d1-51b1-98bd-300759e513b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad56033-c1f9-4477-9dd6-ba7009c30593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad56033-c1f9-4477-9dd6-ba7009c30593.jpg?1",
             "name": "Bronze Tablet",
             "text": "Comes into play tapped.\no4, oc\nT: Remove Bronze Tablet and target card opponent owns from the game. You become owner of opponent's card, and opponent becomes owner of Bronze Tablet. Opponent may prevent this exchange by paying 10 life; if he or she does so, destroy Bronze Tablet. Effects that prevent or redirect damage cannot be used to counter this loss of life. Play this ability as an interrupt.\nRemove Bronze Tablet from your deck before playing if not playing for ante.",
             "colours": [],
@@ -9794,7 +9794,7 @@
         },
         {
             "id": "6f9a9cad-85af-5fda-8dfd-f86b7b2cfd56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ca1534-0049-4672-9677-99f1ba00fb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ca1534-0049-4672-9677-99f1ba00fb78.jpg?1",
             "name": "Celestial Prism",
             "text": "o2, oc\nT: Add one mana of any color to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "4f244144-bb3d-5ab3-9f13-3008c729ee3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd9b203-fa4c-4383-a671-265101f4453a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd9b203-fa4c-4383-a671-265101f4453a.jpg?1",
             "name": "Clay Statue",
             "text": "o2: Regenerate",
             "colours": [],
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "2ce6909d-9f0c-564f-aac2-a80efd648b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a92484b-064c-4588-a1ea-6de8fd485ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a92484b-064c-4588-a1ea-6de8fd485ca4.jpg?1",
             "name": "Clockwork Avian",
             "text": "Flying\nWhen Clockwork Avian comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Avian is assigned to attack or block, remove a counter.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Avian. You may have no more than four of these counters on Clockwork Avian. Use this ability only during your upkeep.",
             "colours": [],
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "f3bf3b80-f4d6-5452-bffc-9a6b93b93e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc8595-32b9-4045-bae3-5078c9a17527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc8595-32b9-4045-bae3-5078c9a17527.jpg?1",
             "name": "Clockwork Beast",
             "text": "When Clockwork Beast comes into play, put seven +1/+0 counters on it. At the end of any combat in which Clockwork Beast is assigned to attack or block, remove a counter.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Beast. You may have no more than seven of these counters on Clockwork Beast. Use this ability only during your upkeep.",
             "colours": [],
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "3664fa1b-ccb5-51e0-b0d1-e73c0df3dd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063acc0f-8062-4461-b0f5-8c3a835e1fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063acc0f-8062-4461-b0f5-8c3a835e1fbf.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample\nColossus does not untap during your untap phase.\no9: Untap Colossus. Use this ability only during your upkeep.",
             "colours": [],
@@ -9941,7 +9941,7 @@
         },
         {
             "id": "0678d1e3-d045-5a0a-bc80-864d0ff9f788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6639eea-d0ae-4f0d-a8da-1b863b482b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6639eea-d0ae-4f0d-a8da-1b863b482b68.jpg?1",
             "name": "Conservator",
             "text": "o3, oc\nT: Prevent up to 2 damage to you.",
             "colours": [],
@@ -9968,7 +9968,7 @@
         },
         {
             "id": "04991ddf-2459-5746-8a8a-435e40dd5529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6065242b-e14e-44fa-bbe0-00f070f0140a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6065242b-e14e-44fa-bbe0-00f070f0140a.jpg?1",
             "name": "Coral Helm",
             "text": "o3: Discard a card at random from your hand to give target creature +2/+2 until end of turn.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "1dd9a508-7bf5-5d7e-85ca-697d10f5e86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c17c7-49c2-41f2-842e-d980e7d62613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c17c7-49c2-41f2-842e-d980e7d62613.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Gain 1 life for a successfully cast blue spell. Use this effect either when the spell is cast or later in the turn but only once for each blue spell cast.",
             "colours": [],
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "eabdab64-c961-59a1-8895-8166b50a9db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cbcab8-5593-4ef0-8689-77e71fb1c41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cbcab8-5593-4ef0-8689-77e71fb1c41a.jpg?1",
             "name": "Cursed Rack",
             "text": "Target opponent discards down to four cards during his or her discard phase.",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "7eec7c4e-ff16-5c62-b075-0f9138c58bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0662881-664f-47d2-8164-b4727125ba0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0662881-664f-47d2-8164-b4727125ba0b.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -10079,7 +10079,7 @@
         },
         {
             "id": "ddac534b-33cf-505e-a54c-cbb28852a952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d2c7c2-5696-49a0-b6b0-789bfe839f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d2c7c2-5696-49a0-b6b0-789bfe839f8d.jpg?1",
             "name": "Diabolic Machine",
             "text": "o3: Regenerate",
             "colours": [],
@@ -10109,7 +10109,7 @@
         },
         {
             "id": "fca9e9ea-9f69-576f-af30-71204cde3cf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c44bba-5eaa-41a6-a11a-0bc8fb751ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c44bba-5eaa-41a6-a11a-0bc8fb751ad8.jpg?1",
             "name": "Dingus Egg",
             "text": "Each time a player puts a land into the graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -10136,7 +10136,7 @@
         },
         {
             "id": "b6aea9a8-76e3-59ce-86c5-c281d8d77902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9b9085-6dd7-44fc-b3a5-7f797c34f8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9b9085-6dd7-44fc-b3a5-7f797c34f8dc.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player chooses and discards one card from his or her hand. Use this ability only during your turn.",
             "colours": [],
@@ -10163,7 +10163,7 @@
         },
         {
             "id": "be0c13bb-b928-5b34-b63a-3475e1e4a704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ecbbb3-2d0d-49dc-90b3-1b396d47bf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ecbbb3-2d0d-49dc-90b3-1b396d47bf56.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: +1/+0 until end of turn",
             "colours": [],
@@ -10193,7 +10193,7 @@
         },
         {
             "id": "bf25c958-daba-588e-9d19-55f2bc300fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665f9dc-a5df-4ad7-9067-9b48f942bdde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665f9dc-a5df-4ad7-9067-9b48f942bdde.jpg?1",
             "name": "Ebony Horse",
             "text": "o2, oc\nT: Untap target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [],
@@ -10220,7 +10220,7 @@
         },
         {
             "id": "36869ce9-21b0-5d9d-a7f1-685736c1509f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7a41cc-277a-4d95-a30c-91bf5aa7ac11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7a41cc-277a-4d95-a30c-91bf5aa7ac11.jpg?1",
             "name": "Fellwar Stone",
             "text": "oc\nT: Add one mana to your mana pool. This mana may be of any type that any land opponent controls can produce. Play this ability as an interrupt.",
             "colours": [],
@@ -10247,7 +10247,7 @@
         },
         {
             "id": "c950a7ad-d002-5cd6-9ebd-0a63bfff62ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300428ea-7909-4c2b-81cc-a03d51030bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300428ea-7909-4c2b-81cc-a03d51030bcb.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn. If that creature is put into the graveyard before end of turn, destroy Flying Carpet.",
             "colours": [],
@@ -10274,7 +10274,7 @@
         },
         {
             "id": "f6599ae6-de4b-5daa-aa13-99c726c68a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d71a210-eb2c-4bcc-ae3b-f60a6fb615cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d71a210-eb2c-4bcc-ae3b-f60a6fb615cb.jpg?1",
             "name": "Glasses of Urza",
             "text": "oc\nT: Look at target player's hand.",
             "colours": [],
@@ -10301,7 +10301,7 @@
         },
         {
             "id": "eb5c188f-d2f0-584c-ba60-3d7cde025cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f96f18-8340-4b50-9b4c-3c72c0bbc2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f96f18-8340-4b50-9b4c-3c72c0bbc2f2.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "oc\nT: Grapeshot Catapult deals 1 damage to target creature with flying.",
             "colours": [],
@@ -10331,7 +10331,7 @@
         },
         {
             "id": "1d7877fb-849d-578f-a9ab-1513e357bdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a6e224-72df-4f1f-93d1-5114779aed2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a6e224-72df-4f1f-93d1-5114779aed2c.jpg?1",
             "name": "Green Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Green Mana Battery.\noc\nT: Add o\nG to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Green Mana Battery, add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "92d6e2ae-58d0-5edb-8fab-f2a070b08bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c0a08-1aaf-4976-8eea-c93a9f9486fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c0a08-1aaf-4976-8eea-c93a9f9486fa.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1, oc\nT: Target creature gains banding until end of turn.",
             "colours": [],
@@ -10387,7 +10387,7 @@
         },
         {
             "id": "efea3ef2-f30a-5d8f-a9db-365f40590567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df1be4-364e-4582-929a-05f2905f8ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df1be4-364e-4582-929a-05f2905f8ce6.jpg?1",
             "name": "Howling Mine",
             "text": "Each player draws one extra card during his or her draw phase.",
             "colours": [],
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "aefb2b05-7cb1-57fa-8765-462a1e14086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8846e66-fd42-4e74-80fe-858944108d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8846e66-fd42-4e74-80fe-858944108d40.jpg?1",
             "name": "Iron Star",
             "text": "o1: Gain 1 life for a successfully cast red spell. Use this effect either when the spell is cast or later in the turn but only once for each red spell cast.",
             "colours": [],
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "84d89519-a8d6-5aea-a1fa-3530796fe683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f378af-ea54-4035-9e3e-e8cf980d1e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f378af-ea54-4035-9e3e-e8cf980d1e84.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Gain 1 life for a successfully cast white spell. Use this effect either when the spell is cast or later in the turn but only once for each white spell cast.",
             "colours": [],
@@ -10468,7 +10468,7 @@
         },
         {
             "id": "8968656c-c168-53e8-bfab-ea39db0de6ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff5624d-fffa-48c1-91f3-f03585e45c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff5624d-fffa-48c1-91f3-f03585e45c69.jpg?1",
             "name": "Ivory Tower",
             "text": "At the beginning of your upkeep, gain 1 life for each card in your hand in excess of four.",
             "colours": [],
@@ -10495,7 +10495,7 @@
         },
         {
             "id": "e87b5651-8beb-54cb-9de3-509275706b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044e5475-4ab5-45c5-b86d-9b4720e7ba0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044e5475-4ab5-45c5-b86d-9b4720e7ba0c.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: Redirect to yourself all damage done to any creature. The source of the damage does not change.",
             "colours": [],
@@ -10522,7 +10522,7 @@
         },
         {
             "id": "dfd7d802-1f9c-54db-93e4-af51330f46c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15b58c-80b4-4da7-8ed6-d963702eda3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15b58c-80b4-4da7-8ed6-d963702eda3a.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3, oc\nT: Untap target creature.",
             "colours": [],
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "eba20a0a-774e-55a5-85c4-4bf99325b9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009fceb-9140-457b-b980-875f6a2f70fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009fceb-9140-457b-b980-875f6a2f70fd.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw one card.",
             "colours": [],
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "f64bb23b-0d85-5c6a-b48c-d7b9c570f5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd054ed-9c91-4bc6-9d0d-0c045c089bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd054ed-9c91-4bc6-9d0d-0c045c089bd9.jpg?1",
             "name": "Kormus Bell",
             "text": "All swamps become 1/1 black creatures. The swamps still count as lands but cannot be tapped for mana the turn they come into play.",
             "colours": [],
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "28df2f32-8c39-5afd-ab0b-f8f8f08416cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b811a515-87a2-4dee-8689-48bfba12e6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b811a515-87a2-4dee-8689-48bfba12e6c5.jpg?1",
             "name": "Library of Leng",
             "text": "Skip the discard phase of your turn. If a spell or effect forces you to discard, you may discard to the top of your library rather than to your graveyard. If the discard is random, you may look at the card before choosing where to discard it.",
             "colours": [],
@@ -10630,7 +10630,7 @@
         },
         {
             "id": "6a8c1bb2-d681-5064-93c7-35d7ed198840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be9942c-89b3-422f-bb9d-b55f51a22a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be9942c-89b3-422f-bb9d-b55f51a22a37.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault does not untap during your untap phase. If it remains tapped during your upkeep, Mana Vault deals 1 damage to you.\no4: Untap Mana Vault. Use this ability only during your upkeep.\noc\nT: Add three colorless mana to your mana pool. Play these additions as interrupts.",
             "colours": [],
@@ -10657,7 +10657,7 @@
         },
         {
             "id": "5b7a23bf-d1ab-5085-ad2e-b94211717678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9714ce0-7fc3-4bf3-ad65-68555a9d2f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9714ce0-7fc3-4bf3-ad65-68555a9d2f35.jpg?1",
             "name": "Meekstone",
             "text": "No creatures with power greater than 2 untap during their controllers' untap phase.",
             "colours": [],
@@ -10684,7 +10684,7 @@
         },
         {
             "id": "b603d42b-cc9d-5e1b-a31e-67772591e256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16f7d28-1bc2-44b6-973b-c60d966101a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16f7d28-1bc2-44b6-973b-c60d966101a6.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Take the top two cards from target player's library and put them into that player's graveyard.",
             "colours": [],
@@ -10711,7 +10711,7 @@
         },
         {
             "id": "a5afed40-fd83-527b-a786-156a17d0d5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7b5921-3e10-47e7-98a7-8411a18313bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7b5921-3e10-47e7-98a7-8411a18313bf.jpg?1",
             "name": "Mishra's War Machine",
             "text": "Banding\nDuring your upkeep, choose and discard one card from your hand, or Mishra's War Machine deals 3 damage to you. If Mishra's War Machine deals damage to you in this way, tap it.",
             "colours": [],
@@ -10741,7 +10741,7 @@
         },
         {
             "id": "8cd1977a-692a-54fb-9896-fa9aaaef8d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427396c-f1ef-46ac-b130-ed1e51e826a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427396c-f1ef-46ac-b130-ed1e51e826a3.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Comes into play tapped.\no1, oc\nT: Destroy all creatures, enchantments, and artifacts, including Nevinyrral's Disk itself.",
             "colours": [],
@@ -10768,7 +10768,7 @@
         },
         {
             "id": "64bcff7d-96c5-5cb2-bde3-dd8adf39cc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837605e3-f4c2-4b60-8478-f21ca8734ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837605e3-f4c2-4b60-8478-f21ca8734ef2.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -10798,7 +10798,7 @@
         },
         {
             "id": "f3477c68-b506-5bca-9659-5cd5f64c8971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64c2dff-9c11-4c91-a606-b5de704f18d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64c2dff-9c11-4c91-a606-b5de704f18d4.jpg?1",
             "name": "Onulet",
             "text": "If Onulet is put into the graveyard from play, you gain 2 life.",
             "colours": [],
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "2fc22d79-502e-5c60-b288-0bd7a61a0e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeb3ce1-1e7f-4269-a326-700f27e9e932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeb3ce1-1e7f-4269-a326-700f27e9e932.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -10858,7 +10858,7 @@
         },
         {
             "id": "28b09388-1548-54eb-80c4-914ab85d9c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc49d724-b46d-449b-bd2b-03551e130a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc49d724-b46d-449b-bd2b-03551e130a06.jpg?1",
             "name": "Primal Clay",
             "text": "When Primal Clay comes into play, choose whether to make it a 1/6 wall, a 2/2 creature with flying, or a 3/3 creature.",
             "colours": [],
@@ -10888,7 +10888,7 @@
         },
         {
             "id": "4f6897d5-846e-5d0a-9c12-8a2bef32064a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e507bc-441d-4f44-85d4-cf93ca199d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e507bc-441d-4f44-85d4-cf93ca199d2e.jpg?1",
             "name": "Red Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on Red Mana Battery.\noc\nT: Add o\nR to your mana pool and remove as many charge counters as you wish. For each charge counter removed from Red Mana Battery, add o\nR to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -10917,7 +10917,7 @@
         },
         {
             "id": "7344c4fa-2b5d-5534-84b7-e964b2ecb09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf9da4-4647-4c66-a3ce-fab7ca9618d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf9da4-4647-4c66-a3ce-fab7ca9618d1.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -10944,7 +10944,7 @@
         },
         {
             "id": "53b8c030-d92e-5d30-96a6-0ae6ff682aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9d1526-9888-41bc-b77d-88d62325e0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9d1526-9888-41bc-b77d-88d62325e0b2.jpg?1",
             "name": "Shapeshifter",
             "text": "Shapeshifter has power and toughness that add up to seven, but neither may be more than seven. Set them when Shapeshifter comes into play; you may change them during your upkeep.",
             "colours": [],
@@ -10974,7 +10974,7 @@
         },
         {
             "id": "ba68ca6f-2b8a-5603-b17a-59bc7ffa04be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccacae0-f8db-45e0-b25a-35418fd24389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccacae0-f8db-45e0-b25a-35418fd24389.jpg?1",
             "name": "Soul Net",
             "text": "o1: Gain 1 life when a creature is put into the graveyard from play. Use this effect only once each time a creature is put into the graveyard.",
             "colours": [],
@@ -11001,7 +11001,7 @@
         },
         {
             "id": "6c1f73fb-eaf0-596b-8d38-63bb3b5bc1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a225462-947c-49d7-81b2-91f875664dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a225462-947c-49d7-81b2-91f875664dca.jpg?1",
             "name": "Sunglasses of Urza",
             "text": "You may use white mana in your mana pool as either white or red mana.",
             "colours": [],
@@ -11028,7 +11028,7 @@
         },
         {
             "id": "bb70e61a-f84f-58de-8739-a94375c50ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d566993f-18a6-4e5c-abc3-0fe9a03e97d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d566993f-18a6-4e5c-abc3-0fe9a03e97d2.jpg?1",
             "name": "Tawnos's Wand",
             "text": "o2, oc\nT: Target creature with power no greater than 2 becomes unblockable until end of turn. Other effects may later be used to increase the creature's power beyond 2.",
             "colours": [],
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "0f5c07bd-d7b8-5f9b-b87a-6d21bd8eb77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4750787e-9fef-4bdf-b2e3-e410c84999f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4750787e-9fef-4bdf-b2e3-e410c84999f2.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "o2, oc\nT: Target creature gets +1/+1 as long as Tawnos's Weaponry remains tapped.\nYou may choose not to untap Tawnos's Weaponry during your untap phase.",
             "colours": [],
@@ -11082,7 +11082,7 @@
         },
         {
             "id": "637a799c-46fb-53a2-acad-7bea043d8013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1a2b2-50f0-4ed0-bd8f-06cd6aada04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1a2b2-50f0-4ed0-bd8f-06cd6aada04f.jpg?1",
             "name": "Tetravus",
             "text": "Flying\nWhen Tetravus comes into play, put three +1/+1 counters on it.\nDuring your upkeep, you may move each of these counters on or off of Tetravus, regardless of who controls them. Counters that are removed become Tetravite tokens. Treat these tokens as 1/1 artifact creatures with flying. These creatures cannot have enchantment played on them and do not share any enchantments on Tetravus.",
             "colours": [],
@@ -11112,7 +11112,7 @@
         },
         {
             "id": "67950764-6e2b-578a-a942-e8eee5df6181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d01a2e-2687-4b37-aed6-63202cd81231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d01a2e-2687-4b37-aed6-63202cd81231.jpg?1",
             "name": "The Hive",
             "text": "5, oc\nT: Put a Wasp token into play. Treat this token as a 1/1 artifact creature with flying.",
             "colours": [],
@@ -11139,7 +11139,7 @@
         },
         {
             "id": "d080d796-76af-5bbe-b0f7-bf471c2103d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e19104f-55d5-40e5-a61d-ddba2cf5a527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e19104f-55d5-40e5-a61d-ddba2cf5a527.jpg?1",
             "name": "The Rack",
             "text": "At the end of target opponent's upkeep, The Rack deals that player 1 damage for each card in his or her hand fewer than three.",
             "colours": [],
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "3c24cbf8-0585-5fb7-b368-012e76707988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e77be1-3c29-40b4-9c47-44fa2d9d4454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e77be1-3c29-40b4-9c47-44fa2d9d4454.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Gain 1 life for a successfully cast black spell. Use this effect either when the spell is cast or later in the turn but only once for each black spell cast.",
             "colours": [],
@@ -11193,7 +11193,7 @@
         },
         {
             "id": "6dde0a14-fc03-5279-9ef3-da9c5a08d3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09294401-a895-4084-8302-196a946863d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09294401-a895-4084-8302-196a946863d6.jpg?1",
             "name": "Triskelion",
             "text": "When Triskelion comes into play, put three +1/+1 counters on it.\no0: Remove one of these counters from Triskelion to have Triskelion deal 1 damage to target creature or player.",
             "colours": [],
@@ -11223,7 +11223,7 @@
         },
         {
             "id": "b3d2e90e-3aaa-5ffe-8e27-fd2aec507450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dd1daa-0b5d-4d0c-9a67-a59083038f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dd1daa-0b5d-4d0c-9a67-a59083038f2d.jpg?1",
             "name": "Urza's Avenger",
             "text": "o0: Urza's Avenger gets -1/-1 until end of turn and your choice of flying, banding, first strike, or trample until end of turn.",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "7dba6348-cce4-5566-9d3d-8c60c62cd2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad580bfc-8827-4a8a-a5ec-b6195b3146bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad580bfc-8827-4a8a-a5ec-b6195b3146bb.jpg?1",
             "name": "Wall of Spears",
             "text": "First strike, counts as a wall",
             "colours": [],
@@ -11283,7 +11283,7 @@
         },
         {
             "id": "b49f1ca7-1e8d-5c76-9740-c5fabe7ca70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b622e694-858d-482f-a67d-0e52d268708c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b622e694-858d-482f-a67d-0e52d268708c.jpg?1",
             "name": "White Mana Battery",
             "text": "o2, oc\nT: Put one charge counter on White Mana Battery.\noc\nT: Add o\nW to your mana pool and remove as many charge counters as you wish. For each charge counter removed from White Mana Battery, add o\nW to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -11312,7 +11312,7 @@
         },
         {
             "id": "bfba2f60-46ba-5206-a96e-51d0794f9a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60ee90d-5f7b-4294-8d52-9744fada8d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60ee90d-5f7b-4294-8d52-9744fada8d36.jpg?1",
             "name": "Winter Orb",
             "text": "No player may untap more than one land during his or her untap phase.",
             "colours": [],
@@ -11339,7 +11339,7 @@
         },
         {
             "id": "c09e02c3-7b89-501a-944e-e331cc63a456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51abf0-8661-4776-929d-35b7bd345e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51abf0-8661-4776-929d-35b7bd345e21.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Gain 1 life for a successfully cast green spell. Use this effect either when the spell is cast or later in the turn but only once for each green spell cast.",
             "colours": [],
@@ -11366,7 +11366,7 @@
         },
         {
             "id": "ae84e95a-0c71-5118-ab1b-3b8df60f8c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaab84be-bb96-437b-a9a7-aa7a11ffd21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaab84be-bb96-437b-a9a7-aa7a11ffd21d.jpg?1",
             "name": "Yotian Soldier",
             "text": "Attacking does not cause Yotian Soldier to tap.",
             "colours": [],
@@ -11396,7 +11396,7 @@
         },
         {
             "id": "2347c3a6-6604-53ee-9ce5-d1094e26b467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff8d4f1-eaad-4afb-9097-2afab133f707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff8d4f1-eaad-4afb-9097-2afab133f707.jpg?1",
             "name": "Mishra's Factory",
             "text": "oc\nT: Add 1 colorless mana to your mana pool.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker still counts as a land but cannot be tapped for mana the turn it comes into play.\noc\nT: Target Assembly Worker gets +1/+1 until end of turn.",
             "colours": [],
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "c6b69718-6590-5289-990b-02b6007b9fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d51a6de-7bb4-4e3d-82a7-a298c8d742ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d51a6de-7bb4-4e3d-82a7-a298c8d742ef.jpg?1",
             "name": "Oasis",
             "text": "oc\nT: Prevent 1 damage to any creature.",
             "colours": [],
@@ -11450,7 +11450,7 @@
         },
         {
             "id": "cc47a9fc-d4e0-5140-9dc8-cfbdee1a0fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5899b46-226b-4be6-8e80-d2396f54210d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5899b46-226b-4be6-8e80-d2396f54210d.jpg?1",
             "name": "Strip Mine",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Sacrifice Strip Mine to destroy target land.",
             "colours": [],
@@ -11477,7 +11477,7 @@
         },
         {
             "id": "fdc50021-e80d-5470-9915-080a682d9905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639e47dc-c90f-4f55-9b3a-721240ec04ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639e47dc-c90f-4f55-9b3a-721240ec04ed.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11513,7 +11513,7 @@
         },
         {
             "id": "8e19b83d-6a97-5a6e-baad-f9bf8f3ac80d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17f8abd-c087-4039-8dfd-c6168f7db0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17f8abd-c087-4039-8dfd-c6168f7db0a6.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11549,7 +11549,7 @@
         },
         {
             "id": "331c2b62-41fc-5d5b-bd89-90e24a3f94b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1317da-9e81-4aff-8c04-9155d14be90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1317da-9e81-4aff-8c04-9155d14be90c.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11585,7 +11585,7 @@
         },
         {
             "id": "412017f1-c163-59fb-943f-672e75228456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06bbd6e-eb0d-45fc-88ef-0e085d6505ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06bbd6e-eb0d-45fc-88ef-0e085d6505ef.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11621,7 +11621,7 @@
         },
         {
             "id": "965542e6-b302-5634-8206-be0cd10df222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e3819-3d75-40d4-9a93-1147834dfd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e3819-3d75-40d4-9a93-1147834dfd69.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11657,7 +11657,7 @@
         },
         {
             "id": "6279ec6e-af89-5318-9712-5f934552c6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a05f9a-1285-4d14-b827-8b81968e09df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a05f9a-1285-4d14-b827-8b81968e09df.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11693,7 +11693,7 @@
         },
         {
             "id": "1b3a28ad-41ca-587a-9feb-5f40154976da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84634023-5c94-4dcc-9449-abf73ecea542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84634023-5c94-4dcc-9449-abf73ecea542.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "d94ba293-88b8-5617-8d0b-164ac11048c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa0be1-7358-4ea2-8c40-be6d699a6631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa0be1-7358-4ea2-8c40-be6d699a6631.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11765,7 +11765,7 @@
         },
         {
             "id": "11f51715-d399-5ce8-bfa0-642dd23f1eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac4979a-5b2f-4db1-b665-9d8ccc15ba82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac4979a-5b2f-4db1-b665-9d8ccc15ba82.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11801,7 +11801,7 @@
         },
         {
             "id": "41f2d93b-bd7b-590a-b1a7-3b7569163c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5c9379-b686-4823-b85a-eaf2c4b63205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5c9379-b686-4823-b85a-eaf2c4b63205.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11837,7 +11837,7 @@
         },
         {
             "id": "3b48a4bf-1f20-5d47-bb1f-31ee7fa14514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10478e22-d1dd-4e02-81a7-d93ce71ed81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10478e22-d1dd-4e02-81a7-d93ce71ed81d.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11873,7 +11873,7 @@
         },
         {
             "id": "88b58c4c-b100-5ac2-9ded-02c3d9cf3b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50352268-88a6-4575-a5e1-cd8bef7f8286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50352268-88a6-4575-a5e1-cd8bef7f8286.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11909,7 +11909,7 @@
         },
         {
             "id": "7e574557-d888-5fde-8ef8-d02f21fedcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c4d73-5b71-446a-a739-25d494591aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c4d73-5b71-446a-a739-25d494591aa1.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11945,7 +11945,7 @@
         },
         {
             "id": "fea502b2-f7ed-5947-8c11-2659905e539a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb35995-0298-4281-88d1-2531c93a4916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb35995-0298-4281-88d1-2531c93a4916.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11981,7 +11981,7 @@
         },
         {
             "id": "51c25e02-f5fa-5100-8a2f-39b1547cba69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794073f-4188-45c9-9e65-c9d7f2ecc24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794073f-4188-45c9-9e65-c9d7f2ecc24b.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/5DN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/5DN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "dd2af968-b944-551b-9833-c7aab9ad6484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0bf63-0399-40d6-9162-4562d7bcdd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0bf63-0399-40d6-9162-4562d7bcdd0e.jpg?1",
             "name": "Abuna's Chant",
             "text": "Choose one You gain 5 life; or prevent the next 5 damage that would be dealt to target creature this turn.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "b6082941-6bf7-5ca5-aa08-38b142db7165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7029fac9-ef8a-499f-aa42-c145b6b528ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7029fac9-ef8a-499f-aa42-c145b6b528ae.jpg?1",
             "name": "Armed Response",
             "text": "Armed Response deals damage to target attacking creature equal to the number of Equipment you control.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "0d1f7fb7-3831-5b3a-94a6-2709881250df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6bf0b-bb39-4d0f-9035-a276e604f609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6bf0b-bb39-4d0f-9035-a276e604f609.jpg?1",
             "name": "Auriok Champion",
             "text": "Protection from black and from red\nWhenever another creature comes into play, you may gain 1 life.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "08730fac-b23f-5af6-bd62-ccffe96578fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c9cd1b-9260-4f98-ac7a-25bb5ae3e06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c9cd1b-9260-4f98-ac7a-25bb5ae3e06d.jpg?1",
             "name": "Auriok Salvagers",
             "text": "{1}{W}: Return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "a3f84e2d-0d21-5b84-b767-04582f9d4ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d060-9858-405c-a442-c7a278134f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d060-9858-405c-a442-c7a278134f00.jpg?1",
             "name": "Auriok Windwalker",
             "text": "Flying\n{T}: Attach target Equipment you control to target creature you control.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "1252fe2e-4d39-52b7-8479-b3d6a4af90d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601bb6d1-77f4-4ffe-94d0-bed74c33013b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601bb6d1-77f4-4ffe-94d0-bed74c33013b.jpg?1",
             "name": "Beacon of Immortality",
             "text": "Double target player's life total. Shuffle Beacon of Immortality into its owner's library.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "18cdf686-d5c7-5017-b942-0bc1237cbe7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a7117-b1e2-46bd-873e-baf9d9fac009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a7117-b1e2-46bd-873e-baf9d9fac009.jpg?1",
             "name": "Bringer of the White Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the White Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may return target artifact card from your graveyard to play.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "1570dbb3-43c5-58b3-a160-5ba143d8f07a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e7267-3d71-4724-b3e7-ae5a6a1f002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e7267-3d71-4724-b3e7-ae5a6a1f002a.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "{2}: The next time an artifact source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "d2582edd-a186-55d4-a613-40e3f80ce0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5320ff-1fe6-492a-b27f-86a84a1768ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5320ff-1fe6-492a-b27f-86a84a1768ed.jpg?1",
             "name": "Leonin Squire",
             "text": "When Leonin Squire comes into play, return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "fd9622a1-7f43-5f70-9979-adc947857b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f0113-3ced-49c7-9fa8-f1cc873bdc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f0113-3ced-49c7-9fa8-f1cc873bdc4c.jpg?1",
             "name": "Loxodon Anchorite",
             "text": "{T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "992210ba-e9e4-5dc1-853e-e2353eb07b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e58f4fb-5b4e-45bc-99b3-d09cd79132df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e58f4fb-5b4e-45bc-99b3-d09cd79132df.jpg?1",
             "name": "Loxodon Stalwart",
             "text": "Attacking doesn't cause Loxodon Stalwart to tap.\n{W}: Loxodon Stalwart gets +0/+1 until end of turn.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "54118dec-49c6-5c67-8a33-2791490183fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45501767-2ba8-443f-af9b-c86ead0aa30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45501767-2ba8-443f-af9b-c86ead0aa30d.jpg?1",
             "name": "Raksha Golden Cub",
             "text": "Attacking doesn't cause Raksha Golden Cub to tap.\nAs long as Raksha is equipped, Cats you control get +2/+2 and have double strike.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "7002b5a8-8f5c-543a-8765-1a9015499765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58acdda6-6754-46f2-ad68-f1580b8ab0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58acdda6-6754-46f2-ad68-f1580b8ab0dd.jpg?1",
             "name": "Retaliate",
             "text": "Destroy all creatures that dealt damage to you this turn.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "4e8029d7-b01d-5a98-babd-40b1c57a1cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d560e242-44ef-4162-8589-965897e4cdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d560e242-44ef-4162-8589-965897e4cdad.jpg?1",
             "name": "Roar of Reclamation",
             "text": "Each player returns all artifact cards from his or her graveyard to play.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "945cc9b8-ca9d-56e5-a2ff-be9ea72ed104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4065bb-8deb-46d5-a57e-d61c77493274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4065bb-8deb-46d5-a57e-d61c77493274.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying\nAttacking doesn't cause Skyhunter Prowler to tap.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "8de80063-ab58-518c-a93d-10b64c9b6dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975d0549-e6b6-456b-8693-227591e4db91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975d0549-e6b6-456b-8693-227591e4db91.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "Flying, double strike",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "339ef173-f5e3-5252-8522-235d0887ce4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d3a024-6cf3-4008-a4f6-1d96ff5de22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d3a024-6cf3-4008-a4f6-1d96ff5de22a.jpg?1",
             "name": "Stand Firm",
             "text": "Target creature gets +1/+1 until end of turn.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "635a8785-29bb-5905-b6dd-750e5afb33d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2ca75e-ccb0-4e5b-8dda-445fe0130732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2ca75e-ccb0-4e5b-8dda-445fe0130732.jpg?1",
             "name": "Stasis Cocoon",
             "text": "Enchanted artifact's activated abilities can't be played.\nIf enchanted artifact is a creature, it can't attack or block.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "708f58a6-102a-5267-a8e0-13a1bdd9f841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75b77f-a230-4bad-b697-a40687671842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75b77f-a230-4bad-b697-a40687671842.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "c3107bb9-40c5-573b-a91b-0523f69daf80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bae717-56c0-4028-b1e7-a445d6a57176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bae717-56c0-4028-b1e7-a445d6a57176.jpg?1",
             "name": "Vanquish",
             "text": "Destroy target blocking creature.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "2f92becf-7732-5fed-9ab8-cb5dd00c0c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993957c7-5d61-4c98-826d-b657aed667e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993957c7-5d61-4c98-826d-b657aed667e1.jpg?1",
             "name": "Acquire",
             "text": "Search target opponent's library for an artifact card and put that card into play under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "784c2661-9c33-545e-901d-cd892e7b534b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384d50a-5801-47ed-ab9f-5c7e4f1f20dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384d50a-5801-47ed-ab9f-5c7e4f1f20dd.jpg?1",
             "name": "Advanced Hoverguard",
             "text": "Flying\n{U}: Advanced Hoverguard can't be the target of spells or abilities this turn.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "5049883c-4aa7-5cb9-9bd4-36a4de847e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe37c88-afd7-45ac-9f84-f4bd881a1462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe37c88-afd7-45ac-9f84-f4bd881a1462.jpg?1",
             "name": "Artificer's Intuition",
             "text": "{U}, Discard an artifact card from your hand: Search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "13784941-0eae-572c-8041-280c4355e27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab166c9-af3e-4e65-88ed-9766b046c95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab166c9-af3e-4e65-88ed-9766b046c95b.jpg?1",
             "name": "Beacon of Tomorrows",
             "text": "Target player takes an extra turn after this one. Shuffle Beacon of Tomorrows into its owner's library.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "5085beee-b5f3-5757-95bd-ac8a273371ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb4d9a3-e7f6-41e2-9545-4682efd71f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb4d9a3-e7f6-41e2-9545-4682efd71f46.jpg?1",
             "name": "Blinkmoth Infusion",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nUntap all artifacts.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "0a546a8d-a2f2-5088-89e8-1f50160ba1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dc82a0-f054-4614-a7b9-4c5a7c9d2a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dc82a0-f054-4614-a7b9-4c5a7c9d2a77.jpg?1",
             "name": "Bringer of the Blue Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Blue Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may draw two cards.",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "bf3b94ff-05ec-552c-98dd-e3e2dc633d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8303b80-e29a-46b8-90b0-c0cfe551b435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8303b80-e29a-46b8-90b0-c0cfe551b435.jpg?1",
             "name": "Condescend",
             "text": "Counter target spell unless its controller pays {X}.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "bc93c235-1539-5221-8add-dbeaf9ae74af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b6f7e-4e08-465d-b9c7-d1a167850cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b6f7e-4e08-465d-b9c7-d1a167850cf9.jpg?1",
             "name": "Disruption Aura",
             "text": "Enchanted artifact has \"At the beginning of your upkeep, sacrifice this artifact unless you pay its mana cost.\"",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "aa3692ec-3801-545b-b629-7b3f46469e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5989d4c4-bfa4-4b07-ab64-65a3aee6144e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5989d4c4-bfa4-4b07-ab64-65a3aee6144e.jpg?1",
             "name": "Early Frost",
             "text": "Tap up to three target lands.",
             "colours": [
@@ -979,7 +979,7 @@
         },
         {
             "id": "47dcd733-b48a-5ec6-9d6b-1bd783a94d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb0716-e0fc-415d-8fc3-d3f5ee31e9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb0716-e0fc-415d-8fc3-d3f5ee31e9c5.jpg?1",
             "name": "Eyes of the Watcher",
             "text": "Whenever you play an instant or sorcery spell, you may pay {1}. If you do, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "42df3437-ae03-57ac-8d96-021163b5d896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615157d6-0160-417b-b06c-0e253b306c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615157d6-0160-417b-b06c-0e253b306c37.jpg?1",
             "name": "Fold into Aether",
             "text": "Counter target spell. If you do, that spell's controller may put a creature card from his or her hand into play.",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "8650c19d-0943-5ec8-aee3-a95cab25433b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55773fd5-86a2-4fd4-9849-a2f0d4c8298f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55773fd5-86a2-4fd4-9849-a2f0d4c8298f.jpg?1",
             "name": "Hoverguard Sweepers",
             "text": "Flying\nWhen Hoverguard Sweepers comes into play, you may return up to two target creatures to their owners' hands.",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "0be714ce-98d7-5dd7-ab1b-522a0981c504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31ff9-f403-4082-88f8-65807c0af812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31ff9-f403-4082-88f8-65807c0af812.jpg?1",
             "name": "Into Thin Air",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nReturn target artifact to its owner's hand.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "33cd41a8-ea0c-54d8-9497-8bc3509eb3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035a8a69-1e48-4c44-b407-cc8acc8ba94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035a8a69-1e48-4c44-b407-cc8acc8ba94c.jpg?1",
             "name": "Plasma Elemental",
             "text": "Plasma Elemental is unblockable.",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "b24cb5d1-eaa0-5033-aacf-a8943180de69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54102e68-dded-440c-b9b1-28771c8033d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54102e68-dded-440c-b9b1-28771c8033d4.jpg?1",
             "name": "Qumulox",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "2d0035b3-65b8-520b-a3be-e9006cf37e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61952-88ba-447a-835a-f1e9643fcd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61952-88ba-447a-835a-f1e9643fcd0d.jpg?1",
             "name": "Serum Visions",
             "text": "Draw a card.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "10e30eeb-cdd8-54ce-9508-2b2638ce4601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a3f75d-9a79-4c16-8f50-43a18add4579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a3f75d-9a79-4c16-8f50-43a18add4579.jpg?1",
             "name": "Spectral Shift",
             "text": "Choose one Change the text of target spell or permanent by replacing all instances of one basic land type with another; or change the text of target spell or permanent by replacing all instances of one color word with another. (These effects don't end at end of turn.)\nEntwine {2}",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "da8d6299-797a-5af9-b622-234bdd0c126b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837b6315-d5c6-480b-902e-44107a72b581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837b6315-d5c6-480b-902e-44107a72b581.jpg?1",
             "name": "Thought Courier",
             "text": "{T}: Draw a card, then discard a card from your hand.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "0258196f-f314-594f-8cf6-6bfa245717c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a41ab-1840-4abb-a8bb-f0b1e7d1b450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a41ab-1840-4abb-a8bb-f0b1e7d1b450.jpg?1",
             "name": "Trinket Mage",
             "text": "When Trinket Mage comes into play, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1311,7 +1311,7 @@
         },
         {
             "id": "eafe03d7-84f7-50a7-b9fa-1fba2bc9c111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d8c7ed-62ce-4865-8f9e-5fcc8b23cff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d8c7ed-62ce-4865-8f9e-5fcc8b23cff5.jpg?1",
             "name": "Vedalken Mastermind",
             "text": "{U}, {T}: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -1346,7 +1346,7 @@
         },
         {
             "id": "419360cc-4b71-5f91-9e6a-72c86eb93f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a0e0c-cf75-46ec-a65b-e6d3d371f28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a0e0c-cf75-46ec-a65b-e6d3d371f28a.jpg?1",
             "name": "Beacon of Unrest",
             "text": "Put target artifact or creature card from a graveyard into play under your control. Shuffle Beacon of Unrest into its owner's library.",
             "colours": [
@@ -1378,7 +1378,7 @@
         },
         {
             "id": "da3e503c-039d-5c92-a5af-b90d01b7b387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5440a-7460-4b4f-a167-a6c4fb2d855e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5440a-7460-4b4f-a167-a6c4fb2d855e.jpg?1",
             "name": "Blind Creeper",
             "text": "Whenever a player plays a spell, Blind Creeper gets -1/-1 until end of turn.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "2bdf763d-bbd3-5058-9815-69a5e4657d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e5e882-02d4-4d69-aabf-ae9bf31f2923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e5e882-02d4-4d69-aabf-ae9bf31f2923.jpg?1",
             "name": "Bringer of the Black Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Black Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may pay 2 life. If you do, search your library for a card, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -1451,7 +1451,7 @@
         },
         {
             "id": "c4375935-cd79-5b0a-9b73-205c3ae669be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641080d8-1b2e-4990-a114-04bea9a5adce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641080d8-1b2e-4990-a114-04bea9a5adce.jpg?1",
             "name": "Cackling Imp",
             "text": "Flying\n{T}: Target player loses 1 life.",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "d0785e19-c015-5fb8-9ff7-96d482f55fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c14a7a-cce3-45a8-9092-834e71447f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c14a7a-cce3-45a8-9092-834e71447f62.jpg?1",
             "name": "Desecration Elemental",
             "text": "Fear\nWhenever a player plays a spell, sacrifice a creature.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "ab32e99d-327e-5ac2-bc1a-589c1bad7987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c80584-b7b5-4dcd-8a00-812b9dd9b1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c80584-b7b5-4dcd-8a00-812b9dd9b1b9.jpg?1",
             "name": "Devour in Shadow",
             "text": "Destroy target creature. It can't be regenerated. You lose life equal to that creature's toughness.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "fdc07f4a-c6b1-597c-a292-be07c5f975e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e61e00-c55b-4384-923b-a777f75cbe79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e61e00-c55b-4384-923b-a777f75cbe79.jpg?1",
             "name": "Dross Crocodile",
             "text": "",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "85263657-fdee-5ce1-88b7-43eff6435dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254ea05c-c349-4a95-8751-779b044603bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254ea05c-c349-4a95-8751-779b044603bb.jpg?1",
             "name": "Ebon Drake",
             "text": "Flying\nWhenever a player plays a spell, you lose 1 life.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "571ec204-371e-5f09-9c9a-2fb91b3a632e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266323da-9528-462e-a0a8-6ef2dda5f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266323da-9528-462e-a0a8-6ef2dda5f1ee.jpg?1",
             "name": "Endless Whispers",
             "text": "Each creature has \"When this creature is put into a graveyard from play, choose target opponent. That player puts this creature card from that graveyard into play under his or her control at end of turn.\"",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "228dee18-2e14-5ab6-a533-df617d49653d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682bbd3-9f52-452d-b886-a6a8def35f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682bbd3-9f52-452d-b886-a6a8def35f27.jpg?1",
             "name": "Fill with Fright",
             "text": "Target player discards two cards from his or her hand.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "1bb8d310-0fab-542d-b81b-811b826e47e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01095217-bc33-4d71-bf10-2ead9f8ebd25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01095217-bc33-4d71-bf10-2ead9f8ebd25.jpg?1",
             "name": "Fleshgrafter",
             "text": "Discard an artifact card from your hand: Fleshgrafter gets +2/+2 until end of turn.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "0d7bc552-bfa8-524c-aed8-66ac48471cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d7bf6-00f4-4c7e-b1a4-f7fd690d4788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d7bf6-00f4-4c7e-b1a4-f7fd690d4788.jpg?1",
             "name": "Lose Hope",
             "text": "Target creature gets -1/-1 until end of turn.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "9904c18b-174a-55e0-bed3-120a9e424128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754f202f-4f08-4c39-9219-1114d8508788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754f202f-4f08-4c39-9219-1114d8508788.jpg?1",
             "name": "Mephidross Vampire",
             "text": "Flying\nEach creature you control is a Vampire in addition to its other creature types and has \"Whenever this creature deals damage to a creature, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "0bb7d751-e71c-5e5e-8a39-1de6aca509ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ffdeb8-52d2-4059-b9c6-0ad71b96516a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ffdeb8-52d2-4059-b9c6-0ad71b96516a.jpg?1",
             "name": "Moriok Rigger",
             "text": "Whenever an artifact is put into a graveyard from play, you may put a +1/+1 counter on Moriok Rigger.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "b7ab5cc9-6085-5f29-8fda-b9654d75a37f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f0c6f6-b90d-4eb1-a5db-86e0a3997501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f0c6f6-b90d-4eb1-a5db-86e0a3997501.jpg?1",
             "name": "Night's Whisper",
             "text": "You draw two cards and you lose 2 life.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "028cd7a1-f550-54d4-b53c-1c22d670b1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ae8bc7-8bf1-4fce-afaa-76acfb261419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ae8bc7-8bf1-4fce-afaa-76acfb261419.jpg?1",
             "name": "Nim Grotesque",
             "text": "Nim Grotesque gets +1/+0 for each artifact you control.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "99a4298a-17be-5de4-824f-4a4f2c324429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c74b4-dd9e-43d6-ad0a-06e026a8d672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c74b4-dd9e-43d6-ad0a-06e026a8d672.jpg?1",
             "name": "Plunge into Darkness",
             "text": "Choose one Sacrifice any number of creatures, then you gain 3 life for each sacrificed creature; or pay X life, then look at the top X cards of your library, put one of those cards into your hand, and remove the rest from the game.\nEntwine {B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "bc49d701-e728-5870-97da-6090b4f41ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9caf97-75c6-4e12-8724-1abe32212bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9caf97-75c6-4e12-8724-1abe32212bef.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature in play named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "e0040697-63f9-5c21-b506-db91b543b6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb957bd-99e4-431e-b163-c25e9b7850d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb957bd-99e4-431e-b163-c25e9b7850d9.jpg?1",
             "name": "Shattered Dreams",
             "text": "Target opponent reveals his or her hand. Choose an artifact card from it. That player discards that card.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "b578504c-6463-5db9-8a1e-545897106c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca003f-dc03-4533-a245-fde836aab5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca003f-dc03-4533-a245-fde836aab5eb.jpg?1",
             "name": "Vicious Betrayal",
             "text": "As an additional cost to play Vicious Betrayal, sacrifice any number of creatures.\nTarget creature gets +2/+2 until end of turn for each creature sacrificed this way.",
             "colours": [
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "bc0e7f1f-3bae-510d-86cd-44c50f3065c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fae532-7189-450e-aa7f-e639163278fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fae532-7189-450e-aa7f-e639163278fc.jpg?1",
             "name": "Beacon of Destruction",
             "text": "Beacon of Destruction deals 5 damage to target creature or player. Shuffle Beacon of Destruction into its owner's library.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "c5ba3725-7a80-5ed8-9f17-7a0e0c936455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a58bb1-4c4d-41f2-9c69-d3c3a8a8ab09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a58bb1-4c4d-41f2-9c69-d3c3a8a8ab09.jpg?1",
             "name": "Bringer of the Red Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Red Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may untap target creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "b0dc3a84-fb9b-595d-844e-05888fa6dd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deaa0b9b-258e-4daf-8fec-ce64864d6bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deaa0b9b-258e-4daf-8fec-ce64864d6bbf.jpg?1",
             "name": "Cosmic Larva",
             "text": "Trample\nAt the beginning of your upkeep, sacrifice Cosmic Larva unless you sacrifice two lands.",
             "colours": [
@@ -2121,7 +2121,7 @@
         },
         {
             "id": "5948e408-d8ee-507d-840f-f36568d1e48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a370375c-14bf-4381-9359-f2e600867e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a370375c-14bf-4381-9359-f2e600867e7c.jpg?1",
             "name": "Feedback Bolt",
             "text": "Feedback Bolt deals damage to target player equal to the number of artifacts you control.",
             "colours": [
@@ -2153,7 +2153,7 @@
         },
         {
             "id": "383642c2-378d-5cbe-853e-a9a74808a2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1726eba-c471-40bd-a487-40d910b75d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1726eba-c471-40bd-a487-40d910b75d64.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "8f4887e2-3600-5bb3-9b6d-20f0a64fdd48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6586c04-f92d-4c3f-8b03-59e5ef158ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6586c04-f92d-4c3f-8b03-59e5ef158ed4.jpg?1",
             "name": "Goblin Brawler",
             "text": "First strike\nGoblin Brawler can't be equipped.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "38dd77f4-ba89-5a36-8c33-530ecf540fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13798b8-689e-4f19-af10-b72d3fe19f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13798b8-689e-4f19-af10-b72d3fe19f3c.jpg?1",
             "name": "Granulate",
             "text": "Destroy each nonland artifact with converted mana cost 4 or less.",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "382a872e-5d24-5c9d-8b80-7fe776a7cf87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296acb6-a304-42ab-b26b-5cbe796e72b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296acb6-a304-42ab-b26b-5cbe796e72b7.jpg?1",
             "name": "Ion Storm",
             "text": "{1}{R}, Remove a +1/+1 counter or a charge counter from a permanent you control: Ion Storm deals 2 damage to target creature or player.",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "40f5f6c6-ab85-570b-8b17-9b4f9fe4ab5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb36352-2f16-4572-b1aa-dc28b11f4229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb36352-2f16-4572-b1aa-dc28b11f4229.jpg?1",
             "name": "Iron-Barb Hellion",
             "text": "Haste\nIron-Barb Hellion can't block.",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "358e06c1-90e1-58f8-8efd-90c44b4c25ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110a5e2-31e1-4a63-96cd-56295f67d436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2110a5e2-31e1-4a63-96cd-56295f67d436.jpg?1",
             "name": "Krark-Clan Engineers",
             "text": "{R}, Sacrifice two artifacts: Destroy target artifact.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "83cad0e6-9a6a-5c08-baf5-4ff7caf9776c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649f561c-0b90-4f1d-a003-bab351632bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649f561c-0b90-4f1d-a003-bab351632bd3.jpg?1",
             "name": "Krark-Clan Ogre",
             "text": "{R}, Sacrifice an artifact: Target creature can't block this turn.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "2cff6552-58a9-5716-a864-02b62e2f9861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57670afe-cc40-44f5-b97c-a8f0377c710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57670afe-cc40-44f5-b97c-a8f0377c710a.jpg?1",
             "name": "Magma Giant",
             "text": "When Magma Giant comes into play, it deals 2 damage to each creature and each player.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "d4a14a9b-112c-5418-8d7c-2f6f6af7019e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea1728-08aa-4553-90b2-919c70712ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea1728-08aa-4553-90b2-919c70712ed5.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to target creature or player.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "2373e03c-9390-5099-9074-cecadff2ce8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0c1e37-fedc-43d9-97fd-b797c6c2fbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0c1e37-fedc-43d9-97fd-b797c6c2fbbe.jpg?1",
             "name": "Magnetic Theft",
             "text": "Attach target Equipment to target creature. (Control of the Equipment doesn't change.)",
             "colours": [
@@ -2488,7 +2488,7 @@
         },
         {
             "id": "90b3dac8-69e1-5b36-9f31-5899f093cb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3929662e-99d7-48e9-afac-1852af8be722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3929662e-99d7-48e9-afac-1852af8be722.jpg?1",
             "name": "Mana Geyser",
             "text": "Add {R} to your mana pool for each tapped land your opponents control.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "aa601f7e-c981-5937-9d51-9c8178f55869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a6ecc6-83c8-408b-8600-687cdb383ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a6ecc6-83c8-408b-8600-687cdb383ca9.jpg?1",
             "name": "Rain of Rust",
             "text": "Choose one Destroy target artifact; or destroy target land.\nEntwine {3}{R} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "ba5644df-a8e2-5847-bd41-311bff5579bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf87c0-369e-4ec2-bb9f-e8e29d63d448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf87c0-369e-4ec2-bb9f-e8e29d63d448.jpg?1",
             "name": "Reversal of Fortune",
             "text": "Target opponent reveals his or her hand. You may copy an instant or sorcery card in it and play the copy without paying its mana cost.",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "6784589d-08f9-568b-bd31-22c0fa549e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8488b6-3785-4346-a81b-c28d355f9d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8488b6-3785-4346-a81b-c28d355f9d25.jpg?1",
             "name": "Screaming Fury",
             "text": "Target creature gets +5/+0 and gains haste until end of turn.",
             "colours": [
@@ -2616,7 +2616,7 @@
         },
         {
             "id": "efe6e99e-3c7f-576c-9631-e342d02d1dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c8bcb2-8247-4d91-baf6-b08de1eb9cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c8bcb2-8247-4d91-baf6-b08de1eb9cde.jpg?1",
             "name": "Spark Elemental",
             "text": "Trample, haste\nAt end of turn, sacrifice Spark Elemental.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "e0e6459c-4908-5114-a1ea-76db282f6268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7207dd-854a-4150-b813-f60713ecfc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7207dd-854a-4150-b813-f60713ecfc30.jpg?1",
             "name": "Vulshok Sorcerer",
             "text": "Haste\n{T}: Vulshok Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "8f1fa4f2-365e-5f27-89a8-1a84bf04e29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefabea5-b6f0-46f4-a1a5-037c2482b979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefabea5-b6f0-46f4-a1a5-037c2482b979.jpg?1",
             "name": "All Suns' Dawn",
             "text": "For each color, return up to one target card of that color from your graveyard to your hand. Then remove All Suns' Dawn from the game.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "511a2ff2-8cec-56ed-a5ef-b2755b573de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc629de-18a3-4780-9df6-28ee54a34b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc629de-18a3-4780-9df6-28ee54a34b81.jpg?1",
             "name": "Beacon of Creation",
             "text": "Put a 1/1 green Insect creature token into play for each Forest you control. Shuffle Beacon of Creation into its owner's library.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "587bfa0d-4a16-5ab9-88aa-128c6461381d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41.jpg?1",
             "name": "Bringer of the Green Dawn",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay Bringer of the Green Dawn's mana cost.\nTrample\nAt the beginning of your upkeep, you may put a 3/3 green Beast creature token into play.",
             "colours": [
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "33697c85-e27b-5fd5-87a9-9906d65530c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf574c8-a7e0-482e-bb41-680454988097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf574c8-a7e0-482e-bb41-680454988097.jpg?1",
             "name": "Channel the Suns",
             "text": "Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "7ff7cb43-c180-5a0b-b07d-5060ab636538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a124f-f11e-4ea1-a7b2-b94eea988d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a124f-f11e-4ea1-a7b2-b94eea988d4e.jpg?1",
             "name": "Dawn's Reflection",
             "text": "Whenever enchanted land is tapped for mana, its controller adds two mana of any combination of colored mana to his or her mana pool.",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "5cdba3c6-0801-52e0-8331-6ad8f75e5819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e10ca7-1e5d-4224-82cf-798a4d436d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e10ca7-1e5d-4224-82cf-798a4d436d72.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness comes into play, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "d262f3d3-b5e0-522e-9643-e5030141f54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59679bcf-4436-48f8-bc6a-d7e0ec6b04c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59679bcf-4436-48f8-bc6a-d7e0ec6b04c9.jpg?1",
             "name": "Fangren Pathcutter",
             "text": "Whenever Fangren Pathcutter attacks, attacking creatures gain trample until end of turn.",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "4a2fc96e-5811-5a1b-a421-720b3c091c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3749181f-7b4e-4b9d-aaf3-94f707c306aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3749181f-7b4e-4b9d-aaf3-94f707c306aa.jpg?1",
             "name": "Ferocious Charge",
             "text": "Target creature gets +4/+4 until end of turn.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "089eb197-9d83-5fa8-8be2-c4f835109d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acf1a5f-1dbd-4481-b58d-b84e32d2b6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acf1a5f-1dbd-4481-b58d-b84e32d2b6b3.jpg?1",
             "name": "Joiner Adept",
             "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "cc6ce5a2-49d0-59de-a17e-362f47b67773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e08f8-7608-4137-9a58-f6eda8f84313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e08f8-7608-4137-9a58-f6eda8f84313.jpg?1",
             "name": "Ouphe Vandals",
             "text": "{G}, Sacrifice Ouphe Vandals: Counter target activated ability from an artifact source and destroy that artifact if it's in play. (Mana abilities can't be targeted.)",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "33b02745-1487-5de2-a6be-deea6ef4fc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea92a0c-f73f-4e85-9d87-6401aa1b052e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea92a0c-f73f-4e85-9d87-6401aa1b052e.jpg?1",
             "name": "Rite of Passage",
             "text": "Whenever a creature you control is dealt damage, put a +1/+1 counter on it. (The damage is dealt before the counter is put on.)",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "759d520c-6a62-5c4a-bc36-2b01484bea99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0164e2ed-b722-4a7d-a4fb-5401af008cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0164e2ed-b722-4a7d-a4fb-5401af008cbf.jpg?1",
             "name": "Rude Awakening",
             "text": "Choose one Untap all lands you control; or until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "6160d1ce-8628-5ec7-9854-f0b5299d75dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed328af-bc0d-4a9d-a9ee-bc0196a2afaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed328af-bc0d-4a9d-a9ee-bc0196a2afaf.jpg?1",
             "name": "Sylvok Explorer",
             "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [
@@ -3127,7 +3127,7 @@
         },
         {
             "id": "36d2bdbd-0db3-5f16-8f0a-64d1afb71c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e13ac56-72a9-4605-b389-24d1cb712b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e13ac56-72a9-4605-b389-24d1cb712b3c.jpg?1",
             "name": "Tangle Asp",
             "text": "Whenever Tangle Asp blocks or becomes blocked by a creature, destroy that creature at end of combat.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "04a7ab22-e8ae-53a2-a9a1-a12548957b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99fefa37-c876-4039-8cc4-4b2138181a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99fefa37-c876-4039-8cc4-4b2138181a1d.jpg?1",
             "name": "Tel-Jilad Justice",
             "text": "Destroy target artifact.\nScry 2 (Look at the top two cards of your library. Put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "abf6a77c-2185-5ccc-acbe-8dc8ce29160e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee58a5ef-68ec-48cf-bb7e-73bcbe86cc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee58a5ef-68ec-48cf-bb7e-73bcbe86cc3c.jpg?1",
             "name": "Tel-Jilad Lifebreather",
             "text": "{G}, {T}, Sacrifice a Forest: Regenerate target creature.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "cb0e8e68-a8f9-5b2c-9288-e38cb318e6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09751cf-6aa9-4d64-a1db-4f1826774f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09751cf-6aa9-4d64-a1db-4f1826774f00.jpg?1",
             "name": "Tornado Elemental",
             "text": "When Tornado Elemental comes into play, it deals 6 damage to each creature with flying.\nYou may have Tornado Elemental deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "6f179741-900d-502f-bca1-5d0e36c35e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb0cc0e-f71f-456f-a6ec-6a70cf838c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb0cc0e-f71f-456f-a6ec-6a70cf838c35.jpg?1",
             "name": "Tyrranax",
             "text": "{1}{G}: Tyrranax gets -1/+1 until end of turn.",
             "colours": [
@@ -3297,7 +3297,7 @@
         },
         {
             "id": "2a1ba908-f8c5-543d-a5db-4e8002fa17bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85673b93-39b7-44e1-b27d-b716bde42f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85673b93-39b7-44e1-b27d-b716bde42f0b.jpg?1",
             "name": "Viridian Lorebearers",
             "text": "{3}{G}, {T}: Target creature gets +X/+X until end of turn, where X is the number of artifacts your opponents control.",
             "colours": [
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "55ae1261-22cc-5d9e-8986-51d18c032448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3260a427-b67f-4908-8c56-5c0fab009598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3260a427-b67f-4908-8c56-5c0fab009598.jpg?1",
             "name": "Viridian Scout",
             "text": "{2}{G}, Sacrifice Viridian Scout: Viridian Scout deals 2 damage to target creature with flying.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "c8ec9d3c-e920-5f00-9480-b9adcf3e811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97773f5-548a-4107-b29c-56b5428d5ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97773f5-548a-4107-b29c-56b5428d5ddb.jpg?1",
             "name": "Anodet Lurker",
             "text": "When Anodet Lurker is put into a graveyard from play, you gain 3 life.",
             "colours": [],
@@ -3399,7 +3399,7 @@
         },
         {
             "id": "3a6d1ad1-3c8c-5710-a008-fb1078918689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836d5ce6-d5c9-4fb5-8302-53d25b5531b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836d5ce6-d5c9-4fb5-8302-53d25b5531b5.jpg?1",
             "name": "Arachnoid",
             "text": "Arachnoid may block as though it had flying.",
             "colours": [],
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "666ff2ce-c498-5246-9651-600b76f58878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4242f34-33c0-4e16-a6d9-18499dc8f2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4242f34-33c0-4e16-a6d9-18499dc8f2eb.jpg?1",
             "name": "Arcbound Wanderer",
             "text": "Modular\u2014\nSunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "06d6a598-24a2-5109-9269-3c021f401450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a5cfa8-4091-445c-8641-64402cca7d2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a5cfa8-4091-445c-8641-64402cca7d2d.jpg?1",
             "name": "Avarice Totem",
             "text": "{5}: Exchange control of Avarice Totem and target nonland permanent.",
             "colours": [],
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "1b442baf-a409-578f-b8cb-f74650cdbf6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d363970c-2418-42f9-8d13-0e5700161b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d363970c-2418-42f9-8d13-0e5700161b62.jpg?1",
             "name": "Baton of Courage",
             "text": "You may play Baton of Courage any time you could play an instant.\nSunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nRemove a charge counter from Baton of Courage: Target creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "f62f0ab9-c670-5132-8494-76c0968bc073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69add35-c529-4b30-8e64-f09b8308432f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69add35-c529-4b30-8e64-f09b8308432f.jpg?1",
             "name": "Battered Golem",
             "text": "Battered Golem doesn't untap during your untap step.\nWhenever an artifact comes into play, you may untap Battered Golem.",
             "colours": [],
@@ -3548,7 +3548,7 @@
         },
         {
             "id": "bb385b99-081d-5ed2-b95d-e4031f575868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e2f832-6601-4232-b250-fd1c88538fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e2f832-6601-4232-b250-fd1c88538fbd.jpg?1",
             "name": "Blasting Station",
             "text": "{T}, Sacrifice a creature: Blasting Station deals 1 damage to target creature or player.\nWhenever a creature comes into play, you may untap Blasting Station.",
             "colours": [],
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "b9341f93-34a6-59b2-888e-945896802f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbe14e2-89f2-4458-a84f-08ed3c6ae3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbe14e2-89f2-4458-a84f-08ed3c6ae3d7.jpg?1",
             "name": "Chimeric Coils",
             "text": "{X}{1}: Chimeric Coils becomes an X/X artifact creature. Sacrifice it at end of turn.",
             "colours": [],
@@ -3604,7 +3604,7 @@
         },
         {
             "id": "5c8148a5-34f8-5fba-986f-0e129b054b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5458c041-dde0-4df7-82bb-ada36a482c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5458c041-dde0-4df7-82bb-ada36a482c53.jpg?1",
             "name": "Clearwater Goblet",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nAt the beginning of your upkeep, you may gain 1 life for each charge counter on Clearwater Goblet.",
             "colours": [],
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "679250de-faea-513b-a1d9-7735ed28b52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffce71b-eb60-4649-a62b-a1b4acaa9d2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffce71b-eb60-4649-a62b-a1b4acaa9d2d.jpg?1",
             "name": "Clock of Omens",
             "text": "Tap two untapped artifacts you control: Untap target artifact.",
             "colours": [],
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "0d3865b6-9df4-576b-9a13-2daaac2c9795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eba4407-0405-41fa-99e5-1bfa3a787398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eba4407-0405-41fa-99e5-1bfa3a787398.jpg?1",
             "name": "Composite Golem",
             "text": "Sacrifice Composite Golem: Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [],
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "d3a70cdc-f694-5e0c-b90e-ae0eaf9c8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32960e-d182-455f-8e74-eb11b10050da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32960e-d182-455f-8e74-eb11b10050da.jpg?1",
             "name": "Conjurer's Bauble",
             "text": "{T}, Sacrifice Conjurer's Bauble: Put up to one target card from your graveyard on the bottom of your library. Draw a card.",
             "colours": [],
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "bb8342fa-767b-548b-ac19-f60ebd63ef7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea95d0-9f95-462b-a080-22a5da7b2e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea95d0-9f95-462b-a080-22a5da7b2e97.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "7a2122c0-11aa-5520-aa72-734ea616518a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312a6058-de08-487d-95bd-b3c56807fdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312a6058-de08-487d-95bd-b3c56807fdd6.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play land cards from your graveyard as though they were in your hand.",
             "colours": [],
@@ -3785,7 +3785,7 @@
         },
         {
             "id": "4b37813d-08c1-5911-ae78-3a1f916ab5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ffeae-6b51-4426-a080-b1b065b1290d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ffeae-6b51-4426-a080-b1b065b1290d.jpg?1",
             "name": "Door to Nothingness",
             "text": "Door to Nothingness comes into play tapped.\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice Door to Nothingness: Target player loses the game.",
             "colours": [],
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "2cb0bb1f-bea4-5ded-85ab-9eefc9b931f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220d3a38-10f8-4d4a-84b8-f17b10a2cd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220d3a38-10f8-4d4a-84b8-f17b10a2cd6c.jpg?1",
             "name": "Doubling Cube",
             "text": "{3}, {T}: Double the amount of each type of mana in your mana pool.",
             "colours": [],
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "18e71a6c-0b2b-524a-8206-2d4e4be28353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6a6ad6-77a5-4dec-922f-1cd6780c8671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6a6ad6-77a5-4dec-922f-1cd6780c8671.jpg?1",
             "name": "Energy Chamber",
             "text": "At the beginning of your upkeep, choose one Put a +1/+1 counter on target artifact creature; or put a charge counter on target noncreature artifact.",
             "colours": [],
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "cb1e9e42-9a35-53c0-8684-3a4027833a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8492a272-e595-4f94-a6eb-08d29f211fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8492a272-e595-4f94-a6eb-08d29f211fd6.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "d3d9ac61-721f-5547-9c1b-04412eaee414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2a16e2-ea98-4bf2-9e5c-7612d2dd039b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2a16e2-ea98-4bf2-9e5c-7612d2dd039b.jpg?1",
             "name": "Ensouled Scimitar",
             "text": "{3}: Ensouled Scimitar becomes a 1/5 artifact creature with flying until end of turn. (Equipment that's a creature can't equip a creature.)\nEquipped creature gets +1/+5.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "480dd905-fa78-5c0c-9bcc-e62c6af77922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d6b270-b4c9-489d-9322-7c8ddc0ca0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d6b270-b4c9-489d-9322-7c8ddc0ca0ac.jpg?1",
             "name": "Eon Hub",
             "text": "Players skip their upkeep steps.",
             "colours": [],
@@ -3961,7 +3961,7 @@
         },
         {
             "id": "901999b3-c419-59ca-97db-1fe26263c874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fcd005-9b54-42c1-8ce1-a20665d0fd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fcd005-9b54-42c1-8ce1-a20665d0fd8b.jpg?1",
             "name": "Etched Oracle",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\n{1}, Remove four +1/+1 counters from Etched Oracle: Target player draws three cards.",
             "colours": [],
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "f935661b-9277-540b-b43c-554d64c40800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf8248c-ef2c-4b1e-8a0b-05def43ca2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf8248c-ef2c-4b1e-8a0b-05def43ca2af.jpg?1",
             "name": "Ferropede",
             "text": "Ferropede is unblockable.\nWhenever Ferropede deals combat damage to a player, you may remove a counter from target permanent.",
             "colours": [],
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "dbb835a4-bd01-56b7-9ebe-14ddad9e1465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9997c580-596b-43d5-b4a0-9acc8fc2ef26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9997c580-596b-43d5-b4a0-9acc8fc2ef26.jpg?1",
             "name": "Fist of Suns",
             "text": "You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you play.",
             "colours": [],
@@ -4057,7 +4057,7 @@
         },
         {
             "id": "c03db40c-826d-51cd-a7b4-547d20d9cb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef37a3-4538-47b2-8f88-3fa0a4e32329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef37a3-4538-47b2-8f88-3fa0a4e32329.jpg?1",
             "name": "Gemstone Array",
             "text": "{2}: Put a charge counter on Gemstone Array.\nRemove a charge counter from Gemstone Array: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "5eb66b7d-beb9-5d02-be63-399798c53b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b023c0cd-7046-418b-ad31-5c91c6930d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b023c0cd-7046-418b-ad31-5c91c6930d45.jpg?1",
             "name": "Goblin Cannon",
             "text": "{2}: Goblin Cannon deals 1 damage to target creature or player. Sacrifice Goblin Cannon.",
             "colours": [],
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "e9e695ea-39e5-5121-b08e-e670f8f67462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5269cfbd-1202-47fe-a12d-d95ff304b335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5269cfbd-1202-47fe-a12d-d95ff304b335.jpg?1",
             "name": "Grafted Wargear",
             "text": "Equipped creature gets +3/+2.\nWhenever Grafted Wargear becomes unattached from a creature, sacrifice that creature.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "1693cad4-6096-5ba5-9af3-6d5a70539d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1df511-b52c-45cd-9503-ffce4271a802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1df511-b52c-45cd-9503-ffce4271a802.jpg?1",
             "name": "Grinding Station",
             "text": "{T}, Sacrifice an artifact: Target player puts the top three cards of his or her library into his or her graveyard.\nWhenever an artifact comes into play, you may untap Grinding Station.",
             "colours": [],
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "48a66494-6b50-5447-a6f5-908552a87c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62a73-b7db-47ec-9b68-65dd7c1a06a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62a73-b7db-47ec-9b68-65dd7c1a06a5.jpg?1",
             "name": "Guardian Idol",
             "text": "Guardian Idol comes into play tapped.\n{T}: Add {1} to your mana pool.\n{2}: Guardian Idol becomes a 2/2 artifact creature until end of turn.",
             "colours": [],
@@ -4199,7 +4199,7 @@
         },
         {
             "id": "028dc6dd-1205-5393-bae2-0106c37f0c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9565f076-54a6-43d6-bcf0-dcb932f6c116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9565f076-54a6-43d6-bcf0-dcb932f6c116.jpg?1",
             "name": "Healer's Headdress",
             "text": "Equipped creature gets +0/+2 and has \"{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\"\n{W}{W}: Attach Healer's Headdress to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "f0a79afd-72e8-5a67-a566-c708cb2f83d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d65fa8e-6944-4fe8-b7b4-c77dfbddf605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d65fa8e-6944-4fe8-b7b4-c77dfbddf605.jpg?1",
             "name": "Heliophial",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\n{2}, Sacrifice Heliophial: Heliophial deals damage to target creature or player equal to the number of charge counters on Heliophial.",
             "colours": [],
@@ -4259,7 +4259,7 @@
         },
         {
             "id": "053bc255-ce7b-59fa-a054-723e9d1ae58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76514aa-3cc1-4d5f-ba33-d933a36920a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76514aa-3cc1-4d5f-ba33-d933a36920a4.jpg?1",
             "name": "Helm of Kaldra",
             "text": "Equipped creature has first strike, trample, and haste.\n{1}: If you control Equipment named Helm of Kaldra, Sword of Kaldra, and Shield of Kaldra, put a 4/4 colorless Avatar Legend creature token named Kaldra into play and attach those Equipment to it.\nEquip {2}",
             "colours": [],
@@ -4291,7 +4291,7 @@
         },
         {
             "id": "e77a965b-3b00-5b91-89fd-77a22faec274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c408a-0a19-44a3-a436-295380573f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c408a-0a19-44a3-a436-295380573f91.jpg?1",
             "name": "Horned Helm",
             "text": "Equipped creature gets +1/+1 and has trample.\n{G}{G}: Attach Horned Helm to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "d9be47c4-5190-56ef-a02a-5255e1123e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fd2639-3c95-435d-8e94-cd4e4d069e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fd2639-3c95-435d-8e94-cd4e4d069e3e.jpg?1",
             "name": "Infused Arrows",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\n{T}, Remove X charge counters from Infused Arrows: Target creature gets -X/-X until end of turn.",
             "colours": [],
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "6dc2e300-bda8-55c7-996b-a790ae396632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60174d6-1f9d-4870-b3db-34d6fcb3f6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60174d6-1f9d-4870-b3db-34d6fcb3f6ab.jpg?1",
             "name": "Krark-Clan Ironworks",
             "text": "Sacrifice an artifact: Add {2} to your mana pool.",
             "colours": [],
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "a361f4b9-8d4a-5597-8e6f-dbdd8ea0b718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e4c78-75fe-4692-b177-974b148f0614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e4c78-75fe-4692-b177-974b148f0614.jpg?1",
             "name": "Lantern of Insight",
             "text": "Each player plays with the top card of his or her library revealed.\n{T}, Sacrifice Lantern of Insight: Target player shuffles his or her library.",
             "colours": [],
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "29b02bd1-ae51-5af4-81f3-7fd80e80ad9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2348e5-6bf9-4a7e-91a4-ba93bb108897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2348e5-6bf9-4a7e-91a4-ba93bb108897.jpg?1",
             "name": "Lunar Avenger",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nRemove a +1/+1 counter from Lunar Avenger: Lunar Avenger gains your choice of flying, first strike, or haste until end of turn.",
             "colours": [],
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "adece9ea-5211-5601-9a23-5b99458352cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3200fa2-182f-4515-b326-ab4fdb95c8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3200fa2-182f-4515-b326-ab4fdb95c8c1.jpg?1",
             "name": "Mycosynth Golem",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nArtifact creature spells you play have affinity for artifacts. (They cost {1} less to play for each artifact you control.)",
             "colours": [],
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "cd21744b-a8ab-5c6d-a359-a8cca8d1fd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5576fe4d-cf12-460b-af15-996baeca5065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5576fe4d-cf12-460b-af15-996baeca5065.jpg?1",
             "name": "Myr Quadropod",
             "text": "{3}: Switch Myr Quadropod's power and toughness until end of turn.",
             "colours": [],
@@ -4500,7 +4500,7 @@
         },
         {
             "id": "26942e5a-c447-55f4-b479-75185044bf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127e05-d1d6-4dd5-90e1-a93e3a51b1b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127e05-d1d6-4dd5-90e1-a93e3a51b1b0.jpg?1",
             "name": "Myr Servitor",
             "text": "At the beginning of your upkeep, if Myr Servitor is in play, each player returns all cards named Myr Servitor from his or her graveyard to play.",
             "colours": [],
@@ -4531,7 +4531,7 @@
         },
         {
             "id": "4ae342e9-f966-52f0-9213-8d3185fac905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ad83a-7374-435d-a5bd-2dd455fa6420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ad83a-7374-435d-a5bd-2dd455fa6420.jpg?1",
             "name": "Neurok Stealthsuit",
             "text": "Equipped creature can't be the target of spells or abilities.\n{U}{U}: Attach Neurok Stealthsuit to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "98b9ec07-54cd-5144-b1e3-6c697df9b03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae84edd-1294-4722-89d1-84d9f336871c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae84edd-1294-4722-89d1-84d9f336871c.jpg?1",
             "name": "Opaline Bracers",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nEquipped creature gets +X/+X, where X is the number of charge counters on Opaline Bracers.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4593,7 +4593,7 @@
         },
         {
             "id": "7c2a11f7-9a20-53c9-842f-dc922d29ec02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252e9e2-2dd5-4bd6-aa56-f0a0ba056a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252e9e2-2dd5-4bd6-aa56-f0a0ba056a77.jpg?1",
             "name": "Paradise Mantle",
             "text": "Equipped creature has \"{T}: Add one mana of any color to your mana pool.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "ea5e4bf2-c980-516b-bfd4-6ae9493341f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672b9b16-daef-44e6-9a3a-cfd9f3c78bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672b9b16-daef-44e6-9a3a-cfd9f3c78bc7.jpg?1",
             "name": "Pentad Prism",
             "text": "Sunburst (This comes into play with a charge counter on it for each color of mana used to pay its cost.)\nRemove a charge counter from Pentad Prism: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "b839e700-f588-5f12-bd1b-c071e33f7886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616836e6-caf4-4398-a772-9c67f84c73c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616836e6-caf4-4398-a772-9c67f84c73c5.jpg?1",
             "name": "Possessed Portal",
             "text": "If a player would draw a card, that player skips that draw instead.\nAt the end of each turn, each player sacrifices a permanent unless he or she discards a card from his or her hand.",
             "colours": [],
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "07a21ea5-dc13-5771-8245-d739073b8c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e79f57-2214-414a-ab34-2b737d4bb972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e79f57-2214-414a-ab34-2b737d4bb972.jpg?1",
             "name": "Razorgrass Screen",
             "text": "(Walls can't attack.)\nRazorgrass Screen blocks each turn if able.",
             "colours": [],
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "58f6e6a9-1a27-5312-8e26-cbac4965ab27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81dbdc0-dffe-4c10-9e81-d66a77eb6c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81dbdc0-dffe-4c10-9e81-d66a77eb6c49.jpg?1",
             "name": "Razormane Masticore",
             "text": "First strike\nAt the beginning of your upkeep, sacrifice Razormane Masticore unless you discard a card from your hand.\nAt the beginning of your draw step, you may have Razormane Masticore deal 3 damage to target creature.",
             "colours": [],
@@ -4741,7 +4741,7 @@
         },
         {
             "id": "2733ce07-081f-5441-8472-8dd377f3427c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d760d8-030e-47d0-a555-d88ee43d3d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d760d8-030e-47d0-a555-d88ee43d3d80.jpg?1",
             "name": "Relic Barrier",
             "text": "{T}: Tap target artifact.",
             "colours": [],
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "e07c5bfa-1fb8-5a2d-a88f-d747c7a54acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0336e07-8eaf-4b90-af54-4764e5ba50f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0336e07-8eaf-4b90-af54-4764e5ba50f2.jpg?1",
             "name": "Salvaging Station",
             "text": "{T}: Return target noncreature artifact card with converted mana cost 1 or less from your graveyard to play.\nWhenever a creature is put into a graveyard from play, you may untap Salvaging Station.",
             "colours": [],
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "4b4a5120-63d3-5786-a15a-f6b951ea696d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c36de4a-807d-471d-ba59-0462d7bb028a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c36de4a-807d-471d-ba59-0462d7bb028a.jpg?1",
             "name": "Sawtooth Thresher",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nRemove two +1/+1 counters from Sawtooth Thresher: Sawtooth Thresher gets +4/+4 until end of turn.",
             "colours": [],
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "d59df6a0-029c-57cc-a2e0-ad4b6ddf46a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65229ebf-da43-476b-9e9d-8cc0102a24c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65229ebf-da43-476b-9e9d-8cc0102a24c3.jpg?1",
             "name": "Silent Arbiter",
             "text": "No more than one creature may attack each combat.\nNo more than one creature may block each combat.",
             "colours": [],
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "8822ae5b-b4e7-5f4c-8ca0-0b3b8c2084f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f32bf4-e58b-42f9-8829-4c985dc94963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f32bf4-e58b-42f9-8829-4c985dc94963.jpg?1",
             "name": "Skullcage",
             "text": "At the beginning of each opponent's upkeep, Skullcage deals 2 damage to that player unless he or she has exactly three or exactly four cards in hand.",
             "colours": [],
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "0f79cb4f-239f-5818-9033-d1d8355cd23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b11e69-09ec-4e26-a64d-c129c45574b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b11e69-09ec-4e26-a64d-c129c45574b1.jpg?1",
             "name": "Skyreach Manta",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nFlying",
             "colours": [],
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "567814dc-bb0b-5b01-a66a-9fee4e707dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9070dd3e-7600-493e-84b9-931ac92f44bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9070dd3e-7600-493e-84b9-931ac92f44bc.jpg?1",
             "name": "Solarion",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\n{T}: Double the number of +1/+1 counters on Solarion.",
             "colours": [],
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "93a17805-ec8f-53b3-b78e-57f89445de68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc31145-19b4-4dbe-8756-f49791aa147e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc31145-19b4-4dbe-8756-f49791aa147e.jpg?1",
             "name": "Sparring Collar",
             "text": "Equipped creature has first strike.\n{R}{R}: Attach Sparring Collar to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4981,7 +4981,7 @@
         },
         {
             "id": "72247469-2c4b-593b-a371-1f692919ce02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aefaec4-741b-4a90-bf2c-e18215aac57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aefaec4-741b-4a90-bf2c-e18215aac57c.jpg?1",
             "name": "Spinal Parasite",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\nRemove two +1/+1 counters from Spinal Parasite: Remove a counter from target permanent.",
             "colours": [],
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "f5ab7fdb-b37c-582f-891f-4df0a8de5391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980fc3b-71d5-427d-bd42-087256fd2059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980fc3b-71d5-427d-bd42-087256fd2059.jpg?1",
             "name": "Staff of Domination",
             "text": "{1}: Untap Staff of Domination.\n{2}, {T}: You gain 1 life.\n{3}, {T}: Untap target creature.\n{4}, {T}: Tap target creature.\n{5}, {T}: Draw a card.",
             "colours": [],
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "08045c26-aa4f-5764-887b-5d8ec73b9528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ac02-5dab-423a-9cf3-275d9203f26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ac02-5dab-423a-9cf3-275d9203f26d.jpg?1",
             "name": "Summoner's Egg",
             "text": "Imprint When Summoner's Egg comes into play, you may remove a card in your hand from the game face down.\nWhen Summoner's Egg is put into a graveyard from play, turn the imprinted face-down card face up. If that card is a creature card, put it into play under your control.",
             "colours": [],
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "972dafe2-254f-520f-be72-cb21ac19a5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8072944-268a-41e0-a1d8-9fe33e964bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8072944-268a-41e0-a1d8-9fe33e964bff.jpg?1",
             "name": "Summoning Station",
             "text": "{T}: Put a 2/2 colorless Pincher creature token into play.\nWhenever an artifact is put into a graveyard from play, you may untap Summoning Station.",
             "colours": [],
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "b608144c-2405-529c-9203-1f4a385e088c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c22071-959e-4986-aa25-ed883a20796b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c22071-959e-4986-aa25-ed883a20796b.jpg?1",
             "name": "Suncrusher",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)\n{4}, {T}, Remove a +1/+1 counter from Suncrusher: Destroy target creature.\n{2}, Remove a +1/+1 counter from Suncrusher: Return Suncrusher to its owner's hand.",
             "colours": [],
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "0957ffa9-88b8-5975-b093-b8b9fd08d2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6c82f-b943-435e-a716-a58ae30b3922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6c82f-b943-435e-a716-a58ae30b3922.jpg?1",
             "name": "Suntouched Myr",
             "text": "Sunburst (This comes into play with a +1/+1 counter on it for each color of mana used to pay its cost.)",
             "colours": [],
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "78bba303-a370-5ab5-a6c0-a483734aaf09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16ef3b5-31ad-45f8-bac1-3b0a08964888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16ef3b5-31ad-45f8-bac1-3b0a08964888.jpg?1",
             "name": "Synod Centurion",
             "text": "When you control no other artifacts, sacrifice Synod Centurion.",
             "colours": [],
@@ -5192,7 +5192,7 @@
         },
         {
             "id": "e9e39c42-5e42-5cdf-aac4-bf28dc116c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb86854f-c933-4b6c-bd0a-67c3615e908f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb86854f-c933-4b6c-bd0a-67c3615e908f.jpg?1",
             "name": "Thermal Navigator",
             "text": "Sacrifice an artifact: Thermal Navigator gains flying until end of turn.",
             "colours": [],
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "80b90a56-8db7-5209-8c0f-4a4a5472583a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b546fa-af65-4afa-bb16-69b33674d3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b546fa-af65-4afa-bb16-69b33674d3d1.jpg?1",
             "name": "Vedalken Orrery",
             "text": "You may play nonland cards any time you could play an instant.",
             "colours": [],
@@ -5251,7 +5251,7 @@
         },
         {
             "id": "0146a3c4-a07d-5640-8047-5ce0271c20d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef06f56-a7a8-4c0f-8755-56b46d2aa82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef06f56-a7a8-4c0f-8755-56b46d2aa82c.jpg?1",
             "name": "Vedalken Shackles",
             "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control as long as Vedalken Shackles remains tapped.",
             "colours": [],
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "298d0681-4f38-52f6-9f31-fa4bdd1b9b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8fc1d-69fa-4a88-8f12-11fd614aac01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8fc1d-69fa-4a88-8f12-11fd614aac01.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/5ED.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/5ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "86a560a1-8c44-5a79-ab56-bc686054679f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b5b70d-e5b9-4bc3-87b1-51dc6e5085a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b5b70d-e5b9-4bc3-87b1-51dc6e5085a5.jpg?1",
             "name": "Abbey Gargoyles",
             "text": "Flying, protection from red",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "d0112a3c-4f56-5257-9b5f-6d0098c26ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b658243-267b-473f-acce-b4e211945c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b658243-267b-473f-acce-b4e211945c67.jpg?1",
             "name": "Akron Legionnaire",
             "text": "Except for Legionnaires and artifact creatures, creatures you control cannot attack.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "90cfb718-6da2-53d4-a641-43977527f4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950acce3-b079-49fc-8016-75fcdbca9b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950acce3-b079-49fc-8016-75fcdbca9b82.jpg?1",
             "name": "Alabaster Potion",
             "text": "Target player gains X life, or prevent X damage to any creature or player.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "c46dfa0f-37cd-5960-b908-9bf5b5f5d914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9ebe90-dad9-44b0-a2fa-13fc77953502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9ebe90-dad9-44b0-a2fa-13fc77953502.jpg?1",
             "name": "Angry Mob",
             "text": "Trample\nDuring your turn, Angry Mob has power and toughness each equal to 2 plus the number of swamps all opponents control. During other turns, Angry Mob has power and toughness each equal to 2.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "1e4b6310-78db-5a61-ae4e-9e29034bb59c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7f102d-18ff-420b-9b0b-323daad759de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7f102d-18ff-420b-9b0b-323daad759de.jpg?1",
             "name": "Animate Wall",
             "text": "Play only on a Wall.\nEnchanted creature can attack as though it were not a Wall.",
             "colours": [
@@ -168,7 +168,7 @@
         },
         {
             "id": "31ead1fe-4755-5418-9c41-d3165d4546ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2bf14c-f04d-4380-b0d5-25028ddd999b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2bf14c-f04d-4380-b0d5-25028ddd999b.jpg?1",
             "name": "Arenson's Aura",
             "text": "o\nW, Sacrifice an enchantment: Destroy target enchantment.\no3o\nUoo\nU Counter target enchantment spell. Play this ability as an interrupt.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "2212f07d-9c92-51ab-9440-027501c46387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8949d6f8-6491-489a-916d-7007deaf0371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8949d6f8-6491-489a-916d-7007deaf0371.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "cdb007cc-9966-56cd-94eb-a4cd520dfd3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdb3c08-aa9e-45d4-ae82-00019aee03b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdb3c08-aa9e-45d4-ae82-00019aee03b6.jpg?1",
             "name": "Armor of Faith",
             "text": "Enchanted creature gets +1/+1.\noo\nW Enchanted creature gets +0/+1 until end of turn.",
             "colours": [
@@ -264,7 +264,7 @@
         },
         {
             "id": "10f50d43-d097-5b5e-a6d7-b6af1c4c98ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01c564f-d997-4667-93af-c8495d8764e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01c564f-d997-4667-93af-c8495d8764e6.jpg?1",
             "name": "Aysen Bureaucrats",
             "text": "oc\nT: Tap target creature with power 2 or less.",
             "colours": [
@@ -298,7 +298,7 @@
         },
         {
             "id": "d01cdd9a-e8e6-5ec7-a2d6-88d3ac9a52c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dcd608-ef94-4047-841d-5c3471375d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dcd608-ef94-4047-841d-5c3471375d5d.jpg?1",
             "name": "Benalish Hero",
             "text": "Banding",
             "colours": [
@@ -332,7 +332,7 @@
         },
         {
             "id": "0eef452f-35b2-5ac9-b8ac-796ba27cd4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee815d6-ce79-42ff-9d18-b2f92671d1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee815d6-ce79-42ff-9d18-b2f92671d1c4.jpg?1",
             "name": "Blessed Wine",
             "text": "Gain 1 life.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -363,7 +363,7 @@
         },
         {
             "id": "98066222-75f2-56ce-a52f-fdc841ea0b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ff7626-de7d-443a-8eb7-fccaba6f2336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ff7626-de7d-443a-8eb7-fccaba6f2336.jpg?1",
             "name": "Blinking Spirit",
             "text": "o0: Return Blinking Spirit to owner's hand.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "793bf221-6295-5a80-bca1-a39d7e3dfe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afcbd6d-2b83-4393-9fc8-fe91f86117fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afcbd6d-2b83-4393-9fc8-fe91f86117fe.jpg?1",
             "name": "Brainwash",
             "text": "Enchanted creature cannot attack this turn unless its controller pays an additional o3.",
             "colours": [
@@ -429,7 +429,7 @@
         },
         {
             "id": "bc0a54bf-1ebd-570b-ac61-d4491cdac445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686022b1-359f-4348-a096-992140fff460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686022b1-359f-4348-a096-992140fff460.jpg?1",
             "name": "Caribou Range",
             "text": "Play only on a land you control.\no\nWo\nW, Tap enchanted land: Put a Caribou token into play. Treat this token as a 0/1 white creature.\nSacrifice a Caribou token: Gain 1 life.",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "8b83a72e-05e3-5009-9cab-6a99db477775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf8196e-3dd6-480f-a431-0e17005f7168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf8196e-3dd6-480f-a431-0e17005f7168.jpg?1",
             "name": "Castle",
             "text": "Each untapped creature you control gets +0/+2 unless it is attacking.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "ee502d84-81d4-5de3-a064-2bf282636aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cca7a8-439a-4388-8daf-6f04e78f5e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cca7a8-439a-4388-8daf-6f04e78f5e3a.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "o2: Prevent all damage to you from an artifact source. Treat further damage from that source normally.",
             "colours": [
@@ -524,7 +524,7 @@
         },
         {
             "id": "85082027-587c-52d0-9882-61580e7fd489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8160786c-288a-4160-8c8b-c575a61e00fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8160786c-288a-4160-8c8b-c575a61e00fc.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage to you from a black source. Treat further damage from that source normally.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "394eec02-f489-5366-b352-c72cac90eca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8b94bd-fffd-4c8a-b705-2b8e60cb8d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8b94bd-fffd-4c8a-b705-2b8e60cb8d68.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage to you from a blue source. Treat further damage from that source normally.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "ff39c9ad-10ef-51fb-8a58-c52b986ef8a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73bc89-887b-4ed8-ab68-20214b8aabcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73bc89-887b-4ed8-ab68-20214b8aabcf.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage to you from a green source. Treat further damage from that source normally.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "cec8c360-7d16-5755-9241-38cab525fad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af7af94-75b1-45ab-8608-6c935cedad77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af7af94-75b1-45ab-8608-6c935cedad77.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage to you from a red source. Treat further damage from that source normally.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "3845f02b-290e-544a-ab2c-c71bca3cbb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1477ea65-76b8-40b7-985d-02bc4aec9210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1477ea65-76b8-40b7-985d-02bc4aec9210.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage to you from a white source. Treat further damage from that source normally.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "7fd7b061-2d2c-5837-842e-049bf38fca5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3745725e-2bae-4c9b-bece-9e6b5f45c3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3745725e-2bae-4c9b-bece-9e6b5f45c3c9.jpg?1",
             "name": "Crusade",
             "text": "All white creatures get +1/+1.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "c84fcc73-b329-5a68-91b4-48b76f9797ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57621be-3420-49f5-87a3-a9f66fc7c2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57621be-3420-49f5-87a3-a9f66fc7c2e1.jpg?1",
             "name": "D'Avenant Archer",
             "text": "oc\nT: D'Avenant Archer deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "d01f79c5-57fb-53c2-8ef5-1b839c63882e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f70687-1d96-4d85-bed6-f08edef223cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f70687-1d96-4d85-bed6-f08edef223cd.jpg?1",
             "name": "Death Speakers",
             "text": "Protection from black",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "85150d1b-376f-55eb-af84-8951563438c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1502b21a-90e0-48af-ad55-b1edf2d0582c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1502b21a-90e0-48af-ad55-b1edf2d0582c.jpg?1",
             "name": "Death Ward",
             "text": "Regenerate target creature.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "33e20ad5-ba76-5234-a458-0f788aaaf9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18720641-3a34-48f1-954e-49a703f12578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18720641-3a34-48f1-954e-49a703f12578.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "cf172249-3ef2-5057-a68f-fd02f7bd0f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53562e-6b8f-484d-a083-2c635c2f222b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53562e-6b8f-484d-a083-2c635c2f222b.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. Gain an amount of life equal to that artifact's total casting cost.",
             "colours": [
@@ -872,7 +872,7 @@
         },
         {
             "id": "53b0ba7e-f033-5aa8-81a8-280a82c0b4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3994c6-8e84-4d06-ab46-fb5f061cc34d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3994c6-8e84-4d06-ab46-fb5f061cc34d.jpg?1",
             "name": "Divine Transformation",
             "text": "Enchanted creature gets +3/+3.",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "97871357-f990-5a2e-8eee-bc62b1fe379d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a9a5c-0e5f-4498-88d8-6aac465923b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a9a5c-0e5f-4498-88d8-6aac465923b1.jpg?1",
             "name": "Dust to Dust",
             "text": "Remove two target artifacts from the game.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "a7f796ca-0b18-561a-b250-622a08e7a248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28234a6-0e6b-4555-b5f9-edcc7b29194b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28234a6-0e6b-4555-b5f9-edcc7b29194b.jpg?1",
             "name": "Eye for an Eye",
             "text": "Play only when a creature, spell, or effect assigns damage to you. Eye for an Eye deals an equal amount of damage to that source's controller.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "0fcac723-73a1-5e1a-a1ce-86aafb4b471e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8eb77b-cdf7-44c6-8dce-898cfa173d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8eb77b-cdf7-44c6-8dce-898cfa173d66.jpg?1",
             "name": "Greater Realm of Preservation",
             "text": "o1oo\nW Prevent all damage to you from a black or red source. Treat further damage from that source normally.",
             "colours": [
@@ -998,7 +998,7 @@
         },
         {
             "id": "564e7a13-5a86-5743-8356-65fa863bfae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20676ce-fd87-4a63-9b96-02a26015edc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20676ce-fd87-4a63-9b96-02a26015edc2.jpg?1",
             "name": "Heal",
             "text": "Prevent 1 damage to any creature or player.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "cc24427d-c87a-5fb7-8471-bb64866041e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6855af25-0d35-4bf7-92e7-9dffdafa1eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6855af25-0d35-4bf7-92e7-9dffdafa1eca.jpg?1",
             "name": "Healing Salve",
             "text": "Target player gains 3 life, or prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "ff1f817d-f746-5dd9-9f6c-6bd25784b6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26fc403-b8af-499a-8cbc-4077ff97b8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26fc403-b8af-499a-8cbc-4077ff97b8b0.jpg?1",
             "name": "Hipparion",
             "text": "Hipparion cannot be assigned to block any creature with power 3 or greater unless you pay an additional o1.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "8fa2edb4-bdd5-5bcf-b227-db8e38a5be8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f938d4-5964-4f55-a2ce-0ca7e25fe565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f938d4-5964-4f55-a2ce-0ca7e25fe565.jpg?1",
             "name": "Holy Strength",
             "text": "Enchanted creature gets +1/+2.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "b65f38d0-e877-50f3-b0e9-f974e24041f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabf21ed-0262-4909-8b0f-c2c0e82830b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabf21ed-0262-4909-8b0f-c2c0e82830b0.jpg?1",
             "name": "Icatian Phalanx",
             "text": "Banding",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "c86238b9-d26a-56ba-a511-a8982e481798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02133f-71ff-45a1-9733-2ee3584dbbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02133f-71ff-45a1-9733-2ee3584dbbe5.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "fe564eb5-e059-54de-ae98-64f6c03aa72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e06788f-e87b-4071-ba7d-e0253a52132d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e06788f-e87b-4071-ba7d-e0253a52132d.jpg?1",
             "name": "Icatian Town",
             "text": "Put four Citizen tokens into play. Treat these tokens as 1/1 white creatures.",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "12bd0d68-1afe-5361-8a9a-2980db991a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5521bab-3252-4f81-9e9e-783160a5718c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5521bab-3252-4f81-9e9e-783160a5718c.jpg?1",
             "name": "Island Sanctuary",
             "text": "Skip drawing a card: Until the beginning of your next turn, only creatures with flying or islandwalk can attack you. Use this ability only during your draw phase and only once each turn.",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "d9d3d61d-a765-5a34-9435-e7399ecec3f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563dd5f5-6e37-4b36-b41b-1f4810e6ef8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563dd5f5-6e37-4b36-b41b-1f4810e6ef8c.jpg?1",
             "name": "Ivory Guardians",
             "text": "Protection from red\nAs long as any opponent controls any red cards in play, all Guardians get +1/+1.",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "782f613b-7640-52f7-bab3-dce80c71cd45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb11e16f-edf5-4e0e-862b-b055fd800682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb11e16f-edf5-4e0e-862b-b055fd800682.jpg?1",
             "name": "Justice",
             "text": "During your upkeep, pay o\nWo\nW or bury Justice.\nWhenever any red creature or spell assigns damage, Justice deals an equal amount of damage to that creature's or spell's controller.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "be35b511-da33-5d2e-ade2-e8c0d8b00e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cd8fd6-f30d-4e79-af68-688c2cfd39ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cd8fd6-f30d-4e79-af68-688c2cfd39ea.jpg?1",
             "name": "Karma",
             "text": "During each player's upkeep, Karma deals to that player an amount of damage equal to the number of swamps he or she controls.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "319614ec-99b6-56e4-99c7-919a0e4e0a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf81644f-6a93-4183-9f71-c3505cca6db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf81644f-6a93-4183-9f71-c3505cca6db4.jpg?1",
             "name": "Kismet",
             "text": "Artifacts, creatures, and lands target player controls come into play tapped.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "6fe3e0a8-7ea4-5d10-85c8-3796d914852c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafc9583-d16c-4a3b-88c5-2938038784bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafc9583-d16c-4a3b-88c5-2938038784bc.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: Redirect from you to Kjeldoran Royal Guard all combat damage dealt by unblocked creatures this turn.",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "5837d6d8-02a2-5d92-b7e9-9cc17d491774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1f4c4d-dbb6-42b9-a56f-5ee119f68cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1f4c4d-dbb6-42b9-a56f-5ee119f68cf6.jpg?1",
             "name": "Kjeldoran Skycaptain",
             "text": "Banding, flying, first strike",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "2b7d7016-a257-5add-a079-a199fce1d91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd27e15-688b-43aa-9d2a-8cd35e960a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd27e15-688b-43aa-9d2a-8cd35e960a9d.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "edd4139a-a117-5867-80d0-51e47bbc9bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552089f3-1ae4-4f73-a19c-731ef98e1979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552089f3-1ae4-4f73-a19c-731ef98e1979.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Banding, flying",
             "colours": [
@@ -1518,7 +1518,7 @@
         },
         {
             "id": "9a87c8e1-d124-5d0a-95a3-7ed3238e6b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc09bb52-c31c-4afd-80ea-a48a46f82f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc09bb52-c31c-4afd-80ea-a48a46f82f00.jpg?1",
             "name": "Order of the Sacred Torch",
             "text": "oc\nT, Pay 1 life: Counter target black spell. Play this ability as an interrupt.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "3c2c5474-ea28-5684-bd30-3760ca4d2c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8581f-d953-4600-b08f-f02c3eccdbcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8581f-d953-4600-b08f-f02c3eccdbcc.jpg?1",
             "name": "Order of the White Shield",
             "text": "Protection from black\noo\nW First strike until end of turn\no\nWoo\nW +1/+0 until end of turn",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "2c3698f3-98fe-5ce1-a715-3b84362fd323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33ef5b-a0ff-459c-a9d4-a0a00ac66b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33ef5b-a0ff-459c-a9d4-a0a00ac66b31.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -1619,7 +1619,7 @@
         },
         {
             "id": "5d53e49a-989b-5fe9-8919-8d41415c7f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a7836f-5a67-4915-8c59-0dd02f8bc0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a7836f-5a67-4915-8c59-0dd02f8bc0a9.jpg?1",
             "name": "Personal Incarnation",
             "text": "Personal Incarnation's owner may redirect any amount of damage from it to himself or herself.\nIf Personal Incarnation is put into any graveyard from play, its owner loses half his or her life, rounded up.",
             "colours": [
@@ -1653,7 +1653,7 @@
         },
         {
             "id": "afb14323-7c78-5ec0-95a1-ebe1ef02766e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18243ac8-6097-4f2c-8064-3dab48038e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18243ac8-6097-4f2c-8064-3dab48038e4a.jpg?1",
             "name": "Pikemen",
             "text": "Banding, first strike",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "9b928199-a333-5e9d-8142-0f1a5e78831d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8ce55-2fb1-4330-9db4-146a120aed81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8ce55-2fb1-4330-9db4-146a120aed81.jpg?1",
             "name": "Prismatic Ward",
             "text": "When you play Prismatic Ward, choose a color.\nAll damage dealt to enchanted creature by sources of the chosen color is reduced to 0.",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "a950ffe2-fdac-5017-bffc-0667aeb46376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bd3587-301e-49ea-a589-1091c880145b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bd3587-301e-49ea-a589-1091c880145b.jpg?1",
             "name": "Repentant Blacksmith",
             "text": "Protection from red",
             "colours": [
@@ -1753,7 +1753,7 @@
         },
         {
             "id": "93510b8d-d978-53d9-853e-b672c937a1fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6987f7d-d7a0-4b75-87ca-3e7b681d449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6987f7d-d7a0-4b75-87ca-3e7b681d449c.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage dealt to you so far this turn from one source is retroactively added to your life total instead of subtracted. Treat further damage from that source normally.",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "dc06afc8-5c6b-5981-bfa8-4c95aa225fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a76892-2806-4fb4-882b-6de2869839c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a76892-2806-4fb4-882b-6de2869839c2.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "c94bca9e-7f90-5484-a820-004dffe0cb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abb4791-d2ad-4266-a900-aef8a802b3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abb4791-d2ad-4266-a900-aef8a802b3e5.jpg?1",
             "name": "Sacred Boon",
             "text": "Prevent up to 3 damage to target creature. At end of turn, put a +0/+1 counter on that creature for each 1 damage prevented in this way.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "8b3eaee6-504c-5f48-a207-1130893ebcb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3b2aaa-f04e-4a2a-8d5f-b3cc54605b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3b2aaa-f04e-4a2a-8d5f-b3cc54605b28.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "7ad050ce-91a9-5a52-9f1b-49931b01c02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2de654e-ee5c-4ae6-bd4c-c564ed6a5e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2de654e-ee5c-4ae6-bd4c-c564ed6a5e83.jpg?1",
             "name": "Seraph",
             "text": "Flying\nWhenever any creature Seraph damaged this turn is put into any graveyard, put that creature into play under your control at end of turn. Bury the creature if you lose control of Seraph.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "25b5bf8c-df2d-5bd6-8a5f-a4483b68122a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92bb33d-567c-4504-8e3c-5152fb61d100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92bb33d-567c-4504-8e3c-5152fb61d100.jpg?1",
             "name": "Serra Bestiary",
             "text": "During your upkeep, pay o\nWo\nW or bury Serra Bestiary.\nEnchanted creature cannot attack, block, or play any ability that includes oc\nT in its activation cost.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "c400cac8-7434-5cfe-9527-5b137caf94a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d282d-a777-4587-ab23-c30a4dba0494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d282d-a777-4587-ab23-c30a4dba0494.jpg?1",
             "name": "Serra Paladin",
             "text": "oc\nT: Prevent 1 damage to any creature or player.\no1o\nWo\nW, oc\nT: Attacking this turn does not cause target creature to tap.",
             "colours": [
@@ -1980,7 +1980,7 @@
         },
         {
             "id": "873bc7f0-f09a-5eef-aad0-648abf2c6e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7cfc0f-b9cc-4405-9c2d-2788d4ab49b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7cfc0f-b9cc-4405-9c2d-2788d4ab49b4.jpg?1",
             "name": "Shield Bearer",
             "text": "Banding",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "8d83191e-6681-5d14-88ca-d50225b95d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0d954-f3d1-4ba6-b9ee-778e09f4eea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0d954-f3d1-4ba6-b9ee-778e09f4eea7.jpg?1",
             "name": "Shield Wall",
             "text": "All creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "f474d7a3-575d-5c49-94d3-e936e6d5e754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3327949d-3b11-4409-911c-4289a89b488f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3327949d-3b11-4409-911c-4289a89b488f.jpg?1",
             "name": "Spirit Link",
             "text": "For each 1 damage enchanted creature deals, gain 1 life.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "806f0368-2b99-5e46-bb62-3d4b73f392a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4f53fc-69d7-49fb-885b-4cc02bf5facc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4f53fc-69d7-49fb-885b-4cc02bf5facc.jpg?1",
             "name": "Truce",
             "text": "Each player may draw up to two cards. For each card less than two any player draws, that player gains 2 life.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "a9ca1bc8-c255-5638-a92c-9a4f76b60c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2f982d-cbd0-466e-8804-b055374a9dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2f982d-cbd0-466e-8804-b055374a9dec.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "261aa57d-2b30-59ca-9567-3dd034025893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bada1968-8bc5-4c75-bd60-91015961907b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bada1968-8bc5-4c75-bd60-91015961907b.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "f627a11c-863c-5b89-8159-7b1ebdc9c836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8529a0-0259-4ccd-a481-8ad1b5feadf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8529a0-0259-4ccd-a481-8ad1b5feadf9.jpg?1",
             "name": "White Knight",
             "text": "First strike, protection from black",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "584ac580-3d3d-5593-b497-5346b25f29b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def142a8-cc73-4bd2-a1a8-ae47a0c9c948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def142a8-cc73-4bd2-a1a8-ae47a0c9c948.jpg?1",
             "name": "Wrath of God",
             "text": "Bury all creatures.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "5a7c81f1-2043-5539-9fe9-e3414372739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6b89e-f24a-4d32-a6f7-8466f46d9ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6b89e-f24a-4d32-a6f7-8466f46d9ad0.jpg?1",
             "name": "Aether Storm",
             "text": "Summon spells cannot be played.\nAny player may pay 4 life to bury \u00c6ther Storm.",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "e59c3a3b-5af3-54da-b83a-b01297c9fe84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692bd3dd-4aa8-44a8-9f96-fd6e8698b6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692bd3dd-4aa8-44a8-9f96-fd6e8698b6a2.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "1f916d33-9468-5101-a2d0-e12e32e418de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54642f0e-2d5f-49eb-8181-054c84038072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54642f0e-2d5f-49eb-8181-054c84038072.jpg?1",
             "name": "Anti-Magic Aura",
             "text": "Enchanted creature cannot be the target of enchantments, instants, or sorceries. This effect does not bury Anti-Magic Aura. (Other enchantments on that creature are buried because their target is now illegal.)",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "8de483cb-62a5-57f2-9a16-1e84fe8ad918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9086e-112a-45e6-854e-70cab2b008a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9086e-112a-45e6-854e-70cab2b008a3.jpg?1",
             "name": "Azure Drake",
             "text": "Flying",
             "colours": [
@@ -2370,7 +2370,7 @@
         },
         {
             "id": "3c1c0a33-d2a1-52aa-b133-7b5490292c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9af233-f0b9-489f-8561-77bff8280814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9af233-f0b9-489f-8561-77bff8280814.jpg?1",
             "name": "Binding Grasp",
             "text": "During your upkeep, pay o1o\nU or bury Binding Grasp.\nGain control of enchanted creature. That creature gets +0/+1.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "94c04eed-a652-553f-a719-c36a462f77fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04c924-3806-44a4-9b1b-d8e1a38432f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04c924-3806-44a4-9b1b-d8e1a38432f0.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to owner's hand.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "9779da12-5dda-58f4-9d55-6ef8c19e1c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffc0bfd-8e64-44bf-ae0a-5d2ee54c58df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffc0bfd-8e64-44bf-ae0a-5d2ee54c58df.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "981141a6-ded8-5ed1-ad8f-4cab7d52c5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6603e3-0680-4ba3-951b-cd9919eefd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6603e3-0680-4ba3-951b-cd9919eefd4f.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards. Then, put any two cards from your hand on top of your library in any order.",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "63c55c67-d47f-5d9f-8718-a9cc8a67e2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b975289d-d8b8-46b4-8c60-d6ed4b594519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b975289d-d8b8-46b4-8c60-d6ed4b594519.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2531,7 +2531,7 @@
         },
         {
             "id": "095da25b-9add-52d9-b59d-950f556f9f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff8402-7bfe-441a-8c6e-6a9ee9608911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff8402-7bfe-441a-8c6e-6a9ee9608911.jpg?1",
             "name": "Dance of Many",
             "text": "During your upkeep, pay o\nUo\nU or bury Dance of Many.\nWhen you play Dance of Many, choose target summon card. When Dance of Many comes into play, put a token creature into play and treat it as an exact copy of that summon card. If either Dance of Many or the token creature leaves play, bury the other.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "0b3dc354-ebae-5fad-bad7-d5b4f154ae22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac60e8c-ef5b-4893-b3e5-4a54cb0a0d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac60e8c-ef5b-4893-b3e5-4a54cb0a0d3a.jpg?1",
             "name": "Dand\u00e2n",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "3bfa80b2-6821-52ab-878d-b860ccc61e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0349-a114-4bb8-a9ae-97d0f8f46ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0349-a114-4bb8-a9ae-97d0f8f46ddb.jpg?1",
             "name": "Dark Maze",
             "text": "o0: Dark Maze can attack this turn as though it were not a Wall. At end of turn, remove Dark Maze from the game.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "a8e38f6d-e582-5708-9fbf-f03a44b6e1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9b1251-17fe-4f00-83cf-4947ac365af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9b1251-17fe-4f00-83cf-4947ac365af6.jpg?1",
             "name": "Deflection",
             "text": "Target spell with a single target now targets a new legal target of your choice.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "c704e0b3-4b16-54c2-b551-96a38334fb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582d8496-f319-4666-a6cd-160ff33578db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582d8496-f319-4666-a6cd-160ff33578db.jpg?1",
             "name": "Drain Power",
             "text": "Target player draws all mana from all lands he or she controls. Put all mana from that player's mana pool into yours.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "0bc390b1-de59-5caa-ac0b-fb359f53748f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75dea2-aec1-4674-8db9-4759270296ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75dea2-aec1-4674-8db9-4759270296ec.jpg?1",
             "name": "Energy Flux",
             "text": "All artifacts gain \"During your upkeep, pay o2 or bury this artifact.\"",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "cd7bb609-5243-5ce1-8963-ad9daf5a9333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357f9dc-6eaf-4dc3-a1b0-ef63fd0b1367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357f9dc-6eaf-4dc3-a1b0-ef63fd0b1367.jpg?1",
             "name": "Enervate",
             "text": "Tap target artifact, creature, or land. Draw a card at the beginning of the next turn.",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "1743ae11-7574-5aad-b3e9-aa8813b46e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d452de7-3f44-4594-bb24-2178812da9d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d452de7-3f44-4594-bb24-2178812da9d6.jpg?1",
             "name": "Feedback",
             "text": "During the upkeep of enchanted enchantment's controller, Feedback deals 1 damage to him or her.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "d70ab11c-0bd1-59f9-922c-e6b25376522d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74e5168-9503-4cf9-8a66-29b68ec2092c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74e5168-9503-4cf9-8a66-29b68ec2092c.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature gains flying.",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "1361f0da-d817-5661-9f54-4d37ab0eece4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aefbeae-ac72-4a13-8898-8d1e42a633a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aefbeae-ac72-4a13-8898-8d1e42a633a6.jpg?1",
             "name": "Flood",
             "text": "o\nUoo\nU Tap target creature without flying.",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "91421c32-3389-5b21-89dd-547be23f950f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba23d540-8c2d-4a42-b4c0-86f0988bd1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba23d540-8c2d-4a42-b4c0-86f0988bd1ce.jpg?1",
             "name": "Force Spike",
             "text": "Counter target spell unless its caster pays an additional o1.",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "2cb637b5-d803-5fe3-a077-8dcd20a36be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaa7b0-b11d-47d6-9cdf-7c9fa85bea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaa7b0-b11d-47d6-9cdf-7c9fa85bea20.jpg?1",
             "name": "Forget",
             "text": "Target player chooses and discards two cards, then draws as many cards as he or she discarded in this way.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "566781aa-1b76-5ba6-ab32-20131bfbb4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28477df-667a-4233-b90a-ee30e5bc29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28477df-667a-4233-b90a-ee30e5bc29fc.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchanted creature neither deals nor receives combat damage.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "a9e77fb8-6089-59e6-b7b2-73ed9a1fa910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5797da37-ece2-40d0-ba2a-c47ce55e3744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5797da37-ece2-40d0-ba2a-c47ce55e3744.jpg?1",
             "name": "Glacial Wall",
             "text": "",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "ca2b4cf5-d3da-58ae-a9a4-80a91f629c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f20d8e-bbdf-4af8-9505-d5604b04ad72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f20d8e-bbdf-4af8-9505-d5604b04ad72.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior cannot be the target of spells or effects until end of turn and does not untap during your next untap phase. Tap Homarid Warrior.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "9bd5a45f-8c58-528a-9ac5-8bcade378e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c7e94-25ef-4859-88db-05b085744dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c7e94-25ef-4859-88db-05b085744dc0.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "Return to target player's hand all artifacts in play he or she owns.",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "732921b6-be4f-5cac-86e7-03b4fc25879c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a30b8f-6594-42ea-8e60-13ccb1e7efc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a30b8f-6594-42ea-8e60-13ccb1e7efc0.jpg?1",
             "name": "Hydroblast",
             "text": "Counter target spell if it is red, or destroy target permanent if it is red. (If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "bff20ebd-a974-5b98-8acc-a58401a80fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60dc7c3-4a6c-4c17-9025-29341a3afee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60dc7c3-4a6c-4c17-9025-29341a3afee1.jpg?1",
             "name": "Juxtapose",
             "text": "Exchange with target player control of the creature with the highest total casting cost that you each control. If two or more creatures are tied for highest total casting cost creature a player controls, he or she chooses between them. Exchange control of artifacts in the same way.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "90c7b1d1-c898-5608-81f1-7914b55c46cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91568ea-cef0-4355-8029-840f5e621ae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91568ea-cef0-4355-8029-840f5e621ae8.jpg?1",
             "name": "Krovikan Sorcerer",
             "text": "oc\nT, Choose and discard a nonblack card: Draw a card.\noc\nT, Choose and discard a black card: Draw two cards, then choose and discard one of them.",
             "colours": [
@@ -3138,7 +3138,7 @@
         },
         {
             "id": "998af111-8461-5d17-88db-1409875b4822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa8c435-55c1-46af-bb93-3f8ce81b1544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa8c435-55c1-46af-bb93-3f8ce81b1544.jpg?1",
             "name": "Labyrinth Minotaur",
             "text": "If Labyrinth Minotaur blocks any creature, that creature does not untap during its controller's next untap phase.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "3afd23c2-e8f0-5836-8fe3-6d100e00d5ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e96456-93bf-4d28-9a4b-5bc24ae07fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e96456-93bf-4d28-9a4b-5bc24ae07fc2.jpg?1",
             "name": "Leviathan",
             "text": "Trample\nLeviathan comes into play tapped and does not untap during your untap phase.\nLeviathan cannot attack this turn unless you sacrifice two islands.\nSacrifice two islands: Untap Leviathan. Use this ability only during your upkeep.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "9fa33a9c-e063-5c00-8b3b-31f7806f36cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af066a2d-d357-45a7-90d8-2c34b6d0ebf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af066a2d-d357-45a7-90d8-2c34b6d0ebf8.jpg?1",
             "name": "Lifetap",
             "text": "Whenever any forest target opponent controls becomes tapped, gain 1 life.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "03ce995a-aadd-5a7b-9e76-9fce7fc67878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaad8e0-947f-47d9-b78f-b0f2a5a06906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaad8e0-947f-47d9-b78f-b0f2a5a06906.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk get +1/+1 and gain islandwalk. (If defending player controls any islands, these creatures are unblockable.)",
             "colours": [
@@ -3268,7 +3268,7 @@
         },
         {
             "id": "055d92ce-6a64-52e7-984e-baa5d2c99479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2349d53-d9f0-450f-be96-463791ee7aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2349d53-d9f0-450f-be96-463791ee7aab.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of target permanent or spell by replacing all instances of one basic land type with another. (For example, you may change \"swampwalk\" to \"plainswalk.\" If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "4e20e8d5-3315-5f6d-8dc9-e34c851ab830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adf168a-039e-4f8f-8ca4-3f364eef373d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adf168a-039e-4f8f-8ca4-3f364eef373d.jpg?1",
             "name": "Magus of the Unseen",
             "text": "o1o\nU, oc\nT: Untap target artifact an opponent controls and gain control of it until end of turn. That artifact is unaffected by summoning sickness this turn. Tap the artifact if you lose control of it at end of this turn.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "aaee744c-8ab2-52a0-b665-bde505186ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9010e5e2-fd32-4f2f-aa68-1dbe58c078a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9010e5e2-fd32-4f2f-aa68-1dbe58c078a2.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of owner's library.",
             "colours": [
@@ -3364,7 +3364,7 @@
         },
         {
             "id": "9a41517a-5a29-5ef5-890f-727a29087555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7003be-4464-4eab-a77d-ab0346643613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7003be-4464-4eab-a77d-ab0346643613.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "fbed7a9f-5d2a-5015-82dd-f9a6c0611c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c46d040-58c2-4f7a-8b66-fea33fcb0e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c46d040-58c2-4f7a-8b66-fea33fcb0e11.jpg?1",
             "name": "Mind Bomb",
             "text": "Mind Bomb deals 3 damage to each player. Each player may choose and discard up to three cards to prevent that amount of damage to him or her from Mind Bomb.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "d5f4faf3-3678-524b-85e6-1ee2b65bec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b26cb-ec7d-464b-b835-82e60e86f827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b26cb-ec7d-464b-b835-82e60e86f827.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nDuring your upkeep, pay o\nU or bury Phantasmal Forces.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "436b63be-361e-5c92-90a1-cc3cceab4b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6541b-9f23-48f1-a9bb-081ad7022fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6541b-9f23-48f1-a9bb-081ad7022fd4.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Enchanted land is a basic land type of your choice.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "c2e14caa-3962-52b8-a6bf-326d36253996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8a6c0-1a17-4b7e-b1e6-cdd52ee1ece8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8a6c0-1a17-4b7e-b1e6-cdd52ee1ece8.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "186828bc-9aee-5d7d-95d2-57a3ff9872b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad5912-6d1e-4ad3-9911-0c768417d6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad5912-6d1e-4ad3-9911-0c768417d6d4.jpg?1",
             "name": "Pirate Ship",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)\noc\nT: Pirate Ship deals 1 damage to target creature or player.",
             "colours": [
@@ -3561,7 +3561,7 @@
         },
         {
             "id": "cb001d15-c4ec-5c5d-b4e0-97d5dbe5566a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e317e0f-4c6e-4ede-846a-fb76fa77c6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e317e0f-4c6e-4ede-846a-fb76fa77c6bf.jpg?1",
             "name": "Portent",
             "text": "Look at the top three cards of target player's library. Shuffle that library or put those three cards back on top of it in any order. Draw a card at the beginning of the next turn.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "bc74a117-fbf7-540f-bb04-64f84f006337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb32bc8-ae9f-4484-b2de-bce35e9f5df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb32bc8-ae9f-4484-b2de-bce35e9f5df5.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless that spell's caster pays an additional o\nX. That player draws and pays all mana from lands and mana pool until o\nX is paid; he or she may also draw and pay mana from other sources if desired.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "f85e9cd6-369d-5318-98ab-343e4d3e2d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c743b0fb-a4cb-40a6-94d9-2318386d0afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c743b0fb-a4cb-40a6-94d9-2318386d0afb.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "1ad629d1-9820-5daa-bd4d-a731f5f66133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004b6463-0aef-4419-b4f2-dc3fa6eee901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004b6463-0aef-4419-b4f2-dc3fa6eee901.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever enchanted land becomes tapped, Psychic Venom deals 2 damage to that land's controller.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "4b73b347-1c2d-51c5-9cfc-57e5f102fc28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e498567-2bb0-4622-8250-a56b9ff79a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e498567-2bb0-4622-8250-a56b9ff79a7e.jpg?1",
             "name": "Ray of Command",
             "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature is unaffected by summoning sickness this turn. Tap the creature if you lose control of it at end of this turn.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "0df3be68-03f6-5bc4-8753-7ee34f709341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53dd70-e2a7-4203-ae00-240694d7220e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53dd70-e2a7-4203-ae00-240694d7220e.jpg?1",
             "name": "Recall",
             "text": "Choose and discard X cards: Return X target cards in your graveyard to your hand. Remove Recall from the game.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "245af4be-cd2b-57f3-a5bd-cc6995ff8675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d712139-bf12-4f7b-bb9b-34d15fac56df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d712139-bf12-4f7b-bb9b-34d15fac56df.jpg?1",
             "name": "Reef Pirates",
             "text": "If Reef Pirates damages any opponent, put the top card of that player's library into his or her graveyard.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "393b45ff-43d7-5131-8e89-b6820df602bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6bbb81-b830-4b22-be9a-852d9edbda21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6bbb81-b830-4b22-be9a-852d9edbda21.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target summon spell.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "418e1ae6-9229-5f2c-896d-3e541f6c54b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e170bb1e-f2eb-4631-af95-ada585b7ef57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e170bb1e-f2eb-4631-af95-ada585b7ef57.jpg?1",
             "name": "Sea Serpent",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "c0f4dd0e-c6d5-534a-9ed0-dd63cb33fbdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08933cca-6ed1-43da-a539-355ded52c5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08933cca-6ed1-43da-a539-355ded52c5b6.jpg?1",
             "name": "Sea Spirit",
             "text": "oo\nU +1/+0 until end of turn",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "89272355-7b1c-5252-a65b-dfb09200cf0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec37c5-b927-47ae-8cd6-3eddd55a3472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cec37c5-b927-47ae-8cd6-3eddd55a3472.jpg?1",
             "name": "Sea Sprite",
             "text": "Flying, protection from red",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "8c007e26-1632-59ae-bbe0-32473e0066b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851545d3-cc23-40da-84c5-93da0dd14a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851545d3-cc23-40da-84c5-93da0dd14a8d.jpg?1",
             "name": "Seasinger",
             "text": "If you control no islands, bury Seasinger.\nYou may choose not to untap Seasinger during your untap phase.\noc\nT: Gain control of target creature whose controller controls any islands as long as you control Seasinger and Seasinger remains tapped.",
             "colours": [
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "6785fbbb-1af6-53e9-94eb-5ede9ff3b7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873c47-dfed-4ffb-a472-2cb304934ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873c47-dfed-4ffb-a472-2cb304934ad9.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk (If defending player controls any islands, this creature is unblockable.)",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "bf225e27-b8b3-5967-801a-68c75bc83f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9382b01d-4ff5-4e33-ab05-412ad694b85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9382b01d-4ff5-4e33-ab05-412ad694b85f.jpg?1",
             "name": "Sibilant Spirit",
             "text": "Flying\nIf Sibilant Spirit attacks, defending player may draw a card.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "67f43f3b-f683-55ff-958c-ace8cc03b018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb4f1c-6754-4269-8fac-d4edc02c8e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb4f1c-6754-4269-8fac-d4edc02c8e00.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of target permanent or spell by replacing all instances of one color word with another. (For example, you may change \"nongreen creature\" to \"nonred creature.\" If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -4047,7 +4047,7 @@
         },
         {
             "id": "ed07bca4-ddf8-5103-b5bf-9ab82a603d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd50e68-2063-4fae-bb56-eb224d43b147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd50e68-2063-4fae-bb56-eb224d43b147.jpg?1",
             "name": "Soul Barrier",
             "text": "Whenever target opponent successfully casts a summon spell, Soul Barrier deals 2 damage to him or her. That player may pay o2 to prevent this damage.",
             "colours": [
@@ -4078,7 +4078,7 @@
         },
         {
             "id": "8849c3de-5ce5-5056-8932-8b92ba1d3dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e4584f-6e44-4ff8-8313-c8791e0156af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e4584f-6e44-4ff8-8313-c8791e0156af.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with total casting cost equal to X.",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "cf69b1e2-6d1f-5319-b342-0bc3de6113e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96570023-a9d6-4536-ac11-f0baad041d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96570023-a9d6-4536-ac11-f0baad041d7c.jpg?1",
             "name": "Stasis",
             "text": "Each player skips his or her untap phase.\nDuring your upkeep, pay o\nU or bury Stasis.",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "a40a30cb-a66f-5e90-95e0-d2bb8ed6f704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e08d3b2-9c85-4482-b110-5f399672e550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e08d3b2-9c85-4482-b110-5f399672e550.jpg?1",
             "name": "Steal Artifact",
             "text": "Gain control of enchanted artifact.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "f8d6c2d2-de5e-5f94-bf16-56421186419f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b1e44-776a-44b9-a976-777e49ae628e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b1e44-776a-44b9-a976-777e49ae628e.jpg?1",
             "name": "Time Elemental",
             "text": "If Time Elemental attacks or blocks, it deals 5 damage to you and is buried at end of combat.\no2o\nUo\nU, oc\nT: Return target permanent with no enchantments on it to owner's hand.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "a89d25de-3960-5332-8814-f54fc4df1edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9fa429-a3d5-418d-b94d-ef534b5b86f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9fa429-a3d5-418d-b94d-ef534b5b86f0.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "1283109d-c517-5b11-8212-8c2fb5f922a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127abfdc-8d9e-4ba3-8f31-c13a54831824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127abfdc-8d9e-4ba3-8f31-c13a54831824.jpg?1",
             "name": "Unstable Mutation",
             "text": "Enchanted creature gets +3/+3.\nDuring its controller's upkeep, put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "68543872-ea16-56f1-83bd-50f79015b743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c830b54-0441-4df2-87de-a579dc734d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c830b54-0441-4df2-87de-a579dc734d97.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to owner's hand.",
             "colours": [
@@ -4301,7 +4301,7 @@
         },
         {
             "id": "cefd17e8-1b4f-5b9d-9aca-e7ce079b0f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4c1316-d6df-4bc4-9bfe-0458ff7c2908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4c1316-d6df-4bc4-9bfe-0458ff7c2908.jpg?1",
             "name": "Updraft",
             "text": "Target creature gains flying until end of turn.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -4332,7 +4332,7 @@
         },
         {
             "id": "7134ebd7-5ea2-53eb-b317-cfc7fa320313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d204d-e495-4067-9c38-1a895824f95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d204d-e495-4067-9c38-1a895824f95a.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -4366,7 +4366,7 @@
         },
         {
             "id": "23b7b5a8-0818-5f31-a7e5-dc623048abca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a53c7-99fa-4183-a173-f84ec06088b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a53c7-99fa-4183-a173-f84ec06088b2.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "5942116c-d792-5840-a414-11960e36a46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70495b9-3fec-4eea-addf-1f401a1f49ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70495b9-3fec-4eea-addf-1f401a1f49ed.jpg?1",
             "name": "Wind Spirit",
             "text": "Flying\nWind Spirit cannot be blocked by only one creature.",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "695ba04f-d026-53f2-9a13-75582b1571ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d11923e-98c6-4041-b115-f4847fb71149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d11923e-98c6-4041-b115-f4847fb71149.jpg?1",
             "name": "Zephyr Falcon",
             "text": "Flying\nAttacking does not cause Zephyr Falcon to tap.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "f6623b62-1d97-571a-bb64-c4fcd1392474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded7b01-2920-4b94-a511-088b521de9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded7b01-2920-4b94-a511-088b521de9f7.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands face up.\nWhenever any player draws a card, any other player may pay 2 life to force the drawing player to discard that card.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "8bbaefc7-64ef-5a52-a559-ff88b7cfd5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32aca-94d0-46df-9ca9-503a51416b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32aca-94d0-46df-9ca9-503a51416b14.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nIf Abyssal Specter damages any player, he or she chooses and discards a card.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "08bb4f23-19be-5a00-9e25-c765df72b5ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2cd314-8f99-4443-ae86-a967effc7490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2cd314-8f99-4443-ae86-a967effc7490.jpg?1",
             "name": "Animate Dead",
             "text": "When you play Animate Dead, choose target creature card in any graveyard. When Animate Dead comes into play, put that creature into play and Animate Dead becomes a creature enchantment that targets the creature. Enchanted creature gets -1/-0. If Animate Dead leaves play, bury the creature.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "80695a3b-fad0-57ec-a055-740babf71e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7240709d-a469-4801-82bd-f5db50859763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7240709d-a469-4801-82bd-f5db50859763.jpg?1",
             "name": "Ashes to Ashes",
             "text": "Remove two target nonartifact creatures from the game. Ashes to Ashes deals 5 damage to you.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "7a76e338-564b-5e63-adce-17f439d9ee5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d28603-b116-4948-a46f-b95ae9118d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d28603-b116-4948-a46f-b95ae9118d9e.jpg?1",
             "name": "Ashes to Ashes",
             "text": "",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "ee2d9396-627c-560d-9166-aeec1010330a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb6d665-42f5-4f44-8797-16c0351ab3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb6d665-42f5-4f44-8797-16c0351ab3c0.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures get +1/+1.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "45a2eb0e-dddd-567d-ab70-8f23928be80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03b6221-2c85-44c0-82f1-b2b9e2c83c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03b6221-2c85-44c0-82f1-b2b9e2c83c80.jpg?1",
             "name": "Black Knight",
             "text": "First strike, protection from white",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "db372037-682b-509d-9f35-751392e81104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affd5566-9ec6-4713-a804-cec9b13b1da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affd5566-9ec6-4713-a804-cec9b13b1da1.jpg?1",
             "name": "Blight",
             "text": "If enchanted land becomes tapped, destroy it at end of turn.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "c27ef5a3-6055-5091-8265-f298501f72b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11924b2-c290-47a1-803d-b00c433cf840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11924b2-c290-47a1-803d-b00c433cf840.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "a9862058-18e6-5db0-b480-ae3844ab6b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e325363-1ab9-4b44-9c00-0758830289e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e325363-1ab9-4b44-9c00-0758830289e8.jpg?1",
             "name": "Bog Rats",
             "text": "Bog Rats cannot be blocked by Walls.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "54ddbfb6-731c-59bd-ab87-1fc06e457d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae74c5b-1090-4910-87a4-81dbffd1fd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae74c5b-1090-4910-87a4-81dbffd1fd69.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "f4db3d68-bf78-54fc-ad6b-c83ec932eff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe305196-fd9d-4f92-a37c-6c4fe5abad1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe305196-fd9d-4f92-a37c-6c4fe5abad1f.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -4863,7 +4863,7 @@
         },
         {
             "id": "4864ea20-099d-5f63-9dc8-aef0527ecd1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9b663-5c02-4221-9efb-59841dfd2188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9b663-5c02-4221-9efb-59841dfd2188.jpg?1",
             "name": "Breeding Pit",
             "text": "During your upkeep, pay o\nBo\nB or bury Breeding Pit.\nAt the end of your turn, put a Thrull token into play. Treat this token as a 0/1 black creature.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "925c89eb-f54e-53c8-8c39-85e0ef972adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824823fb-5ae1-48b1-bc46-e452afa73cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824823fb-5ae1-48b1-bc46-e452afa73cd8.jpg?1",
             "name": "Broken Visage",
             "text": "Bury target nonartifact attacking creature and put a Shadow token into play. Treat this token as a black creature with the same power and toughness as that attacking creature. At end of turn, bury the token.",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "19843078-7ef4-5b9d-8d9e-7f519e072fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bf491b-b876-4453-8c85-8d7c419b0900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bf491b-b876-4453-8c85-8d7c419b0900.jpg?1",
             "name": "Carrion Ants",
             "text": "o1: +1/+1 until end of turn",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "7a1ed85e-cea2-53bd-b78a-ef26e185782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430a4e23-d13c-4413-9032-f18350a128da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430a4e23-d13c-4413-9032-f18350a128da.jpg?1",
             "name": "Cloak of Confusion",
             "text": "o0: Defending player discards a card at random. Enchanted creature deals no combat damage this turn. Use this ability only if enchanted creature is attacking and unblocked and only once each turn.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "55286446-89f4-5167-b444-9ae205ced34f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9801b-9707-4868-bde1-39960b761992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9801b-9707-4868-bde1-39960b761992.jpg?1",
             "name": "Cursed Land",
             "text": "During the upkeep of enchanted land's controller, Cursed Land deals 1 damage to him or her.",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "25fa6a23-7212-5510-99ed-ef2f1747a8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae25afd-0d16-431c-a85e-7ac91cef9050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae25afd-0d16-431c-a85e-7ac91cef9050.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "3f4403d2-8acd-5815-bf22-1c608aa09cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934a6704-3fb5-4259-96e0-1f93a45b3f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934a6704-3fb5-4259-96e0-1f93a45b3f8c.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Counter target green spell. Play this ability as an interrupt.",
             "colours": [
@@ -5086,7 +5086,7 @@
         },
         {
             "id": "79751bca-abab-535c-829c-3479dd979b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b050783f-945e-4d61-a896-9a5b79ae7982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b050783f-945e-4d61-a896-9a5b79ae7982.jpg?1",
             "name": "Derelor",
             "text": "Your black spells cost an additional o\nB to play.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "1a42ef33-0905-5a26-abf7-6f0617eca59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a9b3b2-4ac9-4e50-bcd2-8831d0739e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a9b3b2-4ac9-4e50-bcd2-8831d0739e85.jpg?1",
             "name": "Drain Life",
             "text": "oo\nX Drain Life deals X damage to target creature or player. Spend only black mana in this way. Gain 1 life for each 1 damage dealt, but not more than the toughness of the creature or the life total of the player Drain Life damages.",
             "colours": [
@@ -5150,7 +5150,7 @@
         },
         {
             "id": "5fe0d393-11ab-550f-aa7b-ba427fbc82ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127bb737-85ed-4de3-9a1d-ec789d54b7cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127bb737-85ed-4de3-9a1d-ec789d54b7cd.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "6578f75e-11ba-5f83-b9cd-f046be1a77c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc87da4-8f68-4c40-afdb-2dfcc075ce91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc87da4-8f68-4c40-afdb-2dfcc075ce91.jpg?1",
             "name": "Erg Raiders",
             "text": "At the end of your turn, Erg Raiders deals 2 damage to you if it did not attack this turn. Ignore this effect if Erg Raiders has summoning sickness.",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "cef99eac-7709-5de6-9730-65048869e2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c7e01b-68a9-4380-94b6-d687e2c2ee86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c7e01b-68a9-4380-94b6-d687e2c2ee86.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "Evil Eye of Orms-by-Gore cannot be blocked except by Walls.\nExcept for Evil Eyes, creatures you control cannot attack.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "c0df5508-0422-5202-9e5b-1ff96d588692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3042fdde-595d-4f60-be59-364eedecf3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3042fdde-595d-4f60-be59-364eedecf3bd.jpg?1",
             "name": "Evil Presence",
             "text": "Enchanted land is a swamp.",
             "colours": [
@@ -5283,7 +5283,7 @@
         },
         {
             "id": "dca781b2-9ad7-5511-b4e8-0bb06ad44c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68022e3e-99d0-4f14-9ef8-17f27a157edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68022e3e-99d0-4f14-9ef8-17f27a157edd.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: +2/+1 until end of turn",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "84381ffb-3ae2-5482-915f-3d4e807e407e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c917d05d-395d-4e2f-aecc-616ae9aa9b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c917d05d-395d-4e2f-aecc-616ae9aa9b5b.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -5349,7 +5349,7 @@
         },
         {
             "id": "41c5877f-3cf2-5222-93d9-3d520bde70bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd0b4ff-f49f-4079-991a-f66d1220235d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd0b4ff-f49f-4079-991a-f66d1220235d.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -5382,7 +5382,7 @@
         },
         {
             "id": "5e0a2ef4-68f3-575b-8481-16db8d3d5925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e7bbae-1438-4a47-9c14-c4b6d8702ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e7bbae-1438-4a47-9c14-c4b6d8702ec4.jpg?1",
             "name": "Funeral March",
             "text": "If enchanted creature leaves play, its controller sacrifices a creature.",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "98e54b89-b425-575d-94b4-c3d61be03dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6fff23-21c9-4519-b84a-59868a918996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6fff23-21c9-4519-b84a-59868a918996.jpg?1",
             "name": "Gloom",
             "text": "White spells cost an additional o3 to play. Activated abilities of white enchantments cost an additional o3 to play.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "8f5f2d90-0220-58fd-bca5-0aeb68235c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b77373-6066-436b-aa60-4cb0f8077599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b77373-6066-436b-aa60-4cb0f8077599.jpg?1",
             "name": "Greater Werewolf",
             "text": "At end of combat, put a -0/-2 counter on each creature blocking or blocked by Greater Werewolf.",
             "colours": [
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "74cd8d88-b7c0-5c0a-ae38-0496fadfb411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43671b63-d38e-4ef5-94bd-300cda82a88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43671b63-d38e-4ef5-94bd-300cda82a88b.jpg?1",
             "name": "Hecatomb",
             "text": "When Hecatomb comes into play, sacrifice four creatures or bury Hecatomb.\nTap a swamp you control: Hecatomb deals 1 damage to target creature or player.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "99c65860-258c-528a-928b-c5adb1b64df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88d96c-6192-48e6-9a3b-97eff587e115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88d96c-6192-48e6-9a3b-97eff587e115.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "b885d14e-9b4f-549a-9f0c-b9f01215ac25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83085df-1ffb-4178-9fc0-fd347196673f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83085df-1ffb-4178-9fc0-fd347196673f.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. If o4 or more is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn. Play this ability as a mana source.",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "f39808a6-8193-5529-b199-6cdd2c044274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4a92a3-4df5-4d83-b015-59859e6bccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4a92a3-4df5-4d83-b015-59859e6bccc8.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "2bf09a49-0b56-51f2-856d-4aeb0ccb6b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590c219d-536a-47a4-93a4-b77ce808a024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590c219d-536a-47a4-93a4-b77ce808a024.jpg?1",
             "name": "Kjeldoran Dead",
             "text": "When Kjeldoran Dead comes into play, sacrifice a creature.\noo\nB Regenerate",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "66157ba7-30cd-57c6-88ce-4a65ba3e867e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c73dd-3a80-4355-a71d-c6de99cb11cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c73dd-3a80-4355-a71d-c6de99cb11cb.jpg?1",
             "name": "Knight of Stromgald",
             "text": "Protection from white\no\nB: First strike until end of turn\no\nBo\nB: +1/+0 until end of turn",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "c871e429-be59-54bc-af7c-1625bd6cc208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db46edd-d2d3-4d3e-beae-f8d01bb5078e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db46edd-d2d3-4d3e-beae-f8d01bb5078e.jpg?1",
             "name": "Krovikan Fetish",
             "text": "Draw a card at the beginning of the turn after Krovikan Fetish comes into play.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "87f80bad-3a30-5fca-921e-576f2becbfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6aee0b-1039-496f-a096-2d4d71621d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6aee0b-1039-496f-a096-2d4d71621d99.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Enchanted creature gains swampwalk. (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "f63f64d7-e780-5fa4-b07e-c9f57d1310fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4c083f-d619-4913-aa7b-d345e3bdb1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4c083f-d619-4913-aa7b-d345e3bdb1c4.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nDuring your upkeep, sacrifice a creature other than Lord of the Pit. If you cannot, Lord of the Pit deals 7 damage to you.",
             "colours": [
@@ -5777,7 +5777,7 @@
         },
         {
             "id": "a57aa715-748e-5477-ac27-67fd35f6e362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff73c4c8-1761-4fc8-96b1-8983b9b78b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff73c4c8-1761-4fc8-96b1-8983b9b78b46.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -5811,7 +5811,7 @@
         },
         {
             "id": "4cc49439-cdc7-59c0-bd64-f9bf5d8d3023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9a0296-3690-45c7-98af-d546296ad9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9a0296-3690-45c7-98af-d546296ad9fe.jpg?1",
             "name": "Mind Ravel",
             "text": "Target player chooses and discards a card.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "4998f76b-9cc1-5ee8-b562-10b58ac8ba2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de86fd7e-438c-48a2-a69d-193d8b8ebbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de86fd7e-438c-48a2-a69d-193d8b8ebbac.jpg?1",
             "name": "Mind Warp",
             "text": "Look at target player's hand. He or she discards X cards of your choice.",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "f3cbc787-ee1a-5d18-b366-47014af56faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b1439-b83d-4e6d-8956-b0964b1e3ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b1439-b83d-4e6d-8956-b0964b1e3ed9.jpg?1",
             "name": "Mindstab Thrull",
             "text": "Sacrifice Mindstab Thrull: Defending player chooses and discards three cards. Use this ability only if Mindstab Thrull is attacking and unblocked.",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "ecd058d3-48e9-5947-b1d3-01298f9cf023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90042a-a5e9-4c3f-a08a-c24e5606110b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90042a-a5e9-4c3f-a08a-c24e5606110b.jpg?1",
             "name": "Mindstab Thrull",
             "text": "",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "ecc7bba2-fb35-5e83-a033-9bbe3f6888b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f43c9-1e71-4e5f-a6ce-eca94993558f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f43c9-1e71-4e5f-a6ce-eca94993558f.jpg?1",
             "name": "Mole Worms",
             "text": "You may choose not to untap Mole Worms during your untap phase.\noc\nT: Tap target land. As long as Mole Worms remains tapped, that land does not untap during its controller's untap phase.",
             "colours": [
@@ -5976,7 +5976,7 @@
         },
         {
             "id": "588c71c9-56e2-586f-a11c-18a7ef765970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740564ec-c473-45bc-ba94-288786bf28b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740564ec-c473-45bc-ba94-288786bf28b9.jpg?1",
             "name": "Murk Dwellers",
             "text": "If Murk Dwellers attacks and is not blocked, it gets +2/+0 until end of turn.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "919eb07d-7810-5cd8-864d-2756f064eed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc0941-5837-41cf-9ae6-5f8d1fe4dfe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc0941-5837-41cf-9ae6-5f8d1fe4dfe4.jpg?1",
             "name": "Necrite",
             "text": "Sacrifice Necrite: Bury target creature defending player controls. Use this ability only if Necrite is attacking and unblocked.",
             "colours": [
@@ -6044,7 +6044,7 @@
         },
         {
             "id": "a61f6b9e-6a2a-5281-b5b4-6540c338db74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892150a2-0a0b-4ac5-afb5-6434d6f42396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892150a2-0a0b-4ac5-afb5-6434d6f42396.jpg?1",
             "name": "Necrite",
             "text": "",
             "colours": [
@@ -6079,7 +6079,7 @@
         },
         {
             "id": "c1370d2e-b28a-5b17-be26-a3fd54228df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222cfbec-8839-43fa-95a0-2ea91b59515c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222cfbec-8839-43fa-95a0-2ea91b59515c.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw phase.\nWhenever you discard a card, remove that card from the game.\nPay 1 life: Set aside the top card of your library. Put that card into your hand at the beginning of your discard phase.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "5481b769-78b3-57ac-94a0-1f5bb0b8e540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0877527-6dbe-49f2-862f-5c79e66a92e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0877527-6dbe-49f2-862f-5c79e66a92e9.jpg?1",
             "name": "Nether Shadow",
             "text": "Nether Shadow is unaffected by summoning sickness.\nAt the end of your upkeep, if Nether Shadow is in your graveyard with at least three creature cards above it, you may put Nether Shadow into play.",
             "colours": [
@@ -6143,7 +6143,7 @@
         },
         {
             "id": "d5a5b717-bfd0-54df-8eab-bb49ff437742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60304328-7a02-4f4c-a884-fc6ce7816060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60304328-7a02-4f4c-a884-fc6ce7816060.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare has power and toughness each equal to the number of swamps you control.",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "10c8933e-1865-522f-a52c-4710999aaa87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1823c578-d3a1-40de-bdac-ec6547e8ee24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1823c578-d3a1-40de-bdac-ec6547e8ee24.jpg?1",
             "name": "Paralyze",
             "text": "When Paralyze comes into play, tap enchanted creature.\nEnchanted creature does not untap during its controller's untap phase. That player may pay an additional o4 during his or her upkeep to untap it.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "fa9c4c88-65ea-5516-8495-bcff35ffeffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e46c1-f56d-4836-95c8-76f0d76e0d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e46c1-f56d-4836-95c8-76f0d76e0d02.jpg?1",
             "name": "Pestilence",
             "text": "At the end of any turn, if there are no creatures in play, bury Pestilence.\noo\nB Pestilence deals 1 damage to each creature and player.",
             "colours": [
@@ -6241,7 +6241,7 @@
         },
         {
             "id": "312b1354-c922-5a53-8e11-bfbf145424c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe106ff1-cdc6-44cc-adb7-131203a05292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe106ff1-cdc6-44cc-adb7-131203a05292.jpg?1",
             "name": "Pit Scorpion",
             "text": "If Pit Scorpion damages any player, he or she gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -6274,7 +6274,7 @@
         },
         {
             "id": "31cf1e52-a0fa-566d-af5f-a91e6f8f27bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99fd75c-4b41-411f-92b0-ca3b220946b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99fd75c-4b41-411f-92b0-ca3b220946b5.jpg?1",
             "name": "Plague Rats",
             "text": "Plague Rats has power and toughness each equal to the number of Plague Rats in play.",
             "colours": [
@@ -6307,7 +6307,7 @@
         },
         {
             "id": "b6a296f1-7add-5c31-a26b-36a325cde05d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036057d-c7ab-4a37-a011-d10508cec2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036057d-c7ab-4a37-a011-d10508cec2bc.jpg?1",
             "name": "Pox",
             "text": "Each player loses 1/3 of his or her life; then chooses and discards 1/3 of his or her hand; then sacrifices 1/3 of the creatures he or she controls; and then sacrifices 1/3 of the lands he or she controls. Round each loss up.",
             "colours": [
@@ -6338,7 +6338,7 @@
         },
         {
             "id": "0c0af1d5-316b-5468-b5ef-73cedeb2b53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc54f1d6-8a2c-434e-bcae-942b3ccc44b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc54f1d6-8a2c-434e-bcae-942b3ccc44b5.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at target opponent's hand. That player discards a creature card at random. Use this ability only during your turn.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "24a878ab-f17b-5841-a42e-ce76bb6a4f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58326b13-0ab8-4fe5-8e63-c0333ffe5380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58326b13-0ab8-4fe5-8e63-c0333ffe5380.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card in your graveyard to your hand.",
             "colours": [
@@ -6403,7 +6403,7 @@
         },
         {
             "id": "c4112a24-025e-5b8e-8158-ee2e060bb34f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed910299-b9e3-45b3-8fd1-2ebd47cd8275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed910299-b9e3-45b3-8fd1-2ebd47cd8275.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -6436,7 +6436,7 @@
         },
         {
             "id": "77473910-cf54-5488-825a-71c2fac901a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac17237-778d-4551-9a92-8be546e233dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac17237-778d-4551-9a92-8be546e233dc.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat comes into play, put three Serf tokens into play. Treat these tokens as 0/1 black creatures.\nIf Sengir Autocrat leaves play, bury all Serf tokens.",
             "colours": [
@@ -6469,7 +6469,7 @@
         },
         {
             "id": "fb4ff874-1265-58ca-b8bc-175c787e218c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657979b3-6e4f-41a8-a518-4bd329307770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657979b3-6e4f-41a8-a518-4bd329307770.jpg?1",
             "name": "Sorceress Queen",
             "text": "oc\nT: Target creature other than Sorceress Queen is 0/2 until end of turn.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "743aa35d-92ad-5f01-9c99-2b98ec1baf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afac3a0a-e03d-4610-b12d-4bc2244163d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afac3a0a-e03d-4610-b12d-4bc2244163d1.jpg?1",
             "name": "Stromgald Cabal",
             "text": "oc\nT, Pay 1 life: Counter target white spell. Play this ability as an interrupt.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "3d1f95c4-4e9f-564d-8697-ade292e32f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0191ac-0924-4240-bfb9-700e6c09ddd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0191ac-0924-4240-bfb9-700e6c09ddd1.jpg?1",
             "name": "Terror",
             "text": "Bury target nonartifact, nonblack creature.",
             "colours": [
@@ -6568,7 +6568,7 @@
         },
         {
             "id": "2fbf6f13-4aff-5042-896f-cb3b265637b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729f4543-79f3-4fe2-973f-fb2598045877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729f4543-79f3-4fe2-973f-fb2598045877.jpg?1",
             "name": "The Wretched",
             "text": "At end of combat, gain control of all creatures blocking The Wretched as long as you control The Wretched.",
             "colours": [
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "9907b0c1-7f99-5d59-9f5b-489a8a70aa7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c86ca-a09d-4ca3-a5db-310c7612c96d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c86ca-a09d-4ca3-a5db-310c7612c96d.jpg?1",
             "name": "Thrull Retainer",
             "text": "Enchanted creature gets +1/+1.\nSacrifice Thrull Retainer: Regenerate enchanted creature.",
             "colours": [
@@ -6634,7 +6634,7 @@
         },
         {
             "id": "13fd553b-098c-50f1-8edf-cbd1b48fbb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afdd3de-4f0c-4b78-8534-562db8be9c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afdd3de-4f0c-4b78-8534-562db8be9c6b.jpg?1",
             "name": "Torture",
             "text": "o1oo\nB Put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "358cb717-c6ab-5f4e-89fc-bb3798080acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e529fb-b951-4f64-85c9-1c2e3b9581a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e529fb-b951-4f64-85c9-1c2e3b9581a2.jpg?1",
             "name": "Touch of Death",
             "text": "Touch of Death deals 1 damage to target player and you gain 1 life.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -6698,7 +6698,7 @@
         },
         {
             "id": "719dd814-3194-54e1-94e6-9b3928d8836a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0182f2f-a089-427b-aaf1-4cfaa4c0dc94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0182f2f-a089-427b-aaf1-4cfaa4c0dc94.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchanted creature gets +2/+1.",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "efb09671-65a0-50e3-ae0f-2238b8975125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b8aa03-c777-467f-9b05-812183553f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b8aa03-c777-467f-9b05-812183553f7b.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying\noo\nB +1/+0 until end of turn. You cannot spend more than o\nBo\nB in this way each turn.",
             "colours": [
@@ -6764,7 +6764,7 @@
         },
         {
             "id": "94cedd78-0fdc-5451-8466-baeb6637fabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931152c1-89a7-434e-adff-5f580a3be8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931152c1-89a7-434e-adff-5f580a3be8ed.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "37eb5586-b1d9-59c4-aec2-5a0b6dfde0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94355dce-dfd6-45d6-9b86-0c2bc10e0231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94355dce-dfd6-45d6-9b86-0c2bc10e0231.jpg?1",
             "name": "Warp Artifact",
             "text": "During the upkeep of enchanted artifact's controller, Warp Artifact deals 1 damage to him or her.",
             "colours": [
@@ -6831,7 +6831,7 @@
         },
         {
             "id": "5a5132b2-aeb8-575c-a0ce-cd0e1dc87939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5210f08b-2278-47a2-9582-b0d79ebdfc2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5210f08b-2278-47a2-9582-b0d79ebdfc2f.jpg?1",
             "name": "Weakness",
             "text": "Enchanted creature gets -2/-1.",
             "colours": [
@@ -6864,7 +6864,7 @@
         },
         {
             "id": "bfe44ff6-21fe-52a0-986a-ddc4f44b0810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcedc3f5-f4ab-4f7b-84c0-bd5a6a4b0f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcedc3f5-f4ab-4f7b-84c0-bd5a6a4b0f5e.jpg?1",
             "name": "Xenic Poltergeist",
             "text": "oc\nT: Until your next upkeep, target noncreature artifact is an artifact creature with power and toughness each equal to its total casting cost. (That artifact retains all of its original abilities.)",
             "colours": [
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "f524c048-2e70-543a-8912-4e7e0088ec70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e9f0ff-5436-4faf-9d20-b828fd18baa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e9f0ff-5436-4faf-9d20-b828fd18baa6.jpg?1",
             "name": "Zombie Master",
             "text": "All Zombies gain \"oo\nB Regenerate\" and swampwalk. (If defending player controls any swamps, these creatures are unblockable.)",
             "colours": [
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "4dd93006-b5dc-5b49-88d6-d5e2cdf20fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e464c69-84c0-4c09-ae86-b728a15ec77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e464c69-84c0-4c09-ae86-b728a15ec77f.jpg?1",
             "name": "Ambush Party",
             "text": "First strike\nAmbush Party is unaffected by summoning sickness.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "0426b3f8-35c4-5cbf-bbe9-5dec7abb033a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f123fe6a-99ca-48c1-9a7a-ae905c10108a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f123fe6a-99ca-48c1-9a7a-ae905c10108a.jpg?1",
             "name": "Atog",
             "text": "Sacrifice an artifact: +2/+2 until end of turn",
             "colours": [
@@ -6997,7 +6997,7 @@
         },
         {
             "id": "d8cd6319-97f2-516b-ad1e-621a55641258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede7920-e219-4e9d-bfa5-e0f562460914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede7920-e219-4e9d-bfa5-e0f562460914.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample\nBall Lightning is unaffected by summoning sickness.\nAt the end of any turn, bury Ball Lightning.",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "31fbdcd4-6220-56ca-8afb-cd3be2e8f8ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02750f36-d9d3-4c50-adbf-dadab46e92fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02750f36-d9d3-4c50-adbf-dadab46e92fd.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "4040669e-4fd6-5c12-9758-cbf75cca1419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a63f96-e2d4-4786-80ea-79b206263cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a63f96-e2d4-4786-80ea-79b206263cef.jpg?1",
             "name": "Blood Lust",
             "text": "Target creature gets +4/-4 until end of turn. If this reduces that creature's toughness to less than 1, the creature's toughness is 1.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "0e720eb8-5465-5381-a2d5-69e3fe814cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f068807-3e0d-42b0-aa11-7fd61492f12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f068807-3e0d-42b0-aa11-7fd61492f12b.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Brassclaw Orcs cannot be assigned to block any creature with power 2 or greater.",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "7eb3cd76-827a-5fe0-8a7a-e84fc4334484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3400509-7de8-4c1d-8546-a3df9bee1e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3400509-7de8-4c1d-8546-a3df9bee1e75.jpg?1",
             "name": "Brothers of Fire",
             "text": "o1o\nRoo\nR Brothers of Fire deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "fcea2dcd-19f7-5281-8de1-462d1c3677f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb29b6b9-1674-483f-9912-0892e39ab106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb29b6b9-1674-483f-9912-0892e39ab106.jpg?1",
             "name": "Cave People",
             "text": "If Cave People attacks, it gets +1/-2 until end of turn.\no1o\nRo\nR, oc\nT: Target creature gains mountainwalk until end of turn. (If defending player controls any mountains, that creature is unblockable.)",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "b4112bbc-033f-5876-8af0-0260d1bbaff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29354d9a-6d92-4ddf-a485-33064d666a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29354d9a-6d92-4ddf-a485-33064d666a76.jpg?1",
             "name": "Conquer",
             "text": "Gain control of enchanted land.",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "a3628e43-f944-5ba6-8d7a-839860617052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6884be-9e7c-407b-9165-6a720a634bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6884be-9e7c-407b-9165-6a720a634bb5.jpg?1",
             "name": "Crimson Manticore",
             "text": "Flying\no\nR, oc\nT: Crimson Manticore deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "be8bdc9b-30ac-5a5c-bdbc-43a65f53255a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66b93c-1510-4063-b4b0-11fa1ea81c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66b93c-1510-4063-b4b0-11fa1ea81c6b.jpg?1",
             "name": "Detonate",
             "text": "Bury target artifact with total casting cost equal to X. Detonate deals X damage to that artifact's controller.",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "b5d9fd31-ba7b-5da6-825e-ec1de58f2c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1dce58-c0e5-472e-a575-b8d4b5958b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1dce58-c0e5-472e-a575-b8d4b5958b3a.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate deals X damage to target creature or player. That creature cannot regenerate this turn. If the creature is dealt lethal damage this turn, remove it from the game.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "cd6203a3-bdf8-58d6-af93-6146b75cb329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3617ce3-240f-4846-94d9-ea852c5b842a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3617ce3-240f-4846-94d9-ea852c5b842a.jpg?1",
             "name": "Dwarven Catapult",
             "text": "Dwarven Catapult deals X damage divided evenly, rounded down, among all creatures target opponent controls.",
             "colours": [
@@ -7354,7 +7354,7 @@
         },
         {
             "id": "97a49592-8a4c-5734-a18e-aa4cc56206c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7438382c-15a0-40b1-a17b-2ef7bd67866c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7438382c-15a0-40b1-a17b-2ef7bd67866c.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by any Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "5c7ab097-e203-580b-82da-7449ee2d38aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d217942b-1253-4d4b-b0d2-09fc4e15cc62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d217942b-1253-4d4b-b0d2-09fc4e15cc62.jpg?1",
             "name": "Dwarven Warriors",
             "text": "oc\nT: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -7422,7 +7422,7 @@
         },
         {
             "id": "8d9cdc86-3d58-5a9e-af43-9ec05e78cf7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bde909-899d-4efc-aac5-57b69fa764db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bde909-899d-4efc-aac5-57b69fa764db.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "d0267879-caf2-5e47-bf80-8c48cd348c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b97aa2-cda9-4683-ad5d-1f713bd0505c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b97aa2-cda9-4683-ad5d-1f713bd0505c.jpg?1",
             "name": "Errantry",
             "text": "Enchanted creature gets +3/+0 and cannot attack during any turn in which any other creatures attack.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "e55edefb-437a-562d-b4f0-31d26b572c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1a36ca-2467-4c23-ba03-744c76b0be51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1a36ca-2467-4c23-ba03-744c76b0be51.jpg?1",
             "name": "Eternal Warrior",
             "text": "Attacking does not cause enchanted creature to tap.",
             "colours": [
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "7dd231dc-2dbe-5ffb-9075-a4ae31c67dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94218b-26d7-40cd-aef7-0e2415d1551f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94218b-26d7-40cd-aef7-0e2415d1551f.jpg?1",
             "name": "Fire Drake",
             "text": "Flying\noo\nR +1/+0 until end of turn. You cannot spend more than o\nR in this way each turn.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "ed40c7a7-4f50-5e8d-b44f-f5b6776d46b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad457b10-6e00-411f-b827-ff844f9b300d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad457b10-6e00-411f-b827-ff844f9b300d.jpg?1",
             "name": "Fireball",
             "text": "Pay o1 for each target beyond the first: Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.",
             "colours": [
@@ -7583,7 +7583,7 @@
         },
         {
             "id": "2495e67f-83d0-52ff-b29f-a67ab9acf1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb793e74-cfed-4b1a-aaba-d67d2ab6f149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb793e74-cfed-4b1a-aaba-d67d2ab6f149.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "f524f67e-bf21-59fb-b6b6-d4a009c973d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e60702-1ca3-413a-a44e-22c8fc074b7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e60702-1ca3-413a-a44e-22c8fc074b7f.jpg?1",
             "name": "Flame Spirit",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "aa525fd1-ebcc-52f2-b10d-ba7d64b46b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc046c2-be9b-4f93-ac7d-e7dea6c4df9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc046c2-be9b-4f93-ac7d-e7dea6c4df9a.jpg?1",
             "name": "Flare",
             "text": "Flare deals 1 damage to target creature or player.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "09befe63-d21d-5c87-bc9a-4d4c69b6805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fafab5c-3ce7-41fc-a3e7-68e322566cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fafab5c-3ce7-41fc-a3e7-68e322566cfd.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "474c7984-32e9-51b7-83a8-447617b79954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b44933-6b0b-426a-97d4-7a7cf6ad1d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b44933-6b0b-426a-97d4-7a7cf6ad1d65.jpg?1",
             "name": "Game of Chaos",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. The loser of the flip loses 1 life. The winner of the flip gains 1 life and may choose to repeat the process. Double the stakes each time.",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "577ae165-cfb3-5a7b-b6fc-2c3d5f42292b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4aaab5-a202-4905-839b-ebf39b910082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4aaab5-a202-4905-839b-ebf39b910082.jpg?1",
             "name": "Game of Chaos",
             "text": "",
             "colours": [
@@ -7778,7 +7778,7 @@
         },
         {
             "id": "d93301cc-0df6-5df0-beef-800aaf0d1b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77caee7-b441-4458-bdc8-45fd1185380d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77caee7-b441-4458-bdc8-45fd1185380d.jpg?1",
             "name": "Giant Strength",
             "text": "Enchanted creature gets +2/+2.",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "37b96728-2787-5b92-af5f-ab42315e0b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3feb2-e94b-4d02-8179-63d0289dd7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb3feb2-e94b-4d02-8179-63d0289dd7d1.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT, Sacrifice Goblin Digging Team: Destroy target Wall.",
             "colours": [
@@ -7844,7 +7844,7 @@
         },
         {
             "id": "9564a162-e44c-503d-995b-a0f873554884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d21c8c9-6e16-4eb2-b2f5-3998f0f958ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d21c8c9-6e16-4eb2-b2f5-3998f0f958ae.jpg?1",
             "name": "Goblin Hero",
             "text": "",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "671b3464-7145-5409-92e7-d7b779a9cff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc72e1d3-f782-4b1c-9ea1-8e5b8566a187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc72e1d3-f782-4b1c-9ea1-8e5b8566a187.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and gain mountainwalk. (If defending player controls any mountains, these creatures are unblockable.)",
             "colours": [
@@ -7910,7 +7910,7 @@
         },
         {
             "id": "77928142-a521-5d73-8d34-91cdacccd177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b57d24a-1f2d-4227-a952-03abaecb19de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b57d24a-1f2d-4227-a952-03abaecb19de.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each creature you control cannot be blocked by only one creature.",
             "colours": [
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "78e06a6d-6f82-5c05-acea-231d4204dfc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218245-5e0f-4233-896a-00ec0cc34fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218245-5e0f-4233-896a-00ec0cc34fcc.jpg?1",
             "name": "Goblin Warrens",
             "text": "o2o\nR, Sacrifice two Goblins: Put three Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -7972,7 +7972,7 @@
         },
         {
             "id": "804de3d3-4e2a-5442-9324-180368413129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9d069-1163-46bd-9a71-21c05898330e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9d069-1163-46bd-9a71-21c05898330e.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "62ca630f-d114-5394-9d94-136f643b6e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb3745e-402f-47b6-9aaf-1d177d03cabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb3745e-402f-47b6-9aaf-1d177d03cabe.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -8038,7 +8038,7 @@
         },
         {
             "id": "335cbf2e-ab68-535e-acac-e62bce1845dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a256b0-e25b-43c6-9f7a-2ad76b268d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a256b0-e25b-43c6-9f7a-2ad76b268d22.jpg?1",
             "name": "Imposing Visage",
             "text": "Enchanted creature cannot be blocked by only one creature.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "e0df82de-4ada-57c8-af9a-1389f441681e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0f7e1f-bcb5-414f-a2e9-6a158fec2ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0f7e1f-bcb5-414f-a2e9-6a158fec2ff5.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. Creatures damaged by Incinerate cannot regenerate this turn.",
             "colours": [
@@ -8102,7 +8102,7 @@
         },
         {
             "id": "3005e937-8af8-50b4-8224-40d2cb968fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d04a75-647f-400f-b0dc-c4544f7db2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d04a75-647f-400f-b0dc-c4544f7db2d4.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and player.",
             "colours": [
@@ -8135,7 +8135,7 @@
         },
         {
             "id": "a64c5a3b-f77b-50d9-b01c-1735809a2fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2850e8-f135-4a51-905b-ae30b83913a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2850e8-f135-4a51-905b-ae30b83913a6.jpg?1",
             "name": "Inferno",
             "text": "",
             "colours": [
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "7915658f-76c0-5ffd-95fa-45ab9f30b976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed35d03-80fd-421d-a8be-6708a5570a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed35d03-80fd-421d-a8be-6708a5570a85.jpg?1",
             "name": "Ironclaw Curse",
             "text": "Enchanted creature gets -0/-1 and cannot be assigned to block any creature with power greater than or equal to enchanted creature's toughness.",
             "colours": [
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "dacd6e5e-bb13-5cd2-abce-2ba553c36840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346eef90-35c3-4153-a64a-55f4d7b232e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346eef90-35c3-4153-a64a-55f4d7b232e2.jpg?1",
             "name": "Ironclaw Curse",
             "text": "",
             "colours": [
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "46b4531e-9973-532a-bae0-6d5794312117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628a3506-352d-4d4f-b63e-05abb3ca906d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628a3506-352d-4d4f-b63e-05abb3ca906d.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Ironclaw Orcs cannot be assigned to block any creature with power 2 or greater.",
             "colours": [
@@ -8271,7 +8271,7 @@
         },
         {
             "id": "17f8379d-43b0-5e75-9dfc-33a013ba1c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d81e479-45b7-4237-a0eb-95245582e87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d81e479-45b7-4237-a0eb-95245582e87d.jpg?1",
             "name": "Jokulhaups",
             "text": "Bury all artifacts, creatures, and lands.",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "98ee29fe-4ca1-5da5-82fe-3fab617ad534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c67ccfa-e2ac-4abd-a55d-bd10d570220a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c67ccfa-e2ac-4abd-a55d-bd10d570220a.jpg?1",
             "name": "Keldon Warlord",
             "text": "Keldon Warlord has power and toughness each equal to the number of non-Wall creatures you control.",
             "colours": [
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "9336867f-e184-582b-9494-30b4be3a2800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2e818-a5a8-4b9b-93e8-121dd7fefe32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2e818-a5a8-4b9b-93e8-121dd7fefe32.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads at the same time.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "0e30faa3-c446-5328-be75-217a21dc7ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d9af72-1633-4433-83ce-7de806611448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d9af72-1633-4433-83ce-7de806611448.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever any player taps a land for mana, it produces one additional mana of the same type.",
             "colours": [
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "3e91e939-2fa7-53ec-bec7-4ee5911e3962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a2d1d-0964-44a9-9f32-09804f2c7445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a2d1d-0964-44a9-9f32-09804f2c7445.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever any player taps a land for mana, Manabarbs deals 1 damage to him or her.",
             "colours": [
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "4d8b1e13-856b-5961-880a-ebff6efabef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffef6ac8-a42c-4025-b4ef-3f772129b8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffef6ac8-a42c-4025-b4ef-3f772129b8f7.jpg?1",
             "name": "Manabarbs",
             "text": "",
             "colours": [
@@ -8464,7 +8464,7 @@
         },
         {
             "id": "37a37685-4a76-5860-af98-552c84644b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8324c5a9-d126-4510-90ac-c6b1424137d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8324c5a9-d126-4510-90ac-c6b1424137d9.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -8497,7 +8497,7 @@
         },
         {
             "id": "99b20b82-0cf6-5f45-baee-772dac71bd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbec9fe6-a951-48b2-a0d2-3cdf69b5400f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbec9fe6-a951-48b2-a0d2-3cdf69b5400f.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk (If defending player controls any mountains, this creature is unblockable.)",
             "colours": [
@@ -8530,7 +8530,7 @@
         },
         {
             "id": "177481a3-d5ef-5fab-9666-dcd245baec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ddc97b-b13e-4947-b4df-f35790b89f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ddc97b-b13e-4947-b4df-f35790b89f15.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -8564,7 +8564,7 @@
         },
         {
             "id": "a130c818-55da-5744-afff-db132eaa58c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d422f-101e-44f2-ab0d-7ad962c6d657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d422f-101e-44f2-ab0d-7ad962c6d657.jpg?1",
             "name": "Orcish Captain",
             "text": "o1: Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, target Orc gets +2/+0 until end of turn. Otherwise, that Orc gets -0/-2 until end of turn.",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "297ad706-71d2-53b2-9a8d-a30490370c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17025cde-28a1-4a38-ad5a-1ead518d77af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17025cde-28a1-4a38-ad5a-1ead518d77af.jpg?1",
             "name": "Orcish Conscripts",
             "text": "Orcish Conscripts cannot attack this turn unless at least two other creatures are attacking.\nOrcish Conscripts cannot be assigned to block this turn unless at least two other creatures are blocking.",
             "colours": [
@@ -8631,7 +8631,7 @@
         },
         {
             "id": "f6e04969-c164-5561-aed6-cd1219a669fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2bb2b4-87ff-4971-9835-fd68d913af26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2bb2b4-87ff-4971-9835-fd68d913af26.jpg?1",
             "name": "Orcish Farmer",
             "text": "oc\nT: Target land is a swamp until its controller's next untap phase.",
             "colours": [
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "bc541992-8b32-5828-b41e-8a8e1e8dd507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00e95e-6bf1-445a-a46a-29aeb05bf9be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00e95e-6bf1-445a-a46a-29aeb05bf9be.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "3232e632-7a81-5efc-9eb3-ec8da500e5b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27af5-cb26-4f39-8648-193bb116e3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27af5-cb26-4f39-8648-193bb116e3d6.jpg?1",
             "name": "Orcish Squatters",
             "text": "o0: Gain control of target land defending player controls as long as you control Orcish Squatters. Orcish Squatters deals no combat damage this turn. Use this ability only if Orcish Squatters is attacking and unblocked and only once each turn.",
             "colours": [
@@ -8728,7 +8728,7 @@
         },
         {
             "id": "12dca2b9-a9a2-57b7-97d2-4e1234e1d1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7eef087-8500-4fca-a10a-ff65d348bcb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7eef087-8500-4fca-a10a-ff65d348bcb1.jpg?1",
             "name": "Orgg",
             "text": "Trample\nOrgg cannot attack if defending player controls an untapped creature with power 3 or greater.\nOrgg cannot be assigned to block any creature with power 3 or greater.",
             "colours": [
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "39f19bad-56cd-5f48-9c5e-226c34020d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a86ee4-200e-4994-bd6f-0c1d3227ce5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a86ee4-200e-4994-bd6f-0c1d3227ce5b.jpg?1",
             "name": "Panic",
             "text": "Play only during combat before blockers are declared.\nTarget creature cannot be assigned to block this turn.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -8792,7 +8792,7 @@
         },
         {
             "id": "bfc4b035-59d1-56bf-a0d3-54e1bbfd9b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d8d6d-b8d3-4f71-a88a-5d639ce2925f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d8d6d-b8d3-4f71-a88a-5d639ce2925f.jpg?1",
             "name": "Primordial Ooze",
             "text": "Primordial Ooze attacks each turn if able.\nDuring your upkeep, put a +1/+1 counter on Primordial Ooze. Then pay o\nX, where X is equal to the number of these counters on Primordial Ooze, or tap Primordial Ooze and it deals X damage to you.",
             "colours": [
@@ -8825,7 +8825,7 @@
         },
         {
             "id": "f338e36e-fc5e-5a76-b76d-a2dfbbd6660f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2d7cd-d29d-4f19-8490-88bd526ff1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2d7cd-d29d-4f19-8490-88bd526ff1c5.jpg?1",
             "name": "Pyroblast",
             "text": "Counter target spell if it is blue, or destroy target permanent if it is blue. (If this spell targets a permanent, play it as an instant.)",
             "colours": [
@@ -8856,7 +8856,7 @@
         },
         {
             "id": "ebc667f9-be9b-5ec3-bd5f-d1fb88933662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e9f71f-cb85-4b57-9bb3-fe98ed4a524e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e9f71f-cb85-4b57-9bb3-fe98ed4a524e.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -8887,7 +8887,7 @@
         },
         {
             "id": "ab6ed27e-8bc8-5ebb-b333-27f624a04291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb936214-df72-4d77-b8f7-879c2b4e31d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb936214-df72-4d77-b8f7-879c2b4e31d7.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "b9b60853-248c-5bd7-a1ce-9ae8f3b694d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1edce4-0550-4683-a4d6-5dff6b9f0122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1edce4-0550-4683-a4d6-5dff6b9f0122.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -8951,7 +8951,7 @@
         },
         {
             "id": "ddd47129-c3ac-531d-87ae-0a58ea9c5ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d38e6-b659-4fcb-8192-797bb61e7700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d38e6-b659-4fcb-8192-797bb61e7700.jpg?1",
             "name": "Shatterstorm",
             "text": "Bury all artifacts.",
             "colours": [
@@ -8982,7 +8982,7 @@
         },
         {
             "id": "7a24a4dd-a3e5-5b06-b133-ad4fd6293eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b05edd-4128-4150-9457-8aff895bd0b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b05edd-4128-4150-9457-8aff895bd0b7.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\noo\nR +1/+0 until end of turn",
             "colours": [
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "2f118c2e-da99-54a6-894b-5c948d74b0f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97e7318-f916-4556-9f89-dda7914359c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97e7318-f916-4556-9f89-dda7914359c1.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -9052,7 +9052,7 @@
         },
         {
             "id": "8af58c14-650d-5821-8123-0251ca64425b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4710dd0-2797-40dd-8a24-bdd3da112c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4710dd0-2797-40dd-8a24-bdd3da112c39.jpg?1",
             "name": "Smoke",
             "text": "Players cannot untap more than one creature during their untap phases.",
             "colours": [
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "c052a640-ef6a-5378-bd3c-0edd3470bcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f736379-1fe8-43b8-b749-f1e9baef96a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f736379-1fe8-43b8-b749-f1e9baef96a6.jpg?1",
             "name": "Stone Giant",
             "text": "oc\nT: Target creature you control with toughness less than Stone Giant's power gains flying until end of turn. At end of turn, destroy that creature.",
             "colours": [
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "1a07170d-08bb-5a2a-bebf-34fcd7b402e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5935ef-8cc5-4587-b8eb-f6a2b2856260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5935ef-8cc5-4587-b8eb-f6a2b2856260.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -9147,7 +9147,7 @@
         },
         {
             "id": "4f947827-c670-5b49-8abf-aec77fb048a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c927b-1258-4758-bbff-10cc032587a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c927b-1258-4758-bbff-10cc032587a2.jpg?1",
             "name": "Stone Spirit",
             "text": "Stone Spirit cannot be blocked by creatures with flying.",
             "colours": [
@@ -9181,7 +9181,7 @@
         },
         {
             "id": "8670c8c3-b5b1-5597-a69c-1751132d717b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ded8fa-facf-4196-8964-56ebc6424be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ded8fa-facf-4196-8964-56ebc6424be1.jpg?1",
             "name": "The Brute",
             "text": "Enchanted creature gets +1/+0.\no\nRo\nRoo\nR Regenerate enchanted creature.",
             "colours": [
@@ -9214,7 +9214,7 @@
         },
         {
             "id": "b55111fc-522b-5041-9d65-f79dca7cf353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debc9415-ae75-4514-9d5d-b1b403420d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debc9415-ae75-4514-9d5d-b1b403420d1d.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "5fba64ae-d3cc-5cc8-b341-ac732223153b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47e4f33-3eb5-4aac-acb4-74ff60558db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47e4f33-3eb5-4aac-acb4-74ff60558db7.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "c8ac7c35-46b2-591e-ad41-aaa1fc078f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38712e4f-aabd-40b3-b41f-b034e032a729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38712e4f-aabd-40b3-b41f-b034e032a729.jpg?1",
             "name": "Winds of Change",
             "text": "Each player shuffles his or her hand into his or her library, then draws a new hand of as many cards as he or she had before.",
             "colours": [
@@ -9311,7 +9311,7 @@
         },
         {
             "id": "44cc384b-384e-515d-aa13-40bf7e2bf96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dc1c22-ef39-4f5f-a8af-4267a3d5db6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dc1c22-ef39-4f5f-a8af-4267a3d5db6f.jpg?1",
             "name": "Word of Blasting",
             "text": "Bury target Wall. Word of Blasting deals to that Wall's controller an amount of damage equal to the Wall's total casting cost.",
             "colours": [
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "541286ec-358b-5383-96d8-a70d63b61632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5955eb2b-31a2-4e1e-bbbe-82eb53def698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5955eb2b-31a2-4e1e-bbbe-82eb53def698.jpg?1",
             "name": "An-Havva Constable",
             "text": "An-Havva Constable has toughness equal to 1 plus the number of green creatures in play.",
             "colours": [
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "5cf1ef5b-e3ea-510c-a2d3-ffca0c2195f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38af8356-2d7f-4699-9e57-08906c1c831b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38af8356-2d7f-4699-9e57-08906c1c831b.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Enchanted creature gets +*/+*, where * is equal to half the number of forests you control, rounded down for power and up for toughness.",
             "colours": [
@@ -9408,7 +9408,7 @@
         },
         {
             "id": "6d27eabf-6f22-5161-98e5-7ce54caa859b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd473981-a62c-480f-aeae-0218f3e07fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd473981-a62c-480f-aeae-0218f3e07fa6.jpg?1",
             "name": "Aurochs",
             "text": "Trample\nIf Aurochs attacks, it gets +1/+0 until end of turn for each other Aurochs that attacks.",
             "colours": [
@@ -9441,7 +9441,7 @@
         },
         {
             "id": "dc05274d-da81-59c3-8361-72c973503bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79357f4-ddd1-4b29-9e5f-813c799513ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79357f4-ddd1-4b29-9e5f-813c799513ee.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -9474,7 +9474,7 @@
         },
         {
             "id": "e8ea438b-f1e6-5af9-a696-0bc7b4bbcee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22891f6c-7365-4baf-ae5a-49380be50895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22891f6c-7365-4baf-ae5a-49380be50895.jpg?1",
             "name": "Carapace",
             "text": "Enchanted creature gets +0/+2.\nSacrifice Carapace: Regenerate enchanted creature.",
             "colours": [
@@ -9507,7 +9507,7 @@
         },
         {
             "id": "965d04c8-d5ae-5f25-8a58-7b13dbbb04c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0180bd6-f8eb-4cf7-b6d0-acb513076e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0180bd6-f8eb-4cf7-b6d0-acb513076e00.jpg?1",
             "name": "Cat Warriors",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)",
             "colours": [
@@ -9541,7 +9541,7 @@
         },
         {
             "id": "5af44039-cc59-5e78-ab83-251319769282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d977294-051a-4e6d-b2ba-c04494474aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d977294-051a-4e6d-b2ba-c04494474aac.jpg?1",
             "name": "Chub Toad",
             "text": "If Chub Toad blocks or is blocked, it gets +2/+2 until end of turn.",
             "colours": [
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "bc2ca0c8-d617-58f1-ada1-39bfaa7b114f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853d15cd-a1a2-47a8-89c4-81b7ca663fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853d15cd-a1a2-47a8-89c4-81b7ca663fff.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nIf Cockatrice blocks or is blocked by any non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -9607,7 +9607,7 @@
         },
         {
             "id": "02f97c49-df7c-5d75-a300-ec32cb8968d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06274d3b-8feb-4c68-adbc-b1ee633c3353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06274d3b-8feb-4c68-adbc-b1ee633c3353.jpg?1",
             "name": "Craw Giant",
             "text": "Trample; rampage 2 (For each creature assigned to block it beyond the first, this creature gets +2/+2 until end of turn.)",
             "colours": [
@@ -9640,7 +9640,7 @@
         },
         {
             "id": "d6096cdb-63d6-540e-9a14-955d22d5f87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e6afb-7094-4fa3-9246-58343f8d80b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2e6afb-7094-4fa3-9246-58343f8d80b8.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -9673,7 +9673,7 @@
         },
         {
             "id": "f7fc1872-08b1-5ace-af9c-45adbec50378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c781ee-7ffb-4dd3-ac84-4d6fe4649591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c781ee-7ffb-4dd3-ac84-4d6fe4649591.jpg?1",
             "name": "Crumble",
             "text": "Bury target artifact. That artifact's controller gains an amount of life equal to its total casting cost.",
             "colours": [
@@ -9704,7 +9704,7 @@
         },
         {
             "id": "d6cf5547-7519-5029-b29c-db4110794f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15dc6a9-f288-414a-9052-f03846176bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15dc6a9-f288-414a-9052-f03846176bff.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy target permanent.",
             "colours": [
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "b9ff1479-3dec-5e7f-8ac1-d34a817420a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68418099-c199-428a-b4aa-db54909efd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68418099-c199-428a-b4aa-db54909efd0d.jpg?1",
             "name": "Durkwood Boars",
             "text": "",
             "colours": [
@@ -9768,7 +9768,7 @@
         },
         {
             "id": "d89147f9-31df-5203-a708-0e66ec1f3122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2151c8f2-c031-4c96-a420-ff2108df7ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2151c8f2-c031-4c96-a420-ff2108df7ad8.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG, oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -9803,7 +9803,7 @@
         },
         {
             "id": "9876593c-922c-5ecb-8997-5842ac8f505d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb6c97-b972-4c78-ba95-6053f2466f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb6c97-b972-4c78-ba95-6053f2466f20.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders cannot be blocked except by Walls or creatures with flying.",
             "colours": [
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "0066bb60-6063-5f45-92cc-aa33933d32dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92d92c-a9c7-40c5-82f3-dbd19697f999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd92d92c-a9c7-40c5-82f3-dbd19697f999.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "c6c243ad-90ef-5506-90e3-34a36e091864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82954c1c-8c58-48bf-aefe-e7ec5108a124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82954c1c-8c58-48bf-aefe-e7ec5108a124.jpg?1",
             "name": "Fog",
             "text": "Creatures deal no combat damage this turn.",
             "colours": [
@@ -9901,7 +9901,7 @@
         },
         {
             "id": "6cfc95f5-8b69-54af-a693-e450e731b909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86f61bb-c2b5-4672-b262-1c72bd1de51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86f61bb-c2b5-4672-b262-1c72bd1de51f.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nDuring your upkeep, pay o\nGo\nGo\nGo\nG or Force of Nature deals 8 damage to you.",
             "colours": [
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "7fa802b9-bb7d-5d98-bc83-42ea71bf94be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1638c4-effb-460b-af5d-aa17559dbd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1638c4-effb-460b-af5d-aa17559dbd37.jpg?1",
             "name": "Foxfire",
             "text": "Untap target attacking creature. That creature neither deals nor receives combat damage this turn.\nDraw a card at the beginning of the next turn.",
             "colours": [
@@ -9965,7 +9965,7 @@
         },
         {
             "id": "b2606216-cdbe-574d-ae3c-2d60fd47c151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f6f2bd-4e0e-42d8-b5a6-ad4ee736c69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f6f2bd-4e0e-42d8-b5a6-ad4ee736c69e.jpg?1",
             "name": "Fungusaur",
             "text": "At the end of any turn in which Fungusaur was damaged, put a +1/+1 counter on it.",
             "colours": [
@@ -9999,7 +9999,7 @@
         },
         {
             "id": "0af9c9ae-3db7-5d47-a10d-25dd2b0ef845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8532a8-966e-4cba-b3a5-99cfb0ee1220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8532a8-966e-4cba-b3a5-99cfb0ee1220.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "69156217-5138-5e84-b58b-fe34d9e580fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa6c0d6-aa18-4c32-a641-1ec8e50a26f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa6c0d6-aa18-4c32-a641-1ec8e50a26f3.jpg?1",
             "name": "Ghazb\u00e1n Ogre",
             "text": "During your upkeep, if a player has more life than any other, he or she gains control of Ghazb\u00e1n Ogre.",
             "colours": [
@@ -10066,7 +10066,7 @@
         },
         {
             "id": "87da33ec-5e4c-535e-90c1-1a79f0577bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07aee96b-1cf3-4cd9-9998-39ab16170c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07aee96b-1cf3-4cd9-9998-39ab16170c6b.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -10097,7 +10097,7 @@
         },
         {
             "id": "b4af0d0f-aa1b-523e-8e34-cfb6495a05bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953cf3be-b975-4a10-8c92-c783c727dcfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953cf3be-b975-4a10-8c92-c783c727dcfa.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can block creatures with flying.",
             "colours": [
@@ -10130,7 +10130,7 @@
         },
         {
             "id": "7b3ef7fa-30ce-527c-b74e-1d375404e42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8ad43-adea-47e8-9d9e-e14c2ad41489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8ad43-adea-47e8-9d9e-e14c2ad41489.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -10163,7 +10163,7 @@
         },
         {
             "id": "c9bc22af-de54-5e2e-a7b7-3b1067851796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ba2bff-08e6-4413-929b-80e13f193b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ba2bff-08e6-4413-929b-80e13f193b1e.jpg?1",
             "name": "Hungry Mist",
             "text": "During your upkeep, pay o\nGo\nG or bury Hungry Mist.",
             "colours": [
@@ -10196,7 +10196,7 @@
         },
         {
             "id": "6f4c4c11-b7df-5574-9241-aff8b68ad717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa0de8c-a23f-49d2-ac16-91c0d1eb17a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa0de8c-a23f-49d2-ac16-91c0d1eb17a6.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -10227,7 +10227,7 @@
         },
         {
             "id": "b4b1cd2e-1ff2-564d-aecc-a062a684d2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9b2cc-b362-4488-93ef-e98398ff73ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9b2cc-b362-4488-93ef-e98398ff73ea.jpg?1",
             "name": "Instill Energy",
             "text": "Enchanted creature is unaffected by summoning sickness.\no0: Untap enchanted creature. Use this ability only during your turn and only once each turn.",
             "colours": [
@@ -10260,7 +10260,7 @@
         },
         {
             "id": "6a089758-dc05-55f9-8f5b-4c1c83da1155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdbba38-b4c9-4c14-b869-669b39390e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdbba38-b4c9-4c14-b869-669b39390e4e.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -10293,7 +10293,7 @@
         },
         {
             "id": "3ffbda4e-59b4-5aa3-9c64-e35ead017a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca51ce-e0f4-42ce-b2a5-db73268bcf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca51ce-e0f4-42ce-b2a5-db73268bcf1f.jpg?1",
             "name": "Johtull Wurm",
             "text": "For each creature assigned to block it beyond the first, Johtull Wurm gets -2/-1 until end of turn.",
             "colours": [
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "fb85a79b-ec7a-50c2-9ea6-b330d69cbcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a749837-56ff-4e42-9bf2-82633bccdc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a749837-56ff-4e42-9bf2-82633bccdc39.jpg?1",
             "name": "Killer Bees",
             "text": "Flying\noo\nG +1/+1 until end of turn",
             "colours": [
@@ -10359,7 +10359,7 @@
         },
         {
             "id": "b7c7169c-223b-5adc-826a-2743d208752e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acc4f93-1bf1-4b00-b0e0-d44c2b2cd079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acc4f93-1bf1-4b00-b0e0-d44c2b2cd079.jpg?1",
             "name": "Ley Druid",
             "text": "oc\nT: Untap target land.",
             "colours": [
@@ -10393,7 +10393,7 @@
         },
         {
             "id": "17cdc1c7-b984-5372-824d-eae20cdaf076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fadc2d27-0c6c-4f68-bee0-0af6688f304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fadc2d27-0c6c-4f68-bee0-0af6688f304d.jpg?1",
             "name": "Lhurgoyf",
             "text": "Lhurgoyf has power equal to the number of creature cards in all graveyards and toughness equal to 1 plus the number of creature cards in all graveyards.",
             "colours": [
@@ -10426,7 +10426,7 @@
         },
         {
             "id": "3cfd89a3-9585-5dea-9a51-71f249830bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1681fa-2edc-4c0c-b5ca-f7f2602a3467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1681fa-2edc-4c0c-b5ca-f7f2602a3467.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Counter target black spell. Play this ability as an interrupt.",
             "colours": [
@@ -10457,7 +10457,7 @@
         },
         {
             "id": "e0daff8d-98c5-5028-bb55-0989aedc8ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af097b1-9eae-4bd6-8ee6-582cae57e970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af097b1-9eae-4bd6-8ee6-582cae57e970.jpg?1",
             "name": "Living Artifact",
             "text": "For each 1 damage dealt to you, put a vitality counter on Living Artifact.\nRemove a vitality counter from Living Artifact: Gain 1 life. Use this ability only during your upkeep and only once each turn.",
             "colours": [
@@ -10490,7 +10490,7 @@
         },
         {
             "id": "89bad8f3-36dd-5dc2-ac20-effd36c31a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9a2294-dd5b-4658-9f79-334a51b03ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9a2294-dd5b-4658-9f79-334a51b03ea3.jpg?1",
             "name": "Living Lands",
             "text": "All forests are 1/1 creatures. (These creatures still count as lands.)",
             "colours": [
@@ -10521,7 +10521,7 @@
         },
         {
             "id": "1b769898-d759-547b-b0e4-e934e4d14859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632b9428-45c6-4b81-a701-f1c7d7e8d2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632b9428-45c6-4b81-a701-f1c7d7e8d2f0.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -10555,7 +10555,7 @@
         },
         {
             "id": "3eb8df0a-4ce8-5dc6-9ee7-ab9f179fadd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380e07a-9d5c-4579-93f5-4cf52d90897d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380e07a-9d5c-4579-93f5-4cf52d90897d.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -10588,7 +10588,7 @@
         },
         {
             "id": "a9de76d7-c287-5f81-8062-f4621673fe27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4c0606-f9af-4dee-bc36-5051395b5f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4c0606-f9af-4dee-bc36-5051395b5f44.jpg?1",
             "name": "Marsh Viper",
             "text": "If Marsh Viper damages any player, he or she gets two poison counters. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "de86b3f2-a93f-5edf-8482-eabeb90cbd34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4ffc1-7731-42d9-b970-2a8d84cba14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4ffc1-7731-42d9-b970-2a8d84cba14d.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a forest card and put that card into play. Shuffle your library afterwards.",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "87d7ddfa-0a9b-5eaf-8731-0f186c301d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee195a-c331-4918-ad9e-3877dd3f4e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee195a-c331-4918-ad9e-3877dd3f4e3a.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nG, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -10686,7 +10686,7 @@
         },
         {
             "id": "62890693-8189-502b-b19d-eb3904d5f8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b455a-417a-4490-8495-bda9441306c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b455a-417a-4490-8495-bda9441306c8.jpg?1",
             "name": "Primal Order",
             "text": "During each player's upkeep, Primal Order deals to that player an amount of damage equal to the number of nonbasic lands he or she controls.",
             "colours": [
@@ -10717,7 +10717,7 @@
         },
         {
             "id": "210fa277-6acc-58ad-953f-1c498194c6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dbfeb2-76ac-48b2-99fb-fa4bcc59b2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dbfeb2-76ac-48b2-99fb-fa4bcc59b2a5.jpg?1",
             "name": "Rabid Wombat",
             "text": "Attacking does not cause Rabid Wombat to tap.\nRabid Wombat gets +2/+2 for each creature enchantment on it.",
             "colours": [
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "9925ce80-e5d5-5c08-a3fe-afccd2c84674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf02a10-86ba-4c2d-adc5-e4a2b7cc089e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf02a10-86ba-4c2d-adc5-e4a2b7cc089e.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying until end of turn.",
             "colours": [
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "53119a31-f307-51f0-8d18-f4fbfe6f34b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd0d1d-9422-4941-9491-8a8d64909f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd0d1d-9422-4941-9491-8a8d64909f8e.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "0d648789-a2c5-5303-bcff-a2e0fba101e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad1b3a-3464-4080-819b-a62bf6c23a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad1b3a-3464-4080-819b-a62bf6c23a13.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "814ba42f-59a7-5bc5-815a-17668dec176a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d1549-d0d5-48f8-9d8a-2e2940523307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d1549-d0d5-48f8-9d8a-2e2940523307.jpg?1",
             "name": "Scavenger Folk",
             "text": "o\nG, oc\nT, Sacrifice Scavenger Folk: Destroy target artifact.",
             "colours": [
@@ -10882,7 +10882,7 @@
         },
         {
             "id": "433501ef-d8f9-5378-af63-6a5cbef13a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab52f491-26f1-494f-8ec7-9630c4f9653a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab52f491-26f1-494f-8ec7-9630c4f9653a.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -10915,7 +10915,7 @@
         },
         {
             "id": "078c45d3-46da-52e2-822f-30681e5daa20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34163ceb-5c7a-4a3b-9290-bc4f22e0259d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34163ceb-5c7a-4a3b-9290-bc4f22e0259d.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)",
             "colours": [
@@ -10949,7 +10949,7 @@
         },
         {
             "id": "a26f9817-49d7-5eb0-ad7b-541af34f05a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f96537-76d2-4887-b17f-b8297fa50fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f96537-76d2-4887-b17f-b8297fa50fd5.jpg?1",
             "name": "Shrink",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -10980,7 +10980,7 @@
         },
         {
             "id": "8d987691-d2da-50d9-9945-7ccd65e6f570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcec8997-bc9b-42c0-bac1-5644e9915fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcec8997-bc9b-42c0-bac1-5644e9915fa2.jpg?1",
             "name": "Stampede",
             "text": "All attacking creatures get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -11011,7 +11011,7 @@
         },
         {
             "id": "a2b0ea45-d4af-50e8-8c9b-9e127812e7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738e9ec1-a186-44ad-8a68-d5cc183ccdc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738e9ec1-a186-44ad-8a68-d5cc183ccdc0.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "1130f1d1-e413-5cda-8b87-c08122db60a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b337de-4c43-45b6-a0ca-262a983f3589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b337de-4c43-45b6-a0ca-262a983f3589.jpg?1",
             "name": "Sylvan Library",
             "text": "o0: Draw two cards, then choose any two cards in your hand drawn this turn. For each of those cards, pay 4 life or put that card back on top of your library. Use this ability only during your draw phase and only once each turn.",
             "colours": [
@@ -11073,7 +11073,7 @@
         },
         {
             "id": "157f3b6e-c9bf-548d-910b-edf58c3955ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2160d57-9ebf-43fb-811f-0c014e417ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2160d57-9ebf-43fb-811f-0c014e417ea0.jpg?1",
             "name": "Tarpan",
             "text": "If Tarpan is put into any graveyard from play, gain 1 life.",
             "colours": [
@@ -11106,7 +11106,7 @@
         },
         {
             "id": "26305603-189c-5176-b823-2dabbd2c8505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511d4bc3-05ea-48f3-b182-dd0cd049ce54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511d4bc3-05ea-48f3-b182-dd0cd049ce54.jpg?1",
             "name": "Thicket Basilisk",
             "text": "If Thicket Basilisk blocks or is blocked by any non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -11139,7 +11139,7 @@
         },
         {
             "id": "48a960f0-146f-5835-84dd-1823cf4183ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837f0c8-4822-41f1-8677-988c13efe8d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837f0c8-4822-41f1-8677-988c13efe8d5.jpg?1",
             "name": "Titania's Song",
             "text": "Each noncreature artifact loses its abilities and is an artifact creature with power and toughness each equal to its total casting cost. If Titania's Song leaves play, this effect continues until end of turn.",
             "colours": [
@@ -11170,7 +11170,7 @@
         },
         {
             "id": "b8548b80-9f1f-59b5-ae0f-e76c5947ca22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f8bd4a-ec7f-4da5-bd39-cba29541ee83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f8bd4a-ec7f-4da5-bd39-cba29541ee83.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -11201,7 +11201,7 @@
         },
         {
             "id": "05b53743-f748-5b7a-a1f8-a01877841b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab151ce-9468-4427-853b-4e0011d783fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab151ce-9468-4427-853b-4e0011d783fb.jpg?1",
             "name": "Tsunami",
             "text": "Destroy all islands.",
             "colours": [
@@ -11232,7 +11232,7 @@
         },
         {
             "id": "0f5db6fa-a305-5dde-9f15-889840e26d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979f6606-a4d7-43e8-95fb-c4f06c16d1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979f6606-a4d7-43e8-95fb-c4f06c16d1b4.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a basic land card and put that card into play. Shuffle your library afterwards.",
             "colours": [
@@ -11263,7 +11263,7 @@
         },
         {
             "id": "860b734a-55e9-5621-87ac-1e4c52ef846f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb503ef-31a4-492d-9c7d-26b72c36904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb503ef-31a4-492d-9c7d-26b72c36904b.jpg?1",
             "name": "Venom",
             "text": "If enchanted creature blocks or is blocked by any non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "a808fbfd-aceb-5329-a718-1d6d04bab1be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5bf9e-db83-498d-bccc-9588f2fcb9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5bf9e-db83-498d-bccc-9588f2fcb9ff.jpg?1",
             "name": "Verduran Enchantress",
             "text": "o0: Draw a card. Use this ability only when you successfully cast an enchantment spell and only once for each such spell.",
             "colours": [
@@ -11330,7 +11330,7 @@
         },
         {
             "id": "a43ff381-dc0f-59b2-8323-b161c1876180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8780a20-8504-406e-aea1-722f146be5f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8780a20-8504-406e-aea1-722f146be5f7.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerate",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "81b68fd7-2d5e-5f3f-9b75-82decf9d546c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d93816b-cb5e-49b7-98bd-22de674c7873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d93816b-cb5e-49b7-98bd-22de674c7873.jpg?1",
             "name": "Wanderlust",
             "text": "During the upkeep of enchanted creature's controller, Wanderlust deals 1 damage to him or her.",
             "colours": [
@@ -11397,7 +11397,7 @@
         },
         {
             "id": "2c901cd4-4f79-5f60-8941-f9fe61b962e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38912a6-0327-411a-9499-d659b635e2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38912a6-0327-411a-9499-d659b635e2bd.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -11430,7 +11430,7 @@
         },
         {
             "id": "b41113b0-8562-5400-af12-94039ad5dc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51bfbd4-2319-41eb-b694-72874c24b31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51bfbd4-2319-41eb-b694-72874c24b31a.jpg?1",
             "name": "Whirling Dervish",
             "text": "Protection from black\nIf Whirling Dervish damages any opponent, put a +1/+1 counter on it at end of turn.",
             "colours": [
@@ -11464,7 +11464,7 @@
         },
         {
             "id": "6ead9616-23d3-543d-bd0f-8ea6d55fd0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6630-d57c-47fd-af0f-b2e2c2025599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6630-d57c-47fd-af0f-b2e2c2025599.jpg?1",
             "name": "Wild Growth",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional o\nG.",
             "colours": [
@@ -11497,7 +11497,7 @@
         },
         {
             "id": "9a97948a-0939-5c27-84bd-1b87cc7e3f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b01c34-faa9-43a3-a3dc-0f966e88e089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b01c34-faa9-43a3-a3dc-0f966e88e089.jpg?1",
             "name": "Winter Blast",
             "text": "Tap X target creatures. Winter Blast deals 2 damage to each of those creatures with flying.",
             "colours": [
@@ -11528,7 +11528,7 @@
         },
         {
             "id": "15e00628-0d7b-5398-ab90-66f54a4a7d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6d1e8-0985-4560-aea2-7ad1925a2f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6d1e8-0985-4560-aea2-7ad1925a2f5a.jpg?1",
             "name": "Wolverine Pack",
             "text": "Rampage 2 (For each creature assigned to block it beyond the first, this creature gets +2/+2 until end of turn.)",
             "colours": [
@@ -11561,7 +11561,7 @@
         },
         {
             "id": "ea10c52e-fc00-5168-be71-26fe96a0da8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d06d6b2-2eff-4fc5-99e1-c6bc585a4926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d06d6b2-2eff-4fc5-99e1-c6bc585a4926.jpg?1",
             "name": "Wyluli Wolf",
             "text": "oc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -11594,7 +11594,7 @@
         },
         {
             "id": "872cc4c3-e4e0-5173-986f-7f71cab31f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e4ed4-4470-4b3b-98cd-e4a8660b9768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e4ed4-4470-4b3b-98cd-e4a8660b9768.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -11621,7 +11621,7 @@
         },
         {
             "id": "aec9325a-c672-5b9b-9dca-c9ce606803d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50871a5f-ad52-470a-840a-2277f43ea47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50871a5f-ad52-470a-840a-2277f43ea47b.jpg?1",
             "name": "Amulet of Kroog",
             "text": "o2, oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [],
@@ -11648,7 +11648,7 @@
         },
         {
             "id": "9db7c01a-55c4-50af-bb53-714e0a3465b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d917dd-243e-4df2-9a44-1c2eae6ff859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d917dd-243e-4df2-9a44-1c2eae6ff859.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Whenever a land comes into play, Ankh of Mishra deals 2 damage to that land's controller.",
             "colours": [],
@@ -11675,7 +11675,7 @@
         },
         {
             "id": "72bec6ee-7912-554e-b066-07c64d80ed72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab611c3-3a24-4033-864f-084b71317320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab611c3-3a24-4033-864f-084b71317320.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add two colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -11702,7 +11702,7 @@
         },
         {
             "id": "500b4524-a2db-5091-8327-c1568323805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee48bcd6-afb5-4023-9417-ed3126bcc31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee48bcd6-afb5-4023-9417-ed3126bcc31d.jpg?1",
             "name": "Ashnod's Transmogrant",
             "text": "oc\nT, Sacrifice Ashnod's Transmogrant: Put a +1/+1 counter on target nonartifact creature. That creature becomes an artifact creature permanently.",
             "colours": [],
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "15957305-76b2-517d-8d01-8c2a9adc1dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9791ab-1cc4-41ad-a721-57f214c357f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9791ab-1cc4-41ad-a721-57f214c357f8.jpg?1",
             "name": "Barbed Sextant",
             "text": "o1, oc\nT, Sacrifice Barbed Sextant: Add one mana of any color to your mana pool. Play this ability as a mana source. Draw a card at the beginning of the next turn.",
             "colours": [],
@@ -11756,7 +11756,7 @@
         },
         {
             "id": "dba02447-186d-578e-abc7-10cd49da324b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce3e79-c729-4efd-a2f3-5d2910ba2c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce3e79-c729-4efd-a2f3-5d2910ba2c3f.jpg?1",
             "name": "Barl's Cage",
             "text": "o3: Target creature does not untap during its controller's next untap phase.",
             "colours": [],
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "c3b4cdb6-ad40-52d7-94bf-72e718d72326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e2857f-f6eb-4091-b758-7bb508544170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e2857f-f6eb-4091-b758-7bb508544170.jpg?1",
             "name": "Battering Ram",
             "text": "Banding when attacking\nIf Battering Ram is blocked by any Wall, destroy that Wall at end of combat.",
             "colours": [],
@@ -11813,7 +11813,7 @@
         },
         {
             "id": "65b3355a-230a-5fc2-801a-8968a3e45d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1de13cc-65b4-4a72-8a53-a05a46a40f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1de13cc-65b4-4a72-8a53-a05a46a40f61.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o1, Sacrifice Bottle of Suleiman: Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Bottle of Suleiman deals 5 damage to you. Otherwise, put a Djinn token into play. Treat this token as a 5/5 artifact creature with flying.",
             "colours": [],
@@ -11840,7 +11840,7 @@
         },
         {
             "id": "98f30e50-658e-5558-ae55-52177d1ac187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34727679-9c42-4577-80c3-88495aa0e96d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34727679-9c42-4577-80c3-88495aa0e96d.jpg?1",
             "name": "Clay Statue",
             "text": "o2: Regenerate",
             "colours": [],
@@ -11870,7 +11870,7 @@
         },
         {
             "id": "e4d8f88d-3f38-531b-97bd-9862e331f31c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5507d5-7f1b-4cbf-8341-495c33e5ab6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5507d5-7f1b-4cbf-8341-495c33e5ab6c.jpg?1",
             "name": "Clockwork Beast",
             "text": "When Clockwork Beast comes into play, put seven +1/+0 counters on it. At the end of any combat in which Clockwork Beast attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Beast. You may have no more than seven of of these counters on Clockwork Beast. Use this ability only during your upkeep.",
             "colours": [],
@@ -11900,7 +11900,7 @@
         },
         {
             "id": "507e0d40-7544-53b0-a66f-4fb094ff53d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d83b9-4454-40c0-bac0-de736c634a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d83b9-4454-40c0-bac0-de736c634a53.jpg?1",
             "name": "Clockwork Steed",
             "text": "Clockwork Steed cannot be blocked by artifact creatures.\nWhen Clockwork Steed comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Steed attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Steed. You may have no more than four of these counters on Clockwork Steed. Use this ability only during your upkeep.",
             "colours": [],
@@ -11930,7 +11930,7 @@
         },
         {
             "id": "60e0630f-ac63-57da-8b8c-eb4541c11355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f1ffdd-897e-4a1d-bdd2-d9de0de5d5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f1ffdd-897e-4a1d-bdd2-d9de0de5d5a2.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample\nColossus of Sardia does not untap during your untap phase.\no9: Untap Colossus of Sardia. Use this ability only during your upkeep.",
             "colours": [],
@@ -11960,7 +11960,7 @@
         },
         {
             "id": "03d781e9-44fc-5c90-b872-2d9dd789daff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3a79-d7e5-46e2-bd9f-209e67294f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3a79-d7e5-46e2-bd9f-209e67294f82.jpg?1",
             "name": "Coral Helm",
             "text": "o3, Discard a card at random: Target creature gets +2/+2 until end of turn.",
             "colours": [],
@@ -11987,7 +11987,7 @@
         },
         {
             "id": "1714c49a-28c4-5dad-a110-1e9c56e4df80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b549e5-c25d-4688-b362-faab109ba092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b549e5-c25d-4688-b362-faab109ba092.jpg?1",
             "name": "Crown of the Ages",
             "text": "o4, oc\nT: Move target enchantment from one creature to another. The enchantment's new target must be legal.",
             "colours": [],
@@ -12014,7 +12014,7 @@
         },
         {
             "id": "9144ee6a-cd46-5fb3-a801-730492fdb056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf1c7de-73b5-415b-897b-085ab5776932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf1c7de-73b5-415b-897b-085ab5776932.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Gain 1 life. Use this ability only when a blue spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -12041,7 +12041,7 @@
         },
         {
             "id": "a2b6a27b-72f4-52c4-9028-a99dc3fa5650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f3d92-171f-45e6-b159-b83faad7f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f3d92-171f-45e6-b159-b83faad7f7fd.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "34126198-4299-5d51-8d41-98bd9177c5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c76a433-4760-4ebb-ab0c-d69bba7d7ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c76a433-4760-4ebb-ab0c-d69bba7d7ca1.jpg?1",
             "name": "Diabolic Machine",
             "text": "o3: Regenerate",
             "colours": [],
@@ -12101,7 +12101,7 @@
         },
         {
             "id": "48c311c6-5f14-5b3f-8b02-7d1d1f5b9f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d1107-a18c-4e25-86c7-8e09cba72a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d1107-a18c-4e25-86c7-8e09cba72a12.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into any graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -12128,7 +12128,7 @@
         },
         {
             "id": "4ae6f8dc-bc1d-5f90-8d41-39c0b05785de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f2e80-f7af-4b9d-bb0f-3de14ddf0b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f2e80-f7af-4b9d-bb0f-3de14ddf0b02.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player chooses and discards a card. Use this ability only during your turn.",
             "colours": [],
@@ -12155,7 +12155,7 @@
         },
         {
             "id": "c7a4a479-78b7-52d4-be84-0a0483ac1248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f26891-e624-4aa9-ad04-6db3933a74e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f26891-e624-4aa9-ad04-6db3933a74e9.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: +1/+0 until end of turn",
             "colours": [],
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "0d2ee163-b0a7-5b93-aa3a-3691e84fa98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5b60a9-3041-4524-9a53-ab3a597c20ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5b60a9-3041-4524-9a53-ab3a597c20ac.jpg?1",
             "name": "Elkin Bottle",
             "text": "o3, oc\nT: Set the top card of your library aside face up. You may play that card as though it were in your hand. At the beginning of your next turn, bury the card if you have not played it.",
             "colours": [],
@@ -12212,7 +12212,7 @@
         },
         {
             "id": "4cfb3a9d-e420-5498-87a6-108f7760e5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030301c9-b576-43ba-b05a-a52904c92be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030301c9-b576-43ba-b05a-a52904c92be9.jpg?1",
             "name": "Feldon's Cane",
             "text": "oc\nT, Remove Feldon's Cane from the game: Shuffle your graveyard into your library.",
             "colours": [],
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "deb654c3-3750-57a6-acb6-f1b8ecafebe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2716dacb-4fb7-4fa8-869d-22af82920564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2716dacb-4fb7-4fa8-869d-22af82920564.jpg?1",
             "name": "Fellwar Stone",
             "text": "oc\nT: Add to your mana pool one mana of any type that any opponent's lands can produce. Play this ability as a mana source.",
             "colours": [],
@@ -12266,7 +12266,7 @@
         },
         {
             "id": "07200afc-1406-5cc5-9fb2-a9e6fc9077f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5133a47c-bde3-49d5-ba44-196980ace436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5133a47c-bde3-49d5-ba44-196980ace436.jpg?1",
             "name": "Feroz's Ban",
             "text": "Summon spells cost an additional o2 to play.",
             "colours": [],
@@ -12293,7 +12293,7 @@
         },
         {
             "id": "a7eca833-c427-5b85-93f2-036e8e95efc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f33257-4539-4b33-86d5-26fedbc417b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f33257-4539-4b33-86d5-26fedbc417b1.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn. If that creature is put into any graveyard this turn, bury Flying Carpet.",
             "colours": [],
@@ -12320,7 +12320,7 @@
         },
         {
             "id": "b2e877b9-1cc0-5e54-b1d1-3397dd2eb78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726d567-ad74-4b77-bbd5-8a0902cdaf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726d567-ad74-4b77-bbd5-8a0902cdaf6a.jpg?1",
             "name": "Fountain of Youth",
             "text": "o2, oc\nT: Gain 1 life.",
             "colours": [],
@@ -12347,7 +12347,7 @@
         },
         {
             "id": "daeeceff-a93e-5e3f-bd50-d765a628a7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548045fe-5302-4295-9060-e85614bb9a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548045fe-5302-4295-9060-e85614bb9a91.jpg?1",
             "name": "Gauntlets of Chaos",
             "text": "o5, Sacrifice Gauntlets of Chaos: Exchange control of target artifact, creature, or land you control for control of target permanent of the same type that an opponent controls. Bury all enchantments played on those permanents.",
             "colours": [],
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "fa164117-fc2a-56f0-895f-8ebe4c6303e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a69e-1011-475b-b554-8cf5a25169f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a69e-1011-475b-b554-8cf5a25169f3.jpg?1",
             "name": "Glasses of Urza",
             "text": "oc\nT: Look at target player's hand.",
             "colours": [],
@@ -12401,7 +12401,7 @@
         },
         {
             "id": "0bf896a3-6d84-597b-b609-3c9f2a10aa71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0fe07-85b6-4179-859b-fbae74faab5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0fe07-85b6-4179-859b-fbae74faab5f.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "oc\nT: Grapeshot Catapult deals 1 damage to target creature with flying.",
             "colours": [],
@@ -12431,7 +12431,7 @@
         },
         {
             "id": "a697441f-a3b5-5139-b3fd-686369778986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9664a59d-182a-429b-a6f7-047b8b8e5ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9664a59d-182a-429b-a6f7-047b8b8e5ffe.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1, oc\nT: Target creature gains banding until end of turn.",
             "colours": [],
@@ -12458,7 +12458,7 @@
         },
         {
             "id": "9f48fda8-0e4c-5f6f-bb00-d819c0d7c563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a50b3bd-81b0-408d-ab73-9eadd2fb1eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a50b3bd-81b0-408d-ab73-9eadd2fb1eae.jpg?1",
             "name": "Howling Mine",
             "text": "During each player's draw phase, that player draws an additional card.",
             "colours": [],
@@ -12485,7 +12485,7 @@
         },
         {
             "id": "71883c8a-3143-59cf-b053-2dd16f74caae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbafc838-7458-4542-86f3-594326ec0691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbafc838-7458-4542-86f3-594326ec0691.jpg?1",
             "name": "Infinite Hourglass",
             "text": "During your upkeep, put a time counter on Infinite Hourglass.\nAll creatures get +X/+0, where X is equal to the number of time counters on Infinite Hourglass.\nAny player may pay o3 during any upkeep to remove a time counter from Infinite Hourglass.",
             "colours": [],
@@ -12512,7 +12512,7 @@
         },
         {
             "id": "94df0ad4-0745-5868-b383-c9994c23c827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcbaa97-49f8-41b4-8901-eb53f6c15faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dcbaa97-49f8-41b4-8901-eb53f6c15faf.jpg?1",
             "name": "Iron Star",
             "text": "o1: Gain 1 life. Use this ability only when a red spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -12539,7 +12539,7 @@
         },
         {
             "id": "36231740-4ec6-5859-bdee-e7f402f3ed99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8085b-4bed-4b0b-b05e-5237bb896d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8085b-4bed-4b0b-b05e-5237bb896d00.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Gain 1 life. Use this ability only when a white spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "0373d099-cbe4-5431-b0ec-21d2af46ad2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a8f00d-e813-4cb7-8d09-1edae560f287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a8f00d-e813-4cb7-8d09-1edae560f287.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: Redirect all damage from any creature to yourself.",
             "colours": [],
@@ -12593,7 +12593,7 @@
         },
         {
             "id": "7cf5a64c-4731-5338-bc41-0f23ee82c68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe15fc-420f-49fe-a7d8-84dd74964ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe15fc-420f-49fe-a7d8-84dd74964ce5.jpg?1",
             "name": "Jalum Tome",
             "text": "o2, oc\nT: Draw a card, then choose and discard a card.",
             "colours": [],
@@ -12620,7 +12620,7 @@
         },
         {
             "id": "b0de140e-d27f-55b8-be07-37dadc9ab9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a9b1d-4046-484c-add9-567b3303cc98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a9b1d-4046-484c-add9-567b3303cc98.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3, oc\nT: Untap target creature.",
             "colours": [],
@@ -12647,7 +12647,7 @@
         },
         {
             "id": "3a42ab48-e716-57f0-9716-86b19870f704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0736c836-d90b-440c-bb6f-4b2eeaaa3d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0736c836-d90b-440c-bb6f-4b2eeaaa3d73.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw a card.",
             "colours": [],
@@ -12674,7 +12674,7 @@
         },
         {
             "id": "5aad4dfe-13f0-565b-add3-d119285ce852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10f2619-e723-4402-ae4e-79d762004477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10f2619-e723-4402-ae4e-79d762004477.jpg?1",
             "name": "Jester's Cap",
             "text": "o2, oc\nT, Sacrifice Jester's Cap: Look through target player's library and remove any three of those cards from the game. Shuffle that library afterwards.",
             "colours": [],
@@ -12701,7 +12701,7 @@
         },
         {
             "id": "0bb27381-f2e8-5482-87bc-010b1e899ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7aa8e-5873-4e18-8adb-1523c01d4e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7aa8e-5873-4e18-8adb-1523c01d4e86.jpg?1",
             "name": "Joven's Tools",
             "text": "o4, oc\nT: Target creature cannot be blocked this turn except by Walls.",
             "colours": [],
@@ -12728,7 +12728,7 @@
         },
         {
             "id": "313d2830-beae-538a-bd87-95ba8004a66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe1d1ae-bcc0-4b0d-a60f-f5ed30184329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe1d1ae-bcc0-4b0d-a60f-f5ed30184329.jpg?1",
             "name": "Library of Leng",
             "text": "Skip your discard phase.\nWhenever a spell or effect forces you to discard a card, you may instead discard that card to the top of your library.",
             "colours": [],
@@ -12755,7 +12755,7 @@
         },
         {
             "id": "2612c63c-dc69-52d1-aae7-85ee8fae17bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e9fec4-1e0a-4206-ab2b-cc2543cba667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e9fec4-1e0a-4206-ab2b-cc2543cba667.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault does not untap during your untap phase.\nAt the end of your upkeep, if Mana Vault is tapped, it deals 1 damage to you.\no4: Untap Mana Vault at end of upkeep. Use this ability only during your upkeep.\noc\nT: Add three colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -12782,7 +12782,7 @@
         },
         {
             "id": "b7947d79-e758-51f3-a273-69868522aa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391d903-1370-4a3a-9919-7a07e580a26c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391d903-1370-4a3a-9919-7a07e580a26c.jpg?1",
             "name": "Meekstone",
             "text": "Creatures with power 3 or greater do not untap during their controllers' untap phases.",
             "colours": [],
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "dd3440ee-f90d-5ba2-8298-cf07ee96bd9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e0b9ff-cf4c-446a-b706-58e5c496599e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e0b9ff-cf4c-446a-b706-58e5c496599e.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Put the top two cards of target player's library into his or her graveyard.",
             "colours": [],
@@ -12836,7 +12836,7 @@
         },
         {
             "id": "adc19b3c-24c3-5606-9203-07ab8c2bf513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9652c405-17fb-4505-8470-8a2969c73b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9652c405-17fb-4505-8470-8a2969c73b6b.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk comes into play tapped.\no1, oc\nT: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -12863,7 +12863,7 @@
         },
         {
             "id": "acf97d3a-82c1-5512-b8e9-26927b432e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0672d1-1d47-42ea-b8b0-95c400b0f78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0672d1-1d47-42ea-b8b0-95c400b0f78e.jpg?1",
             "name": "Obelisk of Undoing",
             "text": "o6, oc\nT: Return target permanent you control and own to your hand.",
             "colours": [],
@@ -12890,7 +12890,7 @@
         },
         {
             "id": "fd0f4cf2-2145-53e1-9439-8f0fffd4b3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00427d72-b140-45eb-b2ec-2ac2dab16966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00427d72-b140-45eb-b2ec-2ac2dab16966.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -12920,7 +12920,7 @@
         },
         {
             "id": "32f47529-7dc8-5b9c-bad8-b37cd7fb916d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2334ac3-2a58-49ba-902e-98dbad51547b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2334ac3-2a58-49ba-902e-98dbad51547b.jpg?1",
             "name": "Pentagram of the Ages",
             "text": "o4, oc\nT: Prevent all damage to you from one source. Treat further damage from that source normally.",
             "colours": [],
@@ -12947,7 +12947,7 @@
         },
         {
             "id": "9c3002f4-f817-5c44-b6f8-1884405853e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f731f-78a6-444e-9a43-85446fa38f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f731f-78a6-444e-9a43-85446fa38f30.jpg?1",
             "name": "Primal Clay",
             "text": "When you play Primal Clay, choose one\u2014Primal Clay is a 2/2 artifact creature with flying; or Primal Clay is a 3/3 artifact creature; or Primal Clay is a 1/6 artifact creature that counts as a Wall.",
             "colours": [],
@@ -12977,7 +12977,7 @@
         },
         {
             "id": "31a5ef1a-df22-5df2-8f12-dab053ba1d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1589724f-bec2-43a9-824a-1e85020731a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1589724f-bec2-43a9-824a-1e85020731a4.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -13004,7 +13004,7 @@
         },
         {
             "id": "a923d9d8-5b5f-59aa-8b02-beb8c82df361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08f89d-2ce3-4686-a8bd-ed982280ae4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08f89d-2ce3-4686-a8bd-ed982280ae4d.jpg?1",
             "name": "Serpent Generator",
             "text": "o4, oc\nT: Put a Poison Snake token into play. Treat this token as a 1/1 artifact creature. If any Poison Snake damages any player, he or she gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [],
@@ -13031,7 +13031,7 @@
         },
         {
             "id": "9a040a5b-4d0f-59b6-bce6-7ceb53f8f97a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aca05e-87c0-4c50-af47-37c61c55934d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aca05e-87c0-4c50-af47-37c61c55934d.jpg?1",
             "name": "Shapeshifter",
             "text": "Shapeshifter has total power and toughness of 7, divided any way you choose, though neither can be more than 7.\nWhen you play Shapeshifter, choose its power and toughness.\nDuring your upkeep, choose Shapeshifter's power and toughness.",
             "colours": [],
@@ -13061,7 +13061,7 @@
         },
         {
             "id": "76d475fe-cd86-572e-b301-994a5c4f1c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6baa736-60c3-4192-a5d3-150c90c31847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6baa736-60c3-4192-a5d3-150c90c31847.jpg?1",
             "name": "Skull Catapult",
             "text": "o1, oc\nT, Sacrifice a creature: Skull Catapult deals 2 damage to target creature or player.",
             "colours": [],
@@ -13088,7 +13088,7 @@
         },
         {
             "id": "28759cc4-eb2e-5185-9bb5-d5e810d96078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d3dc9-4bd0-440e-9436-c565f500e126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d3dc9-4bd0-440e-9436-c565f500e126.jpg?1",
             "name": "Soul Net",
             "text": "o1: Gain 1 life. Use this ability only when a creature is put into any graveyard from play and only once for each such creature.",
             "colours": [],
@@ -13115,7 +13115,7 @@
         },
         {
             "id": "fadb23f6-0fd7-50ca-a1ae-0f5632dfe309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe0113-8ac4-4d89-8ed3-010ccb57f3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe0113-8ac4-4d89-8ed3-010ccb57f3f0.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "You may choose not to untap Tawnos's Weaponry during your untap phase.\no2, oc\nT: Target creature gets +1/+1 as long as Tawnos's Weaponry remains tapped.",
             "colours": [],
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "ee954eb9-fe49-5f88-a2b8-9202744738f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c72d8-cee1-4a67-a394-b7dfe89bbd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c72d8-cee1-4a67-a394-b7dfe89bbd2e.jpg?1",
             "name": "The Hive",
             "text": "o5, oc\nT: Put a Wasp token into play. Treat this token as a 1/1 artifact creature with flying.",
             "colours": [],
@@ -13169,7 +13169,7 @@
         },
         {
             "id": "5d4f07f5-f915-55b0-86c9-5d47191091ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631db179-e23c-4099-9214-5bd347e4aa9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631db179-e23c-4099-9214-5bd347e4aa9e.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Gain 1 life. Use this ability only when a black spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -13196,7 +13196,7 @@
         },
         {
             "id": "bdb963c1-3693-5363-8bd2-5d05260188ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b9a42-29a5-47f9-9c65-db9f3d432bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b9a42-29a5-47f9-9c65-db9f3d432bf5.jpg?1",
             "name": "Time Bomb",
             "text": "During your upkeep, put a time counter on Time Bomb.\no1, oc\nT, Sacrifice Time Bomb: Time Bomb deals to each creature and player an amount of damage equal to the number of time counters on Time Bomb.",
             "colours": [],
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "875b382a-70bc-5423-a19a-ac084478bae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bd9559-1a8f-47d0-af6b-d0681cae4060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bd9559-1a8f-47d0-af6b-d0681cae4060.jpg?1",
             "name": "Urza's Avenger",
             "text": "o0: -1/-1 and your choice of banding, flying, first strike, or trample until end of turn",
             "colours": [],
@@ -13253,7 +13253,7 @@
         },
         {
             "id": "4eff710e-528e-5471-b76d-d281fb8d3eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876c1811-990c-41ca-874f-fd0512b59d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876c1811-990c-41ca-874f-fd0512b59d06.jpg?1",
             "name": "Urza's Bauble",
             "text": "oc\nT, Sacrifice Urza's Bauble: Choose a card at random from target player's hand and look at that card. Draw a card at the beginning of the next turn.",
             "colours": [],
@@ -13280,7 +13280,7 @@
         },
         {
             "id": "0e716ba5-29e5-5a1b-9865-e55053348935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a116c9-2f80-4e76-b158-c23f101872db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a116c9-2f80-4e76-b158-c23f101872db.jpg?1",
             "name": "Wall of Spears",
             "text": "First strike\nWall of Spears counts as a Wall.",
             "colours": [],
@@ -13310,7 +13310,7 @@
         },
         {
             "id": "54cd66c1-1694-553e-9e88-f521c93b9c60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a674ec8-5531-4d06-aa57-929c6ac29238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a674ec8-5531-4d06-aa57-929c6ac29238.jpg?1",
             "name": "Winter Orb",
             "text": "Players cannot untap more than one land during their untap phases.",
             "colours": [],
@@ -13337,7 +13337,7 @@
         },
         {
             "id": "2668d2e2-7f38-501e-a550-3f431d193ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d05202-da8d-44b8-8a01-d8a16a2b1898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d05202-da8d-44b8-8a01-d8a16a2b1898.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Gain 1 life. Use this ability only when a green spell is successfully cast and only once for each such spell.",
             "colours": [],
@@ -13364,7 +13364,7 @@
         },
         {
             "id": "ac71cdac-6e55-59bb-812e-3cd022dfc371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1e5f1-4665-4afc-83e4-4968df72eb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1e5f1-4665-4afc-83e4-4968df72eb8f.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "d8f70200-5fe0-5d59-bfa4-b7956015c65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8913994-c3e7-4d9e-9409-a8409ce68442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8913994-c3e7-4d9e-9409-a8409ce68442.jpg?1",
             "name": "Bottomless Vault",
             "text": "Bottomless Vault comes into play tapped.\nYou may choose not to untap Bottomless Vault during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Bottomless Vault: Add an amount of o\nB equal to X to your mana pool.",
             "colours": [],
@@ -13423,7 +13423,7 @@
         },
         {
             "id": "d0b76583-6692-5235-9d55-099922a6706c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6793b15-37fb-495e-b5e2-22c1df4cdc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6793b15-37fb-495e-b5e2-22c1df4cdc05.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "565bf8b1-3d78-53dc-abac-a9d9ed2fdb0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56816a2d-4faa-4fbd-bf1a-35fa3e90ccf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56816a2d-4faa-4fbd-bf1a-35fa3e90ccf6.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -13480,7 +13480,7 @@
         },
         {
             "id": "cbc8c37f-a86d-5212-8eb5-2ede17d4f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cb55f0-f0e8-4644-8c19-54efe5854973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cb55f0-f0e8-4644-8c19-54efe5854973.jpg?1",
             "name": "Dwarven Hold",
             "text": "Dwarven Hold comes into play tapped.\nYou may choose not to untap Dwarven Hold during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Dwarven Hold: Add an amount of o\nR equal to X to your mana pool.",
             "colours": [],
@@ -13509,7 +13509,7 @@
         },
         {
             "id": "1aa8bd00-8840-5b6f-be19-6fc48e642250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fc9a8-cc3c-43a1-89dd-c9a8fa72bdc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048fc9a8-cc3c-43a1-89dd-c9a8fa72bdc6.jpg?1",
             "name": "Dwarven Ruins",
             "text": "Dwarven Ruins comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Dwarven Ruins: Add o\nRo\nR to your mana pool.",
             "colours": [],
@@ -13538,7 +13538,7 @@
         },
         {
             "id": "f316d004-4754-5e08-9b80-c149b50c7760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509266-2bd5-4958-a497-935e004cc20f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509266-2bd5-4958-a497-935e004cc20f.jpg?1",
             "name": "Ebon Stronghold",
             "text": "Ebon Stronghold comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Ebon Stronghold: Add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -13567,7 +13567,7 @@
         },
         {
             "id": "a27e5caf-482f-5936-a9a2-60df91b696be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a1d66-7694-4e12-a4d6-34ca36656db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a1d66-7694-4e12-a4d6-34ca36656db4.jpg?1",
             "name": "Havenwood Battleground",
             "text": "Havenwood Battleground comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Havenwood Battleground: Add o\nGo\nG to your mana pool.",
             "colours": [],
@@ -13596,7 +13596,7 @@
         },
         {
             "id": "3aa015f9-8a8f-580e-95e6-155d33d6e35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d30a4-a24e-4537-9230-bf6f57fbcd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d30a4-a24e-4537-9230-bf6f57fbcd98.jpg?1",
             "name": "Hollow Trees",
             "text": "Hollow Trees comes into play tapped.\nYou may choose not to untap Hollow Trees during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Hollow Trees: Add an amount of o\nG equal to X to your mana pool.",
             "colours": [],
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "75c73cea-ce88-5657-b569-bd4761715b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68c45d3-0f3c-4429-a93e-4ca70ea6b1a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68c45d3-0f3c-4429-a93e-4ca70ea6b1a4.jpg?1",
             "name": "Icatian Store",
             "text": "Icatian Store comes into play tapped.\nYou may choose not to untap Icatian Store during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Icatian Store: Add an amount of o\nW equal to X to your mana pool.",
             "colours": [],
@@ -13654,7 +13654,7 @@
         },
         {
             "id": "45afd269-d65f-5e3a-91b8-58c4d7ce816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550a334-f185-4f1f-8759-d320b154c62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550a334-f185-4f1f-8759-d320b154c62f.jpg?1",
             "name": "Ice Floe",
             "text": "You may choose not to untap Ice Floe during your untap phase.\noc\nT: Tap target creature without flying that is attacking you. As long as Ice Floe remains tapped, that creature does not untap during its controller's untap phase.",
             "colours": [],
@@ -13681,7 +13681,7 @@
         },
         {
             "id": "2569780a-88ef-5db2-a9bf-a19e959d9793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d59e6e-0154-4c89-a58f-521e3424581b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d59e6e-0154-4c89-a58f-521e3424581b.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -13711,7 +13711,7 @@
         },
         {
             "id": "627ecb97-37cf-539a-b7d8-641b0758aaae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ec8a0-5cde-4c24-b605-b5f53553d065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ec8a0-5cde-4c24-b605-b5f53553d065.jpg?1",
             "name": "Ruins of Trokair",
             "text": "Ruins of Trokair comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Ruins of Trokair: Add o\nWo\nW to your mana pool.",
             "colours": [],
@@ -13740,7 +13740,7 @@
         },
         {
             "id": "b9d6be32-2cd8-5460-856f-f14cd0a3beb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769de45-903f-4269-a100-9ceca1df26ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769de45-903f-4269-a100-9ceca1df26ac.jpg?1",
             "name": "Sand Silos",
             "text": "Sand Silos comes into play tapped.\nYou may choose not to untap Sand Silos during your untap phase and put a storage counter on it instead.\noc\nT, Remove X storage counters from Sand Silos: Add an amount of o\nU equal to X to your mana pool.",
             "colours": [],
@@ -13769,7 +13769,7 @@
         },
         {
             "id": "63221e47-a497-52bc-8a42-313b8c01a4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a2097d-5acb-46d5-ac07-021fa9da4026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a2097d-5acb-46d5-ac07-021fa9da4026.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -13799,7 +13799,7 @@
         },
         {
             "id": "7272c44b-4da5-540f-b86d-35555f9a6b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22744530-792f-4098-ad2f-fee1a02b04b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22744530-792f-4098-ad2f-fee1a02b04b1.jpg?1",
             "name": "Svyelunite Temple",
             "text": "Svyelunite Temple comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Svyelunite Temple: Add o\nUo\nU to your mana pool.",
             "colours": [],
@@ -13828,7 +13828,7 @@
         },
         {
             "id": "a1e7303e-2dc1-558a-a7a5-b0bde670d8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9efd79-1b1d-4e02-8922-0154ad20e4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9efd79-1b1d-4e02-8922-0154ad20e4d4.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -13858,7 +13858,7 @@
         },
         {
             "id": "53048d45-9a4e-5b8f-b50f-14682383c3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6c9f3e-6df7-459c-a1b0-d628f17bb7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6c9f3e-6df7-459c-a1b0-d628f17bb7a6.jpg?1",
             "name": "Urza's Mine",
             "text": "oc\nT: Add one colorless mana to your mana pool. If you control Urza's Mine, Urza's Power Plant, and Urza's Tower, add two colorless mana to your mana pool instead of one.",
             "colours": [],
@@ -13888,7 +13888,7 @@
         },
         {
             "id": "2479c9f0-b76d-5ee6-9902-3e1150375437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a294bd-e6f6-4b88-b34c-135aff907b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a294bd-e6f6-4b88-b34c-135aff907b17.jpg?1",
             "name": "Urza's Power Plant",
             "text": "oc\nT: Add one colorless mana to your mana pool. If you control Urza's Mine, Urza's Power Plant, and Urza's Tower, add two colorless mana to your mana pool instead of one.",
             "colours": [],
@@ -13918,7 +13918,7 @@
         },
         {
             "id": "15d47e68-e7ea-52ed-9496-111d3c5aa4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb66579-0840-4ec3-aa6a-731874662dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb66579-0840-4ec3-aa6a-731874662dbb.jpg?1",
             "name": "Urza's Tower",
             "text": "oc\nT: Add one colorless mana to your mana pool. If you control Urza's Mine, Urza's Power Plant, and Urza's Tower, add three colorless mana to your mana pool instead of one.",
             "colours": [],
@@ -13948,7 +13948,7 @@
         },
         {
             "id": "24e70c1e-f19e-5fe4-8841-127e98a57620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cab2ebd-6ab7-4273-bda3-d7dea81b52c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cab2ebd-6ab7-4273-bda3-d7dea81b52c3.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -13985,7 +13985,7 @@
         },
         {
             "id": "b5816194-2e99-5b34-877d-88ad27077d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600cc3f3-5400-40f4-99ff-8a4a905e79cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600cc3f3-5400-40f4-99ff-8a4a905e79cf.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -14022,7 +14022,7 @@
         },
         {
             "id": "80238632-b16e-5d17-a853-c2a4566fd911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38789fff-0207-4b38-9bfd-5464ab62a533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38789fff-0207-4b38-9bfd-5464ab62a533.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -14059,7 +14059,7 @@
         },
         {
             "id": "f97c670a-ab28-5385-a653-8d40ac06fbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1c6830-758e-4242-85f7-3f20b872272c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1c6830-758e-4242-85f7-3f20b872272c.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -14096,7 +14096,7 @@
         },
         {
             "id": "e3e9a356-3e13-5b99-9734-a8c604e390ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8820e22-44ee-4ccf-a1fb-f93d98b8b494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8820e22-44ee-4ccf-a1fb-f93d98b8b494.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "257e0275-21d2-539d-baf4-59fcafcc32f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbf2762-1e9c-4d7c-84d0-8561d9a41735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbf2762-1e9c-4d7c-84d0-8561d9a41735.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14170,7 +14170,7 @@
         },
         {
             "id": "d1df51c2-a741-5857-b23f-11af95a23118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09376cac-44bd-42c4-9c07-9e4d6c972a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09376cac-44bd-42c4-9c07-9e4d6c972a64.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "285dfc75-adfe-5dd0-9d4d-00d1541209f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1218e0-8c75-4f8e-b317-051ce84949a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1218e0-8c75-4f8e-b317-051ce84949a5.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "cbaaa977-9f8b-5830-ace1-8a6544297e7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc8f8cb-dc67-4549-be2f-f4d4057065a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc8f8cb-dc67-4549-be2f-f4d4057065a3.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14281,7 +14281,7 @@
         },
         {
             "id": "4cc4a59c-72da-58a1-8dd8-9b1f61a28d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df95545-fe5e-47a5-99d8-1776e02c5713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df95545-fe5e-47a5-99d8-1776e02c5713.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14318,7 +14318,7 @@
         },
         {
             "id": "dbedf2fb-aa81-5faa-8a14-ef675471cea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31228d3c-08e4-4042-a1a1-db8dff3177d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31228d3c-08e4-4042-a1a1-db8dff3177d9.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "90a0b880-196a-58c8-abe6-8b6b47552a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e09e49-1a87-4967-8557-6d331c48a563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e09e49-1a87-4967-8557-6d331c48a563.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -14392,7 +14392,7 @@
         },
         {
             "id": "6bbb66a9-013e-5a0e-b505-42e767fffec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b08a29-8b53-44c9-82a0-ac689c9feeb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b08a29-8b53-44c9-82a0-ac689c9feeb5.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14429,7 +14429,7 @@
         },
         {
             "id": "85a5f98c-6fe4-5dd1-a2f9-b73d75fe7e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0916a2-e2f1-42b5-9f2c-b6a18a605138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0916a2-e2f1-42b5-9f2c-b6a18a605138.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14466,7 +14466,7 @@
         },
         {
             "id": "4d20c1aa-1753-54bb-bde3-bd14b10ebccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5d88e-1699-4ce3-a4aa-3e8d1ef2bc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5d88e-1699-4ce3-a4aa-3e8d1ef2bc39.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14503,7 +14503,7 @@
         },
         {
             "id": "96e8547f-ea0f-5f18-a1ab-4fdf15f520e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dfeb23-204c-4e48-8a23-c69daf92340f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dfeb23-204c-4e48-8a23-c69daf92340f.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -14540,7 +14540,7 @@
         },
         {
             "id": "c95398e2-3f05-568c-b8c2-ade0c5ecb4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04eb20ea-1784-475e-a612-48057e5578c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04eb20ea-1784-475e-a612-48057e5578c1.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -14577,7 +14577,7 @@
         },
         {
             "id": "c4688bdd-c19d-5927-8d01-fc314bb4365e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13635ba7-0635-4c16-9e14-444470e06287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13635ba7-0635-4c16-9e14-444470e06287.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -14614,7 +14614,7 @@
         },
         {
             "id": "05e85f83-53e0-57de-a9ed-0f91d4f2a7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925e07e8-a897-443f-8962-ef11fc41002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925e07e8-a897-443f-8962-ef11fc41002a.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -14651,7 +14651,7 @@
         },
         {
             "id": "bed7917a-fd4b-571d-8034-6ca9b1533ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdbb450-4b80-4f81-9992-ee8fbeeb1857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdbb450-4b80-4f81-9992-ee8fbeeb1857.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/6ED.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/6ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4c133233-fd46-595a-88f1-0fb33c56d4d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdb3a14-c5cc-4655-9b0c-e8be153413af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdb3a14-c5cc-4655-9b0c-e8be153413af.jpg?1",
             "name": "Animate Wall",
             "text": "Enchanted creature can attack as though it weren't a Wall.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "34b733ae-d709-5e56-b66c-379ae512d361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734c616-cb19-4ed6-af7f-fc077f299e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734c616-cb19-4ed6-af7f-fc077f299e6e.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking doesn't cause Archangel to tap.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "68cd5d1f-0315-5316-b3a7-a1011e8384ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95608d51-9ec0-497c-a065-15adb7eff242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95608d51-9ec0-497c-a065-15adb7eff242.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "ca6b0c3c-bed0-5337-a679-2063aa9c31df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf3abe6-0b86-4010-8fc6-616af77b4ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf3abe6-0b86-4010-8fc6-616af77b4ace.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "06213ae0-94d5-53d2-8c61-0595fe672229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1b462d-4b0f-40cf-89a0-17a3e1c8a0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1b462d-4b0f-40cf-89a0-17a3e1c8a0ba.jpg?1",
             "name": "Armored Pegasus",
             "text": "Flying",
             "colours": [
@@ -168,7 +168,7 @@
         },
         {
             "id": "a13a2e22-f577-507c-a901-0f96ca141c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a77e784-d7a8-4b92-8765-375ad70b929e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a77e784-d7a8-4b92-8765-375ad70b929e.jpg?1",
             "name": "Castle",
             "text": "Untapped creatures you control get +0/+2.",
             "colours": [
@@ -199,7 +199,7 @@
         },
         {
             "id": "bba268ef-ff98-5a8b-93b3-e8e82102fb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a51b3c5-7b4a-4ed3-be33-5b854c005b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a51b3c5-7b4a-4ed3-be33-5b854c005b99.jpg?1",
             "name": "Celestial Dawn",
             "text": "Nonland cards you own that aren't in play are white. Nonland permanents you control are white. Lands you control are plains. Colored mana symbols in the costs on all those cards and permanents are o\nW.",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "fdc1e17a-33c9-5495-8a69-45131682a0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605bbcc8-973b-4e06-8c33-7e444d03fcd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605bbcc8-973b-4e06-8c33-7e444d03fcd8.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -261,7 +261,7 @@
         },
         {
             "id": "774645d1-e0fa-5dfd-80ce-9f0d923b8961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286368f3-65a6-4858-ac7f-edb06a741151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286368f3-65a6-4858-ac7f-edb06a741151.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: The next time a blue source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -292,7 +292,7 @@
         },
         {
             "id": "79d3bf12-53ee-56b4-8bed-9ce23d059f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3187cbd-7925-467b-a745-a0050045900b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3187cbd-7925-467b-a745-a0050045900b.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: The next time a green source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "8ee2d15a-13bc-5706-9795-bc82b7bb6a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3357139a-8b8b-47c5-a35b-3ed98968ba4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3357139a-8b8b-47c5-a35b-3ed98968ba4d.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "7750569b-3948-5666-bf0f-56fc1123a05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b7a978-692e-4015-9b90-e51ee98c5e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b7a978-692e-4015-9b90-e51ee98c5e3e.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: The next time a white source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -385,7 +385,7 @@
         },
         {
             "id": "65a516c2-50fd-50ce-a19d-4b113fd0934c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f5f07-f692-4531-81b6-31813574ec12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f5f07-f692-4531-81b6-31813574ec12.jpg?1",
             "name": "Crusade",
             "text": "White creatures get +1/+1.",
             "colours": [
@@ -416,7 +416,7 @@
         },
         {
             "id": "ed60ae22-bcce-514d-9daf-e390056206f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795a1d6-9caf-472a-a349-fca97bccf8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795a1d6-9caf-472a-a349-fca97bccf8e2.jpg?1",
             "name": "Daraja Griffin",
             "text": "Flying\nSacrifice Daraja Griffin: Destroy target black creature.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "81653e43-7cf2-5583-addd-9467aab4eac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97985bb-75ab-454e-894d-963890043caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97985bb-75ab-454e-894d-963890043caf.jpg?1",
             "name": "D'Avenant Archer",
             "text": "oc\nT: D'Avenant Archer deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "751d31cd-ff3e-5872-9253-dabb5e6b7e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47578ce0-dbaa-4a15-b46c-2fd2cb352be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47578ce0-dbaa-4a15-b46c-2fd2cb352be9.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "c02421b5-10d1-5192-bad5-0520cb696ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d2e46-814b-40cb-81a0-8d89285bf196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d2e46-814b-40cb-81a0-8d89285bf196.jpg?1",
             "name": "Divine Transformation",
             "text": "Enchanted creature gets +3/+3.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "7d1e2fc8-9e04-531d-9249-59d7f9977405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eec4ac-7d28-4f76-a1d5-a0a19c142514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eec4ac-7d28-4f76-a1d5-a0a19c142514.jpg?1",
             "name": "Ekundu Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "091cd056-1c0c-5f06-820c-de7935329b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869da95-2c47-4796-aadc-50652ebb4d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869da95-2c47-4796-aadc-50652ebb4d03.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "49eb435f-5ad6-57a5-9fb9-fc13c1b3da31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1733e2-bee2-4b85-b165-d4329402578b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1733e2-bee2-4b85-b165-d4329402578b.jpg?1",
             "name": "Ethereal Champion",
             "text": "Pay 1 life: Prevent the next 1 damage to Ethereal Champion this turn.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "7c8530db-2ec1-594c-bb32-42ba1d11398b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e3ca4-5b56-40bb-bec7-c92fc7eb50d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e3ca4-5b56-40bb-bec7-c92fc7eb50d2.jpg?1",
             "name": "Exile",
             "text": "Remove target nonwhite attacking creature from the game. You gain life equal to its toughness.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "3b2624ba-0e7d-5a19-ae4e-a898ad38fa79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4953ac06-dc8c-4a9c-8ff6-8e4432dae91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4953ac06-dc8c-4a9c-8ff6-8e4432dae91f.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage to target creature or player this turn.",
             "colours": [
@@ -707,7 +707,7 @@
         },
         {
             "id": "8956a292-120e-5896-8448-7ccac70cdcd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c587228-b633-4049-beb8-e45aae967167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c587228-b633-4049-beb8-e45aae967167.jpg?1",
             "name": "Heavy Ballista",
             "text": "oc\nT: Heavy Ballista deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "f68c5391-315d-51e4-aa87-48abc1b17033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a0f233-895e-4072-8339-c9448110d3e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a0f233-895e-4072-8339-c9448110d3e8.jpg?1",
             "name": "Hero's Resolve",
             "text": "Enchanted creature gets +1/+5.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "09410ad9-90eb-578b-b9e4-f971058ebc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7582903-57b0-42e6-991c-0f93ab9172d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7582903-57b0-42e6-991c-0f93ab9172d0.jpg?1",
             "name": "Icatian Town",
             "text": "Put four 1/1 white Citizen creature tokens into play.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "c9a21aa6-dc8b-5097-a915-72895732a773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c911f-917a-4c3e-ad35-2a01c25339e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c911f-917a-4c3e-ad35-2a01c25339e9.jpg?1",
             "name": "Infantry Veteran",
             "text": "oc\nT: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "3bab7e35-57a5-5dd2-9943-1387e8fac83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d53f6-4cec-4c91-a507-39038d300b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d53f6-4cec-4c91-a507-39038d300b00.jpg?1",
             "name": "Kismet",
             "text": "Artifacts, creatures, and lands your opponents play come into play tapped.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "6d8ded94-4a30-5624-aee6-d3ac7f4027af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e65e795-84e2-44c9-9f20-469e8c59f147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e65e795-84e2-44c9-9f20-469e8c59f147.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: All combat damage that would be dealt to you by unblocked creatures this turn is dealt to Kjeldoran Royal Guard instead.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "428f3662-ac13-533b-9a22-58b6fec8d5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5af047-7d98-4ba9-9ce1-c67563c19866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5af047-7d98-4ba9-9ce1-c67563c19866.jpg?1",
             "name": "Light of Day",
             "text": "Black creatures can't attack or block.",
             "colours": [
@@ -935,7 +935,7 @@
         },
         {
             "id": "055d0e85-2cd2-52cc-9e58-84d3d12bc004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdac001-4cfb-4991-ac70-d430750d5047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdac001-4cfb-4991-ac70-d430750d5047.jpg?1",
             "name": "Longbow Archer",
             "text": "First strike\nLongbow Archer can block as though it had flying.",
             "colours": [
@@ -970,7 +970,7 @@
         },
         {
             "id": "0c5b6fb7-03da-53e1-ac38-7851b0c67d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ce1b8e-13ba-4eed-a445-435300f3101e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ce1b8e-13ba-4eed-a445-435300f3101e.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW Mesa Falcon gets +0/+1 until end of turn.",
             "colours": [
@@ -1003,7 +1003,7 @@
         },
         {
             "id": "92523a80-77a3-5547-9536-65469f1d30f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760cf598-41e1-4cdc-9a30-964e67ffaf52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760cf598-41e1-4cdc-9a30-964e67ffaf52.jpg?1",
             "name": "Order of the Sacred Torch",
             "text": "oc\nT, Pay 1 life: Counter target black spell.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "4c783738-154d-504a-8cec-14bfa20bcb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d0ac2-08aa-4f3b-9616-006c0bf09f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d0ac2-08aa-4f3b-9616-006c0bf09f59.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "84042482-ccfb-5df0-8c71-10771306e836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efee309-2eba-4702-9361-0f75043922bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efee309-2eba-4702-9361-0f75043922bb.jpg?1",
             "name": "Pearl Dragon",
             "text": "Flying\no1oo\nW Pearl Dragon gets +0/+1 until end of turn.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "c57f48ab-27c9-522b-9be6-09e6418d7239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ca9b1c-fead-4bb6-800f-8b762a82fda7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ca9b1c-fead-4bb6-800f-8b762a82fda7.jpg?1",
             "name": "Regal Unicorn",
             "text": "",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "fd44d922-11bf-55da-93b9-2eb6628c9cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cdfb23-3c62-4312-a503-e30be384e3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cdfb23-3c62-4312-a503-e30be384e3ab.jpg?1",
             "name": "Remedy",
             "text": "Prevent the next 5 damage this turn divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "fccc7aed-bcd9-592a-bf5f-fef98b6b2078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229be020-de00-4985-b6f0-e6276018591e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229be020-de00-4985-b6f0-e6276018591e.jpg?1",
             "name": "Reprisal",
             "text": "Destroy target creature with power 4 or greater. It can't be regenerated.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "ba1e4f51-5c6e-576b-9865-c183e583267f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abf09d8-f972-4b81-80e9-70fb4a33ed56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abf09d8-f972-4b81-80e9-70fb4a33ed56.jpg?1",
             "name": "Resistance Fighter",
             "text": "Sacrifice Resistance Fighter: Target creature deals no combat damage this turn.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "121f4121-f11d-5e67-a5ad-16425d3f813c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1040133a-f80d-48dc-a50b-a11e5b793a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1040133a-f80d-48dc-a50b-a11e5b793a2b.jpg?1",
             "name": "Reverse Damage",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "d880ef34-3625-51c5-a12a-a596396ab4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1166d39-e186-4bb0-8ca4-ccc0200d13de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1166d39-e186-4bb0-8ca4-ccc0200d13de.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent the next 1 damage to target creature or player this turn.",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "43484472-949b-59be-a38f-473121cfde64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b37593d-13e7-4489-84bc-7074032b6f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b37593d-13e7-4489-84bc-7074032b6f05.jpg?1",
             "name": "Serenity",
             "text": "At the beginning of your upkeep, destroy all artifacts and enchantments. They can't be regenerated.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "f0fc4cfe-980a-5af5-b719-8b190ba79e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6751671-9ef9-45f2-8e27-8c896936929a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6751671-9ef9-45f2-8e27-8c896936929a.jpg?1",
             "name": "Serra's Blessing",
             "text": "Attacking doesn't cause creatures you control to tap.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "13194d28-20e5-57b1-80cf-d4f1131f10b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb60c6-d5e9-474f-a20f-8f705e7372cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb60c6-d5e9-474f-a20f-8f705e7372cd.jpg?1",
             "name": "Spirit Link",
             "text": "Whenever enchanted creature deals damage, you gain life equal to the damage dealt this way.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "8863123d-22b1-55c1-8cd0-28ced7fa9630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7db7c36-0992-413d-851b-0c7e095d7a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7db7c36-0992-413d-851b-0c7e095d7a6e.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking doesn't cause Standing Troops to tap.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "7f11d449-72cf-5171-ae1f-69f26ef75b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2c54f-a1f4-4015-a4f3-8cd360fa466d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d2c54f-a1f4-4015-a4f3-8cd360fa466d.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, you gain 4 life.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "e69b8d38-4e71-5c5d-875e-7036b5e60e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b55e90-021e-48be-8abd-177e39200d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b55e90-021e-48be-8abd-177e39200d15.jpg?1",
             "name": "Sunweb",
             "text": "(Walls can't attack.)\nFlying\nSunweb can't block creatures with power 2 or less.",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "54ba611c-692f-52d3-ace9-5af164b4c4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61094858-b8a8-425f-9c96-fac4fc6ecae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61094858-b8a8-425f-9c96-fac4fc6ecae8.jpg?1",
             "name": "Tariff",
             "text": "Each player chooses a creature with the highest converted mana cost he or she controls, then pays mana equal to that cost or sacrifices that creature.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "47aea5ba-a0b7-5b5b-8a7f-666899564fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1e1378-9e27-4cce-88e7-a3bf3dcd2977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1e1378-9e27-4cce-88e7-a3bf3dcd2977.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -1557,7 +1557,7 @@
         },
         {
             "id": "719ccffb-0e36-5d05-a47b-9d9a160e2630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7af2b0-e07f-4b59-8fcf-e51c47f4f095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7af2b0-e07f-4b59-8fcf-e51c47f4f095.jpg?1",
             "name": "Unyaro Griffin",
             "text": "Flying\nSacrifice Unyaro Griffin: Counter target red instant or sorcery spell.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "b23f6746-8837-5c82-895b-c9dfa58a525b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fdd5d-2ed0-42d9-a1b5-34f1d61b668b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fdd5d-2ed0-42d9-a1b5-34f1d61b668b.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "5c3303dc-8041-50f0-8a9b-e7d8c918ed5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0219d-1bf9-4514-9ab3-b241bc541525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0219d-1bf9-4514-9ab3-b241bc541525.jpg?1",
             "name": "Wall of Swords",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -1658,7 +1658,7 @@
         },
         {
             "id": "e15fe99d-11c7-5e20-aadd-5e42ed894041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebd9062-a702-4f30-bba4-c2531e5ca5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebd9062-a702-4f30-bba4-c2531e5ca5cd.jpg?1",
             "name": "Warmth",
             "text": "Whenever one of your opponents plays a red spell, you gain 2 life.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "9aad0661-1d4a-5116-b557-3eff37ef3f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74900e91-d661-4846-984e-5774c5ce0540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74900e91-d661-4846-984e-5774c5ce0540.jpg?1",
             "name": "Warrior's Honor",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "d062c914-1c28-5b25-89e7-4c75a8a00a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5513964-1cad-4083-a3a5-1e55ec145a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5513964-1cad-4083-a3a5-1e55ec145a6e.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "1f9a86c7-ca08-5068-8219-290153c0c8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c82bef-50d6-4d25-bc3f-dda2826fc99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c82bef-50d6-4d25-bc3f-dda2826fc99c.jpg?1",
             "name": "Abduction",
             "text": "When Abduction comes into play, untap enchanted creature.\nYou control enchanted creature.\nWhen enchanted creature is put into a graveyard, return that creature to play under its owner's control.",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "be132567-6735-5e7f-933a-7726b770a60a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d31dca7-df16-4a70-8f17-b78d745bac96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d31dca7-df16-4a70-8f17-b78d745bac96.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "2d5f3d1a-81ba-5df3-bb55-717cbb7b85d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9953a9d1-62db-4610-bf8c-74c321f059c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9953a9d1-62db-4610-bf8c-74c321f059c2.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your library and put two of them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "77eea01b-2e7c-5b73-a42a-fa47093ecd9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3c7465-6534-4fa9-a772-8859b7210fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3c7465-6534-4fa9-a772-8859b7210fdf.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "6b1e53ce-fbfd-5f12-bd1f-bc346d699bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd1b41f-5113-4a7c-9c35-04ebdf002af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd1b41f-5113-4a7c-9c35-04ebdf002af2.jpg?1",
             "name": "Browse",
             "text": "o2o\nUoo\nU Look at the top five cards of your library and put one of them into your hand. Remove the rest from the game.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "ab0d1563-943a-5fe6-96f1-795039d73d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24846eba-e085-4d1d-8c7a-d4faf11034a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24846eba-e085-4d1d-8c7a-d4faf11034a6.jpg?1",
             "name": "Chill",
             "text": "Red spells cost o2 more to play.",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "7a264584-27b5-5ba0-b1ee-1a4671ec2d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0d3f5f-7790-4772-bead-5d7114a23e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0d3f5f-7790-4772-bead-5d7114a23e94.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1972,7 +1972,7 @@
         },
         {
             "id": "784f53a5-fcbd-5025-9b4b-8ed578dc2529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0344006b-990e-46a0-a6d4-ace88af66b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0344006b-990e-46a0-a6d4-ace88af66b46.jpg?1",
             "name": "Daring Apprentice",
             "text": "oc\nT, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "c7527261-21ba-5f42-8a2b-27bfcb893101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca34222-bf30-41e9-a166-e6b02bd6e46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca34222-bf30-41e9-a166-e6b02bd6e46a.jpg?1",
             "name": "Deflection",
             "text": "Choose a new target for target spell with a single target.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "2b169a23-71e7-54de-93e8-21c01c324f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac212677-daa3-49ee-adb1-53a169cb7e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac212677-daa3-49ee-adb1-53a169cb7e9d.jpg?1",
             "name": "Desertion",
             "text": "Counter target spell. If it's an artifact or creature card, put it into play under your control instead of into its owner's graveyard.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "8aaabb91-767a-57d8-9e9b-dffc42910a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c00fc18-8101-48ff-9842-2b157eb02681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c00fc18-8101-48ff-9842-2b157eb02681.jpg?1",
             "name": "Diminishing Returns",
             "text": "Each player shuffles his or her hand and graveyard into his or her library. You remove the top ten cards of your library from the game. Then each player draws up to seven cards.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "2d1c8d8d-25f6-59c4-a0bc-489496509f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642bb62e-1339-4f97-8429-ec46ec0435a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642bb62e-1339-4f97-8429-ec46ec0435a0.jpg?1",
             "name": "Dream Cache",
             "text": "Draw three cards. Choose two cards from your hand and put both on either the top or the bottom of your library.",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "d7ede6e2-2929-54ee-af21-511cef6b4c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2f44d-74a9-4635-bf10-bf4cf179cab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2f44d-74a9-4635-bf10-bf4cf179cab5.jpg?1",
             "name": "Flash",
             "text": "Put a creature card from your hand into play. You may pay its mana cost reduced by up to o2. If you don't, sacrifice it.",
             "colours": [
@@ -2161,7 +2161,7 @@
         },
         {
             "id": "5107f7a1-d20e-5914-a689-25c8fdfa1e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99d08e-edc4-4049-a3de-99f6c5cb0f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99d08e-edc4-4049-a3de-99f6c5cb0f70.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature gains flying.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "b08ba496-4703-5256-922a-9c618e60fc86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0e0c8-3121-46ff-b202-9669c16c2df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0e0c8-3121-46ff-b202-9669c16c2df4.jpg?1",
             "name": "Fog Elemental",
             "text": "Flying\nWhen Fog Elemental attacks or blocks, sacrifice it at end of combat.",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "86856b1d-a851-5bfb-ae2e-9f95a0f2af42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e367-1aa4-43b6-b17a-01bfb097f620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e367-1aa4-43b6-b17a-01bfb097f620.jpg?1",
             "name": "Forget",
             "text": "Target player chooses and discards two cards from his or her hand, then draws as many cards as he or she discarded this way.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "8890a65f-404d-5e97-ba05-4348b78606db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d74e17-5d3c-4102-aadd-263bfecca510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d74e17-5d3c-4102-aadd-263bfecca510.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchanted creature deals no combat damage.\nPrevent all combat damage that would be dealt to enchanted creature.",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "fa28ffc8-a7a0-5c00-a518-9b9c5c2691ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea929add-39a4-4840-a127-16aeb37f55f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea929add-39a4-4840-a127-16aeb37f55f5.jpg?1",
             "name": "Glacial Wall",
             "text": "(Walls can't attack.)",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "75d93453-1585-5dc0-9abe-31a080b3718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fc0ba3-6ffa-4fd4-b332-88da41b8778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fc0ba3-6ffa-4fd4-b332-88da41b8778a.jpg?1",
             "name": "Harmattan Efreet",
             "text": "Flying\no1o\nUoo\nU Target creature gains flying until end of turn.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "c6642786-7753-5fd7-a9e9-64fb0291d10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63e2f7d-52aa-43a1-ab86-7a510a131b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63e2f7d-52aa-43a1-ab86-7a510a131b4c.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "fda79319-093a-5b22-a0fb-aece57fdbfda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a4bbf-2afd-48c5-b6b0-73c32bc3561b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a4bbf-2afd-48c5-b6b0-73c32bc3561b.jpg?1",
             "name": "Insight",
             "text": "Whenever one of your opponents plays a green spell, you draw a card.",
             "colours": [
@@ -2421,7 +2421,7 @@
         },
         {
             "id": "3e48e619-7116-515b-940e-0159c5bfb345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1374df24-bcff-45eb-a2fd-2f39439c9e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1374df24-bcff-45eb-a2fd-2f39439c9e6a.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "f41173cb-432e-5fbc-bc22-1383ea7e8ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1fb725-0daa-45f4-ad31-6a061fa4d20f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1fb725-0daa-45f4-ad31-6a061fa4d20f.jpg?1",
             "name": "Juxtapose",
             "text": "You and target player exchange control of the creature you each control with the highest converted mana cost. Then exchange control of artifacts the same way. (If two or more permanents a player controls are tied for highest cost, that player chooses between them.)",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "26d15fd4-1424-5f93-886b-e573017290f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea40438-90ca-47ff-9805-df130d47ae48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea40438-90ca-47ff-9805-df130d47ae48.jpg?1",
             "name": "Library of Lat-Nam",
             "text": "Target opponent chooses one You draw three cards at the beginning of the next turn's upkeep; or you search your library for a card, put that card into your hand, and then shuffle your library.",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "72149ee4-00f8-5c43-982f-3201ccecd523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d753d343-fedc-4406-b889-87e0f719d361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d753d343-fedc-4406-b889-87e0f719d361.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk get +1/+1 and gain islandwalk. (They're unblockable if defending player controls an island.)",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "5dec76ba-0c1d-528d-9256-95606cddea7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2893b8-11e4-4a76-a3bf-6dd86c11ae09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2893b8-11e4-4a76-a3bf-6dd86c11ae09.jpg?1",
             "name": "Mana Short",
             "text": "Tap all lands target player controls and empty his or her mana pool.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "bff5f562-5202-54ca-b02b-bfd2faf3f172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc92a87-3ad2-4db6-aeae-001342f17d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc92a87-3ad2-4db6-aeae-001342f17d10.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "27b5580e-7f65-516c-b4d3-653a6f2e88eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c43f23-19c1-4b5a-91d4-9961ffc7fcf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c43f23-19c1-4b5a-91d4-9961ffc7fcf1.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "0a7392b3-85bc-5f22-b409-2e1598848d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1571b584-9007-45ee-a3c3-6c72f227fee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1571b584-9007-45ee-a3c3-6c72f227fee2.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "e82e2113-20ce-55e3-8215-9d5c2115da3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ab11d8-0cc2-4a00-9fe8-06a9b3683311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ab11d8-0cc2-4a00-9fe8-06a9b3683311.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Enchanted land is a basic land type of your choice.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "b928a993-a4f5-567b-a558-bd0d830c4acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215e560f-077b-4a4f-aba3-e5c8dab912fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215e560f-077b-4a4f-aba3-e5c8dab912fe.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "9b2573da-771c-5ff5-8976-eff70717ee99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b8c9b-40d0-4986-9457-ef1263fdfae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b8c9b-40d0-4986-9457-ef1263fdfae1.jpg?1",
             "name": "Polymorph",
             "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until a creature card is revealed. The player puts that card into play and shuffles all other revealed cards into his or her library.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "b1f0eb77-741d-5994-9632-bdf435fa5e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098d3f20-e377-4579-b8d7-2d5e7ee3fb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098d3f20-e377-4579-b8d7-2d5e7ee3fb4e.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless its controller pays o\nX more. If he or she doesn't, tap all mana-producing lands that player controls and empty his or her mana pool.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "ab62553a-d382-5fce-aefd-3bffc244f58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf045ee-7923-4b3d-9bb4-f573d37cc7d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf045ee-7923-4b3d-9bb4-f573d37cc7d8.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "f43e615f-d8e3-5234-bc22-b385cd720139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0c86df-ee91-4bea-bb05-7e5db3558169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0c86df-ee91-4bea-bb05-7e5db3558169.jpg?1",
             "name": "Prosperity",
             "text": "Each player draws X cards.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "4e2c1f67-76ae-5811-a4ee-8bbf45ad5c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d848a3e1-de15-4b8f-9881-d32aa2456488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d848a3e1-de15-4b8f-9881-d32aa2456488.jpg?1",
             "name": "Psychic Transfer",
             "text": "If the difference between your life total and target player's life total is 5 or less, exchange life totals with that player.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "0dfac25f-8b8b-573a-a779-1ee4c1be8d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba1b264-1dd5-475b-9522-9eb9efcea572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba1b264-1dd5-475b-9522-9eb9efcea572.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever enchanted land is tapped, Psychic Venom deals 2 damage to that land's controller.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "aa01daf8-4a9d-593d-bb99-58e676862a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791af96f-1de9-46f2-a1e5-93921c4905c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791af96f-1de9-46f2-a1e5-93921c4905c7.jpg?1",
             "name": "Recall",
             "text": "Choose and discard X cards from your hand, then return that many cards from your graveyard to your hand. Remove Recall from the game.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "e848b1d6-8547-5518-b4ca-b355a99ca9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358f4122-fffb-46f6-996c-f4558ba79407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358f4122-fffb-46f6-996c-f4558ba79407.jpg?1",
             "name": "Relearn",
             "text": "Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "af0ffc99-8449-55c7-bca7-7b2220202f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19345cab-4595-4325-b6b4-539c2003679e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19345cab-4595-4325-b6b4-539c2003679e.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "e293fccc-2935-5f46-b327-f6c8ee1bee9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f83acb-c7be-49cf-895b-9fa6f4d32083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f83acb-c7be-49cf-895b-9fa6f4d32083.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl comes into play, look at the top four cards of your library and put them back in any order you choose.",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "122bfa87-c0b1-596e-bfbd-12b77a339844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cecf934-d1fe-424f-932a-043908546157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cecf934-d1fe-424f-932a-043908546157.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an island.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "16113dbb-db5b-5ca3-ab85-7b83e9593e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f796dd2-9ecf-490a-86c0-acb46130518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f796dd2-9ecf-490a-86c0-acb46130518b.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk (This creature is unblockable if defending player controls an island.)",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "e74cf0ac-f2f7-5a33-8be7-99d6b21150ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd219fee-45d2-4d68-911e-9ecdc3a6e81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd219fee-45d2-4d68-911e-9ecdc3a6e81c.jpg?1",
             "name": "Sibilant Spirit",
             "text": "Flying\nWhenever Sibilant Spirit attacks, defending player may draw a card.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "f4363234-d4ef-5e51-991f-df53c42e9374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268c3726-0e2d-40df-811d-2cdf6b328ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268c3726-0e2d-40df-811d-2cdf6b328ea3.jpg?1",
             "name": "Soldevi Sage",
             "text": "oc\nT, Sacrifice two lands: Draw three cards, then choose and discard one of them.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "31a9cae2-7f02-5b6f-a127-d527fdc5859c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e470d0f-06a0-4fdf-98eb-79d536dff894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e470d0f-06a0-4fdf-98eb-79d536dff894.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with converted mana cost equal to X.",
             "colours": [
@@ -3221,7 +3221,7 @@
         },
         {
             "id": "9a78cca7-dc6a-54c2-8fc6-078691a06732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1bf438-3cd8-4bd8-85f1-fc97f49b44d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1bf438-3cd8-4bd8-85f1-fc97f49b44d9.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "81f17c10-fd0b-5614-937b-b37e3b26d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae1d63-aee0-4cbe-852d-25fde10fa4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae1d63-aee0-4cbe-852d-25fde10fa4b7.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap up to three target creatures without flying.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "b3277453-5e29-54a9-a4c5-be40504fa150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff96224-d6cd-492b-ab2f-3ec15b3230cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff96224-d6cd-492b-ab2f-3ec15b3230cb.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "e9459099-5c21-56a5-b565-2bd9d836642e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fae146-a0dd-4622-ab11-f00b372f8221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fae146-a0dd-4622-ab11-f00b372f8221.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "eb47023a-c079-5c99-918f-a10b9be47dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a99adbb-7723-4046-92af-95d6d21fae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a99adbb-7723-4046-92af-95d6d21fae53.jpg?1",
             "name": "Wall of Air",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "8b37b7de-70e2-5d1b-8fb8-b348f8c94ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ca5eed-53a3-4da5-b7fc-f08e6cc93946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ca5eed-53a3-4da5-b7fc-f08e6cc93946.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "3f5269eb-af58-52ec-8c21-2f26b5eeedd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9041dc6-7521-4ae3-b8b3-5134fea97581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9041dc6-7521-4ae3-b8b3-5134fea97581.jpg?1",
             "name": "Wind Spirit",
             "text": "Flying\nWind Spirit can't be blocked by only one creature each combat.",
             "colours": [
@@ -3450,7 +3450,7 @@
         },
         {
             "id": "c9f61fe9-ba9e-50b7-976a-d594de985838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a31bb-5f3b-4215-9e21-9965d459f032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a31bb-5f3b-4215-9e21-9965d459f032.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands revealed.\nWhenever a player would draw a card, instead reveal it. Any other player may pay 2 life to put that card into its owner's graveyard. If no one does, that player then draws the card.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "6320df7d-8ffd-5f36-970f-68a188c2917f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f6ad7-4782-40db-8eb3-e71d71ec3388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f6ad7-4782-40db-8eb3-e71d71ec3388.jpg?1",
             "name": "Abyssal Hunter",
             "text": "o\nB, oc\nT: Tap target creature. Abyssal Hunter deals damage equal to its power to that creature.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "e7e2fbc9-9f68-56aa-aea1-c2fb6908b51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e4df76-41c8-4410-a505-4f328c94b974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e4df76-41c8-4410-a505-4f328c94b974.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter deals damage to a player, that player chooses and discards a card from his or her hand.",
             "colours": [
@@ -3548,7 +3548,7 @@
         },
         {
             "id": "12520903-5bfd-5978-b2b4-5c24e2a81ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556e1e2-44a6-49f1-8417-be8dae4ef65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556e1e2-44a6-49f1-8417-be8dae4ef65b.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand and choose two cards from it. Put those cards on top of that player's library in any order you choose.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "3df91841-c427-5808-b987-cea2aa964c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fa11f5-546b-4a14-afd0-80866d4968ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fa11f5-546b-4a14-afd0-80866d4968ab.jpg?1",
             "name": "Ashen Powder",
             "text": "Put target creature card from one of your opponents' graveyards into play under your control.",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "1e0a492d-0a3a-56d1-9ca1-9ece1b536847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a08e1fd-7ab1-4981-9fc4-f9d32a58ac4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a08e1fd-7ab1-4981-9fc4-f9d32a58ac4e.jpg?1",
             "name": "Blight",
             "text": "When enchanted land is tapped, destroy it.",
             "colours": [
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "6e78201b-00fe-51fc-8661-015ccc4c2c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d46c90a-215a-4897-94f8-52a02abf25c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d46c90a-215a-4897-94f8-52a02abf25c4.jpg?1",
             "name": "Blighted Shaman",
             "text": "oc\nT, Sacrifice a swamp: Target creature gets +1/+1 until end of turn.\noc\nT, Sacrifice a creature: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "cceb6ca7-63e4-5b38-b724-3406be1ee7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b30e7e-f628-4ae0-8338-c95022b3fedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b30e7e-f628-4ae0-8338-c95022b3fedf.jpg?1",
             "name": "Blood Pet",
             "text": "Sacrifice Blood Pet: Add o\nB to your mana pool.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "a053eb35-d849-5281-bd56-009e4e5c4c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02b4a5-8302-483c-9f38-b559974a601c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02b4a5-8302-483c-9f38-b559974a601c.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "b0d51ec8-6e01-5d58-b30b-5ba8488c40f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da038c4-73ff-4d82-8440-9bca2f051fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da038c4-73ff-4d82-8440-9bca2f051fd5.jpg?1",
             "name": "Bog Rats",
             "text": "Bog Rats can't be blocked by Walls.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "068b9a8c-8a80-5ead-b41f-8c235a1f1a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145a4b6-36f9-4cdc-9e81-ad8c22a21150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145a4b6-36f9-4cdc-9e81-ad8c22a21150.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable if defending player controls a swamp.)",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "6344a68b-3ff3-5e65-994b-9fdd1f7b4588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8337ac-fddc-4af7-a623-e9a8c8323564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8337ac-fddc-4af7-a623-e9a8c8323564.jpg?1",
             "name": "Coercion",
             "text": "Look at target opponent's hand and choose a card from it. That player discards that card.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "b1fe2fa1-7144-57f2-a42d-4667b794a790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530043ad-d4bf-4fb0-b6e0-f8a744968cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530043ad-d4bf-4fb0-b6e0-f8a744968cfc.jpg?1",
             "name": "Derelor",
             "text": "Your black spells cost o\nB more to play.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "db6adb27-4a5d-53b0-9f4c-d655457ac29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9dbfa-0043-47d2-acfe-f636841afc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9dbfa-0043-47d2-acfe-f636841afc2c.jpg?1",
             "name": "Doomsday",
             "text": "Search your library and graveyard for five cards of your choice and remove the rest from the game. Put the chosen cards on top of your library in any order you choose. You lose half your life, rounded up.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "51944792-fda0-5938-b5aa-87eae19a9c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4105fb4-ab13-4a34-810b-1d294c5a6eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4105fb4-ab13-4a34-810b-1d294c5a6eee.jpg?1",
             "name": "Dread of Night",
             "text": "White creatures get -1/-1.",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "b3c34ec0-82d2-5a25-ba77-303e95b36903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7105716-8f9e-4f32-b6bc-cb7b231d1fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7105716-8f9e-4f32-b6bc-cb7b231d1fa1.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate Drudge Skeletons.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "e599f2f9-b8ca-5951-b751-aa3d1a886f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670f4eb-cca7-45fd-b3d7-58b436c00526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670f4eb-cca7-45fd-b3d7-58b436c00526.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "fd35667d-7534-58b9-a025-31c683fa587b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f765719b-609a-47ae-8dc8-0c97db104d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f765719b-609a-47ae-8dc8-0c97db104d1b.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and each player.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "eb29571b-d84e-5cb5-97f1-350a77f8ab95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63418388-4e48-42cd-a84d-d631d01476a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63418388-4e48-42cd-a84d-d631d01476a3.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchanted creature gets -2/-2.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "3fcf9c11-6ee4-5f2a-84b2-a157a8f0c3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31caa65-accd-4306-a975-1aaa5d98aeaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31caa65-accd-4306-a975-1aaa5d98aeaa.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "Evil Eye of Orms-by-Gore can't be blocked except by Walls.\nExcept for Evil Eye of Orms-by-Gore, creatures you control can't attack.",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "553b43e5-2a7c-5481-aa10-7816225a8430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd81ae10-ebf4-4731-b32c-dc5954c3442c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd81ae10-ebf4-4731-b32c-dc5954c3442c.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "0617c723-e477-524a-94a4-e62c7bef67b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890c3aa-9321-4c41-9b16-cff4e6364350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890c3aa-9321-4c41-9b16-cff4e6364350.jpg?1",
             "name": "Fatal Blow",
             "text": "Destroy target creature that was dealt damage this turn. It can't be regenerated.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "a748cdec-e745-5e06-b22c-0ed6f2d9236b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb729a6b-7efc-4b94-9221-cba25f6506dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb729a6b-7efc-4b94-9221-cba25f6506dc.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "66478a23-2ec6-5335-9d6d-b1f5b0b3a61e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a5a97-d81e-4f4d-ab8f-5a9cabd4c685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a5a97-d81e-4f4d-ab8f-5a9cabd4c685.jpg?1",
             "name": "Feast of the Unicorn",
             "text": "Enchanted creature gets +4/+0.",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "f8aa6cbc-5079-5e7f-b6f2-0e22d38a1f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08263b27-487c-4b5c-aca6-0d77acdcc624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08263b27-487c-4b5c-aca6-0d77acdcc624.jpg?1",
             "name": "Feral Shadow",
             "text": "Flying",
             "colours": [
@@ -4266,7 +4266,7 @@
         },
         {
             "id": "31b453aa-6617-5466-a311-f73ae603d0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f5f509-707b-4ed6-9824-626dea5869b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f5f509-707b-4ed6-9824-626dea5869b0.jpg?1",
             "name": "Forbidden Crypt",
             "text": "Whenever you would draw a card, instead return target card from your graveyard to your hand. If you can't, you lose the game.\nWhenever a card would be put into your graveyard, instead remove that card from the game.",
             "colours": [
@@ -4297,7 +4297,7 @@
         },
         {
             "id": "e11828dc-9b3f-50f9-9d74-05f8bef106c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df21b384-6073-477e-bd95-fc94ca2f2f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df21b384-6073-477e-bd95-fc94ca2f2f2c.jpg?1",
             "name": "Gravebane Zombie",
             "text": "When Gravebane Zombie would be put into a graveyard from play, instead put Gravebane Zombie on top of its owner's library.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "7f894c98-1189-502c-8ce3-ce1f3a0dab0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ae81a3-f76a-406b-bbac-36f8abf456ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ae81a3-f76a-406b-bbac-36f8abf456ce.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "00dee035-db3c-5149-939d-dabd2926c7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977d0b73-ebc1-4082-a90c-eda363732bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977d0b73-ebc1-4082-a90c-eda363732bbe.jpg?1",
             "name": "Greed",
             "text": "o\nB, Pay 2 life: Draw a card.",
             "colours": [
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "ae9b5a97-a5b4-5379-986e-abe934ff6594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d2908e-1608-4858-b93c-e9ea9808f9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d2908e-1608-4858-b93c-e9ea9808f9c9.jpg?1",
             "name": "Hecatomb",
             "text": "When Hecatomb comes into play, you may sacrifice four creatures. If you don't, sacrifice Hecatomb.\nTap an untapped swamp you control: Hecatomb deals 1 damage to target creature or player.",
             "colours": [
@@ -4425,7 +4425,7 @@
         },
         {
             "id": "c753827f-c0d8-5198-94c8-0ea9a1277bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785de2b3-ffd6-40f5-a5d2-c8fa30dbf10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785de2b3-ffd6-40f5-a5d2-c8fa30dbf10f.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play, choose and discard a creature card from your hand. If you don't, sacrifice Hidden Horror.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "d070396f-d208-5edd-a2b6-2f5e9f551b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb9612-cc19-4769-9d07-38d5e2796053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb9612-cc19-4769-9d07-38d5e2796053.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "ea369760-adf0-5893-86fd-b02fbc2f62eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94517aeb-c018-4390-b601-c44a7af0f090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94517aeb-c018-4390-b601-c44a7af0f090.jpg?1",
             "name": "Infernal Contract",
             "text": "Draw four cards. You lose half your life, rounded up.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "2f8d4786-0206-5430-9870-5d162c42d41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dff6e2-4280-494b-9647-9ec85248ac77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dff6e2-4280-494b-9647-9ec85248ac77.jpg?1",
             "name": "Kjeldoran Dead",
             "text": "When Kjeldoran Dead comes into play, sacrifice a creature.\noo\nB Regenerate Kjeldoran Dead.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "fdf09646-de35-5d32-871d-a227dc7cc90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c44599f-f788-43fa-ace3-a521f15256ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c44599f-f788-43fa-ace3-a521f15256ad.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Enchanted creature gains swampwalk. (It's unblockable if defending player controls a swamp.)",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "faa30e91-a2da-5400-9d74-25e2daad70fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401896ac-6234-468a-a9af-cf11c7a11cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401896ac-6234-468a-a9af-cf11c7a11cd0.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk (This creature is unblockable if defending player controls a swamp.)",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "2fe6f150-5146-5d82-b7f0-393deaacfcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f0d58c-24fa-498f-9531-e62144401e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f0d58c-24fa-498f-9531-e62144401e86.jpg?1",
             "name": "Mind Warp",
             "text": "Look at target player's hand and choose X cards from it. That player discards them.",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "4d3cd442-4589-550e-af77-8d1e213c9f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11803b8-d1df-454d-93ec-b1bb276843b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11803b8-d1df-454d-93ec-b1bb276843b6.jpg?1",
             "name": "Mischievous Poltergeist",
             "text": "Flying\nPay 1 life: Regenerate Mischievous Poltergeist.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "02432e52-f31b-57b7-96a6-157d75149e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a9755-f003-456d-a827-d6ef6cc29a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a9755-f003-456d-a827-d6ef6cc29a86.jpg?1",
             "name": "Necrosavant",
             "text": "o3o\nBo\nB, Sacrifice a creature: Return Necrosavant from your graveyard to play.\nPlay this ability only during your upkeep.",
             "colours": [
@@ -4718,7 +4718,7 @@
         },
         {
             "id": "8ce66027-512d-5255-9bc7-b6ba6335d510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2a1e82-4922-4075-a869-3a1b607498c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2a1e82-4922-4075-a869-3a1b607498c3.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of swamps you control.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "fe6712b7-9054-5941-a7ae-c77f87f9612d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdec2ddc-3a91-4872-b4c0-e75af6cbb184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdec2ddc-3a91-4872-b4c0-e75af6cbb184.jpg?1",
             "name": "Painful Memories",
             "text": "Look at target opponent's hand and choose a card from it. Put that card on top of that player's library.",
             "colours": [
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "8d02ce18-c375-5cc2-99b6-b44bcbcb4890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77192bdf-d89f-45a1-a30b-20107e990031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77192bdf-d89f-45a1-a30b-20107e990031.jpg?1",
             "name": "Perish",
             "text": "Destroy all green creatures. They can't be regenerated.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "61f45545-8a67-52a6-aff3-aa733110a330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d852c4-bd53-4a3b-b1e2-896917cbc27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d852c4-bd53-4a3b-b1e2-896917cbc27f.jpg?1",
             "name": "Pestilence",
             "text": "At end of turn, if there are no creatures in play, sacrifice Pestilence.\noo\nB Pestilence deals 1 damage to each creature and each player.",
             "colours": [
@@ -4845,7 +4845,7 @@
         },
         {
             "id": "9d4683b7-ccba-5430-9a11-887929932e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe194-1d9b-4d3f-b7a0-aa058945aca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe194-1d9b-4d3f-b7a0-aa058945aca1.jpg?1",
             "name": "Python",
             "text": "",
             "colours": [
@@ -4878,7 +4878,7 @@
         },
         {
             "id": "b1a9478a-40cb-5dc4-9b28-a2bfa8eff977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef9159a-66ee-4e99-8fb6-6f45b02f9880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef9159a-66ee-4e99-8fb6-6f45b02f9880.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at target opponent's hand. That player discards a creature card at random from it. Play this ability only during your turn.",
             "colours": [
@@ -4912,7 +4912,7 @@
         },
         {
             "id": "7dee27cf-1f9a-5f8d-a135-57bca5047e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bb239e-4517-4add-a660-a89095e40a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bb239e-4517-4add-a660-a89095e40a8e.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "4c267abd-50dd-57c9-9ed1-eca1abfa4c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab55c86-3576-43fd-b555-ab0b3ad936c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab55c86-3576-43fd-b555-ab0b3ad936c7.jpg?1",
             "name": "Razortooth Rats",
             "text": "Razortooth Rats can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -4976,7 +4976,7 @@
         },
         {
             "id": "8370fdce-e2f0-531d-b55a-1bd7774a61e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e992239-691b-4bb2-a005-c73c24a52a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e992239-691b-4bb2-a005-c73c24a52a9b.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "1fbb3b2a-c675-5446-baff-41cb9ae52662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a5401-bbe4-40ab-9204-12d944fbd2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a5401-bbe4-40ab-9204-12d944fbd2b1.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat comes into play, put three 0/1 black Serf creature tokens into play.\nWhen Sengir Autocrat leaves play, remove all Serf tokens from play.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "c9c9963b-66da-5085-91c2-026ee1c1ab08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13382490-205e-4dcd-8524-2b17008b5237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13382490-205e-4dcd-8524-2b17008b5237.jpg?1",
             "name": "Strands of Night",
             "text": "o\nBo\nB, Pay 2 life, Sacrifice a swamp: Return target creature card from your graveyard to play.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "cff5fb99-f0e5-5a29-a479-b37770bab9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d78c90b-b44e-431a-a4e6-ceae0a019428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d78c90b-b44e-431a-a4e6-ceae0a019428.jpg?1",
             "name": "Stromgald Cabal",
             "text": "oc\nT, Pay 1 life: Counter target white spell.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "9e48b63f-cf1d-5ea5-a8a7-a1123cadb535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec72a6-b482-4e04-8491-c6cb0afeb568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec72a6-b482-4e04-8491-c6cb0afeb568.jpg?1",
             "name": "Stupor",
             "text": "Target opponent discards a card at random from his or her hand, then chooses and discards a card from his or her hand.",
             "colours": [
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "ba1679c4-0bd8-508e-9541-3c4e2cb57947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b329533-9d55-456f-8fb1-0ab97c4b3037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b329533-9d55-456f-8fb1-0ab97c4b3037.jpg?1",
             "name": "Syphon Soul",
             "text": "Syphon Soul deals 2 damage to each other player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "f81623bb-ddb6-5a40-8d01-f03e1f31ca23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe73e689-b9da-4b1e-9809-c25056c06048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe73e689-b9da-4b1e-9809-c25056c06048.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "3ef135ce-7a12-52e4-8874-281c947ee92b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8505bc8-218f-4b56-be78-ebde535ebaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8505bc8-218f-4b56-be78-ebde535ebaa0.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "5352cdb6-0fb9-55de-a7a8-b1117832ab90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346707a7-e816-432c-bb93-16b5cb4616e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346707a7-e816-432c-bb93-16b5cb4616e0.jpg?1",
             "name": "Zombie Master",
             "text": "All Zombies gain \"oo\nB Regenerate this creature\" and swampwalk. (They're unblockable if defending player controls a swamp.)",
             "colours": [
@@ -5264,7 +5264,7 @@
         },
         {
             "id": "b8a03d0a-1b1a-58a0-90d5-01e39ee87a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61721ec-6008-4704-85d6-83d4f2558b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61721ec-6008-4704-85d6-83d4f2558b5a.jpg?1",
             "name": "Aether Flash",
             "text": "Whenever a creature comes into play, \u00c6ther Flash deals 2 damage to it.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "ce5cc7af-7e24-570a-b854-70ebf30bec18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c21e32-6f43-4475-bd9e-472ca8cbd4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c21e32-6f43-4475-bd9e-472ca8cbd4a6.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "5c7e061d-d0cc-553b-a9fd-203b900bea5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8eccc-551d-4109-866e-7285435ffd19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8eccc-551d-4109-866e-7285435ffd19.jpg?1",
             "name": "Anaba Shaman",
             "text": "o\nR, oc\nT: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "fb11b588-cee4-582d-b4fc-6a134be6ceb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de983bae-1b73-4dd7-a2f4-4200a21abe6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de983bae-1b73-4dd7-a2f4-4200a21abe6a.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "e07bb1cb-50ec-5767-a9a5-5ca709f28d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbcf78f-b5a9-4ed0-a409-d4565bebc56d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbcf78f-b5a9-4ed0-a409-d4565bebc56d.jpg?1",
             "name": "Balduvian Horde",
             "text": "When Balduvian Horde comes into play, discard a card at random from your hand. If you don't, sacrifice Balduvian Horde.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "86a59a3a-5568-54a3-960a-5b0a1697fb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09111a-e714-4f8f-8a48-61c102e45123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09111a-e714-4f8f-8a48-61c102e45123.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "e2b02f05-4256-5466-a076-35d2f929a902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8cd169-0eaa-4430-a175-7f9bbf552929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8cd169-0eaa-4430-a175-7f9bbf552929.jpg?1",
             "name": "Boil",
             "text": "Destroy all islands.",
             "colours": [
@@ -5492,7 +5492,7 @@
         },
         {
             "id": "3f01110e-ea0c-5904-9c2f-77f4a742398f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c665180c-a69b-446e-9894-3b3be624db7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c665180c-a69b-446e-9894-3b3be624db7f.jpg?1",
             "name": "Burrowing",
             "text": "Enchanted creature gains mountainwalk. (It's unblockable if defending player controls a mountain.)",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "e5683c44-bbb7-58c4-9434-4d2a135a4ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb9ae3b-0da5-40df-8f52-54238c965137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb9ae3b-0da5-40df-8f52-54238c965137.jpg?1",
             "name": "Conquer",
             "text": "You control enchanted land.",
             "colours": [
@@ -5558,7 +5558,7 @@
         },
         {
             "id": "ce64bbd2-8193-5741-8431-b71617be578f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88daedae-a848-4d08-bceb-b71cec2673fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88daedae-a848-4d08-bceb-b71cec2673fb.jpg?1",
             "name": "Crimson Hellkite",
             "text": "Flying\no\nX, oc\nT: Crimson Hellkite deals X damage to target creature. Spend only red mana this way.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "154e8480-0573-5843-95b1-33bfaa0cf649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58f85d-905a-4569-b3e6-adafc387c1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58f85d-905a-4569-b3e6-adafc387c1cb.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "9ded3e49-2a09-530e-9ce4-30cedf6fd705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84b68c-2079-4268-840c-f7a86675c0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84b68c-2079-4268-840c-f7a86675c0ba.jpg?1",
             "name": "Fervor",
             "text": "Creatures you control gain haste. (They may attack and oc\nT the turn they come under your control.)",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "f69d00c0-e385-572b-b445-cff62e67cd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627aeab7-ccdd-4b23-8e6c-976636fe308e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627aeab7-ccdd-4b23-8e6c-976636fe308e.jpg?1",
             "name": "Final Fortune",
             "text": "Take another turn after this one. At the end of that turn, you lose the game.",
             "colours": [
@@ -5684,7 +5684,7 @@
         },
         {
             "id": "f1cadd87-7779-5f12-af1c-65a6d47c5ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3b58b-ce10-459f-87f7-bb243b854fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3b58b-ce10-459f-87f7-bb243b854fc3.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "0060dad6-8a5b-55b3-a02d-4b725db44fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d54f3-d21f-4854-a4ab-5912771330a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d54f3-d21f-4854-a4ab-5912771330a5.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "7e89a663-bf8a-56bf-84f1-90629eefb6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79c17d2-dcf1-4464-ae58-5ea5117ae531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79c17d2-dcf1-4464-ae58-5ea5117ae531.jpg?1",
             "name": "Fit of Rage",
             "text": "Target creature gets +3/+3 and gains first strike until end of turn.",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "dc31c349-4d3e-5278-bffa-1f8f19a2b61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75509b1c-ae9c-4708-8f9b-67af18a7e9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75509b1c-ae9c-4708-8f9b-67af18a7e9d3.jpg?1",
             "name": "Flame Spirit",
             "text": "oo\nR Flame Spirit gets +1/+0 until end of turn.",
             "colours": [
@@ -5815,7 +5815,7 @@
         },
         {
             "id": "3143095b-57f3-57e5-925f-e56ad4485c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc2cc5-4438-481a-83b0-bf822d3f44cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc2cc5-4438-481a-83b0-bf822d3f44cd.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains.",
             "colours": [
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "c8f6d493-9300-57eb-ac0c-0d489123e0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28f7c1c-1d75-4d78-8577-1e98cf8e0703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28f7c1c-1d75-4d78-8577-1e98cf8e0703.jpg?1",
             "name": "Giant Strength",
             "text": "Enchanted creature gets +2/+2.",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "111b4f6b-3bc3-5a74-82cd-8ec43f8ced7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f9cf20-ad89-4942-83f5-17515c538faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f9cf20-ad89-4942-83f5-17515c538faa.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT, Sacrifice Goblin Digging Team: Destroy target Wall.",
             "colours": [
@@ -5912,7 +5912,7 @@
         },
         {
             "id": "67251729-5da8-5bdb-aced-2db37fef4f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb6e4a7-206e-496d-947a-65cbeae60841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb6e4a7-206e-496d-947a-65cbeae60841.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "Whenever Goblin Elite Infantry blocks or is blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -5946,7 +5946,7 @@
         },
         {
             "id": "b0db89bb-cf92-53ca-a33f-6ddaf3c413b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39f3d36-6648-4e3c-bd9d-336479d1ad72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39f3d36-6648-4e3c-bd9d-336479d1ad72.jpg?1",
             "name": "Goblin Hero",
             "text": "",
             "colours": [
@@ -5979,7 +5979,7 @@
         },
         {
             "id": "807f5631-3a0f-579e-ac6c-307140903bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440546d3-91d4-45f3-ae36-bdf5bec2b673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440546d3-91d4-45f3-ae36-bdf5bec2b673.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and gain mountainwalk. (They're unblockable if defending player controls a mountain.)",
             "colours": [
@@ -6012,7 +6012,7 @@
         },
         {
             "id": "b2060664-c1fc-500a-a56d-d4dd70a064f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd1548-2ffa-4705-ba88-913f37d4ce92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd1548-2ffa-4705-ba88-913f37d4ce92.jpg?1",
             "name": "Goblin Recruiter",
             "text": "When Goblin Recruiter comes into play, search your library for any number of Goblin cards you choose. Reveal those cards, then shuffle your library and put them on top of it in any order you choose.",
             "colours": [
@@ -6045,7 +6045,7 @@
         },
         {
             "id": "a2f44b44-46f6-5ce7-8e41-8371b6e9900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1255654b-f983-4862-9112-9e378ea5d9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1255654b-f983-4862-9112-9e378ea5d9fe.jpg?1",
             "name": "Goblin Warrens",
             "text": "o2o\nR, Sacrifice two Goblins: Put three 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "b34c8734-b49c-5f66-8432-579a13180f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759a8d8-9c6b-4d1b-b17a-6b4f349dd553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759a8d8-9c6b-4d1b-b17a-6b4f349dd553.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "Hammer of Bogardan deals 3 damage to target creature or player.\no2o\nRo\nRoo\nR Return Hammer of Bogardan to your hand. Play this ability only during your upkeep and only if Hammer of Bogardan is in your graveyard.",
             "colours": [
@@ -6107,7 +6107,7 @@
         },
         {
             "id": "5bc78588-6b2e-5efa-92c8-2e6a8680c21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966fa96-2453-4555-8a90-8e4b7a393038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966fa96-2453-4555-8a90-8e4b7a393038.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops can't block.",
             "colours": [
@@ -6140,7 +6140,7 @@
         },
         {
             "id": "4bde8263-f5a9-517d-9758-7a2854bdf1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d68c39-cfdd-4883-9058-d648d073ae36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d68c39-cfdd-4883-9058-d648d073ae36.jpg?1",
             "name": "Illicit Auction",
             "text": "Choose target creature. Each player may bid life for control of that creature. You begin the bidding at 0. Proceeding in turn order, each player may top the high bid. The auction ends when the high bid stands. The high bidder loses life equal to the high bid and gains control of the creature.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "292917d0-ca49-57c0-a484-8e85957d906d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfa44a4-5351-4334-a9d5-c5c19fcccca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfa44a4-5351-4334-a9d5-c5c19fcccca5.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and each player.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "253975b1-3e63-5132-bfa3-50839ca51d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef08669-ccce-45a3-94fc-d3caa213c068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef08669-ccce-45a3-94fc-d3caa213c068.jpg?1",
             "name": "Jokulhaups",
             "text": "Destroy all artifacts, creatures, and lands. They can't be regenerated.",
             "colours": [
@@ -6233,7 +6233,7 @@
         },
         {
             "id": "a9717f9b-5817-5b40-bcd2-b0582f4dd755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c92e4a-34d2-4947-9c5f-2ceb8e5ae53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c92e4a-34d2-4947-9c5f-2ceb8e5ae53d.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "85a5bff3-1766-554e-b67e-cfc93029af2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4942f9-c3ec-4cb1-9300-9f6ed9e7caa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4942f9-c3ec-4cb1-9300-9f6ed9e7caa9.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to him or her.",
             "colours": [
@@ -6295,7 +6295,7 @@
         },
         {
             "id": "0199da87-80b6-5816-954c-e58f75835ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47754124-37e2-4878-a711-a3e00ae0bc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47754124-37e2-4878-a711-a3e00ae0bc70.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk (This creature is unblockable if defending player controls a mountain.)",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "5f73f14c-1923-5898-b6b2-36fdaae56222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d71507-d71a-476d-aa8d-9eab60183f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d71507-d71a-476d-aa8d-9eab60183f95.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -6362,7 +6362,7 @@
         },
         {
             "id": "b1772898-24a4-5dd4-a357-e4ae23e71de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11192972-eb57-4042-83f2-2470b49940b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11192972-eb57-4042-83f2-2470b49940b8.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "a17d2332-a3ce-5bf3-bcb9-8a70b4fa4ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04eeaba-7db8-49e8-b775-fbe9c89413fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04eeaba-7db8-49e8-b775-fbe9c89413fd.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "b8fd502a-904e-52c1-aaba-1feae43ebc92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4cb5f-a9f0-41a1-b9a8-ea483e12633f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4cb5f-a9f0-41a1-b9a8-ea483e12633f.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "ef76a188-6cb4-5500-b0fc-2eadd5cd3975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41205d2-ed1c-4c16-a171-096c06016705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41205d2-ed1c-4c16-a171-096c06016705.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6489,7 +6489,7 @@
         },
         {
             "id": "0a6fa674-29eb-5e60-bc3f-c27a13582611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f262e8-0567-4e6d-8435-eda661d89a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f262e8-0567-4e6d-8435-eda661d89a8f.jpg?1",
             "name": "Reckless Embermage",
             "text": "o1oo\nR Reckless Embermage deals 1 damage to target creature or player and 1 damage to itself.",
             "colours": [
@@ -6523,7 +6523,7 @@
         },
         {
             "id": "9169b3ad-56ce-5097-a0de-f5b77ecc90db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb66d77-2bf5-441c-9ef8-1728dc5987ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb66d77-2bf5-441c-9ef8-1728dc5987ca.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You get an additional combat phase followed by an additional main phase this turn.",
             "colours": [
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "61d83a74-5894-5340-977c-0d8b9fed9425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f0585f-f4ea-4b49-b090-8fdf56e5de7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f0585f-f4ea-4b49-b090-8fdf56e5de7d.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -6587,7 +6587,7 @@
         },
         {
             "id": "cae705e7-4d4b-5ca5-b378-3701070e5e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a255e43-be06-45f0-a74e-3436d76899f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a255e43-be06-45f0-a74e-3436d76899f9.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "9b2a6416-37e8-5159-8bc1-b39c5511633e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5129c8a-735b-44f5-9233-24b905e3103a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5129c8a-735b-44f5-9233-24b905e3103a.jpg?1",
             "name": "Shatterstorm",
             "text": "Destroy all artifacts. They can't be regenerated.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "93080b10-1d25-53ff-a53a-45f84afcf871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a68db8-5e4e-4c98-a319-7717cc39e831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a68db8-5e4e-4c98-a319-7717cc39e831.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "0f685883-f795-561c-b765-264154e0c57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ec1676-f59b-4ab6-995c-d2525ac11370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ec1676-f59b-4ab6-995c-d2525ac11370.jpg?1",
             "name": "Spitting Drake",
             "text": "Flying\noo\nR Spitting Drake gets +1/+0 until end of turn. Spend no more than o\nR this way each turn.",
             "colours": [
@@ -6713,7 +6713,7 @@
         },
         {
             "id": "af2147c0-bc9c-5cfe-a8ed-0da90e52a1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e87de2-9d6b-4158-a871-5c81d05db7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e87de2-9d6b-4158-a871-5c81d05db7f0.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to target creature damage equal to the number of mountains you control.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "5f5bf4cb-db6d-5578-9b0e-2e49de51d0e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9a0841-609f-4a57-8a4a-39d460e31af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9a0841-609f-4a57-8a4a-39d460e31af8.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "5a6b8aba-fd83-58c8-8bfa-b04f0324b5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4f1317-5e9b-4f49-9ed8-4f97f8c4b8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4f1317-5e9b-4f49-9ed8-4f97f8c4b8d0.jpg?1",
             "name": "Talruum Minotaur",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6809,7 +6809,7 @@
         },
         {
             "id": "ae5b91a1-e3b3-5ab9-9d76-d70163962171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f143421-a770-4df1-a593-af24025bdb2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f143421-a770-4df1-a593-af24025bdb2f.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "85fd4264-3530-52be-a60b-ead5e53862d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58ac6a-095e-47d7-ba42-56d148e3c6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58ac6a-095e-47d7-ba42-56d148e3c6b9.jpg?1",
             "name": "Vertigo",
             "text": "Vertigo deals 2 damage to target creature with flying. That creature loses flying until end of turn.",
             "colours": [
@@ -6871,7 +6871,7 @@
         },
         {
             "id": "07999653-91b7-5c87-9fdc-5164518aa5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb467271-898f-4bcd-8533-e8165b318b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb467271-898f-4bcd-8533-e8165b318b43.jpg?1",
             "name": "Viashino Warrior",
             "text": "",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "85221803-4a54-500c-b651-1c01a3dbe9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983c88c-6b0d-498a-b8e8-65b9733db62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983c88c-6b0d-498a-b8e8-65b9733db62c.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying; haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "0c9ac8dc-7ad9-50cf-9b11-991db5e207bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e89d367-b213-4f73-8f23-79788c00d7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e89d367-b213-4f73-8f23-79788c00d7c1.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "77db1f33-ec77-51f2-8f82-90f3a80a4306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5da58c5-51a9-4d4b-8b68-a21b6981602d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5da58c5-51a9-4d4b-8b68-a21b6981602d.jpg?1",
             "name": "Wall of Fire",
             "text": "(Walls can't attack.)\noo\nR Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "4bb468a1-c588-5eef-809c-dfbefd741fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad85d15-e700-455d-96f4-dfd6661f9722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad85d15-e700-455d-96f4-dfd6661f9722.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of a color of your choice to your mana pool.",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "884d1652-da1b-5ffa-af7a-b045ee4050e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99602c-92a0-489d-a00d-1e65563365c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99602c-92a0-489d-a00d-1e65563365c6.jpg?1",
             "name": "Call of the Wild",
             "text": "o2o\nGo\nG: Reveal the top card of your library. If it's a creature card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "2b1123d2-6520-5825-a878-e87cf4e95b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90823485-83cd-4260-b860-7f05d8588905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90823485-83cd-4260-b860-7f05d8588905.jpg?1",
             "name": "Cat Warriors",
             "text": "Forestwalk (This creature is unblockable if defending player controls a forest.)",
             "colours": [
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "81892ec7-c0cf-5fa2-9cbf-b4bafcb868ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4cf599-2fd6-46cc-a3dc-4fe8e4c21f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4cf599-2fd6-46cc-a3dc-4fe8e4c21f42.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, land, or enchantment.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "6bf0deb5-c48a-5c8c-bd9c-d79d6fa433d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6232f04-cd4c-4889-97dc-cccc4a09f9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6232f04-cd4c-4889-97dc-cccc4a09f9c4.jpg?1",
             "name": "Dense Foliage",
             "text": "Creatures can't be the targets of spells.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "57643b43-85a6-58db-8356-f3f571e6164e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df2d73-e58b-43e7-90ad-2d61ca33ccbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df2d73-e58b-43e7-90ad-2d61ca33ccbb.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "f9b09a30-b48a-58bc-904d-13eca3bd05ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da912a54-ab69-4765-b23e-7b9d622590a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da912a54-ab69-4765-b23e-7b9d622590a8.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG, oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "a302bb3f-80e3-53ec-8d22-65dc451cca8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d3d239-1e16-4a23-9098-ee67d32e0208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d3d239-1e16-4a23-9098-ee67d32e0208.jpg?1",
             "name": "Elven Cache",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "57b3f0fc-ad27-5985-b0c4-59ca2dac8086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6da6713-f5bd-4613-90d1-37d62b3ed011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6da6713-f5bd-4613-90d1-37d62b3ed011.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders can't be blocked except by creatures with flying or Walls.",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "9edbea9f-2dbf-5c39-8af3-39c828914591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164ee97d-736e-4659-878d-d161c204142e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164ee97d-736e-4659-878d-d161c204142e.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -7326,7 +7326,7 @@
         },
         {
             "id": "b67edbea-92b9-58aa-8aa2-e536f07baa66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b02b12-415c-49f4-9f60-fa53beb4216f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b02b12-415c-49f4-9f60-fa53beb4216f.jpg?1",
             "name": "Fallow Earth",
             "text": "Put target land on top of its owner's library.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "73337c44-0367-565d-be8b-4f3841e07756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e963b-d316-4c45-8c01-4a40042b977e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e963b-d316-4c45-8c01-4a40042b977e.jpg?1",
             "name": "Familiar Ground",
             "text": "Each creature you control can't be blocked by more than one creature each combat.",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "9e084e17-1aa9-5364-a90f-8695e563616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17fb15-fa7a-45f1-b2a4-0b4729a69fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17fb15-fa7a-45f1-b2a4-0b4729a69fea.jpg?1",
             "name": "Femeref Archers",
             "text": "oc\nT: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -7422,7 +7422,7 @@
         },
         {
             "id": "4ba798c6-c5a9-50ab-903c-af0348c80f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c06b61-f6b7-47d1-820a-01eb3f4497bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c06b61-f6b7-47d1-820a-01eb3f4497bc.jpg?1",
             "name": "Fog",
             "text": "Creatures deal no combat damage this turn.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "9923c7da-1cb9-590f-ae8f-807c193578f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2a2d39-92dd-4123-8a3f-5c756d22b6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2a2d39-92dd-4123-8a3f-5c756d22b6ee.jpg?1",
             "name": "Fyndhorn Brownie",
             "text": "o2o\nG, oc\nT: Untap target creature.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "7b75b7bb-68ca-50a7-b237-bca7cc995bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8876d176-5f4e-4c3c-b8b8-5a3fe2fedf65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8876d176-5f4e-4c3c-b8b8-5a3fe2fedf65.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool.",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "16016d7f-1ad3-50f4-9e3c-32e31c427906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9299742-564b-48ca-a7fa-cf5ed0d98ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9299742-564b-48ca-a7fa-cf5ed0d98ef6.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "c32d15c9-b980-556a-9771-2a087142153f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f78166-50e9-4aa8-9025-930b46f70041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f78166-50e9-4aa8-9025-930b46f70041.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can block as though it had flying.",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "50a72d88-2af1-5037-ad7f-522c0cc983e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a296e4f-7ac8-4c4b-99d1-c02963d26b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a296e4f-7ac8-4c4b-99d1-c02963d26b74.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1oo\nG Regenerate Gorilla Chieftain.",
             "colours": [
@@ -7617,7 +7617,7 @@
         },
         {
             "id": "47388ac5-8a7b-58c5-86ea-88d423c5ad67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c845b8-40f1-44df-9e91-dab7606f6271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c845b8-40f1-44df-9e91-dab7606f6271.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "19e3e45f-d294-5c20-bfb7-5a8dce45bebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ea4e2-a64e-4aa7-ade1-bbf6b67ce831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ea4e2-a64e-4aa7-ade1-bbf6b67ce831.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "40f40ba4-eca6-5744-bd5e-c63313454125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805d850-e3c2-44b4-87f0-8bba4038717c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805d850-e3c2-44b4-87f0-8bba4038717c.jpg?1",
             "name": "Living Lands",
             "text": "All forests are 1/1 creatures that are still lands.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "ca44162b-6c9f-53de-9e58-21c5b7a3330d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95a9a7-b0a3-4199-8c05-2519ccda738b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95a9a7-b0a3-4199-8c05-2519ccda738b.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [
@@ -7746,7 +7746,7 @@
         },
         {
             "id": "6658c957-68a3-517f-92e5-58065b020082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79eff92-b47f-4fc6-960c-f085127841ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79eff92-b47f-4fc6-960c-f085127841ca.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -7779,7 +7779,7 @@
         },
         {
             "id": "976403ae-815f-5352-8ae8-f8c30849c932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee9fb8b-5f1a-45ee-b9a4-a024b7b0936d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee9fb8b-5f1a-45ee-b9a4-a024b7b0936d.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -7812,7 +7812,7 @@
         },
         {
             "id": "f5c91798-9394-5821-8156-ce6133629a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95a777-9ba6-4858-9ea9-255b5301c71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a95a777-9ba6-4858-9ea9-255b5301c71a.jpg?1",
             "name": "Nature's Resurgence",
             "text": "Each player draws as many cards as there are creature cards in his or her graveyard.",
             "colours": [
@@ -7843,7 +7843,7 @@
         },
         {
             "id": "87422cc4-b774-5bd6-afec-7d0c5e8a9cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba165e25-5328-40f4-b87c-9d02590f9d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba165e25-5328-40f4-b87c-9d02590f9d38.jpg?1",
             "name": "Panther Warriors",
             "text": "",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "c0a47ab0-9c32-5edd-9149-dc3c740e6a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9b18c-4993-4ce1-b2bd-ab14c9f3aad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9b18c-4993-4ce1-b2bd-ab14c9f3aad7.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nG, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -7911,7 +7911,7 @@
         },
         {
             "id": "5eb161aa-25a4-55d3-9574-5179dd63e6a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae5f0a-1fea-4c20-85b2-4b8eb2aba57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae5f0a-1fea-4c20-85b2-4b8eb2aba57c.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying until end of turn.",
             "colours": [
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "9d792b53-cd66-514c-9c33-5605701c489b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061c59-f8f3-4d47-9996-6f75ef27bd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061c59-f8f3-4d47-9996-6f75ef27bd4e.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -7975,7 +7975,7 @@
         },
         {
             "id": "fc87b990-0811-58ad-b381-0f32528eceeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a954994b-1858-47d3-a81a-5b01d4ea7619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a954994b-1858-47d3-a81a-5b01d4ea7619.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -8008,7 +8008,7 @@
         },
         {
             "id": "1c5bed86-d47d-5fa2-a46a-3e2b7233cc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3fc7bf-4a12-479a-af13-9b5703d46a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3fc7bf-4a12-479a-af13-9b5703d46a3a.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "ceded080-aaca-59b5-83b5-ad776b1dcb32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff58d35-eb23-47ee-9b8c-6919ad1a413a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff58d35-eb23-47ee-9b8c-6919ad1a413a.jpg?1",
             "name": "River Boa",
             "text": "Islandwalk (This creature is unblockable if defending player controls an island.)\noo\nG Regenerate River Boa.",
             "colours": [
@@ -8074,7 +8074,7 @@
         },
         {
             "id": "d895f1b4-94a1-5315-8f47-186baed198af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f17db7-6f3f-45ec-9ed2-dd15ce25ff07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f17db7-6f3f-45ec-9ed2-dd15ce25ff07.jpg?1",
             "name": "Rowen",
             "text": "Reveal the first card you draw each turn. Whenever you reveal a basic land card this way, draw a card.",
             "colours": [
@@ -8105,7 +8105,7 @@
         },
         {
             "id": "8fe9cd75-7611-5c41-a9ad-25663ab328fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3d8906-52d5-4ed1-b548-be13ca82f21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3d8906-52d5-4ed1-b548-be13ca82f21a.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -8138,7 +8138,7 @@
         },
         {
             "id": "1cd7f4ef-c22f-524a-8021-f462f179d9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f7b4be-dce2-414e-a9f4-f7e46c1bd15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f7b4be-dce2-414e-a9f4-f7e46c1bd15e.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk (This creature is unblockable if defending player controls a forest.)",
             "colours": [
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "340b6c6c-f4e0-5464-9b63-77e514344eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35730e8e-bc86-41d5-9c7a-75a92e6dd11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35730e8e-bc86-41d5-9c7a-75a92e6dd11e.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be blocked by more than one creature each combat.",
             "colours": [
@@ -8205,7 +8205,7 @@
         },
         {
             "id": "2c4c5e5b-3613-5b32-a348-1e2b90b1b53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b52f44-11fb-470a-b7ab-aaaeaf6f05e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b52f44-11fb-470a-b7ab-aaaeaf6f05e2.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "b6fe306d-e1c0-50d7-90ca-dbec48e1a35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185823cc-8c08-481f-9429-e996f4983090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185823cc-8c08-481f-9429-e996f4983090.jpg?1",
             "name": "Summer Bloom",
             "text": "Play up to three additional lands this turn.",
             "colours": [
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "4fd23af5-4a40-55a2-8ec4-49cb6d04918a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182fcd8-96ff-4232-917a-0fb4eb9bb7c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182fcd8-96ff-4232-917a-0fb4eb9bb7c2.jpg?1",
             "name": "Thicket Basilisk",
             "text": "Whenever Thicket Basilisk blocks or becomes blocked by a non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "84868018-50b8-5b99-8fa2-3180c256b3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6956b1-148e-47cc-8f5b-ec31e5e8c030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6956b1-148e-47cc-8f5b-ec31e5e8c030.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "c63a9ecb-5874-558f-9f75-013c4abf13e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177118a-6455-4177-8a6d-a43a03160ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177118a-6455-4177-8a6d-a43a03160ab3.jpg?1",
             "name": "Tranquil Grove",
             "text": "o1o\nGoo\nG Destroy all other enchantments.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "f2716d3d-6536-52ed-a45a-d94fcb7964ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51255821-abb7-4b8a-bc74-eb6c9788de02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51255821-abb7-4b8a-bc74-eb6c9788de02.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -8395,7 +8395,7 @@
         },
         {
             "id": "ce43db94-23d5-5ab2-8fb3-4ef1c0303664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a944ef-dbf2-47c9-a245-dfd2533a0680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a944ef-dbf2-47c9-a245-dfd2533a0680.jpg?1",
             "name": "Uktabi Orangutan",
             "text": "When Uktabi Orangutan comes into play, destroy target artifact.",
             "colours": [
@@ -8428,7 +8428,7 @@
         },
         {
             "id": "9035630b-2cef-5fc2-8df5-f85969db4368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7570b03-400e-482f-9d90-2d48b95d5ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7570b03-400e-482f-9d90-2d48b95d5ac3.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "Uktabi Wildcats's power and toughness are each equal to the number of forests you control.\no\nG, Sacrifice a forest: Regenerate Uktabi Wildcats.",
             "colours": [
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "a4241efe-b56a-5f34-a9a0-8ba3fb372dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc03eea5-ff21-4f4d-b4c2-ce9d8f456440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc03eea5-ff21-4f4d-b4c2-ce9d8f456440.jpg?1",
             "name": "Unseen Walker",
             "text": "Forestwalk (This creature is unblockable if defending player controls a forest.)\no1o\nGoo\nG Target creature gains forestwalk until end of turn.",
             "colours": [
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "8122a194-0945-574f-b746-50be2ca9c271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e522c2-ed5d-46bc-b043-6a37d6402a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e522c2-ed5d-46bc-b043-6a37d6402a9f.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a basic land card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "81523555-1efe-588b-925b-124e10f7a2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77131286-50ec-47a3-80fb-6194da338de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77131286-50ec-47a3-80fb-6194da338de6.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -8559,7 +8559,7 @@
         },
         {
             "id": "9086302a-37e4-59f8-9cc0-cf6fc52171ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a4569-fa62-4e1a-b837-f68159cb270d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a4569-fa62-4e1a-b837-f68159cb270d.jpg?1",
             "name": "Vitalize",
             "text": "Untap all creatures you control.",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "fdbe5c97-3eb1-57a4-8e75-0873ee98171d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6.jpg?1",
             "name": "Waiting in the Weeds",
             "text": "Each player counts the untapped forests he or she controls and puts that many 1/1 green Cat creature tokens into play.",
             "colours": [
@@ -8621,7 +8621,7 @@
         },
         {
             "id": "c9c681b6-ac13-5e1e-ad3d-c83e5c21ad85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65630c7-3813-404c-9919-0e46c557f7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65630c7-3813-404c-9919-0e46c557f7b8.jpg?1",
             "name": "Warthog",
             "text": "Swampwalk (This creature is unblockable if defending player controls a swamp.)",
             "colours": [
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "1125b692-e3c7-5b5a-b1bd-1dd6ac480787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac714416-60ec-477d-b49f-83b3853a409f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac714416-60ec-477d-b49f-83b3853a409f.jpg?1",
             "name": "Wild Growth",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional o\nG.",
             "colours": [
@@ -8687,7 +8687,7 @@
         },
         {
             "id": "44196b0e-62a9-507c-a224-6bcfcf60c29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d9054-5ad8-4a7d-a5c8-58bc39051834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d9054-5ad8-4a7d-a5c8-58bc39051834.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "80100e3c-7686-5578-99ca-211c11a226ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a24af58-5d75-4b41-a226-60abc415ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a24af58-5d75-4b41-a226-60abc415ff71.jpg?1",
             "name": "Wyluli Wolf",
             "text": "oc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -8751,7 +8751,7 @@
         },
         {
             "id": "a580f461-2432-53b0-b097-6496f6c68daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6595fe-8190-4e8c-8731-cd801f550eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6595fe-8190-4e8c-8731-cd801f550eab.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "3b0bfa9b-b62f-5b0a-8853-6a253dcc13e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db90a5e7-8238-442a-a6a4-78c59a6adb3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db90a5e7-8238-442a-a6a4-78c59a6adb3d.jpg?1",
             "name": "Amber Prison",
             "text": "You may choose not to untap Amber Prison during your untap step.\no4, oc\nT: Tap target artifact, creature, or land. As long as Amber Prison is tapped, that permanent doesn't untap during its controller's untap step.",
             "colours": [],
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "6e1067cb-0677-515b-b8d0-ebab556cafd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07903f1-defc-4ec7-accb-724b0219acd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07903f1-defc-4ec7-accb-724b0219acd8.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Whenever a land comes into play, Ankh of Mishra deals 2 damage to that land's controller.",
             "colours": [],
@@ -8832,7 +8832,7 @@
         },
         {
             "id": "d9076564-9e77-56db-9804-af3e9682e074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f8965-ecd3-4da2-80aa-9c5034c0cd3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f8965-ecd3-4da2-80aa-9c5034c0cd3b.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "8faf8cf8-ec0c-57eb-94d8-60e4d1d07e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec36f9a-cd66-4c01-ae3f-42fd82f0546b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec36f9a-cd66-4c01-ae3f-42fd82f0546b.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o1, Sacrifice Bottle of Suleiman: Flip a coin. If you lose the flip, Bottle of Suleiman deals 5 damage to you. If you win the flip, put a 5/5 Djinn artifact creature token into play. That creature has flying.",
             "colours": [],
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "0ddce71f-4e8a-5058-b746-33f977a99f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc870ce-f296-4cb8-950f-69440651f4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc870ce-f296-4cb8-950f-69440651f4e7.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond comes into play tapped.\noc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -8915,7 +8915,7 @@
         },
         {
             "id": "28119080-a4ac-5aa6-98ed-6d7b27400a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f1b0a3-fae4-4b87-99be-db1edabe62ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f1b0a3-fae4-4b87-99be-db1edabe62ed.jpg?1",
             "name": "Crystal Rod",
             "text": "Whenever a player plays a blue spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "a483eb21-8cf8-524c-afc5-3f06b0f4939b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048ceee4-0a56-4e43-92f2-80058844baba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048ceee4-0a56-4e43-92f2-80058844baba.jpg?1",
             "name": "Cursed Totem",
             "text": "Players can't play activated abilities of creatures.",
             "colours": [],
@@ -8969,7 +8969,7 @@
         },
         {
             "id": "df5954ce-8fd1-5896-8c33-d9b210fbf49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e64a6d-f54a-418e-8a84-63033447ab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e64a6d-f54a-418e-8a84-63033447ab38.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "42beeb5d-9f5b-51f4-9473-d69ec0ebea4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4262efc-c464-4f67-8885-2160d6a7f542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4262efc-c464-4f67-8885-2160d6a7f542.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into a graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "2434eb8a-1602-5cbb-ac9d-c9f2d1021e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c246aa71-b833-495b-9b12-54bd158dc2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c246aa71-b833-495b-9b12-54bd158dc2a8.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player chooses and discards a card from his or her hand. Play this ability only during your turn.",
             "colours": [],
@@ -9053,7 +9053,7 @@
         },
         {
             "id": "9b6158ff-2e73-5f56-a6da-3757fdae5636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b785730-32eb-40c0-83d0-a7ea59aac3e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b785730-32eb-40c0-83d0-a7ea59aac3e7.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: Dragon Engine gets +1/+0 until end of turn.",
             "colours": [],
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "f961f488-828c-5a92-a6ab-71c26e9910f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5109270-b052-489c-951c-d4b21a41ff6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5109270-b052-489c-951c-d4b21a41ff6f.jpg?1",
             "name": "Dragon Mask",
             "text": "o3, oc\nT: Target creature you control gets +2/+2 until end of turn. At end of turn, return that creature to its owner's hand.",
             "colours": [],
@@ -9110,7 +9110,7 @@
         },
         {
             "id": "3f8c9722-8330-5c16-ae46-06b9d3b36bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57070e7-6359-4be2-b4d3-4a3489a2deaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57070e7-6359-4be2-b4d3-4a3489a2deaa.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond comes into play tapped.\noc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -9139,7 +9139,7 @@
         },
         {
             "id": "a87dd351-b1dc-5da8-b518-b0b1bb9ccbf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936233f9-ad2a-4be1-8107-3ddcad783a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936233f9-ad2a-4be1-8107-3ddcad783a30.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn.",
             "colours": [],
@@ -9166,7 +9166,7 @@
         },
         {
             "id": "bb1bffde-5a2d-53fd-9b6d-6a45011a132d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40eed5d-adc2-469b-9a17-e368e8ebc34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40eed5d-adc2-469b-9a17-e368e8ebc34f.jpg?1",
             "name": "Fountain of Youth",
             "text": "o2, oc\nT: You gain 1 life.",
             "colours": [],
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "6b2852fb-b423-587d-976f-67e01b8e28b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc743ec-4845-4e2e-8918-7e7854ecccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc743ec-4845-4e2e-8918-7e7854ecccfc.jpg?1",
             "name": "Glasses of Urza",
             "text": "oc\nT: Look at target player's hand.",
             "colours": [],
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "ce3ecc70-35be-5733-bbf2-670a3e3de90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95017ca7-4f45-4aea-9973-ca3f0833f77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95017ca7-4f45-4aea-9973-ca3f0833f77f.jpg?1",
             "name": "Grinning Totem",
             "text": "o2, oc\nT, Sacrifice Grinning Totem: Search target opponent's library for a card and set that card aside. That player then shuffles his or her library. You may play the card as though it were in your hand. At the beginning of your next upkeep, if you haven't played the card, put it into its owner's graveyard.",
             "colours": [],
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "298dae5c-c604-56b2-97d6-96bce98f4e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3aa493-3801-400e-965e-e518c38eb770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3aa493-3801-400e-965e-e518c38eb770.jpg?1",
             "name": "The Hive",
             "text": "o5, oc\nT: Put a 1/1 Wasp artifact creature token into play. That creature has flying.",
             "colours": [],
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "c9ed18aa-0fc0-59b3-9134-dc2ff7681381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a6afe-c030-458c-8cc5-5051e0cd6fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a6afe-c030-458c-8cc5-5051e0cd6fd2.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws an additional card.",
             "colours": [],
@@ -9301,7 +9301,7 @@
         },
         {
             "id": "00a3da0c-10ca-5fab-a2b7-07b459f61fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1a0e8-3ca4-4928-9299-36efce7fb641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1a0e8-3ca4-4928-9299-36efce7fb641.jpg?1",
             "name": "Iron Star",
             "text": "Whenever a player plays a red spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "c23fc7d5-10ed-5fa8-b097-66b98f784415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade1a965-fd85-4545-a850-65c93132b8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade1a965-fd85-4545-a850-65c93132b8b5.jpg?1",
             "name": "Ivory Cup",
             "text": "Whenever a player plays a white spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -9355,7 +9355,7 @@
         },
         {
             "id": "1797f329-fc13-5898-86da-84a1d98482f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3055a4-9a1e-4cd3-993e-8fecb6eee9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3055a4-9a1e-4cd3-993e-8fecb6eee9a3.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: The next time a source of your choice would deal damage to target creature this turn, that damage is dealt to you instead.",
             "colours": [],
@@ -9382,7 +9382,7 @@
         },
         {
             "id": "ac3a6b9f-32cd-5aae-a0ba-d7fa062466b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0489c2d-bcf9-4179-b07a-781c6ac07980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0489c2d-bcf9-4179-b07a-781c6ac07980.jpg?1",
             "name": "Jalum Tome",
             "text": "o2, oc\nT: Draw a card, then choose and discard a card from your hand.",
             "colours": [],
@@ -9409,7 +9409,7 @@
         },
         {
             "id": "d140ba57-f08b-5c36-82eb-5c24df3bb636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c53463-5e99-430d-b824-2650264e8fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c53463-5e99-430d-b824-2650264e8fe8.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw a card.",
             "colours": [],
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "43ca3ff6-4455-588b-b894-3d436f116cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba3857-9bd7-434d-b77f-d697776f33e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba3857-9bd7-434d-b77f-d697776f33e4.jpg?1",
             "name": "Lead Golem",
             "text": "Whenever Lead Golem attacks, it doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "a997ee26-0720-5665-a019-c5926a14e307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f77654-7e37-4c0d-9dd2-fb79e968bd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f77654-7e37-4c0d-9dd2-fb79e968bd15.jpg?1",
             "name": "Mana Prism",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add one mana of a color of your choice to your mana pool.",
             "colours": [],
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "c02ccc0c-103b-5ee3-adb9-7beba95c2402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20b4858-3648-4a86-a3c1-698254f90d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20b4858-3648-4a86-a3c1-698254f90d5b.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond comes into play tapped.\noc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "1c8f7cc9-fdf2-5017-adcd-1a335903738f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d01df6-ede2-4cca-89a5-b041b1238ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d01df6-ede2-4cca-89a5-b041b1238ebb.jpg?1",
             "name": "Meekstone",
             "text": "Each creature with power 3 or greater doesn't untap during its controller's untap step.",
             "colours": [],
@@ -9549,7 +9549,7 @@
         },
         {
             "id": "d14e65f4-6db9-5b3a-b8ad-69f0d07b6baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8207d783-2548-45fe-b830-d24c677c1c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8207d783-2548-45fe-b830-d24c677c1c8e.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Put the top two cards of target player's library into his or her graveyard.",
             "colours": [],
@@ -9576,7 +9576,7 @@
         },
         {
             "id": "72475d53-4202-5a84-8e68-74a5166f9646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2551f-f267-4c30-b631-d755e43dc237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2551f-f267-4c30-b631-d755e43dc237.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond comes into play tapped.\noc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "4bc5e73f-4d71-525c-8422-928178b3e663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80bfd76-52f9-4dea-9056-8570c9b290a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80bfd76-52f9-4dea-9056-8570c9b290a4.jpg?1",
             "name": "Mystic Compass",
             "text": "o1, oc\nT: Target land is a basic land type of your choice until end of turn.",
             "colours": [],
@@ -9632,7 +9632,7 @@
         },
         {
             "id": "e221143b-1e7d-5d8d-b94f-bb51eb55393e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96123be9-c1df-418f-b2b3-98746a0f1692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96123be9-c1df-418f-b2b3-98746a0f1692.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "ebaf3ee3-65a2-5be7-a83f-9f3385d7b762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c6ac8a-01b1-4af5-89d8-ad66d9a81ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c6ac8a-01b1-4af5-89d8-ad66d9a81ceb.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -9692,7 +9692,7 @@
         },
         {
             "id": "2b7e2aa0-e8b1-50dc-a92f-9358e6999032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d7ea-6240-44a4-9792-6a8416d15e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d7ea-6240-44a4-9792-6a8416d15e49.jpg?1",
             "name": "Patagia Golem",
             "text": "o3: Patagia Golem gains flying until end of turn.",
             "colours": [],
@@ -9722,7 +9722,7 @@
         },
         {
             "id": "a156c4c3-63fe-50c3-a43c-8a69f7966eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b5650-8b2c-4d2d-9829-3208c130116a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b5650-8b2c-4d2d-9829-3208c130116a.jpg?1",
             "name": "Pentagram of the Ages",
             "text": "o4, oc\nT: The next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [],
@@ -9749,7 +9749,7 @@
         },
         {
             "id": "ea2487bc-a6a9-53b4-a4f5-d7865d958b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f4d88-4773-4520-b4df-22ae6008ebc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f4d88-4773-4520-b4df-22ae6008ebc1.jpg?1",
             "name": "Phyrexian Vault",
             "text": "o2, oc\nT, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "506f047e-5ca7-59f4-aa93-47543c894387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f588d-9ee6-4436-ad75-46a84dd2b168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f588d-9ee6-4436-ad75-46a84dd2b168.jpg?1",
             "name": "Primal Clay",
             "text": "Primal Clay comes into play as your choice of a 3/3 artifact creature; a 2/2 artifact creature with flying; or a 1/6 Wall artifact creature. (Walls can't attack.)",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "5456bcf2-b8c9-5415-9e50-23c83ae50af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bf5fd-141a-4743-ad73-70ec2173e476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bf5fd-141a-4743-ad73-70ec2173e476.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -9833,7 +9833,7 @@
         },
         {
             "id": "920e48e1-1185-51a2-9a15-83b253d207df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1967f0-f6a9-469a-96f9-57fe77059e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1967f0-f6a9-469a-96f9-57fe77059e88.jpg?1",
             "name": "Skull Catapult",
             "text": "o1, oc\nT, Sacrifice a creature: Skull Catapult deals 2 damage to target creature or player.",
             "colours": [],
@@ -9860,7 +9860,7 @@
         },
         {
             "id": "6c80de5b-efbe-5323-a934-7ff4773f757a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c771a9-a652-4661-a175-a97d4684cd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c771a9-a652-4661-a175-a97d4684cd92.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond comes into play tapped.\noc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -9889,7 +9889,7 @@
         },
         {
             "id": "853c438e-81c0-5067-b317-82a046b3ad0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9bc174-1d10-49bf-af4f-2f6061b1796e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9bc174-1d10-49bf-af4f-2f6061b1796e.jpg?1",
             "name": "Snake Basket",
             "text": "o\nX, Sacrifice Snake Basket: Put X 1/1 green Cobra creature tokens into play. Play this ability only if you're allowed to play a sorcery.",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "f0ee2f13-9add-5873-9436-61d75a34aeba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22d79a5-1da4-475e-9605-f4c7bdc76590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22d79a5-1da4-475e-9605-f4c7bdc76590.jpg?1",
             "name": "Soul Net",
             "text": "Whenever a creature is put into a graveyard from play, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -9943,7 +9943,7 @@
         },
         {
             "id": "9094bfdf-cc94-57f8-8603-c65476dca3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab556986-a6f4-4445-b004-64b4bc189e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab556986-a6f4-4445-b004-64b4bc189e55.jpg?1",
             "name": "Storm Cauldron",
             "text": "Each player may play an additional land during each of his or her turns.\nWhenever a land is tapped for mana, return it to its owner's hand.",
             "colours": [],
@@ -9970,7 +9970,7 @@
         },
         {
             "id": "eefb27ca-2d90-5471-afb1-07f0e0a9f95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5caf27-e426-420b-895d-a359e6021993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5caf27-e426-420b-895d-a359e6021993.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player counts the cards in his or her hand, puts them on the bottom of his or her library, and then draws that many cards.",
             "colours": [],
@@ -9997,7 +9997,7 @@
         },
         {
             "id": "be26096f-3770-53d2-9167-5f7f8c613eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca1df90-d51a-4d2f-a03f-a4591031671d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca1df90-d51a-4d2f-a03f-a4591031671d.jpg?1",
             "name": "Throne of Bone",
             "text": "Whenever a player plays a black spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -10024,7 +10024,7 @@
         },
         {
             "id": "f147e35f-8b9b-5636-9189-56c4b70d3152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f37dd8-87d6-432f-a60d-a7a699da3080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f37dd8-87d6-432f-a60d-a7a699da3080.jpg?1",
             "name": "Wand of Denial",
             "text": "oc\nT: Look at the top card of target player's library. If it's a nonland card, you may pay 2 life. If you do, put it into that player's graveyard.",
             "colours": [],
@@ -10051,7 +10051,7 @@
         },
         {
             "id": "1b6ba678-3313-56d9-9c99-4e198b64998e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef706d86-6e7f-4f3a-9e4d-8aa6d9aac74a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef706d86-6e7f-4f3a-9e4d-8aa6d9aac74a.jpg?1",
             "name": "Wooden Sphere",
             "text": "Whenever a player plays a green spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -10078,7 +10078,7 @@
         },
         {
             "id": "82327e30-d60c-5733-8d8e-3caddc957530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764eff32-466f-4443-a3db-1007f446980b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764eff32-466f-4443-a3db-1007f446980b.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "0f6bde03-6078-5786-8064-c352a8589136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792f4213-67ab-41d9-975d-ff783668f93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792f4213-67ab-41d9-975d-ff783668f93d.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "d60769cf-9eaa-557a-9f16-db7e4f92414c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff64e0-e7bd-4e82-8495-2cc8889c4107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff64e0-e7bd-4e82-8495-2cc8889c4107.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass is tapped, it deals 1 damage to you.\noc\nT: Add one mana of a color of your choice to your mana pool.",
             "colours": [],
@@ -10165,7 +10165,7 @@
         },
         {
             "id": "fa4f7fd8-becd-5deb-98a4-7e907f348cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a807243-fdcd-4dfb-b9d1-a15859a15c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a807243-fdcd-4dfb-b9d1-a15859a15c51.jpg?1",
             "name": "Crystal Vein",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Crystal Vein: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "1ac0ed04-a088-5323-b275-fe7c02cd6355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840627fa-dec9-481e-b356-56f3d079a60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840627fa-dec9-481e-b356-56f3d079a60c.jpg?1",
             "name": "Dwarven Ruins",
             "text": "Dwarven Ruins comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Dwarven Ruins: Add o\nRo\nR to your mana pool.",
             "colours": [],
@@ -10221,7 +10221,7 @@
         },
         {
             "id": "6cef8b4d-18d9-5eb9-b44f-e427c9cc1085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b386a-d148-41c8-b540-5637cc0eb458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b386a-d148-41c8-b540-5637cc0eb458.jpg?1",
             "name": "Ebon Stronghold",
             "text": "Ebon Stronghold comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Ebon Stronghold: Add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "3913206a-4d26-5026-a94b-3e892535241b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2f7ee8-bd9b-40a7-9ae2-268b4b9f8315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2f7ee8-bd9b-40a7-9ae2-268b4b9f8315.jpg?1",
             "name": "Havenwood Battleground",
             "text": "Havenwood Battleground comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Havenwood Battleground: Add o\nGo\nG to your mana pool.",
             "colours": [],
@@ -10279,7 +10279,7 @@
         },
         {
             "id": "1b24ca7e-8657-5541-91bb-7c405f8b77ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e8e26-3fb3-4388-bc64-fa751e401dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e8e26-3fb3-4388-bc64-fa751e401dca.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "c9e9a206-c2a5-5f8d-bafb-a6f0806da45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaeb7-7061-4e8c-a086-32a12b6e2666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaeb7-7061-4e8c-a086-32a12b6e2666.jpg?1",
             "name": "Ruins of Trokair",
             "text": "Ruins of Trokair comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Ruins of Trokair: Add o\nWo\nW to your mana pool.",
             "colours": [],
@@ -10338,7 +10338,7 @@
         },
         {
             "id": "e51ebe50-e880-5a44-acaf-a90060ffd5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e40dcb-fde5-4eb0-9e2b-6109132332a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e40dcb-fde5-4eb0-9e2b-6109132332a8.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -10368,7 +10368,7 @@
         },
         {
             "id": "5cd433cb-23fc-5466-badf-8ee04cc66b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d57618a-21d2-4ded-9f17-d72786869b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d57618a-21d2-4ded-9f17-d72786869b19.jpg?1",
             "name": "Svyelunite Temple",
             "text": "Svyelunite Temple comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Svyelunite Temple: Add o\nUo\nU to your mana pool.",
             "colours": [],
@@ -10397,7 +10397,7 @@
         },
         {
             "id": "28be14cd-96a2-52c6-b462-c7d8951be39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142dd41a-0e98-41d7-9de9-63cda1cf8915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142dd41a-0e98-41d7-9de9-63cda1cf8915.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "22ee9de2-7951-56cd-9048-b9418a2c842e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1ab59-3771-484c-8a79-2bb36655b6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1ab59-3771-484c-8a79-2bb36655b6dd.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10464,7 +10464,7 @@
         },
         {
             "id": "f86dec0f-e26d-531b-807a-93d4f7259ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c789adc0-69ed-4d1c-8a20-ca219020fd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c789adc0-69ed-4d1c-8a20-ca219020fd2c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "4cf91220-6c0a-57aa-84fc-4659adb0c8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addf844-2790-4da5-a22d-18df878f2219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addf844-2790-4da5-a22d-18df878f2219.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10538,7 +10538,7 @@
         },
         {
             "id": "7d721cd4-0444-5c87-babf-7118a1d3066b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978fa58-0860-4082-a674-2d6abce899b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978fa58-0860-4082-a674-2d6abce899b9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10575,7 +10575,7 @@
         },
         {
             "id": "bb1aa770-47eb-5daf-a089-e37ad44dfa5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f9ffc8-8115-4858-bd71-deaca9889f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f9ffc8-8115-4858-bd71-deaca9889f72.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10612,7 +10612,7 @@
         },
         {
             "id": "a16d4088-e362-5c17-9b1c-4033c13834b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e8da7b-f565-403b-9603-5f53cd3be8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e8da7b-f565-403b-9603-5f53cd3be8fe.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10649,7 +10649,7 @@
         },
         {
             "id": "094ab429-388b-52e0-93a6-5855781e744f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8958d4-067b-4815-a128-5d1577b94173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8958d4-067b-4815-a128-5d1577b94173.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10686,7 +10686,7 @@
         },
         {
             "id": "bc879be8-0856-5688-b4d0-9bb0f2747eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ff74a8-e1e8-41ec-98fc-1529f4075074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ff74a8-e1e8-41ec-98fc-1529f4075074.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "0c83ca66-3282-533d-8344-cbfda7d18faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2a9fa6-3c7c-409a-8565-e3d533107971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2a9fa6-3c7c-409a-8565-e3d533107971.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10760,7 +10760,7 @@
         },
         {
             "id": "4cd8b145-a2ab-508b-99d6-65bda4bfdfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af0cba-c058-4833-a74a-21ad91e5ad7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af0cba-c058-4833-a74a-21ad91e5ad7c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10797,7 +10797,7 @@
         },
         {
             "id": "6bdebecc-b0e9-5f42-a6ab-db585b98c3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9019a639-929a-40d9-98b1-6b5268da5246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9019a639-929a-40d9-98b1-6b5268da5246.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10834,7 +10834,7 @@
         },
         {
             "id": "151f0d39-58bc-5e8e-ac8f-67f2c7e13720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c576c27d-f361-4448-8607-0f6a99642283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c576c27d-f361-4448-8607-0f6a99642283.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10871,7 +10871,7 @@
         },
         {
             "id": "cea0db39-b74c-5f20-9334-aabb6c192f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e450ae-3ed8-424f-b974-7d9a8e8ac7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e450ae-3ed8-424f-b974-7d9a8e8ac7e4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10908,7 +10908,7 @@
         },
         {
             "id": "aefce677-f215-565c-8db4-10bbfb2c9d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7681b-37e3-4f6c-8415-ab9613446ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7681b-37e3-4f6c-8415-ab9613446ccc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10945,7 +10945,7 @@
         },
         {
             "id": "d824822e-0943-5a46-bfd9-e4a134c74c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c17b3c-6f3b-4952-a06b-0df5a5a18f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c17b3c-6f3b-4952-a06b-0df5a5a18f0d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "a9dc2754-2a14-574d-ab28-fd34958e6126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95585c69-6474-432e-b80a-489a2b69d4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95585c69-6474-432e-b80a-489a2b69d4e6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11019,7 +11019,7 @@
         },
         {
             "id": "25d0bf7f-1a5d-579f-97f3-f4b18db45d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc477b44-a7b3-4dda-b897-6f164e28541b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc477b44-a7b3-4dda-b897-6f164e28541b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11056,7 +11056,7 @@
         },
         {
             "id": "612715d9-fcfa-51c7-beb3-3a93f10da4b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c256a-1f0e-4e57-9667-5b8cb2f18ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c256a-1f0e-4e57-9667-5b8cb2f18ff0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11093,7 +11093,7 @@
         },
         {
             "id": "60bd17e0-c71c-5700-8ec5-ba8badbb9a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade2cdc-9625-427b-92b2-9596ac48904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade2cdc-9625-427b-92b2-9596ac48904b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11130,7 +11130,7 @@
         },
         {
             "id": "f99a52fc-d88e-5225-849a-4c3e96d66e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e57a496-09ce-4c2d-9a00-0c359d01e78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e57a496-09ce-4c2d-9a00-0c359d01e78e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/7ED.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/7ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "cfe05eff-7428-53ef-afc8-788ef5964925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aebe60-bbd4-4591-bf3c-6cec67e41cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aebe60-bbd4-4591-bf3c-6cec67e41cf6.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "ab55424f-58d5-5d9b-bc0d-01e9368aa5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a610860b-cc2f-4f7e-99f4-481d15c7cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a610860b-cc2f-4f7e-99f4-481d15c7cd90.jpg?1",
             "name": "Angelic Page",
             "text": "",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "1ba5c10c-b45e-5151-96bf-2f3d158c2985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67252f6-0265-4f4e-8db8-2d1853262f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67252f6-0265-4f4e-8db8-2d1853262f91.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "7dd7c5f8-8b74-541c-952c-26e72f799657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b57b5e-134e-45a7-92d6-670d762d68b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b57b5e-134e-45a7-92d6-670d762d68b4.jpg?1",
             "name": "Ardent Militia",
             "text": "",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "f5dfb9d3-eb40-5f32-a1cd-90534b56b01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1d373-f619-4855-9154-aee6deeacb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1d373-f619-4855-9154-aee6deeacb59.jpg?1",
             "name": "Blessed Reversal",
             "text": "You gain 3 life for each creature attacking you.",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "c812a5f0-2a05-51f8-9ae2-f6667d15920d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aaa618-ebe9-43ff-90dd-7ab1429f2c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aaa618-ebe9-43ff-90dd-7ab1429f2c58.jpg?1",
             "name": "Blessed Reversal",
             "text": "",
             "colours": [
@@ -214,7 +214,7 @@
         },
         {
             "id": "8601b57c-aa16-50a3-b80c-c7cb077705b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee1bad3-85e0-4c65-916c-d744e6e6ec61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee1bad3-85e0-4c65-916c-d744e6e6ec61.jpg?1",
             "name": "Breath of Life",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "d59b03b8-27ca-5b35-8c98-e64130464d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a985b-d57a-4409-9ec4-fabd31afc461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a985b-d57a-4409-9ec4-fabd31afc461.jpg?1",
             "name": "Breath of Life",
             "text": "",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "1d5daf66-94b9-5e7b-8086-950384df8f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe82e29-e781-48bf-8673-7954553f7cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe82e29-e781-48bf-8673-7954553f7cf0.jpg?1",
             "name": "Castle",
             "text": "Untapped creatures you control get +0/+2.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "92913e85-7b3a-5970-896f-b2ddf8615338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c73efe3-e3ab-4161-88cc-82d3ac7d6a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c73efe3-e3ab-4161-88cc-82d3ac7d6a4a.jpg?1",
             "name": "Castle",
             "text": "",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "e4aff119-2578-5b1b-92c1-ab83bfc9bcef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7967ce4-6688-40d0-bedb-4e0f38502f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7967ce4-6688-40d0-bedb-4e0f38502f09.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "0699ca11-e6d0-5503-ae33-ea74ff283a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c8da0-0201-41ab-be98-8ed3a899cd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c8da0-0201-41ab-be98-8ed3a899cd3d.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "592f46da-afcc-51fe-b323-e5d3daab5f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babb5c99-6cb1-4b13-8aac-e495d508a61c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babb5c99-6cb1-4b13-8aac-e495d508a61c.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: The next time a blue source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "84ef0f0c-116a-5812-8fff-88ef661c48ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb254e-137f-4920-9e2b-d4fbe7861101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb254e-137f-4920-9e2b-d4fbe7861101.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "9a898043-cf57-5192-9355-31eac4114e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0b146-4241-436b-b8b0-45a9be21ead7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0b146-4241-436b-b8b0-45a9be21ead7.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: The next time a green source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "89737e69-cc9d-54a6-a9ed-c43895af45d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf8b0e9-a420-4066-b423-90eec1f27eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf8b0e9-a420-4066-b423-90eec1f27eb0.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "a3d7c9d3-c252-5254-8590-068935de2085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4833ce-5e7b-402e-97a9-4411aa62a46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4833ce-5e7b-402e-97a9-4411aa62a46c.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "c51f205a-106c-5e98-bc98-81c000831c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a65a2a3-ee40-4a00-aa66-f64b04ccdaa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a65a2a3-ee40-4a00-aa66-f64b04ccdaa8.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "16bdfc1c-f8ea-51c1-a64b-2ffd02cbfe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cab871-5783-40e1-a065-0607a842998b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cab871-5783-40e1-a065-0607a842998b.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: The next time a white source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "d7b9f247-8d3d-5718-b9cf-589b331908cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d55297-9049-4627-8154-bafdef63c66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d55297-9049-4627-8154-bafdef63c66d.jpg?1",
             "name": "Circle of Protection: White",
             "text": "",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "6aa8923c-0503-5f48-9ae6-3600d5d83106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cd5854-56ef-48ec-ad12-1690fa45b4a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cd5854-56ef-48ec-ad12-1690fa45b4a5.jpg?1",
             "name": "Cloudchaser Eagle",
             "text": "Flying\nWhen Cloudchaser Eagle comes into play, destroy target enchantment.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "95b3f21f-96c6-5ff2-b22f-0c0ba36ece6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c95d068-e153-4ac9-bce6-c79ef4fe101d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c95d068-e153-4ac9-bce6-c79ef4fe101d.jpg?1",
             "name": "Cloudchaser Eagle",
             "text": "",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "25c3ae0f-f7eb-5745-a5bc-6c86f0a308ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61cc896-1da5-419c-87db-01321522c40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61cc896-1da5-419c-87db-01321522c40b.jpg?1",
             "name": "Crossbow Infantry",
             "text": "oc\nT: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "537acf95-677a-5eff-aed9-38316aef66b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bedaa217-8dbd-4d2c-961a-a7cff2398832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bedaa217-8dbd-4d2c-961a-a7cff2398832.jpg?1",
             "name": "Crossbow Infantry",
             "text": "",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "143b0fd0-d24d-5edc-acf6-94674be12e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f71fc-807c-4718-956b-7ffe66c646d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f71fc-807c-4718-956b-7ffe66c646d4.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "a7569782-df72-5df9-85ed-9232374eced9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4715aacd-ca2f-4dbf-b1a1-c171dea7305f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4715aacd-ca2f-4dbf-b1a1-c171dea7305f.jpg?1",
             "name": "Disenchant",
             "text": "",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "5e817a4b-0fcd-546b-8cda-9ed63d4ec0b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b89ce6-8a73-4e27-8696-e65ea0c16925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b89ce6-8a73-4e27-8696-e65ea0c16925.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "8ef1aa9e-c26a-5fa0-b1e2-94840eb54302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b718ad-1ca3-4587-994d-6a9df47db1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b718ad-1ca3-4587-994d-6a9df47db1e0.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "25e2bc90-61c6-54f8-885c-44741131681c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dc7a7b-ec69-406f-82c5-9af54ac1e9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dc7a7b-ec69-406f-82c5-9af54ac1e9a3.jpg?1",
             "name": "Elite Archers",
             "text": "oc\nT: Elite Archers deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "bedd66e9-a754-5bf6-b2ae-8b4e5ffa0f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269193a9-2647-4b7a-a51b-6e2eae160020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269193a9-2647-4b7a-a51b-6e2eae160020.jpg?1",
             "name": "Elite Archers",
             "text": "",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "53b59473-d5e9-524e-b823-a963080d618e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43378f0-b518-499e-9950-c583bc2f11f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43378f0-b518-499e-9950-c583bc2f11f8.jpg?1",
             "name": "Gerrard's Wisdom",
             "text": "You gain 2 life for each card in your hand.",
             "colours": [
@@ -1065,7 +1065,7 @@
         },
         {
             "id": "73c9e320-f0ab-5cec-82a5-d018b763ca6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71618fb4-22ab-4ef5-932d-69bf596a69d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71618fb4-22ab-4ef5-932d-69bf596a69d0.jpg?1",
             "name": "Gerrard's Wisdom",
             "text": "",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "618b0e3d-b864-56a9-a6ca-04cb0e26ca2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f18de6-a99b-49ce-812b-bca8b0aaec38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f18de6-a99b-49ce-812b-bca8b0aaec38.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "1e1f8f5d-6df1-5770-99e6-2e8c475d7224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607ddd6d-db70-4db0-a3ac-caaa911c8fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607ddd6d-db70-4db0-a3ac-caaa911c8fe4.jpg?1",
             "name": "Glorious Anthem",
             "text": "",
             "colours": [
@@ -1164,7 +1164,7 @@
         },
         {
             "id": "2e5ec1d9-e7cb-579e-acfd-49144acd031b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670a69a-bd68-4de9-bf83-c912564012f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9670a69a-bd68-4de9-bf83-c912564012f6.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "de7577ff-c717-56bb-a2d2-96ec3378e771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eff9691-f3e0-4622-ae8f-b884763bbcd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eff9691-f3e0-4622-ae8f-b884763bbcd6.jpg?1",
             "name": "Healing Salve",
             "text": "",
             "colours": [
@@ -1230,7 +1230,7 @@
         },
         {
             "id": "8fed2ceb-3f5b-5ba5-8baa-77b14aa57553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b665186-7ee5-47dd-b849-cb9c318f31e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b665186-7ee5-47dd-b849-cb9c318f31e6.jpg?1",
             "name": "Heavy Ballista",
             "text": "oc\nT: Heavy Ballista deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "38da3bb8-dfa6-5bc3-aa50-05ea80d495ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6e66f3-8a2e-4b68-b483-7cb6923bd9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6e66f3-8a2e-4b68-b483-7cb6923bd9f9.jpg?1",
             "name": "Heavy Ballista",
             "text": "",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "762fbb16-0eba-5815-beeb-472711966e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabca37-9099-41ca-a169-33332c82d76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabca37-9099-41ca-a169-33332c82d76f.jpg?1",
             "name": "Holy Strength",
             "text": "Enchanted creature gets +1/+2.",
             "colours": [
@@ -1337,7 +1337,7 @@
         },
         {
             "id": "1a055628-85a1-570d-987a-5c127c70450f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20ca0f-8747-43a6-9723-bca7669badb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20ca0f-8747-43a6-9723-bca7669badb7.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1372,7 +1372,7 @@
         },
         {
             "id": "cf3a5ffb-78eb-5452-8830-578bff7d5335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff788a3-3182-4bf5-897e-521d977e6aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff788a3-3182-4bf5-897e-521d977e6aaf.jpg?1",
             "name": "Honor Guard",
             "text": "oo\nW Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "a0b83a94-6684-58eb-879c-c9e57b1062be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3725d9-b58a-4632-b542-26fa94b3ba6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3725d9-b58a-4632-b542-26fa94b3ba6b.jpg?1",
             "name": "Honor Guard",
             "text": "",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "04895a52-82da-52ac-9806-afafd142071d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49430d37-03af-4088-a92b-9e0ff3defe29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49430d37-03af-4088-a92b-9e0ff3defe29.jpg?1",
             "name": "Intrepid Hero",
             "text": "oc\nT: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1480,7 +1480,7 @@
         },
         {
             "id": "3977f1a4-6418-51e7-b791-85a8769ed27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f544e171-c26b-4c14-96ff-3d3ddce7e785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f544e171-c26b-4c14-96ff-3d3ddce7e785.jpg?1",
             "name": "Intrepid Hero",
             "text": "",
             "colours": [
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "2fcaae1c-3291-5b33-adea-5a94ea324217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da50eb5-e559-4d67-8568-d5be80ff62de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da50eb5-e559-4d67-8568-d5be80ff62de.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: All combat damage that unblocked creatures would deal to you this turn is dealt to Kjeldoran Royal Guard instead.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "8873d399-e0cc-52d8-b7b0-6969cdcd4de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb58da0d-4f11-4973-ac9c-d541031ff728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb58da0d-4f11-4973-ac9c-d541031ff728.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "9c6449d5-0a0c-5ee4-a0aa-97c9193bcbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1d55b-6be0-4bb5-b452-ba4994b21774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1d55b-6be0-4bb5-b452-ba4994b21774.jpg?1",
             "name": "Knight Errant",
             "text": "",
             "colours": [
@@ -1624,7 +1624,7 @@
         },
         {
             "id": "5d118f3d-68e3-56a9-b45e-5d7e9e180ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413f10fe-0e53-46ca-bd64-0d66dee8882d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413f10fe-0e53-46ca-bd64-0d66dee8882d.jpg?1",
             "name": "Knight Errant",
             "text": "",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "c9bc5770-4953-5547-a872-0a3dc13c30a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da88c0a-255d-4484-b464-bd742d66e3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da88c0a-255d-4484-b464-bd742d66e3fe.jpg?1",
             "name": "Knighthood",
             "text": "Creatures you control have first strike.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "34b70cd0-fa14-5ae5-9693-c563674b7f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e367b-329f-4ee6-be1e-6263ccc0f06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e367b-329f-4ee6-be1e-6263ccc0f06d.jpg?1",
             "name": "Knighthood",
             "text": "",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "03266ee0-8dad-50cd-a304-9d2acb3c833c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac3672e-ebab-4bb1-bf4d-5020047296d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac3672e-ebab-4bb1-bf4d-5020047296d8.jpg?1",
             "name": "Longbow Archer",
             "text": "First strike\nLongbow Archer may block as though it had flying.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "0ee33b35-0a47-535f-842e-530f79e49fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0437fd-070a-4679-b1c9-6cb22820d181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0437fd-070a-4679-b1c9-6cb22820d181.jpg?1",
             "name": "Longbow Archer",
             "text": "",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "d32b62b9-13eb-52c4-87e6-6350d7183efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfdc12c-fd1f-4053-8a1a-63f440ef0102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfdc12c-fd1f-4053-8a1a-63f440ef0102.jpg?1",
             "name": "Master Healer",
             "text": "oc\nT: Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "48904c35-c5d3-527f-bddf-2cbe48c2838a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5be6df-f35e-4696-a08e-fd725ee9b13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5be6df-f35e-4696-a08e-fd725ee9b13c.jpg?1",
             "name": "Master Healer",
             "text": "",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "d55f9832-d162-5d37-9a7a-c9f367d09f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed1fb50-b7c3-43e9-a0ef-a33135a12300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed1fb50-b7c3-43e9-a0ef-a33135a12300.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target black permanent.",
             "colours": [
@@ -1908,7 +1908,7 @@
         },
         {
             "id": "db315f00-61b8-572a-ab4a-6a387cf89800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cce5e-3af9-4f51-8d65-35be576df236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cce5e-3af9-4f51-8d65-35be576df236.jpg?1",
             "name": "Northern Paladin",
             "text": "",
             "colours": [
@@ -1944,7 +1944,7 @@
         },
         {
             "id": "96ad96eb-1325-5b1b-821b-cae348224b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6758f0-86da-4812-bbe0-ebbb8c67937a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6758f0-86da-4812-bbe0-ebbb8c67937a.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "006f4667-e7b7-5937-a6fb-76fb6ecb29f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3524e49-93df-4a3d-808e-7a2d31c3a12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3524e49-93df-4a3d-808e-7a2d31c3a12d.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "e5a88536-54c7-576d-b734-14f53099a0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079b8e9b-74ac-48c0-8c65-82d70911dd9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079b8e9b-74ac-48c0-8c65-82d70911dd9e.jpg?1",
             "name": "Pariah",
             "text": "All damage that would be dealt to you is dealt to enchanted creature instead.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "8b0773fc-9a64-5a6c-aa42-0286709b9659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a94805d-9f71-4968-a297-7d93859fe79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a94805d-9f71-4968-a297-7d93859fe79f.jpg?1",
             "name": "Pariah",
             "text": "",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "2f4a2e9c-1e59-589c-bcac-bfcdfc59177b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfb77ea-6776-4bb4-886d-9a60f56e1fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfb77ea-6776-4bb4-886d-9a60f56e1fa7.jpg?1",
             "name": "Purify",
             "text": "Destroy all artifacts and enchantments.",
             "colours": [
@@ -2117,7 +2117,7 @@
         },
         {
             "id": "890387a6-de62-5e6e-a38c-f08c057ff255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f84bff-a9e7-4bc4-9dc9-b5eb34166d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f84bff-a9e7-4bc4-9dc9-b5eb34166d40.jpg?1",
             "name": "Purify",
             "text": "",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "670fa953-60ac-52f6-8ad5-fe3567e9f3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc73761c-6d1a-4466-9be1-b350a1dcc48a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc73761c-6d1a-4466-9be1-b350a1dcc48a.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "39439f67-3de7-5774-baf0-c81b408c461b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3131a2d-05b3-494c-9373-e1a7913615f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3131a2d-05b3-494c-9373-e1a7913615f9.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "70124c60-9bf0-5526-9b4a-b6df7b64e4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3868f7ff-8a84-4153-bf5a-ff001d34e0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3868f7ff-8a84-4153-bf5a-ff001d34e0f0.jpg?1",
             "name": "Reprisal",
             "text": "Destroy target creature with power 4 or greater. It can't be regenerated.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "741a14a5-6ad0-5e68-af8a-6d801822da2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f73b0f4-cf49-4ae3-8117-0e2e37c7ab31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f73b0f4-cf49-4ae3-8117-0e2e37c7ab31.jpg?1",
             "name": "Reprisal",
             "text": "",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "5a5c7cdb-2545-5dcf-9ade-59b04a8bf89b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af458eaa-ee16-4b2b-9a55-259458357224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af458eaa-ee16-4b2b-9a55-259458357224.jpg?1",
             "name": "Reverse Damage",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain that much life.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "2a410da7-4d99-532d-80d0-0b94a4950bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867777d-000d-48b9-99da-1c2194722dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1867777d-000d-48b9-99da-1c2194722dde.jpg?1",
             "name": "Reverse Damage",
             "text": "",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "dc814515-3dd0-5fbd-9fe3-66730d4549b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9993e9c6-2e30-4bf4-838d-751cbd153390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9993e9c6-2e30-4bf4-838d-751cbd153390.jpg?1",
             "name": "Rolling Stones",
             "text": "Walls may attack as though they weren't Walls.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "0c5b30c5-d905-5a09-8265-2b6c31babb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66582c6-2eaa-43a8-a0cd-43dab0abc656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66582c6-2eaa-43a8-a0cd-43dab0abc656.jpg?1",
             "name": "Rolling Stones",
             "text": "",
             "colours": [
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "9196ef2d-f7d3-5a57-a416-edc1ff0b2621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43ccab9-c059-4f25-b27c-3f2d506251bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43ccab9-c059-4f25-b27c-3f2d506251bd.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever a spell or ability an opponent controls puts a land into your graveyard from play, return that land to play.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "d2d6f984-0896-53ee-8bf7-5d9d67c416c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83d48a7-c6d3-4aa9-8416-88eece34a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83d48a7-c6d3-4aa9-8416-88eece34a158.jpg?1",
             "name": "Sacred Ground",
             "text": "",
             "colours": [
@@ -2484,7 +2484,7 @@
         },
         {
             "id": "aab9b93d-0fc6-558b-ad35-d6f284d37fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f298a56d-8a33-46b1-aca0-acb68cdb3e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f298a56d-8a33-46b1-aca0-acb68cdb3e29.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "065ad7ce-8339-5d24-9d6c-a70fe2e730eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4b8de0-0bb5-40fb-8b73-d00d38a582d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4b8de0-0bb5-40fb-8b73-d00d38a582d5.jpg?1",
             "name": "Sacred Nectar",
             "text": "",
             "colours": [
@@ -2550,7 +2550,7 @@
         },
         {
             "id": "50549bb2-eeb1-59a3-bd23-7d1ad0f88b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d997ce-6b08-4058-a7f8-82cc74b9974d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d997ce-6b08-4058-a7f8-82cc74b9974d.jpg?1",
             "name": "Samite Healer",
             "text": "oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "985ac0f6-0ca6-50a8-9966-6bad1fd3635d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ff360-3f4c-40e7-acb0-273cb35a903d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ff360-3f4c-40e7-acb0-273cb35a903d.jpg?1",
             "name": "Samite Healer",
             "text": "",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "4fb4da71-0f73-5740-aa9d-ca3e94c6ca44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f15d4-e0e9-416b-9fe8-66c86160ff1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f15d4-e0e9-416b-9fe8-66c86160ff1a.jpg?1",
             "name": "Sanctimony",
             "text": "Whenever an opponent taps a mountain for mana, you may gain 1 life.",
             "colours": [
@@ -2655,7 +2655,7 @@
         },
         {
             "id": "54b7e74d-e916-55e5-9d33-9cefc21c7c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273a8178-bae8-4668-9827-abcf9485554e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273a8178-bae8-4668-9827-abcf9485554e.jpg?1",
             "name": "Sanctimony",
             "text": "",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "f5e7d5d6-3bdf-506a-b440-f54d89d32a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40221db-f36f-40e4-9029-5c18422cc172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40221db-f36f-40e4-9029-5c18422cc172.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "b5dfa47a-b233-56bf-8111-2b0f8204a9c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96600d-9592-4bf7-aea2-5ebf0660b915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96600d-9592-4bf7-aea2-5ebf0660b915.jpg?1",
             "name": "Seasoned Marshal",
             "text": "",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "9ea1b179-4e0e-5edc-a029-4d3a2bb7db2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a411716d-aff1-4b8f-961d-a873707b9f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a411716d-aff1-4b8f-961d-a873707b9f2a.jpg?1",
             "name": "Serra Advocate",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "515e62b3-c4ea-58c3-8f5a-2b99243d5798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f05d654-f3d1-4965-9d89-9848d6fc2123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f05d654-f3d1-4965-9d89-9848d6fc2123.jpg?1",
             "name": "Serra Advocate",
             "text": "",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "609a05ca-05bf-5feb-a96d-16fe0e2d64a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b4e357-de48-4461-8109-bbb07fff5171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b4e357-de48-4461-8109-bbb07fff5171.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nAttacking doesn't cause Serra Angel to tap.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "1badea75-a7fd-5407-926a-2adaeb770d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a398d30-2db9-4530-9f68-fb4dd6ebcbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a398d30-2db9-4530-9f68-fb4dd6ebcbd2.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "d7c50d4d-e9ce-5fdd-a77e-5627137375c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff41d966-5c11-4732-99e1-ada41a6020a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff41d966-5c11-4732-99e1-ada41a6020a7.jpg?1",
             "name": "Serra's Embrace",
             "text": "Enchanted creature gets +2/+2, has flying, and attacking doesn't cause it to tap.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "74af2163-63e4-5317-833e-98af52fcbb45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06573466-dd60-4cab-acdc-9287daf232cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06573466-dd60-4cab-acdc-9287daf232cf.jpg?1",
             "name": "Serra's Embrace",
             "text": "",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "1a4417b3-b11a-50fb-a0b4-1a3acce82014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b70c30-dbc9-4d30-81d8-b0bde9b626df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b70c30-dbc9-4d30-81d8-b0bde9b626df.jpg?1",
             "name": "Shield Wall",
             "text": "Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "fbc4d75d-8b2c-5c5e-b463-f83808500007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb49655-ba5c-4a62-881d-669593a398c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb49655-ba5c-4a62-881d-669593a398c8.jpg?1",
             "name": "Shield Wall",
             "text": "",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "8e618cc1-e3b7-57fa-b4eb-bee4aa015636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41aec1d-d86f-4a52-a446-5cef71d1ebd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41aec1d-d86f-4a52-a446-5cef71d1ebd4.jpg?1",
             "name": "Skyshroud Falcon",
             "text": "Flying\nAttacking doesn't cause Skyshroud Falcon to tap.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "053b653d-1192-5eeb-bc4c-34825e412443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f46ee43-9706-41cf-b413-3b5fec762194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f46ee43-9706-41cf-b413-3b5fec762194.jpg?1",
             "name": "Skyshroud Falcon",
             "text": "",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "34227385-7126-56d2-8b99-cbf5da31a4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fa1570-3103-494c-8316-8f0bf484f22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fa1570-3103-494c-8316-8f0bf484f22d.jpg?1",
             "name": "Southern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target red permanent.",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "73eaf424-96c9-5664-aec7-7e47c52bfc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a98f74-1b59-47ce-b5ab-dda5aefd9f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a98f74-1b59-47ce-b5ab-dda5aefd9f78.jpg?1",
             "name": "Southern Paladin",
             "text": "",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "8d757fae-1745-5268-a802-37a44e792c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f92671-5023-4cf1-bc06-58e8c094c6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f92671-5023-4cf1-bc06-58e8c094c6a2.jpg?1",
             "name": "Spirit Link",
             "text": "Whenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "cb9cab04-a32d-586b-bb37-bb7552c1a8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a6a4db-045d-48f7-8f82-4486231d755a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a6a4db-045d-48f7-8f82-4486231d755a.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "c2e57261-b07c-553c-a89a-62eea0304dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb299f-5601-4852-9fea-3c375b4851e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ccb299f-5601-4852-9fea-3c375b4851e8.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking doesn't cause Standing Troops to tap.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "e2444c3d-44a4-5d88-b830-4a9160c5d40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71123df7-1a4d-47cd-a72e-44c431860e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71123df7-1a4d-47cd-a72e-44c431860e88.jpg?1",
             "name": "Standing Troops",
             "text": "",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "769251bb-f938-5f0e-9cd7-9c19d0353cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9ef338-1a74-433c-a7d9-f667246e6622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9ef338-1a74-433c-a7d9-f667246e6622.jpg?1",
             "name": "Starlight",
             "text": "You gain 3 life for each black creature target opponent controls.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "8db11048-9279-5dfd-be51-22c33fafb2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413c5a7e-e19d-4cbd-9279-88391b75c6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413c5a7e-e19d-4cbd-9279-88391b75c6c5.jpg?1",
             "name": "Starlight",
             "text": "",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "ace51b53-fc1c-5d4a-9768-16bdaf5f62fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c5acf-efcb-4df9-b956-b7bce336a5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c5acf-efcb-4df9-b956-b7bce336a5cb.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, you gain 4 life.",
             "colours": [
@@ -3422,7 +3422,7 @@
         },
         {
             "id": "d25a01b1-8c6e-5bcf-8913-e5be75be927a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc642f16-049f-499b-a300-5f5a7372b98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc642f16-049f-499b-a300-5f5a7372b98f.jpg?1",
             "name": "Staunch Defenders",
             "text": "",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "91826b17-014e-56f6-bdb4-6be103a6a18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8466271c-0d9b-4680-a856-efabc7dbc1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8466271c-0d9b-4680-a856-efabc7dbc1ef.jpg?1",
             "name": "Sunweb",
             "text": "(Walls can't attack.)\nFlying\nSunweb can't block creatures with power 2 or less.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "82aac0a4-2158-5908-af9f-80b5925730a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fdb8e2-76d6-4471-8fe3-c83872f0c198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fdb8e2-76d6-4471-8fe3-c83872f0c198.jpg?1",
             "name": "Sunweb",
             "text": "",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "dd37ad18-2d39-521f-80b4-35736efce32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb7af98-1fba-488b-9e92-2f6a35eb4866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb7af98-1fba-488b-9e92-2f6a35eb4866.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "Flying\nWhenever Sustainer of the Realm blocks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "7567d80c-4877-5cf8-81ae-3b4315644700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286955b5-c866-44f4-a76b-54632192918d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286955b5-c866-44f4-a76b-54632192918d.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "1e7c11ca-a0c7-5d9b-9a28-197d81b19d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b59eeaf-5629-4216-8d97-1dbd1927b8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b59eeaf-5629-4216-8d97-1dbd1927b8fe.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "efc3a32f-b214-5f74-8c01-19ba4466e704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac3fb9a-f4c8-421b-994f-418bb340e84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac3fb9a-f4c8-421b-994f-418bb340e84b.jpg?1",
             "name": "Venerable Monk",
             "text": "",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "2496c546-1cff-5e0a-9d56-4b7c247f0cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b9836-fee4-4e83-add7-5e13cb1275d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011b9836-fee4-4e83-add7-5e13cb1275d6.jpg?1",
             "name": "Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "fb239dcf-2831-5416-b6d1-552adac746bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0e4d5a-079c-429f-b4f7-aa12fded1dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0e4d5a-079c-429f-b4f7-aa12fded1dce.jpg?1",
             "name": "Vengeance",
             "text": "",
             "colours": [
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "792e6e9f-d995-58db-9489-813f72597915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade80fd-813e-4823-a7ac-2989c440a4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ade80fd-813e-4823-a7ac-2989c440a4d8.jpg?1",
             "name": "Wall of Swords",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "10f2067b-1fad-5b98-9c35-7af9cb55ca59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df722ab-3302-4158-a9fb-f0f9608f0cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df722ab-3302-4158-a9fb-f0f9608f0cec.jpg?1",
             "name": "Wall of Swords",
             "text": "",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "b0e52a09-3dfe-5f4e-85b8-75e9c341ca5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7cacaf-6dd9-4ed3-b589-30854a501021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7cacaf-6dd9-4ed3-b589-30854a501021.jpg?1",
             "name": "Worship",
             "text": "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "07742ac0-f4f6-506e-b0ed-1892e53fffc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3283f4-1228-4fb4-9b97-8a9a90929cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3283f4-1228-4fb4-9b97-8a9a90929cb2.jpg?1",
             "name": "Worship",
             "text": "",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "fd6f7db2-e6aa-58a6-a67c-7cb5ceb2edcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d223e83-0d3c-459e-96f5-ba9227fe49dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d223e83-0d3c-459e-96f5-ba9227fe49dd.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "e97cfc4f-02c6-5d46-87e8-2adfbd3119fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc5ed6-41ff-4f8a-b47a-fc9390c2aa81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc5ed6-41ff-4f8a-b47a-fc9390c2aa81.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "54190167-d981-5e50-9e56-330ebe9085ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0331818-208c-460a-b15d-81c8fd54669d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0331818-208c-460a-b15d-81c8fd54669d.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "666bb570-4cab-5c0e-bc3f-04018c09e6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9004140e-0369-44ae-84eb-5208a7ef4ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9004140e-0369-44ae-84eb-5208a7ef4ced.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "8c8d0389-4822-5f04-bd49-b6f58def95ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0ca8-a66a-452f-be5f-17f631ba0ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0ca8-a66a-452f-be5f-17f631ba0ee0.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your library. Put two of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "b1f6b954-62da-5092-bdb9-f8ee4ebe324f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfe6027-1e97-45b1-949b-73e6cf25bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfe6027-1e97-45b1-949b-73e6cf25bc82.jpg?1",
             "name": "Ancestral Memories",
             "text": "",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "32fef4e0-249f-5a51-b087-a88793a31792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e3bcd7-60f8-472a-ada0-c3147cf06588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e3bcd7-60f8-472a-ada0-c3147cf06588.jpg?1",
             "name": "Arcane Laboratory",
             "text": "Each player can't play more than one spell each turn.",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "aac0a14f-b0e4-5f82-9668-679ac064eda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783435f7-5fb1-49bb-98a3-b8da8f76ce25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783435f7-5fb1-49bb-98a3-b8da8f76ce25.jpg?1",
             "name": "Arcane Laboratory",
             "text": "",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "94042d07-cd33-52e6-a621-4334ebfce8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e44374d-b327-4193-ad3b-628191461d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e44374d-b327-4193-ad3b-628191461d05.jpg?1",
             "name": "Archivist",
             "text": "oc\nT: Draw a card.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "cf159560-469e-59ad-b17a-bca95dce0651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067421-8481-449e-9c97-6aa1c4610c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067421-8481-449e-9c97-6aa1c4610c71.jpg?1",
             "name": "Archivist",
             "text": "",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "b2a99474-101b-5e9e-a1ff-c90dc4b9616b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c53b808-c2c5-4941-bead-1cb94adc5a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c53b808-c2c5-4941-bead-1cb94adc5a2f.jpg?1",
             "name": "Baleful Stare",
             "text": "Target opponent reveals his or her hand. You draw a card for each mountain and red card in it.",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "623b5465-b24b-53cf-8f9a-19757a066155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f3896d-f54f-44fc-a619-ea3a71a513c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f3896d-f54f-44fc-a619-ea3a71a513c0.jpg?1",
             "name": "Baleful Stare",
             "text": "",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "975bc023-4c8f-54e9-a74d-8de14d08069e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19577bda-2728-40c8-a262-26051e6c226b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19577bda-2728-40c8-a262-26051e6c226b.jpg?1",
             "name": "Benthic Behemoth",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "9fe13a8c-a0f8-5c08-ae7c-ff5a9a47d45d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb24340-0c10-485c-a9a8-3ac65d494a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb24340-0c10-485c-a9a8-3ac65d494a57.jpg?1",
             "name": "Benthic Behemoth",
             "text": "",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "425a5092-204a-5a49-a7f4-967f09b1a182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7e31b5-fe27-44ad-a1d8-7263c3edbc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7e31b5-fe27-44ad-a1d8-7263c3edbc7d.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "c417a2ab-18ab-5c03-9cfa-62e53a7f6a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724b7896-74d0-491a-8aa6-183324660634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724b7896-74d0-491a-8aa6-183324660634.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "429b478f-c7aa-55c9-b058-dfdcd73ecc8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8440565-8359-4283-aad1-6b594a5a96eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8440565-8359-4283-aad1-6b594a5a96eb.jpg?1",
             "name": "Confiscate",
             "text": "You control enchanted permanent.",
             "colours": [
@@ -4451,7 +4451,7 @@
         },
         {
             "id": "b1ce506a-e733-5acd-b539-4fb9038db2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892f0980-eb6b-4454-88b8-e2e79983d065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892f0980-eb6b-4454-88b8-e2e79983d065.jpg?1",
             "name": "Confiscate",
             "text": "",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "0c93c8bc-d5a8-5789-a63d-4d47b164cf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ea1af2-f944-4ee1-88bd-2f3ea09bf9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ea1af2-f944-4ee1-88bd-2f3ea09bf9e6.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "24dbbc34-1567-5037-9884-7b9b9528a077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cb3579-1a75-4ff4-a007-5d65969b887c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cb3579-1a75-4ff4-a007-5d65969b887c.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "e5280460-9949-5bf9-95ce-b1a4be15b1ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bb1b85-9444-4bfa-b622-092a6873631c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bb1b85-9444-4bfa-b622-092a6873631c.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "dc8bb2d4-2d9b-5397-9009-d7438aea2572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed211e-f3ec-4e9e-b9a7-0989930dd049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed211e-f3ec-4e9e-b9a7-0989930dd049.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "f93e1577-2945-55fa-a60c-afd55b960337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f0cbe-aba9-4f20-909e-c4692a5ad899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f0cbe-aba9-4f20-909e-c4692a5ad899.jpg?1",
             "name": "Daring Apprentice",
             "text": "oc\nT, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "67913b1c-506f-5214-b65c-7632870069bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1b9eb1-fd88-48f9-bd06-d0b5578d7f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1b9eb1-fd88-48f9-bd06-d0b5578d7f82.jpg?1",
             "name": "Daring Apprentice",
             "text": "",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "d6321c26-f3bc-5b34-88c0-a18ff3b30a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b18ce34-2ff4-4662-aab3-24c10e9657cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b18ce34-2ff4-4662-aab3-24c10e9657cc.jpg?1",
             "name": "Deflection",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "d1e74389-9c14-57e6-a000-2169c4cef491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1aa45-1cee-4710-8b61-a80b393d597d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1aa45-1cee-4710-8b61-a80b393d597d.jpg?1",
             "name": "Deflection",
             "text": "",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "028871b9-a7aa-5e3d-81e9-be2ffe5b4f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43fba7-699e-4bb5-ab3e-b5b1c290340c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43fba7-699e-4bb5-ab3e-b5b1c290340c.jpg?1",
             "name": "Delusions of Mediocrity",
             "text": "When Delusions of Mediocrity comes into play, you gain 10 life.\nWhen Delusions of Mediocrity leaves play, you lose 10 life.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "81943386-668a-56e9-af5c-f0e101d9485b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8239e492-0946-4278-add2-9bc6a8b3661d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8239e492-0946-4278-add2-9bc6a8b3661d.jpg?1",
             "name": "Delusions of Mediocrity",
             "text": "",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "f2cf0856-09a5-5752-94ee-f34997d15f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbe8836-88c3-4f5d-88a0-73e54673960e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbe8836-88c3-4f5d-88a0-73e54673960e.jpg?1",
             "name": "Equilibrium",
             "text": "Whenever you play a creature spell, you may pay o1. If you do, return target creature to its owner's hand.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "aca5fee7-2e56-512d-9bc6-8136e034f931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef600ab-dca3-4853-88b8-5f3bd7ec0a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef600ab-dca3-4853-88b8-5f3bd7ec0a68.jpg?1",
             "name": "Equilibrium",
             "text": "",
             "colours": [
@@ -4892,7 +4892,7 @@
         },
         {
             "id": "96914b57-aa02-538c-83de-b8739e8ac58d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1144eb-701d-4716-9051-e8b77480e72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1144eb-701d-4716-9051-e8b77480e72d.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "de650645-248d-501d-9429-4cc1a2e9f3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89dd4a6d-271d-4997-8c61-bc6129bf26da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89dd4a6d-271d-4997-8c61-bc6129bf26da.jpg?1",
             "name": "Evacuation",
             "text": "",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "a960b7d8-b782-56b9-8340-1a9a93af9012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76952add-6ca8-4db0-97bd-4a85432be997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76952add-6ca8-4db0-97bd-4a85432be997.jpg?1",
             "name": "Fighting Drake",
             "text": "Flying",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "af9df135-8013-57c7-9f81-47b87d514f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2206-1c9a-4a08-ae13-61e2b5a10727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2206-1c9a-4a08-ae13-61e2b5a10727.jpg?1",
             "name": "Fighting Drake",
             "text": "",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "18feb622-1d2d-5960-8ce9-fbcf11364455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35971a15-7d8f-4b05-918e-605a26a11f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35971a15-7d8f-4b05-918e-605a26a11f4c.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying\no1oo\nU Return Fleeting Image to its owner's hand.",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "3d78320e-cd24-5a5d-83cb-5268479968e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a6f29-6fbf-4fd9-a923-1fdf33abbe16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a6f29-6fbf-4fd9-a923-1fdf33abbe16.jpg?1",
             "name": "Fleeting Image",
             "text": "",
             "colours": [
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "ee43916a-ad02-503b-bc19-c8a3e953740c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abcd7f6-ce34-4c1f-8250-3e262ef0bc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abcd7f6-ce34-4c1f-8250-3e262ef0bc05.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature has flying.",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "cd82c2f8-5b7e-5f08-8f8d-fe54866805ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b8d33-4b80-4ed6-95ce-b672d495be4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b8d33-4b80-4ed6-95ce-b672d495be4e.jpg?1",
             "name": "Flight",
             "text": "",
             "colours": [
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "97661580-c711-569a-a211-7b8e24e164e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d03d73f-0530-4125-8689-1c43e502e331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d03d73f-0530-4125-8689-1c43e502e331.jpg?1",
             "name": "Force Spike",
             "text": "Counter target spell unless its controller pays o1.",
             "colours": [
@@ -5201,7 +5201,7 @@
         },
         {
             "id": "adc70c66-640a-5b32-947d-1bdcf0f2df84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7d6594-a57d-4557-880a-d65f46bb6033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7d6594-a57d-4557-880a-d65f46bb6033.jpg?1",
             "name": "Force Spike",
             "text": "",
             "colours": [
@@ -5234,7 +5234,7 @@
         },
         {
             "id": "b2737892-9493-51ab-a574-e46949afd72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b707b2d-63e1-4c2c-ba42-9e027f02b1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b707b2d-63e1-4c2c-ba42-9e027f02b1ff.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "db25b444-a013-5f63-a45c-cc9eda8459c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6343d49-1336-445d-ac7a-83e436953332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6343d49-1336-445d-ac7a-83e436953332.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "fe988473-7529-5f28-91e0-eb60cf36718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3207ed8-a7b5-490e-bf7e-602937e4408d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3207ed8-a7b5-490e-bf7e-602937e4408d.jpg?1",
             "name": "Glacial Wall",
             "text": "(Walls can't attack.)",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "308a74b7-a3f5-5f43-9104-f446d8baceb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c498cb2-02f7-487d-8561-974f3e516aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c498cb2-02f7-487d-8561-974f3e516aac.jpg?1",
             "name": "Glacial Wall",
             "text": "",
             "colours": [
@@ -5374,7 +5374,7 @@
         },
         {
             "id": "3fca6db4-4bab-5a93-bf72-77fd1536798f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f7d826-ec78-48dd-bed1-e3768e8fa324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f7d826-ec78-48dd-bed1-e3768e8fa324.jpg?1",
             "name": "Hibernation",
             "text": "Return all green permanents to their owners' hands.",
             "colours": [
@@ -5407,7 +5407,7 @@
         },
         {
             "id": "7218e818-8feb-5f22-bfdf-d30a0161a596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e87e73-b999-4d57-98ee-1c9f33baca74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e87e73-b999-4d57-98ee-1c9f33baca74.jpg?1",
             "name": "Hibernation",
             "text": "",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "8df154ca-afa9-5b77-82f0-a9774341db44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15005ab0-da4e-415e-99fe-34c112819c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15005ab0-da4e-415e-99fe-34c112819c45.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "1adb2b07-5d11-5ac6-841e-dcd0c45d7300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64b45d0-4387-4187-8511-12c8a323a772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64b45d0-4387-4187-8511-12c8a323a772.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "5b0859dd-08af-5d59-989a-fa1b16343823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38c335-5a85-4d39-8d58-2b284758de53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38c335-5a85-4d39-8d58-2b284758de53.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "dd28db1a-35a0-58cd-9bb0-1b142d00652f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494dd66f-44af-4a10-94bb-9447af645512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494dd66f-44af-4a10-94bb-9447af645512.jpg?1",
             "name": "Inspiration",
             "text": "",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "05858b2b-febc-5b0e-bf6f-e16edf26e6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f05d944-1800-4542-a496-62504efc5292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f05d944-1800-4542-a496-62504efc5292.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "668872a0-a5dd-5be7-bb25-8e37b2b1cdb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5c04b2-ec1c-4954-8551-5421c0843e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5c04b2-ec1c-4954-8551-5421c0843e2b.jpg?1",
             "name": "Levitation",
             "text": "",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "1370b5f7-8a2e-534f-afb8-fdeceda5d391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd279366-8de2-47c5-9ac0-f41f8f81c643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd279366-8de2-47c5-9ac0-f41f8f81c643.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk get +1/+1 and have islandwalk. (They're unblockable as long as defending player controls an island.)",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "3a68754f-d55b-5e09-b100-74a228e181de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200f395-4bb9-4d70-9473-a131b46b60ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200f395-4bb9-4d70-9473-a131b46b60ce.jpg?1",
             "name": "Lord of Atlantis",
             "text": "",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "0286f862-2c26-58ef-bff9-9c7c5078e80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d464226-5607-4db2-bd43-7855efb92628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d464226-5607-4db2-bd43-7855efb92628.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "82e041f8-132b-5343-aaee-9ffd59650841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e138f24-73ca-4040-b9cc-7ebcf605372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e138f24-73ca-4040-b9cc-7ebcf605372e.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -5782,7 +5782,7 @@
         },
         {
             "id": "5b5ac019-2a8a-5518-a6bc-b4970dd29307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a7eff-89c8-4799-b264-38892912ba05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a7eff-89c8-4799-b264-38892912ba05.jpg?1",
             "name": "Mana Breach",
             "text": "Whenever a player plays a spell, that player returns a land he or she controls to its owner's hand.",
             "colours": [
@@ -5815,7 +5815,7 @@
         },
         {
             "id": "ce403e97-e400-5d92-b57c-61400adf0134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f8b6a-415a-4b73-bfd9-5081c5fcefb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f8b6a-415a-4b73-bfd9-5081c5fcefb3.jpg?1",
             "name": "Mana Breach",
             "text": "",
             "colours": [
@@ -5848,7 +5848,7 @@
         },
         {
             "id": "dd425fd6-d097-5a38-be01-6b29ed30b92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0486784-de03-47a7-949d-550fd23492bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0486784-de03-47a7-949d-550fd23492bc.jpg?1",
             "name": "Mana Short",
             "text": "Tap all lands target player controls and empty his or her mana pool.",
             "colours": [
@@ -5881,7 +5881,7 @@
         },
         {
             "id": "e2e03199-6250-5bbe-883a-164cab77dcf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279acd2-7d73-4f42-8696-654326d64bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279acd2-7d73-4f42-8696-654326d64bba.jpg?1",
             "name": "Mana Short",
             "text": "",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "0fb091c3-ff71-5f46-9d43-305224a36788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48494f33-34b5-4c76-bb24-23a78b856e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48494f33-34b5-4c76-bb24-23a78b856e3c.jpg?1",
             "name": "Mawcor",
             "text": "Flying\noc\nT: Mawcor deals 1 damage to target creature or player.",
             "colours": [
@@ -5949,7 +5949,7 @@
         },
         {
             "id": "c183f37c-5432-581d-a40a-b0efa3bd59c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abc4a5-25b5-4f05-9278-a557fb268114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abc4a5-25b5-4f05-9278-a557fb268114.jpg?1",
             "name": "Mawcor",
             "text": "",
             "colours": [
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "f7563a03-c7eb-540e-baff-9a49e85644a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d85cc30-ccae-4af8-834a-f7870dace679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d85cc30-ccae-4af8-834a-f7870dace679.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "c5d086f3-fcd4-5cc1-b6d8-cbaece14857a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2437b9-22ed-4835-9ac4-e9625bf8464a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2437b9-22ed-4835-9ac4-e9625bf8464a.jpg?1",
             "name": "Memory Lapse",
             "text": "",
             "colours": [
@@ -6050,7 +6050,7 @@
         },
         {
             "id": "2f467e35-cb7f-573c-8f56-9f83edec94ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec07b20-9768-4c21-90d5-70d57959c698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec07b20-9768-4c21-90d5-70d57959c698.jpg?1",
             "name": "Merfolk Looter",
             "text": "oc\nT: Draw a card, then discard a card from your hand.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "eb9442d4-89e4-53d0-85fc-507d80435779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffaacf-bf53-49ca-8003-795773477ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffaacf-bf53-49ca-8003-795773477ad3.jpg?1",
             "name": "Merfolk Looter",
             "text": "",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "dc684645-d2fd-5d4a-92c2-3c6a702150da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e7d1a5-b8ad-48e8-9b54-3663310eca33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e7d1a5-b8ad-48e8-9b54-3663310eca33.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -6157,7 +6157,7 @@
         },
         {
             "id": "37553ebc-1b36-5d4a-ae35-bccb92c8630b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd471f7-4d06-4a86-bb24-564b88344cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd471f7-4d06-4a86-bb24-564b88344cdc.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -6192,7 +6192,7 @@
         },
         {
             "id": "011a3a24-f471-5030-887e-5668f4627e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01d4d9-c9e9-4826-a155-4527f9be758e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01d4d9-c9e9-4826-a155-4527f9be758e.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -6225,7 +6225,7 @@
         },
         {
             "id": "2ea9ad2a-c794-5fdf-9207-9ed9a909f27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f083a1-664f-46d7-a54d-95f5c10217f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f083a1-664f-46d7-a54d-95f5c10217f2.jpg?1",
             "name": "Opportunity",
             "text": "",
             "colours": [
@@ -6258,7 +6258,7 @@
         },
         {
             "id": "cba06033-ec4d-512d-9320-d77da4ed1e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980e292-1384-4662-aa72-bc4f6ca30d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980e292-1384-4662-aa72-bc4f6ca30d51.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "0cf3d24a-7cb1-5d30-bfec-1c41aebe1647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f849df-8a20-4490-a573-1ad3af65e540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f849df-8a20-4490-a573-1ad3af65e540.jpg?1",
             "name": "Opposition",
             "text": "",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "52fa1bd9-eaba-5bb7-a372-1363424b3d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594550a7-9d75-4bae-9295-14249f60cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594550a7-9d75-4bae-9295-14249f60cc7f.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "859e44d1-2672-5c3a-bde8-e07fd419c677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55672640-d58f-4e00-a0ac-00916c8375b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55672640-d58f-4e00-a0ac-00916c8375b1.jpg?1",
             "name": "Phantom Warrior",
             "text": "",
             "colours": [
@@ -6396,7 +6396,7 @@
         },
         {
             "id": "f9163243-1aec-53d9-b2d9-80f36343862c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30a846e-a5b1-4603-af4f-6494f3c4fbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30a846e-a5b1-4603-af4f-6494f3c4fbb3.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "oc\nT: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "968b80af-f7c7-5b96-a945-044842353432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da1bfc3-de07-4600-ae01-b22057ba59d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da1bfc3-de07-4600-ae01-b22057ba59d1.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "a826b162-7ec7-5828-85c5-a6825bd64c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25f4f0e-bbf4-46b1-97fd-e796ff9e138f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25f4f0e-bbf4-46b1-97fd-e796ff9e138f.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "ee29638f-8a42-5930-9ef1-ba9d9dd26345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1736d01-1bd0-444c-9d7a-3846441bd409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1736d01-1bd0-444c-9d7a-3846441bd409.jpg?1",
             "name": "Remove Soul",
             "text": "",
             "colours": [
@@ -6534,7 +6534,7 @@
         },
         {
             "id": "13a97b00-dc44-5fd7-b351-1a3c6f4fce3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9a3aba-25ae-4b5e-b356-9745e7236f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9a3aba-25ae-4b5e-b356-9745e7236f35.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "5b3eafe5-6253-5ac8-8925-8cebb6cc8b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b79c1-71ee-483d-be6d-07a4a6320200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b79c1-71ee-483d-be6d-07a4a6320200.jpg?1",
             "name": "Sage Owl",
             "text": "",
             "colours": [
@@ -6604,7 +6604,7 @@
         },
         {
             "id": "a4f746d7-87db-54f6-ad54-3fb789d1b28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c8829-80f5-49d3-9887-e6ed276440c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c8829-80f5-49d3-9887-e6ed276440c9.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an island.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "b0c1a7f6-d901-50ad-a3dd-1010d242b47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dad56c-7f9a-4f11-920a-5a9d8eee45ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dad56c-7f9a-4f11-920a-5a9d8eee45ce.jpg?1",
             "name": "Sea Monster",
             "text": "",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "7e7a22e7-6f97-51da-bfbc-37d668ae7f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fff80-4dea-47ee-a020-d8dc9ea7acdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fff80-4dea-47ee-a020-d8dc9ea7acdf.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -6707,7 +6707,7 @@
         },
         {
             "id": "3f12e73d-cfbf-5783-a187-88e0e399f2dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14525e5c-3e50-4478-8149-7e9c012a85bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14525e5c-3e50-4478-8149-7e9c012a85bf.jpg?1",
             "name": "Sleight of Hand",
             "text": "",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "afe2af9f-8f4a-52b4-8db8-0e7307689095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f76c5c-f445-4c02-98d1-d7376a76d612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f76c5c-f445-4c02-98d1-d7376a76d612.jpg?1",
             "name": "Steal Artifact",
             "text": "You control enchanted artifact.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "0adc0928-6404-5252-9899-d66e78e0a278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbad5469-0b78-476f-8573-22fb117392ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbad5469-0b78-476f-8573-22fb117392ab.jpg?1",
             "name": "Steal Artifact",
             "text": "",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "a24b67a1-0f54-5a99-992f-bd8da74d942e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e573308-40d0-43ce-be04-dbab6bc1ed35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e573308-40d0-43ce-be04-dbab6bc1ed35.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "e36dc9cf-c47d-510a-811a-60c9015cf10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c0a35-09b5-449f-be30-d837e330cb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782c0a35-09b5-449f-be30-d837e330cb6b.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "0d3b84cb-17f2-50bd-af73-4abf545e1298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb39c9-7853-4032-882a-83d4863dcbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb39c9-7853-4032-882a-83d4863dcbc5.jpg?1",
             "name": "Telepathic Spies",
             "text": "When Telepathic Spies comes into play, look at target opponent's hand.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "7449b7df-d915-5ae8-86d8-622af39392a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8346c3-8e36-45de-97ec-dfad12ac980c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8346c3-8e36-45de-97ec-dfad12ac980c.jpg?1",
             "name": "Telepathic Spies",
             "text": "",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "ef6fdd8b-559e-5f14-a94f-3ae4e90cd558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b65a4b-d0d9-4439-96f9-0e0dd532c824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b65a4b-d0d9-4439-96f9-0e0dd532c824.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "0ede7443-c168-54cc-b100-bd5ff1a88b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eeef0a-599d-455b-b482-83426f5fdc67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eeef0a-599d-455b-b482-83426f5fdc67.jpg?1",
             "name": "Telepathy",
             "text": "",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "9bbd6068-deea-54fa-9a8c-20c6f5b6b026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef6d283-a966-4ee9-ab23-5485ccceaf5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef6d283-a966-4ee9-ab23-5485ccceaf5c.jpg?1",
             "name": "Temporal Adept",
             "text": "o\nUo\nUo\nU, oc\nT: Return target permanent to its owner's hand.",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "dc8c3824-a62c-5a90-a7c3-83ea6588d88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9f738-3988-4c60-854d-fb6f9b82ee0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9f738-3988-4c60-854d-fb6f9b82ee0b.jpg?1",
             "name": "Temporal Adept",
             "text": "",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "6abc83a2-05f1-5492-9bec-0fc2cfa4c84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a487411-ef89-4500-be3c-8e191bd7ddc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a487411-ef89-4500-be3c-8e191bd7ddc4.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -7125,7 +7125,7 @@
         },
         {
             "id": "4c18797e-f52a-51dc-b5f5-77ec58a08790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5993ed-5ed6-4712-9f69-62d140a0bba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5993ed-5ed6-4712-9f69-62d140a0bba5.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -7160,7 +7160,7 @@
         },
         {
             "id": "cc77f8e3-6a9f-54bc-964a-4b19e7111876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd9981-bb5e-450d-90c3-4405a7097939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd9981-bb5e-450d-90c3-4405a7097939.jpg?1",
             "name": "Tolarian Winds",
             "text": "Discard your hand, then draw that many cards.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "363d5637-c801-55b5-bd89-dd4feac907a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad47859-0756-4aae-b21f-7689da1077bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad47859-0756-4aae-b21f-7689da1077bb.jpg?1",
             "name": "Tolarian Winds",
             "text": "",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "aa751407-1d46-5673-88fa-00667a08b75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f79962-ca0f-4df1-9dc8-d7ea1025cab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f79962-ca0f-4df1-9dc8-d7ea1025cab1.jpg?1",
             "name": "Treasure Trove",
             "text": "o2o\nUoo\nU Draw a card.",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "cbdfb66a-dddd-5291-bef2-89d895d84c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8646aef-f926-4e04-9a6d-c10bea1dd992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8646aef-f926-4e04-9a6d-c10bea1dd992.jpg?1",
             "name": "Treasure Trove",
             "text": "",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "10375afc-d34d-5bbb-858b-c9153c6d8218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9483fed-0fc8-4aff-b1b4-8470166fdb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9483fed-0fc8-4aff-b1b4-8470166fdb9b.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7325,7 +7325,7 @@
         },
         {
             "id": "c96c4851-e1dd-5d4a-a24a-1c21fb29f931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945956d4-ffd6-4fbc-ae2d-32f981337dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945956d4-ffd6-4fbc-ae2d-32f981337dd4.jpg?1",
             "name": "Twiddle",
             "text": "",
             "colours": [
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "f2ad2a16-3a7e-5e02-b1c5-29dac555e68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922636e6-9e4e-4aa8-9030-6e1417d241a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922636e6-9e4e-4aa8-9030-6e1417d241a1.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "28ed483d-c7ea-51b7-9380-83166bc3fdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5616986-970c-45d3-878e-403434b35988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5616986-970c-45d3-878e-403434b35988.jpg?1",
             "name": "Unsummon",
             "text": "",
             "colours": [
@@ -7424,7 +7424,7 @@
         },
         {
             "id": "8e728944-1726-596d-bd46-c0cfa29102ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb4be1f-3e5b-4881-9fae-9ed022f8eeac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb4be1f-3e5b-4881-9fae-9ed022f8eeac.jpg?1",
             "name": "Vigilant Drake",
             "text": "Flying\no2oo\nU Untap Vigilant Drake",
             "colours": [
@@ -7459,7 +7459,7 @@
         },
         {
             "id": "5675c405-7b17-5d42-b46b-5ee7032cbe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1e116a-370d-494f-8fbb-d964c34f49b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1e116a-370d-494f-8fbb-d964c34f49b4.jpg?1",
             "name": "Vigilant Drake",
             "text": "",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "cfe7c04b-1bc2-56bc-8f93-301f86f074a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c681e3-fc54-4da1-80ff-13507688dbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c681e3-fc54-4da1-80ff-13507688dbc3.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -7530,7 +7530,7 @@
         },
         {
             "id": "46982267-9516-5979-889c-11cae30a9fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ecab6-e145-4dfd-9e9e-56492db30b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ecab6-e145-4dfd-9e9e-56492db30b4c.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "710b4e5a-048e-5ac9-898a-590c65094238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b43e8-23d7-4df6-822b-ae3b57c6f1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b43e8-23d7-4df6-822b-ae3b57c6f1dc.jpg?1",
             "name": "Wall of Air",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "277146f2-a08a-5673-b321-bf7c31dc6c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68367ab-cf67-4e0d-a446-676b2734141c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68367ab-cf67-4e0d-a446-676b2734141c.jpg?1",
             "name": "Wall of Air",
             "text": "",
             "colours": [
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "c03a332e-1dda-561d-8c91-dac33b71956e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c73e58-e906-4c67-9f84-b20456629cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c73e58-e906-4c67-9f84-b20456629cb0.jpg?1",
             "name": "Wall of Wonder",
             "text": "(Walls can't attack.)\no2o\nUoo\nU Wall of Wonder gets +4/-4 until end of turn and may attack this turn as though it weren't a Wall.",
             "colours": [
@@ -7671,7 +7671,7 @@
         },
         {
             "id": "0ccd9169-fdb0-566d-9266-c4c2c4235df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713698c2-fd5a-4763-b699-00fe73fa6641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713698c2-fd5a-4763-b699-00fe73fa6641.jpg?1",
             "name": "Wall of Wonder",
             "text": "",
             "colours": [
@@ -7706,7 +7706,7 @@
         },
         {
             "id": "ad1e760c-fad0-568e-8baf-cd86b8857d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314b5efa-c16f-4bcf-beed-bd0d77511a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314b5efa-c16f-4bcf-beed-bd0d77511a25.jpg?1",
             "name": "Wind Dancer",
             "text": "Flying\noc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "4b49ed68-9f3e-5db4-9143-f33de2768b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c7c034-f70e-47c1-b4e9-ec34194bf0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c7c034-f70e-47c1-b4e9-ec34194bf0b6.jpg?1",
             "name": "Wind Dancer",
             "text": "",
             "colours": [
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "b75014aa-920b-53b3-b61f-352bf6aa2f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba63d1d-6170-4ccd-afd9-987e549fa58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba63d1d-6170-4ccd-afd9-987e549fa58e.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "c2017715-ab76-53f3-b3f2-7da67575e2aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e2c8c5-b039-42ed-90f8-95c80d124564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e2c8c5-b039-42ed-90f8-95c80d124564.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -7846,7 +7846,7 @@
         },
         {
             "id": "d5796f65-5b20-5a9d-bafe-26f26280e418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb42943-f599-4068-a364-a023e70c4ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb42943-f599-4068-a364-a023e70c4ed2.jpg?1",
             "name": "Abyssal Horror",
             "text": "Flying\nWhen Abyssal Horror comes into play, target player discards two cards from his or her hand.",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "27e800c1-ba16-53d1-baa6-52e4a95827d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37aa76c5-0391-496a-8f34-d966813fe4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37aa76c5-0391-496a-8f34-d966813fe4e5.jpg?1",
             "name": "Abyssal Horror",
             "text": "",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "616c5add-4a91-5b0a-bc15-a3f01243f164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e6582d-e569-4131-b212-3ef1767be107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e6582d-e569-4131-b212-3ef1767be107.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter deals damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -7951,7 +7951,7 @@
         },
         {
             "id": "130e1923-55e1-5adb-9ad5-60a450495d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcfb1fb-8e04-4312-9a06-ed3fc2e86c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcfb1fb-8e04-4312-9a06-ed3fc2e86c22.jpg?1",
             "name": "Abyssal Specter",
             "text": "",
             "colours": [
@@ -7986,7 +7986,7 @@
         },
         {
             "id": "675284a1-f678-53c1-b12f-808d18704d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967e7ead-72a5-4f11-87a9-d9498e0d1a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967e7ead-72a5-4f11-87a9-d9498e0d1a6c.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand and choose two cards from it. Put them on top of that player's library in any order.",
             "colours": [
@@ -8019,7 +8019,7 @@
         },
         {
             "id": "4b875165-ca6e-5715-ba2c-dd5d88b6514c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0c1ee9-5ebc-466d-a163-74d207ef8fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0c1ee9-5ebc-466d-a163-74d207ef8fd5.jpg?1",
             "name": "Agonizing Memories",
             "text": "",
             "colours": [
@@ -8052,7 +8052,7 @@
         },
         {
             "id": "0baa852c-f346-58ac-b11e-b6e640f29245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db137-33b9-4cea-9193-4e637d2966f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db137-33b9-4cea-9193-4e637d2966f1.jpg?1",
             "name": "Befoul",
             "text": "Destroy target land or nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8085,7 +8085,7 @@
         },
         {
             "id": "1a1bdaa9-31a3-5013-8e43-fd586d3fde21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c92a967-ed52-44a8-a07b-04e643fb2e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c92a967-ed52-44a8-a07b-04e643fb2e78.jpg?1",
             "name": "Befoul",
             "text": "",
             "colours": [
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "0c496840-2ec8-5021-8d5b-f781f74e10f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0962d7-d797-4f07-bd73-9cd7a11ffad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0962d7-d797-4f07-bd73-9cd7a11ffad8.jpg?1",
             "name": "Bellowing Fiend",
             "text": "Flying\nWhenever Bellowing Fiend deals damage to a creature, Bellowing Fiend deals 3 damage to that creature's controller and 3 damage to you.",
             "colours": [
@@ -8153,7 +8153,7 @@
         },
         {
             "id": "4ee12947-a4f6-52cb-8344-8cc41f2fb5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d014dcd8-7132-48e2-b632-00fb0b5c372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d014dcd8-7132-48e2-b632-00fb0b5c372e.jpg?1",
             "name": "Bellowing Fiend",
             "text": "",
             "colours": [
@@ -8188,7 +8188,7 @@
         },
         {
             "id": "84c454b8-7be5-5f2f-9414-df3bf8280446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20daf7-9cdd-4694-8ed4-4c5dc9f9e7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce20daf7-9cdd-4694-8ed4-4c5dc9f9e7b3.jpg?1",
             "name": "Bereavement",
             "text": "Whenever a green creature is put into a graveyard from play, its controller discards a card from his or her hand.",
             "colours": [
@@ -8221,7 +8221,7 @@
         },
         {
             "id": "738853b4-ea67-5932-a8c6-bc2e0ab40c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21138eb5-4eaa-4143-91a6-989fb0c39e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21138eb5-4eaa-4143-91a6-989fb0c39e40.jpg?1",
             "name": "Bereavement",
             "text": "",
             "colours": [
@@ -8254,7 +8254,7 @@
         },
         {
             "id": "1499dea2-3264-58cb-ad23-d00fcdb114cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff08225-82a5-4636-be6a-d38d32f5663f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff08225-82a5-4636-be6a-d38d32f5663f.jpg?1",
             "name": "Blood Pet",
             "text": "Sacrifice Blood Pet: Add o\nB to your mana pool.",
             "colours": [
@@ -8289,7 +8289,7 @@
         },
         {
             "id": "fa904eaa-a772-518e-9131-0a39057de427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e67191-0195-4af7-9566-59df8a24cb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e67191-0195-4af7-9566-59df8a24cb82.jpg?1",
             "name": "Blood Pet",
             "text": "",
             "colours": [
@@ -8324,7 +8324,7 @@
         },
         {
             "id": "75bd9baa-a7ee-53d7-8d80-cb25585e9b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e2c65-d2b0-4bf7-b302-d755e9259ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e2c65-d2b0-4bf7-b302-d755e9259ce2.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "cc473b5f-25db-53c3-9061-b3dc48ff1bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f70e3a-b094-45f9-8e34-02db116292ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f70e3a-b094-45f9-8e34-02db116292ce.jpg?1",
             "name": "Bog Imp",
             "text": "",
             "colours": [
@@ -8394,7 +8394,7 @@
         },
         {
             "id": "02a6c5ca-be4d-55d1-a841-cf44e141f608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5644b8a9-8777-49da-813a-61ce75324d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5644b8a9-8777-49da-813a-61ce75324d48.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "5f66be5b-54ba-51cc-822c-04aec97ce9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6fd6e1-58b0-4c98-b0ca-58409d3b2383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6fd6e1-58b0-4c98-b0ca-58409d3b2383.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -8464,7 +8464,7 @@
         },
         {
             "id": "6eff1f89-1eb6-5187-a956-7b398eaa6aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dc4337-86fd-49b4-8331-fcf44f9e7a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dc4337-86fd-49b4-8331-fcf44f9e7a74.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -8497,7 +8497,7 @@
         },
         {
             "id": "27accc75-a57b-5339-bc8f-bc9ed54e2c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fc008a-99cc-4f11-a47c-b7391249bdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fc008a-99cc-4f11-a47c-b7391249bdab.jpg?1",
             "name": "Corrupt",
             "text": "",
             "colours": [
@@ -8530,7 +8530,7 @@
         },
         {
             "id": "6588258f-88e7-516a-aa09-6efe71104a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2f697-01cc-4610-b4aa-cae83b38647a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2f697-01cc-4610-b4aa-cae83b38647a.jpg?1",
             "name": "Crypt Rats",
             "text": "oo\nX Crypt Rats deals X damage to each creature and each player. Spend only black mana this way.",
             "colours": [
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "d98b072b-ee39-5f6a-9839-56eea67a3ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce46b67-e0a2-47d6-b3b8-6acedfd7b40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce46b67-e0a2-47d6-b3b8-6acedfd7b40f.jpg?1",
             "name": "Crypt Rats",
             "text": "",
             "colours": [
@@ -8600,7 +8600,7 @@
         },
         {
             "id": "50f5074d-226f-5368-be88-5c500561b7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660cc594-63f5-4819-a556-7a9484145f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660cc594-63f5-4819-a556-7a9484145f72.jpg?1",
             "name": "Dakmor Lancer",
             "text": "When Dakmor Lancer comes into play, destroy target nonblack creature.",
             "colours": [
@@ -8636,7 +8636,7 @@
         },
         {
             "id": "c880c3d8-2d0c-572d-94d9-28df13d1d20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca0f0d-c47c-4c29-a47d-d44e2083c3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca0f0d-c47c-4c29-a47d-d44e2083c3d1.jpg?1",
             "name": "Dakmor Lancer",
             "text": "",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "ddb9bd32-d7d2-585d-bbb3-285ef3028a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d03720d-b0ca-4892-9ad1-52189f4a30a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d03720d-b0ca-4892-9ad1-52189f4a30a1.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "5cddadf4-5eff-5406-825d-ef690633e55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1d76a2-4f74-4d96-841a-3246922df92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1d76a2-4f74-4d96-841a-3246922df92e.jpg?1",
             "name": "Dark Banishing",
             "text": "",
             "colours": [
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "ba15d277-31ed-529f-8adc-963c70f316a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb0f91-2084-448a-8226-95d7c87dd6bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb0f91-2084-448a-8226-95d7c87dd6bb.jpg?1",
             "name": "Darkest Hour",
             "text": "All creatures are black.",
             "colours": [
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "b2170655-7d7d-5311-832d-332ad260ad00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad13e04-f099-40c8-a25d-fe2329b47170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad13e04-f099-40c8-a25d-fe2329b47170.jpg?1",
             "name": "Darkest Hour",
             "text": "",
             "colours": [
@@ -8804,7 +8804,7 @@
         },
         {
             "id": "0ec60407-f436-5269-b183-1fa8c216ca1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c4223d-8846-489d-abfc-8330dc58d12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c4223d-8846-489d-abfc-8330dc58d12b.jpg?1",
             "name": "Dregs of Sorrow",
             "text": "Destroy X target nonblack creatures. Draw X cards.",
             "colours": [
@@ -8837,7 +8837,7 @@
         },
         {
             "id": "99b5969c-ee75-56a4-8588-65b514fd1e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14c738-93cc-4c3a-8d59-6ef7fa22fb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14c738-93cc-4c3a-8d59-6ef7fa22fb1c.jpg?1",
             "name": "Dregs of Sorrow",
             "text": "",
             "colours": [
@@ -8870,7 +8870,7 @@
         },
         {
             "id": "5f8d6987-1f00-567b-8b91-fde23bc8b89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be76e8d0-70d3-4fc7-9320-e78ad93bd362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be76e8d0-70d3-4fc7-9320-e78ad93bd362.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerate Drudge Skeletons.",
             "colours": [
@@ -8907,7 +8907,7 @@
         },
         {
             "id": "73449d07-4a1e-5e0c-ae9c-18116a7a85ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55407e4-9d86-4ac9-9360-e44335852a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55407e4-9d86-4ac9-9360-e44335852a29.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "c0faaa3b-ab51-5593-a1da-d99f612b52cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd5d6e8-7e7e-4eb2-8994-10610ebcdf4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd5d6e8-7e7e-4eb2-8994-10610ebcdf4c.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -8981,7 +8981,7 @@
         },
         {
             "id": "800ee05c-a08c-52c7-b539-c742285c26fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de18b04b-16d2-4f92-8b06-35e195ec7b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de18b04b-16d2-4f92-8b06-35e195ec7b58.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "850ac11d-2cc1-5009-bf0f-5bcfba8ede5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c8d82e-6e65-4d36-bf09-b24dde016581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c8d82e-6e65-4d36-bf09-b24dde016581.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. Choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "a1d63a07-098f-5702-9c1f-782659117d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08298bdd-38a4-43ef-a2b6-4d9b69b0d417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08298bdd-38a4-43ef-a2b6-4d9b69b0d417.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "9a96fb35-83ab-5112-90f5-b098fa732304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6dbd6e-c51f-427b-91ab-2d0988fb9966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6dbd6e-c51f-427b-91ab-2d0988fb9966.jpg?1",
             "name": "Eastern Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target green creature.",
             "colours": [
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "c720ab76-d8ff-5b80-9fc0-9f92f1a58315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4283a695-57fd-442c-906b-f88b039de79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4283a695-57fd-442c-906b-f88b039de79d.jpg?1",
             "name": "Eastern Paladin",
             "text": "",
             "colours": [
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "af2420e7-c928-5045-bd3e-c65868441704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669e43e-3b11-42c9-8f20-0acce129e63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669e43e-3b11-42c9-8f20-0acce129e63c.jpg?1",
             "name": "Engineered Plague",
             "text": "As Engineered Plague comes into play, choose a creature type.\nAll creatures of the chosen type get -1/-1.",
             "colours": [
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "3f47a76e-a3d4-53e8-a5ba-bbc5e49c31a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad057e-4314-47b3-ace8-e784635740db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad057e-4314-47b3-ace8-e784635740db.jpg?1",
             "name": "Engineered Plague",
             "text": "",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "06c44555-4838-59bc-8510-5e67398d816d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ecb2c-e732-40cc-9e92-d18b80a26c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ecb2c-e732-40cc-9e92-d18b80a26c4c.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "0d7bfe3c-6f0a-5059-925a-a988d98faa34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84fea71-0018-43b2-ba74-1612cca4ae96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84fea71-0018-43b2-ba74-1612cca4ae96.jpg?1",
             "name": "Fallen Angel",
             "text": "",
             "colours": [
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "10b93069-d761-5e55-b9fd-b7449d4306ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9036d3b2-f13d-4cfd-aab3-2dd1f0dd3479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9036d3b2-f13d-4cfd-aab3-2dd1f0dd3479.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature can't be blocked except by artifact creatures and/or black creatures.",
             "colours": [
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "e1da1e2a-5142-588b-9785-5507f8df26f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28b0f2-ea67-41ff-a187-356eef227bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28b0f2-ea67-41ff-a187-356eef227bc0.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "d2c6954d-8a23-556b-8fad-74848a4e2ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fed5a2-807c-45c0-8692-c9781bee2da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fed5a2-807c-45c0-8692-c9781bee2da9.jpg?1",
             "name": "Foul Imp",
             "text": "Flying\nWhen Foul Imp comes into play, you lose 2 life.",
             "colours": [
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "df90f6e7-c29a-5f84-a4c6-ddaec23a02e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3da66a-ac81-4300-80a1-f70cdb104a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3da66a-ac81-4300-80a1-f70cdb104a90.jpg?1",
             "name": "Foul Imp",
             "text": "",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "b7016653-a523-51f1-a26b-299dc2e3baf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee37df6-ca09-44f2-b4a4-ad21be4b2a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee37df6-ca09-44f2-b4a4-ad21be4b2a4d.jpg?1",
             "name": "Fugue",
             "text": "Target player discards three cards from his or her hand.",
             "colours": [
@@ -9467,7 +9467,7 @@
         },
         {
             "id": "85c4fcff-a522-53d4-9d59-746da69480e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5c89d-5f26-420e-b490-3d94239a6280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5c89d-5f26-420e-b490-3d94239a6280.jpg?1",
             "name": "Fugue",
             "text": "",
             "colours": [
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "ac4c6866-8a4f-51e8-a64e-65eec9d101f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d42a-85fc-4a25-aedc-719b938661e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d42a-85fc-4a25-aedc-719b938661e5.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "8cb3af5f-543d-5a5a-ba15-2aaeca958114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade86194-9b77-4175-8088-da784cbcfd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade86194-9b77-4175-8088-da784cbcfd49.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "8301f0e4-51a4-52d5-8ab8-1a36e3acc97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961dec46-b96e-486c-939f-9c11aa75bd04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961dec46-b96e-486c-939f-9c11aa75bd04.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "1281d54d-9e4d-5a54-b8b5-2c9932fad87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590a3850-c59e-4357-9f34-f7a57c4486e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590a3850-c59e-4357-9f34-f7a57c4486e0.jpg?1",
             "name": "Gravedigger",
             "text": "",
             "colours": [
@@ -9640,7 +9640,7 @@
         },
         {
             "id": "4682b02a-cf4d-5dbf-8bd4-aa67a2244b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06db06b-0780-41c7-9b6c-a688b0f5fa2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06db06b-0780-41c7-9b6c-a688b0f5fa2c.jpg?1",
             "name": "Greed",
             "text": "o\nB, Pay 2 life: Draw a card.",
             "colours": [
@@ -9673,7 +9673,7 @@
         },
         {
             "id": "1ea1a96f-8186-5272-aaea-c1111b04df32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51b23a-d67d-4ede-a1b2-1ba6dad9883e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51b23a-d67d-4ede-a1b2-1ba6dad9883e.jpg?1",
             "name": "Greed",
             "text": "",
             "colours": [
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "b7f1e009-fab6-5651-af8d-19aafdfe8b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e6ed54-a72c-413a-8038-a3ed571571bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e6ed54-a72c-413a-8038-a3ed571571bd.jpg?1",
             "name": "Hollow Dogs",
             "text": "Whenever Hollow Dogs attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -9743,7 +9743,7 @@
         },
         {
             "id": "526cddc6-4d79-5c0d-8109-d127b161ea9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c036abf0-9da3-4cc4-8aa1-92293fad77b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c036abf0-9da3-4cc4-8aa1-92293fad77b2.jpg?1",
             "name": "Hollow Dogs",
             "text": "",
             "colours": [
@@ -9780,7 +9780,7 @@
         },
         {
             "id": "6039c841-a107-5ef4-9a66-6c174c5e3f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fedf1b4-a3ee-410e-8b2b-ff848a8f60c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fedf1b4-a3ee-410e-8b2b-ff848a8f60c4.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -9813,7 +9813,7 @@
         },
         {
             "id": "78d7953b-79a5-5f44-b3a0-4494d78969e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd1202-ad8b-4526-ba6b-0460f56d91a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd1202-ad8b-4526-ba6b-0460f56d91a6.jpg?1",
             "name": "Howl from Beyond",
             "text": "",
             "colours": [
@@ -9846,7 +9846,7 @@
         },
         {
             "id": "c4120fa5-4784-5a3c-9f38-1bd6a041e261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f451a70f-1f1c-4fd6-ab0c-4b77a043c324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f451a70f-1f1c-4fd6-ab0c-4b77a043c324.jpg?1",
             "name": "Infernal Contract",
             "text": "Draw four cards. You lose half your life, rounded up.",
             "colours": [
@@ -9879,7 +9879,7 @@
         },
         {
             "id": "e660dfed-6933-56a4-9496-49fb57a4fb6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272ecc-33bd-4144-996a-9e0c9d0a9e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272ecc-33bd-4144-996a-9e0c9d0a9e20.jpg?1",
             "name": "Infernal Contract",
             "text": "",
             "colours": [
@@ -9912,7 +9912,7 @@
         },
         {
             "id": "85ddd0d4-6e75-5cd6-a21a-00697a8428c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d37d29-b667-4124-907d-5636a6db044f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d37d29-b667-4124-907d-5636a6db044f.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Enchanted creature has swampwalk. (It's unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "e6f69d8a-e701-528a-ae76-4f6ee0258d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2793f9ea-6a3d-4c02-92d2-0eb62a4dedb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2793f9ea-6a3d-4c02-92d2-0eb62a4dedb2.jpg?1",
             "name": "Leshrac's Rite",
             "text": "",
             "colours": [
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "7fceaa02-191a-57c1-99c1-d44e1c515a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c49d4b-cb89-4f63-ac94-a2075f79f628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c49d4b-cb89-4f63-ac94-a2075f79f628.jpg?1",
             "name": "Looming Shade",
             "text": "oo\nB Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10017,7 +10017,7 @@
         },
         {
             "id": "9edf00d1-99cc-569c-82d5-7251d2558972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184befc7-be32-47b2-a634-a6d474daa553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184befc7-be32-47b2-a634-a6d474daa553.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -10052,7 +10052,7 @@
         },
         {
             "id": "91aeb58c-7bc9-5a45-b9b6-2df666244f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4f01f9-a673-43df-a263-7c2269c2235e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4f01f9-a673-43df-a263-7c2269c2235e.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "4c5a817d-0afc-5622-ad97-46944e102ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d12b851-9b48-45ab-93fb-4236a63d59c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d12b851-9b48-45ab-93fb-4236a63d59c9.jpg?1",
             "name": "Megrim",
             "text": "",
             "colours": [
@@ -10118,7 +10118,7 @@
         },
         {
             "id": "bace477f-ae4b-5743-8040-573006a55464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681e85c-79d5-4300-bda6-4ae40bb7d5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681e85c-79d5-4300-bda6-4ae40bb7d5d4.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards from his or her hand.",
             "colours": [
@@ -10151,7 +10151,7 @@
         },
         {
             "id": "2266ff47-2ae8-51a9-b44d-062acff857a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7628b7e-7da8-4ef8-8be2-1865605a7589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7628b7e-7da8-4ef8-8be2-1865605a7589.jpg?1",
             "name": "Mind Rot",
             "text": "",
             "colours": [
@@ -10184,7 +10184,7 @@
         },
         {
             "id": "581ecd1a-27b8-5511-b492-1634be6e774d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71315e3-14c1-433b-97be-2cdf99213bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71315e3-14c1-433b-97be-2cdf99213bba.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -10217,7 +10217,7 @@
         },
         {
             "id": "22d9cf5a-eee8-572a-90e9-d4193a2f7711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32037f20-7443-464c-917f-b062f05f58c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32037f20-7443-464c-917f-b062f05f58c3.jpg?1",
             "name": "Nausea",
             "text": "",
             "colours": [
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "d730a4b1-8513-5483-8125-377ad39e8968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da145ff-8989-4457-b408-792d7ad10df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da145ff-8989-4457-b408-792d7ad10df9.jpg?1",
             "name": "Necrologia",
             "text": "Play Necrologia only during your end of turn step.\nAs an additional cost to play Necrologia, pay any amount of life.\nDraw cards equal to the life paid this way.",
             "colours": [
@@ -10283,7 +10283,7 @@
         },
         {
             "id": "70e0c537-df48-5c75-8cb7-82548f0fea4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb901bc0-e544-4e3a-b447-0eabe8710d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb901bc0-e544-4e3a-b447-0eabe8710d73.jpg?1",
             "name": "Necrologia",
             "text": "",
             "colours": [
@@ -10316,7 +10316,7 @@
         },
         {
             "id": "bd1e27ff-f860-5870-92b2-f8931c08500b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3779fda-5de0-4d80-8af0-95956e87d9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3779fda-5de0-4d80-8af0-95956e87d9e1.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of swamps you control.",
             "colours": [
@@ -10352,7 +10352,7 @@
         },
         {
             "id": "38498161-8bff-554c-83b6-ab24dbabddff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8817ef5f-39f0-4358-bc98-f512f9cce8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8817ef5f-39f0-4358-bc98-f512f9cce8f0.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -10388,7 +10388,7 @@
         },
         {
             "id": "e76dc89f-4205-5fda-9f54-654a69913b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77419949-7e62-48fe-b952-56d943ddd39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77419949-7e62-48fe-b952-56d943ddd39f.jpg?1",
             "name": "Nocturnal Raid",
             "text": "Black creatures get +2/+0 until end of turn.",
             "colours": [
@@ -10421,7 +10421,7 @@
         },
         {
             "id": "adc06ff6-a0ab-56e4-9627-8cf5e99a025d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b354cf4-ca4f-400c-ab74-ac80fe240b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b354cf4-ca4f-400c-ab74-ac80fe240b74.jpg?1",
             "name": "Nocturnal Raid",
             "text": "",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "de139d2f-e1bb-52e0-a58a-8d1548624ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac327f80-983e-4e28-96e8-91ff5377f5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac327f80-983e-4e28-96e8-91ff5377f5a3.jpg?1",
             "name": "Oppression",
             "text": "Whenever a player plays a spell, that player discards a card from his or her hand.",
             "colours": [
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "c9c55e4f-97ff-5ae4-b635-31c9f1c7bbaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc8791c-3d7a-4e61-ac5f-8aec5f44b12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc8791c-3d7a-4e61-ac5f-8aec5f44b12c.jpg?1",
             "name": "Oppression",
             "text": "",
             "colours": [
@@ -10520,7 +10520,7 @@
         },
         {
             "id": "1ce667c5-3b74-516d-b8b7-b27586b502ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdaffcc-59f6-4489-88bf-1061ad6b0512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdaffcc-59f6-4489-88bf-1061ad6b0512.jpg?1",
             "name": "Ostracize",
             "text": "Target opponent reveals his or her hand. Choose a creature card from it. That player discards that card.",
             "colours": [
@@ -10553,7 +10553,7 @@
         },
         {
             "id": "b33e9bcf-2660-5495-906c-cd729d5251fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02ee53c-74dc-487d-88dc-e62a533c63b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02ee53c-74dc-487d-88dc-e62a533c63b3.jpg?1",
             "name": "Ostracize",
             "text": "",
             "colours": [
@@ -10586,7 +10586,7 @@
         },
         {
             "id": "a56c8cc3-bc52-564d-92d1-53a0a93cb95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21334b-f06c-4525-89e1-dc3f148210ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21334b-f06c-4525-89e1-dc3f148210ef.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Target player reveals his or her hand and discards all cards of that color from it.",
             "colours": [
@@ -10619,7 +10619,7 @@
         },
         {
             "id": "e28faeed-a632-5fc4-b913-af61476650bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2385b6f1-e75c-41d3-9cab-39ae6c315b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2385b6f1-e75c-41d3-9cab-39ae6c315b93.jpg?1",
             "name": "Persecute",
             "text": "",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "f07490e6-85d2-5abb-8866-84be66b5ae64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dce7e-1de9-43c9-a29a-144c189873da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dce7e-1de9-43c9-a29a-144c189873da.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "04f52fb7-799d-5855-bb78-6763bc5b632e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91546e2-3384-40c0-a7b9-d83a7a642083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91546e2-3384-40c0-a7b9-d83a7a642083.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -10722,7 +10722,7 @@
         },
         {
             "id": "0aaecdea-6901-5217-983c-3f65db12fd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3809e6-41ac-47e8-80dc-9e9c8be1ed7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3809e6-41ac-47e8-80dc-9e9c8be1ed7a.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Target opponent reveals his or her hand and discards a creature card at random from it. Play this ability only during your turn.",
             "colours": [
@@ -10758,7 +10758,7 @@
         },
         {
             "id": "9d997f60-06ee-5904-a67b-49767bd632bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dd33f6-2b7b-483a-b38e-bcf8e69a935c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dd33f6-2b7b-483a-b38e-bcf8e69a935c.jpg?1",
             "name": "Rag Man",
             "text": "",
             "colours": [
@@ -10794,7 +10794,7 @@
         },
         {
             "id": "25fdc9a4-fe3c-5a51-b09c-d2b3420ec619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929cdbb4-d8b3-4e01-918c-2f46d74bb455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929cdbb4-d8b3-4e01-918c-2f46d74bb455.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -10829,7 +10829,7 @@
         },
         {
             "id": "f9223895-3828-5c5b-8d8e-6258a9753c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d936478a-c9a9-45b6-afd7-de30f1c3221f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d936478a-c9a9-45b6-afd7-de30f1c3221f.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -10864,7 +10864,7 @@
         },
         {
             "id": "b41379c9-ad2a-5d4a-973b-d6aabe1934a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb1c2e-49ae-4f26-9f7d-6643cb79eea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb1c2e-49ae-4f26-9f7d-6643cb79eea5.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -10899,7 +10899,7 @@
         },
         {
             "id": "f7731317-6e2c-587a-80b0-304df2d2973b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062f3566-ff6a-4f2a-9896-9547e46e6bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062f3566-ff6a-4f2a-9896-9547e46e6bac.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -10934,7 +10934,7 @@
         },
         {
             "id": "f7795041-1708-5b7a-9979-eebd38f242d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68064995-c1e4-4ea7-b6b7-246ce49e2cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68064995-c1e4-4ea7-b6b7-246ce49e2cf4.jpg?1",
             "name": "Razortooth Rats",
             "text": "Razortooth Rats can't be blocked except by artifact creatures and/or black creatures.",
             "colours": [
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "04a9d574-a7b3-5218-ab38-f1f1bcf725be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2145f-298b-4c27-b8b2-18f6975087dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2145f-298b-4c27-b8b2-18f6975087dd.jpg?1",
             "name": "Razortooth Rats",
             "text": "",
             "colours": [
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "666aad2b-feaf-58ef-939b-9ebc757c351a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc8c769-f2d1-4ef3-bbcc-277f39a10dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc8c769-f2d1-4ef3-bbcc-277f39a10dbd.jpg?1",
             "name": "Reprocess",
             "text": "Sacrifice any number of artifacts, creatures, and/or lands. Draw a card for each permanent sacrificed this way.",
             "colours": [
@@ -11037,7 +11037,7 @@
         },
         {
             "id": "e9f224cc-d94d-5049-b464-8d96dac87964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaac30c-9ae6-4788-b065-ae4095ee3097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaac30c-9ae6-4788-b065-ae4095ee3097.jpg?1",
             "name": "Reprocess",
             "text": "",
             "colours": [
@@ -11070,7 +11070,7 @@
         },
         {
             "id": "2da6eda0-7679-5d24-82b2-5b55436b4bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c75244-68b3-463d-aad3-2b22f1eaf717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c75244-68b3-463d-aad3-2b22f1eaf717.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -11105,7 +11105,7 @@
         },
         {
             "id": "237e7a69-c113-5572-96b3-ddc575949b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c979ec16-65f4-4afa-8e03-c05ce46337b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c979ec16-65f4-4afa-8e03-c05ce46337b0.jpg?1",
             "name": "Revenant",
             "text": "",
             "colours": [
@@ -11140,7 +11140,7 @@
         },
         {
             "id": "f7f1ae2c-2abb-5387-b2b0-587855c6fdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed515f6f-432e-4455-a871-5cefdd15a37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed515f6f-432e-4455-a871-5cefdd15a37c.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "338f7cd3-0bf3-535b-8728-12f15f3279ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7167902-939f-4aae-819a-8b941ce45cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7167902-939f-4aae-819a-8b941ce45cb1.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "11b1aeee-119a-5a76-b5f1-4fbdf732fa72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be514ca-dd8a-4b84-9125-03a0bf8a047d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be514ca-dd8a-4b84-9125-03a0bf8a047d.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11251,7 +11251,7 @@
         },
         {
             "id": "3f6f0f8d-b464-5b33-bf09-84a2bcfdd12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bddc0b-f000-4679-bbfd-ab7674e30343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bddc0b-f000-4679-bbfd-ab7674e30343.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11288,7 +11288,7 @@
         },
         {
             "id": "5862b060-f1c1-5405-b75e-60376605a8eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4470eb5d-a968-4e08-a96a-4e92ecc6d56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4470eb5d-a968-4e08-a96a-4e92ecc6d56c.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, you lose 3 life.",
             "colours": [
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "02cadd9f-e673-5e22-964f-022fbbe239a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138658d9-368e-46c6-b957-8bdb0699457d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138658d9-368e-46c6-b957-8bdb0699457d.jpg?1",
             "name": "Serpent Warrior",
             "text": "",
             "colours": [
@@ -11360,7 +11360,7 @@
         },
         {
             "id": "992a0698-7f7f-5679-8f0e-e5d88a2b51a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a273c4f4-b156-4bf5-a33d-656a4e49a0ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a273c4f4-b156-4bf5-a33d-656a4e49a0ff.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -11393,7 +11393,7 @@
         },
         {
             "id": "04931a02-a82a-5f59-9b62-57da7e28a15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e0586-dce6-47b5-adad-22d369d4c021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e0586-dce6-47b5-adad-22d369d4c021.jpg?1",
             "name": "Soul Feast",
             "text": "",
             "colours": [
@@ -11426,7 +11426,7 @@
         },
         {
             "id": "aeebc228-ffc6-5f1b-8fc9-2720a1da6257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c091d07-5813-47b9-b1da-d749e3f4e5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c091d07-5813-47b9-b1da-d749e3f4e5aa.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -11463,7 +11463,7 @@
         },
         {
             "id": "acc2544f-b6af-5194-8efb-a65872846b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7ec32-96ca-472f-9a2c-4b4b30cdcc98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7ec32-96ca-472f-9a2c-4b4b30cdcc98.jpg?1",
             "name": "Spineless Thug",
             "text": "",
             "colours": [
@@ -11500,7 +11500,7 @@
         },
         {
             "id": "9c541c1a-7f59-55ce-99d3-08b0bd279562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f6685d-eb5d-403f-b89a-b8b67900b602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f6685d-eb5d-403f-b89a-b8b67900b602.jpg?1",
             "name": "Strands of Night",
             "text": "o\nBo\nB, Pay 2 life, Sacrifice a swamp: Return target creature card from your graveyard to play.",
             "colours": [
@@ -11533,7 +11533,7 @@
         },
         {
             "id": "40b0416a-8888-5aa9-bf02-321d6e5a7f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79771-6bb8-4575-b9f4-bd1107a676c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79771-6bb8-4575-b9f4-bd1107a676c0.jpg?1",
             "name": "Strands of Night",
             "text": "",
             "colours": [
@@ -11566,7 +11566,7 @@
         },
         {
             "id": "9b1af246-8a99-56a1-ae3a-c03aa9ea96ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388ad92-fa79-4a1a-b75c-e340dba016f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388ad92-fa79-4a1a-b75c-e340dba016f4.jpg?1",
             "name": "Stronghold Assassin",
             "text": "oc\nT, Sacrifice a creature: Destroy target nonblack creature.",
             "colours": [
@@ -11603,7 +11603,7 @@
         },
         {
             "id": "dee3a7f1-f51f-5f27-b145-7ef7de8b6897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fba666-9648-44d8-9cbd-f98bca90fccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fba666-9648-44d8-9cbd-f98bca90fccb.jpg?1",
             "name": "Stronghold Assassin",
             "text": "",
             "colours": [
@@ -11640,7 +11640,7 @@
         },
         {
             "id": "2213f56b-2cc3-5484-8899-ccd4bc8e17db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838cffb6-8099-44d7-a127-b2ab3b53ea44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838cffb6-8099-44d7-a127-b2ab3b53ea44.jpg?1",
             "name": "Tainted Aether",
             "text": "Whenever a creature comes into play, its controller sacrifices a creature or land.",
             "colours": [
@@ -11673,7 +11673,7 @@
         },
         {
             "id": "dc3a9a3a-18a1-53e6-996c-a65ea9fc1101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca62508-4f7f-4dac-82ae-b978acb32c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca62508-4f7f-4dac-82ae-b978acb32c67.jpg?1",
             "name": "Tainted Aether",
             "text": "",
             "colours": [
@@ -11706,7 +11706,7 @@
         },
         {
             "id": "cec4371b-cc1c-5189-ba51-d6f93b9fd543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0030407c-9aa0-49ad-b2d6-cde0adbd9d09.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchanted creature gets +2/+1.",
             "colours": [
@@ -11741,7 +11741,7 @@
         },
         {
             "id": "9a40c67b-117f-560e-82f8-815ecb073f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42101792-83a7-492d-a5b0-34aab7db56d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42101792-83a7-492d-a5b0-34aab7db56d1.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -11776,7 +11776,7 @@
         },
         {
             "id": "530eb096-ec15-5414-9314-56237bbef6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5092f-a248-471e-87e0-8394d5e2d3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5092f-a248-471e-87e0-8394d5e2d3fe.jpg?1",
             "name": "Wall of Bone",
             "text": "(Walls can't attack.)\noo\nB Regenerate Wall of Bone.",
             "colours": [
@@ -11812,7 +11812,7 @@
         },
         {
             "id": "b6bd71ae-648c-5fab-b426-8484cf385c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb18ebfa-9a70-48c6-a906-149f0e7cd474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb18ebfa-9a70-48c6-a906-149f0e7cd474.jpg?1",
             "name": "Wall of Bone",
             "text": "",
             "colours": [
@@ -11848,7 +11848,7 @@
         },
         {
             "id": "9ff4881d-e500-5d01-934a-2cd683136da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4d19d4-a29b-4b1f-b29b-adcad557c3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4d19d4-a29b-4b1f-b29b-adcad557c3c7.jpg?1",
             "name": "Western Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target white creature.",
             "colours": [
@@ -11885,7 +11885,7 @@
         },
         {
             "id": "a25a0959-fd9d-56c5-aab5-a8049ca65f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9ad3e-f392-48ed-9f31-3a997a3b7358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9ad3e-f392-48ed-9f31-3a997a3b7358.jpg?1",
             "name": "Western Paladin",
             "text": "",
             "colours": [
@@ -11922,7 +11922,7 @@
         },
         {
             "id": "f287c781-840f-556d-84ae-d7fd8eefbb2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ed0e5-37a0-4909-a37e-ba4745bfae3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ed0e5-37a0-4909-a37e-ba4745bfae3b.jpg?1",
             "name": "Yawgmoth's Edict",
             "text": "Whenever an opponent plays a white spell, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -11955,7 +11955,7 @@
         },
         {
             "id": "74b31c78-56a4-5181-b723-7af590fb68d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2b1255-d917-4884-aa9e-4b1f92e88f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2b1255-d917-4884-aa9e-4b1f92e88f79.jpg?1",
             "name": "Yawgmoth's Edict",
             "text": "",
             "colours": [
@@ -11988,7 +11988,7 @@
         },
         {
             "id": "31eb6863-c020-501f-9090-1a187afb3f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f9197-e910-4c7a-bb4b-2c4a94903c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f9197-e910-4c7a-bb4b-2c4a94903c39.jpg?1",
             "name": "Aether Flash",
             "text": "Whenever a creature comes into play, \u00c6ther Flash deals 2 damage to it.",
             "colours": [
@@ -12021,7 +12021,7 @@
         },
         {
             "id": "8ee43db3-a2ff-5ef3-bcd6-4e2ef0970b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6b8fa-3546-415f-89f1-1176d22ad15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6b8fa-3546-415f-89f1-1176d22ad15e.jpg?1",
             "name": "Aether Flash",
             "text": "",
             "colours": [
@@ -12054,7 +12054,7 @@
         },
         {
             "id": "43e74954-68ea-5001-a2ed-be6e49cebdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2507e14-96d1-40e6-9379-4d4749d74e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2507e14-96d1-40e6-9379-4d4749d74e1d.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12090,7 +12090,7 @@
         },
         {
             "id": "d70572ec-dadd-5399-bfda-9a0a4d354ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c201ace3-4d99-467e-a558-7d22ad004cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c201ace3-4d99-467e-a558-7d22ad004cf2.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12126,7 +12126,7 @@
         },
         {
             "id": "35395ade-6181-5b51-bbc7-166ba98c9718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2788ec1a-930e-4a19-ad69-ea456c1390fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2788ec1a-930e-4a19-ad69-ea456c1390fd.jpg?1",
             "name": "Bedlam",
             "text": "Creatures can't block.",
             "colours": [
@@ -12159,7 +12159,7 @@
         },
         {
             "id": "ed671661-49f6-5c62-8888-eaec5bedb81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbcb398-85be-4923-9888-9dcca89a0b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbcb398-85be-4923-9888-9dcca89a0b59.jpg?1",
             "name": "Bedlam",
             "text": "",
             "colours": [
@@ -12192,7 +12192,7 @@
         },
         {
             "id": "21d76910-b7e2-59a8-b95e-40bcffbeccea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f8c6ab-ae62-4e2e-a5ba-2ec5bbe22445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f8c6ab-ae62-4e2e-a5ba-2ec5bbe22445.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -12225,7 +12225,7 @@
         },
         {
             "id": "d7df02ab-9e9f-55c7-ae16-d9f1f9e41aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a9a4ba-98ef-4eb1-a650-a77b84226701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a9a4ba-98ef-4eb1-a650-a77b84226701.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -12258,7 +12258,7 @@
         },
         {
             "id": "fcb50e71-6a4b-5eec-8691-68b2a8be7ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387dd482-c67d-43da-a4d0-582241431ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387dd482-c67d-43da-a4d0-582241431ffd.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "oc\nT, Sacrifice a creature: Bloodshot Cyclops deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -12294,7 +12294,7 @@
         },
         {
             "id": "442262b1-f7b7-5d9a-8b4c-a563514f2c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c07aa-beae-4818-9424-6dbfb30a428d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c07aa-beae-4818-9424-6dbfb30a428d.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "",
             "colours": [
@@ -12330,7 +12330,7 @@
         },
         {
             "id": "dbef4913-79fc-55d2-acc0-31029398f4d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52969d36-f392-4920-b998-589c8356b898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52969d36-f392-4920-b998-589c8356b898.jpg?1",
             "name": "Boil",
             "text": "Destroy all islands.",
             "colours": [
@@ -12363,7 +12363,7 @@
         },
         {
             "id": "6409bdc3-f0ab-5db3-83de-9bae5d9eb403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09b9aae-0f87-4b0e-b4b2-7961f1e7f2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09b9aae-0f87-4b0e-b4b2-7961f1e7f2e0.jpg?1",
             "name": "Boil",
             "text": "",
             "colours": [
@@ -12396,7 +12396,7 @@
         },
         {
             "id": "2709f74a-8ab0-519e-aea7-8a49e7bcbfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5451e44f-8dd2-48c6-ba67-5c62a04819ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5451e44f-8dd2-48c6-ba67-5c62a04819ef.jpg?1",
             "name": "Crimson Hellkite",
             "text": "Flying\no\nX, oc\nT: Crimson Hellkite deals X damage to target creature. Spend only red mana this way.",
             "colours": [
@@ -12431,7 +12431,7 @@
         },
         {
             "id": "0dd2d898-eba8-5db1-9f95-02e8cea5a97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ed1fde-817d-4e0a-8268-461a680aed96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ed1fde-817d-4e0a-8268-461a680aed96.jpg?1",
             "name": "Crimson Hellkite",
             "text": "",
             "colours": [
@@ -12466,7 +12466,7 @@
         },
         {
             "id": "4a02f6c6-449d-54cb-8225-9c01c2a9d973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d11422-60a9-4386-8e7f-dd7dcdac58d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d11422-60a9-4386-8e7f-dd7dcdac58d8.jpg?1",
             "name": "Disorder",
             "text": "Disorder deals 2 damage to each white creature and each player who controls a white creature.",
             "colours": [
@@ -12499,7 +12499,7 @@
         },
         {
             "id": "dcb171b1-a744-52d2-8ce3-ccef37b096c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569ca10-6c5e-44ea-810e-62082e589d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569ca10-6c5e-44ea-810e-62082e589d5a.jpg?1",
             "name": "Disorder",
             "text": "",
             "colours": [
@@ -12532,7 +12532,7 @@
         },
         {
             "id": "2b52d157-56e1-545b-90a7-097740137230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f04dc5c-2764-42d0-974e-6d902222c138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f04dc5c-2764-42d0-974e-6d902222c138.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -12565,7 +12565,7 @@
         },
         {
             "id": "fb67591e-b390-5ee0-8637-c51430b7fe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39fb5f-9eb7-4a4c-9382-80b5a9459afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39fb5f-9eb7-4a4c-9382-80b5a9459afc.jpg?1",
             "name": "Earthquake",
             "text": "",
             "colours": [
@@ -12598,7 +12598,7 @@
         },
         {
             "id": "ff8ac494-926d-52b5-90b3-bc4c6790b5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53834370-845c-4677-b665-e556eae8f9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53834370-845c-4677-b665-e556eae8f9de.jpg?1",
             "name": "Fervor",
             "text": "Creatures you control have haste. (They may attack and oc\nT the turn they come under your control.)",
             "colours": [
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "b12ea152-1a82-5673-afa7-07ae4af6609b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c955ff9-0615-4872-8a05-770558ff81dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c955ff9-0615-4872-8a05-770558ff81dd.jpg?1",
             "name": "Fervor",
             "text": "",
             "colours": [
@@ -12664,7 +12664,7 @@
         },
         {
             "id": "7cd22d3d-3cc9-52c0-80c2-17cd47a2daaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb80afc3-4887-42a0-afb2-7fa997981fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb80afc3-4887-42a0-afb2-7fa997981fb2.jpg?1",
             "name": "Final Fortune",
             "text": "Take an extra turn after this one. At the end of that turn, you lose the game.",
             "colours": [
@@ -12697,7 +12697,7 @@
         },
         {
             "id": "68a26e0b-c073-59f8-bb29-44f56ac0687a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60b7014-3e29-4308-976c-0d92df5cec3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60b7014-3e29-4308-976c-0d92df5cec3a.jpg?1",
             "name": "Final Fortune",
             "text": "",
             "colours": [
@@ -12730,7 +12730,7 @@
         },
         {
             "id": "9b6af124-6897-52d6-b1d6-5bc8617f1990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b57e53-220c-4181-80d3-8063864aefc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b57e53-220c-4181-80d3-8063864aefc2.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -12765,7 +12765,7 @@
         },
         {
             "id": "61647959-a65e-57a3-99e2-8c625d689e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b05f47-f86b-46e8-912f-b1273005d46d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b05f47-f86b-46e8-912f-b1273005d46d.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -12800,7 +12800,7 @@
         },
         {
             "id": "b07b8c61-b28a-5687-965a-4d02fde2365f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770cc34-0f38-4773-8633-6907f44436c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770cc34-0f38-4773-8633-6907f44436c4.jpg?1",
             "name": "Ghitu Fire-Eater",
             "text": "oc\nT, Sacrifice Ghitu Fire-Eater: Ghitu Fire-Eater deals damage equal to its power to target creature or player.",
             "colours": [
@@ -12836,7 +12836,7 @@
         },
         {
             "id": "4c6ad381-4174-5d3b-b8ee-77332d8610af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6976444-a076-4e67-80f7-014a1c955eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6976444-a076-4e67-80f7-014a1c955eed.jpg?1",
             "name": "Ghitu Fire-Eater",
             "text": "",
             "colours": [
@@ -12872,7 +12872,7 @@
         },
         {
             "id": "b0598837-3dfe-52e7-8fc3-c34da20ee86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7571801-c1df-4387-ae61-1fefd449ebf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7571801-c1df-4387-ae61-1fefd449ebf9.jpg?1",
             "name": "Goblin Chariot",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -12908,7 +12908,7 @@
         },
         {
             "id": "589d3d87-71b3-54b1-a930-35feea96c87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db520e2-9926-45d2-a140-37b119b88106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db520e2-9926-45d2-a140-37b119b88106.jpg?1",
             "name": "Goblin Chariot",
             "text": "",
             "colours": [
@@ -12944,7 +12944,7 @@
         },
         {
             "id": "ce078bfc-329f-5a9e-a247-3d18475f79bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000425a-4761-4370-95eb-6fe3df628482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000425a-4761-4370-95eb-6fe3df628482.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT, Sacrifice Goblin Digging Team: Destroy target Wall.",
             "colours": [
@@ -12979,7 +12979,7 @@
         },
         {
             "id": "49a4c04b-5a5a-5299-a1ac-1d22796270c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84e6b4-2f87-4662-843d-27d2eada54aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84e6b4-2f87-4662-843d-27d2eada54aa.jpg?1",
             "name": "Goblin Digging Team",
             "text": "",
             "colours": [
@@ -13014,7 +13014,7 @@
         },
         {
             "id": "21e49119-58dc-5898-9967-b15e62650153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5b7dfe-f24b-4d73-813f-f63c926f3672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5b7dfe-f24b-4d73-813f-f63c926f3672.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "Whenever Goblin Elite Infantry blocks or becomes blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -13050,7 +13050,7 @@
         },
         {
             "id": "1fd79e20-c1d4-58cc-8a8a-d73522a3fc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9facc1bf-b088-4be0-acce-be95c0a3e9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9facc1bf-b088-4be0-acce-be95c0a3e9e6.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "",
             "colours": [
@@ -13086,7 +13086,7 @@
         },
         {
             "id": "96dd6934-93f2-5aec-93c2-2504689cff27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5b02af-140e-404d-bf8a-6a706b323a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5b02af-140e-404d-bf8a-6a706b323a13.jpg?1",
             "name": "Goblin Gardener",
             "text": "When Goblin Gardener is put into a graveyard from play, destroy target land.",
             "colours": [
@@ -13121,7 +13121,7 @@
         },
         {
             "id": "6c8cb845-6c89-5689-91c6-165560c5f1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009c1788-a3ab-41cb-8f9a-d220c376953b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009c1788-a3ab-41cb-8f9a-d220c376953b.jpg?1",
             "name": "Goblin Gardener",
             "text": "",
             "colours": [
@@ -13156,7 +13156,7 @@
         },
         {
             "id": "fe10ac37-9967-554e-9fe1-b04108a51810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a7e39-8d98-4e84-8a5c-2b067c8654d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a7e39-8d98-4e84-8a5c-2b067c8654d5.jpg?1",
             "name": "Goblin Glider",
             "text": "Flying\nGoblin Glider can't block.",
             "colours": [
@@ -13191,7 +13191,7 @@
         },
         {
             "id": "7ca32d67-c67d-5edd-b96f-b595e7193267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8cf7c4-f217-42c8-a1ea-0866576b9524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8cf7c4-f217-42c8-a1ea-0866576b9524.jpg?1",
             "name": "Goblin Glider",
             "text": "",
             "colours": [
@@ -13226,7 +13226,7 @@
         },
         {
             "id": "6d4d2d26-dd6f-5f32-9b5e-d6b1cc14e998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77029a-7f00-490e-bf8b-dce192d72e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77029a-7f00-490e-bf8b-dce192d72e2f.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -13261,7 +13261,7 @@
         },
         {
             "id": "2dfa58ac-0663-5f60-9e4f-1e0f9b52ae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3637-ffc8-4bda-bfc1-912f5789b5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3637-ffc8-4bda-bfc1-912f5789b5ed.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -13296,7 +13296,7 @@
         },
         {
             "id": "277664ab-1726-522c-bb53-b3e25e77d43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862409e1-33e0-474c-8627-b03d25b654b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862409e1-33e0-474c-8627-b03d25b654b9.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron comes into play, you may search your library for a Goblin card. If you do, reveal that card and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -13331,7 +13331,7 @@
         },
         {
             "id": "5986b22a-fdee-5b8d-87ec-f0dbd684c378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a80d36-349d-4b49-9a0c-7e0a400abb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a80d36-349d-4b49-9a0c-7e0a400abb67.jpg?1",
             "name": "Goblin Matron",
             "text": "",
             "colours": [
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "7fc1b09a-429b-567b-a677-3371063281f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3315d75d-08dc-456c-a8e7-fe3136bf1a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3315d75d-08dc-456c-a8e7-fe3136bf1a6b.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -13402,7 +13402,7 @@
         },
         {
             "id": "9cf619d6-b382-5803-8c09-6f80c8cf8666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88af4784-e126-4628-b228-6c0a95f00a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88af4784-e126-4628-b228-6c0a95f00a25.jpg?1",
             "name": "Goblin Raider",
             "text": "",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "ffe8d2b0-4994-5990-bd9b-183e21abc670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4dfc6-8b3f-45fb-a1e2-b773f74cd9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4dfc6-8b3f-45fb-a1e2-b773f74cd9c2.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -13474,7 +13474,7 @@
         },
         {
             "id": "facfd06f-8f5f-563f-a9ec-93cd066939c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27f5299-696a-4e00-8221-f349f9b1d461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27f5299-696a-4e00-8221-f349f9b1d461.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "",
             "colours": [
@@ -13510,7 +13510,7 @@
         },
         {
             "id": "2de6975c-3796-5afa-8cee-276c20ba1fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b226987d-e271-483c-9d18-09c461ebbf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b226987d-e271-483c-9d18-09c461ebbf36.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each creature you control can't be blocked except by two or more creatures.",
             "colours": [
@@ -13543,7 +13543,7 @@
         },
         {
             "id": "2a0f3b09-f874-51ae-a67d-3fe33e7a1546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2de28d4-ab1d-4e4d-a8b9-6faa19f9d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2de28d4-ab1d-4e4d-a8b9-6faa19f9d283.jpg?1",
             "name": "Goblin War Drums",
             "text": "",
             "colours": [
@@ -13576,7 +13576,7 @@
         },
         {
             "id": "0c3c6be7-8622-5916-8d75-76a80648d782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908c8414-5eff-4887-9007-43050058c2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908c8414-5eff-4887-9007-43050058c2d0.jpg?1",
             "name": "Granite Grip",
             "text": "Enchanted creature gets +1/+0 for each mountain you control.",
             "colours": [
@@ -13611,7 +13611,7 @@
         },
         {
             "id": "5db693bf-e36b-5979-b45a-0ad90afb0b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb23039-0f38-44f9-845d-b76ca85e4761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb23039-0f38-44f9-845d-b76ca85e4761.jpg?1",
             "name": "Granite Grip",
             "text": "",
             "colours": [
@@ -13646,7 +13646,7 @@
         },
         {
             "id": "59d2de9c-e401-5463-97a7-736caf4064da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea1719-2bed-46f4-bb14-e3a4c87ce50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea1719-2bed-46f4-bb14-e3a4c87ce50a.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13681,7 +13681,7 @@
         },
         {
             "id": "8c1961c0-2fa9-58b7-9418-29771388efd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07724b6b-73e6-43b9-980f-149047c8e786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07724b6b-73e6-43b9-980f-149047c8e786.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13716,7 +13716,7 @@
         },
         {
             "id": "8cb1ea03-3b66-5f5f-a5d7-14bc8e27611d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11443908-358f-4886-a2da-9b98002a3a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11443908-358f-4886-a2da-9b98002a3a3a.jpg?1",
             "name": "Impatience",
             "text": "At the end of each player's turn, if that player didn't play a spell that turn, Impatience deals 2 damage to him or her.",
             "colours": [
@@ -13749,7 +13749,7 @@
         },
         {
             "id": "aae2c1d1-736b-5087-9ef0-64a34a87d351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c59ed1-ecc2-4f0b-a49a-473e797059e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c59ed1-ecc2-4f0b-a49a-473e797059e7.jpg?1",
             "name": "Impatience",
             "text": "",
             "colours": [
@@ -13782,7 +13782,7 @@
         },
         {
             "id": "37d4a707-f4e3-5226-8ce1-e7a46131a03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411b7b5-ab91-410a-af6d-b3a21a8e3b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411b7b5-ab91-410a-af6d-b3a21a8e3b70.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and each player.",
             "colours": [
@@ -13815,7 +13815,7 @@
         },
         {
             "id": "c2c66ad7-d4e0-5103-af88-07dfe672bead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0d589d-d539-453b-b401-14a74e3da4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0d589d-d539-453b-b401-14a74e3da4ea.jpg?1",
             "name": "Inferno",
             "text": "",
             "colours": [
@@ -13848,7 +13848,7 @@
         },
         {
             "id": "299714ff-b0fa-5ba3-841e-d128f2c931a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807e5102-1fab-4ff4-aad8-94defbbb8a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807e5102-1fab-4ff4-aad8-94defbbb8a6b.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -13881,7 +13881,7 @@
         },
         {
             "id": "f67c4dfe-4551-5a27-a8ed-7bb6927c3cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1292a1-3d0e-47a3-97ef-e4ffcdfb492e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1292a1-3d0e-47a3-97ef-e4ffcdfb492e.jpg?1",
             "name": "Lava Axe",
             "text": "",
             "colours": [
@@ -13914,7 +13914,7 @@
         },
         {
             "id": "9d23ae96-17bb-55c5-b84e-5164c2282771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e3c502-9e3c-41db-806c-538243dc0453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e3c502-9e3c-41db-806c-538243dc0453.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -13947,7 +13947,7 @@
         },
         {
             "id": "9af90d76-2d6d-5f91-9267-01e452f9b11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd40ef12-d3fd-4bb9-8990-aa967d8df2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd40ef12-d3fd-4bb9-8990-aa967d8df2dd.jpg?1",
             "name": "Lightning Blast",
             "text": "",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "d350a5a2-9ef5-52cb-be38-ca841c118c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df538e3-84c9-4580-85e9-8ac2f9a1294b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df538e3-84c9-4580-85e9-8ac2f9a1294b.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -14015,7 +14015,7 @@
         },
         {
             "id": "07d2cbac-a3ea-5eca-99c8-c5b158bc7556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d80a8-ac70-4847-b406-321af24de47c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d80a8-ac70-4847-b406-321af24de47c.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -14050,7 +14050,7 @@
         },
         {
             "id": "b6e0422c-ff02-50cc-88bf-c8c110b2d794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740b85ff-61a3-4de0-a055-60daad13ac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740b85ff-61a3-4de0-a055-60daad13ac2a.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
             "colours": [
@@ -14083,7 +14083,7 @@
         },
         {
             "id": "3f21f59a-5f67-5204-b2ca-1a4917baaca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c092c3-1fbe-4319-aefe-d5b819ee953f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c092c3-1fbe-4319-aefe-d5b819ee953f.jpg?1",
             "name": "Mana Clash",
             "text": "",
             "colours": [
@@ -14116,7 +14116,7 @@
         },
         {
             "id": "5b765390-8cda-5fd6-947b-0ccaae02c8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2229fe-5b8f-42c0-bfe6-2c0c3d84624a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2229fe-5b8f-42c0-bfe6-2c0c3d84624a.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -14151,7 +14151,7 @@
         },
         {
             "id": "4e62fad1-d925-5997-9111-23f9f35a1da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa53fb37-d746-491b-830f-46bd60bc2817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa53fb37-d746-491b-830f-46bd60bc2817.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "",
             "colours": [
@@ -14186,7 +14186,7 @@
         },
         {
             "id": "66ab234b-8078-5805-a1a9-a979bfa3f3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fd427-baec-435f-9dc7-339c93f43f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fd427-baec-435f-9dc7-339c93f43f89.jpg?1",
             "name": "Okk",
             "text": "Okk can't attack unless a creature with greater power also attacks.\nOkk can't block unless a creature with greater power also blocks.",
             "colours": [
@@ -14221,7 +14221,7 @@
         },
         {
             "id": "db0e65d3-dc87-5410-a18e-d9e1334d942f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c90704-063c-4774-b675-cb5727afa656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c90704-063c-4774-b675-cb5727afa656.jpg?1",
             "name": "Okk",
             "text": "",
             "colours": [
@@ -14256,7 +14256,7 @@
         },
         {
             "id": "da42d6f1-d546-545d-9e07-0a5179e07571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b13fc4-e26a-4a7c-bde2-ea3626da6aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b13fc4-e26a-4a7c-bde2-ea3626da6aa8.jpg?1",
             "name": "Orcish Artillery",
             "text": "oc\nT: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -14292,7 +14292,7 @@
         },
         {
             "id": "780d4fe6-fc26-59d4-8ed8-83109bf0b2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42afac9-b9a4-4d02-b026-3d03c41d15c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42afac9-b9a4-4d02-b026-3d03c41d15c6.jpg?1",
             "name": "Orcish Artillery",
             "text": "",
             "colours": [
@@ -14328,7 +14328,7 @@
         },
         {
             "id": "9388a4f2-22ad-52ed-9531-47203c593809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45467389-980b-4eaf-9b4b-38fefb307a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45467389-980b-4eaf-9b4b-38fefb307a7c.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -14361,7 +14361,7 @@
         },
         {
             "id": "ae93014e-dbf2-5229-9374-df4fc807c70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10c2e08-c18a-4fc6-9e8b-120fb87c4f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10c2e08-c18a-4fc6-9e8b-120fb87c4f26.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "",
             "colours": [
@@ -14394,7 +14394,7 @@
         },
         {
             "id": "bc115d7b-875d-5b0f-98b7-1a609d93ea46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9792efaa-1f73-48de-8c10-5d20c2856f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9792efaa-1f73-48de-8c10-5d20c2856f3d.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -14427,7 +14427,7 @@
         },
         {
             "id": "ea63b091-9574-519d-985d-02ebd2a863e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4fc2a6-02ff-406c-8a8e-c97ea54b3f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4fc2a6-02ff-406c-8a8e-c97ea54b3f8b.jpg?1",
             "name": "Pillage",
             "text": "",
             "colours": [
@@ -14460,7 +14460,7 @@
         },
         {
             "id": "30e2940c-1871-5004-86c9-e62840065644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e01129-254c-4a16-9f11-21a7a9c66f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e01129-254c-4a16-9f11-21a7a9c66f32.jpg?1",
             "name": "Pygmy Pyrosaur",
             "text": "Pygmy Pyrosaur can't block.\noo\nR Pygmy Pyrosaur gets +1/+0 until end of turn.",
             "colours": [
@@ -14495,7 +14495,7 @@
         },
         {
             "id": "6d5f807b-6d2b-5392-bd4b-f078d5f5a852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57eab2ef-6c3c-4f0e-8566-113070604a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57eab2ef-6c3c-4f0e-8566-113070604a1d.jpg?1",
             "name": "Pygmy Pyrosaur",
             "text": "",
             "colours": [
@@ -14530,7 +14530,7 @@
         },
         {
             "id": "bced00fa-a3da-5bfe-bbc8-5e7c487dbc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afce33f-2ead-4943-9655-bff6eaa9fe6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afce33f-2ead-4943-9655-bff6eaa9fe6b.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -14563,7 +14563,7 @@
         },
         {
             "id": "bcf663d1-de58-50a1-b8f0-d682e6eb503e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964b8482-9154-4f26-9ae7-641d0c00ca99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964b8482-9154-4f26-9ae7-641d0c00ca99.jpg?1",
             "name": "Pyroclasm",
             "text": "",
             "colours": [
@@ -14596,7 +14596,7 @@
         },
         {
             "id": "25e81daf-d908-518e-8988-40f691fc3e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5d0adf-9368-4d7f-8bd0-76d0db95ba16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5d0adf-9368-4d7f-8bd0-76d0db95ba16.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -14629,7 +14629,7 @@
         },
         {
             "id": "6f28193f-9849-5935-b72b-2ea74cd033ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfea5f9-500e-45e8-80b0-9ff9bd09e07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfea5f9-500e-45e8-80b0-9ff9bd09e07a.jpg?1",
             "name": "Pyrotechnics",
             "text": "",
             "colours": [
@@ -14662,7 +14662,7 @@
         },
         {
             "id": "5359482c-87c5-5f9f-98d4-abcd7ae87999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657190fe-9c18-4134-a556-e081daff73cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657190fe-9c18-4134-a556-e081daff73cd.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -14698,7 +14698,7 @@
         },
         {
             "id": "11bfc211-af33-59fb-8f18-8984eec9abab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1c9bb-fa05-4947-9e03-6fe397157265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1c9bb-fa05-4947-9e03-6fe397157265.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -14734,7 +14734,7 @@
         },
         {
             "id": "2b914d35-baac-5974-a2f6-1ade5681ef15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f75ed4-b96c-444b-ac91-8aaa02f32f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f75ed4-b96c-444b-ac91-8aaa02f32f2d.jpg?1",
             "name": "Reckless Embermage",
             "text": "o1oo\nR Reckless Embermage deals 1 damage to target creature or player and 1 damage to itself.",
             "colours": [
@@ -14770,7 +14770,7 @@
         },
         {
             "id": "3a97b6ed-f25f-580c-bb92-0746578bf99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8a8bb2-e876-4e62-a437-96cc4dd6be89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8a8bb2-e876-4e62-a437-96cc4dd6be89.jpg?1",
             "name": "Reckless Embermage",
             "text": "",
             "colours": [
@@ -14806,7 +14806,7 @@
         },
         {
             "id": "ae2370a1-cede-5166-9456-77f013fe27ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc8ce35-589b-4903-8d52-8ccbea7b767b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc8ce35-589b-4903-8d52-8ccbea7b767b.jpg?1",
             "name": "Reflexes",
             "text": "Enchanted creature has first strike.",
             "colours": [
@@ -14841,7 +14841,7 @@
         },
         {
             "id": "260658e8-f823-5ca4-9eb8-d1fe69659225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f91d14-b409-44b6-bdfd-44427855373a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f91d14-b409-44b6-bdfd-44427855373a.jpg?1",
             "name": "Reflexes",
             "text": "",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "cf2276c3-2682-5179-963f-16034403c215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c48308-12e8-4b85-a5ef-1e0643bd814c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c48308-12e8-4b85-a5ef-1e0643bd814c.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You get an additional combat phase followed by an additional main phase this turn.",
             "colours": [
@@ -14909,7 +14909,7 @@
         },
         {
             "id": "5e21154b-f59a-577a-a9f0-11b2c6f08834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242d25fe-e03a-4fa9-8049-d1bb0aef3d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242d25fe-e03a-4fa9-8049-d1bb0aef3d07.jpg?1",
             "name": "Relentless Assault",
             "text": "",
             "colours": [
@@ -14942,7 +14942,7 @@
         },
         {
             "id": "f538335b-b3b5-5669-871f-e7aec35c7c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aee4a17-49da-446f-a134-1261980a249f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aee4a17-49da-446f-a134-1261980a249f.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -14977,7 +14977,7 @@
         },
         {
             "id": "2e19e6fa-6029-5ee8-a67c-ff3de6704e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d923644-3137-4e72-93d3-231066314d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d923644-3137-4e72-93d3-231066314d9b.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "",
             "colours": [
@@ -15012,7 +15012,7 @@
         },
         {
             "id": "794e45bf-7200-5765-a468-1df85e40ab8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d399a9ac-01da-44a4-8f81-084d41dfada8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d399a9ac-01da-44a4-8f81-084d41dfada8.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card from your hand: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -15045,7 +15045,7 @@
         },
         {
             "id": "5f22e249-fe19-5d1b-aa60-ddb77bb4cebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a994998-11b1-46fd-a877-d0b67fa8f777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a994998-11b1-46fd-a877-d0b67fa8f777.jpg?1",
             "name": "Seismic Assault",
             "text": "",
             "colours": [
@@ -15078,7 +15078,7 @@
         },
         {
             "id": "d51fa114-2f31-59bb-8462-63dd0b4df909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0017ebd-d672-4933-8136-d929737e5ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0017ebd-d672-4933-8136-d929737e5ecd.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "6d655976-503f-5d90-9e50-1d173a169ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142a7f05-df30-4bac-801d-06f125e7365f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142a7f05-df30-4bac-801d-06f125e7365f.jpg?1",
             "name": "Shatter",
             "text": "",
             "colours": [
@@ -15144,7 +15144,7 @@
         },
         {
             "id": "3cd07b68-5c96-54c1-ad7d-3bf84c44d72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fec2b71-8fa9-4818-9c4f-5d2dcd2af495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fec2b71-8fa9-4818-9c4f-5d2dcd2af495.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\noo\nR Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -15179,7 +15179,7 @@
         },
         {
             "id": "dc330428-8db9-56aa-8c3e-c743f0b46268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de98d9ad-d011-43de-92c8-f97037b42803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de98d9ad-d011-43de-92c8-f97037b42803.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -15214,7 +15214,7 @@
         },
         {
             "id": "e3e0b141-4097-5914-b6d7-04e66134531e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea653772-a5fe-4416-bef3-fd41133371db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea653772-a5fe-4416-bef3-fd41133371db.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "df9f8162-a41f-5e59-87af-0845fb5a089e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d1cef-c181-481b-912c-385b81efd972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d1cef-c181-481b-912c-385b81efd972.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -15280,7 +15280,7 @@
         },
         {
             "id": "daec60f9-555a-593e-9cb1-aa53822b54f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db01746-2734-4686-b443-52de8e379bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db01746-2734-4686-b443-52de8e379bbe.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals damage equal to the number of mountains you control to target creature.",
             "colours": [
@@ -15313,7 +15313,7 @@
         },
         {
             "id": "d9728beb-28e7-5527-bf48-a94d852d0d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724682ef-d591-4d99-8557-0c970a043bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724682ef-d591-4d99-8557-0c970a043bf7.jpg?1",
             "name": "Spitting Earth",
             "text": "",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "1effc43b-a903-524a-9610-f1ca4b9f5038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b70f97-441c-41ae-ab10-22ddd7bff28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b70f97-441c-41ae-ab10-22ddd7bff28d.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -15379,7 +15379,7 @@
         },
         {
             "id": "7d31456a-4530-5c76-b560-8005f6635dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc5314f-bfc1-4960-8a1f-80291e81b7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc5314f-bfc1-4960-8a1f-80291e81b7b9.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "49df6aff-363d-568d-b412-e983396314f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae941462-9086-47e5-8c04-01e53195584f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae941462-9086-47e5-8c04-01e53195584f.jpg?1",
             "name": "Storm Shaman",
             "text": "oo\nR Storm Shaman gets +1/+0 until end of turn.",
             "colours": [
@@ -15449,7 +15449,7 @@
         },
         {
             "id": "96ebe05b-e012-5d40-a494-737f1312a454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cee0af-29a3-48cc-8a81-c3dac65271d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cee0af-29a3-48cc-8a81-c3dac65271d6.jpg?1",
             "name": "Storm Shaman",
             "text": "",
             "colours": [
@@ -15486,7 +15486,7 @@
         },
         {
             "id": "8c86b102-43b2-578a-ac38-5e2ff3e2ec43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef178ad2-f0e1-4fbb-aada-dccc40463ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef178ad2-f0e1-4fbb-aada-dccc40463ece.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -15519,7 +15519,7 @@
         },
         {
             "id": "ae52e3b6-8e72-50e6-96c4-70624e13a98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c987fd13-c690-46f9-b3ed-d2fc052c45ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c987fd13-c690-46f9-b3ed-d2fc052c45ff.jpg?1",
             "name": "Sudden Impact",
             "text": "",
             "colours": [
@@ -15552,7 +15552,7 @@
         },
         {
             "id": "014b8875-c4c9-54a0-bb1d-4f795816108e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a83031-8b57-41d2-b586-bb4dcf16136a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a83031-8b57-41d2-b586-bb4dcf16136a.jpg?1",
             "name": "Trained Orgg",
             "text": "",
             "colours": [
@@ -15587,7 +15587,7 @@
         },
         {
             "id": "505f27f6-d10b-5dc3-b377-67a189caceb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81dc1a-6560-479b-8c6f-54d04b1853f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81dc1a-6560-479b-8c6f-54d04b1853f7.jpg?1",
             "name": "Trained Orgg",
             "text": "",
             "colours": [
@@ -15622,7 +15622,7 @@
         },
         {
             "id": "d3339a06-c9bf-5714-90f7-958697d0df3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281c013-b35a-4c4a-aaee-b6f93968485c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b281c013-b35a-4c4a-aaee-b6f93968485c.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "67bc7b72-651a-5d90-937c-f2250fe439f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd43f654-081f-4ebb-b82e-02a2a8d959fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd43f654-081f-4ebb-b82e-02a2a8d959fa.jpg?1",
             "name": "Tremor",
             "text": "",
             "colours": [
@@ -15688,7 +15688,7 @@
         },
         {
             "id": "a2b9d218-264f-53c2-94b3-046ca16b5a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d93606-4864-4a5f-bcbf-8638211e979d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d93606-4864-4a5f-bcbf-8638211e979d.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to target creature or player.",
             "colours": [
@@ -15721,7 +15721,7 @@
         },
         {
             "id": "80be9379-9bdd-562a-b73d-f3f013d8abd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf796a-8d10-4c37-8fe3-789f99eb526b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf796a-8d10-4c37-8fe3-789f99eb526b.jpg?1",
             "name": "Volcanic Hammer",
             "text": "",
             "colours": [
@@ -15754,7 +15754,7 @@
         },
         {
             "id": "08019087-0b0e-5a6c-8fa1-56c1310eb815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35113d19-0d4a-4513-82f3-c8deaa1e4324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35113d19-0d4a-4513-82f3-c8deaa1e4324.jpg?1",
             "name": "Wall of Fire",
             "text": "(Walls can't attack.)\noo\nR Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -15789,7 +15789,7 @@
         },
         {
             "id": "c03ef4cf-894a-5402-b6e4-19239189becb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8374f-abdf-495e-a11d-6dd7c30a21f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8374f-abdf-495e-a11d-6dd7c30a21f7.jpg?1",
             "name": "Wall of Fire",
             "text": "",
             "colours": [
@@ -15824,7 +15824,7 @@
         },
         {
             "id": "1c03f121-cac7-55f2-ab28-9ff54fe11bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826fd527-9356-4eec-8542-781116f23eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826fd527-9356-4eec-8542-781116f23eb7.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands. Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -15857,7 +15857,7 @@
         },
         {
             "id": "7f2ae2a4-5504-53af-a1e3-b27779ec4ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997a6901-31f5-48d3-aa8d-44b34d5098ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997a6901-31f5-48d3-aa8d-44b34d5098ee.jpg?1",
             "name": "Wildfire",
             "text": "",
             "colours": [
@@ -15890,7 +15890,7 @@
         },
         {
             "id": "7a1e162d-f39c-53c1-8ce1-1a72329e7a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb01c40-8fd7-483f-a0da-e1a3db6c93ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb01c40-8fd7-483f-a0da-e1a3db6c93ef.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "915816a7-ff64-5049-b4a8-bd3e6a8a31f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccffce-5ebd-4aaa-be05-1c6537d211f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccffce-5ebd-4aaa-be05-1c6537d211f4.jpg?1",
             "name": "Anaconda",
             "text": "",
             "colours": [
@@ -15960,7 +15960,7 @@
         },
         {
             "id": "134915fa-9ab7-5f0b-9c04-271fd4d91cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8a99-b01d-4d0a-bf1c-a3cf08fbc469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8a99-b01d-4d0a-bf1c-a3cf08fbc469.jpg?1",
             "name": "Ancient Silverback",
             "text": "oo\nG Regenerate Ancient Silverback.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "13b283f5-061f-5826-9b73-828dcde96ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ebbf7d-30b6-4d57-a168-3b35c54fa8db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ebbf7d-30b6-4d57-a168-3b35c54fa8db.jpg?1",
             "name": "Ancient Silverback",
             "text": "",
             "colours": [
@@ -16030,7 +16030,7 @@
         },
         {
             "id": "743de9bb-11f9-5211-9b76-18924808afb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2985857-fee5-42a6-9b5d-e157ada52a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2985857-fee5-42a6-9b5d-e157ada52a03.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -16065,7 +16065,7 @@
         },
         {
             "id": "d38c9b9e-89a3-57fe-9549-6daedc854ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7106d8-ec4f-4bc2-aa39-9a605b04cf88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7106d8-ec4f-4bc2-aa39-9a605b04cf88.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -16100,7 +16100,7 @@
         },
         {
             "id": "ff56448e-57aa-55a2-82c1-9d0205e19375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ee5083-078f-4e76-a172-8f2edf98aa80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ee5083-078f-4e76-a172-8f2edf98aa80.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchanted creature gets +1/+1 for each forest you control.",
             "colours": [
@@ -16135,7 +16135,7 @@
         },
         {
             "id": "251777ef-c571-5560-a89d-78642d19be91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205388c-dd0d-48c0-809f-420312e54cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205388c-dd0d-48c0-809f-420312e54cca.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -16170,7 +16170,7 @@
         },
         {
             "id": "70ea977b-bdb2-527a-88b2-7064bce56320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044785ad-0f05-4944-aab3-49236727078d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044785ad-0f05-4944-aab3-49236727078d.jpg?1",
             "name": "Bull Hippo",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)",
             "colours": [
@@ -16205,7 +16205,7 @@
         },
         {
             "id": "10d5d75a-2e6f-54b1-bee4-c58fee725ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f345c8-1c0f-4ad0-bb56-0caf2bbc158f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f345c8-1c0f-4ad0-bb56-0caf2bbc158f.jpg?1",
             "name": "Bull Hippo",
             "text": "",
             "colours": [
@@ -16240,7 +16240,7 @@
         },
         {
             "id": "c00dbb2c-fa7b-50b0-bd78-b71f39f7e448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6a2b31-2601-4fdf-afc9-cceccf1b3379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6a2b31-2601-4fdf-afc9-cceccf1b3379.jpg?1",
             "name": "Canopy Spider",
             "text": "Canopy Spider may block as though it had flying.",
             "colours": [
@@ -16275,7 +16275,7 @@
         },
         {
             "id": "631cfe0e-895d-5dc1-9cb0-bd3231d7ab99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ad0711-a36d-4a3f-bbc5-00c9d8f7c448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ad0711-a36d-4a3f-bbc5-00c9d8f7c448.jpg?1",
             "name": "Canopy Spider",
             "text": "",
             "colours": [
@@ -16310,7 +16310,7 @@
         },
         {
             "id": "7f0ead0b-e5fe-5b4f-8978-9d314afba002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fc8eca-7549-45b5-b3db-89a58d7d2a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fc8eca-7549-45b5-b3db-89a58d7d2a4a.jpg?1",
             "name": "Compost",
             "text": "Whenever a black card is put into an opponent's graveyard, you may draw a card.",
             "colours": [
@@ -16343,7 +16343,7 @@
         },
         {
             "id": "ec8d1c26-12b5-5e4e-9bd2-434c5e4a1d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedbed40-f29f-4d5a-adea-8e13680ae671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedbed40-f29f-4d5a-adea-8e13680ae671.jpg?1",
             "name": "Compost",
             "text": "",
             "colours": [
@@ -16376,7 +16376,7 @@
         },
         {
             "id": "f2f97d03-908c-5b74-91f1-dee514bd2245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b589a6-46d7-45a2-8352-dd04338192df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b589a6-46d7-45a2-8352-dd04338192df.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -16409,7 +16409,7 @@
         },
         {
             "id": "76d25cca-de55-5a90-a61a-94eba8118682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02cb174-60eb-47fa-8870-684629c084c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02cb174-60eb-47fa-8870-684629c084c4.jpg?1",
             "name": "Creeping Mold",
             "text": "",
             "colours": [
@@ -16442,7 +16442,7 @@
         },
         {
             "id": "693906aa-1fe1-5456-9735-f0c5566cd50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcbd047-7757-45ea-abe3-1064881ec90b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcbd047-7757-45ea-abe3-1064881ec90b.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -16475,7 +16475,7 @@
         },
         {
             "id": "eb628988-d161-5be3-886d-a10d395768c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb10101-cbd5-4d79-9161-f518f34add11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb10101-cbd5-4d79-9161-f518f34add11.jpg?1",
             "name": "Early Harvest",
             "text": "",
             "colours": [
@@ -16508,7 +16508,7 @@
         },
         {
             "id": "42df5e2c-ad51-5581-a478-a16deb022a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88ff5b-44df-40eb-b0bb-37936ae0d854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88ff5b-44df-40eb-b0bb-37936ae0d854.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG, oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -16545,7 +16545,7 @@
         },
         {
             "id": "9fc618ba-4cd8-592b-9aff-17daa0835e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1540e-58c4-4bec-abc8-e3e2760fcb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1540e-58c4-4bec-abc8-e3e2760fcb1f.jpg?1",
             "name": "Elder Druid",
             "text": "",
             "colours": [
@@ -16582,7 +16582,7 @@
         },
         {
             "id": "add53430-3029-5762-be8b-7604f9ada4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8411c9-4f6f-4301-ac36-386016a32852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8411c9-4f6f-4301-ac36-386016a32852.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -16618,7 +16618,7 @@
         },
         {
             "id": "05e11719-ad64-50d0-b1b8-060c474960b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66166a6c-3127-4f17-99fb-f469c3da92fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66166a6c-3127-4f17-99fb-f469c3da92fb.jpg?1",
             "name": "Elvish Archers",
             "text": "",
             "colours": [
@@ -16654,7 +16654,7 @@
         },
         {
             "id": "cef0836c-c4f0-5490-94c4-374ebcec6536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d00f31-d8fd-4272-87ba-6bcb65c609c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d00f31-d8fd-4272-87ba-6bcb65c609c6.jpg?1",
             "name": "Elvish Champion",
             "text": "All Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -16689,7 +16689,7 @@
         },
         {
             "id": "a01bab37-30c3-594d-9d9d-0eda0e3f9bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6812ca1e-10d0-43ae-a6fc-5ab801539ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6812ca1e-10d0-43ae-a6fc-5ab801539ec9.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -16724,7 +16724,7 @@
         },
         {
             "id": "094783d9-0cde-59e9-989a-79a9d2ef3cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bab3e7-f2c8-4025-8463-9e4de10091e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bab3e7-f2c8-4025-8463-9e4de10091e7.jpg?1",
             "name": "Elvish Lyrist",
             "text": "o\nG, oc\nT, Sacrifice Elvish Lyrist: Destroy target enchantment.",
             "colours": [
@@ -16759,7 +16759,7 @@
         },
         {
             "id": "b6ac39b0-152d-539f-85da-005c9a5c7482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364e2f8-df18-4710-a588-00f1f00f22da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364e2f8-df18-4710-a588-00f1f00f22da.jpg?1",
             "name": "Elvish Lyrist",
             "text": "",
             "colours": [
@@ -16794,7 +16794,7 @@
         },
         {
             "id": "fca07076-c3eb-58f3-b6e3-5ba132f8aef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89476260-19b1-495c-b23e-6f206483e84a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89476260-19b1-495c-b23e-6f206483e84a.jpg?1",
             "name": "Elvish Piper",
             "text": "o\nG, oc\nT: Put a creature card from your hand into play.",
             "colours": [
@@ -16830,7 +16830,7 @@
         },
         {
             "id": "a53cbcd1-1bfa-529b-83a5-2ad9517c25e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7335452-36cc-4d76-bde5-4ca8761dc94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7335452-36cc-4d76-bde5-4ca8761dc94d.jpg?1",
             "name": "Elvish Piper",
             "text": "",
             "colours": [
@@ -16866,7 +16866,7 @@
         },
         {
             "id": "b32f249e-0304-516c-a328-b35d06667557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e990d-726c-4b3b-84b4-9c15a5c4be8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e990d-726c-4b3b-84b4-9c15a5c4be8c.jpg?1",
             "name": "Familiar Ground",
             "text": "Each creature you control can't be blocked by more than one creature.",
             "colours": [
@@ -16899,7 +16899,7 @@
         },
         {
             "id": "c55f3795-7831-5a79-86d6-438bd455ae28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5be1074-fd40-46ba-b3bb-fb3207d2d41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5be1074-fd40-46ba-b3bb-fb3207d2d41b.jpg?1",
             "name": "Familiar Ground",
             "text": "",
             "colours": [
@@ -16932,7 +16932,7 @@
         },
         {
             "id": "da71a626-2b71-5a88-bf76-62f74e4450bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed8a169-1f32-486c-9dfb-aa13fcf3c984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed8a169-1f32-486c-9dfb-aa13fcf3c984.jpg?1",
             "name": "Femeref Archers",
             "text": "oc\nT: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -16968,7 +16968,7 @@
         },
         {
             "id": "3053a8eb-9f0f-5aba-bafa-2f6e3509ef3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1096b-96b5-47c3-93ad-f36bdceb326e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1096b-96b5-47c3-93ad-f36bdceb326e.jpg?1",
             "name": "Femeref Archers",
             "text": "",
             "colours": [
@@ -17004,7 +17004,7 @@
         },
         {
             "id": "36330aaa-52d0-5452-9f81-8db0ece27bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6213c038-d231-4e61-b0ec-d1e39637e5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6213c038-d231-4e61-b0ec-d1e39637e5c3.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -17037,7 +17037,7 @@
         },
         {
             "id": "f510c9ba-f433-54e3-86fc-98c4d8bcf036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492699b8-0d03-474b-9b0f-569440387fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492699b8-0d03-474b-9b0f-569440387fb6.jpg?1",
             "name": "Fog",
             "text": "",
             "colours": [
@@ -17070,7 +17070,7 @@
         },
         {
             "id": "7d36bde4-b426-5230-ac63-fbeeba3bfb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1c3e8c-da95-4d27-9c60-5a2cdcff0b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1c3e8c-da95-4d27-9c60-5a2cdcff0b71.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool.",
             "colours": [
@@ -17106,7 +17106,7 @@
         },
         {
             "id": "f5fd39fe-298e-53c3-a2eb-1fea187b9774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d03d69-2f6f-4c72-93b5-10bb8a278e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d03d69-2f6f-4c72-93b5-10bb8a278e24.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "",
             "colours": [
@@ -17142,7 +17142,7 @@
         },
         {
             "id": "46fbfe02-5a2d-5cc6-97c5-65f0f8b098fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0a61c9-8b14-4255-8453-4b74d90fe0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0a61c9-8b14-4255-8453-4b74d90fe0a3.jpg?1",
             "name": "Gang of Elk",
             "text": "Whenever Gang of Elk becomes blocked, it gets +2/+2 until end of turn for each creature blocking it.",
             "colours": [
@@ -17178,7 +17178,7 @@
         },
         {
             "id": "19278566-f454-596a-a493-18bdb88a0a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91350320-6a51-42f0-b644-bc5ce2a80505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91350320-6a51-42f0-b644-bc5ce2a80505.jpg?1",
             "name": "Gang of Elk",
             "text": "",
             "colours": [
@@ -17214,7 +17214,7 @@
         },
         {
             "id": "a85c380d-cf20-5225-ac91-7ee21ed321d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade9b45-a1f5-4680-8d26-d2ae5879b1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade9b45-a1f5-4680-8d26-d2ae5879b1b6.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -17247,7 +17247,7 @@
         },
         {
             "id": "9f1fb3f9-baa4-5321-acfb-c676426898a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376a82b-ca41-4a75-9d8c-396477b2f340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376a82b-ca41-4a75-9d8c-396477b2f340.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -17280,7 +17280,7 @@
         },
         {
             "id": "e7b009e2-871a-5d15-be8f-75d0df78b969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bcde1e-d379-4b0c-8e59-01fbb3217f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bcde1e-d379-4b0c-8e59-01fbb3217f04.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider may block as though it had flying.",
             "colours": [
@@ -17315,7 +17315,7 @@
         },
         {
             "id": "70814eb2-acac-5f89-863a-255dfec0cf34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ad85b-162e-4dfb-99e5-97ef038cc69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ad85b-162e-4dfb-99e5-97ef038cc69d.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -17350,7 +17350,7 @@
         },
         {
             "id": "46f50f05-1fd8-546e-b41f-080d20dd0eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76185a-519f-4bec-b399-989ebddbab71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76185a-519f-4bec-b399-989ebddbab71.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1oo\nG Regenerate Gorilla Chieftain.",
             "colours": [
@@ -17385,7 +17385,7 @@
         },
         {
             "id": "1ba6a718-88be-5299-ab77-e7ab273c20b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb762ef0-59e9-4c64-b3cb-0f2596059307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb762ef0-59e9-4c64-b3cb-0f2596059307.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "",
             "colours": [
@@ -17420,7 +17420,7 @@
         },
         {
             "id": "8d4a7ebe-9953-59b0-93d2-b50e060bac1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8dadf2-d31a-4b24-a9a7-f7f511ba2867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8dadf2-d31a-4b24-a9a7-f7f511ba2867.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17455,7 +17455,7 @@
         },
         {
             "id": "97f28506-d212-5cff-ba87-825addbfd8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e3de06-572e-48c5-888b-2dac7fa9d0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e3de06-572e-48c5-888b-2dac7fa9d0d0.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17490,7 +17490,7 @@
         },
         {
             "id": "1a892e58-6837-5358-b2a9-9d7c166b6a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0526077-79b6-40ae-8178-8b97c33a53fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0526077-79b6-40ae-8178-8b97c33a53fb.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -17523,7 +17523,7 @@
         },
         {
             "id": "8d35c130-5727-5833-a53f-22952288c1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96005f68-1712-4818-ad31-a0e629c54d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96005f68-1712-4818-ad31-a0e629c54d36.jpg?1",
             "name": "Hurricane",
             "text": "",
             "colours": [
@@ -17556,7 +17556,7 @@
         },
         {
             "id": "bfc5cb0e-8be5-5194-a0cf-0e46391fd19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8a8cfd-baef-4198-b1f3-4926139588b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8a8cfd-baef-4198-b1f3-4926139588b2.jpg?1",
             "name": "Llanowar Elves",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "83a482a2-16e4-52e0-a03a-bf1dd50e7987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fca5b76-2e0b-4557-91c6-283000d17849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fca5b76-2e0b-4557-91c6-283000d17849.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -17628,7 +17628,7 @@
         },
         {
             "id": "c492ac35-29da-521c-81a7-5b897d7c29ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f885c7-4947-4041-ab82-b5e8dc167f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f885c7-4947-4041-ab82-b5e8dc167f0d.jpg?1",
             "name": "Lone Wolf",
             "text": "You may have Lone Wolf deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -17663,7 +17663,7 @@
         },
         {
             "id": "8e6d15d8-947d-5439-b9d1-bc87e90e62b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afae9668-4131-4cf7-acf0-6e5684165896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afae9668-4131-4cf7-acf0-6e5684165896.jpg?1",
             "name": "Lone Wolf",
             "text": "",
             "colours": [
@@ -17698,7 +17698,7 @@
         },
         {
             "id": "ad66a906-0329-539e-8e27-b8b16a5666f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ebfea3-e671-4c75-b0a2-c310d07351a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ebfea3-e671-4c75-b0a2-c310d07351a6.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -17733,7 +17733,7 @@
         },
         {
             "id": "5381d4c8-57fb-5dff-b6bd-4eada2ce7aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9840d08e-cc99-4fe5-ad60-43833bf7d9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9840d08e-cc99-4fe5-ad60-43833bf7d9eb.jpg?1",
             "name": "Lure",
             "text": "",
             "colours": [
@@ -17768,7 +17768,7 @@
         },
         {
             "id": "0dc0c1b1-d8b1-5551-ae29-249bab7ed240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c3853c-8b41-4bce-b4e0-3824fc5888c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c3853c-8b41-4bce-b4e0-3824fc5888c4.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -17803,7 +17803,7 @@
         },
         {
             "id": "98f363d6-bd98-5600-a9eb-2ab911ad3e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc6b4e-a4a0-4658-ad96-1c70d0dd1297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc6b4e-a4a0-4658-ad96-1c70d0dd1297.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -17838,7 +17838,7 @@
         },
         {
             "id": "1abac968-f1b6-5a34-bafb-59cc85a47aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1bab68d-da36-43b9-9778-d385d81a0bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1bab68d-da36-43b9-9778-d385d81a0bc5.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -17871,7 +17871,7 @@
         },
         {
             "id": "ae89b641-ed0e-5cd5-ac12-ae28fc1e6d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a9e47-57a1-45f8-978c-48ef90703832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a9e47-57a1-45f8-978c-48ef90703832.jpg?1",
             "name": "Might of Oaks",
             "text": "",
             "colours": [
@@ -17904,7 +17904,7 @@
         },
         {
             "id": "ffe64fe7-f30e-5550-9ae0-40b271c3dfcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb56633e-692c-41bc-9253-ebd1528f4e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb56633e-692c-41bc-9253-ebd1528f4e99.jpg?1",
             "name": "Monstrous Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -17937,7 +17937,7 @@
         },
         {
             "id": "006a829f-5051-5a88-b2dd-3f809626a107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d911589-f2e8-4d9a-b339-5a5597a783fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d911589-f2e8-4d9a-b339-5a5597a783fd.jpg?1",
             "name": "Monstrous Growth",
             "text": "",
             "colours": [
@@ -17970,7 +17970,7 @@
         },
         {
             "id": "70656221-c651-557b-b87b-c3120e5b32bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287f9f55-829d-4b29-b1d2-34d20d23b3d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287f9f55-829d-4b29-b1d2-34d20d23b3d5.jpg?1",
             "name": "Nature's Resurgence",
             "text": "Each player draws a card for each creature card in his or her graveyard.",
             "colours": [
@@ -18003,7 +18003,7 @@
         },
         {
             "id": "35386ec3-4c45-5a1d-b607-a3aea70f491d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf5760-5da1-4c17-859e-baddd0ec62ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf5760-5da1-4c17-859e-baddd0ec62ae.jpg?1",
             "name": "Nature's Resurgence",
             "text": "",
             "colours": [
@@ -18036,7 +18036,7 @@
         },
         {
             "id": "07cc301f-1ecc-51d7-a8ad-77c52af9e19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c9b948-63f9-458d-82ae-69ebe2ac9fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c9b948-63f9-458d-82ae-69ebe2ac9fe0.jpg?1",
             "name": "Nature's Revolt",
             "text": "All lands are 2/2 creatures that are still lands.",
             "colours": [
@@ -18069,7 +18069,7 @@
         },
         {
             "id": "185a3c56-6fc7-5bf4-a2fe-ced9f5dde041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3f2a56-ec54-4983-9f09-aea67becec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3f2a56-ec54-4983-9f09-aea67becec68.jpg?1",
             "name": "Nature's Revolt",
             "text": "",
             "colours": [
@@ -18102,7 +18102,7 @@
         },
         {
             "id": "211384a5-77ef-547b-8cf3-f719ca8f3439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c3274b-3eb0-450a-88bf-fb378e6cf94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c3274b-3eb0-450a-88bf-fb378e6cf94a.jpg?1",
             "name": "Pride of Lions",
             "text": "You may have Pride of Lions deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -18137,7 +18137,7 @@
         },
         {
             "id": "a29ac9e6-8290-5e1d-a54c-d64d8aeddc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1673b038-97b6-4139-8468-9cbbd01dd239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1673b038-97b6-4139-8468-9cbbd01dd239.jpg?1",
             "name": "Pride of Lions",
             "text": "",
             "colours": [
@@ -18172,7 +18172,7 @@
         },
         {
             "id": "b528646f-aa04-5f1e-9936-91012976bf69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305376d-fcfb-48a1-947f-a9eec0dbc610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305376d-fcfb-48a1-947f-a9eec0dbc610.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -18205,7 +18205,7 @@
         },
         {
             "id": "9093e6ac-e1c4-5781-a3b7-9c7285b18951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb685db-bb38-4b78-ae1e-80817c852096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb685db-bb38-4b78-ae1e-80817c852096.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -18238,7 +18238,7 @@
         },
         {
             "id": "6b636201-56ab-5832-b073-e44b32150af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045e9ca4-ece8-49c2-b022-fb61f4b8b635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045e9ca4-ece8-49c2-b022-fb61f4b8b635.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -18271,7 +18271,7 @@
         },
         {
             "id": "cff32468-3aea-5788-abb3-948731c2250b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160e5d9e-b390-4a77-9435-f6cdc95ca728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160e5d9e-b390-4a77-9435-f6cdc95ca728.jpg?1",
             "name": "Reclaim",
             "text": "",
             "colours": [
@@ -18304,7 +18304,7 @@
         },
         {
             "id": "8d390207-46f9-5e85-bdc7-a47672bde77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc6d29d-2915-418d-856f-13b05430dfda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc6d29d-2915-418d-856f-13b05430dfda.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -18339,7 +18339,7 @@
         },
         {
             "id": "9301f4f6-7188-540b-9421-69327931ed97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb172a6d-0f4f-42bf-8add-bec0e00e8a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb172a6d-0f4f-42bf-8add-bec0e00e8a66.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -18374,7 +18374,7 @@
         },
         {
             "id": "ba1ab738-2284-59a8-9274-77f239ad415d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9ea671-f3e9-4e17-b98a-51fac48f875e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9ea671-f3e9-4e17-b98a-51fac48f875e.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -18409,7 +18409,7 @@
         },
         {
             "id": "f6ac5887-01ad-5f7d-8fcf-85d062baea34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fe41ad-722f-4330-b1ee-c6ca3f81ce86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fe41ad-722f-4330-b1ee-c6ca3f81ce86.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -18444,7 +18444,7 @@
         },
         {
             "id": "62e51ffb-4258-581c-aa3a-26b3ca40a8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc536ff-3e12-4e1b-b96f-b0c32dcb6734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc536ff-3e12-4e1b-b96f-b0c32dcb6734.jpg?1",
             "name": "Rowen",
             "text": "Reveal the first card you draw each turn. Whenever you reveal a basic land card this way, draw a card.",
             "colours": [
@@ -18477,7 +18477,7 @@
         },
         {
             "id": "8e83d7b3-81f6-5e39-943d-4fc8687b17f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7e6a58-eda0-4224-b517-ad6dfb721c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7e6a58-eda0-4224-b517-ad6dfb721c88.jpg?1",
             "name": "Rowen",
             "text": "",
             "colours": [
@@ -18510,7 +18510,7 @@
         },
         {
             "id": "c0eae17b-8048-5f55-a167-27c51538d683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff2dd57-9d8c-44ec-9705-70ed02bf0799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff2dd57-9d8c-44ec-9705-70ed02bf0799.jpg?1",
             "name": "Scavenger Folk",
             "text": "o\nG, oc\nT, Sacrifice Scavenger Folk: Destroy target artifact.",
             "colours": [
@@ -18545,7 +18545,7 @@
         },
         {
             "id": "611c1d3b-f140-58f4-a4b9-2f8a307e2d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9637b1e-3a78-4946-afd9-29d0d90df282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9637b1e-3a78-4946-afd9-29d0d90df282.jpg?1",
             "name": "Scavenger Folk",
             "text": "",
             "colours": [
@@ -18580,7 +18580,7 @@
         },
         {
             "id": "dbdaa6ae-71cc-5ea7-b8ed-e879074c38d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20175-8bfa-417a-912b-d6d472f091ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20175-8bfa-417a-912b-d6d472f091ab.jpg?1",
             "name": "Seeker of Skybreak",
             "text": "oc\nT: Untap target creature.",
             "colours": [
@@ -18615,7 +18615,7 @@
         },
         {
             "id": "62b88556-dd2b-5010-b585-ff6f0b687d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2c491a-1f86-4e44-8dc3-b8ba65f4017c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2c491a-1f86-4e44-8dc3-b8ba65f4017c.jpg?1",
             "name": "Seeker of Skybreak",
             "text": "",
             "colours": [
@@ -18650,7 +18650,7 @@
         },
         {
             "id": "83171929-75d0-57b7-9228-e5290bbd8b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90e8ff87-22e8-4c04-84bc-f0ea2c12a86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90e8ff87-22e8-4c04-84bc-f0ea2c12a86c.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -18686,7 +18686,7 @@
         },
         {
             "id": "bca7ca06-c224-5cd1-a209-f2571db6ecd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19f7690-87bf-4259-adc1-7e69cc3081a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19f7690-87bf-4259-adc1-7e69cc3081a9.jpg?1",
             "name": "Shanodin Dryads",
             "text": "",
             "colours": [
@@ -18722,7 +18722,7 @@
         },
         {
             "id": "66d67d15-756e-531c-a89c-5e48dc2a98bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6cb158-f66f-429b-ac73-bfea87f51def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6cb158-f66f-429b-ac73-bfea87f51def.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -18757,7 +18757,7 @@
         },
         {
             "id": "d83f5bbc-2121-5c5b-bc95-0b64505f0fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54a9970-cffa-43a4-8eeb-4330a3ea2e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54a9970-cffa-43a4-8eeb-4330a3ea2e82.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -18792,7 +18792,7 @@
         },
         {
             "id": "d8120d91-96cb-5dd3-b5bc-5f7f1217e69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46460e5f-2756-486b-99a6-c3a9a209bfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46460e5f-2756-486b-99a6-c3a9a209bfaa.jpg?1",
             "name": "Squall",
             "text": "Squall deals 2 damage to each creature with flying.",
             "colours": [
@@ -18825,7 +18825,7 @@
         },
         {
             "id": "ea03d98b-8ded-52b2-aced-9f68c4d1617b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e4e64-adf5-480c-b47b-c8eb03cb74c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e4e64-adf5-480c-b47b-c8eb03cb74c4.jpg?1",
             "name": "Squall",
             "text": "",
             "colours": [
@@ -18858,7 +18858,7 @@
         },
         {
             "id": "4aaa5731-0240-54d5-887e-4ed1d47647b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4405ab25-c001-4da8-ac72-2afcb01db200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4405ab25-c001-4da8-ac72-2afcb01db200.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -18891,7 +18891,7 @@
         },
         {
             "id": "8ce4b1e9-2f84-52aa-8ab8-78d0e938f3eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce87747f-4565-43f2-b966-8bef41ebbe03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce87747f-4565-43f2-b966-8bef41ebbe03.jpg?1",
             "name": "Stream of Life",
             "text": "",
             "colours": [
@@ -18924,7 +18924,7 @@
         },
         {
             "id": "a33ecd1c-8948-58c0-bb58-420509813a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bea52-3db1-4b61-8418-77ace9cd70b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bea52-3db1-4b61-8418-77ace9cd70b5.jpg?1",
             "name": "Thorn Elemental",
             "text": "You may have Thorn Elemental deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -18959,7 +18959,7 @@
         },
         {
             "id": "bf0c2b85-2e3d-5e12-80bb-c10a552feb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd239e3-dbe5-4a30-973d-9707de425a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd239e3-dbe5-4a30-973d-9707de425a33.jpg?1",
             "name": "Thorn Elemental",
             "text": "",
             "colours": [
@@ -18994,7 +18994,7 @@
         },
         {
             "id": "2feb18e3-3b85-55aa-b728-fff75a3a89bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e214df-93a2-4d21-8818-cc00bff1b318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e214df-93a2-4d21-8818-cc00bff1b318.jpg?1",
             "name": "Thoughtleech",
             "text": "Whenever an island an opponent controls becomes tapped, you may gain 1 life.",
             "colours": [
@@ -19027,7 +19027,7 @@
         },
         {
             "id": "4b3d9c80-3b6f-5b21-ac3e-45ca714f2c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f617305-8043-4576-bc79-67303b91bb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f617305-8043-4576-bc79-67303b91bb69.jpg?1",
             "name": "Thoughtleech",
             "text": "",
             "colours": [
@@ -19060,7 +19060,7 @@
         },
         {
             "id": "12ef7168-4a20-51be-bcba-a7953b26ad38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7c1774-908f-43ab-b589-e46606267381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7c1774-908f-43ab-b589-e46606267381.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19095,7 +19095,7 @@
         },
         {
             "id": "61161199-7a53-5449-837e-95d9f232a8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05381dc1-50e1-4ac4-8f35-46d0b2d0b42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05381dc1-50e1-4ac4-8f35-46d0b2d0b42d.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19130,7 +19130,7 @@
         },
         {
             "id": "a74377fc-f4b6-5a5b-b69f-188371848125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b3f289-7999-4e47-82c6-a7c96293d4f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b3f289-7999-4e47-82c6-a7c96293d4f8.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -19163,7 +19163,7 @@
         },
         {
             "id": "28816986-95d9-584c-b7c4-9a808c8ea037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf477ae-fc28-4c50-a41c-be6bfab489e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf477ae-fc28-4c50-a41c-be6bfab489e4.jpg?1",
             "name": "Tranquility",
             "text": "",
             "colours": [
@@ -19196,7 +19196,7 @@
         },
         {
             "id": "00f2d0d5-3571-5fd9-977d-c7d9f9d5f531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c275bdc-e960-4b6f-a8d3-b662739113c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c275bdc-e960-4b6f-a8d3-b662739113c1.jpg?1",
             "name": "Treefolk Seedlings",
             "text": "Treefolk Seedlings's toughness is equal to the number of forests you control.",
             "colours": [
@@ -19231,7 +19231,7 @@
         },
         {
             "id": "481b53b4-37ef-5cfe-b23e-6670c849ce18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf9a759-13aa-4a8e-bb53-3706c8c69bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf9a759-13aa-4a8e-bb53-3706c8c69bd0.jpg?1",
             "name": "Treefolk Seedlings",
             "text": "",
             "colours": [
@@ -19266,7 +19266,7 @@
         },
         {
             "id": "a9cd9d53-c299-5078-9c92-ff6407f1322c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700bb560-5a4a-4422-9158-1c2edad1913f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700bb560-5a4a-4422-9158-1c2edad1913f.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "Uktabi Wildcats's power and toughness are each equal to the number of forests you control.\no\nG, Sacrifice a forest: Regenerate Uktabi Wildcats.",
             "colours": [
@@ -19301,7 +19301,7 @@
         },
         {
             "id": "2df7635b-5a8f-5905-b117-eead5aa232bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23d1a8c-01cb-4dd3-8562-c3ce7bc88d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23d1a8c-01cb-4dd3-8562-c3ce7bc88d77.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "",
             "colours": [
@@ -19336,7 +19336,7 @@
         },
         {
             "id": "e844dcf5-a079-53ec-b776-c31bfab85cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba496182-b249-40fa-8fdf-9823d521fcd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba496182-b249-40fa-8fdf-9823d521fcd9.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a basic land card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -19369,7 +19369,7 @@
         },
         {
             "id": "a8f505c7-fc89-5302-8911-0e2c84d5a089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc908d9-2a08-4465-81cd-11199685c660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc908d9-2a08-4465-81cd-11199685c660.jpg?1",
             "name": "Untamed Wilds",
             "text": "",
             "colours": [
@@ -19402,7 +19402,7 @@
         },
         {
             "id": "aa3d11f3-ca06-5320-aaa5-b0778cbed821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f99fe-8d5f-4efe-af86-72031dfe562a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f99fe-8d5f-4efe-af86-72031dfe562a.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -19438,7 +19438,7 @@
         },
         {
             "id": "8deba6d1-08b6-56d6-879c-f613b7888daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b87a7f-41d0-4dd7-b479-f6bcccda54be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b87a7f-41d0-4dd7-b479-f6bcccda54be.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -19474,7 +19474,7 @@
         },
         {
             "id": "cbc551f5-8e1c-556a-ba13-0e9acb01c584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0368c8-8021-40c3-b42d-7320d956a84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0368c8-8021-40c3-b42d-7320d956a84f.jpg?1",
             "name": "Vernal Bloom",
             "text": "Whenever a forest is tapped for mana, its controller adds o\nG to his or her mana pool.",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "a6fbb0fc-fa13-5584-96a1-c71e4a4f0596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79ed17b-2a71-4146-8dd7-75faefdfa4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79ed17b-2a71-4146-8dd7-75faefdfa4fa.jpg?1",
             "name": "Vernal Bloom",
             "text": "",
             "colours": [
@@ -19540,7 +19540,7 @@
         },
         {
             "id": "fd54ad77-dcc9-5eb3-aa8d-51d5b0e63389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515daaba-c063-41d5-9539-25b8c8cb639c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515daaba-c063-41d5-9539-25b8c8cb639c.jpg?1",
             "name": "Wild Growth",
             "text": "Whenever enchanted land is tapped for mana, its controller adds o\nG to his or her mana pool.",
             "colours": [
@@ -19575,7 +19575,7 @@
         },
         {
             "id": "5800b2e8-35da-52f7-b11c-2b6db7500cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a02887-beb9-454b-8592-f551f48cd93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a02887-beb9-454b-8592-f551f48cd93c.jpg?1",
             "name": "Wild Growth",
             "text": "",
             "colours": [
@@ -19610,7 +19610,7 @@
         },
         {
             "id": "ef5aa013-a448-5cd8-bbed-c0f431a48e2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37ba325-5a14-473b-9def-6a4660a50d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37ba325-5a14-473b-9def-6a4660a50d7a.jpg?1",
             "name": "Wing Snare",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -19643,7 +19643,7 @@
         },
         {
             "id": "bf047b14-7990-5798-aaf3-522b826c27b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6a0916-c077-427f-983d-c595e8256507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6a0916-c077-427f-983d-c595e8256507.jpg?1",
             "name": "Wing Snare",
             "text": "",
             "colours": [
@@ -19676,7 +19676,7 @@
         },
         {
             "id": "3c90bd84-3653-5fad-b27a-1a505b93a8d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263feecf-a657-4892-a2bb-cd7080d283c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263feecf-a657-4892-a2bb-cd7080d283c2.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a forest card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -19712,7 +19712,7 @@
         },
         {
             "id": "f7906562-a439-5f6d-a2b3-a518781e7e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38082344-f739-495d-947a-74e247b17433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38082344-f739-495d-947a-74e247b17433.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -19748,7 +19748,7 @@
         },
         {
             "id": "aa6624a3-5c03-59e9-bb2a-1243f0cdd8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f45f1-9ed1-4ef2-8c2b-bab513d6a721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f45f1-9ed1-4ef2-8c2b-bab513d6a721.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -19784,7 +19784,7 @@
         },
         {
             "id": "201b7a07-31dc-5929-a8c6-922bcd099fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ec6cdd-11ba-4acd-9bbc-87f01f703642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ec6cdd-11ba-4acd-9bbc-87f01f703642.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "",
             "colours": [
@@ -19820,7 +19820,7 @@
         },
         {
             "id": "b7d61955-ec10-57d7-a5db-3d8df8229d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed511375-e445-4d81-818d-92a793d7deee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed511375-e445-4d81-818d-92a793d7deee.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8, oc\nT: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -19849,7 +19849,7 @@
         },
         {
             "id": "02f98c6a-227a-5e52-bf8e-a6a8ce408e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75da20cc-2737-4a03-a75c-ed4f7b63cf95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75da20cc-2737-4a03-a75c-ed4f7b63cf95.jpg?1",
             "name": "Aladdin's Ring",
             "text": "",
             "colours": [],
@@ -19878,7 +19878,7 @@
         },
         {
             "id": "3082bf43-6ab0-5a90-ab4f-cd7168e33705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c3b59-bd04-4376-aec1-a77404c6072d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c3b59-bd04-4376-aec1-a77404c6072d.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden's power and toughness are each equal to the number of creatures in play.",
             "colours": [],
@@ -19910,7 +19910,7 @@
         },
         {
             "id": "f5fdc667-1877-5fde-ad47-61b59543623d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f92d6f-1d3a-495f-841d-75c6a046e27c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f92d6f-1d3a-495f-841d-75c6a046e27c.jpg?1",
             "name": "Beast of Burden",
             "text": "",
             "colours": [],
@@ -19942,7 +19942,7 @@
         },
         {
             "id": "009ef7b7-642c-55d1-a7ac-d632228708db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769b55a-a0a1-4b6f-8c80-669385a34425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769b55a-a0a1-4b6f-8c80-669385a34425.jpg?1",
             "name": "Caltrops",
             "text": "Whenever a creature attacks, Caltrops deals 1 damage to it.",
             "colours": [],
@@ -19971,7 +19971,7 @@
         },
         {
             "id": "e4e78644-42fe-5b64-b3a0-18072ed0eb51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf0d1da-7c16-4a9a-a71e-4805bd0c0995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf0d1da-7c16-4a9a-a71e-4805bd0c0995.jpg?1",
             "name": "Caltrops",
             "text": "",
             "colours": [],
@@ -20000,7 +20000,7 @@
         },
         {
             "id": "0f73a0c5-b79d-592f-9c52-7d984e70ae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c1d1d-e6e0-47fe-b642-b1ff0201bbf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705c1d1d-e6e0-47fe-b642-b1ff0201bbf9.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond comes into play tapped.\noc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -20033,7 +20033,7 @@
         },
         {
             "id": "7e423224-c4cc-584b-a870-220de5e33bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaab01ef-f14b-4f42-ab51-b1537fa642d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaab01ef-f14b-4f42-ab51-b1537fa642d1.jpg?1",
             "name": "Charcoal Diamond",
             "text": "",
             "colours": [],
@@ -20066,7 +20066,7 @@
         },
         {
             "id": "cf36c43e-97b5-575a-8ec2-a1d4f913671d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52ecee5-ad2d-4f52-9845-f682119ee120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52ecee5-ad2d-4f52-9845-f682119ee120.jpg?1",
             "name": "Charcoal Diamond",
             "text": "",
             "colours": [],
@@ -20099,7 +20099,7 @@
         },
         {
             "id": "8fbdf541-e8b8-5a1b-9778-24135772790d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0ed0c-7092-4c5e-9b06-66ab4de157c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0ed0c-7092-4c5e-9b06-66ab4de157c6.jpg?1",
             "name": "Charcoal Diamond",
             "text": "",
             "colours": [],
@@ -20132,7 +20132,7 @@
         },
         {
             "id": "22aa5ec4-0cde-5f2b-b6ca-beb8b983c4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642852b-8736-4fce-9f91-37594cbc3f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642852b-8736-4fce-9f91-37594cbc3f71.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if there are three Goblins in play, each gets +2/+2.)",
             "colours": [],
@@ -20161,7 +20161,7 @@
         },
         {
             "id": "03e0ca2f-ee2c-54f8-b951-c9d2d47e68ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38ecdea-c269-4f0a-b297-e16a22410802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38ecdea-c269-4f0a-b297-e16a22410802.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -20190,7 +20190,7 @@
         },
         {
             "id": "891f9bdd-9edf-50ad-98af-a8647a8b4402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2017cded-4157-4ccb-80f0-e298aa89d17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2017cded-4157-4ccb-80f0-e298aa89d17d.jpg?1",
             "name": "Crystal Rod",
             "text": "Whenever a player plays a blue spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -20219,7 +20219,7 @@
         },
         {
             "id": "bb7b0cc9-b6b7-5c04-a738-784efb3cbdb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fab1f2d-445e-4feb-93de-c59e2655fa1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fab1f2d-445e-4feb-93de-c59e2655fa1d.jpg?1",
             "name": "Crystal Rod",
             "text": "",
             "colours": [],
@@ -20248,7 +20248,7 @@
         },
         {
             "id": "dd8e0b33-7629-5a17-a256-115c8b5caaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8534792b-96a7-45a6-b854-81066a2e5d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8534792b-96a7-45a6-b854-81066a2e5d90.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into a graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -20277,7 +20277,7 @@
         },
         {
             "id": "372c99bb-a258-5668-9ff2-164dfc0749ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812171e0-bc15-4eb3-924a-1c779414469b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812171e0-bc15-4eb3-924a-1c779414469b.jpg?1",
             "name": "Dingus Egg",
             "text": "",
             "colours": [],
@@ -20306,7 +20306,7 @@
         },
         {
             "id": "87ff3c6b-86ec-518e-8506-95b6de5f4344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94d6842-0b35-4493-8800-cf2b2138d656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94d6842-0b35-4493-8800-cf2b2138d656.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3, oc\nT: Target player discards a card from his or her hand. Play this ability only during your turn.",
             "colours": [],
@@ -20335,7 +20335,7 @@
         },
         {
             "id": "3b1163cf-cfe1-515a-bc6d-f558a82a7daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d47309-9595-4b19-bd9c-4973b87651eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d47309-9595-4b19-bd9c-4973b87651eb.jpg?1",
             "name": "Disrupting Scepter",
             "text": "",
             "colours": [],
@@ -20364,7 +20364,7 @@
         },
         {
             "id": "8cb61508-d315-5f8c-b862-ca2ffec20dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d4fb56-7f63-4087-9ab3-a0df66655886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d4fb56-7f63-4087-9ab3-a0df66655886.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -20393,7 +20393,7 @@
         },
         {
             "id": "bb57bd6c-cdb5-5e07-a5af-1653c8bfda31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0752f333-002c-4c77-bb96-a7bd2dd4ff5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0752f333-002c-4c77-bb96-a7bd2dd4ff5e.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "",
             "colours": [],
@@ -20422,7 +20422,7 @@
         },
         {
             "id": "c8dd2525-a5ca-5d8c-aa7f-4ae89783ab9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188b3863-fa7d-4fbb-b061-97580d394017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188b3863-fa7d-4fbb-b061-97580d394017.jpg?1",
             "name": "Feroz's Ban",
             "text": "Creature spells cost o2 more to play.",
             "colours": [],
@@ -20451,7 +20451,7 @@
         },
         {
             "id": "85fd7181-759c-55a4-8f34-a6c189828200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f6dea-3554-4649-966c-5f33229132d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1f6dea-3554-4649-966c-5f33229132d4.jpg?1",
             "name": "Feroz's Ban",
             "text": "",
             "colours": [],
@@ -20480,7 +20480,7 @@
         },
         {
             "id": "ff71eca6-2114-5389-beeb-76a9fcee28f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a89ca2b-0cc9-421e-8dc0-1105879380a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a89ca2b-0cc9-421e-8dc0-1105879380a0.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond comes into play tapped.\noc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -20511,7 +20511,7 @@
         },
         {
             "id": "9e725ed7-72c1-535f-823c-867bbf2d3da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054ae635-1cc5-4367-9dd9-95acf8bfd937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054ae635-1cc5-4367-9dd9-95acf8bfd937.jpg?1",
             "name": "Fire Diamond",
             "text": "",
             "colours": [],
@@ -20542,7 +20542,7 @@
         },
         {
             "id": "0565de1f-31b9-58ee-b5df-abf1efcdff5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edcc350-ab84-4aff-a9f0-2cc05c7c43bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edcc350-ab84-4aff-a9f0-2cc05c7c43bb.jpg?1",
             "name": "Flying Carpet",
             "text": "o2, oc\nT: Target creature gains flying until end of turn.",
             "colours": [],
@@ -20571,7 +20571,7 @@
         },
         {
             "id": "dbead868-1819-5945-b008-4dc693992ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014b7a72-135e-4ed0-9b1c-0b836aaa260f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014b7a72-135e-4ed0-9b1c-0b836aaa260f.jpg?1",
             "name": "Flying Carpet",
             "text": "",
             "colours": [],
@@ -20600,7 +20600,7 @@
         },
         {
             "id": "174171b2-1833-536d-ac8f-27cce1edc17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff78a37-c321-4f02-bd10-e73823b954cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff78a37-c321-4f02-bd10-e73823b954cf.jpg?1",
             "name": "Grafted Skullcap",
             "text": "At the beginning of your draw step, draw a card.\nAt the end of your turn, discard your hand.",
             "colours": [],
@@ -20629,7 +20629,7 @@
         },
         {
             "id": "ed41cbf7-0aa6-525f-95b3-7ae91faa0b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac035e-06dc-4b37-9b84-26ff0d671564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac035e-06dc-4b37-9b84-26ff0d671564.jpg?1",
             "name": "Grafted Skullcap",
             "text": "",
             "colours": [],
@@ -20658,7 +20658,7 @@
         },
         {
             "id": "e589d63c-8cdf-5946-a9e5-806c6573a591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d63d66-5e59-4302-8b74-db1aa67f50c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d63d66-5e59-4302-8b74-db1aa67f50c5.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "oc\nT: Grapeshot Catapult deals 1 damage to target creature with flying.",
             "colours": [],
@@ -20690,7 +20690,7 @@
         },
         {
             "id": "967a5535-cbf8-5ee6-9c4f-fe431b5cdc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0067413-338a-4a24-afe2-010a9915e73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0067413-338a-4a24-afe2-010a9915e73e.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "",
             "colours": [],
@@ -20722,7 +20722,7 @@
         },
         {
             "id": "e5c90bd6-5681-55c2-9064-92c014d47b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd270d3-da58-4195-80f4-ade6ae32d092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd270d3-da58-4195-80f4-ade6ae32d092.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -20751,7 +20751,7 @@
         },
         {
             "id": "aec010c6-09b5-54ea-af53-46490864c7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d720e-68f9-464a-8b11-0f243f184ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d720e-68f9-464a-8b11-0f243f184ccf.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -20780,7 +20780,7 @@
         },
         {
             "id": "f1a80364-87b2-590e-8406-f1b215974129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da72ad2-1cdd-4505-b0f8-f036ac684776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da72ad2-1cdd-4505-b0f8-f036ac684776.jpg?1",
             "name": "Iron Star",
             "text": "Whenever a player plays a red spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -20809,7 +20809,7 @@
         },
         {
             "id": "a441454e-d26d-5376-a4d1-2e4239eaa254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c1995f-a22e-4b3d-9d3e-f6ed6e75a3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c1995f-a22e-4b3d-9d3e-f6ed6e75a3ea.jpg?1",
             "name": "Iron Star",
             "text": "",
             "colours": [],
@@ -20838,7 +20838,7 @@
         },
         {
             "id": "23cf1248-fe28-5dbd-acf1-2517c073c051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27a54e2-ac65-479a-adfc-8a2edad61e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27a54e2-ac65-479a-adfc-8a2edad61e81.jpg?1",
             "name": "Ivory Cup",
             "text": "Whenever a player plays a white spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -20867,7 +20867,7 @@
         },
         {
             "id": "83ad546a-f1ef-5a78-8eef-01c7d1b8a4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b89b134-f3b7-490a-ba79-d4cd5d82aadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b89b134-f3b7-490a-ba79-d4cd5d82aadc.jpg?1",
             "name": "Ivory Cup",
             "text": "",
             "colours": [],
@@ -20896,7 +20896,7 @@
         },
         {
             "id": "582f75a3-509d-523b-8f2c-282170eaea43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c76784-c4b2-48c8-9513-dd7196d27360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c76784-c4b2-48c8-9513-dd7196d27360.jpg?1",
             "name": "Jalum Tome",
             "text": "o2, oc\nT: Draw a card, then discard a card from your hand.",
             "colours": [],
@@ -20925,7 +20925,7 @@
         },
         {
             "id": "2bebc08b-4c8d-5209-9bbb-c4e9337f1436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38c5b83-449e-4503-a34e-94a302370606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38c5b83-449e-4503-a34e-94a302370606.jpg?1",
             "name": "Jalum Tome",
             "text": "",
             "colours": [],
@@ -20954,7 +20954,7 @@
         },
         {
             "id": "770d40a2-357c-5a70-b9e3-af3829f14f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f8d1ec-a55c-409f-be42-ae1c0f8c66e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f8d1ec-a55c-409f-be42-ae1c0f8c66e1.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3, oc\nT: Untap target creature.",
             "colours": [],
@@ -20983,7 +20983,7 @@
         },
         {
             "id": "5ccfd0ad-9d4d-54ab-9e47-8ceef229094a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb83a18-4efd-4e4e-99ad-bc6f09ddce6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb83a18-4efd-4e4e-99ad-bc6f09ddce6e.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "",
             "colours": [],
@@ -21012,7 +21012,7 @@
         },
         {
             "id": "c65c2d54-f4bd-510a-bc5c-83f16258b691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed9644-5dc1-4d1c-b60d-4bcf305f2d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed9644-5dc1-4d1c-b60d-4bcf305f2d0b.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4, oc\nT: Draw a card.",
             "colours": [],
@@ -21041,7 +21041,7 @@
         },
         {
             "id": "8d778f41-0f92-5538-b8cd-3af80450d4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d7ca08-92c3-42bb-98e3-d6d959d865d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d7ca08-92c3-42bb-98e3-d6d959d865d0.jpg?1",
             "name": "Jayemdae Tome",
             "text": "",
             "colours": [],
@@ -21070,7 +21070,7 @@
         },
         {
             "id": "2c188508-7f51-5fcd-90a8-d53ab9449e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90b2450-c814-47ee-8e85-d16e64d08af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90b2450-c814-47ee-8e85-d16e64d08af8.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond comes into play tapped.\noc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -21101,7 +21101,7 @@
         },
         {
             "id": "44f87dfc-77cb-5112-9c4a-c4f0218556cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8dbea9-25ef-4048-999f-d62ec7e1a13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8dbea9-25ef-4048-999f-d62ec7e1a13f.jpg?1",
             "name": "Marble Diamond",
             "text": "",
             "colours": [],
@@ -21132,7 +21132,7 @@
         },
         {
             "id": "826ac89e-5555-58d3-895a-7a795ddc9ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a691664-9275-4b89-a8e3-b99c88717ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a691664-9275-4b89-a8e3-b99c88717ffb.jpg?1",
             "name": "Meekstone",
             "text": "Creatures with power 3 or greater don't untap during their controllers' untap steps.",
             "colours": [],
@@ -21161,7 +21161,7 @@
         },
         {
             "id": "3c02eb3f-f45c-556e-9828-1a11c5dfac0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35fd53a-08ed-4f7c-937d-3dc6e834a481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35fd53a-08ed-4f7c-937d-3dc6e834a481.jpg?1",
             "name": "Meekstone",
             "text": "",
             "colours": [],
@@ -21190,7 +21190,7 @@
         },
         {
             "id": "310d2cb6-a7bf-5416-8482-0faa80f934c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da21381-38bf-49d0-98d3-81eb9c99ce82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da21381-38bf-49d0-98d3-81eb9c99ce82.jpg?1",
             "name": "Millstone",
             "text": "o2, oc\nT: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -21219,7 +21219,7 @@
         },
         {
             "id": "dcaa711f-5053-5112-b1c0-309e58e813b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d361c3-8aa7-4b3c-ae68-15910cc341ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d361c3-8aa7-4b3c-ae68-15910cc341ca.jpg?1",
             "name": "Millstone",
             "text": "",
             "colours": [],
@@ -21248,7 +21248,7 @@
         },
         {
             "id": "6c945aa0-3ada-51bf-b51a-ad3f99ebdcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4de9d3-56b2-40d9-adca-4fd2dadaaad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4de9d3-56b2-40d9-adca-4fd2dadaaad9.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond comes into play tapped.\noc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -21279,7 +21279,7 @@
         },
         {
             "id": "a1555632-8c66-5a51-81bf-ca8d02b7a2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76fd66-e91d-4f31-b393-465e9a7b795b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76fd66-e91d-4f31-b393-465e9a7b795b.jpg?1",
             "name": "Moss Diamond",
             "text": "",
             "colours": [],
@@ -21310,7 +21310,7 @@
         },
         {
             "id": "30bdd9bd-c75b-5839-a836-84c60c732086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90583dcc-6e0e-45e6-9209-8ad3a6c94555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90583dcc-6e0e-45e6-9209-8ad3a6c94555.jpg?1",
             "name": "Patagia Golem",
             "text": "o3: Patagia Golem gains flying until end of turn.",
             "colours": [],
@@ -21342,7 +21342,7 @@
         },
         {
             "id": "05f7775c-b51d-5500-9712-80dcd089690d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb501ad8-d2b2-454b-bda3-c28c618f2d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb501ad8-d2b2-454b-bda3-c28c618f2d4f.jpg?1",
             "name": "Patagia Golem",
             "text": "",
             "colours": [],
@@ -21374,7 +21374,7 @@
         },
         {
             "id": "108e7d76-cf44-58ec-83c2-db06c8e1d82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887b377f-4080-4cfa-a5a7-bab32b6891f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887b377f-4080-4cfa-a5a7-bab32b6891f9.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "Phyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
             "colours": [],
@@ -21407,7 +21407,7 @@
         },
         {
             "id": "6389c57a-8a66-539e-98cf-85dd9615fdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c279c5b-70c3-426a-86ad-2de1a8771ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c279c5b-70c3-426a-86ad-2de1a8771ae4.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "",
             "colours": [],
@@ -21440,7 +21440,7 @@
         },
         {
             "id": "eea7d506-8008-5fa0-8740-b4c583d4b7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e59c8b-735d-4796-b37c-619ee1782f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e59c8b-735d-4796-b37c-619ee1782f65.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21473,7 +21473,7 @@
         },
         {
             "id": "ef9f7258-d678-52d4-ba95-7d7656c27c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b3869-7305-49f9-9d21-795c94cc83f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b3869-7305-49f9-9d21-795c94cc83f5.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21506,7 +21506,7 @@
         },
         {
             "id": "ca846e2f-62a1-5d49-89d7-ff3387a3947b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc051a-df87-46d9-bc45-8b7b2721b374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc051a-df87-46d9-bc45-8b7b2721b374.jpg?1",
             "name": "Pit Trap",
             "text": "o2, oc\nT, Sacrifice Pit Trap: Destroy target attacking creature without flying. It can't be regenerated.",
             "colours": [],
@@ -21535,7 +21535,7 @@
         },
         {
             "id": "e2d4af39-bcc6-58fe-a3a2-bf09419dc9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e1d888-43e5-4476-98be-e251090cf662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e1d888-43e5-4476-98be-e251090cf662.jpg?1",
             "name": "Pit Trap",
             "text": "",
             "colours": [],
@@ -21564,7 +21564,7 @@
         },
         {
             "id": "de6ea6b2-9e1d-5610-ba8f-4402b29bcd86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68498f5c-4924-4a56-b6a7-40c5fb2d31c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68498f5c-4924-4a56-b6a7-40c5fb2d31c1.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3, oc\nT: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -21593,7 +21593,7 @@
         },
         {
             "id": "03d160d4-29a0-5afd-b471-1be5a735e399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754d90bd-d08d-4510-ad3c-f6ed52a92d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754d90bd-d08d-4510-ad3c-f6ed52a92d6c.jpg?1",
             "name": "Rod of Ruin",
             "text": "",
             "colours": [],
@@ -21622,7 +21622,7 @@
         },
         {
             "id": "6380e2c6-e4dc-5186-a600-db45d9cb112d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae27220-2b62-4214-81b5-612dd770612b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae27220-2b62-4214-81b5-612dd770612b.jpg?1",
             "name": "Sisay's Ring",
             "text": "oc\nT: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -21651,7 +21651,7 @@
         },
         {
             "id": "28635258-6b17-581c-b087-d858b5371bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8383ff-76e5-43b3-99ac-8bdae9830aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8383ff-76e5-43b3-99ac-8bdae9830aca.jpg?1",
             "name": "Sisay's Ring",
             "text": "",
             "colours": [],
@@ -21680,7 +21680,7 @@
         },
         {
             "id": "9490369b-5fa5-5a33-89a0-66817715977a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b426b86d-b1d9-4aee-ac17-4eae7a3b69a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b426b86d-b1d9-4aee-ac17-4eae7a3b69a3.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond comes into play tapped.\noc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -21711,7 +21711,7 @@
         },
         {
             "id": "1beebc1a-b70a-5c23-aa62-1697d5d44e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e50b64-3527-4d28-92a0-a832436b6c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e50b64-3527-4d28-92a0-a832436b6c81.jpg?1",
             "name": "Sky Diamond",
             "text": "",
             "colours": [],
@@ -21742,7 +21742,7 @@
         },
         {
             "id": "90e12943-ea12-501b-9878-4ea20fd3dd16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e267df-22e1-422e-973b-d192b40d5f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e267df-22e1-422e-973b-d192b40d5f19.jpg?1",
             "name": "Soul Net",
             "text": "Whenever a creature is put into a graveyard from play, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -21771,7 +21771,7 @@
         },
         {
             "id": "eb9f9e21-60ba-594b-9a47-a1241dff94c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9454461-c2b4-45e0-8c99-ac8ea506e267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9454461-c2b4-45e0-8c99-ac8ea506e267.jpg?1",
             "name": "Soul Net",
             "text": "",
             "colours": [],
@@ -21800,7 +21800,7 @@
         },
         {
             "id": "8b7ac1f3-f256-5a91-a3a8-4efc1335694b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b6da4-89f8-442e-9c7a-2f60c180ef87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b6da4-89f8-442e-9c7a-2f60c180ef87.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -21829,7 +21829,7 @@
         },
         {
             "id": "e61175cf-c94c-57aa-9c35-16480362adbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55b4d06-43de-438a-8e75-736243b188e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55b4d06-43de-438a-8e75-736243b188e4.jpg?1",
             "name": "Spellbook",
             "text": "",
             "colours": [],
@@ -21858,7 +21858,7 @@
         },
         {
             "id": "11f41a90-38d7-554e-8f0e-c7db7732542d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf43b1-8d4e-4759-bb2d-0b2e03ba7012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf43b1-8d4e-4759-bb2d-0b2e03ba7012.jpg?1",
             "name": "Static Orb",
             "text": "If Static Orb is untapped, players can't untap more than two permanents during their untap steps.",
             "colours": [],
@@ -21887,7 +21887,7 @@
         },
         {
             "id": "fa1a23d6-2d7e-5fcf-b8c8-664bec1ff7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e0877-c792-45f2-9cc3-d86eaa90d85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e0877-c792-45f2-9cc3-d86eaa90d85c.jpg?1",
             "name": "Static Orb",
             "text": "",
             "colours": [],
@@ -21916,7 +21916,7 @@
         },
         {
             "id": "3f321706-0f62-5313-a57f-99f13f737370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb5bdd3-6ecd-49cd-bfa2-e7da1ee85d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb5bdd3-6ecd-49cd-bfa2-e7da1ee85d88.jpg?1",
             "name": "Storm Cauldron",
             "text": "Each player may play an additional land during each of his or her turns.\nWhenever a land is tapped for mana, return it to its owner's hand.",
             "colours": [],
@@ -21945,7 +21945,7 @@
         },
         {
             "id": "b8c6abb9-82fb-51d6-817a-6c29f2b89545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a458f9a-bde3-40ee-847d-aca216d215d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a458f9a-bde3-40ee-847d-aca216d215d4.jpg?1",
             "name": "Storm Cauldron",
             "text": "",
             "colours": [],
@@ -21974,7 +21974,7 @@
         },
         {
             "id": "d1de52d7-73d3-5260-b185-095a7a1235fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5463b9-2088-4ecb-acc3-c00ef54648af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5463b9-2088-4ecb-acc3-c00ef54648af.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in his or her hand on the bottom of his or her library in any order, then draws that many cards.",
             "colours": [],
@@ -22003,7 +22003,7 @@
         },
         {
             "id": "3c400693-5417-5f40-b29d-146724da7578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a784cae-4c1e-4813-8d13-3c435698f446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a784cae-4c1e-4813-8d13-3c435698f446.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -22032,7 +22032,7 @@
         },
         {
             "id": "fc973a5a-3385-52ed-9e7a-47d2a4d9fda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e90f7cf-efcb-48cc-b725-2f5fb6e37da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e90f7cf-efcb-48cc-b725-2f5fb6e37da9.jpg?1",
             "name": "Throne of Bone",
             "text": "Whenever a player plays a black spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -22061,7 +22061,7 @@
         },
         {
             "id": "2ac38dec-2621-5b92-825b-d3065e54b2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4337eed4-c219-4844-9620-980d2430a9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4337eed4-c219-4844-9620-980d2430a9bf.jpg?1",
             "name": "Throne of Bone",
             "text": "",
             "colours": [],
@@ -22090,7 +22090,7 @@
         },
         {
             "id": "9bf14608-569f-5771-8548-00d1d5bd9b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c94f13f-6e7a-4bb1-a9a0-5c885e231d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c94f13f-6e7a-4bb1-a9a0-5c885e231d5c.jpg?1",
             "name": "Wall of Spears",
             "text": "(Walls can't attack.)\nFirst strike",
             "colours": [],
@@ -22122,7 +22122,7 @@
         },
         {
             "id": "611e009c-8400-519b-b46f-718eb712b2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809e9c79-4acc-4933-8da5-993fd71164c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809e9c79-4acc-4933-8da5-993fd71164c4.jpg?1",
             "name": "Wall of Spears",
             "text": "",
             "colours": [],
@@ -22154,7 +22154,7 @@
         },
         {
             "id": "134b36c7-5234-5a5b-adfc-61d76697e7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e04657c-9a09-4e69-a884-39e083ad22b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e04657c-9a09-4e69-a884-39e083ad22b8.jpg?1",
             "name": "Wooden Sphere",
             "text": "Whenever a player plays a green spell, you may pay o1. If you do, you gain 1 life.",
             "colours": [],
@@ -22183,7 +22183,7 @@
         },
         {
             "id": "3c129e3d-4c46-576b-a19b-e3628d40faf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452f2c4-1500-4301-8278-19922026fcaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452f2c4-1500-4301-8278-19922026fcaa.jpg?1",
             "name": "Wooden Sphere",
             "text": "",
             "colours": [],
@@ -22212,7 +22212,7 @@
         },
         {
             "id": "a0efaeb7-189b-5c75-a1e5-f3bf6f496c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd991b2-8c18-4c5f-9b70-461012fee61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd991b2-8c18-4c5f-9b70-461012fee61e.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -22244,7 +22244,7 @@
         },
         {
             "id": "2291e958-e466-5286-8cc5-614dff3c7a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0e5ea0-46f5-4a6c-8fa7-f851c97cb075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0e5ea0-46f5-4a6c-8fa7-f851c97cb075.jpg?1",
             "name": "Adarkar Wastes",
             "text": "",
             "colours": [],
@@ -22276,7 +22276,7 @@
         },
         {
             "id": "a32b1cb7-fa6a-5827-a993-0972315872da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b983b45-e8be-49e1-84c1-cec204395264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b983b45-e8be-49e1-84c1-cec204395264.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -22308,7 +22308,7 @@
         },
         {
             "id": "5d67d47c-1def-5bcc-be09-494b847df27f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3417c159-f524-42fe-93c4-f729cea41341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3417c159-f524-42fe-93c4-f729cea41341.jpg?1",
             "name": "Brushland",
             "text": "",
             "colours": [],
@@ -22340,7 +22340,7 @@
         },
         {
             "id": "1b2c8545-25f5-5736-bc98-0634b89d3036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac29c5c-3c55-4778-9bcd-642d38a0d3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac29c5c-3c55-4778-9bcd-642d38a0d3f9.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -22369,7 +22369,7 @@
         },
         {
             "id": "0b8c171b-40cc-516a-8481-3ccab4db5ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537af4fa-001c-4943-be6f-780d15b0584f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537af4fa-001c-4943-be6f-780d15b0584f.jpg?1",
             "name": "City of Brass",
             "text": "",
             "colours": [],
@@ -22398,7 +22398,7 @@
         },
         {
             "id": "fbf191b4-8074-542b-bf9b-5111dd3e718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6d68-19da-4b85-9852-681c0fc1e400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6d68-19da-4b85-9852-681c0fc1e400.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22439,7 +22439,7 @@
         },
         {
             "id": "b91da1b2-10e2-5e20-bb8b-587400019097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9730c936-a1fc-484d-a9ce-a91804a84609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9730c936-a1fc-484d-a9ce-a91804a84609.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22480,7 +22480,7 @@
         },
         {
             "id": "46caa683-bb63-501e-bb53-49d78d6e42cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def1ac1-652c-4160-9092-46549e577570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def1ac1-652c-4160-9092-46549e577570.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22521,7 +22521,7 @@
         },
         {
             "id": "bc014c8c-a647-5733-9186-42bb89dc06b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1de7-60d3-4bf3-8909-8f4fa5045479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1de7-60d3-4bf3-8909-8f4fa5045479.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22562,7 +22562,7 @@
         },
         {
             "id": "884207a8-3391-5578-b799-ca855a8ec46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172e55c6-b797-4b49-94f1-cc93e4f5b939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172e55c6-b797-4b49-94f1-cc93e4f5b939.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22603,7 +22603,7 @@
         },
         {
             "id": "b8d804f8-fe77-5694-b335-22ba6c8ee3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b7404-ae5a-4921-b70b-775deeb2c984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b7404-ae5a-4921-b70b-775deeb2c984.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22644,7 +22644,7 @@
         },
         {
             "id": "edf03820-7eaf-57bb-b040-b0c585e7b836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69545e9-7219-43f1-8a31-5035d87dca68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69545e9-7219-43f1-8a31-5035d87dca68.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -22685,7 +22685,7 @@
         },
         {
             "id": "fa906109-3dca-5397-8e96-131111e115a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4321609-4f11-4066-9820-cbb483e9214a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4321609-4f11-4066-9820-cbb483e9214a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22726,7 +22726,7 @@
         },
         {
             "id": "24cdabfb-39a8-5149-88f8-23255bdd60a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45610b3-9e9b-4ef9-aab2-426f85a6cce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45610b3-9e9b-4ef9-aab2-426f85a6cce3.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -22767,7 +22767,7 @@
         },
         {
             "id": "10e716e6-62e8-5ee5-b7b8-1f2c4d465201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51487402-2a52-4117-ba88-327e863e5f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51487402-2a52-4117-ba88-327e863e5f56.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -22808,7 +22808,7 @@
         },
         {
             "id": "786a668b-ed48-5bea-99d3-0566a8c8ba07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a0a9ae-a1ae-41da-8308-d49e4afca3c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a0a9ae-a1ae-41da-8308-d49e4afca3c1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -22849,7 +22849,7 @@
         },
         {
             "id": "231f4dc0-9bd7-5f29-99df-c681018c8696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b02969-1959-4422-8e10-63ffb23192a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b02969-1959-4422-8e10-63ffb23192a2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -22890,7 +22890,7 @@
         },
         {
             "id": "d275904b-cdad-513f-83f9-ffae88dfad32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb83039-9a06-4d79-abcc-6f36eec6f29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb83039-9a06-4d79-abcc-6f36eec6f29e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -22931,7 +22931,7 @@
         },
         {
             "id": "6ac0b65f-3654-55d5-beba-06bc504ff2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea43ef7-99c5-40b6-9a59-9661b3b710cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea43ef7-99c5-40b6-9a59-9661b3b710cf.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "09b91fb1-2eae-5417-a1d0-1dd5a8d630dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff68b640-e194-4894-b9c0-76ed619c764d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff68b640-e194-4894-b9c0-76ed619c764d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23013,7 +23013,7 @@
         },
         {
             "id": "c7565c03-669b-534a-9ccb-12e443b29262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23b716f-51b2-402a-9a69-de190d3f6411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23b716f-51b2-402a-9a69-de190d3f6411.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23054,7 +23054,7 @@
         },
         {
             "id": "9e6d4c69-1041-5839-ae20-4a6d7ef2d79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c393b6f-2421-4d77-9025-dac9dfaaae36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c393b6f-2421-4d77-9025-dac9dfaaae36.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -23086,7 +23086,7 @@
         },
         {
             "id": "e42928ee-531e-5f6e-b551-ea8d04def518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c388f490-ee8d-495b-b400-9f83916f0fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c388f490-ee8d-495b-b400-9f83916f0fed.jpg?1",
             "name": "Karplusan Forest",
             "text": "",
             "colours": [],
@@ -23118,7 +23118,7 @@
         },
         {
             "id": "ab5229c3-c69e-5b84-8bcb-6056b7358283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe14fc96-f33a-4bd2-8b04-c339936d3c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe14fc96-f33a-4bd2-8b04-c339936d3c24.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23159,7 +23159,7 @@
         },
         {
             "id": "2faabb03-3dca-528c-8c1f-f5dd4b930d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16328444-5657-4f35-99c5-340d61472770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16328444-5657-4f35-99c5-340d61472770.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23200,7 +23200,7 @@
         },
         {
             "id": "3f1266ac-56a5-57d3-8f08-0069f26955c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01534212-5a65-4088-b45b-0823736a8fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01534212-5a65-4088-b45b-0823736a8fd5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23241,7 +23241,7 @@
         },
         {
             "id": "44f4d592-8068-54ce-95f5-73a5781778d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af90ad7-25e9-4a5c-9169-38f33d7640a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af90ad7-25e9-4a5c-9169-38f33d7640a6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23282,7 +23282,7 @@
         },
         {
             "id": "4c385d7f-14de-5d69-94a2-c8164d320fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae41792d-4aa0-42ae-a9e1-9261cf9181a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae41792d-4aa0-42ae-a9e1-9261cf9181a8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23323,7 +23323,7 @@
         },
         {
             "id": "ffe4be51-f7a3-550c-8061-310d11a76dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ade9a7-2a2e-4ec9-aa9c-20bc8caaf8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ade9a7-2a2e-4ec9-aa9c-20bc8caaf8a3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23364,7 +23364,7 @@
         },
         {
             "id": "d8e5df14-5a6a-5c9f-a257-400a816a0043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff951c38-6e02-40f0-9f54-13ac0915332b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff951c38-6e02-40f0-9f54-13ac0915332b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23405,7 +23405,7 @@
         },
         {
             "id": "61e77cbe-74e1-53c5-b16f-2f8ccd7b5b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f30404-4d66-4aa0-81d3-351820854eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f30404-4d66-4aa0-81d3-351820854eda.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23446,7 +23446,7 @@
         },
         {
             "id": "98fe6ac3-f7c9-59bf-8305-32202febba12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb482d-6279-48d6-baa3-047b48c3e5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb482d-6279-48d6-baa3-047b48c3e5df.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23487,7 +23487,7 @@
         },
         {
             "id": "370d437f-8111-54e9-9ed2-55cf66248de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a6a9b-c91d-4337-bc8c-411a50793385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a6a9b-c91d-4337-bc8c-411a50793385.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23528,7 +23528,7 @@
         },
         {
             "id": "1dd81c47-d8ce-52da-b19d-95a1f461f823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d13dbd6-6c6e-4120-a05a-e77f1e863b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d13dbd6-6c6e-4120-a05a-e77f1e863b35.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23569,7 +23569,7 @@
         },
         {
             "id": "96b07732-5db5-53b7-a8c2-116481fd733d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddcb7af-1f99-427f-971d-dd16b42d1914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddcb7af-1f99-427f-971d-dd16b42d1914.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23610,7 +23610,7 @@
         },
         {
             "id": "ff74969c-efbe-5202-89ca-49bc6899a7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb3ffc-9471-42c7-a1f4-66b6a8f9672c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb3ffc-9471-42c7-a1f4-66b6a8f9672c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23651,7 +23651,7 @@
         },
         {
             "id": "474cf6a0-9d91-59f1-aef8-2b0b8b5e23a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8bfc4f-ba82-462a-a5e6-5717de69414b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8bfc4f-ba82-462a-a5e6-5717de69414b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23692,7 +23692,7 @@
         },
         {
             "id": "48df8f1c-7ec0-5ead-8c56-7e02ede673d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43559560-354d-4147-977f-766b58bca9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43559560-354d-4147-977f-766b58bca9fa.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23733,7 +23733,7 @@
         },
         {
             "id": "270fec25-9e59-562b-81bd-810645b9b1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7604bd-b3b0-4e55-91c4-3717bae7e457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7604bd-b3b0-4e55-91c4-3717bae7e457.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23774,7 +23774,7 @@
         },
         {
             "id": "bcd8070d-ff15-59bf-80ba-72fcf5a2aaa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31327f6-f076-4366-9c7a-b084516ba215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31327f6-f076-4366-9c7a-b084516ba215.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -23806,7 +23806,7 @@
         },
         {
             "id": "1f358563-85e9-5aaf-b757-5100f0169caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3531a023-b37c-472c-9697-8b2c018139c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3531a023-b37c-472c-9697-8b2c018139c5.jpg?1",
             "name": "Sulfurous Springs",
             "text": "",
             "colours": [],
@@ -23838,7 +23838,7 @@
         },
         {
             "id": "e4e15dca-62b2-5f85-bf4b-cbcd280afdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7b6238-752d-49b7-8cdc-56587676e52d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7b6238-752d-49b7-8cdc-56587676e52d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23879,7 +23879,7 @@
         },
         {
             "id": "60f84c9d-c745-51c7-8689-d2cea6783c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40705a25-2de4-4a54-9fc4-02899085da27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40705a25-2de4-4a54-9fc4-02899085da27.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23920,7 +23920,7 @@
         },
         {
             "id": "703fb90f-02d8-57d5-93f0-4fa063e96845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfae795-d3d2-4758-9717-ed33cd0f3bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfae795-d3d2-4758-9717-ed33cd0f3bfb.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23961,7 +23961,7 @@
         },
         {
             "id": "0b3e0893-4955-5b0b-a2b7-e6c0f14fdd41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b65a1-314b-4c22-b942-38f60ba2c392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b65a1-314b-4c22-b942-38f60ba2c392.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -24002,7 +24002,7 @@
         },
         {
             "id": "53999dfd-8247-5fde-804b-0f5ae7a09df8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c956611e-5748-42ff-b8ea-bca0c3d94de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c956611e-5748-42ff-b8ea-bca0c3d94de4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -24043,7 +24043,7 @@
         },
         {
             "id": "60617c18-95fc-53b9-b718-efc8ca480615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cf9d05-153f-42c5-b48a-ad06da0ef4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cf9d05-153f-42c5-b48a-ad06da0ef4d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -24084,7 +24084,7 @@
         },
         {
             "id": "52488505-152f-50ac-abef-9a28b950478e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebdd6db-9434-4e60-bdf2-234e21ccbb10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebdd6db-9434-4e60-bdf2-234e21ccbb10.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -24125,7 +24125,7 @@
         },
         {
             "id": "39c3e8cf-9bb1-5fa6-b69a-5ad4c3bcbba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838fb77-a484-4323-aa62-c944f3fefa95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838fb77-a484-4323-aa62-c944f3fefa95.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -24166,7 +24166,7 @@
         },
         {
             "id": "d20aa985-2452-5f28-991f-b4964149c136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b496660-5a5d-4dec-93ca-60e6b1286221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b496660-5a5d-4dec-93ca-60e6b1286221.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -24198,7 +24198,7 @@
         },
         {
             "id": "f4ca5de5-d8f0-5e56-aaa4-bbdcee5eccfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f22de9-7cdb-464f-9354-61c5aa858c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f22de9-7cdb-464f-9354-61c5aa858c7a.jpg?1",
             "name": "Underground River",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/8ED.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/8ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fa5ac0d2-e14b-537f-bad8-53e0c473c3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552cc36c-4d02-44ee-b36a-f58ff14c6f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552cc36c-4d02-44ee-b36a-f58ff14c6f3d.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "ff3276f4-392f-5656-9b3e-eb5110287bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f25bb-4e27-4e44-887a-f093dc14f861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f25bb-4e27-4e44-887a-f093dc14f861.jpg?1",
             "name": "Angel of Mercy",
             "text": "",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "105922a5-5ba9-5402-9675-671634af61e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a5ec5a-b490-456a-98e8-36cf4b836d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a5ec5a-b490-456a-98e8-36cf4b836d2a.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "f158a58f-02d6-534c-a1bc-6e221c4559a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a624f-3d5a-4519-8711-bd163da305c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a624f-3d5a-4519-8711-bd163da305c7.jpg?1",
             "name": "Angelic Page",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "855a5041-b13f-55ca-a09b-dda777c77599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78a4409-2e27-4c47-81c0-ff862ab7ca37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78a4409-2e27-4c47-81c0-ff862ab7ca37.jpg?1",
             "name": "Angelic Page",
             "text": "",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "f036e0f7-9618-5973-a2a0-7778ee04c895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a680ae-aa4f-4030-8032-113b2b80e1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a680ae-aa4f-4030-8032-113b2b80e1fb.jpg?1",
             "name": "Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "132deedd-dbd9-5fee-9d64-bbbb3ef4ab0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c78d392-9f2f-4241-9a10-6ac9b1e86154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c78d392-9f2f-4241-9a10-6ac9b1e86154.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "de0a98ed-456a-51fa-b212-374faae61aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5597d1e5-4a8c-426d-a2ad-f797f185ca36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5597d1e5-4a8c-426d-a2ad-f797f185ca36.jpg?1",
             "name": "Ardent Militia",
             "text": "",
             "colours": [
@@ -283,7 +283,7 @@
         },
         {
             "id": "93c34bc0-24c1-54f9-be71-b30d54344615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5131c74-a81b-4927-a1b9-98d2c714ab71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5131c74-a81b-4927-a1b9-98d2c714ab71.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "9297646e-dc0f-584e-9461-3addbf4235b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d9362-4f6a-43ad-9494-9c2014a4b5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d9362-4f6a-43ad-9494-9c2014a4b5ad.jpg?1",
             "name": "Avatar of Hope",
             "text": "If you have 3 life or less, Avatar of Hope costs {6} less to play.\nFlying (This creature can't be blocked except by creatures with flying.)\nAvatar of Hope may block any number of creatures.",
             "colours": [
@@ -351,7 +351,7 @@
         },
         {
             "id": "bc5ab0c5-b2de-5ea7-abe1-aa417bcb6c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747f55e1-e1a6-4cef-8326-7c8722ffe1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747f55e1-e1a6-4cef-8326-7c8722ffe1a0.jpg?1",
             "name": "Avatar of Hope",
             "text": "",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "4c85b5b0-8685-5a50-a606-abb7c01e7928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8cacd1-51e7-48af-a7ae-48832dc34a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8cacd1-51e7-48af-a7ae-48832dc34a92.jpg?1",
             "name": "Sea Eagle",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -419,7 +419,7 @@
         },
         {
             "id": "5a0b7932-0166-586c-ba5b-d4d996544222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03872618-1428-48c9-8f6d-8edc53560df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03872618-1428-48c9-8f6d-8edc53560df2.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "f76eaedc-0bc3-5c8a-b810-2b649c056c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11996023-ebf2-427f-ad36-9bf9c3c7949d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11996023-ebf2-427f-ad36-9bf9c3c7949d.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "59eae26c-f332-5a61-922c-34ed399b85a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168821ce-d77c-4294-a9fd-2a30852801ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168821ce-d77c-4294-a9fd-2a30852801ab.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "d896b2f7-86af-58c7-b5c8-6ca0edf5c277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa12005-465d-40b2-804b-a04cc2686ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa12005-465d-40b2-804b-a04cc2686ebd.jpg?1",
             "name": "Aven Flock",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{W}: Aven Flock gets +0/+1 until end of turn.",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "425250fd-feee-5ac8-8592-3984645293df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a12645d-eb05-4c31-b872-0ac35cbf06c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a12645d-eb05-4c31-b872-0ac35cbf06c6.jpg?1",
             "name": "Aven Flock",
             "text": "",
             "colours": [
@@ -597,7 +597,7 @@
         },
         {
             "id": "ed2e1705-1d1e-56dc-9600-ec7858b24606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9256cc2-d4b5-4103-bda8-2d9c98c4fd7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9256cc2-d4b5-4103-bda8-2d9c98c4fd7d.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "3705cd37-11b7-5e71-995a-344dc1306fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d854b-a165-4d40-86d7-d6a0aa17ce18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d854b-a165-4d40-86d7-d6a0aa17ce18.jpg?1",
             "name": "Blessed Reversal",
             "text": "You gain 3 life for each creature attacking you.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "96cbde2c-1e0f-595e-8161-1f56bb4821a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451e9163-d376-44dd-b3c3-c7ad661f4cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451e9163-d376-44dd-b3c3-c7ad661f4cf6.jpg?1",
             "name": "Blessed Reversal",
             "text": "",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "97d4fcb6-6949-5a03-ad0e-fbafe59e4257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b3156-975d-4f64-b19c-172cb21266c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b3156-975d-4f64-b19c-172cb21266c5.jpg?1",
             "name": "Silverback Ape",
             "text": "",
             "colours": [
@@ -729,7 +729,7 @@
         },
         {
             "id": "70687d62-433d-5d5f-b120-3ba0950208f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e502c5-ae2f-4d2e-b5d4-0e8f255eebcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e502c5-ae2f-4d2e-b5d4-0e8f255eebcc.jpg?1",
             "name": "Blinding Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Blinding Angel deals combat damage to a player, that player skips his or her next combat phase.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "eed275f6-fc0c-5363-a905-2df02f87cabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d860996a-6d22-4c35-b741-68337ff15bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d860996a-6d22-4c35-b741-68337ff15bf6.jpg?1",
             "name": "Blinding Angel",
             "text": "",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "2110183a-10c1-53c9-b74a-ee59d6372220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80972578-36fb-4bc2-9593-f9b10fb8424c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80972578-36fb-4bc2-9593-f9b10fb8424c.jpg?1",
             "name": "Chastise",
             "text": "Destroy target attacking creature. You gain life equal to its power.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "63a92b84-7770-5aca-b4da-d8d2c47c042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbdf926-95a5-4144-b707-85483a78f808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbdf926-95a5-4144-b707-85483a78f808.jpg?1",
             "name": "Chastise",
             "text": "",
             "colours": [
@@ -865,7 +865,7 @@
         },
         {
             "id": "c56da9fd-1076-5d94-8506-c968763529ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b5709c-d6bb-4866-a613-cbe93a918caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b5709c-d6bb-4866-a613-cbe93a918caa.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "{1}: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -898,7 +898,7 @@
         },
         {
             "id": "7bb07188-668d-5842-80ac-e2f5e120d23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71c65d-fc6d-4f7b-8054-657c2989db17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71c65d-fc6d-4f7b-8054-657c2989db17.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "",
             "colours": [
@@ -931,7 +931,7 @@
         },
         {
             "id": "3f0e1b38-925e-5374-b13a-c50467c883f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ced2118-dfb3-4f29-ad6b-454c0a8a094b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ced2118-dfb3-4f29-ad6b-454c0a8a094b.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "{1}: The next time a blue source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "8b6e5294-6985-5187-8123-9557d2085d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbfb6bf-efdd-454a-bc9d-e554f0b9bf13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbfb6bf-efdd-454a-bc9d-e554f0b9bf13.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "31e15b0d-22c9-517d-80f5-6de254e9e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc0e7d-a15b-4930-93d1-832c4fed733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc0e7d-a15b-4930-93d1-832c4fed733b.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "{1}: The next time a green source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1030,7 +1030,7 @@
         },
         {
             "id": "bf7820af-2491-57d6-ba03-1e83146f65f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c6a84-82ff-498e-bef1-4e39fa93be7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c6a84-82ff-498e-bef1-4e39fa93be7c.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "b2eac49f-9b23-5fbc-8e5f-e0803547c596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a719732d-4370-4338-9e5b-a0e17c3b6608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a719732d-4370-4338-9e5b-a0e17c3b6608.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "{1}: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "8837128c-0749-56ca-9e00-1cdd95fdc31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65217707-b67a-4d9b-9a6e-6d241e3d0350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65217707-b67a-4d9b-9a6e-6d241e3d0350.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "bc90d3cc-360c-5aa9-805b-c4e0211d7ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e64f2cc-67bd-482a-938b-8dca1a1c6ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e64f2cc-67bd-482a-938b-8dca1a1c6ac1.jpg?1",
             "name": "Circle of Protection: White",
             "text": "{1}: The next time a white source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "748ed56a-044b-5097-b6e6-446b488e5d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff6d61-fe4d-4fa0-a20b-00b9c0879cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff6d61-fe4d-4fa0-a20b-00b9c0879cb4.jpg?1",
             "name": "Circle of Protection: White",
             "text": "",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "8c15f862-30f3-577b-b6a0-fe9e999b0da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47101c-ead0-42a6-b37b-0e5d294959c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47101c-ead0-42a6-b37b-0e5d294959c9.jpg?1",
             "name": "Crossbow Infantry",
             "text": "{T}: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "4e6543b3-731b-5f61-a9f2-e5176d228787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf09dc8-ef87-4eed-801e-e4289985011f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf09dc8-ef87-4eed-801e-e4289985011f.jpg?1",
             "name": "Crossbow Infantry",
             "text": "",
             "colours": [
@@ -1269,7 +1269,7 @@
         },
         {
             "id": "282c84af-efc7-5196-bf30-c932a8660911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4907c728-f08d-4c14-96a2-c92f09dfa6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4907c728-f08d-4c14-96a2-c92f09dfa6d2.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "7005ce22-5464-543c-ae60-707f542fbae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8456c3-cdb0-46af-8884-e47cccd35cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8456c3-cdb0-46af-8884-e47cccd35cef.jpg?1",
             "name": "Demystify",
             "text": "",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "6e187702-8381-5a7d-88c0-225ab85e5661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb0854-87e7-4236-9791-8fe601704200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeb0854-87e7-4236-9791-8fe601704200.jpg?1",
             "name": "Diving Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nAttacking doesn't cause Diving Griffin to tap.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "c450e020-dda4-59d0-a22e-c01549099ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1e4260-c555-48d4-b779-b97e3639e729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1e4260-c555-48d4-b779-b97e3639e729.jpg?1",
             "name": "Diving Griffin",
             "text": "",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "1c03f0f9-4d89-5c5b-a143-600e1246726f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2341478-2a91-4ce8-881a-21e826b55c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2341478-2a91-4ce8-881a-21e826b55c34.jpg?1",
             "name": "Elite Archers",
             "text": "{T}: Elite Archers deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -1442,7 +1442,7 @@
         },
         {
             "id": "39f52a25-1906-501f-9d2d-9dba319c6db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48af300f-ed3a-4b69-9bef-f568b27927c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48af300f-ed3a-4b69-9bef-f568b27927c4.jpg?1",
             "name": "Elite Archers",
             "text": "",
             "colours": [
@@ -1479,7 +1479,7 @@
         },
         {
             "id": "bab1c04c-6e4c-563a-8e76-2ccd994d53ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1839ea-567e-44eb-983f-c1a570ba5c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1839ea-567e-44eb-983f-c1a570ba5c82.jpg?1",
             "name": "Elite Javelineer",
             "text": "Whenever Elite Javelineer blocks, it deals 1 damage to target attacking creature.",
             "colours": [
@@ -1515,7 +1515,7 @@
         },
         {
             "id": "63718c02-2c75-5daa-84d6-401febbc3083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c82ae-1b19-48cf-9a7c-edf0f031e66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c82ae-1b19-48cf-9a7c-edf0f031e66e.jpg?1",
             "name": "Elite Javelineer",
             "text": "",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "c2dd11fd-4c50-5d6d-a90a-70a29eae3f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f95890-0258-431c-b639-c0aba27b8039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f95890-0258-431c-b639-c0aba27b8039.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1584,7 +1584,7 @@
         },
         {
             "id": "e1b35d25-26da-5788-a5bb-beaa164bd58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e550c04a-de51-46c0-a17b-3d2a61aedc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e550c04a-de51-46c0-a17b-3d2a61aedc7f.jpg?1",
             "name": "Glorious Anthem",
             "text": "",
             "colours": [
@@ -1617,7 +1617,7 @@
         },
         {
             "id": "ae5cc46e-cf69-5730-884d-8a188df6b477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502beb90-c562-470a-9315-bc1a1b11ea9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502beb90-c562-470a-9315-bc1a1b11ea9c.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1653,7 +1653,7 @@
         },
         {
             "id": "9ae2d013-0562-5db4-897c-912f3e35e232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e8b55c-231a-41bc-8f15-ad4b93f3d637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e8b55c-231a-41bc-8f15-ad4b93f3d637.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "4eabc2c4-cbd5-5e4d-9e85-e1405b73aad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41703ace-78e3-474e-b06a-43260c060471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41703ace-78e3-474e-b06a-43260c060471.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "aa7b7c8c-2ba4-5a4f-96bd-9e0882aaf38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292d118-5c47-4273-a2fe-d041de7e42e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292d118-5c47-4273-a2fe-d041de7e42e0.jpg?1",
             "name": "Healing Salve",
             "text": "",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "f43b30d4-c9f8-5a99-becb-8ce9f3e92f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72baf7-d9fe-41b4-862d-3709834ee46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72baf7-d9fe-41b4-862d-3709834ee46b.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "5cc6d6b9-792c-5af5-a888-6da27aeaf7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4061db-4d4a-43f3-bed5-51259b69be86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4061db-4d4a-43f3-bed5-51259b69be86.jpg?1",
             "name": "Holy Day",
             "text": "",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "f9d6161a-6e3f-572b-abe8-7ee78ca17973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0038c0e-071f-4fee-bf23-d50d00014703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0038c0e-071f-4fee-bf23-d50d00014703.jpg?1",
             "name": "Holy Strength",
             "text": "Enchanted creature gets +1/+2.",
             "colours": [
@@ -1856,7 +1856,7 @@
         },
         {
             "id": "5df7d717-06d2-5a65-839d-dedabeaa5bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f8a95-1c6a-4cb4-b504-55ac492c4d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f8a95-1c6a-4cb4-b504-55ac492c4d8a.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "e090efa0-5578-5712-a6c0-33a2a461a2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa797080-aa3b-4285-a47a-878a3e8e584f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa797080-aa3b-4285-a47a-878a3e8e584f.jpg?1",
             "name": "Honor Guard",
             "text": "{W}: Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "e7bcdbb4-f5aa-5dc6-a913-d32641b5248f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fa231-4aa4-46ef-917c-fbfcbb8714af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fa231-4aa4-46ef-917c-fbfcbb8714af.jpg?1",
             "name": "Honor Guard",
             "text": "",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "dad32183-6c5a-5f58-b931-04752490a561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d08a6-730c-45a3-9d17-d724d2bdfbcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d08a6-730c-45a3-9d17-d724d2bdfbcd.jpg?1",
             "name": "Intrepid Hero",
             "text": "{T}: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "8fb8650a-71e9-5232-a2ca-2fb6a20f8942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd392d6f-c45b-491f-8205-35c5bf4dab0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd392d6f-c45b-491f-8205-35c5bf4dab0d.jpg?1",
             "name": "Intrepid Hero",
             "text": "",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "f791b952-90c8-51cb-8269-cbd48a5bea3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51842cf5-a658-4522-a5e4-9c764ab1331e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51842cf5-a658-4522-a5e4-9c764ab1331e.jpg?1",
             "name": "Ivory Mask",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "8093e142-018e-5a7a-ac1f-a565fdac76cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3d0e39-8519-4a0b-ada1-15f8bb9f0b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3d0e39-8519-4a0b-ada1-15f8bb9f0b77.jpg?1",
             "name": "Ivory Mask",
             "text": "",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "8eede794-1f69-5c93-85f3-577ef1eea2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9df1cc-9de3-42a6-9c28-f2d8db75322a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9df1cc-9de3-42a6-9c28-f2d8db75322a.jpg?1",
             "name": "Karma",
             "text": "At the beginning of each player's upkeep, Karma deals damage to that player equal to the number of Swamps he or she controls. (Your upkeep step is after you untap and before you draw.)",
             "colours": [
@@ -2134,7 +2134,7 @@
         },
         {
             "id": "53a9707a-5c40-556e-b901-62560e027495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146f69a-f9d1-4124-a108-434a1cd913e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146f69a-f9d1-4124-a108-434a1cd913e9.jpg?1",
             "name": "Karma",
             "text": "",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "7328eece-3952-5df0-9b2b-55bc9cfb6ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc58f97-39ee-4d89-884f-88f9edc3459f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc58f97-39ee-4d89-884f-88f9edc3459f.jpg?1",
             "name": "Master Decoy",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "13c113a1-b389-5b00-a42e-7db29449d04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf99754a-620d-496a-bbc3-12a54f56d8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf99754a-620d-496a-bbc3-12a54f56d8df.jpg?1",
             "name": "Master Decoy",
             "text": "",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "d2178e44-3ec3-5a5c-8a84-052889cd989d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8acbfb-a836-44c4-b655-f5dc919941cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8acbfb-a836-44c4-b655-f5dc919941cc.jpg?1",
             "name": "Master Healer",
             "text": "{T}: Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2275,7 +2275,7 @@
         },
         {
             "id": "c45a67b9-6b8b-55c9-aba8-8c3689a05a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6717914-b2dd-4fb2-8e29-440444534de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6717914-b2dd-4fb2-8e29-440444534de8.jpg?1",
             "name": "Master Healer",
             "text": "",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "e6377278-b56e-584e-ad2e-17c8c8041c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35c327-1998-4331-9280-1617638c1031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd35c327-1998-4331-9280-1617638c1031.jpg?1",
             "name": "Noble Purpose",
             "text": "Whenever a creature you control deals combat damage, you gain that much life.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "7466b64e-0524-5806-856a-34aef7196d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee27eef-d6c4-4b0f-b215-323856a055e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee27eef-d6c4-4b0f-b215-323856a055e1.jpg?1",
             "name": "Noble Purpose",
             "text": "",
             "colours": [
@@ -2377,7 +2377,7 @@
         },
         {
             "id": "25b97619-db02-5eaa-8516-59f9d926f3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc85607-dfdd-4989-b299-c68adb8c7159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc85607-dfdd-4989-b299-c68adb8c7159.jpg?1",
             "name": "Oracle's Attendants",
             "text": "{T}: All damage that would be dealt to target creature this turn by a source of your choice is dealt to Oracle's Attendants instead.",
             "colours": [
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "e72d19a1-d16b-5152-8c48-a78c1a776906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a2390-112b-4a60-91d9-c394e6a3e65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a2390-112b-4a60-91d9-c394e6a3e65d.jpg?1",
             "name": "Oracle's Attendants",
             "text": "",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "7c8a159a-9607-56ea-9ffe-90f9e4f9f74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a9d48-ca39-4275-ba1e-f584a3b647df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8a9d48-ca39-4275-ba1e-f584a3b647df.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -2484,7 +2484,7 @@
         },
         {
             "id": "bade6410-8620-51cc-a7bf-de22465c1b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d9d474-d783-432e-b9bb-22514e9eab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d9d474-d783-432e-b9bb-22514e9eab57.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -2519,7 +2519,7 @@
         },
         {
             "id": "15b16c07-4b03-540e-9f56-f7bc6413ad6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05bd3b7-02fb-4d83-ab8f-fd056c7db2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05bd3b7-02fb-4d83-ab8f-fd056c7db2f1.jpg?1",
             "name": "Peach Garden Oath",
             "text": "You gain 2 life for each creature you control.",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "ff60e8f1-9ebf-5a95-9968-294be0961109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b16c3-0963-4cd7-a4c1-2d4de3bd885c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b16c3-0963-4cd7-a4c1-2d4de3bd885c.jpg?1",
             "name": "Peach Garden Oath",
             "text": "",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "47f77b8a-017f-518e-8cdc-291769097e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a25bf0b-7de0-4e71-ae3e-59a6665dc903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a25bf0b-7de0-4e71-ae3e-59a6665dc903.jpg?1",
             "name": "Rain of Blades",
             "text": "Rain of Blades deals 1 damage to each attacking creature.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "5dd94709-a788-5bf7-b19b-0603fa201ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39600c44-df38-455a-a06d-1bcac7c519cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39600c44-df38-455a-a06d-1bcac7c519cb.jpg?1",
             "name": "Rain of Blades",
             "text": "",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "fef08ac1-58a9-5900-b45a-4e440a08ae60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6023b3c7-53bc-4490-8f9b-beb858b068e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6023b3c7-53bc-4490-8f9b-beb858b068e8.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "02690b82-3f7e-5896-a907-f22f50f6bac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20a487a-cdf7-4ba9-84fd-ca8a91652223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20a487a-cdf7-4ba9-84fd-ca8a91652223.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "d9e27efe-e1ce-5a64-9158-b9af5f5d29a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ba3fde-f5ff-4e59-88a0-3c38fc5e75e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ba3fde-f5ff-4e59-88a0-3c38fc5e75e0.jpg?1",
             "name": "Redeem",
             "text": "Prevent all damage that would be dealt this turn to up to two target creatures.",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "65e4e800-6260-57eb-b85d-b82559750916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5425ad59-03bf-4c66-8286-3bcfc27fef0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5425ad59-03bf-4c66-8286-3bcfc27fef0c.jpg?1",
             "name": "Redeem",
             "text": "",
             "colours": [
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "a4c9ce2f-38ad-5d81-836d-d22c1903cfdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb50bf-7e77-4b8e-a030-e575d0418a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb50bf-7e77-4b8e-a030-e575d0418a00.jpg?1",
             "name": "Rolling Stones",
             "text": "Walls may attack as though they weren't Walls.",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "747763e9-e631-5e0b-b8ba-080316f48964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a931d691-3efc-4043-9e23-677f8bd949e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a931d691-3efc-4043-9e23-677f8bd949e1.jpg?1",
             "name": "Rolling Stones",
             "text": "",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "fdc2f0f8-0309-54c3-b100-36bbfb99861e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101e615-adf1-4b58-87b2-32832b30fabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101e615-adf1-4b58-87b2-32832b30fabb.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever a spell or ability an opponent controls causes a land to be put into your graveyard from play, return that land to play.",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "767e1e19-70bb-55fd-8086-dffac4d2f168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da33-7d58-4292-9827-a074ef123dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da33-7d58-4292-9827-a074ef123dc4.jpg?1",
             "name": "Sacred Ground",
             "text": "",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "b28781d2-8c65-5367-89ed-3843b29d2cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7417bbe7-c1b3-4046-98b3-7d6af9851ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7417bbe7-c1b3-4046-98b3-7d6af9851ab2.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -2952,7 +2952,7 @@
         },
         {
             "id": "84e0980d-9876-5c91-a015-700b357c9373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228f475-0a80-44c6-acd8-8d485a1bbed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228f475-0a80-44c6-acd8-8d485a1bbed2.jpg?1",
             "name": "Sacred Nectar",
             "text": "",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "7564e63b-4ffe-5a3b-97ac-e5a444635aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a93d628-0934-4ddb-bac1-b0ceafdb0ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a93d628-0934-4ddb-bac1-b0ceafdb0ba4.jpg?1",
             "name": "Samite Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "fc903e01-bc11-5537-8bc9-6ac538f30a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbcd61c-a5f7-4b68-a7e2-249ad84c7a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbcd61c-a5f7-4b68-a7e2-249ad84c7a4e.jpg?1",
             "name": "Samite Healer",
             "text": "",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "fd16141d-497c-5ef1-882a-300d33e1e4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74733902-f177-4551-bc39-72f58860c890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74733902-f177-4551-bc39-72f58860c890.jpg?1",
             "name": "Sanctimony",
             "text": "Whenever an opponent taps a Mountain for mana, you may gain 1 life.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "1dd3c084-6a52-53c9-945d-ed0eba81f808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fd979-7c4c-44e3-9324-a3dd4c29ff83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fd979-7c4c-44e3-9324-a3dd4c29ff83.jpg?1",
             "name": "Sanctimony",
             "text": "",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "3dc3faf8-efd4-54b9-b07c-1546dbb4085a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58dbcf3-f8ad-4e82-9515-0290fa5373f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58dbcf3-f8ad-4e82-9515-0290fa5373f7.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "2d7e052d-4743-5936-b8ab-79e1679e1df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea8d9f-2b77-4cff-8b96-387f43366c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea8d9f-2b77-4cff-8b96-387f43366c1a.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "c353d8c6-6c90-54c6-8e96-3d43fac212ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae1da2-f752-481c-a0e8-3c73f6b4ccbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae1da2-f752-481c-a0e8-3c73f6b4ccbe.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -3229,7 +3229,7 @@
         },
         {
             "id": "cb412893-7e48-57f8-bf21-024c123068fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7de3d2-3a98-49dd-810a-0dbba8f8e004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7de3d2-3a98-49dd-810a-0dbba8f8e004.jpg?1",
             "name": "Seasoned Marshal",
             "text": "",
             "colours": [
@@ -3265,7 +3265,7 @@
         },
         {
             "id": "7b066400-b3e1-527f-a7b1-820c90312a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b089b409-2156-4c94-890f-e8804ab5a50c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b089b409-2156-4c94-890f-e8804ab5a50c.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nAttacking doesn't cause Serra Angel to tap.",
             "colours": [
@@ -3300,7 +3300,7 @@
         },
         {
             "id": "a0dd0cea-f9dc-5427-b09b-711a0ba1084b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7b4cf-1413-4816-8bef-4e7ab101ccd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd7b4cf-1413-4816-8bef-4e7ab101ccd2.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "6b30eea8-df6c-5149-9484-845d84fcec6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810eec1-9bb4-480f-9074-712ad9eb8fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810eec1-9bb4-480f-9074-712ad9eb8fba.jpg?1",
             "name": "Solidarity",
             "text": "Creatures you control get +0/+5 until end of turn.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "704b6666-7b3a-521b-b538-c153b2fba284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c75ac1-5b77-4dd1-a33b-7d95acf72f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c75ac1-5b77-4dd1-a33b-7d95acf72f5b.jpg?1",
             "name": "Solidarity",
             "text": "",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "4ebbc8c1-adb1-55d5-a641-44fab2686390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f4f0c-d17c-42b6-b216-1548c51b91f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f4f0c-d17c-42b6-b216-1548c51b91f5.jpg?1",
             "name": "Spirit Link",
             "text": "Whenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3436,7 +3436,7 @@
         },
         {
             "id": "73f03b0c-eff6-5a11-83bf-391c016c305d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b63b26-b7c5-4b18-8cf5-e00abe539b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b63b26-b7c5-4b18-8cf5-e00abe539b36.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "13860fdb-5e65-505b-bdf6-94e5bed5d836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013a1d59-af2a-4ae1-826e-88bd77c7ce5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013a1d59-af2a-4ae1-826e-88bd77c7ce5d.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking doesn't cause Standing Troops to tap.",
             "colours": [
@@ -3507,7 +3507,7 @@
         },
         {
             "id": "f6761742-79c4-524e-ba22-99f4cf8fa8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf40017-d331-4eac-90dc-9e7413f1c8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf40017-d331-4eac-90dc-9e7413f1c8ac.jpg?1",
             "name": "Standing Troops",
             "text": "",
             "colours": [
@@ -3543,7 +3543,7 @@
         },
         {
             "id": "a61ac001-f2a2-50ac-8aa3-1345f3a2c1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a162ae-dfe1-43e0-adf7-3d1365f3a681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a162ae-dfe1-43e0-adf7-3d1365f3a681.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, you gain 4 life.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "50fc86ec-b1ea-5af4-9e56-dc9b78a89dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b767ff-7a4a-499f-8608-aa7ae9139df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b767ff-7a4a-499f-8608-aa7ae9139df4.jpg?1",
             "name": "Staunch Defenders",
             "text": "",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "7e9b28ab-d853-59cd-afa1-9e1d5108b935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b383bd61-0f23-4d3e-a946-b8438a52234d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b383bd61-0f23-4d3e-a946-b8438a52234d.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "f7f19eef-c8cc-5e7f-8006-0647c42a2489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cebcd2-4199-425a-adfc-059f842259e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cebcd2-4199-425a-adfc-059f842259e4.jpg?1",
             "name": "Story Circle",
             "text": "",
             "colours": [
@@ -3681,7 +3681,7 @@
         },
         {
             "id": "4592ffa0-23f7-5daf-a584-9bff5bfbe96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69414b6a-421e-4895-9262-d3097078fb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69414b6a-421e-4895-9262-d3097078fb12.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -3716,7 +3716,7 @@
         },
         {
             "id": "07624a09-5464-51be-b0b2-cef2d231b37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba3c8ed-60df-4eca-95f6-6e38a3647e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba3c8ed-60df-4eca-95f6-6e38a3647e71.jpg?1",
             "name": "Suntail Hawk",
             "text": "",
             "colours": [
@@ -3751,7 +3751,7 @@
         },
         {
             "id": "05f130bf-c7cf-5461-a125-46dbf3888a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261bcea-27e0-417f-b3bf-7089c1e8bf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261bcea-27e0-417f-b3bf-7089c1e8bf1e.jpg?1",
             "name": "Sunweb",
             "text": "(Walls can't attack.)\nFlying (This creature may block creatures with flying.)\nSunweb can't block creatures with power 2 or less.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "2e05cd65-0d13-54d9-b859-8fed765aba2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ed97ad-8ff1-42fb-af77-a45e5d138c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ed97ad-8ff1-42fb-af77-a45e5d138c8b.jpg?1",
             "name": "Sunweb",
             "text": "",
             "colours": [
@@ -3821,7 +3821,7 @@
         },
         {
             "id": "3c738c78-6ac4-5054-83f8-8530d490cc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec270d53-042e-4b11-b0f4-6416348b8fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec270d53-042e-4b11-b0f4-6416348b8fff.jpg?1",
             "name": "Sword Dancer",
             "text": "{W}{W}: Target attacking creature gets -1/-0 until end of turn.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "04088f77-4423-5ca4-8875-dd49127c8de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25917af7-a35c-47fe-8374-952aaf865252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25917af7-a35c-47fe-8374-952aaf865252.jpg?1",
             "name": "Sword Dancer",
             "text": "",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "376d2e38-7676-5584-9b82-7b0ee7c59a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030d414a-5155-41cc-8b01-07d297254d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030d414a-5155-41cc-8b01-07d297254d1c.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "dd7bb79b-2f32-5673-ab36-97f45541fc50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b561f06-0c30-4b3b-b76e-3cbbd3dc0bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b561f06-0c30-4b3b-b76e-3cbbd3dc0bf6.jpg?1",
             "name": "Tundra Wolves",
             "text": "",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "b2d651ef-4080-5a14-bc85-753afbe19586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb78fad6-71d8-49a2-8e32-34675aaec796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb78fad6-71d8-49a2-8e32-34675aaec796.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "af029109-1261-5377-91ed-5d0ea2be15c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55caf83-8d60-4f22-ba42-086723e38daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55caf83-8d60-4f22-ba42-086723e38daf.jpg?1",
             "name": "Venerable Monk",
             "text": "",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "b41da309-1dc9-5f23-af0a-8d1c5168f7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcbe7e6-a584-4c9d-b319-40babff8ec26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcbe7e6-a584-4c9d-b319-40babff8ec26.jpg?1",
             "name": "Wall of Swords",
             "text": "(Walls can't attack.)\nFlying (This creature may block creatures with flying.)",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "a36cf26b-a334-5f8c-b691-8335b135af54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ae0268-e2de-45c5-8556-42455f66d646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ae0268-e2de-45c5-8556-42455f66d646.jpg?1",
             "name": "Wall of Swords",
             "text": "",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "ff74d471-5345-50ca-90e9-8be24f7134c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006c18cf-b6d2-4fba-b9da-c9762fb3885b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006c18cf-b6d2-4fba-b9da-c9762fb3885b.jpg?1",
             "name": "Worship",
             "text": "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "7ccc9c38-1aa6-5ba9-9ca7-72c7d1381bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258fb7d8-8ffd-48e7-94d2-bd6296a47e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258fb7d8-8ffd-48e7-94d2-bd6296a47e62.jpg?1",
             "name": "Worship",
             "text": "",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "78ec433a-1827-57f9-95e4-63f7ef8e8862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0619d670-7b53-4185-a25d-2fab5db1aab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0619d670-7b53-4185-a25d-2fab5db1aab5.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "573a1f79-c1c8-5965-a2b1-40bb61f3c2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d4d3-3edd-4d1c-9da5-a0892dae0393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d4d3-3edd-4d1c-9da5-a0892dae0393.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "15740177-1546-5f18-96c0-bfe2ba39b202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b15648c-1d88-42ec-b2f7-aab9a8c256a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b15648c-1d88-42ec-b2f7-aab9a8c256a2.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "3d9a8666-c1ee-5df3-98ae-e386e7bb56df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8235805-543a-422e-bd32-558d198e5686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8235805-543a-422e-bd32-558d198e5686.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "29c41b0f-55a3-5c4b-ab62-ff8517d352c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083507d3-b28f-4e84-909b-bca2a2131233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083507d3-b28f-4e84-909b-bca2a2131233.jpg?1",
             "name": "Archivist",
             "text": "{T}: Draw a card.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "6527a440-e362-53e4-92cb-e4c429fb51cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e98da9-809e-415b-bd2b-047fcdb620ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e98da9-809e-415b-bd2b-047fcdb620ac.jpg?1",
             "name": "Archivist",
             "text": "",
             "colours": [
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "a9ba7ba2-2e57-5824-ab5c-79c101a66fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfc5265-7e38-4f2e-85ae-08f34eaffb89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfc5265-7e38-4f2e-85ae-08f34eaffb89.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "75a6ea79-3f65-5470-ae9e-cb0dcb4cb0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2265d-e1dc-40f0-bfc0-c20d1d80dd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2265d-e1dc-40f0-bfc0-c20d1d80dd3c.jpg?1",
             "name": "Aven Fisher",
             "text": "",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "b1c45b97-2810-5b43-a832-fd61244f4709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f46988-c3ee-42e9-ade6-0b6302b8b952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f46988-c3ee-42e9-ade6-0b6302b8b952.jpg?1",
             "name": "Balance of Power",
             "text": "If target opponent has more cards in hand than you, draw cards equal to the difference.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "54aa7e0f-6aa4-5c35-83ee-eb6052bfe640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00d1b2-30c2-49c7-abe7-063120a622cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00d1b2-30c2-49c7-abe7-063120a622cb.jpg?1",
             "name": "Balance of Power",
             "text": "",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "6870b481-db06-5721-82bd-f43e8796c56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2275b0a5-7777-49cb-9056-aef0a82424db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2275b0a5-7777-49cb-9056-aef0a82424db.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -4552,7 +4552,7 @@
         },
         {
             "id": "f18f4bf1-b360-5def-a89c-f46edbf26653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09623b0c-a771-46e3-b7c0-d4097486f1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09623b0c-a771-46e3-b7c0-d4097486f1cd.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "7abbf954-2ff0-5c39-b969-973441636990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b099ef-4b43-4b63-a7fc-cec19cf29f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b099ef-4b43-4b63-a7fc-cec19cf29f4e.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card into play under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "d7a112d5-77a3-5d15-ab78-ef5d65ac1ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452456c-f828-4301-9b4f-8a0e77525d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d452456c-f828-4301-9b4f-8a0e77525d5f.jpg?1",
             "name": "Bribery",
             "text": "",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "24e408ec-333c-5cab-8dc9-b5ca8db20b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b50620d-430e-4c38-a95d-3d69a4c29ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b50620d-430e-4c38-a95d-3d69a4c29ff9.jpg?1",
             "name": "Catalog",
             "text": "Draw two cards, then discard a card from your hand.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "1a66389a-253b-5ce3-a7bf-ac417b2cc2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9770db-ac79-4752-8671-47d0748f43a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9770db-ac79-4752-8671-47d0748f43a7.jpg?1",
             "name": "Catalog",
             "text": "",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "c9950776-6ca1-56b2-a705-613c55cb0f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b152c0d-ba43-49c6-9bb5-1d20a9f411f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b152c0d-ba43-49c6-9bb5-1d20a9f411f6.jpg?1",
             "name": "Coastal Hornclaw",
             "text": "Sacrifice a land: Coastal Hornclaw gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "41c741ff-0174-5225-8ca5-7a820ebbcc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee8c0f8-f673-471a-8728-1c33b70e5a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee8c0f8-f673-471a-8728-1c33b70e5a27.jpg?1",
             "name": "Coastal Hornclaw",
             "text": "",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "436c91a9-ae0d-5cae-85d4-a49793d41346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d65495-4d73-46fa-bd38-155f4639649a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d65495-4d73-46fa-bd38-155f4639649a.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "12fc6ad2-478e-5a91-acd3-4bc32c835dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6eaba7-9175-44a3-a4e4-b2da561864d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6eaba7-9175-44a3-a4e4-b2da561864d5.jpg?1",
             "name": "Coastal Piracy",
             "text": "",
             "colours": [
@@ -4853,7 +4853,7 @@
         },
         {
             "id": "3afb910d-06d5-520b-b5f6-d34c3be0f1bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed69afaf-74cc-4b4f-8794-751477231cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed69afaf-74cc-4b4f-8794-751477231cff.jpg?1",
             "name": "Concentrate",
             "text": "Draw three cards.",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "986d41c3-c83d-5e7f-bcd3-6e9840bd54b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e180558-6df5-47dd-af09-78a73dbe5cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e180558-6df5-47dd-af09-78a73dbe5cda.jpg?1",
             "name": "Concentrate",
             "text": "",
             "colours": [
@@ -4919,7 +4919,7 @@
         },
         {
             "id": "4fb2ec39-e049-5454-86e7-b666b5e5c768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48acfd80-eba3-4aa9-804c-563259ca84de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48acfd80-eba3-4aa9-804c-563259ca84de.jpg?1",
             "name": "Confiscate",
             "text": "You control enchanted permanent.",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "675fb2e5-9846-5d02-8cc6-3b98c9c542bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28eb01c-c08c-4f9b-bf67-d15b478b84f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28eb01c-c08c-4f9b-bf67-d15b478b84f0.jpg?1",
             "name": "Confiscate",
             "text": "",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "c9e1d63d-2497-5748-b743-235cc6885e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215244ee-0b78-4fd1-858f-d093a5d42939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215244ee-0b78-4fd1-858f-d093a5d42939.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "3c00e9a5-d0a0-5dc3-b2f3-418a6e6e17cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ac7010-0db0-4c77-a3e8-64c1a5c91d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ac7010-0db0-4c77-a3e8-64c1a5c91d51.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "5d1fed5c-6a76-5d9d-8a9b-7a08d705845e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71fe070-3656-4c69-84ae-dca3a8f7aa5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71fe070-3656-4c69-84ae-dca3a8f7aa5a.jpg?1",
             "name": "Cowardice",
             "text": "Whenever a creature becomes the target of a spell or ability, return that creature to its owner's hand. (It won't be affected by the spell or ability.)",
             "colours": [
@@ -5092,7 +5092,7 @@
         },
         {
             "id": "e5ddaf51-a149-59be-8481-aad83417026e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fc5ef-5196-495b-b56a-c360701462d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fc5ef-5196-495b-b56a-c360701462d7.jpg?1",
             "name": "Cowardice",
             "text": "",
             "colours": [
@@ -5125,7 +5125,7 @@
         },
         {
             "id": "a5471d2a-b1ef-5c81-be5f-7ba71277d990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abab-70b9-4eec-be61-80f41d6a275b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abab-70b9-4eec-be61-80f41d6a275b.jpg?1",
             "name": "Curiosity",
             "text": "Whenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "6cd50c88-0151-5777-ad95-d62b35842a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae15ef61-37dc-46a2-891f-7748996e399d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae15ef61-37dc-46a2-891f-7748996e399d.jpg?1",
             "name": "Curiosity",
             "text": "",
             "colours": [
@@ -5195,7 +5195,7 @@
         },
         {
             "id": "d62c02c1-4cfd-552c-a13d-a2a097b90e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbacff5-c650-4835-b5a1-f747a5db5fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbacff5-c650-4835-b5a1-f747a5db5fd6.jpg?1",
             "name": "Daring Apprentice",
             "text": "{T}, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "3f23eef2-4b55-5aa7-bc1e-54fb57833279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1413a8-dfe8-4b3a-a75e-35d70d8cf904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1413a8-dfe8-4b3a-a75e-35d70d8cf904.jpg?1",
             "name": "Daring Apprentice",
             "text": "",
             "colours": [
@@ -5267,7 +5267,7 @@
         },
         {
             "id": "06cbdac9-1f5e-5d68-bf14-ace1be9fdcf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c899e-f624-4791-af64-b1b1e2ac53cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c899e-f624-4791-af64-b1b1e2ac53cd.jpg?1",
             "name": "Deflection",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -5300,7 +5300,7 @@
         },
         {
             "id": "74eee7f7-c241-59c7-b774-8832a53b71ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e66c8-1061-43a6-a46f-7ef716225e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e66c8-1061-43a6-a46f-7ef716225e53.jpg?1",
             "name": "Deflection",
             "text": "",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "cfddaaf8-c35b-5d86-8db2-9b091b6c272d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce498a03-0b90-480d-9a77-d8db2b32d553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce498a03-0b90-480d-9a77-d8db2b32d553.jpg?1",
             "name": "Dehydration",
             "text": "Enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "81ceb86c-edec-59de-a42c-01d744a21e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd484166-56db-4300-8944-3055fc747f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd484166-56db-4300-8944-3055fc747f3d.jpg?1",
             "name": "Dehydration",
             "text": "",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "9a6f50ce-1910-5e21-8f38-6f8412dfb1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4f1796-765a-4c9d-af0c-7866b3ac96b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4f1796-765a-4c9d-af0c-7866b3ac96b0.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "461fad28-7bec-53f1-8ce0-16c9a20ec9f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba92987-0a10-42b6-a331-ec56f244c5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba92987-0a10-42b6-a331-ec56f244c5eb.jpg?1",
             "name": "Evacuation",
             "text": "",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "7b8ec349-39b3-5d3c-9ab3-83052e963c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0a102-b31c-4cbd-894b-44b1c1e677d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0a102-b31c-4cbd-894b-44b1c1e677d2.jpg?1",
             "name": "Fighting Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "bc27e70f-f729-550d-989d-ab92952a9c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3782fd74-5d94-483d-8c9a-76febdd4d796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3782fd74-5d94-483d-8c9a-76febdd4d796.jpg?1",
             "name": "Fighting Drake",
             "text": "",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "1a7a0578-9c4e-5f60-9938-cd07b1764764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14e61f-481a-4bfa-aca0-fb63dc952be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14e61f-481a-4bfa-aca0-fb63dc952be6.jpg?1",
             "name": "Flash Counter",
             "text": "Counter target instant spell.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "0da78c1e-bd8c-5026-85b2-2edfb903247b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a1aa47-bc73-45c0-b818-cf7175195484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a1aa47-bc73-45c0-b818-cf7175195484.jpg?1",
             "name": "Flash Counter",
             "text": "",
             "colours": [
@@ -5605,7 +5605,7 @@
         },
         {
             "id": "69892c53-abc4-5c97-b91a-78ee7ee75758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c53ee6-9fe0-459e-903f-214a25a07634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c53ee6-9fe0-459e-903f-214a25a07634.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{U}: Return Fleeting Image to its owner's hand.",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "ea2c5824-eb6b-538c-bc4e-88b1e3976a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fd1567-e878-44ea-a6eb-a042e95e3bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fd1567-e878-44ea-a6eb-a042e95e3bb5.jpg?1",
             "name": "Fleeting Image",
             "text": "",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "39a26cd1-20d4-54dc-8bb0-e216d881e1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a7d379-3fb5-40eb-ba3c-7b51b7c5f57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a7d379-3fb5-40eb-ba3c-7b51b7c5f57e.jpg?1",
             "name": "Flight",
             "text": "Enchanted creature has flying. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -5710,7 +5710,7 @@
         },
         {
             "id": "13b0cda1-bfe3-52e2-87b0-cb76148177dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cb6bec-6640-4d7e-ac2f-cdcd4dc1a9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cb6bec-6640-4d7e-ac2f-cdcd4dc1a9f1.jpg?1",
             "name": "Flight",
             "text": "",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "85a348fd-a040-5e81-824b-756175d1420f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d745a5-1d5a-45ec-a662-c13cab70bfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d745a5-1d5a-45ec-a662-c13cab70bfcf.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "29183bb5-22a0-59a9-9e8d-497ce13c993d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc636b1-5fc5-422d-9722-5fa12c754d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc636b1-5fc5-422d-9722-5fa12c754d6c.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5817,7 +5817,7 @@
         },
         {
             "id": "03d9f613-a1ac-5932-b07f-370b66cdd411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33661f0-7dde-4b08-87da-1eeb723ddf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33661f0-7dde-4b08-87da-1eeb723ddf9f.jpg?1",
             "name": "Hibernation",
             "text": "Return all green permanents to their owners' hands.",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "28e17019-23fb-56f9-90f5-da510832d3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2fec63-0687-4e71-958e-31098c301e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2fec63-0687-4e71-958e-31098c301e24.jpg?1",
             "name": "Hibernation",
             "text": "",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "be0eac1e-58b0-5017-b443-e8039951fb86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3cb1a4-2552-4575-be8d-bef9d721cfc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3cb1a4-2552-4575-be8d-bef9d721cfc8.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5918,7 +5918,7 @@
         },
         {
             "id": "cba7f4b3-5f33-5f43-9d32-183fe3eb3b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69060684-8b35-4680-bbd2-994ff8fa2eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69060684-8b35-4680-bbd2-994ff8fa2eef.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "7b8dcd9c-89a8-5a72-9c61-e63c81df839e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64e0a7c-54a9-45b9-be46-ddf6755f1142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64e0a7c-54a9-45b9-be46-ddf6755f1142.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "b8da4aba-c415-559a-8ff2-0cf29b3a6d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645df9c5-3a0a-40b0-b898-7bcf28773366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645df9c5-3a0a-40b0-b898-7bcf28773366.jpg?1",
             "name": "Index",
             "text": "",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "538296ee-2fe7-5ebc-8023-184db280485f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be039716-30fc-4f84-8f84-6019065560e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be039716-30fc-4f84-8f84-6019065560e4.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "4c621024-222c-54be-aa31-5719d068d489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f806fa-11b7-43e1-a8dc-9a94a786f76b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f806fa-11b7-43e1-a8dc-9a94a786f76b.jpg?1",
             "name": "Inspiration",
             "text": "",
             "colours": [
@@ -6085,7 +6085,7 @@
         },
         {
             "id": "ae42016e-ff88-5685-aee8-d1a869818347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d62468e-ed9d-4932-bbbd-103b33b98b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d62468e-ed9d-4932-bbbd-103b33b98b25.jpg?1",
             "name": "Intruder Alarm",
             "text": "Creatures don't untap during their controllers' untap steps.\nWhenever a creature comes into play, untap all creatures.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "26488f6b-3bf8-58a3-aa69-443a134f625a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9ffa2e-ff31-4d42-a47e-ace1b1e68143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9ffa2e-ff31-4d42-a47e-ace1b1e68143.jpg?1",
             "name": "Intruder Alarm",
             "text": "",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "defca1fe-461d-52b5-9247-152d415f9c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d06b2b-9979-49b2-900f-795d1d5945e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d06b2b-9979-49b2-900f-795d1d5945e4.jpg?1",
             "name": "Invisibility",
             "text": "Enchanted creature can't be blocked except by Walls.",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "88bbf348-2556-5dd9-aed2-8568ad6f45f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e677860-dcee-444c-99fb-0c4ed99c1fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e677860-dcee-444c-99fb-0c4ed99c1fe0.jpg?1",
             "name": "Invisibility",
             "text": "",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "26069317-18be-58d0-a417-f058397f533e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c481454e-9544-4b8e-a1bc-d0bbc9fc64ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c481454e-9544-4b8e-a1bc-d0bbc9fc64ef.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "96ce8364-3915-514f-b37b-cc66ae445f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c863b128-0ae6-4811-895f-e4b2b7252714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c863b128-0ae6-4811-895f-e4b2b7252714.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "d5133565-3413-56a7-b38f-2fc0cbae160c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56707af4-eb74-4b33-8741-6cc9b547d919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56707af4-eb74-4b33-8741-6cc9b547d919.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "87d33f01-c5fa-58d7-9989-f817d370e3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0110d7-d3e8-4799-8368-a88b0beabd3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0110d7-d3e8-4799-8368-a88b0beabd3e.jpg?1",
             "name": "Mana Leak",
             "text": "",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "f93bf5cd-3cbb-5add-82c9-a67f73801eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e40516-99ec-45fb-be51-c8503fa4811e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e40516-99ec-45fb-be51-c8503fa4811e.jpg?1",
             "name": "Merchant of Secrets",
             "text": "When Merchant of Secrets comes into play, draw a card.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "10783989-ba88-5b0d-ac26-2cd9ed4f1b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98130e65-fe9e-4a48-a424-5855768e3cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98130e65-fe9e-4a48-a424-5855768e3cd2.jpg?1",
             "name": "Merchant of Secrets",
             "text": "",
             "colours": [
@@ -6429,7 +6429,7 @@
         },
         {
             "id": "9143c894-ecec-5b24-bb70-45050c3a0b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5385d2-ca5d-4fb9-934b-b7cc8b38ac89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5385d2-ca5d-4fb9-934b-b7cc8b38ac89.jpg?1",
             "name": "Merchant Scroll",
             "text": "Search your library for a blue instant card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "88c17866-f54e-52d7-b7a8-f9f511a49ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d32db5e-cf3f-40e9-88b2-e205fb185661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d32db5e-cf3f-40e9-88b2-e205fb185661.jpg?1",
             "name": "Merchant Scroll",
             "text": "",
             "colours": [
@@ -6495,7 +6495,7 @@
         },
         {
             "id": "a59a3519-0dc4-5aef-b83c-04603b46f7b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591db4b-8ce3-4842-bff3-a81e565b6bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591db4b-8ce3-4842-bff3-a81e565b6bf4.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"plainswalk.\" This effect doesn't end at end of turn.)",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "805da97e-cdf6-58ac-9b25-cc6f891eb067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d55cdde-5e6b-4cec-9862-84aa39c04082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d55cdde-5e6b-4cec-9862-84aa39c04082.jpg?1",
             "name": "Mind Bend",
             "text": "",
             "colours": [
@@ -6561,7 +6561,7 @@
         },
         {
             "id": "7304d518-b3ff-514c-aee3-757f038befa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef3f3aa-b54d-433f-9798-3b0fd1755094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef3f3aa-b54d-433f-9798-3b0fd1755094.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -6597,7 +6597,7 @@
         },
         {
             "id": "33a20fbc-0cf1-5f45-931f-224f554719d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700d79fa-9e6b-447e-9d64-af9666cc0b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700d79fa-9e6b-447e-9d64-af9666cc0b0b.jpg?1",
             "name": "Phantom Warrior",
             "text": "",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "bd88b81e-f1ac-563c-83d6-677d439dfc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeab5d7d-2f44-4372-8884-a5c847c92f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeab5d7d-2f44-4372-8884-a5c847c92f92.jpg?1",
             "name": "Puppeteer",
             "text": "{U}, {T}: Tap or untap target creature.",
             "colours": [
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "fce1386a-b467-5bab-becd-3ef810c1707f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451897d5-2600-4b92-87bd-8ff89d32febd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451897d5-2600-4b92-87bd-8ff89d32febd.jpg?1",
             "name": "Puppeteer",
             "text": "",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "4082061e-ac40-54c9-aa50-5b7b87ceba5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ff7228-3040-409e-865e-999bbb779f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ff7228-3040-409e-865e-999bbb779f19.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "3107ae4f-daac-5d10-ab50-c76124d0fd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d4289-d734-42d3-92c5-affdb21f719b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d4289-d734-42d3-92c5-affdb21f719b.jpg?1",
             "name": "Remove Soul",
             "text": "",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "e5dfdead-a4ad-5a46-9aef-814ef6075d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e92dcb1-f543-4d23-a96c-aed280077049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e92dcb1-f543-4d23-a96c-aed280077049.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell, then untap up to four lands.",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "1963a67b-d212-54e5-9522-316bee8435f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f87215-9278-4d1f-95b0-ffb3b1b1c896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f87215-9278-4d1f-95b0-ffb3b1b1c896.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -6837,7 +6837,7 @@
         },
         {
             "id": "8d5610bd-cc20-57d9-808f-2fe091319ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ac8823-9bc0-4d15-a7ab-0d106167a0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ac8823-9bc0-4d15-a7ab-0d106167a0e5.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "{T}, Sacrifice an artifact: Draw a card.",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "a45beb61-c447-5c90-93f9-466317adfb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ef926a-dabc-4120-8e91-6ebc5883d7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ef926a-dabc-4120-8e91-6ebc5883d7af.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "5258850b-8b2d-5fca-a5d3-066524218780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21f6c39-f879-452f-a643-f503d88206d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21f6c39-f879-452f-a643-f503d88206d6.jpg?1",
             "name": "Sage Owl",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Sage Owl comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "8f70843c-5ede-5844-9dba-4cf9c6c2688e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84531ce6-64cd-4d89-875b-7073f423dd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84531ce6-64cd-4d89-875b-7073f423dd41.jpg?1",
             "name": "Sage Owl",
             "text": "",
             "colours": [
@@ -6979,7 +6979,7 @@
         },
         {
             "id": "51ff21a2-e129-55c3-af03-988187d52110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5094b8-085f-4a68-81bf-b1a7ab423ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5094b8-085f-4a68-81bf-b1a7ab423ac4.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an Island.",
             "colours": [
@@ -7014,7 +7014,7 @@
         },
         {
             "id": "9863a6e5-412c-5e04-ad7c-3e44f04bfd61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ee578-1e36-4058-9ecf-ce488a4ef21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ee578-1e36-4058-9ecf-ce488a4ef21c.jpg?1",
             "name": "Sea Monster",
             "text": "",
             "colours": [
@@ -7049,7 +7049,7 @@
         },
         {
             "id": "8e726f51-901b-502b-8281-3967162f9027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed441d0-b8c8-4d63-80ff-cc4fb47d0b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed441d0-b8c8-4d63-80ff-cc4fb47d0b26.jpg?1",
             "name": "Shifting Sky",
             "text": "As Shifting Sky comes into play, choose a color.\nAll nonland permanents are the chosen color.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "dac0324d-fbdd-5dc1-b10b-825448913345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffece9-d4d4-4adb-a87c-8be464b9040f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffece9-d4d4-4adb-a87c-8be464b9040f.jpg?1",
             "name": "Shifting Sky",
             "text": "",
             "colours": [
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "2a43ebef-49e5-54df-9898-d8b0122beed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9020f16-4c26-4a7b-8b5c-1d8df3e910a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9020f16-4c26-4a7b-8b5c-1d8df3e910a9.jpg?1",
             "name": "Sneaky Homunculus",
             "text": "Sneaky Homunculus can't block or be blocked by creatures with power 2 or greater.",
             "colours": [
@@ -7151,7 +7151,7 @@
         },
         {
             "id": "145d5368-28e5-5d9e-88e4-888c062d4be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4e160-68e3-4ae1-999f-3553d73475ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f4e160-68e3-4ae1-999f-3553d73475ef.jpg?1",
             "name": "Sneaky Homunculus",
             "text": "",
             "colours": [
@@ -7187,7 +7187,7 @@
         },
         {
             "id": "cb9fb9da-2c1e-5192-a795-4cfbeade699d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca0925d-c1e8-438c-9d40-c57ad974ed5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca0925d-c1e8-438c-9d40-c57ad974ed5b.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nSacrifice Spiketail Hatchling: Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "ea1dcc74-eebe-5027-bf40-02dd043c21cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7bd303-272e-46c9-b495-dcc18cdd7fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7bd303-272e-46c9-b495-dcc18cdd7fa5.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "85f02f2b-2b27-5ed4-a3ea-9fdfd1d89232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810f874e-98e1-402b-b48e-14c3e2a624f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810f874e-98e1-402b-b48e-14c3e2a624f0.jpg?1",
             "name": "Steal Artifact",
             "text": "You control enchanted artifact.",
             "colours": [
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "0061b979-fcca-5485-a9f2-444e48ebe88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d238d-4084-4561-a19a-a3a6d0326071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0d238d-4084-4561-a19a-a3a6d0326071.jpg?1",
             "name": "Steal Artifact",
             "text": "",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "b535d9c2-add9-59ef-88a4-882826fd4ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6106d-6822-47b5-956e-20e17143a818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6106d-6822-47b5-956e-20e17143a818.jpg?1",
             "name": "Storm Crow",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "fc7e1deb-42ed-593a-b16d-f30eb295a891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5ae3a-e794-4af8-b4e4-d7724ebf30a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5ae3a-e794-4af8-b4e4-d7724ebf30a0.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "52c213fb-e6c7-5bfc-8035-507ae8d3275c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf72bddf-9006-4320-ab5f-6b3e5439d21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf72bddf-9006-4320-ab5f-6b3e5439d21c.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -7430,7 +7430,7 @@
         },
         {
             "id": "97426c64-e874-5dc2-b32c-0b4c54773fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01096c4-6722-40cd-a4dc-742243a346bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01096c4-6722-40cd-a4dc-742243a346bb.jpg?1",
             "name": "Telepathy",
             "text": "",
             "colours": [
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "a9f252c9-0aa5-5d90-9d05-0e685700de1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078e44c6-90bb-4294-9e0a-6194764af00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078e44c6-90bb-4294-9e0a-6194764af00c.jpg?1",
             "name": "Temporal Adept",
             "text": "{U}{U}{U}, {T}: Return target permanent to its owner's hand.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "8b29e069-13af-5318-ac37-d1d715dc5779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b3c184-0ebf-4dab-9433-d6db0a16ae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b3c184-0ebf-4dab-9433-d6db0a16ae8f.jpg?1",
             "name": "Temporal Adept",
             "text": "",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "51913a68-e417-503b-8108-7823284c940d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a1c44-4f2b-4277-935c-a337776c023a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a1c44-4f2b-4277-935c-a337776c023a.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "1aa36cdd-f1f1-52d4-908d-5f38d870d1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0931dc-c401-48e8-8ec2-19aa44cef58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0931dc-c401-48e8-8ec2-19aa44cef58c.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "8e9179b7-c860-597f-874b-374e89d36234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08147258-2319-49d5-bfb1-cc4f817d9c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08147258-2319-49d5-bfb1-cc4f817d9c72.jpg?1",
             "name": "Tidal Kraken",
             "text": "Tidal Kraken is unblockable.",
             "colours": [
@@ -7640,7 +7640,7 @@
         },
         {
             "id": "e9e7c5ca-5147-5c3a-82e9-4debb9c7b44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a82f2-0035-4501-b57e-9a4395d614f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a82f2-0035-4501-b57e-9a4395d614f9.jpg?1",
             "name": "Tidal Kraken",
             "text": "",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "689565a9-b5bc-5bfe-92d9-ab70de85c9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a23417-3419-4edc-a722-b695e676a3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a23417-3419-4edc-a722-b695e676a3ce.jpg?1",
             "name": "Trade Routes",
             "text": "{1}: Return target land you control to its owner's hand.\n{1}, Discard a land card from your hand: Draw a card.",
             "colours": [
@@ -7708,7 +7708,7 @@
         },
         {
             "id": "89a6e403-f541-52e7-a0c5-9d89f8c08d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f99f63-e0b4-48fe-8588-0531c5343a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f99f63-e0b4-48fe-8588-0531c5343a05.jpg?1",
             "name": "Trade Routes",
             "text": "",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "90d50a75-cfe8-5d03-a4b2-c32f33d9c694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f65e7a-be66-4a57-9e33-c1b02285f65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f65e7a-be66-4a57-9e33-c1b02285f65e.jpg?1",
             "name": "Treasure Trove",
             "text": "{2}{U}{U}: Draw a card.",
             "colours": [
@@ -7774,7 +7774,7 @@
         },
         {
             "id": "377cb12b-fd24-5ba5-98c6-bd4ac4707a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac22679-9cfc-47cf-bed6-945dbc0419b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac22679-9cfc-47cf-bed6-945dbc0419b2.jpg?1",
             "name": "Treasure Trove",
             "text": "",
             "colours": [
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "ceb0478b-0416-544e-9109-77a3168d8c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b25858a-ab2d-441a-a3fe-6d5ecd7f05be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b25858a-ab2d-441a-a3fe-6d5ecd7f05be.jpg?1",
             "name": "Twiddle",
             "text": "Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7840,7 +7840,7 @@
         },
         {
             "id": "3a180132-6665-5161-990d-1002658725ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1178a-75d4-471c-9445-4ad623ebe65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1178a-75d4-471c-9445-4ad623ebe65c.jpg?1",
             "name": "Twiddle",
             "text": "",
             "colours": [
@@ -7873,7 +7873,7 @@
         },
         {
             "id": "364f1e07-634b-5801-bf9d-374b05f6a9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb14889-2992-4d99-a6fe-1e245475c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb14889-2992-4d99-a6fe-1e245475c758.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -7906,7 +7906,7 @@
         },
         {
             "id": "c9584153-38cb-523f-be09-61fb96f9e081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5785fc-676f-46da-92f3-59b32fc99933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5785fc-676f-46da-92f3-59b32fc99933.jpg?1",
             "name": "Unsummon",
             "text": "",
             "colours": [
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "b3412502-a38e-52e9-a299-69a84c0151f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e4b04-19dd-42e6-9af4-4cc88a1bfcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e4b04-19dd-42e6-9af4-4cc88a1bfcb4.jpg?1",
             "name": "Wall of Air",
             "text": "(Walls can't attack.)\nFlying (This creature may block creatures with flying.)",
             "colours": [
@@ -7974,7 +7974,7 @@
         },
         {
             "id": "aa3bc5d6-1c11-5c9d-aced-8823ef604642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9b147-5bc1-4f92-bd3b-ac4aff2f0190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9b147-5bc1-4f92-bd3b-ac4aff2f0190.jpg?1",
             "name": "Wall of Air",
             "text": "",
             "colours": [
@@ -8009,7 +8009,7 @@
         },
         {
             "id": "2ff04b54-9a62-5fac-a881-a780739b00ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a57368-881f-4f1b-8fdd-09e76836227e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a57368-881f-4f1b-8fdd-09e76836227e.jpg?1",
             "name": "Wind Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8044,7 +8044,7 @@
         },
         {
             "id": "080f5ca6-4fae-5b4b-96a8-1ff260ac9b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ead9a78-bf5d-4088-85da-e456dd1d6cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ead9a78-bf5d-4088-85da-e456dd1d6cc5.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -8079,7 +8079,7 @@
         },
         {
             "id": "fb3233f4-67c8-5ebe-bf71-e75343f5a917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0111ef4-f0be-4af3-981f-aa19a17a3d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0111ef4-f0be-4af3-981f-aa19a17a3d7b.jpg?1",
             "name": "Wrath of Marit Lage",
             "text": "When Wrath of Marit Lage comes into play, tap all red creatures.\nRed creatures don't untap during their controllers' untap steps.",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "bef65bc4-028b-5296-9b6d-a3d0781ad93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190aadce-a309-48fd-a6b0-97f978d7b1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190aadce-a309-48fd-a6b0-97f978d7b1c4.jpg?1",
             "name": "Wrath of Marit Lage",
             "text": "",
             "colours": [
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "d244ce6a-4c7b-5490-873e-1e4a16775995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c87689-c6bf-4097-adb7-8839cac61609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c87689-c6bf-4097-adb7-8839cac61609.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws the card.",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "67da8d25-7978-5b07-9cb4-f0b106a1a467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7e041b-72bf-4314-9c5c-ffb12fcf6a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7e041b-72bf-4314-9c5c-ffb12fcf6a7e.jpg?1",
             "name": "Zur's Weirding",
             "text": "",
             "colours": [
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "fee01716-cd49-5773-bef7-bd0f912f2be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68672104-44da-491b-930e-a5ec5740f9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68672104-44da-491b-930e-a5ec5740f9a4.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Abyssal Specter deals damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "72ee0214-d914-5b29-b0eb-c3fac832a7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa54bc77-d2cd-4000-bc3f-74075b84d77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa54bc77-d2cd-4000-bc3f-74075b84d77f.jpg?1",
             "name": "Abyssal Specter",
             "text": "",
             "colours": [
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "ff6bb5e1-e9d8-5955-8d97-105193d1ec45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705692ad-763b-42aa-8524-21dc32df3f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705692ad-763b-42aa-8524-21dc32df3f10.jpg?1",
             "name": "Ambition's Cost",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "0482dfe5-c5a9-5112-8dd7-4ea2e905c697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0408be33-ad74-4e27-a722-e85302ba8055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0408be33-ad74-4e27-a722-e85302ba8055.jpg?1",
             "name": "Ambition's Cost",
             "text": "",
             "colours": [
@@ -8347,7 +8347,7 @@
         },
         {
             "id": "4b119450-4a23-5606-abfa-52bb648fd1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94903771-d0d0-49dd-b28a-438ef4bdf416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94903771-d0d0-49dd-b28a-438ef4bdf416.jpg?1",
             "name": "Bog Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "d22cb09f-12cd-5b07-9df8-4178527e94cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79073387-b835-4079-aa22-76c866488fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79073387-b835-4079-aa22-76c866488fbe.jpg?1",
             "name": "Bog Imp",
             "text": "",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "82160e1e-d1d9-52ca-8232-91738e2dd07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d65c4-f471-4e05-84fd-cb83393bee49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d65c4-f471-4e05-84fd-cb83393bee49.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "a0d64c0b-9688-5f10-bd1c-f06de4b4446e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad174e5-b415-431c-bb6f-581a19558d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad174e5-b415-431c-bb6f-581a19558d69.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "37589d14-6e1f-527c-a8b5-83945dac1f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea9d0e-9188-4447-a9c9-8ed209121b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea9d0e-9188-4447-a9c9-8ed209121b43.jpg?1",
             "name": "Carrion Wall",
             "text": "(Walls can't attack.)\n{1}{B}: Regenerate Carrion Wall.",
             "colours": [
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "08e8cb95-f508-5ad6-9f98-80aabfabff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf312cf-fd6a-49a3-8bf0-338bbabc3381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf312cf-fd6a-49a3-8bf0-338bbabc3381.jpg?1",
             "name": "Carrion Wall",
             "text": "",
             "colours": [
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "20af1bd9-6d33-540e-8811-9d19b20bb3a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2f5ec5-84ee-4334-9049-9922591622cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2f5ec5-84ee-4334-9049-9922591622cb.jpg?1",
             "name": "Carrion Wall",
             "text": "",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "1e5c21c2-0549-5c89-b8dd-5f89250319b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5ac075-1796-484e-97b9-ddd00433a40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5ac075-1796-484e-97b9-ddd00433a40c.jpg?1",
             "name": "Carrion Wall",
             "text": "",
             "colours": [
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "c7f49b1b-06e9-5dc4-a382-625e66a0978b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5017726b-f884-4c63-b738-1eb0aacb441d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5017726b-f884-4c63-b738-1eb0aacb441d.jpg?1",
             "name": "Coercion",
             "text": "Target opponent reveals his or her hand. Choose a card from it. That player discards that card.",
             "colours": [
@@ -8668,7 +8668,7 @@
         },
         {
             "id": "bebee1df-2f5c-532e-85e6-7a36cc3252be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8156f4e8-29f8-48f7-8f6b-e00fa5c5a4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8156f4e8-29f8-48f7-8f6b-e00fa5c5a4a9.jpg?1",
             "name": "Coercion",
             "text": "",
             "colours": [
@@ -8701,7 +8701,7 @@
         },
         {
             "id": "1863943d-d72e-503d-bab8-f6417b96fa22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42a59e-f916-48a7-8721-091ee47a6ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42a59e-f916-48a7-8721-091ee47a6ea1.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "355150af-ce2e-5f6d-b09d-2385739488ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fef21d3-c1c5-41a0-913b-6cab2409ac1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fef21d3-c1c5-41a0-913b-6cab2409ac1c.jpg?1",
             "name": "Dark Banishing",
             "text": "",
             "colours": [
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "ac45a546-15e4-5262-8cdf-c849e19c95b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6404e26-353a-478e-81db-03499be8e24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6404e26-353a-478e-81db-03499be8e24b.jpg?1",
             "name": "Death Pit Offering",
             "text": "When Death Pit Offering comes into play, sacrifice all creatures you control.\nCreatures you control get +2/+2.",
             "colours": [
@@ -8800,7 +8800,7 @@
         },
         {
             "id": "d35e963c-5389-517e-ad8f-4cc8a39d51f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4558bef2-2c41-41a3-b248-b2c816d332a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4558bef2-2c41-41a3-b248-b2c816d332a4.jpg?1",
             "name": "Death Pit Offering",
             "text": "",
             "colours": [
@@ -8833,7 +8833,7 @@
         },
         {
             "id": "f8451336-5b7b-57d6-9c75-d8ed0a37b91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3f1b6e-6177-4e14-a51a-a01a44e357b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3f1b6e-6177-4e14-a51a-a01a44e357b2.jpg?1",
             "name": "Death Pits of Rath",
             "text": "Whenever a creature is dealt damage, destroy it. It can't be regenerated.",
             "colours": [
@@ -8868,7 +8868,7 @@
         },
         {
             "id": "2b10462a-0a93-5dbe-95b0-0c4f7f43d43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13af256-c9bd-4c44-b5f7-60b8d8efba75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13af256-c9bd-4c44-b5f7-60b8d8efba75.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "b373cb88-1776-51df-b03d-97e19e46a972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c30cf13-4be5-4ffd-a790-9fe3f5f71374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c30cf13-4be5-4ffd-a790-9fe3f5f71374.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8938,7 +8938,7 @@
         },
         {
             "id": "41a5bdb1-8546-5733-9988-1425ba6e8ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c01d707-36b4-44c8-b91a-3b059e69aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c01d707-36b4-44c8-b91a-3b059e69aacb.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8973,7 +8973,7 @@
         },
         {
             "id": "347a9766-ef3d-5916-87af-20b00ebb5a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a4e022-a5d9-4798-8f04-39c6ce627761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a4e022-a5d9-4798-8f04-39c6ce627761.jpg?1",
             "name": "Deathgazer",
             "text": "Whenever Deathgazer blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -9008,7 +9008,7 @@
         },
         {
             "id": "5f958e7f-85ec-5640-89b5-278537d2a7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dcc58fb-0c13-449c-b3ae-d4e009ea11e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dcc58fb-0c13-449c-b3ae-d4e009ea11e4.jpg?1",
             "name": "Deathgazer",
             "text": "",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "8a192613-0181-586d-a421-6bc25f67a790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4c5c2f-0c1e-44e8-a7f8-2dc2954eacd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4c5c2f-0c1e-44e8-a7f8-2dc2954eacd8.jpg?1",
             "name": "Deepwood Ghoul",
             "text": "Pay 2 life: Regenerate Deepwood Ghoul.",
             "colours": [
@@ -9078,7 +9078,7 @@
         },
         {
             "id": "f3501a5b-2f85-5706-b139-62a26b085569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8ac7d-beca-4ac1-b9f1-3a5a29ca901e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8ac7d-beca-4ac1-b9f1-3a5a29ca901e.jpg?1",
             "name": "Deepwood Ghoul",
             "text": "",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "8fa77e4a-0a34-586a-98bf-7e4d9aa1ae8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7e0f9b-2c02-4e9a-ab86-270fad193de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7e0f9b-2c02-4e9a-ab86-270fad193de0.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "c668e67e-4fde-5eb7-96b5-52c01e8d2caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ff789a-ce9f-489a-8c17-6eea0c947672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ff789a-ce9f-489a-8c17-6eea0c947672.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "65619b96-4f0a-5ce0-8399-f719a440e225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fef91f-3044-4c6e-b090-c3819ee61b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fef91f-3044-4c6e-b090-c3819ee61b9c.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons.",
             "colours": [
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "bc71203d-f8d2-5b4c-ac41-45242326d622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c1119-c273-4051-9093-780b1fc144ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c1119-c273-4051-9093-780b1fc144ad.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "8400ccf4-ad80-52ef-a58f-b9aebfc5bd44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf9c1bd-bbda-4b4f-8b72-c73d24018c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf9c1bd-bbda-4b4f-8b72-c73d24018c7a.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "d1b66230-5b20-51b6-af86-2ce4ae0d3a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7aa7d-0d68-4b53-981f-1505f0dab055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7aa7d-0d68-4b53-981f-1505f0dab055.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "bce3457c-5349-5cca-8644-11393af17c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0721a-dc1f-42e4-a12a-2ecb356f9339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0721a-dc1f-42e4-a12a-2ecb356f9339.jpg?1",
             "name": "Dusk Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "44745a7a-a961-5828-89cd-45f5c3d6056d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ad4029-6b87-4bf1-a221-1720cd85bea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ad4029-6b87-4bf1-a221-1720cd85bea0.jpg?1",
             "name": "Dusk Imp",
             "text": "",
             "colours": [
@@ -9397,7 +9397,7 @@
         },
         {
             "id": "6092cc73-31d0-53f5-b5fe-41c003419e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f7d29-9c73-4b5e-a6fd-5608bb737278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f7d29-9c73-4b5e-a6fd-5608bb737278.jpg?1",
             "name": "Eastern Paladin",
             "text": "{B}{B}, {T}: Destroy target green creature.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "73fcd1d2-a94a-50e7-8bec-623af0d06e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a3f4e-ceb9-43aa-9491-a5219a8744d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692a3f4e-ceb9-43aa-9491-a5219a8744d3.jpg?1",
             "name": "Eastern Paladin",
             "text": "",
             "colours": [
@@ -9471,7 +9471,7 @@
         },
         {
             "id": "1df8fab1-2771-5356-b0a8-9ac2094e827b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ecbc8-767b-475c-bb74-2abc0da5d745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ecbc8-767b-475c-bb74-2abc0da5d745.jpg?1",
             "name": "Execute",
             "text": "Destroy target white creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "de35097f-8946-535a-a9fe-f12a42404528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e73d4-7e1c-48fd-8b6d-b66a2105a742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e73d4-7e1c-48fd-8b6d-b66a2105a742.jpg?1",
             "name": "Execute",
             "text": "",
             "colours": [
@@ -9537,7 +9537,7 @@
         },
         {
             "id": "12617181-75fb-5adf-9e20-e1bc392d86fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c574bf0-0fad-4cde-a75e-88d899a890ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c574bf0-0fad-4cde-a75e-88d899a890ee.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -9572,7 +9572,7 @@
         },
         {
             "id": "e3b13925-ff13-58e9-a311-c4e8da1830ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e4aa36-cf55-4c7c-94c3-337a3da10bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e4aa36-cf55-4c7c-94c3-337a3da10bb3.jpg?1",
             "name": "Fallen Angel",
             "text": "",
             "colours": [
@@ -9607,7 +9607,7 @@
         },
         {
             "id": "6abbfade-db22-51c5-bc21-dad7e68fde91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18630f0-29de-4437-9c69-5f61b6f6fda5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18630f0-29de-4437-9c69-5f61b6f6fda5.jpg?1",
             "name": "Fear",
             "text": "Enchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9642,7 +9642,7 @@
         },
         {
             "id": "c9ed8bb9-ba92-5242-a6a7-f158cdcc17c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e5ccd6-8b39-4bbf-b2a1-901a6058498f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e5ccd6-8b39-4bbf-b2a1-901a6058498f.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -9677,7 +9677,7 @@
         },
         {
             "id": "0d73fa6f-f730-551d-a15a-09b4b1857f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b79ee0-0a1b-474c-b68c-6e4ec69c018c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b79ee0-0a1b-474c-b68c-6e4ec69c018c.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "610eda2b-adf4-5b0f-95b2-6daf3abb655d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2c5ede-4110-41c8-87f1-6552c1743223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2c5ede-4110-41c8-87f1-6552c1743223.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "9e629aaf-aa6c-5f2b-b6e9-99a80d8832c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4730915e-db5a-4a66-b570-aeaaa7c4ca3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4730915e-db5a-4a66-b570-aeaaa7c4ca3d.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "74580ec6-0bcf-554b-92f4-14cf3b55af0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce06092-a69c-4e4b-a8e7-b07b63f0d22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce06092-a69c-4e4b-a8e7-b07b63f0d22c.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "",
             "colours": [
@@ -9817,7 +9817,7 @@
         },
         {
             "id": "12772d61-645b-5a52-85bb-21775a99353e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87fe9b8-3dae-4b22-bceb-be48cd082921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87fe9b8-3dae-4b22-bceb-be48cd082921.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control is put into a graveyard from play, each other player sacrifices a creature.",
             "colours": [
@@ -9850,7 +9850,7 @@
         },
         {
             "id": "05196746-a8bb-5a5b-ad5d-d77173fe0235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655a654b-87e8-41af-b9db-54afee485946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655a654b-87e8-41af-b9db-54afee485946.jpg?1",
             "name": "Grave Pact",
             "text": "",
             "colours": [
@@ -9883,7 +9883,7 @@
         },
         {
             "id": "61af508f-8cc1-536e-bcec-93e95d4309fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679472e-39a5-4a28-a04e-962c393fbcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679472e-39a5-4a28-a04e-962c393fbcc4.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9918,7 +9918,7 @@
         },
         {
             "id": "bec4f032-a627-5ca2-bbd7-5804027073e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdf87dd-6a29-4312-9fd0-5493d65a5856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdf87dd-6a29-4312-9fd0-5493d65a5856.jpg?1",
             "name": "Gravedigger",
             "text": "",
             "colours": [
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "e3ef6198-c6cf-5976-a4cb-8b750c52d69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3eddb-cd89-4cec-92b4-4006dece36a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3eddb-cd89-4cec-92b4-4006dece36a8.jpg?1",
             "name": "Larceny",
             "text": "Whenever a creature you control deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "8ac9f35a-b63c-510b-8302-1b964b49b3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7c8012-1adf-4af7-88aa-09c1c608687f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7c8012-1adf-4af7-88aa-09c1c608687f.jpg?1",
             "name": "Larceny",
             "text": "",
             "colours": [
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "744c173f-9d20-5829-90d3-9318e578a75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf28d4-939c-495a-a6eb-e4f52a62e150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf28d4-939c-495a-a6eb-e4f52a62e150.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10054,7 +10054,7 @@
         },
         {
             "id": "97c8c9dc-d6ca-558c-9a37-c1ddbad45d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b500c957-0ca0-4f68-a046-74dedf960368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b500c957-0ca0-4f68-a046-74dedf960368.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "1d439ffa-c186-5df4-9888-c45502f6073c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d4b539-0e45-49ca-96fa-5df1ccb3b235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d4b539-0e45-49ca-96fa-5df1ccb3b235.jpg?1",
             "name": "Lord of the Undead",
             "text": "All Zombies get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -10124,7 +10124,7 @@
         },
         {
             "id": "ea810e66-baf0-54ba-9b8b-63d2d5c8074d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb669a-0475-44f1-9563-f877e577a07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb669a-0475-44f1-9563-f877e577a07a.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "d880727c-b545-5fe1-a142-38eb2f19a4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2ee72e-68d3-46b9-abc6-08532ce412b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2ee72e-68d3-46b9-abc6-08532ce412b2.jpg?1",
             "name": "Maggot Carrier",
             "text": "When Maggot Carrier comes into play, each player loses 1 life.",
             "colours": [
@@ -10194,7 +10194,7 @@
         },
         {
             "id": "a02edc5b-5eeb-5a49-bbf2-d3518082b715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa250a2-f3e2-42b0-aea0-7816f60f4d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa250a2-f3e2-42b0-aea0-7816f60f4d1d.jpg?1",
             "name": "Maggot Carrier",
             "text": "",
             "colours": [
@@ -10229,7 +10229,7 @@
         },
         {
             "id": "e980294c-3354-5499-9082-b3bc1792b862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d8a020-fa68-4db6-bbe8-671bff043e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d8a020-fa68-4db6-bbe8-671bff043e06.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card from his or her hand, Megrim deals 2 damage to that player.",
             "colours": [
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "e6c28b71-0ebd-5535-b0bd-18a702b0d9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d6f7d-ced6-414d-89d0-792975548cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d6f7d-ced6-414d-89d0-792975548cb7.jpg?1",
             "name": "Megrim",
             "text": "",
             "colours": [
@@ -10295,7 +10295,7 @@
         },
         {
             "id": "6d55a521-b18a-58ff-a31e-1d8a79e1dc36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b780692-9c74-4283-a1ca-63f991dcc2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b780692-9c74-4283-a1ca-63f991dcc2c3.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards from his or her hand.",
             "colours": [
@@ -10328,7 +10328,7 @@
         },
         {
             "id": "c999c2e5-06d4-5ac8-916e-73fe93cb12df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77bf706-ec76-429a-b103-35b7cb445a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77bf706-ec76-429a-b103-35b7cb445a62.jpg?1",
             "name": "Mind Rot",
             "text": "",
             "colours": [
@@ -10361,7 +10361,7 @@
         },
         {
             "id": "b614070c-0125-5dca-900a-446ad984c21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76da89df-edb9-482c-a3bb-e7cf650990cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76da89df-edb9-482c-a3bb-e7cf650990cc.jpg?1",
             "name": "Mind Slash",
             "text": "{B}, Sacrifice a creature: Target opponent reveals his or her hand. Choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -10394,7 +10394,7 @@
         },
         {
             "id": "ec1ccc56-f25e-5122-bbb3-925828e70c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf2d72-9661-4a6e-82cb-b2b2aabd3e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf2d72-9661-4a6e-82cb-b2b2aabd3e9c.jpg?1",
             "name": "Mind Slash",
             "text": "",
             "colours": [
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "1f1b2358-cd32-5d11-bdf3-d7351eca64b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86a26e9-e4cb-452a-9263-489d57233d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86a26e9-e4cb-452a-9263-489d57233d41.jpg?1",
             "name": "Mind Sludge",
             "text": "Target player discards a card from his or her hand for each Swamp you control.",
             "colours": [
@@ -10460,7 +10460,7 @@
         },
         {
             "id": "61c6803c-e2fc-5762-9c81-d0816b8cad28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd44da9-0f97-45f4-8f51-606af042549d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd44da9-0f97-45f4-8f51-606af042549d.jpg?1",
             "name": "Mind Sludge",
             "text": "",
             "colours": [
@@ -10493,7 +10493,7 @@
         },
         {
             "id": "24e21135-9288-5899-86d3-5340561bd4e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063ed19-494b-4199-9120-d479bfcb625a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063ed19-494b-4199-9120-d479bfcb625a.jpg?1",
             "name": "Murderous Betrayal",
             "text": "{B}{B}, Pay half your life rounded up: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -10526,7 +10526,7 @@
         },
         {
             "id": "f0a728b1-51fe-59de-b0be-41f8fdfaee23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a02af31-de74-4721-84b6-410ecced5fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a02af31-de74-4721-84b6-410ecced5fa8.jpg?1",
             "name": "Murderous Betrayal",
             "text": "",
             "colours": [
@@ -10559,7 +10559,7 @@
         },
         {
             "id": "d2143b22-d2cd-5e7b-9cce-06ede30e453f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358efb1e-0366-4943-9a25-6a356e48773c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358efb1e-0366-4943-9a25-6a356e48773c.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -10592,7 +10592,7 @@
         },
         {
             "id": "2a84f4b3-3c1e-55a8-b92b-b654cfbe961d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699bdf95-7202-48ee-a9c8-be34e77b4028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699bdf95-7202-48ee-a9c8-be34e77b4028.jpg?1",
             "name": "Nausea",
             "text": "",
             "colours": [
@@ -10625,7 +10625,7 @@
         },
         {
             "id": "f3c53ead-2f9b-5b45-92e8-689aaf03b8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0d60f-0824-4498-81da-2c65980e3f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0d60f-0824-4498-81da-2c65980e3f98.jpg?1",
             "name": "Nekrataal",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Nekrataal comes into play, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "420878e6-61f7-5953-a0ce-7cd142946a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d195ba-9e07-43b1-b49b-b5706cd14bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d195ba-9e07-43b1-b49b-b5706cd14bc5.jpg?1",
             "name": "Nekrataal",
             "text": "",
             "colours": [
@@ -10697,7 +10697,7 @@
         },
         {
             "id": "8e686f41-6493-561e-a0c9-e859e118db73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd088c4d-3e21-4979-b30f-4ec98a6c81df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd088c4d-3e21-4979-b30f-4ec98a6c81df.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -10733,7 +10733,7 @@
         },
         {
             "id": "101f243c-8c3b-5870-8fd1-deb4f44c00cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c79db0-731a-4aa5-b69f-f21e031815d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c79db0-731a-4aa5-b69f-f21e031815d4.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -10769,7 +10769,7 @@
         },
         {
             "id": "bafb3960-e71a-56a5-8330-18cdbfda63ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c39fda-9a33-4464-99b0-4dbbf5eb7e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c39fda-9a33-4464-99b0-4dbbf5eb7e2a.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Target player reveals his or her hand and discards all cards of that color from it.",
             "colours": [
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "1f1fbe61-6448-591e-86cb-d8a5a9e72c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a01c43-0c2f-4f47-a8c3-a3be83120ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a01c43-0c2f-4f47-a8c3-a3be83120ee1.jpg?1",
             "name": "Persecute",
             "text": "",
             "colours": [
@@ -10835,7 +10835,7 @@
         },
         {
             "id": "c37e6414-a26c-5c63-86ab-f7b436d10429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1cc51f-91bc-4c0a-8fee-84eef1479cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1cc51f-91bc-4c0a-8fee-84eef1479cd8.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life. (Your upkeep step is after you untap and before you draw.)",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "6d03e966-8912-558e-b729-3e759b082522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd89d691-fa7d-41d8-b21a-95749f5268cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd89d691-fa7d-41d8-b21a-95749f5268cf.jpg?1",
             "name": "Phyrexian Arena",
             "text": "",
             "colours": [
@@ -10901,7 +10901,7 @@
         },
         {
             "id": "08c6ad5a-1f57-5e85-8850-d371b38957be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284f9e91-9318-44d9-995b-8c00752a3b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284f9e91-9318-44d9-995b-8c00752a3b01.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "{T}, Sacrifice Phyrexian Plaguelord: Target creature gets -4/-4 until end of turn.\nSacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "20dc276a-cd1c-5dc4-a681-5c2a18867760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3e2495-f8c9-4fcf-9a25-7cb591b06752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3e2495-f8c9-4fcf-9a25-7cb591b06752.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "c5a3d86b-d03b-50e3-b2ff-f4cbf0a70631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1476320-efed-433c-adad-cda2d2a3997f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1476320-efed-433c-adad-cda2d2a3997f.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -11008,7 +11008,7 @@
         },
         {
             "id": "8f21b579-cf67-5e61-8f3d-f31bb16bf6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c651140-4407-49a4-b46d-ccdaebf76706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c651140-4407-49a4-b46d-ccdaebf76706.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -11043,7 +11043,7 @@
         },
         {
             "id": "c1411478-7542-5aab-a020-d1b48d14fb23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056be80b-54df-4a9e-8ccb-1e576a001d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056be80b-54df-4a9e-8ccb-1e576a001d7c.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -11076,7 +11076,7 @@
         },
         {
             "id": "d0b8655c-2bb2-51a7-b92a-249f02d02df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdc23b-5dea-423f-9d62-75d30edbcc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdc23b-5dea-423f-9d62-75d30edbcc23.jpg?1",
             "name": "Plague Wind",
             "text": "",
             "colours": [
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "24161e9f-37d4-52ca-8560-0d53f1c3a9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45931d2-3fbf-4509-aa41-13d7839578df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45931d2-3fbf-4509-aa41-13d7839578df.jpg?1",
             "name": "Primeval Shambler",
             "text": "{B}: Primeval Shambler gets +1/+1 until end of turn.",
             "colours": [
@@ -11145,7 +11145,7 @@
         },
         {
             "id": "19e5738d-81ec-524f-835e-63932cf46bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e061c1-cdfe-4c0c-9043-3976f2a6b561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e061c1-cdfe-4c0c-9043-3976f2a6b561.jpg?1",
             "name": "Primeval Shambler",
             "text": "",
             "colours": [
@@ -11181,7 +11181,7 @@
         },
         {
             "id": "e5eaf617-eb62-5982-a300-3eb7d14a1952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc29ec6b-555e-4472-8bd4-d7e898edabce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc29ec6b-555e-4472-8bd4-d7e898edabce.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "930e5242-c78a-5930-983c-f8ed44cb1181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0ceb70-e680-45b1-b168-d014ee25da8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0ceb70-e680-45b1-b168-d014ee25da8a.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -11247,7 +11247,7 @@
         },
         {
             "id": "98e532de-c3ef-52ea-927f-1d49ddb97c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0ece8-2598-40d4-a222-27e3b34c01a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0ece8-2598-40d4-a222-27e3b34c01a1.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card from his or her hand.",
             "colours": [
@@ -11282,7 +11282,7 @@
         },
         {
             "id": "996f6041-988e-56ce-a56e-900f5f4bdbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c971b-60f6-4757-bdb3-d43102f57f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c971b-60f6-4757-bdb3-d43102f57f3f.jpg?1",
             "name": "Ravenous Rats",
             "text": "",
             "colours": [
@@ -11317,7 +11317,7 @@
         },
         {
             "id": "027b35ca-813a-56cf-8a68-36fa735faa21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed8b7de-a72f-429f-a99c-438af59de19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed8b7de-a72f-429f-a99c-438af59de19e.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11353,7 +11353,7 @@
         },
         {
             "id": "d5c664f5-ccd0-523f-9374-0fef3275e8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb382c6-d027-4875-bc36-dc9631ba3c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb382c6-d027-4875-bc36-dc9631ba3c0a.jpg?1",
             "name": "Royal Assassin",
             "text": "",
             "colours": [
@@ -11389,7 +11389,7 @@
         },
         {
             "id": "bd75aa7f-b4f8-5b17-8c60-2b38fa957aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd1dae-ccad-4f05-b720-b4b8600a298b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd1dae-ccad-4f05-b720-b4b8600a298b.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11424,7 +11424,7 @@
         },
         {
             "id": "714c2a56-100c-5325-bd8e-9f1d7eb136ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26fc06-04c0-4e8a-a25d-ef4e85d847f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26fc06-04c0-4e8a-a25d-ef4e85d847f7.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11459,7 +11459,7 @@
         },
         {
             "id": "6a781c43-673c-5063-8141-3955e7df6918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf5fb1-391c-472a-8b06-503162e458d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf5fb1-391c-472a-8b06-503162e458d7.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, you lose 3 life.",
             "colours": [
@@ -11495,7 +11495,7 @@
         },
         {
             "id": "6b080a48-6b3a-555d-948a-8836b7c20a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249a548-0d1e-4965-8767-7e386203231c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249a548-0d1e-4965-8767-7e386203231c.jpg?1",
             "name": "Serpent Warrior",
             "text": "",
             "colours": [
@@ -11531,7 +11531,7 @@
         },
         {
             "id": "589687d7-79ff-5e79-9212-734b0a36b823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1cb775-3a45-4f2c-9c45-febda6434c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1cb775-3a45-4f2c-9c45-febda6434c59.jpg?1",
             "name": "Sever Soul",
             "text": "Destroy target nonblack creature. It can't be regenerated. You gain life equal to its toughness.",
             "colours": [
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "6d6a9e78-4edd-5c74-97d6-1f9130edac14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c25ea3-1f01-4dcd-9d2d-d7fb85712110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c25ea3-1f01-4dcd-9d2d-d7fb85712110.jpg?1",
             "name": "Sever Soul",
             "text": "",
             "colours": [
@@ -11597,7 +11597,7 @@
         },
         {
             "id": "a8adaf87-51d6-5e41-a7cc-2fb3fe137e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710a3e43-a56a-4a41-86b3-72d48d324bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710a3e43-a56a-4a41-86b3-72d48d324bf3.jpg?1",
             "name": "Severed Legion",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -11632,7 +11632,7 @@
         },
         {
             "id": "72676823-a499-5bde-a950-407ccdef5143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa369ce1-8440-48c0-96af-cda0e63ae1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa369ce1-8440-48c0-96af-cda0e63ae1e3.jpg?1",
             "name": "Severed Legion",
             "text": "",
             "colours": [
@@ -11667,7 +11667,7 @@
         },
         {
             "id": "3f281daa-6769-57d9-a224-f43ce20d98c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5a03c-8b5b-496e-81bf-0d6e36960907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5a03c-8b5b-496e-81bf-0d6e36960907.jpg?1",
             "name": "Slay",
             "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -11700,7 +11700,7 @@
         },
         {
             "id": "29884087-2b32-5722-93b3-a9753cb92e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b01f4-fa93-4aaf-9ea0-9a0a5f9e9783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b01f4-fa93-4aaf-9ea0-9a0a5f9e9783.jpg?1",
             "name": "Slay",
             "text": "",
             "colours": [
@@ -11733,7 +11733,7 @@
         },
         {
             "id": "0b3b0043-c820-5116-b70c-edbbd788891e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b341b3-88d3-4ddc-8fa8-b15596b1b475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b341b3-88d3-4ddc-8fa8-b15596b1b475.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -11766,7 +11766,7 @@
         },
         {
             "id": "407f6878-2ea8-5302-baa3-e533e7b1bdea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b144df1-ae8f-49d0-926c-0d2dfd53310b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b144df1-ae8f-49d0-926c-0d2dfd53310b.jpg?1",
             "name": "Soul Feast",
             "text": "",
             "colours": [
@@ -11799,7 +11799,7 @@
         },
         {
             "id": "4a0588f0-f90d-5b51-8b40-8957253777ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711dfcd8-3083-4876-ac3f-1f7c6924382a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711dfcd8-3083-4876-ac3f-1f7c6924382a.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -11836,7 +11836,7 @@
         },
         {
             "id": "5ad31076-f31a-5594-a8c5-c8887e12666f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf974056-2f7a-4b2c-8b39-a371a322037b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf974056-2f7a-4b2c-8b39-a371a322037b.jpg?1",
             "name": "Spineless Thug",
             "text": "",
             "colours": [
@@ -11873,7 +11873,7 @@
         },
         {
             "id": "d6472d57-e9b1-589d-ac87-7ee22ec5a15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2690a627-23c5-46a4-b508-a5bc6ecc08d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2690a627-23c5-46a4-b508-a5bc6ecc08d7.jpg?1",
             "name": "Swarm of Rats",
             "text": "Swarm of Rats's power is equal to the number of Rats you control.",
             "colours": [
@@ -11908,7 +11908,7 @@
         },
         {
             "id": "16b81bf6-835a-5bdd-8171-33a213f93fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6b7304-6b3f-4c1c-a936-d1a1e0ec21f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6b7304-6b3f-4c1c-a936-d1a1e0ec21f0.jpg?1",
             "name": "Swarm of Rats",
             "text": "",
             "colours": [
@@ -11943,7 +11943,7 @@
         },
         {
             "id": "1783edf1-8268-51db-9284-f43d41bf803f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda4c410-c19c-435d-bbb4-2448ea3eeb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda4c410-c19c-435d-bbb4-2448ea3eeb21.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -11976,7 +11976,7 @@
         },
         {
             "id": "7a793ec7-25c1-54ed-bc45-f5d6014b2c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f89e0-a577-4bd1-8cdf-9572896e6a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f89e0-a577-4bd1-8cdf-9572896e6a3d.jpg?1",
             "name": "Underworld Dreams",
             "text": "",
             "colours": [
@@ -12009,7 +12009,7 @@
         },
         {
             "id": "33538118-b109-5ecb-93cb-1ee5f964cc4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd14a78-d306-43b1-b824-e04c96ce9155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd14a78-d306-43b1-b824-e04c96ce9155.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchanted creature gets +2/+1.",
             "colours": [
@@ -12044,7 +12044,7 @@
         },
         {
             "id": "d43b1838-e3ee-5ad1-bfe7-441540e70d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f630bb-4880-4d19-8211-a035c4b38575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f630bb-4880-4d19-8211-a035c4b38575.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -12079,7 +12079,7 @@
         },
         {
             "id": "c056b8c6-3ada-51b8-af8f-aac2f1fa2b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5235e5-deb7-49eb-82a8-858d3ee7c91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5235e5-deb7-49eb-82a8-858d3ee7c91b.jpg?1",
             "name": "Vampiric Spirit",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Vampiric Spirit comes into play, you lose 4 life.",
             "colours": [
@@ -12114,7 +12114,7 @@
         },
         {
             "id": "da2c1120-a490-53d6-9af0-fc7cbac3cc06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4934546-a53c-41ee-98be-6bb6d9df1071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4934546-a53c-41ee-98be-6bb6d9df1071.jpg?1",
             "name": "Vampiric Spirit",
             "text": "",
             "colours": [
@@ -12149,7 +12149,7 @@
         },
         {
             "id": "56fefa97-dc6e-5a47-b999-e577f7ac8e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf7cf9e-cb8d-49ae-af5b-0da7f283e677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf7cf9e-cb8d-49ae-af5b-0da7f283e677.jpg?1",
             "name": "Vicious Hunger",
             "text": "Vicious Hunger deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -12182,7 +12182,7 @@
         },
         {
             "id": "bfa687e4-8ed1-54db-b68f-dbc8fb8794f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203c511-c149-4f37-ab89-7862a0cc7fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203c511-c149-4f37-ab89-7862a0cc7fa0.jpg?1",
             "name": "Vicious Hunger",
             "text": "",
             "colours": [
@@ -12215,7 +12215,7 @@
         },
         {
             "id": "c21e3947-024f-562d-94f3-02daa3338301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd41ebd-91a8-4972-8f93-3306e68519f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd41ebd-91a8-4972-8f93-3306e68519f9.jpg?1",
             "name": "Warped Devotion",
             "text": "Whenever a permanent is returned to a player's hand, that player discards a card from his or her hand.",
             "colours": [
@@ -12248,7 +12248,7 @@
         },
         {
             "id": "fc6683df-78ac-5636-be11-2e1f41e5091c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d889f-daba-494d-8e91-aa5c6e361f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d889f-daba-494d-8e91-aa5c6e361f3f.jpg?1",
             "name": "Warped Devotion",
             "text": "",
             "colours": [
@@ -12281,7 +12281,7 @@
         },
         {
             "id": "ae578b17-88b0-59af-89f4-bc4cd6732e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f829763-3dce-453f-a783-177ea085ee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f829763-3dce-453f-a783-177ea085ee01.jpg?1",
             "name": "Western Paladin",
             "text": "{B}{B}, {T}: Destroy target white creature.",
             "colours": [
@@ -12318,7 +12318,7 @@
         },
         {
             "id": "386e8533-09ef-5af9-a759-21221bf64204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015832d1-eed5-4b7c-98aa-8a985f733ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015832d1-eed5-4b7c-98aa-8a985f733ecb.jpg?1",
             "name": "Western Paladin",
             "text": "",
             "colours": [
@@ -12355,7 +12355,7 @@
         },
         {
             "id": "0d77168f-272a-5753-952c-a4294f1ee66a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed70fa9-b0ff-4874-ab81-75cd2f39cad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed70fa9-b0ff-4874-ab81-75cd2f39cad3.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -12388,7 +12388,7 @@
         },
         {
             "id": "b86b1746-f876-5f64-9d5b-05de2a29dbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f808f8-904d-48c3-a111-43425ab1b774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f808f8-904d-48c3-a111-43425ab1b774.jpg?1",
             "name": "Zombify",
             "text": "",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "2050d60c-5cc7-5c11-8a38-d270846a4803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c2a5d1-cdf0-4551-aad0-c6590fb3c018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c2a5d1-cdf0-4551-aad0-c6590fb3c018.jpg?1",
             "name": "Anaba Shaman",
             "text": "{R}, {T}: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -12457,7 +12457,7 @@
         },
         {
             "id": "dd9d287f-f544-5217-a401-9cf2c9d570cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142260bd-4e4f-4057-b124-4744cea698d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142260bd-4e4f-4057-b124-4744cea698d7.jpg?1",
             "name": "Anaba Shaman",
             "text": "",
             "colours": [
@@ -12493,7 +12493,7 @@
         },
         {
             "id": "74ef6c88-8717-53e5-b805-bcc6847283d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46092f3f-7ef9-4967-b47b-40747a8cf37d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46092f3f-7ef9-4967-b47b-40747a8cf37d.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12529,7 +12529,7 @@
         },
         {
             "id": "9b67a7a4-0360-540d-b3b1-b4406e5a69ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e1d65-c95d-4400-99a4-9aea1745e489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e1d65-c95d-4400-99a4-9aea1745e489.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12565,7 +12565,7 @@
         },
         {
             "id": "61101fe8-cd71-5562-8f95-2236634522ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de4525e-6c9d-4396-9280-6fed9802123a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de4525e-6c9d-4396-9280-6fed9802123a.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -12598,7 +12598,7 @@
         },
         {
             "id": "042e8ba3-3bb3-5b39-860b-193d2c873a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c16f310-a492-4cea-86d2-b0ba5df9891b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c16f310-a492-4cea-86d2-b0ba5df9891b.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "d5e20783-c30f-57d5-bbac-b2f297ed1698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d75a5e3-4bec-4c2c-a9ad-f894cde292fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d75a5e3-4bec-4c2c-a9ad-f894cde292fd.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -12664,7 +12664,7 @@
         },
         {
             "id": "c203a28d-5e6f-561a-91ff-c817187de495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf2de3-77ff-4dd6-882f-b8bebabb2374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf2de3-77ff-4dd6-882f-b8bebabb2374.jpg?1",
             "name": "Blood Moon",
             "text": "",
             "colours": [
@@ -12697,7 +12697,7 @@
         },
         {
             "id": "eda8364c-ea94-5303-b473-03bf98bb51cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b021f1ea-4db1-40fb-a5dc-af13be53ad15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b021f1ea-4db1-40fb-a5dc-af13be53ad15.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "{T}, Sacrifice a creature: Bloodshot Cyclops deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -12733,7 +12733,7 @@
         },
         {
             "id": "1de7eb80-648e-5860-8240-1cd94f8981d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a2cc8b-4244-46ba-bf58-c2005c3678e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a2cc8b-4244-46ba-bf58-c2005c3678e8.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "",
             "colours": [
@@ -12769,7 +12769,7 @@
         },
         {
             "id": "5f5757dc-f4e3-5ba1-bd44-9a0493c34ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0087c-4e0f-4547-b441-b5a517c00b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0087c-4e0f-4547-b441-b5a517c00b91.jpg?1",
             "name": "Boil",
             "text": "Destroy all Islands.",
             "colours": [
@@ -12802,7 +12802,7 @@
         },
         {
             "id": "714234db-493b-5fee-a437-c544333d9feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23ce7c-9b25-4858-8b59-643892ab0406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23ce7c-9b25-4858-8b59-643892ab0406.jpg?1",
             "name": "Boil",
             "text": "",
             "colours": [
@@ -12835,7 +12835,7 @@
         },
         {
             "id": "d52849d8-4547-539b-9ebc-980041e9c3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a761bfc-71dc-40be-8184-6e0be2f25d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a761bfc-71dc-40be-8184-6e0be2f25d07.jpg?1",
             "name": "Canyon Wildcat",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -12870,7 +12870,7 @@
         },
         {
             "id": "b0712c9f-a5d2-526f-b290-7718f48acde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acfd70-b866-44c8-862d-f66e28fb61bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acfd70-b866-44c8-862d-f66e28fb61bf.jpg?1",
             "name": "Canyon Wildcat",
             "text": "",
             "colours": [
@@ -12905,7 +12905,7 @@
         },
         {
             "id": "d0527d8b-afb4-5c39-919c-a703781bb536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654472-b9b7-48aa-98d3-611807cf6d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654472-b9b7-48aa-98d3-611807cf6d88.jpg?1",
             "name": "Cinder Wall",
             "text": "(Walls can't attack.)\nWhen Cinder Wall blocks, destroy it at end of combat.",
             "colours": [
@@ -12940,7 +12940,7 @@
         },
         {
             "id": "2f2eb43e-c490-59c0-9115-16d2f446bdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1aa661-e00f-4d53-adcc-717e26dc97be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1aa661-e00f-4d53-adcc-717e26dc97be.jpg?1",
             "name": "Cinder Wall",
             "text": "",
             "colours": [
@@ -12975,7 +12975,7 @@
         },
         {
             "id": "96d2c937-4149-5b18-be00-eef938df442c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09770e0-24c0-4842-b31b-61e746ed89d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09770e0-24c0-4842-b31b-61e746ed89d7.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -13008,7 +13008,7 @@
         },
         {
             "id": "3e38fcf7-dffe-5740-8245-aef48d2e7728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3248d216-24dc-4e1b-ac35-af2809259e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3248d216-24dc-4e1b-ac35-af2809259e27.jpg?1",
             "name": "Demolish",
             "text": "",
             "colours": [
@@ -13041,7 +13041,7 @@
         },
         {
             "id": "d0dc61d1-5e6e-55f8-9801-539a2bad0290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d17787-1f59-4e88-ba57-e69f02bb3ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d17787-1f59-4e88-ba57-e69f02bb3ffe.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "{T}: Destroy target Wall.",
             "colours": [
@@ -13076,7 +13076,7 @@
         },
         {
             "id": "1452240b-46bd-5b8c-8738-0fda1ad5c4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f154b0-0ff2-4238-83d6-c336c5625f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f154b0-0ff2-4238-83d6-c336c5625f27.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "",
             "colours": [
@@ -13111,7 +13111,7 @@
         },
         {
             "id": "4b1125a2-a6f9-5861-8092-dda22088ae9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1e6973-003a-4f3e-b793-2e59519b1b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1e6973-003a-4f3e-b793-2e59519b1b8c.jpg?1",
             "name": "Enrage",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -13144,7 +13144,7 @@
         },
         {
             "id": "2a76f7e3-2e78-5e0e-a1b4-7f321fbebd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a415934-9e8c-456a-9fa9-e46d81d997f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a415934-9e8c-456a-9fa9-e46d81d997f0.jpg?1",
             "name": "Enrage",
             "text": "",
             "colours": [
@@ -13177,7 +13177,7 @@
         },
         {
             "id": "0f0720f1-f61a-54a5-bcbf-81e336bc0a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827a2e80-68ef-4d13-ba89-a5ea33d70cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827a2e80-68ef-4d13-ba89-a5ea33d70cc4.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all Plains.",
             "colours": [
@@ -13210,7 +13210,7 @@
         },
         {
             "id": "87c65771-a310-5897-a1a1-496c867b72e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaf72c-8a3a-42fd-811d-25a5cd753da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaf72c-8a3a-42fd-811d-25a5cd753da0.jpg?1",
             "name": "Flashfires",
             "text": "",
             "colours": [
@@ -13243,7 +13243,7 @@
         },
         {
             "id": "f6b5899f-46af-5b8b-9230-49303ddf0c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b41e1a5-cd40-493a-af70-6820e92b2673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b41e1a5-cd40-493a-af70-6820e92b2673.jpg?1",
             "name": "Furnace of Rath",
             "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -13276,7 +13276,7 @@
         },
         {
             "id": "666dc2a8-24e7-565b-8d42-dc20671dc40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089d0d6e-f5fd-4c44-a2d0-b9e4670c4b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089d0d6e-f5fd-4c44-a2d0-b9e4670c4b66.jpg?1",
             "name": "Furnace of Rath",
             "text": "",
             "colours": [
@@ -13309,7 +13309,7 @@
         },
         {
             "id": "4787f38b-2c3f-57df-8631-954dc96817bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6590436-d0f9-4c50-bab4-f7a094aa6e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6590436-d0f9-4c50-bab4-f7a094aa6e1a.jpg?1",
             "name": "Goblin Chariot",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -13345,7 +13345,7 @@
         },
         {
             "id": "2a2041c3-e751-559e-ab9f-af2d488d64c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e3d7fc-0a31-4119-bac1-5ddc1b0aafe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e3d7fc-0a31-4119-bac1-5ddc1b0aafe5.jpg?1",
             "name": "Goblin Chariot",
             "text": "",
             "colours": [
@@ -13381,7 +13381,7 @@
         },
         {
             "id": "d02834db-3e8e-5a56-b570-c67c2bc86988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db30ff-5f50-41b1-acdf-0a0e1a364410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db30ff-5f50-41b1-acdf-0a0e1a364410.jpg?1",
             "name": "Goblin Glider",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nGoblin Glider can't block.",
             "colours": [
@@ -13416,7 +13416,7 @@
         },
         {
             "id": "d60687c5-6c21-5980-8d42-b24baf7707f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d24d46-25b6-422a-af9f-e389ba4ec397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d24d46-25b6-422a-af9f-e389ba4ec397.jpg?1",
             "name": "Goblin Glider",
             "text": "",
             "colours": [
@@ -13451,7 +13451,7 @@
         },
         {
             "id": "cb5b435f-d561-55cc-862d-c2082ad96eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5448159-0516-4f35-a212-c3e1efa84c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5448159-0516-4f35-a212-c3e1efa84c71.jpg?1",
             "name": "Goblin King",
             "text": "All Goblins get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -13486,7 +13486,7 @@
         },
         {
             "id": "d29f31ab-7032-5f9b-b218-0062b31db6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c9eaf-022c-4803-acd1-b312af6c9277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c9eaf-022c-4803-acd1-b312af6c9277.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -13521,7 +13521,7 @@
         },
         {
             "id": "bd9dc052-cb03-5282-84d4-e6aa49424005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0837dd6a-d413-40a4-a684-ec637a4f3d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0837dd6a-d413-40a4-a684-ec637a4f3d4a.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "55747639-8c17-55aa-a230-6139152c729d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d34c5-2a25-4b2c-80b2-1205d0580fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d34c5-2a25-4b2c-80b2-1205d0580fcc.jpg?1",
             "name": "Goblin Raider",
             "text": "",
             "colours": [
@@ -13593,7 +13593,7 @@
         },
         {
             "id": "610788ad-34f1-5659-aa44-3a37e68c0ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63535f0e-dc14-420e-bcb7-b5ef8fafb93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63535f0e-dc14-420e-bcb7-b5ef8fafb93f.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nWhen a spell or ability an opponent controls causes you to discard Guerrilla Tactics from your hand, Guerrilla Tactics deals 4 damage to target creature or player.",
             "colours": [
@@ -13626,7 +13626,7 @@
         },
         {
             "id": "56827ed2-61e8-5218-974a-78fd424191dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81348b40-0fc5-4aeb-b8fa-30eaa2d528f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81348b40-0fc5-4aeb-b8fa-30eaa2d528f9.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "",
             "colours": [
@@ -13659,7 +13659,7 @@
         },
         {
             "id": "96a7573a-9a6c-5fe7-9231-5be133896fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf6e6c0-ddea-4d15-ab1a-5c7d9fa69d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf6e6c0-ddea-4d15-ab1a-5c7d9fa69d51.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "Hammer of Bogardan deals 3 damage to target creature or player.\n{2}{R}{R}{R}: Return Hammer of Bogardan from your graveyard to your hand. Play this ability only during your upkeep. (Your upkeep step is after you untap and before you draw.)",
             "colours": [
@@ -13692,7 +13692,7 @@
         },
         {
             "id": "7272a096-6690-5131-be2e-8cb964fa493c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff985e4-915a-4790-a3a7-4013c2b7c3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff985e4-915a-4790-a3a7-4013c2b7c3a5.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "3e92291b-1713-5743-a6b8-5ace45fde148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3afb143-fd69-4197-96f4-62d5d90a894c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3afb143-fd69-4197-96f4-62d5d90a894c.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13760,7 +13760,7 @@
         },
         {
             "id": "cd0dd1ea-f5b9-58e8-bab4-b4a12df78dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833128ae-927e-4767-8937-19d4ef789a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833128ae-927e-4767-8937-19d4ef789a58.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13795,7 +13795,7 @@
         },
         {
             "id": "639579bd-9032-5f3a-8a70-d6d543edd8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1a5428-9bb4-4e2b-ba94-fccd321ce537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1a5428-9bb4-4e2b-ba94-fccd321ce537.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops can't block.",
             "colours": [
@@ -13830,7 +13830,7 @@
         },
         {
             "id": "44799782-0b42-535e-8d07-e713ce5e3b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e402d-cdde-43fd-9899-2ea5d04d29b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664e402d-cdde-43fd-9899-2ea5d04d29b7.jpg?1",
             "name": "Hulking Cyclops",
             "text": "",
             "colours": [
@@ -13865,7 +13865,7 @@
         },
         {
             "id": "34e92ab4-409d-542e-a55a-f0000e523c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6895de-9c74-49a0-a71c-1e55a6897dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6895de-9c74-49a0-a71c-1e55a6897dfa.jpg?1",
             "name": "Inferno",
             "text": "Inferno deals 6 damage to each creature and each player.",
             "colours": [
@@ -13898,7 +13898,7 @@
         },
         {
             "id": "98f86f82-c495-5d1f-964a-4f717050823b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98644803-d626-436e-a86f-457005a30da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98644803-d626-436e-a86f-457005a30da9.jpg?1",
             "name": "Inferno",
             "text": "",
             "colours": [
@@ -13931,7 +13931,7 @@
         },
         {
             "id": "10e8247f-9a37-5782-8f05-fab70b81d241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddcf8a1-7337-41e9-b3b1-013f23b92eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddcf8a1-7337-41e9-b3b1-013f23b92eb0.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "ac1337bb-aadb-5ada-9772-80940d374eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83376e9-f3ac-4548-a4de-d471c158b1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83376e9-f3ac-4548-a4de-d471c158b1f0.jpg?1",
             "name": "Lava Axe",
             "text": "",
             "colours": [
@@ -13997,7 +13997,7 @@
         },
         {
             "id": "bde21cc3-60b5-5aa9-b7f5-22d568b89a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf83d5c7-a17c-4350-9432-92a01421b39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf83d5c7-a17c-4350-9432-92a01421b39a.jpg?1",
             "name": "Lava Hounds",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nWhen Lava Hounds comes into play, it deals 4 damage to you.",
             "colours": [
@@ -14032,7 +14032,7 @@
         },
         {
             "id": "33cad935-f412-5aaa-83dd-92350e8c7164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2010739e-005c-4a26-b744-03b9072792a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2010739e-005c-4a26-b744-03b9072792a4.jpg?1",
             "name": "Lava Hounds",
             "text": "",
             "colours": [
@@ -14067,7 +14067,7 @@
         },
         {
             "id": "b5d0d7d3-3e0e-5a00-82e1-57b8cac09735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a1067-8dff-485a-8781-39d61585c521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a1067-8dff-485a-8781-39d61585c521.jpg?1",
             "name": "Lesser Gargadon",
             "text": "Whenever Lesser Gargadon attacks or blocks, sacrifice a land.",
             "colours": [
@@ -14102,7 +14102,7 @@
         },
         {
             "id": "969e7dd8-70f9-531e-8c6e-e90b4020520a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7329366-a32e-40a8-a438-b92336231ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7329366-a32e-40a8-a438-b92336231ce0.jpg?1",
             "name": "Lesser Gargadon",
             "text": "",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "4685e3dd-97cc-5cbc-9346-57b3606bd2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20fee0e-93b8-4dc0-b156-8237271ae66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20fee0e-93b8-4dc0-b156-8237271ae66c.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -14170,7 +14170,7 @@
         },
         {
             "id": "c0dd11c0-7dab-5d72-9e90-9db408c95f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419e447f-dc16-4b01-b701-145c75e6047c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419e447f-dc16-4b01-b701-145c75e6047c.jpg?1",
             "name": "Lightning Blast",
             "text": "",
             "colours": [
@@ -14203,7 +14203,7 @@
         },
         {
             "id": "3e9178f1-a2a7-5a83-8d96-67d950d0773d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf2252-5ead-47df-8150-06c81dc47584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf2252-5ead-47df-8150-06c81dc47584.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "b1b0061c-049a-50be-b27d-1b1eb29b8fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4902b4c-4842-45aa-a165-cef86afdd795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4902b4c-4842-45aa-a165-cef86afdd795.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -14273,7 +14273,7 @@
         },
         {
             "id": "fe5fad8c-8bfe-5cdc-9694-b79bebb3297d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1042a84-4550-4ff3-933e-a9c2d26d1bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1042a84-4550-4ff3-933e-a9c2d26d1bd3.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
             "colours": [
@@ -14306,7 +14306,7 @@
         },
         {
             "id": "75b0d036-3b52-567b-9f14-f3a0b12ad3d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a54ce6-d1a7-4c25-8210-3dbd98c46460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a54ce6-d1a7-4c25-8210-3dbd98c46460.jpg?1",
             "name": "Mana Clash",
             "text": "",
             "colours": [
@@ -14339,7 +14339,7 @@
         },
         {
             "id": "6c43cf92-f1b3-5a1a-b768-46cda9eeb395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e98c12-b5b3-4b0f-af4e-7f2d28dc8637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e98c12-b5b3-4b0f-af4e-7f2d28dc8637.jpg?1",
             "name": "Mogg Sentry",
             "text": "Whenever an opponent plays a spell, Mogg Sentry gets +2/+2 until end of turn.",
             "colours": [
@@ -14375,7 +14375,7 @@
         },
         {
             "id": "5076cebd-83f0-5058-b57c-08bc9e5e9367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d54f2-8a3c-4d9a-be05-bbb45cc88e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d54f2-8a3c-4d9a-be05-bbb45cc88e3b.jpg?1",
             "name": "Mogg Sentry",
             "text": "",
             "colours": [
@@ -14411,7 +14411,7 @@
         },
         {
             "id": "975c2a8b-c29f-5dbc-8c3d-fb4edf8b1931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85f9623-5900-473c-a3b1-f98473b9a545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85f9623-5900-473c-a3b1-f98473b9a545.jpg?1",
             "name": "Obliterate",
             "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "442daa4e-18d4-5ea5-90e6-1bcce35fe49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1021bcbd-566c-4f31-b148-0517b96a63db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1021bcbd-566c-4f31-b148-0517b96a63db.jpg?1",
             "name": "Obliterate",
             "text": "",
             "colours": [
@@ -14477,7 +14477,7 @@
         },
         {
             "id": "331318cf-7132-5ca7-8e5d-6382d28dd180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1765dee9-ab94-4ca5-9cd7-cf8e228fdd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1765dee9-ab94-4ca5-9cd7-cf8e228fdd68.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "11d3cd10-554d-5354-b7bf-1f97f96a60c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c31b9d-903c-4b37-9d61-3c2fb49ee1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c31b9d-903c-4b37-9d61-3c2fb49ee1c2.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "",
             "colours": [
@@ -14547,7 +14547,7 @@
         },
         {
             "id": "42492f04-f176-5aad-9589-9ae0666527c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42641800-e209-4326-ae28-77ec83ac4b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42641800-e209-4326-ae28-77ec83ac4b75.jpg?1",
             "name": "Okk",
             "text": "Okk can't attack unless a creature with greater power also attacks.\nOkk can't block unless a creature with greater power also blocks.",
             "colours": [
@@ -14582,7 +14582,7 @@
         },
         {
             "id": "135bb565-b66e-5112-a164-7632e4a78f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737c35a-3f90-4ed6-bce5-5761879c2185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737c35a-3f90-4ed6-bce5-5761879c2185.jpg?1",
             "name": "Okk",
             "text": "",
             "colours": [
@@ -14617,7 +14617,7 @@
         },
         {
             "id": "56d9f9f0-2aa5-5857-86ef-161eb2c95b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d114ae-f574-45dd-903b-7d46d1121294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d114ae-f574-45dd-903b-7d46d1121294.jpg?1",
             "name": "Orcish Artillery",
             "text": "{T}: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -14653,7 +14653,7 @@
         },
         {
             "id": "851afd13-c902-5218-9650-720969940ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096e808-64a3-43b7-8555-28576fc574c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096e808-64a3-43b7-8555-28576fc574c1.jpg?1",
             "name": "Orcish Artillery",
             "text": "",
             "colours": [
@@ -14689,7 +14689,7 @@
         },
         {
             "id": "b0300477-5a9c-5860-ba72-3c1ebb63fc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3948e0-8597-4927-90ce-affa949e3013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3948e0-8597-4927-90ce-affa949e3013.jpg?1",
             "name": "Orcish Spy",
             "text": "{T}: Look at the top three cards of target player's library. (Put them back in the same order.)",
             "colours": [
@@ -14725,7 +14725,7 @@
         },
         {
             "id": "015b3367-32b0-5c99-8bf6-54ef622deecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab96aa0-8df8-461b-8f7e-5932748b2f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab96aa0-8df8-461b-8f7e-5932748b2f2a.jpg?1",
             "name": "Orcish Spy",
             "text": "",
             "colours": [
@@ -14761,7 +14761,7 @@
         },
         {
             "id": "7b732f3a-6904-56db-9b45-a6a111df4026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b65b86b-a346-4b86-bca4-83dae3f14c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b65b86b-a346-4b86-bca4-83dae3f14c1b.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -14794,7 +14794,7 @@
         },
         {
             "id": "9b83fd03-d3cb-509c-bf1d-7030d702f293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f599bb-d545-4bec-a7ef-daec69524c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f599bb-d545-4bec-a7ef-daec69524c62.jpg?1",
             "name": "Panic Attack",
             "text": "",
             "colours": [
@@ -14827,7 +14827,7 @@
         },
         {
             "id": "af6f8a52-8e3d-54c6-87cd-5d76f563b492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec6e8f-a8be-4efe-8082-d807378066b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec6e8f-a8be-4efe-8082-d807378066b1.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -14860,7 +14860,7 @@
         },
         {
             "id": "9fba626c-a83f-595e-981c-dab948183fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc79823f-7ae1-4c22-9c11-8c729eea6c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc79823f-7ae1-4c22-9c11-8c729eea6c4f.jpg?1",
             "name": "Pyroclasm",
             "text": "",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "320cc2d3-657c-5184-87d9-ca569602c401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabea8c3-630f-4b19-8d1e-47998b39866f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabea8c3-630f-4b19-8d1e-47998b39866f.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -14926,7 +14926,7 @@
         },
         {
             "id": "842cde7e-154f-5950-9675-93f6edcf70f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447231d2-31b3-4e4c-bc2e-ab97203ab205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447231d2-31b3-4e4c-bc2e-ab97203ab205.jpg?1",
             "name": "Pyrotechnics",
             "text": "",
             "colours": [
@@ -14959,7 +14959,7 @@
         },
         {
             "id": "ca14cead-4e84-56ba-9107-dfe2e5cb55b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165dc9fc-22b3-48ac-b446-5599af75917e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165dc9fc-22b3-48ac-b446-5599af75917e.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "8b9fc22d-4964-5a2a-ab7e-e832d01e499c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646c62b6-1dec-4ecd-acf0-8833c9c7f265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646c62b6-1dec-4ecd-acf0-8833c9c7f265.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -15031,7 +15031,7 @@
         },
         {
             "id": "dd9a2cbd-a429-51be-b8d0-a9b3b65b8d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a406184-b678-4afd-9599-d1d4f9c1d147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a406184-b678-4afd-9599-d1d4f9c1d147.jpg?1",
             "name": "Reflexes",
             "text": "Enchanted creature has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -15066,7 +15066,7 @@
         },
         {
             "id": "4576fc83-a1a7-5dbf-92ab-d0dfe58e2165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880dd2cd-fb7f-4398-afb6-08587130fb7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880dd2cd-fb7f-4398-afb6-08587130fb7a.jpg?1",
             "name": "Reflexes",
             "text": "",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "189cbd4a-d448-526d-95c2-71a0bea89230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e23c4c-f1f3-417c-a430-957e246a98ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e23c4c-f1f3-417c-a430-957e246a98ec.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -15134,7 +15134,7 @@
         },
         {
             "id": "b23ed661-542b-5130-9769-80e74192fce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58edf9f7-8e6a-49de-a2c0-b2ba8a8493f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58edf9f7-8e6a-49de-a2c0-b2ba8a8493f5.jpg?1",
             "name": "Relentless Assault",
             "text": "",
             "colours": [
@@ -15167,7 +15167,7 @@
         },
         {
             "id": "79daf872-b5ad-5dc2-b210-bbc60c13d28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d9c248-2360-4fdc-9a0f-49d350c11e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d9c248-2360-4fdc-9a0f-49d350c11e95.jpg?1",
             "name": "Ridgeline Rager",
             "text": "{R}: Ridgeline Rager gets +1/+0 until end of turn.",
             "colours": [
@@ -15202,7 +15202,7 @@
         },
         {
             "id": "2aec9fb7-399d-5eeb-8093-4d98013493b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b58c329-bd50-4b7c-80c8-77eaf0b40a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b58c329-bd50-4b7c-80c8-77eaf0b40a20.jpg?1",
             "name": "Ridgeline Rager",
             "text": "",
             "colours": [
@@ -15237,7 +15237,7 @@
         },
         {
             "id": "075809e2-9009-52de-b3bb-f00d8a83d543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805f1f4-ac45-404d-b52c-4d5eb019e24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805f1f4-ac45-404d-b52c-4d5eb019e24a.jpg?1",
             "name": "Rukh Egg",
             "text": "When Rukh Egg is put into a graveyard from play, put a 4/4 red Rukh creature token with flying into play at end of turn.",
             "colours": [
@@ -15273,7 +15273,7 @@
         },
         {
             "id": "f92a53f8-48ab-58b9-9268-e9efd55bbf40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2fbef-a340-4c08-9c77-a157948cacdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2fbef-a340-4c08-9c77-a157948cacdf.jpg?1",
             "name": "Rukh Egg",
             "text": "",
             "colours": [
@@ -15309,7 +15309,7 @@
         },
         {
             "id": "0acff7d5-929e-53ae-b62c-929879110b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85964eb-c586-4e62-9a19-6a665e6ad98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85964eb-c586-4e62-9a19-6a665e6ad98d.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -15344,7 +15344,7 @@
         },
         {
             "id": "e0dbc60b-e5a2-5dbd-8abe-c9150930a5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda983ca-3439-4eab-a2a3-ba8a69e1116e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda983ca-3439-4eab-a2a3-ba8a69e1116e.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "",
             "colours": [
@@ -15379,7 +15379,7 @@
         },
         {
             "id": "19aa2efc-43d6-5f7d-9308-b83c5e16e0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61afd3c5-7103-4247-8bb9-747532ae4265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61afd3c5-7103-4247-8bb9-747532ae4265.jpg?1",
             "name": "Searing Wind",
             "text": "Searing Wind deals 10 damage to target creature or player.",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "774e9fbd-e2d3-5872-ae0a-e56fd3a38ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037b513-a733-4184-91f4-5e5848120dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037b513-a733-4184-91f4-5e5848120dd6.jpg?1",
             "name": "Searing Wind",
             "text": "",
             "colours": [
@@ -15445,7 +15445,7 @@
         },
         {
             "id": "868ba23a-06fa-524a-b24c-a10c2e2a39e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91464144-afb8-4fff-bf5c-2d9bfca408ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91464144-afb8-4fff-bf5c-2d9bfca408ca.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card from your hand: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -15478,7 +15478,7 @@
         },
         {
             "id": "9dc469c5-d01f-55fe-9d5e-130d9e129b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261ab03-6e00-41b8-a863-2b72d1ffbb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261ab03-6e00-41b8-a863-2b72d1ffbb9a.jpg?1",
             "name": "Seismic Assault",
             "text": "",
             "colours": [
@@ -15511,7 +15511,7 @@
         },
         {
             "id": "e8c34d79-b4e0-5335-8e2c-401250a5f2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818401a7-593d-4f04-a782-9fa486b8c2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818401a7-593d-4f04-a782-9fa486b8c2f6.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -15544,7 +15544,7 @@
         },
         {
             "id": "18cbab56-a7fc-5a14-870f-4323ac0ee7b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7333d1-ecc6-4f7e-80f3-4a3f3dcfe374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7333d1-ecc6-4f7e-80f3-4a3f3dcfe374.jpg?1",
             "name": "Shatter",
             "text": "",
             "colours": [
@@ -15577,7 +15577,7 @@
         },
         {
             "id": "e488cdcd-dd89-5604-ad02-7429ec387eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac007d-1616-449c-92d5-1d321235e733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac007d-1616-449c-92d5-1d321235e733.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -15612,7 +15612,7 @@
         },
         {
             "id": "3c6d1c33-3107-57b8-9af6-e7a7091f9171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08a0542-f72a-422d-a8cf-3d37fdb5d375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08a0542-f72a-422d-a8cf-3d37fdb5d375.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -15647,7 +15647,7 @@
         },
         {
             "id": "1b9c897b-892b-5d33-8068-07b2c4527613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daef5f10-ccb5-4304-b04f-b52a7d2f4158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daef5f10-ccb5-4304-b04f-b52a7d2f4158.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -15680,7 +15680,7 @@
         },
         {
             "id": "3e363d59-e7ff-5f55-8cd9-5029ab6f797e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f568875-9ccb-487f-8977-cce816bb3a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f568875-9ccb-487f-8977-cce816bb3a28.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -15713,7 +15713,7 @@
         },
         {
             "id": "324d046e-0244-59b3-bf5c-8c90b4a4bd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fe44af-5d8f-44ee-b767-2267917cf4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fe44af-5d8f-44ee-b767-2267917cf4bf.jpg?1",
             "name": "Shock Troops",
             "text": "Sacrifice Shock Troops: Shock Troops deals 2 damage to target creature or player.",
             "colours": [
@@ -15749,7 +15749,7 @@
         },
         {
             "id": "abca2a5e-769a-5e99-a75a-6cbde062a6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c749a38c-8c58-4fdf-903d-6e05eb993858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c749a38c-8c58-4fdf-903d-6e05eb993858.jpg?1",
             "name": "Shock Troops",
             "text": "",
             "colours": [
@@ -15785,7 +15785,7 @@
         },
         {
             "id": "74f81e08-a8d1-5d27-8086-520a328ea6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfe2a9-1323-4f15-b2ce-d8dd404b914d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfe2a9-1323-4f15-b2ce-d8dd404b914d.jpg?1",
             "name": "Sizzle",
             "text": "Sizzle deals 3 damage to each opponent.",
             "colours": [
@@ -15818,7 +15818,7 @@
         },
         {
             "id": "03b6c50d-85d2-5046-bf52-4bc0e2f6ac53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d39efe8-9676-4e82-8e5e-0ed2f4bcbcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d39efe8-9676-4e82-8e5e-0ed2f4bcbcac.jpg?1",
             "name": "Sizzle",
             "text": "",
             "colours": [
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "8b338d79-c1b9-5534-ba5d-090af3896416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bf7f43-c8db-417e-8600-3124f5fab097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bf7f43-c8db-417e-8600-3124f5fab097.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -15884,7 +15884,7 @@
         },
         {
             "id": "c015a4f5-d61d-51c0-95cd-44e6cf965f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266d561f-b161-4a0f-952f-cce631b54962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266d561f-b161-4a0f-952f-cce631b54962.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -15917,7 +15917,7 @@
         },
         {
             "id": "eaf52524-c51e-5836-90b9-c295c506e895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe1060-3069-46b7-9a84-916d87b30e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe1060-3069-46b7-9a84-916d87b30e6e.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -15950,7 +15950,7 @@
         },
         {
             "id": "59f60c7d-598d-5ae4-99e3-b462f292c462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58bee47e-cd0f-422a-855d-325fa49879a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58bee47e-cd0f-422a-855d-325fa49879a7.jpg?1",
             "name": "Sudden Impact",
             "text": "",
             "colours": [
@@ -15983,7 +15983,7 @@
         },
         {
             "id": "d920e87a-9935-5cbf-b8ab-6d9fc1b42d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8ad32-a701-4b77-bb7e-0e440e4072da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8ad32-a701-4b77-bb7e-0e440e4072da.jpg?1",
             "name": "Thieves' Auction",
             "text": "Set aside all cards in play. Starting with you, each player chooses one of the cards set aside and puts it into play tapped under his or her control. Repeat this process until all those cards have been chosen.",
             "colours": [
@@ -16016,7 +16016,7 @@
         },
         {
             "id": "f721ecdd-b88f-5cc8-a271-694f442eadb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7c571-ef39-4b99-b5e0-01c145672053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7c571-ef39-4b99-b5e0-01c145672053.jpg?1",
             "name": "Thieves' Auction",
             "text": "",
             "colours": [
@@ -16049,7 +16049,7 @@
         },
         {
             "id": "88f17190-244e-5079-ac0a-6454704304d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47f27d-5a25-4d2a-b2a2-027b579b881b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47f27d-5a25-4d2a-b2a2-027b579b881b.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -16082,7 +16082,7 @@
         },
         {
             "id": "915e499a-0e2f-54cf-8e5b-e274c209e2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fef4049-8ec2-49c0-8a0a-1b057c558695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fef4049-8ec2-49c0-8a0a-1b057c558695.jpg?1",
             "name": "Tremor",
             "text": "",
             "colours": [
@@ -16115,7 +16115,7 @@
         },
         {
             "id": "ba962a93-2444-52ad-a909-dffaf3cf3547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe7c1b5-6077-4b6c-a26b-8201f49dad10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe7c1b5-6077-4b6c-a26b-8201f49dad10.jpg?1",
             "name": "Two-Headed Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{R}: Two-Headed Dragon gets +2/+0 until end of turn.\nTwo-Headed Dragon can't be blocked except by two or more creatures.\nTwo-Headed Dragon may block an additional creature.",
             "colours": [
@@ -16150,7 +16150,7 @@
         },
         {
             "id": "3bfae294-16cb-5984-840d-a6d9039624aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105068c1-a5e5-4248-82b6-a521ba1e5205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105068c1-a5e5-4248-82b6-a521ba1e5205.jpg?1",
             "name": "Two-Headed Dragon",
             "text": "",
             "colours": [
@@ -16185,7 +16185,7 @@
         },
         {
             "id": "ed2a09fa-0fd7-565f-b93e-c3d11dcac0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e80de4-1d8f-4a4a-8108-5d3c36dce07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e80de4-1d8f-4a4a-8108-5d3c36dce07b.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nAt end of turn, return Viashino Sandstalker to its owner's hand. (Return it only if it's in play.)",
             "colours": [
@@ -16221,7 +16221,7 @@
         },
         {
             "id": "c99e54c8-20c8-5b52-8703-3fc13fa3abb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14230e3a-2088-4ebc-bf09-4b438ee894ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14230e3a-2088-4ebc-bf09-4b438ee894ed.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "",
             "colours": [
@@ -16257,7 +16257,7 @@
         },
         {
             "id": "78530e0c-9fcc-5700-bb9f-fc5640571fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c47e6a-71d8-4eba-ad05-0e6745f81600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c47e6a-71d8-4eba-ad05-0e6745f81600.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to target creature or player.",
             "colours": [
@@ -16290,7 +16290,7 @@
         },
         {
             "id": "4c2ae22b-6247-541c-9dc6-be3c62e456f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d539abc6-d00a-4969-ae0f-feb189b90428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d539abc6-d00a-4969-ae0f-feb189b90428.jpg?1",
             "name": "Volcanic Hammer",
             "text": "",
             "colours": [
@@ -16323,7 +16323,7 @@
         },
         {
             "id": "6a98dcae-27d4-5593-adff-db94e42770ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718da336-ad97-41a6-86bd-4f124e2cc716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718da336-ad97-41a6-86bd-4f124e2cc716.jpg?1",
             "name": "Wall of Stone",
             "text": "(Walls can't attack.)",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "bcf7037d-e6a5-5b3a-a8c3-5cbc9bf45cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ccff-aa99-43d5-a5f7-877bc285e6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17ccff-aa99-43d5-a5f7-877bc285e6b3.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -16393,7 +16393,7 @@
         },
         {
             "id": "01812e4a-2749-5fd6-92cc-77036c897192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715eea77-a7d7-4731-b706-3ea17bded7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715eea77-a7d7-4731-b706-3ea17bded7fd.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -16428,7 +16428,7 @@
         },
         {
             "id": "a19ff013-8746-56b0-be68-f8acab247dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b2fa1-9f0c-44cc-9d4a-692ffe7d603c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870b2fa1-9f0c-44cc-9d4a-692ffe7d603c.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -16463,7 +16463,7 @@
         },
         {
             "id": "83bafe96-1f74-5c35-bb86-fbd9f5f7ea30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a9d7b8-c77e-48f3-89ce-1d5a6dc735e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a9d7b8-c77e-48f3-89ce-1d5a6dc735e7.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -16498,7 +16498,7 @@
         },
         {
             "id": "b354114d-ad66-50ac-8b33-0777d46c9200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c975c324-c96b-461e-9098-d278c01d4a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c975c324-c96b-461e-9098-d278c01d4a6d.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -16533,7 +16533,7 @@
         },
         {
             "id": "416185e9-798c-523c-bee2-d232362950f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3332b35c-fd4f-4195-baee-e759dee6a682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3332b35c-fd4f-4195-baee-e759dee6a682.jpg?1",
             "name": "Call of the Wild",
             "text": "{2}{G}{G}: Reveal the top card of your library. If it's a creature card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -16566,7 +16566,7 @@
         },
         {
             "id": "4082c0cc-3eed-5542-aeb8-f2a72ff4a4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447492df-3564-4ab1-aa4a-d247697015fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447492df-3564-4ab1-aa4a-d247697015fe.jpg?1",
             "name": "Call of the Wild",
             "text": "",
             "colours": [
@@ -16599,7 +16599,7 @@
         },
         {
             "id": "3c5e3197-98e3-50e1-b6a3-fc9ca413b2f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def682d0-6091-49c8-ac46-da0884b8cdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def682d0-6091-49c8-ac46-da0884b8cdb3.jpg?1",
             "name": "Canopy Spider",
             "text": "Canopy Spider may block as though it had flying.",
             "colours": [
@@ -16634,7 +16634,7 @@
         },
         {
             "id": "55970af1-98de-5127-8807-cb15eee05d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e8f4bf-2634-4f9e-9898-7cbb618c8230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e8f4bf-2634-4f9e-9898-7cbb618c8230.jpg?1",
             "name": "Canopy Spider",
             "text": "",
             "colours": [
@@ -16669,7 +16669,7 @@
         },
         {
             "id": "7f81e7bd-59fa-5e07-8bb4-4a4d05be57ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce4bab-6eb1-421f-b425-7bb0076defc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce4bab-6eb1-421f-b425-7bb0076defc7.jpg?1",
             "name": "Choke",
             "text": "Islands don't untap during their controllers' untap steps.",
             "colours": [
@@ -16702,7 +16702,7 @@
         },
         {
             "id": "ce768205-bd8e-5456-a771-de3edf743c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f8570d-0e7c-401e-8648-63cf0a88d8f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f8570d-0e7c-401e-8648-63cf0a88d8f9.jpg?1",
             "name": "Choke",
             "text": "",
             "colours": [
@@ -16735,7 +16735,7 @@
         },
         {
             "id": "dbdb25fe-cd9e-5a05-8336-9999c108ad5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccce9141-6c73-4e33-a72c-caa87cea7888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccce9141-6c73-4e33-a72c-caa87cea7888.jpg?1",
             "name": "Collective Unconscious",
             "text": "Draw a card for each creature you control.",
             "colours": [
@@ -16768,7 +16768,7 @@
         },
         {
             "id": "9ae7d60f-9ad6-52bb-b19f-411ea1a576e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a616822b-592c-455d-b35e-71e099450e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a616822b-592c-455d-b35e-71e099450e1a.jpg?1",
             "name": "Collective Unconscious",
             "text": "",
             "colours": [
@@ -16801,7 +16801,7 @@
         },
         {
             "id": "4ac37fee-e7c1-595e-8983-37b5eb259215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edc5392-0529-471c-858f-5602aabb626c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edc5392-0529-471c-858f-5602aabb626c.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16836,7 +16836,7 @@
         },
         {
             "id": "315db43c-f8c5-5086-b269-9f48615743ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56659a8-ca72-4343-9f98-770abdd08502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56659a8-ca72-4343-9f98-770abdd08502.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16871,7 +16871,7 @@
         },
         {
             "id": "391ab6cf-8a2c-5df9-b63d-a0ad19a111f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a053c7-650b-4b4a-b54d-082a194e3cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a053c7-650b-4b4a-b54d-082a194e3cc2.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -16904,7 +16904,7 @@
         },
         {
             "id": "444012ab-6df9-56e4-9bf1-4e8721b8577a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c5b5b7-e223-41c0-86e0-ed636ab77ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c5b5b7-e223-41c0-86e0-ed636ab77ae9.jpg?1",
             "name": "Creeping Mold",
             "text": "",
             "colours": [
@@ -16937,7 +16937,7 @@
         },
         {
             "id": "2214fa52-4ced-5b59-843c-e5c6e2a8ca25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c329c4-6c40-467a-ab37-95896a0c1159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c329c4-6c40-467a-ab37-95896a0c1159.jpg?1",
             "name": "Elvish Champion",
             "text": "All Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "51729dab-95a0-59f0-a829-82dc2d748c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c47b726-66d1-4d40-a84c-3c782c9f566e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c47b726-66d1-4d40-a84c-3c782c9f566e.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -17007,7 +17007,7 @@
         },
         {
             "id": "e511e15f-a097-5a25-92b1-74f8ad90d698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1da8da-12b2-47aa-9565-92d305061798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1da8da-12b2-47aa-9565-92d305061798.jpg?1",
             "name": "Elvish Lyrist",
             "text": "{G}, {T}, Sacrifice Elvish Lyrist: Destroy target enchantment.",
             "colours": [
@@ -17042,7 +17042,7 @@
         },
         {
             "id": "0bf86d9e-f4c9-5c80-ad26-ff4ffae0f495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4580c08-939d-4c41-9f61-997584f191e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4580c08-939d-4c41-9f61-997584f191e9.jpg?1",
             "name": "Elvish Lyrist",
             "text": "",
             "colours": [
@@ -17077,7 +17077,7 @@
         },
         {
             "id": "5d6df8e3-84c4-5b6c-87b4-13e35285ba66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88244522-1cf3-40a6-9ff7-bb78f2151b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88244522-1cf3-40a6-9ff7-bb78f2151b60.jpg?1",
             "name": "Elvish Pioneer",
             "text": "When Elvish Pioneer comes into play, you may put a basic land card from your hand into play tapped.",
             "colours": [
@@ -17113,7 +17113,7 @@
         },
         {
             "id": "546f8833-2ca7-5cfe-9124-6d81d9f16435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7311553-f028-4246-94e3-7bcbf3870aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7311553-f028-4246-94e3-7bcbf3870aed.jpg?1",
             "name": "Elvish Pioneer",
             "text": "",
             "colours": [
@@ -17149,7 +17149,7 @@
         },
         {
             "id": "6d2edec0-cbf7-5b41-9c4c-1a9f1412ade5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7031bb78-d35c-4d69-b4d2-df0418add14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7031bb78-d35c-4d69-b4d2-df0418add14c.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: Put a creature card from your hand into play.",
             "colours": [
@@ -17185,7 +17185,7 @@
         },
         {
             "id": "4f93b2e4-6e2f-59c4-9fab-81ac55cf8c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efb9c7c-8215-4439-a5b5-6914c88dd47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efb9c7c-8215-4439-a5b5-6914c88dd47b.jpg?1",
             "name": "Elvish Piper",
             "text": "",
             "colours": [
@@ -17221,7 +17221,7 @@
         },
         {
             "id": "a2187fcf-8a7d-5a53-9c6e-13446b7c50a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ebab87-fd0c-43d0-bde1-e36065d764dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ebab87-fd0c-43d0-bde1-e36065d764dd.jpg?1",
             "name": "Elvish Scrapper",
             "text": "{G}, {T}, Sacrifice Elvish Scrapper: Destroy target artifact.",
             "colours": [
@@ -17256,7 +17256,7 @@
         },
         {
             "id": "c63f820d-b067-5a2b-aa2c-70ec0c741257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d85820-dded-4739-99c9-44ecfb0b3752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d85820-dded-4739-99c9-44ecfb0b3752.jpg?1",
             "name": "Elvish Scrapper",
             "text": "",
             "colours": [
@@ -17291,7 +17291,7 @@
         },
         {
             "id": "41367989-1e37-51d1-90ce-110fd629b693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c512d95-df1a-4712-8bba-7e20047d419f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c512d95-df1a-4712-8bba-7e20047d419f.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -17326,7 +17326,7 @@
         },
         {
             "id": "4850a0d4-90e6-5944-a906-0c1b5353b06f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88eb31da-b350-4cf7-b851-21e48e3270d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88eb31da-b350-4cf7-b851-21e48e3270d0.jpg?1",
             "name": "Emperor Crocodile",
             "text": "",
             "colours": [
@@ -17361,7 +17361,7 @@
         },
         {
             "id": "283944db-b538-513f-9269-0683f877c297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5be15b0-e754-4d1f-a36f-901c20641a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5be15b0-e754-4d1f-a36f-901c20641a40.jpg?1",
             "name": "Fecundity",
             "text": "Whenever a creature is put into a graveyard from play, that creature's controller may draw a card.",
             "colours": [
@@ -17394,7 +17394,7 @@
         },
         {
             "id": "7edabe04-3d12-507c-9b7e-91f7abe52387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde1e739-f086-4f26-997c-e4fe35f9930e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde1e739-f086-4f26-997c-e4fe35f9930e.jpg?1",
             "name": "Fecundity",
             "text": "",
             "colours": [
@@ -17427,7 +17427,7 @@
         },
         {
             "id": "b88a447f-fa97-5591-a9a3-5253f56016d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a4a86-b9ce-415c-9343-db4211cac7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a4a86-b9ce-415c-9343-db4211cac7b8.jpg?1",
             "name": "Fertile Ground",
             "text": "Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool.",
             "colours": [
@@ -17462,7 +17462,7 @@
         },
         {
             "id": "a5c6278c-305f-51fd-9edb-212dfb919ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b464b6e-7c75-4929-9cfe-f520cea16fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b464b6e-7c75-4929-9cfe-f520cea16fab.jpg?1",
             "name": "Fertile Ground",
             "text": "",
             "colours": [
@@ -17497,7 +17497,7 @@
         },
         {
             "id": "bed1cec4-85c0-531e-8cfc-e17c8b433985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d621fad-3a50-4910-a302-23ae9e77ebde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d621fad-3a50-4910-a302-23ae9e77ebde.jpg?1",
             "name": "Foratog",
             "text": "{G}, Sacrifice a Forest: Foratog gets +2/+2 until end of turn.",
             "colours": [
@@ -17532,7 +17532,7 @@
         },
         {
             "id": "7f1a6ce4-4c35-5c6e-9aac-31cc5c9443ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb6e41-bbbe-4f32-bb0a-9dc8295ff9c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb6e41-bbbe-4f32-bb0a-9dc8295ff9c8.jpg?1",
             "name": "Foratog",
             "text": "",
             "colours": [
@@ -17567,7 +17567,7 @@
         },
         {
             "id": "6ec720a5-92cb-564d-9346-ce7efc9525d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79324f73-25cd-477a-b4f0-fd3e1319e451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79324f73-25cd-477a-b4f0-fd3e1319e451.jpg?1",
             "name": "Fungusaur",
             "text": "Whenever Fungusaur is dealt damage, put a +1/+1 counter on it. (The damage is dealt before the counter is put on.)",
             "colours": [
@@ -17603,7 +17603,7 @@
         },
         {
             "id": "40c2653e-fc73-53ff-908e-cc3e3053f2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a3398-892c-4481-af2d-76ac437f9277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a3398-892c-4481-af2d-76ac437f9277.jpg?1",
             "name": "Fungusaur",
             "text": "",
             "colours": [
@@ -17639,7 +17639,7 @@
         },
         {
             "id": "f8a08794-ac85-5dcd-bf7b-4cff69306076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c125cd-ea49-4511-a78c-42c1f7ce802d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c125cd-ea49-4511-a78c-42c1f7ce802d.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "{T}: Add {G}{G} to your mana pool.",
             "colours": [
@@ -17675,7 +17675,7 @@
         },
         {
             "id": "e0d64dc1-93b9-5e2d-b13d-308c120e583c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871fbead-4a9f-4e6e-ac8d-bc872176b39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871fbead-4a9f-4e6e-ac8d-bc872176b39e.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "",
             "colours": [
@@ -17711,7 +17711,7 @@
         },
         {
             "id": "0c9bac39-ccc7-5074-92c5-7b9ab1f74583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab713e16-5103-4f37-b325-a30d3580b5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab713e16-5103-4f37-b325-a30d3580b5dd.jpg?1",
             "name": "Gaea's Herald",
             "text": "Creature spells can't be countered.",
             "colours": [
@@ -17746,7 +17746,7 @@
         },
         {
             "id": "f16b544e-22cc-5da8-be25-81ae8d0a8017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31e72a-5311-4f62-bfac-0d51263512fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31e72a-5311-4f62-bfac-0d51263512fc.jpg?1",
             "name": "Gaea's Herald",
             "text": "",
             "colours": [
@@ -17781,7 +17781,7 @@
         },
         {
             "id": "84681b6b-cc2f-5538-b698-ac307362b655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9dd66-8580-4c96-9ab9-cc392dc6ee74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9dd66-8580-4c96-9ab9-cc392dc6ee74.jpg?1",
             "name": "Giant Badger",
             "text": "Whenever Giant Badger blocks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -17816,7 +17816,7 @@
         },
         {
             "id": "dd00c9c8-ca70-5574-9335-6c05b1e7e1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5d5046-c23b-4414-a752-0f2a27abc745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5d5046-c23b-4414-a752-0f2a27abc745.jpg?1",
             "name": "Giant Badger",
             "text": "",
             "colours": [
@@ -17851,7 +17851,7 @@
         },
         {
             "id": "27da5926-3e3d-5d06-b642-cb5a32d7491c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1210c342-1473-44ae-bcaa-e6b3ef9aea90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1210c342-1473-44ae-bcaa-e6b3ef9aea90.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "d6aa7953-3573-5d37-88c6-54f2a54c07a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4adb1-85af-40ba-bd36-ccd2dc1cb227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4adb1-85af-40ba-bd36-ccd2dc1cb227.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -17917,7 +17917,7 @@
         },
         {
             "id": "24ce63a5-835b-5fb6-a252-74f679043557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4632f3d9-9cdf-4871-9771-e8a8b1eaed52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4632f3d9-9cdf-4871-9771-e8a8b1eaed52.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider may block as though it had flying.",
             "colours": [
@@ -17952,7 +17952,7 @@
         },
         {
             "id": "c704eb87-5bd9-5c3a-9f76-fcee77c325c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2be9ed-7bac-4b80-a03b-a08ec11a05f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2be9ed-7bac-4b80-a03b-a08ec11a05f4.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -17987,7 +17987,7 @@
         },
         {
             "id": "51398c1f-a508-5a5e-9ab7-8ab9e5b4df93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5d8b0-e22d-4bb3-9e36-5038601d22f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5d8b0-e22d-4bb3-9e36-5038601d22f7.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -18022,7 +18022,7 @@
         },
         {
             "id": "af19f25a-7862-5bff-97d6-9eb87e739fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e12ae6-6e75-4786-b881-f1b890363a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e12ae6-6e75-4786-b881-f1b890363a0b.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -18057,7 +18057,7 @@
         },
         {
             "id": "f8337b98-77ab-5e7f-b764-24668a5be221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffce2f7-b619-4483-a75e-916343194641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffce2f7-b619-4483-a75e-916343194641.jpg?1",
             "name": "Horned Troll",
             "text": "{G}: Regenerate Horned Troll.",
             "colours": [
@@ -18092,7 +18092,7 @@
         },
         {
             "id": "8026f32f-56f7-5637-9b76-bbb0351f2356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43c17e-c2b6-4435-b27a-93672537c471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43c17e-c2b6-4435-b27a-93672537c471.jpg?1",
             "name": "Horned Troll",
             "text": "",
             "colours": [
@@ -18127,7 +18127,7 @@
         },
         {
             "id": "b3087862-6832-5257-b5ba-400d3f7aa621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edda2de4-22f6-4d33-b182-3ae5d105f1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edda2de4-22f6-4d33-b182-3ae5d105f1f6.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play.",
             "colours": [
@@ -18162,7 +18162,7 @@
         },
         {
             "id": "1664cfb3-5e0d-537e-8d62-842fbd5c0c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03523c81-ab2e-4c15-97b0-d5b85d7c62b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03523c81-ab2e-4c15-97b0-d5b85d7c62b6.jpg?1",
             "name": "Hunted Wumpus",
             "text": "",
             "colours": [
@@ -18197,7 +18197,7 @@
         },
         {
             "id": "6d4faf3b-1fcb-566a-85d5-b8a9610478cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d664dc-4477-46b3-9dd7-022c94090254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d664dc-4477-46b3-9dd7-022c94090254.jpg?1",
             "name": "Lhurgoyf",
             "text": "Lhurgoyf's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -18232,7 +18232,7 @@
         },
         {
             "id": "61b19ecb-c1ce-5f54-a5f4-fd2f5c2078ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1d394-6135-4064-971b-8df515e7ba50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1d394-6135-4064-971b-8df515e7ba50.jpg?1",
             "name": "Lhurgoyf",
             "text": "",
             "colours": [
@@ -18267,7 +18267,7 @@
         },
         {
             "id": "89afe3ee-d887-5416-8d0b-e587a3c21f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a22646-0e36-491e-9b90-39fad60d64bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a22646-0e36-491e-9b90-39fad60d64bf.jpg?1",
             "name": "Living Terrain",
             "text": "Enchanted land is a 5/6 green Treefolk creature that's still a land.",
             "colours": [
@@ -18302,7 +18302,7 @@
         },
         {
             "id": "2ee19db9-a50a-54ad-b276-371945b27579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a94a14-bce3-465e-b16a-03466d1f5895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a94a14-bce3-465e-b16a-03466d1f5895.jpg?1",
             "name": "Living Terrain",
             "text": "",
             "colours": [
@@ -18337,7 +18337,7 @@
         },
         {
             "id": "f1f53537-e6f4-5850-8cb0-cf03443d73a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ce566a-9385-47a5-8420-f3ffcd88eae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ce566a-9385-47a5-8420-f3ffcd88eae9.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "Tap an untapped creature you control: Llanowar Behemoth gets +1/+1 until end of turn.",
             "colours": [
@@ -18372,7 +18372,7 @@
         },
         {
             "id": "ea728f80-f265-544c-a19c-679b6897b1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2115-c003-432d-8cef-b901cdaf3510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2115-c003-432d-8cef-b901cdaf3510.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "",
             "colours": [
@@ -18407,7 +18407,7 @@
         },
         {
             "id": "5960c8e2-6d35-5f20-aa5a-a5f7bed422e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309d32e9-c9b0-46bb-8d99-1ddd2e34a60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309d32e9-c9b0-46bb-8d99-1ddd2e34a60b.jpg?1",
             "name": "Lone Wolf",
             "text": "You may have Lone Wolf deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -18442,7 +18442,7 @@
         },
         {
             "id": "6aa0ea9c-71d0-5f75-a739-709bf451140f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0c0701-9e5f-42d1-b269-b33225d6a54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0c0701-9e5f-42d1-b269-b33225d6a54b.jpg?1",
             "name": "Lone Wolf",
             "text": "",
             "colours": [
@@ -18477,7 +18477,7 @@
         },
         {
             "id": "99035f4f-b4ba-5560-92de-261ad53b385b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5362cf9-a55b-4df5-941e-d738a68281cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5362cf9-a55b-4df5-941e-d738a68281cf.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -18512,7 +18512,7 @@
         },
         {
             "id": "e3a71d0e-df97-5e56-9450-9c3e596a95e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e502853e-5451-44c8-a42a-440f2387d604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e502853e-5451-44c8-a42a-440f2387d604.jpg?1",
             "name": "Lure",
             "text": "",
             "colours": [
@@ -18547,7 +18547,7 @@
         },
         {
             "id": "e217e06c-9dc1-5a5b-91bb-68f324f81a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728aea83-5817-4ec9-8d73-3043089c17d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728aea83-5817-4ec9-8d73-3043089c17d4.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -18582,7 +18582,7 @@
         },
         {
             "id": "9166d1fa-48c0-5b7d-b2cf-08beff292603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695a29d-fd19-422b-a5a7-15cd218c8876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695a29d-fd19-422b-a5a7-15cd218c8876.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -18617,7 +18617,7 @@
         },
         {
             "id": "fd197ea6-416b-5146-b9a4-8ff14fd73eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b136d50-732b-4265-97c4-1caaa4a54be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b136d50-732b-4265-97c4-1caaa4a54be1.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -18650,7 +18650,7 @@
         },
         {
             "id": "93296851-54b5-5e36-9976-0ff354eee29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dcea2c-147d-4610-a4d8-e305114deaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dcea2c-147d-4610-a4d8-e305114deaaa.jpg?1",
             "name": "Might of Oaks",
             "text": "",
             "colours": [
@@ -18683,7 +18683,7 @@
         },
         {
             "id": "2bfb3791-71c3-5937-8c4b-fb79075e5a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5a2687-af7a-42ad-8938-f3534c7da222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5a2687-af7a-42ad-8938-f3534c7da222.jpg?1",
             "name": "Monstrous Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -18716,7 +18716,7 @@
         },
         {
             "id": "64528ff6-1612-56df-aef2-fee59550057b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c31288-16a5-422b-b2e5-d23f424da826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c31288-16a5-422b-b2e5-d23f424da826.jpg?1",
             "name": "Monstrous Growth",
             "text": "",
             "colours": [
@@ -18749,7 +18749,7 @@
         },
         {
             "id": "dbf43e5e-8755-5fe1-b384-e2af4edac503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15511fda-92ae-4d27-8a83-37e821ec3adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15511fda-92ae-4d27-8a83-37e821ec3adf.jpg?1",
             "name": "Moss Monster",
             "text": "",
             "colours": [
@@ -18784,7 +18784,7 @@
         },
         {
             "id": "4f061ab3-1612-5264-a447-b26a53b07d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5673efb5-3198-470b-aca9-0f1358506d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5673efb5-3198-470b-aca9-0f1358506d3e.jpg?1",
             "name": "Moss Monster",
             "text": "",
             "colours": [
@@ -18819,7 +18819,7 @@
         },
         {
             "id": "a62e2112-eb80-5c55-9abf-95666caeb5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd6695-ee30-4ab1-a732-26b073c2fec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd6695-ee30-4ab1-a732-26b073c2fec6.jpg?1",
             "name": "Nantuko Disciple",
             "text": "{G}, {T}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -18855,7 +18855,7 @@
         },
         {
             "id": "69815bbf-6075-5cf2-8d94-9fa6b2916c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fcbd-814e-4277-8051-ceb04a4b667f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fcbd-814e-4277-8051-ceb04a4b667f.jpg?1",
             "name": "Nantuko Disciple",
             "text": "",
             "colours": [
@@ -18891,7 +18891,7 @@
         },
         {
             "id": "0b244ec7-716b-5eab-b537-0a24e92c20d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d782c5-1462-4533-8004-672450bf5c07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d782c5-1462-4533-8004-672450bf5c07.jpg?1",
             "name": "Natural Affinity",
             "text": "Until end of turn, all lands become 2/2 creatures that are still lands.",
             "colours": [
@@ -18924,7 +18924,7 @@
         },
         {
             "id": "0a9b04a0-78b6-5988-8594-3cf88b12cb03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e786ae-7f0e-46c0-afc7-758b92387fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e786ae-7f0e-46c0-afc7-758b92387fd2.jpg?1",
             "name": "Natural Affinity",
             "text": "",
             "colours": [
@@ -18957,7 +18957,7 @@
         },
         {
             "id": "2dd9f142-afee-5358-b9b2-0a10e78b32f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e905d-a911-40a7-a793-8535e840230e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e905d-a911-40a7-a793-8535e840230e.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -18990,7 +18990,7 @@
         },
         {
             "id": "689f7a4d-ab18-5c27-948c-d37092d98b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e4416-c820-4d3c-83a6-8f9de32dcfec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e4416-c820-4d3c-83a6-8f9de32dcfec.jpg?1",
             "name": "Naturalize",
             "text": "",
             "colours": [
@@ -19023,7 +19023,7 @@
         },
         {
             "id": "dd7882dc-71a0-518f-82b2-0ff666d25728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3415e3a7-99b2-44b5-93a3-fd07c4ecca4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3415e3a7-99b2-44b5-93a3-fd07c4ecca4d.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -19060,7 +19060,7 @@
         },
         {
             "id": "5a4a4ba9-7b74-56e7-89f7-54fdbe168f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56302f44-d9be-4453-8e01-b1c19979f521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56302f44-d9be-4453-8e01-b1c19979f521.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -19097,7 +19097,7 @@
         },
         {
             "id": "54692614-f938-5b59-bc23-148279439a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27128f26-0d89-4962-96e8-5fa343031a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27128f26-0d89-4962-96e8-5fa343031a26.jpg?1",
             "name": "Plow Under",
             "text": "Put two target lands on top of their owner's library.",
             "colours": [
@@ -19130,7 +19130,7 @@
         },
         {
             "id": "991757e7-feba-518e-89ac-c9fcae744c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e98212-08a8-4570-a291-61f22288066e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e98212-08a8-4570-a291-61f22288066e.jpg?1",
             "name": "Plow Under",
             "text": "",
             "colours": [
@@ -19163,7 +19163,7 @@
         },
         {
             "id": "11045076-124f-51e7-9de4-bc93ae9c5329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4e884-b36c-4fde-84bb-a19a3ce160ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4e884-b36c-4fde-84bb-a19a3ce160ae.jpg?1",
             "name": "Primeval Force",
             "text": "When Primeval Force comes into play, sacrifice it unless you sacrifice three Forests.",
             "colours": [
@@ -19198,7 +19198,7 @@
         },
         {
             "id": "9a39742b-5040-5585-8e5f-98763c5fe9a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61af954f-e0ee-43cb-830a-225c8fb46850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61af954f-e0ee-43cb-830a-225c8fb46850.jpg?1",
             "name": "Primeval Force",
             "text": "",
             "colours": [
@@ -19233,7 +19233,7 @@
         },
         {
             "id": "57aa4ee5-9ef4-5bb1-8fbe-785f6d47caf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d56cde-e186-41e7-bcb2-80736a989678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d56cde-e186-41e7-bcb2-80736a989678.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -19266,7 +19266,7 @@
         },
         {
             "id": "5c3c4e75-4e64-5170-96ea-888bad4f0b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336c1d89-7d7e-42f4-a1e1-55f85b3c47e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336c1d89-7d7e-42f4-a1e1-55f85b3c47e1.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -19299,7 +19299,7 @@
         },
         {
             "id": "3ef05c40-faa8-590e-9765-545665979740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a97c91d-66bd-417a-9c13-4ac4d9ddd7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a97c91d-66bd-417a-9c13-4ac4d9ddd7f7.jpg?1",
             "name": "Regeneration",
             "text": "{G}: Regenerate enchanted creature.",
             "colours": [
@@ -19334,7 +19334,7 @@
         },
         {
             "id": "fbbea028-c87a-5a8e-a1c6-115bf52ccda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d78aef4-a4cf-4a6a-80c0-0695a93d3342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d78aef4-a4cf-4a6a-80c0-0695a93d3342.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -19369,7 +19369,7 @@
         },
         {
             "id": "a12692aa-f735-5588-b3a2-0b37eb2bdcfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbd99aa-af0a-489d-9be1-d3aaa0a1f5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbd99aa-af0a-489d-9be1-d3aaa0a1f5a4.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -19402,7 +19402,7 @@
         },
         {
             "id": "18d5a802-9b29-5a71-8892-c55bac34c885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43832b4-c6f2-4296-b2b0-ddc0c39b322b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43832b4-c6f2-4296-b2b0-ddc0c39b322b.jpg?1",
             "name": "Revive",
             "text": "",
             "colours": [
@@ -19435,7 +19435,7 @@
         },
         {
             "id": "cfe8240f-7df7-53d7-9ace-316573b0bd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7e788-8fc7-49f3-804b-2d7f96852d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7e788-8fc7-49f3-804b-2d7f96852d4b.jpg?1",
             "name": "Rhox",
             "text": "You may have Rhox deal its combat damage to defending player as though it weren't blocked.\n{2}{G}: Regenerate Rhox.",
             "colours": [
@@ -19471,7 +19471,7 @@
         },
         {
             "id": "4e22f96d-9a64-5a20-888b-2342901e9d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6761729-b8e1-4a84-a4eb-3b5fc9485867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6761729-b8e1-4a84-a4eb-3b5fc9485867.jpg?1",
             "name": "Rhox",
             "text": "",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "b55647e7-4cb1-5a85-a1f7-d5d3206d71e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d62152d-463b-464d-b3c2-8b404ee1f80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d62152d-463b-464d-b3c2-8b404ee1f80e.jpg?1",
             "name": "Rushwood Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -19542,7 +19542,7 @@
         },
         {
             "id": "a8c3f22b-4856-5934-99a5-ea517c612cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61737f0-857b-48fd-aebe-3d7eea3bff50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61737f0-857b-48fd-aebe-3d7eea3bff50.jpg?1",
             "name": "Rushwood Dryad",
             "text": "",
             "colours": [
@@ -19577,7 +19577,7 @@
         },
         {
             "id": "86c3622d-a0bc-5dcc-a565-e45a5f0233c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba620b1b-d333-443b-961a-25f65ca49a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba620b1b-d333-443b-961a-25f65ca49a1e.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -19612,7 +19612,7 @@
         },
         {
             "id": "d29ae3d7-6393-52b9-8220-e18bc0f2df05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0627ac0e-f371-44fc-8cd9-987e02ed13ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0627ac0e-f371-44fc-8cd9-987e02ed13ec.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -19647,7 +19647,7 @@
         },
         {
             "id": "cb0dc3e7-c804-5081-b8b6-0a7d17584c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeeb515-7d3d-4678-a480-32485b197afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfeeb515-7d3d-4678-a480-32485b197afb.jpg?1",
             "name": "Spitting Spider",
             "text": "Spitting Spider may block as though it had flying.\nSacrifice a land: Spitting Spider deals 1 damage to each creature with flying.",
             "colours": [
@@ -19682,7 +19682,7 @@
         },
         {
             "id": "f166914b-5fb5-56e7-a031-e01e486ea102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b8b3d8-aa1f-473b-a85f-912aea8fa207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b8b3d8-aa1f-473b-a85f-912aea8fa207.jpg?1",
             "name": "Spitting Spider",
             "text": "",
             "colours": [
@@ -19717,7 +19717,7 @@
         },
         {
             "id": "bd99e864-f136-54d3-b5c6-84ea60d5ab56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abaf631-ce63-47c8-8883-04f942f2e7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abaf631-ce63-47c8-8883-04f942f2e7ba.jpg?1",
             "name": "Spreading Algae",
             "text": "Spreading Algae can enchant only a Swamp.\nWhen enchanted land becomes tapped, destroy that land.\nWhen Spreading Algae is put into a graveyard from play, return Spreading Algae to its owner's hand.",
             "colours": [
@@ -19752,7 +19752,7 @@
         },
         {
             "id": "c41ae817-6a0b-5924-bcec-5aa621c1dcf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae057c0c-1993-4e1c-a7c3-a3be8fa5616d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae057c0c-1993-4e1c-a7c3-a3be8fa5616d.jpg?1",
             "name": "Spreading Algae",
             "text": "",
             "colours": [
@@ -19787,7 +19787,7 @@
         },
         {
             "id": "88391e16-5846-5866-9b50-06a860a234de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff34fb-7bc5-4484-ad73-067363a2cc16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff34fb-7bc5-4484-ad73-067363a2cc16.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -19820,7 +19820,7 @@
         },
         {
             "id": "6feb03f2-a6de-548d-a278-e96c91270485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9263d7-4825-4fd4-a6a7-d887cc3d8bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9263d7-4825-4fd4-a6a7-d887cc3d8bae.jpg?1",
             "name": "Stream of Life",
             "text": "",
             "colours": [
@@ -19853,7 +19853,7 @@
         },
         {
             "id": "b8fcc3b5-0e3a-576a-8419-e74d4f8c0796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa0c8c-f069-4f3b-b049-90e1089346ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa0c8c-f069-4f3b-b049-90e1089346ef.jpg?1",
             "name": "Thorn Elemental",
             "text": "You may have Thorn Elemental deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -19888,7 +19888,7 @@
         },
         {
             "id": "6161cec4-0065-5a07-8d65-9e310e1249f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9277322-b379-4d2f-bb39-ae448d414c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9277322-b379-4d2f-bb39-ae448d414c9c.jpg?1",
             "name": "Thorn Elemental",
             "text": "",
             "colours": [
@@ -19923,7 +19923,7 @@
         },
         {
             "id": "a1bb5f59-7e5c-55a0-b27f-00709db3e592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe86493d-e350-40c4-b65f-de63c2f0a91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe86493d-e350-40c4-b65f-de63c2f0a91a.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19958,7 +19958,7 @@
         },
         {
             "id": "90e6d57d-8f2b-5439-b74c-8229132b0d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9a16c6-f7d5-407e-b849-9d636419eedb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9a16c6-f7d5-407e-b849-9d636419eedb.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19993,7 +19993,7 @@
         },
         {
             "id": "6537dbdc-f336-5963-a6d0-9df01ca59c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff050e6-cd70-4289-bd15-e5c3437bef2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff050e6-cd70-4289-bd15-e5c3437bef2d.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -20029,7 +20029,7 @@
         },
         {
             "id": "d36f0554-5902-53c4-afc6-a3fa513fe271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01114884-50d2-434e-905f-20dad4b8dfbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01114884-50d2-434e-905f-20dad4b8dfbd.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -20065,7 +20065,7 @@
         },
         {
             "id": "749af365-1bca-53be-ac53-3ed2b3be3a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabb73c-e3d9-4ba1-9963-986e09ef49a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabb73c-e3d9-4ba1-9963-986e09ef49a7.jpg?1",
             "name": "Vernal Bloom",
             "text": "Whenever a Forest is tapped for mana, its controller adds {G} to his or her mana pool.",
             "colours": [
@@ -20098,7 +20098,7 @@
         },
         {
             "id": "9b76037f-36b4-5cf3-a6f9-08134adaaf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a54bd3f-0b44-487d-88ec-14365d43e8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a54bd3f-0b44-487d-88ec-14365d43e8e5.jpg?1",
             "name": "Vernal Bloom",
             "text": "",
             "colours": [
@@ -20131,7 +20131,7 @@
         },
         {
             "id": "35f7f57d-2e1e-5b07-a5cf-49ca568a061e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba462242-82de-4173-98d2-b1b7a1f3d8b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba462242-82de-4173-98d2-b1b7a1f3d8b4.jpg?1",
             "name": "Vine Trellis",
             "text": "(Walls can't attack.)\n{T}: Add {G} to your mana pool.",
             "colours": [
@@ -20167,7 +20167,7 @@
         },
         {
             "id": "6691b13c-c875-54f5-882c-c8c62344d7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded1c6d2-c0b8-4fb7-a377-cad62ff76599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded1c6d2-c0b8-4fb7-a377-cad62ff76599.jpg?1",
             "name": "Vine Trellis",
             "text": "",
             "colours": [
@@ -20203,7 +20203,7 @@
         },
         {
             "id": "d3592414-3444-5862-8a23-078908dd3957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5beaf0-21ca-4539-8773-8a9430af74b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5beaf0-21ca-4539-8773-8a9430af74b0.jpg?1",
             "name": "Wing Snare",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -20236,7 +20236,7 @@
         },
         {
             "id": "250d01a8-73f0-5c61-af27-be9c0ea99858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a0b4ae-0820-48a8-ba8d-a07eccfe90da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a0b4ae-0820-48a8-ba8d-a07eccfe90da.jpg?1",
             "name": "Wing Snare",
             "text": "",
             "colours": [
@@ -20269,7 +20269,7 @@
         },
         {
             "id": "77c9fa3d-3e54-5256-b221-0cbe776ec2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7aa861-556b-43a1-bf57-1efbbd438975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7aa861-556b-43a1-bf57-1efbbd438975.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a Forest card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -20305,7 +20305,7 @@
         },
         {
             "id": "b5ece50d-147e-5a24-b380-2002cd33498f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da2f237-5dc3-4fc7-a0c2-1a0d325ebfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da2f237-5dc3-4fc7-a0c2-1a0d325ebfbf.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -20341,7 +20341,7 @@
         },
         {
             "id": "ff8b09d7-81e7-50fa-bd12-a6674316aed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed4258-eeb8-4c50-9119-8c54331bd219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed4258-eeb8-4c50-9119-8c54331bd219.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -20377,7 +20377,7 @@
         },
         {
             "id": "69b2b749-5fb2-5370-93e4-e9d435d016e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b986f77f-e05b-4c31-824f-d6f746985de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b986f77f-e05b-4c31-824f-d6f746985de1.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "",
             "colours": [
@@ -20413,7 +20413,7 @@
         },
         {
             "id": "56896575-585a-5848-8393-816d3adaac1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffd2437-04e7-44e4-becc-15be62735b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffd2437-04e7-44e4-becc-15be62735b42.jpg?1",
             "name": "Aladdin's Ring",
             "text": "{8}, {T}: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -20442,7 +20442,7 @@
         },
         {
             "id": "786560c7-8cfd-507a-9317-b8cbd909b670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c025c-c30c-4e1f-a530-726fd742f663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c025c-c30c-4e1f-a530-726fd742f663.jpg?1",
             "name": "Aladdin's Ring",
             "text": "",
             "colours": [],
@@ -20471,7 +20471,7 @@
         },
         {
             "id": "573df73a-c8f6-53d3-98ef-8e344032d470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cc6efd-43cc-4350-bd44-9f20c5a4fdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cc6efd-43cc-4350-bd44-9f20c5a4fdd0.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden's power and toughness are each equal to the number of creatures in play.",
             "colours": [],
@@ -20503,7 +20503,7 @@
         },
         {
             "id": "d8a073a9-a4b3-5069-9f9d-4c226ccbde64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec1aa1c-0b44-49d6-9222-38edf04cd7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec1aa1c-0b44-49d6-9222-38edf04cd7f9.jpg?1",
             "name": "Beast of Burden",
             "text": "",
             "colours": [],
@@ -20535,7 +20535,7 @@
         },
         {
             "id": "cac7f534-7401-52ba-ab43-4de0a9cd17d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc61a67-7fab-484c-aa2b-615353138440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc61a67-7fab-484c-aa2b-615353138440.jpg?1",
             "name": "Brass Herald",
             "text": "As Brass Herald comes into play, choose a creature type.\nWhen Brass Herald comes into play, reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order.\nCreatures of the chosen type get +1/+1.",
             "colours": [],
@@ -20567,7 +20567,7 @@
         },
         {
             "id": "c742e854-a572-5bdd-b38d-3e6f8d1175f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34e9659-fc22-42f8-b118-6b46b4fab409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34e9659-fc22-42f8-b118-6b46b4fab409.jpg?1",
             "name": "Brass Herald",
             "text": "",
             "colours": [],
@@ -20599,7 +20599,7 @@
         },
         {
             "id": "fa068a36-bd6b-5037-ae96-ca785511b7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3995426-2baf-47aa-8111-de07e65f64b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3995426-2baf-47aa-8111-de07e65f64b4.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if there are three Goblins in play, each gets +2/+2.)",
             "colours": [],
@@ -20628,7 +20628,7 @@
         },
         {
             "id": "483a0465-c857-537e-b3dd-02024361e33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e554dd-32c8-4c22-9f3e-32d84cd9edef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e554dd-32c8-4c22-9f3e-32d84cd9edef.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -20657,7 +20657,7 @@
         },
         {
             "id": "2f18f154-0060-5bf5-90b7-ebec9b6848e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe82b91-69e2-4528-b80a-a61183c352ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe82b91-69e2-4528-b80a-a61183c352ad.jpg?1",
             "name": "Crystal Rod",
             "text": "Whenever a player plays a blue spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -20686,7 +20686,7 @@
         },
         {
             "id": "7ba814be-833b-5fbd-b11b-11022a909c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5966f78-198f-48d1-b0a7-cb590547b5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5966f78-198f-48d1-b0a7-cb590547b5f5.jpg?1",
             "name": "Crystal Rod",
             "text": "",
             "colours": [],
@@ -20715,7 +20715,7 @@
         },
         {
             "id": "3a54328a-52c9-59f3-b80e-8ccc4e7cb287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61527b06-bbc9-4f3c-a5db-98ef02063482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61527b06-bbc9-4f3c-a5db-98ef02063482.jpg?1",
             "name": "Defense Grid",
             "text": "During each player's turn, each other player's spells cost {3} more to play.",
             "colours": [],
@@ -20744,7 +20744,7 @@
         },
         {
             "id": "c4495825-0aad-5550-9a4f-b9feaac2c4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fc8efa-5955-4428-9491-66da5bea5e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fc8efa-5955-4428-9491-66da5bea5e0b.jpg?1",
             "name": "Defense Grid",
             "text": "",
             "colours": [],
@@ -20773,7 +20773,7 @@
         },
         {
             "id": "0a535be0-e62b-5a00-b002-e67665a4d3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d893a2-400c-459d-a26d-31f1f3b0642e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d893a2-400c-459d-a26d-31f1f3b0642e.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever a land is put into a graveyard from play, Dingus Egg deals 2 damage to that land's controller.",
             "colours": [],
@@ -20802,7 +20802,7 @@
         },
         {
             "id": "470c87a8-31ec-5c9e-be91-957f1673353b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6bf8b4-b3fe-437e-9c6b-f3f495c8c5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6bf8b4-b3fe-437e-9c6b-f3f495c8c5fc.jpg?1",
             "name": "Dingus Egg",
             "text": "",
             "colours": [],
@@ -20831,7 +20831,7 @@
         },
         {
             "id": "1ce47f82-c00e-53f7-9ccb-0369d596b82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1129d16c-de2b-4d21-a0fd-b63e4ba95d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1129d16c-de2b-4d21-a0fd-b63e4ba95d8d.jpg?1",
             "name": "Disrupting Scepter",
             "text": "{3}, {T}: Target player discards a card from his or her hand. Play this ability only during your turn.",
             "colours": [],
@@ -20860,7 +20860,7 @@
         },
         {
             "id": "8f0b0c58-9889-5af3-be81-cf0a14a16cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09ad3b6-fa9c-4983-9566-00cebd4ca320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09ad3b6-fa9c-4983-9566-00cebd4ca320.jpg?1",
             "name": "Disrupting Scepter",
             "text": "",
             "colours": [],
@@ -20889,7 +20889,7 @@
         },
         {
             "id": "bf92bde8-c8c5-5644-88a4-30c8d1064220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d82d9b7-4b1c-447c-8044-9e114604017e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d82d9b7-4b1c-447c-8044-9e114604017e.jpg?1",
             "name": "Distorting Lens",
             "text": "{T}: Target permanent becomes the color of your choice until end of turn.",
             "colours": [],
@@ -20918,7 +20918,7 @@
         },
         {
             "id": "ce32f0a1-8263-5ba0-b1fd-f6da509ce248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae751b9a-17f6-4180-989a-f91c34f431c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae751b9a-17f6-4180-989a-f91c34f431c9.jpg?1",
             "name": "Distorting Lens",
             "text": "",
             "colours": [],
@@ -20947,7 +20947,7 @@
         },
         {
             "id": "2847fcc5-0497-58c3-a75a-b73d30dc84d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dcf3e-9556-4e1e-929b-eff38abc989c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dcf3e-9556-4e1e-929b-eff38abc989c.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -20976,7 +20976,7 @@
         },
         {
             "id": "40e174e0-3b1a-5680-b67a-9a0a911c0aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058916e-98d5-4312-a845-1195bcff78db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058916e-98d5-4312-a845-1195bcff78db.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "",
             "colours": [],
@@ -21005,7 +21005,7 @@
         },
         {
             "id": "5082c65c-c845-5495-a186-c78af8930761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e5bc70-663f-41a5-a8d1-487c57a6f029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e5bc70-663f-41a5-a8d1-487c57a6f029.jpg?1",
             "name": "Flying Carpet",
             "text": "{2}, {T}: Target creature gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -21034,7 +21034,7 @@
         },
         {
             "id": "cf0ba323-0c64-5d6d-91a3-63135aa1fa44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50b56a-5b0a-4795-8100-df31818744d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50b56a-5b0a-4795-8100-df31818744d9.jpg?1",
             "name": "Flying Carpet",
             "text": "",
             "colours": [],
@@ -21063,7 +21063,7 @@
         },
         {
             "id": "ffb0ce14-b019-5aa8-a050-49a5d3297bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde003e6-d674-42cd-9537-91928730e7dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde003e6-d674-42cd-9537-91928730e7dd.jpg?1",
             "name": "Fodder Cannon",
             "text": "{4}, {T}, Sacrifice a creature: Fodder Cannon deals 4 damage to target creature.",
             "colours": [],
@@ -21092,7 +21092,7 @@
         },
         {
             "id": "1c15d87c-3833-5338-b14c-985b79a06071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42717c4-e5f5-42de-a29d-f74333131efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42717c4-e5f5-42de-a29d-f74333131efd.jpg?1",
             "name": "Fodder Cannon",
             "text": "",
             "colours": [],
@@ -21121,7 +21121,7 @@
         },
         {
             "id": "f4e68162-f43b-56e1-834f-31994218653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661236e2-a414-4a08-b7f7-704f1a2952a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661236e2-a414-4a08-b7f7-704f1a2952a8.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -21150,7 +21150,7 @@
         },
         {
             "id": "28f951ef-743b-5eb9-b36a-88227c7f2866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4f69-d4ff-4cd7-bbfe-f648efc89063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4f69-d4ff-4cd7-bbfe-f648efc89063.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -21179,7 +21179,7 @@
         },
         {
             "id": "8c715e7b-a7bf-552e-b468-18efd7f330da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6d1e6b-80af-4eb1-be3c-62ab74315777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6d1e6b-80af-4eb1-be3c-62ab74315777.jpg?1",
             "name": "Iron Star",
             "text": "Whenever a player plays a red spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -21208,7 +21208,7 @@
         },
         {
             "id": "9e8e0f11-4cea-5c2c-b47c-80cfb8fcb9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9df380-638b-4502-ba70-bfbb5217af27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9df380-638b-4502-ba70-bfbb5217af27.jpg?1",
             "name": "Iron Star",
             "text": "",
             "colours": [],
@@ -21237,7 +21237,7 @@
         },
         {
             "id": "8550f492-a15a-5efe-954f-335e8a7d4330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4cd379-caba-485c-8c0f-e59804c387c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4cd379-caba-485c-8c0f-e59804c387c6.jpg?1",
             "name": "Ivory Cup",
             "text": "Whenever a player plays a white spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -21266,7 +21266,7 @@
         },
         {
             "id": "e304b5e1-806b-5014-b09d-0e7b00b66efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6569df10-35da-4eb8-bc82-f4d937500fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6569df10-35da-4eb8-bc82-f4d937500fd2.jpg?1",
             "name": "Ivory Cup",
             "text": "",
             "colours": [],
@@ -21295,7 +21295,7 @@
         },
         {
             "id": "7c6cdb8a-1101-5c4c-ac0d-c6fd0c412949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73b31b1-c347-4f1c-af4f-8ffbf9e8bf8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73b31b1-c347-4f1c-af4f-8ffbf9e8bf8a.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -21324,7 +21324,7 @@
         },
         {
             "id": "8e9a5d31-60b3-5011-bff7-c590ca22a19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a1a95c-0283-4fc4-a2f5-03ff92385bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a1a95c-0283-4fc4-a2f5-03ff92385bec.jpg?1",
             "name": "Jayemdae Tome",
             "text": "",
             "colours": [],
@@ -21353,7 +21353,7 @@
         },
         {
             "id": "7c2944ab-162a-5346-9fb5-7a65e4610e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c28e220-77ed-466d-9f49-d93b61672ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c28e220-77ed-466d-9f49-d93b61672ee1.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -21382,7 +21382,7 @@
         },
         {
             "id": "832972e6-73ba-590a-a38d-6e980cd7db8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a315d584-2b11-4a1e-8529-5e0b536e06a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a315d584-2b11-4a1e-8529-5e0b536e06a4.jpg?1",
             "name": "Millstone",
             "text": "",
             "colours": [],
@@ -21411,7 +21411,7 @@
         },
         {
             "id": "d7f6c0f7-6905-5d5e-9a31-0faba1b8ffbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66c9c30-35c4-4813-a766-a54a418baf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66c9c30-35c4-4813-a766-a54a418baf8b.jpg?1",
             "name": "Patagia Golem",
             "text": "{3}: Patagia Golem gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -21443,7 +21443,7 @@
         },
         {
             "id": "ea79f7de-7198-518f-8f7a-7f4752605c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74b775-a011-41b6-8732-7a0cb91e030e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74b775-a011-41b6-8732-7a0cb91e030e.jpg?1",
             "name": "Patagia Golem",
             "text": "",
             "colours": [],
@@ -21475,7 +21475,7 @@
         },
         {
             "id": "48948b5e-affa-554d-b934-620f66330252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62f8d95-be99-4c3b-9c75-f5cc1cb43c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62f8d95-be99-4c3b-9c75-f5cc1cb43c44.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "Phyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
             "colours": [],
@@ -21508,7 +21508,7 @@
         },
         {
             "id": "4a9f183e-97d4-5811-b86c-e31d986b208e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203600a-470e-4631-abbc-2c5bf9aa3613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203600a-470e-4631-abbc-2c5bf9aa3613.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "",
             "colours": [],
@@ -21541,7 +21541,7 @@
         },
         {
             "id": "3f7efea1-62ca-568c-b233-64eeab74a1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64af09-2af7-4630-a3c4-e1aa90f2a9fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64af09-2af7-4630-a3c4-e1aa90f2a9fb.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21574,7 +21574,7 @@
         },
         {
             "id": "1f88b6fa-bc1d-558e-9036-b88660377f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a6662b-61eb-44dc-933f-e9246a5b9ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a6662b-61eb-44dc-933f-e9246a5b9ec0.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21607,7 +21607,7 @@
         },
         {
             "id": "3635135b-12a0-547a-8654-c23bb3d91c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8743b2ce-0e18-42c9-aee4-f13197a9c481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8743b2ce-0e18-42c9-aee4-f13197a9c481.jpg?1",
             "name": "Planar Portal",
             "text": "{6}, {T}: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -21636,7 +21636,7 @@
         },
         {
             "id": "84904a80-7433-52a2-b62e-c5e82971c8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90697c9-5be1-4387-9d56-73037223306a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90697c9-5be1-4387-9d56-73037223306a.jpg?1",
             "name": "Planar Portal",
             "text": "",
             "colours": [],
@@ -21665,7 +21665,7 @@
         },
         {
             "id": "634cb432-2462-5f5e-88ba-5767efbe20d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d652801-7f22-41b5-b19c-90efe5d8c0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d652801-7f22-41b5-b19c-90efe5d8c0a8.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -21694,7 +21694,7 @@
         },
         {
             "id": "06cff25a-3b40-5499-9339-7999b51404f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12200b-1d29-4f76-8131-6faae141492b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12200b-1d29-4f76-8131-6faae141492b.jpg?1",
             "name": "Rod of Ruin",
             "text": "",
             "colours": [],
@@ -21723,7 +21723,7 @@
         },
         {
             "id": "e08ea922-01c4-5222-8b92-c8646f86761b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3a7b4-ff44-4909-ab8d-35ba5d187815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3a7b4-ff44-4909-ab8d-35ba5d187815.jpg?1",
             "name": "Skull of Orm",
             "text": "{5}, {T}: Return target enchantment card from your graveyard to your hand.",
             "colours": [],
@@ -21752,7 +21752,7 @@
         },
         {
             "id": "fcfa00bb-b35a-5035-a683-4548bc82d429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5943e3-2c41-4d52-8e38-f5b60db6af7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5943e3-2c41-4d52-8e38-f5b60db6af7d.jpg?1",
             "name": "Skull of Orm",
             "text": "",
             "colours": [],
@@ -21781,7 +21781,7 @@
         },
         {
             "id": "3314166b-d88f-5bdf-9bdf-4c70ae724cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb99979-79f9-4ac0-9f8e-c36ed0a2cc85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb99979-79f9-4ac0-9f8e-c36ed0a2cc85.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -21810,7 +21810,7 @@
         },
         {
             "id": "ff45a073-758e-5cc4-aae2-c4b1b96fa714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c9145-f53a-45a5-91ac-99fefa8a6dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c9145-f53a-45a5-91ac-99fefa8a6dc1.jpg?1",
             "name": "Spellbook",
             "text": "",
             "colours": [],
@@ -21839,7 +21839,7 @@
         },
         {
             "id": "a18d01a3-e65b-5e8b-8ad1-ec8014151fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddaa2b-d836-49bd-9d2f-da2cc4a2bff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddaa2b-d836-49bd-9d2f-da2cc4a2bff4.jpg?1",
             "name": "Star Compass",
             "text": "Star Compass comes into play tapped.\n{T}: Add to your mana pool one mana of any color a basic land you control could produce.",
             "colours": [],
@@ -21868,7 +21868,7 @@
         },
         {
             "id": "cf7e1e3c-70d8-5683-a0a8-e3a1a1638a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cfc596-8857-4862-a404-e4a3f6710ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cfc596-8857-4862-a404-e4a3f6710ddb.jpg?1",
             "name": "Star Compass",
             "text": "",
             "colours": [],
@@ -21897,7 +21897,7 @@
         },
         {
             "id": "4d654a86-73d6-5b8b-90cb-dcadd276cc14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f536f5-0e91-4c78-bba4-036bfa877040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f536f5-0e91-4c78-bba4-036bfa877040.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in his or her hand on the bottom of his or her library in any order, then draws that many cards. (That player draws his or her card for the turn first.)",
             "colours": [],
@@ -21926,7 +21926,7 @@
         },
         {
             "id": "442a7857-0a0c-5b83-9551-897727b7f020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178da82b-161e-47f8-9458-a24926c33e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178da82b-161e-47f8-9458-a24926c33e66.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -21955,7 +21955,7 @@
         },
         {
             "id": "881e1266-3190-5ed9-9a01-d42b267b2b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ef3879-f708-4e2d-a1bc-6a75584fd8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ef3879-f708-4e2d-a1bc-6a75584fd8b1.jpg?1",
             "name": "Throne of Bone",
             "text": "Whenever a player plays a black spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -21984,7 +21984,7 @@
         },
         {
             "id": "32300e1f-b21a-57a5-b299-0be7ae03dbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5148acc2-ef45-40f8-b012-13ca0a16041a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5148acc2-ef45-40f8-b012-13ca0a16041a.jpg?1",
             "name": "Throne of Bone",
             "text": "",
             "colours": [],
@@ -22013,7 +22013,7 @@
         },
         {
             "id": "21dfd03f-5104-588b-acff-95c68bde4edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40375cf-8649-4f06-9e08-f0577f35d1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40375cf-8649-4f06-9e08-f0577f35d1bf.jpg?1",
             "name": "Urza's Armor",
             "text": "If a source would deal damage to you, prevent 1 of that damage.",
             "colours": [],
@@ -22042,7 +22042,7 @@
         },
         {
             "id": "acadc22b-c5f1-5ab3-b63c-92746817aa9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff64fe85-416b-4727-b04f-5c00ea010506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff64fe85-416b-4727-b04f-5c00ea010506.jpg?1",
             "name": "Urza's Armor",
             "text": "",
             "colours": [],
@@ -22071,7 +22071,7 @@
         },
         {
             "id": "d2e2cd58-55a0-5584-8c1e-f78acca37b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1e748b-c836-45f1-96af-ced0cc5aed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1e748b-c836-45f1-96af-ced0cc5aed9f.jpg?1",
             "name": "Vexing Arcanix",
             "text": "{3}, {T}: Target player names a card, then reveals the top card of his or her library. If it's the named card, the player puts it into his or her hand. Otherwise, the player puts it into his or her graveyard and Vexing Arcanix deals 2 damage to him or her.",
             "colours": [],
@@ -22100,7 +22100,7 @@
         },
         {
             "id": "011b843c-b978-5e2d-8ce5-26ad8b93c170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cd438-3d1f-4abe-a10a-90838b0eb6ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cd438-3d1f-4abe-a10a-90838b0eb6ff.jpg?1",
             "name": "Vexing Arcanix",
             "text": "",
             "colours": [],
@@ -22129,7 +22129,7 @@
         },
         {
             "id": "0245e766-b437-5a7f-b8c0-6f814265393f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f34f06-7f89-4f2b-8979-8219ac1c4560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f34f06-7f89-4f2b-8979-8219ac1c4560.jpg?1",
             "name": "Wall of Spears",
             "text": "(Walls can't attack.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -22161,7 +22161,7 @@
         },
         {
             "id": "27ef7ce3-9f26-5196-9942-2e9be5864fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dd88c-58e9-44c9-9ff0-d1844a23b6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dd88c-58e9-44c9-9ff0-d1844a23b6ee.jpg?1",
             "name": "Wall of Spears",
             "text": "",
             "colours": [],
@@ -22193,7 +22193,7 @@
         },
         {
             "id": "b20600a6-1cec-5e2a-b3d0-bcdbc3ed59dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5310b3a7-0a85-4469-be88-5c7ab1de4f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5310b3a7-0a85-4469-be88-5c7ab1de4f4a.jpg?1",
             "name": "Wooden Sphere",
             "text": "Whenever a player plays a green spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [],
@@ -22222,7 +22222,7 @@
         },
         {
             "id": "b74a060d-1de2-518b-98ae-359d593884f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068a6e48-e354-493a-9b28-1d667a58c326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068a6e48-e354-493a-9b28-1d667a58c326.jpg?1",
             "name": "Wooden Sphere",
             "text": "",
             "colours": [],
@@ -22251,7 +22251,7 @@
         },
         {
             "id": "ca450533-cdb5-56bf-b143-9bac47abdd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03220cab-fc78-4323-bd34-b8dbebe35597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03220cab-fc78-4323-bd34-b8dbebe35597.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -22280,7 +22280,7 @@
         },
         {
             "id": "9c6b7ec3-c8c8-5f69-b54c-64bce22d342a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf58637-1560-4851-b4f9-9fa564de4fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf58637-1560-4851-b4f9-9fa564de4fd6.jpg?1",
             "name": "City of Brass",
             "text": "",
             "colours": [],
@@ -22309,7 +22309,7 @@
         },
         {
             "id": "1e209a21-5886-5f25-8e13-8264174b09cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9513c206-b578-4973-93cc-077e5a6658b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9513c206-b578-4973-93cc-077e5a6658b0.jpg?1",
             "name": "Coastal Tower",
             "text": "Coastal Tower comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -22341,7 +22341,7 @@
         },
         {
             "id": "07a55fc6-8ad2-5539-9384-2fa9290e8bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25271fc6-a6dc-4761-8374-8a4c41702a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25271fc6-a6dc-4761-8374-8a4c41702a79.jpg?1",
             "name": "Coastal Tower",
             "text": "",
             "colours": [],
@@ -22373,7 +22373,7 @@
         },
         {
             "id": "ce905c1e-029d-54df-b632-680bfc71a49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e7061a-3b13-466e-b4d0-2769a179b985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e7061a-3b13-466e-b4d0-2769a179b985.jpg?1",
             "name": "Elfhame Palace",
             "text": "Elfhame Palace comes into play tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -22405,7 +22405,7 @@
         },
         {
             "id": "1871629d-3f00-524b-b2f0-80748336839c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2038371-f6c8-4676-97f3-9e878b096ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2038371-f6c8-4676-97f3-9e878b096ff7.jpg?1",
             "name": "Elfhame Palace",
             "text": "",
             "colours": [],
@@ -22437,7 +22437,7 @@
         },
         {
             "id": "585f8e80-3541-5f55-8ad4-6cb28ffa3e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac23896-d4c9-4543-9edc-1d1bb5c74611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac23896-d4c9-4543-9edc-1d1bb5c74611.jpg?1",
             "name": "Salt Marsh",
             "text": "Salt Marsh comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -22469,7 +22469,7 @@
         },
         {
             "id": "1ab0ab3b-1edd-51cb-a303-d5fa7c73dc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d850d74-d751-4644-b5bb-5dc62a00f42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d850d74-d751-4644-b5bb-5dc62a00f42c.jpg?1",
             "name": "Salt Marsh",
             "text": "",
             "colours": [],
@@ -22501,7 +22501,7 @@
         },
         {
             "id": "a1feac78-df8d-5370-8d04-41196ed024aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008d427-b029-409e-b93a-efa86c8777c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008d427-b029-409e-b93a-efa86c8777c3.jpg?1",
             "name": "Shivan Oasis",
             "text": "Shivan Oasis comes into play tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -22533,7 +22533,7 @@
         },
         {
             "id": "54d98deb-5b7f-5136-a5c7-88c0bdf729c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1690a710-e869-4d96-8aa2-991d73b1d46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1690a710-e869-4d96-8aa2-991d73b1d46a.jpg?1",
             "name": "Shivan Oasis",
             "text": "",
             "colours": [],
@@ -22565,7 +22565,7 @@
         },
         {
             "id": "eb0bf20e-ebae-556c-a2b7-c7d66affc645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f98c5c9-cd15-40f7-9aa1-575906df3eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f98c5c9-cd15-40f7-9aa1-575906df3eda.jpg?1",
             "name": "Urborg Volcano",
             "text": "Urborg Volcano comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -22597,7 +22597,7 @@
         },
         {
             "id": "e8bdd481-758e-5c51-bdb2-6bc65d310c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e652c20-78d6-4330-aa53-e393b775614d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e652c20-78d6-4330-aa53-e393b775614d.jpg?1",
             "name": "Urborg Volcano",
             "text": "",
             "colours": [],
@@ -22629,7 +22629,7 @@
         },
         {
             "id": "ed2911b2-bb08-5a26-89a9-dbe6c86acefe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eedb94c-058e-4c3a-96cf-e6624c03d26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eedb94c-058e-4c3a-96cf-e6624c03d26e.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Power-Plant and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22661,7 +22661,7 @@
         },
         {
             "id": "8bdfbeef-cc62-5eca-a05c-8785de78c4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cf2e06-90cc-4acc-8874-5cd4b2a4abf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cf2e06-90cc-4acc-8874-5cd4b2a4abf9.jpg?1",
             "name": "Urza's Mine",
             "text": "",
             "colours": [],
@@ -22693,7 +22693,7 @@
         },
         {
             "id": "97cf943c-def3-5ae7-826c-907ca0cc3a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4499c80b-72af-485c-9106-22967b5252cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4499c80b-72af-485c-9106-22967b5252cd.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22725,7 +22725,7 @@
         },
         {
             "id": "59c41603-efcb-5166-bbdc-2ecb0992db7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b1bbc3-eab3-4e30-8ebc-f4ef5ef0282b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b1bbc3-eab3-4e30-8ebc-f4ef5ef0282b.jpg?1",
             "name": "Urza's Power Plant",
             "text": "",
             "colours": [],
@@ -22757,7 +22757,7 @@
         },
         {
             "id": "f5fd6901-debd-5f07-b4bc-7e31f770ae79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c6dc88-ef09-4b37-b9e8-c483cccd0e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c6dc88-ef09-4b37-b9e8-c483cccd0e0e.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Power-Plant, add {3} to your mana pool instead.",
             "colours": [],
@@ -22789,7 +22789,7 @@
         },
         {
             "id": "c2149f4f-6cab-5cdc-8eb6-056575502548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce1817d-1870-4011-809f-aef3841e779a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce1817d-1870-4011-809f-aef3841e779a.jpg?1",
             "name": "Urza's Tower",
             "text": "",
             "colours": [],
@@ -22821,7 +22821,7 @@
         },
         {
             "id": "d4facd58-20e3-5032-ab7f-97b5478cfa15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c667a-f035-49b2-9f34-9831e186ae82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c667a-f035-49b2-9f34-9831e186ae82.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22862,7 +22862,7 @@
         },
         {
             "id": "e37eab30-b842-558e-9378-6db02acac4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8427be4a-126e-4188-9f3f-ad67b9d7fea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8427be4a-126e-4188-9f3f-ad67b9d7fea5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22903,7 +22903,7 @@
         },
         {
             "id": "c005f67e-6d2d-5524-bc4c-f9ce1818edd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c88ade7-4b1c-4380-a19a-8ba18fa4adaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c88ade7-4b1c-4380-a19a-8ba18fa4adaa.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22944,7 +22944,7 @@
         },
         {
             "id": "255b949b-48f2-5cb2-a8dd-ce61243f799b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5a611-ad7b-4654-a8f1-d024056c346e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5a611-ad7b-4654-a8f1-d024056c346e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22985,7 +22985,7 @@
         },
         {
             "id": "d845fcc0-55f8-5cf4-9600-22bfdfd19901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dd5b8c-2c2f-4185-b176-a94b43729a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dd5b8c-2c2f-4185-b176-a94b43729a29.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23026,7 +23026,7 @@
         },
         {
             "id": "1ec09c95-8523-5eb4-b27e-036306e677ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a34be94-2b31-45a8-9857-02a1cc29f4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a34be94-2b31-45a8-9857-02a1cc29f4cb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23067,7 +23067,7 @@
         },
         {
             "id": "6bfa3eca-3f4d-5bd4-af21-b4f4dd4540e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74b27d-2381-496d-a3ef-af3722c7b4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74b27d-2381-496d-a3ef-af3722c7b4e7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23108,7 +23108,7 @@
         },
         {
             "id": "eb74b1ce-66e5-56e9-b685-72b1762bf840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48af31-8309-46fb-b178-657c3e2fa05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48af31-8309-46fb-b178-657c3e2fa05a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23149,7 +23149,7 @@
         },
         {
             "id": "b3195a42-446c-5442-a7a6-46982eec1c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4146a316-c409-4121-931f-1d3b5ae63675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4146a316-c409-4121-931f-1d3b5ae63675.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23190,7 +23190,7 @@
         },
         {
             "id": "b32bb28d-640b-5f72-b4f0-9c6592788eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d01acc2-bafa-47c9-92ff-b737f1f31f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d01acc2-bafa-47c9-92ff-b737f1f31f16.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23231,7 +23231,7 @@
         },
         {
             "id": "da489e9d-efc8-5d6d-a31f-942e81daa139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f307e72-f33e-4fb1-b15f-a46ab389c20f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f307e72-f33e-4fb1-b15f-a46ab389c20f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23272,7 +23272,7 @@
         },
         {
             "id": "381ea7bb-61fc-5662-b4f2-cac949697d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4e347-90ad-43c7-a236-3ee4d887f069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4e347-90ad-43c7-a236-3ee4d887f069.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23313,7 +23313,7 @@
         },
         {
             "id": "4ee0292a-cd9b-5970-998b-f2e0dca31457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63bc639-5518-4103-8290-c781a6f53f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63bc639-5518-4103-8290-c781a6f53f81.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23354,7 +23354,7 @@
         },
         {
             "id": "20a6df8a-67a6-54ec-a5fa-48c90d34f4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed74e8a1-5636-4d96-aff4-4674494c5e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed74e8a1-5636-4d96-aff4-4674494c5e00.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23395,7 +23395,7 @@
         },
         {
             "id": "78e1fe2e-44c8-5b06-8068-27f943839aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6459577-6834-4f4e-ad7d-a506bef1d372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6459577-6834-4f4e-ad7d-a506bef1d372.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23436,7 +23436,7 @@
         },
         {
             "id": "5c7324ee-c68c-58e7-ad24-dc4b403b78ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e19-0692-4f09-bb99-1b864bfbb479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e19-0692-4f09-bb99-1b864bfbb479.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23477,7 +23477,7 @@
         },
         {
             "id": "c35f693f-8a24-53b9-8f57-167668e8627d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b5162-8724-4df3-a3d5-274036d0049d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b5162-8724-4df3-a3d5-274036d0049d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23518,7 +23518,7 @@
         },
         {
             "id": "66340be0-64dd-50f7-ba74-2b9c11552c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f59dee4-89d0-47bf-ace7-901944b7dcc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f59dee4-89d0-47bf-ace7-901944b7dcc3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23559,7 +23559,7 @@
         },
         {
             "id": "5a400b3d-c3db-5862-aa24-2ab93122f51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22687920-e310-4122-a01d-2aff720d2071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22687920-e310-4122-a01d-2aff720d2071.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23600,7 +23600,7 @@
         },
         {
             "id": "3b92db59-af74-5a61-8072-4731462aa00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88091ab-6fda-4516-b180-daff10cd2417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88091ab-6fda-4516-b180-daff10cd2417.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23641,7 +23641,7 @@
         },
         {
             "id": "577cd441-6ce4-5188-8263-92c79a3550ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f548a-9e41-4b95-812d-a739d945123f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f548a-9e41-4b95-812d-a739d945123f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23682,7 +23682,7 @@
         },
         {
             "id": "9ab66be7-f0d7-5aa9-8972-fba223ba37c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d56d1-ba2c-49d3-bbb9-2c29f09fd9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d56d1-ba2c-49d3-bbb9-2c29f09fd9b5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23723,7 +23723,7 @@
         },
         {
             "id": "a222f3d6-35b7-578d-9bec-29a50f0f50a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3125bc4d-7e9e-4133-8d11-1abf3dc2cec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3125bc4d-7e9e-4133-8d11-1abf3dc2cec9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23764,7 +23764,7 @@
         },
         {
             "id": "e459bfea-0abf-5067-9163-c0c1642e171c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8cdf65-0113-47c3-a0d5-e0b74c333c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8cdf65-0113-47c3-a0d5-e0b74c333c81.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23805,7 +23805,7 @@
         },
         {
             "id": "b37bd5f8-de0d-52f1-94b7-d44da96f4b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f243292a-e8a6-43c2-805c-15715fcebd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f243292a-e8a6-43c2-805c-15715fcebd67.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23846,7 +23846,7 @@
         },
         {
             "id": "aa9efc5e-f28a-57ea-b724-0832e62592ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32eb6ab0-831e-4a30-a2fc-5ea1cb40930c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32eb6ab0-831e-4a30-a2fc-5ea1cb40930c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23887,7 +23887,7 @@
         },
         {
             "id": "fdfd3590-38a7-5b7f-8462-035414c1912c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49c0db1-5acc-48ed-a0f0-0510433d6d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49c0db1-5acc-48ed-a0f0-0510433d6d34.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23928,7 +23928,7 @@
         },
         {
             "id": "5071ae7d-3a07-511e-ae55-bb498a8296cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62465f68-6a84-41ae-8a14-41f41e817eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62465f68-6a84-41ae-8a14-41f41e817eff.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23969,7 +23969,7 @@
         },
         {
             "id": "839104e3-a92c-5a1a-94f7-820347935993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5339dcb-2544-4f19-acf3-86f83793301c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5339dcb-2544-4f19-acf3-86f83793301c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -24010,7 +24010,7 @@
         },
         {
             "id": "72d25549-aac6-5cb5-b114-fd77f6752b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060a07b-7408-4b95-a546-e2b2010d7818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060a07b-7408-4b95-a546-e2b2010d7818.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -24051,7 +24051,7 @@
         },
         {
             "id": "223ea81d-512f-53b3-9dfe-b917d12af141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267a5fa-f9a9-4a7f-89f9-24889868ccff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267a5fa-f9a9-4a7f-89f9-24889868ccff.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -24092,7 +24092,7 @@
         },
         {
             "id": "d0ab9f0f-65a6-5923-86be-f8c69f000dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628ee82b-1f10-4466-bdca-75c0f89d49c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628ee82b-1f10-4466-bdca-75c0f89d49c9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -24133,7 +24133,7 @@
         },
         {
             "id": "5f10bbd8-c2e5-5e96-8545-4d3e77a02d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82d07b-f8f2-4cdd-b799-98d4dc228e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82d07b-f8f2-4cdd-b799-98d4dc228e5c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24174,7 +24174,7 @@
         },
         {
             "id": "44d1f231-23cd-5f6c-ad19-e8cc20e0308e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d62e37-c8ab-4768-9be2-24546d5ded8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d62e37-c8ab-4768-9be2-24546d5ded8c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24215,7 +24215,7 @@
         },
         {
             "id": "6d382bb5-924b-544f-b213-578561df1f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce08c3b-3d08-446e-9f78-4ec22e9308db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce08c3b-3d08-446e-9f78-4ec22e9308db.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24256,7 +24256,7 @@
         },
         {
             "id": "4732dfdc-928d-5b3b-8393-4930ccf3e87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7ca58-e8db-49f5-954a-c4f83fcb44b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7ca58-e8db-49f5-954a-c4f83fcb44b3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24297,7 +24297,7 @@
         },
         {
             "id": "5b8be905-a342-5e94-9f21-7d3f662f2820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee631d-de1e-4c6f-b60e-0e97a5e99fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee631d-de1e-4c6f-b60e-0e97a5e99fe6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24338,7 +24338,7 @@
         },
         {
             "id": "a3c75459-48f0-5fb6-b7a7-4300a4204d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdee883-2002-43c7-a0fd-29e7ada26963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdee883-2002-43c7-a0fd-29e7ada26963.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24379,7 +24379,7 @@
         },
         {
             "id": "0fa3aa1f-c80f-5f8c-b426-be545d4a92d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec41fec-d146-40cc-8d9f-633e913f3ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec41fec-d146-40cc-8d9f-633e913f3ab3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24420,7 +24420,7 @@
         },
         {
             "id": "1420738a-fc87-5f91-b51f-e7254dedbc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f0207-228e-4812-bc5b-ee22cd5fd51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f0207-228e-4812-bc5b-ee22cd5fd51e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/9ED.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/9ED.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "61dbf877-9b49-58dc-b18f-5e8eb26c2dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112433-ae29-4f6a-9798-234c58ff5920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112433-ae29-4f6a-9798-234c58ff5920.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b70b6118-1c56-5b20-92c5-c16357f5d3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a4fffa-e21f-4470-9db8-1e7e218b02a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a4fffa-e21f-4470-9db8-1e7e218b02a2.jpg?1",
             "name": "Angel of Mercy",
             "text": "",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "10afa9c9-8d12-55c9-a4d1-bd9a5d6eaf46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0732d372-1000-435e-905b-4a6c852ba427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0732d372-1000-435e-905b-4a6c852ba427.jpg?1",
             "name": "Eager Cadet",
             "text": "",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "dc256d28-7919-54e6-8b7c-e93d9deecc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490d714e-1ccb-4ad0-9854-f14da2e90f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490d714e-1ccb-4ad0-9854-f14da2e90f7c.jpg?1",
             "name": "Angelic Blessing",
             "text": "Target creature gets +3/+3 and gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "f3ee008c-32cf-585a-b4c5-bdc961e5ca03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6d93a9-9cff-4e7c-9cf7-7e5167ac4d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6d93a9-9cff-4e7c-9cf7-7e5167ac4d91.jpg?1",
             "name": "Angelic Blessing",
             "text": "",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "db95d2fe-3ede-5b2f-8f2a-e5044a6533c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e7a88-d721-490f-8b62-23ce58092be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e7a88-d721-490f-8b62-23ce58092be8.jpg?1",
             "name": "Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "809ddea1-e0a6-5e90-b5a1-8d9312bdb61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17844d4-6316-4045-8fd3-194640b10bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17844d4-6316-4045-8fd3-194640b10bbe.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "7c810360-6601-5e1d-b391-bb5b4b7a8836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586e5a04-9edb-4d27-8018-256db22dc524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586e5a04-9edb-4d27-8018-256db22dc524.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "905acf47-97d7-5da3-b5d8-9860cbf34a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00223901-d462-41b0-9749-b093058f682f.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "81282847-ead5-562a-b5b3-a56731f62ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c97d63-d0f9-402d-948a-b73f73bed919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c97d63-d0f9-402d-948a-b73f73bed919.jpg?1",
             "name": "Aven Flock",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{W}: Aven Flock gets +0/+1 until end of turn.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "d41ef5b6-281d-5b7c-9898-db135d1967c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b5887e-ac30-4552-8457-01ae5a196c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b5887e-ac30-4552-8457-01ae5a196c1c.jpg?1",
             "name": "Aven Flock",
             "text": "",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "7836bea3-5344-5352-8a2f-2a62f90e652c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391d681-3530-4f6a-b421-12025e7c3b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391d681-3530-4f6a-b421-12025e7c3b89.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "2a3bf07f-3d91-5a9e-ab50-203de0f063be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb5923b-f2c1-47c4-af1f-af24ac7cb56b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb5923b-f2c1-47c4-af1f-af24ac7cb56b.jpg?1",
             "name": "Ballista Squad",
             "text": "{X}{W}, {T}: Ballista Squad deals X damage to target attacking or blocking creature.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "9ec0659e-ea83-5eda-88fb-6eb8224908cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede7b9ad-9c88-4319-a7f7-c9bee4be3c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede7b9ad-9c88-4319-a7f7-c9bee4be3c1c.jpg?1",
             "name": "Ballista Squad",
             "text": "",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "426b3a93-6494-5397-870a-9e02b81a95bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01491b39-283b-438f-8c7c-8df1285e9a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01491b39-283b-438f-8c7c-8df1285e9a83.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "7614f14d-e0d9-5553-9fc7-2db7ea5a96be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c044857-2124-44f4-aafb-495511f26b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c044857-2124-44f4-aafb-495511f26b3b.jpg?1",
             "name": "Blessed Orator",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -554,7 +554,7 @@
         },
         {
             "id": "e643802d-a1b6-582a-b3d1-3b5ef21b8083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379777a4-5704-4b5a-9916-7bab4d82eeab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379777a4-5704-4b5a-9916-7bab4d82eeab.jpg?1",
             "name": "Blessed Orator",
             "text": "",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "66104f32-e94e-578b-8928-7c97cad85d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04256f8-c275-4a24-8a95-371d424f7a01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04256f8-c275-4a24-8a95-371d424f7a01.jpg?1",
             "name": "Blinding Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Blinding Angel deals combat damage to a player, that player skips his or her next combat phase.",
             "colours": [
@@ -625,7 +625,7 @@
         },
         {
             "id": "dc40e046-0ac3-5a36-8944-ec0c51cce415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbba7702-6970-4501-918b-b262e0fa8b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbba7702-6970-4501-918b-b262e0fa8b28.jpg?1",
             "name": "Blinding Angel",
             "text": "",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "b5c3bbd2-b0dc-5169-a503-e65a686b2611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a82ffff-e02a-4ecb-a92d-8ed571beac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a82ffff-e02a-4ecb-a92d-8ed571beac46.jpg?1",
             "name": "Vizzerdrix",
             "text": "",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "f45d8c36-c5c9-595d-9892-cd6101f8c136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ac387-be1f-48e0-945e-cbb1254d395c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ac387-be1f-48e0-945e-cbb1254d395c.jpg?1",
             "name": "Blinking Spirit",
             "text": "{0}: Return Blinking Spirit to its owner's hand.",
             "colours": [
@@ -729,7 +729,7 @@
         },
         {
             "id": "9a568028-b633-508c-ba29-38883c0fcc86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b340426-b852-43a5-8868-d5dacfdaf031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b340426-b852-43a5-8868-d5dacfdaf031.jpg?1",
             "name": "Blinking Spirit",
             "text": "",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "3d3f2568-6dfc-5ae9-94ec-189adfb8e396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f026d65f-c365-475b-9454-e9935af00ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f026d65f-c365-475b-9454-e9935af00ec4.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -798,7 +798,7 @@
         },
         {
             "id": "ba1936c9-983c-5316-a2e9-8950cc6a094b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e0d3d9-8c28-46d7-9fab-c115e6c8682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e0d3d9-8c28-46d7-9fab-c115e6c8682f.jpg?1",
             "name": "Chastise",
             "text": "Destroy target attacking creature. You gain life equal to its power.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "31069c30-388f-58d5-93b9-a61f6183a5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe622c34-7b41-4855-a07f-a2ff773a2745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe622c34-7b41-4855-a07f-a2ff773a2745.jpg?1",
             "name": "Chastise",
             "text": "",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "9cc993d4-352b-5fa3-9e10-e4244f8621f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681faafe-68ce-4b71-bf23-a8028614ede5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681faafe-68ce-4b71-bf23-a8028614ede5.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -897,7 +897,7 @@
         },
         {
             "id": "d69b3de2-fe8a-51fb-ab11-8589e552dfb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab2933-5970-4a17-ac00-abcd2c048fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab2933-5970-4a17-ac00-abcd2c048fdc.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "{1}: The next time a black source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "17372879-175f-56c0-bb0d-f1a6c1bd6713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4945b-59fc-47aa-8f41-41d5afdf5775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4945b-59fc-47aa-8f41-41d5afdf5775.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "",
             "colours": [
@@ -963,7 +963,7 @@
         },
         {
             "id": "fe3440de-6184-5464-af4c-63f5d462b1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010c3ded-9df5-4880-b178-80f0e3c54731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010c3ded-9df5-4880-b178-80f0e3c54731.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "db283cdc-be8d-5065-acd6-09559065bf49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7920b6d-ff71-4802-9589-e1df0c58b9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7920b6d-ff71-4802-9589-e1df0c58b9ff.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "{1}: The next time a red source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "bc2ad842-8f54-5b5b-8dc4-798c1612dcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757645fa-5f76-4300-b46c-7cd84e9304f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757645fa-5f76-4300-b46c-7cd84e9304f8.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "c00ad957-9ccb-5fd2-b632-4350fba4eead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d962926a-e415-4075-b5dd-3db68526bdb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d962926a-e415-4075-b5dd-3db68526bdb9.jpg?1",
             "name": "Crossbow Infantry",
             "text": "{T}: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "836a381b-d524-5d24-bda8-c6e319277947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002b75fc-c4ba-40fa-9758-8a550e68043b.jpg?1",
             "name": "Crossbow Infantry",
             "text": "",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "0e8099a7-178d-51ed-b0b9-c442a9bef212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2f98f8-f345-4cd4-90c5-43bc4c4c165d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2f98f8-f345-4cd4-90c5-43bc4c4c165d.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "3326b69e-a683-5080-9705-8b6c106302e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eea828-1a88-4470-aa04-8003343cb92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eea828-1a88-4470-aa04-8003343cb92e.jpg?1",
             "name": "Demystify",
             "text": "",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "00f1c7dc-96b4-52c0-bc64-66b621c69330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baff03f3-a8ca-4c35-ae71-43b5d237b519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baff03f3-a8ca-4c35-ae71-43b5d237b519.jpg?1",
             "name": "Foot Soldiers",
             "text": "",
             "colours": [
@@ -1238,7 +1238,7 @@
         },
         {
             "id": "fc25d285-b294-5812-8f86-fc24177ec14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c39ff7-6234-4cc8-be5c-dd8ff9284a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c39ff7-6234-4cc8-be5c-dd8ff9284a07.jpg?1",
             "name": "Foot Soldiers",
             "text": "",
             "colours": [
@@ -1274,7 +1274,7 @@
         },
         {
             "id": "53020381-5933-53c0-8a79-964a456bc5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b109388-7988-4092-8cf4-c56668a4c66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b109388-7988-4092-8cf4-c56668a4c66b.jpg?1",
             "name": "Gift of Estates",
             "text": "If an opponent has more lands than you, search your library for up to three Plains cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "619d5559-c1c8-5b13-a9c3-e88a2dc8e641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896389ba-a509-4a9c-b35b-c2b122df3fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896389ba-a509-4a9c-b35b-c2b122df3fa4.jpg?1",
             "name": "Gift of Estates",
             "text": "",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "7a434b8e-8fa7-59ce-911a-77b000fa0cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a94e8-baba-42e1-8577-03bbaa8f5707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a94e8-baba-42e1-8577-03bbaa8f5707.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1373,7 +1373,7 @@
         },
         {
             "id": "38e06c9e-5b08-5485-85b6-ed5a75a2a6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f720431d-dbb6-42ed-ac4d-13e2b51c1ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f720431d-dbb6-42ed-ac4d-13e2b51c1ddf.jpg?1",
             "name": "Glorious Anthem",
             "text": "",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "c451546c-92d8-5f26-90d1-5c0f8bf1c791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979748a-4820-4c6a-b4b0-1bfb46e2817a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979748a-4820-4c6a-b4b0-1bfb46e2817a.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1442,7 +1442,7 @@
         },
         {
             "id": "9c92564f-6648-5561-a2ce-ba888bf95733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d275a-28fc-4c06-bd4d-a4f2e03574f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d275a-28fc-4c06-bd4d-a4f2e03574f6.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "f11ff4a2-8649-5a9d-b628-e282ae104060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adefbeb-c9fc-48b7-9030-cd0d367dd19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adefbeb-c9fc-48b7-9030-cd0d367dd19e.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "6e792158-58f3-55bb-9e06-6423701b70fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98746ce2-aa9d-4099-b25b-14f9f809d7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98746ce2-aa9d-4099-b25b-14f9f809d7ed.jpg?1",
             "name": "Holy Day",
             "text": "",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "e26e56ed-49b6-5781-a3fd-ff051390e830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7848f996-ea89-43fd-b0b3-4437f397531a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7848f996-ea89-43fd-b0b3-4437f397531a.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "175fa96e-41ae-57c1-9be4-151596f843ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb4a027-3d07-420a-b191-2172fe871c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb4a027-3d07-420a-b191-2172fe871c13.jpg?1",
             "name": "Holy Strength",
             "text": "",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "863213b2-843a-5dd3-81f0-47c152884c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f208a8-115a-4734-b56a-9330018cb269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f208a8-115a-4734-b56a-9330018cb269.jpg?1",
             "name": "Honor Guard",
             "text": "{W}: Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "85ca68f1-fec7-5b65-8aa0-8ceb0ab69c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ab7db-467f-483e-9bcd-3a484e1d0df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ab7db-467f-483e-9bcd-3a484e1d0df6.jpg?1",
             "name": "Honor Guard",
             "text": "",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "d5d8fcb0-d93d-5fb6-92eb-ec664fd21828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2b04aa-6643-4eae-9197-4acd7d3e3535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2b04aa-6643-4eae-9197-4acd7d3e3535.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "9c44790b-fa6c-58be-a665-06955e53548e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6692c670-d33c-4e6f-87db-4e9dcbc18ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6692c670-d33c-4e6f-87db-4e9dcbc18ab8.jpg?1",
             "name": "Infantry Veteran",
             "text": "",
             "colours": [
@@ -1758,7 +1758,7 @@
         },
         {
             "id": "9403430a-70b7-58f6-b5df-74affff4e75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d30356b-ab7b-4366-9f90-15703d5c3d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d30356b-ab7b-4366-9f90-15703d5c3d10.jpg?1",
             "name": "Inspirit",
             "text": "Untap target creature. It gets +2/+4 until end of turn.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "7029ca48-4f51-5bab-adcd-c84a7787de37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f13470-78c5-48e5-8ad2-23bf20843ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f13470-78c5-48e5-8ad2-23bf20843ebe.jpg?1",
             "name": "Inspirit",
             "text": "",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "d833132b-f40d-5c0f-bf59-551148c61070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02422f7-728b-481b-9eb1-34d17c696ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02422f7-728b-481b-9eb1-34d17c696ce6.jpg?1",
             "name": "Ivory Mask",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "d03f1f8c-ec53-5150-af5e-eeccfefcc948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15221c5b-543c-4f43-a02e-d07e84069f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15221c5b-543c-4f43-a02e-d07e84069f50.jpg?1",
             "name": "Ivory Mask",
             "text": "",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "18ee8a9d-387e-574e-a17d-e70c25f6c462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422fe3bd-d92e-4c91-8c30-3b5aec00201a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422fe3bd-d92e-4c91-8c30-3b5aec00201a.jpg?1",
             "name": "Kami of Old Stone",
             "text": "",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "554a0c49-9a67-5dc7-a3f8-3e75fe2832aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab27f51-230c-469d-9b8a-a21b9d0fccf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab27f51-230c-469d-9b8a-a21b9d0fccf5.jpg?1",
             "name": "Kami of Old Stone",
             "text": "",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "cb9865b4-f7eb-5549-8adf-c7cb247ae0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415fb9e-fe47-435d-b47d-b0e62f51d327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415fb9e-fe47-435d-b47d-b0e62f51d327.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "5dd7f286-bf6c-5625-bd4c-c2b67df57248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb06f76-cbf0-42bb-adc0-0811d077b3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb06f76-cbf0-42bb-adc0-0811d077b3e0.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "66b3fcf1-9e84-54ad-8975-a142e6d84adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4816f18-9f66-4539-9764-2f65f2826812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4816f18-9f66-4539-9764-2f65f2826812.jpg?1",
             "name": "Marble Titan",
             "text": "Creatures with power 3 or greater don't untap during their controllers' untap steps.",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "9231da68-6c9c-53f9-bf24-03751de46689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64b1fae-6e5a-46b4-8966-7e39c777604e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64b1fae-6e5a-46b4-8966-7e39c777604e.jpg?1",
             "name": "Marble Titan",
             "text": "",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "fa1fa246-c5ae-5604-94cd-2fe49a66ecb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a49276-fb02-4b8b-8b63-7477835fb809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a49276-fb02-4b8b-8b63-7477835fb809.jpg?1",
             "name": "Master Decoy",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "207429c1-edc4-59be-93f9-b269e69de3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce511578-8857-45a8-98fe-c8b0bfc54fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce511578-8857-45a8-98fe-c8b0bfc54fcb.jpg?1",
             "name": "Master Decoy",
             "text": "",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "5047bdae-a0ad-5eba-bf71-d5467393776d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a4a15d-9f16-4aa1-adc0-5d4c85991062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a4a15d-9f16-4aa1-adc0-5d4c85991062.jpg?1",
             "name": "Master Healer",
             "text": "{T}: Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2210,7 +2210,7 @@
         },
         {
             "id": "0d7c6f13-a0f3-58b5-b4e7-c157e76a499d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4145d8e-40cc-49ab-83c6-394d4595a1a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4145d8e-40cc-49ab-83c6-394d4595a1a4.jpg?1",
             "name": "Master Healer",
             "text": "",
             "colours": [
@@ -2246,7 +2246,7 @@
         },
         {
             "id": "c4b50fe2-1b65-5444-a56b-a806676a494e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53709642-9d61-425f-9bcf-0c579404b521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53709642-9d61-425f-9bcf-0c579404b521.jpg?1",
             "name": "Mending Hands",
             "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "2a37fb5b-b65e-5b7d-bdbf-f7a226c54329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad55756-15c6-4c07-8b1c-1b8327c40f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad55756-15c6-4c07-8b1c-1b8327c40f14.jpg?1",
             "name": "Mending Hands",
             "text": "",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "8678370b-c6d7-5dcc-98b9-561fbf014dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a180a4-bffc-4f4f-ae34-3afa4a565960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a180a4-bffc-4f4f-ae34-3afa4a565960.jpg?1",
             "name": "Oracle's Attendants",
             "text": "{T}: All damage that would be dealt to target creature this turn by a source of your choice is dealt to Oracle's Attendants instead.",
             "colours": [
@@ -2348,7 +2348,7 @@
         },
         {
             "id": "c8716743-fc3d-5168-b33c-78659a7bae12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b645a86e-2fca-451e-8bda-9f4bd0c5db04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b645a86e-2fca-451e-8bda-9f4bd0c5db04.jpg?1",
             "name": "Oracle's Attendants",
             "text": "",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "2be8be24-21a9-5faf-84bc-0a91efae0b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4f7e7-31fa-4009-9b23-cdc2060be8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4f7e7-31fa-4009-9b23-cdc2060be8b8.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature can't attack or block.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "62961390-072a-51c8-b8cf-f4443c6d3c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a91a5-b897-413e-8fd1-482448a92d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a91a5-b897-413e-8fd1-482448a92d83.jpg?1",
             "name": "Pacifism",
             "text": "",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "a2dffd4d-d652-5f31-a738-d28c3d36f684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc33dd-0ad6-482c-b29f-71dad8b4166b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc33dd-0ad6-482c-b29f-71dad8b4166b.jpg?1",
             "name": "Paladin en-Vec",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from black, protection from red (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black or red.)",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "27acb0c6-070e-5e85-baeb-69c13accf05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05825222-8f73-460b-8066-1b77961325e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05825222-8f73-460b-8066-1b77961325e0.jpg?1",
             "name": "Paladin en-Vec",
             "text": "",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "76de0842-e7de-56ac-91cb-7a78916190c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b9e34-1ffb-4e46-b08c-d6587f350391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b9e34-1ffb-4e46-b08c-d6587f350391.jpg?1",
             "name": "Peace of Mind",
             "text": "{W}, Discard a card: You gain 3 life.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "b03090b9-d70d-5fe7-8f63-2a7f5210de18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ecac8-2061-4e4f-b178-6cfd2f429855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ecac8-2061-4e4f-b178-6cfd2f429855.jpg?1",
             "name": "Peace of Mind",
             "text": "",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "c134fe6c-eac8-59d3-918a-5a97e0d28ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0dee73-4df3-4b2f-9420-b23e6ced65c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0dee73-4df3-4b2f-9420-b23e6ced65c0.jpg?1",
             "name": "Pegasus Charger",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "085fc0ff-0528-50f4-b1d8-eacc86a900cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30e8bea-37f2-47da-baaa-d78fa342ea29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30e8bea-37f2-47da-baaa-d78fa342ea29.jpg?1",
             "name": "Pegasus Charger",
             "text": "",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "11d1ac84-f14c-586f-8fc3-dd16676d8f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f938c52-c7f6-41a4-b480-632b43b60b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f938c52-c7f6-41a4-b480-632b43b60b67.jpg?1",
             "name": "Reverse Damage",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain that much life.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "289af6b2-5104-5b02-97f1-754f332e5819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e5f9e-0693-415a-aad6-339581334e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3e5f9e-0693-415a-aad6-339581334e66.jpg?1",
             "name": "Reverse Damage",
             "text": "",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "eb34db01-d6c1-5be1-8b00-e05667695537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dac325-73d7-4377-8f56-14342e7dacd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dac325-73d7-4377-8f56-14342e7dacd7.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "9f7d23f5-5aa4-5a16-883b-141d9c5357e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4b42e-8efd-4b30-932d-c49049e9aff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4b42e-8efd-4b30-932d-c49049e9aff7.jpg?1",
             "name": "Righteousness",
             "text": "",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "e7c687c0-64fc-54a7-9832-d373e78c81b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72dc68a-d6f9-4a18-8282-0f104999591f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72dc68a-d6f9-4a18-8282-0f104999591f.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever a spell or ability an opponent controls causes a land to be put into your graveyard from play, return that land to play.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "a3990c1f-9182-5d05-b5a8-10bd37ccea17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3adae5-0cdc-404c-bb4f-fdf1bc0332cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3adae5-0cdc-404c-bb4f-fdf1bc0332cc.jpg?1",
             "name": "Sacred Ground",
             "text": "",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "de3dacd2-3830-594c-8801-21613ca7a75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd5e1c-47db-4960-860c-2af14b734b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd5e1c-47db-4960-860c-2af14b734b59.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "b3e4d22c-3a45-5c81-9c85-2841d783d3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6b307-c648-4351-bcbd-afadf192ca6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6b307-c648-4351-bcbd-afadf192ca6f.jpg?1",
             "name": "Sacred Nectar",
             "text": "",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "0b262ee6-fb78-5ad3-83fe-acc8539fada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a74bec-ba6c-45f3-bc25-60cda8fa908b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a74bec-ba6c-45f3-bc25-60cda8fa908b.jpg?1",
             "name": "Samite Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "a51eecab-a643-50b6-b3eb-41cb5a237ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371cd55b-9f40-4730-83c1-5fee54d0d7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371cd55b-9f40-4730-83c1-5fee54d0d7f5.jpg?1",
             "name": "Samite Healer",
             "text": "",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "7a641315-66fd-5e82-8f76-da3a05ee9bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166cd9d3-7750-4f41-bffd-8f6739204d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166cd9d3-7750-4f41-bffd-8f6739204d2e.jpg?1",
             "name": "Sanctum Guardian",
             "text": "Sacrifice Sanctum Guardian: The next time a source of your choice would deal damage to target creature or player this turn, prevent that damage.",
             "colours": [
@@ -3034,7 +3034,7 @@
         },
         {
             "id": "cc058797-a069-5f47-bffb-734ead9b1344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab759df-5120-45a9-897e-4729fcbf6eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab759df-5120-45a9-897e-4729fcbf6eb9.jpg?1",
             "name": "Sanctum Guardian",
             "text": "",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "369232f4-85b1-5991-ae78-34d78e4d9b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9f9f3c-d024-4529-bffb-c7a5a3085e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9f9f3c-d024-4529-bffb-c7a5a3085e58.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "370f9f97-d0ee-5760-ae9b-d261990649e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2b107-1938-4d42-9bfa-0c88fd1e822a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2b107-1938-4d42-9bfa-0c88fd1e822a.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "40ba6ed0-96a0-5448-8dc5-d50441407386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed679-d66b-4f3c-83e4-e59ea106b00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed679-d66b-4f3c-83e4-e59ea106b00a.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "0b34180f-7761-5221-90f9-8e52fec70a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49dc8bb-6fde-426e-9779-813af21367ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49dc8bb-6fde-426e-9779-813af21367ef.jpg?1",
             "name": "Seasoned Marshal",
             "text": "",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "165a1bf7-e9fc-50ce-ad1a-3f971c3cad7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71567cb0-f4f3-4e86-a9d3-c207119a3185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71567cb0-f4f3-4e86-a9d3-c207119a3185.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "646a6755-dda4-5c76-b737-10f42738fb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cb23f-52d2-49b2-b07b-39679d695fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cb23f-52d2-49b2-b07b-39679d695fc1.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "ac5fecec-e4f3-54e8-b6a6-fc7e5cac6a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617547a7-087e-49b0-8c28-5aae457bec99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617547a7-087e-49b0-8c28-5aae457bec99.jpg?1",
             "name": "Serra's Blessing",
             "text": "Creatures you control have vigilance. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "acdd7051-cfe9-564d-b65a-d80821080c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f7aa-abc5-406f-99b5-093615981bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f7aa-abc5-406f-99b5-093615981bc7.jpg?1",
             "name": "Serra's Blessing",
             "text": "",
             "colours": [
@@ -3348,7 +3348,7 @@
         },
         {
             "id": "4f30adcf-bcd7-58ed-b032-e06487f60381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84f34ff-de33-4091-90b6-9de5336987f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84f34ff-de33-4091-90b6-9de5336987f0.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "c5c90b49-bdfc-5fcb-9f13-fc45824142c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bc2496-786d-4647-aa96-b49027b7e13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bc2496-786d-4647-aa96-b49027b7e13d.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "fc382582-2cc4-5869-aba2-eb6f2cfea24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d4f46-4cf7-40f6-9988-5103146f3ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d4f46-4cf7-40f6-9988-5103146f3ff2.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature comes into play, you gain 1 life.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "4b4370f3-fff3-5e2d-98e8-37e9f99a70aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5590a7-dca5-40e3-b760-4d68d99b8740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5590a7-dca5-40e3-b760-4d68d99b8740.jpg?1",
             "name": "Soul Warden",
             "text": "",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "75e4e476-5dab-5d1f-b4d1-4a3d662c096e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38906047-d692-46e4-a42d-08293b42f29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38906047-d692-46e4-a42d-08293b42f29c.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "b3240e85-7504-537f-9a87-d07318b6e100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3171f29-96f6-44cc-b246-fbb9e3ba833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3171f29-96f6-44cc-b246-fbb9e3ba833d.jpg?1",
             "name": "Spirit Link",
             "text": "",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "d4e4d3a3-4259-5c03-8bd6-1be9e4557c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2762550-6c20-4e76-9d6a-b7085e5baebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2762550-6c20-4e76-9d6a-b7085e5baebd.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\n{W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "c9a61107-3c39-5251-af6e-729c0687cd16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8b339-2d1b-4f18-b9cb-08c4102df038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8b339-2d1b-4f18-b9cb-08c4102df038.jpg?1",
             "name": "Story Circle",
             "text": "",
             "colours": [
@@ -3628,7 +3628,7 @@
         },
         {
             "id": "4d7a623e-7260-5d6d-afe9-de2c9aa02594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff9c46b-51d3-44d7-8f27-1a466fa8ba3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff9c46b-51d3-44d7-8f27-1a466fa8ba3d.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "0d0d36ac-8fb8-5550-8b00-d1a542a6685b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9094c7-0033-494e-ae3b-37ee27be8968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9094c7-0033-494e-ae3b-37ee27be8968.jpg?1",
             "name": "Suntail Hawk",
             "text": "",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "61a4ce31-fa75-52c2-b7b5-65230608229a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c3e220-00c8-4afc-a8a3-e95e7c8c1629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c3e220-00c8-4afc-a8a3-e95e7c8c1629.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -3731,7 +3731,7 @@
         },
         {
             "id": "f0867558-e329-5b0a-8e7d-21357e478bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc53b0dc-1243-46e6-8cd9-eab3498a7102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc53b0dc-1243-46e6-8cd9-eab3498a7102.jpg?1",
             "name": "Tempest of Light",
             "text": "",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "9061cdac-b00e-5304-9d8b-e67c7ca8d023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c70b89-9b06-42fe-ba63-99f70642eaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c70b89-9b06-42fe-ba63-99f70642eaf4.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, you gain 2 life.",
             "colours": [
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "dea55495-9abb-5069-b8ef-52050f896348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c1078-6c7b-41c6-9eca-eb2509ea7253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c1078-6c7b-41c6-9eca-eb2509ea7253.jpg?1",
             "name": "Venerable Monk",
             "text": "",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "6a1e26b9-3121-5dba-a5d5-02126542bab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31072355-0b20-4830-9d46-ca71783af84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31072355-0b20-4830-9d46-ca71783af84b.jpg?1",
             "name": "Veteran Cavalier",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "bafd5289-322a-52c5-bf42-d3e22a47fa92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b67b451-b2b6-4c3b-9578-3492bd85586e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b67b451-b2b6-4c3b-9578-3492bd85586e.jpg?1",
             "name": "Veteran Cavalier",
             "text": "",
             "colours": [
@@ -3910,7 +3910,7 @@
         },
         {
             "id": "b5e61673-7054-5825-b71b-6ded5335a2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9718a0-4e8d-4633-ab18-03ed51b9980c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9718a0-4e8d-4633-ab18-03ed51b9980c.jpg?1",
             "name": "Warrior's Honor",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "dfceeb9b-72bb-5c3a-b3b6-f16dd760f132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffc323f-ac91-46fe-a762-39dbe62c6662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffc323f-ac91-46fe-a762-39dbe62c6662.jpg?1",
             "name": "Warrior's Honor",
             "text": "",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "f7e1778a-df64-5615-82b1-b2e0a7c7fd67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4be040-27b1-4501-b3d4-f12976e568c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4be040-27b1-4501-b3d4-f12976e568c9.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "{W}, {T}: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library. Play this ability only if an opponent controls more lands than you.",
             "colours": [
@@ -4013,7 +4013,7 @@
         },
         {
             "id": "e3d5a6ad-3d31-547c-b64f-8644ffd271c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c469cc-1835-4913-8582-63e0fdbc6fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c469cc-1835-4913-8582-63e0fdbc6fce.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "476b70e8-3dd1-52f6-9b70-e7202b5ce198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad20044-8ed8-49ae-9a07-d4cb18527cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad20044-8ed8-49ae-9a07-d4cb18527cc7.jpg?1",
             "name": "Worship",
             "text": "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -4083,7 +4083,7 @@
         },
         {
             "id": "b54af2fd-5390-50b3-bcfd-53b8f27a6a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cc37c-5fad-4e92-a563-0f5a400f0d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cc37c-5fad-4e92-a563-0f5a400f0d1c.jpg?1",
             "name": "Worship",
             "text": "",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "55398f87-dac3-5348-8aa2-ebcf33da87fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c1e9e3-c947-47cc-ac60-dc032d984a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c1e9e3-c947-47cc-ac60-dc032d984a67.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -4149,7 +4149,7 @@
         },
         {
             "id": "a64d4d4d-56ce-5b43-9df3-6334958651b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c478aad9-f876-4c1f-9f04-851e6f0de58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c478aad9-f876-4c1f-9f04-851e6f0de58c.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "083856e8-0144-565a-bfbf-b49699f8693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7621b1af-fdbd-4604-b37c-04fb8f68c3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7621b1af-fdbd-4604-b37c-04fb8f68c3b6.jpg?1",
             "name": "Zealous Inquisitor",
             "text": "{1}{W}: The next 1 damage that would be dealt to Zealous Inquisitor this turn is dealt to target creature instead.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "fbf232b1-6977-51a0-8606-0552477edba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c1481-e29d-4f39-a9c1-cdfa16a6a377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c1481-e29d-4f39-a9c1-cdfa16a6a377.jpg?1",
             "name": "Zealous Inquisitor",
             "text": "",
             "colours": [
@@ -4254,7 +4254,7 @@
         },
         {
             "id": "7c1485bb-d341-5e11-9bdf-ac7b0d611b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0267612-fd15-497f-b6be-9e2797e6895d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0267612-fd15-497f-b6be-9e2797e6895d.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "347c768b-4226-5809-93d5-38362aa3fb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980f75a4-7145-43c0-867a-cafbfaa2944e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980f75a4-7145-43c0-867a-cafbfaa2944e.jpg?1",
             "name": "Air Elemental",
             "text": "",
             "colours": [
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "8c04f561-8152-58b6-92b9-e519f00811f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0df72c6-4f54-43ec-a4e0-5733003f4fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0df72c6-4f54-43ec-a4e0-5733003f4fd7.jpg?1",
             "name": "Annex",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nYou control enchanted land.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "d472a106-880f-5dcf-9f73-e2b6bd710667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f445aa-0e8c-4852-8d07-d9a2819a14a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f445aa-0e8c-4852-8d07-d9a2819a14a6.jpg?1",
             "name": "Annex",
             "text": "",
             "colours": [
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "cddf1582-5819-505d-bcef-02aa3f93c6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f025c11-feeb-429b-9518-f24d70596601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f025c11-feeb-429b-9518-f24d70596601.jpg?1",
             "name": "Archivist",
             "text": "{T}: Draw a card.",
             "colours": [
@@ -4430,7 +4430,7 @@
         },
         {
             "id": "9b1ecd6e-a78f-5eb8-ba78-685520d84304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e92e-6cc0-4e96-95f2-10ac610f8203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e92e-6cc0-4e96-95f2-10ac610f8203.jpg?1",
             "name": "Archivist",
             "text": "",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "e48efaab-e817-512e-ac01-91b87d3f7006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3d4fe-0f94-4989-892d-210ae0be67d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3d4fe-0f94-4989-892d-210ae0be67d8.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "8c71a2ff-b190-595f-a28d-166ba215dd83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac9b50-eb87-484b-bc80-a11d8e76e6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac9b50-eb87-484b-bc80-a11d8e76e6f0.jpg?1",
             "name": "Aven Fisher",
             "text": "",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "9b6e4bf2-0da6-5839-9792-62c6b54efe29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e017119-4040-4277-849f-3ed961c992c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e017119-4040-4277-849f-3ed961c992c6.jpg?1",
             "name": "Aven Windreader",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{U}: Target player reveals the top card of his or her library.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "82b5377d-fcdf-5df5-90c1-0149d3b7c9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688712e6-c17a-45e6-ab52-12ae7e68712b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688712e6-c17a-45e6-ab52-12ae7e68712b.jpg?1",
             "name": "Aven Windreader",
             "text": "",
             "colours": [
@@ -4612,7 +4612,7 @@
         },
         {
             "id": "e7b7d804-2b02-51b6-be91-5129a24094ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dab6a1-0f20-4e87-9cb1-8f97eb860999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dab6a1-0f20-4e87-9cb1-8f97eb860999.jpg?1",
             "name": "Azure Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "11820af5-5e2d-50b7-a712-1e1b46154567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc401172-a1dd-408e-8cf5-7a07ea8d6603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc401172-a1dd-408e-8cf5-7a07ea8d6603.jpg?1",
             "name": "Azure Drake",
             "text": "",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "03ef0ec5-f83c-5f4f-ab50-8f7105e38739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b1df0-1838-40df-af62-08a73c3d8033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b1df0-1838-40df-af62-08a73c3d8033.jpg?1",
             "name": "Baleful Stare",
             "text": "Target opponent reveals his or her hand. You draw a card for each Mountain and red card in it.",
             "colours": [
@@ -4715,7 +4715,7 @@
         },
         {
             "id": "8dec10f6-6a70-5164-a795-bf356178cf04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04fd23b-71f3-4035-a754-26ba6d14c2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04fd23b-71f3-4035-a754-26ba6d14c2e7.jpg?1",
             "name": "Baleful Stare",
             "text": "",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "9893ae41-e08d-5661-a8c8-4b3cad4b85a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b56b6c-1372-4e4b-afe0-6030777efc68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b56b6c-1372-4e4b-afe0-6030777efc68.jpg?1",
             "name": "Battle of Wits",
             "text": "At the beginning of your upkeep, if you have 200 or more cards in your library, you win the game.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "3b016b4c-e1db-5c9c-b413-86d9088439bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a188c7-bfda-4fc0-83dd-f3e47433fefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a188c7-bfda-4fc0-83dd-f3e47433fefd.jpg?1",
             "name": "Battle of Wits",
             "text": "",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "62172901-bdfc-5a1e-9a30-475f33edbede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac61a76-80a5-4bde-9ff3-c8971a218d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac61a76-80a5-4bde-9ff3-c8971a218d60.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -4847,7 +4847,7 @@
         },
         {
             "id": "67895c2c-d3ff-59ed-97b7-29fced207a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13bea02-835e-421d-a38b-8129ad916059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13bea02-835e-421d-a38b-8129ad916059.jpg?1",
             "name": "Boomerang",
             "text": "",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "a7b171fb-8a03-5633-a413-bbcb901d4cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869f64b0-14ca-4171-8fde-1528bf7b9846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869f64b0-14ca-4171-8fde-1528bf7b9846.jpg?1",
             "name": "Clone",
             "text": "As Clone comes into play, you may choose a creature in play. If you do, Clone comes into play as a copy of that creature.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "e1da6d64-2d67-511d-b4de-94b6fd416823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb64c5b-06c9-4fc6-b08d-ca7078101cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb64c5b-06c9-4fc6-b08d-ca7078101cdb.jpg?1",
             "name": "Clone",
             "text": "",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "2e1b3917-049c-5ea9-b056-9ce6b55530e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095d77fd-c1d1-49e6-89f8-a272522e09fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095d77fd-c1d1-49e6-89f8-a272522e09fe.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent (Target a permanent as you play this. This card comes into play attached to that permanent.)\nYou control enchanted permanent.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "d8312d97-4771-58bf-9bb5-9989b24619d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a39ec-a66d-42aa-be3a-62551ad33f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a39ec-a66d-42aa-be3a-62551ad33f73.jpg?1",
             "name": "Confiscate",
             "text": "",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "9cbd2309-0a76-54a4-a170-f2ff24887c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ab2cb6-856c-4696-a17b-8f0002bd48ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ab2cb6-856c-4696-a17b-8f0002bd48ee.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "Draw two cards.",
             "colours": [
@@ -5053,7 +5053,7 @@
         },
         {
             "id": "b5ba51c4-6311-5ab2-9409-28844c810d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33f9573-3ca2-4d5f-82e1-ff3144e5803c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33f9573-3ca2-4d5f-82e1-ff3144e5803c.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "",
             "colours": [
@@ -5086,7 +5086,7 @@
         },
         {
             "id": "9463faa6-0114-5d8d-92fa-0a72297c521f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c3cf8f-c2f6-4ad0-83f9-960e5d74fc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c3cf8f-c2f6-4ad0-83f9-960e5d74fc3e.jpg?1",
             "name": "Cowardice",
             "text": "Whenever a creature becomes the target of a spell or ability, return that creature to its owner's hand. (It won't be affected by the spell or ability.)",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "34c7c425-a52e-5765-9243-563fbbfd36c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfa3bd-4f08-43c7-9ed3-314bc46a357e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfa3bd-4f08-43c7-9ed3-314bc46a357e.jpg?1",
             "name": "Cowardice",
             "text": "",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "0ea9f084-4e50-5d90-b4df-f004168aedcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb5c44-3a6f-49b9-a36a-63d0398a34a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb5c44-3a6f-49b9-a36a-63d0398a34a0.jpg?1",
             "name": "Crafty Pathmage",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -5188,7 +5188,7 @@
         },
         {
             "id": "f74b585d-199f-5f84-90c4-bd3216b8f360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0ab433-35ab-4e7d-a78e-e4b11fee773d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0ab433-35ab-4e7d-a78e-e4b11fee773d.jpg?1",
             "name": "Crafty Pathmage",
             "text": "",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "be08b4f5-582e-531c-852a-6bf60f3abe01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5becbf-77ac-4bd2-912d-7f7c944c2a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5becbf-77ac-4bd2-912d-7f7c944c2a0b.jpg?1",
             "name": "Daring Apprentice",
             "text": "{T}, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "e4175084-0468-5a0c-aa0f-aedca7eecfcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d512d6d-e92f-48a0-8182-b2936b321c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d512d6d-e92f-48a0-8182-b2936b321c91.jpg?1",
             "name": "Daring Apprentice",
             "text": "",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "d92fdc74-14c8-5c65-b160-b2215bd16a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2e44-e2e1-42b7-8f9f-0ce430af2359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2e44-e2e1-42b7-8f9f-0ce430af2359.jpg?1",
             "name": "Dehydration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "ef4b04e3-50b2-5af8-83b9-1d21c1712e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04337aee-6282-4d68-a12a-f71e7013f4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04337aee-6282-4d68-a12a-f71e7013f4c0.jpg?1",
             "name": "Dehydration",
             "text": "",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "d5ce32da-8399-595e-b1a4-b08aacb3a23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3327ff-89d4-40f5-8751-c6669d04fede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3327ff-89d4-40f5-8751-c6669d04fede.jpg?1",
             "name": "Dream Prowler",
             "text": "Dream Prowler is unblockable as long as it's attacking alone.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "cf116ff8-c924-59d5-b640-77e2cce14bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd52df-c78b-48e9-85b1-1e2fef6f9dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd52df-c78b-48e9-85b1-1e2fef6f9dc0.jpg?1",
             "name": "Dream Prowler",
             "text": "",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "058ea251-691b-5137-b562-62b25c8c2996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caccacb7-7d17-4b37-aee9-ba8ed8b90955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caccacb7-7d17-4b37-aee9-ba8ed8b90955.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "681c5ce2-e2c1-5b61-bb2f-c99fedbf9a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53611e65-4ca2-48e4-8fc1-19098c70894e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53611e65-4ca2-48e4-8fc1-19098c70894e.jpg?1",
             "name": "Evacuation",
             "text": "",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "607129fd-a0c5-58e7-b0c4-e08f09288888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae593a2e-42d9-47e3-b6cb-f2e2133944d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae593a2e-42d9-47e3-b6cb-f2e2133944d5.jpg?1",
             "name": "Exhaustion",
             "text": "Creatures and lands target opponent controls don't untap during his or her next untap step.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "9de1f1b5-d475-5e27-8a95-4fce011a7677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d304a85-3129-4230-9e3b-14a2b5bc81d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d304a85-3129-4230-9e3b-14a2b5bc81d9.jpg?1",
             "name": "Exhaustion",
             "text": "",
             "colours": [
@@ -5568,7 +5568,7 @@
         },
         {
             "id": "5000b9ed-30fc-5c34-b2d0-6e2ef8c59a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c4a1f4-0a8e-4e70-a2a8-ceebbca63b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c4a1f4-0a8e-4e70-a2a8-ceebbca63b6c.jpg?1",
             "name": "Fishliver Oil",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has islandwalk. (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "6d56b7ff-0c21-555a-87d5-ed9af1d11d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd83d056-05cd-4d57-9bfc-c9f006ee7d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd83d056-05cd-4d57-9bfc-c9f006ee7d89.jpg?1",
             "name": "Fishliver Oil",
             "text": "",
             "colours": [
@@ -5638,7 +5638,7 @@
         },
         {
             "id": "73613fca-e58b-5eac-ba11-cbd00d98b4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b8cc4-3392-4307-a5e4-5f04e52da3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b8cc4-3392-4307-a5e4-5f04e52da3ab.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{1}{U}: Return Fleeting Image to its owner's hand.",
             "colours": [
@@ -5673,7 +5673,7 @@
         },
         {
             "id": "95ed44bd-a9db-5e35-a62a-4b39e6e789c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6475cfaa-2258-48e7-be21-a7d86a94dcf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6475cfaa-2258-48e7-be21-a7d86a94dcf1.jpg?1",
             "name": "Fleeting Image",
             "text": "",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "ac7f35b1-c168-52d5-8e55-addc27e3516c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f9c524-89ae-4776-a94d-ee89d57d3e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f9c524-89ae-4776-a94d-ee89d57d3e36.jpg?1",
             "name": "Flight",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has flying. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -5743,7 +5743,7 @@
         },
         {
             "id": "43c0994b-26ec-56fe-8f73-8ba708b7dd24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febc86-eb10-4975-b70c-f2f0fc3dc741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febc86-eb10-4975-b70c-f2f0fc3dc741.jpg?1",
             "name": "Flight",
             "text": "",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "7c3ea479-e463-58e7-b1b0-b217c77dae79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453fac7-10b9-49d7-8219-78faf9d92d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453fac7-10b9-49d7-8219-78faf9d92d0c.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "6a0b61c4-a509-5d0e-97c3-70ab8f3e14d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249904d-f917-4607-9dc3-82415e44cc91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7249904d-f917-4607-9dc3-82415e44cc91.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "d6b194ec-c7bc-5416-89b9-2ce1656633d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d807c179-ca5e-4f8d-983f-b1d92eeef40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d807c179-ca5e-4f8d-983f-b1d92eeef40f.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5885,7 +5885,7 @@
         },
         {
             "id": "bf4eb9e8-14e2-550c-8f82-a7bf83a91a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3455682-6f46-4dc9-ae31-c12aa7633b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3455682-6f46-4dc9-ae31-c12aa7633b2a.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "7055f7ae-8eb6-598f-a187-33c761d5e1be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432d8827-e46d-4c0d-bde3-305594f20f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432d8827-e46d-4c0d-bde3-305594f20f19.jpg?1",
             "name": "Imaginary Pet",
             "text": "At the beginning of your upkeep, if you have a card in hand, return Imaginary Pet to its owner's hand.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "a081cae8-a856-5b84-9b50-a53d00fd8406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764702-05db-4d27-91a1-7ec2cbd69861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764702-05db-4d27-91a1-7ec2cbd69861.jpg?1",
             "name": "Imaginary Pet",
             "text": "",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "05e43c46-b937-5349-a521-614b9442bb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ae6722-cf51-4997-bfba-72dac1f33030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ae6722-cf51-4997-bfba-72dac1f33030.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying. (They can't be blocked except by creatures with flying.)",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "6b310995-509a-59d5-b427-f630b5146313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c5afdf-f45f-44a6-821a-25f2903ce0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c5afdf-f45f-44a6-821a-25f2903ce0c1.jpg?1",
             "name": "Levitation",
             "text": "",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "c28ed36f-837b-5e9d-8f83-7868b85aef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b0a060-8ab4-41d9-921d-db5a67fbfaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b0a060-8ab4-41d9-921d-db5a67fbfaa1.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "5f0d39f6-4eea-5e06-b9f9-c7e3bf6340e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f38d7-1b47-4440-a310-3a0eb8326363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f38d7-1b47-4440-a310-3a0eb8326363.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -6128,7 +6128,7 @@
         },
         {
             "id": "25c08211-9ca6-50c4-8544-1cd36066523e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1ef140-9198-4aed-a0cb-2946a87c93c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1ef140-9198-4aed-a0cb-2946a87c93c5.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -6163,7 +6163,7 @@
         },
         {
             "id": "ceaf8d54-38b5-56e7-8f05-f833360a4490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d7b478-b54f-4409-bca9-68cc98951699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d7b478-b54f-4409-bca9-68cc98951699.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "",
             "colours": [
@@ -6198,7 +6198,7 @@
         },
         {
             "id": "60269545-b1fd-5816-a420-83e5a6ef6508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6486c-644f-4b32-b4e9-3ca29bbdb400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6486c-644f-4b32-b4e9-3ca29bbdb400.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -6231,7 +6231,7 @@
         },
         {
             "id": "9cbf605b-5a58-5d6a-8d8d-7115010b58ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217da74b-f139-4e62-8d91-34cadb678535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217da74b-f139-4e62-8d91-34cadb678535.jpg?1",
             "name": "Mana Leak",
             "text": "",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "572bcaac-efd4-564d-9670-eebf85ec1eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57982c7f-e306-426a-ac90-c2ee488b018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57982c7f-e306-426a-ac90-c2ee488b018e.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another. (For example, you may change \"nonblack creature\" to \"nongreen creature\" or \"forestwalk\" to \"plainswalk.\" This effect doesn't end at end of turn.)",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "9afac2ea-177e-5ba5-a116-3dbdfc07d5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8d98e6-3ec8-46a2-b1ae-aa164905d675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8d98e6-3ec8-46a2-b1ae-aa164905d675.jpg?1",
             "name": "Mind Bend",
             "text": "",
             "colours": [
@@ -6330,7 +6330,7 @@
         },
         {
             "id": "cb39f486-af83-55c5-b24e-85709df9ff75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d045ba0-86e9-444a-86df-6f1e5611429d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d045ba0-86e9-444a-86df-6f1e5611429d.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "566e6476-9ea4-545a-a568-458bd3c3a00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63c8900-28c3-4fd5-8159-5b362819ae9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63c8900-28c3-4fd5-8159-5b362819ae9a.jpg?1",
             "name": "Phantom Warrior",
             "text": "",
             "colours": [
@@ -6402,7 +6402,7 @@
         },
         {
             "id": "20d85b9c-9976-56ea-b507-d9b02b85a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eccbe9-f197-4ec0-b8c1-45a36a063e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80eccbe9-f197-4ec0-b8c1-45a36a063e30.jpg?1",
             "name": "Plagiarize",
             "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "74a339a4-5ed9-5642-8f6b-043220bd05ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ddc456-9e31-423d-b2a1-7d48c02660a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ddc456-9e31-423d-b2a1-7d48c02660a4.jpg?1",
             "name": "Plagiarize",
             "text": "",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "a6205136-7faa-5f89-9e1e-58617e1ecc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a681a355-a5e8-4ed2-8983-9c29ab34819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a681a355-a5e8-4ed2-8983-9c29ab34819b.jpg?1",
             "name": "Polymorph",
             "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card into play and shuffles all other cards revealed this way into his or her library.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "c5e0739e-eb0b-5779-9163-51e996a4e041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0498b4-8c36-4463-a7d9-6b943a71b1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0498b4-8c36-4463-a7d9-6b943a71b1b1.jpg?1",
             "name": "Polymorph",
             "text": "",
             "colours": [
@@ -6534,7 +6534,7 @@
         },
         {
             "id": "8f4ef26c-5b52-5f4c-8ca4-1064d13e147e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0359e3-1b8e-4db7-8dec-2d50278e4b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0359e3-1b8e-4db7-8dec-2d50278e4b00.jpg?1",
             "name": "Puppeteer",
             "text": "{U}, {T}: Tap or untap target creature.",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "ccd6da1c-beba-593e-af05-1d76e8109a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098fca68-9ce1-4530-9a06-65a5adc16618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098fca68-9ce1-4530-9a06-65a5adc16618.jpg?1",
             "name": "Puppeteer",
             "text": "",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "05703c21-7ea6-525e-b979-7eb3340ebf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab3a79f-354f-49b9-b3c9-44880369ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab3a79f-354f-49b9-b3c9-44880369ced4.jpg?1",
             "name": "Reminisce",
             "text": "Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "20208aef-d14a-56ac-8c11-4be808a0c642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b22395-e0da-4d7e-b5fe-e233ceadc9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b22395-e0da-4d7e-b5fe-e233ceadc9b2.jpg?1",
             "name": "Reminisce",
             "text": "",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "56f368dd-d4a6-54fa-9674-6706d8239b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171fa545-724c-465e-96f6-dc738c0be59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171fa545-724c-465e-96f6-dc738c0be59d.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target creature spell.",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "74204831-4d69-5322-978a-a108a0266edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab415e3-2503-484e-bbe9-024db39f4a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab415e3-2503-484e-bbe9-024db39f4a34.jpg?1",
             "name": "Remove Soul",
             "text": "",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "02f2650c-0b31-5d6c-840c-6b85c4082390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a7176f-0e35-406b-819a-e91b42d07172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a7176f-0e35-406b-819a-e91b42d07172.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell, then untap up to four lands.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "e542484d-6de7-56cb-a2bf-04d2a570a076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df65c5f-1ee7-4c64-b417-20ba238e1432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df65c5f-1ee7-4c64-b417-20ba238e1432.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "3242c48c-bc46-5d7f-9f8c-f8fd42679315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af71e998-0ce3-4533-84cd-91cc6f288986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af71e998-0ce3-4533-84cd-91cc6f288986.jpg?1",
             "name": "Sage Aven",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Sage Aven comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "c6525682-47d2-55e4-af61-d8b81eb044ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77249403-7dd4-4696-aa26-b061a2a19bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77249403-7dd4-4696-aa26-b061a2a19bee.jpg?1",
             "name": "Sage Aven",
             "text": "",
             "colours": [
@@ -6876,7 +6876,7 @@
         },
         {
             "id": "6d7a3e19-51a3-5f42-903f-ba85989b59aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee7c3e0-e016-445f-ab3a-3e2d5c26bdac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee7c3e0-e016-445f-ab3a-3e2d5c26bdac.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster can't attack unless defending player controls an Island.",
             "colours": [
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "6066445c-2135-51ba-8ac5-2a0f5bc8f243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a14c14-7773-4cc5-be8e-505585496a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a14c14-7773-4cc5-be8e-505585496a7d.jpg?1",
             "name": "Sea Monster",
             "text": "",
             "colours": [
@@ -6946,7 +6946,7 @@
         },
         {
             "id": "b24c0bd4-b39c-52da-a415-8a50dc7a65fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e836c8-4371-402f-8f90-81325a9879b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e836c8-4371-402f-8f90-81325a9879b8.jpg?1",
             "name": "Sea's Claim",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nEnchanted land is an Island.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "dfddae22-ecc5-522a-aae8-7b726ae92e05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2aa85c-e34e-4747-82ed-7715c5dbb1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2aa85c-e34e-4747-82ed-7715c5dbb1e7.jpg?1",
             "name": "Sea's Claim",
             "text": "",
             "colours": [
@@ -7016,7 +7016,7 @@
         },
         {
             "id": "443cd7d3-09e2-5f42-a5f5-2576feb0ba39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d25807-75e1-41cf-b3e7-f9e42f06c5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d25807-75e1-41cf-b3e7-f9e42f06c5d3.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -7049,7 +7049,7 @@
         },
         {
             "id": "8bf71b4d-3a26-5c6d-ae4e-c471dccfdf02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1c40220-5cf8-49cf-8aa4-610dd2b12e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1c40220-5cf8-49cf-8aa4-610dd2b12e3f.jpg?1",
             "name": "Sift",
             "text": "",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "e23d6176-b1ea-5d9b-bc29-9c66f7d1af1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b72631-d537-46e1-b9b3-618fba8a4c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b72631-d537-46e1-b9b3-618fba8a4c46.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "6d85b3d4-a38a-51e8-92e3-a8fed52ab847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950d422f-8c76-423b-8cc2-3e597184d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950d422f-8c76-423b-8cc2-3e597184d58c.jpg?1",
             "name": "Sleight of Hand",
             "text": "",
             "colours": [
@@ -7148,7 +7148,7 @@
         },
         {
             "id": "76d51d19-83e7-5cbd-a413-9df695875ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036ef8c9-72ac-46ce-af07-83b79d736538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036ef8c9-72ac-46ce-af07-83b79d736538.jpg?1",
             "name": "Storm Crow",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -7183,7 +7183,7 @@
         },
         {
             "id": "d8203534-997c-5165-9d87-bd2c250955e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7841a-360c-4094-84e4-3b5bf17c5c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7841a-360c-4094-84e4-3b5bf17c5c1c.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "48de22e9-055f-5ece-aca0-760fc90cb152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b900c68f-4e10-459b-b28f-fea9a32e563b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b900c68f-4e10-459b-b28f-fea9a32e563b.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -7251,7 +7251,7 @@
         },
         {
             "id": "d172eafc-d4a2-58e4-b6cc-c106c6e5960b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8ca1b6-f022-4172-942c-9be4d619c675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8ca1b6-f022-4172-942c-9be4d619c675.jpg?1",
             "name": "Telepathy",
             "text": "",
             "colours": [
@@ -7284,7 +7284,7 @@
         },
         {
             "id": "213cdfb2-8fd1-5ae6-8467-056f5b0e805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2dfe6-dbc0-46c3-9d5c-9f0ba6f511ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2dfe6-dbc0-46c3-9d5c-9f0ba6f511ec.jpg?1",
             "name": "Temporal Adept",
             "text": "{U}{U}{U}, {T}: Return target permanent to its owner's hand.",
             "colours": [
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "4eaa10b0-8952-502f-a8f0-dd3947d2c867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b29df17-235c-408f-9e4b-2f18554e2154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b29df17-235c-408f-9e4b-2f18554e2154.jpg?1",
             "name": "Temporal Adept",
             "text": "",
             "colours": [
@@ -7356,7 +7356,7 @@
         },
         {
             "id": "12312158-2955-57f7-869e-e28abf04c9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3cfe-5bae-4eb7-81a3-744315093ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3cfe-5bae-4eb7-81a3-744315093ae1.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Thieving Magpie deals damage to an opponent, you draw a card.",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "78e69f9d-04df-5185-ae53-b541d301c066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ce8bbf-a487-4fe1-b378-440c20403544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ce8bbf-a487-4fe1-b378-440c20403544.jpg?1",
             "name": "Thieving Magpie",
             "text": "",
             "colours": [
@@ -7426,7 +7426,7 @@
         },
         {
             "id": "eefba0b1-7e1d-5a18-aac7-8213737d9011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d2542-501d-4dfe-8642-962d0299ca45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d2542-501d-4dfe-8642-962d0299ca45.jpg?1",
             "name": "Thought Courier",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "4ed08eac-51c5-5a0e-bfbd-33c610550729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5715ac13-453c-48ae-8c31-80b053e2cab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5715ac13-453c-48ae-8c31-80b053e2cab3.jpg?1",
             "name": "Thought Courier",
             "text": "",
             "colours": [
@@ -7498,7 +7498,7 @@
         },
         {
             "id": "38fc2d01-5ef4-5225-99f3-cfbfa501049b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569d1014-e04a-4f8d-a2b2-699b5be08d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569d1014-e04a-4f8d-a2b2-699b5be08d5d.jpg?1",
             "name": "Tidal Kraken",
             "text": "Tidal Kraken is unblockable.",
             "colours": [
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "fc4720fe-508f-533d-a241-4de9252788de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a8dc0b-4144-40d0-a898-d04669628cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a8dc0b-4144-40d0-a898-d04669628cb1.jpg?1",
             "name": "Tidal Kraken",
             "text": "",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "cca81b74-4814-5c4f-9874-c949c7969037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28e96c6-4c48-466a-81a0-1137269db529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28e96c6-4c48-466a-81a0-1137269db529.jpg?1",
             "name": "Tidings",
             "text": "Draw four cards.",
             "colours": [
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "f251b9fa-21ba-5026-87a9-6bc5cecf3242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42171ada-b287-4471-b5e1-4ebdf955c819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42171ada-b287-4471-b5e1-4ebdf955c819.jpg?1",
             "name": "Tidings",
             "text": "",
             "colours": [
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "cf59c107-d404-5044-b924-daae8a57f73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7952ea1-a574-4e0e-a3af-0977022c2dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7952ea1-a574-4e0e-a3af-0977022c2dfb.jpg?1",
             "name": "Time Ebb",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -7667,7 +7667,7 @@
         },
         {
             "id": "d8aa9fa2-80c4-5563-b467-6e11e2a040f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298be076-2c92-4299-a3b1-0ec68c59ef80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298be076-2c92-4299-a3b1-0ec68c59ef80.jpg?1",
             "name": "Time Ebb",
             "text": "",
             "colours": [
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "ff5312e4-755c-5b28-bffd-04776e295a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e5d7c9-36f7-4312-ada0-b6c2757487c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e5d7c9-36f7-4312-ada0-b6c2757487c8.jpg?1",
             "name": "Trade Routes",
             "text": "{1}: Return target land you control to its owner's hand.\n{1}, Discard a land card: Draw a card.",
             "colours": [
@@ -7733,7 +7733,7 @@
         },
         {
             "id": "ac78c993-7804-5be5-aacc-be6a5f9262f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047b93ed-c6d4-4ecc-8a25-e7b371f599c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047b93ed-c6d4-4ecc-8a25-e7b371f599c6.jpg?1",
             "name": "Trade Routes",
             "text": "",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "dcc6d37a-48a3-559f-9666-27efaa3f74db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a6e8cc-3989-40c4-a49c-cd30ccaba0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a6e8cc-3989-40c4-a49c-cd30ccaba0d5.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -7799,7 +7799,7 @@
         },
         {
             "id": "b6043c0c-d329-520c-9fa4-51f53f606622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f12d6-5612-42c8-809c-86a620ea8824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f12d6-5612-42c8-809c-86a620ea8824.jpg?1",
             "name": "Traumatize",
             "text": "",
             "colours": [
@@ -7832,7 +7832,7 @@
         },
         {
             "id": "f11b54b1-9c41-5ba4-8da1-012430471d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f145a7d4-151b-41dd-94f9-eda406080222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f145a7d4-151b-41dd-94f9-eda406080222.jpg?1",
             "name": "Treasure Trove",
             "text": "{2}{U}{U}: Draw a card.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "57b2131d-d1c3-58fa-a0f3-b049df26ee0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805701a-f98d-4b0c-97a1-901864d677c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d805701a-f98d-4b0c-97a1-901864d677c5.jpg?1",
             "name": "Treasure Trove",
             "text": "",
             "colours": [
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "b4a7925c-07b8-5021-9a32-38b0a4ae1d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562a6a76-7242-4a22-9545-e6aa2dbd5564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562a6a76-7242-4a22-9545-e6aa2dbd5564.jpg?1",
             "name": "Wanderguard Sentry",
             "text": "When Wanderguard Sentry comes into play, look at target opponent's hand.",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "669cf8cc-fae3-5669-a568-55c577c903da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea3aa0-7766-4edc-9dea-c234c49edee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea3aa0-7766-4edc-9dea-c234c49edee3.jpg?1",
             "name": "Wanderguard Sentry",
             "text": "",
             "colours": [
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "3d59cfab-ef7e-5de7-afec-462315c6ca3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fed594b-9aa5-4bab-8066-58c3f795d940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fed594b-9aa5-4bab-8066-58c3f795d940.jpg?1",
             "name": "Wind Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "9d21bbc9-8882-55f1-83cf-f865a31cf6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0a7ab-715f-431f-824b-d6a3950e4b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba0a7ab-715f-431f-824b-d6a3950e4b0d.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -8038,7 +8038,7 @@
         },
         {
             "id": "c53e4002-3e5d-5407-9ebc-b8922e67f249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25580a6-e687-4da5-85f4-07d940acda95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25580a6-e687-4da5-85f4-07d940acda95.jpg?1",
             "name": "Withering Gaze",
             "text": "Target opponent reveals his or her hand. You draw a card for each Forest and green card in it.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "0bb342ea-c791-5a9c-a07d-cdb9424d03ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867dd0d-4dca-43a1-b9ca-f52a610d083d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867dd0d-4dca-43a1-b9ca-f52a610d083d.jpg?1",
             "name": "Withering Gaze",
             "text": "",
             "colours": [
@@ -8104,7 +8104,7 @@
         },
         {
             "id": "9f56a34e-5121-51b7-af5f-728806ef9687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741612e3-fe3a-4099-9d2b-4a654c4ce949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741612e3-fe3a-4099-9d2b-4a654c4ce949.jpg?1",
             "name": "Zur's Weirding",
             "text": "Players play with their hands revealed.\nIf a player would draw a card, he or she reveals it instead. Then any other player may pay 2 life. If a player does, put that card into its owner's graveyard. Otherwise, that player draws the card.",
             "colours": [
@@ -8137,7 +8137,7 @@
         },
         {
             "id": "2e7bab73-c007-584a-bf46-4c70dfc197d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f20b12-63a2-427e-b735-b114d3a4c297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f20b12-63a2-427e-b735-b114d3a4c297.jpg?1",
             "name": "Zur's Weirding",
             "text": "",
             "colours": [
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "a01c1b1b-b230-5472-8ccb-92a8d32cf64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053e7c76-16b7-44eb-9612-a6800ffb35f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053e7c76-16b7-44eb-9612-a6800ffb35f8.jpg?1",
             "name": "Blackmail",
             "text": "Target player reveals three cards from his or her hand and you choose one of them. That player discards that card.",
             "colours": [
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "ae57351b-fb63-5205-99ef-cdc6c286af87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e480ca-1417-407d-b506-763fd489c11d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e480ca-1417-407d-b506-763fd489c11d.jpg?1",
             "name": "Blackmail",
             "text": "",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "64e354f1-7d72-5aac-9ccb-13fc910b1876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f5cda-3d93-4dfd-b1c3-1dff7b814d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f5cda-3d93-4dfd-b1c3-1dff7b814d98.jpg?1",
             "name": "Bog Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -8271,7 +8271,7 @@
         },
         {
             "id": "429b54c8-a009-5450-867a-1281ab54401d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa5efb5-d893-4126-af86-28a29e029ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa5efb5-d893-4126-af86-28a29e029ea8.jpg?1",
             "name": "Bog Imp",
             "text": "",
             "colours": [
@@ -8306,7 +8306,7 @@
         },
         {
             "id": "0459ca87-c43b-56b5-a717-874e71792586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5758d-665f-4585-887d-4bffaf2785a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5758d-665f-4585-887d-4bffaf2785a0.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -8341,7 +8341,7 @@
         },
         {
             "id": "c8d86e2f-be22-57cb-b098-2a803cce088a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49472cb8-e497-4070-8070-796b4f6f76b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49472cb8-e497-4070-8070-796b4f6f76b8.jpg?1",
             "name": "Bog Wraith",
             "text": "",
             "colours": [
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "239e1bb3-187d-586b-9de9-23d919c47c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7a810f-de22-410a-aa08-333920ffdd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7a810f-de22-410a-aa08-333920ffdd1f.jpg?1",
             "name": "Coercion",
             "text": "Target opponent reveals his or her hand. Choose a card from it. That player discards that card.",
             "colours": [
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "2a18e138-8905-5cba-b15f-21ab1309a25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d7c880-17a4-4127-bbc6-072adbb17c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d7c880-17a4-4127-bbc6-072adbb17c40.jpg?1",
             "name": "Coercion",
             "text": "",
             "colours": [
@@ -8442,7 +8442,7 @@
         },
         {
             "id": "ba409b3c-9fbe-577f-895d-dfb32ab92e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe04e55-14b1-4d45-b265-68efdefb1c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe04e55-14b1-4d45-b265-68efdefb1c19.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player. You gain X life.",
             "colours": [
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "78069fda-4084-5b7d-8b62-2734c9376231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d742b1a5-d1f4-4249-80b0-01c4b37c35f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d742b1a5-d1f4-4249-80b0-01c4b37c35f6.jpg?1",
             "name": "Consume Spirit",
             "text": "",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "fcd497bc-4411-5e37-8e0c-10ea170394fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481e8dac-8292-4e8f-89a1-b396ce98d3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481e8dac-8292-4e8f-89a1-b396ce98d3ab.jpg?1",
             "name": "Contaminated Bond",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.",
             "colours": [
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "6702af76-b6a7-55b1-bc50-23504875a5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e966df7-83a3-41fe-a37e-66f73e6aaa36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e966df7-83a3-41fe-a37e-66f73e6aaa36.jpg?1",
             "name": "Contaminated Bond",
             "text": "",
             "colours": [
@@ -8578,7 +8578,7 @@
         },
         {
             "id": "1a52999a-025b-59ba-a146-25b54e4341f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dacf711-2cf7-4545-aea6-95b5f8aaa121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dacf711-2cf7-4545-aea6-95b5f8aaa121.jpg?1",
             "name": "Cruel Edict",
             "text": "Target opponent sacrifices a creature.",
             "colours": [
@@ -8611,7 +8611,7 @@
         },
         {
             "id": "f146f170-cd30-5843-beb8-17936112b0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921b2ea-8df3-40b2-8016-dbf5a0ec51a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921b2ea-8df3-40b2-8016-dbf5a0ec51a8.jpg?1",
             "name": "Cruel Edict",
             "text": "",
             "colours": [
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "96460e14-4d00-5e8a-b0b8-043bdfda63d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b6d545-2bef-4230-99ac-ee9bc3e9a53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b6d545-2bef-4230-99ac-ee9bc3e9a53d.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -8677,7 +8677,7 @@
         },
         {
             "id": "3a4276d5-1795-5625-8c45-a70a2bd12831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94844334-4ec2-4e24-a39f-414f3f35d3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94844334-4ec2-4e24-a39f-414f3f35d3a4.jpg?1",
             "name": "Dark Banishing",
             "text": "",
             "colours": [
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "c7d54a7d-8ee9-53be-878e-b1ebdf9546c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6662873b-2c10-442f-9ab5-6f47a4cdb0ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6662873b-2c10-442f-9ab5-6f47a4cdb0ce.jpg?1",
             "name": "Death Pits of Rath",
             "text": "Whenever a creature is dealt damage, destroy it. It can't be regenerated.",
             "colours": [
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "63a5f0be-a5dd-5347-ac36-b4094cbb8a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40927-5d47-434d-a5a7-d4e5dcb611b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40927-5d47-434d-a5a7-d4e5dcb611b2.jpg?1",
             "name": "Death Pits of Rath",
             "text": "",
             "colours": [
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "8b6256a1-b3bd-5cd1-ba94-a260cdcae925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76502ffc-a26b-4207-a565-044898875f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76502ffc-a26b-4207-a565-044898875f43.jpg?1",
             "name": "Deathgazer",
             "text": "Whenever Deathgazer blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "0fcc22b4-ac40-5a43-974b-e0fc72e621d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73838f5c-ee6c-4645-bbdb-5e3c8a61537c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73838f5c-ee6c-4645-bbdb-5e3c8a61537c.jpg?1",
             "name": "Deathgazer",
             "text": "",
             "colours": [
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "c3a47ebb-1a8b-5241-82c3-1a6bda764647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0035a78-44ff-4e3a-b297-20cac926c2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0035a78-44ff-4e3a-b297-20cac926c2fb.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "feb4c3b7-3f73-5c1e-8d5c-33ca53441ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23657b59-fbe9-4d88-8ba4-24776a0d6da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23657b59-fbe9-4d88-8ba4-24776a0d6da3.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "2cf1eaa5-c183-54cc-8b73-2fc2dfe2e7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddcfc-1e3e-4bf4-a464-1763bec4df35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddcfc-1e3e-4bf4-a464-1763bec4df35.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -8947,7 +8947,7 @@
         },
         {
             "id": "d36221a2-645a-5547-ae51-565f0a444042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013de212-bb3c-4499-8a14-e8f764dedca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013de212-bb3c-4499-8a14-e8f764dedca3.jpg?1",
             "name": "Drudge Skeletons",
             "text": "",
             "colours": [
@@ -8982,7 +8982,7 @@
         },
         {
             "id": "569e4ff2-c8ec-52d7-91a0-1bdc3fc39de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adaf0bf-b26d-4166-8809-431283690de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adaf0bf-b26d-4166-8809-431283690de7.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "a43efef7-6ab1-5196-8faf-f0d5d9d89af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b593775-5900-44f3-98e9-1298ce07a1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b593775-5900-44f3-98e9-1298ce07a1f1.jpg?1",
             "name": "Enfeeblement",
             "text": "",
             "colours": [
@@ -9052,7 +9052,7 @@
         },
         {
             "id": "7b195a22-c037-5c99-9579-9522df862555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875500ff-bb15-4634-be05-0171cb0ac412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875500ff-bb15-4634-be05-0171cb0ac412.jpg?1",
             "name": "Execute",
             "text": "Destroy target white creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "836845b1-019a-5089-b7a0-e56db7fc2468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35119276-d461-4eb2-8b1b-fa73639fe1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35119276-d461-4eb2-8b1b-fa73639fe1de.jpg?1",
             "name": "Execute",
             "text": "",
             "colours": [
@@ -9118,7 +9118,7 @@
         },
         {
             "id": "55e5e981-86a2-5313-87d6-597e52e41603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f38700-502f-4442-8563-6f47fc71b272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f38700-502f-4442-8563-6f47fc71b272.jpg?1",
             "name": "Fear",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9153,7 +9153,7 @@
         },
         {
             "id": "ddc85657-2636-521b-9376-342793b5381a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847d8686-bed4-4f90-af4d-bdfc6195ed42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847d8686-bed4-4f90-af4d-bdfc6195ed42.jpg?1",
             "name": "Fear",
             "text": "",
             "colours": [
@@ -9188,7 +9188,7 @@
         },
         {
             "id": "5ab43dc3-847c-5e97-ab8a-74e635ab92b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00444e40-7436-48c3-9cbb-e6d8b96c1a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00444e40-7436-48c3-9cbb-e6d8b96c1a3a.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "1a4156a1-e3c5-558b-ae1b-03f589ee2682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328cadf0-001f-47bd-9319-c74f8cc688c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328cadf0-001f-47bd-9319-c74f8cc688c2.jpg?1",
             "name": "Festering Goblin",
             "text": "",
             "colours": [
@@ -9260,7 +9260,7 @@
         },
         {
             "id": "4ffc2825-65a3-5c88-8579-8552f609a4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df60bb-3309-43e0-ab4a-cec1390fc7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72df60bb-3309-43e0-ab4a-cec1390fc7cf.jpg?1",
             "name": "Final Punishment",
             "text": "Target player loses life equal to the damage already dealt to him or her this turn.",
             "colours": [
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "599cb34e-795d-5622-b1d5-3152e647ff9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ee758-cbf8-4b1a-acb1-1090d0b2b31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ee758-cbf8-4b1a-acb1-1090d0b2b31b.jpg?1",
             "name": "Final Punishment",
             "text": "",
             "colours": [
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "8d64f0d7-2a6c-5d19-9a6b-ccfbed150759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cc73b9-4a24-4a24-8a0e-76126605a3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cc73b9-4a24-4a24-8a0e-76126605a3e6.jpg?1",
             "name": "Foul Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Foul Imp comes into play, you lose 2 life.",
             "colours": [
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "769335cb-2461-5a91-adb7-50fca6382557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2845b54-7929-4407-9389-4a1e4dead4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2845b54-7929-4407-9389-4a1e4dead4b8.jpg?1",
             "name": "Foul Imp",
             "text": "",
             "colours": [
@@ -9396,7 +9396,7 @@
         },
         {
             "id": "ea77bab2-8a76-556a-9c31-9630346f567c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ca0c01-2e9f-4f1c-9078-f7a68559296d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ca0c01-2e9f-4f1c-9078-f7a68559296d.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "d086fbe8-f0d6-5198-a6a2-26a3ff7a2ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d366fd4c-e416-402b-aac9-6b5bd1feff2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d366fd4c-e416-402b-aac9-6b5bd1feff2e.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "dbf8450a-7757-5378-9a40-6314f2995baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7741c976-000d-476c-9b53-34ef1ee701e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7741c976-000d-476c-9b53-34ef1ee701e1.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -9501,7 +9501,7 @@
         },
         {
             "id": "c56b22b2-972d-55ed-8bc9-322e988d588f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d85b52-4bd9-495b-9027-2bbd87309e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d85b52-4bd9-495b-9027-2bbd87309e6e.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "",
             "colours": [
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "3afcdc7c-b78a-5d6e-9425-9d0b50392803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291af6dc-9f71-4e8e-9ecc-24fa90aacb23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291af6dc-9f71-4e8e-9ecc-24fa90aacb23.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control is put into a graveyard from play, each other player sacrifices a creature.",
             "colours": [
@@ -9569,7 +9569,7 @@
         },
         {
             "id": "38a04db2-3b2e-5799-ab24-ff4e56ee0d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb9e6f-3c04-4b87-9d51-33516d0e9102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeb9e6f-3c04-4b87-9d51-33516d0e9102.jpg?1",
             "name": "Grave Pact",
             "text": "",
             "colours": [
@@ -9602,7 +9602,7 @@
         },
         {
             "id": "5fb5787d-5505-5071-a9aa-d0fa905740bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1efc01-8dca-4e90-b5c4-14937d154fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1efc01-8dca-4e90-b5c4-14937d154fe4.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "0edb73c9-f6a7-53d7-96e6-a554e84e320a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5739e-caef-46f4-a083-25da30bf69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5739e-caef-46f4-a083-25da30bf69f4.jpg?1",
             "name": "Gravedigger",
             "text": "",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "254ed96e-f578-57ce-a699-65c8717fc909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6269968-0f58-4e20-94d0-678d39207988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6269968-0f58-4e20-94d0-678d39207988.jpg?1",
             "name": "Hell's Caretaker",
             "text": "{T}, Sacrifice a creature: Return target creature card from your graveyard to play. Play this ability only during your upkeep.",
             "colours": [
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "38681058-802d-5633-977d-0a31c5d34403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7babe0-0fa8-4224-af41-2f1e0c7315a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7babe0-0fa8-4224-af41-2f1e0c7315a3.jpg?1",
             "name": "Hell's Caretaker",
             "text": "",
             "colours": [
@@ -9742,7 +9742,7 @@
         },
         {
             "id": "abaa6528-3f66-5aa8-990d-cd3e646929ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3d34d2-d060-4690-aa67-af41117e7333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3d34d2-d060-4690-aa67-af41117e7333.jpg?1",
             "name": "Highway Robber",
             "text": "When Highway Robber comes into play, you gain 2 life and target opponent loses 2 life.",
             "colours": [
@@ -9778,7 +9778,7 @@
         },
         {
             "id": "6ab3ce26-8e09-52f8-be02-353ae4104aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a9ece9-3805-401a-bc83-7245342a42e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a9ece9-3805-401a-bc83-7245342a42e5.jpg?1",
             "name": "Highway Robber",
             "text": "",
             "colours": [
@@ -9814,7 +9814,7 @@
         },
         {
             "id": "977871c4-e750-5179-a01a-fa51ee166fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520fcafe-0c4a-49ca-8138-57a60506b0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520fcafe-0c4a-49ca-8138-57a60506b0cd.jpg?1",
             "name": "Hollow Dogs",
             "text": "Whenever Hollow Dogs attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "95f54395-7819-5082-9aae-f82693c6ea82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c431fff3-2189-42c8-b136-2d903c1e7f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c431fff3-2189-42c8-b136-2d903c1e7f1b.jpg?1",
             "name": "Hollow Dogs",
             "text": "",
             "colours": [
@@ -9888,7 +9888,7 @@
         },
         {
             "id": "d9ffa752-07b6-5b2e-a967-ec46998b2b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcae6a15-733d-44ae-ab23-a202ed071f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcae6a15-733d-44ae-ab23-a202ed071f28.jpg?1",
             "name": "Horror of Horrors",
             "text": "Sacrifice a Swamp: Regenerate target black creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -9921,7 +9921,7 @@
         },
         {
             "id": "62c57f06-8e09-5729-9bab-8be86a61ee90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ef53aa-e923-42c0-ac9b-4b712da6ce99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ef53aa-e923-42c0-ac9b-4b712da6ce99.jpg?1",
             "name": "Horror of Horrors",
             "text": "",
             "colours": [
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "350907dc-be3c-5345-aa74-4f5bb79ace50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205b6734-0205-4a57-ba55-2fd7ab40b8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205b6734-0205-4a57-ba55-2fd7ab40b8fa.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
             "colours": [
@@ -9989,7 +9989,7 @@
         },
         {
             "id": "23fd562b-dae4-5b08-9bee-aba21b1f8d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee325a6-0f87-4e14-89e2-2aba7cf0f441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee325a6-0f87-4e14-89e2-2aba7cf0f441.jpg?1",
             "name": "Hypnotic Specter",
             "text": "",
             "colours": [
@@ -10024,7 +10024,7 @@
         },
         {
             "id": "37b60281-a10e-5baa-9266-64a4a1292514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45304a48-f2a3-4a3c-b6ba-22d318fb0d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45304a48-f2a3-4a3c-b6ba-22d318fb0d8c.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10059,7 +10059,7 @@
         },
         {
             "id": "132a7b9d-6e23-501b-8623-5900f9830344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d02a18-7ebe-49ea-90c1-f4f11ef19592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d02a18-7ebe-49ea-90c1-f4f11ef19592.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -10094,7 +10094,7 @@
         },
         {
             "id": "881d0f2b-9bbd-5079-8465-2884902408d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29133d-74e5-4631-a283-22aa3c848d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29133d-74e5-4631-a283-22aa3c848d96.jpg?1",
             "name": "Lord of the Undead",
             "text": "Other Zombies get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -10129,7 +10129,7 @@
         },
         {
             "id": "b37ad916-5c10-5555-8b92-985af194ac89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9669b82-c461-4249-b906-09baa6d21925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9669b82-c461-4249-b906-09baa6d21925.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -10164,7 +10164,7 @@
         },
         {
             "id": "5bff7921-cdab-5b77-835a-42f8a393a1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02edaa79-2c99-4d37-a54f-0258476cd81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02edaa79-2c99-4d37-a54f-0258476cd81c.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -10197,7 +10197,7 @@
         },
         {
             "id": "da615318-51e7-5a39-ba1d-684aac76539b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb165f1-41ff-42c5-9789-234897373455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb165f1-41ff-42c5-9789-234897373455.jpg?1",
             "name": "Megrim",
             "text": "",
             "colours": [
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "21f4447c-73f4-5616-818e-5acf4b45d1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3234588-d421-4548-879e-32574b613707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3234588-d421-4548-879e-32574b613707.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -10263,7 +10263,7 @@
         },
         {
             "id": "580cc581-aec8-56ef-b99e-030536bbd2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6de68d6-9dad-4306-830a-2aab2e3dac7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6de68d6-9dad-4306-830a-2aab2e3dac7a.jpg?1",
             "name": "Mind Rot",
             "text": "",
             "colours": [
@@ -10296,7 +10296,7 @@
         },
         {
             "id": "b048428e-10ce-5426-a36a-5eb6d8814c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d5437b-158f-4a50-9397-bbde1c4a98d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d5437b-158f-4a50-9397-bbde1c4a98d5.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer is put into a graveyard from play, each player discards his or her hand.",
             "colours": [
@@ -10331,7 +10331,7 @@
         },
         {
             "id": "71177d00-a590-55a6-80f2-7fe6d20c12be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e704e8-1cb3-4c24-bdaa-e2528ffc7a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e704e8-1cb3-4c24-bdaa-e2528ffc7a8a.jpg?1",
             "name": "Mindslicer",
             "text": "",
             "colours": [
@@ -10366,7 +10366,7 @@
         },
         {
             "id": "51c5873c-4563-5afa-9a40-781b2654d0da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b2288c-e60e-48c3-8e53-62a47af6da92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b2288c-e60e-48c3-8e53-62a47af6da92.jpg?1",
             "name": "Mortivore",
             "text": "Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\n{B}: Regenerate Mortivore. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "f5d4f6c9-3935-5874-8f70-58a9b3b5f316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9639a0f1-12d3-4a37-890a-5fc48c56537d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9639a0f1-12d3-4a37-890a-5fc48c56537d.jpg?1",
             "name": "Mortivore",
             "text": "",
             "colours": [
@@ -10436,7 +10436,7 @@
         },
         {
             "id": "1e179619-d44f-56ca-95ef-c4665f7d190e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903c05c6-dca4-4094-ac59-0a7cb4d690f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903c05c6-dca4-4094-ac59-0a7cb4d690f6.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -10472,7 +10472,7 @@
         },
         {
             "id": "972d5750-11e4-56bc-b4c2-aa26008d54cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f59a79-47ac-4e50-b1db-8562fbfe0938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f59a79-47ac-4e50-b1db-8562fbfe0938.jpg?1",
             "name": "Nantuko Husk",
             "text": "",
             "colours": [
@@ -10508,7 +10508,7 @@
         },
         {
             "id": "e194f275-1490-56f0-a8e4-e9f21cfb79bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7d0ee9-3053-430a-a6a9-1202316f0648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7d0ee9-3053-430a-a6a9-1202316f0648.jpg?1",
             "name": "Nekrataal",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Nekrataal comes into play, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -10544,7 +10544,7 @@
         },
         {
             "id": "e0d28698-223a-5869-ab6d-b20ca8890c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb6a03-36cf-4368-831e-a33748dffd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aeb6a03-36cf-4368-831e-a33748dffd1b.jpg?1",
             "name": "Nekrataal",
             "text": "",
             "colours": [
@@ -10580,7 +10580,7 @@
         },
         {
             "id": "b8d688ee-3a4b-59cc-910c-3a10d5a7e882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6659c13-1858-4a66-a11f-e37416855951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6659c13-1858-4a66-a11f-e37416855951.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -10616,7 +10616,7 @@
         },
         {
             "id": "f2574d10-156f-5d30-87f8-fcb6fc39a066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3df8ed-ff36-478e-a4f4-bee041b77d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3df8ed-ff36-478e-a4f4-bee041b77d15.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "9eaef27b-7cb6-5150-b5b7-f3b73bf75976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af13f6-7a7b-431d-9dda-6492d135563f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af13f6-7a7b-431d-9dda-6492d135563f.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Target player reveals his or her hand and discards all cards of that color.",
             "colours": [
@@ -10685,7 +10685,7 @@
         },
         {
             "id": "112e93ce-500a-519d-8f91-32c97dbca5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4bf39b-32c4-4eb5-bc48-579fea72049b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4bf39b-32c4-4eb5-bc48-579fea72049b.jpg?1",
             "name": "Persecute",
             "text": "",
             "colours": [
@@ -10718,7 +10718,7 @@
         },
         {
             "id": "72c33715-8dff-50c6-8b57-0cc448f5529a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542370dc-0166-45b9-84bb-000cd97e80b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542370dc-0166-45b9-84bb-000cd97e80b9.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -10751,7 +10751,7 @@
         },
         {
             "id": "0f37ed63-fbac-5351-9601-62e49bbd86ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c25e492-2862-405b-ba1d-f58cb63294dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c25e492-2862-405b-ba1d-f58cb63294dd.jpg?1",
             "name": "Phyrexian Arena",
             "text": "",
             "colours": [
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "2f155825-ffc3-5cef-81df-de88ffea3fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f3d99d-f6e7-4633-948b-21dd64d918fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f3d99d-f6e7-4633-948b-21dd64d918fa.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua comes into play, you draw two cards and you lose 2 life.",
             "colours": [
@@ -10820,7 +10820,7 @@
         },
         {
             "id": "8df8376a-5fcf-5290-9329-29aab52629f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee9135-401c-4906-a844-d4b28ddfb029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee9135-401c-4906-a844-d4b28ddfb029.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "",
             "colours": [
@@ -10856,7 +10856,7 @@
         },
         {
             "id": "d207d4a6-1ec9-5477-aac5-645547f98cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16fc87c-ec62-4b62-9fb1-0fa5a73d1640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16fc87c-ec62-4b62-9fb1-0fa5a73d1640.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -10891,7 +10891,7 @@
         },
         {
             "id": "47de4c98-3dee-50ac-8f0c-a40b3f171d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f771905-27e2-4607-bfed-c40d2f3f9e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f771905-27e2-4607-bfed-c40d2f3f9e46.jpg?1",
             "name": "Plague Beetle",
             "text": "",
             "colours": [
@@ -10926,7 +10926,7 @@
         },
         {
             "id": "3e10304e-2a48-5fd4-96a8-42dc5f6b058d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9c226b-0201-4af8-b164-5ca0fbdf52a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9c226b-0201-4af8-b164-5ca0fbdf52a9.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -10959,7 +10959,7 @@
         },
         {
             "id": "cb2e0ba4-b296-541d-ac70-6bdcd678356d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e420cd31-51db-479b-8b47-ed7b804d3ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e420cd31-51db-479b-8b47-ed7b804d3ae6.jpg?1",
             "name": "Plague Wind",
             "text": "",
             "colours": [
@@ -10992,7 +10992,7 @@
         },
         {
             "id": "3c24fc0a-6763-5b05-b967-e4b92aaca0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768e82c-82d8-4869-9284-7a9ec9d90967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768e82c-82d8-4869-9284-7a9ec9d90967.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -11025,7 +11025,7 @@
         },
         {
             "id": "21d6069f-2938-5848-92d3-a0951e5333f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81f75da-f37e-461b-9c3a-fffe759bc4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81f75da-f37e-461b-9c3a-fffe759bc4df.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "0a499ceb-cb0e-55d5-a712-436d89fa9cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b09e94-9504-444c-b002-7418962bf0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b09e94-9504-444c-b002-7418962bf0f9.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card.",
             "colours": [
@@ -11093,7 +11093,7 @@
         },
         {
             "id": "44c5f08e-d909-56f5-bc72-8e6419caa9bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7269485-ea4e-4560-994d-3788f89194dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7269485-ea4e-4560-994d-3788f89194dd.jpg?1",
             "name": "Ravenous Rats",
             "text": "",
             "colours": [
@@ -11128,7 +11128,7 @@
         },
         {
             "id": "4d8b2a65-85c9-5e62-a13c-2fa804e32354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92750247-eba4-4810-a758-f943cd8a16b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92750247-eba4-4810-a758-f943cd8a16b1.jpg?1",
             "name": "Razortooth Rats",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -11163,7 +11163,7 @@
         },
         {
             "id": "cca21704-d015-5c01-96dd-fbdd37aad31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f128936c-e46d-46fb-993f-6df172f9bb7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f128936c-e46d-46fb-993f-6df172f9bb7d.jpg?1",
             "name": "Razortooth Rats",
             "text": "",
             "colours": [
@@ -11198,7 +11198,7 @@
         },
         {
             "id": "07c0febc-64e5-515b-9f66-a31ebbb0e598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cd1ef7-e89f-444d-81a6-ead16462febc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cd1ef7-e89f-444d-81a6-ead16462febc.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11234,7 +11234,7 @@
         },
         {
             "id": "416c8d0e-f9d0-5235-85d0-6405d729ae7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560b9fd9-f78d-4e2f-84cc-ed9c7575b8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560b9fd9-f78d-4e2f-84cc-ed9c7575b8df.jpg?1",
             "name": "Royal Assassin",
             "text": "",
             "colours": [
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "66074bdb-7728-5f6f-a711-077e392e0e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54360cdf-ecbb-4a52-96a3-fd5d8f9b30bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54360cdf-ecbb-4a52-96a3-fd5d8f9b30bf.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11305,7 +11305,7 @@
         },
         {
             "id": "d3443c88-5e57-5478-a7c8-a9f9a26ba2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01326c97-d1f0-46cf-a84b-2a3d3420aa3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01326c97-d1f0-46cf-a84b-2a3d3420aa3d.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -11340,7 +11340,7 @@
         },
         {
             "id": "fcc5a424-140b-56f4-9046-0215f5287b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fab1e55-6621-48a7-b2c6-1ef844362279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fab1e55-6621-48a7-b2c6-1ef844362279.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhenever a creature dealt damage by Sengir Vampire this turn is put into a graveyard, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -11375,7 +11375,7 @@
         },
         {
             "id": "291cf026-6b2f-5791-828f-2eaafcc5de6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def083a3-b292-44c1-83e4-0d03205b45ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def083a3-b292-44c1-83e4-0d03205b45ea.jpg?1",
             "name": "Sengir Vampire",
             "text": "",
             "colours": [
@@ -11410,7 +11410,7 @@
         },
         {
             "id": "98559b17-0bd6-5dcc-848e-3618844ca73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d825dc-c56b-4f59-aae0-ed960e18dfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d825dc-c56b-4f59-aae0-ed960e18dfab.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, you lose 3 life.",
             "colours": [
@@ -11446,7 +11446,7 @@
         },
         {
             "id": "80ffb8be-89f3-5e23-a5ab-1444251424b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc27d11e-b731-41cf-a756-fd6aca3643f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc27d11e-b731-41cf-a756-fd6aca3643f5.jpg?1",
             "name": "Serpent Warrior",
             "text": "",
             "colours": [
@@ -11482,7 +11482,7 @@
         },
         {
             "id": "2b38066e-ad95-587a-848e-fb28acb8951c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa460f4-9ae2-4c3a-aa1d-7e8bec9b313d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa460f4-9ae2-4c3a-aa1d-7e8bec9b313d.jpg?1",
             "name": "Slay",
             "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -11515,7 +11515,7 @@
         },
         {
             "id": "7a430370-f132-5a89-a1a9-2371760a634f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc91f16f-5022-4481-9578-3c3944b50f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc91f16f-5022-4481-9578-3c3944b50f5b.jpg?1",
             "name": "Slay",
             "text": "",
             "colours": [
@@ -11548,7 +11548,7 @@
         },
         {
             "id": "9963d137-e6e2-5545-b919-5f23c490063c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bb17f-e44a-4e2c-880e-733b6496576e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bb17f-e44a-4e2c-880e-733b6496576e.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -11581,7 +11581,7 @@
         },
         {
             "id": "ee440a33-8e74-5331-bd6e-dca8251037fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0963dbd8-6d02-4c84-8a4f-efe584c87f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0963dbd8-6d02-4c84-8a4f-efe584c87f54.jpg?1",
             "name": "Soul Feast",
             "text": "",
             "colours": [
@@ -11614,7 +11614,7 @@
         },
         {
             "id": "2a60bad7-f055-5902-bb68-992b3b258cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e11c98-e19f-4b38-acda-504d291c7f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e11c98-e19f-4b38-acda-504d291c7f42.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -11651,7 +11651,7 @@
         },
         {
             "id": "4650a3fd-c009-5665-bdd4-fbac640f1291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc0450a-c0e5-4609-9873-6ae08e8b8545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc0450a-c0e5-4609-9873-6ae08e8b8545.jpg?1",
             "name": "Spineless Thug",
             "text": "",
             "colours": [
@@ -11688,7 +11688,7 @@
         },
         {
             "id": "0893dec5-63c8-5777-af62-321871567bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1a92e2-6a8f-45fe-84cc-08fde6210077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1a92e2-6a8f-45fe-84cc-08fde6210077.jpg?1",
             "name": "Swarm of Rats",
             "text": "Swarm of Rats's power is equal to the number of Rats you control.",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "c947b1be-80aa-5ed1-b886-7cebfdcaedb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af6af6-c661-4d54-a8c3-cb67faec6708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af6af6-c661-4d54-a8c3-cb67faec6708.jpg?1",
             "name": "Swarm of Rats",
             "text": "",
             "colours": [
@@ -11758,7 +11758,7 @@
         },
         {
             "id": "090eac32-c495-50b4-a09f-4a51675f949d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1cbd83-c997-4c95-86a0-fe3c83d14975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1cbd83-c997-4c95-86a0-fe3c83d14975.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "88a443b6-50e6-5e4d-be67-3b9b25f73362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a3ca28-8b65-419f-9d37-4854ee92c6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a3ca28-8b65-419f-9d37-4854ee92c6d2.jpg?1",
             "name": "Underworld Dreams",
             "text": "",
             "colours": [
@@ -11824,7 +11824,7 @@
         },
         {
             "id": "955cf244-d726-503d-a97c-0a6ed032aeb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecf0be7-abf8-4681-bb7d-280a7dc5f761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecf0be7-abf8-4681-bb7d-280a7dc5f761.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "5a6cb257-ccfb-58d2-94fb-f41f507c189d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14121a8b-a41c-4213-82fc-c839b711f8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14121a8b-a41c-4213-82fc-c839b711f8f3.jpg?1",
             "name": "Unholy Strength",
             "text": "",
             "colours": [
@@ -11894,7 +11894,7 @@
         },
         {
             "id": "d7b22aa2-a0b6-5c04-8271-f65f4ba5713b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb78e2-cb62-43dc-8f5b-bf81d2f02eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb78e2-cb62-43dc-8f5b-bf81d2f02eea.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{B}: Regenerate Will-o'-the-Wisp. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "bc95a234-7edf-5ade-afad-69042d9af8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074bf953-9a48-4768-b47f-9c9bb9d42874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074bf953-9a48-4768-b47f-9c9bb9d42874.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "",
             "colours": [
@@ -11964,7 +11964,7 @@
         },
         {
             "id": "7401c345-a479-5235-8100-5b5f53816b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a9fe1-ce63-4638-8793-5187fc726731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a9fe1-ce63-4638-8793-5187fc726731.jpg?1",
             "name": "Yawgmoth Demon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nFirst strike (This creature deals combat damage before creatures without first strike.)\nAt the beginning of your upkeep, you may sacrifice an artifact. If you don't, tap Yawgmoth Demon and it deals 2 damage to you.",
             "colours": [
@@ -12000,7 +12000,7 @@
         },
         {
             "id": "fc91b1e1-98d7-52e2-b5a4-8dc390460762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fc12d6-eb2b-467d-87e6-29ae54a7dc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fc12d6-eb2b-467d-87e6-29ae54a7dc6a.jpg?1",
             "name": "Yawgmoth Demon",
             "text": "",
             "colours": [
@@ -12036,7 +12036,7 @@
         },
         {
             "id": "c1596771-0d39-52e6-a3d0-622373594083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9af694a-6a96-494a-ab16-5c7c7e8e17a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9af694a-6a96-494a-ab16-5c7c7e8e17a9.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -12069,7 +12069,7 @@
         },
         {
             "id": "7505160a-b464-52ce-8058-1d284ecee708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c6bba-fdf2-4d8b-bd39-3b0cc071f880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23c6bba-fdf2-4d8b-bd39-3b0cc071f880.jpg?1",
             "name": "Zombify",
             "text": "",
             "colours": [
@@ -12102,7 +12102,7 @@
         },
         {
             "id": "23abd431-25c3-5d8d-ae12-df5386312223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae202e-63f1-4d8b-bf85-2bf1a03c054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae202e-63f1-4d8b-bf85-2bf1a03c054c.jpg?1",
             "name": "Anaba Shaman",
             "text": "{R}, {T}: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -12138,7 +12138,7 @@
         },
         {
             "id": "7800a437-3a2b-5211-b3ab-121b1cd47b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca583969-51f1-489e-ae34-8bb997ee8a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca583969-51f1-489e-ae34-8bb997ee8a6c.jpg?1",
             "name": "Anaba Shaman",
             "text": "",
             "colours": [
@@ -12174,7 +12174,7 @@
         },
         {
             "id": "e4c42d25-15f1-5748-b20d-e0d38fcd639a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a989b0-4305-418c-a326-f89958f0c306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a989b0-4305-418c-a326-f89958f0c306.jpg?1",
             "name": "Anarchist",
             "text": "When Anarchist comes into play, you may return target sorcery card from your graveyard to your hand.",
             "colours": [
@@ -12210,7 +12210,7 @@
         },
         {
             "id": "59ddebf1-4b87-5512-9f70-bb3da7d0f47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ec860b-d8b4-4074-a6d9-eff31c856d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ec860b-d8b4-4074-a6d9-eff31c856d22.jpg?1",
             "name": "Anarchist",
             "text": "",
             "colours": [
@@ -12246,7 +12246,7 @@
         },
         {
             "id": "3e2ba5ef-5b7d-56b1-86e4-7d47b45a0f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caba00ff-df58-456e-8aeb-fc8b632018a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caba00ff-df58-456e-8aeb-fc8b632018a6.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12282,7 +12282,7 @@
         },
         {
             "id": "161823fe-0af1-54a2-9cd5-28b3152f5b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0961eff-e5a9-45cb-8394-c9c3717b9021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0961eff-e5a9-45cb-8394-c9c3717b9021.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -12318,7 +12318,7 @@
         },
         {
             "id": "a07f6351-7f56-5a3e-843b-4998f60eb2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0313ea00-6c9f-4579-b322-4e37c093774c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0313ea00-6c9f-4579-b322-4e37c093774c.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to target creature or player.",
             "colours": [
@@ -12351,7 +12351,7 @@
         },
         {
             "id": "1ef973a5-e5a6-5f04-907d-ea5d078f0a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47cbcb-7245-47d8-aa55-d6a5923f077a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47cbcb-7245-47d8-aa55-d6a5923f077a.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -12384,7 +12384,7 @@
         },
         {
             "id": "575aeeb4-0007-553e-962f-9244a6abad32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fec1a2-20b0-4412-9392-8a5004f9027e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fec1a2-20b0-4412-9392-8a5004f9027e.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -12417,7 +12417,7 @@
         },
         {
             "id": "f8e2e405-258a-5a03-92e6-82c0cfe216c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5bfc1d-1aef-4aef-afd7-05dab8553613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5bfc1d-1aef-4aef-afd7-05dab8553613.jpg?1",
             "name": "Blood Moon",
             "text": "",
             "colours": [
@@ -12450,7 +12450,7 @@
         },
         {
             "id": "4db99d78-e94b-5920-8541-82dfc23ba06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8fe3ff-535b-42d4-807f-0d458ebc8f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8fe3ff-535b-42d4-807f-0d458ebc8f54.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "{R}, Sacrifice Bloodfire Colossus: Bloodfire Colossus deals 6 damage to each creature and each player.",
             "colours": [
@@ -12485,7 +12485,7 @@
         },
         {
             "id": "b4c61d08-bbe1-5191-abfd-d49a22f2d2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9c8b8-4c32-4e87-a148-70d226eb9fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9c8b8-4c32-4e87-a148-70d226eb9fb7.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "",
             "colours": [
@@ -12520,7 +12520,7 @@
         },
         {
             "id": "51388bda-265f-51ca-aef2-49970498c08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08ff26e-c561-4b55-9745-50f896689d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08ff26e-c561-4b55-9745-50f896689d0d.jpg?1",
             "name": "Boiling Seas",
             "text": "Destroy all Islands.",
             "colours": [
@@ -12553,7 +12553,7 @@
         },
         {
             "id": "b2514634-d71d-5da0-8686-4da7903dfbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb1b9f8-7a15-4bcb-bcf4-015fe4f035d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb1b9f8-7a15-4bcb-bcf4-015fe4f035d0.jpg?1",
             "name": "Boiling Seas",
             "text": "",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "3303b992-50a1-5474-a977-1fef567ee04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fb13b-60f0-4b96-b63c-8a9df745bfca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fb13b-60f0-4b96-b63c-8a9df745bfca.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "184f3754-7a75-54e0-9fac-eaf77b02024b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0181e-dc38-40f1-9266-821f01c851a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0181e-dc38-40f1-9266-821f01c851a3.jpg?1",
             "name": "Demolish",
             "text": "",
             "colours": [
@@ -12652,7 +12652,7 @@
         },
         {
             "id": "71faf63d-bc42-5935-b17e-5ef305b1c225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f10e9f0-32c6-40cc-b16d-5590662cdb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f10e9f0-32c6-40cc-b16d-5590662cdb33.jpg?1",
             "name": "Enrage",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -12685,7 +12685,7 @@
         },
         {
             "id": "e8440979-4699-5c27-9dd1-aa688a63d4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df27923c-de30-4adf-821d-3edec4d3ba63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df27923c-de30-4adf-821d-3edec4d3ba63.jpg?1",
             "name": "Enrage",
             "text": "",
             "colours": [
@@ -12718,7 +12718,7 @@
         },
         {
             "id": "56f8e7d7-12c9-542b-85fb-d49eac0f05ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb31487e-72c6-4d11-a80d-1ff3a81e9cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb31487e-72c6-4d11-a80d-1ff3a81e9cd6.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -12753,7 +12753,7 @@
         },
         {
             "id": "d4868162-6d23-52d6-8692-9278565788ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70871e34-5659-4f08-ba43-765de400f262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70871e34-5659-4f08-ba43-765de400f262.jpg?1",
             "name": "Firebreathing",
             "text": "",
             "colours": [
@@ -12788,7 +12788,7 @@
         },
         {
             "id": "d6a0bf14-6b06-59cc-93c6-1b386c893be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce194b3b-a3e1-4a63-91c9-6454e5b41963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce194b3b-a3e1-4a63-91c9-6454e5b41963.jpg?1",
             "name": "Flame Wave",
             "text": "Flame Wave deals 4 damage to target player and each creature he or she controls.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "3dd60813-4f46-5681-9af1-4070988dd96e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edfd311-c8dd-4b54-b5f4-7020970adf1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edfd311-c8dd-4b54-b5f4-7020970adf1a.jpg?1",
             "name": "Flame Wave",
             "text": "",
             "colours": [
@@ -12854,7 +12854,7 @@
         },
         {
             "id": "f6bf3d03-5439-5ad4-9669-5956f9d9019b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e0846-237e-4117-bdd4-d2e4ae450d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e0846-237e-4117-bdd4-d2e4ae450d43.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all Plains.",
             "colours": [
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "5229aed1-c317-5db3-b37f-e99c670a2797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb40337-4bcc-457a-ada7-df93616ff74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb40337-4bcc-457a-ada7-df93616ff74f.jpg?1",
             "name": "Flashfires",
             "text": "",
             "colours": [
@@ -12920,7 +12920,7 @@
         },
         {
             "id": "46a4e728-eed6-5023-bc90-1ce0e8f2a2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd861b1c-8d91-4595-9fcd-b324234f2264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd861b1c-8d91-4595-9fcd-b324234f2264.jpg?1",
             "name": "Flowstone Crusher",
             "text": "{R}: Flowstone Crusher gets +1/-1 until end of turn.",
             "colours": [
@@ -12955,7 +12955,7 @@
         },
         {
             "id": "19730b05-bf76-53fd-87e8-00b9414e754c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec12624-348e-45b9-aab0-91c9f86614d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec12624-348e-45b9-aab0-91c9f86614d5.jpg?1",
             "name": "Flowstone Crusher",
             "text": "",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "83f82a97-cc73-5cd6-b599-a3bc71f81a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65669460-54e6-4358-83de-d7a576f9eea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65669460-54e6-4358-83de-d7a576f9eea3.jpg?1",
             "name": "Flowstone Shambler",
             "text": "{R}: Flowstone Shambler gets +1/-1 until end of turn.",
             "colours": [
@@ -13025,7 +13025,7 @@
         },
         {
             "id": "9ab55d06-ad47-5082-935a-91fc3765f2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2213001-44cf-4f54-8502-58865c1eb7b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2213001-44cf-4f54-8502-58865c1eb7b1.jpg?1",
             "name": "Flowstone Shambler",
             "text": "",
             "colours": [
@@ -13060,7 +13060,7 @@
         },
         {
             "id": "6c2b0297-b585-5fb3-a8a7-b85bf6c8339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66496fd3-6f2e-4d94-a60f-16f5691c3f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66496fd3-6f2e-4d94-a60f-16f5691c3f55.jpg?1",
             "name": "Flowstone Slide",
             "text": "All creatures get +X/-X until end of turn.",
             "colours": [
@@ -13093,7 +13093,7 @@
         },
         {
             "id": "7b0ee3ac-264a-5b7c-8756-c3156173c0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401a2be-cddb-4ebd-9679-eb7145d3d848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401a2be-cddb-4ebd-9679-eb7145d3d848.jpg?1",
             "name": "Flowstone Slide",
             "text": "",
             "colours": [
@@ -13126,7 +13126,7 @@
         },
         {
             "id": "2724eced-6464-5b31-b1ad-e353f83e92f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfc77f1-290a-4394-bc16-76f3659810f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfc77f1-290a-4394-bc16-76f3659810f0.jpg?1",
             "name": "Form of the Dragon",
             "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the end of each turn, your life total becomes 5.\nCreatures without flying can't attack you.",
             "colours": [
@@ -13159,7 +13159,7 @@
         },
         {
             "id": "000da741-09c0-511a-96fc-9668f310abd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274175ba-d079-49f6-83a3-d83f6650e903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274175ba-d079-49f6-83a3-d83f6650e903.jpg?1",
             "name": "Form of the Dragon",
             "text": "",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "1ad09995-cc27-5c15-8d38-e9e191fdcbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e139a085-d8fe-40a0-984d-4ce9378c48f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e139a085-d8fe-40a0-984d-4ce9378c48f7.jpg?1",
             "name": "Furnace of Rath",
             "text": "If a source would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -13225,7 +13225,7 @@
         },
         {
             "id": "8bc5ff43-9405-592d-bd82-0bb30cc9dba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9cee2-c60e-4971-a69f-8af5c81ed5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9cee2-c60e-4971-a69f-8af5c81ed5d2.jpg?1",
             "name": "Furnace of Rath",
             "text": "",
             "colours": [
@@ -13258,7 +13258,7 @@
         },
         {
             "id": "21f33fc2-bf59-5a8d-b5ae-fcab0a52269b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059227f9-f6d7-45ab-8398-35e97b677a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059227f9-f6d7-45ab-8398-35e97b677a08.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "{R}: Goblin Balloon Brigade gains flying until end of turn. (It can't be blocked except by creatures with flying.)",
             "colours": [
@@ -13294,7 +13294,7 @@
         },
         {
             "id": "c22a9345-155e-553e-bab3-6dc3dd1224e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212459a3-0183-4346-8372-5b4d61bc7869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212459a3-0183-4346-8372-5b4d61bc7869.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "",
             "colours": [
@@ -13330,7 +13330,7 @@
         },
         {
             "id": "73a5dd77-916d-5cea-8d53-b6518e72a846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862a481a-f236-4e99-b4b9-086e6cb8f4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862a481a-f236-4e99-b4b9-086e6cb8f4de.jpg?1",
             "name": "Goblin Brigand",
             "text": "Goblin Brigand attacks each turn if able.",
             "colours": [
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "e25f2702-1c4f-5422-88e6-b9f0eb9e9fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43f6241-c629-4fd3-8781-30ed1903c1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43f6241-c629-4fd3-8781-30ed1903c1fe.jpg?1",
             "name": "Goblin Brigand",
             "text": "",
             "colours": [
@@ -13402,7 +13402,7 @@
         },
         {
             "id": "f93f3f97-e22a-5773-a97c-4c275c78f584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a15cb-9591-4521-a142-af766dd7eeef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a15cb-9591-4521-a142-af766dd7eeef.jpg?1",
             "name": "Goblin Chariot",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "d66345b1-192d-546e-b464-95328267a8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c36a55-a010-4661-af85-9f1344c108d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c36a55-a010-4661-af85-9f1344c108d3.jpg?1",
             "name": "Goblin Chariot",
             "text": "",
             "colours": [
@@ -13474,7 +13474,7 @@
         },
         {
             "id": "43d45036-682d-5aa6-acec-84f81ef17308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c68f83-5471-40b5-a673-84032ce24ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c68f83-5471-40b5-a673-84032ce24ba2.jpg?1",
             "name": "Goblin King",
             "text": "Other Goblins get +1/+1 and have mountainwalk. (They're unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -13509,7 +13509,7 @@
         },
         {
             "id": "f02469e5-d2f8-5840-8eed-692ffd481d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09c6616-91d8-4257-9fb7-09ec9e52de78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09c6616-91d8-4257-9fb7-09ec9e52de78.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -13544,7 +13544,7 @@
         },
         {
             "id": "9295299f-9e19-5ceb-b317-b2dc9549d8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8754592a-2f9b-477c-a049-d9a3eed271e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8754592a-2f9b-477c-a049-d9a3eed271e5.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -13580,7 +13580,7 @@
         },
         {
             "id": "9d30e59e-0b0b-51c4-bccc-182321a98045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ce5e37-41dc-4479-8c0d-9d17240739ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ce5e37-41dc-4479-8c0d-9d17240739ed.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "",
             "colours": [
@@ -13616,7 +13616,7 @@
         },
         {
             "id": "2d567dd4-ebc8-5144-9b72-56a0201ec640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c86887-678a-4ba5-b0bb-243f4015ad80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c86887-678a-4ba5-b0bb-243f4015ad80.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -13652,7 +13652,7 @@
         },
         {
             "id": "d6e41224-39d2-5b49-aa97-d74f694ebf44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fffa95-95c8-47b5-a196-431f731781e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fffa95-95c8-47b5-a196-431f731781e6.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "61dbf371-7301-5ae3-ba4c-d5eb04800c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fa6280-5620-47d3-93c5-eaed1e5351d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fa6280-5620-47d3-93c5-eaed1e5351d2.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [
@@ -13724,7 +13724,7 @@
         },
         {
             "id": "d7beab49-70e7-53b8-b023-e6e245062a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec7dd91-fc60-46f7-9dc4-fd3f00fb1f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec7dd91-fc60-46f7-9dc4-fd3f00fb1f29.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "",
             "colours": [
@@ -13760,7 +13760,7 @@
         },
         {
             "id": "e9844eaa-e142-5a73-8ed1-ac8dcf047e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f94743-c228-410a-9cb9-d00a1e55dfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f94743-c228-410a-9cb9-d00a1e55dfcf.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nWhen a spell or ability an opponent controls causes you to discard Guerrilla Tactics, Guerrilla Tactics deals 4 damage to target creature or player.",
             "colours": [
@@ -13793,7 +13793,7 @@
         },
         {
             "id": "85d648c2-47a4-55e5-a16f-5073e27e042e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b7c3d-bad2-495e-a568-ce79b019a188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b7c3d-bad2-495e-a568-ce79b019a188.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "",
             "colours": [
@@ -13826,7 +13826,7 @@
         },
         {
             "id": "6de78db1-9bfc-53ef-a436-136717234fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa75eaf-948f-4503-962d-95b0321b36d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa75eaf-948f-4503-962d-95b0321b36d9.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13861,7 +13861,7 @@
         },
         {
             "id": "401f933f-36a8-59b2-a290-701d844a82c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58968ba0-77a4-49fe-aa1d-0dc8a1db4923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58968ba0-77a4-49fe-aa1d-0dc8a1db4923.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -13896,7 +13896,7 @@
         },
         {
             "id": "762dcec2-47b9-5ce7-8cc7-99cd3d5ca6cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad95118-104c-41d4-a393-941e7b97fd8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad95118-104c-41d4-a393-941e7b97fd8e.jpg?1",
             "name": "Karplusan Yeti",
             "text": "{T}: Karplusan Yeti deals damage equal to its power to target creature. That creature deals damage equal to its power to Karplusan Yeti.",
             "colours": [
@@ -13931,7 +13931,7 @@
         },
         {
             "id": "06266a9a-2a5d-5843-80e4-9cf6644171cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0535c-36d0-4e77-bf59-9c7a6c9b2ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0535c-36d0-4e77-bf59-9c7a6c9b2ddb.jpg?1",
             "name": "Karplusan Yeti",
             "text": "",
             "colours": [
@@ -13966,7 +13966,7 @@
         },
         {
             "id": "6faf816d-a5f5-51fb-a538-76b8f5d3d6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27423c7b-d1fd-471b-9648-8ea5ed9ebaf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27423c7b-d1fd-471b-9648-8ea5ed9ebaf2.jpg?1",
             "name": "Kird Ape",
             "text": "Kird Ape gets +1/+2 as long as you control a Forest.",
             "colours": [
@@ -14001,7 +14001,7 @@
         },
         {
             "id": "55420b2e-d57b-5cfa-8afc-1a91d1ccc7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0f90df-826c-422e-bfbf-4eb14f609c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0f90df-826c-422e-bfbf-4eb14f609c22.jpg?1",
             "name": "Kird Ape",
             "text": "",
             "colours": [
@@ -14036,7 +14036,7 @@
         },
         {
             "id": "9b030a32-eb41-5b72-8a03-9f74d1f55261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbcc027a-55c9-4baf-a801-8db805129d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbcc027a-55c9-4baf-a801-8db805129d5b.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -14069,7 +14069,7 @@
         },
         {
             "id": "a7c05935-275d-5a56-b09b-1cd4207e5a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d49083e-f4e0-4b31-8e65-273a62fab2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d49083e-f4e0-4b31-8e65-273a62fab2f2.jpg?1",
             "name": "Lava Axe",
             "text": "",
             "colours": [
@@ -14102,7 +14102,7 @@
         },
         {
             "id": "ccb4c345-857d-5c66-9a4c-892f12156854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a23bff-6d5a-4020-afec-874ca48765d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a23bff-6d5a-4020-afec-874ca48765d6.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "4c0a404c-7bce-5e26-a363-69231ea43a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb46346-d0e8-4e37-96b1-416c966f7a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb46346-d0e8-4e37-96b1-416c966f7a32.jpg?1",
             "name": "Lightning Elemental",
             "text": "",
             "colours": [
@@ -14172,7 +14172,7 @@
         },
         {
             "id": "84c891f2-68e7-5822-afce-064a2fcf8dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab077f67-09c3-43d0-ad27-d1e6255c4d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab077f67-09c3-43d0-ad27-d1e6255c4d55.jpg?1",
             "name": "Magnivore",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nMagnivore's power and toughness are each equal to the number of sorcery cards in all graveyards.",
             "colours": [
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "49c0df5c-af0d-57da-9e3c-2dc634a27c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79500942-8581-4114-99d3-317f77a2cdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79500942-8581-4114-99d3-317f77a2cdea.jpg?1",
             "name": "Magnivore",
             "text": "",
             "colours": [
@@ -14242,7 +14242,7 @@
         },
         {
             "id": "c3cfd994-cabb-5bec-a513-f026251d5596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41352f-617f-40f6-b612-11022180c18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41352f-617f-40f6-b612-11022180c18b.jpg?1",
             "name": "Mana Clash",
             "text": "You and target opponent each flip a coin. Mana Clash deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip.",
             "colours": [
@@ -14275,7 +14275,7 @@
         },
         {
             "id": "fc3978a6-90ad-5106-b169-98890c06cd70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004909d8-b362-44c4-ae6f-96b28546fb72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004909d8-b362-44c4-ae6f-96b28546fb72.jpg?1",
             "name": "Mana Clash",
             "text": "",
             "colours": [
@@ -14308,7 +14308,7 @@
         },
         {
             "id": "7ce5afb2-81bb-5c1c-9dbd-83555766b29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56100dd7-250d-4a3a-b719-b25fc73873dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56100dd7-250d-4a3a-b719-b25fc73873dc.jpg?1",
             "name": "Mogg Sentry",
             "text": "Whenever an opponent plays a spell, Mogg Sentry gets +2/+2 until end of turn.",
             "colours": [
@@ -14344,7 +14344,7 @@
         },
         {
             "id": "2a665db3-f072-5412-8c5f-a2e963c98087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d7fd07-cce7-4c5d-a86d-5e68361e52d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d7fd07-cce7-4c5d-a86d-5e68361e52d2.jpg?1",
             "name": "Mogg Sentry",
             "text": "",
             "colours": [
@@ -14380,7 +14380,7 @@
         },
         {
             "id": "46fb184e-fcf1-5fb1-aefb-8056403fea9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c08378-7344-4f11-8206-bec2a72f0570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c08378-7344-4f11-8206-bec2a72f0570.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "13f48af3-d354-59dc-a21e-7fda03bb696e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf0228b-43f5-492a-b3c4-10c9a58a2b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf0228b-43f5-492a-b3c4-10c9a58a2b6d.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "",
             "colours": [
@@ -14450,7 +14450,7 @@
         },
         {
             "id": "9475c46f-682a-5c3e-aa29-3d12e37ca44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14addda6-7f7c-4c7f-abfe-e647e0282936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14addda6-7f7c-4c7f-abfe-e647e0282936.jpg?1",
             "name": "Orcish Artillery",
             "text": "{T}: Orcish Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -14486,7 +14486,7 @@
         },
         {
             "id": "9486e207-65e7-50ca-a4fb-0a2c162c040f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d6875-f17d-49cc-87b0-4308b0ee63e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d6875-f17d-49cc-87b0-4308b0ee63e4.jpg?1",
             "name": "Orcish Artillery",
             "text": "",
             "colours": [
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "622dace3-ee8d-5b92-bb35-a328c6ed0269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92688a63-ae5d-48ee-87ce-a8f163ee8650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92688a63-ae5d-48ee-87ce-a8f163ee8650.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -14555,7 +14555,7 @@
         },
         {
             "id": "6e0c9307-c414-522b-a7b8-9b46f695c4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc612c4-5af0-441a-bc21-5aa13cc13a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc612c4-5af0-441a-bc21-5aa13cc13a9b.jpg?1",
             "name": "Panic Attack",
             "text": "",
             "colours": [
@@ -14588,7 +14588,7 @@
         },
         {
             "id": "97ed11ce-bcbd-556a-9bb3-10776b535bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6df956-0dc0-41f4-bf37-c88bcd80cc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6df956-0dc0-41f4-bf37-c88bcd80cc95.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -14621,7 +14621,7 @@
         },
         {
             "id": "b991d85f-57f0-5245-94f2-4d2541cadcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bc456-41a1-471f-ab13-7d0575b0b295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06bc456-41a1-471f-ab13-7d0575b0b295.jpg?1",
             "name": "Pyroclasm",
             "text": "",
             "colours": [
@@ -14654,7 +14654,7 @@
         },
         {
             "id": "05059f94-2937-5854-a284-850de639f801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47a96df-dce7-495b-acc0-5551641f5a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47a96df-dce7-495b-acc0-5551641f5a57.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature may attack the turn it comes under your control.)",
             "colours": [
@@ -14690,7 +14690,7 @@
         },
         {
             "id": "e8924f13-d2fd-5622-b672-b291eba17495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcea609-4a24-468d-a4fe-0524f53a7a01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcea609-4a24-468d-a4fe-0524f53a7a01.jpg?1",
             "name": "Raging Goblin",
             "text": "",
             "colours": [
@@ -14726,7 +14726,7 @@
         },
         {
             "id": "c07d9e49-a7e0-5cdc-bf31-87bd2457c7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dbcf6c-d947-4d02-acfa-f14763785615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94dbcf6c-d947-4d02-acfa-f14763785615.jpg?1",
             "name": "Rathi Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nWhen Rathi Dragon comes into play, sacrifice it unless you sacrifice two Mountains.",
             "colours": [
@@ -14761,7 +14761,7 @@
         },
         {
             "id": "c4520818-625e-5da4-84b5-bb94848817c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03882614-589a-4814-a8f7-f962a70d6bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03882614-589a-4814-a8f7-f962a70d6bb2.jpg?1",
             "name": "Rathi Dragon",
             "text": "",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "93e3e0fc-97e1-5e32-b3aa-99e136e863f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d9770-4316-4ac1-b235-5a1d6e15cece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d9770-4316-4ac1-b235-5a1d6e15cece.jpg?1",
             "name": "Reflexes",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -14831,7 +14831,7 @@
         },
         {
             "id": "28f6c664-eea8-557b-90aa-744ad5538ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac80159-e302-40d2-997e-44749053b162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac80159-e302-40d2-997e-44749053b162.jpg?1",
             "name": "Reflexes",
             "text": "",
             "colours": [
@@ -14866,7 +14866,7 @@
         },
         {
             "id": "2954a762-2f83-57d5-afda-801eac2d7fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b0e2ce-6168-456c-b960-83a21e968504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b0e2ce-6168-456c-b960-83a21e968504.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -14899,7 +14899,7 @@
         },
         {
             "id": "e3f46f91-4079-502b-a6cd-282c6143ff1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd1962-1d11-4d4c-a273-73a1384a88f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd1962-1d11-4d4c-a273-73a1384a88f1.jpg?1",
             "name": "Relentless Assault",
             "text": "",
             "colours": [
@@ -14932,7 +14932,7 @@
         },
         {
             "id": "c62d6cfb-8f1d-50b8-9ecc-ec74dd5238e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e565859-fb56-4287-a1c5-c50cfff4e8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e565859-fb56-4287-a1c5-c50cfff4e8e6.jpg?1",
             "name": "Rogue Kavu",
             "text": "Whenever Rogue Kavu attacks alone, it gets +2/+0 until end of turn.",
             "colours": [
@@ -14967,7 +14967,7 @@
         },
         {
             "id": "e527bae1-e121-50b1-abcc-2d56973f3f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020bf27-8160-4aaa-a321-29c8f43d2624.jpg?1",
             "name": "Rogue Kavu",
             "text": "",
             "colours": [
@@ -15002,7 +15002,7 @@
         },
         {
             "id": "e1fbaa6d-3d00-551a-87a8-df9438130342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfc662-edfb-43ff-8022-1db971b1de22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bfc662-edfb-43ff-8022-1db971b1de22.jpg?1",
             "name": "Rukh Egg",
             "text": "When Rukh Egg is put into a graveyard from play, put a 4/4 red Bird creature token with flying into play at end of turn.",
             "colours": [
@@ -15038,7 +15038,7 @@
         },
         {
             "id": "80227265-52bd-5b7e-9824-ce6afe6b78df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1098d-6d6e-444d-8307-508ffb2a9b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1098d-6d6e-444d-8307-508ffb2a9b4a.jpg?1",
             "name": "Rukh Egg",
             "text": "",
             "colours": [
@@ -15074,7 +15074,7 @@
         },
         {
             "id": "efe54fda-fa1c-5545-84a9-c76e83265f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df10856-6e72-4225-8185-abe359768575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df10856-6e72-4225-8185-abe359768575.jpg?1",
             "name": "Sandstone Warrior",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\n{R}: Sandstone Warrior gets +1/+0 until end of turn.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "3607620c-2179-57ae-83d0-ffe31a42837d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b4d36-b084-4fbc-abcc-d0e9c0ae4650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b4d36-b084-4fbc-abcc-d0e9c0ae4650.jpg?1",
             "name": "Sandstone Warrior",
             "text": "",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "8ab7927a-be62-5e52-96d6-46c34f42a53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10418027-7b05-49e7-8ff4-6a03e3fb656b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10418027-7b05-49e7-8ff4-6a03e3fb656b.jpg?1",
             "name": "Seething Song",
             "text": "Add {R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -15181,7 +15181,7 @@
         },
         {
             "id": "a1e7ac5b-e514-594c-b8bf-bedf1bdb9ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4d8327-49ed-40d0-ade3-459c9f9c4832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4d8327-49ed-40d0-ade3-459c9f9c4832.jpg?1",
             "name": "Seething Song",
             "text": "",
             "colours": [
@@ -15214,7 +15214,7 @@
         },
         {
             "id": "7afedade-6d52-505f-9f98-207f36b358e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d02731-bcdb-4447-adc8-06eea08725ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d02731-bcdb-4447-adc8-06eea08725ba.jpg?1",
             "name": "Shard Phoenix",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\nSacrifice Shard Phoenix: Shard Phoenix deals 2 damage to each creature without flying.\n{R}{R}{R}: Return Shard Phoenix from your graveyard to your hand. Play this ability only during your upkeep.",
             "colours": [
@@ -15249,7 +15249,7 @@
         },
         {
             "id": "d0bb3ef8-3931-59cb-8df5-e9aa44daff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf506981-7f50-46e6-b84c-014637567b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf506981-7f50-46e6-b84c-014637567b74.jpg?1",
             "name": "Shard Phoenix",
             "text": "",
             "colours": [
@@ -15284,7 +15284,7 @@
         },
         {
             "id": "c0dd9507-0d92-5aad-be2f-f033e803cab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e79ce1-29d6-48d3-b7d5-8cd95cef3234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e79ce1-29d6-48d3-b7d5-8cd95cef3234.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -15317,7 +15317,7 @@
         },
         {
             "id": "d135a132-7655-5bd5-81c3-4ce869b94792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14bc5cc-2bff-4fb8-af13-143fee558a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14bc5cc-2bff-4fb8-af13-143fee558a8c.jpg?1",
             "name": "Shatter",
             "text": "",
             "colours": [
@@ -15350,7 +15350,7 @@
         },
         {
             "id": "05467b2d-03c5-50ed-852b-173020c23903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbf9dde-e396-43dc-8288-b39e63a23164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbf9dde-e396-43dc-8288-b39e63a23164.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -15385,7 +15385,7 @@
         },
         {
             "id": "0d4a8c12-971e-5c0f-b8be-292896cf60bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ef10a-4bbc-40ce-883d-f4aa471052fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ef10a-4bbc-40ce-883d-f4aa471052fc.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -15420,7 +15420,7 @@
         },
         {
             "id": "3383c075-bbf0-520e-9801-e526ab528ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b241a-a58e-440a-8591-91dce118bd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b241a-a58e-440a-8591-91dce118bd95.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -15453,7 +15453,7 @@
         },
         {
             "id": "4f1df72d-a22b-539f-8559-2a3892bf3750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8314410-53e1-4264-87f1-5c6484670693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8314410-53e1-4264-87f1-5c6484670693.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -15486,7 +15486,7 @@
         },
         {
             "id": "41bea4a3-19c6-53bb-a06d-2643f0265d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2334c10-fa96-4f8e-8187-c7ecc00cbac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2334c10-fa96-4f8e-8187-c7ecc00cbac8.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -15519,7 +15519,7 @@
         },
         {
             "id": "f2957c90-7d91-5862-ae2e-b61d88cf6e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9bd15ff-c52e-4caf-8146-e61469ad94a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9bd15ff-c52e-4caf-8146-e61469ad94a2.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -15552,7 +15552,7 @@
         },
         {
             "id": "b8a04fec-7e2f-5962-8c37-c8c9cfb6daf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823e98-e0ea-490d-8a32-8e657d766f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823e98-e0ea-490d-8a32-8e657d766f06.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -15585,7 +15585,7 @@
         },
         {
             "id": "f1c47a79-2be6-51e5-9acc-6976f66ab4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e993480b-5a9e-485e-9d21-d8d9ccfc0884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e993480b-5a9e-485e-9d21-d8d9ccfc0884.jpg?1",
             "name": "Sudden Impact",
             "text": "",
             "colours": [
@@ -15618,7 +15618,7 @@
         },
         {
             "id": "2df25a28-9ead-5688-8192-e3ef5fbbcce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31694de6-567f-449e-a5e5-54d2f62be205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31694de6-567f-449e-a5e5-54d2f62be205.jpg?1",
             "name": "Threaten",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. (It may attack this turn.)",
             "colours": [
@@ -15651,7 +15651,7 @@
         },
         {
             "id": "b23d78c2-9360-5cf2-bfb1-e68633975071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aded85-750e-4d28-9834-fc2e02fcecb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aded85-750e-4d28-9834-fc2e02fcecb2.jpg?1",
             "name": "Threaten",
             "text": "",
             "colours": [
@@ -15684,7 +15684,7 @@
         },
         {
             "id": "530922fb-4647-55fb-ba48-939009d3ef67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068c0c3-4ec9-4c02-84db-42b609df545f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068c0c3-4ec9-4c02-84db-42b609df545f.jpg?1",
             "name": "Thundermare",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nWhen Thundermare comes into play, tap all other creatures.",
             "colours": [
@@ -15720,7 +15720,7 @@
         },
         {
             "id": "3b932cad-1a13-55dd-b430-a55b5d70c854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325ebb1-7b3b-4380-90cb-e7158de23841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325ebb1-7b3b-4380-90cb-e7158de23841.jpg?1",
             "name": "Thundermare",
             "text": "",
             "colours": [
@@ -15756,7 +15756,7 @@
         },
         {
             "id": "7b5ce324-621e-54e6-aa23-273d6130a019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1954d2eb-c1d0-4b99-a89c-357beb710055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1954d2eb-c1d0-4b99-a89c-357beb710055.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "Haste (This creature may attack the turn it comes under your control.)\nAt end of turn, return Viashino Sandstalker to its owner's hand. (Return it only if it's in play.)",
             "colours": [
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "06a52aaf-b824-581f-9e51-523ae70e90c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c31c75-f961-40a8-83ba-3ee5997b2b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c31c75-f961-40a8-83ba-3ee5997b2b52.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "",
             "colours": [
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "5fe3a0c8-e0e6-59fa-bd3b-bb2bf89496c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3f454-4aeb-4e48-b961-bea760ea8ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3f454-4aeb-4e48-b961-bea760ea8ddf.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to target creature or player.",
             "colours": [
@@ -15861,7 +15861,7 @@
         },
         {
             "id": "df9a0765-9b8f-5794-b8b1-cb43feeed981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6520a7-2a8e-4536-a124-9980d22c7756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6520a7-2a8e-4536-a124-9980d22c7756.jpg?1",
             "name": "Volcanic Hammer",
             "text": "",
             "colours": [
@@ -15894,7 +15894,7 @@
         },
         {
             "id": "db8b606d-f353-5f25-a250-f14e2f98831f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b672b-1e2b-4969-9b7e-ea44ef766113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b672b-1e2b-4969-9b7e-ea44ef766113.jpg?1",
             "name": "Whip Sergeant",
             "text": "{R}: Target creature gains haste until end of turn. (It may attack this turn.)",
             "colours": [
@@ -15930,7 +15930,7 @@
         },
         {
             "id": "f55ad19c-2ab4-5bbb-b2fd-209c7910f773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8651d50d-be71-4445-94f6-f1877d22816f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8651d50d-be71-4445-94f6-f1877d22816f.jpg?1",
             "name": "Whip Sergeant",
             "text": "",
             "colours": [
@@ -15966,7 +15966,7 @@
         },
         {
             "id": "c049c73e-d0a6-5c2f-b687-f1f6b160864c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db2609-b02f-4b46-8467-eac4c7022d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db2609-b02f-4b46-8467-eac4c7022d5c.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands. Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -15999,7 +15999,7 @@
         },
         {
             "id": "17246fb9-b8ff-544b-b922-51ff27de40ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f278246-fd11-48ba-8ec0-1a4511dfa6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f278246-fd11-48ba-8ec0-1a4511dfa6f4.jpg?1",
             "name": "Wildfire",
             "text": "",
             "colours": [
@@ -16032,7 +16032,7 @@
         },
         {
             "id": "81b9417a-132b-597c-8f55-d5bb548bf944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f57f8bf-228b-4da2-823c-67bce8b574cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f57f8bf-228b-4da2-823c-67bce8b574cd.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -16067,7 +16067,7 @@
         },
         {
             "id": "b135c20b-5683-5aa7-918f-7cda66d18299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d673f-89de-49c5-8391-dac8ae8ec45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d673f-89de-49c5-8391-dac8ae8ec45c.jpg?1",
             "name": "Anaconda",
             "text": "",
             "colours": [
@@ -16102,7 +16102,7 @@
         },
         {
             "id": "5748885e-acf6-5bba-8e65-687b21652fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818a0944-3534-49e4-8d93-274244043696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818a0944-3534-49e4-8d93-274244043696.jpg?1",
             "name": "Ancient Silverback",
             "text": "{G}: Regenerate Ancient Silverback. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -16137,7 +16137,7 @@
         },
         {
             "id": "3dea4cee-6841-5989-83d2-c0ede2948d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1fa5f-c7b6-4747-a4ef-f6bb4dc8ba53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1fa5f-c7b6-4747-a4ef-f6bb4dc8ba53.jpg?1",
             "name": "Ancient Silverback",
             "text": "",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "b5f155de-74c9-508b-98af-2f6ff818d91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d1a10f-ce21-4914-9984-c7c559161230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d1a10f-ce21-4914-9984-c7c559161230.jpg?1",
             "name": "Biorhythm",
             "text": "Each player's life total becomes the number of creatures he or she controls.",
             "colours": [
@@ -16205,7 +16205,7 @@
         },
         {
             "id": "98d93f33-81c3-5bb0-9d31-fa3b86328b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f844dc35-f063-4514-8d4b-82559ab0603f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f844dc35-f063-4514-8d4b-82559ab0603f.jpg?1",
             "name": "Biorhythm",
             "text": "",
             "colours": [
@@ -16238,7 +16238,7 @@
         },
         {
             "id": "5f551000-b982-588e-905b-68d8ea228266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e558f1-74ef-4d16-8135-2a8dc0c58fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e558f1-74ef-4d16-8135-2a8dc0c58fe9.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -16273,7 +16273,7 @@
         },
         {
             "id": "3cf17083-83ba-5be2-8f5a-b852e99c5bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1598d7-3c2f-406e-8e60-18b00233c7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1598d7-3c2f-406e-8e60-18b00233c7c0.jpg?1",
             "name": "Blanchwood Armor",
             "text": "",
             "colours": [
@@ -16308,7 +16308,7 @@
         },
         {
             "id": "08f83f39-b386-5912-80e5-8226f3178c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eee2f9-676d-4d98-a19e-ff5d841c636f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eee2f9-676d-4d98-a19e-ff5d841c636f.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16343,7 +16343,7 @@
         },
         {
             "id": "366e193e-a797-533f-bde2-4c922afe5ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008307f-ca02-4c49-ad99-36bb0cb8775e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008307f-ca02-4c49-ad99-36bb0cb8775e.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -16378,7 +16378,7 @@
         },
         {
             "id": "367e98a7-d5a6-5321-bc1e-96376a2545d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2a3193-8ef0-4c4d-b12c-06a5ef5bf95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2a3193-8ef0-4c4d-b12c-06a5ef5bf95e.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -16411,7 +16411,7 @@
         },
         {
             "id": "7302b198-e71d-50dd-bf57-fddb82d7333c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee13f28-2b0e-4939-b602-1be1552432a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee13f28-2b0e-4939-b602-1be1552432a5.jpg?1",
             "name": "Creeping Mold",
             "text": "",
             "colours": [
@@ -16444,7 +16444,7 @@
         },
         {
             "id": "40f1154a-2baf-5df4-9f43-3b44969d468e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22113d08-ecc9-4efd-90f1-00d699582ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22113d08-ecc9-4efd-90f1-00d699582ec3.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -16477,7 +16477,7 @@
         },
         {
             "id": "16b66af6-8c94-56d4-a875-b624b91a53cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a5ae9a-a0be-4b33-97f1-d38346560966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a5ae9a-a0be-4b33-97f1-d38346560966.jpg?1",
             "name": "Early Harvest",
             "text": "",
             "colours": [
@@ -16510,7 +16510,7 @@
         },
         {
             "id": "fe02e4dc-02e0-5dfa-b9b4-e088cee66b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fda362-63ee-4f0b-8faf-a9073e0d5fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fda362-63ee-4f0b-8faf-a9073e0d5fa0.jpg?1",
             "name": "Elvish Bard",
             "text": "All creatures able to block Elvish Bard do so.",
             "colours": [
@@ -16547,7 +16547,7 @@
         },
         {
             "id": "2a210565-6462-500b-9497-bf6c14bf4cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12f7bb0-d7cf-44e7-9ee3-c44daf87b0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12f7bb0-d7cf-44e7-9ee3-c44daf87b0d8.jpg?1",
             "name": "Elvish Bard",
             "text": "",
             "colours": [
@@ -16584,7 +16584,7 @@
         },
         {
             "id": "1dd71f68-07b4-5d23-95e7-3bd2867cb741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee84f5c-130b-4f44-a045-3e5728ce0950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee84f5c-130b-4f44-a045-3e5728ce0950.jpg?1",
             "name": "Elvish Berserker",
             "text": "Whenever Elvish Berserker becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -16620,7 +16620,7 @@
         },
         {
             "id": "227bcae4-71ee-5e75-b854-8d786536297e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b74e2c-9a79-4551-a433-e5393ccb4f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b74e2c-9a79-4551-a433-e5393ccb4f49.jpg?1",
             "name": "Elvish Berserker",
             "text": "",
             "colours": [
@@ -16656,7 +16656,7 @@
         },
         {
             "id": "30f7a452-47fc-5c42-868a-65f3cf19d7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec5af70-10f3-41fe-9548-e65da6ba852b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec5af70-10f3-41fe-9548-e65da6ba852b.jpg?1",
             "name": "Elvish Champion",
             "text": "Other Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -16691,7 +16691,7 @@
         },
         {
             "id": "b0aba720-ea08-5b72-b5dd-3773686f2c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08433b6b-f2af-4a52-abf8-3968d62d41fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08433b6b-f2af-4a52-abf8-3968d62d41fb.jpg?1",
             "name": "Elvish Champion",
             "text": "",
             "colours": [
@@ -16726,7 +16726,7 @@
         },
         {
             "id": "5fe73932-e350-55cc-8694-368548de19e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb459fb2-b0d3-4be9-99cb-fcff4518abc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb459fb2-b0d3-4be9-99cb-fcff4518abc2.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: Put a creature card from your hand into play.",
             "colours": [
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "33fd1515-393f-5971-a784-9a48fbc3e0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f5e98-fd8e-410a-be94-c0fa1dc382e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f5e98-fd8e-410a-be94-c0fa1dc382e1.jpg?1",
             "name": "Elvish Piper",
             "text": "",
             "colours": [
@@ -16798,7 +16798,7 @@
         },
         {
             "id": "f82559db-bc3b-5bf8-ac14-788da23af3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18e79e9-39fc-426b-b64f-f20f6077a532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18e79e9-39fc-426b-b64f-f20f6077a532.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -16834,7 +16834,7 @@
         },
         {
             "id": "85e29f85-3549-5146-9f0c-39805ead2e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc321f-739a-42fe-bb51-d27511d2493b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc321f-739a-42fe-bb51-d27511d2493b.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -16870,7 +16870,7 @@
         },
         {
             "id": "b8d67bb5-1cc6-554b-bd7f-9a86910e984a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4bf2db-b282-4c9d-8afe-053204271996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4bf2db-b282-4c9d-8afe-053204271996.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -16905,7 +16905,7 @@
         },
         {
             "id": "786196bc-1c33-5d71-9ed4-86d37eb76fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32801a11-4605-46d3-8bb2-5cf5337b3f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32801a11-4605-46d3-8bb2-5cf5337b3f14.jpg?1",
             "name": "Emperor Crocodile",
             "text": "",
             "colours": [
@@ -16940,7 +16940,7 @@
         },
         {
             "id": "c69a06b2-8294-5bd0-9ac8-d540d4f4d037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f3103a-24e9-4462-bf52-8fa5e6214d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f3103a-24e9-4462-bf52-8fa5e6214d6d.jpg?1",
             "name": "Force of Nature",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)\nAt the beginning of your upkeep, Force of Nature deals 8 damage to you unless you pay {G}{G}{G}{G}.",
             "colours": [
@@ -16975,7 +16975,7 @@
         },
         {
             "id": "9dc8f690-a39a-5cd9-9842-aba89da731fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f733dc-41de-42f6-abdb-e27e369b6f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f733dc-41de-42f6-abdb-e27e369b6f3c.jpg?1",
             "name": "Force of Nature",
             "text": "",
             "colours": [
@@ -17010,7 +17010,7 @@
         },
         {
             "id": "23a4d01c-7896-5723-aee5-0a5333167193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b1a8a1-6777-4a00-ad3a-defc82bbac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b1a8a1-6777-4a00-ad3a-defc82bbac27.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -17043,7 +17043,7 @@
         },
         {
             "id": "5b0bd786-aa34-5701-9119-e0c53972d5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b604e2b2-2b8a-482a-9d2d-a7d171002016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b604e2b2-2b8a-482a-9d2d-a7d171002016.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -17076,7 +17076,7 @@
         },
         {
             "id": "40f8264e-48a0-504f-a486-013675c3ec00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072bcf42-6e13-4388-ac47-f91aaa7029d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072bcf42-6e13-4388-ac47-f91aaa7029d1.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can block as though it had flying.",
             "colours": [
@@ -17111,7 +17111,7 @@
         },
         {
             "id": "d1088e9a-905d-5c03-af50-840cbc56180b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389aec36-0b94-407e-bcbb-94adcdc96e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389aec36-0b94-407e-bcbb-94adcdc96e1a.jpg?1",
             "name": "Giant Spider",
             "text": "",
             "colours": [
@@ -17146,7 +17146,7 @@
         },
         {
             "id": "64519b41-0fc7-5711-8ae6-83d54fd8cae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153d7669-9063-4fc2-b53b-480b0e741f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153d7669-9063-4fc2-b53b-480b0e741f3f.jpg?1",
             "name": "Greater Good",
             "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then discard three cards.",
             "colours": [
@@ -17179,7 +17179,7 @@
         },
         {
             "id": "f629eb23-3dfe-591d-8405-1bdc71f283b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a327e66f-0cd7-46f7-b20f-35c5084b158c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a327e66f-0cd7-46f7-b20f-35c5084b158c.jpg?1",
             "name": "Greater Good",
             "text": "",
             "colours": [
@@ -17212,7 +17212,7 @@
         },
         {
             "id": "e596893f-2345-595e-ac96-edeab4fa783a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0264440-2325-4143-87a7-2af5a6b2a2f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0264440-2325-4143-87a7-2af5a6b2a2f9.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17247,7 +17247,7 @@
         },
         {
             "id": "8aaa58b9-dab6-5566-95b1-419a17af6b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea4f90b-f21b-4acd-934f-406eae274bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea4f90b-f21b-4acd-934f-406eae274bcf.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -17282,7 +17282,7 @@
         },
         {
             "id": "1603c721-67a5-5be8-a9af-a8af9e4b356a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424d7132-0f7a-48c7-beb6-37fc114113da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424d7132-0f7a-48c7-beb6-37fc114113da.jpg?1",
             "name": "Groundskeeper",
             "text": "{1}{G}: Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -17318,7 +17318,7 @@
         },
         {
             "id": "5f83de75-66a4-51aa-8f9b-36ae1ddb42ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a282618-c229-4f82-815e-a2db0d0aef58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a282618-c229-4f82-815e-a2db0d0aef58.jpg?1",
             "name": "Groundskeeper",
             "text": "",
             "colours": [
@@ -17354,7 +17354,7 @@
         },
         {
             "id": "4a7eb265-d15d-53dc-8b81-7da2e726b5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238f33-bab3-4f30-9ed8-01589e77fa27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238f33-bab3-4f30-9ed8-01589e77fa27.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play.",
             "colours": [
@@ -17389,7 +17389,7 @@
         },
         {
             "id": "7648f93f-897a-5f9f-83a4-da4cb409ae14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de49e393-aba4-4f04-b30c-89a195bc340e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de49e393-aba4-4f04-b30c-89a195bc340e.jpg?1",
             "name": "Hunted Wumpus",
             "text": "",
             "colours": [
@@ -17424,7 +17424,7 @@
         },
         {
             "id": "e6f7e822-eee4-57ee-b0f1-16c646f30d69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1310a1e-8cb9-4f43-a627-c8d96d600c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1310a1e-8cb9-4f43-a627-c8d96d600c36.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber comes into play, draw a card.",
             "colours": [
@@ -17459,7 +17459,7 @@
         },
         {
             "id": "5a35072f-0d50-5c71-8cd0-e2fefbf7cf1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a24463-9228-4ec4-8c35-98b4d83721b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a24463-9228-4ec4-8c35-98b4d83721b1.jpg?1",
             "name": "Kavu Climber",
             "text": "",
             "colours": [
@@ -17494,7 +17494,7 @@
         },
         {
             "id": "b9f4cc39-5090-5621-a0cf-0c518cd7fdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc34b5-7558-41b1-97e4-1ee13527dec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc34b5-7558-41b1-97e4-1ee13527dec4.jpg?1",
             "name": "King Cheetah",
             "text": "You may play King Cheetah any time you could play an instant.",
             "colours": [
@@ -17529,7 +17529,7 @@
         },
         {
             "id": "f8351171-8912-5ab9-bf02-d26cf453c134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6450a333-9776-4cda-a369-f9342e5b0278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6450a333-9776-4cda-a369-f9342e5b0278.jpg?1",
             "name": "King Cheetah",
             "text": "",
             "colours": [
@@ -17564,7 +17564,7 @@
         },
         {
             "id": "78a36fc2-2d07-5d8c-9faa-e2b3646fb868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dac78d2-dd1b-412a-b1b4-4fef1a4fd583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dac78d2-dd1b-412a-b1b4-4fef1a4fd583.jpg?1",
             "name": "Ley Druid",
             "text": "{T}: Untap target land.",
             "colours": [
@@ -17600,7 +17600,7 @@
         },
         {
             "id": "b140d9f1-68bf-55c8-91df-48543a69859a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac100fb-b43c-4557-adae-484d2706d577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac100fb-b43c-4557-adae-484d2706d577.jpg?1",
             "name": "Ley Druid",
             "text": "",
             "colours": [
@@ -17636,7 +17636,7 @@
         },
         {
             "id": "18b06975-920b-54d3-ad95-8a5ab48268ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47054d9-ab6c-4d66-8744-b458721a6c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47054d9-ab6c-4d66-8744-b458721a6c98.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "Tap an untapped creature you control: Llanowar Behemoth gets +1/+1 until end of turn.",
             "colours": [
@@ -17671,7 +17671,7 @@
         },
         {
             "id": "2021fe5b-60c5-5375-9cce-b81ce90681d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f703c1-29c3-49f1-aa3e-bb1bab0ea040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f703c1-29c3-49f1-aa3e-bb1bab0ea040.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "",
             "colours": [
@@ -17706,7 +17706,7 @@
         },
         {
             "id": "42e38dc7-9bdf-5546-9454-e967bfce7767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913907e2-28dd-4080-b725-52a43868e060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913907e2-28dd-4080-b725-52a43868e060.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -17742,7 +17742,7 @@
         },
         {
             "id": "2c99f20b-3142-5f7d-9af0-29826737a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7bf82d-437a-4c28-98a4-4d092ba8d063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7bf82d-437a-4c28-98a4-4d092ba8d063.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -17778,7 +17778,7 @@
         },
         {
             "id": "9e76af1d-87ab-58b8-bbde-a33593719abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9159e250-4eec-4ec4-80e1-42259331b3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9159e250-4eec-4ec4-80e1-42259331b3b9.jpg?1",
             "name": "Maro",
             "text": "Maro's power and toughness are each equal to the number of cards in your hand.",
             "colours": [
@@ -17813,7 +17813,7 @@
         },
         {
             "id": "1cc39187-4ab1-5a02-befc-2895f5d5d376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122852fa-e28d-4ed7-9bdf-7bd0f40450af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122852fa-e28d-4ed7-9bdf-7bd0f40450af.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -17848,7 +17848,7 @@
         },
         {
             "id": "4dac4f46-5663-5bc3-b56c-519e110d0e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d409378-ae02-4421-a866-df442d67032b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d409378-ae02-4421-a866-df442d67032b.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -17881,7 +17881,7 @@
         },
         {
             "id": "5c67dd02-bf01-598f-b0e8-ce4c4549acf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a24ad-8c67-4078-b110-0a198bcab29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a24ad-8c67-4078-b110-0a198bcab29e.jpg?1",
             "name": "Might of Oaks",
             "text": "",
             "colours": [
@@ -17914,7 +17914,7 @@
         },
         {
             "id": "40319bd0-154d-5ca5-ba90-c2684a226f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4847f8e8-9979-427e-999a-26711e542f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4847f8e8-9979-427e-999a-26711e542f82.jpg?1",
             "name": "Natural Affinity",
             "text": "Until end of turn, all lands become 2/2 creatures that are still lands.",
             "colours": [
@@ -17947,7 +17947,7 @@
         },
         {
             "id": "44ee475a-9acb-5b04-af66-25e42ca166d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee95dc2-ef83-4a2d-80d8-ab25ceb8739a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee95dc2-ef83-4a2d-80d8-ab25ceb8739a.jpg?1",
             "name": "Natural Affinity",
             "text": "",
             "colours": [
@@ -17980,7 +17980,7 @@
         },
         {
             "id": "3e8cc23b-ed6c-5f3e-847f-7dc89419a9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1986db3-dd6c-44f2-8d7a-a6b42d55a7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1986db3-dd6c-44f2-8d7a-a6b42d55a7c1.jpg?1",
             "name": "Natural Spring",
             "text": "Target player gains 8 life.",
             "colours": [
@@ -18013,7 +18013,7 @@
         },
         {
             "id": "15863a61-fb84-5a73-aa20-f6f45e51b9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23917a2c-e56c-461d-ba14-300015a54034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23917a2c-e56c-461d-ba14-300015a54034.jpg?1",
             "name": "Natural Spring",
             "text": "",
             "colours": [
@@ -18046,7 +18046,7 @@
         },
         {
             "id": "d834fd3e-9ba7-53ef-9547-1ae11a0a7bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f1019-2608-4d00-8b9b-7f22e87acd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f1019-2608-4d00-8b9b-7f22e87acd0d.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -18079,7 +18079,7 @@
         },
         {
             "id": "c7269572-c58b-5b13-9c25-b796259b11e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32504d-4032-4da1-8187-fd2637e3f76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32504d-4032-4da1-8187-fd2637e3f76e.jpg?1",
             "name": "Naturalize",
             "text": "",
             "colours": [
@@ -18112,7 +18112,7 @@
         },
         {
             "id": "08490f9e-3a32-563d-9261-a92e9cd5b19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bc178-f5ec-4e90-b8cf-2c7b00386c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bc178-f5ec-4e90-b8cf-2c7b00386c98.jpg?1",
             "name": "Needle Storm",
             "text": "Needle Storm deals 4 damage to each creature with flying.",
             "colours": [
@@ -18145,7 +18145,7 @@
         },
         {
             "id": "5bc5f70f-25d9-5973-a314-a18f083dd4a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c657c97-e8be-4798-b020-15e9e4acfc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c657c97-e8be-4798-b020-15e9e4acfc84.jpg?1",
             "name": "Needle Storm",
             "text": "",
             "colours": [
@@ -18178,7 +18178,7 @@
         },
         {
             "id": "813f2f9a-243e-5916-88e6-d3cb965c5277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf3a7c-e065-468b-a73c-6f986cde3a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf3a7c-e065-468b-a73c-6f986cde3a3d.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -18215,7 +18215,7 @@
         },
         {
             "id": "7c2e1507-e15d-5870-bf52-4b79b5c79405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b983cc1-d631-419b-96e5-02934dcb95f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b983cc1-d631-419b-96e5-02934dcb95f1.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -18252,7 +18252,7 @@
         },
         {
             "id": "f6a0ca24-673a-5f79-a522-a8654a333906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310500b2-8539-441e-af89-81ddfa8ef080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310500b2-8539-441e-af89-81ddfa8ef080.jpg?1",
             "name": "Order of the Sacred Bell",
             "text": "",
             "colours": [
@@ -18288,7 +18288,7 @@
         },
         {
             "id": "b03a711d-9aed-5a81-9147-ff34b79c84e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862a6fb-2aae-4b2a-86e1-4563de788d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862a6fb-2aae-4b2a-86e1-4563de788d7f.jpg?1",
             "name": "Order of the Sacred Bell",
             "text": "",
             "colours": [
@@ -18324,7 +18324,7 @@
         },
         {
             "id": "a8f41f2e-5625-570a-b818-270359fa40e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6da1dd-4172-48df-a3b2-c6d383053f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6da1dd-4172-48df-a3b2-c6d383053f4f.jpg?1",
             "name": "Overgrowth",
             "text": "Enchant land (Target a land as you play this. This card comes into play attached to that land.)\nWhenever enchanted land is tapped for mana, its controller adds {G}{G} to his or her mana pool.",
             "colours": [
@@ -18359,7 +18359,7 @@
         },
         {
             "id": "da1e35e3-ca99-58bf-b897-727976e0b6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27375bf-2492-4cbd-8b4b-96ed4c8533c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27375bf-2492-4cbd-8b4b-96ed4c8533c2.jpg?1",
             "name": "Overgrowth",
             "text": "",
             "colours": [
@@ -18394,7 +18394,7 @@
         },
         {
             "id": "19b75be2-7c68-59d3-8bf7-7f0b654429f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a429a983-d28e-46e7-816f-0398428db11a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a429a983-d28e-46e7-816f-0398428db11a.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -18427,7 +18427,7 @@
         },
         {
             "id": "5f021ca4-6926-5b1c-8ff0-9097a4793608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb82100d-cd49-420f-9aed-89db255d494b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb82100d-cd49-420f-9aed-89db255d494b.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -18460,7 +18460,7 @@
         },
         {
             "id": "aaf4747c-6168-5b95-b737-368ddd707180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a894efb2-7773-4b69-8289-e32d02f679ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a894efb2-7773-4b69-8289-e32d02f679ff.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -18493,7 +18493,7 @@
         },
         {
             "id": "226c81d2-b969-5774-82c5-0e5e2d67ff53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ded13d7-ef04-4fe5-b4df-4ea7c08ab208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ded13d7-ef04-4fe5-b4df-4ea7c08ab208.jpg?1",
             "name": "Reclaim",
             "text": "",
             "colours": [
@@ -18526,7 +18526,7 @@
         },
         {
             "id": "4909c493-72ee-52f9-9076-6e7e07ac8dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0bf1-0506-4d55-8e78-22d50a6edec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0bf1-0506-4d55-8e78-22d50a6edec4.jpg?1",
             "name": "Regeneration",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\n{G}: Regenerate enchanted creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -18561,7 +18561,7 @@
         },
         {
             "id": "8f956756-abe5-5145-9531-44899daa9ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44381391-4a15-45a9-bb73-8b3553223ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44381391-4a15-45a9-bb73-8b3553223ca1.jpg?1",
             "name": "Regeneration",
             "text": "",
             "colours": [
@@ -18596,7 +18596,7 @@
         },
         {
             "id": "d111ddbb-9e7b-5575-9c70-ef5f3e2b2f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bf281-80bc-4e85-9b8e-15577dfcdec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bf281-80bc-4e85-9b8e-15577dfcdec7.jpg?1",
             "name": "River Bear",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -18631,7 +18631,7 @@
         },
         {
             "id": "2e4b29aa-7202-5abf-be78-a59c11d05a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950f6ca6-31cc-44f0-a471-38f979f60a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950f6ca6-31cc-44f0-a471-38f979f60a6d.jpg?1",
             "name": "River Bear",
             "text": "",
             "colours": [
@@ -18666,7 +18666,7 @@
         },
         {
             "id": "eae066d5-ee3b-5edd-868e-93b6d16ccb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae084007-69ba-4857-9b0c-28455897f25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae084007-69ba-4857-9b0c-28455897f25c.jpg?1",
             "name": "Rootbreaker Wurm",
             "text": "Trample (If this creature would deal enough combat damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player.)",
             "colours": [
@@ -18701,7 +18701,7 @@
         },
         {
             "id": "6c210a82-05cc-5619-884e-38dda7ac6042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a698a1-fcd6-407c-a63c-02c54f8f8e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a698a1-fcd6-407c-a63c-02c54f8f8e11.jpg?1",
             "name": "Rootbreaker Wurm",
             "text": "",
             "colours": [
@@ -18736,7 +18736,7 @@
         },
         {
             "id": "6792626c-f199-526e-841a-4f185bf71e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08436832-2aab-47b0-b0da-b1b153e4b200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08436832-2aab-47b0-b0da-b1b153e4b200.jpg?1",
             "name": "Rootwalla",
             "text": "{1}{G}: Rootwalla gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -18771,7 +18771,7 @@
         },
         {
             "id": "7e2ff066-bee6-531e-a1c4-5625593cb23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9995de-7829-4940-b534-cdac215b4826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9995de-7829-4940-b534-cdac215b4826.jpg?1",
             "name": "Rootwalla",
             "text": "",
             "colours": [
@@ -18806,7 +18806,7 @@
         },
         {
             "id": "7c371e2a-bfc7-51d3-9a4a-3d11ab5bd85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e37991-8f7a-4c24-9f94-45bb59dd30b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e37991-8f7a-4c24-9f94-45bb59dd30b6.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -18841,7 +18841,7 @@
         },
         {
             "id": "84052aaf-5295-51b4-9b63-2a5b68c4c602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33b00cb-81c8-4c0b-8361-279967a7ce3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33b00cb-81c8-4c0b-8361-279967a7ce3c.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -18876,7 +18876,7 @@
         },
         {
             "id": "d8b99405-c638-59c3-a9e7-6163a0873cf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1d0254-985c-4d44-9cce-1d563e11f0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1d0254-985c-4d44-9cce-1d563e11f0a4.jpg?1",
             "name": "Seedborn Muse",
             "text": "Untap all permanents you control during each other player's untap step.",
             "colours": [
@@ -18911,7 +18911,7 @@
         },
         {
             "id": "9f6ccea1-e96e-5555-a6e2-136ec3751b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5ff284-8212-4382-b66e-339dacd1f32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5ff284-8212-4382-b66e-339dacd1f32f.jpg?1",
             "name": "Seedborn Muse",
             "text": "",
             "colours": [
@@ -18946,7 +18946,7 @@
         },
         {
             "id": "01dbfe5f-8794-5cb6-8605-e40f651b51bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612fe88c-9c6e-42b4-8936-a9431c1808ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612fe88c-9c6e-42b4-8936-a9431c1808ea.jpg?1",
             "name": "Silklash Spider",
             "text": "Silklash Spider can block as though it had flying.\n{X}{G}{G}: Silklash Spider deals X damage to each creature with flying.",
             "colours": [
@@ -18981,7 +18981,7 @@
         },
         {
             "id": "9a697359-5968-551e-b31a-abb2de70d849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb89572c-9c1b-4d90-a378-d65cc6770ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb89572c-9c1b-4d90-a378-d65cc6770ffa.jpg?1",
             "name": "Silklash Spider",
             "text": "",
             "colours": [
@@ -19016,7 +19016,7 @@
         },
         {
             "id": "f8d062de-8988-5de6-a147-3a50939ebc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341aa1b2-e600-4580-b0cd-e1582b75dc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341aa1b2-e600-4580-b0cd-e1582b75dc81.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -19049,7 +19049,7 @@
         },
         {
             "id": "c4186097-a4ef-537b-b29d-038c03b9169f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beea9dbe-6f5f-4e6a-a9c7-e732ab8a77d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beea9dbe-6f5f-4e6a-a9c7-e732ab8a77d0.jpg?1",
             "name": "Stream of Life",
             "text": "",
             "colours": [
@@ -19082,7 +19082,7 @@
         },
         {
             "id": "08c2f55b-eb4d-59b4-9bf9-ab3c5c700299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ed9d7-012c-43d0-a8c0-e208b58cad6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ed9d7-012c-43d0-a8c0-e208b58cad6f.jpg?1",
             "name": "Summer Bloom",
             "text": "You may play up to three additional lands this turn.",
             "colours": [
@@ -19115,7 +19115,7 @@
         },
         {
             "id": "8dce0c71-e593-5f72-bd32-eef4e7a45f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6729d75-adc2-430c-a0f9-f2991a65bf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6729d75-adc2-430c-a0f9-f2991a65bf83.jpg?1",
             "name": "Summer Bloom",
             "text": "",
             "colours": [
@@ -19148,7 +19148,7 @@
         },
         {
             "id": "f8a3008d-3d96-5e92-a911-ccc5e47f7775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5855f7-b100-4338-bb30-203fa275cba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5855f7-b100-4338-bb30-203fa275cba3.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19183,7 +19183,7 @@
         },
         {
             "id": "5d0ed309-7125-5519-a131-929b217d4d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4af28e-246f-4660-9c29-406d880b128d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4af28e-246f-4660-9c29-406d880b128d.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -19218,7 +19218,7 @@
         },
         {
             "id": "865221ae-ed86-5706-a9c1-0c683baafd8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4724d00a-b93b-43fd-9c86-56f127db450b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4724d00a-b93b-43fd-9c86-56f127db450b.jpg?1",
             "name": "Tree Monkey",
             "text": "Tree Monkey can block as though it had flying.",
             "colours": [
@@ -19253,7 +19253,7 @@
         },
         {
             "id": "f5914255-2ab1-531c-8c9b-37d151ea2ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705f54-f921-417f-9f56-53e6175aaf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705f54-f921-417f-9f56-53e6175aaf69.jpg?1",
             "name": "Tree Monkey",
             "text": "",
             "colours": [
@@ -19288,7 +19288,7 @@
         },
         {
             "id": "32ace6f2-a3a0-5373-a50c-2534f30aaa8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5312742c-0f35-4abc-97ec-fceda2658cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5312742c-0f35-4abc-97ec-fceda2658cec.jpg?1",
             "name": "Treetop Bracers",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +1/+1 and can't be blocked except by creatures with flying.",
             "colours": [
@@ -19323,7 +19323,7 @@
         },
         {
             "id": "0bea003f-85c6-5def-82b4-69c5bef2bb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46626917-d46a-42a5-b79c-5e2eaa6ca94b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46626917-d46a-42a5-b79c-5e2eaa6ca94b.jpg?1",
             "name": "Treetop Bracers",
             "text": "",
             "colours": [
@@ -19358,7 +19358,7 @@
         },
         {
             "id": "aee0bc5b-6285-507b-80d9-64f4cbea4215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bed540-da8d-4148-8794-8e8d01ed5387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bed540-da8d-4148-8794-8e8d01ed5387.jpg?1",
             "name": "Utopia Tree",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -19393,7 +19393,7 @@
         },
         {
             "id": "d8a2ddd7-70a8-51f6-aad1-3f48986a7be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e20c289-2bfa-4e2f-9cb3-37642e9a4a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e20c289-2bfa-4e2f-9cb3-37642e9a4a88.jpg?1",
             "name": "Utopia Tree",
             "text": "",
             "colours": [
@@ -19428,7 +19428,7 @@
         },
         {
             "id": "0bf3bb23-fd97-5419-9bf2-6914ed070ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a5533f-d24d-4cca-a47e-0676c6061a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a5533f-d24d-4cca-a47e-0676c6061a35.jpg?1",
             "name": "Verdant Force",
             "text": "At the beginning of each player's upkeep, put a 1/1 green Saproling creature token into play under your control.",
             "colours": [
@@ -19463,7 +19463,7 @@
         },
         {
             "id": "3ac24baf-1488-51a2-a48b-df2c5b18d1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4e67cf-3c49-480c-b960-128b1ab2a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4e67cf-3c49-480c-b960-128b1ab2a716.jpg?1",
             "name": "Verdant Force",
             "text": "",
             "colours": [
@@ -19498,7 +19498,7 @@
         },
         {
             "id": "fcb70313-2540-5d93-a745-d94af930ee4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d5f1c2-9f9c-416e-a0a2-6534b243e799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d5f1c2-9f9c-416e-a0a2-6534b243e799.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -19534,7 +19534,7 @@
         },
         {
             "id": "dfa3eec5-208f-5eda-9eda-10b5b02119ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159af678-36cc-496e-8ca4-600f0ff629f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159af678-36cc-496e-8ca4-600f0ff629f7.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -19570,7 +19570,7 @@
         },
         {
             "id": "1d60a8ee-af45-5f13-b7b3-a43edc4f4d29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21971049-f988-40ec-b5ae-0ac0575f1939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21971049-f988-40ec-b5ae-0ac0575f1939.jpg?1",
             "name": "Viridian Shaman",
             "text": "When Viridian Shaman comes into play, destroy target artifact.",
             "colours": [
@@ -19606,7 +19606,7 @@
         },
         {
             "id": "baa65d84-96ac-50aa-8e80-b26248914eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740abd3-e264-49c6-aacd-ca192c388e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740abd3-e264-49c6-aacd-ca192c388e54.jpg?1",
             "name": "Viridian Shaman",
             "text": "",
             "colours": [
@@ -19642,7 +19642,7 @@
         },
         {
             "id": "37086380-0361-5da8-af1b-772e6b66c7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91173ce1-62a9-4d0e-8b2a-9bc33858c4fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91173ce1-62a9-4d0e-8b2a-9bc33858c4fc.jpg?1",
             "name": "Web",
             "text": "Enchant creature (Target a creature as you play this. This card comes into play attached to that creature.)\nEnchanted creature gets +0/+2 and can block as though it had flying.",
             "colours": [
@@ -19677,7 +19677,7 @@
         },
         {
             "id": "c5301dfd-d5c5-5808-9359-565211581b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b15a1d5-a892-4d3b-a373-3a43424894c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b15a1d5-a892-4d3b-a373-3a43424894c3.jpg?1",
             "name": "Web",
             "text": "",
             "colours": [
@@ -19712,7 +19712,7 @@
         },
         {
             "id": "b475255d-3c21-5fec-8ca4-8980a0ff62f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd2c25-049a-4df2-bf8f-198d1b41b01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd2c25-049a-4df2-bf8f-198d1b41b01e.jpg?1",
             "name": "Weird Harvest",
             "text": "Each player may search his or her library for up to X creature cards, reveal those cards, and put them into his or her hand. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -19745,7 +19745,7 @@
         },
         {
             "id": "99b93237-139a-56c6-ae56-f89196e351f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759d87cf-4596-4a21-aa9d-48b426eda24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759d87cf-4596-4a21-aa9d-48b426eda24c.jpg?1",
             "name": "Weird Harvest",
             "text": "",
             "colours": [
@@ -19778,7 +19778,7 @@
         },
         {
             "id": "7ab99b79-d28b-5986-8f15-4c2359743f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cea55e-f85a-4f0f-b845-386d5c3fd9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cea55e-f85a-4f0f-b845-386d5c3fd9db.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a Forest card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -19814,7 +19814,7 @@
         },
         {
             "id": "efb46895-81d9-5ec2-8693-4acd43a8b797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4a34e-f1f0-480f-86b8-f2776c824261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4a34e-f1f0-480f-86b8-f2776c824261.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -19850,7 +19850,7 @@
         },
         {
             "id": "e12636fa-34eb-581e-a26f-2461227acbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18637e89-4794-46a8-bb80-b35211648d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18637e89-4794-46a8-bb80-b35211648d4f.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -19886,7 +19886,7 @@
         },
         {
             "id": "93f41570-1425-501d-b5a7-33b35340306f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa01c252-37f4-41af-b1a0-f30cdbdacf01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa01c252-37f4-41af-b1a0-f30cdbdacf01.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "",
             "colours": [
@@ -19922,7 +19922,7 @@
         },
         {
             "id": "ad06929e-df63-56b2-8c17-ab2e83671685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670108c-c3c8-4052-8f19-30dcb2266774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670108c-c3c8-4052-8f19-30dcb2266774.jpg?1",
             "name": "Zodiac Monkey",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -19957,7 +19957,7 @@
         },
         {
             "id": "f7b4e7a7-db9f-59fd-84bc-888d40eb5cf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58dddb-bcb9-444d-80a9-eb1fda23efa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a58dddb-bcb9-444d-80a9-eb1fda23efa2.jpg?1",
             "name": "Zodiac Monkey",
             "text": "",
             "colours": [
@@ -19992,7 +19992,7 @@
         },
         {
             "id": "22fc1065-f041-57cd-931f-1ceb4b9a5745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7370d-8ab4-4506-b7dd-d02c1ba92032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b7370d-8ab4-4506-b7dd-d02c1ba92032.jpg?1",
             "name": "Aladdin's Ring",
             "text": "{8}, {T}: Aladdin's Ring deals 4 damage to target creature or player.",
             "colours": [],
@@ -20021,7 +20021,7 @@
         },
         {
             "id": "98fcbe88-c5a6-542c-9b9e-41c6b8b88cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b31ad9d-823b-4e74-a996-91f200ec72f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b31ad9d-823b-4e74-a996-91f200ec72f7.jpg?1",
             "name": "Aladdin's Ring",
             "text": "",
             "colours": [],
@@ -20050,7 +20050,7 @@
         },
         {
             "id": "0553ffec-eec1-5b7c-b93d-f7cdc64ad909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476f1233-7474-4c01-8e8b-be642a638a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476f1233-7474-4c01-8e8b-be642a638a61.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player plays a white spell, you may gain 1 life.",
             "colours": [],
@@ -20079,7 +20079,7 @@
         },
         {
             "id": "8bfe9730-52b3-5424-bb97-6ddb5fb99b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557d8283-596d-4480-8a9a-c026c2f68cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557d8283-596d-4480-8a9a-c026c2f68cc2.jpg?1",
             "name": "Angel's Feather",
             "text": "",
             "colours": [],
@@ -20108,7 +20108,7 @@
         },
         {
             "id": "35b6431a-f2df-5502-9358-76fac7e9e645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a19f6d-4fab-4be6-af9e-c66acc16e4f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a19f6d-4fab-4be6-af9e-c66acc16e4f8.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden's power and toughness are each equal to the number of creatures in play.",
             "colours": [],
@@ -20140,7 +20140,7 @@
         },
         {
             "id": "c84b3433-2ba5-5fc3-b663-e47f5a99fb88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5371e-6881-41be-8ed2-718dcf0446fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5371e-6881-41be-8ed2-718dcf0446fe.jpg?1",
             "name": "Beast of Burden",
             "text": "",
             "colours": [],
@@ -20172,7 +20172,7 @@
         },
         {
             "id": "4d56b072-1d85-53d4-b14b-b942077ea5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af0c9a0-0dfa-4245-8b29-7bd37982b7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af0c9a0-0dfa-4245-8b29-7bd37982b7d2.jpg?1",
             "name": "Booby Trap",
             "text": "As Booby Trap comes into play, name a card other than a basic land card and choose an opponent.\nThe chosen player reveals each card he or she draws.\nWhen the chosen player draws the named card, sacrifice Booby Trap. If you do, Booby Trap deals 10 damage to that player.",
             "colours": [],
@@ -20201,7 +20201,7 @@
         },
         {
             "id": "0e88e250-2d86-55d4-a9cd-747f62068101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bd218f-0e39-4456-a452-a4abfcb61450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bd218f-0e39-4456-a452-a4abfcb61450.jpg?1",
             "name": "Booby Trap",
             "text": "",
             "colours": [],
@@ -20230,7 +20230,7 @@
         },
         {
             "id": "af5b2663-b49a-5ae1-9d91-68f9096df374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d225c1-22f7-4c98-bba0-216724f2d587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d225c1-22f7-4c98-bba0-216724f2d587.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: You gain 3 life.",
             "colours": [],
@@ -20262,7 +20262,7 @@
         },
         {
             "id": "8b83a628-c2cf-57a0-9fc6-1a0a495a7527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8c6a-500e-4ec8-8c28-76c47126ed53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8c6a-500e-4ec8-8c28-76c47126ed53.jpg?1",
             "name": "Bottle Gnomes",
             "text": "",
             "colours": [],
@@ -20294,7 +20294,7 @@
         },
         {
             "id": "eba4ea5a-47ac-5292-80b3-8e223fa8c86d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf3074-da3b-47e1-9a2c-88cfb1918a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf3074-da3b-47e1-9a2c-88cfb1918a98.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play that shares a creature type with it. (For example, if a Goblin Warrior, a Goblin Scout, and a Zombie Goblin are in play, each gets +2/+2.)",
             "colours": [],
@@ -20323,7 +20323,7 @@
         },
         {
             "id": "df0d06bf-c2d7-5613-8f1f-dd59e0169e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a9098-e181-4052-83e6-fcf1b209120f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215a9098-e181-4052-83e6-fcf1b209120f.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -20352,7 +20352,7 @@
         },
         {
             "id": "7e4f8429-18ee-51bd-9195-84ef96ea1112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede26e9e-95b6-4dbc-9263-59f370c4f6a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede26e9e-95b6-4dbc-9263-59f370c4f6a3.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -20384,7 +20384,7 @@
         },
         {
             "id": "d68820e4-b2ea-5c70-8eca-1a56adb5374e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b760d5-60a3-4399-b1ae-faf68fd122c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b760d5-60a3-4399-b1ae-faf68fd122c6.jpg?1",
             "name": "Dancing Scimitar",
             "text": "",
             "colours": [],
@@ -20416,7 +20416,7 @@
         },
         {
             "id": "cd6c7fbb-d5d2-5be1-9469-405b962b7c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f939dac5-ad71-4163-adde-4f435412477c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f939dac5-ad71-4163-adde-4f435412477c.jpg?1",
             "name": "Defense Grid",
             "text": "During each player's turn, each other player's spells cost {3} more to play.",
             "colours": [],
@@ -20445,7 +20445,7 @@
         },
         {
             "id": "74b5eb29-1284-5cf7-adc1-6469d43c3102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe6283a-95da-4425-93db-e00e8e972ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe6283a-95da-4425-93db-e00e8e972ec0.jpg?1",
             "name": "Defense Grid",
             "text": "",
             "colours": [],
@@ -20474,7 +20474,7 @@
         },
         {
             "id": "caf362c1-709e-5fd9-bcc0-5dcac8b1ebe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98135714-7422-4b1f-94c4-f4ee980c94a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98135714-7422-4b1f-94c4-f4ee980c94a8.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player plays a black spell, you may gain 1 life.",
             "colours": [],
@@ -20503,7 +20503,7 @@
         },
         {
             "id": "51827110-aab9-599a-a1b4-619cd6198e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59923706-2110-4d71-92a2-4d0c4aeeff3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59923706-2110-4d71-92a2-4d0c4aeeff3c.jpg?1",
             "name": "Demon's Horn",
             "text": "",
             "colours": [],
@@ -20532,7 +20532,7 @@
         },
         {
             "id": "7b598ac4-96f2-5838-8813-fadb17a7b09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55be5981-5bbc-4621-9f53-fc4edd4fde7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55be5981-5bbc-4621-9f53-fc4edd4fde7e.jpg?1",
             "name": "Disrupting Scepter",
             "text": "{3}, {T}: Target player discards a card. Play this ability only during your turn.",
             "colours": [],
@@ -20561,7 +20561,7 @@
         },
         {
             "id": "1238f0d3-d5e9-5059-985f-f84de5e6d60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c74aa6b-6f35-420e-87eb-3f21f2259869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c74aa6b-6f35-420e-87eb-3f21f2259869.jpg?1",
             "name": "Disrupting Scepter",
             "text": "",
             "colours": [],
@@ -20590,7 +20590,7 @@
         },
         {
             "id": "17206311-c336-58b1-84ce-ca9b0de656e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd62ce2f-bf20-427a-9dbc-40732ff639ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd62ce2f-bf20-427a-9dbc-40732ff639ab.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player plays a red spell, you may gain 1 life.",
             "colours": [],
@@ -20619,7 +20619,7 @@
         },
         {
             "id": "76e3ddbb-2a66-5301-9e31-5409b52e1ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773ff8d2-29e0-49b3-b45e-673886a03f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773ff8d2-29e0-49b3-b45e-673886a03f88.jpg?1",
             "name": "Dragon's Claw",
             "text": "",
             "colours": [],
@@ -20648,7 +20648,7 @@
         },
         {
             "id": "9a79b91e-5c01-57be-8aff-81d34c5e963f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8fd20a-d26e-417f-b1b7-e7257cc5b22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8fd20a-d26e-417f-b1b7-e7257cc5b22b.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -20677,7 +20677,7 @@
         },
         {
             "id": "12e8eb0d-1e1d-543e-b58b-8740de4440b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d51bff-d11a-41ab-933e-943d111a9550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d51bff-d11a-41ab-933e-943d111a9550.jpg?1",
             "name": "Fellwar Stone",
             "text": "",
             "colours": [],
@@ -20706,7 +20706,7 @@
         },
         {
             "id": "f55193fc-9d18-579d-9252-da2ac50ce7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480f85b2-79bd-4f1c-a815-d101a678cf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480f85b2-79bd-4f1c-a815-d101a678cf27.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws a card.",
             "colours": [],
@@ -20735,7 +20735,7 @@
         },
         {
             "id": "aa17d18e-d47d-5bf7-a9f7-5afba64b9722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8a7833-9420-4228-82ea-537e96c015fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8a7833-9420-4228-82ea-537e96c015fa.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -20764,7 +20764,7 @@
         },
         {
             "id": "aa3a8225-2c16-5b98-8177-08de33c74a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dec5eb-c391-4152-860d-68b2f09b8459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dec5eb-c391-4152-860d-68b2f09b8459.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -20793,7 +20793,7 @@
         },
         {
             "id": "b0d374b6-aa68-5e66-94b8-d77fc24d0526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a423b3-2e3a-4af0-a2bd-5f5dfdb055ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a423b3-2e3a-4af0-a2bd-5f5dfdb055ca.jpg?1",
             "name": "Icy Manipulator",
             "text": "",
             "colours": [],
@@ -20822,7 +20822,7 @@
         },
         {
             "id": "164bf392-82f2-5fc8-b350-9c029fe5f770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0495f8-4f18-4860-b1b4-58fa67414c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0495f8-4f18-4860-b1b4-58fa67414c8e.jpg?1",
             "name": "Jade Statue",
             "text": "{2}: Jade Statue becomes a 3/6 artifact creature until end of combat. Play this ability only during combat.",
             "colours": [],
@@ -20851,7 +20851,7 @@
         },
         {
             "id": "c2521d92-3ad1-581b-8bca-37ec9dd4723e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a739b-a942-4c75-9be9-1c8d2b99a486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a739b-a942-4c75-9be9-1c8d2b99a486.jpg?1",
             "name": "Jade Statue",
             "text": "",
             "colours": [],
@@ -20880,7 +20880,7 @@
         },
         {
             "id": "c264b344-330f-54e4-a658-724eb2383df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ede9d6b-3c7c-4a5f-a09b-80ec471692b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ede9d6b-3c7c-4a5f-a09b-80ec471692b6.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [],
@@ -20909,7 +20909,7 @@
         },
         {
             "id": "ecb7e097-9ef6-5703-81eb-4a8cc83f0c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5af13a-317e-4daa-9655-9f2d6d5c234f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5af13a-317e-4daa-9655-9f2d6d5c234f.jpg?1",
             "name": "Jester's Cap",
             "text": "",
             "colours": [],
@@ -20938,7 +20938,7 @@
         },
         {
             "id": "4b762fd5-4682-5488-b64f-e946bbccd4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80930e8-d2b4-4778-a958-9bf080cba1c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80930e8-d2b4-4778-a958-9bf080cba1c9.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player plays a blue spell, you may gain 1 life.",
             "colours": [],
@@ -20967,7 +20967,7 @@
         },
         {
             "id": "44afdbf9-cc87-5ee1-8004-a60ba32e6e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bf7266-bac5-47ab-8d35-24d19473c11b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bf7266-bac5-47ab-8d35-24d19473c11b.jpg?1",
             "name": "Kraken's Eye",
             "text": "",
             "colours": [],
@@ -20996,7 +20996,7 @@
         },
         {
             "id": "ac4d8786-9de7-57d9-a9bc-c3271bb8cb02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3569f5bd-4afc-455d-90e6-bfa08d505efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3569f5bd-4afc-455d-90e6-bfa08d505efe.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0, has trample, and has \"Whenever this creature deals damage, you gain that much life.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -21027,7 +21027,7 @@
         },
         {
             "id": "ef1ec66b-f9c5-5537-a5c5-6d162354a4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9ea7cf-90f6-4426-88b2-9e33fcb81669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9ea7cf-90f6-4426-88b2-9e33fcb81669.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "",
             "colours": [],
@@ -21058,7 +21058,7 @@
         },
         {
             "id": "9127a9fc-0e05-5226-94e2-ad1296fdd8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b3e79-6cec-4f2f-adaf-c368f099d7a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b3e79-6cec-4f2f-adaf-c368f099d7a5.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -21087,7 +21087,7 @@
         },
         {
             "id": "cc01ec9e-2c28-5c10-af0b-52dce65f705c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8c030-f549-4361-981c-db476b85a26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8c030-f549-4361-981c-db476b85a26d.jpg?1",
             "name": "Millstone",
             "text": "",
             "colours": [],
@@ -21116,7 +21116,7 @@
         },
         {
             "id": "f5be770b-6010-5c05-b1c6-98b9c59ef797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919bc14b-603d-42fa-91fe-58c4d4b3b27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919bc14b-603d-42fa-91fe-58c4d4b3b27f.jpg?1",
             "name": "Ornithopter",
             "text": "Flying (This creature can't be blocked except by creatures with flying.)",
             "colours": [],
@@ -21148,7 +21148,7 @@
         },
         {
             "id": "2976d99f-01fc-5e6f-8ed3-3e71bb72940e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6c46d6-aec8-420b-8018-7b2c3908e5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6c46d6-aec8-420b-8018-7b2c3908e5a0.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -21180,7 +21180,7 @@
         },
         {
             "id": "f8e1d486-e796-5b9e-91a8-b5977cc90c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d6e1ac-8346-464f-91ac-efc45d0c7294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d6e1ac-8346-464f-91ac-efc45d0c7294.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21213,7 +21213,7 @@
         },
         {
             "id": "7df78a4e-5668-53d3-a81a-55b3ed92ce03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ee39b3-80ef-4a48-8de2-57c8c6101775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ee39b3-80ef-4a48-8de2-57c8c6101775.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -21246,7 +21246,7 @@
         },
         {
             "id": "7d08899a-9ac4-5301-8ba7-6ac19bdc2f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb737b9-e526-47f7-806a-794cad54b23f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb737b9-e526-47f7-806a-794cad54b23f.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -21275,7 +21275,7 @@
         },
         {
             "id": "863cab2f-5131-545a-816a-83274dc14c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f50433-9eea-4159-bf89-82258f04ab53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f50433-9eea-4159-bf89-82258f04ab53.jpg?1",
             "name": "Rod of Ruin",
             "text": "",
             "colours": [],
@@ -21304,7 +21304,7 @@
         },
         {
             "id": "daa7751d-22a4-5af2-a874-aa1d695525e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8ad821-853b-47d6-8ae1-c317460a646f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8ad821-853b-47d6-8ae1-c317460a646f.jpg?1",
             "name": "Slate of Ancestry",
             "text": "{4}, {T}, Discard your hand: Draw a card for each creature you control.",
             "colours": [],
@@ -21333,7 +21333,7 @@
         },
         {
             "id": "00b1eeb6-2145-5ea2-a240-08f05b181786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4083ed-e258-41df-b9e0-82435c185653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4083ed-e258-41df-b9e0-82435c185653.jpg?1",
             "name": "Slate of Ancestry",
             "text": "",
             "colours": [],
@@ -21362,7 +21362,7 @@
         },
         {
             "id": "4796c801-bf2b-51ad-a307-e838c91a31d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbc3e2c-f6a6-4e4a-adfe-97fbc1596ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbc3e2c-f6a6-4e4a-adfe-97fbc1596ac3.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -21391,7 +21391,7 @@
         },
         {
             "id": "09f4f45e-f453-51d8-8eb9-78544812ec22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e7d0a-b01f-479b-9bfb-c3e31ade1b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286e7d0a-b01f-479b-9bfb-c3e31ade1b28.jpg?1",
             "name": "Spellbook",
             "text": "",
             "colours": [],
@@ -21420,7 +21420,7 @@
         },
         {
             "id": "53288df1-c683-50b3-af15-7c0681e9dffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa41221-ee75-4713-99bd-683013ba64de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa41221-ee75-4713-99bd-683013ba64de.jpg?1",
             "name": "Storage Matrix",
             "text": "As long as Storage Matrix is untapped, each player chooses artifact, creature, or land during his or her untap step. That player can untap only permanents of the chosen type this step.",
             "colours": [],
@@ -21449,7 +21449,7 @@
         },
         {
             "id": "f75086f5-f4f3-564b-bfa3-9cf1cb0722cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff70f2-780b-43a1-8618-66a9a298371f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff70f2-780b-43a1-8618-66a9a298371f.jpg?1",
             "name": "Storage Matrix",
             "text": "",
             "colours": [],
@@ -21478,7 +21478,7 @@
         },
         {
             "id": "2d651e9c-e58e-5a8d-9c76-88d8f22be366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8ff237-dac6-4c79-9d8c-b047d60083e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8ff237-dac6-4c79-9d8c-b047d60083e8.jpg?1",
             "name": "Tanglebloom",
             "text": "{1}, {T}: You gain 1 life.",
             "colours": [],
@@ -21507,7 +21507,7 @@
         },
         {
             "id": "50c15de4-645a-5cb2-b937-56383afe4c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1a41b-bdac-4164-ad6a-ade034a4f1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1a41b-bdac-4164-ad6a-ade034a4f1bf.jpg?1",
             "name": "Tanglebloom",
             "text": "",
             "colours": [],
@@ -21536,7 +21536,7 @@
         },
         {
             "id": "2c7bcb2b-51a9-504e-aab0-aae97be7a690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415e81e9-ca65-4bc0-8aab-d905d58fe6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415e81e9-ca65-4bc0-8aab-d905d58fe6cc.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in his or her hand on the bottom of his or her library in any order, then draws that many cards.",
             "colours": [],
@@ -21565,7 +21565,7 @@
         },
         {
             "id": "ae3474a8-1cc0-5ccd-9fb3-066c2aa41bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2257f28-0d42-4e83-a389-25efa1dc257b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2257f28-0d42-4e83-a389-25efa1dc257b.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -21594,7 +21594,7 @@
         },
         {
             "id": "fec76d0f-92ef-52f5-af20-393cfbcc272d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b390d5-ae5a-4ed7-b9af-01d504d0551a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b390d5-ae5a-4ed7-b9af-01d504d0551a.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -21626,7 +21626,7 @@
         },
         {
             "id": "75972426-24c0-50ae-b739-5636f9b629e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d40ce-868d-4825-b3a8-37798b062916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d40ce-868d-4825-b3a8-37798b062916.jpg?1",
             "name": "Thran Golem",
             "text": "",
             "colours": [],
@@ -21658,7 +21658,7 @@
         },
         {
             "id": "57aed26a-a1b5-529c-bb46-90c35c503825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50700965-7fac-4351-8967-8eafe5d68aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50700965-7fac-4351-8967-8eafe5d68aff.jpg?1",
             "name": "Ur-Golem's Eye",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -21687,7 +21687,7 @@
         },
         {
             "id": "c8bb909a-380b-5c45-b50e-5dd14bd5aa4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6768616-a677-4d0d-bab6-652968a32e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6768616-a677-4d0d-bab6-652968a32e2b.jpg?1",
             "name": "Ur-Golem's Eye",
             "text": "",
             "colours": [],
@@ -21716,7 +21716,7 @@
         },
         {
             "id": "08d5ba5c-3e09-5e98-9e61-54da70be4e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d5f79-2346-4150-9be9-ca49efa2652b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d5f79-2346-4150-9be9-ca49efa2652b.jpg?1",
             "name": "Vulshok Morningstar",
             "text": "Equipped creature gets +2/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -21747,7 +21747,7 @@
         },
         {
             "id": "59fdf42e-6e64-5aab-b8c7-eb0c680ed38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d515c5f2-d591-4a81-be38-604a0accac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d515c5f2-d591-4a81-be38-604a0accac46.jpg?1",
             "name": "Vulshok Morningstar",
             "text": "",
             "colours": [],
@@ -21778,7 +21778,7 @@
         },
         {
             "id": "680df9d5-8b98-5a21-a9dd-5eeb4bc77713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace337fe-900b-4582-9cbe-1b0473d2734c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace337fe-900b-4582-9cbe-1b0473d2734c.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player plays a green spell, you may gain 1 life.",
             "colours": [],
@@ -21807,7 +21807,7 @@
         },
         {
             "id": "f23c86b0-16eb-5284-8ea3-c0d703681b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3391b88-ec48-4d1f-bb68-23af792a67d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3391b88-ec48-4d1f-bb68-23af792a67d0.jpg?1",
             "name": "Wurm's Tooth",
             "text": "",
             "colours": [],
@@ -21836,7 +21836,7 @@
         },
         {
             "id": "e88bc31a-cce1-5a2f-9c0f-151a879700b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f61de1-4e49-4640-a495-5abefd96babf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f61de1-4e49-4640-a495-5abefd96babf.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -21868,7 +21868,7 @@
         },
         {
             "id": "c0e7f869-3e0e-5e19-bf3e-2bcb5c942796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f462b3f1-3e40-47a4-b1f6-7ab5b5dafbee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f462b3f1-3e40-47a4-b1f6-7ab5b5dafbee.jpg?1",
             "name": "Adarkar Wastes",
             "text": "",
             "colours": [],
@@ -21900,7 +21900,7 @@
         },
         {
             "id": "c5b2c9d8-3def-5788-ade3-98d0c57a94fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5064361-a8c7-4002-908a-992252641572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5064361-a8c7-4002-908a-992252641572.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -21932,7 +21932,7 @@
         },
         {
             "id": "bb52fb45-742f-5b11-a406-5a82571e8184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6cf4b8-875e-4bc8-bf57-24b7d2c6438e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6cf4b8-875e-4bc8-bf57-24b7d2c6438e.jpg?1",
             "name": "Battlefield Forge",
             "text": "",
             "colours": [],
@@ -21964,7 +21964,7 @@
         },
         {
             "id": "d0c7842e-caa6-5cdd-b9ad-859d7b1dee5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd3ea6a-84f7-41d0-8e4d-222809f1d484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd3ea6a-84f7-41d0-8e4d-222809f1d484.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -21996,7 +21996,7 @@
         },
         {
             "id": "b7ee5045-e89d-5470-bce4-2d6cd0e2c6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d182c97-2879-4f20-86e8-8e369dbb437e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d182c97-2879-4f20-86e8-8e369dbb437e.jpg?1",
             "name": "Brushland",
             "text": "",
             "colours": [],
@@ -22028,7 +22028,7 @@
         },
         {
             "id": "513987de-d3d5-56cc-8135-88c89f0dc52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693fbc6-78b0-4203-83f4-5352a997371e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693fbc6-78b0-4203-83f4-5352a997371e.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -22060,7 +22060,7 @@
         },
         {
             "id": "dcf2c1bb-aa03-5835-96b3-5e8880a816c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c33bd-cda4-4014-ae75-8eab8e8701e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c33bd-cda4-4014-ae75-8eab8e8701e9.jpg?1",
             "name": "Caves of Koilos",
             "text": "",
             "colours": [],
@@ -22092,7 +22092,7 @@
         },
         {
             "id": "040d8a8d-9462-5da3-917d-4f2dcfb82c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12ce05-cfc9-4628-a2a3-f207fd9b149a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12ce05-cfc9-4628-a2a3-f207fd9b149a.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -22124,7 +22124,7 @@
         },
         {
             "id": "07aa033b-77bd-55db-bf05-a38f88a476c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363dee3f-48d0-454d-81d3-9def5476a029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363dee3f-48d0-454d-81d3-9def5476a029.jpg?1",
             "name": "Karplusan Forest",
             "text": "",
             "colours": [],
@@ -22156,7 +22156,7 @@
         },
         {
             "id": "09c18e83-3d78-57b4-a124-8120aa5cc482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7218c70-b170-4d23-b98f-f8fa29312994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7218c70-b170-4d23-b98f-f8fa29312994.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -22188,7 +22188,7 @@
         },
         {
             "id": "0e20323f-d67a-5540-b51e-353e4d4adb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb5f66-d9f0-4af5-8d6b-14e1f3eef351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb5f66-d9f0-4af5-8d6b-14e1f3eef351.jpg?1",
             "name": "Llanowar Wastes",
             "text": "",
             "colours": [],
@@ -22220,7 +22220,7 @@
         },
         {
             "id": "0da14250-2d8b-50ff-a3c5-ecfb542a5beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c62bbe-aa06-4d1b-8338-ab270ab617e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c62bbe-aa06-4d1b-8338-ab270ab617e5.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -22249,7 +22249,7 @@
         },
         {
             "id": "58451e24-9652-5ad5-8cf3-d8cec3441f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8358766f-7501-435e-a10d-ff1be4acd7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8358766f-7501-435e-a10d-ff1be4acd7f0.jpg?1",
             "name": "Quicksand",
             "text": "",
             "colours": [],
@@ -22278,7 +22278,7 @@
         },
         {
             "id": "1edcb8b5-6049-5546-a8c1-c73f6735e03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea38777-e67d-40a5-9301-d4e6d3819899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea38777-e67d-40a5-9301-d4e6d3819899.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -22310,7 +22310,7 @@
         },
         {
             "id": "126feaef-8e03-5a29-9e76-b57f5530390e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749d16ac-cb54-42a4-ab26-1172e1465b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749d16ac-cb54-42a4-ab26-1172e1465b41.jpg?1",
             "name": "Shivan Reef",
             "text": "",
             "colours": [],
@@ -22342,7 +22342,7 @@
         },
         {
             "id": "402b4546-3a7c-5054-b864-b36fc84ba15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da34c3-53c7-401a-8f7e-f3cc8a42c888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da34c3-53c7-401a-8f7e-f3cc8a42c888.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -22374,7 +22374,7 @@
         },
         {
             "id": "099d0077-faa5-572b-81e2-07d846b45d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eeaf2fa-2f74-46f8-99fc-0e911cfc51dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eeaf2fa-2f74-46f8-99fc-0e911cfc51dd.jpg?1",
             "name": "Sulfurous Springs",
             "text": "",
             "colours": [],
@@ -22406,7 +22406,7 @@
         },
         {
             "id": "85c3a7f2-9c6c-5c2c-9ffe-e4ca81b118f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9395fc-ad8a-494a-a5bc-fea3f55b0e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9395fc-ad8a-494a-a5bc-fea3f55b0e2c.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -22438,7 +22438,7 @@
         },
         {
             "id": "4e8fb149-b3f0-5c50-8693-ca9b0a7c104c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52900300-dc28-4c2e-adfe-94c4de81ab02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52900300-dc28-4c2e-adfe-94c4de81ab02.jpg?1",
             "name": "Underground River",
             "text": "",
             "colours": [],
@@ -22470,7 +22470,7 @@
         },
         {
             "id": "3a0395a2-a4fb-51bf-81e9-dc720f5f747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a235785-b720-483b-bb28-6de440be2129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a235785-b720-483b-bb28-6de440be2129.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Power-Plant and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22502,7 +22502,7 @@
         },
         {
             "id": "36a53f88-aa71-54a3-831e-b96b616a6fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73bd2a6-676c-47cd-8608-1128cbd0c7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73bd2a6-676c-47cd-8608-1128cbd0c7cb.jpg?1",
             "name": "Urza's Mine",
             "text": "",
             "colours": [],
@@ -22534,7 +22534,7 @@
         },
         {
             "id": "4fb85e59-74c8-51a7-b49d-af15d4c62e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3115c04a-ac26-4361-aecd-c6fb5f03a96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3115c04a-ac26-4361-aecd-c6fb5f03a96f.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Tower, add {2} to your mana pool instead.",
             "colours": [],
@@ -22566,7 +22566,7 @@
         },
         {
             "id": "a19e5a10-874e-50b6-b69c-5a80e10fd536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b23321-861f-4afa-904f-7c63e356f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b23321-861f-4afa-904f-7c63e356f10b.jpg?1",
             "name": "Urza's Power Plant",
             "text": "",
             "colours": [],
@@ -22598,7 +22598,7 @@
         },
         {
             "id": "c15a7b40-1c2d-552e-857b-f9e93292a7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e063c-b328-4e5f-8806-b232c38645f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e063c-b328-4e5f-8806-b232c38645f5.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Power-Plant, add {3} to your mana pool instead.",
             "colours": [],
@@ -22630,7 +22630,7 @@
         },
         {
             "id": "47561a0c-44fc-5c0c-87ab-8ed3199c2b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd1ab7-e11d-4206-8aad-c3de4e2da5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd1ab7-e11d-4206-8aad-c3de4e2da5ec.jpg?1",
             "name": "Urza's Tower",
             "text": "",
             "colours": [],
@@ -22662,7 +22662,7 @@
         },
         {
             "id": "43d47975-d274-56ed-9c4c-604f90fad653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2eff74-8dcc-4c4b-8d74-c93b12966e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2eff74-8dcc-4c4b-8d74-c93b12966e88.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -22694,7 +22694,7 @@
         },
         {
             "id": "a2f7313a-7846-5b3b-9ca3-a5b90cdc07ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b98751-20bc-4c71-a51e-35503b072044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b98751-20bc-4c71-a51e-35503b072044.jpg?1",
             "name": "Yavimaya Coast",
             "text": "",
             "colours": [],
@@ -22726,7 +22726,7 @@
         },
         {
             "id": "b945e43a-cccb-5468-a67e-369d004c2805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e639a9-6010-4453-9c25-4ab03664b9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e639a9-6010-4453-9c25-4ab03664b9b2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22767,7 +22767,7 @@
         },
         {
             "id": "15deb7a4-ec34-5cad-a8fd-b14c886fc5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40b8460-30ae-4390-8bc6-ef69ff048572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40b8460-30ae-4390-8bc6-ef69ff048572.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22808,7 +22808,7 @@
         },
         {
             "id": "e778bfe3-776a-565d-933a-4c8df6f8ec6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c96115-3728-4f3c-9438-d53550974363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c96115-3728-4f3c-9438-d53550974363.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22849,7 +22849,7 @@
         },
         {
             "id": "d0d7d38e-7b09-5f11-8e93-5af58cd614e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8b83f-b7c8-4a8b-9c5c-31c793c6d9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8b83f-b7c8-4a8b-9c5c-31c793c6d9f0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22890,7 +22890,7 @@
         },
         {
             "id": "2c52b625-c51b-5d49-96a0-972ac05a8238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8703ecd3-1ffa-489c-b8e1-f4d9b5ba2c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8703ecd3-1ffa-489c-b8e1-f4d9b5ba2c12.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -22931,7 +22931,7 @@
         },
         {
             "id": "d25f765f-62a9-538c-ad3b-af09aed41814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13182c-0529-4da2-b5ae-9d61fe0a0f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13182c-0529-4da2-b5ae-9d61fe0a0f5f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "6d7699d9-885b-552f-b5e3-75779661a2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aae970-d66c-424e-8a23-577711af6eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aae970-d66c-424e-8a23-577711af6eab.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -23013,7 +23013,7 @@
         },
         {
             "id": "238c9dbb-b606-59de-82ee-de53794d0b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d20b8a-0aa7-45f6-8c87-01d85beb2771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d20b8a-0aa7-45f6-8c87-01d85beb2771.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -23054,7 +23054,7 @@
         },
         {
             "id": "c5745762-9012-5446-80d4-5974be9de1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0eac72f-915b-41a2-a9cf-1707b65d9ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0eac72f-915b-41a2-a9cf-1707b65d9ac9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23095,7 +23095,7 @@
         },
         {
             "id": "75b04cf4-e753-5fa3-b562-2556b6c95003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ddcce6-2f0f-4450-9aac-58b89ddc2e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ddcce6-2f0f-4450-9aac-58b89ddc2e50.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23136,7 +23136,7 @@
         },
         {
             "id": "70facbf8-ecc7-5b33-8c43-7b6d3180336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5ab443-b415-45e5-a9f7-539a5299bf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5ab443-b415-45e5-a9f7-539a5299bf27.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23177,7 +23177,7 @@
         },
         {
             "id": "8899ab1a-3831-5e23-ba22-6ddb86b1ca08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785f977-0635-4a20-ab8f-eab79659d16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785f977-0635-4a20-ab8f-eab79659d16e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23218,7 +23218,7 @@
         },
         {
             "id": "12546133-7808-5ed5-a8ef-5c521d31944a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d7f6bf-051c-45a4-b19e-2a50bbd6398e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d7f6bf-051c-45a4-b19e-2a50bbd6398e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23259,7 +23259,7 @@
         },
         {
             "id": "153d08d8-2466-59fb-9ebe-801aeda30d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434dc08b-0f4f-4230-bd39-7dc1c9d9cd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434dc08b-0f4f-4230-bd39-7dc1c9d9cd1e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23300,7 +23300,7 @@
         },
         {
             "id": "7b34d085-b477-56d2-bf1f-67400916fc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cf7cd5-3c25-4760-b783-36e7827154e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cf7cd5-3c25-4760-b783-36e7827154e2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -23341,7 +23341,7 @@
         },
         {
             "id": "472a2552-d0ab-5414-9a65-0384278eaf88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e3f97-531a-4336-af16-e0f738ebb85e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155e3f97-531a-4336-af16-e0f738ebb85e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -23382,7 +23382,7 @@
         },
         {
             "id": "5e671add-0a87-52d2-8067-cd66f8b3823d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc9d935-2a33-4928-b4b2-25c48544bf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc9d935-2a33-4928-b4b2-25c48544bf24.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23423,7 +23423,7 @@
         },
         {
             "id": "d65d6a9f-e5fc-590a-a861-59ad74a62bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0daa93a-8cc3-4fa3-944b-5b0b41e88fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0daa93a-8cc3-4fa3-944b-5b0b41e88fa3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23464,7 +23464,7 @@
         },
         {
             "id": "6336246e-e896-5327-b80b-e7dddd0c19ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e964e2e-8bc5-423c-ac85-4f0c860afb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e964e2e-8bc5-423c-ac85-4f0c860afb8a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23505,7 +23505,7 @@
         },
         {
             "id": "d5fb6761-80e5-5744-8eb1-03b3d6972e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aca4e94-3e7f-462b-a900-84e1f3609ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aca4e94-3e7f-462b-a900-84e1f3609ed8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23546,7 +23546,7 @@
         },
         {
             "id": "58185414-50c8-560b-94cc-911813550c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a54b0-49e6-4f79-8379-ccb30d06fb60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a54b0-49e6-4f79-8379-ccb30d06fb60.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23587,7 +23587,7 @@
         },
         {
             "id": "64dd5c3d-c54a-52e8-8186-4c0301b26c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8def00d9-2e93-4d65-bba5-09c45258bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8def00d9-2e93-4d65-bba5-09c45258bf5e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23628,7 +23628,7 @@
         },
         {
             "id": "50b58fcb-faf2-512d-971e-55b1a03635b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6190620-f88c-4eaf-853f-bfa0ea8f96d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6190620-f88c-4eaf-853f-bfa0ea8f96d3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -23669,7 +23669,7 @@
         },
         {
             "id": "02631ed2-f324-5f72-87d7-5e2c4d30d11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45919fc2-da64-4bfd-ba15-e61ed268b422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45919fc2-da64-4bfd-ba15-e61ed268b422.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -23710,7 +23710,7 @@
         },
         {
             "id": "9e96846f-a6f3-5b86-99d3-822116f99311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e2ee4c-5548-4a17-bf27-e906d2825867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e2ee4c-5548-4a17-bf27-e906d2825867.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23751,7 +23751,7 @@
         },
         {
             "id": "8a497168-508e-5672-a8d1-eaf9163a0459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b9efbc-ab04-4438-81e2-a558a67cafd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b9efbc-ab04-4438-81e2-a558a67cafd0.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23792,7 +23792,7 @@
         },
         {
             "id": "d5bb8759-4736-5996-9692-471b010863e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41bb43-0328-4093-88c6-4dc00dfdfb7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41bb43-0328-4093-88c6-4dc00dfdfb7e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23833,7 +23833,7 @@
         },
         {
             "id": "eb92cd72-3967-5794-ab5d-c87988ff8848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a0f125-041e-4a5d-b100-3dbb6bf729a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a0f125-041e-4a5d-b100-3dbb6bf729a1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23874,7 +23874,7 @@
         },
         {
             "id": "c9e00be2-45c1-536d-a521-c6aecb4ee496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2655e7b-ae35-45f0-b86d-c2f74ef3ee04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2655e7b-ae35-45f0-b86d-c2f74ef3ee04.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23915,7 +23915,7 @@
         },
         {
             "id": "84c9f6a2-ec56-5d45-97eb-259a660b1d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb734fd1-7e4a-4d56-b85e-6638012cbda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb734fd1-7e4a-4d56-b85e-6638012cbda9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -23956,7 +23956,7 @@
         },
         {
             "id": "02d2429d-bb88-5040-b8a4-d8c67eca5abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a6ddd-6684-49b1-8e2f-1516ca7a2a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a6ddd-6684-49b1-8e2f-1516ca7a2a34.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -23997,7 +23997,7 @@
         },
         {
             "id": "82fc0b59-8d31-5036-822e-06933ca7d8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aec9409-1812-4f85-b396-39bd9783b65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aec9409-1812-4f85-b396-39bd9783b65e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -24038,7 +24038,7 @@
         },
         {
             "id": "cd239a7d-5d69-5d5e-aa91-743935b9522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5029a818-e076-4ae3-a246-693ec7615e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5029a818-e076-4ae3-a246-693ec7615e15.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24079,7 +24079,7 @@
         },
         {
             "id": "45ddb1bb-7232-58fc-b4fa-7a6ad4c88272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0df6e1-1945-49e0-8960-e7022d81cc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0df6e1-1945-49e0-8960-e7022d81cc4f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24120,7 +24120,7 @@
         },
         {
             "id": "a4a99f87-62f8-5533-9583-e291e322850a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbc9c84-348b-40f5-ab3d-bbe8c27529a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbc9c84-348b-40f5-ab3d-bbe8c27529a4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24161,7 +24161,7 @@
         },
         {
             "id": "2936dbe4-ec25-5a6f-ba0b-235f82b6ed1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0d673b-cd7d-4d8f-8c62-63c79531ff85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0d673b-cd7d-4d8f-8c62-63c79531ff85.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24202,7 +24202,7 @@
         },
         {
             "id": "9a71c5e5-4732-53f0-81cd-d567318e8083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aaaad-a217-490a-8a90-31ce592ad742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aaaad-a217-490a-8a90-31ce592ad742.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24243,7 +24243,7 @@
         },
         {
             "id": "75cf0d63-188a-597b-8f0a-4cb19e450c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f15b112-500e-42ad-bdaa-5dadcd4351e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f15b112-500e-42ad-bdaa-5dadcd4351e1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -24284,7 +24284,7 @@
         },
         {
             "id": "d0cc9e31-977f-510d-a6da-af6b3562775f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e797e006-7379-45c2-a4b7-d0ef133379df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e797e006-7379-45c2-a4b7-d0ef133379df.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -24325,7 +24325,7 @@
         },
         {
             "id": "04da863e-44fa-5f3c-9c9d-02ed9f06f1a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412103f2-fdc1-4205-8f96-831186b58513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412103f2-fdc1-4205-8f96-831186b58513.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/A25.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/A25.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "36ec140e-8588-5daa-af1d-7638cee8c0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969860ba-6923-4715-b065-81803bba3dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969860ba-6923-4715-b065-81803bba3dd6.jpg?1",
             "name": "Act of Heroism",
             "text": "Untap target creature. It gets +2/+2 until end of turn and can block an additional creature this turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "83d4a1e2-c245-5f32-9183-bd9900f62aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9049ad-2bcd-4b5e-b09c-06424cf76cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9049ad-2bcd-4b5e-b09c-06424cf76cdc.jpg?1",
             "name": "Akroma, Angel of Wrath",
             "text": "Flying, first strike, vigilance, trample, haste, protection from black and from red",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "0e07bb7c-117e-5b1a-8f13-2af4a598b666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea781d-0aa1-4ccc-a48b-d4af7e5dfdd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea781d-0aa1-4ccc-a48b-d4af7e5dfdd5.jpg?1",
             "name": "Akroma's Vengeance",
             "text": "Destroy all artifacts, creatures, and enchantments.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "19083451-db64-52d8-826e-8f5811ecbf8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5022ca-9b8b-4d54-a4fa-706690b535d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5022ca-9b8b-4d54-a4fa-706690b535d4.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "b58854d2-c7af-5832-99d3-1b391ac27749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f1f6ac-983f-4f3e-8906-47f774e8367b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f1f6ac-983f-4f3e-8906-47f774e8367b.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "d12c29e5-7981-50fe-a92d-5bcd2bf11136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05fde4-a866-459c-9a24-2884116ab647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05fde4-a866-459c-9a24-2884116ab647.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "1a9806e2-28e2-54ff-a257-0e6ba75638ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b1e18f-f781-498c-ba84-cdee49c24230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b1e18f-f781-498c-ba84-cdee49c24230.jpg?1",
             "name": "Cloudshift",
             "text": "Exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "065d16f8-b517-5654-b5c5-db3feee06404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690166f-be52-48c4-9877-630b3f3dc614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690166f-be52-48c4-9877-630b3f3dc614.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -270,7 +270,7 @@
         },
         {
             "id": "4663ad3c-9657-5265-967f-196d4180652c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5f96a4-55e0-4ae3-bd78-f01703649e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5f96a4-55e0-4ae3-bd78-f01703649e9d.jpg?1",
             "name": "Darien, King of Kjeldor",
             "text": "Whenever you're dealt damage, you may create that many 1/1 white Soldier creature tokens.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "bea8cc6b-d8f5-58d5-b27c-c5b94222d794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b49b72c-16dc-45c7-ba76-545c4dec42d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b49b72c-16dc-45c7-ba76-545c4dec42d9.jpg?1",
             "name": "Dauntless Cathar",
             "text": "{1}{W}, Exile Dauntless Cathar from your graveyard: Create a 1/1 white Spirit creature token with flying. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "c22064c6-7fff-5018-a294-97c33acf67ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c236a8ab-51a6-4b48-8f33-de652a4c75f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c236a8ab-51a6-4b48-8f33-de652a4c75f2.jpg?1",
             "name": "Decree of Justice",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "c514087e-1252-591a-85c9-3cd9f3b2cac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a51270d-9143-46f5-a5d1-4ff3bf20ce34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a51270d-9143-46f5-a5d1-4ff3bf20ce34.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "c1ade745-3912-5508-9d7c-48b6b0002735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d074f-63b8-463f-b7e8-cc20e272208c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d074f-63b8-463f-b7e8-cc20e272208c.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "2158ed93-1afc-55b9-bde1-f1c7b3288bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99e7b7-f6ef-488d-ba85-a97c594cd664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99e7b7-f6ef-488d-ba85-a97c594cd664.jpg?1",
             "name": "Fiend Hunter",
             "text": "When Fiend Hunter enters the battlefield, you may exile another target creature.\nWhen Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "28d7ac1a-8652-5365-8899-4f392b48b304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd246d1-a7cb-45a0-b735-53509ba2d5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd246d1-a7cb-45a0-b735-53509ba2d5ca.jpg?1",
             "name": "Geist of the Moors",
             "text": "Flying",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "7e5df86d-f792-509f-ac0d-444ea3b2fe81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949e3977-8e67-421f-a2ff-a982b5a75714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949e3977-8e67-421f-a2ff-a982b5a75714.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1.",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "cd3ad779-3b76-55e2-8c15-3ad18cd0edfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6cb8ea-0dbf-45f8-b1e9-bd219de3fb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6cb8ea-0dbf-45f8-b1e9-bd219de3fb69.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "5f3d81ae-b4ad-5ce7-bfbc-de30b50ed713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29214308-711a-490f-8e93-bf61baf1749c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29214308-711a-490f-8e93-bf61baf1749c.jpg?1",
             "name": "Karona's Zealot",
             "text": "Morph {3}{W}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Karona's Zealot is turned face up, all damage that would be dealt to it this turn is dealt to target creature instead.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "ff40d959-d4f9-5bf6-9560-395fd31b73f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c908f812-a7ee-411e-89f1-1f84793d095d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c908f812-a7ee-411e-89f1-1f84793d095d.jpg?1",
             "name": "Knight of the Skyward Eye",
             "text": "{3}{G}: Knight of the Skyward Eye gets +3/+3 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "59cd4e91-3808-5bcc-83cb-598f3b8deb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c9e4fd-e987-4653-abb1-e32971745db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c9e4fd-e987-4653-abb1-e32971745db2.jpg?1",
             "name": "Kongming, \"Sleeping Dragon\"",
             "text": "Other creatures you control get +1/+1.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "7f114c73-ccc0-54c0-8fd3-1da8fb4e748a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd4a52-0c8f-4fca-b7dc-c2503794e5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd4a52-0c8f-4fca-b7dc-c2503794e5a4.jpg?1",
             "name": "Kor Firewalker",
             "text": "Protection from red\nWhenever a player casts a red spell, you may gain 1 life.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "b83df396-9f78-5440-b417-723b54084b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8854cc80-6201-4066-80c8-97c0fdc9baa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8854cc80-6201-4066-80c8-97c0fdc9baa8.jpg?1",
             "name": "Loyal Sentry",
             "text": "When Loyal Sentry blocks a creature, destroy that creature and Loyal Sentry.",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "ca728f3f-c50b-5b2c-bb27-c6bca2d6dd02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3770d86-4496-4c06-aab1-2917cfec100e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3770d86-4496-4c06-aab1-2917cfec100e.jpg?1",
             "name": "Luminarch Ascension",
             "text": "At the beginning of each opponent's end step, if you didn't lose life this turn, you may put a quest counter on Luminarch Ascension.\n{1}{W}: Create a 4/4 white Angel creature token with flying. Activate this ability only if Luminarch Ascension has four or more quest counters on it.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "49bb2c7a-5cf5-5eeb-933d-cad655b1c47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d63c045-5563-4ecd-804b-d4a77209501f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d63c045-5563-4ecd-804b-d4a77209501f.jpg?1",
             "name": "Lunarch Mantle",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}, Sacrifice a permanent: This creature gains flying until end of turn.\"",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "dc6d4c43-73e7-5e6b-ad58-27f1a9cad93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82073551-8106-4e88-8d55-913d86bbe48a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82073551-8106-4e88-8d55-913d86bbe48a.jpg?1",
             "name": "Noble Templar",
             "text": "Vigilance\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -856,7 +856,7 @@
         },
         {
             "id": "834400ad-461c-530f-9299-e86eabb7d017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad98e518-4ec9-403e-a978-217244262c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad98e518-4ec9-403e-a978-217244262c8f.jpg?1",
             "name": "Nyx-Fleece Ram",
             "text": "At the beginning of your upkeep, you gain 1 life.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "845f2242-de08-5d9e-af05-ae60cd878663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd652c85-f8ca-4e38-a21b-f21b729bcf92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd652c85-f8ca-4e38-a21b-f21b729bcf92.jpg?1",
             "name": "Ordeal of Heliod",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Heliod.\nWhen you sacrifice Ordeal of Heliod, you gain 10 life.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "3eafd0f4-6607-5ec4-a8c6-baf53d1408f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db339-9b27-404a-878d-16511b546862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5db339-9b27-404a-878d-16511b546862.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "cd3f302b-02a3-5717-bf56-47b04a4020f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41369848-ba9a-40ef-931e-1a65bc979209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41369848-ba9a-40ef-931e-1a65bc979209.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy target creature. Its owner gains 4 life.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "79b0cec7-a435-571d-bdca-53672bca46ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba42cce-4555-4d21-ba8e-fc2ff1a995c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba42cce-4555-4d21-ba8e-fc2ff1a995c2.jpg?1",
             "name": "Promise of Bunrei",
             "text": "When a creature you control dies, sacrifice Promise of Bunrei. If you do, create four 1/1 colorless Spirit creature tokens.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "eb1b3ddb-12b8-5a15-87ad-0c01c5f1ae40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849b907-9d80-484d-bdfa-6d287f5bc2d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849b907-9d80-484d-bdfa-6d287f5bc2d6.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "8a0f5058-ec35-5ebc-80d2-1ffde2b91e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b39be-0fec-4647-ade1-8e1626dc5470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b39be-0fec-4647-ade1-8e1626dc5470.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all cards from all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "81a64794-b8a1-59ff-b53a-fe39329908c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9757246-e782-4d7a-8273-d9efe284edaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9757246-e782-4d7a-8273-d9efe284edaf.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "a4781937-3f77-5671-adc2-2a2fd79dc69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e81806d-5d87-4032-ad94-c2cdeabecdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e81806d-5d87-4032-ad94-c2cdeabecdbf.jpg?1",
             "name": "Squadron Hawk",
             "text": "Flying\nWhen Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "6221685c-1864-58ac-b873-295852f2b70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220accc-2095-43d9-9114-7599c1cb8e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220accc-2095-43d9-9114-7599c1cb8e41.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1187,7 +1187,7 @@
         },
         {
             "id": "bb57ece7-d091-5050-8ac4-a7a7dcfc87b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff44c9-6ff5-432d-9876-488c96833c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff44c9-6ff5-432d-9876-488c96833c39.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "39cc8148-f53f-5da1-992c-a423ae02d69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f41db0-335d-4745-8759-0129baf72992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f41db0-335d-4745-8759-0129baf72992.jpg?1",
             "name": "Urbis Protector",
             "text": "When Urbis Protector enters the battlefield, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "54630d68-fb81-546c-bf7e-b0ae21ad8224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2a3fe4-a0c3-4956-a52b-060c4538c0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2a3fe4-a0c3-4956-a52b-060c4538c0b2.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "3ce3ba4d-95f6-5f1b-aa4a-03bf6a0ad640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27394079-924a-4fdb-8be2-f853193eca80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27394079-924a-4fdb-8be2-f853193eca80.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "0e0c2332-70ae-5a6d-b1fa-e5278f194bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad88e5ee-0eee-47af-a7b4-9bac044e1c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad88e5ee-0eee-47af-a7b4-9bac044e1c8c.jpg?1",
             "name": "Accumulated Knowledge",
             "text": "Draw a card, then draw cards equal to the number of cards named Accumulated Knowledge in all graveyards.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "ea4122d2-2490-539d-b6a4-35eb86e7a873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1ffeb1-6c31-45f7-8140-913c397022a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1ffeb1-6c31-45f7-8140-913c397022a3.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "90dc896f-5228-5a4f-a8ca-969025362559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5903aac6-171c-48b7-984a-f074c176d179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5903aac6-171c-48b7-984a-f074c176d179.jpg?1",
             "name": "Bident of Thassa",
             "text": "Whenever a creature you control deals combat damage to a player, you may draw a card.\n{1}{U}, {T}: Creatures your opponents control attack this turn if able.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "9636d9c3-50e2-515d-b4d7-4a773985af89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f51f88f-f662-4572-a371-9a77718ed079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f51f88f-f662-4572-a371-9a77718ed079.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target red spell.\n\u2022 Destroy target red permanent.",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "5105c0e8-98b9-5ea9-8ab1-9cad812a0fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500a2aa4-712f-41be-920e-f2f448ff83d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500a2aa4-712f-41be-920e-f2f448ff83d0.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "be3524e4-b87a-50a7-ab8a-3233bfcaec08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26334142-e9a2-4bf0-983e-dca4b4d817d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26334142-e9a2-4bf0-983e-dca4b4d817d7.jpg?1",
             "name": "Borrowing 100,000 Arrows",
             "text": "Draw a card for each tapped creature target opponent controls.",
             "colours": [
@@ -1520,7 +1520,7 @@
         },
         {
             "id": "5013e019-bf84-53c9-b13a-70043673a95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea8d5cb-cf7e-4194-8019-812b3f56cf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea8d5cb-cf7e-4194-8019-812b3f56cf20.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "e820824c-fdf3-50d1-b994-847f5cafc936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a4eb0b-415f-4b62-8b66-83eae0626d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a4eb0b-415f-4b62-8b66-83eae0626d9f.jpg?1",
             "name": "Brine Elemental",
             "text": "Morph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Brine Elemental is turned face up, each opponent skips his or her next untap step.",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "271f6162-1e1a-51d4-9f35-3a6c05575e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14884e61-fb1e-4989-ae29-57dfd910b53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14884e61-fb1e-4989-ae29-57dfd910b53f.jpg?1",
             "name": "Choking Tethers",
             "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "7cace6fa-e530-5e38-95ac-83f90028bef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbfa0fa-da69-4d6b-a722-52856c20f4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbfa0fa-da69-4d6b-a722-52856c20f4f0.jpg?1",
             "name": "Coralhelm Guide",
             "text": "{4}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "a3b1904e-7d51-5bfe-83fa-1be9b20cbc43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca8eb95-d071-46a4-885c-3da25b401806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca8eb95-d071-46a4-885c-3da25b401806.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "0969dae1-e5ce-54b9-8468-2867e5537316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3843e98-192c-44a2-be54-9ba79e51657c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3843e98-192c-44a2-be54-9ba79e51657c.jpg?1",
             "name": "Court Hussar",
             "text": "Vigilance\nWhen Court Hussar enters the battlefield, look at the top three cards of your library, then put one of them into your hand and the rest on the bottom of your library in any order.\nWhen Court Hussar enters the battlefield, sacrifice it unless {W} was spent to cast it.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "69d59f07-ce11-5a3e-9fc8-f1f875e6c028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd040ac-7e96-4082-a2d9-13d7dd26829e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd040ac-7e96-4082-a2d9-13d7dd26829e.jpg?1",
             "name": "Curiosity",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -1756,7 +1756,7 @@
         },
         {
             "id": "82e2eb8e-f9c7-57c7-b702-a6f953676e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d257a3c9-443f-4899-badc-f075a14667c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d257a3c9-443f-4899-badc-f075a14667c5.jpg?1",
             "name": "Cursecatcher",
             "text": "Sacrifice Cursecatcher: Counter target instant or sorcery spell unless its controller pays {1}.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "169d666f-705e-58ff-86e1-c2da3012ddd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20656d9-cd4f-4694-8715-04c017eb6760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20656d9-cd4f-4694-8715-04c017eb6760.jpg?1",
             "name": "Dragon's Eye Savants",
             "text": "Morph\u2014\nReveal a blue card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Dragon's Eye Savants is turned face up, look at target opponent's hand.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "9d2eda38-4c6c-5772-bb61-9504c60f1066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a50f54-6363-41dd-88a7-9f9e820e7d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a50f54-6363-41dd-88a7-9f9e820e7d5f.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "6dcba420-1762-5c8c-a7de-6f6375eb85a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750fcc79-daee-47da-8e91-a1afe48b8474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750fcc79-daee-47da-8e91-a1afe48b8474.jpg?1",
             "name": "Fathom Seer",
             "text": "Morph\u2014\nReturn two Islands you control to their owner's hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Fathom Seer is turned face up, draw two cards.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "0b0e870c-d3bc-56a5-b3cd-43585627110a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31459c2-9656-4e9a-bb72-71a910e8570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31459c2-9656-4e9a-bb72-71a910e8570b.jpg?1",
             "name": "Flash",
             "text": "You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by up to {2}.",
             "colours": [
@@ -1924,7 +1924,7 @@
         },
         {
             "id": "4ffb4bfd-978e-51d5-84d0-021bd30a8a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ee6f6-50c1-4f56-b9ce-4c309bfb92ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ee6f6-50c1-4f56-b9ce-4c309bfb92ca.jpg?1",
             "name": "Freed from the Real",
             "text": "Enchant creature\n{U}: Tap enchanted creature.\n{U}: Untap enchanted creature.",
             "colours": [
@@ -1958,7 +1958,7 @@
         },
         {
             "id": "32bc77b3-8a23-5443-b4a4-cb1636501bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ba3a2f-0224-4ace-bb49-8dc41b34fb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ba3a2f-0224-4ace-bb49-8dc41b34fb57.jpg?1",
             "name": "Genju of the Falls",
             "text": "Enchant Island\n{2}: Enchanted Island becomes a 3/2 blue Spirit creature with flying until end of turn. It's still a land.\nWhen enchanted Island is put into a graveyard, you may return Genju of the Falls from your graveyard to your hand.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "a0578098-adcd-56fa-9c92-c7f0bf640cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76d9d80-b7fb-43ed-bc9c-767dd1613d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76d9d80-b7fb-43ed-bc9c-767dd1613d37.jpg?1",
             "name": "Ghost Ship",
             "text": "Flying\n{U}{U}{U}: Regenerate Ghost Ship.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "dbde8a37-2044-5266-a2e0-03bb5ff64e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f46cb4e-1bdf-4322-8df1-58a8887fb963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f46cb4e-1bdf-4322-8df1-58a8887fb963.jpg?1",
             "name": "Horseshoe Crab",
             "text": "{U}: Untap Horseshoe Crab.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "f888d8cc-55f9-52fe-a47b-a3abf0b875b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c057dc0d-4017-4e60-9c5e-45fc569a8d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c057dc0d-4017-4e60-9c5e-45fc569a8d31.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles his or her hand into his or her library.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "96658e4f-9064-58c3-95c3-ad672664d026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9719c8-2dfe-4141-9ede-2ee3a282b5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9719c8-2dfe-4141-9ede-2ee3a282b5e9.jpg?1",
             "name": "Jalira, Master Polymorphist",
             "text": "{2}{U}, {T}, Sacrifice another creature: Reveal cards from the top of your library until you reveal a nonlegendary creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "903080d0-32cb-5b8e-9d59-655917e83d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fac7b68-db59-4b38-80e6-fcba3e3c91bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fac7b68-db59-4b38-80e6-fcba3e3c91bf.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "130e20a8-846f-58a6-ac96-f951ef55614e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cae1a42-052e-4110-9afc-d3ec83b7c8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cae1a42-052e-4110-9afc-d3ec83b7c8a9.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2202,7 +2202,7 @@
         },
         {
             "id": "8f82f15f-3d6d-5ea5-9ca5-f74f5afaf1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603920d6-7b83-4e55-b6df-2056afc40108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603920d6-7b83-4e55-b6df-2056afc40108.jpg?1",
             "name": "Murder of Crows",
             "text": "Flying\nWhenever another creature dies, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "717df329-fbef-5840-b6da-b9018a48c08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45261b50-e7cc-40f6-9d0d-44b5ada45e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45261b50-e7cc-40f6-9d0d-44b5ada45e42.jpg?1",
             "name": "Mystic of the Hidden Way",
             "text": "Mystic of the Hidden Way can't be blocked.\nMorph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "e423c65c-5459-53bc-9b1e-94491c5fc9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd125949-38c4-470f-9128-b80c45621086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd125949-38c4-470f-9128-b80c45621086.jpg?1",
             "name": "Pact of Negation",
             "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "24410b81-f879-5d2d-b913-ebe776c770cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5e968-6ba4-44e9-9587-6ef456721b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5e968-6ba4-44e9-9587-6ef456721b97.jpg?1",
             "name": "Phantasmal Bear",
             "text": "When Phantasmal Bear becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "34aa1613-431f-56a4-b554-536268aebced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147eb02-4cfc-49ed-a5aa-dd6b3f3a2e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147eb02-4cfc-49ed-a5aa-dd6b3f3a2e51.jpg?1",
             "name": "Reef Worm",
             "text": "When Reef Worm dies, create a 3/3 blue Fish creature token with \"When this creature dies, create a 6/6 blue Whale creature token with \u2018\nWhen this creature dies, create a 9/9 blue Kraken creature token.'\"",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "4a0f2081-6fc0-5953-84ea-5582364eabcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa3fdd0-34d8-47b3-9753-d2929838732e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa3fdd0-34d8-47b3-9753-d2929838732e.jpg?1",
             "name": "Retraction Helix",
             "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "13fd8f25-20c1-5146-9b13-4699b690e6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9957cbe-da88-41fe-a4aa-e32ec9e7aa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9957cbe-da88-41fe-a4aa-e32ec9e7aa38.jpg?1",
             "name": "Shoreline Ranger",
             "text": "Flying\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "4cbc42e1-94d5-5e5c-a5fa-128ca29fe227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5296fbac-b86f-458e-bfd8-34d05e4e212c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5296fbac-b86f-458e-bfd8-34d05e4e212c.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "14cb2797-ec94-5709-b177-adb7b7b950d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa6ad7-9057-4339-bff3-1250d5b44493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aa6ad7-9057-4339-bff3-1250d5b44493.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "a2fba370-cdfd-513a-987a-5d263b070090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c38f83-32af-4819-b259-a986860f484a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c38f83-32af-4819-b259-a986860f484a.jpg?1",
             "name": "Twisted Image",
             "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "f81b27c0-261c-57ae-81d2-3ed247b02620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd702cf1-10ca-4448-9fb1-b6de635e839c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd702cf1-10ca-4448-9fb1-b6de635e839c.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "cf8c2c84-1d2f-528b-910e-be55249081e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a131b03-f76b-455b-9e6e-0f30a42e04f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a131b03-f76b-455b-9e6e-0f30a42e04f1.jpg?1",
             "name": "Vesuvan Shapeshifter",
             "text": "As Vesuvan Shapeshifter enters the battlefield or is turned face up, you may choose another creature on the battlefield. If you do, until Vesuvan Shapeshifter is turned face down, it becomes a copy of that creature and gains \"At the beginning of your upkeep, you may turn this creature face down.\"\nMorph {1}{U}",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "deedf871-b391-5afa-8fb3-6deca8f251ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fac295-3563-4989-86b6-1672a4e97afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fac295-3563-4989-86b6-1672a4e97afd.jpg?1",
             "name": "Willbender",
             "text": "Morph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Willbender is turned face up, change the target of target spell or ability with a single target.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "961801d8-921c-57a4-81f9-271c9777ea91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20631989-64e7-4ad7-adf7-660033f893e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20631989-64e7-4ad7-adf7-660033f893e8.jpg?1",
             "name": "Ancient Craving",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "f25128c5-a235-5caa-a128-513f1d372ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd63bb3b-c927-4470-b308-6d4b51da1b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd63bb3b-c927-4470-b308-6d4b51da1b9c.jpg?1",
             "name": "Bloodhunter Bat",
             "text": "Flying\nWhen Bloodhunter Bat enters the battlefield, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2708,7 +2708,7 @@
         },
         {
             "id": "ae2f824a-0da6-5615-97b7-f680691743a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002443d-a296-4f68-8a94-991165e6ea38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002443d-a296-4f68-8a94-991165e6ea38.jpg?1",
             "name": "Caustic Tar",
             "text": "Enchant land\nEnchanted land has \"{T}: Target player loses 3 life.\"",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "dcfb5bf8-3c92-5d99-ae46-0a9d500b30e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f27eeb-6f14-4db3-adb9-9be5ed76b34b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f27eeb-6f14-4db3-adb9-9be5ed76b34b.jpg?1",
             "name": "Dark Ritual",
             "text": "Add {B}{B}{B} to your mana pool.",
             "colours": [
@@ -2774,7 +2774,7 @@
         },
         {
             "id": "b93bd88b-ba97-5ee8-90ad-af4e492a4bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbdf30e-effe-4008-ba9d-2157f6d21f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbdf30e-effe-4008-ba9d-2157f6d21f55.jpg?1",
             "name": "Deadly Designs",
             "text": "{2}: Put a plot counter on Deadly Designs. Any player may activate this ability.\nWhen there are five or more plot counters on Deadly Designs, sacrifice it. If you do, destroy up to two target creatures.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "91b29d94-dd0e-5567-8944-af8d09dc9d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426aeebc-3ff5-411d-b123-49a42e57e9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426aeebc-3ff5-411d-b123-49a42e57e9de.jpg?1",
             "name": "Death's-Head Buzzard",
             "text": "Flying\nWhen Death's-Head Buzzard dies, all creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "11acebd0-1432-5be6-ac70-bc9c98c57ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4992d2-8664-4179-a3f3-bfb2166484dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4992d2-8664-4179-a3f3-bfb2166484dd.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "14386065-4acf-5a84-8af8-83f3b24baee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69a1a58-6aab-4feb-850c-31fd2220bbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69a1a58-6aab-4feb-850c-31fd2220bbc0.jpg?1",
             "name": "Dirge of Dread",
             "text": "All creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)\nWhen you cycle Dirge of Dread, you may have target creature gain fear until end of turn.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "7a888e60-7991-5711-9d83-da9828b40965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a6be4-c9fa-4154-9e91-22eb939bfc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a6be4-c9fa-4154-9e91-22eb939bfc4f.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "68534bac-75d1-5e27-af48-99625ed58591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c73755-9678-467a-abd5-f8dd1556864e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c73755-9678-467a-abd5-f8dd1556864e.jpg?1",
             "name": "Doomsday",
             "text": "Search your library and graveyard for five cards and exile the rest. Put the chosen cards on top of your library in any order. You lose half your life, rounded up.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "31380b1d-7cd4-59d7-8f42-0efc59a8a654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9ef61-1c6d-49d1-b185-2b022482b442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9ef61-1c6d-49d1-b185-2b022482b442.jpg?1",
             "name": "Dusk Legion Zealot",
             "text": "When Dusk Legion Zealot enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "736514e3-5eb6-5751-9ee1-65fd43514311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29d88ad-5074-4f37-bb6a-2a7fe75c5771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29d88ad-5074-4f37-bb6a-2a7fe75c5771.jpg?1",
             "name": "Erg Raiders",
             "text": "At the beginning of your end step, if Erg Raiders didn't attack this turn, Erg Raiders deals 2 damage to you unless it came under your control this turn.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "992b0bcb-00a3-57b7-b62e-81a7cc4fb0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3baa621-1b50-4a7f-9ed4-4ae0e0e9e4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3baa621-1b50-4a7f-9ed4-4ae0e0e9e4e7.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature: Fallen Angel gets +2/+1 until end of turn.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "ff0353b4-4275-55f5-9e00-155add0f354d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a65ccf-37b6-48a3-9873-7a4cafef27cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a65ccf-37b6-48a3-9873-7a4cafef27cb.jpg?1",
             "name": "Hell's Caretaker",
             "text": "{T}, Sacrifice a creature: Return target creature card from your graveyard to the battlefield. Activate this ability only during your upkeep.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "4d8a30bc-8a79-57bc-bdec-9e7f64a4ceda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1f0958-5bf6-4a4f-a4bc-2943c93ba15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1f0958-5bf6-4a4f-a4bc-2943c93ba15e.jpg?1",
             "name": "Horror of the Broken Lands",
             "text": "Whenever you cycle or discard another card, Horror of the Broken Lands gets +2/+1 until end of turn.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "ca565281-e390-5763-9cd7-3a28816fe0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff128110-b87e-451c-a51d-9f116892e482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff128110-b87e-451c-a51d-9f116892e482.jpg?1",
             "name": "Ihsan's Shade",
             "text": "Protection from white",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "1aa8c5cf-9240-5d5d-8b56-4f5402083622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7ed355-894a-4592-9a64-ef061550d560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7ed355-894a-4592-9a64-ef061550d560.jpg?1",
             "name": "Laquatus's Champion",
             "text": "When Laquatus's Champion enters the battlefield, target player loses 6 life.\nWhen Laquatus's Champion leaves the battlefield, that player gains 6 life.\n{B}: Regenerate Laquatus's Champion.",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "e728eb32-6c88-5390-8a61-2bcbc5f8bb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2be583-2fa4-4ffe-9d89-c48a43d78a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2be583-2fa4-4ffe-9d89-c48a43d78a4e.jpg?1",
             "name": "Living Death",
             "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "49485f8b-7bc4-5711-8322-36b2f6506e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864930ce-7c56-4ad2-9b90-57b10e5a0842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864930ce-7c56-4ad2-9b90-57b10e5a0842.jpg?1",
             "name": "Mesmeric Fiend",
             "text": "When Mesmeric Fiend enters the battlefield, target opponent reveals his or her hand and you choose a nonland card from it. Exile that card.\nWhen Mesmeric Fiend leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -3279,7 +3279,7 @@
         },
         {
             "id": "18ee7f27-c1d3-55b7-944f-73f50bfa890d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c5d614-7b7a-4768-8e81-707f1f6bb34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c5d614-7b7a-4768-8e81-707f1f6bb34f.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3311,7 +3311,7 @@
         },
         {
             "id": "1ae04b12-3e65-5080-b064-8006732d0132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9c29bf-a177-40d5-9ade-129221222900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9c29bf-a177-40d5-9ade-129221222900.jpg?1",
             "name": "Nezumi Cutthroat",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nNezumi Cutthroat can't block.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "007b621a-9bd2-5ae8-8b8c-48ab926ecff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3c258-5d30-490f-9127-83d93d276345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3c258-5d30-490f-9127-83d93d276345.jpg?1",
             "name": "Phyrexian Ghoul",
             "text": "Sacrifice a creature: Phyrexian Ghoul gets +2/+2 until end of turn.",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "2e4c2ee7-6581-56c4-a291-450dc941b8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf5cbe2-84fa-46f4-a4f2-97b48ddf2d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf5cbe2-84fa-46f4-a4f2-97b48ddf2d39.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "17d53f15-6969-5cff-b3b4-eee8bc674933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d21d0d-7de7-4f03-8663-002c9290512f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d21d0d-7de7-4f03-8663-002c9290512f.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "137651a6-d349-561c-a505-29c185ae4226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cb08a7-cfcf-49ee-948b-4be859c1d256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cb08a7-cfcf-49ee-948b-4be859c1d256.jpg?1",
             "name": "Ratcatcher",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nAt the beginning of your upkeep, you may search your library for a Rat card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "ae247bb4-0565-5226-9571-45ce39dcf36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4846664-4463-4521-bb3f-3a4d00fa418d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4846664-4463-4521-bb3f-3a4d00fa418d.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -3518,7 +3518,7 @@
         },
         {
             "id": "606dc666-5318-59c8-9e71-3387b808876f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f47b6e-9557-4853-b8d6-7602a91c59a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f47b6e-9557-4853-b8d6-7602a91c59a7.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -3552,7 +3552,7 @@
         },
         {
             "id": "0530a1a0-7ba1-53fa-9bb1-75d5954e3b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa1dc6-b2e7-457b-9ad4-d024f21e8888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa1dc6-b2e7-457b-9ad4-d024f21e8888.jpg?1",
             "name": "Returned Phalanx",
             "text": "Defender\n{1}{U}: Returned Phalanx can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "0c3b767a-3b0b-5bb1-9d36-12eb337c8dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc78993c-ca67-43b3-a64d-ce0c3bc415bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc78993c-ca67-43b3-a64d-ce0c3bc415bc.jpg?1",
             "name": "Ruthless Ripper",
             "text": "Deathtouch\nMorph\u2014\nReveal a black card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Ruthless Ripper is turned face up, target player loses 2 life.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "8378b0fc-758a-5dbe-92d3-0b0032d9e6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81c6c07-0a76-4e43-a2ef-45ccffa7b0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81c6c07-0a76-4e43-a2ef-45ccffa7b0b8.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "09311699-945a-51be-9171-6931c711d482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f1b32-5546-40c5-9bfa-7af3dffb0a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f1b32-5546-40c5-9bfa-7af3dffb0a75.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "e51dcd48-fb42-53b3-941f-0218e9491d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813995f5-e49a-431d-8a3a-8ec569844e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813995f5-e49a-431d-8a3a-8ec569844e11.jpg?1",
             "name": "Triskaidekaphobia",
             "text": "At the beginning of your upkeep, choose one \u2014\n\u2022 Each player with exactly 13 life loses the game, then each player gains 1 life.\n\u2022 Each player with exactly 13 life loses the game, then each player loses 1 life.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "2e04d78f-d88d-52db-b455-b81ab1f354ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c276c8a7-2874-4ecb-9489-b1923d289510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c276c8a7-2874-4ecb-9489-b1923d289510.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -3756,7 +3756,7 @@
         },
         {
             "id": "7847db74-ebb4-5eda-adf6-be405484c397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bad2f48-9aa9-4f38-a22f-9b4802d0ee7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bad2f48-9aa9-4f38-a22f-9b4802d0ee7f.jpg?1",
             "name": "Undead Gladiator",
             "text": "{1}{B}, Discard a card: Return Undead Gladiator from your graveyard to your hand. Activate this ability only during your upkeep.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3791,7 +3791,7 @@
         },
         {
             "id": "fd9682a8-432c-506c-843b-8d3b39b3ee95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed268699-e1cc-4742-b19f-7f0ceaed2733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed268699-e1cc-4742-b19f-7f0ceaed2733.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3823,7 +3823,7 @@
         },
         {
             "id": "737f1e6d-fdc2-5b5e-a029-fd4aafc6fd75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c947c96-b4a5-4c3b-aacb-85ee0bf3afda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c947c96-b4a5-4c3b-aacb-85ee0bf3afda.jpg?1",
             "name": "Vampire Lacerator",
             "text": "At the beginning of your upkeep, you lose 1 life unless an opponent has 10 or less life.",
             "colours": [
@@ -3858,7 +3858,7 @@
         },
         {
             "id": "9a78c837-d705-53f7-8f69-be1591f9bb03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a1cd2-6778-45bb-84b8-4a9958cf10d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a1cd2-6778-45bb-84b8-4a9958cf10d7.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying\n{B}: Regenerate Will-o'-the-Wisp.",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "f83536e3-6b5a-5abd-b77c-30a3a8ed6437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9aa95-a8d5-42e6-b92e-b25b04b9ce8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a9aa95-a8d5-42e6-b92e-b25b04b9ce8a.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3924,7 +3924,7 @@
         },
         {
             "id": "07c28e35-2175-5aa1-8e10-53163c57252d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43a15b7-e013-4353-8643-cbcc8263714e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43a15b7-e013-4353-8643-cbcc8263714e.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "0b714dd5-854d-5dbf-9911-8ddf79e77ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e05fce1-0092-497d-9b43-a130fea0e06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e05fce1-0092-497d-9b43-a130fea0e06c.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "f4e81d97-3c32-5a72-92a2-72283a999298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d471a-801e-4d79-8f5e-bc621868fa05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d471a-801e-4d79-8f5e-bc621868fa05.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "Akroma, Angel of Fury can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "d01abff4-c754-5c12-acd0-03f04c0ddca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f853-4afb-4a91-8b4c-0d647ce9c216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f853-4afb-4a91-8b4c-0d647ce9c216.jpg?1",
             "name": "Balduvian Horde",
             "text": "When Balduvian Horde enters the battlefield, sacrifice it unless you discard a card at random.",
             "colours": [
@@ -4063,7 +4063,7 @@
         },
         {
             "id": "0f1a3c09-a53a-5754-b378-a4d915ebad63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635f581e-3954-4e46-82ff-ca2de3d64af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635f581e-3954-4e46-82ff-ca2de3d64af6.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample, haste\nAt the beginning of the end step, sacrifice Ball Lightning.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "6473f08c-e611-54ce-9103-b7aa7c12f8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50988ad-a7dc-4ae3-bdd7-c4d6d3789bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50988ad-a7dc-4ae3-bdd7-c4d6d3789bf2.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "b9a6e006-3ace-5e99-bd30-27060209dc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e9f60-f8ea-4f29-b7e2-ca87f8336fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e9f60-f8ea-4f29-b7e2-ca87f8336fca.jpg?1",
             "name": "Browbeat",
             "text": "Any player may have Browbeat deal 5 damage to him or her. If no one does, target player draws three cards.",
             "colours": [
@@ -4161,7 +4161,7 @@
         },
         {
             "id": "70336e3c-a787-52a2-801c-37c25a62cd96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7be4d-e3e7-4dd4-99f9-d7bfe3ad1614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7be4d-e3e7-4dd4-99f9-d7bfe3ad1614.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4193,7 +4193,7 @@
         },
         {
             "id": "dce8e228-2e2a-566d-9c96-d7cd509f5b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a32ab2-cc55-43fb-82d8-c51a3849b344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a32ab2-cc55-43fb-82d8-c51a3849b344.jpg?1",
             "name": "Chartooth Cougar",
             "text": "{R}: Chartooth Cougar gets +1/+0 until end of turn.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "76212181-aaac-564e-86f2-07b700e6a2b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a5856-b8a4-445a-93d2-f3869a03031f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a5856-b8a4-445a-93d2-f3869a03031f.jpg?1",
             "name": "Cinder Storm",
             "text": "Cinder Storm deals 7 damage to target creature or player.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "3340e79c-5ee3-5d11-a370-6c673a0a411c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f544fa-170f-4da4-bd28-72f713a045ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f544fa-170f-4da4-bd28-72f713a045ba.jpg?1",
             "name": "Crimson Mage",
             "text": "{R}: Target creature you control gains haste until end of turn.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "46669750-20d3-58c4-b834-1afb6814f554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183ef738-0559-49ca-85b4-e6836521f203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183ef738-0559-49ca-85b4-e6836521f203.jpg?1",
             "name": "Eidolon of the Great Revel",
             "text": "Whenever a player casts a spell with converted mana cost 3 or less, Eidolon of the Great Revel deals 2 damage to that player.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "1171244e-8363-537a-8cb5-c088ddadc5c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623fbebb-a43a-487b-a8f6-57781e5d5199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623fbebb-a43a-487b-a8f6-57781e5d5199.jpg?1",
             "name": "Enthralling Victor",
             "text": "When Enthralling Victor enters the battlefield, gain control of target creature an opponent controls with power 2 or less until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "61236f07-99ad-5653-b9e6-d94a35a71a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9700b3c-c309-4305-8761-3cf3ec902639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9700b3c-c309-4305-8761-3cf3ec902639.jpg?1",
             "name": "Fortune Thief",
             "text": "Damage that would reduce your life total to less than 1 reduces it to 1 instead.\nMorph {R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4400,7 +4400,7 @@
         },
         {
             "id": "545f818e-76f5-5877-8d04-8df962c80b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b95c20-552a-41b9-8e65-bee9019d987f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b95c20-552a-41b9-8e65-bee9019d987f.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "2b2b6eff-585d-5c90-9773-c0414e6b0ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777cc6bb-638c-4535-8072-f8a2a1ba5b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777cc6bb-638c-4535-8072-f8a2a1ba5b45.jpg?1",
             "name": "Genju of the Spires",
             "text": "Enchant Mountain\n{2}: Enchanted Mountain becomes a 6/1 red Spirit creature until end of turn. It's still a land.\nWhen enchanted Mountain is put into a graveyard, you may return Genju of the Spires from your graveyard to your hand.",
             "colours": [
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "baea9eca-fd81-5ae8-adf3-85e8e5c69a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d18b250-cbfb-4248-96c6-c1b36f8299b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d18b250-cbfb-4248-96c6-c1b36f8299b8.jpg?1",
             "name": "Goblin War Drums",
             "text": "Creatures you control have menace.",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "b89eb386-4487-5f63-afe7-45c7a12a088d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4138531-ef42-4c56-864e-d3525a4f2082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4138531-ef42-4c56-864e-d3525a4f2082.jpg?1",
             "name": "Hordeling Outburst",
             "text": "Create three 1/1 red Goblin creature tokens.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "e17695d9-dfd5-5f42-a8e5-4d88e673db96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63be8070-b64d-443d-a00e-6495258688c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63be8070-b64d-443d-a00e-6495258688c7.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "4ade0c2f-99ee-5df4-9ec9-25ba1e730d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca0bc75-00a6-429a-bac9-5296e3146709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca0bc75-00a6-429a-bac9-5296e3146709.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "ff020c1a-d9e9-5ca5-9f67-2be10d7199d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea54760c-2cd3-43eb-bc45-adc0997b34b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea54760c-2cd3-43eb-bc45-adc0997b34b0.jpg?1",
             "name": "Ire Shaman",
             "text": "Menace\nMegamorph {R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ire Shaman is turned face up, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "09bde164-70f3-50b1-a93a-731cb03884f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc8fd50-b3be-49b0-9209-f5ce82d9868e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc8fd50-b3be-49b0-9209-f5ce82d9868e.jpg?1",
             "name": "Izzet Chemister",
             "text": "Haste\n{R}, {T}: Exile target instant or sorcery card from your graveyard.\n{1}{R}, {T}, Sacrifice Izzet Chemister: Cast any number of cards exiled with Izzet Chemister without paying their mana costs.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "ad349082-aed3-5dda-80fe-c9b68647e408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8743b2-30e3-4d15-89fc-72974747aec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8743b2-30e3-4d15-89fc-72974747aec5.jpg?1",
             "name": "Jackal Pup",
             "text": "Whenever Jackal Pup is dealt damage, it deals that much damage to you.",
             "colours": [
@@ -4707,7 +4707,7 @@
         },
         {
             "id": "77d44517-67d7-568f-9b06-4a089eb0b6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687518f-73ff-4813-a56f-5b5cc4f36e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687518f-73ff-4813-a56f-5b5cc4f36e7a.jpg?1",
             "name": "Kindle",
             "text": "Kindle deals X damage to target creature or player, where X is 2 plus the number of cards named Kindle in all graveyards.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "88d7451f-97a3-51cc-8e8e-722c951d783b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3285e6b-3e79-4d7c-bf96-d920f973b122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3285e6b-3e79-4d7c-bf96-d920f973b122.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "1454d3cc-e812-5914-8426-4d2969bf0971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b6dde7-77b7-4993-b983-4beb110b2d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b6dde7-77b7-4993-b983-4beb110b2d83.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards his or her hand, then draws seven cards.",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "498f983d-f71f-5f4c-9a2a-f1784b906454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507a123-cf1a-42e1-a8fa-221960c48c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507a123-cf1a-42e1-a8fa-221960c48c16.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies can't attack or block alone.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "22623546-4df3-5b6e-b615-b387b01059f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded44c07-ef04-4c2d-9b8d-5474de9d2ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded44c07-ef04-4c2d-9b8d-5474de9d2ec3.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "280c8a45-d4d7-59d7-ba57-d2744e98b92c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd970484-49b3-442a-806a-cabc56526ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd970484-49b3-442a-806a-cabc56526ee1.jpg?1",
             "name": "Pyre Hound",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on Pyre Hound.",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "ba39d106-f2eb-5603-aab2-1feff2623e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8f3b5e-71b4-42e0-9ddb-630e3dcf1be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8f3b5e-71b4-42e0-9ddb-630e3dcf1be7.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "a8550b67-801f-58ff-9641-d62089e4a2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a45e9b-699e-425a-9f3d-267274830d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a45e9b-699e-425a-9f3d-267274830d3e.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target blue spell.\n\u2022 Destroy target blue permanent.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "75138bb9-25b3-56b7-88ff-641e16eb2845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1ac65-aed8-4ac6-ba90-e088db6c1389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1ac65-aed8-4ac6-ba90-e088db6c1389.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "Exile Simian Spirit Guide from your hand: Add {R} to your mana pool.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "81d45be8-7e13-54dd-b089-fda2aee3675b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ce40e-23e3-47e7-a900-c77c12f122a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ce40e-23e3-47e7-a900-c77c12f122a5.jpg?1",
             "name": "Skeletonize",
             "text": "Skeletonize deals 3 damage to target creature. When a creature dealt damage this way dies this turn, create a 1/1 black Skeleton creature token with \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "ad1b7117-27e6-51d0-8e51-8a2331ce3d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259a6b6d-368a-4ee0-b0ed-b52301bfd78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259a6b6d-368a-4ee0-b0ed-b52301bfd78f.jpg?1",
             "name": "Skirk Commando",
             "text": "Whenever Skirk Commando deals combat damage to a player, you may have it deal 2 damage to target creature that player controls.\nMorph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "95e33f59-d967-53ba-8664-e7e6e4c54375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c52c8-a2c3-4f48-a5c3-2db92011e0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c52c8-a2c3-4f48-a5c3-2db92011e0cc.jpg?1",
             "name": "Soulbright Flamekin",
             "text": "{2}: Target creature gains trample until end of turn. If this is the third time this ability has resolved this turn, you may add {R}{R}{R}{R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "602de6fc-286a-594e-bc6b-3029bfc5ee0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b2651d-6418-42c6-abf4-e8cdb977833f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b2651d-6418-42c6-abf4-e8cdb977833f.jpg?1",
             "name": "Spikeshot Goblin",
             "text": "{R}, {T}: Spikeshot Goblin deals damage equal to its power to target creature or player.",
             "colours": [
@@ -5143,7 +5143,7 @@
         },
         {
             "id": "a712ff17-161d-556d-91b5-bbb43aacfd28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff0d9ba-100a-4f4a-b04b-1382ed912eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff0d9ba-100a-4f4a-b04b-1382ed912eaa.jpg?1",
             "name": "Thresher Lizard",
             "text": "Thresher Lizard gets +1/+2 as long as you have one or fewer cards in hand.",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "827c992c-59d1-59d3-8ecc-c7f02612978d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3e8c1c-481e-4f90-8eeb-29584d157f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3e8c1c-481e-4f90-8eeb-29584d157f1f.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5209,7 +5209,7 @@
         },
         {
             "id": "26fd6533-ed6c-544f-b02d-090dbad640bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b3375-f937-4d53-afa2-0711d8e59379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b3375-f937-4d53-afa2-0711d8e59379.jpg?1",
             "name": "Uncaged Fury",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "30d4d791-2d56-537e-86c8-e3d24f8d406b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa36309-4bcc-4455-813a-c0243b906792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa36309-4bcc-4455-813a-c0243b906792.jpg?1",
             "name": "Zada, Hedron Grinder",
             "text": "Whenever you cast an instant or sorcery spell that targets only Zada, Hedron Grinder, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "8119b27e-44e2-552d-8d6b-d0304fad978c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993399a-da99-4226-815c-55222684dfd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993399a-da99-4226-815c-55222684dfd8.jpg?1",
             "name": "Ainok Survivalist",
             "text": "Megamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ainok Survivalist is turned face up, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "5ac2489a-a5d0-50e6-9c4d-02feefc4629a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c05b3-ea23-477c-8a55-370cb6ae0941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c05b3-ea23-477c-8a55-370cb6ae0941.jpg?1",
             "name": "Ambassador Oak",
             "text": "When Ambassador Oak enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -5348,7 +5348,7 @@
         },
         {
             "id": "f5677206-e057-5b1b-9069-449e268d0857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea4a23-63fa-4d3d-90e3-c007ba0c0e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ea4a23-63fa-4d3d-90e3-c007ba0c0e78.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "b959df3c-2bcd-5fcc-bfa5-20f937345d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81165e-f091-4211-8b47-5ea6868b0d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b81165e-f091-4211-8b47-5ea6868b0d4c.jpg?1",
             "name": "Arbor Elf",
             "text": "{T}: Untap target Forest.",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "725a4c08-5b33-524d-b33c-5c4c4d589cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc38affd-b51d-4ea4-8198-d121c24ee5cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc38affd-b51d-4ea4-8198-d121c24ee5cf.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "dd8cd893-48bd-530e-9e03-149567c267a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b795f9-ee23-490b-af3d-de394ec07161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b795f9-ee23-490b-af3d-de394ec07161.jpg?1",
             "name": "Broodhatch Nantuko",
             "text": "Whenever Broodhatch Nantuko is dealt damage, you may create that many 1/1 green Insect creature tokens.\nMorph {2}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "30fe9cf6-a816-568d-96b5-dd83df74b67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0f3faf-c011-49b8-b604-d68a87615737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0f3faf-c011-49b8-b604-d68a87615737.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "c15cc5e9-e78c-5ae0-a433-e3839ee91102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8683a978-1bef-4b01-9361-56b1fc157d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8683a978-1bef-4b01-9361-56b1fc157d26.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library if it's a land card.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -5556,7 +5556,7 @@
         },
         {
             "id": "ae6eb4d0-b127-5e11-a8e5-01f7bca9fdf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419c85-c476-42b8-979f-143b45c6819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419c85-c476-42b8-979f-143b45c6819b.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "b380c3ba-e60d-5f54-815b-895707584ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04367e72-3f8c-4cba-8bdf-5a1ba9c9f01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04367e72-3f8c-4cba-8bdf-5a1ba9c9f01f.jpg?1",
             "name": "Echoing Courage",
             "text": "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
             "colours": [
@@ -5620,7 +5620,7 @@
         },
         {
             "id": "57c4f647-ed33-5c0a-93d6-bae1d326d3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a51425-d796-48b8-b68c-bc21fb465c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a51425-d796-48b8-b68c-bc21fb465c81.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G} to your mana pool.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "43a1476a-5993-5684-9f62-1ba41f324ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e47b9-6735-4e46-b3fd-ac69edc39745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e47b9-6735-4e46-b3fd-ac69edc39745.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "888c1784-cb44-53f1-a251-8192828e6bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3215b51-01df-4670-994d-b4d7a57b80f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3215b51-01df-4670-994d-b4d7a57b80f8.jpg?1",
             "name": "Ember Weaver",
             "text": "Reach\nAs long as you control a red permanent, Ember Weaver gets +1/+0 and has first strike.",
             "colours": [
@@ -5724,7 +5724,7 @@
         },
         {
             "id": "32f4b8c4-1cba-514e-b167-d1900896e531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ac4e89-d5fa-4f1b-bd61-be15eb322f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ac4e89-d5fa-4f1b-bd61-be15eb322f40.jpg?1",
             "name": "Epic Confrontation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control.",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "5f0a1f9b-7da2-5aaa-8db8-a70a3bda4601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c2fdf5-2cff-4c27-875f-450cc382fe8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c2fdf5-2cff-4c27-875f-450cc382fe8c.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "37eba0cc-2e11-5d9d-96a3-0b60bbf18aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b712e6e-eb48-4a71-b95d-ce343966b236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b712e6e-eb48-4a71-b95d-ce343966b236.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5822,7 +5822,7 @@
         },
         {
             "id": "c4e338d2-e574-5db7-9db2-9ca14cf947e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678c71b-585b-41ba-a038-8027f818e839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678c71b-585b-41ba-a038-8027f818e839.jpg?1",
             "name": "Invigorate",
             "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "8036298f-c426-53d8-ab1b-318f911e9e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c05f3bf-5785-4a53-9c34-cffd7783d107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c05f3bf-5785-4a53-9c34-cffd7783d107.jpg?1",
             "name": "Iwamori of the Open Fist",
             "text": "Trample\nWhen Iwamori of the Open Fist enters the battlefield, each opponent may put a legendary creature card from his or her hand onto the battlefield.",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "45184045-287d-5d61-bf06-3a45fff5f02f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da95f41d-ad5a-4861-94e2-a564dbf4f3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da95f41d-ad5a-4861-94e2-a564dbf4f3c9.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber enters the battlefield, draw a card.",
             "colours": [
@@ -5925,7 +5925,7 @@
         },
         {
             "id": "3e99907a-55c3-505c-b661-6b4be77f0c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8728ed5-02cc-4094-9278-48d22f9568dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8728ed5-02cc-4094-9278-48d22f9568dc.jpg?1",
             "name": "Kavu Predator",
             "text": "Trample\nWhenever an opponent gains life, put that many +1/+1 counters on Kavu Predator.",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "e8b4c834-0f37-5086-996f-33c4a9c26e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f41b01b-0c19-4f3f-93e5-d3df52fdd576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f41b01b-0c19-4f3f-93e5-d3df52fdd576.jpg?1",
             "name": "Krosan Colossus",
             "text": "Morph {6}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5993,7 +5993,7 @@
         },
         {
             "id": "fb984c2b-8c80-5703-8d31-cb49e0e69c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ab2ac7-f6bd-4f47-8bd4-128bf64f8768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ab2ac7-f6bd-4f47-8bd4-128bf64f8768.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle your library. (Do this before you draw.)",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "389a541e-237e-5211-bb02-e39b28198d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d505d319-093d-47af-8ee9-fafae3885aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d505d319-093d-47af-8ee9-fafae3885aa0.jpg?1",
             "name": "Living Wish",
             "text": "You may choose a creature or land card you own from outside the game, reveal that card, and put it into your hand. Exile Living Wish.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "0a52d36c-b2b7-5394-b82f-ef646aaff8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb38b2-3eba-4b2e-b5d8-58e9ad799d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb38b2-3eba-4b2e-b5d8-58e9ad799d1f.jpg?1",
             "name": "Lull",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "fc012bfd-64de-542a-999a-2a1ab163c1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c56fda1-d286-46b1-9617-4f7c430abb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c56fda1-d286-46b1-9617-4f7c430abb79.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "At the beginning of your upkeep, create a 2/2 green Wolf creature token.\n{T}: Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves.",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "80242932-23d6-557a-809b-db244a38705d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f290ed2-d1a8-4a90-a3a7-8240652dc109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f290ed2-d1a8-4a90-a3a7-8240652dc109.jpg?1",
             "name": "Nettle Sentinel",
             "text": "Nettle Sentinel doesn't untap during your untap step.\nWhenever you cast a green spell, you may untap Nettle Sentinel.",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "562f9059-38f3-56ab-bc2c-c43797dd7ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8abe42-32c2-41c5-b2ea-f1fb51fc5629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8abe42-32c2-41c5-b2ea-f1fb51fc5629.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "658df6d5-3752-5dd7-a26c-baf5e0491c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922cf7de-3c37-4f4d-ae1a-7a14234a6dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922cf7de-3c37-4f4d-ae1a-7a14234a6dab.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Create a 1/1 green Elf Warrior creature token.\"",
             "colours": [
@@ -6228,7 +6228,7 @@
         },
         {
             "id": "1682dd99-ad66-5481-9a87-94f4a1548d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f0c4714-b9cd-48a3-8a2a-72860d0ac000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f0c4714-b9cd-48a3-8a2a-72860d0ac000.jpg?1",
             "name": "Protean Hulk",
             "text": "When Protean Hulk dies, search your library for any number of creature cards with total converted mana cost 6 or less and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "6b7347b3-a8a5-5039-9609-08e1882eb912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4d8527-af29-408d-a3a3-6781db0cf439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4d8527-af29-408d-a3a3-6781db0cf439.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -6296,7 +6296,7 @@
         },
         {
             "id": "8455a8aa-ee01-5f1e-9a81-760ed8d0a445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb187bce-54fe-4adb-bf67-ad588d38ee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb187bce-54fe-4adb-bf67-ad588d38ee66.jpg?1",
             "name": "Regrowth",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "0f0d2d5d-8bd0-5ca7-aeba-5b63f7b8aa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35390394-013f-4996-9d1a-e4c53de941ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35390394-013f-4996-9d1a-e4c53de941ba.jpg?1",
             "name": "Stampede Driver",
             "text": "{1}{G}, {T}, Discard a card: Creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -6363,7 +6363,7 @@
         },
         {
             "id": "f0539351-4d80-550f-ba7d-f5585ef587e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4550b26a-3a73-4724-99d5-1e0a52c36701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4550b26a-3a73-4724-99d5-1e0a52c36701.jpg?1",
             "name": "Summoner's Pact",
             "text": "Search your library for a green creature card, reveal it, put it into your hand, then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "eb987b52-cfc8-5eff-bdf2-476453d36dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3d1b54-ceef-425d-a349-80a49ac5d879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3d1b54-ceef-425d-a349-80a49ac5d879.jpg?1",
             "name": "Timberpack Wolf",
             "text": "Timberpack Wolf gets +1/+1 for each other creature you control named Timberpack Wolf.",
             "colours": [
@@ -6429,7 +6429,7 @@
         },
         {
             "id": "106d8207-2525-5cf5-b57e-8167ae21ccb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39cc3c8-79c2-4593-8340-c3285f3a4c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39cc3c8-79c2-4593-8340-c3285f3a4c3a.jpg?1",
             "name": "Tree of Redemption",
             "text": "Defender\n{T}: Exchange your life total with Tree of Redemption's toughness.",
             "colours": [
@@ -6463,7 +6463,7 @@
         },
         {
             "id": "c243f49e-ea0d-5764-b4ec-d09761e1a435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625580-3cbd-459c-a667-87efdcdaf2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625580-3cbd-459c-a667-87efdcdaf2b2.jpg?1",
             "name": "Utopia Sprawl",
             "text": "Enchant Forest\nAs Utopia Sprawl enters the battlefield, choose a color.\nWhenever enchanted Forest is tapped for mana, its controller adds one mana of the chosen color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -6497,7 +6497,7 @@
         },
         {
             "id": "d0f3a062-b4fb-589d-a757-9ba050605b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d502ecf-b3a5-4657-8718-104e8f0ab9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d502ecf-b3a5-4657-8718-104e8f0ab9af.jpg?1",
             "name": "Vessel of Nascency",
             "text": "{1}{G}, Sacrifice Vessel of Nascency: Reveal the top four cards of your library. You may put an artifact, creature, enchantment, land, or planeswalker card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "ed96a192-54f2-5303-bdfc-d32669fac8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07e9ea5-0e50-4efc-a294-06aedc19de65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07e9ea5-0e50-4efc-a294-06aedc19de65.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "59fd94b5-aea6-5ad7-97f2-698caf224b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ea1434-16c4-4b1a-8728-806360131587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ea1434-16c4-4b1a-8728-806360131587.jpg?1",
             "name": "Woolly Loxodon",
             "text": "Morph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6599,7 +6599,7 @@
         },
         {
             "id": "e6bfbfbd-9bc9-5788-9211-37a4e9c6bcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df98d4a-0f11-4064-a113-54ab14b9b3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df98d4a-0f11-4064-a113-54ab14b9b3eb.jpg?1",
             "name": "Animar, Soul of Elements",
             "text": "Protection from white and from black\nWhenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.\nCreature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "c71772e7-0497-5336-b8db-7a0b9c3b74c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100855e6-ac3e-481f-a462-afb5fcb5d476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100855e6-ac3e-481f-a462-afb5fcb5d476.jpg?1",
             "name": "Baloth Null",
             "text": "When Baloth Null enters the battlefield, return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -6676,7 +6676,7 @@
         },
         {
             "id": "6dc51b0d-c353-58f4-a817-29ab30f1bb58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf0f075-4401-41da-a17f-a209d6a03782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf0f075-4401-41da-a17f-a209d6a03782.jpg?1",
             "name": "Blightning",
             "text": "Blightning deals 3 damage to target player. That player discards two cards.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "1d3895f6-fc93-5387-825e-ad75a1d761d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e601a7-c542-4843-98c6-e0a38aaf6cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e601a7-c542-4843-98c6-e0a38aaf6cab.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014\n\u2022 Boros Charm deals 4 damage to target player.\n\u2022 Permanents you control gain indestructible until end of turn.\n\u2022 Target creature gains double strike until end of turn.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "eb4d3494-4399-539d-8aac-7ec38ad9e4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b097c70a-d1d6-4972-b94d-d7d8a6f443e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b097c70a-d1d6-4972-b94d-d7d8a6f443e2.jpg?1",
             "name": "Brion Stoutarm",
             "text": "Lifelink\n{R}, {T}, Sacrifice another creature: Brion Stoutarm deals damage equal to the sacrificed creature's power to target player.",
             "colours": [
@@ -6783,7 +6783,7 @@
         },
         {
             "id": "ec92d49c-7afa-5f7d-844a-7cc8e5056f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00b58c-785d-481d-9c8a-f329672a117f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00b58c-785d-481d-9c8a-f329672a117f.jpg?1",
             "name": "Cloudblazer",
             "text": "Flying\nWhen Cloudblazer enters the battlefield, you gain 2 life and draw two cards.",
             "colours": [
@@ -6820,7 +6820,7 @@
         },
         {
             "id": "414bfe34-a7e1-5de8-bc80-b50bce222149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83777ac9-93d9-4097-96ca-a8a6a79b84e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83777ac9-93d9-4097-96ca-a8a6a79b84e2.jpg?1",
             "name": "Conflux",
             "text": "Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "3b8e99e7-d8b7-5277-b7be-061c749ea188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42936b12-df0c-4332-a91f-2da2acc36dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42936b12-df0c-4332-a91f-2da2acc36dd7.jpg?1",
             "name": "Eladamri's Call",
             "text": "Search your library for a creature card, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "2ca198e7-8ea4-50ee-81c3-bdf170514d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d039ff5-907f-4c27-8941-83e5e75bd19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d039ff5-907f-4c27-8941-83e5e75bd19d.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "0d1ebaf1-3f77-5d10-876b-a3ba4b133f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19c383-88bd-4bde-ac81-c0eb6d5b5bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19c383-88bd-4bde-ac81-c0eb6d5b5bd4.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "Grenzo, Dungeon Warden enters the battlefield with X +1/+1 counters on it.\n{2}: Put the bottom card of your library into your graveyard. If it's a creature card with power less than or equal to Grenzo's power, put it onto the battlefield.",
             "colours": [
@@ -6971,7 +6971,7 @@
         },
         {
             "id": "c9763078-d9e8-5f38-870b-0a549a1858a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed9d83-cbf4-4ebe-af20-915752233fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed9d83-cbf4-4ebe-af20-915752233fc9.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -7010,7 +7010,7 @@
         },
         {
             "id": "54ee3de4-6488-577c-8853-cfe481f645c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae50a9a-1589-43fe-87a6-7b2c96745392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae50a9a-1589-43fe-87a6-7b2c96745392.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, you may put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -7046,7 +7046,7 @@
         },
         {
             "id": "87170beb-2a6d-56c6-b709-c2dcbd5e095e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4bacd1-b602-4bcc-9aea-1229949a7d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4bacd1-b602-4bcc-9aea-1229949a7d20.jpg?1",
             "name": "Mystic Snake",
             "text": "Flash\nWhen Mystic Snake enters the battlefield, counter target spell.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "2503411e-e8c0-509a-8284-98c62025dd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e92ba96-372c-418d-b271-45e1bf5c7af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e92ba96-372c-418d-b271-45e1bf5c7af5.jpg?1",
             "name": "Nicol Bolas",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Nicol Bolas unless you pay {U}{B}{R}.\nWhenever Nicol Bolas deals damage to an opponent, that player discards his or her hand.",
             "colours": [
@@ -7123,7 +7123,7 @@
         },
         {
             "id": "a52083a9-ae15-5c54-8fbd-7d63534fb5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029dd036-abda-4b5d-806d-8b39357edf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029dd036-abda-4b5d-806d-8b39357edf1e.jpg?1",
             "name": "Niv-Mizzet, the Firemind",
             "text": "Flying\nWhenever you draw a card, Niv-Mizzet, the Firemind deals 1 damage to target creature or player.\n{T}: Draw a card.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "71206f12-a91a-5bb3-89c7-c38aa94b181f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be530d89-6735-4bd3-9369-22432fe6affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be530d89-6735-4bd3-9369-22432fe6affb.jpg?1",
             "name": "Notion Thief",
             "text": "Flash\nIf an opponent would draw a card except the first one he or she draws in each of his or her draw steps, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -7199,7 +7199,7 @@
         },
         {
             "id": "7dff1d33-6976-5edc-91ca-2c3acfe6bbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8652e3a1-bcd4-4c0c-a085-34f19702df26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8652e3a1-bcd4-4c0c-a085-34f19702df26.jpg?1",
             "name": "Pernicious Deed",
             "text": "{X}, Sacrifice Pernicious Deed: Destroy each artifact, creature, and enchantment with converted mana cost X or less.",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "f35a62b2-1353-5a76-8df3-03ce995bbac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc97379-91aa-4bba-80af-8980eeb57630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc97379-91aa-4bba-80af-8980eeb57630.jpg?1",
             "name": "Pillory of the Sleepless",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"At the beginning of your upkeep, you lose 1 life.\"",
             "colours": [
@@ -7269,7 +7269,7 @@
         },
         {
             "id": "cee2f9b2-9147-52ab-bb64-86320112d376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889c1a0f-7df2-4497-8058-04358173d7e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889c1a0f-7df2-4497-8058-04358173d7e8.jpg?1",
             "name": "Prossh, Skyraider of Kher",
             "text": "Flying\nWhen you cast Prossh, Skyraider of Kher, create X 0/1 red Kobold creature tokens named Kobolds of Kher Keep, where X is the amount of mana spent to cast Prossh.\nSacrifice another creature: Prossh gets +1/+0 until end of turn.",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "251f3da8-48cf-55fd-9e08-ff3b8d95b19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a376f7a3-50fa-4be9-830c-102507682256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a376f7a3-50fa-4be9-830c-102507682256.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target player. You draw a card.\"",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "e19795b0-d09f-56f6-8109-6d1d9e22be3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59221f7c-c950-4d66-b166-a2d8f8d0e959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59221f7c-c950-4d66-b166-a2d8f8d0e959.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each combat if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "a0bfbb71-a550-5f4f-b842-21ccfeec7e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31120987-4b68-4d0e-917f-b8f2ca050090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31120987-4b68-4d0e-917f-b8f2ca050090.jpg?1",
             "name": "Shadowmage Infiltrator",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever Shadowmage Infiltrator deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -7421,7 +7421,7 @@
         },
         {
             "id": "6921cc3f-3cb8-511d-9625-e518701cac8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23f846e-b5e6-48c2-afea-c9be7fc8b7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23f846e-b5e6-48c2-afea-c9be7fc8b7c3.jpg?1",
             "name": "Stangg",
             "text": "When Stangg enters the battlefield, create a legendary 3/4 red and green Human Warrior creature token named Stangg Twin. Exile that token when Stangg leaves the battlefield. Sacrifice Stangg when that token leaves the battlefield.",
             "colours": [
@@ -7460,7 +7460,7 @@
         },
         {
             "id": "68b9188b-fddb-544d-976a-50d8398ae747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1658f12b-8ac5-4d29-86d5-f20c4d5f7e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1658f12b-8ac5-4d29-86d5-f20c4d5f7e48.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "9c69ff74-cf17-51d7-99c2-5217808578c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682af5e9-26b5-4f88-99e1-ab2aa34fba86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682af5e9-26b5-4f88-99e1-ab2aa34fba86.jpg?1",
             "name": "Watchwolf",
             "text": "",
             "colours": [
@@ -7530,7 +7530,7 @@
         },
         {
             "id": "dd08f688-a559-55b6-87b3-07220b2b20b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a288d2-de94-4c49-a17e-5b0ed0281a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a288d2-de94-4c49-a17e-5b0ed0281a5b.jpg?1",
             "name": "Assembly-Worker",
             "text": "{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -7561,7 +7561,7 @@
         },
         {
             "id": "3298e1e3-7d8a-5766-b796-59f04b9a7ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0d2e8e-c8f2-4b31-a6ba-6283fc8740d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0d2e8e-c8f2-4b31-a6ba-6283fc8740d4.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "544a848c-9f66-562d-bc77-966931a5cd2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c532e8-21f1-4d6f-a931-1ea48a6aeea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c532e8-21f1-4d6f-a931-1ea48a6aeea2.jpg?1",
             "name": "Coalition Relic",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color to your mana pool for each charge counter removed this way.",
             "colours": [],
@@ -7617,7 +7617,7 @@
         },
         {
             "id": "c8db9cf7-4609-5f66-b3a2-47a3641e06ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8dc8a5-3b53-4860-af60-6386e8c0010f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8dc8a5-3b53-4860-af60-6386e8c0010f.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Creatures with power greater than the number of cards in your hand can't attack.",
             "colours": [],
@@ -7645,7 +7645,7 @@
         },
         {
             "id": "04fc8717-0437-5eba-b6c0-7397c7b0e6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813fae24-ff38-45e8-8ab9-d539d4494435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813fae24-ff38-45e8-8ab9-d539d4494435.jpg?1",
             "name": "Heavy Arbalest",
             "text": "Equipped creature doesn't untap during its controller's untap step.\nEquipped creature has \"{T}: This creature deals 2 damage to target creature or player.\"\nEquip {4}",
             "colours": [],
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "cc7dafec-5283-59d7-a59f-ca33644f8246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5892a23-efae-4731-9b8f-41c87960fe93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5892a23-efae-4731-9b8f-41c87960fe93.jpg?1",
             "name": "Nihil Spellbomb",
             "text": "{T}, Sacrifice Nihil Spellbomb: Exile all cards from target player's graveyard.\nWhen Nihil Spellbomb is put into a graveyard from the battlefield, you may pay {B}. If you do, draw a card.",
             "colours": [],
@@ -7705,7 +7705,7 @@
         },
         {
             "id": "2352dea9-08dd-5e16-915e-439febcfd0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33823e16-810e-4138-950b-e18ef1204438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33823e16-810e-4138-950b-e18ef1204438.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr dies, it deals 2 damage to target creature or player.",
             "colours": [],
@@ -7737,7 +7737,7 @@
         },
         {
             "id": "8a9fe3b3-6f4a-5a34-ad58-e616d6fdb5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e51f1b3-d8a3-4746-b0db-67d5ec71fb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e51f1b3-d8a3-4746-b0db-67d5ec71fb17.jpg?1",
             "name": "Primal Clay",
             "text": "As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types.",
             "colours": [],
@@ -7768,7 +7768,7 @@
         },
         {
             "id": "a9f1d857-71aa-506f-a1e2-d615910a11be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecd6741-bab2-4921-b961-ea1584213558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecd6741-bab2-4921-b961-ea1584213558.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "6a25cce1-658c-5d71-ab3e-752e20109ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77812f-fe6c-4d26-9c34-c51cb05fd43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77812f-fe6c-4d26-9c34-c51cb05fd43a.jpg?1",
             "name": "Sai of the Shinobi",
             "text": "Equipped creature gets +1/+1.\nWhenever a creature enters the battlefield under your control, you may attach Sai of the Shinobi to it.\nEquip {2}",
             "colours": [],
@@ -7826,7 +7826,7 @@
         },
         {
             "id": "8a68e614-cdf5-589f-b010-dea4e25d6c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86ba613-29bd-45d8-b5ed-f8fe8323fe75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86ba613-29bd-45d8-b5ed-f8fe8323fe75.jpg?1",
             "name": "Self-Assembler",
             "text": "When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "7ebf6a23-8aa7-5a6e-b89c-2cf71f498749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccbd2c4-ffe0-4992-88d9-5be1adb3bda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccbd2c4-ffe0-4992-88d9-5be1adb3bda6.jpg?1",
             "name": "Strionic Resonator",
             "text": "{2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy.",
             "colours": [],
@@ -7885,7 +7885,7 @@
         },
         {
             "id": "b2fad72d-f89f-5cf7-b2b5-bf9030361e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0263c742-345b-4425-8326-75bfa60e08ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0263c742-345b-4425-8326-75bfa60e08ea.jpg?1",
             "name": "Sundering Titan",
             "text": "When Sundering Titan enters the battlefield or leaves the battlefield, choose a land of each basic land type, then destroy those lands.",
             "colours": [],
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "dd9a53c1-0f4a-5bd6-8e75-7741d7189d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae09e17-b881-492c-ba47-8f381c09755d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae09e17-b881-492c-ba47-8f381c09755d.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "b56e76b5-780c-5fbb-99ca-365e537ac432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fca48f-790e-4293-b456-84f36ca95924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fca48f-790e-4293-b456-84f36ca95924.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with converted mana cost 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -7977,7 +7977,7 @@
         },
         {
             "id": "6808b404-501f-5ea9-8927-0a73f3fd7993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f20e43-55f9-46a2-bee2-46a747584d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f20e43-55f9-46a2-bee2-46a747584d75.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C} to your mana pool.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [],
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "3fd09e7e-e707-52b5-82e7-75d763e37211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bd7f43-a0ed-4601-a6d8-f87e7bbd269d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bd7f43-a0ed-4601-a6d8-f87e7bbd269d.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {C} to your mana pool.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "ea3d087f-91e0-5538-935f-1785da6b5acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0547b3a-dc3e-42ba-bb80-1815ee62e9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0547b3a-dc3e-42ba-bb80-1815ee62e9f1.jpg?1",
             "name": "Fetid Heath",
             "text": "{T}: Add {C} to your mana pool.\n{WB}, {T}: Add {W}{W}, {W}{B}, or {B}{B} to your mana pool.",
             "colours": [],
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "a4653182-0d79-5bee-8e4a-17e3c00244b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9272917e-3ccd-4494-9e3f-91bc86b784d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9272917e-3ccd-4494-9e3f-91bc86b784d5.jpg?1",
             "name": "Flooded Grove",
             "text": "{T}: Add {C} to your mana pool.\n{GW}, {T}: Add {G}{G}, {G}{U}, or {U}{U} to your mana pool.",
             "colours": [],
@@ -8098,7 +8098,7 @@
         },
         {
             "id": "b12f74e7-f609-591c-9609-278cad688635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ef3b0-5b73-4bf2-bbae-0e419bd498c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ef3b0-5b73-4bf2-bbae-0e419bd498c9.jpg?1",
             "name": "Haunted Fengraf",
             "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
             "colours": [],
@@ -8126,7 +8126,7 @@
         },
         {
             "id": "c718ff20-21bf-5a9d-864e-807052d26a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7033a4c-a2de-45d0-a6a6-1db028baf40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7033a4c-a2de-45d0-a6a6-1db028baf40b.jpg?1",
             "name": "Mikokoro, Center of the Sea",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Each player draws a card.",
             "colours": [],
@@ -8156,7 +8156,7 @@
         },
         {
             "id": "bde5bcc7-7736-50c7-930b-63e050a09ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245cdc59-d560-4c10-b721-f51cc312e370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245cdc59-d560-4c10-b721-f51cc312e370.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -8184,7 +8184,7 @@
         },
         {
             "id": "9b09beac-2f0b-5200-b14e-72464b8c9184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f364d5-8257-4d5e-9ed9-d363a7fdaf16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f364d5-8257-4d5e-9ed9-d363a7fdaf16.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8212,7 +8212,7 @@
         },
         {
             "id": "7017e055-26da-508d-888f-40f6fc251cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf85879-4d14-4d86-978c-b155c47b7dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf85879-4d14-4d86-978c-b155c47b7dcd.jpg?1",
             "name": "Pendelhaven",
             "text": "{T}: Add {G} to your mana pool.\n{T}: Target 1/1 creature gets +1/+2 until end of turn.",
             "colours": [],
@@ -8244,7 +8244,7 @@
         },
         {
             "id": "07d64f06-e936-5609-891d-87b970f09c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce833a90-7c1d-4c05-ace3-57e974c0769b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce833a90-7c1d-4c05-ace3-57e974c0769b.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -8272,7 +8272,7 @@
         },
         {
             "id": "69b87a87-3cbf-5fa9-abe9-6438a59d4954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2507bc2-da17-4e46-b4c5-ba0080ce2c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2507bc2-da17-4e46-b4c5-ba0080ce2c6f.jpg?1",
             "name": "Rishadan Port",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Tap target land.",
             "colours": [],
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "e686fb05-d412-513e-8e78-164533aaa22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ccc48-879b-4ff0-81ed-66aa2843d286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47ccc48-879b-4ff0-81ed-66aa2843d286.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {C} to your mana pool.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W} to your mana pool.",
             "colours": [],
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "e34ca8d2-5902-55be-af49-5c09dca7e346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f7d8f4-0452-4163-960c-499ce07933eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f7d8f4-0452-4163-960c-499ce07933eb.jpg?1",
             "name": "Twilight Mire",
             "text": "{T}: Add {C} to your mana pool.\n{BG}, {T}: Add {B}{B}, {B}{G}, or {G}{G} to your mana pool.",
             "colours": [],
@@ -8362,7 +8362,7 @@
         },
         {
             "id": "9f2e22bb-3613-523b-9256-09355ad48722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16964263-61fc-40f2-b206-4f69060affba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16964263-61fc-40f2-b206-4f69060affba.jpg?1",
             "name": "Zoetic Cavern",
             "text": "{T}: Add {C} to your mana pool.\nMorph {2} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "32016ad6-ef16-52de-854b-17f428fcaecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef264a95-afe4-4b8c-9648-e8f95bfaed2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef264a95-afe4-4b8c-9648-e8f95bfaed2a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -8420,7 +8420,7 @@
         },
         {
             "id": "a7aa4057-37c7-5ade-8897-7d6a2cffbef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1671013a-2c15-44f0-b4bc-057eb5f727db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1671013a-2c15-44f0-b4bc-057eb5f727db.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8454,7 +8454,7 @@
         },
         {
             "id": "35a7681e-d9c9-5147-bde8-e7353bf31a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227a4e23-ff87-486b-aba1-32f1d8c33592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227a4e23-ff87-486b-aba1-32f1d8c33592.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8488,7 +8488,7 @@
         },
         {
             "id": "55748f9d-28c4-5f68-8f42-8a7f8ad3381a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070b2ce3-33a7-42a5-b4c2-6b0ed2bf926a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070b2ce3-33a7-42a5-b4c2-6b0ed2bf926a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8522,7 +8522,7 @@
         },
         {
             "id": "aa821c4e-0561-5ad5-a9b3-c326a3bfcbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9badcaa0-8abb-4654-b947-b5ff254a8d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9badcaa0-8abb-4654-b947-b5ff254a8d19.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "dc740497-2711-5203-b204-272381eae905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg?1",
             "name": "Fish // Kraken",
             "text": "",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "5aac3b9e-2b4f-577d-8cac-47dcfbf2aa3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce300b8-ab50-4c96-ba05-30701a249230.jpg?1",
             "name": "Fish // Kraken",
             "text": "",
             "colours": [
@@ -8624,7 +8624,7 @@
         },
         {
             "id": "87734902-9648-5791-873f-5c366c38aef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622397a1-6513-44b9-928a-388be06d4022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622397a1-6513-44b9-928a-388be06d4022.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "f08192e3-745c-5f8c-91c5-7da8649604af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3331a0-5840-439d-9553-d4489c343f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3331a0-5840-439d-9553-d4489c343f21.jpg?1",
             "name": "Whale",
             "text": "",
             "colours": [
@@ -8692,7 +8692,7 @@
         },
         {
             "id": "fbda3073-ceef-5d65-8622-e2185199b506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb1ab0-f8f4-44e8-b8a7-df37a8782e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abb1ab0-f8f4-44e8-b8a7-df37a8782e76.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -8726,7 +8726,7 @@
         },
         {
             "id": "0b453fff-0b78-54f9-894c-d7c1398dc3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7913ab41-f5d1-43d3-85e3-451befc97753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7913ab41-f5d1-43d3-85e3-451befc97753.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8760,7 +8760,7 @@
         },
         {
             "id": "ce3f64ac-f4d1-5c1e-bda1-bcb0bcf376d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc03591-1114-4e36-a397-0bb3db8a153c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc03591-1114-4e36-a397-0bb3db8a153c.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -8794,7 +8794,7 @@
         },
         {
             "id": "cbb556b6-7460-520e-ae74-94492cb0646d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ed4bf-b276-45ed-b44d-c757e9c25846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ed4bf-b276-45ed-b44d-c757e9c25846.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -8829,7 +8829,7 @@
         },
         {
             "id": "0a6d2b2d-3dc9-5175-9e18-dbf1463d8124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d7c6dc-4d0b-4a05-8b79-5dd728a74bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d7c6dc-4d0b-4a05-8b79-5dd728a74bb3.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8863,7 +8863,7 @@
         },
         {
             "id": "0fda6a57-5bf8-5a18-aaca-152041cb86c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff5727c-7001-45db-9e0c-771824e849b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff5727c-7001-45db-9e0c-771824e849b0.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8897,7 +8897,7 @@
         },
         {
             "id": "382fab3e-a008-5648-a93c-23591b97da58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba90d37-d7ac-4097-a04d-1f27e4c9e5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba90d37-d7ac-4097-a04d-1f27e4c9e5de.jpg?1",
             "name": "Stangg Twin",
             "text": "",
             "colours": [
@@ -8936,7 +8936,7 @@
         },
         {
             "id": "0d854bcb-6335-5040-a1e6-3f19a590a625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0b42a0-5e08-406d-82b0-be5f72870c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0b42a0-5e08-406d-82b0-be5f72870c47.jpg?1",
             "name": "Morph",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ACR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ACR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d1c00a42-14a5-5480-a704-b1c457f177db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1b63ce-47d3-4633-9062-3fecd810e85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1b63ce-47d3-4633-9062-3fecd810e85f.jpg?1",
             "name": "The Capitoline Triad",
             "text": "Those Who Came Before \u2014 This spell costs {1} less to cast for each historic card in your graveyard. (Artifacts, legendaries, and Sagas are historic.)\nExile any number of historic cards from your graveyard with total mana value 30 or greater: You get an emblem with \"Creatures you control have base power and toughness 9/9.\"",
             "colours": [],
@@ -40,7 +40,7 @@
         },
         {
             "id": "c74344f2-826e-58de-8f98-b27a5937bd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60f18e-4709-4b91-a342-74eb3fca71e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60f18e-4709-4b91-a342-74eb3fca71e1.jpg?1",
             "name": "Caduceus, Staff of Hermes",
             "text": "Equipped creature has lifelink.\nAs long as you have 30 or more life, equipped creature gets +5/+5 and has indestructible and \"Prevent all damage that would be dealt to this creature.\"\nEquip {W}{W}",
             "colours": [
@@ -79,7 +79,7 @@
         },
         {
             "id": "842a0043-af21-5929-bf42-b3421c7e4426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5554433e-0dee-4960-a58c-c4a24e01a989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5554433e-0dee-4960-a58c-c4a24e01a989.jpg?1",
             "name": "Distract the Guards",
             "text": "Freerunning {1}{W} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nCreate three 1/1 white Human Rogue creature tokens.",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "3a46c2ac-08cb-53e2-be70-de41ad59e799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a8c84b-7d6c-4068-97b1-bc5dec46732c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a8c84b-7d6c-4068-97b1-bc5dec46732c.jpg?1",
             "name": "Fall of the First Civilization",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You and target opponent each draw two cards.\nII \u2014 Exile target artifact an opponent controls.\nIII \u2014 Each player chooses three nonland permanents they control. Destroy all other nonland permanents.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "fef6159b-39a0-5ed6-b3af-1c84556df9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e791f0-297b-46bf-acd5-f62458009d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e791f0-297b-46bf-acd5-f62458009d76.jpg?1",
             "name": "Haystack",
             "text": "{2}, {T}: Target creature you control phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "b9fc31c7-eb8c-599c-877d-3a478bbd53b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17eca56-f658-410f-b505-8cbc87d4f253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17eca56-f658-410f-b505-8cbc87d4f253.jpg?1",
             "name": "Hookblade",
             "text": "When Hookblade enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0.\nAs long as it's your turn, equipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "34de6edc-e1f6-5ec2-bc79-388d0125984c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2278d97e-791a-4843-a385-65bac79bde7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2278d97e-791a-4843-a385-65bac79bde7a.jpg?1",
             "name": "Layla Hassan",
             "text": "First strike\nWhen Layla Hassan enters the battlefield and whenever one or more Assassins you control deal combat damage to a player, return target historic card from your graveyard to your hand.",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "eeadf819-cd5b-5a33-8749-4e6cea87618c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671a03d-0858-41e7-976c-60825c29af04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671a03d-0858-41e7-976c-60825c29af04.jpg?1",
             "name": "Senu, Keen-Eyed Protector",
             "text": "Flying, vigilance\n{T}, Exile Senu, Keen-Eyed Protector: You gain 2 life and scry 2.\nWhen a legendary creature you control attacks and isn't blocked, if Senu is exiled, put it onto the battlefield attacking.",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "7d2389a4-0528-51f8-abfd-18c217b9831d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300b5af-9223-4e97-9d33-a9226bd900f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300b5af-9223-4e97-9d33-a9226bd900f3.jpg?1",
             "name": "Tax Collector",
             "text": "When Tax Collector enters the battlefield, choose one \u2014\n\u2022 Tax \u2014 Until your next turn, spells your opponents cast cost {1} more to cast.\n\u2022 Arrest \u2014 Detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "418e44c5-e8be-5043-9029-3ebe63aba585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a1bec-9128-4c5e-98c3-317424f892d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a1bec-9128-4c5e-98c3-317424f892d1.jpg?1",
             "name": "Templar Knight",
             "text": "Vigilance\n{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Templar Knight.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "0aeb8e51-4fc9-5043-b2f3-12aed233eca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe034544-e13f-45fc-ae43-83d0f399ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe034544-e13f-45fc-ae43-83d0f399ed33.jpg?1",
             "name": "What Must Be Done",
             "text": "Choose one \u2014\n\u2022 Let the World Burn \u2014 Destroy all artifacts and creatures.\n\u2022 Release Juno \u2014 Return target historic permanent card from your graveyard to the battlefield. It enters with two additional +1/+1 counters on it if it's a creature. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "e56a9799-27a3-592b-a318-491d37f00567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ebdd18-7f07-417c-8f30-470c1f14dfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ebdd18-7f07-417c-8f30-470c1f14dfae.jpg?1",
             "name": "Assassin Gauntlet",
             "text": "When Assassin Gauntlet enters the battlefield, attach it to up to one target creature you control. Tap all creatures target opponent controls.\nEquipped creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, draw a card, then discard a card.\"\nEquip {2}",
             "colours": [
@@ -442,7 +442,7 @@
         },
         {
             "id": "04e18c9d-660a-533a-b7fc-2a91fdcb91ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6b1b2f-903c-438c-baba-a3b3e60b1d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6b1b2f-903c-438c-baba-a3b3e60b1d4f.jpg?1",
             "name": "Ballad of the Black Flag",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Mill three cards. You may put a historic card from among them into your hand. (Artifacts, legendaries, and Sagas are historic.)\nIV \u2014 Historic spells you cast this turn cost {2} less to cast.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "22b7a077-12c6-5a72-99de-5f6547730d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321777f-399b-4f80-9baf-da6a0aaa325a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321777f-399b-4f80-9baf-da6a0aaa325a.jpg?1",
             "name": "Become Anonymous",
             "text": "Exile target nontoken creature you own and the top two cards of your library in a face-down pile, shuffle that pile, then cloak those cards. They enter the battlefield tapped. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "f8c0d132-cde9-5230-876f-4edcda507553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10fa72b-6742-4b65-8654-ac70b6240e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10fa72b-6742-4b65-8654-ac70b6240e38.jpg?1",
             "name": "Crystal Skull, Isu Spyglass",
             "text": "You may look at the top card of your library any time.\nYou may play historic lands and cast historic spells from the top of your library. (Artifacts, legendaries, and Sagas are historic.)\n{T}: Add {U}.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "f52ce968-e98f-5643-8921-ed28d6d108bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd3561-0143-40b7-81bc-640a978b8b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd3561-0143-40b7-81bc-640a978b8b15.jpg?1",
             "name": "Desynchronization",
             "text": "Return each nonland permanent that's not historic to its owner's hand. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "036fed43-7ffb-5ffe-bb9b-2932e9d8926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5197e8d6-cbfe-4469-95e1-f17eeb4715f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5197e8d6-cbfe-4469-95e1-f17eeb4715f1.jpg?1",
             "name": "Eagle Vision",
             "text": "Freerunning {1}{U} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nDraw three cards.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "37abf786-299c-5094-969c-9aa2bfc2d200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec676a8f-612d-4ef4-a370-6208407a86af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec676a8f-612d-4ef4-a370-6208407a86af.jpg?1",
             "name": "Escape Detection",
             "text": "Freerunning\u2014\nReturn a blue creature you control to its owner's hand. (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "33bd36d5-2089-5acd-8a80-9c3d0db442a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f1ff84-d363-4aa2-b884-e9640cf62537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f1ff84-d363-4aa2-b884-e9640cf62537.jpg?1",
             "name": "Evie Frye",
             "text": "Partner with Jacob Frye (When this creature enters the battlefield, target player may put Jacob into their hand from their library, then shuffle.)\n{1}, {T}: Draw a card, then discard a card. When you discard a creature card this way, target creature you control can't be blocked this turn.",
             "colours": [
@@ -690,7 +690,7 @@
         },
         {
             "id": "642b71eb-8669-5621-9b0a-a09c8d1ebac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d04a5-3639-42de-b940-ffa7e609e527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d04a5-3639-42de-b940-ffa7e609e527.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "{3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.\n{2}{U}, {T}: Draw a card, then discard a card. If the discarded card was an artifact card, exile it from your graveyard. If you do, create a token that's a copy of it, except it's a 0/2 Thopter artifact creature with flying in addition to its other types.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "c2cf66fd-efc4-5a81-812b-49f2f3cf4e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1e598a-840c-4166-88a6-92a8b9958536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1e598a-840c-4166-88a6-92a8b9958536.jpg?1",
             "name": "Loyal Inventor",
             "text": "Vigilance\nWhen Loyal Inventor enters the battlefield, you may search your library for an artifact card, reveal it, then shuffle. Put that card into your hand if you control an Assassin. Otherwise, put that card on top of your library.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "18299f1a-7573-5895-9463-cdb29164e6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4e330-d878-48f3-b9fe-3158d69f2da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4e330-d878-48f3-b9fe-3158d69f2da2.jpg?1",
             "name": "Assassin Initiate",
             "text": "{1}: Assassin Initiate gains your choice of flying, deathtouch, or lifelink until end of turn.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "fe7e007e-6584-5748-bc81-96f0c8ffdf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bcd9c9-5957-48ee-9c12-f659c5fd07d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bcd9c9-5957-48ee-9c12-f659c5fd07d0.jpg?1",
             "name": "Chain Assassination",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nDestroy target creature. If another creature died this turn, draw a card.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "08d90b17-1130-5861-b18a-d5e5b9dd001f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9523cd1-c3cf-4745-af09-77c1a83ac86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9523cd1-c3cf-4745-af09-77c1a83ac86f.jpg?1",
             "name": "Desmond Miles",
             "text": "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "044e7db1-a470-5c5d-812c-5ebfdfacb1b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae9ee75-30b8-4e24-af8b-031c816d3221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae9ee75-30b8-4e24-af8b-031c816d3221.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}. (You may cast a spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "12f63700-5bee-5e2a-b790-f086c066eb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea6cde3-a4e6-4052-aca3-4d209be15db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea6cde3-a4e6-4052-aca3-4d209be15db3.jpg?1",
             "name": "Hemlock Vial",
             "text": "When Hemlock Vial enters the battlefield, you draw a card and you lose 1 life.\n{B}, {T}, Sacrifice Hemlock Vial: Each equipped creature and Equipment you control gains deathtouch until end of turn.",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "ba1c2c64-3f12-5312-93a2-b8782a2e298d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23422e75-e1c7-484b-aa1f-155ef9a998ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23422e75-e1c7-484b-aa1f-155ef9a998ec.jpg?1",
             "name": "Jacob Frye",
             "text": "Partner with Evie Frye (When this creature enters the battlefield, target player may put Evie into their hand from their library, then shuffle.)\nWhenever one or more Assassins you control deal combat damage to a player, exile up to one target Assassin card or card with freerunning from your graveyard. If you do, copy it. You may cast the copy.",
             "colours": [
@@ -999,7 +999,7 @@
         },
         {
             "id": "5e25eeda-84fc-5ead-8ffb-fa436b25f5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45abc0a4-ae33-470f-9a39-2dd776dd6adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45abc0a4-ae33-470f-9a39-2dd776dd6adb.jpg?1",
             "name": "Petty Larceny",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nLook at the top two cards of target opponent's library and exile those cards face down. You may play those cards for as long as they remain exiled, and mana of any type can be spent to cast them. Create a Treasure token.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "c3aa1b31-ed33-5aa1-9aa3-913cb14f61ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5ec61b-5393-422b-b021-46b80bb42ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5ec61b-5393-422b-b021-46b80bb42ac4.jpg?1",
             "name": "Phantom Blade",
             "text": "When Phantom Blade enters the battlefield, attach it to up to one target creature you control. Destroy up to one other target creature.\nEquipped creature gets +1/+1 and has menace. (It can't be blocked except by two or more creatures.)\nEquip {2}",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "ddebbe77-4556-5a60-8a2e-195d1a5eaea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2b1b20-e5fd-4ccb-8529-12dbde0e0811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2b1b20-e5fd-4ccb-8529-12dbde0e0811.jpg?1",
             "name": "Restart Sequence",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "4266dc7c-2f92-5aa1-9bfb-8cb8f95d137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed77def5-ac92-4907-805d-261cae0db357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed77def5-ac92-4907-805d-261cae0db357.jpg?1",
             "name": "The Revelations of Ezio",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target tapped creature an opponent controls.\nII \u2014 Whenever an Assassin you control attacks this turn, put a +1/+1 counter on it.\nIII \u2014 Return target Assassin creature card from your graveyard to the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "48fd9ee2-f829-520f-b58c-df45d8547a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17e6aa-8be5-40ea-a627-783c478c8eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17e6aa-8be5-40ea-a627-783c478c8eda.jpg?1",
             "name": "Roshan, Hidden Magister",
             "text": "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "f637722b-5640-51de-897d-3b2deda9db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81b94b2-4052-4686-a788-9baf0fa0f81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81b94b2-4052-4686-a788-9baf0fa0f81a.jpg?1",
             "name": "Alexios, Deimos of Kosmos",
             "text": "Trample\nAlexios, Deimos of Kosmos attacks each combat if able, can't be sacrificed, and can't attack its owner.\nAt the beginning of each player's upkeep, that player gains control of Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "43489133-525e-5062-85e2-a346b1e68977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188fe5a-92ac-4c1c-a9a4-2dd5912cc14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188fe5a-92ac-4c1c-a9a4-2dd5912cc14e.jpg?1",
             "name": "Hidden Footblade",
             "text": "Flash\nWhen Hidden Footblade enters the battlefield, attach it to target creature you control. That creature gains first strike until end of turn.\nEquipped creature gets +1/+0 and has haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "811c1125-8a49-523d-89fd-2bb988e47ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2e91f0-3a4e-4388-9460-6756f758316b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2e91f0-3a4e-4388-9460-6756f758316b.jpg?1",
             "name": "Monastery Raid",
             "text": "Freerunning {X}{R} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nExile the top two cards of your library. If this spell's freerunning cost was paid, exile the top X cards of your library instead. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "60d92288-1042-5986-b09a-8bf706446aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da80cd-d0b8-4094-bfe7-28811d655f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14da80cd-d0b8-4094-bfe7-28811d655f8b.jpg?1",
             "name": "Origin of the Hidden Ones",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Origin of the Hidden Ones deals 4 damage to any target.\nII \u2014 Create two 1/1 black Assassin creature tokens with menace.\nIII \u2014 Whenever an Assassin you control attacks this turn, create a 1/1 black Assassin creature token with menace that's tapped and attacking.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "abf8d16c-1600-5ff9-9228-cca6dfd00fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ad338e-88ee-4919-aec4-320071a7cfb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ad338e-88ee-4919-aec4-320071a7cfb5.jpg?1",
             "name": "Overpowering Attack",
             "text": "Freerunning {2}{R} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nUntap all creatures you control that attacked this turn. If it's your main phase, there is an additional combat phase after this phase, followed by an additional main phase.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "635fd929-0d93-5485-9fa0-962cccac7a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d6ce7-2452-41a2-aa70-41e1b8045c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d6ce7-2452-41a2-aa70-41e1b8045c54.jpg?1",
             "name": "The Spear of Leonidas",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Bull Rush \u2014 It gains double strike until end of turn.\n\u2022 Summon \u2014 Create Phobos, a legendary 3/2 red Horse creature token.\n\u2022 Revelation \u2014 Discard two cards, then draw two cards.\nEquip {2}",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "4e1dd242-f3cf-5a4a-b019-63f9a2e65b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbcea0-53ba-444d-b2e0-6d184f945f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efbcea0-53ba-444d-b2e0-6d184f945f92.jpg?1",
             "name": "The Aesir Escape Valhalla",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile a permanent card from your graveyard. You gain life equal to its mana value.\nII \u2014 Put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card.\nIII \u2014 Return The Aesir Escape Valhalla and the exiled card to their owner's hand.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "5701878f-b6a3-59b0-ae35-fc6403194f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3b4f73-e241-4d60-a877-25327092c291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3b4f73-e241-4d60-a877-25327092c291.jpg?1",
             "name": "Aveline de Grandpr\u00e9",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, put that many +1/+1 counters on that creature.\nDisguise {B}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "516bec9e-8423-59ec-b39e-01b1daf375eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2765df-edff-4607-843c-8528d5d4fce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2765df-edff-4607-843c-8528d5d4fce9.jpg?1",
             "name": "Hunter's Bow",
             "text": "When Hunter's Bow enters the battlefield, attach it to target creature you control. That creature deals damage equal to its power to up to one target creature you don't control.\nEquipped creature has reach and ward {2}.\nEquip {1}",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "28dcb5e9-c462-5eab-a81f-5a937745b90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37a14c4-5398-491b-8b37-8c4eeff3054f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37a14c4-5398-491b-8b37-8c4eeff3054f.jpg?1",
             "name": "Palazzo Archers",
             "text": "Reach\nWhenever a creature with flying attacks you or a planeswalker you control, Palazzo Archers deals damage equal to its power to that creature.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "a2a92868-a19e-5af0-bd19-d13a5062e44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f10999-c7c2-462e-bd75-e3710f7a3364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f10999-c7c2-462e-bd75-e3710f7a3364.jpg?1",
             "name": "Viewpoint Synchronization",
             "text": "Freerunning {2}{G} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nSearch your library for up to three basic land cards and reveal them. Put two of them onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "2760a719-9788-5dc5-afae-d7e7cdf24a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914efc24-5c3a-4d22-9d77-fce337a08d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914efc24-5c3a-4d22-9d77-fce337a08d4d.jpg?1",
             "name": "Ad\u00e9wal\u00e9, Breaker of Chains",
             "text": "When Ad\u00e9wal\u00e9 enters the battlefield, reveal the top six cards of your library. Put an Assassin, Pirate, or Vehicle card from among them into your hand and the rest on the bottom of your library in a random order.\nWhenever a Vehicle you control deals combat damage to a player, you may return Ad\u00e9wal\u00e9 from your graveyard to your hand.",
             "colours": [
@@ -1619,7 +1619,7 @@
         },
         {
             "id": "6a29a32b-9446-5f96-be64-b28ee4b1f62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358026de-ab7c-4a17-8cac-cfbee391b127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358026de-ab7c-4a17-8cac-cfbee391b127.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "First strike\nWhenever Alta\u00efr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.",
             "colours": [
@@ -1664,7 +1664,7 @@
         },
         {
             "id": "94913857-2f9e-5ba0-885b-9687b278f036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7187506-4af3-47e9-bad0-4ce8c78ccc10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7187506-4af3-47e9-bad0-4ce8c78ccc10.jpg?1",
             "name": "Arbaaz Mir",
             "text": "Whenever Arbaaz Mir or another nontoken historic permanent enters the battlefield under your control, Arbaaz Mir deals 1 damage to each opponent and you gain 1 life. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "2c24b224-f991-580a-bad8-0a95a1cf1696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41142b10-a493-499a-9fc5-043eeca5d1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41142b10-a493-499a-9fc5-043eeca5d1ee.jpg?1",
             "name": "Arno Dorian",
             "text": "Deathtouch\nOther Assassins you control get +2/+0.\nDisguise {B}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "afb9b6a6-b6c0-56fe-a891-0a6df63efab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd1928-18ec-4f55-acd8-9a62f9869fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd1928-18ec-4f55-acd8-9a62f9869fff.jpg?1",
             "name": "Aya of Alexandria",
             "text": "Menace, lifelink\nWhenever a historic creature you control deals combat damage to a player, create a 1/1 black Assassin creature token with menace. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "79f2af42-ba37-5b3f-9d29-6eb309914b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8aa19c1-4e87-4f42-814c-490e75565f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8aa19c1-4e87-4f42-814c-490e75565f6e.jpg?1",
             "name": "Basim Ibn Ishaq",
             "text": "Whenever you cast a historic spell, draw a card. Basim Ibn Ishaq can't be blocked this turn. This ability triggers only once each turn. (Artifacts, legendaries, and Sagas are historic.)\nWhenever Basim Ibn Ishaq deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "2167b2d3-79e0-5319-8912-d1788184ce0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4510e9-dc3f-4403-ae52-348d2a3eef84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4510e9-dc3f-4403-ae52-348d2a3eef84.jpg?1",
             "name": "Bayek of Siwa",
             "text": "Double strike\nAs long as it's your turn, other historic creatures you control have double strike.\nDisguise {1}{R}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "3ccfbdf1-72f4-51dd-9e12-94157813be94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e942730-712a-42b2-8683-a18702d685f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e942730-712a-42b2-8683-a18702d685f6.jpg?1",
             "name": "Bleeding Effect",
             "text": "At the beginning of combat on your turn, creatures you control gain flying until end of turn if a creature card in your graveyard has flying. The same is true for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "5ac15833-1fc9-5f9e-857d-cc1d945dc204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769bbbb3-37e9-47ec-9cee-db63672275e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769bbbb3-37e9-47ec-9cee-db63672275e6.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "Allies \u2014 At the beginning of your end step, put a +1/+1 counter on each of up to two other target legendary creatures.\nBetrayal \u2014 Whenever a legendary creature with counters on it dies, draw a card for each counter on it. You lose 2 life.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "d9a0e7ee-e8ad-511c-86c9-1b68979f79ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472be1e-388c-45fe-a18d-35b2cb12dc5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472be1e-388c-45fe-a18d-35b2cb12dc5f.jpg?1",
             "name": "Edward Kenway",
             "text": "At the beginning of your end step, create a Treasure token for each tapped Assassin, Pirate, and/or Vehicle you control.\nWhenever a Vehicle you control deals combat damage to a player, look at the top card of that player's library, then exile it face down. You may play that card for as long as it remains exiled.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "33af6163-a388-5d71-852d-4025824f463f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88667198-3bec-413c-b41e-de96abc8db7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88667198-3bec-413c-b41e-de96abc8db7b.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "Trample, haste\nWhenever Eivor, Wolf-Kissed deals combat damage to a player, you mill that many cards. You may put a Saga card and/or a land card from among them onto the battlefield.",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "3527cf2a-15fe-5ffe-9dc4-afbe964fa1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3351cae2-87be-4438-ba58-f4f4aff2416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3351cae2-87be-4438-ba58-f4f4aff2416c.jpg?1",
             "name": "Ezio, Brash Novice",
             "text": "Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "f4c3e698-5d50-5c36-be96-05b163e2a3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c44cc99-eb71-4be3-89f2-74473f2717d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c44cc99-eb71-4be3-89f2-74473f2717d3.jpg?1",
             "name": "Havi, the All-Father",
             "text": "Havi, the All-Father has indestructible as long as there are four or more historic cards in your graveyard. (Artifacts, legendaries, and Sagas are historic.)\nSage Project \u2014 Whenever Havi or another legendary creature you control dies, return target legendary creature card with lesser mana value from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "8f64b2a4-8895-5270-8bdf-5cbfb4215021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73468f53-7de5-4a64-8f83-c0376f1d1f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73468f53-7de5-4a64-8f83-c0376f1d1f3f.jpg?1",
             "name": "Haytham Kenway",
             "text": "Protection from Assassins\nOther Knights you control get +2/+2 and have protection from Assassins.\nWhen Haytham Kenway enters the battlefield, for each opponent, exile up to one target creature that player controls until Haytham Kenway leaves the battlefield.",
             "colours": [
@@ -2172,7 +2172,7 @@
         },
         {
             "id": "1a426f2c-1b45-5eab-99d7-f5c5382367f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056bb9-e825-418a-a8ff-692980aa65fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056bb9-e825-418a-a8ff-692980aa65fe.jpg?1",
             "name": "Jackdaw",
             "text": "Whenever Jackdaw deals combat damage to a player, you may discard your hand. If you do, draw a card for each artifact you control.\nCrew 3",
             "colours": [
@@ -2213,7 +2213,7 @@
         },
         {
             "id": "f71bca21-126f-594f-bf7c-4d019d4686d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e127a40c-90c8-4c2d-aff4-daab1c56a4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e127a40c-90c8-4c2d-aff4-daab1c56a4c5.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "Haste\nWhen Kassandra enters the battlefield, search your graveyard, hand, and library for a card named The Spear of Leonidas, put it onto the battlefield, then shuffle.\nWhenever a creature you control with a legendary Equipment attached to it deals combat damage to a player, draw a card.",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "1c66ab59-8956-52a8-8466-d378100bfa08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6c700-f961-484a-8fe2-57107f5b7717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6c700-f961-484a-8fe2-57107f5b7717.jpg?1",
             "name": "Lydia Frye",
             "text": "Lydia Frye can't be blocked by creatures with power 3 or greater.\nAt the beginning of your end step, surveil X, where X is the number of tapped Assassins you control. (Look at the top X cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "d241cf76-ded0-5f4f-87b0-bb8b9ef02b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116bf8c6-8488-4eff-b350-b3ea821353b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116bf8c6-8488-4eff-b350-b3ea821353b1.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "Haste\n{T}: Draw a card, then discard a card.\nWhenever you discard an Island, Pirate, or Vehicle card, create a tapped Treasure token.",
             "colours": [
@@ -2343,7 +2343,7 @@
         },
         {
             "id": "d7b08679-a433-595e-80b0-2a86c4ddc900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b16a212-602c-4839-9e34-fc5c5b0388f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b16a212-602c-4839-9e34-fc5c5b0388f0.jpg?1",
             "name": "Ratonhnhak\u00e9\ua789ton",
             "text": "As long as Ratonhnhak\u00e9:ton hasn't dealt damage yet, it has hexproof and can't be blocked.\nWhenever Ratonhnhak\u00e9:ton deals combat damage to a player, create a 1/1 black Assassin creature token with menace. When you do, return target Equipment card from your graveyard to the battlefield, then attach it to that token.",
             "colours": [
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "0406352f-6f2e-583e-b197-19581339eb7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085568e5-d622-45ff-9a31-52eaa513ff31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085568e5-d622-45ff-9a31-52eaa513ff31.jpg?1",
             "name": "Shao Jun",
             "text": "Leap Strike \u2014 As long as it's your turn, Shao Jun has flying and first strike.\nRope Dart \u2014 Tap two untapped artifacts you control: Shao Jun deals 1 damage to each opponent.",
             "colours": [
@@ -2429,7 +2429,7 @@
         },
         {
             "id": "14979f66-946a-5e30-8e3c-30132a4d0b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90080ea-062b-4b92-89e7-b6dcb2c70a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90080ea-062b-4b92-89e7-b6dcb2c70a8c.jpg?1",
             "name": "Shaun & Rebecca, Agents",
             "text": "Vigilance\nWhen Shaun & Rebecca, Agents enters the battlefield, search your graveyard, hand, and library for a card named The Animus and put it onto the battlefield, then shuffle.\n{T}: Add {C}. When you do, mill two cards.",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "538847a0-69d4-537d-a5de-cf80f4964f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ca7f13-df00-4904-a7be-44f94272bfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ca7f13-df00-4904-a7be-44f94272bfee.jpg?1",
             "name": "Shay Cormac",
             "text": "{1}: Permanents your opponents control lose hexproof, indestructible, protection, shroud, and ward until end of turn.\nWhenever a creature an opponent controls becomes the target of a spell or ability you control, put a bounty counter on that creature.\nWhenever a creature with a bounty counter on it dies, put two +1/+1 counters on Shay Cormac.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "29da401e-8289-5b45-8d81-30a492b9dacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ceade9-f12a-4724-b198-312fb4b1210b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ceade9-f12a-4724-b198-312fb4b1210b.jpg?1",
             "name": "Sigurd, Jarl of Ravensthorpe",
             "text": "Vigilance, trample, lifelink\nBoast \u2014 {1}: Put a lore counter on target Saga you control or remove one from it. (Activate only if this creature attacked this turn and only once each turn.)\nWhenever you put a lore counter on a Saga you control, put a +1/+1 counter on up to one other target creature.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "3e6b7e28-1c27-576b-96ef-a2a20c22e5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9266244-e8bc-47f8-a440-55d208b961df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9266244-e8bc-47f8-a440-55d208b961df.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "Defender\nSokrates, Athenian Teacher has hexproof as long as it's untapped.\nSokratic Dialogue \u2014 {T}: Until end of turn, target creature gains \"If this creature would deal combat damage to a player, prevent that damage. This creature's controller and that player each draw half that many cards, rounded down.\"",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "37863bed-f1bd-572f-9481-57849aab91db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d878fc-cc21-407f-b3cc-95bf2d717a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d878fc-cc21-407f-b3cc-95bf2d717a80.jpg?1",
             "name": "Adrestia",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Adrestia attacks, if an Assassin crewed it this turn, draw a card. Adrestia becomes an Assassin in addition to its other types until end of turn.\nCrew 1",
             "colours": [],
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "a9358013-ba0f-5be0-85ea-a6f55fc071e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad574010-01ee-4bbc-87c5-4b04338b6ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad574010-01ee-4bbc-87c5-4b04338b6ef6.jpg?1",
             "name": "The Animus",
             "text": "At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.",
             "colours": [],
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "8abf19be-1771-5c28-b1b9-2c12cb6925e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17dd0b7f-bd26-4a46-a7a1-bc65138d54ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17dd0b7f-bd26-4a46-a7a1-bc65138d54ed.jpg?1",
             "name": "Apple of Eden, Isu Relic",
             "text": "{T}, Pay 4 life, Sacrifice Apple of Eden: Look at target opponent's hand and exile those cards face down. You may play those cards this turn, and mana of any type can be spent to cast them. Until end of turn, whenever you play a land or cast a spell this way, its owner draws a card. At the beginning of the next end step, return the exiled cards to their owner's hand. Activate only as a sorcery.",
             "colours": [],
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "defdc406-2dae-592a-aee3-44de66b9a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6439a6-288d-427e-b14b-a99e8ef8c5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6439a6-288d-427e-b14b-a99e8ef8c5cd.jpg?1",
             "name": "Brotherhood Regalia",
             "text": "Equipped creature has ward {2}, is an Assassin in addition to its other types, and can't be blocked.\nEquip legendary creature {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "bb5870ed-c581-5bdc-ba67-1eda2e2edcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dbf574-3193-413e-a982-4b9d27dafaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dbf574-3193-413e-a982-4b9d27dafaf5.jpg?1",
             "name": "Excalibur, Sword of Eden",
             "text": "This spell costs {X} less to cast, where X is the total mana value of historic permanents you control. (Artifacts, legendaries, and Sagas are historic.)\nEquipped creature gets +10/+0 and has vigilance.\nEquip legendary creature {2}",
             "colours": [],
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "1ebf6afe-2107-5cf5-a775-d0a9bf4c1e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a488f-cb64-4f4c-9c2e-6cdb5d563f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a488f-cb64-4f4c-9c2e-6cdb5d563f13.jpg?1",
             "name": "Hidden Blade",
             "text": "Flash\nWhen Hidden Blade enters the battlefield, attach it to target creature you control. If that creature is an Assassin, it gains deathtouch until end of turn.\nEquipped creature gets +1/+0 and has first strike.\nEquip {2}",
             "colours": [],
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "f2793080-9c48-5c31-9e41-73aad3e340f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df09fc8c-e008-427b-b007-ceec9a4aa4ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df09fc8c-e008-427b-b007-ceec9a4aa4ab.jpg?1",
             "name": "Mj\u00f6lnir, Storm Hammer",
             "text": "When Mj\u00f6lnir enters the battlefield, attach it to target legendary creature you control.\nWhenever equipped creature attacks, tap target creature defending player controls and put a stun counter on it. Then Mj\u00f6lnir deals damage to each opponent equal to the number of tapped creatures that opponent controls.\nEquip {4}",
             "colours": [],
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "f8f3c9dd-b674-5639-85f0-a112663e96c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4330d8ce-3b82-4297-ad5f-c63b54b6665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4330d8ce-3b82-4297-ad5f-c63b54b6665a.jpg?1",
             "name": "Smoke Bomb",
             "text": "Flash\nAll creatures have shroud. (They can't be the targets of spells or abilities.)\nAt the beginning of your upkeep, sacrifice Smoke Bomb. When you do, target creature you control can't be blocked this turn.",
             "colours": [],
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "b7d2ae50-13b8-5937-81ae-5c08b729be70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ce94a9-d6f4-432d-9447-e6d1446c393b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ce94a9-d6f4-432d-9447-e6d1446c393b.jpg?1",
             "name": "Staff of Eden, Vault's Key",
             "text": "When Staff of Eden, Vault's Key enters the battlefield, put target legendary permanent card not named Staff of Eden, Vault's Key from a graveyard onto the battlefield under your control.\n{T}: Draw a card for each permanent you control but don't own.",
             "colours": [],
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "269c7f75-2a41-5e97-ba18-23afee521931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19115bf-562c-4bef-967d-52ec1e54c82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19115bf-562c-4bef-967d-52ec1e54c82e.jpg?1",
             "name": "Towering Viewpoint",
             "text": "Defender, reach\nLeap of Faith \u2014 {3}: Target creature gains flying until end of turn.",
             "colours": [],
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "3be55569-8dea-538b-9058-46c8d2c4fdfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240a9ef-06cd-4c48-ba97-fea1e55f20e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240a9ef-06cd-4c48-ba97-fea1e55f20e2.jpg?1",
             "name": "Yggdrasil, Rebirth Engine",
             "text": "When Yggdrasil, Rebirth Engine enters the battlefield, exile all creature cards from your graveyard.\n{T}: Exile the top three cards of your library.\n{4}, {T}: Put a creature card exiled with Yggdrasil onto the battlefield under your control. It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "b4afed83-eb85-5f52-83ff-ac5d7e59ee89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d197866-7633-493c-80dd-ec3a09165934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d197866-7633-493c-80dd-ec3a09165934.jpg?1",
             "name": "Abstergo Entertainment",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Exile Abstergo Entertainment: Return up to one target historic card from your graveyard to your hand, then exile all graveyards. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "d7dec264-9d8e-5321-bdc4-23614b484e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535f43c4-8926-4981-967d-f681f98e07d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535f43c4-8926-4981-967d-f681f98e07d9.jpg?1",
             "name": "Brotherhood Headquarters",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast an Assassin spell or a spell that has freerunning, or to activate an ability of an Assassin source.",
             "colours": [],
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "9a2713fa-a33a-5ee6-b8ca-fc4cc3c96dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4ed445-7b35-4090-9d0e-92532b07c8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4ed445-7b35-4090-9d0e-92532b07c8c7.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "c34068c2-2f05-5321-aa61-abf749de46df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f203ce7d-a079-44b8-bfda-4c63ec79b82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f203ce7d-a079-44b8-bfda-4c63ec79b82d.jpg?1",
             "name": "Reconnaissance",
             "text": "{0}: Remove target attacking creature you control from combat and untap it. (If you activate during end of combat, the creature will untap after it deals combat damage.)",
             "colours": [
@@ -3099,7 +3099,7 @@
         },
         {
             "id": "db967b87-874a-5d71-8461-1e47a576d513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98040e14-8182-4a94-9322-bbd967dc4dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98040e14-8182-4a94-9322-bbd967dc4dfe.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "8e190b39-c89e-51cc-b16b-a1ab1760f18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdc8ac7-a9aa-4323-84c9-fa0cade02bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdc8ac7-a9aa-4323-84c9-fa0cade02bd1.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "9c99fcd4-233e-5313-8dc0-6f41e2e92485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7c9072-d14c-442c-a386-bfdc0cbe110d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7c9072-d14c-442c-a386-bfdc0cbe110d.jpg?1",
             "name": "Propaganda",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "bbb3f072-ddb6-5fd2-8343-a4098a85b4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7385611f-d26f-4a6e-b141-adcf3dbfc438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7385611f-d26f-4a6e-b141-adcf3dbfc438.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "2a47cc9b-4e34-59b4-aea5-4f0aadfcc8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac8176-d0db-4397-820d-acbdd3264377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac8176-d0db-4397-820d-acbdd3264377.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life. (It has every creature type.)",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "dd06ebaf-9904-529e-8db7-7188b86e3aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3cbcbb-d865-42df-88e1-0c9bd24b5c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3cbcbb-d865-42df-88e1-0c9bd24b5c79.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy enters the battlefield, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "2102c8d0-9626-5e13-88af-efba071f2be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512263f7-975a-4107-b58f-6c8ec85e375e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512263f7-975a-4107-b58f-6c8ec85e375e.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness enters the battlefield, choose a creature type.\nCreatures of the chosen type have fear. (They can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "f9b3659b-6284-582f-8ef2-30cead5cfa30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6949e85-2db2-43a7-93bd-485c7b196298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6949e85-2db2-43a7-93bd-485c7b196298.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has mana value 2 or less.\nRevolt \u2014 Destroy that creature if it has mana value 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "41a688c3-18d7-5b48-9a75-e40f3d9c20e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f95ad5d-d0c7-4a65-9e46-1d33abbf77aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f95ad5d-d0c7-4a65-9e46-1d33abbf77aa.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "53784d39-0b6c-5841-8ef4-24f1ba667f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d73f4c-0bbd-4616-81a6-102db6cd7db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d73f4c-0bbd-4616-81a6-102db6cd7db9.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "7b2fb092-f2b2-5539-b247-e39ea59bd486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18205d-cce3-4aef-90bd-06cfb4d8387f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18205d-cce3-4aef-90bd-06cfb4d8387f.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "ae38dbc4-5521-58dc-b088-fabcce4a50d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aaab05-db3b-4317-ae32-553c76f6bade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aaab05-db3b-4317-ae32-553c76f6bade.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "737693d7-3d57-58b0-9534-76b4de1aacb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def90432-6d13-4d28-aa27-f75dd26456bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def90432-6d13-4d28-aa27-f75dd26456bb.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "20971247-7460-5f11-ad6d-e46c81fe976a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11de7338-243a-40e2-84e3-c31240840768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11de7338-243a-40e2-84e3-c31240840768.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "25f9ef1c-302b-5193-bbaf-b8315a694392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80d4e1-8883-4951-8081-a444ab26c5d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80d4e1-8883-4951-8081-a444ab26c5d7.jpg?1",
             "name": "Reconstruct History",
             "text": "Return up to one target artifact card, up to one target enchantment card, up to one target instant card, up to one target sorcery card, and up to one target planeswalker card from your graveyard to your hand.\nExile Reconstruct History.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "ea176650-2db7-5803-8a9b-29cc3ef02a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c38679-5563-4390-ba1f-804731953206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c38679-5563-4390-ba1f-804731953206.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "2b2fcd0f-dc50-53ee-b3e9-5649df64111d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6176a-3938-4c59-b485-8751969358ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6176a-3938-4c59-b485-8751969358ad.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "7f0e9d3b-2a10-5591-bdcb-b933ec18d6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4b10aa-47ff-4897-b56a-00c8b19a2d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4b10aa-47ff-4897-b56a-00c8b19a2d34.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "ea6dae5e-70f6-58c7-a0e3-25226fb35755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ad5a57-7296-43cb-b477-826e65d37222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ad5a57-7296-43cb-b477-826e65d37222.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "11dcc90b-4828-54e7-beaf-7d61f3cc0075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578c984-afb6-4532-b5be-093ed4ecb8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578c984-afb6-4532-b5be-093ed4ecb8b9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "fc1261e4-f172-5af7-b5e3-7028e874af78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22426c4-914a-4e0b-a28a-b8573b63e320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22426c4-914a-4e0b-a28a-b8573b63e320.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "f5db7d4b-1379-57fd-b703-4ad150932827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76f785d-1972-4bd6-8a43-848d51068712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76f785d-1972-4bd6-8a43-848d51068712.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3876,7 +3876,7 @@
         },
         {
             "id": "2bf3a763-313e-5aed-a77d-941a4b0b8435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163a697-01ee-4a55-814f-b0ba79be3a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163a697-01ee-4a55-814f-b0ba79be3a7f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "b413a424-453c-5853-8cfd-2243e7df4f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a6df7a-a080-4aef-9a76-5b08bbc4e762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a6df7a-a080-4aef-9a76-5b08bbc4e762.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "a33bf20c-ee53-51e6-8e33-2196cfb6b14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a534ae1-4e6f-43ae-a8ad-89e306f11f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a534ae1-4e6f-43ae-a8ad-89e306f11f21.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "11627c7f-0d83-5fc8-ac17-18b91c911818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a55d99-d668-4621-bb14-f7df210adbe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a55d99-d668-4621-bb14-f7df210adbe4.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "654bf456-d9aa-5df6-a887-86ac18778808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a081ef-a2d4-4989-8b06-721f8b2c9798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a081ef-a2d4-4989-8b06-721f8b2c9798.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "efb9c7f1-f5af-517f-9971-b84d027ce832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650e47f3-476f-4b32-b892-c1a01335d0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650e47f3-476f-4b32-b892-c1a01335d0fe.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "1f255c5d-2764-5771-b0f5-812d36905876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5b2ce3-3cf0-47dd-9b76-940ae7eb8498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5b2ce3-3cf0-47dd-9b76-940ae7eb8498.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "{T}, Pay 1 life: Add {R} or {W}.\n{1}, {T}, Sacrifice Sunbaked Canyon: Draw a card.",
             "colours": [],
@@ -4127,7 +4127,7 @@
         },
         {
             "id": "c950cc64-4e68-553a-8b9f-2f5b523c8bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73be68-aec6-4033-9cdd-bc473d7db93a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73be68-aec6-4033-9cdd-bc473d7db93a.jpg?1",
             "name": "Fiery Islet",
             "text": "{T}, Pay 1 life: Add {U} or {R}.\n{1}, {T}, Sacrifice Fiery Islet: Draw a card.",
             "colours": [],
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "b9d7ce32-fbeb-51eb-9754-2227f3aee9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4c94f-a38a-461c-9bb8-aadc587a1ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b4c94f-a38a-461c-9bb8-aadc587a1ae6.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}.\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "c87de66a-d87a-5b7b-a425-48e31d914f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b80c5-fe04-4e5e-9637-b745c2c8956b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b80c5-fe04-4e5e-9637-b745c2c8956b.jpg?1",
             "name": "Nurturing Peatland",
             "text": "{T}, Pay 1 life: Add {B} or {G}.\n{1}, {T}, Sacrifice Nurturing Peatland: Draw a card.",
             "colours": [],
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "5dca83ba-09f1-5376-a675-cc105a92d69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de40ccf-5db9-4e4f-b61b-8fc4454209ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de40ccf-5db9-4e4f-b61b-8fc4454209ae.jpg?1",
             "name": "Silent Clearing",
             "text": "{T}, Pay 1 life: Add {W} or {B}.\n{1}, {T}, Sacrifice Silent Clearing: Draw a card.",
             "colours": [],
@@ -4266,7 +4266,7 @@
         },
         {
             "id": "b40e392f-f15b-5279-8923-26f695a7ff14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6631b9b3-57fb-45d0-94fc-7d07556c8f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6631b9b3-57fb-45d0-94fc-7d07556c8f7f.jpg?1",
             "name": "Waterlogged Grove",
             "text": "{T}, Pay 1 life: Add {G} or {U}.\n{1}, {T}, Sacrifice Waterlogged Grove: Draw a card.",
             "colours": [],
@@ -4297,7 +4297,7 @@
         },
         {
             "id": "990914c7-ad7e-5084-a8e7-683c6ada07ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0f02da-62b2-424a-9f1d-6b6b387c15cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0f02da-62b2-424a-9f1d-6b6b387c15cd.jpg?1",
             "name": "The Capitoline Triad",
             "text": "Those Who Came Before \u2014 This spell costs {1} less to cast for each historic card in your graveyard.\nExile any number of historic cards from your graveyard with total mana value 30 or greater: You get an emblem with \"Creatures you control have base power and toughness 9/9.\"",
             "colours": [],
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "011ed5e4-d86e-5430-84a6-6f7fa5b20586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba0ca29-99a7-4cfd-8e16-e32ccaa5ee1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba0ca29-99a7-4cfd-8e16-e32ccaa5ee1e.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "{3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.\n{2}{U}, {T}: Draw a card, then discard a card. If the discarded card was an artifact card, exile it from your graveyard. If you do, create a token that's a copy of it, except it's a 0/2 Thopter artifact creature with flying in addition to its other types.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "0de2f82c-0b21-554f-93ac-b58789e7c58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f82c4-7223-4dae-b037-aac96a32212f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f82c4-7223-4dae-b037-aac96a32212f.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "11d81177-1155-54f8-8c46-bbb37eeaf45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52adcfc1-d8eb-4753-b6fd-a093b6d23637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52adcfc1-d8eb-4753-b6fd-a093b6d23637.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "Allies \u2014 At the beginning of your end step, put a +1/+1 counter on each of up to two other target legendary creatures.\nBetrayal \u2014 Whenever a legendary creature with counters on it dies, draw a card for each counter on it. You lose 2 life.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "61dad622-041e-5731-9206-9f4cc5dcf01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a19dd-2ead-4712-928e-008a75c64fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a19dd-2ead-4712-928e-008a75c64fe2.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "Haste\n{T}: Draw a card, then discard a card.\nWhenever you discard an Island, Pirate, or Vehicle card, create a tapped Treasure token.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "6b51adea-f6a8-5992-810d-1497197fe2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4bfe8-c213-4cff-80fd-824b8f2c6f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4bfe8-c213-4cff-80fd-824b8f2c6f8f.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "",
             "colours": [
@@ -4545,7 +4545,7 @@
         },
         {
             "id": "de4745d5-5342-59fd-8865-20d278088990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b107dc-387e-4c92-a273-6cb44a485caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b107dc-387e-4c92-a273-6cb44a485caa.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "Defender\nSokrates, Athenian Teacher has hexproof as long as it's untapped.\nSokratic Dialogue \u2014 {T}: Until end of turn, target creature gains \"If this creature would deal combat damage to a player, prevent that damage. This creature's controller and that player each draw half that many cards, rounded down.\"",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "8253fa2d-3581-5b3e-ab02-969fedee3d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b2ac8-5bb6-4d40-abd5-e885e1e1fa7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b2ac8-5bb6-4d40-abd5-e885e1e1fa7b.jpg?1",
             "name": "Apple of Eden, Isu Relic",
             "text": "{T}, Pay 4 life, Sacrifice Apple of Eden: Look at target opponent's hand and exile those cards face down. You may play those cards this turn, and mana of any type can be spent to cast them. Until end of turn, whenever you play a land or cast a spell this way, its owner draws a card. At the beginning of the next end step, return the exiled cards to their owner's hand. Activate only as a sorcery.",
             "colours": [],
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "39810c68-6851-5620-8199-9717f9026341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e0225-e272-4a25-a32b-085c4b950597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e0225-e272-4a25-a32b-085c4b950597.jpg?1",
             "name": "Staff of Eden, Vault's Key",
             "text": "When Staff of Eden, Vault's Key enters the battlefield, put target legendary permanent card not named Staff of Eden, Vault's Key from a graveyard onto the battlefield under your control.\n{T}: Draw a card for each permanent you control but don't own.",
             "colours": [],
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "fccf7056-f59b-5ad6-81ab-23e076254752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba4c892-fe7e-4d0c-bce4-724eb4744831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba4c892-fe7e-4d0c-bce4-724eb4744831.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "cb39bfda-40b0-57af-87b1-387508d6ccb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7736bed-b0db-435d-86b3-fa860dbf55f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7736bed-b0db-435d-86b3-fa860dbf55f0.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "8a729352-aa51-57cf-bf76-0778b11324c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c563a0e0-0f9b-450d-8840-728429b9f4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c563a0e0-0f9b-450d-8840-728429b9f4d6.jpg?1",
             "name": "Yggdrasil, Rebirth Engine",
             "text": "When Yggdrasil, Rebirth Engine enters the battlefield, exile all creature cards from your graveyard.\n{T}: Exile the top three cards of your library.\n{4}, {T}: Put a creature card exiled with Yggdrasil onto the battlefield under your control. It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "cd3fcfc7-bb54-5269-a229-26f0635a0bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597080d9-72a2-4da8-bcd5-53ac01da8503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597080d9-72a2-4da8-bcd5-53ac01da8503.jpg?1",
             "name": "Layla Hassan",
             "text": "First strike\nWhen Layla Hassan enters the battlefield and whenever one or more Assassins you control deal combat damage to a player, return target historic card from your graveyard to your hand.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "98ac78e2-5d50-5eb5-aae8-9e4279d13ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f9ff05-8a97-425e-b556-cc658630c869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f9ff05-8a97-425e-b556-cc658630c869.jpg?1",
             "name": "Senu, Keen-Eyed Protector",
             "text": "Flying, vigilance\n{T}, Exile Senu, Keen-Eyed Protector: You gain 2 life and scry 2.\nWhen a legendary creature you control attacks and isn't blocked, if Senu is exiled, put it onto the battlefield attacking.",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "aff18ad5-b2dc-5966-90e4-c3e5af041f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fb3313-b171-4264-81b7-8c043ddcacda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fb3313-b171-4264-81b7-8c043ddcacda.jpg?1",
             "name": "Evie Frye",
             "text": "Partner with Jacob Frye\n{1}, {T}: Draw a card, then discard a card. When you discard a creature card this way, target creature you control can't be blocked this turn.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "f5023414-ef15-50e5-8b6f-61bbc17ad92b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31006604-83cf-4d8d-bf68-bc2ebb2fb5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31006604-83cf-4d8d-bf68-bc2ebb2fb5a0.jpg?1",
             "name": "Desmond Miles",
             "text": "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
             "colours": [
@@ -4913,7 +4913,7 @@
         },
         {
             "id": "5edbb947-0379-5f3b-8953-40de7d223191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ce00ad-acb5-4418-9ea1-50eaf2273242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ce00ad-acb5-4418-9ea1-50eaf2273242.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}.\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "dd4fe600-9a59-5aa8-a4a1-a1c049f9aac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd5f46-2a61-4553-8469-fd69cccec9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd5f46-2a61-4553-8469-fd69cccec9d8.jpg?1",
             "name": "Jacob Frye",
             "text": "Partner with Evie Frye\nWhenever one or more Assassins you control deal combat damage to a player, exile up to one target Assassin card or card with freerunning from your graveyard. If you do, copy it. You may cast the copy.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "1b70d3f5-940f-5e72-8732-495c9339a292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca1f92-2b5c-4d16-be17-6ba450b43ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca1f92-2b5c-4d16-be17-6ba450b43ea3.jpg?1",
             "name": "Roshan, Hidden Magister",
             "text": "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "0a6197eb-a7f4-5099-8fc4-9d1d6bc9e89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab907c09-56c0-40ed-aebd-63b64c7e1c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab907c09-56c0-40ed-aebd-63b64c7e1c2e.jpg?1",
             "name": "Alexios, Deimos of Kosmos",
             "text": "Trample\nAlexios, Deimos of Kosmos attacks each combat if able, can't be sacrificed, and can't attack its owner.\nAt the beginning of each player's upkeep, that player gains control of Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "10f16bc4-697d-5014-b437-dbe943ff63c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba9494-1443-4043-8cb9-3b3f18cd6676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba9494-1443-4043-8cb9-3b3f18cd6676.jpg?1",
             "name": "Aveline de Grandpr\u00e9",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, put that many +1/+1 counters on that creature.\nDisguise {B}{G}",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "359ff7ef-46c3-5883-9c63-f283b94240d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e0ee24-94fc-4042-b3cf-a5a8a2432ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e0ee24-94fc-4042-b3cf-a5a8a2432ba4.jpg?1",
             "name": "Ad\u00e9wal\u00e9, Breaker of Chains",
             "text": "When Ad\u00e9wal\u00e9 enters the battlefield, reveal the top six cards of your library. Put an Assassin, Pirate, or Vehicle card from among them into your hand and the rest on the bottom of your library in a random order.\nWhenever a Vehicle you control deals combat damage to a player, you may return Ad\u00e9wal\u00e9 from your graveyard to your hand.",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "45845ce5-72b4-527d-a245-fe9428c6de6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96abfdf-21fa-46dc-9632-37add4c10c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96abfdf-21fa-46dc-9632-37add4c10c2a.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "First strike\nWhenever Alta\u00efr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.",
             "colours": [
@@ -5208,7 +5208,7 @@
         },
         {
             "id": "c8890551-9f28-52ff-be60-16420cd0caf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458bf178-a2d8-4f7d-afed-48a7e2bbf246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458bf178-a2d8-4f7d-afed-48a7e2bbf246.jpg?1",
             "name": "Arbaaz Mir",
             "text": "Whenever Arbaaz Mir or another nontoken historic permanent enters the battlefield under your control, Arbaaz Mir deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "1fc6e930-e126-53ae-b853-fa51f1c8a05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a97041-4c09-46f2-b979-e4f63c676fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a97041-4c09-46f2-b979-e4f63c676fb4.jpg?1",
             "name": "Arno Dorian",
             "text": "Deathtouch\nOther Assassins you control get +2/+0.\nDisguise {B}{R}",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "5840b55b-7254-5456-ac31-d893ec292cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720096c1-cbbc-4a2f-b585-899c3b87032c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720096c1-cbbc-4a2f-b585-899c3b87032c.jpg?1",
             "name": "Aya of Alexandria",
             "text": "Menace, lifelink\nWhenever a historic creature you control deals combat damage to a player, create a 1/1 black Assassin creature token with menace.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "bd0dc1fa-3819-529b-9f7f-56e4cb280aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e74cc38-108d-46d4-9d4b-43ed5653982a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e74cc38-108d-46d4-9d4b-43ed5653982a.jpg?1",
             "name": "Basim Ibn Ishaq",
             "text": "Whenever you cast a historic spell, draw a card. Basim Ibn Ishaq can't be blocked this turn. This ability triggers only once each turn.\nWhenever Basim Ibn Ishaq deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -5376,7 +5376,7 @@
         },
         {
             "id": "fc4d20a3-2e75-59e1-a7f8-c947abbecb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d27847-42d8-442d-9c3d-7e58f7d1ec5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d27847-42d8-442d-9c3d-7e58f7d1ec5b.jpg?1",
             "name": "Bayek of Siwa",
             "text": "Double strike\nAs long as it's your turn, other historic creatures you control have double strike.\nDisguise {1}{R}{W}",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "9274e184-95b7-584f-a9f7-9a84d880563d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181f4713-6167-4a79-8584-30cb87e6f92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181f4713-6167-4a79-8584-30cb87e6f92b.jpg?1",
             "name": "Edward Kenway",
             "text": "At the beginning of your end step, create a Treasure token for each tapped Assassin, Pirate, and/or Vehicle you control.\nWhenever a Vehicle you control deals combat damage to a player, look at the top card of that player's library, then exile it face down. You may play that card for as long as it remains exiled.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "ad05cc8c-5da8-5670-b4bc-048db81a3752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f45655-c9c9-4adc-a263-106dcca97c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f45655-c9c9-4adc-a263-106dcca97c69.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "Trample, haste\nWhenever Eivor, Wolf-Kissed deals combat damage to a player, you mill that many cards. You may put a Saga card and/or a land card from among them onto the battlefield.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "03c4ab37-59d0-579b-afb9-e07046fe9a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f4e32b-9252-42a9-a259-cd9a68cb3f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f4e32b-9252-42a9-a259-cd9a68cb3f4a.jpg?1",
             "name": "Ezio, Brash Novice",
             "text": "Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "0eb039ac-2810-5fd2-9139-dbb5c5f0d78c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffdd5a9-bc4f-48de-b87b-8087241f6d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffdd5a9-bc4f-48de-b87b-8087241f6d41.jpg?1",
             "name": "Havi, the All-Father",
             "text": "Havi, the All-Father has indestructible as long as there are four or more historic cards in your graveyard.\nSage Project \u2014 Whenever Havi or another legendary creature you control dies, return target legendary creature card with lesser mana value from your graveyard to the battlefield tapped.",
             "colours": [
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "e50c06c7-c7e7-55eb-809b-09c1004949f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23aa895d-659f-49cb-82af-fd8fa491004f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23aa895d-659f-49cb-82af-fd8fa491004f.jpg?1",
             "name": "Haytham Kenway",
             "text": "Protection from Assassins\nOther Knights you control get +2/+2 and have protection from Assassins.\nWhen Haytham Kenway enters the battlefield, for each opponent, exile up to one target creature that player controls until Haytham Kenway leaves the battlefield.",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "c9c24337-d5cb-5c92-ad0a-bafc171e6934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7016d0a-0352-4955-86af-949cf6ba6a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7016d0a-0352-4955-86af-949cf6ba6a3f.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "Haste\nWhen Kassandra enters the battlefield, search your graveyard, hand, and library for a card named The Spear of Leonidas, put it onto the battlefield, then shuffle.\nWhenever a creature you control with a legendary Equipment attached to it deals combat damage to a player, draw a card.",
             "colours": [
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "e89eb8da-247e-5e93-8caf-c92d3c4fa675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910570c8-c868-4513-8b27-22268d0cff68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910570c8-c868-4513-8b27-22268d0cff68.jpg?1",
             "name": "Lydia Frye",
             "text": "Lydia Frye can't be blocked by creatures with power 3 or greater.\nAt the beginning of your end step, surveil X, where X is the number of tapped Assassins you control.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "7eee0881-fb69-5d38-ba10-af707ef0a37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0e1e27-9a74-4151-8902-aacd12897946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0e1e27-9a74-4151-8902-aacd12897946.jpg?1",
             "name": "Ratonhnhak\u00e9\ua789ton",
             "text": "As long as Ratonhnhak\u00e9:ton hasn't dealt damage yet, it has hexproof and can't be blocked.\nWhenever Ratonhnhak\u00e9:ton deals combat damage to a player, create a 1/1 black Assassin creature token with menace. When you do, return target Equipment card from your graveyard to the battlefield, then attach it to that token.",
             "colours": [
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "6ad210df-5121-5341-89af-7bdd6bd4babb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9313f099-7f76-4b3e-af6a-f62b13cad7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9313f099-7f76-4b3e-af6a-f62b13cad7b8.jpg?1",
             "name": "Shao Jun",
             "text": "Leap Strike \u2014 As long as it's your turn, Shao Jun has flying and first strike.\nRope Dart \u2014 Tap two untapped artifacts you control: Shao Jun deals 1 damage to each opponent.",
             "colours": [
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "a4779279-cb32-5492-a468-0475439bccef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5395d40f-75ae-4198-bb8a-c91265bcf824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5395d40f-75ae-4198-bb8a-c91265bcf824.jpg?1",
             "name": "Shaun & Rebecca, Agents",
             "text": "Vigilance\nWhen Shaun & Rebecca, Agents enters the battlefield, search your graveyard, hand, and library for a card named The Animus and put it onto the battlefield, then shuffle.\n{T}: Add {C}. When you do, mill two cards.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "43b9750c-3075-589f-af91-b61835a746f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3012ba-1537-4f54-bb4a-65b909b87e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3012ba-1537-4f54-bb4a-65b909b87e59.jpg?1",
             "name": "Shay Cormac",
             "text": "{1}: Permanents your opponents control lose hexproof, indestructible, protection, shroud, and ward until end of turn.\nWhenever a creature an opponent controls becomes the target of a spell or ability you control, put a bounty counter on that creature.\nWhenever a creature with a bounty counter on it dies, put two +1/+1 counters on Shay Cormac.",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "2ce9bb49-fe5f-5eb9-b8ec-a3434a8d3f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769bc61-cde4-4033-9bbe-e01bc9574261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769bc61-cde4-4033-9bbe-e01bc9574261.jpg?1",
             "name": "Sigurd, Jarl of Ravensthorpe",
             "text": "Vigilance, trample, lifelink\nBoast \u2014 {1}: Put a lore counter on target Saga you control or remove one from it.\nWhenever you put a lore counter on a Saga you control, put a +1/+1 counter on up to one other target creature.",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "79802e2a-a81b-5bc0-afcb-f9456212aada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badfc613-88d9-4a81-a525-1ef74f3ac420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badfc613-88d9-4a81-a525-1ef74f3ac420.jpg?1",
             "name": "Caduceus, Staff of Hermes",
             "text": "Equipped creature has lifelink.\nAs long as you have 30 or more life, equipped creature gets +5/+5 and has indestructible and \"Prevent all damage that would be dealt to this creature.\"\nEquip {W}{W}",
             "colours": [
@@ -5980,7 +5980,7 @@
         },
         {
             "id": "8184f3b4-ab00-58a3-80e5-31db9236e44a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9bf9e0-cb43-411c-a955-dc8e2f331e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9bf9e0-cb43-411c-a955-dc8e2f331e2d.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -6015,7 +6015,7 @@
         },
         {
             "id": "345d4071-04f3-59ca-b38f-af937403c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5f9cb4-a912-4117-97c8-ffe3f5c88eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5f9cb4-a912-4117-97c8-ffe3f5c88eed.jpg?1",
             "name": "What Must Be Done",
             "text": "Choose one \u2014\n\u2022 Let the World Burn \u2014 Destroy all artifacts and creatures.\n\u2022 Release Juno \u2014 Return target historic permanent card from your graveyard to the battlefield. It enters with two additional +1/+1 counters on it if it's a creature.",
             "colours": [
@@ -6050,7 +6050,7 @@
         },
         {
             "id": "a533c237-518d-52ef-ab34-4132846086a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1068ed8a-a062-4249-802d-6f4070992de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1068ed8a-a062-4249-802d-6f4070992de0.jpg?1",
             "name": "Crystal Skull, Isu Spyglass",
             "text": "You may look at the top card of your library any time.\nYou may play historic lands and cast historic spells from the top of your library.\n{T}: Add {U}.",
             "colours": [
@@ -6087,7 +6087,7 @@
         },
         {
             "id": "415f7101-fb2c-5d99-bf40-eec1ec53961b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096632a-a156-4aa5-9b09-f222939ab574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5096632a-a156-4aa5-9b09-f222939ab574.jpg?1",
             "name": "Desynchronization",
             "text": "Return each nonland permanent that's not historic to its owner's hand.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "b13c6e9a-8e4d-57d3-a6b3-a9dfacdb5650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edb50b3-27dd-4d1b-b811-8a2ea5bead1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edb50b3-27dd-4d1b-b811-8a2ea5bead1f.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -6157,7 +6157,7 @@
         },
         {
             "id": "f4d74de7-8e09-5d62-be98-bc08684746c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318f8ec3-0613-448d-87d2-0bcc9e95da64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318f8ec3-0613-448d-87d2-0bcc9e95da64.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.",
             "colours": [
@@ -6192,7 +6192,7 @@
         },
         {
             "id": "129625c3-9a66-5f32-812a-98c4922c0973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6aeb38-811c-4b5b-8bdd-876f41211035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6aeb38-811c-4b5b-8bdd-876f41211035.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy enters the battlefield, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "bf9acae6-7ce6-5ffd-b139-0ae6d5a161f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40c2274-250c-4aa1-8c28-7d963d31435f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40c2274-250c-4aa1-8c28-7d963d31435f.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness enters the battlefield, choose a creature type.\nCreatures of the chosen type have fear.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "e0c5a035-50d2-5388-8a82-0855111f3b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae86188f-dcee-4d19-b5b0-e0d18df4f081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae86188f-dcee-4d19-b5b0-e0d18df4f081.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "52ffb332-d8dd-5c31-b671-0cb9f8de7a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b729699-efb7-4769-a166-29aaadef335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b729699-efb7-4769-a166-29aaadef335b.jpg?1",
             "name": "The Spear of Leonidas",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Bull Rush \u2014 It gains double strike until end of turn.\n\u2022 Summon \u2014 Create Phobos, a legendary 3/2 red Horse creature token.\n\u2022 Revelation \u2014 Discard two cards, then draw two cards.\nEquip {2}",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "0973b0d5-9403-5672-8d7e-56d81684f291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4c0e5f-3437-4fae-ab9f-36a36a086e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4c0e5f-3437-4fae-ab9f-36a36a086e88.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "ac2f90cc-5fa4-5508-93cb-dbfacee60426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55196729-4a74-49b9-acd0-07b8f2d632bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55196729-4a74-49b9-acd0-07b8f2d632bb.jpg?1",
             "name": "Jackdaw",
             "text": "Whenever Jackdaw deals combat damage to a player, you may discard your hand. If you do, draw a card for each artifact you control.\nCrew 3",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "eefdb304-9368-53d4-95f7-6eb0aa2a7e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330dfd52-5e11-4df3-b2e6-7160c940e4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330dfd52-5e11-4df3-b2e6-7160c940e4cb.jpg?1",
             "name": "The Animus",
             "text": "At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.",
             "colours": [],
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "8036f324-72da-540f-a477-7a87af0cd27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f36b1-9f73-490e-87df-c17434113dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f36b1-9f73-490e-87df-c17434113dfd.jpg?1",
             "name": "Excalibur, Sword of Eden",
             "text": "This spell costs {X} less to cast, where X is the total mana value of historic permanents you control.\nEquipped creature gets +10/+0 and has vigilance.\nEquip legendary creature {2}",
             "colours": [],
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "c42edd5b-2fc3-548e-85de-299672ba8f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f43e214-2e20-4168-abff-e5abefc5b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f43e214-2e20-4168-abff-e5abefc5b009.jpg?1",
             "name": "Mj\u00f6lnir, Storm Hammer",
             "text": "When Mj\u00f6lnir enters the battlefield, attach it to target legendary creature you control.\nWhenever equipped creature attacks, tap target creature defending player controls and put a stun counter on it. Then Mj\u00f6lnir deals damage to each opponent equal to the number of tapped creatures that opponent controls.\nEquip {4}",
             "colours": [],
@@ -6521,7 +6521,7 @@
         },
         {
             "id": "7e1dbedf-3af8-573c-af04-51f3241be5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760d9a05-e0b9-4c26-b994-6b0eaf0af90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760d9a05-e0b9-4c26-b994-6b0eaf0af90e.jpg?1",
             "name": "Abstergo Entertainment",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Exile Abstergo Entertainment: Return up to one target historic card from your graveyard to your hand, then exile all graveyards.",
             "colours": [],
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "4f356dd4-0e39-5869-a06d-4a6fdf068fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa62c7e-7f03-42c0-b761-1fdeb3c9e4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa62c7e-7f03-42c0-b761-1fdeb3c9e4ee.jpg?1",
             "name": "The Capitoline Triad",
             "text": "Those Who Came Before \u2014 This spell costs {1} less to cast for each historic card in your graveyard.\nExile any number of historic cards from your graveyard with total mana value 30 or greater: You get an emblem with \"Creatures you control have base power and toughness 9/9.\"",
             "colours": [],
@@ -6589,7 +6589,7 @@
         },
         {
             "id": "facef648-f308-5e1d-9057-83e9dab21276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42db7f-b1f3-4588-9ff5-4f4bc3f53ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42db7f-b1f3-4588-9ff5-4f4bc3f53ee4.jpg?1",
             "name": "Caduceus, Staff of Hermes",
             "text": "Equipped creature has lifelink.\nAs long as you have 30 or more life, equipped creature gets +5/+5 and has indestructible and \"Prevent all damage that would be dealt to this creature.\"\nEquip {W}{W}",
             "colours": [
@@ -6627,7 +6627,7 @@
         },
         {
             "id": "95d86261-2ceb-503f-83ab-f7e86256acf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2285f6e4-99bd-4f61-9788-0107c119753e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2285f6e4-99bd-4f61-9788-0107c119753e.jpg?1",
             "name": "Distract the Guards",
             "text": "Freerunning {1}{W}\nCreate three 1/1 white Human Rogue creature tokens.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "918d67e7-1be3-50fe-9530-c10810dd4a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fffb8d-e639-4863-84a1-37cd330a3226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fffb8d-e639-4863-84a1-37cd330a3226.jpg?1",
             "name": "Haystack",
             "text": "{2}, {T}: Target creature you control phases out.",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "da4297c4-3427-5cb9-9e6c-2820f2a8125a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b283b1-a3df-48f8-b1e6-a97a1aa1dcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b283b1-a3df-48f8-b1e6-a97a1aa1dcc6.jpg?1",
             "name": "Hookblade",
             "text": "When Hookblade enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0.\nAs long as it's your turn, equipped creature has flying.\nEquip {2}",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "27e4e9cd-e41e-5cf3-b848-b5a48e586867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67367ca8-0a23-4192-bca5-08dbd655f0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67367ca8-0a23-4192-bca5-08dbd655f0ba.jpg?1",
             "name": "Layla Hassan",
             "text": "First strike\nWhen Layla Hassan enters the battlefield and whenever one or more Assassins you control deal combat damage to a player, return target historic card from your graveyard to your hand.",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "34a6d039-4b61-5c4b-9f31-1ec649a6db7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f532fa8-9a97-4d9d-b6aa-f9d356721459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f532fa8-9a97-4d9d-b6aa-f9d356721459.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "2f592fa6-58cc-581c-a211-1966d7953b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9c27c-d73a-4c8e-a396-4348a2695edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9c27c-d73a-4c8e-a396-4348a2695edb.jpg?1",
             "name": "Reconnaissance",
             "text": "{0}: Remove target attacking creature you control from combat and untap it. (If you activate during end of combat, the creature will untap after it deals combat damage.)",
             "colours": [
@@ -6833,7 +6833,7 @@
         },
         {
             "id": "f4fcba81-44bb-52e1-9181-2d66a923c74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9648392a-78a2-4ae5-a218-cfd2bcd9bc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9648392a-78a2-4ae5-a218-cfd2bcd9bc5d.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "872216e7-c662-5b47-a9ac-6219d2165af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca84e5a-4ce8-47fa-98b8-9d2dc65dd6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca84e5a-4ce8-47fa-98b8-9d2dc65dd6c8.jpg?1",
             "name": "Senu, Keen-Eyed Protector",
             "text": "Flying, vigilance\n{T}, Exile Senu, Keen-Eyed Protector: You gain 2 life and scry 2.\nWhen a legendary creature you control attacks and isn't blocked, if Senu is exiled, put it onto the battlefield attacking.",
             "colours": [
@@ -6906,7 +6906,7 @@
         },
         {
             "id": "3db8b1fc-4847-52b5-9401-6453ec2f300c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825615d2-2bb9-486e-8a05-4244b7ba66c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825615d2-2bb9-486e-8a05-4244b7ba66c3.jpg?1",
             "name": "Tax Collector",
             "text": "When Tax Collector enters the battlefield, choose one \u2014\n\u2022 Tax \u2014 Until your next turn, spells your opponents cast cost {1} more to cast.\n\u2022 Arrest \u2014 Detain target creature an opponent controls.",
             "colours": [
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "b79d4445-2619-5faf-8fb2-9adfba9a0f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4107fda1-ed94-4920-95c9-329d243fdc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4107fda1-ed94-4920-95c9-329d243fdc01.jpg?1",
             "name": "Templar Knight",
             "text": "Vigilance\n{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Templar Knight.",
             "colours": [
@@ -6978,7 +6978,7 @@
         },
         {
             "id": "8692f1db-648f-57b3-83ce-9bee6974c053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9cdb95-d110-4cc8-bfb0-665539fb4712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9cdb95-d110-4cc8-bfb0-665539fb4712.jpg?1",
             "name": "What Must Be Done",
             "text": "Choose one \u2014\n\u2022 Let the World Burn \u2014 Destroy all artifacts and creatures.\n\u2022 Release Juno \u2014 Return target historic permanent card from your graveyard to the battlefield. It enters with two additional +1/+1 counters on it if it's a creature.",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "9b393510-dbd9-587a-b55b-f6b7e7f623b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede0e73-35ae-42f2-af1d-db1a346743ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede0e73-35ae-42f2-af1d-db1a346743ad.jpg?1",
             "name": "Assassin Gauntlet",
             "text": "When Assassin Gauntlet enters the battlefield, attach it to up to one target creature you control. Tap all creatures target opponent controls.\nEquipped creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, draw a card, then discard a card.\"\nEquip {2}",
             "colours": [
@@ -7047,7 +7047,7 @@
         },
         {
             "id": "dc6dd1cd-5bf6-5408-a2a3-e694b4d129ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4c9ebe-996a-44ae-9f97-46f0e8096da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4c9ebe-996a-44ae-9f97-46f0e8096da4.jpg?1",
             "name": "Become Anonymous",
             "text": "Exile target creature you control and the top two cards of your library in a face-down pile, shuffle that pile, then cloak those cards. They enter the battlefield tapped.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "c54598fc-706c-5f1e-8f3e-900e75599a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c07fa3-a823-420a-b9c5-72f0b9766bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c07fa3-a823-420a-b9c5-72f0b9766bb4.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "fb8743b6-eeab-5494-bf8a-5dda76074bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be26a459-2595-44ed-a875-1163942b3656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be26a459-2595-44ed-a875-1163942b3656.jpg?1",
             "name": "Crystal Skull, Isu Spyglass",
             "text": "You may look at the top card of your library any time.\nYou may play historic lands and cast historic spells from the top of your library.\n{T}: Add {U}.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "0d55740d-e7fe-5d00-825e-833810cb5c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeb049f-6d05-47c5-9f6c-e0f1547e3638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeb049f-6d05-47c5-9f6c-e0f1547e3638.jpg?1",
             "name": "Desynchronization",
             "text": "Return each nonland permanent that's not historic to its owner's hand.",
             "colours": [
@@ -7183,7 +7183,7 @@
         },
         {
             "id": "f7999a2c-65c5-5613-b5ee-e9f4e163c875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab7020-bd24-4c43-9c7c-5a283d6f650d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab7020-bd24-4c43-9c7c-5a283d6f650d.jpg?1",
             "name": "Eagle Vision",
             "text": "Freerunning {1}{U}\nDraw three cards.",
             "colours": [
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "f6fb398c-ffcc-547c-8eec-cf08b0bd465b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726bf33c-1555-4056-9544-e7477659726b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726bf33c-1555-4056-9544-e7477659726b.jpg?1",
             "name": "Escape Detection",
             "text": "Freerunning\u2014\nReturn a blue creature you control to its owner's hand.\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -7249,7 +7249,7 @@
         },
         {
             "id": "24cf4664-ea6a-5481-bc37-e1429e331ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d942a-8f41-49fb-982e-152001855ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d942a-8f41-49fb-982e-152001855ee0.jpg?1",
             "name": "Evie Frye",
             "text": "Partner with Jacob Frye\n{1}, {T}: Draw a card, then discard a card. When you discard a creature card this way, target creature you control can't be blocked this turn.",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "9a255a00-bd42-5132-a203-e85bacd90fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f8996b-bb80-4722-9b47-3b54472155e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f8996b-bb80-4722-9b47-3b54472155e0.jpg?1",
             "name": "Leonardo da Vinci",
             "text": "{3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.\n{2}{U}, {T}: Draw a card, then discard a card. If the discarded card was an artifact card, exile it from your graveyard. If you do, create a token that's a copy of it, except it's a 0/2 Thopter artifact creature with flying in addition to its other types.",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "3fcacf40-a94f-5767-86a6-a69c39b3b19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317cb518-1b76-4402-93b5-01c971a5dc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317cb518-1b76-4402-93b5-01c971a5dc55.jpg?1",
             "name": "Loyal Inventor",
             "text": "Vigilance\nWhen Loyal Inventor enters the battlefield, you may search your library for an artifact card, reveal it, then shuffle. Put that card into your hand if you control an Assassin. Otherwise, put that card on top of your library.",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "abf69e85-cbf4-5c50-9690-2823e6d65eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c8a2b-dbba-423d-8f86-7c5ec184bfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c8a2b-dbba-423d-8f86-7c5ec184bfcf.jpg?1",
             "name": "Propaganda",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "50396ff3-7d08-5d0d-8a34-365b979f9d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c42842-d844-4b3b-bef3-dc7da7d2efb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c42842-d844-4b3b-bef3-dc7da7d2efb8.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "1b444658-e303-597a-8a77-9253c60c6d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653745b0-4e3b-4147-8b48-16560e706055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653745b0-4e3b-4147-8b48-16560e706055.jpg?1",
             "name": "Assassin Initiate",
             "text": "{1}: Assassin Initiate gains your choice of flying, deathtouch, or lifelink until end of turn.",
             "colours": [
@@ -7467,7 +7467,7 @@
         },
         {
             "id": "7f2535b8-0796-5431-9828-46ffd49f0ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c3514a-5e57-44b5-867d-cbfb66a90dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c3514a-5e57-44b5-867d-cbfb66a90dfb.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.",
             "colours": [
@@ -7501,7 +7501,7 @@
         },
         {
             "id": "9f65a921-9b01-54b4-b975-ac767ad683db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11374a-183c-454a-882b-cbc2059dba26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11374a-183c-454a-882b-cbc2059dba26.jpg?1",
             "name": "Chain Assassination",
             "text": "Freerunning {1}{B}\nDestroy target creature. If another creature died this turn, draw a card.",
             "colours": [
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "991dacbd-b2b3-5966-be06-1aa85e63aada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454aa2e5-fc90-4338-a319-010d4d706ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454aa2e5-fc90-4338-a319-010d4d706ae7.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy enters the battlefield, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "bece0746-8a9c-56bd-af40-1639dde7ef20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90bbc98-f3ae-4963-910d-f5c8d9a0ba72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90bbc98-f3ae-4963-910d-f5c8d9a0ba72.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness enters the battlefield, choose a creature type.\nCreatures of the chosen type have fear.",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "5f421a6f-c65a-54b7-b9b3-37a54d1c517a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c1e9c6-a9ec-4aca-a80d-9a00b05c1218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c1e9c6-a9ec-4aca-a80d-9a00b05c1218.jpg?1",
             "name": "Desmond Miles",
             "text": "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
             "colours": [
@@ -7641,7 +7641,7 @@
         },
         {
             "id": "8160561f-90a6-53e8-ac8b-76a2d7d9ca12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5184ac-f73a-4fdc-a531-0f577892997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5184ac-f73a-4fdc-a531-0f577892997a.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "Menace\nAssassin spells you cast have freerunning {B}{B}.\nWhenever Ezio deals combat damage to a player, you may pay {W}{U}{B}{R}{G} if that player has 10 or less life. When you do, that player loses the game.",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "7667622e-3052-59fe-bb82-5372531d83bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841fefda-5da3-455e-9f11-1ef5c97c1b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841fefda-5da3-455e-9f11-1ef5c97c1b0d.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has mana value 2 or less.\nRevolt \u2014 Destroy that creature if it has mana value 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "3ade7430-eb68-5774-9d7c-26cd7874d0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbeed2f0-f42a-4f1f-a9a3-12140f4842f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbeed2f0-f42a-4f1f-a9a3-12140f4842f6.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "e34dbea2-e978-52fd-9690-049353330a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fb6b8-7c74-42f7-82f2-33503c1f910a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181fb6b8-7c74-42f7-82f2-33503c1f910a.jpg?1",
             "name": "Hemlock Vial",
             "text": "When Hemlock Vial enters the battlefield, you draw a card and you lose 1 life.\n{B}, {T}, Sacrifice Hemlock Vial: Each equipped creature and Equipment you control gains deathtouch until end of turn.",
             "colours": [
@@ -7785,7 +7785,7 @@
         },
         {
             "id": "d017ee66-09ea-59cc-93d8-a3c423a5ed85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666fafa-54b5-495e-8168-c579fd901b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666fafa-54b5-495e-8168-c579fd901b58.jpg?1",
             "name": "Jacob Frye",
             "text": "Partner with Evie Frye\nWhenever one or more Assassins you control deal combat damage to a player, exile up to one target Assassin card or card with freerunning from your graveyard. If you do, copy it. You may cast the copy.",
             "colours": [
@@ -7824,7 +7824,7 @@
         },
         {
             "id": "91fbf840-4b5e-5c06-b29d-4141ff6b73c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e18830-3668-4c23-96aa-d241f79adbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e18830-3668-4c23-96aa-d241f79adbd5.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "2025d6c5-73e2-5ecf-906d-4313b1e979eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec58f0-494d-46bb-a49e-265a6d852244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec58f0-494d-46bb-a49e-265a6d852244.jpg?1",
             "name": "Petty Larceny",
             "text": "Freerunning {1}{B}\nLook at the top two cards of target opponent's library and exile those cards face down. You may play those cards for as long as they remain exiled, and mana of any type can be spent to cast them. Create a Treasure token.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "5548605f-e576-51b2-ba71-ca0f196f1c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b5257-f171-4bd5-80db-f5a627fd337d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b5257-f171-4bd5-80db-f5a627fd337d.jpg?1",
             "name": "Phantom Blade",
             "text": "When Phantom Blade enters the battlefield, attach it to up to one target creature you control. Destroy up to one other target creature.\nEquipped creature gets +1/+1 and has menace.\nEquip {2}",
             "colours": [
@@ -7925,7 +7925,7 @@
         },
         {
             "id": "0dfe1c5a-bb20-53ab-b632-a94af7d743d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e71c-e401-4e5b-a4b9-d67c21bd1b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e71c-e401-4e5b-a4b9-d67c21bd1b7c.jpg?1",
             "name": "Restart Sequence",
             "text": "Freerunning {1}{B}\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -7958,7 +7958,7 @@
         },
         {
             "id": "5b469aab-2a43-5833-b2eb-d4ab5920f49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ddae3-192e-4b88-836b-b0e3defd2e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ddae3-192e-4b88-836b-b0e3defd2e99.jpg?1",
             "name": "Roshan, Hidden Magister",
             "text": "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
             "colours": [
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "a748cf5e-5bdb-58d1-9858-3328e829eed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319a380-974a-486f-9b1e-495383c58d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319a380-974a-486f-9b1e-495383c58d82.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -8035,7 +8035,7 @@
         },
         {
             "id": "5502dc77-ab44-5c80-86d3-ad5247fb8020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d6fad-24c7-47dc-8feb-de58c8e51c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d6fad-24c7-47dc-8feb-de58c8e51c33.jpg?1",
             "name": "Alexios, Deimos of Kosmos",
             "text": "Trample\nAlexios, Deimos of Kosmos attacks each combat if able, can't be sacrificed, and can't attack its owner.\nAt the beginning of each player's upkeep, that player gains control of Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -8074,7 +8074,7 @@
         },
         {
             "id": "24db147d-fb61-5b6f-89ea-852c318c8a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16abb80e-12ef-48a2-855e-c237c10a3f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16abb80e-12ef-48a2-855e-c237c10a3f92.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "ced0c00d-9a6a-5aaa-903d-6cadac149722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c014fb8d-748d-4a58-9065-17937fd4a9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c014fb8d-748d-4a58-9065-17937fd4a9f2.jpg?1",
             "name": "Hidden Footblade",
             "text": "Flash\nWhen Hidden Footblade enters the battlefield, attach it to target creature you control. That creature gains first strike until end of turn.\nEquipped creature gets +1/+0 and has haste.\nEquip {2}",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "c6ac9fcc-67ab-5a9c-9c4b-9fd5bacd155c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30933821-a64e-4c15-a7aa-e13cb89f46f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30933821-a64e-4c15-a7aa-e13cb89f46f5.jpg?1",
             "name": "Monastery Raid",
             "text": "Freerunning {X}{R}\nExile the top two cards of your library. If this spell's freerunning cost was paid, exile the top X cards of your library instead. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -8175,7 +8175,7 @@
         },
         {
             "id": "6efd980c-0dca-5fdb-8381-793743ce137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62be00b-b6cb-47df-aa60-7c77c2f15fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62be00b-b6cb-47df-aa60-7c77c2f15fd3.jpg?1",
             "name": "Overpowering Attack",
             "text": "Freerunning {2}{R}\nUntap all creatures you control that attacked this turn. If it's your main phase, there is an additional combat phase after this phase, followed by an additional main phase.",
             "colours": [
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "144b4b8f-0eaf-50bc-86bf-802ce7019464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a71cfd0-0e24-4ae4-9a7e-a5ab5fea46c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a71cfd0-0e24-4ae4-9a7e-a5ab5fea46c8.jpg?1",
             "name": "The Spear of Leonidas",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Bull Rush \u2014 It gains double strike until end of turn.\n\u2022 Summon \u2014 Create Phobos, a legendary 3/2 red Horse creature token.\n\u2022 Revelation \u2014 Discard two cards, then draw two cards.\nEquip {2}",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "62e0d0fa-3209-531d-8877-6715d62cb06e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f97fbc-2abd-4496-a29e-4cecac1440c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f97fbc-2abd-4496-a29e-4cecac1440c1.jpg?1",
             "name": "Aveline de Grandpr\u00e9",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, put that many +1/+1 counters on that creature.\nDisguise {B}{G}",
             "colours": [
@@ -8286,7 +8286,7 @@
         },
         {
             "id": "3bdc41d3-d7a2-5ad4-9e0d-dea4c41a9503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1cc216-14b3-4870-8162-18c646f958f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1cc216-14b3-4870-8162-18c646f958f4.jpg?1",
             "name": "Hunter's Bow",
             "text": "When Hunter's Bow enters the battlefield, attach it to target creature you control. That creature deals damage equal to its power to up to one target creature you don't control.\nEquipped creature has reach and ward {2}.\nEquip {1}",
             "colours": [
@@ -8321,7 +8321,7 @@
         },
         {
             "id": "188ac3e0-9a67-5298-94f4-ac5f88f3b50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262c036d-4c44-48e7-a6df-f54442d93386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262c036d-4c44-48e7-a6df-f54442d93386.jpg?1",
             "name": "Palazzo Archers",
             "text": "Reach\nWhenever a creature with flying attacks you or a planeswalker you control, Palazzo Archers deals damage equal to its power to that creature.",
             "colours": [
@@ -8357,7 +8357,7 @@
         },
         {
             "id": "04914ed7-746b-52b3-86a9-56b1e711abf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa22038-6b13-422c-a07c-41e233b7405b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa22038-6b13-422c-a07c-41e233b7405b.jpg?1",
             "name": "Viewpoint Synchronization",
             "text": "Freerunning {2}{G}\nSearch your library for up to three basic land cards and reveal them. Put two of them onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "4310b6d6-adb7-58e7-be57-b43c230224f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb23cf5-f046-4310-853b-e5995693f2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb23cf5-f046-4310-853b-e5995693f2dd.jpg?1",
             "name": "Ad\u00e9wal\u00e9, Breaker of Chains",
             "text": "When Ad\u00e9wal\u00e9 enters the battlefield, reveal the top six cards of your library. Put an Assassin, Pirate, or Vehicle card from among them into your hand and the rest on the bottom of your library in a random order.\nWhenever a Vehicle you control deals combat damage to a player, you may return Ad\u00e9wal\u00e9 from your graveyard to your hand.",
             "colours": [
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "7c661814-c828-564f-97cc-056015029d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba4aba6-6ed8-46cc-89eb-ce546940e250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba4aba6-6ed8-46cc-89eb-ce546940e250.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "First strike\nWhenever Alta\u00efr Ibn-La'Ahad attacks, exile up to one target Assassin creature card from your graveyard with a memory counter on it. Then for each creature card you own in exile with a memory counter on it, create a tapped and attacking token that's a copy of it. Exile those tokens at end of combat.",
             "colours": [
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "e35d0b7c-7c9e-577f-bb7c-1d23259f289f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c92faf6-1fbb-4e5e-93d8-22da66886f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c92faf6-1fbb-4e5e-93d8-22da66886f33.jpg?1",
             "name": "Arbaaz Mir",
             "text": "Whenever Arbaaz Mir or another nontoken historic permanent enters the battlefield under your control, Arbaaz Mir deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -8517,7 +8517,7 @@
         },
         {
             "id": "cf9e937f-64c2-5ea8-935e-dcab50c5c890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd4a-861c-4df4-a34b-f1a49a8e74fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd4a-861c-4df4-a34b-f1a49a8e74fa.jpg?1",
             "name": "Arno Dorian",
             "text": "Deathtouch\nOther Assassins you control get +2/+0.\nDisguise {B}{R}",
             "colours": [
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "7160c82d-2845-598c-8f6b-25464fc28ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66da05e-b3a7-4557-a7c3-97051ba24cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66da05e-b3a7-4557-a7c3-97051ba24cab.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -8594,7 +8594,7 @@
         },
         {
             "id": "b4d5eede-5cec-5ee8-8639-c44218626450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8afbe-1c29-4b23-9832-5656ac60acea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f8afbe-1c29-4b23-9832-5656ac60acea.jpg?1",
             "name": "Aya of Alexandria",
             "text": "Menace, lifelink\nWhenever a historic creature you control deals combat damage to a player, create a 1/1 black Assassin creature token with menace.",
             "colours": [
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "3abdaa2a-a2f0-58f6-a348-12db3d2fbea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2146945f-efdc-4612-a341-acadb4bb36f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2146945f-efdc-4612-a341-acadb4bb36f2.jpg?1",
             "name": "Basim Ibn Ishaq",
             "text": "Whenever you cast a historic spell, draw a card. Basim Ibn Ishaq can't be blocked this turn. This ability triggers only once each turn.\nWhenever Basim Ibn Ishaq deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -8676,7 +8676,7 @@
         },
         {
             "id": "408a98a2-f25d-5f60-bb76-74abbeb004c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381497ac-653e-4c98-be03-2192d42885f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381497ac-653e-4c98-be03-2192d42885f5.jpg?1",
             "name": "Bayek of Siwa",
             "text": "Double strike\nAs long as it's your turn, other historic creatures you control have double strike.\nDisguise {1}{R}{W}",
             "colours": [
@@ -8717,7 +8717,7 @@
         },
         {
             "id": "20d84a9f-7de5-52d6-8e99-e175d1bec323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829debdc-862d-4277-9c87-1e5966e4837d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829debdc-862d-4277-9c87-1e5966e4837d.jpg?1",
             "name": "Bleeding Effect",
             "text": "At the beginning of combat on your turn, creatures you control gain flying until end of turn if a creature card in your graveyard has flying. The same is true for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -8752,7 +8752,7 @@
         },
         {
             "id": "cdf666b7-d602-5ebb-bc61-c81f93ee848a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef2b03a-0956-4086-85cf-c32cce09d6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef2b03a-0956-4086-85cf-c32cce09d6ef.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "Allies \u2014 At the beginning of your end step, put a +1/+1 counter on each of up to two other target legendary creatures.\nBetrayal \u2014 Whenever a legendary creature with counters on it dies, draw a card for each counter on it. You lose 2 life.",
             "colours": [
@@ -8794,7 +8794,7 @@
         },
         {
             "id": "fd7f4263-d662-5869-80ed-c9a05cd78d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0ce737-8066-444b-ae33-c84713305b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0ce737-8066-444b-ae33-c84713305b1a.jpg?1",
             "name": "Edward Kenway",
             "text": "At the beginning of your end step, create a Treasure token for each tapped Assassin, Pirate, and/or Vehicle you control.\nWhenever a Vehicle you control deals combat damage to a player, look at the top card of that player's library, then exile it face down. You may play that card for as long as it remains exiled.",
             "colours": [
@@ -8839,7 +8839,7 @@
         },
         {
             "id": "32008df4-a00c-57d5-9fc7-c7b2d5f02de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad1af4d-9643-46da-a91b-e85d56829c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad1af4d-9643-46da-a91b-e85d56829c43.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "Trample, haste\nWhenever Eivor, Wolf-Kissed deals combat damage to a player, you mill that many cards. You may put a Saga card and/or a land card from among them onto the battlefield.",
             "colours": [
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "1958464f-ff48-5dd8-abae-48d67f5c1990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e48432-2e3a-4673-aa08-1d1d4ed2f472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e48432-2e3a-4673-aa08-1d1d4ed2f472.jpg?1",
             "name": "Ezio, Brash Novice",
             "text": "Whenever Ezio, Brash Novice attacks, put a +1/+1 counter on it.\nAs long as Ezio has two or more counters on it, it has first strike and is an Assassin in addition to its other types.",
             "colours": [
@@ -8924,7 +8924,7 @@
         },
         {
             "id": "171c996e-03c2-5b64-9324-8303530ae03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99b18c2-3732-4e3c-a553-d2cb833f5eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99b18c2-3732-4e3c-a553-d2cb833f5eb5.jpg?1",
             "name": "Havi, the All-Father",
             "text": "Havi, the All-Father has indestructible as long as there are four or more historic cards in your graveyard.\nSage Project \u2014 Whenever Havi or another legendary creature you control dies, return target legendary creature card with lesser mana value from your graveyard to the battlefield tapped.",
             "colours": [
@@ -8967,7 +8967,7 @@
         },
         {
             "id": "8358f0f6-c319-5c22-9030-8a8e5360cfe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba72b7f-7dd2-47cf-a0fc-d14662878db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba72b7f-7dd2-47cf-a0fc-d14662878db8.jpg?1",
             "name": "Haytham Kenway",
             "text": "Protection from Assassins\nOther Knights you control get +2/+2 and have protection from Assassins.\nWhen Haytham Kenway enters the battlefield, for each opponent, exile up to one target creature that player controls until Haytham Kenway leaves the battlefield.",
             "colours": [
@@ -9008,7 +9008,7 @@
         },
         {
             "id": "a478eb48-7973-56b8-b579-ec60bc969630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4e1b9a-ac75-441c-bfdc-2dd7fc07d2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4e1b9a-ac75-441c-bfdc-2dd7fc07d2c2.jpg?1",
             "name": "Jackdaw",
             "text": "Whenever Jackdaw deals combat damage to a player, you may discard your hand. If you do, draw a card for each artifact you control.\nCrew 3",
             "colours": [
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "9111a371-26ba-5f19-a10f-9fb4a5a4f5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c803e701-61d5-4f13-a0c4-78f00af1a4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c803e701-61d5-4f13-a0c4-78f00af1a4ea.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "Haste\nWhen Kassandra enters the battlefield, search your graveyard, hand, and library for a card named The Spear of Leonidas, put it onto the battlefield, then shuffle.\nWhenever a creature you control with a legendary Equipment attached to it deals combat damage to a player, draw a card.",
             "colours": [
@@ -9091,7 +9091,7 @@
         },
         {
             "id": "c7a54d0e-ecd3-5f90-a5f9-bf49a247a90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88081ed8-0416-4c1b-bd59-5bf9fdc3cc5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88081ed8-0416-4c1b-bd59-5bf9fdc3cc5f.jpg?1",
             "name": "Lydia Frye",
             "text": "Lydia Frye can't be blocked by creatures with power 3 or greater.\nAt the beginning of your end step, surveil X, where X is the number of tapped Assassins you control.",
             "colours": [
@@ -9132,7 +9132,7 @@
         },
         {
             "id": "3e6ca01b-2c53-503f-b5c1-f4fb5eb787a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b07542-b347-43ca-8203-cbf648d5426c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b07542-b347-43ca-8203-cbf648d5426c.jpg?1",
             "name": "Mary Read and Anne Bonny",
             "text": "Haste\n{T}: Draw a card, then discard a card.\nWhenever you discard an Island, Pirate, or Vehicle card, create a tapped Treasure token.",
             "colours": [
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "cf578fcd-0e44-5daf-99bf-41a7be1b6b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96eb5dd-e846-433d-9cad-15c309c1ab75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96eb5dd-e846-433d-9cad-15c309c1ab75.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "5c57fb2f-488f-5425-8224-372dcaa13fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6133c3ab-9552-4b02-8c07-4128773a78b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6133c3ab-9552-4b02-8c07-4128773a78b9.jpg?1",
             "name": "Ratonhnhak\u00e9\ua789ton",
             "text": "As long as Ratonhnhak\u00e9:ton hasn't dealt damage yet, it has hexproof and can't be blocked.\nWhenever Ratonhnhak\u00e9:ton deals combat damage to a player, create a 1/1 black Assassin creature token with menace. When you do, return target Equipment card from your graveyard to the battlefield, then attach it to that token.",
             "colours": [
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "e3323e5a-8d74-5ff5-9dcd-bf66982b803b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d341e9-4d06-48fe-b668-3bd883c1bbe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d341e9-4d06-48fe-b668-3bd883c1bbe8.jpg?1",
             "name": "Reconstruct History",
             "text": "Return up to one target artifact card, up to one target enchantment card, up to one target instant card, up to one target sorcery card, and up to one target planeswalker card from your graveyard to your hand.\nExile Reconstruct History.",
             "colours": [
@@ -9288,7 +9288,7 @@
         },
         {
             "id": "edac2aac-66dc-51d5-a59d-df07384c1f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f07870-359c-4f7a-8287-b5f59b7dc72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f07870-359c-4f7a-8287-b5f59b7dc72b.jpg?1",
             "name": "Shao Jun",
             "text": "Leap Strike \u2014 As long as it's your turn, Shao Jun has flying and first strike.\nRope Dart \u2014 Tap two untapped artifacts you control: Shao Jun deals 1 damage to each opponent.",
             "colours": [
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "b1704986-eb4e-5718-aef0-f4421f6b4691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375bfc8-9272-4421-96cb-80bd8759db47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375bfc8-9272-4421-96cb-80bd8759db47.jpg?1",
             "name": "Shaun & Rebecca, Agents",
             "text": "Vigilance\nWhen Shaun & Rebecca, Agents enters the battlefield, search your graveyard, hand, and library for a card named The Animus and put it onto the battlefield, then shuffle.\n{T}: Add {C}. When you do, mill two cards.",
             "colours": [
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "62814d9c-45d6-564c-a9b9-1b76cfed9a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3293c01a-5b3d-4405-979c-726c0a6b0e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3293c01a-5b3d-4405-979c-726c0a6b0e97.jpg?1",
             "name": "Shay Cormac",
             "text": "{1}: Permanents your opponents control lose hexproof, indestructible, protection, shroud, and ward until end of turn.\nWhenever a creature an opponent controls becomes the target of a spell or ability you control, put a bounty counter on that creature.\nWhenever a creature with a bounty counter on it dies, put two +1/+1 counters on Shay Cormac.",
             "colours": [
@@ -9415,7 +9415,7 @@
         },
         {
             "id": "9ce0d1f4-f5cf-5a8d-819f-85748af59594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c62a9-65b7-4ad8-a276-568c2a3d8cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c62a9-65b7-4ad8-a276-568c2a3d8cff.jpg?1",
             "name": "Sigurd, Jarl of Ravensthorpe",
             "text": "Vigilance, trample, lifelink\nBoast \u2014 {1}: Put a lore counter on target Saga you control or remove one from it.\nWhenever you put a lore counter on a Saga you control, put a +1/+1 counter on up to one other target creature.",
             "colours": [
@@ -9458,7 +9458,7 @@
         },
         {
             "id": "d75eb381-e3e5-5b59-89ea-5fb9abb04a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b54844c-f757-426c-8d4b-5636673cb87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b54844c-f757-426c-8d4b-5636673cb87a.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "Defender\nSokrates, Athenian Teacher has hexproof as long as it's untapped.\nSokratic Dialogue \u2014 {T}: Until end of turn, target creature gains \"If this creature would deal combat damage to a player, prevent that damage. This creature's controller and that player each draw half that many cards, rounded down.\"",
             "colours": [
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "4f2704ed-b629-50c1-9f60-6dad08a35fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d640f44-7521-4e36-ba27-cb1c94507d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d640f44-7521-4e36-ba27-cb1c94507d0e.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "29c3a43d-5d6b-543a-a7e4-03b4d7222ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42de1eb-0d5a-406d-ab09-2913d59b9788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42de1eb-0d5a-406d-ab09-2913d59b9788.jpg?1",
             "name": "Adrestia",
             "text": "Islandwalk\nWhenever Adrestia attacks, if an Assassin crewed it this turn, draw a card. Adrestia becomes an Assassin in addition to its other types until end of turn.\nCrew 1",
             "colours": [],
@@ -9568,7 +9568,7 @@
         },
         {
             "id": "081906d3-3a5a-5a14-85f0-073e461d3bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a84bf5-bb15-4a6e-b4c7-7218967b33f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a84bf5-bb15-4a6e-b4c7-7218967b33f2.jpg?1",
             "name": "The Animus",
             "text": "At the beginning of your end step, exile up to one target legendary creature card from a graveyard with a memory counter on it.\n{T}: Until your next turn, target legendary creature you control becomes a copy of target creature card in exile with a memory counter on it. Activate only as a sorcery.",
             "colours": [],
@@ -9600,7 +9600,7 @@
         },
         {
             "id": "a81ebf5f-5682-519a-9b3b-7b27f916a144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f7995-1817-46e9-93ba-6f10051d3865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f7995-1817-46e9-93ba-6f10051d3865.jpg?1",
             "name": "Apple of Eden, Isu Relic",
             "text": "{T}, Pay 4 life, Sacrifice Apple of Eden: Look at target opponent's hand and exile those cards face down. You may play those cards this turn, and mana of any type can be spent to cast them. Until end of turn, whenever you play a land or cast a spell this way, its owner draws a card. At the beginning of the next end step, return the exiled cards to their owner's hand. Activate only as a sorcery.",
             "colours": [],
@@ -9632,7 +9632,7 @@
         },
         {
             "id": "8821299f-2a47-5d6c-af04-008ec09956a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2e512d-0aa2-4a1e-82cc-8ed60129bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2e512d-0aa2-4a1e-82cc-8ed60129bf5e.jpg?1",
             "name": "Brotherhood Regalia",
             "text": "Equipped creature has ward {2}, is an Assassin in addition to its other types, and can't be blocked.\nEquip legendary creature {1}\nEquip {3}",
             "colours": [],
@@ -9663,7 +9663,7 @@
         },
         {
             "id": "2537bd68-d651-5c0d-8595-e023ef491fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e357b2d-a3c1-490e-a37c-cdf42abcfa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e357b2d-a3c1-490e-a37c-cdf42abcfa60.jpg?1",
             "name": "Excalibur, Sword of Eden",
             "text": "This spell costs {X} less to cast, where X is the total mana value of historic permanents you control.\nEquipped creature gets +10/+0 and has vigilance.\nEquip legendary creature {2}",
             "colours": [],
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "7140383c-9942-54aa-99aa-dff7c10054a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5986796-08a5-4bbb-992e-5fb8cdf2864a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5986796-08a5-4bbb-992e-5fb8cdf2864a.jpg?1",
             "name": "Hidden Blade",
             "text": "Flash\nWhen Hidden Blade enters the battlefield, attach it to target creature you control. If that creature is an Assassin, it gains deathtouch until end of turn.\nEquipped creature gets +1/+0 and has first strike.\nEquip {2}",
             "colours": [],
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "e480cd0b-d129-5b41-acc6-4721c4253096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb2f71-f973-4565-9c24-dab21da80b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb2f71-f973-4565-9c24-dab21da80b14.jpg?1",
             "name": "Mj\u00f6lnir, Storm Hammer",
             "text": "When Mj\u00f6lnir enters the battlefield, attach it to target legendary creature you control.\nWhenever equipped creature attacks, tap target creature defending player controls and put a stun counter on it. Then Mj\u00f6lnir deals damage to each opponent equal to the number of tapped creatures that opponent controls.\nEquip {4}",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "72cd52ba-6979-5da8-a0db-b0459a107a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd57bdd4-9b93-4a0c-8c80-46bc02af9a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd57bdd4-9b93-4a0c-8c80-46bc02af9a3c.jpg?1",
             "name": "Smoke Bomb",
             "text": "Flash\nAll creatures have shroud.\nAt the beginning of your upkeep, sacrifice Smoke Bomb. When you do, target creature you control can't be blocked this turn.",
             "colours": [],
@@ -9792,7 +9792,7 @@
         },
         {
             "id": "e00c737a-9769-5a25-a420-7184c4c1e0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63c09d-2898-4ebb-b88e-b5962d427abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63c09d-2898-4ebb-b88e-b5962d427abc.jpg?1",
             "name": "Staff of Eden, Vault's Key",
             "text": "When Staff of Eden, Vault's Key enters the battlefield, put target legendary permanent card not named Staff of Eden, Vault's Key from a graveyard onto the battlefield under your control.\n{T}: Draw a card for each permanent you control but don't own.",
             "colours": [],
@@ -9824,7 +9824,7 @@
         },
         {
             "id": "1562c3ca-83bb-525f-920c-4c4361fe4ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c187b0-f196-4180-bbe0-d7f470974880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c187b0-f196-4180-bbe0-d7f470974880.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -9856,7 +9856,7 @@
         },
         {
             "id": "39203528-aa58-5cf1-bc12-cb37a08f014d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef2d91d-97fc-4523-8471-511e6376ce64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef2d91d-97fc-4523-8471-511e6376ce64.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -9888,7 +9888,7 @@
         },
         {
             "id": "d9224ee7-da7a-5b95-ad6d-9afb901f974d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e84b05-15fe-4335-a5fd-a26d1905f313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e84b05-15fe-4335-a5fd-a26d1905f313.jpg?1",
             "name": "Towering Viewpoint",
             "text": "Defender, reach\nLeap of Faith \u2014 {3}: Target creature gains flying until end of turn.",
             "colours": [],
@@ -9920,7 +9920,7 @@
         },
         {
             "id": "5b7355f0-b82b-56cb-91ee-02d28de637e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef1c0fa-590b-437e-992c-811577e14e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef1c0fa-590b-437e-992c-811577e14e58.jpg?1",
             "name": "Yggdrasil, Rebirth Engine",
             "text": "When Yggdrasil, Rebirth Engine enters the battlefield, exile all creature cards from your graveyard.\n{T}: Exile the top three cards of your library.\n{4}, {T}: Put a creature card exiled with Yggdrasil onto the battlefield under your control. It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "4e40f59b-b1c7-5c1b-800a-757390c28071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9f47d4-44fc-4278-8cc8-8914e9a9e565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9f47d4-44fc-4278-8cc8-8914e9a9e565.jpg?1",
             "name": "Abstergo Entertainment",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{3}, {T}, Exile Abstergo Entertainment: Return up to one target historic card from your graveyard to your hand, then exile all graveyards.",
             "colours": [],
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "8fd3ab39-e1e4-52b0-a79e-c1921304e2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e43b4-2208-4df0-a8b2-380cfd22dde5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e43b4-2208-4df0-a8b2-380cfd22dde5.jpg?1",
             "name": "Brotherhood Headquarters",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast an Assassin spell or a spell that has freerunning, or to activate an ability of an Assassin source.",
             "colours": [],
@@ -10013,7 +10013,7 @@
         },
         {
             "id": "52ee09de-468a-5a6b-8cdb-e96498e7c0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282a9380-01a1-4fc6-bcd4-2c8543a75eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282a9380-01a1-4fc6-bcd4-2c8543a75eba.jpg?1",
             "name": "Ezio Auditore da Firenze",
             "text": "",
             "colours": [
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "c484ba92-cf15-568f-98fa-c40886b209d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f92d7b6-58c8-485c-86ff-d63f1d3dd481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f92d7b6-58c8-485c-86ff-d63f1d3dd481.jpg?1",
             "name": "Alta\u00efr Ibn-La'Ahad",
             "text": "",
             "colours": [
@@ -10102,7 +10102,7 @@
         },
         {
             "id": "3646421f-71bf-5ec4-b3f1-3064772bd4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f4e4d-e3ed-483f-b9af-2f4072524742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f4e4d-e3ed-483f-b9af-2f4072524742.jpg?1",
             "name": "Edward Kenway",
             "text": "",
             "colours": [
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "936baacb-9eb5-50a2-acf6-51c378601611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fcb189-1a34-4bf5-8bde-3846eec88172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fcb189-1a34-4bf5-8bde-3846eec88172.jpg?1",
             "name": "Eivor, Wolf-Kissed",
             "text": "",
             "colours": [
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "c9747c67-1734-5ab2-b742-2d5980403c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f053676-de35-4465-b3b2-ce6050055e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f053676-de35-4465-b3b2-ce6050055e85.jpg?1",
             "name": "Kassandra, Eagle Bearer",
             "text": "",
             "colours": [
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "aba94376-4071-51d9-a063-f407ac03e016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2036b2e-89d6-448a-bfcb-50b2247ee17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2036b2e-89d6-448a-bfcb-50b2247ee17a.jpg?1",
             "name": "Cleopatra, Exiled Pharaoh",
             "text": "",
             "colours": [
@@ -10277,7 +10277,7 @@
         },
         {
             "id": "3c389f9c-e459-5b16-87b5-d51644f05b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a5db83-0098-4e2b-bf23-146e88b9cca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a5db83-0098-4e2b-bf23-146e88b9cca9.jpg?1",
             "name": "Sokrates, Athenian Teacher",
             "text": "",
             "colours": [
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "d921ca62-c66b-5133-a74b-9240bbff9a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4242961d-87e8-4dd2-bdea-5d765a5cf136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4242961d-87e8-4dd2-bdea-5d765a5cf136.jpg?1",
             "name": "Eivor, Battle-Ready",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nHaste (This creature can attack as soon as it comes under your control.)\nWhenever Eivor, Battle-Ready attacks, it deals damage equal to the number of Equipment you control to each opponent.",
             "colours": [
@@ -10358,7 +10358,7 @@
         },
         {
             "id": "05acdbd7-bed4-55c2-8bff-3e56d74ef76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdc8019-9b5e-4d9a-a09b-2a14f41ddfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdc8019-9b5e-4d9a-a09b-2a14f41ddfe1.jpg?1",
             "name": "Ezio, Blade of Vengeance",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever an Assassin you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -10396,7 +10396,7 @@
         },
         {
             "id": "5e62a0e8-e94f-54ad-9bab-87e6afb62ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cf2cd1-f7b3-4a23-a23a-6eb0af5451cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cf2cd1-f7b3-4a23-a23a-6eb0af5451cf.jpg?1",
             "name": "Battlefield Improvisation",
             "text": "Target creature gets +2/+2 until end of turn. If that creature is attacking, you may attach any number of Equipment you control to it.",
             "colours": [
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "30d659fd-5603-591d-9979-e724561a33f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe06e87f-8915-4fc2-81fd-168a371dc407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe06e87f-8915-4fc2-81fd-168a371dc407.jpg?1",
             "name": "Detained by Legionnaires",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -10460,7 +10460,7 @@
         },
         {
             "id": "f04f0cf2-8e4e-52f7-a9aa-ceb6269a1763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c9e60-fc14-48fe-bca9-b74f82301835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c9e60-fc14-48fe-bca9-b74f82301835.jpg?1",
             "name": "Escarpment Fortress",
             "text": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)\nOther creatures you control get +1/+0.\nWhenever you attack with two or more creatures, draw a card.",
             "colours": [
@@ -10493,7 +10493,7 @@
         },
         {
             "id": "130e7e0b-2ca6-5245-91ab-36a677802e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda99319-9312-42c4-adc0-77b49768d014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda99319-9312-42c4-adc0-77b49768d014.jpg?1",
             "name": "Keen-Eyed Raven",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Keen-Eyed Raven enters the battlefield, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -10526,7 +10526,7 @@
         },
         {
             "id": "fd9801ef-2774-5745-9c99-3752d2990dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301310b3-c031-4fd3-a47e-9645b6177329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301310b3-c031-4fd3-a47e-9645b6177329.jpg?1",
             "name": "Settlement Blacksmith",
             "text": "When Settlement Blacksmith enters the battlefield, if you control an Equipment, draw a card.",
             "colours": [
@@ -10560,7 +10560,7 @@
         },
         {
             "id": "fce9a5eb-e510-56bd-9408-84906d7879fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef45be55-42d7-475c-b405-78e856530277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef45be55-42d7-475c-b405-78e856530277.jpg?1",
             "name": "Assassin Den",
             "text": "Defender (This creature can't attack.)\n{3}{U}: Put a +1/+1 counter on target creature you control. It can't be blocked this turn. Activate only as a sorcery.",
             "colours": [
@@ -10593,7 +10593,7 @@
         },
         {
             "id": "6f2063a0-3b72-522c-80c8-b362be13aa13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0157325c-b064-4c0a-9b5d-ecdf0ed15d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0157325c-b064-4c0a-9b5d-ecdf0ed15d9c.jpg?1",
             "name": "Brotherhood Spy",
             "text": "At the beginning of combat on your turn, if you control a legendary Assassin, Brotherhood Spy gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -10627,7 +10627,7 @@
         },
         {
             "id": "f5c72d3c-bb9c-55ee-9014-041eb0bf417e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551d1f1e-8bc0-4196-8998-0aa7db23b388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551d1f1e-8bc0-4196-8998-0aa7db23b388.jpg?1",
             "name": "Hookblade Veteran",
             "text": "As long as it's your turn, Hookblade Veteran has flying. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "3cc8fd5e-3326-5a2e-a265-974c2e6a638a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ad4bd6-c6a5-420f-8491-7696f9850a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ad4bd6-c6a5-420f-8491-7696f9850a05.jpg?1",
             "name": "Tranquilize",
             "text": "Tap target creature an opponent controls and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "126bd3d0-2ca2-53b2-b4df-38068c7d4782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef922e-81b4-47e6-bd37-8ec0cb29700a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef922e-81b4-47e6-bd37-8ec0cb29700a.jpg?1",
             "name": "Brotherhood Ambushers",
             "text": "Freerunning {3}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)",
             "colours": [
@@ -10726,7 +10726,7 @@
         },
         {
             "id": "55855d9a-9530-5433-bca9-5c6495247075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b79ee23-d917-48f3-b014-d513f1c5ff54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b79ee23-d917-48f3-b014-d513f1c5ff54.jpg?1",
             "name": "Brotherhood Patriarch",
             "text": "When Brotherhood Patriarch dies, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -10760,7 +10760,7 @@
         },
         {
             "id": "bb207ae4-a434-5dd6-8fb6-85a3f1224b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb19a35-7224-4fe2-a0c0-17b93d2837ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb19a35-7224-4fe2-a0c0-17b93d2837ad.jpg?1",
             "name": "Merciless Harlequin",
             "text": "Freerunning {1}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nWhen Merciless Harlequin enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -10794,7 +10794,7 @@
         },
         {
             "id": "4749c4cd-9a7f-54aa-9ae9-8ec3b4a639da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3efb96a-a722-493a-be0e-a64583f8c3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3efb96a-a722-493a-be0e-a64583f8c3df.jpg?1",
             "name": "Poison-Blade Mentor",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Poison-Blade Mentor attacks, another target Assassin you control gains deathtouch until end of turn.",
             "colours": [
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "a91d1445-90f7-562b-a285-0a5249e52f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbf2a-46d5-4371-b4eb-a8dbebe18dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbf2a-46d5-4371-b4eb-a8dbebe18dcc.jpg?1",
             "name": "Headsplitter",
             "text": "When Headsplitter enters the battlefield, create a 1/1 black Assassin creature token with menace, then attach Headsplitter to it.\nEquipped creature gets +1/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -10861,7 +10861,7 @@
         },
         {
             "id": "630d2b52-7fe4-55a8-9e5e-df80eb51288a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc770fd-d513-420b-94f8-f2d28d8ed8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc770fd-d513-420b-94f8-f2d28d8ed8d1.jpg?1",
             "name": "Labyrinth Adversary",
             "text": "Trample (This creature can deal excess combat damage to the player it's attacking.)\nWhenever you attack, you may pay {1}{R}. When you do, target creature can't block this turn.",
             "colours": [
@@ -10894,7 +10894,7 @@
         },
         {
             "id": "6ad57373-188a-52f5-b352-fb7002f637e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34a45ab-793e-4198-8327-e13287e0b74c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34a45ab-793e-4198-8327-e13287e0b74c.jpg?1",
             "name": "Misthios's Fury",
             "text": "Misthios's Fury deals 3 damage to target creature. If you control an Equipment, Misthios's Fury also deals 2 damage to that creature's controller.",
             "colours": [
@@ -10925,7 +10925,7 @@
         },
         {
             "id": "791a866a-2585-5d98-8eb7-df759c7f4f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16fba05-25d7-4495-a9f6-cec6b3aabbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16fba05-25d7-4495-a9f6-cec6b3aabbbd.jpg?1",
             "name": "Spartan Veteran",
             "text": "As long as it's your turn, Spartan Veteran has first strike. (It deals combat damage before creatures without first strike.)\n{2}: Spartan Veteran gets +1/+0 until end of turn.",
             "colours": [
@@ -10959,7 +10959,7 @@
         },
         {
             "id": "e164db71-817b-5084-baf6-445ef8626fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be38985c-f7a9-4885-9035-09390b4b754a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be38985c-f7a9-4885-9035-09390b4b754a.jpg?1",
             "name": "Surtr, Fiery J\u00f6tun",
             "text": "Trample (This creature can deal excess combat damage to the player it's attacking.)\nWhenever you cast a historic spell, Surtr, Fiery J\u00f6tun deals 3 damage to any target. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -10996,7 +10996,7 @@
         },
         {
             "id": "46eb0998-287a-541b-bd7f-72218e46baa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ead24c-dd4a-40cd-839e-de08017a7c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ead24c-dd4a-40cd-839e-de08017a7c29.jpg?1",
             "name": "Achilles Davenport",
             "text": "Freerunning {U}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nMenace (This creature can't be blocked except by two or more creatures.)\nOther Assassins you control get +1/+1.",
             "colours": [
@@ -11034,7 +11034,7 @@
         },
         {
             "id": "d87b7f60-2895-5f42-8a78-ad99ea555344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7426f3dc-385b-42ea-85cb-853e6035ca6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7426f3dc-385b-42ea-85cb-853e6035ca6f.jpg?1",
             "name": "Auditore Ambush",
             "text": "Choose one or both \u2014\n\u2022 Return target creature to its owner's hand.\n\u2022 Target player searches their library and/or graveyard for a card named Ezio, Blade of Vengeance, reveals it, and puts it into their hand. If they search their library this way, they shuffle.",
             "colours": [
@@ -11067,7 +11067,7 @@
         },
         {
             "id": "35eb64ff-95a9-55b8-83db-e33adbf8ea46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58766566-6e19-4f74-bfce-5a61429ffaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58766566-6e19-4f74-bfce-5a61429ffaa9.jpg?1",
             "name": "Bureau Headmaster",
             "text": "Equipment spells you cast cost {1} less to cast.\nEquip abilities you activate cost {1} less to activate.",
             "colours": [
@@ -11103,7 +11103,7 @@
         },
         {
             "id": "0106a121-4fea-501f-a115-fea4e027534e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01de51d1-bbea-407c-b19e-dfef7fce1510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01de51d1-bbea-407c-b19e-dfef7fce1510.jpg?1",
             "name": "Raven Clan War-Axe",
             "text": "When Raven Clan War-Axe enters the battlefield, you may search your library and/or graveyard for a card named Eivor, Battle-Ready, reveal it, and put it into your hand. If you search your library this way, shuffle.\nEquipped creature gets +2/+0 and has trample.\nEquip {2}",
             "colours": [
@@ -11138,7 +11138,7 @@
         },
         {
             "id": "b1542cb2-548b-5854-a049-0a4171928ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef0eb-5b11-49e8-b2b2-a9e0422f6e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef0eb-5b11-49e8-b2b2-a9e0422f6e65.jpg?1",
             "name": "Rooftop Bypass",
             "text": "Whenever one or more nontoken creatures you control deal combat damage to a player, create a 1/1 black Assassin creature token with menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "51e8cfb8-e8e2-5a4f-b1df-66d9ab9ecaeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac703b47-398c-42cd-8d30-99c398cf734e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac703b47-398c-42cd-8d30-99c398cf734e.jpg?1",
             "name": "Hired Blade",
             "text": "Flash (You may cast this spell any time you could cast an instant.)",
             "colours": [
@@ -11205,7 +11205,7 @@
         },
         {
             "id": "ac8d7020-32a7-57c4-9e88-6d0e2df9a75a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e66e29-ef63-4faa-b60f-8a128800e093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e66e29-ef63-4faa-b60f-8a128800e093.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11235,7 +11235,7 @@
         },
         {
             "id": "5c5563e2-bf21-5e24-b108-070c5e4d266a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f04f32-f672-443a-86c0-63f5f4747c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f04f32-f672-443a-86c0-63f5f4747c67.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11265,7 +11265,7 @@
         },
         {
             "id": "7b39bb1f-fbce-51f3-9404-f3b1198b9d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3df51a-d173-44c8-9630-4652630cc544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3df51a-d173-44c8-9630-4652630cc544.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11301,7 +11301,7 @@
         },
         {
             "id": "b47c160c-6a16-5ede-a9cf-21969fe48b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dbf10c-a813-4f76-9066-b3cdd9cfd5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dbf10c-a813-4f76-9066-b3cdd9cfd5d4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11337,7 +11337,7 @@
         },
         {
             "id": "7ecd9dac-93b0-5970-b617-6637d290c912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36aaa8d9-4b03-4dd2-9b3c-d8b3bf19da73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36aaa8d9-4b03-4dd2-9b3c-d8b3bf19da73.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11373,7 +11373,7 @@
         },
         {
             "id": "3783bb90-249d-5cc4-987f-90073cf3412e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b469d5fa-89c2-4e5e-9c1d-c3edb80f7b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b469d5fa-89c2-4e5e-9c1d-c3edb80f7b59.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11409,7 +11409,7 @@
         },
         {
             "id": "79b3b784-ab4f-558b-b076-a9a74d4debfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d9cde9-8937-4861-8eec-17a94e1602c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d9cde9-8937-4861-8eec-17a94e1602c7.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11447,7 +11447,7 @@
         },
         {
             "id": "950f2739-8761-5141-a790-fd29f83541c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2d197-48bf-4df1-bcd3-caf07339e383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e2d197-48bf-4df1-bcd3-caf07339e383.jpg?1",
             "name": "Hidden Blade",
             "text": "Flash\nWhen Hidden Blade enters the battlefield, attach it to target creature you control. If that creature is an Assassin, it gains deathtouch until end of turn.\nEquipped creature gets +1/+0 and has first strike.\nEquip {2}",
             "colours": [],
@@ -11479,7 +11479,7 @@
         },
         {
             "id": "35d765d0-3113-5bc3-b38c-e3ca22b91300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31d4312-08cd-4f1e-9d8f-72cbe4abb285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31d4312-08cd-4f1e-9d8f-72cbe4abb285.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -11507,7 +11507,7 @@
         },
         {
             "id": "b8a61b58-bb26-509f-b7c8-9630d88432ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20ad1e6-d698-4a0a-8ed5-903e1d463004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20ad1e6-d698-4a0a-8ed5-903e1d463004.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -11538,7 +11538,7 @@
         },
         {
             "id": "2f673f4d-2464-52f6-9d47-acc9143eac7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05946b39-0b54-4f63-b521-4d5deb238541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05946b39-0b54-4f63-b521-4d5deb238541.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "9d84f8de-71d4-53d2-a181-97cec6d4f132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cb2062-86f0-4ce3-b5fb-d3c310f36ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cb2062-86f0-4ce3-b5fb-d3c310f36ec3.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -11609,7 +11609,7 @@
         },
         {
             "id": "d34384d2-c8cc-578e-9af7-29d2b2407858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447bd736-6b47-440c-86ed-db54bd655274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447bd736-6b47-440c-86ed-db54bd655274.jpg?1",
             "name": "Phobos",
             "text": "",
             "colours": [
@@ -11646,7 +11646,7 @@
         },
         {
             "id": "8988fa56-4617-5970-b299-76994fefa25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536a82d3-f5e2-46b7-969e-84683f937b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536a82d3-f5e2-46b7-969e-84683f937b38.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -11677,7 +11677,7 @@
         },
         {
             "id": "7a5976fa-5339-58e6-bd9b-623bc67d2544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05402b51-8cf9-4f69-aa12-8a9d5981f8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05402b51-8cf9-4f69-aa12-8a9d5981f8b1.jpg?1",
             "name": "The Capitoline Triad Emblem",
             "text": "",
             "colours": [],
@@ -11705,7 +11705,7 @@
         },
         {
             "id": "786e800f-ce0f-50d5-b942-c99bc8430f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76a6163-6fd9-4cdf-9b14-07f75c2f0fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76a6163-6fd9-4cdf-9b14-07f75c2f0fa1.jpg?1",
             "name": "A Mysterious Creature",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/AER.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/AER.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "83d72830-8e68-5d6c-a8b7-69d8ff0e7d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89cab47-25fb-49ea-bb43-90a0089b6b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89cab47-25fb-49ea-bb43-90a0089b6b20.jpg?1",
             "name": "Aerial Modification",
             "text": "Enchant creature or Vehicle\nAs long as enchanted permanent is a Vehicle, it's a creature in addition to its other types.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "97ab0c37-14e0-542a-adcc-fb1cbfd6f19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff15c06c-160d-4960-92d5-6f8e7b33f051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff15c06c-160d-4960-92d5-6f8e7b33f051.jpg?1",
             "name": "Aeronaut Admiral",
             "text": "Flying\nVehicles you control have flying.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "a24b9a7a-bc77-5a5e-a0cf-2bbddd89361e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dcbe97-d582-464e-98e7-dd06d8652606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dcbe97-d582-464e-98e7-dd06d8652606.jpg?1",
             "name": "Aether Inspector",
             "text": "Vigilance\nWhen Aether Inspector enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Inspector attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "b3cc53e5-e841-5766-810e-f9f71877cffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bb3abd-ebaf-4dc2-97eb-ed4a2b005177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bb3abd-ebaf-4dc2-97eb-ed4a2b005177.jpg?1",
             "name": "Aethergeode Miner",
             "text": "Whenever Aethergeode Miner attacks, you get {E}{E} (two energy counters).\nPay {E}{E}: Exile Aethergeode Miner, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "576ad40f-7821-5632-bb10-1d089cf88cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49827a57-cf10-4a44-a1fd-ac611da39dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49827a57-cf10-4a44-a1fd-ac611da39dc9.jpg?1",
             "name": "Airdrop Aeronauts",
             "text": "Flying\nRevolt \u2014 When Airdrop Aeronauts enters the battlefield, if a permanent you controlled left the battlefield this turn, you gain 5 life.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "91d3b1ee-0a95-5556-a7c5-a94f8b69f76a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc10173d-25ff-4734-b8f2-84f94fe52b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc10173d-25ff-4734-b8f2-84f94fe52b17.jpg?1",
             "name": "Alley Evasion",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+2 until end of turn.\n\u2022 Return target creature you control to its owner's hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "16ec2ade-7f83-578f-a1f1-c1f418d44e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a348bb-cdc5-4e2a-933f-21f91faab891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a348bb-cdc5-4e2a-933f-21f91faab891.jpg?1",
             "name": "Audacious Infiltrator",
             "text": "Audacious Infiltrator can't be blocked by artifact creatures.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "deacc32c-f796-517f-8167-a70237e8f4cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b9c0f7-d49b-4d74-9038-44954054ce21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b9c0f7-d49b-4d74-9038-44954054ce21.jpg?1",
             "name": "Bastion Enforcer",
             "text": "",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "3ae5d1d7-08a7-5b4c-a78f-ee0dfeb3dcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeca4557-98aa-433b-a3ee-050e4a3e6d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeca4557-98aa-433b-a3ee-050e4a3e6d88.jpg?1",
             "name": "Call for Unity",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a unity counter on Call for Unity.\nCreatures you control get +1/+1 for each unity counter on Call for Unity.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "9821480d-37a7-5ee5-9cc3-385cd3f6f41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5bea27-d825-4691-8ae0-c4831574ec53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5bea27-d825-4691-8ae0-c4831574ec53.jpg?1",
             "name": "Caught in the Brights",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen a Vehicle you control attacks, exile enchanted creature.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "95c70089-9408-5fba-b498-a72655ba3561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb7a26-fbf0-4b91-847b-cfc46e01a342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb7a26-fbf0-4b91-847b-cfc46e01a342.jpg?1",
             "name": "Consulate Crackdown",
             "text": "When Consulate Crackdown enters the battlefield, exile all artifacts your opponents control until Consulate Crackdown leaves the battlefield.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "1827ebd4-bb59-5bea-bde7-68bf12dcb7f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f805e97-c28b-4780-b204-74514c0c47d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f805e97-c28b-4780-b204-74514c0c47d2.jpg?1",
             "name": "Conviction",
             "text": "Enchant creature\nEnchanted creature gets +1/+3.\n{W}: Return Conviction to its owner's hand.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "26a44e5b-ba2a-54c8-b033-79b6d48d50f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d6f334-0040-42b1-9c72-362e4dcaa65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d6f334-0040-42b1-9c72-362e4dcaa65e.jpg?1",
             "name": "Countless Gears Renegade",
             "text": "Revolt \u2014 When Countless Gears Renegade enters the battlefield, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "e0982339-8666-5af8-9e59-799dc635c8cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7113ddc-cb3c-46da-a6c7-2567bd0affa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7113ddc-cb3c-46da-a6c7-2567bd0affa9.jpg?1",
             "name": "Dawnfeather Eagle",
             "text": "Flying\nWhen Dawnfeather Eagle enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "e8590620-0370-5e57-afb1-b965fca731d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccd6864-1404-43c2-aa59-ccc8b3529a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccd6864-1404-43c2-aa59-ccc8b3529a62.jpg?1",
             "name": "Dawnfeather Eagle",
             "text": "",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "51765bb0-0fc2-5c10-aeb3-94198e7aef0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018decf-25e1-45fc-be7d-2523dcfb7a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018decf-25e1-45fc-be7d-2523dcfb7a4c.jpg?1",
             "name": "Deadeye Harpooner",
             "text": "Revolt \u2014 When Deadeye Harpooner enters the battlefield, if a permanent you controlled left the battlefield this turn, destroy target tapped creature an opponent controls.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "89dc417b-c18b-5490-9448-e80426fb1827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cca66e9-be21-4fc7-8951-cd99e9b213dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cca66e9-be21-4fc7-8951-cd99e9b213dc.jpg?1",
             "name": "Decommission",
             "text": "Destroy target artifact or enchantment.\nRevolt \u2014 If a permanent you controlled left the battlefield this turn, you gain 3 life.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "85d602a8-8ac7-539d-978a-c97b01cf4d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb26d5b-ffeb-4dac-ad61-f85e5e7b1675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb26d5b-ffeb-4dac-ad61-f85e5e7b1675.jpg?1",
             "name": "Deft Dismissal",
             "text": "Deft Dismissal deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "5c1eb6b6-410b-56fb-99be-27d49cc61662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04018c9-510c-4610-9daa-677434628805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04018c9-510c-4610-9daa-677434628805.jpg?1",
             "name": "Exquisite Archangel",
             "text": "Flying\nIf you would lose the game, instead exile Exquisite Archangel and your life total becomes equal to your starting life total.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "482f8766-a32d-597e-b36d-1a471dcc1912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bdbed8-5d21-4bf5-8a32-9623b1139c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bdbed8-5d21-4bf5-8a32-9623b1139c85.jpg?1",
             "name": "Felidar Guardian",
             "text": "When Felidar Guardian enters the battlefield, you may exile another target permanent you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "4026b5c8-38dd-51b3-9179-279ebb71f485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2186f382-2d68-4191-b490-a072f49eaabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2186f382-2d68-4191-b490-a072f49eaabf.jpg?1",
             "name": "Ghirapur Osprey",
             "text": "Flying",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "9d917b2e-a5ba-5152-b46b-18bb62cd363e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63682db3-1a56-4d8e-a9b7-04465a577518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63682db3-1a56-4d8e-a9b7-04465a577518.jpg?1",
             "name": "Restoration Specialist",
             "text": "{W}, Sacrifice Restoration Specialist: Return up to one target artifact card and up to one target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "b0a5baa5-d847-5b67-ac23-2082bdfeadcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5990c2f1-94d7-4d2e-b1ad-6406c25b91aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5990c2f1-94d7-4d2e-b1ad-6406c25b91aa.jpg?1",
             "name": "Solemn Recruit",
             "text": "Double strike\nRevolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on Solemn Recruit.",
             "colours": [
@@ -790,7 +790,7 @@
         },
         {
             "id": "b70763ed-0964-50e2-ac75-8063f4895e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b323e2c-59dd-4d70-9a48-b10f807bb818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b323e2c-59dd-4d70-9a48-b10f807bb818.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
             "colours": [
@@ -827,7 +827,7 @@
         },
         {
             "id": "7443dc50-ea28-5931-b6b0-e1ce2d45248a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6d47b0-4c19-4c19-9e21-54cd87a5e34d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6d47b0-4c19-4c19-9e21-54cd87a5e34d.jpg?1",
             "name": "Sram's Expertise",
             "text": "Create three 1/1 colorless Servo artifact creature tokens.\nYou may cast a card with converted mana cost 3 or less from your hand without paying its mana cost.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "0372c930-c948-531c-a2a6-8e8bb11768fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e738cb-e4ea-41c2-99a1-55b6167eccb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e738cb-e4ea-41c2-99a1-55b6167eccb0.jpg?1",
             "name": "Thopter Arrest",
             "text": "When Thopter Arrest enters the battlefield, exile target artifact or creature an opponent controls until Thopter Arrest leaves the battlefield.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "76bf628b-13ec-5914-91ff-8ceb2ee70cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c34dbe3-3a66-40b3-a5c2-c2d6acb47773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c34dbe3-3a66-40b3-a5c2-c2d6acb47773.jpg?1",
             "name": "Aether Swooper",
             "text": "Flying\nWhen Aether Swooper enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Swooper attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "8edddeca-a7d4-51cf-9244-467f93eb0f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38722c25-13a7-47af-a4cd-90722f289499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38722c25-13a7-47af-a4cd-90722f289499.jpg?1",
             "name": "Aethertide Whale",
             "text": "Flying\nWhen Aethertide Whale enters the battlefield, you get {E}{E}{E}{E}{E}{E} (six energy counters).\nPay {E}{E}{E}{E}: Return Aethertide Whale to its owner's hand.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "0730e14e-7a5d-57de-a9fb-f6b761376a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e16d94-1166-4050-8554-686e153a7f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e16d94-1166-4050-8554-686e153a7f80.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "6077079d-260a-5c32-8a9d-204f3be27497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d273f5b7-b3a3-485a-acc8-34e10a504646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d273f5b7-b3a3-485a-acc8-34e10a504646.jpg?1",
             "name": "Baral's Expertise",
             "text": "Return up to three target artifacts and/or creatures to their owners' hands.\nYou may cast a card with converted mana cost 4 or less from your hand without paying its mana cost.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "aa4a672f-942b-5811-9c0b-c42994ddc15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856f804d-0213-4b86-bc6a-6a0a1147c4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856f804d-0213-4b86-bc6a-6a0a1147c4f9.jpg?1",
             "name": "Bastion Inventor",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "a6a473d2-b12e-50df-a99a-667a20d8ade2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f05814-a5a5-460f-9d29-0ab03efecf4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f05814-a5a5-460f-9d29-0ab03efecf4c.jpg?1",
             "name": "Disallow",
             "text": "Counter target spell, activated ability, or triggered ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "912f8708-c8fb-58a0-9585-6016a4789628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d93a915-ffea-4f50-88ac-2b3253f7dfdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d93a915-ffea-4f50-88ac-2b3253f7dfdf.jpg?1",
             "name": "Dispersal Technician",
             "text": "When Dispersal Technician enters the battlefield, you may return target artifact to its owner's hand.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "9c785fb7-9080-598e-afe8-1c36bdc6e2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfbe1d5-beb7-49b8-a504-f1cc47ee4731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfbe1d5-beb7-49b8-a504-f1cc47ee4731.jpg?1",
             "name": "Efficient Construction",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "c6aa7290-e9af-585a-a1b0-6e790acfaaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418448d0-3e8d-4581-b598-696165775d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418448d0-3e8d-4581-b598-696165775d23.jpg?1",
             "name": "Hinterland Drake",
             "text": "Flying\nHinterland Drake can't block artifact creatures.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "11ca36b9-658f-5f73-8162-dc12b53fed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01d2835-060c-4ac3-b586-84811878a64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01d2835-060c-4ac3-b586-84811878a64d.jpg?1",
             "name": "Ice Over",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "79a4cb21-9197-59b2-a99a-b33b180b7d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eede83-6f1b-4054-b01c-0da17b197bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eede83-6f1b-4054-b01c-0da17b197bad.jpg?1",
             "name": "Illusionist's Stratagem",
             "text": "Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.\nDraw a card.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "e20ef810-082c-522e-9df1-4293ba013ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c01bd77-beb0-4a26-858d-022311e550bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c01bd77-beb0-4a26-858d-022311e550bf.jpg?1",
             "name": "Leave in the Dust",
             "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "9a18d69c-59c3-5d55-a9b6-cc0e7eedaaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235dd8f1-215a-4b0a-9e94-0d0d5a3c730b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235dd8f1-215a-4b0a-9e94-0d0d5a3c730b.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "5563f8ef-6989-5372-8a2c-06e2eb02ba7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f712ac26-dca4-459b-84c1-010597007f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f712ac26-dca4-459b-84c1-010597007f60.jpg?1",
             "name": "Metallic Rebuke",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "fc6d69aa-36bd-5e60-89cd-9d40d6f195b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb142515-0856-441d-84d4-9c9d450a86e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb142515-0856-441d-84d4-9c9d450a86e9.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "f9884ad2-0701-5c01-948b-0363e40c1767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f922e87-1744-4966-9e3a-54917f7f3d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f922e87-1744-4966-9e3a-54917f7f3d9e.jpg?1",
             "name": "Quicksmith Spy",
             "text": "When Quicksmith Spy enters the battlefield, target artifact you control gains \"{T}: Draw a card\" for as long as you control Quicksmith Spy.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "2705ce57-4edf-5a1b-83fc-87bb3b6f9b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56f8cca-6b8f-45ea-926f-161938716ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56f8cca-6b8f-45ea-926f-161938716ee9.jpg?1",
             "name": "Reverse Engineer",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "792f7587-0a70-5e6b-a906-c96d8a322469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480be626-cf37-410d-a9c7-e5464345085f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480be626-cf37-410d-a9c7-e5464345085f.jpg?1",
             "name": "Salvage Scuttler",
             "text": "Whenever Salvage Scuttler attacks, return an artifact you control to its owner's hand.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "e9411f46-db6b-5424-9d38-a8a2e3a075c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34be31b-eeb4-40e5-acf7-6cd0ba6d4bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34be31b-eeb4-40e5-acf7-6cd0ba6d4bcf.jpg?1",
             "name": "Shielded Aether Thief",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever Shielded Aether Thief blocks, you get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Draw a card.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "8f2f0414-ad17-5cd4-b099-cdb250ed1b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c6de3-4e09-40d9-afdb-89ff08e1844b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c6de3-4e09-40d9-afdb-89ff08e1844b.jpg?1",
             "name": "Shipwreck Moray",
             "text": "When Shipwreck Moray enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}: Shipwreck Moray gets +2/-2 until end of turn.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "95c429a6-cacf-5ebd-911c-7353cc5ee6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fedbc91-67e4-40d6-b307-7e6197f47c6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fedbc91-67e4-40d6-b307-7e6197f47c6e.jpg?1",
             "name": "Skyship Plunderer",
             "text": "Flying\nWhenever Skyship Plunderer deals combat damage to a player, for each kind of counter on target permanent or player, give that permanent or player another counter of that kind.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "b9a4ff4c-8d4a-524a-856b-54434337acf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b412718a-7bc7-4b16-af60-1b955c820b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b412718a-7bc7-4b16-af60-1b955c820b0f.jpg?1",
             "name": "Take into Custody",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "362b0a88-7c7a-53d7-b6e5-ab0331d2ce27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19754fe4-2f61-42a3-afa2-3a6a8257b81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19754fe4-2f61-42a3-afa2-3a6a8257b81b.jpg?1",
             "name": "Trophy Mage",
             "text": "When Trophy Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 3, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "28a0672e-1c94-5f14-8dcf-835a39e0a82e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279fd3c-9252-4958-9d7a-5f33aa25907e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279fd3c-9252-4958-9d7a-5f33aa25907e.jpg?1",
             "name": "Whir of Invention",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nSearch your library for an artifact card with converted mana cost X or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "f8fd0d59-a4d4-51ce-8ea2-fd31b651052a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfaa040-61fd-4705-a7ee-c67b49f740e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfaa040-61fd-4705-a7ee-c67b49f740e3.jpg?1",
             "name": "Wind-Kin Raiders",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFlying",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "842d7264-6b7c-5e50-8ea3-0d3e06dc3d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b217f1-1621-40d1-8a98-24c1f7cba800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b217f1-1621-40d1-8a98-24c1f7cba800.jpg?1",
             "name": "Aether Poisoner",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Aether Poisoner enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Poisoner attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "62cdb518-f3d5-55a6-a6c3-83c2aca18af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131d558-5f6b-448b-a378-1882e2d02bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131d558-5f6b-448b-a378-1882e2d02bd2.jpg?1",
             "name": "Alley Strangler",
             "text": "Menace",
             "colours": [
@@ -1804,7 +1804,7 @@
         },
         {
             "id": "24d3dea3-444a-5bbe-bc8d-733fd1d4a9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b97fa0-4c5b-4211-9c8d-99197dc20636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b97fa0-4c5b-4211-9c8d-99197dc20636.jpg?1",
             "name": "Alley Strangler",
             "text": "",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "999c088e-db4e-51b8-900a-1f04361904cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d8b644-4cca-451e-a46c-5237c13bf373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d8b644-4cca-451e-a46c-5237c13bf373.jpg?1",
             "name": "Battle at the Bridge",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nTarget creature gets -X/-X until end of turn. You gain X life.",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "f88c421a-1456-5ba0-9c67-d77a8383824e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c22e911-cf40-4ed8-b075-186f2b1393db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c22e911-cf40-4ed8-b075-186f2b1393db.jpg?1",
             "name": "Cruel Finality",
             "text": "Target creature gets -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "6aaf7352-c868-5594-8883-7b90f04ad793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6378898-50b7-47c9-8c25-dc660606be9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6378898-50b7-47c9-8c25-dc660606be9f.jpg?1",
             "name": "Daring Demolition",
             "text": "Destroy target creature or Vehicle.",
             "colours": [
@@ -1936,7 +1936,7 @@
         },
         {
             "id": "e52111bb-bd8e-53e4-99aa-984c8c9efc99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afbfb2c-3f1a-4ef9-9f61-6ca51af853d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afbfb2c-3f1a-4ef9-9f61-6ca51af853d8.jpg?1",
             "name": "Defiant Salvager",
             "text": "Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "5f7a211c-5ef9-54a5-8b70-4016f8783c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e81649-9954-424c-89d1-f87d73b66047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e81649-9954-424c-89d1-f87d73b66047.jpg?1",
             "name": "Fatal Push",
             "text": "Destroy target creature if it has converted mana cost 2 or less.\nRevolt \u2014 Destroy that creature if it has converted mana cost 4 or less instead if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "456b4e7c-fe5f-50e5-8814-4a69aa830c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ef4616-e3c2-4448-83b1-f7d439705eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ef4616-e3c2-4448-83b1-f7d439705eaf.jpg?1",
             "name": "Fen Hauler",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFen Hauler can't be blocked by artifact creatures.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "3206c375-bb45-5043-813b-24a2f436d022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dc7865-16ed-4d12-bdb4-d40fbdd48a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dc7865-16ed-4d12-bdb4-d40fbdd48a23.jpg?1",
             "name": "Foundry Hornet",
             "text": "Flying\nWhen Foundry Hornet enters the battlefield, if you control a creature with a +1/+1 counter on it, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2071,7 +2071,7 @@
         },
         {
             "id": "679b5c02-a328-567d-9e34-2b4c2aefbeff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73aaaa09-c985-42f8-b426-06fd3b8de66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73aaaa09-c985-42f8-b426-06fd3b8de66d.jpg?1",
             "name": "Fourth Bridge Prowler",
             "text": "When Fourth Bridge Prowler enters the battlefield, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -2106,7 +2106,7 @@
         },
         {
             "id": "79a81861-cc00-592a-add7-31182cf30c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abceb4fd-e3c5-400d-af7a-6dd17108a4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abceb4fd-e3c5-400d-af7a-6dd17108a4b4.jpg?1",
             "name": "Gifted Aetherborn",
             "text": "Deathtouch, lifelink",
             "colours": [
@@ -2141,7 +2141,7 @@
         },
         {
             "id": "401a0efa-e2cc-5804-80f7-bb158d9f3ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315976db-4cab-4393-8386-ce3b0ae3f490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315976db-4cab-4393-8386-ce3b0ae3f490.jpg?1",
             "name": "Glint-Sleeve Siphoner",
             "text": "Menace\nWhenever Glint-Sleeve Siphoner enters the battlefield or attacks, you get {E} (an energy counter).\nAt the beginning of your upkeep, you may pay {E}{E}. If you do, you draw a card and you lose 1 life.",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "ee7bc90f-d66e-5747-8141-1ed1176e5cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c97f5a9-6e04-45c3-aa8d-dcf0fd81d5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c97f5a9-6e04-45c3-aa8d-dcf0fd81d5b9.jpg?1",
             "name": "Gonti's Machinations",
             "text": "Whenever you lose life for the first time each turn, you get {E}. (You get an energy counter. Damage causes loss of life.)\nPay {E}{E}, Sacrifice Gonti's Machinations: Each opponent loses 3 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "6f943929-a257-5cb3-bbb4-5a62434dab28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a69ebe-4229-4067-8414-381b123fe63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a69ebe-4229-4067-8414-381b123fe63c.jpg?1",
             "name": "Herald of Anguish",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFlying\nAt the beginning of your end step, each opponent discards a card.\n{1}{B}, Sacrifice an artifact: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2242,7 +2242,7 @@
         },
         {
             "id": "6e139c36-628b-5459-a68f-2668a7435181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a5535b-b1d1-4648-aa72-4f64e9fcd95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a5535b-b1d1-4648-aa72-4f64e9fcd95d.jpg?1",
             "name": "Ironclad Revolutionary",
             "text": "When Ironclad Revolutionary enters the battlefield, you may sacrifice an artifact. If you do, put two +1/+1 counters on Ironclad Revolutionary and each opponent loses 2 life.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "4f04727b-4549-5b3e-ab3a-560a2acba291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2838c6dd-d816-4363-a861-f2f8052d1430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2838c6dd-d816-4363-a861-f2f8052d1430.jpg?1",
             "name": "Midnight Entourage",
             "text": "Other Aetherborn you control get +1/+1.\nWhenever Midnight Entourage or another Aetherborn you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "9e6fc9b4-d5bd-57fa-a166-47b74d4f4780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2637f860-01dd-4559-97b3-71c2e7cdbca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2637f860-01dd-4559-97b3-71c2e7cdbca4.jpg?1",
             "name": "Night Market Aeronaut",
             "text": "Flying\nRevolt \u2014 Night Market Aeronaut enters the battlefield with a +1/+1 counter on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "0c1f81d5-e61e-5299-a72e-015ae4679f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0edc708-0c76-4fcd-a175-d9c6f1ca3ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0edc708-0c76-4fcd-a175-d9c6f1ca3ac1.jpg?1",
             "name": "Perilous Predicament",
             "text": "Each opponent sacrifices an artifact creature and a nonartifact creature.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "c089c3a0-61a2-5a19-8c3e-1f056c263952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b0a5d5-99d7-492b-bd85-77c3cee12c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b0a5d5-99d7-492b-bd85-77c3cee12c8d.jpg?1",
             "name": "Renegade's Getaway",
             "text": "Target permanent gains indestructible until end of turn. Create a 1/1 colorless Servo artifact creature token. (Effects that say \"destroy\" don't destroy a permanent with indestructible, and if it's a creature, it can't be destroyed by damage.)",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "e8eeb39e-1b1e-5ec3-a2c1-55770fd6e5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f57d0b-ab6a-4074-885d-678659729b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f57d0b-ab6a-4074-885d-678659729b8a.jpg?1",
             "name": "Resourceful Return",
             "text": "Return target creature card from your graveyard to your hand. If you control an artifact, draw a card.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "29c679f5-7145-5ac5-b819-fefe8b7160a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b9f3e2-b5e8-4234-aaf3-5f1938a20c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b9f3e2-b5e8-4234-aaf3-5f1938a20c78.jpg?1",
             "name": "Secret Salvage",
             "text": "Exile target nonland card from your graveyard. Search your library for any number of cards with the same name as that card, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "6f61a7fe-78be-5fc4-ab31-b7a166f69ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d05324-6d85-40da-a087-b5822bc8f42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d05324-6d85-40da-a087-b5822bc8f42e.jpg?1",
             "name": "Sly Requisitioner",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nWhenever a nontoken artifact you control is put into a graveyard from the battlefield, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "f0e11711-4d28-5f0b-9b0b-17c328b05004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e34edfc-77fc-43b5-bad6-1c4c2a76c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e34edfc-77fc-43b5-bad6-1c4c2a76c8c3.jpg?1",
             "name": "Vengeful Rebel",
             "text": "Revolt \u2014 When Vengeful Rebel enters the battlefield, if a permanent you controlled left the battlefield this turn, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "7513c7d8-b727-58ae-afbc-eed3b09c8eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37e2466-57c3-453f-aebe-340995f2eca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37e2466-57c3-453f-aebe-340995f2eca7.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "10b75d6c-a45a-5ba1-89ce-bdb83b63abc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f28735-122c-45ba-bde5-decfd9b11b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f28735-122c-45ba-bde5-decfd9b11b32.jpg?1",
             "name": "Yahenni's Expertise",
             "text": "All creatures get -3/-3 until end of turn.\nYou may cast a card with converted mana cost 3 or less from your hand without paying its mana cost.",
             "colours": [
@@ -2614,7 +2614,7 @@
         },
         {
             "id": "db7de268-b5fc-5151-b520-58480ac0952b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290cde84-d97a-4737-aff2-c443a4e43f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290cde84-d97a-4737-aff2-c443a4e43f7d.jpg?1",
             "name": "Aether Chaser",
             "text": "First strike\nWhen Aether Chaser enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Chaser attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -2649,7 +2649,7 @@
         },
         {
             "id": "c2beb4f5-0cfc-50c6-a60f-70fb7dd8343a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcee99c-72a0-4db1-b4c9-65c878284450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcee99c-72a0-4db1-b4c9-65c878284450.jpg?1",
             "name": "Chandra's Revolution",
             "text": "Chandra's Revolution deals 4 damage to target creature. Tap target land. That land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2681,7 +2681,7 @@
         },
         {
             "id": "172e82ea-2b8e-5a9d-a8b7-d9e2ea25b9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00154b70-57d2-4c32-860f-1c36fc49b10c.jpg?1",
             "name": "Destructive Tampering",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Creatures without flying can't block this turn.",
             "colours": [
@@ -2713,7 +2713,7 @@
         },
         {
             "id": "8915d7e1-191a-54ac-9412-eebd13d2692d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad5c175-581c-4fdd-b008-e7d10b0928c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad5c175-581c-4fdd-b008-e7d10b0928c7.jpg?1",
             "name": "Embraal Gear-Smasher",
             "text": "{T}, Sacrifice an artifact: Embraal Gear-Smasher deals 2 damage to each opponent.",
             "colours": [
@@ -2748,7 +2748,7 @@
         },
         {
             "id": "e705af06-5dab-5723-bd90-edcde8dd667b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc3b59-baae-4bf0-b5ce-fa9a915af066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dc3b59-baae-4bf0-b5ce-fa9a915af066.jpg?1",
             "name": "Enraged Giant",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nTrample, haste",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "0dff43b7-c8bc-5777-881c-291a8cd7c070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b5147f-b422-47d3-98a0-dcc2d6f4e17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b5147f-b422-47d3-98a0-dcc2d6f4e17a.jpg?1",
             "name": "Freejam Regent",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nFlying\n{1}{R}: Freejam Regent gets +2/+0 until end of turn.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "22dcc93d-0cfa-567a-97c5-cb3968d4731c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742738a-2663-474d-b75a-28f1f67dc335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742738a-2663-474d-b75a-28f1f67dc335.jpg?1",
             "name": "Frontline Rebel",
             "text": "Frontline Rebel attacks each combat if able.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "0c912843-46e4-5741-8a75-26e6105c7b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51438f5-c4d4-434a-b7ea-dee0b60303e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51438f5-c4d4-434a-b7ea-dee0b60303e4.jpg?1",
             "name": "Gremlin Infestation",
             "text": "Enchant artifact\nAt the beginning of your end step, Gremlin Infestation deals 2 damage to enchanted artifact's controller.\nWhen enchanted artifact is put into a graveyard, create a 2/2 red Gremlin creature token.",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "66f41cea-6e1d-5959-b8dc-5fa8289cd1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca23676-f36f-4266-ba4f-5e9ebf3adb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca23676-f36f-4266-ba4f-5e9ebf3adb57.jpg?1",
             "name": "Hungry Flames",
             "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player.",
             "colours": [
@@ -2917,7 +2917,7 @@
         },
         {
             "id": "882d5d61-d560-5e48-bfcc-dbfbbb048ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd00e45-2ae1-4cd0-92a1-155c95f8dc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd00e45-2ae1-4cd0-92a1-155c95f8dc72.jpg?1",
             "name": "Indomitable Creativity",
             "text": "Destroy X target artifacts and/or creatures. For each permanent destroyed this way, its controller reveals cards from the top of his or her library until an artifact or creature card is revealed and exiles that card. Those players put the exiled cards onto the battlefield, then shuffle their libraries.",
             "colours": [
@@ -2949,7 +2949,7 @@
         },
         {
             "id": "0b95e521-1159-53d9-bbde-5b187f4003ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1d1727-99d4-4aee-b6f5-8399ac1d0184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1d1727-99d4-4aee-b6f5-8399ac1d0184.jpg?1",
             "name": "Invigorated Rampage",
             "text": "Choose one \u2014\n\u2022 Target creature gets +4/+0 and gains trample until end of turn.\n\u2022 Two target creatures each get +2/+0 and gain trample until end of turn.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "e3f86614-17b1-51b3-87ec-b223f9eca7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72495879-39ce-449d-ad2f-ef32ea46f3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72495879-39ce-449d-ad2f-ef32ea46f3aa.jpg?1",
             "name": "Kari Zev, Skyship Raider",
             "text": "First strike, menace\nWhenever Kari Zev, Skyship Raider attacks, create a legendary 2/1 red Monkey creature token named Ragavan that's tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "b8266e5b-a310-54bf-ad25-b7dd9423e147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c7400-6307-4c51-88b8-9c0232110714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c7400-6307-4c51-88b8-9c0232110714.jpg?1",
             "name": "Kari Zev's Expertise",
             "text": "Gain control of target creature or Vehicle until end of turn. Untap it. It gains haste until end of turn.\nYou may cast a card with converted mana cost 2 or less from your hand without paying its mana cost.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "810b4255-4470-5336-99f0-a5e053837d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33998799-f31b-4522-93b2-0c34c570ebf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33998799-f31b-4522-93b2-0c34c570ebf7.jpg?1",
             "name": "Lathnu Sailback",
             "text": "",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "d2133ec8-fed4-5505-ba8b-2c9833b022f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d9c7eb-dca4-4471-a91f-a5aad3a69c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d9c7eb-dca4-4471-a91f-a5aad3a69c2f.jpg?1",
             "name": "Lightning Runner",
             "text": "Double strike, haste\nWhenever Lightning Runner attacks, you get {E}{E} (two energy counters), then you may pay {E}{E}{E}{E}{E}{E}{E}{E}. If you pay, untap all creatures you control, and after this phase, there is an additional combat phase.",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "d0cf7797-966a-573d-bbe6-c2007e5dd7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da6ff6-4d81-488e-83ff-8758f6c7bb9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da6ff6-4d81-488e-83ff-8758f6c7bb9f.jpg?1",
             "name": "Pia's Revolution",
             "text": "Whenever a nontoken artifact is put into your graveyard from the battlefield, return that card to your hand unless target opponent has Pia's Revolution deal 3 damage to him or her.",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "2b844e4f-f252-560e-b1a7-cbf586ae5e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd2e7ab-b63e-48e8-a32a-6ff8673241d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd2e7ab-b63e-48e8-a32a-6ff8673241d9.jpg?1",
             "name": "Precise Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "e368709d-693e-5acc-9972-c8ba8e40e07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5f9755-b137-439c-9b54-1ad71ec1f9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5f9755-b137-439c-9b54-1ad71ec1f9ec.jpg?1",
             "name": "Quicksmith Rebel",
             "text": "When Quicksmith Rebel enters the battlefield, target artifact you control gains \"{T}: This artifact deals 2 damage to target creature or player\" for as long as you control Quicksmith Rebel.",
             "colours": [
@@ -3218,7 +3218,7 @@
         },
         {
             "id": "5466107e-8570-5d93-a3a6-fb22d6ee6511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd793778-f099-4b8e-af19-fc0ec4292824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd793778-f099-4b8e-af19-fc0ec4292824.jpg?1",
             "name": "Ravenous Intruder",
             "text": "Sacrifice an artifact: Ravenous Intruder gets +2/+2 until end of turn.",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "90c374a2-49a2-5961-9630-5f2a5ee782ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0afd6-1242-42bf-a13f-9f218c9d9dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0afd6-1242-42bf-a13f-9f218c9d9dfc.jpg?1",
             "name": "Reckless Racer",
             "text": "First strike\nWhenever Reckless Racer becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3287,7 +3287,7 @@
         },
         {
             "id": "3eb17ee4-2d8d-5b60-a0b1-a45f209a702f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ba75be-2428-45aa-bf02-75c379a5dfa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ba75be-2428-45aa-bf02-75c379a5dfa2.jpg?1",
             "name": "Release the Gremlins",
             "text": "Destroy X target artifacts. Create X 2/2 red Gremlin creature tokens.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "9f83d4e5-ccfa-52a0-ac12-4a390c6147b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ef25c-e9cf-4801-a753-2c329c2a8bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ef25c-e9cf-4801-a753-2c329c2a8bdb.jpg?1",
             "name": "Scrapper Champion",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nWhen Scrapper Champion enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Scrapper Champion attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "8f37f2bc-62ee-56bd-ad7e-3b694253b236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00365412-41db-427c-9109-8f69c17c326d.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "17bb8f8c-190f-51d7-aea6-e2b3e1ee2ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a4e33f-53f0-4919-98a1-c832dcd32efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a4e33f-53f0-4919-98a1-c832dcd32efb.jpg?1",
             "name": "Siege Modification",
             "text": "Enchant creature or Vehicle\nAs long as enchanted permanent is a Vehicle, it's a creature in addition to its other types.\nEnchanted creature gets +3/+0 and has first strike.",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "281c3006-75de-5c4f-951e-eff99e9a8eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b477d12a-9ba5-4302-a3f0-af0afb5d87f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b477d12a-9ba5-4302-a3f0-af0afb5d87f4.jpg?1",
             "name": "Sweatworks Brawler",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nMenace",
             "colours": [
@@ -3455,7 +3455,7 @@
         },
         {
             "id": "4827b797-7ef2-547b-9174-a954ebdf5be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea93a49-5a7c-4d15-8548-a57c9460e0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea93a49-5a7c-4d15-8548-a57c9460e0f0.jpg?1",
             "name": "Wrangle",
             "text": "Gain control of target creature with power 4 or less until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "6b6f85f5-6bf0-502f-bc9e-d7f03577b780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ba0db-4276-45aa-91ed-52f6ffbc6ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ba0db-4276-45aa-91ed-52f6ffbc6ad3.jpg?1",
             "name": "Wrangle",
             "text": "",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "8ef5929c-d224-54f3-a299-b4d1088d2a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8744a31-451b-4349-8f62-e2392a72a154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8744a31-451b-4349-8f62-e2392a72a154.jpg?1",
             "name": "Aether Herder",
             "text": "When Aether Herder enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Aether Herder attacks, you may pay {E}{E}. If you do, create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "b795d78c-c194-51b9-96cf-21c6d59580f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3a727a-5eca-44de-aa8f-0d2573db83eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3a727a-5eca-44de-aa8f-0d2573db83eb.jpg?1",
             "name": "Aetherstream Leopard",
             "text": "Trample\nWhen Aetherstream Leopard enters the battlefield, you get {E} (an energy counter).\nWhenever Aetherstream Leopard attacks, you may pay {E}. If you do, it gets +2/+0 until end of turn.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "00596d10-05fa-501c-8e39-fd61c94ca525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04d5fa-6ba2-4833-8ea0-1941a03bd3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04d5fa-6ba2-4833-8ea0-1941a03bd3e9.jpg?1",
             "name": "Aetherwind Basker",
             "text": "Trample\nWhenever Aetherwind Basker enters the battlefield or attacks, you get {E} (an energy counter) for each creature you control.\nPay {E}: Aetherwind Basker gets +1/+1 until end of turn.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "3b677162-6dad-5b4c-96c5-deeb6b0b650f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565cb7fc-cf90-4020-84fe-05ec7b18709d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565cb7fc-cf90-4020-84fe-05ec7b18709d.jpg?1",
             "name": "Aid from the Cowl",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, reveal the top card of your library. If it's a permanent card, you may put it onto the battlefield. Otherwise, you may put it on the bottom of your library.",
             "colours": [
@@ -3658,7 +3658,7 @@
         },
         {
             "id": "66abd889-b8d9-52e5-a6c1-2fc07b7b6b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683f79b-0330-4fac-8279-6c0d888414b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683f79b-0330-4fac-8279-6c0d888414b8.jpg?1",
             "name": "Druid of the Cowl",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "47a2ecf7-cb22-5560-a683-71dc0e6faa7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f06124-bcc4-48c0-a7a6-a461c7485ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f06124-bcc4-48c0-a7a6-a461c7485ecd.jpg?1",
             "name": "Greenbelt Rampager",
             "text": "When Greenbelt Rampager enters the battlefield, pay {E}{E} (two energy counters). If you can't, return Greenbelt Rampager to its owner's hand and you get {E}.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "cd504c1b-0ab8-5668-9627-7219e32c1fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad9bf0f-4271-497f-8d67-3c7bf09342dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad9bf0f-4271-497f-8d67-3c7bf09342dc.jpg?1",
             "name": "Greenwheel Liberator",
             "text": "Revolt \u2014 Greenwheel Liberator enters the battlefield with two +1/+1 counters on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "f346aef2-e827-5a6c-95a5-07ecc1106aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5a620c-fde7-4b72-bf8a-efc4f14560c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5a620c-fde7-4b72-bf8a-efc4f14560c5.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "67b701ce-6b07-5a2e-92ee-1c552a5720d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8db01-415e-42a1-8eb2-57280d58b38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8db01-415e-42a1-8eb2-57280d58b38e.jpg?1",
             "name": "Hidden Herbalists",
             "text": "Revolt \u2014 When Hidden Herbalists enters the battlefield, if a permanent you controlled left the battlefield this turn, add {G}{G} to your mana pool.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "c5c5eca4-0078-57aa-b0ab-cf4a99558bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08325c39-0eeb-4bd0-9adc-2892c1c6637e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08325c39-0eeb-4bd0-9adc-2892c1c6637e.jpg?1",
             "name": "Highspire Infusion",
             "text": "Target creature gets +3/+3 until end of turn. You get {E}{E} (two energy counters).",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "dd579469-f222-5203-bb63-ef323c9c44eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bc60c8-f0a3-4bbf-b570-7d98d0a3e2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bc60c8-f0a3-4bbf-b570-7d98d0a3e2b0.jpg?1",
             "name": "Lifecraft Awakening",
             "text": "Put X +1/+1 counters on target artifact you control. If it isn't a creature or Vehicle, it becomes a 0/0 Construct artifact creature.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "ac0c1f0b-2950-5176-aa43-5d551c40ec05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a92a03-4e1d-4b79-ad75-a29db2ea5495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a92a03-4e1d-4b79-ad75-a29db2ea5495.jpg?1",
             "name": "Lifecraft Cavalry",
             "text": "Trample\nRevolt \u2014 Lifecraft Cavalry enters the battlefield with two +1/+1 counters on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "d4b50b2b-b40e-5f13-a34c-1bc833bfa5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759f13b-e755-495d-87df-a685455cdf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759f13b-e755-495d-87df-a685455cdf33.jpg?1",
             "name": "Lifecrafter's Gift",
             "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "ad3b07a0-ab0e-5197-9d70-310c2e71f943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dcdba-419b-41e1-8c9d-8bca6fe2752b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dcdba-419b-41e1-8c9d-8bca6fe2752b.jpg?1",
             "name": "Maulfist Revolutionary",
             "text": "Trample\nWhen Maulfist Revolutionary enters the battlefield or dies, for each kind of counter on target permanent or player, give that permanent or player another counter of that kind.",
             "colours": [
@@ -3995,7 +3995,7 @@
         },
         {
             "id": "9b790496-b33f-5031-9975-f3e4caf530be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebf95d-a231-402a-8888-9c50889a9556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebf95d-a231-402a-8888-9c50889a9556.jpg?1",
             "name": "Monstrous Onslaught",
             "text": "Monstrous Onslaught deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast Monstrous Onslaught.",
             "colours": [
@@ -4027,7 +4027,7 @@
         },
         {
             "id": "0db7f377-0b88-5957-a8b9-54c028ef874b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041cc6b1-61c8-4c34-86fc-d647ce306f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041cc6b1-61c8-4c34-86fc-d647ce306f59.jpg?1",
             "name": "Narnam Renegade",
             "text": "Deathtouch\nRevolt \u2014 Narnam Renegade enters the battlefield with a +1/+1 counter on it if a permanent you controlled left the battlefield this turn.",
             "colours": [
@@ -4062,7 +4062,7 @@
         },
         {
             "id": "c155028c-6418-53ba-9b59-70f990063540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff693e03-4cc6-4903-8fc4-388d23c2f92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff693e03-4cc6-4903-8fc4-388d23c2f92f.jpg?1",
             "name": "Natural Obsolescence",
             "text": "Put target artifact on the bottom of its owner's library.",
             "colours": [
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "48543fad-44f8-5296-bc3b-5d36558e2b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1bc709-2157-4711-a027-c0ff00ff2728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1bc709-2157-4711-a027-c0ff00ff2728.jpg?1",
             "name": "Peema Aether-Seer",
             "text": "When Peema Aether-Seer enters the battlefield, you get an amount of {E} (energy counters) equal to the greatest power among creatures you control.\nPay {E}{E}{E}: Target creature blocks this turn if able.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "bfc3fd94-6712-5e2f-9f7d-bb07290bb6bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166f0a2d-d660-4ea2-8b2f-143dc1fc0a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166f0a2d-d660-4ea2-8b2f-143dc1fc0a8e.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4161,7 +4161,7 @@
         },
         {
             "id": "29d33524-7d3e-5ca2-b022-308c7ba364be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b689cc-35ef-4a23-bb1e-4d81b9fb8455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b689cc-35ef-4a23-bb1e-4d81b9fb8455.jpg?1",
             "name": "Ridgescale Tusker",
             "text": "When Ridgescale Tusker enters the battlefield, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "b03bd941-3c16-519c-874e-7bbfd2ccbab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cff0dc6-5455-4dea-940b-dff7fe88dc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cff0dc6-5455-4dea-940b-dff7fe88dc5d.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G} to your mana pool.\"",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "eb5e9477-99e7-5ff5-ab81-39724834b70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58ba68-05c1-4cd8-a93d-321cd1739ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58ba68-05c1-4cd8-a93d-321cd1739ccb.jpg?1",
             "name": "Rishkar's Expertise",
             "text": "Draw cards equal to the greatest power among creatures you control.\nYou may cast a card with converted mana cost 5 or less from your hand without paying its mana cost.",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "258cdba8-0ce3-55b7-88c1-1ad657cb42f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a11a7-175d-440d-b09d-918572c8e5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a11a7-175d-440d-b09d-918572c8e5d3.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "3b6381c6-a0b8-5a7e-90ab-f9541af3fce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10938c8-6fc4-495f-912a-1d3f12278f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10938c8-6fc4-495f-912a-1d3f12278f78.jpg?1",
             "name": "Silkweaver Elite",
             "text": "Reach (This creature can block creatures with flying.)\nRevolt \u2014 When Silkweaver Elite enters the battlefield, if a permanent you controlled left the battlefield this turn, draw a card.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "3c89c610-030b-5a4e-9580-b2794af62229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc419-a6ce-447d-9994-744cf41f9a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc419-a6ce-447d-9994-744cf41f9a27.jpg?1",
             "name": "Unbridled Growth",
             "text": "Enchant land\nEnchanted land has \"{T}: Add one mana of any color to your mana pool.\"\nSacrifice Unbridled Growth: Draw a card.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "c1c970e9-5586-5990-865d-ee8a22f9ca18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b82ee9-2ac6-4b81-8c64-dd4f47c2d8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b82ee9-2ac6-4b81-8c64-dd4f47c2d8cb.jpg?1",
             "name": "Ajani Unyielding",
             "text": "+2: Reveal the top three cards of your library. Put all nonland permanent cards revealed this way into your hand and the rest on the bottom of your library in any order.\n\u22122: Exile target creature. Its controller gains life equal to its power.\n\u22129: Put five +1/+1 counters on each creature you control and five loyalty counters on each other planeswalker you control.",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "f7bffe4f-03e3-5fd0-99db-8e0e8ffe4245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8f103c-a688-4f22-ae59-2bce1db9d44a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8f103c-a688-4f22-ae59-2bce1db9d44a.jpg?1",
             "name": "Dark Intimations",
             "text": "Each opponent sacrifices a creature or planeswalker, then discards a card. You return a creature or planeswalker card from your graveyard to your hand, then draw a card.\nWhen you cast a Bolas planeswalker spell, exile Dark Intimations from your graveyard. That planeswalker enters the battlefield with an additional loyalty counter on it.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "6cb2fe85-24ed-5d2e-817d-2d62431002a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2176a5-66f8-4a21-bbe2-969c82ca36bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2176a5-66f8-4a21-bbe2-969c82ca36bd.jpg?1",
             "name": "Hidden Stockpile",
             "text": "Revolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 colorless Servo artifact creature token.\n{1}, Sacrifice a creature: Scry 1.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "fff52524-bc7c-5c5d-b790-22b5b32bb5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad17d67-538e-4c60-a582-a394032a5112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad17d67-538e-4c60-a582-a394032a5112.jpg?1",
             "name": "Maverick Thopterist",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nWhen Maverick Thopterist enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.",
             "colours": [
@@ -4514,7 +4514,7 @@
         },
         {
             "id": "b5dfc5f2-7feb-59e6-b187-04e57d0d30e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7d5a-b037-4ff7-b6d2-df00adf5691b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968c7d5a-b037-4ff7-b6d2-df00adf5691b.jpg?1",
             "name": "Oath of Ajani",
             "text": "When Oath of Ajani enters the battlefield, put a +1/+1 counter on each creature you control.\nPlaneswalker spells you cast cost {1} less to cast.",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "6a3c3612-48ff-525c-9764-bc63aeecbf41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135912b3-978b-4a9b-8758-7b138b190232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135912b3-978b-4a9b-8758-7b138b190232.jpg?1",
             "name": "Outland Boar",
             "text": "Outland Boar can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "1352572f-329f-58f7-a329-824779fde7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90bad312-80e3-45b0-9556-60ce06808a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90bad312-80e3-45b0-9556-60ce06808a47.jpg?1",
             "name": "Renegade Rallier",
             "text": "Revolt \u2014 When Renegade Rallier enters the battlefield, if a permanent you controlled left the battlefield this turn, return target permanent card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "e3988591-59fc-5086-b4dc-b879218beeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956a341-10fd-48af-b382-88c2b2934a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956a341-10fd-48af-b382-88c2b2934a3e.jpg?1",
             "name": "Renegade Wheelsmith",
             "text": "Whenever Renegade Wheelsmith becomes tapped, target creature can't block this turn.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "3e963d28-149b-598e-aca8-89d381537791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618652b4-7ce9-4994-9d16-68d2cc8644ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618652b4-7ce9-4994-9d16-68d2cc8644ef.jpg?1",
             "name": "Rogue Refiner",
             "text": "When Rogue Refiner enters the battlefield, draw a card and you get {E}{E} (two energy counters).",
             "colours": [
@@ -4697,7 +4697,7 @@
         },
         {
             "id": "84bf86c1-913a-530d-b3e8-b1ad48fa0eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daaf494-70af-4a8d-836f-f6a9d6c1f080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daaf494-70af-4a8d-836f-f6a9d6c1f080.jpg?1",
             "name": "Spire Patrol",
             "text": "Flying\nWhen Spire Patrol enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "4638d349-694a-5a28-b0de-a9da22a3c9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58265203-bc16-41d2-875c-2ff3b4870824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58265203-bc16-41d2-875c-2ff3b4870824.jpg?1",
             "name": "Tezzeret the Schemer",
             "text": "+1: Create a colorless artifact token named Etherium Cell with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\n\u22122: Target creature gets +X/-X until end of turn, where X is the number of artifacts you control.\n\u22127: You get an emblem with \"At the beginning of combat on your turn, target artifact you control becomes an artifact creature with base power and toughness 5/5.\"",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "8102d464-c3c7-5b3d-ae67-4fd70cf9d018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2e917f-734e-4b8b-abc6-ea33c0fc722e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2e917f-734e-4b8b-abc6-ea33c0fc722e.jpg?1",
             "name": "Tezzeret's Touch",
             "text": "Enchant artifact\nEnchanted artifact is a creature with base power and toughness 5/5 in addition to its other types.\nWhen enchanted artifact is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -4808,7 +4808,7 @@
         },
         {
             "id": "4ef622c2-c217-58a5-a260-f22f52bbe19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51464df6-557f-47e5-838e-2a30145511f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51464df6-557f-47e5-838e-2a30145511f0.jpg?1",
             "name": "Weldfast Engineer",
             "text": "At the beginning of combat on your turn, target artifact creature you control gets +2/+0 until end of turn.",
             "colours": [
@@ -4845,7 +4845,7 @@
         },
         {
             "id": "41cc95b5-d68b-50cc-85bc-40c3b0e8e385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c8aa8-c8f8-4cbf-821b-bd2cb33354f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c8aa8-c8f8-4cbf-821b-bd2cb33354f0.jpg?1",
             "name": "Winding Constrictor",
             "text": "If one or more counters would be placed on an artifact or creature you control, that many of those counters plus one are placed on that permanent instead.\nIf you would get one or more counters, you get that many of those counters plus one instead.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "1f9f70c9-d667-51eb-8cb5-728a27993e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f9fa2d-4bf4-4fcb-9b76-fd4a9ff5a58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f9fa2d-4bf4-4fcb-9b76-fd4a9ff5a58c.jpg?1",
             "name": "Aegis Automaton",
             "text": "{4}{W}: Return another target creature you control to its owner's hand.",
             "colours": [],
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "b211495f-7ff6-55d7-8a1e-d6b4075b2963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4160bb5f-4b49-4535-94f5-776d7abd1d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4160bb5f-4b49-4535-94f5-776d7abd1d1a.jpg?1",
             "name": "Aethersphere Harvester",
             "text": "Flying\nWhen Aethersphere Harvester enters the battlefield, you get {E}{E} (two energy counters).\nPay {E}: Aethersphere Harvester gains lifelink until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -4944,7 +4944,7 @@
         },
         {
             "id": "25b2ec2e-d371-5472-9501-2cc18f1301d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d017798-8278-4f9c-a691-912935c10c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d017798-8278-4f9c-a691-912935c10c20.jpg?1",
             "name": "Augmenting Automaton",
             "text": "{1}{B}: Augmenting Automaton gets +1/+1 until end of turn.",
             "colours": [],
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "4593845a-06d0-5b87-b15f-6b4480c0dfbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc81a94-955d-4734-b056-9b9a86cae60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc81a94-955d-4734-b056-9b9a86cae60b.jpg?1",
             "name": "Barricade Breaker",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nBarricade Breaker attacks each combat if able.",
             "colours": [],
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "7a3414dd-20f3-5601-a13d-c57064181f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddacdd-bbc4-4f9b-be1c-5f2c64be3cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dddacdd-bbc4-4f9b-be1c-5f2c64be3cbc.jpg?1",
             "name": "Cogwork Assembler",
             "text": "{7}: Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "744b6792-c02e-5bcd-b4b0-2b4e833401b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11eff338-1940-4684-94c7-ef90e56dea99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11eff338-1940-4684-94c7-ef90e56dea99.jpg?1",
             "name": "Consulate Dreadnought",
             "text": "Crew 6 (Tap any number of creatures you control with total power 6 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "d2ec4c40-979b-5cfb-b474-7ca78a3cb279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c55b5b-58fd-4340-b089-8e271633e8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c55b5b-58fd-4340-b089-8e271633e8dd.jpg?1",
             "name": "Consulate Turret",
             "text": "{T}: You get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Consulate Turret deals 2 damage to target player.",
             "colours": [],
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "7691a620-fce5-548e-b12d-3eda96de3abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993bc69a-b615-48c5-af81-252a73384e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993bc69a-b615-48c5-af81-252a73384e8c.jpg?1",
             "name": "Crackdown Construct",
             "text": "Whenever you activate an ability of an artifact or creature that isn't a mana ability, Crackdown Construct gets +1/+1 until end of turn.",
             "colours": [],
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "d59c5598-db1d-5d72-a698-38b099947529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bbbc98-0806-4226-8fd1-16b812334cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bbbc98-0806-4226-8fd1-16b812334cee.jpg?1",
             "name": "Daredevil Dragster",
             "text": "At end of combat, if Daredevil Dragster attacked or blocked this combat, put a velocity counter on it. Then if it has two or more velocity counters on it, sacrifice it and draw two cards.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "a52bf074-e6fb-5115-a7b0-7c7f9023e0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e817c-079e-4e7c-a8ca-54634f30bf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e817c-079e-4e7c-a8ca-54634f30bf36.jpg?1",
             "name": "Filigree Crawler",
             "text": "When Filigree Crawler dies, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [],
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "c98d181e-1d46-5888-9f56-a4a7e70112f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a2862-a2d7-4d87-a4b8-def9f441f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a2862-a2d7-4d87-a4b8-def9f441f5fa.jpg?1",
             "name": "Foundry Assembler",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "660c1062-ea7b-5239-898e-398a2b4bf822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4fc5ed-e90d-4965-985a-ed126a713506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4fc5ed-e90d-4965-985a-ed126a713506.jpg?1",
             "name": "Gonti's Aether Heart",
             "text": "Whenever Gonti's Aether Heart or another artifact enters the battlefield under your control, you get {E}{E} (two energy counters).\nPay {E}{E}{E}{E}{E}{E}{E}{E}, Exile Gonti's Aether Heart: Take an extra turn after this one.",
             "colours": [],
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "931b78e6-7d7e-5b80-be11-f2169716ba0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e847c44-1849-4251-9075-88ed5c7792a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e847c44-1849-4251-9075-88ed5c7792a6.jpg?1",
             "name": "Heart of Kiran",
             "text": "Flying, vigilance\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nYou may remove a loyalty counter from a planeswalker you control rather than pay Heart of Kiran's crew cost.",
             "colours": [],
@@ -5282,7 +5282,7 @@
         },
         {
             "id": "525e2be4-336b-5b55-85cf-87d47ad6ab62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4bcadd-7eff-4294-94d5-52482a734d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4bcadd-7eff-4294-94d5-52482a734d5b.jpg?1",
             "name": "Hope of Ghirapur",
             "text": "Flying\nSacrifice Hope of Ghirapur: Until your next turn, target player who was dealt combat damage by Hope of Ghirapur this turn can't cast noncreature spells.",
             "colours": [],
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "ad016c99-f85c-56c6-a294-84b9ab090e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b1c8da-604a-42f0-8658-82580700dd31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b1c8da-604a-42f0-8658-82580700dd31.jpg?1",
             "name": "Implement of Combustion",
             "text": "{R}, Sacrifice Implement of Combustion: It deals 1 damage to target player.\nWhen Implement of Combustion is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "48ef1e75-c9a5-5c14-8fe2-5832e15a98b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a791aa71-00db-422d-a78a-53b121c24db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a791aa71-00db-422d-a78a-53b121c24db5.jpg?1",
             "name": "Implement of Examination",
             "text": "{U}, Sacrifice Implement of Examination: Draw a card.\nWhen Implement of Examination is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5375,7 +5375,7 @@
         },
         {
             "id": "9387d36e-26ab-5866-a5ab-91df5290f2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdee084-0d1a-486a-8361-680d394a5e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdee084-0d1a-486a-8361-680d394a5e23.jpg?1",
             "name": "Implement of Ferocity",
             "text": "{G}, Sacrifice Implement of Ferocity: Put a +1/+1 counter on target creature. Activate this ability only any time you could cast a sorcery.\nWhen Implement of Ferocity is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "2d4c110b-df9a-521c-bd78-041bf33cb7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8eb0c-d7fa-4229-ae65-1890c77b2c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8eb0c-d7fa-4229-ae65-1890c77b2c7c.jpg?1",
             "name": "Implement of Improvement",
             "text": "{W}, Sacrifice Implement of Improvement: You gain 2 life.\nWhen Implement of Improvement is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "5dd673fe-dbcc-5fb7-a86a-901f4056ad68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e45ca82-e387-4df0-890d-d53a7d0dadf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e45ca82-e387-4df0-890d-d53a7d0dadf7.jpg?1",
             "name": "Implement of Malice",
             "text": "{B}, Sacrifice Implement of Malice: Target player discards a card. Activate this ability only any time you could cast a sorcery.\nWhen Implement of Malice is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -5465,7 +5465,7 @@
         },
         {
             "id": "674183c4-4a97-5685-9d09-38b0e93d148e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2564f-0066-41e0-a767-13ef33a17024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2564f-0066-41e0-a767-13ef33a17024.jpg?1",
             "name": "Inspiring Statuary",
             "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "ba7f265c-8599-578d-adc8-a689a20b205a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81873223-29c7-466b-b922-6717ec84afff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81873223-29c7-466b-b922-6717ec84afff.jpg?1",
             "name": "Irontread Crusher",
             "text": "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "fe7f4628-fa11-5219-9774-a165234005ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439a855-4041-4d14-8edf-6741a734e55d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439a855-4041-4d14-8edf-6741a734e55d.jpg?1",
             "name": "Lifecrafter's Bestiary",
             "text": "At the beginning of your upkeep, scry 1.\nWhenever you cast a creature spell, you may pay {G}. If you do, draw a card.",
             "colours": [],
@@ -5553,7 +5553,7 @@
         },
         {
             "id": "64cfec52-7c50-53d5-a953-4da6e82728f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955b4bc9-1ded-4f23-b415-ab968c681eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955b4bc9-1ded-4f23-b415-ab968c681eb7.jpg?1",
             "name": "Merchant's Dockhand",
             "text": "{3}{U}, {T}, Tap X untapped artifacts you control: Look at the top X cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [],
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "006708ff-3943-5b2e-bbb3-c8456b3c3223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4eba9-9e91-4beb-9296-a18baa73a318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4eba9-9e91-4beb-9296-a18baa73a318.jpg?1",
             "name": "Metallic Mimic",
             "text": "As Metallic Mimic enters the battlefield, choose a creature type.\nMetallic Mimic is the chosen type in addition to its other types.\nEach other creature you control of the chosen type enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [],
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "9a07ae79-5dc9-5067-8242-01b01618bc00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da443378-f5cb-4240-9524-2c40ec17c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da443378-f5cb-4240-9524-2c40ec17c933.jpg?1",
             "name": "Mobile Garrison",
             "text": "Whenever Mobile Garrison attacks, untap another target artifact or creature you control.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "3aab726c-a42b-5f7b-83bc-571ab642a72f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae03e5c-9655-425c-90ef-b70a0e66868d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae03e5c-9655-425c-90ef-b70a0e66868d.jpg?1",
             "name": "Night Market Guard",
             "text": "Night Market Guard can block an additional creature each combat.",
             "colours": [],
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "c2bb7b92-204e-5d41-8989-c34679ac0be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb96645-44d2-426c-90cb-3186297a8728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb96645-44d2-426c-90cb-3186297a8728.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "2310e67d-5282-57ab-a45e-6c1a87c5a63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed742a-a12a-4728-a771-07e3d1417419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bed742a-a12a-4728-a771-07e3d1417419.jpg?1",
             "name": "Pacification Array",
             "text": "{2}, {T}: Tap target artifact or creature.",
             "colours": [],
@@ -5737,7 +5737,7 @@
         },
         {
             "id": "88e86b72-397f-5199-9b97-52c2dc877b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ccd81-9e11-47fa-8e16-064c52c24506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ccd81-9e11-47fa-8e16-064c52c24506.jpg?1",
             "name": "Paradox Engine",
             "text": "Whenever you cast a spell, untap all nonland permanents you control.",
             "colours": [],
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "58cdf4ec-71bb-5433-b2a0-e889dcfec7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1599b545-6b8e-4350-980a-59349374400d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1599b545-6b8e-4350-980a-59349374400d.jpg?1",
             "name": "Peacewalker Colossus",
             "text": "{1}{W}: Another target Vehicle you control becomes an artifact creature until end of turn.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5799,7 +5799,7 @@
         },
         {
             "id": "c671cd1d-addf-501d-b560-e419ec7aee22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991397cf-5c7d-4e8a-8f46-8e2e0ed29eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991397cf-5c7d-4e8a-8f46-8e2e0ed29eff.jpg?1",
             "name": "Planar Bridge",
             "text": "{8}, {T}: Search your library for a permanent card, put it onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "57b1eb85-9a64-5d8d-93d8-eb85a910b24f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e389c92-b54b-46b3-a7ab-b8a5a2a7d380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e389c92-b54b-46b3-a7ab-b8a5a2a7d380.jpg?1",
             "name": "Prizefighter Construct",
             "text": "",
             "colours": [],
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "02bb4f24-51a9-5962-9b5d-066a866fab68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac063445-d0e2-4015-96dc-97098433f30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac063445-d0e2-4015-96dc-97098433f30a.jpg?1",
             "name": "Renegade Map",
             "text": "Renegade Map enters the battlefield tapped.\n{T}, Sacrifice Renegade Map: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -5888,7 +5888,7 @@
         },
         {
             "id": "7de3669e-21ae-5668-ac88-16d5e153add0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afe3be3-b0bc-4617-b4de-f60d14f1b91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afe3be3-b0bc-4617-b4de-f60d14f1b91d.jpg?1",
             "name": "Reservoir Walker",
             "text": "When Reservoir Walker enters the battlefield, you gain 3 life and get {E}{E}{E} (three energy counters).",
             "colours": [],
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "2601421d-0a60-50f4-8d39-ef17f576eb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68abc75f-596f-4169-96fc-ada941ef47ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68abc75f-596f-4169-96fc-ada941ef47ed.jpg?1",
             "name": "Scrap Trawler",
             "text": "Whenever Scrap Trawler or another artifact you control is put into a graveyard from the battlefield, return to your hand target artifact card in your graveyard with lesser converted mana cost.",
             "colours": [],
@@ -5950,7 +5950,7 @@
         },
         {
             "id": "558e9886-81e3-51e6-bcf5-076400067ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2299e0-d31f-4ec4-9497-16e494ee21e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2299e0-d31f-4ec4-9497-16e494ee21e6.jpg?1",
             "name": "Servo Schematic",
             "text": "When Servo Schematic enters the battlefield or is put into a graveyard from the battlefield, create a 1/1 colorless Servo artifact creature token.",
             "colours": [],
@@ -5978,7 +5978,7 @@
         },
         {
             "id": "6179872c-ba31-51c0-8461-0530cb117de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5d73d2-60cc-4b64-8274-4ba1bb98b6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5d73d2-60cc-4b64-8274-4ba1bb98b6fa.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with converted mana cost 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "87689662-83a0-59f8-9e50-285f1f327823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b66b2-12b2-497b-a328-b43630c79e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b66b2-12b2-497b-a328-b43630c79e73.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "60f6d339-1bf5-532d-920e-38b857f2d155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba729d8-fd5e-4183-806a-0997f443a58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba729d8-fd5e-4183-806a-0997f443a58f.jpg?1",
             "name": "Untethered Express",
             "text": "Trample\nWhenever Untethered Express attacks, put a +1/+1 counter on it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6067,7 +6067,7 @@
         },
         {
             "id": "9563e007-cc92-5c6b-9ded-9b3805021280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c66c5a-0b1b-4936-9e07-2d169f16c1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c66c5a-0b1b-4936-9e07-2d169f16c1a6.jpg?1",
             "name": "Verdant Automaton",
             "text": "{3}{G}: Put a +1/+1 counter on Verdant Automaton.",
             "colours": [],
@@ -6100,7 +6100,7 @@
         },
         {
             "id": "b1f6b291-19de-505c-827d-8a96bf48b7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329a8738-3e17-403a-857a-0ba529ce8cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329a8738-3e17-403a-857a-0ba529ce8cd1.jpg?1",
             "name": "Walking Ballista",
             "text": "Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to target creature or player.",
             "colours": [],
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "aeccbb0a-91d7-542a-acc6-616dda8a6bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138b5fde-417d-4860-aca9-eae7f78b5768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138b5fde-417d-4860-aca9-eae7f78b5768.jpg?1",
             "name": "Watchful Automaton",
             "text": "{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "8ff75d91-fd63-5070-a44f-99dd9ae7d7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b5bae4-be97-4c10-b222-e1e317a8ffbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b5bae4-be97-4c10-b222-e1e317a8ffbc.jpg?1",
             "name": "Welder Automaton",
             "text": "{3}{R}: Welder Automaton deals 1 damage to each opponent.",
             "colours": [],
@@ -6197,7 +6197,7 @@
         },
         {
             "id": "7cdb28c5-cd41-5e8e-ba99-40134798cfe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331724d-6fab-454a-b06c-b06e499fa552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331724d-6fab-454a-b06c-b06e499fa552.jpg?1",
             "name": "Spire of Industry",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add one mana of any color to your mana pool. Activate this ability only if you control an artifact.",
             "colours": [],
@@ -6225,7 +6225,7 @@
         },
         {
             "id": "4a254341-f3dc-51e0-860f-b8f66eb55431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fdd9a-0ab6-4db9-84f9-859d2d862518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fdd9a-0ab6-4db9-84f9-859d2d862518.jpg?1",
             "name": "Ajani, Valiant Protector",
             "text": "+2: Put two +1/+1 counters on up to one target creature.\n+1: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.\n\u221211: Put X +1/+1 counters on target creature, where X is your life total. That creature gains trample until end of turn.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "2bbd85a2-ab7e-5bb4-97f7-991b44d8ec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef9708e-bfe4-4d24-8304-1618daa1c3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef9708e-bfe4-4d24-8304-1618daa1c3ee.jpg?1",
             "name": "Inspiring Roar",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "f932464a-6213-50e1-9d83-bd701aabe45d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bebef1c-2f03-4e0a-b3ba-861546ebf8a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bebef1c-2f03-4e0a-b3ba-861546ebf8a6.jpg?1",
             "name": "Ajani's Comrade",
             "text": "Trample\nAt the beginning of combat on your turn, if you control an Ajani planeswalker, put a +1/+1 counter on Ajani's Comrade.",
             "colours": [
@@ -6327,7 +6327,7 @@
         },
         {
             "id": "6cfa9c06-ee5b-54c1-8a93-cb371c60a8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7026c374-0776-403b-86fd-5092677fd5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7026c374-0776-403b-86fd-5092677fd5c9.jpg?1",
             "name": "Ajani's Aid",
             "text": "When Ajani's Aid enters the battlefield, you may search your library and/or graveyard for a card named Ajani, Valiant Protector, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nSacrifice Ajani's Aid: Prevent all combat damage a creature of your choice would deal this turn.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "f8f03132-aaef-58b8-ac50-3208bab2200d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea97c40-310e-4774-ae56-d4c0500a6189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea97c40-310e-4774-ae56-d4c0500a6189.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -6390,7 +6390,7 @@
         },
         {
             "id": "d06214d2-4c33-55ce-a497-88a1608a0b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c6614c-cc2b-4e5b-9c0d-ce8e4b2d8ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c6614c-cc2b-4e5b-9c0d-ce8e4b2d8ea7.jpg?1",
             "name": "Tezzeret, Master of Metal",
             "text": "+1: Reveal cards from the top of your library until you reveal an artifact card. Put that card into your hand and the rest on the bottom of your library in a random order.\n\u22123: Target opponent loses life equal to the number of artifacts you control.\n\u22128: Gain control of all artifacts and creatures target opponent controls.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "aaeaf498-6159-5a47-aadf-a3c936d469b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d71efa6-5de8-476f-86ce-0790956e574f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d71efa6-5de8-476f-86ce-0790956e574f.jpg?1",
             "name": "Tezzeret's Betrayal",
             "text": "Destroy target creature. You may search your library and/or graveyard for a card named Tezzeret, Master of Metal, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "9de2cedc-c9f4-5946-8afb-f0bd7b937d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19751aa-823e-4a0f-a004-dee333b34327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19751aa-823e-4a0f-a004-dee333b34327.jpg?1",
             "name": "Pendulum of Patterns",
             "text": "When Pendulum of Patterns enters the battlefield, you gain 3 life.\n{5}, {T}, Sacrifice Pendulum of Patterns: Draw a card.",
             "colours": [],
@@ -6487,7 +6487,7 @@
         },
         {
             "id": "c7510a7c-e7e4-565f-9a29-dd964eed6384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eacfeec-a341-45bc-bf95-e3df0094505a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eacfeec-a341-45bc-bf95-e3df0094505a.jpg?1",
             "name": "Tezzeret's Simulacrum",
             "text": "{T}: Target opponent loses 1 life. If you control a Tezzeret planeswalker, that player loses 3 life instead.",
             "colours": [],
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "7ea12951-7dd1-5f9f-bdc3-328392bb8b93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd7aab-c0ac-4566-bf99-c49931eeea2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd7aab-c0ac-4566-bf99-c49931eeea2a.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "8bc7da35-6721-5652-bcee-d69bfe27b90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6071fed-39c1-4f3b-a821-1611aedd8054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6071fed-39c1-4f3b-a821-1611aedd8054.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -6581,7 +6581,7 @@
         },
         {
             "id": "c7192a84-4ec9-557f-b467-9937ad9930b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebc91a9-23e0-4ca1-bc6d-e710ad2efb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebc91a9-23e0-4ca1-bc6d-e710ad2efb31.jpg?1",
             "name": "Ragavan",
             "text": "",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "1efcee85-7d6b-5bb3-98ef-dd925b820808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9616ca53-ea6a-4fc1-8e01-94e0fb47e5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9616ca53-ea6a-4fc1-8e01-94e0fb47e5ed.jpg?1",
             "name": "Etherium Cell",
             "text": "",
             "colours": [],
@@ -6645,7 +6645,7 @@
         },
         {
             "id": "eb01613c-a4d9-55db-b2c9-d7c0b43a5d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f136537-1ebe-4018-b406-44ef32ceef04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f136537-1ebe-4018-b406-44ef32ceef04.jpg?1",
             "name": "Tezzeret the Schemer Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/AFR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/AFR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "84d2e61d-46ef-5fa7-aeff-7a4cd8db71c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882c9f9-bf30-46b6-bedc-379d2c80e5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882c9f9-bf30-46b6-bedc-379d2c80e5cb.jpg?1",
             "name": "+2 Mace",
             "text": "",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "6d3bc1d2-45a5-5010-b36b-6cc33c962d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc45c9d4-ecc7-4a9d-9efe-f4b7d697dd97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc45c9d4-ecc7-4a9d-9efe-f4b7d697dd97.jpg?1",
             "name": "Arborea Pegasus",
             "text": "Flying\nWhen Arborea Pegasus enters the battlefield, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "567a3bb4-1ad0-529f-9e0b-fe882f560c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc040492-7fb7-4fdb-aafe-8179e5f2b28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc040492-7fb7-4fdb-aafe-8179e5f2b28c.jpg?1",
             "name": "Blink Dog",
             "text": "Double strike\nTeleport \u2014 {3}{W}: Blink Dog phases out. (Treat it and anything attached to it as though they don't exist until your next turn.)",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "e5465719-ba59-52ef-b475-f553e6fc57f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1899bb1-dd8e-4437-8ea3-4ad637eabf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1899bb1-dd8e-4437-8ea3-4ad637eabf2b.jpg?1",
             "name": "The Book of Exalted Deeds",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, create a 3/3 white Angel creature token with flying.\n{W}{W}{W}, {T}, Exile The Book of Exalted Deeds: Put an enlightened counter on target Angel. It gains \"You can't lose the game and your opponents can't win the game.\" Activate only as a sorcery.",
             "colours": [
@@ -146,7 +146,7 @@
         },
         {
             "id": "c228e9d4-2a6c-5f5c-bf27-93b3a8bd0852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d68812-8862-4e34-a992-7d6bbadaf316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d68812-8862-4e34-a992-7d6bbadaf316.jpg?1",
             "name": "Celestial Unicorn",
             "text": "Whenever you gain life, put a +1/+1 counter on Celestial Unicorn.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "f17eebae-bc94-5f8f-90a0-1959b8eb94e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ce8b7e-d8e1-489a-a69e-99089eeb8739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ce8b7e-d8e1-489a-a69e-99089eeb8739.jpg?1",
             "name": "Cleric Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nIf you would gain life, you gain that much life plus 1 instead.\n{3}{W}: Level 2\n//Level_2//\nWhenever you gain life, put a +1/+1 counter on target creature you control.\n{4}{W}: Level 3\n//Level_3//\nWhen this Class becomes level 3, return target creature card from your graveyard to the battlefield. You gain life equal to its toughness.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "c844fdc1-48ae-5811-9b85-7fd1ffc3a185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297bf274-d13d-4b75-b251-2d004b16b431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297bf274-d13d-4b75-b251-2d004b16b431.jpg?1",
             "name": "Cloister Gargoyle",
             "text": "When Cloister Gargoyle enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nAs long as you've completed a dungeon, Cloister Gargoyle gets +3/+0 and has flying.",
             "colours": [
@@ -253,7 +253,7 @@
         },
         {
             "id": "88ee70f1-7bf9-59d3-8a76-3ac5c4a18c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b16a4-c35a-4eec-94ed-8df6720240e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b16a4-c35a-4eec-94ed-8df6720240e0.jpg?1",
             "name": "A-Cloister Gargoyle",
             "text": "",
             "colours": [
@@ -287,7 +287,7 @@
         },
         {
             "id": "bf36f3bd-23d3-5c20-a9f1-978014e233ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3d7824-1297-408c-a11f-0622cab9c4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3d7824-1297-408c-a11f-0622cab9c4c3.jpg?1",
             "name": "Dancing Sword",
             "text": "Equipped creature gets +2/+1.\nWhen equipped creature dies, you may have Dancing Sword become a 2/1 Construct artifact creature with flying and ward {1}. If you do, it isn't an Equipment.\nEquip {1}",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "d7b3475e-801c-57da-b83f-2c3aa6a52c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00856f7-fef5-4ba5-9079-59a81d452c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00856f7-fef5-4ba5-9079-59a81d452c82.jpg?1",
             "name": "Dawnbringer Cleric",
             "text": "When Dawnbringer Cleric enters the battlefield, choose one \u2014\n\u2022 Cure Wounds \u2014 You gain 2 life.\n\u2022 Dispel Magic \u2014 Destroy target enchantment.\n\u2022 Gentle Repose \u2014 Exile target card from a graveyard.",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "11dacbba-07d1-5e52-8bc9-3adf00352234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53df7b80-71bf-4013-ad44-f76eae8ac81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53df7b80-71bf-4013-ad44-f76eae8ac81b.jpg?1",
             "name": "Delver's Torch",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, venture into the dungeon. (Enter the first room or advance to the next room.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "dcd89f7d-3b62-5b8c-aa57-d74f0cf858fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3620ed96-1d15-4942-b9e5-9f9a64b0cab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3620ed96-1d15-4942-b9e5-9f9a64b0cab4.jpg?1",
             "name": "Devoted Paladin",
             "text": "Beacon of Hope \u2014 When Devoted Paladin enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "c1ec41d7-43c7-52ec-a449-716175cd2b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d0852-4df3-4b29-830d-c6975265ef53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d0852-4df3-4b29-830d-c6975265ef53.jpg?1",
             "name": "Divine Smite",
             "text": "Target creature or planeswalker an opponent controls phases out. If that permanent is black, exile it instead. (If it phases out, treat it and anything attached to it as though they don't exist until its controller's next turn.)",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "c851a84d-4e49-543c-913c-61805d8ce89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e6b78-3e99-49f5-9eaf-bbb2e9789fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e6b78-3e99-49f5-9eaf-bbb2e9789fbe.jpg?1",
             "name": "Dragon's Disciple",
             "text": "As Dragon's Disciple enters the battlefield, you may reveal a Dragon card from your hand. If you do or if you control a Dragon, Dragon's Disciple enters the battlefield with a +1/+1 counter on it.\nDragons you control have ward {1}. (Whenever a Dragon you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -494,7 +494,7 @@
         },
         {
             "id": "cb121a4d-6362-5168-8cc5-60785696e27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2404a028-05f5-469b-80e0-e820721ff266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2404a028-05f5-469b-80e0-e820721ff266.jpg?1",
             "name": "Dwarfhold Champion",
             "text": "As long as Dwarfhold Champion is equipped, it gets +0/+2.",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "01076b72-fd33-5cdd-97ae-9935fcbd3a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191a73b3-9efc-4f79-bf10-e8e2d6951c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191a73b3-9efc-4f79-bf10-e8e2d6951c6c.jpg?1",
             "name": "A-Dwarfhold Champion",
             "text": "",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "76fa6f2a-2ff5-5816-a84e-a42100e64366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc86e78-8911-4a0d-ba3a-7802f8d991ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc86e78-8911-4a0d-ba3a-7802f8d991ef.jpg?1",
             "name": "Flumph",
             "text": "Defender, flying\nWhenever Flumph is dealt damage, you and target opponent each draw a card.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "e7b65025-b095-54d0-aada-fab46a112bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388722ad-dcc6-41b9-afd8-a93be91b30e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388722ad-dcc6-41b9-afd8-a93be91b30e0.jpg?1",
             "name": "Gloom Stalker",
             "text": "As long as you've completed a dungeon, Gloom Stalker has double strike.",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "fcb329b5-43b5-57d6-b7e5-5bb216cf05ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca4ffff-404e-4e8e-8fd6-4e64d4828fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca4ffff-404e-4e8e-8fd6-4e64d4828fc7.jpg?1",
             "name": "Grand Master of Flowers",
             "text": "As long as Grand Master of Flowers has seven or more loyalty counters on him, he's a 7/7 Dragon God creature with flying and indestructible.\n+1: Target creature without first strike, double strike, or vigilance can't attack or block until your next turn.\n+1: Search your library and/or graveyard for a card named Monk of the Open Hand, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "b2f6e00d-cb79-56d7-83f8-2087e3d5def2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3dda1-a1d3-48c9-8c81-da7eae20ac8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3dda1-a1d3-48c9-8c81-da7eae20ac8a.jpg?1",
             "name": "Guardian of Faith",
             "text": "Flash\nVigilance\nWhen Guardian of Faith enters the battlefield, any number of other target creatures you control phase out. (Treat them and anything attached to them as though they don't exist until their controller's next turn.)",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "9c8ddf4b-2120-5183-b5ec-a15bda5d755b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10f1687-fb20-4ad2-bad7-52e4470b35e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10f1687-fb20-4ad2-bad7-52e4470b35e4.jpg?1",
             "name": "Half-Elf Monk",
             "text": "Vigilance\nStunning Strike \u2014 {1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "c65c30e4-9046-584a-bfd8-d73f27140c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b0e68a-9d4e-42ea-8dac-c47cbed0c6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b0e68a-9d4e-42ea-8dac-c47cbed0c6ad.jpg?1",
             "name": "Icingdeath, Frost Tyrant",
             "text": "Flying, vigilance\nWhen Icingdeath, Frost Tyrant dies, create Icingdeath, Frost Tongue, a legendary white Equipment artifact token with \"Equipped creature gets +2/+0,\" \"Whenever equipped creature attacks, tap target creature defending player controls,\" and equip {2}.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "8cd37e6b-3866-5a7d-b155-7d3aa5013b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad29773-7c1b-410d-9f69-7aa751f6ebca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad29773-7c1b-410d-9f69-7aa751f6ebca.jpg?1",
             "name": "Ingenious Smith",
             "text": "When Ingenious Smith enters the battlefield, look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nWhenever one or more artifacts enter the battlefield under your control, put a +1/+1 counter on Ingenious Smith. This ability triggers only once each turn.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "a2f470ee-0d84-51f7-b8b1-d712c5ece2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de169d64-8242-4f57-980e-47f901fd57ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de169d64-8242-4f57-980e-47f901fd57ab.jpg?1",
             "name": "Keen-Eared Sentry",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\nEach opponent can't venture into the dungeon more than once each turn.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "35645741-09eb-52ae-baa5-337af54b9f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f408c5e4-e18d-4e4d-959a-f41df4c3019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f408c5e4-e18d-4e4d-959a-f41df4c3019c.jpg?1",
             "name": "Loyal Warhound",
             "text": "Vigilance\nWhen Loyal Warhound enters the battlefield, if an opponent controls more lands than you, search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -889,7 +889,7 @@
         },
         {
             "id": "da0c3781-fcee-593a-a9cd-4458f7b5782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0556f0d9-50d2-4c67-8522-de366d96500a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0556f0d9-50d2-4c67-8522-de366d96500a.jpg?1",
             "name": "Minimus Containment",
             "text": "Enchant nonland permanent\nEnchanted permanent is a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other abilities. (If it was a creature, it's no longer a creature.)",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "d767e021-9ad1-538e-9660-8045f86ff981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d934765f-f490-4e8d-843d-b2b559ee0418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d934765f-f490-4e8d-843d-b2b559ee0418.jpg?1",
             "name": "Monk of the Open Hand",
             "text": "Flurry of Blows \u2014 Whenever you cast your second spell each turn, put a +1/+1 counter on Monk of the Open Hand.",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "b531ede1-1dae-5ef0-b2da-c75205f45d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7fea79-9600-41d2-84d2-34a61a08a0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7fea79-9600-41d2-84d2-34a61a08a0d4.jpg?1",
             "name": "Moon-Blessed Cleric",
             "text": "Divine Intervention \u2014 When Moon-Blessed Cleric enters the battlefield, you may search your library for an enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "b03d91e9-f7b1-5db3-8611-383d70cc12d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878a0d8c-11c1-4c65-9051-78e036ac496f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878a0d8c-11c1-4c65-9051-78e036ac496f.jpg?1",
             "name": "Nadaar, Selfless Paladin",
             "text": "Vigilance\nWhenever Nadaar, Selfless Paladin enters the battlefield or attacks, venture into the dungeon. (Enter the first room or advance to the next room.)\nOther creatures you control get +1/+1 as long as you've completed a dungeon.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "abe6ed57-43fa-5c01-a7bf-aee87a786fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba1650f-eddf-49a9-820e-489cb8d5b6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba1650f-eddf-49a9-820e-489cb8d5b6fa.jpg?1",
             "name": "Oswald Fiddlebender",
             "text": "Magical Tinkering \u2014 {W}, {T}, Sacrifice an artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "899f8454-af79-5f96-9d7d-51f9c2f0fc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf81fb1-7992-4ae9-b1a8-80c31579a2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf81fb1-7992-4ae9-b1a8-80c31579a2bf.jpg?1",
             "name": "Paladin Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nSpells your opponents cast during your turn cost {1} more to cast.\n{2}{W}: Level 2\n//Level_2//\nCreatures you control get +1/+1.\n{4}{W}: Level 3\n//Level_3//\nWhenever you attack, until end of turn, target attacking creature gets +1/+1 for each other attacking creature and gains double strike.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "d2f6bef8-a422-5c2a-81b8-0cea3b504033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e13b103-202f-41d7-a855-a6807e5fb4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e13b103-202f-41d7-a855-a6807e5fb4b7.jpg?1",
             "name": "Paladin's Shield",
             "text": "Flash\nWhen Paladin's Shield enters the battlefield, attach it to target creature you control.\nEquipped creature gets +0/+2.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1140,7 +1140,7 @@
         },
         {
             "id": "6e30c4e6-42d6-586b-9122-3bb3d290d55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e7457a-8ab4-4f3c-a2d8-2da4d81b7470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e7457a-8ab4-4f3c-a2d8-2da4d81b7470.jpg?1",
             "name": "Planar Ally",
             "text": "Flying\nWhenever Planar Ally attacks, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "eedd8fc2-48c8-57fe-91aa-b64ae75b5e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad447e50-cfb1-40df-ae01-a65c46f2f572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad447e50-cfb1-40df-ae01-a65c46f2f572.jpg?1",
             "name": "Plate Armor",
             "text": "Equipped creature gets +3/+3 and has ward {1}. (Whenever equipped creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nEquip {3}. This ability costs {1} less to activate for each other Equipment you control.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "a26ef69b-d755-5df9-9691-410691a8bdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594323b6-558d-4597-beb8-5346599ea571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594323b6-558d-4597-beb8-5346599ea571.jpg?1",
             "name": "A-Plate Armor",
             "text": "",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "06bd6912-deef-5163-8f5e-ade2cf7ba95f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fca8c0-ae3e-439e-b202-228b9f360e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fca8c0-ae3e-439e-b202-228b9f360e9a.jpg?1",
             "name": "Portable Hole",
             "text": "When Portable Hole enters the battlefield, exile target nonland permanent an opponent controls with mana value 2 or less until Portable Hole leaves the battlefield.",
             "colours": [
@@ -1275,7 +1275,7 @@
         },
         {
             "id": "4b5bdccf-d218-56c9-99b1-415778cd65bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5edb608-c7d7-4fa9-b969-262c9789fc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5edb608-c7d7-4fa9-b969-262c9789fc17.jpg?1",
             "name": "Potion of Healing",
             "text": "When Potion of Healing enters the battlefield, draw a card.\n{W}, {T}, Sacrifice Potion of Healing: You gain 3 life.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "4838b7ef-da7b-50ac-a5a2-239a7c41d4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10caff0-701a-48d8-a943-f947482e795a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10caff0-701a-48d8-a943-f947482e795a.jpg?1",
             "name": "Priest of Ancient Lore",
             "text": "When Priest of Ancient Lore enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "580e6e67-a2da-58b5-8342-d7793278de8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926ce53e-8e30-4018-a9e7-7266791b5d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926ce53e-8e30-4018-a9e7-7266791b5d27.jpg?1",
             "name": "Rally Maneuver",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn. Up to one other target creature gets +0/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "bda23a83-f6c7-5465-b862-b0af319d87fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a7744-e49d-4b4e-b6ae-7fc6d2892cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7a7744-e49d-4b4e-b6ae-7fc6d2892cef.jpg?1",
             "name": "Ranger's Hawk",
             "text": "Flying\n{3}, {T}, Tap another untapped creature you control: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "f0084dc6-1982-5965-beab-805d40f72183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c06b6e-faf5-467d-bfe1-9ff00be9e2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c06b6e-faf5-467d-bfe1-9ff00be9e2f5.jpg?1",
             "name": "Steadfast Paladin",
             "text": "Lifelink",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "35f87929-b34f-560c-83cb-c692280dd87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90140bc0-4a9c-4422-b07c-3400c7ccde56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90140bc0-4a9c-4422-b07c-3400c7ccde56.jpg?1",
             "name": "Teleportation Circle",
             "text": "At the beginning of your end step, exile up to one target artifact or creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "645015fb-8771-51ca-8d2c-6beb24d4a079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe33b3-afaf-4a98-ae64-7d7e0eabe993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe33b3-afaf-4a98-ae64-7d7e0eabe993.jpg?1",
             "name": "Veteran Dungeoneer",
             "text": "When Veteran Dungeoneer enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1512,7 +1512,7 @@
         },
         {
             "id": "61853856-abd2-5ad7-a1e2-72444bb6e6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e290c4-6c94-472a-9dec-6994aade29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e290c4-6c94-472a-9dec-6994aade29c2.jpg?1",
             "name": "White Dragon",
             "text": "Flying\nCold Breath \u2014 When White Dragon enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "80e2626e-6553-5977-b747-f9af228f5c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e939ab-9d0c-4685-805c-c8bc4e6af163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e939ab-9d0c-4685-805c-c8bc4e6af163.jpg?1",
             "name": "You Hear Something on Watch",
             "text": "Choose one \u2014\n\u2022 Rouse the Party \u2014 Creatures you control get +1/+1 until end of turn.\n\u2022 Set Off Traps \u2014 This spell deals 5 damage to target attacking creature.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "297cc57b-125b-51cc-b268-9a9c6d7cb74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726da84a-fdd4-46df-8ba4-f94d582bcce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726da84a-fdd4-46df-8ba4-f94d582bcce4.jpg?1",
             "name": "You're Ambushed on the Road",
             "text": "Choose one \u2014\n\u2022 Make a Retreat \u2014 Return target creature you control to its owner's hand.\n\u2022 Stand and Fight \u2014 Target creature gets +1/+3 until end of turn.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "1fc1b94c-fdf8-5006-ab2e-bdfe43986c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c6401a-e152-4acf-a2ca-75c484f296d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c6401a-e152-4acf-a2ca-75c484f296d5.jpg?1",
             "name": "Aberrant Mind Sorcerer",
             "text": "Psionic Spells \u2014 When Aberrant Mind Sorcerer enters the battlefield, choose target instant or sorcery card in your graveyard, then roll a d20.\n1\u20139 | You may put that card on top of your library.\n10\u201320 | Return that card to your hand.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "78287b02-d01a-51ff-8dc6-6e1670f0f47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba82564-a9a9-4ded-a5fa-0e5fab2a3faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba82564-a9a9-4ded-a5fa-0e5fab2a3faa.jpg?1",
             "name": "Air-Cult Elemental",
             "text": "Flying\nWhirlwind \u2014 When Air-Cult Elemental enters the battlefield, return up to one other target creature to its owner's hand.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "7f1e78e9-ef2e-5fe5-987d-16af8cff0f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc457520-9947-4f65-bbe7-9b95bd2c23af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc457520-9947-4f65-bbe7-9b95bd2c23af.jpg?1",
             "name": "Arcane Investigator",
             "text": "Search the Room \u2014 {5}{U}: Roll a d20.\n1\u20139 | Draw a card.\n10\u201320 | Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "6a24eca5-1dff-5007-b7e5-9427a657451a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b1e53f-1384-4860-9944-e68922afc65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b1e53f-1384-4860-9944-e68922afc65c.jpg?1",
             "name": "Bar the Gate",
             "text": "Counter target creature or planeswalker spell. Venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "e40944a0-a800-5547-975c-74e4a93b6197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317cbf3-13a1-4471-a23c-de429941e8a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317cbf3-13a1-4471-a23c-de429941e8a4.jpg?1",
             "name": "The Blackstaff of Waterdeep",
             "text": "You may choose not to untap The Blackstaff of Waterdeep during your untap step.\nAnimate Walking Statue \u2014 {1}{U}, {T}: Another target nontoken artifact you control becomes a 4/4 artifact creature for as long as The Blackstaff of Waterdeep remains tapped. Activate only as a sorcery.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "d2e35f3a-b4d4-500b-8eac-8e331703542a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98dea71b-2778-4374-8ea2-7fa82f0f6110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98dea71b-2778-4374-8ea2-7fa82f0f6110.jpg?1",
             "name": "Blue Dragon",
             "text": "Flying\nLightning Breath \u2014 When Blue Dragon enters the battlefield, until your next turn, target creature an opponent controls gets -3/-0, up to one other target creature gets -2/-0, and up to one other target creature gets -1/-0.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "8915342f-a13c-57cd-a477-e96ec7e00f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238ad00-af9c-4535-a589-c5afb0d2ec57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238ad00-af9c-4535-a589-c5afb0d2ec57.jpg?1",
             "name": "Charmed Sleep",
             "text": "Enchant creature\nWhen Charmed Sleep enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "eb25a48a-6516-5e50-a3c2-86723bfa08d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9784c97-3839-4a4b-ae8a-965844dbeb70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9784c97-3839-4a4b-ae8a-965844dbeb70.jpg?1",
             "name": "Clever Conjurer",
             "text": "Mage Hand \u2014 {T}: Untap target permanent not named Clever Conjurer. Activate only as a sorcery.",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "01060037-0fa1-501a-99cf-f4e2db926237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fefb38-c6f2-43c4-a6b9-ac82f8827bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fefb38-c6f2-43c4-a6b9-ac82f8827bc2.jpg?1",
             "name": "Contact Other Plane",
             "text": "Roll a d20.\n1\u20139 | Draw two cards.\n10\u201319 | Scry 2, then draw two cards.\n20 | Scry 3, then draw three cards.",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "7aef98ff-f51e-5a0b-9adf-7d41ca99b5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1351ed-b9df-4a6d-aaa1-ec6db673d265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1351ed-b9df-4a6d-aaa1-ec6db673d265.jpg?1",
             "name": "Demilich",
             "text": "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn.\nWhenever Demilich attacks, exile up to one target instant or sorcery card from your graveyard. Copy it. You may cast the copy.\nYou may cast Demilich from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "ba8f67a1-86c5-51a1-b6c6-559608da7820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8f1-3738-4db4-a2b3-7aeb4c2fd59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8f1-3738-4db4-a2b3-7aeb4c2fd59b.jpg?1",
             "name": "A-Demilich",
             "text": "",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "9a8fd651-d7bd-5e0a-b91c-9dc8ccf81a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d5c36c-bcc8-459c-9f4b-b265ccdb1f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d5c36c-bcc8-459c-9f4b-b265ccdb1f06.jpg?1",
             "name": "Displacer Beast",
             "text": "When Displacer Beast enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nDisplacement \u2014 {3}{U}: Return Displacer Beast to its owner's hand.",
             "colours": [
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "c60d0c0b-ba48-535f-8065-ff69981e874e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a42698-bf3b-4352-8178-9c98abfc5b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a42698-bf3b-4352-8178-9c98abfc5b09.jpg?1",
             "name": "Djinni Windseer",
             "text": "Flying\nWhen Djinni Windseer enters the battlefield, roll a d20.\n1\u20139 | Scry 1.\n10\u201319 | Scry 2.\n20 | Scry 3.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "cf713528-5222-5099-bdcf-9bdfe018aab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d436ba80-386f-40ad-b0ca-a98cc50de964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d436ba80-386f-40ad-b0ca-a98cc50de964.jpg?1",
             "name": "Dragon Turtle",
             "text": "Flash\nDrag Below \u2014 When Dragon Turtle enters the battlefield, tap it and up to one target creature an opponent controls. They don't untap during their controllers' next untap steps.",
             "colours": [
@@ -2103,7 +2103,7 @@
         },
         {
             "id": "7be456da-7ee8-5b46-ba63-eab6fd8cccfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa08ac-9a94-4e22-91bb-c6966cd0a0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa08ac-9a94-4e22-91bb-c6966cd0a0de.jpg?1",
             "name": "Eccentric Apprentice",
             "text": "Flying\nWhen Eccentric Apprentice enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nAt the beginning of combat on your turn, if you've completed a dungeon, up to one target creature becomes a Bird with base power and toughness 1/1 and flying until end of turn.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "b2ae9acd-2d87-5e06-ba25-72de5c74f55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93e0296-69e0-45e0-a1c2-0214a53c52d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93e0296-69e0-45e0-a1c2-0214a53c52d0.jpg?1",
             "name": "Feywild Trickster",
             "text": "Whenever you roll one or more dice, create a 1/1 blue Faerie Dragon creature token with flying.",
             "colours": [
@@ -2173,7 +2173,7 @@
         },
         {
             "id": "004f96ed-3950-5989-9b7e-eec980dac3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a91cc6-67e1-4f1b-86e2-eb388a75d6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a91cc6-67e1-4f1b-86e2-eb388a75d6ad.jpg?1",
             "name": "Fly",
             "text": "Enchant creature\nEnchanted creature has flying and \"Whenever this creature deals combat damage to a player, venture into the dungeon.\" (Enter the first room or advance to the next room.)",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "288f6728-bfa5-5618-aea3-25dbac4fbdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cca453-4611-4f3d-85d8-d74d260c7598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cca453-4611-4f3d-85d8-d74d260c7598.jpg?1",
             "name": "Grazilaxx, Illithid Scholar",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "8f753719-f926-515f-955b-d1bcc362c0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4348ec-fdb1-4c3b-bec5-42513c6c0662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4348ec-fdb1-4c3b-bec5-42513c6c0662.jpg?1",
             "name": "Guild Thief",
             "text": "Whenever Guild Thief deals combat damage to a player, put a +1/+1 counter on it.\nCunning Action \u2014 {3}{U}: Guild Thief can't be blocked this turn.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "aa7aaea3-07a0-5d21-9b2a-7399f530e3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e6025d-d273-4ae4-9929-5e588612f1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e6025d-d273-4ae4-9929-5e588612f1b3.jpg?1",
             "name": "Iymrith, Desert Doom",
             "text": "Flying\nIymrith, Desert Doom has ward {4} as long as it's untapped.\nWhenever Iymrith deals combat damage to a player, draw a card. Then if you have fewer than three cards in hand, draw cards equal to the difference.",
             "colours": [
@@ -2318,7 +2318,7 @@
         },
         {
             "id": "ef295af2-dcbc-5045-83bd-a31bac6f0cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ac797-a186-4224-94e1-9bb9dca4b029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ac797-a186-4224-94e1-9bb9dca4b029.jpg?1",
             "name": "Mind Flayer",
             "text": "Dominate Monster \u2014 When Mind Flayer enters the battlefield, gain control of target creature for as long as you control Mind Flayer.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "01b81265-d14d-53ed-9d1c-a3db1896b055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5e4c7-12fa-4ec4-bd4b-752e367306c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa5e4c7-12fa-4ec4-bd4b-752e367306c7.jpg?1",
             "name": "Mordenkainen",
             "text": "+2: Draw two cards, then put a card from your hand on the bottom of your library.\n\u22122: Create a blue Dog Illusion creature token with \"This creature's power and toughness are each equal to twice the number of cards in your hand.\"\n\u221210: Exchange your hand and library, then shuffle. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "7520da57-eb4d-5ccc-bbf6-6facb30e284e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6551442-d74c-4f16-a9de-0cfdc88208a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6551442-d74c-4f16-a9de-0cfdc88208a5.jpg?1",
             "name": "Mordenkainen's Polymorph",
             "text": "Until end of turn, target creature becomes a Dragon with base power and toughness 4/4 and gains flying. (It loses all other creature types.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "fb85ea00-52bc-526f-8f9f-c7db5c71a318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65631b9-ca62-4851-9eca-9c760fb1a177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65631b9-ca62-4851-9eca-9c760fb1a177.jpg?1",
             "name": "Pixie Guide",
             "text": "Flying\nGrant an Advantage \u2014 If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "32ddf2da-bb81-58c8-99b1-b0d9080fe208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d84cb72-d0a0-4af0-aded-47e5fb7addef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d84cb72-d0a0-4af0-aded-47e5fb7addef.jpg?1",
             "name": "Power of Persuasion",
             "text": "Choose target creature an opponent controls, then roll a d20.\n1\u20139 | Return it to its owner's hand.\n10\u201319 | Its owner puts it on the top or bottom of their library.\n20 | Gain control of it until the end of your next turn.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "e004d31b-cce6-5146-a386-1c4179c9d0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edd5058-a964-4288-937b-84df6e9ba7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edd5058-a964-4288-937b-84df6e9ba7c4.jpg?1",
             "name": "Ray of Frost",
             "text": "Flash\nEnchant creature\nWhen Ray of Frost enters the battlefield, if enchanted creature is red, tap it.\nAs long as enchanted creature is red, it loses all abilities.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "f576f880-f951-5755-a9c9-6706a35c02df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767b499e-3bdb-4809-b430-6e965bd100d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767b499e-3bdb-4809-b430-6e965bd100d4.jpg?1",
             "name": "Rimeshield Frost Giant",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "79677dd7-db55-5b2d-a1a1-7778ec1df2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0abdb4-4898-4818-b7e2-24a90f15e49d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0abdb4-4898-4818-b7e2-24a90f15e49d.jpg?1",
             "name": "Scion of Stygia",
             "text": "Flash\nCone of Cold \u2014 When Scion of Stygia enters the battlefield, choose target creature an opponent controls, then roll a d20.\n1\u20139 | Tap that creature.\n10\u201320 | Tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "356d5bbc-ccd3-5c34-8c75-9222693d1b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191e400-aa4e-4955-aca0-ecbe63ea240f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191e400-aa4e-4955-aca0-ecbe63ea240f.jpg?1",
             "name": "Secret Door",
             "text": "Defender\n{4}{U}: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "4bb6e122-bb02-589b-a9ef-0a61373fb6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95fe13-c09b-4eed-aeae-fb1c5b6eb476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95fe13-c09b-4eed-aeae-fb1c5b6eb476.jpg?1",
             "name": "Shocking Grasp",
             "text": "Target creature gets -2/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2665,7 +2665,7 @@
         },
         {
             "id": "9088f568-0ea7-5d2a-9c3a-4c96ac184460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d2635-c4f4-44cd-8f82-37e3016e421e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d2635-c4f4-44cd-8f82-37e3016e421e.jpg?1",
             "name": "Shortcut Seeker",
             "text": "Whenever Shortcut Seeker deals combat damage to a player, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "9b6e0133-7a33-55ce-91b7-5aad074841f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a671ec19-32f4-4fde-8ee0-1224471e79db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a671ec19-32f4-4fde-8ee0-1224471e79db.jpg?1",
             "name": "Silver Raven",
             "text": "Flying\nWhen Silver Raven enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "fb81a0ca-771b-53b9-b1d2-413d784dd70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c7c23-d418-42f0-b497-50c39e5321ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c7c23-d418-42f0-b497-50c39e5321ad.jpg?1",
             "name": "Soulknife Spy",
             "text": "Whenever Soulknife Spy deals combat damage to a player, draw a card.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "9698e68c-2e32-56da-9b88-43425599280f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a0a96-f90a-4852-9a92-848795518e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a0a96-f90a-4852-9a92-848795518e0a.jpg?1",
             "name": "Split the Party",
             "text": "Choose target player. Return half the creatures they control to their owner's hand, rounded up.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "600da950-44c0-5779-9a75-dc2fc8f0e3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec3c87-d5aa-4f8a-a9bf-ef4e38e21ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec3c87-d5aa-4f8a-a9bf-ef4e38e21ad1.jpg?1",
             "name": "Sudden Insight",
             "text": "Draw a card for each different mana value among nonland cards in your graveyard.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "1856e137-f857-5f62-ae24-0d54b0637136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4932113-904f-427a-9566-509cc008f3ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4932113-904f-427a-9566-509cc008f3ef.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "Each opponent exiles cards from the top of their library until that player has exiled cards with total mana value 20 or more.",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "fadc99f4-201f-51d8-aefa-9802f153f220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cb9973-c9ce-48f1-9972-651092624751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cb9973-c9ce-48f1-9972-651092624751.jpg?1",
             "name": "Trickster's Talisman",
             "text": "Invoke Duplicity \u2014 Equipped creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, you may sacrifice Trickster's Talisman. If you do, create a token that's a copy of this creature.\"\nEquip {2}",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "530e6d78-a560-5ccd-b2c3-48992a3c128f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a1f384-9266-425c-b739-09d74871fc7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a1f384-9266-425c-b739-09d74871fc7b.jpg?1",
             "name": "True Polymorph",
             "text": "Target artifact or creature becomes a copy of another target artifact or creature.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "ba15381c-f047-5a1d-b3ed-d8323e2c0c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f629fb-b097-4240-8560-ef47f5678f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f629fb-b097-4240-8560-ef47f5678f48.jpg?1",
             "name": "Wizard Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nYou have no maximum hand size.\n{2}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, draw two cards.\n{4}{U}: Level 3\n//Level_3//\nWhenever you draw a card, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "03e93041-9a58-5019-b8e4-b88c150d941e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab73fa2c-b89f-4f1c-b8bf-f00c024a00bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab73fa2c-b89f-4f1c-b8bf-f00c024a00bd.jpg?1",
             "name": "A-Wizard Class",
             "text": "",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "6c8872f8-e479-50cc-9ae6-53920725df73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed0a4c-0234-4341-8dcb-5eea6a9632e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed0a4c-0234-4341-8dcb-5eea6a9632e7.jpg?1",
             "name": "Wizard's Spellbook",
             "text": "{T}: Exile target instant or sorcery card from a graveyard. Roll a d20. Activate only as a sorcery.\n1\u20139 | Copy that card. You may cast the copy.\n10\u201319 | Copy that card. You may cast the copy by paying {1} rather than paying its mana cost.\n20 | Copy each card exiled with Wizard's Spellbook. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "abb683c4-b785-50b9-b49a-ace63ad485d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf9bab7-98a0-4394-90c0-e7c52e14eb37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf9bab7-98a0-4394-90c0-e7c52e14eb37.jpg?1",
             "name": "You Come to a River",
             "text": "Choose one \u2014\n\u2022 Fight the Current \u2014 Return target nonland permanent to its owner's hand.\n\u2022 Find a Crossing \u2014 Target creature gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "8815e98a-6d2a-5a08-a03d-9b9978c3dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6704458-6e9e-4795-a56d-25b68fbf9672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6704458-6e9e-4795-a56d-25b68fbf9672.jpg?1",
             "name": "You Find the Villains' Lair",
             "text": "Choose one \u2014\n\u2022 Foil Their Scheme \u2014 Counter target spell.\n\u2022 Learn Their Secrets \u2014 Draw two cards, then discard two cards.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "29c3b987-75de-5a70-a021-799395a57a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c5fd8e-753a-45e1-bcdd-fb6e072ffbb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c5fd8e-753a-45e1-bcdd-fb6e072ffbb0.jpg?1",
             "name": "You See a Guard Approach",
             "text": "Choose one \u2014\n\u2022 Distract the Guard \u2014 Tap target creature.\n\u2022 Hide \u2014 Target creature you control gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "b2d123e1-4368-5a0e-bb5d-030dca899907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f51afd9-7093-4aa3-ad5b-7383684d6285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f51afd9-7093-4aa3-ad5b-7383684d6285.jpg?1",
             "name": "Yuan-Ti Malison",
             "text": "Yuan-Ti Malison can't be blocked as long as it's attacking alone.\nWhenever Yuan-Ti Malison deals combat damage to a player, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "732fd43f-9dd5-54ab-84ac-cf62ea3b6c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52d0bd-3abd-401c-9f56-ee911613da3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52d0bd-3abd-401c-9f56-ee911613da3b.jpg?1",
             "name": "Acererak the Archlich",
             "text": "When Acererak the Archlich enters the battlefield, if you haven't completed Tomb of Annihilation, return Acererak the Archlich to its owner's hand and venture into the dungeon.\nWhenever Acererak the Archlich attacks, for each opponent, you create a 2/2 black Zombie creature token unless that player sacrifices a creature.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "ee850195-8744-5177-8419-b56b4ecd7bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb363654-2004-4db8-bbd2-5b121da4f2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb363654-2004-4db8-bbd2-5b121da4f2a0.jpg?1",
             "name": "A-Acererak the Archlich",
             "text": "",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "70e61f81-2036-51f4-805a-71dc9265da98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6b864-58e7-43b9-9d79-1d0361340960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6b864-58e7-43b9-9d79-1d0361340960.jpg?1",
             "name": "Asmodeus the Archfiend",
             "text": "Binding Contract \u2014 If you would draw a card, exile the top card of your library face down instead.\n{B}{B}{B}: Draw seven cards.\n{B}: Return all cards exiled with Asmodeus the Archfiend to their owner's hand and you lose that much life.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "cf476891-4ff5-575c-94ba-29656db9b3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d6ef6-d8a3-4288-8917-4c0a179ed4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d6ef6-d8a3-4288-8917-4c0a179ed4e0.jpg?1",
             "name": "Baleful Beholder",
             "text": "When Baleful Beholder enters the battlefield, choose one \u2014\n\u2022 Antimagic Cone \u2014 Each opponent sacrifices an enchantment.\n\u2022 Fear Ray \u2014 Creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "ed8922d9-88e9-5e0a-8b8a-82e6382c1676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca283a-39f1-4ae7-98fb-7821a927ef86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca283a-39f1-4ae7-98fb-7821a927ef86.jpg?1",
             "name": "Black Dragon",
             "text": "Flying\nAcid Breath \u2014 When Black Dragon enters the battlefield, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "323cd41d-5080-53f6-b4bb-8c014872c9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05dcff61-8c48-401f-a31f-5fc53a298356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05dcff61-8c48-401f-a31f-5fc53a298356.jpg?1",
             "name": "The Book of Vile Darkness",
             "text": "At the beginning of your end step, if you lost 2 or more life this turn, create a 2/2 black Zombie creature token.\n{T}, Exile The Book of Vile Darkness and artifacts you control named Eye of Vecna and Hand of Vecna: Create Vecna, a legendary 8/8 black Zombie God creature token with indestructible. It gains all triggered abilities of the exiled cards.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "11426a68-91cf-51b1-ba4b-ae7c32d96ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f58ea8a-30ac-45b0-a701-8b8d8262cfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f58ea8a-30ac-45b0-a701-8b8d8262cfcf.jpg?1",
             "name": "Check for Traps",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If an instant card or a card with flash is exiled this way, they lose 1 life. Otherwise, you lose 1 life.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "10cf68ba-9c72-562a-9c97-4c8db9e24645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac0b2b-d4d3-4977-b241-7788239362de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac0b2b-d4d3-4977-b241-7788239362de.jpg?1",
             "name": "Clattering Skeletons",
             "text": "When Clattering Skeletons dies, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "ce2ff8be-efc7-56b7-89ad-0c9d2a5d49a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7373fe95-ad1c-44b9-8c7f-464ce8cbffc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7373fe95-ad1c-44b9-8c7f-464ce8cbffc6.jpg?1",
             "name": "Deadly Dispute",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "9ec4dbea-2cb5-5364-9f07-31fde3fd5043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126b2636-030a-4a0e-9307-54c3372afb52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126b2636-030a-4a0e-9307-54c3372afb52.jpg?1",
             "name": "Death-Priest of Myrkul",
             "text": "Skeletons, Vampires, and Zombies you control get +1/+1.\nAt the beginning of your end step, if a creature died this turn, you may pay {1}. If you do, create a 1/1 black Skeleton creature token.",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "563992c1-5a64-5f3b-9286-ab80e13aa9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f756f0c8-bab6-45cf-a433-409b3c999263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f756f0c8-bab6-45cf-a433-409b3c999263.jpg?1",
             "name": "A-Death-Priest of Myrkul",
             "text": "",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "6a2bfb66-7b12-55c3-a216-34a63be21138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e7ac6-65e5-4a16-ab0b-0988c3a3cfea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e7ac6-65e5-4a16-ab0b-0988c3a3cfea.jpg?1",
             "name": "Demogorgon's Clutches",
             "text": "Target opponent discards two cards, mills two cards, and loses 2 life. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "051c5c0a-a27b-5658-b396-43fc1a0224ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c34f2d-2eac-4241-8b23-9cab3268c254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c34f2d-2eac-4241-8b23-9cab3268c254.jpg?1",
             "name": "Devour Intellect",
             "text": "Target opponent discards a card. If mana from a Treasure was spent to cast this spell, instead that player reveals their hand, you choose a nonland card from it, then that player discards that card.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "aca3bc38-5d58-5232-93dd-8d277a2e8abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc06a88-1eb6-4edb-8f03-d8274560cc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc06a88-1eb6-4edb-8f03-d8274560cc41.jpg?1",
             "name": "Drider",
             "text": "Reach\nWhenever Drider deals combat damage to a player, create a 2/1 black Spider creature token with menace and reach.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "eaf97c2d-7bf1-5f08-af56-4fddbd437343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138b66d-cf18-42a5-8522-241bd3969624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138b66d-cf18-42a5-8522-241bd3969624.jpg?1",
             "name": "Dungeon Crawler",
             "text": "Dungeon Crawler enters the battlefield tapped.\nWhenever you complete a dungeon, you may return Dungeon Crawler from your graveyard to your hand.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "337f7563-4636-5f32-a818-186dbcd2ac1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3f460-92ba-4af0-aad9-cf86615d4177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3f460-92ba-4af0-aad9-cf86615d4177.jpg?1",
             "name": "Ebondeath, Dracolich",
             "text": "Flash\nFlying\nEbondeath, Dracolich enters the battlefield tapped.\nYou may cast Ebondeath, Dracolich from your graveyard if a creature not named Ebondeath, Dracolich died this turn.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "04870bbc-4ac2-554b-99cf-9b9b53348413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9e5402-690f-497d-ada3-aa41fa900fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9e5402-690f-497d-ada3-aa41fa900fdd.jpg?1",
             "name": "Eyes of the Beholder",
             "text": "Target creature gets -11/-11 until end of turn.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "75b004de-ff34-53e7-84d4-33b85e85cf5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ff3d76-e985-4d8d-837e-89360cc23824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ff3d76-e985-4d8d-837e-89360cc23824.jpg?1",
             "name": "Fates' Reversal",
             "text": "Return up to one target creature card from your graveyard to your hand. Venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "81581ca7-994a-534e-a420-8e1bfc912aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca09f699-c3e9-436e-b1b3-0fcd1ef3273f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca09f699-c3e9-436e-b1b3-0fcd1ef3273f.jpg?1",
             "name": "A-Fates' Reversal",
             "text": "",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "69d73377-2b6c-51a7-b693-1b82bf75bc3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af7061-fca6-4a06-be3c-01881e6b96f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af7061-fca6-4a06-be3c-01881e6b96f7.jpg?1",
             "name": "Feign Death",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "1f0291a0-9b05-54f8-bde8-5c6706165b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acaf396-f950-42da-85ab-149ffb31fee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acaf396-f950-42da-85ab-149ffb31fee6.jpg?1",
             "name": "Forsworn Paladin",
             "text": "Menace\n{1}{B}, {T}, Pay 1 life: Create a Treasure token.\n{2}{B}: Target creature gets +2/+0 until end of turn. If mana from a Treasure was spent to activate this ability, that creature also gains deathtouch until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "6ff02819-54cc-557f-a5ae-abb4aa0afa76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c472e70-300c-4881-86e7-c5ca690ab9b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c472e70-300c-4881-86e7-c5ca690ab9b6.jpg?1",
             "name": "Gelatinous Cube",
             "text": "Engulf \u2014 When Gelatinous Cube enters the battlefield, exile target non-Ooze creature an opponent controls until Gelatinous Cube leaves the battlefield.\nDissolve \u2014 {X}{B}: Put target creature card with mana value X exiled with Gelatinous Cube into its owner's graveyard.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "d31dc231-0556-52e8-8d0b-b8b94aacb042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98e0ab1-dea8-492b-a712-2057f2b1d020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98e0ab1-dea8-492b-a712-2057f2b1d020.jpg?1",
             "name": "Grim Bounty",
             "text": "Destroy target creature or planeswalker. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "34c64088-eed6-5177-ac49-689cde3f52ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e339f0f7-a79d-4947-a9c4-b9a0949dd06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e339f0f7-a79d-4947-a9c4-b9a0949dd06a.jpg?1",
             "name": "Grim Wanderer",
             "text": "Flash\nTragic Backstory \u2014 Cast this spell only if a creature died this turn.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "768fd46f-3c36-54ea-8b22-0d9421066615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa74204-2593-4468-856d-a5791336126a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa74204-2593-4468-856d-a5791336126a.jpg?1",
             "name": "Herald of Hadar",
             "text": "Circle of Death \u2014 {5}{B}: Roll a d20.\n1\u20139 | Each opponent loses 2 life.\n10\u201319 | Each opponent loses 2 life and you gain 2 life.\n20 | Each opponent loses 2 life and you gain 2 life. Create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "7527157a-21fc-5876-a489-dfc268144cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cbf01-90d0-4962-92d5-5e1566e8ef4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cbf01-90d0-4962-92d5-5e1566e8ef4b.jpg?1",
             "name": "Hired Hexblade",
             "text": "When Hired Hexblade enters the battlefield, if mana from a Treasure was spent to cast it, you draw a card and you lose 1 life.",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "e1e38eaa-bbd6-501a-bfec-30d7d9faeb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b723d9cd-05f5-4894-9f2b-52a434a3019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b723d9cd-05f5-4894-9f2b-52a434a3019c.jpg?1",
             "name": "Hoard Robber",
             "text": "Whenever Hoard Robber deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "510ac995-ace6-551b-b093-a493fd3cfc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f88de61-8dee-46b3-91b2-d4cdb4db36bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f88de61-8dee-46b3-91b2-d4cdb4db36bf.jpg?1",
             "name": "Lightfoot Rogue",
             "text": "Sneak Attack \u2014 Whenever Lightfoot Rogue attacks, roll a d20.\n1\u20139 | Lightfoot Rogue gains deathtouch until end of turn.\n10\u201319 | It gets +1/+0 and gains deathtouch until end of turn.\n20 | It gets +3/+0 and gains first strike and deathtouch until end of turn.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "62a32218-36da-5a88-8873-00b54b752f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420a5689-d73e-4dda-82fd-8b8897ff5b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420a5689-d73e-4dda-82fd-8b8897ff5b55.jpg?1",
             "name": "Lolth, Spider Queen",
             "text": "Whenever a creature you control dies, put a loyalty counter on Lolth, Spider Queen.\n0: You draw a card and you lose 1 life.\n\u22123: Create two 2/1 black Spider creature tokens with menace and reach.\n\u22128: You get an emblem with \"Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference.\"",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "1ff334b3-8af0-5f6a-a4d1-154d010eed53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d9117-724a-4b67-be27-142b9c283788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d9117-724a-4b67-be27-142b9c283788.jpg?1",
             "name": "Manticore",
             "text": "Flash\nFlying\nTail Spikes \u2014 When Manticore enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "05fd7c0e-9965-5b81-b982-c59681d98d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395b6ce4-143f-4eed-b565-98aa3d6208ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395b6ce4-143f-4eed-b565-98aa3d6208ef.jpg?1",
             "name": "Power Word Kill",
             "text": "Destroy target non-Angel, non-Demon, non-Devil, non-Dragon creature.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "258184db-3658-58ac-a0ac-e91966e3468d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7293f9b4-565a-4065-940b-543f76ebecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7293f9b4-565a-4065-940b-543f76ebecae.jpg?1",
             "name": "Precipitous Drop",
             "text": "Enchant creature\nWhen Precipitous Drop enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nEnchanted creature gets -2/-2. It gets -5/-5 instead as long as you've completed a dungeon.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "747815de-0316-5e3e-b88b-6c111ff7c1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77808663-2511-4495-a779-d4294a621c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77808663-2511-4495-a779-d4294a621c7f.jpg?1",
             "name": "A-Precipitous Drop",
             "text": "",
             "colours": [
@@ -4317,7 +4317,7 @@
         },
         {
             "id": "70ba8c5c-6833-582e-92a7-6345b56b2d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5d948b-fd89-4b90-9b63-ad7da13b5f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5d948b-fd89-4b90-9b63-ad7da13b5f0e.jpg?1",
             "name": "Ray of Enfeeblement",
             "text": "Target creature gets -4/-1 until end of turn. If that creature is white, it gets -4/-4 until end of turn instead.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "bdf1d766-617c-50d2-93c2-ef47caa29e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b68168-e77d-4745-9393-726ef9fb72ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b68168-e77d-4745-9393-726ef9fb72ec.jpg?1",
             "name": "Reaper's Talisman",
             "text": "Whenever equipped creature attacks, it gains deathtouch until end of turn.\nWhenever equipped creature attacks alone, defending player loses 2 life and you gain 2 life.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "38a438c7-9f83-52c7-bf66-db0d3aa1dbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b302bc8-683f-4a26-ab86-87eaa19dce4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b302bc8-683f-4a26-ab86-87eaa19dce4d.jpg?1",
             "name": "Sepulcher Ghoul",
             "text": "Sacrifice another creature: Sepulcher Ghoul gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "07b79f04-d641-5b87-9ede-ab6ab093e371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af167ef-40f9-4734-a14b-6024ddf93871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af167ef-40f9-4734-a14b-6024ddf93871.jpg?1",
             "name": "A-Sepulcher Ghoul",
             "text": "",
             "colours": [
@@ -4450,7 +4450,7 @@
         },
         {
             "id": "9f9b3530-ee98-56f9-bf30-e6bd31dc6c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96198a7-dd19-4940-bf8f-23135011fc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96198a7-dd19-4940-bf8f-23135011fc84.jpg?1",
             "name": "Shambling Ghast",
             "text": "When Shambling Ghast dies, choose one \u2014\n\u2022 Brave the Stench \u2014 Target creature an opponent controls gets -1/-1 until end of turn.\n\u2022 Search the Body \u2014 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "810c5a9c-2047-5470-9ff1-f11b7187374f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb8865-dc37-4d56-9a2d-a92f7462c338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb8865-dc37-4d56-9a2d-a92f7462c338.jpg?1",
             "name": "Skullport Merchant",
             "text": "When Skullport Merchant enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{1}{B}, Sacrifice another creature or a Treasure: Draw a card.",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "4e092a3d-d58a-5040-8619-94937696dff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2315a9-584b-4c59-af43-dd38bcb6c322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2315a9-584b-4c59-af43-dd38bcb6c322.jpg?1",
             "name": "Sphere of Annihilation",
             "text": "Sphere of Annihilation enters the battlefield with X void counters on it.\nAt the beginning of your upkeep, exile Sphere of Annihilation, all creatures and planeswalkers with mana value less than or equal to the number of void counters on it, and all creature and planeswalker cards in graveyards with mana value less than or equal to the number of void counters on it.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "d62f9016-8491-55c8-a588-fd18c21a8a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b922e-32dd-4645-b6f4-c07d1a0c70fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b922e-32dd-4645-b6f4-c07d1a0c70fc.jpg?1",
             "name": "Thieves' Tools",
             "text": "When Thieves' Tools enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature can't be blocked as long as its power is 3 or less.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "f77bcd4a-eb30-535b-bf2d-ad5de7273336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8975c72-b2ec-4c5f-86a4-4e1e3bb41c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8975c72-b2ec-4c5f-86a4-4e1e3bb41c15.jpg?1",
             "name": "Vampire Spawn",
             "text": "When Vampire Spawn enters the battlefield, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "e7d85626-4781-5372-ac5e-ae715d0b3587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7adbe69f-326d-4b4f-850f-c57a1860d17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7adbe69f-326d-4b4f-850f-c57a1860d17c.jpg?1",
             "name": "Vorpal Sword",
             "text": "Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains \"Whenever equipped creature deals combat damage to a player, that player loses the game.\"\nEquip {B}{B}",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "67788daf-fa5d-5e95-bfa3-a91515600170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7faf899-96b7-454e-b634-6684c2d72f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7faf899-96b7-454e-b634-6684c2d72f26.jpg?1",
             "name": "Warlock Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nAt the beginning of your end step, if a creature died this turn, each opponent loses 1 life.\n{1}{B}: Level 2\n//Level_2//\nWhen this Class becomes level 2, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n{6}{B}: Level 3\n//Level_3//\nAt the beginning of your end step, each opponent loses life equal to the life they lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "6713fd53-4a86-5ee2-b4c0-2d0fa44b4b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e757cc7d-b9cc-4ef1-80c9-a22755a6d271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e757cc7d-b9cc-4ef1-80c9-a22755a6d271.jpg?1",
             "name": "Westgate Regent",
             "text": "Flying\nWard\u2014\nDiscard a card. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player discards a card.)\nWhenever Westgate Regent deals combat damage to a player, put that many +1/+1 counters on it.",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "e90d59a4-1624-57fe-a72e-a5740cd2cf04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62abe9c-7599-433b-a964-10d6641f3586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62abe9c-7599-433b-a964-10d6641f3586.jpg?1",
             "name": "Wight",
             "text": "Wight enters the battlefield tapped.\nLife Drain \u2014 Whenever a creature dealt damage by Wight this turn dies, create a tapped 2/2 black Zombie creature token and exile that card.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "9b234f2c-385e-5f1e-84f7-fefa4b04ccc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e0e09c-ed43-4a37-85f2-c60bdfdb2624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e0e09c-ed43-4a37-85f2-c60bdfdb2624.jpg?1",
             "name": "Yuan-Ti Fang-Blade",
             "text": "Deathtouch\nWhenever Yuan-Ti Fang-Blade deals combat damage to a player, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "f4797ad6-2ad2-54e0-b7ec-df4b787a0169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dbed36-190c-4748-b282-409a2fb5d134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dbed36-190c-4748-b282-409a2fb5d134.jpg?1",
             "name": "Zombie Ogre",
             "text": "At the beginning of your end step, if a creature died this turn, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "463bdf2d-e1b8-519d-bcac-52b271b75984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177f57e-c239-47e8-ae50-5f593f6d54ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177f57e-c239-47e8-ae50-5f593f6d54ec.jpg?1",
             "name": "Armory Veteran",
             "text": "As long as Armory Veteran is equipped, it has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "fab07f09-5524-5819-b55a-cb8e0cd28255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f13ba-e165-4add-9935-d88503e1e761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f13ba-e165-4add-9935-d88503e1e761.jpg?1",
             "name": "A-Armory Veteran",
             "text": "",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "b0273110-eb0a-5739-9eee-651b7a3105c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647c2269-bdc7-4455-9158-73abbff6e50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647c2269-bdc7-4455-9158-73abbff6e50e.jpg?1",
             "name": "Barbarian Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nIf you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\n{1}{R}: Level 2\n//Level_2//\nWhenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn.\n{2}{R}: Level 3\n//Level_3//\nCreatures you control have haste.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "5b9f1b27-625b-5570-97fc-e66eb9a9210a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9766a427-2bb3-4028-a502-d1194cdc93aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9766a427-2bb3-4028-a502-d1194cdc93aa.jpg?1",
             "name": "Battle Cry Goblin",
             "text": "{1}{R}: Goblins you control get +1/+0 and gain haste until end of turn.\nPack tactics \u2014 Whenever Battle Cry Goblin attacks, if you attacked with creatures with total power 6 or greater this combat, create a 1/1 red Goblin creature token that's tapped and attacking.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "3765a967-9dfe-5231-81bb-ca7c0f3eab16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9913-3d4f-4f47-ba3a-6586a50ddbd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9913-3d4f-4f47-ba3a-6586a50ddbd7.jpg?1",
             "name": "Boots of Speed",
             "text": "Equipped creature gets +1/+0 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "0d504cc0-0529-5958-818d-f3fce3da8e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3658e65b-df54-4327-9104-c2f3dd65df85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3658e65b-df54-4327-9104-c2f3dd65df85.jpg?1",
             "name": "Brazen Dwarf",
             "text": "Whenever you roll one or more dice, Brazen Dwarf deals 1 damage to each opponent.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "237ef449-554e-5fe3-9a35-723cb586dc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e2d723-3fa0-4411-8f98-e4e6b3a5e6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e2d723-3fa0-4411-8f98-e4e6b3a5e6df.jpg?1",
             "name": "Burning Hands",
             "text": "Burning Hands deals 2 damage to target creature or planeswalker. If that permanent is green, Burning Hands deals 6 damage instead.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "0548f416-ba0f-5dc2-a1f1-67174b2799d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb587-f732-42c9-a2a7-152629889997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb587-f732-42c9-a2a7-152629889997.jpg?1",
             "name": "Chaos Channeler",
             "text": "Wild Magic Surge \u2014 Whenever Chaos Channeler attacks, roll a d20.\n1\u20139 | Exile the top card of your library. You may play it this turn.\n10\u201319 | Exile the top two cards of your library. You may play them this turn.\n20 | Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "c4afaccb-e720-532a-942e-340dfc79864f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9aaaf-0b51-4721-b75c-923892a41743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9aaaf-0b51-4721-b75c-923892a41743.jpg?1",
             "name": "Critical Hit",
             "text": "Target creature gains double strike until end of turn.\nWhen you roll a natural 20, return Critical Hit from your graveyard to your hand. (A natural 20 is a roll that displays 20 on the die.)",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "50dfb676-1b9c-59e4-be6b-5c9c928e5f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87459aa-af8f-4bd2-a310-151353083a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87459aa-af8f-4bd2-a310-151353083a2e.jpg?1",
             "name": "Delina, Wild Mage",
             "text": "Whenever Delina, Wild Mage attacks, choose target creature you control, then roll a d20.\n1\u201314 | Create a tapped and attacking token that's a copy of that creature, except it's not legendary and it has \"Exile this creature at end of combat.\"\n15\u201320 | Create one of those tokens. Roll again.",
             "colours": [
@@ -5179,7 +5179,7 @@
         },
         {
             "id": "e92523cc-b633-5bc9-9013-4b427c72b9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666987a-5267-46d3-9b00-31baa92a9cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666987a-5267-46d3-9b00-31baa92a9cbc.jpg?1",
             "name": "Dragon's Fire",
             "text": "As an additional cost to cast this spell, you may reveal a Dragon card from your hand or choose a Dragon you control.\nDragon's Fire deals 3 damage to target creature or planeswalker. If you revealed a Dragon card or chose a Dragon as you cast this spell, Dragon's Fire deals damage equal to the power of that card or creature instead.",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "6c996341-be3c-5b0b-9ec7-7ea0c732b5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c304118a-c83b-490a-b0e2-721734a996ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c304118a-c83b-490a-b0e2-721734a996ee.jpg?1",
             "name": "Dueling Rapier",
             "text": "Flash\nWhen Dueling Rapier enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "e41145ff-bd05-591a-abe8-596cb6856fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa05f317-b2f8-4eea-951b-0c374774764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa05f317-b2f8-4eea-951b-0c374774764b.jpg?1",
             "name": "Earth-Cult Elemental",
             "text": "Siege Monster \u2014 When Earth-Cult Elemental enters the battlefield, roll a d20.\n1\u20139 | Each player sacrifices a permanent.\n10\u201319 | Each opponent sacrifices a permanent.\n20 | Each opponent sacrifices two permanents.",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "5d9ca8ca-3f86-5345-83aa-c3c25097f0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a46987-f05a-4b83-af56-f18000874e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a46987-f05a-4b83-af56-f18000874e65.jpg?1",
             "name": "Farideh's Fireball",
             "text": "Farideh's Fireball deals 5 damage to target creature or planeswalker. Roll a d20.\n1\u20139 | Farideh's Fireball deals 2 damage to each player.\n10\u201320 | Farideh's Fireball deals 2 damage to each opponent.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "d9e04a19-9770-5501-8042-ee5c04de1fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3f766-4098-4023-9a23-e9ff6722b66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3f766-4098-4023-9a23-e9ff6722b66d.jpg?1",
             "name": "Flameskull",
             "text": "Flying\nFlameskull can't block.\nRejuvenation \u2014 When Flameskull dies, exile it. If you do, exile the top card of your library. Until the end of your next turn, you may play one of those cards. (If you cast Flameskull this way, you can't play the other card, and vice versa.)",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "267025df-3279-555c-8b2e-5d45a2ddde5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3f1b-40cb-413d-adb9-0809e4a2abdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32b3f1b-40cb-413d-adb9-0809e4a2abdd.jpg?1",
             "name": "Goblin Javelineer",
             "text": "Haste\nWhenever Goblin Javelineer becomes blocked, it deals 1 damage to target creature blocking it.",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "edb843a4-64ba-5c4d-826d-8cdc662491d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998f3785-c806-4848-adcb-d89ea51159c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998f3785-c806-4848-adcb-d89ea51159c5.jpg?1",
             "name": "Goblin Morningstar",
             "text": "Equipped creature gets +1/+0 and has trample.\nEquip {1}{R}\nWhen Goblin Morningstar enters the battlefield, roll a d20.\n1\u20139 | Create a 1/1 red Goblin creature token.\n10\u201320 | Create a 1/1 red Goblin creature token, then attach Goblin Morningstar to it.",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "2ad4c22c-c17a-554e-8b30-4aa9e3313586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df39eaac-b13f-4cb3-960d-8f7a0d590663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df39eaac-b13f-4cb3-960d-8f7a0d590663.jpg?1",
             "name": "Hoarding Ogre",
             "text": "Whenever Hoarding Ogre attacks, roll a d20.\n1\u20139 | Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n10\u201319 | Create two Treasure tokens.\n20 | Create three Treasure tokens.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "c3ac4c31-5b04-5473-8f33-ebf235a60a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e9dc36-f2d8-4384-98cb-e44c00b02433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e9dc36-f2d8-4384-98cb-e44c00b02433.jpg?1",
             "name": "Hobgoblin Bandit Lord",
             "text": "Other Goblins you control get +1/+1.\n{R}, {T}: Hobgoblin Bandit Lord deals damage equal to the number of Goblins that entered the battlefield under your control this turn to any target.",
             "colours": [
@@ -5489,7 +5489,7 @@
         },
         {
             "id": "09676604-3492-5f86-b952-611438d92f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0aa86-fd3b-4e0f-9d37-ce1ea8922243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0aa86-fd3b-4e0f-9d37-ce1ea8922243.jpg?1",
             "name": "Hobgoblin Captain",
             "text": "Pack tactics \u2014 Whenever Hobgoblin Captain attacks, if you attacked with creatures with total power 6 or greater this combat, Hobgoblin Captain gains first strike until end of turn.",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "e7ca8bc3-0bf2-5df0-a40e-c655250a597d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55d43d4-5f63-45c3-b8f8-0aebd23750a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55d43d4-5f63-45c3-b8f8-0aebd23750a5.jpg?1",
             "name": "Hulking Bugbear",
             "text": "Haste",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "bed203af-7d49-56f2-9460-fcdc5af98c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d5fd00-c616-4079-a91e-4da0bcaf9120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d5fd00-c616-4079-a91e-4da0bcaf9120.jpg?1",
             "name": "Improvised Weaponry",
             "text": "Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5592,7 +5592,7 @@
         },
         {
             "id": "7c9417e3-8e35-57f4-9711-b74af2edb06f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c788c6a6-20d9-4a93-a898-330b085226c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c788c6a6-20d9-4a93-a898-330b085226c4.jpg?1",
             "name": "Inferno of the Star Mounts",
             "text": "This spell can't be countered.\nFlying, haste\n{R}: Inferno of the Star Mounts gets +1/+0 until end of turn. When its power becomes 20 this way, it deals 20 damage to any target.",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "f1b0ac92-4a0a-5808-9abb-0f1f30b860f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5219c0-fb43-47b1-b682-131ba7c70990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5219c0-fb43-47b1-b682-131ba7c70990.jpg?1",
             "name": "Jaded Sell-Sword",
             "text": "When Jaded Sell-Sword enters the battlefield, if mana from a Treasure was spent to cast it, it gains first strike and haste until end of turn.",
             "colours": [
@@ -5665,7 +5665,7 @@
         },
         {
             "id": "01733566-8103-56e1-b06c-7cdc35bb7000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222102d0-fed3-41fd-87b0-f6d22766d7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222102d0-fed3-41fd-87b0-f6d22766d7fd.jpg?1",
             "name": "Kick in the Door",
             "text": "Put a +1/+1 counter on target creature. That creature gains haste until end of turn and can't be blocked by Walls this turn. Venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "9e85e1d8-b32a-5e36-b269-726960011cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c814ac58-8826-48cd-8209-4af6803866e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c814ac58-8826-48cd-8209-4af6803866e3.jpg?1",
             "name": "Magic Missile",
             "text": "This spell can't be countered.\nMagic Missile deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -5731,7 +5731,7 @@
         },
         {
             "id": "ffdcd935-8e9f-5da3-b765-09a227de4c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f5e669-4e69-4763-bbb9-e9685bde912c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f5e669-4e69-4763-bbb9-e9685bde912c.jpg?1",
             "name": "Meteor Swarm",
             "text": "Meteor Swarm deals 8 damage divided as you choose among X target creatures and/or planeswalkers.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "861e78d4-7e1e-516e-ab6a-df04413f1da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0a827-778b-48c3-bb85-4b4acef351d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0a827-778b-48c3-bb85-4b4acef351d6.jpg?1",
             "name": "Minion of the Mighty",
             "text": "Menace\nPack tactics \u2014 Whenever Minion of the Mighty attacks, if you attacked with creatures with total power 6 or greater this combat, you may put a Dragon creature card from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "217ea53c-ffe3-5e9d-a9fd-65fc2f1e5f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1c2cdd-353c-4747-bf0e-b995dd37ffca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1c2cdd-353c-4747-bf0e-b995dd37ffca.jpg?1",
             "name": "Orb of Dragonkind",
             "text": "{1}, {T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon spells or activate abilities of Dragons.\n{R}, {T}, Sacrifice Orb of Dragonkind: Look at the top seven cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "c434b3b6-b98c-5c01-ba74-20d4b6d7a894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d875881c-c285-47f1-8a37-e4a0239d47ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d875881c-c285-47f1-8a37-e4a0239d47ec.jpg?1",
             "name": "Plundering Barbarian",
             "text": "When Plundering Barbarian enters the battlefield, choose one \u2014\n\u2022 Smash the Chest \u2014 Destroy target artifact.\n\u2022 Pry It Open \u2014 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "5b009797-55f1-5ead-a52d-231b0d26cd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47634528-cc34-406a-8572-812a41d6a86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47634528-cc34-406a-8572-812a41d6a86a.jpg?1",
             "name": "Price of Loyalty",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If mana from a Treasure was spent to cast this spell, that creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "945abbff-d223-586f-8f6c-4d10312e011d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf57369-b8e2-481c-89d4-c83c617499a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf57369-b8e2-481c-89d4-c83c617499a3.jpg?1",
             "name": "Red Dragon",
             "text": "Flying\nFire Breath \u2014 When Red Dragon enters the battlefield, it deals 4 damage to each opponent.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "b572fbf5-1a5e-5ac4-af7c-80272793d8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c6b2c-9ba0-4fc1-9922-0988acf2dfde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c6b2c-9ba0-4fc1-9922-0988acf2dfde.jpg?1",
             "name": "Rust Monster",
             "text": "First strike\nSacrifice an artifact: Rust Monster gets +2/+0 until end of turn.",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "0f031188-8df3-5514-ba93-7cd433d7ccbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623c1d1b-69a4-4bc4-b388-17a7600fd960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623c1d1b-69a4-4bc4-b388-17a7600fd960.jpg?1",
             "name": "Swarming Goblins",
             "text": "When Swarming Goblins enters the battlefield, roll a d20.\n1\u20139 | Create a 1/1 red Goblin creature token.\n10\u201319 | Create two of those tokens.\n20 | Create three of those tokens.",
             "colours": [
@@ -6008,7 +6008,7 @@
         },
         {
             "id": "18c9db6f-1ca9-50fa-a674-eb5f2053cb05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0c229-aa31-4c79-bafe-28a8d8e64c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0c229-aa31-4c79-bafe-28a8d8e64c61.jpg?1",
             "name": "Tiger-Tribe Hunter",
             "text": "Trample\nPack tactics \u2014 Whenever Tiger-Tribe Hunter attacks, if you attacked with creatures with total power 6 or greater this combat, you may sacrifice another creature. When you do, Tiger-Tribe Hunter deals damage equal to the sacrificed creature's power to target creature.",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "5686f3cc-2746-597f-9082-b7756ed11bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6a5fb-39f5-4cf8-85f7-661cb4570507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6a5fb-39f5-4cf8-85f7-661cb4570507.jpg?1",
             "name": "Unexpected Windfall",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "9ac9bceb-4766-5de9-bc46-4d89eea4aaa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bc162c-bdf1-43f7-882f-d8cee4f3f415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bc162c-bdf1-43f7-882f-d8cee4f3f415.jpg?1",
             "name": "Valor Singer",
             "text": "Combat Inspiration \u2014\u00a0\nAt the beginning of combat on your turn, target creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "9ad6656c-8260-512a-abb6-8bc1f1d1b37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed021d2-e2bc-44b3-8934-4bd02e0a42ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed021d2-e2bc-44b3-8934-4bd02e0a42ec.jpg?1",
             "name": "Wish",
             "text": "You may play a card you own from outside the game this turn.",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "fc3d9bc3-028e-5a9f-8a9a-a0cefcf3776a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73fdf76-e3a6-49d0-bfb0-4b7cdbd4271e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73fdf76-e3a6-49d0-bfb0-4b7cdbd4271e.jpg?1",
             "name": "Xorn",
             "text": "If you would create one or more Treasure tokens, instead create those tokens plus an additional Treasure token.",
             "colours": [
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "212bc754-794a-5233-b50d-2108921020c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893613-423e-409b-9334-292bd252405b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893613-423e-409b-9334-292bd252405b.jpg?1",
             "name": "You Come to the Gnoll Camp",
             "text": "Choose one \u2014\n\u2022 Intimidate Them \u2014 Up to two target creatures can't block this turn.\n\u2022 Fend Them Off \u2014 Target creature gets +3/+1 until end of turn.",
             "colours": [
@@ -6212,7 +6212,7 @@
         },
         {
             "id": "376c062b-e9fc-5a83-84f7-fe1a4e6c5790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a95ae-feb2-42c3-99b4-9ea7a491d326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a95ae-feb2-42c3-99b4-9ea7a491d326.jpg?1",
             "name": "You Find Some Prisoners",
             "text": "Choose one \u2014\n\u2022 Break Their Chains \u2014 Destroy target artifact.\n\u2022 Interrogate Them \u2014 Exile the top three cards of target opponent's library. Choose one of them. Until the end of your next turn, you may play that card, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "0747baf0-032d-5255-8b94-2352087f85f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e7200-96ea-4455-83cc-0a497d56efe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e7200-96ea-4455-83cc-0a497d56efe5.jpg?1",
             "name": "You See a Pair of Goblins",
             "text": "Choose one \u2014\n\u2022 Charge Them \u2014 Creatures you control get +2/+0 until end of turn.\n\u2022 Befriend Them \u2014 Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -6276,7 +6276,7 @@
         },
         {
             "id": "1022040a-1c4e-5845-a3c7-8c968398e932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6da066-accb-4c09-9acb-4de263dadad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6da066-accb-4c09-9acb-4de263dadad3.jpg?1",
             "name": "Zalto, Fire Giant Duke",
             "text": "Trample\nWhenever Zalto, Fire Giant Duke is dealt damage, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "cabe2e74-11e5-5d13-94db-6eace2ac964d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5b866-d479-4698-98b2-87a973f6b8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5b866-d479-4698-98b2-87a973f6b8f6.jpg?1",
             "name": "Zariel, Archduke of Avernus",
             "text": "+1: Creatures you control get +1/+0 and gain haste until end of turn.\n0: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22126: You get an emblem with \"At the end of the first combat phase on your turn, untap target creature you control. After this phase, there is an additional combat phase.\"",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "0fbc9cdf-081c-56c9-9644-90d47b2488bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206a9e7b-45c1-4213-8fc4-27d90e2ab0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206a9e7b-45c1-4213-8fc4-27d90e2ab0e9.jpg?1",
             "name": "Bulette",
             "text": "At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on Bulette.",
             "colours": [
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "5e79ffa0-396e-5189-8109-b41507e8af2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092cab70-c771-4c96-a5ce-22f2e32e3ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092cab70-c771-4c96-a5ce-22f2e32e3ea8.jpg?1",
             "name": "Bull's Strength",
             "text": "Target creature gets +2/+2 and gains trample until end of turn. Untap it.",
             "colours": [
@@ -6421,7 +6421,7 @@
         },
         {
             "id": "774d9a90-1980-5931-8b63-9ee246e54ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213726e4-e2f5-4e52-b05a-21c4bab9927c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213726e4-e2f5-4e52-b05a-21c4bab9927c.jpg?1",
             "name": "Choose Your Weapon",
             "text": "Choose one \u2014\n\u2022 Two-Weapon Fighting \u2014 Double target creature's power and toughness until end of turn.\n\u2022 Archery \u2014 This spell deals 5 damage to target creature with flying.",
             "colours": [
@@ -6453,7 +6453,7 @@
         },
         {
             "id": "d91e85f3-25d4-5084-8393-06f3350f53e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6fdec0-a2c4-4da2-ae14-961185eaee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6fdec0-a2c4-4da2-ae14-961185eaee66.jpg?1",
             "name": "Circle of Dreams Druid",
             "text": "{T}: Add {G} for each creature you control.",
             "colours": [
@@ -6490,7 +6490,7 @@
         },
         {
             "id": "cc5bf1a4-63ab-5dec-9f8e-81278f82e4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700c9ed8-6bfe-4f1e-855a-5f31e0d2fc9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700c9ed8-6bfe-4f1e-855a-5f31e0d2fc9b.jpg?1",
             "name": "Circle of the Moon Druid",
             "text": "Bear Form \u2014 As long as it's your turn, Circle of the Moon Druid is a Bear with base power and toughness 4/2. (It loses all other creature types.)",
             "colours": [
@@ -6526,7 +6526,7 @@
         },
         {
             "id": "bc02d308-fd82-516f-98ed-715a60a68be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7e501d-943e-4e6d-9d8e-6bedc32a0dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7e501d-943e-4e6d-9d8e-6bedc32a0dd8.jpg?1",
             "name": "Compelled Duel",
             "text": "Target creature gets +3/+3 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "c31b441c-4d5b-5b42-8861-9a39c2545150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4769d-31ba-40d3-9375-494b93f01183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab4769d-31ba-40d3-9375-494b93f01183.jpg?1",
             "name": "Dire Wolf Prowler",
             "text": "{1}{G}: Dire Wolf Prowler gets +2/+2 and gains haste until end of turn. Activate only once each turn.",
             "colours": [
@@ -6594,7 +6594,7 @@
         },
         {
             "id": "2737a540-8d73-55f6-ae84-bccb67ea8014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09278e95-eaae-4cd4-a0d8-a2d15b0abb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09278e95-eaae-4cd4-a0d8-a2d15b0abb58.jpg?1",
             "name": "Druid Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever a land enters the battlefield under your control, you gain 1 life.\n{2}{G}: Level 2\n//Level_2//\nYou may play an additional land on each of your turns.\n{4}{G}: Level 3\n//Level_3//\nWhen this Class becomes level 3, target land you control becomes a creature with haste and \"This creature's power and toughness are each equal to the number of lands you control.\" It's still a land.",
             "colours": [
@@ -6628,7 +6628,7 @@
         },
         {
             "id": "22ad51a3-5cb9-5450-8ad9-618ae5ca99ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbd3554-0096-470d-ba9d-011f5c8212c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbd3554-0096-470d-ba9d-011f5c8212c4.jpg?1",
             "name": "A-Druid Class",
             "text": "",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "90ebc623-874c-5938-a3ba-187d4cf70990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab81bc0-0369-469e-9296-6d9681697b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab81bc0-0369-469e-9296-6d9681697b21.jpg?1",
             "name": "Ellywick Tumblestrum",
             "text": "+1: Venture into the dungeon. (Enter the first room or advance to the next room.)\n\u22122: Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. If it's legendary, you gain 3 life. Put the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Creatures you control have trample and haste and get +2/+2 for each differently named dungeon you've completed.\"",
             "colours": [
@@ -6699,7 +6699,7 @@
         },
         {
             "id": "7bd30146-08e5-56c0-ae62-d33d169932f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49215be1-88ed-4302-a708-99496d90d175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49215be1-88ed-4302-a708-99496d90d175.jpg?1",
             "name": "A-Ellywick Tumblestrum",
             "text": "",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "eff3e47b-9d7c-5747-be21-db4d578764b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6898737-957f-44a6-bef7-fb196658176f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6898737-957f-44a6-bef7-fb196658176f.jpg?1",
             "name": "Elturgard Ranger",
             "text": "Reach\nWhen Elturgard Ranger enters the battlefield, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -6770,7 +6770,7 @@
         },
         {
             "id": "d2d646fe-a6dd-5dce-af60-ae44bff7a019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afe37a0-ccc3-467a-b787-304465b38355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afe37a0-ccc3-467a-b787-304465b38355.jpg?1",
             "name": "Find the Path",
             "text": "Enchant land\nWhen Find the Path enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nEnchanted land has \"{T}: Add {G}{G}.\"",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "933a00f3-1281-5784-9c70-e7355fc9223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a223fc-ded8-4675-a72a-74ca6a44a642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a223fc-ded8-4675-a72a-74ca6a44a642.jpg?1",
             "name": "A-Find the Path",
             "text": "",
             "colours": [
@@ -6837,7 +6837,7 @@
         },
         {
             "id": "af5bdb09-136a-5888-babe-6af35b3e0f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e9567-2585-4c03-99a5-3e84fd8044d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e9567-2585-4c03-99a5-3e84fd8044d2.jpg?1",
             "name": "Froghemoth",
             "text": "Trample, haste\nWhenever Froghemoth deals combat damage to a player, exile up to that many target cards from their graveyard. Put a +1/+1 counter on Froghemoth for each creature card exiled this way. You gain 1 life for each noncreature card exiled this way.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "64ce89c2-5e2d-5b90-9fa9-1ab9c2ed1e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0634cb-e973-4f05-965e-d39b09fe57a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0634cb-e973-4f05-965e-d39b09fe57a9.jpg?1",
             "name": "Gnoll Hunter",
             "text": "Pack tactics \u2014 Whenever Gnoll Hunter attacks, if you attacked with creatures with total power 6 or greater this combat, put a +1/+1 counter on Gnoll Hunter.",
             "colours": [
@@ -6910,7 +6910,7 @@
         },
         {
             "id": "e518d8f6-3cf5-5d38-92f1-247baf331de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45804134-cc04-4587-9674-2c884964083d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45804134-cc04-4587-9674-2c884964083d.jpg?1",
             "name": "Green Dragon",
             "text": "Flying\nPoison Breath \u2014 When Green Dragon enters the battlefield, until end of turn, whenever a creature an opponent controls is dealt damage, destroy it.",
             "colours": [
@@ -6946,7 +6946,7 @@
         },
         {
             "id": "33ff348f-dd6e-55fe-9f6b-feeea41d10d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69315cc-c230-4704-9d66-411f624f3e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69315cc-c230-4704-9d66-411f624f3e49.jpg?1",
             "name": "Hill Giant Herdgorger",
             "text": "When Hill Giant Herdgorger enters the battlefield, you gain 3 life.",
             "colours": [
@@ -6980,7 +6980,7 @@
         },
         {
             "id": "4f256c46-dbfa-5cc3-8283-7ce24f74e446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62023c58-8b94-4a81-a259-a047e1edd342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62023c58-8b94-4a81-a259-a047e1edd342.jpg?1",
             "name": "Hunter's Mark",
             "text": "This spell costs {3} less to cast if it targets a blue permanent you don't control.\nThis spell can't be countered.\nTarget creature you control gets +1/+1 until end of turn. Then it deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "38cd5e2d-327f-587d-8e7a-e3a20ef1b264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33db66-d205-4164-b168-6084df562ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33db66-d205-4164-b168-6084df562ebb.jpg?1",
             "name": "Inspiring Bard",
             "text": "When Inspiring Bard enters the battlefield, choose one \u2014\n\u2022 Bardic Inspiration \u2014 Target creature gets +2/+2 until end of turn.\n\u2022 Song of Rest \u2014 You gain 3 life.",
             "colours": [
@@ -7047,7 +7047,7 @@
         },
         {
             "id": "776d1f63-fdd1-51c8-acef-d5f42a856970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58486dc-3e78-4649-89c7-46f6210ff80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58486dc-3e78-4649-89c7-46f6210ff80f.jpg?1",
             "name": "Instrument of the Bards",
             "text": "At the beginning of your upkeep, you may put a harmony counter on Instrument of the Bards.\n{3}{G}, {T}: Search your library for a creature card with mana value equal to the number of harmony counters on Instrument of the Bards, reveal it, and put it into your hand. If that card is legendary, create a Treasure token. Then shuffle.",
             "colours": [
@@ -7083,7 +7083,7 @@
         },
         {
             "id": "2eddc82c-79a2-596a-bedb-bac138ab5be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b00777-d921-4264-9faf-5c048b656210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b00777-d921-4264-9faf-5c048b656210.jpg?1",
             "name": "Intrepid Outlander",
             "text": "Reach\nPack tactics \u2014 Whenever Intrepid Outlander attacks, if you attacked with creatures with total power 6 or greater this combat, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -7118,7 +7118,7 @@
         },
         {
             "id": "772e12dd-6d3d-532f-8d7f-e19493147199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ac66df-760d-495d-a067-13114071b7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ac66df-760d-495d-a067-13114071b7b8.jpg?1",
             "name": "Loathsome Troll",
             "text": "{3}{G}: Roll a d20. Activate only if Loathsome Troll is in your graveyard.\n1\u20139 | Put Loathsome Troll on top of your library.\n10\u201319 | Return Loathsome Troll to your hand.\n20 | Return Loathsome Troll to the battlefield tapped.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "fc58a2a4-367b-5002-beb9-7726b2182a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e930-3b6b-4b2f-a09c-0730d491545c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e930-3b6b-4b2f-a09c-0730d491545c.jpg?1",
             "name": "Long Rest",
             "text": "Return X target cards with different mana values from your graveyard to your hand. If eight or more cards were returned to your hand this way, your life total becomes equal to your starting life total. Exile Long Rest.",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "b9004b46-fa3e-5ea2-a262-3d2f2ac77b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce25d7-3f22-48ce-9428-184e661696b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce25d7-3f22-48ce-9428-184e661696b9.jpg?1",
             "name": "Lurking Roper",
             "text": "Lurking Roper doesn't untap during your untap step.\nWhenever you gain life, untap Lurking Roper.",
             "colours": [
@@ -7224,7 +7224,7 @@
         },
         {
             "id": "25ba960a-f764-5e53-8048-c7210e2f0085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d7cc7-bbdd-4db3-906e-a2f7672e0f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d7cc7-bbdd-4db3-906e-a2f7672e0f67.jpg?1",
             "name": "Neverwinter Dryad",
             "text": "{2}, Sacrifice Neverwinter Dryad: Search your library for a basic Forest card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7260,7 +7260,7 @@
         },
         {
             "id": "345acc61-1b81-5201-ab44-8cec4c6751b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23cfb7-c6b6-4f04-abba-5b2a6117ea12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23cfb7-c6b6-4f04-abba-5b2a6117ea12.jpg?1",
             "name": "Ochre Jelly",
             "text": "Trample\nOchre Jelly enters the battlefield with X +1/+1 counters on it.\nSplit \u2014 When Ochre Jelly dies, if it had two or more +1/+1 counters on it, create a token that's a copy of it at the beginning of the next end step. The token enters the battlefield with half that many +1/+1 counters on it, rounded down.",
             "colours": [
@@ -7296,7 +7296,7 @@
         },
         {
             "id": "becbf226-d80d-5f2a-b8e1-20c6eef78ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e499ccce-359a-45ac-a09b-5e4ca96ac1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e499ccce-359a-45ac-a09b-5e4ca96ac1cd.jpg?1",
             "name": "A-Ochre Jelly",
             "text": "",
             "colours": [
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "368b7d4d-232d-5488-a100-2c9697d5837c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ceba8b-de19-4db8-b5a7-f5df49bf241f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ceba8b-de19-4db8-b5a7-f5df49bf241f.jpg?1",
             "name": "Old Gnawbone",
             "text": "Flying\nWhenever a creature you control deals combat damage to a player, create that many Treasure tokens.",
             "colours": [
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "6fabca4e-6b8d-5c0d-897d-6398de7a1a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e8a00f-8131-470d-8072-4c23b812281a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e8a00f-8131-470d-8072-4c23b812281a.jpg?1",
             "name": "Owlbear",
             "text": "Trample\nKeen Senses \u2014 When Owlbear enters the battlefield, draw a card.",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "6602a099-6507-5b20-854f-75bd8beff0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be85ceb-be98-43ce-9565-a72990797437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be85ceb-be98-43ce-9565-a72990797437.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "fd83a9cc-1068-5315-afe2-cd004fd75284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096d3c0c-98e2-4cfc-a6e1-fddb0359c63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096d3c0c-98e2-4cfc-a6e1-fddb0359c63f.jpg?1",
             "name": "Prosperous Innkeeper",
             "text": "When Prosperous Innkeeper enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "198a4589-345d-5547-8d0d-01bb03d970ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419d58b-6241-4892-9080-f6894ac7ba89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419d58b-6241-4892-9080-f6894ac7ba89.jpg?1",
             "name": "Purple Worm",
             "text": "This spell costs {2} less to cast if a creature died this turn.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -7509,7 +7509,7 @@
         },
         {
             "id": "8bfe2b13-9a56-5a6e-a8b6-25fdc75a000d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca392ca-3219-4694-9a74-aa079c76b91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca392ca-3219-4694-9a74-aa079c76b91e.jpg?1",
             "name": "Ranger Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Ranger Class enters the battlefield, create a 2/2 green Wolf creature token.\n{1}{G}: Level 2\n//Level_2//\nWhenever you attack, put a +1/+1 counter on target attacking creature.\n{3}{G}: Level 3\n//Level_3//\nYou may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.",
             "colours": [
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "9b0bd4e2-e31f-540b-96ee-f2191da43e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c99b32-353c-4930-a6ee-3fb44cf70253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c99b32-353c-4930-a6ee-3fb44cf70253.jpg?1",
             "name": "Ranger's Longbow",
             "text": "Equipped creature gets +2/+1 and has reach.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7577,7 +7577,7 @@
         },
         {
             "id": "6673dea6-1e31-5d8d-a5c3-ec5467e3ba94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb05274-5a94-44e3-889a-667cba1da033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb05274-5a94-44e3-889a-667cba1da033.jpg?1",
             "name": "Scaled Herbalist",
             "text": "{T}: You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -7612,7 +7612,7 @@
         },
         {
             "id": "d9737a9f-891f-5464-ba48-f895b6c084b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfdfd4-8621-40ef-a60f-74e9c107bbaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10dfdfd4-8621-40ef-a60f-74e9c107bbaf.jpg?1",
             "name": "Spoils of the Hunt",
             "text": "Target creature you control gets +1/+0 until end of turn for each mana from a Treasure that was spent to cast this spell. Then that creature deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -7644,7 +7644,7 @@
         },
         {
             "id": "87ce91e2-f5e7-54a9-841d-f15c402ce0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d608fb-35b0-498e-988a-f53986b59dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d608fb-35b0-498e-988a-f53986b59dd2.jpg?1",
             "name": "Sylvan Shepherd",
             "text": "Vigilance\nWhenever Sylvan Shepherd attacks, roll a d20.\n1\u20139 | You gain 1 life.\n10\u201319 | You gain 2 life.\n20 | You gain 5 life.",
             "colours": [
@@ -7679,7 +7679,7 @@
         },
         {
             "id": "124bc00f-7aa5-5499-8c4c-b47cc22730fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26fa15-d81f-4152-ae33-e91aa276b3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26fa15-d81f-4152-ae33-e91aa276b3fc.jpg?1",
             "name": "The Tarrasque",
             "text": "The Tarrasque has haste and ward {1}0 as long as it was cast.\nWhenever The Tarrasque attacks, it fights target creature defending player controls.",
             "colours": [
@@ -7717,7 +7717,7 @@
         },
         {
             "id": "5f02ee59-47d1-5041-8aff-948133d24c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed220158-e4e3-4d46-8098-7b940a923ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed220158-e4e3-4d46-8098-7b940a923ce9.jpg?1",
             "name": "Underdark Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -7753,7 +7753,7 @@
         },
         {
             "id": "c09ccc28-da73-55ce-80db-a5506f5a253b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bd3ea9-f06d-4df7-8b8d-ac6a0e591b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bd3ea9-f06d-4df7-8b8d-ac6a0e591b09.jpg?1",
             "name": "Varis, Silverymoon Ranger",
             "text": "Reach, ward {1}\nWhenever you cast a creature or planeswalker spell, venture into the dungeon. This ability triggers only once each turn. (To venture into the dungeon, enter the first room or advance to the next room.)\nWhenever you complete a dungeon, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -7793,7 +7793,7 @@
         },
         {
             "id": "902704a3-38ea-5f4c-9c1e-dd444344bbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c7f123-31c8-469b-85e5-d20c4d21b2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c7f123-31c8-469b-85e5-d20c4d21b2a0.jpg?1",
             "name": "Wandering Troubadour",
             "text": "At the beginning of your end step, if you had a land enter the battlefield under your control this turn, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "0d76a462-45ec-57e2-aea7-3741b4117a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88e6b39-bb4d-4d69-8007-d42f31bcbc29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88e6b39-bb4d-4d69-8007-d42f31bcbc29.jpg?1",
             "name": "Werewolf Pack Leader",
             "text": "Pack tactics \u2014 Whenever Werewolf Pack Leader attacks, if you attacked with creatures with total power 6 or greater this combat, draw a card.\n{3}{G}: Until end of turn, Werewolf Pack Leader has base power and toughness 5/3, gains trample, and isn't a Human.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "f7be14f3-7f0b-5860-8a20-4b426f14ee12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9738f1-b2e7-45a5-b235-290256aabed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9738f1-b2e7-45a5-b235-290256aabed0.jpg?1",
             "name": "Wild Shape",
             "text": "Choose one. Until end of turn, target creature you control has that base power and toughness, becomes that creature type, and gains that ability.\n\u2022 1/3 Turtle with hexproof.\n\u2022 1/5 Spider with reach.\n\u2022 3/3 Elephant with trample.",
             "colours": [
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "60353423-6d1a-5ecf-b466-b5d02a921ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb5671a-942a-4730-9756-32fe600e0528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb5671a-942a-4730-9756-32fe600e0528.jpg?1",
             "name": "You Find a Cursed Idol",
             "text": "Choose one \u2014\n\u2022 Smash It \u2014 Destroy target artifact.\n\u2022 Lift the Curse \u2014 Destroy target enchantment.\n\u2022 Steal Its Eyes \u2014 Create a Treasure token and venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "6d8d1cb1-e066-568e-9ded-a90687c4bf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae7693-a6b5-42f8-9f05-c0643b95a710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae7693-a6b5-42f8-9f05-c0643b95a710.jpg?1",
             "name": "You Happen On a Glade",
             "text": "Choose one \u2014\n\u2022 Journey On \u2014 Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Make Camp \u2014 Return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -7961,7 +7961,7 @@
         },
         {
             "id": "b1a1da21-c81f-524e-ad6b-e6a98d874d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593aa59a-4025-4df8-9f27-188fc7712fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593aa59a-4025-4df8-9f27-188fc7712fde.jpg?1",
             "name": "You Meet in a Tavern",
             "text": "Choose one \u2014\n\u2022 Form a Party \u2014 Look at the top five cards of your library. You may reveal any number of creature cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.\n\u2022 Start a Brawl \u2014 Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "d26f2bf9-ea90-52e4-beb4-c86c6fe67638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a76010-d932-4727-8b5e-b8e2d14e1362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a76010-d932-4727-8b5e-b8e2d14e1362.jpg?1",
             "name": "Adult Gold Dragon",
             "text": "Flying, lifelink, haste",
             "colours": [
@@ -8031,7 +8031,7 @@
         },
         {
             "id": "9a6aa7c5-70d0-596b-8097-c105713ecc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d6343a-c514-4ca6-a415-62d1a473ae20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d6343a-c514-4ca6-a415-62d1a473ae20.jpg?1",
             "name": "Bard Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nLegendary creatures you control enter the battlefield with an additional +1/+1 counter on them.\n{R}{G}: Level 2\n//Level_2//\nLegendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\n{3}{R}{G}: Level 3\n//Level_3//\nWhenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "6fac771e-016f-5d32-ac95-86ed7e18b859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6896c311-5593-4437-b945-43ade9665e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6896c311-5593-4437-b945-43ade9665e43.jpg?1",
             "name": "Barrowin of Clan Undurr",
             "text": "When Barrowin of Clan Undurr enters the battlefield, venture into the dungeon. (Enter the first room or advance to the next room.)\nWhenever Barrowin of Clan Undurr attacks, return up to one creature card with mana value 3 or less from your graveyard to the battlefield if you've completed a dungeon.",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "6d12aa8d-1c5d-5871-8da3-ee08421a3a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e1eb00-412e-4c25-bc7b-6d074330fd97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e1eb00-412e-4c25-bc7b-6d074330fd97.jpg?1",
             "name": "Bruenor Battlehammer",
             "text": "Each creature you control gets +2/+0 for each Equipment attached to it.\nYou may pay {0} rather than pay the equip cost of the first equip ability you activate each turn.",
             "colours": [
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "75cb418b-fb04-5966-9590-992afb043989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad77890-cf97-4707-ab31-be0f5be0e120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad77890-cf97-4707-ab31-be0f5be0e120.jpg?1",
             "name": "A-Bruenor Battlehammer",
             "text": "",
             "colours": [
@@ -8187,7 +8187,7 @@
         },
         {
             "id": "989de269-08a7-5ddd-9ccb-9485c32636f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e3259e-93c2-48c0-8b96-835cdb883383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e3259e-93c2-48c0-8b96-835cdb883383.jpg?1",
             "name": "Drizzt Do'Urden",
             "text": "Double strike\nWhen Drizzt Do'Urden enters the battlefield, create Guenhwyvar, a legendary 4/1 green Cat creature token with trample.\nWhenever a creature dies, if it had power greater than Drizzt's power, put a number of +1/+1 counters on Drizzt equal to the difference.",
             "colours": [
@@ -8228,7 +8228,7 @@
         },
         {
             "id": "ec35e110-cdde-5e7d-91c1-60a068298206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ff142-029b-4446-960a-2ff200fb9aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ff142-029b-4446-960a-2ff200fb9aee.jpg?1",
             "name": "Farideh, Devil's Chosen",
             "text": "Dark One's Own Luck \u2014 Whenever you roll one or more dice, Farideh, Devil's Chosen gains flying and menace until end of turn. If any of those results was 10 or higher, draw a card.",
             "colours": [
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "f3b2af35-b189-525a-80f0-06c8628d863c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54a8329-b940-42c9-8ace-1d74407d14cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54a8329-b940-42c9-8ace-1d74407d14cb.jpg?1",
             "name": "Fighter Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Fighter Class enters the battlefield, search your library for an Equipment card, reveal it, put it into your hand, then shuffle.\n{1}{R}{W}: Level 2\n//Level_2//\nEquip abilities you activate cost {2} less to activate.\n{3}{R}{W}: Level 3\n//Level_3//\nWhenever a creature you control attacks, up to one target creature blocks it this combat if able.",
             "colours": [
@@ -8305,7 +8305,7 @@
         },
         {
             "id": "62e115a1-4bb6-538e-ac9e-49a42fd238f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8b248e-1460-4650-9721-85c134c21b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8b248e-1460-4650-9721-85c134c21b89.jpg?1",
             "name": "Gretchen Titchwillow",
             "text": "{2}{G}{U}: Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "8a4bc11a-b683-5c8e-b11d-7f67beacbf1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b8eb2e-73ac-4ad6-9ab6-4f8da7b41020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b8eb2e-73ac-4ad6-9ab6-4f8da7b41020.jpg?1",
             "name": "Hama Pashar, Ruin Seeker",
             "text": "Room abilities of dungeons you own trigger an additional time.",
             "colours": [
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "9f0e609f-ce30-53d3-b4c4-12bb6be77cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45e9552-7737-4c61-89b0-5a3bec3c8f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45e9552-7737-4c61-89b0-5a3bec3c8f34.jpg?1",
             "name": "Kalain, Reclusive Painter",
             "text": "When Kalain, Reclusive Painter enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nOther creatures you control enter the battlefield with an additional +1/+1 counter on them for each mana from a Treasure spent to cast them.",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "cd1609d4-eb90-5467-afe7-44feb2d35fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f4d622-2d50-4e6e-87a5-5a1cc65d6919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f4d622-2d50-4e6e-87a5-5a1cc65d6919.jpg?1",
             "name": "Krydle of Baldur's Gate",
             "text": "Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, you may pay {2}. If you do, target creature can't be blocked this turn.",
             "colours": [
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "be5a1f46-7327-5dae-bf9b-ac764b95514b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72405607-a60e-42af-b523-64008d3f89b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72405607-a60e-42af-b523-64008d3f89b9.jpg?1",
             "name": "Minsc, Beloved Ranger",
             "text": "When Minsc, Beloved Ranger enters the battlefield, create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n{X}: Until end of turn, target creature you control has base power and toughness X/X and becomes a Giant in addition to its other types. Activate only as a sorcery.",
             "colours": [
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "a9e22ac9-240b-57ef-b2b3-2b5639f659f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2edd708-46ee-4963-b7e6-b631616d78fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2edd708-46ee-4963-b7e6-b631616d78fe.jpg?1",
             "name": "Monk Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nThe second spell you cast each turn costs {1} less to cast.\n{W}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, return up to one target nonland permanent to its owner's hand.\n{1}{W}{U}: Level 3\n//Level_3//\nAt the beginning of your upkeep, exile the top card of your library. For as long as it remains exiled, it has \"You may cast this card from exile as long as you've cast another spell this turn.\"",
             "colours": [
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "d1d00ca5-0006-5753-b03f-c83b27c75bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f5c6d3-fb04-4a2e-87b6-9ed2314085a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f5c6d3-fb04-4a2e-87b6-9ed2314085a8.jpg?1",
             "name": "Orcus, Prince of Undeath",
             "text": "Flying, trample\nWhen Orcus, Prince of Undeath enters the battlefield, choose one \u2014\n\u2022 Each other creature gets -X/-X until end of turn. You lose X life.\n\u2022 Return up to X target creature cards with total mana value X or less from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "6b281540-866e-54f3-9891-7d45d1bca7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0727f65b-cfbe-47d5-87c6-239cf8d93ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0727f65b-cfbe-47d5-87c6-239cf8d93ca6.jpg?1",
             "name": "Rogue Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever a creature you control deals combat damage to a player, exile the top card of that player's library face down. You may look at it for as long as it remains exiled.\n{1}{U}{B}: Level 2\n//Level_2//\nCreatures you control have menace.\n{2}{U}{B}: Level 3\n//Level_3//\nYou may play cards exiled with Rogue Class, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "fe529b21-f370-5686-a79a-dab440712998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ca5fef-af21-4e2b-9efa-61e08a638a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ca5fef-af21-4e2b-9efa-61e08a638a1f.jpg?1",
             "name": "Shessra, Death's Whisper",
             "text": "Bewitching Whispers \u2014 When Shessra, Death's Whisper enters the battlefield, target creature blocks this turn if able.\nWhispers of the Grave \u2014 At the beginning of your end step, if a creature died this turn, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -8668,7 +8668,7 @@
         },
         {
             "id": "ede12ddf-a43f-5383-964b-8f4e38453885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef5fb8c-ee26-464e-bc89-47b2e4c39222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef5fb8c-ee26-464e-bc89-47b2e4c39222.jpg?1",
             "name": "A-Shessra, Death's Whisper",
             "text": "",
             "colours": [
@@ -8707,7 +8707,7 @@
         },
         {
             "id": "44dd475f-50d0-5a5d-bdaf-9bbbcdab9bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768ac68-0d87-4f99-aa77-2d009df0a567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768ac68-0d87-4f99-aa77-2d009df0a567.jpg?1",
             "name": "Skeletal Swarming",
             "text": "Each Skeleton you control has trample, attacks each combat if able, and gets +X/+0, where X is the number of other Skeletons you control.\nAt the beginning of your end step, create a tapped 1/1 black Skeleton creature token. If a creature died this turn, create two of those tokens instead.",
             "colours": [
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "d29aac9c-8149-5a6c-91f1-f5babb31058b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754b385-a28d-48de-a91f-2b4f33cc47f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754b385-a28d-48de-a91f-2b4f33cc47f7.jpg?1",
             "name": "Sorcerer Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Sorcerer Class enters the battlefield, draw two cards, then discard two cards.\n{U}{R}: Level 2\n//Level_2//\nCreatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\"\n{3}{U}{R}: Level 3\n//Level_3//\nWhenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.",
             "colours": [
@@ -8779,7 +8779,7 @@
         },
         {
             "id": "cce3ede4-0d00-59a5-8eea-5b8e9625f0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67afa501-d561-4a02-9321-351d19daa10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67afa501-d561-4a02-9321-351d19daa10d.jpg?1",
             "name": "A-Sorcerer Class",
             "text": "",
             "colours": [
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "8c2aaa45-de1e-5f78-ac2b-99ef91d4a0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe57856-9d35-470e-9138-360b02ac0c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe57856-9d35-470e-9138-360b02ac0c90.jpg?1",
             "name": "Targ Nar, Demon-Fang Gnoll",
             "text": "Pack tactics \u2014 Whenever Targ Nar, Demon-Fang Gnoll attacks, if you attacked with creatures with total power 6 or greater this combat, attacking creatures get +1/+0 until end of turn.\n{2}{R}{G}: Double Targ Nar's power and toughness until end of turn.",
             "colours": [
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "e79b9335-6a28-52e2-8758-b150b3568967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0b9b0-55f4-4ce7-a916-6f23687f3fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0b9b0-55f4-4ce7-a916-6f23687f3fe4.jpg?1",
             "name": "Tiamat",
             "text": "Flying\nWhen Tiamat enters the battlefield, if you cast it, search your library for up to five Dragon cards not named Tiamat that each have different names, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -8899,7 +8899,7 @@
         },
         {
             "id": "61ff7c1c-6ca3-5a84-9e68-2b0b13d14e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4b54c-a8fa-464e-a3dd-f3f3a08606f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4b54c-a8fa-464e-a3dd-f3f3a08606f5.jpg?1",
             "name": "Trelasarra, Moon Dancer",
             "text": "Whenever you gain life, put a +1/+1 counter on Trelasarra, Moon Dancer and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "320cabf7-0dc7-54ae-81f0-de0be7b8243f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214d3167-4eea-42a1-a464-ddff59843142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214d3167-4eea-42a1-a464-ddff59843142.jpg?1",
             "name": "Triumphant Adventurer",
             "text": "Deathtouch\nAs long as it's your turn, Triumphant Adventurer has first strike.\nWhenever Triumphant Adventurer attacks, venture into the dungeon. (Enter the first room or advance to the next room.)",
             "colours": [
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "5c8de630-f70b-5fde-9f54-be31c99e7a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a95341-168b-4a97-90dc-9a444f5de8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a95341-168b-4a97-90dc-9a444f5de8e6.jpg?1",
             "name": "A-Triumphant Adventurer",
             "text": "",
             "colours": [
@@ -9015,7 +9015,7 @@
         },
         {
             "id": "605463ee-269f-5c8d-a150-4b2e4dc99b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ae01f9-7461-47b4-aa1e-93bd6ff1bf9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ae01f9-7461-47b4-aa1e-93bd6ff1bf9e.jpg?1",
             "name": "Volo, Guide to Monsters",
             "text": "Whenever you cast a creature spell that doesn't share a creature type with a creature you control or a creature card in your graveyard, copy that spell. (A copy of a creature spell becomes a token.)",
             "colours": [
@@ -9056,7 +9056,7 @@
         },
         {
             "id": "ba9c72e5-95b2-5ae1-bbfb-a9b8cbf087cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58050-a615-4090-9cf5-cd49ccb4e2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58050-a615-4090-9cf5-cd49ccb4e2c6.jpg?1",
             "name": "Xanathar, Guild Kingpin",
             "text": "At the beginning of your upkeep, choose target opponent. Until end of turn, that player can't cast spells, you may look at the top card of their library any time, you may play the top card of their library, and you may spend mana as though it were mana of any color to cast spells this way.",
             "colours": [
@@ -9096,7 +9096,7 @@
         },
         {
             "id": "51b02894-e05f-5d8e-b048-865a4bd61844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5e4e9-491b-4c80-8801-f4cd5225c601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5e4e9-491b-4c80-8801-f4cd5225c601.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -9124,7 +9124,7 @@
         },
         {
             "id": "c44f435a-5983-5244-91b9-49440b51c0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddbdc6-0757-43cb-bb41-dc83c6cf42ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddbdc6-0757-43cb-bb41-dc83c6cf42ea.jpg?1",
             "name": "The Deck of Many Things",
             "text": "{2}, {T}: Roll a d20 and subtract the number of cards in your hand. If the result is 0 or less, discard your hand.\n1\u20139 | Return a card at random from your graveyard to your hand.\n10\u201319 | Draw two cards.\n20 | Put a creature card from any graveyard onto the battlefield under your control. When that creature dies, its owner loses the game.",
             "colours": [],
@@ -9156,7 +9156,7 @@
         },
         {
             "id": "4df4a564-0f40-5889-8903-32a2a888ae2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028506ad-ad36-44e5-b488-d038e2d2445f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028506ad-ad36-44e5-b488-d038e2d2445f.jpg?1",
             "name": "Dungeon Map",
             "text": "{T}: Add {C}.\n{3}, {T}: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [],
@@ -9184,7 +9184,7 @@
         },
         {
             "id": "202c72ae-9def-5241-8a50-7b58eb361039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91e2431-500e-441a-881d-094ebef62283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91e2431-500e-441a-881d-094ebef62283.jpg?1",
             "name": "Eye of Vecna",
             "text": "When Eye of Vecna enters the battlefield, you draw a card and you lose 2 life.\nAt the beginning of your upkeep, you may pay {2}. If you do, you draw a card and you lose 2 life.",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "5e002689-44c9-5ee3-bf0d-88513e865e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7ebe7b-732f-4245-a194-e087c3878f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7ebe7b-732f-4245-a194-e087c3878f61.jpg?1",
             "name": "Fifty Feet of Rope",
             "text": "Climb Over \u2014 {T}: Target Wall can't block this turn.\nTie Up \u2014 {3}, {T}: Target creature doesn't untap during its controller's next untap step.\nRappel Down \u2014 {4}, {T}: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [],
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "828e50c3-fb21-5db2-82a5-2134412fed18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e840aef6-eec4-40dd-bbc4-6fd0b2b57805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e840aef6-eec4-40dd-bbc4-6fd0b2b57805.jpg?1",
             "name": "Greataxe",
             "text": "Equipped creature gets +4/+0.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "9812417d-9bae-525a-9cd4-e28db7e6e902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd0beb7-80dc-4665-bab2-747c795d97db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd0beb7-80dc-4665-bab2-747c795d97db.jpg?1",
             "name": "Hand of Vecna",
             "text": "At the beginning of combat on your turn, equipped creature or a creature you control named Vecna gets +X/+X until end of turn, where X is the number of cards in your hand.\nEquip\u2014\nPay 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -9308,7 +9308,7 @@
         },
         {
             "id": "20d4baa6-d11f-5c39-b750-791d57604a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae24ef5-b12c-48ee-935a-00e048fb8d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae24ef5-b12c-48ee-935a-00e048fb8d0f.jpg?1",
             "name": "Iron Golem",
             "text": "Vigilance\nIron Golem attacks or blocks each combat if able.",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "36e691e3-76e5-5fa4-bc3f-101c1c34ceed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62d4e76-cdb0-48c7-aa1c-b1f514057b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62d4e76-cdb0-48c7-aa1c-b1f514057b68.jpg?1",
             "name": "Leather Armor",
             "text": "Equipped creature gets +0/+1 and has ward {1}. (Whenever equipped creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nEquip {0}. Activate only once each turn.",
             "colours": [],
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "67ff69bb-5ed7-549d-aae9-abf5babad432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da96aab-cf84-4150-b9d0-a4b84fcf585f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da96aab-cf84-4150-b9d0-a4b84fcf585f.jpg?1",
             "name": "Mimic",
             "text": "{T}, Sacrifice Mimic: Add one mana of any color.\n{2}: Mimic becomes a Shapeshifter artifact creature with base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -9403,7 +9403,7 @@
         },
         {
             "id": "58aa877a-de5a-5092-9a29-2db08e4fd884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6b0291-00f8-45bf-9f3a-ee43739c2b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6b0291-00f8-45bf-9f3a-ee43739c2b77.jpg?1",
             "name": "Spare Dagger",
             "text": "Equipped creature gets +1/+0 and has \"Whenever this creature attacks, you may sacrifice Spare Dagger. When you do, this creature deals 1 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "5d2a08ce-6893-5e36-9e53-03ebfdde491a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fbf45a-23b4-4d06-abd9-4cc3895cb29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fbf45a-23b4-4d06-abd9-4cc3895cb29d.jpg?1",
             "name": "Spiked Pit Trap",
             "text": "Flash\n{5}, {T}, Sacrifice Spiked Pit Trap: Choose target creature, then roll a d20.\n1\u20139 | Spiked Pit Trap deals 5 damage to that creature.\n10\u201320 | Spiked Pit Trap deals 5 damage to that creature. Create a Treasure token.",
             "colours": [],
@@ -9461,7 +9461,7 @@
         },
         {
             "id": "902a5cc6-7325-5e1e-a894-d975ff5d91d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecbeb07-0f45-49bf-9a12-f4ca09969122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecbeb07-0f45-49bf-9a12-f4ca09969122.jpg?1",
             "name": "Treasure Chest",
             "text": "{4}, Sacrifice Treasure Chest: Roll a d20.\n1 | Trapped \u2014 You lose 3 life.\n2\u20139 | Create five Treasure tokens.\n10\u201319 | You gain 3 life and draw three cards.\n20 | Search your library for a card. If it's an artifact card, you may put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "dc26d551-ab4c-51df-8c19-5b1c1b4393c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb41396-5008-4a5f-92ca-54ecac42e926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb41396-5008-4a5f-92ca-54ecac42e926.jpg?1",
             "name": "Cave of the Frost Dragon",
             "text": "If you control two or more other lands, Cave of the Frost Dragon enters the battlefield tapped.\n{T}: Add {W}.\n{4}{W}: Cave of the Frost Dragon becomes a 3/4 white Dragon creature with flying until end of turn. It's still a land.",
             "colours": [],
@@ -9524,7 +9524,7 @@
         },
         {
             "id": "4d6d76bc-9f24-5b4d-be18-28d209c5e8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231caf8-56c0-4719-a90d-5e5efbee3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231caf8-56c0-4719-a90d-5e5efbee3148.jpg?1",
             "name": "Den of the Bugbear",
             "text": "If you control two or more other lands, Den of the Bugbear enters the battlefield tapped.\n{T}: Add {R}.\n{3}{R}: Until end of turn, Den of the Bugbear becomes a 3/2 red Goblin creature with \"Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\" It's still a land.",
             "colours": [],
@@ -9556,7 +9556,7 @@
         },
         {
             "id": "d6c17748-199a-581f-8d3a-f94d86ff4c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4cccdbc-f4f4-42b6-9747-6ef703ff949a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4cccdbc-f4f4-42b6-9747-6ef703ff949a.jpg?1",
             "name": "Dungeon Descent",
             "text": "Dungeon Descent enters the battlefield tapped.\n{T}: Add {C}.\n{4}, {T}, Tap an untapped legendary creature you control: Venture into the dungeon. Activate only as a sorcery. (Enter the first room or advance to the next room.)",
             "colours": [],
@@ -9586,7 +9586,7 @@
         },
         {
             "id": "9a1ee072-4f15-5730-b992-94eb1c5b4bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7673def9-9f27-4382-b65b-ec616fae1768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7673def9-9f27-4382-b65b-ec616fae1768.jpg?1",
             "name": "A-Dungeon Descent",
             "text": "",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "0b4202f9-eb96-523f-95a5-9fe4576de393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71afb548-691d-4c72-b369-85f9b451c71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71afb548-691d-4c72-b369-85f9b451c71d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9643,7 +9643,7 @@
         },
         {
             "id": "a82c2976-1ad3-5af2-8112-35c223b4beee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8f052d-8840-4905-a807-9a305f4fd8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8f052d-8840-4905-a807-9a305f4fd8f7.jpg?1",
             "name": "Hall of Storm Giants",
             "text": "If you control two or more other lands, Hall of Storm Giants enters the battlefield tapped.\n{T}: Add {U}.\n{5}{U}: Until end of turn, Hall of Storm Giants becomes a 7/7 blue Giant creature with ward {3}. It's still a land. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)",
             "colours": [],
@@ -9675,7 +9675,7 @@
         },
         {
             "id": "6a6c5e71-4425-51a3-90b9-e898fbba61ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb391dc-0378-4793-a5de-899b09792a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb391dc-0378-4793-a5de-899b09792a4b.jpg?1",
             "name": "Hive of the Eye Tyrant",
             "text": "If you control two or more other lands, Hive of the Eye Tyrant enters the battlefield tapped.\n{T}: Add {B}.\n{3}{B}: Until end of turn, Hive of the Eye Tyrant becomes a 3/3 black Beholder creature with menace and \"Whenever this creature attacks, exile target card from defending player's graveyard.\" It's still a land.",
             "colours": [],
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "33ea16d3-6837-5c1b-b4e6-ecdefec8f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670bb0f-680f-4036-bdb6-ac73e866a398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670bb0f-680f-4036-bdb6-ac73e866a398.jpg?1",
             "name": "Lair of the Hydra",
             "text": "If you control two or more other lands, Lair of the Hydra enters the battlefield tapped.\n{T}: Add {G}.\n{X}{G}: Until end of turn, Lair of the Hydra becomes an X/X green Hydra creature. It's still a land. X can't be 0.",
             "colours": [],
@@ -9739,7 +9739,7 @@
         },
         {
             "id": "a497720c-037e-5f0c-b4e5-5a8cf1a4f085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79b3c6-ccbe-48ae-a1f7-ddfd37ecdbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79b3c6-ccbe-48ae-a1f7-ddfd37ecdbf5.jpg?1",
             "name": "Temple of the Dragon Queen",
             "text": "As Temple of the Dragon Queen enters the battlefield, you may reveal a Dragon card from your hand. Temple of the Dragon Queen enters the battlefield tapped unless you revealed a Dragon card this way or you control a Dragon.\nAs Temple of the Dragon Queen enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9769,7 +9769,7 @@
         },
         {
             "id": "dc349524-d18d-56cf-8029-814939734b61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0931eb3-b403-4b1a-ad46-a7b0a51bb9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0931eb3-b403-4b1a-ad46-a7b0a51bb9a4.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "4d253d2e-5d59-54bf-9b40-460d06f964ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879f7f54-25a3-440b-848d-0e780277a681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879f7f54-25a3-440b-848d-0e780277a681.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "57b88f59-c0c3-519b-89da-5fb7e568a2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4f4abf-841b-4fae-9a53-505a2f8dc1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4f4abf-841b-4fae-9a53-505a2f8dc1ff.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9876,7 +9876,7 @@
         },
         {
             "id": "72b8be9b-f238-5350-b5f8-0cdba3e492d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d1a81e-6710-4922-ba0a-510966c39449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d1a81e-6710-4922-ba0a-510966c39449.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9914,7 +9914,7 @@
         },
         {
             "id": "ba560387-2a12-58b7-a56f-eab4ca57deda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86626d69-78e0-42b9-81ed-fef46e3a89f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86626d69-78e0-42b9-81ed-fef46e3a89f7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "df708cfb-2c50-53e1-aa99-67e1257016b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e70c602-cb80-472b-9c8d-9625de084fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e70c602-cb80-472b-9c8d-9625de084fe7.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9990,7 +9990,7 @@
         },
         {
             "id": "6adf644c-3d6c-572d-bacb-bcdac7d81f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d575fc-037b-421a-a205-12d492e9361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d575fc-037b-421a-a205-12d492e9361e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10028,7 +10028,7 @@
         },
         {
             "id": "602e2e28-318e-56c9-be1f-4c7a4cd08ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d04a06f-06a7-410d-a714-3b8b96ee3319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d04a06f-06a7-410d-a714-3b8b96ee3319.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10066,7 +10066,7 @@
         },
         {
             "id": "e7fe7a5b-883b-574c-8ec5-99933e3f033f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa60b6-cd0d-4c23-af81-88049ea45475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa60b6-cd0d-4c23-af81-88049ea45475.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10104,7 +10104,7 @@
         },
         {
             "id": "5da121e9-b0d1-52e6-a038-138a94fc5304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab950987-d88c-4326-98f4-1b1195788921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab950987-d88c-4326-98f4-1b1195788921.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "21ef560e-6bf8-5db7-883e-71e18b6d79f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea640731-b367-4ece-934e-6d86634fc1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea640731-b367-4ece-934e-6d86634fc1c8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10180,7 +10180,7 @@
         },
         {
             "id": "a59480e0-7654-58ee-9dd1-af8d796ed3c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f8def9-ee46-4abf-9059-7d1ec6f24951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f8def9-ee46-4abf-9059-7d1ec6f24951.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10218,7 +10218,7 @@
         },
         {
             "id": "5a47c1cb-e072-5a2a-8c01-e3a2b6568353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166fc328-20d1-4158-bcb6-3cebcf788ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166fc328-20d1-4158-bcb6-3cebcf788ef5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10256,7 +10256,7 @@
         },
         {
             "id": "dbb15a2e-b99d-5120-857c-fa67d0035f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc558-2c54-4c7b-a6fa-1e75ddcf12f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc558-2c54-4c7b-a6fa-1e75ddcf12f9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "0502177c-e69d-5fb0-aaec-621ac75acde1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e313f-ba75-4324-b1ac-f2bbae99f7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e313f-ba75-4324-b1ac-f2bbae99f7ab.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10332,7 +10332,7 @@
         },
         {
             "id": "269ae981-1dda-58c6-a973-7752d5e91bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d1c48f-1ca3-43ea-8109-964b29bb2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d1c48f-1ca3-43ea-8109-964b29bb2d50.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "fee4df77-3874-5dcc-bd70-c27bb1cc0373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9095db-44ad-444b-bd9d-4a06102fe230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9095db-44ad-444b-bd9d-4a06102fe230.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "0fd18bfb-3c45-5d74-ba52-28f0be493e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a46b11-3225-45aa-b54e-4d19d81b51cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a46b11-3225-45aa-b54e-4d19d81b51cf.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "5ab8a1d8-48ab-5e70-bd65-9229fe35ddce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1cc13-8959-4914-afe8-58daf9529f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1cc13-8959-4914-afe8-58daf9529f61.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "bb7a2bde-75b1-5f03-84f0-383a6eae1c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdc5ca9-6d01-4ee3-8117-3c1e74320553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdc5ca9-6d01-4ee3-8117-3c1e74320553.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10522,7 +10522,7 @@
         },
         {
             "id": "d12d8c26-f579-54ef-8102-f1222e423037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee856e7a-37ee-435c-80e8-d0ac6f15892f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee856e7a-37ee-435c-80e8-d0ac6f15892f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10560,7 +10560,7 @@
         },
         {
             "id": "899dce33-13fc-5b42-85be-6a302a0bffbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020d8b5-3173-4219-b063-f36a27e2004b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020d8b5-3173-4219-b063-f36a27e2004b.jpg?1",
             "name": "Grand Master of Flowers",
             "text": "As long as Grand Master of Flowers has seven or more loyalty counters on him, he's a 7/7 Dragon God creature with flying and indestructible.\n+1: Target creature without first strike, double strike, or vigilance can't attack or block until your next turn.\n+1: Search your library and/or graveyard for a card named Monk of the Open Hand, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "323cb1ec-100c-5884-93be-d06c5a70a765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8df51c3-cd9c-45eb-ac70-d13976e0e1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8df51c3-cd9c-45eb-ac70-d13976e0e1c4.jpg?1",
             "name": "Mordenkainen",
             "text": "+2: Draw two cards, then put a card from your hand on the bottom of your library.\n\u22122: Create a blue Dog Illusion creature token with \"This creature's power and toughness are each equal to twice the number of cards in your hand.\"\n\u221210: Exchange your hand and library, then shuffle. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -10636,7 +10636,7 @@
         },
         {
             "id": "45167e93-3d84-53ae-a860-e2865ca22668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e1624-06f6-4377-96a4-842adfa78778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e1624-06f6-4377-96a4-842adfa78778.jpg?1",
             "name": "Lolth, Spider Queen",
             "text": "Whenever a creature you control dies, put a loyalty counter on Lolth, Spider Queen.\n0: You draw a card and you lose 1 life.\n\u22123: Create two 2/1 black Spider creature tokens with menace and reach.\n\u22128: You get an emblem with \"Whenever an opponent is dealt combat damage by one or more creatures you control, if that player lost less than 8 life this turn, they lose life equal to the difference.\"",
             "colours": [
@@ -10674,7 +10674,7 @@
         },
         {
             "id": "41a850d8-5f11-5335-9422-df7d768b84eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad8828d-96b8-432f-bcee-3a60b6ef1270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad8828d-96b8-432f-bcee-3a60b6ef1270.jpg?1",
             "name": "Zariel, Archduke of Avernus",
             "text": "+1: Creatures you control get +1/+0 and gain haste until end of turn.\n0: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22126: You get an emblem with \"At the end of the first combat phase on your turn, untap target creature you control. After this phase, there is an additional combat phase.\"",
             "colours": [
@@ -10712,7 +10712,7 @@
         },
         {
             "id": "fc418565-4781-507f-9074-f14cda6219d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c97e5-87b2-4534-af7c-f4772f61469c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c97e5-87b2-4534-af7c-f4772f61469c.jpg?1",
             "name": "Ellywick Tumblestrum",
             "text": "+1: Venture into the dungeon.\n\u22122: Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. If it's legendary, you gain 3 life. Put the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Creatures you control have trample and haste and get +2/+2 for each differently named dungeon you've completed.\"",
             "colours": [
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "ec24e831-46c9-5cf9-9d08-db194f069384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b030b-4284-418b-889b-b705e7379d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b030b-4284-418b-889b-b705e7379d66.jpg?1",
             "name": "Icingdeath, Frost Tyrant",
             "text": "Flying, vigilance\nWhen Icingdeath, Frost Tyrant dies, create Icingdeath, Frost Tongue, a legendary white Equipment artifact token with \"Equipped creature gets +2/+0,\" \"Whenever equipped creature attacks, tap target creature defending player controls,\" and equip {2}.",
             "colours": [
@@ -10788,7 +10788,7 @@
         },
         {
             "id": "aba7e9d5-4638-510e-85cd-41f6ecc08c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e55e7-1d31-450e-bade-7bebe131ccfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e55e7-1d31-450e-bade-7bebe131ccfa.jpg?1",
             "name": "White Dragon",
             "text": "Flying\nCold Breath \u2014 When White Dragon enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -10824,7 +10824,7 @@
         },
         {
             "id": "6a45fe36-a432-5ba9-8447-a32b7b598458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9efd57-f894-4ce8-9fb0-6f06ec3da5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9efd57-f894-4ce8-9fb0-6f06ec3da5a8.jpg?1",
             "name": "Blue Dragon",
             "text": "Flying\nLightning Breath \u2014 When Blue Dragon enters the battlefield, until your next turn, target creature an opponent controls gets -3/-0, up to one other target creature gets -2/-0, and up to one other target creature gets -1/-0.",
             "colours": [
@@ -10860,7 +10860,7 @@
         },
         {
             "id": "1a0264fd-a917-515e-8768-5105b39d2ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd111eb2-cce5-413d-816a-f821771a1fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd111eb2-cce5-413d-816a-f821771a1fa6.jpg?1",
             "name": "Iymrith, Desert Doom",
             "text": "Flying\nIymrith, Desert Doom has ward {4} as long as it's untapped.\nWhenever Iymrith deals combat damage to a player, draw a card. Then if you have fewer than three cards in hand, draw cards equal to the difference.",
             "colours": [
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "c21f7c91-4fb3-5678-82ee-793b7703c068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c4c732-46b4-43f6-9466-fcfc86a99df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c4c732-46b4-43f6-9466-fcfc86a99df3.jpg?1",
             "name": "Black Dragon",
             "text": "Flying\nAcid Breath \u2014 When Black Dragon enters the battlefield, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -10934,7 +10934,7 @@
         },
         {
             "id": "e41949e0-9382-5561-aca4-cb2286e545cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed78a14-8c51-444c-a451-9a57e895c86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed78a14-8c51-444c-a451-9a57e895c86d.jpg?1",
             "name": "Ebondeath, Dracolich",
             "text": "Flash\nFlying\nEbondeath, Dracolich enters the battlefield tapped.\nYou may cast Ebondeath, Dracolich from your graveyard if a creature not named Ebondeath, Dracolich died this turn.",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "8937d320-f3ff-5646-81c0-65bdf0a6c1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45a5d3-8393-4506-b2e9-f9106ec80607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45a5d3-8393-4506-b2e9-f9106ec80607.jpg?1",
             "name": "Inferno of the Star Mounts",
             "text": "This spell can't be countered.\nFlying, haste\n{R}: Inferno of the Star Mounts gets +1/+0 until end of turn. When its power becomes 20 this way, it deals 20 damage to any target.",
             "colours": [
@@ -11011,7 +11011,7 @@
         },
         {
             "id": "2be7f77d-8b27-5b86-877f-117587f33e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ffffa9-c6ca-4752-bb56-3cedeadaabba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ffffa9-c6ca-4752-bb56-3cedeadaabba.jpg?1",
             "name": "Red Dragon",
             "text": "Flying\nFire Breath \u2014 When Red Dragon enters the battlefield, it deals 4 damage to each opponent.",
             "colours": [
@@ -11047,7 +11047,7 @@
         },
         {
             "id": "ccd336ae-5b5e-5fe2-ae72-314edaa5fb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798c207-c9cf-48c5-a5cd-0cf7d392115a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798c207-c9cf-48c5-a5cd-0cf7d392115a.jpg?1",
             "name": "Green Dragon",
             "text": "Flying\nPoison Breath \u2014 When Green Dragon enters the battlefield, until end of turn, whenever a creature an opponent controls is dealt damage, destroy it.",
             "colours": [
@@ -11083,7 +11083,7 @@
         },
         {
             "id": "0745868c-d0ef-529a-9265-50bf531d4492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ead969-8ba4-4587-a68d-47730943605e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ead969-8ba4-4587-a68d-47730943605e.jpg?1",
             "name": "Old Gnawbone",
             "text": "Flying\nWhenever a creature you control deals combat damage to a player, create that many Treasure tokens.",
             "colours": [
@@ -11121,7 +11121,7 @@
         },
         {
             "id": "9e39cc78-616e-594e-bfc4-4f9fb33d8728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62906879-fcc3-4ede-aa9e-b63d963d331a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62906879-fcc3-4ede-aa9e-b63d963d331a.jpg?1",
             "name": "Adult Gold Dragon",
             "text": "Flying, lifelink, haste",
             "colours": [
@@ -11159,7 +11159,7 @@
         },
         {
             "id": "8e287cf6-0244-5091-bca3-6732410c5afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fe79b-7af2-4911-8497-cbee8d529d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fe79b-7af2-4911-8497-cbee8d529d18.jpg?1",
             "name": "Tiamat",
             "text": "Flying\nWhen Tiamat enters the battlefield, if you cast it, search your library for up to five Dragon cards not named Tiamat that each have different names, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -11206,7 +11206,7 @@
         },
         {
             "id": "245a7947-877e-5b5d-b523-69bdf17a0950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf942df-d30b-4d1b-8a46-bca4abaeb147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf942df-d30b-4d1b-8a46-bca4abaeb147.jpg?1",
             "name": "Arborea Pegasus",
             "text": "Flying\nWhen Arborea Pegasus enters the battlefield, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -11242,7 +11242,7 @@
         },
         {
             "id": "196318b1-4d1a-5f41-a024-256e63c89a55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcf1082-25ac-4537-9fd9-631f834097ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcf1082-25ac-4537-9fd9-631f834097ad.jpg?1",
             "name": "Blink Dog",
             "text": "Double strike\nTeleport \u2014 {3}{W}: Blink Dog phases out.",
             "colours": [
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "80a6282b-7e49-583e-b725-7d0d4ba8a13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bba29a-6d7c-4f53-a4ad-e27a33fe19cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bba29a-6d7c-4f53-a4ad-e27a33fe19cc.jpg?1",
             "name": "Celestial Unicorn",
             "text": "Whenever you gain life, put a +1/+1 counter on Celestial Unicorn.",
             "colours": [
@@ -11314,7 +11314,7 @@
         },
         {
             "id": "da05016e-bcb0-5b9f-9d06-86fec4704641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab380bf5-2202-4098-b850-2cb660ec5351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab380bf5-2202-4098-b850-2cb660ec5351.jpg?1",
             "name": "Cloister Gargoyle",
             "text": "When Cloister Gargoyle enters the battlefield, venture into the dungeon.\nAs long as you've completed a dungeon, Cloister Gargoyle gets +3/+0 and has flying.",
             "colours": [
@@ -11351,7 +11351,7 @@
         },
         {
             "id": "2b2aa8f4-174f-5681-98de-e49547c43bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbd2a5-1d12-4900-8487-92912d66c059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbd2a5-1d12-4900-8487-92912d66c059.jpg?1",
             "name": "Nadaar, Selfless Paladin",
             "text": "Vigilance\nWhenever Nadaar, Selfless Paladin enters the battlefield or attacks, venture into the dungeon.\nOther creatures you control get +1/+1 as long as you've completed a dungeon.",
             "colours": [
@@ -11390,7 +11390,7 @@
         },
         {
             "id": "61cd845e-1870-5441-9031-cc0217b2a948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853c9db7-504e-4dfb-8067-abd2a36f6a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853c9db7-504e-4dfb-8067-abd2a36f6a1a.jpg?1",
             "name": "Oswald Fiddlebender",
             "text": "Magical Tinkering \u2014 {W}, {T}, Sacrifice an artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -11429,7 +11429,7 @@
         },
         {
             "id": "5778c32e-9afd-5931-bda5-3969f05fa7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8646ae5c-e757-4d16-bf2a-d48770d620fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8646ae5c-e757-4d16-bf2a-d48770d620fa.jpg?1",
             "name": "Displacer Beast",
             "text": "When Displacer Beast enters the battlefield, venture into the dungeon.\nDisplacement \u2014 {3}{U}: Return Displacer Beast to its owner's hand.",
             "colours": [
@@ -11466,7 +11466,7 @@
         },
         {
             "id": "d5f29a23-7938-5572-969e-2dfbbfef4976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7cd8c3-8365-4e40-a089-02bc9b93581a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7cd8c3-8365-4e40-a089-02bc9b93581a.jpg?1",
             "name": "Djinni Windseer",
             "text": "Flying\nWhen Djinni Windseer enters the battlefield, roll a d20.\n1\u20139 | Scry 1.\n10\u201319 | Scry 2.\n20 | Scry 3.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "9264f46d-a0bb-5a22-900a-5234cbb473e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f70431-12c9-4530-b51b-d85c38746989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f70431-12c9-4530-b51b-d85c38746989.jpg?1",
             "name": "Dragon Turtle",
             "text": "Flash\nDrag Below \u2014 When Dragon Turtle enters the battlefield, tap it and up to one target creature an opponent controls. They don't untap during their controllers' next untap steps.",
             "colours": [
@@ -11539,7 +11539,7 @@
         },
         {
             "id": "7454d5fd-6e9b-5933-b35e-b55642ebb122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc1142e-ccf6-42bb-9d56-d74344ce8f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc1142e-ccf6-42bb-9d56-d74344ce8f97.jpg?1",
             "name": "Mind Flayer",
             "text": "Dominate Monster \u2014 When Mind Flayer enters the battlefield, gain control of target creature for as long as you control Mind Flayer.",
             "colours": [
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "11d40f29-e683-5bdc-a488-4389abb31d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2074a9-8b6f-4904-bb8c-ae705d31f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2074a9-8b6f-4904-bb8c-ae705d31f2f1.jpg?1",
             "name": "Pixie Guide",
             "text": "Flying\nGrant an Advantage \u2014 If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
             "colours": [
@@ -11611,7 +11611,7 @@
         },
         {
             "id": "88e8bea8-8e78-5650-97de-c71820a67c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1fc7-be88-46a3-8bd9-3f16332c2bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1fc7-be88-46a3-8bd9-3f16332c2bd8.jpg?1",
             "name": "Rimeshield Frost Giant",
             "text": "Ward {3}",
             "colours": [
@@ -11648,7 +11648,7 @@
         },
         {
             "id": "2ab4f75a-db73-5acf-b7cf-79c0f87439a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f3cba-df13-4c89-b92d-47ee3be6809c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f3cba-df13-4c89-b92d-47ee3be6809c.jpg?1",
             "name": "Baleful Beholder",
             "text": "When Baleful Beholder enters the battlefield, choose one \u2014\n\u2022 Antimagic Cone \u2014 Each opponent sacrifices an enchantment.\n\u2022 Fear Ray \u2014 Creatures you control gain menace until end of turn.",
             "colours": [
@@ -11684,7 +11684,7 @@
         },
         {
             "id": "58fa6612-3319-5050-a007-19faefbda947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1090e40c-c04b-4ee2-aa12-1575f896d31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1090e40c-c04b-4ee2-aa12-1575f896d31a.jpg?1",
             "name": "Clattering Skeletons",
             "text": "When Clattering Skeletons dies, venture into the dungeon.",
             "colours": [
@@ -11720,7 +11720,7 @@
         },
         {
             "id": "1fdb2eee-52af-5ba9-9eb9-6d16bea57bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f99dbef-9f38-4ef1-8b4e-03385edf3339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f99dbef-9f38-4ef1-8b4e-03385edf3339.jpg?1",
             "name": "Gelatinous Cube",
             "text": "Engulf \u2014 When Gelatinous Cube enters the battlefield, exile target non-Ooze creature an opponent controls until Gelatinous Cube leaves the battlefield.\nDissolve \u2014 {X}{B}: Put target creature card with mana value X exiled with Gelatinous Cube into its owner's graveyard.",
             "colours": [
@@ -11756,7 +11756,7 @@
         },
         {
             "id": "d02f16bf-bdb8-54e9-b219-df6718b3b694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6730db48-3884-45bd-b514-7738c5c36b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6730db48-3884-45bd-b514-7738c5c36b97.jpg?1",
             "name": "Manticore",
             "text": "Flash\nFlying\nTail Spikes \u2014 When Manticore enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -11792,7 +11792,7 @@
         },
         {
             "id": "8ae19b3d-99f1-51a0-96a4-f12cdb706cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b32f97-327c-403c-8fdf-f614bf8fe198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b32f97-327c-403c-8fdf-f614bf8fe198.jpg?1",
             "name": "Westgate Regent",
             "text": "Flying\nWard\u2014\nDiscard a card.\nWhenever Westgate Regent deals combat damage to a player, put that many +1/+1 counters on it.",
             "colours": [
@@ -11828,7 +11828,7 @@
         },
         {
             "id": "64c39ed1-0b57-5a2c-b8bb-b20df9f855de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c5b88-4cca-410a-8464-5111b4eaa3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c5b88-4cca-410a-8464-5111b4eaa3b6.jpg?1",
             "name": "Wight",
             "text": "Wight enters the battlefield tapped.\nLife Drain \u2014 Whenever a creature dealt damage by Wight this turn dies, create a tapped 2/2 black Zombie creature token and exile that card.",
             "colours": [
@@ -11865,7 +11865,7 @@
         },
         {
             "id": "1044d399-82ed-55ae-bb8d-8b892e45cf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1dc68-868b-4f3f-b10a-62842d88edc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1dc68-868b-4f3f-b10a-62842d88edc4.jpg?1",
             "name": "Delina, Wild Mage",
             "text": "Whenever Delina, Wild Mage attacks, choose target creature you control, then roll a d20.\n1\u201314 | Create a tapped and attacking token that's a copy of that creature, except it's not legendary and it has \"Exile this creature at end of combat.\"\n15\u201320 | Create one of those tokens. Roll again.",
             "colours": [
@@ -11904,7 +11904,7 @@
         },
         {
             "id": "bca09977-8755-591d-a62b-38f5b8c77661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf573ba-6471-434b-88fd-c9caa539515a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf573ba-6471-434b-88fd-c9caa539515a.jpg?1",
             "name": "Goblin Javelineer",
             "text": "Haste\nWhenever Goblin Javelineer becomes blocked, it deals 1 damage to target creature blocking it.",
             "colours": [
@@ -11941,7 +11941,7 @@
         },
         {
             "id": "18f6eac2-73da-5139-9a65-706c83b68e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a081f0aa-65ad-4483-991f-1d6159b7560a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a081f0aa-65ad-4483-991f-1d6159b7560a.jpg?1",
             "name": "Hulking Bugbear",
             "text": "Haste",
             "colours": [
@@ -11977,7 +11977,7 @@
         },
         {
             "id": "4121f2bb-91e3-5880-86e9-f500684dc228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e763a-ba7d-4e32-a5f1-87a457b12db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e763a-ba7d-4e32-a5f1-87a457b12db2.jpg?1",
             "name": "Minion of the Mighty",
             "text": "Menace\nPack tactics \u2014 Whenever Minion of the Mighty attacks, if you attacked with creatures with total power 6 or greater this combat, you may put a Dragon creature card from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "0e4ee5d1-ffcf-5da0-8e1f-739e2bf8e5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf004dae-c411-4b0e-b695-fd727f475948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf004dae-c411-4b0e-b695-fd727f475948.jpg?1",
             "name": "Rust Monster",
             "text": "First strike\nSacrifice an artifact: Rust Monster gets +2/+0 until end of turn.",
             "colours": [
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "cd7ac4cf-6d4c-582d-bfd2-b12cb97fc8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a6502-5239-449a-b04a-c82d525f9916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a6502-5239-449a-b04a-c82d525f9916.jpg?1",
             "name": "Xorn",
             "text": "If you would create one or more Treasure tokens, instead create those tokens plus an additional Treasure token.",
             "colours": [
@@ -12085,7 +12085,7 @@
         },
         {
             "id": "7bd7421a-cd26-58f4-b207-a683ed833eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f43-ea54-4ab3-afd5-683e4bd0d3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f43-ea54-4ab3-afd5-683e4bd0d3e0.jpg?1",
             "name": "Zalto, Fire Giant Duke",
             "text": "Trample\nWhenever Zalto, Fire Giant Duke is dealt damage, venture into the dungeon.",
             "colours": [
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "f960ea96-128f-50bd-8ae4-ecc2cc39c400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76c993-7cc5-428f-bfbc-7747c6a566d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76c993-7cc5-428f-bfbc-7747c6a566d0.jpg?1",
             "name": "Bulette",
             "text": "At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on Bulette.",
             "colours": [
@@ -12160,7 +12160,7 @@
         },
         {
             "id": "07dd3038-2292-53ea-af35-46670148b89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7669e373-0173-43db-8b86-abc319c9e8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7669e373-0173-43db-8b86-abc319c9e8fc.jpg?1",
             "name": "Dire Wolf Prowler",
             "text": "{1}{G}: Dire Wolf Prowler gets +2/+2 and gains haste until end of turn. Activate only once each turn.",
             "colours": [
@@ -12196,7 +12196,7 @@
         },
         {
             "id": "6036298d-36e4-57ab-9e0b-480e42b33c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b8a1e6-a649-4be1-8899-104fffdb2dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b8a1e6-a649-4be1-8899-104fffdb2dff.jpg?1",
             "name": "Gnoll Hunter",
             "text": "Pack tactics \u2014 Whenever Gnoll Hunter attacks, if you attacked with creatures with total power 6 or greater this combat, put a +1/+1 counter on Gnoll Hunter.",
             "colours": [
@@ -12232,7 +12232,7 @@
         },
         {
             "id": "1c50d443-921f-557c-9313-01a4c0518365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0505a8a-841b-471b-970d-125583b9ba9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0505a8a-841b-471b-970d-125583b9ba9d.jpg?1",
             "name": "Loathsome Troll",
             "text": "{3}{G}: Roll a d20. Activate only if Loathsome Troll is in your graveyard.\n1\u20139 | Put Loathsome Troll on top of your library.\n10\u201319 | Return Loathsome Troll to your hand.\n20 | Return Loathsome Troll to the battlefield tapped.",
             "colours": [
@@ -12268,7 +12268,7 @@
         },
         {
             "id": "2bb659fe-5f4c-5fe3-8192-f02439eba791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f3b766-3c2a-41fa-8614-015fdc83c98c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f3b766-3c2a-41fa-8614-015fdc83c98c.jpg?1",
             "name": "Lurking Roper",
             "text": "Lurking Roper doesn't untap during your untap step.\nWhenever you gain life, untap Lurking Roper.",
             "colours": [
@@ -12304,7 +12304,7 @@
         },
         {
             "id": "e041bb48-9f4b-54fc-9496-d651ab0a3a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01234d4c-ff3d-40a8-8404-9790d3ee3620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01234d4c-ff3d-40a8-8404-9790d3ee3620.jpg?1",
             "name": "Neverwinter Dryad",
             "text": "{2}, Sacrifice Neverwinter Dryad: Search your library for a basic Forest card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "75adc8ae-f127-57fa-92f2-3beee573907a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60bdf5-d954-4e28-9858-d3780c1b5b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60bdf5-d954-4e28-9858-d3780c1b5b41.jpg?1",
             "name": "Ochre Jelly",
             "text": "Trample\nOchre Jelly enters the battlefield with X +1/+1 counters on it.\nSplit \u2014 When Ochre Jelly dies, if it had two or more +1/+1 counters on it, create a token that's a copy of it at the beginning of the next end step. The token enters the battlefield with half that many +1/+1 counters on it, rounded down.",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "9e24da46-619b-576e-b218-39f2f3c77e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b19309-a7f6-44da-b856-d12da11156e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b19309-a7f6-44da-b856-d12da11156e8.jpg?1",
             "name": "Owlbear",
             "text": "Trample\nKeen Senses \u2014 When Owlbear enters the battlefield, draw a card.",
             "colours": [
@@ -12413,7 +12413,7 @@
         },
         {
             "id": "c0b1a688-ac2b-524b-b7af-c3a0e546c09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4bad2-1e56-44f4-beef-59edafcc9d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4bad2-1e56-44f4-beef-59edafcc9d95.jpg?1",
             "name": "Purple Worm",
             "text": "This spell costs {2} less to cast if a creature died this turn.\nWard {2}",
             "colours": [
@@ -12449,7 +12449,7 @@
         },
         {
             "id": "007e6de3-9a15-57bb-a0db-ed255243adfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785d199-3e8a-494a-9fd7-5215eb6b3eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785d199-3e8a-494a-9fd7-5215eb6b3eea.jpg?1",
             "name": "The Tarrasque",
             "text": "The Tarrasque has haste and ward {1}0 as long as it was cast.\nWhenever The Tarrasque attacks, it fights target creature defending player controls.",
             "colours": [
@@ -12487,7 +12487,7 @@
         },
         {
             "id": "10582c26-4734-51d3-8d35-e5f734fa9fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96116efa-b580-4764-aba5-09cb8ce24806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96116efa-b580-4764-aba5-09cb8ce24806.jpg?1",
             "name": "Underdark Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -12523,7 +12523,7 @@
         },
         {
             "id": "5d2934cc-d160-56a5-9f9c-9b07d6c43079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051be39-298e-44dc-8fd9-bfbecdf98a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051be39-298e-44dc-8fd9-bfbecdf98a58.jpg?1",
             "name": "Varis, Silverymoon Ranger",
             "text": "Reach, ward {1}\nWhenever you cast a creature or planeswalker spell, venture into the dungeon. This ability triggers only once each turn.\nWhenever you complete a dungeon, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -12563,7 +12563,7 @@
         },
         {
             "id": "95453148-bccc-5d77-b932-6cccdf473d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38ce406d-8253-48f8-a146-8302518c5187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38ce406d-8253-48f8-a146-8302518c5187.jpg?1",
             "name": "Barrowin of Clan Undurr",
             "text": "When Barrowin of Clan Undurr enters the battlefield, venture into the dungeon.\nWhenever Barrowin of Clan Undurr attacks, return up to one creature card with mana value 3 or less from your graveyard to the battlefield if you've completed a dungeon.",
             "colours": [
@@ -12604,7 +12604,7 @@
         },
         {
             "id": "b11d179d-52be-5ed8-85c1-8788cf9f9171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e7d7-60f8-452b-9563-5624791ae893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e7d7-60f8-452b-9563-5624791ae893.jpg?1",
             "name": "Bruenor Battlehammer",
             "text": "Each creature you control gets +2/+0 for each Equipment attached to it.\nYou may pay {0} rather than pay the equip cost of the first equip ability you activate each turn.",
             "colours": [
@@ -12645,7 +12645,7 @@
         },
         {
             "id": "28cd45eb-bfa4-5405-9208-16c9e6f240d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcd9221-c59b-4c92-b6fc-972a17e2dd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcd9221-c59b-4c92-b6fc-972a17e2dd0e.jpg?1",
             "name": "Drizzt Do'Urden",
             "text": "Double strike\nWhen Drizzt Do'Urden enters the battlefield, create Guenhwyvar, a legendary 4/1 green Cat creature token with trample.\nWhenever a creature dies, if it had power greater than Drizzt's power, put a number of +1/+1 counters on Drizzt equal to the difference.",
             "colours": [
@@ -12686,7 +12686,7 @@
         },
         {
             "id": "617cc46e-c80c-55dd-9059-e9ea037b4efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f83fa5-c77b-4a70-a6cf-2c8e196b6f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f83fa5-c77b-4a70-a6cf-2c8e196b6f3f.jpg?1",
             "name": "Farideh, Devil's Chosen",
             "text": "Dark One's Own Luck \u2014 Whenever you roll one or more dice, Farideh, Devil's Chosen gains flying and menace until end of turn. If any of those results was 10 or higher, draw a card.",
             "colours": [
@@ -12727,7 +12727,7 @@
         },
         {
             "id": "3bb59b6f-8a31-58d1-9239-0475966a8c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c41d97-7c2f-4d8b-a35d-40d98329a728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c41d97-7c2f-4d8b-a35d-40d98329a728.jpg?1",
             "name": "Gretchen Titchwillow",
             "text": "{2}{G}{U}: Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -12768,7 +12768,7 @@
         },
         {
             "id": "5083ee72-600a-5ff9-a1df-d4a320067428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a71cdb-d97c-449e-a7cb-af7030164ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a71cdb-d97c-449e-a7cb-af7030164ff4.jpg?1",
             "name": "Hama Pashar, Ruin Seeker",
             "text": "Room abilities of dungeons you own trigger an additional time.",
             "colours": [
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "03236afc-1e37-505c-94ca-9cfd42da8c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df8cb7c-ad05-473b-9deb-7ce56c6799b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df8cb7c-ad05-473b-9deb-7ce56c6799b8.jpg?1",
             "name": "Kalain, Reclusive Painter",
             "text": "When Kalain, Reclusive Painter enters the battlefield, create a Treasure token.\nOther creatures you control enter the battlefield with an additional +1/+1 counter on them for each mana from a Treasure spent to cast them.",
             "colours": [
@@ -12851,7 +12851,7 @@
         },
         {
             "id": "dad2113e-40c0-5710-aaa6-43c97e8af1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f77be2-2333-4b3a-9954-15f4de7a61c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f77be2-2333-4b3a-9954-15f4de7a61c0.jpg?1",
             "name": "Krydle of Baldur's Gate",
             "text": "Whenever Krydle of Baldur's Gate deals combat damage to a player, that player loses 1 life and mills a card, then you gain 1 life and scry 1.\nWhenever you attack, you may pay {2}. If you do, target creature can't be blocked this turn.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "b3134e1a-86ef-51ca-b037-dd0e25f2e30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034f75c7-bb57-426a-8e3f-4b7f0110f02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034f75c7-bb57-426a-8e3f-4b7f0110f02b.jpg?1",
             "name": "Minsc, Beloved Ranger",
             "text": "When Minsc, Beloved Ranger enters the battlefield, create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n{X}: Until end of turn, target creature you control has base power and toughness X/X and becomes a Giant in addition to its other types. Activate only as a sorcery.",
             "colours": [
@@ -12936,7 +12936,7 @@
         },
         {
             "id": "c6c19a89-a749-55ae-b770-a57db659b657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a98a2d-a837-4911-b726-b2cee17cf450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a98a2d-a837-4911-b726-b2cee17cf450.jpg?1",
             "name": "Shessra, Death's Whisper",
             "text": "Bewitching Whispers \u2014 When Shessra, Death's Whisper enters the battlefield, target creature blocks this turn if able.\nWhispers of the Grave \u2014 At the beginning of your end step, if a creature died this turn, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -12978,7 +12978,7 @@
         },
         {
             "id": "ab079d5d-105c-57ed-bc97-f93d14b20500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e3a2-3d8d-458d-960b-ded60d2ad4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e3a2-3d8d-458d-960b-ded60d2ad4a1.jpg?1",
             "name": "Trelasarra, Moon Dancer",
             "text": "Whenever you gain life, put a +1/+1 counter on Trelasarra, Moon Dancer and scry 1.",
             "colours": [
@@ -13019,7 +13019,7 @@
         },
         {
             "id": "3eff2c57-aa8a-5747-a213-9d8746ad30b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f910f2-a7ed-4535-b554-d672ba49f38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f910f2-a7ed-4535-b554-d672ba49f38c.jpg?1",
             "name": "Volo, Guide to Monsters",
             "text": "Whenever you cast a creature spell that doesn't share a creature type with a creature you control or a creature card in your graveyard, copy that spell. (A copy of a creature spell becomes a token.)",
             "colours": [
@@ -13060,7 +13060,7 @@
         },
         {
             "id": "32cdeba8-d0c1-55c4-87d0-404305e77dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47852cc6-a6de-4aed-9650-0c7ce346c3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47852cc6-a6de-4aed-9650-0c7ce346c3b9.jpg?1",
             "name": "Iron Golem",
             "text": "Vigilance\nIron Golem attacks or blocks each combat if able.",
             "colours": [],
@@ -13093,7 +13093,7 @@
         },
         {
             "id": "73ce4804-3da8-5345-9631-fb5a36c01bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059c316-2be1-4f66-9888-d31714280a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059c316-2be1-4f66-9888-d31714280a5e.jpg?1",
             "name": "Mimic",
             "text": "{T}, Sacrifice Mimic: Add one mana of any color.\n{2}: Mimic becomes a Shapeshifter artifact creature with base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -13125,7 +13125,7 @@
         },
         {
             "id": "8edf5a3f-eae0-58e0-a871-70ebbf23c2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c35234-2518-494c-8c1e-fd5702145967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c35234-2518-494c-8c1e-fd5702145967.jpg?1",
             "name": "Cave of the Frost Dragon",
             "text": "If you control two or more other lands, Cave of the Frost Dragon enters the battlefield tapped.\n{T}: Add {W}.\n{4}{W}: Cave of the Frost Dragon becomes a 3/4 white Dragon creature with flying until end of turn. It's still a land.",
             "colours": [],
@@ -13157,7 +13157,7 @@
         },
         {
             "id": "64e31d5f-41f7-5476-9ad7-51da7bbfa26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565be37a-4c14-420b-a07c-18e21f7fd731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565be37a-4c14-420b-a07c-18e21f7fd731.jpg?1",
             "name": "Den of the Bugbear",
             "text": "If you control two or more other lands, Den of the Bugbear enters the battlefield tapped.\n{T}: Add {R}.\n{3}{R}: Until end of turn, Den of the Bugbear becomes a 3/2 red Goblin creature with \"Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\" It's still a land.",
             "colours": [],
@@ -13189,7 +13189,7 @@
         },
         {
             "id": "3e1bf33d-e7c0-56cd-9d3a-9097c462798c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c7b02d-ac45-45b1-9f1b-2dbd2b5c3cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c7b02d-ac45-45b1-9f1b-2dbd2b5c3cdc.jpg?1",
             "name": "Dungeon Descent",
             "text": "Dungeon Descent enters the battlefield tapped.\n{T}: Add {C}.\n{4}, {T}, Tap an untapped legendary creature you control: Venture into the dungeon. Activate only as a sorcery.",
             "colours": [],
@@ -13219,7 +13219,7 @@
         },
         {
             "id": "9aa88c25-0525-5817-a227-7ff2aeb23b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6069f2-7a32-4cb7-b2ab-ea6b51267cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6069f2-7a32-4cb7-b2ab-ea6b51267cca.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -13249,7 +13249,7 @@
         },
         {
             "id": "cb23ca0a-da9b-5c7d-a6ef-ddf08e4ed1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d959ee0b-9fb1-4e32-ad45-f04cdd5c678a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d959ee0b-9fb1-4e32-ad45-f04cdd5c678a.jpg?1",
             "name": "Hall of Storm Giants",
             "text": "If you control two or more other lands, Hall of Storm Giants enters the battlefield tapped.\n{T}: Add {U}.\n{5}{U}: Until end of turn, Hall of Storm Giants becomes a 7/7 blue Giant creature with ward {3}. It's still a land.",
             "colours": [],
@@ -13281,7 +13281,7 @@
         },
         {
             "id": "1343e3f6-b68e-56f2-9195-71cbe43e2213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b9d17d-3ab0-4755-b396-391df50e70dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b9d17d-3ab0-4755-b396-391df50e70dd.jpg?1",
             "name": "Hive of the Eye Tyrant",
             "text": "If you control two or more other lands, Hive of the Eye Tyrant enters the battlefield tapped.\n{T}: Add {B}.\n{3}{B}: Until end of turn, Hive of the Eye Tyrant becomes a 3/3 black Beholder creature with menace and \"Whenever this creature attacks, exile target card from defending player's graveyard.\" It's still a land.",
             "colours": [],
@@ -13313,7 +13313,7 @@
         },
         {
             "id": "0702e5b3-3e6e-5c45-b2b5-7d7d77613b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10d359-543a-4d2e-9bbe-23f93a14aa2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10d359-543a-4d2e-9bbe-23f93a14aa2d.jpg?1",
             "name": "Lair of the Hydra",
             "text": "If you control two or more other lands, Lair of the Hydra enters the battlefield tapped.\n{T}: Add {G}.\n{X}{G}: Until end of turn, Lair of the Hydra becomes an X/X green Hydra creature. It's still a land. X can't be 0.",
             "colours": [],
@@ -13345,7 +13345,7 @@
         },
         {
             "id": "5a91508d-d5b9-5897-a4ce-bb763e3b650e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01054cee-3105-4e80-9ded-0ae57db5c159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01054cee-3105-4e80-9ded-0ae57db5c159.jpg?1",
             "name": "Temple of the Dragon Queen",
             "text": "As Temple of the Dragon Queen enters the battlefield, you may reveal a Dragon card from your hand. Temple of the Dragon Queen enters the battlefield tapped unless you revealed a Dragon card this way or you control a Dragon.\nAs Temple of the Dragon Queen enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -13375,7 +13375,7 @@
         },
         {
             "id": "125ffb5a-124f-54b9-bfef-6da5713e9441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d75f53d-d105-4973-ab2e-58cdf3a41eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d75f53d-d105-4973-ab2e-58cdf3a41eed.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -13406,7 +13406,7 @@
         },
         {
             "id": "5031765f-0bd8-5866-89ac-2e9a3ec1b7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c795f284-4d77-474b-a546-afb0def84d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c795f284-4d77-474b-a546-afb0def84d4f.jpg?1",
             "name": "The Book of Exalted Deeds",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, create a 3/3 white Angel creature token with flying.\n{W}{W}{W}, {T}, Exile The Book of Exalted Deeds: Put an enlightened counter on target Angel. It gains \"You can't lose the game and your opponents can't win the game.\" Activate only as a sorcery.",
             "colours": [
@@ -13442,7 +13442,7 @@
         },
         {
             "id": "3d27450b-fbd7-5a63-ad1b-dee86bf4db03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8b5883-b2e7-4c56-89b5-b40fb8416a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8b5883-b2e7-4c56-89b5-b40fb8416a3a.jpg?1",
             "name": "Dancing Sword",
             "text": "Equipped creature gets +2/+1.\nWhen equipped creature dies, you may have Dancing Sword become a 2/1 Construct artifact creature with flying and ward {1}. If you do, it isn't an Equipment.\nEquip {1}",
             "colours": [
@@ -13478,7 +13478,7 @@
         },
         {
             "id": "78519a87-1993-5add-a65f-dbcc6be65d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263501c5-dec0-4c01-8129-61f9fdd22b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263501c5-dec0-4c01-8129-61f9fdd22b54.jpg?1",
             "name": "Flumph",
             "text": "Defender, flying\nWhenever Flumph is dealt damage, you and target opponent each draw a card.",
             "colours": [
@@ -13514,7 +13514,7 @@
         },
         {
             "id": "0b6be946-55fb-53da-bf48-047b0960cede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363a43f-d9aa-4196-bde5-2d98ad377e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363a43f-d9aa-4196-bde5-2d98ad377e48.jpg?1",
             "name": "Guardian of Faith",
             "text": "Flash\nVigilance\nWhen Guardian of Faith enters the battlefield, any number of other target creatures you control phase out.",
             "colours": [
@@ -13551,7 +13551,7 @@
         },
         {
             "id": "31c37543-73c8-5471-b3e2-544e9d5ff7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce58575-7607-49a4-a7c9-b23b715c3bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce58575-7607-49a4-a7c9-b23b715c3bf5.jpg?1",
             "name": "Loyal Warhound",
             "text": "Vigilance\nWhen Loyal Warhound enters the battlefield, if an opponent controls more lands than you, search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13587,7 +13587,7 @@
         },
         {
             "id": "5b217df5-6601-525d-90dc-c6eadb1017db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc13fd-8e08-4846-87ef-0562bdd3ba93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc13fd-8e08-4846-87ef-0562bdd3ba93.jpg?1",
             "name": "Teleportation Circle",
             "text": "At the beginning of your end step, exile up to one target artifact or creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -13621,7 +13621,7 @@
         },
         {
             "id": "60af052c-0278-5876-876f-13c0988d7876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcf9cf4-73d3-4212-b29a-660c3d3f537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcf9cf4-73d3-4212-b29a-660c3d3f537f.jpg?1",
             "name": "The Blackstaff of Waterdeep",
             "text": "You may choose not to untap The Blackstaff of Waterdeep during your untap step.\nAnimate Walking Statue \u2014 {1}{U}, {T}: Another target nontoken artifact you control becomes a 4/4 artifact creature for as long as The Blackstaff of Waterdeep remains tapped. Activate only as a sorcery.",
             "colours": [
@@ -13657,7 +13657,7 @@
         },
         {
             "id": "466bafac-7fd5-5fed-8236-41b669e8566c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a5b2f1-4bf7-48c4-ab56-e03b35ea3f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a5b2f1-4bf7-48c4-ab56-e03b35ea3f21.jpg?1",
             "name": "Demilich",
             "text": "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn.\nWhenever Demilich attacks, exile up to one target instant or sorcery card from your graveyard. Copy it. You may cast the copy.\nYou may cast Demilich from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.",
             "colours": [
@@ -13694,7 +13694,7 @@
         },
         {
             "id": "03a3e10f-dd7d-5816-9bca-3db1c448646e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480d92e-5c03-49b8-8bdd-fbcce80de998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480d92e-5c03-49b8-8bdd-fbcce80de998.jpg?1",
             "name": "Grazilaxx, Illithid Scholar",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -13732,7 +13732,7 @@
         },
         {
             "id": "6707e88a-9751-533d-a474-8640f413564e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9667e453-5dc1-4ee7-82e4-edfc41db1151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9667e453-5dc1-4ee7-82e4-edfc41db1151.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "Each opponent exiles cards from the top of their library until that player has exiled cards with total mana value 20 or more.",
             "colours": [
@@ -13766,7 +13766,7 @@
         },
         {
             "id": "58fe404f-94bd-53bf-9fc3-1bb6ba9f8770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7667ac49-09b8-424f-8310-a5576977745b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7667ac49-09b8-424f-8310-a5576977745b.jpg?1",
             "name": "True Polymorph",
             "text": "Target artifact or creature becomes a copy of another target artifact or creature.",
             "colours": [
@@ -13800,7 +13800,7 @@
         },
         {
             "id": "ac8950b0-60dd-52af-85cf-1f04b55f67c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c470b5-91d7-4cf2-b6c0-61280a63bce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c470b5-91d7-4cf2-b6c0-61280a63bce1.jpg?1",
             "name": "Wizard's Spellbook",
             "text": "{T}: Exile target instant or sorcery card from a graveyard. Roll a d20. Activate only as a sorcery.\n1\u20139 | Copy that card. You may cast the copy.\n10\u201319 | Copy that card. You may cast the copy by paying {1} rather than paying its mana cost.\n20 | Copy each card exiled with Wizard's Spellbook. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -13834,7 +13834,7 @@
         },
         {
             "id": "89c068b9-b595-51f4-a78a-6d7c664239fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9043519d-c9d8-4d08-b4a9-feaf792bc7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9043519d-c9d8-4d08-b4a9-feaf792bc7a4.jpg?1",
             "name": "Yuan-Ti Malison",
             "text": "Yuan-Ti Malison can't be blocked as long as it's attacking alone.\nWhenever Yuan-Ti Malison deals combat damage to a player, venture into the dungeon.",
             "colours": [
@@ -13871,7 +13871,7 @@
         },
         {
             "id": "11d68034-56a0-5251-8d0e-f56206f7dfc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376b3cee-9386-41b0-a5d9-f60d147caff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376b3cee-9386-41b0-a5d9-f60d147caff7.jpg?1",
             "name": "Acererak the Archlich",
             "text": "When Acererak the Archlich enters the battlefield, if you haven't completed Tomb of Annihilation, return Acererak the Archlich to its owner's hand and venture into the dungeon.\nWhenever Acererak the Archlich attacks, for each opponent, you create a 2/2 black Zombie creature token unless that player sacrifices a creature.",
             "colours": [
@@ -13910,7 +13910,7 @@
         },
         {
             "id": "bdaf3b11-9f44-58ce-a7fc-d28e4a5487a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0bbab6-b9ad-456d-ab4a-485dd8d89b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0bbab6-b9ad-456d-ab4a-485dd8d89b35.jpg?1",
             "name": "Asmodeus the Archfiend",
             "text": "Binding Contract \u2014 If you would draw a card, exile the top card of your library face down instead.\n{B}{B}{B}: Draw seven cards.\n{B}: Return all cards exiled with Asmodeus the Archfiend to their owner's hand and you lose that much life.",
             "colours": [
@@ -13949,7 +13949,7 @@
         },
         {
             "id": "d215087e-1292-5888-bae8-b52a7e5c0c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe97c8c-6bb0-4456-aa99-91c721f19777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe97c8c-6bb0-4456-aa99-91c721f19777.jpg?1",
             "name": "The Book of Vile Darkness",
             "text": "At the beginning of your end step, if you lost 2 or more life this turn, create a 2/2 black Zombie creature token.\n{T}, Exile The Book of Vile Darkness and artifacts you control named Eye of Vecna and Hand of Vecna: Create Vecna, a legendary 8/8 black Zombie God creature token with indestructible. It gains all triggered abilities of the exiled cards.",
             "colours": [
@@ -13985,7 +13985,7 @@
         },
         {
             "id": "53538eee-50d2-5812-b542-730d337f8ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa3a489-5fa3-421e-9655-755f31414f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa3a489-5fa3-421e-9655-755f31414f3d.jpg?1",
             "name": "Forsworn Paladin",
             "text": "Menace\n{1}{B}, {T}, Pay 1 life: Create a Treasure token.\n{2}{B}: Target creature gets +2/+0 until end of turn. If mana from a Treasure was spent to activate this ability, that creature also gains deathtouch until end of turn.",
             "colours": [
@@ -14022,7 +14022,7 @@
         },
         {
             "id": "11d8235a-1c64-592f-9262-df2fe165bb9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af7ba0-3d14-4d29-9434-395a1f9f3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af7ba0-3d14-4d29-9434-395a1f9f3148.jpg?1",
             "name": "Sphere of Annihilation",
             "text": "Sphere of Annihilation enters the battlefield with X void counters on it.\nAt the beginning of your upkeep, exile Sphere of Annihilation, all creatures and planeswalkers with mana value less than or equal to the number of void counters on it, and all creature and planeswalker cards in graveyards with mana value less than or equal to the number of void counters on it.",
             "colours": [
@@ -14056,7 +14056,7 @@
         },
         {
             "id": "3f586cac-5221-5b6f-aa0f-5ba2d0ed6293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f98860-d51a-4873-ab14-98f29b4eee5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f98860-d51a-4873-ab14-98f29b4eee5d.jpg?1",
             "name": "Vorpal Sword",
             "text": "Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains \"Whenever equipped creature deals combat damage to a player, that player loses the game.\"\nEquip {B}{B}",
             "colours": [
@@ -14093,7 +14093,7 @@
         },
         {
             "id": "29c24ffd-f0f7-5a70-a4cd-4b89f015a15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8826a883-197b-48e9-bd07-e2c8ce361fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8826a883-197b-48e9-bd07-e2c8ce361fcf.jpg?1",
             "name": "Flameskull",
             "text": "Flying\nFlameskull can't block.\nRejuvenation \u2014 When Flameskull dies, exile it. If you do, exile the top card of your library. Until the end of your next turn, you may play one of those cards. (If you cast Flameskull this way, you can't play the other card, and vice versa.)",
             "colours": [
@@ -14129,7 +14129,7 @@
         },
         {
             "id": "67ed296e-d745-5ef3-9a57-f3c21c5c5112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da8e543-c9ef-4f2d-99e4-ef6ba496ae75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da8e543-c9ef-4f2d-99e4-ef6ba496ae75.jpg?1",
             "name": "Hobgoblin Bandit Lord",
             "text": "Other Goblins you control get +1/+1.\n{R}, {T}: Hobgoblin Bandit Lord deals damage equal to the number of Goblins that entered the battlefield under your control this turn to any target.",
             "colours": [
@@ -14166,7 +14166,7 @@
         },
         {
             "id": "0cd488e5-2edb-5c78-ba72-219db718e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a44f5-1f19-4218-95fc-8765b058778b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2a44f5-1f19-4218-95fc-8765b058778b.jpg?1",
             "name": "Meteor Swarm",
             "text": "Meteor Swarm deals 8 damage divided as you choose among X target creatures and/or planeswalkers.",
             "colours": [
@@ -14200,7 +14200,7 @@
         },
         {
             "id": "9ab1b833-7629-5f0c-a53c-d4d652a2ec08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a7c198-da05-434f-bbef-4b5e8f0597cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a7c198-da05-434f-bbef-4b5e8f0597cd.jpg?1",
             "name": "Orb of Dragonkind",
             "text": "{1}, {T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon spells or activate abilities of Dragons.\n{R}, {T}, Sacrifice Orb of Dragonkind: Look at the top seven cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14234,7 +14234,7 @@
         },
         {
             "id": "4209e887-b83d-593f-8a1c-381e4c8b8521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c2d90f-bd33-402d-b5fd-ee1ae62b59cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c2d90f-bd33-402d-b5fd-ee1ae62b59cf.jpg?1",
             "name": "Wish",
             "text": "You may play a card you own from outside the game this turn.",
             "colours": [
@@ -14268,7 +14268,7 @@
         },
         {
             "id": "1f0cf29d-0239-55a8-81ab-0065cc93752f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d206f867-c41b-4dad-be1e-c00851f56983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d206f867-c41b-4dad-be1e-c00851f56983.jpg?1",
             "name": "Circle of Dreams Druid",
             "text": "{T}: Add {G} for each creature you control.",
             "colours": [
@@ -14305,7 +14305,7 @@
         },
         {
             "id": "bf2a5a56-3a19-56ff-ade3-4321b1baa079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2064ba7-a03e-4beb-b251-9383154dbfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2064ba7-a03e-4beb-b251-9383154dbfaa.jpg?1",
             "name": "Froghemoth",
             "text": "Trample, haste\nWhenever Froghemoth deals combat damage to a player, exile up to that many target cards from their graveyard. Put a +1/+1 counter on Froghemoth for each creature card exiled this way. You gain 1 life for each noncreature card exiled this way.",
             "colours": [
@@ -14342,7 +14342,7 @@
         },
         {
             "id": "04caa0c9-48fc-5fe1-b449-fa8c7bf6e806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100fad49-3eac-4a9a-bf39-5b50c995126d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100fad49-3eac-4a9a-bf39-5b50c995126d.jpg?1",
             "name": "Instrument of the Bards",
             "text": "At the beginning of your upkeep, you may put a harmony counter on Instrument of the Bards.\n{3}{G}, {T}: Search your library for a creature card with mana value equal to the number of harmony counters on Instrument of the Bards, reveal it, and put it into your hand. If that card is legendary, create a Treasure token. Then shuffle.",
             "colours": [
@@ -14378,7 +14378,7 @@
         },
         {
             "id": "daf17990-e965-5ab1-8a6c-b59712596782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3876bba-75d3-46be-994a-878048573286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3876bba-75d3-46be-994a-878048573286.jpg?1",
             "name": "Long Rest",
             "text": "Return X target cards with different mana values from your graveyard to your hand. If eight or more cards were returned to your hand this way, your life total becomes equal to your starting life total. Exile Long Rest.",
             "colours": [
@@ -14412,7 +14412,7 @@
         },
         {
             "id": "7331c7fa-d876-51ea-9079-9475d112ad49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212a090-a9dc-4fd4-b138-34f3d8f1f563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212a090-a9dc-4fd4-b138-34f3d8f1f563.jpg?1",
             "name": "Werewolf Pack Leader",
             "text": "Pack tactics \u2014 Whenever Werewolf Pack Leader attacks, if you attacked with creatures with total power 6 or greater this combat, draw a card.\n{3}{G}: Until end of turn, Werewolf Pack Leader has base power and toughness 5/3, gains trample, and isn't a Human.",
             "colours": [
@@ -14449,7 +14449,7 @@
         },
         {
             "id": "2732175b-a9e0-5f1f-8be7-fca50d8826f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8e32bc-33b4-447c-a99d-295d10ef2aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8e32bc-33b4-447c-a99d-295d10ef2aeb.jpg?1",
             "name": "Orcus, Prince of Undeath",
             "text": "Flying, trample\nWhen Orcus, Prince of Undeath enters the battlefield, choose one \u2014\n\u2022 Each other creature gets -X/-X until end of turn. You lose X life.\n\u2022 Return up to X target creature cards with total mana value X or less from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -14489,7 +14489,7 @@
         },
         {
             "id": "d538ed37-32c2-5cef-9b40-21aa0857439d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a56df59-3e7b-40b5-a28c-10508bb7036f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a56df59-3e7b-40b5-a28c-10508bb7036f.jpg?1",
             "name": "Skeletal Swarming",
             "text": "Each Skeleton you control has trample, attacks each combat if able, and gets +X/+0, where X is the number of other Skeletons you control.\nAt the beginning of your end step, create a tapped 1/1 black Skeleton creature token. If a creature died this turn, create two of those tokens instead.",
             "colours": [
@@ -14525,7 +14525,7 @@
         },
         {
             "id": "bca813ca-03bb-5344-9ac7-71910f772a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38da306-c1d3-4fa4-aae5-0354fb3b2dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38da306-c1d3-4fa4-aae5-0354fb3b2dfd.jpg?1",
             "name": "Triumphant Adventurer",
             "text": "Deathtouch\nAs long as it's your turn, Triumphant Adventurer has first strike.\nWhenever Triumphant Adventurer attacks, venture into the dungeon.",
             "colours": [
@@ -14564,7 +14564,7 @@
         },
         {
             "id": "d2cac61f-9254-568f-9080-2283cadc3a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d4caf8-06cf-4320-a744-988a551d23e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d4caf8-06cf-4320-a744-988a551d23e5.jpg?1",
             "name": "Xanathar, Guild Kingpin",
             "text": "At the beginning of your upkeep, choose target opponent. Until end of turn, that player can't cast spells, you may look at the top card of their library any time, you may play the top card of their library, and you may spend mana as though it were mana of any color to cast spells this way.",
             "colours": [
@@ -14604,7 +14604,7 @@
         },
         {
             "id": "54ebf301-3886-5528-a724-d95cafb00004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484d4d-6000-4e7b-87cf-cabfe4e19b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48484d4d-6000-4e7b-87cf-cabfe4e19b0e.jpg?1",
             "name": "The Deck of Many Things",
             "text": "{2}, {T}: Roll a d20 and subtract the number of cards in your hand. If the result is 0 or less, discard your hand.\n1\u20139 | Return a card at random from your graveyard to your hand.\n10\u201319 | Draw two cards.\n20 | Put a creature card from any graveyard onto the battlefield under your control. When that creature dies, its owner loses the game.",
             "colours": [],
@@ -14636,7 +14636,7 @@
         },
         {
             "id": "660ab36d-c49e-5c90-a7b2-479a52b6e2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f305d0-f610-400d-a365-6d9afcfb6ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f305d0-f610-400d-a365-6d9afcfb6ab8.jpg?1",
             "name": "Eye of Vecna",
             "text": "When Eye of Vecna enters the battlefield, you draw a card and you lose 2 life.\nAt the beginning of your upkeep, you may pay {2}. If you do, you draw a card and you lose 2 life.",
             "colours": [],
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "ce758da1-a482-5e75-bd0e-0cb31ab18977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0502e4-508a-4d78-b987-0801e6b0978c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0502e4-508a-4d78-b987-0801e6b0978c.jpg?1",
             "name": "Hand of Vecna",
             "text": "At the beginning of combat on your turn, equipped creature or a creature you control named Vecna gets +X/+X until end of turn, where X is the number of cards in your hand.\nEquip\u2014\nPay 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -14702,7 +14702,7 @@
         },
         {
             "id": "f3329c77-496d-5fa7-be3f-d8dfd0187c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91174da-4cfb-4440-8f1e-8216ec21f725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91174da-4cfb-4440-8f1e-8216ec21f725.jpg?1",
             "name": "Treasure Chest",
             "text": "{4}, Sacrifice Treasure Chest: Roll a d20.\n1 | Trapped \u2014 You lose 3 life.\n2\u20139 | Create five Treasure tokens.\n10\u201319 | You gain 3 life and draw three cards.\n20 | Search your library for a card. If it's an artifact card, you may put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -14733,7 +14733,7 @@
         },
         {
             "id": "e1a64d19-7157-5967-a5c8-641926c05c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88527eb2-7264-4128-8bdf-df80b4053a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88527eb2-7264-4128-8bdf-df80b4053a48.jpg?1",
             "name": "Vorpal Sword",
             "text": "Equipped creature gets +2/+0 and has deathtouch.\n{5}{B}{B}{B}: Until end of turn, Vorpal Sword gains \"Whenever equipped creature deals combat damage to a player, that player loses the game.\"\nEquip {B}{B}",
             "colours": [
@@ -14769,7 +14769,7 @@
         },
         {
             "id": "aa88ec58-662d-5c34-b261-fc988ba8a133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ae20c0-b056-4c4f-a6d0-bbd72c37d0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ae20c0-b056-4c4f-a6d0-bbd72c37d0fc.jpg?1",
             "name": "Treasure Chest",
             "text": "{4}, Sacrifice Treasure Chest: Roll a d20.\n1 | Trapped \u2014 You lose 3 life.\n2\u20139 | Create five Treasure tokens.\n10\u201319 | You gain 3 life and draw three cards.\n20 | Search your library for a card. If it's an artifact card, you may put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -14799,7 +14799,7 @@
         },
         {
             "id": "7c1a4894-9704-5068-9c76-9831181ac184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8898d1fe-f4fe-4978-bcbc-f514ac2e73b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8898d1fe-f4fe-4978-bcbc-f514ac2e73b9.jpg?1",
             "name": "Portable Hole",
             "text": "",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "d85660ff-6f74-5dbe-8faa-2a7aab7d695c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1accce8c-7ca4-4cc5-bd8a-26b19622984b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1accce8c-7ca4-4cc5-bd8a-26b19622984b.jpg?1",
             "name": "You Find the Villains' Lair",
             "text": "",
             "colours": [
@@ -14867,7 +14867,7 @@
         },
         {
             "id": "ffd68558-8dcb-5e4b-be4d-612d35f1ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3febf51-6f40-478c-8b71-c529be420ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3febf51-6f40-478c-8b71-c529be420ff7.jpg?1",
             "name": "Power Word Kill",
             "text": "",
             "colours": [
@@ -14901,7 +14901,7 @@
         },
         {
             "id": "242d3e99-e775-5775-9a4c-b8096a02049f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13045ec-27e4-497a-bbc4-134cf46b7b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13045ec-27e4-497a-bbc4-134cf46b7b89.jpg?1",
             "name": "Magic Missile",
             "text": "",
             "colours": [
@@ -14935,7 +14935,7 @@
         },
         {
             "id": "0a80399a-7244-52e1-bac3-bcff3acc0857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea414698-5f87-461b-b1b2-b317b929280f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea414698-5f87-461b-b1b2-b317b929280f.jpg?1",
             "name": "Prosperous Innkeeper",
             "text": "",
             "colours": [
@@ -14972,7 +14972,7 @@
         },
         {
             "id": "d3d27491-b15c-5475-9f2e-73ad7064b00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323dd323-2ca2-4c85-9ef6-34341cd40d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323dd323-2ca2-4c85-9ef6-34341cd40d96.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -15007,7 +15007,7 @@
         },
         {
             "id": "2e465b1c-3018-571c-a2bc-3bdbf839b631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c981c9-3376-4f6e-b30d-859e5fc7347e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c981c9-3376-4f6e-b30d-859e5fc7347e.jpg?1",
             "name": "Icingdeath, Frost Tongue",
             "text": "",
             "colours": [
@@ -15044,7 +15044,7 @@
         },
         {
             "id": "25d3b098-e75c-5393-8f9b-d0e142c4c5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3c0bd9-8a37-4164-9937-f35d1c210fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3c0bd9-8a37-4164-9937-f35d1c210fe8.jpg?1",
             "name": "Dog Illusion",
             "text": "",
             "colours": [
@@ -15080,7 +15080,7 @@
         },
         {
             "id": "a6f382cb-a984-502b-a750-6ebfd49c0dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb6e0c-3630-46bf-b124-1ff2ddddf63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb6e0c-3630-46bf-b124-1ff2ddddf63e.jpg?1",
             "name": "Faerie Dragon",
             "text": "",
             "colours": [
@@ -15116,7 +15116,7 @@
         },
         {
             "id": "959ea7b6-fdde-57d0-b137-2a1fa11b39dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f8e40f-fb5e-4ab8-add3-a8b87e7bcdd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f8e40f-fb5e-4ab8-add3-a8b87e7bcdd9.jpg?1",
             "name": "The Atropal",
             "text": "",
             "colours": [
@@ -15154,7 +15154,7 @@
         },
         {
             "id": "81944633-42a8-59d8-a7ee-f3fe9a78670d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6fdb57-82f3-4695-b1fa-1f301ea4ef83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6fdb57-82f3-4695-b1fa-1f301ea4ef83.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -15189,7 +15189,7 @@
         },
         {
             "id": "32e9dfb0-c0f4-5aee-87d9-aab57cecb719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124e0b03-d9fb-44f1-9e3c-3462aabdd42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124e0b03-d9fb-44f1-9e3c-3462aabdd42e.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -15224,7 +15224,7 @@
         },
         {
             "id": "24276f6c-70a9-50f5-83bc-818575dda480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86881c5f-df5e-4f50-b554-e4c49d5316f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86881c5f-df5e-4f50-b554-e4c49d5316f9.jpg?1",
             "name": "Vecna",
             "text": "",
             "colours": [
@@ -15262,7 +15262,7 @@
         },
         {
             "id": "f3e2ed5c-6482-53b9-bbbb-a519f69103dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08d210-01cb-46c5-9150-4dfb47f50ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08d210-01cb-46c5-9150-4dfb47f50ae7.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -15297,7 +15297,7 @@
         },
         {
             "id": "37221bba-4459-5a1a-9b22-382c2f961d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e8e79-8673-41c2-a1ad-273c37e27aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e8e79-8673-41c2-a1ad-273c37e27aca.jpg?1",
             "name": "Boo",
             "text": "",
             "colours": [
@@ -15334,7 +15334,7 @@
         },
         {
             "id": "de807b5d-5a96-5bd8-ba32-ddcaf8ecac0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbc2ca1-4aad-4dfa-9eab-e783f5802078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbc2ca1-4aad-4dfa-9eab-e783f5802078.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -15369,7 +15369,7 @@
         },
         {
             "id": "cebf210a-3fd8-57f0-a1fa-f95900d45a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1425e965-7eea-419c-a7ec-c8169fa9edbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1425e965-7eea-419c-a7ec-c8169fa9edbf.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -15404,7 +15404,7 @@
         },
         {
             "id": "fda93a46-0633-58b7-a7e3-757852f6e47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c8f52-1580-42d5-8434-c4c70e31e31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c8f52-1580-42d5-8434-c4c70e31e31b.jpg?1",
             "name": "Guenhwyvar",
             "text": "",
             "colours": [
@@ -15441,7 +15441,7 @@
         },
         {
             "id": "dcef956d-cd2a-5cda-b6a4-90d79c7ee812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864d5b9-7151-42f0-8d37-8c319c3ab264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1864d5b9-7151-42f0-8d37-8c319c3ab264.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -15476,7 +15476,7 @@
         },
         {
             "id": "6a613aa7-be49-5cc5-abd3-4fab87bb0065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a684b7-27e0-4d9e-a064-9e03c6e50c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a684b7-27e0-4d9e-a064-9e03c6e50c89.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -15507,7 +15507,7 @@
         },
         {
             "id": "fc04e76b-ec4f-5e4f-bf47-c4e529329e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289bd243-8754-49f8-a4f9-0be477c84ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289bd243-8754-49f8-a4f9-0be477c84ee1.jpg?1",
             "name": "Ellywick Tumblestrum Emblem",
             "text": "",
             "colours": [],
@@ -15537,7 +15537,7 @@
         },
         {
             "id": "3073a46e-c831-5525-b99e-f4edb3c3b627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34001fd-0e9b-445b-9c0b-381721dfebc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34001fd-0e9b-445b-9c0b-381721dfebc2.jpg?1",
             "name": "Lolth, Spider Queen Emblem",
             "text": "",
             "colours": [],
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "5c91cc3b-7faa-5025-a819-4ef25d33d1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c63f14a-db47-46aa-addf-7c6fc40169b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c63f14a-db47-46aa-addf-7c6fc40169b9.jpg?1",
             "name": "Mordenkainen Emblem",
             "text": "",
             "colours": [],
@@ -15597,7 +15597,7 @@
         },
         {
             "id": "e4f80f25-1d66-5ceb-9e51-c6d1bfd6e2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36520c3-627a-40b9-a5c7-42cc4c813b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36520c3-627a-40b9-a5c7-42cc4c813b67.jpg?1",
             "name": "Zariel, Archduke of Avernus Emblem",
             "text": "",
             "colours": [],
@@ -15627,7 +15627,7 @@
         },
         {
             "id": "aa281821-2a70-5b23-8a0d-a5874c753e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f509dbe-6ec7-4438-ab36-e20be46c9922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f509dbe-6ec7-4438-ab36-e20be46c9922.jpg?1",
             "name": "Dungeon of the Mad Mage",
             "text": "",
             "colours": [],
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "deb0e4bd-0431-526c-8ad7-d10716d4d58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b11ff8-f118-4978-87dd-509dc0c8c932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b11ff8-f118-4978-87dd-509dc0c8c932.jpg?1",
             "name": "Lost Mine of Phandelver",
             "text": "",
             "colours": [],
@@ -15683,7 +15683,7 @@
         },
         {
             "id": "a7f3efba-4ee7-57b3-94c3-8bc4e91ae75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b284bd-7a8f-4b60-8238-f746bdc5b236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b284bd-7a8f-4b60-8238-f746bdc5b236.jpg?1",
             "name": "Tomb of Annihilation",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/AKH.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/AKH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c2a33099-bf35-558d-aace-6cf79cb5c60a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1cbf0-1273-406a-bc99-ce20ce53e5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b1cbf0-1273-406a-bc99-ce20ce53e5aa.jpg?1",
             "name": "Angel of Sanctions",
             "text": "Flying\nWhen Angel of Sanctions enters the battlefield, you may exile target nonland permanent an opponent controls until Angel of Sanctions leaves the battlefield.\nEmbalm {5}{W} ({5}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Angel with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "9b73cac8-070f-5fe6-82f9-0f0e22ff7ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52c265-6920-4929-ba0a-70da08df01f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52c265-6920-4929-ba0a-70da08df01f1.jpg?1",
             "name": "Anointed Procession",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "c6d9875e-b051-565a-b086-ecb59fb867ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f922231-bf41-47d3-8fa3-13b9baf4a0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f922231-bf41-47d3-8fa3-13b9baf4a0f3.jpg?1",
             "name": "Anointer Priest",
             "text": "Whenever a creature token enters the battlefield under your control, you gain 1 life.\nEmbalm {3}{W} ({3}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Cleric with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "82178cbf-23b5-504a-9354-52d8304efb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf59a6e-7708-45a1-884d-d12e9f7b9ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf59a6e-7708-45a1-884d-d12e9f7b9ed9.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "If Approach of the Second Sun was cast from your hand and you've cast another spell named Approach of the Second Sun this game, you win the game. Otherwise, put Approach of the Second Sun into its owner's library seventh from the top and you gain 7 life.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "c5b49b82-a868-5741-bc75-9210e38a8004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a50cc-fa16-42a4-b9f2-d8327e5d1bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a50cc-fa16-42a4-b9f2-d8327e5d1bb6.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "95fd40bf-5f44-5877-90fb-e76e5eb67842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae54072-ae27-4aae-a2b7-71f4551934f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae54072-ae27-4aae-a2b7-71f4551934f6.jpg?1",
             "name": "Binding Mummy",
             "text": "Whenever another Zombie enters the battlefield under your control, you may tap target artifact or creature.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "332a0db5-a42f-5fdb-8567-20725f1449de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eaf94e-85a7-4958-aa58-8e2fe44db58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eaf94e-85a7-4958-aa58-8e2fe44db58d.jpg?1",
             "name": "Cartouche of Solidarity",
             "text": "Enchant creature you control\nWhen Cartouche of Solidarity enters the battlefield, create a 1/1 white Warrior creature token with vigilance.\nEnchanted creature gets +1/+1 and has first strike.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "3cb49aaa-3869-583f-a354-b41065798dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ff0dd0-489e-4773-93f6-b77fc3b8ef2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ff0dd0-489e-4773-93f6-b77fc3b8ef2e.jpg?1",
             "name": "Cast Out",
             "text": "Flash\nWhen Cast Out enters the battlefield, exile target nonland permanent an opponent controls until Cast Out leaves the battlefield.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "fb3fccf7-76be-5f2c-a4cb-0479c1071bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cb3a5b-beee-4f53-a6b5-e9b5603546fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cb3a5b-beee-4f53-a6b5-e9b5603546fa.jpg?1",
             "name": "Compulsory Rest",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"{2}, Sacrifice this creature: You gain 2 life.\"",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "76963fc6-e573-51ef-9ca7-9e9c130c74d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3677f10-b530-4606-b7c8-a72dd2131160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3677f10-b530-4606-b7c8-a72dd2131160.jpg?1",
             "name": "Devoted Crop-Mate",
             "text": "You may exert Devoted Crop-Mate as it attacks. When you do, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "96ba344c-00bd-5832-aa69-2156a464bdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad60ebb9-4acc-41a8-90d9-04d55e414ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad60ebb9-4acc-41a8-90d9-04d55e414ed1.jpg?1",
             "name": "Djeru's Resolve",
             "text": "Untap target creature. Prevent all damage that would be dealt to it this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "71eb6d19-3d57-5181-8fc3-972e431dbb40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cec477-f86f-4ccf-aa57-b6b7ade46eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cec477-f86f-4ccf-aa57-b6b7ade46eed.jpg?1",
             "name": "Fan Bearer",
             "text": "{2}, {T}: Tap target creature.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "99e89213-dd32-5166-a6bf-70571fbf41b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca4e95e-f14e-4cfa-918a-cfb15f912293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca4e95e-f14e-4cfa-918a-cfb15f912293.jpg?1",
             "name": "Forsake the Worldly",
             "text": "Exile target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -440,7 +440,7 @@
         },
         {
             "id": "e3c7bcc3-5545-541e-b3ef-f32f15053735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ce13f-519f-4472-bbd1-f26a972723d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ce13f-519f-4472-bbd1-f26a972723d7.jpg?1",
             "name": "Gideon of the Trials",
             "text": "+1: Until your next turn, prevent all damage target permanent would deal.\n0: Until end of turn, Gideon of the Trials becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n0: You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\"",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "36322139-3574-5789-9e7e-23c42ea92e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2524fb-ec90-4f8e-b851-f78034edef3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2524fb-ec90-4f8e-b851-f78034edef3f.jpg?1",
             "name": "Gideon's Intervention",
             "text": "As Gideon's Intervention enters the battlefield, choose a card name.\nYour opponents can't cast spells with the chosen name.\nPrevent all damage that would be dealt to you and permanents you control by sources with the chosen name.",
             "colours": [
@@ -508,7 +508,7 @@
         },
         {
             "id": "ccbf43c8-f296-5989-b81f-d7637dc72c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e23a06-4ed3-4948-aca5-fbdda03f4f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e23a06-4ed3-4948-aca5-fbdda03f4f2a.jpg?1",
             "name": "Glory-Bound Initiate",
             "text": "You may exert Glory-Bound Initiate as it attacks. When you do, it gets +1/+3 and gains lifelink until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "c5c0d76d-90a0-5b21-b73a-10de83a321c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49307ab6-392e-4b61-ad60-e6ea53da39f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49307ab6-392e-4b61-ad60-e6ea53da39f7.jpg?1",
             "name": "Gust Walker",
             "text": "You may exert Gust Walker as it attacks. When you do, it gets +1/+1 and gains flying until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "fe7b4a74-be76-5f96-91f2-ffa4dbc354d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98cee1e-64d8-4662-a911-009b031dc888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98cee1e-64d8-4662-a911-009b031dc888.jpg?1",
             "name": "Impeccable Timing",
             "text": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "fe848efd-88ca-52bf-8b09-046972865b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf535ef-79ee-4a31-a614-f6c77fea72b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf535ef-79ee-4a31-a614-f6c77fea72b5.jpg?1",
             "name": "In Oketra's Name",
             "text": "Zombies you control get +2/+1 until end of turn. Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "6d5c6b78-4376-575c-b2d9-b86cc3f016f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13692658-051b-44ea-bc23-aa33ce6385d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13692658-051b-44ea-bc23-aa33ce6385d3.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -674,7 +674,7 @@
         },
         {
             "id": "aae892ba-cd35-549d-bc99-9e21ec77d422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cc79cf-d4db-4236-b3e2-fd12662b2a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cc79cf-d4db-4236-b3e2-fd12662b2a74.jpg?1",
             "name": "Oketra the True",
             "text": "Double strike, indestructible\nOketra the True can't attack or block unless you control at least three other creatures.\n{3}{W}: Create a 1/1 white Warrior creature token with vigilance.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "a902baac-4c88-597c-bfcb-51606aae6b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6074fe64-8a2d-411e-8d33-97b1c60633e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6074fe64-8a2d-411e-8d33-97b1c60633e4.jpg?1",
             "name": "Oketra's Attendant",
             "text": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)\nEmbalm {3}{W}{W} ({3}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Soldier with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "e5dd9049-3459-5957-a2a3-e206662ffd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d01e04-7c40-4af0-b5bd-5fa267d10378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d01e04-7c40-4af0-b5bd-5fa267d10378.jpg?1",
             "name": "Protection of the Hekma",
             "text": "If a source an opponent controls would deal damage to you, prevent 1 of that damage.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "ad861664-559c-5293-a04b-e78ec2f6260f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd349f95-3eae-4ef2-abf8-e911bb8e93e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd349f95-3eae-4ef2-abf8-e911bb8e93e5.jpg?1",
             "name": "Regal Caracal",
             "text": "Other Cats you control get +1/+1 and have lifelink.\nWhen Regal Caracal enters the battlefield, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "4e88a28d-3da0-55d9-85bd-a9963f80265f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08abfd48-abd5-4b91-bcac-745b76aeb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08abfd48-abd5-4b91-bcac-745b76aeb775.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "96b26caf-3f6b-5b39-aefd-440f2b4c210c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcfc2d3-8719-4ba1-b4c5-b2f8f6bab634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcfc2d3-8719-4ba1-b4c5-b2f8f6bab634.jpg?1",
             "name": "Rhet-Crop Spearmaster",
             "text": "You may exert Rhet-Crop Spearmaster as it attacks. When you do, it gets +1/+0 and gains first strike until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "f377cbcf-5dbc-5b11-82f8-40f6ad3b52e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08891c78-13c1-4d84-aa9c-78346b3b7d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08891c78-13c1-4d84-aa9c-78346b3b7d18.jpg?1",
             "name": "Sacred Cat",
             "text": "Lifelink\nEmbalm {W} ({W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Cat with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "a11eed8e-90f4-5b1e-bdf1-94260eaa9772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dc4ed8-4674-44a1-8a06-ecce72c85e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dc4ed8-4674-44a1-8a06-ecce72c85e60.jpg?1",
             "name": "Seraph of the Suns",
             "text": "Flying\nIndestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "030a7cfc-af3f-5f1b-b5e6-c093e85ab35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec1587-0405-4b4d-96b5-1ac2c5a7c9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec1587-0405-4b4d-96b5-1ac2c5a7c9dc.jpg?1",
             "name": "Sparring Mummy",
             "text": "When Sparring Mummy enters the battlefield, untap target creature.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "5a25b6d6-a640-5aa4-ba99-183736aad45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d247bd88-9593-462c-8f9e-28e29c064c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d247bd88-9593-462c-8f9e-28e29c064c10.jpg?1",
             "name": "Supply Caravan",
             "text": "When Supply Caravan enters the battlefield, if you control a tapped creature, create a 1/1 white Warrior creature token with vigilance.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "f349dfe0-3d94-5acc-bca7-9d1a7a36cc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8dda75-a196-47bc-98d8-522eb35e7d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8dda75-a196-47bc-98d8-522eb35e7d1a.jpg?1",
             "name": "Tah-Crop Elite",
             "text": "Flying\nYou may exert Tah-Crop Elite as it attacks. When you do, creatures you control get +1/+1 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "dec041c3-42ab-5f10-9847-a74642b6cdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f27dd9-7ee4-4cdc-8f65-a4349b6aa47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f27dd9-7ee4-4cdc-8f65-a4349b6aa47f.jpg?1",
             "name": "Those Who Serve",
             "text": "",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "da164767-d036-5634-a102-dfdf001611a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60ec4f7-7cf1-4b97-906b-536ab89b12be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60ec4f7-7cf1-4b97-906b-536ab89b12be.jpg?1",
             "name": "Time to Reflect",
             "text": "Exile target creature that blocked or was blocked by a Zombie this turn.",
             "colours": [
@@ -1115,7 +1115,7 @@
         },
         {
             "id": "5440b2f4-9dc7-5538-bbe7-2dbc149f4c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2604d43-a105-440b-86b1-60d1d0c04339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2604d43-a105-440b-86b1-60d1d0c04339.jpg?1",
             "name": "Trial of Solidarity",
             "text": "When Trial of Solidarity enters the battlefield, creatures you control get +2/+1 and gain vigilance until end of turn.\nWhen a Cartouche enters the battlefield under your control, return Trial of Solidarity to its owner's hand.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "e9ff496f-3677-5548-9471-ef7b9f562e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628f5230-6c0d-4f24-b89a-7f3d443511f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628f5230-6c0d-4f24-b89a-7f3d443511f3.jpg?1",
             "name": "Trueheart Duelist",
             "text": "Trueheart Duelist can block an additional creature each combat.\nEmbalm {2}{W} ({2}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "96db7e3b-d6e2-5016-922d-a169cb56bcc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73fe35-68d6-4882-aeab-5c1e7b97b938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73fe35-68d6-4882-aeab-5c1e7b97b938.jpg?1",
             "name": "Unwavering Initiate",
             "text": "Vigilance\nEmbalm {4}{W} ({4}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "9233e310-1c11-5d02-8125-e6d89e8bcbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684f2e5-e3f9-4277-94a1-aba6913ac53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684f2e5-e3f9-4277-94a1-aba6913ac53b.jpg?1",
             "name": "Vizier of Deferment",
             "text": "Flash\nWhen Vizier of Deferment enters the battlefield, you may exile target creature if it attacked or blocked this turn. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "77a316ec-bd8a-5c4a-bbf6-20042f1ea6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ab760e-93e0-4dbc-aaa1-02316f62ed3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ab760e-93e0-4dbc-aaa1-02316f62ed3f.jpg?1",
             "name": "Vizier of Remedies",
             "text": "If one or more -1/-1 counters would be put on a creature you control, that many -1/-1 counters minus one are put on it instead.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "1dadec4d-18b0-5483-bf20-68c419ab9600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04301470-82d9-43c7-aaf1-a41e185cb109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04301470-82d9-43c7-aaf1-a41e185cb109.jpg?1",
             "name": "Winged Shepherd",
             "text": "Flying, vigilance\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "da3bf502-5014-5f7d-9000-eea73db91fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2ca68b-15fb-4691-b549-268df92ca413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2ca68b-15fb-4691-b549-268df92ca413.jpg?1",
             "name": "Ancient Crab",
             "text": "",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "59720bf9-6333-56a2-bb6f-23b6dd87ed3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14c753e-c5bf-4c34-b408-ac367b6ca6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14c753e-c5bf-4c34-b408-ac367b6ca6ab.jpg?1",
             "name": "Angler Drake",
             "text": "Flying\nWhen Angler Drake enters the battlefield, you may return target creature to its owner's hand.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "7795998a-9626-50ef-b52c-62a1d9c292d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f91d225-788e-42fc-9d01-8668f672b717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f91d225-788e-42fc-9d01-8668f672b717.jpg?1",
             "name": "As Foretold",
             "text": "At the beginning of your upkeep, put a time counter on As Foretold.\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast with converted mana cost X or less, where X is the number of time counters on As Foretold.",
             "colours": [
@@ -1421,7 +1421,7 @@
         },
         {
             "id": "82061a2f-26c0-5df1-a0a1-c8e3066db42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61203781-24ad-4bc9-9b69-97149f3043bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61203781-24ad-4bc9-9b69-97149f3043bc.jpg?1",
             "name": "Aven Initiate",
             "text": "Flying\nEmbalm {6}{U} ({6}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "6517ce7c-7b98-53b9-bd4c-41ce66d55bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7258e651-868a-4f63-9454-6c6c95d25387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7258e651-868a-4f63-9454-6c6c95d25387.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "baa6116a-3d95-5dc3-af8d-a82ab0eaf680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d806458e-81cd-4413-bba0-14d957bece79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d806458e-81cd-4413-bba0-14d957bece79.jpg?1",
             "name": "Cartouche of Knowledge",
             "text": "Enchant creature you control\nWhen Cartouche of Knowledge enters the battlefield, draw a card.\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "164da53b-655a-51b5-a19a-6b385e945ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb4e315-1a77-479a-9f15-fb23575de805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb4e315-1a77-479a-9f15-fb23575de805.jpg?1",
             "name": "Censor",
             "text": "Counter target spell unless its controller pays {1}.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1555,7 +1555,7 @@
         },
         {
             "id": "005aef37-8ff5-5483-857f-950295e056d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c35f4d5-2337-4ea0-a571-5a73e2d0d54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c35f4d5-2337-4ea0-a571-5a73e2d0d54a.jpg?1",
             "name": "Compelling Argument",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "7db99049-f10d-55ae-b39c-a43e6da89c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d11a24-8abf-46ff-8cc6-57b8ac3013f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d11a24-8abf-46ff-8cc6-57b8ac3013f6.jpg?1",
             "name": "Cryptic Serpent",
             "text": "Cryptic Serpent costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "9d0933d1-d7c8-5f69-8bfc-7531f2864db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16caa0b6-dba9-4f93-bf8d-3b339474cbf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16caa0b6-dba9-4f93-bf8d-3b339474cbf1.jpg?1",
             "name": "Curator of Mysteries",
             "text": "Flying\nWhenever you cycle or discard another card, scry 1.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "5bfe6f32-d1e0-5784-9b84-01873737273b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eb8d39-9eb8-4592-ab74-54cdc2460e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eb8d39-9eb8-4592-ab74-54cdc2460e62.jpg?1",
             "name": "Decision Paralysis",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "46cbf022-2f42-5fa6-8b7d-ac45a7eb901a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4318da9d-dadf-444b-a0d4-fd270b216f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4318da9d-dadf-444b-a0d4-fd270b216f5b.jpg?1",
             "name": "Drake Haven",
             "text": "Whenever you cycle or discard a card, you may pay {1}. If you do, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "0d03b2a6-3b2f-5e59-bcd0-66c6027bcc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e325e1-f1f9-4448-84e3-1fd929b0bc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e325e1-f1f9-4448-84e3-1fd929b0bc12.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "6c0f7682-30c2-5a32-a7d6-048ecc6bdba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a211df0-fe9e-4d2c-9e0e-c7be50e6b906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a211df0-fe9e-4d2c-9e0e-c7be50e6b906.jpg?1",
             "name": "Floodwaters",
             "text": "Return up to two target creatures to their owners' hands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "bff10aaf-ec1e-5b31-9725-ebd917af6987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe6633a-dee9-4840-9a18-ab4a511eb4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe6633a-dee9-4840-9a18-ab4a511eb4c4.jpg?1",
             "name": "Galestrike",
             "text": "Return target tapped creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "ac5c4243-1389-5783-9481-c9db6213ffa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2663738-1688-4306-be6d-6a1f94a2319c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2663738-1688-4306-be6d-6a1f94a2319c.jpg?1",
             "name": "Glyph Keeper",
             "text": "Flying\nWhenever Glyph Keeper becomes the target of a spell or ability for the first time each turn, counter that spell or ability.\nEmbalm {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Sphinx with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -1849,7 +1849,7 @@
         },
         {
             "id": "eae49f2f-7d5a-570c-b461-e71224683997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7e690-e5f7-4d6e-b756-22aea959a612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7e690-e5f7-4d6e-b756-22aea959a612.jpg?1",
             "name": "Hekma Sentinels",
             "text": "Whenever you cycle or discard a card, Hekma Sentinels gets +1/+1 until end of turn.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "ed6348df-986b-5509-a286-5637ea73422c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a0e75-53bb-43e4-890f-0e1972a7e0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a0e75-53bb-43e4-890f-0e1972a7e0b9.jpg?1",
             "name": "Hieroglyphic Illumination",
             "text": "Draw two cards.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1916,7 +1916,7 @@
         },
         {
             "id": "88ee1d6d-07c3-53d5-9d59-410bb5ac2af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67aefde-2c91-4974-b89d-84333a2874eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67aefde-2c91-4974-b89d-84333a2874eb.jpg?1",
             "name": "Illusory Wrappings",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/2.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "c937b801-ba50-5506-bd7c-73a16aba7644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbda3b24-f2a6-4bcf-9a0a-bab69ffa8069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbda3b24-f2a6-4bcf-9a0a-bab69ffa8069.jpg?1",
             "name": "Kefnet the Mindful",
             "text": "Flying, indestructible\nKefnet the Mindful can't attack or block unless you have seven or more cards in hand.\n{3}{U}: Draw a card, then you may return a land you control to its owner's hand.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "995e3a1d-9bc4-5e8b-b328-59b8a74c93c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17921573-e3d1-45a7-b7e5-a27ae1fa3c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17921573-e3d1-45a7-b7e5-a27ae1fa3c2c.jpg?1",
             "name": "Labyrinth Guardian",
             "text": "When Labyrinth Guardian becomes the target of a spell, sacrifice it.\nEmbalm {3}{U} ({3}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Illusion Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "642d2955-88df-578b-888b-9d0d161a23fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0e741f-0448-4a95-9178-074356e50426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0e741f-0448-4a95-9178-074356e50426.jpg?1",
             "name": "Lay Claim",
             "text": "Enchant permanent\nYou control enchanted permanent.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "323f6f74-f5aa-5c9f-8f09-1121d495a701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9060b7b5-3ef1-443e-8f8a-450cc42c43a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9060b7b5-3ef1-443e-8f8a-450cc42c43a6.jpg?1",
             "name": "Naga Oracle",
             "text": "When Naga Oracle enters the battlefield, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "ab71fffa-100e-57cd-8fdc-fdd0611f01f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b5290-997d-44de-ac83-4bc9a9911858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b5290-997d-44de-ac83-4bc9a9911858.jpg?1",
             "name": "New Perspectives",
             "text": "When New Perspectives enters the battlefield, draw three cards.\nAs long as you have seven or more cards in hand, you may pay {0} rather than pay cycling costs.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "502323b5-12d5-5312-843e-8d42fe639cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df4db1e-f2a7-44e7-9b8d-fecf73d1e01c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df4db1e-f2a7-44e7-9b8d-fecf73d1e01c.jpg?1",
             "name": "Open into Wonder",
             "text": "X target creatures can't be blocked this turn. Until end of turn, those creatures gain \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "996d1bc9-e4e7-581b-b1b2-17335e263f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1eccf27-c934-45fb-87ae-67006cd4e0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1eccf27-c934-45fb-87ae-67006cd4e0ed.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "72b1d05a-f36f-5c64-92d8-9d16413e496d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89500ba-8256-4002-a9f2-62d529e9886b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89500ba-8256-4002-a9f2-62d529e9886b.jpg?1",
             "name": "River Serpent",
             "text": "River Serpent can't attack unless there are five or more cards in your graveyard.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "776621e6-810e-5c69-8414-c8d4998b878f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc2ab27-0f68-480c-99c9-53243c1ab0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc2ab27-0f68-480c-99c9-53243c1ab0ac.jpg?1",
             "name": "Sacred Excavation",
             "text": "Return up to two target cards with cycling from your graveyard to your hand.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "bb1562d6-544c-5034-b963-2c6f2793c6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ffaefe-1b9e-418d-9760-b7d546f03542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ffaefe-1b9e-418d-9760-b7d546f03542.jpg?1",
             "name": "Scribe of the Mindful",
             "text": "{1}, {T}, Sacrifice Scribe of the Mindful: Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "aa86b45a-b297-5fc4-9e97-c4dec9eeb652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0b7bfc-f126-4885-a663-6f8dcc52e663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0b7bfc-f126-4885-a663-6f8dcc52e663.jpg?1",
             "name": "Seeker of Insight",
             "text": "{T}: Draw a card, then discard a card. Activate this ability only if you've cast a noncreature spell this turn.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "93b78fbe-8961-5ea6-a4dd-360e2b3d64ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb13075-0ea0-480a-84c0-8eec3119db45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb13075-0ea0-480a-84c0-8eec3119db45.jpg?1",
             "name": "Shimmerscale Drake",
             "text": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "fdc3e63f-c755-5a0a-85dc-4a013b2e8f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf067e-4d76-4676-85fa-ebfb0755440a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf067e-4d76-4676-85fa-ebfb0755440a.jpg?1",
             "name": "Slither Blade",
             "text": "Slither Blade can't be blocked.",
             "colours": [
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "52f64f13-6a66-5631-a80b-b5de2f26340c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0429ec-0809-4e68-9790-8c21bde201a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0429ec-0809-4e68-9790-8c21bde201a2.jpg?1",
             "name": "Tah-Crop Skirmisher",
             "text": "Embalm {3}{U} ({3}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Naga Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "2c38b0a0-178a-5a87-a4f5-5716697ad272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89020c72-4cda-4634-8475-6d16a02236f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89020c72-4cda-4634-8475-6d16a02236f1.jpg?1",
             "name": "Trial of Knowledge",
             "text": "When Trial of Knowledge enters the battlefield, draw three cards, then discard a card.\nWhen a Cartouche enters the battlefield under your control, return Trial of Knowledge to its owner's hand.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "079aa73f-980c-553e-8644-c6e4b98162c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2781c44-aa90-4a37-a812-33c643ba4deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2781c44-aa90-4a37-a812-33c643ba4deb.jpg?1",
             "name": "Vizier of Many Faces",
             "text": "You may have Vizier of Many Faces enter the battlefield as a copy of any creature on the battlefield, except if Vizier of Many Faces was embalmed, the token has no mana cost, it's white, and it's a Zombie in addition to its other types.\nEmbalm {3}{U}{U}",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "fbc11c7a-07be-5326-99be-9608900baf30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ff0f5-abee-4f3e-89ae-1b7ee771ec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ff0f5-abee-4f3e-89ae-1b7ee771ec68.jpg?1",
             "name": "Vizier of Tumbling Sands",
             "text": "{T}: Untap another target permanent.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Vizier of Tumbling Sands, untap target permanent.",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "30d5ad6b-6404-5c1a-aebe-358ee34c4145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2718457-1e3b-48bc-99fe-2300277ee1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2718457-1e3b-48bc-99fe-2300277ee1e0.jpg?1",
             "name": "Winds of Rebuke",
             "text": "Return target nonland permanent to its owner's hand. Each player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "cba6ac44-b847-5df4-8cdb-584fcbfa3f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b711b5-aeec-47c4-a718-6bf43e561944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b711b5-aeec-47c4-a718-6bf43e561944.jpg?1",
             "name": "Zenith Seeker",
             "text": "Flying\nWhenever you cycle or discard a card, target creature gains flying until end of turn.",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "8f3c761b-f380-5a21-86dd-6bb878d30018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33176679-d571-47a1-ae05-bed9b748491d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33176679-d571-47a1-ae05-bed9b748491d.jpg?1",
             "name": "Archfiend of Ifnir",
             "text": "Flying\nWhenever you cycle or discard another card, put a -1/-1 counter on each creature your opponents control.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "3f39981b-6475-546c-9047-8f52ede1d8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb662d58-ae50-423d-b1c5-abd45baca12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb662d58-ae50-423d-b1c5-abd45baca12b.jpg?1",
             "name": "Baleful Ammit",
             "text": "Lifelink\nWhen Baleful Ammit enters the battlefield, put a -1/-1 counter on target creature you control.",
             "colours": [
@@ -2664,7 +2664,7 @@
         },
         {
             "id": "92ce39fc-734f-5f08-b6d0-8069dceca0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da308e9-1862-46c1-a62a-90720b484d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da308e9-1862-46c1-a62a-90720b484d91.jpg?1",
             "name": "Blighted Bat",
             "text": "Flying\n{1}: Blighted Bat gains haste until end of turn.",
             "colours": [
@@ -2699,7 +2699,7 @@
         },
         {
             "id": "dad332dd-d57a-57f6-80aa-abfe5b98b5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6a825-43f7-40a4-95f0-335dc538b6cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6a825-43f7-40a4-95f0-335dc538b6cd.jpg?1",
             "name": "Bone Picker",
             "text": "Bone Picker costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "952ca62d-4d6f-5270-ad1a-b35cf48abd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07386-909f-4946-9120-3acb58622e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07386-909f-4946-9120-3acb58622e2f.jpg?1",
             "name": "Bontu the Glorified",
             "text": "Menace, indestructible\nBontu the Glorified can't attack or block unless a creature died under your control this turn.\n{1}{B}, Sacrifice another creature: Scry 1. Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "503ac325-e50a-5cfb-a113-1265db00e8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b96b1-b75e-4ee1-a6d7-6545a34fef9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b96b1-b75e-4ee1-a6d7-6545a34fef9b.jpg?1",
             "name": "Cartouche of Ambition",
             "text": "Enchant creature you control\nWhen Cartouche of Ambition enters the battlefield, you may put a -1/-1 counter on target creature.\nEnchanted creature gets +1/+1 and has lifelink.",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "692d8686-73df-51fe-8258-8d8642bd007d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a91cf5-4eab-4d9b-90bd-fb933bb00540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a91cf5-4eab-4d9b-90bd-fb933bb00540.jpg?1",
             "name": "Cruel Reality",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player sacrifices a creature or planeswalker. If the player can't, he or she loses 5 life.",
             "colours": [
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "b22d3025-1aa5-57ce-8d61-216a35d8927c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3990d2f-39d9-49f9-936f-1d40adcf295c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3990d2f-39d9-49f9-936f-1d40adcf295c.jpg?1",
             "name": "Cursed Minotaur",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2874,7 +2874,7 @@
         },
         {
             "id": "4ed5df52-a63e-573c-9002-873710159ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb88be3-f790-45d7-a6d1-c78f6ba00208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb88be3-f790-45d7-a6d1-c78f6ba00208.jpg?1",
             "name": "Dispossess",
             "text": "Choose an artifact card name. Search target opponent's graveyard, hand, and library for any number of cards with the chosen name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "2d932232-5d1f-5fb5-aff0-ed3eccfe6b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "747d5ce9-b2f3-5c64-8f84-41b85ca75982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343fc82d-7d10-4489-8f7e-9995322114e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343fc82d-7d10-4489-8f7e-9995322114e2.jpg?1",
             "name": "Dread Wanderer",
             "text": "Dread Wanderer enters the battlefield tapped.\n{2}{B}: Return Dread Wanderer from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery and only if you have one or fewer cards in hand.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "62f9d4d5-7005-5a29-a87c-26419acd2ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cb904-c725-4d57-bc17-7aa87a7cd8e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cb904-c725-4d57-bc17-7aa87a7cd8e0.jpg?1",
             "name": "Dune Beetle",
             "text": "",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "79606c89-ebf4-53a8-9761-3f3433b063d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26e0e0-d157-4d63-bebe-b02d208c5572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26e0e0-d157-4d63-bebe-b02d208c5572.jpg?1",
             "name": "Faith of the Devoted",
             "text": "Whenever you cycle or discard a card, you may pay {1}. If you do, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "8d486592-aea9-5693-a2c9-f966a6eb5167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906c4c95-5815-44c8-8d3c-b0fda9db55a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906c4c95-5815-44c8-8d3c-b0fda9db55a1.jpg?1",
             "name": "Festering Mummy",
             "text": "When Festering Mummy dies, you may put a -1/-1 counter on target creature.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "1c3e9ad8-27ff-5b24-9b45-6b0cfef1dcdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f202f6b-710f-4376-a49c-e5f135b26eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f202f6b-710f-4376-a49c-e5f135b26eaf.jpg?1",
             "name": "Final Reward",
             "text": "Exile target creature.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "3a72e135-4ed8-564d-ae62-e46becdd15da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606f1ce-afeb-4fc5-bd4c-2484cd232924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606f1ce-afeb-4fc5-bd4c-2484cd232924.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "f63f4a78-3882-5817-92e5-698ebf09c9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ae6769-2b2b-48e3-9503-e9744984743a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ae6769-2b2b-48e3-9503-e9744984743a.jpg?1",
             "name": "Grim Strider",
             "text": "Grim Strider gets -1/-1 for each card in your hand.",
             "colours": [
@@ -3175,7 +3175,7 @@
         },
         {
             "id": "1f6c8446-6c59-516a-9474-a4c9de2aeb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35828576-124a-45d6-ad4c-af2926314953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35828576-124a-45d6-ad4c-af2926314953.jpg?1",
             "name": "Horror of the Broken Lands",
             "text": "Whenever you cycle or discard another card, Horror of the Broken Lands gets +2/+1 until end of turn.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "26df36e6-21ac-588c-9c61-3ee13f463a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b76ff8-b26c-4567-9339-bb6a37713f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b76ff8-b26c-4567-9339-bb6a37713f4b.jpg?1",
             "name": "Lay Bare the Heart",
             "text": "Target opponent reveals his or her hand. You choose a nonlegendary, nonland card from it. That player discards that card.",
             "colours": [
@@ -3241,7 +3241,7 @@
         },
         {
             "id": "e9b3f7f3-acaa-54b2-a8b5-599991e1e57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d8f490-f04d-4d59-9ab0-a977527fd529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d8f490-f04d-4d59-9ab0-a977527fd529.jpg?1",
             "name": "Liliana, Death's Majesty",
             "text": "+1: Create a 2/2 black Zombie creature token. Put the top two cards of your library into your graveyard.\n\u22123: Return target creature card from your graveyard to the battlefield. That creature is a black Zombie in addition to its other colors and types.\n\u22127: Destroy all non-Zombie creatures.",
             "colours": [
@@ -3277,7 +3277,7 @@
         },
         {
             "id": "2cb71270-7f90-5164-a813-b716015c1caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c57b3b8-71f1-479c-b7f7-508fee2b5b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c57b3b8-71f1-479c-b7f7-508fee2b5b0f.jpg?1",
             "name": "Liliana's Mastery",
             "text": "Zombies you control get +1/+1.\nWhen Liliana's Mastery enters the battlefield, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "200526e9-8753-56d2-8d72-4841c768f8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941562d-3e39-4746-9a18-d3aa6d3468b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941562d-3e39-4746-9a18-d3aa6d3468b0.jpg?1",
             "name": "Lord of the Accursed",
             "text": "Other Zombies you control get +1/+1.\n{1}{B}, {T}: All Zombies gain menace until end of turn.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "42c85bf2-7d42-5f63-8b5d-919dc9330a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ef9e66-678c-4e8d-9ca7-3f2b72b9468c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ef9e66-678c-4e8d-9ca7-3f2b72b9468c.jpg?1",
             "name": "Miasmic Mummy",
             "text": "When Miasmic Mummy enters the battlefield, each player discards a card.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "06c9712f-5dc5-5662-98a2-8034a69eef85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa6b45-055a-411e-b2db-b373a4d3826d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa6b45-055a-411e-b2db-b373a4d3826d.jpg?1",
             "name": "Nest of Scarabs",
             "text": "Whenever you put one or more -1/-1 counters on a creature, create that many 1/1 black Insect creature tokens.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "1f4cd12f-9623-5f52-99c8-b0e6d87abe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becbd481-311d-4f85-aacd-df1f7d7ef587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becbd481-311d-4f85-aacd-df1f7d7ef587.jpg?1",
             "name": "Painful Lesson",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "5f843823-994b-5df3-93a0-7bb472d079aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eb0615-d1b2-4128-bad5-bcff83672f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eb0615-d1b2-4128-bad5-bcff83672f6b.jpg?1",
             "name": "Pitiless Vizier",
             "text": "Whenever you cycle or discard a card, Pitiless Vizier gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "0dfbe265-9114-5b35-a06e-632a81cb5c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280ae211-f025-4971-83e6-118ca08a1911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280ae211-f025-4971-83e6-118ca08a1911.jpg?1",
             "name": "Plague Belcher",
             "text": "Menace\nWhen Plague Belcher enters the battlefield, put two -1/-1 counters on target creature you control.\nWhenever another Zombie you control dies, each opponent loses 1 life.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "ba7fd652-bb94-50a2-9999-132b5e32c948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d916306a-5cb3-4a38-9038-a433525c5b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d916306a-5cb3-4a38-9038-a433525c5b7b.jpg?1",
             "name": "Ruthless Sniper",
             "text": "Whenever you cycle or discard a card, you may pay {1}. If you do, put a -1/-1 counter on target creature.",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "0005f481-f2d4-53fa-ba37-cfcf5a5f87f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7540895c-cbbc-46ac-ba96-882628358865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7540895c-cbbc-46ac-ba96-882628358865.jpg?1",
             "name": "Scarab Feast",
             "text": "Exile up to three target cards from a single graveyard.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "0e155b44-c358-5233-afdd-4b5a5c001baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0205cb-c163-4332-9624-394e1024bf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0205cb-c163-4332-9624-394e1024bf6a.jpg?1",
             "name": "Shadow of the Grave",
             "text": "Return to your hand all cards in your graveyard that you cycled or discarded this turn.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "bedeb789-ef10-55d4-8b25-613426676893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0504be31-eaab-4b3e-8cfb-274e46d3d67a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0504be31-eaab-4b3e-8cfb-274e46d3d67a.jpg?1",
             "name": "Soulstinger",
             "text": "When Soulstinger enters the battlefield, put two -1/-1 counters on target creature you control.\nWhen Soulstinger dies, you may put a -1/-1 counter on target creature for each -1/-1 counter on Soulstinger.",
             "colours": [
@@ -3646,7 +3646,7 @@
         },
         {
             "id": "b379037b-798b-5b47-8d0d-737a9238262d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d38abd-116d-4015-91e4-3fc267ad099d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d38abd-116d-4015-91e4-3fc267ad099d.jpg?1",
             "name": "Splendid Agony",
             "text": "Distribute two -1/-1 counters among one or two target creatures.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "53473058-9745-53a1-b7cc-71826e3a98a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb84193-9648-46e5-a34d-c12cc3f1d7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb84193-9648-46e5-a34d-c12cc3f1d7f2.jpg?1",
             "name": "Stir the Sands",
             "text": "Create three 2/2 black Zombie creature tokens.\nCycling {3}{B} ({3}{B}, Discard this card: Draw a card.)\nWhen you cycle Stir the Sands, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "d8f89a91-587a-5b20-8cf0-90636cd81d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cac5753-54e7-45a8-b486-4860533ce93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cac5753-54e7-45a8-b486-4860533ce93c.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "4c9f6b90-d443-5b29-b13e-1bdfb8925e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef4c59-ab84-4d84-b795-015b21ae3fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ef4c59-ab84-4d84-b795-015b21ae3fe0.jpg?1",
             "name": "Trespasser's Curse",
             "text": "Enchant player\nWhenever a creature enters the battlefield under enchanted player's control, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "64b2cc0c-f1e0-51a4-8ea1-f57761b32934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1e79b7-931d-49bf-8c2c-d42c55a93c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1e79b7-931d-49bf-8c2c-d42c55a93c74.jpg?1",
             "name": "Trial of Ambition",
             "text": "When Trial of Ambition enters the battlefield, target opponent sacrifices a creature.\nWhen a Cartouche enters the battlefield under your control, return Trial of Ambition to its owner's hand.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "11725a41-f9b7-5e8c-8583-f125748db4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d81da3-dc88-4cf7-ab9a-c8ade2cfa0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d81da3-dc88-4cf7-ab9a-c8ade2cfa0e1.jpg?1",
             "name": "Unburden",
             "text": "Target player discards two cards.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "70968a28-1e8e-5293-b75d-cb4150899c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea7ad5c-d9b9-4b12-90dd-c02399d73b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea7ad5c-d9b9-4b12-90dd-c02399d73b26.jpg?1",
             "name": "Wander in Death",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "2dd79a90-2e31-5396-988d-26d42ae47399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bab1782-498c-40fc-bf2e-5c991d0c3501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bab1782-498c-40fc-bf2e-5c991d0c3501.jpg?1",
             "name": "Wasteland Scorpion",
             "text": "Deathtouch\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "c4568563-ee1d-5410-a320-125786944f37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5db68c-24d5-44ce-9809-e446f26fac5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5db68c-24d5-44ce-9809-e446f26fac5d.jpg?1",
             "name": "Ahn-Crop Crasher",
             "text": "Haste\nYou may exert Ahn-Crop Crasher as it attacks. When you do, target creature can't block this turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -3942,7 +3942,7 @@
         },
         {
             "id": "f882d34b-9b47-575a-a80d-64e004427bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb1a40-8239-4544-96a1-a4acaf7e2054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb1a40-8239-4544-96a1-a4acaf7e2054.jpg?1",
             "name": "Battlefield Scavenger",
             "text": "You may exert Battlefield Scavenger as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "ce356909-1daf-5df2-9265-8d305759a75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba450179-4591-4e8a-b6ca-66cbef1817f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba450179-4591-4e8a-b6ca-66cbef1817f2.jpg?1",
             "name": "Blazing Volley",
             "text": "Blazing Volley deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "13a091b1-8327-56c2-90b9-e1fe586850a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cd0757-1b06-4e1b-a236-31271bd0d9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cd0757-1b06-4e1b-a236-31271bd0d9a3.jpg?1",
             "name": "Bloodlust Inciter",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4044,7 +4044,7 @@
         },
         {
             "id": "8758ea0c-ff14-5a34-b206-221198c5ce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6080f9e-2415-4e05-97a1-0fe4ad4fdf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6080f9e-2415-4e05-97a1-0fe4ad4fdf3b.jpg?1",
             "name": "Bloodrage Brawler",
             "text": "When Bloodrage Brawler enters the battlefield, discard a card.",
             "colours": [
@@ -4079,7 +4079,7 @@
         },
         {
             "id": "91110dcb-704a-580c-9f89-9a8127275694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7bd68d-02eb-44ec-955f-08b328e1b6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7bd68d-02eb-44ec-955f-08b328e1b6d3.jpg?1",
             "name": "Brute Strength",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "d1635228-e8f6-56c0-9f4a-014a349cfb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cdfdb2-b47f-446d-9850-8581bd1d806c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cdfdb2-b47f-446d-9850-8581bd1d806c.jpg?1",
             "name": "By Force",
             "text": "Destroy X target artifacts.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "6a2dab65-1b9a-51db-84e3-7a338b28ca4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09b2d9-b944-480b-93f9-76fc9bc319ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09b2d9-b944-480b-93f9-76fc9bc319ce.jpg?1",
             "name": "Cartouche of Zeal",
             "text": "Enchant creature you control\nWhen Cartouche of Zeal enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "c3a83ff8-a54d-54c1-ae07-165ff654036d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b63c3d-2e55-4343-b49a-11fa602ec473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b63c3d-2e55-4343-b49a-11fa602ec473.jpg?1",
             "name": "Combat Celebrant",
             "text": "If Combat Celebrant hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4213,7 +4213,7 @@
         },
         {
             "id": "86aa0619-3589-555f-95a4-a7224e06739c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529d230-89b0-453b-987b-a47e15bc3830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529d230-89b0-453b-987b-a47e15bc3830.jpg?1",
             "name": "Consuming Fervor",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has \"At the beginning of your upkeep, put a -1/-1 counter on this creature.\"",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "d337ad6c-7737-5500-b63b-c0e8bfcffdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2ed5f-62b8-4308-a656-f273f62f6ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a2ed5f-62b8-4308-a656-f273f62f6ab8.jpg?1",
             "name": "Deem Worthy",
             "text": "Deem Worthy deals 7 damage to target creature.\nCycling {3}{R} ({3}{R}, Discard this card: Draw a card.)\nWhen you cycle Deem Worthy, you may have it deal 2 damage to target creature.",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "c4060679-9d28-5b2a-a7e6-48eb7fc83fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047c2e5-8b3b-4c6b-91cf-3484f21e52f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047c2e5-8b3b-4c6b-91cf-3484f21e52f0.jpg?1",
             "name": "Desert Cerodon",
             "text": "Cycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "b415d4b8-1587-57be-8440-53a338192cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c67128-2e5a-4c97-b265-6f3c73b4997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c67128-2e5a-4c97-b265-6f3c73b4997a.jpg?1",
             "name": "Electrify",
             "text": "Electrify deals 4 damage to target creature.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "07dd7930-b400-5dea-a310-a1d3cc9d0bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7aeca-eaba-4d9a-b061-0d9a63b03b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7aeca-eaba-4d9a-b061-0d9a63b03b3a.jpg?1",
             "name": "Emberhorn Minotaur",
             "text": "You may exert Emberhorn Minotaur as it attacks. When you do, it gets +1/+1 and gains menace until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "3c88ce22-77a6-5a1e-bab7-8820102d8705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f974d05a-3b31-4661-af18-58d87b76f19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f974d05a-3b31-4661-af18-58d87b76f19e.jpg?1",
             "name": "Flameblade Adept",
             "text": "Menace\nWhenever you cycle or discard a card, Flameblade Adept gets +1/+0 until end of turn.",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "ca5c7cb1-d5d3-5d39-b66e-6f6db1bba081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02363a7-4455-4571-bfff-4ce94c7c1e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02363a7-4455-4571-bfff-4ce94c7c1e3b.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -4447,7 +4447,7 @@
         },
         {
             "id": "faa7bb16-f96f-5515-b849-60e1a3d69c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2922b976-7beb-4c68-b39e-1b66d5c6f65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2922b976-7beb-4c68-b39e-1b66d5c6f65e.jpg?1",
             "name": "Glorious End",
             "text": "End the turn. (Exile all spells and abilities on the stack, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)\nAt the beginning of your next end step, you lose the game.",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "12854d7a-9434-5c46-b2ce-7dd4eac954d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3277ad99-5682-4baa-b106-de15721876a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3277ad99-5682-4baa-b106-de15721876a6.jpg?1",
             "name": "Glorybringer",
             "text": "Flying, haste\nYou may exert Glorybringer as it attacks. When you do, it deals 4 damage to target non-Dragon creature an opponent controls. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "19949cdb-ecfe-5cb7-b44d-416f3fbb8ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936bf9d-c973-4bce-b5c2-2a01b7953638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936bf9d-c973-4bce-b5c2-2a01b7953638.jpg?1",
             "name": "Harsh Mentor",
             "text": "Whenever an opponent activates an ability of an artifact, creature, or land on the battlefield, if it isn't a mana ability, Harsh Mentor deals 2 damage to that player.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "30e45bd0-8fa1-51bc-a968-443e225e0a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ed9f9d-99a7-49f4-b0ad-d71355809d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ed9f9d-99a7-49f4-b0ad-d71355809d32.jpg?1",
             "name": "Hazoret the Fervent",
             "text": "Indestructible, haste\nHazoret the Fervent can't attack or block unless you have one or fewer cards in hand.\n{2}{R}, Discard a card: Hazoret deals 2 damage to each opponent.",
             "colours": [
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "44e03ee8-7536-5603-b1c9-1d9fe0091587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b467412-c06b-4cd9-a877-7722051fb758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b467412-c06b-4cd9-a877-7722051fb758.jpg?1",
             "name": "Hazoret's Favor",
             "text": "At the beginning of combat on your turn, you may have target creature you control get +2/+0 and gain haste until end of turn. If you do, sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4616,7 +4616,7 @@
         },
         {
             "id": "cfce9dfc-6b1e-5d64-a360-14a8c7fd751c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64160a-96e0-4593-ba42-c5e8bbfa0b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64160a-96e0-4593-ba42-c5e8bbfa0b15.jpg?1",
             "name": "Heart-Piercer Manticore",
             "text": "When Heart-Piercer Manticore enters the battlefield, you may sacrifice another creature. When you do, Heart-Piercer Manticore deals damage equal to that creature's power to target creature or player.\nEmbalm {5}{R} ({5}{R}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Manticore with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "5a9e9993-1216-55cf-9c6d-ac6412009469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fa8351-567e-4ef4-8346-c58e50c778a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fa8351-567e-4ef4-8346-c58e50c778a6.jpg?1",
             "name": "Hyena Pack",
             "text": "",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "cb04f12f-81ab-5a51-a33a-0b451b4dab9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95cb6a18-1222-4e56-8466-0f7bd634ef3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95cb6a18-1222-4e56-8466-0f7bd634ef3d.jpg?1",
             "name": "Limits of Solidarity",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "1791de6f-2605-55b7-aee5-c58745283f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a7993-eb7d-4ae2-8a22-1676f517558b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a7993-eb7d-4ae2-8a22-1676f517558b.jpg?1",
             "name": "Magma Spray",
             "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "eb9f6dab-cf68-5f5f-a910-a553fbad85e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b6ece3-1574-4634-b940-829e54c4f78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b6ece3-1574-4634-b940-829e54c4f78d.jpg?1",
             "name": "Manticore of the Gauntlet",
             "text": "When Manticore of the Gauntlet enters the battlefield, put a -1/-1 counter on target creature you control. Manticore of the Gauntlet deals 3 damage to target opponent.",
             "colours": [
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "26b26cf2-df02-5561-83d7-1360fbc80a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777b98c3-d0b8-4ee3-9d89-e86344269ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777b98c3-d0b8-4ee3-9d89-e86344269ff1.jpg?1",
             "name": "Minotaur Sureshot",
             "text": "Reach (This creature can block creatures with flying.)\n{1}{R}: Minotaur Sureshot gets +1/+0 until end of turn.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "d14c9473-11dd-5407-8d0a-54846d5efcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96569dc0-ea94-4a43-b002-85c5066e5386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96569dc0-ea94-4a43-b002-85c5066e5386.jpg?1",
             "name": "Nef-Crop Entangler",
             "text": "Trample\nYou may exert Nef-Crop Entangler as it attacks. When you do, it gets +1/+2 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4852,7 +4852,7 @@
         },
         {
             "id": "3d676361-6155-593a-9e21-b418d31974a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36a17b-89d6-4de9-867b-9762afedb4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36a17b-89d6-4de9-867b-9762afedb4f1.jpg?1",
             "name": "Nimble-Blade Khenra",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "5f319a58-e0c7-558d-baa4-56c7f1511996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc6b34-aaa7-4ec1-9f37-b03f9b5919f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc6b34-aaa7-4ec1-9f37-b03f9b5919f2.jpg?1",
             "name": "Pathmaker Initiate",
             "text": "{T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "5b1e80dd-a9e0-5769-916f-36c0f8152d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5668ae2-fa74-47c9-877e-5326cac67659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5668ae2-fa74-47c9-877e-5326cac67659.jpg?1",
             "name": "Pursue Glory",
             "text": "Attacking creatures get +2/+0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "0db88cd3-9c93-5943-97b1-ec35d8493cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg?1",
             "name": "Soul-Scar Mage",
             "text": "Prowess\nIf a source you control would deal noncombat damage to a creature an opponent controls, put that many -1/-1 counters on that creature instead.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "922bd54f-c131-5eb5-a80e-1d9190dc726e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg?1",
             "name": "Sweltering Suns",
             "text": "Sweltering Suns deals 3 damage to each creature.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -5021,7 +5021,7 @@
         },
         {
             "id": "d6928a9c-b908-5cf6-ae22-f4e6b8a58370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642c5f4-4229-47c4-ac44-7feb5ee9cf9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642c5f4-4229-47c4-ac44-7feb5ee9cf9e.jpg?1",
             "name": "Thresher Lizard",
             "text": "Thresher Lizard gets +1/+2 as long as you have one or fewer cards in hand.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "128be3a1-6667-5baa-af15-0b718bd4e3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5fbcb-b1fb-4ded-a48d-4fcb501c6b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5fbcb-b1fb-4ded-a48d-4fcb501c6b68.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "5fe7c1b6-532d-5e0d-9205-b7446288bc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543539ce-af50-4bbe-82aa-f35fd2c2a256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543539ce-af50-4bbe-82aa-f35fd2c2a256.jpg?1",
             "name": "Trial of Zeal",
             "text": "When Trial of Zeal enters the battlefield, it deals 3 damage to target creature or player.\nWhen a Cartouche enters the battlefield under your control, return Trial of Zeal to its owner's hand.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "b0b44daa-4f68-5a82-9342-aba2935a5b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac510911-1a65-4509-b6c9-ddac1950c838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac510911-1a65-4509-b6c9-ddac1950c838.jpg?1",
             "name": "Trueheart Twins",
             "text": "You may exert Trueheart Twins as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "d7eb31ab-f719-5866-8f6c-fbdcf23719ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b8673a-ce93-4881-b712-8db82446d83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b8673a-ce93-4881-b712-8db82446d83c.jpg?1",
             "name": "Violent Impact",
             "text": "Destroy target artifact or land.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5186,7 +5186,7 @@
         },
         {
             "id": "d6439c71-c0fb-523e-885c-19bc4b655b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce75b3c-4f83-4c09-9361-d7463e4921e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce75b3c-4f83-4c09-9361-d7463e4921e6.jpg?1",
             "name": "Warfire Javelineer",
             "text": "When Warfire Javelineer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "a07d2923-c3ce-5237-ac63-9cf9e7d31ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc98fcdd-8482-4462-ab71-935cea48e409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc98fcdd-8482-4462-ab71-935cea48e409.jpg?1",
             "name": "Benefaction of Rhonas",
             "text": "Reveal the top five cards of your library. You may put a creature card and/or an enchantment card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "68168d37-a913-59e3-b644-d732fa18b0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54edbb-c35d-4f7f-b5ce-d39b0f766ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54edbb-c35d-4f7f-b5ce-d39b0f766ab8.jpg?1",
             "name": "Bitterblade Warrior",
             "text": "You may exert Bitterblade Warrior as it attacks. When you do, it gets +1/+0 and gains deathtouch until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -5288,7 +5288,7 @@
         },
         {
             "id": "b4480a77-6450-5869-934a-446634f249ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb237c-4e39-4879-90b4-2f507a90d3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb237c-4e39-4879-90b4-2f507a90d3d7.jpg?1",
             "name": "Cartouche of Strength",
             "text": "Enchant creature you control\nWhen Cartouche of Strength enters the battlefield, you may have enchanted creature fight target creature an opponent controls. (Each deals damage equal to its power to the other.)\nEnchanted creature gets +1/+1 and has trample.",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "eeb99780-406e-5b22-acf1-6dd8ee6c4fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b185b24d-ae33-48ca-966a-511627fdac6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b185b24d-ae33-48ca-966a-511627fdac6d.jpg?1",
             "name": "Champion of Rhonas",
             "text": "You may exert Champion of Rhonas as it attacks. When you do, you may put a creature card from your hand onto the battlefield. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -5358,7 +5358,7 @@
         },
         {
             "id": "d0cbff55-40eb-5d50-85d8-2376c181662b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef38c5a-07fc-477f-a1c0-70cc3ad64f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef38c5a-07fc-477f-a1c0-70cc3ad64f96.jpg?1",
             "name": "Channeler Initiate",
             "text": "When Channeler Initiate enters the battlefield, put three -1/-1 counters on target creature you control.\n{T}, Remove a -1/-1 counter from Channeler Initiate: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "d52be47f-a398-50e1-8d9d-14886b07d334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg?1",
             "name": "Colossapede",
             "text": "",
             "colours": [
@@ -5427,7 +5427,7 @@
         },
         {
             "id": "57ed2278-3c90-55f7-b058-6b5e79976cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f64ca9c-99c4-45d4-bd21-3ede61702250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f64ca9c-99c4-45d4-bd21-3ede61702250.jpg?1",
             "name": "Crocodile of the Crossing",
             "text": "Haste\nWhen Crocodile of the Crossing enters the battlefield, put a -1/-1 counter on target creature you control.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "6dd41a0e-bbfc-5f28-8cac-e84d40fae967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74cb0ba-c691-4823-aa94-399b1aaeaf0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74cb0ba-c691-4823-aa94-399b1aaeaf0b.jpg?1",
             "name": "Defiant Greatmaw",
             "text": "When Defiant Greatmaw enters the battlefield, put two -1/-1 counters on target creature you control.\nWhenever you put one or more -1/-1 counters on Defiant Greatmaw, remove a -1/-1 counter from another target creature you control.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "90e2aa2c-8d50-58a3-9ac7-55a0581566b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543eb854-bac7-468f-b3b0-d9987cfac318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543eb854-bac7-468f-b3b0-d9987cfac318.jpg?1",
             "name": "Dissenter's Deliverance",
             "text": "Destroy target artifact.\nCycling {G} ({G}, Discard this card: Draw a card.)",
             "colours": [
@@ -5527,7 +5527,7 @@
         },
         {
             "id": "6b3870e5-1591-5e5b-b125-8e1d24ed6b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30501c5-f6d9-47b3-b12b-8bd1c5ea6a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30501c5-f6d9-47b3-b12b-8bd1c5ea6a9b.jpg?1",
             "name": "Exemplar of Strength",
             "text": "When Exemplar of Strength enters the battlefield, put three -1/-1 counters on target creature you control.\nWhenever Exemplar of Strength attacks, remove a -1/-1 counter from it. If you do, you gain 1 life.",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "29e77fda-9720-5332-886d-0465286fed98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f99a5-40be-4fb1-bd9b-96a9adc5c2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f99a5-40be-4fb1-bd9b-96a9adc5c2af.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "8d086328-43e6-5341-9d5f-0f4979f78e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a2b15f-c289-4270-830c-50577325b97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a2b15f-c289-4270-830c-50577325b97a.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "45c02b17-f530-5f63-9734-3ae9b34ed08b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411d177-45fd-4193-8414-0f7e7846d2b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411d177-45fd-4193-8414-0f7e7846d2b9.jpg?1",
             "name": "Greater Sandwurm",
             "text": "Greater Sandwurm can't be blocked by creatures with power 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "d58fa55e-5cda-59b8-b65a-904d46997382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199d6a8d-008d-4495-9cbc-b8d680fab13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199d6a8d-008d-4495-9cbc-b8d680fab13c.jpg?1",
             "name": "Hapatra's Mark",
             "text": "Target creature you control gains hexproof until end of turn. Remove all -1/-1 counters from it. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "09721960-d398-5377-9614-262a77dea577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18e745-a925-477f-a50f-3ec7fba22d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18e745-a925-477f-a50f-3ec7fba22d88.jpg?1",
             "name": "Harvest Season",
             "text": "Search your library for up to X basic land cards, where X is the number of tapped creatures you control, and put those cards onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "cd16cb2e-dc7b-5723-9ee6-83527b8a45a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636925d-1c32-4fdc-b814-e6111393d04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636925d-1c32-4fdc-b814-e6111393d04e.jpg?1",
             "name": "Haze of Pollen",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "425f5587-3f81-5b11-87c8-b3fd4458cead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c33902-a06a-4321-bdf4-cea5494fda63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c33902-a06a-4321-bdf4-cea5494fda63.jpg?1",
             "name": "Honored Hydra",
             "text": "Trample\nEmbalm {3}{G} ({3}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Snake Hydra with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -5795,7 +5795,7 @@
         },
         {
             "id": "65e636c7-1ccb-5de8-88e9-b043e8c0dff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4dab03-abf1-4c8f-983e-77dffcfb1578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4dab03-abf1-4c8f-983e-77dffcfb1578.jpg?1",
             "name": "Hooded Brawler",
             "text": "You may exert Hooded Brawler as it attacks. When you do, it gets +2/+2 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "80d454f2-31ff-57dd-99f5-515715ac7d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0046b802-bc71-44af-8925-666684d5fc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0046b802-bc71-44af-8925-666684d5fc87.jpg?1",
             "name": "Initiate's Companion",
             "text": "Whenever Initiate's Companion deals combat damage to a player, untap target creature or land.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "d5fa338a-9c26-5168-b5fe-0f3f3381797f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa3a844-97e6-4f5d-a36f-56fea4e06932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa3a844-97e6-4f5d-a36f-56fea4e06932.jpg?1",
             "name": "Manglehorn",
             "text": "When Manglehorn enters the battlefield, you may destroy target artifact.\nArtifacts your opponents control enter the battlefield tapped.",
             "colours": [
@@ -5898,7 +5898,7 @@
         },
         {
             "id": "fc3139c4-cab8-5733-a2a7-1c837da03297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a8551-8788-47ea-b774-477f0f3ff22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a8551-8788-47ea-b774-477f0f3ff22a.jpg?1",
             "name": "Naga Vitalist",
             "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "cf14fdb6-7c02-5174-8095-3d4d017e3fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10be36-8e57-4b08-bc3b-e69769e0908a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10be36-8e57-4b08-bc3b-e69769e0908a.jpg?1",
             "name": "Oashra Cultivator",
             "text": "{2}{G}, {T}, Sacrifice Oashra Cultivator: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5968,7 +5968,7 @@
         },
         {
             "id": "cc773e67-031f-5fa0-91fc-f6f315a5a322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1d3a1-8c1b-4b77-b149-13d5ad9f125a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1d3a1-8c1b-4b77-b149-13d5ad9f125a.jpg?1",
             "name": "Ornery Kudu",
             "text": "When Ornery Kudu enters the battlefield, put a -1/-1 counter on target creature you control.",
             "colours": [
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "8a6863cf-8b44-581f-8e29-670bd97e8fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a590-75c1-4e85-b8b7-8c0c0f18b96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a590-75c1-4e85-b8b7-8c0c0f18b96e.jpg?1",
             "name": "Pouncing Cheetah",
             "text": "Flash",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "788b6610-767e-5a75-b875-62a25836e41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92921fc1-11d0-41a9-b9b2-b44fd0913d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92921fc1-11d0-41a9-b9b2-b44fd0913d31.jpg?1",
             "name": "Prowling Serpopard",
             "text": "Prowling Serpopard can't be countered.\nCreature spells you control can't be countered.",
             "colours": [
@@ -6071,7 +6071,7 @@
         },
         {
             "id": "2deccebb-9105-53ec-8e30-39a0fcab837a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2877c5-7680-4c2d-8e46-1d4548f0b03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2877c5-7680-4c2d-8e46-1d4548f0b03a.jpg?1",
             "name": "Quarry Hauler",
             "text": "When Quarry Hauler enters the battlefield, for each kind of counter on target permanent, put another counter of that kind on it or remove one from it.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "58ab9067-e604-5cf8-b4f1-8f2282398399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f23c47-278c-4188-8fb4-ae20a0c423c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f23c47-278c-4188-8fb4-ae20a0c423c5.jpg?1",
             "name": "Rhonas the Indomitable",
             "text": "Deathtouch, indestructible\nRhonas the Indomitable can't attack or block unless you control another creature with power 4 or greater.\n{2}{G}: Another target creature gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "89185033-6416-5df9-b6fe-ccd31531f0d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bd2c5-e3db-4fde-a695-9e67a7e937be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bd2c5-e3db-4fde-a695-9e67a7e937be.jpg?1",
             "name": "Sandwurm Convergence",
             "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "f9a752dc-125f-57e9-a43e-333ab909684f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c05a60f-660a-42d3-82b3-06984366afb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c05a60f-660a-42d3-82b3-06984366afb4.jpg?1",
             "name": "Scaled Behemoth",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6207,7 +6207,7 @@
         },
         {
             "id": "3aa09054-4724-590a-9929-40393a6cf72a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81803f44-6260-4df9-b566-2a2694d4deb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81803f44-6260-4df9-b566-2a2694d4deb0.jpg?1",
             "name": "Shed Weakness",
             "text": "Target creature gets +2/+2 until end of turn. You may remove a -1/-1 counter from it.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "bc421f4a-b0eb-515f-88e8-09fab1283d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ef62-875a-4735-9a63-6f3152d10d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ef62-875a-4735-9a63-6f3152d10d61.jpg?1",
             "name": "Shefet Monitor",
             "text": "Cycling {3}{G} ({3}{G}, Discard this card: Draw a card.)\nWhen you cycle Shefet Monitor, you may search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle your library. (Do this before you draw.)",
             "colours": [
@@ -6273,7 +6273,7 @@
         },
         {
             "id": "8e7310af-f8ba-5910-b3b1-3c63658afab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e564db6b-0b8b-4c67-9135-5da76d2225fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e564db6b-0b8b-4c67-9135-5da76d2225fe.jpg?1",
             "name": "Sixth Sense",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, you may draw a card.\"",
             "colours": [
@@ -6307,7 +6307,7 @@
         },
         {
             "id": "398a6c04-42b4-555e-8a91-c9cf94a2ca94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c64b40f-f99a-4e35-821f-9d87b4c759a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c64b40f-f99a-4e35-821f-9d87b4c759a7.jpg?1",
             "name": "Spidery Grasp",
             "text": "Untap target creature. It gets +2/+4 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -6339,7 +6339,7 @@
         },
         {
             "id": "df78347b-8605-5c6e-a436-0274729db3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c4c26-1118-41fa-aec8-1b43a7792e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c4c26-1118-41fa-aec8-1b43a7792e59.jpg?1",
             "name": "Stinging Shot",
             "text": "Put three -1/-1 counters on target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "47686906-0b0b-5130-8bfc-e7e83385d399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb09d11-5a6d-498f-9173-3539760b19fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb09d11-5a6d-498f-9173-3539760b19fb.jpg?1",
             "name": "Synchronized Strike",
             "text": "Untap up to two target creatures. They each get +2/+2 until end of turn.",
             "colours": [
@@ -6403,7 +6403,7 @@
         },
         {
             "id": "1a437a44-0231-505b-8855-4833ae2a9538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadb754-4a3b-4633-b784-252c0e1ab650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadb754-4a3b-4633-b784-252c0e1ab650.jpg?1",
             "name": "Trial of Strength",
             "text": "When Trial of Strength enters the battlefield, create a 4/2 green Beast creature token.\nWhen a Cartouche enters the battlefield under your control, return Trial of Strength to its owner's hand.",
             "colours": [
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "cf726ed6-9243-540c-a87d-df84025b75f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca204351-7a7e-4e4b-8c2b-f90fa0f9d724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca204351-7a7e-4e4b-8c2b-f90fa0f9d724.jpg?1",
             "name": "Vizier of the Menagerie",
             "text": "You may look at the top card of your library. (You may do this at any time.)\nYou may cast the top card of your library if it's a creature card.\nYou may spend mana as though it were mana of any type to cast creature spells.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "e0b8138e-0eeb-5fdf-9a2a-f2d92c4824e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae361e-20e2-4388-bd82-ce041f427495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae361e-20e2-4388-bd82-ce041f427495.jpg?1",
             "name": "Watchful Naga",
             "text": "You may exert Watchful Naga as it attacks. When you do, draw a card. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -6505,7 +6505,7 @@
         },
         {
             "id": "058a3fc5-9de1-5c00-ad92-ba268774dbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddda94a-4b2d-47b0-8d2c-3ad70a0d5584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddda94a-4b2d-47b0-8d2c-3ad70a0d5584.jpg?1",
             "name": "Ahn-Crop Champion",
             "text": "You may exert Ahn-Crop Champion as it attacks. When you do, untap all other creatures you control. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -6542,7 +6542,7 @@
         },
         {
             "id": "d76c32fd-f022-508d-9519-45dc23a5d2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bc716-2b1b-4731-bd0c-f4a5caf26e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bc716-2b1b-4731-bd0c-f4a5caf26e40.jpg?1",
             "name": "Aven Wind Guide",
             "text": "Flying, vigilance\nCreature tokens you control have flying and vigilance.\nEmbalm {4}{W}{U} ({4}{W}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Bird Warrior with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -6579,7 +6579,7 @@
         },
         {
             "id": "3e9e6924-e13f-5f39-b32c-f30ee37f3f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574dab03-b8e6-4051-9dd5-31439c817223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574dab03-b8e6-4051-9dd5-31439c817223.jpg?1",
             "name": "Bounty of the Luxa",
             "text": "At the beginning of your precombat main phase, remove all flood counters from Bounty of the Luxa. If no counters were removed this way, put a flood counter on Bounty of the Luxa and draw a card. Otherwise, add {C}{G}{U} to your mana pool.",
             "colours": [
@@ -6613,7 +6613,7 @@
         },
         {
             "id": "e312c3b5-4605-527b-992f-36ff87ad39d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75e834-fa46-4833-ae9f-1bc2809ece2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75e834-fa46-4833-ae9f-1bc2809ece2f.jpg?1",
             "name": "Decimator Beetle",
             "text": "When Decimator Beetle enters the battlefield, put a -1/-1 counter on target creature you control.\nWhenever Decimator Beetle attacks, remove a -1/-1 counter from target creature you control and put a -1/-1 counter on up to one target creature defending player controls.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "4c94dd1a-dff7-54d6-8693-fa88cf57798f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66286631-c16e-410c-b963-25cfe8005d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66286631-c16e-410c-b963-25cfe8005d8f.jpg?1",
             "name": "Enigma Drake",
             "text": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -6685,7 +6685,7 @@
         },
         {
             "id": "9e98ed00-0adc-57b5-a0da-2d0b0967b949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fbbcc9-db23-4902-b0f7-cea78a2a36af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fbbcc9-db23-4902-b0f7-cea78a2a36af.jpg?1",
             "name": "Hapatra, Vizier of Poisons",
             "text": "Whenever Hapatra, Vizier of Poisons deals combat damage to a player, you may put a -1/-1 counter on target creature.\nWhenever you put one or more -1/-1 counters on a creature, create a 1/1 green Snake creature token with deathtouch.",
             "colours": [
@@ -6724,7 +6724,7 @@
         },
         {
             "id": "33aff80b-017a-54f7-b7b2-e9e967eb8e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b44194-fed5-491c-a791-80b986dd66d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b44194-fed5-491c-a791-80b986dd66d6.jpg?1",
             "name": "Honored Crop-Captain",
             "text": "Whenever Honored Crop-Captain attacks, other attacking creatures get +1/+0 until end of turn.",
             "colours": [
@@ -6761,7 +6761,7 @@
         },
         {
             "id": "dd482df2-3f88-5d7a-8982-0e2d32cc21ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab1454e-3c69-4450-bd4c-934af2ff2bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab1454e-3c69-4450-bd4c-934af2ff2bcb.jpg?1",
             "name": "Khenra Charioteer",
             "text": "Trample\nOther creatures you control have trample.",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "ed74a8e7-de70-53a1-8081-78285dc2e269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0e8c57-3046-414d-be00-39bfb2537026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0e8c57-3046-414d-be00-39bfb2537026.jpg?1",
             "name": "Merciless Javelineer",
             "text": "{2}, Discard a card: Put a -1/-1 counter on target creature. That creature can't block this turn.",
             "colours": [
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "9ed535d4-d77f-5553-94bf-8c7e1073ce32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d5fb-c6b3-4d24-b9d3-97a4378161fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7593d5fb-c6b3-4d24-b9d3-97a4378161fd.jpg?1",
             "name": "Neheb, the Worthy",
             "text": "First strike\nOther Minotaurs you control have first strike.\nAs long as you have one or fewer cards in hand, Minotaurs you control get +2/+0.\nWhenever Neheb, the Worthy deals combat damage to a player, each player discards a card.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "a037ae21-92f8-56cd-91c3-5575933b531f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79036a1-2239-4d4f-8b58-6cf9ac4863fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79036a1-2239-4d4f-8b58-6cf9ac4863fc.jpg?1",
             "name": "Nissa, Steward of Elements",
             "text": "+2: Scry 2.\n0: Look at the top card of your library. If it's a land card or a creature card with converted mana cost less than or equal to the number of loyalty counters on Nissa, Steward of Elements, you may put that card onto the battlefield.\n\u22126: Untap up to two target lands you control. They become 5/5 Elemental creatures with flying and haste until end of turn. They're still lands.",
             "colours": [
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "afad7b5a-566b-53dc-a3ba-7b5d143c6a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f2d8f1-43a9-438a-830c-9d6b5701f950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f2d8f1-43a9-438a-830c-9d6b5701f950.jpg?1",
             "name": "Samut, Voice of Dissent",
             "text": "Flash\nDouble strike, vigilance, haste\nOther creatures you control have haste.\n{W}, {T}: Untap another target creature.",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "f09ff657-f627-559e-af9b-27fe0ec5a294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea72b393-e47c-46de-a458-624ef0227486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea72b393-e47c-46de-a458-624ef0227486.jpg?1",
             "name": "Shadowstorm Vizier",
             "text": "Flying\nWhenever you cycle or discard a card, Shadowstorm Vizier gets +1/+1 until end of turn.",
             "colours": [
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "923ad903-d63c-5555-b874-9c6848bd73f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af12a34-52a1-4940-a8d5-9e9811fcd59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af12a34-52a1-4940-a8d5-9e9811fcd59f.jpg?1",
             "name": "Temmet, Vizier of Naktamun",
             "text": "At the beginning of combat on your turn, target creature token you control gets +1/+1 until end of turn and can't be blocked this turn.\nEmbalm {3}{W}{U} ({3}{W}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a white Zombie Human Cleric with no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "74654008-bd71-58d5-9e40-f4faa588ebe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e00112-8c6c-4551-ad68-389e315fe148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e00112-8c6c-4551-ad68-389e315fe148.jpg?1",
             "name": "Wayward Servant",
             "text": "Whenever another Zombie enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "adfaed49-f240-51bc-9ae0-b63a745fca6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac35181-baae-4c50-b397-a10b234833e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac35181-baae-4c50-b397-a10b234833e5.jpg?1",
             "name": "Weaver of Currents",
             "text": "{T}: Add {C}{C} to your mana pool.",
             "colours": [
@@ -7101,7 +7101,7 @@
         },
         {
             "id": "f9f10d34-071c-57a6-b58c-7553abad5c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Destroy all creatures with power 3 or greater.",
             "colours": [
@@ -7133,7 +7133,7 @@
         },
         {
             "id": "87f0062a-8321-5c16-960e-a12ce1df5839",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/937dbc51-b589-4237-9fce-ea5c757f7c48.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nReturn all creature cards with power 2 or less from your graveyard to your hand.",
             "colours": [
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "71a0621f-32a6-5450-8ad8-6cdae505cf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg?1",
             "name": "Commit // Memory",
             "text": "Put target spell or nonland permanent into its owner's library second from the top.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "95a37a67-eac8-5ae2-9a50-31f81f810f18",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06c9e2e8-2b4c-4087-9141-6aa25a506626.jpg?1",
             "name": "Commit // Memory",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles his or her hand and graveyard into his or her library, then draws seven cards.",
             "colours": [
@@ -7229,7 +7229,7 @@
         },
         {
             "id": "875ba98c-721c-537b-b326-22d803fab7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg?1",
             "name": "Never // Return",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "6acc8501-aa59-5777-a7d0-e3ef66a609ea",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg?1",
             "name": "Never // Return",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile target card from a graveyard. Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "8c8d3c24-09c9-5d5a-879c-00cca5d29410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg?1",
             "name": "Insult // Injury",
             "text": "Damage can't be prevented this turn. If a source you control would deal damage this turn, it deals double that damage instead.",
             "colours": [
@@ -7325,7 +7325,7 @@
         },
         {
             "id": "c44192e3-0732-528d-a4c4-b27a49d8ebe4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg?1",
             "name": "Insult // Injury",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nInjury deals 2 damage to target creature and 2 damage to target player.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "6298d70e-4ecc-5cff-9221-aeb532c33e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg?1",
             "name": "Mouth // Feed",
             "text": "Create a 3/3 green Hippo creature token.",
             "colours": [
@@ -7389,7 +7389,7 @@
         },
         {
             "id": "e765058a-4a7c-513f-bb97-cb7d3aa56218",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg?1",
             "name": "Mouth // Feed",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw a card for each creature you control with power 3 or greater.",
             "colours": [
@@ -7421,7 +7421,7 @@
         },
         {
             "id": "17100b0d-3b74-5329-a832-dfad07d5c35b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg?1",
             "name": "Start // Finish",
             "text": "Create two 1/1 white Warrior creature tokens with vigilance.",
             "colours": [
@@ -7454,7 +7454,7 @@
         },
         {
             "id": "93de0571-9509-5933-b298-2660f5f97f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9c6f5433-57cc-4cb3-8621-2575fcbff392.jpg?1",
             "name": "Start // Finish",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAs an additional cost to cast Finish, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -7487,7 +7487,7 @@
         },
         {
             "id": "c1640f4d-6d39-5634-8e9b-32b9ddf5f5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg?1",
             "name": "Reduce // Rubble",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "57aa1356-3638-57b6-9b4f-4ef1f77de5df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2f3035c-ca27-40f3-ad73-c4e54bb2bcd7.jpg?1",
             "name": "Reduce // Rubble",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nUp to three target lands don't untap during their controller's next untap step.",
             "colours": [
@@ -7553,7 +7553,7 @@
         },
         {
             "id": "7684c16e-2758-5fc8-9bd9-cff4a7ca4c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg?1",
             "name": "Destined // Lead",
             "text": "Target creature gets +1/+0 and gains indestructible until end of turn.",
             "colours": [
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "a241affc-f016-5e33-94c2-c4e9b95b1cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cf5c549-1e2a-4c47-baf7-e608661b3088.jpg?1",
             "name": "Destined // Lead",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nAll creatures able to block target creature this turn do so.",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "ce891eb4-0423-53ab-aed8-5964f57dd50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg?1",
             "name": "Onward // Victory",
             "text": "Target creature gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -7652,7 +7652,7 @@
         },
         {
             "id": "d683ca15-e3af-5170-bf22-109b3393696d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517b32e4-4b34-431f-8f3b-98a6cffc245a.jpg?1",
             "name": "Onward // Victory",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gains double strike until end of turn.",
             "colours": [
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "9e5fa4dc-893e-5ab3-aa77-f23bbde12f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg?1",
             "name": "Spring // Mind",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "26a57e19-d546-56d2-aa5d-1a78eb1fa265",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/6431d464-1f2b-42c4-ad38-67b7d0984080.jpg?1",
             "name": "Spring // Mind",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards.",
             "colours": [
@@ -7751,7 +7751,7 @@
         },
         {
             "id": "b7820f85-71f4-5eca-8aa8-67279ef3fd8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg?1",
             "name": "Prepare // Fight",
             "text": "Untap target creature. It gets +2/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -7784,7 +7784,7 @@
         },
         {
             "id": "d74c9178-45df-57ea-91a8-c24a2f1d7f05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f59ea6f6-2dff-4e58-9166-57cac03f1d0a.jpg?1",
             "name": "Prepare // Fight",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature you control fights target creature an opponent controls.",
             "colours": [
@@ -7817,7 +7817,7 @@
         },
         {
             "id": "4e870ad1-5290-5c84-801a-b52bd1ff522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg?1",
             "name": "Failure // Comply",
             "text": "Return target spell to its owner's hand.",
             "colours": [
@@ -7850,7 +7850,7 @@
         },
         {
             "id": "dfe9df6b-4995-5516-8f4c-435d6e34b724",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9623c8c-01b4-4e8f-a5b9-eeea408ec027.jpg?1",
             "name": "Failure // Comply",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nChoose a card name. Until your next turn, your opponents can't cast spells with the chosen name.",
             "colours": [
@@ -7883,7 +7883,7 @@
         },
         {
             "id": "bb0a0546-ccc4-5f0b-b157-f10814fb09ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg?1",
             "name": "Rags // Riches",
             "text": "All creatures get -2/-2 until end of turn.",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "07e3e8eb-c75a-5281-b69a-29d4b69536ff",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11d84618-aca9-47dc-ae73-36a2c29f584c.jpg?1",
             "name": "Rags // Riches",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent chooses a creature he or she controls. You gain control of those creatures.",
             "colours": [
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "69e2ed1a-fa4a-5513-9a8f-28f61263d37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg?1",
             "name": "Cut // Ribbons",
             "text": "Cut deals 4 damage to target creature.",
             "colours": [
@@ -7982,7 +7982,7 @@
         },
         {
             "id": "a6b57044-acd3-5380-8da8-12b349ace615",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6f61e2b-e93b-4dda-95cf-9d0ff198c0a6.jpg?1",
             "name": "Cut // Ribbons",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach opponent loses X life.",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "f1523235-010a-5014-85fc-94de770e6793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg?1",
             "name": "Heaven // Earth",
             "text": "Heaven deals X damage to each creature with flying.",
             "colours": [
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "a0f3e7c6-46c8-505a-8f6c-15bd4286167d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe1a4032-efbb-4f72-9181-994b2b35f598.jpg?1",
             "name": "Heaven // Earth",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEarth deals X damage to each creature without flying.",
             "colours": [
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "b7fba506-eaa8-509d-b3c1-b31446650859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b00377-9acc-47c4-ae2f-b396d7050a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b00377-9acc-47c4-ae2f-b396d7050a15.jpg?1",
             "name": "Bontu's Monument",
             "text": "Black creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, each opponent loses 1 life and you gain 1 life.",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "4a32d9d3-45a0-5f85-94ac-09d8da42a120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e6fa29-087f-4da6-9114-30feec708560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e6fa29-087f-4da6-9114-30feec708560.jpg?1",
             "name": "Edifice of Authority",
             "text": "{1}, {T}: Target creature can't attack this turn. Put a brick counter on Edifice of Authority.\n{1}, {T}: Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate this ability only if there are three or more brick counters on Edifice of Authority.",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "58dc60a3-8446-50e2-8898-e44cedf8064e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c044f47-7435-4cb4-b4ad-48bb146daa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c044f47-7435-4cb4-b4ad-48bb146daa9f.jpg?1",
             "name": "Embalmer's Tools",
             "text": "Activated abilities of creature cards in your graveyard cost {1} less to activate.\nTap an untapped Zombie you control: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -8167,7 +8167,7 @@
         },
         {
             "id": "ed9d1e09-0064-5d4a-84f2-66309372907b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b544a59-86b9-447d-b54d-b94a262b6866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b544a59-86b9-447d-b54d-b94a262b6866.jpg?1",
             "name": "Gate to the Afterlife",
             "text": "Whenever a nontoken creature you control dies, you gain 1 life. Then you may draw a card. If you do, discard a card.\n{2}, {T}, Sacrifice Gate to the Afterlife: Search your graveyard, hand, and/or library for a card named God-Pharaoh's Gift and put it onto the battlefield. If you search your library this way, shuffle it. Activate this ability only if there are six or more creature cards in your graveyard.",
             "colours": [],
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "db634f35-5ec7-56d6-86b8-ad03e7de0ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0a70f2-f2cb-4a08-a1a7-95c8fc3de6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0a70f2-f2cb-4a08-a1a7-95c8fc3de6e3.jpg?1",
             "name": "Hazoret's Monument",
             "text": "Red creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, you may discard a card. If you do, draw a card.",
             "colours": [],
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "d5bd7921-052c-5b78-81b1-946ea354c0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d80b98-baa2-48ea-9611-96e64d7cb950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d80b98-baa2-48ea-9611-96e64d7cb950.jpg?1",
             "name": "Honed Khopesh",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8255,7 +8255,7 @@
         },
         {
             "id": "9a23052b-af27-5cc8-a306-90c1f3ef2d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d20f0a-aa7c-4d40-acb2-2b86666afd53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d20f0a-aa7c-4d40-acb2-2b86666afd53.jpg?1",
             "name": "Kefnet's Monument",
             "text": "Blue creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, target creature an opponent controls doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -8285,7 +8285,7 @@
         },
         {
             "id": "b4610f0a-31f7-523e-bdac-234fdf0991f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f43dc6f-910c-42a1-b329-038e20dfb264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f43dc6f-910c-42a1-b329-038e20dfb264.jpg?1",
             "name": "Luxa River Shrine",
             "text": "{1}, {T}: You gain 1 life. Put a brick counter on Luxa River Shrine.\n{T}: You gain 2 life. Activate this ability only if there are three or more brick counters on Luxa River Shrine.",
             "colours": [],
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "e61404bb-0543-5100-bf0c-2b8b934fce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104503a6-bca5-48d7-88b1-424f98985d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104503a6-bca5-48d7-88b1-424f98985d75.jpg?1",
             "name": "Oketra's Monument",
             "text": "White creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, create a 1/1 white Warrior creature token with vigilance.",
             "colours": [],
@@ -8343,7 +8343,7 @@
         },
         {
             "id": "727daa7f-d3f5-5c92-8152-cfca01356242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fcc4a5-3ab0-4344-85af-d80aae293b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fcc4a5-3ab0-4344-85af-d80aae293b75.jpg?1",
             "name": "Oracle's Vault",
             "text": "{2}, {T}: Exile the top card of your library. Until end of turn, you may play that card. Put a brick counter on Oracle's Vault.\n{T}: Exile the top card of your library. Until end of turn, you may play that card without paying its mana cost. Activate this ability only if there are three or more brick counters on Oracle's Vault.",
             "colours": [],
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "145da165-5178-5d38-ad6e-52f713c0c208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef335b2-8086-4b29-b8e3-47de6faa1334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef335b2-8086-4b29-b8e3-47de6faa1334.jpg?1",
             "name": "Pyramid of the Pantheon",
             "text": "{2}, {T}: Add one mana of any color to your mana pool. Put a brick counter on Pyramid of the Pantheon.\n{T}: Add three mana of any one color to your mana pool. Activate this ability only if there are three or more brick counters on Pyramid of the Pantheon.",
             "colours": [],
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "4f84c687-636f-5423-9cec-a22c866e2338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d2260a-e001-4d03-a108-759591e4d233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d2260a-e001-4d03-a108-759591e4d233.jpg?1",
             "name": "Rhonas's Monument",
             "text": "Green creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, target creature you control gets +2/+2 and gains trample until end of turn.",
             "colours": [],
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "d236a672-fbf8-5cd3-9efa-1c1d6bcd5e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe402b8e-f966-4971-90a5-950d8cff5025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe402b8e-f966-4971-90a5-950d8cff5025.jpg?1",
             "name": "Throne of the God-Pharaoh",
             "text": "At the beginning of your end step, each opponent loses life equal to the number of tapped creatures you control.",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "f3ac3d25-7d7d-59c2-b6c1-6c6c86186881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30efc831-3673-4bc1-8a25-150c0349253a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30efc831-3673-4bc1-8a25-150c0349253a.jpg?1",
             "name": "Watchers of the Dead",
             "text": "Exile Watchers of the Dead: Each opponent chooses two cards in his or her graveyard and exiles the rest.",
             "colours": [],
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "710b7eae-b659-5282-acfd-298ea3f6d199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb273d9-466d-416d-b27d-d1bc8a249076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb273d9-466d-416d-b27d-d1bc8a249076.jpg?1",
             "name": "Canyon Slough",
             "text": "({T}: Add {B} or {R} to your mana pool.)\nCanyon Slough enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "01b5693f-bc43-5fa2-91ba-30cae4128c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778739db-4431-4e58-91de-d2619aeef3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778739db-4431-4e58-91de-d2619aeef3ce.jpg?1",
             "name": "Cascading Cataracts",
             "text": "Indestructible\n{T}: Add {C} to your mana pool.\n{5}, {T}: Add five mana in any combination of colors to your mana pool.",
             "colours": [],
@@ -8552,7 +8552,7 @@
         },
         {
             "id": "b5659a6b-4d05-5d07-a6d4-e00698237ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41713e82-c3d3-4c2f-b075-f684cbd68ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41713e82-c3d3-4c2f-b075-f684cbd68ce8.jpg?1",
             "name": "Cradle of the Accursed",
             "text": "{T}: Add {C} to your mana pool.\n{3}, {T}, Sacrifice Cradle of the Accursed: Create a 2/2 black Zombie creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "86a3c113-a3f2-527a-9fe7-bcfb46bf0f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b39e1c7-b175-462e-83ab-dd67abec6bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b39e1c7-b175-462e-83ab-dd67abec6bfb.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "7d9b629b-d35f-53dc-a09c-199704886f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae703d94-6f1f-463b-ab25-1b3f462e7e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae703d94-6f1f-463b-ab25-1b3f462e7e78.jpg?1",
             "name": "Fetid Pools",
             "text": "({T}: Add {U} or {B} to your mana pool.)\nFetid Pools enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "224a7bc8-d2c2-5980-ae70-b79c5b86ca63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fcc939-6a31-4fb3-abe7-7663b85868dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fcc939-6a31-4fb3-abe7-7663b85868dd.jpg?1",
             "name": "Grasping Dunes",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Grasping Dunes: Put a -1/-1 counter on target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -8674,7 +8674,7 @@
         },
         {
             "id": "84cd6d95-c30b-5475-bfe3-72a07b7e603b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d87fcc0-cef5-4410-adf1-91c5f50c1d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d87fcc0-cef5-4410-adf1-91c5f50c1d01.jpg?1",
             "name": "Irrigated Farmland",
             "text": "({T}: Add {W} or {U} to your mana pool.)\nIrrigated Farmland enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8708,7 +8708,7 @@
         },
         {
             "id": "3336a1a3-42a5-5bf2-b42c-f75ddae5b15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b373131-2a1d-4710-8a11-c1b366a174d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b373131-2a1d-4710-8a11-c1b366a174d4.jpg?1",
             "name": "Painted Bluffs",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "79924f36-d5e8-5747-bd4f-7197ca31939a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb541aa-3bf6-41f3-89e5-9c6c56ea210a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccb541aa-3bf6-41f3-89e5-9c6c56ea210a.jpg?1",
             "name": "Scattered Groves",
             "text": "({T}: Add {G} or {W} to your mana pool.)\nScattered Groves enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8772,7 +8772,7 @@
         },
         {
             "id": "bfea94a8-75a9-5de5-95c0-d41c6f93236c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23cd764-3f5c-4c93-ba83-e5ff397003a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23cd764-3f5c-4c93-ba83-e5ff397003a2.jpg?1",
             "name": "Sheltered Thicket",
             "text": "({T}: Add {R} or {G} to your mana pool.)\nSheltered Thicket enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "848879b0-667b-5c83-849f-82cda8ed76e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405434c7-9206-45b7-af0f-d59aae294d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405434c7-9206-45b7-af0f-d59aae294d39.jpg?1",
             "name": "Sunscorched Desert",
             "text": "When Sunscorched Desert enters the battlefield, it deals 1 damage to target player.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "5f55da7f-dea7-5eea-b801-47453ee40198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7191d23-b68f-406b-8c28-8dadbaef6562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7191d23-b68f-406b-8c28-8dadbaef6562.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "af070e79-f9a2-5fb0-ae31-a11740c9b6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec6fced-62bb-4a99-9ea1-374056b5781b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec6fced-62bb-4a99-9ea1-374056b5781b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "b243d6b5-d619-54d1-94de-fe3224f57d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7c997-e520-4ff6-8b3b-705c2f12a9d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7c997-e520-4ff6-8b3b-705c2f12a9d4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8950,7 +8950,7 @@
         },
         {
             "id": "0bdf65c2-e1f7-5ceb-ac1c-743a6d8229f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3112990-3919-46b0-b927-14566c689a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3112990-3919-46b0-b927-14566c689a81.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "d7dd6951-74bd-5b71-92ab-469fcaae2712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fc9f7-21af-4416-abf5-6fcb4f543680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fc9f7-21af-4416-abf5-6fcb4f543680.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "db1660c3-22cc-556b-beed-189c96812159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0422da01-0252-4f3b-b2e5-9f5b2c0b94ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0422da01-0252-4f3b-b2e5-9f5b2c0b94ae.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9064,7 +9064,7 @@
         },
         {
             "id": "7a3f9218-4d70-599c-bb9d-d8e160be77e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba708fff-a428-4783-b405-4c7e6ea72fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba708fff-a428-4783-b405-4c7e6ea72fd3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "757d2a8a-cc33-5b25-a8d9-e602e07925d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4734a7c-67d0-4124-b76e-d53634557c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4734a7c-67d0-4124-b76e-d53634557c7d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9140,7 +9140,7 @@
         },
         {
             "id": "1e9e330f-9cca-5b29-85c7-cae1bc03aa5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559fc49-54f3-426f-b2d2-525790a249a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559fc49-54f3-426f-b2d2-525790a249a5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9178,7 +9178,7 @@
         },
         {
             "id": "bba24995-7ce5-596d-a6da-3043284df24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177da89-184b-4ecd-ae08-a074ac4862e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177da89-184b-4ecd-ae08-a074ac4862e1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "c5242ee8-096a-563f-a6b5-7a4612d96a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61c6c6c-319f-4636-8482-26b6909f7b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61c6c6c-319f-4636-8482-26b6909f7b8e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9254,7 +9254,7 @@
         },
         {
             "id": "c895c3a3-9096-5aa1-a683-95fed4a2766e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dbed02-6871-4830-8308-9f2f48e6730d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dbed02-6871-4830-8308-9f2f48e6730d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9292,7 +9292,7 @@
         },
         {
             "id": "ba2e12fe-c9bc-5392-91ca-6aec6f468cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6566108-ccc7-4fac-b935-1eb212889543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6566108-ccc7-4fac-b935-1eb212889543.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9330,7 +9330,7 @@
         },
         {
             "id": "5ed035a2-6b02-53a6-86f7-84459c3a512e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be28351-642c-4ed1-9041-e99ecb79cba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be28351-642c-4ed1-9041-e99ecb79cba8.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9368,7 +9368,7 @@
         },
         {
             "id": "ceb6d29d-d752-55f6-9a66-40e0fbf21add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37827425-f304-43eb-979b-1ec5b923a2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37827425-f304-43eb-979b-1ec5b923a2b5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9406,7 +9406,7 @@
         },
         {
             "id": "bc2d3e38-a147-5d66-b251-d5ce17da922b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eced8a4-67ce-403c-a567-82ace69d1cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eced8a4-67ce-403c-a567-82ace69d1cf1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "897ffccd-d859-5d59-9ab8-359f5ab880e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb742de-57fa-49f5-977e-bee1b8186e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb742de-57fa-49f5-977e-bee1b8186e9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9482,7 +9482,7 @@
         },
         {
             "id": "6473a050-03c6-59e8-9c1d-550e3e858d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f4e594-01e5-40ae-903c-f55aad740de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f4e594-01e5-40ae-903c-f55aad740de0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9520,7 +9520,7 @@
         },
         {
             "id": "bdebae8c-28cc-51c9-88db-2874cfbda5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c94463-31e8-4a2e-b879-d096a27cc60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c94463-31e8-4a2e-b879-d096a27cc60e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9558,7 +9558,7 @@
         },
         {
             "id": "26710a14-b4d1-5da8-8e97-6546206e8ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3b0668-0a4c-489f-aa2b-4faa8ef3e429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3b0668-0a4c-489f-aa2b-4faa8ef3e429.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9596,7 +9596,7 @@
         },
         {
             "id": "003d9ecd-53bc-55c7-993f-26ec405f71e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c057ca8-9811-4dc3-9b0e-f9f69f752d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c057ca8-9811-4dc3-9b0e-f9f69f752d1d.jpg?1",
             "name": "Gideon, Martial Paragon",
             "text": "+2: Untap all creatures you control. Those creatures get +1/+1 until end of turn.\n0: Until end of turn, Gideon, Martial Paragon becomes a 5/5 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n\u221210: Creatures you control get +2/+2 until end of turn. Tap all creatures your opponents control.",
             "colours": [
@@ -9631,7 +9631,7 @@
         },
         {
             "id": "fffa4546-e7ac-5291-b878-2e66ea1b1dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ac220-058f-4212-ba8b-a389bb0528bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ac220-058f-4212-ba8b-a389bb0528bd.jpg?1",
             "name": "Companion of the Trials",
             "text": "Flying\n{1}{W}: Untap target creature. Activate this ability only if you control a Gideon planeswalker.",
             "colours": [
@@ -9665,7 +9665,7 @@
         },
         {
             "id": "c643b97e-6c04-5ad8-b12c-484d8c988b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b8c40-39ac-423f-b7da-845a16cd1b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b8c40-39ac-423f-b7da-845a16cd1b63.jpg?1",
             "name": "Gideon's Resolve",
             "text": "When Gideon's Resolve enters the battlefield, you may search your library and/or graveyard for a card named Gideon, Martial Paragon, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nCreatures you control get +1/+1.",
             "colours": [
@@ -9696,7 +9696,7 @@
         },
         {
             "id": "fa770156-9edf-5018-aa54-9c1b574acb48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42ba8bf-9fc1-4d57-9c80-42491d18d929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42ba8bf-9fc1-4d57-9c80-42491d18d929.jpg?1",
             "name": "Graceful Cat",
             "text": "Whenever Graceful Cat attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "2aa0d087-6996-56ac-98f7-95a0a5bc395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2280a5db-72be-4c13-8e15-8d40b7d9f9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2280a5db-72be-4c13-8e15-8d40b7d9f9e7.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -9759,7 +9759,7 @@
         },
         {
             "id": "4ea1e23e-5c15-5488-9ea9-20646c48eb89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac79d8f6-7c36-4eb9-8bda-3b813c634399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac79d8f6-7c36-4eb9-8bda-3b813c634399.jpg?1",
             "name": "Liliana, Death Wielder",
             "text": "+2: Put a -1/-1 counter on up to one target creature.\n\u22123: Destroy target creature with a -1/-1 counter on it.\n\u221210: Return all creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -9794,7 +9794,7 @@
         },
         {
             "id": "9e509550-4c0e-5a81-95ca-13c17617e9fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f31e96-bb66-4b28-b14a-426d1d5839a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f31e96-bb66-4b28-b14a-426d1d5839a6.jpg?1",
             "name": "Desiccated Naga",
             "text": "{3}{B}: Target opponent loses 2 life and you gain 2 life. Activate this ability only if you control a Liliana planeswalker.",
             "colours": [
@@ -9828,7 +9828,7 @@
         },
         {
             "id": "d07e8986-d359-5216-8273-3465f0c859c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cdf48e-e0d4-45ca-b48d-74ada54ba62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cdf48e-e0d4-45ca-b48d-74ada54ba62e.jpg?1",
             "name": "Liliana's Influence",
             "text": "Put a -1/-1 counter on each creature you don't control. You may search your library and/or graveyard for a card named Liliana, Death Wielder, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "2ef18e21-8b43-547c-b21f-da0b080f1078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a5267-eb90-43bc-bf92-fcfb06821bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a5267-eb90-43bc-bf92-fcfb06821bae.jpg?1",
             "name": "Tattered Mummy",
             "text": "When Tattered Mummy dies, each opponent loses 2 life.",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "939293e4-06aa-5902-a3e6-df3332dd2dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81435771-2f13-4e53-9a5f-4a4e4ad735ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81435771-2f13-4e53-9a5f-4a4e4ad735ac.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -9923,7 +9923,7 @@
         },
         {
             "id": "709b1a04-0ded-5b6b-8ed7-d027682c4241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12fa835-c13d-4d73-9d26-97bc2268e971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12fa835-c13d-4d73-9d26-97bc2268e971.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "e597d40a-20f0-5af6-ac4f-f994070a05f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7795db-c96a-4f94-bcc8-6977e38d0fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7795db-c96a-4f94-bcc8-6977e38d0fe2.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "edbe8c50-ff87-5895-81cb-bc344feb8c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b64bd5c-d014-4a5e-bb71-7cee8756ae8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b64bd5c-d014-4a5e-bb71-7cee8756ae8c.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -10013,7 +10013,7 @@
         },
         {
             "id": "7ececcea-605b-5cf1-8506-cb35c55a4ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745525ff-4afe-4a81-8c9d-5e6b9cca1eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745525ff-4afe-4a81-8c9d-5e6b9cca1eba.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -10043,7 +10043,7 @@
         },
         {
             "id": "7a1ef1af-fd2a-5b65-9b23-5f6dc776f306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e966e-cb51-461a-9089-25054dec57fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e966e-cb51-461a-9089-25054dec57fb.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -10073,7 +10073,7 @@
         },
         {
             "id": "9a9496e9-7aeb-52e7-ad13-6ceb234b2c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81ae262-fe8d-4c78-8604-711fb8d366d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81ae262-fe8d-4c78-8604-711fb8d366d8.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -10103,7 +10103,7 @@
         },
         {
             "id": "e91277c4-d0fc-58ee-a50f-4e9ace2c7dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6054534-a926-460e-8d3c-db8b576b1352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6054534-a926-460e-8d3c-db8b576b1352.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -10133,7 +10133,7 @@
         },
         {
             "id": "814fad14-2734-5fe1-a433-8cf34c83af59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff0f82-1326-479c-ba88-8cc85c56d883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff0f82-1326-479c-ba88-8cc85c56d883.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -10163,7 +10163,7 @@
         },
         {
             "id": "5d60c9c8-5f5a-58b1-9271-410bd0879b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1786cb3-6f38-4f10-b5f1-8feb20e3baaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1786cb3-6f38-4f10-b5f1-8feb20e3baaf.jpg?1",
             "name": "Angel of Sanctions",
             "text": "",
             "colours": [
@@ -10198,7 +10198,7 @@
         },
         {
             "id": "ffea7959-8128-5703-b08d-0456bc5e59e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98956e73-04e4-4d7f-bda5-cfa78eb71350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98956e73-04e4-4d7f-bda5-cfa78eb71350.jpg?1",
             "name": "Anointer Priest",
             "text": "",
             "colours": [
@@ -10234,7 +10234,7 @@
         },
         {
             "id": "766616ef-47e2-5ca9-90d6-c30f1cfaab20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3814e3-7ad2-4c87-8630-ab56e13b6ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3814e3-7ad2-4c87-8630-ab56e13b6ee9.jpg?1",
             "name": "Aven Initiate",
             "text": "",
             "colours": [
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "7993f19a-e1ab-55be-a5be-82cfbd6dceac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f339c6-2c0d-4631-849b-44d4360b5131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f339c6-2c0d-4631-849b-44d4360b5131.jpg?1",
             "name": "Aven Wind Guide",
             "text": "",
             "colours": [
@@ -10306,7 +10306,7 @@
         },
         {
             "id": "7de9db3f-95d8-5e17-bba0-864b205da459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d97a02-9187-4dbc-a511-2a15ca840cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d97a02-9187-4dbc-a511-2a15ca840cda.jpg?1",
             "name": "Glyph Keeper",
             "text": "",
             "colours": [
@@ -10341,7 +10341,7 @@
         },
         {
             "id": "d221c39f-0f44-5d8b-a246-e5bb061b466a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e534d68-a97f-4ae1-b202-31c7a5366b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e534d68-a97f-4ae1-b202-31c7a5366b58.jpg?1",
             "name": "Heart-Piercer Manticore",
             "text": "",
             "colours": [
@@ -10376,7 +10376,7 @@
         },
         {
             "id": "ec0ab5d6-95e0-5d59-ac3f-6d6f69ab109e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365ffff-b171-4275-9fdb-e622f8456858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365ffff-b171-4275-9fdb-e622f8456858.jpg?1",
             "name": "Honored Hydra",
             "text": "",
             "colours": [
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "95acee24-bd84-578d-9bdb-6740843423e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754eeff5-b495-4aa5-94ce-ff20216c952b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754eeff5-b495-4aa5-94ce-ff20216c952b.jpg?1",
             "name": "Labyrinth Guardian",
             "text": "",
             "colours": [
@@ -10448,7 +10448,7 @@
         },
         {
             "id": "5769a877-f6e1-5479-8679-44e2a655b3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5fedcd-e5d5-4250-b64e-a04772cb9025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5fedcd-e5d5-4250-b64e-a04772cb9025.jpg?1",
             "name": "Oketra's Attendant",
             "text": "",
             "colours": [
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "455416fe-e5a6-57bd-8f3b-f0d24770cff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea5f68-3818-43d3-9b7b-c344305a8423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea5f68-3818-43d3-9b7b-c344305a8423.jpg?1",
             "name": "Sacred Cat",
             "text": "",
             "colours": [
@@ -10519,7 +10519,7 @@
         },
         {
             "id": "d21fa0d2-7baa-5abc-b7f7-866f7c71197c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e835c-0f39-4fd1-a839-125bee0c9dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e835c-0f39-4fd1-a839-125bee0c9dbc.jpg?1",
             "name": "Tah-Crop Skirmisher",
             "text": "",
             "colours": [
@@ -10555,7 +10555,7 @@
         },
         {
             "id": "6041f40e-4280-5861-916b-0e93b2f4a80d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6201e6-7dcd-40b1-97aa-fd9c860cea97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6201e6-7dcd-40b1-97aa-fd9c860cea97.jpg?1",
             "name": "Temmet, Vizier of Naktamun",
             "text": "",
             "colours": [
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "7636b4d6-167c-599c-bbd5-c9902a8264b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c770d91c-b7d1-44ef-922d-128cb3faef08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c770d91c-b7d1-44ef-922d-128cb3faef08.jpg?1",
             "name": "Trueheart Duelist",
             "text": "",
             "colours": [
@@ -10627,7 +10627,7 @@
         },
         {
             "id": "15035eeb-889c-512f-9b16-5532d151b56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab720d-40fc-4315-bc8d-c7073cea588b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab720d-40fc-4315-bc8d-c7073cea588b.jpg?1",
             "name": "Unwavering Initiate",
             "text": "",
             "colours": [
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "d2f89cc8-d965-508e-b98d-c2bb51b5d8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39520c16-1f4b-4f15-aeb4-53c91e8ecfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39520c16-1f4b-4f15-aeb4-53c91e8ecfcc.jpg?1",
             "name": "Vizier of Many Faces",
             "text": "",
             "colours": [
@@ -10699,7 +10699,7 @@
         },
         {
             "id": "909fb00f-9bf6-563a-9dab-1a1ec252d97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -10733,7 +10733,7 @@
         },
         {
             "id": "9100049f-4585-5c92-8a35-98ae8a4effb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1446ed-f114-421d-bb60-9aeb655e5adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1446ed-f114-421d-bb60-9aeb655e5adb.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "2311a216-8dd8-52b4-b96c-45bc5579862c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65844e72-aa84-483f-b07e-9e34e798aaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65844e72-aa84-483f-b07e-9e34e798aaec.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "161588d4-baa0-5561-ad4b-a1107639c5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242c381e-df58-4365-a68c-add1127a83cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242c381e-df58-4365-a68c-add1127a83cc.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -10835,7 +10835,7 @@
         },
         {
             "id": "95f36818-6a89-5a1e-9821-03016d94f604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -10869,7 +10869,7 @@
         },
         {
             "id": "f46a6204-28fa-5704-8b0f-f13a2f8e23ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7ecd1-c70e-467c-a9ea-99c2668c3405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7ecd1-c70e-467c-a9ea-99c2668c3405.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -10903,7 +10903,7 @@
         },
         {
             "id": "2851fca7-1dd8-52e3-81ea-2ac617521b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00.jpg?1",
             "name": "Hippo",
             "text": "",
             "colours": [
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "cf497fe2-7f92-5fcf-bd9f-9e0831988e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8539-8d21-4da1-8410-d4354078390f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8539-8d21-4da1-8410-d4354078390f.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -10971,7 +10971,7 @@
         },
         {
             "id": "59e3bd40-8468-5afc-b33f-8464378c862a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c01a7-6399-496b-a5a3-8be45475ce33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c01a7-6399-496b-a5a3-8be45475ce33.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -11005,7 +11005,7 @@
         },
         {
             "id": "84f5dfde-13b4-5244-9a34-938d9e470857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbebd89c-0b29-44c7-bc99-53dd4b836520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbebd89c-0b29-44c7-bc99-53dd4b836520.jpg?1",
             "name": "Gideon of the Trials Emblem",
             "text": "",
             "colours": [],
@@ -11034,7 +11034,7 @@
         },
         {
             "id": "b80a2d58-5c15-5c6f-89f4-e2635d621dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b4bfd-c5c1-4d0e-b7ff-7615245f9df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b4bfd-c5c1-4d0e-b7ff-7615245f9df8.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],
@@ -11061,7 +11061,7 @@
         },
         {
             "id": "157abc21-4a8e-5712-95df-152191e7adf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca931b5-6e12-468c-a1d1-e01363b872b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca931b5-6e12-468c-a1d1-e01363b872b1.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ALA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ALA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3550ed10-1448-56a9-9340-39560975af48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc045-b938-4321-aec3-51685cbbaa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc045-b938-4321-aec3-51685cbbaa52.jpg?1",
             "name": "Akrasan Squire",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b0c72592-e426-599d-8757-f86a638fdc24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36197ed0-4382-4de3-8359-73cb74edc78b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36197ed0-4382-4de3-8359-73cb74edc78b.jpg?1",
             "name": "Angel's Herald",
             "text": "{2}{W}, {T}, Sacrifice a green creature, a white creature, and a blue creature: Search your library for a card named Empyrial Archangel and put it into play. Then shuffle your library.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "a4c8a4d2-d052-5cbd-a238-3d74b03bf91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b9071-7dde-4128-8b18-1d7b07904638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b9071-7dde-4128-8b18-1d7b07904638.jpg?1",
             "name": "Angelic Benediction",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may tap target creature.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "3cf60faa-c154-5a9d-8980-0fbfa23a1fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0832e87f-afef-41a5-ba36-3eaf65551576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0832e87f-afef-41a5-ba36-3eaf65551576.jpg?1",
             "name": "Angelsong",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "2ae2a6e1-b9c6-55bc-9d79-bf5b2b776df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c597b1d-d8b5-4922-a3f2-1f173a73ea2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c597b1d-d8b5-4922-a3f2-1f173a73ea2a.jpg?1",
             "name": "Bant Battlemage",
             "text": "{G}, {T}: Target creature gains trample until end of turn.\n{U}, {T}: Target creature gains flying until end of turn.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "0d381488-9d11-5a96-a29a-1630984cab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1142-3ba8-4915-9541-757e59ed046c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1142-3ba8-4915-9541-757e59ed046c.jpg?1",
             "name": "Battlegrace Angel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains lifelink until end of turn.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "cadc1cf1-c97c-5731-a796-275277a0bfca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e54ce5-b496-4669-af2b-04a41ba20423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e54ce5-b496-4669-af2b-04a41ba20423.jpg?1",
             "name": "Cradle of Vitality",
             "text": "Whenever you gain life, you may pay {1}{W}. If you do, put a +1/+1 counter on target creature for each 1 life you gained.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "b409c487-3607-5611-b979-edca1be89ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cf0771-10d6-427a-b4e5-3e1d4db14667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cf0771-10d6-427a-b4e5-3e1d4db14667.jpg?1",
             "name": "Dispeller's Capsule",
             "text": "{2}{W}, {T}, Sacrifice Dispeller's Capsule: Destroy target artifact or enchantment.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "b7e1c806-feff-58ef-8fb9-d5178187a05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c52e52-2b1c-4ca8-ab6d-20d97a342704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c52e52-2b1c-4ca8-ab6d-20d97a342704.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "+1: Put a 1/1 white Soldier creature token into play.\n+1: Target creature gets +3/+3 and gains flying until end of turn.\n-8: For the rest of the game, artifacts, creatures, enchantments, and lands you control are indestructible.",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "b51d1cd4-98e2-57ea-8247-b36cedf72b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebe7a8-b982-4be4-83ca-3594e8f606b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aebe7a8-b982-4be4-83ca-3594e8f606b4.jpg?1",
             "name": "Ethersworn Canonist",
             "text": "Each player who has played a nonartifact spell this turn can't play additional nonartifact spells.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "a4759480-4519-5613-8a47-2a0b6509d992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe080bc-e642-4fce-b4ee-bbe25d735673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe080bc-e642-4fce-b4ee-bbe25d735673.jpg?1",
             "name": "Excommunicate",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "fe4d0be3-1d63-5a13-933b-e0dfda6f09f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f718030-cc41-4e0d-a1ca-a33f577dc1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f718030-cc41-4e0d-a1ca-a33f577dc1fb.jpg?1",
             "name": "Guardians of Akrasa",
             "text": "Defender\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "41ed29f2-535c-5207-b7bf-0004351d8e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5343e6f2-7db7-4731-8e1b-70bf74316a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5343e6f2-7db7-4731-8e1b-70bf74316a79.jpg?1",
             "name": "Gustrider Exuberant",
             "text": "Flying\nSacrifice Gustrider Exuberant: Creatures you control with power 5 or greater gain flying until end of turn.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "4235ea07-62c9-542b-97b2-839b4649cd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c64bc-ba0c-4bab-9329-54805f4efa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c64bc-ba0c-4bab-9329-54805f4efa8a.jpg?1",
             "name": "Invincible Hymn",
             "text": "Count the number of cards in your library. Your life total becomes that number.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "0e0b0712-9a36-5fe8-b751-02da8a00c454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d56e2bf-1937-42c1-8f61-1fd93e84cef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d56e2bf-1937-42c1-8f61-1fd93e84cef7.jpg?1",
             "name": "Knight of the Skyward Eye",
             "text": "{3}{G}: Knight of the Skyward Eye gets +3/+3 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "9d97de87-334b-5b8b-98a6-ffb895980605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c6354-4dab-45c9-a1a6-57bd16f16e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c6354-4dab-45c9-a1a6-57bd16f16e30.jpg?1",
             "name": "Knight of the White Orchid",
             "text": "First strike\nWhen Knight of the White Orchid comes into play, if an opponent controls more lands than you, you may search your library for a Plains card, put it into play, then shuffle your library.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "12083d67-aa70-5e95-bb4a-ecc1fd5f2319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg?1",
             "name": "Knight-Captain of Eos",
             "text": "When Knight-Captain of Eos comes into play, put two 1/1 white Soldier creature tokens into play.\n{W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "ea409957-eaf7-5f77-aeed-d03fe0a08344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76e9580-9154-476b-923f-b23bf55db026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76e9580-9154-476b-923f-b23bf55db026.jpg?1",
             "name": "Marble Chalice",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "2431356a-11c8-5cb4-b1bf-0153da269162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad9f9d5-62c1-4dae-a2c8-5552210a70a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad9f9d5-62c1-4dae-a2c8-5552210a70a4.jpg?1",
             "name": "Metallurgeon",
             "text": "{W}, {T}: Regenerate target artifact.",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "a89e24d5-04c8-51da-a9a8-834872bdd323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895c270d-84d8-4c7f-9df3-5a595e113dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895c270d-84d8-4c7f-9df3-5a595e113dd7.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring comes into play, remove another target nonland permanent from the game.\nWhen Oblivion Ring leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -685,7 +685,7 @@
         },
         {
             "id": "6811dccc-8160-5a7d-9572-ec55f669c142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30ee26-5f78-4ac2-9105-1baa9ece8a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30ee26-5f78-4ac2-9105-1baa9ece8a21.jpg?1",
             "name": "Ranger of Eos",
             "text": "When Ranger of Eos comes into play, you may search your library for up to two creature cards with converted mana cost 1 or less, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "8327aaa4-bba0-52b8-b302-6140e2856792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3b0908-5408-41fd-8e69-2bc785e19304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3b0908-5408-41fd-8e69-2bc785e19304.jpg?1",
             "name": "Resounding Silence",
             "text": "Remove target attacking creature from the game.\nCycling {5}{G}{W}{U} ({5}{G}{W}{U}, Discard this card: Draw a card.)\nWhen you cycle Resounding Silence, remove up to two target attacking creatures from the game.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "900ce6bf-a910-5a64-9443-3a5808a09683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab62812-acc5-4b4b-97d3-106e399d69da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab62812-acc5-4b4b-97d3-106e399d69da.jpg?1",
             "name": "Rockcaster Platoon",
             "text": "{4}{G}: Rockcaster Platoon deals 2 damage to each creature with flying and each player.",
             "colours": [
@@ -791,7 +791,7 @@
         },
         {
             "id": "0ff583cd-f479-5cbd-819d-9cb78212310d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da1a2d5-d1fe-4aa2-aa83-64d6c269f7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da1a2d5-d1fe-4aa2-aa83-64d6c269f7bc.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle comes into play, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -826,7 +826,7 @@
         },
         {
             "id": "370405b0-e132-5b82-a8a4-fae2d9145569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8993b57-3060-45ca-80ed-3366784ec61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8993b57-3060-45ca-80ed-3366784ec61d.jpg?1",
             "name": "Scourglass",
             "text": "{T}, Sacrifice Scourglass: Destroy all permanents except for artifacts and lands. Play this ability only during your upkeep.",
             "colours": [
@@ -858,7 +858,7 @@
         },
         {
             "id": "26ebb1c0-3a17-52db-b6f6-26c83295ed14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07e2d4c-a33b-42b1-9576-2269d137a868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07e2d4c-a33b-42b1-9576-2269d137a868.jpg?1",
             "name": "Sighted-Caste Sorcerer",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{U}: Sighted-Caste Sorcerer gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -894,7 +894,7 @@
         },
         {
             "id": "ad021abd-8583-508c-afb1-cd1edb429edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b22520d-c495-4528-9b24-4aa19e046a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b22520d-c495-4528-9b24-4aa19e046a9e.jpg?1",
             "name": "Sigiled Paladin",
             "text": "First strike\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "f9a6edc0-08be-58c1-be48-0ef27881d266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2e8701-f2c3-4cc1-ac81-ba1987d80fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2e8701-f2c3-4cc1-ac81-ba1987d80fec.jpg?1",
             "name": "Soul's Grace",
             "text": "You gain life equal to target creature's power.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "ef56081d-4c94-5ec4-b4fa-a78380c7abf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44447e-09d1-450f-907f-42f79b004fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44447e-09d1-450f-907f-42f79b004fe7.jpg?1",
             "name": "Sunseed Nurturer",
             "text": "At the end of your turn, if you control a creature with power 5 or greater, you may gain 2 life.\n{T}: Add {1} to your mana pool.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "dbb243d7-7ce3-5ec3-a374-e0432a320fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198363f2-1a19-4954-b527-6d10ac277719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198363f2-1a19-4954-b527-6d10ac277719.jpg?1",
             "name": "Welkin Guide",
             "text": "Flying\nWhen Welkin Guide comes into play, target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "842b9905-8c3b-570b-b67a-4217a8ac0fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbbc7dc-efdf-46e8-bf19-0daa4034f6ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbbc7dc-efdf-46e8-bf19-0daa4034f6ec.jpg?1",
             "name": "Yoked Plowbeast",
             "text": "Cycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "a8a16a53-46c3-5d63-84e7-9a1bb4939036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0206c951-e38f-43ae-b4d2-0c71b6ccf8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0206c951-e38f-43ae-b4d2-0c71b6ccf8b1.jpg?1",
             "name": "Call to Heel",
             "text": "Return target creature to its owner's hand. Its controller draws a card.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "e4d7cd3c-7fbe-5057-9159-38c3a5f5ad79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479f56c2-8256-4325-909a-bf460505dbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479f56c2-8256-4325-909a-bf460505dbc5.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "4fe11754-cb6c-52e8-8257-7b9c629ce724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e63626d-f55c-4155-9712-511f591c0614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e63626d-f55c-4155-9712-511f591c0614.jpg?1",
             "name": "Cathartic Adept",
             "text": "{T}: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "58053228-c880-5db0-a2ed-a14ec32971d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f71ec76-47e1-4f55-bc57-e7b1c88baedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f71ec76-47e1-4f55-bc57-e7b1c88baedd.jpg?1",
             "name": "Cloudheath Drake",
             "text": "Flying\n{1}{W}: Cloudheath Drake gains vigilance until end of turn.",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "52bec705-35ab-577d-9b98-35b24428e4cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b820c-fd07-4e1f-9451-da9267347acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b820c-fd07-4e1f-9451-da9267347acd.jpg?1",
             "name": "Coma Veil",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -1235,7 +1235,7 @@
         },
         {
             "id": "0ce1ef37-cbe4-56c4-abcc-9cecfa8ca338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ae12ff-8039-4aac-aa50-f879376888a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ae12ff-8039-4aac-aa50-f879376888a1.jpg?1",
             "name": "Courier's Capsule",
             "text": "{1}{U}, {T}, Sacrifice Courier's Capsule: Draw two cards.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "55330417-236a-5e31-9043-c3a39dc38ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef9a534-8938-4f73-aa62-dd4d81a18cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef9a534-8938-4f73-aa62-dd4d81a18cc1.jpg?1",
             "name": "Covenant of Minds",
             "text": "Reveal the top three cards of your library. Target opponent may choose to put those cards into your hand. If he or she doesn't, put those cards into your graveyard and draw five cards.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "28ad9087-964c-5883-9fb3-7fc172b0e7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c1ff65-8ad5-42e0-9e4c-1caf83ab86e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c1ff65-8ad5-42e0-9e4c-1caf83ab86e0.jpg?1",
             "name": "Dawnray Archer",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{W}, {T}: Dawnray Archer deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "613bf8de-dcc6-5668-8813-19cf7e654ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac0076-8bd5-4fe2-bac8-fd102688fdcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac0076-8bd5-4fe2-bac8-fd102688fdcb.jpg?1",
             "name": "Esper Battlemage",
             "text": "{W}, {T}: Prevent the next 2 damage that would be dealt to you this turn.\n{B}, {T}: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -1373,7 +1373,7 @@
         },
         {
             "id": "6e513830-1f48-5b13-b660-8e4780e3d755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60731c6-7a25-4f2b-8ed1-2469a2d300c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60731c6-7a25-4f2b-8ed1-2469a2d300c6.jpg?1",
             "name": "Etherium Astrolabe",
             "text": "Flash\n{B}, {T}, Sacrifice an artifact: Draw a card.",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "f88c3bcd-18a0-567b-baf1-c65eb40c2600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d050f2d-bd65-4ab9-9ea6-9deba91b2792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d050f2d-bd65-4ab9-9ea6-9deba91b2792.jpg?1",
             "name": "Etherium Sculptor",
             "text": "Artifact spells you play cost {1} less to play.",
             "colours": [
@@ -1442,7 +1442,7 @@
         },
         {
             "id": "cdcf6faa-e84d-5e45-9b79-330a920796e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4becff-8280-4e29-a370-bf82fb6734d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4becff-8280-4e29-a370-bf82fb6734d5.jpg?1",
             "name": "Fatestitcher",
             "text": "{T}: You may tap or untap another target permanent.\nUnearth {U} ({U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "b94975e4-7252-5bd7-9cd7-a09f403487ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08790aaf-0142-4b20-89cf-cdaffeea4582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08790aaf-0142-4b20-89cf-cdaffeea4582.jpg?1",
             "name": "Filigree Sages",
             "text": "{2}{U}: Untap target artifact.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "d1cf4186-5ccc-58ef-9b28-fa070e3bf39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbadf982-f22e-4f4f-b5c9-ac387f25c15f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbadf982-f22e-4f4f-b5c9-ac387f25c15f.jpg?1",
             "name": "Gather Specimens",
             "text": "If a creature would come into play under an opponent's control this turn, it comes into play under your control instead.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "a08108e1-4de6-5c76-ae28-faa8d9f9fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55b1b92-575e-4b6f-9179-21d0bc1acd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55b1b92-575e-4b6f-9179-21d0bc1acd11.jpg?1",
             "name": "Jhessian Lookout",
             "text": "",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "a20e71ad-3bad-5d9f-9253-2707cc6d8d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150cf865-79e2-4f74-a872-44e1e5bc73c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150cf865-79e2-4f74-a872-44e1e5bc73c4.jpg?1",
             "name": "Kathari Screecher",
             "text": "Flying\nUnearth {2}{U} ({2}{U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "ca966e80-295a-5c38-8990-56154d5bab4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e04b01-ba98-4b69-976e-9ab8be3b5f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e04b01-ba98-4b69-976e-9ab8be3b5f7a.jpg?1",
             "name": "Kederekt Leviathan",
             "text": "When Kederekt Leviathan comes into play, return all other nonland permanents to their owners' hands.\nUnearth {6}{U} ({6}{U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "71bda905-471b-56e5-83e7-06e8a3246c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322cdf67-5b36-43f9-99b3-f0e24d423314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322cdf67-5b36-43f9-99b3-f0e24d423314.jpg?1",
             "name": "Master of Etherium",
             "text": "Master of Etherium's power and toughness are each equal to the number of artifacts you control.\nOther artifact creatures you control get +1/+1.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "89a7c985-3b15-50e6-8318-a6d082736b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fcee4c-58f4-43c6-832b-ca04ded704c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fcee4c-58f4-43c6-832b-ca04ded704c7.jpg?1",
             "name": "Memory Erosion",
             "text": "Whenever an opponent plays a spell, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "d38a31c2-c280-5582-b491-9bebe9a2a2ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c84e9f-ccbb-4fbc-98e1-4072968a1f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c84e9f-ccbb-4fbc-98e1-4072968a1f8a.jpg?1",
             "name": "Mindlock Orb",
             "text": "Players can't search libraries.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "35009170-a07b-567f-8961-c42775deea39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b681c8-6d20-4e43-95f8-e83d34626145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b681c8-6d20-4e43-95f8-e83d34626145.jpg?1",
             "name": "Outrider of Jhess",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "04e2ad23-644b-50cc-86b3-f7c756ed3109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273e2198-5549-4e82-8580-8769284d729d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273e2198-5549-4e82-8580-8769284d729d.jpg?1",
             "name": "Protomatter Powder",
             "text": "{4}{W}, {T}, Sacrifice Protomatter Powder: Return target artifact card from your graveyard to play.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "a0ec676d-e3c4-5039-8fd1-fd4bdc02edb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eca679-076d-42f0-9ec0-b8116a94e373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eca679-076d-42f0-9ec0-b8116a94e373.jpg?1",
             "name": "Resounding Wave",
             "text": "Return target permanent to its owner's hand.\nCycling {5}{W}{U}{B} ({5}{W}{U}{B}, Discard this card: Draw a card.)\nWhen you cycle Resounding Wave, return two target permanents to their owners' hands.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "5c494767-64be-5eeb-8619-44962c19706a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1722d394-ef72-4265-bc5b-eed7b91f5cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1722d394-ef72-4265-bc5b-eed7b91f5cb4.jpg?1",
             "name": "Sharding Sphinx",
             "text": "Flying\nWhenever an artifact creature you control deals combat damage to a player, you may put a 1/1 blue Thopter artifact creature token with flying into play.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "a1e35fb7-0614-5790-8605-304cecdf6811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ac7c8-8e01-4f80-a3fa-d533cb594d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ac7c8-8e01-4f80-a3fa-d533cb594d7c.jpg?1",
             "name": "Skill Borrower",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is an artifact or creature card, Skill Borrower has all activated abilities of that card. (If any of the abilities use that card's name, use this creature's name instead.)",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "4cebcfeb-1ebc-58ad-8668-ce25ea9203b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6870203-ece9-4fe0-912b-2dcf685f3eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6870203-ece9-4fe0-912b-2dcf685f3eb0.jpg?1",
             "name": "Spell Snip",
             "text": "Counter target spell unless its controller pays {1}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "5217edb4-01b9-5599-86cf-b9d8bbe1ccca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7e2501-2d36-41eb-a77a-747b62affc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7e2501-2d36-41eb-a77a-747b62affc09.jpg?1",
             "name": "Sphinx's Herald",
             "text": "{2}{U}, {T}, Sacrifice a white creature, a blue creature, and a black creature: Search your library for a card named Sphinx Sovereign and put it into play. Then shuffle your library.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "8198e8f0-60b2-5da7-bae9-c3ecf9d8ce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b02044-f3b4-425c-8e6c-697fff2c4ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b02044-f3b4-425c-8e6c-697fff2c4ef7.jpg?1",
             "name": "Steelclad Serpent",
             "text": "Steelclad Serpent can't attack unless you control another artifact.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "0c9c632a-0611-5bdb-931b-6524c02d252b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b214b6f-4734-4200-8467-92d7e3469b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b214b6f-4734-4200-8467-92d7e3469b5d.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "+1: Untap up to two target artifacts.\n-X: Search your library for an artifact card with converted mana cost X or less and put it into play. Then shuffle your library.\n-5: Artifacts you control become 5/5 artifact creatures until end of turn.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "f1889b36-2576-571f-bab9-a1e7728ffbdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ff8324-42b8-4eeb-8d0b-ea679c984933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ff8324-42b8-4eeb-8d0b-ea679c984933.jpg?1",
             "name": "Tortoise Formation",
             "text": "Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "f1711ec3-674b-5ae2-b5b6-ab151e2ec9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0198220-073f-4479-a1c4-1bd626891e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0198220-073f-4479-a1c4-1bd626891e28.jpg?1",
             "name": "Vectis Silencers",
             "text": "{2}{B}: Vectis Silencers gains deathtouch until end of turn. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "6deaff86-d4d7-5002-8c5e-5fc6d8365902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4ce4a1-65e3-4b40-be35-8fc55a968ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4ce4a1-65e3-4b40-be35-8fc55a968ec8.jpg?1",
             "name": "Ad Nauseam",
             "text": "Reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost. You may repeat this process any number of times.",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "851b7f1c-b7e6-5fcc-9348-ef4d7180a227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg?1",
             "name": "Archdemon of Unx",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a non-Zombie creature, then put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "e3578338-48ea-5f84-bf6e-314d18fd61b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef85030-d591-407d-8045-c595326dd6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef85030-d591-407d-8045-c595326dd6fa.jpg?1",
             "name": "Banewasp Affliction",
             "text": "Enchant creature\nWhen enchanted creature is put into a graveyard, that creature's controller loses life equal to its toughness.",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "2ba9fa75-10aa-55fa-a606-5f6786036313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f42bdeb-5a51-4303-96d8-9722f95d2905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f42bdeb-5a51-4303-96d8-9722f95d2905.jpg?1",
             "name": "Blister Beetle",
             "text": "When Blister Beetle comes into play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "6c15935d-d44f-5920-a681-4ca14f5a0560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a4b3a3-b7ae-4210-8037-098fdf5808d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a4b3a3-b7ae-4210-8037-098fdf5808d0.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to play Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "01a122bf-ae5d-5c8b-ac72-e2b216a4f1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feecfe75-ca1e-4e89-af2f-0e4ed2df1ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feecfe75-ca1e-4e89-af2f-0e4ed2df1ead.jpg?1",
             "name": "Corpse Connoisseur",
             "text": "When Corpse Connoisseur comes into play, you may search your library for a creature card and put that card into your graveyard. If you do, shuffle your library.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "9ec56341-c2b4-518f-b844-933269b5a308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972891e6-6a23-40df-af22-adf8cd7ea582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972891e6-6a23-40df-af22-adf8cd7ea582.jpg?1",
             "name": "Cunning Lethemancer",
             "text": "At the beginning of your upkeep, each player discards a card.",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "d3070188-507a-5d5b-9fd3-c10666ddc9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d59b5e5-fc16-4f1a-9f17-f42908473531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d59b5e5-fc16-4f1a-9f17-f42908473531.jpg?1",
             "name": "Death Baron",
             "text": "Skeleton creatures you control and other Zombie creatures you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "e20248f3-642c-5e92-bc60-0b1496370650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de74fa19-943e-4606-a793-ab5ccbe8db4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de74fa19-943e-4606-a793-ab5ccbe8db4a.jpg?1",
             "name": "Deathgreeter",
             "text": "Whenever another creature is put into a graveyard from play, you may gain 1 life.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "9b9459e1-b5d4-5435-b1b0-388e7597645d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aa309e-5df3-4419-9e9c-3fd928c1e360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aa309e-5df3-4419-9e9c-3fd928c1e360.jpg?1",
             "name": "Demon's Herald",
             "text": "{2}{B}, {T}, Sacrifice a blue creature, a black creature, and a red creature: Search your library for a card named Prince of Thralls and put it into play. Then shuffle your library.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "6902eda5-909b-5495-a4c7-018cf861e382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7771eba-bc2d-40f2-bab4-5e9cc4fe8f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7771eba-bc2d-40f2-bab4-5e9cc4fe8f34.jpg?1",
             "name": "Dreg Reaver",
             "text": "",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "4ceec1db-4f8b-565b-9df7-c47435089d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65b7ad-4ab0-4622-81f4-434254625a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65b7ad-4ab0-4622-81f4-434254625a1e.jpg?1",
             "name": "Dregscape Zombie",
             "text": "Unearth {B} ({B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "8e447aad-49b8-5786-8eb0-296a4d20a025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185059-fff9-47b0-9774-ad37dee345ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185059-fff9-47b0-9774-ad37dee345ed.jpg?1",
             "name": "Executioner's Capsule",
             "text": "{1}{B}, {T}, Sacrifice Executioner's Capsule: Destroy target nonblack creature.",
             "colours": [
@@ -2572,7 +2572,7 @@
         },
         {
             "id": "58f6dcbd-9072-59d3-9206-88a96c782e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71e4391-04a8-4df8-9d52-3a3480bcd5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71e4391-04a8-4df8-9d52-3a3480bcd5b6.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder comes into play, each player sacrifices a creature.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "f5e04b6b-8d68-5e41-a7db-1208c4ef70f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e030fb1-12a8-4c28-836f-8097ec753271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e030fb1-12a8-4c28-836f-8097ec753271.jpg?1",
             "name": "Glaze Fiend",
             "text": "Flying\nWhenever another artifact comes into play under your control, Glaze Fiend gets +2/+2 until end of turn.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "4210b7dd-5a20-52e2-88b8-18225ebb7eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd260c-a625-42a4-8192-27e42e18ac0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd260c-a625-42a4-8192-27e42e18ac0f.jpg?1",
             "name": "Grixis Battlemage",
             "text": "{U}, {T}: Draw a card, then discard a card.\n{R}, {T}: Target creature can't block this turn.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "a0f9c7d5-74c8-50c6-812e-d43a33eb3009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79ec57-7c45-4ef9-9051-449d473b65ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79ec57-7c45-4ef9-9051-449d473b65ea.jpg?1",
             "name": "Immortal Coil",
             "text": "{T}, Remove two cards in your graveyard from the game: Draw a card.\nIf damage would be dealt to you, prevent that damage. Remove a card in your graveyard from the game for each 1 damage prevented this way.\nWhen there are no cards in your graveyard, you lose the game.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "69bbddaa-a79f-5491-bb07-8bd562d04992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9dd080-5e13-4334-8614-8eec41ae89c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9dd080-5e13-4334-8614-8eec41ae89c2.jpg?1",
             "name": "Infest",
             "text": "All creatures get -2/-2 until end of turn.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "56fcf4a7-be80-5e28-91c7-eec968ce0c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3686eb57-e9c8-480f-8ab4-2894e1b5fe20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3686eb57-e9c8-480f-8ab4-2894e1b5fe20.jpg?1",
             "name": "Onyx Goblet",
             "text": "{T}: Target player loses 1 life.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "0035c018-9dcc-51f3-ab3f-ff49d4bfe405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ee904-95ca-4ec3-ad7d-ee084aa0c00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ee904-95ca-4ec3-ad7d-ee084aa0c00f.jpg?1",
             "name": "Puppet Conjurer",
             "text": "{U}, {T}: Put a 0/1 blue Homunculus artifact creature token into play.\nAt the beginning of your upkeep, sacrifice a Homunculus.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "d66459b5-6fd4-5ec2-854b-2e8d1646c774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d27eb7-2d3b-4daf-9cf6-c254fdacceb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d27eb7-2d3b-4daf-9cf6-c254fdacceb0.jpg?1",
             "name": "Resounding Scream",
             "text": "Target player discards a card at random.\nCycling {5}{U}{B}{R} ({5}{U}{B}{R}, Discard this card: Draw a card.)\nWhen you cycle Resounding Scream, target player discards two cards at random.",
             "colours": [
@@ -2846,7 +2846,7 @@
         },
         {
             "id": "bbe043b0-6545-5e8e-92e3-aa4abfcae36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b02c538-c2f9-47ef-9a07-8a41fe172d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b02c538-c2f9-47ef-9a07-8a41fe172d10.jpg?1",
             "name": "Salvage Titan",
             "text": "You may sacrifice three artifacts rather than pay Salvage Titan's mana cost.\nRemove three artifact cards in your graveyard from the game: Return Salvage Titan from your graveyard to your hand.",
             "colours": [
@@ -2881,7 +2881,7 @@
         },
         {
             "id": "ea3e987f-c7f4-5c0e-867f-c98d27ae6035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b7806f-c28f-40d4-b79e-f5a7725db298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b7806f-c28f-40d4-b79e-f5a7725db298.jpg?1",
             "name": "Scavenger Drake",
             "text": "Flying\nWhenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Scavenger Drake.",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "ccbd4119-63bd-5996-ae5d-36d116fe3a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ccd8c7-7472-47df-9d3e-1b5fb1431118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ccd8c7-7472-47df-9d3e-1b5fb1431118.jpg?1",
             "name": "Shadowfeed",
             "text": "Remove target card in a graveyard from the game. You gain 3 life.",
             "colours": [
@@ -2947,7 +2947,7 @@
         },
         {
             "id": "f9286a74-4fd0-5d18-a0ab-b614f54fd323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e5763-4892-47e4-8fd5-f576844c0a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e5763-4892-47e4-8fd5-f576844c0a0d.jpg?1",
             "name": "Shore Snapper",
             "text": "{U}: Shore Snapper gains islandwalk until end of turn.",
             "colours": [
@@ -2982,7 +2982,7 @@
         },
         {
             "id": "1a530311-5d85-5722-a7ed-31c2e8e3f2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e7e593-e5b0-4348-b8e5-20173d41aa39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e7e593-e5b0-4348-b8e5-20173d41aa39.jpg?1",
             "name": "Skeletal Kathari",
             "text": "Flying\n{B}, Sacrifice a creature: Regenerate Skeletal Kathari.",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "f067ce32-7790-519e-bdee-efb29b666692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1903f8-2863-4203-9552-a75759fa8c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1903f8-2863-4203-9552-a75759fa8c94.jpg?1",
             "name": "Tar Fiend",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\nWhen Tar Fiend comes into play, target player discards a card for each creature it devoured.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "1689a0af-78a2-57f1-b99a-f378a1010ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab9a62a-5503-430d-8b67-061a46b5c22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab9a62a-5503-430d-8b67-061a46b5c22c.jpg?1",
             "name": "Undead Leotau",
             "text": "{R}: Undead Leotau gets +1/-1 until end of turn.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3087,7 +3087,7 @@
         },
         {
             "id": "0fe80296-0168-5b6d-8b3b-d0cc8ccb917f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6402470-d829-4b9a-840c-1f97d6fd786f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6402470-d829-4b9a-840c-1f97d6fd786f.jpg?1",
             "name": "Vein Drinker",
             "text": "Flying\n{R}, {T}: Vein Drinker deals damage equal to its power to target creature. That creature deals damage equal to its power to Vein Drinker.\nWhenever a creature dealt damage by Vein Drinker this turn is put into a graveyard, put a +1/+1 counter on Vein Drinker.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "400f7219-1c7e-5bfd-b69d-749f691272af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d2d84-7141-4485-8379-b3c71af47cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6d2d84-7141-4485-8379-b3c71af47cd1.jpg?1",
             "name": "Viscera Dragger",
             "text": "Cycling {2} ({2}, Discard this card: Draw a card.)\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "6f86e8e3-d587-5748-8f1a-3f48080e8610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e39677-5e04-45af-8f4c-1d4b6e737213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e39677-5e04-45af-8f4c-1d4b6e737213.jpg?1",
             "name": "Bloodpyre Elemental",
             "text": "Sacrifice Bloodpyre Elemental: Bloodpyre Elemental deals 4 damage to target creature. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -3192,7 +3192,7 @@
         },
         {
             "id": "6bc4439b-6861-5d62-a292-ccdafcbaa82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769e8f6-15ad-4f1b-bb4d-848ae6b7549e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8769e8f6-15ad-4f1b-bb4d-848ae6b7549e.jpg?1",
             "name": "Bloodthorn Taunter",
             "text": "Haste\n{T}: Target creature with power 5 or greater gains haste until end of turn.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "032469db-9fb8-51ce-81b1-d3c115ad7476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg?1",
             "name": "Caldera Hellion",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nWhen Caldera Hellion comes into play, it deals 3 damage to each creature.",
             "colours": [
@@ -3261,7 +3261,7 @@
         },
         {
             "id": "8c5c6f0a-7ca3-5ad2-a606-359705e76dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a2d4ba-7bd0-4852-aad3-dfdaf5368e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a2d4ba-7bd0-4852-aad3-dfdaf5368e3e.jpg?1",
             "name": "Crucible of Fire",
             "text": "Dragon creatures you control get +3/+3.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "bbdc9bb3-6870-5cc3-a7fa-8d17728097aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab4120-e7d8-4132-a304-30b88e3175e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab4120-e7d8-4132-a304-30b88e3175e2.jpg?1",
             "name": "Dragon Fodder",
             "text": "Put two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -3325,7 +3325,7 @@
         },
         {
             "id": "2fa731b0-775e-5c92-a486-2f1c784d5491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5873e8-ba15-4a24-aab8-91f1f390d821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5873e8-ba15-4a24-aab8-91f1f390d821.jpg?1",
             "name": "Dragon's Herald",
             "text": "{2}{R}, {T}, Sacrifice a black creature, a red creature, and a green creature: Search your library for a card named Hellkite Overlord and put it into play. Then shuffle your library.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "d1ba0674-c8d0-507a-9cd4-e7c55d7572b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c08845-d195-447e-9e4d-020dcab5f80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c08845-d195-447e-9e4d-020dcab5f80f.jpg?1",
             "name": "Exuberant Firestoker",
             "text": "At the end of your turn, if you control a creature with power 5 or greater, you may have Exuberant Firestoker deal 2 damage to target player.\n{T}: Add {1} to your mana pool.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "f94eec89-7f0e-5bdd-9ae3-f6d215be498e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544b26b-0bc4-4c1b-9616-613e9bf08557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544b26b-0bc4-4c1b-9616-613e9bf08557.jpg?1",
             "name": "Flameblast Dragon",
             "text": "Flying\nWhenever Flameblast Dragon attacks, you may pay {X}{R}. If you do, Flameblast Dragon deals X damage to target creature or player.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "75e11199-6b16-5736-a259-be171e25dfa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039402e-2c74-4bea-b360-b93979b52698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039402e-2c74-4bea-b360-b93979b52698.jpg?1",
             "name": "Goblin Assault",
             "text": "At the beginning of your upkeep, put a 1/1 red Goblin creature token with haste into play.\nGoblin creatures attack each turn if able.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "fbf969f5-00e9-5557-94e1-4e6e88d7449b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa1475-797d-4cdc-93d6-e186c25e0bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afa1475-797d-4cdc-93d6-e186c25e0bf5.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "Mountainwalk",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "88c01b4b-01f1-5298-9303-7ed9fc8337ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848f6c49-0913-4f12-886d-8b6defe8bfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848f6c49-0913-4f12-886d-8b6defe8bfab.jpg?1",
             "name": "Hell's Thunder",
             "text": "Flying, haste\nAt end of turn, sacrifice Hell's Thunder.\nUnearth {4}{R} ({4}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "e06729b0-7a65-5754-a1fd-cb55244ad1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8b8b90-cb6e-4910-bc40-d96b78b0d70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8b8b90-cb6e-4910-bc40-d96b78b0d70c.jpg?1",
             "name": "Hissing Iguanar",
             "text": "Whenever another creature is put into a graveyard from play, you may have Hissing Iguanar deal 1 damage to target player.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "30d80e43-e7ad-55df-94b0-98a7f90dccce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad3381e-ae2f-40cf-8a7b-62375e9f453e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad3381e-ae2f-40cf-8a7b-62375e9f453e.jpg?1",
             "name": "Incurable Ogre",
             "text": "",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "e6f68e20-811a-59c1-aa83-9523f2ae500b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8c962f-11b0-48f7-bbba-a2212e41990f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8c962f-11b0-48f7-bbba-a2212e41990f.jpg?1",
             "name": "Jund Battlemage",
             "text": "{B}, {T}: Target player loses 1 life.\n{G}, {T}: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "2137909f-6350-5746-952d-18ee646a01a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc1ad4c-b394-48b9-9a5a-ec9f42bf6a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc1ad4c-b394-48b9-9a5a-ec9f42bf6a00.jpg?1",
             "name": "Lightning Talons",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and has first strike.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "b2d01a66-68f4-53a9-8819-333c4d5a6feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708ec768-f455-48e4-b834-e0a2b3768c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708ec768-f455-48e4-b834-e0a2b3768c45.jpg?1",
             "name": "Magma Spray",
             "text": "Magma Spray deals 2 damage to target creature. If that creature would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "6e1b969d-27e4-510b-a2ac-79e047221419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg?1",
             "name": "Predator Dragon",
             "text": "Flying, haste\nDevour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "efcff0f2-cff3-577d-b7c8-31fc3a9ba81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7955-d939-4195-aba8-b46a8c925616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7955-d939-4195-aba8-b46a8c925616.jpg?1",
             "name": "Resounding Thunder",
             "text": "Resounding Thunder deals 3 damage to target creature or player.\nCycling {5}{B}{R}{G} ({5}{B}{R}{G}, Discard this card: Draw a card.)\nWhen you cycle Resounding Thunder, it deals 6 damage to target creature or player.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "dac9b025-3a49-5ce3-87c1-d100ccfb1e85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4275a8dd-f777-4160-b773-9a868e743218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4275a8dd-f777-4160-b773-9a868e743218.jpg?1",
             "name": "Ridge Rannet",
             "text": "Cycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "414cb7e6-bd56-5109-b32f-ac14f7709705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f26025-8777-41a2-a871-ea8d1af164ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f26025-8777-41a2-a871-ea8d1af164ae.jpg?1",
             "name": "Rockslide Elemental",
             "text": "First strike\nWhenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Rockslide Elemental.",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "64387a8c-ada7-5d39-a2ca-df87721aff40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e2ba9-8d23-4aca-8b50-4beb598d4a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e2ba9-8d23-4aca-8b50-4beb598d4a60.jpg?1",
             "name": "Scourge Devil",
             "text": "When Scourge Devil comes into play, creatures you control get +1/+0 until end of turn.\nUnearth {2}{R} ({2}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "dd7e6f86-0dfd-5969-81e0-e2d2f66ea95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c7f048-3e2b-4e97-a900-36da9b6ee2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c7f048-3e2b-4e97-a900-36da9b6ee2a8.jpg?1",
             "name": "Skeletonize",
             "text": "Skeletonize deals 3 damage to target creature. When a creature dealt damage this way is put into a graveyard this turn, put a 1/1 black Skeleton creature token into play with \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "1fc454c6-7f23-5b04-af04-1aaf15b01b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59a0305-65f8-45c4-859e-6c73544dfa3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59a0305-65f8-45c4-859e-6c73544dfa3e.jpg?1",
             "name": "Soul's Fire",
             "text": "Target creature you control in play deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "a0a76682-f9b2-516e-b6de-d64f22591ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7987de9-d812-4615-845a-3a90572d9b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7987de9-d812-4615-845a-3a90572d9b44.jpg?1",
             "name": "Thorn-Thrash Viashino",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\n{G}: Thorn-Thrash Viashino gains trample until end of turn.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "9d328c03-b945-5cd1-8276-9e22e9846122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552da28-01a3-4277-9e69-b297c3874ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552da28-01a3-4277-9e69-b297c3874ea4.jpg?1",
             "name": "Thunder-Thrash Elder",
             "text": "Devour 3 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with three times that many +1/+1 counters on it.)",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "553dcdb7-1198-51db-b9c7-f6225b87d665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9451a62-31a4-4aaf-beef-2bf149f25ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9451a62-31a4-4aaf-beef-2bf149f25ae3.jpg?1",
             "name": "Viashino Skeleton",
             "text": "{1}{B}, Discard a card: Regenerate Viashino Skeleton.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "7511cfb7-63a5-54cb-a741-ccac0e802724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d040791e-eee4-4eef-ace1-507216a5d268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d040791e-eee4-4eef-ace1-507216a5d268.jpg?1",
             "name": "Vicious Shadows",
             "text": "Whenever a creature is put into a graveyard from play, you may have Vicious Shadows deal damage to target player equal to the number of cards in that player's hand.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "b92a27ee-512d-5a6b-b62a-3c6525db82fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf290e2f-2c78-4cf5-8925-0c598ec0d60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf290e2f-2c78-4cf5-8925-0c598ec0d60e.jpg?1",
             "name": "Vithian Stinger",
             "text": "{T}: Vithian Stinger deals 1 damage to target creature or player.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -4112,7 +4112,7 @@
         },
         {
             "id": "d21faaf9-d6ed-52c3-941f-6a8974b83ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec1f1fa-41c9-4bc0-9171-902cd456aa73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec1f1fa-41c9-4bc0-9171-902cd456aa73.jpg?1",
             "name": "Volcanic Submersion",
             "text": "Destroy target artifact or land.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "09fe49d9-eb70-5e88-ae4f-b22b5a404013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e3faa-9573-4639-be99-517708c06218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e3faa-9573-4639-be99-517708c06218.jpg?1",
             "name": "Where Ancients Tread",
             "text": "Whenever a creature with power 5 or greater comes into play under your control, you may have Where Ancients Tread deal 5 damage to target creature or player.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "e38cfb30-6835-5d11-b81d-de07d6b44e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946e08b5-1c99-467c-abba-07ddede07a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946e08b5-1c99-467c-abba-07ddede07a6c.jpg?1",
             "name": "Algae Gharial",
             "text": "Shroud\nWhenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Algae Gharial.",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "daca1ad3-e80d-501a-a5f4-1d2520da41ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51e84d7-bf9f-454f-bdcd-a2458b1b5b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51e84d7-bf9f-454f-bdcd-a2458b1b5b33.jpg?1",
             "name": "Behemoth's Herald",
             "text": "{2}{G}, {T}, Sacrifice a red creature, a green creature, and a white creature: Search your library for a card named Godsire and put it into play. Then shuffle your library.",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "7cbb7cbb-9b54-5877-a996-2cd6eaf8d1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34748acb-7045-42b6-a93f-a3f11a1bc839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34748acb-7045-42b6-a93f-a3f11a1bc839.jpg?1",
             "name": "Cavern Thoctar",
             "text": "{1}{R}: Cavern Thoctar gets +1/+0 until end of turn.",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "34516754-941e-5a8a-9ae5-ed51b7d98532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3776b1c-4a3f-43b9-962e-64010f286ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3776b1c-4a3f-43b9-962e-64010f286ba5.jpg?1",
             "name": "Court Archers",
             "text": "Reach (This can block creatures with flying.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "9cd890c2-33b8-51cb-a328-e0f18d3c37bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3afaab6-4768-4852-a0b6-4e6a0295bde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3afaab6-4768-4852-a0b6-4e6a0295bde7.jpg?1",
             "name": "Cylian Elf",
             "text": "",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "8e867e59-a493-5d0d-baec-45c33fc62e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de32bf78-73c2-4cd4-b3b3-ef8be53e1e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de32bf78-73c2-4cd4-b3b3-ef8be53e1e5e.jpg?1",
             "name": "Druid of the Anima",
             "text": "{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [
@@ -4387,7 +4387,7 @@
         },
         {
             "id": "737c3399-e2ef-52e6-898d-19755f054569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83b664-a17e-4a48-8b9a-bd3af2d9cd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83b664-a17e-4a48-8b9a-bd3af2d9cd87.jpg?1",
             "name": "Drumhunter",
             "text": "At the end of your turn, if you control a creature with power 5 or greater, you may draw a card.\n{T}: Add {1} to your mana pool.",
             "colours": [
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "1da2555f-8856-585e-bc39-50a78ad255d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faccfa5f-4d89-4a86-92d7-36cb5a16c5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faccfa5f-4d89-4a86-92d7-36cb5a16c5c9.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary comes into play, draw a card.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "1dc6ea2d-4468-50ec-b63e-c9efff20d9f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f76986-e9fb-4c51-b946-880b501775b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f76986-e9fb-4c51-b946-880b501775b0.jpg?1",
             "name": "Feral Hydra",
             "text": "Feral Hydra comes into play with X +1/+1 counters on it.\n{3}: Put a +1/+1 counter on Feral Hydra. Any player may play this ability.",
             "colours": [
@@ -4493,7 +4493,7 @@
         },
         {
             "id": "6bcb67f6-1c60-51f6-b450-740b41238d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850be87-54de-49b3-a407-6fb2b278b25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1850be87-54de-49b3-a407-6fb2b278b25c.jpg?1",
             "name": "Gift of the Gargantuan",
             "text": "Look at the top four cards of your library. You may reveal a creature card and/or a land card from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "015cccc3-0056-5702-a430-98d78b72d4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032059cb-c1ad-4cc9-a89d-d68289800312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032059cb-c1ad-4cc9-a89d-d68289800312.jpg?1",
             "name": "Godtoucher",
             "text": "{1}{W}, {T}: Prevent all damage that would be dealt to target creature with power 5 or greater this turn.",
             "colours": [
@@ -4561,7 +4561,7 @@
         },
         {
             "id": "269dc5f8-829c-5295-9f62-c51db15a234f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46870b-3d8d-4aae-8d59-6bd88a50b37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46870b-3d8d-4aae-8d59-6bd88a50b37c.jpg?1",
             "name": "Jungle Weaver",
             "text": "Reach (This can block creatures with flying.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4595,7 +4595,7 @@
         },
         {
             "id": "d533c498-b61e-5c92-a58c-f4ca9aadc03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb023a2-e929-47e9-bd58-cbc6f241e7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb023a2-e929-47e9-bd58-cbc6f241e7a4.jpg?1",
             "name": "Keeper of Progenitus",
             "text": "Whenever a player taps a Mountain, Forest, or Plains for mana, that player adds one mana to his or her mana pool of any type that land produced.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "a93a7753-f0e6-558f-aa81-a4468ca391ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62047f2-a41f-44b5-a6bc-28e35fad093b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62047f2-a41f-44b5-a6bc-28e35fad093b.jpg?1",
             "name": "Lush Growth",
             "text": "Enchant land\nEnchanted land is a Mountain, Forest, and Plains.",
             "colours": [
@@ -4664,7 +4664,7 @@
         },
         {
             "id": "37e877fd-b36a-5a4c-81a5-6fd941ac925a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee66318-4dbb-49a3-a3c8-ee0e1a9f02b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee66318-4dbb-49a3-a3c8-ee0e1a9f02b7.jpg?1",
             "name": "Mighty Emergence",
             "text": "Whenever a creature with power 5 or greater comes into play under your control, you may put two +1/+1 counters on it.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "9567fd12-cb9b-500b-81a1-dda9fc0df459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d2cc1-9868-4509-a541-728faf355b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d2cc1-9868-4509-a541-728faf355b6d.jpg?1",
             "name": "Manaplasm",
             "text": "Whenever you play a spell, Manaplasm gets +X/+X until end of turn, where X is that spell's converted mana cost.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "8bd306d1-e302-59ce-9547-1baad4dfde1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05afd921-ef3b-40fe-a1a8-582ee94ed3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05afd921-ef3b-40fe-a1a8-582ee94ed3f0.jpg?1",
             "name": "Mosstodon",
             "text": "{1}: Target creature with power 5 or greater gains trample until end of turn.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "185138b8-1a8f-53fd-8e48-56e4a0f82fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15360a16-b785-4ffe-bfa8-6c7f6a37455d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15360a16-b785-4ffe-bfa8-6c7f6a37455d.jpg?1",
             "name": "Mycoloth",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\nAt the beginning of your upkeep, put a 1/1 green Saproling creature token into play for each +1/+1 counter on Mycoloth.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "5f04f940-c5d4-5c4d-a710-f0b7b0a59bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7531879b-d5fd-4b60-b838-733883571473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7531879b-d5fd-4b60-b838-733883571473.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4831,7 +4831,7 @@
         },
         {
             "id": "650bbbd5-5ae4-5909-842f-c2ae291a1054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe73f62-2e80-4d5f-b7b5-c54c895a3e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe73f62-2e80-4d5f-b7b5-c54c895a3e4d.jpg?1",
             "name": "Naya Battlemage",
             "text": "{R}, {T}: Target creature gets +2/+0 until end of turn.\n{W}, {T}: Tap target creature.",
             "colours": [
@@ -4868,7 +4868,7 @@
         },
         {
             "id": "0dc236a3-d886-596c-b208-389708e5aeb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623e57ed-7ed7-4283-b48f-77ecacad70b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623e57ed-7ed7-4283-b48f-77ecacad70b0.jpg?1",
             "name": "Ooze Garden",
             "text": "{1}{G}, Sacrifice a non-Ooze creature: Put an X/X green Ooze creature token into play, where X is the sacrificed creature's power. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "843b9e6e-4ef9-55d8-880d-7c670134c937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217bf237-a758-4500-b221-5e88fed9d0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217bf237-a758-4500-b221-5e88fed9d0fc.jpg?1",
             "name": "Resounding Roar",
             "text": "Target creature gets +3/+3 until end of turn.\nCycling {5}{R}{G}{W} ({5}{R}{G}{W}, Discard this card: Draw a card.)\nWhen you cycle Resounding Roar, target creature gets +6/+6 until end of turn.",
             "colours": [
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "ba10cfcf-26d1-5693-92b7-28b80020b8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaae6a3-ae3c-4b7e-82e8-69147f61ee18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaae6a3-ae3c-4b7e-82e8-69147f61ee18.jpg?1",
             "name": "Rhox Charger",
             "text": "Trample\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4969,7 +4969,7 @@
         },
         {
             "id": "9f019054-8d92-5efa-8cc7-5f3f02da475e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad80819-22d4-43a8-97b2-7cf20f61bca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad80819-22d4-43a8-97b2-7cf20f61bca5.jpg?1",
             "name": "Sacellum Godspeaker",
             "text": "{T}: Reveal any number of creature cards with power 5 or greater from your hand. Add {G} to your mana pool for each card revealed this way.",
             "colours": [
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "b09839d4-4cfd-5320-ac4c-ae85d598359d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0367fac8-6990-4544-ac7d-ed363b55a9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0367fac8-6990-4544-ac7d-ed363b55a9cf.jpg?1",
             "name": "Savage Hunger",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has trample.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5038,7 +5038,7 @@
         },
         {
             "id": "572b841d-429b-58dc-a6a1-b7cc728d5e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5178576-573d-4da8-97ae-a684e1e95fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5178576-573d-4da8-97ae-a684e1e95fa4.jpg?1",
             "name": "Skullmulcher",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nWhen Skullmulcher comes into play, draw a card for each creature it devoured.",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "51da6e6f-1361-55ee-82e8-6826794c623c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ef536d-d55b-447a-b6ab-04123f1cfaa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ef536d-d55b-447a-b6ab-04123f1cfaa3.jpg?1",
             "name": "Soul's Might",
             "text": "Put X +1/+1 counters on target creature, where X is that creature's power.",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "9d39f8cf-27e8-58e3-9ba4-9cb66edeca73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132367ee-22e9-48e2-82e0-62ad9aaa62f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132367ee-22e9-48e2-82e0-62ad9aaa62f3.jpg?1",
             "name": "Spearbreaker Behemoth",
             "text": "Spearbreaker Behemoth is indestructible.\n{1}: Target creature with power 5 or greater is indestructible this turn.",
             "colours": [
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "5c2af4fe-8cda-50f8-9004-59d81da92335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0952ed-efc7-4ff5-a233-e64c0f11119b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0952ed-efc7-4ff5-a233-e64c0f11119b.jpg?1",
             "name": "Topan Ascetic",
             "text": "Tap an untapped creature you control: Topan Ascetic gets +1/+1 until end of turn.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "6c9b2396-b8aa-5013-956c-cb0796411472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb18038-eb6a-4d27-ba52-52a1cee6b512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb18038-eb6a-4d27-ba52-52a1cee6b512.jpg?1",
             "name": "Wild Nacatl",
             "text": "Wild Nacatl gets +1/+1 as long as you control a Mountain.\nWild Nacatl gets +1/+1 as long as you control a Plains.",
             "colours": [
@@ -5208,7 +5208,7 @@
         },
         {
             "id": "2dd0754e-f50a-5074-aa0f-ed97a70e775a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e246294f-7614-48e9-a655-647faf0bf697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e246294f-7614-48e9-a655-647faf0bf697.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "726e5400-7359-59f4-81dd-a23b91c85488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc108a3-15e5-44ab-a6e2-182b309f9c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc108a3-15e5-44ab-a6e2-182b309f9c0c.jpg?1",
             "name": "Ajani Vengeant",
             "text": "+1: Target permanent doesn't untap during its controller's next untap step.\n-2: Ajani Vengeant deals 3 damage to target creature or player and you gain 3 life.\n-7: Destroy all lands target player controls.",
             "colours": [
@@ -5280,7 +5280,7 @@
         },
         {
             "id": "697d6989-aac9-5160-88b3-64b31caf1997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b65c87-b084-44aa-b841-411a3c73e234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b65c87-b084-44aa-b841-411a3c73e234.jpg?1",
             "name": "Bant Charm",
             "text": "Choose one Destroy target artifact; or put target creature on the bottom of its owner's library; or counter target instant spell.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "8f5f7ba2-1fa4-5259-bb0c-06666e93eff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c05e8a2-b7d0-4f24-b2ae-8e4db30e5842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c05e8a2-b7d0-4f24-b2ae-8e4db30e5842.jpg?1",
             "name": "Blightning",
             "text": "Blightning deals 3 damage to target player. That player discards two cards.",
             "colours": [
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "8b39aa36-e553-559c-a5a7-99d2cfd20490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb468da0-b72b-4b46-994a-20677206ffb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb468da0-b72b-4b46-994a-20677206ffb7.jpg?1",
             "name": "Blood Cultist",
             "text": "{T}: Blood Cultist deals 1 damage to target creature.\nWhenever a creature dealt damage by Blood Cultist this turn is put into a graveyard, put a +1/+1 counter on Blood Cultist.",
             "colours": [
@@ -5387,7 +5387,7 @@
         },
         {
             "id": "28f377fe-a392-5784-adca-d540adc7bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7468876-f401-4a75-81c0-bed09cdda3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7468876-f401-4a75-81c0-bed09cdda3e1.jpg?1",
             "name": "Branching Bolt",
             "text": "Choose one or both Branching Bolt deals 3 damage to target creature with flying; and/or Branching Bolt deals 3 damage to target creature without flying.",
             "colours": [
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "d370ddcb-3c24-5fa9-95b1-062ab677f0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593409fd-26ef-463e-9101-ec5ad53dfd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593409fd-26ef-463e-9101-ec5ad53dfd67.jpg?1",
             "name": "Brilliant Ultimatum",
             "text": "Remove the top five cards of your library from the game. An opponent separates those cards into two piles. You may play any number of cards from one of those piles without paying their mana costs.",
             "colours": [
@@ -5457,7 +5457,7 @@
         },
         {
             "id": "4581b6e0-8653-5274-96eb-87718fa0e267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1360e-7c6b-400c-893a-82d93e53101e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea1360e-7c6b-400c-893a-82d93e53101e.jpg?1",
             "name": "Broodmate Dragon",
             "text": "Flying\nWhen Broodmate Dragon comes into play, put a 4/4 red Dragon creature token with flying into play.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "fefeefc6-8e67-51a3-a144-4475d76b56d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae0fe2-5d52-434c-8ad1-4a5e42f4b7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae0fe2-5d52-434c-8ad1-4a5e42f4b7c4.jpg?1",
             "name": "Bull Cerodon",
             "text": "Vigilance, haste",
             "colours": [
@@ -5531,7 +5531,7 @@
         },
         {
             "id": "808b0592-a5c5-55f8-ba8e-e3d4a2f87669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c7b9e-eb80-4842-8aa3-1d0c46d9677e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c7b9e-eb80-4842-8aa3-1d0c46d9677e.jpg?1",
             "name": "Carrion Thrash",
             "text": "When Carrion Thrash is put into a graveyard from play, you may pay {2}. If you do, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "88df3b21-3898-5baa-b560-30bcdf6d3cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e8bf21-0baf-4ee9-b224-b9eee50df280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e8bf21-0baf-4ee9-b224-b9eee50df280.jpg?1",
             "name": "Clarion Ultimatum",
             "text": "Choose five permanents you control. For each of those permanents, you may search your library for a card with the same name as that permanent. Put those cards into play tapped, then shuffle your library.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "84a1e895-67d8-50a8-84c3-6a873daece9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d267804-23de-4521-ae64-4dd5cd836c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d267804-23de-4521-ae64-4dd5cd836c6c.jpg?1",
             "name": "Cruel Ultimatum",
             "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "5ea5f834-4687-53bc-9036-7cb6df98a8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4885a83-9410-4c88-b45e-1e1626fe90ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4885a83-9410-4c88-b45e-1e1626fe90ea.jpg?1",
             "name": "Deft Duelist",
             "text": "First strike\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -5679,7 +5679,7 @@
         },
         {
             "id": "d0271649-5c3a-5fa0-9ccf-4a13875c0629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b789ea-df50-49a5-bd64-3b74b4042f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b789ea-df50-49a5-bd64-3b74b4042f83.jpg?1",
             "name": "Empyrial Archangel",
             "text": "Flying, shroud\nAll damage that would be dealt to you is dealt to Empyrial Archangel instead.",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "bc4e162f-7978-5df5-81d1-b51d2a95752c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d70a07-8d91-462c-aa96-901cc9a81531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d70a07-8d91-462c-aa96-901cc9a81531.jpg?1",
             "name": "Esper Charm",
             "text": "Choose one Destroy target enchantment; or draw two cards; or target player discards two cards.",
             "colours": [
@@ -5753,7 +5753,7 @@
         },
         {
             "id": "8abfaf81-8d7e-5762-96fa-ded92fa9f4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70db6085-9707-4902-966d-b13bb6a0f62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70db6085-9707-4902-966d-b13bb6a0f62f.jpg?1",
             "name": "Fire-Field Ogre",
             "text": "First strike\nUnearth {U}{B}{R} ({U}{B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "fea4f333-e0ba-50f8-aac0-428e5211ff1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fd1253-1af1-42a7-9875-4d6ac9ce722c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fd1253-1af1-42a7-9875-4d6ac9ce722c.jpg?1",
             "name": "Goblin Deathraiders",
             "text": "Trample",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "b20e873f-1d00-5acd-82a4-0d29d67d455b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2539ff7-2b7d-47e3-bd77-3138a6c42d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2539ff7-2b7d-47e3-bd77-3138a6c42d2b.jpg?1",
             "name": "Godsire",
             "text": "Vigilance\n{T}: Put an 8/8 Beast creature token into play that's red, green, and white.",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "a963bd60-c7a4-5724-a79d-6af3d001fb42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a6695-44ce-445f-b476-e18a0b5dd8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a6695-44ce-445f-b476-e18a0b5dd8f2.jpg?1",
             "name": "Grixis Charm",
             "text": "Choose one Return target permanent to its owner's hand; or target creature gets -4/-4 until end of turn; or creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "a57bfd6f-3205-5d22-b473-f4ea30677431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89185829-5c93-4fd9-8c56-11820be6a970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89185829-5c93-4fd9-8c56-11820be6a970.jpg?1",
             "name": "Hellkite Overlord",
             "text": "Flying, trample, haste\n{R}: Hellkite Overlord gets +1/+0 until end of turn.\n{B}{G}: Regenerate Hellkite Overlord.",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "d1636960-1147-5937-9bd8-8fae33a4978f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e43870-4bed-4d76-a633-a6326c736d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e43870-4bed-4d76-a633-a6326c736d22.jpg?1",
             "name": "Hindering Light",
             "text": "Counter target spell that targets you or a permanent you control.\nDraw a card.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "3d2c92b6-18f1-5863-95ca-c1db14d20c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1761d867-2eb0-406b-b175-97a90c457844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1761d867-2eb0-406b-b175-97a90c457844.jpg?1",
             "name": "Jhessian Infiltrator",
             "text": "Jhessian Infiltrator is unblockable.",
             "colours": [
@@ -6012,7 +6012,7 @@
         },
         {
             "id": "3810b9f6-0ea7-545e-855a-95b84ecc4be9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ddf00-926c-4283-a8b2-daa02fa99b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ddf00-926c-4283-a8b2-daa02fa99b8b.jpg?1",
             "name": "Jund Charm",
             "text": "Choose one Remove target player's graveyard from the game; or Jund Charm deals 2 damage to each creature; or put two +1/+1 counters on target creature.",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "04337c9d-2158-5d25-bd60-84bf270aba1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701498e5-1d4d-42f4-9dd0-5d4cf78f0e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701498e5-1d4d-42f4-9dd0-5d4cf78f0e68.jpg?1",
             "name": "Kederekt Creeper",
             "text": "Deathtouch (Whenever this creature deals damage to a creature, destroy that creature.)\nKederekt Creeper can't be blocked except by two or more creatures.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "d5cfe434-6b6a-50f7-a44e-360a3d41acc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b094f-1d43-4240-9333-398464fc1ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993b094f-1d43-4240-9333-398464fc1ac6.jpg?1",
             "name": "Kiss of the Amesha",
             "text": "Target player gains 7 life and draws two cards.",
             "colours": [
@@ -6120,7 +6120,7 @@
         },
         {
             "id": "59f46ccf-da29-5e0d-9b6d-a32132e1bf4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485fe46-ed24-4b55-8ddc-ac2fdf4eec93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485fe46-ed24-4b55-8ddc-ac2fdf4eec93.jpg?1",
             "name": "Kresh the Bloodbraided",
             "text": "Whenever another creature is put into a graveyard from play, you may put X +1/+1 counters on Kresh the Bloodbraided, where X is that creature's power.",
             "colours": [
@@ -6161,7 +6161,7 @@
         },
         {
             "id": "c016f269-0761-5dda-ae2e-e3d105eb4777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316b1fd1-5ec4-4bdc-938b-cbace1bb3f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316b1fd1-5ec4-4bdc-938b-cbace1bb3f42.jpg?1",
             "name": "Mayael the Anima",
             "text": "{3}{R}{G}{W}, {T}: Look at the top five cards of your library. You may put a creature card with power 5 or greater from among them into play. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "780e59ed-f13c-5ef2-9eb6-390b482544ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47748c3a-c60a-4f2e-9eb8-2675c067bb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47748c3a-c60a-4f2e-9eb8-2675c067bb9c.jpg?1",
             "name": "Naya Charm",
             "text": "Choose one Naya Charm deals 3 damage to target creature; or return target card in a graveyard to its owner's hand; or tap all creatures target player controls.",
             "colours": [
@@ -6238,7 +6238,7 @@
         },
         {
             "id": "77358242-1cff-5044-95ba-c01022ba44d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3ea5f-1261-4f27-a87a-2b4475ad6a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3ea5f-1261-4f27-a87a-2b4475ad6a4b.jpg?1",
             "name": "Necrogenesis",
             "text": "{2}: Remove target creature card in a graveyard from the game. Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "ce7ff7e5-c4e5-57c7-8b18-bb3d5bcb1a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d6e8a2-d1b0-4aae-95f5-6ecc5718d454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d6e8a2-d1b0-4aae-95f5-6ecc5718d454.jpg?1",
             "name": "Prince of Thralls",
             "text": "Whenever a permanent an opponent controls is put into a graveyard, put that card into play under your control unless that opponent pays 3 life.",
             "colours": [
@@ -6310,7 +6310,7 @@
         },
         {
             "id": "b56b01f3-576c-5307-a463-db5009913000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc37d01-ffe5-4dfe-b59e-204df82d1d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc37d01-ffe5-4dfe-b59e-204df82d1d36.jpg?1",
             "name": "Punish Ignorance",
             "text": "Counter target spell. Its controller loses 3 life and you gain 3 life.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "bde234d9-db51-58d1-a19f-ff981e1ad048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e1284-eea2-4fc4-99e4-ed53176939ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e1284-eea2-4fc4-99e4-ed53176939ba.jpg?1",
             "name": "Qasali Ambusher",
             "text": "Reach\nIf a creature is attacking you and you control a Forest and a Plains, you may play Qasali Ambusher without paying its mana cost and as though it had flash.",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "91ab4603-562c-59b7-8337-6c5ef922477a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c188d-c11d-46f7-a2d8-a67df4ba401b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249c188d-c11d-46f7-a2d8-a67df4ba401b.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -6426,7 +6426,7 @@
         },
         {
             "id": "34b6adf4-3e43-5724-bb2a-5c5b10714c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995ab8-7382-4c2a-b8c7-8b9272cab4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995ab8-7382-4c2a-b8c7-8b9272cab4fb.jpg?1",
             "name": "Rakeclaw Gargantuan",
             "text": "{1}: Target creature with power 5 or greater gains first strike until end of turn.",
             "colours": [
@@ -6464,7 +6464,7 @@
         },
         {
             "id": "9681fb76-bc23-50c6-99e8-7ca130f855e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ecfc6-1f9e-443e-a445-51df518025a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ecfc6-1f9e-443e-a445-51df518025a5.jpg?1",
             "name": "Realm Razer",
             "text": "When Realm Razer comes into play, remove all lands from the game.\nWhen Realm Razer leaves play, return the removed cards to play tapped under their owners' control.",
             "colours": [
@@ -6502,7 +6502,7 @@
         },
         {
             "id": "ff970dc0-db93-5832-a398-9b8ff796e8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb67e1-b791-4246-aebc-49fcf0f92c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb67e1-b791-4246-aebc-49fcf0f92c6c.jpg?1",
             "name": "Rhox War Monk",
             "text": "Lifelink",
             "colours": [
@@ -6541,7 +6541,7 @@
         },
         {
             "id": "84fab52d-144d-5ec3-a647-51ff85a0e10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d61c4a0-054b-479e-82d9-dc60c5c708e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d61c4a0-054b-479e-82d9-dc60c5c708e2.jpg?1",
             "name": "Rip-Clan Crasher",
             "text": "Haste",
             "colours": [
@@ -6578,7 +6578,7 @@
         },
         {
             "id": "3d491719-44f6-5498-a5a0-a24eea9a1790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4527e-e449-45d0-a551-634e2ceb21c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4527e-e449-45d0-a551-634e2ceb21c4.jpg?1",
             "name": "Sangrite Surge",
             "text": "Target creature gets +3/+3 and gains double strike until end of turn.",
             "colours": [
@@ -6612,7 +6612,7 @@
         },
         {
             "id": "f56c7b74-9f65-538f-a06f-79b477636b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89ded2-db31-43c0-b00c-999d5d3fa5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89ded2-db31-43c0-b00c-999d5d3fa5c6.jpg?1",
             "name": "Sarkhan Vol",
             "text": "+1: Creatures you control get +1/+1 and gain haste until end of turn.\n-2: Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n-6: Put five 4/4 red Dragon creature tokens with flying into play.",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "8e2d580b-b198-58e6-9314-d45f6f09be21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ca8f2a-ee0e-4708-97d8-c1836d824d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ca8f2a-ee0e-4708-97d8-c1836d824d4e.jpg?1",
             "name": "Sedraxis Specter",
             "text": "Flying\nWhenever Sedraxis Specter deals combat damage to a player, that player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "da710717-1785-5d97-8532-064eb21ce7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70206cff-9f54-4e27-982c-b0093a51d358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70206cff-9f54-4e27-982c-b0093a51d358.jpg?1",
             "name": "Sedris, the Traitor King",
             "text": "Each creature card in your graveyard has unearth {2}{B}. ({2}{B}: Return the card to play. The creature gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -6729,7 +6729,7 @@
         },
         {
             "id": "cdebe993-317c-5139-9c9a-c67126b907c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589eaa8-95ec-4c97-8155-185487560ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589eaa8-95ec-4c97-8155-185487560ae6.jpg?1",
             "name": "Sharuum the Hegemon",
             "text": "Flying\nWhen Sharuum the Hegemon comes into play, you may return target artifact card from your graveyard to play.",
             "colours": [
@@ -6770,7 +6770,7 @@
         },
         {
             "id": "247d0eb6-6d5d-599e-a5fc-d022325b8efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae9ce20-d283-4d29-8140-bc4cf8de66df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae9ce20-d283-4d29-8140-bc4cf8de66df.jpg?1",
             "name": "Sigil Blessing",
             "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "a6529835-b028-5fac-8ec7-a3b6979e8a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fc130e-57ed-40a7-a9ba-d689e7dc3698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fc130e-57ed-40a7-a9ba-d689e7dc3698.jpg?1",
             "name": "Sphinx Sovereign",
             "text": "Flying\nAt the end of your turn, you gain 3 life if Sphinx Sovereign is untapped. Otherwise, each opponent loses 3 life.",
             "colours": [
@@ -6843,7 +6843,7 @@
         },
         {
             "id": "dfa09747-4701-5a53-a575-05ce49c034d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8950df86-1e27-4b6b-8b5c-25298a3bda85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8950df86-1e27-4b6b-8b5c-25298a3bda85.jpg?1",
             "name": "Sprouting Thrinax",
             "text": "When Sprouting Thrinax is put into a graveyard from play, put three 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -6881,7 +6881,7 @@
         },
         {
             "id": "73910073-be5d-5e1f-8932-4874fd95678b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e21ff9-0030-4e53-8ddf-86d8e78e347f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e21ff9-0030-4e53-8ddf-86d8e78e347f.jpg?1",
             "name": "Steward of Valeron",
             "text": "Vigilance\n{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6919,7 +6919,7 @@
         },
         {
             "id": "d15a77d4-e09b-598a-bcac-16bb0ebdf2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d559e0-ae4e-4e21-bd3b-726fffb87d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d559e0-ae4e-4e21-bd3b-726fffb87d2b.jpg?1",
             "name": "Stoic Angel",
             "text": "Flying, vigilance\nPlayers can't untap more than one creature during their untap steps.",
             "colours": [
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "6d1cb59d-0569-520e-824f-9b21cb46a79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10affb59-7c57-4b72-892b-d813f385f4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10affb59-7c57-4b72-892b-d813f385f4a9.jpg?1",
             "name": "Swerve",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "d3195ab6-95a3-5284-a36b-e928638a2888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9af048-43c2-44ff-9ca0-2a81609a4e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9af048-43c2-44ff-9ca0-2a81609a4e91.jpg?1",
             "name": "Thoughtcutter Agent",
             "text": "{U}{B}, {T}: Target player loses 1 life and reveals his or her hand.",
             "colours": [
@@ -7029,7 +7029,7 @@
         },
         {
             "id": "d96b7e36-63b3-5ba1-b817-f97ff929dfe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abecc77-07f2-43e4-8585-0a8199cdcf01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abecc77-07f2-43e4-8585-0a8199cdcf01.jpg?1",
             "name": "Tidehollow Sculler",
             "text": "When Tidehollow Sculler comes into play, target opponent reveals his or her hand and you choose a nonland card from it. Remove that card from the game.\nWhen Tidehollow Sculler leaves play, return the removed card to its owner's hand.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "b18d3df9-ba28-5f21-9ed9-d978bdcfd53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aafc65d-faa8-4bfe-83ac-7714c969022b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aafc65d-faa8-4bfe-83ac-7714c969022b.jpg?1",
             "name": "Tidehollow Strix",
             "text": "Flying\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -7103,7 +7103,7 @@
         },
         {
             "id": "f335ad3a-d7b3-526c-bad7-a092b53bb30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d28fd77-1f7c-47b4-b9ff-55835a7f2526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d28fd77-1f7c-47b4-b9ff-55835a7f2526.jpg?1",
             "name": "Titanic Ultimatum",
             "text": "Until end of turn, creatures you control get +5/+5 and gain first strike, lifelink, and trample.",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "374521b1-28bf-596b-b875-67da4564f9f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10504d1b-8d3e-411a-bf40-51a8e7a863a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10504d1b-8d3e-411a-bf40-51a8e7a863a0.jpg?1",
             "name": "Tower Gargoyle",
             "text": "Flying",
             "colours": [
@@ -7178,7 +7178,7 @@
         },
         {
             "id": "88593e5b-ab39-58c0-81f4-5172f3fecc08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6ac9ce-e163-426f-8fbd-5ee1ec177dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6ac9ce-e163-426f-8fbd-5ee1ec177dc1.jpg?1",
             "name": "Violent Ultimatum",
             "text": "Destroy three target permanents.",
             "colours": [
@@ -7214,7 +7214,7 @@
         },
         {
             "id": "64dad49d-44a1-55bc-a75e-2f5d209c34ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75ebcb4-5db8-4c72-9f65-8ee8f2c893ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75ebcb4-5db8-4c72-9f65-8ee8f2c893ea.jpg?1",
             "name": "Waveskimmer Aven",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -7253,7 +7253,7 @@
         },
         {
             "id": "71e72a68-6b5f-50c7-bec8-99fdf936f3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0e7d-9146-402f-898e-16a0ff08d368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0e7d-9146-402f-898e-16a0ff08d368.jpg?1",
             "name": "Windwright Mage",
             "text": "Lifelink (Whenever this creature deals damage, you gain that much life.)\nWindwright Mage has flying as long as an artifact card is in your graveyard.",
             "colours": [
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "01bc9e62-f8b9-5ecd-84fb-7af022492617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5907d5-ae5c-4c9d-a5df-61f1c94f979d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5907d5-ae5c-4c9d-a5df-61f1c94f979d.jpg?1",
             "name": "Woolly Thoctar",
             "text": "",
             "colours": [
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "94b40729-8d60-5d41-b65e-5ef1c927909e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78aa9a89-b7bf-49bc-a6e8-793d52120a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78aa9a89-b7bf-49bc-a6e8-793d52120a22.jpg?1",
             "name": "Lich's Mirror",
             "text": "If you would lose the game, instead shuffle your hand, your graveyard, and all permanents you own into your library, then draw seven cards and your life total becomes 20.",
             "colours": [],
@@ -7359,7 +7359,7 @@
         },
         {
             "id": "bf059961-8133-5dd1-83e0-98ee903310d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a48f9-4f14-4d19-b3dc-3bf3fafac32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a48f9-4f14-4d19-b3dc-3bf3fafac32d.jpg?1",
             "name": "Minion Reflector",
             "text": "Whenever a nontoken creature comes into play under your control, you may pay {2}. If you do, put a token into play that's a copy of that creature. That token has haste and \"At end of turn, sacrifice this permanent.\"",
             "colours": [],
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "6b9b966e-e28f-55ee-b86e-7b927d9aab9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cefe6ab-c018-4b87-8948-295a28f63cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cefe6ab-c018-4b87-8948-295a28f63cb1.jpg?1",
             "name": "Obelisk of Bant",
             "text": "{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [],
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "8e39d5b8-c326-5e69-82a9-c2a36796a513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19869e75-0925-45dc-b5d9-6968fbfb35b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19869e75-0925-45dc-b5d9-6968fbfb35b5.jpg?1",
             "name": "Obelisk of Esper",
             "text": "{T}: Add {W}, {U}, or {B} to your mana pool.",
             "colours": [],
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "863a9b29-b699-588e-828e-dd0c95d2ecf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200e41f-fe10-4c39-ab12-c6e13fb81a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200e41f-fe10-4c39-ab12-c6e13fb81a3d.jpg?1",
             "name": "Obelisk of Grixis",
             "text": "{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7483,7 +7483,7 @@
         },
         {
             "id": "6a3f7df6-2a19-519b-8350-1b36e62debe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe1a49a-5c1c-4274-a2ed-9a8a44abfaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe1a49a-5c1c-4274-a2ed-9a8a44abfaa6.jpg?1",
             "name": "Obelisk of Jund",
             "text": "{T}: Add {B}, {R}, or {G} to your mana pool.",
             "colours": [],
@@ -7515,7 +7515,7 @@
         },
         {
             "id": "3880e794-6024-525b-8e65-29255a7d5c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6317b0-15fd-4924-9302-41bed2354546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6317b0-15fd-4924-9302-41bed2354546.jpg?1",
             "name": "Obelisk of Naya",
             "text": "{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [],
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "f22a3c3c-fad2-53d5-97d2-fd7f924c937d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d1b27-fb90-4649-a905-f8e90d4a1852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d1b27-fb90-4649-a905-f8e90d4a1852.jpg?1",
             "name": "Quietus Spike",
             "text": "Equipped creature has deathtouch.\nWhenever equipped creature deals combat damage to a player, that player loses half his or her life, rounded up.\nEquip {3}",
             "colours": [],
@@ -7577,7 +7577,7 @@
         },
         {
             "id": "f2ac8a61-cd66-5a26-b235-e53b497c5fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c41192-64ef-43aa-9af0-75f0d3f56688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c41192-64ef-43aa-9af0-75f0d3f56688.jpg?1",
             "name": "Relic of Progenitus",
             "text": "{T}: Target player removes a card in his or her graveyard from the game.\n{1}, Remove Relic of Progenitus from the game: Remove all graveyards from the game. Draw a card.",
             "colours": [],
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "f1b2db02-3202-5897-b76d-727c64a88b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac2d98-bc5d-4823-9903-b880988ff0f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac2d98-bc5d-4823-9903-b880988ff0f4.jpg?1",
             "name": "Sigil of Distinction",
             "text": "Sigil of Distinction comes into play with X charge counters on it.\nEquipped creature gets +1/+1 for each charge counter on Sigil of Distinction.\nEquip\u2014\nRemove a charge counter from Sigil of Distinction.",
             "colours": [],
@@ -7635,7 +7635,7 @@
         },
         {
             "id": "7771916d-6540-5894-b03c-ba6bc70040f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edc0681-4252-4d3d-baf3-f03c22af1208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6edc0681-4252-4d3d-baf3-f03c22af1208.jpg?1",
             "name": "Arcane Sanctum",
             "text": "Arcane Sanctum comes into play tapped.\n{T}: Add {W}, {U}, or {B} to your mana pool.",
             "colours": [],
@@ -7667,7 +7667,7 @@
         },
         {
             "id": "0c5d1d3b-484a-593b-805f-63ca0eab0ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c6b34-0066-47f8-8062-9363c024fa56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c6b34-0066-47f8-8062-9363c024fa56.jpg?1",
             "name": "Bant Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Bant Panorama: Search your library for a basic Forest, Plains, or Island card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7695,7 +7695,7 @@
         },
         {
             "id": "2165c158-4c3a-55fe-a896-710a4442a2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94da8e38-77a4-4d25-9e1f-f33c246f60c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94da8e38-77a4-4d25-9e1f-f33c246f60c8.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "Crumbling Necropolis comes into play tapped.\n{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "015b2039-2985-5e79-bf02-3f5c73f1687d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03324b45-dd69-45d2-a1c0-e3cc4cf1eaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03324b45-dd69-45d2-a1c0-e3cc4cf1eaf5.jpg?1",
             "name": "Esper Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Esper Panorama: Search your library for a basic Plains, Island, or Swamp card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "66192c87-6509-5ada-8e90-9f682d4b4984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca30ea9e-9302-4dd0-a572-b5c6e6894851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca30ea9e-9302-4dd0-a572-b5c6e6894851.jpg?1",
             "name": "Grixis Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Grixis Panorama: Search your library for a basic Island, Swamp, or Mountain card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "67315436-4f4d-5470-9836-0bd48632da59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b31fcd-43eb-44ad-b63e-4f2e6984963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b31fcd-43eb-44ad-b63e-4f2e6984963c.jpg?1",
             "name": "Jund Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Jund Panorama: Search your library for a basic Swamp, Mountain, or Forest card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "f2d014f8-3641-5ad6-8dc7-108b563743aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine comes into play tapped.\n{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [],
@@ -7843,7 +7843,7 @@
         },
         {
             "id": "1962172e-244e-5135-82c2-165f6bbe5290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba31e86-0924-424d-b4e3-41a878e3e0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba31e86-0924-424d-b4e3-41a878e3e0e1.jpg?1",
             "name": "Naya Panorama",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Naya Panorama: Search your library for a basic Mountain, Forest, or Plains card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "e3b4dc9f-7074-5c8d-b2f8-0f64503ac3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bcded3-6eea-4533-a855-e03d4c4620d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bcded3-6eea-4533-a855-e03d4c4620d6.jpg?1",
             "name": "Savage Lands",
             "text": "Savage Lands comes into play tapped.\n{T}: Add {B}, {R}, or {G} to your mana pool.",
             "colours": [],
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "f34d3f11-9b48-5a23-8915-586a230ce2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1995d2a-4550-4c84-ad44-183b06579e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1995d2a-4550-4c84-ad44-183b06579e98.jpg?1",
             "name": "Seaside Citadel",
             "text": "Seaside Citadel comes into play tapped.\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [],
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "80e1113b-ba55-5026-a221-eb97d0d1441b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e2710-7b95-46d0-8261-0afa6b192e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e2710-7b95-46d0-8261-0afa6b192e70.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "f61366f9-cc2e-52e1-afa7-57ecbb72472b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef285a1-dbd0-4e41-9f04-a9120a0421f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef285a1-dbd0-4e41-9f04-a9120a0421f7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8011,7 +8011,7 @@
         },
         {
             "id": "a276b18e-9f96-56b9-a60a-2155f039946a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd1595-d94d-46b1-b87f-b910ae35fa3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdd1595-d94d-46b1-b87f-b910ae35fa3a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "d6b2d79d-d5ba-5c42-932e-460ed84e9e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aec487-ac03-4912-969b-f537864902ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aec487-ac03-4912-969b-f537864902ce.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8087,7 +8087,7 @@
         },
         {
             "id": "7cc0f7a3-770a-5da4-94be-f8875ef0b8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdcf679-4269-4ed9-84f1-1ac7a513f475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdcf679-4269-4ed9-84f1-1ac7a513f475.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "87d18412-d5d1-5021-b653-55efed8d020f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e659905-5f87-4181-8fc8-59ab2138b7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e659905-5f87-4181-8fc8-59ab2138b7fc.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "ddbf57b2-3b87-5923-827a-78f81c68ef8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf6f14a-99d1-4abd-b36f-a5819718a43f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf6f14a-99d1-4abd-b36f-a5819718a43f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "57f533cc-97fe-57c6-865a-594af5edc9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb31304-eff0-44f9-b240-b7fa631ea4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb31304-eff0-44f9-b240-b7fa631ea4ce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "936b1a90-e718-56b7-b212-ec394144061a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbe554-ffdc-4de6-bf27-57790b71effb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbe554-ffdc-4de6-bf27-57790b71effb.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "a1cf29d8-331c-5877-8e01-7095c54b7390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e809db1f-12d7-4556-bdd2-db832f991cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e809db1f-12d7-4556-bdd2-db832f991cd0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8315,7 +8315,7 @@
         },
         {
             "id": "be5ed61f-3d14-5356-8d1e-5be6a8875592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ec4ca-ab4c-4d5f-98df-aa166b60bb1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ec4ca-ab4c-4d5f-98df-aa166b60bb1d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "30f98b02-abcd-5b08-91db-80b13ca6cf0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3133726-0eda-480c-9d67-64719cb77f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3133726-0eda-480c-9d67-64719cb77f1d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "a6768016-14b4-5dde-a17d-12a22fd53aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2cc19c-84ce-4c0b-b56f-7a2b3878a26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2cc19c-84ce-4c0b-b56f-7a2b3878a26e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "b553531d-25aa-506f-a990-4e2ff3258ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfb1db3-c0ea-4f8d-8208-5f8895ff686d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfb1db3-c0ea-4f8d-8208-5f8895ff686d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "77058e43-ac8d-54e6-8264-d9656e8d5168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969d5979-8ae8-4442-a3a5-3412ffeb5af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969d5979-8ae8-4442-a3a5-3412ffeb5af8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "3738c7a7-6e82-53ca-b45a-36caa3f02213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e4622-e905-49da-948f-aeba1ba674ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e4622-e905-49da-948f-aeba1ba674ce.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "e0cfd303-b175-5646-888a-8c90bf555d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12495cfa-ab19-4e9e-a49e-a94499f664a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12495cfa-ab19-4e9e-a49e-a94499f664a2.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "b807bb5a-1ecc-512a-a26a-1d332a30d4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8a605e-73a6-4666-ae08-ec6e9845e629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8a605e-73a6-4666-ae08-ec6e9845e629.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "0716a7c6-ae72-55de-9229-6635555da05c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368be73f-24d2-44db-a55e-d04176db3142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368be73f-24d2-44db-a55e-d04176db3142.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8657,7 +8657,7 @@
         },
         {
             "id": "0e17ef07-92d3-5717-8841-bc0206c9e5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bc8e3-b106-43bb-acf6-885328d24a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bc8e3-b106-43bb-acf6-885328d24a65.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "96472135-42b3-5127-8e18-240d592cce1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e181878-d9fb-44d5-98ce-2899793ab2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e181878-d9fb-44d5-98ce-2899793ab2e7.jpg?1",
             "name": "Rafiq of the Many",
             "text": "",
             "colours": [
@@ -8737,7 +8737,7 @@
         },
         {
             "id": "cc38a9ca-b576-5193-aa82-324eac09d676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "f11ebafa-5f5f-5ae3-9d32-a18e812e74b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3546df95-926d-421d-a763-e559a1847273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3546df95-926d-421d-a763-e559a1847273.jpg?1",
             "name": "Homunculus",
             "text": "",
             "colours": [
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "8cc5adc3-60ab-5f43-a619-e0eb073dcbc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510a8b-a5a2-421b-a8b4-5ab60c848628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510a8b-a5a2-421b-a8b4-5ab60c848628.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "e916c0a8-79eb-5b79-9143-8f5f8237fa9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894192e-782b-49ef-b9fc-28b76e2268ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894192e-782b-49ef-b9fc-28b76e2268ab.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "3e71087a-c958-51d8-b915-14a23d6c660f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "7c8f18d1-8d46-5d55-89f2-0441c12fd638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "86b88555-4c47-554d-a097-dfb4854bb61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2b01b8-3dcb-4eab-9402-0db343543c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2b01b8-3dcb-4eab-9402-0db343543c38.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "8d4c65cf-be37-53bc-a823-5a87eb5f2521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4b6d1-c5f5-4a2d-a00c-97f6395c941b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4b6d1-c5f5-4a2d-a00c-97f6395c941b.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "c0edfb5e-e4bc-52df-aa04-92671cb93cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9045,7 +9045,7 @@
         },
         {
             "id": "e73801f6-f0d4-5bce-b7ef-b559c990a996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7382e4b-43dc-4b35-8a9e-ab886ea0a981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7382e4b-43dc-4b35-8a9e-ab886ea0a981.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/ALL.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ALL.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fdac1889-3454-5860-9899-9dc7bf20e058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5543b08d-d470-435e-83d9-a3a84c1cc2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5543b08d-d470-435e-83d9-a3a84c1cc2e6.jpg?1",
             "name": "Carrier Pigeons",
             "text": "Flying\nDraw a card at the beginning of the upkeep of the turn after Carrier Pigeons comes into play.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "e43ab3e7-0296-52f9-881d-a1010b200493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68befe-78bc-4d9c-968b-f7e6b3042f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68befe-78bc-4d9c-968b-f7e6b3042f27.jpg?1",
             "name": "Carrier Pigeons",
             "text": "Flying\nDraw a card at the beginning of the upkeep of the turn after Carrier Pigeons comes into play.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "23aaaf1c-be7d-5398-9d5e-c752de17f5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3c539b-4039-45c2-8d43-80648d946e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3c539b-4039-45c2-8d43-80648d946e91.jpg?1",
             "name": "Errand of Duty",
             "text": "Put a Knight token into play. Treat this token as a 1/1 white creature with banding.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "1299ff49-3c05-5a40-b03f-19c6786fb010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7362e2-8dc0-4d76-a4eb-55ed56b1cd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7362e2-8dc0-4d76-a4eb-55ed56b1cd66.jpg?1",
             "name": "Errand of Duty",
             "text": "Put a Knight token into play. Treat this token as a 1/1 white creature with banding.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "52fdc2da-8152-538b-be8f-f9aadcbe9a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b85ff-ed03-4b3e-872f-1cad1a27b930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108b85ff-ed03-4b3e-872f-1cad1a27b930.jpg?1",
             "name": "Exile",
             "text": "Remove target non-white attacking creature from the game. Gain life equal to that creature's toughness.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "56531814-5941-5e9b-8a28-6f3a71a0f7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe88de7-b226-4a43-9662-8b408e4281d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe88de7-b226-4a43-9662-8b408e4281d3.jpg?1",
             "name": "Inheritance",
             "text": "o3: Draw a card. Use this ability only when a creature is put into the graveyard from play, and only once for each creature put into the graveyard.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "d6bab378-ba71-563e-89e2-bb8fdaba707e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365820e4-7b43-423b-98ce-f383eb4d2a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365820e4-7b43-423b-98ce-f383eb4d2a96.jpg?1",
             "name": "Ivory Gargoyle",
             "text": "Flying\nIf Ivory Gargoyle is put into the graveyard from play, put it into play under owner's control at end of turn and skip your next draw phase.\no4o\nW: Remove Ivory Gargoyle from the game.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "aa214087-ddbf-56a4-b267-dbd5a7eba82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d10f-7368-4b40-b4a6-baf46c616c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d10f-7368-4b40-b4a6-baf46c616c34.jpg?1",
             "name": "Juniper Order Advocate",
             "text": "As long as Juniper Order Advocate is untapped, all green creatures you control get +1/+1.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "e56ad485-0b14-5c78-8875-2d899d51310d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7536a-5417-4de0-9a48-82a5f82d9af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7536a-5417-4de0-9a48-82a5f82d9af4.jpg?1",
             "name": "Kjeldoran Escort",
             "text": "Banding",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "a7daa7b9-93fc-5b52-bedd-3d2689117d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f54ca5-1f1b-40c7-ad0b-569c54d1b5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f54ca5-1f1b-40c7-ad0b-569c54d1b5aa.jpg?1",
             "name": "Kjeldoran Escort",
             "text": "Banding",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "ce976068-66ea-53fd-ba96-0a0d1dc17e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d16f9-848f-44ca-8e85-d01a58558077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d16f9-848f-44ca-8e85-d01a58558077.jpg?1",
             "name": "Kjeldoran Home Guard",
             "text": "At the end of any combat in which Kjeldoran Home Guard attacked or blocked, put a -0/-1 counter on Kjeldoran Home Guard and put a Deserter token into play. Treat this token as a 0/1 white creature.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "33aa3b02-e2cb-5b4d-9517-38ef709eb0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0acdf4d-6fdd-4430-9204-9c80dc8fb387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0acdf4d-6fdd-4430-9204-9c80dc8fb387.jpg?1",
             "name": "Kjeldoran Pride",
             "text": "Enchanted creature gets +1/+2.\no2o\nU: Switch Kjeldoran Pride from creature it enchants to another creature. Kjeldoran Pride's new target must be legal. Treat Kjeldoran Pride as though it were just cast on the new target.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "00f811a9-f7e1-5956-88ce-93d0312674b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88d1c1a-b53e-459b-8a83-4d559177188a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88d1c1a-b53e-459b-8a83-4d559177188a.jpg?1",
             "name": "Kjeldoran Pride",
             "text": "Enchanted creature gets +1/+2.\no2o\nU: Switch Kjeldoran Pride from creature it enchants to another creature. Kjeldoran Pride's new target must be legal. Treat Kjeldoran Pride as though it were just cast on the new target.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "8be7755b-fcd9-5ada-9526-bd93f2dbcae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab5775a-7138-4526-83fe-350127695224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab5775a-7138-4526-83fe-350127695224.jpg?1",
             "name": "Martyrdom",
             "text": "Until end of turn, you may redirect to target creature you control any amount of damage.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "16d098dc-40a6-5610-ba62-1125513ea093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f91817-8e79-4885-a57b-d26241c4791f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f91817-8e79-4885-a57b-d26241c4791f.jpg?1",
             "name": "Martyrdom",
             "text": "Until end of turn, you may redirect to target creature you control any amount of damage.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "ce8bd807-d92a-5cd6-baa6-f80a2b98cbdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a35751-a232-40ba-a73b-d3ca7a44867d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a35751-a232-40ba-a73b-d3ca7a44867d.jpg?1",
             "name": "Noble Steeds",
             "text": "o1o\nW: Target creature gains first strike until end of turn.",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "a3aa07a1-553e-5b70-a6f1-a5257247524c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bc5b2-c5fb-4340-9c11-73891adb4b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bc5b2-c5fb-4340-9c11-73891adb4b93.jpg?1",
             "name": "Noble Steeds",
             "text": "o1o\nW: Target creature gains first strike until end of turn.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "63edf68b-588c-5732-9b8f-21c89e6cff63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d734086b-a0fb-4504-96e5-89842aa587b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d734086b-a0fb-4504-96e5-89842aa587b3.jpg?1",
             "name": "Reinforcements",
             "text": "Put up to three target creature cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "13ad77f4-59ef-567f-9d13-35f6b5ec6274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b26881-3ad7-4d70-8051-a7e222d910bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b26881-3ad7-4d70-8051-a7e222d910bf.jpg?1",
             "name": "Reinforcements",
             "text": "Put up to three target creature cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "a4ffe3b0-55a6-52e6-9a5b-29dd55585da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179f50be-6658-42f4-b9b9-c97c7d3f239a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179f50be-6658-42f4-b9b9-c97c7d3f239a.jpg?1",
             "name": "Reprisal",
             "text": "Bury target creature with power 4 or greater.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "935eddd3-c047-5d3c-aa22-eb77f411cdf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839df85a-1aca-4d4b-b327-2778caa6d289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839df85a-1aca-4d4b-b327-2778caa6d289.jpg?1",
             "name": "Reprisal",
             "text": "Bury target creature with power 4 or greater.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "28c6ea87-7f8d-5794-b2b6-a92c1edd1481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22231f5-30af-4f46-b2c9-0b71124c6939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22231f5-30af-4f46-b2c9-0b71124c6939.jpg?1",
             "name": "Royal Decree",
             "text": "Cumulative Upkeep: o\nW\nWhenever a swamp, mountain, black permanent, or red permanent becomes tapped, Royal Decree deals 1 damage to that permanent's controller.",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "567aded4-6a5a-5b47-b563-00f5b9062e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027e03e1-1a39-47ba-b206-44d022b4c346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027e03e1-1a39-47ba-b206-44d022b4c346.jpg?1",
             "name": "Royal Herbalist",
             "text": "o2: Remove the top card of your library from the game to gain 1 life.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "82aa7009-5782-548e-922a-f145bd59addf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6456ee12-7c09-434e-9028-613506ef7ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6456ee12-7c09-434e-9028-613506ef7ff6.jpg?1",
             "name": "Royal Herbalist",
             "text": "o2: Remove the top card of your library from the game to gain 1 life.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "4c8d3de1-4626-57da-9a26-261a0998ed8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632870c3-7c0b-48ad-865d-95f8c4e887d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632870c3-7c0b-48ad-865d-95f8c4e887d0.jpg?1",
             "name": "Scars of the Veteran",
             "text": "You may remove a white card in your hand from the game instead of paying Scars of the Veteran's casting cost.\nPrevent up to 7 damage to target creature or player. For each 1 damage to a creature prevented by Scars of the Veteran, put a +0/+1 counter on that creature at end of turn.",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "ac424936-0598-5298-8d85-c38144d9f4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8be4b6b-23a2-42d2-911d-fa14f7f5a95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8be4b6b-23a2-42d2-911d-fa14f7f5a95b.jpg?1",
             "name": "Seasoned Tactician",
             "text": "o3: Remove the top four cards of your library from the game to prevent all damage to you from one source.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "06ac3cbe-0b3a-5c14-bdd2-122fec0cdd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecf91a-9ce1-44a1-8859-7163d32cfba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecf91a-9ce1-44a1-8859-7163d32cfba6.jpg?1",
             "name": "Sustaining Spirit",
             "text": "Cumulative Upkeep: o1o\nW\nAny damage that would reduce your life total to less than 1 instead reduces it to 1.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "d01679ad-e2d7-54a7-8e5a-d3f0b8863f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328e6ceb-30f7-415e-93b4-7075af0fed89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328e6ceb-30f7-415e-93b4-7075af0fed89.jpg?1",
             "name": "Sworn Defender",
             "text": "o1: Change Sworn Defender's power to the toughness of target creature blocking or being blocked by Sworn Defender, minus 1, until end of turn. Change Sworn Defender's toughness to 1 plus the power of that creature, until end of turn.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "51b8e655-e99f-5965-bb7a-e2b20fb980d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d2c73-1934-4504-bbfb-62ba82e0a0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d2c73-1934-4504-bbfb-62ba82e0a0e3.jpg?1",
             "name": "Unlikely Alliance",
             "text": "o1o\nW: Target non-attacking, non-blocking creature gets +0/+2 until end of turn.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "8d67c057-3b49-5ceb-bb88-116d0e97563e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0decda-d77a-4b7b-8ca4-08528d476f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0decda-d77a-4b7b-8ca4-08528d476f51.jpg?1",
             "name": "Wild Aesthir",
             "text": "Flying, first strike\no\nWo\nW: +2/+0 until end of turn. You cannot spend more than o\nWo\nW in this way each turn.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "858dddc4-8308-5f6f-920b-ccf7f0c2c7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffecf097-a5b1-4bd9-ac3f-784bd44e447c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffecf097-a5b1-4bd9-ac3f-784bd44e447c.jpg?1",
             "name": "Wild Aesthir",
             "text": "Flying, first strike\no\nWo\nW: +2/+0 until end of turn. You cannot spend more than o\nWo\nW in this way each turn.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "e8db1150-b771-56d3-8040-4b84ddbe39d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c5728e-43e7-417a-ba18-5038345cec67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c5728e-43e7-417a-ba18-5038345cec67.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. That spell's caster may draw up to two cards at the beginning of the next turn's upkeep.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "825770fb-6760-5b0d-993f-0dfe58b55aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a3104-90e6-4235-b67f-69337c7fe714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a3104-90e6-4235-b67f-69337c7fe714.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. That spell's caster may draw up to two cards at the beginning of the next turn's upkeep.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "0552859b-7408-5f6a-969e-dfd367796fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80017e84-87bc-4eb8-a663-5c263d8df812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80017e84-87bc-4eb8-a663-5c263d8df812.jpg?1",
             "name": "Awesome Presence",
             "text": "Enchanted creature cannot be blocked unless defending player pays an additional o3 for each creature assigned to block enchanted creature.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "3ba29eaf-b8f4-59da-b3ec-e3ab5a3d89d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8a120-5c13-4852-bdc8-80ae50a6e3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8a120-5c13-4852-bdc8-80ae50a6e3d3.jpg?1",
             "name": "Awesome Presence",
             "text": "Enchanted creature cannot be blocked unless defending player pays an additional o3 for each creature assigned to block enchanted creature.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "c51ae66a-1de7-5569-a7ae-2d5c18fa9f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146eb650-92c8-48a9-a40d-e7bba6545f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146eb650-92c8-48a9-a40d-e7bba6545f36.jpg?1",
             "name": "Benthic Explorers",
             "text": "oc\nT: Untap target tapped land an opponent controls to add one mana of any type that land produces to your mana pool.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "14baaad6-3504-5f4b-8c60-df275b1c89b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397d7602-d374-484c-aab2-3e57f12ceaa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397d7602-d374-484c-aab2-3e57f12ceaa4.jpg?1",
             "name": "Benthic Explorers",
             "text": "oc\nT: Untap target tapped land an opponent controls to add one mana of any type that land produces to your mana pool.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "6f17b55f-3144-5528-8a7c-086d1699baaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578549f0-5643-4891-b467-2d1cb49fe4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578549f0-5643-4891-b467-2d1cb49fe4ea.jpg?1",
             "name": "Browse",
             "text": "o2o\nUo\nU: Look at the top five cards of your library and put one of them into your hand. Remove the remaining four from the game.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "10c5f3d9-8531-553e-ba33-0fcf07f59866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375ec24-4841-4792-ad58-f29cdf0d1bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a375ec24-4841-4792-ad58-f29cdf0d1bbb.jpg?1",
             "name": "Diminishing Returns",
             "text": "Each player shuffles his or her hand and graveyard into his or her library. Remove the top ten cards of your library from the game. Each player draws up to seven cards.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "ec74fd98-0487-539a-a4a9-4b46462d5533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69773e2b-bfee-449d-b8e8-5646442f5487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69773e2b-bfee-449d-b8e8-5646442f5487.jpg?1",
             "name": "False Demise",
             "text": "If enchanted creature is put into the graveyard, return that creature to play under your control as though it were just cast.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "771f2ce8-6590-534e-88ce-d783f50888b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e844464-cf1b-4a34-ac37-3a4da858c6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e844464-cf1b-4a34-ac37-3a4da858c6bf.jpg?1",
             "name": "False Demise",
             "text": "If enchanted creature is put into the graveyard, return that creature to play under your control as though it were just cast.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "804ddf5e-9a08-51c7-af44-491e487cee4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a879b60-4381-447d-8a5a-8e0b6a1d49ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a879b60-4381-447d-8a5a-8e0b6a1d49ca.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and remove a blue card in your hand from the game instead of paying Force of Will's casting cost. Effects that prevent or redirect damage cannot be used to counter this loss of life.\nCounter target spell.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "b6432856-d0b5-580e-8058-3c4f2d476359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12e624c-8879-4e60-a1be-286abc5e0106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12e624c-8879-4e60-a1be-286abc5e0106.jpg?1",
             "name": "Foresight",
             "text": "Search your library for any three cards and remove them from the game. Shuffle your library afterwards.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "1902d567-81ea-5399-921d-e5a2fa9134f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fe74e0-bcde-4176-8da5-38e78daad5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fe74e0-bcde-4176-8da5-38e78daad5e5.jpg?1",
             "name": "Foresight",
             "text": "Search your library for any three cards and remove them from the game. Shuffle your library afterwards.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "8389620a-4077-5f56-9d56-19cdafb322fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3420b-424e-4c30-b329-bc4447f121d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3420b-424e-4c30-b329-bc4447f121d3.jpg?1",
             "name": "Lat-Nam's Legacy",
             "text": "Choose a card from your hand and shuffle that card into your library to draw two cards at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1518,7 +1518,7 @@
         },
         {
             "id": "f663d93f-b36d-52f5-b33a-851e0ec3c4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3b0741-dd5e-4d98-a50b-19a0f20dd72c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3b0741-dd5e-4d98-a50b-19a0f20dd72c.jpg?1",
             "name": "Lat-Nam's Legacy",
             "text": "Choose a card from your hand and shuffle that card into your library to draw two cards at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "45fb073d-5dd7-521c-92b4-6f2e0d77909b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5fa739-e8d4-4e1d-8b6b-c334d1e91bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5fa739-e8d4-4e1d-8b6b-c334d1e91bef.jpg?1",
             "name": "Library of Lat-Nam",
             "text": "Target opponent chooses one: you draw three cards at the beginning of the next turn's upkeep; or you search your library for a card, put it into your hand, and then shuffle your library.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "3ed62ab5-c4d7-581f-9afa-4edba59ed519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84617c7-c70a-497c-b834-3d98346180cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84617c7-c70a-497c-b834-3d98346180cf.jpg?1",
             "name": "Phantasmal Sphere",
             "text": "Flying\nAt the beginning of your upkeep, put a +1/+1 counter on Phantasmal Sphere. During your upkeep, pay o1 for each of these +1/+1 counters or bury Phantasmal Sphere.\nIf Phantasmal Sphere leaves play, put an Orb token into play under target opponent's control. Treat this token as a */* blue creature with flying, where * is equal to the number of these +1/+1 counters on Phantasmal Sphere.",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "9ca59128-cd47-51e6-8dfe-e5db4d08d2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46accc8-b926-4443-bc12-dfd5870b2d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46accc8-b926-4443-bc12-dfd5870b2d2e.jpg?1",
             "name": "Soldevi Heretic",
             "text": "o\nW, oc\nT: Prevent up to 2 damage to any creature. Target opponent may draw a card.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "774184b6-ec2e-5557-b5f6-a05792d11611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9613ca47-c9d1-4485-b0bd-71b0b587567e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9613ca47-c9d1-4485-b0bd-71b0b587567e.jpg?1",
             "name": "Soldevi Heretic",
             "text": "o\nW, oc\nT: Prevent up to 2 damage to any creature. Target opponent may draw a card.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "3fff50ac-faaf-5718-b978-9b0d40f35c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392841-2df5-47f1-9868-edae3376e35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392841-2df5-47f1-9868-edae3376e35a.jpg?1",
             "name": "Soldevi Sage",
             "text": "oc\nT: Sacrifice two lands to draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "f37d4358-4531-501d-a67c-58a11c2936bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53dc5902-817c-4a85-a0b9-20555574fad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53dc5902-817c-4a85-a0b9-20555574fad1.jpg?1",
             "name": "Soldevi Sage",
             "text": "oc\nT: Sacrifice two lands to draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "732d9004-c6c0-5c6c-891f-29f2a7d2418a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4242dda-6078-481d-a068-e7b10c873b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4242dda-6078-481d-a068-e7b10c873b89.jpg?1",
             "name": "Spiny Starfish",
             "text": "o\nU: Regenerate\nAt the end of any turn in which Spiny Starfish regenerated, put a Starfish token into play for each time it regenerated that turn. Treat these tokens as 0/1 blue creatures.",
             "colours": [
@@ -1794,7 +1794,7 @@
         },
         {
             "id": "143207e5-b63d-5ff5-ae7c-254d02912a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ea78-16f1-46ac-8a60-db20c37aad5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ea78-16f1-46ac-8a60-db20c37aad5e.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "d5c5a847-944e-5c9c-bb53-88f51446f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbf72f7-2360-4105-beae-946556884e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbf72f7-2360-4105-beae-946556884e40.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "b51c6ae8-e690-5646-bf60-f6b929afb92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24de2b5e-78b1-490d-ac47-67f7076bc6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24de2b5e-78b1-490d-ac47-67f7076bc6b6.jpg?1",
             "name": "Storm Elemental",
             "text": "Flying\no\nU: Remove the top card of your library from the game to tap target creature with flying.\no\nU: Remove the top card of your library from the game. If that card is a snow-covered land, Storm Elemental gets +1/+1 until end of turn.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "20f2b1ab-5df2-55d4-b668-f4f474432ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22104df-8147-45fd-897a-f99a815be062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22104df-8147-45fd-897a-f99a815be062.jpg?1",
             "name": "Suffocation",
             "text": "Play only when a red sorcery or instant deals damage to you. Suffocation deals 4 damage to that spell's caster.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1928,7 +1928,7 @@
         },
         {
             "id": "b0e3b786-769c-5039-8004-ff17f1338ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bbac1-ca51-4c72-9f1f-5fc6c82a4a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59bbac1-ca51-4c72-9f1f-5fc6c82a4a27.jpg?1",
             "name": "Thought Lash",
             "text": "Cumulative Upkeep: Remove the top card of your library from the game. If you do not, remove your library from the game and bury Thought Lash.\no0: Remove the top card of your library from the game to prevent 1 damage to you.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "8e9e7c5f-9420-51e7-a4e4-556fe45fcb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7b7d-3d37-4bb6-ab48-1fec2bfb4fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7b7d-3d37-4bb6-ab48-1fec2bfb4fdc.jpg?1",
             "name": "Tidal Control",
             "text": "Cumulative Upkeep: o2\nAny player may pay o2 or 2 life to counter target red or green spell. Play this ability as an interrupt. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "cc5b1957-ff14-5af3-852e-a3eb99f9a78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c3f55a-5aa7-42e1-9aab-168a7e61c112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c3f55a-5aa7-42e1-9aab-168a7e61c112.jpg?1",
             "name": "Viscerid Armor",
             "text": "Enchanted creature gets +1/+1.\no1o\nU: Return Viscerid Armor to owner's hand.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "b0d688ef-0246-596a-a1fb-e8c2eccce6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b719f89d-2a2c-460c-95e4-ada21353b340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b719f89d-2a2c-460c-95e4-ada21353b340.jpg?1",
             "name": "Viscerid Armor",
             "text": "Enchanted creature gets +1/+1.\no1o\nU: Return Viscerid Armor to owner's hand.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "a44218f0-7b2e-58ed-8443-b213864c37c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccd245f-e374-4bb8-8ac9-743b27ecf817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccd245f-e374-4bb8-8ac9-743b27ecf817.jpg?1",
             "name": "Viscerid Drone",
             "text": "oc\nT: Sacrifice a creature and a swamp to bury target non-artifact creature.\noc\nT: Sacrifice a creature and a snow-covered swamp to bury target creature.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "dfebf396-adbf-5d5c-8653-17a34e89218f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac1875a-feab-4213-aa15-69892b7df58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac1875a-feab-4213-aa15-69892b7df58b.jpg?1",
             "name": "Balduvian Dead",
             "text": "o2o\nR: Remove target summon card in your graveyard from the game to put a Graveborn token into play. Treat this token as a 3/1 black and red creature that can attack the turn it comes into play. Bury Graveborn token at end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "bbad8fb1-0dcb-57e5-83e8-0bc45593d85b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e823c295-b66e-41c3-bd77-1a13f95e69c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e823c295-b66e-41c3-bd77-1a13f95e69c3.jpg?1",
             "name": "Casting of Bones",
             "text": "If enchanted creature is put into the graveyard, draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "6d148149-9b44-5c2b-b46f-d4b6d92899a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88442ddf-c12b-4a25-804d-29fef5a90a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88442ddf-c12b-4a25-804d-29fef5a90a0c.jpg?1",
             "name": "Casting of Bones",
             "text": "If enchanted creature is put into the graveyard, draw three cards. Choose and discard one of those cards.",
             "colours": [
@@ -2198,7 +2198,7 @@
         },
         {
             "id": "4b6b7ee4-8b72-5faa-89f3-13fdc923fa88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8f94a-7690-47f5-b664-61411a32ab74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8f94a-7690-47f5-b664-61411a32ab74.jpg?1",
             "name": "Contagion",
             "text": "You may pay 1 life and remove a black card in your hand from the game instead of paying Contagion's casting cost. Effects that prevent or redirect damage cannot be used to counter this loss of life. Put two -2/-1 counters, distributed any way you choose, on any number of target creatures.",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "9d3730b5-54a1-545e-abb1-4cc93b9c6b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39703080-524d-4aa1-8c58-d512c41ae5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39703080-524d-4aa1-8c58-d512c41ae5d4.jpg?1",
             "name": "Diseased Vermin",
             "text": "During your upkeep, Diseased Vermin deals 1 damage to a single target opponent it has previously damaged for each infection counter on Diseased Vermin.\nIf Diseased Vermin damages a player in combat, put an infection counter on it.",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "f1c75d21-8922-57d9-a726-5ac3b6e5934c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bb451-706d-44ff-bbad-9ddc6f9f786a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bb451-706d-44ff-bbad-9ddc6f9f786a.jpg?1",
             "name": "Dystopia",
             "text": "Cumulative Upkeep: 1 life\nDuring each player's upkeep, if that player controls any green or white permanents, he or she sacrifices a green or white permanent.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "e80ae691-5537-5c22-963e-35f4b071923f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ba0b83-9671-4ee7-996d-57a3616b9c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ba0b83-9671-4ee7-996d-57a3616b9c66.jpg?1",
             "name": "Fatal Lore",
             "text": "Target opponent chooses one: you draw three cards; or you choose and bury up to two target creatures that opponent controls and he or she draws up to three cards.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "c41d14ca-f687-51c3-8861-0ec3c93470c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c185b4d-8da5-4b8a-85f0-5f0622c7bade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c185b4d-8da5-4b8a-85f0-5f0622c7bade.jpg?1",
             "name": "Feast or Famine",
             "text": "Bury target non-black, non-artifact creature or put a Zombie token into play. Treat this token as a 2/2 black creature.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "ba2be988-dafb-5b10-a77f-0ff3567c3018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac1586-c3d5-4add-bade-b527dcf4a391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ac1586-c3d5-4add-bade-b527dcf4a391.jpg?1",
             "name": "Feast or Famine",
             "text": "Bury target non-black, non-artifact creature or put a Zombie token into play. Treat this token as a 2/2 black creature.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "44495054-e580-514d-8f35-3a804029df9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e53d6c-67f5-4d74-8205-6325c75d1d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e53d6c-67f5-4d74-8205-6325c75d1d07.jpg?1",
             "name": "Fevered Strength",
             "text": "Target creature gets +2/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "5cba17d9-c520-53fa-a133-ed094fdea680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca621684-1e0d-44d3-8bc4-f77e354b9ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca621684-1e0d-44d3-8bc4-f77e354b9ab4.jpg?1",
             "name": "Fevered Strength",
             "text": "Target creature gets +2/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "a4c76392-3396-5188-b075-4e4895d2a44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfb7c7e-5a0a-4d4d-be98-ffed0386592b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfb7c7e-5a0a-4d4d-be98-ffed0386592b.jpg?1",
             "name": "Insidious Bookworms",
             "text": "o1o\nB: Target player discards a card at random from his or her hand. Use this ability only when Insidious Bookworms is put into the graveyard from play. You cannot spend more than o1o\nB in this way each turn.",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "1d6f45ab-e845-55c9-85e9-388b47007b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043cc2-1bd4-4b44-ba23-d2585ffc3841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043cc2-1bd4-4b44-ba23-d2585ffc3841.jpg?1",
             "name": "Insidious Bookworms",
             "text": "o1o\nB: Target player discards a card at random from his or her hand. Use this ability only when Insidious Bookworms is put into the graveyard from play. You cannot spend more than o1o\nB in this way each turn.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "158bc6bb-6abe-529a-b17a-6a60f901aa3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf8b0ec-f81a-488c-850c-098a8a3119e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf8b0ec-f81a-488c-850c-098a8a3119e5.jpg?1",
             "name": "Keeper of Tresserhorn",
             "text": "If Keeper of Tresserhorn attacks and is not blocked, it deals no damage to defending player this turn and that player loses 2 life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "3d0c202b-eca8-5ad7-8936-0d8215536888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3cb1c-6bde-4b55-b5bc-5b64b56930f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3cb1c-6bde-4b55-b5bc-5b64b56930f2.jpg?1",
             "name": "Krovikan Horror",
             "text": "At the end of any turn, if Krovikan Horror is in your graveyard with a summon card directly above it, you may put Krovikan Horror into your hand.\no1: Sacrifice a creature to have Krovikan Horror deal 1 damage to target creature or player.",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "f005d409-2b6a-509e-a18c-7198fc6c4448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b258e192-20af-4a45-981f-05181f4cd997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b258e192-20af-4a45-981f-05181f4cd997.jpg?1",
             "name": "Krovikan Plague",
             "text": "Play on a non-wall creature you control.\nDraw a card at the beginning of the upkeep of the turn after Krovikan Plague comes into play.\no0: Tap enchanted creature to have Krovikan Plague deal 1 damage to target creature or player. Put a -0/-1 counter on enchanted creature.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "3278d50f-d35a-5da4-a7c5-07f7c808e69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5afe9b5-3be8-472a-95c3-2c34231bc042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5afe9b5-3be8-472a-95c3-2c34231bc042.jpg?1",
             "name": "Lim-D\u00fbl's High Guard",
             "text": "First strike\no1o\nB: Regenerate",
             "colours": [
@@ -2661,7 +2661,7 @@
         },
         {
             "id": "4464aba0-c86e-5d5e-8aff-57d42acb6b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470fce6-30cf-43bd-a258-a9fde4be0be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470fce6-30cf-43bd-a258-a9fde4be0be8.jpg?1",
             "name": "Lim-D\u00fbl's High Guard",
             "text": "First strike\no1o\nB: Regenerate",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "5274c64d-b450-544b-abf0-76cbfe7368fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8638df-7915-4867-882a-95439486bd7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8638df-7915-4867-882a-95439486bd7b.jpg?1",
             "name": "Misinformation",
             "text": "Put up to three target cards from an opponent's graveyard on top of his or her library in any order.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "6677bdaf-704b-52e6-8f73-71a7d788a37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a05d428-7c70-4813-8e6c-20278cc0b0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a05d428-7c70-4813-8e6c-20278cc0b0bd.jpg?1",
             "name": "Phantasmal Fiend",
             "text": "o\nB: +1/-1 until end of turn\no1o\nU: Switch Phantasmal Fiend's power and toughness until end of turn. Effects that alter Phantasmal Fiend's power alter its toughness instead, and vice versa.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "6dee161b-7fcc-58f5-aa17-0997a5ceb846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2842a1-25b8-4c4b-b5f8-496929288ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2842a1-25b8-4c4b-b5f8-496929288ff3.jpg?1",
             "name": "Phantasmal Fiend",
             "text": "o\nB: +1/-1 until end of turn\no1o\nU: Switch Phantasmal Fiend's power and toughness until end of turn. Effects that alter Phantasmal Fiend's power alter its toughness instead, and vice versa.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "f32df083-3e01-5de3-8db5-88dcb9a7aaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9734708-d8e3-4d72-86b9-dd91fcfab5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9734708-d8e3-4d72-86b9-dd91fcfab5b4.jpg?1",
             "name": "Phyrexian Boon",
             "text": "As long as enchanted creature is black, it gets +2/+1; otherwise, it gets -1/-2.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "960e6281-13cd-546c-a673-04e23b41f4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f82668b-50b3-4746-b7fd-82f8560ebd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f82668b-50b3-4746-b7fd-82f8560ebd95.jpg?1",
             "name": "Phyrexian Boon",
             "text": "As long as enchanted creature is black, it gets +2/+1; otherwise, it gets -1/-2.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "6821924b-fea1-522f-952f-77103810d0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b4109-ae7c-451a-8576-97f817a70d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b4109-ae7c-451a-8576-97f817a70d75.jpg?1",
             "name": "Ritual of the Machine",
             "text": "Sacrifice a creature to gain control of target non-black, non-artifact creature.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "25213b29-35dd-5ca7-8511-393d3e68ce4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2651b0-1ab2-4d7e-834f-7505797da474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2651b0-1ab2-4d7e-834f-7505797da474.jpg?1",
             "name": "Soldevi Adnate",
             "text": "oc\nT: Sacrifice a black or artifact creature to add an amount of o\nB equal to that creature's casting cost to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "853a5287-06c3-52cd-8e5b-4ecb0ca95916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80812871-d9a7-40de-94a5-b854e55409db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80812871-d9a7-40de-94a5-b854e55409db.jpg?1",
             "name": "Soldevi Adnate",
             "text": "oc\nT: Sacrifice a black or artifact creature to add an amount of o\nB equal to that creature's casting cost to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2972,7 +2972,7 @@
         },
         {
             "id": "bee771c0-8dce-5d16-8659-1753d337a4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a45644-549a-4eaa-8367-b170027bd5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a45644-549a-4eaa-8367-b170027bd5a2.jpg?1",
             "name": "Stench of Decay",
             "text": "All non-artifact creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "6502c706-8cf1-5afb-a085-826a0c1e2a52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b93845-f17a-4892-a1ce-a4630dced218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b93845-f17a-4892-a1ce-a4630dced218.jpg?1",
             "name": "Stench of Decay",
             "text": "All non-artifact creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "b740442e-1776-52be-a648-7efdd7d6baf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cecc-449f-4cc6-ac4d-440722df0ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf8cecc-449f-4cc6-ac4d-440722df0ab9.jpg?1",
             "name": "Stromgald Spy",
             "text": "If Stromgald Spy attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, defending player must play with his or her hand face up on the table until Stromgald Spy leaves play.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "22868fb0-aa0f-570a-8851-2d98d8ac74be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21961b79-637a-4aa5-89b5-4e6e9f60d4d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21961b79-637a-4aa5-89b5-4e6e9f60d4d1.jpg?1",
             "name": "Swamp Mosquito",
             "text": "Flying\nIf Swamp Mosquito attacks and is not blocked, defending player gets a poison counter. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "ce98b81e-712a-5140-81fb-79d10a98c02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2fbe77-8757-4333-a083-975d5c3c6433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2fbe77-8757-4333-a083-975d5c3c6433.jpg?1",
             "name": "Swamp Mosquito",
             "text": "Flying\nIf Swamp Mosquito attacks and is not blocked, defending player gets a poison counter. If a player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "330baca6-81d9-531a-9e05-90fef79776e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7506f8-cf09-46ca-ad80-3c398c487ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7506f8-cf09-46ca-ad80-3c398c487ae2.jpg?1",
             "name": "Agent of Stromgald",
             "text": "o\nR: Add o\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -3179,7 +3179,7 @@
         },
         {
             "id": "df54abe8-ff7e-5b90-bd59-990d95a26018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9236d75-1724-4121-9fa9-57fa96b19361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9236d75-1724-4121-9fa9-57fa96b19361.jpg?1",
             "name": "Agent of Stromgald",
             "text": "o\nR: Add o\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "50b29747-09b9-5a6a-b382-fbcc69e71241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e167a6c-05f8-4d90-9f6b-eb0f1046d54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e167a6c-05f8-4d90-9f6b-eb0f1046d54a.jpg?1",
             "name": "Balduvian Horde",
             "text": "When Balduvian Horde comes into play, discard a card at random from your hand or bury Balduvian Horde.",
             "colours": [
@@ -3250,7 +3250,7 @@
         },
         {
             "id": "2e4959d4-d55c-5aea-8556-b7396ae373c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fd561e-6a26-4140-a033-1204f5dda5f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fd561e-6a26-4140-a033-1204f5dda5f3.jpg?1",
             "name": "Balduvian War-Makers",
             "text": "Rampage: 1\nBalduvian War-Makers can attack the turn it comes into play on your side.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "e4a3e2fa-034c-59cb-9c28-053570d1cbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada7aeb-0062-4fb2-8bcb-abdd75029fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada7aeb-0062-4fb2-8bcb-abdd75029fb2.jpg?1",
             "name": "Balduvian War-Makers",
             "text": "Rampage: 1\nBalduvian War-Makers can attack the turn it comes into play on your side.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "0f74c9e0-6ba0-5e9b-8bf9-b30dc838b96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626225b9-2cfd-4cf5-b11c-89e5a231b09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626225b9-2cfd-4cf5-b11c-89e5a231b09e.jpg?1",
             "name": "Bestial Fury",
             "text": "Draw a card at the beginning of the upkeep of the turn after Bestial Fury comes into play.\nIf enchanted creature attacks and is blocked, it gains trample and gets +4/+0 until end of turn.",
             "colours": [
@@ -3357,7 +3357,7 @@
         },
         {
             "id": "5dab5156-b4e0-5a8b-84b9-d839c2c4cb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271e0d7-0c55-4020-97de-b8a27ba51d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271e0d7-0c55-4020-97de-b8a27ba51d4b.jpg?1",
             "name": "Bestial Fury",
             "text": "Draw a card at the beginning of the upkeep of the turn after Bestial Fury comes into play.\nIf enchanted creature attacks and is blocked, it gains trample and gets +4/+0 until end of turn.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "36433d34-3713-55be-b9d6-c5edffa80637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8f5a18-e490-4010-ac1c-c74a5f2dcbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8f5a18-e490-4010-ac1c-c74a5f2dcbda.jpg?1",
             "name": "Burnout",
             "text": "Counter target interrupt spell if it is blue.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "8b2cc088-a54b-5972-bb26-5714280dcbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7d7c80-4e3c-454e-b2ed-6f0436df19c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7d7c80-4e3c-454e-b2ed-6f0436df19c9.jpg?1",
             "name": "Chaos Harlequin",
             "text": "o\nR: Remove the top card of your library from the game. If that card is a land, Chaos Harlequin gets -4/-0 until end of turn; otherwise, Chaos Harlequin gets +2/+0 until end of turn.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "285e4018-126d-52df-8bfd-f88dc64b93c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba841b44-475c-402c-ac11-763de0cf27d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba841b44-475c-402c-ac11-763de0cf27d9.jpg?1",
             "name": "Death Spark",
             "text": "Death Spark deals 1 damage to target creature or player.\nAt the end of your upkeep, if Death Spark is in your graveyard with a creature card directly above it, you may pay o1 to put Death Spark into your hand.",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "9fe797ee-5e0e-5204-9bd2-aa0d5ea39916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea21414e-65f7-4d65-b0dc-7fec7b9b416d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea21414e-65f7-4d65-b0dc-7fec7b9b416d.jpg?1",
             "name": "Enslaved Scout",
             "text": "o2: Mountainwalk until end of turn",
             "colours": [
@@ -3523,7 +3523,7 @@
         },
         {
             "id": "bc297d5e-8b78-50af-b0d6-2f7731b7f500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac0e04a-d223-426b-b856-2829dbdffda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac0e04a-d223-426b-b856-2829dbdffda0.jpg?1",
             "name": "Enslaved Scout",
             "text": "o2: Mountainwalk until end of turn",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "e09f2c53-0cf2-5d39-a69b-6000c8876942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8b213e-31ca-4eb5-bf0b-515a0ad4fd31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8b213e-31ca-4eb5-bf0b-515a0ad4fd31.jpg?1",
             "name": "Gorilla Shaman",
             "text": "o\nXo\nXo1: Destroy target non-creature artifact with casting cost equal to X.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "13d8d421-6ef4-586d-8908-f3108bd2e45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a16231c-1f73-4dec-9d88-e3d62e93a70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a16231c-1f73-4dec-9d88-e3d62e93a70f.jpg?1",
             "name": "Gorilla Shaman",
             "text": "o\nXo\nXo1: Destroy target non-creature artifact with casting cost equal to X.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "9166f85a-6c02-53e5-ab79-ffc8fcbe04fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613762ea-6111-4f74-bea2-c13b76e0751c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613762ea-6111-4f74-bea2-c13b76e0751c.jpg?1",
             "name": "Gorilla War Cry",
             "text": "Attacking creatures cannot be blocked by only one creature this turn. Play only during combat before defense is chosen.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "f71d7928-24d2-57eb-bb7d-5aebbb4311a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14752ef-bebf-4c31-b130-32167473482f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14752ef-bebf-4c31-b130-32167473482f.jpg?1",
             "name": "Gorilla War Cry",
             "text": "Attacking creatures cannot be blocked by only one creature this turn. Play only during combat before defense is chosen.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "2329888a-a475-5a90-abc5-ec1f50fff880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51811f2a-7002-4ba7-98d8-5b09d887975c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51811f2a-7002-4ba7-98d8-5b09d887975c.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nIf a spell or effect controlled by an opponent causes you to discard Guerrilla Tactics from your hand, reveal Guerrilla Tactics to all players, and it deals 4 damage to target creature or player.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "d0b66433-284d-589d-8369-372dc8544da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c005ca3-0508-4ac2-afec-3d4a27334c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c005ca3-0508-4ac2-afec-3d4a27334c31.jpg?1",
             "name": "Guerrilla Tactics",
             "text": "Guerrilla Tactics deals 2 damage to target creature or player.\nIf a spell or effect controlled by an opponent causes you to discard Guerrilla Tactics from your hand, reveal Guerrilla Tactics to all players, and it deals 4 damage to target creature or player.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "7aae0493-78de-5681-8aa7-46ae5ca30dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c724b46-6e17-4bee-9bc6-e9fc5a379dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c724b46-6e17-4bee-9bc6-e9fc5a379dd7.jpg?1",
             "name": "Omen of Fire",
             "text": "Return all islands to their owners' hands. Each player sacrifices a plains or a white permanent for each white permanent he or she controls.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "245f051c-58e8-5fab-88a6-6c42ff44e14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389ecb50-b007-4086-89fb-ec2daa5afdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389ecb50-b007-4086-89fb-ec2daa5afdcf.jpg?1",
             "name": "Pillage",
             "text": "Bury target artifact or land.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "2b37c0a8-1520-5737-9411-6d0c6d20972f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b7829b-2a10-47e7-9cf9-8ae49d2b398a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b7829b-2a10-47e7-9cf9-8ae49d2b398a.jpg?1",
             "name": "Primitive Justice",
             "text": "Destroy target artifact.\nDestroy a target artifact for each o1o\nR you pay in addition to the casting cost.\nDestroy a target artifact and gain 1 life for each o1o\nG you pay in addition to the casting cost.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "e303165a-5c77-5d68-aa87-897cf608a8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a5e85-6cbc-43c1-9362-4056ad017ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2a5e85-6cbc-43c1-9362-4056ad017ef0.jpg?1",
             "name": "Pyrokinesis",
             "text": "You may remove a red card in your hand from the game instead of paying Pyrokinesis's casting cost. Pyrokinesis deals 4 damage, divided any way you choose among any number of target creatures.",
             "colours": [
@@ -3888,7 +3888,7 @@
         },
         {
             "id": "47473373-9c52-5844-8ad4-9eb226e3380d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aebf3b-e77d-4d18-b58b-117ae91792e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aebf3b-e77d-4d18-b58b-117ae91792e2.jpg?1",
             "name": "Rogue Skycaptain",
             "text": "Flying\nAt the beginning of your upkeep, put a wage counter on Rogue Skycaptain. During your upkeep, pay o2 for each wage counter on Rogue Skycaptain, or remove all wage counters from Rogue Skycaptain and target opponent gains control of Rogue Skycaptain.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "0a8d5d40-6b40-5eb3-a980-569cfe3ccc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c05f46-2081-4ebb-a758-894ac040ea2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c05f46-2081-4ebb-a758-894ac040ea2a.jpg?1",
             "name": "Soldier of Fortune",
             "text": "o\nR, oc\nT: Target player shuffles his or her library.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "9340c3de-3d93-518c-b8e1-0d7a70cc9b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c30a0a-3083-4d9f-9fe0-de5d6294f80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c30a0a-3083-4d9f-9fe0-de5d6294f80e.jpg?1",
             "name": "Storm Shaman",
             "text": "o\nR: +1/+0 until end of turn",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "5de21b71-d898-5582-a016-ae1dd7f67909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8f1150-6306-42a6-84e1-7dd5bfef6d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8f1150-6306-42a6-84e1-7dd5bfef6d14.jpg?1",
             "name": "Storm Shaman",
             "text": "o\nR: +1/+0 until end of turn",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "2a799687-45b8-5d6f-b57b-54b8d5c79437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ade7ad-ce32-4296-8cec-20bd79c7b16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ade7ad-ce32-4296-8cec-20bd79c7b16a.jpg?1",
             "name": "Varchild's Crusader",
             "text": "o0: Varchild's Crusader cannot be blocked except by walls this turn. Bury Varchild's Crusader at end of turn.",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "9302b8dc-ee10-5b54-8e1b-b1cbee26ea3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730611f-ad45-40b7-80c8-5decf2627e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730611f-ad45-40b7-80c8-5decf2627e79.jpg?1",
             "name": "Varchild's Crusader",
             "text": "o0: Varchild's Crusader cannot be blocked except by walls this turn. Bury Varchild's Crusader at end of turn.",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "b89f8b59-f675-5748-a88a-498e993afca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1d41da-aa72-434b-811f-95d4bae4ba5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1d41da-aa72-434b-811f-95d4bae4ba5c.jpg?1",
             "name": "Varchild's War-Riders",
             "text": "Trample, rampage: 1\nCumulative Upkeep: Put a Survivor token into play under target opponent's control. Treat this token as a 1/1 red creature.",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "29d23063-854c-5a16-8d14-5fc47ead825f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93babf85-eb13-4e06-b45b-8927791bcde5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93babf85-eb13-4e06-b45b-8927791bcde5.jpg?1",
             "name": "Veteran's Voice",
             "text": "Play on a creature you control.\no0: Tap enchanted creature to give any other target creature +2/+1 until end of turn.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "7afe2f25-ef95-51e3-a2ef-0579290bab9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1ecb9a-7443-49cb-8197-ef180124aabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1ecb9a-7443-49cb-8197-ef180124aabb.jpg?1",
             "name": "Veteran's Voice",
             "text": "Play on a creature you control.\no0: Tap enchanted creature to give any other target creature +2/+1 until end of turn.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "6194acb4-b45b-550f-9726-6a89d0483543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed522a-cf5a-41e1-9677-1226f689ec9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed522a-cf5a-41e1-9677-1226f689ec9c.jpg?1",
             "name": "Bounty of the Hunt",
             "text": "You may remove a green card in your hand from the game instead of paying Bounty of the Hunt's casting cost.\nPut three +1/+1 counters, distributed any way you choose, on any number of target creatures. Remove these counters at end of turn.",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "8ffcd600-e746-55d3-bd50-1ab64fd7c7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add1b999-5c3f-4187-adac-ed1037406b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add1b999-5c3f-4187-adac-ed1037406b3f.jpg?1",
             "name": "Deadly Insect",
             "text": "Cannot be the target of spells or effects.",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "f27cf285-184f-547c-8f73-e6c5ee62242f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030963d9-b59f-4ccb-abed-d817a4bc4e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030963d9-b59f-4ccb-abed-d817a4bc4e05.jpg?1",
             "name": "Deadly Insect",
             "text": "Cannot be the target of spells or effects.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "187189d7-613f-5256-84dc-60499000105d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62261004-ed32-4865-824a-4320548f4234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62261004-ed32-4865-824a-4320548f4234.jpg?1",
             "name": "Elvish Bard",
             "text": "All creatures able to block Elvish Bard do so. If this forces a creature to block more attackers than allowed, defending player assigns that creature to block as many of those attackers as allowed.",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "3c0c4763-047b-5c1e-bf09-f17a2beecbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9f1b09-73c2-43c5-a28b-4a40fff7b727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9f1b09-73c2-43c5-a28b-4a40fff7b727.jpg?1",
             "name": "Elvish Ranger",
             "text": "",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "f87bc0f2-31d5-5d49-aa79-1857bc70d268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b08a164-d6f4-423e-8666-e4a4c2d21045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b08a164-d6f4-423e-8666-e4a4c2d21045.jpg?1",
             "name": "Elvish Ranger",
             "text": "",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "b67fd7f0-d9b1-58f1-8857-071beae61650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b94f37f-ebdf-4b79-a615-58331d27cf4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b94f37f-ebdf-4b79-a615-58331d27cf4e.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "If Elvish Spirit Guide is in your hand, you may remove it from the game to add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "69e5a6b5-01dc-5468-b995-ae8682cc7376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778b028f-fa4e-4638-82b4-fb287223ea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/778b028f-fa4e-4638-82b4-fb287223ea20.jpg?1",
             "name": "Fyndhorn Druid",
             "text": "If Fyndhorn Druid is put into the graveyard the same turn it was blocked, gain 4 life.",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "ef785048-9e3a-5175-8f7f-a8b9819e0403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d880c-0052-4e2c-92aa-bf3cbd107cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d880c-0052-4e2c-92aa-bf3cbd107cbd.jpg?1",
             "name": "Fyndhorn Druid",
             "text": "If Fyndhorn Druid is put into the graveyard the same turn it was blocked, gain 4 life.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "4fd5fa6c-de49-51f7-ad3a-1f8df1043d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f367c2-f47e-43e1-9936-4324be664475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f367c2-f47e-43e1-9936-4324be664475.jpg?1",
             "name": "Gargantuan Gorilla",
             "text": "During your upkeep, sacrifice a forest, or bury Gargantuan Gorilla and Gargantuan Gorilla deals 7 damage to you. If you sacrifice a snow-covered forest in this way, Gargantuan Gorilla gains trample until end of turn.\noc\nT: Gargantuan Gorilla deals an amount of damage equal to its power to any other target creature. That creature deals an amount of damage equal to its power to Gargantuan Gorilla.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "7a7e5fac-bfb8-542f-91cf-56f375d87fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da48976b-667d-4a1e-92de-9c3cb25dfd21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da48976b-667d-4a1e-92de-9c3cb25dfd21.jpg?1",
             "name": "Gift of the Woods",
             "text": "If enchanted creature blocks or is blocked by any creatures, enchanted creature gets +0/+3 until end of turn and you gain 1 life.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "c47505c4-92a8-5515-bd98-c4fc823a82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0df4e9-b201-4fc7-8e37-59d99b583f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0df4e9-b201-4fc7-8e37-59d99b583f76.jpg?1",
             "name": "Gift of the Woods",
             "text": "If enchanted creature blocks or is blocked by any creatures, enchanted creature gets +0/+3 until end of turn and you gain 1 life.",
             "colours": [
@@ -4624,7 +4624,7 @@
         },
         {
             "id": "987b6034-3edd-58f3-9e78-a6605ab84340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344b4613-17f8-4c8b-b5bc-f773a8f8007a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344b4613-17f8-4c8b-b5bc-f773a8f8007a.jpg?1",
             "name": "Gorilla Berserkers",
             "text": "Trample, rampage: 2\nCannot be blocked by fewer than three creatures.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "c45d0d3e-8479-5457-a265-78b227e0b43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c32b65-58e7-455b-9a30-7a2edcc27b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c32b65-58e7-455b-9a30-7a2edcc27b9d.jpg?1",
             "name": "Gorilla Berserkers",
             "text": "Trample, rampage: 2\nCannot be blocked by fewer than three creatures.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "f13d761d-eff4-5726-8d5d-37581a171598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f1eedd-7021-4cce-a808-2e9384a5ef15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f1eedd-7021-4cce-a808-2e9384a5ef15.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1o\nG: Regenerate",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "874f902e-fb80-539f-9ee9-3f1cf2ad7a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdde5d2-3dd2-4eaa-9c52-4ad400b56ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdde5d2-3dd2-4eaa-9c52-4ad400b56ed1.jpg?1",
             "name": "Gorilla Chieftain",
             "text": "o1o\nG: Regenerate",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "ce806604-58c6-59ee-8817-5f526306f6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e9d786-4e9b-447b-a5dc-ca117c4961c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e9d786-4e9b-447b-a5dc-ca117c4961c5.jpg?1",
             "name": "Hail Storm",
             "text": "Hail Storm deals 2 damage to each attacking creature and 1 damage to you and each creature you control.",
             "colours": [
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "b032c906-f72b-5ab4-94cd-1bbf4d41be7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4b6daf-cf37-43c6-9446-3aa0de222ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4b6daf-cf37-43c6-9446-3aa0de222ac4.jpg?1",
             "name": "Kaysa",
             "text": "All green creatures you control get +1/+1.",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "03016d28-cf16-5325-8c38-77cb502f1fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0b831-9d7e-40ce-8514-e852daee1a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0b831-9d7e-40ce-8514-e852daee1a9e.jpg?1",
             "name": "Nature's Chosen",
             "text": "Play on a creature you control.\no0: Untap enchanted creature. Use this ability only during your turn and only once each turn.\no0: Tap enchanted creature to untap target artifact, creature, or land. Use this ability only if enchanted creature is white and only once each turn.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "dbeb30f2-5f3c-539b-b8a0-55976492c3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450759f0-5d60-4f05-9011-b0b66dbb06a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450759f0-5d60-4f05-9011-b0b66dbb06a7.jpg?1",
             "name": "Nature's Wrath",
             "text": "During your upkeep, pay o\nG or bury Nature's Wrath.\nWhenever a player puts a swamp or black permanent into play, he or she sacrifices a swamp or black permanent.\nWhenever a player puts an island or a blue permanent into play, he or she sacrifices an island or blue permanent.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "38685a11-4b2d-50fa-b236-1ae3737987ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afa94e5-fef6-4f3a-9196-d7aa6dd841c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afa94e5-fef6-4f3a-9196-d7aa6dd841c2.jpg?1",
             "name": "Splintering Wind",
             "text": "o2o\nG: Splintering Wind deals 1 damage to target creature. Put a Splinter token into play. Treat this token as a 1/1 green creature with flying and Cumulative Upkeep: o\nG.\nIf this token leaves play, it deals 1 damage to you and to each creature you control.",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "4e62e057-32c2-55e6-bbe7-ddf0d0391d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9248694-88fa-4fe1-9902-f03a41100cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9248694-88fa-4fe1-9902-f03a41100cd6.jpg?1",
             "name": "Taste of Paradise",
             "text": "Gain 3 life.\nGain 3 life for each o1o\nG you pay in addition to the casting cost.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "11b6715d-1e71-50db-9102-6d33d27024fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a774c426-ec0e-48de-b00f-5a05cc6dc34b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a774c426-ec0e-48de-b00f-5a05cc6dc34b.jpg?1",
             "name": "Taste of Paradise",
             "text": "Gain 3 life.\nGain 3 life for each o1o\nG you pay in addition to the casting cost.",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "5027dc75-2914-5ffa-8ce5-fe02f83795e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fd58e4-eb9a-4a12-8914-0a9a8300626c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fd58e4-eb9a-4a12-8914-0a9a8300626c.jpg?1",
             "name": "Tornado",
             "text": "Cumulative Upkeep: o\nG\no2o\nG: Pay 3 life for each velocity counter on Tornado. Destroy target permanent and put a velocity counter on Tornado. Use this ability only once each turn. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "4aaa15e3-ea14-5c88-9d23-ba10bd695407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade0829-8b90-4ed2-99f3-dd748e7706b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ade0829-8b90-4ed2-99f3-dd748e7706b8.jpg?1",
             "name": "Undergrowth",
             "text": "No creatures deal damage in combat this turn. If you pay o2o\nR in addition to the casting cost, Undergrowth does not affect red creatures.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "3a1b1f76-4e8e-5992-9181-e142e084cd5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b07df91-49be-4a50-9d3b-ddde0e6c1be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b07df91-49be-4a50-9d3b-ddde0e6c1be9.jpg?1",
             "name": "Undergrowth",
             "text": "No creatures deal damage in combat this turn. If you pay o2o\nR in addition to the casting cost, Undergrowth does not affect red creatures.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "445345b8-0a1e-5091-9ff8-b7d5c1650493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66b9fe-47f1-4786-96d5-981d62012663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66b9fe-47f1-4786-96d5-981d62012663.jpg?1",
             "name": "Whip Vine",
             "text": "Can block creatures with flying.\nYou may choose not to untap Whip Vine during your untap phase.\noc\nT: Tap target creature with flying blocked by Whip Vine. That creature does not untap during its controller's untap phase as long as Whip Vine remains tapped.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "a4db117d-2118-5541-be17-1189fe3b4906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ee1c89-d7df-4ee7-b403-24dfabae38a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ee1c89-d7df-4ee7-b403-24dfabae38a0.jpg?1",
             "name": "Whip Vine",
             "text": "Can block creatures with flying. You may choose not to untap Whip Vine during your untap phase.\noc\nT: Tap target creature with flying blocked by Whip Vine. That creature does not untap during its controller's untap phase as long as Whip Vine remains tapped.",
             "colours": [
@@ -5165,7 +5165,7 @@
         },
         {
             "id": "79afaef4-a2a4-5961-8f27-bbbace2e4e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fc4db5-08e5-4cf8-bf47-f7c6a58162b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fc4db5-08e5-4cf8-bf47-f7c6a58162b2.jpg?1",
             "name": "Yavimaya Ancients",
             "text": "o\nG: +1/-2 until end of turn",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "0826319e-e518-5239-a2bb-8fc42a78cc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91708e45-f9a1-4c2e-973d-bfc294926c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91708e45-f9a1-4c2e-973d-bfc294926c93.jpg?1",
             "name": "Yavimaya Ancients",
             "text": "o\nG: +1/-2 until end of turn",
             "colours": [
@@ -5235,7 +5235,7 @@
         },
         {
             "id": "6d3e9607-fa70-5d6b-b9c2-f43dd65b47e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ded1c83-a289-4951-b72a-477a041610d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ded1c83-a289-4951-b72a-477a041610d3.jpg?1",
             "name": "Yavimaya Ants",
             "text": "Trample\nCumulative Upkeep: o\nGo\nG\nYavimaya Ants can attack the turn it comes into play on your side.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "f4de3ab7-7de0-5ed9-a7f8-30f1c90a275b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81cd99e-902a-44dd-8928-803a96fe25c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81cd99e-902a-44dd-8928-803a96fe25c4.jpg?1",
             "name": "Energy Arc",
             "text": "Untap any number of target creatures. Those creatures neither deal nor receive damage in combat this turn.",
             "colours": [
@@ -5301,7 +5301,7 @@
         },
         {
             "id": "36a70bd8-be17-56ed-84e3-911d69ee19b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b0164c-2d4e-48ab-addd-322d9b504739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b0164c-2d4e-48ab-addd-322d9b504739.jpg?1",
             "name": "Lim-D\u00fbl's Vault",
             "text": "Look at the top five cards of your library. As many times as you choose, you may pay 1 life to put those cards on the bottom of your library and look at the top five cards of your library.\nShuffle all but the top five cards of your library; put those five on top of your library in any order. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "a4a28fe3-72b9-5cc9-a0a6-a6d4361064db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44be2d66-359e-4cc1-9670-119cb9c7d5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44be2d66-359e-4cc1-9670-119cb9c7d5f5.jpg?1",
             "name": "Lim-D\u00fbl's Paladin",
             "text": "Trample\nDuring your upkeep, choose and discard a card from your hand, or bury Lim-D\u00fbl's Paladin and draw a card.\nIf any creatures are assigned to block it, Lim-D\u00fbl's Paladin gets +6/+3 until end of turn.\nIf Lim-D\u00fbl's Paladin attacks and is not blocked, it deals no damage to defending player this turn and that player loses 4 life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "fc0d0551-abdd-5b1f-a6b2-8b25cf735302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff700-af02-4861-b7ed-be9950e69bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff700-af02-4861-b7ed-be9950e69bf1.jpg?1",
             "name": "Surge of Strength",
             "text": "Choose and discard a red or green card from your hand to have target creature gain trample and get +X/+0 until end of turn, where X is equal to that creature's casting cost.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "9e733a65-8484-50f8-84b9-32a36c3f3b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba0e677-361d-4e03-9c2c-018d1c383456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba0e677-361d-4e03-9c2c-018d1c383456.jpg?1",
             "name": "Nature's Blessing",
             "text": "o\nWo\nG: Choose and discard a card from your hand to have target creature gain banding, first strike, or trample or get a +1/+1 counter.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "88a9647d-be75-576a-8d2a-a5e7a1a6dfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b1b6c-1f02-4918-bb5c-2dbcdb0997ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b1b6c-1f02-4918-bb5c-2dbcdb0997ec.jpg?1",
             "name": "Wandering Mage",
             "text": "o\nW: Pay 1 life to prevent up to 2 damage to any creature. Effects that prevent or redirect damage cannot be used to counter this loss of life.\no\nU: Prevent 1 damage to any Cleric or Wizard.\no\nB: Put a -1/-1 counter on target creature you control to prevent up to 2 damage to any player.",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "e56d7b2e-de14-54d3-8f5a-79de24b6a3d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc9497a-42bf-4d78-afaf-67645514ade4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc9497a-42bf-4d78-afaf-67645514ade4.jpg?1",
             "name": "Lord of Tresserhorn",
             "text": "When Lord of Tresserhorn comes into play, pay 2 life and sacrifice two creatures, and target opponent draws two cards. Effects that prevent or redirect damage cannot be used to counter this loss of life.\no\nB: Regenerate",
             "colours": [
@@ -5514,7 +5514,7 @@
         },
         {
             "id": "bc77ddc5-76b3-5a6f-b30f-123131a4bc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14cc32a-eb4f-4690-aceb-160780743ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14cc32a-eb4f-4690-aceb-160780743ebe.jpg?1",
             "name": "Misfortune",
             "text": "Target opponent chooses one: you put a +1/+1 counter on each creature you control and gain 4 life; or you put a -1/-1 counter on each creature that opponent controls and Misfortune deals 4 damage to him or her.",
             "colours": [
@@ -5549,7 +5549,7 @@
         },
         {
             "id": "834fa6fe-12ad-5d80-b9af-76e2eda43754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f020ebc-4950-4407-8cb8-7630cad226f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f020ebc-4950-4407-8cb8-7630cad226f6.jpg?1",
             "name": "Winter's Night",
             "text": "Whenever a snow-covered land is tapped for mana, it produces one additional mana of the same type and does not untap during its controller's next untap phase.",
             "colours": [
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "f973ff23-32f3-5bcf-84ca-616b7a2626e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9631cb2-d53b-4401-b53b-29d27bdefc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9631cb2-d53b-4401-b53b-29d27bdefc44.jpg?1",
             "name": "Phelddagrif",
             "text": "o\nW: Flying until end of turn. Target opponent gains 2 life.\no\nU: Return Phelddagrif to owner's hand. Target opponent may draw a card.\no\nG: Trample until end of turn. Put a Hippo token into play under target opponent's control. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "781c7c6f-12a8-5ce4-adc0-0f12cedb6975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a8080f-ca3c-46fe-81cf-003ac7ba7f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a8080f-ca3c-46fe-81cf-003ac7ba7f24.jpg?1",
             "name": "Aesthir Glider",
             "text": "Flying\nCannot be assigned to block.",
             "colours": [],
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "ec6d8d5f-4c6a-52cf-a8ce-6cab82b82d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b78cb-5acc-4d14-966f-979322d99114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b78cb-5acc-4d14-966f-979322d99114.jpg?1",
             "name": "Aesthir Glider",
             "text": "Flying\nCannot be assigned to block.",
             "colours": [],
@@ -5691,7 +5691,7 @@
         },
         {
             "id": "4b17878f-2c7b-50f0-b3c0-7e840036e9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84e6fcf-4745-4dfb-9103-17beec4e45b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84e6fcf-4745-4dfb-9103-17beec4e45b6.jpg?1",
             "name": "Ashnod's Cylix",
             "text": "o3, oc\nT: Target player looks at the top three cards of his or her library and puts one of them on top of that library. Remove the remaining two from the game.",
             "colours": [],
@@ -5718,7 +5718,7 @@
         },
         {
             "id": "b8f8c42e-360f-5878-848f-d99cfd3b0f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97ad2d4-0660-4503-9f16-246dae87601c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97ad2d4-0660-4503-9f16-246dae87601c.jpg?1",
             "name": "Astrolabe",
             "text": "o1, oc\nT: Sacrifice Astrolabe to add two mana of any one color to your mana pool. Play this ability as an interrupt. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "94c7eac3-2683-5fbf-9273-68b208c79a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3a4e30-f919-4c96-89f2-467355135f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3a4e30-f919-4c96-89f2-467355135f8f.jpg?1",
             "name": "Astrolabe",
             "text": "o1, oc\nT: Sacrifice Astrolabe to add two mana of any one color to your mana pool. Play this ability as an interrupt. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -5776,7 +5776,7 @@
         },
         {
             "id": "bdb4c6cf-163b-5105-ad6b-1489c5f48b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d272c3cb-0b68-4693-abef-8a5375b2463e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d272c3cb-0b68-4693-abef-8a5375b2463e.jpg?1",
             "name": "Floodwater Dam",
             "text": "o\nXo\nXo1, oc\nT: Tap X target lands.",
             "colours": [],
@@ -5803,7 +5803,7 @@
         },
         {
             "id": "7fe93d78-2228-5997-bdbe-3a7b86c05738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797c84fa-3704-4fec-bd72-468d6415ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797c84fa-3704-4fec-bd72-468d6415ae70.jpg?1",
             "name": "Gustha's Scepter",
             "text": "If Gustha's Scepter leaves play or you lose control of it, put all cards under Gustha's Scepter into your graveyard.\noc\nT: Put any card from your hand face down under Gustha's Scepter. You may look at that card at any time.\noc\nT: Return any card under Gustha's Scepter to your hand.",
             "colours": [],
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "e7526623-beef-5a28-9361-fead1983c57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17e9216-b1ed-4101-a04e-2bb139ccfa55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17e9216-b1ed-4101-a04e-2bb139ccfa55.jpg?1",
             "name": "Helm of Obedience",
             "text": "o\nX, oc\nT: Put the top card of target opponent's library into his or her graveyard. Continue doing this until you have put X cards or a creature card into that graveyard, whichever occurs first. If the last card put into the graveyard is a creature card, bury Helm of Obedience and put that creature into play under your control as though it were just cast. X cannot be equal to 0.",
             "colours": [],
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "aff0ea48-612f-5a96-a02b-d3c3eda15a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d88a33-3990-4044-a5fe-4123d5781f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d88a33-3990-4044-a5fe-4123d5781f18.jpg?1",
             "name": "Lodestone Bauble",
             "text": "o1, oc\nT: Sacrifice Lodestone Bauble to put up to four target basic lands from any player's graveyard on top of his or her library in any order. That player draws a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "ea074234-63c8-5a2a-8ffb-cc09767a7f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2dc26-30aa-4e20-84b0-ea4be8894475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2dc26-30aa-4e20-84b0-ea4be8894475.jpg?1",
             "name": "Mishra's Groundbreaker",
             "text": "oc\nT: Sacrifice Mishra's Groundbreaker. Target land becomes a 3/3 artifact creature. That creature still counts as a land.",
             "colours": [],
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "707b55a5-9eb4-500e-ae08-374db8d42874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53ba3a-f2f7-4ea6-a2f6-dd5b87029e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53ba3a-f2f7-4ea6-a2f6-dd5b87029e58.jpg?1",
             "name": "Mystic Compass",
             "text": "o1, oc\nT: Target mana-producing land becomes a basic land type of your choice until end of turn.",
             "colours": [],
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "ddfc0a06-6fbb-56d0-8ff3-b2a56f61b588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319430fa-11e4-426e-8297-67df8474c3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319430fa-11e4-426e-8297-67df8474c3cc.jpg?1",
             "name": "Phyrexian Devourer",
             "text": "If Phyrexian Devourer's power is 7 or greater, bury it.\no0: Remove the top card of your library from the game to put a +X/+X counter on Phyrexian Devourer, where X is equal to that card's casting cost.",
             "colours": [],
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "82e97677-fa05-58e4-bd15-e7ab978d2917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f77387-1239-4ad2-b59f-d13e317477ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f77387-1239-4ad2-b59f-d13e317477ba.jpg?1",
             "name": "Phyrexian Portal",
             "text": "o3: Target opponent looks at the top ten cards of your library and separates them into two face-down piles. Choose one of those piles and remove it from the game. Search the remaining pile and put one of those cards into your hand. Shuffle the remaining cards into your library. Ignore this effect if you have fewer than ten cards in your library.",
             "colours": [],
@@ -5996,7 +5996,7 @@
         },
         {
             "id": "33c6db6f-40b7-5118-9f34-11512947c820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a83384-8762-4028-8cab-b690593790a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a83384-8762-4028-8cab-b690593790a6.jpg?1",
             "name": "Phyrexian War Beast",
             "text": "If Phyrexian War Beast leaves play, sacrifice a land, and Phyrexian War Beast deals 1 damage to you.",
             "colours": [],
@@ -6029,7 +6029,7 @@
         },
         {
             "id": "2e32d22e-49be-54de-8e20-6bb3280fd938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d651f6-50be-4df9-80f8-4c62bb860e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d651f6-50be-4df9-80f8-4c62bb860e71.jpg?1",
             "name": "Phyrexian War Beast",
             "text": "If Phyrexian War Beast leaves play, sacrifice a land, and Phyrexian War Beast deals 1 damage to you.",
             "colours": [],
@@ -6062,7 +6062,7 @@
         },
         {
             "id": "3b97f299-b292-5608-80e3-be4feaef7932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da1c71-6059-4e4e-933d-dbca1cc4bd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5da1c71-6059-4e4e-933d-dbca1cc4bd15.jpg?1",
             "name": "Scarab of the Unseen",
             "text": "oc\nT: Sacrifice Scarab of the Unseen to return all enchantments on target permanent you own to their owners' hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "8d5bb4f9-f2cc-5859-9898-ec3a48c21bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1730d219-a28f-4930-8088-4cfcb627f157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1730d219-a28f-4930-8088-4cfcb627f157.jpg?1",
             "name": "Shield Sphere",
             "text": "Counts as a wall\nIf Shield Sphere is assigned as a blocker, put a -0/-1 counter on it.",
             "colours": [],
@@ -6119,7 +6119,7 @@
         },
         {
             "id": "5e25c508-173e-5092-8dee-5686f12e600a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62652722-e345-4670-9547-d9579efa227d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62652722-e345-4670-9547-d9579efa227d.jpg?1",
             "name": "Sol Grail",
             "text": "When Sol Grail comes into play, choose a color.\noc\nT: Add one mana of the chosen color to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -6146,7 +6146,7 @@
         },
         {
             "id": "df2ca800-e1fb-5c69-a716-d77325bd6385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a0ab4-e8ef-45fd-9a73-86d1ee30cb48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3a0ab4-e8ef-45fd-9a73-86d1ee30cb48.jpg?1",
             "name": "Soldevi Digger",
             "text": "o2: Put the top card of your graveyard on the bottom of your library.",
             "colours": [],
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "23151c29-7d47-5240-91b2-74e0b3c6db02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85976b5c-4eed-4cf9-b2b0-a8421a97ab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85976b5c-4eed-4cf9-b2b0-a8421a97ab2a.jpg?1",
             "name": "Soldevi Sentry",
             "text": "o1: Regenerate. Target opponent may draw a card.",
             "colours": [],
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "772b3250-9063-5588-96e5-5a5d51260e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2a84d7-3f49-4652-bb31-4be7e3474e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2a84d7-3f49-4652-bb31-4be7e3474e26.jpg?1",
             "name": "Soldevi Sentry",
             "text": "o1: Regenerate. Target opponent may draw a card.",
             "colours": [],
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "05e25387-b88b-5e11-9e3a-5608490a4e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead79d2c-170e-4106-962d-d69c4b5fead0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead79d2c-170e-4106-962d-d69c4b5fead0.jpg?1",
             "name": "Soldevi Steam Beast",
             "text": "Whenever Soldevi Steam Beast becomes tapped, target opponent gains 2 life.\no2: Regenerate",
             "colours": [],
@@ -6269,7 +6269,7 @@
         },
         {
             "id": "52051e5b-03b5-5012-b0e9-ae8e6426c65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5e730-1d5c-4326-b3fc-2f0f97edc07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5e730-1d5c-4326-b3fc-2f0f97edc07e.jpg?1",
             "name": "Soldevi Steam Beast",
             "text": "Whenever Soldevi Steam Beast becomes tapped, target opponent gains 2 life.\no2: Regenerate",
             "colours": [],
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "f1f319f1-2d7b-56eb-8875-7397cd83128f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68b531-a3f2-4830-b170-fb8a1195c149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68b531-a3f2-4830-b170-fb8a1195c149.jpg?1",
             "name": "Storm Cauldron",
             "text": "During each player's turn, that player may put one additional land into play.\nWhenever a land is tapped for mana, return that land to owner's hand.",
             "colours": [],
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "db7acb9e-34a9-5ea4-b0eb-f4845fae0307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b54c3-325b-4f2e-857b-fc1d59b6b3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b54c3-325b-4f2e-857b-fc1d59b6b3c5.jpg?1",
             "name": "Urza's Engine",
             "text": "Trample\no3: Banding until end of turn\no3: All creatures banded with Urza's Engine gain trample until end of turn.",
             "colours": [],
@@ -6358,7 +6358,7 @@
         },
         {
             "id": "1622e8a7-767e-577e-8182-9129e6169937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6206d65a-6907-4d11-acb0-8820277f2cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6206d65a-6907-4d11-acb0-8820277f2cf2.jpg?1",
             "name": "Whirling Catapult",
             "text": "o2: Remove the top two cards of your library from the game to have Whirling Catapult deal 1 damage to each creature with flying and each player.",
             "colours": [],
@@ -6385,7 +6385,7 @@
         },
         {
             "id": "201c58eb-3d9a-51f5-8bd0-a47acb4f3a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a329ff98-36fd-44c3-b037-dcc6e78ee61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a329ff98-36fd-44c3-b037-dcc6e78ee61e.jpg?1",
             "name": "Balduvian Trading Post",
             "text": "When Balduvian Trading Post comes into play, sacrifice an untapped mountain or bury Balduvian Trading Post.\noc\nT: Add o1o\nR to your mana pool.\no1, oc\nT: Balduvian Trading Post deals 1 damage to target attacking creature.",
             "colours": [],
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "3962f72f-ad7a-5201-8266-dae2c1499cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c59cb9-559b-4716-9bd7-c818b3f46f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c59cb9-559b-4716-9bd7-c818b3f46f1d.jpg?1",
             "name": "Heart of Yavimaya",
             "text": "When Heart of Yavimaya comes into play, sacrifice a forest or bury Heart of Yavimaya.\noc\nT: Add o\nG to your mana pool.\noc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "b40957c0-8c24-5e43-b186-178b65cf0eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769fc7-50b5-4b49-8aff-af04536288fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0769fc7-50b5-4b49-8aff-af04536288fb.jpg?1",
             "name": "Kjeldoran Outpost",
             "text": "When Kjeldoran Outpost comes into play, sacrifice a plains or bury Kjeldoran Outpost.\noc\nT: Add o\nW to your mana pool.\no1o\nW, oc\nT: Put a Soldier token into play. Treat this token as a 1/1 white creature.",
             "colours": [],
@@ -6472,7 +6472,7 @@
         },
         {
             "id": "4643ebd2-ff72-5e68-8941-379cc9685afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee806ce-effa-4244-9659-43246e944d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee806ce-effa-4244-9659-43246e944d80.jpg?1",
             "name": "Lake of the Dead",
             "text": "When Lake of the Dead comes into play, sacrifice a swamp or bury Lake of the Dead.\noc\nT: Add o\nB to your mana pool.\noc\nT: Sacrifice a swamp to add o\nBo\nBo\nBo\nB to your mana pool.",
             "colours": [],
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "dbdabd7f-2a71-5897-9ed3-08e37b6a02af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1438606d-556d-4b96-9662-fcac051af045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1438606d-556d-4b96-9662-fcac051af045.jpg?1",
             "name": "School of the Unseen",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "aeb620bb-abf7-51bc-b33b-2bf2c12c627d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049d7a08-1605-4ce2-b8c5-634ce2a261e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049d7a08-1605-4ce2-b8c5-634ce2a261e0.jpg?1",
             "name": "Sheltered Valley",
             "text": "When Sheltered Valley comes into play, bury any other Sheltered Valley you control.\nDuring your upkeep, if you control three or fewer lands, gain 1 life.\noc\nT: Add one colorless mana to your mana pool.",
             "colours": [],
@@ -6555,7 +6555,7 @@
         },
         {
             "id": "d233f799-1bb5-59b8-a551-299e964a222c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbda146-ed0a-4bf6-b99d-dc6d59bd9447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbda146-ed0a-4bf6-b99d-dc6d59bd9447.jpg?1",
             "name": "Soldevi Excavations",
             "text": "When Soldevi Excavations comes into play, sacrifice an untapped island or bury Soldevi Excavations.\noc\nT: Add o1o\nU to your mana pool.\no1, oc\nT: Look at the top card of your library. You may put that card on the bottom of your library.",
             "colours": [],
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "89749851-59f7-5f14-b938-9708a7bc257e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411a8c6-010f-4863-a0fa-bbebe09d5c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6411a8c6-010f-4863-a0fa-bbebe09d5c34.jpg?1",
             "name": "Thawing Glaciers",
             "text": "Comes into play tapped.\no1, oc\nT: Search your library for a basic land and put it into play tapped. This does not count towards your one land per turn limit. Shuffle your library afterwards. At end of turn, return Thawing Glaciers to owner's hand.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ANB.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ANB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "cb13f155-d2ec-501c-b1fd-7863f74b2dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf7d90-74f4-4a69-8783-699fa3a1b0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf7d90-74f4-4a69-8783-699fa3a1b0e2.jpg?1",
             "name": "Angel of Vitality",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nAngel of Vitality gets +2/+2 as long as you have 25 or more life.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "3889222e-3e34-5aad-9793-6a2984a33a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51b95b-c491-49de-95bd-7ac5f8f89836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51b95b-c491-49de-95bd-7ac5f8f89836.jpg?1",
             "name": "Angelic Guardian",
             "text": "Flying\nWhenever one or more creatures you control attack, they gain indestructible until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "12a9f318-65d4-5c84-9bef-aaf7819c08e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05a2131-d367-483a-bada-54a484bfe75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05a2131-d367-483a-bada-54a484bfe75e.jpg?1",
             "name": "Angelic Reward",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has flying.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "1de52b70-805b-59de-8572-a83c8855afc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948351f2-2273-4cad-acfd-b7b4643beb7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948351f2-2273-4cad-acfd-b7b4643beb7b.jpg?1",
             "name": "Bond of Discipline",
             "text": "Tap all creatures your opponents control. Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "bcb83398-97bf-5600-a781-2b66dcbf2eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667d7ba8-f48a-4ac7-b27f-1893778a760f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667d7ba8-f48a-4ac7-b27f-1893778a760f.jpg?1",
             "name": "Charmed Stray",
             "text": "Lifelink\nWhen Charmed Stray enters the battlefield, put a +1/+1 counter on each other creature you control named Charmed Stray.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "fb315b59-19f1-536b-8b25-ae3e72164a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87673b63-cacb-43b3-8723-924a7d5aed0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87673b63-cacb-43b3-8723-924a7d5aed0c.jpg?1",
             "name": "Confront the Assault",
             "text": "Cast this spell only if a creature is attacking you.\nCreate three 1/1 white Spirit creature tokens with flying.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "a9cd265a-33a3-5fa2-83f7-17675306e34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ba9f0-588d-4d4a-afe5-b188ba79aa70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ba9f0-588d-4d4a-afe5-b188ba79aa70.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -232,7 +232,7 @@
         },
         {
             "id": "937660aa-32d3-5634-9f05-7a7971ed0755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dcc4a4-f426-469d-b2af-1cd516177ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dcc4a4-f426-469d-b2af-1cd516177ef7.jpg?1",
             "name": "Goring Ceratops",
             "text": "Double strike\nWhenever Goring Ceratops attacks, other creatures you control gain double strike until end of turn.",
             "colours": [
@@ -265,7 +265,7 @@
         },
         {
             "id": "4df82244-824b-595e-b31f-3ba61206e160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26899e78-fa6f-49fa-bb9b-be1c432612ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26899e78-fa6f-49fa-bb9b-be1c432612ee.jpg?1",
             "name": "Hallowed Priest",
             "text": "Whenever you gain life, put a +1/+1 counter on Hallowed Priest.",
             "colours": [
@@ -299,7 +299,7 @@
         },
         {
             "id": "f18094aa-3328-5216-acf0-6e17225bcb9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20726907-ee1f-49ef-a694-7d3f53ee1e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20726907-ee1f-49ef-a694-7d3f53ee1e2d.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -333,7 +333,7 @@
         },
         {
             "id": "84aad5cc-588d-5a6d-b606-6ec941677145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47eafcb-3f6c-4c84-a93d-d59178ff4828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47eafcb-3f6c-4c84-a93d-d59178ff4828.jpg?1",
             "name": "Inspiring Commander",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -367,7 +367,7 @@
         },
         {
             "id": "7f5d7e70-fae4-5fc7-9478-07d12b47baca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b3432-fa06-43d2-9112-b5ad23e02ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b3432-fa06-43d2-9112-b5ad23e02ccc.jpg?1",
             "name": "Knight's Pledge",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -400,7 +400,7 @@
         },
         {
             "id": "2954289b-60b3-519d-9514-972630e8b2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387c4ae-1a45-4ea5-875a-5a6c1d6a7846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387c4ae-1a45-4ea5-875a-5a6c1d6a7846.jpg?1",
             "name": "Leonin Warleader",
             "text": "Whenever Leonin Warleader attacks, create two 1/1 white Cat creature tokens with lifelink that are tapped and attacking.",
             "colours": [
@@ -434,7 +434,7 @@
         },
         {
             "id": "916381e6-9019-57ef-a754-ea3b8e2e8a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087f35cc-ccb4-479a-baf2-8249a58e4a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087f35cc-ccb4-479a-baf2-8249a58e4a68.jpg?1",
             "name": "Loxodon Line Breaker",
             "text": "",
             "colours": [
@@ -468,7 +468,7 @@
         },
         {
             "id": "83dbacc0-8e84-551c-85f0-2a83082c5203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e6b88e-a7fc-495a-ac8c-7ccb243164ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e6b88e-a7fc-495a-ac8c-7ccb243164ee.jpg?1",
             "name": "Moorland Inquisitor",
             "text": "{2}{W}: Moorland Inquisitor gains first strike until end of turn.",
             "colours": [
@@ -502,7 +502,7 @@
         },
         {
             "id": "5fe132e0-9ebb-5e23-b9a0-a5b8e503fa2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0671ff-ad06-43ae-87cd-06a1341e971b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0671ff-ad06-43ae-87cd-06a1341e971b.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -535,7 +535,7 @@
         },
         {
             "id": "c9deb5ef-2557-5f7b-9f9d-e3043ce90437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61170c40-1e85-4fc2-804a-7fdc7062ac55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61170c40-1e85-4fc2-804a-7fdc7062ac55.jpg?1",
             "name": "Sanctuary Cat",
             "text": "",
             "colours": [
@@ -568,7 +568,7 @@
         },
         {
             "id": "868341f7-7866-5a1f-b774-a60d8b29648a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97ae05c-4186-4b76-b674-d1aebd25ba46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97ae05c-4186-4b76-b674-d1aebd25ba46.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -601,7 +601,7 @@
         },
         {
             "id": "e2863fa3-e174-51f9-bb47-c8d72aa04819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2d3642-3eda-4b15-96dd-b0f0f9680bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2d3642-3eda-4b15-96dd-b0f0f9680bd7.jpg?1",
             "name": "Shrine Keeper",
             "text": "",
             "colours": [
@@ -635,7 +635,7 @@
         },
         {
             "id": "ab83926d-e05a-53a7-a0ad-8fb30d75ca4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f519ff42-3737-4242-b097-f8a3442b9123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f519ff42-3737-4242-b097-f8a3442b9123.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -669,7 +669,7 @@
         },
         {
             "id": "246fba94-126b-57e9-9cb0-060cdf8d08f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadcfcf-f093-44e9-a632-fcc719c570d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadcfcf-f093-44e9-a632-fcc719c570d7.jpg?1",
             "name": "Spiritual Guardian",
             "text": "When Spiritual Guardian enters the battlefield, you gain 4 life.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "0c55568b-815d-5239-b1c5-e956d5d38286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1274d0f3-2b5c-45f6-827f-3548e63f3692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1274d0f3-2b5c-45f6-827f-3548e63f3692.jpg?1",
             "name": "Tactical Advantage",
             "text": "Target blocking or blocked creature you control gets +2/+2 until end of turn.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "6b84de55-eadd-5a3b-92ef-be727332618c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28b4c7a-42d8-413e-a349-5a2d589e54f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28b4c7a-42d8-413e-a349-5a2d589e54f5.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "619823fd-4cf6-5935-9c19-e6178f342dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a783f2-04d3-42fc-acc1-5f2974f9aca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a783f2-04d3-42fc-acc1-5f2974f9aca2.jpg?1",
             "name": "Armored Whirl Turtle",
             "text": "",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "8247ee21-825f-537d-ad9c-0b20b19b92e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8cddc6-fcbf-47d3-8068-5c0f1123b558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8cddc6-fcbf-47d3-8068-5c0f1123b558.jpg?1",
             "name": "Cloudkin Seer",
             "text": "Flying\nWhen Cloudkin Seer enters the battlefield, draw a card.",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "2c4d138a-8fd6-5c6b-b498-f6dd1088a0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467a49ef-39e4-431b-9b4a-2c329d3a1edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467a49ef-39e4-431b-9b4a-2c329d3a1edb.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -866,7 +866,7 @@
         },
         {
             "id": "3a682c9f-b6e2-52d3-94ec-207c2d7d52ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e82bd0d-647f-42bd-b6d2-9a5d2a7bcd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e82bd0d-647f-42bd-b6d2-9a5d2a7bcd2f.jpg?1",
             "name": "Frilled Sea Serpent",
             "text": "{5}{U}{U}: Frilled Sea Serpent can't be blocked this turn.",
             "colours": [
@@ -899,7 +899,7 @@
         },
         {
             "id": "42430f27-2a2f-5406-a203-ef3ed9c04bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9db535-6279-4b5e-87c3-15c1321b50c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9db535-6279-4b5e-87c3-15c1321b50c8.jpg?1",
             "name": "Glint",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "74be9b88-a716-5160-9562-f5bc45e5d384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec0a0fc-7b82-4812-b8cc-cbfba4987142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec0a0fc-7b82-4812-b8cc-cbfba4987142.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2.",
             "colours": [
@@ -963,7 +963,7 @@
         },
         {
             "id": "4e6dfdf4-bb79-5b99-a836-40ab234791c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83443ce0-61d7-484d-b6b2-aaf35fb81fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83443ce0-61d7-484d-b6b2-aaf35fb81fea.jpg?1",
             "name": "Overflowing Insight",
             "text": "Target player draws seven cards.",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "e0f894ad-459a-5fb6-9442-bf82998a5cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e480ab2-d862-4620-8369-18af0577278b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e480ab2-d862-4620-8369-18af0577278b.jpg?1",
             "name": "Riddlemaster Sphinx",
             "text": "Flying\nWhen Riddlemaster Sphinx enters the battlefield, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1027,7 +1027,7 @@
         },
         {
             "id": "dd80be47-06cd-5fe8-8172-0add21d815fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6d038a-706a-4a93-bcab-4533340fb960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6d038a-706a-4a93-bcab-4533340fb960.jpg?1",
             "name": "River's Favor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "3b31a8e1-d3bf-5e97-af54-e52e1c063758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d899e1-bded-4e16-8ecc-cc07784af4bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d899e1-bded-4e16-8ecc-cc07784af4bb.jpg?1",
             "name": "Shorecomber Crab",
             "text": "",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "8b3e2da4-8d61-52a5-9bba-d6f4b6a9cad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959aeb66-311d-4a73-9120-e73692cb252c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959aeb66-311d-4a73-9120-e73692cb252c.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "f41f11d0-d03a-5893-93b8-90d9ac8902e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7631df-2e6c-4472-8dd6-8b07fcc545fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7631df-2e6c-4472-8dd6-8b07fcc545fb.jpg?1",
             "name": "Soulblade Djinn",
             "text": "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "768cd238-f7f2-591c-8404-8f233437dfa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a86fb-3652-4ac7-a879-c78899c493d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a86fb-3652-4ac7-a879-c78899c493d6.jpg?1",
             "name": "Sworn Guardian",
             "text": "",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "b14bc833-95e8-58e2-ad16-a00780103d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824cebc-6b5f-4e2a-95a1-8bfc2032ed21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824cebc-6b5f-4e2a-95a1-8bfc2032ed21.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "8249ce5c-7e8a-595d-ad62-976a517ba1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50691365-dde3-4956-bc7d-3d0b05d32c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50691365-dde3-4956-bc7d-3d0b05d32c73.jpg?1",
             "name": "Wall of Runes",
             "text": "Defender\nWhen Wall of Runes enters the battlefield, scry 1.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "26a6fa2c-8891-5125-88b7-a4f30f237b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0daadff-ac69-48e7-9889-81aa624486b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0daadff-ac69-48e7-9889-81aa624486b1.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "9d9a9760-503d-5882-8815-569f8911c32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d5581-68c8-4e78-aa80-69dd0d62b08d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d5581-68c8-4e78-aa80-69dd0d62b08d.jpg?1",
             "name": "Waterkin Shaman",
             "text": "Whenever a creature with flying enters the battlefield under your control, Waterkin Shaman gets +1/+1 until end of turn.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "b04d31dd-0001-53d1-9e55-67d9a353f554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d53c5ec-eb0b-48cc-b244-99cb42d61b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d53c5ec-eb0b-48cc-b244-99cb42d61b4a.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "61a763d5-5102-5554-a8c2-7a89838a2a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a391d1-5916-4396-98c3-8a954d736eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a391d1-5916-4396-98c3-8a954d736eda.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "068163e5-91a2-5741-bbd9-5a5a3ae6ca7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40dae56-be19-4b64-b99d-f45b7f816287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40dae56-be19-4b64-b99d-f45b7f816287.jpg?1",
             "name": "Windstorm Drake",
             "text": "Flying\nOther creatures you control with flying get +1/+0.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "1ee639cb-e8f4-5fc7-ba3e-a1f0941a1e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3449f98f-92d2-4be4-a596-fefa8843b6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3449f98f-92d2-4be4-a596-fefa8843b6fd.jpg?1",
             "name": "Winged Words",
             "text": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "3ee9a045-cf21-5768-b105-7bc7896162fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626e13bc-c7d4-405f-b365-54264676d49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626e13bc-c7d4-405f-b365-54264676d49c.jpg?1",
             "name": "Zephyr Gull",
             "text": "Flying",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "47165480-bed6-5155-a666-a39cb93c1ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73d8462-6901-47c4-99e8-93efb5d54737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73d8462-6901-47c4-99e8-93efb5d54737.jpg?1",
             "name": "Bad Deal",
             "text": "You draw two cards and each opponent discards two cards. Each player loses 2 life.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "8a282f4a-c2ab-5607-852d-79bdc69f3a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3d009-6cd3-4a2a-9154-954812097069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3d009-6cd3-4a2a-9154-954812097069.jpg?1",
             "name": "Compound Fracture",
             "text": "Target creature gets -1/-1 until end of turn. It gets an additional -1/-1 until end of turn for each card named Compound Fracture in your graveyard.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "10f8d33f-fb69-5bbf-b0bd-70a17163a363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343bba3d-d235-4855-8ab2-cb715f29fb60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343bba3d-d235-4855-8ab2-cb715f29fb60.jpg?1",
             "name": "Cruel Cut",
             "text": "Destroy target creature with power 2 or less.",
             "colours": [
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "90c38782-d935-5744-945a-4101ed1f6294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827efbc-70a4-413d-bb73-41661c1a9830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827efbc-70a4-413d-bb73-41661c1a9830.jpg?1",
             "name": "Demon of Loathing",
             "text": "Flying, trample\nWhenever Demon of Loathing deals combat damage to a player, that player sacrifices a creature.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "e1e56b48-f7ad-51a5-bb1c-bb0e9dded764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48fe5e5-0a24-4231-af68-f99158ebbea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48fe5e5-0a24-4231-af68-f99158ebbea5.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "40eafc47-2865-51b2-97c3-69969bed5e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b672836-dba8-4a32-ac04-616644268534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b672836-dba8-4a32-ac04-616644268534.jpg?1",
             "name": "Krovikan Scoundrel",
             "text": "",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "77a35ade-f4b5-5638-b766-0c296582bbaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b89c0a7-9fb6-4930-a110-f33915ce93c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b89c0a7-9fb6-4930-a110-f33915ce93c3.jpg?1",
             "name": "Malakir Cullblade",
             "text": "Whenever a creature an opponent controls dies, put a +1/+1 counter on Malakir Cullblade.",
             "colours": [
@@ -1713,7 +1713,7 @@
         },
         {
             "id": "9ddc62bb-fa37-5178-a0ef-412989f2a266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0afbaf-2a0b-4f2f-9649-662923713d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0afbaf-2a0b-4f2f-9649-662923713d8b.jpg?1",
             "name": "Mardu Outrider",
             "text": "As an additional cost to cast this spell, discard a card.",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "5d7a1418-36a5-594e-a636-cf9eb138bfee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cffe0-0a60-406c-9dab-8c065cd798e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cffe0-0a60-406c-9dab-8c065cd798e9.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "fc090d6c-614d-5f43-8fad-3cbe7ee66413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1871e0-623b-4543-8b3c-3e54137cfe43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1871e0-623b-4543-8b3c-3e54137cfe43.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "36e9eca9-7697-5757-b72a-301f0dd0d427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706a38f3-8e7a-4ce5-9af9-e9f4c8afc9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706a38f3-8e7a-4ce5-9af9-e9f4c8afc9ec.jpg?1",
             "name": "Nimble Pilferer",
             "text": "Flash",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "06b462bf-dd61-51b8-94fa-bbe145d70245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fdb3d-cb34-4691-ada3-ff47b6802363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fdb3d-cb34-4691-ada3-ff47b6802363.jpg?1",
             "name": "Raise Dead",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "776568cd-6c66-59ef-98fe-8d72a2bc5696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4139383e-6c7c-4053-8e89-8b601e4ae98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4139383e-6c7c-4053-8e89-8b601e4ae98e.jpg?1",
             "name": "Rise from the Grave",
             "text": "",
             "colours": [
@@ -1908,7 +1908,7 @@
         },
         {
             "id": "38f6476d-ac22-5164-9728-19edb7de0e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ed607-2338-4119-b24c-7657133dc6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ed607-2338-4119-b24c-7657133dc6be.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "371bb42c-fe39-5f26-9b99-c85e86c42e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee2735e-05a8-4e3b-a44c-4e7532f1d312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee2735e-05a8-4e3b-a44c-4e7532f1d312.jpg?1",
             "name": "Savage Gorger",
             "text": "Flying\nAt the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on Savage Gorger. (Damage causes loss of life.)",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "5d6b03a7-be45-5374-b800-497131375fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa1144a-6110-408d-9d4b-2bfe6aebd7e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa1144a-6110-408d-9d4b-2bfe6aebd7e0.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -2007,7 +2007,7 @@
         },
         {
             "id": "2a30127b-4fff-59b5-aa0f-7ef9d642e0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00508913-ba8c-4985-9547-d74e07e1cc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00508913-ba8c-4985-9547-d74e07e1cc6b.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "a949bb21-567d-5864-92a8-138fc82e70ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd1af7-6094-46f3-8894-9add826b1031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd1af7-6094-46f3-8894-9add826b1031.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "5ee50241-4f51-59c1-9ce1-03f6c9d117be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16537b4c-5dd8-4d38-a1ce-7ac803c3f48a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16537b4c-5dd8-4d38-a1ce-7ac803c3f48a.jpg?1",
             "name": "Soulhunter Rakshasa",
             "text": "Soulhunter Rakshasa can't block.\nWhen Soulhunter Rakshasa enters the battlefield, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "de43ebd4-822e-5ead-aa30-57d1308b9877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4985d1-f311-4132-8d32-0a76ee53392e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4985d1-f311-4132-8d32-0a76ee53392e.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "f1a19b29-95ad-5917-9255-e398016c9186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf7a3f-35df-4322-a61e-e0e4f47da623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf7a3f-35df-4322-a61e-e0e4f47da623.jpg?1",
             "name": "Unlikely Aid",
             "text": "Target creature gets +2/+0 and gains indestructible until end of turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "5a7d10e2-c45f-5818-9b19-5dad54400b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982538c4-0b93-416d-9110-e0d2602d70aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982538c4-0b93-416d-9110-e0d2602d70aa.jpg?1",
             "name": "Vampire Opportunist",
             "text": "{6}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "5f90a657-b5a1-5015-a7dd-e940896949ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1f9bd-2891-4338-bcce-c55e55e6c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1f9bd-2891-4338-bcce-c55e55e6c933.jpg?1",
             "name": "Witch's Familiar",
             "text": "",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "e4a1e9a5-8d53-5b8a-8df5-85e9cef5cdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af04ac4f-7588-4fbb-95a7-78b3b6a5c209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af04ac4f-7588-4fbb-95a7-78b3b6a5c209.jpg?1",
             "name": "Bombard",
             "text": "Bombard deals 4 damage to target creature.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "193812f4-8645-5cc7-83c1-e228cfaca777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d007b-2db1-4e58-9281-5ade8d81ecf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d007b-2db1-4e58-9281-5ade8d81ecf9.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "11f526a9-c55d-55e0-99e1-cacbfc803800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9351dc-9af0-48d1-9012-7c478fdc34e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9351dc-9af0-48d1-9012-7c478fdc34e1.jpg?1",
             "name": "Fearless Halberdier",
             "text": "",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "ffe762bf-b14f-5f58-a4fc-5d9e0dc0f291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ebf8-5616-4cff-81d9-cd20b20102ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ebf8-5616-4cff-81d9-cd20b20102ee.jpg?1",
             "name": "Goblin Gang Leader",
             "text": "When Goblin Gang Leader enters the battlefield, create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "5bd2796c-e9dc-5d7b-a9ae-fd7041d75836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599032a9-4652-46c5-bdf4-43be00e25db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599032a9-4652-46c5-bdf4-43be00e25db3.jpg?1",
             "name": "Goblin Gathering",
             "text": "Create a number of 1/1 red Goblin creature tokens equal to two plus the number of cards named Goblin Gathering in your graveyard.",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "e8755a49-c8d6-5d36-bb60-6c11bc876c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f95fec8-99f6-4ce5-bfc3-426a568ee053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f95fec8-99f6-4ce5-bfc3-426a568ee053.jpg?1",
             "name": "Goblin Trashmaster",
             "text": "Other Goblins you control get +1/+1.\nSacrifice a Goblin: Destroy target artifact.",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "e1ac69ef-6880-572a-a2a0-9234b269a239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd7f3f-ca38-46cc-a2f6-1970b7cdec1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd7f3f-ca38-46cc-a2f6-1970b7cdec1f.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "c6a1e89c-efa4-5f92-b322-41d4f8daa662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb64a1-3791-4b39-b68d-2ea4459d5a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb64a1-3791-4b39-b68d-2ea4459d5a72.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "be0c3509-4eaa-5243-a20e-06522586320b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7701e2d1-ebc2-4c2d-bb50-25ce73d9c59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7701e2d1-ebc2-4c2d-bb50-25ce73d9c59a.jpg?1",
             "name": "Immortal Phoenix",
             "text": "Flying\nWhen Immortal Phoenix dies, return it to its owner's hand.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "48bf2e6c-e0df-5e87-896c-8a3fa934dda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e77225-3b31-49ba-909c-b0c2b3aaeb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e77225-3b31-49ba-909c-b0c2b3aaeb9b.jpg?1",
             "name": "Inescapable Blaze",
             "text": "This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "7b54b98d-444b-5803-879b-a210373d9252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f9ee1b-6002-4ebb-b755-f1a3ef5810cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f9ee1b-6002-4ebb-b755-f1a3ef5810cf.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "e6887992-8739-518c-a87d-a671f94c16bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cd434c-a04c-4ac8-9b1a-a79903d84060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cd434c-a04c-4ac8-9b1a-a79903d84060.jpg?1",
             "name": "Molten Ravager",
             "text": "{R}: Molten Ravager gets +1/+0 until end of turn.",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "e0d54f4e-70a1-5e50-a1c9-b8a8dfcb7f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48165add-7fef-456b-a703-be548df3e972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48165add-7fef-456b-a703-be548df3e972.jpg?1",
             "name": "Nest Robber",
             "text": "Haste",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "0a806a85-4fe9-526b-a1ed-86188787b428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe6f1c-bd4c-412a-af18-228319dc8e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe6f1c-bd4c-412a-af18-228319dc8e87.jpg?1",
             "name": "Ogre Battledriver",
             "text": "Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "a915042e-9583-546a-8baf-bf2395d50044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae1f0-60b6-4c4a-975b-13e659a33f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae1f0-60b6-4c4a-975b-13e659a33f50.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste",
             "colours": [
@@ -2730,7 +2730,7 @@
         },
         {
             "id": "daf5518f-0033-53ee-aad5-e0865b9052e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce45801e-2fca-435c-833f-dd1b8f11f308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce45801e-2fca-435c-833f-dd1b8f11f308.jpg?1",
             "name": "Raid Bombardment",
             "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to the player or planeswalker that creature is attacking.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "3467e666-b717-5102-baea-e46eb97867f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c978c53c-1b27-4c8d-8b01-5646ee1bdb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c978c53c-1b27-4c8d-8b01-5646ee1bdb1c.jpg?1",
             "name": "Reduce to Ashes",
             "text": "Reduce to Ashes deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e7ad0c62-682a-5bcd-a5a4-528c3ed75699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c146ec-3006-4ac1-b2b6-fe0f9e879dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c146ec-3006-4ac1-b2b6-fe0f9e879dc9.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "9e321e64-0bd9-57a1-b30f-a5771cd96da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67baa699-de43-4100-8a5a-82e39eec11f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67baa699-de43-4100-8a5a-82e39eec11f5.jpg?1",
             "name": "Siege Dragon",
             "text": "Flying\nWhen Siege Dragon enters the battlefield, destroy all Walls your opponents control.\nWhenever Siege Dragon attacks, if defending player controls no Walls, it deals 2 damage to each creature without flying that player controls.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "ae774d91-4735-5467-9672-35f9dff57a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3da54f-b4ee-4e9a-929e-619094691434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3da54f-b4ee-4e9a-929e-619094691434.jpg?1",
             "name": "Storm Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "37c2a5d0-120a-5d49-a362-b71c2935cc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26307e83-66ae-4def-9532-dd874fd39efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26307e83-66ae-4def-9532-dd874fd39efc.jpg?1",
             "name": "Tin Street Cadet",
             "text": "Whenever Tin Street Cadet becomes blocked, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "7c61972b-505c-5315-9ea3-5ebe2efcd11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afac4b5-2148-489e-b3dd-01388a234a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afac4b5-2148-489e-b3dd-01388a234a90.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying, haste",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "91af4939-2ee7-5439-ae01-ec166b29eb97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123bc3aa-d959-47e8-b160-1443b2cd41ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123bc3aa-d959-47e8-b160-1443b2cd41ce.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "2dd705bc-aa36-5a6a-9d42-cc689eef8b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b22c5d-3b29-47c1-8a04-13586461a143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b22c5d-3b29-47c1-8a04-13586461a143.jpg?1",
             "name": "Baloth Packhunter",
             "text": "Trample\nWhen Baloth Packhunter enters the battlefield, put two +1/+1 counters on each other creature you control named Baloth Packhunter.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "0241228b-7e18-5a66-9f11-9411e8670bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66feeb05-7adc-4a0e-ba2e-24781e5a291a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66feeb05-7adc-4a0e-ba2e-24781e5a291a.jpg?1",
             "name": "Charging Badger",
             "text": "Trample",
             "colours": [
@@ -3052,7 +3052,7 @@
         },
         {
             "id": "e69f515c-81c7-54ee-b048-69030816e408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44353b14-f3ab-4371-adb0-70e49dc6764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44353b14-f3ab-4371-adb0-70e49dc6764b.jpg?1",
             "name": "Colossal Majesty",
             "text": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "1325f67f-5313-59e6-9d34-06a720a1bea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3783bbed-5ae8-4d62-b39e-99136c42eeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3783bbed-5ae8-4d62-b39e-99136c42eeb6.jpg?1",
             "name": "Epic Proportions",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +5/+5 and has trample.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "7bb67b40-4978-52d0-b458-44937d87a258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f39c3fd-8ada-46e5-b247-428f7f2fe60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f39c3fd-8ada-46e5-b247-428f7f2fe60c.jpg?1",
             "name": "Feral Roar",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "5ae97426-172e-5922-b682-4fcb10a15e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b74b7-9d2d-4d91-a036-e9a3dc49bc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b74b7-9d2d-4d91-a036-e9a3dc49bc7f.jpg?1",
             "name": "Generous Stray",
             "text": "When Generous Stray enters the battlefield, draw a card.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "434d9ac8-3b3b-5536-a2e9-12342f3544cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600c2484-7d1a-4acd-9cc7-82bf70ace19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600c2484-7d1a-4acd-9cc7-82bf70ace19e.jpg?1",
             "name": "Gigantosaurus",
             "text": "",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "c07c88c7-4655-5394-9083-41c07a32fda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a50513-8570-47f0-9c57-6a775f0d2cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a50513-8570-47f0-9c57-6a775f0d2cf2.jpg?1",
             "name": "Greenwood Sentinel",
             "text": "Vigilance",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "cf6363f2-854c-5cf9-bcba-50dac2618585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cd7334-d55a-4e0d-aa25-a403c6e24a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cd7334-d55a-4e0d-aa25-a403c6e24a53.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "ddb6b0d5-9770-534a-ae31-0fff222bf616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fd403a-397e-423e-979a-69cf7a6096d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fd403a-397e-423e-979a-69cf7a6096d8.jpg?1",
             "name": "Jungle Delver",
             "text": "{3}{G}: Put a +1/+1 counter on Jungle Delver.",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "6a9cdb21-7ae0-5da9-91a0-9fe6bf36d35b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757d1e9b-4292-4dcc-ae52-d9f60aa6694d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757d1e9b-4292-4dcc-ae52-d9f60aa6694d.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "5d7f84b8-2743-5ddf-a039-20200bd4a477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41754001-4d64-4aa2-a273-aca4a1d323d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41754001-4d64-4aa2-a273-aca4a1d323d0.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "9f2eb732-0204-5806-919f-b37a3c926d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797dcbaa-d41b-4059-92fa-4a804e16a2ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797dcbaa-d41b-4059-92fa-4a804e16a2ce.jpg?1",
             "name": "Rampaging Brontodon",
             "text": "Trample\nWhenever Rampaging Brontodon attacks, it gets +1/+1 until end of turn for each land you control.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "f4e1d075-3d62-5852-8f2f-fa1022fb4b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28b7565-3da0-4878-bf5d-188f7019d47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28b7565-3da0-4878-bf5d-188f7019d47f.jpg?1",
             "name": "Rumbling Baloth",
             "text": "",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "12c4a78e-53ca-5d01-b593-4e0dfc1e0b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bdafb1-abb9-4020-8f74-18f9321de90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bdafb1-abb9-4020-8f74-18f9321de90a.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "e9827d5d-c385-5259-abfc-e271dce84189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0597ce-f91a-43a0-aad6-fbb2a4d9fe57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0597ce-f91a-43a0-aad6-fbb2a4d9fe57.jpg?1",
             "name": "Stony Strength",
             "text": "Put a +1/+1 counter on target creature you control. Untap that creature.",
             "colours": [
@@ -3508,7 +3508,7 @@
         },
         {
             "id": "c33b720f-76ed-5e87-ae07-8b319636a319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e463fb-f861-4042-a6ef-8961968624f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e463fb-f861-4042-a6ef-8961968624f1.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "3460704e-3a79-5884-ac55-a8f2fdde2479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c42e1a-9a4d-4630-b6c2-749d76c4cafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c42e1a-9a4d-4630-b6c2-749d76c4cafb.jpg?1",
             "name": "Treetop Warden",
             "text": "",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "bcff940d-22e1-5580-9811-e0eaa5f03db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193031-f981-4ca5-96e5-df1a5ffee246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193031-f981-4ca5-96e5-df1a5ffee246.jpg?1",
             "name": "Wildwood Patrol",
             "text": "Trample",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "9a0ee7cc-6961-5c04-aab1-2fdb822f6151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c9a583-2356-47ec-b908-c77d6acf24b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c9a583-2356-47ec-b908-c77d6acf24b8.jpg?1",
             "name": "Woodland Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "dc1653ba-a177-5f4e-b113-b2e17fa1a12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc05f8d-7f92-4f54-8d12-ab51030a15a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc05f8d-7f92-4f54-8d12-ab51030a15a6.jpg?1",
             "name": "World Shaper",
             "text": "Whenever World Shaper attacks, you may mill three cards.\nWhen World Shaper dies, return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3675,7 +3675,7 @@
         },
         {
             "id": "55045a71-ec8c-59d9-8eb4-4ae40ca0c5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c1f416-95e1-4d94-9ea5-e74da7071223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c1f416-95e1-4d94-9ea5-e74da7071223.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "ed40a1e5-455f-5eb1-9b00-2d3283b4defc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef83f4c-d3ff-4905-a16d-f2bae673a5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef83f4c-d3ff-4905-a16d-f2bae673a5b2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "5a838d65-5bc8-5c52-8637-c20e3ad686a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8550f5-cf3c-4061-8010-74b3d8709c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8550f5-cf3c-4061-8010-74b3d8709c68.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "258b4dde-8428-5431-b9df-bb97c71fe532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330e5230-7c5a-4720-b582-1087e5aa0cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330e5230-7c5a-4720-b582-1087e5aa0cf8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "a8f6bc20-f48c-5c84-a096-47e03f8481e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f284507-5cdc-48ee-9bc8-724045814664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f284507-5cdc-48ee-9bc8-724045814664.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "8b238069-cd13-525b-b597-36d22c5a823d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f796dc-7a6b-4652-9268-3523d7b54e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f796dc-7a6b-4652-9268-3523d7b54e94.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "6d223288-3e3b-5382-ba61-1f27e2ae3f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae6e393-315b-4f70-9da2-c58003e2813d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae6e393-315b-4f70-9da2-c58003e2813d.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "484cbb6b-e7b6-53e7-a3cf-945a5515b994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde73c08-40f6-42bd-9c38-348fcef97aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde73c08-40f6-42bd-9c38-348fcef97aa5.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/APC.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/APC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "55b7fa67-2e15-5238-91af-eec9756df435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7af8350-9a51-437c-a55e-19f3e07acfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7af8350-9a51-437c-a55e-19f3e07acfa9.jpg?1",
             "name": "Angelfire Crusader",
             "text": "o\nR: Angelfire Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "0d6779fd-6d98-507a-9e9c-7aae8522da87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e417461-a230-4548-bcc1-71377487f21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e417461-a230-4548-bcc1-71377487f21b.jpg?1",
             "name": "Coalition Flag",
             "text": "Coalition Flag can enchant only a creature you control.\nEnchanted creature's type is Flagbearer.\nIf an opponent plays a spell or ability that could target a Flagbearer in play, that player chooses at least one Flagbearer as a target.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "50bcc84e-38d9-50d4-8c19-2af36f46e763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b7be3e-b4af-46d4-bcc6-b44c651f2012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b7be3e-b4af-46d4-bcc6-b44c651f2012.jpg?1",
             "name": "Coalition Honor Guard",
             "text": "If an opponent plays a spell or ability that could target a Flagbearer in play, that player chooses at least one Flagbearer as a target.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "5a786323-8603-546a-b277-bf6203471d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9cd7d9-8aad-4607-890c-9c8efe016a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9cd7d9-8aad-4607-890c-9c8efe016a92.jpg?1",
             "name": "Dega Disciple",
             "text": "o\nB, oc\nT: Target creature gets -2/-0 until end of turn.\no\nR, oc\nT: Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "d078a5c3-46ae-59c1-ac7b-f3eb012b3b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ddfdb5-3981-4954-af5f-2459d22ec575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ddfdb5-3981-4954-af5f-2459d22ec575.jpg?1",
             "name": "Dega Sanctuary",
             "text": "At the beginning of your upkeep, if you control a black or red permanent, you gain 2 life. If you control a black permanent and a red permanent, you gain 4 life instead.",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "29712086-42f9-5366-8003-9fdba2f25777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a52c3a-2f58-4b4d-b3c6-f9a08e25c7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a52c3a-2f58-4b4d-b3c6-f9a08e25c7de.jpg?1",
             "name": "Degavolver",
             "text": "Kicker o1o\nB and/or o\nR\nIf you paid the o1o\nB kicker cost, Degavolver comes into play with two +1/+1 counters on it and has \"Pay 3 life: Regenerate Degavolver.\"\nIf you paid the o\nR kicker cost, Degavolver comes into play with a +1/+1 counter on it and has first strike.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "d41a29f3-099e-5ae8-b15d-6aa1d6ace507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5061e4-a76d-4a7c-b196-96c81f94e0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5061e4-a76d-4a7c-b196-96c81f94e0e5.jpg?1",
             "name": "Diversionary Tactics",
             "text": "Tap two untapped creatures you control: Tap target creature.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "7b13aa63-a4e1-59f1-9a77-2763752d0936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f596ce1-b754-4e34-98e3-e1ddda2fd9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f596ce1-b754-4e34-98e3-e1ddda2fd9b0.jpg?1",
             "name": "Divine Light",
             "text": "Prevent all damage that would be dealt this turn to creatures you control.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "0ac5051c-2784-5eeb-b542-93fb5a5ef6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38138bb4-25ea-4aaf-8b1c-e9e60678fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38138bb4-25ea-4aaf-8b1c-e9e60678fc6b.jpg?1",
             "name": "Enlistment Officer",
             "text": "First strike\nWhen Enlistment Officer comes into play, reveal the top four cards of your library. Put all Soldier cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "add7f8fe-721b-5c72-8e5a-3c8aee5cf0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695e0ba-005a-4652-aea7-e1d1f9ff5d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695e0ba-005a-4652-aea7-e1d1f9ff5d66.jpg?1",
             "name": "False Dawn",
             "text": "Colored mana symbols on all permanents you control and on all cards you own that aren't in play become o\nW until end of turn.\nDraw a card.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "ffe26573-a49b-554c-9ee4-38e273e80ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca800f-e850-4bec-95d0-70280b51b7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccca800f-e850-4bec-95d0-70280b51b7a7.jpg?1",
             "name": "Gerrard Capashen",
             "text": "At the beginning of your upkeep, you gain 1 life for each card in target opponent's hand.\no3o\nW: Tap target creature. Play this ability only if Gerrard Capashen is attacking.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "11cf5b54-b939-5edd-8c26-8744618cbe44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d2d11b-12e4-4810-a32d-8f1cdda3ec49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d2d11b-12e4-4810-a32d-8f1cdda3ec49.jpg?1",
             "name": "Haunted Angel",
             "text": "Flying\nWhen Haunted Angel is put into a graveyard from play, remove Haunted Angel from the game and each other player puts a 3/3 black Angel creature token with flying into play.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "33968db0-33fc-5c47-9284-c33b9271c671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4d395e-d7d6-4e93-9761-b0bae63b7b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4d395e-d7d6-4e93-9761-b0bae63b7b1c.jpg?1",
             "name": "Helionaut",
             "text": "Flying\no1, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "a5619b62-7c1d-5e54-97b9-b752c999c64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da5010-78b6-426f-aeb4-73c21d2af581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da5010-78b6-426f-aeb4-73c21d2af581.jpg?1",
             "name": "Manacles of Decay",
             "text": "Enchanted creature can't attack.\no\nB: Enchanted creature gets -1/-1 until end of turn.\no\nR: Enchanted creature can't block this turn.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "2efc772b-c0a2-5205-9a6a-e81dcccf4f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bf192-4baf-46ba-947b-a22d07635b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bf192-4baf-46ba-947b-a22d07635b04.jpg?1",
             "name": "Orim's Thunder",
             "text": "Kicker o\nR (You may pay an additional o\nR as you play this spell.)\nDestroy target artifact or enchantment. If you paid the kicker cost, Orim's Thunder deals damage equal to that artifact or enchantment's converted mana cost to target creature.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "513b7f07-c48e-5bd1-bd9d-8dce24e9f855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddf4ee0-75d6-48a5-955c-97faf73b899f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddf4ee0-75d6-48a5-955c-97faf73b899f.jpg?1",
             "name": "Shield of Duty and Reason",
             "text": "Enchanted creature has protection from green and from blue.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "dcda054a-ce64-5d45-914c-ce43eaf8b81d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13099abe-721e-42b4-9666-9e6b5f1d75c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13099abe-721e-42b4-9666-9e6b5f1d75c9.jpg?1",
             "name": "Spectral Lynx",
             "text": "Protection from green\no\nB: Regenerate Spectral Lynx.",
             "colours": [
@@ -591,7 +591,7 @@
         },
         {
             "id": "521bd8d3-d5ab-5e65-993b-037cfab6007f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f8e16a-55f0-4147-a01a-dba7938f31c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f8e16a-55f0-4147-a01a-dba7938f31c4.jpg?1",
             "name": "Standard Bearer",
             "text": "If an opponent plays a spell or ability that could target a Flagbearer in play, that player chooses at least one Flagbearer as a target.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "61c04e81-2f9f-5e6c-bf20-6b21b5bc5dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c40c26-3b82-4f72-acb5-85fbdd51665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c40c26-3b82-4f72-acb5-85fbdd51665a.jpg?1",
             "name": "Ceta Disciple",
             "text": "o\nR, oc\nT: Target creature gets +2/+0 until end of turn.\no\nG, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "233784b1-3db1-5ed6-9262-04c55217c7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cec6f3-295a-45e3-8466-e35fb043a596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cec6f3-295a-45e3-8466-e35fb043a596.jpg?1",
             "name": "Ceta Sanctuary",
             "text": "At the beginning of your upkeep, if you control a red or green permanent, draw a card, then discard a card from your hand. If you control a red permanent and a green permanent, instead draw two cards, then discard a card from your hand.",
             "colours": [
@@ -695,7 +695,7 @@
         },
         {
             "id": "260b9135-d37b-58a7-baa5-025bb6572f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69063cc2-4f6e-4cce-bb09-ccd57b69b993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69063cc2-4f6e-4cce-bb09-ccd57b69b993.jpg?1",
             "name": "Cetavolver",
             "text": "Kicker o1o\nR and/or o\nG\nIf you paid the o1o\nR kicker cost, Cetavolver comes into play with two +1/+1 counters on it and has first strike.\nIf you paid the o\nG kicker cost, Cetavolver comes into play with a +1/+1 counter on it and has trample.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "ecc640cc-b043-5b59-a631-2b6b44a0a5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87aaa74-26c6-4057-84b9-a007383684a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87aaa74-26c6-4057-84b9-a007383684a5.jpg?1",
             "name": "Coastal Drake",
             "text": "Flying\no1o\nU, oc\nT: Return target Kavu to its owner's hand.",
             "colours": [
@@ -765,7 +765,7 @@
         },
         {
             "id": "7a0ed27c-e704-5308-8bc6-75f53bfbf60f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b4f29-ada4-41d2-8292-b5af537c6fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b4f29-ada4-41d2-8292-b5af537c6fd2.jpg?1",
             "name": "Evasive Action",
             "text": "Counter target spell unless its controller pays o1 for each basic land type among lands you control.",
             "colours": [
@@ -797,7 +797,7 @@
         },
         {
             "id": "4bba59e6-8f80-51f9-84e5-35c04e304cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2877c2-4426-4c07-92a2-8ba5107d5e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2877c2-4426-4c07-92a2-8ba5107d5e7e.jpg?1",
             "name": "Ice Cave",
             "text": "Whenever a player plays a spell, any other player may pay that spell's mana cost. If a player does, counter the spell. (Mana cost includes color.)",
             "colours": [
@@ -829,7 +829,7 @@
         },
         {
             "id": "4a9b9eff-cb90-507c-8d02-222a093f2e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd57-ba92-48ff-9ad4-d40dad2ff418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd57-ba92-48ff-9ad4-d40dad2ff418.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "919eef1a-8343-58ce-9462-e8a4fe36e3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ab1f0-4e75-4165-85bc-6f838c221d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ab1f0-4e75-4165-85bc-6f838c221d6a.jpg?1",
             "name": "Jaded Response",
             "text": "Counter target spell if it shares a color with a creature you control.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "45bddd32-1b38-5eb3-a5ef-514d043592b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a010d2b1-960d-4032-a47a-61fe0998bee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a010d2b1-960d-4032-a47a-61fe0998bee3.jpg?1",
             "name": "Jilt",
             "text": "Kicker o1o\nR (You may pay an additional o1o\nR as you play this spell.)\nReturn target creature to its owner's hand. If you paid the kicker cost, Jilt deals 2 damage to another target creature.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "25d7e557-6a54-5be1-99b6-fe951d3eafce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0441eef-392e-4af4-b189-2f1fb8bf3fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0441eef-392e-4af4-b189-2f1fb8bf3fca.jpg?1",
             "name": "Living Airship",
             "text": "Flying\no2o\nG: Regenerate Living Airship.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "3470dcab-0237-51f8-b58d-e66f071f17fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f56714-0baa-48f9-8da1-50d9279e759c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f56714-0baa-48f9-8da1-50d9279e759c.jpg?1",
             "name": "Reef Shaman",
             "text": "oc\nT: Target land's type becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "4e3e7c1e-7161-537e-bcce-e248ee400b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7263e20e-5473-42e9-90c3-3bcd848644ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7263e20e-5473-42e9-90c3-3bcd848644ca.jpg?1",
             "name": "Shimmering Mirage",
             "text": "Target land's type becomes the basic land type of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "2d88affb-fffd-5b92-b2b6-b0c5cd137de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7cd5d-e81a-4729-b5d3-45587756413a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7cd5d-e81a-4729-b5d3-45587756413a.jpg?1",
             "name": "Tidal Courier",
             "text": "When Tidal Courier comes into play, reveal the top four cards of your library. Put all Merfolk cards revealed this way into your hand and the rest on the bottom of your library.\no3o\nU: Tidal Courier gains flying until end of turn.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "4fc558c2-9712-59d5-b2e1-34aeff7a3453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575e2cb-3990-4c73-b81c-e16311ec6bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575e2cb-3990-4c73-b81c-e16311ec6bbb.jpg?1",
             "name": "Unnatural Selection",
             "text": "o1: Choose a creature type other than Wall. Target creature's type becomes that type until end of turn.",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "378842d7-d4b0-5a56-ae91-17fbd19a801d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ec203a-067e-4360-9b4d-2d67db472aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ec203a-067e-4360-9b4d-2d67db472aab.jpg?1",
             "name": "Vodalian Mystic",
             "text": "oc\nT: Target instant or sorcery spell becomes the color of your choice.",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "ceca5400-1485-5bb4-bdd5-da1d42d5aa76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e866093-89a3-458d-8ebc-de805ef7885e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e866093-89a3-458d-8ebc-de805ef7885e.jpg?1",
             "name": "Whirlpool Drake",
             "text": "Flying\nWhen Whirlpool Drake comes into play, shuffle the cards from your hand into your library, then draw that many cards.\nWhen Whirlpool Drake is put into a graveyard from play, shuffle the cards from your hand into your library, then draw that many cards.",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "1ca74389-9e30-5f63-9108-b5dc3cfe23c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de47f44-8c5e-4114-9064-145d2d8813c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de47f44-8c5e-4114-9064-145d2d8813c6.jpg?1",
             "name": "Whirlpool Rider",
             "text": "When Whirlpool Rider comes into play, shuffle the cards from your hand into your library, then draw that many cards.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "4e54bd45-bc1e-57f6-aa53-00ea6dcd0c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f891ca-4e6a-4710-b1cf-5dabb5e1ad93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f891ca-4e6a-4710-b1cf-5dabb5e1ad93.jpg?1",
             "name": "Whirlpool Warrior",
             "text": "When Whirlpool Warrior comes into play, shuffle the cards from your hand into your library, then draw that many cards.\no\nR, Sacrifice Whirlpool Warrior: Each player shuffles the cards from his or her hand into his or her library, then draws that many cards.",
             "colours": [
@@ -1233,7 +1233,7 @@
         },
         {
             "id": "51884ace-d80d-5392-8bdd-dcc44893444a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78028c-3ebd-432d-b628-e1fa284f08f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78028c-3ebd-432d-b628-e1fa284f08f3.jpg?1",
             "name": "Dead Ringers",
             "text": "Destroy two target nonblack creatures unless either one is a color the other isn't. They can't be regenerated.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "635d60ae-3b6b-5770-b49e-1185da31b8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445127d4-8afb-47cf-b2a1-564540b1fdae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445127d4-8afb-47cf-b2a1-564540b1fdae.jpg?1",
             "name": "Desolation Angel",
             "text": "Kicker o\nWo\nW (You may pay an additional o\nWo\nW as you play this spell.)\nFlying\nWhen Desolation Angel comes into play, destroy all lands you control. If you paid the kicker cost, destroy all lands instead.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "2b825a40-3d20-593a-96a5-48ee813580be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a6fa8-d422-4e56-9e7b-2ff2fc8aecfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a6fa8-d422-4e56-9e7b-2ff2fc8aecfe.jpg?1",
             "name": "Foul Presence",
             "text": "Enchanted creature gets -1/-1 and has \"oc\nT: Target creature gets -1/-1 until end of turn.\"",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "7aa610be-b103-5c50-85d4-f9088c26d51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f76edc-6067-43bd-9582-1d59caf91597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f76edc-6067-43bd-9582-1d59caf91597.jpg?1",
             "name": "Grave Defiler",
             "text": "When Grave Defiler comes into play, reveal the top four cards of your library. Put all Zombie cards revealed this way into your hand and the rest on the bottom of your library.\no1o\nB: Regenerate Grave Defiler.",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "954fd56c-5830-563f-a158-33bf96225b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12317075-92a2-4b3a-a694-3b764132beaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12317075-92a2-4b3a-a694-3b764132beaf.jpg?1",
             "name": "Last Caress",
             "text": "Target player loses 1 life and you gain 1 life.\nDraw a card.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "0ddffc82-4945-584f-8510-c69dd41adaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d77ddcc-e66b-4036-8a55-ec42953918d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d77ddcc-e66b-4036-8a55-ec42953918d1.jpg?1",
             "name": "Mind Extraction",
             "text": "As an additional cost to play Mind Extraction, sacrifice a creature.\nTarget player reveals his or her hand and discards all cards of each of the sacrificed creature's colors from it.",
             "colours": [
@@ -1432,7 +1432,7 @@
         },
         {
             "id": "0dc91e96-a634-547b-b789-429939978527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba12fb1-de8c-46c6-b33f-e0580ed2a3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba12fb1-de8c-46c6-b33f-e0580ed2a3ee.jpg?1",
             "name": "Mournful Zombie",
             "text": "o\nW, oc\nT: Target player gains 1 life.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "f144ded4-0597-5eda-9c60-cd99148cfbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a771f-bd21-4388-857f-08160b24e26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a771f-bd21-4388-857f-08160b24e26e.jpg?1",
             "name": "Necra Disciple",
             "text": "o\nG, oc\nT: Add one mana of any color to your mana pool.\no\nW, oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "244c8fbd-2a3c-545e-b07a-532535e6ed9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0bf165-d7eb-4ae6-b30a-4e9fd55f401d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0bf165-d7eb-4ae6-b30a-4e9fd55f401d.jpg?1",
             "name": "Necra Sanctuary",
             "text": "At the beginning of your upkeep, if you control a green or white permanent, target player loses 1 life. If you control a green permanent and a white permanent, that player loses 3 life instead.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "fe3e9de7-cfd8-5e59-8431-8483b1354fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232c32d9-9b0c-458d-b1b3-e4219bd34c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232c32d9-9b0c-458d-b1b3-e4219bd34c82.jpg?1",
             "name": "Necravolver",
             "text": "Kicker o1o\nG and/or o\nW\nIf you paid the o1o\nG kicker cost, Necravolver comes into play with two +1/+1 counters on it and has trample.\nIf you paid the o\nW kicker cost, Necravolver comes into play with a +1/+1 counter on it and has \"Whenever Necravolver deals damage, you gain that much life.\"",
             "colours": [
@@ -1572,7 +1572,7 @@
         },
         {
             "id": "f63fdeae-9ebc-571b-a6c9-6d9c36fd265b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e19975-e3e1-453b-b902-a1b1fc1d8504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e19975-e3e1-453b-b902-a1b1fc1d8504.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -1604,7 +1604,7 @@
         },
         {
             "id": "47a266f8-7f58-5c28-a722-445c2a828c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c80cdd-4287-4ecb-992b-f265cd422098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c80cdd-4287-4ecb-992b-f265cd422098.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua comes into play, you draw two cards and you lose 2 life.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "953d8f58-f865-5074-b1ca-9b01c575cd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3addf34c-ea54-42a3-bccd-b73453d964d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3addf34c-ea54-42a3-bccd-b73453d964d2.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager comes into play, you draw a card and you lose 1 life.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "6a1358a9-9258-581c-8ea2-a98df9b8c2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a92d454-3f23-45bf-921f-25b0da4ce138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a92d454-3f23-45bf-921f-25b0da4ce138.jpg?1",
             "name": "Planar Despair",
             "text": "All creatures get -1/-1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "a80cde27-06b0-54a4-b5bd-e5d148308f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a75a004-d150-4fc1-a9a9-3b337a63e3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a75a004-d150-4fc1-a9a9-3b337a63e3e5.jpg?1",
             "name": "Quagmire Druid",
             "text": "o\nG, oc\nT, Sacrifice a creature: Destroy target enchantment.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "ec54e6fa-27ba-5e39-8b5b-8b6b75371db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642eefde-8727-44ff-9e04-373abfcd0679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642eefde-8727-44ff-9e04-373abfcd0679.jpg?1",
             "name": "Suppress",
             "text": "Target player removes all cards in his or her hand from the game face down. At the end of that player's next turn, that player returns those cards to his or her hand.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "3b1b0612-e90c-5e66-b542-e2f488350cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961619e3-f48b-4099-8a33-ca1e294085dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961619e3-f48b-4099-8a33-ca1e294085dd.jpg?1",
             "name": "Urborg Uprising",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -1806,7 +1806,7 @@
         },
         {
             "id": "b1b1fcac-d1fd-51ac-8980-5cdbeed31679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb8c277-3154-47c9-835f-327cac297a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb8c277-3154-47c9-835f-327cac297a5e.jpg?1",
             "name": "Zombie Boa",
             "text": "o1o\nB: Choose a color. Whenever Zombie Boa becomes blocked by a creature of that color this turn, destroy that creature. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1841,7 +1841,7 @@
         },
         {
             "id": "44a9e486-0a26-533f-ade9-b326127a0f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518145f3-9919-4ed6-9e2e-772ee349ea57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518145f3-9919-4ed6-9e2e-772ee349ea57.jpg?1",
             "name": "Bloodfire Colossus",
             "text": "o\nR, Sacrifice Bloodfire Colossus: Bloodfire Colossus deals 6 damage to each creature and each player.",
             "colours": [
@@ -1875,7 +1875,7 @@
         },
         {
             "id": "202f0775-a748-5f52-9a19-1f9441bd7630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b5c38e-7d74-4862-8187-f5db4a3d1e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b5c38e-7d74-4862-8187-f5db4a3d1e0f.jpg?1",
             "name": "Bloodfire Dwarf",
             "text": "o\nR, Sacrifice Bloodfire Dwarf: Bloodfire Dwarf deals 1 damage to each creature without flying.",
             "colours": [
@@ -1909,7 +1909,7 @@
         },
         {
             "id": "1b6124b1-cd37-5d63-9636-4f49ecc8d9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2639e9b7-ed8c-48fd-a8b7-b99d8dad4bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2639e9b7-ed8c-48fd-a8b7-b99d8dad4bc0.jpg?1",
             "name": "Bloodfire Infusion",
             "text": "Bloodfire Infusion can enchant only a creature you control.\no\nR, Sacrifice enchanted creature: Bloodfire Infusion deals damage equal to the enchanted creature's power to each creature.",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "b68c0685-d18e-51c5-ad86-523d9d94f1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1442b1f3-8c2c-4553-906f-c864fcdc6ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1442b1f3-8c2c-4553-906f-c864fcdc6ae5.jpg?1",
             "name": "Bloodfire Kavu",
             "text": "o\nR, Sacrifice Bloodfire Kavu: Bloodfire Kavu deals 2 damage to each creature.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "3ae995bf-9a22-56df-b7bf-f14e48a15761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7291da-1d14-4763-8691-c67136ab67c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7291da-1d14-4763-8691-c67136ab67c7.jpg?1",
             "name": "Desolation Giant",
             "text": "Kicker o\nWo\nW (You may pay an additional o\nWo\nW as you play this spell.)\nWhen Desolation Giant comes into play, destroy all other creatures you control. If you paid the kicker cost, destroy all other creatures instead.",
             "colours": [
@@ -2012,7 +2012,7 @@
         },
         {
             "id": "664f77f4-1678-5c9e-8b22-e6e002682702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab243e-d08d-4ece-9725-4bb5f67b1c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab243e-d08d-4ece-9725-4bb5f67b1c92.jpg?1",
             "name": "Dwarven Landslide",
             "text": "Kicker\u2014o2o\nR, Sacrifice a land. (You may pay o2o\nR and sacrifice a land in addition to any other costs as you play this spell.)\nDestroy target land. If you paid the kicker cost, destroy another target land.",
             "colours": [
@@ -2044,7 +2044,7 @@
         },
         {
             "id": "cb9d86b5-34ff-5f0b-9b23-48e4783c7127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c08df5-f5e7-4498-ac80-25ccbe304b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c08df5-f5e7-4498-ac80-25ccbe304b26.jpg?1",
             "name": "Dwarven Patrol",
             "text": "Dwarven Patrol doesn't untap during your untap step.\nWhenever you play a nonred spell, untap Dwarven Patrol.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "6862c1c4-ef6a-57f1-979c-37baad31b281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b2cd77-9552-48b1-80cb-26966323c1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b2cd77-9552-48b1-80cb-26966323c1ea.jpg?1",
             "name": "Goblin Ringleader",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhen Goblin Ringleader comes into play, reveal the top four cards of your library. Put all Goblin cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "659bd22b-2199-5b1f-8b9c-b85fb6a0f9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceef2761-7301-42de-8f54-49b8cd1e457b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceef2761-7301-42de-8f54-49b8cd1e457b.jpg?1",
             "name": "Illuminate",
             "text": "Kicker o2o\nR and/or o3o\nU (You may pay an additional o2o\nR and/or o3o\nU as you play this spell.)\nIlluminate deals X damage to target creature. If you paid the o2o\nR kicker cost, Illuminate deals X damage to that creature's controller. If you paid the o3o\nU kicker cost, you draw X cards.",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "a273da3a-558f-5c31-b2a1-45887f86ab95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aa5a8-2769-4a8a-b457-001abc862b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158aa5a8-2769-4a8a-b457-001abc862b35.jpg?1",
             "name": "Kavu Glider",
             "text": "o\nW: Kavu Glider gets +0/+1 until end of turn.\no\nU: Kavu Glider gains flying until end of turn.",
             "colours": [
@@ -2181,7 +2181,7 @@
         },
         {
             "id": "0c18b569-5fd3-5ddb-814f-1725aa222a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097decb6-03bd-4a84-ab9a-75becf85cae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097decb6-03bd-4a84-ab9a-75becf85cae8.jpg?1",
             "name": "Minotaur Tactician",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nMinotaur Tactician gets +1/+1 as long as you control a white creature.\nMinotaur Tactician gets +1/+1 as long as you control a blue creature.",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "319b6a71-0daa-52ea-91e6-b00c2b15eb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41462d43-4f9f-46ba-b79d-434597e74b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41462d43-4f9f-46ba-b79d-434597e74b6b.jpg?1",
             "name": "Raka Disciple",
             "text": "o\nW, oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\no\nU, oc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "a01114b6-aa26-568d-9413-d78a0743c79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cab0be-589c-42a0-a297-1faaec46c73f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cab0be-589c-42a0-a297-1faaec46c73f.jpg?1",
             "name": "Raka Sanctuary",
             "text": "At the beginning of your upkeep, if you control a white or blue permanent, Raka Sanctuary deals 1 damage to target creature. If you control a white permanent and a blue permanent, Raka Sanctuary deals 3 damage to that creature instead.",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "c3aff943-ee8c-5178-9f31-4568afc00392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787e24-0b7d-4005-8db4-68544476bd34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787e24-0b7d-4005-8db4-68544476bd34.jpg?1",
             "name": "Rakavolver",
             "text": "Kicker o1o\nW and/or o\nU\nIf you paid the o1o\nW kicker cost, Rakavolver comes into play with two +1/+1 counters on it and has \"Whenever Rakavolver deals damage, you gain that much life.\"\nIf you paid the o\nU kicker cost, Rakavolver comes into play with a +1/+1 counter on it and has flying.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "ee2bf9cb-8171-506d-b2f2-202489a0e20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c869c-74c2-42b6-bb23-a2f481c4b673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c869c-74c2-42b6-bb23-a2f481c4b673.jpg?1",
             "name": "Smash",
             "text": "Destroy target artifact.\nDraw a card.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "f64e0857-e4a0-542e-8b91-a08be2ca4dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442a4331-99ce-405e-b261-19b7f3375ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442a4331-99ce-405e-b261-19b7f3375ddf.jpg?1",
             "name": "Tahngarth's Glare",
             "text": "Look at the top three cards of target opponent's library, then put them back in any order. That player looks at the top three cards of your library, then puts them back in any order.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "9035ffec-861f-5861-b253-bc6dfd889011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc34e735-ac3c-4954-a4c8-3ed55d811715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc34e735-ac3c-4954-a4c8-3ed55d811715.jpg?1",
             "name": "Tundra Kavu",
             "text": "oc\nT: Target land becomes a plains or an island until end of turn.",
             "colours": [
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "8654f834-9e11-5028-b261-a75c0ac6d970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f00e6f1-e854-40b0-855d-7e0d7d233850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f00e6f1-e854-40b0-855d-7e0d7d233850.jpg?1",
             "name": "Wild Research",
             "text": "o1o\nW: Search your library for an enchantment card and reveal that card. Put it into your hand, then discard a card at random from your hand. Then shuffle your library.\no1o\nU: Search your library for an instant card and reveal that card. Put it into your hand, then discard a card at random from your hand. Then shuffle your library.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "267481bc-1240-5af2-9cb0-0cba903cbfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efe00f9-bf42-4d6f-9a22-b357b1c1e092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efe00f9-bf42-4d6f-9a22-b357b1c1e092.jpg?1",
             "name": "Ana Disciple",
             "text": "o\nU, oc\nT: Target creature gains flying until end of turn.\no\nB, oc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "0ab00963-09a9-5176-a194-c92fd4abeb6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1599bb-4f43-4ab3-985a-8be5219f2195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1599bb-4f43-4ab3-985a-8be5219f2195.jpg?1",
             "name": "Ana Sanctuary",
             "text": "At the beginning of your upkeep, if you control a blue or black permanent, target creature gets +1/+1 until end of turn. If you control a blue permanent and a black permanent, that creature gets +5/+5 until end of turn instead.",
             "colours": [
@@ -2521,7 +2521,7 @@
         },
         {
             "id": "81001cb3-2910-570f-a4bf-2581f54de86e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e685a8c-fba6-495f-ac0f-1ff5456b22d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e685a8c-fba6-495f-ac0f-1ff5456b22d0.jpg?1",
             "name": "Anavolver",
             "text": "Kicker o1o\nU and/or o\nB\nIf you paid the o1o\nU kicker cost, Anavolver comes into play with two +1/+1 counters on it and has flying.\nIf you paid the o\nB kicker cost, Anavolver comes into play with a +1/+1 counter on it and has \"Pay 3 life: Regenerate Anavolver.\"",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "3cfc10c0-781b-5560-8715-83339ede5311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f230831-023c-41aa-832e-16ac81e68588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f230831-023c-41aa-832e-16ac81e68588.jpg?1",
             "name": "Bog Gnarr",
             "text": "Whenever a player plays a black spell, Bog Gnarr gets +2/+2 until end of turn.",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "a79b69f6-b752-51a2-90f1-08e9631935f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ffc5f8-ff1c-4733-b046-8679fa16371b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ffc5f8-ff1c-4733-b046-8679fa16371b.jpg?1",
             "name": "Gaea's Balance",
             "text": "As an additional cost to play Gaea's Balance, sacrifice five lands.\nSearch your library for a land card of each basic land type and put them into play. Then shuffle your library.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "05fe4d46-3938-57e6-9de1-e225fcaaa22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38eeae-918b-4d19-b37a-175ac5db37a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38eeae-918b-4d19-b37a-175ac5db37a4.jpg?1",
             "name": "Glade Gnarr",
             "text": "Whenever a player plays a blue spell, Glade Gnarr gets +2/+2 until end of turn.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "53b014d6-74dc-5bc6-8135-5ba58dc7304c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf502f-445d-4724-b7d0-8fdd5bf557a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf502f-445d-4724-b7d0-8fdd5bf557a8.jpg?1",
             "name": "Kavu Howler",
             "text": "When Kavu Howler comes into play, reveal the top four cards of your library. Put all Kavu cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "98adfd5a-d320-5e60-b4a4-a49c2af1b682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79adc3af-5fa3-4cb6-9bbc-52ede0c69263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79adc3af-5fa3-4cb6-9bbc-52ede0c69263.jpg?1",
             "name": "Kavu Mauler",
             "text": "Trample\nWhenever Kavu Mauler attacks, it gets +1/+1 until end of turn for each other attacking Kavu.",
             "colours": [
@@ -2725,7 +2725,7 @@
         },
         {
             "id": "20761409-7b67-50e9-b89a-d16eded91e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b10608-8917-4337-ad60-ab31ab8c0fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b10608-8917-4337-ad60-ab31ab8c0fc4.jpg?1",
             "name": "Lay of the Land",
             "text": "Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "c249a421-7c8a-5083-a98f-1bd691c5c51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21049fee-a748-4856-99ae-3a225a168532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21049fee-a748-4856-99ae-3a225a168532.jpg?1",
             "name": "Penumbra Bobcat",
             "text": "When Penumbra Bobcat is put into a graveyard from play, put a 2/1 black Cat creature token into play.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "f6f425bc-a5d8-56f1-8286-887d13bd2838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee334211-4109-46ff-8676-856048221a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee334211-4109-46ff-8676-856048221a1c.jpg?1",
             "name": "Penumbra Kavu",
             "text": "When Penumbra Kavu is put into a graveyard from play, put a 3/3 black Kavu creature token into play.",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "7bd760e0-5297-5c22-8309-e07bff62030f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3dffe7-ecaf-4cf0-a43e-8e2746282992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3dffe7-ecaf-4cf0-a43e-8e2746282992.jpg?1",
             "name": "Penumbra Wurm",
             "text": "Trample\nWhen Penumbra Wurm is put into a graveyard from play, put a 6/6 black Wurm creature token with trample into play.",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "68d9deb6-ea2b-5793-aebd-22003fa1ae5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ad3f87-9f25-455f-9933-3b0b0eaad467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ad3f87-9f25-455f-9933-3b0b0eaad467.jpg?1",
             "name": "Savage Gorilla",
             "text": "o\nUo\nB, oc\nT, Sacrifice Savage Gorilla: Target creature gets -3/-3 until end of turn. Draw a card.",
             "colours": [
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "aa8a7eac-a6be-554b-8e43-26ed6ada3561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87aab031-4e44-44cd-89a7-6cffc7288cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87aab031-4e44-44cd-89a7-6cffc7288cd1.jpg?1",
             "name": "Strength of Night",
             "text": "Kicker o\nB (You may pay an additional o\nB as you play this spell.)\nCreatures you control get +1/+1 until end of turn. If you paid the kicker cost, Zombies you control get an additional +2/+2 until end of turn.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "b0108a70-7e3c-5526-bc86-8cb592d739da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg?1",
             "name": "Sylvan Messenger",
             "text": "Trample\nWhen Sylvan Messenger comes into play, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "91350bec-12f0-5648-8e6f-4907f542cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e2b7e9-d52b-478e-b118-e890a81fd471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e2b7e9-d52b-478e-b118-e890a81fd471.jpg?1",
             "name": "Symbiotic Deployment",
             "text": "Skip your draw step.\no1, Tap two untapped creatures you control: Draw a card.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "dafc274c-c5d1-5502-9873-31fc2287e7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8c059-3309-49a5-ae97-c048aefc922f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8c059-3309-49a5-ae97-c048aefc922f.jpg?1",
             "name": "Tranquil Path",
             "text": "Destroy all enchantments.\nDraw a card.",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "79dee1b4-7ba5-5ef1-b37a-98ebdb7a6716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8521bf-d026-4d26-831e-a2f253307c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8521bf-d026-4d26-831e-a2f253307c93.jpg?1",
             "name": "Urborg Elf",
             "text": "oc\nT: Add o\nG, o\nU, or o\nB to your mana pool.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "109075ca-ff7d-5151-a44e-9412b58947e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9507116-ede8-40a1-8fa3-705e6f6f64c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9507116-ede8-40a1-8fa3-705e6f6f64c0.jpg?1",
             "name": "Aether Mutation",
             "text": "Return target creature to its owner's hand. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "d04846b3-96f1-582c-a481-ebdc68c2acfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb50813c-72df-49e7-bac5-e6e247649241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb50813c-72df-49e7-bac5-e6e247649241.jpg?1",
             "name": "Captain's Maneuver",
             "text": "The next X damage that would be dealt to target creature or player this turn is dealt to another target creature or player instead.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "c39353a0-4a03-5918-adf5-40bec83a0571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f005fc90-7e81-4bd4-a479-438337110979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f005fc90-7e81-4bd4-a479-438337110979.jpg?1",
             "name": "Consume Strength",
             "text": "Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "1a55f93a-033a-50e7-8b8c-ac66cf4ccdb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9e0a23-d2a8-40a6-9076-ed6fb539141b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9e0a23-d2a8-40a6-9076-ed6fb539141b.jpg?1",
             "name": "Cromat",
             "text": "o\nWo\nB: Destroy target creature blocking or blocked by Cromat.\no\nUo\nR: Cromat gains flying until end of turn.\no\nBo\nG: Regenerate Cromat.\no\nRo\nW: Cromat gets +1/+1 until end of turn.\no\nGo\nU: Put Cromat on top of its owner's library.",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "a4695791-baa3-5979-9cc5-b774b6689122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893dd4-8c37-496e-bc39-cd83d42b4cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893dd4-8c37-496e-bc39-cd83d42b4cc4.jpg?1",
             "name": "Death Grasp",
             "text": "Death Grasp deals X damage to target creature or player. You gain X life.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "7f79047c-86f4-5c13-a193-32cbf2eeadfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c643d87-50bc-4380-b1d6-0a465eef5dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c643d87-50bc-4380-b1d6-0a465eef5dbf.jpg?1",
             "name": "Death Mutation",
             "text": "Destroy target nonblack creature. It can't be regenerated. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -3277,7 +3277,7 @@
         },
         {
             "id": "459f99fd-5c6b-52f7-8a61-afbc007d93d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85dadb-351f-4975-a2c3-febf5e80bc85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85dadb-351f-4975-a2c3-febf5e80bc85.jpg?1",
             "name": "Ebony Treefolk",
             "text": "o\nBo\nG: Ebony Treefolk gets +1/+1 until end of turn.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "a8cdf5a6-83ac-5df6-9ee8-7aff8eb35bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d610a9d5-c650-45ad-a9b0-b55113701e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d610a9d5-c650-45ad-a9b0-b55113701e05.jpg?1",
             "name": "Fervent Charge",
             "text": "Whenever a creature you control attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "ffad7fea-19b9-5143-bba5-7db1c074fb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57abdab-d99c-418c-818d-b06a8722d733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57abdab-d99c-418c-818d-b06a8722d733.jpg?1",
             "name": "Flowstone Charger",
             "text": "Whenever Flowstone Charger attacks, it gets +3/-3 until end of turn.",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "b52296f8-55d9-5703-96f2-3e64fbb4c952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b65f96b-019b-40a9-9b4d-acd4abf4a0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b65f96b-019b-40a9-9b4d-acd4abf4a0f9.jpg?1",
             "name": "Fungal Shambler",
             "text": "Trample\nWhenever Fungal Shambler deals damage to an opponent, you draw a card and that opponent discards a card from his or her hand.",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "eaa17629-3042-51e3-93b9-8d1492b6e62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a564432-c2b3-4cf6-b4bc-2e2600b92911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a564432-c2b3-4cf6-b4bc-2e2600b92911.jpg?1",
             "name": "Gaea's Skyfolk",
             "text": "Flying",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "05078a00-a5b3-555c-9738-650747befd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583740c0-68cf-4205-b682-2f97c0880d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583740c0-68cf-4205-b682-2f97c0880d42.jpg?1",
             "name": "Gerrard's Verdict",
             "text": "Target player discards two cards from his or her hand. You gain 3 life for each land card discarded this way.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "855a67eb-5387-54b4-af62-3f4c0f96bf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c684407e-277a-4e32-a978-cdac9548acce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c684407e-277a-4e32-a978-cdac9548acce.jpg?1",
             "name": "Goblin Legionnaire",
             "text": "o\nR, Sacrifice Goblin Legionnaire: Goblin Legionnaire deals 2 damage to target creature or player.\no\nW, Sacrifice Goblin Legionnaire: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "270cd359-5064-5017-ac0e-c31242000fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100844c-6a41-40f5-b7f8-9b426d5a6945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100844c-6a41-40f5-b7f8-9b426d5a6945.jpg?1",
             "name": "Goblin Trenches",
             "text": "o2, Sacrifice a land: Put two 1/1 red and white Goblin Soldier creature tokens into play.",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "f2bdcc24-d758-546f-8ff5-c38d57425a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e8e58-aee1-4882-943a-17a6af2f8410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e8e58-aee1-4882-943a-17a6af2f8410.jpg?1",
             "name": "Guided Passage",
             "text": "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle your library.",
             "colours": [
@@ -3602,7 +3602,7 @@
         },
         {
             "id": "e75e287f-e978-5cab-af70-7ca290e22568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb114a4-44e5-4375-92b8-00a0b0acbe94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb114a4-44e5-4375-92b8-00a0b0acbe94.jpg?1",
             "name": "Jungle Barrier",
             "text": "(Walls can't attack.)\nWhen Jungle Barrier comes into play, draw a card.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "1dd7d663-8f2a-5a4b-b387-f2a629bc33a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc3d054-6266-4ce0-89ed-f8b170794f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc3d054-6266-4ce0-89ed-f8b170794f2e.jpg?1",
             "name": "Last Stand",
             "text": "Target opponent loses 2 life for each swamp you control. Last Stand deals damage equal to the number of mountains you control to target creature. Put a 1/1 green Saproling creature token into play for each forest you control. You gain 2 life for each plains you control. Draw a card for each island you control, then discard that many cards from your hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "d8f562d8-1f92-5b2d-b556-b38e6c75f43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518d0c5-58ee-4089-bf19-5030d4319681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518d0c5-58ee-4089-bf19-5030d4319681.jpg?1",
             "name": "Lightning Angel",
             "text": "Flying; haste (This creature may attack and oc\nT the turn it comes under your control.)\nAttacking doesn't cause Lightning Angel to tap.",
             "colours": [
@@ -3717,7 +3717,7 @@
         },
         {
             "id": "b20e3cb2-d4d2-5be6-bc32-f59ad717e8f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271969e-1529-42d1-878b-011f80ab0f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271969e-1529-42d1-878b-011f80ab0f05.jpg?1",
             "name": "Llanowar Dead",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "03fa0618-f64f-5929-8109-5572b485608e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906a775-7c2d-47b7-a20e-a325dd28d0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906a775-7c2d-47b7-a20e-a325dd28d0bd.jpg?1",
             "name": "Martyrs' Tomb",
             "text": "Pay 2 life: Prevent the next 1 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "753ab4f3-dffc-5cb5-8e1f-59e3467c236d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a49d29-6d01-4b1d-80c8-9e5378a76878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a49d29-6d01-4b1d-80c8-9e5378a76878.jpg?1",
             "name": "Minotaur Illusionist",
             "text": "o1o\nU: Minotaur Illusionist can't be the target of spells or abilities this turn.\no\nR, Sacrifice Minotaur Illusionist: Minotaur Illusionist deals damage equal to its power to target creature.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "9dc6586f-4586-515f-aac4-44f123f7ae99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098a28c-5f9b-4a2c-b109-c342365eb948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098a28c-5f9b-4a2c-b109-c342365eb948.jpg?1",
             "name": "Mystic Snake",
             "text": "You may play Mystic Snake any time you could play an instant.\nWhen Mystic Snake comes into play, counter target spell.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "db74f0af-d839-5a3c-8437-b4cd1fa451a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c48c58-3532-4022-9eec-1a870385cbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c48c58-3532-4022-9eec-1a870385cbf3.jpg?1",
             "name": "Overgrown Estate",
             "text": "Sacrifice a land: You gain 3 life.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "c33a5b05-e38d-5482-8a94-290735648a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cbb33-4947-49f0-b612-a92141fbfaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cbb33-4947-49f0-b612-a92141fbfaa6.jpg?1",
             "name": "Pernicious Deed",
             "text": "o\nX, Sacrifice Pernicious Deed: Destroy each artifact, creature, and enchantment with converted mana cost X or less.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "feb8889f-5478-5724-9970-ca58c72dec2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17807b9-8feb-48ac-813a-829577f5b9e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17807b9-8feb-48ac-813a-829577f5b9e8.jpg?1",
             "name": "Powerstone Minefield",
             "text": "Whenever a creature attacks or blocks, Powerstone Minefield deals 2 damage to it.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "35600a9f-d7b3-5c9c-b3bc-1e8e33a87bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f74291-c452-4a60-bf5f-73efad6583d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f74291-c452-4a60-bf5f-73efad6583d4.jpg?1",
             "name": "Prophetic Bolt",
             "text": "Prophetic Bolt deals 4 damage to target creature or player. Look at the top four cards of your library. Put one of those cards into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "4f47321c-8730-5870-b3d9-b6a67c15c161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fce298-3338-4f41-8156-ab6322951a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fce298-3338-4f41-8156-ab6322951a76.jpg?1",
             "name": "Putrid Warrior",
             "text": "Whenever Putrid Warrior deals damage, choose one each player loses 1 life; or each player gains 1 life.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "6f86c7b0-fc44-5f49-a9d5-e130c582e21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74012-6060-4fad-aa73-6e6afd33c482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74012-6060-4fad-aa73-6e6afd33c482.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchanted creature has \"oc\nT: This creature deals 1 damage to target player. You draw a card.\"",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "cf2363a3-b01f-5a7e-af17-776559b67283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99829552-917a-4373-9772-4255dff542d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99829552-917a-4373-9772-4255dff542d6.jpg?1",
             "name": "Razorfin Hunter",
             "text": "oc\nT: Razorfin Hunter deals 1 damage to target creature or player.",
             "colours": [
@@ -4110,7 +4110,7 @@
         },
         {
             "id": "4bb74cb6-eefb-55ab-9dd3-2a40fe9c9d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425e0ca4-8592-4802-b7c4-6e3323edd78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425e0ca4-8592-4802-b7c4-6e3323edd78c.jpg?1",
             "name": "Soul Link",
             "text": "Whenever enchanted creature deals or is dealt damage, you gain that much life.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "b8d2adc8-f064-5585-8c91-f9e02c6e8ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6e67-f690-4f19-bb25-a7c2d2aaf42f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6e67-f690-4f19-bb25-a7c2d2aaf42f.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\no\nB: Regenerate Spiritmonger.\no\nG: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "c928f9c1-7f97-58f8-a42c-2b3dc7f891ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682a705-9341-4d1e-a9c5-d428e50b9a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e682a705-9341-4d1e-a9c5-d428e50b9a03.jpg?1",
             "name": "Squee's Embrace",
             "text": "Enchanted creature gets +2/+2.\nWhen enchanted creature is put into a graveyard, return that creature card to its owner's hand.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "a2613de0-790f-5feb-a500-fd9e2ad6dc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b391ee3-c1cd-47bc-9540-977cbc32913e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b391ee3-c1cd-47bc-9540-977cbc32913e.jpg?1",
             "name": "Squee's Revenge",
             "text": "Choose a number. Flip a coin that many times or until you lose a flip, whichever comes first. If you win all the flips, draw two cards for each flip.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "1d0c1abf-b90f-561a-9fd8-a6d1a64717bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a70297-2a7b-4a0c-ace5-cd61bfe6dafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a70297-2a7b-4a0c-ace5-cd61bfe6dafd.jpg?1",
             "name": "Suffocating Blast",
             "text": "Counter target spell and Suffocating Blast deals 3 damage to target creature.",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "8a8003ae-8001-561c-9273-02af92c33779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b584dfd1-a56c-406e-8504-47ea136dc102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b584dfd1-a56c-406e-8504-47ea136dc102.jpg?1",
             "name": "Temporal Spring",
             "text": "Put target permanent on top of its owner's library.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "a1cdbff7-0dec-5ffe-8131-63ac68359871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1bfefd-dae8-49e9-9d56-cc852e3dc93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1bfefd-dae8-49e9-9d56-cc852e3dc93b.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -4354,7 +4354,7 @@
         },
         {
             "id": "262a6c4c-b778-58f5-afdf-0a05457d39f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b41ff1-240a-447b-bb47-1b9be53ab3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b41ff1-240a-447b-bb47-1b9be53ab3e6.jpg?1",
             "name": "Yavimaya's Embrace",
             "text": "You control enchanted creature.\nEnchanted creature gets +2/+2 and has trample.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "0ad9df53-068e-5bbd-9a83-d0dc4168ce6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "d6bfcef0-7cb3-5651-b110-0e6ff432a887",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f98f4538-5b5b-475d-b98f-49d01dae6f04.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "e1daff6e-043f-5374-b908-a70cf713e3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg?1",
             "name": "Illusion // Reality",
             "text": "Destroy target artifact.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "88381ee9-f96c-5a37-abcd-16bf7d34e3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7dd90a-4f93-43aa-b503-18289fdd571e.jpg?1",
             "name": "Illusion // Reality",
             "text": "Destroy target artifact.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "875e0cd8-096a-5a4a-a09d-504f8f587a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg?1",
             "name": "Life // Death",
             "text": "Return target creature card from your graveyard to play. You lose life equal to its converted mana cost.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "7ee304fd-fec1-587c-93e2-cbf32930d585",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ab75cdb-93a1-4f78-b404-37566295c321.jpg?1",
             "name": "Life // Death",
             "text": "Return target creature card from your graveyard to play. You lose life equal to its converted mana cost.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "0a18d581-5298-5a3a-9608-236e52a15ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg?1",
             "name": "Night // Day",
             "text": "Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "b316580d-53d1-5225-b8d6-641753983ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8f109f1-9798-4bd3-b51a-49f173251dfd.jpg?1",
             "name": "Night // Day",
             "text": "Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "b09c1874-9f3e-5afe-bcd6-a4c70f42fae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg?1",
             "name": "Order // Chaos",
             "text": "Remove target attacking creature from the game.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "dad3e574-dee5-5161-9d6e-cac54f13f597",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14e4f5a4-b1ea-4816-b2d7-cf148468a388.jpg?1",
             "name": "Order // Chaos",
             "text": "Remove target attacking creature from the game.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "759a2e06-256d-5574-9468-f8778b9d7f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd60a7-2ba4-4fce-bf74-2ea9b8fd4dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bd60a7-2ba4-4fce-bf74-2ea9b8fd4dbe.jpg?1",
             "name": "Brass Herald",
             "text": "As Brass Herald comes into play, choose a creature type.\nWhen Brass Herald comes into play, reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library.\nCreatures of the chosen type get +1/+1.",
             "colours": [],
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "73f898f4-1210-54aa-b024-755106239774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded8b992-a1c2-4e43-ad0a-ea3995a3c8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded8b992-a1c2-4e43-ad0a-ea3995a3c8b8.jpg?1",
             "name": "Dodecapod",
             "text": "If a spell or ability an opponent controls causes you to discard Dodecapod from your hand, put it into play with two +1/+1 counters on it instead of putting it into your graveyard.",
             "colours": [],
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "a99629b9-dc40-5037-8abb-5b6071511eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec581b8-e509-420c-b142-afaa6dd06cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec581b8-e509-420c-b142-afaa6dd06cc8.jpg?1",
             "name": "Dragon Arch",
             "text": "o2, oc\nT: Put a multicolored creature card from your hand into play.",
             "colours": [],
@@ -4810,7 +4810,7 @@
         },
         {
             "id": "8ff06e32-6f85-5614-8c91-b56fcecea8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527fc6-4f4c-4ded-9e72-49186b7e5bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527fc6-4f4c-4ded-9e72-49186b7e5bd3.jpg?1",
             "name": "Emblazoned Golem",
             "text": "Kicker o\nX (You may pay an additional o\nX as you play this spell.)\nSpend only colored mana on X. No more than one mana of each color may be spent this way.\nIf you paid the kicker cost, Emblazoned Golem comes into play with X +1/+1 counters on it.",
             "colours": [],
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "74bfe9ec-9aca-552e-b8e9-10a763d518c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385d8691-b9bd-4b4d-86db-7a7cc6181104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385d8691-b9bd-4b4d-86db-7a7cc6181104.jpg?1",
             "name": "Legacy Weapon",
             "text": "o\nWo\nUo\nBo\nRo\nG: Remove target permanent from the game.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "de3e1298-8494-54ca-9bf2-a33d85755ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f623ae51-5f15-4153-b2ed-d03b57b7db54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f623ae51-5f15-4153-b2ed-d03b57b7db54.jpg?1",
             "name": "Mask of Intolerance",
             "text": "At the beginning of each player's upkeep, if there are four or more basic land types among lands that player controls, Mask of Intolerance deals 3 damage to him or her.",
             "colours": [],
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "bacd573c-9949-5bcd-8471-4d0a0228574d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c25e71-0140-48fe-8b9e-33b4b50c5c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c25e71-0140-48fe-8b9e-33b4b50c5c12.jpg?1",
             "name": "Battlefield Forge",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nW to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -4936,7 +4936,7 @@
         },
         {
             "id": "a77e52c8-f5db-532d-9b02-e21111c029d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144dd08e-451e-4438-b572-7a138e1a15f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144dd08e-451e-4438-b572-7a138e1a15f3.jpg?1",
             "name": "Caves of Koilos",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nB to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -4967,7 +4967,7 @@
         },
         {
             "id": "c48818a8-e169-50e3-84c4-9983b2f61e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610b7cd5-5532-45a9-acfe-24a818034d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610b7cd5-5532-45a9-acfe-24a818034d1c.jpg?1",
             "name": "Llanowar Wastes",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nG to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "ee471a9f-4835-5d09-aaca-57d6663957b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3403143-2b4e-4408-b138-c856bbc1e9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3403143-2b4e-4408-b138-c856bbc1e9a5.jpg?1",
             "name": "Shivan Reef",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nR to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -5029,7 +5029,7 @@
         },
         {
             "id": "2eb56c36-3797-5001-95e9-33227a67ff74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ee102-d981-4fc3-9f09-9dd07755f22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ee102-d981-4fc3-9f09-9dd07755f22c.jpg?1",
             "name": "Yavimaya Coast",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nU to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ARB.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ARB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e1001f62-0c7f-544e-8905-738feb82bf88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d521737-ee07-4387-bc07-5ced53db374d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d521737-ee07-4387-bc07-5ced53db374d.jpg?1",
             "name": "Ardent Plea",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "e61536eb-5acb-54cd-90d9-476f86d9a50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49876185-e23d-4137-8612-1347da3a1df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49876185-e23d-4137-8612-1347da3a1df6.jpg?1",
             "name": "Aven Mimeomancer",
             "text": "Flying\nAt the beginning of your upkeep, you may put a feather counter on target creature. If you do, that creature is 3/1 and has flying as long as it has a feather counter on it.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "68787d65-0187-56fe-80a6-b3f82ea1d19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094a235d-a5b8-434e-b4b0-c982da45a54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094a235d-a5b8-434e-b4b0-c982da45a54d.jpg?1",
             "name": "Ethercaste Knight",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "aae5b8a2-d311-5212-8589-be08548728fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5340e18-faed-4787-a42c-c12935bb0646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5340e18-faed-4787-a42c-c12935bb0646.jpg?1",
             "name": "Ethersworn Shieldmage",
             "text": "Flash\nWhen Ethersworn Shieldmage comes into play, prevent all damage that would be dealt to artifact creatures this turn.",
             "colours": [
@@ -151,7 +151,7 @@
         },
         {
             "id": "22d7eec3-b2a2-537b-8865-f4e050b7b496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9650a717-b1e4-4cd2-894d-766f6b311369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9650a717-b1e4-4cd2-894d-766f6b311369.jpg?1",
             "name": "Fieldmist Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Fieldmist Borderpost's mana cost.\nFieldmist Borderpost comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "0a07a3e8-f503-5d94-8aea-0e934cc5bae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c7a2a-85c1-4b20-95b9-04aab0bd0d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0c7a2a-85c1-4b20-95b9-04aab0bd0d3b.jpg?1",
             "name": "Filigree Angel",
             "text": "Flying\nWhen Filigree Angel comes into play, you gain 3 life for each artifact you control.",
             "colours": [
@@ -222,7 +222,7 @@
         },
         {
             "id": "99c42685-c894-57fe-bffb-4913ed88634e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397e6ff5-f5ee-4963-9942-4aa25f5eb64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397e6ff5-f5ee-4963-9942-4aa25f5eb64a.jpg?1",
             "name": "Glassdust Hulk",
             "text": "Whenever another artifact comes into play under your control, Glassdust Hulk gets +1/+1 until end of turn and is unblockable this turn.\nCycling {WU} ({WU}, Discard this card: Draw a card.)",
             "colours": [
@@ -259,7 +259,7 @@
         },
         {
             "id": "3c7cf112-ba65-595e-a43e-b5e1cb1cddf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55308b-5772-430a-93e4-b65c416b86cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55308b-5772-430a-93e4-b65c416b86cf.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage comes into play, name a nonland card.\nThe named card can't be played.",
             "colours": [
@@ -296,7 +296,7 @@
         },
         {
             "id": "937ea00a-f4ab-5bd6-8bda-750fc653ff1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260fe443-ca03-42b1-bcee-86e5173c1aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260fe443-ca03-42b1-bcee-86e5173c1aaf.jpg?1",
             "name": "Offering to Asha",
             "text": "Counter target spell unless its controller pays {4}. You gain 4 life.",
             "colours": [
@@ -330,7 +330,7 @@
         },
         {
             "id": "d780941a-b8f3-5540-aa62-f57d2bf9d9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73887514-7644-4b2b-8c67-4b7e64150478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73887514-7644-4b2b-8c67-4b7e64150478.jpg?1",
             "name": "Sanctum Plowbeast",
             "text": "Defender\nPlainscycling {2}, islandcycling {2} ({2}, Discard this card: Search your library for a Plains or Island card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -367,7 +367,7 @@
         },
         {
             "id": "82c1c8e6-6264-553f-8a3d-f6b2deaa504c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6474b6-1e1a-4c29-8f01-1cabf729b34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6474b6-1e1a-4c29-8f01-1cabf729b34f.jpg?1",
             "name": "Shield of the Righteous",
             "text": "Equipped creature gets +0/+2 and has vigilance.\nWhenever equipped creature blocks a creature, that creature doesn't untap during its controller's next untap step.\nEquip {2}",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "6e1cdea9-8c02-5987-974c-9ed00cade0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a9e7e-649f-457b-aba7-9c74c2704adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2a9e7e-649f-457b-aba7-9c74c2704adf.jpg?1",
             "name": "Sovereigns of Lost Alara",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may search your library for an Aura card that could enchant that creature, put it into play attached to that creature, then shuffle your library.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "f916a802-d4ff-532c-b2e6-579d7684611f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15931d65-9b4e-4506-8f1d-714d06f9c2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15931d65-9b4e-4506-8f1d-714d06f9c2f3.jpg?1",
             "name": "Stormcaller's Boon",
             "text": "Sacrifice Stormcaller's Boon: Creatures you control gain flying until end of turn.\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "7c581212-e99c-5d37-8b44-e5cfb474377f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a6a0d-5c56-47f5-92d0-f883f1bb7630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a6a0d-5c56-47f5-92d0-f883f1bb7630.jpg?1",
             "name": "Talon Trooper",
             "text": "Flying",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "e716bf6b-4443-541a-9460-18a8032e7f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac7672c-c75f-4ce4-8f28-2c5db623e752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac7672c-c75f-4ce4-8f28-2c5db623e752.jpg?1",
             "name": "Unbender Tine",
             "text": "{T}: Untap another target permanent.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "0166bc69-b44f-54e5-9b8d-de967e61f41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd66cb50-6ef5-4b1f-b6c3-ad1210d2d380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd66cb50-6ef5-4b1f-b6c3-ad1210d2d380.jpg?1",
             "name": "Wall of Denial",
             "text": "Defender, flying, shroud",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "1093e390-b8c8-5099-903b-f191b98cf1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd69ea7-aab6-4f30-98f4-640cb0a6046c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd69ea7-aab6-4f30-98f4-640cb0a6046c.jpg?1",
             "name": "Architects of Will",
             "text": "When Architects of Will comes into play, look at the top three cards of target player's library, then put them back in any order.\nCycling {UB} ({UB}, Discard this card: Draw a card.)",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "8dfa4834-6958-5cad-93c1-5cb0964ce5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c08bd-120d-49a5-a258-bda3859c1d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c08bd-120d-49a5-a258-bda3859c1d4c.jpg?1",
             "name": "Brainbite",
             "text": "Target opponent reveals his or her hand. You choose a card from it. That player discards that card.\nDraw a card.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "ab593973-79da-5ceb-9883-b0d5e8495c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f138fe9f-3cb9-4f16-adc4-76fcb0c7e064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f138fe9f-3cb9-4f16-adc4-76fcb0c7e064.jpg?1",
             "name": "Deny Reality",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "6492d27e-7cce-5870-a39d-6a50c0d22928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbd63-d6ff-4da5-868f-ed68cbc12d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbd63-d6ff-4da5-868f-ed68cbc12d43.jpg?1",
             "name": "Etherium Abomination",
             "text": "Unearth {1}{U}{B} ({1}{U}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -723,7 +723,7 @@
         },
         {
             "id": "6e8b7817-f770-53e4-bbde-a641c55ebf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d69f7f-ac70-477b-9246-8d81fef7d335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d69f7f-ac70-477b-9246-8d81fef7d335.jpg?1",
             "name": "Illusory Demon",
             "text": "Flying\nWhen you play a spell, sacrifice Illusory Demon.",
             "colours": [
@@ -760,7 +760,7 @@
         },
         {
             "id": "fa50ab73-24af-5210-aec2-cde30c0d77b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d3f7fd-f414-4c17-ad63-c8b39bde301d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d3f7fd-f414-4c17-ad63-c8b39bde301d.jpg?1",
             "name": "Jhessian Zombies",
             "text": "Fear\nIslandcycling {2}, swampcycling {2} ({2}, Discard this card: Search your library for an Island or Swamp card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "8b7f5c31-28de-59e0-832f-9dacfbae85c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c56c6-fd72-4917-96d1-d7f9f8236fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c56c6-fd72-4917-96d1-d7f9f8236fa2.jpg?1",
             "name": "Kathari Remnant",
             "text": "Flying\n{B}: Regenerate Kathari Remnant.\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "d203ccdf-1e89-58ba-b1e0-785c8632a383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df38c422-7830-4f25-b74b-ed90b7047f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df38c422-7830-4f25-b74b-ed90b7047f53.jpg?1",
             "name": "Lich Lord of Unx",
             "text": "{U}{B}, {T}: Put a 1/1 blue and black Zombie Wizard creature token into play.\n{U}{U}{B}{B}: Target player loses X life and puts the top X cards of his or her library into his or her graveyard, where X is the number of Zombies you control.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "de64875c-ae9b-5ed6-bef2-7121c9cabbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc0c40f-1d6c-4940-9c0a-566458a8ab04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc0c40f-1d6c-4940-9c0a-566458a8ab04.jpg?1",
             "name": "Mask of Riddles",
             "text": "Equipped creature has fear.\nWhenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2}",
             "colours": [
@@ -906,7 +906,7 @@
         },
         {
             "id": "710d511a-9abb-571f-a7cc-fe38cac9060a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335168b9-bc12-4459-9b7e-56f568a8887a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335168b9-bc12-4459-9b7e-56f568a8887a.jpg?1",
             "name": "Mind Funeral",
             "text": "Target opponent reveals cards from the top of his or her library until four land cards are revealed. That player puts all cards revealed this way into his or her graveyard.",
             "colours": [
@@ -940,7 +940,7 @@
         },
         {
             "id": "b57c7f60-0b92-5f30-b513-1329a37a49c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974a0de-6c14-431d-bfdb-2e76a1778ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974a0de-6c14-431d-bfdb-2e76a1778ad0.jpg?1",
             "name": "Mistvein Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Mistvein Borderpost's mana cost.\nMistvein Borderpost comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [
@@ -974,7 +974,7 @@
         },
         {
             "id": "d93534d9-42d2-5e9e-80f4-0911ac184127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105176cc-26b0-42a8-8913-5540f54656f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105176cc-26b0-42a8-8913-5540f54656f7.jpg?1",
             "name": "Nemesis of Reason",
             "text": "Whenever Nemesis of Reason attacks, defending player puts the top ten cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "77dffba4-077a-5793-b6de-e3db43da68d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd3cb05-c6f9-435a-a0e7-1f85da4a36eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd3cb05-c6f9-435a-a0e7-1f85da4a36eb.jpg?1",
             "name": "Soul Manipulation",
             "text": "Choose one or both \u2014 Counter target creature spell; and/or return target creature card in your graveyard to your hand.",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "37c8db5b-ef13-5a75-88b0-1adf28364546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a7470-b93e-4c3a-ab1c-0a4dd401e95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a7470-b93e-4c3a-ab1c-0a4dd401e95a.jpg?1",
             "name": "Soulquake",
             "text": "Return all creatures in play and all creature cards in graveyards to their owners' hands.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "a62a2d91-f525-531d-a7bc-194de3ec7dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e565-f5e1-467c-a1d1-8d05228b2f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c620e565-f5e1-467c-a1d1-8d05228b2f37.jpg?1",
             "name": "Time Sieve",
             "text": "{T}, Sacrifice five artifacts: Take an extra turn after this one.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "c4eab165-fd56-5de8-a649-7f1bed11077e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01072149-fe5e-4139-b3b2-3810fd220c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01072149-fe5e-4139-b3b2-3810fd220c8e.jpg?1",
             "name": "Vedalken Ghoul",
             "text": "Whenever Vedalken Ghoul becomes blocked, defending player loses 4 life.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "1c389a04-0cfa-59a8-b67a-6c7a98b6e292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab106855-bd85-4c00-b596-c46d34f8cdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab106855-bd85-4c00-b596-c46d34f8cdd0.jpg?1",
             "name": "Anathemancer",
             "text": "When Anathemancer comes into play, it deals damage to target player equal to the number of nonbasic lands that player controls.\nUnearth {5}{B}{R} ({5}{B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1187,7 +1187,7 @@
         },
         {
             "id": "85616586-607d-5b3b-bb52-45334ed7dd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6a3c48-b01e-4462-a4a1-8d5009a6a844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6a3c48-b01e-4462-a4a1-8d5009a6a844.jpg?1",
             "name": "Bituminous Blast",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nBituminous Blast deals 4 damage to target creature.",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "574cdd9f-e3a0-5ad9-b2c6-3b34092b54fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a12e4d0-8471-46ac-85e4-a2ea5be8bf8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a12e4d0-8471-46ac-85e4-a2ea5be8bf8f.jpg?1",
             "name": "Breath of Malfegor",
             "text": "Breath of Malfegor deals 5 damage to each opponent.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "acc8caba-1faa-541b-a3d3-29d7c4ae8b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09f166f-dd3c-4cf5-b5f9-3989f46f050c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09f166f-dd3c-4cf5-b5f9-3989f46f050c.jpg?1",
             "name": "Deathbringer Thoctar",
             "text": "Whenever another creature is put into a graveyard from play, you may put a +1/+1 counter on Deathbringer Thoctar.\nRemove a +1/+1 counter from Deathbringer Thoctar: Deathbringer Thoctar deals 1 damage to target creature or player.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "35ccb77c-54ad-5692-a801-eaf464a28a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e8b418-04af-4b99-b8fd-deb1fe21a61c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e8b418-04af-4b99-b8fd-deb1fe21a61c.jpg?1",
             "name": "Defiler of Souls",
             "text": "Flying\nAt the beginning of each player's upkeep, that player sacrifices a monocolored creature.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "bad4daed-7888-5e70-85f4-aed9ccc12b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb81132e-ab33-435f-ade4-af4416d36044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb81132e-ab33-435f-ade4-af4416d36044.jpg?1",
             "name": "Demonic Dread",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nTarget creature can't block this turn.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "580ae286-03cd-5217-9d33-50e61df6f602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a4434-0d5e-4ba8-8d10-cba9b4db5713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a4434-0d5e-4ba8-8d10-cba9b4db5713.jpg?1",
             "name": "Demonspine Whip",
             "text": "{X}: Equipped creature gets +X/+0 until end of turn.\nEquip {1}",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "82c2253a-2274-50ac-b84d-77010ae3f81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d59b32-d47f-4b05-87eb-58ffb8006fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d59b32-d47f-4b05-87eb-58ffb8006fa8.jpg?1",
             "name": "Igneous Pouncer",
             "text": "Haste\nSwampcycling {2}, mountaincycling {2} ({2}, Discard this card: Search your library for a Swamp or Mountain card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1434,7 +1434,7 @@
         },
         {
             "id": "7e970360-8b64-5d31-9acf-990f87f8b646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0d4f83-6319-4d40-9fee-6a44b05c8e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0d4f83-6319-4d40-9fee-6a44b05c8e9e.jpg?1",
             "name": "Kathari Bomber",
             "text": "Flying\nWhen Kathari Bomber deals combat damage to a player, put two 1/1 red Goblin creature tokens into play and sacrifice Kathari Bomber.\nUnearth {3}{B}{R} ({3}{B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "57e01cfd-bdd7-5953-b1c9-ab053b74f030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0860d-d3b9-4a00-a8cb-617bc317b93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0860d-d3b9-4a00-a8cb-617bc317b93d.jpg?1",
             "name": "Lightning Reaver",
             "text": "Fear, haste\nWhenever Lightning Reaver deals combat damage to a player, put a charge counter on it.\nAt the end of your turn, Lightning Reaver deals damage equal to the number of charge counters on it to each opponent.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "1b6edd72-e2ee-58af-97d5-1a139d5a8bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e668d-02ca-4164-88ee-c7ea6c665975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e668d-02ca-4164-88ee-c7ea6c665975.jpg?1",
             "name": "Monstrous Carabid",
             "text": "Monstrous Carabid attacks each turn if able.\nCycling {BR} ({BR}, Discard this card: Draw a card.)",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "60184302-f250-5a8a-be69-a90a39fdf11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c088d28d-16c2-4dd2-b036-946dfdb8ec98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c088d28d-16c2-4dd2-b036-946dfdb8ec98.jpg?1",
             "name": "Sanity Gnawers",
             "text": "When Sanity Gnawers comes into play, target player discards a card at random.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "a5414dea-6bed-5276-8600-63946c2c934a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1564d7-43fe-4072-91a6-622713848b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1564d7-43fe-4072-91a6-622713848b7e.jpg?1",
             "name": "Singe-Mind Ogre",
             "text": "When Singe-Mind Ogre comes into play, target player reveals a card at random from his or her hand, then loses life equal to that card's converted mana cost.",
             "colours": [
@@ -1617,7 +1617,7 @@
         },
         {
             "id": "c4320d6f-8955-5c69-8512-d57b9494331c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8acab8-4469-4baa-af2f-a3f49b841a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8acab8-4469-4baa-af2f-a3f49b841a55.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -1651,7 +1651,7 @@
         },
         {
             "id": "78d48bdc-78cd-584d-92d2-2d95e68a266b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b38a7e-d7c4-40c2-ba54-ae5649589cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b38a7e-d7c4-40c2-ba54-ae5649589cc9.jpg?1",
             "name": "Thought Hemorrhage",
             "text": "Name a nonland card. Target player reveals his or her hand. Thought Hemorrhage deals 3 damage to that player for each card with that name revealed this way. Search that player's graveyard, hand, and library for all cards with that name and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "577e54e6-a84b-53da-bf21-4c7a39bc83f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ad0cc1-66bd-43c3-a296-c36cf9a64e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ad0cc1-66bd-43c3-a296-c36cf9a64e85.jpg?1",
             "name": "Veinfire Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Veinfire Borderpost's mana cost.\nVeinfire Borderpost comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "aa5e05ee-265b-55ad-9871-a9583709a963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4a16be-ab3b-4020-9f26-631c0ee6730a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4a16be-ab3b-4020-9f26-631c0ee6730a.jpg?1",
             "name": "Blitz Hellion",
             "text": "Trample, haste\nAt end of turn, Blitz Hellion's owner shuffles it into his or her library.",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "6e177b7e-e008-52aa-91ce-cbd5e1977232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef67487-c8e5-49bb-b0f7-e073ff2e31f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef67487-c8e5-49bb-b0f7-e073ff2e31f1.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "34330743-fd16-5c17-8bac-4796bd1b9958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294330bb-3e77-4524-be2c-3299cf6f841f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294330bb-3e77-4524-be2c-3299cf6f841f.jpg?1",
             "name": "Colossal Might",
             "text": "Target creature gets +4/+2 and gains trample until end of turn.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "0003d249-25d9-5223-af1e-1130f09622a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aacb131b-74c9-4e6c-9466-27710bc9441f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aacb131b-74c9-4e6c-9466-27710bc9441f.jpg?1",
             "name": "Deadshot Minotaur",
             "text": "When Deadshot Minotaur comes into play, it deals 3 damage to target creature with flying.\nCycling {RG} ({RG}, Discard this card: Draw a card.)",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "9bee1432-76d0-51a8-b133-9b6869534311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f99431-ae43-4b68-82f0-faf940216c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f99431-ae43-4b68-82f0-faf940216c91.jpg?1",
             "name": "Dragon Broodmother",
             "text": "Flying\nAt the beginning of each upkeep, put a 1/1 red and green Dragon creature token with flying and devour 2 into play. (As the token comes into play, you may sacrifice any number of creatures. It comes into play with twice that many +1/+1 counters on it.)",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "ede81bb9-5212-5e0c-9ccf-4d767a9cb296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb37a8bd-6b6c-47f3-b7a0-5a20fa2d507c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb37a8bd-6b6c-47f3-b7a0-5a20fa2d507c.jpg?1",
             "name": "Firewild Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Firewild Borderpost's mana cost.\nFirewild Borderpost comes into play tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "4647038f-8118-5ba8-af41-664bf9e9737d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3fb7a-3eed-4b0a-9de0-ed8b7cf03533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3fb7a-3eed-4b0a-9de0-ed8b7cf03533.jpg?1",
             "name": "Godtracker of Jund",
             "text": "Whenever a creature with power 5 or greater comes into play under your control, you may put a +1/+1 counter on Godtracker of Jund.",
             "colours": [
@@ -1969,7 +1969,7 @@
         },
         {
             "id": "4a258abc-8ede-5f95-ad78-332d11e3f5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e5a9be-bfb2-466b-b0fe-3b24694e9f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e5a9be-bfb2-466b-b0fe-3b24694e9f84.jpg?1",
             "name": "Gorger Wurm",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "5396538f-d9f4-5d08-98ad-c95e52c3d897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0bfe8c-120c-4c4b-8709-efe40e26a35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0bfe8c-120c-4c4b-8709-efe40e26a35c.jpg?1",
             "name": "Mage Slayer",
             "text": "Whenever equipped creature attacks, it deals damage equal to its power to defending player.\nEquip {3}",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "e79c7009-8762-55bd-a383-ffaeba6d9bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595ae3af-cc28-407a-a045-a6d71cd6be60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595ae3af-cc28-407a-a045-a6d71cd6be60.jpg?1",
             "name": "Predatory Advantage",
             "text": "At the end of each opponent's turn, if that player didn't play a creature spell this turn, put a 2/2 green Lizard creature token into play.",
             "colours": [
@@ -2075,7 +2075,7 @@
         },
         {
             "id": "6e6d6b86-e967-548a-85fc-b51b082f8b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237de286-5bf0-4c8e-8504-2d01d3133b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237de286-5bf0-4c8e-8504-2d01d3133b55.jpg?1",
             "name": "Rhox Brute",
             "text": "",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "51ed4bec-6b5f-5720-830c-0c5298d1166a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a197e3f2-e69f-4716-9979-a304a87506c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a197e3f2-e69f-4716-9979-a304a87506c3.jpg?1",
             "name": "Spellbreaker Behemoth",
             "text": "Spellbreaker Behemoth can't be countered.\nCreature spells you control with power 5 or greater can't be countered.",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "af72ecf0-310e-508c-a1bb-b16e5035c067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2027335a-224b-411d-a59f-f4ad39b38a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2027335a-224b-411d-a59f-f4ad39b38a69.jpg?1",
             "name": "Valley Rannet",
             "text": "Mountaincycling {2}, forestcycling {2} ({2}, Discard this card: Search your library for a Mountain or Forest card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "69281173-cfe0-548c-b0f5-7fa32d8c545d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a504fb-b3ce-40f9-8fcb-86d5ad038e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a504fb-b3ce-40f9-8fcb-86d5ad038e5d.jpg?1",
             "name": "Vengeful Rebirth",
             "text": "Return target card from your graveyard to your hand. If you return a nonland card to your hand this way, Vengeful Rebirth deals damage equal to that card's converted mana cost to target creature or player.\nRemove Vengeful Rebirth from the game.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "a9f5cce0-fc4d-5b13-a782-5cd7587ade1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b58856a-f88e-4625-8636-62b5c717b956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b58856a-f88e-4625-8636-62b5c717b956.jpg?1",
             "name": "Violent Outburst",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nCreatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "b71dc8cf-95c2-5ba0-818a-53eb6925162b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7459a075-1a5d-4053-ab49-21bb696b6400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7459a075-1a5d-4053-ab49-21bb696b6400.jpg?1",
             "name": "Vithian Renegades",
             "text": "When Vithian Renegades comes into play, destroy target artifact.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "1706c3a6-5b31-5c3c-a7a6-6086aaca2e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a224-2db7-47d0-ba8b-98aeb50ad5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a224-2db7-47d0-ba8b-98aeb50ad5d3.jpg?1",
             "name": "Behemoth Sledge",
             "text": "Equipped creature gets +2/+2 and has lifelink and trample.\nEquip {3}",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "59e0f8a3-0271-5e21-a252-f8a479d85cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcafc9eb-efa3-4f6c-a2ca-aec8692fddc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcafc9eb-efa3-4f6c-a2ca-aec8692fddc1.jpg?1",
             "name": "Captured Sunlight",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)\nYou gain 4 life.",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "b2c9407d-7890-55ed-90fc-917567c054e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832309e0-c047-4c82-baa3-16f3c76e4b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832309e0-c047-4c82-baa3-16f3c76e4b6f.jpg?1",
             "name": "Dauntless Escort",
             "text": "Sacrifice Dauntless Escort: Creatures you control are indestructible this turn.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "7630e262-02a5-5df5-a3ff-9e4d6d08d2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605149-3959-4a51-8400-350e6fac2ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605149-3959-4a51-8400-350e6fac2ab2.jpg?1",
             "name": "Enlisted Wurm",
             "text": "Cascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "6c975c50-ddac-5f21-a6f4-e5cdb6991d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b388381-9e13-4ce7-b5b3-56a74cc23d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b388381-9e13-4ce7-b5b3-56a74cc23d93.jpg?1",
             "name": "Grizzled Leotau",
             "text": "",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "17b348b7-0f90-5c55-afc0-b5ce751ada66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3fc235-d0d7-41f8-b35a-6e08761f7fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3fc235-d0d7-41f8-b35a-6e08761f7fa4.jpg?1",
             "name": "Knight of New Alara",
             "text": "Each other multicolored creature you control gets +1/+1 for each of its colors.",
             "colours": [
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "26f2ec96-6c71-5b12-a3a3-8beb3b56020e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a715673f-77f1-46d6-91ae-01fb3af54760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a715673f-77f1-46d6-91ae-01fb3af54760.jpg?1",
             "name": "Knotvine Paladin",
             "text": "Whenever Knotvine Paladin attacks, it gets +1/+1 until end of turn for each untapped creature you control.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "0f383a3f-c413-5f00-af35-dfd161cfc407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a57cdbd-3cd2-47c1-aec8-7f4fd7a7b804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a57cdbd-3cd2-47c1-aec8-7f4fd7a7b804.jpg?1",
             "name": "Leonin Armorguard",
             "text": "When Leonin Armorguard comes into play, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "05a2a90a-085d-5d11-8c0f-f1fa52e9a695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331079e-0193-4243-9db9-ec7762a27633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8331079e-0193-4243-9db9-ec7762a27633.jpg?1",
             "name": "Mycoid Shepherd",
             "text": "Whenever Mycoid Shepherd or another creature you control with power 5 or greater is put into a graveyard from play, you may gain 5 life.",
             "colours": [
@@ -2615,7 +2615,7 @@
         },
         {
             "id": "05d6d9b6-96c8-571a-9dbb-1cbc18ae09f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fad19c-fd45-45cf-b58c-82cdcdf49b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fad19c-fd45-45cf-b58c-82cdcdf49b06.jpg?1",
             "name": "Pale Recluse",
             "text": "Reach (This can block creatures with flying.)\nForestcycling {2}, plainscycling {2} ({2}, Discard this card: Search your library for a Forest or Plains card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "1a5d1058-a7c2-56a7-9bba-e129945ad15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75256550-bbe0-499d-909e-af10691749c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75256550-bbe0-499d-909e-af10691749c2.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "8149e83e-8881-5560-afce-45cdcfd7281c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038868-6278-4d8c-a107-35aa85b5648f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038868-6278-4d8c-a107-35aa85b5648f.jpg?1",
             "name": "Reborn Hope",
             "text": "Return target multicolored card from your graveyard to your hand.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "7a0094a0-d8b4-5799-a135-268f9200f98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f767f262-57fd-4479-b719-189942ddfd9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f767f262-57fd-4479-b719-189942ddfd9e.jpg?1",
             "name": "Sigil Captain",
             "text": "Whenever a creature comes into play under your control, if that creature is 1/1, put two +1/+1 counters on it.",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "af341369-eed7-575f-ab7c-43dd6a2ed386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a856dec4-fe4f-477c-9300-e9de86d3cc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a856dec4-fe4f-477c-9300-e9de86d3cc95.jpg?1",
             "name": "Sigil of the Nayan Gods",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each creature you control.\nCycling {RW} ({RW}, Discard this card: Draw a card.)",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "ab220b48-3bfa-5e4d-bb5d-6d69d6765b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0195ee6-c5d9-402e-8339-2caa50c4e46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0195ee6-c5d9-402e-8339-2caa50c4e46b.jpg?1",
             "name": "Sigiled Behemoth",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "f7d9d3db-69a2-54ce-b69d-352e0c30a0f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a788e7-f3c8-41cc-9f1a-2e9f58aabc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a788e7-f3c8-41cc-9f1a-2e9f58aabc0e.jpg?1",
             "name": "Wildfield Borderpost",
             "text": "You may pay {1} and return a basic land you control to its owner's hand rather than pay Wildfield Borderpost's mana cost.\nWildfield Borderpost comes into play tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "8cf1527f-f8b7-5c5a-851a-b682f7fd2686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d0de1-39af-4b08-81a3-2cca8aae5d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d0de1-39af-4b08-81a3-2cca8aae5d40.jpg?1",
             "name": "Identity Crisis",
             "text": "Remove all cards in target player's hand and graveyard from the game.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "414fd82a-04f2-53da-b5f6-358f46f94450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e39147-6261-4e49-b6f2-28584582489f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e39147-6261-4e49-b6f2-28584582489f.jpg?1",
             "name": "Necromancer's Covenant",
             "text": "When Necromancer's Covenant comes into play, remove all creature cards in target player's graveyard from the game, then put a 2/2 black Zombie creature token into play for each card removed this way.\nZombies you control have lifelink.",
             "colours": [
@@ -2933,7 +2933,7 @@
         },
         {
             "id": "4c548969-c030-576b-af09-8728885ab21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcf3694-d6b0-459d-8c3a-1532237b487a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcf3694-d6b0-459d-8c3a-1532237b487a.jpg?1",
             "name": "Tainted Sigil",
             "text": "{T}, Sacrifice Tainted Sigil: You gain life equal to the total life lost by all players this turn. (Damage causes loss of life.)",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "b36af59d-5597-520a-a958-c4b1bd6c4fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb7589-a53e-4580-bd92-641fd4785934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb7589-a53e-4580-bd92-641fd4785934.jpg?1",
             "name": "Vectis Dominator",
             "text": "{T}: Tap target creature unless its controller pays 2 life.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "8386f2a2-7f87-5db8-9d3f-6440ed826f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8ae46-14ec-4878-ba8a-a47d4508c6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8ae46-14ec-4878-ba8a-a47d4508c6d7.jpg?1",
             "name": "Zealous Persecution",
             "text": "Until end of turn, creatures you control get +1/+1 and creatures your opponents control get -1/-1.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "43149872-866a-51a8-800d-a3a7303bd051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62ee3ea-8b85-4b14-87ae-7fca1d98b98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62ee3ea-8b85-4b14-87ae-7fca1d98b98b.jpg?1",
             "name": "Cloven Casting",
             "text": "Whenever you play a multicolored instant or sorcery spell, you may pay {1}. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "f7b766bd-bd75-5d64-b975-ea7c538ac820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e3c58-3cda-4891-8b3d-33bb21568cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e3c58-3cda-4891-8b3d-33bb21568cf5.jpg?1",
             "name": "Double Negative",
             "text": "Counter up to two target spells.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "28f19755-8cc9-5def-b90f-cf2b3ff4515d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18c2d9-60c4-454b-b6c7-7c22ed2985fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18c2d9-60c4-454b-b6c7-7c22ed2985fb.jpg?1",
             "name": "Magefire Wings",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has flying.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "53fa6e06-2aef-55e2-888e-991ef1dae055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafde9c4-57c0-4ae5-a4db-38aae434ddcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafde9c4-57c0-4ae5-a4db-38aae434ddcd.jpg?1",
             "name": "Skyclaw Thrash",
             "text": "Whenever Skyclaw Thrash attacks, flip a coin. If you win the flip, Skyclaw Thrash gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "6fd61cc7-9f32-5f5e-b371-bed650ce2c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551518b7-1b71-4fa6-8828-5ae08eab1887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551518b7-1b71-4fa6-8828-5ae08eab1887.jpg?1",
             "name": "Spellbound Dragon",
             "text": "Flying\nWhenever Spellbound Dragon attacks, draw a card, then discard a card. Spellbound Dragon gets +X/+0 until end of turn, where X is the discarded card's converted mana cost.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "bd9a7f82-541e-5a2d-9bb9-2617d52f6b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf60d69-fc68-4b23-a9e8-9d310c00a865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf60d69-fc68-4b23-a9e8-9d310c00a865.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "d48cbd22-7443-5b8d-bcd0-7d560958958b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb651c3a-cb27-4b73-8eb6-b87d65211097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb651c3a-cb27-4b73-8eb6-b87d65211097.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -3287,7 +3287,7 @@
         },
         {
             "id": "4c142e32-5aa8-56e0-9b7b-73d8a146fb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31a32e7-e709-4524-8752-ad0ec8c77fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31a32e7-e709-4524-8752-ad0ec8c77fde.jpg?1",
             "name": "Marrow Chomper",
             "text": "Devour 2 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with twice that many +1/+1 counters on it.)\nWhen Marrow Chomper comes into play, you gain 2 life for each creature it devoured.",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "4692c0b7-4f00-5511-b2a9-1a552fbc686c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ebc3a-e3b4-4dee-92ff-4a85556e0571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ebc3a-e3b4-4dee-92ff-4a85556e0571.jpg?1",
             "name": "Morbid Bloom",
             "text": "Remove target creature card in a graveyard from the game, then put X 1/1 green Saproling creature tokens into play, where X is the removed card's toughness.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "d5b7fefe-c5c4-556c-b3b7-41d87fee0647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa47568-5668-4a9f-ad1c-9a13010ffc2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa47568-5668-4a9f-ad1c-9a13010ffc2b.jpg?1",
             "name": "Putrid Leech",
             "text": "Pay 2 life: Putrid Leech gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "8e39ab08-7028-5a0a-9645-e0e64a1a5148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a85165-5aed-4e26-a314-1370d4638deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a85165-5aed-4e26-a314-1370d4638deb.jpg?1",
             "name": "Cerodon Yearling",
             "text": "Vigilance, haste",
             "colours": [
@@ -3431,7 +3431,7 @@
         },
         {
             "id": "b869023b-921c-5471-8489-4d2b2bbd85da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552ca9b-0245-4f91-9646-a5b5443863a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5552ca9b-0245-4f91-9646-a5b5443863a2.jpg?1",
             "name": "Fight to the Death",
             "text": "Destroy all blocking creatures and all blocked creatures.",
             "colours": [
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "6dc47332-8701-5274-ba71-4128466921a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6117bf5-4084-45bd-82aa-81cf6d9b7eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6117bf5-4084-45bd-82aa-81cf6d9b7eb4.jpg?1",
             "name": "Glory of Warfare",
             "text": "As long as it's your turn, creatures you control get +2/+0.\nAs long as it's not your turn, creatures you control get +0/+2.",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "5dbb5c0f-16f6-593a-91b3-56c1fb0799da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e4fb54-9f31-4d75-b4ab-7b11f745b807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e4fb54-9f31-4d75-b4ab-7b11f745b807.jpg?1",
             "name": "Intimidation Bolt",
             "text": "Intimidation Bolt deals 3 damage to target creature. Other creatures can't attack this turn.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "64b23a0b-b9d4-5240-b354-b985c66cf04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f413258e-2915-41e1-ba0d-98d9d0673ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f413258e-2915-41e1-ba0d-98d9d0673ab2.jpg?1",
             "name": "Stun Sniper",
             "text": "{1}, {T}: Stun Sniper deals 1 damage to target creature. Tap that creature.",
             "colours": [
@@ -3570,7 +3570,7 @@
         },
         {
             "id": "0ffeeb3e-a514-50b8-ae7c-6da6c12eb55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81c31c9-d7d7-4b45-893e-7e36d26c645f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81c31c9-d7d7-4b45-893e-7e36d26c645f.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, you may put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "9eb3fe8e-d37d-558f-b6df-848f36da110e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263f594-621e-46af-8561-f7eee565a19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263f594-621e-46af-8561-f7eee565a19a.jpg?1",
             "name": "Nulltread Gargantuan",
             "text": "When Nulltread Gargantuan comes into play, put a creature you control on top of its owner's library.",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "5ed9e023-d658-5506-8f98-e94a9af84812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a21af-cd1a-4438-a4c2-0c92ad92efef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a21af-cd1a-4438-a4c2-0c92ad92efef.jpg?1",
             "name": "Sages of the Anima",
             "text": "If you would draw a card, instead reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "378fa6e1-5590-5ecd-9cdc-82f493b1e30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab2ba75-e52e-46f5-8a34-3fe1e07446fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab2ba75-e52e-46f5-8a34-3fe1e07446fd.jpg?1",
             "name": "Vedalken Heretic",
             "text": "Whenever Vedalken Heretic deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -3716,7 +3716,7 @@
         },
         {
             "id": "80d91515-e7af-5572-8970-250e3f568e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23ae2b-9f69-4d8d-87f9-ebcbccd67342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23ae2b-9f69-4d8d-87f9-ebcbccd67342.jpg?1",
             "name": "Winged Coatl",
             "text": "Flash\nFlying\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "7a64b3ad-237d-5e93-9f8e-bbaea92bfd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe9da-4c82-4476-8e83-24297fe5c176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe9da-4c82-4476-8e83-24297fe5c176.jpg?1",
             "name": "Enigma Sphinx",
             "text": "Flying\nWhen Enigma Sphinx is put into your graveyard from play, put it into your library third from the top.\nCascade (When you play this spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -3791,7 +3791,7 @@
         },
         {
             "id": "ceedc6a5-a4e3-59c4-884d-d85076d8616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896d502a-d9c3-4101-92af-a8c9d945f47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896d502a-d9c3-4101-92af-a8c9d945f47b.jpg?1",
             "name": "Esper Sojourners",
             "text": "When you cycle Esper Sojourners or it's put into a graveyard from play, you may tap or untap target permanent.\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "525ae369-3389-593c-8125-01d32b560816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568785f1-47c7-4011-926f-44693f7e0233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568785f1-47c7-4011-926f-44693f7e0233.jpg?1",
             "name": "Etherwrought Page",
             "text": "At the beginning of your upkeep, choose one \u2014 You gain 2 life; or look at the top card of your library, then you may put that card into your graveyard; or each opponent loses 1 life.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "deddcbd4-7339-5831-98e3-bfa0af5a933e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418f8ecb-544b-430c-8ae9-61aaaf2dfba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418f8ecb-544b-430c-8ae9-61aaaf2dfba6.jpg?1",
             "name": "Sen Triplets",
             "text": "At the beginning of your upkeep, choose target opponent. This turn, that player can't play spells or activated abilities and plays with his or her hand revealed. You can play cards from that player's hand this turn.",
             "colours": [
@@ -3909,7 +3909,7 @@
         },
         {
             "id": "4a97bd0f-71a3-5d2f-91c6-786cea92ffd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c860cf0f-ef68-455f-9c71-a6dd25b51d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c860cf0f-ef68-455f-9c71-a6dd25b51d71.jpg?1",
             "name": "Sphinx of the Steel Wind",
             "text": "Flying, first strike, vigilance, lifelink, protection from red and from green",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "5ea81320-eb12-5452-baf0-b4314a884ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f430-d6a5-4380-95f2-9e0fc9e81597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f430-d6a5-4380-95f2-9e0fc9e81597.jpg?1",
             "name": "Drastic Revelation",
             "text": "Discard your hand. Draw seven cards, then discard three cards at random.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "66c99f1c-f0b9-5030-82c2-b4b887846fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde5f43-0b91-45c9-9382-20ea6328266f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde5f43-0b91-45c9-9382-20ea6328266f.jpg?1",
             "name": "Grixis Sojourners",
             "text": "When you cycle Grixis Sojourners or it's put into a graveyard from play, you may remove target card in a graveyard from the game.\nCycling {2}{B} ({2}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "93c79e90-353d-5aa8-a733-03b24bf1bd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1a69e5-d099-4b13-8072-f341430f31a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1a69e5-d099-4b13-8072-f341430f31a1.jpg?1",
             "name": "Thraximundar",
             "text": "Haste\nWhenever Thraximundar attacks, defending player sacrifices a creature.\nWhenever a player sacrifices a creature, you may put a +1/+1 counter on Thraximundar.",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "36180107-f73d-5491-9c78-4558000a4bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc647ef4-1f17-4b8b-a312-60d548347d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc647ef4-1f17-4b8b-a312-60d548347d12.jpg?1",
             "name": "Unscythe, Killer of Kings",
             "text": "Equipped creature gets +3/+3 and has first strike.\nWhenever a creature dealt damage by equipped creature this turn is put into a graveyard, you may remove that card from the game. If you do, put a 2/2 black Zombie creature token into play.\nEquip {2}",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "2db5c43b-db34-557c-9e75-6a1f0b3e1e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8fb53-000a-4a04-afdf-38f2cd052c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8fb53-000a-4a04-afdf-38f2cd052c72.jpg?1",
             "name": "Dragon Appeasement",
             "text": "Skip your draw step.\nWhenever you sacrifice a creature, you may draw a card.",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "3f56a477-a38e-5082-8d0b-a052ad270f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893c08b2-1391-4aaf-b79c-d1125b232f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893c08b2-1391-4aaf-b79c-d1125b232f73.jpg?1",
             "name": "Jund Sojourners",
             "text": "When you cycle Jund Sojourners or it's put into a graveyard from play, you may have it deal 1 damage to target creature or player.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "c8adb099-2652-5244-bc13-1a10a2ef3637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956a90f-e27b-4d5a-bc23-70e878b2dfeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956a90f-e27b-4d5a-bc23-70e878b2dfeb.jpg?1",
             "name": "Karrthus, Tyrant of Jund",
             "text": "Flying, haste\nWhen Karrthus, Tyrant of Jund comes into play, gain control of all Dragons, then untap all Dragons.\nOther Dragon creatures you control have haste.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "27d4105b-b02a-5e3a-9be6-1442e34f87ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749981d6-78e7-4f53-80a8-f211e61bd532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749981d6-78e7-4f53-80a8-f211e61bd532.jpg?1",
             "name": "Lavalanche",
             "text": "Lavalanche deals X damage to target player and each creature he or she controls.",
             "colours": [
@@ -4255,7 +4255,7 @@
         },
         {
             "id": "d610e906-2c57-51ea-8f76-5bdf87f9fd76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4fd58-2052-4f97-b634-f89e2139d980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4fd58-2052-4f97-b634-f89e2139d980.jpg?1",
             "name": "Madrush Cyclops",
             "text": "Creatures you control have haste.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "1448fcd6-401d-5ba4-a014-631a8a88041c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02e9e6-4cff-404a-94a3-e844ef7cadee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02e9e6-4cff-404a-94a3-e844ef7cadee.jpg?1",
             "name": "Gloryscale Viashino",
             "text": "Whenever you play a multicolored spell, Gloryscale Viashino gets +3/+3 until end of turn.",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "14b2300a-b015-54d4-8cb1-e5d5f649b7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6f5dc-2fa6-450a-a1b1-6b6e31773365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6f5dc-2fa6-450a-a1b1-6b6e31773365.jpg?1",
             "name": "Mayael's Aria",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "ddb0a229-2d2d-59a6-8c4f-7bbc6de86dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2de336-8c61-45b1-affd-6322530b91ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2de336-8c61-45b1-affd-6322530b91ca.jpg?1",
             "name": "Naya Sojourners",
             "text": "When you cycle Naya Sojourners or it's put into a graveyard from play, you may put a +1/+1 counter on target creature.\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "c26fa6c5-81da-599e-802c-1f42a5028828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289adeb9-952d-437e-aa66-358a780dc083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289adeb9-952d-437e-aa66-358a780dc083.jpg?1",
             "name": "Retaliator Griffin",
             "text": "Flying\nWhenever a source an opponent controls deals damage to you, you may put that many +1/+1 counters on Retaliator Griffin.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "6a4ace05-7105-5d5b-a561-805d371ff386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e22185-47d0-465b-8181-afe194af5cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e22185-47d0-465b-8181-afe194af5cac.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "Uril, the Miststalker can't be the target of spells or abilities your opponents control.\nUril gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "da070dce-a395-5be1-b389-8a32982ae5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff007af-0329-4872-8621-41e90d9f06e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff007af-0329-4872-8621-41e90d9f06e6.jpg?1",
             "name": "Bant Sojourners",
             "text": "When you cycle Bant Sojourners or it's put into a graveyard from play, you may put a 1/1 white Soldier creature token into play.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "578bd4d0-112d-5b3c-864e-df296a83e461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bb726e-e561-4a14-913d-afde1964c64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bb726e-e561-4a14-913d-afde1964c64a.jpg?1",
             "name": "Finest Hour",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, if it's the first combat phase of the turn, untap that creature. After this phase, there is an additional combat phase.",
             "colours": [
@@ -4561,7 +4561,7 @@
         },
         {
             "id": "4db28cdf-f2be-5316-ab34-dcbaf335d3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbabaf1d-0220-438d-8263-e23d8010fe24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbabaf1d-0220-438d-8263-e23d8010fe24.jpg?1",
             "name": "Flurry of Wings",
             "text": "Put X 1/1 white Bird Soldier creature tokens with flying into play, where X is the number of attacking creatures.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "2b09d1ec-4ba1-5765-81de-17d134724c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d643c335-e3a7-461d-a024-095795ab6770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d643c335-e3a7-461d-a024-095795ab6770.jpg?1",
             "name": "Jenara, Asura of War",
             "text": "Flying\n{1}{W}: Put a +1/+1 counter on Jenara, Asura of War.",
             "colours": [
@@ -4637,7 +4637,7 @@
         },
         {
             "id": "fd8b252a-4f41-5abd-bc56-503c4ada4204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4fe11d-c404-489a-b17f-34f33b1597e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4fe11d-c404-489a-b17f-34f33b1597e8.jpg?1",
             "name": "Wargate",
             "text": "Search your library for a permanent card with converted mana cost X or less, put it into play, then shuffle your library.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "ea6a6ffb-d7e6-546b-8c29-2a404153bdc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b3c5b-de65-46b2-b26d-347cc31beb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425b3c5b-de65-46b2-b26d-347cc31beb4c.jpg?1",
             "name": "Maelstrom Nexus",
             "text": "The first spell you play each turn has cascade. (When you play your first spell, remove cards from the top of your library from the game until you remove a nonland card that costs less. You may play it without paying its mana cost. Put the removed cards on the bottom in a random order.)",
             "colours": [
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "8994c60a-d4da-5fd5-9f73-6a3daa76497f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c72f4-fbce-41c5-a46f-bfe4d1833965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63c72f4-fbce-41c5-a46f-bfe4d1833965.jpg?1",
             "name": "Arsenal Thresher",
             "text": "As Arsenal Thresher comes into play, you may reveal any number of other artifact cards from your hand. Arsenal Thresher comes into play with a +1/+1 counter on it for each card revealed this way.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "1bd70fc8-5715-54de-9e7f-bf0c663bf609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ac6f0-fdec-4e2c-86c6-02d36c7bbaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ac6f0-fdec-4e2c-86c6-02d36c7bbaf5.jpg?1",
             "name": "Esper Stormblade",
             "text": "As long as you control another multicolored permanent, Esper Stormblade gets +1/+1 and has flying.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "fed9edac-7a75-5a91-9781-9dd8331f9aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8d797-b01d-49cf-9818-d84bba17029d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8d797-b01d-49cf-9818-d84bba17029d.jpg?1",
             "name": "Thopter Foundry",
             "text": "{1}, Sacrifice a nontoken artifact: Put a 1/1 blue Thopter artifact creature token with flying into play. You gain 1 life.",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "be3e4139-85d8-5802-9f1e-ad06ccb8b910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbcb812-15ad-4878-9968-cfa65a352703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbcb812-15ad-4878-9968-cfa65a352703.jpg?1",
             "name": "Grixis Grimblade",
             "text": "As long as you control another multicolored permanent, Grixis Grimblade gets +1/+1 and has deathtouch. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "e0d7cb90-c354-5aca-8762-dd9c36c6e227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf97c08-e074-4353-b9fa-c79793622585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf97c08-e074-4353-b9fa-c79793622585.jpg?1",
             "name": "Sewn-Eye Drake",
             "text": "Flying, haste",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "33fa641c-4195-5c55-a317-8a38ad060edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc177ec-dcd5-409d-a278-d84c3e6d28fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc177ec-dcd5-409d-a278-d84c3e6d28fa.jpg?1",
             "name": "Slave of Bolas",
             "text": "Gain control of target creature. Untap that creature. It gains haste until end of turn. Sacrifice it at end of turn.",
             "colours": [
@@ -4942,7 +4942,7 @@
         },
         {
             "id": "1958a923-a7a4-541a-b3d0-fe090d292175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6782d0-5399-4853-ae6f-0d05372dbf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6782d0-5399-4853-ae6f-0d05372dbf34.jpg?1",
             "name": "Giant Ambush Beetle",
             "text": "Haste\nWhen Giant Ambush Beetle comes into play, you may have target creature block it this turn if able.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "cef53ce6-83cc-5445-90fc-46f835baf27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e3b73a-598b-4854-b811-2fd40fbce2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e3b73a-598b-4854-b811-2fd40fbce2d0.jpg?1",
             "name": "Jund Hackblade",
             "text": "As long as you control another multicolored permanent, Jund Hackblade gets +1/+1 and has haste.",
             "colours": [
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "9e09d571-eb38-5e44-b23d-46d817ea63be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56b15e-d02d-4306-82a6-ced778fee90f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56b15e-d02d-4306-82a6-ced778fee90f.jpg?1",
             "name": "Sangrite Backlash",
             "text": "Enchant creature\nEnchanted creature gets +3/-3.",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "9e5ea807-8675-5511-9206-b46af6a2741c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadf8cc5-ea30-46b6-99b4-e6f19eb46306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadf8cc5-ea30-46b6-99b4-e6f19eb46306.jpg?1",
             "name": "Marisi's Twinclaws",
             "text": "Double strike",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "e088c95d-7a75-5ffe-985f-58a936e4f4e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eed1b7f-0672-4066-9e21-c5252f6dc482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eed1b7f-0672-4066-9e21-c5252f6dc482.jpg?1",
             "name": "Naya Hushblade",
             "text": "As long as you control another multicolored permanent, Naya Hushblade gets +1/+1 and has shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "468da9c7-a72f-5fdc-8aa8-df6edc9e3b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151001a-cf4b-4f95-a986-7181313e2224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151001a-cf4b-4f95-a986-7181313e2224.jpg?1",
             "name": "Trace of Abundance",
             "text": "Enchant land\nEnchanted land has shroud. (It can't be the target of spells or abilities.)\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "442c0494-c204-52c2-ba85-340b7cc7ba0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162feb2b-e641-4338-bcf1-1f7e7a11bb9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162feb2b-e641-4338-bcf1-1f7e7a11bb9d.jpg?1",
             "name": "Bant Sureblade",
             "text": "As long as you control another multicolored permanent, Bant Sureblade gets +1/+1 and has first strike.",
             "colours": [
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "d1db0102-f0db-55b0-a976-11e09b8af829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e1b-bd37-43a7-abd3-4582315a268d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e1b-bd37-43a7-abd3-4582315a268d.jpg?1",
             "name": "Crystallization",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen enchanted creature becomes the target of a spell or ability, remove that creature from the game.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "3d070d03-d43e-596d-a08a-e6dd793956c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f088f625-9c72-4949-8e53-c2313397a197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f088f625-9c72-4949-8e53-c2313397a197.jpg?1",
             "name": "Messenger Falcons",
             "text": "Flying\nWhen Messenger Falcons comes into play, draw a card.",
             "colours": [
@@ -5288,7 +5288,7 @@
         },
         {
             "id": "ba9ae285-6acc-5b86-b278-e08a9343f03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b55dcf-ae63-4b84-8d39-80b5a6de3c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b55dcf-ae63-4b84-8d39-80b5a6de3c1a.jpg?1",
             "name": "Bird Soldier",
             "text": "",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "f0c20d71-8d21-5252-abbe-0e52f758a157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83790fd3-f371-494c-97a2-3aa469a399f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83790fd3-f371-494c-97a2-3aa469a399f1.jpg?1",
             "name": "Lizard",
             "text": "",
             "colours": [
@@ -5357,7 +5357,7 @@
         },
         {
             "id": "ad66a158-b3c3-5194-98b2-a8b263cc9d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb628da-a02f-4d3e-b919-0c03821dd5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb628da-a02f-4d3e-b919-0c03821dd5f2.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "80cadb0d-9c14-5cfa-a90f-76310cc9e4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde17901-35fb-4045-8ba5-deab046cd44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde17901-35fb-4045-8ba5-deab046cd44f.jpg?1",
             "name": "Zombie Wizard",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/ARN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ARN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3dd0bd56-5340-5542-8457-646b9acd58ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9ad288-d164-44a6-96ec-4185a1587f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9ad288-d164-44a6-96ec-4185a1587f1a.jpg?1",
             "name": "Abu Ja'far",
             "text": "If Abu dies without regenerating while participating in an attack or defense,all creatures Abu is blocking or being blocked by are also killed and may not regenerate.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "ab071a55-aec9-5b7c-8f8e-133f1f902152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d170015-b125-49a6-a15e-8fd116bbcb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d170015-b125-49a6-a15e-8fd116bbcb14.jpg?1",
             "name": "Army of Allah",
             "text": "All attacking creatures gain +2/+0 until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "7a5ab36e-15b0-51d1-87c0-b4b3a5cd93a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9899352a-a4c9-47bf-b9cb-0c34060ae1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9899352a-a4c9-47bf-b9cb-0c34060ae1c4.jpg?1",
             "name": "Army of Allah",
             "text": "All attacking creatures gain +2/+0 until end of turn.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "e452b3bc-4618-538f-80a1-403b65eed48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0078aa8-bfb8-43b0-a6b7-1991596c21e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0078aa8-bfb8-43b0-a6b7-1991596c21e1.jpg?1",
             "name": "Camel",
             "text": "Bands\nAll creatures attacking in a band with Camel are immune to damage done by Deserts.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "5bac4ab4-6e72-5240-9cb8-a5fd3bc55ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933ca2a-097b-44f4-ae56-ad524d26fd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933ca2a-097b-44f4-ae56-ad524d26fd06.jpg?1",
             "name": "Eye for an Eye",
             "text": "Can be cast only when a creature or spell does damage to you. Eye for an Eye does an equal amount of damage to the controller of that creature or spell. If some spell or effect reduces the amount of damage you receive, it does not reduce the damage dealt by Eye for an Eye.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "911ef63f-9f56-55b5-bc10-f95a68245a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c7705a-2987-4ef1-92b1-2c55d989ec6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c7705a-2987-4ef1-92b1-2c55d989ec6f.jpg?1",
             "name": "Jihad",
             "text": "Choose a color. As long as opponent has cards of this color in play, all white creatures gain +2/+1. Jihad must be discarded immediately if at any time opponent has no cards of this color in play.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "14c38b2a-106d-5e58-82ab-34669ca24741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3dce0f-2168-4f63-b2f9-156a11beeea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3dce0f-2168-4f63-b2f9-156a11beeea7.jpg?1",
             "name": "King Suleiman",
             "text": "Tap to destroy an Efreet or Djinn.",
             "colours": [
@@ -232,7 +232,7 @@
         },
         {
             "id": "3f2c1f58-94af-54c1-8b29-7f2fd879e4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f0781-7614-4779-a58d-f13ce96bdf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f0781-7614-4779-a58d-f13ce96bdf33.jpg?1",
             "name": "Moorish Cavalry",
             "text": "Trample",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "3e40ff4f-332a-54c5-a1a0-7a342906e706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113a6b31-3748-48c1-a915-ab0b613eabb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113a6b31-3748-48c1-a915-ab0b613eabb3.jpg?1",
             "name": "Moorish Cavalry",
             "text": "Trample",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "d81c7077-759e-5442-99a9-23606c4ff053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649c571-d7ec-4ebc-9e18-b0657cab495b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649c571-d7ec-4ebc-9e18-b0657cab495b.jpg?1",
             "name": "Piety",
             "text": "All defending creatures gain +0/+3 until end of turn.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "6b868997-8c1d-5064-9ac5-8d7c7dbb1f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a1a13-dfc8-49b7-9b17-3f0c5ca1b8be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a1a13-dfc8-49b7-9b17-3f0c5ca1b8be.jpg?1",
             "name": "Piety",
             "text": "All defending creatures gain +0/+3 until end of turn.",
             "colours": [
@@ -370,7 +370,7 @@
         },
         {
             "id": "fadb8147-0294-52c1-8f3b-5866c2dd846d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc30b6-1355-425b-a86f-18f59f83141c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc30b6-1355-425b-a86f-18f59f83141c.jpg?1",
             "name": "Repentant Blacksmith",
             "text": "Protection from red",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "e730794a-1d40-5f1b-ae09-0f6f5981de85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1",
             "name": "Shahrazad",
             "text": "Players must leave game in progress as it is and use the cards left in their libraries as decks with which to play a subgame of Magic. When subgame is over, players shuffle these cards, return them to libraries, and resume game in progress, with any loser of subgame halving his or her remaining life points, rounding down. Effects that prevent damage may not be used to counter this loss of life. The subgame has no ante; using less than forty cards may be necessary.",
             "colours": [
@@ -434,7 +434,7 @@
         },
         {
             "id": "6f1e6bbc-3493-523c-946d-c228c41cfed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c366-95cc-4799-b6c6-34d8fad8c202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c366-95cc-4799-b6c6-34d8fad8c202.jpg?1",
             "name": "War Elephant",
             "text": "Trample, bands",
             "colours": [
@@ -469,7 +469,7 @@
         },
         {
             "id": "22d06541-1812-5b49-8d64-98e79286f45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87344d-9113-4fec-9a93-38bc1abe2af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87344d-9113-4fec-9a93-38bc1abe2af5.jpg?1",
             "name": "War Elephant",
             "text": "Trample, bands",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "adb34839-4a26-5be9-a584-2a0b3557cd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414d3cae-b8cf-4d53-bd6b-1aa83a828ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414d3cae-b8cf-4d53-bd6b-1aa83a828ba9.jpg?1",
             "name": "Dand\u00e2n",
             "text": "Dand\u00e2n cannot attack unless opponent has islands in play. Dand\u00e2n is destroyed immediately if at any time you have no islands in play.",
             "colours": [
@@ -537,7 +537,7 @@
         },
         {
             "id": "d3fa5b26-f3a6-5c51-8d50-289238027741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb6ed87-aa07-4b5e-ac40-1e16dc2a817a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb6ed87-aa07-4b5e-ac40-1e16dc2a817a.jpg?1",
             "name": "Fishliver Oil",
             "text": "Target creature gains islandwalk ability.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "313c0e3b-f824-5e66-a5f3-e8122fcf9d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c066c452-1d87-4946-8d3b-6cc160a82282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c066c452-1d87-4946-8d3b-6cc160a82282.jpg?1",
             "name": "Fishliver Oil",
             "text": "Target creature gains islandwalk ability.",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "46656b4e-38a5-573e-97ea-ee947398ca7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ab9a2b-e248-4ae2-aac3-b49fdb3e260a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ab9a2b-e248-4ae2-aac3-b49fdb3e260a.jpg?1",
             "name": "Flying Men",
             "text": "Flying",
             "colours": [
@@ -640,7 +640,7 @@
         },
         {
             "id": "8d6993cf-f4d3-54b8-8a21-7f5ca5845b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096f7ac8-c639-4347-9767-7305eaf490ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096f7ac8-c639-4347-9767-7305eaf490ba.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gains +0/+3 while untapped.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "c8784a69-7358-5e22-8f37-584d42ad75d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170fa026-c17b-4731-b520-455c39ccbe6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170fa026-c17b-4731-b520-455c39ccbe6d.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gains +0/+3 while untapped.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "5463c1fa-1357-5e07-931a-e7eb6779f267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8537cb0f-4821-417b-80cc-ea57d51ee9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8537cb0f-4821-417b-80cc-ea57d51ee9b8.jpg?1",
             "name": "Island Fish Jasconius",
             "text": "You must pay o\nUo\nUo\nU during your untap phase to untap Island Fish. Island Fish cannot attack unless opponent has islands in play. Island Fish is destroyed immediately if at any time you have no islands in play.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "911cf5ad-d656-5c73-8020-3eb9857d09c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b827094-fb2c-46db-b898-02e0c308601f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b827094-fb2c-46db-b898-02e0c308601f.jpg?1",
             "name": "Merchant Ship",
             "text": "If Merchant Ship attacks and is not blocked, you gain 2 life. Merchant Ship cannot attack unless opponent has islands in play. Merchant Ship is destroyed immediately if at any time you have no islands in play.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "2a5daf35-e227-51e4-8144-5c466ba107ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10f8a05-78b0-42a7-adcd-83f6bafe5417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10f8a05-78b0-42a7-adcd-83f6bafe5417.jpg?1",
             "name": "Old Man of the Sea",
             "text": "Tap to gain control of a creature with power no greater than Old Man's power. If Old Man becomes untapped, you lose control of this creature; you may choose not to untap Old Man as normal. You also lose control of the creature if Old Man dies or if the creature's power becomes greater than Old Man's.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "3af4abdc-fc31-5e2f-b86a-a40a7e71afb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0458b733-d689-4cb5-8970-3b675c67fc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0458b733-d689-4cb5-8970-3b675c67fc4d.jpg?1",
             "name": "Serendib Djinn",
             "text": "Flying\nDuring your upkeep, you must choose one of your own lands and destroy it. If you destroy an island in this manner, Serendib Djinn does 3 damage to you. Serendib Djinn is destroyed immediately if at any time you have no land in play.",
             "colours": [
@@ -842,7 +842,7 @@
         },
         {
             "id": "cfe0c113-a1b7-5314-b984-ed92b2c24994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf56e862-3169-4f63-acd0-731080fa32f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf56e862-3169-4f63-acd0-731080fa32f2.jpg?1",
             "name": "Serendib Efreet",
             "text": "Flying\nSerendib Efreet does 1 damage to you during your upkeep.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "681fc62c-b87a-54cd-a0b4-69971e0fab39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b112a10-ac40-4353-bbdd-e5efd4546330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b112a10-ac40-4353-bbdd-e5efd4546330.jpg?1",
             "name": "Sindbad",
             "text": "Tap to draw a card from your library, but discard that card if it is not a land.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "93382e50-2240-5a3b-93cc-0761dd4e4e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79e9236-a39e-471a-b18a-2c2ba16e7774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79e9236-a39e-471a-b18a-2c2ba16e7774.jpg?1",
             "name": "Unstable Mutation",
             "text": "Target creature gains +3/+3. Each round, put a -1/-1 counter on the creature during its controller's upkeep. These counters remain even if this enchantment is removed before the creature dies.",
             "colours": [
@@ -941,7 +941,7 @@
         },
         {
             "id": "304c2a53-39cb-5c1c-b9fa-45dc5af82e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7995c3f9-a147-43c9-9f82-470924818a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7995c3f9-a147-43c9-9f82-470924818a4c.jpg?1",
             "name": "Cuombajj Witches",
             "text": "Tap to do 1 damage to any target; opponent may also do 1 damage to any target. You choose your target before opponent does, but damage is inflicted simultaneously.",
             "colours": [
@@ -975,7 +975,7 @@
         },
         {
             "id": "85941dd6-d6ff-59cb-8fc9-bc194f745bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b610d3-2005-4347-bcda-c30b5b7972e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b610d3-2005-4347-bcda-c30b5b7972e5.jpg?1",
             "name": "El-Hajj\u00e2j",
             "text": "You gain 1 life for every point of damage El-Hajj\u00e2j inflicts.",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "0924b359-5336-5655-8f5c-40ff1ec9d0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c73a97-531d-4dd5-8236-39b89c183c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c73a97-531d-4dd5-8236-39b89c183c38.jpg?1",
             "name": "Erg Raiders",
             "text": "If you do not attack with Raiders, they do 2 damage to you at end of turn. Raiders do no damage to you during the turn in which they are summoned.",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "ecc4ff59-82ba-50f2-ac8f-18d74af2e503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2717b2e2-bea8-4ba8-9ad1-abb60abf6e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2717b2e2-bea8-4ba8-9ad1-abb60abf6e4c.jpg?1",
             "name": "Erg Raiders",
             "text": "If you do not attack with Raiders, they do 2 damage to you at end of turn. Raiders do no damage to you during the turn in which they are summoned.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "451f9c5d-455a-57da-994b-e94ceef4ee06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9941f83b-2903-4eab-ac6d-5313e3978fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9941f83b-2903-4eab-ac6d-5313e3978fa3.jpg?1",
             "name": "Guardian Beast",
             "text": "As long as Guardian Beast is untapped, your non-creature artifacts cannot be further enchanted, destroyed, or taken under someone else's control. If something occurs that would destroy the Guardian Beast and artifacts simultaneously, the Guardian Beast is destroyed but your artifacts are not. If an artifact is enchanted or stolen while Guardian Beast is tapped, it remains so when Guardian Beast becomes untapped.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "e507abdf-7351-5061-92d7-e6d13d899845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f310cf5-0985-4826-9779-19a713089d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f310cf5-0985-4826-9779-19a713089d6d.jpg?1",
             "name": "Hasran Ogress",
             "text": "Unless you pay o2 each time Hasran Ogress\nattacks, Hasran Ogress does 3 damage to you.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "a36afedf-54d1-5bcd-9a6f-cfc3eea08966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fcc83f-c67f-46a2-bb0e-dafbf0a2bfc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fcc83f-c67f-46a2-bb0e-dafbf0a2bfc0.jpg?1",
             "name": "Hasran Ogress",
             "text": "Unless you pay o2 each time Hasran Ogress\nattacks, Hasran Ogress does 3 damage to you.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "39ade5ff-a12f-5fc2-abd5-8b31e5de33ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46783a-b91e-4829-a173-5515b09ca615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f46783a-b91e-4829-a173-5515b09ca615.jpg?1",
             "name": "Jun\u00fan Efreet",
             "text": "Flying\nYou must pay o\nBo\nB during your upkeep or Jun\u00fan Efreet is destroyed and may not regenerate.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "b9c5eb58-53a7-5ace-8110-59a3637e7f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bf3f14-b5df-498b-a1bb-965885c82401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bf3f14-b5df-498b-a1bb-965885c82401.jpg?1",
             "name": "Juz\u00e1m Djinn",
             "text": "Juz\u00e1m Djinn does 1 damage to you during your upkeep.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "f386d40e-bb91-52c7-9019-93f876ecd5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18607bf6-ce11-41cb-b001-0c9538406ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18607bf6-ce11-41cb-b001-0c9538406ba0.jpg?1",
             "name": "Khab\u00e1l Ghoul",
             "text": "At the end of each turn, put a +1/+1 counter on Khab\u00e1l Ghoul for each other creature that died during the turn and was not regenerated.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "184eabef-2042-5e2d-a2b3-96921e251de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1450f-2909-410e-9920-731278fa74de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1450f-2909-410e-9920-731278fa74de.jpg?1",
             "name": "Oubliette",
             "text": "Select a creature in play when Oubliette is cast. That creature is considered out of play as long as Oubliette is in play. Hence the creature cannot be the target of spells and cannot receive damage, use special powers, attack, or defend. All counters and enchantments on the creature remain but are also out of play. If Oubliette is removed, creature returns to play tapped.",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "a9464941-0d21-5d3f-a797-0202e6ae9fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d74d1d-3f68-4cab-903e-e146a33258f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d74d1d-3f68-4cab-903e-e146a33258f3.jpg?1",
             "name": "Oubliette",
             "text": "Select a creature in play when Oubliette is cast. That creature is considered out of play as long as Oubliette is in play. Hence the creature cannot be the target of spells and cannot receive damage, use special powers, attack, or defend. All counters and enchantments on the creature remain but are also out of play. If Oubliette is removed, creature returns to play tapped.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "95734514-50f1-580b-9079-837f933ddbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94742003-f0f1-4483-b1a0-e7163995db1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94742003-f0f1-4483-b1a0-e7163995db1b.jpg?1",
             "name": "Sorceress Queen",
             "text": "Tap to make another creature 0/2 until end of turn. Treat this exactly as if the numbers in the lower right of the target card were 0/2. All special characteristics and enchantments on the creature are unaffected.",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "3979048d-1b6b-56d5-b1b5-d3b601d2a1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c387dd-1347-4443-91ce-b71f7ccdceba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c387dd-1347-4443-91ce-b71f7ccdceba.jpg?1",
             "name": "Stone-Throwing Devils",
             "text": "First strike",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "14f305bb-b59e-524d-ad10-c189334727bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0b28ac-144e-43c5-84f3-d4a2a229f49b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0b28ac-144e-43c5-84f3-d4a2a229f49b.jpg?1",
             "name": "Stone-Throwing Devils",
             "text": "First strike",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "cf727891-b246-533c-8bfa-410247ccb352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db52bad2-a3ec-4f6f-9418-12e8c40703f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db52bad2-a3ec-4f6f-9418-12e8c40703f6.jpg?1",
             "name": "Aladdin",
             "text": "o1o\nRo\nR and tap to take control of an artifact from opponent. Artifact is returned when Aladdin is removed from play or when game ends.",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "f1c3f7ed-329c-524f-9c5a-ea3cf1ef40a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7064-3703-43e0-8702-d1ba13703fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7064-3703-43e0-8702-d1ba13703fd8.jpg?1",
             "name": "Ali Baba",
             "text": "oo\nR Tap a wall.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "a2daba07-3fb1-5526-8896-e49d97b9f404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42027613-d261-4ce2-8ba1-7a2480c660f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42027613-d261-4ce2-8ba1-7a2480c660f8.jpg?1",
             "name": "Ali from Cairo",
             "text": "While Ali is in play, damage that would reduce you to less than 1 life lowers you to 1 life. All further damage is prevented.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "59936d4a-cad3-5df6-b7d9-9dd2998d0a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba0b9-db01-447f-90cc-a2fc2c24146e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba0b9-db01-447f-90cc-a2fc2c24146e.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "78493c6a-deff-5c94-a7a6-a3924bad0212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709532d8-cd3e-4844-b580-e6925ce837ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709532d8-cd3e-4844-b580-e6925ce837ff.jpg?1",
             "name": "Bird Maiden",
             "text": "Flying",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "c8754dc9-a9be-5a36-be01-1548c7a9b269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d0c10-ec09-48ba-9e93-1392dca8111a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d0c10-ec09-48ba-9e93-1392dca8111a.jpg?1",
             "name": "Desert Nomads",
             "text": "Desertwalk\nDesert Nomads are immune to damage done by Deserts.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "580c9965-81cc-5651-b5f4-371124c6f813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4aadda8-8577-480d-8186-532d2b173c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4aadda8-8577-480d-8186-532d2b173c15.jpg?1",
             "name": "Hurr Jackal",
             "text": "Tap to prevent a target creature from regenerating for the remainder of the turn.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "c712ec7b-f4aa-507c-85b5-b666f35c6fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe8845e-df1c-481c-949c-aab84af99a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe8845e-df1c-481c-949c-aab84af99a05.jpg?1",
             "name": "Kird Ape",
             "text": "Kird Ape gains +1/+2 if you have any forests in play.",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "ee8575a8-5f9f-5ad3-9009-de194816dc56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95fde48b-e40a-4183-b324-1ec276dde015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95fde48b-e40a-4183-b324-1ec276dde015.jpg?1",
             "name": "Magnetic Mountain",
             "text": "Blue creatures do not untap as normal. During their untap phases, players must spend o4 for each blue creature they wish to untap. This cost must be paid in addition to any other untap cost a given blue creature may already require.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "7231c384-3377-5826-9173-1585b2b61e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ddbe51-cd1a-4b2c-849a-7c82d622122a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ddbe51-cd1a-4b2c-849a-7c82d622122a.jpg?1",
             "name": "Mijae Djinn",
             "text": "If you choose to attack with Mijae Djinn, flip a coin immediately after attack is announced; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Mijae Djinn is tapped but does not attack.",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "6c80baa9-109a-50e1-8f3c-aebee456ef27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28f9e63-e5e4-44b5-a17e-8301ff17c623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28f9e63-e5e4-44b5-a17e-8301ff17c623.jpg?1",
             "name": "Rukh Egg",
             "text": "If Rukh Egg goes to the graveyard, a Rukh\u2014a 4/4 red flying creature\u2014comes into play on your side at the end of that turn. Use a counter to represent Rukh. Rukh is treated exactly like a normal creature except that if it leaves play it is removed from the game entirely.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "6e806a18-e9eb-5f58-aff0-d847c85889ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4defc2-b1a2-4ae2-bda0-24ecd4ff8181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4defc2-b1a2-4ae2-bda0-24ecd4ff8181.jpg?1",
             "name": "Rukh Egg",
             "text": "If Rukh Egg goes to the graveyard, a Rukh\u2014a 4/4 red flying creature\u2014comes into play on your side at the end of that turn. Use a counter to represent Rukh. Rukh is treated exactly like a normal creature except that if it leaves play it is removed from the game entirely.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "43be57eb-8bb1-5cdb-a80f-a38fb2e740e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdba2a9-d171-45ed-8dd4-9d0046128f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdba2a9-d171-45ed-8dd4-9d0046128f68.jpg?1",
             "name": "Ydwen Efreet",
             "text": "If you choose to block with Ydwen Efreet, flip a coin immediately after defense is announced; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, Ydwen Efreet cannot block this turn.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "b9f4fd87-fdf7-5b6c-8db5-829d4d348b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11684d6-5b74-47a7-a2d0-256c9e437aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11684d6-5b74-47a7-a2d0-256c9e437aa6.jpg?1",
             "name": "Cyclone",
             "text": "Put one chip on Cyclone each round during your upkeep, then pay o\nG for each chip or discard Cyclone. If not discarded, Cyclone immediately does 1 damage per chip to each player and each creature in play.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "54398c43-042c-5add-822a-b18b0d854d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d77c149-cca2-45c7-bc83-5ba1872ad5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d77c149-cca2-45c7-bc83-5ba1872ad5e0.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy any card in play.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "d046eec4-3167-5074-974f-4110f7329097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e090d4-e7fe-403c-9aca-05c1b45ed238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e090d4-e7fe-403c-9aca-05c1b45ed238.jpg?1",
             "name": "Drop of Honey",
             "text": "During your upkeep, the creature in play with the lowest power is destroyed and cannot be regenerated. If there is a tie you choose which to destroy. Drop of Honey must be discarded if there are no creatures in play.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "c36fd58a-cce8-528c-8a16-88b34360071d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bc0c3f-0a52-4bdc-83da-6484bf3102f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bc0c3f-0a52-4bdc-83da-6484bf3102f3.jpg?1",
             "name": "Erhnam Djinn",
             "text": "During your upkeep, you must choose one of opponent's non-wall creatures in play. Until your next upkeep, that creature gains the forestwalk ability. If opponent has no creatures, ignore this effect.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "1c7bc984-4bdd-5f3a-9966-0bd28f8bcbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d613d5-36a2-4633-b5af-64511bb29cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d613d5-36a2-4633-b5af-64511bb29cc2.jpg?1",
             "name": "Ghazb\u00e1n Ogre",
             "text": "During its current controller's upkeep, the player with the highest life total takes control of Ghazb\u00e1n Ogre.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "0086e71c-3c89-519b-976c-b721515b112b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b10fb7-8667-42bf-aeb6-35767a82917b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b10fb7-8667-42bf-aeb6-35767a82917b.jpg?1",
             "name": "Ifh-B\u00edff Efreet",
             "text": "Flying\nWhile Ifh-B\u00edff Efreet is in play, any player can pay o\nG to have Ifh-B\u00edff Efreet do 1 damage to each player and each flying creature in play. This ability does not tap the Ifh-B\u00edff Efreet, and can be used as soon as it is successfully summoned.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "8352dcb3-1f22-50c7-ad90-730a33545344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc6cfc3-b232-40bf-bc0c-4618f6f5c9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc6cfc3-b232-40bf-bc0c-4618f6f5c9a5.jpg?1",
             "name": "Metamorphosis",
             "text": "Sacrifice a creature of yours in play for an amount of mana equal to its casting cost plus 1. This mana can be of any one color, and can only be used to summon creatures.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "b76531a6-b2f0-5d2f-a9fc-b86a18423c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965f722c-2b18-4c22-8c30-12552def5940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965f722c-2b18-4c22-8c30-12552def5940.jpg?1",
             "name": "Nafs Asp",
             "text": "If Asp inflicts any damage on your opponent, your opponent must spend o1 before the draw phase of his or her next turn or lose an additional 1 life.",
             "colours": [
@@ -2153,7 +2153,7 @@
         },
         {
             "id": "aa392433-d212-5011-9575-09d62b0167fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecc8d7c-c64f-4ada-b389-756728401b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecc8d7c-c64f-4ada-b389-756728401b64.jpg?1",
             "name": "Nafs Asp",
             "text": "If Asp inflicts any damage on your opponent, your opponent must spend o1 before the draw phase of his or her next turn or lose an additional 1 life.",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "3646247d-762b-5205-85ea-43fc33d49543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cba9cd-73d9-442e-bd99-9cba9f398b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cba9cd-73d9-442e-bd99-9cba9f398b64.jpg?1",
             "name": "Sandstorm",
             "text": "All attacking creatures suffer 1 damage.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "21173f54-3bf7-5212-b71f-8125583ef0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3003bf1e-8085-45d8-882b-c449109e7631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3003bf1e-8085-45d8-882b-c449109e7631.jpg?1",
             "name": "Singing Tree",
             "text": "Tap to reduce an attacking creature's power to 0.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "b179db24-7a93-5c35-b3a8-e42cd11d9051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ccebe1-ef08-4805-a65f-a1c57abed9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ccebe1-ef08-4805-a65f-a1c57abed9f2.jpg?1",
             "name": "Wyluli Wolf",
             "text": "Tap to give any creature in play +1/+1 until end of turn.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "d429117f-4b10-5e66-ad2f-e233252a034a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc1188c-4331-41dc-a577-bd4bedd7ca76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc1188c-4331-41dc-a577-bd4bedd7ca76.jpg?1",
             "name": "Wyluli Wolf",
             "text": "Tap to give any creature in play +1/+1 until end of turn.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "2b337664-eea0-5df5-976c-4ae0b93156bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fecc5d2-5298-4d47-b085-f160603f220e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fecc5d2-5298-4d47-b085-f160603f220e.jpg?1",
             "name": "Aladdin's Lamp",
             "text": "oo\nX Instead of drawing a card from the top of your library, draw X cards but choose only one to put in your hand. You must shuffle the leftover cards and put them at the bottom of your library.",
             "colours": [],
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "6e6b0872-4d06-55de-acca-bf3d3d25581e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2b74a2-cb74-4b54-b9c6-78c63f14cf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2b74a2-cb74-4b54-b9c6-78c63f14cf5b.jpg?1",
             "name": "Aladdin's Ring",
             "text": "o8: Do 4 damage to any target.",
             "colours": [],
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "680b0beb-bf12-54ca-808e-142a45f06982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474cd6b-5610-49eb-ac98-918d900efe8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474cd6b-5610-49eb-ac98-918d900efe8b.jpg?1",
             "name": "Bottle of Suleiman",
             "text": "o4: Flip a coin, with opponent calling heads or tails while coin is in the air. If the flip ends up in opponent's favor, Bottle of Suleiman does 5 damage to you. Otherwise, a 5/5 flying Djinn immediately comes into play on your side. Use a counter to represent Djinn. Djinn is treated exactly like a normal artifact creature except that if it leaves play it is removed from the game entirely. No matter how the flip turns out, Bottle of Suleiman is discarded after use.",
             "colours": [],
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "e574a9f4-5ccd-5b92-87af-ddf36a03e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a364362-e42b-415c-9d95-b6ec7139f5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a364362-e42b-415c-9d95-b6ec7139f5e7.jpg?1",
             "name": "Brass Man",
             "text": "Brass Man does not untap as normal; you must pay o1 during your untap phase to untap it.",
             "colours": [],
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "dc2a3373-3c26-5443-a826-c92c7fc03c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598b346-a47d-4c4c-9571-156824e86b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598b346-a47d-4c4c-9571-156824e86b9c.jpg?1",
             "name": "City in a Bottle",
             "text": "All cards from Arabian Nights must be discarded from play, except for City in a Bottle. While City in a Bottle is in play, no further cards from Arabian Nights can be played.",
             "colours": [],
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "78a0788b-a066-5a59-b735-732f2939c85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2e494-1414-4d1f-91d2-7cb20acdb128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2e494-1414-4d1f-91d2-7cb20acdb128.jpg?1",
             "name": "Dancing Scimitar",
             "text": "Flying",
             "colours": [],
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "813f76c9-46ba-50e7-9b58-14739fb6e31c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae81ec7-2b7d-4301-8114-032be5e6b663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae81ec7-2b7d-4301-8114-032be5e6b663.jpg?1",
             "name": "Ebony Horse",
             "text": "o2: Remove one of your attacking creatures from combat. Treat this as if the creature never attacked, except that defenders assigned to block it cannot choose to block another creature.",
             "colours": [],
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "3bb554dc-a247-5ed2-84a3-d454fe4774d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b71ff49-ee0a-4065-9131-380468d62a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b71ff49-ee0a-4065-9131-380468d62a30.jpg?1",
             "name": "Flying Carpet",
             "text": "o2: Gives one creature flying ability until end of turn. If that creature is destroyed before end of turn, so is Flying Carpet.",
             "colours": [],
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "975fa200-a4a1-5be4-ba79-eadc78d20993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71504078-a16f-4dc4-9626-0ecc42b1e93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71504078-a16f-4dc4-9626-0ecc42b1e93b.jpg?1",
             "name": "Jandor's Ring",
             "text": "o2: Discard a card you just drew from your library, and draw another card to replace it.",
             "colours": [],
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "a2e03391-2efc-5cb3-950b-cc7dcea942ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b92-7d4e-4b03-8cb4-e6b356c338b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b92-7d4e-4b03-8cb4-e6b356c338b4.jpg?1",
             "name": "Jandor's Saddlebags",
             "text": "o3: Untap a creature.",
             "colours": [],
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "0440e3de-3b4f-5480-83f8-18576526ebc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfffb65d-851d-4dc9-9233-d53abf955dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfffb65d-851d-4dc9-9233-d53abf955dcd.jpg?1",
             "name": "Jeweled Bird",
             "text": "Draw a card, and exchange Jeweled Bird for your contribution to the ante. Your former contribution goes to your graveyard. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [],
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "5d4c0c95-dc55-57e6-8f3a-a319ddf42497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9decf-47b7-44e0-b380-8055b6011021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e9decf-47b7-44e0-b380-8055b6011021.jpg?1",
             "name": "Pyramids",
             "text": "o2: Prevents a land from being destroyed, or removes an enchantment from any land.",
             "colours": [],
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "dcf0f844-f329-5063-85f4-6037e1965e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc1004f-7cee-420a-9f0e-2986ed3ab852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc1004f-7cee-420a-9f0e-2986ed3ab852.jpg?1",
             "name": "Ring of Ma'r\u00fbf",
             "text": "o5: Instead of drawing a card from the top of your library, select one of your cards from outside the game. This card can be any card you have that you're not using in your deck or that for some reason has left the game. Ring of Ma'r\u00fbf is removed from the game entirely after use.",
             "colours": [],
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "9b9d06e9-049f-5cac-8775-5cf26e4febb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99a520-b8a9-40b0-9854-48aac297c5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99a520-b8a9-40b0-9854-48aac297c5ee.jpg?1",
             "name": "Sandals of Abdallah",
             "text": "o2: Gives one creature islandwalk ability until end of turn. If that creature is destroyed before end of turn, so are Sandals.",
             "colours": [],
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "be687077-8e91-50bf-b44b-3e52d2d22a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff37b863-f8c4-4584-8cc2-ac0e096e583f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff37b863-f8c4-4584-8cc2-ac0e096e583f.jpg?1",
             "name": "Bazaar of Baghdad",
             "text": "Tap to take two cards from your library, after which you must immediately discard three from your hand to your graveyard. If you don't have three or more cards in your hand, discard your whole hand. No spells may be cast between drawing and discarding cards.",
             "colours": [],
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "711d99ff-bcab-52ad-9f34-c6960eb0da48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e32327-380d-471e-813b-4c27477787ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e32327-380d-471e-813b-4c27477787ce.jpg?1",
             "name": "City of Brass",
             "text": "Tap to add 1 mana of any color to your mana pool. You suffer 1 damage whenever City of Brass becomes tapped.",
             "colours": [],
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "d432c1bb-b3a1-5725-8884-70dea10a2633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201155ea-f474-4e13-acda-cb071a6ca977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201155ea-f474-4e13-acda-cb071a6ca977.jpg?1",
             "name": "Desert",
             "text": "Tap to add 1 colorless mana to your mana pool or do 1 damage to an attacking creature after it deals its damage.",
             "colours": [],
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "a6b37a73-e152-5416-af8f-f35c1c3c4d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f6f21-15a0-4a36-be95-5a0299cd01a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f6f21-15a0-4a36-be95-5a0299cd01a5.jpg?1",
             "name": "Diamond Valley",
             "text": "Tap to sacrifice one of your creatures in exchange for a number of life points equal to its toughness. Note that this ability may be used after blocking has been declared.",
             "colours": [],
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "3848de3a-5625-52d6-be9c-5cfe84c3843b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18348df2-9037-4db4-bddb-76dc933229bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18348df2-9037-4db4-bddb-76dc933229bf.jpg?1",
             "name": "Elephant Graveyard",
             "text": "Tap to add 1 colorless mana to your mana pool or regenerate an Elephant or Mammoth.",
             "colours": [],
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "d763a70c-4caf-5fdf-aa87-185fc25fb1be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09cbd18-79f1-49a0-a3bd-b380ff5ecf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09cbd18-79f1-49a0-a3bd-b380ff5ecf03.jpg?1",
             "name": "Island of Wak-Wak",
             "text": "Tap to reduce target flying creature's power to 0.",
             "colours": [],
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "c395c80e-298a-5870-8877-cd0a7e273146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee266113-34ce-4189-84e7-ee2c86a2722c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee266113-34ce-4189-84e7-ee2c86a2722c.jpg?1",
             "name": "Library of Alexandria",
             "text": "Tap to add 1 colorless mana to your mana pool or draw a card from your library; you may use the card-drawing ability only if you have exactly seven cards in your hand.",
             "colours": [],
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "e7ef4860-f739-52cc-b84a-388e3de3c0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c321d0e1-ff30-4424-979b-25e1a33e45d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c321d0e1-ff30-4424-979b-25e1a33e45d5.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -2930,7 +2930,7 @@
         },
         {
             "id": "aceae48d-9e48-5983-8baf-32ff5b97281e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38565e-88b9-433d-b0e9-a3b9734f183f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38565e-88b9-433d-b0e9-a3b9734f183f.jpg?1",
             "name": "Oasis",
             "text": "Tap to prevent 1 damage to any creature.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ATQ.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ATQ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2172f6a4-a1a1-5c61-bcb3-393b381e7a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83a3cb-467d-44f6-a051-4855c8cf52a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83a3cb-467d-44f6-a051-4855c8cf52a6.jpg?1",
             "name": "Argivian Archaeologist",
             "text": "o\nWoo\nW Tap to bring one artifact from your graveyard to your hand.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "c43e408c-64cf-57c8-8c4f-acdd4a9fa912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f604338-5ee4-4c47-ad5a-5c805c96c8de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f604338-5ee4-4c47-ad5a-5c805c96c8de.jpg?1",
             "name": "Argivian Blacksmith",
             "text": "Tap to prevent up to 2 damage to target artifact creature.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "93a5a9ef-4f3d-5413-bbff-1b3dca579da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5101a-ec66-4658-950c-9ad49c29b836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5101a-ec66-4658-950c-9ad49c29b836.jpg?1",
             "name": "Artifact Ward",
             "text": "Target creature cannot be blocked by artifact creatures, and any damage taken from an artifact source is reduced to 0. Target creature is unaffected by any artifact effects that target it.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "fc1966ef-41bd-5f01-bc79-ae706037eb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ebd5a3-fef8-4097-b038-89a6cb38227d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ebd5a3-fef8-4097-b038-89a6cb38227d.jpg?1",
             "name": "Circle of Protection: Artifacts",
             "text": "o2: Prevents all damage against you from any one artifact source. If a source does damage to you more than once in a turn, you must pay o2 each time you want to prevent the damage.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "8a03a3b6-6f37-578c-9f72-fe141793c957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ab9836-bc90-4d92-a86d-b8e1b7671aa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ab9836-bc90-4d92-a86d-b8e1b7671aa7.jpg?1",
             "name": "Damping Field",
             "text": "Players may not untap more than one artifact during each of their own untap phases.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "a4c662b9-3a91-59b6-98fd-45fd1763860e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde037b9-4947-4ff7-8ea4-e9f1a7e4ab88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde037b9-4947-4ff7-8ea4-e9f1a7e4ab88.jpg?1",
             "name": "Martyrs of Korlis",
             "text": "Unless Martyrs of Korlis is tapped, any damage done to you by artifacts is instead applied to Martyrs of Korlis. You may not take this damage yourself, though you may prevent it if possible. No more than one Bodyguard of your choice can take damage for you in this manner each turn.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "62ba1509-14a9-5fdb-a6ed-40c76fe7d711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7ed8ba-3886-4779-a9b3-6892a7ed3527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7ed8ba-3886-4779-a9b3-6892a7ed3527.jpg?1",
             "name": "Reverse Polarity",
             "text": "All damage done to you so far this turn by artifacts is retroactively added to your life total instead of subtracted. Further damage this turn is treated normally.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "44f6abee-a596-5e23-93f9-234bb96bf1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be2aa3b-207b-4d21-abfb-6788520c7676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be2aa3b-207b-4d21-abfb-6788520c7676.jpg?1",
             "name": "Drafna's Restoration",
             "text": "Take any number of artifacts of your choice from target player's graveyard and place them on top of that player's library, in any order.",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "1fc46567-9a43-543f-bd97-391e2adb2f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1f624b-e8f2-462f-838a-7cb9e8fda988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1f624b-e8f2-462f-838a-7cb9e8fda988.jpg?1",
             "name": "Energy Flux",
             "text": "All artifacts in play now require an upkeep cost of o2 in addition to any other upkeep costs they may have. If the upkeep cost for an artifact is not paid, the artifact must be discarded.",
             "colours": [
@@ -293,7 +293,7 @@
         },
         {
             "id": "31ce9fd3-2c07-5362-b628-be49b29e59d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32373dd-06d8-45d1-8777-3b1411bcb30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32373dd-06d8-45d1-8777-3b1411bcb30a.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "All artifacts in play owned by target player are returned to target player's hand. Any enchantments on those artifacts are discarded. Cannot be played during the damage-dealing phase of an attack.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "ec79b3db-99bd-536b-b09d-5438bac5536e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48bc89e-6da5-43da-b4e0-60d5f850199c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48bc89e-6da5-43da-b4e0-60d5f850199c.jpg?1",
             "name": "Power Artifact",
             "text": "The activation cost of target artifact is reduced by o2. If this would reduce target artifact's activation cost below o1, target artifact's activation cost becomes o1. Power Artifact has no effect on artifacts that have no activation cost or whose activation cost is o0.",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "7b3f65b8-2dd9-5026-be22-ef18aa7f21b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa2d27b-cc25-4baa-86f4-4db45b30e2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa2d27b-cc25-4baa-86f4-4db45b30e2a4.jpg?1",
             "name": "Reconstruction",
             "text": "Bring one artifact from your graveyard to your hand.",
             "colours": [
@@ -388,7 +388,7 @@
         },
         {
             "id": "8ea7d80c-110e-55ae-bbf6-38d6861a559a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff60ce-073c-46b8-807c-8b40467b960c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff60ce-073c-46b8-807c-8b40467b960c.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "Tap to draw a card from your library. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "98893d8a-85dc-5429-9648-c93feda4873e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eab6765-eba3-4844-81ca-ae37a6e903df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eab6765-eba3-4844-81ca-ae37a6e903df.jpg?1",
             "name": "Transmute Artifact",
             "text": "Search through your library for one artifact and immediately place it into play; also, choose any artifact in play that you control and place it in its owner's graveyard. If the new artifact has a casting cost greater than that of the discarded one, you must pay the difference or Transmute Artifact fails and both artifacts are discarded. Shuffle your library after playing this card.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "2c5aef2a-628a-56a7-92df-97fbc176df8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587d6ac8-fad8-49e0-862e-636e06628ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587d6ac8-fad8-49e0-862e-636e06628ff9.jpg?1",
             "name": "Artifact Possession",
             "text": "Artifact Possession does 2 damage to target artifact's controller each time target artifact is tapped or its activation cost is paid. Has no effect if cast on a continuous artifact.",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "ca6c9d78-48ad-5ce6-a8ff-55c699fd6a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f372950-6693-4838-80ef-8fd9aa3e0349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f372950-6693-4838-80ef-8fd9aa3e0349.jpg?1",
             "name": "Gate to Phyrexia",
             "text": "Sacrifice one of your creatures during your upkeep to destroy any one artifact. You may not sacrifice a creature that is already on its way to the graveyard.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "b2a0023e-3ae7-5d59-a33f-2af006890b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f6ef2f-a3a2-4e1f-b7eb-59abc8414114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f6ef2f-a3a2-4e1f-b7eb-59abc8414114.jpg?1",
             "name": "Haunting Wind",
             "text": "Each time an artifact in play is tapped or its activation cost is paid, Haunting Wind does 1 damage to that artifact's controller. Is not triggered by continuous artifacts.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "0a53e07a-4fae-56a5-9976-be85f7da6bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a985a9-5612-4844-982e-fd1aa6249770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a985a9-5612-4844-982e-fd1aa6249770.jpg?1",
             "name": "Phyrexian Gremlins",
             "text": "Tap Gremlins to tap an artifact. As long as Gremlins remain tapped and in play, that artifact does not untap as normal during its controller's untap phase. You may choose not to untap Gremlins during your untap phase.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "d5e8a38a-5439-511c-8fff-35616be82a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fd4054-42fc-4f95-a6f7-369a5da43dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fd4054-42fc-4f95-a6f7-369a5da43dd5.jpg?1",
             "name": "Priest of Yawgmoth",
             "text": "Tap to add an amount of black mana equal to target artifact's casting cost to your mana pool. This effect is played as an interrupt. Target artifact, which must belong to you, is discarded. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "6fc80bbd-ee58-5515-86cb-918583d6e465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5149ffff-d38f-458e-bcfa-a4b6b332a0b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5149ffff-d38f-458e-bcfa-a4b6b332a0b4.jpg?1",
             "name": "Xenic Poltergeist",
             "text": "Tap to turn target non-creature artifact into an artifact creature with both power and toughness equal to its casting cost. This transformation lasts until your next upkeep; target retains all its original abilities as well.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "c6e4d57e-e983-58ba-bd0b-b440e9a95166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bbd231-0d5f-4cbf-92a7-10d2c5c4b82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bbd231-0d5f-4cbf-92a7-10d2c5c4b82c.jpg?1",
             "name": "Yawgmoth Demon",
             "text": "Flying, first strike\nDuring your upkeep, choose one of your artifacts in play and place it in the graveyard, or Yawgmoth Demon becomes tapped and deals 2 points of damage to you. Artifact creatures destroyed this way may not be regenerated.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "8d049b0a-7571-57bc-853a-d1fb8232fec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1506d99d-7b2e-4101-84a5-c950dadb263a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1506d99d-7b2e-4101-84a5-c950dadb263a.jpg?1",
             "name": "Artifact Blast",
             "text": "Counters any artifact as it is being cast.",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "062dec00-8d7e-51f2-ba8d-ea6f930ffcf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2249fc40-4412-48fd-800a-7ea3678aee3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2249fc40-4412-48fd-800a-7ea3678aee3f.jpg?1",
             "name": "Atog",
             "text": "o0: +2/+2 until end of turn. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "79afd8d0-d940-561d-8485-d57e3c9ca1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77fda65-f70d-44b1-89db-910d2761b81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77fda65-f70d-44b1-89db-910d2761b81c.jpg?1",
             "name": "Atog",
             "text": "",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "24c4d57a-3560-564d-8404-5b1e746606c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd7eb90-ae95-49df-898a-9510187bce1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd7eb90-ae95-49df-898a-9510187bce1c.jpg?1",
             "name": "Detonate",
             "text": "Targets any artifact; X is the casting cost of target artifact. Target artifact is destroyed, and Detonate does X points of damage to artifact's controller. Artifact creatures destroyed in this manner may not be regenerated.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "9b1fe74e-ec49-5c02-b0be-c382c3d8e5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0848d94a-2704-460f-986b-b192dd6d26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0848d94a-2704-460f-986b-b192dd6d26b7.jpg?1",
             "name": "Dwarven Weaponsmith",
             "text": "Tap during your upkeep to add a permanent +1/+1 counter to any creature. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one that is already on its way to the graveyard, and artifact creatures killed in this way may not be regenerated.",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "4a8ced8a-e033-5a50-a50f-2b628fb60818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6669d96e-9a7b-4427-a477-f4e76831f593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6669d96e-9a7b-4427-a477-f4e76831f593.jpg?1",
             "name": "Goblin Artisans",
             "text": "You may tap Goblin Artisans as you cast an artifact. Then flip a coin; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, your artifact is countered. Otherwise, draw another card from your library. You can only use this ability once for each time you cast an artifact.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "03014f7c-5ed1-5eaa-b405-53e66a114061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e34fc6b-5f00-4a22-9ee2-afc1caf99961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e34fc6b-5f00-4a22-9ee2-afc1caf99961.jpg?1",
             "name": "Orcish Mechanics",
             "text": "Tap to do 2 points of damage to any target. Each time you use this ability, you must choose one of your artifacts in play and place it in the graveyard. This artifact cannot be one already on its way to the graveyard, and artifact creatures killed this way may not be regenerated.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "37cb60a3-9bbf-5035-b542-cc86387fe39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987461a-45c0-4956-8627-cd27a7e038d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987461a-45c0-4956-8627-cd27a7e038d0.jpg?1",
             "name": "Shatterstorm",
             "text": "All artifacts in play are discarded.\nArtifact creatures cannot be regenerated.",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "3e7ed4d3-43e8-5ab2-b343-2bd0cd564a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5712e87a-2381-4f5b-a853-6973841f9bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5712e87a-2381-4f5b-a853-6973841f9bf1.jpg?1",
             "name": "Argothian Pixies",
             "text": "Cannot be blocked by artifact creatures. Any damage Argothian Pixies take from artifact creatures is reduced to 0.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "24a035d4-f042-51f8-b018-31697d0ae891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db8882e-4db6-4e3c-9e9e-8c71d557a071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db8882e-4db6-4e3c-9e9e-8c71d557a071.jpg?1",
             "name": "Argothian Treefolk",
             "text": "Any damage Argothian Treefolk take from an artifact source is reduced to 0.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "6360649f-b0d4-5d11-8d4a-4481b3f2d8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a130dc-3b1f-4fae-8459-b26bb5647fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a130dc-3b1f-4fae-8459-b26bb5647fec.jpg?1",
             "name": "Citanul Druid",
             "text": "Druid gains a +1/+1 counter each time opponent casts an artifact.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "3a12cebc-8f57-5bd8-82f0-a947038da26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2101f86-8d3c-4ba8-ac42-bd3df0644280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2101f86-8d3c-4ba8-ac42-bd3df0644280.jpg?1",
             "name": "Crumble",
             "text": "Destroy target artifact; artifact creatures may not regenerate. Artifact's controller gains life points equal to target artifact's casting cost.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "f00a51ae-00ac-560a-8e98-e59bd69d1cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d763bd-b0a9-46ba-bcd2-9304063446f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d763bd-b0a9-46ba-bcd2-9304063446f2.jpg?1",
             "name": "Gaea's Avenger",
             "text": "The *s below are the number of artifacts opponent has in play.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "546a88d7-1cda-5567-8721-cf58d21609f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1d7b09-3a1f-410f-b330-04ae768b0455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1d7b09-3a1f-410f-b330-04ae768b0455.jpg?1",
             "name": "Powerleech",
             "text": "Gain 1 life whenever one of opponent's artifacts becomes tapped, or whenever the activation cost of one of opponent's artifacts is paid. Is not triggered by continuous artifacts.",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "61475d58-937f-5116-b319-03779a9cc58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a53af-2e2a-4f3f-8eab-bd874c6ed80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a53af-2e2a-4f3f-8eab-bd874c6ed80a.jpg?1",
             "name": "Titania's Song",
             "text": "All non-creature artifacts in play lose all their usual abilities and become artifact creatures with toughness and power both equal to their casting costs. If Titania's Song leaves play, artifacts return to normal just before the untap phase of the next turn.",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "06d37a54-ac63-5960-a952-a896193c3995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b094f8dd-0184-41a2-9767-e848a6e4eac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b094f8dd-0184-41a2-9767-e848a6e4eac1.jpg?1",
             "name": "Amulet of Kroog",
             "text": "o2: Prevent 1 damage to any target.",
             "colours": [],
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "85cc73a1-602e-57dd-b4df-8ccc47bf2cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a31889-6a8d-450c-a73d-381a7ff28bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a31889-6a8d-450c-a73d-381a7ff28bf9.jpg?1",
             "name": "Armageddon Clock",
             "text": "Put one counter on Armageddon Clock during each of your upkeeps. At the end of your upkeep, each player takes damage equal to the number of counters on the Clock. Any player may spend o4 during any upkeep to remove a counter.",
             "colours": [],
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "3108f008-0f9f-51f2-9f35-e0facff6e640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcccb0f-ce96-453b-9e82-41d87f52e58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcccb0f-ce96-453b-9e82-41d87f52e58b.jpg?1",
             "name": "Ashnod's Altar",
             "text": "o0: Sacrifice one of your creatures to add 2 colorless mana to your mana pool. This effect is played as an interrupt. You may not sacrifice a creature that is already on its way to the graveyard.",
             "colours": [],
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "89582854-9011-5b30-a8c7-88ef6103914f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeec853-dd3f-4ac3-8b20-c07fada8888f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeeec853-dd3f-4ac3-8b20-c07fada8888f.jpg?1",
             "name": "Ashnod's Battle Gear",
             "text": "o2: Give a creature of yours +2/-2 as long as Ashnod's Battle Gear is tapped. You may choose not to untap Ashnod's Battle Gear during untap phase.",
             "colours": [],
@@ -1282,7 +1282,7 @@
         },
         {
             "id": "eb81a30d-0113-5c65-b177-d5201be5e269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5b289-36ba-49b1-a5ac-f23bf71f8241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5b289-36ba-49b1-a5ac-f23bf71f8241.jpg?1",
             "name": "Ashnod's Transmogrant",
             "text": "Target non-artifact creature gains +1/+1 and is now considered an artifact creature, though it retains its original color. Discard Ashnod's Transmogrant after it is used.",
             "colours": [],
@@ -1309,7 +1309,7 @@
         },
         {
             "id": "45b2a364-e246-5f74-8d90-e742370a4cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a69e35-d209-41c0-aa3c-c78414617075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a69e35-d209-41c0-aa3c-c78414617075.jpg?1",
             "name": "Battering Ram",
             "text": "Bands, but only when attacking. Any wall blocking Battering Ram is destroyed. Walls destroyed this way deal their damage before dying.",
             "colours": [],
@@ -1339,7 +1339,7 @@
         },
         {
             "id": "47a60b39-e13f-5741-a332-bab38681d506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb10552-dd47-4f8a-ac7c-8c2b61e56736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb10552-dd47-4f8a-ac7c-8c2b61e56736.jpg?1",
             "name": "Bronze Tablet",
             "text": "o4: Target any card opponent has in play; remove it and Bronze Tablet from game. You become owner of that card, and your opponent becomes owner of Bronze Tablet. Exchange is permanent; play as interrupt. Opponent can prevent exchange by spending 10 life; this discards Bronze Tablet. Damage-preventing effects cannot counter such loss of life. Bronze Tablet comes into play tapped. Remove this card from deck if not playing for ante.",
             "colours": [],
@@ -1366,7 +1366,7 @@
         },
         {
             "id": "c30b2434-0f06-53e1-b79b-e98fc6c0024a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a335bf-7358-460f-b7c9-1e8bc4300f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a335bf-7358-460f-b7c9-1e8bc4300f64.jpg?1",
             "name": "Candelabra of Tawnos",
             "text": "oo\nX Untap X separate lands.",
             "colours": [],
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "ed4beaef-692d-5825-8a3c-faba028d397d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64975352-8d35-4d02-94ac-fa0c6ee12409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64975352-8d35-4d02-94ac-fa0c6ee12409.jpg?1",
             "name": "Clay Statue",
             "text": "o2: Regenerates",
             "colours": [],
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "f35653fe-6fa3-5565-9677-04e07742c570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dea8c2f-4aea-478d-aee7-cba1f74edd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dea8c2f-4aea-478d-aee7-cba1f74edd6c.jpg?1",
             "name": "Clockwork Avian",
             "text": "Flying\nPut four +1/+0 counters on Avian. After Avian attacks or blocks a creature, discard a counter.\nDuring his or her upkeep, controller may buy back lost counters for o1 per counter; this taps Avian.",
             "colours": [],
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "9edc0231-4585-5908-91bc-530b5e37c41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c44e9-1b23-42fd-9acb-daafb62c32a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c44e9-1b23-42fd-9acb-daafb62c32a2.jpg?1",
             "name": "Colossus of Sardia",
             "text": "Trample\nColossus does not untap normally during untap phase; you may spend o9 during your upkeep phase to untap Colossus.",
             "colours": [],
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "ee5206cd-b4f0-5f2b-b4a0-50f2bf298ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6df9db-0a46-40a5-ae9d-59f47dae9056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6df9db-0a46-40a5-ae9d-59f47dae9056.jpg?1",
             "name": "Coral Helm",
             "text": "o3: Give target creature +2/+2 until end of turn. Each time you use this ability, you must discard one card at random from your hand. Coral Helm cannot be used if you have no cards in your hand.",
             "colours": [],
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "e5a4cd29-5cce-5fa0-80a7-44f06589505b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720d871d-1e7b-482e-bd1e-8ec79519fb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720d871d-1e7b-482e-bd1e-8ec79519fb86.jpg?1",
             "name": "Cursed Rack",
             "text": "Opponent must discard down to four cards during his or her discard phase.",
             "colours": [],
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "f8a02129-c89c-5f6a-b255-0501f8604783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07793a71-1106-4303-b620-e403bd378020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07793a71-1106-4303-b620-e403bd378020.jpg?1",
             "name": "Dragon Engine",
             "text": "o2: +1/+0 until end of turn.",
             "colours": [],
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "a4c55bc8-a284-516a-838e-30a689e0ccf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6af436-bcfd-4d47-a1aa-e84b587a725a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6af436-bcfd-4d47-a1aa-e84b587a725a.jpg?1",
             "name": "Feldon's Cane",
             "text": "o0: Reshuffle your graveyard into your library. If Feldon's Cane is used, remove it from the game, returning it to its owner's deck only when the game is over.",
             "colours": [],
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "81388425-7e8b-56a8-b7d9-10369e1840fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856be1dd-a20b-49c2-be9d-7db76c7efd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856be1dd-a20b-49c2-be9d-7db76c7efd8b.jpg?1",
             "name": "Golgothian Sylex",
             "text": "o1: All cards from the Antiquities expansion, including Golgothian Sylex, must be discarded from play.",
             "colours": [],
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "5b2752e8-947a-562f-85ac-9238d11f689e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a7348-c82e-453c-975c-e5365e152a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a7348-c82e-453c-975c-e5365e152a3a.jpg?1",
             "name": "Grapeshot Catapult",
             "text": "Tap to deal 1 damage to target flying creature.",
             "colours": [],
@@ -1651,7 +1651,7 @@
         },
         {
             "id": "5658fb05-55d8-51ee-96c6-f11a95491c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f23039-45ca-4c15-af50-bfd40ea26453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f23039-45ca-4c15-af50-bfd40ea26453.jpg?1",
             "name": "Ivory Tower",
             "text": "During your upkeep phase, gain 1 life for each card in your hand above four.",
             "colours": [],
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "27b3d07b-e9bf-581d-ab94-1b7a150cdceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7c5a-ee63-4a1b-9a0f-fb0a309168df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7c5a-ee63-4a1b-9a0f-fb0a309168df.jpg?1",
             "name": "Jalum Tome",
             "text": "o2: Draw a card from your library, then immediately discard a card of your choice to your graveyard.",
             "colours": [],
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "5d492ae6-cb7c-5c83-bb72-9dba7e91822a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ba599-5299-4831-a118-1712ada10ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ba599-5299-4831-a118-1712ada10ef6.jpg?1",
             "name": "Mightstone",
             "text": "All attacking creatures gain +1/+0.",
             "colours": [],
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "aae274de-d935-5ca7-a450-6812bceaf87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107646bc-2181-49f4-8821-1eaa46291855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107646bc-2181-49f4-8821-1eaa46291855.jpg?1",
             "name": "Millstone",
             "text": "o2: Take the top two cards from target player's library and put them in target player's graveyard.",
             "colours": [],
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "18295dd4-f5a8-594a-8655-2e6e6b17f603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b4652-a1d4-418f-a89b-6a977a920a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b4652-a1d4-418f-a89b-6a977a920a9e.jpg?1",
             "name": "Mishra's War Machine",
             "text": "Bands\nDuring your upkeep, discard one card of your choice from your hand, or Mishra's War Machine becomes tapped and does 3 points of damage to you.",
             "colours": [],
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "770e06ad-a595-539c-99e6-1d43f663c337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba61ccd-4429-4f7c-b9f3-30867878d88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba61ccd-4429-4f7c-b9f3-30867878d88e.jpg?1",
             "name": "Obelisk of Undoing",
             "text": "o6: Return any of your permanents in play to your hand; enchantments on that permanent are discarded. Can be used only on permanents you cast.",
             "colours": [],
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "d9e1f806-d023-5989-9340-2ee737f03025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77fe8e2-8438-473e-ace5-01baddd2c4ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77fe8e2-8438-473e-ace5-01baddd2c4ed.jpg?1",
             "name": "Onulet",
             "text": "If Onulet goes to the graveyard, its controller gains 2 life.",
             "colours": [],
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "bf1fa173-654a-5aff-a402-4d4614e03421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cc9bdb-7cf2-4795-bac7-ffff605c9eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cc9bdb-7cf2-4795-bac7-ffff605c9eb0.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "90ccad0a-0c43-5ecc-9f58-efb7c6311dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9d0e3f-cf7c-41f8-bcd7-bb08ea8cc2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9d0e3f-cf7c-41f8-bcd7-bb08ea8cc2f8.jpg?1",
             "name": "Primal Clay",
             "text": "When you cast Primal Clay, you must choose whether to make it a 1/6 wall, a 3/3 creature, or a 2/2 flying creature. Primal Clay then remains in this form until altered by another card or removed from play.",
             "colours": [],
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "5cfae833-52ae-52d7-9141-fc6efcc66275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7c711-3ff4-4691-914f-242e6737066c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd7c711-3ff4-4691-914f-242e6737066c.jpg?1",
             "name": "Rakalite",
             "text": "o2: Prevent 1 damage to any target. If Rakalite is used, it returns to its owner's hand at end of turn; all enchantments on Rakalite are then discarded.",
             "colours": [],
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "12a49ccf-364a-5252-89ae-39cf5c847ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bb2093-78a8-4a6c-abe7-9a5afc181ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bb2093-78a8-4a6c-abe7-9a5afc181ec5.jpg?1",
             "name": "Rocket Launcher",
             "text": "o2: Do 1 damage to any target. Rocket Launcher may not be used until it begins a turn in play on your side. If it is used, Rocket Launcher is destroyed at end of turn.",
             "colours": [],
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "484f1f05-d8e9-5ef3-a8b8-07a9edc23f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc278af4-b60d-41b7-b9d7-36c8aefca1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc278af4-b60d-41b7-b9d7-36c8aefca1a7.jpg?1",
             "name": "Shapeshifter",
             "text": "The *s below represent any number from 0 to 6. You set * when Shapeshifter is cast, and you may change it during your upkeep.",
             "colours": [],
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "476d2ec1-6212-5308-a718-72a5850c31e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bf858d-bba9-4a16-9045-55384b1de633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bf858d-bba9-4a16-9045-55384b1de633.jpg?1",
             "name": "Staff of Zegon",
             "text": "o3: Target creature loses -2/-0 until end of turn. Creatures with power less than 1 deal no damage.",
             "colours": [],
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "685c9d21-bac0-545f-a6cc-c1041add2225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d4f93-0c04-4078-aec0-7e9de92f260f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d4f93-0c04-4078-aec0-7e9de92f260f.jpg?1",
             "name": "Su-Chi",
             "text": "If Su-Chi goes to the graveyard, its controller gains 4 colorless mana.",
             "colours": [],
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "ea0f41f1-0e3e-566e-9ad1-b796c970fcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7a2718-301f-4191-b348-0c44c7c07d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7a2718-301f-4191-b348-0c44c7c07d43.jpg?1",
             "name": "Tablet of Epityr",
             "text": "o1: You gain 1 life every time one of your artifacts goes to the graveyard. Can only give 1 life each time an artifact reaches the graveyard.",
             "colours": [],
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "81527540-94fa-5e90-8853-7d0b9ac68a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27bc1de-8246-4dc8-af51-ec21def9e226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27bc1de-8246-4dc8-af51-ec21def9e226.jpg?1",
             "name": "Tawnos's Coffin",
             "text": "o3: Select a creature in play; that creature is considered out of play as long as Coffin remains tapped. Hence the creature cannot be the target of spells and cannot receive damage, use special powers, attack, or defend. All counters and enchantments on the creature remain but are also out of play. If Coffin is untapped or removed, creature returns to play tapped. You may choose not to untap Coffin during the untap phase.",
             "colours": [],
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "9e44fef0-b169-5493-b274-a13cf27d4f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f09dd-121a-4da5-ba16-5c03fbdce084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f09dd-121a-4da5-ba16-5c03fbdce084.jpg?1",
             "name": "Tawnos's Wand",
             "text": "o2: Make a creature of power no greater than 2 unblockable by all creatures except artifact creatures until end of turn. Other cards may be used to increase target creature's power beyond 2 after defense is chosen.",
             "colours": [],
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "2012a5ac-9d24-5d6e-9931-7435a3d26903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035cead-a501-4204-9154-5fd648577d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035cead-a501-4204-9154-5fd648577d32.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "o2: Target creature gains +1/+1 as long as Tawnos's Weaponry remains tapped. You may choose not to untap Tawnos's Weaponry during untap phase.",
             "colours": [],
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "38792f46-6fa4-5afb-aca9-db8d4732fd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca371f0-e7c9-4154-8e1d-47576c0202bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca371f0-e7c9-4154-8e1d-47576c0202bc.jpg?1",
             "name": "Tawnos's Weaponry",
             "text": "",
             "colours": [],
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "23d749b2-d958-51e5-a251-9ae96ae09bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb19f9-2e8f-4bf0-9bf8-868e6da70e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb19f9-2e8f-4bf0-9bf8-868e6da70e2d.jpg?1",
             "name": "Tetravus",
             "text": "Flying\nTetravus gets three +1/+1 counters when cast. During your upkeep, you may move each of these counters on or off Tetravus.  Counters moved off of Tetravus become independent 1/1 flying artifact creatures.  If such a creature dies, the counter is removed from play.  Such creatures may not have enchantments cast on them, and they do not share any enchantments on Tetravus.",
             "colours": [],
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "8282dfbf-e403-599c-88f9-89b77a95c303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0686ba-1277-4412-a397-7a6227808311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0686ba-1277-4412-a397-7a6227808311.jpg?1",
             "name": "The Rack",
             "text": "If opponent has fewer than three cards in hand during his or her upkeep, the Rack does 1 damage to opponent for each card fewer than three.",
             "colours": [],
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "93b4c02e-bca7-52e7-9cdf-5e5bb924315a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c99e1-722a-44b6-8fa3-2be3f0c193d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c99e1-722a-44b6-8fa3-2be3f0c193d8.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion gets three +1/+1 counters when cast. Controller may discard a +1/+1 counter at any time to do 1 damage to any target.",
             "colours": [],
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "d1454386-64d1-52f3-b1be-baf1786ddc17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448e1811-fb16-4390-ac22-b7066a4a019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448e1811-fb16-4390-ac22-b7066a4a019c.jpg?1",
             "name": "Urza's Avenger",
             "text": "o0: Avenger loses -1/-1 and gains one of your choice of flying, banding, first strike, or trample until end of turn. Attribute losses and ability gains are cumulative.",
             "colours": [],
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "e11d3332-fa89-5f0c-bbc0-916b89e52fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3728537-86d3-42be-9046-90bba1bfafc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3728537-86d3-42be-9046-90bba1bfafc1.jpg?1",
             "name": "Urza's Chalice",
             "text": "o1: Any artifact cast by any player gives you 1 life. Can only give 1 life each time an artifact is cast.",
             "colours": [],
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "14f6fa46-4534-5a82-b31d-ec7b428e76e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438f0c61-a61d-4a9e-b21f-4e86420c7913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438f0c61-a61d-4a9e-b21f-4e86420c7913.jpg?1",
             "name": "Urza's Miter",
             "text": "o3: Draw one card from your library every time an artifact of yours goes to the graveyard. Can only let you draw one card per artifact destruction. May not be used when you destroy an artifact to gain benefits from another card.",
             "colours": [],
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "c526289b-a705-5350-a7fe-d72b312c6f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dda179-c49a-4995-ba5a-db93ac43dbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dda179-c49a-4995-ba5a-db93ac43dbe7.jpg?1",
             "name": "Wall of Spears",
             "text": "First strike, counts as a wall.",
             "colours": [],
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "a072feb1-0ada-594c-be41-88f7b72618f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46adf48f-99d2-440e-9129-794584c1ea21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46adf48f-99d2-440e-9129-794584c1ea21.jpg?1",
             "name": "Weakstone",
             "text": "All attacking creatures lose -1/-0. Creatures with power less than 1 deal no damage.",
             "colours": [],
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "bb438a2c-feba-5e98-841b-dcce02d063b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27cf53e3-76f6-4831-800e-1259394d779d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27cf53e3-76f6-4831-800e-1259394d779d.jpg?1",
             "name": "Yotian Soldier",
             "text": "Attacking does not cause Yotian Soldier to tap.",
             "colours": [],
@@ -2444,7 +2444,7 @@
         },
         {
             "id": "927c9c55-20a2-5ae1-a64f-31495b5d4d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a696c5b6-f216-454d-8029-74e84bbd1428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a696c5b6-f216-454d-8029-74e84bbd1428.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "d947adc6-97e9-5acf-be62-3ebd8b00c7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4047df9c-335c-4c1a-968d-00f40e2e7386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4047df9c-335c-4c1a-968d-00f40e2e7386.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "d8ad1e4e-4bc5-5c9f-a860-f5a48b02e9f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44669b2-bf9a-41c3-91c7-d845b0061fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44669b2-bf9a-41c3-91c7-d845b0061fbf.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "a29a3bd1-465b-5c6c-9220-24f433f38f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac09a506-427f-4636-bcfd-b40f8d511905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac09a506-427f-4636-bcfd-b40f8d511905.jpg?1",
             "name": "Mishra's Factory",
             "text": "Tap to add 1 colorless mana to your mana pool or give any Assembly Worker +1/+1 until end of turn.\no1: Mishra's Factory becomes an Assembly Worker, a 2/2 artifact creature, until end of turn. Assembly Worker is still considered a land as well.",
             "colours": [],
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "4938b0bf-0804-58a4-b08c-28eaa0d50b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135de5c7-6ac9-4b68-8f1a-97f120a4b125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135de5c7-6ac9-4b68-8f1a-97f120a4b125.jpg?1",
             "name": "Mishra's Workshop",
             "text": "Tap to add 3 colorless mana to your mana pool. This mana may only be used to cast artifacts.",
             "colours": [],
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "b769fe08-b7ac-55ac-a271-5071c335cd45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7880157-7f27-4f1b-9cdc-ab36a6252376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7880157-7f27-4f1b-9cdc-ab36a6252376.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "51340ce9-e346-5866-850b-44a8c939cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48bd745-5e9f-4807-97b0-29222a5b838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48bd745-5e9f-4807-97b0-29222a5b838d.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "5c14e66e-3a74-57bf-916e-07bd777346b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e98db-a0c4-4836-9e4b-3fda142eedf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e98db-a0c4-4836-9e4b-3fda142eedf6.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "4506940f-2074-5217-9e4c-d0686f89d7e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f6a92f-edd8-4cb6-be91-f3ec229b20a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f6a92f-edd8-4cb6-be91-f3ec229b20a6.jpg?1",
             "name": "Strip Mine",
             "text": "Tap to add 1 colorless mana to your mana pool or place Strip Mine in your graveyard and destroy one land of your choice.",
             "colours": [],
@@ -2719,7 +2719,7 @@
         },
         {
             "id": "07fff1b2-e42f-57fb-bb5b-f2d7811b849e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf85792-470b-4b42-99ac-9cb43a575523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf85792-470b-4b42-99ac-9cb43a575523.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "c3209e37-85dd-51dc-911d-d56541017839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27886da1-9161-4bed-81b5-06da21a25f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27886da1-9161-4bed-81b5-06da21a25f91.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "b283ac99-3b95-55be-9c4d-c93cf9d3bde3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da68a5c0-84fe-4a8f-93b2-790eca3cc95c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da68a5c0-84fe-4a8f-93b2-790eca3cc95c.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2821,7 +2821,7 @@
         },
         {
             "id": "a41407e3-c878-50bf-8b99-6423266b923e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8617d2-a0e9-4fb4-85da-2c7e385be3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8617d2-a0e9-4fb4-85da-2c7e385be3f6.jpg?1",
             "name": "Urza's Mine",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2855,7 +2855,7 @@
         },
         {
             "id": "dd2315b3-8e04-5f9e-bcb8-1802eeac49d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94896e0b-859c-47e4-bf27-35ed37b841e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94896e0b-859c-47e4-bf27-35ed37b841e0.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "04f6bbac-81d2-5ae7-ae0d-e18ef003760c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e237d921-6d84-402e-b5e3-6bbdb3028f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e237d921-6d84-402e-b5e3-6bbdb3028f57.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "21491a40-9e69-5c60-9594-44f62f44a6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc02459-83ae-4b6c-85a1-26eeaf7a2ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc02459-83ae-4b6c-85a1-26eeaf7a2ee7.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "a38bd19b-0272-5b82-9f7c-be82514e5bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bbe643-3e07-4541-a2e6-45c63a5133cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bbe643-3e07-4541-a2e6-45c63a5133cf.jpg?1",
             "name": "Urza's Power Plant",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 2 colorless mana to your mana pool.",
             "colours": [],
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "e555dd4a-3b70-5579-b4e0-5ed49b9892b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed85655-fc59-4a57-bcf9-75e1899dff78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed85655-fc59-4a57-bcf9-75e1899dff78.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "82c21ea8-a057-55f0-bab1-7ead4bee5ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aba1f0f-73b0-4898-8d07-43322e43d74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aba1f0f-73b0-4898-8d07-43322e43d74e.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],
@@ -3059,7 +3059,7 @@
         },
         {
             "id": "5d31d685-4a95-5674-a175-398ce3e2feed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a03554a-0ee7-4106-b3e4-4bc51f48032d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a03554a-0ee7-4106-b3e4-4bc51f48032d.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "7d956150-e28d-5468-ab92-95f38675ddb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78f2e5-c02b-4f58-8510-660ca27d9a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78f2e5-c02b-4f58-8510-660ca27d9a71.jpg?1",
             "name": "Urza's Tower",
             "text": "Tap to add 1 colorless mana to your mana pool. If you have Urza's Mine, Urza's Tower, and Urza's Power Plant in play at the same time, tap to add 3 colorless mana to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/AVR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/AVR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1bb3e236-992e-51f8-95f4-c61a89901a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8be765-0949-491c-875c-0385fb83e4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8be765-0949-491c-875c-0385fb83e4b9.jpg?1",
             "name": "Angel of Glory's Rise",
             "text": "Flying\nWhen Angel of Glory's Rise enters the battlefield, exile all Zombies, then return all Human creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "ccaa2df4-67e5-5e73-b5c6-d07a769b14a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5dfed-4dee-4e48-a445-89f03d7794e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5dfed-4dee-4e48-a445-89f03d7794e6.jpg?1",
             "name": "Angel of Jubilation",
             "text": "Flying\nOther nonblack creatures you control get +1/+1.\nPlayers can't pay life or sacrifice creatures to cast spells or activate abilities.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "5d324527-2765-5ac0-94da-4a8e623a432d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a437999-26ae-49fa-8647-c8c2b4640702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a437999-26ae-49fa-8647-c8c2b4640702.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "e7ce43af-ce65-5ba7-b913-168148343a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b2450d-87a7-46dc-b43a-2db2abeca44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b2450d-87a7-46dc-b43a-2db2abeca44f.jpg?1",
             "name": "Angelic Wall",
             "text": "Defender, flying",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "d0f7989f-fb29-59d9-9da6-a19e9157f8f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741b2a7-7bda-481a-b8f8-9b04c96035b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741b2a7-7bda-481a-b8f8-9b04c96035b0.jpg?1",
             "name": "Archangel",
             "text": "Flying, vigilance",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "2ed7c882-83c3-5867-87bc-5a6c8e69db56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba149706-cd17-4da6-8403-ccfe2d6cb437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba149706-cd17-4da6-8403-ccfe2d6cb437.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance\nAvacyn, Angel of Hope and other permanents you control are indestructible.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "ca0faf82-518f-5642-a609-71fef4f59f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238d8437-1abd-4bb7-8b5b-54f959bc2c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238d8437-1abd-4bb7-8b5b-54f959bc2c79.jpg?1",
             "name": "Banishing Stroke",
             "text": "Put target artifact, creature, or enchantment on the bottom of its owner's library.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "fb8f7089-f6ba-5e4b-a2a3-45c2a0354323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad27af1-b482-40d5-9dbb-11201ffa0410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad27af1-b482-40d5-9dbb-11201ffa0410.jpg?1",
             "name": "Builder's Blessing",
             "text": "Untapped creatures you control get +0/+2.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "a92899bd-56fd-5d64-9824-df755deb1038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4a3e80-6e95-4346-8ab8-eecc1a09ca24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4a3e80-6e95-4346-8ab8-eecc1a09ca24.jpg?1",
             "name": "Call to Serve",
             "text": "Enchant nonblack creature\nEnchanted creature gets +1/+2, has flying, and is an Angel in addition to its other types.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "13af6bdd-a412-5eef-9f41-328314b9f007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78154978-9e7d-44e9-a03f-c578072a8ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78154978-9e7d-44e9-a03f-c578072a8ff7.jpg?1",
             "name": "Cathars' Crusade",
             "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "3f2aa9f7-85e8-5586-866d-a9ed46ddd923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cac47a-9e83-4039-8d80-fa9bdadb7527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cac47a-9e83-4039-8d80-fa9bdadb7527.jpg?1",
             "name": "Cathedral Sanctifier",
             "text": "When Cathedral Sanctifier enters the battlefield, you gain 3 life.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "3e2a0249-7f9f-5487-accf-4be7bd5000c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b06c8f-5f08-43bd-a548-2a98ba30fd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b06c8f-5f08-43bd-a548-2a98ba30fd41.jpg?1",
             "name": "Cloudshift",
             "text": "Exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -405,7 +405,7 @@
         },
         {
             "id": "679c2039-414f-59bc-b6a4-5c940402e8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ef4383-11e7-4426-a04a-058570f46e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ef4383-11e7-4426-a04a-058570f46e47.jpg?1",
             "name": "Commander's Authority",
             "text": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, put a 1/1 white Human creature token onto the battlefield.\"",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "0c857ed6-0c8b-5634-9107-22a39768e521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71a0883-316c-4870-a029-25f16952fbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71a0883-316c-4870-a029-25f16952fbc0.jpg?1",
             "name": "Cursebreak",
             "text": "Destroy target enchantment. You gain 2 life.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "e334cdc8-2614-5d3d-abdf-c1f28f3a0a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12fee0b-c237-4188-a718-1572f72c63ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12fee0b-c237-4188-a718-1572f72c63ba.jpg?1",
             "name": "Defang",
             "text": "Enchant creature\nPrevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -505,7 +505,7 @@
         },
         {
             "id": "241a806b-e40c-55ef-8546-1eaf93d53aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028028d7-80ff-4d63-8b84-795f257a3456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028028d7-80ff-4d63-8b84-795f257a3456.jpg?1",
             "name": "Defy Death",
             "text": "Return target creature card from your graveyard to the battlefield. If it's an Angel, put two +1/+1 counters on it.",
             "colours": [
@@ -537,7 +537,7 @@
         },
         {
             "id": "b88706af-5749-5f33-88e6-f8948542d171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ceb7f1-14b7-4102-ade2-fbeb835d3804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ceb7f1-14b7-4102-ade2-fbeb835d3804.jpg?1",
             "name": "Devout Chaplain",
             "text": "{T}, Tap two untapped Humans you control: Exile target artifact or enchantment.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "92cdca9e-ba50-50ba-abbe-31122727c4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec06e42f-e294-44ef-8fa8-1d1a4c2090d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec06e42f-e294-44ef-8fa8-1d1a4c2090d8.jpg?1",
             "name": "Divine Deflection",
             "text": "Prevent the next X damage that would be dealt to you and/or permanents you control this turn. If damage is prevented this way, Divine Deflection deals that much damage to target creature or player.",
             "colours": [
@@ -604,7 +604,7 @@
         },
         {
             "id": "f88e24d3-1606-5cb8-ac7d-9162d5a59104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bc00e-28ca-4152-b832-f36425d2b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bc00e-28ca-4152-b832-f36425d2b615.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -638,7 +638,7 @@
         },
         {
             "id": "93d5fc46-7b67-5524-a364-83938e9bb944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31292616-70e6-4d19-a883-e63ad860f50c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31292616-70e6-4d19-a883-e63ad860f50c.jpg?1",
             "name": "Entreat the Angels",
             "text": "Put X 4/4 white Angel creature tokens with flying onto the battlefield.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -670,7 +670,7 @@
         },
         {
             "id": "7078f0b7-6fe4-5dfe-ac09-3b96ebfac7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489c6a2f-38b4-4ff9-95f7-431384480ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489c6a2f-38b4-4ff9-95f7-431384480ed9.jpg?1",
             "name": "Farbog Explorer",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "eb14ee08-8ea5-5c82-b25f-587e368a8a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ebec82-9d4a-4e78-b923-37c3a52133e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ebec82-9d4a-4e78-b923-37c3a52133e7.jpg?1",
             "name": "Goldnight Commander",
             "text": "Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "98f51f50-4cdc-57c0-a8fe-0713d01dce57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5656e3-5f53-41f8-9f24-04caad5e4ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5656e3-5f53-41f8-9f24-04caad5e4ca3.jpg?1",
             "name": "Goldnight Redeemer",
             "text": "Flying\nWhen Goldnight Redeemer enters the battlefield, you gain 2 life for each other creature you control.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "66e00850-7250-5e0a-91c5-a5c94a19874b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e92bbb-c22d-4879-9437-b87a3ff70a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e92bbb-c22d-4879-9437-b87a3ff70a2d.jpg?1",
             "name": "Herald of War",
             "text": "Flying\nWhenever Herald of War attacks, put a +1/+1 counter on it.\nAngel spells and Human spells you cast cost {1} less to cast for each +1/+1 counter on Herald of War.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "0b9025d0-02fb-558f-b69e-aeb6cfa78deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cad49-1db3-4611-a80d-7ce95f000fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cad49-1db3-4611-a80d-7ce95f000fad.jpg?1",
             "name": "Holy Justiciar",
             "text": "{2}{W}, {T}: Tap target creature. If that creature is a Zombie, exile it.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "74153b9c-af8a-5f75-8754-be7fea4be20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba52aed-440c-4b32-8f25-0c5364441712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba52aed-440c-4b32-8f25-0c5364441712.jpg?1",
             "name": "Leap of Faith",
             "text": "Target creature gains flying until end of turn. Prevent all damage that would be dealt to that creature this turn.",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "856cb03c-92dd-5224-b366-2913185e978a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371bd0c-ca38-4a62-b525-bef4d1ca0646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371bd0c-ca38-4a62-b525-bef4d1ca0646.jpg?1",
             "name": "Midnight Duelist",
             "text": "Protection from Vampires",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "95192ca6-1a79-51be-8029-ca1aef4d1abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6214f-90cb-4575-b221-3c8d0ed65ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6214f-90cb-4575-b221-3c8d0ed65ffe.jpg?1",
             "name": "Midvast Protector",
             "text": "When Midvast Protector enters the battlefield, target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "290044cc-ace2-5249-a621-41534dddc016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf4c4cf-df35-4725-81ca-d62b70b8d0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf4c4cf-df35-4725-81ca-d62b70b8d0dd.jpg?1",
             "name": "Moonlight Geist",
             "text": "Flying\n{3}{W}: Prevent all combat damage that would be dealt to and dealt by Moonlight Geist this turn.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "0a5e4992-aa45-5d93-8b01-466a46cca2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dbbea-9995-4e4b-ba5c-d6d5597e4ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dbbea-9995-4e4b-ba5c-d6d5597e4ace.jpg?1",
             "name": "Moorland Inquisitor",
             "text": "{2}{W}: Moorland Inquisitor gains first strike until end of turn.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "39d1390d-3ff7-5c7b-a50c-caf2ff262ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81d6fe0-c7c2-46a6-811c-f121284937ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81d6fe0-c7c2-46a6-811c-f121284937ea.jpg?1",
             "name": "Nearheath Pilgrim",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Nearheath Pilgrim is paired with another creature, both creatures have lifelink.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "c091d31c-9544-57df-acbe-7b055b56b1b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8639-e586-47f4-baca-2a1af5aa281b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8639-e586-47f4-baca-2a1af5aa281b.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "0c336c62-4316-5b92-9220-578bf7bf70c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1647b-9271-4426-9938-7eb620ad0769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1647b-9271-4426-9938-7eb620ad0769.jpg?1",
             "name": "Riders of Gavony",
             "text": "Vigilance\nAs Riders of Gavony enters the battlefield, choose a creature type.\nHuman creatures you control have protection from creatures of the chosen type.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "5eb5afc7-9629-5f9d-bfce-c0b36cd520ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b640fdc-7a19-475e-858f-e159f61e154e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b640fdc-7a19-475e-858f-e159f61e154e.jpg?1",
             "name": "Righteous Blow",
             "text": "Righteous Blow deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -1151,7 +1151,7 @@
         },
         {
             "id": "7ca912a5-4157-5d84-b537-cbf6db3830df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da345bd-8f2b-4966-97f5-c0e4c6cfe3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da345bd-8f2b-4966-97f5-c0e4c6cfe3b7.jpg?1",
             "name": "Seraph of Dawn",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "85d54976-1824-5f99-86e7-a1d481eb045a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16298ca0-80d4-4299-a550-500b7ef6ac67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16298ca0-80d4-4299-a550-500b7ef6ac67.jpg?1",
             "name": "Silverblade Paladin",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Silverblade Paladin is paired with another creature, both creatures have double strike.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "08cf2f7c-45bd-5ebe-8293-30932fb07c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f774e0eb-5c05-4a9e-8ab7-9ee4c7741591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f774e0eb-5c05-4a9e-8ab7-9ee4c7741591.jpg?1",
             "name": "Spectral Gateguards",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Spectral Gateguards is paired with another creature, both creatures have vigilance.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "6c4a281a-bcb7-5207-838c-fd5737b5bca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0982ea7e-05a4-4e40-98ab-ea9aa6c7342e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0982ea7e-05a4-4e40-98ab-ea9aa6c7342e.jpg?1",
             "name": "Terminus",
             "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "e3318fe1-0b3d-52ce-87fc-5ae920ccd84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20558f69-9240-49b9-9695-caf75ee2db1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20558f69-9240-49b9-9695-caf75ee2db1b.jpg?1",
             "name": "Thraben Valiant",
             "text": "Vigilance",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "810198a7-1d0b-5430-a9e0-29f9c1397df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b785276b-3778-49f3-b46f-a1f3d91db097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b785276b-3778-49f3-b46f-a1f3d91db097.jpg?1",
             "name": "Voice of the Provinces",
             "text": "Flying\nWhen Voice of the Provinces enters the battlefield, put a 1/1 white Human creature token onto the battlefield.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "321f0392-0cf0-51b8-9c1a-bab1b777f146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a01fb-dd47-44de-b528-8b7ca4b3388b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a01fb-dd47-44de-b528-8b7ca4b3388b.jpg?1",
             "name": "Zealous Strike",
             "text": "Target creature gets +2/+2 and gains first strike until end of turn.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "7993d5ce-462a-5224-b02b-202fd4826abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abba67-1241-4fb3-88b5-4c4668ec5f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31abba67-1241-4fb3-88b5-4c4668ec5f25.jpg?1",
             "name": "Alchemist's Apprentice",
             "text": "Sacrifice Alchemist's Apprentice: Draw a card.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "d335e275-d305-5b83-9afe-2fc247b4e58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b48d60-fc99-4d21-9293-4f7ce1c02928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b48d60-fc99-4d21-9293-4f7ce1c02928.jpg?1",
             "name": "Amass the Components",
             "text": "Draw three cards, then put a card from your hand on the bottom of your library.",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "4e0997a5-a04f-5960-b114-61d0af9372a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32355574-34ed-4427-86d9-72295d32ac4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32355574-34ed-4427-86d9-72295d32ac4f.jpg?1",
             "name": "Arcane Melee",
             "text": "Instant and sorcery spells cost {2} less to cast.",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "a773aba9-a7b2-5c94-9196-0bcadcbe21d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43aa68e-a182-4006-b4d6-b4fc67e68583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43aa68e-a182-4006-b4d6-b4fc67e68583.jpg?1",
             "name": "Captain of the Mists",
             "text": "Whenever another Human enters the battlefield under your control, untap Captain of the Mists.\n{1}{U}, {T}: You may tap or untap target permanent.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "dbc34186-3499-5a03-b655-e434bfbc132e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79791bd9-aded-48d9-866d-9f7bd6848905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79791bd9-aded-48d9-866d-9f7bd6848905.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "66867265-8e32-534c-9195-e7322be214f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa94262b-f740-48fb-a937-75776864c9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa94262b-f740-48fb-a937-75776864c9ee.jpg?1",
             "name": "Deadeye Navigator",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Deadeye Navigator is paired with another creature, each of those creatures has \"{1}{U}: Exile this creature, then return it to the battlefield under your control.\"",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "2bc136dd-bec0-52a2-ab88-3b4f1c6c221a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b62be6-1a80-4f16-a94a-374203052662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b62be6-1a80-4f16-a94a-374203052662.jpg?1",
             "name": "Devastation Tide",
             "text": "Return all nonland permanents to their owners' hands.\nMiracle {1}{U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "dbb38f70-ab7b-5dc7-aff6-97ce07576cf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88245a41-d4d5-46bf-969f-48d4dd540e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88245a41-d4d5-46bf-969f-48d4dd540e2c.jpg?1",
             "name": "Dreadwaters",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of lands you control.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "1162119e-537d-55cd-8c1f-8c130944da62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d376ef-c900-4abb-9a0b-5eb9369f5739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d376ef-c900-4abb-9a0b-5eb9369f5739.jpg?1",
             "name": "Elgaud Shieldmate",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Elgaud Shieldmate is paired with another creature, both creatures have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "707a90f7-d5f7-5f6e-b1d2-d885104ab5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg?1",
             "name": "Favorable Winds",
             "text": "Creatures you control with flying get +1/+1.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "978246c2-aaff-58a8-b742-d8095dc041ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e89ef0e-1bfe-4e12-90ee-38f993cd8110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e89ef0e-1bfe-4e12-90ee-38f993cd8110.jpg?1",
             "name": "Fettergeist",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Fettergeist unless you pay {1} for each other creature you control.",
             "colours": [
@@ -1753,7 +1753,7 @@
         },
         {
             "id": "1451f183-4a75-5409-af6b-9a4789a3d470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba49d16-e3e4-470a-8ca2-a93a5b358f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba49d16-e3e4-470a-8ca2-a93a5b358f6e.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "57ffd28a-f8a6-584d-8b33-38f4c9b8fd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e24d65-0e6f-4978-8de1-c5e4acac12fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e24d65-0e6f-4978-8de1-c5e4acac12fb.jpg?1",
             "name": "Galvanic Alchemist",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Galvanic Alchemist is paired with another creature, each of those creatures has \"{2}{U}: Untap this creature.\"",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "cd8ee5b9-9402-565e-b921-02baf2db6d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dac5db-ef96-4bd5-aabc-e5ae2b95c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dac5db-ef96-4bd5-aabc-e5ae2b95c8c3.jpg?1",
             "name": "Geist Snatch",
             "text": "Counter target creature spell. Put a 1/1 blue Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "c0bb7489-ebcd-5a3f-996d-a08bd92c97c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg?1",
             "name": "Ghostform",
             "text": "Up to two target creatures are unblockable this turn.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "f4cc10e0-3c88-5854-ab91-4de1386cfae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a44373-0c50-4e14-a7c6-0de66796b81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a44373-0c50-4e14-a7c6-0de66796b81e.jpg?1",
             "name": "Ghostly Flicker",
             "text": "Exile two target artifacts, creatures, and/or lands you control, then return those cards to the battlefield under your control.",
             "colours": [
@@ -1916,7 +1916,7 @@
         },
         {
             "id": "617728e3-514b-530a-a563-2986df4c6798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebae54a-47e0-4e82-8a29-b5d9354a748b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebae54a-47e0-4e82-8a29-b5d9354a748b.jpg?1",
             "name": "Ghostly Touch",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, you may tap or untap target permanent.\"",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "3f8fece2-0a15-5df4-8258-7f3b88e81890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7238136-c8de-4949-9b54-ff75094e0569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7238136-c8de-4949-9b54-ff75094e0569.jpg?1",
             "name": "Gryff Vanguard",
             "text": "Flying\nWhen Gryff Vanguard enters the battlefield, draw a card.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "7de9703e-6b9c-5652-898b-1bd9ee8c8249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7ff97f-fb06-4a61-98cd-50965a6522d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7ff97f-fb06-4a61-98cd-50965a6522d4.jpg?1",
             "name": "Havengul Skaab",
             "text": "Whenever Havengul Skaab attacks, return another creature you control to its owner's hand.",
             "colours": [
@@ -2020,7 +2020,7 @@
         },
         {
             "id": "000ed184-57ec-5b1e-a900-5d770a945999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42506c54-e9bf-4d0f-8dd5-8b218668c925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42506c54-e9bf-4d0f-8dd5-8b218668c925.jpg?1",
             "name": "Infinite Reflection",
             "text": "Enchant creature\nWhen Infinite Reflection enters the battlefield attached to a creature, each other nontoken creature you control becomes a copy of that creature.\nNontoken creatures you control enter the battlefield as a copy of enchanted creature.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "3b58a9b0-2455-5529-a416-2eac4a012bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddd1050-8abd-4dfe-9e52-5b56af358653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddd1050-8abd-4dfe-9e52-5b56af358653.jpg?1",
             "name": "Into the Void",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "5360a47e-419c-5812-bef4-a380ad0ed900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e7589-9cee-4d57-8648-ce733781bfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e7589-9cee-4d57-8648-ce733781bfb2.jpg?1",
             "name": "Latch Seeker",
             "text": "Latch Seeker is unblockable.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "531df4fa-eb0a-5063-ae9e-41132abc5bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e12186e-9c93-4136-9ea3-e8d2ae1ee2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e12186e-9c93-4136-9ea3-e8d2ae1ee2e5.jpg?1",
             "name": "Lone Revenant",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Lone Revenant deals combat damage to a player, if you control no other creatures, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "aa30f137-99f5-5536-8a2c-dcebbfd6b7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346d236-528c-4164-9995-74cdc56597a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346d236-528c-4164-9995-74cdc56597a9.jpg?1",
             "name": "Lunar Mystic",
             "text": "Whenever you cast an instant spell, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "ebd0e2c0-bf16-57e3-b9ff-3e56f5626343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9ae51-fd2b-45ca-a780-725f51f897b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9ae51-fd2b-45ca-a780-725f51f897b2.jpg?1",
             "name": "Mass Appeal",
             "text": "Draw a card for each Human you control.",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "a9de2b4a-59f1-55cc-82df-3aa990c6ada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f0c4-021a-407a-8b0c-5500d804f959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f0c4-021a-407a-8b0c-5500d804f959.jpg?1",
             "name": "Mist Raven",
             "text": "Flying\nWhen Mist Raven enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "913a1d0f-fb29-57f2-9156-5ac27f377467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db4fe28-e580-479b-910f-b719d69468b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db4fe28-e580-479b-910f-b719d69468b1.jpg?1",
             "name": "Misthollow Griffin",
             "text": "Flying\nYou may cast Misthollow Griffin from exile.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "b13ddad1-affc-515b-b802-bc794eb5a27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a531b2f-2a9e-4cc9-aea6-9dce239f5511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a531b2f-2a9e-4cc9-aea6-9dce239f5511.jpg?1",
             "name": "Nephalia Smuggler",
             "text": "{3}{U}, {T}: Exile another target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "46294611-e685-5f2e-b100-be327c720fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429f7cf0-579a-4003-b5cf-4baf5d420796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429f7cf0-579a-4003-b5cf-4baf5d420796.jpg?1",
             "name": "Outwit",
             "text": "Counter target spell that targets a player.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "b15e5ead-4055-539e-9833-8a768ab682cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41285b-5961-4653-96a0-fb6d27111390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41285b-5961-4653-96a0-fb6d27111390.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "efe4c9a5-29ca-5629-be93-fdc7c6341e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b5ba6-0de1-4f5c-867b-57e2c10bde8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b5ba6-0de1-4f5c-867b-57e2c10bde8e.jpg?1",
             "name": "Rotcrown Ghoul",
             "text": "When Rotcrown Ghoul dies, target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2422,7 +2422,7 @@
         },
         {
             "id": "33c712ec-25cc-5127-a6f7-765c97c77349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f03bae-1d23-43ea-9079-4b09d61bbadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f03bae-1d23-43ea-9079-4b09d61bbadd.jpg?1",
             "name": "Scrapskin Drake",
             "text": "Flying\nScrapskin Drake can block only creatures with flying.",
             "colours": [
@@ -2457,7 +2457,7 @@
         },
         {
             "id": "792de4bb-9c00-5afa-9819-8688f1865e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d22d093-8e89-4d54-ac04-14c8759de3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d22d093-8e89-4d54-ac04-14c8759de3ea.jpg?1",
             "name": "Second Guess",
             "text": "Counter target spell that's the second spell cast this turn.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "4632015d-608b-5a42-b27c-f604b80fd0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d141bc-7307-40c2-a7ed-427caaec5efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d141bc-7307-40c2-a7ed-427caaec5efc.jpg?1",
             "name": "Spectral Prison",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nWhen enchanted creature becomes the target of a spell, sacrifice Spectral Prison.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "279edbfa-2d00-5e0f-ab43-668387d6491f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8823bdc-0467-47f1-9bef-a281b4a7071d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8823bdc-0467-47f1-9bef-a281b4a7071d.jpg?1",
             "name": "Spirit Away",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "d3cda24d-3839-5116-ad15-957e66a6c76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe4d34f-68f0-4d79-9aab-58c5304224d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe4d34f-68f0-4d79-9aab-58c5304224d9.jpg?1",
             "name": "Stern Mentor",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Stern Mentor is paired with another creature, each of those creatures has \"{T}: Target player puts the top two cards of his or her library into his or her graveyard.\"",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "c774c073-74c4-595d-ba1b-666d7dee2c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53203dfc-5ad5-4c17-9802-ca2f874d327a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53203dfc-5ad5-4c17-9802-ca2f874d327a.jpg?1",
             "name": "Stolen Goods",
             "text": "Target opponent exiles cards from the top of his or her library until he or she exiles a nonland card. Until end of turn, you may cast that card without paying its mana cost.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "b1639e5a-3436-52b2-b977-bab544345fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9398926-13b9-47b8-b66b-1ab9d06bb704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9398926-13b9-47b8-b66b-1ab9d06bb704.jpg?1",
             "name": "Tamiyo, the Moon Sage",
             "text": "+1: Tap target permanent. It doesn't untap during its controller's next untap step.\n-2: Draw a card for each tapped creature target player controls.\n-8: You get an emblem with \"You have no maximum hand size\" and \"Whenever a card is put into your graveyard from anywhere, you may return it to your hand.\"",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "33b275b6-d040-5851-920b-40bc7d4d3e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83564e67-2677-4955-a3b9-3b221dbb100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83564e67-2677-4955-a3b9-3b221dbb100b.jpg?1",
             "name": "Tandem Lookout",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Tandem Lookout is paired with another creature, each of those creatures has \"Whenever this creature deals damage to an opponent, draw a card.\"",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "19b07896-e129-5fcf-841d-8abc2b23be0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266e5267-2288-4bb0-8c54-0c556521cec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266e5267-2288-4bb0-8c54-0c556521cec3.jpg?1",
             "name": "Temporal Mastery",
             "text": "Take an extra turn after this one. Exile Temporal Mastery.\nMiracle {1}{U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "f45d0f07-1dfd-50df-9ea5-10a6f25d01ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece40c1-790c-4471-a790-1d356b345603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece40c1-790c-4471-a790-1d356b345603.jpg?1",
             "name": "Vanishment",
             "text": "Put target nonland permanent on top of its owner's library.\nMiracle {U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "3ed34ffa-4dce-584a-80f7-130865c22d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a3059f-92f2-4163-b79a-154118a4e36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a3059f-92f2-4163-b79a-154118a4e36d.jpg?1",
             "name": "Wingcrafter",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Wingcrafter is paired with another creature, both creatures have flying.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "ec25d579-bd75-55f0-8016-c1d081d271cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062ee892-cce7-42bd-97c7-032cec61faca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062ee892-cce7-42bd-97c7-032cec61faca.jpg?1",
             "name": "Appetite for Brains",
             "text": "Target opponent reveals his or her hand. You choose a card from it with converted mana cost 4 or greater and exile that card.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "505f1717-370e-5b3f-82bf-9a8f7c8a1644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b4fab6-73ce-4a56-a305-4d2e93dbb4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b4fab6-73ce-4a56-a305-4d2e93dbb4ee.jpg?1",
             "name": "Barter in Blood",
             "text": "Each player sacrifices two creatures.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "493ee06d-f040-5e78-9f7e-75f19d556238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1fb442-68ff-4249-8e44-87edf6fae211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1fb442-68ff-4249-8e44-87edf6fae211.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "4d2e5601-07dc-5729-ba78-1ed0add3c3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97485dbf-2f31-4ed2-a6cd-529ca22c9ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97485dbf-2f31-4ed2-a6cd-529ca22c9ac5.jpg?1",
             "name": "Bloodflow Connoisseur",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "1b6aae59-3454-5081-be2e-b7b64e2f461a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387eda28-f35b-48b0-ba59-773d82902327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387eda28-f35b-48b0-ba59-773d82902327.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "511986a6-5629-54d9-982b-27b38331e58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg?1",
             "name": "Butcher Ghoul",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2992,7 +2992,7 @@
         },
         {
             "id": "8b184e27-d0d6-513b-893f-2c9658095cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3eed10-7a8f-4c89-8be8-389f979e10b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3eed10-7a8f-4c89-8be8-389f979e10b7.jpg?1",
             "name": "Corpse Traders",
             "text": "{2}{B}, Sacrifice a creature: Target opponent reveals his or her hand. You choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "a1415a83-cf21-5d47-8089-edd899bd7912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0382cb94-0836-4e23-99b7-034faa363203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0382cb94-0836-4e23-99b7-034faa363203.jpg?1",
             "name": "Crypt Creeper",
             "text": "Sacrifice Crypt Creeper: Exile target card from a graveyard.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "89b2a84b-0367-5d77-a4f5-12dde8a488d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5e8815-cda8-407d-847c-968b72c061e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5e8815-cda8-407d-847c-968b72c061e8.jpg?1",
             "name": "Dark Impostor",
             "text": "{4}{B}{B}: Exile target creature and put a +1/+1 counter on Dark Impostor.\nDark Impostor has all activated abilities of all creature cards exiled with it.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "5e0333c5-b3ef-5d4f-9706-0707d81b152a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a0961-cca5-4d63-867f-7426dbef8639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a0961-cca5-4d63-867f-7426dbef8639.jpg?1",
             "name": "Death Wind",
             "text": "Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "c983a7eb-9b50-5a7f-8d44-0f91463c31ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2136a82-b535-47f6-9eee-5b7585ac5cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2136a82-b535-47f6-9eee-5b7585ac5cf1.jpg?1",
             "name": "Demonic Rising",
             "text": "At the beginning of your end step, if you control exactly one creature, put a 5/5 black Demon creature token with flying onto the battlefield.",
             "colours": [
@@ -3160,7 +3160,7 @@
         },
         {
             "id": "ec037ce2-3c7e-53c6-858f-b04919b875ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5d6266-30a7-4360-84bc-22b52fb782b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5d6266-30a7-4360-84bc-22b52fb782b3.jpg?1",
             "name": "Demonic Taskmaster",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice a creature other than Demonic Taskmaster.",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "dc387c49-263d-5845-b9aa-3a5a32b1db42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785da9a3-09af-45aa-bc04-4ab69cfb2ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785da9a3-09af-45aa-bc04-4ab69cfb2ba4.jpg?1",
             "name": "Demonlord of Ashmouth",
             "text": "Flying\nWhen Demonlord of Ashmouth enters the battlefield, exile it unless you sacrifice another creature.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "5a6d6302-914c-56e5-b9fc-74437be02942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa016bb7-ad8b-40d5-90db-412a9cf19e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa016bb7-ad8b-40d5-90db-412a9cf19e4e.jpg?1",
             "name": "Descent into Madness",
             "text": "At the beginning of your upkeep, put a despair counter on Descent into Madness, then each player exiles X permanents he or she controls and/or cards from his or her hand, where X is the number of despair counters on Descent into Madness.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "d08e9fc9-9599-5ce1-bddd-2f0be9efecb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a3abd-a4a2-48e6-b709-1c0240a76c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a3abd-a4a2-48e6-b709-1c0240a76c5e.jpg?1",
             "name": "Dread Slaver",
             "text": "Whenever a creature dealt damage by Dread Slaver this turn dies, return it to the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "3bf2d69a-ea05-54d2-a8e7-6b30de5a2579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56113cde-4210-46be-bd53-8966c36ef2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56113cde-4210-46be-bd53-8966c36ef2a3.jpg?1",
             "name": "Driver of the Dead",
             "text": "When Driver of the Dead dies, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "de2cfdb0-bddc-5b81-8a02-db653fd63d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3fac03-a019-4faa-bc1c-09e3a394fff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3fac03-a019-4faa-bc1c-09e3a394fff7.jpg?1",
             "name": "Essence Harvest",
             "text": "Target player loses X life and you gain X life, where X is the greatest power among creatures you control.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "3b44c831-6bf0-581b-99fc-6b648a52476f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1091fadf-97c4-4f87-8466-6a1246a72226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1091fadf-97c4-4f87-8466-6a1246a72226.jpg?1",
             "name": "Evernight Shade",
             "text": "{B}: Evernight Shade gets +1/+1 until end of turn.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "feb5dd4f-57f0-54c4-acb9-cca2d402fd9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd54279-57f5-4cd9-b524-4f094bd2fc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd54279-57f5-4cd9-b524-4f094bd2fc36.jpg?1",
             "name": "Exquisite Blood",
             "text": "Whenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "70e540dd-65d2-5cca-b331-d1ff1d41e3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eed3d1b-3142-437c-99e9-85ba76e23e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eed3d1b-3142-437c-99e9-85ba76e23e6d.jpg?1",
             "name": "Ghoulflesh",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 and is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "15294074-17ad-5bd3-9202-3bf7dc8763aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00c711-007d-4c85-9dd9-dd9d52f1649d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b00c711-007d-4c85-9dd9-dd9d52f1649d.jpg?1",
             "name": "Gloom Surgeon",
             "text": "If combat damage would be dealt to Gloom Surgeon, prevent that damage and exile that many cards from the top of your library.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "fc00c8b7-b4c7-5940-bb66-15bfe0ef28c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f420c4-801b-48e7-a10b-de44a2417265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f420c4-801b-48e7-a10b-de44a2417265.jpg?1",
             "name": "Grave Exchange",
             "text": "Return target creature card from your graveyard to your hand. Target player sacrifices a creature.",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "4917126a-6d6a-5084-af17-59784e760b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51666ae-2aef-4cb1-9cd4-44aec81530f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51666ae-2aef-4cb1-9cd4-44aec81530f8.jpg?1",
             "name": "Griselbrand",
             "text": "Flying, lifelink\nPay 7 life: Draw seven cards.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "f3c51097-28a6-550b-9321-d2fd0e5966b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c0d25-dc1f-402e-9183-01c273efe0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c0d25-dc1f-402e-9183-01c273efe0e1.jpg?1",
             "name": "Harvester of Souls",
             "text": "Deathtouch\nWhenever another nontoken creature dies, you may draw a card.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "c23cbd68-7e1e-587a-823c-191675648f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022960a1-8223-4b83-aea2-85359c39f3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022960a1-8223-4b83-aea2-85359c39f3b8.jpg?1",
             "name": "Homicidal Seclusion",
             "text": "As long as you control exactly one creature, that creature gets +3/+1 and has lifelink.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "5f9e3769-4dc9-5ac0-99ac-60c279edd163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1de712-86ac-4c03-be86-2403cd121f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1de712-86ac-4c03-be86-2403cd121f66.jpg?1",
             "name": "Human Frailty",
             "text": "Destroy target Human creature.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "be24332d-ebb2-5f4a-a343-d223845fe610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb443cf7-70bd-4df7-b446-107e099c19e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb443cf7-70bd-4df7-b446-107e099c19e3.jpg?1",
             "name": "Hunted Ghoul",
             "text": "Hunted Ghoul can't block Humans.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "957cc636-3b72-5422-8efb-2ef5d81051b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg?1",
             "name": "Killing Wave",
             "text": "For each creature, its controller sacrifices it unless he or she pays X life.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "d7aa8f82-365d-59ef-a6ae-04638933318d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63dd203-bce9-4ab7-8a0c-059d19d384e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63dd203-bce9-4ab7-8a0c-059d19d384e9.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When Maalfeld Twins dies, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "10b43c03-2e7b-5a96-b167-45997a98fca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38dcbad0-267e-411f-8e99-5d90b537bf9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38dcbad0-267e-411f-8e99-5d90b537bf9b.jpg?1",
             "name": "Marrow Bats",
             "text": "Flying\nPay 4 life: Regenerate Marrow Bats.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "73c4d41f-495e-522c-a724-a13cd357c007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8a1d51-aa7f-41fd-b97d-56bc48221615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8a1d51-aa7f-41fd-b97d-56bc48221615.jpg?1",
             "name": "Mental Agony",
             "text": "Target player discards two cards and loses 2 life.",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "44c58a00-bd3d-5ddc-b198-f8e0b8027d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59918-cf12-4d73-a4e0-31f38e792dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59918-cf12-4d73-a4e0-31f38e792dc4.jpg?1",
             "name": "Necrobite",
             "text": "Target creature gains deathtouch until end of turn. Regenerate it.",
             "colours": [
@@ -3860,7 +3860,7 @@
         },
         {
             "id": "3e8e0af3-ebe2-5dc5-959a-2dd9936c562d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036c1954-37d3-4787-8df8-f2d0dd39058a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036c1954-37d3-4787-8df8-f2d0dd39058a.jpg?1",
             "name": "Polluted Dead",
             "text": "When Polluted Dead dies, destroy target land.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "9f1d8760-0803-5b9a-83ad-dbb118aeafd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88810a96-d5f8-4030-93f1-e2ad0d480317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88810a96-d5f8-4030-93f1-e2ad0d480317.jpg?1",
             "name": "Predator's Gambit",
             "text": "Enchant creature\nEnchanted creature gets +2/+1.\nEnchanted creature has intimidate as long as its controller controls no other creatures. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "85ea88a7-afcd-5964-bec0-26ace610cb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395696f8-9be2-4925-852f-b783850e1ca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395696f8-9be2-4925-852f-b783850e1ca2.jpg?1",
             "name": "Renegade Demon",
             "text": "",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "3e6313e3-0fe2-5a2f-939a-012dbd1dd4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dc1a94-0193-464e-a481-730b34b57db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dc1a94-0193-464e-a481-730b34b57db5.jpg?1",
             "name": "Searchlight Geist",
             "text": "Flying\n{3}{B}: Searchlight Geist gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "444e8d0a-cb7e-5224-b34b-34ceac505fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce1b1d3-9602-42bf-b341-d96976ff1e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce1b1d3-9602-42bf-b341-d96976ff1e60.jpg?1",
             "name": "Soulcage Fiend",
             "text": "When Soulcage Fiend dies, each player loses 3 life.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "4d2c25e8-068a-5aff-93c3-d69c5bfa8b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec7dfd7-d7b2-44fa-b351-022a19fe81b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec7dfd7-d7b2-44fa-b351-022a19fe81b8.jpg?1",
             "name": "Treacherous Pit-Dweller",
             "text": "When Treacherous Pit-Dweller enters the battlefield from a graveyard, target opponent gains control of it.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "9fed4335-91c3-57fe-8b7c-6f9a5805a9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906618e2-2638-4017-9d6e-e6f282967a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906618e2-2638-4017-9d6e-e6f282967a81.jpg?1",
             "name": "Triumph of Cruelty",
             "text": "At the beginning of your upkeep, target opponent discards a card if you control the creature with the greatest power or tied for the greatest power.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "3fa0263e-0720-5173-b10e-d389232ddd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d330058-16af-4486-aa89-b6be759e35d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d330058-16af-4486-aa89-b6be759e35d4.jpg?1",
             "name": "Undead Executioner",
             "text": "When Undead Executioner dies, you may have target creature get -2/-2 until end of turn.",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "4d4c9bf9-a245-59d0-9c43-359fdf0edbe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26d73e6-9138-43b2-8031-6e3b25fa33f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26d73e6-9138-43b2-8031-6e3b25fa33f9.jpg?1",
             "name": "Unhallowed Pact",
             "text": "Enchant creature\nWhen enchanted creature dies, return that card to the battlefield under your control.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "80cc0bb1-f0a2-5cd7-afab-6a4125374665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999f40a7-b723-42e1-83c1-f45a72a26dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999f40a7-b723-42e1-83c1-f45a72a26dd4.jpg?1",
             "name": "Aggravate",
             "text": "Aggravate deals 1 damage to each creature target player controls. Each creature dealt damage this way attacks this turn if able.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "9daa0e09-e1c5-5ab9-8797-687032f1237d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg?1",
             "name": "Archwing Dragon",
             "text": "Flying, haste\nAt the beginning of the end step, return Archwing Dragon to its owner's hand.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "8e71cbe4-1c73-54e0-a37b-a76910051d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7792df3-e2ab-4e60-abee-f24b72807107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7792df3-e2ab-4e60-abee-f24b72807107.jpg?1",
             "name": "Banners Raised",
             "text": "Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "e1ec1f88-d986-5fab-a881-e818eb8630a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5d46e-7054-44f8-9a14-b412f2f0ab86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5d46e-7054-44f8-9a14-b412f2f0ab86.jpg?1",
             "name": "Battle Hymn",
             "text": "Add {R} to your mana pool for each creature you control.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "1635df5b-d2d6-5083-82bc-d6633b10f8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60610fe-891d-46de-b556-d03b637dccec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60610fe-891d-46de-b556-d03b637dccec.jpg?1",
             "name": "Bonfire of the Damned",
             "text": "Bonfire of the Damned deals X damage to target player and each creature he or she controls.\nMiracle {X}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "523f4a1a-e308-5ebc-bb1a-f2b4e6490da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46e9902-81fb-4a3c-9f2f-d3faf031631d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46e9902-81fb-4a3c-9f2f-d3faf031631d.jpg?1",
             "name": "Burn at the Stake",
             "text": "As an additional cost to cast Burn at the Stake, tap any number of untapped creatures you control.\nBurn at the Stake deals damage to target creature or player equal to three times the number of creatures tapped this way.",
             "colours": [
@@ -4358,7 +4358,7 @@
         },
         {
             "id": "5433da49-2a85-5dbd-b2d4-25f615d23e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c4042-703f-4548-9a0f-cb550c468bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c4042-703f-4548-9a0f-cb550c468bf9.jpg?1",
             "name": "Dangerous Wager",
             "text": "Discard your hand, then draw two cards.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "93afdba0-696e-5e76-8be6-917c15d0e147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4657aa15-8274-4bd7-afe4-504693064373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4657aa15-8274-4bd7-afe4-504693064373.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "f75df442-b3c7-5e58-9650-b98cfcaa785d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa45bfd-7075-470d-8aaa-16e34109eb5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa45bfd-7075-470d-8aaa-16e34109eb5a.jpg?1",
             "name": "Dual Casting",
             "text": "Enchant creature\nEnchanted creature has \"{R}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\"",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "c8809724-7402-5a10-9043-1dfacefa2454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e23909-7e08-4686-ae59-e18e7d4cfd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e23909-7e08-4686-ae59-e18e7d4cfd3c.jpg?1",
             "name": "Falkenrath Exterminator",
             "text": "Whenever Falkenrath Exterminator deals combat damage to a player, put a +1/+1 counter on it.\n{2}{R}: Falkenrath Exterminator deals damage to target creature equal to the number of +1/+1 counters on Falkenrath Exterminator.",
             "colours": [
@@ -4491,7 +4491,7 @@
         },
         {
             "id": "83422d16-cca5-5fa9-ae0b-0f9b0b31b51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fceeb14-a22a-4ab6-9e6d-ba375b6865c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fceeb14-a22a-4ab6-9e6d-ba375b6865c0.jpg?1",
             "name": "Fervent Cathar",
             "text": "Haste\nWhen Fervent Cathar enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "25884608-5fc6-5bc8-b742-b42ea9faf121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430b9fa-3bc6-4183-ad5b-d70ad401fa97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430b9fa-3bc6-4183-ad5b-d70ad401fa97.jpg?1",
             "name": "Gang of Devils",
             "text": "When Gang of Devils dies, it deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "303db6d0-28a7-5d7d-a8b6-55aa950462df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb10d42-fa19-400c-bad8-ec3827f077bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb10d42-fa19-400c-bad8-ec3827f077bc.jpg?1",
             "name": "Guise of Fire",
             "text": "Enchant creature\nEnchanted creature gets +1/-1 and attacks each turn if able.",
             "colours": [
@@ -4594,7 +4594,7 @@
         },
         {
             "id": "ef334544-24c3-5c82-b913-b68c516344db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73884fd1-5be9-4ad5-8c72-c0fbe27ad4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73884fd1-5be9-4ad5-8c72-c0fbe27ad4c1.jpg?1",
             "name": "Hanweir Lancer",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Hanweir Lancer is paired with another creature, both creatures have first strike.",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "bb84ea43-98af-56a8-926e-bff858d1b7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc09839-1463-40b8-86bd-fb96797b2633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc09839-1463-40b8-86bd-fb96797b2633.jpg?1",
             "name": "Havengul Vampire",
             "text": "Whenever Havengul Vampire deals combat damage to a player, put a +1/+1 counter on it.\nWhenever another creature dies, put a +1/+1 counter on Havengul Vampire.",
             "colours": [
@@ -4663,7 +4663,7 @@
         },
         {
             "id": "736e27c2-6df7-5dfa-8bb6-eddd6c430de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff89ad3b-b154-49e2-a0fd-135279512250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff89ad3b-b154-49e2-a0fd-135279512250.jpg?1",
             "name": "Heirs of Stromkirk",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever Heirs of Stromkirk deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4697,7 +4697,7 @@
         },
         {
             "id": "41faa04c-2fd2-5bee-b749-22eaad9e0bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg?1",
             "name": "Hound of Griselbrand",
             "text": "Double strike\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4732,7 +4732,7 @@
         },
         {
             "id": "f01eaedc-de56-54db-8db3-3daaa25854ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce9a30f-a850-4826-a255-ce511d567b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce9a30f-a850-4826-a255-ce511d567b60.jpg?1",
             "name": "Kessig Malcontents",
             "text": "When Kessig Malcontents enters the battlefield, it deals damage to target player equal to the number of Humans you control.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "891c9563-cc22-5e9e-8044-ac28c351275c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e72249-84ea-4e9c-9f64-b67b02ffdf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e72249-84ea-4e9c-9f64-b67b02ffdf3a.jpg?1",
             "name": "Kruin Striker",
             "text": "Whenever another creature enters the battlefield under your control, Kruin Striker gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -4802,7 +4802,7 @@
         },
         {
             "id": "1394293b-5ec7-588f-ae89-5e4d65fd9be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241cc968-b93e-4fe3-a66d-7776d29aa023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241cc968-b93e-4fe3-a66d-7776d29aa023.jpg?1",
             "name": "Lightning Mauler",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Lightning Mauler is paired with another creature, both creatures have haste.",
             "colours": [
@@ -4837,7 +4837,7 @@
         },
         {
             "id": "13bc6593-397b-5fd3-94b0-57400f5e62f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5578e3e2-2460-4dfb-9016-527463f2d918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5578e3e2-2460-4dfb-9016-527463f2d918.jpg?1",
             "name": "Lightning Prowess",
             "text": "Enchant creature\nEnchanted creature has haste and \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "d4dcb2af-c4b0-5581-9045-f73dd9405a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172383d9-9135-4daa-a647-9d76435d3158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172383d9-9135-4daa-a647-9d76435d3158.jpg?1",
             "name": "Mad Prophet",
             "text": "Haste\n{T}, Discard a card: Draw a card.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "0a13a00d-4209-53f5-b3cc-97073844fb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dda42d-55eb-46fc-89da-17cc5bfaa823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dda42d-55eb-46fc-89da-17cc5bfaa823.jpg?1",
             "name": "Malicious Intent",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Target creature can't block this turn.\"",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "723d56f2-6b9e-558f-be5a-873186087137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7000-4a1d-4cd4-a85e-4b7b20d8e543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7000-4a1d-4cd4-a85e-4b7b20d8e543.jpg?1",
             "name": "Malignus",
             "text": "Malignus's power and toughness are each equal to half the highest life total among your opponents, rounded up.\nDamage that would be dealt by Malignus can't be prevented.",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "181188e3-2e18-5c20-a120-3f7114113f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c983e879-d9d2-47cc-9958-506711ca80cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c983e879-d9d2-47cc-9958-506711ca80cd.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "e932ffcc-00cb-5403-9707-1ee2a6e6a4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78833788-ffb2-43fc-9345-975f1cd46f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78833788-ffb2-43fc-9345-975f1cd46f38.jpg?1",
             "name": "Raging Poltergeist",
             "text": "",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "3cf44c9d-bd28-5c4c-aaeb-d7c69793a28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36506caa-2630-46ec-9aa0-e1885749ad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36506caa-2630-46ec-9aa0-e1885749ad90.jpg?1",
             "name": "Reforge the Soul",
             "text": "Each player discards his or her hand and draws seven cards.\nMiracle {1}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "8c20905d-6e48-513c-b366-69e3fd2809d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c043f30b-548f-4c31-a415-0e59c2841dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c043f30b-548f-4c31-a415-0e59c2841dcf.jpg?1",
             "name": "Riot Ringleader",
             "text": "Whenever Riot Ringleader attacks, Human creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "3ac2ecee-ab8b-5069-b435-b648aaa4c72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e7fec3-94b5-411e-aeb0-44a64f517986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e7fec3-94b5-411e-aeb0-44a64f517986.jpg?1",
             "name": "Rite of Ruin",
             "text": "Choose an order for artifacts, creatures, and lands. Each player sacrifices one permanent of the first type, sacrifices two of the second type, then sacrifices three of the third type.",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "040f4f73-8993-5859-a45f-071efe987c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2884824-d138-47f2-913b-32cd475e9584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2884824-d138-47f2-913b-32cd475e9584.jpg?1",
             "name": "Rush of Blood",
             "text": "Target creature gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -5172,7 +5172,7 @@
         },
         {
             "id": "c36baa0c-faf7-5c98-9856-541e9218e0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe49a97-dac8-4273-b4dc-45cdf8f5a6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe49a97-dac8-4273-b4dc-45cdf8f5a6e0.jpg?1",
             "name": "Scalding Devil",
             "text": "{2}{R}: Scalding Devil deals 1 damage to target player.",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "f8c98d46-64e1-5add-98d1-f6153d26266c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69eb29-a7e4-4826-9535-9a073136c688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69eb29-a7e4-4826-9535-9a073136c688.jpg?1",
             "name": "Somberwald Vigilante",
             "text": "Whenever Somberwald Vigilante becomes blocked by a creature, Somberwald Vigilante deals 1 damage to that creature.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "ce147123-e51b-53b2-822d-e50348b43aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9564d79d-5f4d-4192-94ee-5e5998011266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9564d79d-5f4d-4192-94ee-5e5998011266.jpg?1",
             "name": "Stonewright",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Stonewright is paired with another creature, each of those creatures has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "b08db5c5-cf17-521f-aa88-5a3ff5798f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28bd68-47a8-47c6-be16-75ae622daf0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28bd68-47a8-47c6-be16-75ae622daf0a.jpg?1",
             "name": "Thatcher Revolt",
             "text": "Put three 1/1 red Human creature tokens with haste onto the battlefield. Sacrifice those tokens at the beginning of the next end step.",
             "colours": [
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "23ff9637-0ccc-5c99-9b63-b7669fe5badf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5845a5bc-6b7d-4bbb-80b3-a0f877b95553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5845a5bc-6b7d-4bbb-80b3-a0f877b95553.jpg?1",
             "name": "Thunderbolt",
             "text": "Choose one \u2014 Thunderbolt deals 3 damage to target player; or Thunderbolt deals 4 damage to target creature with flying.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "cfbbffc0-a0f3-5693-b3db-d71b701e59b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa39826-7f89-41cb-a7fe-7f7be817d5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa39826-7f89-41cb-a7fe-7f7be817d5cd.jpg?1",
             "name": "Thunderous Wrath",
             "text": "Thunderous Wrath deals 5 damage to target creature or player.\nMiracle {R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "17997927-44ed-5e4e-8034-d99d1548a82e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddb3936-8f5a-498d-a46c-27eb9546c76c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddb3936-8f5a-498d-a46c-27eb9546c76c.jpg?1",
             "name": "Tibalt, the Fiend-Blooded",
             "text": "+1: Draw a card, then discard a card at random.\n-4: Tibalt, the Fiend-Blooded deals damage equal to the number of cards in target player's hand to that player.\n-6: Gain control of all creatures until end of turn. Untap them. They gain haste until end of turn.",
             "colours": [
@@ -5408,7 +5408,7 @@
         },
         {
             "id": "a0eeeef6-dfd2-57fd-82ae-0ad8d46e281f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7c8ea-e9c1-4d78-972c-15c4014915a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7c8ea-e9c1-4d78-972c-15c4014915a0.jpg?1",
             "name": "Tyrant of Discord",
             "text": "When Tyrant of Discord enters the battlefield, target opponent chooses a permanent he or she controls at random and sacrifices it. If a nonland permanent is sacrificed this way, repeat this process.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "e6aedc3d-2a7c-5b04-af22-d0e0d3b1469b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b747e-446a-4c25-9834-0be8476dc22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b747e-446a-4c25-9834-0be8476dc22d.jpg?1",
             "name": "Uncanny Speed",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "4d2c0af5-fd0d-59e0-a2db-593acef98ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbefd98-4b17-4cc2-9ef9-8807f594cb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbefd98-4b17-4cc2-9ef9-8807f594cb16.jpg?1",
             "name": "Vexing Devil",
             "text": "When Vexing Devil enters the battlefield, any opponent may have it deal 4 damage to him or her. If a player does, sacrifice Vexing Devil.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "f9180e42-860f-5eb4-ac6c-f0d6b3696c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9db329b-6248-4082-bfc8-5d2c0db43338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9db329b-6248-4082-bfc8-5d2c0db43338.jpg?1",
             "name": "Vigilante Justice",
             "text": "Whenever a Human enters the battlefield under your control, Vigilante Justice deals 1 damage to target creature or player.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "64993ef4-95be-5ed7-8770-3516d2fcd291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027b11-1ecc-430d-a862-586a14bb23c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027b11-1ecc-430d-a862-586a14bb23c3.jpg?1",
             "name": "Zealous Conscripts",
             "text": "Haste\nWhen Zealous Conscripts enters the battlefield, gain control of target permanent until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "4f0b1302-bc1c-5a7c-94eb-67fe2f802729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbc8fd0-dc15-4ac9-b97b-173f7fb66ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbc8fd0-dc15-4ac9-b97b-173f7fb66ed7.jpg?1",
             "name": "Abundant Growth",
             "text": "Enchant land\nWhen Abundant Growth enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "b3c4c464-7207-5cb6-bc64-c444de0687eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16453f1-c6ca-4288-ab72-315ed9bb0ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16453f1-c6ca-4288-ab72-315ed9bb0ab0.jpg?1",
             "name": "Blessings of Nature",
             "text": "Distribute four +1/+1 counters among any number of target creatures.\nMiracle {G} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "0a4bb4fa-982d-5cc3-8698-0e3688ba28f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f067c26-c51d-44d0-a0af-106b5778f06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f067c26-c51d-44d0-a0af-106b5778f06a.jpg?1",
             "name": "Borderland Ranger",
             "text": "When Borderland Ranger enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "5e8b5e6c-c996-5e8f-b4e5-979e874d3125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f0048f-aaa0-4597-b898-ee754d0bbe4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f0048f-aaa0-4597-b898-ee754d0bbe4b.jpg?1",
             "name": "Bower Passage",
             "text": "Creatures with flying can't block creatures you control.",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "c2b3fd2a-1afa-5a8d-8c81-7385bdc9837e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ab9cd3-2faf-4500-a2ee-90b3a8d559c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ab9cd3-2faf-4500-a2ee-90b3a8d559c4.jpg?1",
             "name": "Champion of Lambholt",
             "text": "Creatures with power less than Champion of Lambholt's power can't block creatures you control.\nWhenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "5c5b6753-0cfd-5c8e-9ba5-c31c0b0be3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249be17-73ed-4108-89c0-f7e87939beb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249be17-73ed-4108-89c0-f7e87939beb8.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "9a020248-cb6b-5113-b8ea-38c48d39b0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada93208-5cda-4e2d-b9a7-15345e30b831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada93208-5cda-4e2d-b9a7-15345e30b831.jpg?1",
             "name": "Descendants' Path",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card that shares a creature type with a creature you control, you may cast that card without paying its mana cost. Otherwise, put that card on the bottom of your library.",
             "colours": [
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "29b920b1-f6fb-5272-8283-49cbf34cf396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640e21ad-5064-41bc-886e-2c997f69a3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640e21ad-5064-41bc-886e-2c997f69a3f5.jpg?1",
             "name": "Diregraf Escort",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Diregraf Escort is paired with another creature, both creatures have protection from Zombies.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "8f0e63c2-b748-52dc-8fdf-ae9fb3663c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8c794a-7964-41f0-bc9c-27af7cf87aaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8c794a-7964-41f0-bc9c-27af7cf87aaa.jpg?1",
             "name": "Druid's Familiar",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Druid's Familiar is paired with another creature, each of those creatures gets +2/+2.",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "f829c4c3-3636-5fcd-bcea-0263a1db7c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6fb62-7ee3-444d-8fd4-c1f44014a05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6fb62-7ee3-444d-8fd4-c1f44014a05c.jpg?1",
             "name": "Druids' Repository",
             "text": "Whenever a creature you control attacks, put a charge counter on Druids' Repository.\nRemove a charge counter from Druids' Repository: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "fd5beded-104f-53f6-95bb-fa7a10be31cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efea1b1-f212-4b97-98dd-922f85ab191f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efea1b1-f212-4b97-98dd-922f85ab191f.jpg?1",
             "name": "Eaten by Spiders",
             "text": "Destroy target creature with flying and all Equipment attached to that creature.",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "27e86bb2-ff97-5502-8d16-0dba06b945b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fa2ddc-142b-4562-8812-ecb72e3bae57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fa2ddc-142b-4562-8812-ecb72e3bae57.jpg?1",
             "name": "Flowering Lumberknot",
             "text": "Flowering Lumberknot can't attack or block unless it's paired with a creature with soulbond.",
             "colours": [
@@ -5977,7 +5977,7 @@
         },
         {
             "id": "03e0b91b-c149-5cb6-ba8f-ada3ad1069d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f00a18-0ff7-42e4-be16-aa34fe27093b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f00a18-0ff7-42e4-be16-aa34fe27093b.jpg?1",
             "name": "Geist Trappers",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Geist Trappers is paired with another creature, both creatures have reach.",
             "colours": [
@@ -6012,7 +6012,7 @@
         },
         {
             "id": "d5e16585-f5ce-5bf6-b970-428f123653d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a016c872-09bd-42e1-94da-f587e8252492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a016c872-09bd-42e1-94da-f587e8252492.jpg?1",
             "name": "Gloomwidow",
             "text": "Reach\nGloomwidow can block only creatures with flying.",
             "colours": [
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "372493ae-5b51-55a6-ade3-5d85841541b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4982f0-0ede-4846-82c8-bcf7ad63d099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4982f0-0ede-4846-82c8-bcf7ad63d099.jpg?1",
             "name": "Grounded",
             "text": "Enchant creature\nEnchanted creature loses flying.",
             "colours": [
@@ -6080,7 +6080,7 @@
         },
         {
             "id": "30409c33-1c56-5b5c-86bd-bbf805f39ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad60d45-1c99-41d1-a237-c0ee18ce5361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad60d45-1c99-41d1-a237-c0ee18ce5361.jpg?1",
             "name": "Howlgeist",
             "text": "Creatures with power less than Howlgeist's power can't block it.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "9d1dec3b-43b8-58f2-b09f-63660a66b84a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6516c7c6-d49b-49c5-8968-563622c2c8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6516c7c6-d49b-49c5-8968-563622c2c8c1.jpg?1",
             "name": "Joint Assault",
             "text": "Target creature gets +2/+2 until end of turn. If it's paired with a creature, that creature also gets +2/+2 until end of turn.",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "8b524d36-72ec-52f1-bed0-7d819b12c218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604948d8-6224-45ca-9ebb-d716644bbfd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604948d8-6224-45ca-9ebb-d716644bbfd0.jpg?1",
             "name": "Lair Delve",
             "text": "Reveal the top two cards of your library. Put all creature and land cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "57490094-c06a-56e3-a0bf-d55ab5b06b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d25235-de1c-4b67-9712-24f0564bd2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d25235-de1c-4b67-9712-24f0564bd2bf.jpg?1",
             "name": "Natural End",
             "text": "Destroy target artifact or enchantment. You gain 3 life.",
             "colours": [
@@ -6211,7 +6211,7 @@
         },
         {
             "id": "d4d5d4bc-c1d3-58c0-b221-99cf5a8d7f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75935f0e-9086-485b-b3e6-1a958fd0f2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75935f0e-9086-485b-b3e6-1a958fd0f2af.jpg?1",
             "name": "Nettle Swine",
             "text": "",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "7a84911c-515c-5e89-892b-f0587f5362b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3de66c-2283-458f-9d0d-943027520aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3de66c-2283-458f-9d0d-943027520aa2.jpg?1",
             "name": "Nightshade Peddler",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Nightshade Peddler is paired with another creature, both creatures have deathtouch.",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "4b120470-2494-5e93-abf6-4640dd3aecd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65eded-37ef-4cf0-b55c-390d34aab7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65eded-37ef-4cf0-b55c-390d34aab7b8.jpg?1",
             "name": "Pathbreaker Wurm",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Pathbreaker Wurm is paired with another creature, both creatures have trample.",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "6e2ddd84-2d72-5b9c-b5b6-d020a45c91b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278f7bd-afff-4a1d-a0bb-bf9ce3ad5a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278f7bd-afff-4a1d-a0bb-bf9ce3ad5a2e.jpg?1",
             "name": "Primal Surge",
             "text": "Exile the top card of your library. If it's a permanent card, you may put it onto the battlefield. If you do, repeat this process.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "947064bc-9c8a-5566-895f-f8346a0fd30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1cb530-b9d5-4386-b89e-2acecc8294c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1cb530-b9d5-4386-b89e-2acecc8294c8.jpg?1",
             "name": "Rain of Thorns",
             "text": "Choose one or more \u2014 Destroy target artifact; destroy target enchantment; and/or destroy target land.",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "6ce2576a-8eb1-50d9-a09c-0db945403d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7d663-115c-4ad0-a072-633df054cce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7d663-115c-4ad0-a072-633df054cce4.jpg?1",
             "name": "Revenge of the Hunted",
             "text": "Until end of turn, target creature gets +6/+6 and gains trample, and all creatures able to block it this turn do so.\nMiracle {G} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -6410,7 +6410,7 @@
         },
         {
             "id": "9339bb8b-6f07-50bb-8129-16118b1b6485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cd9be4-1ce4-4a7c-b2a6-98d3fde0a92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cd9be4-1ce4-4a7c-b2a6-98d3fde0a92b.jpg?1",
             "name": "Sheltering Word",
             "text": "Target creature you control gains hexproof until end of turn. You gain life equal to that creature's toughness. (A creature with hexproof can't be the target of spells or abilities opponents control.)",
             "colours": [
@@ -6442,7 +6442,7 @@
         },
         {
             "id": "893948a1-b43f-5c9d-a099-9ccd0f481292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f75827-a144-4fe2-a713-4439ae7567eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f75827-a144-4fe2-a713-4439ae7567eb.jpg?1",
             "name": "Snare the Skies",
             "text": "Target creature gets +1/+1 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "6017e59d-9271-57ed-b267-f3aa46345515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c0272-7a43-4a6c-ab3f-740397b1f5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409c0272-7a43-4a6c-ab3f-740397b1f5c8.jpg?1",
             "name": "Somberwald Sage",
             "text": "{T}: Add three mana of any one color to your mana pool. Spend this mana only to cast creature spells.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "bab0d449-ffc6-5b12-a361-4c339ace82b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078f5e79-18dd-44e5-a930-8dc288f0b535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078f5e79-18dd-44e5-a930-8dc288f0b535.jpg?1",
             "name": "Soul of the Harvest",
             "text": "Trample\nWhenever another nontoken creature enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "6c06c4c2-49a7-5b2f-9ef8-2d22eeb6eebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8d0a22-f31b-45c0-85c7-0101aa63c77b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8d0a22-f31b-45c0-85c7-0101aa63c77b.jpg?1",
             "name": "Terrifying Presence",
             "text": "Prevent all combat damage that would be dealt by creatures other than target creature this turn.",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "c62d8e90-abeb-5ae4-990b-a5c861d93f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae80fefb-af78-4f98-8058-71b61e91842f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae80fefb-af78-4f98-8058-71b61e91842f.jpg?1",
             "name": "Timberland Guide",
             "text": "When Timberland Guide enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -6610,7 +6610,7 @@
         },
         {
             "id": "619b4420-a8ea-5706-860b-6405aa15d3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb41fa6-0cc6-43e5-9aa8-fcd9c781f4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb41fa6-0cc6-43e5-9aa8-fcd9c781f4ce.jpg?1",
             "name": "Triumph of Ferocity",
             "text": "At the beginning of your upkeep, draw a card if you control the creature with the greatest power or tied for the greatest power.",
             "colours": [
@@ -6642,7 +6642,7 @@
         },
         {
             "id": "da01fdcf-47f7-5077-9134-35d932a7d229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee66ef9-10a7-4aab-88f7-84956811cc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee66ef9-10a7-4aab-88f7-84956811cc6c.jpg?1",
             "name": "Trusted Forcemage",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Trusted Forcemage is paired with another creature, each of those creatures gets +1/+1.",
             "colours": [
@@ -6677,7 +6677,7 @@
         },
         {
             "id": "e452ea08-40aa-563e-8660-a2d11ae66fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46199391-a4f5-4532-b89c-b7691b229bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46199391-a4f5-4532-b89c-b7691b229bd0.jpg?1",
             "name": "Ulvenwald Tracker",
             "text": "{1}{G}, {T}: Target creature you control fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "1f595939-3051-52be-86fe-923cacf3660e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg?1",
             "name": "Vorstclaw",
             "text": "",
             "colours": [
@@ -6747,7 +6747,7 @@
         },
         {
             "id": "f311c85b-ebae-532c-8844-4ef45b615398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac606ad5-b8d0-4c93-a9de-5e41229a8229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac606ad5-b8d0-4c93-a9de-5e41229a8229.jpg?1",
             "name": "Wandering Wolf",
             "text": "Creatures with power less than Wandering Wolf's power can't block it.",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "658073a4-d810-5700-a0f6-4f5d293b0ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaa6be7-2c6f-4442-85d1-ae31ad87fd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eaa6be7-2c6f-4442-85d1-ae31ad87fd98.jpg?1",
             "name": "Wild Defiance",
             "text": "Whenever a creature you control becomes the target of an instant or sorcery spell, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "a22efafc-0a30-52ea-8c00-c88d0858161f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4658b4b2-7043-4ca2-96fd-4f663c20c80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4658b4b2-7043-4ca2-96fd-4f663c20c80f.jpg?1",
             "name": "Wildwood Geist",
             "text": "Wildwood Geist gets +2/+2 as long as it's your turn.",
             "colours": [
@@ -6847,7 +6847,7 @@
         },
         {
             "id": "ec6da448-8d30-5606-a758-8462c1bbd3ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cc00e5-9683-4ccc-a914-c422b76f6014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cc00e5-9683-4ccc-a914-c422b76f6014.jpg?1",
             "name": "Wolfir Avenger",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\n{1}{G}: Regenerate Wolfir Avenger.",
             "colours": [
@@ -6882,7 +6882,7 @@
         },
         {
             "id": "f5572a23-e3bf-57e2-936c-c39fdf754fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8629c598-11c8-4911-acfb-0643e5feffa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8629c598-11c8-4911-acfb-0643e5feffa8.jpg?1",
             "name": "Wolfir Silverheart",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Wolfir Silverheart is paired with another creature, each of those creatures gets +4/+4.",
             "colours": [
@@ -6917,7 +6917,7 @@
         },
         {
             "id": "e35300ad-acc7-5c7c-950b-dc3795c59cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9320432-4f89-4363-91e6-2e740535cc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9320432-4f89-4363-91e6-2e740535cc2e.jpg?1",
             "name": "Yew Spirit",
             "text": "{2}{G}{G}: Yew Spirit gets +X/+X until end of turn, where X is its power.",
             "colours": [
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "325f9795-56e3-559c-acab-6162a3e23096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e390bc78-31ad-4131-a9e4-93ee0c7c2f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e390bc78-31ad-4131-a9e4-93ee0c7c2f34.jpg?1",
             "name": "Bruna, Light of Alabaster",
             "text": "Flying, vigilance\nWhenever Bruna, Light of Alabaster attacks or blocks, you may attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "53c760d7-6971-5eec-8c29-fbbffaacedfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7208fcb8-83e6-44ce-af9a-ca1566825018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7208fcb8-83e6-44ce-af9a-ca1566825018.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "9ee79691-5b8c-516a-84f1-3c20818d5605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feccd0e2-fae6-4ced-acdf-4252ed5c56e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feccd0e2-fae6-4ced-acdf-4252ed5c56e7.jpg?1",
             "name": "Sigarda, Host of Herons",
             "text": "Flying, hexproof\nSpells and abilities your opponents control can't cause you to sacrifice permanents.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "f8c9bb51-fe6a-5492-9dd8-b9518568a72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28226303-7e67-4b88-adae-2386aff033ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28226303-7e67-4b88-adae-2386aff033ec.jpg?1",
             "name": "Angel's Tomb",
             "text": "Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.",
             "colours": [],
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "66cba7ff-5c5d-590b-9a29-8402227c78eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa99b48-469d-4112-bdfd-2391fa439514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa99b48-469d-4112-bdfd-2391fa439514.jpg?1",
             "name": "Angelic Armaments",
             "text": "Equipped creature gets +2/+2, has flying, and is a white Angel in addition to its other colors and types.\nEquip {4}",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "63cc10bd-5c44-5020-ade2-76e917203d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a5116-043c-46aa-880e-be8dcb1618bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a5116-043c-46aa-880e-be8dcb1618bc.jpg?1",
             "name": "Bladed Bracers",
             "text": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human or an Angel, it has vigilance.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "d3c594a6-8d14-5cef-9b84-10fc40f3b28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7378e998-0382-42fc-8606-c6e7fc04b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7378e998-0382-42fc-8606-c6e7fc04b6a4.jpg?1",
             "name": "Conjurer's Closet",
             "text": "At the beginning of your end step, you may exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [],
@@ -7182,7 +7182,7 @@
         },
         {
             "id": "3b4a6307-7020-573b-93c5-71be8ad329d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a840ee7-5728-4b1b-92ac-54612e5397b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a840ee7-5728-4b1b-92ac-54612e5397b3.jpg?1",
             "name": "Gallows at Willow Hill",
             "text": "{3}, {T}, Tap three untapped Humans you control: Destroy target creature. Its controller puts a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [],
@@ -7210,7 +7210,7 @@
         },
         {
             "id": "c31e61ac-7bcf-5f08-a2d5-42d2694be2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d97f8b8-bdb0-4d4b-b077-9affe2f9cd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d97f8b8-bdb0-4d4b-b077-9affe2f9cd91.jpg?1",
             "name": "Haunted Guardian",
             "text": "Defender, first strike",
             "colours": [],
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "98425373-4063-54cf-baa2-f5496cd75fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5efb85-1e5f-40ba-97b1-0ef6ac680330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5efb85-1e5f-40ba-97b1-0ef6ac680330.jpg?1",
             "name": "Moonsilver Spear",
             "text": "Equipped creature has first strike.\nWhenever equipped creature attacks, put a 4/4 white Angel creature token with flying onto the battlefield.\nEquip {4}",
             "colours": [],
@@ -7271,7 +7271,7 @@
         },
         {
             "id": "58872471-37fa-531d-b6c1-7a86f912ce9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f808ed9b-95ac-4069-bdca-b100bc816b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f808ed9b-95ac-4069-bdca-b100bc816b5b.jpg?1",
             "name": "Narstad Scrapper",
             "text": "{2}: Narstad Scrapper gets +1/+0 until end of turn.",
             "colours": [],
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "0179ce30-51c8-57f1-be93-b56a660a6d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e4aa67-4643-42ff-8172-200498686494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e4aa67-4643-42ff-8172-200498686494.jpg?1",
             "name": "Otherworld Atlas",
             "text": "{T}: Put a charge counter on Otherworld Atlas.\n{T}: Each player draws a card for each charge counter on Otherworld Atlas.",
             "colours": [],
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "298c74c0-5b87-5603-971b-e283761188b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871e6e2a-7e45-446b-b964-94377eb6ca92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871e6e2a-7e45-446b-b964-94377eb6ca92.jpg?1",
             "name": "Scroll of Avacyn",
             "text": "{1}, Sacrifice Scroll of Avacyn: Draw a card. If you control an Angel, you gain 5 life.",
             "colours": [],
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "a4175f04-18e8-576d-9f1a-329b667d28c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2263ceaf-49d2-40fe-86b8-146271b11e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2263ceaf-49d2-40fe-86b8-146271b11e46.jpg?1",
             "name": "Scroll of Griselbrand",
             "text": "{1}, Sacrifice Scroll of Griselbrand: Target opponent discards a card. If you control a Demon, that player loses 3 life.",
             "colours": [],
@@ -7386,7 +7386,7 @@
         },
         {
             "id": "a0dc02da-49a2-509f-a658-7e562886f5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543d454-27d6-42ba-aad8-54811d180cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543d454-27d6-42ba-aad8-54811d180cfb.jpg?1",
             "name": "Tormentor's Trident",
             "text": "Equipped creature gets +3/+0 and attacks each turn if able.\nEquip {3}",
             "colours": [],
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "9eec313d-6653-5ace-acdd-6156f0f613e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8d9db6-5737-4a1f-ae4e-75821a602784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8d9db6-5737-4a1f-ae4e-75821a602784.jpg?1",
             "name": "Vanguard's Shield",
             "text": "Equipped creature gets +0/+3 and can block an additional creature.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7446,7 +7446,7 @@
         },
         {
             "id": "9773d59f-982d-51d6-8d01-805ffdbc66d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec733373-3f68-47ad-ac35-6f39092f1e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec733373-3f68-47ad-ac35-6f39092f1e26.jpg?1",
             "name": "Vessel of Endless Rest",
             "text": "When Vessel of Endless Rest enters the battlefield, put target card from a graveyard on the bottom of its owner's library.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "2a5f85b7-cde5-5436-b175-216dbf0801c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c767a897-52e3-4401-8104-930157bb2b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c767a897-52e3-4401-8104-930157bb2b02.jpg?1",
             "name": "Alchemist's Refuge",
             "text": "{T}: Add {1} to your mana pool.\n{G}{U}, {T}: You may cast nonland cards this turn as though they had flash.",
             "colours": [],
@@ -7505,7 +7505,7 @@
         },
         {
             "id": "0034b3e0-5f1d-56fc-99f1-0b8f60a5ddf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381c8f1-a292-4bdf-b20c-a5c2a169ee84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381c8f1-a292-4bdf-b20c-a5c2a169ee84.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "1fd4e4be-dec0-5a90-8e5e-9d112ca26255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fb45bc-6152-4b01-9831-a8e80b1c1852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fb45bc-6152-4b01-9831-a8e80b1c1852.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -7564,7 +7564,7 @@
         },
         {
             "id": "9a4f986b-a710-58f9-90bb-2246f7d430b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f903b04a-2733-4ce7-9d83-9db8d5e1e10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f903b04a-2733-4ce7-9d83-9db8d5e1e10d.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "When Seraph Sanctuary enters the battlefield, you gain 1 life.\nWhenever an Angel enters the battlefield under your control, you gain 1 life.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "0e7dbab6-611c-521e-a397-e4c322df1a2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a4351-3ec7-4e6c-8cdd-766bfd670391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a4351-3ec7-4e6c-8cdd-766bfd670391.jpg?1",
             "name": "Slayers' Stronghold",
             "text": "{T}: Add {1} to your mana pool.\n{R}{W}, {T}: Target creature gets +2/+0 and gains vigilance and haste until end of turn.",
             "colours": [],
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "7c7df70c-3bbf-549c-aadf-376bd5697e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f090db87-b7a9-4c88-a211-495b27ae37c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f090db87-b7a9-4c88-a211-495b27ae37c9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7660,7 +7660,7 @@
         },
         {
             "id": "b35af7d3-d686-5aa9-bbdf-6b95daa879b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91348123-e2d0-4acb-ab4e-ec17652b7853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91348123-e2d0-4acb-ab4e-ec17652b7853.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7697,7 +7697,7 @@
         },
         {
             "id": "a95de563-b7b0-5afc-8ec3-ee7eb4541e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca16bd5-e261-4229-a92d-7cd55654dd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca16bd5-e261-4229-a92d-7cd55654dd11.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7734,7 +7734,7 @@
         },
         {
             "id": "bee5dfaa-da2d-5e31-9166-2ad7efb01e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25934479-a47e-45b8-bc35-fc4b659b0d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25934479-a47e-45b8-bc35-fc4b659b0d68.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7771,7 +7771,7 @@
         },
         {
             "id": "7f9fec7e-b46d-5172-bb6f-c71787797df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f920a5-74ea-4b94-8822-5867e6d5017a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f920a5-74ea-4b94-8822-5867e6d5017a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "18ad4b57-245e-51bb-928e-8f6d7960bec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3685e-0ed3-4dc3-9033-8faa10b17c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3685e-0ed3-4dc3-9033-8faa10b17c27.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "ee435f53-78df-506c-b872-218310db1abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339c3f05-444c-4e0a-a556-fc09417ee984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339c3f05-444c-4e0a-a556-fc09417ee984.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7882,7 +7882,7 @@
         },
         {
             "id": "0cd389b6-198d-5838-96b7-86877bdbda2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c57bee-2810-467c-8ed7-6cecb5cbc379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c57bee-2810-467c-8ed7-6cecb5cbc379.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7919,7 +7919,7 @@
         },
         {
             "id": "c3ffc16f-2be6-5c54-a393-6dc6620d1502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a570b2-bcab-4500-b790-252baaf1f6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a570b2-bcab-4500-b790-252baaf1f6d8.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7956,7 +7956,7 @@
         },
         {
             "id": "db12fd6d-5933-5e4f-ab45-341014e0261c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53b7e7e-494b-4346-b18e-0e879bba7cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53b7e7e-494b-4346-b18e-0e879bba7cec.jpg?1",
             "name": "Mountain",
             "text": "B",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "3912e456-0f8b-5492-8572-6c1263c174fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b728a4-c3a9-408e-8333-8266a02c64fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b728a4-c3a9-408e-8333-8266a02c64fa.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "c767168d-690f-5c90-b54e-02742df4e673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e468809-d639-43f0-8834-16e921547dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e468809-d639-43f0-8834-16e921547dee.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "8333c8a3-b761-5053-bb7c-b1359ac9d545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097c9ce-8fe9-4150-9810-52f6c92c6099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097c9ce-8fe9-4150-9810-52f6c92c6099.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8104,7 +8104,7 @@
         },
         {
             "id": "6154b8c2-bb17-5903-9e5f-c23a67ef52c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104987-f678-4ba4-b7f5-69ae7fdc01a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104987-f678-4ba4-b7f5-69ae7fdc01a3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8141,7 +8141,7 @@
         },
         {
             "id": "a31867ec-1cb5-52ed-8245-dfa975640cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4974-fcef-46d1-8baa-6a215f7f3292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4974-fcef-46d1-8baa-6a215f7f3292.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "42d30cfb-64e6-5daf-bec6-fed19aa86fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dd1682-a5d5-4323-b876-66a86c311c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dd1682-a5d5-4323-b876-66a86c311c43.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8212,7 +8212,7 @@
         },
         {
             "id": "1f71dbee-03ad-5988-8f49-4dd36f705b39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894949b-f190-461e-996a-cf2b39f08a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894949b-f190-461e-996a-cf2b39f08a5d.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "ce2518f9-9b10-5646-b0c0-66fe6e097d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e79ba0-33c8-46c8-8694-8bf854345fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e79ba0-33c8-46c8-8694-8bf854345fe7.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8280,7 +8280,7 @@
         },
         {
             "id": "c992e266-a14b-5f4f-90dd-0b271c54c87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c14591-f807-40cf-9c00-4c94b85fff44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c14591-f807-40cf-9c00-4c94b85fff44.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "aad5a6cd-c4be-5a78-8702-7fa09025f049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3fc83f-ab02-4a44-910a-bfadc71cf162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3fc83f-ab02-4a44-910a-bfadc71cf162.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -8348,7 +8348,7 @@
         },
         {
             "id": "ec9a4944-adaf-511f-a79e-40eb615aa5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b877c19d-6022-4377-92e7-4511e24eb98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b877c19d-6022-4377-92e7-4511e24eb98e.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "e4207f06-6f40-59b1-b699-f6e453af79db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef9d-878a-49d8-afe5-86ad18e30c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da1ef9d-878a-49d8-afe5-86ad18e30c3d.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "0675aa73-0756-581d-b2d7-10712b724ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7547c-6d3d-4586-83b2-3d208113b045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7547c-6d3d-4586-83b2-3d208113b045.jpg?1",
             "name": "Tamiyo, the Moon Sage Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/BFZ.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/BFZ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a6ff733f-5c9d-54a5-8476-63223b2a1c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741e62a-4b86-46ff-a7df-a8ceaf3b9a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741e62a-4b86-46ff-a7df-a8ceaf3b9a0c.jpg?1",
             "name": "Bane of Bala Ged",
             "text": "Whenever Bane of Bala Ged attacks, defending player exiles two permanents he or she controls.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "dfa8ba79-c270-52ef-9e56-098d0c663265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3a74-ff78-4041-8137-93356d370ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3a74-ff78-4041-8137-93356d370ece.jpg?1",
             "name": "Blight Herder",
             "text": "When you cast Blight Herder, you may put two cards your opponents own from exile into their owners' graveyards. If you do, put three 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "ea3cfe5f-b709-51bd-8c2d-4f364a9e2229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784e843e-7010-466d-adbd-1dd1595aead1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784e843e-7010-466d-adbd-1dd1595aead1.jpg?1",
             "name": "Breaker of Armies",
             "text": "All creatures able to block Breaker of Armies do so.",
             "colours": [],
@@ -95,7 +95,7 @@
         },
         {
             "id": "74850cf9-020c-5005-9c22-add1ae4358ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc855d3-817c-4748-a7f5-1533d8b0e930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc855d3-817c-4748-a7f5-1533d8b0e930.jpg?1",
             "name": "Conduit of Ruin",
             "text": "When you cast Conduit of Ruin, you may search your library for a colorless creature card with converted mana cost 7 or greater, reveal it, then shuffle your library and put that card on top of it.\nThe first creature spell you cast each turn costs {2} less to cast.",
             "colours": [],
@@ -125,7 +125,7 @@
         },
         {
             "id": "22b1f1d9-1142-5f22-bde1-2a5cbe5accb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f1df-f99a-43c5-81cd-9d333226857a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d98f1df-f99a-43c5-81cd-9d333226857a.jpg?1",
             "name": "Deathless Behemoth",
             "text": "Vigilance\nSacrifice two Eldrazi Scions: Return Deathless Behemoth from your graveyard to your hand. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -155,7 +155,7 @@
         },
         {
             "id": "733e82d7-3bfc-5f41-a026-0cbfb81535a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d229d8d-5e64-4403-a4ae-a0a186a83935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d229d8d-5e64-4403-a4ae-a0a186a83935.jpg?1",
             "name": "Desolation Twin",
             "text": "When you cast Desolation Twin, put a 10/10 colorless Eldrazi creature token onto the battlefield.",
             "colours": [],
@@ -185,7 +185,7 @@
         },
         {
             "id": "5914c6df-b12d-57e6-857b-ad6f8bcc3f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b13e32-01b9-4a86-a3df-ca8b784c6a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b13e32-01b9-4a86-a3df-ca8b784c6a6c.jpg?1",
             "name": "Eldrazi Devastator",
             "text": "Trample",
             "colours": [],
@@ -215,7 +215,7 @@
         },
         {
             "id": "5b4fa9ae-e76e-5ffd-bea5-9bd730bb3e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64820f4f-1f78-4338-beb8-5ed5a447cfe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64820f4f-1f78-4338-beb8-5ed5a447cfe4.jpg?1",
             "name": "Endless One",
             "text": "Endless One enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -245,7 +245,7 @@
         },
         {
             "id": "30e73d85-2e53-522d-bade-b92843c93a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3e464c-3032-4579-8840-4fe75474e3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3e464c-3032-4579-8840-4fe75474e3fb.jpg?1",
             "name": "Gruesome Slaughter",
             "text": "Until end of turn, colorless creatures you control gain \"{T}: This creature deals damage equal to its power to target creature.\"",
             "colours": [],
@@ -273,7 +273,7 @@
         },
         {
             "id": "4f56bba5-16c8-539d-88b0-e19fffc5e2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c550d179-32ec-4ad8-91c2-d79320a21cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c550d179-32ec-4ad8-91c2-d79320a21cba.jpg?1",
             "name": "Kozilek's Channeler",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -303,7 +303,7 @@
         },
         {
             "id": "81daa4ac-86a9-5830-bad2-625006d4e496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e07a4d-8096-4532-bb00-e6e66f1c6843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e07a4d-8096-4532-bb00-e6e66f1c6843.jpg?1",
             "name": "Oblivion Sower",
             "text": "When you cast Oblivion Sower, target opponent exiles the top four cards of his or her library, then you may put any number of land cards that player owns from exile onto the battlefield under your control.",
             "colours": [],
@@ -333,7 +333,7 @@
         },
         {
             "id": "94f4e266-6ecc-5ac6-903f-57dc7100d634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d997088b-f8f9-4e4c-ba64-aa7f43cc7505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d997088b-f8f9-4e4c-ba64-aa7f43cc7505.jpg?1",
             "name": "Ruin Processor",
             "text": "When you cast Ruin Processor, you may put a card an opponent owns from exile into that player's graveyard. If you do, you gain 5 life.",
             "colours": [],
@@ -364,7 +364,7 @@
         },
         {
             "id": "ffbff514-ea66-5ee4-9377-949b381453ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e47edb2-e43d-479f-a911-e72b67a06c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e47edb2-e43d-479f-a911-e72b67a06c3b.jpg?1",
             "name": "Scour from Existence",
             "text": "Exile target permanent.",
             "colours": [],
@@ -392,7 +392,7 @@
         },
         {
             "id": "226047a2-94a3-555d-95eb-e9faa639ac5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d5e3ab-9719-4918-af4f-25bda5401191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d5e3ab-9719-4918-af4f-25bda5401191.jpg?1",
             "name": "Titan's Presence",
             "text": "As an additional cost to cast Titan's Presence, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
             "colours": [],
@@ -420,7 +420,7 @@
         },
         {
             "id": "47cdfd09-d0c8-59b8-ac7b-9856d2813903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1192f7a9-102e-4b3a-b154-18c8eb332217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1192f7a9-102e-4b3a-b154-18c8eb332217.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast Ulamog, the Ceaseless Hunger, exile two target permanents.\nIndestructible\nWhenever Ulamog attacks, defending player exiles the top twenty cards of his or her library.",
             "colours": [],
@@ -452,7 +452,7 @@
         },
         {
             "id": "66919e34-982f-52c8-bbc9-0dbfc8482054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b6b7f0-d7fc-46b6-99ff-ba8206ecd628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b6b7f0-d7fc-46b6-99ff-ba8206ecd628.jpg?1",
             "name": "Ulamog's Despoiler",
             "text": "As Ulamog's Despoiler enters the battlefield, you may put two cards your opponents own from exile into their owners' graveyards. If you do, Ulamog's Despoiler enters the battlefield with four +1/+1 counters on it.",
             "colours": [],
@@ -483,7 +483,7 @@
         },
         {
             "id": "f6333177-12a3-5271-8b7a-fe553cfca48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbedb0a-34ca-4d42-bb43-cbea0f3c6d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbedb0a-34ca-4d42-bb43-cbea0f3c6d02.jpg?1",
             "name": "Void Winnower",
             "text": "Your opponents can't cast spells with even converted mana costs. (Zero is even.)\nYour opponents can't block with creatures with even converted mana costs.",
             "colours": [],
@@ -513,7 +513,7 @@
         },
         {
             "id": "43b74fa9-d360-5966-9a7e-e26c9885d52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f882ac2-3cbc-4548-8c83-d2a7443991df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f882ac2-3cbc-4548-8c83-d2a7443991df.jpg?1",
             "name": "Angel of Renewal",
             "text": "Flying\nWhen Angel of Renewal enters the battlefield, you gain 1 life for each creature you control.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "cd246617-b8c8-5a0d-94da-fcb1e7d8a9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941246b-7d6a-4b2d-8144-f36ac890a389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941246b-7d6a-4b2d-8144-f36ac890a389.jpg?1",
             "name": "Angelic Gift",
             "text": "Enchant creature\nWhen Angelic Gift enters the battlefield, draw a card.\nEnchanted creature has flying.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "d41249df-9e1e-565d-a2ae-e1b9e120f7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c755ae6-badc-4dc8-bfa6-fdebcb00bfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c755ae6-badc-4dc8-bfa6-fdebcb00bfba.jpg?1",
             "name": "Cliffside Lookout",
             "text": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "d7612e06-8c7a-52bb-944a-b545df4d1634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3afc71-f5db-45c3-96b2-8454b7f33542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3afc71-f5db-45c3-96b2-8454b7f33542.jpg?1",
             "name": "Courier Griffin",
             "text": "Flying\nWhen Courier Griffin enters the battlefield, you gain 2 life.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "e95e4214-1529-5977-a231-94ad4dca9583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c366f25-93c7-4088-88a4-64d3ee18a89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c366f25-93c7-4088-88a4-64d3ee18a89a.jpg?1",
             "name": "Emeria Shepherd",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may return target nonland permanent card from your graveyard to your hand. If that land is a Plains, you may return that nonland permanent card to the battlefield instead.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "bb01e473-ad7d-5c9d-b612-29e52fd034fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575da7cb-6715-43df-a7b4-a4ca00216a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575da7cb-6715-43df-a7b4-a4ca00216a1d.jpg?1",
             "name": "Encircling Fissure",
             "text": "Prevent all combat damage that would be dealt this turn by creatures target opponent controls.\nAwaken 2\u2014{4}{W} (If you cast this spell for {4}{W}, also put two +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "ea6bee58-8333-525b-a3a3-e8ec96fe0af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41193ef1-1619-4448-9905-26b05079c79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41193ef1-1619-4448-9905-26b05079c79a.jpg?1",
             "name": "Expedition Envoy",
             "text": "",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "56cb424c-d22d-5242-b2ba-4d1b7f6b8240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea76a183-e15c-4968-b29d-91c074aa8681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea76a183-e15c-4968-b29d-91c074aa8681.jpg?1",
             "name": "Felidar Cub",
             "text": "Sacrifice Felidar Cub: Destroy target enchantment.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "64bebf91-9dd4-5d30-9639-47eee3135ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039499c3-0b35-4e8e-b0c9-bdf0b4cd90d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039499c3-0b35-4e8e-b0c9-bdf0b4cd90d5.jpg?1",
             "name": "Felidar Sovereign",
             "text": "Vigilance, lifelink\nAt the beginning of your upkeep, if you have 40 or more life, you win the game.",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "319fc57c-4e44-522a-b05d-6b11d59bee70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e2ab-a7f5-45bc-8b2f-31198ea27bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5095e2ab-a7f5-45bc-8b2f-31198ea27bba.jpg?1",
             "name": "Fortified Rampart",
             "text": "Defender",
             "colours": [
@@ -858,7 +858,7 @@
         },
         {
             "id": "1bb77732-ad50-5a75-b6f5-67845d1df3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de867066-df5c-4412-9d51-56626b6d0220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de867066-df5c-4412-9d51-56626b6d0220.jpg?1",
             "name": "Ghostly Sentinel",
             "text": "Flying, vigilance",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "5ae34679-cf9a-5de0-a03f-aeb166372c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e887c-c39d-4d25-a506-cdc95fc70316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e887c-c39d-4d25-a506-cdc95fc70316.jpg?1",
             "name": "Gideon, Ally of Zendikar",
             "text": "+1: Until end of turn, Gideon, Ally of Zendikar becomes a 5/5 Human Soldier Ally creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.0: Put a 2/2 white Knight Ally creature token onto the battlefield.\u22124: You get an emblem with \"Creatures you control get +1/+1.\"",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "fe1e7965-df83-5529-9b8e-d9db02130632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d8ec3-15ae-4851-9efb-161ca2ee6019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d8ec3-15ae-4851-9efb-161ca2ee6019.jpg?1",
             "name": "Gideon's Reproach",
             "text": "Gideon's Reproach deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "93c31117-0853-5c86-8982-0b370420155c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg?1",
             "name": "Hero of Goma Fada",
             "text": "Rally \u2014 Whenever Hero of Goma Fada or another Ally enters the battlefield under your control, creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "79e09113-a77e-557c-ba0b-8327f8fdf97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b42ef87-8147-4124-9086-0279d42589c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b42ef87-8147-4124-9086-0279d42589c9.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "aeea404b-c58d-54c0-afdf-17356001e6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a07aad-4ed5-47ae-b04c-9b9919000f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a07aad-4ed5-47ae-b04c-9b9919000f6c.jpg?1",
             "name": "Kitesail Scout",
             "text": "Flying",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "06b1a136-55ab-5f1b-b353-82f115781795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b12c7-df11-4450-95e1-b9a5aa97af0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b12c7-df11-4450-95e1-b9a5aa97af0e.jpg?1",
             "name": "Kor Bladewhirl",
             "text": "Rally \u2014 Whenever Kor Bladewhirl or another Ally enters the battlefield under your control, creatures you control gain first strike until end of turn.",
             "colours": [
@@ -1100,7 +1100,7 @@
         },
         {
             "id": "1f511aee-e57f-52c1-9519-0a88594bcd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db2f0e-d7d4-417b-9b94-5ade727907e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db2f0e-d7d4-417b-9b94-5ade727907e9.jpg?1",
             "name": "Kor Castigator",
             "text": "Kor Castigator can't be blocked by Eldrazi Scions.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "9e72e4b5-48b6-5c2d-83fe-6da3716884d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039ead5-2afa-49d6-ae4a-45ae2118188a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039ead5-2afa-49d6-ae4a-45ae2118188a.jpg?1",
             "name": "Kor Entanglers",
             "text": "Rally \u2014 Whenever Kor Entanglers or another Ally enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -1172,7 +1172,7 @@
         },
         {
             "id": "8621fc9c-e4d6-5978-89e6-46c39c3b8c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg?1",
             "name": "Lantern Scout",
             "text": "Rally \u2014 Whenever Lantern Scout or another Ally enters the battlefield under your control, creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "9c35e8f9-1de6-597c-a134-6a13a24e90ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5a1376-88b3-4bdc-9ce9-e90617e6c55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5a1376-88b3-4bdc-9ce9-e90617e6c55e.jpg?1",
             "name": "Lithomancer's Focus",
             "text": "Target creature gets +2/+2 until end of turn. Prevent all damage that would be dealt to that creature this turn by colorless sources.",
             "colours": [
@@ -1240,7 +1240,7 @@
         },
         {
             "id": "c1b1dbe6-61ed-5357-849d-78c61cc63c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae03f018-3062-4b1c-99b8-13fcffd70b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae03f018-3062-4b1c-99b8-13fcffd70b49.jpg?1",
             "name": "Makindi Patrol",
             "text": "Rally \u2014 Whenever Makindi Patrol or another Ally enters the battlefield under your control, creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "b3af1e61-18ff-56a8-ac44-8014b90cddcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9668e-05dc-41c4-9326-ef4c0e15dd80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9668e-05dc-41c4-9326-ef4c0e15dd80.jpg?1",
             "name": "Ondu Greathorn",
             "text": "First strike\nLandfall \u2014 Whenever a land enters the battlefield under your control, Ondu Greathorn gets +2/+2 until end of turn.",
             "colours": [
@@ -1310,7 +1310,7 @@
         },
         {
             "id": "c333b4a4-caae-5cb2-b767-b66e7b20bb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb9f87-7ba4-408c-952d-fc9a7611df42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb9f87-7ba4-408c-952d-fc9a7611df42.jpg?1",
             "name": "Ondu Rising",
             "text": "Whenever a creature attacks this turn, it gains lifelink until end of turn.\nAwaken 4\u2014{4}{W} (If you cast this spell for {4}{W}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "2b5a89d3-c7ee-5259-b24f-d5c5a47d9151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34f930-a7c6-400d-b6e8-b9908e0f0404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34f930-a7c6-400d-b6e8-b9908e0f0404.jpg?1",
             "name": "Planar Outburst",
             "text": "Destroy all nonland creatures.\nAwaken 4\u2014{5}{W}{W}{W} (If you cast this spell for {5}{W}{W}{W}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "ed5c62fa-15b7-5667-98da-3cf51e57877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c525ab-08d5-4d29-aef1-01b0c75ee8d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c525ab-08d5-4d29-aef1-01b0c75ee8d9.jpg?1",
             "name": "Quarantine Field",
             "text": "Quarantine Field enters the battlefield with X isolation counters on it.\nWhen Quarantine Field enters the battlefield, for each isolation counter on it, exile up to one target nonland permanent an opponent controls until Quarantine Field leaves the battlefield.",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "02cfd7ad-d706-5b6d-86e6-863fb2a89440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65101f-808a-40b8-8864-ee84c00d2496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b65101f-808a-40b8-8864-ee84c00d2496.jpg?1",
             "name": "Retreat to Emeria",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Put a 1/1 white Kor Ally creature token onto the battlefield.\u2022 Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1438,7 +1438,7 @@
         },
         {
             "id": "d0d7b48c-5445-5b0b-898f-ee585f5f32de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de575e-d955-48da-8fc8-05d7398bd261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de575e-d955-48da-8fc8-05d7398bd261.jpg?1",
             "name": "Roil's Retribution",
             "text": "Roil's Retribution deals 5 damage divided as you choose among any number of target attacking or blocking creatures.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "bd8043ee-4f9a-5581-91a2-d95b74688c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f5dd4-4dc7-4e2c-a30b-9286499433d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f5dd4-4dc7-4e2c-a30b-9286499433d8.jpg?1",
             "name": "Serene Steward",
             "text": "Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature.",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "e8c97e17-0abf-590f-be45-cd217091ca6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ffaf62-2e12-4b1d-a590-f63aacb4a30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ffaf62-2e12-4b1d-a590-f63aacb4a30b.jpg?1",
             "name": "Shadow Glider",
             "text": "Flying",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "4be2fbd7-598f-50ce-adb5-a53e083798aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c85fa4-862d-4f94-9531-b62775838ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c85fa4-862d-4f94-9531-b62775838ab9.jpg?1",
             "name": "Sheer Drop",
             "text": "Destroy target tapped creature.\nAwaken 3\u2014{5}{W} (If you cast this spell for {5}{W}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -1573,7 +1573,7 @@
         },
         {
             "id": "fcc0142b-86c9-5853-a828-0998960045df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766aad27-e987-45ab-82aa-e5f44fcc34ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766aad27-e987-45ab-82aa-e5f44fcc34ef.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "0cb375bd-61ef-5b65-916a-8ddcb190fa17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff820544-f4a3-40c4-a48e-84b5e2d06caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff820544-f4a3-40c4-a48e-84b5e2d06caa.jpg?1",
             "name": "Stasis Snare",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Stasis Snare enters the battlefield, exile target creature an opponent controls until Stasis Snare leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -1637,7 +1637,7 @@
         },
         {
             "id": "f21c499f-9625-5db5-8a06-fb5b5bbea838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956563b-bde3-4aec-93fe-e03bade49458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956563b-bde3-4aec-93fe-e03bade49458.jpg?1",
             "name": "Stone Haven Medic",
             "text": "{W}, {T}: You gain 1 life.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "292a2a85-f6af-570d-b7ee-5929dde7cf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8aaf9c-9aa5-44db-9610-402389a3ddc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8aaf9c-9aa5-44db-9610-402389a3ddc5.jpg?1",
             "name": "Tandem Tactics",
             "text": "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "0fdd8e35-479d-5601-baac-d8152ca67831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53472387-6909-462e-8183-02fd1d45126e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53472387-6909-462e-8183-02fd1d45126e.jpg?1",
             "name": "Unified Front",
             "text": "Converge \u2014 Put a 1/1 white Kor Ally creature token onto the battlefield for each color of mana spent to cast Unified Front.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "09ebac3a-adde-538f-8474-b7aee7e969ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d86e0b-294f-41b8-a5cd-d3144a019334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d86e0b-294f-41b8-a5cd-d3144a019334.jpg?1",
             "name": "Adverse Conditions",
             "text": "Devoid (This card has no color.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step. Put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "b7c3fa8e-e293-594b-b248-e9ea65a9dacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380ae58-08cc-42df-ac74-3c6890a62463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f380ae58-08cc-42df-ac74-3c6890a62463.jpg?1",
             "name": "Benthic Infiltrator",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)Benthic Infiltrator can't be blocked.",
             "colours": [],
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "b9f6dde8-f31e-5724-b8f3-7ad2fe10e33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2061f7-5e51-4862-9650-0005002d04b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2061f7-5e51-4862-9650-0005002d04b6.jpg?1",
             "name": "Cryptic Cruiser",
             "text": "Devoid (This card has no color.){2}{U}, Put a card an opponent owns from exile into that player's graveyard: Tap target creature.",
             "colours": [],
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "16b90cb9-0828-5dbb-a14b-2702648ff916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd5b48c-6850-47d4-8106-297be6c8f708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd5b48c-6850-47d4-8106-297be6c8f708.jpg?1",
             "name": "Drowner of Hope",
             "text": "Devoid (This card has no color.)\nWhen Drowner of Hope enters the battlefield, put two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"Sacrifice an Eldrazi Scion: Tap target creature.",
             "colours": [],
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "d062850a-9a8a-55d0-a9ae-47372b26ac5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9c1a10-446e-492a-95cc-a459dc6c08a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9c1a10-446e-492a-95cc-a459dc6c08a0.jpg?1",
             "name": "Eldrazi Skyspawner",
             "text": "Devoid (This card has no color.)\nFlying\nWhen Eldrazi Skyspawner enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "37ad78fc-7305-53fa-b4aa-7b8c1c329d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd05532-686e-40dc-858b-8a77a3628c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd05532-686e-40dc-858b-8a77a3628c99.jpg?1",
             "name": "Horribly Awry",
             "text": "Devoid (This card has no color.)\nCounter target creature spell with converted mana cost 4 or less. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [],
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "46046801-f5fd-5282-b0c5-a1c217a546a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0855762-7068-4111-a6bf-fe6d5b092c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0855762-7068-4111-a6bf-fe6d5b092c74.jpg?1",
             "name": "Incubator Drone",
             "text": "Devoid (This card has no color.)\nWhen Incubator Drone enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "e6871bbd-d7f6-50b8-910f-8c3463e7a315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2e662-d8c3-44d4-b666-fe0d4a046271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2e662-d8c3-44d4-b666-fe0d4a046271.jpg?1",
             "name": "Mist Intruder",
             "text": "Devoid (This card has no color.)\nFlying\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)",
             "colours": [],
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "9294216c-a013-5a6c-940d-f225529856da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130849ba-3893-490d-bfb0-51c76e53cf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130849ba-3893-490d-bfb0-51c76e53cf62.jpg?1",
             "name": "Murk Strider",
             "text": "Devoid (This card has no color.)\nWhen Murk Strider enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target creature to its owner's hand.",
             "colours": [],
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "9dc8043d-f71f-576c-b312-01773b7a14c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c121d73-0c87-4a3f-b013-4f9314e22606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c121d73-0c87-4a3f-b013-4f9314e22606.jpg?1",
             "name": "Oracle of Dust",
             "text": "Devoid (This card has no color.){2}, Put a card an opponent owns from exile into that player's graveyard: Draw a card, then discard a card.",
             "colours": [],
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "a587b7b9-abea-5c98-a499-8957ce40ecad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bdbe64-d985-4bc5-bb1d-4cbf12ef60b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bdbe64-d985-4bc5-bb1d-4cbf12ef60b2.jpg?1",
             "name": "Ruination Guide",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)\nOther colorless creatures you control get +1/+0.",
             "colours": [],
@@ -2092,7 +2092,7 @@
         },
         {
             "id": "36ff2e8a-e476-52ed-acf8-3b0b88a2ddbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8ce2a9-9d8e-442b-bc12-74545ceb65bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8ce2a9-9d8e-442b-bc12-74545ceb65bd.jpg?1",
             "name": "Salvage Drone",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)\nWhen Salvage Drone dies, you may draw a card. If you do, discard a card.",
             "colours": [],
@@ -2125,7 +2125,7 @@
         },
         {
             "id": "f7ad5416-3578-577d-be73-4ace38e9d537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa110cb-f091-48f0-bc62-80f5f18568e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa110cb-f091-48f0-bc62-80f5f18568e8.jpg?1",
             "name": "Spell Shrivel",
             "text": "Devoid (This card has no color.)\nCounter target spell unless its controller pays {4}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [],
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "7a344106-1a72-5048-a19c-89cea1eeb1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c590579-e0ef-4839-8f67-f52813cd9fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c590579-e0ef-4839-8f67-f52813cd9fe7.jpg?1",
             "name": "Tide Drifter",
             "text": "Devoid (This card has no color.)\nOther colorless creatures you control get +0/+1.",
             "colours": [],
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "b7349964-9cc0-5ff9-9eb5-13ba259794c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a237a6-0e72-47ce-b28d-a0260963f406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a237a6-0e72-47ce-b28d-a0260963f406.jpg?1",
             "name": "Ulamog's Reclaimer",
             "text": "Devoid (This card has no color.)\nWhen Ulamog's Reclaimer enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [],
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "460dd1b7-8bd3-59b1-941e-0507a57fddba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c1931-06b4-4c69-9c2f-0dee3543c632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c1931-06b4-4c69-9c2f-0dee3543c632.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "1dea24c8-febb-559a-bf7a-a889ab562df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc4013b-fb4f-4bbe-a15c-488f89545695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc4013b-fb4f-4bbe-a15c-488f89545695.jpg?1",
             "name": "Brilliant Spectrum",
             "text": "Converge \u2014 Draw X cards, where X is the number of colors of mana spent to cast Brilliant Spectrum. Then discard two cards.",
             "colours": [
@@ -2285,7 +2285,7 @@
         },
         {
             "id": "e394f64e-1a56-5b6b-a4e4-56aeed9e7c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1854f819-d08e-4a23-bedb-4618b79623e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1854f819-d08e-4a23-bedb-4618b79623e9.jpg?1",
             "name": "Cloud Manta",
             "text": "Flying",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "012f4e74-fade-55ce-bfab-57630b5b15df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d20f482-e0b2-4e4a-be32-347ab112912c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d20f482-e0b2-4e4a-be32-347ab112912c.jpg?1",
             "name": "Clutch of Currents",
             "text": "Return target creature to its owner's hand.\nAwaken 3\u2014{4}{U} (If you cast this spell for {4}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "9986f842-3fea-5b21-b199-62e59ba65c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df2411-0b0d-4b93-bf30-a22487b3c6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df2411-0b0d-4b93-bf30-a22487b3c6ef.jpg?1",
             "name": "Coastal Discovery",
             "text": "Draw two cards.\nAwaken 4\u2014{5}{U} (If you cast this spell for {5}{U}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2383,7 +2383,7 @@
         },
         {
             "id": "d3e0cbea-70d8-5ec3-bbfa-20d18b9b9243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33787a5b-d1d1-4d60-ba09-d9c98025e9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33787a5b-d1d1-4d60-ba09-d9c98025e9b3.jpg?1",
             "name": "Coralhelm Guide",
             "text": "{4}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "043a8620-eddc-5113-8a54-9d4e607b7ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4393f6-54d7-4963-a3c0-b3a083c2440c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4393f6-54d7-4963-a3c0-b3a083c2440c.jpg?1",
             "name": "Dampening Pulse",
             "text": "Creatures your opponents control get -1/-0.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "918e460b-cd42-5ad6-b32f-fcdcead639c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceab6b3-6b64-4964-a501-ce806a6c13ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceab6b3-6b64-4964-a501-ce806a6c13ad.jpg?1",
             "name": "Dispel",
             "text": "Counter target instant spell.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "77eee0f0-5559-5933-abc0-22924a0518d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35e9d13-ee4b-42f1-a154-18ab32947ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35e9d13-ee4b-42f1-a154-18ab32947ad3.jpg?1",
             "name": "Exert Influence",
             "text": "Converge \u2014 Gain control of target creature if its power is less than or equal to the number of colors of mana spent to cast Exert Influence.",
             "colours": [
@@ -2515,7 +2515,7 @@
         },
         {
             "id": "9863ad0b-e3d0-5213-9663-49181c5c2ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b55cf5e-4499-4e3a-9748-7b1568286b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b55cf5e-4499-4e3a-9748-7b1568286b5a.jpg?1",
             "name": "Guardian of Tazeem",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, tap target creature an opponent controls. If that land is an Island, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2549,7 +2549,7 @@
         },
         {
             "id": "93594dcc-64e7-54ac-89e0-dfd9bafbfb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3e3b18-bf00-4f1a-9918-9a0e9d75b747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3e3b18-bf00-4f1a-9918-9a0e9d75b747.jpg?1",
             "name": "Halimar Tidecaller",
             "text": "When Halimar Tidecaller enters the battlefield, you may return target card with awaken from your graveyard to your hand.\nLand creatures you control have flying.",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "5ca42991-3cd7-5fce-b55d-23809e7f6bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fe992f-0441-42be-89f9-2387b4bc24ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fe992f-0441-42be-89f9-2387b4bc24ce.jpg?1",
             "name": "Part the Waterveil",
             "text": "Take an extra turn after this one. Exile Part the Waterveil.\nAwaken 6\u2014{6}{U}{U}{U} (If you cast this spell for {6}{U}{U}{U}, also put six +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2617,7 +2617,7 @@
         },
         {
             "id": "811dbd1e-76db-5ff7-8eca-2660d519079a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18c46d-dd6b-4feb-9eb3-3d52985ce6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18c46d-dd6b-4feb-9eb3-3d52985ce6e1.jpg?1",
             "name": "Prism Array",
             "text": "Converge \u2014 Prism Array enters the battlefield with a crystal counter on it for each color of mana spent to cast it.\nRemove a crystal counter from Prism Array: Tap target creature.{W}{U}{B}{R}{G}: Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2653,7 +2653,7 @@
         },
         {
             "id": "e8e6086b-0eb7-5b13-a282-39491756e293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68684c8e-dc19-4a56-b511-4e21140b137f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68684c8e-dc19-4a56-b511-4e21140b137f.jpg?1",
             "name": "Retreat to Coralhelm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 You may tap or untap target creature.\u2022 Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "8e97d084-6f32-5001-ac7e-8cd71a8ef373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2194713-c08c-4fba-8e31-bb67c9932173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2194713-c08c-4fba-8e31-bb67c9932173.jpg?1",
             "name": "Roilmage's Trick",
             "text": "Converge \u2014 Creatures your opponents control get -X/-0 until end of turn, where X is the number of colors of mana spent to cast Roilmage's Trick.\nDraw a card.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "9cd805da-cbae-5ebc-91ce-694f35d201c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae6f63-d1b2-4bf9-a423-ed6fbb540d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ae6f63-d1b2-4bf9-a423-ed6fbb540d4b.jpg?1",
             "name": "Rush of Ice",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nAwaken 3\u2014{4}{U} (If you cast this spell for {4}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "c73c4631-2d1d-52cd-9875-2f54c22f3eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ad49f-fe15-4fe5-9731-fd71d31c1e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73ad49f-fe15-4fe5-9731-fd71d31c1e7f.jpg?1",
             "name": "Scatter to the Winds",
             "text": "Counter target spell.\nAwaken 3\u2014{4}{U}{U} (If you cast this spell for {4}{U}{U}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "405dea5b-b3b6-50d9-9cd0-c1d58a7050f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a014dd06-626d-4917-8981-e0064718b571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a014dd06-626d-4917-8981-e0064718b571.jpg?1",
             "name": "Tightening Coils",
             "text": "Enchant creature\nEnchanted creature gets -6/-0 and loses flying.",
             "colours": [
@@ -2815,7 +2815,7 @@
         },
         {
             "id": "76a49258-76a8-5f0c-ac22-dd89196ecb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37d5938-9c8f-4203-8f3f-d6e89ced28ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37d5938-9c8f-4203-8f3f-d6e89ced28ef.jpg?1",
             "name": "Ugin's Insight",
             "text": "Scry X, where X is the highest converted mana cost among permanents you control, then draw three cards.",
             "colours": [
@@ -2847,7 +2847,7 @@
         },
         {
             "id": "c0a41f1b-c030-5670-b85c-0193b8d2ac94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b45809-87fc-409d-942a-1f31f68d27ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b45809-87fc-409d-942a-1f31f68d27ac.jpg?1",
             "name": "Wave-Wing Elemental",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, Wave-Wing Elemental gets +2/+2 until end of turn.",
             "colours": [
@@ -2881,7 +2881,7 @@
         },
         {
             "id": "ae31b545-785d-5e81-a391-a49d9ce4eb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac7b904-7658-4248-a75c-b3a862bde196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac7b904-7658-4248-a75c-b3a862bde196.jpg?1",
             "name": "Windrider Patrol",
             "text": "Flying\nWhenever Windrider Patrol deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "d9e912ef-b482-565d-a408-cac504037632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d94e878-6c49-4420-9d34-f9ee64e811ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d94e878-6c49-4420-9d34-f9ee64e811ba.jpg?1",
             "name": "Complete Disregard",
             "text": "Devoid (This card has no color.)\nExile target creature with power 3 or less.",
             "colours": [],
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "fd1183ad-ae98-5c4b-b93d-97d32b74d999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a623415-46c0-45aa-ab75-1e2d9708013a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a623415-46c0-45aa-ab75-1e2d9708013a.jpg?1",
             "name": "Culling Drone",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)",
             "colours": [],
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "05767988-710c-54ed-a1f0-6b2f4361ac90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e7e2b5-3141-4a19-aa49-91ab7e5c211c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e7e2b5-3141-4a19-aa49-91ab7e5c211c.jpg?1",
             "name": "Dominator Drone",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)\nWhen Dominator Drone enters the battlefield, if you control another colorless creature, each opponent loses 2 life.",
             "colours": [],
@@ -3012,7 +3012,7 @@
         },
         {
             "id": "40c0003b-32d8-5fec-8baa-46c53acb1f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e996a30-3a4d-4a26-8386-f9eb9c999dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e996a30-3a4d-4a26-8386-f9eb9c999dc0.jpg?1",
             "name": "Grave Birthing",
             "text": "Devoid (This card has no color.)\nTarget opponent exiles a card from his or her graveyard. You put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"Draw a card.",
             "colours": [],
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "d68066e4-c4e0-5b47-8a21-d19ed3a449c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850b388a-c188-433a-8124-1d51b43a4e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850b388a-c188-433a-8124-1d51b43a4e51.jpg?1",
             "name": "Grip of Desolation",
             "text": "Devoid (This card has no color.)\nExile target creature and target land.",
             "colours": [],
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "09be79b7-c83b-5faa-9d91-b64a57079fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d07fea-e16a-45e3-a172-9d726cd42769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d07fea-e16a-45e3-a172-9d726cd42769.jpg?1",
             "name": "Mind Raker",
             "text": "Devoid (This card has no color.)\nWhen Mind Raker enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, each opponent discards a card.",
             "colours": [],
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "159409a6-59e0-5622-bd86-75387c21c12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b715fc0-9c36-4619-8d65-6d1064ed8a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b715fc0-9c36-4619-8d65-6d1064ed8a32.jpg?1",
             "name": "Silent Skimmer",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever Silent Skimmer attacks, defending player loses 2 life.",
             "colours": [],
@@ -3138,7 +3138,7 @@
         },
         {
             "id": "949be71e-35f7-5253-9645-698dfb0986a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cbecdc-bc30-4797-bf6f-a7a61db05b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cbecdc-bc30-4797-bf6f-a7a61db05b48.jpg?1",
             "name": "Skitterskin",
             "text": "Devoid (This card has no color.)Skitterskin can't block.{1}{B}: Regenerate Skitterskin. Activate this ability only if you control another colorless creature.",
             "colours": [],
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "c58bda48-7dc3-5c01-b63f-58d011ef32dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9782b463-0677-40f4-ab2c-4c3ff19f1168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9782b463-0677-40f4-ab2c-4c3ff19f1168.jpg?1",
             "name": "Sludge Crawler",
             "text": "Devoid (This card has no color.)\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.){2}: Sludge Crawler gets +1/+1 until end of turn.",
             "colours": [],
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "46b65a4d-396b-55ff-a408-8c9c7c1b1471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81d0de-01a3-4f28-8a2b-c2e6f36a03c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81d0de-01a3-4f28-8a2b-c2e6f36a03c4.jpg?1",
             "name": "Smothering Abomination",
             "text": "Devoid (This card has no color.)\nFlying\nAt the beginning of your upkeep, sacrifice a creature.\nWhenever you sacrifice a creature, draw a card.",
             "colours": [],
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "8d2a80df-9144-547a-8a6f-51ab63fc9271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837287cc-f3a4-4ba7-8518-9b1e4a53acda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837287cc-f3a4-4ba7-8518-9b1e4a53acda.jpg?1",
             "name": "Swarm Surge",
             "text": "Devoid (This card has no color.)\nCreatures you control get +2/+0 until end of turn. Colorless creatures you control also gain first strike until end of turn.",
             "colours": [],
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "29ba7037-2b75-5c93-96c4-0f6be2cf6520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5742910-3d0f-4710-a5f5-f7a7908833dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5742910-3d0f-4710-a5f5-f7a7908833dc.jpg?1",
             "name": "Transgress the Mind",
             "text": "Devoid (This card has no color.)\nTarget player reveals his or her hand. You choose a card from it with converted mana cost 3 or greater and exile that card.",
             "colours": [],
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "b2b9b572-8bc5-5958-95c6-00e80d4ae100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e215ab0-efd6-4ea2-8bd2-0a93865e1e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e215ab0-efd6-4ea2-8bd2-0a93865e1e3c.jpg?1",
             "name": "Wasteland Strangler",
             "text": "Devoid (This card has no color.)\nWhen Wasteland Strangler enters the battlefield, you may put a card an opponent owns from exile into that player's graveyard. If you do, target creature gets -3/-3 until end of turn.",
             "colours": [],
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "c1f29695-767f-5b55-ba3d-ec61c93d2312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ca3f24-eb14-46fe-9a7a-3752f706d067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ca3f24-eb14-46fe-9a7a-3752f706d067.jpg?1",
             "name": "Altar's Reap",
             "text": "As an additional cost to cast Altar's Reap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "1785dbb1-354e-50cb-b2c4-b9116c1c2d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca31ce70-24c5-4fb2-8d88-c9ffa8474c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca31ce70-24c5-4fb2-8d88-c9ffa8474c8f.jpg?1",
             "name": "Bloodbond Vampire",
             "text": "Whenever you gain life, put a +1/+1 counter on Bloodbond Vampire.",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "4bd12a68-fa94-53f8-90ff-071224fc4131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74780faa-1c64-4d73-8d09-53b47ba02d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74780faa-1c64-4d73-8d09-53b47ba02d7a.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "8ac00196-9b73-5a9d-b889-d2507f8e0b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2ab895-9225-4eba-90c3-4023db4f8b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2ab895-9225-4eba-90c3-4023db4f8b70.jpg?1",
             "name": "Carrier Thrall",
             "text": "When Carrier Thrall dies, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "386c74f0-9b01-508e-86bf-2e1f0713a2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b5dd64-9e58-4f22-9d86-7a518d976037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b5dd64-9e58-4f22-9d86-7a518d976037.jpg?1",
             "name": "Defiant Bloodlord",
             "text": "Flying\nWhenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "9c72b004-a983-5593-a568-f1905ec3ed8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff953948-db26-43af-9905-7d387769b4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff953948-db26-43af-9905-7d387769b4a9.jpg?1",
             "name": "Demon's Grasp",
             "text": "Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "66555fc7-38c6-5c1d-863a-7642fe6e5e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f6ed18-eb6f-4d07-8660-cf7c074c87cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f6ed18-eb6f-4d07-8660-cf7c074c87cd.jpg?1",
             "name": "Drana, Liberator of Malakir",
             "text": "Flying, first strike\nWhenever Drana, Liberator of Malakir deals combat damage to a player, put a +1/+1 counter on each attacking creature you control.",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "af4fa59c-8f63-556d-8a4b-10814caf68f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d6cb71-c911-4f82-93e9-654e8ffa85c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d6cb71-c911-4f82-93e9-654e8ffa85c9.jpg?1",
             "name": "Dutiful Return",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "e424a07f-69e2-508b-8af6-901bed70099b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d1e1e1-fa24-4e78-a77c-4d41a58b8aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d1e1e1-fa24-4e78-a77c-4d41a58b8aa0.jpg?1",
             "name": "Geyserfield Stalker",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, Geyserfield Stalker gets +2/+2 until end of turn.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "6e5616f0-efde-5360-bd5b-c37b9ab8d93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793bb4e0-8fdd-440e-9e6e-92a899794cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793bb4e0-8fdd-440e-9e6e-92a899794cae.jpg?1",
             "name": "Guul Draz Overseer",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, other creatures you control get +1/+0 until end of turn. If that land is a Swamp, those creatures get +2/+0 until end of turn instead.",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "83f1ff24-22b0-586a-81fa-d7baa6cebd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706b2e3-bd0e-4111-8b68-976869c7d707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706b2e3-bd0e-4111-8b68-976869c7d707.jpg?1",
             "name": "Hagra Sharpshooter",
             "text": "{4}{B}: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "51aa0f08-ace5-593b-ac45-3ffe2fdd34d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c21cb3-21f4-4a8d-8068-52649f2a1846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c21cb3-21f4-4a8d-8068-52649f2a1846.jpg?1",
             "name": "Kalastria Healer",
             "text": "Rally \u2014 Whenever Kalastria Healer or another Ally enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "b2b8310d-5533-56eb-b20c-1cb818fd7edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13989bf2-fd02-4702-9170-4b066837de65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13989bf2-fd02-4702-9170-4b066837de65.jpg?1",
             "name": "Kalastria Nightwatch",
             "text": "Whenever you gain life, Kalastria Nightwatch gains flying until end of turn.",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "bbc49cb1-bfac-5144-a227-d37c24191a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f03b00a-f6d0-419a-abfd-fa8bc63226db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f03b00a-f6d0-419a-abfd-fa8bc63226db.jpg?1",
             "name": "Malakir Familiar",
             "text": "Flying, deathtouch\nWhenever you gain life, Malakir Familiar gets +1/+1 until end of turn.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "64362925-f2b4-5d79-b29d-9ac7728fcf4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d737fb-fd09-4483-8128-8897cbcdc4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d737fb-fd09-4483-8128-8897cbcdc4f5.jpg?1",
             "name": "Mire's Malice",
             "text": "Target opponent discards two cards.\nAwaken 3\u2014{5}{B} (If you cast this spell for {5}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "3c670188-d515-5967-94c9-d0de8c1fcd5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca43ea1-ba7b-4dc7-b6f6-a0c92321ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca43ea1-ba7b-4dc7-b6f6-a0c92321ebe1.jpg?1",
             "name": "Nirkana Assassin",
             "text": "Whenever you gain life, Nirkana Assassin gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3876,7 +3876,7 @@
         },
         {
             "id": "84682207-f123-57a0-af12-22750a232488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b2d6e9-2a43-4ebe-9ae8-944375b46cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b2d6e9-2a43-4ebe-9ae8-944375b46cce.jpg?1",
             "name": "Ob Nixilis Reignited",
             "text": "+1: You draw a card and you lose 1 life.\u22123: Destroy target creature.\u22128: Target opponent gets an emblem with \"Whenever a player draws a card, you lose 2 life.\"",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "a3cccf34-9318-5d47-9907-814ad54c0e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a3afdb-aeb2-4699-91f9-5c42284b3a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a3afdb-aeb2-4699-91f9-5c42284b3a4a.jpg?1",
             "name": "Painful Truths",
             "text": "Converge \u2014 You draw X cards and you lose X life, where X is the number of colors of mana spent to cast Painful Truths.",
             "colours": [
@@ -3944,7 +3944,7 @@
         },
         {
             "id": "8d2a7c53-d986-5521-82b5-de480219e9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48505c90-ee73-40ad-b774-a6f4bfffff4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48505c90-ee73-40ad-b774-a6f4bfffff4b.jpg?1",
             "name": "Retreat to Hagra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Target creature gets +1/+0 and gains deathtouch until end of turn.\u2022 Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "a1e0d3b2-8b76-5727-9e27-a8048c8a5030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9a8e87-3b8b-4dbf-9c1e-0a3290a33a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9a8e87-3b8b-4dbf-9c1e-0a3290a33a0b.jpg?1",
             "name": "Rising Miasma",
             "text": "All creatures get -2/-2 until end of turn.\nAwaken 3\u2014{5}{B}{B} (If you cast this spell for {5}{B}{B}, also put three +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "07f02c9c-6fbe-57c7-8cd0-ba7ea8d0f111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709ab9cf-eed8-4d73-b10d-c7f6d8750328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709ab9cf-eed8-4d73-b10d-c7f6d8750328.jpg?1",
             "name": "Ruinous Path",
             "text": "Destroy target creature or planeswalker.\nAwaken 4\u2014{5}{B}{B} (If you cast this spell for {5}{B}{B}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "92f64c2a-78a6-59bb-ad03-ec150a705fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416309a-5824-48f5-876e-00e0f180acf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416309a-5824-48f5-876e-00e0f180acf9.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "d714c755-d296-52bf-aa44-8414a1ffb9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74364056-f4ee-46d3-834d-a5157ec312b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74364056-f4ee-46d3-834d-a5157ec312b9.jpg?1",
             "name": "Voracious Null",
             "text": "{1}{B}, Sacrifice another creature: Put two +1/+1 counters on Voracious Null. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "db9ec4e8-d4e6-57e7-9aaa-c02b56875a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c963d97-c948-45d9-84cc-58e246d35970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c963d97-c948-45d9-84cc-58e246d35970.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "f9b10401-1ce7-5bc1-989d-831356ef6306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a83120-c0c5-4277-acae-6ecb6f6bf3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a83120-c0c5-4277-acae-6ecb6f6bf3e1.jpg?1",
             "name": "Barrage Tyrant",
             "text": "Devoid (This card has no color.){2}{R}, Sacrifice another colorless creature: Barrage Tyrant deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [],
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "978dc2b1-19ef-559f-9180-9db0e789b0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63352c11-807d-4878-a975-02ef451c3184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63352c11-807d-4878-a975-02ef451c3184.jpg?1",
             "name": "Crumble to Dust",
             "text": "Devoid (This card has no color.)\nExile target nonbasic land. Search its controller's graveyard, hand, and library for any number of cards with the same name as that land and exile them. Then that player shuffles his or her library.",
             "colours": [],
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "bfc55522-1119-5b1f-9e27-485da5d54712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c6a0f-3f75-45ff-aae9-5c866be279d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c6a0f-3f75-45ff-aae9-5c866be279d0.jpg?1",
             "name": "Kozilek's Sentinel",
             "text": "Devoid (This card has no color.)\nWhenever you cast a colorless spell, Kozilek's Sentinel gets +1/+0 until end of turn.",
             "colours": [],
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "e5c95e71-5b8d-5f51-a3db-7d6ac988b7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8aaf5-e2bf-40ea-bd5d-663017cfd4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8aaf5-e2bf-40ea-bd5d-663017cfd4a6.jpg?1",
             "name": "Molten Nursery",
             "text": "Devoid (This card has no color.)\nWhenever you cast a colorless spell, Molten Nursery deals 1 damage to target creature or player.",
             "colours": [],
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "5d94a7f2-930d-5b52-aaf4-433cc89432d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e633833a-cc4b-4c8c-a0d3-cd263e09df81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e633833a-cc4b-4c8c-a0d3-cd263e09df81.jpg?1",
             "name": "Nettle Drone",
             "text": "Devoid (This card has no color.){T}: Nettle Drone deals 1 damage to each opponent.\nWhenever you cast a colorless spell, untap Nettle Drone.",
             "colours": [],
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "9c58bb8b-769d-5b0c-96a9-79eb248ac5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a689975-d27b-4b8f-8d46-6e97c754ae81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a689975-d27b-4b8f-8d46-6e97c754ae81.jpg?1",
             "name": "Processor Assault",
             "text": "Devoid (This card has no color.)\nAs an additional cost to cast Processor Assault, put a card an opponent owns from exile into that player's graveyard.Processor Assault deals 5 damage to target creature.",
             "colours": [],
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "cbbdc21a-853d-5a71-a45f-8c7d3c7d31be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53222f33-6d18-4008-a38d-6f7995691260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53222f33-6d18-4008-a38d-6f7995691260.jpg?1",
             "name": "Serpentine Spike",
             "text": "Devoid (This card has no color.)Serpentine Spike deals 2 damage to target creature, 3 damage to another target creature, and 4 damage to a third target creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [],
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "5749a517-a4be-5f11-b3ba-c0d62e585378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006ead4a-dc57-4856-8e13-235ba55483e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006ead4a-dc57-4856-8e13-235ba55483e6.jpg?1",
             "name": "Touch of the Void",
             "text": "Devoid (This card has no color.)Touch of the Void deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [],
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "5ddb2bad-e84c-5034-b3bb-a53e614f28c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de8ef35-f141-4bc6-8ea1-f87aa6f5ecd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de8ef35-f141-4bc6-8ea1-f87aa6f5ecd7.jpg?1",
             "name": "Turn Against",
             "text": "Devoid (This card has no color.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [],
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "596bc95b-8993-5bc6-a740-09f68331a6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d84986-64a1-4bd1-a4f6-3eb147aca357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d84986-64a1-4bd1-a4f6-3eb147aca357.jpg?1",
             "name": "Vestige of Emrakul",
             "text": "Devoid (This card has no color.)\nTrample",
             "colours": [],
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "29d10c5f-ed45-55fc-aadc-027f1bafaa98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec66525-a7e9-450f-83df-03d9957837d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec66525-a7e9-450f-83df-03d9957837d5.jpg?1",
             "name": "Vile Aggregate",
             "text": "Devoid (This card has no color.)Vile Aggregate's power is equal to the number of colorless creatures you control.\nTrample\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.)",
             "colours": [],
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "ae2cba2e-b82b-54fe-a3a3-643da5c075d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304a2e4c-da2c-43fb-b44d-9db55ff94f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304a2e4c-da2c-43fb-b44d-9db55ff94f04.jpg?1",
             "name": "Akoum Firebird",
             "text": "Flying, hasteAkoum Firebird attacks each turn if able.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may pay {4}{R}{R}. If you do, return Akoum Firebird from your graveyard to the battlefield.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "da3e0034-0da0-571a-9ffa-9cefd2543284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce837a65-a588-4b50-b298-f4ca37dbd06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce837a65-a588-4b50-b298-f4ca37dbd06d.jpg?1",
             "name": "Akoum Hellkite",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, Akoum Hellkite deals 1 damage to target creature or player. If that land is a Mountain, Akoum Hellkite deals 2 damage to that creature or player instead.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "bc787458-d536-52d2-b1d3-388272573021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ab7b5-6a29-463e-b294-3cb0efaccddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ab7b5-6a29-463e-b294-3cb0efaccddb.jpg?1",
             "name": "Akoum Stonewaker",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {2}{R}. If you do, put a 3/1 red Elemental creature token with trample and haste onto the battlefield. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "7ccf707b-6177-5ea8-b517-da993ae2b654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b5b7d2-acb8-4aca-b9e7-67e59aeb384b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b5b7d2-acb8-4aca-b9e7-67e59aeb384b.jpg?1",
             "name": "Belligerent Whiptail",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Belligerent Whiptail gains first strike until end of turn.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "9e2eef4e-7b72-5bbd-b612-e6fbfc7c5da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaab44c-4ce1-43fb-915c-c687fe8559ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaab44c-4ce1-43fb-915c-c687fe8559ce.jpg?1",
             "name": "Boiling Earth",
             "text": "Boiling Earth deals 1 damage to each creature your opponents control.\nAwaken 4\u2014{6}{R} (If you cast this spell for {6}{R}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "218af701-ab0d-56a7-9ff2-5a1b8f20026a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd0fad7-264d-40fc-a616-a88dc94fa4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd0fad7-264d-40fc-a616-a88dc94fa4d7.jpg?1",
             "name": "Chasm Guide",
             "text": "Rally \u2014 Whenever Chasm Guide or another Ally enters the battlefield under your control, creatures you control gain haste until end of turn.",
             "colours": [
@@ -4691,7 +4691,7 @@
         },
         {
             "id": "75b796f3-2b2a-57e6-9eac-1f4a06e26495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d1424-03c8-443b-a3bc-14bb168e32c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d1424-03c8-443b-a3bc-14bb168e32c9.jpg?1",
             "name": "Dragonmaster Outcast",
             "text": "At the beginning of your upkeep, if you control six or more lands, put a 5/5 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "aded6d73-f61b-528c-ad3e-ce93213b37de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197411bf-3307-4056-a7d4-31db0d4b8f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197411bf-3307-4056-a7d4-31db0d4b8f9a.jpg?1",
             "name": "Firemantle Mage",
             "text": "Rally \u2014 Whenever Firemantle Mage or another Ally enters the battlefield under your control, creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "b42b488c-41d3-520c-b330-ab0a857a0690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ff3183-c273-4a61-ad25-526db29111c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ff3183-c273-4a61-ad25-526db29111c8.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -4796,7 +4796,7 @@
         },
         {
             "id": "0b19e75f-d1e6-5c97-be4d-4703bd5708a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428f13f-c445-4eb4-bab1-309f27cab208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2428f13f-c445-4eb4-bab1-309f27cab208.jpg?1",
             "name": "Lavastep Raider",
             "text": "{2}{R}: Lavastep Raider gets +2/+0 until end of turn.",
             "colours": [
@@ -4831,7 +4831,7 @@
         },
         {
             "id": "b173eab2-c7c5-5f66-89a9-1e7dc63116f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6da400-ee4e-44d1-887d-1e2fb59b9322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6da400-ee4e-44d1-887d-1e2fb59b9322.jpg?1",
             "name": "Makindi Sliderunner",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Makindi Sliderunner gets +1/+1 until end of turn.",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "c667bddb-a65b-539e-a6ae-2465e0179b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708e1979-902b-410a-ae46-3fd1d2acc31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708e1979-902b-410a-ae46-3fd1d2acc31d.jpg?1",
             "name": "Ondu Champion",
             "text": "Rally \u2014 Whenever Ondu Champion or another Ally enters the battlefield under your control, creatures you control gain trample until end of turn.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "b0409791-7818-5225-b284-9efa9655fa81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3373281-7319-4320-8afb-4546fb55ab4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3373281-7319-4320-8afb-4546fb55ab4c.jpg?1",
             "name": "Outnumber",
             "text": "Outnumber deals damage to target creature equal to the number of creatures you control.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "2a98eb58-b457-58ca-8d33-6fcf4a6ee760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f4fe69-c541-4320-9074-9c6a3bc70ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f4fe69-c541-4320-9074-9c6a3bc70ea3.jpg?1",
             "name": "Radiant Flames",
             "text": "Converge \u2014 Radiant Flames deals X damage to each creature, where X is the number of colors of mana spent to cast Radiant Flames.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "6a5ef048-6f1f-507b-984d-2cf81a9c69c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a4cdec-e5fc-4ea8-a7bc-f1109fadae3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a4cdec-e5fc-4ea8-a7bc-f1109fadae3c.jpg?1",
             "name": "Reckless Cohort",
             "text": "Reckless Cohort attacks each combat if able unless you control another Ally.",
             "colours": [
@@ -5001,7 +5001,7 @@
         },
         {
             "id": "b96581dc-d1bf-5bc6-845d-f7e9155050fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a9ce97-ef6d-468c-b389-8d19c76174c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a9ce97-ef6d-468c-b389-8d19c76174c2.jpg?1",
             "name": "Retreat to Valakut",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Target creature gets +2/+0 until end of turn.\u2022 Target creature can't block this turn.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "395a846d-cafd-52e5-9f1e-53d1f12e5650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd980d5-c6d1-4834-977b-22e80f0b449d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd980d5-c6d1-4834-977b-22e80f0b449d.jpg?1",
             "name": "Rolling Thunder",
             "text": "Rolling Thunder deals X damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -5065,7 +5065,7 @@
         },
         {
             "id": "d4b85f47-ff11-5e40-9d93-764aba27b829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8add5f2-4ccf-4505-86f6-cc36aff1c3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8add5f2-4ccf-4505-86f6-cc36aff1c3fe.jpg?1",
             "name": "Shatterskull Recruit",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "bf1f7056-7817-5e20-be04-5df4f0a1ea4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa37f74-50dd-4013-b48a-c33f1dbfb3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa37f74-50dd-4013-b48a-c33f1dbfb3e1.jpg?1",
             "name": "Stonefury",
             "text": "Stonefury deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "1486be6e-ac9e-58a1-9c36-e69e0586f6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074dd176-4608-42ca-8fc3-c7040cd7b32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074dd176-4608-42ca-8fc3-c7040cd7b32e.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5165,7 +5165,7 @@
         },
         {
             "id": "cf311ba7-a31d-53bb-a4c9-17f51d4c0b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4071152-5e64-4133-88a2-8fa5cb0eeb6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4071152-5e64-4133-88a2-8fa5cb0eeb6c.jpg?1",
             "name": "Tunneling Geopede",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Tunneling Geopede deals 1 damage to each opponent.",
             "colours": [
@@ -5199,7 +5199,7 @@
         },
         {
             "id": "74409194-5905-5fd7-88f9-bfd1ae0994b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178c66b8-c577-49c6-9efc-7bab740e66b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178c66b8-c577-49c6-9efc-7bab740e66b6.jpg?1",
             "name": "Valakut Invoker",
             "text": "{8}: Valakut Invoker deals 3 damage to target creature or player.",
             "colours": [
@@ -5234,7 +5234,7 @@
         },
         {
             "id": "5eb08c49-5bd7-58ba-8496-46821cc4fbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318272-8192-4d6d-a22a-eca87abb480d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318272-8192-4d6d-a22a-eca87abb480d.jpg?1",
             "name": "Valakut Predator",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Valakut Predator gets +2/+2 until end of turn.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "40744aa7-10b3-55ec-9d24-206c4b525179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90bd68-0521-4db3-b590-a4e007da9f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90bd68-0521-4db3-b590-a4e007da9f2e.jpg?1",
             "name": "Volcanic Upheaval",
             "text": "Destroy target land.",
             "colours": [
@@ -5300,7 +5300,7 @@
         },
         {
             "id": "eb609609-d23a-5122-ba01-9048da9f3cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0969f1-92a0-47c3-8eff-d106fbef2f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0969f1-92a0-47c3-8eff-d106fbef2f7e.jpg?1",
             "name": "Zada, Hedron Grinder",
             "text": "Whenever you cast an instant or sorcery spell that targets only Zada, Hedron Grinder, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -5337,7 +5337,7 @@
         },
         {
             "id": "6da6feb9-664d-58cc-9316-0c053b9207a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f1803-634a-41b0-ae21-484d6f914a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f1803-634a-41b0-ae21-484d6f914a0d.jpg?1",
             "name": "Blisterpod",
             "text": "Devoid (This card has no color.)\nWhen Blisterpod dies, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "2f531a70-c9cd-5e78-8125-620d2b8d4862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d4a49-8681-4f95-8718-96648bf73c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d4a49-8681-4f95-8718-96648bf73c39.jpg?1",
             "name": "Brood Monitor",
             "text": "Devoid (This card has no color.)\nWhen Brood Monitor enters the battlefield, put three 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "bc1b432c-c353-5b51-9281-f47d5838278b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d248ed0-c2b4-4558-9a09-ace8fd4b0599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d248ed0-c2b4-4558-9a09-ace8fd4b0599.jpg?1",
             "name": "Call the Scions",
             "text": "Devoid (This card has no color.)\nPut two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5433,7 +5433,7 @@
         },
         {
             "id": "dd8c98bb-94fe-5567-917f-da7d68ea0ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d949d0e-baf7-4573-bb15-7e30e3e9b202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d949d0e-baf7-4573-bb15-7e30e3e9b202.jpg?1",
             "name": "Eyeless Watcher",
             "text": "Devoid (This card has no color.)\nWhen Eyeless Watcher enters the battlefield, put two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "41c7cbc1-f44f-585f-9343-3e35404bc263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5559960-e306-4992-b607-9654327c4507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5559960-e306-4992-b607-9654327c4507.jpg?1",
             "name": "From Beyond",
             "text": "Devoid (This card has no color.)\nAt the beginning of your upkeep, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"{1}{G}, Sacrifice From Beyond: Search your library for an Eldrazi card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "bd092a4c-fe09-522e-8631-48446b664b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8293c66d-9a9b-4817-9bc3-ffd57fda290c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8293c66d-9a9b-4817-9bc3-ffd57fda290c.jpg?1",
             "name": "Unnatural Aggression",
             "text": "Devoid (This card has no color.)\nTarget creature you control fights target creature an opponent controls. If the creature an opponent controls would die this turn, exile it instead.",
             "colours": [],
@@ -5526,7 +5526,7 @@
         },
         {
             "id": "59ac3c52-803d-561b-975a-231ffd06f3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f66eb97-b151-48b1-aff0-f1280af66291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f66eb97-b151-48b1-aff0-f1280af66291.jpg?1",
             "name": "Void Attendant",
             "text": "Devoid (This card has no color.){1}{G}, Put a card an opponent owns from exile into that player's graveyard: Put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "cbeda0c1-e3f8-5fbd-ab69-f287510faa5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg?1",
             "name": "Beastcaller Savant",
             "text": "Haste{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell.",
             "colours": [
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "f84fccd1-742a-5170-b8aa-3cf3996f2c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c852d-9c7c-4d9b-8e79-70ea5ac865df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11c852d-9c7c-4d9b-8e79-70ea5ac865df.jpg?1",
             "name": "Broodhunter Wurm",
             "text": "",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "28ddd278-0257-5ba4-a893-b9c4f6f85313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadc77d8-ef1c-431d-8716-9583f4fad33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadc77d8-ef1c-431d-8716-9583f4fad33f.jpg?1",
             "name": "Earthen Arms",
             "text": "Put two +1/+1 counters on target permanent.\nAwaken 4\u2014{6}{G} (If you cast this spell for {6}{G}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "f4fa1bce-ccc1-5bc3-9fa9-e444db16d4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98518e4a-d1d0-4e41-bae7-242c779f06a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98518e4a-d1d0-4e41-bae7-242c779f06a1.jpg?1",
             "name": "Giant Mantis",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "552b1b4d-cfdd-5fb2-bc1a-f28b74aacab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b03132c-0bb7-48f9-babd-6e106d8f202c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b03132c-0bb7-48f9-babd-6e106d8f202c.jpg?1",
             "name": "Greenwarden of Murasa",
             "text": "When Greenwarden of Murasa enters the battlefield, you may return target card from your graveyard to your hand.\nWhen Greenwarden of Murasa dies, you may exile it. If you do, return target card from your graveyard to your hand.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "96047e5c-03a7-564b-8afe-09e32d7b72b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec25fe4-7967-42e2-8790-593738991eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec25fe4-7967-42e2-8790-593738991eaa.jpg?1",
             "name": "Infuse with the Elements",
             "text": "Converge \u2014 Put X +1/+1 counters on target creature, where X is the number of colors of mana spent to cast Infuse with the Elements. That creature gains trample until end of turn.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "8f10015a-c0b6-5866-8f71-dc150a5ae6b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca704d5-b6e0-4726-8856-0b3a6732bbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca704d5-b6e0-4726-8856-0b3a6732bbd8.jpg?1",
             "name": "Jaddi Offshoot",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -5795,7 +5795,7 @@
         },
         {
             "id": "10514861-104b-570f-b9f0-3abf39df02cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657719-7d4d-46db-a5f4-699ee2032ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657719-7d4d-46db-a5f4-699ee2032ebe.jpg?1",
             "name": "Lifespring Druid",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "18519e03-bb0e-5cad-bc45-7e7d1b59a6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a3c02b-b576-4099-9016-15449f93bb09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a3c02b-b576-4099-9016-15449f93bb09.jpg?1",
             "name": "Murasa Ranger",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {3}{G}. If you do, put two +1/+1 counters on Murasa Ranger.",
             "colours": [
@@ -5866,7 +5866,7 @@
         },
         {
             "id": "591ea105-8628-58fb-960d-a6828b65681a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11cd83-5930-4cff-8f9b-55337ed263b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11cd83-5930-4cff-8f9b-55337ed263b7.jpg?1",
             "name": "Natural Connection",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5898,7 +5898,7 @@
         },
         {
             "id": "8a875707-0430-5823-be7b-3b6b89d9f3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91aa2ff1-12ea-4896-a955-a9cd76c3b49d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91aa2ff1-12ea-4896-a955-a9cd76c3b49d.jpg?1",
             "name": "Nissa's Renewal",
             "text": "Search your library for up to three basic land cards, put them onto the battlefield tapped, then shuffle your library. You gain 7 life.",
             "colours": [
@@ -5930,7 +5930,7 @@
         },
         {
             "id": "be4a442c-5ce0-52f6-8a97-ffc70d7bef7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3276b-2cbc-4266-b16a-bf72c044d95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3276b-2cbc-4266-b16a-bf72c044d95b.jpg?1",
             "name": "Oran-Rief Hydra",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Oran-Rief Hydra. If that land is a Forest, put two +1/+1 counters on Oran-Rief Hydra instead.",
             "colours": [
@@ -5964,7 +5964,7 @@
         },
         {
             "id": "a6b192fc-1807-5080-b84f-bc52aab40689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957875c-e1a2-4d14-8b61-c806903fc760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957875c-e1a2-4d14-8b61-c806903fc760.jpg?1",
             "name": "Oran-Rief Invoker",
             "text": "{8}: Oran-Rief Invoker gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "849870a1-602a-50c0-8fa8-e5ae20070864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd68e01c-4a09-450b-bfa0-8fbac8721764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd68e01c-4a09-450b-bfa0-8fbac8721764.jpg?1",
             "name": "Plated Crusher",
             "text": "Trample, hexproof",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "358c5647-9f47-5f5d-9497-36336d8c7bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6acb5b-b087-4cad-b40f-2de37029847c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6acb5b-b087-4cad-b40f-2de37029847c.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "7ef05352-671b-5ec7-bc9c-3b5e068c24cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be4c1a-58d7-409e-b7e0-aadb5ccf814d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be4c1a-58d7-409e-b7e0-aadb5ccf814d.jpg?1",
             "name": "Reclaiming Vines",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "a5faa897-92ec-5c69-bb77-3d1e4ae94f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53884f2a-6749-4d85-be64-82919eb30e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53884f2a-6749-4d85-be64-82919eb30e39.jpg?1",
             "name": "Retreat to Kazandu",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\u2022 Put a +1/+1 counter on target creature.\u2022 You gain 2 life.",
             "colours": [
@@ -6129,7 +6129,7 @@
         },
         {
             "id": "14f53506-a55f-55ef-9cf6-68dd1c9ce627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a403b28-f91a-4637-af72-d6fc86c3bb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a403b28-f91a-4637-af72-d6fc86c3bb9a.jpg?1",
             "name": "Rot Shambler",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Rot Shambler.",
             "colours": [
@@ -6163,7 +6163,7 @@
         },
         {
             "id": "10d02e48-d21d-5d78-9e1a-301fcf9f32ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ef0054-a290-4c41-846d-12f8119c52ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ef0054-a290-4c41-846d-12f8119c52ae.jpg?1",
             "name": "Scythe Leopard",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Scythe Leopard gets +1/+1 until end of turn.",
             "colours": [
@@ -6197,7 +6197,7 @@
         },
         {
             "id": "6399d8b6-961d-51a7-af33-f3f9c178661f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824f44fe-ee16-4b15-a308-5c620cfd3d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824f44fe-ee16-4b15-a308-5c620cfd3d93.jpg?1",
             "name": "Seek the Wilds",
             "text": "Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "440da4e4-09a4-566e-bcaa-f543efd024e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834409e3-134e-4a34-89cb-53e2a039e980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834409e3-134e-4a34-89cb-53e2a039e980.jpg?1",
             "name": "Snapping Gnarlid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Snapping Gnarlid gets +1/+1 until end of turn.",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "2f7a3d18-d9d1-54ec-8b8b-d2ff5d642f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06da6fe-57bf-437e-8589-7e57a5881801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06da6fe-57bf-437e-8589-7e57a5881801.jpg?1",
             "name": "Swell of Growth",
             "text": "Target creature gets +2/+2 until end of turn. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -6295,7 +6295,7 @@
         },
         {
             "id": "bee997d6-12f5-5a5a-90a9-fc90a219cd78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b93087-e6a0-4ba9-83ba-a0ed2e396dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b93087-e6a0-4ba9-83ba-a0ed2e396dc7.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -6327,7 +6327,7 @@
         },
         {
             "id": "83989f1c-8e82-5480-b2b3-e79da4259290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447b4af-2eb2-48ae-a12e-2fdf83d4cb70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447b4af-2eb2-48ae-a12e-2fdf83d4cb70.jpg?1",
             "name": "Tajuru Beastmaster",
             "text": "Rally \u2014 Whenever Tajuru Beastmaster or another Ally enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6363,7 +6363,7 @@
         },
         {
             "id": "9c0dbaf9-d112-52e8-92f5-87393ac65661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f916220b-a942-41af-8949-aa384fa7857d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f916220b-a942-41af-8949-aa384fa7857d.jpg?1",
             "name": "Tajuru Stalwart",
             "text": "Converge \u2014 Tajuru Stalwart enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -6399,7 +6399,7 @@
         },
         {
             "id": "2952141f-7ba3-51e8-997c-a68c0c2bcf16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762501fe-5102-4c21-8ad5-430590a59830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762501fe-5102-4c21-8ad5-430590a59830.jpg?1",
             "name": "Tajuru Warcaller",
             "text": "Rally \u2014 Whenever Tajuru Warcaller or another Ally enters the battlefield under your control, creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "9aec098c-3cbd-5812-b191-7476a953220d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d4afc-5bb7-4159-9a11-f9c989dd9043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d4afc-5bb7-4159-9a11-f9c989dd9043.jpg?1",
             "name": "Territorial Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Territorial Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -6469,7 +6469,7 @@
         },
         {
             "id": "27017d06-7614-54fb-b814-f16ba45b555f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53104d8-5b9a-45b6-a2f9-b2c5d231a03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53104d8-5b9a-45b6-a2f9-b2c5d231a03d.jpg?1",
             "name": "Undergrowth Champion",
             "text": "If damage would be dealt to Undergrowth Champion while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from Undergrowth Champion.\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Undergrowth Champion.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "ce7ec50e-3713-53ad-b938-01ec900b59cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1e6db8-5093-44e4-95d7-3fdf8c55c1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc1e6db8-5093-44e4-95d7-3fdf8c55c1dd.jpg?1",
             "name": "Woodland Wanderer",
             "text": "Vigilance, trample\nConverge \u2014 Woodland Wanderer enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "cb4f4636-1820-5b6d-92fa-a917efa4b43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f60fdd6-bc18-4c04-83d8-c204f2b35ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f60fdd6-bc18-4c04-83d8-c204f2b35ff1.jpg?1",
             "name": "Brood Butcher",
             "text": "Devoid (This card has no color.)\nWhen Brood Butcher enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"{B}{G}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.",
             "colours": [],
@@ -6571,7 +6571,7 @@
         },
         {
             "id": "52c4de18-7e50-5d0a-82b1-a9a570d86be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0eb64b-a463-4f25-9278-340051139f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0eb64b-a463-4f25-9278-340051139f0e.jpg?1",
             "name": "Brutal Expulsion",
             "text": "Devoid (This card has no color.)\nChoose one or both \u2014\u2022 Return target spell or creature to its owner's hand.\u2022 Brutal Expulsion deals 2 damage to target creature or planeswalker. If that permanent would be put into a graveyard this turn, exile it instead.",
             "colours": [],
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "c0c192d8-f3f6-57cc-98d4-4bf9011e9391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3b220b-e699-45b0-8ec1-1022c1f50329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3b220b-e699-45b0-8ec1-1022c1f50329.jpg?1",
             "name": "Catacomb Sifter",
             "text": "Devoid (This card has no color.)\nWhen Catacomb Sifter enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"Whenever another creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "430abad5-8262-5bce-af98-b152fd055f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2322e8c3-a983-4b3d-b6fa-f6b67f6fa8cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2322e8c3-a983-4b3d-b6fa-f6b67f6fa8cc.jpg?1",
             "name": "Dust Stalker",
             "text": "Devoid (This card has no color.)\nHaste\nAt the beginning of each end step, if you control no other colorless creatures, return Dust Stalker to its owner's hand.",
             "colours": [],
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "b9628192-c7b3-5f7d-ab72-904a390420a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b080ed31-db68-4e3c-8bf6-48b53d3ba622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b080ed31-db68-4e3c-8bf6-48b53d3ba622.jpg?1",
             "name": "Fathom Feeder",
             "text": "Devoid (This card has no color.)\nDeathtouch\nIngest (Whenever this creature deals combat damage to a player, that player exiles the top card of his or her library.){3}{U}{B}: Draw a card. Each opponent exiles the top card of his or her library.",
             "colours": [],
@@ -6703,7 +6703,7 @@
         },
         {
             "id": "d48b30e9-1737-5442-a5f2-ce6060051610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38aba41-a83f-47ef-9fc9-ea3424fc6d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38aba41-a83f-47ef-9fc9-ea3424fc6d64.jpg?1",
             "name": "Forerunner of Slaughter",
             "text": "Devoid (This card has no color.){1}: Target colorless creature gains haste until end of turn.",
             "colours": [],
@@ -6737,7 +6737,7 @@
         },
         {
             "id": "69947233-8afc-596e-b8e7-409152bea516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4180ae-1fd9-4185-b4f0-9e8f668a5737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4180ae-1fd9-4185-b4f0-9e8f668a5737.jpg?1",
             "name": "Herald of Kozilek",
             "text": "Devoid (This card has no color.)\nColorless spells you cast cost {1} less to cast.",
             "colours": [],
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "3bd3caf0-376f-5f45-af7d-13b952e23aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6252913-7b8e-4746-91e0-658ce13cdf18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6252913-7b8e-4746-91e0-658ce13cdf18.jpg?1",
             "name": "Sire of Stagnation",
             "text": "Devoid (This card has no color.)\nWhenever a land enters the battlefield under an opponent's control, that player exiles the top two cards of his or her library and you draw two cards.",
             "colours": [],
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "0d38df89-3436-55de-8929-56eb980d3296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd482ad-ca4a-470f-8a76-14ec7b58316a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd482ad-ca4a-470f-8a76-14ec7b58316a.jpg?1",
             "name": "Ulamog's Nullifier",
             "text": "Devoid (This card has no color.)\nFlash\nFlying\nWhen Ulamog's Nullifier enters the battlefield, you may put two cards your opponents own from exile into their owners' graveyards. If you do, counter target spell.",
             "colours": [],
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "1513b563-34ab-547c-b214-ee43a35fad06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0baf56-816a-4e0a-beb3-73b51487ff00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0baf56-816a-4e0a-beb3-73b51487ff00.jpg?1",
             "name": "Angelic Captain",
             "text": "Flying\nWhenever Angelic Captain attacks, it gets +1/+1 until end of turn for each other attacking Ally.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "25c7623a-8ca2-5aeb-b75d-c6a716f61887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25b13a4-6282-4426-8b01-9550f7d52d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25b13a4-6282-4426-8b01-9550f7d52d16.jpg?1",
             "name": "Bring to Light",
             "text": "Converge \u2014 Search your library for a creature, instant, or sorcery card with converted mana cost less than or equal to the number of colors of mana spent to cast Bring to Light, exile that card, then shuffle your library. You may cast that card without paying its mana cost.",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "212aa446-00ab-505e-aa41-7625ad8b5ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e82d47-9bbb-4bf9-a935-2c0b27b64a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e82d47-9bbb-4bf9-a935-2c0b27b64a84.jpg?1",
             "name": "Drana's Emissary",
             "text": "Flying\nAt the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "4a22edf4-4436-59c1-9862-a8750c982bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012b8eff-cdf3-423e-ae17-72a909e7ebd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012b8eff-cdf3-423e-ae17-72a909e7ebd3.jpg?1",
             "name": "Grove Rumbler",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Grove Rumbler gets +2/+2 until end of turn.",
             "colours": [
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "bfddf344-8d13-5927-809a-618e80067700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2fd3a4-e09a-4fe5-93eb-2276a65c4911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2fd3a4-e09a-4fe5-93eb-2276a65c4911.jpg?1",
             "name": "Grovetender Druids",
             "text": "Rally \u2014 Whenever Grovetender Druids or another Ally enters the battlefield under your control, you may pay {1}. If you do, put a 1/1 green Plant creature token onto the battlefield.",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "ad179bc3-62b6-5bac-8e46-c8ee7ac803c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b63c228-3265-4029-9bc0-36b3e31dfb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b63c228-3265-4029-9bc0-36b3e31dfb53.jpg?1",
             "name": "Kiora, Master of the Depths",
             "text": "+1: Untap up to one target creature and up to one target land.\u22122: Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.\u22128: You get an emblem with \"Whenever a creature enters the battlefield under your control, you may have it fight target creature.\" Then put three 8/8 blue Octopus creature tokens onto the battlefield.",
             "colours": [
@@ -7059,7 +7059,7 @@
         },
         {
             "id": "35f539dc-08e8-54e5-9b94-24781c6540f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dd138-fc8e-4a24-ad6d-2df71f94c0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dd138-fc8e-4a24-ad6d-2df71f94c0c0.jpg?1",
             "name": "March from the Tomb",
             "text": "Return any number of target Ally creature cards with total converted mana cost 8 or less from your graveyard to the battlefield.",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "6e0ce847-038d-5926-baaf-38c2e6aef0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee09fe-46d7-492b-a2f3-3fb0c3f83f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee09fe-46d7-492b-a2f3-3fb0c3f83f07.jpg?1",
             "name": "Munda, Ambush Leader",
             "text": "Haste\nRally \u2014 Whenever Munda, Ambush Leader or another Ally enters the battlefield under your control, you may look at the top four cards of your library. If you do, reveal any number of Ally cards from among them, then put those cards on top of your library in any order and the rest on the bottom in any order.",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "f66bc103-f7d5-54f2-b713-78444647684c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a66fc-e7aa-42df-a622-50743cb20183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a66fc-e7aa-42df-a622-50743cb20183.jpg?1",
             "name": "Noyan Dar, Roil Shaper",
             "text": "Whenever you cast an instant or sorcery spell, you may put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.",
             "colours": [
@@ -7171,7 +7171,7 @@
         },
         {
             "id": "f2c042ad-bf9d-593a-bfaf-0270f8b13a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f311e7-7ebf-4428-b5a3-154255eb3ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f311e7-7ebf-4428-b5a3-154255eb3ba1.jpg?1",
             "name": "Omnath, Locus of Rage",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a 5/5 red and green Elemental creature token onto the battlefield.\nWhenever Omnath, Locus of Rage or another Elemental you control dies, Omnath deals 3 damage to target creature or player.",
             "colours": [
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "9262ce4a-7cdc-5c01-b558-e5ec1f5eb3f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea96f8d-0c57-448d-8145-51f9cca04432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea96f8d-0c57-448d-8145-51f9cca04432.jpg?1",
             "name": "Resolute Blademaster",
             "text": "Rally \u2014 Whenever Resolute Blademaster or another Ally enters the battlefield under your control, creatures you control gain double strike until end of turn.",
             "colours": [
@@ -7247,7 +7247,7 @@
         },
         {
             "id": "c203fa16-4251-58a5-bc2f-7e1f96b39d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fdecc-ba16-4aa2-9c20-7c2942ec143e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fdecc-ba16-4aa2-9c20-7c2942ec143e.jpg?1",
             "name": "Roil Spout",
             "text": "Put target creature on top of its owner's library.\nAwaken 4\u2014{4}{W}{U} (If you cast this spell for {4}{W}{U}, also put four +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)",
             "colours": [
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "25a9d37f-3829-5eb5-8e04-8eabcb76f2c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eb787-aec7-43fd-9813-184111d9dcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eb787-aec7-43fd-9813-184111d9dcc5.jpg?1",
             "name": "Skyrider Elf",
             "text": "Flying\nConverge \u2014 Skyrider Elf enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -7319,7 +7319,7 @@
         },
         {
             "id": "83a355fb-47b1-5e5f-94ff-3258457315f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c7f3e0-b23a-4786-b452-583d905113e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c7f3e0-b23a-4786-b452-583d905113e2.jpg?1",
             "name": "Veteran Warleader",
             "text": "Veteran Warleader's power and toughness are each equal to the number of creatures you control.\nTap another untapped Ally you control: Veteran Warleader gains your choice of first strike, vigilance, or trample until end of turn.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "8f60f432-da18-574a-aa16-172dab38de32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef436b-e82e-4e1f-9da0-5e35f0c37bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef436b-e82e-4e1f-9da0-5e35f0c37bde.jpg?1",
             "name": "Aligned Hedron Network",
             "text": "When Aligned Hedron Network enters the battlefield, exile all creatures with power 5 or greater until Aligned Hedron Network leaves the battlefield. (Those creatures return under their owners' control.)",
             "colours": [],
@@ -7385,7 +7385,7 @@
         },
         {
             "id": "af52679e-36b4-5aa1-9a42-a32373eab1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519149c-f8a3-413f-b7b2-cd596970be4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519149c-f8a3-413f-b7b2-cd596970be4c.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {2} to your mana pool.{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "f2fb747c-c254-5c3c-8919-7127ba2a99ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87242e1d-babe-4b0d-aa1f-ab62e0bc4ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87242e1d-babe-4b0d-aa1f-ab62e0bc4ab7.jpg?1",
             "name": "Hedron Blade",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature becomes blocked by one or more colorless creatures, it gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "719ebada-27f5-5438-8b5f-a633a2fb9b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b98611-a6f7-498c-87e3-893a3f4b4f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b98611-a6f7-498c-87e3-893a3f4b4f73.jpg?1",
             "name": "Pathway Arrows",
             "text": "Equipped creature has \"{2}, {T}: This creature deals 1 damage to target creature. If a colorless creature is dealt damage this way, tap it.\"Equip {2}",
             "colours": [],
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "aa7ea9fb-b60c-5ca1-83d5-4b4c3943d9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dbd56-95a0-4697-9599-3f6110daf6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dbd56-95a0-4697-9599-3f6110daf6bc.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "45618248-64b5-5284-b462-e23231df105d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c64671-9bdd-475f-8def-7575775bf900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c64671-9bdd-475f-8def-7575775bf900.jpg?1",
             "name": "Slab Hammer",
             "text": "Whenever equipped creature attacks, you may return a land you control to its owner's hand. If you do, the creature gets +2/+2 until end of turn.\nEquip {2}",
             "colours": [],
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "3693b1dc-a948-5190-92f4-2efd4c8183af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb7124c-ba69-4da8-ad81-58f00fd0181d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb7124c-ba69-4da8-ad81-58f00fd0181d.jpg?1",
             "name": "Ally Encampment",
             "text": "{T}: Add {1} to your mana pool.{T}: Add one mana of any color to your mana pool. Spend this mana only to cast an Ally spell.{1}, {T}, Sacrifice Ally Encampment: Return target Ally you control to its owner's hand.",
             "colours": [],
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "94dedca4-6b21-5b0d-b355-174774f3ecc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8908b6b0-a488-426c-954d-458456be0651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8908b6b0-a488-426c-954d-458456be0651.jpg?1",
             "name": "Blighted Cataract",
             "text": "{T}: Add {1} to your mana pool.{5}{U}, {T}, Sacrifice Blighted Cataract: Draw two cards.",
             "colours": [],
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "1bf5439b-3653-5d1a-bd73-ac90da653c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d02950-cd50-4662-97af-3106598dc3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d02950-cd50-4662-97af-3106598dc3c4.jpg?1",
             "name": "Blighted Fen",
             "text": "{T}: Add {1} to your mana pool.{4}{B}, {T}, Sacrifice Blighted Fen: Target opponent sacrifices a creature.",
             "colours": [],
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "c869f59a-8742-59ad-bdb9-03ffd6f48b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cbfe5d-79b7-45db-b3cd-4ae7a9964a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cbfe5d-79b7-45db-b3cd-4ae7a9964a37.jpg?1",
             "name": "Blighted Gorge",
             "text": "{T}: Add {1} to your mana pool.{4}{R}, {T}, Sacrifice Blighted Gorge: Blighted Gorge deals 2 damage to target creature or player.",
             "colours": [],
@@ -7652,7 +7652,7 @@
         },
         {
             "id": "ae3428c8-260b-567d-8472-aa791b63cb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43df8ee-d3e4-419e-aed0-1059d95f9cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43df8ee-d3e4-419e-aed0-1059d95f9cab.jpg?1",
             "name": "Blighted Steppe",
             "text": "{T}: Add {1} to your mana pool.{3}{W}, {T}, Sacrifice Blighted Steppe: You gain 2 life for each creature you control.",
             "colours": [],
@@ -7682,7 +7682,7 @@
         },
         {
             "id": "87bd7efa-2795-5978-bfe8-83517309df15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7508d531-da52-41fb-a729-3f5704c9a194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7508d531-da52-41fb-a729-3f5704c9a194.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {1} to your mana pool.{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "2d227ca6-e593-50d1-b45a-1dd7df241b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3262c7f-4fdf-4648-ba59-9279c75d222d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3262c7f-4fdf-4648-ba59-9279c75d222d.jpg?1",
             "name": "Canopy Vista",
             "text": "({T}: Add {G} or {W} to your mana pool.)Canopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -7746,7 +7746,7 @@
         },
         {
             "id": "34869c66-7413-539a-8e9a-e373f15d15e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfabc340-0391-4019-8e96-f010177b1d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfabc340-0391-4019-8e96-f010177b1d68.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G} to your mana pool.)Cinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "3df7b6b6-604c-5912-8f8c-2faeb153bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8c9ac8-0741-4261-b43b-d745839e11f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8c9ac8-0741-4261-b43b-d745839e11f5.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "81677e7c-039c-5069-bcc4-4397bc124d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15231a9b-1956-4ff6-b637-942444d3349f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15231a9b-1956-4ff6-b637-942444d3349f.jpg?1",
             "name": "Fertile Thicket",
             "text": "Fertile Thicket enters the battlefield tapped.\nWhen Fertile Thicket enters the battlefield, you may look at the top five cards of your library. If you do, reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom in any order.{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "0b1514fc-b521-584a-b592-85f753d8d3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88177a2-de41-417d-a8f1-07edf005b453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88177a2-de41-417d-a8f1-07edf005b453.jpg?1",
             "name": "Looming Spires",
             "text": "Looming Spires enters the battlefield tapped.\nWhen Looming Spires enters the battlefield, target creature gets +1/+1 and gains first strike until end of turn.{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -7868,7 +7868,7 @@
         },
         {
             "id": "80fe085a-b9b5-52c8-9bbd-dce15a436799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8d2e4-3ebe-4311-b99e-dea9fb0b20ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8d2e4-3ebe-4311-b99e-dea9fb0b20ac.jpg?1",
             "name": "Lumbering Falls",
             "text": "Lumbering Falls enters the battlefield tapped.{T}: Add {G} or {U} to your mana pool.{2}{G}{U}: Lumbering Falls becomes a 3/3 green and blue Elemental creature with hexproof until end of turn. It's still a land.",
             "colours": [],
@@ -7899,7 +7899,7 @@
         },
         {
             "id": "f58a735a-468b-5df0-ac01-12a275872de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b31722-9626-4fea-9971-54c9aa8238e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b31722-9626-4fea-9971-54c9aa8238e8.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "2b7b34f3-0516-5994-b0ba-11e85a900226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625911f-1dd3-4044-ac06-3c0c3198b6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625911f-1dd3-4044-ac06-3c0c3198b6fd.jpg?1",
             "name": "Prairie Stream",
             "text": "({T}: Add {W} or {U} to your mana pool.)Prairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "76f3a630-b104-55a3-9996-7aeb9e19a62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86798d03-9f2d-46bd-a660-13c8dd5535ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86798d03-9f2d-46bd-a660-13c8dd5535ce.jpg?1",
             "name": "Sanctum of Ugin",
             "text": "{T}: Add {1} to your mana pool.\nWhenever you cast a colorless spell with converted mana cost 7 or greater, you may sacrifice Sanctum of Ugin. If you do, search your library for a colorless creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7991,7 +7991,7 @@
         },
         {
             "id": "18558289-3fcf-5ea4-b90e-ac72d2c9f309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781e932-4605-47aa-add1-4ee62f4e7ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781e932-4605-47aa-add1-4ee62f4e7ead.jpg?1",
             "name": "Sandstone Bridge",
             "text": "Sandstone Bridge enters the battlefield tapped.\nWhen Sandstone Bridge enters the battlefield, target creature gets +1/+1 and gains vigilance until end of turn.{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "37b25995-9d68-58c8-877f-c2a5a5fe1964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a73816-1f33-4798-a9d6-5f0410d19625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a73816-1f33-4798-a9d6-5f0410d19625.jpg?1",
             "name": "Shambling Vent",
             "text": "Shambling Vent enters the battlefield tapped.{T}: Add {W} or {B} to your mana pool.{1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.",
             "colours": [],
@@ -8052,7 +8052,7 @@
         },
         {
             "id": "4110badb-44f8-5e6c-a244-83cd2b208375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da2af9a-28c4-4edd-95c4-cc09c2de4adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da2af9a-28c4-4edd-95c4-cc09c2de4adc.jpg?1",
             "name": "Shrine of the Forsaken Gods",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {2} to your mana pool. Spend this mana only to cast colorless spells. Activate this ability only if you control seven or more lands.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "164fd70a-e44a-5380-8a71-efd0a5c8ce2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b0027d-c232-4cdd-89c4-75947687aa71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b0027d-c232-4cdd-89c4-75947687aa71.jpg?1",
             "name": "Skyline Cascade",
             "text": "Skyline Cascade enters the battlefield tapped.\nWhen Skyline Cascade enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "0aeaa88a-ae66-5d20-ba07-41174eda8c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b189d-aa51-4e90-820a-e79884562e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b189d-aa51-4e90-820a-e79884562e34.jpg?1",
             "name": "Smoldering Marsh",
             "text": "({T}: Add {B} or {R} to your mana pool.)Smoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "1938b5c0-6de4-5c99-b012-c84e96cfcb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a532b2-de88-40af-8961-b01eada05bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a532b2-de88-40af-8961-b01eada05bd3.jpg?1",
             "name": "Spawning Bed",
             "text": "{T}: Add {1} to your mana pool.{6}, {T}, Sacrifice Spawning Bed: Put three 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "71be7e0d-4fb9-51a3-80f6-4e455d1acec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B} to your mana pool.)Sunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -8206,7 +8206,7 @@
         },
         {
             "id": "2bf40901-e276-5177-96f5-3df0a68d7367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a735c9-08a1-4950-bf8c-ed1cfba76765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a735c9-08a1-4950-bf8c-ed1cfba76765.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "50f86fcd-9add-5ba5-8a19-73786e42e87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84908444-ee0f-430b-9a5e-f6810aa8bce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84908444-ee0f-430b-9a5e-f6810aa8bce1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "895d2006-13ac-5f34-9600-0a916efc939c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8279b9-c1dd-43db-a01b-89567bb43374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8279b9-c1dd-43db-a01b-89567bb43374.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8337,7 +8337,7 @@
         },
         {
             "id": "c79a58de-24f7-5f5c-aadd-50a01cb773f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b0679c-e7cd-43e0-bf8b-4518734f946b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b0679c-e7cd-43e0-bf8b-4518734f946b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8380,7 +8380,7 @@
         },
         {
             "id": "9c343f93-45da-5857-b351-3ca85192790f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143c32-d78b-40ee-8d2b-a8ce303162d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143c32-d78b-40ee-8d2b-a8ce303162d6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "e632a414-f788-5484-bdbb-2acaf5bf7ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405b531e-0f43-479c-9f8e-cf83f7b943a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405b531e-0f43-479c-9f8e-cf83f7b943a4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "0909f672-15bf-5ae1-84e8-8829101bc685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11c9a26-3234-480b-94cf-49f15f2b0002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11c9a26-3234-480b-94cf-49f15f2b0002.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8511,7 +8511,7 @@
         },
         {
             "id": "60c16888-7e54-585a-996b-cf0675ebde9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75d8ab6-0391-4bd7-9861-d2f6dd745a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75d8ab6-0391-4bd7-9861-d2f6dd745a51.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "f583c6b9-1a76-5a6c-ad59-87548f51855e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3138154c-5763-4105-a635-b697fe4c1e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3138154c-5763-4105-a635-b697fe4c1e52.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "77b5bdd8-aecc-5e22-8625-c387294a43ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77ab1-aae2-44b4-94a8-74819db16363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77ab1-aae2-44b4-94a8-74819db16363.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "cb840982-18eb-5e51-a8ef-a07bc64abfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8490261d-4246-4232-b7fc-23204c14a7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8490261d-4246-4232-b7fc-23204c14a7b5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8685,7 +8685,7 @@
         },
         {
             "id": "5e81770c-676a-5b1d-81a9-463d6bddddbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52db5b6-59bb-4215-9bdb-ba3dde3e5e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52db5b6-59bb-4215-9bdb-ba3dde3e5e4b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8728,7 +8728,7 @@
         },
         {
             "id": "55e2239b-5a24-58d3-b217-00fc0afb5462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde9dcf-f0b4-4e76-ac4e-d4a8ac355fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde9dcf-f0b4-4e76-ac4e-d4a8ac355fbe.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8772,7 +8772,7 @@
         },
         {
             "id": "16630c23-bfe9-5a6d-81df-c3edf2331e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7661ef-9119-4fe3-8363-b0c3b1d75cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7661ef-9119-4fe3-8363-b0c3b1d75cd7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "4b46a11f-3ac1-5499-993d-b58c4f4e83b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41579-5cbf-41c8-ac1b-e6256220087d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41579-5cbf-41c8-ac1b-e6256220087d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "601c9535-9dfe-584c-96e7-ab4a4524b1f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf86c2b-f3f5-45e7-8fa5-da279f652e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf86c2b-f3f5-45e7-8fa5-da279f652e32.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8902,7 +8902,7 @@
         },
         {
             "id": "11b57177-56d7-52cb-88fa-c7e7cdf67bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f7519-b011-4a86-9226-80c2d9747a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f7519-b011-4a86-9226-80c2d9747a42.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8946,7 +8946,7 @@
         },
         {
             "id": "c524d256-e22f-5969-a767-42415a34a2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab4a950-c558-42fc-ad9b-ce72b7dff817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab4a950-c558-42fc-ad9b-ce72b7dff817.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "ac02394c-0ae0-508b-8306-46af71c883df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71207752-0d8a-4ab5-be64-cca600608e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71207752-0d8a-4ab5-be64-cca600608e76.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9033,7 +9033,7 @@
         },
         {
             "id": "44f2955f-ed35-5a11-b90f-6cf527707897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e862d50-8fa5-4b6e-af19-a161dc4c251d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e862d50-8fa5-4b6e-af19-a161dc4c251d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "65561ead-b578-5e3f-8ed0-8e3adc66d00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132155ae-f7a4-4957-91cb-e51ff52716f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132155ae-f7a4-4957-91cb-e51ff52716f9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "10dac5ea-cb96-59a7-9be6-538369bbff65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20e773f-9220-4212-b39a-eaccb1c265c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20e773f-9220-4212-b39a-eaccb1c265c6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9163,7 +9163,7 @@
         },
         {
             "id": "d9a15b93-2fd4-5a74-af21-5acbb4a8d1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8594426-c965-4187-a72d-7582f21b0ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8594426-c965-4187-a72d-7582f21b0ea1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9207,7 +9207,7 @@
         },
         {
             "id": "18000881-a730-510f-a0c6-5cd0c020548b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44092af-f1a0-4018-a77b-d9ef2a9579ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44092af-f1a0-4018-a77b-d9ef2a9579ca.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9250,7 +9250,7 @@
         },
         {
             "id": "e8675f08-fd0d-5129-900d-1a7df0f53fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5452c8e4-3463-4ae3-a9d1-5947bea4684e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5452c8e4-3463-4ae3-a9d1-5947bea4684e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "46658f14-1abd-5cd2-86a3-75cb392912ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4d0d7a-0ab1-45c6-95a5-308b89e8d197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4d0d7a-0ab1-45c6-95a5-308b89e8d197.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9337,7 +9337,7 @@
         },
         {
             "id": "9466c7c2-d80c-5993-bec6-166c16fb7acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0aaac-fc82-4ce9-87d1-8dead8ec29fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e0aaac-fc82-4ce9-87d1-8dead8ec29fd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9381,7 +9381,7 @@
         },
         {
             "id": "31407797-89b5-5998-8e74-d64ac9909168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6d08cf-a746-4147-91e3-180646de7158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6d08cf-a746-4147-91e3-180646de7158.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9424,7 +9424,7 @@
         },
         {
             "id": "00631b32-5cfa-551a-9b2d-5c1ad960f368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c590ebb-1e3a-4861-b8f2-aef9c4259efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c590ebb-1e3a-4861-b8f2-aef9c4259efd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "7344d22a-6c88-54ad-a88b-1d56ce7da9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8728eb-ae5e-4ff6-8012-5e30d88a04db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8728eb-ae5e-4ff6-8012-5e30d88a04db.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9511,7 +9511,7 @@
         },
         {
             "id": "3e948f92-a0c4-5d78-91a4-1074d8cb12f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9cbae1-6b04-4408-82fe-3fcf61dffbe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9cbae1-6b04-4408-82fe-3fcf61dffbe2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "ae367089-e41a-56b2-b4d6-dcefda260007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e2923f-a585-4096-8268-1136655bbf3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e2923f-a585-4096-8268-1136655bbf3c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9598,7 +9598,7 @@
         },
         {
             "id": "a877b90f-6730-5fd1-8c2c-2c9dc236186e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a42ac42-b21a-449b-abda-6906f06e8120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a42ac42-b21a-449b-abda-6906f06e8120.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9642,7 +9642,7 @@
         },
         {
             "id": "4098268a-1987-59bd-9149-6e1429b90af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7d9208-883e-4fce-8750-c694398c4ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7d9208-883e-4fce-8750-c694398c4ea2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9685,7 +9685,7 @@
         },
         {
             "id": "2d82d469-61fc-5f68-996c-32a2da66a96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37acb733-b3bd-4140-915d-b2c0989208aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37acb733-b3bd-4140-915d-b2c0989208aa.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "bb6480a6-2eb6-521a-938c-0e74dc3d7138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cac2df-9964-4931-9e03-7bc43395b88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62cac2df-9964-4931-9e03-7bc43395b88c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9772,7 +9772,7 @@
         },
         {
             "id": "5ff238cf-f2b0-5c6c-b631-808d67c86343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c94acd-ad60-4aec-b11b-f4dc4a9adfbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c94acd-ad60-4aec-b11b-f4dc4a9adfbc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9816,7 +9816,7 @@
         },
         {
             "id": "6d725517-619a-5fdf-9c1a-45cf0f8c26ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261592a-82d1-46dd-964f-a0a1cf22808f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261592a-82d1-46dd-964f-a0a1cf22808f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "2e41e90e-72de-527e-bc24-a607f6ad5c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cecf0db-0e0e-4329-b055-bb9dad912ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cecf0db-0e0e-4329-b055-bb9dad912ca8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9903,7 +9903,7 @@
         },
         {
             "id": "544aee98-a48a-5b2a-9397-180bb885388d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea6d05f-dfeb-4d1b-b9ad-d006ec2437f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea6d05f-dfeb-4d1b-b9ad-d006ec2437f8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9946,7 +9946,7 @@
         },
         {
             "id": "b692617a-216d-59ca-94fe-2c7f459e72ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642102a2-abde-4e76-a6d6-08f7befe1196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642102a2-abde-4e76-a6d6-08f7befe1196.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9990,7 +9990,7 @@
         },
         {
             "id": "0161f9f2-9d93-51b5-a5be-902ed5089e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f865d8-fced-4763-b73e-fd40e9387e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f865d8-fced-4763-b73e-fd40e9387e45.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "04e11f16-cb1c-5820-a26d-ef423db74f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b26e4-1d52-457c-a00c-bdee127f8a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b26e4-1d52-457c-a00c-bdee127f8a97.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10077,7 +10077,7 @@
         },
         {
             "id": "5675b6f8-ca15-5455-aaf7-56dfb038ec52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131ab8d-c884-4430-8059-9e3e1d16c747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131ab8d-c884-4430-8059-9e3e1d16c747.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10120,7 +10120,7 @@
         },
         {
             "id": "e45a60bb-8ce4-5ddd-9501-5cce67a487b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3a6ecf-323d-4650-aabf-92995e3c72c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3a6ecf-323d-4650-aabf-92995e3c72c6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10164,7 +10164,7 @@
         },
         {
             "id": "6511454a-5465-5e76-9957-f69012f90878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76349ec5-a7ad-45cf-a6b8-1f71d7e6f74d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76349ec5-a7ad-45cf-a6b8-1f71d7e6f74d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10207,7 +10207,7 @@
         },
         {
             "id": "86634289-9488-5ce8-a4e0-4a6579aa47be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f206a-7b5e-4fd5-8c9e-d665ac3f7dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f206a-7b5e-4fd5-8c9e-d665ac3f7dea.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "fe928dc1-7594-53ca-9de5-53e0a1711b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f909e5-f993-467d-be46-10d8a67ee9f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f909e5-f993-467d-be46-10d8a67ee9f4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "25504530-b778-5120-85c6-ce6808ad7c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c70181e-7b28-46b1-a51a-ba99e58e8566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c70181e-7b28-46b1-a51a-ba99e58e8566.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10338,7 +10338,7 @@
         },
         {
             "id": "4fb5d3f7-cc7b-5502-8906-555ba919bd02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbf7cc-f20c-49d3-85ff-406dd32f6444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbf7cc-f20c-49d3-85ff-406dd32f6444.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "c2fb5049-79aa-5d1b-98a8-b8e5a2997ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff04d5-ecaf-4be2-94f4-d5409f1c1e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff04d5-ecaf-4be2-94f4-d5409f1c1e4e.jpg?1",
             "name": "Eldrazi",
             "text": "",
             "colours": [],
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "108b11f1-acda-5ea3-bda7-dc1f7a48b9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999a0fe-d2d0-4367-9abb-6ce5f3764f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999a0fe-d2d0-4367-9abb-6ce5f3764f19.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -10442,7 +10442,7 @@
         },
         {
             "id": "4b047f53-a4fb-5a40-b690-c43f2afb0356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcdf03d-d237-4ceb-91fa-8f95341af369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcdf03d-d237-4ceb-91fa-8f95341af369.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -10473,7 +10473,7 @@
         },
         {
             "id": "71f5dc54-b903-5d65-a988-781176660519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5c74d5-b219-4514-8fd6-62705459422c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5c74d5-b219-4514-8fd6-62705459422c.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -10504,7 +10504,7 @@
         },
         {
             "id": "e31700d9-327d-5e8e-b8d9-c7527922db9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0419a202-6e32-4f0a-a032-72f6c00cae5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0419a202-6e32-4f0a-a032-72f6c00cae5e.jpg?1",
             "name": "Knight Ally",
             "text": "",
             "colours": [
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "f3e2cc8f-c56e-550d-9604-c52722e1d945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be224180-a482-4b94-8a9d-3a92ee0eb34b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be224180-a482-4b94-8a9d-3a92ee0eb34b.jpg?1",
             "name": "Kor Ally",
             "text": "",
             "colours": [
@@ -10574,7 +10574,7 @@
         },
         {
             "id": "054c2216-1a1d-5e06-af97-fd864688227e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ac0a35-fae7-49f9-ae96-4406df992dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ac0a35-fae7-49f9-ae96-4406df992dc9.jpg?1",
             "name": "Octopus",
             "text": "",
             "colours": [
@@ -10608,7 +10608,7 @@
         },
         {
             "id": "a8ae86dd-06bb-5c57-8e78-e86ede39d412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e4b631-7374-4503-aa66-2a45a41972d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e4b631-7374-4503-aa66-2a45a41972d3.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -10642,7 +10642,7 @@
         },
         {
             "id": "22800811-dd59-5787-bb06-d9bdd23eacf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cb10f5-e22a-4ccd-a1b0-c6f245b15f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cb10f5-e22a-4ccd-a1b0-c6f245b15f64.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "0c4a1f92-77f2-5332-a3d6-e6d087c915d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a63c10-9bf9-4e0f-831c-830d7994a62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a63c10-9bf9-4e0f-831c-830d7994a62a.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "1fe99bbe-0572-5f86-9a6d-31c15cd68542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed666385-a2e7-4e1f-ad2c-babbfc0c50b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed666385-a2e7-4e1f-ad2c-babbfc0c50b3.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "0345e01d-3065-59fe-9326-cccd3b49ff26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8be597-f402-4fb0-9135-897c4a0946f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8be597-f402-4fb0-9135-897c4a0946f6.jpg?1",
             "name": "Gideon, Ally of Zendikar Emblem",
             "text": "",
             "colours": [],
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "b4c96854-da57-5211-975f-8dc9debcbff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a77885-c0de-4487-a920-6fb9ea9bc408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a77885-c0de-4487-a920-6fb9ea9bc408.jpg?1",
             "name": "Ob Nixilis Reignited Emblem",
             "text": "",
             "colours": [],
@@ -10804,7 +10804,7 @@
         },
         {
             "id": "7512bead-cee3-56fc-8619-83840027c735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55952cc8-09d8-4260-8387-284df7223d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55952cc8-09d8-4260-8387-284df7223d74.jpg?1",
             "name": "Kiora, Master of the Depths Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/BIG.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/BIG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8b959fa6-401f-56dc-bc55-4474bcfa3a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg?1",
             "name": "Collector's Cage",
             "text": "Hideaway 5 (When this artifact enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\n{1}, {T}: Put a +1/+1 counter on target creature you control. Then if you control three or more creatures with different powers, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "825bfaec-78b2-5df0-837a-f9c075c72494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -77,7 +77,7 @@
         },
         {
             "id": "fca1ea22-e5d4-5f09-9859-7cab8662912b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg?1",
             "name": "Oltec Matterweaver",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Create a 1/1 colorless Gnome artifact creature token.\n\u2022 Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -115,7 +115,7 @@
         },
         {
             "id": "7ab95887-888b-571c-882f-3003a165dd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d108c2b1-236e-4b8d-8445-d9749ccc4fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d108c2b1-236e-4b8d-8445-d9749ccc4fea.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -150,7 +150,7 @@
         },
         {
             "id": "8cee956e-4c65-5d1f-b6d1-077c393981d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dbb2755-97d9-492e-8697-5548160678c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dbb2755-97d9-492e-8697-5548160678c8.jpg?1",
             "name": "Esoteric Duplicator",
             "text": "Whenever you sacrifice Esoteric Duplicator or another artifact, you may pay {2}. If you do, at the beginning of the next end step, create a token that's a copy of that artifact.\n{2}, Sacrifice Esoteric Duplicator: Draw a card.",
             "colours": [
@@ -187,7 +187,7 @@
         },
         {
             "id": "30466b24-10b4-5a9c-8eae-5df40e9cf1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg?1",
             "name": "Simulacrum Synthesizer",
             "text": "When Simulacrum Synthesizer enters the battlefield, scry 2.\nWhenever another artifact with mana value 3 or greater enters the battlefield under your control, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [
@@ -222,7 +222,7 @@
         },
         {
             "id": "3eba9b11-1208-5a0e-a445-e533d6455c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg?1",
             "name": "Worldwalker Helm",
             "text": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "b1aebc89-6fff-59ed-967b-afbe112aafc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b60a1a6-b2ca-4dc2-a6d9-eff97092079a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b60a1a6-b2ca-4dc2-a6d9-eff97092079a.jpg?1",
             "name": "Greed's Gambit",
             "text": "When Greed's Gambit enters the battlefield, you draw three cards, gain 6 life, and create three 2/1 black Bat creature tokens with flying.\nAt the beginning of your end step, you discard a card, lose 2 life, and sacrifice a creature.\nWhen Greed's Gambit leaves the battlefield, you discard three cards, lose 6 life, and sacrifice three creatures.",
             "colours": [
@@ -292,7 +292,7 @@
         },
         {
             "id": "60eff4be-2617-51fc-bc8d-aa5f755dcdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg?1",
             "name": "Harvester of Misery",
             "text": "Menace\nWhen Harvester of Misery enters the battlefield, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard Harvester of Misery: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -329,7 +329,7 @@
         },
         {
             "id": "82e030cc-eab3-5b89-8756-f3089d96928b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg?1",
             "name": "Hostile Investigator",
             "text": "When Hostile Investigator enters the battlefield, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "75a96eed-9b8e-5289-8158-034d40a8bdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg?1",
             "name": "Generous Plunderer",
             "text": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "4fdb4bf6-d3cd-56fc-82eb-b1d665f9f668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg?1",
             "name": "Legion Extruder",
             "text": "When Legion Extruder enters the battlefield, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "5b2daf16-28fc-5f5c-a5b2-eee8a3d3c5ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg?1",
             "name": "Memory Vessel",
             "text": "{T}, Exile Memory Vessel: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "abe15199-46ff-563f-9aac-e944549ab9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg?1",
             "name": "Molten Duplication",
             "text": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "8cdcf11a-b5b3-5402-b648-e1d0fd7a98e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71059bc8-f63a-4d9c-9d08-2e995e74cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71059bc8-f63a-4d9c-9d08-2e995e74cc59.jpg?1",
             "name": "Territory Forge",
             "text": "When Territory Forge enters the battlefield, if you cast it, exile target artifact or land.\nTerritory Forge has all activated abilities of the exiled card.",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "92071066-e49e-548c-b1f6-d0bea2532388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg?1",
             "name": "Ancient Cornucopia",
             "text": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "371dfc14-724a-5d81-99eb-d1154c96f16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498c4de-5e80-4baa-9fcb-70f164880c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498c4de-5e80-4baa-9fcb-70f164880c84.jpg?1",
             "name": "Bristlebud Farmer",
             "text": "Trample\nWhen Bristlebud Farmer enters the battlefield, create two Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.",
             "colours": [
@@ -619,7 +619,7 @@
         },
         {
             "id": "67f8fc77-6145-511d-b8ef-5d3ae29e77ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49c9b72-61c0-4e3a-a3a6-994b149398a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49c9b72-61c0-4e3a-a3a6-994b149398a9.jpg?1",
             "name": "Omenpath Journey",
             "text": "When Omenpath Journey enters the battlefield, search your library for up to five land cards that have different names, exile them, then shuffle.\nAt the beginning of your end step, choose a card at random exiled with Omenpath Journey and put it onto the battlefield tapped.",
             "colours": [
@@ -654,7 +654,7 @@
         },
         {
             "id": "0ac3a104-8c33-5ed1-b9ea-39053932ac70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg?1",
             "name": "Sandstorm Salvager",
             "text": "When Sandstorm Salvager enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
             "colours": [
@@ -692,7 +692,7 @@
         },
         {
             "id": "fa6828ad-a350-58d0-abf9-b802b1e11b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b3f560-262b-4bc3-9aef-535fd7082c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b3f560-262b-4bc3-9aef-535fd7082c28.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.",
             "colours": [
@@ -730,7 +730,7 @@
         },
         {
             "id": "e65aaef6-bb56-5a20-9bee-d6a08b6392c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb169fa2-c92e-45f7-89a2-0ca0e3910a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb169fa2-c92e-45f7-89a2-0ca0e3910a1c.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "c8a71468-a0c7-5443-96a1-c63789ffb638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a01b92-dafb-4ea6-8eff-29f881f6be24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a01b92-dafb-4ea6-8eff-29f881f6be24.jpg?1",
             "name": "Pest Control",
             "text": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "063797b3-2776-535c-bbd7-9cf9a5a2e649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936504c-4e90-408f-ba98-0fb8c0378471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936504c-4e90-408f-ba98-0fb8c0378471.jpg?1",
             "name": "Lost Jitte",
             "text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one \u2014\n\u2022 Untap target land.\n\u2022 Target creature can't block this turn.\n\u2022 Put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [],
@@ -847,7 +847,7 @@
         },
         {
             "id": "a8c83c7a-c0b8-587f-a51b-a0df78eb3f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02267717-66e0-41f7-8009-75586a4aa4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02267717-66e0-41f7-8009-75586a4aa4be.jpg?1",
             "name": "Lotus Ring",
             "text": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
             "colours": [],
@@ -881,7 +881,7 @@
         },
         {
             "id": "e5b0214e-9c5a-558f-baac-e003a2a8a4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f61742-522c-4b36-97db-41d0c412a072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f61742-522c-4b36-97db-41d0c412a072.jpg?1",
             "name": "Nexus of Becoming",
             "text": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
             "colours": [],
@@ -912,7 +912,7 @@
         },
         {
             "id": "b4672eaf-4004-5721-9587-e5d304b79acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9e5041-3c05-4a8a-9f00-081b01685d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9e5041-3c05-4a8a-9f00-081b01685d0c.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
             "colours": [],
@@ -946,7 +946,7 @@
         },
         {
             "id": "60917bf0-4a28-511a-af9a-a762c98febd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf02a38-d10d-463e-ab99-e7fd848a1bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf02a38-d10d-463e-ab99-e7fd848a1bd3.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -977,7 +977,7 @@
         },
         {
             "id": "19ccb9c7-cf07-55c2-babc-6723942e07d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe673-d688-499a-882b-4fe5418739e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe673-d688-499a-882b-4fe5418739e3.jpg?1",
             "name": "Transmutation Font",
             "text": "{T}: Create your choice of a Blood token, a Clue token, or a Food token.\n{3}, {T}, Sacrifice three artifact tokens with different names: Search your library for an artifact card, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [],
@@ -1008,7 +1008,7 @@
         },
         {
             "id": "acc256d0-870e-5266-a8e5-d6a14f289b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5433b98-4657-4bbe-9e72-d3c94c6aa8ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5433b98-4657-4bbe-9e72-d3c94c6aa8ef.jpg?1",
             "name": "Fomori Vault",
             "text": "{T}: Add {C}.\n{3}, {T}, Discard a card: Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -1039,7 +1039,7 @@
         },
         {
             "id": "f1f86ff4-a918-513f-81fd-add1ce12df51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962552a1-ec34-49e2-a23d-85dfb405d5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962552a1-ec34-49e2-a23d-85dfb405d5e0.jpg?1",
             "name": "Tarnation Vista",
             "text": "Tarnation Vista enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{1}, {T}: For each color among monocolored permanents you control, add one mana of that color.",
             "colours": [],
@@ -1071,7 +1071,7 @@
         },
         {
             "id": "b7045ad4-a28e-54a0-9318-f4bd2c42ae20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8391dbb8-3c8d-42c3-892b-b85e40bb28e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8391dbb8-3c8d-42c3-892b-b85e40bb28e0.jpg?1",
             "name": "Collector's Cage",
             "text": "Hideaway 5\n{1}, {T}: Put a +1/+1 counter on target creature you control. Then if you control three or more creatures with different powers, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "f97bb97e-653d-532a-8d91-082b88ad9025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03304c72-fe8e-42af-96ae-1e64ba0105b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03304c72-fe8e-42af-96ae-1e64ba0105b3.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -1144,7 +1144,7 @@
         },
         {
             "id": "601dc4a0-946e-502d-b7c7-e69bb45a71d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e068335-92f9-4ebd-bb00-f4ff741e3d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e068335-92f9-4ebd-bb00-f4ff741e3d7d.jpg?1",
             "name": "Oltec Matterweaver",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Create a 1/1 colorless Gnome artifact creature token.\n\u2022 Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "c8076b17-ccc2-5f97-a149-c87a9418000f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ef698-caad-47cd-ba35-41be64a58c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ef698-caad-47cd-ba35-41be64a58c99.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "fc5f3a0c-271b-5763-a3e5-31ca11bf784e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4b7ac-d45a-4ce9-97b4-35789df8a162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4b7ac-d45a-4ce9-97b4-35789df8a162.jpg?1",
             "name": "Esoteric Duplicator",
             "text": "Whenever you sacrifice Esoteric Duplicator or another artifact, you may pay {2}. If you do, at the beginning of the next end step, create a token that's a copy of that artifact.\n{2}, Sacrifice Esoteric Duplicator: Draw a card.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "73030017-9483-5f73-b4be-0660e1a5c1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a11489-11c5-4018-aab8-c9d036638414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a11489-11c5-4018-aab8-c9d036638414.jpg?1",
             "name": "Simulacrum Synthesizer",
             "text": "When Simulacrum Synthesizer enters the battlefield, scry 2.\nWhenever another artifact with mana value 3 or greater enters the battlefield under your control, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "25bd235a-f251-5da8-95de-afba45cc38da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abd5601-c8b4-4ac8-aab0-be5c7b3aaf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abd5601-c8b4-4ac8-aab0-be5c7b3aaf56.jpg?1",
             "name": "Worldwalker Helm",
             "text": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token.\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "9f34964f-f02b-5ad0-bc15-f44d167cb67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cb3add-c39c-4124-a028-87333aab0929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cb3add-c39c-4124-a028-87333aab0929.jpg?1",
             "name": "Greed's Gambit",
             "text": "When Greed's Gambit enters the battlefield, you draw three cards, gain 6 life, and create three 2/1 black Bat creature tokens with flying.\nAt the beginning of your end step, you discard a card, lose 2 life, and sacrifice a creature.\nWhen Greed's Gambit leaves the battlefield, you discard three cards, lose 6 life, and sacrifice three creatures.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "11df0150-4ded-54ea-bd5d-77bce572d502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e81c9e-02f4-4c18-9326-127e08c9b47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e81c9e-02f4-4c18-9326-127e08c9b47f.jpg?1",
             "name": "Harvester of Misery",
             "text": "Menace\nWhen Harvester of Misery enters the battlefield, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard Harvester of Misery: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "9079f8fd-1e9e-53da-8b9d-6832313dd265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cd1d1b-dbde-4a2c-94ed-58395867799c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cd1d1b-dbde-4a2c-94ed-58395867799c.jpg?1",
             "name": "Hostile Investigator",
             "text": "When Hostile Investigator enters the battlefield, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "1b0d880e-fdfb-5905-9a74-7d6742fb1774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351eea06-f5be-4044-b3b3-cc6bf805abb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351eea06-f5be-4044-b3b3-cc6bf805abb1.jpg?1",
             "name": "Generous Plunderer",
             "text": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
             "colours": [
@@ -1473,7 +1473,7 @@
         },
         {
             "id": "7691ba3c-4844-54b2-8571-e73e4b6c7ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d67fd7-30c8-4cd7-ab1a-97225b9c9437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d67fd7-30c8-4cd7-ab1a-97225b9c9437.jpg?1",
             "name": "Legion Extruder",
             "text": "When Legion Extruder enters the battlefield, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "b0a74035-98d2-55f0-b5a8-5c4204aadb32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db47f1bc-7f50-493f-bb3f-c1285cbaf244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db47f1bc-7f50-493f-bb3f-c1285cbaf244.jpg?1",
             "name": "Memory Vessel",
             "text": "{T}, Exile Memory Vessel: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "f72327f3-9884-5390-b3d2-0bb5d8299449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4ba0c9-ec77-4406-a62a-82a550791e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4ba0c9-ec77-4406-a62a-82a550791e61.jpg?1",
             "name": "Molten Duplication",
             "text": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "cd4c50f2-a945-5c43-8410-6151da7b8bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd6bde-29ec-4de2-b369-bb3e1d2714d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd6bde-29ec-4de2-b369-bb3e1d2714d9.jpg?1",
             "name": "Territory Forge",
             "text": "When Territory Forge enters the battlefield, if you cast it, exile target artifact or land.\nTerritory Forge has all activated abilities of the exiled card.",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "c3084caa-ba9d-5984-a79b-2dd9aece669a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f23dffc-c76b-4f01-98c2-67dae3b3114b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f23dffc-c76b-4f01-98c2-67dae3b3114b.jpg?1",
             "name": "Ancient Cornucopia",
             "text": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "f7155008-08c2-57cc-aeeb-8c60ffe6a84a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713be7b8-e73f-4ed1-8a14-cc1c144e844e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713be7b8-e73f-4ed1-8a14-cc1c144e844e.jpg?1",
             "name": "Bristlebud Farmer",
             "text": "Trample\nWhen Bristlebud Farmer enters the battlefield, create two Food tokens.\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "388ac8d4-0add-529e-ae3e-7da222d478c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385e6c23-0eab-4bc9-8b30-524879051ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385e6c23-0eab-4bc9-8b30-524879051ce9.jpg?1",
             "name": "Omenpath Journey",
             "text": "When Omenpath Journey enters the battlefield, search your library for up to five land cards that have different names, exile them, then shuffle.\nAt the beginning of your end step, choose a card at random exiled with Omenpath Journey and put it onto the battlefield tapped.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "16133d48-d867-56d2-b103-75c657260ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613173-2892-47d7-8a09-2102f2f0965f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613173-2892-47d7-8a09-2102f2f0965f.jpg?1",
             "name": "Sandstorm Salvager",
             "text": "When Sandstorm Salvager enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "1ff3d49d-979d-5237-b2dd-28f4da08401a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f0544c-0124-497c-a8f1-5d5fb959ca39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f0544c-0124-497c-a8f1-5d5fb959ca39.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "be7910d3-5594-5ecd-b300-ab3917bf2ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3db1928-86f2-4606-ad2d-4b7dfd7e5d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3db1928-86f2-4606-ad2d-4b7dfd7e5d6b.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
             "colours": [
@@ -1842,7 +1842,7 @@
         },
         {
             "id": "d43c007b-ed48-5345-a141-ed45d68b4bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d67c7fb-043f-4984-a700-5e8aa44c90aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d67c7fb-043f-4984-a700-5e8aa44c90aa.jpg?1",
             "name": "Pest Control",
             "text": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2}",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "d8155cfe-316d-58c1-a728-510d8b0b5cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc679a0e-bf7b-40b5-b904-9c2d3508fa83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc679a0e-bf7b-40b5-b904-9c2d3508fa83.jpg?1",
             "name": "Lost Jitte",
             "text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one \u2014\n\u2022 Untap target land.\n\u2022 Target creature can't block this turn.\n\u2022 Put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [],
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "53906ad8-855f-56ff-aee3-865b69a25575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fb925a-5845-4d73-8122-6e7a36a9bd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fb925a-5845-4d73-8122-6e7a36a9bd0d.jpg?1",
             "name": "Lotus Ring",
             "text": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
             "colours": [],
@@ -1948,7 +1948,7 @@
         },
         {
             "id": "4c3fb2ad-f882-50ff-a955-73f81e21522e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f329b59c-1c1d-4a0a-89b4-c3fc4a8074bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f329b59c-1c1d-4a0a-89b4-c3fc4a8074bc.jpg?1",
             "name": "Nexus of Becoming",
             "text": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
             "colours": [],
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "3594daed-c644-5230-9138-d6407092e183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf08dd1-3d35-4842-807d-37f94b9ba578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf08dd1-3d35-4842-807d-37f94b9ba578.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
             "colours": [],
@@ -2013,7 +2013,7 @@
         },
         {
             "id": "d7068cbb-25ca-5cd0-ae7f-2788a710898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc2948-f185-4c3f-b80e-2bc8f47825c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc2948-f185-4c3f-b80e-2bc8f47825c9.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -2044,7 +2044,7 @@
         },
         {
             "id": "aba80c2e-54e7-53df-af5f-74f47a494282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7227906c-043b-4742-8141-694f7811dc06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7227906c-043b-4742-8141-694f7811dc06.jpg?1",
             "name": "Transmutation Font",
             "text": "{T}: Create your choice of a Blood token, a Clue token, or a Food token.\n{3}, {T}, Sacrifice three artifact tokens with different names: Search your library for an artifact card, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [],
@@ -2075,7 +2075,7 @@
         },
         {
             "id": "40ccc7b4-6dc5-5f4c-839a-ff2cbc821660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad282dc0-6310-47ab-99cd-90f34168bd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad282dc0-6310-47ab-99cd-90f34168bd27.jpg?1",
             "name": "Fomori Vault",
             "text": "{T}: Add {C}.\n{3}, {T}, Discard a card: Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -2106,7 +2106,7 @@
         },
         {
             "id": "bd01e647-7d11-5440-9192-35aa97124486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad49fd74-db70-49c0-8ad9-1185e2b0787d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad49fd74-db70-49c0-8ad9-1185e2b0787d.jpg?1",
             "name": "Tarnation Vista",
             "text": "Tarnation Vista enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{1}, {T}: For each color among monocolored permanents you control, add one mana of that color.",
             "colours": [],
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "109bba79-b3ec-5ff9-8641-26e47148d6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba9e2cc-e0a3-4c5a-9ca0-f683ff8b5c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba9e2cc-e0a3-4c5a-9ca0-f683ff8b5c94.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "b04b2cdb-9115-5ae0-9545-ad4d8c8a7819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18fa57-fab9-48f6-b80a-d03fb89d2683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18fa57-fab9-48f6-b80a-d03fb89d2683.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "62567c60-1e1a-5ec8-b4fc-93a8453e2796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa77cff4-0f0a-430a-b0c8-aab82299c570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa77cff4-0f0a-430a-b0c8-aab82299c570.jpg?1",
             "name": "Lotus Ring",
             "text": "",
             "colours": [],
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "cc00fbf0-4b78-5ba7-bef9-f9e3aa2bb421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59193e1f-7231-4967-82eb-1cb0b5494dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59193e1f-7231-4967-82eb-1cb0b5494dc7.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "",
             "colours": [],
@@ -2285,7 +2285,7 @@
         },
         {
             "id": "3115f5e2-aa7b-5a03-9540-e8044a0c38f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad50cee8-0f7f-4058-8fe1-5d7156c2429b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad50cee8-0f7f-4058-8fe1-5d7156c2429b.jpg?1",
             "name": "Tarnation Vista",
             "text": "",
             "colours": [],
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "ec5277f0-1e92-58f1-90a8-131fac302520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f40f6a3-5f38-498e-99fe-e60e93d7a05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f40f6a3-5f38-498e-99fe-e60e93d7a05c.jpg?1",
             "name": "Collector's Cage",
             "text": "Hideaway 5\n{1}, {T}: Put a +1/+1 counter on target creature you control. Then if you control three or more creatures with different powers, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "7cafe33b-979f-55a1-80eb-4858385a6b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439551c-6764-4c35-a5ba-c7adb727cf7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439551c-6764-4c35-a5ba-c7adb727cf7a.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "82e69281-20b3-5b27-b2c0-1495e449522e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1617d39d-4989-4ac4-8cd0-ac1b4e7312df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1617d39d-4989-4ac4-8cd0-ac1b4e7312df.jpg?1",
             "name": "Oltec Matterweaver",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Create a 1/1 colorless Gnome artifact creature token.\n\u2022 Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "56ef73df-6329-574c-89f6-c71833b30690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a52b1bc-cf29-49bd-a877-03a21fe8a6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a52b1bc-cf29-49bd-a877-03a21fe8a6c5.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "8e837162-2843-536a-86e2-74d23007b1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba1736b-9e11-4169-9525-1540a64a3188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba1736b-9e11-4169-9525-1540a64a3188.jpg?1",
             "name": "Esoteric Duplicator",
             "text": "Whenever you sacrifice Esoteric Duplicator or another artifact, you may pay {2}. If you do, at the beginning of the next end step, create a token that's a copy of that artifact.\n{2}, Sacrifice Esoteric Duplicator: Draw a card.",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "c3cfc938-9b15-5ca1-9361-e89523d310dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e003f9-2fad-48b4-8e5b-4cda8612ecd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e003f9-2fad-48b4-8e5b-4cda8612ecd2.jpg?1",
             "name": "Simulacrum Synthesizer",
             "text": "When Simulacrum Synthesizer enters the battlefield, scry 2.\nWhenever another artifact with mana value 3 or greater enters the battlefield under your control, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "d37798bc-b707-50df-9101-c543bedc0060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db3d9f-d95e-4854-8ea6-7970877221d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db3d9f-d95e-4854-8ea6-7970877221d6.jpg?1",
             "name": "Worldwalker Helm",
             "text": "If you would create one or more artifact tokens, instead create those tokens plus an additional Map token.\n{1}{U}, {T}: Create a token that's a copy of target artifact token you control.",
             "colours": [
@@ -2569,7 +2569,7 @@
         },
         {
             "id": "2edf98ba-c6ea-5860-86b7-f650bec76557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c57172-6de4-421f-93d8-be1c601c1d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c57172-6de4-421f-93d8-be1c601c1d0b.jpg?1",
             "name": "Greed's Gambit",
             "text": "When Greed's Gambit enters the battlefield, you draw three cards, gain 6 life, and create three 2/1 black Bat creature tokens with flying.\nAt the beginning of your end step, you discard a card, lose 2 life, and sacrifice a creature.\nWhen Greed's Gambit leaves the battlefield, you discard three cards, lose 6 life, and sacrifice three creatures.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "402daa86-3f2e-5628-aa16-e76b04ba9d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2adbac7-e479-4c73-8978-f7fde9f6e14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2adbac7-e479-4c73-8978-f7fde9f6e14d.jpg?1",
             "name": "Harvester of Misery",
             "text": "Menace\nWhen Harvester of Misery enters the battlefield, other creatures get -2/-2 until end of turn.\n{1}{B}, Discard Harvester of Misery: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "a1f3a6a7-78d5-5b45-890c-a144b2644cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c9365-af51-4874-be5b-57d0514825fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c9365-af51-4874-be5b-57d0514825fe.jpg?1",
             "name": "Hostile Investigator",
             "text": "When Hostile Investigator enters the battlefield, target opponent discards a card.\nWhenever one or more players discard one or more cards, investigate. This ability triggers only once each turn.",
             "colours": [
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "1b925c9d-4bf8-50d1-8858-6ddda3710521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393bf5fc-0ad2-4116-83b4-346d61ac2911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393bf5fc-0ad2-4116-83b4-346d61ac2911.jpg?1",
             "name": "Generous Plunderer",
             "text": "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "ad9a9ad4-a5ae-5656-a0e7-8805cc145719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffddccb-4195-4c8b-b2b3-5c545c656fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffddccb-4195-4c8b-b2b3-5c545c656fee.jpg?1",
             "name": "Legion Extruder",
             "text": "When Legion Extruder enters the battlefield, it deals 2 damage to any target.\n{2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "710280ef-b562-587c-bdeb-659d0e916455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9f1d0c-6f99-4b34-a367-052dd612ecda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9f1d0c-6f99-4b34-a367-052dd612ecda.jpg?1",
             "name": "Memory Vessel",
             "text": "{T}, Exile Memory Vessel: Each player exiles the top seven cards of their library. Until your next turn, players may play cards they exiled this way, and they can't play cards from their hand. Activate only as a sorcery.",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "b3544854-6769-5c74-aa07-4a7df696e259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fbf320-63e1-461e-9696-561a2d6f554a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fbf320-63e1-461e-9696-561a2d6f554a.jpg?1",
             "name": "Molten Duplication",
             "text": "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "17b01af4-9ce9-5d36-9d54-a520261624ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5999e2ac-7111-470a-b597-4c751ffecbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5999e2ac-7111-470a-b597-4c751ffecbfd.jpg?1",
             "name": "Territory Forge",
             "text": "When Territory Forge enters the battlefield, if you cast it, exile target artifact or land.\nTerritory Forge has all activated abilities of the exiled card.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "b81f887f-4215-5d20-8f13-af2f6de239f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b9c600-72e2-4648-9276-99b21cec00dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b9c600-72e2-4648-9276-99b21cec00dd.jpg?1",
             "name": "Ancient Cornucopia",
             "text": "Whenever you cast a spell that's one or more colors, you may gain 1 life for each of that spell's colors. Do this only once each turn.\n{T}: Add one mana of any color.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "38d75be4-1864-5794-8867-c50119746f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa29302-65bb-4852-94dd-9c5f5477f94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa29302-65bb-4852-94dd-9c5f5477f94f.jpg?1",
             "name": "Bristlebud Farmer",
             "text": "Trample\nWhen Bristlebud Farmer enters the battlefield, create two Food tokens.\nWhenever Bristlebud Farmer attacks, you may sacrifice a Food. If you do, mill three cards. You may put a permanent card from among them into your hand.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "2a6ce767-3e3f-5917-b7f1-ec24cb2c4efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e6422-801a-48ec-8fb7-ff59e1fed25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e6422-801a-48ec-8fb7-ff59e1fed25c.jpg?1",
             "name": "Omenpath Journey",
             "text": "When Omenpath Journey enters the battlefield, search your library for up to five land cards that have different names, exile them, then shuffle.\nAt the beginning of your end step, choose a card at random exiled with Omenpath Journey and put it onto the battlefield tapped.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "817df7eb-fe55-52ca-8a40-bca55c2435c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c96b72-b0e1-4ea3-9984-5a67718d070d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c96b72-b0e1-4ea3-9984-5a67718d070d.jpg?1",
             "name": "Sandstorm Salvager",
             "text": "When Sandstorm Salvager enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{2}, {T}: Put a +1/+1 counter on each creature token you control. They gain trample until end of turn.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "34140249-3c3f-5c18-99d6-c1f4f21632de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca436a-e992-40a9-978a-501a82e443ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca436a-e992-40a9-978a-501a82e443ed.jpg?1",
             "name": "Vaultborn Tyrant",
             "text": "Trample\nWhenever Vaultborn Tyrant or another creature with power 4 or greater enters the battlefield under your control, you gain 3 life and draw a card.\nWhen Vaultborn Tyrant dies, if it's not a token, create a token that's a copy of it, except it's an artifact in addition to its other types.",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "3ec753c7-3c00-501e-9e68-0d438a377bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db35dae-6701-45a1-97c4-3e3049b45555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db35dae-6701-45a1-97c4-3e3049b45555.jpg?1",
             "name": "Loot, the Key to Everything",
             "text": "Ward {1}\nAt the beginning of your upkeep, exile the top X cards of your library, where X is the number of card types among other nonland permanents you control. You may play those cards this turn.",
             "colours": [
@@ -3087,7 +3087,7 @@
         },
         {
             "id": "57bc0a37-1f46-5a43-9259-c8f2d804d171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d62921-f76d-436a-ae8b-c3a52715b47d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d62921-f76d-436a-ae8b-c3a52715b47d.jpg?1",
             "name": "Pest Control",
             "text": "Destroy all nonland permanents with mana value 1 or less.\nCycling {2}",
             "colours": [
@@ -3124,7 +3124,7 @@
         },
         {
             "id": "6232a2a9-0d22-58d3-b80e-64ffc5d9319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a723b3-e93b-499e-a5cf-f79a3634d4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a723b3-e93b-499e-a5cf-f79a3634d4da.jpg?1",
             "name": "Lost Jitte",
             "text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one \u2014\n\u2022 Untap target land.\n\u2022 Target creature can't block this turn.\n\u2022 Put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [],
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "17bf0ea6-715f-5a2c-ab21-231e0d0fae77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d0c7a2-9614-4e72-a18f-7187de102dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d0c7a2-9614-4e72-a18f-7187de102dc3.jpg?1",
             "name": "Lotus Ring",
             "text": "Indestructible\nEquipped creature gets +3/+3 and has vigilance and \"{T}, Sacrifice this creature: Add three mana of any one color.\"\nEquip {3}",
             "colours": [],
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "b991f38f-86c3-5a89-a5f4-4f91b4c0dfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb8d780-ed74-4084-ac3b-245af39d00da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb8d780-ed74-4084-ac3b-245af39d00da.jpg?1",
             "name": "Nexus of Becoming",
             "text": "At the beginning of combat on your turn, draw a card. Then you may exile an artifact or creature card from your hand. If you do, create a token that's a copy of the exiled card, except it's a 3/3 Golem artifact creature in addition to its other types.",
             "colours": [],
@@ -3224,7 +3224,7 @@
         },
         {
             "id": "1aa0c4aa-017c-5d6d-b2a5-316e0f0cfc55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdcd21-55a3-4cad-8b73-3d6f85a69ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdcd21-55a3-4cad-8b73-3d6f85a69ce1.jpg?1",
             "name": "Sword of Wealth and Power",
             "text": "Equipped creature gets +2/+2 and has protection from instants and from sorceries.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nEquip {2}",
             "colours": [],
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "eec50a2e-2e7c-529b-9c14-0f7c64b32c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034bf77-38dc-4b43-9a00-831d89af437a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034bf77-38dc-4b43-9a00-831d89af437a.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "adc75fcb-2b7c-5fb3-a0eb-9253e52af69d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2058a-24a7-4b10-a1d5-0b69e94c8688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2058a-24a7-4b10-a1d5-0b69e94c8688.jpg?1",
             "name": "Transmutation Font",
             "text": "{T}: Create your choice of a Blood token, a Clue token, or a Food token.\n{3}, {T}, Sacrifice three artifact tokens with different names: Search your library for an artifact card, put it onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [],
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "0d0b10ee-f9c8-5a50-ae58-138f8d18a32e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419022-bed8-425c-99a9-fc288446efd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419022-bed8-425c-99a9-fc288446efd1.jpg?1",
             "name": "Fomori Vault",
             "text": "{T}: Add {C}.\n{3}, {T}, Discard a card: Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "61f2ac50-f6ba-51d9-b93b-76db551df577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b85d6ea-e312-48b9-9c22-398454d9a45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b85d6ea-e312-48b9-9c22-398454d9a45c.jpg?1",
             "name": "Tarnation Vista",
             "text": "Tarnation Vista enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{1}, {T}: For each color among monocolored permanents you control, add one mana of that color.",
             "colours": [],
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "b27f7542-51ce-5c9b-8042-37377b10d01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f138e5-501d-486f-b9a0-3f37640398a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f138e5-501d-486f-b9a0-3f37640398a0.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "309ddf88-4480-5518-8c98-1f1e60b013dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0753c3b5-6127-4e42-a029-b165d5f8170c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0753c3b5-6127-4e42-a029-b165d5f8170c.jpg?1",
             "name": "Blood",
             "text": "",
             "colours": [],
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "c0107955-7c56-5df9-9df1-740a54f52416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d2d1-61f2-4295-b0fc-827965eaaefc.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "9300919a-d231-50be-9f4b-3ed4a4258350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e3af6-7904-4214-8141-e145c48e2687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e3af6-7904-4214-8141-e145c48e2687.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "f407d357-2a03-5d42-8567-c942802d7ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a257ae72-2a82-4861-a2fb-a0a09be00646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a257ae72-2a82-4861-a2fb-a0a09be00646.jpg?1",
             "name": "Gnome",
             "text": "",
             "colours": [],
@@ -3544,7 +3544,7 @@
         },
         {
             "id": "a890ea09-dc01-5f95-8ccd-bbcae0d2bb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "ca9e0bcd-65f0-57dd-b5a1-eb8dac469f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03516d49-0613-46f7-8d88-3bf26d2c8659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03516d49-0613-46f7-8d88-3bf26d2c8659.jpg?1",
             "name": "Map",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/BLB.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/BLB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "43463b33-91c0-5c9a-afbd-16348aee95f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a06f82-ebdb-4dd6-bfe8-958018ce557c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a06f82-ebdb-4dd6-bfe8-958018ce557c.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "d32ba1b1-d971-575a-a7c6-4723ca7859f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc310a26-b6a0-4e42-98ab-bdfd7b06cb63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc310a26-b6a0-4e42-98ab-bdfd7b06cb63.jpg?1",
             "name": "Beza, the Bounding Spring",
             "text": "When Beza, the Bounding Spring enters, create a Treasure token if an opponent controls more lands than you. You gain 4 life if an opponent has more life than you. Create two 1/1 blue Fish creature tokens if an opponent controls more creatures than you. Draw a card if an opponent has more cards in hand than you.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "60ca340a-dae9-59eb-b478-ed1a4cbb1544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd4693-424d-4d6e-86cf-24401a23d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd4693-424d-4d6e-86cf-24401a23d6b1.jpg?1",
             "name": "Brave-Kin Duo",
             "text": "{1}, {T}: Target creature gets +1/+1 until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "a8a20283-129e-5418-99d2-a02aaab2252b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7fea2e-7414-4bc8-adb0-9342e174c009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7fea2e-7414-4bc8-adb0-9342e174c009.jpg?1",
             "name": "Brightblade Stoat",
             "text": "First strike, lifelink",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "55164590-76b4-5111-a850-7d3fbc6bb1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fa581a-724e-4196-a9a3-ff84c54bdb7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fa581a-724e-4196-a9a3-ff84c54bdb7d.jpg?1",
             "name": "Builder's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Builder's Talent enters, create a 0/4 white Wall creature token with defender.\n{W}: Level 2\n//Level_2//\nWhenever one or more noncreature, nonland permanents you control enter, put a +1/+1 counter on target creature you control.\n{4}{W}: Level 3\n//Level_3//\nWhen this Class becomes level 3, return target noncreature, nonland permanent card from your graveyard to the battlefield.",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "8bbc28f3-0f0b-5418-8f23-52b4aea94e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ea98a-e36e-4ab9-b4da-cc572f3777db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ea98a-e36e-4ab9-b4da-cc572f3777db.jpg?1",
             "name": "Caretaker's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever one or more tokens you control enter, draw a card. This ability triggers only once each turn.\n{W}: Level 2\n//Level_2//\nWhen this Class becomes level 2, create a token that's a copy of target token you control.\n{3}{W}: Level 3\n//Level_3//\nCreature tokens you control get +2/+2.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "06ee1d2b-9cb8-5aa6-93b5-fdf8c2c90ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb03bb4f-8b4b-417e-bfc6-294cd2186b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb03bb4f-8b4b-417e-bfc6-294cd2186b2e.jpg?1",
             "name": "Carrot Cake",
             "text": "When Carrot Cake enters and when you sacrifice it, create a 1/1 white Rabbit creature token and scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{2}, {T}, Sacrifice Carrot Cake: You gain 3 life.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "89648894-3761-5c3a-bc7a-00408aaa6de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7b3b25-d4b3-4451-9f5c-6eb369541175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7b3b25-d4b3-4451-9f5c-6eb369541175.jpg?1",
             "name": "Crumb and Get It",
             "text": "Gift a Food (You may promise an opponent a gift as you cast this spell. If you do, they create a Food token before its other effects. It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nTarget creature you control gets +2/+2 until end of turn. If the gift was promised, that creature also gains indestructible until end of turn.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "411b89a3-9905-5e86-ad59-6d0bcdef526f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72bfa0-efef-48ce-aff8-d5818ed71ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72bfa0-efef-48ce-aff8-d5818ed71ba6.jpg?1",
             "name": "Dawn's Truce",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nYou and permanents you control gain hexproof until end of turn. If the gift was promised, permanents you control also gain indestructible until end of turn.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "8454441c-3070-53d5-bfbc-f37dc6f5fcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666aefc2-44e0-4c27-88d5-7906f245a71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666aefc2-44e0-4c27-88d5-7906f245a71f.jpg?1",
             "name": "Dewdrop Cure",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn up to two target creature cards each with mana value 2 or less from your graveyard to the battlefield. If the gift was promised, instead return up to three target creature cards each with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "d1655fc0-abe9-57d0-8ddc-cdc64a8b582c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ab2de3-3aea-461a-a74f-fb742cf8a198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ab2de3-3aea-461a-a74f-fb742cf8a198.jpg?1",
             "name": "Driftgloom Coyote",
             "text": "When Driftgloom Coyote enters, exile target creature an opponent controls until Driftgloom Coyote leaves the battlefield. If that creature had power 2 or less, put a +1/+1 counter on Driftgloom Coyote.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "030d297d-c2c6-51d2-b51e-fc50ad3983c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf7e4c-4d5d-4acc-a834-e6c4a7629408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf7e4c-4d5d-4acc-a834-e6c4a7629408.jpg?1",
             "name": "Essence Channeler",
             "text": "As long as you've lost life this turn, Essence Channeler has flying and vigilance.\nWhenever you gain life, put a +1/+1 counter on Essence Channeler.\nWhen Essence Channeler dies, put its counters on target creature you control.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "c22733cb-1827-5cf1-acd3-f3b40f991ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb41503-8632-4bf1-9bfe-6d9b9993c337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb41503-8632-4bf1-9bfe-6d9b9993c337.jpg?1",
             "name": "Feather of Flight",
             "text": "Flash\nEnchant creature\nWhen Feather of Flight enters, draw a card.\nEnchanted creature gets +1/+0 and has flying.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "2bbf8952-5e38-5653-89f1-ed1d65ac28da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff118f-9c3c-43a2-8085-980c7fe7d227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ff118f-9c3c-43a2-8085-980c7fe7d227.jpg?1",
             "name": "Flowerfoot Swordmaster",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nValiant \u2014 Whenever this creature becomes the target of a spell or ability you control for the first time each turn, Mice you control get +1/+0 until end of turn.",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "4174a7d3-37ad-5b7b-aba5-9a0e16e48e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41762689-0c13-4d45-9d81-ba2afad980f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41762689-0c13-4d45-9d81-ba2afad980f8.jpg?1",
             "name": "Harvestrite Host",
             "text": "Whenever Harvestrite Host or another Rabbit you control enters, target creature you control gets +1/+0 until end of turn. Then draw a card if this is the second time this ability has resolved this turn.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "5f1915e5-2cbd-5178-be2b-b244d4e88be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7207f8-5daa-42af-aeea-7a489047110b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7207f8-5daa-42af-aeea-7a489047110b.jpg?1",
             "name": "Hop to It",
             "text": "Create three 1/1 white Rabbit creature tokens.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "0e9c0952-72c4-5ded-bdfa-9ec5d5c899ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d70b99d-c8bf-4a56-8957-cf587fe60b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d70b99d-c8bf-4a56-8957-cf587fe60b81.jpg?1",
             "name": "Intrepid Rabbit",
             "text": "Offspring {1} (You may pay an additional {1} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "4502bd7c-49ad-516b-bc55-e98a95d625c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121af600-6143-450a-9f87-12ce4833f1ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121af600-6143-450a-9f87-12ce4833f1ec.jpg?1",
             "name": "Jackdaw Savior",
             "text": "Flying\nWhenever Jackdaw Savior or another creature you control with flying dies, return another target creature card with lesser mana value from your graveyard to the battlefield.",
             "colours": [
@@ -627,7 +627,7 @@
         },
         {
             "id": "0bbf1c63-e1b9-5ce1-b8e5-25654f106798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eab51d6-ba17-4a8c-8834-25db363f2b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eab51d6-ba17-4a8c-8834-25db363f2b6b.jpg?1",
             "name": "Jolly Gerbils",
             "text": "Whenever you give a gift, draw a card.",
             "colours": [
@@ -662,7 +662,7 @@
         },
         {
             "id": "5e029c84-b08b-5548-af4b-17d0956cce42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca543405-5e12-48a0-9a77-082ac9bcb2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca543405-5e12-48a0-9a77-082ac9bcb2f2.jpg?1",
             "name": "Lifecreed Duo",
             "text": "Flying\nWhenever another creature you control enters, you gain 1 life.",
             "colours": [
@@ -697,7 +697,7 @@
         },
         {
             "id": "29a310b0-918a-59e7-a30c-aa7db1b32811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfcf83f-089c-4e35-855e-b61b98bb1cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfcf83f-089c-4e35-855e-b61b98bb1cd8.jpg?1",
             "name": "Mabel's Mettle",
             "text": "Target creature gets +2/+2 until end of turn. Up to one other target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -729,7 +729,7 @@
         },
         {
             "id": "a8d4ff66-893b-5d7c-bdd7-2af337d5af9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1bc5a-03e7-44ec-893e-44042cbc02ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba1bc5a-03e7-44ec-893e-44042cbc02ef.jpg?1",
             "name": "Mouse Trapper",
             "text": "Flash\nValiant \u2014 Whenever Mouse Trapper becomes the target of a spell or ability you control for the first time each turn, tap target creature an opponent controls.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "a902dba4-1c65-5a5b-a2bc-6ca48131da7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c3cc3-2aa2-453e-a17c-2baeeaabe0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9c3cc3-2aa2-453e-a17c-2baeeaabe0a9.jpg?1",
             "name": "Nettle Guard",
             "text": "Valiant \u2014 Whenever Nettle Guard becomes the target of a spell or ability you control for the first time each turn, it gets +0/+2 until end of turn.\n{1}, Sacrifice Nettle Guard: Destroy target artifact or enchantment.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "3db803d4-f111-54e3-be00-d3b1c64025a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1086e826-94b8-4398-8a38-d8eacca56a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1086e826-94b8-4398-8a38-d8eacca56a43.jpg?1",
             "name": "Parting Gust",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nExile target nontoken creature. If the gift wasn't promised, return that creature to the battlefield under its owner's control with a +1/+1 counter on it at the beginning of the next end step.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "3d62cdb2-06cf-5a56-9037-7b823d5e8545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae442cd6-c4df-4aad-9b1d-ccd936c5ec96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae442cd6-c4df-4aad-9b1d-ccd936c5ec96.jpg?1",
             "name": "Pileated Provisioner",
             "text": "Flying\nWhen Pileated Provisioner enters, put a +1/+1 counter on target creature you control without flying.",
             "colours": [
@@ -866,7 +866,7 @@
         },
         {
             "id": "56fb4235-0a6a-5752-b6b1-2cc2a49d1e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ded450-346d-4917-917a-b62bc0267509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ded450-346d-4917-917a-b62bc0267509.jpg?1",
             "name": "Rabbit Response",
             "text": "Creatures you control get +2/+1 until end of turn. If you control a Rabbit, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
             "colours": [
@@ -898,7 +898,7 @@
         },
         {
             "id": "21513c17-e7d0-5aea-8f6a-cf641af659a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d068192a-6270-4981-819d-4945fa4a2b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d068192a-6270-4981-819d-4945fa4a2b83.jpg?1",
             "name": "Repel Calamity",
             "text": "Destroy target creature with power or toughness 4 or greater.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "1f654bec-85ba-5d89-b735-d3e9b3e9df59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2656160-d319-4530-a6e5-c418596c3f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2656160-d319-4530-a6e5-c418596c3f12.jpg?1",
             "name": "Salvation Swan",
             "text": "Flash\nFlying\nWhenever Salvation Swan or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "c467fb82-19c8-5f90-a4bf-093da8183330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf9c60-4e58-48a4-8e53-abef7ab3b671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf9c60-4e58-48a4-8e53-abef7ab3b671.jpg?1",
             "name": "Season of the Burrow",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a 1/1 white Rabbit creature token.\n{Paw Print}{Paw Print} \u2014 Exile target nonland permanent. Its controller draws a card.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return target permanent card with mana value 3 or less from your graveyard to the battlefield with an indestructible counter on it.",
             "colours": [
@@ -1001,7 +1001,7 @@
         },
         {
             "id": "9fbacd89-01c6-5df4-b63f-3590d05bee5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90873995-876f-4e89-8bc7-41a74f4d931f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90873995-876f-4e89-8bc7-41a74f4d931f.jpg?1",
             "name": "Seasoned Warrenguard",
             "text": "Whenever Seasoned Warrenguard attacks while you control a token, Seasoned Warrenguard gets +2/+0 until end of turn.",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "f2bd680c-c60d-5189-8fb2-82b169ed31c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306fec2c-d8b7-4f4b-8f58-10e3b9f3158f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306fec2c-d8b7-4f4b-8f58-10e3b9f3158f.jpg?1",
             "name": "Shrike Force",
             "text": "Flying, double strike, vigilance",
             "colours": [
@@ -1071,7 +1071,7 @@
         },
         {
             "id": "922a88c7-456f-59ce-963e-8d9bd3974978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50da179-751f-47a8-a547-8c4a291ed381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50da179-751f-47a8-a547-8c4a291ed381.jpg?1",
             "name": "Sonar Strike",
             "text": "Sonar Strike deals 4 damage to target attacking, blocking, or tapped creature. You gain 3 life if you control a Bat.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "664f2845-7239-5250-81ec-73aae3669ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e209237-00f7-4bf0-8287-ccde02ce8e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e209237-00f7-4bf0-8287-ccde02ce8e8d.jpg?1",
             "name": "Star Charter",
             "text": "Flying\nAt the beginning of your end step, if you gained or lost life this turn, look at the top four cards of your library. You may reveal a creature card with power 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1138,7 +1138,7 @@
         },
         {
             "id": "19f24ef3-a354-5158-9ca5-a68105890961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aea38e6-ec58-4091-b27c-2761bdd12b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aea38e6-ec58-4091-b27c-2761bdd12b13.jpg?1",
             "name": "Starfall Invocation",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nDestroy all creatures. If the gift was promised, return a creature card put into your graveyard this way to the battlefield under your control.",
             "colours": [
@@ -1172,7 +1172,7 @@
         },
         {
             "id": "579f8dec-429c-5538-9044-b0c53c9fb950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa8d83f-8586-4127-8b55-9715e9547488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa8d83f-8586-4127-8b55-9715e9547488.jpg?1",
             "name": "Thistledown Players",
             "text": "Whenever Thistledown Players attacks, untap target nonland permanent.",
             "colours": [
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "88e5e27c-9dc6-52b6-8c7a-1a8c5e066a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba629ca8-a368-4282-8a61-9bf6a5c217f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba629ca8-a368-4282-8a61-9bf6a5c217f0.jpg?1",
             "name": "Valley Questcaller",
             "text": "Whenever one or more other Rabbits, Bats, Birds, and/or Mice you control enter, scry 1.\nOther Rabbits, Bats, Birds, and Mice you control get +1/+1.",
             "colours": [
@@ -1244,7 +1244,7 @@
         },
         {
             "id": "53e060fd-774c-56a7-a9ef-572a12321c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf20069-5a20-4f95-976b-6af2b69f3ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf20069-5a20-4f95-976b-6af2b69f3ad0.jpg?1",
             "name": "Warren Elder",
             "text": "{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1279,7 +1279,7 @@
         },
         {
             "id": "d95721eb-7505-501b-81e4-346394de4c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5237a0-5ac3-4ded-9f92-5f782a7bbbd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5237a0-5ac3-4ded-9f92-5f782a7bbbd7.jpg?1",
             "name": "Warren Warleader",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhenever you attack, choose one \u2014\n\u2022 Create a 1/1 white Rabbit creature token that's tapped and attacking.\n\u2022 Attacking creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "33471dcc-2afe-59d8-872c-336bb71e6d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90ea719-5320-46c6-a347-161853a14776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90ea719-5320-46c6-a347-161853a14776.jpg?1",
             "name": "Wax-Wane Witness",
             "text": "Flying, vigilance\nWhenever you gain or lose life during your turn, Wax-Wane Witness gets +1/+0 until end of turn.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "973fbc4a-d667-5971-aff2-ed5ea05b47eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a78d59-af31-4af9-95aa-2573fe553925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a78d59-af31-4af9-95aa-2573fe553925.jpg?1",
             "name": "Whiskervale Forerunner",
             "text": "Valiant \u2014 Whenever Whiskervale Forerunner becomes the target of a spell or ability you control for the first time each turn, look at the top five cards of your library. You may reveal a creature card with mana value 3 or less from among them. You may put it onto the battlefield if it's your turn. If you don't put it onto the battlefield, put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "4f2dac19-98f3-5837-a0e5-e3f5b845c8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211af1bf-910b-41a5-b928-f378188d1871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211af1bf-910b-41a5-b928-f378188d1871.jpg?1",
             "name": "Azure Beastbinder",
             "text": "Vigilance\nAzure Beastbinder can't be blocked by creatures with power 2 or greater.\nWhenever Azure Beastbinder attacks, up to one target artifact, creature, or planeswalker an opponent controls loses all abilities until your next turn. If it's a creature, it also has base power and toughness 2/2 until your next turn.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "0fac1752-c0c3-522a-9831-d708d1e2592c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2215dd-6300-49cf-b9b2-3a840b786c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2215dd-6300-49cf-b9b2-3a840b786c31.jpg?1",
             "name": "Bellowing Crier",
             "text": "When Bellowing Crier enters, draw a card, then discard a card.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "17da92d5-8c1a-5100-971a-f8430ff2b94a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bc8b2-ffa0-4549-aead-aacb3db3cf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bc8b2-ffa0-4549-aead-aacb3db3cf19.jpg?1",
             "name": "Calamitous Tide",
             "text": "Return up to two target creatures to their owners' hands. Draw two cards, then discard a card.",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "8dde85b7-9c48-5bbc-b1ce-1518eb5f58a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19422406-0c1a-497e-bed1-708bc556491a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19422406-0c1a-497e-bed1-708bc556491a.jpg?1",
             "name": "Daring Waverider",
             "text": "When Daring Waverider enters, you may cast target instant or sorcery card with mana value 4 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "ab1ab4dd-b944-5b45-bb8c-bb39b5222bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8739f1ac-2e57-4b52-a7ff-cc8df5936aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8739f1ac-2e57-4b52-a7ff-cc8df5936aad.jpg?1",
             "name": "Dazzling Denial",
             "text": "Counter target spell unless its controller pays {2}. If you control a Bird, counter that spell unless its controller pays {4} instead.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "b5bbc0f6-2a01-5d9c-a919-4c17419dfae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1931f22-974c-43ad-911e-684bf3f9995d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1931f22-974c-43ad-911e-684bf3f9995d.jpg?1",
             "name": "Dire Downdraft",
             "text": "This spell costs {1} less to cast if it targets an attacking or tapped creature.\nTarget creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "1adefd64-8d6a-5639-95af-5f2f0c846484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6402133e-eed1-4a46-9667-8b7a310362c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6402133e-eed1-4a46-9667-8b7a310362c1.jpg?1",
             "name": "Dour Port-Mage",
             "text": "Whenever one or more other creatures you control leave the battlefield without dying, draw a card.\n{1}{U}, {T}: Return another target creature you control to its owner's hand.",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "6dfc336f-dc24-5d20-9643-9f2a09ad284e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d45abe-4962-47d9-a54e-7e623ea8647c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d45abe-4962-47d9-a54e-7e623ea8647c.jpg?1",
             "name": "Eddymurk Crab",
             "text": "Flash\nThis spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nEddymurk Crab enters tapped if it's not your turn.\nWhen Eddymurk Crab enters, tap up to two target creatures.",
             "colours": [
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "63eb7424-ca13-5d17-9b8a-e47838772dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2bf6ba-cd1a-4382-9572-6dfbcf6ed0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2bf6ba-cd1a-4382-9572-6dfbcf6ed0c6.jpg?1",
             "name": "Eluge, the Shoreless Sea",
             "text": "Eluge's power and toughness are each equal to the number of Islands you control.\nWhenever Eluge enters or attacks, put a flood counter on target land. It's an Island in addition to its other types for as long as it has a flood counter on it.\nThe first instant or sorcery spell you cast each turn costs {U} (or {1}) less to cast for each land you control with a flood counter on it.",
             "colours": [
@@ -1702,7 +1702,7 @@
         },
         {
             "id": "f44925a9-4f22-571f-bb89-094e2b0984b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c671eab-d1ef-4d79-94eb-8b85f0d18699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c671eab-d1ef-4d79-94eb-8b85f0d18699.jpg?1",
             "name": "Finch Formation",
             "text": "Offspring {3} (You may pay an additional {3} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nFlying\nWhen this creature enters, target creature you control gains flying until end of turn.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "c522938e-c76a-5d8a-9cb2-00a36af806f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b299889a-03d6-4659-b0e1-f0830842e40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b299889a-03d6-4659-b0e1-f0830842e40f.jpg?1",
             "name": "Gossip's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever a creature you control enters, surveil 1.\n{1}{U}: Level 2\n//Level_2//\nWhenever you attack, target attacking creature with power 3 or less can't be blocked this turn.\n{3}{U}: Level 3\n//Level_3//\nWhenever a creature you control deals combat damage to a player, you may exile it, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1771,7 +1771,7 @@
         },
         {
             "id": "0b38336b-a943-5b9f-9760-3e265299e271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9575a-53d9-4df7-b86c-cda021107d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9575a-53d9-4df7-b86c-cda021107d3f.jpg?1",
             "name": "Into the Flood Maw",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nReturn target creature an opponent controls to its owner's hand. If the gift was promised, instead return target nonland permanent an opponent controls to its owner's hand.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "0a1b8142-e685-5050-a747-84b40c70d7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085be5d1-fd85-46d1-ad39-a8aa75a06a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085be5d1-fd85-46d1-ad39-a8aa75a06a96.jpg?1",
             "name": "Kitnap",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they draw a card.)\nEnchant creature\nWhen Kitnap enters, tap enchanted creature. If the gift wasn't promised, put three stun counters on it.\nYou control enchanted creature.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "a1ff23cd-4083-5567-a61b-dfd0dd6359a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff751a-ec64-41d5-b22c-2a483ad9a9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff751a-ec64-41d5-b22c-2a483ad9a9b2.jpg?1",
             "name": "Kitsa, Otterball Elite",
             "text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{T}: Draw a card, then discard a card.\n{2}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy. Activate only if Kitsa's power is 3 or greater.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "d7f8fc02-958f-5418-b540-3643d249747d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fb7f4f-2153-4527-8f11-adbf508d3533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fb7f4f-2153-4527-8f11-adbf508d3533.jpg?1",
             "name": "Knightfisher",
             "text": "Flying\nWhenever another nontoken Bird you control enters, create a 1/1 blue Fish creature token.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "d900dd42-d9ba-5495-87d4-5ddf83367af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00c834-b4a9-45b8-bb3f-22c2a42314a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00c834-b4a9-45b8-bb3f-22c2a42314a0.jpg?1",
             "name": "Lightshell Duo",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Lightshell Duo enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1948,7 +1948,7 @@
         },
         {
             "id": "d9657403-90a5-5621-a37e-f0cff934bfc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c267719-cd03-4003-b281-e732d5e42a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c267719-cd03-4003-b281-e732d5e42a1e.jpg?1",
             "name": "Long River Lurker",
             "text": "Ward {1}\nOther Frogs you control have ward {1}.\nWhen Long River Lurker enters, target creature you control can't be blocked this turn. Whenever that creature deals combat damage this turn, you may exile it. If you do, return it to the battlefield under its owner's control.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "c7ffede4-35e7-5c43-9f00-842cff5470ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c81d0fa-81a1-4f9b-a5fd-5a648fd01dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c81d0fa-81a1-4f9b-a5fd-5a648fd01dea.jpg?1",
             "name": "Long River's Pull",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nCounter target creature spell. If the gift was promised, instead counter target spell.",
             "colours": [
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "b3f48cee-6b67-54f2-909b-1412606c6d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e24fe6a-607b-49b8-9fca-cecb1e40de7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e24fe6a-607b-49b8-9fca-cecb1e40de7f.jpg?1",
             "name": "Mind Spiral",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nTarget player draws three cards. If the gift was promised, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "44cf98b4-8067-5fcf-8571-07652861dde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa10f34-5bfd-4d87-8f07-58de3b0f5663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa10f34-5bfd-4d87-8f07-58de3b0f5663.jpg?1",
             "name": "Mindwhisker",
             "text": "At the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nThreshold \u2014 As long as seven or more cards are in your graveyard, creatures your opponents control get -1/-0.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "a01673a3-0a53-5599-82fe-b7f0c536dfbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade32396-8841-4ba4-8852-d11146607f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade32396-8841-4ba4-8852-d11146607f21.jpg?1",
             "name": "Mockingbird",
             "text": "Flying\nYou may have Mockingbird enter as a copy of any creature on the battlefield with mana value less than or equal to the amount of mana spent to cast Mockingbird, except it's a Bird in addition to its other types and it has flying.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "b083e825-83c8-5b47-9cbf-cc26cfb0a56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0928e04f-2568-41e8-b603-7a25cf5f94d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0928e04f-2568-41e8-b603-7a25cf5f94d0.jpg?1",
             "name": "Nightwhorl Hermit",
             "text": "Vigilance\nThreshold \u2014 As long as seven or more cards are in your graveyard, Nightwhorl Hermit gets +1/+0 and can't be blocked.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "54fbb709-a8e3-540f-ab22-a02ec6994371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff83ff7-e428-4ccc-8341-f223dab76bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff83ff7-e428-4ccc-8341-f223dab76bd1.jpg?1",
             "name": "Otterball Antics",
             "text": "Create a 1/1 blue and red Otter creature token with prowess. If this spell was cast from anywhere other than your hand, put a +1/+1 counter on that creature. (Whenever you cast a noncreature spell, a creature with prowess gets +1/+1 until end of turn.)\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "2068caf3-2429-5a98-a0db-f798f01fb716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb9575-1138-4f99-8e90-0eaf00bdf4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb9575-1138-4f99-8e90-0eaf00bdf4a1.jpg?1",
             "name": "Pearl of Wisdom",
             "text": "This spell costs {1} less to cast if you control an Otter.\nDraw two cards.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "32e8669c-b544-5bed-8da7-fbc1a2a7bc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71320ed-2f30-49ce-bcb0-19aebba3f0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71320ed-2f30-49ce-bcb0-19aebba3f0e8.jpg?1",
             "name": "Plumecreed Escort",
             "text": "Flash\nFlying\nWhen Plumecreed Escort enters, target creature you control gains hexproof until end of turn.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "73472084-a1fa-51ea-b3cf-815a9a6bc374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8599e2dd-9164-4da3-814f-adccef3b9497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8599e2dd-9164-4da3-814f-adccef3b9497.jpg?1",
             "name": "Portent of Calamity",
             "text": "Reveal the top X cards of your library. For each card type, you may exile a card of that type from among them. Put the rest into your graveyard. You may cast a spell from among the exiled cards without paying its mana cost if you exiled four or more cards this way. Then put the rest of the exiled cards into your hand.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "a747a12c-3789-5186-9f97-ffed149735c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb7ec70-a5a4-4188-ba1a-e88b81bdbad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb7ec70-a5a4-4188-ba1a-e88b81bdbad0.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "119697c2-da08-5655-8103-d3e8725ed718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5713bb4-bdd9-4253-b6b9-e590532ed773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5713bb4-bdd9-4253-b6b9-e590532ed773.jpg?1",
             "name": "Season of Weaving",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Draw a card.\n{Paw Print}{Paw Print} \u2014 Choose an artifact or creature you control. Create a token that's a copy of it.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return each nonland, nontoken permanent to its owner's hand.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "cd39dec1-f987-5bb3-bcb0-03bfdfe87ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3b49e-3674-494c-bdea-4374cefd10f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3b49e-3674-494c-bdea-4374cefd10f4.jpg?1",
             "name": "Shore Up",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "dc494320-fa3c-5ca6-a4da-122629bbe077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bf8cf0-419a-4dc9-9342-aad55c1af05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bf8cf0-419a-4dc9-9342-aad55c1af05a.jpg?1",
             "name": "Shoreline Looter",
             "text": "Shoreline Looter can't be blocked.\nThreshold \u2014 Whenever Shoreline Looter deals combat damage to a player, draw a card. Then discard a card unless seven or more cards are in your graveyard.",
             "colours": [
@@ -2422,7 +2422,7 @@
         },
         {
             "id": "a1bc029c-fcd7-5157-ac77-871ab74e21cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6844bad-ffbe-4c6e-b438-08562eccea52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6844bad-ffbe-4c6e-b438-08562eccea52.jpg?1",
             "name": "Skyskipper Duo",
             "text": "Flying\nWhen Skyskipper Duo enters, exile up to one other target creature you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -2457,7 +2457,7 @@
         },
         {
             "id": "2fff7e2b-5a58-5444-8460-5f7ba9df1134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6620a-1d40-429d-9a0c-aaeb62adaa71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6620a-1d40-429d-9a0c-aaeb62adaa71.jpg?1",
             "name": "Spellgyre",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Surveil 2, then draw two cards. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "7c8f3415-c496-5fef-940f-86be5df5ea8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ee125-35a0-46cd-a201-e6797d12d33a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ee125-35a0-46cd-a201-e6797d12d33a.jpg?1",
             "name": "Splash Lasher",
             "text": "Offspring {1}{U} (You may pay an additional {1}{U} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, tap up to one target creature and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "eea16815-4f89-5f27-804b-08b4771ce130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbaa356-28ba-487f-930a-a957d9960ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbaa356-28ba-487f-930a-a957d9960ab0.jpg?1",
             "name": "Splash Portal",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control. If that creature is a Bird, Frog, Otter, or Rat, draw a card.",
             "colours": [
@@ -2556,7 +2556,7 @@
         },
         {
             "id": "777bfc89-21ee-54ca-886c-db6421d785ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36e682d-b43d-4e08-bf5b-70d7e924dbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36e682d-b43d-4e08-bf5b-70d7e924dbe5.jpg?1",
             "name": "Stormchaser's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Stormchaser's Talent enters, create a 1/1 blue and red Otter creature token with prowess.\n{3}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, return target instant or sorcery card from your graveyard to your hand.\n{5}{U}: Level 3\n//Level_3//\nWhenever you cast an instant or sorcery spell, create a 1/1 blue and red Otter creature token with prowess.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "c1ca3fc4-6a3e-5c0d-a26c-c04944e26fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcacbe71-efb0-49e1-b2d0-3ee65ec6cf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcacbe71-efb0-49e1-b2d0-3ee65ec6cf8b.jpg?1",
             "name": "Sugar Coat",
             "text": "Flash\nEnchant creature or Food\nEnchanted permanent is a colorless Food artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life\" and loses all other card types and abilities.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "f11cc39c-03bc-50c0-b00c-00e57039b7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0d83b-cc41-4f82-892c-ef6d3293228a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0d83b-cc41-4f82-892c-ef6d3293228a.jpg?1",
             "name": "Thought Shucker",
             "text": "Threshold \u2014 {1}{U}: Put a +1/+1 counter on Thought Shucker and draw a card. Activate only if seven or more cards are in your graveyard and only once.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "ba4bcc94-0edf-526f-8730-2d10e01be0a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf3af94-b7c8-415c-a5a1-d89967fd0bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf3af94-b7c8-415c-a5a1-d89967fd0bba.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "Offspring {4} (You may pay an additional {4} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "26392e57-b17f-5326-8a3b-e910def5c57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b12da0-f666-471d-95f5-15d8c9b31c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b12da0-f666-471d-95f5-15d8c9b31c92.jpg?1",
             "name": "Valley Floodcaller",
             "text": "Flash\nYou may cast noncreature spells as though they had flash.\nWhenever you cast a noncreature spell, Birds, Frogs, Otters, and Rats you control get +1/+1 until end of turn. Untap them.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "331ab074-0ae4-5324-81af-234bc5cbeada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35898b39-98e2-405b-8f18-0e054bd2c29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35898b39-98e2-405b-8f18-0e054bd2c29e.jpg?1",
             "name": "Waterspout Warden",
             "text": "Whenever Waterspout Warden attacks, if another creature entered the battlefield under your control this turn, Waterspout Warden gains flying until end of turn.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "30e880b1-e2ec-54aa-98ea-39e289dac445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeb20aa-b253-49b8-9947-c397a3a4002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeb20aa-b253-49b8-9947-c397a3a4002a.jpg?1",
             "name": "Wishing Well",
             "text": "{T}: Put a coin counter on Wishing Well. When you do, you may cast target instant or sorcery card with mana value equal to the number of coin counters on Wishing Well from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -2803,7 +2803,7 @@
         },
         {
             "id": "5fd9f8ad-3260-58a8-aa89-8fa6f5f8088b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ebb84a-1c52-4b07-9bd0-b360523b3a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ebb84a-1c52-4b07-9bd0-b360523b3a5b.jpg?1",
             "name": "Agate-Blade Assassin",
             "text": "Whenever Agate-Blade Assassin attacks, defending player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "68d3eae5-3c81-55dd-b4ce-6bc08b382624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485dc8d8-9e44-4a0f-9ff6-fa448e232290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485dc8d8-9e44-4a0f-9ff6-fa448e232290.jpg?1",
             "name": "Bandit's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Bandit's Talent enters, each opponent discards two cards unless they discard a nonland card.\n{B}: Level 2\n//Level_2//\nAt the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, they lose 2 life.\n{3}{B}: Level 3\n//Level_3//\nAt the beginning of your draw step, draw an additional card for each opponent who has one or fewer cards in hand.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "04c6c11d-d510-566e-b2bd-5a99929818e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf226fa-ca09-4468-8804-87b2a7de2c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf226fa-ca09-4468-8804-87b2a7de2c66.jpg?1",
             "name": "Bonebind Orator",
             "text": "{3}{B}, Exile Bonebind Orator from your graveyard: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "f0036c9a-34bc-533a-9c3e-69f275b846b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82defb87-237f-4b77-9673-5bf00607148f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82defb87-237f-4b77-9673-5bf00607148f.jpg?1",
             "name": "Bonecache Overseer",
             "text": "{T}, Pay 1 life: Draw a card. Activate only if three or more cards left your graveyard this turn or if you've sacrificed a Food this turn.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "f8400fd6-198e-5d45-8c27-aca70c1945a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d5de3e-0440-4dd1-899c-ab40c0752343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d5de3e-0440-4dd1-899c-ab40c0752343.jpg?1",
             "name": "Coiling Rebirth",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn target creature card from your graveyard to the battlefield. Then if the gift was promised and that creature isn't legendary, create a token that's a copy of that creature, except it's 1/1.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "6465bfe9-4675-54a6-99be-8c85dd5c20a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50acc41-3517-42db-b1d3-1bdfd7294d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50acc41-3517-42db-b1d3-1bdfd7294d84.jpg?1",
             "name": "Consumed by Greed",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nTarget opponent sacrifices a creature with the greatest power among creatures they control. If the gift was promised, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "0932fc55-6cba-5414-92d0-72a044bee59c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4539a-0157-4cbe-b50f-6e2575df74e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4539a-0157-4cbe-b50f-6e2575df74e9.jpg?1",
             "name": "Cruelclaw's Heist",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nTarget opponent reveals their hand. You choose a nonland card from it. Exile that card. If the gift was promised, you may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "d48e8250-7c66-57e3-90ef-998b61ce97ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2bb34-e328-44fb-918a-72208c9457e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2bb34-e328-44fb-918a-72208c9457e4.jpg?1",
             "name": "Daggerfang Duo",
             "text": "Deathtouch\nWhen Daggerfang Duo enters, you may mill two cards. (You may put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "ddd52317-1405-5fd3-87c4-4c482804941e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c603751-1e2b-4c8e-a8d2-5c0876e7254f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c603751-1e2b-4c8e-a8d2-5c0876e7254f.jpg?1",
             "name": "Darkstar Augur",
             "text": "Offspring {B} (You may pay an additional {B} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nFlying\nAt the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "83705c4b-ac3a-5096-bd9a-28f2015ca814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fada29c0-5293-40a4-b36d-d073ee99e650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fada29c0-5293-40a4-b36d-d073ee99e650.jpg?1",
             "name": "Diresight",
             "text": "Surveil 2, then draw two cards. You lose 2 life. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "4462068a-630b-5aa4-b8d9-2a2de921eaa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cfd628-933a-4d3d-b2e5-70bc86960d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cfd628-933a-4d3d-b2e5-70bc86960d1c.jpg?1",
             "name": "Downwind Ambusher",
             "text": "Flash\nWhen Downwind Ambusher enters, choose one \u2014\n\u2022 Target creature an opponent controls gets -1/-1 until end of turn.\n\u2022 Destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "eeaa199c-d233-556e-a8bf-b8e49df95d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5030e6ac-211d-4145-8c87-998a8351a467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5030e6ac-211d-4145-8c87-998a8351a467.jpg?1",
             "name": "Early Winter",
             "text": "Choose one \u2014\n\u2022 Exile target creature.\n\u2022 Target opponent exiles an enchantment they control.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "4598827b-2aa5-5d51-bc77-3a6a24df7e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e017ff8-2936-4a1b-bece-00004cfbad06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e017ff8-2936-4a1b-bece-00004cfbad06.jpg?1",
             "name": "Feed the Cycle",
             "text": "As an additional cost to cast this spell, forage or pay {B}. (To forage, exile three cards from your graveyard or sacrifice a Food.)\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "d145e5da-cffb-5475-b668-c8d19cbf7d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96ac326-de44-470b-a592-a4c2a052c091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96ac326-de44-470b-a592-a4c2a052c091.jpg?1",
             "name": "Fell",
             "text": "Destroy target creature.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "e669918a-2ac3-528f-ab35-dbfb6c794f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4831e7ae-54e3-4bd9-b5af-52dc29f81715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4831e7ae-54e3-4bd9-b5af-52dc29f81715.jpg?1",
             "name": "Glidedive Duo",
             "text": "Flying\nWhen Glidedive Duo enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "c4276d74-1ac6-5a53-a63b-4d6b548a536f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239363df-4de8-4b64-80fc-a1f4b5c36027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239363df-4de8-4b64-80fc-a1f4b5c36027.jpg?1",
             "name": "Hazel's Nocturne",
             "text": "Return up to two target creature cards from your graveyard to your hand. Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "bbf269d6-56ec-53ff-aa27-8d5c28887b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f61d7-4eb0-41c5-8a34-a0793c2abc51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f61d7-4eb0-41c5-8a34-a0793c2abc51.jpg?1",
             "name": "Huskburster Swarm",
             "text": "This spell costs {1} less to cast for each creature card you own in exile and in your graveyard.\nMenace, deathtouch",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "9dfd7a3a-67f6-5211-bd6a-26bb78e03cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bc854c-4e72-48e0-a098-e3451d6e511d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bc854c-4e72-48e0-a098-e3451d6e511d.jpg?1",
             "name": "Iridescent Vinelasher",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nLandfall \u2014 Whenever a land you control enters, this creature deals 1 damage to target opponent.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "1f64bc9e-23c2-5f50-a6e4-2d84b4fee207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3320ec-c4e8-405a-982d-e009c58c9e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3320ec-c4e8-405a-982d-e009c58c9e21.jpg?1",
             "name": "Maha, Its Feathers Night",
             "text": "Flying, trample\nWard\u2014\nDiscard a card.\nCreatures your opponents control have base toughness 1.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "e9816c69-f879-5d06-87ba-416ebd0aa9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e4aa8d-1d06-48db-b205-aa2f1392bbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e4aa8d-1d06-48db-b205-aa2f1392bbcb.jpg?1",
             "name": "Moonstone Harbinger",
             "text": "Flying, deathtouch\nWhenever you gain or lose life during your turn, Bats you control get +1/+0 and gain deathtouch until end of turn. This ability triggers only once each turn.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "c29b4d3c-5229-53e2-b927-7b6235504608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742c0409-9abd-4559-b52e-932cc90c531a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742c0409-9abd-4559-b52e-932cc90c531a.jpg?1",
             "name": "Nocturnal Hunger",
             "text": "Gift a Food (You may promise an opponent a gift as you cast this spell. If you do, they create a Food token before its other effects. It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nDestroy target creature. If the gift wasn't promised, you lose 2 life.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "503d35f7-5656-5187-97c7-6b218c6d818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8238dd-858f-466c-96de-986bd66861d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8238dd-858f-466c-96de-986bd66861d7.jpg?1",
             "name": "Osteomancer Adept",
             "text": "Deathtouch\n{T}: Until end of turn, you may cast creature spells from your graveyard by foraging in addition to paying their other costs. If you cast a spell this way, that creature enters with a finality counter on it. (To forage, exile three cards from your graveyard or sacrifice a Food. If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "7ea58d34-cf25-55ea-b471-efdc6992f2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b900c71-713b-4b7e-b4be-ad9f4aa0c139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b900c71-713b-4b7e-b4be-ad9f4aa0c139.jpg?1",
             "name": "Persistent Marshstalker",
             "text": "Persistent Marshstalker gets +1/+0 for each other Rat you control.\nThreshold \u2014 Whenever you attack with one or more Rats, if seven or more cards are in your graveyard, you may pay {2}{B}. If you do, return Persistent Marshstalker from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "71a359f1-6e5f-5526-b303-11afdb64ac1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df900308-8432-4a0a-be21-17482026012b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df900308-8432-4a0a-be21-17482026012b.jpg?1",
             "name": "Psychic Whorl",
             "text": "Target opponent discards two cards. Then if you control a Rat, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "957dca38-5366-58dd-b7bc-71f7e90c0922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874510be-7ecd-4eff-abad-b9594eb4821a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874510be-7ecd-4eff-abad-b9594eb4821a.jpg?1",
             "name": "Ravine Raider",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{1}{B}: Ravine Raider gets +1/+1 until end of turn.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "4ddc306f-e695-577a-b8b5-e169db27908f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735e79b1-a3a9-4ddf-8bbc-f756c8a0452b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735e79b1-a3a9-4ddf-8bbc-f756c8a0452b.jpg?1",
             "name": "Rottenmouth Viper",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of nonland permanents. This spell costs {1} less to cast for each permanent sacrificed this way.\nWhenever Rottenmouth Viper enters or attacks, put a blight counter on it. Then for each blight counter on it, each opponent loses 4 life unless that player sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -3701,7 +3701,7 @@
         },
         {
             "id": "aff2aa75-2f60-5ab2-972b-835a6083b3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4360c-8d68-4058-b9ec-da9948cb060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4360c-8d68-4058-b9ec-da9948cb060d.jpg?1",
             "name": "Ruthless Negotiation",
             "text": "Target opponent exiles a card from their hand. If this spell was cast from a graveyard, draw a card.\nFlashback {4}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "2cfd460b-1df1-5ec9-8dc2-ed21fb6c53d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397f689-dca1-4d35-864b-92c5606afb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397f689-dca1-4d35-864b-92c5606afb9a.jpg?1",
             "name": "Savor",
             "text": "Target creature gets -2/-2 until end of turn. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "924378a0-8cff-5d4a-808c-a1e1ea121af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae14276-dbbd-4257-80e9-accd6c19f5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae14276-dbbd-4257-80e9-accd6c19f5b2.jpg?1",
             "name": "Scales of Shale",
             "text": "This spell costs {1} less to cast for each Lizard you control.\nTarget creature gets +2/+0 and gains lifelink and indestructible until end of turn.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "ea34c9e8-404f-5564-b7ba-3e0940472894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52b7fe-87ae-425b-85fd-b24e6e0395f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a52b7fe-87ae-425b-85fd-b24e6e0395f1.jpg?1",
             "name": "Scavenger's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever one or more creatures you control die, create a Food token. This ability triggers only once each turn.\n{1}{B}: Level 2\n//Level_2//\nWhenever you sacrifice a permanent, target player mills two cards.\n{2}{B}: Level 3\n//Level_3//\nAt the beginning of your end step, you may sacrifice three other nonland permanents. If you do, return a creature card from your graveyard to the battlefield with a finality counter on it.",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "f4489d5c-12aa-5ba9-8118-66ad64f2f2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc540652-916b-45c5-ae5a-0a0bc557cee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc540652-916b-45c5-ae5a-0a0bc557cee1.jpg?1",
             "name": "Season of Loss",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Each player sacrifices a creature.\n{Paw Print}{Paw Print} \u2014 Draw a card for each creature you controlled that died this turn.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Each opponent loses X life, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "a5c081b3-33ce-5211-b127-7ff0aec6d7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a15e06c-2608-4e7a-a16c-d35417669d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a15e06c-2608-4e7a-a16c-d35417669d86.jpg?1",
             "name": "Sinister Monolith",
             "text": "At the beginning of combat on your turn, each opponent loses 1 life and you gain 1 life.\n{T}, Pay 2 life, Sacrifice Sinister Monolith: Draw two cards. Activate only as a sorcery.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "810c7391-a41f-529f-a989-c7031b86151d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fc599-8de7-44d2-8fdd-9bddf5948a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777fc599-8de7-44d2-8fdd-9bddf5948a0c.jpg?1",
             "name": "Stargaze",
             "text": "Look at twice X cards from the top of your library. Put X cards from among them into your hand and the rest into your graveyard. You lose X life.",
             "colours": [
@@ -3929,7 +3929,7 @@
         },
         {
             "id": "c3dbe13b-2651-5d44-bae5-398cb9058f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c1eca-2991-438f-b5d2-cd2529b9c9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c1eca-2991-438f-b5d2-cd2529b9c9b4.jpg?1",
             "name": "Starlit Soothsayer",
             "text": "Flying\nAt the beginning of your end step, if you gained or lost life this turn, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3964,7 +3964,7 @@
         },
         {
             "id": "9364f011-5bac-52fe-883f-5467a18aa340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a938a7-0154-4350-87cb-00da24ec3824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a938a7-0154-4350-87cb-00da24ec3824.jpg?1",
             "name": "Starscape Cleric",
             "text": "Offspring {2}{B} (You may pay an additional {2}{B} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nFlying\nThis creature can't block.\nWhenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "45b18826-29ad-5ccb-9b86-59080da9e772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f66c4a-feaa-4ba6-aa56-955b43329a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f66c4a-feaa-4ba6-aa56-955b43329a9e.jpg?1",
             "name": "Thornplate Intimidator",
             "text": "Offspring {3} (You may pay an additional {3} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, target opponent loses 3 life unless they sacrifice a nonland permanent or discard a card.",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "1a13f516-3670-5fed-b8fe-490a87dfab3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e80284-d489-493b-ae92-95b742d07cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e80284-d489-493b-ae92-95b742d07cb3.jpg?1",
             "name": "Thought-Stalker Warlock",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Thought-Stalker Warlock enters, choose target opponent. If they lost life this turn, they reveal their hand, you choose a nonland card from it, and they discard that card. Otherwise, they discard a card.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "7c42140c-4161-53a2-a160-f7f8d0b9a96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da80a9a-b1d5-4fc5-92f7-36946195d0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da80a9a-b1d5-4fc5-92f7-36946195d0c7.jpg?1",
             "name": "Valley Rotcaller",
             "text": "Menace\nWhenever Valley Rotcaller attacks, each opponent loses X life and you gain X life, where X is the number of other Squirrels, Bats, Lizards, and Rats you control.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "a41a71cb-cdb1-51c5-9c5d-23d7f846e574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29089810-d7fb-4abe-b729-bfabed6aed2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29089810-d7fb-4abe-b729-bfabed6aed2b.jpg?1",
             "name": "Wick, the Whorled Mind",
             "text": "Whenever Wick or another Rat you control enters, create a 1/1 black Snail creature token if you don't control a Snail. Otherwise, put a +1/+1 counter on a Snail you control.\n{U}{B}{R}, Sacrifice a Snail: Wick deals damage equal to the sacrificed creature's power to each opponent. Then draw cards equal to the sacrificed creature's power.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "34089d93-c8c7-56f3-a75e-8fed780dd67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa0c53d-fe7b-4b8b-ad81-7967ca318ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa0c53d-fe7b-4b8b-ad81-7967ca318ff7.jpg?1",
             "name": "Wick's Patrol",
             "text": "When Wick's Patrol enters, mill three cards. When you do, target creature an opponent controls gets -X/-X until end of turn, where X is the greatest mana value among cards in your graveyard.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "66e5a5c4-80ee-5a13-88d8-bac05995e364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9946b-515e-4e0d-9da2-711e126e9fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9946b-515e-4e0d-9da2-711e126e9fa6.jpg?1",
             "name": "Agate Assault",
             "text": "Choose one \u2014\n\u2022 Agate Assault deals 4 damage to target creature. If that creature would die this turn, exile it instead.\n\u2022 Exile target artifact.",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "f3cdf530-dbd6-5b1f-b12b-6817d24e67c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3871fe6-e26e-4ab4-bd81-7e3c7b8135c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3871fe6-e26e-4ab4-bd81-7e3c7b8135c1.jpg?1",
             "name": "Alania's Pathmaker",
             "text": "When Alania's Pathmaker enters, exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "1611c55a-ccc9-5a63-aeaa-c1ec3de4a3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e51d9-189b-4dd6-87cb-628ea6373e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e51d9-189b-4dd6-87cb-628ea6373e81.jpg?1",
             "name": "Artist's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhenever you cast a noncreature spell, you may discard a card. If you do, draw a card.\n{2}{R}: Level 2\n//Level_2//\nNoncreature spells you cast cost {1} less to cast.\n{2}{R}: Level 3\n//Level_3//\nIf a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "f3a4cc06-146c-5f09-9570-23028b0b653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb318fa-481d-40a7-978e-f01b49101ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb318fa-481d-40a7-978e-f01b49101ae0.jpg?1",
             "name": "Blacksmith's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Blacksmith's Talent enters, create a colorless Equipment artifact token named Sword with \"Equipped creature gets +1/+1\" and equip {2}.\n{2}{R}: Level 2\n//Level_2//\nAt the beginning of combat on your turn, attach target Equipment you control to up to one target creature you control.\n{3}{R}: Level 3\n//Level_3//\nDuring your turn, equipped creatures you control have double strike and haste.",
             "colours": [
@@ -4317,7 +4317,7 @@
         },
         {
             "id": "05b32d66-15ba-5f84-bf56-10a690cdcf56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd92a83-cec3-4085-a929-3f204e3e0140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd92a83-cec3-4085-a929-3f204e3e0140.jpg?1",
             "name": "Blooming Blast",
             "text": "Gift a Treasure (You may promise an opponent a gift as you cast this spell. If you do, they create a Treasure token before its other effects. It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nBlooming Blast deals 2 damage to target creature. If the gift was promised, Blooming Blast also deals 3 damage to that creature's controller.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "72da7eef-6f31-5784-93ab-d1bd79c1d1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8bf-f2f3-4157-8e04-02baf07a963e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e200b8bf-f2f3-4157-8e04-02baf07a963e.jpg?1",
             "name": "Brambleguard Captain",
             "text": "At the beginning of combat on your turn, target creature you control gets +X/+0 until end of turn, where X is Brambleguard Captain's power.",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "f34a9827-7dc9-55da-8943-7e506b95f162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b55a58-c669-4dc6-aa63-5d9dff52e613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b55a58-c669-4dc6-aa63-5d9dff52e613.jpg?1",
             "name": "Brazen Collector",
             "text": "First strike\nWhenever Brazen Collector attacks, add {R}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -4419,7 +4419,7 @@
         },
         {
             "id": "8d0a7cd0-563c-54e5-95fe-e7e1b55084b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41fc718-641b-4f32-a8c1-3e5591a05bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41fc718-641b-4f32-a8c1-3e5591a05bf8.jpg?1",
             "name": "Byway Barterer",
             "text": "Menace\nWhenever you expend 4, you may discard your hand. If you do, draw two cards. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "1a8a18d6-a40b-58a7-a9d8-8e72116ea1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f373dd6-2412-453c-85ba-10230dfe473a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f373dd6-2412-453c-85ba-10230dfe473a.jpg?1",
             "name": "Conduct Electricity",
             "text": "Conduct Electricity deals 6 damage to target creature and 2 damage to up to one target creature token.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "cef659a5-d62c-5149-8604-f2679bba4303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2c1de0-6233-469a-be72-a050b97d2c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2c1de0-6233-469a-be72-a050b97d2c8f.jpg?1",
             "name": "Coruscation Mage",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhenever you cast a noncreature spell, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "a0ccbe49-01e7-59e1-a5c5-c0cc3df0b13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659789c-6a2c-439f-a348-b9b1b06c55b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659789c-6a2c-439f-a348-b9b1b06c55b8.jpg?1",
             "name": "Dragonhawk, Fate's Tempest",
             "text": "Flying\nWhenever Dragonhawk enters or attacks, exile the top X cards of your library, where X is the number of creatures you control with power 4 or greater. You may play those cards until your next end step. At the beginning of your next end step, Dragonhawk deals 2 damage to each opponent for each of those cards that are still exiled.",
             "colours": [
@@ -4562,7 +4562,7 @@
         },
         {
             "id": "77db8a79-101c-5c7c-ab69-768f9086bfc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035082e-bb86-4f95-be48-ffc87fe5286d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035082e-bb86-4f95-be48-ffc87fe5286d.jpg?1",
             "name": "Emberheart Challenger",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nValiant \u2014 Whenever Emberheart Challenger becomes the target of a spell or ability you control for the first time each turn, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "a86f8c6c-c670-5fa9-afb0-f2852e7b585a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433ee12-2013-4fdc-979f-ae065f63a527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433ee12-2013-4fdc-979f-ae065f63a527.jpg?1",
             "name": "Festival of Embers",
             "text": "During your turn, you may cast instant and sorcery spells from your graveyard by paying 1 life in addition to their other costs.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.\n{1}{R}: Sacrifice Festival of Embers.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "6a6bd527-1732-5333-9c73-6998f428dea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8e7c97-8393-41b8-bb0b-3983dcc5e7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8e7c97-8393-41b8-bb0b-3983dcc5e7f4.jpg?1",
             "name": "Flamecache Gecko",
             "text": "When Flamecache Gecko enters, if an opponent lost life this turn, add {B}{R}.\n{1}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "3b07085d-394a-5aa4-9645-c5525a05192d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bbd6d-e329-42cf-963d-88d1ce8fe51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bbd6d-e329-42cf-963d-88d1ce8fe51e.jpg?1",
             "name": "Frilled Sparkshooter",
             "text": "Menace, reach\nFrilled Sparkshooter enters with a +1/+1 counter on it if an opponent lost life this turn.",
             "colours": [
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "6ccc1247-bae7-5040-9efa-fbbd309f3858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56beeb6-88ca-475e-8654-1d4e8b4aa3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56beeb6-88ca-475e-8654-1d4e8b4aa3c0.jpg?1",
             "name": "Harnesser of Storms",
             "text": "Whenever you cast a noncreature or Otter spell, you may exile the top card of your library. Until end of turn, you may play that card. This ability triggers only once each turn.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "15193a55-e85a-551a-a60e-c2e8b26cdb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ace959-66b2-40c8-9bff-fd7ed9c99a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ace959-66b2-40c8-9bff-fd7ed9c99a82.jpg?1",
             "name": "Heartfire Hero",
             "text": "Valiant \u2014 Whenever Heartfire Hero becomes the target of a spell or ability you control for the first time each turn, put a +1/+1 counter on it.\nWhen Heartfire Hero dies, it deals damage equal to its power to each opponent.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "17d424cf-aa86-5f3f-a319-842236f1857e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1cf5c-9738-4062-8cb1-87a372d36687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef1cf5c-9738-4062-8cb1-87a372d36687.jpg?1",
             "name": "Hearthborn Battler",
             "text": "Haste\nWhenever a player casts their second spell each turn, Hearthborn Battler deals 2 damage to target opponent.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "636c6c93-07fb-533d-98de-60435646eab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae41080-0d67-4719-adb2-49bf2a268b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae41080-0d67-4719-adb2-49bf2a268b6c.jpg?1",
             "name": "Hired Claw",
             "text": "Whenever you attack with one or more Lizards, Hired Claw deals 1 damage to target opponent.\n{1}{R}: Put a +1/+1 counter on Hired Claw. Activate only if an opponent lost life this turn and only once each turn.",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "8e910181-bb43-5354-97fa-368fc42fbc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ed5079-07b4-4575-a2c8-5f0cbff888c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ed5079-07b4-4575-a2c8-5f0cbff888c3.jpg?1",
             "name": "Hoarder's Overflow",
             "text": "When Hoarder's Overflow enters and whenever you expend 4, put a stash counter on it. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)\n{1}{R}, Sacrifice Hoarder's Overflow: Discard your hand, then draw cards equal to the number of stash counters on Hoarder's Overflow.",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "93162d80-023e-57c5-a5d6-9b8bc33c6619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a839fba3-1b66-4dd1-bf43-9b015b44fc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a839fba3-1b66-4dd1-bf43-9b015b44fc81.jpg?1",
             "name": "Kindlespark Duo",
             "text": "{T}: Kindlespark Duo deals 1 damage to target opponent.\nWhenever you cast a noncreature spell, untap Kindlespark Duo.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "96b27fad-9db3-5a74-b1f3-65e1d50f5317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3832b5-e83f-4569-bd49-fb7b86fa2d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3832b5-e83f-4569-bd49-fb7b86fa2d47.jpg?1",
             "name": "Manifold Mouse",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nAt the beginning of combat on your turn, target Mouse you control gains your choice of double strike or trample until end of turn.",
             "colours": [
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "a7f5d753-3c0a-5638-8fc7-01a150c0ba31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509bf254-8a2b-4dfa-9ae5-386321b35e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509bf254-8a2b-4dfa-9ae5-386321b35e8b.jpg?1",
             "name": "Might of the Meek",
             "text": "Target creature gains trample until end of turn. It also gets +1/+0 until end of turn if you control a Mouse.\nDraw a card.",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "8fdb5cef-b2e3-53df-a77b-17e7616e9a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07956edf-34c1-4218-9784-ddbca13e380c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07956edf-34c1-4218-9784-ddbca13e380c.jpg?1",
             "name": "Playful Shove",
             "text": "Playful Shove deals 1 damage to any target.\nDraw a card.",
             "colours": [
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "f5fc9879-6e76-5e0e-be99-0a7097d270fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b7fd3-a139-49ea-8a89-b64261e868ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b7fd3-a139-49ea-8a89-b64261e868ef.jpg?1",
             "name": "Quaketusk Boar",
             "text": "Reach, trample, haste",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "932a29a6-13cb-5141-b893-76ffa3b9795f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f815bae-820a-49f6-8eed-46f658e7b6ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f815bae-820a-49f6-8eed-46f658e7b6ff.jpg?1",
             "name": "Rabid Gnaw",
             "text": "Target creature you control gets +1/+0 until end of turn. Then it deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "0303bce7-92ec-53d3-8dc4-d27dceab6c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b5180f-5a1c-4df8-9019-195e65a50ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b5180f-5a1c-4df8-9019-195e65a50ce3.jpg?1",
             "name": "Raccoon Rallier",
             "text": "{T}: Target creature you control gains haste until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -5118,7 +5118,7 @@
         },
         {
             "id": "6dc2b83c-6d75-5c6e-8fc9-3d6ee3a27c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dec453-c9d7-42cb-980a-c82f82bede76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dec453-c9d7-42cb-980a-c82f82bede76.jpg?1",
             "name": "Reptilian Recruiter",
             "text": "Trample\nWhen Reptilian Recruiter enters, choose target creature. If that creature's power is 2 or less or if you control another Lizard, gain control of that creature until end of turn, untap it, and it gains haste until end of turn.",
             "colours": [
@@ -5153,7 +5153,7 @@
         },
         {
             "id": "35c09b80-0047-576f-bfd6-8a921a291c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cdcfb9-a247-4c2d-a098-5b57570f8cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cdcfb9-a247-4c2d-a098-5b57570f8cd5.jpg?1",
             "name": "Roughshod Duo",
             "text": "Trample\nWhenever you expend 4, target creature you control gets +1/+1 and gains trample until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5188,7 +5188,7 @@
         },
         {
             "id": "999118a8-e125-5ddb-8f46-d35268d3e4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963080-b3ec-467d-82f7-39db6ecd6bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963080-b3ec-467d-82f7-39db6ecd6bbc.jpg?1",
             "name": "Sazacap's Brew",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nAs an additional cost to cast this spell, discard a card.\nTarget player draws two cards. If the gift was promised, target creature you control gets +2/+0 until end of turn.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "0956b5e6-d46e-5b5e-8f04-12be740b0e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84352565-558b-4f9b-a411-532147806a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84352565-558b-4f9b-a411-532147806a78.jpg?1",
             "name": "Season of the Bold",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a tapped Treasure token.\n{Paw Print}{Paw Print} \u2014 Exile the top two cards of your library. Until the end of your next turn, you may play them.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Until the end of your next turn, whenever you cast a spell, Season of the Bold deals 2 damage to up to one target creature.",
             "colours": [
@@ -5254,7 +5254,7 @@
         },
         {
             "id": "23eace4a-db0c-5a65-b5c8-1fee2c7024ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf1296-e347-4070-8c6f-5c362c2f9364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf1296-e347-4070-8c6f-5c362c2f9364.jpg?1",
             "name": "Steampath Charger",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature dies, it deals 1 damage to target player.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "e5c8c953-c55d-5cd8-bcdc-13591dbcc59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f214d3-6b93-40db-a693-55e491c8a283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f214d3-6b93-40db-a693-55e491c8a283.jpg?1",
             "name": "Stormsplitter",
             "text": "Haste\nWhenever you cast an instant or sorcery spell, create a token that's a copy of Stormsplitter. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "74d6878d-e2df-59aa-a34f-9a71262a1796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8995ceaf-b7e0-423c-8f3e-25212d522502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8995ceaf-b7e0-423c-8f3e-25212d522502.jpg?1",
             "name": "Sunspine Lynx",
             "text": "Players can't gain life.\nDamage can't be prevented.\nWhen Sunspine Lynx enters, it deals damage to each player equal to the number of nonbasic lands that player controls.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "1adc1f7e-4bbf-5370-8d20-020cf0099932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c6f00-af4c-4d35-b682-6c0e759df9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c6f00-af4c-4d35-b682-6c0e759df9a5.jpg?1",
             "name": "Take Out the Trash",
             "text": "Take Out the Trash deals 3 damage to target creature or planeswalker. If you control a Raccoon, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "f27db4c9-42b6-5500-bed5-0433bef426c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30506844-349f-4b68-8cc1-d028c1611cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30506844-349f-4b68-8cc1-d028c1611cc7.jpg?1",
             "name": "Teapot Slinger",
             "text": "Menace\nWhenever you expend 4, Teapot Slinger deals 2 damage to each opponent. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "b62a2d33-dac1-5f62-bc14-72f354ca45a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0812db4-b7d1-4cf7-aaa5-9c0e784079a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0812db4-b7d1-4cf7-aaa5-9c0e784079a1.jpg?1",
             "name": "Valley Flamecaller",
             "text": "If a Lizard, Mouse, Otter, or Raccoon you control would deal damage to a permanent or player, it deals that much damage plus 1 instead.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "88ba0f66-a005-5bbe-a7cd-3da23d66e86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6178258-1ad6-4122-a56f-6eb7d0611e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6178258-1ad6-4122-a56f-6eb7d0611e84.jpg?1",
             "name": "Valley Rally",
             "text": "Gift a Food (You may promise an opponent a gift as you cast this spell. If you do, they create a Food token before its other effects. It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nCreatures you control get +2/+0 until end of turn. If the gift was promised, target creature you control gains first strike until end of turn.",
             "colours": [
@@ -5499,7 +5499,7 @@
         },
         {
             "id": "723ee39b-f071-5eee-a588-346be06a3d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105964a7-88b7-4340-aa66-e908189a3638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105964a7-88b7-4340-aa66-e908189a3638.jpg?1",
             "name": "War Squeak",
             "text": "Enchant creature\nWhen War Squeak enters, target creature an opponent controls can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "1fd1de57-85ca-560d-8795-f0169b732cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da653996-9bd4-40bd-afb4-48c7e070a269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da653996-9bd4-40bd-afb4-48c7e070a269.jpg?1",
             "name": "Whiskerquill Scribe",
             "text": "Valiant \u2014 Whenever Whiskerquill Scribe becomes the target of a spell or ability you control for the first time each turn, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5568,7 +5568,7 @@
         },
         {
             "id": "d3b93838-3ac2-5a98-ad6e-7f782352c20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7392d397-9836-4df2-944d-c930c9566811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7392d397-9836-4df2-944d-c930c9566811.jpg?1",
             "name": "Wildfire Howl",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nWildfire Howl deals 2 damage to each creature. If the gift was promised, instead Wildfire Howl deals 1 damage to any target and 2 damage to each creature.",
             "colours": [
@@ -5600,7 +5600,7 @@
         },
         {
             "id": "10519632-c4ea-5b56-b6f3-cf4208da4a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5309354f-1ff4-4fa9-9141-01ea2f7588ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5309354f-1ff4-4fa9-9141-01ea2f7588ab.jpg?1",
             "name": "Bakersbane Duo",
             "text": "When Bakersbane Duo enters, create a Food token.\nWhenever you expend 4, Bakersbane Duo gets +1/+1 until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "8804ad80-48bd-5c2c-8195-71cdbbadebd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582637a9-6aa0-4824-bed7-d5fc91bda35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582637a9-6aa0-4824-bed7-d5fc91bda35e.jpg?1",
             "name": "Bark-Knuckle Boxer",
             "text": "Whenever you expend 4, Bark-Knuckle Boxer gains indestructible until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "c5b3cb79-ea28-53ec-b456-d2b919613f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac9f6f8-6797-4580-9fc4-9a825872e017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac9f6f8-6797-4580-9fc4-9a825872e017.jpg?1",
             "name": "Brambleguard Veteran",
             "text": "Whenever you expend 4, Raccoons you control get +1/+1 and gain vigilance until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -5705,7 +5705,7 @@
         },
         {
             "id": "ae7bdf47-28e2-5272-9bf4-1759372f759b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de60cf7-fa82-4b6f-9f88-6590fba5c863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de60cf7-fa82-4b6f-9f88-6590fba5c863.jpg?1",
             "name": "Bushy Bodyguard",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, you may forage. If you do, put two +1/+1 counters on it. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "8133451f-5768-5a50-b187-b7549a7ac502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd977dc-a7c3-4d0a-aca7-b25bd154e963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd977dc-a7c3-4d0a-aca7-b25bd154e963.jpg?1",
             "name": "Cache Grab",
             "text": "Mill four cards. You may put a permanent card from among the cards milled this way into your hand. If you control a Squirrel or returned a Squirrel card to your hand this way, create a Food token. (To mill four cards, put the top four cards of your library into your graveyard. A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -5772,7 +5772,7 @@
         },
         {
             "id": "8472521e-ffc7-5f36-bf79-53917c714f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d3bcc-65f3-4c69-8ea1-446870a1193d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d3bcc-65f3-4c69-8ea1-446870a1193d.jpg?1",
             "name": "Clifftop Lookout",
             "text": "Reach\nWhen Clifftop Lookout enters, reveal cards from the top of your library until you reveal a land card. Put that card onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "67608a58-3aa2-5d37-b222-cde5f14951fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64653b4a-e139-45f9-a915-ab49afb6b795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64653b4a-e139-45f9-a915-ab49afb6b795.jpg?1",
             "name": "Curious Forager",
             "text": "When Curious Forager enters, you may forage. When you do, return target permanent card from your graveyard to your hand. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "b6e12e36-0aa1-5979-9b28-0a213ad9a1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b485cf7-bad0-4824-9ba7-cb112ce4769f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b485cf7-bad0-4824-9ba7-cb112ce4769f.jpg?1",
             "name": "Druid of the Spade",
             "text": "As long as you control a token, Druid of the Spade gets +2/+0 and has trample.",
             "colours": [
@@ -5877,7 +5877,7 @@
         },
         {
             "id": "81d46f95-4241-503b-83d1-86d08d381e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b3e815-0e2e-4325-b1d5-5531b7b92da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b3e815-0e2e-4325-b1d5-5531b7b92da6.jpg?1",
             "name": "Fecund Greenshell",
             "text": "Reach\nAs long as you control ten or more lands, creatures you control get +2/+2.\nWhenever Fecund Greenshell or another creature you control with toughness greater than its power enters, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. Otherwise, put it into your hand.",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "23095f59-1d57-55c1-a3a3-e416b3e5c368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec72a27-b622-47d7-bdf3-970ccaef0d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec72a27-b622-47d7-bdf3-970ccaef0d2a.jpg?1",
             "name": "For the Common Good",
             "text": "Create X tokens that are copies of target token you control. Then tokens you control gain indestructible until your next turn. You gain 1 life for each token you control.",
             "colours": [
@@ -5948,7 +5948,7 @@
         },
         {
             "id": "0dd7f131-2db2-5fad-8f3a-ee0d05981973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58706bd8-558a-43b9-9f1e-c1ff0044203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58706bd8-558a-43b9-9f1e-c1ff0044203b.jpg?1",
             "name": "Galewind Moose",
             "text": "Flash\nVigilance, reach, trample",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "d609bc43-5a24-51a0-b9df-893b77409d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2882982-b3a3-4762-a550-6b82db1038e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2882982-b3a3-4762-a550-6b82db1038e8.jpg?1",
             "name": "Hazardroot Herbalist",
             "text": "Whenever you attack, target creature you control gets +1/+0 until end of turn. If that creature is a token, it also gains deathtouch until end of turn.",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "af24c4f8-56a0-5e8d-afaa-77af56a2b00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5349db-0e0a-4b15-886e-0db403ef49cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5349db-0e0a-4b15-886e-0db403ef49cb.jpg?1",
             "name": "Heaped Harvest",
             "text": "When Heaped Harvest enters and when you sacrifice it, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{2}, {T}, Sacrifice Heaped Harvest: You gain 3 life.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "1842f195-9f82-5c17-9fc3-53c3fd3a4577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8cf4b-8e65-4a1c-b458-28b5ab56b390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8cf4b-8e65-4a1c-b458-28b5ab56b390.jpg?1",
             "name": "High Stride",
             "text": "Target creature gets +1/+3 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "dfd67618-c7b5-5933-8341-4549be2a8dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821970a3-a291-4fe9-bb13-dfc54f9c3caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821970a3-a291-4fe9-bb13-dfc54f9c3caf.jpg?1",
             "name": "Hivespine Wolverine",
             "text": "When Hivespine Wolverine enters, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Hivespine Wolverine fights target creature token.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -6119,7 +6119,7 @@
         },
         {
             "id": "7b087864-462e-5095-9646-a2143cba2fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ee537-52e1-474a-9326-dfacc2a758ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ee537-52e1-474a-9326-dfacc2a758ab.jpg?1",
             "name": "Honored Dreyleader",
             "text": "Trample\nWhen Honored Dreyleader enters, put a +1/+1 counter on it for each other Squirrel and/or Food you control.\nWhenever another Squirrel or Food you control enters, put a +1/+1 counter on Honored Dreyleader.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "2af284c7-e3c3-510a-ba7d-90da9e070180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a31863-9649-4a4f-99e4-c93729938bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a31863-9649-4a4f-99e4-c93729938bd7.jpg?1",
             "name": "Hunter's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nWhen Hunter's Talent enters, target creature you control deals damage equal to its power to target creature you don't control.\n{1}{G}: Level 2\n//Level_2//\nWhenever you attack, target attacking creature gets +1/+0 and gains trample until end of turn.\n{3}{G}: Level 3\n//Level_3//\nAt the beginning of your end step, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "97fadbaf-7cd0-5347-847a-d78751dd588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b0afc-0e8f-45f2-ae7f-07595e164611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b0afc-0e8f-45f2-ae7f-07595e164611.jpg?1",
             "name": "Innkeeper's Talent",
             "text": "(Gain the next level as a sorcery to add its ability.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\n{G}: Level 2\n//Level_2//\nPermanents you control with counters on them have ward {1}.\n{3}{G}: Level 3\n//Level_3//\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
             "colours": [
@@ -6222,7 +6222,7 @@
         },
         {
             "id": "394e9a47-0cd5-5f67-94c7-a624b79b9ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf33d80-0704-4dc4-8e8d-1dcbcbc35add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf33d80-0704-4dc4-8e8d-1dcbcbc35add.jpg?1",
             "name": "Keen-Eyed Curator",
             "text": "As long as there are four or more card types among cards exiled with Keen-Eyed Curator, it gets +4/+4 and has trample.\n{1}: Exile target card from a graveyard.",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "622c45b4-f041-51e8-ac77-a824b951f03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef748c-b5e5-4e7d-bf2e-d3e6c08edb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef748c-b5e5-4e7d-bf2e-d3e6c08edb42.jpg?1",
             "name": "Longstalk Brawl",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, they create a tapped 1/1 blue Fish creature token before its other effects.)\nChoose target creature you control and target creature you don't control. Put a +1/+1 counter on the creature you control if the gift was promised. Then those creatures fight each other.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "2c6d7ee7-b635-584f-b96f-59979998134f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f3aaf-3960-48cd-b34b-32e4ae5ae088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f3aaf-3960-48cd-b34b-32e4ae5ae088.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "f10e6c50-6024-5ca0-9383-b425a3b1c4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5246540-5a84-41d8-9e30-8e7a6c0e84e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5246540-5a84-41d8-9e30-8e7a6c0e84e1.jpg?1",
             "name": "Mistbreath Elder",
             "text": "At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on Mistbreath Elder. Otherwise, you may return Mistbreath Elder to its owner's hand.",
             "colours": [
@@ -6369,7 +6369,7 @@
         },
         {
             "id": "1bdacfb0-dff7-5c96-aaae-887e9cf1b594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e979f-b618-4625-989c-e0ea5b61ed8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e979f-b618-4625-989c-e0ea5b61ed8a.jpg?1",
             "name": "Overprotect",
             "text": "Target creature you control gets +3/+3 and gains trample, hexproof, and indestructible until end of turn.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "8052bbb4-017b-5562-8410-b11967b1073a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c20ad-0f69-4822-ae76-770832cccdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c20ad-0f69-4822-ae76-770832cccdf7.jpg?1",
             "name": "Pawpatch Formation",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.\n\u2022 Draw a card. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "f85c443e-61d8-5924-ba72-f9810608aea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4d88ba-0ee4-4f66-995b-2e50614f50ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4d88ba-0ee4-4f66-995b-2e50614f50ee.jpg?1",
             "name": "Pawpatch Recruit",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nTrample\nWhenever a creature you control becomes the target of a spell or ability an opponent controls, put a +1/+1 counter on target creature you control other than that creature.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "386589f0-aee0-51f0-af74-6a4d7082c6ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72466c-505b-4371-9366-0fde525a37e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72466c-505b-4371-9366-0fde525a37e6.jpg?1",
             "name": "Peerless Recycling",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn target permanent card from your graveyard to your hand. If the gift was promised, instead return two target permanent cards from your graveyard to your hand.",
             "colours": [
@@ -6502,7 +6502,7 @@
         },
         {
             "id": "6e85ca17-65f2-5300-bdd6-012d957e6987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc4963c-d90b-4588-bdb7-85956e42a623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc4963c-d90b-4588-bdb7-85956e42a623.jpg?1",
             "name": "Polliwallop",
             "text": "This spell costs {1} less to cast for each Frog you control.\nTarget creature you control deals damage equal to twice its power to target creature you don't control.",
             "colours": [
@@ -6534,7 +6534,7 @@
         },
         {
             "id": "93d470a3-356f-5a70-9100-9e5ccfb31978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96b01f5-83de-4237-a68d-f946c53e31a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96b01f5-83de-4237-a68d-f946c53e31a6.jpg?1",
             "name": "Rust-Shield Rampager",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nThis creature can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "655a9a51-91e9-5608-9933-3e3ebbd11c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42ab407-e72d-4c48-9a9e-2055b5e71c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42ab407-e72d-4c48-9a9e-2055b5e71c69.jpg?1",
             "name": "Scrapshooter",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they draw a card.)\nReach\nWhen Scrapshooter enters, if the gift was promised, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "ced02e60-d7a4-5c48-8e39-b3352ea11659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dd3c27-e0d5-434e-a0f3-4a95245e21c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dd3c27-e0d5-434e-a0f3-4a95245e21c2.jpg?1",
             "name": "Season of Gathering",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Put a +1/+1 counter on a creature you control. It gains vigilance and trample until end of turn.\n{Paw Print}{Paw Print} \u2014 Choose artifact or enchantment. Destroy all permanents of the chosen type.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Draw cards equal to the greatest power among creatures you control.",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "f592629d-ff40-5c2d-8b4c-168412ce2ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fa9651-b217-4f93-9c46-9bdb11feedcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fa9651-b217-4f93-9c46-9bdb11feedcb.jpg?1",
             "name": "Stickytongue Sentinel",
             "text": "Reach\nWhen Stickytongue Sentinel enters, return up to one other target permanent you control to its owner's hand.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "ed4fcbc7-fc0e-5dbe-b005-db5f61fa87a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e95c7b-f0b2-4276-8c5e-4191b7ba35d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e95c7b-f0b2-4276-8c5e-4191b7ba35d1.jpg?1",
             "name": "Stocking the Pantry",
             "text": "Whenever you put one or more +1/+1 counters on a creature you control, put a supply counter on Stocking the Pantry.\n{2}, Remove a supply counter from Stocking the Pantry: Draw a card.",
             "colours": [
@@ -6707,7 +6707,7 @@
         },
         {
             "id": "617ea1e5-e438-5572-81dd-6bd41ab1f70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740abc5-54e1-478d-966e-0fa64e727995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740abc5-54e1-478d-966e-0fa64e727995.jpg?1",
             "name": "Sunshower Druid",
             "text": "When Sunshower Druid enters, put a +1/+1 counter on target creature and you gain 1 life.",
             "colours": [
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "6dafe5d8-4c94-5415-a57f-45514282048d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8bfa91-adb0-4596-8c16-d8bb64fdb26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8bfa91-adb0-4596-8c16-d8bb64fdb26d.jpg?1",
             "name": "Tender Wildguide",
             "text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\n{T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -6779,7 +6779,7 @@
         },
         {
             "id": "90493523-1401-5e97-9c82-83f375875c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2d6b02-a453-40f9-992a-5c5542987cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2d6b02-a453-40f9-992a-5c5542987cfb.jpg?1",
             "name": "Thornvault Forager",
             "text": "{T}: Add {G}.\n{T}, Forage: Add two mana in any combination of colors. (To forage, exile three cards from your graveyard or sacrifice a Food.)\n{3}{G}, {T}: Search your library for a Squirrel card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6816,7 +6816,7 @@
         },
         {
             "id": "d0e195ea-4fb1-5124-9a89-7214fc1eeab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ab6e14-26e0-4174-b5c6-bc0f5c26b177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ab6e14-26e0-4174-b5c6-bc0f5c26b177.jpg?1",
             "name": "Three Tree Rootweaver",
             "text": "{T}: Add one mana of any color.",
             "colours": [
@@ -6851,7 +6851,7 @@
         },
         {
             "id": "a16d0fa8-1a9b-57e8-acaa-94d309302b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ca1b3-4c1a-4be5-b321-f57db5ff0528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ca1b3-4c1a-4be5-b321-f57db5ff0528.jpg?1",
             "name": "Three Tree Scribe",
             "text": "Whenever Three Tree Scribe or another creature you control leaves the battlefield without dying, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -6886,7 +6886,7 @@
         },
         {
             "id": "908a367b-0dfa-5874-8af2-18bdb3f1f2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c8456e-c971-42b7-abf3-ff5ae1320abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c8456e-c971-42b7-abf3-ff5ae1320abe.jpg?1",
             "name": "Treeguard Duo",
             "text": "When Treeguard Duo enters, until end of turn, target creature you control gains vigilance and gets +X/+X, where X is the number of creatures you control.",
             "colours": [
@@ -6921,7 +6921,7 @@
         },
         {
             "id": "902df20c-532a-5b64-80e8-293d28c9edb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d4d6e-1fe5-4ff6-9877-8c849a24f5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d4d6e-1fe5-4ff6-9877-8c849a24f5e0.jpg?1",
             "name": "Treetop Sentries",
             "text": "Reach\nWhen Treetop Sentries enters, you may forage. If you do, draw a card. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -6956,7 +6956,7 @@
         },
         {
             "id": "9e04936a-e8a3-5fe6-b7f3-7ba2eb37c2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7256451f-0122-452a-88e8-0fb0f6bea3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7256451f-0122-452a-88e8-0fb0f6bea3f3.jpg?1",
             "name": "Valley Mightcaller",
             "text": "Trample\nWhenever another Frog, Rabbit, Raccoon, or Squirrel you control enters, put a +1/+1 counter on Valley Mightcaller.",
             "colours": [
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "3742aaef-7d0d-5a68-af05-0d07bf6d9758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded2b83-3b7d-4c8c-83c4-0624a1069628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fded2b83-3b7d-4c8c-83c4-0624a1069628.jpg?1",
             "name": "Wear Down",
             "text": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nDestroy target artifact or enchantment. If the gift was promised, instead destroy two target artifacts and/or enchantments.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "501fe30c-0e8a-5be5-829d-4a0f3378bec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436d6a84-4cea-4ca7-94aa-9d08280652af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436d6a84-4cea-4ca7-94aa-9d08280652af.jpg?1",
             "name": "Alania, Divergent Storm",
             "text": "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "61794ed1-64cd-5b87-8c61-47f7e9fa67c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e93be2-e06b-4774-8ba5-ccf82a6da1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e93be2-e06b-4774-8ba5-ccf82a6da1d8.jpg?1",
             "name": "Baylen, the Haymaker",
             "text": "Tap two untapped tokens you control: Add one mana of any color.\nTap three untapped tokens you control: Draw a card.\nTap four untapped tokens you control: Put three +1/+1 counters on Baylen, the Haymaker. It gains trample until end of turn.",
             "colours": [
@@ -7112,7 +7112,7 @@
         },
         {
             "id": "97c389c1-ab1b-5965-b49b-1a62a538e76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87138ace-3594-499e-bad5-ec76148613ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87138ace-3594-499e-bad5-ec76148613ea.jpg?1",
             "name": "Burrowguard Mentor",
             "text": "Trample\nBurrowguard Mentor's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "57a3b0f4-d10b-590f-9de0-6d0df0b521cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c16eaec-924c-42f6-9fea-07edd7ed93b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c16eaec-924c-42f6-9fea-07edd7ed93b9.jpg?1",
             "name": "Camellia, the Seedmiser",
             "text": "Menace\nOther Squirrels you control have menace.\nWhenever you sacrifice one or more Foods, create a 1/1 green Squirrel creature token.\n{2}, Forage: Put a +1/+1 counter on each other Squirrel you control. (To forage, exile three cards from your graveyard or sacrifice a Food.)",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "930a4f3b-6905-59f8-993c-20cd32b2ffa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ea10dd-21ea-4622-be27-79d03a802b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ea10dd-21ea-4622-be27-79d03a802b85.jpg?1",
             "name": "Cindering Cutthroat",
             "text": "Cindering Cutthroat enters with a +1/+1 counter on it if an opponent lost life this turn.\n{1}{BR}: Cindering Cutthroat gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "b681f5f3-3509-5445-a648-bd45fa864865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028130c-c91d-4bf7-b0b0-450f71107d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028130c-c91d-4bf7-b0b0-450f71107d7a.jpg?1",
             "name": "Clement, the Worrywort",
             "text": "Vigilance\nWhenever Clement, the Worrywort or another creature you control enters, return up to one target creature you control with lesser mana value to its owner's hand.\nFrogs you control have \"{T}: Add {G} or {U}. Spend this mana only to cast a creature spell.\"",
             "colours": [
@@ -7270,7 +7270,7 @@
         },
         {
             "id": "2380a1a6-aa65-5d47-8aef-0e23e543a403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c911a759-ed7b-452b-88a3-663478357610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c911a759-ed7b-452b-88a3-663478357610.jpg?1",
             "name": "Corpseberry Cultivator",
             "text": "At the beginning of combat on your turn, you may forage. (Exile three cards from your graveyard or sacrifice a Food.)\nWhenever you forage, put a +1/+1 counter on Corpseberry Cultivator.",
             "colours": [
@@ -7307,7 +7307,7 @@
         },
         {
             "id": "17c21423-3502-5c5f-9ac0-7da2859c613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bd6b0d-8606-4a37-8be3-a852f1a8e99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bd6b0d-8606-4a37-8be3-a852f1a8e99c.jpg?1",
             "name": "Dreamdew Entrancer",
             "text": "Reach\nWhen Dreamdew Entrancer enters, tap up to one target creature and put three stun counters on it. If you control that creature, draw two cards.",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "63ceb0db-c869-59a2-a991-55ef153ae668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee197d-c313-4364-b52c-f83d5f579bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee197d-c313-4364-b52c-f83d5f579bc3.jpg?1",
             "name": "Finneas, Ace Archer",
             "text": "Vigilance, reach\nWhenever Finneas, Ace Archer attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "774ece02-5471-56e6-b802-26a718dfce90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78fbaa3-c580-4290-9c28-b74169aab2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78fbaa3-c580-4290-9c28-b74169aab2fc.jpg?1",
             "name": "Fireglass Mentor",
             "text": "At the beginning of your second main phase, if an opponent lost life this turn, exile the top two cards of your library. Choose one of them. Until end of turn, you may play that card.",
             "colours": [
@@ -7425,7 +7425,7 @@
         },
         {
             "id": "508f76fa-05ec-5114-b2af-476807379444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131ea976-289e-4f32-896d-27bbfd423ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131ea976-289e-4f32-896d-27bbfd423ba9.jpg?1",
             "name": "Gev, Scaled Scorch",
             "text": "Ward\u2014\nPay 2 life.\nOther creatures you control enter with an additional +1/+1 counter on them for each opponent who lost life this turn.\nWhenever you cast a Lizard spell, Gev, Scaled Scorch deals 1 damage to target opponent.",
             "colours": [
@@ -7466,7 +7466,7 @@
         },
         {
             "id": "e45ea350-e4be-5fda-8c4e-365beee24879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc70b2d-5a3a-49ea-97db-175a62248302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc70b2d-5a3a-49ea-97db-175a62248302.jpg?1",
             "name": "Glarb, Calamity's Augur",
             "text": "Deathtouch\nYou may look at the top card of your library any time.\nYou may play lands and cast spells with mana value 4 or greater from the top of your library.\n{T}: Surveil 2.",
             "colours": [
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "a340b1db-1f86-5135-84af-f3743143cda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc20157-edd3-484d-8864-925c071c0551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc20157-edd3-484d-8864-925c071c0551.jpg?1",
             "name": "Head of the Homestead",
             "text": "When Head of the Homestead enters, create two 1/1 white Rabbit creature tokens.",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "f776c069-4c14-55fc-86d5-2936a0fe67df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40339715-22d0-4f99-822b-a00d9824f27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40339715-22d0-4f99-822b-a00d9824f27a.jpg?1",
             "name": "Helga, Skittish Seer",
             "text": "Whenever you cast a creature spell with mana value 4 or greater, you draw a card, gain 1 life, and put a +1/+1 counter on Helga, Skittish Seer.\n{T}: Add X mana of any one color, where X is Helga, Skittish Seer's power. Spend this mana only to cast creature spells with mana value 4 or greater or creature spells with {X} in their mana costs.",
             "colours": [
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "c08421e1-e91c-5b5e-925a-d491f69b3e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d7f4a-c947-4389-befa-1d547d0d1237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d7f4a-c947-4389-befa-1d547d0d1237.jpg?1",
             "name": "Hugs, Grisly Guardian",
             "text": "Trample\nWhen Hugs, Grisly Guardian enters, exile the top X cards of your library. Until the end of your next turn, you may play those cards.\nYou may play an additional land on each of your turns.",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "8e32c59f-a70f-5bdf-b3a3-cc141a754d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6c9196-6d28-4cc2-9748-60e9632a502b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6c9196-6d28-4cc2-9748-60e9632a502b.jpg?1",
             "name": "The Infamous Cruelclaw",
             "text": "Menace\nWhenever The Infamous Cruelclaw deals combat damage to a player, exile cards from the top of your library until you exile a nonland card. You may cast that card by discarding a card rather than paying its mana cost.",
             "colours": [
@@ -7672,7 +7672,7 @@
         },
         {
             "id": "f561a611-9914-588f-b53e-5d07e2c71d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918fd89b-5ab7-4ae2-920c-faca5e9da7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918fd89b-5ab7-4ae2-920c-faca5e9da7b9.jpg?1",
             "name": "Junkblade Bruiser",
             "text": "Trample\nWhenever you expend 4, Junkblade Bruiser gets +2/+1 until end of turn. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "e5056616-d943-5a5b-97f4-1ea6a7854322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf68793-22a2-4a59-9d37-6791584edca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf68793-22a2-4a59-9d37-6791584edca1.jpg?1",
             "name": "Kastral, the Windcrested",
             "text": "Flying\nWhenever one or more Birds you control deal combat damage to a player, choose one \u2014\n\u2022 You may put a Bird creature card from your hand or graveyard onto the battlefield with a finality counter on it.\n\u2022 Put a +1/+1 counter on each Bird you control.\n\u2022 Draw a card.",
             "colours": [
@@ -7751,7 +7751,7 @@
         },
         {
             "id": "6daa593b-1c16-55a9-94d6-d2196277692a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64de7b1f-a03e-4407-91f1-e108a2f26735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64de7b1f-a03e-4407-91f1-e108a2f26735.jpg?1",
             "name": "Lilysplash Mentor",
             "text": "Reach\n{1}{G}{U}: Exile another target creature you control, then return it to the battlefield under its owner's control with a +1/+1 counter on it. Activate only as a sorcery.",
             "colours": [
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "c734001a-0dab-5d0a-a109-e7c2d208b945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ee50d4-c878-457b-964d-29c039ce9852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ee50d4-c878-457b-964d-29c039ce9852.jpg?1",
             "name": "Lunar Convocation",
             "text": "At the beginning of your end step, if you gained life this turn, each opponent loses 1 life.\nAt the beginning of your end step, if you gained and lost life this turn, create a 1/1 black Bat creature token with flying.\n{1}{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -7824,7 +7824,7 @@
         },
         {
             "id": "7d22b1e6-c247-511e-86c3-8c27aa87b17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6627fd-729d-44f2-b6bf-5299f49d1e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6627fd-729d-44f2-b6bf-5299f49d1e3d.jpg?1",
             "name": "Mabel, Heir to Cragflame",
             "text": "Other Mice you control get +1/+1.\nWhen Mabel, Heir to Cragflame enters, create Cragflame, a legendary colorless Equipment artifact token with \"Equipped creature gets +1/+1 and has vigilance, trample, and haste\" and equip {2}.",
             "colours": [
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "b9a24d9d-e6e4-5bb1-b9fb-9d0fc28a2c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507ba708-ca9b-453e-b4c2-23b6650eb5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507ba708-ca9b-453e-b4c2-23b6650eb5a8.jpg?1",
             "name": "Mind Drill Assailant",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Mind Drill Assailant gets +3/+0.\n{2}{UB}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "1c8bb701-040c-5db1-be28-0d1887909e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f2a71f-31e8-4b51-9dd4-51a5336b3b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f2a71f-31e8-4b51-9dd4-51a5336b3b86.jpg?1",
             "name": "Moonrise Cleric",
             "text": "Flying\nWhenever Moonrise Cleric attacks, you gain 1 life.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "fa85b556-4969-5d6e-9180-a676e2853518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40e4658-fd68-46d0-9a89-25570a023d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40e4658-fd68-46d0-9a89-25570a023d19.jpg?1",
             "name": "Muerra, Trash Tactician",
             "text": "At the beginning of your first main phase, add {R} or {G} for each Raccoon you control.\nWhenever you expend 4, you gain 3 life. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)\nWhenever you expend 8, exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "647205f1-10f0-566b-ba52-374dba97f400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa988f-547e-449a-9f1a-296c01d68d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa988f-547e-449a-9f1a-296c01d68d96.jpg?1",
             "name": "Plumecreed Mentor",
             "text": "Flying\nWhenever Plumecreed Mentor or another creature you control with flying enters, put a +1/+1 counter on target creature you control without flying.",
             "colours": [
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "f5653433-93e1-5ec9-ab13-0ef16d82fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb959e74-61ea-453d-bb9f-ad0183c0e1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb959e74-61ea-453d-bb9f-ad0183c0e1b1.jpg?1",
             "name": "Pond Prophet",
             "text": "When Pond Prophet enters, draw a card.",
             "colours": [
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "aa9d0afa-4410-5199-9c5a-3d1f5f289825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfde780-899a-4c5b-a39b-f4a3ff129103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfde780-899a-4c5b-a39b-f4a3ff129103.jpg?1",
             "name": "Ral, Crackling Wit",
             "text": "Whenever you cast a noncreature spell, put a loyalty counter on Ral, Crackling Wit.\n+1: Create a 1/1 blue and red Otter creature token with prowess.\n\u22123: Draw three cards, then discard two cards.\n\u221210: Draw three cards. You get an emblem with \"Instant and sorcery spells you cast have storm.\" (Whenever you cast an instant or sorcery spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -8096,7 +8096,7 @@
         },
         {
             "id": "19a61260-efef-5c6e-9f79-331732a07d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c3e41-0636-49a3-8c9c-384c5e5c9c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c3e41-0636-49a3-8c9c-384c5e5c9c3e.jpg?1",
             "name": "Seedglaive Mentor",
             "text": "Vigilance, haste\nValiant \u2014 Whenever Seedglaive Mentor becomes the target of a spell or ability you control for the first time each turn, put a +1/+1 counter on it.",
             "colours": [
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "bf4f26e0-d6a1-5ca2-813a-46d0fd5d5b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3684577-51ce-490e-9b59-b19c733be466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3684577-51ce-490e-9b59-b19c733be466.jpg?1",
             "name": "Seedpod Squire",
             "text": "Flying\nWhenever Seedpod Squire attacks, target creature you control without flying gets +1/+1 until end of turn.",
             "colours": [
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "a3b19e2a-bf09-5501-b2bd-fa39aa7a7ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f6dc5-9fe8-49c1-b24c-1d99ce1da619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f6dc5-9fe8-49c1-b24c-1d99ce1da619.jpg?1",
             "name": "Starseer Mentor",
             "text": "Flying, vigilance\nAt the beginning of your end step, if you gained or lost life this turn, target opponent loses 3 life unless they sacrifice a nonland permanent or discard a card.",
             "colours": [
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "05a75131-677a-5006-bd71-afdebf85e8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99754055-6d67-4fde-aff3-41f6af6ea764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99754055-6d67-4fde-aff3-41f6af6ea764.jpg?1",
             "name": "Stormcatch Mentor",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "039d071b-cfed-55df-ba49-51b2094c28e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850daae4-f0b7-4604-95e7-ad044ec165c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850daae4-f0b7-4604-95e7-ad044ec165c3.jpg?1",
             "name": "Tempest Angler",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Tempest Angler.",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "423b3520-924b-5474-9a10-87e7d3c26bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa10ffac-7cc2-41ef-b8a0-9431923c0542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa10ffac-7cc2-41ef-b8a0-9431923c0542.jpg?1",
             "name": "Tidecaller Mentor",
             "text": "Menace\nThreshold \u2014 When Tidecaller Mentor enters, if seven or more cards are in your graveyard, return up to one target nonland permanent to its owner's hand.",
             "colours": [
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "7b858680-8602-592b-9b80-988b5e9dac95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db43c46-b616-4ef8-80ed-0fab345ab3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db43c46-b616-4ef8-80ed-0fab345ab3d0.jpg?1",
             "name": "Veteran Guardmouse",
             "text": "Valiant \u2014 Whenever Veteran Guardmouse becomes the target of a spell or ability you control for the first time each turn, it gets +1/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -8357,7 +8357,7 @@
         },
         {
             "id": "faf49a49-ada3-5ca5-b0ad-c3e4ff9b5c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b615ba-45c4-42a1-8525-1535f0b55300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b615ba-45c4-42a1-8525-1535f0b55300.jpg?1",
             "name": "Vinereap Mentor",
             "text": "When Vinereap Mentor enters or dies, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -8394,7 +8394,7 @@
         },
         {
             "id": "4af2dbb1-cf54-5958-a289-c81b311cc793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506277d-f031-4db5-9d16-bf2389094785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506277d-f031-4db5-9d16-bf2389094785.jpg?1",
             "name": "Vren, the Relentless",
             "text": "Ward {2}\nIf a creature an opponent controls would die, exile it instead.\nAt the beginning of each end step, create X 1/1 black Rat creature tokens with \"This creature gets +1/+1 for each other Rat you control,\" where X is the number of creatures your opponents controlled that were exiled this turn.",
             "colours": [
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "92e7f651-af8f-54cb-8dc6-99044483b0e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c399a55-d02e-41ed-b827-8784b738c118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c399a55-d02e-41ed-b827-8784b738c118.jpg?1",
             "name": "Wandertale Mentor",
             "text": "Whenever you expend 4, put a +1/+1 counter on Wandertale Mentor. (You expend 4 as you spend your fourth total mana to cast spells during a turn.)\n{T}: Add {R} or {G}.",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "8691865e-524b-5ee6-b6a3-75a2a7070034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ac7673-eae8-4c4b-889e-5025213a6151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ac7673-eae8-4c4b-889e-5025213a6151.jpg?1",
             "name": "Ygra, Eater of All",
             "text": "Ward\u2014\nSacrifice a Food.\nOther creatures are Food artifacts in addition to their other types and have \"{2}, {T}, Sacrifice this permanent: You gain 3 life.\"\nWhenever a Food is put into a graveyard from the battlefield, put two +1/+1 counters on Ygra, Eater of All.",
             "colours": [
@@ -8513,7 +8513,7 @@
         },
         {
             "id": "7f0a2429-2d70-595e-8bb9-d7596cc05895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f99fd5-5298-4b27-923d-9d31203c931a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f99fd5-5298-4b27-923d-9d31203c931a.jpg?1",
             "name": "Zoraline, Cosmos Caller",
             "text": "Flying, vigilance\nWhenever a Bat you control attacks, you gain 1 life.\nWhenever Zoraline enters or attacks, you may pay {W}{B} and 2 life. When you do, return target nonland permanent card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.",
             "colours": [
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "9b9e4069-0dbb-54f8-a063-9483fa1ff7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77049a6-0f22-415b-bc89-20bcb32accf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77049a6-0f22-415b-bc89-20bcb32accf6.jpg?1",
             "name": "Barkform Harvester",
             "text": "Changeling (This card is every creature type.)\nReach\n{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -8585,7 +8585,7 @@
         },
         {
             "id": "66e214d2-f7c4-55f1-a96d-b21b6805803e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0affd5-5dcd-4dd1-a694-37a9aedf4084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0affd5-5dcd-4dd1-a694-37a9aedf4084.jpg?1",
             "name": "Bumbleflower's Sharepot",
             "text": "When Bumbleflower's Sharepot enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{5}, {T}, Sacrifice Bumbleflower's Sharepot: Destroy target nonland permanent. Activate only as a sorcery.",
             "colours": [],
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "aff0f307-047c-5454-bce3-780878a03e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c94bc0-a49d-451b-8e8d-64d46b8b8603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c94bc0-a49d-451b-8e8d-64d46b8b8603.jpg?1",
             "name": "Fountainport Bell",
             "text": "When Fountainport Bell enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.\n{1}, Sacrifice Fountainport Bell: Draw a card.",
             "colours": [],
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "ba4da240-f920-5bee-a5e5-2ec2768aaaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7839ce48-0175-494a-ab89-9bdfb7a50cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7839ce48-0175-494a-ab89-9bdfb7a50cb1.jpg?1",
             "name": "Heirloom Epic",
             "text": "{4}, {T}: Draw a card. For each mana in this ability's activation cost, you may tap an untapped creature you control rather than pay that mana. Activate only as a sorcery.",
             "colours": [],
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "f6a25449-d5d7-5a3c-88a3-29b8bc156e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a982c8-bc08-44ba-b3ed-9e4b124615d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a982c8-bc08-44ba-b3ed-9e4b124615d6.jpg?1",
             "name": "Patchwork Banner",
             "text": "As Patchwork Banner enters, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "c831abb5-53fd-5d08-b671-6e13d8a20662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8b72b-fa8f-48d3-bddc-d3ce9b8ba2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8b72b-fa8f-48d3-bddc-d3ce9b8ba2ea.jpg?1",
             "name": "Short Bow",
             "text": "Equipped creature gets +1/+1 and has vigilance and reach.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "5edae66d-00cb-5af9-ba54-2288ee536a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23d8e96-b972-4c6c-b0c4-b6627621f048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23d8e96-b972-4c6c-b0c4-b6627621f048.jpg?1",
             "name": "Starforged Sword",
             "text": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they create a tapped 1/1 blue Fish creature token.)\nWhen Starforged Sword enters, if the gift was promised, attach Starforged Sword to target creature you control.\nEquipped creature gets +3/+3 and loses flying.\nEquip {3}",
             "colours": [],
@@ -8757,7 +8757,7 @@
         },
         {
             "id": "30e474a4-85ae-58c7-ae87-680dbe94a4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258ef349-5042-4992-bae9-9f8f54b55db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258ef349-5042-4992-bae9-9f8f54b55db0.jpg?1",
             "name": "Tangle Tumbler",
             "text": "Vigilance\n{3}, {T}: Put a +1/+1 counter on target creature.\nTap two untapped tokens you control: Tangle Tumbler becomes an artifact creature until end of turn.",
             "colours": [],
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "c64cd705-540d-5019-bd42-7b827ecb200c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaced75b-6e07-457c-8ea2-f74d99710d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaced75b-6e07-457c-8ea2-f74d99710d15.jpg?1",
             "name": "Three Tree Mascot",
             "text": "Changeling (This card is every creature type.)\n{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "47d266fb-dcb1-5696-9b20-72d885220658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8809830f-d8e1-4603-9652-0ad8b00234e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8809830f-d8e1-4603-9652-0ad8b00234e9.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -8848,7 +8848,7 @@
         },
         {
             "id": "2c7cf757-d382-581b-9ff3-de3d38f2ed47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658cfcb7-81b7-48c6-9dd2-1663d06108cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658cfcb7-81b7-48c6-9dd2-1663d06108cf.jpg?1",
             "name": "Fountainport",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a token: Draw a card.\n{3}, {T}, Pay 1 life: Create a 1/1 blue Fish creature token.\n{4}, {T}: Create a Treasure token.",
             "colours": [],
@@ -8878,7 +8878,7 @@
         },
         {
             "id": "e473b0b8-76c0-5904-bc67-dadc7aee1497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8f2e7-8357-4862-97dc-1942d066023a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8f2e7-8357-4862-97dc-1942d066023a.jpg?1",
             "name": "Hidden Grotto",
             "text": "When Hidden Grotto enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "f65c0023-ea13-50a1-ad2c-fc2384cd8ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e95a7cc-ed77-4ca4-80db-61c0fc68bf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e95a7cc-ed77-4ca4-80db-61c0fc68bf50.jpg?1",
             "name": "Lilypad Village",
             "text": "{T}: Add {C}.\n{T}: Add {U}. Spend this mana only to cast a creature spell.\n{U}, {T}: Surveil 2. Activate only if a Bird, Frog, Otter, or Rat entered the battlefield under your control this turn.",
             "colours": [],
@@ -8936,7 +8936,7 @@
         },
         {
             "id": "e3ce094a-3db0-5567-bf05-b97d5bee94e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab9d56f-9178-4ec9-a5f6-b934f50d8d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab9d56f-9178-4ec9-a5f6-b934f50d8d9d.jpg?1",
             "name": "Lupinflower Village",
             "text": "{T}: Add {C}.\n{T}: Add {W}. Spend this mana only to cast a creature spell.\n{1}{W}, {T}, Sacrifice Lupinflower Village: Look at the top six cards of your library. You may reveal a Bat, Bird, Mouse, or Rabbit card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8966,7 +8966,7 @@
         },
         {
             "id": "11995b50-3d97-50c9-8a8c-7e31da946086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4ad3-9cf0-4f1b-a9db-d63feee594ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4ad3-9cf0-4f1b-a9db-d63feee594ab.jpg?1",
             "name": "Mudflat Village",
             "text": "{T}: Add {C}.\n{T}: Add {B}. Spend this mana only to cast a creature spell.\n{1}{B}, {T}, Sacrifice Mudflat Village: Return target Bat, Lizard, Rat, or Squirrel card from your graveyard to your hand.",
             "colours": [],
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "ca257ece-6379-5d4b-b007-6312e228f2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49b016-b02b-459f-85e9-c04f6bdcb94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49b016-b02b-459f-85e9-c04f6bdcb94e.jpg?1",
             "name": "Oakhollow Village",
             "text": "{T}: Add {C}.\n{T}: Add {G}. Spend this mana only to cast a creature spell.\n{G}, {T}: Put a +1/+1 counter on each Frog, Rabbit, Raccoon, or Squirrel you control that entered the battlefield this turn.",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "daeafe9e-c593-5020-be6f-1d5be4f7cefc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62799d24-39a6-4e66-8ac3-7cafa99e6e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62799d24-39a6-4e66-8ac3-7cafa99e6e6d.jpg?1",
             "name": "Rockface Village",
             "text": "{T}: Add {C}.\n{T}: Add {R}. Spend this mana only to cast a creature spell.\n{R}, {T}: Target Lizard, Mouse, Otter, or Raccoon you control gets +1/+0 and gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -9056,7 +9056,7 @@
         },
         {
             "id": "fc09ab40-43a2-5195-80db-ec9328370356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f88a48-cced-4a9d-8c19-e4f105f0d8a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f88a48-cced-4a9d-8c19-e4f105f0d8a2.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -9091,7 +9091,7 @@
         },
         {
             "id": "8f1bb2aa-8e64-5269-be16-55e2de73d533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b90f54-d629-4126-82cc-13b51d6c1c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b90f54-d629-4126-82cc-13b51d6c1c3e.jpg?1",
             "name": "Uncharted Haven",
             "text": "Uncharted Haven enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9119,7 +9119,7 @@
         },
         {
             "id": "7fd6af75-a023-50ec-9fe7-ede1dafd7e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663ff0c-d02f-49ac-bb88-6f0dbd684337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663ff0c-d02f-49ac-bb88-6f0dbd684337.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9159,7 +9159,7 @@
         },
         {
             "id": "80e1a433-5304-585c-83e0-8d6914c038e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab53b300-38b2-436c-834c-b0162dd3b757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab53b300-38b2-436c-834c-b0162dd3b757.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9199,7 +9199,7 @@
         },
         {
             "id": "97c5fb07-ca38-5bda-aad8-4fea46d0afb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f04188d-9a76-495d-b3a7-ee44810cf671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f04188d-9a76-495d-b3a7-ee44810cf671.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "71f4abb3-cdf4-50d5-b518-b3700ae6bbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94c04-b6d3-4118-b252-5146eedae4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94c04-b6d3-4118-b252-5146eedae4e8.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "c2ae9b30-b202-5105-acfa-c0df262b9138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106a5332-0104-4ec9-9e1f-806381ae4cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106a5332-0104-4ec9-9e1f-806381ae4cad.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9319,7 +9319,7 @@
         },
         {
             "id": "42225ec3-8c45-5af4-87ca-e076a10a3bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b92adb-a384-4e03-8ba7-1e41b9fb2516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b92adb-a384-4e03-8ba7-1e41b9fb2516.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "e86450f3-acad-53ee-a3bf-5231427e1a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408eb23f-13fa-4f98-b316-18e3057f9136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408eb23f-13fa-4f98-b316-18e3057f9136.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "7a75f632-6b9a-530c-b933-72dd498d6beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9db98e-9f1d-4139-95c5-49f9d17a2107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9db98e-9f1d-4139-95c5-49f9d17a2107.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9439,7 +9439,7 @@
         },
         {
             "id": "804c7373-dfb5-5d37-aebb-6c10dc2ae42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa54bef-c90e-4e9b-b94b-942ea829e0d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa54bef-c90e-4e9b-b94b-942ea829e0d2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "21dbe39b-fe7b-5f8f-bd39-2044049f180f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbc78a-7854-4a66-911f-a40b33e25f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbc78a-7854-4a66-911f-a40b33e25f39.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9519,7 +9519,7 @@
         },
         {
             "id": "9acab90e-5a23-5f01-a726-7bbab4623e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0223cf7f-4c6e-487f-babb-a740a15e1f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0223cf7f-4c6e-487f-babb-a740a15e1f0c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9559,7 +9559,7 @@
         },
         {
             "id": "5f999834-95b3-5a21-b254-1c5496940804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4650ebaf-8e9f-431c-998d-e0f426b24d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4650ebaf-8e9f-431c-998d-e0f426b24d41.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9599,7 +9599,7 @@
         },
         {
             "id": "f83a0b58-4096-5eea-bec9-5f6471f11b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bba8fb-d763-4efa-8db1-e5e81994b5f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bba8fb-d763-4efa-8db1-e5e81994b5f9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "b6137def-ebe0-51ae-844a-cc013dfbd146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02244055-cbeb-4074-9482-42ec20721312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02244055-cbeb-4074-9482-42ec20721312.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "d4b36d6f-8766-5509-99c2-b2f5ab35ed8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b384d24-8771-4860-8fc1-1b74217f1c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b384d24-8771-4860-8fc1-1b74217f1c4c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9719,7 +9719,7 @@
         },
         {
             "id": "67b0cd1e-0afa-595f-b402-8939691f0470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38bea4-2d1b-442b-aad5-ab1a0ae67aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38bea4-2d1b-442b-aad5-ab1a0ae67aac.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9759,7 +9759,7 @@
         },
         {
             "id": "e48cc37d-b7a9-56f2-9815-d1e5e14496c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791876a-f3fb-45b8-90a9-af846d8b8f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791876a-f3fb-45b8-90a9-af846d8b8f74.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "79b116c7-2a3a-52fc-8055-a3a46fe9aa55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a2a54-47e1-4694-b4f6-b7d659bb2b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a2a54-47e1-4694-b4f6-b7d659bb2b1f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9839,7 +9839,7 @@
         },
         {
             "id": "d072fad7-a565-581a-8c2e-78325ca3911d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000419b-0bba-4488-8f7a-6194544ce91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000419b-0bba-4488-8f7a-6194544ce91e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9879,7 +9879,7 @@
         },
         {
             "id": "5d467433-dcb0-526e-94ca-49a2c2b37104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208014f4-eed8-4856-a9d9-dbac10c4aa6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208014f4-eed8-4856-a9d9-dbac10c4aa6a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "a2e0ba05-45c7-5071-aa41-04588e778a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba10fbc2-193a-4516-a8dd-8b5f8b33a9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba10fbc2-193a-4516-a8dd-8b5f8b33a9de.jpg?1",
             "name": "Season of the Burrow",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a 1/1 white Rabbit creature token.\n{Paw Print}{Paw Print} \u2014 Exile target nonland permanent. Its controller draws a card.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return target permanent card with mana value 3 or less from your graveyard to the battlefield with an indestructible counter on it.",
             "colours": [
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "af4147bf-9775-56c6-9149-0e567bea1366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61da9522-3844-4753-8122-d11ae2780a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61da9522-3844-4753-8122-d11ae2780a4c.jpg?1",
             "name": "Season of Weaving",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Draw a card.\n{Paw Print}{Paw Print} \u2014 Choose an artifact or creature you control. Create a token that's a copy of it.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Return each nonland, nontoken permanent to its owner's hand.",
             "colours": [
@@ -9987,7 +9987,7 @@
         },
         {
             "id": "fe59ca69-41b0-5484-a26e-e859f1553480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a428d58-b376-489e-8224-17a41ef6e81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a428d58-b376-489e-8224-17a41ef6e81b.jpg?1",
             "name": "Season of Loss",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Each player sacrifices a creature.\n{Paw Print}{Paw Print} \u2014 Draw a card for each creature you controlled that died this turn.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Each opponent loses X life, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "c0082986-56b8-5ea8-a664-d1522c23b5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d88763-35bd-472a-810e-02c795d0c873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d88763-35bd-472a-810e-02c795d0c873.jpg?1",
             "name": "Season of the Bold",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Create a tapped Treasure token.\n{Paw Print}{Paw Print} \u2014 Exile the top two cards of your library. Until the end of your next turn, you may play them.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Until the end of your next turn, whenever you cast a spell, Season of the Bold deals 2 damage to up to one target creature.",
             "colours": [
@@ -10055,7 +10055,7 @@
         },
         {
             "id": "042cb735-0e69-5448-8ec4-488cef1a3b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e99fa55-2594-434b-9396-95b8f661bd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e99fa55-2594-434b-9396-95b8f661bd0d.jpg?1",
             "name": "Season of Gathering",
             "text": "Choose up to five {Paw Print} worth of modes. You may choose the same mode more than once.\n{Paw Print} \u2014 Put a +1/+1 counter on a creature you control. It gains vigilance and trample until end of turn.\n{Paw Print}{Paw Print} \u2014 Choose artifact or enchantment. Destroy all permanents of the chosen type.\n{Paw Print}{Paw Print}{Paw Print} \u2014 Draw cards equal to the greatest power among creatures you control.",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "733cd23e-f49d-538a-b633-4ea7efbc719e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc98b72-d268-4ce5-93b4-57c812a24eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc98b72-d268-4ce5-93b4-57c812a24eff.jpg?1",
             "name": "Beza, the Bounding Spring",
             "text": "When Beza, the Bounding Spring enters, create a Treasure token if an opponent controls more lands than you. You gain 4 life if an opponent has more life than you. Create two 1/1 blue Fish creature tokens if an opponent controls more creatures than you. Draw a card if an opponent has more cards in hand than you.",
             "colours": [
@@ -10128,7 +10128,7 @@
         },
         {
             "id": "880d82eb-d340-5d30-b55d-b7d1b4e52a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9da428-3af7-4027-b3f0-9138d953c37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9da428-3af7-4027-b3f0-9138d953c37b.jpg?1",
             "name": "Eluge, the Shoreless Sea",
             "text": "Eluge's power and toughness are each equal to the number of Islands you control.\nWhenever Eluge enters or attacks, put a flood counter on target land. It's an Island in addition to its other types for as long as it has a flood counter on it.\nThe first instant or sorcery spell you cast each turn costs {U} (or {1}) less to cast for each land you control with a flood counter on it.",
             "colours": [
@@ -10167,7 +10167,7 @@
         },
         {
             "id": "ce805977-0855-5e86-9b75-bca727f57c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd53428-56c3-4c99-828d-665e3c2d15a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd53428-56c3-4c99-828d-665e3c2d15a8.jpg?1",
             "name": "Maha, Its Feathers Night",
             "text": "Flying, trample\nWard\u2014\nDiscard a card.\nCreatures your opponents control have base toughness 1.",
             "colours": [
@@ -10206,7 +10206,7 @@
         },
         {
             "id": "58ea6e49-f0e6-5537-8754-b71ce82e03f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bad7555-3e5d-4096-a671-184630d38113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bad7555-3e5d-4096-a671-184630d38113.jpg?1",
             "name": "Rottenmouth Viper",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of nonland permanents. This spell costs {1} less to cast for each permanent sacrificed this way.\nWhenever Rottenmouth Viper enters or attacks, put a blight counter on it. Then for each blight counter on it, each opponent loses 4 life unless that player sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -10243,7 +10243,7 @@
         },
         {
             "id": "86bf9358-93a7-5f41-b367-f7f2c8cbaf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ef78d-ba5e-415e-9684-816464c5611a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ef78d-ba5e-415e-9684-816464c5611a.jpg?1",
             "name": "Dragonhawk, Fate's Tempest",
             "text": "Flying\nWhenever Dragonhawk enters or attacks, exile the top X cards of your library, where X is the number of creatures you control with power 4 or greater. You may play those cards until your next end step. At the beginning of your next end step, Dragonhawk deals 2 damage to each opponent for each of those cards that are still exiled.",
             "colours": [
@@ -10282,7 +10282,7 @@
         },
         {
             "id": "f000f599-57df-56c5-861e-dd291777306d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c414b4-3374-44e4-98b4-03193e701eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c414b4-3374-44e4-98b4-03193e701eb1.jpg?1",
             "name": "Sunspine Lynx",
             "text": "Players can't gain life.\nDamage can't be prevented.\nWhen Sunspine Lynx enters, it deals damage to each player equal to the number of nonbasic lands that player controls.",
             "colours": [
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "f4816114-a089-5bbd-a451-5eef36e7ce2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99587a-7fb1-41fc-b7ea-1178f9625081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99587a-7fb1-41fc-b7ea-1178f9625081.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "a9231445-d673-54d5-97d2-c6eb87d5a3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0d6ca-eed9-4b57-a34a-0105c41b20b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0d6ca-eed9-4b57-a34a-0105c41b20b9.jpg?1",
             "name": "Ygra, Eater of All",
             "text": "Ward\u2014\nSacrifice a Food.\nOther creatures are Food artifacts in addition to their other types and have \"{2}, {T}, Sacrifice this permanent: You gain 3 life.\"\nWhenever a Food is put into a graveyard from the battlefield, put two +1/+1 counters on Ygra, Eater of All.",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "420748e7-0567-58f5-829b-6e6b00d6cb14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce7aec-f9b0-461b-8245-5286b741409d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce7aec-f9b0-461b-8245-5286b741409d.jpg?1",
             "name": "Dawn's Truce",
             "text": "Gift a card\nYou and permanents you control gain hexproof until end of turn. If the gift was promised, permanents you control also gain indestructible until end of turn.",
             "colours": [
@@ -10435,7 +10435,7 @@
         },
         {
             "id": "9e69eab6-92db-5a4e-8a78-845a3e8d190a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4411204e-8387-4f1c-bfb3-1e3092d07937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4411204e-8387-4f1c-bfb3-1e3092d07937.jpg?1",
             "name": "Jackdaw Savior",
             "text": "Flying\nWhenever Jackdaw Savior or another creature you control with flying dies, return another target creature card with lesser mana value from your graveyard to the battlefield.",
             "colours": [
@@ -10472,7 +10472,7 @@
         },
         {
             "id": "beb18ed9-82a1-5917-adae-41c2a016150d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25e2bd6-c95b-422f-b6c2-d687c0745ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25e2bd6-c95b-422f-b6c2-d687c0745ecb.jpg?1",
             "name": "Salvation Swan",
             "text": "Flash\nFlying\nWhenever Salvation Swan or another Bird you control enters, exile up to one target creature you control without flying. Return it to the battlefield under its owner's control with a flying counter on it at the beginning of the next end step.",
             "colours": [
@@ -10509,7 +10509,7 @@
         },
         {
             "id": "169c31b7-95b0-5ca0-b6f0-2ede9062a23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fe9b09-383a-4cf6-9e2c-bd00499e5eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fe9b09-383a-4cf6-9e2c-bd00499e5eb0.jpg?1",
             "name": "Starfall Invocation",
             "text": "Gift a card\nDestroy all creatures. If the gift was promised, return a creature card put into your graveyard this way to the battlefield under your control.",
             "colours": [
@@ -10543,7 +10543,7 @@
         },
         {
             "id": "7e0e6ab8-108f-509c-ba07-35ae67b29a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f25130-678d-4338-8eb4-b20d2da5bc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f25130-678d-4338-8eb4-b20d2da5bc74.jpg?1",
             "name": "Valley Questcaller",
             "text": "Whenever one or more other Rabbits, Bats, Birds, and/or Mice you control enter, scry 1.\nOther Rabbits, Bats, Birds, and Mice you control get +1/+1.",
             "colours": [
@@ -10580,7 +10580,7 @@
         },
         {
             "id": "7fc9a20f-437b-53f4-aa55-658478694269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48062f31-167a-4f16-9453-7c41f026ca96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48062f31-167a-4f16-9453-7c41f026ca96.jpg?1",
             "name": "Warren Warleader",
             "text": "Offspring {2}\nWhenever you attack, choose one \u2014\n\u2022 Create a 1/1 white Rabbit creature token that's tapped and attacking.\n\u2022 Attacking creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -10617,7 +10617,7 @@
         },
         {
             "id": "3485ecbd-b74a-5f23-af9b-541bf5009703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea69966-8961-4447-bd39-70d3d8d48ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea69966-8961-4447-bd39-70d3d8d48ede.jpg?1",
             "name": "Whiskervale Forerunner",
             "text": "Valiant \u2014 Whenever Whiskervale Forerunner becomes the target of a spell or ability you control for the first time each turn, look at the top five cards of your library. You may reveal a creature card with mana value 3 or less from among them. You may put it onto the battlefield if it's your turn. If you don't put it onto the battlefield, put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10654,7 +10654,7 @@
         },
         {
             "id": "c1f23801-ecd0-5fcd-8a00-c69c07f10187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493ef3c-673b-4e70-b957-0ee7b6d38216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493ef3c-673b-4e70-b957-0ee7b6d38216.jpg?1",
             "name": "Azure Beastbinder",
             "text": "Vigilance\nAzure Beastbinder can't be blocked by creatures with power 2 or greater.\nWhenever Azure Beastbinder attacks, up to one target artifact, creature, or planeswalker an opponent controls loses all abilities until your next turn. If it's a creature, it also has base power and toughness 2/2 until your next turn.",
             "colours": [
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "aa049f9f-e45c-5ec3-a50e-959ebf803ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e407118-95b7-4e62-a4f0-dbd8b6b80830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e407118-95b7-4e62-a4f0-dbd8b6b80830.jpg?1",
             "name": "Dour Port-Mage",
             "text": "Whenever one or more other creatures you control leave the battlefield without dying, draw a card.\n{1}{U}, {T}: Return another target creature you control to its owner's hand.",
             "colours": [
@@ -10728,7 +10728,7 @@
         },
         {
             "id": "b11a10df-905d-5ad0-9ae4-9d5f5dbb67f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bbfdc9-8d68-4b4e-ac68-ac165cdc168d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bbfdc9-8d68-4b4e-ac68-ac165cdc168d.jpg?1",
             "name": "Kitsa, Otterball Elite",
             "text": "Vigilance\nProwess\n{T}: Draw a card, then discard a card.\n{2}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy. Activate only if Kitsa's power is 3 or greater.",
             "colours": [
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "0d480bf9-d6b9-5bcb-b4a9-aa70d1b53144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed827d1-a374-48b4-8b65-abec9044de85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed827d1-a374-48b4-8b65-abec9044de85.jpg?1",
             "name": "Mockingbird",
             "text": "Flying\nYou may have Mockingbird enter as a copy of any creature on the battlefield with mana value less than or equal to the amount of mana spent to cast Mockingbird, except it's a Bird in addition to its other types and it has flying.",
             "colours": [
@@ -10804,7 +10804,7 @@
         },
         {
             "id": "9c9211a9-b0d8-5a6e-afb1-9ce2216a850f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb6618b-276b-4ce1-873f-eace471fafde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb6618b-276b-4ce1-873f-eace471fafde.jpg?1",
             "name": "Portent of Calamity",
             "text": "Reveal the top X cards of your library. For each card type, you may exile a card of that type from among them. Put the rest into your graveyard. You may cast a spell from among the exiled cards without paying its mana cost if you exiled four or more cards this way. Then put the rest of the exiled cards into your hand.",
             "colours": [
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "9e8d8a93-f5f4-5dbb-a10d-76391f6dd422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ec3510-c168-4acc-aee8-65529d0f5ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ec3510-c168-4acc-aee8-65529d0f5ad7.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "Offspring {4}\nWhen this creature enters, look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10876,7 +10876,7 @@
         },
         {
             "id": "6fcb8e40-a95b-5f61-89c5-9eaabe7a6cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c744764-3b54-49a0-aa68-1fb22d8162a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c744764-3b54-49a0-aa68-1fb22d8162a9.jpg?1",
             "name": "Valley Floodcaller",
             "text": "Flash\nYou may cast noncreature spells as though they had flash.\nWhenever you cast a noncreature spell, Birds, Frogs, Otters, and Rats you control get +1/+1 until end of turn. Untap them.",
             "colours": [
@@ -10913,7 +10913,7 @@
         },
         {
             "id": "c1b065d1-ed40-5d5f-8435-987e85b16734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640725a5-8251-4f7a-b1e3-481519c85b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640725a5-8251-4f7a-b1e3-481519c85b5d.jpg?1",
             "name": "Coiling Rebirth",
             "text": "Gift a card\nReturn target creature card from your graveyard to the battlefield. Then if the gift was promised and that creature isn't legendary, create a token that's a copy of that creature, except it's 1/1.",
             "colours": [
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "8ed0ead7-8570-504f-a111-7d96514d23c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ec21-3eb1-4f4c-a74a-84408fd1dce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ec21-3eb1-4f4c-a74a-84408fd1dce6.jpg?1",
             "name": "Cruelclaw's Heist",
             "text": "Gift a card\nTarget opponent reveals their hand. You choose a nonland card from it. Exile that card. If the gift was promised, you may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -10981,7 +10981,7 @@
         },
         {
             "id": "6d3ea749-8643-5517-9697-91f3a715374f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9abfd1-59ba-46f4-ad1d-cf0e125dd4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9abfd1-59ba-46f4-ad1d-cf0e125dd4b9.jpg?1",
             "name": "Darkstar Augur",
             "text": "Offspring {B}\nFlying\nAt the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
             "colours": [
@@ -11018,7 +11018,7 @@
         },
         {
             "id": "bd58ff64-32ed-503f-9898-d6feb805b9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4532d-63ea-4a70-86b3-58327b7e9706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4532d-63ea-4a70-86b3-58327b7e9706.jpg?1",
             "name": "Osteomancer Adept",
             "text": "Deathtouch\n{T}: Until end of turn, you may cast creature spells from your graveyard by foraging in addition to paying their other costs. If you cast a spell this way, that creature enters with a finality counter on it.",
             "colours": [
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "663ee619-ce60-5097-b99e-2f4608f24997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278a127-5f3c-4948-88bd-2af4f6834a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4278a127-5f3c-4948-88bd-2af4f6834a03.jpg?1",
             "name": "Valley Rotcaller",
             "text": "Menace\nWhenever Valley Rotcaller attacks, each opponent loses X life and you gain X life, where X is the number of other Squirrels, Bats, Lizards, and Rats you control.",
             "colours": [
@@ -11092,7 +11092,7 @@
         },
         {
             "id": "3a94a428-be15-514f-b9d9-5f73598974fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a9d17-2b19-4e17-9b7e-667bf2285950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a9d17-2b19-4e17-9b7e-667bf2285950.jpg?1",
             "name": "Wick, the Whorled Mind",
             "text": "Whenever Wick or another Rat you control enters, create a 1/1 black Snail creature token if you don't control a Snail. Otherwise, put a +1/+1 counter on a Snail you control.\n{U}{B}{R}, Sacrifice a Snail: Wick deals damage equal to the sacrificed creature's power to each opponent. Then draw cards equal to the sacrificed creature's power.",
             "colours": [
@@ -11133,7 +11133,7 @@
         },
         {
             "id": "95a46554-7b71-5daa-a806-2dc29e5411c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde5980-ad2c-4ddf-8244-f9688a6225f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde5980-ad2c-4ddf-8244-f9688a6225f2.jpg?1",
             "name": "Emberheart Challenger",
             "text": "Haste\nProwess\nValiant \u2014 Whenever Emberheart Challenger becomes the target of a spell or ability you control for the first time each turn, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -11170,7 +11170,7 @@
         },
         {
             "id": "ca1b3d9d-8bbd-5553-8e8a-95821b3dfced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02134775-9c86-4f1a-af2e-5c1f531038fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02134775-9c86-4f1a-af2e-5c1f531038fe.jpg?1",
             "name": "Festival of Embers",
             "text": "During your turn, you may cast instant and sorcery spells from your graveyard by paying 1 life in addition to their other costs.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.\n{1}{R}: Sacrifice Festival of Embers.",
             "colours": [
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "75d372ee-7457-5374-863d-17d1d35348b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda3d3ef-c858-4707-9c3f-be1b775eb8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda3d3ef-c858-4707-9c3f-be1b775eb8c1.jpg?1",
             "name": "Hired Claw",
             "text": "Whenever you attack with one or more Lizards, Hired Claw deals 1 damage to target opponent.\n{1}{R}: Put a +1/+1 counter on Hired Claw. Activate only if an opponent lost life this turn and only once each turn.",
             "colours": [
@@ -11241,7 +11241,7 @@
         },
         {
             "id": "d9185ba1-e49b-5fcb-bb57-11e7a4f7982a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a990c-6ee9-44e1-85f9-83b261507308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a990c-6ee9-44e1-85f9-83b261507308.jpg?1",
             "name": "Manifold Mouse",
             "text": "Offspring {2}\nAt the beginning of combat on your turn, target Mouse you control gains your choice of double strike or trample until end of turn.",
             "colours": [
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "f78215fc-26b3-587c-88d3-fae9f4a27c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5235d-46a2-4b04-97fc-b8eb0f1ba14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5235d-46a2-4b04-97fc-b8eb0f1ba14a.jpg?1",
             "name": "Stormsplitter",
             "text": "Haste\nWhenever you cast an instant or sorcery spell, create a token that's a copy of Stormsplitter. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -11315,7 +11315,7 @@
         },
         {
             "id": "4430b18b-cd4f-5dda-90cc-217dc962f272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f266f6da-93b0-4036-b7df-be5eac4e1135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f266f6da-93b0-4036-b7df-be5eac4e1135.jpg?1",
             "name": "Valley Flamecaller",
             "text": "If a Lizard, Mouse, Otter, or Raccoon you control would deal damage to a permanent or player, it deals that much damage plus 1 instead.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "d4d7718e-573b-56c1-9aa6-3b72220daf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d1e35e-f5c8-422d-83d2-839ab7766f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d1e35e-f5c8-422d-83d2-839ab7766f25.jpg?1",
             "name": "For the Common Good",
             "text": "Create X tokens that are copies of target token you control. Then tokens you control gain indestructible until your next turn. You gain 1 life for each token you control.",
             "colours": [
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "4f919ce3-d185-52bd-8852-ebf3f3e0707d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004a67ce-60ef-4cc2-9f4d-f30e3029d80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004a67ce-60ef-4cc2-9f4d-f30e3029d80a.jpg?1",
             "name": "Keen-Eyed Curator",
             "text": "As long as there are four or more card types among cards exiled with Keen-Eyed Curator, it gets +4/+4 and has trample.\n{1}: Exile target card from a graveyard.",
             "colours": [
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "87069759-97b4-5fcf-8a58-af1dcb76ce08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ed58e4-b612-483e-9c0e-f1fbfaa5950c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ed58e4-b612-483e-9c0e-f1fbfaa5950c.jpg?1",
             "name": "Mistbreath Elder",
             "text": "At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on Mistbreath Elder. Otherwise, you may return Mistbreath Elder to its owner's hand.",
             "colours": [
@@ -11460,7 +11460,7 @@
         },
         {
             "id": "ba549ac6-fb7f-5328-9afd-eeeb59154365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afd22ab-64e7-4b85-804d-faccd4452487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afd22ab-64e7-4b85-804d-faccd4452487.jpg?1",
             "name": "Scrapshooter",
             "text": "Gift a card\nReach\nWhen Scrapshooter enters, if the gift was promised, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -11497,7 +11497,7 @@
         },
         {
             "id": "1a7509de-37c4-58ef-aeb7-fa2a297c8d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc164c8-62ca-4d59-ae1c-ef273fde9d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc164c8-62ca-4d59-ae1c-ef273fde9d10.jpg?1",
             "name": "Tender Wildguide",
             "text": "Offspring {2}\n{T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -11534,7 +11534,7 @@
         },
         {
             "id": "84008bd6-54f6-5114-be43-14c014d2d4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31330554-1824-436b-aee5-931a7b652ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31330554-1824-436b-aee5-931a7b652ddf.jpg?1",
             "name": "Valley Mightcaller",
             "text": "Trample\nWhenever another Frog, Rabbit, Raccoon, or Squirrel you control enters, put a +1/+1 counter on Valley Mightcaller.",
             "colours": [
@@ -11571,7 +11571,7 @@
         },
         {
             "id": "66076563-e3e4-5d1f-b8b7-356f88e54f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dc7b8e-d381-49a0-a7f8-c8cd9acadc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9dc7b8e-d381-49a0-a7f8-c8cd9acadc54.jpg?1",
             "name": "Alania, Divergent Storm",
             "text": "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -11613,7 +11613,7 @@
         },
         {
             "id": "7cb0a1f7-c402-5fec-b5b7-014a1b0342ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ea9ca9-3dff-4d5d-92ec-3475234b4713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ea9ca9-3dff-4d5d-92ec-3475234b4713.jpg?1",
             "name": "Camellia, the Seedmiser",
             "text": "Menace\nOther Squirrels you control have menace.\nWhenever you sacrifice one or more Foods, create a 1/1 green Squirrel creature token.\n{2}, Forage: Put a +1/+1 counter on each other Squirrel you control.",
             "colours": [
@@ -11655,7 +11655,7 @@
         },
         {
             "id": "bf8db8db-412e-554f-9db2-e74c6de2bca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a68d51-cd4e-4ee3-abc7-01435085aa26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a68d51-cd4e-4ee3-abc7-01435085aa26.jpg?1",
             "name": "Clement, the Worrywort",
             "text": "Vigilance\nWhenever Clement, the Worrywort or another creature you control enters, return up to one target creature you control with lesser mana value to its owner's hand.\nFrogs you control have \"{T}: Add {G} or {U}. Spend this mana only to cast a creature spell.\"",
             "colours": [
@@ -11697,7 +11697,7 @@
         },
         {
             "id": "9b636c36-85de-5c85-842b-12f2936b67ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77374ac-3456-48a3-a412-4474547d437c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77374ac-3456-48a3-a412-4474547d437c.jpg?1",
             "name": "Finneas, Ace Archer",
             "text": "Vigilance, reach\nWhenever Finneas, Ace Archer attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
             "colours": [
@@ -11739,7 +11739,7 @@
         },
         {
             "id": "0e3b50ec-85b2-512b-8a71-4cc7b9ff7194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fab12e-0f81-4728-9a35-4dc896ba3744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fab12e-0f81-4728-9a35-4dc896ba3744.jpg?1",
             "name": "Glarb, Calamity's Augur",
             "text": "Deathtouch\nYou may look at the top card of your library any time.\nYou may play lands and cast spells with mana value 4 or greater from the top of your library.\n{T}: Surveil 2.",
             "colours": [
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "0585bfc3-1e14-55c5-9b83-21ccf2662107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768ef947-85fc-4fb2-bda9-e0e446cd8886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768ef947-85fc-4fb2-bda9-e0e446cd8886.jpg?1",
             "name": "Helga, Skittish Seer",
             "text": "Whenever you cast a creature spell with mana value 4 or greater, you draw a card, gain 1 life, and put a +1/+1 counter on Helga, Skittish Seer.\n{T}: Add X mana of any one color, where X is Helga, Skittish Seer's power. Spend this mana only to cast creature spells with mana value 4 or greater or creature spells with {X} in their mana costs.",
             "colours": [
@@ -11826,7 +11826,7 @@
         },
         {
             "id": "ae9e4bc4-c9f2-538e-abcf-1ecefbbe24d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b2be42-467d-4210-b9bf-4d09ee504a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b2be42-467d-4210-b9bf-4d09ee504a22.jpg?1",
             "name": "Hugs, Grisly Guardian",
             "text": "Trample\nWhen Hugs, Grisly Guardian enters, exile the top X cards of your library. Until the end of your next turn, you may play those cards.\nYou may play an additional land on each of your turns.",
             "colours": [
@@ -11867,7 +11867,7 @@
         },
         {
             "id": "17b629ea-bb6b-5430-930b-849206cc3499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc26a7-f47e-44d7-a42b-b5415fc86f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fc26a7-f47e-44d7-a42b-b5415fc86f8f.jpg?1",
             "name": "The Infamous Cruelclaw",
             "text": "Menace\nWhenever The Infamous Cruelclaw deals combat damage to a player, exile cards from the top of your library until you exile a nonland card. You may cast that card by discarding a card rather than paying its mana cost.",
             "colours": [
@@ -11908,7 +11908,7 @@
         },
         {
             "id": "0a7e24ad-9a28-5ed2-ad23-77ec6f076efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a84790-665b-4a23-a00f-84d1009e3d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a84790-665b-4a23-a00f-84d1009e3d28.jpg?1",
             "name": "Kastral, the Windcrested",
             "text": "Flying\nWhenever one or more Birds you control deal combat damage to a player, choose one \u2014\n\u2022 You may put a Bird creature card from your hand or graveyard onto the battlefield with a finality counter on it.\n\u2022 Put a +1/+1 counter on each Bird you control.\n\u2022 Draw a card.",
             "colours": [
@@ -11950,7 +11950,7 @@
         },
         {
             "id": "cd1816ac-7dd4-5b47-8c12-529b596e1e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1696453f-a678-47ff-b583-53c2130b7d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1696453f-a678-47ff-b583-53c2130b7d49.jpg?1",
             "name": "Mabel, Heir to Cragflame",
             "text": "Other Mice you control get +1/+1.\nWhen Mabel, Heir to Cragflame enters, create Cragflame, a legendary colorless Equipment artifact token with \"Equipped creature gets +1/+1 and has vigilance, trample, and haste\" and equip {2}.",
             "colours": [
@@ -11992,7 +11992,7 @@
         },
         {
             "id": "c61a003a-45bc-591d-86b2-2745583327e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b0f9e-fa3b-4a40-acea-b6ecc584a79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b0f9e-fa3b-4a40-acea-b6ecc584a79f.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12027,7 +12027,7 @@
         },
         {
             "id": "f7190d6f-6dfb-584a-8cff-4896159464de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06008bcb-ce6b-482c-9253-f5b9b5e0718e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06008bcb-ce6b-482c-9253-f5b9b5e0718e.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12062,7 +12062,7 @@
         },
         {
             "id": "9d360dcf-3cf4-545c-98d3-ff6409cef25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e1d8486-370a-49b6-9145-060814f38677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e1d8486-370a-49b6-9145-060814f38677.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12097,7 +12097,7 @@
         },
         {
             "id": "1db2d22a-e9d1-5f3e-93ea-e452e539930e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb16046-10bf-433a-acaf-7127c0954a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb16046-10bf-433a-acaf-7127c0954a1c.jpg?1",
             "name": "Three Tree City",
             "text": "As Three Tree City enters, choose a creature type.\n{T}: Add {C}.\n{2}, {T}: Choose a color. Add an amount of mana of that color equal to the number of creatures you control of the chosen type.",
             "colours": [],
@@ -12132,7 +12132,7 @@
         },
         {
             "id": "1a3d6192-8dd0-552b-a460-dfcac3c02826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a74dbdd-5baa-4896-80d4-1a9743410d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a74dbdd-5baa-4896-80d4-1a9743410d4c.jpg?1",
             "name": "Ral, Crackling Wit",
             "text": "Whenever you cast a noncreature spell, put a loyalty counter on Ral, Crackling Wit.\n+1: Create a 1/1 blue and red Otter creature token with prowess.\n\u22123: Draw three cards, then discard two cards.\n\u221210: Draw three cards. You get an emblem with \"Instant and sorcery spells you cast have storm.\"",
             "colours": [
@@ -12173,7 +12173,7 @@
         },
         {
             "id": "7d95bac2-c3d1-5784-879e-daf2b2e41655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b3c33-aa44-4001-87ff-695bf04f51be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b3c33-aa44-4001-87ff-695bf04f51be.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -12214,7 +12214,7 @@
         },
         {
             "id": "947e7baa-d2ec-50f9-9d1e-f5a33caa344c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487cfce-2b73-4082-a1f2-dea263811516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487cfce-2b73-4082-a1f2-dea263811516.jpg?1",
             "name": "Lumra, Bellow of the Woods",
             "text": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -12254,7 +12254,7 @@
         },
         {
             "id": "a8afcf4b-d76b-5b7a-9df0-d9298aceb455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ace81d-823f-43d1-902e-345418cd8fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ace81d-823f-43d1-902e-345418cd8fd2.jpg?1",
             "name": "Alania, Divergent Storm",
             "text": "Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -12295,7 +12295,7 @@
         },
         {
             "id": "03966aa5-83c2-59bd-990a-ae36d79c5a5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b511524-e628-41d4-b0dc-d98961d4e9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b511524-e628-41d4-b0dc-d98961d4e9e1.jpg?1",
             "name": "Baylen, the Haymaker",
             "text": "Tap two untapped tokens you control: Add one mana of any color.\nTap three untapped tokens you control: Draw a card.\nTap four untapped tokens you control: Put three +1/+1 counters on Baylen, the Haymaker. It gains trample until end of turn.",
             "colours": [
@@ -12337,7 +12337,7 @@
         },
         {
             "id": "567ac1f0-7343-5904-ba46-33f4c3de7734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f59ece-1ba5-422b-820d-e80c83f46290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f59ece-1ba5-422b-820d-e80c83f46290.jpg?1",
             "name": "Camellia, the Seedmiser",
             "text": "Menace\nOther Squirrels you control have menace.\nWhenever you sacrifice one or more Foods, create a 1/1 green Squirrel creature token.\n{2}, Forage: Put a +1/+1 counter on each other Squirrel you control.",
             "colours": [
@@ -12378,7 +12378,7 @@
         },
         {
             "id": "9053974b-4479-5f53-9645-b7f0ecdc2981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfe689-83d4-4dcb-810c-d618a39c5ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfe689-83d4-4dcb-810c-d618a39c5ab9.jpg?1",
             "name": "Clement, the Worrywort",
             "text": "Vigilance\nWhenever Clement, the Worrywort or another creature you control enters, return up to one target creature you control with lesser mana value to its owner's hand.\nFrogs you control have \"{T}: Add {G} or {U}. Spend this mana only to cast a creature spell.\"",
             "colours": [
@@ -12419,7 +12419,7 @@
         },
         {
             "id": "72f9bea4-4e3c-5d10-aad7-82a2dc0403d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d99aec-c114-4287-ab61-a34e5adab5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d99aec-c114-4287-ab61-a34e5adab5ab.jpg?1",
             "name": "Finneas, Ace Archer",
             "text": "Vigilance, reach\nWhenever Finneas, Ace Archer attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
             "colours": [
@@ -12460,7 +12460,7 @@
         },
         {
             "id": "e1f36337-1100-5bcb-9105-052f99f8b9b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad70a0b-3845-4b92-9c15-985a3fe0e1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad70a0b-3845-4b92-9c15-985a3fe0e1f2.jpg?1",
             "name": "Gev, Scaled Scorch",
             "text": "Ward\u2014\nPay 2 life.\nOther creatures you control enter with an additional +1/+1 counter on them for each opponent who lost life this turn.\nWhenever you cast a Lizard spell, Gev, Scaled Scorch deals 1 damage to target opponent.",
             "colours": [
@@ -12500,7 +12500,7 @@
         },
         {
             "id": "bd425e97-68db-59c5-a878-6c3b9753b6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6d51dc-ca49-417c-8b5a-fcb5cd669c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6d51dc-ca49-417c-8b5a-fcb5cd669c6f.jpg?1",
             "name": "Kastral, the Windcrested",
             "text": "Flying\nWhenever one or more Birds you control deal combat damage to a player, choose one \u2014\n\u2022 You may put a Bird creature card from your hand or graveyard onto the battlefield with a finality counter on it.\n\u2022 Put a +1/+1 counter on each Bird you control.\n\u2022 Draw a card.",
             "colours": [
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "194af200-8013-56d1-bc65-0565521fb37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbdaae3-acba-44e1-bdd6-9c7066143d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbdaae3-acba-44e1-bdd6-9c7066143d33.jpg?1",
             "name": "Mabel, Heir to Cragflame",
             "text": "Other Mice you control get +1/+1.\nWhen Mabel, Heir to Cragflame enters, create Cragflame, a legendary colorless Equipment artifact token with \"Equipped creature gets +1/+1 and has vigilance, trample, and haste\" and equip {2}.",
             "colours": [
@@ -12582,7 +12582,7 @@
         },
         {
             "id": "23889ad9-537a-5a0e-979a-15d11a5c1318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b4e695-5ec4-4821-8637-8df501ba0653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b4e695-5ec4-4821-8637-8df501ba0653.jpg?1",
             "name": "Muerra, Trash Tactician",
             "text": "At the beginning of your first main phase, add {R} or {G} for each Raccoon you control.\nWhenever you expend 4, you gain 3 life.\nWhenever you expend 8, exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -12622,7 +12622,7 @@
         },
         {
             "id": "b78e915c-cb64-5144-b5d1-41b02ba68796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c496c-c70e-46f0-b161-661620767de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c496c-c70e-46f0-b161-661620767de5.jpg?1",
             "name": "Ral, Crackling Wit",
             "text": "Whenever you cast a noncreature spell, put a loyalty counter on Ral, Crackling Wit.\n+1: Create a 1/1 blue and red Otter creature token with prowess.\n\u22123: Draw three cards, then discard two cards.\n\u221210: Draw three cards. You get an emblem with \"Instant and sorcery spells you cast have storm.\"",
             "colours": [
@@ -12662,7 +12662,7 @@
         },
         {
             "id": "c705867f-fbdc-5331-9aff-80ee95d6b4ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca7c86-92d8-4a24-81b1-9eb11392160d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca7c86-92d8-4a24-81b1-9eb11392160d.jpg?1",
             "name": "Vren, the Relentless",
             "text": "Ward {2}\nIf a creature an opponent controls would die, exile it instead.\nAt the beginning of each end step, create X 1/1 black Rat creature tokens with \"This creature gets +1/+1 for each other Rat you control,\" where X is the number of creatures your opponents controlled that were exiled this turn.",
             "colours": [
@@ -12702,7 +12702,7 @@
         },
         {
             "id": "a634a2c2-dcb6-560d-a7d8-f1e9d84964a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34690573-d8d6-471e-9878-cf5d931d9f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34690573-d8d6-471e-9878-cf5d931d9f55.jpg?1",
             "name": "Zoraline, Cosmos Caller",
             "text": "Flying, vigilance\nWhenever a Bat you control attacks, you gain 1 life.\nWhenever Zoraline enters or attacks, you may pay {W}{B} and 2 life. When you do, return target nonland permanent card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.",
             "colours": [
@@ -12742,7 +12742,7 @@
         },
         {
             "id": "8707a4b0-c722-5124-a174-08ab86a6114d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5c86a-0991-4322-a0a2-48424c4be2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5c86a-0991-4322-a0a2-48424c4be2af.jpg?1",
             "name": "Essence Channeler",
             "text": "As long as you've lost life this turn, Essence Channeler has flying and vigilance.\nWhenever you gain life, put a +1/+1 counter on Essence Channeler.\nWhen Essence Channeler dies, put its counters on target creature you control.",
             "colours": [
@@ -12779,7 +12779,7 @@
         },
         {
             "id": "d722ca3e-5b47-5ebd-837f-b8b74427423e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f3b75d-87d6-42dc-8096-41f5480b12fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f3b75d-87d6-42dc-8096-41f5480b12fa.jpg?1",
             "name": "Kitnap",
             "text": "Gift a card\nEnchant creature\nWhen Kitnap enters, tap enchanted creature. If the gift wasn't promised, put three stun counters on it.\nYou control enchanted creature.",
             "colours": [
@@ -12815,7 +12815,7 @@
         },
         {
             "id": "45bd58ea-7b75-5776-a40a-d762b1b24cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e054e77f-94b9-4c43-94a4-75a7a5d1bd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e054e77f-94b9-4c43-94a4-75a7a5d1bd30.jpg?1",
             "name": "Wishing Well",
             "text": "{T}: Put a coin counter on Wishing Well. When you do, you may cast target instant or sorcery card with mana value equal to the number of coin counters on Wishing Well from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -12849,7 +12849,7 @@
         },
         {
             "id": "cf8492ea-d3a4-5d4e-b27c-76d9a671e061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e34b4-6762-465f-a5c7-24e42e112fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e34b4-6762-465f-a5c7-24e42e112fbe.jpg?1",
             "name": "Iridescent Vinelasher",
             "text": "Offspring {2}\nLandfall \u2014 Whenever a land you control enters, this creature deals 1 damage to target opponent.",
             "colours": [
@@ -12886,7 +12886,7 @@
         },
         {
             "id": "94734754-74e4-5710-8815-8d9fc9ab7364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aebd0f9-fa08-407f-b3d3-fb4b13b1ea97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aebd0f9-fa08-407f-b3d3-fb4b13b1ea97.jpg?1",
             "name": "Byway Barterer",
             "text": "Menace\nWhenever you expend 4, you may discard your hand. If you do, draw two cards.",
             "colours": [
@@ -12923,7 +12923,7 @@
         },
         {
             "id": "4d433efd-f4e5-52f9-ae0e-634d10467a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a10a11-a21f-4e93-8771-8d971c158911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a10a11-a21f-4e93-8771-8d971c158911.jpg?1",
             "name": "Hearthborn Battler",
             "text": "Haste\nWhenever a player casts their second spell each turn, Hearthborn Battler deals 2 damage to target opponent.",
             "colours": [
@@ -12960,7 +12960,7 @@
         },
         {
             "id": "d8b4b907-dcf5-5b86-bf33-037687c4bbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56301392-3496-48d0-8d91-6b82e1164c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56301392-3496-48d0-8d91-6b82e1164c98.jpg?1",
             "name": "Fecund Greenshell",
             "text": "Reach\nAs long as you control ten or more lands, creatures you control get +2/+2.\nWhenever Fecund Greenshell or another creature you control with toughness greater than its power enters, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. Otherwise, put it into your hand.",
             "colours": [
@@ -12997,7 +12997,7 @@
         },
         {
             "id": "8ced1bf6-e33d-581a-8f3e-8a87b7438a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc5b558-4470-4bd7-9458-fbd275ded168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc5b558-4470-4bd7-9458-fbd275ded168.jpg?1",
             "name": "Pawpatch Recruit",
             "text": "Offspring {2}\nTrample\nWhenever a creature you control becomes the target of a spell or ability an opponent controls, put a +1/+1 counter on target creature you control other than that creature.",
             "colours": [
@@ -13034,7 +13034,7 @@
         },
         {
             "id": "f8efff88-b5c7-5bb4-884f-f0f6b68870e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ffe1ab-df93-4017-bb29-bb214c86d73a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ffe1ab-df93-4017-bb29-bb214c86d73a.jpg?1",
             "name": "Thornvault Forager",
             "text": "{T}: Add {G}.\n{T}, Forage: Add two mana in any combination of colors.\n{3}{G}, {T}: Search your library for a Squirrel card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -13071,7 +13071,7 @@
         },
         {
             "id": "5423288a-f88f-5312-ad67-c7199bf21c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2efb27-c181-43f7-93fe-a8c4d286f8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2efb27-c181-43f7-93fe-a8c4d286f8ad.jpg?1",
             "name": "Dreamdew Entrancer",
             "text": "Reach\nWhen Dreamdew Entrancer enters, tap up to one target creature and put three stun counters on it. If you control that creature, draw two cards.",
             "colours": [
@@ -13110,7 +13110,7 @@
         },
         {
             "id": "8b36f850-9288-52ee-8df9-c9e996d85443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396e4c7-660d-4055-bc94-4ccea95223b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396e4c7-660d-4055-bc94-4ccea95223b7.jpg?1",
             "name": "Lunar Convocation",
             "text": "At the beginning of your end step, if you gained life this turn, each opponent loses 1 life.\nAt the beginning of your end step, if you gained and lost life this turn, create a 1/1 black Bat creature token with flying.\n{1}{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -13146,7 +13146,7 @@
         },
         {
             "id": "a8ab5ba9-bc91-568a-acee-1e125a4e6fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda8a2e-6bf1-4d8c-b71b-bbc8d8130fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda8a2e-6bf1-4d8c-b71b-bbc8d8130fff.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -13176,7 +13176,7 @@
         },
         {
             "id": "35dc150c-0e17-5148-8778-6ab6c29bf351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd04367b-59d8-4ee6-8b5a-abfb1373c226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd04367b-59d8-4ee6-8b5a-abfb1373c226.jpg?1",
             "name": "Fountainport",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a token: Draw a card.\n{3}, {T}, Pay 1 life: Create a 1/1 blue Fish creature token.\n{4}, {T}: Create a Treasure token.",
             "colours": [],
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "06649302-997a-58e6-8d80-21ced2f30252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449d4122-ee9d-477c-976a-809ba8cb1443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449d4122-ee9d-477c-976a-809ba8cb1443.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -13246,7 +13246,7 @@
         },
         {
             "id": "7897f1f5-3d18-57a0-9710-838d4e7d886e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b61a1-db66-416d-8187-edc32123131f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b61a1-db66-416d-8187-edc32123131f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -13286,7 +13286,7 @@
         },
         {
             "id": "1195f7e4-455a-5e3f-964e-77e638e0b960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46848fc2-ba58-4738-b4ce-0399d9053f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46848fc2-ba58-4738-b4ce-0399d9053f48.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13326,7 +13326,7 @@
         },
         {
             "id": "59c80579-10b2-5a53-b42c-086be6a12076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10125dab-fe82-4796-b5db-3bd6ad389e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10125dab-fe82-4796-b5db-3bd6ad389e1d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "ce543f0d-5c7b-5ff5-b618-9b1373bb5439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6125ffe3-4e48-4e0f-8390-7462446fc8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6125ffe3-4e48-4e0f-8390-7462446fc8bf.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13406,7 +13406,7 @@
         },
         {
             "id": "1df5f06a-420d-5e39-8a8b-83c8cbbe44f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbfdbdd-6322-4ea6-9680-d4e480d78437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbfdbdd-6322-4ea6-9680-d4e480d78437.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13446,7 +13446,7 @@
         },
         {
             "id": "e3d57a49-793d-5ddd-99a4-b0ab1a79de53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b827c54-8bfe-4ef5-830e-e17b8690bbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b827c54-8bfe-4ef5-830e-e17b8690bbe7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -13486,7 +13486,7 @@
         },
         {
             "id": "9951ede6-9c13-515c-b9b1-5dd498b73360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62aaa129-69ff-4e22-861e-b2efd1cd5a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62aaa129-69ff-4e22-861e-b2efd1cd5a10.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -13526,7 +13526,7 @@
         },
         {
             "id": "7edb292e-d32c-5cf8-ae5b-fac3aef0d394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b3be4a-973d-4aeb-a94e-37e2710ac178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b3be4a-973d-4aeb-a94e-37e2710ac178.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -13566,7 +13566,7 @@
         },
         {
             "id": "23a4a236-daa6-57c8-bdc3-3a9d7b4db18d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddc66f7-4e94-4857-ba7d-6b0083d0bfa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddc66f7-4e94-4857-ba7d-6b0083d0bfa0.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -13606,7 +13606,7 @@
         },
         {
             "id": "e991d23a-8f81-5fbe-861e-ea50ac11b324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c96b3-68da-4a42-89ab-d9ccc79ce0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c96b3-68da-4a42-89ab-d9ccc79ce0dd.jpg?1",
             "name": "Bria, Riptide Rogue",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nOther creatures you control have prowess. (If a creature has multiple instances of prowess, each triggers separately.)\nWhenever you cast a noncreature spell, target creature you control can't be blocked this turn.",
             "colours": [
@@ -13645,7 +13645,7 @@
         },
         {
             "id": "06b266a0-7c12-5c37-b027-c16aa3b225fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6441abd3-320b-424a-9753-61e3581fe1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6441abd3-320b-424a-9753-61e3581fe1a9.jpg?1",
             "name": "Byrke, Long Ear of the Law",
             "text": "Vigilance\nWhen Byrke, Long Ear of the Law enters, put a +1/+1 counter on each of up to two target creatures.\nWhenever a creature you control with a +1/+1 counter on it attacks, double the number of +1/+1 counters on it.",
             "colours": [
@@ -13684,7 +13684,7 @@
         },
         {
             "id": "413733c3-e799-51b3-bec4-cde87a64cb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684614e3-5454-4e68-87da-a2027b6af6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684614e3-5454-4e68-87da-a2027b6af6d7.jpg?1",
             "name": "Hop to It",
             "text": "Create three 1/1 white Rabbit creature tokens.",
             "colours": [
@@ -13718,7 +13718,7 @@
         },
         {
             "id": "92900508-75e7-5a15-b09c-56135dd11b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb0b3c-a403-4212-93d3-3340c3f1e9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cb0b3c-a403-4212-93d3-3340c3f1e9db.jpg?1",
             "name": "Shoreline Looter",
             "text": "Shoreline Looter can't be blocked.\nThreshold \u2014 Whenever Shoreline Looter deals combat damage to a player, draw a card. Then discard a card unless seven or more cards are in your graveyard.",
             "colours": [
@@ -13755,7 +13755,7 @@
         },
         {
             "id": "b6ff9221-6d14-5ca5-a19d-58ea15a40f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bb137-2639-4158-a24b-93c8e4f4cc21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4bb137-2639-4158-a24b-93c8e4f4cc21.jpg?1",
             "name": "Fell",
             "text": "Destroy target creature.",
             "colours": [
@@ -13789,7 +13789,7 @@
         },
         {
             "id": "d3da415c-1de6-5da8-9b1a-28ff0328f38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c394081-0292-49f8-8a6f-213956754020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c394081-0292-49f8-8a6f-213956754020.jpg?1",
             "name": "Wear Down",
             "text": "Gift a card\nDestroy target artifact or enchantment. If the gift was promised, instead destroy two target artifacts and/or enchantments.",
             "colours": [
@@ -13823,7 +13823,7 @@
         },
         {
             "id": "5bc391f5-126a-52ab-bb4a-c68dc93dab8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e5a7a1-4ac5-4d9f-8d27-0877efca47f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e5a7a1-4ac5-4d9f-8d27-0877efca47f1.jpg?1",
             "name": "Stormcatch Mentor",
             "text": "Haste, prowess\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -13862,7 +13862,7 @@
         },
         {
             "id": "0353d774-65f7-5470-9725-5f937a2145f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52caa08-34ae-4c74-83ad-008d17005576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52caa08-34ae-4c74-83ad-008d17005576.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "Offspring {4} (You may pay an additional {4} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nWhen this creature enters, look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13900,7 +13900,7 @@
         },
         {
             "id": "34144cef-a2e3-5e5e-8614-eacf17bfe99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9aef-bd9c-4332-ace4-b5b065bac6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9aef-bd9c-4332-ace4-b5b065bac6d8.jpg?1",
             "name": "Serra Redeemer",
             "text": "Flying\nWhenever another creature you control with power 2 or less enters, put two +1/+1 counters on that creature.",
             "colours": [
@@ -13934,7 +13934,7 @@
         },
         {
             "id": "e76de6e8-86f2-5c46-99d4-cb153ce60781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d171802-2604-45a5-a0f2-ab5afa1db5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d171802-2604-45a5-a0f2-ab5afa1db5d5.jpg?1",
             "name": "Charmed Sleep",
             "text": "Enchant creature\nWhen Charmed Sleep enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "5e245e76-e789-5efb-9025-7f0cd44b38e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7d174-eb7c-41ad-a241-cfbfdc71e3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7d174-eb7c-41ad-a241-cfbfdc71e3a7.jpg?1",
             "name": "Mind Spring",
             "text": "Draw X cards.",
             "colours": [
@@ -13998,7 +13998,7 @@
         },
         {
             "id": "bf1cc7cd-a29b-5100-8fa2-42c4544c7341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a258be-39e3-4689-b2d0-7c353ce7d574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a258be-39e3-4689-b2d0-7c353ce7d574.jpg?1",
             "name": "Thieving Otter",
             "text": "Whenever Thieving Otter deals damage to an opponent, draw a card.",
             "colours": [
@@ -14031,7 +14031,7 @@
         },
         {
             "id": "dbc7797b-a323-5c7d-82d9-0f24102626da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6440439-7178-4a97-9e18-7fdef4b02678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6440439-7178-4a97-9e18-7fdef4b02678.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to any target.",
             "colours": [
@@ -14062,7 +14062,7 @@
         },
         {
             "id": "ccd8353f-04d2-5135-b03b-8fde30911b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cad902-ffd2-4bab-b114-b4b6df2ac6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cad902-ffd2-4bab-b114-b4b6df2ac6b3.jpg?1",
             "name": "Colossification",
             "text": "Enchant creature\nWhen Colossification enters, tap enchanted creature.\nEnchanted creature gets +20/+20.",
             "colours": [
@@ -14095,7 +14095,7 @@
         },
         {
             "id": "5c279393-7e27-59cf-b752-159df8ca0b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70722d6-b4d5-45c2-9488-9a5eb0bdb9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70722d6-b4d5-45c2-9488-9a5eb0bdb9bd.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -14126,7 +14126,7 @@
         },
         {
             "id": "d0765684-8596-56a2-92a4-effcf953c613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a73200-b798-4bfd-a431-8b94e17b70be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a73200-b798-4bfd-a431-8b94e17b70be.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -14157,7 +14157,7 @@
         },
         {
             "id": "3ab85213-6185-5609-949e-e3f05cf2d8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b5fc1-7611-44ac-ad8d-1f0c6d4fc9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b5fc1-7611-44ac-ad8d-1f0c6d4fc9a3.jpg?1",
             "name": "Sword of Vengeance",
             "text": "Equipped creature gets +2/+0 and has first strike, vigilance, trample, and haste.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -14186,7 +14186,7 @@
         },
         {
             "id": "61eae6a4-5cb6-5233-9601-e8357b6a7acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa2cc9-e427-4104-bad7-b0294e392b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa2cc9-e427-4104-bad7-b0294e392b1f.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters tapped.\nWhen Blossoming Sands enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -14216,7 +14216,7 @@
         },
         {
             "id": "37bb3fc2-f4a3-50a6-ab56-a55b3f618e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e43510-c444-4b2e-b2a0-528dcc09c899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e43510-c444-4b2e-b2a0-528dcc09c899.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters tapped.\nWhen Swiftwater Cliffs enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -14246,7 +14246,7 @@
         },
         {
             "id": "e0711851-a9c9-59a1-94c7-ff70ddc0d4ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c977b7-12cb-4e6f-8260-a7399b60940f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c977b7-12cb-4e6f-8260-a7399b60940f.jpg?1",
             "name": "Flowerfoot Swordmaster",
             "text": "",
             "colours": [
@@ -14282,7 +14282,7 @@
         },
         {
             "id": "69e8d088-1553-55bb-9ac9-25a259d91ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1cd58d-c0bc-48e5-b6fa-fb222fba77ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1cd58d-c0bc-48e5-b6fa-fb222fba77ab.jpg?1",
             "name": "Intrepid Rabbit",
             "text": "",
             "colours": [
@@ -14318,7 +14318,7 @@
         },
         {
             "id": "9a2bfa2b-416f-59d3-b8ae-10bc73d26c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg?1",
             "name": "Rabbit",
             "text": "",
             "colours": [
@@ -14353,7 +14353,7 @@
         },
         {
             "id": "5c11257f-fd89-5f00-87c8-ff8fad9fb5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a41de-91dd-4696-bfc1-10d702787c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a41de-91dd-4696-bfc1-10d702787c3e.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -14388,7 +14388,7 @@
         },
         {
             "id": "997e530b-8b57-558f-8318-6e9f69c6c975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc9b628-0a3a-4d09-ae4a-57c7f6f9ac36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc9b628-0a3a-4d09-ae4a-57c7f6f9ac36.jpg?1",
             "name": "Warren Warleader",
             "text": "",
             "colours": [
@@ -14424,7 +14424,7 @@
         },
         {
             "id": "52e2005b-645c-51c3-9533-9e29812c015a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8be9b74-6f1a-4692-a09a-1013cae4da18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8be9b74-6f1a-4692-a09a-1013cae4da18.jpg?1",
             "name": "Finch Formation",
             "text": "",
             "colours": [
@@ -14460,7 +14460,7 @@
         },
         {
             "id": "abb2d41a-24fb-50ae-a778-b6177b7bc6ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -14495,7 +14495,7 @@
         },
         {
             "id": "45010c8a-c3b4-5ded-968b-1e3cc19b919f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53065735-c427-458e-ade4-ec2d81c8d277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53065735-c427-458e-ade4-ec2d81c8d277.jpg?1",
             "name": "Splash Lasher",
             "text": "",
             "colours": [
@@ -14531,7 +14531,7 @@
         },
         {
             "id": "8bb6cfe7-742d-5e76-9608-3326ead39b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bcbe35-7764-4c75-b954-cbba11372dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bcbe35-7764-4c75-b954-cbba11372dec.jpg?1",
             "name": "Thundertrap Trainer",
             "text": "",
             "colours": [
@@ -14567,7 +14567,7 @@
         },
         {
             "id": "ee795bc4-13de-5a15-a292-714c3056d705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100c0127-49dd-4a78-9c88-1881e7923674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100c0127-49dd-4a78-9c88-1881e7923674.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "66c5362f-7915-51e3-b392-ce1205324ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b55966-0910-484d-9b2b-0a59233c44c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b55966-0910-484d-9b2b-0a59233c44c4.jpg?1",
             "name": "Darkstar Augur",
             "text": "",
             "colours": [
@@ -14638,7 +14638,7 @@
         },
         {
             "id": "c39bbf40-9bf9-5400-8be3-0fb961f0a643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55c677-dc14-4ae3-9518-0d80b528c3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55c677-dc14-4ae3-9518-0d80b528c3fb.jpg?1",
             "name": "Iridescent Vinelasher",
             "text": "",
             "colours": [
@@ -14674,7 +14674,7 @@
         },
         {
             "id": "debc732d-24ac-5768-8a05-db5eaca77802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0977b2-3342-4b7e-b1c7-f06bd8ab7fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0977b2-3342-4b7e-b1c7-f06bd8ab7fbf.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -14709,7 +14709,7 @@
         },
         {
             "id": "3f9392c7-5385-5776-ab98-b3baee335282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9bb0a91-b73e-465b-8c0e-50fc28e66fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9bb0a91-b73e-465b-8c0e-50fc28e66fda.jpg?1",
             "name": "Snail",
             "text": "",
             "colours": [
@@ -14744,7 +14744,7 @@
         },
         {
             "id": "c4a30fa6-79cc-5cc5-a1ce-4a4cb6ccec1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5379a77e-4b98-4abc-b967-fbc76bb85fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5379a77e-4b98-4abc-b967-fbc76bb85fc6.jpg?1",
             "name": "Starscape Cleric",
             "text": "",
             "colours": [
@@ -14780,7 +14780,7 @@
         },
         {
             "id": "c962ed7f-456a-5fd7-a214-95b61fcb6bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd3dd0-81b6-4f4a-86e6-920170017c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd3dd0-81b6-4f4a-86e6-920170017c92.jpg?1",
             "name": "Thornplate Intimidator",
             "text": "",
             "colours": [
@@ -14816,7 +14816,7 @@
         },
         {
             "id": "cecb15c5-7b41-5362-b4d1-8c271f7d3d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c208-4d8d-4833-bee2-bfc87c93049d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c208-4d8d-4833-bee2-bfc87c93049d.jpg?1",
             "name": "Coruscation Mage",
             "text": "",
             "colours": [
@@ -14852,7 +14852,7 @@
         },
         {
             "id": "97fedff9-99d6-5997-916e-a218e9ead776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5067c54-0f31-40e6-9ead-5d0183c9f00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5067c54-0f31-40e6-9ead-5d0183c9f00a.jpg?1",
             "name": "Manifold Mouse",
             "text": "",
             "colours": [
@@ -14888,7 +14888,7 @@
         },
         {
             "id": "52a3babf-c034-5160-859d-a260dfe110f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a41850-49d2-4c1f-84df-cc7f7fb951f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a41850-49d2-4c1f-84df-cc7f7fb951f8.jpg?1",
             "name": "Steampath Charger",
             "text": "",
             "colours": [
@@ -14924,7 +14924,7 @@
         },
         {
             "id": "25699c57-043c-5fef-9a11-681a0fa05445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c247d48f-d1e9-4b28-b372-bf4eea67cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c247d48f-d1e9-4b28-b372-bf4eea67cb8c.jpg?1",
             "name": "Bushy Bodyguard",
             "text": "",
             "colours": [
@@ -14960,7 +14960,7 @@
         },
         {
             "id": "9a82dac7-6859-5b38-8c39-b3190b8e4f64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdd8679-93a7-4e58-a6f3-b48897697e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdd8679-93a7-4e58-a6f3-b48897697e89.jpg?1",
             "name": "Pawpatch Recruit",
             "text": "",
             "colours": [
@@ -14996,7 +14996,7 @@
         },
         {
             "id": "446e12f8-083c-56f0-8428-16ad6df13ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dd6325-e3d8-4816-ac52-8838c12b4922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dd6325-e3d8-4816-ac52-8838c12b4922.jpg?1",
             "name": "Rust-Shield Rampager",
             "text": "",
             "colours": [
@@ -15032,7 +15032,7 @@
         },
         {
             "id": "da457623-e6de-51b0-a22f-e279640934a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6ec62e-0e9b-4312-bfe8-cc85d76fd9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6ec62e-0e9b-4312-bfe8-cc85d76fd9e0.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -15067,7 +15067,7 @@
         },
         {
             "id": "9349efc1-c80a-5adb-9635-6da39593ee3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4e41-7ce4-45ca-b365-fcde289ffe8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4e41-7ce4-45ca-b365-fcde289ffe8c.jpg?1",
             "name": "Tender Wildguide",
             "text": "",
             "colours": [
@@ -15103,7 +15103,7 @@
         },
         {
             "id": "49481296-5e87-500b-9d95-8011f432466a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b2c465-c446-4dee-9101-763105dcf813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b2c465-c446-4dee-9101-763105dcf813.jpg?1",
             "name": "Otter",
             "text": "",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "524e2513-4a49-53bf-a5fa-150dc718c5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76fa1c6-6000-47b2-9188-9c15b2c73f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76fa1c6-6000-47b2-9188-9c15b2c73f8f.jpg?1",
             "name": "Cragflame",
             "text": "",
             "colours": [],
@@ -15173,7 +15173,7 @@
         },
         {
             "id": "08ce3bb9-14a8-554b-8d2f-328f500a2379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce2241-e58b-41d4-b57c-9794fc8ee004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce2241-e58b-41d4-b57c-9794fc8ee004.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -15204,7 +15204,7 @@
         },
         {
             "id": "7d7a7feb-09d6-55fb-b019-c2736adb8ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1e78e6-a9e7-48a4-9231-61fb331c5837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1e78e6-a9e7-48a4-9231-61fb331c5837.jpg?1",
             "name": "Sword",
             "text": "",
             "colours": [],
@@ -15235,7 +15235,7 @@
         },
         {
             "id": "4811acb4-e116-5e6b-8d42-707057b51299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0357fb-d90c-49c7-b16a-8b52ac686c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0357fb-d90c-49c7-b16a-8b52ac686c3b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -15266,7 +15266,7 @@
         },
         {
             "id": "412c22db-2a44-59b4-bfcf-55d7996307fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4c9934-fe82-4560-b0bf-0ebc863ff0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4c9934-fe82-4560-b0bf-0ebc863ff0d1.jpg?1",
             "name": "Ral, Crackling Wit Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/BNG.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/BNG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f51fea6e-e9f1-5704-94ca-954ee1d619e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8980af-c3fa-4027-917a-4a3d441c0a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8980af-c3fa-4027-917a-4a3d441c0a75.jpg?1",
             "name": "Acolyte's Reward",
             "text": "Prevent the next X damage that would be dealt to target creature this turn, where X is your devotion to white. If damage is prevented this way, Acolyte's Reward deals that much damage to target creature or player. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "0b2170d9-78f5-5fcb-8eb3-52f14505eafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe23019a-e432-4a27-8acb-b17728a1e8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe23019a-e432-4a27-8acb-b17728a1e8b0.jpg?1",
             "name": "Akroan Phalanx",
             "text": "Vigilance\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "8f1d4633-bf42-518f-827d-5284b0f3c079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55e85c3-234e-49c4-a307-96fb4497eea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55e85c3-234e-49c4-a307-96fb4497eea8.jpg?1",
             "name": "Akroan Skyguard",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Akroan Skyguard, put a +1/+1 counter on Akroan Skyguard.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "910b07c9-ea52-5962-9095-f00e16d1f0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6c4afb-6a94-4519-91c6-9824fed2892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6c4afb-6a94-4519-91c6-9824fed2892c.jpg?1",
             "name": "Archetype of Courage",
             "text": "Creatures you control have first strike.\nCreatures your opponents control lose first strike and can't have or gain first strike.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "e14067e8-9800-5a96-9838-1e7635c86bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54eb705-6326-4bac-bf0e-68d42db7a270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54eb705-6326-4bac-bf0e-68d42db7a270.jpg?1",
             "name": "Brimaz, King of Oreskos",
             "text": "Vigilance\nWhenever Brimaz, King of Oreskos attacks, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield attacking.\nWhenever Brimaz blocks a creature, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield blocking that creature.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "2616cfdc-3cc8-5721-8fad-ad27e42843f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026ee3ff-bfd3-42d7-a4fa-2a6372599aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026ee3ff-bfd3-42d7-a4fa-2a6372599aef.jpg?1",
             "name": "Dawn to Dusk",
             "text": "Choose one or both \u2014 Return target enchantment card from your graveyard to your hand; and/or destroy target enchantment.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "5f6e46ac-59e1-56bd-8816-383d6096fe0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d16283b-b5bb-48e8-8c97-db5ad74fd544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d16283b-b5bb-48e8-8c97-db5ad74fd544.jpg?1",
             "name": "Eidolon of Countless Battles",
             "text": "Bestow {2}{W}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEidolon of Countless Battles and enchanted creature each get +1/+1 for each creature you control and +1/+1 for each Aura you control.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "5266d7b9-8268-5d87-9aab-08ac7c10a902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982eed00-e9fe-4d0f-a2b7-9606aa7926a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982eed00-e9fe-4d0f-a2b7-9606aa7926a1.jpg?1",
             "name": "Elite Skirmisher",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Elite Skirmisher, you may tap target creature.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "105c0e7b-a92d-51c2-b09c-f0b74b155c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0741582-0c7b-4d5b-83a9-dd8862de1f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0741582-0c7b-4d5b-83a9-dd8862de1f24.jpg?1",
             "name": "Ephara's Radiance",
             "text": "Enchant creature\nEnchanted creature has \"{1}{W}, {T}: You gain 3 life.\"",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "97811d02-86ad-5926-89b3-87c311031434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5023a5-b77c-48c6-9e84-ef525300ecdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5023a5-b77c-48c6-9e84-ef525300ecdf.jpg?1",
             "name": "Excoriate",
             "text": "Exile target tapped creature.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "daaa442d-0e80-555d-a263-c79bbd591028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8158b330-2868-4147-907e-4d86e44cfaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8158b330-2868-4147-907e-4d86e44cfaad.jpg?1",
             "name": "Fated Retribution",
             "text": "Destroy all creatures and planeswalkers. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "a2720973-1cee-596f-a095-a6525b3d3e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b1e720-c7cd-450a-a8af-61fcbca7eb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b1e720-c7cd-450a-a8af-61fcbca7eb24.jpg?1",
             "name": "Ghostblade Eidolon",
             "text": "Bestow {5}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nDouble strike (This creature deals both first-strike and regular combat damage.)\nEnchanted creature gets +1/+1 and has double strike.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "cf1a82da-9760-5e3e-94d3-4ded410d8e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f241e5f7-3168-4bd2-b586-185aad3ae9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f241e5f7-3168-4bd2-b586-185aad3ae9d9.jpg?1",
             "name": "Glimpse the Sun God",
             "text": "Tap X target creatures. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "bf975bdb-30e7-52b1-9588-f645822c1c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c2db0-5a79-47b8-8a42-5674c6d9d0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c2db0-5a79-47b8-8a42-5674c6d9d0fd.jpg?1",
             "name": "God-Favored General",
             "text": "Inspired \u2014 Whenever God-Favored General becomes untapped, you may pay {2}{W}. If you do, put two 1/1 white Soldier enchantment creature tokens onto the battlefield.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "569d7d52-6b9d-5b4c-8ddc-d6d1673150c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cd7d2b-e9c4-4900-89a0-f6eb0c6cb22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cd7d2b-e9c4-4900-89a0-f6eb0c6cb22b.jpg?1",
             "name": "Great Hart",
             "text": "",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "6ce716e6-8daa-57fc-bcdb-8a97ef330c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b569fadd-d9ca-4b0d-bee2-9d45574e56f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b569fadd-d9ca-4b0d-bee2-9d45574e56f0.jpg?1",
             "name": "Griffin Dreamfinder",
             "text": "Flying\nWhen Griffin Dreamfinder enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "1c063f16-66c9-55fd-b680-8f010f7dda36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7917f2ee-f093-4ffb-83ed-a181b14b5957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7917f2ee-f093-4ffb-83ed-a181b14b5957.jpg?1",
             "name": "Hero of Iroas",
             "text": "Aura spells you cast cost {1} less to cast.\nHeroic \u2014 Whenever you cast a spell that targets Hero of Iroas, put a +1/+1 counter on Hero of Iroas.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "cab3cdd9-35ee-5553-ae56-5e1581ab5559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeb407d-6a42-488a-9869-83da3047e45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeb407d-6a42-488a-9869-83da3047e45d.jpg?1",
             "name": "Hold at Bay",
             "text": "Prevent the next 7 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "172047ef-c75d-593e-84fd-64791b20af42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b29f36-e84d-402e-9ab7-935fd2e7532d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b29f36-e84d-402e-9ab7-935fd2e7532d.jpg?1",
             "name": "Loyal Pegasus",
             "text": "Flying\nLoyal Pegasus can't attack or block alone.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "afbe3475-3e99-5e5b-a4d8-28089c0924dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f95c-aeed-4cb6-a43b-2748a5dd6138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f95c-aeed-4cb6-a43b-2748a5dd6138.jpg?1",
             "name": "Mortal's Ardor",
             "text": "Target creature gets +1/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "ae6371f7-3b66-53e1-b894-285e9a8eee01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64204816-6e1d-4bf8-acd0-8f83ca7eb8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64204816-6e1d-4bf8-acd0-8f83ca7eb8c7.jpg?1",
             "name": "Nyxborn Shieldmate",
             "text": "Bestow {2}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "380d04d7-afe2-5a7a-a32e-ead0dd32abed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064435e7-20ea-4ba4-b039-a945afeeb5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064435e7-20ea-4ba4-b039-a945afeeb5c6.jpg?1",
             "name": "Oreskos Sun Guide",
             "text": "Inspired \u2014 Whenever Oreskos Sun Guide becomes untapped, you gain 2 life.",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "374719f3-ef9d-546b-a84d-1abe6585b75b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a0bf4-10c7-4afa-8cf6-e31196cc2bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a0bf4-10c7-4afa-8cf6-e31196cc2bd5.jpg?1",
             "name": "Ornitharch",
             "text": "Flying\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Ornitharch enters the battlefield, if tribute wasn't paid, put two 1/1 white Bird creature tokens with flying onto the battlefield.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "5575bd84-ad1c-5c54-9580-756143ef657b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1d6d76-f399-475a-b5cd-544bd7c6d967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1d6d76-f399-475a-b5cd-544bd7c6d967.jpg?1",
             "name": "Plea for Guidance",
             "text": "Search your library for up to two enchantment cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "3948f89f-dac5-55c2-89a5-fa21d8e4f943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597916e4-0294-4911-98e0-6ac5993533ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597916e4-0294-4911-98e0-6ac5993533ae.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "bb46c51e-ceca-5297-80bf-7f712e361b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ece7c-b979-4a31-ba5f-6a8a382f2862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177ece7c-b979-4a31-ba5f-6a8a382f2862.jpg?1",
             "name": "Silent Sentinel",
             "text": "Flying\nWhenever Silent Sentinel attacks, you may return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "bfde9cbf-5460-5023-8373-50de45de0430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e5128-e146-4e46-b313-a40d82719d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e5128-e146-4e46-b313-a40d82719d1d.jpg?1",
             "name": "Spirit of the Labyrinth",
             "text": "Each player can't draw more than one card each turn.",
             "colours": [
@@ -921,7 +921,7 @@
         },
         {
             "id": "89d87907-8b01-5c28-95d7-4e658c9d14e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f14bbff-8a3c-4aa0-a5aa-0dd6cb23b2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f14bbff-8a3c-4aa0-a5aa-0dd6cb23b2a3.jpg?1",
             "name": "Sunbond",
             "text": "Enchant creature\nEnchanted creature has \"Whenever you gain life, put that many +1/+1 counters on this creature.\"",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "c16334d9-522a-5da1-b4e8-758b164487d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb38717-97d5-4763-9e6c-46251df704ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb38717-97d5-4763-9e6c-46251df704ed.jpg?1",
             "name": "Vanguard of Brimaz",
             "text": "Vigilance\nHeroic \u2014 Whenever you cast a spell that targets Vanguard of Brimaz, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "146d79e6-93fb-56a0-a7cc-21ef59ed3ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c8b3b9-f0fb-4cc1-8916-82ee2c74f089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c8b3b9-f0fb-4cc1-8916-82ee2c74f089.jpg?1",
             "name": "Aerie Worshippers",
             "text": "Inspired \u2014 Whenever Aerie Worshippers becomes untapped, you may pay {2}{U}. If you do, put a 2/2 blue Bird enchantment creature token with flying onto the battlefield.",
             "colours": [
@@ -1025,7 +1025,7 @@
         },
         {
             "id": "cd069255-5bb7-54ae-8443-d01befc602aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e58ba3-4202-4f91-b27f-7528d27c1d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e58ba3-4202-4f91-b27f-7528d27c1d5c.jpg?1",
             "name": "Arbiter of the Ideal",
             "text": "Flying\nInspired \u2014 Whenever Arbiter of the Ideal becomes untapped, reveal the top card of your library. If it's an artifact, creature, or land card, you may put it onto the battlefield with a manifestation counter on it. That permanent is an enchantment in addition to its other types.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "885b846c-226e-502b-bd64-f964c16810cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de0f770-b62b-4a9d-bea7-6bb7bc2020ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de0f770-b62b-4a9d-bea7-6bb7bc2020ad.jpg?1",
             "name": "Archetype of Imagination",
             "text": "Creatures you control have flying.\nCreatures your opponents control lose flying and can't have or gain flying.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "6f65cc73-3281-5023-8053-32db67449d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e576f7a-0390-4514-aaed-20406fe6acdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e576f7a-0390-4514-aaed-20406fe6acdf.jpg?1",
             "name": "Chorus of the Tides",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Chorus of the Tides, scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "9d5cbccb-6b03-5451-a26a-f8131a1e1c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd445b01-34af-4132-a9fe-a03858624492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd445b01-34af-4132-a9fe-a03858624492.jpg?1",
             "name": "Crypsis",
             "text": "Target creature you control gains protection from creatures your opponents control until end of turn. Untap it.",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "53d0fab6-cb40-5486-80fe-a28cc9849d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab7c6a7-8214-4644-8f2e-ec74d2aff27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab7c6a7-8214-4644-8f2e-ec74d2aff27e.jpg?1",
             "name": "Deepwater Hypnotist",
             "text": "Inspired \u2014 Whenever Deepwater Hypnotist becomes untapped, target creature an opponent controls gets -3/-0 until end of turn.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "e633c125-086f-5260-934c-f8010450ddb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9964e-cfe0-4400-b903-3f590889f88d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9964e-cfe0-4400-b903-3f590889f88d.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "f1decf52-9245-5349-b838-1a4195849da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa167147-68ca-49af-98d3-538474ea1158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa167147-68ca-49af-98d3-538474ea1158.jpg?1",
             "name": "Eternity Snare",
             "text": "Enchant creature\nWhen Eternity Snare enters the battlefield, draw a card.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "07c7acfd-0b2e-5da6-b973-1e36b20a7791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38cfe97-77b3-4423-95ac-88eb850cf854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38cfe97-77b3-4423-95ac-88eb850cf854.jpg?1",
             "name": "Evanescent Intellect",
             "text": "Enchant creature\nEnchanted creature has \"{1}{U}, {T}: Target player puts the top three cards of his or her library into his or her graveyard.\"",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "897f3f55-71ba-50c4-9eeb-78e7cb4ede55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ba99d-d95d-4a3b-b6b6-a5e2589d538e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ba99d-d95d-4a3b-b6b6-a5e2589d538e.jpg?1",
             "name": "Fated Infatuation",
             "text": "Put a token onto the battlefield that's a copy of target creature you control. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "54e57d9c-7026-56b3-ab95-5599e1da7e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a79cee0-6023-42bc-a934-69b99fd5fb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a79cee0-6023-42bc-a934-69b99fd5fb02.jpg?1",
             "name": "Flitterstep Eidolon",
             "text": "Bestow {5}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlitterstep Eidolon can't be blocked.\nEnchanted creature gets +1/+1 and can't be blocked.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "429adf18-6881-54b0-965c-09900e3630b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2a4b24-096a-4d36-a872-73fa4552bb35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2a4b24-096a-4d36-a872-73fa4552bb35.jpg?1",
             "name": "Floodtide Serpent",
             "text": "Floodtide Serpent can't attack unless you return an enchantment you control to its owner's hand. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -1397,7 +1397,7 @@
         },
         {
             "id": "69ff93ac-7cee-50a9-a60f-079f2b967e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ae69b3-afa5-4763-a0c8-c3d9d96f6ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ae69b3-afa5-4763-a0c8-c3d9d96f6ddc.jpg?1",
             "name": "Kraken of the Straits",
             "text": "Creatures with power less than the number of Islands you control can't block Kraken of the Straits.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "19497ced-163e-5dff-ba2c-2c2d314e88d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9adca9-3e69-474f-896d-bb05b1d67252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9adca9-3e69-474f-896d-bb05b1d67252.jpg?1",
             "name": "Meletis Astronomer",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Meletis Astronomer, look at the top three cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1466,7 +1466,7 @@
         },
         {
             "id": "a2a2fd79-f87d-5fdc-91d1-9294684467a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87912ae7-3edc-4ea2-9b4b-caf2bc149ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87912ae7-3edc-4ea2-9b4b-caf2bc149ad1.jpg?1",
             "name": "Mindreaver",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Mindreaver, exile the top three cards of target player's library.\n{U}{U}, Sacrifice Mindreaver: Counter target spell with the same name as a card exiled with Mindreaver.",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "794160c7-5fc8-5078-93a5-1ceb21f31e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940d859-3fb1-4946-8277-b7c503605b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940d859-3fb1-4946-8277-b7c503605b1e.jpg?1",
             "name": "Nullify",
             "text": "Counter target creature or Aura spell.",
             "colours": [
@@ -1533,7 +1533,7 @@
         },
         {
             "id": "aeeba675-bd88-5344-800f-7ae6964dd61a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65371de6-13a2-401f-9334-ae9e19619487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65371de6-13a2-401f-9334-ae9e19619487.jpg?1",
             "name": "Nyxborn Triton",
             "text": "Bestow {4}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +2/+3.",
             "colours": [
@@ -1568,7 +1568,7 @@
         },
         {
             "id": "98178ddc-ddb7-53bf-8257-514f52b55b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546dae51-070c-4f3f-b0b4-6b88ff314af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546dae51-070c-4f3f-b0b4-6b88ff314af1.jpg?1",
             "name": "Oracle's Insight",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Scry 1, then draw a card.\" (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "0eb32ad2-4528-5ea3-ad77-76407333c37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cff40b-9cae-47d0-8df4-c287a17a33e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cff40b-9cae-47d0-8df4-c287a17a33e4.jpg?1",
             "name": "Perplexing Chimera",
             "text": "Whenever an opponent casts a spell, you may exchange control of Perplexing Chimera and that spell. If you do, you may choose new targets for the spell. (If the spell becomes a permanent, you control that permanent.)",
             "colours": [
@@ -1637,7 +1637,7 @@
         },
         {
             "id": "1c0b124b-80bc-5058-9e98-267dfcd9540d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe8c0b9-fdf4-4fc0-aa7c-774546cdd792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe8c0b9-fdf4-4fc0-aa7c-774546cdd792.jpg?1",
             "name": "Retraction Helix",
             "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
             "colours": [
@@ -1669,7 +1669,7 @@
         },
         {
             "id": "c70016bb-e74c-54fa-9832-7075d5cce176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba93d9a-94cd-4d90-860a-f567793a5be4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba93d9a-94cd-4d90-860a-f567793a5be4.jpg?1",
             "name": "Siren of the Fanged Coast",
             "text": "Flying\nTribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Siren of the Fanged Coast enters the battlefield, if tribute wasn't paid, gain control of target creature.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "56b3abec-0acb-5fca-bcfe-d5a24b421445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba33f00d-dbed-4bfb-a295-90f729be98de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba33f00d-dbed-4bfb-a295-90f729be98de.jpg?1",
             "name": "Sphinx's Disciple",
             "text": "Flying\nInspired \u2014 Whenever Sphinx's Disciple becomes untapped, draw a card.",
             "colours": [
@@ -1738,7 +1738,7 @@
         },
         {
             "id": "fe18128c-f52a-542c-a96d-ebce0fb03aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg?1",
             "name": "Stratus Walk",
             "text": "Enchant creature\nWhen Stratus Walk enters the battlefield, draw a card.\nEnchanted creature has flying.\nEnchanted creature can block only creatures with flying.",
             "colours": [
@@ -1772,7 +1772,7 @@
         },
         {
             "id": "6cf10253-e02f-5ede-a9d0-a73dbb79ed0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6beffc33-58fd-4364-b87b-d4573ecaf4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6beffc33-58fd-4364-b87b-d4573ecaf4bd.jpg?1",
             "name": "Sudden Storm",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controllers' next untap steps. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1804,7 +1804,7 @@
         },
         {
             "id": "24866092-ab5c-571a-9012-4dccbb1ea7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816a6ff7-cede-4346-b3e6-aee33aefac3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816a6ff7-cede-4346-b3e6-aee33aefac3a.jpg?1",
             "name": "Thassa's Rebuff",
             "text": "Counter target spell unless its controller pays {X}, where X is your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "38757d7d-b090-5835-b640-411f21d9fccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fcad7f-2740-49ff-a448-4b232c456e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fcad7f-2740-49ff-a448-4b232c456e16.jpg?1",
             "name": "Tromokratis",
             "text": "Tromokratis has hexproof unless it's attacking or blocking.\nTromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "be95e88d-362b-586c-961c-08bf7f334e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb7ca2b-c5de-4c8a-91cb-8dd8ab5387d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb7ca2b-c5de-4c8a-91cb-8dd8ab5387d8.jpg?1",
             "name": "Vortex Elemental",
             "text": "{U}: Put Vortex Elemental and each creature blocking or blocked by it on top of their owners' libraries, then those players shuffle their libraries.\n{3}{U}{U}: Target creature blocks Vortex Elemental this turn if able.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "d46367c1-29b1-5be7-80af-759f76df3c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcabd4c7-093f-4ef6-8b89-b08565c48e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcabd4c7-093f-4ef6-8b89-b08565c48e3c.jpg?1",
             "name": "Whelming Wave",
             "text": "Return all creatures to their owners' hands except for Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "850f1669-d953-5b98-9f16-9940beb40301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b9c5-063b-4c53-a696-11cd89fc88d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b9c5-063b-4c53-a696-11cd89fc88d8.jpg?1",
             "name": "Archetype of Finality",
             "text": "Creatures you control have deathtouch.\nCreatures your opponents control lose deathtouch and can't have or gain deathtouch.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "533a23c6-a209-55bd-8ef3-b2bb14c8fdbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86acd1cc-5238-4734-a324-b4cecffc0bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86acd1cc-5238-4734-a324-b4cecffc0bab.jpg?1",
             "name": "Ashiok's Adept",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Ashiok's Adept, each opponent discards a card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "032f150d-0b3c-5489-bfd2-42a75831ff95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894f3f5f-586d-45e4-9af7-4de80e44dfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894f3f5f-586d-45e4-9af7-4de80e44dfae.jpg?1",
             "name": "Asphyxiate",
             "text": "Destroy target untapped creature.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "b4108175-5a2d-53b7-8f0e-da892063641a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca11057-e50a-4817-924a-5bb504d0780f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca11057-e50a-4817-924a-5bb504d0780f.jpg?1",
             "name": "Bile Blight",
             "text": "Target creature and all other creatures with the same name as that creature get -3/-3 until end of turn.",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "9dab9aa7-bc53-5809-87c1-8bd0bbe74bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e9195-a711-4f4d-9d53-d5d230c092ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e9195-a711-4f4d-9d53-d5d230c092ef.jpg?1",
             "name": "Black Oak of Odunos",
             "text": "Defender\n{B}, Tap another untapped creature you control: Black Oak of Odunos gets +1/+1 until end of turn.",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "efbd4008-42c4-5423-aa6d-2e8650c6b8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342196b9-ab65-4922-864e-00f067153261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342196b9-ab65-4922-864e-00f067153261.jpg?1",
             "name": "Champion of Stray Souls",
             "text": "{3}{B}{B}, {T}, Sacrifice X other creatures: Return X target creature cards from your graveyard to the battlefield.\n{5}{B}{B}: Put Champion of Stray Souls on top of your library from your graveyard.",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "d62e384d-d8b6-5e8f-be35-aa8ddd2fb581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51db556-b3e8-4628-9e39-6353023b0696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51db556-b3e8-4628-9e39-6353023b0696.jpg?1",
             "name": "Claim of Erebos",
             "text": "Enchant creature\nEnchanted creature has \"{1}{B}, {T}: Target player loses 2 life.\"",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "794b3d74-f101-5d0e-912f-b49688d1f91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c7570-8080-43dc-a586-963e15566446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287c7570-8080-43dc-a586-963e15566446.jpg?1",
             "name": "Drown in Sorrow",
             "text": "All creatures get -2/-2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "04002005-a950-5884-8060-7a849694516f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75f3d3f-925d-45ef-92e6-22aca22e5451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75f3d3f-925d-45ef-92e6-22aca22e5451.jpg?1",
             "name": "Eater of Hope",
             "text": "Flying\n{B}, Sacrifice another creature: Regenerate Eater of Hope.\n{2}{B}, Sacrifice two other creatures: Destroy target creature.",
             "colours": [
@@ -2242,7 +2242,7 @@
         },
         {
             "id": "4400ce8e-36c4-5293-ab4b-0aebba5b0695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d4eb34-0529-48a0-ac52-b57cead7b651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d4eb34-0529-48a0-ac52-b57cead7b651.jpg?1",
             "name": "Eye Gouge",
             "text": "Target creature gets -1/-1 until end of turn. If it's a Cyclops, destroy it.",
             "colours": [
@@ -2274,7 +2274,7 @@
         },
         {
             "id": "3325c2de-62f1-5331-95ff-7f107a053a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15cd233-e27b-4cfd-aa4e-18040d1de22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15cd233-e27b-4cfd-aa4e-18040d1de22f.jpg?1",
             "name": "Fate Unraveler",
             "text": "Whenever an opponent draws a card, Fate Unraveler deals 1 damage to that player.",
             "colours": [
@@ -2309,7 +2309,7 @@
         },
         {
             "id": "996a3776-3720-5266-8155-ff6165ef10f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55878ec-a903-4694-8709-e29fa88b2c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55878ec-a903-4694-8709-e29fa88b2c28.jpg?1",
             "name": "Fated Return",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. It gains indestructible. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "0b6b2de4-3de0-5f57-8d41-9a330eaaa85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a829bb0-6a84-46de-9c2d-14176cf542e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a829bb0-6a84-46de-9c2d-14176cf542e6.jpg?1",
             "name": "Felhide Brawler",
             "text": "Felhide Brawler can't block unless you control another Minotaur.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "9a53c891-07c7-557e-9e00-7f284973f11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c236a33-fb20-41f4-8946-beb65d1cf684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c236a33-fb20-41f4-8946-beb65d1cf684.jpg?1",
             "name": "Forlorn Pseudamma",
             "text": "Intimidate\nInspired \u2014 Whenever Forlorn Pseudamma becomes untapped, you may pay {2}{B}. If you do, put a 2/2 black Zombie enchantment creature token onto the battlefield.",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "c1b68600-ccfa-51ab-bf2e-c2203833aeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05445d18-3590-4216-9392-9438d9f9395d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05445d18-3590-4216-9392-9438d9f9395d.jpg?1",
             "name": "Forsaken Drifters",
             "text": "When Forsaken Drifters dies, put the top four cards of your library into your graveyard.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "6e3fa07d-33f5-52e4-b0ea-529470a13b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5e6c4-02c8-4602-96d6-19dad34f7804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5e6c4-02c8-4602-96d6-19dad34f7804.jpg?1",
             "name": "Gild",
             "text": "Exile target creature. Put a colorless artifact token named Gold onto the battlefield. It has \"Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "d3020f61-95d8-5f1c-838e-4824fda1ab7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb0ce84-560f-4e39-a0ab-7bd710d541cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb0ce84-560f-4e39-a0ab-7bd710d541cc.jpg?1",
             "name": "Grisly Transformation",
             "text": "Enchant creature\nWhen Grisly Transformation enters the battlefield, draw a card.\nEnchanted creature has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2509,7 +2509,7 @@
         },
         {
             "id": "a8d73b0d-8335-5aed-be3d-5395be3d824e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7e5ab-57d7-4a86-b7c2-262932ac3344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7e5ab-57d7-4a86-b7c2-262932ac3344.jpg?1",
             "name": "Herald of Torment",
             "text": "Bestow {3}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying\nAt the beginning of your upkeep, you lose 1 life.\nEnchanted creature gets +3/+3 and has flying.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "16be6641-34b0-58b6-b026-99398d712ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093d2e4c-f2c4-4d4e-a1b7-200327ce23b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093d2e4c-f2c4-4d4e-a1b7-200327ce23b0.jpg?1",
             "name": "Marshmist Titan",
             "text": "Marshmist Titan costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "db2e0e64-49a8-5b4e-9586-064f74ace51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0955932-8ca9-4896-882c-2969fe7c7818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0955932-8ca9-4896-882c-2969fe7c7818.jpg?1",
             "name": "Necrobite",
             "text": "Target creature gains deathtouch until end of turn. Regenerate it.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "2655e65f-f32a-5cce-b22a-1ba7be18f2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f79804-cd90-472b-9d09-3c71e4c6be22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f79804-cd90-472b-9d09-3c71e4c6be22.jpg?1",
             "name": "Nyxborn Eidolon",
             "text": "Bestow {4}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "824c82e0-56da-5fb2-9c15-5ce0fda87a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d1eda4-ac34-4905-9022-59f91d38dbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d1eda4-ac34-4905-9022-59f91d38dbb3.jpg?1",
             "name": "Odunos River Trawler",
             "text": "When Odunos River Trawler enters the battlefield, return target enchantment creature card from your graveyard to your hand.\n{W}, Sacrifice Odunos River Trawler: Return target enchantment creature card from your graveyard to your hand.",
             "colours": [
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "5a778e7a-e79f-572b-a6bf-2dda9d2a5bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8891f-b44c-4be4-878e-9fc45a9dc9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce8891f-b44c-4be4-878e-9fc45a9dc9cb.jpg?1",
             "name": "Pain Seer",
             "text": "Inspired \u2014 Whenever Pain Seer becomes untapped, reveal the top card of your library and put that card into your hand. You lose life equal to that card's converted mana cost.",
             "colours": [
@@ -2715,7 +2715,7 @@
         },
         {
             "id": "5b8e6756-ffe6-549e-9cb2-e0461d7797a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb129def-4055-4b12-9944-39406b451553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb129def-4055-4b12-9944-39406b451553.jpg?1",
             "name": "Sanguimancy",
             "text": "You draw X cards and you lose X life, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2747,7 +2747,7 @@
         },
         {
             "id": "222a5c67-6f16-5365-bc3a-7d43d50bb7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb16d4f-ed42-4b19-9e45-330db88eea9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb16d4f-ed42-4b19-9e45-330db88eea9b.jpg?1",
             "name": "Servant of Tymaret",
             "text": "Inspired \u2014 Whenever Servant of Tymaret becomes untapped, each opponent loses 1 life. You gain life equal to the life lost this way.\n{2}{B}: Regenerate Servant of Tymaret.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "42fb4556-4584-5a55-bcdc-508be0072f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b1eeb-6cc9-48a7-a068-afa1011c45f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b1eeb-6cc9-48a7-a068-afa1011c45f2.jpg?1",
             "name": "Shrike Harpy",
             "text": "Flying\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Shrike Harpy enters the battlefield, if tribute wasn't paid, target opponent sacrifices a creature.",
             "colours": [
@@ -2815,7 +2815,7 @@
         },
         {
             "id": "0ca8cfb0-bd3a-5acd-8d0d-49d68bba711b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017e8cfb-7cb0-403c-b8be-abee22369661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017e8cfb-7cb0-403c-b8be-abee22369661.jpg?1",
             "name": "Spiteful Returned",
             "text": "Bestow {3}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhenever Spiteful Returned or enchanted creature attacks, defending player loses 2 life.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2850,7 +2850,7 @@
         },
         {
             "id": "3c30d366-7938-5cc6-a1c3-b4926d277999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757948b3-8cb2-4709-9bbf-031c2bf6d4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/757948b3-8cb2-4709-9bbf-031c2bf6d4c5.jpg?1",
             "name": "Warchanter of Mogis",
             "text": "Inspired \u2014 Whenever Warchanter of Mogis becomes untapped, target creature you control gains intimidate until end of turn. (A creature with intimidate can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "f9da3720-9dc4-5564-8691-e1fd803a2274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg?1",
             "name": "Weight of the Underworld",
             "text": "Enchant creature\nEnchanted creature gets -3/-2.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "2c35587d-17ae-5641-85ab-e996ad401b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb529f-44fd-409d-932f-be9c403f12f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb529f-44fd-409d-932f-be9c403f12f6.jpg?1",
             "name": "Akroan Conscriptor",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Conscriptor, gain control of another target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "f62a85eb-65c0-5af4-96ce-fb57875e2340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13946413-c76d-41a8-a699-404fd56b2067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13946413-c76d-41a8-a699-404fd56b2067.jpg?1",
             "name": "Archetype of Aggression",
             "text": "Creatures you control have trample.\nCreatures your opponents control lose trample and can't have or gain trample.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "4cc5e33e-9a6e-595f-871a-5cc1cb43844b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df70b14-5d67-4a92-aaba-72480c621d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df70b14-5d67-4a92-aaba-72480c621d10.jpg?1",
             "name": "Bolt of Keranos",
             "text": "Bolt of Keranos deals 3 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "1a068201-08b7-5e60-9570-bfc00284ca19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a25c69-8e57-4a44-955a-da1541bbe0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a25c69-8e57-4a44-955a-da1541bbe0fe.jpg?1",
             "name": "Cyclops of One-Eyed Pass",
             "text": "",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "3f58f691-aa7d-5622-9df2-92c3b796118d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a0128-4499-498d-9721-b1fd70ea84b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a0128-4499-498d-9721-b1fd70ea84b4.jpg?1",
             "name": "Epiphany Storm",
             "text": "Enchant creature\nEnchanted creature has \"{R}, {T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "b0e8f09f-8ed7-5673-ad3a-adc1dba03324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018d5ea-5229-40ca-b7c5-31d3e8ebb894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018d5ea-5229-40ca-b7c5-31d3e8ebb894.jpg?1",
             "name": "Everflame Eidolon",
             "text": "Bestow {2}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\n{R}: Everflame Eidolon gets +1/+0 until end of turn. If it's an Aura, enchanted creature gets +1/+0 until end of turn instead.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -3125,7 +3125,7 @@
         },
         {
             "id": "6aa7cb07-f01a-58a4-b5a9-f3eab81ac4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1a4b-db3b-4dfc-8d3a-cc73b011a5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6f1a4b-db3b-4dfc-8d3a-cc73b011a5dd.jpg?1",
             "name": "Fall of the Hammer",
             "text": "Target creature you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "d085cab1-bfe8-5bc1-8cd5-226744d3f3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ea1aeb-bd42-4960-b40f-e7c2fd1efb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ea1aeb-bd42-4960-b40f-e7c2fd1efb5c.jpg?1",
             "name": "Fated Conflagration",
             "text": "Fated Conflagration deals 5 damage to target creature or planeswalker. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3189,7 +3189,7 @@
         },
         {
             "id": "65c167f0-d98a-51fc-98bc-24a41ad8fb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e7884c-2d66-42d1-87d1-1341a6fa52d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e7884c-2d66-42d1-87d1-1341a6fa52d8.jpg?1",
             "name": "Fearsome Temper",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{2}{R}: Target creature can't block this creature this turn.\"",
             "colours": [
@@ -3223,7 +3223,7 @@
         },
         {
             "id": "d7adc072-e896-559d-8d68-12b5925e4375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbe4ce-d6a6-428d-aeee-1c316f358777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbe4ce-d6a6-428d-aeee-1c316f358777.jpg?1",
             "name": "Felhide Spiritbinder",
             "text": "Inspired \u2014 Whenever Felhide Spiritbinder becomes untapped, you may pay {1}{R}. If you do, put a token onto the battlefield that's a copy of another target creature except it's an enchantment in addition to its other types. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "867f7bf6-8c71-517d-b467-3cafd61cdabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36bca58-e92f-4496-92d6-5ecba7a0424d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36bca58-e92f-4496-92d6-5ecba7a0424d.jpg?1",
             "name": "Flame-Wreathed Phoenix",
             "text": "Flying\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Flame-Wreathed Phoenix enters the battlefield, if tribute wasn't paid, it gains haste and \"When this creature dies, return it to its owner's hand.\"",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "7042f764-fd09-500c-bd3d-64c572a516c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd44170-ded7-4895-8950-bfa9d19e471d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd44170-ded7-4895-8950-bfa9d19e471d.jpg?1",
             "name": "Forgestoker Dragon",
             "text": "Flying\n{1}{R}: Forgestoker Dragon deals 1 damage to target creature. That creature can't block this combat. Activate this ability only if Forgestoker Dragon is attacking.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "5ccfe18e-1ec9-5f5d-a74c-3dd7310b52b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d4c13b-95ef-49df-b349-26e0fec109ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d4c13b-95ef-49df-b349-26e0fec109ad.jpg?1",
             "name": "Impetuous Sunchaser",
             "text": "Flying, haste\nImpetuous Sunchaser attacks each turn if able.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "02603a60-b864-5455-ad31-b59f844a5f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d1dcab-7e46-4ff1-91f6-77352ef0cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d1dcab-7e46-4ff1-91f6-77352ef0cd90.jpg?1",
             "name": "Kragma Butcher",
             "text": "Inspired \u2014 Whenever Kragma Butcher becomes untapped, it gets +2/+0 until end of turn.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "b972c1aa-98a7-59bc-8781-630ff55635d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af8746-033d-4a8a-b62d-ab5addb33d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af8746-033d-4a8a-b62d-ab5addb33d4d.jpg?1",
             "name": "Lightning Volley",
             "text": "Until end of turn, creatures you control gain \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "909de1d7-4e56-5e47-ab35-2efe95e4e82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2081bf0-09f5-4c95-b4cc-48a8784294d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2081bf0-09f5-4c95-b4cc-48a8784294d4.jpg?1",
             "name": "Nyxborn Rollicker",
             "text": "Bestow {1}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "00af3c5b-10f5-5717-b693-f7694e0cf04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb1931e-c282-47a7-9382-608de6ec8efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb1931e-c282-47a7-9382-608de6ec8efa.jpg?1",
             "name": "Oracle of Bones",
             "text": "Haste\nTribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Oracle of Bones enters the battlefield, if tribute wasn't paid, you may cast an instant or sorcery card from your hand without paying its mana cost.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "b9e2d3bd-3c60-5094-80bb-693a9a6d3bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef1b9b-58f1-40af-a7c2-06cdaf1ec974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef1b9b-58f1-40af-a7c2-06cdaf1ec974.jpg?1",
             "name": "Pharagax Giant",
             "text": "Tribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.)\nWhen Pharagax Giant enters the battlefield, if tribute wasn't paid, Pharagax Giant deals 5 damage to each opponent.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "e1223246-d1d2-5f8a-b7e3-39388113d2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26ff2fa-82de-4831-9341-a446abf9ed03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26ff2fa-82de-4831-9341-a446abf9ed03.jpg?1",
             "name": "Pinnacle of Rage",
             "text": "Pinnacle of Rage deals 3 damage to each of two target creatures and/or players.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "3719fe63-11be-58f9-a273-64954247e800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188adefd-a808-4991-80be-53249c24df8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188adefd-a808-4991-80be-53249c24df8f.jpg?1",
             "name": "Reckless Reveler",
             "text": "{R}, Sacrifice Reckless Reveler: Destroy target artifact.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "063c1bcc-e0aa-594e-8951-8a3784cf2cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c656ad1b-e85b-4b0c-b538-506afe4a9da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c656ad1b-e85b-4b0c-b538-506afe4a9da5.jpg?1",
             "name": "Rise to the Challenge",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "696dcf3e-f699-539b-a55b-d7fff1fbd7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc6a735-cbf5-4af2-b15c-7ced82f0d9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc6a735-cbf5-4af2-b15c-7ced82f0d9da.jpg?1",
             "name": "Satyr Firedancer",
             "text": "Whenever an instant or sorcery spell you control deals damage to an opponent, Satyr Firedancer deals that much damage to target creature that player controls.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "b574f80d-ec4b-5c69-abda-1ed52c1d2cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2c65e-3cba-4813-9949-87e15f592247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2c65e-3cba-4813-9949-87e15f592247.jpg?1",
             "name": "Satyr Nyx-Smith",
             "text": "Haste\nInspired \u2014 Whenever Satyr Nyx-Smith becomes untapped, you may pay {2}{R}. If you do, put a 3/1 red Elemental enchantment creature token with haste onto the battlefield.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "08a176d1-54d1-55ea-97fe-47abf3779ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273f25fc-9c9f-4b73-a28b-1461d8fcd443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273f25fc-9c9f-4b73-a28b-1461d8fcd443.jpg?1",
             "name": "Scouring Sands",
             "text": "Scouring Sands deals 1 damage to each creature your opponents control. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "922ca516-0583-5f72-a6f1-25d5c238bd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb43fd07-d281-447d-88bf-c53498c2cf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb43fd07-d281-447d-88bf-c53498c2cf20.jpg?1",
             "name": "Searing Blood",
             "text": "Searing Blood deals 2 damage to target creature. When that creature dies this turn, Searing Blood deals 3 damage to the creature's controller.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "37390117-7a90-5db7-bc2d-1b1fec3e3d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397bdc3-a866-45be-8740-185d9ccf29c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397bdc3-a866-45be-8740-185d9ccf29c4.jpg?1",
             "name": "Stormcaller of Keranos",
             "text": "Haste\n{1}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "a2788f9a-3555-52d6-a888-25a9ed7dec73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fa4f8-4b87-41dc-802d-dfd160ccf1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fa4f8-4b87-41dc-802d-dfd160ccf1a8.jpg?1",
             "name": "Thunder Brute",
             "text": "Trample\nTribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Thunder Brute enters the battlefield, if tribute wasn't paid, it gains haste until end of turn.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "dea8afd8-dba7-5506-98a6-5b0143874bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d361851d-e2d4-4912-ba08-81913f6b6e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d361851d-e2d4-4912-ba08-81913f6b6e08.jpg?1",
             "name": "Thunderous Might",
             "text": "Enchant creature\nWhenever enchanted creature attacks, it gets +X/+0 until end of turn, where X is your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "7cc99945-396b-5962-b6c1-6cc03e9d7c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ef2fc3-0072-450b-acab-7d19c4903128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ef2fc3-0072-450b-acab-7d19c4903128.jpg?1",
             "name": "Whims of the Fates",
             "text": "Starting with you, each player separates all permanents he or she controls into three piles. Then each player chooses one of his or her piles at random and sacrifices those permanents. (Piles can be empty.)",
             "colours": [
@@ -3900,7 +3900,7 @@
         },
         {
             "id": "b3e3f707-d114-5407-bacb-6f9c58223ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3145ca68-7a9d-4161-9456-518591251b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3145ca68-7a9d-4161-9456-518591251b56.jpg?1",
             "name": "Archetype of Endurance",
             "text": "Creatures you control have hexproof.\nCreatures your opponents control lose hexproof and can't have or gain hexproof.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "b345370e-820c-5cca-97ae-d69240c29bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19353629-07be-47e2-a7d5-3a5e5e1120c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19353629-07be-47e2-a7d5-3a5e5e1120c8.jpg?1",
             "name": "Aspect of Hydra",
             "text": "Target creature gets +X/+X until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "7e2daa7c-5ba0-58b4-b73e-d06cfe8a62bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d88ad54-43fc-45e0-8e00-db6be0c021ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d88ad54-43fc-45e0-8e00-db6be0c021ea.jpg?1",
             "name": "Charging Badger",
             "text": "Trample",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "897132b6-0460-510a-a3c0-8cc688f72d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5a807f-58e8-4d92-a61c-47bb9b28977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5a807f-58e8-4d92-a61c-47bb9b28977f.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library if it's a land card.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -4036,7 +4036,7 @@
         },
         {
             "id": "95c4d602-bcc8-5e42-9667-1d4761712595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c45eda-9f00-4b40-b91d-0ed00151923c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c45eda-9f00-4b40-b91d-0ed00151923c.jpg?1",
             "name": "Culling Mark",
             "text": "Target creature blocks this turn if able.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "ade2ef5f-321a-5b77-b75e-75f15108e83b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e1afc-0d06-4c01-abef-3b3e93bd21c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e1afc-0d06-4c01-abef-3b3e93bd21c3.jpg?1",
             "name": "Fated Intervention",
             "text": "Put two 3/3 green Centaur enchantment creature tokens onto the battlefield. If it's your turn, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "2c70d499-da91-5b27-acf8-9d1619d0baa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41810472-ba24-44b6-886c-f8906ff0a7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41810472-ba24-44b6-886c-f8906ff0a7df.jpg?1",
             "name": "Graverobber Spider",
             "text": "Reach\n{3}{B}: Graverobber Spider gets +X/+X until end of turn, where X is the number of creature cards in your graveyard. Activate this ability only once each turn.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "ed88ce51-91c6-5956-b18a-ec4b4f5dc979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f022c0c3-6331-47be-b07f-9768930afd3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f022c0c3-6331-47be-b07f-9768930afd3a.jpg?1",
             "name": "Hero of Leina Tower",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Hero of Leina Tower, you may pay {X}. If you do, put X +1/+1 counters on Hero of Leina Tower.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "3688309e-9583-573c-a0a3-741c6c63b75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2323c-3e35-4ac6-9f07-2c0584371f9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2323c-3e35-4ac6-9f07-2c0584371f9e.jpg?1",
             "name": "Hunter's Prowess",
             "text": "Until end of turn, target creature gets +3/+3 and gains trample and \"Whenever this creature deals combat damage to a player, draw that many cards.\"",
             "colours": [
@@ -4202,7 +4202,7 @@
         },
         {
             "id": "f2e31c93-659f-56ad-9342-57b22603bfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc036932-38c2-42df-9922-2d901028f2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc036932-38c2-42df-9922-2d901028f2b8.jpg?1",
             "name": "Karametra's Favor",
             "text": "Enchant creature\nWhen Karametra's Favor enters the battlefield, draw a card.\nEnchanted creature has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -4236,7 +4236,7 @@
         },
         {
             "id": "f9a71860-d8c2-5b42-bf31-4ed94ef91be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daa44b4-5c30-41d8-b4d6-6219c5729a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daa44b4-5c30-41d8-b4d6-6219c5729a5f.jpg?1",
             "name": "Mischief and Mayhem",
             "text": "Up to two target creatures each get +4/+4 until end of turn.",
             "colours": [
@@ -4268,7 +4268,7 @@
         },
         {
             "id": "84b83d03-2307-5540-83f4-ac1f793a8609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a96b4-393d-4e8e-9b6a-f15f3804febb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131a96b4-393d-4e8e-9b6a-f15f3804febb.jpg?1",
             "name": "Mortal's Resolve",
             "text": "Target creature gets +1/+1 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "72aa5025-b6c3-5afb-b07a-0d7451814d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0683b2-8bc2-4c6a-964e-b909693b68c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0683b2-8bc2-4c6a-964e-b909693b68c1.jpg?1",
             "name": "Nessian Demolok",
             "text": "Tribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Nessian Demolok enters the battlefield, if tribute wasn't paid, destroy target noncreature permanent.",
             "colours": [
@@ -4334,7 +4334,7 @@
         },
         {
             "id": "cd257775-3720-5e3b-8427-088b53b6c5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65368cf0-7d92-4248-b930-633fd023065b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65368cf0-7d92-4248-b930-633fd023065b.jpg?1",
             "name": "Nessian Wilds Ravager",
             "text": "Tribute 6 (As this creature enters the battlefield, an opponent of your choice may place six +1/+1 counters on it.)\nWhen Nessian Wilds Ravager enters the battlefield, if tribute wasn't paid, you may have Nessian Wilds Ravager fight another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4368,7 +4368,7 @@
         },
         {
             "id": "ff5d9e61-8404-5b9c-9997-540f212f1c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8447c3-4fce-4971-a3d7-e5671fe269f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8447c3-4fce-4971-a3d7-e5671fe269f5.jpg?1",
             "name": "Noble Quarry",
             "text": "Bestow {5}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nAll creatures able to block Noble Quarry or enchanted creature do so.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "1daddee5-4014-58ef-87a7-ce55c7d7fb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a78895-5e09-46a5-8a74-a07f0befc4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a78895-5e09-46a5-8a74-a07f0befc4e5.jpg?1",
             "name": "Nyxborn Wolf",
             "text": "Bestow {4}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "df31913c-4c8b-5afa-ac2a-c9722e18d23f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03835e3e-9fd1-47c7-86a5-a5481420f2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03835e3e-9fd1-47c7-86a5-a5481420f2d3.jpg?1",
             "name": "Peregrination",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle your library, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4470,7 +4470,7 @@
         },
         {
             "id": "99fc35eb-aa50-5a35-9305-a9b0cacc7d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80856020-f569-4d73-8c44-7b48535a69e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80856020-f569-4d73-8c44-7b48535a69e8.jpg?1",
             "name": "Pheres-Band Raiders",
             "text": "Inspired \u2014 Whenever Pheres-Band Raiders becomes untapped, you may pay {2}{G}. If you do, put a 3/3 green Centaur enchantment creature token onto the battlefield.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "84cc01d8-5c49-585e-ae20-660f46366a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d7e7d1-70ee-450b-8018-ff373cc91c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d7e7d1-70ee-450b-8018-ff373cc91c68.jpg?1",
             "name": "Pheres-Band Tromper",
             "text": "Inspired \u2014 Whenever Pheres-Band Tromper becomes untapped, put a +1/+1 counter on it.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "f6b00717-3490-58ed-9069-493513cbe8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaace7-86e2-427e-97b1-b09dfdd30fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaace7-86e2-427e-97b1-b09dfdd30fee.jpg?1",
             "name": "Raised by Wolves",
             "text": "Enchant creature\nWhen Raised by Wolves enters the battlefield, put two 2/2 green Wolf creature tokens onto the battlefield.\nEnchanted creature gets +1/+1 for each Wolf you control.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "5b845020-6cac-5603-951f-6065c8d5ef61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c5a1ce-932a-4b3d-8b86-ed920e646afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c5a1ce-932a-4b3d-8b86-ed920e646afc.jpg?1",
             "name": "Satyr Wayfinder",
             "text": "When Satyr Wayfinder enters the battlefield, reveal the top four cards of your library. You may put a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "3661b920-66cc-5996-8245-883bbdb949ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef76dc-7cef-449b-b8a7-e038887129d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef76dc-7cef-449b-b8a7-e038887129d9.jpg?1",
             "name": "Scourge of Skola Vale",
             "text": "Trample\nScourge of Skola Vale enters the battlefield with two +1/+1 counters on it.\n{T}, Sacrifice another creature: Put a number of +1/+1 counters on Scourge of Skola Vale equal to the sacrificed creature's toughness.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "a9065f87-1497-5341-8320-9657e782d44a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5579755-4718-406a-bba6-27f1f2811e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5579755-4718-406a-bba6-27f1f2811e59.jpg?1",
             "name": "Setessan Oathsworn",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Setessan Oathsworn, put two +1/+1 counters on Setessan Oathsworn.",
             "colours": [
@@ -4677,7 +4677,7 @@
         },
         {
             "id": "1cc722ee-57e2-511c-b66a-88c5f7626ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03af8b3b-a897-43e2-a87d-833da93edc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03af8b3b-a897-43e2-a87d-833da93edc41.jpg?1",
             "name": "Setessan Starbreaker",
             "text": "When Setessan Starbreaker enters the battlefield, you may destroy target Aura.",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "15e465fc-65b9-5536-8bd3-0334ecf1ee1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb76b3-b527-4ed8-8ce3-d3de48562b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb76b3-b527-4ed8-8ce3-d3de48562b6e.jpg?1",
             "name": "Skyreaping",
             "text": "Skyreaping deals damage to each creature with flying equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -4744,7 +4744,7 @@
         },
         {
             "id": "37ab165d-3c3b-5dcb-ba42-afb95a2072d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b10bd7-3f8b-426f-acdf-5a9559b9bc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b10bd7-3f8b-426f-acdf-5a9559b9bc7d.jpg?1",
             "name": "Snake of the Golden Grove",
             "text": "Tribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.)\nWhen Snake of the Golden Grove enters the battlefield, if tribute wasn't paid, you gain 4 life.",
             "colours": [
@@ -4778,7 +4778,7 @@
         },
         {
             "id": "5d2d0e87-9222-576f-99f2-42f38223f048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776ebd7-91fc-49e1-a978-f2012162d1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776ebd7-91fc-49e1-a978-f2012162d1cf.jpg?1",
             "name": "Swordwise Centaur",
             "text": "",
             "colours": [
@@ -4813,7 +4813,7 @@
         },
         {
             "id": "d86e50e4-c17f-59e7-9822-09b23e4c1a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5584c26f-62ac-4d0b-9142-5159f2a05734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5584c26f-62ac-4d0b-9142-5159f2a05734.jpg?1",
             "name": "Unravel the Aether",
             "text": "Choose target artifact or enchantment. Its owner shuffles it into his or her library.",
             "colours": [
@@ -4845,7 +4845,7 @@
         },
         {
             "id": "6ed339bb-b893-5023-9f11-64eca630cd7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d171b46-69e7-4e39-b3b2-97ed022cd933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d171b46-69e7-4e39-b3b2-97ed022cd933.jpg?1",
             "name": "Chromanticore",
             "text": "Bestow {2}{W}{U}{B}{R}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying, first strike, vigilance, trample, lifelink\nEnchanted creature gets +4/+4 and has flying, first strike, vigilance, trample, and lifelink.",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "a89eaec2-e0a0-5b81-a9c8-5c0573ce812c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6832e495-7ee9-43e0-94ea-03c88344080e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6832e495-7ee9-43e0-94ea-03c88344080e.jpg?1",
             "name": "Ephara, God of the Polis",
             "text": "Indestructible\nAs long as your devotion to white and blue is less than seven, Ephara isn't a creature.\nAt the beginning of each upkeep, if you had another creature enter the battlefield under your control last turn, draw a card.",
             "colours": [
@@ -4927,7 +4927,7 @@
         },
         {
             "id": "8d832a0c-f85b-52e7-b190-cdc8e4052089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e480d04-9a35-463e-928e-8da3556629e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e480d04-9a35-463e-928e-8da3556629e6.jpg?1",
             "name": "Ephara's Enlightenment",
             "text": "Enchant creature\nWhen Ephara's Enlightenment enters the battlefield, put a +1/+1 counter on enchanted creature.\nEnchanted creature has flying.\nWhenever a creature enters the battlefield under your control, you may return Ephara's Enlightenment to its owner's hand.",
             "colours": [
@@ -4963,7 +4963,7 @@
         },
         {
             "id": "d09dfc5c-83e1-5b3f-911b-bfb0b5c21602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3687799c-81bd-4c49-902a-2a96863629c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3687799c-81bd-4c49-902a-2a96863629c3.jpg?1",
             "name": "Fanatic of Xenagos",
             "text": "Trample\nTribute 1 (As this creature enters the battlefield, an opponent of your choice may place a +1/+1 counter on it.)\nWhen Fanatic of Xenagos enters the battlefield, if tribute wasn't paid, it gets +1/+1 and gains haste until end of turn.",
             "colours": [
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "02766927-49dc-5d68-814a-9a7cad3c4d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74050cb3-ba99-475d-9124-726e498fb68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74050cb3-ba99-475d-9124-726e498fb68e.jpg?1",
             "name": "Karametra, God of Harvests",
             "text": "Indestructible\nAs long as your devotion to green and white is less than seven, Karametra isn't a creature.\nWhenever you cast a creature spell, you may search your library for a Forest or Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "b772d54e-ad34-53fa-a92a-e413fbb06eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77ac7fa-718d-425f-a0aa-2f8e2bfc0950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77ac7fa-718d-425f-a0aa-2f8e2bfc0950.jpg?1",
             "name": "Kiora, the Crashing Wave",
             "text": "+1: Until your next turn, prevent all damage that would be dealt to and dealt by target permanent an opponent controls.\n-1: Draw a card. You may play an additional land this turn.\n-5: You get an emblem with \"At the beginning of your end step, put a 9/9 blue Kraken creature token onto the battlefield.\"",
             "colours": [
@@ -5077,7 +5077,7 @@
         },
         {
             "id": "8f87b5e9-eb91-57e4-8b26-f2746125992c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ce307-8ec3-4db6-a4a3-49f92ebcc783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ce307-8ec3-4db6-a4a3-49f92ebcc783.jpg?1",
             "name": "Kiora's Follower",
             "text": "{T}: Untap another target permanent.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "fdf8e38f-b2e8-55b9-8ef4-3308d81d99b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0417bf-b735-46d7-9985-2d991051020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0417bf-b735-46d7-9985-2d991051020f.jpg?1",
             "name": "Mogis, God of Slaughter",
             "text": "Indestructible\nAs long as your devotion to black and red is less than seven, Mogis isn't a creature.\nAt the beginning of each opponent's upkeep, Mogis deals 2 damage to that player unless he or she sacrifices a creature.",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "af4897c3-9895-5af4-b16b-3d458618d3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfcb129-4665-40e4-b5cb-a79f3f40ae5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfcb129-4665-40e4-b5cb-a79f3f40ae5c.jpg?1",
             "name": "Phenax, God of Deception",
             "text": "Indestructible\nAs long as your devotion to blue and black is less than seven, Phenax isn't a creature.\nCreatures you control have \"{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is this creature's toughness.\"",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "224b8893-d896-5aa7-a8dd-fbb8bfb2751a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb6eda2-e3df-440a-8900-8310f11db6e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb6eda2-e3df-440a-8900-8310f11db6e9.jpg?1",
             "name": "Ragemonger",
             "text": "Minotaur spells you cast cost {B}{R} less to cast. This effect reduces only the amount of colored mana you pay. (For example, if you cast a Minotaur spell with mana cost {2}{R}, it costs {2} to cast.)",
             "colours": [
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "1d034529-2a15-51e0-82d6-9ccf51cd11a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120babed-841f-4bf1-ac2d-3ab097c0760b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120babed-841f-4bf1-ac2d-3ab097c0760b.jpg?1",
             "name": "Reap What Is Sown",
             "text": "Put a +1/+1 counter on each of up to three target creatures.",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "a6e41a1d-de32-5038-8e3d-1310461840df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4438-aa74-4460-8bac-93480d0bb0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990f4438-aa74-4460-8bac-93480d0bb0dc.jpg?1",
             "name": "Siren of the Silent Song",
             "text": "Flying\nInspired \u2014 Whenever Siren of the Silent Song becomes untapped, each opponent discards a card, then puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "e2b02aff-5f55-580b-8cd0-2f809a7d0661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3184b138-1109-4195-9d96-4f190164e98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3184b138-1109-4195-9d96-4f190164e98b.jpg?1",
             "name": "Xenagos, God of Revels",
             "text": "Indestructible\nAs long as your devotion to red and green is less than seven, Xenagos isn't a creature.\nAt the beginning of combat on your turn, another target creature you control gains haste and gets +X/+X until end of turn, where X is that creature's power.",
             "colours": [
@@ -5338,7 +5338,7 @@
         },
         {
             "id": "51d295e7-3633-5a64-aca8-bdf63a4cb0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b8011-c712-418f-869e-42fda3dc0830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b8011-c712-418f-869e-42fda3dc0830.jpg?1",
             "name": "Astral Cornucopia",
             "text": "Astral Cornucopia enters the battlefield with X charge counters on it.\n{T}: Choose a color. Add one mana of that color to your mana pool for each charge counter on Astral Cornucopia.",
             "colours": [],
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "dc9db0bf-b559-51ad-82b8-b37b12f15f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745dd92-9f7a-44a4-a27f-2ff17753db1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745dd92-9f7a-44a4-a27f-2ff17753db1c.jpg?1",
             "name": "Gorgon's Head",
             "text": "Equipped creature has deathtouch.\nEquip {2}",
             "colours": [],
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "2a939a80-1e1d-5c58-b521-8841e31f672d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb14f9-343c-4672-b4ee-db7f1d1a98ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb14f9-343c-4672-b4ee-db7f1d1a98ff.jpg?1",
             "name": "Heroes' Podium",
             "text": "Each legendary creature you control gets +1/+1 for each other legendary creature you control.\n{X}, {T}: Look at the top X cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "32bf336e-56d3-5a7d-abd3-ec151ec4562b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c1371b-ffec-41c7-8fc1-acb2bd538080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c1371b-ffec-41c7-8fc1-acb2bd538080.jpg?1",
             "name": "Pillar of War",
             "text": "Defender\nAs long as Pillar of War is enchanted, it can attack as though it didn't have defender.",
             "colours": [],
@@ -5457,7 +5457,7 @@
         },
         {
             "id": "09ca1b6a-51f9-57b8-914c-e360fabe1866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfeca720-3163-4391-b90d-5f7aa5f5987b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfeca720-3163-4391-b90d-5f7aa5f5987b.jpg?1",
             "name": "Siren Song Lyre",
             "text": "Equipped creature has \"{2}, {T}: Tap target creature.\"\nEquip {2}",
             "colours": [],
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "adc5b382-479d-534d-9c2d-b17c9e0c6d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9d645-0220-4a65-bbc7-abc64ded548e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9d645-0220-4a65-bbc7-abc64ded548e.jpg?1",
             "name": "Springleaf Drum",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5515,7 +5515,7 @@
         },
         {
             "id": "d14a1b79-8da7-5133-bda5-bfd54d5afa97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c657a645-f454-4eaf-be0d-15c9989fa4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c657a645-f454-4eaf-be0d-15c9989fa4ef.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -5546,7 +5546,7 @@
         },
         {
             "id": "2673338f-90cb-5133-85be-b6c8669048a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f50818-aede-4667-883a-e0339d86d870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f50818-aede-4667-883a-e0339d86d870.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "9f0b77e5-1875-5c2d-bb5a-7feb8a1ad33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0830054-b140-49c3-90cb-24e2502757be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0830054-b140-49c3-90cb-24e2502757be.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "5be401dd-cfeb-5052-bd97-62670082329d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862470b-f273-4e01-945b-bf3697cd1359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862470b-f273-4e01-945b-bf3697cd1359.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "d8a7431e-3edd-5b15-8b6f-e62203a3ae4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921d6192-6b6d-4aa1-be80-bc0b9f503e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921d6192-6b6d-4aa1-be80-bc0b9f503e33.jpg?1",
             "name": "Cat Soldier",
             "text": "",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "f004576c-fc48-53cb-88a9-56b336d0576a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f90245-fa63-48b2-a20a-8a6f00dd5853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f90245-fa63-48b2-a20a-8a6f00dd5853.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "2fb5a9ca-1d6f-5b51-9a54-a1d765e9a33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6ce21f-2a29-480e-91f9-b089232863ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6ce21f-2a29-480e-91f9-b089232863ff.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "ed4c8fc4-0156-5a7d-afa1-5291f3850694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9576efe-03eb-49da-bb00-5bf8e50877fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9576efe-03eb-49da-bb00-5bf8e50877fb.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "109dee31-0fa6-5f4a-b5c4-3ae29a8a79ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa525567-24f3-4ad4-b0b2-3b09d87cd106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa525567-24f3-4ad4-b0b2-3b09d87cd106.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "ba2d3c4f-49dd-56d4-bb45-bccd35b323a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e5fee3-6dd9-4bbe-b64d-ddfa4b9d4256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e5fee3-6dd9-4bbe-b64d-ddfa4b9d4256.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "f71ba2ee-cd84-56f4-9735-017ede02cedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985be507-6125-4db2-b99f-8b61149ffeeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985be507-6125-4db2-b99f-8b61149ffeeb.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -5886,7 +5886,7 @@
         },
         {
             "id": "54343ae9-3769-5833-a9fd-e4f53a0f17fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8958b650-c831-4499-813b-5699954ab2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8958b650-c831-4499-813b-5699954ab2f0.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "22a28f99-386e-5b4c-98b1-ce589600b6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8298e-5ce6-4ff6-9563-fcd158ce841e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8298e-5ce6-4ff6-9563-fcd158ce841e.jpg?1",
             "name": "Gold",
             "text": "",
             "colours": [],
@@ -5950,7 +5950,7 @@
         },
         {
             "id": "77f2b6f0-6c4b-54ad-82fc-81f979872e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45f7850-2ebb-4530-9859-f87b4e0e27be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45f7850-2ebb-4530-9859-f87b4e0e27be.jpg?1",
             "name": "Kiora, the Crashing Wave Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/BOK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/BOK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "44e15b78-f2ee-5eba-b6cc-e0b2b3ee6026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f49ff1-54f6-4825-987b-c50a152f7275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f49ff1-54f6-4825-987b-c50a152f7275.jpg?1",
             "name": "Day of Destiny",
             "text": "Legendary creatures you control get +2/+2.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "0e8f777c-b8b6-50b0-91a8-c186be7ecb90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c2e405-afe2-4de2-9e45-c5f357d788ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c2e405-afe2-4de2-9e45-c5f357d788ac.jpg?1",
             "name": "Empty-Shrine Kannushi",
             "text": "Empty-Shrine Kannushi has protection from the colors of permanents you control.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "7472759d-0b05-53ef-8053-951448d5d2c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg?1",
             "name": "Faithful Squire // Kaiso, Memory of Loyalty",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Faithful Squire.\nAt end of turn, if there are two or more ki counters on Faithful Squire, you may flip it.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "74d83cb0-c66c-56e3-9f04-c73e54e5d855",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/758abd53-6ad2-406e-8615-8e48678405b4.jpg?1",
             "name": "Faithful Squire // Kaiso, Memory of Loyalty",
             "text": "Flying\nRemove a ki counter from Kaiso, Memory of Loyalty: Prevent all damage that would be dealt to target creature this turn.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "e9af55f4-8aca-5d98-b19f-371b64d9bb35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2503e136-031f-498a-b042-4077baebe8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2503e136-031f-498a-b042-4077baebe8f8.jpg?1",
             "name": "Final Judgment",
             "text": "Remove all creatures from the game.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "4b69e6f6-0cbc-5b49-bc9f-91135635105a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cf9142-be8e-48d8-a1b4-9a7fb71718d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cf9142-be8e-48d8-a1b4-9a7fb71718d0.jpg?1",
             "name": "Genju of the Fields",
             "text": "{2}: Until end of turn, enchanted Plains becomes a 2/5 white Spirit creature with \"Whenever this creature deals damage, you gain that much life.\" It's still a land.\nWhen enchanted Plains is put into a graveyard, you may return Genju of the Fields from your graveyard to your hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "abb0aa58-dbb2-5e82-b39e-868662b172bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8566f5e-0ec5-4c9b-8b5b-4e580b20522a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8566f5e-0ec5-4c9b-8b5b-4e580b20522a.jpg?1",
             "name": "Heart of Light",
             "text": "Prevent all damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "65e745cd-f2e9-528a-8563-01748c8d669f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a03f5d5-d5c3-4a7d-8d44-e60b498b4ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a03f5d5-d5c3-4a7d-8d44-e60b498b4ed5.jpg?1",
             "name": "Hokori, Dust Drinker",
             "text": "Lands don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player untaps a land he or she controls.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "c9711bcb-fd9a-58a4-9a33-694bd789747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed548e0-9196-4bfc-9cfd-149abb945574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed548e0-9196-4bfc-9cfd-149abb945574.jpg?1",
             "name": "Hundred-Talon Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nSplice onto Arcane\u2014\nTap an untapped white creature you control. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "3a0665bc-c6b4-5be0-bb0f-e9d478b49148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb03bc2b-6d39-4315-964c-ca7db2db054a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb03bc2b-6d39-4315-964c-ca7db2db054a.jpg?1",
             "name": "Indebted Samurai",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever a Samurai you control is put into a graveyard from play, you may put a +1/+1 counter on Indebted Samurai.",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "e3d31de2-7ce0-55e0-b8b7-59b7590f97ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e4f5e6-935e-429f-89b4-4571376f442e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e4f5e6-935e-429f-89b4-4571376f442e.jpg?1",
             "name": "Kami of False Hope",
             "text": "Sacrifice Kami of False Hope: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "42cf19d0-174e-53ee-a5bf-d5143a1043cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6deb57-4ee3-4716-8644-28283704f994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6deb57-4ee3-4716-8644-28283704f994.jpg?1",
             "name": "Kami of Tattered Shoji",
             "text": "Whenever you play a Spirit or Arcane spell, Kami of Tattered Shoji gains flying until end of turn.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "728fa79b-9561-5ffe-bbfd-22fbe85bd79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e53299-f480-4769-bfc6-86fb19964280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e53299-f480-4769-bfc6-86fb19964280.jpg?1",
             "name": "Kami of the Honored Dead",
             "text": "Flying\nWhenever Kami of the Honored Dead is dealt damage, you gain that much life.\nSoulshift 6 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 6 or less from your graveyard to your hand.)",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "81b0531a-f530-5711-9d73-940db29f6b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcea3b3-5852-4ae1-a952-7b392564cb9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcea3b3-5852-4ae1-a952-7b392564cb9d.jpg?1",
             "name": "Kentaro, the Smiling Cat",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nYou may pay {X} rather than pay the mana cost for Samurai spells you play, where X is that spell's converted mana cost.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "a1d9bd80-5870-5ebc-9b00-ff2bdd261aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb981f8b-4f03-4fd2-a255-b10635958bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb981f8b-4f03-4fd2-a255-b10635958bfd.jpg?1",
             "name": "Kitsune Palliator",
             "text": "{T}: Prevent the next 1 damage that would be dealt to each creature and each player this turn.",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "29af53f2-90a2-50a1-9357-e11ff4c65f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ba253-fb50-4240-8129-6b86895d1ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ba253-fb50-4240-8129-6b86895d1ff9.jpg?1",
             "name": "Mending Hands",
             "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "95b3b9a4-dddf-5b57-b298-d9241c6dbc23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d39ff1-402c-4218-ad42-276a22c087a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d39ff1-402c-4218-ad42-276a22c087a7.jpg?1",
             "name": "Moonlit Strider",
             "text": "Sacrifice Moonlit Strider: Target creature you control gains protection from the color of your choice until end of turn.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "993307b6-316d-5211-a43f-060f00f5a88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08d5618-4fe0-4ae5-af16-696467aae02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08d5618-4fe0-4ae5-af16-696467aae02d.jpg?1",
             "name": "Opal-Eye, Konda's Yojimbo",
             "text": "Bushido 1; defender (This creature can't attack.)\n{T}: The next time a source of your choice would deal damage this turn, that damage is dealt to Opal-Eye, Konda's Yojimbo instead.\n{1}{W}: Prevent the next 1 damage that would be dealt to Opal-Eye this turn.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "7963d18a-6f55-5173-b56b-1c24e4674598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313bd276-2f69-447e-a2b1-240cf839614a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313bd276-2f69-447e-a2b1-240cf839614a.jpg?1",
             "name": "Oyobi, Who Split the Heavens",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, put a 3/3 white Spirit creature token with flying into play.",
             "colours": [
@@ -662,7 +662,7 @@
         },
         {
             "id": "1b175fa3-cc00-5c29-abda-72798d30b66e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102ee72e-5fb8-4059-9dfa-98004e222c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102ee72e-5fb8-4059-9dfa-98004e222c27.jpg?1",
             "name": "Patron of the Kitsune",
             "text": "Fox offering (You may play this card any time you could play an instant by sacrificing a Fox and paying the difference in mana costs between this and the sacrificed Fox. Mana cost includes color.)\nWhenever a creature attacks, you may gain 1 life.",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "bda909b3-68b4-5e1a-82ed-a40601fb0133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cac762-7482-471f-b4de-e0cb6da5451c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cac762-7482-471f-b4de-e0cb6da5451c.jpg?1",
             "name": "Scour",
             "text": "Remove target enchantment from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that enchantment and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -730,7 +730,7 @@
         },
         {
             "id": "b454bcac-bed7-5773-81fd-cf2b58527f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca16f8-336a-444b-9f78-e97a3f20a3bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca16f8-336a-444b-9f78-e97a3f20a3bc.jpg?1",
             "name": "Shining Shoal",
             "text": "You may remove a white card with converted mana cost X in your hand from the game rather than pay Shining Shoal's mana cost.\nThe next X damage that a source of your choice would deal to you or a creature you control this turn is dealt to target creature or player instead.",
             "colours": [
@@ -764,7 +764,7 @@
         },
         {
             "id": "30faa8a4-318e-5515-ba06-ab5c887f37d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2a6d9-5848-4481-a0f9-42320ff2c230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2a6d9-5848-4481-a0f9-42320ff2c230.jpg?1",
             "name": "Silverstorm Samurai",
             "text": "You may play Silverstorm Samurai any time you could play an instant.\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "1ccf0336-a4c5-5e61-91e9-ebc0e7020b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0528fe29-f3c1-4d10-9030-053c3de57b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0528fe29-f3c1-4d10-9030-053c3de57b7b.jpg?1",
             "name": "Split-Tail Miko",
             "text": "{W}, {T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -834,7 +834,7 @@
         },
         {
             "id": "96e884ad-a136-5ef6-aad6-d2082cd37c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf9cd2e-5cf6-4959-abf2-56b686b636a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf9cd2e-5cf6-4959-abf2-56b686b636a3.jpg?1",
             "name": "Takeno's Cavalry",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{T}: Takeno's Cavalry deals 1 damage to target attacking or blocking Spirit.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "57909662-b038-5cb0-9912-b29b20e42fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018aa51-d75e-4d94-b4b3-0cd14fc87d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a018aa51-d75e-4d94-b4b3-0cd14fc87d44.jpg?1",
             "name": "Tallowisp",
             "text": "Whenever you play a Spirit or Arcane spell, you may search your library for an enchant creature card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "f4e88aaf-1522-526b-bf3e-a3ae2c06d9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63cfebd-8cab-48b4-814a-4d8751dd1b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63cfebd-8cab-48b4-814a-4d8751dd1b57.jpg?1",
             "name": "Terashi's Grasp",
             "text": "Destroy target artifact or enchantment. You gain life equal to its converted mana cost.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "30e7c67c-2b64-5b17-bc88-ba114c2acea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fa34b-95c6-4e02-9e15-3f595f744741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fa34b-95c6-4e02-9e15-3f595f744741.jpg?1",
             "name": "Terashi's Verdict",
             "text": "Destroy target attacking creature with power 3 or less.",
             "colours": [
@@ -972,7 +972,7 @@
         },
         {
             "id": "004ea5e7-bd25-5fcc-a4bb-c7f619068867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73acef0c-34b1-4e04-8569-4f8d754585df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73acef0c-34b1-4e04-8569-4f8d754585df.jpg?1",
             "name": "Ward of Piety",
             "text": "{1}{W}: The next 1 damage that would be dealt to enchanted creature this turn is dealt to target creature or player instead.",
             "colours": [
@@ -1006,7 +1006,7 @@
         },
         {
             "id": "cb69d8aa-780a-5151-a403-4a4a74c3cde8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e084a-f5cb-49f5-8de2-5729d00e1aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e084a-f5cb-49f5-8de2-5729d00e1aba.jpg?1",
             "name": "Waxmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Waxmane Baku.\n{1}, Remove X ki counters from Waxmane Baku: Tap X target creatures.",
             "colours": [
@@ -1040,7 +1040,7 @@
         },
         {
             "id": "cc5d61c3-3d2a-54c4-a6ee-fc8872a3e42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f611af49-3c59-4365-a398-93f7e05ff0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f611af49-3c59-4365-a398-93f7e05ff0d0.jpg?1",
             "name": "Yomiji, Who Bars the Way",
             "text": "Whenever a legendary permanent other than Yomiji, Who Bars the Way is put into a graveyard from play, return that card to its owner's hand.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "0fe8e5c4-25ec-587a-bc60-83510ae6f2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg?1",
             "name": "Callow Jushi // Jaraku the Interloper",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Callow Jushi.\nAt end of turn, if there are two or more ki counters on Callow Jushi, you may flip it.",
             "colours": [
@@ -1111,7 +1111,7 @@
         },
         {
             "id": "54001e85-889a-5723-9998-91ec33094946",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca03131a-9bd4-4fba-b95c-90f1831e86e7.jpg?1",
             "name": "Callow Jushi // Jaraku the Interloper",
             "text": "Remove a ki counter from Jaraku the Interloper: Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "e1b666a5-3dbd-58d9-ba70-d85435cc1156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c359b1a-d441-4763-96c7-e5c010eae53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c359b1a-d441-4763-96c7-e5c010eae53f.jpg?1",
             "name": "Chisei, Heart of Oceans",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Chisei, Heart of Oceans unless you remove a counter from a permanent you control.",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "4d63dd59-42e1-55d3-bba3-0c3333944234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15589745-4c0a-4edf-ad45-3b7fa45e70c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15589745-4c0a-4edf-ad45-3b7fa45e70c5.jpg?1",
             "name": "Disrupting Shoal",
             "text": "You may remove a blue card with converted mana cost X in your hand from the game rather than pay Disrupting Shoal's mana cost.\nCounter target spell if its converted mana cost is X.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "49fd6ce2-86ed-5cde-86ba-415e5ee472dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0058be07-a8a1-448e-8c3d-61718cb384ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0058be07-a8a1-448e-8c3d-61718cb384ec.jpg?1",
             "name": "Floodbringer",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Tap target land.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "bad9761e-36b3-540f-928f-9f97c8a0f154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776f97c-bd9c-4c7b-be1c-93802ce6ff6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776f97c-bd9c-4c7b-be1c-93802ce6ff6a.jpg?1",
             "name": "Genju of the Falls",
             "text": "{2}: Enchanted Island becomes a 3/2 blue Spirit creature with flying until end of turn. It's still a land.\nWhen enchanted Island is put into a graveyard, you may return Genju of the Falls from your graveyard to your hand.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "c68e6d8b-db02-519b-b272-3fe619235f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb953ffc-0e73-42a2-a026-e6d3041fd8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb953ffc-0e73-42a2-a026-e6d3041fd8ec.jpg?1",
             "name": "Heed the Mists",
             "text": "Put the top card of your library into your graveyard, then draw cards equal to that card's converted mana cost.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "3f65f1fa-2198-53a1-b0e2-488efadef92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f3cf5-f8aa-49d4-947d-76b91799547a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f3cf5-f8aa-49d4-947d-76b91799547a.jpg?1",
             "name": "Higure, the Still Wind",
             "text": "Ninjutsu {2}{U}{U} ({2}{U}{U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Higure deals combat damage to a player, you may search your library for a Ninja card, reveal it, and put it into your hand. If you do, shuffle your library.\n{2}: Target Ninja is unblockable this turn.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "dff1d79f-f144-5310-8bda-7e34fb2b7082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3015369-df39-44cb-ba16-533f7ad5824d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3015369-df39-44cb-ba16-533f7ad5824d.jpg?1",
             "name": "Jetting Glasskite",
             "text": "Flying\nWhenever Jetting Glasskite becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "72e59b01-d6fd-5ef7-a81e-40fbf47e25f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e177ce-98bf-4fbc-83d1-1f64ca5d86c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e177ce-98bf-4fbc-83d1-1f64ca5d86c6.jpg?1",
             "name": "Kaijin of the Vanishing Touch",
             "text": "Defender (This creature can't attack.)\nWhenever Kaijin of the Vanishing Touch blocks a creature, return that creature to its owner's hand at end of combat. (Return it only if it's in play.)",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "70cf308a-bdc9-563c-8ab4-dafb048bb686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc73a66f-4745-40c2-9c90-96396f6e7bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc73a66f-4745-40c2-9c90-96396f6e7bce.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.\"",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "bd249b1d-8956-5376-adfd-9ff8301a6b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93382c5e-082e-4a51-a3ec-b659cb503747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93382c5e-082e-4a51-a3ec-b659cb503747.jpg?1",
             "name": "Minamo Sightbender",
             "text": "{X}, {T}: Target creature with power X or less is unblockable this turn.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "eff51563-1a20-5bcb-925e-608eaea1b915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502c4aca-98f8-4c7d-89fd-ee42c938fac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502c4aca-98f8-4c7d-89fd-ee42c938fac7.jpg?1",
             "name": "Minamo's Meddling",
             "text": "Counter target spell. That spell's controller reveals his or her hand, then discards each card with the same name as a card spliced onto that spell.",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "3bed5fa4-4985-58b9-b7de-ff6809aff53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06f58f-0419-4637-8060-4a93670a4c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c06f58f-0419-4637-8060-4a93670a4c68.jpg?1",
             "name": "Mistblade Shinobi",
             "text": "Ninjutsu {U} ({U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Mistblade Shinobi deals combat damage to a player, you may return target creature that player controls to its owner's hand.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "fcdf57bd-60ec-57f7-9699-f299f48bce75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367a67c7-54db-4336-b55a-3fa27625172a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367a67c7-54db-4336-b55a-3fa27625172a.jpg?1",
             "name": "Ninja of the Deep Hours",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Ninja of the Deep Hours deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "07d85d05-3b69-5ec6-a3a3-579f39634bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5fcd6f-1653-44bf-a796-4c9ff9adf390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5fcd6f-1653-44bf-a796-4c9ff9adf390.jpg?1",
             "name": "Patron of the Moon",
             "text": "Moonfolk offering (You may play this card any time you could play an instant by sacrificing a Moonfolk and paying the difference in mana costs between this and the sacrificed Moonfolk. Mana cost includes color.)\nFlying\n{1}: Put up to two land cards from your hand into play tapped.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "7517a4d7-45e1-5900-a7bc-00b5527f08ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96e5a18-5958-426e-892f-5c68f44c1b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96e5a18-5958-426e-892f-5c68f44c1b41.jpg?1",
             "name": "Phantom Wings",
             "text": "Enchanted creature has flying.\nSacrifice Phantom Wings: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -1668,7 +1668,7 @@
         },
         {
             "id": "ee07613c-9d1a-56e8-a49e-4db799072f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca8c31-a9ea-4388-b257-951c1c68b86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca8c31-a9ea-4388-b257-951c1c68b86d.jpg?1",
             "name": "Quash",
             "text": "Counter target instant or sorcery spell. Search its controller's graveyard, hand, and library for all cards with the same name as that spell and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "a2dc0f0a-df18-5c40-a9bd-6a3d2329a9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9140fc-9d50-4e63-aae6-1ba2974a25a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9140fc-9d50-4e63-aae6-1ba2974a25a3.jpg?1",
             "name": "Quillmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Quillmane Baku.\n{1}, {T}, Remove X ki counters from Quillmane Baku: Return target creature with converted mana cost X or less to its owner's hand.",
             "colours": [
@@ -1734,7 +1734,7 @@
         },
         {
             "id": "5b69031b-544e-5788-973c-6e633f8d29b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10962b1b-4039-4d8a-88e0-fc67537920a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10962b1b-4039-4d8a-88e0-fc67537920a9.jpg?1",
             "name": "Reduce to Dreams",
             "text": "Return all artifacts and enchantments to their owners' hands.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "d467bbe2-43cc-5625-8f2c-5c9b5733699a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a3b0da-026e-4ea9-8035-38c909e5f9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a3b0da-026e-4ea9-8035-38c909e5f9a4.jpg?1",
             "name": "Ribbons of the Reikai",
             "text": "Draw a card for each Spirit you control.",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "7fcb4df9-a6fa-53ba-b776-d4a163efe409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bfedca-5a85-41e9-94be-67ed16bd634e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bfedca-5a85-41e9-94be-67ed16bd634e.jpg?1",
             "name": "Shimmering Glasskite",
             "text": "Flying\nWhenever Shimmering Glasskite becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.",
             "colours": [
@@ -1834,7 +1834,7 @@
         },
         {
             "id": "574b3a8e-8827-5525-a62d-3b8b5602bfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c71d1c3-7a8f-404f-a448-cd5cf97ec7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c71d1c3-7a8f-404f-a448-cd5cf97ec7de.jpg?1",
             "name": "Soratami Mindsweeper",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "aeed80e7-2c70-50ba-b765-572281a3075c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499be0ce-928b-496f-9d81-4ef39752377c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499be0ce-928b-496f-9d81-4ef39752377c.jpg?1",
             "name": "Stream of Consciousness",
             "text": "Target player shuffles up to four target cards from his or her graveyard into his or her library.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "a8dd679e-ca61-5163-baf6-8ac9c0e89e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb58d9e-d181-4167-8b80-64b238183bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb58d9e-d181-4167-8b80-64b238183bdb.jpg?1",
             "name": "Sway of the Stars",
             "text": "Each player shuffles his or her hand, graveyard, and permanents he or she owns into his or her library, then draws seven cards. Each player's life total becomes 7.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "811d59a4-ff57-524d-9eae-3e9acca81ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b015ae03-c083-4e4a-b4a2-88e55aef9001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b015ae03-c083-4e4a-b4a2-88e55aef9001.jpg?1",
             "name": "Teardrop Kami",
             "text": "Sacrifice Teardrop Kami: Tap or untap target creature.",
             "colours": [
@@ -1969,7 +1969,7 @@
         },
         {
             "id": "dfc4b171-c703-5b52-b28f-aadc6d8a7453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999440a5-9659-4218-8594-1950f1155975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999440a5-9659-4218-8594-1950f1155975.jpg?1",
             "name": "Threads of Disloyalty",
             "text": "Threads of Disloyalty can enchant only a creature with converted mana cost 2 or less.\nYou control enchanted creature.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "c86bb471-cbaa-5c23-b734-a4bef4535fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0881f8bf-5c28-4f54-9080-9612790ffa83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0881f8bf-5c28-4f54-9080-9612790ffa83.jpg?1",
             "name": "Toils of Night and Day",
             "text": "Tap or untap target permanent, then tap or untap another target permanent.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "da9b0852-7f62-51cc-81a6-5de216eebbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095813f9-d559-40bd-a50f-7c1f6e494e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095813f9-d559-40bd-a50f-7c1f6e494e60.jpg?1",
             "name": "Tomorrow, Azami's Familiar",
             "text": "If you would draw a card, look at the top three cards of your library instead. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "8a32eab4-f2c9-56a1-8762-c231a28174b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ae5c2-4f97-4315-b03f-c061eed3ed79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ae5c2-4f97-4315-b03f-c061eed3ed79.jpg?1",
             "name": "Veil of Secrecy",
             "text": "Target creature is unblockable and can't be the target of spells or abilities this turn.\nSplice onto Arcane\u2014\nReturn a blue creature you control to its owner's hand. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "1fae63ea-331a-5901-ab78-a7ce51f3001d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34469923-9a48-4fa5-aff8-4e09926f039f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34469923-9a48-4fa5-aff8-4e09926f039f.jpg?1",
             "name": "Walker of Secret Ways",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Walker of Secret Ways deals combat damage to a player, look at that player's hand.\n{1}{U}: Return target Ninja you control to its owner's hand. Play this ability only during your turn.",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "9403bc97-1283-591e-8e7e-299894bed009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801c2b46-c7a7-44d6-ae38-5d34bf00c404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801c2b46-c7a7-44d6-ae38-5d34bf00c404.jpg?1",
             "name": "Bile Urchin",
             "text": "Sacrifice Bile Urchin: Target player loses 1 life.",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "cb030931-f7b2-5032-aed3-aa7003844163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba1cf-d913-4285-9d8b-38acf78cc45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba1cf-d913-4285-9d8b-38acf78cc45e.jpg?1",
             "name": "Blessing of Leeches",
             "text": "You may play Blessing of Leeches any time you could play an instant.\nAt the beginning of your upkeep, you lose 1 life.\n{0}: Regenerate enchanted creature.",
             "colours": [
@@ -2210,7 +2210,7 @@
         },
         {
             "id": "6abd8532-677d-59d2-8bd7-dfde3b1f90c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ed26-8036-4505-83d3-b782e7e1fb45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ed26-8036-4505-83d3-b782e7e1fb45.jpg?1",
             "name": "Call for Blood",
             "text": "As an additional cost to play Call for Blood, sacrifice a creature.\nTarget creature gets -X/-X until end of turn, where X is the sacrificed creature's power.",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "25993f5e-061e-53d2-933e-c606f84c5793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c735bda-5454-4177-a23a-f9f00b7480d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c735bda-5454-4177-a23a-f9f00b7480d2.jpg?1",
             "name": "Crawling Filth",
             "text": "Fear\nSoulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -2278,7 +2278,7 @@
         },
         {
             "id": "a59f0cd4-2bf4-5208-9fc1-d53d83b3293b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e0e5-798c-4791-85fe-24d0838df8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6e0e5-798c-4791-85fe-24d0838df8f4.jpg?1",
             "name": "Eradicate",
             "text": "Remove target nonblack creature from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that creature and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "de39f9db-fef0-5eda-8fa6-d8965938f102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924fa2d7-ec9b-4b82-8384-0f904cb624f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924fa2d7-ec9b-4b82-8384-0f904cb624f7.jpg?1",
             "name": "Genju of the Fens",
             "text": "{2}: Until end of turn, enchanted Swamp becomes a 2/2 black Spirit creature with \"{B}: This creature gets +1/+1 until end of turn.\" It's still a land.\nWhen enchanted Swamp is put into a graveyard, you may return Genju of the Fens from your graveyard to your hand.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "a3781a4d-b87f-56e5-a686-020c23a068f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027e6c5-eed3-44e7-bb12-67569721af99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027e6c5-eed3-44e7-bb12-67569721af99.jpg?1",
             "name": "Goryo's Vengeance",
             "text": "Return target legendary creature card from your graveyard to play. That creature gains haste. Remove it from the game at end of turn.\nSplice onto Arcane {2}{B} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "4d3561d8-1289-5b13-9cf9-08c89de95e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22dd514-814f-4a62-926d-fef311896c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22dd514-814f-4a62-926d-fef311896c02.jpg?1",
             "name": "Hero's Demise",
             "text": "Destroy target legendary creature.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "f4989495-0939-544f-9b84-d7b82cb1fdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg?1",
             "name": "Hired Muscle // Scarmaker",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Hired Muscle.\nAt end of turn, if there are two or more ki counters on Hired Muscle, you may flip it.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "e417dba8-bcac-55c8-ba01-aa75de3edf73",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28f72260-c8f9-4c44-92b5-23cef6690fdd.jpg?1",
             "name": "Hired Muscle // Scarmaker",
             "text": "Remove a ki counter from Scarmaker: Target creature gains fear until end of turn.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "8394398a-bddf-561f-836f-51ac3a871ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aad5179-4b73-498e-85c5-1fc363d26223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aad5179-4b73-498e-85c5-1fc363d26223.jpg?1",
             "name": "Horobi's Whisper",
             "text": "If you control a Swamp, destroy target nonblack creature.\nSplice onto Arcane\u2014\nRemove four cards in your graveyard from the game. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2515,7 +2515,7 @@
         },
         {
             "id": "ab8486a9-7eaa-5c49-a8cc-8aa32eeb13dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386d391d-a3f8-49a4-802a-409944b2acf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386d391d-a3f8-49a4-802a-409944b2acf3.jpg?1",
             "name": "Ink-Eyes, Servant of Oni",
             "text": "Ninjutsu {3}{B}{B} ({3}{B}{B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Ink-Eyes, Servant of Oni deals combat damage to a player, you may put target creature card from that player's graveyard into play under your control.\n{1}{B}: Regenerate Ink-Eyes.",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "bf08d1ec-b389-5c64-a61c-a3ea915ea019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0969e6-f667-4e29-a038-8569022cce32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0969e6-f667-4e29-a038-8569022cce32.jpg?1",
             "name": "Kyoki, Sanity's Eclipse",
             "text": "Whenever you play a Spirit or Arcane spell, target opponent removes a card in his or her hand from the game.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "ef2704d4-77e2-5711-823a-7b4c8073b191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632679e5-7368-4660-a765-07be196c3c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632679e5-7368-4660-a765-07be196c3c35.jpg?1",
             "name": "Mark of the Oni",
             "text": "You control enchanted creature.\nAt end of turn, if you control no Demons, sacrifice Mark of the Oni.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "6eac5714-9caf-5ec2-9a56-09661d9a4276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bdcdce-68fb-460b-874d-40df7afd99ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bdcdce-68fb-460b-874d-40df7afd99ca.jpg?1",
             "name": "Nezumi Shadow-Watcher",
             "text": "Sacrifice Nezumi Shadow-Watcher: Destroy target Ninja.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "2bcd8e2e-f9ec-5c6c-961b-4eba5c916a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f083bd50-d171-4e49-b8e6-972802879c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f083bd50-d171-4e49-b8e6-972802879c24.jpg?1",
             "name": "Ogre Marauder",
             "text": "Whenever Ogre Marauder attacks, it can't be blocked this turn unless defending player sacrifices a creature.",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "025600ee-74dc-515f-a985-c62a2d8ce55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9297e-301e-4e70-af9b-3218eacacf8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9297e-301e-4e70-af9b-3218eacacf8d.jpg?1",
             "name": "Okiba-Gang Shinobi",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Okiba-Gang Shinobi deals combat damage to a player, that player discards two cards.",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "4ab7451e-554f-5f51-94a6-f608e9d18343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e5d64-11ec-4eb5-8160-b2fb8a333812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622e5d64-11ec-4eb5-8160-b2fb8a333812.jpg?1",
             "name": "Patron of the Nezumi",
             "text": "Rat offering (You may play this card any time you could play an instant by sacrificing a Rat and paying the difference in mana costs between this and the sacrificed Rat. Mana cost includes color.)\nWhenever a permanent is put into an opponent's graveyard, that player loses 1 life.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "081719ae-fd27-594d-996f-fe85b07242e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2f024b-e77e-426b-930e-85b87e046f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2f024b-e77e-426b-930e-85b87e046f9b.jpg?1",
             "name": "Psychic Spear",
             "text": "Target player reveals his or her hand. Choose a Spirit or Arcane card from it. That player discards that card.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "078d944e-7f95-53bf-b24d-5249edd81591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f142dea-4751-453f-93a5-c8fdaba8a1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f142dea-4751-453f-93a5-c8fdaba8a1b3.jpg?1",
             "name": "Pus Kami",
             "text": "{B}, Sacrifice Pus Kami: Destroy target nonblack creature.\nSoulshift 6 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 6 or less from your graveyard to your hand.)",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "76f8e324-724e-5f08-a584-8ca5a770c077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7692ef1-bfae-411d-a589-f493128ef44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7692ef1-bfae-411d-a589-f493128ef44b.jpg?1",
             "name": "Scourge of Numai",
             "text": "At the beginning of your upkeep, you lose 2 life if you don't control an Ogre.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "a3d5df6e-a033-5d35-a246-13e2a8e809c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7ced3-08b8-4599-9f44-3c6c8f905c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7ced3-08b8-4599-9f44-3c6c8f905c9b.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from play, you may return that creature card to play under your control at end of turn if Shirei, Shizo's Caretaker is still in play.",
             "colours": [
@@ -2901,7 +2901,7 @@
         },
         {
             "id": "8fd32306-3d4e-5efa-a38b-02488df0d191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f4129-19fc-4ee9-9e3d-77fcf1563e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f4129-19fc-4ee9-9e3d-77fcf1563e4b.jpg?1",
             "name": "Sickening Shoal",
             "text": "You may remove a black card with converted mana cost X in your hand from the game rather than pay Sickening Shoal's mana cost.\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "83562f98-7742-5fa7-a02b-8f9c4f696bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005edd3a-238d-471a-8d5b-2df735c49f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005edd3a-238d-471a-8d5b-2df735c49f67.jpg?1",
             "name": "Skullmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Skullmane Baku.\n{1}, {T}, Remove X ki counters from Skullmane Baku: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "2f901215-d9b1-538e-99d6-910285ead4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb76fa1-a930-468d-bfd4-dd06c2a9fe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb76fa1-a930-468d-bfd4-dd06c2a9fe9e.jpg?1",
             "name": "Skullsnatcher",
             "text": "Ninjutsu {B} ({B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Skullsnatcher deals combat damage to a player, remove up to two target cards in that player's graveyard from the game.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "a1a3ab11-d14a-5ad8-8f9f-9b5bfa1517cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7287f68f-f2e2-4e6f-a772-29a629bb9ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7287f68f-f2e2-4e6f-a772-29a629bb9ccd.jpg?1",
             "name": "Stir the Grave",
             "text": "Return target creature card with converted mana cost X or less from your graveyard to play.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "ac287583-8089-5722-847c-7fd1ce923679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa3d318-83ff-41db-b33a-e4f5b7cd7a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa3d318-83ff-41db-b33a-e4f5b7cd7a77.jpg?1",
             "name": "Takenuma Bleeder",
             "text": "Whenever Takenuma Bleeder attacks or blocks, you lose 1 life if you don't control a Demon.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "70c17494-4219-55dd-90be-a9525f6603a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acaa44-15d5-4760-9aa8-b44eda9ed98a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acaa44-15d5-4760-9aa8-b44eda9ed98a.jpg?1",
             "name": "Three Tragedies",
             "text": "Target player discards three cards.",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "70394da4-2fb8-5ad8-8d04-006b6e0fbc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dcfdb4-c2ff-4fc5-aa2a-0c6e311d2910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dcfdb4-c2ff-4fc5-aa2a-0c6e311d2910.jpg?1",
             "name": "Throat Slitter",
             "text": "Ninjutsu {2}{B} ({2}{B}, Return an unblocked attacker you control to hand: Put this card into play from your hand tapped and attacking.)\nWhenever Throat Slitter deals combat damage to a player, destroy target nonblack creature that player controls.",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "6703071b-6e24-54dd-9054-b0cc0e7ffc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e767e07-febd-4025-bf03-d4d816bc1d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e767e07-febd-4025-bf03-d4d816bc1d3d.jpg?1",
             "name": "Toshiro Umezawa",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever a creature an opponent controls is put into a graveyard from play, you may play target instant card in your graveyard. If that card would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "b0ddfd27-8b31-547d-9199-abf8a02f8f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aeca31-1175-4d2d-adc3-e3682d7e9e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aeca31-1175-4d2d-adc3-e3682d7e9e07.jpg?1",
             "name": "Yukora, the Prisoner",
             "text": "When Yukora, the Prisoner leaves play, sacrifice all non-Ogre creatures you control.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "37b03848-9740-5383-aa22-f05f0762395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1ee90-67d1-4e83-ae1e-3bd71069aae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1ee90-67d1-4e83-ae1e-3bd71069aae4.jpg?1",
             "name": "Akki Blizzard-Herder",
             "text": "When Akki Blizzard-Herder is put into a graveyard from play, each player sacrifices a land.",
             "colours": [
@@ -3249,7 +3249,7 @@
         },
         {
             "id": "5dab75b5-a0c0-5bc6-a152-756d18f88c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fb34ae-157c-4f4b-bb47-2a9dc394a20c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fb34ae-157c-4f4b-bb47-2a9dc394a20c.jpg?1",
             "name": "Akki Raider",
             "text": "Whenever a land is put into a graveyard from play, Akki Raider gets +1/+0 until end of turn.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "5379eadc-493f-5575-bdd2-2a5d6c15080d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3218e3-4640-4f73-a52b-f11ea5ea23a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3218e3-4640-4f73-a52b-f11ea5ea23a9.jpg?1",
             "name": "Ashen Monstrosity",
             "text": "Haste\nAshen Monstrosity attacks each turn if able.",
             "colours": [
@@ -3318,7 +3318,7 @@
         },
         {
             "id": "5610d52b-9e10-5b00-b323-8adc82f0162f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132af2c2-2bae-4c05-9d61-a5777818a057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132af2c2-2bae-4c05-9d61-a5777818a057.jpg?1",
             "name": "Aura Barbs",
             "text": "Each enchantment deals 2 damage to its controller, then each enchantment enchanting a creature deals 2 damage to the creature it's enchanting.",
             "colours": [
@@ -3352,7 +3352,7 @@
         },
         {
             "id": "1e6a92c5-4b61-5560-b982-c2b00f6393ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bfd388-3648-4bc3-8c10-d6b3b79a9479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bfd388-3648-4bc3-8c10-d6b3b79a9479.jpg?1",
             "name": "Blademane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Blademane Baku.\n{1}, Remove X ki counters from Blademane Baku: For each counter removed, Blademane Baku gets +2/+0 until end of turn.",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "1885479d-9ce3-52f8-a853-1cb28cc17c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b915daa-d239-4460-bd6b-e1327fdf7f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b915daa-d239-4460-bd6b-e1327fdf7f51.jpg?1",
             "name": "Blazing Shoal",
             "text": "You may remove a red card with converted mana cost X in your hand from the game rather than pay Blazing Shoal's mana cost.\nTarget creature gets +X/+0 until end of turn.",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "28925ce5-4641-5440-90d7-e624aa999d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dcfb2-6088-49c9-89b2-88d63c9add53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dcfb2-6088-49c9-89b2-88d63c9add53.jpg?1",
             "name": "Clash of Realities",
             "text": "All Spirits have \"When this creature comes into play, you may have it deal 3 damage to target non-Spirit creature.\"\nAll non-Spirit creatures have \"When this creature comes into play, you may have it deal 3 damage to target Spirit.\"",
             "colours": [
@@ -3452,7 +3452,7 @@
         },
         {
             "id": "42116b64-2e16-5ca4-9913-04a6951303fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab16152-4617-4deb-b995-195e21f8f485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab16152-4617-4deb-b995-195e21f8f485.jpg?1",
             "name": "Crack the Earth",
             "text": "Each player sacrifices a permanent.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "7734be83-3d66-5900-b4aa-09824a5a59c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg?1",
             "name": "Cunning Bandit // Azamuki, Treachery Incarnate",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Cunning Bandit.\nAt end of turn, if there are two or more ki counters on Cunning Bandit, you may flip it.",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "a51e78e2-0401-5796-a2d3-1d21cbd8b5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1fe2b76f-ddb7-49d5-933b-ccb06be5d46f.jpg?1",
             "name": "Cunning Bandit // Azamuki, Treachery Incarnate",
             "text": "Remove a ki counter from Azamuki, Treachery Incarnate: Gain control of target creature until end of turn.",
             "colours": [
@@ -3557,7 +3557,7 @@
         },
         {
             "id": "2c1d39f6-7c7b-5c16-8807-0a2f734d2c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e5e360-ed47-40c1-8ad7-57645c2854ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e5e360-ed47-40c1-8ad7-57645c2854ca.jpg?1",
             "name": "First Volley",
             "text": "First Volley deals 1 damage to target creature and 1 damage to that creature's controller.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "b4544c9f-4594-5247-ad0f-091fdc937e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79701b4-d220-4c3e-b96c-7a77a22ba899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79701b4-d220-4c3e-b96c-7a77a22ba899.jpg?1",
             "name": "Flames of the Blood Hand",
             "text": "Flames of the Blood Hand deals 4 damage to target player. The damage can't be prevented. If that player would gain life this turn, that player gains no life instead.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "02cc3e00-1bc5-5143-aa84-7ee2c0331656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91e5f1-9179-4763-b7c9-b7ad5451f6d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91e5f1-9179-4763-b7c9-b7ad5451f6d0.jpg?1",
             "name": "Frost Ogre",
             "text": "",
             "colours": [
@@ -3658,7 +3658,7 @@
         },
         {
             "id": "83d04883-4bbd-509e-b89b-a5f87ae2d9e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bb08f9-355d-443e-8f08-a20ef7322e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bb08f9-355d-443e-8f08-a20ef7322e78.jpg?1",
             "name": "Frostling",
             "text": "Sacrifice Frostling: Frostling deals 1 damage to target creature.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "27865a76-588b-5b9b-a2c7-97fb59d36ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482678b8-bce6-4847-9f43-1761d61645d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482678b8-bce6-4847-9f43-1761d61645d8.jpg?1",
             "name": "Fumiko the Lowblood",
             "text": "Fumiko the Lowblood has bushido X, where X is the number of attacking creatures. (When this blocks or becomes blocked, it gets +X/+X until end of turn.)\nCreatures your opponents control attack each turn if able.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "8be51286-18d1-539b-8dbb-9081bd9e7e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4302b20-d445-4ef4-a6b7-6db311aa24a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4302b20-d445-4ef4-a6b7-6db311aa24a2.jpg?1",
             "name": "Genju of the Spires",
             "text": "{2}: Enchanted Mountain becomes a 6/1 red Spirit creature until end of turn. It's still a land.\nWhen enchanted Mountain is put into a graveyard, you may return Genju of the Spires from your graveyard to your hand.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "c9c2c24f-22c5-54b1-9f09-287594a690de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8964afec-50a9-45c4-bd2b-d06f8e75f4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8964afec-50a9-45c4-bd2b-d06f8e75f4ae.jpg?1",
             "name": "Goblin Cohort",
             "text": "Goblin Cohort can't attack unless you've played a creature spell this turn.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "ddc1705d-2f11-5413-bc7a-89237fe362a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ab177-d9ab-46bf-bd92-20a9ecf2d0ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ab177-d9ab-46bf-bd92-20a9ecf2d0ad.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "{T}: Heartless Hidetsugu deals to each player damage equal to half that player's life total, rounded down.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "965f4919-189c-5fe3-a428-0b09dd5cb5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12b7124-d9d0-480c-b622-777a74d4f679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12b7124-d9d0-480c-b622-777a74d4f679.jpg?1",
             "name": "In the Web of War",
             "text": "Whenever a creature comes into play under your control, it gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "c2027f5a-8b9f-5e33-a204-1a154577c03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b927e30-3508-4daf-91ce-8978b04062cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b927e30-3508-4daf-91ce-8978b04062cb.jpg?1",
             "name": "Ire of Kaminari",
             "text": "Ire of Kaminari deals damage to target creature or player equal to the number of Arcane cards in your graveyard.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "79fae3b5-7d9c-58e3-bd39-0514cf732fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e94fec2-dc56-4961-ba80-b9c904a345ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e94fec2-dc56-4961-ba80-b9c904a345ab.jpg?1",
             "name": "Ishi-Ishi, Akki Crackshot",
             "text": "Whenever an opponent plays a Spirit or Arcane spell, Ishi-Ishi, Akki Crackshot deals 2 damage to that player.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "ec76d3aa-b501-572e-8c3e-2525d695f1a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f0d9aa-4270-41cd-8993-765354c03d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f0d9aa-4270-41cd-8993-765354c03d03.jpg?1",
             "name": "Kumano's Blessing",
             "text": "You may play Kumano's Blessing any time you could play an instant.\nIf a creature dealt damage by enchanted creature this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "3f812e5e-0df8-59e3-85e5-65e6590b1c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b403bdbb-13ab-43dd-a994-d45b994f6e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b403bdbb-13ab-43dd-a994-d45b994f6e0e.jpg?1",
             "name": "Mannichi, the Fevered Dream",
             "text": "{1}{R}: Switch each creature's power and toughness until end of turn.",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "0d6f7756-6501-532b-8f2b-d61d40fee3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa425203-71fc-4d19-8014-871d16b11bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa425203-71fc-4d19-8014-871d16b11bfd.jpg?1",
             "name": "Ogre Recluse",
             "text": "Whenever a player plays a spell, tap Ogre Recluse.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "3b921b2e-6388-58f7-a84d-41f1c8338c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97040b82-ad9e-4c06-a9ac-74d0688279f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97040b82-ad9e-4c06-a9ac-74d0688279f9.jpg?1",
             "name": "Overblaze",
             "text": "Each time target permanent would deal damage to a creature or player this turn, it deals double that damage to that creature or player instead.\nSplice onto Arcane {2}{R}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "4ec8baf0-5481-5917-9a46-6d868ad41dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18325283-ace8-414b-bf48-2ed36b5a9c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18325283-ace8-414b-bf48-2ed36b5a9c24.jpg?1",
             "name": "Patron of the Akki",
             "text": "Goblin offering (You may play this card any time you could play an instant by sacrificing a Goblin and paying the difference in mana costs between this and the sacrificed Goblin. Mana cost includes color.)\nWhenever Patron of the Akki attacks, creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "bb8886f1-64ae-5632-9d0d-c5be19f7bf8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f12b75-af29-49ea-a23d-915052db9fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f12b75-af29-49ea-a23d-915052db9fef.jpg?1",
             "name": "Ronin Cliffrider",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever Ronin Cliffrider attacks, you may have it deal 1 damage to each creature defending player controls.",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "0b5d2e04-2fd0-5054-a291-415885e7a147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdaf49b-9524-4824-807e-c40fcb381742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdaf49b-9524-4824-807e-c40fcb381742.jpg?1",
             "name": "Shinka Gatekeeper",
             "text": "Whenever Shinka Gatekeeper is dealt damage, it deals that much damage to you.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "106c2cf6-1a70-5043-a070-8c589d323c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd243ce5-152b-4d9c-991e-be56b6731d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd243ce5-152b-4d9c-991e-be56b6731d99.jpg?1",
             "name": "Sowing Salt",
             "text": "Remove target nonbasic land from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that land and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "fc4c0e16-568d-5209-9fd1-e56ff479d963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716ae2ca-800a-4cc0-8cb1-fe8d6495306f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716ae2ca-800a-4cc0-8cb1-fe8d6495306f.jpg?1",
             "name": "Torrent of Stone",
             "text": "Torrent of Stone deals 4 damage to target creature.\nSplice onto Arcane\u2014\nSacrifice two mountains. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "ed6638a8-b432-579f-be54-58bcc915ef73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b6607c-0c34-4ffc-b1b7-154417492766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b6607c-0c34-4ffc-b1b7-154417492766.jpg?1",
             "name": "Twist Allegiance",
             "text": "You and target opponent each gain control of all creatures the other controls until end of turn. Untap those creatures. Those creatures gain haste until end of turn.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "0e4a2501-afb8-5915-ada3-0dfff5c88877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe8e0-23ab-4fe7-8a48-1902be142c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe8e0-23ab-4fe7-8a48-1902be142c6a.jpg?1",
             "name": "Body of Jukai",
             "text": "Trample\nSoulshift 8 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 8 or less from your graveyard to your hand.)",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "2185cdf1-2279-5cf6-911d-2eb98bb6e153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg?1",
             "name": "Budoka Pupil // Ichiga, Who Topples Oaks",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Budoka Pupil.\nAt end of turn, if there are two or more ki counters on Budoka Pupil, you may flip it.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "50d83b31-5be7-5752-a2ca-8a2033883849",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73636ca0-2309-4bb3-9300-8bd0c0bb5b31.jpg?1",
             "name": "Budoka Pupil // Ichiga, Who Topples Oaks",
             "text": "Trample\nRemove a ki counter from Ichiga, Who Topples Oaks: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -4386,7 +4386,7 @@
         },
         {
             "id": "25ca66d8-c42b-5b61-822a-e057c9e9429e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32c342f-ee1a-461c-9082-d2f6d9412f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32c342f-ee1a-461c-9082-d2f6d9412f54.jpg?1",
             "name": "Child of Thorns",
             "text": "Sacrifice Child of Thorns: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "4df77839-0ccd-53da-aa5f-8d426af7b05f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeefab6e-582a-42bb-bb27-d6aadd1d35c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeefab6e-582a-42bb-bb27-d6aadd1d35c5.jpg?1",
             "name": "Enshrined Memories",
             "text": "Reveal the top X cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "282d6da0-8c42-57e5-b39f-832147a6eb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff39ae5-a241-4607-903e-201f56c675f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff39ae5-a241-4607-903e-201f56c675f9.jpg?1",
             "name": "Forked-Branch Garami",
             "text": "Soulshift 4, soulshift 4 (When this is put into a graveyard from play, you may return up to two target Spirit cards with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "2c2d00fd-a4d9-5282-9648-f8cb83bc8993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d621b82-c863-437b-b42c-31a0872be6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d621b82-c863-437b-b42c-31a0872be6d4.jpg?1",
             "name": "Genju of the Cedars",
             "text": "{2}: Enchanted Forest becomes a 4/4 green Spirit creature until end of turn. It's still a land.\nWhen enchanted Forest is put into a graveyard, you may return Genju of the Cedars from your graveyard to your hand.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "74ddca44-cc62-5a47-a6c9-0524ac4d4227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c28728d-4839-4cdf-91d4-b9fb4b5d0449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c28728d-4839-4cdf-91d4-b9fb4b5d0449.jpg?1",
             "name": "Gnarled Mass",
             "text": "",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "38520521-3e27-5914-a7cb-4097caec89f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fd23b5-5e57-44dc-8248-c4b9eb71c4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fd23b5-5e57-44dc-8248-c4b9eb71c4f3.jpg?1",
             "name": "Harbinger of Spring",
             "text": "Protection from non-Spirit creatures\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "d4ff7d8c-abd2-5e91-9710-253472e01af6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90334b59-73d8-4459-af59-d7a0539e2cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90334b59-73d8-4459-af59-d7a0539e2cc5.jpg?1",
             "name": "Isao, Enlightened Bushi",
             "text": "Isao, Enlightened Bushi can't be countered.\nBushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{2}: Regenerate target Samurai.",
             "colours": [
@@ -4625,7 +4625,7 @@
         },
         {
             "id": "9bc681b5-8e9a-5120-82c2-d8aec6511529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c51fcf-ab5c-46fa-aa4b-14cd01c7a577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c51fcf-ab5c-46fa-aa4b-14cd01c7a577.jpg?1",
             "name": "Iwamori of the Open Fist",
             "text": "Trample\nWhen Iwamori of the Open Fist comes into play, each opponent may put a legendary creature card from his or her hand into play.",
             "colours": [
@@ -4662,7 +4662,7 @@
         },
         {
             "id": "7ec146dc-4692-52a2-a694-91db8d02d3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9264c5-1ecd-48cc-a12d-d4bd8050cfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9264c5-1ecd-48cc-a12d-d4bd8050cfae.jpg?1",
             "name": "Kodama of the Center Tree",
             "text": "Kodama of the Center Tree's power and toughness are each equal to the number of Spirits you control.\nKodama of the Center Tree has soulshift X, where X is the number of Spirits you control.",
             "colours": [
@@ -4698,7 +4698,7 @@
         },
         {
             "id": "7bafd9e0-6d35-5ff8-a145-2fa293cd585f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eaba1c-3137-4419-bf90-eb287a7c736e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eaba1c-3137-4419-bf90-eb287a7c736e.jpg?1",
             "name": "Lifegift",
             "text": "Whenever a land comes into play, you may gain 1 life.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "7c35c5f7-9b55-5d53-a7f5-dbdb679d204b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a83083-f7c6-4ddf-aee9-538a1778697d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a83083-f7c6-4ddf-aee9-538a1778697d.jpg?1",
             "name": "Lifespinner",
             "text": "{T}, Sacrifice three Spirits: Search your library for a legendary Spirit card and put it into play. Then shuffle your library.",
             "colours": [
@@ -4764,7 +4764,7 @@
         },
         {
             "id": "ae7e25f2-4073-5006-a034-5bbf2d49ebd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f635b35-48c8-43e8-9d74-c01d3c0c74e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f635b35-48c8-43e8-9d74-c01d3c0c74e1.jpg?1",
             "name": "Loam Dweller",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a land card from your hand into play tapped.",
             "colours": [
@@ -4798,7 +4798,7 @@
         },
         {
             "id": "89b77f5a-128a-56b6-950e-3d30ee9d956e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7611a97d-6500-4311-baa1-be3ee0791f3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7611a97d-6500-4311-baa1-be3ee0791f3a.jpg?1",
             "name": "Mark of Sakiko",
             "text": "Enchanted creature has \"Whenever this creature deals combat damage to a player, add that much {G} to your mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from your mana pool as phases end.\"",
             "colours": [
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "696add83-f7a6-5e83-be33-8b79adb726fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143af295-040d-400e-ae23-59abd2f88e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143af295-040d-400e-ae23-59abd2f88e11.jpg?1",
             "name": "Matsu-Tribe Sniper",
             "text": "{T}: Matsu-Tribe Sniper deals 1 damage to target creature with flying.\nWhenever Matsu-Tribe Sniper deals damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4868,7 +4868,7 @@
         },
         {
             "id": "ee40ce0c-63e8-5901-aebf-fdf97d522960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6af212-2a94-4ddf-acdc-d70fafa1c5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6af212-2a94-4ddf-acdc-d70fafa1c5ee.jpg?1",
             "name": "Nourishing Shoal",
             "text": "You may remove a green card with converted mana cost X in your hand from the game rather than pay Nourishing Shoal's mana cost.\nYou gain X life.",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "44d727b7-3cd6-5fb9-bd4b-97f3b29eef06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6787c4-170a-45b6-8792-af3ea32ef538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6787c4-170a-45b6-8792-af3ea32ef538.jpg?1",
             "name": "Patron of the Orochi",
             "text": "Snake offering (You may play this card any time you could play an instant by sacrificing a Snake and paying the difference in mana costs between this and the sacrificed Snake. Mana cost includes color.)\n{T}: Untap all Forests and all green creatures. Play this ability only once each turn.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "9f0da37c-ccba-599d-bc20-7844cea69fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7ba032-66d6-41bd-af4f-9853b031a474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7ba032-66d6-41bd-af4f-9853b031a474.jpg?1",
             "name": "Petalmane Baku",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Petalmane Baku.\n{1}, Remove X ki counters from Petalmane Baku: Add X mana of any one color to your mana pool.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "e74ea3e4-8f9b-5a6f-85b6-0110aa9501bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b70649-12f8-47b9-9959-40323684a777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b70649-12f8-47b9-9959-40323684a777.jpg?1",
             "name": "Roar of Jukai",
             "text": "If you control a Forest, each blocked creature gets +2/+2 until end of turn.\nSplice onto Arcane\u2014\nAn opponent gains 5 life. (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "a9bd8c82-007c-51de-8228-1d885fb8d19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774ec405-5127-4475-8c74-b8858bd84379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774ec405-5127-4475-8c74-b8858bd84379.jpg?1",
             "name": "Sakiko, Mother of Summer",
             "text": "Whenever a creature you control deals combat damage to a player, add that much {G} to your mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from your mana pool as phases end.",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "01aa2246-6cf0-563c-8aad-ad3663ca1571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ca7687-ba90-4479-8c6e-ece3f29fff12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ca7687-ba90-4479-8c6e-ece3f29fff12.jpg?1",
             "name": "Sakura-Tribe Springcaller",
             "text": "At the beginning of your upkeep, add {G} to your mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from your mana pool as phases end.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "649be30d-ad1b-5acc-a049-b164bd45b11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b27457e-2c40-4983-9680-b7292db4c668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b27457e-2c40-4983-9680-b7292db4c668.jpg?1",
             "name": "Scaled Hulk",
             "text": "Whenever you play a Spirit or Arcane spell, Scaled Hulk gets +2/+2 until end of turn.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "31bca2b6-d965-5ed2-a914-996ded55df31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab9407d-9389-4ec9-963c-80de095a6812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab9407d-9389-4ec9-963c-80de095a6812.jpg?1",
             "name": "Shizuko, Caller of Autumn",
             "text": "At the beginning of each player's upkeep, that player adds {G}{G}{G} to his or her mana pool. This mana doesn't cause mana burn. Until end of turn, this mana doesn't empty from that player's mana pool as phases end.",
             "colours": [
@@ -5149,7 +5149,7 @@
         },
         {
             "id": "9f97dd03-059d-5dd4-a14c-cc8f8776873f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42359e94-9f57-45ae-ae39-d4b939813015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42359e94-9f57-45ae-ae39-d4b939813015.jpg?1",
             "name": "Sosuke's Summons",
             "text": "Put two 1/1 green Snake creature tokens into play.\nWhenever a nontoken Snake comes into play under your control, you may return Sosuke's Summons from your graveyard to your hand.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "cb1f644a-f2bb-5143-b769-d158beb23cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc210b-e37e-463c-8fd4-83e5113429a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc210b-e37e-463c-8fd4-83e5113429a9.jpg?1",
             "name": "Splinter",
             "text": "Remove target artifact from the game. Search its controller's graveyard, hand, and library for all cards with the same name as that artifact and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "85fa4483-92c3-51cd-9e03-b0de5aff27b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65aabe-5fd8-4b62-b13c-12e4bb91aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65aabe-5fd8-4b62-b13c-12e4bb91aacb.jpg?1",
             "name": "Traproot Kami",
             "text": "Defender (This creature can't attack.)\nTraproot Kami's toughness is equal to the number of Forests in play.\nTraproot Kami may block as though it had flying.",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "fbd61c9e-d2fa-5f07-8a88-e14413ea556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7791182-fe63-47bc-9fdf-ef346d6ad4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7791182-fe63-47bc-9fdf-ef346d6ad4b5.jpg?1",
             "name": "Unchecked Growth",
             "text": "Target creature gets +4/+4 until end of turn. If it's a Spirit, it gains trample until end of turn.",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "fc6c03de-81f8-5590-8ed9-3ebec766b571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88357572-0edd-4115-93c3-49f6f5a191b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88357572-0edd-4115-93c3-49f6f5a191b4.jpg?1",
             "name": "Uproot",
             "text": "Put target land on top of its owner's library.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "e9a36e8f-d95c-59ea-931e-291d7c64a1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba28f326-67d1-4afb-90fe-e9f036210942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba28f326-67d1-4afb-90fe-e9f036210942.jpg?1",
             "name": "Vital Surge",
             "text": "You gain 3 life.\nSplice onto Arcane {1}{G} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5349,7 +5349,7 @@
         },
         {
             "id": "11e3e65c-8e89-5720-ba7d-830520453a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9eb7b9b-5189-4d20-8dec-e9d3df63e26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9eb7b9b-5189-4d20-8dec-e9d3df63e26e.jpg?1",
             "name": "Genju of the Realm",
             "text": "{2}: Enchanted land becomes a legendary 8/12 Spirit creature with trample until end of turn. It's still a land.\nWhen enchanted land is put into a graveyard, you may return Genju of the Realm from your graveyard to your hand.",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "ce15fb9c-7433-5ce3-9d75-c72c4179a7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1dbb8-3df8-4e7e-b74b-baab7d6f97c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1dbb8-3df8-4e7e-b74b-baab7d6f97c1.jpg?1",
             "name": "Baku Altar",
             "text": "Whenever you play a Spirit or Arcane spell, you may put a ki counter on Baku Altar.\n{2}, {T}, Remove a ki counter from Baku Altar: Put a 1/1 colorless Spirit creature token into play.",
             "colours": [],
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "400b1730-8c5c-514f-96f9-e0a9844c34d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097fbb8-0db5-4ceb-8972-dcd21b3fb4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f097fbb8-0db5-4ceb-8972-dcd21b3fb4d5.jpg?1",
             "name": "Blinding Powder",
             "text": "Equipped creature has \"Unattach Blinding Powder: Prevent all combat damage that would be dealt to this creature this turn.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "37bcaa96-96bf-5f0d-87f1-c4b3f1fc739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00beba34-54cc-4a30-8424-71a1215647a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00beba34-54cc-4a30-8424-71a1215647a6.jpg?1",
             "name": "Mirror Gallery",
             "text": "The \"legend rule\" doesn't apply.",
             "colours": [],
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "ef98cea0-1808-5fef-b589-c431dfc5093a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13884a26-1e30-40d7-ae38-494154a5cf85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13884a26-1e30-40d7-ae38-494154a5cf85.jpg?1",
             "name": "Neko-Te",
             "text": "Whenever equipped creature deals damage to a creature, tap that creature. As long as Neko-Te remains in play, that creature doesn't untap during its controller's untap step.\nWhenever equipped creature deals damage to a player, that player loses 1 life.\nEquip {2}",
             "colours": [],
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "3326b2ec-a5b6-5a4f-9d9a-71a0213c8113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbe52a3-f85e-4b3a-a345-413b64d69c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbe52a3-f85e-4b3a-a345-413b64d69c49.jpg?1",
             "name": "Orb of Dreams",
             "text": "Permanents come into play tapped.",
             "colours": [],
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "9dd9fba2-04cc-53be-96ef-7a53cba8dede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb4c10-59cb-4bc1-b824-6ec8edd6f45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baeb4c10-59cb-4bc1-b824-6ec8edd6f45e.jpg?1",
             "name": "Ornate Kanzashi",
             "text": "{2}, {T}: Target opponent removes the top card of his or her library from the game. You may play that card this turn.",
             "colours": [],
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "8aa78369-15c8-5d5d-8d4a-aa6f3050f87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad31cd-38dc-4fd3-b9e4-8988f4898719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad31cd-38dc-4fd3-b9e4-8988f4898719.jpg?1",
             "name": "Ronin Warclub",
             "text": "Equipped creature gets +2/+1.\nWhenever a creature comes into play under your control, attach Ronin Warclub to that creature.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "ea8cf134-a05a-512d-a364-d9a133db2a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47456b8-cef8-4085-90b1-92788e16fd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47456b8-cef8-4085-90b1-92788e16fd27.jpg?1",
             "name": "Shuko",
             "text": "Equipped creature gets +1/+0.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "f9641e79-b81e-5901-bdcc-927146582e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e7f3b-55a4-41bf-b7ec-81114f2c63c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e7f3b-55a4-41bf-b7ec-81114f2c63c4.jpg?1",
             "name": "Shuriken",
             "text": "Equipped creature has \"{T}, Unattach Shuriken: Shuriken deals 2 damage to target creature. That creature's controller gains control of Shuriken unless it was unattached from a Ninja.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "9d7f00b9-bc10-51ff-b650-a29a67dcf896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32ac983-a909-4342-882e-f3b7e2e064d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32ac983-a909-4342-882e-f3b7e2e064d8.jpg?1",
             "name": "Slumbering Tora",
             "text": "{2}, Discard a Spirit or Arcane card: Slumbering Tora becomes an X/X artifact creature until end of turn, where X is the discarded card's converted mana cost.",
             "colours": [],
@@ -5683,7 +5683,7 @@
         },
         {
             "id": "3026e795-cf34-5d30-88cc-54429dc4dd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80c84ad-171f-42c3-94b4-a9fe25b877e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80c84ad-171f-42c3-94b4-a9fe25b877e7.jpg?1",
             "name": "That Which Was Taken",
             "text": "{4}, {T}: Put a divinity counter on target permanent other than That Which Was Taken.\nEach permanent with a divinity counter on it is indestructible.",
             "colours": [],
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "b9eb9778-51c7-5c12-8524-4aaaf14c68c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6e5956-f795-451b-bb24-56462d1ced27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6e5956-f795-451b-bb24-56462d1ced27.jpg?1",
             "name": "Umezawa's Jitte",
             "text": "Whenever equipped creature deals combat damage, put two charge counters on Umezawa's Jitte.\nRemove a charge counter from Umezawa's Jitte: Choose one Equipped creature gets +2/+2 until end of turn; or target creature gets -1/-1 until end of turn; or you gain 2 life.\nEquip {2}",
             "colours": [],
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "670f1af5-e33b-583e-ab46-fe2270b03f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc33a21-d196-4c17-a296-87ff08e7ef69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc33a21-d196-4c17-a296-87ff08e7ef69.jpg?1",
             "name": "Gods' Eye, Gate to the Reikai",
             "text": "{T}: Add {1} to your mana pool.\nWhen Gods' Eye, Gate to the Reikai is put into a graveyard from play, put a 1/1 colorless Spirit creature token into play.",
             "colours": [],
@@ -5775,7 +5775,7 @@
         },
         {
             "id": "34e99f42-adcb-5c48-9ab8-433a5b351d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d246f521-b9a0-4b4f-b38c-0e4eb4066212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d246f521-b9a0-4b4f-b38c-0e4eb4066212.jpg?1",
             "name": "Tendo Ice Bridge",
             "text": "Tendo Ice Bridge comes into play with a charge counter on it.\n{T}: Add {1} to your mana pool.\n{T}, Remove a charge counter from Tendo Ice Bridge: Add one mana of any color to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/BRO.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/BRO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6ff98307-b89c-5a43-bc3c-3f81d803617d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a62bb2-bc33-44d4-9a7e-92c9ea7d3c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a62bb2-bc33-44d4-9a7e-92c9ea7d3c2c.jpg?1",
             "name": "Aeronaut Cavalry",
             "text": "Flying\nWhen Aeronaut Cavalry enters the battlefield, put a +1/+1 counter on another target Soldier you control.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "e4d66ec1-7ba2-5c80-a9c1-e33500cfdbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad55575-6053-43b1-9496-bcb1ea25e2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad55575-6053-43b1-9496-bcb1ea25e2a1.jpg?1",
             "name": "Airlift Chaplain",
             "text": "Flying\nWhen Airlift Chaplain enters the battlefield, mill three cards. You may put a Plains card or a creature card with mana value 3 or less from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Airlift Chaplain. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "8d065ec5-4e7f-50f6-92c8-277673a6fb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa00c0e-163d-4f59-b8b9-3ee9143d27bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa00c0e-163d-4f59-b8b9-3ee9143d27bb.jpg?1",
             "name": "Ambush Paratrooper",
             "text": "Flash\nFlying\n{5}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "45e16536-c429-54c9-906e-43b9f9ee83b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013bed2b-25db-4dfc-9283-e80c9ac6c841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013bed2b-25db-4dfc-9283-e80c9ac6c841.jpg?1",
             "name": "Calamity's Wake",
             "text": "Exile all graveyards. Players can't cast noncreature spells this turn. Exile Calamity's Wake.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "d184bcd7-1c35-558f-8fd4-c2065a349018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eca0ae-d400-4afb-9a45-7100f4cd7149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eca0ae-d400-4afb-9a45-7100f4cd7149.jpg?1",
             "name": "Deadly Riposte",
             "text": "Deadly Riposte deals 3 damage to target tapped creature and you gain 2 life.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "6efabf68-3dc3-5c60-9446-6525679733ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658c5caa-d739-4d30-a512-43ac4de900cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658c5caa-d739-4d30-a512-43ac4de900cb.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "51aecba1-d4b9-596f-9037-3ef33dca9816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc83d586-bf46-437f-a5a3-996bd62d5866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc83d586-bf46-437f-a5a3-996bd62d5866.jpg?1",
             "name": "Great Desert Prospector",
             "text": "When Great Desert Prospector enters the battlefield, create a tapped Powerstone token for each other creature you control. (They're artifacts with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "ada20bab-ada6-5bed-9d45-d87790233c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ff86e9-1ce6-43cc-8135-f2adb1b6c5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ff86e9-1ce6-43cc-8135-f2adb1b6c5a7.jpg?1",
             "name": "In the Trenches",
             "text": "Creatures you control get +1/+1.\n{5}{W}: Exile target nonland permanent you don't control until In the Trenches leaves the battlefield. Activate only as a sorcery and only once.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "64155ae3-130f-5da4-9360-ee9bb617e25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0737dbec-1646-41a0-adbf-706c9bd4fc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0737dbec-1646-41a0-adbf-706c9bd4fc7a.jpg?1",
             "name": "Kayla's Command",
             "text": "Choose two \u2014\n\u2022 Create a 2/2 colorless Construct artifact creature token.\n\u2022 Put a +1/+1 counter on a creature you control. It gains double strike until end of turn.\n\u2022 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n\u2022 You gain 2 life and scry 2.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "47fd005b-6e60-5024-a08a-428a150f89ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb84e72-0231-461a-a230-d8afa6e54289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb84e72-0231-461a-a230-d8afa6e54289.jpg?1",
             "name": "Kayla's Reconstruction",
             "text": "Look at the top seven cards of your library. Put up to X artifact and/or creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "75daa469-6ba9-5c9b-a5e3-9509cfb6cf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5649ee5a-4485-40a2-96d1-2e061905a71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5649ee5a-4485-40a2-96d1-2e061905a71e.jpg?1",
             "name": "Lay Down Arms",
             "text": "Exile target creature with mana value less than or equal to the number of Plains you control. Its controller gains 3 life.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "04e54bdf-b04f-52d8-8503-4ca1fce8688e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59faa45d-868b-4bc7-934c-0e077642e129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59faa45d-868b-4bc7-934c-0e077642e129.jpg?1",
             "name": "Loran of the Third Path",
             "text": "Vigilance\nWhen Loran of the Third Path enters the battlefield, destroy up to one target artifact or enchantment.\n{T}: You and target opponent each draw a card.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "7fba79dd-5f55-5549-9e57-d99aaddea2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9998f898-1f08-481b-8505-b890f0fec5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9998f898-1f08-481b-8505-b890f0fec5e0.jpg?1",
             "name": "Loran, Disciple of History",
             "text": "Whenever Loran, Disciple of History or another legendary creature enters the battlefield under your control, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "ec4978dd-5363-5d7c-8ce2-27406d933598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3765610d-a0c1-4de9-a81b-ffa3eb06454b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3765610d-a0c1-4de9-a81b-ffa3eb06454b.jpg?1",
             "name": "Loran's Escape",
             "text": "Target artifact or creature gains hexproof and indestructible until end of turn. Scry 1.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "750e9798-2294-5b8f-9022-e90b37f8e65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a08b7-dd30-446e-a8a7-2e084bbb9586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a08b7-dd30-446e-a8a7-2e084bbb9586.jpg?1",
             "name": "Mass Production",
             "text": "Create four 1/1 colorless Soldier artifact creature tokens.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "8c24486d-4d6b-5c3e-a78a-26057db06745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811461a-6a90-416f-940c-c9579659ae0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811461a-6a90-416f-940c-c9579659ae0c.jpg?1",
             "name": "Meticulous Excavation",
             "text": "{2}{W}: Return target permanent you control to its owner's hand. If it has unearth, instead exile it, then return that card to its owner's hand. Activate only during your turn.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "082e9de2-d7d0-59d7-8dbf-c7bf8a8509ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94778e17-87c4-4765-b2f0-40455069f2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94778e17-87c4-4765-b2f0-40455069f2c4.jpg?1",
             "name": "Military Discipline",
             "text": "Flash\nEnchant creature\nWhen Military Discipline enters the battlefield, enchanted creature gains first strike until end of turn.\nEnchanted creature gets +1/+0.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "7e666059-3fbc-59ca-ade0-0ed75abb1584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e632ed57-bb00-4493-adef-7b4805edd7ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e632ed57-bb00-4493-adef-7b4805edd7ea.jpg?1",
             "name": "Myrel, Shield of Argive",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.\nWhenever Myrel, Shield of Argive attacks, create X 1/1 colorless Soldier artifact creature tokens, where X is the number of Soldiers you control.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "5fbfd67f-dd8a-5e5c-9a83-93701d1ccf49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abe2af7-deba-4569-822a-2d9309aeaadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abe2af7-deba-4569-822a-2d9309aeaadd.jpg?1",
             "name": "Phalanx Vanguard",
             "text": "Vigilance\nWhenever an artifact enters the battlefield under your control, Phalanx Vanguard gets +1/+0 until end of turn.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "0b629b0e-376d-5259-a000-308f8cdf0dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2901c5f6-5d83-437d-b434-d9beb115dd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2901c5f6-5d83-437d-b434-d9beb115dd82.jpg?1",
             "name": "Powerstone Engineer",
             "text": "When Powerstone Engineer dies, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "047b6ef3-a654-5d6c-8378-057d3555c403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76832ca8-95b2-4bc8-a191-9e2f50b77626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76832ca8-95b2-4bc8-a191-9e2f50b77626.jpg?1",
             "name": "Prison Sentence",
             "text": "Enchant creature\nWhen Prison Sentence enters the battlefield, scry 2.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -725,7 +725,7 @@
         },
         {
             "id": "afbdb5e1-6bcf-5953-867f-e7611515ba93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a64e330-1257-4ec3-9a75-889cdcac3ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a64e330-1257-4ec3-9a75-889cdcac3ade.jpg?1",
             "name": "Recommission",
             "text": "Return target artifact or creature card with mana value 3 or less from your graveyard to the battlefield. If a creature enters the battlefield this way, it enters with an additional +1/+1 counter on it.",
             "colours": [
@@ -757,7 +757,7 @@
         },
         {
             "id": "9e9dbe89-2cd8-5e3c-9e2f-09f7171993aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c226656b-68d5-4df2-b313-a323a728c520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c226656b-68d5-4df2-b313-a323a728c520.jpg?1",
             "name": "Recruitment Officer",
             "text": "{3}{W}: Look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -792,7 +792,7 @@
         },
         {
             "id": "6473c629-d525-55ca-b36d-0d0abaa9d8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff4a4b-4e86-41d1-a6b6-312aac0d3e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ff4a4b-4e86-41d1-a6b6-312aac0d3e1a.jpg?1",
             "name": "Repair and Recharge",
             "text": "Return target artifact, enchantment, or planeswalker card from your graveyard to the battlefield. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "b6be96d4-e937-59b7-bd1b-a1edf15e3eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57e2a32-6e52-4f6e-96ec-55f5b7ba77e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57e2a32-6e52-4f6e-96ec-55f5b7ba77e0.jpg?1",
             "name": "Siege Veteran",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\nWhenever another nontoken Soldier you control dies, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "c26dd17d-fdbc-5c78-bc0e-75037167eeee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bb8ec0-9729-4aa1-8ce4-a3a5598b0d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bb8ec0-9729-4aa1-8ce4-a3a5598b0d70.jpg?1",
             "name": "Soul Partition",
             "text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may play it. A spell cast by an opponent this way costs {2} more to cast.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "09371945-5baf-5ec4-8f9c-7836bfe41789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab5cb30-3ced-4450-a3c4-b519f3762620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab5cb30-3ced-4450-a3c4-b519f3762620.jpg?1",
             "name": "Static Net",
             "text": "When Static Net enters the battlefield, exile target nonland permanent an opponent controls until Static Net leaves the battlefield.\nWhen Static Net enters the battlefield, you gain 2 life and create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -927,7 +927,7 @@
         },
         {
             "id": "81154bf5-29b5-559b-adad-9e73fe6fd62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817bcc8d-a5b7-448c-a3eb-825dc65944ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817bcc8d-a5b7-448c-a3eb-825dc65944ec.jpg?1",
             "name": "Survivor of Korlis",
             "text": "First strike\n{1}{W}, Exile Survivor of Korlis from your graveyard: Scry 2.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "52ac19cc-f469-59cc-bac2-21a416227986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61017325-cec0-46ac-aa32-5855e5904888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61017325-cec0-46ac-aa32-5855e5904888.jpg?1",
             "name": "Thopter Architect",
             "text": "Whenever an artifact enters the battlefield under your control, target creature gains flying until end of turn.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "7d046c74-975d-5346-bdb9-6a5b562dcc06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cd89f1-f9f4-4cb5-a573-79809d0b6dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cd89f1-f9f4-4cb5-a573-79809d0b6dfd.jpg?1",
             "name": "Tocasia's Welcome",
             "text": "Whenever one or more creatures with mana value 3 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "6d5efcac-b2df-57d9-b0f0-a69d3e909994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486a0745-7360-4cc9-9cc2-30c0eda6e00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486a0745-7360-4cc9-9cc2-30c0eda6e00c.jpg?1",
             "name": "Union of the Third Path",
             "text": "Draw a card, then you gain life equal to the number of cards in your hand.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "a4aa5ae5-0639-5ff9-adce-76f84c188bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873cc9e-30b6-498e-b008-9d11a8bbf9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873cc9e-30b6-498e-b008-9d11a8bbf9b9.jpg?1",
             "name": "Warlord's Elite",
             "text": "As an additional cost to cast this spell, tap two untapped artifacts, creatures, and/or lands you control.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "bfdcdca9-9049-55ab-835a-2d0014f37f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b9c48-6eca-4677-961b-614f5ec594ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21b9c48-6eca-4677-961b-614f5ec594ce.jpg?1",
             "name": "Yotian Medic",
             "text": "Lifelink",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "5530e090-4ccf-5586-820f-155ef62f98dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dee863-e6ef-4061-a877-ddd3c4dbe87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dee863-e6ef-4061-a877-ddd3c4dbe87e.jpg?1",
             "name": "Autonomous Assembler",
             "text": "Vigilance\n{1}, {T}: Put a +1/+1 counter on target Assembly-Worker you control.\n//PRT-Prototype_\nMech//\n{1}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "3fd79852-cf48-50bb-90b8-15ddc84ef25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dfabfd-e13b-4512-a733-abe514be6404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dfabfd-e13b-4512-a733-abe514be6404.jpg?1",
             "name": "Combat Thresher",
             "text": "Double strike\nWhen Combat Thresher enters the battlefield, draw a card.\n//PRT-Prototype_\nMech//\n{2}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/1",
             "colours": [],
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "26fa24a0-20f0-525c-903b-d50a0e0aa680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4825e3-c549-4bcb-84b5-2d0782c5c4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4825e3-c549-4bcb-84b5-2d0782c5c4e5.jpg?1",
             "name": "Platoon Dispenser",
             "text": "At the beginning of your end step, if you control two or more other creatures, draw a card.\n{3}{W}: Create a 1/1 colorless Soldier artifact creature token.\nUnearth {2}{W}{W}",
             "colours": [],
@@ -1237,7 +1237,7 @@
         },
         {
             "id": "7b7d0872-b1c9-5f44-94a2-309fca1b2c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b0f17e-603a-4840-b2c3-381ec6f102f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b0f17e-603a-4840-b2c3-381ec6f102f3.jpg?1",
             "name": "Scrapwork Cohort",
             "text": "When Scrapwork Cohort enters the battlefield, create a 1/1 colorless Soldier artifact creature token.\nUnearth {2}{W} ({2}{W}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -1270,7 +1270,7 @@
         },
         {
             "id": "d9f29611-757d-594b-85d4-b6b6e0359e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ef5f5-4058-4f89-a573-9e2da87a9f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ef5f5-4058-4f89-a573-9e2da87a9f2e.jpg?1",
             "name": "Steel Seraph",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gains your choice of flying, vigilance, or lifelink until end of turn.\n//PRT-Prototype_\nMech//\n{1}{W}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "8ac41de4-ab58-52eb-8dbf-6d1ee421ce35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4abf2fb-f78a-4e75-b46f-524d3d7405db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4abf2fb-f78a-4e75-b46f-524d3d7405db.jpg?1",
             "name": "Tocasia's Onulet",
             "text": "When Tocasia's Onulet leaves the battlefield, you gain 2 life.\nUnearth {3}{W} ({3}{W}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -1338,7 +1338,7 @@
         },
         {
             "id": "4690bfdc-d744-562f-ae90-4151108eb0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3000d1c6-dbb3-4e65-b428-dbf167bb8797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3000d1c6-dbb3-4e65-b428-dbf167bb8797.jpg?1",
             "name": "Urza's Sylex",
             "text": "{2}{W}{W}, {T}, Exile Urza's Sylex: Each player chooses six lands they control. Destroy all other permanents. Activate only as a sorcery.\nWhen Urza's Sylex is put into exile from the battlefield, you may pay {2}. If you do, search your library for a planeswalker card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -1372,7 +1372,7 @@
         },
         {
             "id": "4cb62e4e-d548-57c6-b130-da8f8e0599fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d823e1-a7d6-4296-94c8-b8ba9b4daa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d823e1-a7d6-4296-94c8-b8ba9b4daa38.jpg?1",
             "name": "Veteran's Powerblade",
             "text": "Equipped creature gets +2/+0.\nEquip Soldier {W}\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "6249d867-06d9-5d40-b0d3-53281b51ca7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa05d1e-6728-4e77-bfb2-da0b9598e44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa05d1e-6728-4e77-bfb2-da0b9598e44b.jpg?1",
             "name": "Yotian Frontliner",
             "text": "Whenever Yotian Frontliner attacks, another target creature you control gets +1/+1 until end of turn.\nUnearth {W} ({W}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "9e0911c6-a7cf-577b-ab8f-c539c2565c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991e1a6c-914b-45c8-9170-c09e72696117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991e1a6c-914b-45c8-9170-c09e72696117.jpg?1",
             "name": "Air Marshal",
             "text": "{3}: Target Soldier gains flying until end of turn.",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "4e78becd-1c9b-552d-a630-af3d48c28a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8c3fc8-c1cc-4dfc-94cb-1538bff9d09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8c3fc8-c1cc-4dfc-94cb-1538bff9d09a.jpg?1",
             "name": "Curate",
             "text": "Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nDraw a card.",
             "colours": [
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "24a41773-df24-5ee8-8b13-136c4e1e2d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd32168-0b9c-4633-adec-d41cf125cc35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd32168-0b9c-4633-adec-d41cf125cc35.jpg?1",
             "name": "Defabricate",
             "text": "Choose one \u2014\n\u2022 Counter target artifact or enchantment spell. If a spell is countered this way, exile it instead of putting it into its owner's graveyard.\n\u2022 Counter target activated or triggered ability.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "ea8c71d1-140e-5763-8e18-e6c704cdc2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e101e5-2b20-48dd-aac4-15a3c32a7441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e101e5-2b20-48dd-aac4-15a3c32a7441.jpg?1",
             "name": "Desynchronize",
             "text": "Target nonland permanent's owner puts it on the top or bottom of their library. Scry 2.",
             "colours": [
@@ -1568,7 +1568,7 @@
         },
         {
             "id": "0774f54e-77f9-5aa3-bf8d-0a542c420607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7355905-2b3b-4191-a89c-a0fc1494928b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7355905-2b3b-4191-a89c-a0fc1494928b.jpg?1",
             "name": "Drafna, Founder of Lat-Nam",
             "text": "{1}{U}: Return target artifact you control to its owner's hand.\n{3}, {T}: Copy target artifact spell you control. (The copy becomes a token.)",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "9b10b4f9-a266-574f-a26a-29737fcf6316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eab397-25a6-4377-8e12-e8acef9675cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eab397-25a6-4377-8e12-e8acef9675cf.jpg?1",
             "name": "Fallaji Archaeologist",
             "text": "When Fallaji Archaeologist enters the battlefield, mill three cards. You may put a noncreature, nonland card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Fallaji Archaeologist. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "eac32d48-3333-5a71-8c03-a62bedebfd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea316f3-4a68-4cd4-a388-da9d0455d0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea316f3-4a68-4cd4-a388-da9d0455d0a9.jpg?1",
             "name": "Flow of Knowledge",
             "text": "Draw a card for each Island you control, then discard two cards.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "7208c427-c7cd-5062-a864-a0408f593fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057f6add-1f1d-4cce-9c9d-5e59fb74d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057f6add-1f1d-4cce-9c9d-5e59fb74d78e.jpg?1",
             "name": "Forging the Anchor",
             "text": "Look at the top five cards of your library. You may reveal any number of artifact cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "d8a5211c-798e-5ac8-b096-ff71914c06fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcee066-425f-4341-bde5-13a5bdf06f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcee066-425f-4341-bde5-13a5bdf06f2a.jpg?1",
             "name": "Hurkyl, Master Wizard",
             "text": "At the beginning of your end step, if you've cast a noncreature spell this turn, reveal the top five cards of your library. For each card type among noncreature spells you've cast this turn, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "9c5059ff-b8f5-5005-8172-25c21cf3a8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577f345-9577-42f8-b244-089b9a7c2e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577f345-9577-42f8-b244-089b9a7c2e56.jpg?1",
             "name": "Hurkyl's Final Meditation",
             "text": "As long as it's not your turn, this spell costs {3} more to cast.\nReturn all nonland permanents to their owners' hands. End the turn. (Exile all spells and abilities from the stack, including this card. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "5f337d77-c71c-53a2-b97e-96e76fe93a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fcaf6d-6491-4459-98b0-b3c7d43df59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fcaf6d-6491-4459-98b0-b3c7d43df59e.jpg?1",
             "name": "Involuntary Cooldown",
             "text": "Tap up to two target artifacts and/or creatures. Put two stun counters on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "bb2294ea-049d-5ae0-a51d-848a29dbc4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09200388-47c9-4472-ac9e-98f57653e084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09200388-47c9-4472-ac9e-98f57653e084.jpg?1",
             "name": "Keeper of the Cadence",
             "text": "{3}: Put target artifact, instant, or sorcery card from a graveyard on the bottom of its owner's library.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "00b98aba-64c7-5ed2-b913-ec4d8220cd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdbcb87-c6ea-477f-a560-c175d99e21b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdbcb87-c6ea-477f-a560-c175d99e21b8.jpg?1",
             "name": "Koilos Roc",
             "text": "Flash\nFlying\nWhen Koilos Roc enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "4f8688b3-9df6-50f0-94f4-7d873db143bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e088de-e99f-4706-89e0-a7efdaf9403a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e088de-e99f-4706-89e0-a7efdaf9403a.jpg?1",
             "name": "Lat-Nam Adept",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on Lat-Nam Adept.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "738721a0-c730-508d-ac2d-86be3d63c80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08eadf5-a86d-4e8d-b65d-79b4f88477b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08eadf5-a86d-4e8d-b65d-79b4f88477b9.jpg?1",
             "name": "Machine Over Matter",
             "text": "This spell costs {1} less to cast if you control an artifact creature.\nReturn target nonland permanent to its owner's hand.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "1d8cbd80-5292-5212-86dc-3f5547e5eedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c540e42-22e2-4127-bbd9-2e9200023fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c540e42-22e2-4127-bbd9-2e9200023fec.jpg?1",
             "name": "Mightstone's Animation",
             "text": "Enchant artifact\nWhen Mightstone's Animation enters the battlefield, draw a card.\nEnchanted artifact is a creature with base power and toughness 4/4 in addition to its other types.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "91f74e4d-1391-53fe-a12b-20f721a6a813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7868529f-8abb-4b1d-9c04-e628f81e08d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7868529f-8abb-4b1d-9c04-e628f81e08d2.jpg?1",
             "name": "One with the Multiverse",
             "text": "You may look at the top card of your library any time.\nYou may play lands and cast spells from the top of your library.\nOnce during each of your turns, you may cast a spell from your hand or the top of your library without paying its mana cost.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "2366b4b7-b042-5b9b-b52c-df6c99d4ee82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333a7b1-936e-42f3-ba22-2c76dd2f1c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333a7b1-936e-42f3-ba22-2c76dd2f1c9a.jpg?1",
             "name": "Retrieval Agent",
             "text": "{2}: Retrieval Agent gets +1/-1 until end of turn.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "b137f7d6-407d-5802-a771-48908e2aecc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2852c9-d566-4824-836a-2f4c7a5148a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2852c9-d566-4824-836a-2f4c7a5148a1.jpg?1",
             "name": "Scatter Ray",
             "text": "Counter target artifact or creature spell unless its controller pays {4}.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "8a42bf3e-cdc4-53a1-8563-df025b229066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925fa343-d9c3-4ed9-bd1f-aaa31c0badd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925fa343-d9c3-4ed9-bd1f-aaa31c0badd7.jpg?1",
             "name": "Skystrike Officer",
             "text": "Flying\nWhenever Skystrike Officer attacks, create a 1/1 colorless Soldier artifact creature token.\nTap three untapped Soldiers you control: Draw a card.",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "9ae558eb-5fc1-5d96-8a27-7ca1723003cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569dab90-a0d8-4c0a-8e32-b2cb3aec39a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569dab90-a0d8-4c0a-8e32-b2cb3aec39a6.jpg?1",
             "name": "Splitting the Powerstone",
             "text": "As an additional cost to cast this spell, sacrifice an artifact.\nCreate two tapped Powerstone tokens. If the sacrificed artifact was legendary, draw a card. (The tokens are artifacts with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "3eee28ec-10fb-5f37-9abc-6b6a7a6463ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151caa2-10ed-4f30-83eb-cd1bd3f642ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151caa2-10ed-4f30-83eb-cd1bd3f642ce.jpg?1",
             "name": "Stern Lesson",
             "text": "Draw two cards, then discard a card. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "33fd266e-62df-5296-a2d5-322b216670a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2108e-e45e-4b21-a03b-5f644b6043be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2108e-e45e-4b21-a03b-5f644b6043be.jpg?1",
             "name": "Take Flight",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has flying and \"Whenever this creature attacks, draw a card.\"",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "835faa90-e4a1-5564-a88e-6b61c63f70d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4f1ec-eadf-4f1e-8821-f22293ad2580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4f1ec-eadf-4f1e-8821-f22293ad2580.jpg?1",
             "name": "Teferi, Temporal Pilgrim",
             "text": "Whenever you draw a card, put a loyalty counter on Teferi, Temporal Pilgrim.\n0: Draw a card.\n\u22122: Create a 2/2 blue Spirit creature token with vigilance and \"Whenever you draw a card, put a +1/+1 counter on this creature.\"\n\u221212: Target opponent chooses a permanent they control and returns it to its owner's hand. Then they shuffle each nonland permanent they control into its owner's library.",
             "colours": [
@@ -2259,7 +2259,7 @@
         },
         {
             "id": "b70f3d29-fdf8-5203-8adc-51c918e2fdbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793a51ab-59fb-424f-a315-3f63e8990322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793a51ab-59fb-424f-a315-3f63e8990322.jpg?1",
             "name": "Third Path Savant",
             "text": "{7}: Draw two cards.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "0aa26dee-74d7-504a-a080-7af3dce0ada1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577b5c7-91ed-4201-bdfd-0919142124eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577b5c7-91ed-4201-bdfd-0919142124eb.jpg?1",
             "name": "Thopter Mechanic",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on Thopter Mechanic.\nWhen Thopter Mechanic dies, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -2329,7 +2329,7 @@
         },
         {
             "id": "8bae54a4-9288-5ea9-aa63-b1628df29522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445f897e-a059-4cd5-bfd2-302dc7a4c8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445f897e-a059-4cd5-bfd2-302dc7a4c8e2.jpg?1",
             "name": "Urza, Powerstone Prodigy",
             "text": "Vigilance\n{1}, {T}: Draw a card, then discard a card.\nWhenever you discard one or more artifact cards, create a tapped Powerstone token. This ability triggers only once each turn. (The token is an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "0f4988ce-d720-536c-a7e8-b237e474f5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b4a02c-e57f-4287-943e-6bc859ac149e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b4a02c-e57f-4287-943e-6bc859ac149e.jpg?1",
             "name": "Urza's Command",
             "text": "Choose two \u2014\n\u2022 Creatures you don't control get -2/-0 until end of turn.\n\u2022 Create a tapped Powerstone token.\n\u2022 Create a tapped 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\n\u2022 Scry 1, then draw a card.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "1130add5-7160-5229-8478-4914bb83cd8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6f90b3-450c-490a-b6d0-2393c4646c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6f90b3-450c-490a-b6d0-2393c4646c85.jpg?1",
             "name": "Urza's Rebuff",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Tap up to two target creatures.",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "aadf7223-9df6-541d-8c72-64d2b6335aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef93ac79-8575-40f8-a222-63c2ffb30f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef93ac79-8575-40f8-a222-63c2ffb30f60.jpg?1",
             "name": "Weakstone's Subjugation",
             "text": "Enchant artifact or creature\nWhen Weakstone's Subjugation enters the battlefield, you may pay {3}. If you do, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "968b7463-a420-590b-a0cb-2c2292248804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e640c3-02bb-453c-a609-05d8214e2e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e640c3-02bb-453c-a609-05d8214e2e2e.jpg?1",
             "name": "Wing Commando",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "429a6c4c-de20-5bbd-af08-e3938f47441d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935adbb-d2e3-48d0-b38c-41f3b583fecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935adbb-d2e3-48d0-b38c-41f3b583fecb.jpg?1",
             "name": "Zephyr Sentinel",
             "text": "Flash\nFlying\nWhen Zephyr Sentinel enters the battlefield, return up to one other target creature you control to its owner's hand. If it was a Soldier, put a +1/+1 counter on Zephyr Sentinel.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "7047d44f-0eb7-5a0b-9a2b-7ef51448bb16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d74d2e-7382-4fe3-ac3e-6906203ffcc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d74d2e-7382-4fe3-ac3e-6906203ffcc7.jpg?1",
             "name": "Arcane Proxy",
             "text": "When Arcane Proxy enters the battlefield, if you cast it, exile target instant or sorcery card with mana value less than or equal to Arcane Proxy's power from your graveyard. Copy that card. You may cast the copy without paying its mana cost.\n//PRT-Prototype_\nMech//\n{1}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/1",
             "colours": [],
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "19e99524-d1f6-5fd2-a771-02c3bff68e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24567f8-d195-4547-bba4-7a8131dc7889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24567f8-d195-4547-bba4-7a8131dc7889.jpg?1",
             "name": "Coastal Bulwark",
             "text": "Defender\nCoastal Bulwark gets +2/+0 as long as you control an Island.\n{2}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [],
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "15f083e6-50d8-5ae8-a989-e9ae292d5dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171edf80-ffc1-4894-9be5-c3e93a96f734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171edf80-ffc1-4894-9be5-c3e93a96f734.jpg?1",
             "name": "Combat Courier",
             "text": "{2}, Sacrifice Combat Courier: Draw a card.\nUnearth {U} ({U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "49a88f40-39fe-5132-8ea3-8723902b2799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e09173-a92d-4cc3-9d02-bf18ab0850ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e09173-a92d-4cc3-9d02-bf18ab0850ec.jpg?1",
             "name": "Depth Charge Colossus",
             "text": "Depth Charge Colossus doesn't untap during your untap step.\n{3}: Untap Depth Charge Colossus.\n//PRT-Prototype_\nMech//\n{4}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n6/6",
             "colours": [],
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "019970ca-fe45-5866-bc30-d7978b9ce8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f0b81-8b87-4854-9dc4-6da84cc38623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f0b81-8b87-4854-9dc4-6da84cc38623.jpg?1",
             "name": "Hulking Metamorph",
             "text": "You may have Hulking Metamorph enter the battlefield as a copy of an artifact or creature you control, except it's an artifact creature in addition to its other types, and its power and toughness are equal to Hulking Metamorph's power and toughness.\n//PRT-Prototype_\nMech//\n{2}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "9130bfbc-ce82-5bb0-bb01-b8d324281643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90175ae-4109-4845-b3ff-1531fb67a0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90175ae-4109-4845-b3ff-1531fb67a0e1.jpg?1",
             "name": "Spotter Thopter",
             "text": "Flying\nWhen Spotter Thopter enters the battlefield, scry X, where X is its power.\n//PRT-Prototype_\nMech//\n{3}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/3",
             "colours": [],
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "cb94121c-119f-599a-86d2-b3bb975c36ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c9c5-e992-4f1c-a779-124176c3aade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c9c5-e992-4f1c-a779-124176c3aade.jpg?1",
             "name": "Surge Engine",
             "text": "Defender\n{U}: Surge Engine loses defender and gains \"This creature can't be blocked.\"\n{2}{U}: Surge Engine becomes blue and has base power and toughness 5/4. Activate only if Surge Engine doesn't have defender.\n{4}{U}{U}: Draw three cards. Activate only if Surge Engine is blue and only once.",
             "colours": [],
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "48ae69fb-5a74-5ce1-ab9b-27f0380c2f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a212d59-b72e-4939-a757-c131ca4323ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a212d59-b72e-4939-a757-c131ca4323ce.jpg?1",
             "name": "The Temporal Anchor",
             "text": "At the beginning of your upkeep, scry 2.\nWhenever you choose to put one or more cards on the bottom of your library while scrying, exile that many cards from the bottom of your library.\nDuring your turn, you may play cards exiled with The Temporal Anchor.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "4fec2fa3-1a45-52f1-8b81-24c0d1239793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd86daf-7cee-454c-8d4d-97f59fe36958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd86daf-7cee-454c-8d4d-97f59fe36958.jpg?1",
             "name": "Terisian Mindbreaker",
             "text": "Whenever Terisian Mindbreaker attacks, defending player mills half their library, rounded up.\nUnearth {1}{U}{U}{U} ({1}{U}{U}{U}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "ee495376-282a-5d74-9c39-c6dea2be21ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb43c15-50a9-488f-b0be-84a5e0a6d10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb43c15-50a9-488f-b0be-84a5e0a6d10b.jpg?1",
             "name": "Ashnod, Flesh Mechanist",
             "text": "Deathtouch\nWhenever Ashnod, Flesh Mechanist attacks, you may sacrifice another creature. If you do, create a tapped Powerstone token.\n{5}, Exile a creature card from your graveyard: Create a tapped 3/3 colorless Zombie artifact creature token.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "feb12e81-c070-5a1c-b96e-178a908b34f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf491db-d12b-4c58-9c05-085cac34a73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf491db-d12b-4c58-9c05-085cac34a73e.jpg?1",
             "name": "Ashnod's Intervention",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies or is put into exile from the battlefield, return it to its owner's hand.\"",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "6d208bed-b342-59e4-919c-94713a1b57aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c47e31-d4f6-46f3-94b7-1726c4a4a8eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c47e31-d4f6-46f3-94b7-1726c4a4a8eb.jpg?1",
             "name": "Battlefield Butcher",
             "text": "{5}, {T}: Each opponent loses 2 life. This ability costs {1} less to activate for each creature card in your graveyard.",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "1900591f-6ce8-57c8-8f1e-e44f1fff6da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759acb8-82c0-479f-86f3-f22ca7a2006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6759acb8-82c0-479f-86f3-f22ca7a2006c.jpg?1",
             "name": "Carrion Locust",
             "text": "Flying\nWhen Carrion Locust enters the battlefield, exile target card from an opponent's graveyard. If it was a creature card, that player loses 1 life.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "05d760c0-3e76-597c-9881-9f204d345d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ea561-80da-4fe1-ad87-ce47d9eb80bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ea561-80da-4fe1-ad87-ce47d9eb80bc.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "7c7b5d32-5d02-54d8-bd2d-14617045d866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72ab698-de67-4ca8-8e42-b05346bf52fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72ab698-de67-4ca8-8e42-b05346bf52fa.jpg?1",
             "name": "Diabolic Intent",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "29eb43ae-adbc-516e-835a-da3f9ecec5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d356456-865d-4c92-8923-ce7384e29a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d356456-865d-4c92-8923-ce7384e29a79.jpg?1",
             "name": "Disciples of Gix",
             "text": "When Disciples of Gix enters the battlefield, search your library for up to three artifact cards, put them into your graveyard, then shuffle.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "7989250b-642f-5867-b353-045e61465145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9c6f1-3938-448b-bdc3-22420c5984d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9c6f1-3938-448b-bdc3-22420c5984d3.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "dffa810f-3e01-592e-ba31-8cad64602e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ac92e-c61a-4c11-aa6a-9ae1cb703e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ac92e-c61a-4c11-aa6a-9ae1cb703e5c.jpg?1",
             "name": "Dreams of Steel and Oil",
             "text": "Target opponent reveals their hand. You choose an artifact or creature card from it, then choose an artifact or creature card from their graveyard. Exile the chosen cards.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "c96c9548-88e1-5f09-b75c-7385a1ae706e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec94d440-3922-4588-bf7b-d8670f81ef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec94d440-3922-4588-bf7b-d8670f81ef4e.jpg?1",
             "name": "Emergency Weld",
             "text": "Return target artifact or creature card from your graveyard to your hand. Create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "72b41357-920e-5eef-b950-407073dbf5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbed8f9-3615-428b-8d0d-18291c5a99be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbed8f9-3615-428b-8d0d-18291c5a99be.jpg?1",
             "name": "Fateful Handoff",
             "text": "Draw cards equal to the mana value of target artifact or creature you control. An opponent gains control of that permanent.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "e9b50125-62d1-5dea-bc7c-5ed5c1ca239c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c76f7e0-37e7-4e87-93a3-a25ba0674645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c76f7e0-37e7-4e87-93a3-a25ba0674645.jpg?1",
             "name": "Gix, Yawgmoth Praetor",
             "text": "Whenever a creature deals combat damage to one of your opponents, its controller may pay 1 life. If they do, they draw a card.\n{4}{B}{B}{B}, Discard X cards: Exile the top X cards of target opponent's library. You may play lands and cast spells from among cards exiled this way without paying their mana costs.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "5840eb1f-563f-546d-b532-a6e2b2386bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1140cb9-6c48-4054-966e-5cc02aa7d5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1140cb9-6c48-4054-966e-5cc02aa7d5a4.jpg?1",
             "name": "Gix's Caress",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nCreate a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "c9fdec83-848c-5f75-938a-51bcffa70524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606de75-c25f-411b-a271-258ac5a60987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9606de75-c25f-411b-a271-258ac5a60987.jpg?1",
             "name": "Gix's Command",
             "text": "Choose two \u2014\n\u2022 Put two +1/+1 counters on up to one creature. It gains lifelink until end of turn.\n\u2022 Destroy each creature with power 2 or less.\n\u2022 Return up to two creature cards from your graveyard to your hand.\n\u2022 Each opponent sacrifices a creature with the highest power among creatures they control.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "e0a113c6-8557-5796-8783-7ca191ff1cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a3317-7d1f-4f29-8353-180f1ab48d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a3317-7d1f-4f29-8353-180f1ab48d18.jpg?1",
             "name": "Gixian Infiltrator",
             "text": "Whenever you sacrifice another permanent, put a +1/+1 counter on Gixian Infiltrator.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "8525e87c-d49c-5ecf-840c-0e1674c96470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc86e18-ffbc-4c5f-a694-922332b146cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc86e18-ffbc-4c5f-a694-922332b146cc.jpg?1",
             "name": "Gixian Puppeteer",
             "text": "Whenever you draw your second card each turn, each opponent loses 2 life and you gain 2 life.\nWhen Gixian Puppeteer dies, return another target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "3e161a51-8262-5aae-b456-fa1f3e89f2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdcf02b-1876-44d7-8a22-679ea1272856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdcf02b-1876-44d7-8a22-679ea1272856.jpg?1",
             "name": "Gixian Skullflayer",
             "text": "At the beginning of your upkeep, if there are three or more creature cards in your graveyard, put a +1/+1 counter on Gixian Skullflayer.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "d934252a-9310-51b2-8934-7f8209deb5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa2fa48-ddb7-45f0-b183-4186df98f7cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa2fa48-ddb7-45f0-b183-4186df98f7cc.jpg?1",
             "name": "Gnawing Vermin",
             "text": "When Gnawing Vermin enters the battlefield, target player mills two cards.\nWhen Gnawing Vermin dies, target creature you don't control gets -1/-1 until end of turn.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "67542236-53d8-5f03-bdf4-0b100361890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94117b09-d852-4f2e-be8e-68ee0ee3c3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94117b09-d852-4f2e-be8e-68ee0ee3c3d8.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "cdb0ebd6-e07a-5e88-8eb7-a45eb09c8d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cd0ece-a267-42ab-b95a-6e7931bd837a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cd0ece-a267-42ab-b95a-6e7931bd837a.jpg?1",
             "name": "Gruesome Realization",
             "text": "Choose one \u2014\n\u2022 You draw two cards and you lose 2 life.\n\u2022 Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "06ac58c4-0646-5424-a9b7-c73b1a4990d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0d139-2bea-48df-a007-cee7c8ce07bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0d139-2bea-48df-a007-cee7c8ce07bd.jpg?1",
             "name": "Gurgling Anointer",
             "text": "Flying\nWhenever you draw your second card each turn, put a +1/+1 counter on Gurgling Anointer.\nWhen Gurgling Anointer dies, return another target creature card with mana value less than or equal to Gurgling Anointer's power from your graveyard to the battlefield.",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "209c7eb3-cc3c-560f-b734-14c567184d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f827a9a0-7b72-49e2-85fa-adcce1e8fdda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f827a9a0-7b72-49e2-85fa-adcce1e8fdda.jpg?1",
             "name": "Hostile Negotiations",
             "text": "Exile the top three cards of your library in a face-down pile, then exile the top three cards of your library in another face-down pile. Look at the cards in each pile, then turn a pile of your choice face up. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. You lose 3 life.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "186ddb34-0355-5c13-b6ed-2c28d1a38ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f97974-bb65-46b0-a710-12fa4b9343ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f97974-bb65-46b0-a710-12fa4b9343ac.jpg?1",
             "name": "Kill-Zone Acrobat",
             "text": "Whenever Kill-Zone Acrobat attacks, you may sacrifice another creature or artifact. If you do, Kill-Zone Acrobat gains flying until end of turn.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "f4f98343-a7e3-5c64-9e09-39ee25c248e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c5e77-9ecc-41c9-b104-76343601fafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c5e77-9ecc-41c9-b104-76343601fafb.jpg?1",
             "name": "Misery's Shadow",
             "text": "If a creature an opponent controls would die, exile it instead.\n{1}: Misery's Shadow gets +1/+1 until end of turn.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "78b1e3b4-256b-5657-82d5-af3431c17d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e99fb27-a1e9-491f-ab2a-3ccb493168cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e99fb27-a1e9-491f-ab2a-3ccb493168cb.jpg?1",
             "name": "Moment of Defiance",
             "text": "Target creature gets +2/+1 and gains lifelink until end of turn.\nDraw a card.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "a188e94b-90ab-53f0-b052-ff841258730b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7e030c-98d1-452c-8020-cd92a3ef02c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7e030c-98d1-452c-8020-cd92a3ef02c3.jpg?1",
             "name": "No One Left Behind",
             "text": "This spell costs {3} less to cast if it targets a creature card with mana value 3 or less.\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "080beaae-6561-5edd-b687-da779a3a85ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202cbfa4-3b3d-47fd-84a6-892692c906d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202cbfa4-3b3d-47fd-84a6-892692c906d6.jpg?1",
             "name": "Overwhelming Remorse",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nExile target creature or planeswalker.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "4ee85284-88e4-5168-aa63-9ab8cb74c7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed5e030-874f-4a00-8544-78ba04033f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed5e030-874f-4a00-8544-78ba04033f53.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless they discard a card.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "94c34e6e-a652-5351-ab53-f16a6358afc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323301f-565a-4c0f-bffd-18386ccd1f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323301f-565a-4c0f-bffd-18386ccd1f7a.jpg?1",
             "name": "Powerstone Fracture",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "912af102-4fc5-510f-83fc-99f62841b6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fee3328-75c2-4d13-86e1-bf3a40fbf538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fee3328-75c2-4d13-86e1-bf3a40fbf538.jpg?1",
             "name": "Ravenous Gigamole",
             "text": "When Ravenous Gigamole enters the battlefield, mill three cards. You may put a creature card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Ravenous Gigamole. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "9d287ad5-77e3-5ab8-a3c2-0d32032e25b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faed400-0712-4fc1-b710-144db40a5e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faed400-0712-4fc1-b710-144db40a5e11.jpg?1",
             "name": "Thran Vigil",
             "text": "Whenever one or more artifact and/or creature cards leave your graveyard during your turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "055805a3-7883-5fc0-b8de-c03af6d48525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc59ca3b-d417-4cf2-99a3-89816bf2bd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc59ca3b-d417-4cf2-99a3-89816bf2bd09.jpg?1",
             "name": "Thraxodemon",
             "text": "{3}, {T}, Sacrifice another creature or artifact: Draw a card.",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "3e21addf-0613-56bb-bc9a-3043ccb3cb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1b987a-a3b9-4cd1-85b0-e58df4130934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1b987a-a3b9-4cd1-85b0-e58df4130934.jpg?1",
             "name": "Trench Stalker",
             "text": "As long as you've drawn two or more cards this turn, Trench Stalker has deathtouch and lifelink.",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "b712d4de-7f45-5c43-9762-43886a709ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58baa977-16c1-4983-8343-dbd65e98ddb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58baa977-16c1-4983-8343-dbd65e98ddb7.jpg?1",
             "name": "Ashnod's Harvester",
             "text": "Whenever Ashnod's Harvester attacks, exile target card from a graveyard.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "5c159b6b-bc26-5704-870e-fae650100a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc295bac-5031-46c8-8d9a-368656bcf6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc295bac-5031-46c8-8d9a-368656bcf6d3.jpg?1",
             "name": "Clay Revenant",
             "text": "Clay Revenant enters the battlefield tapped.\n{2}{B}: Return Clay Revenant from your graveyard to your hand.",
             "colours": [],
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "afd6f93b-9f42-5bf5-8020-bd4961dbb56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e133a2-631f-43f6-9fdd-e542d4d15e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e133a2-631f-43f6-9fdd-e542d4d15e10.jpg?1",
             "name": "Dredging Claw",
             "text": "Equipped creature gets +1/+0 and has menace. (It can't be blocked except by two or more creatures.)\nWhenever a creature enters the battlefield from your graveyard, you may attach Dredging Claw to it.\nEquip {1}{B} ({1}{B}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "e0d3fa69-dd19-5086-9ba2-d25997a9a240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d927dfd-ae66-4235-a61b-39c85d0c1222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d927dfd-ae66-4235-a61b-39c85d0c1222.jpg?1",
             "name": "Goring Warplow",
             "text": "Deathtouch\n//PRT-Prototype_\nMech//\n{1}{B}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/1",
             "colours": [],
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "a2729f74-a4cd-5e76-b2b7-2c7552ce41d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d37423-3445-412a-9abd-0480da404637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d37423-3445-412a-9abd-0480da404637.jpg?1",
             "name": "Phyrexian Fleshgorger",
             "text": "Menace, lifelink\nWard\u2014\nPay life equal to Phyrexian Fleshgorger's power.\n//PRT-Prototype_\nMech//\n{1}{B}{B}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "c6dc221e-bf69-5e21-8878-610217966484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfaf8cc-7819-4ec2-8d79-e3b0c1814590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfaf8cc-7819-4ec2-8d79-e3b0c1814590.jpg?1",
             "name": "Razorlash Transmogrant",
             "text": "Razorlash Transmogrant can't block.\n{4}{B}{B}: Return Razorlash Transmogrant from your graveyard to the battlefield with a +1/+1 counter on it. This ability costs {4} less to activate if an opponent controls four or more nonbasic lands.",
             "colours": [],
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "cf3cea5e-c033-5414-9295-d5cb884b614a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de770-7975-4aa9-b656-e7dbe6bff290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de770-7975-4aa9-b656-e7dbe6bff290.jpg?1",
             "name": "Scrapwork Rager",
             "text": "When Scrapwork Rager enters the battlefield, you draw a card and you lose 1 life.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -4199,7 +4199,7 @@
         },
         {
             "id": "6f2000fe-162c-539a-a481-e72c664473f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca28d210-a35d-491e-beda-76b95d09dc2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca28d210-a35d-491e-beda-76b95d09dc2d.jpg?1",
             "name": "Transmogrant Altar",
             "text": "{B}, {T}, Sacrifice a creature: Add {C}{C}{C}.\n{2}, {T}, Sacrifice a creature: Create a 3/3 colorless Zombie artifact creature token. Activate only as a sorcery.",
             "colours": [],
@@ -4229,7 +4229,7 @@
         },
         {
             "id": "b048468a-ae5e-5a2a-8944-543736e6df6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc913ed6-3032-4b45-a6c1-6a4208a7e00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc913ed6-3032-4b45-a6c1-6a4208a7e00a.jpg?1",
             "name": "Transmogrant's Crown",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, draw a card.\nEquip {2} or {B}",
             "colours": [],
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "10477d89-b01c-5096-a6b2-181c64b4b881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd83b2c3-bb06-42db-83bf-8903a126512c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd83b2c3-bb06-42db-83bf-8903a126512c.jpg?1",
             "name": "Arms Race",
             "text": "{3}{R}: You may put an artifact card from your hand onto the battlefield. That artifact gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "bb4c6914-7243-5321-bb6b-e1658cc7a9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345a1c80-41d6-43b1-83ab-1aa56dd06b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345a1c80-41d6-43b1-83ab-1aa56dd06b1b.jpg?1",
             "name": "Bitter Reunion",
             "text": "When Bitter Reunion enters the battlefield, you may discard a card. If you do, draw two cards.\n{1}, Sacrifice Bitter Reunion: Creatures you control gain haste until end of turn.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "75f61232-8129-5ca8-8a8b-4f997eece2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7666d-0d60-4fe5-b144-286d4e47b704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7666d-0d60-4fe5-b144-286d4e47b704.jpg?1",
             "name": "Brotherhood's End",
             "text": "Choose one \u2014\n\u2022 Brotherhood's End deals 3 damage to each creature and each planeswalker.\n\u2022 Destroy all artifacts with mana value 3 or less.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "141932e4-29ee-5bd9-962e-ffb0f05b6d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b0449-8ff7-4549-893b-aeca93720c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50b0449-8ff7-4549-893b-aeca93720c64.jpg?1",
             "name": "Conscripted Infantry",
             "text": "When Conscripted Infantry dies, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "436e7988-635e-53f0-92ff-388e110a89b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71240ad-1daf-419a-aaeb-5f9d5079c3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71240ad-1daf-419a-aaeb-5f9d5079c3dd.jpg?1",
             "name": "Draconic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying, haste, and \"{1}: This creature gets +1/+0 until end of turn.\" It's a Dragon in addition to its other types.\nWhen enchanted creature dies, return Draconic Destiny to its owner's hand.",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "361051ec-1c5a-5b94-a9ea-e0cecdae4029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd6a95a-11b9-43aa-b293-20a3102bae71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd6a95a-11b9-43aa-b293-20a3102bae71.jpg?1",
             "name": "Dwarven Forge-Chanter",
             "text": "Ward\u2014\nPay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "5831d344-544b-5181-a190-59543831a3f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a169612e-f5de-4653-bc31-9ede8c5bdc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a169612e-f5de-4653-bc31-9ede8c5bdc75.jpg?1",
             "name": "Excavation Explosion",
             "text": "Excavation Explosion deals 3 damage to any target. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "731cdeaa-0788-59a2-9316-cafad78d902d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f454583d-d227-4fc8-842e-128e025880e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f454583d-d227-4fc8-842e-128e025880e4.jpg?1",
             "name": "The Fall of Kroog",
             "text": "Choose target opponent. Destroy target land that player controls. The Fall of Kroog deals 3 damage to that player and 1 damage to each creature they control.",
             "colours": [
@@ -4531,7 +4531,7 @@
         },
         {
             "id": "852af449-1fb2-5a2c-8fc5-09e12fc31d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2da75-160d-47f9-b978-e153262ec1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2da75-160d-47f9-b978-e153262ec1fc.jpg?1",
             "name": "Fallaji Chaindancer",
             "text": "{2}: Fallaji Chaindancer gains double strike until end of turn.",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "b466129f-9f09-5f8e-ae20-15dd8f846303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca4cb0e-63ad-4275-a27f-da476260b467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca4cb0e-63ad-4275-a27f-da476260b467.jpg?1",
             "name": "Feldon, Ronom Excavator",
             "text": "Haste\nFeldon, Ronom Excavator can't block.\nWhenever Feldon is dealt damage, exile that many cards from the top of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "82228a95-1f9a-5357-82f7-8c59738744c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349465f-d29f-4d4b-a653-f4388574c336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349465f-d29f-4d4b-a653-f4388574c336.jpg?1",
             "name": "Giant Cindermaw",
             "text": "Trample\nPlayers can't gain life.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "13a116b6-cd94-5edb-a0a0-a0e8a8a480c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd77c575-93a4-44ec-8940-adcbfc6e7a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd77c575-93a4-44ec-8940-adcbfc6e7a84.jpg?1",
             "name": "Goblin Blast-Runner",
             "text": "Goblin Blast-Runner gets +2/+0 and has menace as long as you sacrificed a permanent this turn.",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "d4a7c7a8-4560-5154-b1d5-0c47e497abca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd965a9-caa2-42a3-b2f9-e4f57341ac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd965a9-caa2-42a3-b2f9-e4f57341ac27.jpg?1",
             "name": "Horned Stoneseeker",
             "text": "Menace\nWhen Horned Stoneseeker enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\nWhen Horned Stoneseeker leaves the battlefield, sacrifice a Powerstone.",
             "colours": [
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "f4a94ab7-9014-59d3-96ea-7958a4aea87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2d026f-bdca-4376-9d70-c81c707598e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2d026f-bdca-4376-9d70-c81c707598e8.jpg?1",
             "name": "Mechanized Warfare",
             "text": "If a red or artifact source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -4742,7 +4742,7 @@
         },
         {
             "id": "27af9f0f-bba8-59e0-ad46-9e826774a976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d02416-8578-40a5-bf31-d1ef9b8764f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d02416-8578-40a5-bf31-d1ef9b8764f1.jpg?1",
             "name": "Mishra, Excavation Prodigy",
             "text": "Haste\n{1}, {T}, Discard a card: Draw a card.\nWhenever you discard one or more artifact cards, add {R}{R}. This ability triggers only once each turn.",
             "colours": [
@@ -4779,7 +4779,7 @@
         },
         {
             "id": "a08863ce-af1c-50e6-8094-54e53ec56859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d2e518-30c6-480c-aaf4-b7596c9479e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d2e518-30c6-480c-aaf4-b7596c9479e4.jpg?1",
             "name": "Mishra's Command",
             "text": "Choose two \u2014\n\u2022 Choose target player. They may discard up to X cards. Then they draw a card for each card discarded this way.\n\u2022 This spell deals X damage to target creature.\n\u2022 This spell deals X damage to target planeswalker.\n\u2022 Target creature gets +X/+0 and gains haste until end of turn.",
             "colours": [
@@ -4813,7 +4813,7 @@
         },
         {
             "id": "04e5b7b9-6c39-52f4-8e08-76e8266d80e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c71fb1-a30b-4e0e-a6d6-4656cfff2da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c71fb1-a30b-4e0e-a6d6-4656cfff2da1.jpg?1",
             "name": "Mishra's Domination",
             "text": "Enchant creature\nAs long as you control enchanted creature, it gets +2/+2. Otherwise, it can't block.",
             "colours": [
@@ -4847,7 +4847,7 @@
         },
         {
             "id": "b7ebaeff-7a7b-5d65-809b-772627c10206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda82e38-c1d4-4019-8f79-f91602d941b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda82e38-c1d4-4019-8f79-f91602d941b0.jpg?1",
             "name": "Mishra's Onslaught",
             "text": "Choose one \u2014\n\u2022 Create two 1/1 colorless Soldier artifact creature tokens.\n\u2022 Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4879,7 +4879,7 @@
         },
         {
             "id": "7a8bbb63-420b-5c84-be26-79a871ee1415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfa227-4309-40ed-952c-279595eab17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfa227-4309-40ed-952c-279595eab17e.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "4f5cf6bd-9492-5b05-b521-09a475e567dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f886411-8216-4fb7-9172-a408c39043ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f886411-8216-4fb7-9172-a408c39043ee.jpg?1",
             "name": "Obliterating Bolt",
             "text": "Obliterating Bolt deals 4 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "0703631b-8ad9-59e8-a462-e59e05600520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01eb9702-55c5-41b2-8bef-63d33dafa599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01eb9702-55c5-41b2-8bef-63d33dafa599.jpg?1",
             "name": "Over the Top",
             "text": "Each player reveals a number of cards from the top of their library equal to the number of nonland permanents they control, puts all permanent cards they revealed this way onto the battlefield, and puts the rest into their graveyard.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "0328369b-ccca-54ca-8379-57be49826b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2deb43-7134-4f9c-b02d-78407a8986b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2deb43-7134-4f9c-b02d-78407a8986b1.jpg?1",
             "name": "Penregon Strongbull",
             "text": "{1}, Sacrifice an artifact: Penregon Strongbull gets +1/+1 until end of turn and deals 1 damage to each opponent.",
             "colours": [
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "1fdc7357-e19a-55e4-9369-2260c7d90f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a523d5a7-58b1-45a3-81a7-078da02fda16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a523d5a7-58b1-45a3-81a7-078da02fda16.jpg?1",
             "name": "Pyrrhic Blast",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nPyrrhic Blast deals damage equal to the sacrificed creature's power to any target. Draw a card.",
             "colours": [
@@ -5046,7 +5046,7 @@
         },
         {
             "id": "427d4499-1504-5f0f-90fa-34897c7e3579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b25d2-7615-4375-a5e6-3d762c9072a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b25d2-7615-4375-a5e6-3d762c9072a5.jpg?1",
             "name": "Raze to the Ground",
             "text": "This spell can't be countered.\nDestroy target artifact. If its mana value was 1 or less, draw a card.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "a9aa5ab4-6a56-50b1-adc5-439501659132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8b2f2b-6f19-47f7-bb65-00665989bc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8b2f2b-6f19-47f7-bb65-00665989bc30.jpg?1",
             "name": "Roc Hunter",
             "text": "Reach",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "d5bee0a3-7e2b-5266-88f1-0383cc31aeba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c42d56-5b0e-4624-8831-77280f8d56cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c42d56-5b0e-4624-8831-77280f8d56cf.jpg?1",
             "name": "Sardian Cliffstomper",
             "text": "As long as it's your turn and you control four or more Mountains, Sardian Cliffstomper gets +X/+0, where X is the number of Mountains you control.",
             "colours": [
@@ -5150,7 +5150,7 @@
         },
         {
             "id": "a042d331-b476-5474-8a11-fcb23278d97c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44b24de-60b4-4855-9111-f1237f71bc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44b24de-60b4-4855-9111-f1237f71bc4d.jpg?1",
             "name": "Sibling Rivalry",
             "text": "Gain control of target artifact or creature until end of turn. Untap it. It gains haste until end of turn. Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "d2753000-fcdd-5e40-861b-655f88702140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d462d30c-9060-46d6-b5b3-cac476ee2ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d462d30c-9060-46d6-b5b3-cac476ee2ce1.jpg?1",
             "name": "Tomakul Scrapsmith",
             "text": "When Tomakul Scrapsmith enters the battlefield, mill three cards. You may put an artifact card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Tomakul Scrapsmith. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "e3f37554-cdb7-5053-9526-5b4a102a590c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg?1",
             "name": "Tyrant of Kher Ridges",
             "text": "Flying\nWhen Tyrant of Kher Ridges enters the battlefield, it deals 4 damage to any target.\n{R}: Tyrant of Kher Ridges gets +1/+0 until end of turn.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "e6ab5bd7-c7cd-5217-882d-c3ae7f44bb05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be13abf-b717-4122-ab2b-7e597a251d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be13abf-b717-4122-ab2b-7e597a251d52.jpg?1",
             "name": "Unleash Shell",
             "text": "Unleash Shell deals 5 damage to target creature or planeswalker and 2 damage to that permanent's controller.",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "7fb9f9e3-df5d-57ec-bbc2-aff651002431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e922ef35-b62a-4cf8-9282-319f6de150b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e922ef35-b62a-4cf8-9282-319f6de150b0.jpg?1",
             "name": "Visions of Phyrexia",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "086fa39d-8406-5503-a2ae-bd90b4ac878e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17950ae-43aa-4d03-a41e-726ca96eb1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17950ae-43aa-4d03-a41e-726ca96eb1ba.jpg?1",
             "name": "Whirling Strike",
             "text": "Target creature gets +2/+0 and gains first strike and trample until end of turn.",
             "colours": [
@@ -5351,7 +5351,7 @@
         },
         {
             "id": "b6c4533d-f98e-5288-b55d-1f214323c5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e5529a-848b-486c-97fb-1def35df7837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e5529a-848b-486c-97fb-1def35df7837.jpg?1",
             "name": "Blitz Automaton",
             "text": "Haste\n//PRT-Prototype_\nMech//\n{2}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/2",
             "colours": [],
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "fd946a7d-759e-58c5-92d9-8824fb360bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7761ed0-a784-4dfb-ab6c-0f4b9a411cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7761ed0-a784-4dfb-ab6c-0f4b9a411cf3.jpg?1",
             "name": "Fallaji Dragon Engine",
             "text": "Flying\n{2}: Fallaji Dragon Engine gets +1/+0 until end of turn.\n//PRT-Prototype_\nMech//\n{2}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/3",
             "colours": [],
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "62074b30-e6cf-5120-9316-874abd2db2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72de800-b28e-42c4-a3ca-5ec3a765d807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72de800-b28e-42c4-a3ca-5ec3a765d807.jpg?1",
             "name": "Heavyweight Demolisher",
             "text": "Menace\nAt the beginning of your upkeep, tap Heavyweight Demolisher unless you pay {3}.\nUnearth {6}{R}{R} ({6}{R}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "0389cce5-ceeb-5f1b-a9ec-3033872af362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30457c3-57df-4720-8b45-962f16316d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30457c3-57df-4720-8b45-962f16316d17.jpg?1",
             "name": "Mishra's Juggernaut",
             "text": "Trample\nMishra's Juggernaut attacks each combat if able.\nUnearth {5}{R} ({5}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5483,7 +5483,7 @@
         },
         {
             "id": "6d4c37b1-193d-55f4-874f-58e9d934641d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb142d99-b210-47c8-897c-be62f90d2192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb142d99-b210-47c8-897c-be62f90d2192.jpg?1",
             "name": "Mishra's Research Desk",
             "text": "{1}, {T}, Sacrifice Mishra's Research Desk: Exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to the battlefield. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "1fed551b-5e52-56bb-943d-0d42937e98bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b826be-4256-4fd6-ad4d-6c80933ee940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b826be-4256-4fd6-ad4d-6c80933ee940.jpg?1",
             "name": "Phyrexian Dragon Engine // Mishra, Lost to Phyrexia",
             "text": "Double strike\nWhen Phyrexian Dragon Engine enters the battlefield from your graveyard, you may discard your hand. If you do, draw three cards.\nUnearth {3}{R}{R}\n(Melds with Mishra, Claimed by Gix.)",
             "colours": [],
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "a36682d1-8f05-5039-a892-9ce0072591cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/0220c1e9-07bc-44f0-b39e-ca345ec4ea28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0220c1e9-07bc-44f0-b39e-ca345ec4ea28.jpg?1",
             "name": "Mishra, Lost to Phyrexia",
             "text": "Double strike\nWhen Phyrexian Dragon Engine enters the battlefield from your graveyard, you may discard your hand. If you do, draw three cards.\nUnearth {3}{R}{R}\n(Melds with Mishra, Claimed by Gix.)",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "40fd4f3f-e274-56c3-bd09-16c0366dca3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4742800a-4872-4c2d-b884-01e0ba16950c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4742800a-4872-4c2d-b884-01e0ba16950c.jpg?1",
             "name": "Scrapwork Mutt",
             "text": "When Scrapwork Mutt enters the battlefield, you may discard a card. If you do, draw a card.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -5620,7 +5620,7 @@
         },
         {
             "id": "bcdfe769-d83d-5680-901a-27a6e4dd161f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc1715-4ddb-4404-83c6-0b8a61922578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fc1715-4ddb-4404-83c6-0b8a61922578.jpg?1",
             "name": "Skitterbeam Battalion",
             "text": "Trample, haste\nWhen Skitterbeam Battalion enters the battlefield, if you cast it, create two tokens that are copies of it.\n//PRT-Prototype_\nMech//\n{3}{R}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "da278dac-f4fc-5b5f-8973-24d4067c0285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a49b18-a339-401c-ab77-fcd04772cf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a49b18-a339-401c-ab77-fcd04772cf69.jpg?1",
             "name": "Alloy Animist",
             "text": "{2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "97ae6f61-f18a-591b-b3e4-e695792465c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22586ce-efcc-4b20-83f9-c23b8eeaa88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22586ce-efcc-4b20-83f9-c23b8eeaa88c.jpg?1",
             "name": "Argothian Opportunist",
             "text": "When Argothian Opportunist enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "bf113b54-578e-5a44-a10c-2b4192fe3f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbc383-7e08-4701-8d4a-6b99b74fe358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbc383-7e08-4701-8d4a-6b99b74fe358.jpg?1",
             "name": "Argothian Sprite",
             "text": "Argothian Sprite can't be blocked by artifact creatures.\n{7}: Put two +1/+1 counters on Argothian Sprite.",
             "colours": [
@@ -5759,7 +5759,7 @@
         },
         {
             "id": "6f546755-0a79-57c7-98da-3e672031d255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b0813a-38cf-4a07-81d6-91d24af8b549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b0813a-38cf-4a07-81d6-91d24af8b549.jpg?1",
             "name": "Audacity",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Audacity is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "314fc60c-69ab-593d-8b90-2607bfc9bc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c95f8b8-faba-4412-8d8f-093e2ec903f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c95f8b8-faba-4412-8d8f-093e2ec903f0.jpg?1",
             "name": "Awaken the Woods",
             "text": "Create X 1/1 green Forest Dryad land creature tokens. (They're affected by summoning sickness.)",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "0c193a0e-6d64-5231-a8cc-cf77cb65c1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c0a68-53be-4905-8ed3-79b4782dfd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c0a68-53be-4905-8ed3-79b4782dfd6e.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "7247d9dc-4a21-5445-8581-863a0d1ad376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6988b6-ade0-4cd5-b27c-146e5e7ae91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6988b6-ade0-4cd5-b27c-146e5e7ae91f.jpg?1",
             "name": "Blanchwood Prowler",
             "text": "When Blanchwood Prowler enters the battlefield, mill three cards. You may put a land card from among the cards milled this way into your hand. If you don't, put a +1/+1 counter on Blanchwood Prowler. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "93f5f893-8ae2-5de7-811c-ac29676e64e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c8c73c-ee2e-4aa9-aa6c-42cf9d58d9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c8c73c-ee2e-4aa9-aa6c-42cf9d58d9cc.jpg?1",
             "name": "Burrowing Razormaw",
             "text": "When Burrowing Razormaw dies, mill four cards. (Put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -5931,7 +5931,7 @@
         },
         {
             "id": "e3a4342f-3269-5a42-8649-66f3aba2b352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712a0640-d9c8-46fc-b38b-bf20a40fa902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712a0640-d9c8-46fc-b38b-bf20a40fa902.jpg?1",
             "name": "Bushwhack",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n\u2022 Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "3e05e119-95ff-515a-98c4-216571e85b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a842a945-21d9-432c-b970-6da65b16f309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a842a945-21d9-432c-b970-6da65b16f309.jpg?1",
             "name": "Citanul Stalwart",
             "text": "{T}, Tap an untapped artifact or creature you control: Add one mana of any color.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "23ef6d8a-0429-5197-89f1-f7d1c7b28c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ba6c05-a4c2-422b-a4cb-852b3aef77a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ba6c05-a4c2-422b-a4cb-852b3aef77a5.jpg?1",
             "name": "Epic Confrontation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "caf578d5-3349-5335-a06f-bcc5d5d9c1e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f13f67-e852-4a6a-8f32-b16195e53ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f13f67-e852-4a6a-8f32-b16195e53ec3.jpg?1",
             "name": "Fade from History",
             "text": "Each player who controls an artifact or enchantment creates a 2/2 green Bear creature token. Then destroy all artifacts and enchantments.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "42c97eed-5a55-5c54-9b20-56f9dab23a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac75c41f-82dc-4b06-a233-9b74ea177a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac75c41f-82dc-4b06-a233-9b74ea177a3d.jpg?1",
             "name": "Fallaji Excavation",
             "text": "Create three tapped Powerstone tokens. You gain 3 life. (The tokens are artifacts with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "61fdcf9c-4ed3-51e6-ba87-f643b2ae83ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b906eb-3223-474c-9b74-eda2c280f9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b906eb-3223-474c-9b74-eda2c280f9c5.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "a07b5281-2d89-5962-a8d5-6e6966a4d266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37096c19-32c9-448a-94e9-f5fe2d74e3a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37096c19-32c9-448a-94e9-f5fe2d74e3a3.jpg?1",
             "name": "Fog of War",
             "text": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn by creatures with power 3 or less.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "b8718011-8424-5f62-868d-6ca6a25a4183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0b94e5-d270-4820-83b9-1d346d378ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0b94e5-d270-4820-83b9-1d346d378ff8.jpg?1",
             "name": "Gaea's Courser",
             "text": "Whenever Gaea's Courser attacks, if there are three or more creature cards in your graveyard, draw a card.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "d1117672-0188-5448-8816-e1c05e115cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5503186a-46fe-4956-8ae3-5ab3343f8a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5503186a-46fe-4956-8ae3-5ab3343f8a93.jpg?1",
             "name": "Gaea's Gift",
             "text": "Put a +1/+1 counter on target creature you control. It gains reach, trample, hexproof, and indestructible until end of turn. (It can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -6233,7 +6233,7 @@
         },
         {
             "id": "5bf95967-9b61-556d-ab34-e5f95409a41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeece336-e5e8-4455-a297-c3739198d011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeece336-e5e8-4455-a297-c3739198d011.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6265,7 +6265,7 @@
         },
         {
             "id": "a64ade57-b73e-530c-9e20-2c3bb09c094b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7382154-ac8f-40ca-94e4-2f0533c0cf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7382154-ac8f-40ca-94e4-2f0533c0cf20.jpg?1",
             "name": "Gnarlroot Pallbearer",
             "text": "Trample\nWhen Gnarlroot Pallbearer enters the battlefield, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -6300,7 +6300,7 @@
         },
         {
             "id": "20c40ff1-79fe-54c2-9fd9-e291a958710d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee387b7-18e4-41b7-aefe-f2b5954e3051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee387b7-18e4-41b7-aefe-f2b5954e3051.jpg?1",
             "name": "Gwenna, Eyes of Gaea",
             "text": "{T}: Add two mana in any combination of colors. Spend this mana only to cast creature spells or activate abilities of a creature or creature card.\nWhenever you cast a creature spell with power 5 or greater, put a +1/+1 counter on Gwenna, Eyes of Gaea and untap it.",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "b55af31c-cfb7-5158-be43-c3ce69e765d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559afec-6bb8-4501-8805-4eb108443048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559afec-6bb8-4501-8805-4eb108443048.jpg?1",
             "name": "Hoarding Recluse",
             "text": "Reach, deathtouch\nWhen Hoarding Recluse dies, put up to one other target card from a graveyard on the bottom of its owner's library.",
             "colours": [
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "09d8ecde-d26b-55da-9840-16fc25b0bd5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b7809f-f3a3-439e-8bae-c083842de1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b7809f-f3a3-439e-8bae-c083842de1bf.jpg?1",
             "name": "Obstinate Baloth",
             "text": "When Obstinate Baloth enters the battlefield, you gain 4 life.\nIf a spell or ability an opponent controls causes you to discard Obstinate Baloth, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6408,7 +6408,7 @@
         },
         {
             "id": "49246e91-908f-57d0-8984-c1ae5d4988aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4719bc1-4c27-45d8-89f7-8c76ccf946d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4719bc1-4c27-45d8-89f7-8c76ccf946d2.jpg?1",
             "name": "Perimeter Patrol",
             "text": "Whenever an artifact enters the battlefield under your control, Perimeter Patrol gets +1/+0 until end of turn.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "8b1e24f2-e131-54b6-adbe-2607d3d6f3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96761b2-eb9c-4963-a496-ba53a01f4b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96761b2-eb9c-4963-a496-ba53a01f4b17.jpg?1",
             "name": "Sarinth Steelseeker",
             "text": "Whenever an artifact enters the battlefield under your control, look at the top card of your library. If it's a land card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [
@@ -6479,7 +6479,7 @@
         },
         {
             "id": "40bf36df-6265-571f-8d67-4f8101fa9be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20014a1c-197c-4e04-94b2-874886183e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20014a1c-197c-4e04-94b2-874886183e2f.jpg?1",
             "name": "Shoot Down",
             "text": "Exile target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -6511,7 +6511,7 @@
         },
         {
             "id": "cbf28c20-39fe-5b7f-8e58-e6152b3ac1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbd975d-52f8-4fba-bf97-b8837413edd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbd975d-52f8-4fba-bf97-b8837413edd8.jpg?1",
             "name": "Tawnos's Tinkering",
             "text": "Put two +1/+1 counters on target artifact, creature, or land you control. Untap that permanent. If it isn't a creature, it becomes a 0/0 creature in addition to its other types.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "2bc9fb4b-da7f-56dc-a166-20b2facf2dcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2350027a-f3a4-4cba-9dfc-27e33bddb3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2350027a-f3a4-4cba-9dfc-27e33bddb3be.jpg?1",
             "name": "Teething Wurmlet",
             "text": "Teething Wurmlet has deathtouch as long as you control three or more artifacts.\nWhenever an artifact enters the battlefield under your control, you gain 1 life. If this is the first time this ability has resolved this turn, put a +1/+1 counter on Teething Wurmlet.",
             "colours": [
@@ -6579,7 +6579,7 @@
         },
         {
             "id": "0790c50f-12b7-5cfb-9527-17e0ffc97580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb6a21-23b0-44f1-b70e-5899bb9d4a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb6a21-23b0-44f1-b70e-5899bb9d4a84.jpg?1",
             "name": "Titania, Voice of Gaea // Titania, Gaea Incarnate",
             "text": "Reach\nWhenever one or more land cards are put into your graveyard from anywhere, you gain 2 life.\nAt the beginning of your upkeep, if there are four or more land cards in your graveyard and you both own and control Titania, Voice of Gaea and a land named Argoth, Sanctum of Nature, exile them, then meld them into Titania, Gaea Incarnate.",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "e56f4544-f67c-5233-b921-19333dbf47f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753567c7-c484-4c0d-8128-7710e23c428f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753567c7-c484-4c0d-8128-7710e23c428f.jpg?1",
             "name": "Titania's Command",
             "text": "Choose two \u2014\n\u2022 Exile target player's graveyard. You gain 1 life for each card exiled this way.\n\u2022 Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle.\n\u2022 Create two 2/2 green Bear creature tokens.\n\u2022 Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "0b3eebce-033c-5e33-9d9b-6275c0a92b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7745439-f40b-4647-8bff-53751d511bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7745439-f40b-4647-8bff-53751d511bbd.jpg?1",
             "name": "Tomakul Honor Guard",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "532b5cb0-f0ba-5625-8707-cadcfb27283e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a0c819-36d1-442b-bec5-e6df58a122c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a0c819-36d1-442b-bec5-e6df58a122c0.jpg?1",
             "name": "Wasteful Harvest",
             "text": "Mill five cards. You may put a permanent card from among the cards milled this way into your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -6716,7 +6716,7 @@
         },
         {
             "id": "fb9f08cf-aa64-5f98-b70d-67b29d033ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6e5338-9b95-4ac7-a57c-5efaa6423531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6e5338-9b95-4ac7-a57c-5efaa6423531.jpg?1",
             "name": "Boulderbranch Golem",
             "text": "When Boulderbranch Golem enters the battlefield, you gain life equal to its power.\n//PRT-Prototype_\nMech//\n{3}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -6749,7 +6749,7 @@
         },
         {
             "id": "2cf7fc0a-0543-559f-ab34-4fbc00528e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc9b90-792e-4cf7-ab8c-cb616d94092a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc9b90-792e-4cf7-ab8c-cb616d94092a.jpg?1",
             "name": "Cradle Clearcutter",
             "text": "{T}: Add an amount of {G} equal to Cradle Clearcutter's power.\n//PRT-Prototype_\nMech//\n{2}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n1/3",
             "colours": [],
@@ -6782,7 +6782,7 @@
         },
         {
             "id": "4cc2e974-bd0c-5568-9ac0-537368c3042a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847a175e-ead1-4596-baf3-5f7f57859e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847a175e-ead1-4596-baf3-5f7f57859e0b.jpg?1",
             "name": "Haywire Mite",
             "text": "When Haywire Mite dies, you gain 2 life.\n{G}, Sacrifice Haywire Mite: Exile target noncreature artifact or noncreature enchantment.",
             "colours": [],
@@ -6815,7 +6815,7 @@
         },
         {
             "id": "0d9b74f3-200b-56a7-87f2-ef9f6686860c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2ec10-f45f-46ef-a076-52425bf3fe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2ec10-f45f-46ef-a076-52425bf3fe3b.jpg?1",
             "name": "Iron-Craw Crusher",
             "text": "Whenever Iron-Craw Crusher attacks, target attacking creature gets +X/+0 until end of turn, where X is Iron-Craw Crusher's power.\n//PRT-Prototype_\nMech//\n{2}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/5",
             "colours": [],
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "fe27490c-9c04-5a9a-bab8-2c7a51484463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db83275-bfd2-42c2-8d0f-e8a9b4f60e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db83275-bfd2-42c2-8d0f-e8a9b4f60e78.jpg?1",
             "name": "Mask of the Jadecrafter",
             "text": "{X}, {T}, Sacrifice Mask of the Jadecrafter: Create an X/X colorless Golem artifact creature token. Activate only as a sorcery.\nUnearth {2}{G} ({2}{G}: Return this card from your graveyard to the battlefield. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -6878,7 +6878,7 @@
         },
         {
             "id": "89919133-f7c6-5da5-b9d5-6e50f2da65e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb74e91-f7e5-49dd-8aa8-83a679f88a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb74e91-f7e5-49dd-8aa8-83a679f88a21.jpg?1",
             "name": "Perennial Behemoth",
             "text": "You may play lands from your graveyard.\nUnearth {G}{G} ({G}{G}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "5ea8ee46-f5ce-53a8-8465-4b6addb949bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2498b591-4a80-459f-a639-fe4cf8880be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2498b591-4a80-459f-a639-fe4cf8880be2.jpg?1",
             "name": "Rootwire Amalgam",
             "text": "{3}{G}{G}, Sacrifice Rootwire Amalgam: Create an X/X colorless Golem artifact creature token, where X is three times Rootwire Amalgam's power. It gains haste until end of turn. Activate only as a sorcery.\n//PRT-Prototype_\nMech//\n{1}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/3",
             "colours": [],
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "184e1578-4318-568c-9bd7-121f98ca9d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8348f73d-4226-4296-9d51-a2c497ee8270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8348f73d-4226-4296-9d51-a2c497ee8270.jpg?1",
             "name": "Rust Goliath",
             "text": "Reach, trample\n//PRT-Prototype_\nMech//\n{3}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/5",
             "colours": [],
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "5154d2db-cc4c-52a7-b9a9-86d1ea614496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85e2a35-cb55-434c-bbd7-54c3438345c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85e2a35-cb55-434c-bbd7-54c3438345c1.jpg?1",
             "name": "Simian Simulacrum",
             "text": "When Simian Simulacrum enters the battlefield, put two +1/+1 counters on target creature you control.\nUnearth {2}{G}{G} ({2}{G}{G}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -7016,7 +7016,7 @@
         },
         {
             "id": "1f28a30c-885f-5d5b-922f-68b19bcf27cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df343bf9-f535-42c7-a2d0-8adfd068b354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df343bf9-f535-42c7-a2d0-8adfd068b354.jpg?1",
             "name": "Arbalest Engineers",
             "text": "When Arbalest Engineers enters the battlefield, choose one \u2014\n\u2022 Arbalest Engineers deals 1 damage to any target.\n\u2022 Put a +1/+1 counter on target creature. It gains trample and haste until end of turn.\n\u2022 Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "ad9ae075-3e9c-5369-92c7-878ceaa1b800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5306d6-0f08-429a-8590-1b8136f953a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5306d6-0f08-429a-8590-1b8136f953a9.jpg?1",
             "name": "Battery Bearer",
             "text": "Creatures you control have \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\"\nWhenever you cast an artifact spell with mana value 6 or greater, draw a card.",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "a7e21039-ff09-50c7-8299-1ea8a3cdc6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ff816d-1eb7-4985-90ec-f44802a696fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ff816d-1eb7-4985-90ec-f44802a696fc.jpg?1",
             "name": "Deathbloom Ritualist",
             "text": "{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "16b1dd47-c8b3-5add-aa98-dd636dbc1ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b60003-a987-49b0-a0f8-bb825c97da4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b60003-a987-49b0-a0f8-bb825c97da4d.jpg?1",
             "name": "Evangel of Synthesis",
             "text": "When Evangel of Synthesis enters the battlefield, draw a card, then discard a card.\nAs long as you've drawn two or more cards this turn, Evangel of Synthesis gets +1/+0 and has menace.",
             "colours": [
@@ -7167,7 +7167,7 @@
         },
         {
             "id": "d2d93bbc-2060-528c-98a6-f8085f346f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe9ee1c-5eb3-4d63-a641-0ec5adf7b058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe9ee1c-5eb3-4d63-a641-0ec5adf7b058.jpg?1",
             "name": "Fallaji Vanguard",
             "text": "First strike\nWhenever Fallaji Vanguard or another creature enters the battlefield under your control, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "b8b76c44-86c5-5fbf-9ae7-b2fee43d4b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0a2f82-57d3-45d8-b1c8-357883c62728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0a2f82-57d3-45d8-b1c8-357883c62728.jpg?1",
             "name": "Hajar, Loyal Bodyguard",
             "text": "Sacrifice Hajar, Loyal Bodyguard: Legendary creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -7245,7 +7245,7 @@
         },
         {
             "id": "8f457986-a684-5af9-aef6-5cd93ffe6157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b88be69-3201-4345-a193-cc21bd066d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b88be69-3201-4345-a193-cc21bd066d15.jpg?1",
             "name": "Harbin, Vanguard Aviator",
             "text": "Flying\nWhenever you attack with five or more Soldiers, creatures you control get +1/+1 and gain flying until end of turn.",
             "colours": [
@@ -7286,7 +7286,7 @@
         },
         {
             "id": "192fee3d-a7e0-53c8-a9ac-24d3f7686ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c72d5-f08e-4e46-a5cb-26d1fc0a71c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c72d5-f08e-4e46-a5cb-26d1fc0a71c8.jpg?1",
             "name": "Hero of the Dunes",
             "text": "When Hero of the Dunes enters the battlefield, return target artifact or creature card with mana value 3 or less from your graveyard to the battlefield.\nCreatures you control with mana value 3 or less get +1/+0.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "edde2c6d-4d34-5af5-be7e-c5c209dbd25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15b0676-b698-4160-8d2f-a22a1011bac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15b0676-b698-4160-8d2f-a22a1011bac0.jpg?1",
             "name": "Junkyard Genius",
             "text": "When Junkyard Genius enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n{1}{B}{R}, Sacrifice another creature or artifact: Until end of turn, other creatures you control get +1/+0 and gain menace and haste.",
             "colours": [
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "22d70591-589f-5189-8c4e-e0f7ac5294d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94faea39-4540-4adc-b9bd-78fefd09ecdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94faea39-4540-4adc-b9bd-78fefd09ecdf.jpg?1",
             "name": "Legions to Ashes",
             "text": "Exile target nonland permanent an opponent controls and all tokens that player controls with the same name as that permanent.",
             "colours": [
@@ -7396,7 +7396,7 @@
         },
         {
             "id": "a0befb3c-dd24-5fc6-98a5-ebaff509e262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a469d7ec-42de-45de-9d8f-469bb979de58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a469d7ec-42de-45de-9d8f-469bb979de58.jpg?1",
             "name": "Mishra, Claimed by Gix // Mishra, Lost to Phyrexia",
             "text": "Whenever you attack, each opponent loses X life and you gain X life, where X is the number of attacking creatures. If Mishra, Claimed by Gix and a creature named Phyrexian Dragon Engine are attacking, and you both own and control them, exile them, then meld them into Mishra, Lost to Phyrexia. It enters the battlefield tapped and attacking.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "89b49f3f-7ad9-56b4-86e7-05abffd49eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585a753d-a692-474a-bc28-48dd93b73ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585a753d-a692-474a-bc28-48dd93b73ace.jpg?1",
             "name": "Mishra, Tamer of Mak Fawa",
             "text": "Permanents you control have \"Ward\u2014\nSacrifice a permanent.\"\nEach artifact card in your graveyard has unearth {1}{B}{R}. ({1}{B}{R}: Return the card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -7477,7 +7477,7 @@
         },
         {
             "id": "0f6d154d-92b2-5bfe-b455-a0b71c09250d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685c9767-eaa7-4e16-b245-816181e2fc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685c9767-eaa7-4e16-b245-816181e2fc36.jpg?1",
             "name": "Queen Kayla bin-Kroog",
             "text": "{4}, {T}: Discard all the cards in your hand, then draw that many cards. You may choose an artifact or creature card with mana value 1 you discarded this way, then do the same for artifact or creature cards with mana values 2 and 3. Return those cards to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "afc2ada3-6503-526b-9797-66372368c1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657562-323c-40d0-a261-d029ed549695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3657562-323c-40d0-a261-d029ed549695.jpg?1",
             "name": "Saheeli, Filigree Master",
             "text": "+1: Scry 1. You may tap an untapped artifact you control. If you do, draw a card.\n\u22122: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n\u22124: You get an emblem with \"Artifact creatures you control get +1/+1\" and \"Artifact spells you cast cost {1} less to cast.\"",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "c6714756-ee82-5b3b-b803-3cff347bde81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee6fcb-23de-4347-84b6-1e9849a537fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee6fcb-23de-4347-84b6-1e9849a537fc.jpg?1",
             "name": "Sarinth Greatwurm",
             "text": "Trample\nWhenever a land enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [
@@ -7597,7 +7597,7 @@
         },
         {
             "id": "e967f647-227f-53c7-a2fa-a4d61f7feebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87300ac8-8b6f-4c37-8058-beb59eaa66be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87300ac8-8b6f-4c37-8058-beb59eaa66be.jpg?1",
             "name": "Skyfisher Spider",
             "text": "Reach\nWhen Skyfisher Spider enters the battlefield, you may sacrifice another creature. When you do, destroy target nonland permanent.\nWhen Skyfisher Spider dies, you may gain 1 life for each creature card in your graveyard. If you do, exile Skyfisher Spider from your graveyard.",
             "colours": [
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "cc0643ac-cd6b-54bd-ae75-4e766d666352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f855a7e-3a97-4b62-a2a7-06ff1fbb2c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f855a7e-3a97-4b62-a2a7-06ff1fbb2c4c.jpg?1",
             "name": "Tawnos, the Toymaker",
             "text": "Whenever you cast a Beast or Bird creature spell, you may copy it, except the copy is an artifact in addition to its other types. (The copy becomes a token.)",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "5ff62b2f-368e-56e6-9004-645edce1f8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a21287-e244-4960-84fb-c4f6e5c346d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a21287-e244-4960-84fb-c4f6e5c346d9.jpg?1",
             "name": "Third Path Iconoclast",
             "text": "Whenever you cast a noncreature spell, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "cd6e6c26-d3e1-5107-b2da-fc434fb9ab9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919a32a6-b66d-4a75-a02f-fa1c4c87b738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919a32a6-b66d-4a75-a02f-fa1c4c87b738.jpg?1",
             "name": "Tocasia, Dig Site Mentor",
             "text": "Creatures you control have vigilance and \"{T}: Surveil 1.\" (To surveil 1, look at the top card of your library. You may put that card into your graveyard.)\n{2}{G}{G}{W}{W}{U}{U}, Exile Tocasia, Dig Site Mentor from your graveyard: Return any number of target artifact cards with total mana value 10 or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "a7bf10ae-b926-5ecd-9060-8d4f4931e6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aefe8bd-216a-4ec1-9362-3f9dbf7fd083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aefe8bd-216a-4ec1-9362-3f9dbf7fd083.jpg?1",
             "name": "Urza, Lord Protector // Urza, Planeswalker",
             "text": "Artifact, instant, and sorcery spells you cast cost {1} less to cast.\n{7}: If you both own and control Urza, Lord Protector and an artifact named The Mightstone and Weakstone, exile them, then meld them into Urza, Planeswalker. Activate only as a sorcery.",
             "colours": [
@@ -7793,7 +7793,7 @@
         },
         {
             "id": "09f6f5ad-b643-523f-a061-6f2e63ad4d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7329cd-95af-4d71-984f-f5f28982520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7329cd-95af-4d71-984f-f5f28982520c.jpg?1",
             "name": "Urza, Prince of Kroog",
             "text": "Artifact creatures you control get +2/+2.\n{6}: Create a token that's a copy of target artifact you control, except it's a 1/1 Soldier creature in addition to its other types.",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "9563f5e5-965f-53f4-8c7e-a4f52cae3815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb02f00-c188-4193-a049-d26f7643e5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb02f00-c188-4193-a049-d26f7643e5da.jpg?1",
             "name": "Yotian Dissident",
             "text": "Whenever an artifact enters the battlefield under your control, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "b852123c-17f5-5080-937e-fd24bbd119be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760c0369-c2e4-4bd7-a301-9f707f5f48a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760c0369-c2e4-4bd7-a301-9f707f5f48a8.jpg?1",
             "name": "Yotian Tactician",
             "text": "Other Soldiers you control get +1/+1.",
             "colours": [
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "90babbf8-48bd-5261-9b87-3e6a882cbf63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5a528-d16d-4cb9-b532-b85648c8395a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5a528-d16d-4cb9-b532-b85648c8395a.jpg?1",
             "name": "Bladecoil Serpent",
             "text": "When Bladecoil Serpent enters the battlefield, for each {U}{U} spent to cast it, draw a card.\nWhen Bladecoil Serpent enters the battlefield, for each {B}{B} spent to cast it, each opponent discards a card.\nWhen Bladecoil Serpent enters the battlefield, for each {R}{R} spent to cast it, it gets +1/+0 and gains trample and haste until end of turn.",
             "colours": [],
@@ -7945,7 +7945,7 @@
         },
         {
             "id": "ff9ce47a-8c7c-52a7-a78e-de84fadc9726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625f3b20-4b9a-4f61-8afe-31a761711b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625f3b20-4b9a-4f61-8afe-31a761711b43.jpg?1",
             "name": "Clay Champion",
             "text": "Clay Champion enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.\nWhen Clay Champion enters the battlefield, choose up to two other target creatures you control. For each {W}{W} spent to cast Clay Champion, put a +1/+1 counter on each of them.",
             "colours": [],
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "88a2f1d1-3885-50d2-9b07-b6a7a9bb2aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc65821-e4e7-471c-941c-9d3e25ae8bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc65821-e4e7-471c-941c-9d3e25ae8bb9.jpg?1",
             "name": "Aeronaut's Wings",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8011,7 +8011,7 @@
         },
         {
             "id": "5e50d57d-75bd-5617-b0df-b2d2baf82b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e3bf5a-0a90-46d3-bcfe-9a47df41b72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e3bf5a-0a90-46d3-bcfe-9a47df41b72b.jpg?1",
             "name": "Argivian Avenger",
             "text": "{1}: Until end of turn, Argivian Avenger gets -1/-1 and gains your choice of flying, vigilance, deathtouch, or haste.",
             "colours": [],
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "37fac802-b4f8-5546-9d40-73130868cea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a87278-4c82-4056-8354-253d86b0ef3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a87278-4c82-4056-8354-253d86b0ef3d.jpg?1",
             "name": "Cityscape Leveler",
             "text": "Trample\nWhen you cast this spell and whenever Cityscape Leveler attacks, destroy up to one target nonland permanent. Its controller creates a tapped Powerstone token.\nUnearth {8}",
             "colours": [],
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "8d96f7f1-a839-56a3-acf7-1c092bff6b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a81fb-5045-4b7b-8cfb-b90c4f4a1f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a81fb-5045-4b7b-8cfb-b90c4f4a1f51.jpg?1",
             "name": "Energy Refractor",
             "text": "When Energy Refractor enters the battlefield, draw a card.\n{2}: Add one mana of any color.",
             "colours": [],
@@ -8103,7 +8103,7 @@
         },
         {
             "id": "4ef34f7f-63a1-5e81-bc5b-d684165bdd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba00d0f-0ea5-417c-a792-06b3b9d1c8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba00d0f-0ea5-417c-a792-06b3b9d1c8f1.jpg?1",
             "name": "Goblin Firebomb",
             "text": "Flash\n{7}, {T}, Sacrifice Goblin Firebomb: Destroy target permanent.",
             "colours": [],
@@ -8131,7 +8131,7 @@
         },
         {
             "id": "cbfddd32-d5dc-51dc-8dca-37d37b3315e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a17e2-e019-4686-9795-651da2d2955c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a17e2-e019-4686-9795-651da2d2955c.jpg?1",
             "name": "Levitating Statue",
             "text": "Flying\nWhenever you cast a noncreature spell, put a +1/+1 counter on Levitating Statue.\n{2}: Levitating Statue becomes a 1/1 Construct artifact creature until end of turn.",
             "colours": [],
@@ -8159,7 +8159,7 @@
         },
         {
             "id": "b632b5df-ae5e-57c7-82cf-95d6ba5d7614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6768-bcab-43c4-bfc1-76e961689ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6768-bcab-43c4-bfc1-76e961689ae9.jpg?1",
             "name": "Liberator, Urza's Battlethopter",
             "text": "Flash\nFlying\nYou may cast colorless spells and artifact spells as though they had flash.\nWhenever you cast a spell, if the amount of mana spent to cast that spell is greater than Liberator, Urza's Battlethopter's power, put a +1/+1 counter on Liberator.",
             "colours": [],
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "c65122ae-e701-568a-b243-15e7b0c35dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02aea379-b444-46a3-82f4-3038f698d4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02aea379-b444-46a3-82f4-3038f698d4f4.jpg?1",
             "name": "The Mightstone and Weakstone // Urza, Planeswalker",
             "text": "When The Mightstone and Weakstone enters the battlefield, choose one \u2014\n\u2022 Draw two cards.\n\u2022 Target creature gets -5/-5 until end of turn.\n{T}: Add {C}{C}. This mana can't be spent to cast nonartifact spells.\n(Melds with Urza, Lord Protector.)",
             "colours": [],
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "286fd366-82c8-5948-8101-d10bcf67fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40a01679-3224-427e-bd1d-b797b0ab68b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a01679-3224-427e-bd1d-b797b0ab68b7.jpg?1",
             "name": "Urza, Planeswalker",
             "text": "When The Mightstone and Weakstone enters the battlefield, choose one \u2014\n\u2022 Draw two cards.\n\u2022 Target creature gets -5/-5 until end of turn.\n{T}: Add {C}{C}. This mana can't be spent to cast nonartifact spells.\n(Melds with Urza, Lord Protector.)",
             "colours": [
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "ca11a65f-4f32-5548-b507-af7484ca98b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa63321-aa28-449d-a31f-869a98c5a6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa63321-aa28-449d-a31f-869a98c5a6be.jpg?1",
             "name": "Mine Worker",
             "text": "{T}: You gain 1 life. If you control creatures named Power Plant Worker and Tower Worker, you gain 3 life instead.",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "a275f01f-6b25-5ce6-bd51-9153b1c7f94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608efc-0dbc-4cc3-aadd-ed473bfc29ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608efc-0dbc-4cc3-aadd-ed473bfc29ab.jpg?1",
             "name": "Portal to Phyrexia",
             "text": "When Portal to Phyrexia enters the battlefield, each opponent sacrifices three creatures.\nAt the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control. It's a Phyrexian in addition to its other types.",
             "colours": [],
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "a2598db8-76dc-542a-a56c-c99af0a101a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99965310-e4bd-40d9-80f5-3fd1754c61c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99965310-e4bd-40d9-80f5-3fd1754c61c5.jpg?1",
             "name": "Power Plant Worker",
             "text": "{3}: Power Plant Worker gets +2/+2 until end of turn. If you control creatures named Mine Worker and Tower Worker, put two +1/+1 counters on Power Plant Worker instead. Activate only once each turn.",
             "colours": [],
@@ -8356,7 +8356,7 @@
         },
         {
             "id": "fd8a3125-d584-5d26-9aea-c257e971a938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc8a8d8-6d8e-44b3-a29b-5fa4a851a25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc8a8d8-6d8e-44b3-a29b-5fa4a851a25b.jpg?1",
             "name": "Reconstructed Thopter",
             "text": "Flying\nUnearth {2} ({2}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "74de0397-b875-5f40-93c0-5d5ac07c2154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbfa72-2025-455c-8cc4-afbf6c8e141a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbfa72-2025-455c-8cc4-afbf6c8e141a.jpg?1",
             "name": "Slagstone Refinery",
             "text": "Whenever Slagstone Refinery or another nontoken artifact you control is put into a graveyard from the battlefield or is put into exile from the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [],
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "13aeee91-aa42-562c-a501-873274e3d203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cbe05-7b36-4569-94f3-671c28c7468a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cbe05-7b36-4569-94f3-671c28c7468a.jpg?1",
             "name": "Spectrum Sentinel",
             "text": "Protection from multicolored (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything multicolored.)\nWhenever a nonbasic land enters the battlefield under an opponent's control, you gain 1 life.",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "4b8a9ed6-0ace-5791-8355-369b54e27e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45537ac3-fc61-4253-a782-7f3e436b2aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45537ac3-fc61-4253-a782-7f3e436b2aa6.jpg?1",
             "name": "The Stasis Coffin",
             "text": "{2}, {T}, Exile The Stasis Coffin: You gain protection from everything until your next turn.",
             "colours": [],
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "20e2afbc-32a0-504c-8320-c6775f2d6633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386c139a-13fc-49ca-923d-45faca4f9a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386c139a-13fc-49ca-923d-45faca4f9a2f.jpg?1",
             "name": "Steel Exemplar",
             "text": "Trample\nSteel Exemplar enters the battlefield with two +1/+1 counters on it unless two or more colors of mana were spent to cast it.",
             "colours": [],
@@ -8509,7 +8509,7 @@
         },
         {
             "id": "23bdec55-7f79-5517-a5f8-c029016e7bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570ebf2-a94c-4621-8808-b06e6e830c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570ebf2-a94c-4621-8808-b06e6e830c06.jpg?1",
             "name": "The Stone Brain",
             "text": "{2}, {T}, Exile The Stone Brain: Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way. Activate only as a sorcery.",
             "colours": [],
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "5e13f63c-637e-5bba-8224-6c3883fd6f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a36d1f-f6cc-4962-9ad6-589f7b3e5f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a36d1f-f6cc-4962-9ad6-589f7b3e5f95.jpg?1",
             "name": "Stone Retrieval Unit",
             "text": "When Stone Retrieval Unit enters the battlefield, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [],
@@ -8572,7 +8572,7 @@
         },
         {
             "id": "b97d4f4c-8626-579f-b8f6-6ab638abbde4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb04dad2-4561-4cef-9cee-80d6f1a44bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb04dad2-4561-4cef-9cee-80d6f1a44bee.jpg?1",
             "name": "Su-Chi Cave Guard",
             "text": "Vigilance\nWard {4} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {4}.)\nWhen Su-Chi Cave Guard dies, add eight {C}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -8603,7 +8603,7 @@
         },
         {
             "id": "8b4513b5-ca5f-5b2b-b6aa-5a99fba37c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a5d3e9-bada-448b-894d-9d4e7e0463c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a5d3e9-bada-448b-894d-9d4e7e0463c7.jpg?1",
             "name": "Supply Drop",
             "text": "Flash\nWhen Supply Drop enters the battlefield, target creature you control gets +2/+2 until end of turn.\n{4}, {T}, Sacrifice Supply Drop: Draw a card.",
             "colours": [],
@@ -8631,7 +8631,7 @@
         },
         {
             "id": "db63275f-5242-5c0d-8e47-8548f2a75a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ae38a2-2f95-4750-9b59-53eb1771e5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ae38a2-2f95-4750-9b59-53eb1771e5ab.jpg?1",
             "name": "Swiftgear Drake",
             "text": "Flying, haste\nWhen Swiftgear Drake enters the battlefield, put up to one target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "88e78772-4102-563a-a56d-5cb178adacac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786bce65-1c04-45fc-b81b-e7590afbd117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786bce65-1c04-45fc-b81b-e7590afbd117.jpg?1",
             "name": "Symmetry Matrix",
             "text": "Whenever a creature with power equal to its toughness enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [],
@@ -8690,7 +8690,7 @@
         },
         {
             "id": "37d12ab5-9cd2-5342-ae01-e6714f4c18d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bfb8c5-9105-41e4-a58f-9c9eee32b18a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bfb8c5-9105-41e4-a58f-9c9eee32b18a.jpg?1",
             "name": "Thran Power Suit",
             "text": "Equipped creature gets +1/+1 for each Aura and Equipment attached to it and has ward {2}. (Whenever equipped creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "372e83af-fdcf-539e-8357-ceec0a7f8662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e0ddb-3dd4-4db3-aa05-dec8691432a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e0ddb-3dd4-4db3-aa05-dec8691432a0.jpg?1",
             "name": "Thran Spider",
             "text": "Reach\nWhen Thran Spider enters the battlefield, you and target opponent each create a tapped Powerstone token.\n{7}: Look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8753,7 +8753,7 @@
         },
         {
             "id": "9deb8927-52f0-5ba8-a1f4-105b0abbc8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bd134-22c8-4031-8f85-ac0855914d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bd134-22c8-4031-8f85-ac0855914d11.jpg?1",
             "name": "Tower Worker",
             "text": "Reach\n{T}: Add {C}. If you control creatures named Mine Worker and Power Plant Worker, add {C}{C}{C} instead.",
             "colours": [],
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "39396ccd-e82b-59a3-9bdf-764cc8c17f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29c9e4f-7b98-4610-a681-ae6297e8fc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29c9e4f-7b98-4610-a681-ae6297e8fc72.jpg?1",
             "name": "Argoth, Sanctum of Nature // Titania, Gaea Incarnate",
             "text": "Argoth, Sanctum of Nature enters the battlefield tapped unless you control a legendary green creature.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Create a 2/2 green Bear creature token, then mill three cards. Activate only as a sorcery.\n(Melds with Titania, Voice of Gaea.)",
             "colours": [],
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "8736023c-a553-572a-a00c-07fca44030a8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/414b9230-9d25-4bdf-8b1e-b4fa2035b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414b9230-9d25-4bdf-8b1e-b4fa2035b6a4.jpg?1",
             "name": "Titania, Gaea Incarnate",
             "text": "Argoth, Sanctum of Nature enters the battlefield tapped unless you control a legendary green creature.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Create a 2/2 green Bear creature token, then mill three cards. Activate only as a sorcery.\n(Melds with Titania, Voice of Gaea.)",
             "colours": [
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "cf5c593c-e1fc-5eb7-b6a6-dbee9d8d65d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642584bb-7586-4796-9b94-f01ec5bd9e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642584bb-7586-4796-9b94-f01ec5bd9e9f.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "dccb779e-5a01-586d-9902-27e20ce8ba98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e911be-8166-4263-8c57-e86358b8ceb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e911be-8166-4263-8c57-e86358b8ceb8.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -8914,7 +8914,7 @@
         },
         {
             "id": "727a1c9a-40f0-5c81-b069-b7d401e49e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d236ce-3b78-403a-b5f9-4fb44123d85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d236ce-3b78-403a-b5f9-4fb44123d85b.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {W}. Brushland deals 1 damage to you.",
             "colours": [],
@@ -8947,7 +8947,7 @@
         },
         {
             "id": "eb840c40-ae48-5964-a12b-7f59708f34e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c88546-13c9-4d7e-a618-cb2ccd1dbc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9c88546-13c9-4d7e-a618-cb2ccd1dbc0f.jpg?1",
             "name": "Demolition Field",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Demolition Field: Destroy target nonbasic land an opponent controls. That land's controller may search their library for a basic land card, put it onto the battlefield, then shuffle. You may search your library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "a1897b41-e40b-557a-83cc-3207a114890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238de888-b1bd-4cce-9aa2-d0dd69ae7f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238de888-b1bd-4cce-9aa2-d0dd69ae7f0d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9003,7 +9003,7 @@
         },
         {
             "id": "d6d6bf3d-8b9d-5f5a-9d59-bd27c5a7c780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e248204c-865d-42d9-b745-8ff73225b4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e248204c-865d-42d9-b745-8ff73225b4a1.jpg?1",
             "name": "Fortified Beachhead",
             "text": "As Fortified Beachhead enters the battlefield, you may reveal a Soldier card from your hand. Fortified Beachhead enters the battlefield tapped unless you revealed a Soldier card this way or you control a Soldier.\n{T}: Add {W} or {U}.\n{5}, {T}: Soldiers you control get +1/+1 until end of turn.",
             "colours": [],
@@ -9036,7 +9036,7 @@
         },
         {
             "id": "88ca67b5-006e-5901-bdba-383f75973ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8007012-39c5-4247-ba77-1cfcaade37fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8007012-39c5-4247-ba77-1cfcaade37fa.jpg?1",
             "name": "Hall of Tagsin",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}: Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")",
             "colours": [],
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "152d799e-5eae-534c-aee1-d37786f3eadd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10716909-1254-4b2b-997e-23a18994a98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10716909-1254-4b2b-997e-23a18994a98d.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "ff2169a0-a9f2-5b5a-9cc8-6892aa68fba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7699b2-e1af-4bc0-8c5b-84ba3e868d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7699b2-e1af-4bc0-8c5b-84ba3e868d7c.jpg?1",
             "name": "Mishra's Foundry",
             "text": "{T}: Add {C}.\n{2}: Mishra's Foundry becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
             "colours": [],
@@ -9130,7 +9130,7 @@
         },
         {
             "id": "da276698-7a48-58fc-839f-332a8506e850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d4b90c-95b1-4828-bc08-7067da0d5364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d4b90c-95b1-4828-bc08-7067da0d5364.jpg?1",
             "name": "Tocasia's Dig Site",
             "text": "{T}: Add {C}.\n{3}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [],
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "64a65d7e-44b3-5ac8-98c1-d02338a1cdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb52820c-8660-4c4a-bb64-5b2fc580b6a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb52820c-8660-4c4a-bb64-5b2fc580b6a3.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Underground River deals 1 damage to you.",
             "colours": [],
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "9ae1ab61-b907-5f63-992c-424bf6bcd3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22de1edc-ec67-4694-ab88-2a679c8a450f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22de1edc-ec67-4694-ab88-2a679c8a450f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "8b72255b-bf4f-5191-b99d-41718b0c6892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd136b1-c276-41f9-98ee-3e07eb87bacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd136b1-c276-41f9-98ee-3e07eb87bacb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9267,7 +9267,7 @@
         },
         {
             "id": "02dec623-655b-5a5a-9869-f97d19cbeb5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee75629-86b4-40b0-884a-22646ebf6e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee75629-86b4-40b0-884a-22646ebf6e27.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "ab4ab447-e7d7-5847-9ea6-b970ef9bc917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35ed4f-fa34-4fd6-b7d8-3c4aeda1e9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35ed4f-fa34-4fd6-b7d8-3c4aeda1e9ea.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9343,7 +9343,7 @@
         },
         {
             "id": "752304e1-c429-5e37-b7d0-961c6061f03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c90f777-2f98-4010-80a3-5fe395747e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c90f777-2f98-4010-80a3-5fe395747e5f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9381,7 +9381,7 @@
         },
         {
             "id": "21a2532d-1274-526b-8a5c-bc6697c74502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcf9b0-ee35-4911-b515-7182e703beba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcf9b0-ee35-4911-b515-7182e703beba.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "3c268a24-8845-5c9e-88d0-56c4377c6e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95083e1d-faf5-40e4-9be5-909cd01cc2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95083e1d-faf5-40e4-9be5-909cd01cc2b5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "e0e70bea-af7e-5e64-bd1c-a3bd21a7b5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf2ec64-a850-47e3-91a8-7323e04a5f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf2ec64-a850-47e3-91a8-7323e04a5f4a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9495,7 +9495,7 @@
         },
         {
             "id": "2c28ab78-255f-538a-af7a-6153c75718cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63eab07-46e5-4b75-954f-b5a9f1f451cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63eab07-46e5-4b75-954f-b5a9f1f451cd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9533,7 +9533,7 @@
         },
         {
             "id": "2a980176-aa7f-5adf-8dda-03381fc12295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73d19b-72e3-4944-ac20-5b4c7b54c2aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a73d19b-72e3-4944-ac20-5b4c7b54c2aa.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9571,7 +9571,7 @@
         },
         {
             "id": "01536373-791b-5b3d-8552-7f913bf3229e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e134268-9ce9-4192-b548-90bedbfe654e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e134268-9ce9-4192-b548-90bedbfe654e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9609,7 +9609,7 @@
         },
         {
             "id": "e6f6c943-e131-597f-b8af-f1278c770725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b6636d-a342-4d49-9d1a-ab15b3d837c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b6636d-a342-4d49-9d1a-ab15b3d837c5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9647,7 +9647,7 @@
         },
         {
             "id": "d6a46536-5dcf-5b89-a382-0070a2cd4f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d36d3-9373-407c-91fd-975d8ee9e4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d36d3-9373-407c-91fd-975d8ee9e4fe.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9685,7 +9685,7 @@
         },
         {
             "id": "175704bb-12d2-5d7a-9d1c-1eef3b02d3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20af588-2ce3-4e5a-9ab3-949401ead071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d20af588-2ce3-4e5a-9ab3-949401ead071.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9723,7 +9723,7 @@
         },
         {
             "id": "f3d2fe2d-46b9-5e21-bffa-4d5e5be8f2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabe866d-01c3-4ec5-9d41-70305208c2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabe866d-01c3-4ec5-9d41-70305208c2b1.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9761,7 +9761,7 @@
         },
         {
             "id": "11324c99-a07b-5f8f-b1b2-67802e5a254a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7232adef-c8eb-461f-b563-cb54cdeb22d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7232adef-c8eb-461f-b563-cb54cdeb22d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "3fa31ad3-44af-5fba-b955-2b42a9954bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b81a-3d91-4d07-bc9d-6756780417e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b81a-3d91-4d07-bc9d-6756780417e3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "2cdc66e7-edc9-531f-8a3a-f3fd34e9f881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd757142-45b7-40db-80f2-fe161379aa4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd757142-45b7-40db-80f2-fe161379aa4e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9875,7 +9875,7 @@
         },
         {
             "id": "22f0524a-7d97-5a61-b802-0b99dc79a11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b7277-0c09-42ab-aa6b-542a1e402580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b7277-0c09-42ab-aa6b-542a1e402580.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9913,7 +9913,7 @@
         },
         {
             "id": "e8a22501-2304-5dd8-b7c8-ab755ef9caef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c2a41c-e974-4c14-8d01-d278ecdb31bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c2a41c-e974-4c14-8d01-d278ecdb31bc.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9951,7 +9951,7 @@
         },
         {
             "id": "421fb941-5bb8-582b-99e7-d59aa251f2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598def2c-003c-4aa4-ac7c-44ffd9639fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598def2c-003c-4aa4-ac7c-44ffd9639fdc.jpg?1",
             "name": "Rescue Retriever",
             "text": "Flash\nWhen Rescue Retriever enters the battlefield, put a +1/+1 counter on each other Soldier you control.\nPrevent all damage that would be dealt to other attacking Soldiers you control.",
             "colours": [
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "00a2b46d-8f74-56e1-bee2-6d7a7b9c323e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb1f21c-60fa-4fcc-844b-25bf5b47fd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb1f21c-60fa-4fcc-844b-25bf5b47fd1f.jpg?1",
             "name": "Geology Enthusiast",
             "text": "At the beginning of your end step, create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n{6}: Draw a card and put a +1/+1 counter on Geology Enthusiast.",
             "colours": [
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "d3ef8a19-4b2a-5ca6-a08a-e93915119d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31215674-0bcd-46f1-b8a1-5415f8b674d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31215674-0bcd-46f1-b8a1-5415f8b674d1.jpg?1",
             "name": "Terror Ballista",
             "text": "Menace\nWhenever Terror Ballista attacks, you may sacrifice another creature. When you do, destroy target creature an opponent controls.\nUnearth {3}{B}{B} ({3}{B}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -10060,7 +10060,7 @@
         },
         {
             "id": "5228982e-997d-5edc-9d3d-a29252504277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd88d6c-7d3a-45b1-85b4-b390d60cae14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd88d6c-7d3a-45b1-85b4-b390d60cae14.jpg?1",
             "name": "Artificer's Dragon",
             "text": "Flying\n{R}: Artifact creatures you control get +1/+0 until end of turn.\nUnearth {3}{R}{R} ({3}{R}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [],
@@ -10095,7 +10095,7 @@
         },
         {
             "id": "a89e0ffd-5b3b-5227-8818-e4270e8f06d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0418156-bcba-4edc-8ea5-ce9ca9b979bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0418156-bcba-4edc-8ea5-ce9ca9b979bd.jpg?1",
             "name": "Woodcaller Automaton",
             "text": "When Woodcaller Automaton enters the battlefield, if you cast it, untap target land you control. It becomes a Treefolk creature with haste and base power and toughness equal to Woodcaller Automaton's power and toughness. It's still a land.\n//PRT-Prototype_\nMech//\n{2}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -10130,7 +10130,7 @@
         },
         {
             "id": "5f68bc3e-b091-5664-852a-77a5b76da717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee692dd-4030-4783-92a8-21304e40533a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee692dd-4030-4783-92a8-21304e40533a.jpg?1",
             "name": "Teferi, Temporal Pilgrim",
             "text": "Whenever you draw a card, put a loyalty counter on Teferi, Temporal Pilgrim.\n0: Draw a card.\n\u22122: Create a 2/2 blue Spirit creature token with vigilance and \"Whenever you draw a card, put a +1/+1 counter on this creature.\"\n\u221212: Target opponent chooses a permanent they control and returns it to its owner's hand. Then they shuffle each nonland permanent they control into its owner's library.",
             "colours": [
@@ -10168,7 +10168,7 @@
         },
         {
             "id": "2fcf94ae-3197-595e-ab1b-c2e5ce1bdc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d40063a-7397-49a5-80c6-6e4f245e1e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d40063a-7397-49a5-80c6-6e4f245e1e2e.jpg?1",
             "name": "Saheeli, Filigree Master",
             "text": "+1: Scry 1. You may tap an untapped artifact you control. If you do, draw a card.\n\u22122: Create two 1/1 colorless Thopter artifact creature tokens with flying. They gain haste until end of turn.\n\u22124: You get an emblem with \"Artifact creatures you control get +1/+1\" and \"Artifact spells you cast cost {1} less to cast.\"",
             "colours": [
@@ -10208,7 +10208,7 @@
         },
         {
             "id": "7644f06e-d2b5-5c2b-9e79-74423cc282e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81aac1-4d23-4826-912e-6355d8ccb3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc81aac1-4d23-4826-912e-6355d8ccb3ee.jpg?1",
             "name": "Mishra, Tamer of Mak Fawa",
             "text": "Permanents you control have \"Ward\u2014\nSacrifice a permanent.\"\nEach artifact card in your graveyard has unearth {1}{B}{R}.",
             "colours": [
@@ -10249,7 +10249,7 @@
         },
         {
             "id": "9dd2f168-d9d5-5e65-a488-0d49e3453c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f944c2f-c84f-4986-9e6f-ec8e171298c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f944c2f-c84f-4986-9e6f-ec8e171298c6.jpg?1",
             "name": "Urza, Prince of Kroog",
             "text": "Artifact creatures you control get +2/+2.\n{6}: Create a token that's a copy of target artifact you control, except it's a 1/1 Soldier creature in addition to its other types.",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "45879fad-95e2-56b7-8c66-f6418fd71c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd1d94-9ae2-46dc-9ece-26e72a323fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd1d94-9ae2-46dc-9ece-26e72a323fd1.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -10323,7 +10323,7 @@
         },
         {
             "id": "31471d99-2558-5cca-a3c0-d3e9c9205d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98178c9d-e113-4f0e-9a7b-3ebfaafe2503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98178c9d-e113-4f0e-9a7b-3ebfaafe2503.jpg?1",
             "name": "Brushland",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {W}. Brushland deals 1 damage to you.",
             "colours": [],
@@ -10356,7 +10356,7 @@
         },
         {
             "id": "e305d472-817d-5df3-bfa6-99ddd364aff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8528e41-299d-461e-83c6-04ba3da6b17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8528e41-299d-461e-83c6-04ba3da6b17d.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -10389,7 +10389,7 @@
         },
         {
             "id": "0ae3a904-ab32-52c3-a419-4253baa2805e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4fa784-010d-4b27-9e35-43ad78e1ed5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4fa784-010d-4b27-9e35-43ad78e1ed5e.jpg?1",
             "name": "Underground River",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Underground River deals 1 damage to you.",
             "colours": [],
@@ -10422,7 +10422,7 @@
         },
         {
             "id": "521456b0-a324-5792-b178-b829a3694544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257ab263-a9f2-4376-ad43-46150a39fcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257ab263-a9f2-4376-ad43-46150a39fcdb.jpg?1",
             "name": "In the Trenches",
             "text": "Creatures you control get +1/+1.\n{5}{W}: Exile target nonland permanent you don't control until In the Trenches leaves the battlefield. Activate only as a sorcery and only once.",
             "colours": [
@@ -10456,7 +10456,7 @@
         },
         {
             "id": "7e776c0c-cd71-5916-be3d-0bd009990d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed2cec-7935-49b8-9fdf-5168e228edb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feed2cec-7935-49b8-9fdf-5168e228edb7.jpg?1",
             "name": "Kayla's Command",
             "text": "Choose two \u2014\n\u2022 Create a 2/2 colorless Construct artifact creature token.\n\u2022 Put a +1/+1 counter on a creature you control. It gains double strike until end of turn.\n\u2022 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n\u2022 You gain 2 life and scry 2.",
             "colours": [
@@ -10490,7 +10490,7 @@
         },
         {
             "id": "d325ae4a-84ec-5348-add0-99ae78d85ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63feee-550c-4d6c-a50b-9340b12832e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63feee-550c-4d6c-a50b-9340b12832e4.jpg?1",
             "name": "Kayla's Reconstruction",
             "text": "Look at the top seven cards of your library. Put up to X artifact and/or creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10524,7 +10524,7 @@
         },
         {
             "id": "bd7e5700-5ffc-5434-a0d0-75877b5a5a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35a0fc1-790e-4f47-b756-a6b4b298e299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35a0fc1-790e-4f47-b756-a6b4b298e299.jpg?1",
             "name": "Loran of the Third Path",
             "text": "Vigilance\nWhen Loran of the Third Path enters the battlefield, destroy up to one target artifact or enchantment.\n{T}: You and target opponent each draw a card.",
             "colours": [
@@ -10563,7 +10563,7 @@
         },
         {
             "id": "13581180-e40f-5482-9e82-8b1d4e4332e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977da60c-073a-42d1-b9f5-789a2b7071b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977da60c-073a-42d1-b9f5-789a2b7071b8.jpg?1",
             "name": "Myrel, Shield of Argive",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.\nWhenever Myrel, Shield of Argive attacks, create X 1/1 colorless Soldier artifact creature tokens, where X is the number of Soldiers you control.",
             "colours": [
@@ -10602,7 +10602,7 @@
         },
         {
             "id": "4189b180-4dcf-5de5-a98c-7bd168f7feef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b4140-ba70-4860-b6cc-cb307da3793a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b4140-ba70-4860-b6cc-cb307da3793a.jpg?1",
             "name": "Siege Veteran",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\nWhenever another nontoken Soldier you control dies, create a 1/1 colorless Soldier artifact creature token.",
             "colours": [
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "212ffd05-1709-5367-974d-de45edf2148f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798bdb6-a04e-4dce-bd4a-f54b907b9f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798bdb6-a04e-4dce-bd4a-f54b907b9f36.jpg?1",
             "name": "Soul Partition",
             "text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may play it. A spell cast by an opponent this way costs {2} more to cast.",
             "colours": [
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "5b6ee7f1-4b45-53d9-b09a-e604743f1cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedc76a2-f0b2-4cb3-8662-88537b7474cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedc76a2-f0b2-4cb3-8662-88537b7474cc.jpg?1",
             "name": "Tocasia's Welcome",
             "text": "Whenever one or more creatures with mana value 3 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -10707,7 +10707,7 @@
         },
         {
             "id": "d6e86456-532a-5fde-8356-a1cf3fb20bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a6c36-7ca2-433c-95f4-b9b4d9f638b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a6c36-7ca2-433c-95f4-b9b4d9f638b1.jpg?1",
             "name": "Autonomous Assembler",
             "text": "Vigilance\n{1}, {T}: Put a +1/+1 counter on target Assembly-Worker you control.\n//PRT-Prototype_\nMech//\n{1}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -10742,7 +10742,7 @@
         },
         {
             "id": "896211d1-4b92-5bc5-8e0c-2a5abee89f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1549221a-9b37-44a9-af36-9c2e6c99684e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1549221a-9b37-44a9-af36-9c2e6c99684e.jpg?1",
             "name": "Platoon Dispenser",
             "text": "At the beginning of your end step, if you control two or more other creatures, draw a card.\n{3}{W}: Create a 1/1 colorless Soldier artifact creature token.\nUnearth {2}{W}{W}",
             "colours": [],
@@ -10777,7 +10777,7 @@
         },
         {
             "id": "24e509f5-73ee-5c78-b869-35d5ea33e7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a0d3d-58a7-42e3-923b-cc14b85716f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a0d3d-58a7-42e3-923b-cc14b85716f6.jpg?1",
             "name": "Steel Seraph",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gains your choice of flying, vigilance, or lifelink until end of turn.\n//PRT-Prototype_\nMech//\n{1}{W}{W}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -10812,7 +10812,7 @@
         },
         {
             "id": "776f4f5e-39df-524e-b162-f379c6b729dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01c3c7c-d9a0-421b-8174-310b3e3cb163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01c3c7c-d9a0-421b-8174-310b3e3cb163.jpg?1",
             "name": "Urza's Sylex",
             "text": "{2}{W}{W}, {T}, Exile Urza's Sylex: Each player chooses six lands they control. Destroy all other permanents. Activate only as a sorcery.\nWhen Urza's Sylex is put into exile from the battlefield, you may pay {2}. If you do, search your library for a planeswalker card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -10846,7 +10846,7 @@
         },
         {
             "id": "a7d33e0d-857d-557a-b664-525e89d5a4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f9fd87-5c9b-4732-b8a5-f6be360a5fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f9fd87-5c9b-4732-b8a5-f6be360a5fa5.jpg?1",
             "name": "Drafna, Founder of Lat-Nam",
             "text": "{1}{U}: Return target artifact you control to its owner's hand.\n{3}, {T}: Copy target artifact spell you control.",
             "colours": [
@@ -10886,7 +10886,7 @@
         },
         {
             "id": "1c6cf0f6-2b76-5672-a128-bd465c129a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9392a373-0629-4f58-905f-292f3e069127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9392a373-0629-4f58-905f-292f3e069127.jpg?1",
             "name": "Hurkyl, Master Wizard",
             "text": "At the beginning of your end step, if you've cast a noncreature spell this turn, reveal the top five cards of your library. For each card type among noncreature spells you've cast this turn, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10926,7 +10926,7 @@
         },
         {
             "id": "c43526cb-fc87-52d6-81ef-7b598e041b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00e1564-f11e-44b9-b4ac-7a327a854e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00e1564-f11e-44b9-b4ac-7a327a854e6b.jpg?1",
             "name": "Hurkyl's Final Meditation",
             "text": "As long as it's not your turn, this spell costs {3} more to cast.\nReturn all nonland permanents to their owners' hands. End the turn.",
             "colours": [
@@ -10960,7 +10960,7 @@
         },
         {
             "id": "000fe506-f3b7-5c10-98ed-9c77aa47f90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e44a396-d09d-4f87-9c04-0f74d94a3dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e44a396-d09d-4f87-9c04-0f74d94a3dcd.jpg?1",
             "name": "One with the Multiverse",
             "text": "You may look at the top card of your library any time.\nYou may play lands and cast spells from the top of your library.\nOnce during each of your turns, you may cast a spell from your hand or the top of your library without paying its mana cost.",
             "colours": [
@@ -10994,7 +10994,7 @@
         },
         {
             "id": "4106a07d-e28a-584f-91a7-2cb9dc194a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d01c40-d5fe-4dc5-9358-02dac8542509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d01c40-d5fe-4dc5-9358-02dac8542509.jpg?1",
             "name": "Skystrike Officer",
             "text": "Flying\nWhenever Skystrike Officer attacks, create a 1/1 colorless Soldier artifact creature token.\nTap three untapped Soldiers you control: Draw a card.",
             "colours": [
@@ -11031,7 +11031,7 @@
         },
         {
             "id": "bb182d22-cb99-5aa1-bb16-12c05bd34f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1511ad30-16fb-48d9-887e-fce5caede441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1511ad30-16fb-48d9-887e-fce5caede441.jpg?1",
             "name": "Urza's Command",
             "text": "Choose two \u2014\n\u2022 Creatures you don't control get -2/-0 until end of turn.\n\u2022 Create a tapped Powerstone token.\n\u2022 Create a tapped 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\n\u2022 Scry 1, then draw a card.",
             "colours": [
@@ -11065,7 +11065,7 @@
         },
         {
             "id": "7a16b020-5aef-5d65-bcae-69de05097a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57ef48e-66e6-4395-9cf2-6eb634523874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57ef48e-66e6-4395-9cf2-6eb634523874.jpg?1",
             "name": "Arcane Proxy",
             "text": "When Arcane Proxy enters the battlefield, if you cast it, exile target instant or sorcery card with mana value less than or equal to Arcane Proxy's power from your graveyard. Copy that card. You may cast the copy without paying its mana cost.\n//PRT-Prototype_\nMech//\n{1}{U}{U}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/1",
             "colours": [],
@@ -11100,7 +11100,7 @@
         },
         {
             "id": "6a59fbee-ff2e-507f-812a-23cd707579c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a4b87-59fd-45fd-a6ea-598e49fc2cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a4b87-59fd-45fd-a6ea-598e49fc2cc5.jpg?1",
             "name": "Surge Engine",
             "text": "Defender\n{U}: Surge Engine loses defender and gains \"This creature can't be blocked.\"\n{2}{U}: Surge Engine becomes blue and has base power and toughness 5/4. Activate only if Surge Engine doesn't have defender.\n{4}{U}{U}: Draw three cards. Activate only if Surge Engine is blue and only once.",
             "colours": [],
@@ -11135,7 +11135,7 @@
         },
         {
             "id": "1cb4597b-95e2-5ec8-b550-f8079fba21f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72c739-9897-4d50-8232-45027869e4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f72c739-9897-4d50-8232-45027869e4c3.jpg?1",
             "name": "The Temporal Anchor",
             "text": "At the beginning of your upkeep, scry 2.\nWhenever you choose to put one or more cards on the bottom of your library while scrying, exile that many cards from the bottom of your library.\nDuring your turn, you may play cards exiled with The Temporal Anchor.",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "808a3a0c-9764-51d2-a179-bae8f1acbfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfc1f6e-9a93-4608-905f-f1fe7d1a9ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfc1f6e-9a93-4608-905f-f1fe7d1a9ee1.jpg?1",
             "name": "Terisian Mindbreaker",
             "text": "Whenever Terisian Mindbreaker attacks, defending player mills half their library, rounded up.\nUnearth {1}{U}{U}{U}",
             "colours": [],
@@ -11206,7 +11206,7 @@
         },
         {
             "id": "b874e3fe-1a87-5974-a757-ee9f4f87db96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e6775a-f711-4709-a4c7-ae159023f0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e6775a-f711-4709-a4c7-ae159023f0fd.jpg?1",
             "name": "Ashnod, Flesh Mechanist",
             "text": "Deathtouch\nWhenever Ashnod, Flesh Mechanist attacks, you may sacrifice another creature. If you do, create a tapped Powerstone token.\n{5}, Exile a creature card from your graveyard: Create a tapped 3/3 colorless Zombie artifact creature token.",
             "colours": [
@@ -11245,7 +11245,7 @@
         },
         {
             "id": "e54be92e-5052-5a31-874c-4224fc5e9e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a21794-dea0-46c8-a575-c41527ea46b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a21794-dea0-46c8-a575-c41527ea46b5.jpg?1",
             "name": "Diabolic Intent",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -11279,7 +11279,7 @@
         },
         {
             "id": "53d494ab-cbc8-56f1-9228-af413b29f3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15095c3-b9a1-43e2-8140-2a73a89336de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15095c3-b9a1-43e2-8140-2a73a89336de.jpg?1",
             "name": "Fateful Handoff",
             "text": "Draw cards equal to the mana value of target artifact or creature you control. An opponent gains control of that permanent.",
             "colours": [
@@ -11313,7 +11313,7 @@
         },
         {
             "id": "676270f1-744d-5dfe-b46f-7d415bc75bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87dbd3-1b80-4c91-b4f7-b13bdd885c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87dbd3-1b80-4c91-b4f7-b13bdd885c3c.jpg?1",
             "name": "Gix, Yawgmoth Praetor",
             "text": "Whenever a creature deals combat damage to one of your opponents, its controller may pay 1 life. If they do, they draw a card.\n{4}{B}{B}{B}, Discard X cards: Exile the top X cards of target opponent's library. You may play lands and cast spells from among cards exiled this way without paying their mana costs.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "c0417813-e68a-5dd7-9062-20d26db306ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2495b60a-7cd0-4514-84ff-f82f28602d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2495b60a-7cd0-4514-84ff-f82f28602d42.jpg?1",
             "name": "Gix's Command",
             "text": "Choose two \u2014\n\u2022 Put two +1/+1 counters on up to one creature. It gains lifelink until end of turn.\n\u2022 Destroy each creature with power 2 or less.\n\u2022 Return up to two creature cards from your graveyard to your hand.\n\u2022 Each opponent sacrifices a creature with the highest power among creatures they control.",
             "colours": [
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "8637f38e-2e68-5264-a019-c8d49eb255ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a114052-6cd1-4f88-ab5a-0828f7fd3bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a114052-6cd1-4f88-ab5a-0828f7fd3bf2.jpg?1",
             "name": "Gixian Puppeteer",
             "text": "Whenever you draw your second card each turn, each opponent loses 2 life and you gain 2 life.\nWhen Gixian Puppeteer dies, return another target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "7cd0a1de-2e2d-5bc2-bf6f-f37e7a0f8318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9525527a-1f4d-4050-893a-cbeca21dceeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9525527a-1f4d-4050-893a-cbeca21dceeb.jpg?1",
             "name": "Hostile Negotiations",
             "text": "Exile the top three cards of your library in a face-down pile, then exile the top three cards of your library in another face-down pile. Look at the cards in each pile, then turn a pile of your choice face up. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. You lose 3 life.",
             "colours": [
@@ -11457,7 +11457,7 @@
         },
         {
             "id": "1d951dc7-36de-5196-b9b1-a018eeadddf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ed1ad1-f28b-4de3-8df6-ad5bdcf393c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ed1ad1-f28b-4de3-8df6-ad5bdcf393c1.jpg?1",
             "name": "Misery's Shadow",
             "text": "If a creature an opponent controls would die, exile it instead.\n{1}: Misery's Shadow gets +1/+1 until end of turn.",
             "colours": [
@@ -11493,7 +11493,7 @@
         },
         {
             "id": "0050066b-8882-5a39-8c5a-232f02ee7a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97467f7-01a9-46c8-8e1c-7ebc5f65a0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97467f7-01a9-46c8-8e1c-7ebc5f65a0c1.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless they discard a card.",
             "colours": [
@@ -11527,7 +11527,7 @@
         },
         {
             "id": "751e08c6-2cdf-5200-891d-64cbadc68fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dc4676-5e8e-4ce8-a7f7-8cb956bd5a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dc4676-5e8e-4ce8-a7f7-8cb956bd5a10.jpg?1",
             "name": "Phyrexian Fleshgorger",
             "text": "Menace, lifelink\nWard\u2014\nPay life equal to Phyrexian Fleshgorger's power.\n//PRT-Prototype_\nMech//\n{1}{B}{B}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -11563,7 +11563,7 @@
         },
         {
             "id": "bfa1c763-6166-5487-a4b7-93b0eab62bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e021e750-74f3-466a-b670-f5cd9cebb84a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e021e750-74f3-466a-b670-f5cd9cebb84a.jpg?1",
             "name": "Razorlash Transmogrant",
             "text": "Razorlash Transmogrant can't block.\n{4}{B}{B}: Return Razorlash Transmogrant from your graveyard to the battlefield with a +1/+1 counter on it. This ability costs {4} less to activate if an opponent controls four or more nonbasic lands.",
             "colours": [],
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "f3f71420-d2bb-53d3-a37a-27a8cc3fcf97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c99eb4-0c18-461c-ad26-0351adbf0a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c99eb4-0c18-461c-ad26-0351adbf0a3c.jpg?1",
             "name": "Transmogrant's Crown",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, draw a card.\nEquip {2} or {B}",
             "colours": [],
@@ -11632,7 +11632,7 @@
         },
         {
             "id": "ee202a92-b224-5b8f-ab58-78aa261086a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c3d2cc-e2d8-4b44-9f87-17d25b5918a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c3d2cc-e2d8-4b44-9f87-17d25b5918a1.jpg?1",
             "name": "Brotherhood's End",
             "text": "Choose one \u2014\n\u2022 Brotherhood's End deals 3 damage to each creature and each planeswalker.\n\u2022 Destroy all artifacts with mana value 3 or less.",
             "colours": [
@@ -11666,7 +11666,7 @@
         },
         {
             "id": "54d9f51f-3ce4-59d8-9b29-a19ad0473e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce511-ecc3-48f7-80ec-66f3367998ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce511-ecc3-48f7-80ec-66f3367998ff.jpg?1",
             "name": "Draconic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying, haste, and \"{1}: This creature gets +1/+0 until end of turn.\" It's a Dragon in addition to its other types.\nWhen enchanted creature dies, return Draconic Destiny to its owner's hand.",
             "colours": [
@@ -11702,7 +11702,7 @@
         },
         {
             "id": "42b513b4-1eb0-5b70-866d-56fd0a454dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5e5ae-e35a-4be0-bc13-0d7f41506a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e5e5ae-e35a-4be0-bc13-0d7f41506a26.jpg?1",
             "name": "Feldon, Ronom Excavator",
             "text": "Haste\nFeldon, Ronom Excavator can't block.\nWhenever Feldon is dealt damage, exile that many cards from the top of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -11741,7 +11741,7 @@
         },
         {
             "id": "456a210c-cdef-55e9-b223-acfcaea7e206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887679d-0319-4907-abdb-a8b813ff27d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887679d-0319-4907-abdb-a8b813ff27d8.jpg?1",
             "name": "Mechanized Warfare",
             "text": "If a red or artifact source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -11775,7 +11775,7 @@
         },
         {
             "id": "7dd2f582-55f8-5fb5-a5ec-a70ce47c0991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c64a7f-7cce-43d1-8356-e9ad1d4e6f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c64a7f-7cce-43d1-8356-e9ad1d4e6f12.jpg?1",
             "name": "Mishra's Command",
             "text": "Choose two \u2014\n\u2022 Choose target player. They may discard up to X cards. Then they draw a card for each card discarded this way.\n\u2022 This spell deals X damage to target creature.\n\u2022 This spell deals X damage to target planeswalker.\n\u2022 Target creature gets +X/+0 and gains haste until end of turn.",
             "colours": [
@@ -11809,7 +11809,7 @@
         },
         {
             "id": "f6f8e31b-f2a8-57e6-bafa-a8b8d58f6326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913dba9-70ca-4ba3-a7b8-876843b1b1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913dba9-70ca-4ba3-a7b8-876843b1b1df.jpg?1",
             "name": "Over the Top",
             "text": "Each player reveals a number of cards from the top of their library equal to the number of nonland permanents they control, puts all permanent cards they revealed this way onto the battlefield, and puts the rest into their graveyard.",
             "colours": [
@@ -11843,7 +11843,7 @@
         },
         {
             "id": "c68c04c2-a257-56c9-ae40-ea190a06bbe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aff76d6-336a-4746-9002-4daefef44984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aff76d6-336a-4746-9002-4daefef44984.jpg?1",
             "name": "Tyrant of Kher Ridges",
             "text": "Flying\nWhen Tyrant of Kher Ridges enters the battlefield, it deals 4 damage to any target.\n{R}: Tyrant of Kher Ridges gets +1/+0 until end of turn.",
             "colours": [
@@ -11879,7 +11879,7 @@
         },
         {
             "id": "1327d9f3-ce82-50ea-943b-fcd26096de79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c493e826-121f-4445-94db-5c75e5d16f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c493e826-121f-4445-94db-5c75e5d16f75.jpg?1",
             "name": "Visions of Phyrexia",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.\nAt the beginning of your end step, if you didn't play a card from exile this turn, create a tapped Powerstone token.",
             "colours": [
@@ -11913,7 +11913,7 @@
         },
         {
             "id": "ecf1f452-515b-5a57-8688-3cd6412a20d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fb5c7-f3e7-4c98-a5a4-3cf0571b6334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fb5c7-f3e7-4c98-a5a4-3cf0571b6334.jpg?1",
             "name": "Skitterbeam Battalion",
             "text": "Trample, haste\nWhen Skitterbeam Battalion enters the battlefield, if you cast it, create two tokens that are copies of it.\n//PRT-Prototype_\nMech//\n{3}{R}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "4bfcab29-0538-5f3d-b3a1-814d35f19006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d661aa8e-46fd-4f47-ade7-99c9142f3733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d661aa8e-46fd-4f47-ade7-99c9142f3733.jpg?1",
             "name": "Awaken the Woods",
             "text": "Create X 1/1 green Forest Dryad land creature tokens. (They're affected by summoning sickness.)",
             "colours": [
@@ -11982,7 +11982,7 @@
         },
         {
             "id": "886dc66e-b737-550a-b3f6-142732fed9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92646d9a-67ea-40b0-9b92-c8e1cbd31e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92646d9a-67ea-40b0-9b92-c8e1cbd31e4b.jpg?1",
             "name": "Fade from History",
             "text": "Each player who controls an artifact or enchantment creates a 2/2 green Bear creature token. Then destroy all artifacts and enchantments.",
             "colours": [
@@ -12016,7 +12016,7 @@
         },
         {
             "id": "b94baf78-bd7a-5696-8cb4-8276dd31672b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeed580-d00d-4d8c-a137-18b0f354933d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeed580-d00d-4d8c-a137-18b0f354933d.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -12053,7 +12053,7 @@
         },
         {
             "id": "6ae32945-b108-5460-8a42-077950b75ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4774554-1de5-4011-bd74-d3982bf33971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4774554-1de5-4011-bd74-d3982bf33971.jpg?1",
             "name": "Gwenna, Eyes of Gaea",
             "text": "{T}: Add two mana in any combination of colors. Spend this mana only to cast creature spells or activate abilities of a creature or creature card.\nWhenever you cast a creature spell with power 5 or greater, put a +1/+1 counter on Gwenna, Eyes of Gaea and untap it.",
             "colours": [
@@ -12093,7 +12093,7 @@
         },
         {
             "id": "11b6c124-2b87-582e-9996-d8bb4566e3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f19007-b501-44e6-8f86-51493dc69da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f19007-b501-44e6-8f86-51493dc69da3.jpg?1",
             "name": "Teething Wurmlet",
             "text": "Teething Wurmlet has deathtouch as long as you control three or more artifacts.\nWhenever an artifact enters the battlefield under your control, you gain 1 life. If this is the first time this ability has resolved this turn, put a +1/+1 counter on Teething Wurmlet.",
             "colours": [
@@ -12129,7 +12129,7 @@
         },
         {
             "id": "cb2c157b-cb5f-543d-be8a-fd4b69f8dcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c29a0-b7ea-433f-b342-a3228de0e092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c29a0-b7ea-433f-b342-a3228de0e092.jpg?1",
             "name": "Titania's Command",
             "text": "Choose two \u2014\n\u2022 Exile target player's graveyard. You gain 1 life for each card exiled this way.\n\u2022 Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle.\n\u2022 Create two 2/2 green Bear creature tokens.\n\u2022 Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -12163,7 +12163,7 @@
         },
         {
             "id": "ab92af48-0ed7-5c79-a992-60f973716cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4815d9a-0c59-4446-8cd8-416f8cd43a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4815d9a-0c59-4446-8cd8-416f8cd43a60.jpg?1",
             "name": "Perennial Behemoth",
             "text": "You may play lands from your graveyard.\nUnearth {G}{G}",
             "colours": [],
@@ -12198,7 +12198,7 @@
         },
         {
             "id": "a13f2b56-7a8f-5ad4-8407-6820dc9dd81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c4622d-eecb-449c-acd4-c05ed4094b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c4622d-eecb-449c-acd4-c05ed4094b20.jpg?1",
             "name": "Rootwire Amalgam",
             "text": "{3}{G}{G}, Sacrifice Rootwire Amalgam: Create an X/X colorless Golem artifact creature token, where X is three times Rootwire Amalgam's power. It gains haste until end of turn. Activate only as a sorcery.\n//PRT-Prototype_\nMech//\n{1}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/3",
             "colours": [],
@@ -12233,7 +12233,7 @@
         },
         {
             "id": "473fb80b-21ed-5f92-a214-b767a1ece03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036eee90-b002-4d9a-a72e-56cef7cc8648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036eee90-b002-4d9a-a72e-56cef7cc8648.jpg?1",
             "name": "Simian Simulacrum",
             "text": "When Simian Simulacrum enters the battlefield, put two +1/+1 counters on target creature you control.\nUnearth {2}{G}{G}",
             "colours": [],
@@ -12268,7 +12268,7 @@
         },
         {
             "id": "d203789a-6051-5b44-933a-c26cf6e54b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e988c8-c70f-4995-b500-8bc0fa580f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e988c8-c70f-4995-b500-8bc0fa580f1d.jpg?1",
             "name": "Deathbloom Ritualist",
             "text": "{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -12307,7 +12307,7 @@
         },
         {
             "id": "4ebefaf9-7cf9-5ce6-bec4-13cd8f6e94eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f42a51-02a0-4915-a459-887ac787a90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f42a51-02a0-4915-a459-887ac787a90e.jpg?1",
             "name": "Hajar, Loyal Bodyguard",
             "text": "Sacrifice Hajar, Loyal Bodyguard: Legendary creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -12348,7 +12348,7 @@
         },
         {
             "id": "14c3df66-3f32-5f21-b5da-cbb3a50b8d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d3faf-73fc-4f2d-8d88-2b15298461ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494d3faf-73fc-4f2d-8d88-2b15298461ce.jpg?1",
             "name": "Harbin, Vanguard Aviator",
             "text": "Flying\nWhenever you attack with five or more Soldiers, creatures you control get +1/+1 and gain flying until end of turn.",
             "colours": [
@@ -12389,7 +12389,7 @@
         },
         {
             "id": "547786b0-c9c4-5d9f-8174-dc7760e64c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a5af15-86cf-48c7-8743-6b13295db41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a5af15-86cf-48c7-8743-6b13295db41e.jpg?1",
             "name": "Legions to Ashes",
             "text": "Exile target nonland permanent an opponent controls and all tokens that player controls with the same name as that permanent.",
             "colours": [
@@ -12425,7 +12425,7 @@
         },
         {
             "id": "506eb59d-2ac5-539e-ba44-731ad4f62423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bdc53f-03af-404f-b62d-f59dda792887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bdc53f-03af-404f-b62d-f59dda792887.jpg?1",
             "name": "Queen Kayla bin-Kroog",
             "text": "{4}, {T}: Discard all the cards in your hand, then draw that many cards. You may choose an artifact or creature card with mana value 1 you discarded this way, then do the same for artifact or creature cards with mana values 2 and 3. Return those cards to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -12467,7 +12467,7 @@
         },
         {
             "id": "0e1cbcc8-2229-5957-bcec-3ba9a4a07a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659b228-67e9-4cf6-be90-810d0393720a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659b228-67e9-4cf6-be90-810d0393720a.jpg?1",
             "name": "Sarinth Greatwurm",
             "text": "Trample\nWhenever a land enters the battlefield, create a tapped Powerstone token.",
             "colours": [
@@ -12505,7 +12505,7 @@
         },
         {
             "id": "2363e96a-f42b-573a-918c-a59e9e5b826a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8cde13-e7c8-4781-acf0-56f522afe425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8cde13-e7c8-4781-acf0-56f522afe425.jpg?1",
             "name": "Tawnos, the Toymaker",
             "text": "Whenever you cast a Beast or Bird creature spell, you may copy it, except the copy is an artifact in addition to its other types.",
             "colours": [
@@ -12546,7 +12546,7 @@
         },
         {
             "id": "16175410-1879-524e-bfe1-21d48bba6e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d759dc-0501-481a-8330-005f83b999d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d759dc-0501-481a-8330-005f83b999d7.jpg?1",
             "name": "Tocasia, Dig Site Mentor",
             "text": "Creatures you control have vigilance and \"{T}: Surveil 1.\"\n{2}{G}{G}{W}{W}{U}{U}, Exile Tocasia, Dig Site Mentor from your graveyard: Return any number of target artifact cards with total mana value 10 or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -12589,7 +12589,7 @@
         },
         {
             "id": "f7c07bb4-b739-5cf5-ac6b-93b59512bb35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10471a6-38ee-4a84-986a-779bdf4f1464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10471a6-38ee-4a84-986a-779bdf4f1464.jpg?1",
             "name": "Bladecoil Serpent",
             "text": "When Bladecoil Serpent enters the battlefield, for each {U}{U} spent to cast it, draw a card.\nWhen Bladecoil Serpent enters the battlefield, for each {B}{B} spent to cast it, each opponent discards a card.\nWhen Bladecoil Serpent enters the battlefield, for each {R}{R} spent to cast it, it gets +1/+0 and gains trample and haste until end of turn.",
             "colours": [],
@@ -12626,7 +12626,7 @@
         },
         {
             "id": "e0f5e194-4001-5cd2-87df-572972627587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bca059b-e5ea-42f3-adad-cb1801ddf3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bca059b-e5ea-42f3-adad-cb1801ddf3cb.jpg?1",
             "name": "Clay Champion",
             "text": "Clay Champion enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.\nWhen Clay Champion enters the battlefield, choose up to two other target creatures you control. For each {W}{W} spent to cast Clay Champion, put a +1/+1 counter on each of them.",
             "colours": [],
@@ -12662,7 +12662,7 @@
         },
         {
             "id": "c2e83103-ed7a-5f00-a9f0-ab48a39cc412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2bcd1-3ed3-4b99-9bb6-d0fa0a9f2ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2bcd1-3ed3-4b99-9bb6-d0fa0a9f2ea1.jpg?1",
             "name": "Cityscape Leveler",
             "text": "Trample\nWhen you cast this spell and whenever Cityscape Leveler attacks, destroy up to one target nonland permanent. Its controller creates a tapped Powerstone token.\nUnearth {8}",
             "colours": [],
@@ -12695,7 +12695,7 @@
         },
         {
             "id": "23c396d1-fa5f-53b9-aa4b-6e84d40cad00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04acd5af-bd55-4c16-9b6d-10822d564c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04acd5af-bd55-4c16-9b6d-10822d564c14.jpg?1",
             "name": "Liberator, Urza's Battlethopter",
             "text": "Flash\nFlying\nYou may cast colorless spells and artifact spells as though they had flash.\nWhenever you cast a spell, if the amount of mana spent to cast that spell is greater than Liberator, Urza's Battlethopter's power, put a +1/+1 counter on Liberator.",
             "colours": [],
@@ -12730,7 +12730,7 @@
         },
         {
             "id": "22b9ee49-fd8b-5953-89c4-1054e70c3fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05bda29-654a-4f4f-9296-702ccda7f800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05bda29-654a-4f4f-9296-702ccda7f800.jpg?1",
             "name": "Portal to Phyrexia",
             "text": "When Portal to Phyrexia enters the battlefield, each opponent sacrifices three creatures.\nAt the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control. It's a Phyrexian in addition to its other types.",
             "colours": [],
@@ -12760,7 +12760,7 @@
         },
         {
             "id": "cfa9495d-30ce-532a-9c9e-5b91068c091f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41793ef-73a3-41fc-8efc-df0d72ede984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41793ef-73a3-41fc-8efc-df0d72ede984.jpg?1",
             "name": "The Stasis Coffin",
             "text": "{2}, {T}, Exile The Stasis Coffin: You gain protection from everything until your next turn.",
             "colours": [],
@@ -12792,7 +12792,7 @@
         },
         {
             "id": "3f5f7024-cfe0-5a01-ac7c-7f6cedd53282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913460c0-2482-4d1b-9235-1cecfee653cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913460c0-2482-4d1b-9235-1cecfee653cb.jpg?1",
             "name": "The Stone Brain",
             "text": "{2}, {T}, Exile The Stone Brain: Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way. Activate only as a sorcery.",
             "colours": [],
@@ -12824,7 +12824,7 @@
         },
         {
             "id": "bed93d30-21e0-5685-8691-94fe13808ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c400de-25cb-4865-ad1b-9a8a8da3da55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c400de-25cb-4865-ad1b-9a8a8da3da55.jpg?1",
             "name": "Thran Spider",
             "text": "Reach\nWhen Thran Spider enters the battlefield, you and target opponent each create a tapped Powerstone token.\n{7}: Look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -12857,7 +12857,7 @@
         },
         {
             "id": "a665883a-8366-580f-b6f8-ffce2eb0f158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9b863-10b7-46d6-badd-97381e6c7c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9b863-10b7-46d6-badd-97381e6c7c5e.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "d094af49-3bf5-5292-a067-903b053bdf4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60a5e3-7b37-4363-ab22-c30a6fcf5716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60a5e3-7b37-4363-ab22-c30a6fcf5716.jpg?1",
             "name": "Fortified Beachhead",
             "text": "As Fortified Beachhead enters the battlefield, you may reveal a Soldier card from your hand. Fortified Beachhead enters the battlefield tapped unless you revealed a Soldier card this way or you control a Soldier.\n{T}: Add {W} or {U}.\n{5}, {T}: Soldiers you control get +1/+1 until end of turn.",
             "colours": [],
@@ -12920,7 +12920,7 @@
         },
         {
             "id": "1b500c45-9741-5329-b4fb-5025d5be25ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a4e7-317e-480e-9d38-da1c42c47521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a4e7-317e-480e-9d38-da1c42c47521.jpg?1",
             "name": "Hall of Tagsin",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}: Create a tapped Powerstone token.",
             "colours": [],
@@ -12950,7 +12950,7 @@
         },
         {
             "id": "cf38aff6-92f1-5ab5-babc-7bb0198fee70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493bc22-2e38-4459-81f1-37cd1ce921cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f493bc22-2e38-4459-81f1-37cd1ce921cf.jpg?1",
             "name": "Mishra's Foundry",
             "text": "{T}: Add {C}.\n{2}: Mishra's Foundry becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
             "colours": [],
@@ -12981,7 +12981,7 @@
         },
         {
             "id": "5f38f91c-3102-5120-bf3c-4d45a646a6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dde654-5bde-47f9-8e90-4f38dddc07b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dde654-5bde-47f9-8e90-4f38dddc07b3.jpg?1",
             "name": "Rescue Retriever",
             "text": "Flash\nWhen Rescue Retriever enters the battlefield, put a +1/+1 counter on each other Soldier you control.\nPrevent all damage that would be dealt to other attacking Soldiers you control.",
             "colours": [
@@ -13018,7 +13018,7 @@
         },
         {
             "id": "fe567e51-0b96-5551-b347-abfdf0ea4cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae85295-9bad-4f5b-9935-7242632e9008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae85295-9bad-4f5b-9935-7242632e9008.jpg?1",
             "name": "Geology Enthusiast",
             "text": "At the beginning of your end step, create a tapped Powerstone token.\n{6}: Draw a card and put a +1/+1 counter on Geology Enthusiast.",
             "colours": [
@@ -13055,7 +13055,7 @@
         },
         {
             "id": "69bb1966-c092-5656-8c4c-b925cbe0ae13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef8698-982d-4c35-b3a0-99788fc2f8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef8698-982d-4c35-b3a0-99788fc2f8a0.jpg?1",
             "name": "Terror Ballista",
             "text": "Menace\nWhenever Terror Ballista attacks, you may sacrifice another creature. When you do, destroy target creature an opponent controls.\nUnearth {3}{B}{B}",
             "colours": [],
@@ -13090,7 +13090,7 @@
         },
         {
             "id": "c4a8e16e-d4cc-5e46-945e-7717007d6b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e71c3b-4c97-4eac-9ac9-c97cd6253849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e71c3b-4c97-4eac-9ac9-c97cd6253849.jpg?1",
             "name": "Artificer's Dragon",
             "text": "Flying\n{R}: Artifact creatures you control get +1/+0 until end of turn.\nUnearth {3}{R}{R}",
             "colours": [],
@@ -13125,7 +13125,7 @@
         },
         {
             "id": "135aeec4-f811-5944-afca-a45f163cbae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37065a61-3883-49fa-a931-8f1566451795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37065a61-3883-49fa-a931-8f1566451795.jpg?1",
             "name": "Woodcaller Automaton",
             "text": "When Woodcaller Automaton enters the battlefield, if you cast it, untap target land you control. It becomes a Treefolk creature with haste and base power and toughness equal to Woodcaller Automaton's power and toughness. It's still a land.\n//PRT-Prototype_\nMech//\n{2}{G}{G}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n3/3",
             "colours": [],
@@ -13160,7 +13160,7 @@
         },
         {
             "id": "dfa66ff6-f403-5e8a-837b-9fa1bbdb6dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91f9a1e-809b-4bc0-afca-c0c3755d130f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91f9a1e-809b-4bc0-afca-c0c3755d130f.jpg?1",
             "name": "Mishra's Foundry",
             "text": "{T}: Add {C}.\n{2}: Mishra's Foundry becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
             "colours": [],
@@ -13190,7 +13190,7 @@
         },
         {
             "id": "9862ad68-fe97-55e9-9884-9dc2c236eef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d8c862-47e9-4cc5-833c-0e762ee2a670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d8c862-47e9-4cc5-833c-0e762ee2a670.jpg?1",
             "name": "Queen Kayla bin-Kroog",
             "text": "{4}, {T}: Discard all the cards in your hand, then draw that many cards. You may choose an artifact or creature card with mana value 1 you discarded this way, then do the same for artifact or creature cards with mana values 2 and 3. Return those cards to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -13231,7 +13231,7 @@
         },
         {
             "id": "c0712b85-a002-5e55-98e9-902bb3776977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8340f-19ca-40d2-ae8e-68bba18e918b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8340f-19ca-40d2-ae8e-68bba18e918b.jpg?1",
             "name": "Lay Down Arms",
             "text": "Exile target creature with mana value less than or equal to the number of Plains you control. Its controller gains 3 life.",
             "colours": [
@@ -13265,7 +13265,7 @@
         },
         {
             "id": "8dd8300a-ab15-5eee-be5e-583438b5184a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de8324f-07ee-4dd1-9547-1a1cfb361ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de8324f-07ee-4dd1-9547-1a1cfb361ff5.jpg?1",
             "name": "Flow of Knowledge",
             "text": "Draw a card for each Island you control, then discard two cards.",
             "colours": [
@@ -13299,7 +13299,7 @@
         },
         {
             "id": "281cc1c7-b5c3-5784-b1d0-7916b18598b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7c6f6f-9516-4cfd-830f-5910a25bd1a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7c6f6f-9516-4cfd-830f-5910a25bd1a2.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -13333,7 +13333,7 @@
         },
         {
             "id": "6999b379-736a-5b82-832d-df979909dbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b86f24-de8c-40f5-9486-119a366c42e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b86f24-de8c-40f5-9486-119a366c42e1.jpg?1",
             "name": "Sardian Cliffstomper",
             "text": "As long as it's your turn and you control four or more Mountains, Sardian Cliffstomper gets +X/+0, where X is the number of Mountains you control.",
             "colours": [
@@ -13370,7 +13370,7 @@
         },
         {
             "id": "8eadb239-db1e-5c89-8111-a31136c9f448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9755c1da-f1ed-4328-b85f-e905b7468504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9755c1da-f1ed-4328-b85f-e905b7468504.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -13406,7 +13406,7 @@
         },
         {
             "id": "60494a81-fb59-5124-8026-50238c0b9308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e3241-8f9d-4c52-9848-e01b575fd372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e3241-8f9d-4c52-9848-e01b575fd372.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -13441,7 +13441,7 @@
         },
         {
             "id": "3f82c456-50fe-51af-9b92-369d7df9e749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772dac39-269b-4a35-aad3-320279af833f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772dac39-269b-4a35-aad3-320279af833f.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -13476,7 +13476,7 @@
         },
         {
             "id": "6405b3fc-e11e-57cb-acdc-52ecdd339108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de70f2-93b6-4fc5-8c4d-464f880d3c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de70f2-93b6-4fc5-8c4d-464f880d3c54.jpg?1",
             "name": "Forest Dryad",
             "text": "",
             "colours": [
@@ -13513,7 +13513,7 @@
         },
         {
             "id": "a528342a-7f6f-5f00-9703-fa3582eb99ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087ab398-474f-4455-bef4-ea42c6913486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087ab398-474f-4455-bef4-ea42c6913486.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -13545,7 +13545,7 @@
         },
         {
             "id": "f304a222-6ed8-55dd-ab01-607fc5e3ee7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914fecab-24c0-4179-84d6-ded78c29134f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914fecab-24c0-4179-84d6-ded78c29134f.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -13577,7 +13577,7 @@
         },
         {
             "id": "e9d4c9dd-aabd-5b24-9c12-495ba9642306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474c8cfe-71ce-46c7-8cf4-dfeae3c0e73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474c8cfe-71ce-46c7-8cf4-dfeae3c0e73b.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -13609,7 +13609,7 @@
         },
         {
             "id": "af8db311-3520-5cf7-8410-7390c29da873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fe4b6-aeaf-4f84-b660-c7b482ed8512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45fe4b6-aeaf-4f84-b660-c7b482ed8512.jpg?1",
             "name": "Powerstone",
             "text": "",
             "colours": [],
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "435879cb-6a56-5018-990c-71480a1da759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37da5b54-ec55-46e3-9f0b-565cbbe1ac7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37da5b54-ec55-46e3-9f0b-565cbbe1ac7a.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [],
@@ -13672,7 +13672,7 @@
         },
         {
             "id": "ef3f1a25-63d2-52cc-ac87-7b72b26cee32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83981313-ff55-4030-ac82-d6a3087cf675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83981313-ff55-4030-ac82-d6a3087cf675.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [],
@@ -13704,7 +13704,7 @@
         },
         {
             "id": "f282f43b-3966-5b9c-b2da-bbb804c11b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4501d15d-d306-4372-9516-bd63cf788f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4501d15d-d306-4372-9516-bd63cf788f45.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -13736,7 +13736,7 @@
         },
         {
             "id": "5aa6ab25-11cf-5cac-830f-9d255c06bd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef47d03-9050-48ed-994f-f72582967dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef47d03-9050-48ed-994f-f72582967dbd.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [],
@@ -13768,7 +13768,7 @@
         },
         {
             "id": "86fd16f7-1f35-539d-b47d-0c9d07d63850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020571d-97fb-4f46-85ec-6cb3141bfc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9020571d-97fb-4f46-85ec-6cb3141bfc87.jpg?1",
             "name": "Saheeli, Filigree Master Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/CHK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/CHK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "59681d76-e221-525d-8c12-b775856afe7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2d8650-b8c3-4e89-9aa2-424a98715c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2d8650-b8c3-4e89-9aa2-424a98715c38.jpg?1",
             "name": "Blessed Breath",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nSplice onto Arcane {W} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "0587fcbb-8caa-5469-bfa5-62e5d599c933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg?1",
             "name": "Bushi Tenderfoot // Kenzo the Hardhearted",
             "text": "When a creature dealt damage by Bushi Tenderfoot this turn is put into a graveyard, flip Bushi Tenderfoot.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "911287a8-f255-5af7-a53f-fc56f215dd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/864ad989-19a6-4930-8efc-bbc077a18c32.jpg?1",
             "name": "Bushi Tenderfoot // Kenzo the Hardhearted",
             "text": "Double strike; bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "3f2ed15b-b7d4-5a51-8ac5-cc65e68994d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a80b6a-90ed-482f-9714-eb856269e9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a80b6a-90ed-482f-9714-eb856269e9d3.jpg?1",
             "name": "Cage of Hands",
             "text": "Enchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "cca39489-af45-573b-bf88-014a1f7727d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fcfe4-0347-4ac6-8e29-f945cb1d7295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fcfe4-0347-4ac6-8e29-f945cb1d7295.jpg?1",
             "name": "Call to Glory",
             "text": "Untap all creatures you control. Samurai you control get +1/+1 until end of turn.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "f920de35-353c-5ad0-9127-ebc7dabf3aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758d20f-6f0f-462e-a7ec-2511c146983d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758d20f-6f0f-462e-a7ec-2511c146983d.jpg?1",
             "name": "Candles' Glow",
             "text": "Prevent the next 3 damage that would be dealt to target creature or player this turn. You gain 1 life for each damage prevented this way.\nSplice onto Arcane {1}{W} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "cbc25f97-1c2c-59e1-9067-9a2b8b6b9980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897707f-9669-4d44-8607-cba569da73e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897707f-9669-4d44-8607-cba569da73e0.jpg?1",
             "name": "Cleanfall",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "bc84980c-3b29-5d77-b493-cccc5d336d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc41d6d6-d7e5-4874-b6e2-fa4c72454f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc41d6d6-d7e5-4874-b6e2-fa4c72454f15.jpg?1",
             "name": "Devoted Retainer",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "971bfb78-f275-51df-b1cd-f887e51a68ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc72076-fb6c-420b-9c88-faabb9b91a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc72076-fb6c-420b-9c88-faabb9b91a03.jpg?1",
             "name": "Eight-and-a-Half-Tails",
             "text": "{1}{W}: Target permanent you control gains protection from white until end of turn.\n{1}: Target spell or permanent becomes white until end of turn.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "0f610e65-4d15-506d-b8a1-27d242f89d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1996af-5f15-447f-9b1d-98a7e97df53a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1996af-5f15-447f-9b1d-98a7e97df53a.jpg?1",
             "name": "Ethereal Haze",
             "text": "Prevent all damage that would be dealt by creatures this turn.",
             "colours": [
@@ -350,7 +350,7 @@
         },
         {
             "id": "2deee42f-c529-531c-a36c-f0e750625c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d7de2b-c909-48dc-9ab7-c4a8328e37bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d7de2b-c909-48dc-9ab7-c4a8328e37bb.jpg?1",
             "name": "Ghostly Prison",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature attacking you. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "364a0a3c-0eaf-5dc7-ab81-2f03745ba24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e19753-b94b-458f-a51b-c8ec8fbec6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e19753-b94b-458f-a51b-c8ec8fbec6c8.jpg?1",
             "name": "Harsh Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, untap Harsh Deceiver and it gets +1/+1 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -416,7 +416,7 @@
         },
         {
             "id": "71533159-1c83-5856-ad59-b059cdced62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc7ba1-6194-45ba-97c5-ad14331cc3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc7ba1-6194-45ba-97c5-ad14331cc3a6.jpg?1",
             "name": "Hikari, Twilight Guardian",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may remove Hikari, Twilight Guardian from the game. If you do, return it to play under its owner's control at end of turn.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "e536ca09-ab21-58c3-9837-b158fbf716da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de34d107-8a28-4e88-919e-c7ccf984bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de34d107-8a28-4e88-919e-c7ccf984bcda.jpg?1",
             "name": "Hold the Line",
             "text": "Blocking creatures get +7/+7 until end of turn.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "880d7558-143b-5848-bb03-987994d5521a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463f598a-7de0-4691-a61a-fe24c29f9e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463f598a-7de0-4691-a61a-fe24c29f9e1b.jpg?1",
             "name": "Honden of Cleansing Fire",
             "text": "At the beginning of your upkeep, you gain 2 life for each Shrine you control.",
             "colours": [
@@ -520,7 +520,7 @@
         },
         {
             "id": "ad48ee01-9338-5eca-af18-911aae691480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6317b9-a426-453b-a82a-e63905a77019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6317b9-a426-453b-a82a-e63905a77019.jpg?1",
             "name": "Horizon Seed",
             "text": "Whenever you play a Spirit or Arcane spell, regenerate target creature.",
             "colours": [
@@ -554,7 +554,7 @@
         },
         {
             "id": "1269707b-e642-59e9-959b-2d28282d1a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b2892a-5c16-4624-9a47-6a47f10e2466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b2892a-5c16-4624-9a47-6a47f10e2466.jpg?1",
             "name": "Hundred-Talon Kami",
             "text": "Flying\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -588,7 +588,7 @@
         },
         {
             "id": "af638154-c327-5cf3-93c6-27d2741b2f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73263906-c66b-4f85-b138-0b5deda64ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73263906-c66b-4f85-b138-0b5deda64ab1.jpg?1",
             "name": "Indomitable Will",
             "text": "You may play Indomitable Will any time you could play an instant.\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "13298cf8-bd62-5d20-bebc-47da3162da26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df62efbb-2313-4667-82e6-3b474d998ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df62efbb-2313-4667-82e6-3b474d998ef5.jpg?1",
             "name": "Innocence Kami",
             "text": "{W}, {T}: Tap target creature.\nWhenever you play a Spirit or Arcane spell, untap Innocence Kami.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "c81ea548-0fc6-5cec-b041-8782a80701d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f9919-0713-4ef9-96eb-3e0c444e47f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f9919-0713-4ef9-96eb-3e0c444e47f4.jpg?1",
             "name": "Isamaru, Hound of Konda",
             "text": "",
             "colours": [
@@ -692,7 +692,7 @@
         },
         {
             "id": "098326ed-fc28-5cb9-95e5-19d05d6187f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3ccd16-bb1b-40d5-87a6-47a6132e0143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3ccd16-bb1b-40d5-87a6-47a6132e0143.jpg?1",
             "name": "Kabuto Moth",
             "text": "Flying\n{T}: Target creature gets +1/+2 until end of turn.",
             "colours": [
@@ -726,7 +726,7 @@
         },
         {
             "id": "6558fb89-301c-5f7f-8bc5-6dec683caf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cb7fdc-fa47-4485-b268-7c2ddff28568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cb7fdc-fa47-4485-b268-7c2ddff28568.jpg?1",
             "name": "Kami of Ancient Law",
             "text": "Sacrifice Kami of Ancient Law: Destroy target enchantment.",
             "colours": [
@@ -760,7 +760,7 @@
         },
         {
             "id": "5920398d-9131-5015-8bc8-d72014fb10ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815cad73-1d46-4d2b-9dd8-edcd6abc6cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815cad73-1d46-4d2b-9dd8-edcd6abc6cbe.jpg?1",
             "name": "Kami of Old Stone",
             "text": "",
             "colours": [
@@ -794,7 +794,7 @@
         },
         {
             "id": "0dd55d02-0dd5-59e2-bf9a-f603cfc0aa7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068739c-0a6a-49a1-88c3-68d7abc58ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7068739c-0a6a-49a1-88c3-68d7abc58ee2.jpg?1",
             "name": "Kami of the Painted Road",
             "text": "Whenever you play a Spirit or Arcane spell, Kami of the Painted Road gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -828,7 +828,7 @@
         },
         {
             "id": "c36fe777-5667-5690-9376-aba1112d2879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690980ce-bbdc-4d52-b34e-2bad11e436a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690980ce-bbdc-4d52-b34e-2bad11e436a1.jpg?1",
             "name": "Kami of the Palace Fields",
             "text": "Flying, first strike\nSoulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -862,7 +862,7 @@
         },
         {
             "id": "cdf28191-2045-5517-b46f-6cdc5b5d911e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9d108d-ee19-4b1d-9d4b-b4c4d9b8ad0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9d108d-ee19-4b1d-9d4b-b4c4d9b8ad0d.jpg?1",
             "name": "Kitsune Blademaster",
             "text": "First strike\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -897,7 +897,7 @@
         },
         {
             "id": "183c8aeb-e585-5d81-97d2-a2dbac3ffea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50fb007-d1fd-4b61-91c3-4863e40472ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50fb007-d1fd-4b61-91c3-4863e40472ed.jpg?1",
             "name": "Kitsune Diviner",
             "text": "{T}: Tap target Spirit.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "c8f830b9-849f-5be1-9fbc-3fb4b119fc24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bb6894-b56a-4a63-859a-65a0c2d160fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bb6894-b56a-4a63-859a-65a0c2d160fc.jpg?1",
             "name": "Kitsune Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\n{T}: Prevent all damage that would be dealt to target legendary creature this turn.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "a0bd4b3d-44ed-5c12-99ce-c6822e88a15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg?1",
             "name": "Kitsune Mystic // Autumn-Tail, Kitsune Sage",
             "text": "At end of turn, if Kitsune Mystic is enchanted by two or more enchantments, flip it.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "8613f299-d2d6-5dcb-bdd4-08f143102e13",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg?1",
             "name": "Kitsune Mystic // Autumn-Tail, Kitsune Sage",
             "text": "{1}: Move target enchantment enchanting a creature to another creature.",
             "colours": [
@@ -1039,7 +1039,7 @@
         },
         {
             "id": "f4b90261-27d2-5e5f-967e-09f17b31aba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f545d9d0-52d8-4b90-a8bb-178f4ba3c4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f545d9d0-52d8-4b90-a8bb-178f4ba3c4b7.jpg?1",
             "name": "Kitsune Riftwalker",
             "text": "Protection from Spirits and from Arcane",
             "colours": [
@@ -1074,7 +1074,7 @@
         },
         {
             "id": "5a3603e3-6560-5fc4-b695-344f2d0b88e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg?1",
             "name": "Konda, Lord of Eiganjo",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nBushido 5 (When this blocks or becomes blocked, it gets +5/+5 until end of turn.)\nKonda, Lord of Eiganjo is indestructible.",
             "colours": [
@@ -1111,7 +1111,7 @@
         },
         {
             "id": "de8f8b6c-d5b8-56f0-a517-4ece4e0f3048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cf6-f6ad-4302-8f07-099eabdd4b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cf6-f6ad-4302-8f07-099eabdd4b40.jpg?1",
             "name": "Konda's Hatamoto",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nAs long as you control a legendary Samurai, Konda's Hatamoto gets +1/+2 and has vigilance. (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "4d56bf38-0694-5542-a5c9-d84a8926f75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99625787-f184-48a5-a678-e30b7024c7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99625787-f184-48a5-a678-e30b7024c7bb.jpg?1",
             "name": "Lantern Kami",
             "text": "Flying",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "9b0efd08-9e9a-550a-a5a2-8c4cd357c3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2507f-4035-47d5-8295-0a3773f187fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2507f-4035-47d5-8295-0a3773f187fb.jpg?1",
             "name": "Masako the Humorless",
             "text": "You may play Masako the Humorless any time you could play an instant.\nTapped creatures you control may block as though they were untapped.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "6c22631e-8ae2-506e-848a-7a6579a2a33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a236f7-f008-4eb8-91d9-31ea8589cf0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a236f7-f008-4eb8-91d9-31ea8589cf0c.jpg?1",
             "name": "Mothrider Samurai",
             "text": "Flying\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "163cbec7-6e2c-5372-87b4-593a02dd787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0570ba0-2877-46f6-acea-6913f8915d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0570ba0-2877-46f6-acea-6913f8915d6d.jpg?1",
             "name": "Myojin of Cleansing Fire",
             "text": "Myojin of Cleansing Fire comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Cleansing Fire is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Cleansing Fire: Destroy each other creature.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "e571ccd1-f93d-5a01-a0ed-90adb6d2177e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45258f4-c36d-46cc-80e8-cc458351e003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45258f4-c36d-46cc-80e8-cc458351e003.jpg?1",
             "name": "Nagao, Bound by Honor",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever Nagao, Bound by Honor attacks, Samurai you control get +1/+1 until end of turn.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "8fc64558-cb7f-5ae2-b34b-7daa69d3cf73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a293db52-49f2-4a9c-8ee0-054d994b7299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a293db52-49f2-4a9c-8ee0-054d994b7299.jpg?1",
             "name": "Otherworldly Journey",
             "text": "Remove target creature from the game. At end of turn, return that creature to play under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "733224c7-1b0c-58c5-8cc4-6e8507c55b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4124b9-5169-471e-b805-ceeffeec9184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4124b9-5169-471e-b805-ceeffeec9184.jpg?1",
             "name": "Pious Kitsune",
             "text": "At the beginning of your upkeep, put a devotion counter on Pious Kitsune. Then if a creature named Eight-and-a-Half-Tails is in play, you gain 1 life for each devotion counter on Pious Kitsune.\n{T}, Remove a devotion counter from Pious Kitsune: You gain 1 life.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "37817393-5a5a-5f05-a148-e0cfcd701930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd4d7cd-12a9-49f2-912d-2a6024112d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd4d7cd-12a9-49f2-912d-2a6024112d13.jpg?1",
             "name": "Quiet Purity",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "b0bb4ecc-98d3-55ba-ad95-fc1630d6bc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c835f8-9269-4950-95c9-125d58b7b19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c835f8-9269-4950-95c9-125d58b7b19e.jpg?1",
             "name": "Reciprocate",
             "text": "Remove from the game target creature that dealt damage to you this turn.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "4f7dd03e-6703-520f-9668-9c6eab5393d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae9c988-5e8c-4d3a-af6d-8ac083698159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae9c988-5e8c-4d3a-af6d-8ac083698159.jpg?1",
             "name": "Reverse the Sands",
             "text": "Redistribute any number of players' life totals. (Each of those players gets one life total back.)",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "3dd3c2e2-c681-5d3d-aa6b-28631661e246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2be3fe-87a2-47b2-8af1-b99a48622c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2be3fe-87a2-47b2-8af1-b99a48622c7b.jpg?1",
             "name": "Samurai Enforcers",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "3aa2b361-a9a8-544e-a5fc-beef1a7cc23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead15cf8-f692-4cb9-ac86-0dff00236145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead15cf8-f692-4cb9-ac86-0dff00236145.jpg?1",
             "name": "Samurai of the Pale Curtain",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf a permanent would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "72de7408-0aed-5169-aa17-d47d1078ebb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93dd897-3fb5-48b1-bdff-9383ce1feb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93dd897-3fb5-48b1-bdff-9383ce1feb21.jpg?1",
             "name": "Sensei Golden-Tail",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{1}{W}, {T}: Put a training counter on target creature. That creature gains bushido 1 and becomes a Samurai in addition to its other creature types. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1599,7 +1599,7 @@
         },
         {
             "id": "97c1bed6-9796-5bb7-a655-cf2be05e3351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272dfee6-9c90-4409-9289-f451261909e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272dfee6-9c90-4409-9289-f451261909e7.jpg?1",
             "name": "Silent-Chant Zubera",
             "text": "When Silent-Chant Zubera is put into a graveyard from play, you gain 2 life for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "9c3b4078-b1f3-5bc4-83ee-5a62984f9848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d038df46-4a30-4125-be0e-8781b16b523e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d038df46-4a30-4125-be0e-8781b16b523e.jpg?1",
             "name": "Takeno, Samurai General",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\nEach other Samurai you control gets +1/+1 for each point of bushido it has.",
             "colours": [
@@ -1671,7 +1671,7 @@
         },
         {
             "id": "e6eb4a22-2253-5802-a237-7732c0bcead7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7176139f-8a9a-4ee4-a56d-672fd09390e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7176139f-8a9a-4ee4-a56d-672fd09390e4.jpg?1",
             "name": "Terashi's Cry",
             "text": "Tap up to three target creatures.",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "038d1b1d-cd84-539c-9395-bfc3497437d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef25165-2458-4c00-8b7c-0ad6fd98e3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef25165-2458-4c00-8b7c-0ad6fd98e3af.jpg?1",
             "name": "Vassal's Duty",
             "text": "{1}: The next 1 damage that would be dealt to target legendary creature you control this turn is dealt to you instead.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "dae584af-f082-5567-a2ca-9ce29c84bb9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24dc353-abc9-430a-a7f5-5da3b38cd411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24dc353-abc9-430a-a7f5-5da3b38cd411.jpg?1",
             "name": "Vigilance",
             "text": "Enchanted creature has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -1771,7 +1771,7 @@
         },
         {
             "id": "5121c22c-ddf9-554f-b18d-05b6a97a5702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b38f14a-bd10-47c1-8772-5abe0a0b243f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b38f14a-bd10-47c1-8772-5abe0a0b243f.jpg?1",
             "name": "Yosei, the Morning Star",
             "text": "Flying\nWhen Yosei, the Morning Star is put into a graveyard from play, target player skips his or her next untap step. Tap up to five target permanents that player controls.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "fa61fa37-6146-5c70-baed-a777f6436713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26913c27-5794-42c7-a2a2-af565ce84fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26913c27-5794-42c7-a2a2-af565ce84fd1.jpg?1",
             "name": "Aura of Dominion",
             "text": "{1}, Tap an untapped creature you control: Untap enchanted creature.",
             "colours": [
@@ -1842,7 +1842,7 @@
         },
         {
             "id": "563b6bed-a458-576c-9ff3-cd8a482bd164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ea91b1-f2ff-4b99-8148-333aa27ea8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ea91b1-f2ff-4b99-8148-333aa27ea8cd.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "b73c882f-4eae-5ce0-afd5-7b704bfe7cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628d3058-d32e-438c-9a86-3e9c2be73c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628d3058-d32e-438c-9a86-3e9c2be73c4a.jpg?1",
             "name": "Callous Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Callous Deceiver gets +1/+0 and gains flying until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "abe9c41f-6451-55ef-b5cb-e86f5ed4c66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee99c-74ca-4d78-ade2-c6a93b0bd4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee99c-74ca-4d78-ade2-c6a93b0bd4fd.jpg?1",
             "name": "Consuming Vortex",
             "text": "Return target creature to its owner's hand.\nSplice onto Arcane {3}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1947,7 +1947,7 @@
         },
         {
             "id": "3caae284-7f5a-525f-b576-109187699e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401911c-bfb0-4c94-9fc1-49198ccecc94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4401911c-bfb0-4c94-9fc1-49198ccecc94.jpg?1",
             "name": "Counsel of the Soratami",
             "text": "Draw two cards.",
             "colours": [
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "1114ab88-a865-5077-a7e7-a4bbf0a1ff04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff18307-9ef8-4e3a-89e9-cb8c04997222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff18307-9ef8-4e3a-89e9-cb8c04997222.jpg?1",
             "name": "Cut the Tethers",
             "text": "For each Spirit, return it to its owner's hand unless that player pays {3}.",
             "colours": [
@@ -2011,7 +2011,7 @@
         },
         {
             "id": "cc30989a-c329-50cc-9d36-8d32cd359a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4806218-ff27-4df3-922d-5a085ffa44a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4806218-ff27-4df3-922d-5a085ffa44a6.jpg?1",
             "name": "Dampen Thought",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard.\nSplice onto Arcane {1}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "c0761af0-a771-5ac2-978b-e2107cae233a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af326c1-fcc8-45c3-b75e-ae4dbbd59ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af326c1-fcc8-45c3-b75e-ae4dbbd59ced.jpg?1",
             "name": "Eerie Procession",
             "text": "Search your library for an Arcane card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -2079,7 +2079,7 @@
         },
         {
             "id": "c538167c-c1cc-5356-8a8a-0185b02a7ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b307af89-1890-4fac-a12e-f8a678f1101f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b307af89-1890-4fac-a12e-f8a678f1101f.jpg?1",
             "name": "Eye of Nowhere",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -2113,7 +2113,7 @@
         },
         {
             "id": "e89d8bfb-66e8-574d-a389-f5fc7299676c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c6fc-324b-4cff-9109-6d817767865f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c6fc-324b-4cff-9109-6d817767865f.jpg?1",
             "name": "Field of Reality",
             "text": "Enchanted creature can't be blocked by Spirits.\n{1}{U}: Return Field of Reality to its owner's hand.",
             "colours": [
@@ -2147,7 +2147,7 @@
         },
         {
             "id": "5886dced-e60d-5574-b6e2-fad4352e84a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55a8-6c21-4cc1-a2c4-86cd60cddced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55a8-6c21-4cc1-a2c4-86cd60cddced.jpg?1",
             "name": "Floating-Dream Zubera",
             "text": "When Floating-Dream Zubera is put into a graveyard from play, draw a card for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "750e54a9-d3d0-5e32-bd61-e3a618491445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b91eb5-ea53-4a21-a2e5-9c545a42fa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b91eb5-ea53-4a21-a2e5-9c545a42fa30.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -2214,7 +2214,7 @@
         },
         {
             "id": "2cba7299-4295-5889-9a4a-148fc3aeb46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648430cc-80d1-479f-ae31-76687d2eb57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648430cc-80d1-479f-ae31-76687d2eb57c.jpg?1",
             "name": "Graceful Adept",
             "text": "You have no maximum hand size.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "59b57b9c-606c-51dc-b7ad-1c48a6610c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d16011-956b-40ac-afb6-6c7ad774802f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d16011-956b-40ac-afb6-6c7ad774802f.jpg?1",
             "name": "Guardian of Solitude",
             "text": "Whenever you play a Spirit or Arcane spell, target creature gains flying until end of turn.",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "4409747b-156f-5451-b35e-fe788cfc477f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7befed-805b-4a02-a87d-7df3a95db8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7befed-805b-4a02-a87d-7df3a95db8a0.jpg?1",
             "name": "Hinder",
             "text": "Counter target spell. If it's countered this way, put that card on the top or bottom of its owner's library instead of that player's graveyard.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "6ede2ca4-0a25-54f1-837e-f82b631efec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87aea05-5970-455e-a728-668cf23940a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87aea05-5970-455e-a728-668cf23940a6.jpg?1",
             "name": "Hisoka, Minamo Sensei",
             "text": "{2}{U}, Discard a card: Counter target spell if it has the same converted mana cost as the discarded card.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "9cc7cd5a-955a-5db6-a3e8-9cc5c70aade0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd4d01-1204-46a3-b237-45c37985acac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd4d01-1204-46a3-b237-45c37985acac.jpg?1",
             "name": "Hisoka's Defiance",
             "text": "Counter target Spirit or Arcane spell.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "f51b54e6-dd32-5e7f-a5bc-0060416e3860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7aec86-7b12-4025-af06-1c1928e56c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7aec86-7b12-4025-af06-1c1928e56c19.jpg?1",
             "name": "Hisoka's Guard",
             "text": "You may choose not to untap Hisoka's Guard during your untap step.\n{1}{U}, {T}: As long as Hisoka's Guard remains tapped, target creature you control other than Hisoka's Guard can't be the target of spells or abilities.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "d09cb0c3-7870-5af3-85a2-4888fc5dbaf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad732186-eeb9-4edb-a17a-51f8bac71802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad732186-eeb9-4edb-a17a-51f8bac71802.jpg?1",
             "name": "Honden of Seeing Winds",
             "text": "At the beginning of your upkeep, draw a card for each Shrine you control.",
             "colours": [
@@ -2455,7 +2455,7 @@
         },
         {
             "id": "8afd5f86-6980-5487-af73-84e843f88751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg?1",
             "name": "Jushi Apprentice // Tomoya the Revealer",
             "text": "{2}{U}, {T}: Draw a card. If you have nine or more cards in hand, flip Jushi Apprentice.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "cac83f97-0eb4-5ddb-84dc-622734b13134",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg?1",
             "name": "Jushi Apprentice // Tomoya the Revealer",
             "text": "{3}{U}{U}, {T}: Target player draws X cards, where X is the number of cards in your hand.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "7c647122-6c79-5ad8-bde1-2ecb12d0c035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf1b2f-933f-4ad3-a816-2797d96ff37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf1b2f-933f-4ad3-a816-2797d96ff37f.jpg?1",
             "name": "Kami of Twisted Reflection",
             "text": "Sacrifice Kami of Twisted Reflection: Return target creature you control to its owner's hand.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "3ec11245-5aa9-531e-b60c-389f4e83f13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea83eaeb-cf82-406b-977f-2bac41925739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea83eaeb-cf82-406b-977f-2bac41925739.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star is put into a graveyard from play, gain control of target creature.",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "d5960bb5-0fd6-5d40-9175-08411d04afd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f08f3d-82ef-4c3f-af2d-a3c834e22b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f08f3d-82ef-4c3f-af2d-a3c834e22b99.jpg?1",
             "name": "Lifted by Clouds",
             "text": "Target creature gains flying until end of turn.\nSplice onto Arcane {1}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "eee3a30f-be71-5158-bdee-cd8013fe779c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caaa733-6d4c-4e18-a64e-f95851c7063b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caaa733-6d4c-4e18-a64e-f95851c7063b.jpg?1",
             "name": "Meloku the Clouded Mirror",
             "text": "Flying\n{1}, Return a land you control to its owner's hand: Put a 1/1 blue Illusion creature token with flying into play.",
             "colours": [
@@ -2669,7 +2669,7 @@
         },
         {
             "id": "8d04764c-973d-5117-8b74-f29678d54110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5f8d3a-95e7-4dd9-8510-43517eb02693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5f8d3a-95e7-4dd9-8510-43517eb02693.jpg?1",
             "name": "Myojin of Seeing Winds",
             "text": "Myojin of Seeing Winds comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Seeing Winds is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Seeing Winds: Draw a card for each permanent you control.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "8293c8ea-120a-5b12-b6a2-428212554436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc4428-3f86-4359-927d-4009ada52c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc4428-3f86-4359-927d-4009ada52c5d.jpg?1",
             "name": "Mystic Restraints",
             "text": "You may play Mystic Restraints any time you could play an instant.\nWhen Mystic Restraints comes into play, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "80d81097-2fb1-50ab-9b27-1e382ed7afe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d870e607-1607-46f3-bc9f-925d0164bcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d870e607-1607-46f3-bc9f-925d0164bcf9.jpg?1",
             "name": "Part the Veil",
             "text": "Return all creatures you control to their owner's hand.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "c1c64348-9d29-5996-a767-823d6ca6a4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be02570-b840-46cc-af54-5279463fdcab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be02570-b840-46cc-af54-5279463fdcab.jpg?1",
             "name": "Peer Through Depths",
             "text": "Look at the top five cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "d7239e79-b951-56cd-8660-0091915493fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f59a16-45a8-4b52-a8df-ea96abafd8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f59a16-45a8-4b52-a8df-ea96abafd8ff.jpg?1",
             "name": "Petals of Insight",
             "text": "Look at the top three cards of your library. You may put those cards on the bottom of your library in any order. If you do, return Petals of Insight to its owner's hand. Otherwise, draw three cards.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "1d636ebe-e83a-5e28-ab30-a42f33bbfe06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e341d6b-f4b0-4347-8055-f5fab756334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e341d6b-f4b0-4347-8055-f5fab756334c.jpg?1",
             "name": "Psychic Puppetry",
             "text": "Tap or untap target permanent.\nSplice onto Arcane {U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -2875,7 +2875,7 @@
         },
         {
             "id": "b130874a-63d4-540e-a13e-612eb5040d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63a2cd-dd67-4692-9baf-520ebf6ab331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63a2cd-dd67-4692-9baf-520ebf6ab331.jpg?1",
             "name": "Reach Through Mists",
             "text": "Draw a card.",
             "colours": [
@@ -2909,7 +2909,7 @@
         },
         {
             "id": "71d3c3a9-170a-5869-b264-55eef08358c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff68016-80b4-4801-b796-5c5fdbc8faa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff68016-80b4-4801-b796-5c5fdbc8faa1.jpg?1",
             "name": "Reweave",
             "text": "Target permanent's controller sacrifices it. That player reveals cards from the top of his or her library until he or she reveals a card that shares a card type with the sacrificed permanent. The player puts that card into play, then shuffles his or her library.\nSplice onto Arcane {2}{U}{U}",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "9a5b54c3-9b71-51d7-a43c-8ec570e625e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e403cad6-84b0-4a6b-a2d8-cb572ec09932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e403cad6-84b0-4a6b-a2d8-cb572ec09932.jpg?1",
             "name": "River Kaijin",
             "text": "",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "39514909-56f3-5a74-ba89-bbffba1a92db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bde4d-4cdb-42db-acc5-441ed8fa4a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bde4d-4cdb-42db-acc5-441ed8fa4a5b.jpg?1",
             "name": "Sift Through Sands",
             "text": "Draw two cards, then discard a card.\nIf you played a spell named Peer Through Depths and a spell named Reach Through Mists this turn, you may search your library for a card named The Unspeakable, put it into play, then shuffle your library.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "39a1cd64-5baa-5ecf-9210-be662455a95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e76d003-2d15-43d7-9cbb-e00564d0cabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e76d003-2d15-43d7-9cbb-e00564d0cabf.jpg?1",
             "name": "Sire of the Storm",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may draw a card.",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "8a47e710-b73f-5029-9a4b-f6dd5c88e3c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3d3024-bef2-4b50-ab84-8ae2a23cdf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3d3024-bef2-4b50-ab84-8ae2a23cdf27.jpg?1",
             "name": "Soratami Cloudskater",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Draw a card, then discard a card.",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "69eaadb9-57a1-5bb0-a943-4827ad2cd2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff8968b-cd96-4f44-85f8-2af20d61d7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff8968b-cd96-4f44-85f8-2af20d61d7cb.jpg?1",
             "name": "Soratami Mirror-Guard",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "84a4cfe3-745d-53a8-a364-8a9fdc6682fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215209b1-1a5d-48f4-9eca-19a9848b2fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215209b1-1a5d-48f4-9eca-19a9848b2fed.jpg?1",
             "name": "Soratami Mirror-Mage",
             "text": "Flying\n{3}, Return three lands you control to their owner's hand: Return target creature to its owner's hand.",
             "colours": [
@@ -3150,7 +3150,7 @@
         },
         {
             "id": "4657e057-ac11-534c-8b0b-e317eed68ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b942ee46-c78b-414a-9de7-4376370532fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b942ee46-c78b-414a-9de7-4376370532fa.jpg?1",
             "name": "Soratami Rainshaper",
             "text": "Flying\n{3}, Return a land you control to its owner's hand: Target creature you control can't be the target of spells or abilities this turn.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "b6758b32-6bb7-53dd-83db-a7bd87f0a70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ea2db8-67c6-4bcd-8ba1-f620b8e8a8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ea2db8-67c6-4bcd-8ba1-f620b8e8a8c4.jpg?1",
             "name": "Soratami Savant",
             "text": "Flying\n{3}, Return a land you control to its owner's hand: Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "d46d58e1-ab32-52d5-8268-c6429f7fd2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a861d-e5c5-48b1-95c0-3ef04b690eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462a861d-e5c5-48b1-95c0-3ef04b690eac.jpg?1",
             "name": "Soratami Seer",
             "text": "Flying\n{4}, Return two lands you control to their owner's hand: Discard your hand, then draw that many cards.",
             "colours": [
@@ -3255,7 +3255,7 @@
         },
         {
             "id": "ba7baec1-2870-559f-bd33-6c36f8aa8362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29421dd2-70a7-4623-afe0-ca4cb415ec87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29421dd2-70a7-4623-afe0-ca4cb415ec87.jpg?1",
             "name": "Squelch",
             "text": "Counter target activated ability. (Mana abilities can't be targeted.)\nDraw a card.",
             "colours": [
@@ -3287,7 +3287,7 @@
         },
         {
             "id": "453533eb-3f36-5715-a6ff-a405167e69f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg?1",
             "name": "Student of Elements // Tobita, Master of Winds",
             "text": "When Student of Elements has flying, flip it.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "b4634985-8eba-5f39-a99d-7af5d87af8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9de1eebf-5725-438c-bcf0-f3a4d8a89fb0.jpg?1",
             "name": "Student of Elements // Tobita, Master of Winds",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "fa075c7a-d012-5458-a709-735047ab77fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea50e09-4ab3-439e-83d7-d584f8af8f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea50e09-4ab3-439e-83d7-d584f8af8f16.jpg?1",
             "name": "Swirl the Mists",
             "text": "As Swirl the Mists comes into play, choose a color word.\nAll instances of color words on spells and permanents become the chosen color word.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "db9316ff-7374-5125-935d-ce89ec0cc6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c914db7d-c907-4d25-a180-f68b274a5cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c914db7d-c907-4d25-a180-f68b274a5cb7.jpg?1",
             "name": "Teller of Tales",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, tap or untap target creature.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "df9fc4a1-8a2e-5b8e-8a46-17ac1ec559a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7919cf41-67bb-4dc4-90de-cf3fa2096c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7919cf41-67bb-4dc4-90de-cf3fa2096c2e.jpg?1",
             "name": "Thoughtbind",
             "text": "Counter target spell with converted mana cost 4 or less.",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "03dd60b2-6186-5415-a1b5-334888d91b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f968c5e9-12a8-4542-90b4-84e0238fa375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f968c5e9-12a8-4542-90b4-84e0238fa375.jpg?1",
             "name": "Time Stop",
             "text": "End the turn. (Remove all spells and abilities on the stack from the game, including this card. The player whose turn it is discards down to his or her maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "39eceb36-9351-5192-9347-d6714c1e7009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bd3e-e8d8-483e-871b-29fd378f817e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bd3e-e8d8-483e-871b-29fd378f817e.jpg?1",
             "name": "The Unspeakable",
             "text": "Flying, trample\nWhenever The Unspeakable deals combat damage to a player, you may return target Arcane card from your graveyard to your hand.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "a6d77b5a-be43-54f2-b001-360b4972340f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbfb3c53-1e68-48ce-8008-93bc49e188dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbfb3c53-1e68-48ce-8008-93bc49e188dd.jpg?1",
             "name": "Uyo, Silent Prophet",
             "text": "Flying\n{2}, Return two lands you control to their owner's hand: Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "39668d00-1aa9-59a3-9ae0-dce7fc119a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f973d6b-4a34-4b0e-b092-ead05bf2e535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f973d6b-4a34-4b0e-b092-ead05bf2e535.jpg?1",
             "name": "Wandering Ones",
             "text": "",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "01631cb7-e30e-5be8-87ba-00afce115628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee88d-849d-4715-ad88-7cdb855a3088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee88d-849d-4715-ad88-7cdb855a3088.jpg?1",
             "name": "Ashen-Skin Zubera",
             "text": "When Ashen-Skin Zubera is put into a graveyard from play, target opponent discards a card for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "0f72e445-d433-5083-93dc-4a33c4835b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfff5d3-1433-4a24-83e6-6361a446b974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfff5d3-1433-4a24-83e6-6361a446b974.jpg?1",
             "name": "Befoul",
             "text": "Destroy target land or nonblack creature. It can't be regenerated.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "7d40e039-e287-53e8-8b55-08a425c62aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f218bb94-d5a2-41f6-8bca-b689dcd09a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f218bb94-d5a2-41f6-8bca-b689dcd09a43.jpg?1",
             "name": "Blood Speaker",
             "text": "At the beginning of your upkeep, you may sacrifice Blood Speaker. If you do, search your library for a Demon card, reveal that card, and put it into your hand. Then shuffle your library.\nWhenever a Demon comes into play under your control, return Blood Speaker from your graveyard to your hand.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "7241f895-28e8-5a0d-b56e-74dac36e758c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557f035-f93b-41ce-b8de-dea79dcf15be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557f035-f93b-41ce-b8de-dea79dcf15be.jpg?1",
             "name": "Bloodthirsty Ogre",
             "text": "{T}: Put a devotion counter on Bloodthirsty Ogre.\n{T}: Target creature gets -X/-X until end of turn, where X is the number of devotion counters on Bloodthirsty Ogre. Play this ability only if you control a Demon.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "2752eee9-5af7-514c-b8af-8642b5747a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cad7a3-777e-4c84-b404-5f504844ab3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cad7a3-777e-4c84-b404-5f504844ab3b.jpg?1",
             "name": "Cranial Extraction",
             "text": "Name a nonland card. Search target player's graveyard, hand, and library for all cards with that name and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "9069e675-35af-53e1-9cc9-d01445165fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6972a-5305-423f-a936-16ee0fbf9200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6972a-5305-423f-a936-16ee0fbf9200.jpg?1",
             "name": "Cruel Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Cruel Deceiver gains \"Whenever Cruel Deceiver deals damage to a creature, destroy that creature\" until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "0ed0e641-0d49-58c9-8004-47a467ae62f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f24fe9-22c4-4e53-9d7a-3cbf5533ac9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f24fe9-22c4-4e53-9d7a-3cbf5533ac9b.jpg?1",
             "name": "Cursed Ronin",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{B}: Cursed Ronin gets +1/+1 until end of turn.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "072b5d8d-0398-5f57-9d1f-a77e68376dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a1b403-776f-4fd7-a77a-b73946ab179d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a1b403-776f-4fd7-a77a-b73946ab179d.jpg?1",
             "name": "Dance of Shadows",
             "text": "Creatures you control get +1/+0 and gain fear until end of turn.",
             "colours": [
@@ -3871,7 +3871,7 @@
         },
         {
             "id": "9b432e1f-f41b-50a3-916b-3d7e062ea072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bd3c73-fff4-40e8-b9db-80a010a4dd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bd3c73-fff4-40e8-b9db-80a010a4dd37.jpg?1",
             "name": "Deathcurse Ogre",
             "text": "When Deathcurse Ogre is put into a graveyard from play, each player loses 3 life.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "cec183d4-1ad1-55ee-a8ea-9a0f9de4b136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a72347d-91cd-45a8-a026-a655e5507322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a72347d-91cd-45a8-a026-a655e5507322.jpg?1",
             "name": "Devouring Greed",
             "text": "As an additional cost to play Devouring Greed, you may sacrifice any number of Spirits.\nTarget player loses 2 life plus 2 life for each Spirit sacrificed this way. You gain that much life.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "fc66ca1a-b171-587d-bd29-f4ddd34d46ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8130a902-3a03-4473-a64f-84cf3590f4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8130a902-3a03-4473-a64f-84cf3590f4c6.jpg?1",
             "name": "Distress",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "c8b741cd-28fa-58ce-ae8b-b44f973f0b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3e988f-314c-4e83-b279-c2a736933e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3e988f-314c-4e83-b279-c2a736933e64.jpg?1",
             "name": "Gibbering Kami",
             "text": "Flying\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "54360fc9-8f6e-5fb4-a004-080493df924b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7698a5da-5c70-4818-927b-3a923314e537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7698a5da-5c70-4818-927b-3a923314e537.jpg?1",
             "name": "Gutwrencher Oni",
             "text": "Trample\nAt the beginning of your upkeep, discard a card if you don't control an Ogre.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "6605d255-9a80-52f5-9085-a6d345f04a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf0f8d-f988-45ec-b75b-d97206326cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf0f8d-f988-45ec-b75b-d97206326cfb.jpg?1",
             "name": "He Who Hungers",
             "text": "Flying\n{1}, Sacrifice a Spirit: Target opponent reveals his or her hand. Choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.\nSoulshift 4",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "367f3cb8-6b07-5183-8d4a-425cacbe24a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941fd135-1c5a-4650-8faf-dfa2c93ec8c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941fd135-1c5a-4650-8faf-dfa2c93ec8c9.jpg?1",
             "name": "Hideous Laughter",
             "text": "All creatures get -2/-2 until end of turn.\nSplice onto Arcane {3}{B}{B} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "3eede8c6-ccb4-5aac-9d8a-f71e772139ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526419ae-5a49-40e8-ac45-f213a76c7326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526419ae-5a49-40e8-ac45-f213a76c7326.jpg?1",
             "name": "Honden of Night's Reach",
             "text": "At the beginning of your upkeep, target opponent discards a card for each Shrine you control.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "688620fc-1f8d-5478-a278-3b03aa712251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41983cb-c4e4-4384-bd69-df3fc6e74cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41983cb-c4e4-4384-bd69-df3fc6e74cd0.jpg?1",
             "name": "Horobi, Death's Wail",
             "text": "Flying\nWhenever a creature becomes the target of a spell or ability, destroy that creature.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "e3a5a99c-6c22-546a-b8f0-c5e7964aed40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd67e11-3dad-4e59-b15d-02911e53fbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd67e11-3dad-4e59-b15d-02911e53fbbf.jpg?1",
             "name": "Iname, Death Aspect",
             "text": "When Iname, Death Aspect comes into play, you may search your library for any number of Spirit cards and put them into your graveyard. If you do, shuffle your library.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "49866d76-aa9d-51b4-b745-5e7d9bb0ee77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baef070-d265-4c6d-9b4b-3cafbd3b34c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baef070-d265-4c6d-9b4b-3cafbd3b34c3.jpg?1",
             "name": "Kami of Lunacy",
             "text": "Flying\nSoulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "e84caa99-ad1e-5fe8-ae21-60e3434a1032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a395a6-b1f5-4b7f-87cc-c77b4d497e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a395a6-b1f5-4b7f-87cc-c77b4d497e9a.jpg?1",
             "name": "Kami of the Waning Moon",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, target creature gains fear until end of turn.",
             "colours": [
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "e522c443-2bdf-5b03-b32d-276593c9390c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e18994-d08b-4a8e-abfb-b5531fd6f816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e18994-d08b-4a8e-abfb-b5531fd6f816.jpg?1",
             "name": "Kiku, Night's Flower",
             "text": "{2}{B}{B}, {T}: Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "eea786c2-ee22-5b8d-8faa-4dbfa32c53cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63dc0698-e92f-4134-80e4-5cc37b80e37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63dc0698-e92f-4134-80e4-5cc37b80e37c.jpg?1",
             "name": "Kokusho, the Evening Star",
             "text": "Flying\nWhen Kokusho, the Evening Star is put into a graveyard from play, each opponent loses 5 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "e2aff046-d957-5e58-941e-86b51d487deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d23ff5-849d-4032-9c70-8e9effcbac81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d23ff5-849d-4032-9c70-8e9effcbac81.jpg?1",
             "name": "Kuro, Pitlord",
             "text": "At the beginning of your upkeep, sacrifice Kuro, Pitlord unless you pay {B}{B}{B}{B}.\nPay 1 life: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "9227808c-c937-5440-bd55-d2e7cff77bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e4548b-c171-4f10-b896-af37543dcf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e4548b-c171-4f10-b896-af37543dcf0f.jpg?1",
             "name": "Marrow-Gnawer",
             "text": "All Rats have fear.\n{T}, Sacrifice a Rat: Put X 1/1 black Rat creature tokens into play, where X is the number of Rats you control.",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "ea1e9831-0d6f-5f98-b469-375a95323eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d797e91-3fc7-4f62-8cd8-dbd5f445e69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d797e91-3fc7-4f62-8cd8-dbd5f445e69c.jpg?1",
             "name": "Midnight Covenant",
             "text": "Enchanted creature has \"{B}: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "c69ac42a-d22f-5abb-a849-0f092d9d57f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a295b0-535e-4c2d-879d-62603d1f2f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a295b0-535e-4c2d-879d-62603d1f2f1b.jpg?1",
             "name": "Myojin of Night's Reach",
             "text": "Myojin of Night's Reach comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Night's Reach is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Night's Reach: Each opponent discards his or her hand.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "625b5929-508d-57d5-9fb8-bb1e6774901d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f27ff7-c7e4-4099-b3ac-6560c6ccba41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f27ff7-c7e4-4099-b3ac-6560c6ccba41.jpg?1",
             "name": "Nezumi Bone-Reader",
             "text": "{B}, Sacrifice a creature: Target player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "d412abac-ef2c-5b10-9e4a-c7062911f9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166af8cd-9690-4741-ade3-5d5f9723c431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166af8cd-9690-4741-ade3-5d5f9723c431.jpg?1",
             "name": "Nezumi Cutthroat",
             "text": "Fear\nNezumi Cutthroat can't block.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "bce68d4d-0332-5be5-86e0-bf9d214fa8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg?1",
             "name": "Nezumi Graverobber // Nighteyes the Desecrator",
             "text": "{1}{B}: Remove target card in an opponent's graveyard from the game. If no cards are in that graveyard, flip Nezumi Graverobber.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "c81c2f3d-eebe-59ea-b7e8-c3f91908eadd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77ffd913-8efa-48e5-a5cf-293d3068dbbf.jpg?1",
             "name": "Nezumi Graverobber // Nighteyes the Desecrator",
             "text": "{4}{B}: Put target creature card in a graveyard into play under your control.",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "50b1de8e-ddfa-57e9-a6a8-52d164e55f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b8d6f-c60a-4107-b931-31b10f497237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b8d6f-c60a-4107-b931-31b10f497237.jpg?1",
             "name": "Nezumi Ronin",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "a888a494-31c0-592a-bc4a-b4a9c9181ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg?1",
             "name": "Nezumi Shortfang // Stabwhisker the Odious",
             "text": "{1}{B}, {T}: Target opponent discards a card. Then if that player has no cards in hand, flip Nezumi Shortfang.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "996c7cc2-9201-5f7c-ba67-f62158d6bcb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg?1",
             "name": "Nezumi Shortfang // Stabwhisker the Odious",
             "text": "At the beginning of each opponent's upkeep, that player loses 1 life for each card fewer than three in his or her hand.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "f7a4a9d3-a921-56fa-8d81-f54a8138aade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d012ee-9523-469f-8ddb-f4b664093c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d012ee-9523-469f-8ddb-f4b664093c13.jpg?1",
             "name": "Night Dealings",
             "text": "Whenever a source you control deals damage to another player, put that many theft counters on Night Dealings.\n{2}{B}{B}, Remove X theft counters from Night Dealings: Search your library for a nonland card with converted mana cost X, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "0b43426f-d3da-5656-9186-57abc2693be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce44980-0540-4b31-9a81-35357a4382fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce44980-0540-4b31-9a81-35357a4382fa.jpg?1",
             "name": "Night of Souls' Betrayal",
             "text": "All creatures get -1/-1.",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "dbd0b8c0-4eb0-595f-a992-e25b56513de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b878d1c2-34ce-4cb4-9ea3-8d7cd2028484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b878d1c2-34ce-4cb4-9ea3-8d7cd2028484.jpg?1",
             "name": "Numai Outcast",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{B}, Pay 5 life: Regenerate Numai Outcast.",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "ba229631-4b4d-55be-a2a3-ef4aabc10a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f122d-e1b7-4dd4-a770-a8f206ba42da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f122d-e1b7-4dd4-a770-a8f206ba42da.jpg?1",
             "name": "Oni Possession",
             "text": "At the beginning of your upkeep, sacrifice a creature.\nEnchanted creature gets +3/+3 and has trample.\nEnchanted creature is a Demon Spirit.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "48c35ae3-82d0-519f-ba4e-6a4f22c20e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b371b32-7758-4dc9-b4c5-1d1df1f1826a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b371b32-7758-4dc9-b4c5-1d1df1f1826a.jpg?1",
             "name": "Painwracker Oni",
             "text": "Fear\nAt the beginning of your upkeep, sacrifice a creature if you don't control an Ogre.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "4f33d2b8-d6d3-5ef5-9eba-f1187b910ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016afdaa-29bf-4690-bdfe-9074087a191c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016afdaa-29bf-4690-bdfe-9074087a191c.jpg?1",
             "name": "Pull Under",
             "text": "Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "53fc5dd8-dd48-5096-9ae1-8e10d48f9028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ef007a-fcf4-4293-933e-4f9f7f602002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ef007a-fcf4-4293-933e-4f9f7f602002.jpg?1",
             "name": "Rag Dealer",
             "text": "{2}{B}, {T}: Remove up to three target cards in a single graveyard from the game.",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "4f074153-39c7-5f93-b131-b00b97abf074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f3312f-71d0-4dfd-ba39-c2a2ff8d5bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f3312f-71d0-4dfd-ba39-c2a2ff8d5bd0.jpg?1",
             "name": "Ragged Veins",
             "text": "You may play Ragged Veins any time you could play an instant.\nWhenever enchanted creature is dealt damage, its controller loses that much life.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "8a8c3be1-6736-5bee-b29c-b1e068b9e57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b300a3-e6a8-4ca9-bb26-03f57b5ff6ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b300a3-e6a8-4ca9-bb26-03f57b5ff6ec.jpg?1",
             "name": "Rend Flesh",
             "text": "Destroy target non-Spirit creature.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "1026cf1b-cccb-5672-ad2f-a30cf80fb309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0235-a7fe-4e23-b154-3d30668a29a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100f0235-a7fe-4e23-b154-3d30668a29a7.jpg?1",
             "name": "Rend Spirit",
             "text": "Destroy target Spirit.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "f04e1ce3-8056-5827-965b-83a6a09bbf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d9bf4e-3bb1-4154-b1ff-a3d8a2810c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d9bf4e-3bb1-4154-b1ff-a3d8a2810c1b.jpg?1",
             "name": "Scuttling Death",
             "text": "Sacrifice Scuttling Death: Target creature gets -1/-1 until end of turn.\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "9ae1b13e-bcee-56b4-99d9-097fef1c9ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e61750-f7d7-4e6d-9d68-e1e357868a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e61750-f7d7-4e6d-9d68-e1e357868a8d.jpg?1",
             "name": "Seizan, Perverter of Truth",
             "text": "At the beginning of each player's upkeep, that player loses 2 life and draws two cards.",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "f4b63a47-eac8-5d53-9da8-3cd85a4a811f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36712c-1ccb-4efe-8db8-823b9b80a99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36712c-1ccb-4efe-8db8-823b9b80a99f.jpg?1",
             "name": "Soulless Revival",
             "text": "Return target creature card from your graveyard to your hand.\nSplice onto Arcane {1}{B} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5198,7 +5198,7 @@
         },
         {
             "id": "00cd486e-5d5f-50ca-b522-49400e412b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba827c43-5dd5-471f-83b2-cb5428fcd063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba827c43-5dd5-471f-83b2-cb5428fcd063.jpg?1",
             "name": "Struggle for Sanity",
             "text": "Target opponent reveals his or her hand. That player sets aside a card from it, then you set aside a card from it. Repeat this process until all cards in that hand have been set aside. That player returns the cards he or she set aside to his or her hand and puts the rest into his or her graveyard.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "21d70727-d5e6-5f57-b878-f90fdba5cd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac549d51-3862-4eb0-9951-f13a8ba28822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac549d51-3862-4eb0-9951-f13a8ba28822.jpg?1",
             "name": "Swallowing Plague",
             "text": "Swallowing Plague deals X damage to target creature and you gain X life.",
             "colours": [
@@ -5264,7 +5264,7 @@
         },
         {
             "id": "8dc5a3e7-6230-5dda-a8fa-e1fceffb4d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3029b8-01e2-4419-817e-318f23d6ce04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3029b8-01e2-4419-817e-318f23d6ce04.jpg?1",
             "name": "Thief of Hope",
             "text": "Whenever you play a Spirit or Arcane spell, target opponent loses 1 life and you gain 1 life.\nSoulshift 2 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 2 or less from your graveyard to your hand.)",
             "colours": [
@@ -5298,7 +5298,7 @@
         },
         {
             "id": "97715cb8-2dbd-5d70-b548-4c1ca8ed0c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c1ba-eae4-442b-8b80-20869ba20568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c1ba-eae4-442b-8b80-20869ba20568.jpg?1",
             "name": "Villainous Ogre",
             "text": "Villainous Ogre can't block.\nAs long as you control a Demon, Villainous Ogre has \"{B}: Regenerate Villainous Ogre.\"",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "ae4f8627-af5f-5b4d-8170-f89c11a96e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b892f31-816e-47c0-98b9-d71008bb6af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b892f31-816e-47c0-98b9-d71008bb6af4.jpg?1",
             "name": "Waking Nightmare",
             "text": "Target player discards two cards.",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "d0f12dcc-e8a3-5e3e-87c6-08221ad1f3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3172965-6057-472f-9712-1dd23d25d1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3172965-6057-472f-9712-1dd23d25d1a7.jpg?1",
             "name": "Wicked Akuba",
             "text": "{B}: Target player dealt damage by Wicked Akuba this turn loses 1 life.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "7021c457-18a6-5dd5-bcd8-3c98ff283d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfef6acb-a11c-4a3f-9cfb-9394dece2675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfef6acb-a11c-4a3f-9cfb-9394dece2675.jpg?1",
             "name": "Akki Avalanchers",
             "text": "Sacrifice a land: Akki Avalanchers gets +2/+0 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "798956d8-3d5e-5b15-9ac8-5b69d2d2384c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3793580a-052b-4e33-83ab-290086511a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3793580a-052b-4e33-83ab-290086511a21.jpg?1",
             "name": "Akki Coalflinger",
             "text": "First strike\n{R}, {T}: Attacking creatures gain first strike until end of turn.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "26ec184a-58f2-54bf-b6d3-c82c6aaea1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg?1",
             "name": "Akki Lavarunner // Tok-Tok, Volcano Born",
             "text": "Haste\nWhenever Akki Lavarunner deals damage to an opponent, flip it.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "c5e0b33c-79ea-5650-851c-94eff9bcd7f8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg?1",
             "name": "Akki Lavarunner // Tok-Tok, Volcano Born",
             "text": "Protection from red\nIf a red source would deal damage to a player, it deals that much damage plus 1 to that player instead.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "af841b07-2d78-5662-beae-aae51af6d3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8b6685-2c74-4026-aef0-73ca7bc43306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8b6685-2c74-4026-aef0-73ca7bc43306.jpg?1",
             "name": "Akki Rockspeaker",
             "text": "When Akki Rockspeaker comes into play, add {R} to your mana pool.",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "8cc5cbec-c6c9-5f65-a577-aab17476396d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdd1e22-d68d-4858-b253-80071d26d50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdd1e22-d68d-4858-b253-80071d26d50e.jpg?1",
             "name": "Akki Underminer",
             "text": "Whenever Akki Underminer deals combat damage to a player, that player sacrifices a permanent.",
             "colours": [
@@ -5614,7 +5614,7 @@
         },
         {
             "id": "125af987-62ba-526c-8d6c-885e42c49bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e4394a-fa91-4cf9-99c1-dc0bc1011c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e4394a-fa91-4cf9-99c1-dc0bc1011c5b.jpg?1",
             "name": "Battle-Mad Ronin",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\nBattle-Mad Ronin attacks each turn if able.",
             "colours": [
@@ -5649,7 +5649,7 @@
         },
         {
             "id": "497dce11-4a3e-5c1e-b999-ba355ec2d8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c015a6-4d7d-421b-84fa-30bf070cff83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c015a6-4d7d-421b-84fa-30bf070cff83.jpg?1",
             "name": "Ben-Ben, Akki Hermit",
             "text": "{T}: Ben-Ben, Akki Hermit deals damage to target attacking creature equal to the number of untapped Mountains you control.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "4eadac49-a360-56a9-8b7b-37b3382b22c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50a0fe0-249d-4a88-a538-cdf622388ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50a0fe0-249d-4a88-a538-cdf622388ce2.jpg?1",
             "name": "Blind with Anger",
             "text": "Untap target nonlegendary creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -5720,7 +5720,7 @@
         },
         {
             "id": "c701003d-8bc2-526a-b9d8-3da2d3fcd5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af8cd97-28cb-4499-a197-687e8f31644a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af8cd97-28cb-4499-a197-687e8f31644a.jpg?1",
             "name": "Blood Rites",
             "text": "{1}{R}, Sacrifice a creature: Blood Rites deals 2 damage to target creature or player.",
             "colours": [
@@ -5752,7 +5752,7 @@
         },
         {
             "id": "a7d7f03a-d876-52aa-97f6-44d371226533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef8c94-469b-4a76-b507-25b51f2501ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef8c94-469b-4a76-b507-25b51f2501ab.jpg?1",
             "name": "Brothers Yamazaki",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf there are exactly two permanents named Brothers Yamazaki in play, the \"legend rule\" doesn't apply to them.\nEach other creature named Brothers Yamazaki gets +2/+2 and has haste.",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "aacfd47d-9b20-52ad-a62c-cba3414357ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d854a02-661c-4071-9a92-a97a3ad607b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d854a02-661c-4071-9a92-a97a3ad607b3.jpg?1",
             "name": "Brothers Yamazaki",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nIf there are exactly two permanents named Brothers Yamazaki in play, the \"legend rule\" doesn't apply to them.\nEach other creature named Brothers Yamazaki gets +2/+2 and has haste.",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "141aa7e5-7473-518f-a4b9-9208deb92782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d532b3-4bd6-4c1d-974d-789976117497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d532b3-4bd6-4c1d-974d-789976117497.jpg?1",
             "name": "Brutal Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Brutal Deceiver gets +1/+0 and gains first strike until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "360b24a1-46a6-5c87-81ff-adf3071744b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58b4374-1a50-4574-8493-f5535c1020e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58b4374-1a50-4574-8493-f5535c1020e8.jpg?1",
             "name": "Crushing Pain",
             "text": "Crushing Pain deals 6 damage to target creature that was dealt damage this turn.",
             "colours": [
@@ -5898,7 +5898,7 @@
         },
         {
             "id": "e34d6af7-7a99-5c74-9c2b-e47b29b9896e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bdb92a-7bdb-434b-8cc0-873969faf566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bdb92a-7bdb-434b-8cc0-873969faf566.jpg?1",
             "name": "Desperate Ritual",
             "text": "Add {R}{R}{R} to your mana pool.\nSplice onto Arcane {1}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "1517e3c7-bf17-5551-a27e-609e6535e0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608a6e1e-3e95-4ce4-aaf6-5f14c0456850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608a6e1e-3e95-4ce4-aaf6-5f14c0456850.jpg?1",
             "name": "Devouring Rage",
             "text": "As an additional cost to play Devouring Rage, you may sacrifice any number of Spirits.\nTarget creature gets +3/+0 until end of turn. For each Spirit sacrificed this way, that creature gets an additional +3/+0 until end of turn.",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "9592a215-745d-519c-bbf8-6ef468d41fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b47a9-c21e-4c0a-9c70-38b8ebbffab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b47a9-c21e-4c0a-9c70-38b8ebbffab3.jpg?1",
             "name": "Earthshaker",
             "text": "Whenever you play a Spirit or Arcane spell, Earthshaker deals 2 damage to each creature without flying.",
             "colours": [
@@ -6000,7 +6000,7 @@
         },
         {
             "id": "a7a49856-51a6-59ef-987b-2a37ead25b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150e3f0-237e-4669-9401-d2cd08e86387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150e3f0-237e-4669-9401-d2cd08e86387.jpg?1",
             "name": "Ember-Fist Zubera",
             "text": "When Ember-Fist Zubera is put into a graveyard from play, it deals damage to target creature or player equal to the number of Zubera put into all graveyards from play this turn.",
             "colours": [
@@ -6035,7 +6035,7 @@
         },
         {
             "id": "d75640b0-e469-570b-af09-11684a6696d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54df527-6949-4b74-821b-b051f493f3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54df527-6949-4b74-821b-b051f493f3c5.jpg?1",
             "name": "Frostwielder",
             "text": "{T}: Frostwielder deals 1 damage to target creature or player.\nIf a creature dealt damage by Frostwielder this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "5dd488ee-cd93-54ae-996e-f4658b971bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5637a3b0-6204-4893-878e-c34babeab2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5637a3b0-6204-4893-878e-c34babeab2e6.jpg?1",
             "name": "Glacial Ray",
             "text": "Glacial Ray deals 2 damage to target creature or player.\nSplice onto Arcane {1}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -6104,7 +6104,7 @@
         },
         {
             "id": "79ac4dcb-ba4a-5947-a4d0-45382564a49c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcff0b92-edd0-4197-965b-3fd86bc884d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcff0b92-edd0-4197-965b-3fd86bc884d8.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord comes into play, you may search your library for an Equipment card and put it into play. If you do, shuffle your library.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, you get an additional combat phase.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "47e4af50-e87a-5c6c-975e-d48dcee6cb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881fecf4-8c14-4614-84bd-c1a3dcdbb5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881fecf4-8c14-4614-84bd-c1a3dcdbb5ff.jpg?1",
             "name": "Hanabi Blast",
             "text": "Hanabi Blast deals 2 damage to target creature or player. Return Hanabi Blast to its owner's hand, then discard a card at random.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "482c941a-1b19-5888-aba2-7e269cf4ec0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7361289-5111-49c2-a786-b7181384596b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7361289-5111-49c2-a786-b7181384596b.jpg?1",
             "name": "Hearth Kami",
             "text": "{X}, Sacrifice Hearth Kami: Destroy target artifact with converted mana cost X.",
             "colours": [
@@ -6207,7 +6207,7 @@
         },
         {
             "id": "db80a87a-4e9b-5d47-bfa8-37026dbbb42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b254f341-aac1-433b-a739-fee8bd7fdf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b254f341-aac1-433b-a739-fee8bd7fdf69.jpg?1",
             "name": "Honden of Infinite Rage",
             "text": "At the beginning of your upkeep, Honden of Infinite Rage deals damage to target creature or player equal to the number of Shrines you control.",
             "colours": [
@@ -6243,7 +6243,7 @@
         },
         {
             "id": "82b31423-2fe1-5c9e-b27b-704f70a4b300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg?1",
             "name": "Initiate of Blood // Goka the Unjust",
             "text": "{T}: Initiate of Blood deals 1 damage to target creature that was dealt damage this turn. When that creature is put into a graveyard this turn, flip Initiate of Blood.",
             "colours": [
@@ -6278,7 +6278,7 @@
         },
         {
             "id": "491c88ad-5ae6-510b-870c-db5e3c9d913d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3523b8e-065f-427c-8d5b-eb731ca91ede.jpg?1",
             "name": "Initiate of Blood // Goka the Unjust",
             "text": "{T}: Goka the Unjust deals 4 damage to target creature that was dealt damage this turn.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "6ec7ae63-f9e2-5dc3-a795-1b5caea5b11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4380118d-f209-446d-829b-3564796e0219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4380118d-f209-446d-829b-3564796e0219.jpg?1",
             "name": "Kami of Fire's Roar",
             "text": "Whenever you play a Spirit or Arcane spell, target creature can't block this turn.",
             "colours": [
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "0e5c49fe-778f-5d24-86c5-6c11477d4dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162018eb-5483-4fa2-9c5a-abb639eecf91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162018eb-5483-4fa2-9c5a-abb639eecf91.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Put a creature token into play that's a copy of target nonlegendary creature you control. That creature token has haste. Sacrifice it at end of turn.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "8080c7bb-3bf9-5aac-8aca-ccacdb86c2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93870f9-343f-43e7-8ae8-e7aaa56aacca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93870f9-343f-43e7-8ae8-e7aaa56aacca.jpg?1",
             "name": "Kumano, Master Yamabushi",
             "text": "{1}{R}: Kumano, Master Yamabushi deals 1 damage to target creature or player.\nIf a creature dealt damage by Kumano this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -6423,7 +6423,7 @@
         },
         {
             "id": "a473b4f0-ea3d-5d2d-a4a1-47423f0f2e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62b233e-95fe-4cfd-ad89-86e07656bf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62b233e-95fe-4cfd-ad89-86e07656bf8b.jpg?1",
             "name": "Kumano's Pupils",
             "text": "If a creature dealt damage by Kumano's Pupils this turn would be put into a graveyard, remove it from the game instead.",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "53e6b34f-4cb2-5294-afd0-1affd40d2fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b2fae1-242b-45e0-a757-b1adc02c06f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b2fae1-242b-45e0-a757-b1adc02c06f3.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player.",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "1bb6e20b-2573-5c3d-9cd9-0c0e5e5aff29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bde4cba-57b2-485f-9724-0f79d156d664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bde4cba-57b2-485f-9724-0f79d156d664.jpg?1",
             "name": "Mana Seism",
             "text": "Sacrifice any number of lands. Add {1} to your mana pool for each land sacrificed this way.",
             "colours": [
@@ -6524,7 +6524,7 @@
         },
         {
             "id": "5ff62879-e528-5bb6-a11e-fd7bc0fa9adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59418766-5567-4ec4-af1f-1cb2db2958d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59418766-5567-4ec4-af1f-1cb2db2958d0.jpg?1",
             "name": "Mindblaze",
             "text": "Name a nonland card and choose a number greater than 0. Target player reveals his or her library. If that library contains exactly the chosen number of the named card, Mindblaze deals 8 damage to that player. Then that player shuffles his or her library.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "4e9d5e36-f68d-52fd-991e-1b40cd2577a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df630ae9-aa17-46e9-95e7-4980f4a76ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df630ae9-aa17-46e9-95e7-4980f4a76ade.jpg?1",
             "name": "Myojin of Infinite Rage",
             "text": "Myojin of Infinite Rage comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Infinite Rage is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Infinite Rage: Destroy all lands.",
             "colours": [
@@ -6592,7 +6592,7 @@
         },
         {
             "id": "c9319a64-1a1b-55c5-8767-1877f762b134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc8bbb9-d6a1-474b-8f34-594b5a9d4178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc8bbb9-d6a1-474b-8f34-594b5a9d4178.jpg?1",
             "name": "Ore Gorger",
             "text": "Whenever you play a Spirit or Arcane spell, you may destroy target nonbasic land.",
             "colours": [
@@ -6626,7 +6626,7 @@
         },
         {
             "id": "6eccfad1-02e6-5591-bf72-92246b0f9f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693317ea-0237-4b65-812f-b31a6427b2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693317ea-0237-4b65-812f-b31a6427b2a3.jpg?1",
             "name": "Pain Kami",
             "text": "{X}{R}, Sacrifice Pain Kami: Pain Kami deals X damage to target creature.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "80a52ed9-92c8-5a82-b752-71d5f84fdfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614ead7b-1975-4a99-bdc2-f8afc6cf92d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614ead7b-1975-4a99-bdc2-f8afc6cf92d7.jpg?1",
             "name": "Ronin Houndmaster",
             "text": "Haste\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "797075fb-e4be-5f28-b34b-b1e4f5880d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17898412-6275-4762-a03b-04daf30fee7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17898412-6275-4762-a03b-04daf30fee7f.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star is put into a graveyard from play, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "040ebbe1-21f9-5029-80e5-4867f007fa34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de0e2c-61ca-496e-8990-ed0e6f6521a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de0e2c-61ca-496e-8990-ed0e6f6521a6.jpg?1",
             "name": "Shimatsu the Bloodcloaked",
             "text": "As Shimatsu the Bloodcloaked comes into play, sacrifice any number of permanents. Shimatsu comes into play with that many +1/+1 counters on it.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "9361d03d-9548-5b43-b6db-fc675f47393e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd611b7-7bd3-4a76-bd69-34a7235965ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd611b7-7bd3-4a76-bd69-34a7235965ae.jpg?1",
             "name": "Sideswipe",
             "text": "You may change any targets of target Arcane spell.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "77cea115-7942-5ec4-9e10-3b3b45db42ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d147088-2191-49e8-9c0b-419d4048604a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d147088-2191-49e8-9c0b-419d4048604a.jpg?1",
             "name": "Sokenzan Bruiser",
             "text": "Mountainwalk",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "fa7ac9d4-e8fd-5330-aa83-1cf6fe94ff21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b20126-da96-4d79-8d3f-8d7da8e94f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b20126-da96-4d79-8d3f-8d7da8e94f4a.jpg?1",
             "name": "Soul of Magma",
             "text": "Whenever you play a Spirit or Arcane spell, Soul of Magma deals 1 damage to target creature.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "736adf06-5ebb-5b0d-8807-af0a5e24796a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fe38cc-2b12-4491-8deb-fbcb306febf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fe38cc-2b12-4491-8deb-fbcb306febf2.jpg?1",
             "name": "Soulblast",
             "text": "As an additional cost to play Soulblast, sacrifice all creatures you control.\nSoulblast deals damage to target creature or player equal to the total power of the sacrificed creatures.",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "db54ce97-88a5-55f0-a38b-2c8debff6c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ac6701-f522-4ded-89bb-d8cce7fa2b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ac6701-f522-4ded-89bb-d8cce7fa2b40.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "2f504f37-c070-546e-852e-f6bc733f9ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a78af-a991-4a5e-bdc2-f39947b89bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a78af-a991-4a5e-bdc2-f39947b89bb2.jpg?1",
             "name": "Strange Inversion",
             "text": "Switch target creature's power and toughness until end of turn.\nSplice onto Arcane {1}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -6968,7 +6968,7 @@
         },
         {
             "id": "740d74ee-384a-5bd5-8fd2-a80d018956c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09e6a-2965-4855-bd41-41b41ba188fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09e6a-2965-4855-bd41-41b41ba188fb.jpg?1",
             "name": "Through the Breach",
             "text": "Put a creature card from your hand into play. That creature has haste. Sacrifice that creature at end of turn.\nSplice onto Arcane {2}{R}{R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "9c2262b0-336b-576b-9a54-5c1735cfced3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5bd60-87ed-41d2-bbcb-bd4a40a772c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43b5bd60-87ed-41d2-bbcb-bd4a40a772c9.jpg?1",
             "name": "Tide of War",
             "text": "Whenever one or more creatures blocks, flip a coin. If you win the flip, the defending player sacrifices all blocking creatures. Otherwise, the attacking player sacrifices the blocked creatures.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "1b207d9c-2363-5dc3-8f4f-04ea32737a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fca4fa-d0e1-41c4-999a-9804786eacbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fca4fa-d0e1-41c4-999a-9804786eacbb.jpg?1",
             "name": "Uncontrollable Anger",
             "text": "You may play Uncontrollable Anger any time you could play an instant.\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -7068,7 +7068,7 @@
         },
         {
             "id": "fe43c56e-0c31-5db7-bef4-21a533634920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034ad87-fd28-4c23-b897-1d6343ce8282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d034ad87-fd28-4c23-b897-1d6343ce8282.jpg?1",
             "name": "Unearthly Blizzard",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -7102,7 +7102,7 @@
         },
         {
             "id": "3e610bd1-66ea-55d2-a3cc-41a5e3c9c082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a542b1f4-82f8-471a-b0a6-7ead9167da27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a542b1f4-82f8-471a-b0a6-7ead9167da27.jpg?1",
             "name": "Unnatural Speed",
             "text": "Target creature gains haste until end of turn.",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "9bd75f47-9310-5975-bebc-fa99890ecec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9bacba-55c4-4b92-bdd9-01b6035ed1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9bacba-55c4-4b92-bdd9-01b6035ed1b2.jpg?1",
             "name": "Yamabushi's Flame",
             "text": "Yamabushi's Flame deals 3 damage to target creature or player. If a creature dealt damage this way would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "36d7f024-42cf-5d90-9b1c-2e30671f99bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a930d-ae59-47e2-9b98-f703e308b5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a930d-ae59-47e2-9b98-f703e308b5c0.jpg?1",
             "name": "Yamabushi's Storm",
             "text": "Yamabushi's Storm deals 1 damage to each creature. If a creature dealt damage this way would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -7200,7 +7200,7 @@
         },
         {
             "id": "c32a5de3-1455-5ce5-8bc9-cd14b2a39f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4666b6-76f2-4c25-989e-d6a0e50be94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4666b6-76f2-4c25-989e-d6a0e50be94d.jpg?1",
             "name": "Zo-Zu the Punisher",
             "text": "Whenever a land comes into play, Zo-Zu the Punisher deals 2 damage to that land's controller.",
             "colours": [
@@ -7237,7 +7237,7 @@
         },
         {
             "id": "bf97b65e-82cc-5a1b-bd97-1c011a004215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed862a2-d3e2-4543-81a6-453a96399d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed862a2-d3e2-4543-81a6-453a96399d14.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "b435b1ae-d180-51ad-a1e0-d4895a513ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg?1",
             "name": "Budoka Gardener // Dokai, Weaver of Life",
             "text": "{T}: You may put a land card from your hand into play. If you control ten or more lands, flip Budoka Gardener.",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "aca801cc-39a9-5cab-968c-d841914212fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49999b95-5e62-414c-b975-4191b9c1ab39.jpg?1",
             "name": "Budoka Gardener // Dokai, Weaver of Life",
             "text": "{4}{G}{G}, {T}: Put an X/X green Elemental creature token into play, where X is the number of lands you control.",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "12026c02-7a3d-51bb-b67a-7fece779cace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935e52a1-a651-4d88-99a8-7de074a01576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935e52a1-a651-4d88-99a8-7de074a01576.jpg?1",
             "name": "Burr Grafter",
             "text": "Sacrifice Burr Grafter: Target creature gets +2/+2 until end of turn.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -7380,7 +7380,7 @@
         },
         {
             "id": "d5c7f588-6451-54be-b371-eb6d7f22b47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0b706e-017d-4f82-b280-cf9fdf75aef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0b706e-017d-4f82-b280-cf9fdf75aef8.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "db0a589c-5e41-5a6d-97dc-6b58af6459de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb190db-48fc-4c39-ae9f-5e304eabb4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb190db-48fc-4c39-ae9f-5e304eabb4f4.jpg?1",
             "name": "Dosan the Falling Leaf",
             "text": "Players can play spells only during their own turns.",
             "colours": [
@@ -7449,7 +7449,7 @@
         },
         {
             "id": "49c1e833-173d-59a5-a62d-c7ec585adc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e752b762-38b7-463c-aa09-37fecfe71a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e752b762-38b7-463c-aa09-37fecfe71a53.jpg?1",
             "name": "Dripping-Tongue Zubera",
             "text": "When Dripping-Tongue Zubera is put into a graveyard from play, put a 1/1 colorless Spirit creature token into play for each Zubera put into a graveyard from play this turn.",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "116530b5-f830-5141-9f11-23eaa6ac3c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33119e6a-d69b-4039-add2-97fe35a89e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33119e6a-d69b-4039-add2-97fe35a89e8e.jpg?1",
             "name": "Feast of Worms",
             "text": "Destroy target land. If that land is legendary, its controller sacrifices another land.",
             "colours": [
@@ -7518,7 +7518,7 @@
         },
         {
             "id": "61b3cff8-e060-54ba-93a0-78f716d11b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49d705-9b0c-4c2e-9c27-46eec35deb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49d705-9b0c-4c2e-9c27-46eec35deb92.jpg?1",
             "name": "Feral Deceiver",
             "text": "{1}: Look at the top card of your library.\n{2}: Reveal the top card of your library. If it's a land, Feral Deceiver gets +2/+2 and gains trample until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "c5949c79-9754-5645-849f-d02712af32db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5c233-a373-4ac4-9b99-81ed97df1f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5c233-a373-4ac4-9b99-81ed97df1f9b.jpg?1",
             "name": "Gale Force",
             "text": "Gale Force deals 5 damage to each creature with flying.",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "b8aba793-aec1-56da-b2c5-be55deb63e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddcd76b-a7a1-4ae6-bf4a-f929c6574bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddcd76b-a7a1-4ae6-bf4a-f929c6574bdc.jpg?1",
             "name": "Glimpse of Nature",
             "text": "Whenever you play a creature spell this turn, draw a card.",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "c442fafe-07cd-52a0-980d-5bef433f88f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8304b24-4db8-4082-bdb7-7010bf35e416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8304b24-4db8-4082-bdb7-7010bf35e416.jpg?1",
             "name": "Hana Kami",
             "text": "{1}{G}, Sacrifice Hana Kami: Return target Arcane card from your graveyard to your hand.",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "5f76e7d2-c6cf-594e-a6e5-cb78c76ef324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3ba05-dce0-463b-bfe6-d51df63cc1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3ba05-dce0-463b-bfe6-d51df63cc1a8.jpg?1",
             "name": "Heartbeat of Spring",
             "text": "Whenever a player taps a land for mana, that player adds one mana of that type to his or her mana pool.",
             "colours": [
@@ -7682,7 +7682,7 @@
         },
         {
             "id": "85c7758d-cef3-53f4-a081-ff6ab6d63b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c618af6-b02e-448f-9131-3c50ef0d433b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c618af6-b02e-448f-9131-3c50ef0d433b.jpg?1",
             "name": "Honden of Life's Web",
             "text": "At the beginning of your upkeep, put a 1/1 colorless Spirit creature token into play for each Shrine you control.",
             "colours": [
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "fcff8760-57de-526a-a671-ce261718cd16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bbc89-d5ee-4813-9ebe-ac5b998b076b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31bbc89-d5ee-4813-9ebe-ac5b998b076b.jpg?1",
             "name": "Humble Budoka",
             "text": "Humble Budoka can't be the target of spells or abilities.",
             "colours": [
@@ -7753,7 +7753,7 @@
         },
         {
             "id": "62a1c11c-3b51-5f23-a42f-58e2632b7ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be027e3c-8891-46f0-bca7-d28a94ca281a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be027e3c-8891-46f0-bca7-d28a94ca281a.jpg?1",
             "name": "Iname, Life Aspect",
             "text": "When Iname, Life Aspect is put into a graveyard from play, you may remove Iname, Life Aspect from the game. If you do, return any number of target Spirit cards from your graveyard to your hand.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "8ada7358-608b-56fa-9dec-7806e70276e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e33847f-fa55-4b2e-9d88-9a9e118b5cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e33847f-fa55-4b2e-9d88-9a9e118b5cc8.jpg?1",
             "name": "Joyous Respite",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -7823,7 +7823,7 @@
         },
         {
             "id": "6ca0435f-cfd4-5ca9-9cba-08d55ef5e534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77814d-c594-45a8-845f-79f608b8cde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77814d-c594-45a8-845f-79f608b8cde7.jpg?1",
             "name": "Jugan, the Rising Star",
             "text": "Flying\nWhen Jugan, the Rising Star is put into a graveyard from play, you may distribute five +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -7860,7 +7860,7 @@
         },
         {
             "id": "0a9bda6f-8456-5b57-9bfb-3eacf161404d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e1967e-5bc5-47e7-9998-7fcfdffc3bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e1967e-5bc5-47e7-9998-7fcfdffc3bb1.jpg?1",
             "name": "Jukai Messenger",
             "text": "Forestwalk",
             "colours": [
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "d948c001-2920-5147-b83e-c1ed57be321b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ace3c4e-3287-4975-b4d0-91f009c0cf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ace3c4e-3287-4975-b4d0-91f009c0cf5b.jpg?1",
             "name": "Kami of the Hunt",
             "text": "Whenever you play a Spirit or Arcane spell, Kami of the Hunt gets +1/+1 until end of turn.",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "ce19f7c4-ac9f-55b0-95c0-6e67f87859f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d417f90-10e9-4c41-ac3b-1a861147d69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d417f90-10e9-4c41-ac3b-1a861147d69e.jpg?1",
             "name": "Kashi-Tribe Reaver",
             "text": "Whenever Kashi-Tribe Reaver deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\n{1}{G}: Regenerate Kashi-Tribe Reaver.",
             "colours": [
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "4d1fddd6-72d0-5b3e-88e4-e1782105041d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd4df4a-fbab-4598-ad8e-b24ed0bb4497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd4df4a-fbab-4598-ad8e-b24ed0bb4497.jpg?1",
             "name": "Kashi-Tribe Warriors",
             "text": "Whenever Kashi-Tribe Warriors deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -7999,7 +7999,7 @@
         },
         {
             "id": "e8fdac0a-1f7f-5032-a311-e6ad3ce10492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b5c33-63c4-4ddd-9f04-37bb36970b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b5c33-63c4-4ddd-9f04-37bb36970b43.jpg?1",
             "name": "Kodama of the North Tree",
             "text": "Trample\nKodama of the North Tree can't be the target of spells or abilities.",
             "colours": [
@@ -8035,7 +8035,7 @@
         },
         {
             "id": "dff2c6cd-e60e-5e36-ad71-2d21138d5846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120c05f1-5ec3-4a0f-8628-6919e393104a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120c05f1-5ec3-4a0f-8628-6919e393104a.jpg?1",
             "name": "Kodama of the South Tree",
             "text": "Whenever you play a Spirit or Arcane spell, each other creature you control gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "6fc8e5fb-ef1e-5475-a78a-f8c475a5fe2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ef91bb-ec25-463f-9fc9-f0f9c0652cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ef91bb-ec25-463f-9fc9-f0f9c0652cf5.jpg?1",
             "name": "Kodama's Might",
             "text": "Target creature gets +2/+2 until end of turn.\nSplice onto Arcane {G} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -8105,7 +8105,7 @@
         },
         {
             "id": "d06c407b-1688-5f2e-a97c-f5e12d4fe2fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d207ac-0680-47ef-85d9-4323c1321d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d207ac-0680-47ef-85d9-4323c1321d6f.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for two basic land cards, reveal those cards, and put one into play tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "a5f90bbd-1459-5ffd-9068-5fd1d10d8181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c193e4-4484-46c1-83ce-c421d47bed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c193e4-4484-46c1-83ce-c421d47bed9f.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so.",
             "colours": [
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "dce7f6e2-b811-5e7e-bfb0-6bc7a2f7353a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bf9bec-9a5d-48a6-941b-95e1633b9484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bf9bec-9a5d-48a6-941b-95e1633b9484.jpg?1",
             "name": "Matsu-Tribe Decoy",
             "text": "{2}{G}: Target creature blocks Matsu-Tribe Decoy this turn if able.\nWhenever Matsu-Tribe Decoy deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "4742d542-7650-5444-9426-dc8cce9e047c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a437cde4-c40b-40a3-bc19-e461c98186dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a437cde4-c40b-40a3-bc19-e461c98186dc.jpg?1",
             "name": "Moss Kami",
             "text": "Trample",
             "colours": [
@@ -8242,7 +8242,7 @@
         },
         {
             "id": "c28294fb-a052-521e-a295-4d565732a9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb926ad-e762-4883-8841-73e034d8e21e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb926ad-e762-4883-8841-73e034d8e21e.jpg?1",
             "name": "Myojin of Life's Web",
             "text": "Myojin of Life's Web comes into play with a divinity counter on it if you played it from your hand.\nMyojin of Life's Web is indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Life's Web: Put any number of creature cards from your hand into play.",
             "colours": [
@@ -8278,7 +8278,7 @@
         },
         {
             "id": "fda5c6bf-62cd-5eb3-99cc-8ba317b707d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a291a0-db0d-4ccc-b7ae-240cafa41883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a291a0-db0d-4ccc-b7ae-240cafa41883.jpg?1",
             "name": "Nature's Will",
             "text": "Whenever one or more creatures you control deal combat damage to a player, tap all lands that player controls and untap all lands you control.",
             "colours": [
@@ -8310,7 +8310,7 @@
         },
         {
             "id": "cd6fcb4b-6809-535d-bcbb-82b873d7a2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8f0459-a839-4820-8f99-58da5851ff36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8f0459-a839-4820-8f99-58da5851ff36.jpg?1",
             "name": "Orbweaver Kumo",
             "text": "Orbweaver Kumo may block as though it had flying.\nWhenever you play a Spirit or Arcane spell, Orbweaver Kumo gains forestwalk until end of turn.",
             "colours": [
@@ -8344,7 +8344,7 @@
         },
         {
             "id": "d1dfb8ad-5448-5cdc-8ae7-28390a643015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9093a-4397-432f-b9e3-3693efcaec20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9093a-4397-432f-b9e3-3693efcaec20.jpg?1",
             "name": "Order of the Sacred Bell",
             "text": "",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "d4de80b3-5f95-5cee-8001-7309b101275f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg?1",
             "name": "Orochi Eggwatcher // Shidako, Broodmistress",
             "text": "{2}{G}, {T}: Put a 1/1 green Snake creature token into play. If you control ten or more creatures, flip Orochi Eggwatcher.",
             "colours": [
@@ -8414,7 +8414,7 @@
         },
         {
             "id": "9fd475be-e75e-56eb-9ec3-b4fb7b4bccee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22.jpg?1",
             "name": "Orochi Eggwatcher // Shidako, Broodmistress",
             "text": "{G}, Sacrifice a creature: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -8451,7 +8451,7 @@
         },
         {
             "id": "3b80264a-a943-5128-934e-ae6258266846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c39031-1c49-4c1e-83df-66c3795ddc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c39031-1c49-4c1e-83df-66c3795ddc72.jpg?1",
             "name": "Orochi Leafcaller",
             "text": "{G}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "77e0c4e9-d1e3-5b9a-96e8-7c13e0e2969b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc216f-4447-4370-b31a-18304507669b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc216f-4447-4370-b31a-18304507669b.jpg?1",
             "name": "Orochi Ranger",
             "text": "Whenever Orochi Ranger deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -8522,7 +8522,7 @@
         },
         {
             "id": "7e38f33f-2af8-586b-ab93-57b21e707883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40d7a-f2d3-4c9a-a1ab-6b08bd143fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40d7a-f2d3-4c9a-a1ab-6b08bd143fe5.jpg?1",
             "name": "Orochi Sustainer",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "c71fe36a-2f74-5607-8e55-1bfa9fcb4bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5502b-acae-4320-ac01-4d711cb2c49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5502b-acae-4320-ac01-4d711cb2c49a.jpg?1",
             "name": "Rootrunner",
             "text": "{G}{G}, Sacrifice Rootrunner: Put target land on the top of its owner's library.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "c548ee02-e0aa-52f4-8cd6-f4faea86d55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b36f-b879-417c-b284-0176990fb9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b36f-b879-417c-b284-0176990fb9f9.jpg?1",
             "name": "Sachi, Daughter of Seshiro",
             "text": "Other Snakes you control get +0/+1.\nShamans you control have \"{T}: Add {G}{G} to your mana pool.\"",
             "colours": [
@@ -8628,7 +8628,7 @@
         },
         {
             "id": "1a5ca13c-903a-55e9-a80d-e6bdb47e25b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7707a-bae0-4196-bf26-d276f57b7369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c7707a-bae0-4196-bf26-d276f57b7369.jpg?1",
             "name": "Sakura-Tribe Elder",
             "text": "Sacrifice Sakura-Tribe Elder: Search your library for a basic land card, put that card into play tapped, then shuffle your library.",
             "colours": [
@@ -8663,7 +8663,7 @@
         },
         {
             "id": "0c9ef020-8877-52b3-a80a-63cbeca91e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5722d9-d1a4-4ad2-bf85-db666d4a30d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5722d9-d1a4-4ad2-bf85-db666d4a30d9.jpg?1",
             "name": "Serpent Skin",
             "text": "You may play Serpent Skin any time you could play an instant.\nEnchanted creature gets +1/+1.\n{G}: Regenerate enchanted creature.",
             "colours": [
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "e047d7bd-cddd-5c7f-bfd5-b207466037b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg?1",
             "name": "Seshiro the Anointed",
             "text": "Other Snakes you control get +2/+2.\nWhenever a Snake you control deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "5a69cb21-b91e-5995-9df6-d9d56a9b7157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc79c9c-f776-4c55-a7d1-9fac33f14630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc79c9c-f776-4c55-a7d1-9fac33f14630.jpg?1",
             "name": "Shisato, Whispering Hunter",
             "text": "At the beginning of your upkeep, sacrifice a Snake.\nWhenever Shisato, Whispering Hunter deals combat damage to a player, that player skips his or her next untap step.",
             "colours": [
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "eeab6527-a1db-5bac-a7b0-a4c569a2c1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4066c3-bcb0-41c4-a4d3-a22bd186fd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4066c3-bcb0-41c4-a4d3-a22bd186fd13.jpg?1",
             "name": "Soilshaper",
             "text": "Whenever you play a Spirit or Arcane spell, target land becomes a 3/3 creature until end of turn. It's still a land.",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "52d71abf-a55d-5f47-b321-0be28d8681ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa2451-e4f0-423b-826e-ae1f93b99e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa2451-e4f0-423b-826e-ae1f93b99e07.jpg?1",
             "name": "Sosuke, Son of Seshiro",
             "text": "Other Snakes you control get +1/+0.\nWhenever a Warrior you control deals combat damage to a creature, destroy that creature at end of combat.",
             "colours": [
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "7ca888e4-dffb-5fac-a82d-e678c372af48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ab46f5-d3e1-403f-92e7-f40de51a3d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ab46f5-d3e1-403f-92e7-f40de51a3d4d.jpg?1",
             "name": "Strength of Cedars",
             "text": "Target creature gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -8876,7 +8876,7 @@
         },
         {
             "id": "6c6f32af-6ef5-55ab-880a-8c7e14b21a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88355e-dff0-4d51-a33c-08e14d6217d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88355e-dff0-4d51-a33c-08e14d6217d4.jpg?1",
             "name": "Thousand-legged Kami",
             "text": "Soulshift 7 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 7 or less from your graveyard to your hand.)",
             "colours": [
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "2d44a299-6f81-52c2-81d9-a85930531b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514577a5-c7ae-4cfc-872a-e3786d78a6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514577a5-c7ae-4cfc-872a-e3786d78a6c3.jpg?1",
             "name": "Time of Need",
             "text": "Search your library for a legendary creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "7bd4dab5-fff9-5003-97af-d76871935567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308566ed-18cc-4e3b-b5ab-d5b17795f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308566ed-18cc-4e3b-b5ab-d5b17795f2f1.jpg?1",
             "name": "Venerable Kumo",
             "text": "Venerable Kumo may block as though it had flying.\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "97b39b66-d97d-5983-a382-4ddb7863f815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5241c8-7f50-413e-9ac0-9ab0ad5c884c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5241c8-7f50-413e-9ac0-9ab0ad5c884c.jpg?1",
             "name": "Vine Kami",
             "text": "Vine Kami can't be blocked except by two or more creatures.\nSoulshift 6 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 6 or less from your graveyard to your hand.)",
             "colours": [
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "b16cb9d4-f9c6-5a01-87d2-370824d987b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e809799-ce47-4eaf-b2c2-2c8807182532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e809799-ce47-4eaf-b2c2-2c8807182532.jpg?1",
             "name": "Wear Away",
             "text": "Destroy target artifact or enchantment.\nSplice onto Arcane {3}{G} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "a87103f7-84f4-52d8-ad80-084a3a023f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1382c339-256f-4ba1-a4cc-6307d0859964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1382c339-256f-4ba1-a4cc-6307d0859964.jpg?1",
             "name": "General's Kabuto",
             "text": "Equipped creature can't be the target of spells or abilities.\nPrevent all combat damage that would be dealt to equipped creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "9976b721-0517-5e66-9ad7-4e7423a36de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5354475-6a0b-4b1f-b94c-7c103d99e88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5354475-6a0b-4b1f-b94c-7c103d99e88b.jpg?1",
             "name": "Hair-Strung Koto",
             "text": "Tap an untapped creature you control: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "e485aa4c-09a4-5cdd-a142-5e360807512a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22a88a-4f04-4500-9e05-909b54ad43e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22a88a-4f04-4500-9e05-909b54ad43e3.jpg?1",
             "name": "Hankyu",
             "text": "Equipped creature has \"{T}: Put an aim counter on Hankyu\" and \"{T}, Remove all aim counters from Hankyu: This creature deals damage to target creature or player equal to the number of aim counters removed.\"\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9132,7 +9132,7 @@
         },
         {
             "id": "46bec07e-c9a4-57b3-8b6c-c215540a18ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babe91f2-06be-4501-a95b-20968e906e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babe91f2-06be-4501-a95b-20968e906e1b.jpg?1",
             "name": "Honor-Worn Shaku",
             "text": "{T}: Add {1} to your mana pool.\nTap an untapped legendary permanent you control: Untap Honor-Worn Shaku.",
             "colours": [],
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "66809300-e7c9-5ea0-94fc-24b5f8cca195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c33332-8a72-4b81-a8e9-a73aaac6013c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c33332-8a72-4b81-a8e9-a73aaac6013c.jpg?1",
             "name": "Imi Statue",
             "text": "Players can't untap more than one artifact during their untap steps.",
             "colours": [],
@@ -9188,7 +9188,7 @@
         },
         {
             "id": "c3edae41-7135-5098-9228-d8df5cae67b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58f63c5-cdc5-4079-a727-cff45668d546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58f63c5-cdc5-4079-a727-cff45668d546.jpg?1",
             "name": "Jade Idol",
             "text": "Whenever you play a Spirit or Arcane spell, Jade Idol becomes a 4/4 Spirit artifact creature until end of turn.",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "f14ad054-5460-5e7f-9e10-da0c15d3197d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa17062-4355-468f-b8ba-352b7511b847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa17062-4355-468f-b8ba-352b7511b847.jpg?1",
             "name": "Journeyer's Kite",
             "text": "{3}, {T}: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "ab151a7f-fe66-5a97-b289-eb6223df611c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd002c7-21ec-4f77-81be-2788fa267f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd002c7-21ec-4f77-81be-2788fa267f21.jpg?1",
             "name": "Junkyo Bell",
             "text": "At the beginning of your upkeep, you may have target creature you control get +X/+X until end of turn, where X is the number of creatures you control. If you do, sacrifice that creature at end of turn.",
             "colours": [],
@@ -9272,7 +9272,7 @@
         },
         {
             "id": "46852e55-a17a-55b6-b5b2-82f329450ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759b2f39-e1b1-44aa-b49a-00ef6926a6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759b2f39-e1b1-44aa-b49a-00ef6926a6ac.jpg?1",
             "name": "Konda's Banner",
             "text": "Konda's Banner can be attached only to a legendary creature.\nCreatures that share a color with equipped creature get +1/+1.\nCreatures that share a creature type with equipped creature get +1/+1.\nEquip {2}",
             "colours": [],
@@ -9304,7 +9304,7 @@
         },
         {
             "id": "d65ca207-723a-5f35-a603-9ce7f23afed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a700bd-6424-4a0c-b055-e8b64cf430ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a700bd-6424-4a0c-b055-e8b64cf430ec.jpg?1",
             "name": "Kusari-Gama",
             "text": "Equipped creature has \"{2}: This creature gets +1/+0 until end of turn.\"\nWhenever equipped creature deals damage to a blocking creature, Kusari-Gama deals that much damage to each other creature defending player controls.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9334,7 +9334,7 @@
         },
         {
             "id": "2548cd2e-7e72-570e-89fb-c21d44d1d25f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc4b500-ca74-4b90-9a8c-d4efa80ebe2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc4b500-ca74-4b90-9a8c-d4efa80ebe2c.jpg?1",
             "name": "Long-Forgotten Gohei",
             "text": "Arcane spells you play cost {1} less to play.\nSpirits you control get +1/+1.",
             "colours": [],
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "b9de8479-b8ac-5fde-a3d0-f1053b08034a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d36357a-97f6-4b2f-abbf-43f84c29609d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d36357a-97f6-4b2f-abbf-43f84c29609d.jpg?1",
             "name": "Moonring Mirror",
             "text": "Whenever you draw a card, remove the top card of your library from the game face down.\nAt the beginning of your upkeep, you may remove your hand from the game face down. If you do, put into your hand all other cards you own removed from the game with Moonring Mirror.",
             "colours": [],
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "83bac8e6-2f16-5cc1-aa7a-877d963aeb68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e60aa-1a0a-499e-9887-7d17a1f80a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e60aa-1a0a-499e-9887-7d17a1f80a02.jpg?1",
             "name": "Nine-Ringed Bo",
             "text": "{T}: Nine-Ringed Bo deals 1 damage to target Spirit. If that creature would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [],
@@ -9418,7 +9418,7 @@
         },
         {
             "id": "436cf76a-d188-53d4-8e09-4fc0f5cf14db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6061a8-d27f-4258-9e95-cd12365c4248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6061a8-d27f-4258-9e95-cd12365c4248.jpg?1",
             "name": "No-Dachi",
             "text": "Equipped creature gets +2/+0 and has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9448,7 +9448,7 @@
         },
         {
             "id": "682de493-27af-5283-abb8-1b5d9eac8297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b7c8e4-db88-48f3-bfd5-8d990f449b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b7c8e4-db88-48f3-bfd5-8d990f449b1c.jpg?1",
             "name": "Oathkeeper, Takeno's Daisho",
             "text": "Equipped creature gets +3/+1.\nWhenever equipped creature is put into a graveyard from play, return that card to play under your control if it's a Samurai.\nWhen Oathkeeper, Takeno's Daisho is put into a graveyard from play, remove equipped creature from the game.\nEquip {2}",
             "colours": [],
@@ -9480,7 +9480,7 @@
         },
         {
             "id": "476f3549-8dd6-5486-b80a-9c86c61781ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e662e2e-f706-4d79-86ed-48b60787a5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e662e2e-f706-4d79-86ed-48b60787a5d0.jpg?1",
             "name": "Orochi Hatchery",
             "text": "Orochi Hatchery comes into play with X charge counters on it.\n{5}, {T}: Put a 1/1 green Snake creature token into play for each charge counter on Orochi Hatchery.",
             "colours": [],
@@ -9508,7 +9508,7 @@
         },
         {
             "id": "2bed78b4-d862-50a6-a4da-fd18b914f161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eba910-852b-47e0-b4cd-07f30d80f921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eba910-852b-47e0-b4cd-07f30d80f921.jpg?1",
             "name": "Reito Lantern",
             "text": "{3}: Put target card in a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "005d7725-aae9-516b-9b4d-59f6fdd2d686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a08ca06-58db-4ce6-b490-be4bea8956a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a08ca06-58db-4ce6-b490-be4bea8956a1.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -9564,7 +9564,7 @@
         },
         {
             "id": "cad67ee8-2d44-5eb6-8f08-0e876240a137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80f3e7-c3f0-462f-8ae9-8b27a7c15fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d80f3e7-c3f0-462f-8ae9-8b27a7c15fcd.jpg?1",
             "name": "Shell of the Last Kappa",
             "text": "{3}, {T}: Remove from the game target instant or sorcery spell that targets you. (The spell has no effect.)\n{3}, {T}, Sacrifice Shell of the Last Kappa: You may play a card removed from the game with Shell of the Last Kappa without paying its mana cost.",
             "colours": [],
@@ -9594,7 +9594,7 @@
         },
         {
             "id": "3ccae0ba-6ac4-58f1-93fb-beb82469867b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d3bc63-8814-46e7-a6ee-dd5b94a8257e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d3bc63-8814-46e7-a6ee-dd5b94a8257e.jpg?1",
             "name": "Tatsumasa, the Dragon's Fang",
             "text": "Equipped creature gets +5/+5.\n{6}, Remove Tatsumasa, the Dragon's Fang from the game: Put a 5/5 blue Dragon Spirit creature token with flying into play. Return Tatsumasa to play under its owner's control when that token is put into a graveyard.\nEquip {3}",
             "colours": [],
@@ -9626,7 +9626,7 @@
         },
         {
             "id": "f0e7be60-a430-5b8d-8048-f6b1d06ad225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1aa03d7-ac4f-4793-8f8d-5ffd2f8f38b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1aa03d7-ac4f-4793-8f8d-5ffd2f8f38b1.jpg?1",
             "name": "Tenza, Godo's Maul",
             "text": "Equipped creature gets +1/+1. As long as it's legendary, it gets an additional +2/+2. As long as it's red, it has trample.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9658,7 +9658,7 @@
         },
         {
             "id": "1fd3c028-5846-5c44-9385-e9e6afea502a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ecb4e-d08f-4fac-8842-c3e772b95bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ecb4e-d08f-4fac-8842-c3e772b95bd5.jpg?1",
             "name": "Uba Mask",
             "text": "If a player would draw a card, that player removes that card from the game face up instead.\nEach player may play cards he or she removed from the game with Uba Mask this turn.",
             "colours": [],
@@ -9686,7 +9686,7 @@
         },
         {
             "id": "f03dc40e-5b23-5364-ab57-06d16c889ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0180d9a8-992c-4d55-8ac4-33a587786993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0180d9a8-992c-4d55-8ac4-33a587786993.jpg?1",
             "name": "Boseiju, Who Shelters All",
             "text": "Boseiju, Who Shelters All comes into play tapped.\n{T}, Pay 2 life: Add {1} to your mana pool. If that mana is spent on an instant or sorcery spell, that spell can't be countered by spells or abilities.",
             "colours": [],
@@ -9716,7 +9716,7 @@
         },
         {
             "id": "352fa09e-8ed4-5584-84b2-ba442d55e3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcbd030-762e-4754-ae95-685d59ccdfb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcbd030-762e-4754-ae95-685d59ccdfb9.jpg?1",
             "name": "Cloudcrest Lake",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Cloudcrest Lake doesn't untap during your next untap step.",
             "colours": [],
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "6557c919-4e9e-52dd-98a6-d6b5624096fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c1d76-40cf-4edf-8145-e6cec8ca39ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c1d76-40cf-4edf-8145-e6cec8ca39ad.jpg?1",
             "name": "Eiganjo Castle",
             "text": "{T}: Add {W} to your mana pool.\n{W}, {T}: Prevent the next 2 damage that would be dealt to target legendary creature this turn.",
             "colours": [],
@@ -9779,7 +9779,7 @@
         },
         {
             "id": "fc46e4b0-3a8e-5c4a-be87-5d303d9f54c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d78261-c8c9-4e0e-b157-f70ed46c3a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d78261-c8c9-4e0e-b157-f70ed46c3a25.jpg?1",
             "name": "Forbidden Orchard",
             "text": "{T}: Add one mana of any color to your mana pool.\nWhenever you tap Forbidden Orchard for mana, put a 1/1 colorless Spirit creature token into play under target opponent's control.",
             "colours": [],
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "e40b1b21-a91c-5ccb-82f0-005435a9a019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa5bab-8626-4b45-a3a3-621f6d9509ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa5bab-8626-4b45-a3a3-621f6d9509ab.jpg?1",
             "name": "Hall of the Bandit Lord",
             "text": "Hall of the Bandit Lord comes into play tapped.\n{T}, Pay 3 life: Add {1} to your mana pool. If that mana is spent on a creature spell, that creature has haste.",
             "colours": [],
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "976c640a-f112-5935-97fa-e5ce487b7cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a7675-787f-49be-9b44-edd0a7d73812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a7675-787f-49be-9b44-edd0a7d73812.jpg?1",
             "name": "Lantern-Lit Graveyard",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Lantern-Lit Graveyard doesn't untap during your next untap step.",
             "colours": [],
@@ -9868,7 +9868,7 @@
         },
         {
             "id": "1db4eb74-9208-5f8f-86e5-8b49a592da2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536292c-da25-41c8-ba28-1e35758a7f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536292c-da25-41c8-ba28-1e35758a7f3d.jpg?1",
             "name": "Minamo, School at Water's Edge",
             "text": "{T}: Add {U} to your mana pool.\n{U}, {T}: Untap target legendary permanent.",
             "colours": [],
@@ -9900,7 +9900,7 @@
         },
         {
             "id": "ee85824a-2994-5f42-980a-760d17de3995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8cf7aa-388c-47ec-be59-6ba98f3853cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8cf7aa-388c-47ec-be59-6ba98f3853cb.jpg?1",
             "name": "Okina, Temple to the Grandfathers",
             "text": "{T}: Add {G} to your mana pool.\n{G}, {T}: Target legendary creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -9932,7 +9932,7 @@
         },
         {
             "id": "c265e2d4-cdea-5e55-8166-cfd0f768c33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900552f-6147-49ec-8c02-f253e4896c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900552f-6147-49ec-8c02-f253e4896c4d.jpg?1",
             "name": "Pinecrest Ridge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Pinecrest Ridge doesn't untap during your next untap step.",
             "colours": [],
@@ -9963,7 +9963,7 @@
         },
         {
             "id": "4985bf15-2714-5a93-841f-42e3f6cf0fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f30e-cc3a-46c1-82a9-2cd73705b2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f30e-cc3a-46c1-82a9-2cd73705b2f5.jpg?1",
             "name": "Shinka, the Bloodsoaked Keep",
             "text": "{T}: Add {R} to your mana pool.\n{R}, {T}: Target legendary creature gains first strike until end of turn.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "e649bbf4-7653-5c0b-a0b2-3c6cda41843c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de9a046-3db1-436e-b666-ba96e2e8c5db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de9a046-3db1-436e-b666-ba96e2e8c5db.jpg?1",
             "name": "Shizo, Death's Storehouse",
             "text": "{T}: Add {B} to your mana pool.\n{B}, {T}: Target legendary creature gains fear until end of turn.",
             "colours": [],
@@ -10027,7 +10027,7 @@
         },
         {
             "id": "c02ef97d-a53a-5fe3-9248-fce09c932184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112b6577-fbd6-46dd-b77d-37df0abe9845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112b6577-fbd6-46dd-b77d-37df0abe9845.jpg?1",
             "name": "Tranquil Garden",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Tranquil Garden doesn't untap during your next untap step.",
             "colours": [],
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "1b2a2aa9-a1c7-5d9b-89ca-e1060f5004db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c571f66-7a00-4cb0-9da9-8271083f49d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c571f66-7a00-4cb0-9da9-8271083f49d3.jpg?1",
             "name": "Untaidake, the Cloud Keeper",
             "text": "Untaidake, the Cloud Keeper comes into play tapped.\n{T}, Pay 2 life: Add {2} to your mana pool. Spend this mana only to play legendary spells.",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "354f7fa8-3be5-5271-89f8-e546c0422ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405805e0-07f6-420f-86f9-5bde822caa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405805e0-07f6-420f-86f9-5bde822caa5c.jpg?1",
             "name": "Waterveil Cavern",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Waterveil Cavern doesn't untap during your next untap step.",
             "colours": [],
@@ -10119,7 +10119,7 @@
         },
         {
             "id": "4eecab9a-8d08-596d-98fe-ca05a8c9479a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deff6a75-2ecd-49d6-b58b-a9d24615f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deff6a75-2ecd-49d6-b58b-a9d24615f9b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "afe0de65-02a8-55e6-89ba-ac8518c1b596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4add62bc-d24c-4a1f-81bc-e3a6befe3f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4add62bc-d24c-4a1f-81bc-e3a6befe3f0d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10195,7 +10195,7 @@
         },
         {
             "id": "fdeec99d-e25d-576b-b760-14df70c8a2e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fae600-d829-412a-8f77-3f25a106f574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fae600-d829-412a-8f77-3f25a106f574.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10233,7 +10233,7 @@
         },
         {
             "id": "ac18e09d-8f1a-5e47-b90f-f3e29edbf83a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e590059d-57e5-4696-9bb1-30d8d35c4329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e590059d-57e5-4696-9bb1-30d8d35c4329.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10271,7 +10271,7 @@
         },
         {
             "id": "3fbe38f5-5483-553b-87f9-bbe9050f8d89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5170ce9-2463-4fec-945b-6c2f23eb7e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5170ce9-2463-4fec-945b-6c2f23eb7e22.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "059b05c1-e603-5c4f-a499-d8e3875ea0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12c5ae3-8c55-4bd9-a64f-3960d45c0563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12c5ae3-8c55-4bd9-a64f-3960d45c0563.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "e7b98d23-82bf-5a78-b84c-1a7bc1a7b842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d141922-570d-4652-9620-2b53eb68294a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d141922-570d-4652-9620-2b53eb68294a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "75e6a8a3-99ae-58a9-bae2-7341a58fed96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c20f8b-6ad1-4aa2-94d3-7bd42562a1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c20f8b-6ad1-4aa2-94d3-7bd42562a1ac.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10423,7 +10423,7 @@
         },
         {
             "id": "50064480-8581-566b-ab66-b62b87cd6f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d376282-adf0-4d37-b9a4-1329cd496516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d376282-adf0-4d37-b9a4-1329cd496516.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10461,7 +10461,7 @@
         },
         {
             "id": "d82cec4f-bca5-59bb-bc22-650cc3400d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a6fa7-58e7-459c-8e2e-be5a4692450b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a6fa7-58e7-459c-8e2e-be5a4692450b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10499,7 +10499,7 @@
         },
         {
             "id": "3591f751-8ef3-5e9d-8218-cba928260ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0878ac9-6a80-4412-999d-4c6549b9afd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0878ac9-6a80-4412-999d-4c6549b9afd4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10537,7 +10537,7 @@
         },
         {
             "id": "72afed2e-7bea-5390-8212-f5e54d742141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d03a6-35bf-415e-9faa-972edff92777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d03a6-35bf-415e-9faa-972edff92777.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10575,7 +10575,7 @@
         },
         {
             "id": "73aba641-5707-5de0-9274-bfe3153a613e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22262a3a-c2e0-4639-9002-361b39ea9b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22262a3a-c2e0-4639-9002-361b39ea9b3a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10613,7 +10613,7 @@
         },
         {
             "id": "ca8ecbd8-6afb-582b-bf55-7ed3c3082850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a514a-076a-40c0-a756-c6fdd261c3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266a514a-076a-40c0-a756-c6fdd261c3cb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "4bd8a0df-50c1-5fa4-90c6-d44dedf403a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1a59c7-53d9-4e2c-9596-c64394838575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1a59c7-53d9-4e2c-9596-c64394838575.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "3593ffc5-5999-51dc-b458-8603ba47077d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e5767-64e1-4f4e-a02e-1143db0f648e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e5767-64e1-4f4e-a02e-1143db0f648e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10727,7 +10727,7 @@
         },
         {
             "id": "7bfd0b79-2a67-5dcf-97d6-021ef4a45fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3209b22-56af-45ac-9224-67574c035638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3209b22-56af-45ac-9224-67574c035638.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10765,7 +10765,7 @@
         },
         {
             "id": "5aba50b9-1c8c-5bc2-ba1e-310ea8ca3404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf9a4b-be51-4f5d-ac0e-e4f79bbfaecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf9a4b-be51-4f5d-ac0e-e4f79bbfaecd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10803,7 +10803,7 @@
         },
         {
             "id": "ddbc18af-8340-5e53-9006-5e67f30772ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1629dba-02af-4586-ba59-58faac7cf59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1629dba-02af-4586-ba59-58faac7cf59b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "132961e0-9295-5a7b-b67e-f7c9f850ab4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f06e37-f113-4865-9ad9-13483dd15084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f06e37-f113-4865-9ad9-13483dd15084.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/CLB.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/CLB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ad82cd8d-c3e4-5c4d-9a01-a7d74086bbed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25564fba-5765-457b-8dd3-f26b877221b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25564fba-5765-457b-8dd3-f26b877221b8.jpg?1",
             "name": "Faceless One",
             "text": "If Faceless One is your commander, choose a color before the game begins. Faceless One is the chosen color.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "ae83f439-f05e-5d15-849a-808b8c8c8098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f9198-67b6-45d8-91b4-dc853bff9623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f9198-67b6-45d8-91b4-dc853bff9623.jpg?1",
             "name": "Abdel Adrian, Gorion's Ward",
             "text": "When Abdel Adrian, Gorion's Ward enters the battlefield, exile any number of other nonland permanents you control until Abdel Adrian leaves the battlefield. Create a 1/1 white Soldier creature token for each permanent exiled this way.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "76a4bc4d-2691-5281-a1c8-103eee5b2aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421395b1-2694-42fd-bb90-0007e78adefc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421395b1-2694-42fd-bb90-0007e78adefc.jpg?1",
             "name": "Ancient Gold Dragon",
             "text": "Flying\nWhenever Ancient Gold Dragon deals combat damage to a player, roll a d20. You create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to the result.",
             "colours": [
@@ -114,7 +114,7 @@
         },
         {
             "id": "bce001b0-6b2f-5382-94ec-283c71e067c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6589e02-8c84-4069-88d1-ebcc8520cae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6589e02-8c84-4069-88d1-ebcc8520cae1.jpg?1",
             "name": "Archivist of Oghma",
             "text": "Flash\nWhenever an opponent searches their library, you gain 1 life and draw a card.",
             "colours": [
@@ -151,7 +151,7 @@
         },
         {
             "id": "71ec06b8-cd44-539a-9812-6337bfdd7ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26c05b-f166-40ab-9693-2129b4bf75e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26c05b-f166-40ab-9693-2129b4bf75e9.jpg?1",
             "name": "Ascend from Avernus",
             "text": "Return all creature and planeswalker cards with mana value X or less from your graveyard to the battlefield. Exile Ascend from Avernus.",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "81e7bf2b-d41e-5574-9130-2d1cfce4c50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe66d8-1b35-49f1-9bc0-74c5861e5abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefe66d8-1b35-49f1-9bc0-74c5861e5abf.jpg?1",
             "name": "Astral Confrontation",
             "text": "This spell costs {1} less to cast for each opponent you're attacking.\nExile target creature.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "5f11f412-2b58-5971-849e-0eca2e54ebdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164a728-131f-41ce-9346-8036c86543e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164a728-131f-41ce-9346-8036c86543e2.jpg?1",
             "name": "Bane's Invoker",
             "text": "Wind Walk \u2014 {8}: Up to two target creatures each get +2/+2 and gain flying until end of turn.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "505e9f9f-8d76-5741-b441-4ff197d62f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71caadb-31ab-4b7f-b304-e7d3e8f9d132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71caadb-31ab-4b7f-b304-e7d3e8f9d132.jpg?1",
             "name": "Banishment",
             "text": "Flash\nWhen Banishment enters the battlefield, exile target nonland permanent an opponent controls and all other nonland permanents your opponents control with the same name as that permanent until Banishment leaves the battlefield.",
             "colours": [
@@ -284,7 +284,7 @@
         },
         {
             "id": "7c8eae3a-ada2-51dd-abe9-5dd83b5b53f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c91dbf4-94fa-45d0-b8ed-a778b11d789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c91dbf4-94fa-45d0-b8ed-a778b11d789b.jpg?1",
             "name": "Battle Angels of Tyr",
             "text": "Flying, myriad\nWhenever Battle Angels of Tyr deals combat damage to a player, draw a card if that player has more cards in hand than each other player. Then you create a Treasure token if that player controls more lands than each other player. Then you gain 3 life if that player has more life than each other player.",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "4703046e-388a-5105-bab8-72f66a94b5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02d647-b95b-4442-a924-64a4c94a4e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc02d647-b95b-4442-a924-64a4c94a4e8d.jpg?1",
             "name": "Beckoning Will-o'-Wisp",
             "text": "Flying\nLure the Unwary \u2014 At the beginning of combat on your turn, choose an opponent.\nCreatures attacking the last chosen player get +1/+0.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "0bb794fb-e218-5535-8887-fa2c74e5b3bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg?1",
             "name": "Blessed Hippogriff // Tyr's Blessing",
             "text": "Flying\nWhenever Blessed Hippogriff attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "c33a4c6b-58e1-5784-ad20-1145c0f7e911",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4590e53-ca8d-4896-a8cf-6af1e4bc456f.jpg?1",
             "name": "Blessed Hippogriff // Tyr's Blessing",
             "text": "Target creature gains indestructible until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "e6a6f418-31d8-53cc-9876-f5433c4f097e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59299b0-91d9-4131-b8d9-614088e1ccaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59299b0-91d9-4131-b8d9-614088e1ccaf.jpg?1",
             "name": "Contraband Livestock",
             "text": "Exile target creature, then roll a d20.\n1\u20139 | Its controller creates a 4/4 green Ox creature token.\n10\u201319 | Its controller creates a 2/2 green Boar creature token.\n20 | Its controller creates a 0/1 white Goat creature token.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "6d36c15b-3cef-593d-9c82-21650129e2f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg?1",
             "name": "Crystal Dragon // Rob the Hoard",
             "text": "Flying, vigilance",
             "colours": [
@@ -489,7 +489,7 @@
         },
         {
             "id": "17f80c87-d7a2-5a80-ad45-6db1e70599bc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/384ec8b7-472e-4026-9632-349ab9df2b27.jpg?1",
             "name": "Crystal Dragon // Rob the Hoard",
             "text": "Return target artifact, enchantment, or legendary card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "feb7dc7b-1e1e-510d-9ca8-ddea39cdce89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846a4d-da81-41e0-89a9-6685c821dbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846a4d-da81-41e0-89a9-6685c821dbb4.jpg?1",
             "name": "Cut a Deal",
             "text": "Each opponent draws a card, then you draw a card for each opponent who drew a card this way.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "393f5784-7ca4-56b1-a183-07eb98ee5005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f06ef-c180-4ce3-afaf-bec3b14c0222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201f06ef-c180-4ce3-afaf-bec3b14c0222.jpg?1",
             "name": "Dawnbringer Cleric",
             "text": "When Dawnbringer Cleric enters the battlefield, choose one \u2014\n\u2022 Cure Wounds \u2014 You gain 2 life.\n\u2022 Dispel Magic \u2014 Destroy target enchantment.\n\u2022 Gentle Repose \u2014 Exile target card from a graveyard.",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "5f80576b-43e4-5e5b-8e45-8974e6b2d3bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a038dbc9-0da1-4e65-9369-45c614f285f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a038dbc9-0da1-4e65-9369-45c614f285f8.jpg?1",
             "name": "Ellyn Harbreeze, Busybody",
             "text": "{T}: Look at the top X cards of your library, where X is the number of tokens you created this turn. Put one of those cards into your hand and the rest on the bottom of your library in a random order.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "4d23e669-328f-5358-ac91-814fd3ba585b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabc3688-2362-4757-a5be-087e577c4691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabc3688-2362-4757-a5be-087e577c4691.jpg?1",
             "name": "Far Traveler",
             "text": "Commander creatures you own have \"At the beginning of your end step, exile up to one target tapped creature you control, then return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "3aed8cfc-6268-5427-826a-9deafb6d4264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122c9f-5513-4ba7-ae04-3c2060121d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122c9f-5513-4ba7-ae04-3c2060121d73.jpg?1",
             "name": "Flaming Fist",
             "text": "Commander creatures you own have \"Whenever this creature attacks, it gains double strike until end of turn.\"",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "c0146296-83c3-5d69-b0d2-cfb67a4d2672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98722a04-0674-4083-b6f5-51bb88a99814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98722a04-0674-4083-b6f5-51bb88a99814.jpg?1",
             "name": "Flaming Fist Officer",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Flaming Fist Officer.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "13777428-31a5-5599-939b-8301d09fe2f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a088ea-c397-4bdd-8779-59561ff73ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a088ea-c397-4bdd-8779-59561ff73ec2.jpg?1",
             "name": "Githzerai Monk",
             "text": "Flash\nFlying\nPsychic Defense \u2014 When Githzerai Monk enters the battlefield, tap all creatures you don't control.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "469024d1-6550-52aa-97b3-b75533b4d561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8324aa-f356-42bc-9664-46803bc8a93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8324aa-f356-42bc-9664-46803bc8a93b.jpg?1",
             "name": "Goliath Paladin",
             "text": "Vigilance\nWhen Goliath Paladin enters the battlefield, you take the initiative.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "aedbb333-d691-598e-abf9-9449206b05d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50088a60-642b-47ed-a289-ef0b617b688f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50088a60-642b-47ed-a289-ef0b617b688f.jpg?1",
             "name": "Greatsword of Tyr",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on it and tap up to one target creature defending player controls.\nEquip {W} ({W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "79cfe8ae-2f9c-566e-b1a4-a6374d0cbca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg?1",
             "name": "Guardian Naga // Banishing Coils",
             "text": "Vigilance\nAs long as it's your turn, prevent all damage that would be dealt to Guardian Naga.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "2ad179c1-6110-511a-8b10-fa3418667f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18da890e-0f8d-41e9-a29f-24cb5393c464.jpg?1",
             "name": "Guardian Naga // Banishing Coils",
             "text": "Exile target artifact or enchantment. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "7b24729e-18d7-5438-a928-ae600d47cf87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd552f81-1947-47e0-beee-f04e73551055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd552f81-1947-47e0-beee-f04e73551055.jpg?1",
             "name": "Guiding Bolt",
             "text": "Destroy target creature with power 4 or greater.\nScry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "62b89699-43cb-5f9a-bd43-6aa396841eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7429a5b-5579-4c4e-89ff-ee7f43db37e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7429a5b-5579-4c4e-89ff-ee7f43db37e4.jpg?1",
             "name": "Hammers of Moradin",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\nWhenever Hammers of Moradin attacks, for each opponent, tap up to one target creature that player controls.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "7b48e7c0-4331-5eb2-8fb9-72290988af54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {3}",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "9a34b0b7-b1a1-5d75-8ff7-75d16bfc60a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Create X 1/1 white Soldier creature tokens. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "d9d757e0-9195-5bcb-b5ce-e619af772182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb153e2-345d-4993-9f2d-f0d0ddfbc8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb153e2-345d-4993-9f2d-f0d0ddfbc8a7.jpg?1",
             "name": "Icewind Stalwart",
             "text": "Protection Fighting Style \u2014 When Icewind Stalwart enters the battlefield, exile up to one target non-Warrior creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "42bffcd2-a19e-53f6-98d9-e12ded5a858b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6eb9f3-0f7b-4623-806e-5e604a05d470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6eb9f3-0f7b-4623-806e-5e604a05d470.jpg?1",
             "name": "Inspiring Leader",
             "text": "Commander creatures you own have \"Creature tokens you control get +2/+2.\"",
             "colours": [
@@ -1125,7 +1125,7 @@
         },
         {
             "id": "b531ba67-f3ba-505b-a89e-39b630c3e322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a93f587-ab72-42da-88c4-31af1c9cdf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a93f587-ab72-42da-88c4-31af1c9cdf1b.jpg?1",
             "name": "Lae'zel, Vlaakith's Champion",
             "text": "If you would put one or more counters on a creature or planeswalker you control or on yourself, put that many plus one of each of those kinds of counters on that permanent or player instead.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "19ec4a9a-b080-5b84-b6f9-910f627c7eee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d102241-4463-437f-b2bb-f574d9dbbd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d102241-4463-437f-b2bb-f574d9dbbd1e.jpg?1",
             "name": "Lae'zel's Acrobatics",
             "text": "Exile all nontoken creatures you control, then roll a d20.\n1\u20139 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10\u201320 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "a8ad8c55-eafe-5a24-a940-92871d30c96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9158965b-b705-4922-8ea9-9e3a93838eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9158965b-b705-4922-8ea9-9e3a93838eab.jpg?1",
             "name": "Legion Loyalty",
             "text": "Creatures you control have myriad. (Whenever a creature with myriad attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1233,7 +1233,7 @@
         },
         {
             "id": "74e43e52-e062-5a89-9a2e-e1d27900e873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d67e95e-c4a7-45bc-ae83-0b532ad530db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d67e95e-c4a7-45bc-ae83-0b532ad530db.jpg?1",
             "name": "Lulu, Loyal Hollyphant",
             "text": "Flying\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on each tapped creature you control, then untap them.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "7720372b-a010-5d70-84d0-3fcf97ae9e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e520fcba-3503-4d7d-aba9-7ed8c064700d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e520fcba-3503-4d7d-aba9-7ed8c064700d.jpg?1",
             "name": "Martial Impetus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, each other creature that's attacking one of your opponents gets +1/+1 until end of turn.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "45d26744-2b19-506e-967a-da8f75eae9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874b3590-932a-46b7-a7aa-e3e864ec22d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874b3590-932a-46b7-a7aa-e3e864ec22d1.jpg?1",
             "name": "Minimus Containment",
             "text": "Enchant nonland permanent\nEnchanted permanent is a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other abilities. (If it was a creature, it's no longer a creature.)",
             "colours": [
@@ -1341,7 +1341,7 @@
         },
         {
             "id": "4f3fc13f-0309-5d36-9fb6-313ff153a498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e49fd5a-6893-4a06-b835-4bf611c9ada1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e49fd5a-6893-4a06-b835-4bf611c9ada1.jpg?1",
             "name": "Noble Heritage",
             "text": "Commander creatures you own have \"When this creature enters the battlefield and at the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. For each opponent who does, you gain protection from that player until your next turn.\" (You can't be targeted, dealt damage, or enchanted by anything controlled by that player.)",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "133de4c8-7502-5405-ae5e-a4ad6ba541bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg?1",
             "name": "Pegasus Guardian // Rescue the Foal",
             "text": "Flying\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, create a 1/1 white Pegasus creature token with flying.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "8deafd61-a408-516e-8263-76fbb7b11c31",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d958ec3-1ddc-4622-9089-cbe5b3b47c90.jpg?1",
             "name": "Pegasus Guardian // Rescue the Foal",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "51f0a76f-ce93-5a67-83a2-bf90c4499d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6597ec7-0fc8-4aa5-a8a6-ea5f95f4ce15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6597ec7-0fc8-4aa5-a8a6-ea5f95f4ce15.jpg?1",
             "name": "Rasaad yn Bashir",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\nWhenever Rasaad yn Bashir attacks, if you have the initiative, double the toughness of each creature you control until end of turn.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "e4bb2c30-5c12-53ed-9451-959045b30b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbd2822-d161-41df-9f48-abecd5da19c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbd2822-d161-41df-9f48-abecd5da19c4.jpg?1",
             "name": "Recruitment Drive",
             "text": "Roll a d20.\n1\u20139 | Create two 1/1 white Soldier creature tokens.\n10\u201319 | Create two 2/2 white Knight creature tokens.\n20 | Create three 2/2 white Knight creature tokens.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "d2ef53c6-b53d-53f6-bc35-50d08e44aca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b17c29-c796-460b-a0c6-7638fb80e397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b17c29-c796-460b-a0c6-7638fb80e397.jpg?1",
             "name": "Rescuer Chwinga",
             "text": "Flash\nNatural Shelter \u2014 When Rescuer Chwinga enters the battlefield, you may return another permanent you control to its owner's hand.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "4291229b-7b88-5779-94a1-c97b8afc4aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b0ed9c-9a99-4a50-80a9-396420a8dcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b0ed9c-9a99-4a50-80a9-396420a8dcf9.jpg?1",
             "name": "Roving Harper",
             "text": "When Roving Harper enters the battlefield, draw a card.",
             "colours": [
@@ -1589,7 +1589,7 @@
         },
         {
             "id": "d7c5c51b-2494-5221-a3db-09050e086ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2209e-7a5c-4394-876c-e0f68cfba9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2209e-7a5c-4394-876c-e0f68cfba9ca.jpg?1",
             "name": "Scouting Hawk",
             "text": "Flying\nKeen Sight \u2014 When Scouting Hawk enters the battlefield, if an opponent controls more lands than you, search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "b21ef30e-735f-5269-873e-94284ce8bfd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16d8fe-a770-4bbd-bf20-447c0165de5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16d8fe-a770-4bbd-bf20-447c0165de5a.jpg?1",
             "name": "Sculpted Sunburst",
             "text": "Choose a creature you control, then each opponent chooses a creature they control with equal or lesser power. If you chose a creature this way, exile each creature not chosen by any player this way.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "cc08658d-b115-5da7-9e04-6779b7b3615f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9f8aea-0c9a-4686-b551-35e2a72ef701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9f8aea-0c9a-4686-b551-35e2a72ef701.jpg?1",
             "name": "Slaughter the Strong",
             "text": "Each player chooses any number of creatures they control with total power 4 or less, then sacrifices all other creatures they control.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "9d4ea403-b585-5b75-9c94-e7f1f7fd5446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13762890-6c5e-44e4-9bd8-998bd054db20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13762890-6c5e-44e4-9bd8-998bd054db20.jpg?1",
             "name": "Steadfast Unicorn",
             "text": "{3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn.",
             "colours": [
@@ -1723,7 +1723,7 @@
         },
         {
             "id": "b822fe73-218b-5f38-b68f-40ce73e81e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b9fdaa-9da9-48ff-b271-e6a41aabf073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b9fdaa-9da9-48ff-b271-e6a41aabf073.jpg?1",
             "name": "Stoneskin",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +0/+10.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "d4d23986-7a54-58b8-8075-03223bfe5021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e38761-70e0-4f6e-a4c2-7c9a17557d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e38761-70e0-4f6e-a4c2-7c9a17557d25.jpg?1",
             "name": "Tabaxi Toucaneers",
             "text": "Flying\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "0b9b12f5-b9d8-545f-9a8c-92334f518414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca369b-4e04-4c80-923b-1212183419d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca369b-4e04-4c80-923b-1212183419d8.jpg?1",
             "name": "Undercellar Sweep",
             "text": "When Undercellar Sweep enters the battlefield, you take the initiative.\nWhenever you attack, if you or a player you're attacking has the initiative, you create two 1/1 white Soldier creature tokens that are tapped and attacking.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "595dbf61-b9c8-5633-8d65-68f0c6fe5869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f074e-914e-4924-8b5e-b80b247bc341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f074e-914e-4924-8b5e-b80b247bc341.jpg?1",
             "name": "Veteran Soldier",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, for each opponent, create a 1/1 white Soldier creature token that's tapped and attacking that player.\"",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "d26aa5e3-a966-5330-8ccc-d66b23a6a706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256ddc8-8b12-434c-a610-1a872e948f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256ddc8-8b12-434c-a610-1a872e948f2f.jpg?1",
             "name": "White Plume Adventurer",
             "text": "When White Plume Adventurer enters the battlefield, you take the initiative.\nAt the beginning of each opponent's upkeep, untap a creature you control. If you've completed a dungeon, untap all creatures you control instead.",
             "colours": [
@@ -1899,7 +1899,7 @@
         },
         {
             "id": "87544546-1980-5b59-a61e-637aa72d577e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2f5-6d8b-4321-9aa1-d84c291a5c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2f5-6d8b-4321-9aa1-d84c291a5c20.jpg?1",
             "name": "Windshaper Planetar",
             "text": "Flash\nFlying\nWhen Windshaper Planetar enters the battlefield during the declare attackers step, for each attacking creature, you may reselect which player or planeswalker that creature is attacking. (It can't attack its controller or its controller's planeswalkers.)",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "e40d27c1-f3de-5463-88a2-0b1ad69f7d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00a57fc-b4a6-48fa-a20c-864c10099e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00a57fc-b4a6-48fa-a20c-864c10099e4b.jpg?1",
             "name": "Wyrm's Crossing Patrol",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1970,7 +1970,7 @@
         },
         {
             "id": "f881ddfc-180f-59bf-acd0-48dafdfea8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad8aa76-b643-4bd2-aaeb-036c1d50db54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad8aa76-b643-4bd2-aaeb-036c1d50db54.jpg?1",
             "name": "Your Temple Is Under Attack",
             "text": "Choose one \u2014\n\u2022 Pray for Protection \u2014 Creatures you control gain indestructible until end of turn.\n\u2022 Strike a Deal \u2014 You and target opponent each draw two cards.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "fdc1d084-cfb7-56ce-b7d4-727eb74ea6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76e5d23-a45f-4100-8638-fce33f290fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76e5d23-a45f-4100-8638-fce33f290fc6.jpg?1",
             "name": "You're Confronted by Robbers",
             "text": "Choose one \u2014\n\u2022 Stall for Time \u2014 Tap up to three target creatures.\n\u2022 Call for Aid \u2014 Create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "b99eb1ea-43ad-5b7d-9549-aee93e555009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83882c-3e03-4e85-aaac-97fa1d08a772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83882c-3e03-4e85-aaac-97fa1d08a772.jpg?1",
             "name": "Aarakocra Sneak",
             "text": "Flying\nWhen Aarakocra Sneak enters the battlefield, you take the initiative.",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "e3a75e01-cf18-5619-a245-86e8624bc220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c779b-d1d8-4b1e-bb06-ed7071a5ec0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c779b-d1d8-4b1e-bb06-ed7071a5ec0b.jpg?1",
             "name": "Alora, Merry Thief",
             "text": "Whenever you attack, up to one target attacking creature can't be blocked this turn. Return that creature to its owner's hand at the beginning of the next end step.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "1961bcf7-f26f-5bdb-b0ff-b54a3c9af1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced18935-4ce9-466e-a88d-2b14ff8f989f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced18935-4ce9-466e-a88d-2b14ff8f989f.jpg?1",
             "name": "Ancient Silver Dragon",
             "text": "Flying\nWhenever Ancient Silver Dragon deals combat damage to a player, roll a d20. Draw cards equal to the result. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -2147,7 +2147,7 @@
         },
         {
             "id": "8cee6780-ca8d-5a80-a771-024e08b2bd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f81099-f657-4f7d-84ad-f472ae87d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f81099-f657-4f7d-84ad-f472ae87d9c5.jpg?1",
             "name": "Bane's Contingency",
             "text": "Counter target spell. If that spell targets a commander you control, instead counter that spell, scry 2, then draw a card.",
             "colours": [
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "56688ea9-6cbb-5c0e-8996-817cc776250f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a43413-3ab0-4ef6-83de-192a11d48f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a43413-3ab0-4ef6-83de-192a11d48f00.jpg?1",
             "name": "Blur",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "2f93c0e3-61e0-59c1-8813-ad0ceb8bd1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33464767-45f3-42b8-8d83-33b090eead93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33464767-45f3-42b8-8d83-33b090eead93.jpg?1",
             "name": "Candlekeep Inspiration",
             "text": "Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards you own in exile and in your graveyard that are instant cards, are sorcery cards, and/or have an Adventure.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "ef7f8b49-533a-58fb-88f0-517271ba423d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f706ac3-0ad8-44ac-a99e-21c04075951d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f706ac3-0ad8-44ac-a99e-21c04075951d.jpg?1",
             "name": "Candlekeep Sage",
             "text": "Commander creatures you own have \"When this creature enters or leaves the battlefield, draw a card.\"",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "65a247a0-b5e5-50e6-b1b3-542c44f2bc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d010948a-d3f8-4ce3-9c9b-6e905a3f7087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d010948a-d3f8-4ce3-9c9b-6e905a3f7087.jpg?1",
             "name": "Cone of Cold",
             "text": "Roll a d20.\n1\u20139 | Tap all creatures your opponents control.\n10\u201319 | Tap all creatures your opponents control. Those creatures don't untap during their controllers' next untap steps.\n20 | Tap all creatures your opponents control. Those creatures don't untap during their controllers' next untap steps. Until your next turn, creatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -2313,7 +2313,7 @@
         },
         {
             "id": "a724e0b8-3fee-5530-9c15-ce580242569a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5d9323-ddf4-49b0-9d39-c2249c50f1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5d9323-ddf4-49b0-9d39-c2249c50f1e3.jpg?1",
             "name": "Contact Other Plane",
             "text": "Roll a d20.\n1\u20139 | Draw two cards.\n10\u201319 | Scry 2, then draw two cards.\n20 | Scry 3, then draw three cards.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "18c3a658-eda3-53cb-ad3e-3a16c8f5da6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a401b8-29fb-46ef-a663-427f66724d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a401b8-29fb-46ef-a663-427f66724d5c.jpg?1",
             "name": "Displacer Kitten",
             "text": "Avoidance \u2014 Whenever you cast a noncreature spell, exile up to one target nonland permanent you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "4673f0e5-58db-5327-93cc-9b49603e4d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557f2aa6-0b82-4f60-9617-610b613c2a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557f2aa6-0b82-4f60-9617-610b613c2a48.jpg?1",
             "name": "Draconic Lore",
             "text": "This spell costs {2} less to cast if you control a Dragon.\nDraw three cards.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "c709a8f8-e945-55b6-8989-bf188df76a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570e8aaa-5273-42f4-b151-51976ab7730c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570e8aaa-5273-42f4-b151-51976ab7730c.jpg?1",
             "name": "Dragonborn Looter",
             "text": "{1}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "6751b0cd-371b-5fa5-be42-d353381e360f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daca6a57-38b7-4547-9174-a7f548ea1258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daca6a57-38b7-4547-9174-a7f548ea1258.jpg?1",
             "name": "Dream Fracture",
             "text": "Counter target spell. Its controller draws a card.\nDraw a card.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "80c5cc6f-89be-571e-b24c-a037ca60f0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba131bb-b8b3-4577-9f41-4700d9985134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba131bb-b8b3-4577-9f41-4700d9985134.jpg?1",
             "name": "Dungeon Delver",
             "text": "Commander creatures you own have \"Room abilities of dungeons you own trigger an additional time.\"",
             "colours": [
@@ -2519,7 +2519,7 @@
         },
         {
             "id": "da65c2fc-8d78-5384-bdd4-46f404a8ff3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a6e6a-758d-417d-82c9-2c78db37d91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a6e6a-758d-417d-82c9-2c78db37d91e.jpg?1",
             "name": "Elminster's Simulacrum",
             "text": "For each opponent, you create a token that's a copy of up to one target creature that player controls.",
             "colours": [
@@ -2553,7 +2553,7 @@
         },
         {
             "id": "b0ef51a7-cf1c-5f4c-b123-df445679cf4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c959ab97-0727-4589-bfd9-d78dd8ebd86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c959ab97-0727-4589-bfd9-d78dd8ebd86b.jpg?1",
             "name": "Feywild Caretaker",
             "text": "When Feywild Caretaker enters the battlefield, you take the initiative.\nAt the beginning of your end step, if you have the initiative, create a 1/1 blue Faerie Dragon creature token with flying.",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "e275a1d6-4569-58b0-8fc9-5a4046063fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e833a9-d82f-4942-a488-67d9c02817db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e833a9-d82f-4942-a488-67d9c02817db.jpg?1",
             "name": "Feywild Visitor",
             "text": "Commander creatures you own have \"Whenever one or more nontoken creatures you control deal combat damage to a player, you create a 1/1 blue Faerie Dragon creature token with flying.\"",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "1f644c2b-c820-5029-903e-269b9a836e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137ee879-bbc3-4e11-b103-3cc604867b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137ee879-bbc3-4e11-b103-3cc604867b1c.jpg?1",
             "name": "Font of Magic",
             "text": "Instant and sorcery spells you cast cost {1} less to cast for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "9c23fad6-2b6d-5702-8b06-6521fa3f5a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edf31f-ed67-4617-bf73-28a939a232a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edf31f-ed67-4617-bf73-28a939a232a7.jpg?1",
             "name": "Gale, Waterdeep Prodigy",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast up to one target card of the other type from your graveyard. If a spell cast from your graveyard this way would be put into your graveyard, exile it instead.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "784ca4f3-95a3-592f-8f01-6600ed54ba38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5ddcf8-c87b-4a26-b226-8593f517a74a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5ddcf8-c87b-4a26-b226-8593f517a74a.jpg?1",
             "name": "Gale's Redirection",
             "text": "Exile target spell, then roll a d20 and add that spell's mana value.\n1\u201314 | You may cast the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\n15+ | You may cast the exiled card without paying its mana cost for as long as it remains exiled.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "e43e91f3-0d97-522a-abdb-5b24fdf9877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2aa14-4b8d-4f33-856d-296bc59a0ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2aa14-4b8d-4f33-856d-296bc59a0ade.jpg?1",
             "name": "Goggles of Night",
             "text": "Whenever equipped creature deals combat damage to a player, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "23a0ac18-71ef-5ad7-a172-0d7c3be6f288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b211832-907e-43d6-81af-c58fdd427303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b211832-907e-43d6-81af-c58fdd427303.jpg?1",
             "name": "Gray Harbor Merfolk",
             "text": "Gray Harbor Merfolk can't be blocked.\nGray Harbor Merfolk gets +2/+0 as long as you control a commander that's a creature or planeswalker.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "5507f7dd-0153-5a75-b609-498fe1d0b26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Ceremorphosis \u2014 When Illithid Harvester enters the battlefield, turn any number of target tapped nontoken creatures face down. They're 2/2 Horror creatures.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "3069507a-dfa8-58c9-af86-0f017b01746a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Tap X target creatures. They don't untap during their controllers' next untap steps. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "f403aa76-d362-5f6b-9828-8ccaaca112ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097264b-e383-4864-a587-dc7d5468f359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1097264b-e383-4864-a587-dc7d5468f359.jpg?1",
             "name": "Imoen, Mystic Trickster",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your end step, if you have the initiative, draw a card. Draw another card if you've completed a dungeon.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -2918,7 +2918,7 @@
         },
         {
             "id": "e3765622-998d-5e75-a5bd-159d82ac3856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a791df-2483-406d-90b0-a8d402d615d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a791df-2483-406d-90b0-a8d402d615d6.jpg?1",
             "name": "Irenicus's Vile Duplication",
             "text": "Create a token that's a copy of target creature you control, except the token has flying and isn't legendary if that creature is legendary.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "e3e9f065-cb54-5495-8ddd-9d1982d5830c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc26897-4644-4af5-ac37-099e641c27d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc26897-4644-4af5-ac37-099e641c27d1.jpg?1",
             "name": "Juvenile Mist Dragon",
             "text": "Flying\nConfounding Clouds \u2014 When Juvenile Mist Dragon enters the battlefield, for each opponent, tap up to one target creature that player controls. Each of those creatures doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2984,7 +2984,7 @@
         },
         {
             "id": "ad4790ac-f425-5bee-b99a-333af8d64ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f30aca-5055-45f1-9121-e7a5675f07e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f30aca-5055-45f1-9121-e7a5675f07e4.jpg?1",
             "name": "Kenku Artificer",
             "text": "Homunculus Servant \u2014 When Kenku Artificer enters the battlefield, put three +1/+1 counters on up to one target noncreature artifact. That artifact becomes a 0/0 Homunculus artifact creature with flying.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "fa61c7d5-d000-5e34-a3b1-8e6bf2a8fb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5462e9-c602-4431-a845-f7c6cafbc3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5462e9-c602-4431-a845-f7c6cafbc3cf.jpg?1",
             "name": "Kindred Discovery",
             "text": "As Kindred Discovery enters the battlefield, choose a creature type.\nWhenever a creature you control of the chosen type enters the battlefield or attacks, draw a card.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "71dac0a3-47ee-562b-ba52-f6d28a7e4619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ed684b-e3a1-421d-8cfd-c5eee673a3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ed684b-e3a1-421d-8cfd-c5eee673a3a1.jpg?1",
             "name": "Lapis Orb of Dragonkind",
             "text": "{T}: Add {U}. When you spend this mana to cast a Dragon creature spell, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "0544ab2f-dd54-54a6-966e-7b64369ff467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f915b034-ab16-48a6-a151-71eaa0b542f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f915b034-ab16-48a6-a151-71eaa0b542f9.jpg?1",
             "name": "Modify Memory",
             "text": "Exchange control of two target creatures controlled by different players. If you control neither creature, draw three cards.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "64ac35f3-8619-503f-b8dc-3bbbf96c4e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg?1",
             "name": "Moonshae Pixie // Pixie Dust",
             "text": "Flying\nWhen Moonshae Pixie enters the battlefield, draw cards equal to the number of opponents who were dealt combat damage this turn.",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "88389f1e-689f-5911-b1da-d5c187b9f440",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63780e4a-3f63-473c-97d0-5d9462e264f2.jpg?1",
             "name": "Moonshae Pixie // Pixie Dust",
             "text": "Up to three target creatures gain flying until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "3d6e12ce-3302-56e5-9b07-19774c6803dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894a0f5-2e1d-474f-9400-bdaa91b19fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8894a0f5-2e1d-474f-9400-bdaa91b19fda.jpg?1",
             "name": "Mystery Key",
             "text": "When equipped creature deals combat damage to a player, sacrifice Mystery Key. If you do, draw three cards.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "3b6f4751-d9a1-5513-9491-1f02d5458469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df69a02-0b89-46af-abbc-51d1c419daed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df69a02-0b89-46af-abbc-51d1c419daed.jpg?1",
             "name": "Nimbleclaw Adept",
             "text": "Bigby's Hand \u2014 {T}: Untap two other target permanents. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "14b0e058-0eeb-5f5f-977a-6051f56dd493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fda8b66-fdf1-43e9-9d65-60b991348aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fda8b66-fdf1-43e9-9d65-60b991348aac.jpg?1",
             "name": "Oceanus Dragon",
             "text": "Flying\nWhen Oceanus Dragon enters the battlefield, tap target creature an opponent controls. Goad it. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "f6101041-6b04-54f0-a46a-300be575f668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d69ee8-a616-4191-b111-1330dfb24f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d69ee8-a616-4191-b111-1330dfb24f72.jpg?1",
             "name": "Pseudodragon Familiar",
             "text": "Flying\n{2}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "cf5ea39b-3d96-5298-8ed3-f01877107b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288e811e-7beb-4379-95a3-e5f4e759aa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288e811e-7beb-4379-95a3-e5f4e759aa9d.jpg?1",
             "name": "Psychic Impetus",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, you scry 2.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "571809e7-c3c8-5999-b964-6d95b4b21f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c044363-d661-4703-841c-8279fa4aa5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c044363-d661-4703-841c-8279fa4aa5e5.jpg?1",
             "name": "Renari, Merchant of Marvels",
             "text": "You may cast Dragon spells and artifact spells as though they had flash.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "8f16722f-b34d-5598-b6fd-73dbfa8886b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb29b-5169-44d7-bded-c2c94718e61f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb29b-5169-44d7-bded-c2c94718e61f.jpg?1",
             "name": "Robe of the Archmagi",
             "text": "Whenever equipped creature deals combat damage to a player, you draw that many cards.\nEquip {4}\nEquip Shaman, Warlock, or Wizard {1}",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "72d6bc22-33fd-5eb0-b37a-8297affe40e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6427-6d7d-4a90-b4b9-529895082d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6427-6d7d-4a90-b4b9-529895082d60.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "3a646511-132d-558f-8dc1-863dac4db7c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d175a716-5b69-401b-9902-684a30810288.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d175a716-5b69-401b-9902-684a30810288.jpg?1",
             "name": "Sailors' Bane",
             "text": "This spell costs {1} less to cast for each card you own in exile and in your graveyard that's an instant card, a sorcery card, or a card that has an Adventure.\nWard {4} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {4}.)",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "83c235e0-fd57-547f-8742-cea364f00db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg?1",
             "name": "Sapphire Dragon // Psionic Pulse",
             "text": "Flying\nWhenever Sapphire Dragon attacks or blocks, scry 2.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "4c9c8560-aca8-5646-8442-27bcd339977e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0deb9ea-a0d4-4c3f-888e-abd1995cf2b3.jpg?1",
             "name": "Sapphire Dragon // Psionic Pulse",
             "text": "Counter target noncreature spell. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "2d344f1d-82fd-5789-848a-742019f84d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg?1",
             "name": "Sea Hag // Aquatic Ingress",
             "text": "When Sea Hag enters the battlefield, creatures your opponents control get -4/-0 until end of turn.",
             "colours": [
@@ -3601,7 +3601,7 @@
         },
         {
             "id": "994cec17-a263-517d-9b8c-32bf25b3ea6c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0f31357-3fd2-4355-acad-05d253a04b4a.jpg?1",
             "name": "Sea Hag // Aquatic Ingress",
             "text": "Up to two target creatures each get +1/+0 until end of turn and can't be blocked this turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "ce73bee9-5e3e-5d14-8e9c-c63f4d38ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65ad0e2-8f78-4e60-a97e-1cd20901680f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65ad0e2-8f78-4e60-a97e-1cd20901680f.jpg?1",
             "name": "Shameless Charlatan",
             "text": "Commander creatures you own have \"{2}{U}: This creature becomes a copy of another target creature.\"",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "a3e3f62e-d2cc-5901-9880-fe6ca75a32fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582dffab-2851-4498-ad69-c4d072617f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582dffab-2851-4498-ad69-c4d072617f32.jpg?1",
             "name": "Stunning Strike",
             "text": "Flash\nEnchant creature\nWhen Stunning Strike enters the battlefield, tap enchanted creature and remove it from combat.\nAs long as enchanted creature isn't legendary, it doesn't untap during its controller's untap step.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "123c67de-5aa9-5ee2-82f3-50770f3dd8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704f8ab7-63fd-4963-bacd-0076fffb34a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704f8ab7-63fd-4963-bacd-0076fffb34a1.jpg?1",
             "name": "Sword Coast Sailor",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, this creature can't be blocked this turn.\"",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "3a7d60ac-4a4c-576d-a5de-ea4f64646361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg?1",
             "name": "Sword Coast Serpent // Capsizing Wave",
             "text": "Sword Coast Serpent can't be blocked as long as you've cast a noncreature spell this turn.",
             "colours": [
@@ -3780,7 +3780,7 @@
         },
         {
             "id": "8f7f0242-131a-5da4-a6f2-3ce82aa139e1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bbfb7ae-9a32-428d-903c-99d0d8669b8d.jpg?1",
             "name": "Sword Coast Serpent // Capsizing Wave",
             "text": "Return target creature to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3814,7 +3814,7 @@
         },
         {
             "id": "7ab6a783-6229-5473-946e-096d79f09854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b5bf0c-e617-4a41-bfaa-2b299728a93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b5bf0c-e617-4a41-bfaa-2b299728a93f.jpg?1",
             "name": "Tomb of Horrors Adventurer",
             "text": "When Tomb of Horrors Adventurer enters the battlefield, you take the initiative.\nWhenever you cast your second spell each turn, copy it. If you've completed a dungeon, copy that spell twice instead. You may choose new targets for the copies. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "422b39fa-0761-5b2d-ab89-ece79e222db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5535db-696f-4c43-a8b9-c8e521b62c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5535db-696f-4c43-a8b9-c8e521b62c9c.jpg?1",
             "name": "Tymora's Invoker",
             "text": "Sleight of Hand \u2014 {8}: Draw two cards.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "5ce88808-7f7c-5caa-8ae6-dbcfec2a5bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46738fb3-ab5e-486c-b66a-1526ba1cdfa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46738fb3-ab5e-486c-b66a-1526ba1cdfa8.jpg?1",
             "name": "Vhal, Candlekeep Researcher",
             "text": "Vigilance\n{T}: Add an amount of {C} equal to Vhal, Candlekeep Researcher's toughness. This mana can't be spent to cast spells from your hand.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "be98a8ed-15dc-59c5-b5ef-6519a62c6b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862b6d5e-548f-4765-9d39-08d6115b4012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862b6d5e-548f-4765-9d39-08d6115b4012.jpg?1",
             "name": "Volo, Itinerant Scholar",
             "text": "When Volo enters the battlefield, create Volo's Journal, a legendary colorless artifact token with hexproof and \"Whenever you cast a creature spell, note one of its creature types that hasn't been noted for this artifact.\"\n{2}, {T}: Draw a card for each creature type noted for target permanent you control named Volo's Journal.\nChoose a Background",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "c5a930b9-503a-50af-b577-dea64805cd37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9afba96-2ec7-45f2-9ddd-31ec27a423ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9afba96-2ec7-45f2-9ddd-31ec27a423ca.jpg?1",
             "name": "Winter Eladrin",
             "text": "Gust of Wind \u2014 When Winter Eladrin enters the battlefield, return up to one other target creature to its owner's hand.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "918b4cb6-270c-543d-bd73-08164d62588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952e4e6b-fe74-4f3c-95d1-8e043f72072c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952e4e6b-fe74-4f3c-95d1-8e043f72072c.jpg?1",
             "name": "Wizards of Thay",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\nInstant and sorcery spells you cast cost {1} less to cast.\nYou may cast sorcery spells as though they had flash.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "9ca136f0-d4a1-575a-a394-7db7f580b006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg?1",
             "name": "Young Blue Dragon // Sand Augury",
             "text": "Flying",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "95b6fd24-b01d-5c93-b2c3-840b1d844ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56b0f66b-dca9-4a01-9394-20a513c2b225.jpg?1",
             "name": "Young Blue Dragon // Sand Augury",
             "text": "Scry 1, then draw a card. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "6ec171fe-fa65-548e-8104-72c515b73242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5984d3-1e76-4d97-9373-b59cfa9c38ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5984d3-1e76-4d97-9373-b59cfa9c38ae.jpg?1",
             "name": "Agent of the Iron Throne",
             "text": "Commander creatures you own have \"Whenever an artifact or creature you control is put into a graveyard from the battlefield, each opponent loses 1 life.\"",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "98de5916-f93d-5530-bab9-c60ed54a0698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50448e9-afe4-4d4e-b027-bbb855f17aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50448e9-afe4-4d4e-b027-bbb855f17aeb.jpg?1",
             "name": "Agent of the Shadow Thieves",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, put a +1/+1 counter on this creature. It gains deathtouch and indestructible until end of turn.\"",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "085285a3-7b25-564e-8bb6-b8972b0324b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "{2}{B}, {T}, Exile a creature you control: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "7d4c6fc2-5039-5673-b147-7b70b6c556e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "Create a tapped 4/1 black Skeleton creature token with menace. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "8ff967b4-e34f-5691-b99b-2eb1d35df45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e0bfe-fa2d-43a1-a880-2d2083aa559a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e0bfe-fa2d-43a1-a880-2d2083aa559a.jpg?1",
             "name": "Ambition's Cost",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "c495dcb1-3054-5eb4-a11c-b68b6288fdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430c61b-407d-471d-9012-07f1ddef28aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430c61b-407d-471d-9012-07f1ddef28aa.jpg?1",
             "name": "Ancient Brass Dragon",
             "text": "Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "c1cf3bc9-9ea8-56e9-8e0c-bc6a932d1f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f5d5be-777f-4e7b-b18c-ce4a9cedb7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f5d5be-777f-4e7b-b18c-ce4a9cedb7d0.jpg?1",
             "name": "Armor of Shadows",
             "text": "Until end of turn, target creature gets +1/+0 and gains indestructible. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "f7c70cd6-01db-52cc-9a3b-6d6d24c194e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fd431-8f6d-4ca5-bc0c-53881c500da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1fd431-8f6d-4ca5-bc0c-53881c500da1.jpg?1",
             "name": "Arms of Hadar",
             "text": "Creatures target player controls get -2/-2 until end of turn.",
             "colours": [
@@ -4387,7 +4387,7 @@
         },
         {
             "id": "8ad09c17-b1cb-5aa0-9c92-f36478551290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366640a-ca4a-4325-8578-1ec78d0382cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366640a-ca4a-4325-8578-1ec78d0382cc.jpg?1",
             "name": "Astarion's Thirst",
             "text": "Exile target creature. Put X +1/+1 counters on a commander creature you control, where X is the power of the creature exiled this way.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "f006c0c7-78c3-57bc-90b1-3acbbeaf2158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6098b4a-a92f-4477-8122-5913ac9247f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6098b4a-a92f-4477-8122-5913ac9247f8.jpg?1",
             "name": "Atrocious Experiment",
             "text": "Target player mills two cards, draws two cards, and loses 2 life. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "011ed823-a276-51d1-b1cc-f187a2c22f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45c18c-b8eb-465c-8dfc-fd6da73e25b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45c18c-b8eb-465c-8dfc-fd6da73e25b5.jpg?1",
             "name": "Blood Money",
             "text": "Destroy all creatures. For each nontoken creature destroyed this way, you create a tapped Treasure token.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "2445b81f-642c-5bc7-8609-51ef1c402687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f411d0-c796-443f-b957-c632aa23deb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f411d0-c796-443f-b957-c632aa23deb0.jpg?1",
             "name": "Bonecaller Cleric",
             "text": "{3}{B}, Sacrifice Bonecaller Cleric: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "a3db8b74-bab9-51ed-be8d-acde4cafc6a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836cfea-c203-49f4-b8d1-f1e8aa790db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836cfea-c203-49f4-b8d1-f1e8aa790db5.jpg?1",
             "name": "Call to the Void",
             "text": "Each player secretly chooses a creature they control and a creature they don't control. Then those choices are revealed. Destroy each creature chosen this way.",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "11a7f6d8-f3eb-5368-9df9-610791fca2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba79021-39af-4e74-beb5-f2f508c865b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba79021-39af-4e74-beb5-f2f508c865b2.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "87086ecb-94dd-58f6-9ea8-9da9780d9f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b434c1d-792e-4ca7-aea0-938e85fe167c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b434c1d-792e-4ca7-aea0-938e85fe167c.jpg?1",
             "name": "Chain Devil",
             "text": "Animate Chains \u2014 When Chain Devil enters the battlefield, each player sacrifices a nontoken creature.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "66892dc4-e99e-58f8-ae3f-2ef9fac0a9e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71b2b8-f5ef-4885-9f8d-284fe335d184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71b2b8-f5ef-4885-9f8d-284fe335d184.jpg?1",
             "name": "Cloudkill",
             "text": "All creatures get -X/-X until end of turn, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "eab73edd-71ce-5559-a56e-c0902b220a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6410a2a2-48d9-4032-b585-4eaa5bc06581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6410a2a2-48d9-4032-b585-4eaa5bc06581.jpg?1",
             "name": "Criminal Past",
             "text": "Commander creatures you own have menace and \"This creature gets +X/+0, where X is the number of creature cards in your graveyard.\" (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "91565789-4c60-5191-ac06-92d342832ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7b4af-d521-4f4f-8910-7e05f2f60eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7b4af-d521-4f4f-8910-7e05f2f60eb6.jpg?1",
             "name": "Cultist of the Absolute",
             "text": "Commander creatures you own get +3/+3 and have flying, deathtouch, \"Ward\u2014\nPay 3 life,\" and \"At the beginning of your upkeep, sacrifice a creature.\"",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "cf74ff29-ad21-5614-a2dd-e2efe814a9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5172be3-4379-43fc-98bd-e77c579dea55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5172be3-4379-43fc-98bd-e77c579dea55.jpg?1",
             "name": "Deadly Dispute",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "c9cbfe17-d564-521c-8f28-e5f56e7dc9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82a13bf-da32-4c12-a9dd-271d8ca45c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82a13bf-da32-4c12-a9dd-271d8ca45c21.jpg?1",
             "name": "Elder Brain",
             "text": "Menace\nWhenever Elder Brain attacks a player, exile all cards from that player's hand, then they draw that many cards. You may play lands and cast spells from among the exiled cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "737b60e5-0a32-53ec-9d0f-8d056e5a87ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d578bdc3-1edf-4267-b612-2236b54329c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d578bdc3-1edf-4267-b612-2236b54329c6.jpg?1",
             "name": "Eldritch Pact",
             "text": "Target player draws X cards and loses X life, where X is the number of cards in their graveyard.",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "714b9ade-1ccb-56b6-8abc-bd0e8dc6a188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564728ed-dbf0-471c-a34a-5bd3b486b7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564728ed-dbf0-471c-a34a-5bd3b486b7e5.jpg?1",
             "name": "Ghastly Death Tyrant",
             "text": "When Ghastly Death Tyrant enters the battlefield, choose one \u2014\n\u2022 Disintegration Ray \u2014 Destroy target enchantment an opponent controls. You lose life equal to its mana value.\n\u2022 Death Ray \u2014 Creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -4868,7 +4868,7 @@
         },
         {
             "id": "ca2431c4-58d4-5eb0-bf40-acf75820e58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg?1",
             "name": "Ghost Lantern // Bind Spirit",
             "text": "Whenever a creature you control dies, put a +1/+1 counter on equipped creature.\nEquip {1}",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "04e80805-510c-5a39-8b90-994547e8e1fe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2bde2d6-7c2a-4566-a45a-ccdbbed039b7.jpg?1",
             "name": "Ghost Lantern // Bind Spirit",
             "text": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -4936,7 +4936,7 @@
         },
         {
             "id": "5f6a6bfe-07f9-542e-b81f-58aaac735dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg?1",
             "name": "Gray Slaad // Entropic Decay",
             "text": "As long as there are four or more creature cards in your graveyard, Gray Slaad has menace and deathtouch.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "18a5ef60-3657-5da2-a0e0-235667c6b57a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2b6960-ff4c-4557-ba6d-d504f87d4516.jpg?1",
             "name": "Gray Slaad // Entropic Decay",
             "text": "Mill four cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "8e1bbbdf-5a39-531e-99c0-a35eb2a7f520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7efb10f-c760-431c-8ac6-904965d850dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7efb10f-c760-431c-8ac6-904965d850dc.jpg?1",
             "name": "Guildsworn Prowler",
             "text": "Deathtouch\nWhen Guildsworn Prowler dies, if it wasn't blocking, draw a card.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "22aa6943-3508-509a-a55d-a274db0ada30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg?1",
             "name": "Hezrou // Demonic Stench",
             "text": "Whenever one or more creatures you control become blocked, each blocking creature gets -1/-1 until end of turn.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "55c1311a-d982-5041-91e4-314c4e7972f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c2f40e7-82b0-4847-994d-9326a88c4965.jpg?1",
             "name": "Hezrou // Demonic Stench",
             "text": "Each creature that blocked this turn gets -1/-1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "66185cd3-e33c-59d8-a74e-e709aadcb7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52d30a3-a436-4854-91e9-2c359c40457b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52d30a3-a436-4854-91e9-2c359c40457b.jpg?1",
             "name": "Intellect Devourer",
             "text": "Devour Intellect \u2014 When Intellect Devourer enters the battlefield, each opponent exiles a card from their hand until Intellect Devourer leaves the battlefield.\nBody Thief \u2014 You may play lands and cast spells from among cards exiled with Intellect Devourer. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "ccca8a51-02f8-5611-817b-7da9a994d9fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5da403-d791-4ad4-a949-e8a56459cac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5da403-d791-4ad4-a949-e8a56459cac1.jpg?1",
             "name": "Mold Folk",
             "text": "Lifelink\nMold Harvest \u2014 {1}, Sacrifice another creature or an artifact: Put a +1/+1 counter on Mold Folk.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "26268b82-2e06-5e79-938a-92caad06f69a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdef7fea-2bd0-42a2-96f6-6def18bd7f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdef7fea-2bd0-42a2-96f6-6def18bd7f0c.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "43b75666-c115-535e-ba79-3b547861e53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7c427-aa31-4077-8397-74a9a3802ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7c427-aa31-4077-8397-74a9a3802ee7.jpg?1",
             "name": "Myrkul's Edict",
             "text": "Roll a d20.\n1\u20139 | Choose an opponent. That player sacrifices a creature.\n10\u201319 | Each opponent sacrifices a creature.\n20 | Each opponent sacrifices a creature with the greatest power among creatures that player controls.",
             "colours": [
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "ab09d7c6-2970-5687-be8f-c11bae8c08cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca67faa9-2c23-4cc5-b77f-ff75cf0349f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca67faa9-2c23-4cc5-b77f-ff75cf0349f3.jpg?1",
             "name": "Myrkul's Invoker",
             "text": "Psychic Blades \u2014 {8}: Creatures you control get +2/+0 and gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5280,7 +5280,7 @@
         },
         {
             "id": "8039b8fd-6f62-58da-9df3-1f018b4429da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc61b93-b87a-47f4-b5b5-eedb1db48288.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc61b93-b87a-47f4-b5b5-eedb1db48288.jpg?1",
             "name": "Nefarious Imp",
             "text": "Flying\nWhenever one or more permanents you control leave the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5314,7 +5314,7 @@
         },
         {
             "id": "388d0789-2953-58e7-9f4d-e957bcdfd9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9fd859-577f-4836-b785-1cf11808b892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9fd859-577f-4836-b785-1cf11808b892.jpg?1",
             "name": "Nothic",
             "text": "Weird Insight \u2014 When Nothic dies, roll a d20.\n1\u20139 | You draw a card and you lose 1 life.\n10\u201319 | You draw two cards and you lose 2 life.\n20 | You draw seven cards and you lose 7 life.",
             "colours": [
@@ -5348,7 +5348,7 @@
         },
         {
             "id": "b1ed22b5-5d98-51ff-964f-2def15e32a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b0cf66-c6ec-4ff6-96a5-334e2c9c7818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b0cf66-c6ec-4ff6-96a5-334e2c9c7818.jpg?1",
             "name": "Pact Weapon",
             "text": "As long as Pact Weapon is attached to a creature, you don't lose the game for having 0 or less life.\nWhenever equipped creature attacks, draw a card and reveal it. The creature gets +X/+X until end of turn and you lose X life, where X is that card's mana value.\nEquip\u2014\nDiscard a card.",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "4bc9a69f-36f4-504c-9897-4cc924fae5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82958da6-71d5-4ad3-a149-aaa31f25e7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82958da6-71d5-4ad3-a149-aaa31f25e7cf.jpg?1",
             "name": "Parasitic Impetus",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "78ca12bb-c8f6-5847-b936-2cef3eb19cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeee54a-5e16-4519-b04a-49eaaf896b9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeee54a-5e16-4519-b04a-49eaaf896b9a.jpg?1",
             "name": "Passageway Seer",
             "text": "Lifelink\nWhen Passageway Seer enters the battlefield, you take the initiative.\nAt the beginning of your end step, if you have the initiative, put a +1/+1 counter on Passageway Seer.",
             "colours": [
@@ -5453,7 +5453,7 @@
         },
         {
             "id": "56fa204d-a348-51f8-a345-e3637d8b0dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e27c36-d883-4681-8430-b4d0ad7f1df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e27c36-d883-4681-8430-b4d0ad7f1df0.jpg?1",
             "name": "Ravenloft Adventurer",
             "text": "When Ravenloft Adventurer enters the battlefield, you take the initiative.\nIf a creature an opponent controls would die, instead exile it and put a hit counter on it.\nWhenever Ravenloft Adventurer attacks, if you've completed a dungeon, defending player loses 1 life for each card they own in exile with a hit counter on it.",
             "colours": [
@@ -5491,7 +5491,7 @@
         },
         {
             "id": "ec5e569a-d99a-536c-aab1-2aa47054c40c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9367f66-6556-459c-a43d-5ba7a84b568d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9367f66-6556-459c-a43d-5ba7a84b568d.jpg?1",
             "name": "Safana, Calimport Cutthroat",
             "text": "Menace\nAt the beginning of your end step, if you have the initiative, create a Treasure token. Create three of those tokens instead if you've completed a dungeon.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5531,7 +5531,7 @@
         },
         {
             "id": "52f095f3-a87d-5155-a4a5-6d2743c4be32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009d5ab-945d-43c3-9077-f10f96249fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4009d5ab-945d-43c3-9077-f10f96249fc4.jpg?1",
             "name": "Sarevok, Deathbringer",
             "text": "At the beginning of each player's end step, if no permanents left the battlefield this turn, that player loses X life, where X is Sarevok's power.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "8a089e1e-8363-5970-903e-ad8bf29c50c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c876f9b3-b4f6-4177-9c43-443ae2a028d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c876f9b3-b4f6-4177-9c43-443ae2a028d0.jpg?1",
             "name": "Scion of Halaster",
             "text": "Commander creatures you own have \"The first time you would draw a card each turn, instead look at the top two cards of your library. Put one of them into your graveyard and the other back on top of your library. Then draw a card.\"",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "c955cdd5-9b39-5af7-b823-6055b093dacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a0913d-776b-4ef8-adef-8861349df2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a0913d-776b-4ef8-adef-8861349df2b5.jpg?1",
             "name": "Shadowheart, Dark Justiciar",
             "text": "{1}{B}, {T}, Sacrifice another creature: Draw X cards, where X is that creature's power.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5650,7 +5650,7 @@
         },
         {
             "id": "4bb5c10d-601d-5ea8-97a4-596f3157f963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fdf8bd-1893-4599-936a-fe0d6a87545f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fdf8bd-1893-4599-936a-fe0d6a87545f.jpg?1",
             "name": "Sigil of Myrkul",
             "text": "At the beginning of combat on your turn, mill a card. When you do, if there are four or more creature cards in your graveyard, put a +1/+1 counter on target creature you control and it gains deathtouch until end of turn. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "da4c39ba-5d0d-5be2-a6be-404d7a0bd859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bc010-5b60-4075-be12-0b36f41f32c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bc010-5b60-4075-be12-0b36f41f32c6.jpg?1",
             "name": "Sivriss, Nightmare Speaker",
             "text": "{T}, Sacrifice another creature or an artifact: For each opponent, you mill a card, then return that card from your graveyard to your hand unless that player pays 3 life. (To mill a card, put the top card of your library into your graveyard.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "dcc4090d-c03e-5eba-9d2a-2b6960953949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3362080e-57e9-4da1-9065-d28932869fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3362080e-57e9-4da1-9065-d28932869fe5.jpg?1",
             "name": "Skullport Merchant",
             "text": "When Skullport Merchant enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{1}{B}, Sacrifice another creature or a Treasure: Draw a card.",
             "colours": [
@@ -5758,7 +5758,7 @@
         },
         {
             "id": "9296b40a-80b4-5cfc-b6c2-205e68b305b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d59fb-c3ff-4995-a695-51f2a4dae404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d59fb-c3ff-4995-a695-51f2a4dae404.jpg?1",
             "name": "Stirge",
             "text": "Flying\nStirge can't block.\nBlood Drain \u2014 {1}{B}, Pay 1 life, Sacrifice Stirge: Draw a card.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "30a89a22-83ab-5349-8608-7170c5fa74eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278f7705-01a4-4baf-929b-b93e538a8d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278f7705-01a4-4baf-929b-b93e538a8d77.jpg?1",
             "name": "Summon Undead",
             "text": "You may mill three cards. Then return a creature card from your graveyard to the battlefield. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "9ac264cd-eb35-5d0e-bbae-b887fb10b179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bf4ee1-b6a8-4a69-adab-6839c1786cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bf4ee1-b6a8-4a69-adab-6839c1786cc9.jpg?1",
             "name": "Thieves' Tools",
             "text": "When Thieves' Tools enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature can't be blocked as long as its power is 3 or less.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5859,7 +5859,7 @@
         },
         {
             "id": "18918c76-eab3-546c-b063-2dce39a1542f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg?1",
             "name": "Topaz Dragon // Entropic Cloud",
             "text": "Flying, deathtouch",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "2ea932c1-0a1a-5df8-b4dd-5bbab65683d7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783adffd-449f-44a6-8faf-3e38a201b05b.jpg?1",
             "name": "Topaz Dragon // Entropic Cloud",
             "text": "Creatures you control gain deathtouch until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "f2206082-b5b7-5597-839e-9ff2d8d91dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bf9736-b5f5-4fd4-8406-9f57fefd86e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bf9736-b5f5-4fd4-8406-9f57fefd86e7.jpg?1",
             "name": "Underdark Explorer",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Underdark Explorer enters the battlefield, you take the initiative.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "ffacac1a-8fdc-5452-a61c-386ff95c744f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f939d8-3d41-4d8b-baea-7f022104c704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f939d8-3d41-4d8b-baea-7f022104c704.jpg?1",
             "name": "Vicious Battlerager",
             "text": "When Vicious Battlerager enters the battlefield, you take the initiative.\nSpiked Retribution \u2014 Whenever Vicious Battlerager becomes blocked by a creature, that creature's controller loses 5 life.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "9e611995-bb58-52ea-9cda-ad47c4a58e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631762a-e833-40a5-a6e9-b6cde38f62f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631762a-e833-40a5-a6e9-b6cde38f62f0.jpg?1",
             "name": "Viconia, Drow Apostate",
             "text": "At the beginning of your upkeep, if there are four or more creature cards in your graveyard, return a creature card at random from your graveyard to your hand.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "d8e61eb7-14b3-50f4-b94e-dfc42ab546e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5111905c-3d19-4a06-b8c6-a253260b5d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5111905c-3d19-4a06-b8c6-a253260b5d24.jpg?1",
             "name": "Vrock",
             "text": "Flying\nToxic Spores \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, each opponent loses 3 life.",
             "colours": [
@@ -6072,7 +6072,7 @@
         },
         {
             "id": "fb0aef8c-da27-5afa-849a-7e296e982d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1a27c1-ff44-47a7-991d-c294e30eea34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1a27c1-ff44-47a7-991d-c294e30eea34.jpg?1",
             "name": "Zhentarim Bandit",
             "text": "Whenever Zhentarim Bandit attacks, you may pay 1 life. If you do, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6107,7 +6107,7 @@
         },
         {
             "id": "d8c8cb32-02e1-500f-a2a9-55a59e2ba40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34806912-daf8-4e5c-804f-af0858500438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34806912-daf8-4e5c-804f-af0858500438.jpg?1",
             "name": "Amber Gristle O'Maul",
             "text": "Haste\nWhenever Amber Gristle O'Maul attacks, you may discard your hand. If you do, draw a card for each player being attacked.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "4e5ae695-dbb1-5f98-9333-e3b926d23d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg?1",
             "name": "Amethyst Dragon // Explosive Crystal",
             "text": "Flying, haste",
             "colours": [
@@ -6181,7 +6181,7 @@
         },
         {
             "id": "de522e4d-8725-5844-b304-6487d46a94d9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57adbd6e-88ec-4472-a9c9-90b679fa881f.jpg?1",
             "name": "Amethyst Dragon // Explosive Crystal",
             "text": "Explosive Crystal deals 4 damage divided as you choose among any number of targets. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "a572dff6-b14d-5771-8fac-aa2f585b3fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836dddd-a7e4-499f-ad49-ce298aa65720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836dddd-a7e4-499f-ad49-ce298aa65720.jpg?1",
             "name": "Ancient Copper Dragon",
             "text": "Flying\nWhenever Ancient Copper Dragon deals combat damage to a player, roll a d20. You create a number of Treasure tokens equal to the result.",
             "colours": [
@@ -6253,7 +6253,7 @@
         },
         {
             "id": "c340cb90-d1fe-5bf9-b4bd-df8d2447082a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1b3da-e8e6-4118-a268-1e3871e6ffee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1b3da-e8e6-4118-a268-1e3871e6ffee.jpg?1",
             "name": "Balor",
             "text": "Flying\nWhenever Balor attacks or dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent draws three cards, then discards three cards at random.\n\u2022 Target opponent sacrifices a nontoken artifact.\n\u2022 Balor deals damage to target opponent equal to the number of cards in their hand.",
             "colours": [
@@ -6289,7 +6289,7 @@
         },
         {
             "id": "b8cdc67a-9f65-5b8b-ab9f-a15f8295df81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd3e535-8412-4f79-a2b1-dfda9db1c496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd3e535-8412-4f79-a2b1-dfda9db1c496.jpg?1",
             "name": "Bhaal's Invoker",
             "text": "Scorching Ray \u2014 {8}: Bhaal's Invoker deals 4 damage to each opponent.",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "9700953a-7e55-5edc-b349-f2e327b5adbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdf1222-2fc5-4dae-a7a5-6ba774b02843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdf1222-2fc5-4dae-a7a5-6ba774b02843.jpg?1",
             "name": "Bloodboil Sorcerer",
             "text": "Whenever Bloodboil Sorcerer enters the battlefield, you take the initiative.\nCrown of Madness \u2014 {1}{R}, Sacrifice an artifact or creature: Goad target creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -6359,7 +6359,7 @@
         },
         {
             "id": "b6b44716-1af2-5251-b171-71870a19444e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0174e40a-0ef5-4439-91e6-3fc39f482520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0174e40a-0ef5-4439-91e6-3fc39f482520.jpg?1",
             "name": "Breath Weapon",
             "text": "Breath Weapon deals 2 damage to each non-Dragon creature.",
             "colours": [
@@ -6391,7 +6391,7 @@
         },
         {
             "id": "d54c35d4-fc61-5911-b17e-ad8c319da052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e41166-bdaa-4aed-986a-7be1d043240c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e41166-bdaa-4aed-986a-7be1d043240c.jpg?1",
             "name": "Carnelian Orb of Dragonkind",
             "text": "{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.",
             "colours": [
@@ -6423,7 +6423,7 @@
         },
         {
             "id": "b817292b-7be6-5d61-b536-eb1c167c7255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09abb6df-2aa1-4999-b550-db2892faa8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09abb6df-2aa1-4999-b550-db2892faa8c7.jpg?1",
             "name": "Caves of Chaos Adventurer",
             "text": "Trample\nWhen Caves of Chaos Adventurer enters the battlefield, you take the initiative.\nWhenever Caves of Chaos Adventurer attacks, exile the top card of your library. If you've completed a dungeon, you may play that card this turn without paying its mana cost. Otherwise, you may play that card this turn.",
             "colours": [
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "01aa8e2a-19e8-516b-bcbc-7eae368c6c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8647092a-9d09-42cb-bcda-4e5e7a6c8a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8647092a-9d09-42cb-bcda-4e5e7a6c8a1c.jpg?1",
             "name": "Coronation of Chaos",
             "text": "Up to three target creatures can't block this turn. Goad them. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "95ceba8e-bd76-55ae-91fc-ce294525e541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faadf72f-b2d5-4271-8d5c-a586acf63453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faadf72f-b2d5-4271-8d5c-a586acf63453.jpg?1",
             "name": "Descent into Avernus",
             "text": "At the beginning of your upkeep, put two descent counters on Descent into Avernus. Then each player creates X Treasure tokens and Descent into Avernus deals X damage to each player, where X is the number of descent counters on Descent into Avernus.",
             "colours": [
@@ -6526,7 +6526,7 @@
         },
         {
             "id": "5d06c6e2-573f-5abb-9bce-20a0924efd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06ad968-ca7a-470b-ba3b-e0afc597b2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06ad968-ca7a-470b-ba3b-e0afc597b2cd.jpg?1",
             "name": "Dragon Cultist",
             "text": "Commander creatures you own have \"At the beginning of your end step, if a source you controlled dealt 5 or more damage this turn, create a 4/4 red Dragon creature token with flying.\"",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "3ff54cbe-639f-5bf5-8ca7-210a04077c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f700c6-7591-481d-b223-21f5b820e831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f700c6-7591-481d-b223-21f5b820e831.jpg?1",
             "name": "Earth Tremor",
             "text": "Earth Tremor deals damage to target creature or planeswalker equal to the number of lands you control.",
             "colours": [
@@ -6596,7 +6596,7 @@
         },
         {
             "id": "68bd10a5-0e58-50ba-b874-a7218170c3c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e376b59a-5702-4706-b713-01cab4e253cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e376b59a-5702-4706-b713-01cab4e253cc.jpg?1",
             "name": "Elturel Survivors",
             "text": "Trample, myriad\nAs long as Elturel Survivors is attacking, it gets +X/+0, where X is the number of lands defending player controls.",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "2a8633f8-a360-554b-9e36-09003d871471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg?1",
             "name": "Fang Dragon // Forktail Sweep",
             "text": "Flying",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "30e5e727-c609-5806-83a9-a7094aa2691d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d74937b-c87f-4894-8f00-36e4d6844ebd.jpg?1",
             "name": "Fang Dragon // Forktail Sweep",
             "text": "Forktail Sweep deals 1 damage to each creature you don't control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6701,7 +6701,7 @@
         },
         {
             "id": "d487cb7a-be2c-5b5e-8b3b-f8f2faaf1760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255900-11ac-4a82-bd30-2dc24addd8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255900-11ac-4a82-bd30-2dc24addd8e6.jpg?1",
             "name": "Firbolg Flutist",
             "text": "Enthralling Performance \u2014 When Firbolg Flutist enters the battlefield, gain control of target creature you don't control until end of turn. Untap it. It gains haste and myriad until end of turn. (Whenever it attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "43c95dcf-bf6d-50cc-9f92-e8e1f8cc8e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45a43e-a5b7-4fd4-873b-7b3c021be198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45a43e-a5b7-4fd4-873b-7b3c021be198.jpg?1",
             "name": "Fireball",
             "text": "This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.",
             "colours": [
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "ee6a1494-cca9-5775-915d-be1e920ced90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5bb319-29b2-4a7c-82e9-f8b5e47909a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5bb319-29b2-4a7c-82e9-f8b5e47909a1.jpg?1",
             "name": "Ganax, Astral Hunter",
             "text": "Flying\nWhenever Ganax, Astral Hunter or another Dragon enters the battlefield under your control, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "0e8a3d85-b127-5933-ad0d-fa1d191b7c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac424e1-7806-46ee-84a9-ca2f0dd468a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac424e1-7806-46ee-84a9-ca2f0dd468a4.jpg?1",
             "name": "Genasi Enforcers",
             "text": "Myriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\n{1}{R}: Creatures you control named Genasi Enforcers get +1/+0 until end of turn.",
             "colours": [
@@ -6846,7 +6846,7 @@
         },
         {
             "id": "e9ee87bb-561c-5f7e-a97c-ebd9425c9f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfecffd-33af-43a9-b26c-f1ff193c6323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfecffd-33af-43a9-b26c-f1ff193c6323.jpg?1",
             "name": "Gnoll War Band",
             "text": "This spell costs {1} less to cast for each opponent who was dealt damage this turn.\nMenace\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "45164d97-93a1-5616-8949-74d5236bd61d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe5cc84-db39-4f64-b877-599880a8729a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe5cc84-db39-4f64-b877-599880a8729a.jpg?1",
             "name": "Guild Artisan",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, you create two Treasure tokens.\" (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6918,7 +6918,7 @@
         },
         {
             "id": "063508e0-d066-54cf-bed2-683a6d214bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ca18d-9099-4f1e-95c1-f04da58a26bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ca18d-9099-4f1e-95c1-f04da58a26bd.jpg?1",
             "name": "Gut, True Soul Zealot",
             "text": "Whenever you attack, you may sacrifice another creature or an artifact. If you do, create a 4/1 black Skeleton creature token with menace that's tapped and attacking. (It can't be blocked except by two or more creatures.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "b71d968b-7199-5268-9356-7d8c78986992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746fec80-5ddb-42b8-bc54-728bcd3863b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746fec80-5ddb-42b8-bc54-728bcd3863b3.jpg?1",
             "name": "Hoarding Ogre",
             "text": "Whenever Hoarding Ogre attacks, roll a d20.\n1\u20139 | Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n10\u201319 | Create two Treasure tokens.\n20 | Create three Treasure tokens.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "dacc4f49-b5cf-5c38-8b70-296576dc134c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8dd6c3-3699-4dd1-a019-fdb569eaf722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8dd6c3-3699-4dd1-a019-fdb569eaf722.jpg?1",
             "name": "Ingenious Artillerist",
             "text": "Whenever one or more artifacts enter the battlefield under your control, Ingenious Artillerist deals that much damage to each opponent.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "31ced9ec-c7cd-5c58-82b6-7df4dcc437b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e6b1d3-1ac2-4f20-997e-25c93f1f7897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e6b1d3-1ac2-4f20-997e-25c93f1f7897.jpg?1",
             "name": "Inspired Tinkering",
             "text": "Exile the top three cards of your library. Until the end of your next turn, you may play those cards.\nCreate three Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7059,7 +7059,7 @@
         },
         {
             "id": "6f230290-cf21-59ca-becb-c065ab82ce84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f401e-1403-49f8-a39e-1eed05b41c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f401e-1403-49f8-a39e-1eed05b41c34.jpg?1",
             "name": "Insufferable Balladeer",
             "text": "Vicious Mockery \u2014 When Insufferable Balladeer enters the battlefield, target creature an opponent controls can't block this turn. Goad it. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "d116ccf0-3589-5932-89b4-7fa77b5ef22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d2f660-97f9-404b-82bb-37e396602580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d2f660-97f9-404b-82bb-37e396602580.jpg?1",
             "name": "Javelin of Lightning",
             "text": "Flash\nWhen Javelin of Lightning enters the battlefield, attach it to target creature you control.\nAs long as it's your turn, equipped creature gets +2/+0 and has first strike.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "beb54d94-c11e-5da2-a0c7-194fdb7d83a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775480ed-f574-40cb-bd9b-21102eaaff63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775480ed-f574-40cb-bd9b-21102eaaff63.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "Whenever you attack, if it's the first combat phase of the turn, untap all attacking creatures. They gain first strike until end of turn. After this phase, there is an additional combat phase.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "0b0ac66e-a46b-5a7d-ba53-07d6c06e9561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5f9fb1-5a55-4db3-98a1-2628e3598c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5f9fb1-5a55-4db3-98a1-2628e3598c18.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "a45cf3ab-8c12-568c-9b06-e9c2d4eb1673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c5b52-94bc-48e3-8e4f-e2db1eca7536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c5b52-94bc-48e3-8e4f-e2db1eca7536.jpg?1",
             "name": "Livaan, Cultist of Tiamat",
             "text": "Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "4c97f86d-bcad-5bb4-ad5b-537d015c9088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743840f-fe99-4cb4-a558-1763b605b35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743840f-fe99-4cb4-a558-1763b605b35f.jpg?1",
             "name": "Nemesis Phoenix",
             "text": "Flying\n{2}{R}: Return Nemesis Phoenix from your graveyard to the battlefield tapped and attacking. Activate only during the declare attackers step and only if you're attacking two or more opponents.",
             "colours": [
@@ -7278,7 +7278,7 @@
         },
         {
             "id": "a36ea1a4-c1a3-5aae-acbe-bf862bfbb50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef30c5-a6a6-4cd9-805f-dc6f66f28997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef30c5-a6a6-4cd9-805f-dc6f66f28997.jpg?1",
             "name": "Pack Attack",
             "text": "Attacking creatures get +X/+0 until end of turn, where X is the number of players being attacked.\nDraw a card.",
             "colours": [
@@ -7310,7 +7310,7 @@
         },
         {
             "id": "fecdfc35-bdb2-53d4-88d8-552f7219c702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b2b8ca-7433-4bfe-abab-e19128e46a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b2b8ca-7433-4bfe-abab-e19128e46a1d.jpg?1",
             "name": "Patron of the Arts",
             "text": "When Patron of the Arts enters the battlefield or dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "654c3801-fd3c-5eb8-96bd-f9e533e640f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91844266-8b2f-421f-a944-544c51734e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91844266-8b2f-421f-a944-544c51734e64.jpg?1",
             "name": "Popular Entertainer",
             "text": "Commander creatures you own have \"Whenever one or more creatures you control deal combat damage to a player, goad target creature that player controls.\" (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -7383,7 +7383,7 @@
         },
         {
             "id": "01a0b782-8cc6-5e7c-83a9-92172b06f43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c912e984-1d27-4da2-9733-d56e437bcf58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c912e984-1d27-4da2-9733-d56e437bcf58.jpg?1",
             "name": "Reckless Barbarian",
             "text": "Sacrifice Reckless Barbarian: Add {R}{R}.",
             "colours": [
@@ -7418,7 +7418,7 @@
         },
         {
             "id": "0964a722-400a-5345-ba32-1c4394a0cafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57520d99-744f-41bb-9134-f28397a5cb2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57520d99-744f-41bb-9134-f28397a5cb2a.jpg?1",
             "name": "Shiny Impetus",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7452,7 +7452,7 @@
         },
         {
             "id": "295f998b-6ef9-579b-9d9a-320b80bab605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d9d83-d1e6-4499-a1ac-6f865159f6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d9d83-d1e6-4499-a1ac-6f865159f6b6.jpg?1",
             "name": "Stirring Bard",
             "text": "Defender\nWhen Stirring Bard enters the battlefield, you take the initiative.\nMantle of Inspiration \u2014 {T}: Target creature gains menace and haste until end of turn.",
             "colours": [
@@ -7487,7 +7487,7 @@
         },
         {
             "id": "3ad747df-19d1-5500-a769-7ab7e436a9e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a655b3-969f-40d7-9d69-61abf338df86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a655b3-969f-40d7-9d69-61abf338df86.jpg?1",
             "name": "Storm King's Thunder",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell X times. You may choose new targets for the copies.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "8d20ee56-9995-5186-916b-63276e5109d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5249c-52b6-4349-adcd-dafdc21f572b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5249c-52b6-4349-adcd-dafdc21f572b.jpg?1",
             "name": "Street Urchin",
             "text": "Commander creatures you own have \"{1}, Sacrifice another creature or an artifact: This creature deals 1 damage to any target.\"",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "c702239b-94f5-5cea-8f82-f89bbf3504fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06604f3-c70c-44d6-b1b9-e915552084e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06604f3-c70c-44d6-b1b9-e915552084e0.jpg?1",
             "name": "Swashbuckler Extraordinaire",
             "text": "When Swashbuckler Extraordinaire enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever you attack, you may sacrifice one or more Treasures. When you do, up to that many target creatures gain double strike until end of turn.",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "efbd66ff-810b-5205-9d5a-432a152af3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149c2a-503b-46e0-9a7f-cc40a9507883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149c2a-503b-46e0-9a7f-cc40a9507883.jpg?1",
             "name": "Taunting Kobold",
             "text": "Haste\nWhenever Taunting Kobold attacks, goad target creature an opponent controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "99217a70-db44-5613-8cfd-1b21718f56fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07f8fc3-83a5-4e0a-b87f-ce415292c790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07f8fc3-83a5-4e0a-b87f-ce415292c790.jpg?1",
             "name": "Tavern Brawler",
             "text": "Commander creatures you own have \"At the beginning of your upkeep, exile the top card of your library. This creature gets +X/+0 until end of turn, where X is that card's mana value. You may play that card this turn.\"",
             "colours": [
@@ -7669,7 +7669,7 @@
         },
         {
             "id": "3fbe3439-b59e-59d1-99b2-a5ca39b8dd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9531098-63ea-4568-81e9-80e00a5f8995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9531098-63ea-4568-81e9-80e00a5f8995.jpg?1",
             "name": "Thunderwave",
             "text": "Roll a d20.\n1\u20139 | Thunderwave deals 3 damage to each creature.\n10\u201319 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.\n20 | Thunderwave deals 6 damage to each creature your opponents control.",
             "colours": [
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "9ba7a104-1520-5b6d-85d3-8ccf815bacdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279c2ec3-abfc-4054-bdd9-3c8fa7d8b426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279c2ec3-abfc-4054-bdd9-3c8fa7d8b426.jpg?1",
             "name": "Tiamat's Fanatics",
             "text": "Haste\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -7736,7 +7736,7 @@
         },
         {
             "id": "bcb60fa7-8613-52f7-8dc4-bd209608dc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg?1",
             "name": "Two-Handed Axe // Sweeping Cleave",
             "text": "Whenever equipped creature attacks, double its power until end of turn.\nEquip {1}{R}",
             "colours": [
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "971c286f-9458-5288-9ed0-7a763a62906c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/1/21e34888-f57c-4f5d-bb5c-b82be980d145.jpg?1",
             "name": "Two-Handed Axe // Sweeping Cleave",
             "text": "Target creature you control gains double strike until end of turn. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "a391e0a5-bd49-53cc-aa81-4282a035e998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df67ec01-9d4c-4ae1-9c8a-f94d649c81bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df67ec01-9d4c-4ae1-9c8a-f94d649c81bc.jpg?1",
             "name": "Wand of Wonder",
             "text": "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1\u20139 | X is one.\n10\u201319 | X is two.\n20 | X is three.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "d8824837-e01b-5154-9ea2-b5cc2fd295cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7a5951-4f71-47a0-ad80-f236f61d3f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7a5951-4f71-47a0-ad80-f236f61d3f22.jpg?1",
             "name": "Warehouse Thief",
             "text": "{2}, {T}, Sacrifice an artifact or creature: Exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -7874,7 +7874,7 @@
         },
         {
             "id": "9be143bb-a097-588b-b78e-141df7afaea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c89d88-9d40-46b6-bee0-6bc2e2ca8ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c89d88-9d40-46b6-bee0-6bc2e2ca8ba1.jpg?1",
             "name": "Wild Magic Surge",
             "text": "Destroy target permanent an opponent controls. Its controller reveals cards from the top of their library until they reveal a permanent card that shares a card type with that permanent. They put that card onto the battlefield and the rest on the bottom of their library in a random order.",
             "colours": [
@@ -7906,7 +7906,7 @@
         },
         {
             "id": "b1bccb2f-9028-5247-870f-f65066298317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd207de-eec3-4d82-b8b9-b1e60a7bad12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd207de-eec3-4d82-b8b9-b1e60a7bad12.jpg?1",
             "name": "Wrathful Red Dragon",
             "text": "Flying\nWhenever a Dragon you control is dealt damage, it deals that much damage to any target that isn't a Dragon.",
             "colours": [
@@ -7942,7 +7942,7 @@
         },
         {
             "id": "0760b7dd-4c1e-5294-91e9-58ce0d9ef66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9d4562-964d-48ce-b03f-7cb491fa040d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9d4562-964d-48ce-b03f-7cb491fa040d.jpg?1",
             "name": "Wyll, Blade of Frontiers",
             "text": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\nWhenever you roll one or more dice, put a +1/+1 counter on Wyll, Blade of Frontiers.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -7982,7 +7982,7 @@
         },
         {
             "id": "5c5a2561-82cc-55d5-b8d3-7a82b771ae72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8df219-1da0-4311-b9bb-c74b5fa55293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8df219-1da0-4311-b9bb-c74b5fa55293.jpg?1",
             "name": "Wyll's Reversal",
             "text": "Choose target spell or ability with one or more targets. Roll a d20 and add the greatest power among creatures you control.\n1\u201314 | You may choose new targets for that spell or ability.\n15+ | You may choose new targets for that spell or ability. Then copy it. You may choose new targets for the copy.",
             "colours": [
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "b9d9cc91-5c8e-56b8-b7fc-abb41e5644f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg?1",
             "name": "Young Red Dragon // Bathe in Gold",
             "text": "Flying\nYoung Red Dragon can't block.",
             "colours": [
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "6472915d-6d47-5a27-ba15-65f4d793ea7e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0b9865a-be87-48fd-a325-be6aca8a31e9.jpg?1",
             "name": "Young Red Dragon // Bathe in Gold",
             "text": "Create a Treasure token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8084,7 +8084,7 @@
         },
         {
             "id": "fc7b703a-d727-5e13-a10c-55c0f7d85423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82730ad9-26d1-4349-a1f0-10307d76ad97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82730ad9-26d1-4349-a1f0-10307d76ad97.jpg?1",
             "name": "You've Been Caught Stealing",
             "text": "Choose one \u2014\n\u2022 Threaten the Merchant \u2014 Each creature blocks this turn if able.\n\u2022 Bribe the Guards \u2014 You create a Treasure token for each opponent who was dealt damage this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "6764837c-0e0b-5c6f-b689-a1aa007a221f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0260e1f-ff6a-4ef3-bef7-8c77f8413500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0260e1f-ff6a-4ef3-bef7-8c77f8413500.jpg?1",
             "name": "Acolyte of Bahamut",
             "text": "Commander creatures you own have \"The first Dragon spell you cast each turn costs {2} less to cast.\"",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "869c508b-2596-582a-86ce-4444a44d5712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e56a516-d71a-49c4-a929-9a8973125d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e56a516-d71a-49c4-a929-9a8973125d3c.jpg?1",
             "name": "Ambitious Dragonborn",
             "text": "Ambitious Dragonborn enters the battlefield with X +1/+1 counters on it, where X is the greatest power among creatures you control and creature cards in your graveyard.",
             "colours": [
@@ -8189,7 +8189,7 @@
         },
         {
             "id": "6609150b-1381-586c-b83b-cb64dc4dfb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781af4dd-9e3c-48af-80e9-b52c427d2120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781af4dd-9e3c-48af-80e9-b52c427d2120.jpg?1",
             "name": "Ancient Bronze Dragon",
             "text": "Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.",
             "colours": [
@@ -8227,7 +8227,7 @@
         },
         {
             "id": "d0ac15f2-0d57-5d5c-b3ba-987d6603e101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4072640-0f9b-4f0a-84cc-eda415cc92e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4072640-0f9b-4f0a-84cc-eda415cc92e7.jpg?1",
             "name": "Avenging Hunter",
             "text": "Trample\nWhen Avenging Hunter enters the battlefield, you take the initiative.",
             "colours": [
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "0df799a1-6e04-5ace-874a-96d4f0339170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c454312c-ba0d-4b93-a3f5-e7764fcfbe20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c454312c-ba0d-4b93-a3f5-e7764fcfbe20.jpg?1",
             "name": "Band Together",
             "text": "Up to two target creatures you control each deal damage equal to their power to another target creature.",
             "colours": [
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "2226feb7-ae16-5ef5-b446-849d79f693ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452a08e-1a04-432f-9c35-11699d7d44fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452a08e-1a04-432f-9c35-11699d7d44fe.jpg?1",
             "name": "Barroom Brawl",
             "text": "Target creature you control fights target creature the opponent to your left controls. Then that player may copy this spell and may choose new targets for the copy.",
             "colours": [
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "c9590242-c4cd-5dfe-a9eb-13b31e618863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fae6a19-6a16-443e-adae-78a7380ee012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fae6a19-6a16-443e-adae-78a7380ee012.jpg?1",
             "name": "Bramble Sovereign",
             "text": "Whenever another nontoken creature enters the battlefield, you may pay {1}{G}. If you do, that creature's controller creates a token that's a copy of that creature.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "6661999f-70c6-5c99-aa7e-cb0d6e5046de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8d2b97-72b9-4bde-ad31-fd9562512d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8d2b97-72b9-4bde-ad31-fd9562512d30.jpg?1",
             "name": "Carefree Swinemaster",
             "text": "Whenever Carefree Swinemaster attacks, you may pay {1}{G}. If you do, create a 2/2 green Boar creature token that's tapped and attacking.",
             "colours": [
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "f408ac5a-8311-5211-97f3-02102eb65741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e84fc74-5b33-423a-82c7-983320fce7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e84fc74-5b33-423a-82c7-983320fce7a3.jpg?1",
             "name": "Circle of the Land Druid",
             "text": "When Circle of the Land Druid enters the battlefield, you may mill four cards. (You may put the top four cards of your library into your graveyard.)\nNatural Recovery \u2014 When Circle of the Land Druid dies, return target land card from your graveyard to your hand.",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "1a245e18-75a4-519c-9e1b-9dadd8114a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8689d-a0c1-4041-bead-7b512fe25663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8689d-a0c1-4041-bead-7b512fe25663.jpg?1",
             "name": "Cloakwood Hermit",
             "text": "Commander creatures you own have \"At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens.\"",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "b2354898-392f-5754-930c-de3761fe4805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6918a85-1a10-4a73-917c-23bd0a877a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6918a85-1a10-4a73-917c-23bd0a877a04.jpg?1",
             "name": "Cloakwood Swarmkeeper",
             "text": "Gathered Swarm \u2014 Whenever one or more tokens enter the battlefield under your control, put a +1/+1 counter on Cloakwood Swarmkeeper.",
             "colours": [
@@ -8507,7 +8507,7 @@
         },
         {
             "id": "2f64353f-2221-55e3-8483-2b69f13f1917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg?1",
             "name": "Colossal Badger // Dig Deep",
             "text": "When Colossal Badger enters the battlefield, you gain 3 life.",
             "colours": [
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "9c27836f-06bc-5254-95d6-5c52937c1ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fe31ab9-d217-464e-96b1-d8a1ca6ad005.jpg?1",
             "name": "Colossal Badger // Dig Deep",
             "text": "Choose target creature. Mill four cards, then put a +1/+1 counter on that creature for each creature card milled this way.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "0a3c96df-591f-5780-8890-ce6bc6f72714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9bf864-1f93-4d73-a212-f71265411768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9bf864-1f93-4d73-a212-f71265411768.jpg?1",
             "name": "Draconic Muralists",
             "text": "When Draconic Muralists dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "86de47d2-867a-550c-8bac-02ed760141e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg?1",
             "name": "Dread Linnorm // Scale Deflection",
             "text": "Dread Linnorm can't be blocked by creatures with power 3 or less.",
             "colours": [
@@ -8645,7 +8645,7 @@
         },
         {
             "id": "556875d8-6386-59a2-879a-b2b34963a140",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/174ee9e7-8040-4b53-8d0d-177ce924521c.jpg?1",
             "name": "Dread Linnorm // Scale Deflection",
             "text": "Put two +1/+1 counters on target creature and untap it. It gains hexproof until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8679,7 +8679,7 @@
         },
         {
             "id": "22550aeb-12c0-551f-a491-761440edc7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a270d07-29da-4c31-ae6a-5f60c162f508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a270d07-29da-4c31-ae6a-5f60c162f508.jpg?1",
             "name": "Druid of the Emerald Grove",
             "text": "When Druid of the Emerald Grove enters the battlefield, search your library for up to two basic land cards and reveal them, then roll a d20.\n1\u20139 | Put those cards into your hand, then shuffle.\n10\u201319 | Put one of those cards onto the battlefield tapped and the other into your hand, then shuffle.\n20 | Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -8714,7 +8714,7 @@
         },
         {
             "id": "465ed5b6-5a09-5a54-8986-826f4b604091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54935597-b5d0-476d-82f3-42a9201e4556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54935597-b5d0-476d-82f3-42a9201e4556.jpg?1",
             "name": "Druidic Ritual",
             "text": "You may mill three cards. Then return up to one creature card and up to one land card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "ffa22e79-07f0-58ae-9178-bfdff14d495a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedfd30-8075-429e-a0fa-4919920c8632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedfd30-8075-429e-a0fa-4919920c8632.jpg?1",
             "name": "Earthquake Dragon",
             "text": "This spell costs {X} less to cast, where X is the total mana value of Dragons you control.\nFlying, trample\n{2}{G}, Sacrifice a land: Return Earthquake Dragon from your graveyard to your hand.",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "d8404b87-e9ab-5e32-8256-fa5d6f198a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg?1",
             "name": "Emerald Dragon // Dissonant Wave",
             "text": "Flying, trample",
             "colours": [
@@ -8817,7 +8817,7 @@
         },
         {
             "id": "a4c9a58e-6406-5b6c-a3ff-b796036434f1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d07c21e-55dc-45b2-b406-2ac38ca5d871.jpg?1",
             "name": "Emerald Dragon // Dissonant Wave",
             "text": "Counter target activated or triggered ability from a noncreature source. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "81629b7c-4a6f-556f-91b4-54986a456628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7d041-957a-4b19-9517-214689dadd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7d041-957a-4b19-9517-214689dadd45.jpg?1",
             "name": "Erinis, Gloom Stalker",
             "text": "Deathtouch\nWhenever Erinis, Gloom Stalker attacks, return target land card from your graveyard to the battlefield.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "64a44ebb-09f5-5b3a-96b6-fe422ca2a3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg?1",
             "name": "Ettercap // Web Shot",
             "text": "Reach",
             "colours": [
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "53b24747-3f62-56c8-b6b1-f270be4b9fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8f5228dc-ec9d-456f-a89c-1bc592a1bbab.jpg?1",
             "name": "Ettercap // Web Shot",
             "text": "Destroy target creature with flying. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "ce188c75-4ed3-5d69-a040-c47cf855849d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbf06f5-d1c7-474c-8f09-72f5ad0c8120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbf06f5-d1c7-474c-8f09-72f5ad0c8120.jpg?1",
             "name": "Explore the Underdark",
             "text": "Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle.\nYou take the initiative.",
             "colours": [
@@ -8992,7 +8992,7 @@
         },
         {
             "id": "e7c5354b-19e2-5767-b206-d7521a659072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc420f2c-09fa-4f90-a1c3-7d151ecaa8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc420f2c-09fa-4f90-a1c3-7d151ecaa8b3.jpg?1",
             "name": "Giant Ankheg",
             "text": "Trample\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nOther creatures you control have trample and ward {2}.",
             "colours": [
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "cfeadd68-f55d-5024-b407-0480cc6a8020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e5c-b6f9-4d36-a6b1-d7315de38fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e185e5c-b6f9-4d36-a6b1-d7315de38fca.jpg?1",
             "name": "Halsin, Emerald Archdruid",
             "text": "{1}: Until end of turn, target token you control becomes a green Bear creature with base power and toughness 4/4 in addition to its other colors and types.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "0f691067-55bd-5cce-a9dd-0ba04d3cea27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44498893-3ff8-4d1e-abdf-4579e0c67020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44498893-3ff8-4d1e-abdf-4579e0c67020.jpg?1",
             "name": "Hardy Outlander",
             "text": "Commander creatures you own have \"Whenever this creature attacks a player, if no opponent has more life than that player, another target creature you control gets +X/+X until end of turn, where X is this creature's power.\"",
             "colours": [
@@ -9104,7 +9104,7 @@
         },
         {
             "id": "a3299285-dbe1-57a0-84ad-9851e3b8e695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b32bae4-65e4-4bdb-8bc5-b98a5aac1568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b32bae4-65e4-4bdb-8bc5-b98a5aac1568.jpg?1",
             "name": "Jade Orb of Dragonkind",
             "text": "{T}: Add {G}. When you spend this mana to cast a Dragon creature spell, it enters the battlefield with an additional +1/+1 counter on it and gains hexproof until your next turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "3a780e9f-15db-5a8f-88ea-bbeba2b38ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb7ad1b-4466-48f7-b46d-cc83d4e22b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb7ad1b-4466-48f7-b46d-cc83d4e22b51.jpg?1",
             "name": "Jaheira, Friend of the Forest",
             "text": "Tokens you control have \"{T}: Add {G}.\"\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -9177,7 +9177,7 @@
         },
         {
             "id": "842680e2-6d37-52ff-ad28-1858a354202e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ce0b01-7b52-4cb9-86ea-13395cf52312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ce0b01-7b52-4cb9-86ea-13395cf52312.jpg?1",
             "name": "Jaheira's Respite",
             "text": "Search your library for up to X basic land cards, where X is the number of creatures attacking you, put those cards onto the battlefield tapped, then shuffle.\nPrevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -9211,7 +9211,7 @@
         },
         {
             "id": "a509a8dd-b1ce-521c-8bb5-d281210460cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de5a3e-7b08-438b-866e-9fce1a36b243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de5a3e-7b08-438b-866e-9fce1a36b243.jpg?1",
             "name": "Lurking Green Dragon",
             "text": "Flying\nLurking Green Dragon can't attack unless defending player controls a creature with flying.",
             "colours": [
@@ -9245,7 +9245,7 @@
         },
         {
             "id": "f031f0f5-cbee-5d8d-9b50-a9d8d82f11fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaadb067-4a77-4d6e-931d-447bd0c06594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaadb067-4a77-4d6e-931d-447bd0c06594.jpg?1",
             "name": "Majestic Genesis",
             "text": "Reveal the top X cards of your library, where X is the greatest mana value of a commander you own on the battlefield or in the command zone. You may put any number of permanent cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "da1b7343-372d-5f94-b391-a4a4f89accb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b534b1cb-0cd7-4b8c-bb25-42207fcba209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b534b1cb-0cd7-4b8c-bb25-42207fcba209.jpg?1",
             "name": "Master Chef",
             "text": "Commander creatures you own have \"This creature enters the battlefield with an additional +1/+1 counter on it\" and \"Other creatures you control enter the battlefield with an additional +1/+1 counter on them.\"",
             "colours": [
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "18f53fac-dbd3-57a9-b7b3-caf6466706bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "{1}{G}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -9351,7 +9351,7 @@
         },
         {
             "id": "80779d61-8562-5cf8-b3d6-396d92672243",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "Mill five cards, then return a creature card milled this way to your hand. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "c6a1dae6-26b9-5092-a1e5-0a2b5102189a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70408d70-1e4b-41f0-80b1-0d37b3a3918c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70408d70-1e4b-41f0-80b1-0d37b3a3918c.jpg?1",
             "name": "Myconid Spore Tender",
             "text": "Infesting Spores \u2014 When Myconid Spore Tender enters the battlefield, destroy up to one target artifact or enchantment.",
             "colours": [
@@ -9421,7 +9421,7 @@
         },
         {
             "id": "6d74aa93-3527-5b4e-a67a-4269ee38eb74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d1e79-cac6-455c-9fda-f13c849579d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d1e79-cac6-455c-9fda-f13c849579d6.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -9453,7 +9453,7 @@
         },
         {
             "id": "ea499ec3-74bd-5767-90f6-ea8c7f869f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c498c-ac7c-4e58-8789-9bde047c2d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616c498c-ac7c-4e58-8789-9bde047c2d47.jpg?1",
             "name": "Overwhelming Encounter",
             "text": "Creatures you control gain vigilance and trample until end of turn. Roll a d20.\n1\u20139 | Creatures you control get +2/+2 until end of turn.\n10\u201319 | Put two +1/+1 counters on each creature you control.\n20 | Put four +1/+1 counters on each creature you control.",
             "colours": [
@@ -9485,7 +9485,7 @@
         },
         {
             "id": "e532d3de-58aa-501c-9811-b51aa47662ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be177b66-dab3-47ef-bcdf-8d99eb57e19f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be177b66-dab3-47ef-bcdf-8d99eb57e19f.jpg?1",
             "name": "Owlbear Cub",
             "text": "Mama's Coming \u2014 Whenever Owlbear Cub attacks a player who controls eight or more lands, look at the top eight cards of your library. You may put a creature card from among them onto the battlefield tapped and attacking that player. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "d90081fe-23a5-5f7c-b608-27e72d5ff7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4813b2-3fd7-4a2b-b87a-9ce5bb18bdd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4813b2-3fd7-4a2b-b87a-9ce5bb18bdd4.jpg?1",
             "name": "Owlbear Shepherd",
             "text": "At the beginning of your end step, if creatures you control have total power 8 or greater, draw a card.",
             "colours": [
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "af0e7f5e-c353-5e5c-8124-0e515547d701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4bf10-a502-4748-9118-5459684542a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4bf10-a502-4748-9118-5459684542a7.jpg?1",
             "name": "Poison the Blade",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -9589,7 +9589,7 @@
         },
         {
             "id": "3395d70e-516e-5b9e-aabd-acb21ff85ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0077099d-aafa-46b3-ab64-e1915a9dda70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0077099d-aafa-46b3-ab64-e1915a9dda70.jpg?1",
             "name": "Predatory Impetus",
             "text": "Enchant creature\nEnchanted creature gets +3/+3, must be blocked if able, and is goaded. (It attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "95278a38-f476-5697-97fc-0484b160479b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c93414-935e-462b-ad89-27ca21d01bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c93414-935e-462b-ad89-27ca21d01bf9.jpg?1",
             "name": "Raised by Giants",
             "text": "Commander creatures you own have base power and toughness 10/10 and are Giants in addition to their other types.",
             "colours": [
@@ -9661,7 +9661,7 @@
         },
         {
             "id": "aa09cf65-7bff-5165-8b42-43a15d2d5ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc8d802-33bd-48c1-bb4f-31fefac85a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc8d802-33bd-48c1-bb4f-31fefac85a5a.jpg?1",
             "name": "Saddle of the Cavalier",
             "text": "Equipped creature gets +3/+3 and can't be blocked by creatures with power 3 or less.\nEquip {3}",
             "colours": [
@@ -9695,7 +9695,7 @@
         },
         {
             "id": "91e46046-44fd-583c-953b-2019d24711b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae5a76-b8b9-431d-8060-a6a96f5d1e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae5a76-b8b9-431d-8060-a6a96f5d1e0b.jpg?1",
             "name": "Scaled Nurturer",
             "text": "{T}: Add {G}. When you spend this mana to cast a Dragon creature spell, you gain 2 life.",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "63f9b5af-d4a3-5141-af6b-b004d82319bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcd60dc-9534-412d-af48-31fcd8ea0843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcd60dc-9534-412d-af48-31fcd8ea0843.jpg?1",
             "name": "Sharpshooter Elf",
             "text": "Reach\nSharpshooter Elf's power is equal to the number of creatures you control.\nWhen Sharpshooter Elf enters the battlefield, it deals damage equal to its power to target creature with flying an opponent controls.",
             "colours": [
@@ -9765,7 +9765,7 @@
         },
         {
             "id": "d77f96f6-fef4-52ff-a9d6-a5d6ae77a234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd1bb8-013b-4028-becd-e0cb4b84f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd1bb8-013b-4028-becd-e0cb4b84f1ad.jpg?1",
             "name": "Silvanus's Invoker",
             "text": "Conjure Elemental \u2014 {8}: Untap target land you control. It becomes an 8/8 Elemental creature with trample and haste until end of turn. It's still a land.",
             "colours": [
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "0b3482ad-c206-5b61-9314-315d9013227e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9233c-9d9f-480b-89fb-54d74d63a17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9233c-9d9f-480b-89fb-54d74d63a17a.jpg?1",
             "name": "Skanos Dragonheart",
             "text": "Whenever Skanos Dragonheart attacks, it gets +X/+X until end of turn, where X is the greatest power among other Dragons you control and Dragon cards in your graveyard.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "54d86ba7-e113-504c-9f4b-29661fb37d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d406ed-bf60-4adc-9721-e64d1313f6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d406ed-bf60-4adc-9721-e64d1313f6b7.jpg?1",
             "name": "Skullwinder",
             "text": "Deathtouch\nWhen Skullwinder enters the battlefield, return target card from your graveyard to your hand, then choose an opponent. That player returns a card from their graveyard to their hand.",
             "colours": [
@@ -9874,7 +9874,7 @@
         },
         {
             "id": "e9d8aa9d-d611-5ce9-b2db-3a3bba20d17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55893f8b-0fea-40a5-b96d-954c99938810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55893f8b-0fea-40a5-b96d-954c99938810.jpg?1",
             "name": "Split the Spoils",
             "text": "Exile up to five target permanent cards from your graveyard and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)",
             "colours": [
@@ -9906,7 +9906,7 @@
         },
         {
             "id": "98097480-e58f-5003-9512-1852b2da9a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef192364-713a-42ff-8249-69a73ae61bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef192364-713a-42ff-8249-69a73ae61bd8.jpg?1",
             "name": "Traverse the Outlands",
             "text": "Search your library for up to X basic land cards, where X is the greatest power among creatures you control. Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -9940,7 +9940,7 @@
         },
         {
             "id": "db5ff9c5-0eb7-5524-b868-47b54e9d7897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c5b3e-737f-4794-b482-af5f0ee901e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c5b3e-737f-4794-b482-af5f0ee901e5.jpg?1",
             "name": "Undercellar Myconid",
             "text": "Whenever Undercellar Myconid enters the battlefield or dies, create a 1/1 green Saproling creature token.\n{T}: Add one mana of any color.",
             "colours": [
@@ -9974,7 +9974,7 @@
         },
         {
             "id": "3c0fd201-237f-5ec0-bb29-58b0ec1b7721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f53a3-521f-4463-a0b6-758a45d8f661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f53a3-521f-4463-a0b6-758a45d8f661.jpg?1",
             "name": "Undermountain Adventurer",
             "text": "Vigilance\nWhen Undermountain Adventurer enters the battlefield, you take the initiative.\n{T}: Add {G}{G}. If you've completed a dungeon, add six {G} instead.",
             "colours": [
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "81a24226-1309-54cf-9b4b-2b5a905a0b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe0daf8-43da-484b-baa1-76f8313c5a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe0daf8-43da-484b-baa1-76f8313c5a0c.jpg?1",
             "name": "Wilson, Refined Grizzly",
             "text": "This spell can't be countered.\nVigilance, reach, trample\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -10051,7 +10051,7 @@
         },
         {
             "id": "f351451b-724b-5685-a262-94a3881979bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f00a908-1898-48e9-8b04-88c2450b2dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f00a908-1898-48e9-8b04-88c2450b2dd3.jpg?1",
             "name": "You Look Upon the Tarrasque",
             "text": "Choose one \u2014\n\u2022 Run and Hide \u2014 Prevent all combat damage that would be dealt to you and creatures you control this turn.\n\u2022 Gather Your Courage \u2014 Target creature gets +5/+5 and gains indestructible until end of turn. All creatures your opponents control able to block that creature this turn do so.",
             "colours": [
@@ -10083,7 +10083,7 @@
         },
         {
             "id": "622288e4-52c2-5026-9dc7-7201b630558f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddbd7a-799c-4432-810c-d839c5c354b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddbd7a-799c-4432-810c-d839c5c354b9.jpg?1",
             "name": "You Meet in a Tavern",
             "text": "Choose one \u2014\n\u2022 Form a Party \u2014 Look at the top five cards of your library. You may reveal any number of creature cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.\n\u2022 Start a Brawl \u2014 Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -10115,7 +10115,7 @@
         },
         {
             "id": "c1233ea7-dd70-5c29-960f-791a366042df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c33bb-47fe-4334-9105-00f4b87811bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22c33bb-47fe-4334-9105-00f4b87811bd.jpg?1",
             "name": "Alaundo the Seer",
             "text": "{T}: Draw a card, then exile a card from your hand and put a number of time counters on it equal to its mana value. It gains \"When the last time counter is removed from this card, if it's exiled, you may cast it without paying its mana cost. If you cast a creature spell this way, it gains haste until end of turn.\" Then remove a time counter from each other card you own in exile.",
             "colours": [
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "6fb43831-6b0a-5218-9de2-d00db14a18d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d932b9-5682-4427-a871-7d452a488674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d932b9-5682-4427-a871-7d452a488674.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "Deathtouch, lifelink\nAt the beginning of your end step, choose one \u2014\n\u2022 Feed \u2014 Target opponent loses life equal to the amount of life they lost this turn.\n\u2022 Friends \u2014 You gain life equal to the amount of life you gained this turn.",
             "colours": [
@@ -10200,7 +10200,7 @@
         },
         {
             "id": "d65a0708-7309-508c-a088-98c86392b5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef42c3f-f22e-4e99-adb0-9e8f8d442347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef42c3f-f22e-4e99-adb0-9e8f8d442347.jpg?1",
             "name": "Baba Lysaga, Night Witch",
             "text": "{T}, Sacrifice up to three permanents: If there were three or more card types among the sacrificed permanents, each opponent loses 3 life, you gain 3 life, and you draw three cards.",
             "colours": [
@@ -10242,7 +10242,7 @@
         },
         {
             "id": "facfdd97-3e6a-5491-8837-a6cf430838bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a576d17-693d-4cc1-bb5b-bf81c74de03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a576d17-693d-4cc1-bb5b-bf81c74de03b.jpg?1",
             "name": "Bane, Lord of Darkness",
             "text": "As long as your life total is less than or equal to half your starting life total, Bane, Lord of Darkness has indestructible.\nWhenever another nontoken creature you control dies, target opponent may have you draw a card. If they don't, you may put a creature card with equal or lesser toughness from your hand onto the battlefield.",
             "colours": [
@@ -10285,7 +10285,7 @@
         },
         {
             "id": "7f531935-7985-580c-a932-6272e5baef73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b11da8-f9af-4ef3-9bc2-c28f0a8a5dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b11da8-f9af-4ef3-9bc2-c28f0a8a5dd1.jpg?1",
             "name": "Bhaal, Lord of Murder",
             "text": "As long as your life total is less than or equal to half your starting life total, Bhaal, Lord of Murder has indestructible.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on target creature and goad it.",
             "colours": [
@@ -10328,7 +10328,7 @@
         },
         {
             "id": "6b42c91e-effc-5a31-be3d-0b46cd489840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75994e0b-b0c7-4b0d-8f48-4be303429bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75994e0b-b0c7-4b0d-8f48-4be303429bd6.jpg?1",
             "name": "Cadira, Caller of the Small",
             "text": "Trample\nWhenever Cadira, Caller of the Small deals combat damage to a player, for each token you control, create a 1/1 white Rabbit creature token.",
             "colours": [
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "938f21bc-21b9-5d11-ac38-fe71a513b311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8b247-455e-4a3f-9f88-b20918c36cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac8b247-455e-4a3f-9f88-b20918c36cc3.jpg?1",
             "name": "Commander Liara Portyr",
             "text": "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards.",
             "colours": [
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "01ad1b3d-4372-53e8-8e3e-5ec04e442b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0873cfa8-046c-4b14-ae22-3fd6a691f763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0873cfa8-046c-4b14-ae22-3fd6a691f763.jpg?1",
             "name": "The Council of Four",
             "text": "Whenever a player draws their second card during their turn, you draw a card.\nWhenever a player casts their second spell during their turn, you create a 2/2 white Knight creature token.",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "5b513a4d-1a3d-5fca-a496-20c186819c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a8ffc-a052-498f-b457-8d70ea18a943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082a8ffc-a052-498f-b457-8d70ea18a943.jpg?1",
             "name": "Duke Ulder Ravengard",
             "text": "At the beginning of combat on your turn, another target creature you control gains haste and myriad until end of turn. (Whenever it attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -10497,7 +10497,7 @@
         },
         {
             "id": "02947ad3-ba99-524f-8bf0-072a1c2f7b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c301b389-d802-4a8b-8681-9b50c8667423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c301b389-d802-4a8b-8681-9b50c8667423.jpg?1",
             "name": "Dynaheir, Invoker Adept",
             "text": "Haste\nYou may activate abilities of other creatures you control as though those creatures had haste.\n{T}: When you next activate an ability this turn by spending four or more mana to activate it, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "e7d3c679-75eb-59df-8a67-2c7fd924b9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eac2b49-6cb6-4ff4-8fac-2ba669326640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eac2b49-6cb6-4ff4-8fac-2ba669326640.jpg?1",
             "name": "Elminster",
             "text": "Whenever you scry, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of cards looked at while scrying this way.\n+2: Draw a card, then scry 2.\n\u22123: Exile the top card of your library. Create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to that card's mana value.\nElminster can be your commander.",
             "colours": [
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "e87d6797-99c2-5fbb-bbc4-8bbe9a9f456c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e889a-5865-4464-9923-bffa25c50cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e889a-5865-4464-9923-bffa25c50cd2.jpg?1",
             "name": "Gluntch, the Bestower",
             "text": "Flying\nAt the beginning of your end step, choose a player. They put two +1/+1 counters on a creature they control. Choose a second player to draw a card. Then choose a third player to create two Treasure tokens.",
             "colours": [
@@ -10622,7 +10622,7 @@
         },
         {
             "id": "717adb2e-cd70-5719-92ce-0fc510fbb42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001c648a-db66-47f3-8fee-3658b9e76ac2.jpg?1",
             "name": "Gorion, Wise Mentor",
             "text": "Vigilance\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
             "colours": [
@@ -10666,7 +10666,7 @@
         },
         {
             "id": "9f61e784-3be7-5e33-bbad-9eee0d2e6622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215a08-41db-4440-8e33-34a84a33db50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215a08-41db-4440-8e33-34a84a33db50.jpg?1",
             "name": "Jan Jansen, Chaos Crafter",
             "text": "Haste\n{T}, Sacrifice an artifact creature: Create two Treasure tokens.\n{T}, Sacrifice a noncreature artifact: Create two 1/1 colorless Construct artifact creature tokens.",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "efe9e85b-ea47-54e3-90ea-62d1947ef775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfddb61e-986f-4557-819d-d6c0ca85c74a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfddb61e-986f-4557-819d-d6c0ca85c74a.jpg?1",
             "name": "Jon Irenicus, Shattered One",
             "text": "At the beginning of your end step, target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it. It's goaded for the rest of the game and it gains \"This creature can't be sacrificed.\" (It attacks each combat if able and attacks a player other than you if able.)\nWhenever a creature you own but don't control attacks, you draw a card.",
             "colours": [
@@ -10752,7 +10752,7 @@
         },
         {
             "id": "fabbb438-d392-5458-97f1-d118210601fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6351adc8-2e44-4e5c-ae58-975b7332155e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6351adc8-2e44-4e5c-ae58-975b7332155e.jpg?1",
             "name": "Kagha, Shadow Archdruid",
             "text": "Whenever Kagha, Shadow Archdruid attacks, it gains deathtouch until end of turn. Mill two cards. (Put the top two cards of your library into your graveyard.)\nOnce during each of your turns, you may play a land or cast a permanent spell from among cards in your graveyard that were put there from your library this turn.",
             "colours": [
@@ -10794,7 +10794,7 @@
         },
         {
             "id": "63c311b5-e5ae-5974-8e0e-547f9ed39c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d08ac-6c24-4158-87a1-c59d1cd447a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d08ac-6c24-4158-87a1-c59d1cd447a8.jpg?1",
             "name": "Korlessa, Scale Singer",
             "text": "You may look at the top card of your library any time.\nYou may cast Dragon spells from the top of your library.",
             "colours": [
@@ -10836,7 +10836,7 @@
         },
         {
             "id": "a132296c-32ae-587f-8636-64cc3548bb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe604232-19da-4331-a6f2-ddb004f1dd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe604232-19da-4331-a6f2-ddb004f1dd90.jpg?1",
             "name": "Lozhan, Dragons' Legacy",
             "text": "Flying\nWhenever you cast an Adventure or Dragon spell, Lozhan, Dragons' Legacy deals damage equal to that spell's mana value to any target that isn't a commander.",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "166538c6-5136-59f8-a24c-684e908f91ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3da2b1a-76c5-4d36-bdf8-025b86f61eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3da2b1a-76c5-4d36-bdf8-025b86f61eb5.jpg?1",
             "name": "Mahadi, Emporium Master",
             "text": "At the beginning of your end step, create a Treasure token for each creature that died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -10919,7 +10919,7 @@
         },
         {
             "id": "c734994c-41aa-57ce-8d59-b014d47bae19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d79c221-e07a-41e1-b92f-dc057802449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d79c221-e07a-41e1-b92f-dc057802449c.jpg?1",
             "name": "Mazzy, Truesword Paladin",
             "text": "Whenever an enchanted creature attacks one of your opponents, it gets +2/+0 and gains trample until end of turn.\nWhenever an Aura you control is put into your graveyard from the battlefield, exile it. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -10963,7 +10963,7 @@
         },
         {
             "id": "325c59d6-e30e-5622-8776-45d2a821efe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a934590b-5c70-4f07-af67-fbe817a99531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a934590b-5c70-4f07-af67-fbe817a99531.jpg?1",
             "name": "Miirym, Sentinel Wyrm",
             "text": "Flying, ward {2}\nWhenever another nontoken Dragon enters the battlefield under your control, create a token that's a copy of it, except the token isn't legendary if that Dragon is legendary.",
             "colours": [
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "cfe9ad7d-67c3-56c1-b9f4-83eb9b4aa803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928036c9-11b8-493e-b9f2-8fbd3487cd19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928036c9-11b8-493e-b9f2-8fbd3487cd19.jpg?1",
             "name": "Minsc & Boo, Timeless Heroes",
             "text": "When Minsc & Boo, Timeless Heroes enters the battlefield and at the beginning of your upkeep, you may create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n+1: Put three +1/+1 counters on up to one target creature with trample or haste.\n\u22122: Sacrifice a creature. When you do, Minsc & Boo, Timeless Heroes deals X damage to any target, where X is that creature's power. If the sacrificed creature was a Hamster, draw X cards.\nMinsc & Boo, Timeless Heroes can be your commander.",
             "colours": [
@@ -11047,7 +11047,7 @@
         },
         {
             "id": "bde4774c-6945-5483-b5a6-08350f250d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9e944b-98fa-4aea-825d-b8b8a9d7ed47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9e944b-98fa-4aea-825d-b8b8a9d7ed47.jpg?1",
             "name": "Minthara, Merciless Soul",
             "text": "Ward {X}, where X is the number of experience counters you have.\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, you get an experience counter.\nCreatures you control get +1/+0 for each experience counter you have.",
             "colours": [
@@ -11089,7 +11089,7 @@
         },
         {
             "id": "6d5cf048-d915-5f14-8b26-2bb7caa4fffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82824d05-5215-459a-aa73-3c5a6be3d464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82824d05-5215-459a-aa73-3c5a6be3d464.jpg?1",
             "name": "Myrkul, Lord of Bones",
             "text": "As long as your life total is less than or equal to half your starting life total, Myrkul, Lord of Bones has indestructible.\nWhenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that card, except it's an enchantment and loses all other card types.",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "573ee749-6d2d-5109-8e4e-e564b777656c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5431f73-9a70-47dc-b5d4-7f43e41b878e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5431f73-9a70-47dc-b5d4-7f43e41b878e.jpg?1",
             "name": "Neera, Wild Mage",
             "text": "Whenever you cast a spell, you may put it on the bottom of its owner's library. If you do, reveal cards from the top of your library until you reveal a nonland card. You may cast that card without paying its mana cost. Then put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
             "colours": [
@@ -11175,7 +11175,7 @@
         },
         {
             "id": "649b9a67-a844-597d-816e-4928c03a9053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480ac0a-883a-4f73-8e7c-56d64be410a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5480ac0a-883a-4f73-8e7c-56d64be410a3.jpg?1",
             "name": "Nine-Fingers Keene",
             "text": "Menace\nWard\u2014\nPay 9 life.\nWhenever Nine-Fingers Keene deals combat damage to a player, look at the top nine cards of your library. You may put a Gate card from among them onto the battlefield. Then if you control nine or more Gates, put the rest into your hand. Otherwise, put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11219,7 +11219,7 @@
         },
         {
             "id": "67c6cb58-8004-5cbb-a343-d69b56a83e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13129e63-558d-415d-87eb-616868205341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13129e63-558d-415d-87eb-616868205341.jpg?1",
             "name": "Oji, the Exquisite Blade",
             "text": "When Oji, the Exquisite Blade enters the battlefield, you gain 2 life and scry 2.\nWhenever you cast your second spell each turn, exile up to one target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -11261,7 +11261,7 @@
         },
         {
             "id": "9dbfc52d-c4da-54e4-9578-949ece69a060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1166ce2a-4e0b-4a57-929d-566f461a6282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1166ce2a-4e0b-4a57-929d-566f461a6282.jpg?1",
             "name": "Raggadragga, Goreguts Boss",
             "text": "Each creature you control with a mana ability gets +2/+2.\nWhenever a creature you control with a mana ability attacks, untap it.\nWhenever you cast a spell, if at least seven mana was spent to cast it, untap target creature. It gets +7/+7 and gains trample until end of turn.",
             "colours": [
@@ -11303,7 +11303,7 @@
         },
         {
             "id": "564f739c-222b-57aa-be67-c6a984fa8ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6902a4-2db0-47fe-ace8-0c890675bf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6902a4-2db0-47fe-ace8-0c890675bf19.jpg?1",
             "name": "Raphael, Fiendish Savior",
             "text": "Flying\nOther Demons, Devils, Imps, and Tieflings you control get +1/+1 and have lifelink.\nAt the beginning of each end step, if a creature card was put into your graveyard from anywhere this turn, create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -11345,7 +11345,7 @@
         },
         {
             "id": "e54aa6cb-c2ca-5371-b167-b49e60b51dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54484439-6f8a-47f1-8d62-4689af7f00c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54484439-6f8a-47f1-8d62-4689af7f00c2.jpg?1",
             "name": "Rilsa Rael, Kingpin",
             "text": "Deathtouch\nWhen Rilsa Rael, Kingpin enters the battlefield, you take the initiative.\nWhenever you attack, target attacking creature gains deathtouch until end of turn. If you've completed a dungeon, that creature also gets +5/+0 and gains first strike and menace until end of turn.",
             "colours": [
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "a848ea78-29b9-5ff9-89a8-bbdf5c39c4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c5f679-82d0-4434-9f13-d39ad57282b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c5f679-82d0-4434-9f13-d39ad57282b8.jpg?1",
             "name": "Tasha, the Witch Queen",
             "text": "Whenever you cast a spell you don't own, create a 3/3 black Demon creature token.\n+1: Draw a card. For each opponent, exile up to one target instant or sorcery card from that player's graveyard and put a page counter on it.\n\u22123: You may cast a spell from among cards in exile with page counters on them without paying its mana cost.\nTasha, the Witch Queen can be your commander.",
             "colours": [
@@ -11427,7 +11427,7 @@
         },
         {
             "id": "28243440-30c8-512f-91fa-db25c7775b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2255d1e4-f387-4187-8c10-7d0009f6ec79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2255d1e4-f387-4187-8c10-7d0009f6ec79.jpg?1",
             "name": "Thrakkus the Butcher",
             "text": "Trample\nWhenever Thrakkus the Butcher attacks, double the power of each Dragon you control until end of turn.",
             "colours": [
@@ -11469,7 +11469,7 @@
         },
         {
             "id": "1a23c5b1-233b-5875-9e39-77c94484e96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e51138-9745-465d-84dd-27605f8a2264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e51138-9745-465d-84dd-27605f8a2264.jpg?1",
             "name": "Zevlor, Elturel Exile",
             "text": "Haste\n{2}, {T}: When you next cast an instant or sorcery spell that targets a single opponent or a single permanent an opponent controls this turn, for each other opponent, choose that player or a permanent they control, copy that spell, and the copy targets the chosen player or permanent.",
             "colours": [
@@ -11513,7 +11513,7 @@
         },
         {
             "id": "8dc68bf3-47e9-547d-b5b1-2712e94224dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ff4cb8-a0e0-4527-a77d-03394065ffe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ff4cb8-a0e0-4527-a77d-03394065ffe0.jpg?1",
             "name": "Arcane Encyclopedia",
             "text": "{3}, {T}: Draw a card.",
             "colours": [],
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "7710df94-7399-5c1d-bed7-8b14d9cba963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b245a5b-5a99-4d22-99ef-3f5bf49c3262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b245a5b-5a99-4d22-99ef-3f5bf49c3262.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -11569,7 +11569,7 @@
         },
         {
             "id": "e65945c6-69bd-5a99-92ac-8098385ce3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f4b4f-4f48-4031-b62a-91a0d6716ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f4b4f-4f48-4031-b62a-91a0d6716ddd.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -11597,7 +11597,7 @@
         },
         {
             "id": "82066678-8c6e-512c-8c1b-f60002ba5c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a55efe-a870-4cd7-b22b-37c917065653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a55efe-a870-4cd7-b22b-37c917065653.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -11629,7 +11629,7 @@
         },
         {
             "id": "64abd632-6566-5173-93e0-810de62ba5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3367f8-5f5a-4205-909a-247b92a9c082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3367f8-5f5a-4205-909a-247b92a9c082.jpg?1",
             "name": "Blade of Selves",
             "text": "Equipped creature has myriad. (Whenever it attacks, for each opponent other than defending player, you may create a token that's a copy of that creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)\nEquip {4}",
             "colours": [],
@@ -11661,7 +11661,7 @@
         },
         {
             "id": "3e59ac89-490e-51bd-b725-7e003a8acb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cfd2c0-2110-47f1-809e-487b9b0a1043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cfd2c0-2110-47f1-809e-487b9b0a1043.jpg?1",
             "name": "Bronze Walrus",
             "text": "When Bronze Walrus enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{T}: Add one mana of any color.",
             "colours": [],
@@ -11692,7 +11692,7 @@
         },
         {
             "id": "49396d26-86fe-5189-8d1f-4ce48ab4150b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c3f711-7191-4621-b36e-6c1e281216e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c3f711-7191-4621-b36e-6c1e281216e2.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "53455dfe-459c-5030-9f6e-f2d919d26820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba581225-0966-4ff0-be04-1ad11f37937f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba581225-0966-4ff0-be04-1ad11f37937f.jpg?1",
             "name": "Campfire",
             "text": "{1}, {T}: You gain 2 life.\n{2}, {T}, Exile Campfire: Put all commanders you own from the command zone and from your graveyard into your hand. Then shuffle your graveyard into your library.",
             "colours": [],
@@ -11751,7 +11751,7 @@
         },
         {
             "id": "89139d12-93d0-5248-80cb-5ae9b4610348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0475c79-bc7f-4de8-a020-226bc658d303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0475c79-bc7f-4de8-a020-226bc658d303.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "c5e6fc51-05f3-559b-aa10-c87fbb8daed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a950d8be-dcf7-4253-a3cc-c040ba632355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a950d8be-dcf7-4253-a3cc-c040ba632355.jpg?1",
             "name": "Chardalyn Dragon",
             "text": "Flying",
             "colours": [],
@@ -11814,7 +11814,7 @@
         },
         {
             "id": "da59f561-53fb-580a-acc9-485f9e10cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f508a65-ff32-480a-b9c6-075074d0c3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f508a65-ff32-480a-b9c6-075074d0c3c3.jpg?1",
             "name": "Cloak of the Bat",
             "text": "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11846,7 +11846,7 @@
         },
         {
             "id": "aa033eca-ac9d-59c6-a398-f2c8097d6008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbb37d7-7053-4b1f-b899-91695f88f7e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbb37d7-7053-4b1f-b899-91695f88f7e0.jpg?1",
             "name": "Clockwork Fox",
             "text": "When Clockwork Fox leaves the battlefield, you draw two cards and each opponent draws a card.",
             "colours": [],
@@ -11877,7 +11877,7 @@
         },
         {
             "id": "9e8adabe-f191-59a4-a8c8-6c7b5d94973a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bbc36-58ea-44c4-a857-75a3aff058f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518bbc36-58ea-44c4-a857-75a3aff058f5.jpg?1",
             "name": "Decanter of Endless Water",
             "text": "You have no maximum hand size.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -11907,7 +11907,7 @@
         },
         {
             "id": "921b22ac-5021-5355-a3f6-875349cb425b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e29bae1-0643-4781-9edc-50a8e6d1a3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e29bae1-0643-4781-9edc-50a8e6d1a3a1.jpg?1",
             "name": "Dire Mimic",
             "text": "Flash\n{T}, Sacrifice Dire Mimic: Add one mana of any color.\n{3}: Dire Mimic becomes a Shapeshifter artifact creature with base power and toughness 5/5 until end of turn.",
             "colours": [],
@@ -11937,7 +11937,7 @@
         },
         {
             "id": "46d5290a-27b5-508b-830a-3e21239f92ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9803002e-08f8-4533-b645-7e54d18bbc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9803002e-08f8-4533-b645-7e54d18bbc54.jpg?1",
             "name": "Drillworks Mole",
             "text": "{2}, {T}: Put a +1/+1 counter on Drillworks Mole and a +1/+1 counter on up to one target commander creature you control.",
             "colours": [],
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "4314997f-29ac-5d05-94aa-cbe658c0b61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74e656-480a-4c1b-963d-1b207075c27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74e656-480a-4c1b-963d-1b207075c27f.jpg?1",
             "name": "Dungeoneer's Pack",
             "text": "Dungeoneer's Pack enters the battlefield tapped.\n{2}, {T}, Sacrifice Dungeoneer's Pack: You take the initiative, gain 3 life, draw a card, and create a Treasure token. Activate only as a sorcery. (A Treasure token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -11996,7 +11996,7 @@
         },
         {
             "id": "3eb6a40c-e9c9-5bcb-a9f1-2b2b67422041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561484-438b-4ce9-911e-97078ac5b0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561484-438b-4ce9-911e-97078ac5b0fa.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -12028,7 +12028,7 @@
         },
         {
             "id": "44122479-67d1-5a15-9c86-2a52a5472361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bf7702-c97d-4b88-b815-769c4906e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bf7702-c97d-4b88-b815-769c4906e014.jpg?1",
             "name": "Fraying Line",
             "text": "When Fraying Line enters the battlefield, put a rope counter on target creature you control.\nAt the beginning of each player's upkeep, that player may pay {2}. If they do, they put a rope counter on a creature they control. Otherwise, exile Fraying Line and each creature without a rope counter on it, then remove all rope counters from all creatures.",
             "colours": [],
@@ -12058,7 +12058,7 @@
         },
         {
             "id": "2fed6927-fc89-5dc6-a5ba-026cb3cb594c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2318e7-250d-4a30-8b45-55d4c1db68e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2318e7-250d-4a30-8b45-55d4c1db68e9.jpg?1",
             "name": "Gate Colossus",
             "text": "This spell costs {1} less to cast for each Gate you control.\nGate Colossus can't be blocked by creatures with power 2 or less.\nWhenever a Gate enters the battlefield under your control, you may put Gate Colossus from your graveyard on top of your library.",
             "colours": [],
@@ -12089,7 +12089,7 @@
         },
         {
             "id": "36757f1a-3132-5010-947c-e33ab03987ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdc8f60-fa67-4dd6-94af-8250eb7f7141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdc8f60-fa67-4dd6-94af-8250eb7f7141.jpg?1",
             "name": "Geode Golem",
             "text": "Trample\nWhenever Geode Golem deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost. (You still pay any additional costs.)",
             "colours": [],
@@ -12120,7 +12120,7 @@
         },
         {
             "id": "101833ff-36e9-5570-87bd-6e342f03fff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633151-d704-42a4-b1c6-66446bf48bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633151-d704-42a4-b1c6-66446bf48bee.jpg?1",
             "name": "Iron Mastiff",
             "text": "Whenever Iron Mastiff attacks, roll a d20 for each player being attacked and ignore all but the highest roll.\n1\u20139 | Iron Mastiff deals damage equal to its power to you.\n10\u201319 | Iron Mastiff deals damage equal to its power to defending player.\n20 | Iron Mastiff deals damage equal to its power to each opponent.",
             "colours": [],
@@ -12151,7 +12151,7 @@
         },
         {
             "id": "3140c896-09f0-521b-80fd-6f13345ef412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43d21a-4400-4770-95a9-ce074ee68232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43d21a-4400-4770-95a9-ce074ee68232.jpg?1",
             "name": "Lantern of Revealing",
             "text": "{T}: Add one mana of any color.\n{4}, {T}: Look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you don't put the card onto the battlefield, you may put it on the bottom of your library.",
             "colours": [],
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "5be13068-c9e5-5c33-af84-e39518641b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a15cd-a359-48c9-9280-ce139f1fb061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a15cd-a359-48c9-9280-ce139f1fb061.jpg?1",
             "name": "Manifold Key",
             "text": "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -12207,7 +12207,7 @@
         },
         {
             "id": "d5514901-4a08-5dbc-a75a-3aea3b5e2a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0930f71c-c3c8-4bdd-8468-6a61349cc8ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0930f71c-c3c8-4bdd-8468-6a61349cc8ca.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "866ce491-3f71-5034-b3ff-5ef871cdb1d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e46fc-1ebc-4151-bfd3-333fa6b77816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e46fc-1ebc-4151-bfd3-333fa6b77816.jpg?1",
             "name": "Marching Duodrone",
             "text": "Whenever Marching Duodrone attacks, each player creates a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12272,7 +12272,7 @@
         },
         {
             "id": "f83c8b23-049d-5494-9e6b-dda57de0e994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce857f-2870-4dc9-a763-9ce710e4b375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce857f-2870-4dc9-a763-9ce710e4b375.jpg?1",
             "name": "Marut",
             "text": "Trample\nWhen Marut enters the battlefield, if mana from a Treasure was spent to cast it, create a Treasure token for each mana from a Treasure spent to cast it. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12303,7 +12303,7 @@
         },
         {
             "id": "8d2b0b35-b12f-5673-abdf-518942bc0ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e17f8c-c705-43ab-ae1a-cde48aceca0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e17f8c-c705-43ab-ae1a-cde48aceca0a.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -12334,7 +12334,7 @@
         },
         {
             "id": "8f84ff81-4006-569c-9018-ae2fc3ea29cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257f12c2-db58-413f-9896-6e556bd9c0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257f12c2-db58-413f-9896-6e556bd9c0d9.jpg?1",
             "name": "Mighty Servant of Leuk-o",
             "text": "Trample\nWard\u2014\nDiscard a card.\nWhenever Mighty Servant of Leuk-o becomes crewed for the first time each turn, if it was crewed by exactly two creatures, it gains \"Whenever this creature deals combat damage to a player, draw two cards\" until end of turn.\nCrew 4",
             "colours": [],
@@ -12366,7 +12366,7 @@
         },
         {
             "id": "942054f5-de20-582f-bad6-dd4b48aee4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1969ddc0-ee6c-4c3d-a9dd-7f1c491609be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1969ddc0-ee6c-4c3d-a9dd-7f1c491609be.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -12394,7 +12394,7 @@
         },
         {
             "id": "ef12e1e4-78e0-5356-9067-19fd575c3340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0937a60-887b-46d0-b573-099626d57bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0937a60-887b-46d0-b573-099626d57bcf.jpg?1",
             "name": "Mirror of Life Trapping",
             "text": "Whenever a creature enters the battlefield, if it was cast, exile it, then return all other permanent cards exiled with Mirror of Life Trapping to the battlefield under their owners' control.",
             "colours": [],
@@ -12424,7 +12424,7 @@
         },
         {
             "id": "51189d62-339b-57b4-b975-53b6eed2cf0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcae3a-d58c-4832-8280-3f65b5dfd853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcae3a-d58c-4832-8280-3f65b5dfd853.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "e5318909-f30c-565c-bdf1-a2462265abce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e2f75e-75f3-4255-969f-0eab32f7bd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e2f75e-75f3-4255-969f-0eab32f7bd1e.jpg?1",
             "name": "Nautiloid Ship",
             "text": "Flying\nWhen Nautiloid Ship enters the battlefield, exile target player's graveyard.\nWhenever Nautiloid Ship deals combat damage to a player, you may put a creature card exiled with Nautiloid Ship onto the battlefield under your control.\nCrew 3",
             "colours": [],
@@ -12488,7 +12488,7 @@
         },
         {
             "id": "1eabe002-f573-52a0-bd39-c3a6dac5012a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512a77e-2435-4695-9408-df8e17dd1fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512a77e-2435-4695-9408-df8e17dd1fbd.jpg?1",
             "name": "Navigation Orb",
             "text": "{2}, {T}, Sacrifice Navigation Orb: Search your library for up to two basic land cards and/or Gate cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [],
@@ -12516,7 +12516,7 @@
         },
         {
             "id": "c1ecbbe2-2cfd-5e0d-b239-43ed95b6b29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34282856-c0f1-4845-bfc8-537466c6a5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34282856-c0f1-4845-bfc8-537466c6a5bb.jpg?1",
             "name": "Nimblewright Schematic",
             "text": "When Nimblewright Schematic enters the battlefield or is put into a graveyard from the battlefield, create a 1/1 colorless Construct artifact creature token.",
             "colours": [],
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "a48a127b-20cc-5751-8750-bcb2b8cc0e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be533558-3b16-4df0-a0ca-faa1ebf2e641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be533558-3b16-4df0-a0ca-faa1ebf2e641.jpg?1",
             "name": "Noble's Purse",
             "text": "Noble's Purse enters the battlefield tapped and with three coin counters on it.\n{T}, Remove a coin counter from Noble's Purse: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12572,7 +12572,7 @@
         },
         {
             "id": "e0768e86-f3f9-56c5-ae1e-a54fd94f3628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f920f0-4dfc-477b-af7e-a17dfc9ba455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f920f0-4dfc-477b-af7e-a17dfc9ba455.jpg?1",
             "name": "Patriar's Seal",
             "text": "{T}: Add one mana of any color.\n{1}, {T}: Untap target legendary creature you control.",
             "colours": [],
@@ -12600,7 +12600,7 @@
         },
         {
             "id": "45d603e2-b224-5cf6-979c-e2c6a1c078cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32161267-e12b-454f-a7e1-94e078566ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32161267-e12b-454f-a7e1-94e078566ffa.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "bfb4ec15-5a21-5a64-b074-278d11061802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a49829-c354-4823-8cc1-a159fc46c0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a49829-c354-4823-8cc1-a159fc46c0d7.jpg?1",
             "name": "Prized Statue",
             "text": "When Prized Statue enters the battlefield or is put into a graveyard from the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -12659,7 +12659,7 @@
         },
         {
             "id": "343a24fe-4ed9-52a1-b4e6-820f91d3bc02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b837b21-9165-4965-a7b5-c59811647951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b837b21-9165-4965-a7b5-c59811647951.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -12687,7 +12687,7 @@
         },
         {
             "id": "a2ed009a-cef6-5427-998d-e30a38d863e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73d1cb0-d0dc-4f2a-9cf2-954d5889dd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73d1cb0-d0dc-4f2a-9cf2-954d5889dd08.jpg?1",
             "name": "Rug of Smothering",
             "text": "Flying\nWhenever a player casts a spell, they lose 1 life for each spell they've cast this turn.",
             "colours": [],
@@ -12718,7 +12718,7 @@
         },
         {
             "id": "42d54111-0701-5f4c-9317-6f1ec12ed4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47abfb2-9bcf-485c-9bd4-2c09b714eb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47abfb2-9bcf-485c-9bd4-2c09b714eb32.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -12750,7 +12750,7 @@
         },
         {
             "id": "f986a7d8-4e97-5ffe-a18c-4e186c30c324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99e6e1-3b88-4d2f-bc5d-70439585a063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99e6e1-3b88-4d2f-bc5d-70439585a063.jpg?1",
             "name": "Stonespeaker Crystal",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Stonespeaker Crystal: Exile any number of target players' graveyards. Draw a card.",
             "colours": [],
@@ -12780,7 +12780,7 @@
         },
         {
             "id": "e4536570-e3dc-58dd-8283-aaaa6f8fb711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c23cde-e1c0-4cdf-ae59-18d64db518d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c23cde-e1c0-4cdf-ae59-18d64db518d4.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control.)\nEquip {1}",
             "colours": [],
@@ -12810,7 +12810,7 @@
         },
         {
             "id": "ba09fff6-1806-5c4e-909e-ae6b863c90b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f76ae-e93b-4ca1-ac62-753707f6319e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4f76ae-e93b-4ca1-ac62-753707f6319e.jpg?1",
             "name": "Trailblazer's Torch",
             "text": "When Trailblazer's Torch enters the battlefield, you take the initiative.\nWhenever equipped creature becomes blocked, it deals 2 damage to each creature blocking it.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -12840,7 +12840,7 @@
         },
         {
             "id": "53f30027-a7da-57f6-8f7d-7715bf0b1f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68ab416-3394-4cb6-bfc6-33e62964dd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68ab416-3394-4cb6-bfc6-33e62964dd1c.jpg?1",
             "name": "Treasure Keeper",
             "text": "When Treasure Keeper dies, reveal cards from the top of your library until you reveal a nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.",
             "colours": [],
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "b6fd7400-b8c2-58f3-9270-447c65e8fa67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e142122f-3a04-436e-a958-dc2224b4fc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e142122f-3a04-436e-a958-dc2224b4fc6d.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -12899,7 +12899,7 @@
         },
         {
             "id": "967feb0f-473a-5069-9a9e-b98118fd2b94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c477fb1a-5aac-4722-80d8-7570a8b09e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c477fb1a-5aac-4722-80d8-7570a8b09e44.jpg?1",
             "name": "Vexing Puzzlebox",
             "text": "Whenever you roll one or more dice, put a number of charge counters on Vexing Puzzlebox equal to the result.\n{T}: Add one mana of any color. Roll a d20.\n{T}, Remove 100 charge counters from Vexing Puzzlebox: Search your library for an artifact card, put that card onto the battlefield, then shuffle.",
             "colours": [],
@@ -12929,7 +12929,7 @@
         },
         {
             "id": "338911db-75ba-53cd-97db-99e259c15ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b865d247-fe0a-4583-b088-ae900ffe521b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b865d247-fe0a-4583-b088-ae900ffe521b.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -12957,7 +12957,7 @@
         },
         {
             "id": "7c7e4dd6-cff8-54d5-b154-fae5305a5c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2436aa14-9200-4295-8041-b682cf3c4216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2436aa14-9200-4295-8041-b682cf3c4216.jpg?1",
             "name": "Baldur's Gate",
             "text": "{T}: Add {C}.\n{2}, {T}: Add X mana of any one color, where X is the number of other Gates you control.",
             "colours": [],
@@ -12991,7 +12991,7 @@
         },
         {
             "id": "f36e1636-5351-5e49-956b-face4d7a1d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a306025-d429-4006-b7ed-bdb287e83f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a306025-d429-4006-b7ed-bdb287e83f57.jpg?1",
             "name": "Basilisk Gate",
             "text": "{T}: Add {C}.\n{2}, {T}: Target creature gets +X/+X until end of turn, where X is the number of Gates you control. Activate only as a sorcery.",
             "colours": [],
@@ -13021,7 +13021,7 @@
         },
         {
             "id": "068a80ec-e8e1-5400-9b6b-efd632f98686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ceb589-c741-44ac-98c8-3d997953ee61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ceb589-c741-44ac-98c8-3d997953ee61.jpg?1",
             "name": "Black Dragon Gate",
             "text": "Black Dragon Gate enters the battlefield tapped.\nAs Black Dragon Gate enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -13053,7 +13053,7 @@
         },
         {
             "id": "9fbf898a-2da6-50a3-9287-fbdef18ded25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5125a8d8-344d-4419-b37a-ddf343493c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5125a8d8-344d-4419-b37a-ddf343493c5f.jpg?1",
             "name": "Bountiful Promenade",
             "text": "Bountiful Promenade enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -13086,7 +13086,7 @@
         },
         {
             "id": "eb7a79c3-3940-5954-af28-c941f404c33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e6f002-9a10-49a1-8604-2b8ff57732dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e6f002-9a10-49a1-8604-2b8ff57732dd.jpg?1",
             "name": "Citadel Gate",
             "text": "Citadel Gate enters the battlefield tapped.\nAs Citadel Gate enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -13118,7 +13118,7 @@
         },
         {
             "id": "e9a0e341-2650-5558-b5dd-f19febe3b331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557470dc-c594-4b26-81b9-356bedb0c215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557470dc-c594-4b26-81b9-356bedb0c215.jpg?1",
             "name": "Cliffgate",
             "text": "Cliffgate enters the battlefield tapped.\nAs Cliffgate enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -13150,7 +13150,7 @@
         },
         {
             "id": "2cd4fbb8-4382-59aa-a513-78384b4f400f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eafe88e-ab38-442c-b147-bb01cc81178d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eafe88e-ab38-442c-b147-bb01cc81178d.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "d513feaa-fc49-5793-a35d-c38ccae8f41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc8841a-0f6e-4078-a0b9-a4bda642182e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc8841a-0f6e-4078-a0b9-a4bda642182e.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -13206,7 +13206,7 @@
         },
         {
             "id": "4f40e20d-0c6c-529d-a576-98bb8a422c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746672d9-7c6b-415e-9f34-3cc3ac557008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746672d9-7c6b-415e-9f34-3cc3ac557008.jpg?1",
             "name": "Gond Gate",
             "text": "Gates you control enter the battlefield untapped.\n{T}: Add {C}.\n{T}: Add one mana of any color that a Gate you control could produce.",
             "colours": [],
@@ -13236,7 +13236,7 @@
         },
         {
             "id": "3bc0d4d3-c159-5a4d-a975-44918739253f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68489d65-1978-48b1-a903-2ef38c583239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68489d65-1978-48b1-a903-2ef38c583239.jpg?1",
             "name": "Heap Gate",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{1}, {T}, Tap an untapped Gate you control: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -13266,7 +13266,7 @@
         },
         {
             "id": "f4a7c548-ed29-5ac6-b85c-15eb4f724e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc5fc38-4054-4663-9061-df5455788c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc5fc38-4054-4663-9061-df5455788c4a.jpg?1",
             "name": "Luxury Suite",
             "text": "Luxury Suite enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -13299,7 +13299,7 @@
         },
         {
             "id": "d44813aa-8337-5737-a9db-b761a96c0dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793d4978-9e00-453d-8dc2-6d51ad6c26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793d4978-9e00-453d-8dc2-6d51ad6c26b7.jpg?1",
             "name": "Manor Gate",
             "text": "Manor Gate enters the battlefield tapped.\nAs Manor Gate enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -13331,7 +13331,7 @@
         },
         {
             "id": "1df5c3cc-2b34-5e67-90d2-8917199cca9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e40927-dd87-42ed-b805-0ae8ba81f5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e40927-dd87-42ed-b805-0ae8ba81f5fb.jpg?1",
             "name": "Morphic Pool",
             "text": "Morphic Pool enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -13364,7 +13364,7 @@
         },
         {
             "id": "a8d6eea3-57ee-56dc-bb2a-1bc063e4696e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1b3f5-473d-45ca-be0d-e67e77ba30ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1b3f5-473d-45ca-be0d-e67e77ba30ce.jpg?1",
             "name": "Reflecting Pool",
             "text": "{T}: Add one mana of any type that a land you control could produce.",
             "colours": [],
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "1d01a42a-812e-5c47-a5ef-1a54de71b068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f31e1-bcaf-4316-a2de-49e2cf7566ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f31e1-bcaf-4316-a2de-49e2cf7566ec.jpg?1",
             "name": "Sea Gate",
             "text": "Sea Gate enters the battlefield tapped.\nAs Sea Gate enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "9ead4c9d-27e2-5638-abea-c770532af319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fb722f-40af-4bd1-b660-e8186b98f233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fb722f-40af-4bd1-b660-e8186b98f233.jpg?1",
             "name": "Sea of Clouds",
             "text": "Sea of Clouds enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -13459,7 +13459,7 @@
         },
         {
             "id": "c0ab1d25-1263-5b55-8c2b-d92b96c014de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72aed540-7833-4442-90a9-aa5468014c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72aed540-7833-4442-90a9-aa5468014c65.jpg?1",
             "name": "Spire Garden",
             "text": "Spire Garden enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -13492,7 +13492,7 @@
         },
         {
             "id": "350929d4-a62a-5d53-921f-3f0d42f70fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06700514-b19c-4fc8-beb1-2c801f320b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06700514-b19c-4fc8-beb1-2c801f320b25.jpg?1",
             "name": "Elminster",
             "text": "Whenever you scry, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of cards looked at while scrying this way.\n+2: Draw a card, then scry 2.\n\u22123: Exile the top card of your library. Create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to that card's mana value.\nElminster can be your commander.",
             "colours": [
@@ -13532,7 +13532,7 @@
         },
         {
             "id": "5228c703-170a-53e4-9013-a9edcd5074b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e308b016-5611-450c-a2ea-906647d1b7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e308b016-5611-450c-a2ea-906647d1b7e3.jpg?1",
             "name": "Minsc & Boo, Timeless Heroes",
             "text": "When Minsc & Boo, Timeless Heroes enters the battlefield and at the beginning of your upkeep, you may create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n+1: Put three +1/+1 counters on up to one target creature with trample or haste.\n\u22122: Sacrifice a creature. When you do, Minsc & Boo, Timeless Heroes deals X damage to any target, where X is that creature's power. If the sacrificed creature was a Hamster, draw X cards.\nMinsc & Boo, Timeless Heroes can be your commander.",
             "colours": [
@@ -13572,7 +13572,7 @@
         },
         {
             "id": "0599538e-1e54-5765-900f-50505149d509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce387e9c-2d0e-4314-ac8d-4b7c93286fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce387e9c-2d0e-4314-ac8d-4b7c93286fb2.jpg?1",
             "name": "Tasha, the Witch Queen",
             "text": "Whenever you cast a spell you don't own, create a 3/3 black Demon creature token.\n+1: Draw a card. For each opponent, exile up to one target instant or sorcery card from that player's graveyard and put a page counter on it.\n\u22123: You may cast a spell from among cards in exile with page counters on them without paying its mana cost.\nTasha, the Witch Queen can be your commander.",
             "colours": [
@@ -13612,7 +13612,7 @@
         },
         {
             "id": "3118aa84-4308-59d2-995f-40ef202bdec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ae6ea-fc0b-4ff0-92bc-4a20c7ba7e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ae6ea-fc0b-4ff0-92bc-4a20c7ba7e38.jpg?1",
             "name": "Ancient Gold Dragon",
             "text": "Flying\nWhenever Ancient Gold Dragon deals combat damage to a player, roll a d20. You create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to the result.",
             "colours": [
@@ -13650,7 +13650,7 @@
         },
         {
             "id": "a189db9a-fba5-5b38-8462-94a54ded2654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34761bda-03f9-4607-bb01-10b1598509f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34761bda-03f9-4607-bb01-10b1598509f7.jpg?1",
             "name": "Ancient Silver Dragon",
             "text": "Flying\nWhenever Ancient Silver Dragon deals combat damage to a player, roll a d20. Draw cards equal to the result. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "5db10c51-7ca6-5847-863c-53793cea171e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631a9966-b5d2-4696-a2f1-2d56fccad9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/631a9966-b5d2-4696-a2f1-2d56fccad9b2.jpg?1",
             "name": "Ancient Brass Dragon",
             "text": "Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.",
             "colours": [
@@ -13726,7 +13726,7 @@
         },
         {
             "id": "b54df50e-f837-554e-8d84-f062be364763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ac08c-11ce-4e8a-8ea8-c18cfc745ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ac08c-11ce-4e8a-8ea8-c18cfc745ac7.jpg?1",
             "name": "Ancient Copper Dragon",
             "text": "Flying\nWhenever Ancient Copper Dragon deals combat damage to a player, roll a d20. You create a number of Treasure tokens equal to the result.",
             "colours": [
@@ -13764,7 +13764,7 @@
         },
         {
             "id": "7b06d589-d4ed-5521-bdb5-009cc54f619c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b957a1f-6d26-47bb-84ba-81acc01a8dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b957a1f-6d26-47bb-84ba-81acc01a8dae.jpg?1",
             "name": "Ancient Bronze Dragon",
             "text": "Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.",
             "colours": [
@@ -13802,7 +13802,7 @@
         },
         {
             "id": "2da6f6d0-af3e-5d00-bc70-e73db9869e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd40caa-0cbb-426d-a988-1d826988e707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd40caa-0cbb-426d-a988-1d826988e707.jpg?1",
             "name": "Battle Angels of Tyr",
             "text": "Flying, myriad\nWhenever Battle Angels of Tyr deals combat damage to a player, draw a card if that player has more cards in hand than each other player. Then you create a Treasure token if that player controls more lands than each other player. Then you gain 3 life if that player has more life than each other player.",
             "colours": [
@@ -13839,7 +13839,7 @@
         },
         {
             "id": "3bf1732e-b93b-5110-a074-800e44b63333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06408b0-3ae9-46f9-ae6f-cd50c88147bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06408b0-3ae9-46f9-ae6f-cd50c88147bc.jpg?1",
             "name": "Legion Loyalty",
             "text": "Creatures you control have myriad.",
             "colours": [
@@ -13873,7 +13873,7 @@
         },
         {
             "id": "742e363d-b6f4-5b02-952b-9d2c0e72a493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763fde16-5de2-4541-90f1-a6efee920e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763fde16-5de2-4541-90f1-a6efee920e28.jpg?1",
             "name": "Bramble Sovereign",
             "text": "Whenever another nontoken creature enters the battlefield, you may pay {1}{G}. If you do, that creature's controller creates a token that's a copy of that creature.",
             "colours": [
@@ -13909,7 +13909,7 @@
         },
         {
             "id": "7d73dadc-636f-5f2d-9f97-86e94e53a840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91758c02-b2d1-4821-a29f-0154a611a904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91758c02-b2d1-4821-a29f-0154a611a904.jpg?1",
             "name": "Nautiloid Ship",
             "text": "Flying\nWhen Nautiloid Ship enters the battlefield, exile target player's graveyard.\nWhenever Nautiloid Ship deals combat damage to a player, you may put a creature card exiled with Nautiloid Ship onto the battlefield under your control.\nCrew 3",
             "colours": [],
@@ -13941,7 +13941,7 @@
         },
         {
             "id": "7fc5694b-b161-54d1-8c49-06f9d86f5892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49084bff-baef-4b73-ae5b-325bd6a81958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49084bff-baef-4b73-ae5b-325bd6a81958.jpg?1",
             "name": "Vexing Puzzlebox",
             "text": "Whenever you roll one or more dice, put a number of charge counters on Vexing Puzzlebox equal to the result.\n{T}: Add one mana of any color. Roll a d20.\n{T}, Remove 100 charge counters from Vexing Puzzlebox: Search your library for an artifact card, put that card onto the battlefield, then shuffle.",
             "colours": [],
@@ -13971,7 +13971,7 @@
         },
         {
             "id": "bb0f7485-1506-558e-a40f-95dbffd890b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4857125b-bd0f-4f09-9d6c-56544834a359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4857125b-bd0f-4f09-9d6c-56544834a359.jpg?1",
             "name": "Abdel Adrian, Gorion's Ward",
             "text": "When Abdel Adrian, Gorion's Ward enters the battlefield, exile any number of other nonland permanents you control until Abdel Adrian leaves the battlefield. Create a 1/1 white Soldier creature token for each permanent exiled this way.\nChoose a Background",
             "colours": [
@@ -14011,7 +14011,7 @@
         },
         {
             "id": "d7e41904-d19d-5b27-9dea-a89d62351397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f53d47-fd5c-41de-8d7a-490c1b529f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f53d47-fd5c-41de-8d7a-490c1b529f4f.jpg?1",
             "name": "Ancient Gold Dragon",
             "text": "Flying\nWhenever Ancient Gold Dragon deals combat damage to a player, roll a d20. You create a number of 1/1 blue Faerie Dragon creature tokens with flying equal to the result.",
             "colours": [
@@ -14049,7 +14049,7 @@
         },
         {
             "id": "aac1a6bf-1076-5407-9fc2-f0481043bb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249bc870-e945-466c-81cd-8b9e9b7ac4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249bc870-e945-466c-81cd-8b9e9b7ac4ac.jpg?1",
             "name": "Ellyn Harbreeze, Busybody",
             "text": "{T}: Look at the top X cards of your library, where X is the number of tokens you created this turn. Put one of those cards into your hand and the rest on the bottom of your library in a random order.\nChoose a Background",
             "colours": [
@@ -14089,7 +14089,7 @@
         },
         {
             "id": "7b371c99-bc96-5828-b67d-a81b7bb4f5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44927f22-0017-4c19-bd0a-41f09c0ce19f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44927f22-0017-4c19-bd0a-41f09c0ce19f.jpg?1",
             "name": "Lae'zel, Vlaakith's Champion",
             "text": "If you would put one or more counters on a creature or planeswalker you control or on yourself, put that many plus one of each of those kinds of counters on that permanent or player instead.\nChoose a Background",
             "colours": [
@@ -14129,7 +14129,7 @@
         },
         {
             "id": "4ae70a29-24b5-5a82-9323-f16e17d3feca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0447c-9077-4d63-9d5e-f012f912e862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0447c-9077-4d63-9d5e-f012f912e862.jpg?1",
             "name": "Lulu, Loyal Hollyphant",
             "text": "Flying\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on each tapped creature you control, then untap them.\nChoose a Background",
             "colours": [
@@ -14169,7 +14169,7 @@
         },
         {
             "id": "83096478-032c-5a81-b219-5115a2989811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b634d96-62ae-46d2-b77f-7148837346b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b634d96-62ae-46d2-b77f-7148837346b2.jpg?1",
             "name": "Rasaad yn Bashir",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\nWhenever Rasaad yn Bashir attacks, if you have the initiative, double the toughness of each creature you control until end of turn.\nChoose a Background",
             "colours": [
@@ -14209,7 +14209,7 @@
         },
         {
             "id": "a71e50ee-7d5c-5665-a46e-574cc3c5f5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7777a4f-0fc6-4231-b2a4-503f3820c0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7777a4f-0fc6-4231-b2a4-503f3820c0f6.jpg?1",
             "name": "Alora, Merry Thief",
             "text": "Whenever you attack, up to one target attacking creature can't be blocked this turn. Return that creature to its owner's hand at the beginning of the next end step.\nChoose a Background",
             "colours": [
@@ -14249,7 +14249,7 @@
         },
         {
             "id": "0c118423-e082-52fe-a23a-0ada212c49ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d9a4d3-e1d2-42ae-bca4-02bc2cf69c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d9a4d3-e1d2-42ae-bca4-02bc2cf69c9d.jpg?1",
             "name": "Ancient Silver Dragon",
             "text": "Flying\nWhenever Ancient Silver Dragon deals combat damage to a player, roll a d20. Draw cards equal to the result. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -14287,7 +14287,7 @@
         },
         {
             "id": "22cef728-5985-5903-ab3c-6b9a3cb1ad4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cd3224-c392-4c33-aa7b-d2e7041c0d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cd3224-c392-4c33-aa7b-d2e7041c0d89.jpg?1",
             "name": "Gale, Waterdeep Prodigy",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast up to one target card of the other type from your graveyard. If a spell cast from your graveyard this way would be put into your graveyard, exile it instead.\nChoose a Background",
             "colours": [
@@ -14327,7 +14327,7 @@
         },
         {
             "id": "1e193e98-9e4c-52f5-ac05-a3691c821951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753e654-f02c-46eb-b5f5-cba1a99a0253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753e654-f02c-46eb-b5f5-cba1a99a0253.jpg?1",
             "name": "Goggles of Night",
             "text": "Whenever equipped creature deals combat damage to a player, scry 1, then draw a card.\nEquip {2}",
             "colours": [
@@ -14363,7 +14363,7 @@
         },
         {
             "id": "ac9de9a8-df53-5269-8788-5ab02cd467dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce62167-bd2c-4192-9ce4-dd19a1080db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce62167-bd2c-4192-9ce4-dd19a1080db6.jpg?1",
             "name": "Imoen, Mystic Trickster",
             "text": "Ward {2}\nAt the beginning of your end step, if you have the initiative, draw a card. Draw another card if you've completed a dungeon.\nChoose a Background",
             "colours": [
@@ -14404,7 +14404,7 @@
         },
         {
             "id": "173a6c95-2459-544d-b685-3daa1eac1032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff38ea-53e4-49e3-bf54-233100107fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff38ea-53e4-49e3-bf54-233100107fee.jpg?1",
             "name": "Renari, Merchant of Marvels",
             "text": "You may cast Dragon spells and artifact spells as though they had flash.\nChoose a Background",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "fec1a995-870d-5ba5-92fd-a830c48a1d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a373d7-43b8-4037-828d-080ecb5c2a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a373d7-43b8-4037-828d-080ecb5c2a08.jpg?1",
             "name": "Vhal, Candlekeep Researcher",
             "text": "Vigilance\n{T}: Add an amount of {C} equal to Vhal, Candlekeep Researcher's toughness. This mana can't be spent to cast spells from your hand.\nChoose a Background",
             "colours": [
@@ -14484,7 +14484,7 @@
         },
         {
             "id": "8005e72f-5513-5b4f-95e7-b9da3f4a970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8772547-79b8-4516-8d75-9b85202d9c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8772547-79b8-4516-8d75-9b85202d9c32.jpg?1",
             "name": "Volo, Itinerant Scholar",
             "text": "When Volo enters the battlefield, create Volo's Journal, a legendary colorless artifact token with hexproof and \"Whenever you cast a creature spell, note one of its creature types that hasn't been noted for this artifact.\"\n{2}, {T}: Draw a card for each creature type noted for target permanent you control named Volo's Journal.\nChoose a Background",
             "colours": [
@@ -14524,7 +14524,7 @@
         },
         {
             "id": "2fa2ff2e-45e9-51ea-8fbe-031eb4755cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d7fcb-e5f0-4438-8d35-8beb4cc015e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d7fcb-e5f0-4438-8d35-8beb4cc015e4.jpg?1",
             "name": "Ancient Brass Dragon",
             "text": "Flying\nWhenever Ancient Brass Dragon deals combat damage to a player, roll a d20. When you do, put any number of target creature cards with total mana value X or less from graveyards onto the battlefield under your control, where X is the result.",
             "colours": [
@@ -14562,7 +14562,7 @@
         },
         {
             "id": "0578af5c-1a9e-58a4-86c3-df5bb5d88afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356440f-6d49-481e-8332-1a675a48a94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356440f-6d49-481e-8332-1a675a48a94e.jpg?1",
             "name": "Safana, Calimport Cutthroat",
             "text": "Menace\nAt the beginning of your end step, if you have the initiative, create a Treasure token. Create three of those tokens instead if you've completed a dungeon.\nChoose a Background",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "20afdf59-9211-50f6-9bdb-9d983d989960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff9756-12cc-4144-a815-a244fbe13b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ff9756-12cc-4144-a815-a244fbe13b72.jpg?1",
             "name": "Sarevok, Deathbringer",
             "text": "At the beginning of each player's end step, if no permanents left the battlefield this turn, that player loses X life, where X is Sarevok's power.\nChoose a Background",
             "colours": [
@@ -14642,7 +14642,7 @@
         },
         {
             "id": "39bf319a-9512-57f0-b7f5-4be66cafdb7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94951251-91a2-4b71-9346-903d400cc28e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94951251-91a2-4b71-9346-903d400cc28e.jpg?1",
             "name": "Shadowheart, Dark Justiciar",
             "text": "{1}{B}, {T}, Sacrifice another creature: Draw X cards, where X is that creature's power.\nChoose a Background",
             "colours": [
@@ -14683,7 +14683,7 @@
         },
         {
             "id": "5b3884ec-42a4-5f16-a604-2b05e0f81588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9af754-e96a-46b5-9c28-3420a447b098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da9af754-e96a-46b5-9c28-3420a447b098.jpg?1",
             "name": "Sivriss, Nightmare Speaker",
             "text": "{T}, Sacrifice another creature or an artifact: For each opponent, you mill a card, then return that card from your graveyard to your hand unless that player pays 3 life.\nChoose a Background",
             "colours": [
@@ -14724,7 +14724,7 @@
         },
         {
             "id": "852835ff-0ab2-507f-835e-695b56331412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99ecf8e-3819-4a14-b2e8-8fcd3fef5846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99ecf8e-3819-4a14-b2e8-8fcd3fef5846.jpg?1",
             "name": "Viconia, Drow Apostate",
             "text": "At the beginning of your upkeep, if there are four or more creature cards in your graveyard, return a creature card at random from your graveyard to your hand.\nChoose a Background",
             "colours": [
@@ -14764,7 +14764,7 @@
         },
         {
             "id": "a882292a-028c-5367-b494-8fb7125ca086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1272ef5-4ceb-4b07-a9af-393113b58ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1272ef5-4ceb-4b07-a9af-393113b58ef4.jpg?1",
             "name": "Amber Gristle O'Maul",
             "text": "Haste\nWhenever Amber Gristle O'Maul attacks, you may discard your hand. If you do, draw a card for each player being attacked.\nChoose a Background",
             "colours": [
@@ -14804,7 +14804,7 @@
         },
         {
             "id": "6a3a2f98-ec89-552c-a179-719b081f001e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12d32a7-60b4-4e49-b279-970b170c1a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12d32a7-60b4-4e49-b279-970b170c1a9c.jpg?1",
             "name": "Ancient Copper Dragon",
             "text": "Flying\nWhenever Ancient Copper Dragon deals combat damage to a player, roll a d20. You create a number of Treasure tokens equal to the result.",
             "colours": [
@@ -14842,7 +14842,7 @@
         },
         {
             "id": "356725cb-a908-5bd9-be49-e6941eeaebb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a97aae-d8a7-4451-a47e-ea878dea6e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a97aae-d8a7-4451-a47e-ea878dea6e4c.jpg?1",
             "name": "Fireball",
             "text": "This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "f5b22c63-6587-535b-84be-ce8585c3bd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3347e3-df90-465d-9346-77d3b4fead10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3347e3-df90-465d-9346-77d3b4fead10.jpg?1",
             "name": "Ganax, Astral Hunter",
             "text": "Flying\nWhenever Ganax, Astral Hunter or another Dragon enters the battlefield under your control, create a Treasure token.\nChoose a Background",
             "colours": [
@@ -14915,7 +14915,7 @@
         },
         {
             "id": "07e3082c-07ca-5e55-b6c6-319a4b3f20ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6988467-8552-4ab9-9472-c5c536ed7bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6988467-8552-4ab9-9472-c5c536ed7bae.jpg?1",
             "name": "Gut, True Soul Zealot",
             "text": "Whenever you attack, you may sacrifice another creature or an artifact. If you do, create a 4/1 black Skeleton creature token with menace that's tapped and attacking.\nChoose a Background",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "df1cbea9-2fa3-55fa-a673-1d407ed3d266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b123fa-c232-4bb4-ba9d-2cde4a0eef99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b123fa-c232-4bb4-ba9d-2cde4a0eef99.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "Whenever you attack, if it's the first combat phase of the turn, untap all attacking creatures. They gain first strike until end of turn. After this phase, there is an additional combat phase.\nChoose a Background",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "578de53b-151a-5082-9c0a-81409d544162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69f668b-cf28-495a-bbe1-24e9d0089fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69f668b-cf28-495a-bbe1-24e9d0089fa1.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -15029,7 +15029,7 @@
         },
         {
             "id": "87edfc52-85a5-5ba1-ac38-71e59e533172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcc2a8-c7be-45c8-8048-e81638558d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcc2a8-c7be-45c8-8048-e81638558d66.jpg?1",
             "name": "Livaan, Cultist of Tiamat",
             "text": "Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.\nChoose a Background",
             "colours": [
@@ -15069,7 +15069,7 @@
         },
         {
             "id": "963cd782-ce81-5382-a7c7-c62f043d1d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d0aded-3db0-45a7-b9ab-5831c714096f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d0aded-3db0-45a7-b9ab-5831c714096f.jpg?1",
             "name": "Nemesis Phoenix",
             "text": "Flying\n{2}{R}: Return Nemesis Phoenix from your graveyard to the battlefield tapped and attacking. Activate only during the declare attackers step and only if you're attacking two or more opponents.",
             "colours": [
@@ -15105,7 +15105,7 @@
         },
         {
             "id": "b23d88fc-8046-51fb-a2d0-9fb99630617f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d4f041-c485-464e-91b1-73597b1e7f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d4f041-c485-464e-91b1-73597b1e7f73.jpg?1",
             "name": "Taunting Kobold",
             "text": "Haste\nWhenever Taunting Kobold attacks, goad target creature an opponent controls.",
             "colours": [
@@ -15141,7 +15141,7 @@
         },
         {
             "id": "d3fef082-c891-5926-9d59-42994fca074b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589fdaa-9a0c-4bee-b991-38977255f0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589fdaa-9a0c-4bee-b991-38977255f0d5.jpg?1",
             "name": "Wyll, Blade of Frontiers",
             "text": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\nWhenever you roll one or more dice, put a +1/+1 counter on Wyll, Blade of Frontiers.\nChoose a Background",
             "colours": [
@@ -15181,7 +15181,7 @@
         },
         {
             "id": "91831817-2f92-5c56-a4f1-8360af5823c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261fba2-0420-4271-87f4-f168a1e74c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261fba2-0420-4271-87f4-f168a1e74c9b.jpg?1",
             "name": "Ancient Bronze Dragon",
             "text": "Flying\nWhenever Ancient Bronze Dragon deals combat damage to a player, roll a d20. When you do, put X +1/+1 counters on each of up to two target creatures, where X is the result.",
             "colours": [
@@ -15219,7 +15219,7 @@
         },
         {
             "id": "4f577f2f-13a9-589e-b772-91d933ef97db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73d15f7-d36c-45b8-a933-dac17040c9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73d15f7-d36c-45b8-a933-dac17040c9ee.jpg?1",
             "name": "Erinis, Gloom Stalker",
             "text": "Deathtouch\nWhenever Erinis, Gloom Stalker attacks, return target land card from your graveyard to the battlefield.\nChoose a Background",
             "colours": [
@@ -15259,7 +15259,7 @@
         },
         {
             "id": "8f7575d8-4bca-532a-99a9-5b824cbea161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cdc433-a41b-4f45-b40f-3618c399e196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cdc433-a41b-4f45-b40f-3618c399e196.jpg?1",
             "name": "Halsin, Emerald Archdruid",
             "text": "{1}: Until end of turn, target token you control becomes a green Bear creature with base power and toughness 4/4 in addition to its other colors and types.\nChoose a Background",
             "colours": [
@@ -15299,7 +15299,7 @@
         },
         {
             "id": "4fcd0460-82c3-516c-adfd-1b9b897f9340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4de176-0f2e-4d8c-b3ac-ef2e626b4aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4de176-0f2e-4d8c-b3ac-ef2e626b4aac.jpg?1",
             "name": "Jaheira, Friend of the Forest",
             "text": "Tokens you control have \"{T}: Add {G}.\"\nChoose a Background",
             "colours": [
@@ -15340,7 +15340,7 @@
         },
         {
             "id": "a6a92ab0-5374-5a6b-9cc5-fdb015ad54f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda500f-4c54-4e0a-b4c7-e604d1e72d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda500f-4c54-4e0a-b4c7-e604d1e72d77.jpg?1",
             "name": "Skanos Dragonheart",
             "text": "Whenever Skanos Dragonheart attacks, it gets +X/+X until end of turn, where X is the greatest power among other Dragons you control and Dragon cards in your graveyard.\nChoose a Background",
             "colours": [
@@ -15380,7 +15380,7 @@
         },
         {
             "id": "7bb48689-6f0f-546e-b89d-43ea320d20d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ebc0c-ae58-46c9-addc-a91d32201a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ebc0c-ae58-46c9-addc-a91d32201a95.jpg?1",
             "name": "Wilson, Refined Grizzly",
             "text": "This spell can't be countered.\nVigilance, reach, trample, ward {2}\nChoose a Background",
             "colours": [
@@ -15420,7 +15420,7 @@
         },
         {
             "id": "1781279b-c12c-51b7-b3c0-680eb3984094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95de91-03bf-48a2-9947-b818ac78dec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95de91-03bf-48a2-9947-b818ac78dec6.jpg?1",
             "name": "Alaundo the Seer",
             "text": "{T}: Draw a card, then exile a card from your hand and put a number of time counters on it equal to its mana value. It gains \"When the last time counter is removed from this card, if it's exiled, you may cast it without paying its mana cost. If you cast a creature spell this way, it gains haste until end of turn.\" Then remove a time counter from each other card you own in exile.",
             "colours": [
@@ -15462,7 +15462,7 @@
         },
         {
             "id": "c0df5565-cb89-5aaf-b0a2-e74522a46034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f6ae-cd25-4c98-9700-be2f40a0a37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f6ae-cd25-4c98-9700-be2f40a0a37b.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "Deathtouch, lifelink\nAt the beginning of your end step, choose one \u2014\n\u2022 Feed \u2014 Target opponent loses life equal to the amount of life they lost this turn.\n\u2022 Friends \u2014 You gain life equal to the amount of life you gained this turn.",
             "colours": [
@@ -15505,7 +15505,7 @@
         },
         {
             "id": "56bc7464-4105-56da-8219-607388f6d531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f293aa-dca1-48c2-9f48-069d32b89f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f293aa-dca1-48c2-9f48-069d32b89f3b.jpg?1",
             "name": "Baba Lysaga, Night Witch",
             "text": "{T}, Sacrifice up to three permanents: If there were three or more card types among the sacrificed permanents, each opponent loses 3 life, you gain 3 life, and you draw three cards.",
             "colours": [
@@ -15547,7 +15547,7 @@
         },
         {
             "id": "6f340973-743a-57b6-ba19-dc6aeb76f3ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4ab793-0dac-4b38-ae43-2e3fe454a6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4ab793-0dac-4b38-ae43-2e3fe454a6b2.jpg?1",
             "name": "Bane, Lord of Darkness",
             "text": "As long as your life total is less than or equal to half your starting life total, Bane, Lord of Darkness has indestructible.\nWhenever another nontoken creature you control dies, target opponent may have you draw a card. If they don't, you may put a creature card with equal or lesser toughness from your hand onto the battlefield.",
             "colours": [
@@ -15590,7 +15590,7 @@
         },
         {
             "id": "d1fe2535-b045-53e6-81fa-1cd1be311e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fef6465-987c-461b-8177-b6b7332bbe4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fef6465-987c-461b-8177-b6b7332bbe4e.jpg?1",
             "name": "Bhaal, Lord of Murder",
             "text": "As long as your life total is less than or equal to half your starting life total, Bhaal, Lord of Murder has indestructible.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on target creature and goad it.",
             "colours": [
@@ -15633,7 +15633,7 @@
         },
         {
             "id": "a44e607d-3821-51ee-bf10-54db0c79ca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101af06e-24fa-40e5-9e53-77ef571b7f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101af06e-24fa-40e5-9e53-77ef571b7f71.jpg?1",
             "name": "Cadira, Caller of the Small",
             "text": "Trample\nWhenever Cadira, Caller of the Small deals combat damage to a player, for each token you control, create a 1/1 white Rabbit creature token.",
             "colours": [
@@ -15675,7 +15675,7 @@
         },
         {
             "id": "3002b209-0f1d-53e3-8fba-2d110829f656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb052fe-c834-4c72-a6b1-4cb64505e3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb052fe-c834-4c72-a6b1-4cb64505e3ee.jpg?1",
             "name": "Commander Liara Portyr",
             "text": "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards.",
             "colours": [
@@ -15717,7 +15717,7 @@
         },
         {
             "id": "396625ff-207b-5faa-be58-c97fbe595632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba6df0f-d190-4683-b2fe-567e20c54028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba6df0f-d190-4683-b2fe-567e20c54028.jpg?1",
             "name": "The Council of Four",
             "text": "Whenever a player draws their second card during their turn, you draw a card.\nWhenever a player casts their second spell during their turn, you create a 2/2 white Knight creature token.",
             "colours": [
@@ -15759,7 +15759,7 @@
         },
         {
             "id": "c870021b-4958-5f88-8846-53a99063cf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd153bb9-6b47-4d27-9928-82b6cc3d6d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd153bb9-6b47-4d27-9928-82b6cc3d6d02.jpg?1",
             "name": "Duke Ulder Ravengard",
             "text": "At the beginning of combat on your turn, another target creature you control gains haste and myriad until end of turn.",
             "colours": [
@@ -15802,7 +15802,7 @@
         },
         {
             "id": "73525228-be5e-5579-806f-342df8259109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09541c8e-5a75-4833-aa9c-b90834f9b242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09541c8e-5a75-4833-aa9c-b90834f9b242.jpg?1",
             "name": "Dynaheir, Invoker Adept",
             "text": "Haste\nYou may activate abilities of other creatures you control as though those creatures had haste.\n{T}: When you next activate an ability this turn by spending four or more mana to activate it, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -15846,7 +15846,7 @@
         },
         {
             "id": "1e2051ce-7eb8-5d2f-887d-aa743bcfce84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836e3cf0-7335-481d-a9df-386cb1371657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836e3cf0-7335-481d-a9df-386cb1371657.jpg?1",
             "name": "Gluntch, the Bestower",
             "text": "Flying\nAt the beginning of your end step, choose a player. They put two +1/+1 counters on a creature they control. Choose a second player to draw a card. Then choose a third player to create two Treasure tokens.",
             "colours": [
@@ -15887,7 +15887,7 @@
         },
         {
             "id": "93a371c5-b928-5ffc-ae23-e4e81bcfae1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31a975-a4a1-4288-b781-6614eb9acf68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31a975-a4a1-4288-b781-6614eb9acf68.jpg?1",
             "name": "Gorion, Wise Mentor",
             "text": "Vigilance\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
             "colours": [
@@ -15931,7 +15931,7 @@
         },
         {
             "id": "0c3a9c69-b246-5122-b6ef-b8abc078dfee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cb9ff-9f85-44e0-90b4-574814868a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cb9ff-9f85-44e0-90b4-574814868a25.jpg?1",
             "name": "Jan Jansen, Chaos Crafter",
             "text": "Haste\n{T}, Sacrifice an artifact creature: Create two Treasure tokens.\n{T}, Sacrifice a noncreature artifact: Create two 1/1 colorless Construct artifact creature tokens.",
             "colours": [
@@ -15975,7 +15975,7 @@
         },
         {
             "id": "4d8a646a-e605-5e4c-9ff3-5c121693fec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca5d83a-04d8-4828-a63a-432f8ef39b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca5d83a-04d8-4828-a63a-432f8ef39b50.jpg?1",
             "name": "Jon Irenicus, Shattered One",
             "text": "At the beginning of your end step, target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it. It's goaded for the rest of the game and it gains \"This creature can't be sacrificed.\"\nWhenever a creature you own but don't control attacks, you draw a card.",
             "colours": [
@@ -16017,7 +16017,7 @@
         },
         {
             "id": "4e13d91f-d598-541b-8097-2b406fa90d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a8926b-15f5-422b-b6cf-66d71f2c86dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a8926b-15f5-422b-b6cf-66d71f2c86dc.jpg?1",
             "name": "Kagha, Shadow Archdruid",
             "text": "Whenever Kagha, Shadow Archdruid attacks, it gains deathtouch until end of turn. Mill two cards.\nOnce during each of your turns, you may play a land or cast a permanent spell from among cards in your graveyard that were put there from your library this turn.",
             "colours": [
@@ -16059,7 +16059,7 @@
         },
         {
             "id": "6bd296d6-8f88-5480-9da1-d25125025262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a453d55e-9a50-4339-ad7c-387f67179fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a453d55e-9a50-4339-ad7c-387f67179fe7.jpg?1",
             "name": "Korlessa, Scale Singer",
             "text": "You may look at the top card of your library any time.\nYou may cast Dragon spells from the top of your library.",
             "colours": [
@@ -16101,7 +16101,7 @@
         },
         {
             "id": "d606d446-3a10-542b-a046-7a43cc7b5b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49228e0-b944-458d-a832-8d374efb69df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49228e0-b944-458d-a832-8d374efb69df.jpg?1",
             "name": "Lozhan, Dragons' Legacy",
             "text": "Flying\nWhenever you cast an Adventure or Dragon spell, Lozhan, Dragons' Legacy deals damage equal to that spell's mana value to any target that isn't a commander.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "736bc8ae-e898-5c7a-9245-a3045e8fa42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4dad0e-4a4e-4898-a786-efcbceb4d70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4dad0e-4a4e-4898-a786-efcbceb4d70b.jpg?1",
             "name": "Mahadi, Emporium Master",
             "text": "At the beginning of your end step, create a Treasure token for each creature that died this turn.",
             "colours": [
@@ -16184,7 +16184,7 @@
         },
         {
             "id": "56d8114e-ff51-51b4-bc27-718a476030d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47b5f9c-4db8-4257-8999-18b9210c5708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47b5f9c-4db8-4257-8999-18b9210c5708.jpg?1",
             "name": "Mazzy, Truesword Paladin",
             "text": "Whenever an enchanted creature attacks one of your opponents, it gets +2/+0 and gains trample until end of turn.\nWhenever an Aura you control is put into your graveyard from the battlefield, exile it. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -16228,7 +16228,7 @@
         },
         {
             "id": "57f03a8f-bcaa-5eed-ad2c-b4b4d7109506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0daf2-36c5-4b3e-ab81-7317682a406b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0daf2-36c5-4b3e-ab81-7317682a406b.jpg?1",
             "name": "Miirym, Sentinel Wyrm",
             "text": "Flying, ward {2}\nWhenever another nontoken Dragon enters the battlefield under your control, create a token that's a copy of it, except the token isn't legendary if that Dragon is legendary.",
             "colours": [
@@ -16272,7 +16272,7 @@
         },
         {
             "id": "14d027ad-79a5-558d-9e57-765c30c49f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64395505-914c-4e10-aed1-818425709b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64395505-914c-4e10-aed1-818425709b12.jpg?1",
             "name": "Minthara, Merciless Soul",
             "text": "Ward {X}, where X is the number of experience counters you have.\nAt the beginning of your end step, if a permanent you controlled left the battlefield this turn, you get an experience counter.\nCreatures you control get +1/+0 for each experience counter you have.",
             "colours": [
@@ -16314,7 +16314,7 @@
         },
         {
             "id": "e541b123-ba4f-5bc7-a6ff-4fea06d092a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f2783f-9512-4cfe-9e95-ab943afd4e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f2783f-9512-4cfe-9e95-ab943afd4e53.jpg?1",
             "name": "Myrkul, Lord of Bones",
             "text": "As long as your life total is less than or equal to half your starting life total, Myrkul, Lord of Bones has indestructible.\nWhenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that card, except it's an enchantment and loses all other card types.",
             "colours": [
@@ -16357,7 +16357,7 @@
         },
         {
             "id": "25da518a-da3a-5ff7-9da0-621b2a0b7b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499bd497-4c72-4a61-88c8-abe2d379fe41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499bd497-4c72-4a61-88c8-abe2d379fe41.jpg?1",
             "name": "Neera, Wild Mage",
             "text": "Whenever you cast a spell, you may put it on the bottom of its owner's library. If you do, reveal cards from the top of your library until you reveal a nonland card. You may cast that card without paying its mana cost. Then put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
             "colours": [
@@ -16400,7 +16400,7 @@
         },
         {
             "id": "466ebb0c-8370-5c71-b060-e66f27b04427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac9e11-0fa8-4a58-8268-b46ad18c75c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac9e11-0fa8-4a58-8268-b46ad18c75c2.jpg?1",
             "name": "Nine-Fingers Keene",
             "text": "Menace\nWard\u2014\nPay 9 life.\nWhenever Nine-Fingers Keene deals combat damage to a player, look at the top nine cards of your library. You may put a Gate card from among them onto the battlefield. Then if you control nine or more Gates, put the rest into your hand. Otherwise, put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -16444,7 +16444,7 @@
         },
         {
             "id": "457cb4e3-6936-5ace-8e2e-6ce8dfb928af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d41d4f-d2e0-490c-bde0-ce57eb8fda22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d41d4f-d2e0-490c-bde0-ce57eb8fda22.jpg?1",
             "name": "Oji, the Exquisite Blade",
             "text": "When Oji, the Exquisite Blade enters the battlefield, you gain 2 life and scry 2.\nWhenever you cast your second spell each turn, exile up to one target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -16486,7 +16486,7 @@
         },
         {
             "id": "702116c7-51c8-5280-a5cd-44e9f5310a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d8f9c5-b5b6-451c-be60-ce8d16423f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d8f9c5-b5b6-451c-be60-ce8d16423f31.jpg?1",
             "name": "Raggadragga, Goreguts Boss",
             "text": "Each creature you control with a mana ability gets +2/+2.\nWhenever a creature you control with a mana ability attacks, untap it.\nWhenever you cast a spell, if at least seven mana was spent to cast it, untap target creature. It gets +7/+7 and gains trample until end of turn.",
             "colours": [
@@ -16528,7 +16528,7 @@
         },
         {
             "id": "44f4e6bb-a3b8-5121-b78b-53cc75bae520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daf0dab-7660-49bc-a959-1906a2796c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daf0dab-7660-49bc-a959-1906a2796c01.jpg?1",
             "name": "Raphael, Fiendish Savior",
             "text": "Flying\nOther Demons, Devils, Imps, and Tieflings you control get +1/+1 and have lifelink.\nAt the beginning of each end step, if a creature card was put into your graveyard from anywhere this turn, create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -16570,7 +16570,7 @@
         },
         {
             "id": "7807cb4c-ee3e-5307-8334-94c2d2be3431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a599ba-c16b-4ce0-a995-e30974bcc423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a599ba-c16b-4ce0-a995-e30974bcc423.jpg?1",
             "name": "Rilsa Rael, Kingpin",
             "text": "Deathtouch\nWhen Rilsa Rael, Kingpin enters the battlefield, you take the initiative.\nWhenever you attack, target attacking creature gains deathtouch until end of turn. If you've completed a dungeon, that creature also gets +5/+0 and gains first strike and menace until end of turn.",
             "colours": [
@@ -16612,7 +16612,7 @@
         },
         {
             "id": "2a5b897e-e0e2-54d1-b388-040b1efd5afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3f56b9-7460-49b6-8f6d-48cccd7978fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3f56b9-7460-49b6-8f6d-48cccd7978fd.jpg?1",
             "name": "Thrakkus the Butcher",
             "text": "Trample\nWhenever Thrakkus the Butcher attacks, double the power of each Dragon you control until end of turn.",
             "colours": [
@@ -16654,7 +16654,7 @@
         },
         {
             "id": "0e281a21-3911-55b6-98c7-8ba3896cc657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abfec4f-54b8-427e-9abf-6209aa659994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abfec4f-54b8-427e-9abf-6209aa659994.jpg?1",
             "name": "Zevlor, Elturel Exile",
             "text": "Haste\n{2}, {T}: When you next cast an instant or sorcery spell that targets a single opponent or a single permanent an opponent controls this turn, for each other opponent, choose that player or a permanent they control, copy that spell, and the copy targets the chosen player or permanent.",
             "colours": [
@@ -16698,7 +16698,7 @@
         },
         {
             "id": "283bd001-766d-58a4-8b82-49fef09464bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c435b6-4010-4bb6-b645-67732b1ebeab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c435b6-4010-4bb6-b645-67732b1ebeab.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "dd218720-ea2c-58c0-b6ca-148ee47ca57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea5a5f3-7147-4abd-af8d-8baab4c2aa06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea5a5f3-7147-4abd-af8d-8baab4c2aa06.jpg?1",
             "name": "Cloak of the Bat",
             "text": "Equipped creature has flying and haste.\nEquip {2}",
             "colours": [],
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "9b81c60a-dc52-5f00-8cdd-6236be41e77e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914b42b3-03af-4945-9f1f-46c09a1a2314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914b42b3-03af-4945-9f1f-46c09a1a2314.jpg?1",
             "name": "Decanter of Endless Water",
             "text": "You have no maximum hand size.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -16792,7 +16792,7 @@
         },
         {
             "id": "c52cb7ec-28b2-5428-96bf-1e5856e248f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fa8865-c600-4d8d-976d-789cd565802e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fa8865-c600-4d8d-976d-789cd565802e.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -16824,7 +16824,7 @@
         },
         {
             "id": "6b2e3e0b-d976-59bf-b2d6-cb4d3b20c655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6efa9-f198-4d8c-8a30-36a620679477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6efa9-f198-4d8c-8a30-36a620679477.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -16856,7 +16856,7 @@
         },
         {
             "id": "10f49ac1-8265-5728-ad52-3194a68e68d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec4350-cd61-4520-98a4-4a14fcbc226f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec4350-cd61-4520-98a4-4a14fcbc226f.jpg?1",
             "name": "Marching Duodrone",
             "text": "Whenever Marching Duodrone attacks, each player creates a Treasure token.",
             "colours": [],
@@ -16889,7 +16889,7 @@
         },
         {
             "id": "1935156b-2b53-58f3-8edd-b5e67f4b58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89149fb5-3afd-4da0-9a44-9366feb20804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89149fb5-3afd-4da0-9a44-9366feb20804.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -16921,7 +16921,7 @@
         },
         {
             "id": "3463de27-a942-507a-9520-e0432f951b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b21297-be34-445e-8a5a-6c297ab0ee77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b21297-be34-445e-8a5a-6c297ab0ee77.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -16953,7 +16953,7 @@
         },
         {
             "id": "6c89618e-cd50-53c0-81aa-10b302a6cc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7654eb50-4ac1-4388-aea6-373aa2b361ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7654eb50-4ac1-4388-aea6-373aa2b361ae.jpg?1",
             "name": "Stonespeaker Crystal",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Stonespeaker Crystal: Exile any number of target players' graveyards. Draw a card.",
             "colours": [],
@@ -16983,7 +16983,7 @@
         },
         {
             "id": "b6e3d141-a5a0-58ce-820b-a61bbf2bbf78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f5f561-39fd-4cdf-b22e-40cfd6a19d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f5f561-39fd-4cdf-b22e-40cfd6a19d12.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17021,7 +17021,7 @@
         },
         {
             "id": "02c66102-489c-5543-a451-dcad813a98e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be390eb-3470-4f36-9bf4-3f9f8e5d5b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be390eb-3470-4f36-9bf4-3f9f8e5d5b31.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17059,7 +17059,7 @@
         },
         {
             "id": "1a77214d-2ae5-54cc-93e0-c5ff05b59e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524ff04c-932e-4441-a2a7-1416cd43d232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524ff04c-932e-4441-a2a7-1416cd43d232.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17097,7 +17097,7 @@
         },
         {
             "id": "0341170c-2d9a-5e69-8bbe-bbec969ab74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f55597c-f265-4c4b-a5f1-cc58da609534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f55597c-f265-4c4b-a5f1-cc58da609534.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17135,7 +17135,7 @@
         },
         {
             "id": "0b582562-e380-558b-afeb-9a7f21ef5888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3ffe47-53a3-42ec-ae89-afc79793380d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3ffe47-53a3-42ec-ae89-afc79793380d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17173,7 +17173,7 @@
         },
         {
             "id": "2b891378-a0d3-532a-84ce-e03446a90ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b99a83-bfe4-4149-b626-269953c5ac51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b99a83-bfe4-4149-b626-269953c5ac51.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17211,7 +17211,7 @@
         },
         {
             "id": "38ae0023-429f-5ea0-b83e-72f2dbdb26ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995e06d-8145-485e-aeed-3da27a07545b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995e06d-8145-485e-aeed-3da27a07545b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17249,7 +17249,7 @@
         },
         {
             "id": "39f54b10-791b-5677-8a2f-f5b05dc0de0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c9ea23-93c5-4aae-9786-3b3c03a07778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c9ea23-93c5-4aae-9786-3b3c03a07778.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17287,7 +17287,7 @@
         },
         {
             "id": "63e134c8-d2cb-57e2-a78f-4bdef3e8cf92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4111be-6dae-4ca5-bd58-c1ce7cfa9cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4111be-6dae-4ca5-bd58-c1ce7cfa9cf6.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17325,7 +17325,7 @@
         },
         {
             "id": "0eb01d56-20c6-5737-a81d-fb72c07e2a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0866a19-429b-43e4-a4a1-338fe12ead42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0866a19-429b-43e4-a4a1-338fe12ead42.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17363,7 +17363,7 @@
         },
         {
             "id": "6516d981-cce0-5613-9de5-22fad2396c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716460ce-2602-476c-aa53-40d1f22ea7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716460ce-2602-476c-aa53-40d1f22ea7c8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17401,7 +17401,7 @@
         },
         {
             "id": "a9404f0e-8c15-5f20-aad4-0ecdf06ae707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c03592-debd-4b4f-a5ea-a31ce63f5d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c03592-debd-4b4f-a5ea-a31ce63f5d23.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17439,7 +17439,7 @@
         },
         {
             "id": "9d4104c4-bdc1-5a60-94f6-cb31e7ef18ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab63e49-0869-4c7c-a033-d8e50032dd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab63e49-0869-4c7c-a033-d8e50032dd13.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17477,7 +17477,7 @@
         },
         {
             "id": "5f3e9f14-0f1b-5b85-a7dd-ff2043381f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4376426-c901-44eb-8186-c009a3657893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4376426-c901-44eb-8186-c009a3657893.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17515,7 +17515,7 @@
         },
         {
             "id": "efbad82c-56f8-5629-a664-141023fc6ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0333e39b-45e7-46df-908c-0748092ce8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0333e39b-45e7-46df-908c-0748092ce8c1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17553,7 +17553,7 @@
         },
         {
             "id": "d60b336c-10e1-5da1-af88-ab65cb33111b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35132c99-01b9-463c-a00d-6f125893c870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35132c99-01b9-463c-a00d-6f125893c870.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17591,7 +17591,7 @@
         },
         {
             "id": "a0bdc942-0c19-5fa0-be0b-682faab0fe82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf23791-1b15-43ee-b81a-5fe068709bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf23791-1b15-43ee-b81a-5fe068709bc1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17629,7 +17629,7 @@
         },
         {
             "id": "42dd32ec-1107-51fc-b229-b12a0f2a459c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b86b3a4-981e-497a-b78b-30b2dbc5ea7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b86b3a4-981e-497a-b78b-30b2dbc5ea7a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17667,7 +17667,7 @@
         },
         {
             "id": "a7a0181b-2441-590e-83d9-ce5e976600c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca33d91-3c1a-4351-9d9d-d46a6e3de084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca33d91-3c1a-4351-9d9d-d46a6e3de084.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17705,7 +17705,7 @@
         },
         {
             "id": "d2ca566c-ccc4-5d97-84b2-0fbe9f440819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3812e162-3511-4988-b2a1-3bc6945ac45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3812e162-3511-4988-b2a1-3bc6945ac45b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17743,7 +17743,7 @@
         },
         {
             "id": "79bc740b-edab-5413-9297-7674c979b6c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cb7668-e07d-4551-9525-68974b33ad87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cb7668-e07d-4551-9525-68974b33ad87.jpg?1",
             "name": "Abdel Adrian, Gorion's Ward",
             "text": "",
             "colours": [
@@ -17782,7 +17782,7 @@
         },
         {
             "id": "7f9415f8-0c4e-5cde-b1d2-f7e659680a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6e8f9-d6e3-46e0-8e5e-2fe7a7c7efbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6e8f9-d6e3-46e0-8e5e-2fe7a7c7efbe.jpg?1",
             "name": "Ellyn Harbreeze, Busybody",
             "text": "",
             "colours": [
@@ -17821,7 +17821,7 @@
         },
         {
             "id": "5a716ab5-3d3c-5761-af8a-0563d5075d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d826e586-8efd-4725-9d0c-22a7cb7baed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d826e586-8efd-4725-9d0c-22a7cb7baed9.jpg?1",
             "name": "Far Traveler",
             "text": "",
             "colours": [
@@ -17858,7 +17858,7 @@
         },
         {
             "id": "738b2466-2892-5e19-94dd-b8f95d198850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80415872-e35d-4798-a021-b4690d9f78a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80415872-e35d-4798-a021-b4690d9f78a0.jpg?1",
             "name": "Flaming Fist",
             "text": "",
             "colours": [
@@ -17895,7 +17895,7 @@
         },
         {
             "id": "c3680f83-8203-5b96-9e06-e733b013e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394f432d-e59f-44ce-a166-1a939a648cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394f432d-e59f-44ce-a166-1a939a648cbd.jpg?1",
             "name": "Inspiring Leader",
             "text": "",
             "colours": [
@@ -17932,7 +17932,7 @@
         },
         {
             "id": "c9bcf65f-6d29-5f90-8a05-5dbaf8266a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4833ef6c-3ff8-4a3c-826b-58e4a27480a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4833ef6c-3ff8-4a3c-826b-58e4a27480a3.jpg?1",
             "name": "Lae'zel, Vlaakith's Champion",
             "text": "",
             "colours": [
@@ -17971,7 +17971,7 @@
         },
         {
             "id": "0d07aaa5-14d5-54a8-9f89-2eb47bc5406f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2eda80a-14d3-47ab-8133-cafd15a8c17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2eda80a-14d3-47ab-8133-cafd15a8c17c.jpg?1",
             "name": "Lulu, Loyal Hollyphant",
             "text": "",
             "colours": [
@@ -18010,7 +18010,7 @@
         },
         {
             "id": "e7f74101-2890-5951-90d9-2ec10542e67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d11a8-5e1f-41c3-a5a3-1ccd2a2782bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d11a8-5e1f-41c3-a5a3-1ccd2a2782bb.jpg?1",
             "name": "Noble Heritage",
             "text": "",
             "colours": [
@@ -18047,7 +18047,7 @@
         },
         {
             "id": "203f046f-5706-56ea-8765-193bc189ef68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba007e7-e18c-405e-b7ea-6d8a240e68b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba007e7-e18c-405e-b7ea-6d8a240e68b2.jpg?1",
             "name": "Rasaad yn Bashir",
             "text": "",
             "colours": [
@@ -18086,7 +18086,7 @@
         },
         {
             "id": "c3023c8f-9dc4-56dd-9897-8f533b3add33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e011dd48-9238-4e4b-a915-b7ac5fa9b78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e011dd48-9238-4e4b-a915-b7ac5fa9b78f.jpg?1",
             "name": "Veteran Soldier",
             "text": "",
             "colours": [
@@ -18123,7 +18123,7 @@
         },
         {
             "id": "b653a414-0a71-5235-8dab-268d91bce14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b896c-24f1-41d5-9aae-070d8e96fd35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b896c-24f1-41d5-9aae-070d8e96fd35.jpg?1",
             "name": "Alora, Merry Thief",
             "text": "",
             "colours": [
@@ -18162,7 +18162,7 @@
         },
         {
             "id": "26eedfc5-459e-5292-8b40-92ae55f5292d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbcce-bcce-4806-9c73-e4a82a630b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fcbcce-bcce-4806-9c73-e4a82a630b76.jpg?1",
             "name": "Candlekeep Sage",
             "text": "",
             "colours": [
@@ -18199,7 +18199,7 @@
         },
         {
             "id": "432667b9-8d25-5e92-bd7f-225bc88f0190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a772b9d-2331-4444-a897-c78196ce4836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a772b9d-2331-4444-a897-c78196ce4836.jpg?1",
             "name": "Dungeon Delver",
             "text": "",
             "colours": [
@@ -18236,7 +18236,7 @@
         },
         {
             "id": "ff070d05-c901-58e1-9796-97e3f82b07df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23cdac1-bf6f-46d4-a8f8-d4d30cd0a4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23cdac1-bf6f-46d4-a8f8-d4d30cd0a4f1.jpg?1",
             "name": "Feywild Visitor",
             "text": "",
             "colours": [
@@ -18273,7 +18273,7 @@
         },
         {
             "id": "a46f071e-9b06-5aa3-959d-c48edd96ce55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe5a61-b636-4f4a-a9bb-f26ab430fd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe5a61-b636-4f4a-a9bb-f26ab430fd92.jpg?1",
             "name": "Gale, Waterdeep Prodigy",
             "text": "",
             "colours": [
@@ -18312,7 +18312,7 @@
         },
         {
             "id": "8ba59d29-a503-53cc-ad5b-f146d5aae063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07f957-ad7b-463f-b642-b5d47eadf37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07f957-ad7b-463f-b642-b5d47eadf37a.jpg?1",
             "name": "Imoen, Mystic Trickster",
             "text": "",
             "colours": [
@@ -18352,7 +18352,7 @@
         },
         {
             "id": "6c5aae1c-14db-5300-a3b7-52f186c7ba3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80290716-17c3-41e4-8ef8-814dd25b11e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80290716-17c3-41e4-8ef8-814dd25b11e4.jpg?1",
             "name": "Renari, Merchant of Marvels",
             "text": "",
             "colours": [
@@ -18391,7 +18391,7 @@
         },
         {
             "id": "7d28999e-259d-5d00-a469-3eb216feb49a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f962b9a9-612e-4355-8ab0-a6e41ea4c026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f962b9a9-612e-4355-8ab0-a6e41ea4c026.jpg?1",
             "name": "Shameless Charlatan",
             "text": "",
             "colours": [
@@ -18428,7 +18428,7 @@
         },
         {
             "id": "5b85b3bc-c3f0-5fef-abe4-be15c629e073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d172475f-7063-44fe-ad11-56852d2e86da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d172475f-7063-44fe-ad11-56852d2e86da.jpg?1",
             "name": "Sword Coast Sailor",
             "text": "",
             "colours": [
@@ -18465,7 +18465,7 @@
         },
         {
             "id": "01a2637c-3bd8-51d9-85c1-1dee1ff3354e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73b53a4-11f9-417f-b568-a3e48e0548f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73b53a4-11f9-417f-b568-a3e48e0548f8.jpg?1",
             "name": "Vhal, Candlekeep Researcher",
             "text": "",
             "colours": [
@@ -18504,7 +18504,7 @@
         },
         {
             "id": "48fd4c07-42a6-5280-8e16-c315a052b996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f77bd3a-b9a5-4330-9397-3992a28d157e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f77bd3a-b9a5-4330-9397-3992a28d157e.jpg?1",
             "name": "Volo, Itinerant Scholar",
             "text": "",
             "colours": [
@@ -18543,7 +18543,7 @@
         },
         {
             "id": "fb212980-e0a1-5ac1-9c3d-f539c451eafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82bfc55-8ebd-4a0f-b301-027b76416f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82bfc55-8ebd-4a0f-b301-027b76416f7d.jpg?1",
             "name": "Agent of the Iron Throne",
             "text": "",
             "colours": [
@@ -18580,7 +18580,7 @@
         },
         {
             "id": "499ba51a-b971-5398-a9ba-bd5e6f61195c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae796b5c-1979-4dd2-9539-4b9e18903834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae796b5c-1979-4dd2-9539-4b9e18903834.jpg?1",
             "name": "Agent of the Shadow Thieves",
             "text": "",
             "colours": [
@@ -18617,7 +18617,7 @@
         },
         {
             "id": "5fd68534-0370-5d78-b224-895704b62980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf8122-e282-4def-9f17-b930238bc7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf8122-e282-4def-9f17-b930238bc7d2.jpg?1",
             "name": "Criminal Past",
             "text": "",
             "colours": [
@@ -18654,7 +18654,7 @@
         },
         {
             "id": "5c916b9b-adac-5c56-a7bc-75425528a772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b11ac-187c-4cda-9197-93244d6906c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b11ac-187c-4cda-9197-93244d6906c8.jpg?1",
             "name": "Cultist of the Absolute",
             "text": "",
             "colours": [
@@ -18691,7 +18691,7 @@
         },
         {
             "id": "04f3b78a-2443-52db-887c-b850708aa8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb19fe09-d1d9-40bc-9af7-b19d129f5519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb19fe09-d1d9-40bc-9af7-b19d129f5519.jpg?1",
             "name": "Safana, Calimport Cutthroat",
             "text": "",
             "colours": [
@@ -18730,7 +18730,7 @@
         },
         {
             "id": "6f74423a-0b0a-5b56-a2df-1d204ccaf62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162db102-5675-4827-a668-27a8561b18d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162db102-5675-4827-a668-27a8561b18d1.jpg?1",
             "name": "Sarevok, Deathbringer",
             "text": "",
             "colours": [
@@ -18769,7 +18769,7 @@
         },
         {
             "id": "8f82d67a-4fba-53e8-94a1-f7bdf350335f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7ce463-6427-4040-baec-c5fa361db806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7ce463-6427-4040-baec-c5fa361db806.jpg?1",
             "name": "Scion of Halaster",
             "text": "",
             "colours": [
@@ -18806,7 +18806,7 @@
         },
         {
             "id": "4891513e-aaf6-5d84-82fd-a329678b8864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e13ed-54f9-43f9-ae44-285037e8f074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8e13ed-54f9-43f9-ae44-285037e8f074.jpg?1",
             "name": "Shadowheart, Dark Justiciar",
             "text": "",
             "colours": [
@@ -18846,7 +18846,7 @@
         },
         {
             "id": "f159c699-165b-578a-b9ca-49b2d43e8725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d27849-e6a5-44e9-8d7e-a742351d2a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d27849-e6a5-44e9-8d7e-a742351d2a05.jpg?1",
             "name": "Sivriss, Nightmare Speaker",
             "text": "",
             "colours": [
@@ -18886,7 +18886,7 @@
         },
         {
             "id": "6978ec5b-ef10-5749-96d6-499fd1ec2bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842b106-0b54-485e-bb30-72ea6c4370fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842b106-0b54-485e-bb30-72ea6c4370fd.jpg?1",
             "name": "Viconia, Drow Apostate",
             "text": "",
             "colours": [
@@ -18925,7 +18925,7 @@
         },
         {
             "id": "7f27978a-d9f5-5d55-8cca-ff06f3207b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff35b8d7-d6e5-4474-8648-79f2c538a434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff35b8d7-d6e5-4474-8648-79f2c538a434.jpg?1",
             "name": "Amber Gristle O'Maul",
             "text": "",
             "colours": [
@@ -18964,7 +18964,7 @@
         },
         {
             "id": "ee86be06-ffc1-5473-9080-fdb4a1202eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465cb37e-627d-44ec-9d2d-6a630b14c25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465cb37e-627d-44ec-9d2d-6a630b14c25f.jpg?1",
             "name": "Dragon Cultist",
             "text": "",
             "colours": [
@@ -19001,7 +19001,7 @@
         },
         {
             "id": "3e96b757-9222-5156-b91f-9c334368cf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb28cc-67bd-4e1f-933a-3b859f38ea64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb28cc-67bd-4e1f-933a-3b859f38ea64.jpg?1",
             "name": "Ganax, Astral Hunter",
             "text": "",
             "colours": [
@@ -19039,7 +19039,7 @@
         },
         {
             "id": "dcca6ca6-ed0f-5983-97f8-a6908a894805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a331542-11e4-49dc-be2f-ee56f07ccee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a331542-11e4-49dc-be2f-ee56f07ccee0.jpg?1",
             "name": "Guild Artisan",
             "text": "",
             "colours": [
@@ -19076,7 +19076,7 @@
         },
         {
             "id": "23e80ec1-4dfc-5fa9-a730-ce27a1e701d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163a7729-b115-46dd-afb4-7a5df89c3ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163a7729-b115-46dd-afb4-7a5df89c3ed1.jpg?1",
             "name": "Gut, True Soul Zealot",
             "text": "",
             "colours": [
@@ -19115,7 +19115,7 @@
         },
         {
             "id": "f1cc4434-2d9f-59f8-b365-81794909ce60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231621a3-01dc-41af-827a-94aaa63179ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231621a3-01dc-41af-827a-94aaa63179ae.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "",
             "colours": [
@@ -19154,7 +19154,7 @@
         },
         {
             "id": "f99956ea-01e9-5129-b894-56364204693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515eb7b-d42b-4a3d-880d-d4dec99db4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515eb7b-d42b-4a3d-880d-d4dec99db4b2.jpg?1",
             "name": "Livaan, Cultist of Tiamat",
             "text": "",
             "colours": [
@@ -19193,7 +19193,7 @@
         },
         {
             "id": "837fa2a2-c3db-53db-9199-a44f256a28e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98fe671-e358-43f6-8f85-a84668be3a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98fe671-e358-43f6-8f85-a84668be3a5d.jpg?1",
             "name": "Popular Entertainer",
             "text": "",
             "colours": [
@@ -19230,7 +19230,7 @@
         },
         {
             "id": "e3207772-927c-5d1d-975a-2b71ac2f7c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c393ffd7-18e6-4399-ba6f-5e211c669113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c393ffd7-18e6-4399-ba6f-5e211c669113.jpg?1",
             "name": "Street Urchin",
             "text": "",
             "colours": [
@@ -19267,7 +19267,7 @@
         },
         {
             "id": "0169b206-2c44-581f-bc1a-10d801718d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f74187e-64ac-4685-ad21-0746cb2b61f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f74187e-64ac-4685-ad21-0746cb2b61f4.jpg?1",
             "name": "Tavern Brawler",
             "text": "",
             "colours": [
@@ -19304,7 +19304,7 @@
         },
         {
             "id": "135bc328-a39a-5218-bb02-f56ee03605df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e01be28-d138-4204-b425-a9922448d97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e01be28-d138-4204-b425-a9922448d97c.jpg?1",
             "name": "Wyll, Blade of Frontiers",
             "text": "",
             "colours": [
@@ -19343,7 +19343,7 @@
         },
         {
             "id": "20bbbd6a-2314-5877-854d-9df7f06dddf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddd9b4f-621a-40d2-bc46-08d5adc3571f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddd9b4f-621a-40d2-bc46-08d5adc3571f.jpg?1",
             "name": "Acolyte of Bahamut",
             "text": "",
             "colours": [
@@ -19380,7 +19380,7 @@
         },
         {
             "id": "56c863e1-fbcb-55c7-b173-a223cd86b4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bfbfaa-d66c-48d2-938e-024ef8c33c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bfbfaa-d66c-48d2-938e-024ef8c33c32.jpg?1",
             "name": "Cloakwood Hermit",
             "text": "",
             "colours": [
@@ -19417,7 +19417,7 @@
         },
         {
             "id": "b986c71f-1963-5bb8-9885-e9200f6fd1e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07efa583-c8ef-4d02-a548-1b4186790470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07efa583-c8ef-4d02-a548-1b4186790470.jpg?1",
             "name": "Erinis, Gloom Stalker",
             "text": "",
             "colours": [
@@ -19456,7 +19456,7 @@
         },
         {
             "id": "02469c04-a421-5fe5-b56e-5ff7bf989b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f546b455-20b5-4970-adb8-24d469842298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f546b455-20b5-4970-adb8-24d469842298.jpg?1",
             "name": "Halsin, Emerald Archdruid",
             "text": "",
             "colours": [
@@ -19495,7 +19495,7 @@
         },
         {
             "id": "585a91e6-2ca9-5536-a1b6-0aeb8098131e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d418c62c-ba1f-4399-a06c-cc3a0d23b117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d418c62c-ba1f-4399-a06c-cc3a0d23b117.jpg?1",
             "name": "Hardy Outlander",
             "text": "",
             "colours": [
@@ -19532,7 +19532,7 @@
         },
         {
             "id": "fbf1db14-47b1-51ba-814b-bf10bf95f8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27186d29-7b24-40f9-909f-456e0e3d8847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27186d29-7b24-40f9-909f-456e0e3d8847.jpg?1",
             "name": "Jaheira, Friend of the Forest",
             "text": "",
             "colours": [
@@ -19572,7 +19572,7 @@
         },
         {
             "id": "25957c3a-5ce0-5274-90a3-3f496bc34ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd941ff-b423-4379-91c3-7c3d95a4b0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd941ff-b423-4379-91c3-7c3d95a4b0cb.jpg?1",
             "name": "Master Chef",
             "text": "",
             "colours": [
@@ -19609,7 +19609,7 @@
         },
         {
             "id": "d6f9df44-26c0-52e0-b2f4-0816f59f527b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9caae7-fb67-42bf-bee0-b935a1b88d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9caae7-fb67-42bf-bee0-b935a1b88d79.jpg?1",
             "name": "Raised by Giants",
             "text": "",
             "colours": [
@@ -19646,7 +19646,7 @@
         },
         {
             "id": "60ede1c7-e412-5bde-b2ac-c727fc259e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7bfe9-1abb-4562-9182-eb37460a1c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7bfe9-1abb-4562-9182-eb37460a1c6c.jpg?1",
             "name": "Skanos Dragonheart",
             "text": "",
             "colours": [
@@ -19685,7 +19685,7 @@
         },
         {
             "id": "d3c30744-71fe-5389-accc-faa106d53a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91422b68-b4a8-4138-8aee-bc98d33d6a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91422b68-b4a8-4138-8aee-bc98d33d6a6c.jpg?1",
             "name": "Wilson, Refined Grizzly",
             "text": "",
             "colours": [
@@ -19724,7 +19724,7 @@
         },
         {
             "id": "2d781461-95c5-5c5a-b8ed-51e4e879834d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e31d6fa-187f-4163-af23-aea86bc2e5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e31d6fa-187f-4163-af23-aea86bc2e5cb.jpg?1",
             "name": "Alaundo the Seer",
             "text": "",
             "colours": [
@@ -19765,7 +19765,7 @@
         },
         {
             "id": "bc64f7a0-2b66-5bde-9cce-58f832e6ab4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87edd00-062d-48b8-b212-cc0073fe05ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87edd00-062d-48b8-b212-cc0073fe05ea.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "",
             "colours": [
@@ -19807,7 +19807,7 @@
         },
         {
             "id": "7b2e076e-9b85-5c58-8f12-f856382b737d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b330c216-4c1f-4318-8add-20b766afd94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b330c216-4c1f-4318-8add-20b766afd94c.jpg?1",
             "name": "Baba Lysaga, Night Witch",
             "text": "",
             "colours": [
@@ -19848,7 +19848,7 @@
         },
         {
             "id": "8b476199-0d26-5e4e-9d9f-a225583db3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5176ed32-2548-41cb-8128-28a9a73acdf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5176ed32-2548-41cb-8128-28a9a73acdf9.jpg?1",
             "name": "Bane, Lord of Darkness",
             "text": "",
             "colours": [
@@ -19890,7 +19890,7 @@
         },
         {
             "id": "2a82b602-1707-548f-bf83-91d436b67d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a5e627-69a5-4e31-9744-97d4589d606b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a5e627-69a5-4e31-9744-97d4589d606b.jpg?1",
             "name": "Bhaal, Lord of Murder",
             "text": "",
             "colours": [
@@ -19932,7 +19932,7 @@
         },
         {
             "id": "159e1095-755a-56e6-a7ef-df7683fedb33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb03f28-f327-4071-b08e-b72df6e69137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb03f28-f327-4071-b08e-b72df6e69137.jpg?1",
             "name": "Cadira, Caller of the Small",
             "text": "",
             "colours": [
@@ -19973,7 +19973,7 @@
         },
         {
             "id": "03d8d7f5-5b95-5108-8310-7f4351c7a161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11466e07-ba23-4058-8490-28b144ab39ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11466e07-ba23-4058-8490-28b144ab39ae.jpg?1",
             "name": "Commander Liara Portyr",
             "text": "",
             "colours": [
@@ -20014,7 +20014,7 @@
         },
         {
             "id": "67e640bb-9639-55f6-9ea4-ebc1e5159eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1610d8b1-6b4c-450a-96c2-b56fd08b3f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1610d8b1-6b4c-450a-96c2-b56fd08b3f86.jpg?1",
             "name": "The Council of Four",
             "text": "",
             "colours": [
@@ -20055,7 +20055,7 @@
         },
         {
             "id": "cf7ee656-49bb-532b-b702-316637b6fe80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b8a4a3-20c5-4c6c-85ae-e9e3f5724859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b8a4a3-20c5-4c6c-85ae-e9e3f5724859.jpg?1",
             "name": "Duke Ulder Ravengard",
             "text": "",
             "colours": [
@@ -20097,7 +20097,7 @@
         },
         {
             "id": "0f0a6029-d1b8-500d-b162-f57026fca6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c92d2a9-a4f9-4fff-a57f-9cd2370bb5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c92d2a9-a4f9-4fff-a57f-9cd2370bb5bf.jpg?1",
             "name": "Dynaheir, Invoker Adept",
             "text": "",
             "colours": [
@@ -20140,7 +20140,7 @@
         },
         {
             "id": "028c2d88-0ab0-55d6-967d-5b3236a9ca7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836d7e5-98cd-4f1e-9a66-150b80cd0325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3836d7e5-98cd-4f1e-9a66-150b80cd0325.jpg?1",
             "name": "Gluntch, the Bestower",
             "text": "",
             "colours": [
@@ -20180,7 +20180,7 @@
         },
         {
             "id": "103cc44a-2fcf-505b-acd8-2a32230933cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec0854e-5005-45e6-be3f-008c5d7b85f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec0854e-5005-45e6-be3f-008c5d7b85f0.jpg?1",
             "name": "Gorion, Wise Mentor",
             "text": "",
             "colours": [
@@ -20223,7 +20223,7 @@
         },
         {
             "id": "9f2035ec-71bf-55d6-9b6e-c8779e62b2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e19be3-8bf7-4f20-926b-76aa69fe36d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e19be3-8bf7-4f20-926b-76aa69fe36d3.jpg?1",
             "name": "Jan Jansen, Chaos Crafter",
             "text": "",
             "colours": [
@@ -20266,7 +20266,7 @@
         },
         {
             "id": "35c9967f-09ba-5758-813a-6b294de7868e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41796670-081a-41e9-8c1c-e6cf391b5896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41796670-081a-41e9-8c1c-e6cf391b5896.jpg?1",
             "name": "Jon Irenicus, Shattered One",
             "text": "",
             "colours": [
@@ -20307,7 +20307,7 @@
         },
         {
             "id": "c7f310a3-62be-5025-a378-38991cef8d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dfb05a-e88c-426c-999c-1a9871ec4197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dfb05a-e88c-426c-999c-1a9871ec4197.jpg?1",
             "name": "Kagha, Shadow Archdruid",
             "text": "",
             "colours": [
@@ -20348,7 +20348,7 @@
         },
         {
             "id": "c070e8aa-e72e-54ee-b98f-ed1c8f238ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bae554-6c95-4d83-a85b-163b5dfbf4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bae554-6c95-4d83-a85b-163b5dfbf4ff.jpg?1",
             "name": "Korlessa, Scale Singer",
             "text": "",
             "colours": [
@@ -20389,7 +20389,7 @@
         },
         {
             "id": "6e2d8cf9-6c16-54f5-926f-7cee98a1c5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24ed5b7-2f71-4f11-a787-fa683216469c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24ed5b7-2f71-4f11-a787-fa683216469c.jpg?1",
             "name": "Lozhan, Dragons' Legacy",
             "text": "",
             "colours": [
@@ -20430,7 +20430,7 @@
         },
         {
             "id": "f4f74cb1-48b4-5746-9aec-d38993944b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c502480-111e-46a3-9f2f-9c4901d88323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c502480-111e-46a3-9f2f-9c4901d88323.jpg?1",
             "name": "Mahadi, Emporium Master",
             "text": "",
             "colours": [
@@ -20470,7 +20470,7 @@
         },
         {
             "id": "346b434b-1c81-522f-a6fa-de5e1074c369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f41f17-ba7c-4028-b4b6-3a47fa63ac58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f41f17-ba7c-4028-b4b6-3a47fa63ac58.jpg?1",
             "name": "Mazzy, Truesword Paladin",
             "text": "",
             "colours": [
@@ -20513,7 +20513,7 @@
         },
         {
             "id": "bf160340-e15a-51a6-94ef-944a5ffe18df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179cada0-44d5-40f6-8c50-42e56a595fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179cada0-44d5-40f6-8c50-42e56a595fb3.jpg?1",
             "name": "Miirym, Sentinel Wyrm",
             "text": "",
             "colours": [
@@ -20556,7 +20556,7 @@
         },
         {
             "id": "2f48280a-4770-5bfa-a508-88554e516bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09de7bd-ad2a-46c0-bdfb-f529d7f9ebc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09de7bd-ad2a-46c0-bdfb-f529d7f9ebc6.jpg?1",
             "name": "Minthara, Merciless Soul",
             "text": "",
             "colours": [
@@ -20597,7 +20597,7 @@
         },
         {
             "id": "a7f40136-227d-5d1f-9d54-94ed98721af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd790307-9926-4b7c-a90d-ca844adbe0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd790307-9926-4b7c-a90d-ca844adbe0ba.jpg?1",
             "name": "Myrkul, Lord of Bones",
             "text": "",
             "colours": [
@@ -20639,7 +20639,7 @@
         },
         {
             "id": "caa41e61-147e-551e-9fa7-a34d0fb5899c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55339f7c-667b-471c-8ed3-41c368bcfc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55339f7c-667b-471c-8ed3-41c368bcfc49.jpg?1",
             "name": "Neera, Wild Mage",
             "text": "",
             "colours": [
@@ -20681,7 +20681,7 @@
         },
         {
             "id": "099acbee-cb02-50fe-8592-a0cdc9fff85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223ccdc-abf2-42b5-a8b3-c5afbf843552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223ccdc-abf2-42b5-a8b3-c5afbf843552.jpg?1",
             "name": "Nine-Fingers Keene",
             "text": "",
             "colours": [
@@ -20724,7 +20724,7 @@
         },
         {
             "id": "eb4dd12e-d86f-532d-9d0c-84f0f34d4ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e8e3ba-692c-4ad8-8b89-75de05c0488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e8e3ba-692c-4ad8-8b89-75de05c0488a.jpg?1",
             "name": "Oji, the Exquisite Blade",
             "text": "",
             "colours": [
@@ -20765,7 +20765,7 @@
         },
         {
             "id": "210a4563-272e-5290-b793-4db6abfb6fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc26ee-5a1e-4fbb-b104-f454fd9dc7e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc26ee-5a1e-4fbb-b104-f454fd9dc7e9.jpg?1",
             "name": "Raggadragga, Goreguts Boss",
             "text": "",
             "colours": [
@@ -20806,7 +20806,7 @@
         },
         {
             "id": "cd640b8a-4848-5ee2-a0ce-cde99ae31d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee93ebf-710c-4c8b-a62b-26c41d8a5406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee93ebf-710c-4c8b-a62b-26c41d8a5406.jpg?1",
             "name": "Raphael, Fiendish Savior",
             "text": "",
             "colours": [
@@ -20847,7 +20847,7 @@
         },
         {
             "id": "2574c3b0-27b1-52f7-9a42-535bfd56662b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c909c8d2-72c3-40b5-a74c-e78b0e8fceda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c909c8d2-72c3-40b5-a74c-e78b0e8fceda.jpg?1",
             "name": "Rilsa Rael, Kingpin",
             "text": "",
             "colours": [
@@ -20888,7 +20888,7 @@
         },
         {
             "id": "876bc8de-4757-5b95-b9b3-5bf35320bfd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa117d-2404-418d-8d5b-0a68550c1e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa117d-2404-418d-8d5b-0a68550c1e9b.jpg?1",
             "name": "Thrakkus the Butcher",
             "text": "",
             "colours": [
@@ -20929,7 +20929,7 @@
         },
         {
             "id": "edc2eb71-560c-5cbd-bf33-642689a83ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4c302c-47d6-42af-9fdd-e13f11d803a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4c302c-47d6-42af-9fdd-e13f11d803a5.jpg?1",
             "name": "Zevlor, Elturel Exile",
             "text": "",
             "colours": [
@@ -20972,7 +20972,7 @@
         },
         {
             "id": "ea110350-353e-5823-a0d1-ef672e0c5113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67ef30-a8ef-4437-8c9a-d125a98fbd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67ef30-a8ef-4437-8c9a-d125a98fbd6b.jpg?1",
             "name": "Archivist of Oghma",
             "text": "Flash\nWhenever an opponent searches their library, you gain 1 life and draw a card.",
             "colours": [
@@ -21009,7 +21009,7 @@
         },
         {
             "id": "98800342-0d4f-5dcf-8b09-054499d8539b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe418c35-b0f1-4322-8ade-c5fe574de878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe418c35-b0f1-4322-8ade-c5fe574de878.jpg?1",
             "name": "Ascend from Avernus",
             "text": "Return all creature and planeswalker cards with mana value X or less from your graveyard to the battlefield. Exile Ascend from Avernus.",
             "colours": [
@@ -21043,7 +21043,7 @@
         },
         {
             "id": "88516c02-5bb1-5604-880f-f21f7f7ad2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {3}",
             "colours": [
@@ -21079,7 +21079,7 @@
         },
         {
             "id": "08646398-5418-57f2-bc71-e07a666544a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99a3e531-35bf-4e47-90a9-a5aebf909604.jpg?1",
             "name": "Horn of Valhalla // Ysgard's Call",
             "text": "Create X 1/1 white Soldier creature tokens. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -21115,7 +21115,7 @@
         },
         {
             "id": "a3d4cf00-d8da-59b2-b220-d14810c18e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d9db1-c3e9-4efa-a095-9c2b8a61dcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d9db1-c3e9-4efa-a095-9c2b8a61dcec.jpg?1",
             "name": "Lae'zel's Acrobatics",
             "text": "Exile all nontoken creatures you control, then roll a d20.\n1\u20139 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10\u201320 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -21149,7 +21149,7 @@
         },
         {
             "id": "edea17cc-fdfe-5045-9684-7cd8ba60faf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6087b40-4fd5-4fbc-8599-e67a5cb76832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6087b40-4fd5-4fbc-8599-e67a5cb76832.jpg?1",
             "name": "Sculpted Sunburst",
             "text": "Choose a creature you control, then each opponent chooses a creature they control with equal or lesser power. If you chose a creature this way, exile each creature not chosen by any player this way.",
             "colours": [
@@ -21183,7 +21183,7 @@
         },
         {
             "id": "fd3fb8aa-7755-52e6-adb8-6f7fd53eccb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b944490b-4366-46d1-b499-9c3f66c9ba35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b944490b-4366-46d1-b499-9c3f66c9ba35.jpg?1",
             "name": "White Plume Adventurer",
             "text": "When White Plume Adventurer enters the battlefield, you take the initiative.\nAt the beginning of each opponent's upkeep, untap a creature you control. If you've completed a dungeon, untap all creatures you control instead.",
             "colours": [
@@ -21220,7 +21220,7 @@
         },
         {
             "id": "3de2f75a-e661-5e21-beaa-7125ea4dc690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36216a6-e043-42f5-96d2-e0844055c83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36216a6-e043-42f5-96d2-e0844055c83a.jpg?1",
             "name": "Windshaper Planetar",
             "text": "Flash\nFlying\nWhen Windshaper Planetar enters the battlefield during the declare attackers step, for each attacking creature, you may reselect which player or planeswalker that creature is attacking.",
             "colours": [
@@ -21256,7 +21256,7 @@
         },
         {
             "id": "8fad51e2-d244-5e96-802d-3fd261d7573b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a53e8fc-bfd2-4866-a61c-f3204b0a98bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a53e8fc-bfd2-4866-a61c-f3204b0a98bf.jpg?1",
             "name": "Displacer Kitten",
             "text": "Avoidance \u2014 Whenever you cast a noncreature spell, exile up to one target nonland permanent you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -21293,7 +21293,7 @@
         },
         {
             "id": "69f80a8b-f0f8-55ad-84a1-4dad0695a18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3184cbb-71d4-4b33-ae5d-f8d18b36ba22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3184cbb-71d4-4b33-ae5d-f8d18b36ba22.jpg?1",
             "name": "Elminster's Simulacrum",
             "text": "For each opponent, you create a token that's a copy of up to one target creature that player controls.",
             "colours": [
@@ -21327,7 +21327,7 @@
         },
         {
             "id": "3608a839-e667-5b54-9b30-b93337410083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f204b1-73cb-4d51-8003-97e83d6b52b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f204b1-73cb-4d51-8003-97e83d6b52b8.jpg?1",
             "name": "Font of Magic",
             "text": "Instant and sorcery spells you cast cost {1} less to cast for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -21361,7 +21361,7 @@
         },
         {
             "id": "35cc2be2-9d3a-5e3f-9d24-3923c3b7a10b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaaa47-236e-48ff-a601-a454afc0250f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaaa47-236e-48ff-a601-a454afc0250f.jpg?1",
             "name": "Gale's Redirection",
             "text": "Exile target spell, then roll a d20 and add that spell's mana value.\n1\u201314 | You may cast the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\n15+ | You may cast the exiled card without paying its mana cost for as long as it remains exiled.",
             "colours": [
@@ -21395,7 +21395,7 @@
         },
         {
             "id": "14c4e5fc-8545-56aa-b73f-58e07a1f5814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Ceremorphosis \u2014 When Illithid Harvester enters the battlefield, turn any number of target tapped nontoken creatures face down. They're 2/2 Horror creatures.",
             "colours": [
@@ -21431,7 +21431,7 @@
         },
         {
             "id": "38a2308c-57be-5bf4-bf9d-fcd7cbcb90ea",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/022d2005-2a09-4f9a-802c-e655bfcb95f4.jpg?1",
             "name": "Illithid Harvester // Plant Tadpoles",
             "text": "Tap X target creatures. They don't untap during their controllers' next untap steps. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -21467,7 +21467,7 @@
         },
         {
             "id": "2bc6ddd4-53cc-5b51-b3df-9f363a59b6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f744b4e-18be-4d41-8ea5-eac47a32cfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f744b4e-18be-4d41-8ea5-eac47a32cfcf.jpg?1",
             "name": "Kindred Discovery",
             "text": "As Kindred Discovery enters the battlefield, choose a creature type.\nWhenever a creature you control of the chosen type enters the battlefield or attacks, draw a card.",
             "colours": [
@@ -21501,7 +21501,7 @@
         },
         {
             "id": "7049f82f-0335-59b6-a85e-98cc8d84c5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76c7f02-43dd-437d-82c7-79ef7de5b916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76c7f02-43dd-437d-82c7-79ef7de5b916.jpg?1",
             "name": "Robe of the Archmagi",
             "text": "Whenever equipped creature deals combat damage to a player, you draw that many cards.\nEquip {4}\nEquip Shaman, Warlock, or Wizard {1}",
             "colours": [
@@ -21537,7 +21537,7 @@
         },
         {
             "id": "b3ccef91-fd62-5fbe-8be9-d7e3cc1818ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4cbadb-ca60-4a4b-97d3-c9133feefb54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4cbadb-ca60-4a4b-97d3-c9133feefb54.jpg?1",
             "name": "Tomb of Horrors Adventurer",
             "text": "When Tomb of Horrors Adventurer enters the battlefield, you take the initiative.\nWhenever you cast your second spell each turn, copy it. If you've completed a dungeon, copy that spell twice instead. You may choose new targets for the copies.",
             "colours": [
@@ -21574,7 +21574,7 @@
         },
         {
             "id": "a0199f3d-8ca3-5ce6-9eb0-74b98a3641dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c434dcde-8745-447f-8675-03ae6b57ec3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c434dcde-8745-447f-8675-03ae6b57ec3b.jpg?1",
             "name": "Wizards of Thay",
             "text": "Myriad\nInstant and sorcery spells you cast cost {1} less to cast.\nYou may cast sorcery spells as though they had flash.",
             "colours": [
@@ -21611,7 +21611,7 @@
         },
         {
             "id": "041c3653-d6ef-52b5-9225-c127aba299b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "{2}{B}, {T}, Exile a creature you control: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -21645,7 +21645,7 @@
         },
         {
             "id": "104260ef-d40f-53cf-9dc1-e20f477625e8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18098505-2d75-4310-bf1e-788b85ac3aed.jpg?1",
             "name": "Altar of Bhaal // Bone Offering",
             "text": "Create a tapped 4/1 black Skeleton creature token with menace. (Then exile this card. You may cast the artifact later from exile.)",
             "colours": [
@@ -21681,7 +21681,7 @@
         },
         {
             "id": "50073cee-07f8-52d9-8141-3c52ef28018e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653436b2-899c-48e9-b069-1ec84844cc48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653436b2-899c-48e9-b069-1ec84844cc48.jpg?1",
             "name": "Astarion's Thirst",
             "text": "Exile target creature. Put X +1/+1 counters on a commander creature you control, where X is the power of the creature exiled this way.",
             "colours": [
@@ -21715,7 +21715,7 @@
         },
         {
             "id": "caa90052-1b45-5720-849d-e83fc8b3da08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9875dc-b271-40a6-b6e1-f9f0fbb00db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9875dc-b271-40a6-b6e1-f9f0fbb00db7.jpg?1",
             "name": "Blood Money",
             "text": "Destroy all creatures. For each nontoken creature destroyed this way, you create a tapped Treasure token.",
             "colours": [
@@ -21749,7 +21749,7 @@
         },
         {
             "id": "dcc8b391-16f1-56e9-add3-887c04f46419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d7a1c-2f9a-4af7-9795-4046ac96347a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d7a1c-2f9a-4af7-9795-4046ac96347a.jpg?1",
             "name": "Call to the Void",
             "text": "Each player secretly chooses a creature they control and a creature they don't control. Then those choices are revealed. Destroy each creature chosen this way.",
             "colours": [
@@ -21783,7 +21783,7 @@
         },
         {
             "id": "67cf0ca6-5b62-567f-8089-383aa7623ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e49d20-170a-4b6a-ac82-d3ceaab226ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e49d20-170a-4b6a-ac82-d3ceaab226ea.jpg?1",
             "name": "Elder Brain",
             "text": "Menace\nWhenever Elder Brain attacks a player, exile all cards from that player's hand, then they draw that many cards. You may play lands and cast spells from among the exiled cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -21820,7 +21820,7 @@
         },
         {
             "id": "293dcfea-6224-5821-9e84-242cbab84138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a741f-288c-4f19-b200-cacef57674e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a741f-288c-4f19-b200-cacef57674e9.jpg?1",
             "name": "Eldritch Pact",
             "text": "Target player draws X cards and loses X life, where X is the number of cards in their graveyard.",
             "colours": [
@@ -21854,7 +21854,7 @@
         },
         {
             "id": "24a2f4b3-99a5-5932-a97b-9149c36be3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73342536-fd44-4958-b77e-56eec222252e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73342536-fd44-4958-b77e-56eec222252e.jpg?1",
             "name": "Intellect Devourer",
             "text": "Devour Intellect \u2014 When Intellect Devourer enters the battlefield, each opponent exiles a card from their hand until Intellect Devourer leaves the battlefield.\nBody Thief \u2014 You may play lands and cast spells from among cards exiled with Intellect Devourer. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -21890,7 +21890,7 @@
         },
         {
             "id": "a297d7a8-ee4a-5af4-8671-6a59ca63970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdfbc37-f259-42c0-a8cd-c772a0343257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdfbc37-f259-42c0-a8cd-c772a0343257.jpg?1",
             "name": "Pact Weapon",
             "text": "As long as Pact Weapon is attached to a creature, you don't lose the game for having 0 or less life.\nWhenever equipped creature attacks, draw a card and reveal it. The creature gets +X/+X until end of turn and you lose X life, where X is that card's mana value.\nEquip\u2014\nDiscard a card.",
             "colours": [
@@ -21926,7 +21926,7 @@
         },
         {
             "id": "e55b66c6-dde8-5e62-ab79-ac461f0eaba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057dedd1-6632-4d87-a5bb-8c66c7492857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057dedd1-6632-4d87-a5bb-8c66c7492857.jpg?1",
             "name": "Ravenloft Adventurer",
             "text": "When Ravenloft Adventurer enters the battlefield, you take the initiative.\nIf a creature an opponent controls would die, instead exile it and put a hit counter on it.\nWhenever Ravenloft Adventurer attacks, if you've completed a dungeon, defending player loses 1 life for each card they own in exile with a hit counter on it.",
             "colours": [
@@ -21964,7 +21964,7 @@
         },
         {
             "id": "4e7537da-57b4-5e83-9a0f-e75fe9034553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc9987-73f6-4cbe-9965-1894deabd080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc9987-73f6-4cbe-9965-1894deabd080.jpg?1",
             "name": "Balor",
             "text": "Flying\nWhenever Balor attacks or dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent draws three cards, then discards three cards at random.\n\u2022 Target opponent sacrifices a nontoken artifact.\n\u2022 Balor deals damage to target opponent equal to the number of cards in their hand.",
             "colours": [
@@ -22000,7 +22000,7 @@
         },
         {
             "id": "fd6760cb-b48b-5c43-8e70-3e6859555f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb5d440-8f2c-4b21-8fdb-fd40e5710475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb5d440-8f2c-4b21-8fdb-fd40e5710475.jpg?1",
             "name": "Caves of Chaos Adventurer",
             "text": "Trample\nWhen Caves of Chaos Adventurer enters the battlefield, you take the initiative.\nWhenever Caves of Chaos Adventurer attacks, exile the top card of your library. If you've completed a dungeon, you may play that card this turn without paying its mana cost. Otherwise, you may play that card this turn.",
             "colours": [
@@ -22037,7 +22037,7 @@
         },
         {
             "id": "84b4d9c3-1f42-51ad-b303-a0833ad24c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75e9d08-489d-42ee-9513-0984d25d8c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75e9d08-489d-42ee-9513-0984d25d8c4a.jpg?1",
             "name": "Descent into Avernus",
             "text": "At the beginning of your upkeep, put two descent counters on Descent into Avernus. Then each player creates X Treasure tokens and Descent into Avernus deals X damage to each player, where X is the number of descent counters on Descent into Avernus.",
             "colours": [
@@ -22071,7 +22071,7 @@
         },
         {
             "id": "dd62e7b7-1e49-5723-9320-c1d75e1caac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7828e-3e92-4a94-9090-24353fc2e670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7828e-3e92-4a94-9090-24353fc2e670.jpg?1",
             "name": "Elturel Survivors",
             "text": "Trample, myriad\nAs long as Elturel Survivors is attacking, it gets +X/+0, where X is the number of lands defending player controls.",
             "colours": [
@@ -22108,7 +22108,7 @@
         },
         {
             "id": "ea66057a-1ede-5934-82d5-e37d832150dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738abf75-009d-439d-91d5-07545bccdb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738abf75-009d-439d-91d5-07545bccdb1f.jpg?1",
             "name": "Firbolg Flutist",
             "text": "Enthralling Performance \u2014 When Firbolg Flutist enters the battlefield, gain control of target creature you don't control until end of turn. Untap it. It gains haste and myriad until end of turn.",
             "colours": [
@@ -22145,7 +22145,7 @@
         },
         {
             "id": "2d6523c3-5a13-5401-bd3c-cbe93515239c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4096d51-2b96-489f-9fb9-631f47706fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4096d51-2b96-489f-9fb9-631f47706fd0.jpg?1",
             "name": "Storm King's Thunder",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell X times. You may choose new targets for the copies.",
             "colours": [
@@ -22179,7 +22179,7 @@
         },
         {
             "id": "e495c38d-479e-5df0-ba5d-7fd1bdfa20bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fffd5-dba1-4987-ac99-7d516dcd203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fffd5-dba1-4987-ac99-7d516dcd203b.jpg?1",
             "name": "Wand of Wonder",
             "text": "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1\u20139 | X is one.\n10\u201319 | X is two.\n20 | X is three.",
             "colours": [
@@ -22214,7 +22214,7 @@
         },
         {
             "id": "2ad75ba1-4a60-5863-8395-be3a6a00f88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8965c80-dece-4f36-aa75-c2b5ced40800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8965c80-dece-4f36-aa75-c2b5ced40800.jpg?1",
             "name": "Wrathful Red Dragon",
             "text": "Flying\nWhenever a Dragon you control is dealt damage, it deals that much damage to any target that isn't a Dragon.",
             "colours": [
@@ -22250,7 +22250,7 @@
         },
         {
             "id": "c3039b8f-d4c6-5b12-8d8c-589aad375f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4070ed-146e-490e-ae76-bfaa26b13b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4070ed-146e-490e-ae76-bfaa26b13b18.jpg?1",
             "name": "Wyll's Reversal",
             "text": "Choose target spell or ability with one or more targets. Roll a d20 and add the greatest power among creatures you control.\n1\u201314 | You may choose new targets for that spell or ability.\n15+ | You may choose new targets for that spell or ability. Then copy it. You may choose new targets for the copy.",
             "colours": [
@@ -22284,7 +22284,7 @@
         },
         {
             "id": "e531f8bb-480b-56d4-9d3a-d6cc8c6ee45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84188f7b-0338-4313-a794-8e858736dff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84188f7b-0338-4313-a794-8e858736dff9.jpg?1",
             "name": "Barroom Brawl",
             "text": "Target creature you control fights target creature the opponent to your left controls. Then that player may copy this spell and may choose new targets for the copy.",
             "colours": [
@@ -22318,7 +22318,7 @@
         },
         {
             "id": "80a8975d-abae-5329-8b47-a5d5ceea4b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edfb64-2177-442d-bd10-7ed1fdaa3537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edfb64-2177-442d-bd10-7ed1fdaa3537.jpg?1",
             "name": "Earthquake Dragon",
             "text": "This spell costs {X} less to cast, where X is the total mana value of Dragons you control.\nFlying, trample\n{2}{G}, Sacrifice a land: Return Earthquake Dragon from your graveyard to your hand.",
             "colours": [
@@ -22355,7 +22355,7 @@
         },
         {
             "id": "9a264dc2-dc9b-5da7-9264-2e28dbea7bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0a6836-6b45-4528-85bd-1de8b28ab4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0a6836-6b45-4528-85bd-1de8b28ab4d8.jpg?1",
             "name": "Jaheira's Respite",
             "text": "Search your library for up to X basic land cards, where X is the number of creatures attacking you, put those cards onto the battlefield tapped, then shuffle.\nPrevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -22389,7 +22389,7 @@
         },
         {
             "id": "0846ff07-76e5-56b2-9466-85b56c2512a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528ef70f-4844-48fa-a768-4003c6ee6dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528ef70f-4844-48fa-a768-4003c6ee6dae.jpg?1",
             "name": "Majestic Genesis",
             "text": "Reveal the top X cards of your library, where X is the greatest mana value of a commander you own on the battlefield or in the command zone. You may put any number of permanent cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -22423,7 +22423,7 @@
         },
         {
             "id": "0d90e36f-1a0e-5373-af4b-02ac1d113590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -22457,7 +22457,7 @@
         },
         {
             "id": "a99ecdf6-e82d-565c-8be7-3ec2ffe08328",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc00c54e-9159-4c4d-80d9-9e873ee35d73.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -22493,7 +22493,7 @@
         },
         {
             "id": "46c4fef8-49da-5b32-bd78-93bbcbf4f458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc39cc-c5ae-4e6e-ba31-f30841d49351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc39cc-c5ae-4e6e-ba31-f30841d49351.jpg?1",
             "name": "Owlbear Cub",
             "text": "Mama's Coming \u2014 Whenever Owlbear Cub attacks a player who controls eight or more lands, look at the top eight cards of your library. You may put a creature card from among them onto the battlefield tapped and attacking that player. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -22530,7 +22530,7 @@
         },
         {
             "id": "74fd2993-652c-5841-8e93-7693f2becd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba004fc5-c144-41fa-abc1-531a977378a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba004fc5-c144-41fa-abc1-531a977378a8.jpg?1",
             "name": "Traverse the Outlands",
             "text": "Search your library for up to X basic land cards, where X is the greatest power among creatures you control. Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22564,7 +22564,7 @@
         },
         {
             "id": "f3263161-b7d7-5044-9bc9-324bd8276fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f3d5a-2d94-4765-bf51-192d7f6021b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f3d5a-2d94-4765-bf51-192d7f6021b1.jpg?1",
             "name": "Undermountain Adventurer",
             "text": "Vigilance\nWhen Undermountain Adventurer enters the battlefield, you take the initiative.\n{T}: Add {G}{G}. If you've completed a dungeon, add six {G} instead.",
             "colours": [
@@ -22601,7 +22601,7 @@
         },
         {
             "id": "67f3c313-9f7d-5ca0-93c7-569dc4371c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0225d038-bba4-4965-8f90-5d9d2e6dcf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0225d038-bba4-4965-8f90-5d9d2e6dcf70.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -22633,7 +22633,7 @@
         },
         {
             "id": "e616594a-0780-57b6-b2ad-e3962db7aeb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbaaf68-c97f-443b-9be9-e6567925eddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbaaf68-c97f-443b-9be9-e6567925eddc.jpg?1",
             "name": "Blade of Selves",
             "text": "Equipped creature has myriad.\nEquip {4}",
             "colours": [],
@@ -22665,7 +22665,7 @@
         },
         {
             "id": "05bb1145-702f-59ca-9ec2-6b4222b4cac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f831e-3ed1-464f-8b7a-dbbff0733f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f831e-3ed1-464f-8b7a-dbbff0733f81.jpg?1",
             "name": "Fraying Line",
             "text": "When Fraying Line enters the battlefield, put a rope counter on target creature you control.\nAt the beginning of each player's upkeep, that player may pay {2}. If they do, they put a rope counter on a creature they control. Otherwise, exile Fraying Line and each creature without a rope counter on it, then remove all rope counters from all creatures.",
             "colours": [],
@@ -22695,7 +22695,7 @@
         },
         {
             "id": "777bbd42-57a1-594f-af45-48644b9ab016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c420e-5abe-4339-a47f-bcbf756045a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c420e-5abe-4339-a47f-bcbf756045a2.jpg?1",
             "name": "Mighty Servant of Leuk-o",
             "text": "Trample\nWard\u2014\nDiscard a card.\nWhenever Mighty Servant of Leuk-o becomes crewed for the first time each turn, if it was crewed by exactly two creatures, it gains \"Whenever this creature deals combat damage to a player, draw two cards\" until end of turn.\nCrew 4",
             "colours": [],
@@ -22727,7 +22727,7 @@
         },
         {
             "id": "24602bc7-f2df-5217-9075-6091f72f8fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2f8bc-a907-4511-87be-9f8a87b4a1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2f8bc-a907-4511-87be-9f8a87b4a1f0.jpg?1",
             "name": "Mirror of Life Trapping",
             "text": "Whenever a creature enters the battlefield, if it was cast, exile it, then return all other permanent cards exiled with Mirror of Life Trapping to the battlefield under their owners' control.",
             "colours": [],
@@ -22757,7 +22757,7 @@
         },
         {
             "id": "49c06f60-75ae-5220-8710-2c9472e95007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890abef-5291-4ffd-9c15-41c776ea9a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890abef-5291-4ffd-9c15-41c776ea9a00.jpg?1",
             "name": "Baldur's Gate",
             "text": "{T}: Add {C}.\n{2}, {T}: Add X mana of any one color, where X is the number of other Gates you control.",
             "colours": [],
@@ -22791,7 +22791,7 @@
         },
         {
             "id": "11db9b17-0dc2-5270-800e-ff0eb4f2ab79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cad6ad-9548-4732-81b3-97cf15a544ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cad6ad-9548-4732-81b3-97cf15a544ab.jpg?1",
             "name": "Bountiful Promenade",
             "text": "Bountiful Promenade enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -22824,7 +22824,7 @@
         },
         {
             "id": "06484fe5-7fc6-5bbe-8feb-f6befce09b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f76198-f04c-433b-823f-e99ea54c01ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f76198-f04c-433b-823f-e99ea54c01ee.jpg?1",
             "name": "Luxury Suite",
             "text": "Luxury Suite enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -22857,7 +22857,7 @@
         },
         {
             "id": "63a5546f-82af-5c7d-821c-4f9ad9f12877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c569b0-f011-4570-9eb8-b819f8fe54f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c569b0-f011-4570-9eb8-b819f8fe54f6.jpg?1",
             "name": "Morphic Pool",
             "text": "Morphic Pool enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -22890,7 +22890,7 @@
         },
         {
             "id": "7bf02b86-7f75-5879-8aa0-7d6a14ba0883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6509467-3acf-4e53-9087-b6bc18bf0fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6509467-3acf-4e53-9087-b6bc18bf0fd1.jpg?1",
             "name": "Reflecting Pool",
             "text": "{T}: Add one mana of any type that a land you control could produce.",
             "colours": [],
@@ -22920,7 +22920,7 @@
         },
         {
             "id": "e9e62a6c-6fa4-57b5-91aa-b1d993246744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521f3f6-f90c-4fde-9b53-0e7301a5f8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521f3f6-f90c-4fde-9b53-0e7301a5f8b7.jpg?1",
             "name": "Sea of Clouds",
             "text": "Sea of Clouds enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -22953,7 +22953,7 @@
         },
         {
             "id": "1096d743-cf8c-5017-ae56-fbff42d44d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0df5f8-6660-4908-bc00-2fd4c270ab6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0df5f8-6660-4908-bc00-2fd4c270ab6e.jpg?1",
             "name": "Spire Garden",
             "text": "Spire Garden enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -22986,7 +22986,7 @@
         },
         {
             "id": "55ae184b-85cf-508e-ba89-adcf46ac7771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac23a376-4b3a-4316-b3e2-2e25ca2b5e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac23a376-4b3a-4316-b3e2-2e25ca2b5e76.jpg?1",
             "name": "Deep Gnome Terramancer",
             "text": "Flash\nMold Earth \u2014 Whenever one or more lands enter the battlefield under an opponent's control without being played, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle. Do this only once each turn.",
             "colours": [
@@ -23022,7 +23022,7 @@
         },
         {
             "id": "af586419-db68-58a4-abe5-d518cd8a8a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848c10bc-3d08-4706-ab8e-e9c84a0c0c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848c10bc-3d08-4706-ab8e-e9c84a0c0c3d.jpg?1",
             "name": "Folk Hero",
             "text": "Commander creatures you own have \"Whenever you cast a spell that shares a creature type with this creature, draw a card. This ability triggers only once each turn.\"",
             "colours": [
@@ -23060,7 +23060,7 @@
         },
         {
             "id": "dc36dccf-6a97-5993-8ab0-981685ebbd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7166157a-cea9-4dd8-8bac-c3790da6a942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7166157a-cea9-4dd8-8bac-c3790da6a942.jpg?1",
             "name": "Harper Recruiter",
             "text": "Flying\nWhenever Harper Recruiter attacks, look at the top four cards of your library. You may reveal a Cleric card, a Rogue card, a Warrior card, and/or a Wizard card from among them and put those cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -23097,7 +23097,7 @@
         },
         {
             "id": "70284b7a-2b5c-5719-ac74-1dd9c6700c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648d9da3-5790-4d64-8b52-83141d2faf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648d9da3-5790-4d64-8b52-83141d2faf36.jpg?1",
             "name": "Seasoned Dungeoneer",
             "text": "When Seasoned Dungeoneer enters the battlefield, you take the initiative.\nWhenever you attack, target attacking Cleric, Rogue, Warrior, or Wizard gains protection from creatures until end of turn. It explores.",
             "colours": [
@@ -23133,7 +23133,7 @@
         },
         {
             "id": "468cb4ca-9e3d-54fc-83d6-1acde7171fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0870aef-cae2-4670-a866-28cad523ca39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0870aef-cae2-4670-a866-28cad523ca39.jpg?1",
             "name": "Stick Together",
             "text": "Each player chooses a party from among creatures they control, then sacrifices the rest. (To choose a party, choose up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -23167,7 +23167,7 @@
         },
         {
             "id": "9267a5e5-e49e-5070-9dba-21f45ed02451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01693860-2f79-4777-b2f5-5ebfbff8ad42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01693860-2f79-4777-b2f5-5ebfbff8ad42.jpg?1",
             "name": "Aboleth Spawn",
             "text": "Flash\nWard {2}\nProbing Telepathy \u2014 Whenever a creature entering the battlefield under an opponent's control causes a triggered ability of that creature to trigger, you may copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -23203,7 +23203,7 @@
         },
         {
             "id": "38ac640b-9d90-5486-934c-822719cc8053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf8b03-1f5c-46c5-a684-ae5c04630286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf8b03-1f5c-46c5-a684-ae5c04630286.jpg?1",
             "name": "Astral Dragon",
             "text": "Flying\nProject Image \u2014 When Astral Dragon enters the battlefield, create two tokens that are copies of target noncreature permanent, except they're 3/3 Dragon creatures in addition to their other types, and they have flying.",
             "colours": [
@@ -23238,7 +23238,7 @@
         },
         {
             "id": "44aa4dd5-9cd7-5355-be97-31180b76de98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef54f6-c7d0-42ac-86f1-80457cb3241e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ef54f6-c7d0-42ac-86f1-80457cb3241e.jpg?1",
             "name": "Clan Crafter",
             "text": "Commander creatures you own have \"{2}, Sacrifice an artifact: Put a +1/+1 counter on this creature and draw a card.\"",
             "colours": [
@@ -23276,7 +23276,7 @@
         },
         {
             "id": "735e577a-142c-5d64-a5a4-ba980467f5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428343cf-54e6-42df-aee3-d85e6874e437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428343cf-54e6-42df-aee3-d85e6874e437.jpg?1",
             "name": "Endless Evil",
             "text": "Enchant creature you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except the token is 1/1.\nWhen enchanted creature dies, if that creature was a Horror, return Endless Evil to its owner's hand.",
             "colours": [
@@ -23311,7 +23311,7 @@
         },
         {
             "id": "4946fb87-fbfd-5fce-82a1-ac3c7da74d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ca0ae3-0529-49b1-aff7-d3a05eae45ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ca0ae3-0529-49b1-aff7-d3a05eae45ba.jpg?1",
             "name": "Grell Philosopher",
             "text": "Aberrant Tinkering \u2014 When Grell Philosopher enters the battlefield and at the beginning of your upkeep, each Horror you control gains all activated abilities of target artifact an opponent controls until end of turn. You may spend blue mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -23347,7 +23347,7 @@
         },
         {
             "id": "289f657d-c064-5f6f-a614-49f26781148a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb48ed1-6386-4f3f-8413-671b59eb7b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb48ed1-6386-4f3f-8413-671b59eb7b96.jpg?1",
             "name": "Mocking Doppelganger",
             "text": "Flash\nYou may have Mocking Doppelganger enter the battlefield as a copy of a creature an opponent controls, except it has \"Other creatures with the same name as this creature are goaded.\"",
             "colours": [
@@ -23382,7 +23382,7 @@
         },
         {
             "id": "1a7d2a9c-2cf5-51eb-9aaa-f984cc2b1368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b5739a-e228-4b9a-871b-0d4684d5cf89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b5739a-e228-4b9a-871b-0d4684d5cf89.jpg?1",
             "name": "Psionic Ritual",
             "text": "Replicate\u2014\nTap an untapped Horror you control.\nExile target instant or sorcery card from a graveyard and copy it. You may cast the copy without paying its mana cost.\nExile Psionic Ritual.",
             "colours": [
@@ -23415,7 +23415,7 @@
         },
         {
             "id": "1c8a73ce-dd4e-520c-8e63-72e47fad4d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba00ab71-f686-46eb-af3a-7d70f22e13b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba00ab71-f686-46eb-af3a-7d70f22e13b6.jpg?1",
             "name": "Zellix, Sanity Flayer",
             "text": "Hive Mind \u2014 Whenever a player mills one or more creature cards, you create a 1/1 black Horror creature token.\n{1}, {T}: Target player mills three cards.\nChoose a Background",
             "colours": [
@@ -23453,7 +23453,7 @@
         },
         {
             "id": "d285f4d8-b5b6-514a-86d5-e7866fe54f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b28572c-d2ba-4834-8630-3d82202ebb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b28572c-d2ba-4834-8630-3d82202ebb6f.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life.",
             "colours": [
@@ -23486,7 +23486,7 @@
         },
         {
             "id": "128d4dac-b685-548e-a1dc-6403141d2196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdeda32b-9c70-47c6-bfbe-06b651af1ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdeda32b-9c70-47c6-bfbe-06b651af1ce1.jpg?1",
             "name": "Brainstealer Dragon",
             "text": "Flying\nAt the beginning of your end step, exile the top card of each opponent's library. You may play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.\nWhenever a nonland permanent an opponent owns enters the battlefield under your control, they lose life equal to its mana value.",
             "colours": [
@@ -23522,7 +23522,7 @@
         },
         {
             "id": "dc96dfbb-10e9-553d-8007-448c7eeeff7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acd5ba4-444e-4ac7-a888-6230be54374d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acd5ba4-444e-4ac7-a888-6230be54374d.jpg?1",
             "name": "Burakos, Party Leader",
             "text": "Burakos, Party Leader is also a Cleric, Rogue, Warrior, and Wizard.\nWhenever Burakos attacks, defending player loses X life and you create X Treasure tokens, where X is the number of creatures in your party.\nChoose a Background",
             "colours": [
@@ -23560,7 +23560,7 @@
         },
         {
             "id": "2fcfa363-39f4-54f9-bfae-585e04667e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df4c09f-0140-4b7c-85f8-c3d9e5b91638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df4c09f-0140-4b7c-85f8-c3d9e5b91638.jpg?1",
             "name": "From the Catacombs",
             "text": "Put target creature card from a graveyard onto the battlefield under your control with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.\nYou take the initiative.\nEscape\u2014{3}{B}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -23593,7 +23593,7 @@
         },
         {
             "id": "89f18945-73e4-5460-a8f4-676b6bf01b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb9b67c-b0e4-4c62-8332-74a53b67f3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb9b67c-b0e4-4c62-8332-74a53b67f3bb.jpg?1",
             "name": "Haunted One",
             "text": "Commander creatures you own have \"Whenever this creature becomes tapped, it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn.\"",
             "colours": [
@@ -23631,7 +23631,7 @@
         },
         {
             "id": "eb9438f3-96b5-5fa1-ad63-8905500a9c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a013f6d-e8ac-4fed-8e9f-a616881b0404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a013f6d-e8ac-4fed-8e9f-a616881b0404.jpg?1",
             "name": "Solemn Doomguide",
             "text": "Flying\nEach creature card in your graveyard that's a Cleric, Rogue, Warrior, and/or Wizard has unearth {1}{B}.",
             "colours": [
@@ -23667,7 +23667,7 @@
         },
         {
             "id": "f04aad36-a84b-53a9-aba4-d7f25ce2009c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893a0e6-bac4-4758-a0f9-42521e5d0777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893a0e6-bac4-4758-a0f9-42521e5d0777.jpg?1",
             "name": "Uchuulon",
             "text": "Uchuulon's power is equal to the number of Crabs, Oozes, and/or Horrors you control.\nHorrific Symbiosis \u2014 At the beginning of your end step, exile up to one target creature card from an opponent's graveyard. If you do, create a token that's a copy of Uchuulon.",
             "colours": [
@@ -23704,7 +23704,7 @@
         },
         {
             "id": "754b99fd-8db6-5346-a1d5-78e013411fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c1e006-77bf-4adb-bb65-23262edfaf6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c1e006-77bf-4adb-bb65-23262edfaf6d.jpg?1",
             "name": "Baeloth Barrityl, Entertainer",
             "text": "Creatures your opponents control with power less than Baeloth Barrityl's power are goaded.\nWhenever a goaded attacking or blocking creature dies, you create a Treasure token.\nChoose a Background",
             "colours": [
@@ -23743,7 +23743,7 @@
         },
         {
             "id": "31627de1-382c-5894-a71e-16ae3498977a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37544c90-371a-42c2-910d-d0f4de5c8537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37544c90-371a-42c2-910d-d0f4de5c8537.jpg?1",
             "name": "Bothersome Quasit",
             "text": "Menace\nGoaded creatures your opponents control can't block.\nWhenever you cast a noncreature spell, goad target creature an opponent controls.",
             "colours": [
@@ -23778,7 +23778,7 @@
         },
         {
             "id": "6715f995-eca8-5eea-a24e-e63631e8758f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0c414b-4345-4787-8a9e-d9f82c5ba9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0c414b-4345-4787-8a9e-d9f82c5ba9b9.jpg?1",
             "name": "Death Kiss",
             "text": "Whenever a creature an opponent controls attacks one of your opponents, double its power until end of turn.\n{X}{X}{R}: Monstrosity X.\nWhen Death Kiss becomes monstrous, goad up to X target creatures your opponents control.",
             "colours": [
@@ -23813,7 +23813,7 @@
         },
         {
             "id": "24c82576-7a3b-5e20-b77f-ba48b4140a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400c76c6-f677-4e7e-87ad-2e526d4b498a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400c76c6-f677-4e7e-87ad-2e526d4b498a.jpg?1",
             "name": "Delayed Blast Fireball",
             "text": "Delayed Blast Fireball deals 2 damage to each opponent and each creature they control. If this spell was cast from exile, it deals 5 damage to each opponent and each creature they control instead.\nForetell {4}{R}{R}",
             "colours": [
@@ -23846,7 +23846,7 @@
         },
         {
             "id": "a407c97e-0328-5792-941f-7e8039826b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a225e62-e95d-4b9b-aab7-25925e35b925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a225e62-e95d-4b9b-aab7-25925e35b925.jpg?1",
             "name": "Loot Dispute",
             "text": "When Loot Dispute enters the battlefield, you take the initiative and create a Treasure token.\nWhenever you attack the player who has the initiative, create a Treasure token.\nLoud Ruckus \u2014 Whenever you complete a dungeon, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -23879,7 +23879,7 @@
         },
         {
             "id": "c7f36ea4-b3c8-5e2d-aa4e-97ed36de133d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e3b25f-beb1-4688-8b14-be597b9aee81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e3b25f-beb1-4688-8b14-be597b9aee81.jpg?1",
             "name": "Nalfeshnee",
             "text": "Flying\nWhenever you cast a spell from exile, copy it. You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\"",
             "colours": [
@@ -23915,7 +23915,7 @@
         },
         {
             "id": "3a532aa6-591a-5aa8-8f86-19485642e741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b515f-732d-415a-bc1e-6f1022150ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b515f-732d-415a-bc1e-6f1022150ebd.jpg?1",
             "name": "Passionate Archaeologist",
             "text": "Commander creatures you own have \"Whenever you cast a spell from exile, this creature deals damage equal to that spell's mana value to target opponent.\"",
             "colours": [
@@ -23953,7 +23953,7 @@
         },
         {
             "id": "25775b9f-c7a3-5423-9e38-fa52638a4cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0036977-7dc3-4147-9303-4060694c5db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0036977-7dc3-4147-9303-4060694c5db4.jpg?1",
             "name": "Spectacular Showdown",
             "text": "Put a double strike counter on target creature, then goad each creature that had a double strike counter put on it this way.\nOverload {4}{R}{R}{R}",
             "colours": [
@@ -23986,7 +23986,7 @@
         },
         {
             "id": "c3c48205-222a-5355-b250-63d8ebf6c298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2347c1fd-9a7d-470b-9e8e-d75b6a5b7f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2347c1fd-9a7d-470b-9e8e-d75b6a5b7f23.jpg?1",
             "name": "Durnan of the Yawning Portal",
             "text": "Whenever Durnan attacks, look at the top four cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in any order. For as long as that card remains exiled, you may cast it. That spell has undaunted.\nChoose a Background",
             "colours": [
@@ -24025,7 +24025,7 @@
         },
         {
             "id": "0fe67e17-2e14-5bfe-b88b-7aa96b11b69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f700972f-2c26-443b-9af0-72a4b5d4d723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f700972f-2c26-443b-9af0-72a4b5d4d723.jpg?1",
             "name": "Green Slime",
             "text": "Flash\nWhen Green Slime enters the battlefield, counter target activated or triggered ability from an artifact or enchantment source. If a permanent's ability is countered this way, destroy that permanent.\nForetell {G}",
             "colours": [
@@ -24060,7 +24060,7 @@
         },
         {
             "id": "6a25f8d2-5f25-5e5b-baff-094bd694862a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0a5d1d-0aa2-4655-96ce-156eb82d7afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0a5d1d-0aa2-4655-96ce-156eb82d7afa.jpg?1",
             "name": "Journey to the Lost City",
             "text": "At the beginning of your upkeep, exile the top four cards of your library, then roll a d20.\n1\u20139 | You may put a land card from among those cards onto the battlefield.\n10\u201319 | Create a 2/2 green Wolf creature token, then put a +1/+1 counter on it for each creature card among those cards.\n20 | Put all permanent cards exiled with Journey to the Lost City onto the battlefield, then sacrifice it.",
             "colours": [
@@ -24093,7 +24093,7 @@
         },
         {
             "id": "35b4d9b2-ea75-51b2-8d39-7626a550aebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Trample\nOnce each turn, you may pay {0} rather than pay the mana cost for a creature spell you cast from exile.",
             "colours": [
@@ -24129,7 +24129,7 @@
         },
         {
             "id": "84a4e1dd-5150-5ee0-a427-899c4d681c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7ebbbf7-8ece-41ba-b9be-cbd62f0ca473.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Exile target creature card from your graveyard. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -24164,7 +24164,7 @@
         },
         {
             "id": "520b5930-93bf-55ba-900a-845ab1d01950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05987b6e-beb6-4ab0-9cd4-b9928959625c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05987b6e-beb6-4ab0-9cd4-b9928959625c.jpg?1",
             "name": "Venture Forth",
             "text": "Exile cards from the top of your library until you exile a land card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Exile Venture Forth with three time counters on it.\nSuspend 3\u2014{1}{G}",
             "colours": [
@@ -24197,7 +24197,7 @@
         },
         {
             "id": "be1a3f7b-4fa6-5dc8-ad1d-df07eb678786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512c364-9512-4566-aa96-4a2884ec6230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512c364-9512-4566-aa96-4a2884ec6230.jpg?1",
             "name": "Captain N'ghathrod",
             "text": "Horrors you control have menace.\nWhenever a Horror you control deals combat damage to a player, that player mills that many cards.\nAt the beginning of your end step, choose target artifact or creature card in an opponent's graveyard that was put there from their library this turn. Put it onto the battlefield under your control.",
             "colours": [
@@ -24239,7 +24239,7 @@
         },
         {
             "id": "46d0aa00-b0b0-5437-8258-324e956c56e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba78cd7-a3b6-4ef2-b6b7-3416c0ba61f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba78cd7-a3b6-4ef2-b6b7-3416c0ba61f1.jpg?1",
             "name": "Faldorn, Dread Wolf Herald",
             "text": "Whenever you cast a spell from exile or a land enters the battlefield under your control from exile, create a 2/2 green Wolf creature token.\n{1}, {T}, Discard a card: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -24281,7 +24281,7 @@
         },
         {
             "id": "41340e62-61bd-5ee7-9d9d-14a307f2a27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7b14d-c860-448e-8d7b-66ea05be281c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7b14d-c860-448e-8d7b-66ea05be281c.jpg?1",
             "name": "Firkraag, Cunning Instigator",
             "text": "Flying, haste\nWhenever one or more Dragons you control attack an opponent, goad target creature that player controls.\nWhenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag, Cunning Instigator and you draw a card.",
             "colours": [
@@ -24322,7 +24322,7 @@
         },
         {
             "id": "7d9c82e6-7ae0-5320-9e29-f9e5c9530972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee97908-314a-4704-a8bd-962fcb4db947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee97908-314a-4704-a8bd-962fcb4db947.jpg?1",
             "name": "Nalia de'Arnise",
             "text": "You may look at the top card of your library any time.\nYou may cast Cleric, Rogue, Warrior, and Wizard spells from the top of your library.\nAt the beginning of combat on your turn, if you have a full party, put a +1/+1 counter on each creature you control and those creatures gain deathtouch until end of turn.",
             "colours": [
@@ -24364,7 +24364,7 @@
         },
         {
             "id": "ba4862bb-ef92-5de6-9bb1-92f503198809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1feb99-eb5d-454a-b1bc-0ffb4778d5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1feb99-eb5d-454a-b1bc-0ffb4778d5f4.jpg?1",
             "name": "Multiclass Baldric",
             "text": "Equipped creature has lifelink if you control a Cleric, deathtouch if you control a Rogue, haste if you control a Warrior, and flying if you control a Wizard.\nAs long as you have a full party, prevent all damage that would be dealt to equipped creature.\nEquip {2}",
             "colours": [],
@@ -24395,7 +24395,7 @@
         },
         {
             "id": "86d96c11-21d7-59cc-b91e-bdaf1b583c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12794c31-8aea-4cd9-9534-e890fe3ebc8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12794c31-8aea-4cd9-9534-e890fe3ebc8c.jpg?1",
             "name": "Sarevok's Tome",
             "text": "When Sarevok's Tome enters the battlefield, you take the initiative.\n{T}: Add {C}. If you have the initiative, add {C}{C} instead.\n{3}, {T}: Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Activate only if you've completed a dungeon.",
             "colours": [],
@@ -24424,7 +24424,7 @@
         },
         {
             "id": "8e550aec-dc64-5866-ba6c-2c63109ac095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c02dc8-0743-400c-b334-ca029caf0463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c02dc8-0743-400c-b334-ca029caf0463.jpg?1",
             "name": "Captain N'ghathrod",
             "text": "Horrors you control have menace.\nWhenever a Horror you control deals combat damage to a player, that player mills that many cards.\nAt the beginning of your end step, choose target artifact or creature card in an opponent's graveyard that was put there from their library this turn. Put it onto the battlefield under your control.",
             "colours": [
@@ -24465,7 +24465,7 @@
         },
         {
             "id": "d52c2867-1d6d-5441-9516-8dc7ebf9d927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213e530e-33a9-4358-b43b-4a276a7e7190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213e530e-33a9-4358-b43b-4a276a7e7190.jpg?1",
             "name": "Faldorn, Dread Wolf Herald",
             "text": "Whenever you cast a spell from exile or a land enters the battlefield under your control from exile, create a 2/2 green Wolf creature token.\n{1}, {T}, Discard a card: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -24506,7 +24506,7 @@
         },
         {
             "id": "0c50a986-8548-54df-b226-58db7d66b4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55e624b-6f6a-42ae-89aa-0cc62ee55a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55e624b-6f6a-42ae-89aa-0cc62ee55a31.jpg?1",
             "name": "Firkraag, Cunning Instigator",
             "text": "Flying, haste\nWhenever one or more Dragons you control attack an opponent, goad target creature that player controls.\nWhenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag, Cunning Instigator and you draw a card.",
             "colours": [
@@ -24546,7 +24546,7 @@
         },
         {
             "id": "e2f5403b-1e5b-5764-8862-8e26c91a12bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1294fd-9885-4dfd-8192-0ca074fc83f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1294fd-9885-4dfd-8192-0ca074fc83f7.jpg?1",
             "name": "Nalia de'Arnise",
             "text": "You may look at the top card of your library any time.\nYou may cast Cleric, Rogue, Warrior, and Wizard spells from the top of your library.\nAt the beginning of combat on your turn, if you have a full party, put a +1/+1 counter on each creature you control and those creatures gain deathtouch until end of turn.",
             "colours": [
@@ -24587,7 +24587,7 @@
         },
         {
             "id": "2ccd7f84-1faf-5bda-b964-79b9627de768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3aae8-fc36-45ed-84ed-efb8f543cada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3aae8-fc36-45ed-84ed-efb8f543cada.jpg?1",
             "name": "Folk Hero",
             "text": "Commander creatures you own have \"Whenever you cast a spell that shares a creature type with this creature, draw a card. This ability triggers only once each turn.\"",
             "colours": [
@@ -24624,7 +24624,7 @@
         },
         {
             "id": "ecae572d-ae94-5cc0-9ed2-b52d7252d91b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82f96f-bd2b-4672-b729-c44c943fcac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82f96f-bd2b-4672-b729-c44c943fcac9.jpg?1",
             "name": "Clan Crafter",
             "text": "Commander creatures you own have \"{2}, Sacrifice an artifact: Put a +1/+1 counter on this creature and draw a card.\"",
             "colours": [
@@ -24661,7 +24661,7 @@
         },
         {
             "id": "d5241add-b1c7-5791-b90d-c3fc96b163b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d57db6-0aa5-4e28-b156-e97b74af2cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d57db6-0aa5-4e28-b156-e97b74af2cee.jpg?1",
             "name": "Zellix, Sanity Flayer",
             "text": "Hive Mind \u2014 Whenever a player mills one or more creature cards, you create a 1/1 black Horror creature token.\n{1}, {T}: Target player mills three cards.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24698,7 +24698,7 @@
         },
         {
             "id": "0964bdbf-acd7-516e-8c89-f0a116c0da3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899e278d-5d4e-461a-9878-2b85de16b38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899e278d-5d4e-461a-9878-2b85de16b38d.jpg?1",
             "name": "Burakos, Party Leader",
             "text": "Burakos, Party Leader is also a Cleric, Rogue, Warrior, and Wizard.\nWhenever Burakos attacks, defending player loses X life and you create X Treasure tokens, where X is the number of creatures in your party.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24735,7 +24735,7 @@
         },
         {
             "id": "b71e22a3-ce32-568f-8ca3-2b9fca42e2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53b1af-0f4a-4475-a131-27cb5d5b0cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc53b1af-0f4a-4475-a131-27cb5d5b0cf1.jpg?1",
             "name": "Haunted One",
             "text": "Commander creatures you own have \"Whenever this creature becomes tapped, it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn.\" (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -24772,7 +24772,7 @@
         },
         {
             "id": "d6ea03ac-d31f-533a-beea-fa7c852ee243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec983aac-9eda-4086-ad7e-34da9b2987cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec983aac-9eda-4086-ad7e-34da9b2987cc.jpg?1",
             "name": "Baeloth Barrityl, Entertainer",
             "text": "Creatures your opponents control with power less than Baeloth Barrityl's power are goaded. (They attack each combat if able and attack a player other than you if able.)\nWhenever a goaded attacking or blocking creature dies, you create a Treasure token.\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24810,7 +24810,7 @@
         },
         {
             "id": "ad096140-4909-5e9c-b57f-60c4cfd9d57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5bbfa6-e5f4-413d-b132-ebae32d38657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5bbfa6-e5f4-413d-b132-ebae32d38657.jpg?1",
             "name": "Passionate Archaeologist",
             "text": "Commander creatures you own have \"Whenever you cast a spell from exile, this creature deals damage equal to that spell's mana value to target opponent.\"",
             "colours": [
@@ -24847,7 +24847,7 @@
         },
         {
             "id": "439fedf1-5870-5db4-90e0-5229e212fffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f287c1-bd17-43fd-b0e3-b52472b0aa70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f287c1-bd17-43fd-b0e3-b52472b0aa70.jpg?1",
             "name": "Durnan of the Yawning Portal",
             "text": "Whenever Durnan attacks, look at the top four cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in any order. For as long as that card remains exiled, you may cast it. That spell has undaunted. (It costs {1}\u200b less to cast for each opponent.)\nChoose a Background (You can have a Background as a second commander.)",
             "colours": [
@@ -24885,7 +24885,7 @@
         },
         {
             "id": "abfa3d39-f72e-5ee4-a66b-e0764612aafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75f9f1-5873-450f-a0b2-871b55036954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75f9f1-5873-450f-a0b2-871b55036954.jpg?1",
             "name": "Deep Gnome Terramancer",
             "text": "Flash\nMold Earth \u2014 Whenever one or more lands enter the battlefield under an opponent's control without being played, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle. Do this only once each turn.",
             "colours": [
@@ -24921,7 +24921,7 @@
         },
         {
             "id": "934f0ef4-db2f-57fc-b6a3-c28569b3371e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb131fd-d96f-43e0-a40d-fa6394a4b75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb131fd-d96f-43e0-a40d-fa6394a4b75c.jpg?1",
             "name": "Harper Recruiter",
             "text": "Flying\nWhenever Harper Recruiter attacks, look at the top four cards of your library. You may reveal a Cleric card, a Rogue card, a Warrior card, and/or a Wizard card from among them and put those cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -24957,7 +24957,7 @@
         },
         {
             "id": "472e2abd-2edd-5369-9a0d-6b843361361e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee3f76-20a8-4621-84fb-ddf79c955532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee3f76-20a8-4621-84fb-ddf79c955532.jpg?1",
             "name": "Seasoned Dungeoneer",
             "text": "When Seasoned Dungeoneer enters the battlefield, you take the initiative.\nWhenever you attack, target attacking Cleric, Rogue, Warrior, or Wizard gains protection from creatures until end of turn. It explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -24993,7 +24993,7 @@
         },
         {
             "id": "b7f444ac-9398-5977-a593-1b34152e2e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d77a57a-e30b-46d7-acb8-1d164c7dff78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d77a57a-e30b-46d7-acb8-1d164c7dff78.jpg?1",
             "name": "Stick Together",
             "text": "Each player chooses a party from among creatures they control, then sacrifices the rest. (To choose a party, choose up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -25026,7 +25026,7 @@
         },
         {
             "id": "f31ba484-a049-5cb0-b950-dbda72a48283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51889b3f-082a-40e9-8be7-11f8c1a7a9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51889b3f-082a-40e9-8be7-11f8c1a7a9a8.jpg?1",
             "name": "Aboleth Spawn",
             "text": "Flash\nWard {2}\nProbing Telepathy \u2014 Whenever a creature entering the battlefield under an opponent's control causes a triggered ability of that creature to trigger, you may copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -25062,7 +25062,7 @@
         },
         {
             "id": "c9d9960d-9c6c-513b-84c8-c0a3895da6ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4e9335-06e3-4b27-8fd8-3e44ece89a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4e9335-06e3-4b27-8fd8-3e44ece89a36.jpg?1",
             "name": "Artificer Class",
             "text": "(Gain the next level as a sorcery to add its ability.)\nThe first artifact spell you cast each turn costs {1} less to cast.\n{1}{U}: Level 2\n//Level_2//\nWhen this Class becomes level 2, reveal cards from the top of your library until you reveal an artifact card. Put that card into your hand and the rest on the bottom of your library in a random order.\n{5}{U}: Level 3\n//Level_3//\nAt the beginning of your end step, create a token that's a copy of target artifact you control.",
             "colours": [
@@ -25095,7 +25095,7 @@
         },
         {
             "id": "6d4252de-fef7-56f9-91b9-a5ede197111e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670fbc63-4c9b-4e57-b53e-4ca4d7a224ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670fbc63-4c9b-4e57-b53e-4ca4d7a224ba.jpg?1",
             "name": "Astral Dragon",
             "text": "Flying\nProject Image \u2014 When Astral Dragon enters the battlefield, create two tokens that are copies of target noncreature permanent, except they're 3/3 Dragon creatures in addition to their other types, and they have flying.",
             "colours": [
@@ -25130,7 +25130,7 @@
         },
         {
             "id": "2ac896b8-7810-5c5f-87ac-34fb034ce2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804b3378-b330-45d2-9e2c-602ec080f285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804b3378-b330-45d2-9e2c-602ec080f285.jpg?1",
             "name": "Endless Evil",
             "text": "Enchant creature you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except the token is 1/1.\nWhen enchanted creature dies, if that creature was a Horror, return Endless Evil to its owner's hand.",
             "colours": [
@@ -25165,7 +25165,7 @@
         },
         {
             "id": "4bf61d4f-dde5-542b-aab8-b2b9517d7f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18bb373-a0bb-4e3c-b7db-83f747820fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18bb373-a0bb-4e3c-b7db-83f747820fcd.jpg?1",
             "name": "Grell Philosopher",
             "text": "Aberrant Tinkering \u2014 When Grell Philosopher enters the battlefield and at the beginning of your upkeep, each Horror you control gains all activated abilities of target artifact an opponent controls until end of turn. You may spend blue mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -25201,7 +25201,7 @@
         },
         {
             "id": "f2ea2b35-2781-52e6-a376-b5aa88d926aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5f81d8-b189-4f6e-872f-a237bb872aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5f81d8-b189-4f6e-872f-a237bb872aa9.jpg?1",
             "name": "Mocking Doppelganger",
             "text": "Flash\nYou may have Mocking Doppelganger enter the battlefield as a copy of a creature an opponent controls, except it has \"Other creatures with the same name as this creature are goaded.\" (They attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -25236,7 +25236,7 @@
         },
         {
             "id": "2bcaff64-7dc2-5116-9407-bc2d3ccea92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb36d21-0136-4fee-a348-92a99b7c5305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb36d21-0136-4fee-a348-92a99b7c5305.jpg?1",
             "name": "Psionic Ritual",
             "text": "Replicate\u2014\nTap an untapped Horror you control. (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nExile target instant or sorcery card from a graveyard and copy it. You may cast the copy without paying its mana cost.\nExile Psionic Ritual.",
             "colours": [
@@ -25269,7 +25269,7 @@
         },
         {
             "id": "1fdeefbb-8c55-5b8c-93ad-5318228dc031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb0d3-3452-4c1f-81ec-024b4c45bbad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb0d3-3452-4c1f-81ec-024b4c45bbad.jpg?1",
             "name": "Black Market Connections",
             "text": "At the beginning of your precombat main phase, choose one or more \u2014\n\u2022 Sell Contraband \u2014 Create a Treasure token. You lose 1 life.\n\u2022 Buy Information \u2014 Draw a card. You lose 2 life.\n\u2022 Hire a Mercenary \u2014 Create a 3/2 colorless Shapeshifter creature token with changeling. You lose 3 life. (It has every creature type.)",
             "colours": [
@@ -25302,7 +25302,7 @@
         },
         {
             "id": "fb6ce31f-4dbc-5470-8899-7942167deca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984b1f1-dfc8-4cb9-90a3-e084950438bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984b1f1-dfc8-4cb9-90a3-e084950438bf.jpg?1",
             "name": "Brainstealer Dragon",
             "text": "Flying\nAt the beginning of your end step, exile the top card of each opponent's library. You may play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.\nWhenever a nonland permanent an opponent owns enters the battlefield under your control, they lose life equal to its mana value.",
             "colours": [
@@ -25338,7 +25338,7 @@
         },
         {
             "id": "b9f86790-237c-5e1f-8f68-332b9917bd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08737950-4662-4d36-a1ea-6fd87e38c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08737950-4662-4d36-a1ea-6fd87e38c02b.jpg?1",
             "name": "From the Catacombs",
             "text": "Put target creature card from a graveyard onto the battlefield under your control with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.\nYou take the initiative.\nEscape\u2014{3}{B}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -25371,7 +25371,7 @@
         },
         {
             "id": "88808ec3-1f06-5552-b891-d828de1078a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b467929d-5fc3-4104-8a29-a8157835f274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b467929d-5fc3-4104-8a29-a8157835f274.jpg?1",
             "name": "Solemn Doomguide",
             "text": "Flying\nEach creature card in your graveyard that's a Cleric, Rogue, Warrior, and/or Wizard has unearth {1}{B}. ({1}{B}: Return the card to the battlefield. The creature gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -25407,7 +25407,7 @@
         },
         {
             "id": "111bf9ce-7e9f-5ee2-9956-7371bc75e8f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecef5fca-72ec-4aee-af6e-ee5d6f6bc567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecef5fca-72ec-4aee-af6e-ee5d6f6bc567.jpg?1",
             "name": "Uchuulon",
             "text": "Uchuulon's power is equal to the number of Crabs, Oozes, and/or Horrors you control.\nHorrific Symbiosis \u2014 At the beginning of your end step, exile up to one target creature card from an opponent's graveyard. If you do, create a token that's a copy of Uchuulon.",
             "colours": [
@@ -25444,7 +25444,7 @@
         },
         {
             "id": "52813751-2932-5189-bb2a-3b16a408e5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a0a23-cd62-4762-b751-ac0159a1b3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9a0a23-cd62-4762-b751-ac0159a1b3c5.jpg?1",
             "name": "Bothersome Quasit",
             "text": "Menace\nGoaded creatures your opponents control can't block.\nWhenever you cast a noncreature spell, goad target creature an opponent controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -25479,7 +25479,7 @@
         },
         {
             "id": "1d915c91-fa7e-5c17-8b74-54edd5e7b33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b9888-70c5-4bee-8f26-d1457fdf1167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537b9888-70c5-4bee-8f26-d1457fdf1167.jpg?1",
             "name": "Death Kiss",
             "text": "Whenever a creature an opponent controls attacks one of your opponents, double its power until end of turn.\n{X}{X}{R}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen Death Kiss becomes monstrous, goad up to X target creatures your opponents control.",
             "colours": [
@@ -25514,7 +25514,7 @@
         },
         {
             "id": "91f07837-84a7-5cc9-bc54-8b858fb8ed6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59903e3-a344-4218-9d41-8b19a9bc8311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59903e3-a344-4218-9d41-8b19a9bc8311.jpg?1",
             "name": "Delayed Blast Fireball",
             "text": "Delayed Blast Fireball deals 2 damage to each opponent and each creature they control. If this spell was cast from exile, it deals 5 damage to each opponent and each creature they control instead.\nForetell {4}{R}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -25547,7 +25547,7 @@
         },
         {
             "id": "01ae00d7-95ab-5949-9d50-990af0544ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669a2bb-11c7-45d8-9299-09246ff4e72c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669a2bb-11c7-45d8-9299-09246ff4e72c.jpg?1",
             "name": "Loot Dispute",
             "text": "When Loot Dispute enters the battlefield, you take the initiative and create a Treasure token.\nWhenever you attack the player who has the initiative, create a Treasure token.\nLoud Ruckus \u2014 Whenever you complete a dungeon, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -25580,7 +25580,7 @@
         },
         {
             "id": "991f9b3e-0537-5376-a15b-5f43b2699a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7717617-706a-4338-a207-dd8c08feb1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7717617-706a-4338-a207-dd8c08feb1c3.jpg?1",
             "name": "Nalfeshnee",
             "text": "Flying\nWhenever you cast a spell from exile, copy it. You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\" (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -25616,7 +25616,7 @@
         },
         {
             "id": "a378ad7f-0d23-5d84-81b0-d07d02338374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b1cbee-528f-48f7-b7c9-16aa3dab850a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b1cbee-528f-48f7-b7c9-16aa3dab850a.jpg?1",
             "name": "Spectacular Showdown",
             "text": "Put a double strike counter on target creature, then goad each creature that had a double strike counter put on it this way. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)\nOverload {4}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -25649,7 +25649,7 @@
         },
         {
             "id": "ace028e6-85de-56c0-a767-bc9e976794b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1beaaae-9406-4beb-8e74-d278822434c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1beaaae-9406-4beb-8e74-d278822434c7.jpg?1",
             "name": "Green Slime",
             "text": "Flash\nWhen Green Slime enters the battlefield, counter target activated or triggered ability from an artifact or enchantment source. If a permanent's ability is countered this way, destroy that permanent.\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -25684,7 +25684,7 @@
         },
         {
             "id": "8434e8a1-b452-5494-a178-df77cdd40267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b19ce-062d-470c-8716-425a8dec0e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b19ce-062d-470c-8716-425a8dec0e18.jpg?1",
             "name": "Journey to the Lost City",
             "text": "At the beginning of your upkeep, exile the top four cards of your library, then roll a d20.\n1\u20139 | You may put a land card from among those cards onto the battlefield.\n10\u201319 | Create a 2/2 green Wolf creature token, then put a +1/+1 counter on it for each creature card among those cards.\n20 | Put all permanent cards exiled with Journey to the Lost City onto the battlefield, then sacrifice it.",
             "colours": [
@@ -25717,7 +25717,7 @@
         },
         {
             "id": "ba051050-32bb-5e45-9cab-e10c8fc570af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Trample\nOnce each turn, you may pay {0} rather than pay the mana cost for a creature spell you cast from exile.",
             "colours": [
@@ -25753,7 +25753,7 @@
         },
         {
             "id": "450d88c9-a04d-5eea-8607-81315b4cd77e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg?1",
             "name": "Tlincalli Hunter // Retrieve Prey",
             "text": "Exile target creature card from your graveyard. Until the end of your next turn, you may cast that card.",
             "colours": [
@@ -25788,7 +25788,7 @@
         },
         {
             "id": "c5204d0e-11d0-5927-95fe-56d093a28eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4db814-3821-47ea-9e33-0e9f49128a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4db814-3821-47ea-9e33-0e9f49128a36.jpg?1",
             "name": "Venture Forth",
             "text": "Exile cards from the top of your library until you exile a land card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Exile Venture Forth with three time counters on it.\nSuspend 3\u2014{1}{G}",
             "colours": [
@@ -25821,7 +25821,7 @@
         },
         {
             "id": "ae46ab07-b385-54cd-938e-98d1f02912c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb7927d-c3c4-4464-8ada-bcd8466b2012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb7927d-c3c4-4464-8ada-bcd8466b2012.jpg?1",
             "name": "Multiclass Baldric",
             "text": "Equipped creature has lifelink if you control a Cleric, deathtouch if you control a Rogue, haste if you control a Warrior, and flying if you control a Wizard.\nAs long as you have a full party, prevent all damage that would be dealt to equipped creature.\nEquip {2}",
             "colours": [],
@@ -25852,7 +25852,7 @@
         },
         {
             "id": "ef52e455-d25a-5b3f-8ab0-e5672751f711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a470690-a05d-4311-963c-50cbf779846d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a470690-a05d-4311-963c-50cbf779846d.jpg?1",
             "name": "Sarevok's Tome",
             "text": "When Sarevok's Tome enters the battlefield, you take the initiative.\n{T}: Add {C}. If you have the initiative, add {C}{C} instead.\n{3}, {T}: Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Activate only if you've completed a dungeon.",
             "colours": [],
@@ -25881,7 +25881,7 @@
         },
         {
             "id": "8126fb0a-86e4-565e-9fd7-53527c47ff07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0b1acd-68e5-4922-8b51-06fa7eda984c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0b1acd-68e5-4922-8b51-06fa7eda984c.jpg?1",
             "name": "Archpriest of Iona",
             "text": "Archpriest of Iona's power is equal to the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -25915,7 +25915,7 @@
         },
         {
             "id": "d554842a-8c87-56e5-8fc5-5b76e09d0b5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24036e-075f-4991-a740-a9d943722ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24036e-075f-4991-a740-a9d943722ad2.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with mana value 3 or less.\n\u2022 Destroy all creatures with mana value 4 or greater.",
             "colours": [
@@ -25946,7 +25946,7 @@
         },
         {
             "id": "446672fd-cc44-53cd-92d5-0e0944267035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cf468f-4e9d-4551-a0ed-10bd6a2316ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cf468f-4e9d-4551-a0ed-10bd6a2316ad.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -25980,7 +25980,7 @@
         },
         {
             "id": "0edfb705-d0b3-57a1-946d-ed84054a1a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf879fc7-9f84-40a7-a7be-9cc98a720af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf879fc7-9f84-40a7-a7be-9cc98a720af5.jpg?1",
             "name": "Bygone Bishop",
             "text": "Flying\nWhenever you cast a creature spell with mana value 3 or less, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -26014,7 +26014,7 @@
         },
         {
             "id": "d58df723-44cf-5654-b100-c14f8f4f19a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13559d7-f86c-4958-a649-7f81bfb154a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13559d7-f86c-4958-a649-7f81bfb154a0.jpg?1",
             "name": "Crib Swap",
             "text": "Changeling (This card is every creature type.)\nExile target creature. Its controller creates a 1/1 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -26048,7 +26048,7 @@
         },
         {
             "id": "354e4511-fbdb-5868-b7b7-58e4f5bc582a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Destroy all creatures with power 3 or greater.",
             "colours": [
@@ -26079,7 +26079,7 @@
         },
         {
             "id": "f0173228-f822-549e-908b-38fd3bc0e215",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f295b713-1d6a-43fd-910d-fb35414bf58a.jpg?1",
             "name": "Dusk // Dawn",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nReturn all creature cards with power 2 or less from your graveyard to your hand.",
             "colours": [
@@ -26110,7 +26110,7 @@
         },
         {
             "id": "0185409e-1856-5191-ab84-de2fc48873f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef722374-0305-4c30-ab45-cb772b252faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef722374-0305-4c30-ab45-cb772b252faf.jpg?1",
             "name": "Eight-and-a-Half-Tails",
             "text": "{1}{W}: Target permanent you control gains protection from white until end of turn.\n{1}: Target spell or permanent becomes white until end of turn.",
             "colours": [
@@ -26146,7 +26146,7 @@
         },
         {
             "id": "b033b9ea-2a1b-5b95-bba7-e4517f0ecbf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9ad9ce-f862-4663-9a36-caf0844eb416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9ad9ce-f862-4663-9a36-caf0844eb416.jpg?1",
             "name": "Frontline Medic",
             "text": "Battalion \u2014 Whenever Frontline Medic and at least two other creatures attack, creatures you control gain indestructible until end of turn.\nSacrifice Frontline Medic: Counter target spell with {X} in its mana cost unless its controller pays {3}.",
             "colours": [
@@ -26180,7 +26180,7 @@
         },
         {
             "id": "7017e37f-0d94-56a9-8d19-c3ce81f3641c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222b4c5a-2cd0-4851-9f2f-8685a658ebb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222b4c5a-2cd0-4851-9f2f-8685a658ebb4.jpg?1",
             "name": "Galepowder Mage",
             "text": "Flying\nWhenever Galepowder Mage attacks, exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -26214,7 +26214,7 @@
         },
         {
             "id": "5a86ebac-63f9-5a1a-b30e-47ec1ef7fa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e63385a-e32f-4abc-aff6-bb022b2f56f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e63385a-e32f-4abc-aff6-bb022b2f56f7.jpg?1",
             "name": "Glorious Protector",
             "text": "Flash\nFlying\nWhen Glorious Protector enters the battlefield, you may exile any number of non-Angel creatures you control until Glorious Protector leaves the battlefield.\nForetell {2}{W}",
             "colours": [
@@ -26248,7 +26248,7 @@
         },
         {
             "id": "7ec6f2fa-7a16-5ea6-a3ba-b0e10d4b2a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61775227-34ad-469a-a4d4-ee8ce69dd10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61775227-34ad-469a-a4d4-ee8ce69dd10f.jpg?1",
             "name": "Irregular Cohort",
             "text": "Changeling (This card is every creature type.)\nWhen Irregular Cohort enters the battlefield, create a 2/2 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -26281,7 +26281,7 @@
         },
         {
             "id": "57a0f3c0-4044-5f6b-97bf-e5c8fb8b8d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d17b05a-7753-451b-a7b4-ee1fe3b51110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d17b05a-7753-451b-a7b4-ee1fe3b51110.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -26317,7 +26317,7 @@
         },
         {
             "id": "d8633eab-2795-5e7a-8985-b7bb0d172976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7039d47-276b-4c7c-acc3-94a9baae97e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7039d47-276b-4c7c-acc3-94a9baae97e5.jpg?1",
             "name": "Mage's Attendant",
             "text": "When Mage's Attendant enters the battlefield, create a 1/1 blue Wizard creature token with \"{1}, Sacrifice this creature: Counter target noncreature spell unless its controller pays {1}.\"",
             "colours": [
@@ -26351,7 +26351,7 @@
         },
         {
             "id": "a0679bda-50b6-5db6-a1bc-6f9bb433f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63074e4-2c4c-411c-b320-c90d3a4a96d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63074e4-2c4c-411c-b320-c90d3a4a96d0.jpg?1",
             "name": "Magus of the Balance",
             "text": "{4}{W}, {T}, Sacrifice Magus of the Balance: Each player chooses a number of lands they control equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.",
             "colours": [
@@ -26385,7 +26385,7 @@
         },
         {
             "id": "f1df5d12-2876-5dba-8d68-db95abf6b0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f18de2a-4aab-47a1-b162-6b8cf18e7bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f18de2a-4aab-47a1-b162-6b8cf18e7bbf.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -26421,7 +26421,7 @@
         },
         {
             "id": "9afd5bc2-7c5d-522b-afae-825a51a229ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9149ed-0e59-48b3-b48c-d5ea77b7239e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9149ed-0e59-48b3-b48c-d5ea77b7239e.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
             "colours": [
@@ -26454,7 +26454,7 @@
         },
         {
             "id": "f12c07b2-a058-5b5e-a7cd-09037a735f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e19147-e459-43a6-8ef0-e37968a462e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e19147-e459-43a6-8ef0-e37968a462e3.jpg?1",
             "name": "Mother of Runes",
             "text": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -26488,7 +26488,7 @@
         },
         {
             "id": "6ce2b050-ebdf-5b6c-8696-934ad14397e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaa62f-4959-4321-a2d5-dc255f1e5eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaa62f-4959-4321-a2d5-dc255f1e5eaf.jpg?1",
             "name": "Order of Whiteclay",
             "text": "{1}{W}{W}, {Q}: Return target creature card with mana value 3 or less from your graveyard to the battlefield. ({Q} is the untap symbol.)",
             "colours": [
@@ -26522,7 +26522,7 @@
         },
         {
             "id": "0864d5a0-85ba-5363-b682-67fe94ecf404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6f7b89-1648-4c2b-8d68-88ad43267c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6f7b89-1648-4c2b-8d68-88ad43267c6f.jpg?1",
             "name": "Priest of Ancient Lore",
             "text": "When Priest of Ancient Lore enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -26556,7 +26556,7 @@
         },
         {
             "id": "74ca1404-5409-5910-bfe8-3c7e6afcaaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7782044-616e-4d4f-b38f-93320ba19797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7782044-616e-4d4f-b38f-93320ba19797.jpg?1",
             "name": "Rumor Gatherer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, scry 1. If this is the second time this ability has resolved this turn, draw a card instead.",
             "colours": [
@@ -26590,7 +26590,7 @@
         },
         {
             "id": "1d5f394f-4d40-5efa-9a92-31a5c9e97f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d8d0c-cb0e-4745-a0fb-d556c9324428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d8d0c-cb0e-4745-a0fb-d556c9324428.jpg?1",
             "name": "Selfless Spirit",
             "text": "Flying\nSacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -26624,7 +26624,7 @@
         },
         {
             "id": "4924a247-0a7a-569b-8876-23ce6af5baae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458db878-07ba-42cc-9bee-910957685596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458db878-07ba-42cc-9bee-910957685596.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -26655,7 +26655,7 @@
         },
         {
             "id": "dbdd4eb0-5f0f-5686-acf3-38cbe448f22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b93ee66-bc1d-42ad-8839-d77ab5992f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b93ee66-bc1d-42ad-8839-d77ab5992f14.jpg?1",
             "name": "Solemn Recruit",
             "text": "Double strike\nRevolt \u2014 At the beginning of your end step, if a permanent you controlled left the battlefield this turn, put a +1/+1 counter on Solemn Recruit.",
             "colours": [
@@ -26689,7 +26689,7 @@
         },
         {
             "id": "3e0e2fa8-b198-5fa8-a8d1-5e6726d79d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5390bbf3-9906-46a9-81d3-60e23eb89ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5390bbf3-9906-46a9-81d3-60e23eb89ca1.jpg?1",
             "name": "Squad Commander",
             "text": "When Squad Commander enters the battlefield, create a 1/1 white Kor Warrior creature token for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -26723,7 +26723,7 @@
         },
         {
             "id": "9fa9432d-bc3e-5384-8dca-677de072ab9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123ae9bd-896c-4f50-afe3-880cea85eee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123ae9bd-896c-4f50-afe3-880cea85eee0.jpg?1",
             "name": "Unbreakable Formation",
             "text": "Creatures you control gain indestructible until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, put a +1/+1 counter on each of those creatures and they gain vigilance until end of turn.",
             "colours": [
@@ -26754,7 +26754,7 @@
         },
         {
             "id": "d128cd33-31ec-51e6-928e-2396df11e99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014fbb81-5d54-4f8f-8c91-071521b9cd33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014fbb81-5d54-4f8f-8c91-071521b9cd33.jpg?1",
             "name": "Valiant Changeling",
             "text": "This spell costs {1} less to cast for each creature type among creatures you control. This effect can't reduce the amount of mana this spell costs by more than {5}.\nChangeling (This card is every creature type.)\nDouble strike",
             "colours": [
@@ -26787,7 +26787,7 @@
         },
         {
             "id": "ed7b7bb4-38ae-5596-b1fe-a933f9d77383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd153e03-4fe1-477d-9e7f-ee5c432a4285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd153e03-4fe1-477d-9e7f-ee5c432a4285.jpg?1",
             "name": "Aether Gale",
             "text": "Return six target nonland permanents to their owners' hands.",
             "colours": [
@@ -26818,7 +26818,7 @@
         },
         {
             "id": "d0935e66-c11d-5877-8443-2e521a4ae90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8d57fc-9695-45df-8b88-0048330608bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8d57fc-9695-45df-8b88-0048330608bd.jpg?1",
             "name": "Angler Turtle",
             "text": "Hexproof\nCreatures your opponents control attack each combat if able.",
             "colours": [
@@ -26851,7 +26851,7 @@
         },
         {
             "id": "26ff52e3-8275-51db-b666-bc36f4af9a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72c6461-8ba4-4ee7-b2c4-0f8d396ce585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72c6461-8ba4-4ee7-b2c4-0f8d396ce585.jpg?1",
             "name": "Chasm Skulker",
             "text": "Whenever you draw a card, put a +1/+1 counter on Chasm Skulker.\nWhen Chasm Skulker dies, create X 1/1 blue Squid creature tokens with islandwalk, where X is the number of +1/+1 counters on Chasm Skulker. (They can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -26885,7 +26885,7 @@
         },
         {
             "id": "cda3b812-62e3-56aa-9d00-97fcef3808b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bc62c8-c795-4e4a-a57c-a5f34121b5d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bc62c8-c795-4e4a-a57c-a5f34121b5d1.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless they discard a land card.",
             "colours": [
@@ -26916,7 +26916,7 @@
         },
         {
             "id": "f9933949-d487-5eb7-ab1a-ad4dacf84556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ef264e-f987-422e-aac1-ae4963c797f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ef264e-f987-422e-aac1-ae4963c797f5.jpg?1",
             "name": "Curse of the Swine",
             "text": "Exile X target creatures. For each creature exiled this way, its controller creates a 2/2 green Boar creature token.",
             "colours": [
@@ -26947,7 +26947,7 @@
         },
         {
             "id": "d0c18842-9d74-5b4f-a0a9-f7a595ae2bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff611add-0b1b-4008-a78b-e793ccb38260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff611add-0b1b-4008-a78b-e793ccb38260.jpg?1",
             "name": "Curse of Verbosity",
             "text": "Enchant player\nWhenever enchanted player is attacked, you draw a card. Each opponent attacking that player does the same.",
             "colours": [
@@ -26981,7 +26981,7 @@
         },
         {
             "id": "ab94fb46-dafb-559d-a482-012eb296360d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2d9f47-2bd2-4a97-90c7-beca18a8e7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2d9f47-2bd2-4a97-90c7-beca18a8e7fa.jpg?1",
             "name": "Dissipation Field",
             "text": "Whenever a permanent deals damage to you, return it to its owner's hand.",
             "colours": [
@@ -27012,7 +27012,7 @@
         },
         {
             "id": "59db6c85-ada9-5d2b-9404-8417ab0b2e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c3836d-a08b-424c-aefe-e1585161edf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c3836d-a08b-424c-aefe-e1585161edf7.jpg?1",
             "name": "Domineering Will",
             "text": "Target player gains control of up to three target nonattacking creatures until end of turn. Untap those creatures. They block this turn if able.",
             "colours": [
@@ -27043,7 +27043,7 @@
         },
         {
             "id": "b6e335fe-16bc-53a7-81f8-c555e9f3ab37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d5a3ec-eb03-47c1-9570-98832ebf8898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d5a3ec-eb03-47c1-9570-98832ebf8898.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -27074,7 +27074,7 @@
         },
         {
             "id": "06d5396c-ebcd-52c0-af27-f9e7efc8a36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d314354-1fb1-498c-8342-ecafac9ff37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d314354-1fb1-498c-8342-ecafac9ff37a.jpg?1",
             "name": "Forgotten Creation",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nAt the beginning of your upkeep, you may discard all the cards in your hand. If you do, draw that many cards.",
             "colours": [
@@ -27108,7 +27108,7 @@
         },
         {
             "id": "e680b1b2-ac9b-511d-a602-3f0a8c0af590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81875876-c1a0-4f64-8dfc-39217b5e4020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81875876-c1a0-4f64-8dfc-39217b5e4020.jpg?1",
             "name": "Fractured Sanity",
             "text": "Each opponent mills fourteen cards.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Fractured Sanity, each opponent mills four cards.",
             "colours": [
@@ -27139,7 +27139,7 @@
         },
         {
             "id": "881c85fe-d947-5f5c-a26c-c16ff481cc2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de11222-c2fa-4544-a501-a02b31797259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de11222-c2fa-4544-a501-a02b31797259.jpg?1",
             "name": "Grazilaxx, Illithid Scholar",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -27174,7 +27174,7 @@
         },
         {
             "id": "2858bbfa-2720-5fb6-8436-2a3899ae41c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf786c50-1ba1-4f81-a800-bc98189040dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf786c50-1ba1-4f81-a800-bc98189040dd.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -27208,7 +27208,7 @@
         },
         {
             "id": "14c8a4a2-55fb-5903-a25b-59dd067296bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d544dc-1d2a-4b33-ae62-d0e0217db0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d544dc-1d2a-4b33-ae62-d0e0217db0a2.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star dies, gain control of target creature.",
             "colours": [
@@ -27244,7 +27244,7 @@
         },
         {
             "id": "3c2e575a-e579-5faa-91c2-4c94858d80ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57bdaa1-ce8a-4103-8598-fee751e65a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57bdaa1-ce8a-4103-8598-fee751e65a53.jpg?1",
             "name": "Leyline of Anticipation",
             "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast spells as though they had flash.",
             "colours": [
@@ -27275,7 +27275,7 @@
         },
         {
             "id": "4e87fe54-15f4-50e3-82a4-f15e13974033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ca85ed-3870-4ba4-abe7-cdcab3cad122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ca85ed-3870-4ba4-abe7-cdcab3cad122.jpg?1",
             "name": "Midnight Clock",
             "text": "{T}: Add {U}.\n{2}{U}: Put an hour counter on Midnight Clock.\nAt the beginning of each upkeep, put an hour counter on Midnight Clock.\nWhen the twelfth hour counter is put on Midnight Clock, shuffle your hand and graveyard into your library, then draw seven cards. Exile Midnight Clock.",
             "colours": [
@@ -27306,7 +27306,7 @@
         },
         {
             "id": "4b557015-28ce-5d0f-b627-afb6ff6e5fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cb10f5-ee9f-49e6-826a-a2a2395daa92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cb10f5-ee9f-49e6-826a-a2a2395daa92.jpg?1",
             "name": "Mind Flayer",
             "text": "Dominate Monster \u2014 When Mind Flayer enters the battlefield, gain control of target creature for as long as you control Mind Flayer.",
             "colours": [
@@ -27339,7 +27339,7 @@
         },
         {
             "id": "f24571f0-d39b-52d7-82e5-06d08ebdfd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065a3c0-c5bd-4817-be7b-efcd750332b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065a3c0-c5bd-4817-be7b-efcd750332b9.jpg?1",
             "name": "Overcharged Amalgam",
             "text": "Flash\nFlying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Overcharged Amalgam exploits a creature, counter target spell, activated ability, or triggered ability.",
             "colours": [
@@ -27373,7 +27373,7 @@
         },
         {
             "id": "2e01dec8-f905-55c3-b3bd-cd256ac1c24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f293d7-9c2b-41cb-8e3c-dfc1daa6635f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f293d7-9c2b-41cb-8e3c-dfc1daa6635f.jpg?1",
             "name": "Propaganda",
             "text": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -27404,7 +27404,7 @@
         },
         {
             "id": "947578d5-edb7-5f3d-8f77-a9b5f5bf2e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d91bf6-25c7-4478-854a-e35290b6b049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d91bf6-25c7-4478-854a-e35290b6b049.jpg?1",
             "name": "Pull from Tomorrow",
             "text": "Draw X cards, then discard a card.",
             "colours": [
@@ -27435,7 +27435,7 @@
         },
         {
             "id": "072f3c73-6601-5d7e-88d4-435a229369db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba925b-9216-4e37-814d-b061950b3998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba925b-9216-4e37-814d-b061950b3998.jpg?1",
             "name": "Pursued Whale",
             "text": "When Pursued Whale enters the battlefield, each opponent creates a 1/1 red Pirate creature token with \"This creature can't block\" and \"Creatures you control attack each combat if able.\"\nSpells your opponents cast that target Pursued Whale cost {3} more to cast.",
             "colours": [
@@ -27468,7 +27468,7 @@
         },
         {
             "id": "3c987ef6-a7c8-575f-a395-c0833f73e071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af34c32-22dc-41d3-8946-b5f77ef577ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af34c32-22dc-41d3-8946-b5f77ef577ff.jpg?1",
             "name": "Reflections of Littjara",
             "text": "As Reflections of Littjara enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, copy that spell. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -27499,7 +27499,7 @@
         },
         {
             "id": "13c07c2b-1207-557d-8c02-217b1c3eff97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5730aa-c74a-4c74-bb1b-a133a3c353ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5730aa-c74a-4c74-bb1b-a133a3c353ec.jpg?1",
             "name": "Reins of Power",
             "text": "Untap all creatures you control and all creatures target opponent controls. You and that opponent each gain control of all creatures the other controls until end of turn. Those creatures gain haste until end of turn.",
             "colours": [
@@ -27530,7 +27530,7 @@
         },
         {
             "id": "5bc1d316-514f-58dc-bf88-ce2749031785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32be366-d86e-48aa-8257-ca8afb87ba18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32be366-d86e-48aa-8257-ca8afb87ba18.jpg?1",
             "name": "Sludge Monster",
             "text": "Whenever Sludge Monster enters the battlefield or attacks, put a slime counter on up to one other target creature.\nNon-Horror creatures with slime counters on them lose all abilities and have base power and toughness 2/2.",
             "colours": [
@@ -27563,7 +27563,7 @@
         },
         {
             "id": "1e8c2af6-8398-5939-9bdd-a0cdba4ffadd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ed183a-a78a-4934-9317-9f16b29e69a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ed183a-a78a-4934-9317-9f16b29e69a2.jpg?1",
             "name": "Sly Instigator",
             "text": "{U}, {T}: Until your next turn, target creature an opponent controls can't be blocked. Goad that creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -27597,7 +27597,7 @@
         },
         {
             "id": "4fb4d644-455b-5f9d-820f-9fef89453f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b434ba9e-528c-43b4-a463-0e697dce8d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b434ba9e-528c-43b4-a463-0e697dce8d5d.jpg?1",
             "name": "Wharf Infiltrator",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhenever Wharf Infiltrator deals combat damage to a player, you may draw a card. If you do, discard a card.\nWhenever you discard a creature card, you may pay {2}. If you do, create a 3/2 colorless Eldrazi Horror creature token.",
             "colours": [
@@ -27631,7 +27631,7 @@
         },
         {
             "id": "3153fa80-c3ce-5ae4-881c-5cf812d121a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406a3ae5-f57e-40ff-8eac-a01781f2329f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406a3ae5-f57e-40ff-8eac-a01781f2329f.jpg?1",
             "name": "Will Kenrith",
             "text": "+2: Until your next turn, up to two target creatures each have base power and toughness 0/3 and lose all abilities.\n\u22122: Target player draws two cards. Until your next turn, instant, sorcery, and planeswalker spells that player casts cost {2} less to cast.\n\u22128: Target player gets an emblem with \"Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy.\"\nPartner with Rowan Kenrith\nWill Kenrith can be your commander.",
             "colours": [
@@ -27666,7 +27666,7 @@
         },
         {
             "id": "8f22f3a8-52de-5e36-b641-612d1977eb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c80c6d-f3ae-48d3-ba6a-b9b738e1affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c80c6d-f3ae-48d3-ba6a-b9b738e1affb.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -27697,7 +27697,7 @@
         },
         {
             "id": "a0dfcbe0-12b7-5d1a-8176-88ba08fd62fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d6137-5eff-4e82-8232-64e8679bc11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d6137-5eff-4e82-8232-64e8679bc11c.jpg?1",
             "name": "Bloodsoaked Champion",
             "text": "Bloodsoaked Champion can't block.\nRaid \u2014 {1}{B}: Return Bloodsoaked Champion from your graveyard to the battlefield. Activate only if you attacked this turn.",
             "colours": [
@@ -27731,7 +27731,7 @@
         },
         {
             "id": "ace33997-552e-5033-ac5c-980d641c392e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c18f8-a19f-406a-ad60-491087f9d660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c18f8-a19f-406a-ad60-491087f9d660.jpg?1",
             "name": "Butcher of Malakir",
             "text": "Flying\nWhenever Butcher of Malakir or another creature you control dies, each opponent sacrifices a creature.",
             "colours": [
@@ -27765,7 +27765,7 @@
         },
         {
             "id": "edbb76fe-26aa-571d-ac02-96b1815b5216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dccdab-9dda-4964-9b1a-eec6d31c7995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dccdab-9dda-4964-9b1a-eec6d31c7995.jpg?1",
             "name": "Calculating Lich",
             "text": "Menace\nWhenever a creature attacks one of your opponents, that player loses 1 life.",
             "colours": [
@@ -27799,7 +27799,7 @@
         },
         {
             "id": "7007e513-d465-5ec8-ac56-d1699ef86164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2c053f-0ef8-45f2-b2af-24cbb9a7fec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2c053f-0ef8-45f2-b2af-24cbb9a7fec4.jpg?1",
             "name": "Changeling Outcast",
             "text": "Changeling (This card is every creature type.)\nChangeling Outcast can't block and can't be blocked.",
             "colours": [
@@ -27832,7 +27832,7 @@
         },
         {
             "id": "afbf6bdd-2fb6-5675-ac35-82c2a2163c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600eaa36-5497-42dc-8d21-a5fcdd01fa79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600eaa36-5497-42dc-8d21-a5fcdd01fa79.jpg?1",
             "name": "Corpse Augur",
             "text": "When Corpse Augur dies, you draw X cards and you lose X life, where X is the number of creature cards in target player's graveyard.",
             "colours": [
@@ -27866,7 +27866,7 @@
         },
         {
             "id": "3e756452-18f2-548f-a494-4f6405c8ebab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5bc7db-0627-410b-bc27-970e1fa6789e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5bc7db-0627-410b-bc27-970e1fa6789e.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -27897,7 +27897,7 @@
         },
         {
             "id": "fb8183dc-e7ef-57fa-a11a-34fa5b39c741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2f493d-34d1-4fea-b5d0-b4a965aaf32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2f493d-34d1-4fea-b5d0-b4a965aaf32e.jpg?1",
             "name": "Curtains' Call",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
             "colours": [
@@ -27928,7 +27928,7 @@
         },
         {
             "id": "cc7bef21-22af-5a14-a935-bb650a7c33fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133e9654-74a3-4997-b371-7f36b5d9c4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133e9654-74a3-4997-b371-7f36b5d9c4f1.jpg?1",
             "name": "Dark Hatchling",
             "text": "Flying\nWhen Dark Hatchling enters the battlefield, destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -27961,7 +27961,7 @@
         },
         {
             "id": "3d60fad2-0bda-534d-949f-76d02ff592a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c41afe6-7eed-4cf5-9bbb-ccc9f82cb4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c41afe6-7eed-4cf5-9bbb-ccc9f82cb4fa.jpg?1",
             "name": "Dauthi Horror",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Horror can't be blocked by white creatures.",
             "colours": [
@@ -27995,7 +27995,7 @@
         },
         {
             "id": "81dc6131-9a2d-56fd-9ebe-0162d00763b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887384de-403c-4cca-b542-ce0303100d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887384de-403c-4cca-b542-ce0303100d42.jpg?1",
             "name": "Dire Fleet Ravager",
             "text": "Menace, deathtouch\nWhen Dire Fleet Ravager enters the battlefield, each player loses a third of their life, rounded up.",
             "colours": [
@@ -28030,7 +28030,7 @@
         },
         {
             "id": "56909fc1-2b86-5886-9b6f-6411eb0bdb90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f77a00-1880-416c-813b-c6a870dd5f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f77a00-1880-416c-813b-c6a870dd5f58.jpg?1",
             "name": "Dross Harvester",
             "text": "Protection from white\nAt the beginning of your end step, you lose 4 life.\nWhenever a creature dies, you gain 2 life.",
             "colours": [
@@ -28063,7 +28063,7 @@
         },
         {
             "id": "a9942adc-8e35-5a6c-ada0-6f94682cde1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed473b7d-2078-424e-b1a0-a58e04bf9cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed473b7d-2078-424e-b1a0-a58e04bf9cc2.jpg?1",
             "name": "Dusk Mangler",
             "text": "As an additional cost to cast this spell, sacrifice a creature, discard a card, or pay 4 life.\nWhen Dusk Mangler enters the battlefield, each opponent sacrifices a creature, discards a card, and loses 4 life.",
             "colours": [
@@ -28096,7 +28096,7 @@
         },
         {
             "id": "63c7ea40-33cc-5a5e-a361-85ad39cdc197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86c30e0-35f3-4da8-a28c-722254b1bbe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86c30e0-35f3-4da8-a28c-722254b1bbe4.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
             "colours": [
@@ -28127,7 +28127,7 @@
         },
         {
             "id": "5ae30776-1969-5157-910f-4eb7011d797d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedbfd3-907f-4042-98c1-6fe3fb8cbc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedbfd3-907f-4042-98c1-6fe3fb8cbc01.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -28163,7 +28163,7 @@
         },
         {
             "id": "0376d4e2-fa87-534f-b845-48a371965eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c19b87-e114-46d4-9f6c-c02e838a08dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c19b87-e114-46d4-9f6c-c02e838a08dd.jpg?1",
             "name": "Grim Haruspex",
             "text": "Morph {B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever another nontoken creature you control dies, draw a card.",
             "colours": [
@@ -28197,7 +28197,7 @@
         },
         {
             "id": "db0d1c45-9184-5e2f-95ab-4945ab6e3606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38326f48-548c-4b18-9ad2-0b7c23385deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38326f48-548c-4b18-9ad2-0b7c23385deb.jpg?1",
             "name": "Grim Hireling",
             "text": "Whenever one or more creatures you control deal combat damage to a player, create two Treasure tokens.\n{B}, Sacrifice X Treasures: Target creature gets -X/-X until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -28231,7 +28231,7 @@
         },
         {
             "id": "e5ba1ce1-8f67-5392-afe9-3dbdbb6fbe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8276b064-60ba-4079-b790-e2eea831e35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8276b064-60ba-4079-b790-e2eea831e35e.jpg?1",
             "name": "Guiltfeeder",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever Guiltfeeder attacks and isn't blocked, defending player loses 1 life for each card in their graveyard.",
             "colours": [
@@ -28264,7 +28264,7 @@
         },
         {
             "id": "d0b45b51-ae3d-5bf2-843a-d7150dd78678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c38f3-4b5c-4e7f-af66-e410dea19314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067c38f3-4b5c-4e7f-af66-e410dea19314.jpg?1",
             "name": "Hex",
             "text": "Destroy six target creatures.",
             "colours": [
@@ -28295,7 +28295,7 @@
         },
         {
             "id": "49962639-905e-5d36-a1ab-31fec11aaf02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f74866-d0ea-42ce-bc44-500219fb73d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f74866-d0ea-42ce-bc44-500219fb73d4.jpg?1",
             "name": "Hunted Horror",
             "text": "Trample\nWhen Hunted Horror enters the battlefield, target opponent creates two 3/3 green Centaur creature tokens with protection from black.",
             "colours": [
@@ -28328,7 +28328,7 @@
         },
         {
             "id": "ced34cd2-3671-506e-afd3-4b59a09bff05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a6f727-8239-45e6-9dbb-67d2d3c9239d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a6f727-8239-45e6-9dbb-67d2d3c9239d.jpg?1",
             "name": "In Garruk's Wake",
             "text": "Destroy all creatures you don't control and all planeswalkers you don't control.",
             "colours": [
@@ -28359,7 +28359,7 @@
         },
         {
             "id": "62a9bad8-334e-5934-9dad-883b5522f151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbd64da-6071-49f4-87aa-066209ec1ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbd64da-6071-49f4-87aa-066209ec1ae9.jpg?1",
             "name": "Malakir Blood-Priest",
             "text": "When Malakir Blood-Priest enters the battlefield, each opponent loses X life and you gain X life, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -28393,7 +28393,7 @@
         },
         {
             "id": "38c99152-e933-5115-8071-b092bae20902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ed059-9bd1-4a18-ac85-7b00b8057426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626ed059-9bd1-4a18-ac85-7b00b8057426.jpg?1",
             "name": "Mardu Strike Leader",
             "text": "Whenever Mardu Strike Leader attacks, create a 2/1 black Warrior creature token.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -28427,7 +28427,7 @@
         },
         {
             "id": "91ba0822-e763-5fe0-be74-785704d31214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c5f18-13a3-42c9-b9d7-bf789eefe249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c5f18-13a3-42c9-b9d7-bf789eefe249.jpg?1",
             "name": "Mindblade Render",
             "text": "Whenever your opponents are dealt combat damage, if any of that damage was dealt by a Warrior, you draw a card and you lose 1 life.",
             "colours": [
@@ -28461,7 +28461,7 @@
         },
         {
             "id": "5cf978fd-2be9-537e-a6cf-45694f11d94b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf5e98-9d40-4cb0-83de-043751b1382f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cf5e98-9d40-4cb0-83de-043751b1382f.jpg?1",
             "name": "Nighthawk Scavenger",
             "text": "Flying, deathtouch, lifelink\nNighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards.",
             "colours": [
@@ -28495,7 +28495,7 @@
         },
         {
             "id": "2d3cfb80-ae97-56b6-bf30-1111056b9fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76dab3d-1788-4ab7-8d2b-70f7787cf935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76dab3d-1788-4ab7-8d2b-70f7787cf935.jpg?1",
             "name": "Nighthowler",
             "text": "Bestow {2}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nNighthowler and enchanted creature each get +X/+X, where X is the number of creature cards in all graveyards.",
             "colours": [
@@ -28529,7 +28529,7 @@
         },
         {
             "id": "d0a6f024-f021-59da-9117-d17115443044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598900a0-e244-45e3-a04a-685837fb1867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598900a0-e244-45e3-a04a-685837fb1867.jpg?1",
             "name": "Nihilith",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nSuspend 7\u2014{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with seven time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Nihilith is suspended, you may remove a time counter from Nihilith.",
             "colours": [
@@ -28562,7 +28562,7 @@
         },
         {
             "id": "66658304-8f6b-528d-bfc4-6dcce3e179fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a530be-8527-46f9-b1e9-725915fd6d5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a530be-8527-46f9-b1e9-725915fd6d5e.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -28596,7 +28596,7 @@
         },
         {
             "id": "c31ecb4c-f0b9-5451-8d75-051fb34bc788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82559e5-110b-4c6a-956a-7cba83788dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82559e5-110b-4c6a-956a-7cba83788dc8.jpg?1",
             "name": "Plague Spitter",
             "text": "At the beginning of your upkeep, Plague Spitter deals 1 damage to each creature and each player.\nWhen Plague Spitter dies, Plague Spitter deals 1 damage to each creature and each player.",
             "colours": [
@@ -28630,7 +28630,7 @@
         },
         {
             "id": "6e2d9439-ae98-52f6-837d-bd0392139ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04c8f5-e174-4055-a98c-efec2f064d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa04c8f5-e174-4055-a98c-efec2f064d69.jpg?1",
             "name": "Pontiff of Blight",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nOther creatures you control have extort. (If a creature has multiple instances of extort, each triggers separately.)",
             "colours": [
@@ -28664,7 +28664,7 @@
         },
         {
             "id": "8e3708d0-28dd-56e5-8dd7-10be6d052c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fd8dba-0aca-4b47-9b4b-19d5c77cf8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fd8dba-0aca-4b47-9b4b-19d5c77cf8f3.jpg?1",
             "name": "Puppeteer Clique",
             "text": "Flying\nWhen Puppeteer Clique enters the battlefield, put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. At the beginning of your next end step, exile it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -28698,7 +28698,7 @@
         },
         {
             "id": "6ea4f86f-474e-5dec-b077-bf52d8729708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de4804-d330-403a-9ab0-e8be78655618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de4804-d330-403a-9ab0-e8be78655618.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -28732,7 +28732,7 @@
         },
         {
             "id": "24155829-61ab-546d-abc0-7c203de54135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8d320-fecc-42c2-b9d8-a9f6dd44b36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8d320-fecc-42c2-b9d8-a9f6dd44b36d.jpg?1",
             "name": "Sewer Nemesis",
             "text": "As Sewer Nemesis enters the battlefield, choose a player.\nSewer Nemesis's power and toughness are each equal to the number of cards in the chosen player's graveyard.\nWhenever the chosen player casts a spell, that player mills a card.",
             "colours": [
@@ -28765,7 +28765,7 @@
         },
         {
             "id": "9268d590-0055-58f1-8f69-0290b2c8bbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187502d9-c751-4967-adff-09d7a300d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187502d9-c751-4967-adff-09d7a300d935.jpg?1",
             "name": "Syphon Mind",
             "text": "Each other player discards a card. You draw a card for each card discarded this way.",
             "colours": [
@@ -28796,7 +28796,7 @@
         },
         {
             "id": "cdee006e-0a8c-559c-8a09-be02f2a8c53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc339d3b-9c89-4679-bc83-8399d9a864c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc339d3b-9c89-4679-bc83-8399d9a864c7.jpg?1",
             "name": "Thwart the Grave",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nReturn target creature card and up to one target Cleric, Rogue, Warrior, or Wizard creature card from your graveyard to the battlefield.",
             "colours": [
@@ -28827,7 +28827,7 @@
         },
         {
             "id": "0009093e-de41-5432-9815-8d1f2efe16dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6c62a-b149-4cc2-9210-6420f31a6781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6c62a-b149-4cc2-9210-6420f31a6781.jpg?1",
             "name": "Woe Strider",
             "text": "When Woe Strider enters the battlefield, create a 0/1 white Goat creature token.\nSacrifice another creature: Scry 1.\nEscape\u2014{3}{B}{B}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nWoe Strider escapes with two +1/+1 counters on it.",
             "colours": [
@@ -28860,7 +28860,7 @@
         },
         {
             "id": "8d70d27d-faf5-5229-8bdf-fb88eeb6fbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ef00c1-613a-4cbd-8972-77c41f649431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ef00c1-613a-4cbd-8972-77c41f649431.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -28895,7 +28895,7 @@
         },
         {
             "id": "3c366b0b-4501-5937-80a4-235f635d2722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e885f56a-a1e8-4289-bbf5-3b156e53f7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e885f56a-a1e8-4289-bbf5-3b156e53f7db.jpg?1",
             "name": "Agitator Ant",
             "text": "At the beginning of your end step, each player may put two +1/+1 counters on a creature they control. Goad each creature that had counters put on it this way. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -28928,7 +28928,7 @@
         },
         {
             "id": "cb2e41c0-10cd-55af-b4d4-d1167bcd5055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78161e60-878a-45a2-aced-40b739bd0a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78161e60-878a-45a2-aced-40b739bd0a07.jpg?1",
             "name": "The Akroan War",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Gain control of target creature for as long as The Akroan War remains on the battlefield.\nII \u2014 Until your next turn, creatures your opponents control attack each combat if able.\nIII \u2014 Each tapped creature deals damage to itself equal to its power.",
             "colours": [
@@ -28961,7 +28961,7 @@
         },
         {
             "id": "64c86dd9-3cfd-5730-9480-e64f2933a178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a9e74f-8090-4314-9361-97777fb7b63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a9e74f-8090-4314-9361-97777fb7b63a.jpg?1",
             "name": "Aurora Phoenix",
             "text": "Flying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nWhenever you cast a spell with cascade, return Aurora Phoenix from your graveyard to your hand.",
             "colours": [
@@ -28994,7 +28994,7 @@
         },
         {
             "id": "a659e4b8-120e-5a75-b746-78638b79daad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7951ef42-8e14-4920-bf8a-75ab48e8645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7951ef42-8e14-4920-bf8a-75ab48e8645a.jpg?1",
             "name": "Avatar of Slaughter",
             "text": "All creatures have double strike and attack each combat if able.",
             "colours": [
@@ -29027,7 +29027,7 @@
         },
         {
             "id": "7f9c1b40-f4bd-5e0a-9e30-b5c14a3db22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba975f60-ca29-4fc8-b2f0-416be395f200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba975f60-ca29-4fc8-b2f0-416be395f200.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -29058,7 +29058,7 @@
         },
         {
             "id": "70bd0fe2-10e7-5a35-97b5-32c981340284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Whenever Bonecrusher Giant becomes the target of a spell, Bonecrusher Giant deals 2 damage to that spell's controller.",
             "colours": [
@@ -29091,7 +29091,7 @@
         },
         {
             "id": "c23a1071-887a-5dc1-91f0-6a27d3f5bb33",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Damage can't be prevented this turn. Stomp deals 2 damage to any target.",
             "colours": [
@@ -29124,7 +29124,7 @@
         },
         {
             "id": "6bf9b79d-7228-50e2-9317-89fcf7ee4227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1480f99-83f8-48e7-ba52-9a3f3a9a24f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1480f99-83f8-48e7-ba52-9a3f3a9a24f3.jpg?1",
             "name": "Brash Taunter",
             "text": "Indestructible\nWhenever Brash Taunter is dealt damage, it deals that much damage to target opponent.\n{2}{R}, {T}: Brash Taunter fights another target creature.",
             "colours": [
@@ -29157,7 +29157,7 @@
         },
         {
             "id": "9096adac-6652-5a79-ae59-bcacf367cc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ca793e-a54a-4e8f-a87d-f0dc4f178412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ca793e-a54a-4e8f-a87d-f0dc4f178412.jpg?1",
             "name": "Chain Reaction",
             "text": "Chain Reaction deals X damage to each creature, where X is the number of creatures on the battlefield.",
             "colours": [
@@ -29188,7 +29188,7 @@
         },
         {
             "id": "a7cd2c5f-b09f-502d-a3d8-ae381f8fd4fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08219fbc-c155-4d1d-a08c-d2546c44bccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08219fbc-c155-4d1d-a08c-d2546c44bccc.jpg?1",
             "name": "Chaos Dragon",
             "text": "Flying, haste\nChaos Dragon attacks each combat if able.\nAt the beginning of combat on your turn, each player rolls a d20. If one or more opponents had the highest result, Chaos Dragon can't attack those players or planeswalkers they control this combat.",
             "colours": [
@@ -29221,7 +29221,7 @@
         },
         {
             "id": "07bce218-ea7c-5895-a4d8-563011de5bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ee7b0-ea23-4657-a171-ac8a1308cc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ee7b0-ea23-4657-a171-ac8a1308cc4d.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -29252,7 +29252,7 @@
         },
         {
             "id": "b0a0f8f4-f728-5ebb-9687-a6b4ebfe4e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440acae3-aadb-40f0-a608-d1d93578c6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440acae3-aadb-40f0-a608-d1d93578c6b0.jpg?1",
             "name": "Curse of Opulence",
             "text": "Enchant player\nWhenever enchanted player is attacked, create a Gold token. Each opponent attacking that player does the same. (A Gold token is an artifact with \"Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -29286,7 +29286,7 @@
         },
         {
             "id": "c9b435c8-a93a-57e0-9373-6f72496beaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c43bf24-399e-407a-a563-bb04f93a0497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c43bf24-399e-407a-a563-bb04f93a0497.jpg?1",
             "name": "Demon Bolt",
             "text": "Demon Bolt deals 4 damage to target creature or planeswalker.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -29317,7 +29317,7 @@
         },
         {
             "id": "39a0ec8c-ac37-5827-9f75-fbfded7b7138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfc626c-1a03-4346-ba07-e26385ec0fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfc626c-1a03-4346-ba07-e26385ec0fd8.jpg?1",
             "name": "Dire Fleet Daredevil",
             "text": "First strike\nWhen Dire Fleet Daredevil enters the battlefield, exile target instant or sorcery card from an opponent's graveyard. You may cast it this turn, and you may spend mana as though it were mana of any type to cast that spell. If that spell would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -29351,7 +29351,7 @@
         },
         {
             "id": "a0015b18-56c5-5970-96d8-8c15dcc72165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc692-f994-4975-acae-4440e9e5857c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc692-f994-4975-acae-4440e9e5857c.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -29382,7 +29382,7 @@
         },
         {
             "id": "496bdde3-98ba-5f7e-8d9f-6544e6d2f790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8429f1-1a91-4f29-8d56-4c061f21c183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8429f1-1a91-4f29-8d56-4c061f21c183.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -29417,7 +29417,7 @@
         },
         {
             "id": "3b105a95-3353-5ae0-9d2a-19da607623aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c8d00f-23f3-429a-a99a-a6f3ec21c137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c8d00f-23f3-429a-a99a-a6f3ec21c137.jpg?1",
             "name": "Dream Pillager",
             "text": "Flying\nWhenever Dream Pillager deals combat damage to a player, exile that many cards from the top of your library. Until end of turn, you may cast spells from among those exiled cards.",
             "colours": [
@@ -29450,7 +29450,7 @@
         },
         {
             "id": "c09ddaef-592a-537b-a585-c31e2ee84a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -29484,7 +29484,7 @@
         },
         {
             "id": "cafef292-7128-5281-9fd2-9d4bdfc07cef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e2f789b3-3274-4a93-b44b-fabc44c1833c.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "Destroy target artifact. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -29517,7 +29517,7 @@
         },
         {
             "id": "14e3b9a0-8ff2-51ab-b4b1-9103dfb76bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc068c30-d677-4a7d-815f-f976e4787f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc068c30-d677-4a7d-815f-f976e4787f4b.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -29553,7 +29553,7 @@
         },
         {
             "id": "9b7f52c7-7c19-5276-b26a-8d7aa15504b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5974dd-78fc-4bfb-8678-72041c797584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5974dd-78fc-4bfb-8678-72041c797584.jpg?1",
             "name": "Geode Rager",
             "text": "First strike\nLandfall \u2014 Whenever a land enters the battlefield under your control, goad each creature target player controls. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -29586,7 +29586,7 @@
         },
         {
             "id": "fba57d1d-7c34-57fe-afe9-4314de9956cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687ea64-fcc0-4bd8-aa7e-3c893d4ef2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687ea64-fcc0-4bd8-aa7e-3c893d4ef2a8.jpg?1",
             "name": "Goblin Spymaster",
             "text": "First strike\nAt the beginning of each opponent's end step, that player creates a 1/1 red Goblin creature token with \"Creatures you control attack each combat if able.\"",
             "colours": [
@@ -29620,7 +29620,7 @@
         },
         {
             "id": "c128f951-15d2-58e6-9f66-8e09c2c50ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574fd1ec-fb73-4bf1-b3e4-5f976bf40a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574fd1ec-fb73-4bf1-b3e4-5f976bf40a62.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate only if Greater Gargadon is suspended.",
             "colours": [
@@ -29653,7 +29653,7 @@
         },
         {
             "id": "dce1c183-20a8-5850-863c-d46791595516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e82d3c-a7ec-4e0d-a17e-51ebd2f3f331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e82d3c-a7ec-4e0d-a17e-51ebd2f3f331.jpg?1",
             "name": "Ignite the Future",
             "text": "Exile the top three cards of your library. Until the end of your next turn, you may play those cards. If this spell was cast from a graveyard, you may play cards this way without paying their mana costs.\nFlashback {7}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -29684,7 +29684,7 @@
         },
         {
             "id": "ac501c73-a639-5304-9bd3-1926d275ffa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970c679-562b-48ee-b631-2e3016f4f37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970c679-562b-48ee-b631-2e3016f4f37c.jpg?1",
             "name": "Izzet Chemister",
             "text": "Haste\n{R}, {T}: Exile target instant or sorcery card from your graveyard.\n{1}{R}, {T}, Sacrifice Izzet Chemister: Cast any number of cards exiled with Izzet Chemister without paying their mana costs.",
             "colours": [
@@ -29718,7 +29718,7 @@
         },
         {
             "id": "e5cc2047-1816-5a46-8e29-fed0ec8478e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3308993d-8bfb-477a-887a-89ed35577f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3308993d-8bfb-477a-887a-89ed35577f57.jpg?1",
             "name": "Jeska's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Add {R} for each card in target opponent's hand.\n\u2022 Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -29749,7 +29749,7 @@
         },
         {
             "id": "1252dfea-a391-5551-ad8a-831d4703f995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce569cd-964e-44d6-a155-5a853ccc1478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce569cd-964e-44d6-a155-5a853ccc1478.jpg?1",
             "name": "Kazuul, Tyrant of the Cliffs",
             "text": "Whenever a creature an opponent controls attacks, if you're the defending player, create a 3/3 red Ogre creature token unless that creature's controller pays {3}.",
             "colours": [
@@ -29785,7 +29785,7 @@
         },
         {
             "id": "7a1203db-3ceb-5184-8342-dd5a4daf0599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e90b9b2-8e8e-4b00-b3a0-b26dd4551550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e90b9b2-8e8e-4b00-b3a0-b26dd4551550.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -29821,7 +29821,7 @@
         },
         {
             "id": "1ffbc473-f096-52db-844b-6cfdaaabf946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7034ff11-f7c7-4f33-be89-491ffec84833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7034ff11-f7c7-4f33-be89-491ffec84833.jpg?1",
             "name": "Light Up the Stage",
             "text": "Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nExile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -29852,7 +29852,7 @@
         },
         {
             "id": "bdaf543b-7840-5ad1-8070-ef0518ee95ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b2931-0af1-4743-b7c1-91e1dc9294d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b2931-0af1-4743-b7c1-91e1dc9294d5.jpg?1",
             "name": "Mizzium Mortars",
             "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -29883,7 +29883,7 @@
         },
         {
             "id": "6b44ed08-f63d-5e54-9d15-f49726cbe4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f75fce-f0a1-4dec-982d-a86925c6e9d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f75fce-f0a1-4dec-982d-a86925c6e9d4.jpg?1",
             "name": "Outpost Siege",
             "text": "As Outpost Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your upkeep, exile the top card of your library. Until end of turn, you may play that card.\n\u2022 Dragons \u2014 Whenever a creature you control leaves the battlefield, Outpost Siege deals 1 damage to any target.",
             "colours": [
@@ -29914,7 +29914,7 @@
         },
         {
             "id": "3ab16b2b-d171-5fb5-a293-7b429a57934a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf0514e-63b3-4695-93ae-527524d48c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf0514e-63b3-4695-93ae-527524d48c25.jpg?1",
             "name": "Rowan Kenrith",
             "text": "+2: During target player's next turn, each creature that player controls attacks if able.\n\u22122: Rowan Kenrith deals 3 damage to each tapped creature target player controls.\n\u22128: Target player gets an emblem with \"Whenever you activate an ability that isn't a mana ability, copy it. You may choose new targets for the copy.\"\nPartner with Will Kenrith\nRowan Kenrith can be your commander.",
             "colours": [
@@ -29949,7 +29949,7 @@
         },
         {
             "id": "7c955ef0-6cd7-5d8c-a1e9-8abefc1261e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -29985,7 +29985,7 @@
         },
         {
             "id": "e6780cf7-5ed0-5ce7-9be2-3dd30c6a6647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e37dde2-2ad4-46c6-ab69-8487f8a2bdb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e37dde2-2ad4-46c6-ab69-8487f8a2bdb6.jpg?1",
             "name": "Stolen Strategy",
             "text": "At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -30016,7 +30016,7 @@
         },
         {
             "id": "e769225f-97c4-5424-8804-0f2cf2c9b09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ec9d7-9784-481d-91d9-3dd1f666f7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ec9d7-9784-481d-91d9-3dd1f666f7d1.jpg?1",
             "name": "Tectonic Giant",
             "text": "Whenever Tectonic Giant attacks or becomes the target of a spell an opponent controls, choose one \u2014\n\u2022 Tectonic Giant deals 3 damage to each opponent.\n\u2022 Exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -30050,7 +30050,7 @@
         },
         {
             "id": "692c5baa-98e1-5797-8d8e-43029ca10b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21618490-f33b-4607-ac61-25df8cb096a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21618490-f33b-4607-ac61-25df8cb096a1.jpg?1",
             "name": "Territorial Hellkite",
             "text": "Flying, haste\nAt the beginning of combat on your turn, choose an opponent at random that Territorial Hellkite didn't attack during your last combat. Territorial Hellkite attacks that player this combat if able. If you can't choose an opponent this way, tap Territorial Hellkite.",
             "colours": [
@@ -30083,7 +30083,7 @@
         },
         {
             "id": "b854e2fa-353e-5864-a08d-2f99612379d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff75ff4-495f-4a0c-9d98-69eff1b3fa32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff75ff4-495f-4a0c-9d98-69eff1b3fa32.jpg?1",
             "name": "Thunder Dragon",
             "text": "Flying\nWhen Thunder Dragon enters the battlefield, it deals 3 damage to each creature without flying.",
             "colours": [
@@ -30116,7 +30116,7 @@
         },
         {
             "id": "49a24cda-4f82-562a-93d2-847c9c527443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93970fae-19f7-41dd-9750-ca428ae1de7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93970fae-19f7-41dd-9750-ca428ae1de7a.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "Creatures you control have haste.\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -30152,7 +30152,7 @@
         },
         {
             "id": "8181667b-c383-5241-a0ce-fdab85c0ed1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dabc03-a706-4e84-83e4-dbd405dfb025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dabc03-a706-4e84-83e4-dbd405dfb025.jpg?1",
             "name": "Vengeful Ancestor",
             "text": "Flying\nWhenever Vengeful Ancestor enters the battlefield or attacks, goad target creature. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)\nWhenever a goaded creature attacks, it deals 1 damage to its controller.",
             "colours": [
@@ -30186,7 +30186,7 @@
         },
         {
             "id": "584406e2-c514-5e8b-82a6-57a37459c910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fb4747-6734-4fbf-ab45-6d6e67f41be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fb4747-6734-4fbf-ab45-6d6e67f41be7.jpg?1",
             "name": "Volcanic Torrent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nVolcanic Torrent deals X damage to each creature and planeswalker your opponents control, where X is the number of spells you've cast this turn.",
             "colours": [
@@ -30217,7 +30217,7 @@
         },
         {
             "id": "d0922e63-c69c-512e-a433-d1d1221ea50d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedbf64-cd51-4f40-9735-272bd86fdf84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedbf64-cd51-4f40-9735-272bd86fdf84.jpg?1",
             "name": "Warmonger Hellkite",
             "text": "Flying\nAll creatures attack each combat if able.\n{1}{R}: Attacking creatures get +1/+0 until end of turn.",
             "colours": [
@@ -30250,7 +30250,7 @@
         },
         {
             "id": "d9f790e3-843a-5bcd-856b-a9acdd39492a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe1bfe0-0be7-496d-94db-e8028d4d9493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe1bfe0-0be7-496d-94db-e8028d4d9493.jpg?1",
             "name": "Warstorm Surge",
             "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to any target.",
             "colours": [
@@ -30281,7 +30281,7 @@
         },
         {
             "id": "e580066a-1722-581d-8636-4add7389ff12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5de7331-d0c6-46a5-b08d-0e032db63223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5de7331-d0c6-46a5-b08d-0e032db63223.jpg?1",
             "name": "Wild-Magic Sorcerer",
             "text": "The first spell you cast from exile each turn has cascade. (When you cast your first spell from exile, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -30315,7 +30315,7 @@
         },
         {
             "id": "3778ec72-5044-535d-88dc-90aaa4719552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/558b6db8-4a54-4d25-98e7-e27efc1cab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/558b6db8-4a54-4d25-98e7-e27efc1cab38.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -30351,7 +30351,7 @@
         },
         {
             "id": "5a6c79a9-5dd7-5a7f-8f08-5d86d73950a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70dc42-a28c-41f3-8d3b-5a0375aab326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70dc42-a28c-41f3-8d3b-5a0375aab326.jpg?1",
             "name": "Battle Mammoth",
             "text": "Trample\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\nForetell {2}{G}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -30384,7 +30384,7 @@
         },
         {
             "id": "46d1f9ed-163a-5675-89d1-939eea286f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Beanstalk Giant's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -30417,7 +30417,7 @@
         },
         {
             "id": "a606d74d-ba6e-5733-99cc-40e4329972d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47ceeea0-dd47-4c5c-a713-f100571107b9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -30450,7 +30450,7 @@
         },
         {
             "id": "d948fa72-473a-5c7b-abc4-4f74e3dad041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2fba2-fa50-4e69-aadb-d28479f821b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb2fba2-fa50-4e69-aadb-d28479f821b9.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Beast creature token.",
             "colours": [
@@ -30481,7 +30481,7 @@
         },
         {
             "id": "f0460ab5-3c50-5b05-a549-4c02d8e49a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960ee5f-1109-4569-9191-be68a2c0f7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960ee5f-1109-4569-9191-be68a2c0f7d5.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -30512,7 +30512,7 @@
         },
         {
             "id": "878657fa-d4b4-52b7-8c14-a25e87cc5f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a74813-6d8b-4b11-8a5e-5b83d2d98c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a74813-6d8b-4b11-8a5e-5b83d2d98c34.jpg?1",
             "name": "End-Raze Forerunners",
             "text": "Vigilance, trample, haste\nWhen End-Raze Forerunners enters the battlefield, other creatures you control get +2/+2 and gain vigilance and trample until end of turn.",
             "colours": [
@@ -30545,7 +30545,7 @@
         },
         {
             "id": "03e71b88-3b25-5cf0-8fb0-4870d56bf24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a70945-8f8b-4dc7-a78b-d285694f9f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a70945-8f8b-4dc7-a78b-d285694f9f50.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -30576,7 +30576,7 @@
         },
         {
             "id": "9e4f1485-2297-5f36-93ed-3bf55a465f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dbfc25-f06e-4b5f-848f-6dd4cb72079e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dbfc25-f06e-4b5f-848f-6dd4cb72079e.jpg?1",
             "name": "Ezuri's Predation",
             "text": "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures.",
             "colours": [
@@ -30607,7 +30607,7 @@
         },
         {
             "id": "86097cef-0931-5579-9ad3-4ed81334d75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7c1a5-eb4e-4f75-ad41-1b84741ecab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7c1a5-eb4e-4f75-ad41-1b84741ecab1.jpg?1",
             "name": "Hornet Queen",
             "text": "Flying, deathtouch\nWhen Hornet Queen enters the battlefield, create four 1/1 green Insect creature tokens with flying and deathtouch.",
             "colours": [
@@ -30640,7 +30640,7 @@
         },
         {
             "id": "3e2b4766-02b3-5a38-8dd9-7f3168611c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979741db-e720-4efd-bc8e-2bf47e777ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979741db-e720-4efd-bc8e-2bf47e777ab3.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -30673,7 +30673,7 @@
         },
         {
             "id": "98c3870d-ffb4-55ae-9e14-7d2fca76e9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Lovestruck Beast can't attack unless you control a 1/1 creature.",
             "colours": [
@@ -30707,7 +30707,7 @@
         },
         {
             "id": "582c3888-8a93-5643-9f1d-6acd5b5565de",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Create a 1/1 white Human creature token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -30740,7 +30740,7 @@
         },
         {
             "id": "5a90edfc-7557-5eb3-944d-19a702d749a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330aefb9-629f-4d07-94d4-7252f17f85ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330aefb9-629f-4d07-94d4-7252f17f85ba.jpg?1",
             "name": "Managorger Hydra",
             "text": "Trample\nWhenever a player casts a spell, put a +1/+1 counter on Managorger Hydra.",
             "colours": [
@@ -30773,7 +30773,7 @@
         },
         {
             "id": "2d744cd9-d10e-5e79-a3c3-cb62ec0ab0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c4fc42-e5c6-438b-a4b7-1f77e818597f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c4fc42-e5c6-438b-a4b7-1f77e818597f.jpg?1",
             "name": "Natural Reclamation",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -30804,7 +30804,7 @@
         },
         {
             "id": "1a24b2fd-0631-5e66-b50e-fa36df50588c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9e943-9650-434c-a540-35ca7c96365b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9e943-9650-434c-a540-35ca7c96365b.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nWhenever a land enters the battlefield under your control, you gain 3 life.",
             "colours": [
@@ -30835,7 +30835,7 @@
         },
         {
             "id": "14c09a3b-bcde-5065-b0b8-432093579f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e0861-7934-4141-9ef5-120339ac83a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e0861-7934-4141-9ef5-120339ac83a5.jpg?1",
             "name": "Return of the Wildspeaker",
             "text": "Choose one \u2014\n\u2022 Draw cards equal to the greatest power among non-Human creatures you control.\n\u2022 Non-Human creatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -30866,7 +30866,7 @@
         },
         {
             "id": "bcbdaa13-0d0a-5c61-a55a-3a69b0b6145a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec23f98d-1bfd-4957-92b6-0a1da823db0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec23f98d-1bfd-4957-92b6-0a1da823db0f.jpg?1",
             "name": "Sakura-Tribe Elder",
             "text": "Sacrifice Sakura-Tribe Elder: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -30900,7 +30900,7 @@
         },
         {
             "id": "2681cd9c-3f33-534b-923a-677fd87aae1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d2a7e4-acc9-4236-a78f-c3171fd0c9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d2a7e4-acc9-4236-a78f-c3171fd0c9ec.jpg?1",
             "name": "Sandwurm Convergence",
             "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
             "colours": [
@@ -30931,7 +30931,7 @@
         },
         {
             "id": "d1b3ecec-e96b-5d88-b6f0-b3f7c3b91bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5e2fbf-87fe-48cd-aeca-e37f0a388a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5e2fbf-87fe-48cd-aeca-e37f0a388a30.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -30962,7 +30962,7 @@
         },
         {
             "id": "4fb11b2f-7090-53a7-969e-b8a0319c92cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c6325-450d-47f3-a69b-cdfc25ae65e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c6325-450d-47f3-a69b-cdfc25ae65e6.jpg?1",
             "name": "Sweet-Gum Recluse",
             "text": "Flash\nCascade\nReach\nWhen Sweet-Gum Recluse enters the battlefield, put three +1/+1 counters on each of any number of target creatures that entered the battlefield this turn.",
             "colours": [
@@ -30995,7 +30995,7 @@
         },
         {
             "id": "0975a650-91aa-583a-afbe-d04a5d4fad88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7b2ac-1263-402a-b2a0-bc31f61e66b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7b2ac-1263-402a-b2a0-bc31f61e66b5.jpg?1",
             "name": "Terramorph",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -31026,7 +31026,7 @@
         },
         {
             "id": "50d790fa-9183-59bb-986a-3d971ee74ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad698c3-687e-4b73-88d2-fd0ac7d755c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad698c3-687e-4b73-88d2-fd0ac7d755c5.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -31057,7 +31057,7 @@
         },
         {
             "id": "e07a64d3-dfc8-550b-9192-375e0df04679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11dc967-ae38-4c19-bf54-b3209e203b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11dc967-ae38-4c19-bf54-b3209e203b39.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "You may cast creature spells as though they had flash.\n+1: Until your next turn, up to one target creature gains vigilance and reach.\n\u22122: Look at the top three cards of your library. Exile one face down and put the rest on the bottom of your library in any order. For as long as it remains exiled, you may look at that card and you may cast it if it's a creature spell.",
             "colours": [
@@ -31092,7 +31092,7 @@
         },
         {
             "id": "81faa2d5-bd53-5ffa-8713-2f9d734666a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8174d8dc-ae0f-469f-a773-cb294540ea25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8174d8dc-ae0f-469f-a773-cb294540ea25.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -31128,7 +31128,7 @@
         },
         {
             "id": "803af955-50b7-5105-adcb-f016d25a2546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464dbaf6-8430-45af-b982-9099e6c6e8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464dbaf6-8430-45af-b982-9099e6c6e8a7.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -31163,7 +31163,7 @@
         },
         {
             "id": "ef54ac89-9b82-549a-81ad-9995b6f0a7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83902f7a-b675-45a6-8d03-a4e82335547a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83902f7a-b675-45a6-8d03-a4e82335547a.jpg?1",
             "name": "Despark",
             "text": "Exile target permanent with mana value 4 or greater.",
             "colours": [
@@ -31196,7 +31196,7 @@
         },
         {
             "id": "fcbfde25-901a-5a95-91f1-fb82960f78dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b9762-740b-4c1c-a411-20dbf023aea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b9762-740b-4c1c-a411-20dbf023aea5.jpg?1",
             "name": "Drown in the Loch",
             "text": "Choose one \u2014\n\u2022 Counter target spell with mana value less than or equal to the number of cards in its controller's graveyard.\n\u2022 Destroy target creature with mana value less than or equal to the number of cards in its controller's graveyard.",
             "colours": [
@@ -31229,7 +31229,7 @@
         },
         {
             "id": "fed0603e-eab0-5b04-b581-89162965393a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d58c2d-2bff-4d25-a023-0a6342167f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d58c2d-2bff-4d25-a023-0a6342167f5f.jpg?1",
             "name": "Escape to the Wilds",
             "text": "Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn.\nYou may play an additional land this turn.",
             "colours": [
@@ -31262,7 +31262,7 @@
         },
         {
             "id": "af81f38a-40cd-55db-b97c-6e4231e2172d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc868df-df15-4927-88dc-9b4d38d28c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc868df-df15-4927-88dc-9b4d38d28c5f.jpg?1",
             "name": "Extract from Darkness",
             "text": "Each player mills two cards. Then you put a creature card from a graveyard onto the battlefield under your control. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -31295,7 +31295,7 @@
         },
         {
             "id": "9fea787a-3f31-5c46-b9a9-e0648fe005bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8abf0-e8c3-4c19-bdf1-18aabe75a3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8abf0-e8c3-4c19-bdf1-18aabe75a3de.jpg?1",
             "name": "Felisa, Fang of Silverquill",
             "text": "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhenever a nontoken creature you control dies, if it had counters on it, create X tapped 2/1 white and black Inkling creature tokens with flying, where X is the number of counters it had on it.",
             "colours": [
@@ -31333,7 +31333,7 @@
         },
         {
             "id": "6bf47bc6-d821-5555-8af9-6c0530862f43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1bbe5-c63e-4a8d-b79a-0dcca221a726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1bbe5-c63e-4a8d-b79a-0dcca221a726.jpg?1",
             "name": "Firja's Retribution",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 4/4 white Angel Warrior creature token with flying and vigilance.\nII \u2014 Until end of turn, Angels you control gain \"{T}: Destroy target creature with power less than this creature's power.\"\nIII \u2014 Angels you control gain double strike until end of turn.",
             "colours": [
@@ -31368,7 +31368,7 @@
         },
         {
             "id": "5c91e955-6404-5828-a79e-3cda4dbd2c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa40ce2-76df-43bd-a59e-7cf6e4f46a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa40ce2-76df-43bd-a59e-7cf6e4f46a1d.jpg?1",
             "name": "Grumgully, the Generous",
             "text": "Each other non-Human creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -31406,7 +31406,7 @@
         },
         {
             "id": "11afb26a-2b2a-51e8-9956-1b6db8a58004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc264fad-c541-4cc6-8b56-44abf3f1e8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc264fad-c541-4cc6-8b56-44abf3f1e8a0.jpg?1",
             "name": "High Priest of Penance",
             "text": "Whenever High Priest of Penance is dealt damage, you may destroy target nonland permanent.",
             "colours": [
@@ -31442,7 +31442,7 @@
         },
         {
             "id": "77bfee50-63fb-5549-941e-61eee6107ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9b3d8d-4941-44ca-b829-d53242feba1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9b3d8d-4941-44ca-b829-d53242feba1e.jpg?1",
             "name": "Memory Plunder",
             "text": "You may cast target instant or sorcery card from an opponent's graveyard without paying its mana cost.",
             "colours": [
@@ -31475,7 +31475,7 @@
         },
         {
             "id": "10a08c70-dea4-5d0a-ae51-fa50f52c145a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022aacc6-2d82-43c0-ac08-ba9b20578929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022aacc6-2d82-43c0-ac08-ba9b20578929.jpg?1",
             "name": "Nemesis of Reason",
             "text": "Whenever Nemesis of Reason attacks, defending player mills ten cards.",
             "colours": [
@@ -31511,7 +31511,7 @@
         },
         {
             "id": "0c2cbf05-c0c8-5011-931b-ea010d463dac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035a97f-5104-4b56-84a4-5206e75607fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3035a97f-5104-4b56-84a4-5206e75607fc.jpg?1",
             "name": "Niv-Mizzet, Parun",
             "text": "This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.",
             "colours": [
@@ -31549,7 +31549,7 @@
         },
         {
             "id": "5d1512be-667f-5658-aedd-8e0c79140295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361385d8-d9c7-4de8-a5c8-683e682779f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361385d8-d9c7-4de8-a5c8-683e682779f4.jpg?1",
             "name": "Sprite Dragon",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on Sprite Dragon.",
             "colours": [
@@ -31585,7 +31585,7 @@
         },
         {
             "id": "98f6e07e-3c17-5cb6-b9dc-1aba32e2aa0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfd90ee-a142-4a80-b383-802bbee2cef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfd90ee-a142-4a80-b383-802bbee2cef1.jpg?1",
             "name": "Xenagos, the Reveler",
             "text": "+1: Add X mana in any combination of {R} and/or {G}, where X is the number of creatures you control.\n0: Create a 2/2 red and green Satyr creature token with haste.\n\u22126: Exile the top seven cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield.",
             "colours": [
@@ -31622,7 +31622,7 @@
         },
         {
             "id": "9f43ae71-39bb-545b-b01e-f8e526c707f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe00149-b9ca-43d9-aff1-5c2da4dc7753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe00149-b9ca-43d9-aff1-5c2da4dc7753.jpg?1",
             "name": "Bloodthirsty Blade",
             "text": "Equipped creature gets +2/+0 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\n{1}: Attach Bloodthirsty Blade to target creature an opponent controls. Activate only as a sorcery.",
             "colours": [],
@@ -31651,7 +31651,7 @@
         },
         {
             "id": "d4d7eded-81a0-5767-91f7-cfc233c2f047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e065e040-80c1-47d3-a425-28381e5a29f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e065e040-80c1-47d3-a425-28381e5a29f2.jpg?1",
             "name": "Chaos Wand",
             "text": "{4}, {T}: Target opponent exiles cards from the top of their library until they exile an instant or sorcery card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of that library in a random order.",
             "colours": [],
@@ -31678,7 +31678,7 @@
         },
         {
             "id": "b08f32f6-574b-51c1-b61e-1a1ca0c2ed71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d1dd6c-21d3-4fe8-af1b-7088dcceef08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d1dd6c-21d3-4fe8-af1b-7088dcceef08.jpg?1",
             "name": "Dimir Keyrune",
             "text": "{T}: Add {U} or {B}.\n{U}{B}: Dimir Keyrune becomes a 2/2 blue and black Horror artifact creature until end of turn and can't be blocked this turn.",
             "colours": [],
@@ -31708,7 +31708,7 @@
         },
         {
             "id": "ee47885a-1b8a-5e90-a937-a7330c7987d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0ff83-04a7-4d5a-b901-6b8a698c5a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0ff83-04a7-4d5a-b901-6b8a698c5a4d.jpg?1",
             "name": "Dimir Signet",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -31738,7 +31738,7 @@
         },
         {
             "id": "76bcc90f-bfef-5900-a0d8-1ca3973e4584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b6f0a8-b6c2-49fc-880c-01ad63213271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b6f0a8-b6c2-49fc-880c-01ad63213271.jpg?1",
             "name": "Dragon's Hoard",
             "text": "Whenever a Dragon enters the battlefield under your control, put a gold counter on Dragon's Hoard.\n{T}, Remove a gold counter from Dragon's Hoard: Draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -31765,7 +31765,7 @@
         },
         {
             "id": "944c30a9-e029-5345-99a3-6825f9eb13ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c235-7749-4016-917c-dd8b586ac819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c235-7749-4016-917c-dd8b586ac819.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -31792,7 +31792,7 @@
         },
         {
             "id": "1d8db14d-1e8d-5c3d-90ae-4641687dfc54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bca6877-4e1d-4ecb-8812-d75d3470ffee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bca6877-4e1d-4ecb-8812-d75d3470ffee.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -31819,7 +31819,7 @@
         },
         {
             "id": "af84ebcc-e015-5787-a208-93d0defd9ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d76d25c-b962-43e4-aa6f-7c6e3bd79f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d76d25c-b962-43e4-aa6f-7c6e3bd79f16.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -31846,7 +31846,7 @@
         },
         {
             "id": "d4c41f1f-253c-562f-930f-a6a736c61bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178274fd-8b9b-4d69-a47e-31b29b776742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178274fd-8b9b-4d69-a47e-31b29b776742.jpg?1",
             "name": "Herald's Horn",
             "text": "As Herald's Horn enters the battlefield, choose a creature type.\nCreature spells you cast of the chosen type cost {1} less to cast.\nAt the beginning of your upkeep, look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand.",
             "colours": [],
@@ -31873,7 +31873,7 @@
         },
         {
             "id": "17d7a21a-72fa-5113-834a-db4985b30e16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc741b-18d8-41b1-b61b-e2249cad8526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc741b-18d8-41b1-b61b-e2249cad8526.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -31903,7 +31903,7 @@
         },
         {
             "id": "45973b43-e3b2-5368-a64d-6b97000693bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f47af-5929-44f4-bc6b-3ac7e521177d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9f47af-5929-44f4-bc6b-3ac7e521177d.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -31932,7 +31932,7 @@
         },
         {
             "id": "283d02a3-377d-5bd6-9091-3ca72985f38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1246c42d-57c0-4cba-959a-15ad89d8a50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1246c42d-57c0-4cba-959a-15ad89d8a50b.jpg?1",
             "name": "Maskwood Nexus",
             "text": "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling. (It is every creature type.)",
             "colours": [],
@@ -31959,7 +31959,7 @@
         },
         {
             "id": "b18f5598-b3cd-5559-ba6b-671b007b33f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8858a941-8175-476d-8177-2db4ffdcb3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8858a941-8175-476d-8177-2db4ffdcb3ad.jpg?1",
             "name": "Mindcrank",
             "text": "Whenever an opponent loses life, that player mills that many cards. (Damage causes loss of life.)",
             "colours": [],
@@ -31986,7 +31986,7 @@
         },
         {
             "id": "6cca813c-235f-5574-b029-943e1766e5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb325f3-3c39-410b-b7a6-1615a7c4fe54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb325f3-3c39-410b-b7a6-1615a7c4fe54.jpg?1",
             "name": "Orzhov Signet",
             "text": "{1}, {T}: Add {W}{B}.",
             "colours": [],
@@ -32016,7 +32016,7 @@
         },
         {
             "id": "b8bb05dc-fa55-5946-8e4d-8779330a1a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ef9f3b-d6f8-4795-ba96-2f92b8792360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ef9f3b-d6f8-4795-ba96-2f92b8792360.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, choose a nonland card name.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -32047,7 +32047,7 @@
         },
         {
             "id": "837cd9e6-164a-5874-bb48-16f088eea0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe2c9e8-e35a-47a4-bcad-7c1c16dcdfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe2c9e8-e35a-47a4-bcad-7c1c16dcdfcf.jpg?1",
             "name": "Psychosis Crawler",
             "text": "Psychosis Crawler's power and toughness are each equal to the number of cards in your hand.\nWhenever you draw a card, each opponent loses 1 life.",
             "colours": [],
@@ -32078,7 +32078,7 @@
         },
         {
             "id": "57e3760f-4d20-5dcc-95ca-ad8e05871d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1877be5-fb98-4bd2-a754-dda1132ef8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1877be5-fb98-4bd2-a754-dda1132ef8a0.jpg?1",
             "name": "Skullclamp",
             "text": "Equipped creature gets +1/-1.\nWhenever equipped creature dies, draw two cards.\nEquip {1}",
             "colours": [],
@@ -32107,7 +32107,7 @@
         },
         {
             "id": "926332b2-d527-5eeb-9779-fb158ed79a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199cde21-5bc3-49cd-acd4-bae3af6e5881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199cde21-5bc3-49cd-acd4-bae3af6e5881.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -32134,7 +32134,7 @@
         },
         {
             "id": "e0442292-c3e6-5bff-bdca-bd9e6973df65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec09ec-a300-4d3c-8054-0250bb70b93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec09ec-a300-4d3c-8054-0250bb70b93b.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -32164,7 +32164,7 @@
         },
         {
             "id": "757889e8-a12e-5acd-96b9-a5beed31d51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72204934-f5aa-4559-8f7e-7b0b223580d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72204934-f5aa-4559-8f7e-7b0b223580d0.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -32197,7 +32197,7 @@
         },
         {
             "id": "3f45e8ed-4670-5f9b-b35c-3188655e7185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8823b43b-8a30-4226-b5a7-ac1c06ba146b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8823b43b-8a30-4226-b5a7-ac1c06ba146b.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: Steel Hellkite gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with mana value X whose controller was dealt combat damage by Steel Hellkite this turn. Activate only once each turn.",
             "colours": [],
@@ -32227,7 +32227,7 @@
         },
         {
             "id": "255c39b7-2794-5794-9add-df3342d294f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978c2c7d-6898-4be2-aed7-e673210ce654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978c2c7d-6898-4be2-aed7-e673210ce654.jpg?1",
             "name": "Stuffy Doll",
             "text": "Indestructible\nAs Stuffy Doll enters the battlefield, choose a player.\nWhenever Stuffy Doll is dealt damage, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -32257,7 +32257,7 @@
         },
         {
             "id": "9be41ccb-f0bb-5d01-be8e-0827508812f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b4fea5-aa7b-40e7-a3c4-cb467af16b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b4fea5-aa7b-40e7-a3c4-cb467af16b42.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -32287,7 +32287,7 @@
         },
         {
             "id": "2571255b-abe5-5736-95f2-94f5e31b4dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca2a0f9-b403-4d1e-961c-32b64bab81d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca2a0f9-b403-4d1e-961c-32b64bab81d0.jpg?1",
             "name": "Talisman of Dominance",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Talisman of Dominance deals 1 damage to you.",
             "colours": [],
@@ -32317,7 +32317,7 @@
         },
         {
             "id": "1a8ee515-ed9e-5acc-96fd-a69757a0ffef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299c93e-f3a6-4b41-857b-e3d1aff0f622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299c93e-f3a6-4b41-857b-e3d1aff0f622.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Talisman of Hierarchy deals 1 damage to you.",
             "colours": [],
@@ -32347,7 +32347,7 @@
         },
         {
             "id": "18ec150c-a0c2-558e-a9a6-34dcf670627d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9cbf2-99ed-4f70-8744-b9a08a5f5f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e9cbf2-99ed-4f70-8744-b9a08a5f5f42.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -32374,7 +32374,7 @@
         },
         {
             "id": "116688b9-0238-506e-b269-5ebaf736d06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71aebf-f5d3-45ee-91a4-51088f7141ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb71aebf-f5d3-45ee-91a4-51088f7141ec.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -32401,7 +32401,7 @@
         },
         {
             "id": "bc2b9d73-6282-5b1c-86ed-d587162d81ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e0ad38-31b3-46ba-9999-9b6ff57906ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e0ad38-31b3-46ba-9999-9b6ff57906ae.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {C}.\n{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -32430,7 +32430,7 @@
         },
         {
             "id": "00a32502-6419-5f9d-be14-bafba69f4a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1c157-cebc-45fe-9caa-1ea4b305ccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1c157-cebc-45fe-9caa-1ea4b305ccfc.jpg?1",
             "name": "Bojuka Bog",
             "text": "Bojuka Bog enters the battlefield tapped.\nWhen Bojuka Bog enters the battlefield, exile target player's graveyard.\n{T}: Add {B}.",
             "colours": [],
@@ -32459,7 +32459,7 @@
         },
         {
             "id": "62d8b41b-c7c3-55e6-9a43-9a9f8d1568f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4126a6-5f79-4dad-8d18-e279ca19d2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4126a6-5f79-4dad-8d18-e279ca19d2b2.jpg?1",
             "name": "Castle Embereth",
             "text": "Castle Embereth enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -32488,7 +32488,7 @@
         },
         {
             "id": "0f918ffb-a0f0-560b-a4e5-0253929615f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19336e3a-2242-4a30-a563-32f2e4fc18e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19336e3a-2242-4a30-a563-32f2e4fc18e9.jpg?1",
             "name": "Castle Locthwain",
             "text": "Castle Locthwain enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{1}{B}{B}, {T}: Draw a card, then you lose life equal to the number of cards in your hand.",
             "colours": [],
@@ -32517,7 +32517,7 @@
         },
         {
             "id": "f4d0b5ef-7600-5d77-8860-46368e5445f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf70844-18b1-4046-ae1d-ef41790bdcde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf70844-18b1-4046-ae1d-ef41790bdcde.jpg?1",
             "name": "Castle Vantress",
             "text": "Castle Vantress enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{2}{U}{U}, {T}: Scry 2.",
             "colours": [],
@@ -32546,7 +32546,7 @@
         },
         {
             "id": "2b4a3fd9-c551-5d53-a825-91db6fa30697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11cf7c-f71c-4416-acbc-d3d5807a7625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11cf7c-f71c-4416-acbc-d3d5807a7625.jpg?1",
             "name": "Choked Estuary",
             "text": "As Choked Estuary enters the battlefield, you may reveal an Island or Swamp card from your hand. If you don't, Choked Estuary enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -32576,7 +32576,7 @@
         },
         {
             "id": "88239a7d-eadd-5c43-8984-2b681a8a55b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b5a17-491e-416f-990d-187fce6c4ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b5a17-491e-416f-990d-187fce6c4ce4.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G}.)\nCinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -32609,7 +32609,7 @@
         },
         {
             "id": "2818fca3-9b31-53a3-b134-62350ee517d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f60e172-fcdc-4699-a212-815201375d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f60e172-fcdc-4699-a212-815201375d47.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{1}{U}{B}: Creeping Tar Pit becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land.",
             "colours": [],
@@ -32639,7 +32639,7 @@
         },
         {
             "id": "a8d10eff-f675-5dd4-bf0e-d24f0e8e72f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dbc012-8b38-4089-947a-c309d02ad1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dbc012-8b38-4089-947a-c309d02ad1b1.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -32669,7 +32669,7 @@
         },
         {
             "id": "3d67f177-fc66-56a5-bdad-a311973ddd2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7f5239-29d3-4b2b-b464-7e43107b1348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7f5239-29d3-4b2b-b464-7e43107b1348.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "{T}: Add {C}.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -32699,7 +32699,7 @@
         },
         {
             "id": "4bd5da26-26c2-559f-9679-2de3f16a71ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7552d5-ec37-4599-8789-fe20b6d4b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7552d5-ec37-4599-8789-fe20b6d4b7bf.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B}.",
             "colours": [],
@@ -32729,7 +32729,7 @@
         },
         {
             "id": "d86276ad-224b-5c06-99fb-7facc4e2ce83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c61b1b-d8fa-4c8b-9ddb-ca2682a3f5ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c61b1b-d8fa-4c8b-9ddb-ca2682a3f5ef.jpg?1",
             "name": "Drownyard Temple",
             "text": "{T}: Add {C}.\n{3}: Return Drownyard Temple from your graveyard to the battlefield tapped.",
             "colours": [],
@@ -32756,7 +32756,7 @@
         },
         {
             "id": "3687b0d8-c3b6-5991-84be-e1624e594e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de15320-485c-4191-8f15-12f9d1b340ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de15320-485c-4191-8f15-12f9d1b340ba.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -32783,7 +32783,7 @@
         },
         {
             "id": "350a36a5-6704-58b5-a3be-6e39a0cd1784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104635cd-b75f-4111-a948-50740f9cfff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104635cd-b75f-4111-a948-50740f9cfff8.jpg?1",
             "name": "Game Trail",
             "text": "As Game Trail enters the battlefield, you may reveal a Mountain or Forest card from your hand. If you don't, Game Trail enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -32813,7 +32813,7 @@
         },
         {
             "id": "96960450-b6dc-5f7b-927d-c69089a08f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104961dc-6684-474e-b126-4fcd95849f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104961dc-6684-474e-b126-4fcd95849f98.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G}.",
             "colours": [],
@@ -32843,7 +32843,7 @@
         },
         {
             "id": "b27156d6-f24a-5b47-ba74-f746058d2c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f64a32-c364-4750-94ed-d4d71c1a3511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f64a32-c364-4750-94ed-d4d71c1a3511.jpg?1",
             "name": "Highland Forest",
             "text": "({T}: Add {R} or {G}.)\nHighland Forest enters the battlefield tapped.",
             "colours": [],
@@ -32878,7 +32878,7 @@
         },
         {
             "id": "5159c30d-db2a-567f-a1fe-6a05a148b1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86e42c6-342b-443f-9b99-a68cf536ff45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86e42c6-342b-443f-9b99-a68cf536ff45.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R}.",
             "colours": [],
@@ -32908,7 +32908,7 @@
         },
         {
             "id": "2dedca1c-9af0-51b0-bff2-895ea769bc85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814e1393-34e1-4a31-98c5-97a3290a105b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814e1393-34e1-4a31-98c5-97a3290a105b.jpg?1",
             "name": "Kessig Wolf Run",
             "text": "{T}: Add {C}.\n{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",
             "colours": [],
@@ -32938,7 +32938,7 @@
         },
         {
             "id": "39720c3c-7d73-5cc7-957d-f34e23c48a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44bba8e-59e9-4a06-b845-c3ba7625ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44bba8e-59e9-4a06-b845-c3ba7625ff58.jpg?1",
             "name": "Kher Keep",
             "text": "{T}: Add {C}.\n{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep.",
             "colours": [],
@@ -32969,7 +32969,7 @@
         },
         {
             "id": "0384e066-cdf8-5742-b12e-c1a6c541ba31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058f30e5-64a9-4d6b-b7a6-0fd95d460cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058f30e5-64a9-4d6b-b7a6-0fd95d460cae.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.\n{T}: Add {B}.",
             "colours": [],
@@ -32998,7 +32998,7 @@
         },
         {
             "id": "0c7cbe57-cd4e-5953-bd0a-dca5220a3f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4581f-382c-420b-a2aa-bc8010b48c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4581f-382c-420b-a2aa-bc8010b48c7d.jpg?1",
             "name": "Mossfire Valley",
             "text": "{1}, {T}: Add {R}{G}.",
             "colours": [],
@@ -33028,7 +33028,7 @@
         },
         {
             "id": "a79cf7ea-2094-5614-acc7-75f9cbcfc67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d3a6d-4e6a-42ac-84de-3a3868ca026d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d3a6d-4e6a-42ac-84de-3a3868ca026d.jpg?1",
             "name": "Mosswort Bridge",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nMosswort Bridge enters the battlefield tapped.\n{T}: Add {G}.\n{G}, {T}: You may play the exiled card without paying its mana cost if creatures you control have total power 10 or greater.",
             "colours": [],
@@ -33057,7 +33057,7 @@
         },
         {
             "id": "0da85651-c287-5591-a627-be87d1516f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc2f10-142d-4e6a-984e-b25f566cc960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc2f10-142d-4e6a-984e-b25f566cc960.jpg?1",
             "name": "Mutavault",
             "text": "{T}: Add {C}.\n{1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -33084,7 +33084,7 @@
         },
         {
             "id": "2cfbafd5-8511-539c-ab6d-b8029152b2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f49f9-019b-44cb-a551-0fba9851ecc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f49f9-019b-44cb-a551-0fba9851ecc7.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -33111,7 +33111,7 @@
         },
         {
             "id": "4c4d83bf-3d5f-51ee-8ea3-f941cd845999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e332d52-7533-4d71-a4ba-36874f5ea3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e332d52-7533-4d71-a4ba-36874f5ea3fa.jpg?1",
             "name": "Nephalia Drownyard",
             "text": "{T}: Add {C}.\n{1}{U}{B}, {T}: Target player mills three cards.",
             "colours": [],
@@ -33141,7 +33141,7 @@
         },
         {
             "id": "74030271-746a-5574-a3e8-7b5408b1d093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ed0bb4-91b8-4144-b3d6-f92d6821d979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ed0bb4-91b8-4144-b3d6-f92d6821d979.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -33171,7 +33171,7 @@
         },
         {
             "id": "d0165038-8212-5cab-97d4-869502dab1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43710f35-c43f-48bf-82e1-64ba5c3fa03e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43710f35-c43f-48bf-82e1-64ba5c3fa03e.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -33198,7 +33198,7 @@
         },
         {
             "id": "f926a337-17fe-52ea-be1f-52bb926127ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62711f58-c52e-4493-b641-a77352bd4ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62711f58-c52e-4493-b641-a77352bd4ff8.jpg?1",
             "name": "Port of Karfell",
             "text": "Port of Karfell enters the battlefield tapped.\n{T}: Add {U}.\n{3}{U}{B}{B}, {T}, Sacrifice Port of Karfell: Mill four cards, then return a creature card from your graveyard to the battlefield tapped. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -33228,7 +33228,7 @@
         },
         {
             "id": "2f874eb3-7ce9-5687-b10a-05d517f5b7d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf90c219-508f-49af-a7f9-540021d49d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf90c219-508f-49af-a7f9-540021d49d8c.jpg?1",
             "name": "Prismari Campus",
             "text": "Prismari Campus enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -33258,7 +33258,7 @@
         },
         {
             "id": "cf8e5cd0-f29e-5c62-a9a5-e548b3be776f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c981c0-3e40-4339-a4c8-ad96c7fb68d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c981c0-3e40-4339-a4c8-ad96c7fb68d2.jpg?1",
             "name": "Raging Ravine",
             "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
             "colours": [],
@@ -33288,7 +33288,7 @@
         },
         {
             "id": "b83ba0d8-255f-576c-afa1-376e7bde6f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1241912a-92d6-4942-b97b-f795e702c4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1241912a-92d6-4942-b97b-f795e702c4ca.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -33315,7 +33315,7 @@
         },
         {
             "id": "145ddffd-ddc0-573e-9128-97971e1d0269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8a98a9-864c-4ea5-842b-ca4ddf5571cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8a98a9-864c-4ea5-842b-ca4ddf5571cd.jpg?1",
             "name": "River of Tears",
             "text": "{T}: Add {U}. If you played a land this turn, add {B} instead.",
             "colours": [],
@@ -33345,7 +33345,7 @@
         },
         {
             "id": "bdeb828f-4247-52f6-985b-65fee8fb0c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1dd27-be41-4bfa-b59d-3a002647f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f1dd27-be41-4bfa-b59d-3a002647f1ad.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -33372,7 +33372,7 @@
         },
         {
             "id": "3cd57812-aea8-541b-9249-be38f95bcf05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5bf05a-04a1-4dde-845b-eced21a785fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5bf05a-04a1-4dde-845b-eced21a785fa.jpg?1",
             "name": "Shambling Vent",
             "text": "Shambling Vent enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.",
             "colours": [],
@@ -33402,7 +33402,7 @@
         },
         {
             "id": "f12c1ddf-dd97-5471-985c-581eacdc5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6e17f2-b1e4-4189-a02f-92fa4b13a1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6e17f2-b1e4-4189-a02f-92fa4b13a1ed.jpg?1",
             "name": "Snowfield Sinkhole",
             "text": "({T}: Add {W} or {B}.)\nSnowfield Sinkhole enters the battlefield tapped.",
             "colours": [],
@@ -33437,7 +33437,7 @@
         },
         {
             "id": "ddb1f664-7768-558e-95c4-de2feef60b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5d990f-0eb4-4634-a446-7783915e8eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5d990f-0eb4-4634-a446-7783915e8eec.jpg?1",
             "name": "Spinerock Knoll",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nSpinerock Knoll enters the battlefield tapped.\n{T}: Add {R}.\n{R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
             "colours": [],
@@ -33466,7 +33466,7 @@
         },
         {
             "id": "356d3453-6406-532b-b915-2d731736060e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5774836-0140-420a-9a0f-8ba291cc5ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5774836-0140-420a-9a0f-8ba291cc5ca8.jpg?1",
             "name": "Starlit Sanctum",
             "text": "{T}: Add {C}.\n{W}, {T}, Sacrifice a Cleric creature: You gain life equal to the sacrificed creature's toughness.\n{B}, {T}, Sacrifice a Cleric creature: Target player loses life equal to the sacrificed creature's power.",
             "colours": [],
@@ -33496,7 +33496,7 @@
         },
         {
             "id": "763645bd-ca52-5278-bbe2-4f4a6ca88ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c1fd3e-e899-4d66-8ad1-fdfbcdd70e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c1fd3e-e899-4d66-8ad1-fdfbcdd70e8b.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B}.)\nSunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -33529,7 +33529,7 @@
         },
         {
             "id": "113c3059-d85c-5c85-9e3c-13bfdf55fb80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f04e85-1b2b-4eb6-8332-4c13c2149d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f04e85-1b2b-4eb6-8332-4c13c2149d39.jpg?1",
             "name": "Tainted Field",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -33559,7 +33559,7 @@
         },
         {
             "id": "b8a723e7-4be4-5f20-8f15-b8d5a64619e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e376192-6dd2-4af0-b129-3751c8e3a8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e376192-6dd2-4af0-b129-3751c8e3a8bf.jpg?1",
             "name": "Tainted Isle",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -33589,7 +33589,7 @@
         },
         {
             "id": "fefaf0df-f938-574a-96d0-e518ba21b77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e544fd20-019a-4f96-891a-6eab4d6a01d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e544fd20-019a-4f96-891a-6eab4d6a01d7.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -33619,7 +33619,7 @@
         },
         {
             "id": "d1e50193-19ac-54e8-b898-9abf1990ccf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e3214a-0f76-4c60-8df9-4984b8d56d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e3214a-0f76-4c60-8df9-4984b8d56d89.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -33649,7 +33649,7 @@
         },
         {
             "id": "ca36c862-7e30-5794-b550-7efdc682dd58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3692d4-be30-4b23-b6e7-0c4af8c034a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3692d4-be30-4b23-b6e7-0c4af8c034a2.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -33679,7 +33679,7 @@
         },
         {
             "id": "b79f9ebd-f893-534e-a2a1-af3bd5e195c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3288ba-038c-4d8e-939d-c513a76fbfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3288ba-038c-4d8e-939d-c513a76fbfbf.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -33709,7 +33709,7 @@
         },
         {
             "id": "050fcd45-341f-5835-89f2-0891b5291647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8b9fd8-ece4-45ba-9fdf-4cb715bcd843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8b9fd8-ece4-45ba-9fdf-4cb715bcd843.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {C}{C}. Activate only if you control five or more lands.",
             "colours": [],
@@ -33736,7 +33736,7 @@
         },
         {
             "id": "a366d66b-a8a5-5fbe-9b2c-53fad1978db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40e9f0f-8c0d-4bfd-9872-370ce3763006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40e9f0f-8c0d-4bfd-9872-370ce3763006.jpg?1",
             "name": "Terrain Generator",
             "text": "{T}: Add {C}.\n{2}, {T}: You may put a basic land card from your hand onto the battlefield tapped.",
             "colours": [],
@@ -33763,7 +33763,7 @@
         },
         {
             "id": "1affea5f-336c-515b-b836-6ae6d109b977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004cea-51d4-4d69-ad98-37a2e02492e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004cea-51d4-4d69-ad98-37a2e02492e0.jpg?1",
             "name": "Vault of the Archangel",
             "text": "{T}: Add {C}.\n{2}{W}{B}, {T}: Creatures you control gain deathtouch and lifelink until end of turn.",
             "colours": [],
@@ -33793,7 +33793,7 @@
         },
         {
             "id": "e0509173-f469-5df1-9cda-a7fb7d823929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a6a8e-a01e-4d14-a6e5-c02c8205c749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a6a8e-a01e-4d14-a6e5-c02c8205c749.jpg?1",
             "name": "Wandering Fumarole",
             "text": "Wandering Fumarole enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with \"{0}: Switch this creature's power and toughness until end of turn.\" It's still a land.",
             "colours": [],
@@ -33823,7 +33823,7 @@
         },
         {
             "id": "d627814b-d437-531e-a1f6-24cc531da45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5cebc0-6a58-468d-a75e-46087ea2eb46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5cebc0-6a58-468d-a75e-46087ea2eb46.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -33850,7 +33850,7 @@
         },
         {
             "id": "a7b468d7-a408-5fc1-a258-8a109291b33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4aa7d1-e168-4fa0-baf0-1102086dc717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4aa7d1-e168-4fa0-baf0-1102086dc717.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWindbrisk Heights enters the battlefield tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -33879,7 +33879,7 @@
         },
         {
             "id": "945120e9-f362-5544-8ba3-3aa8a407a246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa652e2-caa6-4b48-bd04-67354380a761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa652e2-caa6-4b48-bd04-67354380a761.jpg?1",
             "name": "Captain N'ghathrod",
             "text": "Horrors you control have menace.\nWhenever a Horror you control deals combat damage to a player, that player mills that many cards.\nAt the beginning of your end step, choose target artifact or creature card in an opponent's graveyard that was put there from their library this turn. Put it onto the battlefield under your control.",
             "colours": [
@@ -33920,7 +33920,7 @@
         },
         {
             "id": "9dc2878d-0f28-5aba-a731-239d4895312a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dfa8eb-df44-4dcb-ad4f-4d548474eda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dfa8eb-df44-4dcb-ad4f-4d548474eda6.jpg?1",
             "name": "Faldorn, Dread Wolf Herald",
             "text": "Whenever you cast a spell from exile or a land enters the battlefield under your control from exile, create a 2/2 green Wolf creature token.\n{1}, {T}, Discard a card: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -33961,7 +33961,7 @@
         },
         {
             "id": "d1f9ce9d-46a6-5e81-abbe-0dfed1ae2141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee54e6d-e657-4eab-b937-1df6f0dd2b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee54e6d-e657-4eab-b937-1df6f0dd2b6b.jpg?1",
             "name": "Firkraag, Cunning Instigator",
             "text": "Flying, haste\nWhenever one or more Dragons you control attack an opponent, goad target creature that player controls.\nWhenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag, Cunning Instigator and you draw a card.",
             "colours": [
@@ -34001,7 +34001,7 @@
         },
         {
             "id": "67053319-c00d-5b46-bfdc-b9ceff85bafa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa32d2-e49a-4a06-a40f-ac41d1ceef39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa32d2-e49a-4a06-a40f-ac41d1ceef39.jpg?1",
             "name": "Nalia de'Arnise",
             "text": "You may look at the top card of your library any time.\nYou may cast Cleric, Rogue, Warrior, and Wizard spells from the top of your library.\nAt the beginning of combat on your turn, if you have a full party, put a +1/+1 counter on each creature you control and those creatures gain deathtouch until end of turn.",
             "colours": [
@@ -34042,7 +34042,7 @@
         },
         {
             "id": "5c1e4c62-9598-508c-9c2e-28dd6e8c7f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f79ec90-9fa7-4414-8eba-e2c890a91a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f79ec90-9fa7-4414-8eba-e2c890a91a70.jpg?1",
             "name": "Wand of Wonder",
             "text": "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1\u20139 | X is one.\n10\u201319 | X is two.\n20 | X is three.",
             "colours": [
@@ -34076,7 +34076,7 @@
         },
         {
             "id": "d639ee06-feaa-5f20-bb53-cf85348ebe9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f68bfe-1da0-41ec-b18d-92dc82d0217e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f68bfe-1da0-41ec-b18d-92dc82d0217e.jpg?1",
             "name": "Elder Brain",
             "text": "Menace\nWhenever Elder Brain attacks a player, exile all cards from that player's hand, then they draw that many cards. You may play lands and cast spells from among the exiled cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -34112,7 +34112,7 @@
         },
         {
             "id": "e5d042b4-3ce3-5aed-a1f4-5521484e37da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d56324-8293-4500-a9ad-fed351ccf966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d56324-8293-4500-a9ad-fed351ccf966.jpg?1",
             "name": "Baldur's Gate Wilderness",
             "text": "",
             "colours": [],
@@ -34139,7 +34139,7 @@
         },
         {
             "id": "0d657a73-829c-597f-89eb-ceb62ac7bcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce4f2b0-d63e-4f65-8261-ae61a8c9f591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce4f2b0-d63e-4f65-8261-ae61a8c9f591.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -34174,7 +34174,7 @@
         },
         {
             "id": "3f618808-a33a-5ed8-8f01-6d2edd98f875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633bba-9402-4d8c-a277-c370f25bd01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633bba-9402-4d8c-a277-c370f25bd01f.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -34209,7 +34209,7 @@
         },
         {
             "id": "5ddc1a52-47ba-55f1-b125-b370a47ac01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b0ed9-a4c0-4c58-978a-918ca266c699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1b0ed9-a4c0-4c58-978a-918ca266c699.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -34244,7 +34244,7 @@
         },
         {
             "id": "757d445d-7e7c-5c31-a4c2-7993764da291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ca55e0-d269-4178-bc90-920a12066e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ca55e0-d269-4178-bc90-920a12066e4f.jpg?1",
             "name": "Rabbit",
             "text": "",
             "colours": [
@@ -34279,7 +34279,7 @@
         },
         {
             "id": "8e4feafb-d457-5954-9d4c-acb3b30eb384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5000cf8-2104-4d85-95df-29efa92256f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5000cf8-2104-4d85-95df-29efa92256f6.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -34314,7 +34314,7 @@
         },
         {
             "id": "94fd9955-060a-561a-8c4a-2b7d4ab105f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1eb498-8496-4234-8e87-78dc3f647534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1eb498-8496-4234-8e87-78dc3f647534.jpg?1",
             "name": "Faerie Dragon",
             "text": "",
             "colours": [
@@ -34350,7 +34350,7 @@
         },
         {
             "id": "2cdb5ae3-cf29-521f-b22a-e31e1daf73fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d744d755-ac09-4511-8664-5ff973e92fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d744d755-ac09-4511-8664-5ff973e92fc5.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -34385,7 +34385,7 @@
         },
         {
             "id": "3e6b7f39-90ba-5ebb-9727-ab997d006897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c245f-af2f-46a7-81f3-670a04940901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c245f-af2f-46a7-81f3-670a04940901.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -34420,7 +34420,7 @@
         },
         {
             "id": "477cb973-0ce1-5729-9f93-10f29fed22cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0475e9-68ae-4553-a5ef-650091e04967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0475e9-68ae-4553-a5ef-650091e04967.jpg?1",
             "name": "Boo",
             "text": "",
             "colours": [
@@ -34457,7 +34457,7 @@
         },
         {
             "id": "efeccbc7-bff1-5698-8377-783048680330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895df6af-6799-4ec6-b8f4-912b06f30ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895df6af-6799-4ec6-b8f4-912b06f30ed2.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -34492,7 +34492,7 @@
         },
         {
             "id": "3efec4a7-cadf-5ce8-b302-7a3cb149f404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32b97de-9cbb-40a2-ba3b-54e861023df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32b97de-9cbb-40a2-ba3b-54e861023df0.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -34527,7 +34527,7 @@
         },
         {
             "id": "51573dff-8abe-52bf-be05-04519caa5949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb796a0-4eb0-4fc5-bf84-92a71bec4466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb796a0-4eb0-4fc5-bf84-92a71bec4466.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -34562,7 +34562,7 @@
         },
         {
             "id": "6eff2377-e886-54a6-bcaa-b9757116853c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6655f22c-963f-42d6-b45c-8ea5fb256785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6655f22c-963f-42d6-b45c-8ea5fb256785.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -34597,7 +34597,7 @@
         },
         {
             "id": "94e7154b-94e6-5f1c-a43e-b0199ee94b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cbc9fc-42d2-4d1a-b6c0-29a35cfd1588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cbc9fc-42d2-4d1a-b6c0-29a35cfd1588.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -34632,7 +34632,7 @@
         },
         {
             "id": "350a7767-3ea5-5755-8e65-c8737275e503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380330b4-2d01-4042-97ac-41d9c60c982d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380330b4-2d01-4042-97ac-41d9c60c982d.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -34667,7 +34667,7 @@
         },
         {
             "id": "ee753323-2089-5cb6-9410-a0b89a596a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5715cf-fbf6-4b13-af91-525edc7706ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5715cf-fbf6-4b13-af91-525edc7706ea.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -34699,7 +34699,7 @@
         },
         {
             "id": "7fb44e8f-f3f6-5834-b4ef-a0249adacc31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770b988d-4f31-4746-8c23-4ed8d9a6b393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770b988d-4f31-4746-8c23-4ed8d9a6b393.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -34730,7 +34730,7 @@
         },
         {
             "id": "356c13a7-56ea-54b1-a904-6946c10ebd75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0fe7c9-b0ab-4d48-94d0-99e7bee0c0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0fe7c9-b0ab-4d48-94d0-99e7bee0c0de.jpg?1",
             "name": "Volo's Journal",
             "text": "",
             "colours": [],
@@ -34761,7 +34761,7 @@
         },
         {
             "id": "20210bc2-0b4a-55fc-bfd3-fc4abe806d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d7dc49-7116-489b-a719-7b293a513cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d7dc49-7116-489b-a719-7b293a513cdc.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -34789,7 +34789,7 @@
         },
         {
             "id": "3e24568b-33d4-5e56-8e89-8a2e545ae88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg?1",
             "name": "Undercity // The Initiative",
             "text": "",
             "colours": [],
@@ -34819,7 +34819,7 @@
         },
         {
             "id": "0fb61d8a-f3c2-5b88-ae63-6bf564498528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg?1",
             "name": "Undercity // The Initiative",
             "text": "",
             "colours": [],
@@ -34847,7 +34847,7 @@
         },
         {
             "id": "09c25ab4-3ed8-587d-918c-a7b71f984620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60abe28a-342e-49d0-80f6-6b3ce041372b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60abe28a-342e-49d0-80f6-6b3ce041372b.jpg?1",
             "name": "Eldrazi Horror",
             "text": "",
             "colours": [],
@@ -34878,7 +34878,7 @@
         },
         {
             "id": "2f8ad9ad-6ea8-5326-a8f3-03d7d8d1db8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bde9bf-fffc-4b86-9698-d5620b21d6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bde9bf-fffc-4b86-9698-d5620b21d6b8.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -34908,7 +34908,7 @@
         },
         {
             "id": "cadb4b9f-11fb-52c1-a2f4-7c74aa810aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd65e932-8ed6-424b-958f-d8edad2aa2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd65e932-8ed6-424b-958f-d8edad2aa2f4.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -34938,7 +34938,7 @@
         },
         {
             "id": "c799cc36-8f2b-5f7e-b81b-9a7c853afae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1186b536-e6c8-433d-a906-b29f334d619c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1186b536-e6c8-433d-a906-b29f334d619c.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -34968,7 +34968,7 @@
         },
         {
             "id": "b859c19a-c41b-52dc-b630-c3a35fda1743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2db6fe1-b6ec-43ca-933f-dbab4cd08064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2db6fe1-b6ec-43ca-933f-dbab4cd08064.jpg?1",
             "name": "Angel Warrior",
             "text": "",
             "colours": [
@@ -35003,7 +35003,7 @@
         },
         {
             "id": "10538b40-ba95-5a8e-bb63-e1d43dec0066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dad439-cae3-4f65-b6fb-c737321d322c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dad439-cae3-4f65-b6fb-c737321d322c.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -35037,7 +35037,7 @@
         },
         {
             "id": "d597aedf-6bd9-5d51-a9f0-d59010988656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138b304-4dc0-48bb-a043-6246abafef53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138b304-4dc0-48bb-a043-6246abafef53.jpg?1",
             "name": "Kor Warrior",
             "text": "",
             "colours": [
@@ -35072,7 +35072,7 @@
         },
         {
             "id": "5590d878-c28a-5c12-b61d-065c7c8e7a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce94fb42-cde4-4637-b938-13f17793bf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce94fb42-cde4-4637-b938-13f17793bf1f.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [
@@ -35106,7 +35106,7 @@
         },
         {
             "id": "70a05fe8-0f85-55f5-b3dc-b630d5457d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743688fa-ca30-4a4b-92ec-6708af8692db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743688fa-ca30-4a4b-92ec-6708af8692db.jpg?1",
             "name": "Squid",
             "text": "",
             "colours": [
@@ -35140,7 +35140,7 @@
         },
         {
             "id": "c510f2dd-8d22-5882-b4df-6ccb807b39d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53eb7d1-9c36-4184-b411-ebe65aa64230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53eb7d1-9c36-4184-b411-ebe65aa64230.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -35174,7 +35174,7 @@
         },
         {
             "id": "4960f41c-d50d-552c-a20e-79e7fe7e0566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddf9fb5-473f-44a2-98bd-93b4f7478d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddf9fb5-473f-44a2-98bd-93b4f7478d4f.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [
@@ -35208,7 +35208,7 @@
         },
         {
             "id": "1c17a5be-dc89-57f7-901b-7fd2520b4de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883ac854-ee35-418a-9d4e-c30ba2a5ade8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883ac854-ee35-418a-9d4e-c30ba2a5ade8.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -35242,7 +35242,7 @@
         },
         {
             "id": "feea9589-40b1-5e56-b7bd-3c91bf3133dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87386f2-5e90-4efd-a5d7-4716220d6ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87386f2-5e90-4efd-a5d7-4716220d6ab7.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -35276,7 +35276,7 @@
         },
         {
             "id": "fd1a2863-d5ce-5ad5-953d-18f8613d8f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db51576-a755-45de-b37b-f16b27e8f3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db51576-a755-45de-b37b-f16b27e8f3a1.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -35310,7 +35310,7 @@
         },
         {
             "id": "caf943a4-435e-548a-9081-161b0834d11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9bfd0a-9a31-4191-a615-a747cbca2015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9bfd0a-9a31-4191-a615-a747cbca2015.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -35344,7 +35344,7 @@
         },
         {
             "id": "ccd91ef2-6318-5c07-95dd-21435dbc55ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d725a8-daff-4458-aab0-06803ae33be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d725a8-daff-4458-aab0-06803ae33be3.jpg?1",
             "name": "Ogre",
             "text": "",
             "colours": [
@@ -35378,7 +35378,7 @@
         },
         {
             "id": "855bb2c7-8aa9-56b2-b9fc-a04788cc1c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42248cea-29e8-4ebe-ad64-e87e216b55d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42248cea-29e8-4ebe-ad64-e87e216b55d6.jpg?1",
             "name": "Pirate",
             "text": "",
             "colours": [
@@ -35412,7 +35412,7 @@
         },
         {
             "id": "2a3aa42b-6284-5143-9ab2-0f0bf6a49092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e095bd-091c-442f-aa21-0826c40acb6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e095bd-091c-442f-aa21-0826c40acb6c.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -35446,7 +35446,7 @@
         },
         {
             "id": "1ab1d189-ff59-5430-a10d-6221a4842c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd41697-6fe6-423c-a04a-035a3d4f8fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd41697-6fe6-423c-a04a-035a3d4f8fd2.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -35480,7 +35480,7 @@
         },
         {
             "id": "321db9fd-973a-5c69-aafe-6ac2fdedb3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca5cf3c-18f8-430a-a20f-2226d9cac387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca5cf3c-18f8-430a-a20f-2226d9cac387.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -35514,7 +35514,7 @@
         },
         {
             "id": "08b5de20-9d0a-5f95-9294-40bc92f051f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f64d14-c203-4401-a379-c6227d1cbac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f64d14-c203-4401-a379-c6227d1cbac2.jpg?1",
             "name": "Phyrexian Beast",
             "text": "",
             "colours": [
@@ -35549,7 +35549,7 @@
         },
         {
             "id": "16a543d2-390b-5eb2-81bd-b72b8acd4660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab34a7-0d18-4a6c-ac40-3b9901ff841b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab34a7-0d18-4a6c-ac40-3b9901ff841b.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -35583,7 +35583,7 @@
         },
         {
             "id": "a140e094-ab54-580d-bd5f-5fc47ab04de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81605b8d-cf1d-49dc-aebb-a857d6796a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81605b8d-cf1d-49dc-aebb-a857d6796a77.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -35617,7 +35617,7 @@
         },
         {
             "id": "91faceb7-2d3c-5282-84ec-6a739f964fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54afe5d9-a6b6-46a2-89e9-470ad9e44a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54afe5d9-a6b6-46a2-89e9-470ad9e44a06.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -35651,7 +35651,7 @@
         },
         {
             "id": "a5f2f661-0af5-5e6b-9478-b7f5a1748209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b57d024-2ff6-467f-bb4e-37270be60104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b57d024-2ff6-467f-bb4e-37270be60104.jpg?1",
             "name": "Inkling",
             "text": "",
             "colours": [
@@ -35687,7 +35687,7 @@
         },
         {
             "id": "fa454d81-8f62-5119-8cf8-01ff30476681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831fbc86-e328-4c26-a8b2-35feb24f6430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831fbc86-e328-4c26-a8b2-35feb24f6430.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -35723,7 +35723,7 @@
         },
         {
             "id": "baed3045-80da-57c5-b3f8-948a60b0ee0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25234a6-cb8d-479a-90f5-9d1a1084277b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25234a6-cb8d-479a-90f5-9d1a1084277b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -35753,7 +35753,7 @@
         },
         {
             "id": "6c4de848-5258-50e6-9a57-ceccc81aefce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b15a8a-58bd-4b7e-9b7f-e143c90f35d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b15a8a-58bd-4b7e-9b7f-e143c90f35d7.jpg?1",
             "name": "Gold",
             "text": "",
             "colours": [],
@@ -35783,7 +35783,7 @@
         },
         {
             "id": "c7221a00-3fe3-5573-8418-d7f62770b7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2f81ee-f258-40c4-abc6-0c80421b0837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2f81ee-f258-40c4-abc6-0c80421b0837.jpg?1",
             "name": "Rowan Kenrith Emblem",
             "text": "",
             "colours": [],
@@ -35812,7 +35812,7 @@
         },
         {
             "id": "d8e56fc8-229f-53d6-b9d5-6d60cc361700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de08752-9fc4-4e6b-b30b-2d9d33a1e37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de08752-9fc4-4e6b-b30b-2d9d33a1e37b.jpg?1",
             "name": "Will Kenrith Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/CMM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/CMM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1c8d3f82-7b94-5fc0-80d5-60a8d6363bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78c2713-39e7-4a6e-a132-027099a89665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78c2713-39e7-4a6e-a132-027099a89665.jpg?1",
             "name": "The Prismatic Piper",
             "text": "If The Prismatic Piper is your commander, choose a color before the game begins. The Prismatic Piper is the chosen color.\nPartner (You can have two commanders if both have partner.)",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "eb6d32be-f67d-5e7e-86ad-a118ef00c49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41554e7-2a07-4cc7-b01b-44deed08e588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41554e7-2a07-4cc7-b01b-44deed08e588.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -71,7 +71,7 @@
         },
         {
             "id": "2db25501-acbd-5eb3-bf02-20e9aaa3d132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84238335-e08c-421c-b9b9-70a679ff2967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84238335-e08c-421c-b9b9-70a679ff2967.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -113,7 +113,7 @@
         },
         {
             "id": "5eaa4ed1-5fac-517f-bdf5-c04b256c282d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1d4d8-7df9-41e0-b2d9-dbca9c9f6994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1d4d8-7df9-41e0-b2d9-dbca9c9f6994.jpg?1",
             "name": "Pathrazer of Ulamog",
             "text": "Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents.)\nPathrazer of Ulamog can't be blocked except by three or more creatures.",
             "colours": [],
@@ -143,7 +143,7 @@
         },
         {
             "id": "54cabf20-978c-5367-aff0-2b135dba2708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74ae706-b3b3-4097-a387-6f6c38a9b603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74ae706-b3b3-4097-a387-6f6c38a9b603.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -179,7 +179,7 @@
         },
         {
             "id": "0399c0d4-640d-5afa-8152-0df22386acc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699c0f6f-b26b-4741-8140-8a6030cad127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699c0f6f-b26b-4741-8140-8a6030cad127.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each combat if able.",
             "colours": [],
@@ -209,7 +209,7 @@
         },
         {
             "id": "cad13cc2-1785-51e1-aeb5-bf43b2cb7eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956c523-507c-4256-88b8-58a8a108c79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6956c523-507c-4256-88b8-58a8a108c79f.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "dea6b3af-65eb-52a5-9bca-2b9008c2649f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdf5020-ea97-4f95-a096-cb5688dad2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdf5020-ea97-4f95-a096-cb5688dad2e2.jpg?1",
             "name": "Alharu, Solemn Ritualist",
             "text": "When Alharu, Solemn Ritualist enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.\nWhenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white Spirit creature token with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -281,7 +281,7 @@
         },
         {
             "id": "c29c0ca7-5b6e-50ee-9fb9-46a22d0b4fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0b82a-f943-4330-b9e7-bb4527354bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0b82a-f943-4330-b9e7-bb4527354bfd.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "39b6ca2c-4a04-51ec-882e-33708a2fd32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ac07a-a30f-4ebf-8877-27cd9ebe2f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ac07a-a30f-4ebf-8877-27cd9ebe2f71.jpg?1",
             "name": "Alms Collector",
             "text": "Flash\nIf an opponent would draw two or more cards, instead you and that player each draw a card.",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "602dd155-9bf3-5f29-8af2-91186ba3efc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1717da7b-9e87-4694-873b-abd4e3bcd5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1717da7b-9e87-4694-873b-abd4e3bcd5e2.jpg?1",
             "name": "Anafenza, Kin-Tree Spirit",
             "text": "Whenever another nontoken creature enters the battlefield under your control, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "f7ba57be-c558-5443-babc-25ee81b890cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24705dee-027c-42a2-8505-66c0a34a4a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24705dee-027c-42a2-8505-66c0a34a4a58.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "622099c4-1c5d-5de9-847a-d18b5bd95a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496e9fe2-843c-4dfe-b94a-b542a2ddaae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496e9fe2-843c-4dfe-b94a-b542a2ddaae4.jpg?1",
             "name": "Angelic Field Marshal",
             "text": "Flying\nLieutenant \u2014 As long as you control your commander, Angelic Field Marshal gets +2/+2 and creatures you control have vigilance.",
             "colours": [
@@ -461,7 +461,7 @@
         },
         {
             "id": "6a06d42a-2000-54eb-ba2b-435f06ad8335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1133-7cf8-4b7a-919e-88c45f8c2c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1133-7cf8-4b7a-919e-88c45f8c2c3a.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -499,7 +499,7 @@
         },
         {
             "id": "02a784bc-b61d-5e59-9178-7321a4e03973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bbe20b-0d39-46fc-a09a-fc8c676f1fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bbe20b-0d39-46fc-a09a-fc8c676f1fe7.jpg?1",
             "name": "Baird, Steward of Argive",
             "text": "Vigilance\nCreatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -536,7 +536,7 @@
         },
         {
             "id": "4d2b7017-bf6c-54fc-82d9-da231b348f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ebad9-bf65-48e2-9640-c11b5f04e38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ebad9-bf65-48e2-9640-c11b5f04e38b.jpg?1",
             "name": "Balan, Wandering Knight",
             "text": "First strike\nBalan, Wandering Knight has double strike as long as two or more Equipment are attached to it.\n{1}{W}: Attach all Equipment you control to Balan.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "977b8e46-a963-5482-9481-8b7e5b3a592c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90301f8c-f7af-4179-8faf-9901931bba8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90301f8c-f7af-4179-8faf-9901931bba8d.jpg?1",
             "name": "Battle Screech",
             "text": "Create two 1/1 white Bird creature tokens with flying.\nFlashback\u2014\nTap three untapped white creatures you control. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "c9c078d1-bbfb-503e-8e00-ece365a071f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d0b07f-9823-45b7-89bb-0a2a71833d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d0b07f-9823-45b7-89bb-0a2a71833d46.jpg?1",
             "name": "Cartographer's Hawk",
             "text": "Flying\nWhen Cartographer's Hawk deals combat damage to a player who controls more lands than you, return it to its owner's hand. If you do, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "ea5c735e-99fb-5077-b102-bf9e4daa10c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1771d71b-18b1-44dd-b413-4319519b0778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1771d71b-18b1-44dd-b413-4319519b0778.jpg?1",
             "name": "Custodi Squire",
             "text": "Flying\nWill of the council \u2014 When Custodi Squire enters the battlefield, starting with you, each player votes for an artifact, creature, or enchantment card in your graveyard. Return each card with the most votes or tied for most votes to your hand.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "f2acfed9-fa4a-5052-85ed-b67004eddc52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f77e4-edb6-43c6-b8ca-d4f62d26d0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f77e4-edb6-43c6-b8ca-d4f62d26d0c0.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "7ca00d58-bcb6-5450-9c02-845eabe3490b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47a6750-4fdd-44e2-86ae-5bc4d414bf42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47a6750-4fdd-44e2-86ae-5bc4d414bf42.jpg?1",
             "name": "Darksteel Mutation",
             "text": "Enchant creature\nEnchanted creature is an Insect artifact creature with base power and toughness 0/1 and has indestructible, and it loses all other abilities, card types, and creature types.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "c294b39d-9f36-57fb-8206-c0a5988c6a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ca5bcc-f49f-4370-9f95-031836bb771b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ca5bcc-f49f-4370-9f95-031836bb771b.jpg?1",
             "name": "Elite Scaleguard",
             "text": "When Elite Scaleguard enters the battlefield, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)\nWhenever a creature you control with a +1/+1 counter on it attacks, tap target creature defending player controls.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "c82a7a42-018e-5acd-99ed-5fa4d5355762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994094f8-e175-4e2e-aa39-c096f0ed9e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994094f8-e175-4e2e-aa39-c096f0ed9e6a.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "e3d57f06-9bde-5f66-878c-f963361bbc3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab12f69e-1491-47a8-8c46-d85bbf637ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab12f69e-1491-47a8-8c46-d85bbf637ff6.jpg?1",
             "name": "Flawless Maneuver",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCreatures you control gain indestructible until end of turn.",
             "colours": [
@@ -854,7 +854,7 @@
         },
         {
             "id": "9fbef1d5-be5a-5f2e-bd3d-7b21a331f428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d78a93-1a9f-4bc1-82b4-d3434367d27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d78a93-1a9f-4bc1-82b4-d3434367d27b.jpg?1",
             "name": "Gavony Silversmith",
             "text": "When Gavony Silversmith enters the battlefield, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -889,7 +889,7 @@
         },
         {
             "id": "838b2819-6dcf-57ae-bcfe-233fde8ac904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8c02ab-6348-4b04-8ce0-b36309a14a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8c02ab-6348-4b04-8ce0-b36309a14a5e.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "b4e3f2ac-efd1-5b39-bb11-aff92ab6589b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e30ca4-1769-4686-aa18-31610246cd80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e30ca4-1769-4686-aa18-31610246cd80.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "fb58ce8e-db0e-51f3-ad0b-d149ce33faaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f34f41-bbd8-4424-88a3-b97a795b6daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f34f41-bbd8-4424-88a3-b97a795b6daf.jpg?1",
             "name": "Heavenly Blademaster",
             "text": "Flying, double strike\nWhen Heavenly Blademaster enters the battlefield, you may attach any number of Auras and Equipment you control to it.\nOther creatures you control get +1/+1 for each Aura and Equipment attached to Heavenly Blademaster.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "18331c2c-9d4c-51b1-aadc-fc5ca4d337f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3245ff74-1f9c-4518-a23f-1579f338f232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3245ff74-1f9c-4518-a23f-1579f338f232.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nWhenever you gain life, put a +1/+1 counter on target creature or enchantment you control.\n{1}{W}: Another target creature gains lifelink until end of turn.",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "fccf0fe7-6880-5997-a15f-7281e2fd8a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d57d75-275d-45c8-85f4-aab230af35b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d57d75-275d-45c8-85f4-aab230af35b2.jpg?1",
             "name": "Herald of the Host",
             "text": "Flying, vigilance\nMyriad (Whenever this creature attacks, for each opponent other than defending player, you may create a token that's a copy of this creature that's tapped and attacking that player or a planeswalker they control. Exile the tokens at end of combat.)",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "e835a5b7-8da9-5219-972c-89f0fdd7ef7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d251846-7aa5-4318-a96b-fbd9daf691f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d251846-7aa5-4318-a96b-fbd9daf691f9.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "cd2af96f-607a-5fb7-90f3-8d6faf63bed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616d54a1-33f7-47c9-852f-4f3a07309f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616d54a1-33f7-47c9-852f-4f3a07309f27.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -1141,7 +1141,7 @@
         },
         {
             "id": "1c86bb93-0166-5ece-9b9c-49a3360f7024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc95324a-9a7f-4ed9-a3da-36a3eca91936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc95324a-9a7f-4ed9-a3da-36a3eca91936.jpg?1",
             "name": "Keleth, Sunmane Familiar",
             "text": "Whenever a commander you control attacks, put a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "14995e68-e2a7-5dbb-88c1-b8258b7f788e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacc4290-6a72-4c00-8bdd-e40ae28885a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacc4290-6a72-4c00-8bdd-e40ae28885a8.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, create a 2/2 white Cat creature token for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "693f54a4-9e3e-5de0-b58b-79b53302bcd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbbbbf7-eaae-462e-a8eb-7f6a97703600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbbbbf7-eaae-462e-a8eb-7f6a97703600.jpg?1",
             "name": "Kirtar's Wrath",
             "text": "Destroy all creatures. They can't be regenerated.\nThreshold \u2014 If seven or more cards are in your graveyard, instead destroy all creatures, then create two 1/1 white Spirit creature tokens with flying. Creatures destroyed this way can't be regenerated.",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "c35ff682-9d2f-5b0c-b7bd-857856e4884f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0489ee-96b6-4437-a716-ee07ecbd4cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0489ee-96b6-4437-a716-ee07ecbd4cb7.jpg?1",
             "name": "Knighted Myr",
             "text": "{2}{W}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Knighted Myr, it gains double strike until end of turn.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "5837f5f2-6207-535c-88bd-5d11396800e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9258ad10-cbe6-4676-93b4-6ef4a33f12ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9258ad10-cbe6-4676-93b4-6ef4a33f12ee.jpg?1",
             "name": "Land Tax",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "8ebe69b1-4460-5480-bf88-75f880411e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6b54de-8e79-4f60-b642-3d259bf74ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6b54de-8e79-4f60-b642-3d259bf74ea0.jpg?1",
             "name": "Losheel, Clockwork Scholar",
             "text": "Prevent all combat damage that would be dealt to attacking artifact creatures you control.\nWhenever one or more artifact creatures enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "d4673c28-b6c3-528b-adb1-bfb2d3d1c5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b35e70-9a0e-4204-9454-a1f2c58eb0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b35e70-9a0e-4204-9454-a1f2c58eb0e0.jpg?1",
             "name": "Loyal Retainers",
             "text": "Sacrifice Loyal Retainers: Return target legendary creature card from your graveyard to the battlefield. Activate only during your turn, before attackers are declared.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "2bbe3232-0914-5e1d-975f-dd6743cddb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d7203b-55ed-4d08-ac2e-2c4b4b93c274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d7203b-55ed-4d08-ac2e-2c4b4b93c274.jpg?1",
             "name": "Loyal Unicorn",
             "text": "Vigilance\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn. Other creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "a8bafd39-7c53-5aa6-b260-25ed0afbf65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a08aff-3a50-4f2e-97a1-f1d79d5c4ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a08aff-3a50-4f2e-97a1-f1d79d5c4ade.jpg?1",
             "name": "Mace of the Valiant",
             "text": "Equipped creature gets +1/+1 for each charge counter on Mace of the Valiant and has vigilance.\nWhenever a creature enters the battlefield under your control, put a charge counter on Mace of the Valiant.\nEquip {3}",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "9f2e198d-ae73-53db-a651-4e576ff79152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e77ae5-a1a6-4e51-9853-10e81ca2dd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e77ae5-a1a6-4e51-9853-10e81ca2dd2c.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -1499,7 +1499,7 @@
         },
         {
             "id": "0fbae37d-f612-5b7d-a955-5ee09b748063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d9c9db-28a0-47fa-b561-6040e47c2392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d9c9db-28a0-47fa-b561-6040e47c2392.jpg?1",
             "name": "Ministrant of Obligation",
             "text": "Afterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -1534,7 +1534,7 @@
         },
         {
             "id": "46b2319b-e5c9-5e73-91f8-b474bb57b8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea3e84-2d78-489f-875a-48e58c956451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea3e84-2d78-489f-875a-48e58c956451.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, create a 1/1 colorless Myr artifact creature token.",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "e2976694-f753-50e5-9cae-eb43a29522ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b074e60a-6f9b-4679-9617-261e2e15e1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b074e60a-6f9b-4679-9617-261e2e15e1e8.jpg?1",
             "name": "Nahiri, the Lithomancer",
             "text": "+2: Create a 1/1 white Kor Soldier creature token. You may attach an Equipment you control to it.\n\u22122: You may put an Equipment card from your hand or graveyard onto the battlefield.\n\u221210: Create a colorless Equipment artifact token named Stoneforged Blade. It has indestructible, \"Equipped creature gets +5/+5 and has double strike,\" and equip {0}.\nNahiri, the Lithomancer can be your commander.",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "2c3549e7-e311-5d16-b4c6-ddbde1d1dbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bfcec9-a789-41f1-aa3d-4e4cdd7555b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bfcec9-a789-41f1-aa3d-4e4cdd7555b2.jpg?1",
             "name": "Odric, Master Tactician",
             "text": "First strike\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "803ba915-a741-5426-bcda-a4c464e5c74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ee31a-e80f-481a-b2e7-7a6c68eb1efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ee31a-e80f-481a-b2e7-7a6c68eb1efb.jpg?1",
             "name": "Palace Jailer",
             "text": "When Palace Jailer enters the battlefield, you become the monarch.\nWhen Palace Jailer enters the battlefield, exile target creature an opponent controls until an opponent becomes the monarch.",
             "colours": [
@@ -1681,7 +1681,7 @@
         },
         {
             "id": "709ba022-04cf-5148-9de8-9a6ead666942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0bbbe0-e6cf-43df-9c44-b6bbfa9c9af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0bbbe0-e6cf-43df-9c44-b6bbfa9c9af7.jpg?1",
             "name": "Palace Sentinels",
             "text": "When Palace Sentinels enters the battlefield, you become the monarch.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "89af9c87-295b-579e-84fa-7bbf3ad23ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970389b-08f4-4a15-a128-954b072a8137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970389b-08f4-4a15-a128-954b072a8137.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "36349731-08cf-5cf7-86e9-6f5730b89ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ebb129-aa8d-4107-8e74-0b04525d76e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ebb129-aa8d-4107-8e74-0b04525d76e0.jpg?1",
             "name": "Pianna, Nomad Captain",
             "text": "Whenever Pianna, Nomad Captain attacks, attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "d6d49893-84f8-57cf-99a3-7cb4bced1413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f8a324-006d-4cb8-9816-620a603b4229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f8a324-006d-4cb8-9816-620a603b4229.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "034508d3-0aeb-5515-b39a-7cffd9dc67c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57ba1d-2b43-4839-b77d-38fee2e81bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57ba1d-2b43-4839-b77d-38fee2e81bf6.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "99742e09-2242-5dd9-ba64-0194848f7468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2faf6-e65b-4962-82d4-0294912c2ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2faf6-e65b-4962-82d4-0294912c2ddb.jpg?1",
             "name": "Righteous Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Create a 2/2 white Knight creature token with vigilance.\n\u2022 Exile target enchantment.\n\u2022 You gain 5 life.",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "b0e03074-8387-50fd-a44f-3e6b88ab6f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729ee848-6c27-4202-b2bc-605f45209468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729ee848-6c27-4202-b2bc-605f45209468.jpg?1",
             "name": "Sephara, Sky's Blade",
             "text": "You may pay {W} and tap four untapped creatures you control with flying rather than pay this spell's mana cost.\nFlying, lifelink\nOther creatures you control with flying have indestructible.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "1e699fc6-6edd-5a49-b310-e3e0e3a0cb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51647010-99f0-4b02-8c91-fdd826db130d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51647010-99f0-4b02-8c91-fdd826db130d.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "fec3e760-7f6d-5c02-b8d6-cc046b49bdc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fedc9-6dd1-4190-a0c9-e9d10fd91315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fedc9-6dd1-4190-a0c9-e9d10fd91315.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "56c915af-68f7-59cf-b4dd-ac8722abf010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861b5889-0183-4bee-afeb-a4b2aa700a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861b5889-0183-4bee-afeb-a4b2aa700a8e.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "4c2f088a-c4b9-5947-9ec1-f20113883c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3cce9-d570-4a45-b484-089849a91b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3cce9-d570-4a45-b484-089849a91b6c.jpg?1",
             "name": "Spectral Grasp",
             "text": "Enchant creature\nEnchanted creature can't attack you or planeswalkers you control.\nEnchanted creature can't block creatures you control.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "878844f2-1f7e-5da7-95f0-c8c90d34af3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d61383-b739-4422-a76c-d8cbca13c5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d61383-b739-4422-a76c-d8cbca13c5b2.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "7c7d11b5-dafa-50bc-a690-e13d4cb5f7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8f810f-844b-4ebd-b28c-46432cf0203d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8f810f-844b-4ebd-b28c-46432cf0203d.jpg?1",
             "name": "Sublime Exhalation",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy all creatures.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "2f66b5c8-8569-5f23-9475-f3d77b47cfcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407041c4-0154-42ee-a736-7815024d1719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407041c4-0154-42ee-a736-7815024d1719.jpg?1",
             "name": "Sunblade Angel",
             "text": "Flying, first strike, vigilance, lifelink",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "200ed638-c337-5aa2-b8db-f8a45f0154f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303df3ba-1258-4141-ace2-577f9e89a14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303df3ba-1258-4141-ace2-577f9e89a14c.jpg?1",
             "name": "Sunspear Shikari",
             "text": "As long as Sunspear Shikari is equipped, it has first strike and lifelink.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "d87a39a0-8a96-5a13-b06a-321edb81e073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbc3b-a2e9-4a14-a603-581413bc0b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbc3b-a2e9-4a14-a603-581413bc0b17.jpg?1",
             "name": "Supply Runners",
             "text": "When Supply Runners enters the battlefield, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "2bcd66f5-9e7c-550b-90a4-a59c2ebdfc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d70dcbe-0b90-40b4-8a54-e5218b7135b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d70dcbe-0b90-40b4-8a54-e5218b7135b1.jpg?1",
             "name": "Swift Response",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "1d80cade-17cc-5f55-9604-543553c3800d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9b45b-d466-4c06-9a25-6edb6e8f6f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9b45b-d466-4c06-9a25-6edb6e8f6f2f.jpg?1",
             "name": "Teshar, Ancestor's Apostle",
             "text": "Flying\nWhenever you cast a historic spell, return target creature card with mana value 3 or less from your graveyard to the battlefield. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "e6ac24d0-74d7-5a64-85ce-cb03262cf861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299cc386-2ed5-4504-9ba6-17a52e0c9a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299cc386-2ed5-4504-9ba6-17a52e0c9a0c.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "e015da42-3fe6-565d-8b56-bf767d0bf44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732c3b63-5e15-4510-813c-58e20cd9833f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732c3b63-5e15-4510-813c-58e20cd9833f.jpg?1",
             "name": "Unbounded Potential",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on each of up to two target creatures.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEntwine {3}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "9cee1fc0-7b60-57fe-ae41-abfa409d10d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b3918-94f7-4981-9702-f01970fac37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b3918-94f7-4981-9702-f01970fac37c.jpg?1",
             "name": "Wakening Sun's Avatar",
             "text": "When Wakening Sun's Avatar enters the battlefield, if you cast it from your hand, destroy all non-Dinosaur creatures.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "51ee1a3e-7fb8-5f78-96ab-fbc141865d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb14b6-1fd8-49be-bf95-f147f48b072c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecb14b6-1fd8-49be-bf95-f147f48b072c.jpg?1",
             "name": "Wanderer's Strike",
             "text": "Exile target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "68855283-bd13-5794-94d7-8b21b2dc4320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537d2b05-3f52-45d6-8fe3-26282085d0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537d2b05-3f52-45d6-8fe3-26282085d0c6.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "545e863f-7054-5849-a6f0-35204d0bc268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3425c9-9bec-40e4-a2e9-ce8ac4281688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3425c9-9bec-40e4-a2e9-ce8ac4281688.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "222d6470-0c0a-56e8-99e7-eda2cf0de494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792ebc50-909f-4b81-a2cd-0da1ba36a0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792ebc50-909f-4b81-a2cd-0da1ba36a0d3.jpg?1",
             "name": "Aether Gale",
             "text": "Return six target nonland permanents to their owners' hands.",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "b96d409e-2d32-5fc6-9997-9209e7744021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92496b98-b533-4d34-aa79-cad0805c984b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92496b98-b533-4d34-aa79-cad0805c984b.jpg?1",
             "name": "Aminatou's Augury",
             "text": "Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a spell of that type from among the exiled cards without paying its mana cost.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "58c3b291-d23b-5974-8d9f-fc10be3b9d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa727656-fb33-485b-9378-18b80cad42b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa727656-fb33-485b-9378-18b80cad42b9.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "87368c4a-3889-5b3f-b362-fcdd179370d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d434b49-c3e8-4b4d-b573-c144ba78e98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d434b49-c3e8-4b4d-b573-c144ba78e98b.jpg?1",
             "name": "Body Double",
             "text": "You may have Body Double enter the battlefield as a copy of any creature card in a graveyard.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "78580561-e67a-557b-97f6-f85269087aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea0a701-1349-4d32-9fe7-8a2563c9613d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea0a701-1349-4d32-9fe7-8a2563c9613d.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from their hand onto the battlefield.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "c547b61c-d368-5a60-a6ce-59a7a3bb3367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fd737a-d7da-421b-a741-d6d0d213299f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fd737a-d7da-421b-a741-d6d0d213299f.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "e77f3c72-8bf8-577e-9a56-4242d4b1b2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606f8ea-815b-4308-8f1d-3dad4f45f70e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606f8ea-815b-4308-8f1d-3dad4f45f70e.jpg?1",
             "name": "Brinelin, the Moon Kraken",
             "text": "When Brinelin, the Moon Kraken enters the battlefield and whenever you cast a spell with mana value 6 or greater, you may return target nonland permanent to its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "7bf1379a-31a7-52ad-be47-19850a6a7e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87d0298-f76b-4ea8-82c4-5861c4539d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87d0298-f76b-4ea8-82c4-5861c4539d8b.jpg?1",
             "name": "Capture of Jingzhou",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "3a18adc1-afa2-512b-ab83-664705bf3153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca0a9a8-5ebc-43a3-8450-420ab6b7b76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca0a9a8-5ebc-43a3-8450-420ab6b7b76e.jpg?1",
             "name": "Commandeer",
             "text": "You may exile two blue cards from your hand rather than pay this spell's mana cost.\nGain control of target noncreature spell. You may choose new targets for it. (If that spell is an artifact, enchantment, or planeswalker, the permanent enters the battlefield under your control.)",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "33ae707b-b9ae-556e-ad6a-943ee2ef3094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8493131c-0a7b-4be6-a8a2-0b425f4f67fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8493131c-0a7b-4be6-a8a2-0b425f4f67fb.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "58807b0d-dcd7-5cfc-8562-0295eb435282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15935478-c2e1-4fb5-b6ba-0969ea5a0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15935478-c2e1-4fb5-b6ba-0969ea5a0e81.jpg?1",
             "name": "Coveted Peacock",
             "text": "Flying\nWhenever Coveted Peacock attacks, you may goad target creature defending player controls. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -2901,7 +2901,7 @@
         },
         {
             "id": "4ee64dc2-7c46-5ccc-8cbe-8a2f35d250b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1af32a-dba2-4c2f-b0ee-9c83849fda53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1af32a-dba2-4c2f-b0ee-9c83849fda53.jpg?1",
             "name": "Cryptic Serpent",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "3dba32f6-a18a-5485-a8ad-ac0c25ade224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77ebe57-ea56-4300-b293-6260c4c01a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77ebe57-ea56-4300-b293-6260c4c01a43.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "c6916d25-2ac1-54e9-9a5d-df58dd0f7c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac13a82d-43f5-4b96-bf5f-18e33fae921b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac13a82d-43f5-4b96-bf5f-18e33fae921b.jpg?1",
             "name": "Day's Undoing",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities from the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "22ef6efb-9962-5cab-827f-b5fc8e975d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479ce7-4617-4c7c-93f2-cf8c9c5e1dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479ce7-4617-4c7c-93f2-cf8c9c5e1dac.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "6498d01d-6f16-5efb-9a70-fa2e92d20384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee8f524-f45d-49ff-a472-a47441eee279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee8f524-f45d-49ff-a472-a47441eee279.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "86a02da0-2a10-5927-92ae-c4adc057bcd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d2f70-816c-4410-b3a3-9b9a4b69df52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d2f70-816c-4410-b3a3-9b9a4b69df52.jpg?1",
             "name": "Efficient Construction",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "fe1b2313-a9bd-59b1-9cbb-29c836a54bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e3c91a-d702-4fa2-864c-9f7067a88752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e3c91a-d702-4fa2-864c-9f7067a88752.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "b51468bb-5d46-5e06-918f-f3b083b4468c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bc5a5-4483-42e9-9c14-1ad229b28eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bc5a5-4483-42e9-9c14-1ad229b28eb7.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "efb1d4d2-4265-599a-86c0-1e738165a50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04588d2f-9e90-4f83-b85e-67e4bc222a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04588d2f-9e90-4f83-b85e-67e4bc222a62.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "7d9438f3-8c6b-55da-850f-1873713ead44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaada60d-1857-4fc2-a997-d7775565221a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaada60d-1857-4fc2-a997-d7775565221a.jpg?1",
             "name": "Faerie Artisans",
             "text": "Flying\nWhenever a nontoken creature enters the battlefield under an opponent's control, create a token that's a copy of that creature except it's an artifact in addition to its other types. Then exile all other tokens created with Faerie Artisans.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "5161052e-c70a-5eee-91be-7fb339aad791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29679998-2fb4-4fb4-9048-27b6bf6b79e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29679998-2fb4-4fb4-9048-27b6bf6b79e8.jpg?1",
             "name": "Fall from Favor",
             "text": "Enchant creature\nWhen Fall from Favor enters the battlefield, tap enchanted creature and you become the monarch.\nEnchanted creature doesn't untap during its controller's untap step unless that player is the monarch.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "bdf4ac41-38e1-58d2-9112-c18e55236aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3dd95-bd14-4e0f-a388-444f9cf1b0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3dd95-bd14-4e0f-a388-444f9cf1b0dc.jpg?1",
             "name": "Fierce Guardianship",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCounter target noncreature spell.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "da000bc4-3756-58a5-96a3-0cae50b19f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75600598-f988-49fc-ba86-692367c007b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75600598-f988-49fc-ba86-692367c007b4.jpg?1",
             "name": "Filigree Attendant",
             "text": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "175ed2d0-10bf-58da-8df9-7f2a180d1a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb00e3c-b67a-44c7-ae61-23ecf4d4971a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb00e3c-b67a-44c7-ae61-23ecf4d4971a.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "3779f08b-0d52-5a18-8dff-5ec15e13c170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daab8ff-443d-4292-80f3-63b621ad1c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daab8ff-443d-4292-80f3-63b621ad1c88.jpg?1",
             "name": "Ghost of Ramirez DePietro",
             "text": "Ghost of Ramirez DePietro can't be blocked by creatures with toughness 3 or greater.\nWhenever Ghost of Ramirez DePietro deals combat damage to a player, choose up to one target card in a graveyard that was discarded or put there from a library this turn. Put that card into its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3414,7 +3414,7 @@
         },
         {
             "id": "c4290205-6066-589d-92b5-d928ab185df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc143ba3-2a58-4980-9fa0-a05a9e9ed082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc143ba3-2a58-4980-9fa0-a05a9e9ed082.jpg?1",
             "name": "Ghostly Flicker",
             "text": "Exile two target artifacts, creatures, and/or lands you control, then return those cards to the battlefield under your control.",
             "colours": [
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "67a55223-8aea-5210-8877-fc79e151ee45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374cddb8-b360-4c7b-8911-a6a1b401ffdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374cddb8-b360-4c7b-8911-a6a1b401ffdd.jpg?1",
             "name": "Goliath Sphinx",
             "text": "Flying",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "de1c4167-8469-523d-a9c1-e8d1eb39fb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c190eceb-f6d8-408f-bbc4-df0fefb778ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c190eceb-f6d8-408f-bbc4-df0fefb778ad.jpg?1",
             "name": "Inga Rune-Eyes",
             "text": "When Inga Rune-Eyes enters the battlefield, scry 3.\nWhen Inga Rune-Eyes dies, draw three cards if three or more creatures died this turn.",
             "colours": [
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "406cd151-af6f-5069-a15b-a296cf6b0d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5ad263-6b0d-4eaa-bc5a-16f5077206e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5ad263-6b0d-4eaa-bc5a-16f5077206e1.jpg?1",
             "name": "Kaho, Minamo Historian",
             "text": "When Kaho, Minamo Historian enters the battlefield, search your library for up to three instant cards, exile them, then shuffle.\n{X}, {T}: You may cast a spell with mana value X from among cards exiled with Kaho without paying its mana cost.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "51e27b99-0015-5e4d-aeb1-f91c3e8c1231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7083c77c-166f-4c6f-a2ca-dd1b877ff5f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7083c77c-166f-4c6f-a2ca-dd1b877ff5f7.jpg?1",
             "name": "Looter il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Looter il-Kor deals damage to an opponent, draw a card, then discard a card.",
             "colours": [
@@ -3589,7 +3589,7 @@
         },
         {
             "id": "d3f63c49-956e-5741-b37c-fc35405eaf99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7a64cf-3c7a-4dfc-ae44-8413def80ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7a64cf-3c7a-4dfc-ae44-8413def80ce2.jpg?1",
             "name": "Lorthos, the Tidemaker",
             "text": "Whenever Lorthos, the Tidemaker attacks, you may pay {8}. If you do, tap up to eight target permanents. Those permanents don't untap during their controllers' next untap steps.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "ecc7d9a7-2d27-5c88-8de2-407447fbc0f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d827bb89-4e28-4b77-94c0-10f79ec9099a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d827bb89-4e28-4b77-94c0-10f79ec9099a.jpg?1",
             "name": "Loyal Drake",
             "text": "Flying\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, draw a card.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "43cf0df8-64aa-5720-8912-2f4ead5733bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacc197-7c22-444d-8e6e-950dca63eb2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacc197-7c22-444d-8e6e-950dca63eb2c.jpg?1",
             "name": "Minds Aglow",
             "text": "Join forces \u2014 Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "75debaa1-18c1-57ed-8e30-52ea81817c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7dc810-c4cb-4dca-ae06-d79daf8e1477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7dc810-c4cb-4dca-ae06-d79daf8e1477.jpg?1",
             "name": "Murder of Crows",
             "text": "Flying\nWhenever another creature dies, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "370e0ad2-958d-5480-bf5e-216ff5168038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f19337d-0824-442d-bb67-748a9980e816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f19337d-0824-442d-bb67-748a9980e816.jpg?1",
             "name": "Murmuring Mystic",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 blue Bird Illusion creature token with flying.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "224f78a2-a709-5761-84d3-398e365667d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5d409-c0b6-4123-802d-eb32f223bd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5d409-c0b6-4123-802d-eb32f223bd1a.jpg?1",
             "name": "Mystic Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Return target creature to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "1750b69e-d38d-5db1-96ef-226ea08b3609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4aef8-64fc-4e9d-adac-ef4c85d40b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a4aef8-64fc-4e9d-adac-ef4c85d40b4a.jpg?1",
             "name": "Padeem, Consul of Innovation",
             "text": "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the highest mana value or tied for the highest mana value, draw a card.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "8c1d5421-00b2-530f-bed6-15c3647b1ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2887fc25-22cd-48c9-ad2b-6539c8139e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2887fc25-22cd-48c9-ad2b-6539c8139e27.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -3870,7 +3870,7 @@
         },
         {
             "id": "1fa3d9ed-938e-582a-9355-90c50c27e976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fcefb3c-2581-4dfa-96c5-36a17d762526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fcefb3c-2581-4dfa-96c5-36a17d762526.jpg?1",
             "name": "Phyrexian Ingester",
             "text": "Imprint \u2014 When Phyrexian Ingester enters the battlefield, you may exile target nontoken creature.\nPhyrexian Ingester gets +X/+Y, where X is the exiled creature card's power and Y is its toughness.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "49f7cfc9-7c0c-5144-9e6c-9e9df9a670ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9924a6-2470-44b6-9f54-766996aef57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9924a6-2470-44b6-9f54-766996aef57f.jpg?1",
             "name": "Portal Mage",
             "text": "Flash\nWhen Portal Mage enters the battlefield during the declare attackers step, you may reselect which player or permanent target attacking creature is attacking. (It can't attack its controller or their permanents.)",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "5b39f496-6489-5239-958b-482a8184fce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0850a187-ba95-46f2-aa81-397b45460bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0850a187-ba95-46f2-aa81-397b45460bbc.jpg?1",
             "name": "Reality Shift",
             "text": "Exile target creature. Its controller manifests the top card of their library. (That player puts the top card of their library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "e36825ed-a4fd-5b85-a46e-c5445b447d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a397298-9d7d-495f-983a-1683291a7b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a397298-9d7d-495f-983a-1683291a7b9f.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "ee419f05-8dd8-5c7d-b8e1-853703076481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c7819-7e53-4793-bc4f-3dd489a25d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c7819-7e53-4793-bc4f-3dd489a25d63.jpg?1",
             "name": "Resculpt",
             "text": "Exile target artifact or creature. Its controller creates a 4/4 blue and red Elemental creature token.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "0e95305c-0400-5c15-83a3-d8dfe2b9cf7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fff0a3-1315-42f7-9d36-4f5eaad0c62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fff0a3-1315-42f7-9d36-4f5eaad0c62e.jpg?1",
             "name": "Reverse Engineer",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "392028ef-d381-5c50-ae00-0b191c6dbf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6378465-0f28-46b6-8464-ff57b77d50e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6378465-0f28-46b6-8464-ff57b77d50e8.jpg?1",
             "name": "Rise from the Tides",
             "text": "Create a tapped 2/2 black Zombie creature token for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "3361904e-a25c-5809-b0b0-e325fa29a83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b5c09-5075-408e-84c5-1095354ac53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b5c09-5075-408e-84c5-1095354ac53e.jpg?1",
             "name": "Sai, Master Thopterist",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{U}, Sacrifice two artifacts: Draw a card.",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "371fa758-fda3-5605-874c-7eefdb79f19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce24e4-78cf-4550-866e-108706e82b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce24e4-78cf-4550-866e-108706e82b99.jpg?1",
             "name": "Shipwreck Dowser",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Shipwreck Dowser enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "537ddaad-df59-5f53-8e18-c29b1e7faa26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749c591-2fbe-41d8-ac5b-56ebce82d33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749c591-2fbe-41d8-ac5b-56ebce82d33e.jpg?1",
             "name": "Spellseeker",
             "text": "When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with mana value 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "94fa8d95-a99a-5f61-90b4-729bd1cd9700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ce6c30-a301-4a8a-ac3a-abacaf358a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ce6c30-a301-4a8a-ac3a-abacaf358a56.jpg?1",
             "name": "Stitcher Geralf",
             "text": "{2}{U}, {T}: Each player mills three cards. Exile up to two creature cards put into graveyards this way. Create an X/X blue Zombie creature token, where X is the total power of the cards exiled this way.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "c6518620-2274-51f3-9f76-732c959d4d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525d742f-dadb-4a59-b70d-3b328bf99cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525d742f-dadb-4a59-b70d-3b328bf99cca.jpg?1",
             "name": "Stormsurge Kraken",
             "text": "Hexproof\nLieutenant \u2014 As long as you control your commander, Stormsurge Kraken gets +2/+2 and has \"Whenever Stormsurge Kraken becomes blocked, you may draw two cards.\"",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "b2cf7276-650c-5d9c-bdc0-a687fd7d029f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c71971-fa26-4ae6-aa6f-a401e5285b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c71971-fa26-4ae6-aa6f-a401e5285b76.jpg?1",
             "name": "Sun Quan, Lord of Wu",
             "text": "Creatures you control have horsemanship. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [
@@ -4331,7 +4331,7 @@
         },
         {
             "id": "9ad49447-3310-5f9a-839f-67d06a22600b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc649f1b-b713-4c1f-9e05-4984b8cbfc63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc649f1b-b713-4c1f-9e05-4984b8cbfc63.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "5a7be855-d2ea-53e1-ba44-0644e8fcd272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368c6e60-804c-447c-bc2b-ac9dc4cab5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368c6e60-804c-447c-bc2b-ac9dc4cab5e7.jpg?1",
             "name": "Teferi, Temporal Archmage",
             "text": "+1: Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\n\u22121: Untap up to four target permanents.\n\u221210: You get an emblem with \"You may activate loyalty abilities of planeswalkers you control on any player's turn any time you could cast an instant.\"\nTeferi, Temporal Archmage can be your commander.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "40af42b7-269e-51f8-93f0-0afcbe68d8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f03792-5d06-45f4-ab19-5a415abbc382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f03792-5d06-45f4-ab19-5a415abbc382.jpg?1",
             "name": "Tetsuko Umezawa, Fugitive",
             "text": "Creatures you control with power or toughness 1 or less can't be blocked.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "90d17434-6d47-5fe5-a5e9-d19311ec4321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbdae80-1481-4a8c-b3c3-f4224204d29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbdae80-1481-4a8c-b3c3-f4224204d29d.jpg?1",
             "name": "Thryx, the Sudden Storm",
             "text": "Flash\nFlying\nSpells you cast with mana value 5 or greater cost {1} less to cast and can't be countered.",
             "colours": [
@@ -4483,7 +4483,7 @@
         },
         {
             "id": "aa56ae88-6ca8-58d9-9693-c44de1dbf6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92872fea-2fb4-4154-815e-cad9d966e60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92872fea-2fb4-4154-815e-cad9d966e60f.jpg?1",
             "name": "Torrential Gearhulk",
             "text": "Flash\nWhen Torrential Gearhulk enters the battlefield, you may cast target instant card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "b22bd4e8-3cec-5855-b8ae-8214584313d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ad933-ddd9-4975-a222-21fe3305137c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ad933-ddd9-4975-a222-21fe3305137c.jpg?1",
             "name": "Tromokratis",
             "text": "Tromokratis has hexproof unless it's attacking or blocking.\nTromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "6780bf07-c1a5-57cf-8533-3a7c5d25980a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a348a-51f7-4dc5-8fe7-1c70fea5e050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a348a-51f7-4dc5-8fe7-1c70fea5e050.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "dfa2b7dc-157c-50ec-8e25-0e530c3c6a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9aef509-50f0-4848-87d5-3c169453186f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9aef509-50f0-4848-87d5-3c169453186f.jpg?1",
             "name": "Vizier of Tumbling Sands",
             "text": "{T}: Untap another target permanent.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Vizier of Tumbling Sands, untap target permanent.",
             "colours": [
@@ -4632,7 +4632,7 @@
         },
         {
             "id": "b8322339-5056-5056-a5dd-bcc785af1a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e85ad25-7496-4832-b945-e7a39582faaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e85ad25-7496-4832-b945-e7a39582faaa.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "01f35f71-d5fa-5275-bc33-b7925b764106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1e538-9e68-4481-9bd6-3d37e20645f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1e538-9e68-4481-9bd6-3d37e20645f2.jpg?1",
             "name": "Windcaller Aven",
             "text": "Flying\nCycling {U} ({U}, Discard this card: Draw a card.)\nWhen you cycle Windcaller Aven, target creature gains flying until end of turn.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "c93a4eaf-c2c8-5535-9591-53b099390bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c2c48-146d-49f6-bc10-2eed733184b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0c2c48-146d-49f6-bc10-2eed733184b4.jpg?1",
             "name": "Windrider Wizard",
             "text": "Flying\nWhenever you cast an instant, sorcery, or Wizard spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "ccc85884-8138-543e-a5dd-c7a1cf890aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f028cd-1cb4-4a5b-b989-4acd8777ac5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f028cd-1cb4-4a5b-b989-4acd8777ac5c.jpg?1",
             "name": "Witching Well",
             "text": "When Witching Well enters the battlefield, scry 2.\n{3}{U}, Sacrifice Witching Well: Draw two cards.",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "228fa2ce-9b21-5bbf-8e3b-f5b2e5ea6971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880fc139-4200-483f-bdb1-dc9ef32d63a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880fc139-4200-483f-bdb1-dc9ef32d63a5.jpg?1",
             "name": "Zahid, Djinn of the Lamp",
             "text": "You may pay {3}{U} and tap an untapped artifact you control rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "3d095e14-8264-5cde-8028-2d5e8d15a451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d1e901-cef9-45ca-a946-a4a9cba6702d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d1e901-cef9-45ca-a946-a4a9cba6702d.jpg?1",
             "name": "Archfiend of Despair",
             "text": "Flying\nYour opponents can't gain life.\nAt the beginning of each end step, each opponent loses life equal to the life that player lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "b95298c9-88dc-56c9-b126-8ab355da5998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa32ff-3ced-405c-8508-7dd35cd20f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa32ff-3ced-405c-8508-7dd35cd20f02.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "When Bastion of Remembrance enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "0e3473db-c646-5dad-b725-8a6bd7d03552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56d1535-d9de-459f-bc31-0923f621e0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56d1535-d9de-459f-bc31-0923f621e0e9.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "ee4d4ca2-9601-5322-8808-ecb172e6b4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9a1276-5ad5-44ee-83e5-2d1ab728946e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9a1276-5ad5-44ee-83e5-2d1ab728946e.jpg?1",
             "name": "Cabal Patriarch",
             "text": "{2}{B}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.\n{2}{B}, Exile a creature card from your graveyard: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "32acf87f-13f5-5ece-abb0-fba9c80b59e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06ab823-9591-460d-a896-3073d9843df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06ab823-9591-460d-a896-3073d9843df0.jpg?1",
             "name": "Cadaver Imp",
             "text": "Flying\nWhen Cadaver Imp enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "c467c4b3-0a20-5337-9ede-c2c7b37a0a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e551c-0b47-4ccb-8893-f192de92908e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e551c-0b47-4ccb-8893-f192de92908e.jpg?1",
             "name": "Carrier Thrall",
             "text": "When Carrier Thrall dies, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "2dbd4449-1f76-59b2-8dd9-1ff8461e2807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d485efd-667f-4561-b747-7605bf1ebc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d485efd-667f-4561-b747-7605bf1ebc09.jpg?1",
             "name": "Carrion Grub",
             "text": "Carrion Grub gets +X/+0, where X is the greatest power among creature cards in your graveyard.\nWhen Carrion Grub enters the battlefield, mill four cards. (Put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "465cf455-f620-5e61-955d-d7a7bef25416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186c30e6-2b84-415d-83e4-ecddaeb11ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186c30e6-2b84-415d-83e4-ecddaeb11ca1.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "e21e20c3-6abc-5e64-b6b4-a7a8e614c963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0dfb-663a-4713-902e-96dbecc404b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0dfb-663a-4713-902e-96dbecc404b7.jpg?1",
             "name": "Corpse Augur",
             "text": "When Corpse Augur dies, you draw X cards and you lose X life, where X is the number of creature cards in target player's graveyard.",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "87205ff5-3455-56db-ae1e-3b12fc3fe58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d3f1b5-b41c-4181-8c14-d0f2f4ba0710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d3f1b5-b41c-4181-8c14-d0f2f4ba0710.jpg?1",
             "name": "Curtains' Call",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "b291eecb-9fe2-5df1-bf73-78a21643d6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13f735-54fa-42b6-aea4-ced33811d7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13f735-54fa-42b6-aea4-ced33811d7d4.jpg?1",
             "name": "Deadly Rollick",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nExile target creature.",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "d160dcdd-208c-57eb-96a8-5b77731cd07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6702a-a7d9-4d86-8ba2-364417a31dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6702a-a7d9-4d86-8ba2-364417a31dbb.jpg?1",
             "name": "Decree of Pain",
             "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "4d2cfc03-e301-500f-b33d-e014447aca3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7f2ce1-b442-4051-b1fe-90efde9bc181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7f2ce1-b442-4051-b1fe-90efde9bc181.jpg?1",
             "name": "Demon's Disciple",
             "text": "When Demon's Disciple enters the battlefield, each player sacrifices a creature or planeswalker.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "ac58f1a8-27ae-5dd4-9ed6-9aaf145dc8ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24b4cb6-cebb-428b-8654-74347a6a8d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24b4cb6-cebb-428b-8654-74347a6a8d63.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "7257317a-e719-5ca3-8573-5f7c0825040e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07114d8-40b3-4102-8d70-e3ed94a7f515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07114d8-40b3-4102-8d70-e3ed94a7f515.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "Flying, trample\nWhen Demonlord Belzenlok enters the battlefield, exile cards from the top of your library until you exile a nonland card, then put that card into your hand. If the card's mana value is 4 or greater, repeat this process. Demonlord Belzenlok deals 1 damage to you for each card put into your hand this way.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "cd9a3378-5ad3-5546-9b66-a7c6a536c245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ef119f-e777-42e7-be43-ea1f31d7ce59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ef119f-e777-42e7-be43-ea1f31d7ce59.jpg?1",
             "name": "Dread Drone",
             "text": "When Dread Drone enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "b394d224-87f5-537c-92b4-36e09540f25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a87901-98bb-41dd-b566-bcb510c20022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a87901-98bb-41dd-b566-bcb510c20022.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "2e4aa19d-218a-5411-9b97-363a539312a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512357b-0d08-4996-9301-5853eae1ea64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512357b-0d08-4996-9301-5853eae1ea64.jpg?1",
             "name": "Drown in Sorrow",
             "text": "All creatures get -2/-2 until end of turn. Scry 1.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "ef24b787-536c-55d7-9980-074e78c4e06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123490fb-5908-45f2-b376-7959ccdf9c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123490fb-5908-45f2-b376-7959ccdf9c3e.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you cast a creature spell, create X 1/1 black Thrull creature tokens, where X is that spell's mana value.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "1e7d2dec-5813-5e6b-99b4-6542020f67d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5352af-e275-4186-a265-2fd3c2c47c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5352af-e275-4186-a265-2fd3c2c47c6a.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "60491339-7c40-5c6b-a535-5d4ba77dc1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1888ac60-a885-43a7-8e95-9523a0213644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1888ac60-a885-43a7-8e95-9523a0213644.jpg?1",
             "name": "Extinguish All Hope",
             "text": "Destroy all nonenchantment creatures.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "35f828d6-26af-5cbb-ab60-3e5ffba34e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f15c50-cfb2-4567-bad5-3d18a2d7d0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f15c50-cfb2-4567-bad5-3d18a2d7d0aa.jpg?1",
             "name": "Feast of Succession",
             "text": "All creatures get -4/-4 until end of turn. You become the monarch.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "744cb1c5-a938-54a4-95e8-a855167aa7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840d02c6-3d9c-47cd-9307-978d03380d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840d02c6-3d9c-47cd-9307-978d03380d0f.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "0fded734-6930-5105-92a3-f475a99896f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f24b7c-4952-4abc-aaba-22a529012468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f24b7c-4952-4abc-aaba-22a529012468.jpg?1",
             "name": "Final Parting",
             "text": "Search your library for two cards. Put one into your hand and the other into your graveyard. Then shuffle.",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "8e1a1a65-f1e9-5def-9568-00173248fa73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d7906e-8a89-4644-acb5-46fbe97ab39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d7906e-8a89-4644-acb5-46fbe97ab39f.jpg?1",
             "name": "Ghoulcaller Gisa",
             "text": "{B}, {T}, Sacrifice another creature: Create X 2/2 black Zombie creature tokens, where X is the sacrificed creature's power.",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "f54efde0-8d8d-53f0-a33c-1591a0bbd58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01852cd2-16e4-4518-b5d5-b9a378b8664d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01852cd2-16e4-4518-b5d5-b9a378b8664d.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "4af34644-f169-5671-b5d3-db309080b138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad6c2f-9c26-496d-9079-adf1fec08a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad6c2f-9c26-496d-9079-adf1fec08a59.jpg?1",
             "name": "Goremand",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample\nWhen Goremand enters the battlefield, each opponent sacrifices a creature.",
             "colours": [
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "f1e30223-11b6-5fcf-adeb-858fad5f252c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12615d0d-e38c-4e7b-918e-33e88299d1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12615d0d-e38c-4e7b-918e-33e88299d1f9.jpg?1",
             "name": "Gorex, the Tombshell",
             "text": "As an additional cost to cast this spell, you may exile any number of creature cards from your graveyard. This spell costs {2} less to cast for each card exiled this way.\nDeathtouch\nWhenever Gorex, the Tombshell attacks or dies, choose a card at random exiled with Gorex and put that card into its owner's hand.",
             "colours": [
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "a8601dea-b8a2-5685-8333-dcd1963cde0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4970b-2ba6-4c91-a301-369369cdf360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4970b-2ba6-4c91-a301-369369cdf360.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -5818,7 +5818,7 @@
         },
         {
             "id": "dad47f02-0cda-5034-97a2-a6ebde9b5c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11dea2a-fe20-4e1b-9e1e-8759e0950f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11dea2a-fe20-4e1b-9e1e-8759e0950f0a.jpg?1",
             "name": "Heartless Act",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with no counters on it.\n\u2022 Remove up to three counters from target creature.",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "ff5986b7-ba79-5f73-aaee-c4aa1ef23266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb0e8e7-266f-441e-b1cd-12b8ec3f7d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb0e8e7-266f-441e-b1cd-12b8ec3f7d71.jpg?1",
             "name": "Imp's Mischief",
             "text": "Change the target of target spell with a single target. You lose life equal to that spell's mana value.",
             "colours": [
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "84fea78d-fa0d-5a63-a0ed-74e43dedfd79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5de9b95-1c20-4d1a-be7d-4307ec2803ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5de9b95-1c20-4d1a-be7d-4307ec2803ba.jpg?1",
             "name": "Isareth the Awakener",
             "text": "Deathtouch\nWhenever Isareth the Awakener attacks, you may pay {X}. When you do, return target creature card with mana value X from your graveyard to the battlefield with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "476881ff-2cc1-5658-a336-07b971969120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af613b69-b9f6-4221-a21b-c8e4b0f010f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af613b69-b9f6-4221-a21b-c8e4b0f010f1.jpg?1",
             "name": "Kindred Dominance",
             "text": "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
             "colours": [
@@ -5956,7 +5956,7 @@
         },
         {
             "id": "ab9dd048-6204-53d0-a732-a94927b65a69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ea9ea5-acf1-4980-b7e5-083da455adb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ea9ea5-acf1-4980-b7e5-083da455adb0.jpg?1",
             "name": "Legion Vanguard",
             "text": "{1}, Sacrifice another creature: Legion Vanguard explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "95a1bc40-d3c9-51f4-bdbe-bbbeab93b359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09237f1b-eff6-45bf-bd7d-a883deda122a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09237f1b-eff6-45bf-bd7d-a883deda122a.jpg?1",
             "name": "Lotleth Giant",
             "text": "Undergrowth \u2014 When Lotleth Giant enters the battlefield, it deals 1 damage to target opponent for each creature card in your graveyard.",
             "colours": [
@@ -6026,7 +6026,7 @@
         },
         {
             "id": "3fe187b0-2cbc-52d9-8229-6adeea4e11f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1949469a-faa5-4bff-8b0f-0a1bc7ca87da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1949469a-faa5-4bff-8b0f-0a1bc7ca87da.jpg?1",
             "name": "Loyal Subordinate",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, each opponent loses 3 life.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "36e148a6-d412-5c09-9793-593cebce3a2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1f42a2-fe11-45da-9552-069803b4068a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1f42a2-fe11-45da-9552-069803b4068a.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -6101,7 +6101,7 @@
         },
         {
             "id": "c7bccae8-c561-5026-be98-e04dac1e681f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a070b7af-7c85-4129-81ca-e2ec0540085e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a070b7af-7c85-4129-81ca-e2ec0540085e.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "533f897b-c929-5d8c-89d3-1ff019d41eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd606c3-795a-49d8-8b75-6a3aacb4a72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd606c3-795a-49d8-8b75-6a3aacb4a72f.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "554c3ed5-c6e8-5c08-81d3-376b71fbeca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4e4509-ffd8-4fd0-a678-19c9975d571b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4e4509-ffd8-4fd0-a678-19c9975d571b.jpg?1",
             "name": "Ob Nixilis of the Black Oath",
             "text": "+2: Each opponent loses 1 life. You gain life equal to the life lost this way.\n\u22122: Create a 5/5 black Demon creature token with flying. You lose 2 life.\n\u22128: You get an emblem with \"{1}{B}, Sacrifice a creature: You gain X life and draw X cards, where X is the sacrificed creature's power.\"\nOb Nixilis of the Black Oath can be your commander.",
             "colours": [
@@ -6211,7 +6211,7 @@
         },
         {
             "id": "4853b865-ff09-50f1-b73a-1560c9e04573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2373e57c-01bb-4d49-94ad-b9ff75335cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2373e57c-01bb-4d49-94ad-b9ff75335cb7.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "498ac274-b2a2-5c4d-a459-837bbc5eb9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08648c0a-e075-45ac-ad8c-80c425d3487e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08648c0a-e075-45ac-ad8c-80c425d3487e.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "edb15404-87c2-527c-ae22-af3df243d5f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14db0f35-905b-45c9-a0cc-1c47720380eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14db0f35-905b-45c9-a0cc-1c47720380eb.jpg?1",
             "name": "Priest of the Blood Rite",
             "text": "When Priest of the Blood Rite enters the battlefield, create a 5/5 black Demon creature token with flying.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "ca653ed6-97c7-5b1f-b7d1-1dd33969955c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32399c54-632f-434e-bd5a-81b6a7c4fe9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32399c54-632f-434e-bd5a-81b6a7c4fe9b.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "Flying, haste\nWhenever Rankle, Master of Pranks deals combat damage to a player, choose any number \u2014\n\u2022 Each player discards a card.\n\u2022 Each player loses 1 life and draws a card.\n\u2022 Each player sacrifices a creature.",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "949ee1b8-1964-5150-900b-2c2c5071d87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb956d-0df6-4910-9320-55f2c5674d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bb956d-0df6-4910-9320-55f2c5674d98.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "Flying, trample\nPay 2 life, Sacrifice another creature: Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "df475c83-e44d-56b9-97f2-b073e6d3ff96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c66076-fb85-4a5e-8cd0-d103834b3cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c66076-fb85-4a5e-8cd0-d103834b3cd1.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "7cfe7cd6-6878-56ba-a024-d5910aa4f7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00566375-e976-4e96-b751-cf0430452c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00566375-e976-4e96-b751-cf0430452c9c.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "b4a825ed-c14e-5b61-ade2-7ef212f456d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d67da-4fc9-4d4a-95e4-0303c5404705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d67da-4fc9-4d4a-95e4-0303c5404705.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -6498,7 +6498,7 @@
         },
         {
             "id": "faa5ed8b-fa41-5d2d-a401-69f3bd6bedc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78509763-4bb8-4030-b205-76917de75c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78509763-4bb8-4030-b205-76917de75c57.jpg?1",
             "name": "Serrated Scorpion",
             "text": "When Serrated Scorpion dies, it deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -6532,7 +6532,7 @@
         },
         {
             "id": "a25fe32d-a6d5-5d2e-8294-b94e70a364da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69848ec1-dba7-419f-a5f9-f934bebeeaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69848ec1-dba7-419f-a5f9-f934bebeeaa6.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from the battlefield, you may return that card to the battlefield at the beginning of the next end step if Shirei, Shizo's Caretaker is still on the battlefield.",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "d9962425-24e7-5cc5-aeef-16c6c88f20c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532301e-9005-4770-9e04-868f69f6becf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532301e-9005-4770-9e04-868f69f6becf.jpg?1",
             "name": "Sower of Discord",
             "text": "Flying\nAs Sower of Discord enters the battlefield, choose two players.\nWhenever damage is dealt to one of the chosen players, the other chosen player also loses that much life.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "cacf6f06-dca7-5a6f-b835-bccdd06e37a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b349b4b-f08d-45e8-81f6-3467a02e6d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b349b4b-f08d-45e8-81f6-3467a02e6d23.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "ba3cca4a-5a59-5a0f-a118-95363f54cc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bb6abe-3844-4399-b38a-1d6dd81a6c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bb6abe-3844-4399-b38a-1d6dd81a6c78.jpg?1",
             "name": "Taborax, Hope's Demise",
             "text": "Flying\nTaborax, Hope's Demise has lifelink as long as it has five or more +1/+1 counters on it.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on Taborax. If that creature was a Cleric, you may draw a card. If you do, you lose 1 life.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "f798000a-d416-539c-b614-50bc37eda013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b266e2-1cad-40df-bc0e-3e1464b299b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b266e2-1cad-40df-bc0e-3e1464b299b3.jpg?1",
             "name": "Thorn of the Black Rose",
             "text": "Deathtouch\nWhen Thorn of the Black Rose enters the battlefield, you become the monarch.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "b501d7a4-7b75-5aa1-9d29-36bb7cfc30c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6fdd97-a896-4110-b48f-a6c49394f854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6fdd97-a896-4110-b48f-a6c49394f854.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "064c9a03-a224-50bd-80f0-654f34bbb88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588332da-8ec5-49d1-a365-455beb7913a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588332da-8ec5-49d1-a365-455beb7913a2.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "110cef60-4539-5690-9a5a-b38a1008715b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74353dcc-7653-4c5a-b621-ae587c448657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74353dcc-7653-4c5a-b621-ae587c448657.jpg?1",
             "name": "Twilight Prophet",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, if you have the city's blessing, reveal the top card of your library and put it into your hand. Each opponent loses X life and you gain X life, where X is that card's mana value.",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "64488805-c07c-517a-b7ce-f74bf7da06b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcaee2c-fad7-4ee2-8fe7-20b2c1eee5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcaee2c-fad7-4ee2-8fe7-20b2c1eee5c5.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "f1f58e9d-1223-57c7-87d7-b69123162ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e4993e-154c-4ac4-8927-6352b8816f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e4993e-154c-4ac4-8927-6352b8816f58.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "775a5140-c383-5b3f-acf6-1e667a69fd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120b644-477d-4297-b94f-56120a384bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120b644-477d-4297-b94f-56120a384bc2.jpg?1",
             "name": "Vindictive Lich",
             "text": "When Vindictive Lich dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent sacrifices a creature.\n\u2022 Target opponent discards two cards.\n\u2022 Target opponent loses 5 life.",
             "colours": [
@@ -6917,7 +6917,7 @@
         },
         {
             "id": "dc54f37f-8a32-5215-8fde-5325c69ebd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1780be8-26f6-4f33-9bc6-ecafc3751c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1780be8-26f6-4f33-9bc6-ecafc3751c8e.jpg?1",
             "name": "Wake the Dead",
             "text": "Cast this spell only during combat on an opponent's turn.\nReturn X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step.",
             "colours": [
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "a3039ef7-9f76-515a-a336-5f7f59fc03b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ce13b0-372d-4664-a888-85f4c72e030d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ce13b0-372d-4664-a888-85f4c72e030d.jpg?1",
             "name": "Whisper, Blood Liturgist",
             "text": "{T}, Sacrifice two creatures: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -6988,7 +6988,7 @@
         },
         {
             "id": "749d5ecf-6830-5384-94da-bb58890cd7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c15046-dd24-41aa-96f3-fb008a6988dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c15046-dd24-41aa-96f3-fb008a6988dd.jpg?1",
             "name": "Witch's Cauldron",
             "text": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -7020,7 +7020,7 @@
         },
         {
             "id": "71003b91-0d37-5529-86ec-52f63152b515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20203edb-1363-4ed3-8c5b-b1d96ff2b7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20203edb-1363-4ed3-8c5b-b1d96ff2b7c0.jpg?1",
             "name": "Wretched Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target creature gets -2/-2 until end of turn.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "009e66bb-9437-5a19-bc28-a2d3b474006d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c19c3-0ea6-4b05-9cde-e9863b1fbe04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c19c3-0ea6-4b05-9cde-e9863b1fbe04.jpg?1",
             "name": "Yahenni, Undying Partisan",
             "text": "Haste\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Yahenni, Undying Partisan.\nSacrifice another creature: Yahenni gains indestructible until end of turn.",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "c3188424-75c2-52c2-9f05-8a911a8fa7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8febc0fe-c52d-4b6a-9d18-e1e4a43b6dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8febc0fe-c52d-4b6a-9d18-e1e4a43b6dc3.jpg?1",
             "name": "Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "31ceb167-81b1-560d-bba5-db556b8b593f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d9e279-61c1-4567-9f54-50a7138fb36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d9e279-61c1-4567-9f54-50a7138fb36d.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -7160,7 +7160,7 @@
         },
         {
             "id": "00315f0b-da57-5d01-a114-bb439a7bf95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad107ae0-2540-46f8-9970-72983b87ba04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad107ae0-2540-46f8-9970-72983b87ba04.jpg?1",
             "name": "Anax, Hardened in the Forge",
             "text": "Anax's power is equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)\nWhenever Anax or another nontoken creature you control dies, create a 1/1 red Satyr creature token with \"This creature can't block.\" If the creature had power 4 or greater, create two of those tokens instead.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "6f0c4ced-bf75-54ec-aa54-ef06f7062e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c687123-6c34-4aef-8350-70a72b5fb58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c687123-6c34-4aef-8350-70a72b5fb58f.jpg?1",
             "name": "Ashling the Pilgrim",
             "text": "{1}{R}: Put a +1/+1 counter on Ashling the Pilgrim. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling the Pilgrim, and it deals that much damage to each creature and each player.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "12db4189-7580-5c4f-9ef6-3fd2ff28cce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dd6cc-53e8-4c67-8838-180b19f02088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dd6cc-53e8-4c67-8838-180b19f02088.jpg?1",
             "name": "Avatar of Slaughter",
             "text": "All creatures have double strike and attack each combat if able.",
             "colours": [
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "b264084b-418c-509f-8501-4b9230e48620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37def363-c431-43b4-8c5f-933941507681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37def363-c431-43b4-8c5f-933941507681.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "bdf97011-a290-589e-92d1-7a4b95138b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075947cd-2e06-486a-83a7-97321445a679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075947cd-2e06-486a-83a7-97321445a679.jpg?1",
             "name": "Blood Aspirant",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Blood Aspirant.\n{1}{R}, {T}, Sacrifice a creature or enchantment: Blood Aspirant deals 1 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "99a388eb-27c0-57b5-b24a-ff77f7004aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d640bc10-51ce-48e9-bceb-c3e69d7eae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d640bc10-51ce-48e9-bceb-c3e69d7eae31.jpg?1",
             "name": "Captain Ripley Vance",
             "text": "Whenever you cast your third spell each turn, put a +1/+1 counter on Captain Ripley Vance, then it deals damage equal to its power to any target.",
             "colours": [
@@ -7381,7 +7381,7 @@
         },
         {
             "id": "7ac1e47b-ced8-5792-8abf-bd9e5fa7c32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203dba7d-5e89-4a5a-998a-c26bf17c92f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203dba7d-5e89-4a5a-998a-c26bf17c92f9.jpg?1",
             "name": "Champion of the Flame",
             "text": "Trample\nChampion of the Flame gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "a2f675bf-5a41-566c-b3e0-b68749b9a509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf54657-5943-4a45-a296-dc91c41109d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf54657-5943-4a45-a296-dc91c41109d4.jpg?1",
             "name": "Crimson Fleet Commodore",
             "text": "Trample\nWhen Crimson Fleet Commodore enters the battlefield, you become the monarch.",
             "colours": [
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "a0002ef7-6eb4-5abc-a6b9-73a329ef591f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd56c7dd-8388-400c-a8fb-bc6a69655c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd56c7dd-8388-400c-a8fb-bc6a69655c56.jpg?1",
             "name": "Cyclops Electromancer",
             "text": "When Cyclops Electromancer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "08e0022f-b5eb-5060-87fa-e7c49c80cfca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb9d4a0-66bd-454d-b676-80192a96c723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb9d4a0-66bd-454d-b676-80192a96c723.jpg?1",
             "name": "Daretti, Scrap Savant",
             "text": "+2: Discard up to two cards, then draw that many cards.\n\u22122: Sacrifice an artifact. If you do, return target artifact card from your graveyard to the battlefield.\n\u221210: You get an emblem with \"Whenever an artifact is put into your graveyard from the battlefield, return that card to the battlefield at the beginning of the next end step.\"\nDaretti, Scrap Savant can be your commander.",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "6ecd7308-462f-5856-9f92-38b0ecee9034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b36435-55b3-4615-8812-af41d4fc64d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b36435-55b3-4615-8812-af41d4fc64d9.jpg?1",
             "name": "Deflecting Swat",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nYou may choose new targets for target spell or ability.",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "f147a476-32d2-50eb-a57d-4c689caf3a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50359328-9378-448d-9817-805503186a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50359328-9378-448d-9817-805503186a55.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -7594,7 +7594,7 @@
         },
         {
             "id": "901098bd-d213-5bda-903e-244f73b619f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd7456-71dd-463f-98a2-2d6a9cfb7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd7456-71dd-463f-98a2-2d6a9cfb7395.jpg?1",
             "name": "Divergent Transformations",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nExile two target creatures. For each of those creatures, its controller reveals cards from the top of their library until they reveal a creature card, puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -7628,7 +7628,7 @@
         },
         {
             "id": "b1b07da4-39f0-53d3-92f5-f3169ffafef8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f4777d-ea0e-408c-961e-eef7b3ffe51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f4777d-ea0e-408c-961e-eef7b3ffe51d.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -7660,7 +7660,7 @@
         },
         {
             "id": "42509787-6ebb-54b9-bfaa-a806bcac9e14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe78a66-2e72-4bd8-b8a4-db77a63f36b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe78a66-2e72-4bd8-b8a4-db77a63f36b3.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "12c250ab-1cc0-5edd-a953-640f93e0196b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47f7ea0-3cda-4e62-bd10-32854ed2e260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47f7ea0-3cda-4e62-bd10-32854ed2e260.jpg?1",
             "name": "Dwarven Hammer",
             "text": "When Dwarven Hammer enters the battlefield, you may pay {2}. If you do, create a 2/1 red Dwarf Berserker creature token, then attach Dwarven Hammer to it.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "aa7685d4-86c0-575d-99a8-383dc3314d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf84ec7-a202-41fe-baa7-0b921bc67d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf84ec7-a202-41fe-baa7-0b921bc67d1b.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "7d2539be-243e-5cf4-a3c2-1fba0d1daad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6fab0-7872-445d-a514-774ecccd2355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff6fab0-7872-445d-a514-774ecccd2355.jpg?1",
             "name": "Fiendlash",
             "text": "Equipped creature gets +2/+0 and has reach.\nWhenever equipped creature is dealt damage, it deals damage equal to its power to target player or planeswalker.\nEquip {2}{R}",
             "colours": [
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "91ed52b5-7b65-542d-ad1a-d3c7746402c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed7ef7f-bb40-4e1b-8635-e2226a05ac38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed7ef7f-bb40-4e1b-8635-e2226a05ac38.jpg?1",
             "name": "Fiery Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Fiery Confluence deals 1 damage to each creature.\n\u2022 Fiery Confluence deals 2 damage to each opponent.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "f00018bc-b7ab-5d7c-886c-88fb9b0a6cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b34af88-bc4e-4ca8-8662-7dc4050c62c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b34af88-bc4e-4ca8-8662-7dc4050c62c5.jpg?1",
             "name": "Fists of Flame",
             "text": "Draw a card. Until end of turn, target creature gains trample and gets +1/+0 for each card you've drawn this turn.",
             "colours": [
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "aa1a1659-27eb-5405-bd6a-87c6306519ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39282507-8921-43e3-a836-f73ba6da5623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39282507-8921-43e3-a836-f73ba6da5623.jpg?1",
             "name": "Frontier Warmonger",
             "text": "Whenever one or more creatures attack one of your opponents or a planeswalker they control, those creatures gain menace until end of turn.",
             "colours": [
@@ -7901,7 +7901,7 @@
         },
         {
             "id": "e595d9bf-236c-5687-a791-a4e391be0728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5da1ab-d720-4140-8121-89de760d020c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5da1ab-d720-4140-8121-89de760d020c.jpg?1",
             "name": "Furious Rise",
             "text": "At the beginning of your end step, if you control a creature with power 4 or greater, exile the top card of your library. You may play that card until you exile another card with Furious Rise.",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "196e2a38-0a97-57f4-b2d2-7fae9843abb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079d5536-1b2e-4d5b-bae9-9fd14562087a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079d5536-1b2e-4d5b-bae9-9fd14562087a.jpg?1",
             "name": "Gargadon",
             "text": "Trample\nSuspend 4\u2014{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "818c0bc2-d82b-567b-aed7-18ae89aa3728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d566cf-cb32-461d-8afe-b0f3f4c24160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d566cf-cb32-461d-8afe-b0f3f4c24160.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card, put it onto the battlefield, then shuffle.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -8006,7 +8006,7 @@
         },
         {
             "id": "c9bae6df-c03e-509d-afc9-0c82fe7876d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e4a51-e7ab-4107-b458-771e6d31d110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e4a51-e7ab-4107-b458-771e6d31d110.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "Whenever a creature you control deals combat damage to a player, choose one \u2014\n\u2022 Goad target creature that player controls.\n\u2022 Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "162b809f-ebec-579f-a56c-6c60df2a810b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4276d10-d163-4068-a6db-5bb0a1ac88e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4276d10-d163-4068-a6db-5bb0a1ac88e3.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "23882eae-26f6-5bb8-a1ae-7c2157fcff0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7790d21-4751-4f1b-a7f4-2bbcf842b0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7790d21-4751-4f1b-a7f4-2bbcf842b0b6.jpg?1",
             "name": "Havoc Jester",
             "text": "Whenever you sacrifice a permanent, Havoc Jester deals 1 damage to any target.",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "d67e79ed-8dc8-5242-b107-d3e4fd193532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ff07c-9653-4197-ad3d-638e712e8465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ff07c-9653-4197-ad3d-638e712e8465.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "{T}: Heartless Hidetsugu deals damage to each player equal to half that player's life total, rounded down.",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "fc201530-28b1-52a7-90ca-9176ec70b5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836c646-83ff-4bf8-96dd-4cbdd6c7e861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6836c646-83ff-4bf8-96dd-4cbdd6c7e861.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -8190,7 +8190,7 @@
         },
         {
             "id": "ecc61756-9f8e-5484-b3be-d561e0d0305f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42363046-28d4-4540-a0d0-3635459ba769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42363046-28d4-4540-a0d0-3635459ba769.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle.\nWhen Hoarding Dragon dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -8224,7 +8224,7 @@
         },
         {
             "id": "4c4b4433-f669-59ad-8ab2-f7c1efb3593f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea2e32d-d711-40ae-87d5-c16893bfc8ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea2e32d-d711-40ae-87d5-c16893bfc8ca.jpg?1",
             "name": "Impulsive Pilferer",
             "text": "When Impulsive Pilferer dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEncore {3}{R} ({3}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -8259,7 +8259,7 @@
         },
         {
             "id": "74270beb-ebb9-58f2-8bf4-3fee9b7a1d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee80c14-5857-4752-b958-a51cf6706c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee80c14-5857-4752-b958-a51cf6706c96.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "4536616a-e272-50d7-abaa-1621e967f2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a0a8c-1953-46e6-9da5-b4c20909ce1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a0a8c-1953-46e6-9da5-b4c20909ce1c.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -8330,7 +8330,7 @@
         },
         {
             "id": "618ec973-5e89-5b2b-bde0-9d0786180ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7c54ed-594d-40d7-a64a-a57db6d5ba16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7c54ed-594d-40d7-a64a-a57db6d5ba16.jpg?1",
             "name": "Kazuul, Tyrant of the Cliffs",
             "text": "Whenever a creature an opponent controls attacks, if you're the defending player, create a 3/3 red Ogre creature token unless that creature's controller pays {3}.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "fab36c87-62c2-56a5-9e8c-2fe8b3416ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27141cae-3ca1-4a4f-933f-9608bbcf9bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27141cae-3ca1-4a4f-933f-9608bbcf9bd9.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "0865e53b-b7c9-517b-a5e5-7fc78b752ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457dc72b-e97a-4308-855f-a1aa528423e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457dc72b-e97a-4308-855f-a1aa528423e0.jpg?1",
             "name": "Living Lightning",
             "text": "When Living Lightning dies, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "6dd1af5d-faf4-5dda-8692-9596ceaa8642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a692fb-7ef7-4fae-b258-8719711cf38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a692fb-7ef7-4fae-b258-8719711cf38c.jpg?1",
             "name": "Loyal Apprentice",
             "text": "Haste\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.",
             "colours": [
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "25db473e-65d8-51f8-a88a-f8f78e1853ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952dd9-ef09-40f0-993f-eb3a1516616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952dd9-ef09-40f0-993f-eb3a1516616a.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards their hand, then draws seven cards.",
             "colours": [
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "3124c117-d66e-5849-bb04-eeeb8184120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60715b6d-b223-431a-85d8-27d7c05469b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60715b6d-b223-431a-85d8-27d7c05469b2.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "b340a216-21fe-5dd3-8e02-6484474804b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502ba85-7246-4652-9ab6-5672f7e490bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502ba85-7246-4652-9ab6-5672f7e490bb.jpg?1",
             "name": "Meteoric Mace",
             "text": "Equipped creature gets +4/+0 and has trample.\nEquip {4}\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "a436f325-8f07-50c4-a804-a52818e9b3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98695d3-a8ec-43f0-9a2a-fef4566f3a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98695d3-a8ec-43f0-9a2a-fef4566f3a2f.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "0cde0ce5-a769-59fb-ae5d-1caba21a2be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72e980-6c07-46cd-ae25-d7e92fd94277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72e980-6c07-46cd-ae25-d7e92fd94277.jpg?1",
             "name": "Nesting Dragon",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, create a 0/2 red Dragon Egg creature token with defender and \"When this creature dies, create a 2/2 red Dragon creature token with flying and \u2018{R}: This creature gets +1/+0 until end of turn.'\"",
             "colours": [
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "7a349723-04dc-5b42-818c-94361e485199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736a2c4-c89c-48db-a104-6303e7e2eee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736a2c4-c89c-48db-a104-6303e7e2eee8.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "d868e3f7-7ebb-544a-9a4c-1007fdb21dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd36b274-5b76-44ec-8d62-069b08debe89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd36b274-5b76-44ec-8d62-069b08debe89.jpg?1",
             "name": "Rakka Mar",
             "text": "Haste\n{R}, {T}: Create a 3/1 red Elemental creature token with haste.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "19e15b36-d9e6-52d1-a43e-71185a2bf2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4020485e-aacc-45dc-bdc0-9f70e35b88b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4020485e-aacc-45dc-bdc0-9f70e35b88b2.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "c4a8775c-7576-5373-a75d-882d45496158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8e2ef7-fabd-4ae9-8224-5acb3fd7d1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8e2ef7-fabd-4ae9-8224-5acb3fd7d1ae.jpg?1",
             "name": "Rapacious One",
             "text": "Trample\nWhenever Rapacious One deals combat damage to a player, create that many 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -8803,7 +8803,7 @@
         },
         {
             "id": "4f492fc4-d234-562b-ba76-5e1faf41a613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae28c04c-d208-4949-a3ec-7d549f5740c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae28c04c-d208-4949-a3ec-7d549f5740c3.jpg?1",
             "name": "Ravaging Blaze",
             "text": "Ravaging Blaze deals X damage to target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Ravaging Blaze also deals X damage to that creature's controller.",
             "colours": [
@@ -8835,7 +8835,7 @@
         },
         {
             "id": "1ddedc75-a0d4-5c7a-abb7-f182fbdfa965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32668329-2f62-48ed-8da3-3cb0c3692ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32668329-2f62-48ed-8da3-3cb0c3692ed9.jpg?1",
             "name": "Rorix Bladewing",
             "text": "Flying, haste",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "86f0738f-18ba-50b0-a395-b787db1ab38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c979cab-3ae6-43b1-b067-1e5abfc2e2ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c979cab-3ae6-43b1-b067-1e5abfc2e2ed.jpg?1",
             "name": "Savage Beating",
             "text": "Cast this spell only during your turn and only during combat.\nChoose one \u2014\n\u2022 Creatures you control gain double strike until end of turn.\n\u2022 Untap all creatures you control. After this phase, there is an additional combat phase.\nEntwine {1}{R}",
             "colours": [
@@ -8905,7 +8905,7 @@
         },
         {
             "id": "ae86e80c-c068-56ff-9c03-c065740ea7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37af681-e7a2-48ff-a069-26cb149e5e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37af681-e7a2-48ff-a069-26cb149e5e8e.jpg?1",
             "name": "Scourge of the Throne",
             "text": "Flying\nDethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nWhenever Scourge of the Throne attacks for the first time each turn, if it's attacking the player with the most life or tied for most life, untap all attacking creatures. After this phase, there is an additional combat phase.",
             "colours": [
@@ -8941,7 +8941,7 @@
         },
         {
             "id": "a78ed458-a672-5ac0-91ab-237d8025efbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e080dc5-361e-4e0b-b0d6-9ca060edceed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e080dc5-361e-4e0b-b0d6-9ca060edceed.jpg?1",
             "name": "Skyline Despot",
             "text": "Flying\nWhen Skyline Despot enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if you're the monarch, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "55b0ca0d-35f0-55b8-93e0-43d4d593ed9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad077c9-abc7-4296-a5d1-9441aa6c38c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad077c9-abc7-4296-a5d1-9441aa6c38c0.jpg?1",
             "name": "Slice and Dice",
             "text": "Slice and Dice deals 4 damage to each creature.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
             "colours": [
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "41007287-4046-58fb-8d54-4192c8fef4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae922301-181d-4824-802d-e3ba1714cade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae922301-181d-4824-802d-e3ba1714cade.jpg?1",
             "name": "Spikeshot Goblin",
             "text": "{R}, {T}: Spikeshot Goblin deals damage equal to its power to any target.",
             "colours": [
@@ -9042,7 +9042,7 @@
         },
         {
             "id": "6493a3a2-5e66-54ef-9295-fde6e94e1ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c0bea-c956-412a-b30b-9f75207cd493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c0bea-c956-412a-b30b-9f75207cd493.jpg?1",
             "name": "Spitebellows",
             "text": "When Spitebellows leaves the battlefield, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "79aa8e2f-064e-5ebf-9085-07ecd1b8369c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d6d674-40aa-42d7-88b3-f65603ecaa1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d6d674-40aa-42d7-88b3-f65603ecaa1e.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -9112,7 +9112,7 @@
         },
         {
             "id": "94cc5db1-b1fd-5b35-b2f6-faa7d248b5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526d13cb-3616-4ac8-9ac0-04c729d447b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526d13cb-3616-4ac8-9ac0-04c729d447b2.jpg?1",
             "name": "Star of Extinction",
             "text": "Destroy target land. Star of Extinction deals 20 damage to each creature and each planeswalker.",
             "colours": [
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "d8a86c0b-08b1-5a65-ba7e-9524b70a3892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69825b24-f469-4b6a-890b-bfa571c9013b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69825b24-f469-4b6a-890b-bfa571c9013b.jpg?1",
             "name": "Storm-Kiln Artist",
             "text": "Storm-Kiln Artist gets +1/+0 for each artifact you control.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a Treasure token.",
             "colours": [
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "b0a761be-dda2-5cd7-8e5f-393f4935d3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62b97e-e4cd-462d-9ab9-2230ca360c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62b97e-e4cd-462d-9ab9-2230ca360c32.jpg?1",
             "name": "Subira, Tulzidi Caravanner",
             "text": "Haste\n{1}: Another target creature with power 2 or less can't be blocked this turn.\n{1}{R}, {T}, Discard your hand: Until end of turn, whenever a creature you control with power 2 or less deals combat damage to a player, draw a card.",
             "colours": [
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "7caba302-bece-58e9-a986-6a06348e0c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabae267-54fa-4e6d-8f7d-15152fe37397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabae267-54fa-4e6d-8f7d-15152fe37397.jpg?1",
             "name": "Sulfurous Blast",
             "text": "Sulfurous Blast deals 2 damage to each creature and each player. If you cast this spell during your main phase, Sulfurous Blast deals 3 damage to each creature and each player instead.",
             "colours": [
@@ -9252,7 +9252,7 @@
         },
         {
             "id": "db63d06e-4da0-5840-ac9f-da696bd1fb5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808af8d4-1872-466e-a2d2-e73ecef09ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808af8d4-1872-466e-a2d2-e73ecef09ed7.jpg?1",
             "name": "Tempt with Vengeance",
             "text": "Tempting offer \u2014 Create X 1/1 red Elemental creature tokens with haste. Each opponent may create X 1/1 red Elemental creature tokens with haste. For each opponent who does, create X 1/1 red Elemental creature tokens with haste.",
             "colours": [
@@ -9286,7 +9286,7 @@
         },
         {
             "id": "9baa8609-6f2c-57b8-9ea0-8d3d30903a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375bc646-942e-4bf5-9c71-2c5471828e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375bc646-942e-4bf5-9c71-2c5471828e35.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -9318,7 +9318,7 @@
         },
         {
             "id": "20450753-2ebe-5b81-809a-1ffec65453f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5facc43f-f865-45ad-888b-398f6e07b947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5facc43f-f865-45ad-888b-398f6e07b947.jpg?1",
             "name": "Treasure Nabber",
             "text": "Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.",
             "colours": [
@@ -9356,7 +9356,7 @@
         },
         {
             "id": "db2bb2a3-a009-5f56-be6e-0d0fe814ffc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1bd49-e059-401e-b999-63166f9bc1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c1bd49-e059-401e-b999-63166f9bc1fe.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "d90a94c2-0059-5cda-a3e6-388a7a6aa13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afc402-ddc4-4819-bc2a-584a43b9b60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afc402-ddc4-4819-bc2a-584a43b9b60e.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -9427,7 +9427,7 @@
         },
         {
             "id": "ddf1ef4f-61d8-5799-b841-44b916418445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4520cdcc-a10f-4b39-9c6f-ba86f6aa2c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4520cdcc-a10f-4b39-9c6f-ba86f6aa2c87.jpg?1",
             "name": "Zada, Hedron Grinder",
             "text": "Whenever you cast an instant or sorcery spell that targets only Zada, Hedron Grinder, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "8860eb37-5303-5751-8144-fe416ec2e17a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e137a-d9d9-4ba7-89fb-e680ddb2c2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e137a-d9d9-4ba7-89fb-e680ddb2c2d1.jpg?1",
             "name": "Abundant Harvest",
             "text": "Choose land or nonland. Reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9496,7 +9496,7 @@
         },
         {
             "id": "ca2b7746-6988-5c2e-bbe3-675e6b0082b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d48fb-42b5-4aaa-a91c-d35cdb5e41a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d48fb-42b5-4aaa-a91c-d35cdb5e41a3.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -9530,7 +9530,7 @@
         },
         {
             "id": "c66a242e-091c-5dc0-a6c2-f3b4b9d28f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64860ab-9b10-4587-a1db-05b3797df3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64860ab-9b10-4587-a1db-05b3797df3a7.jpg?1",
             "name": "Animal Magnetism",
             "text": "Reveal the top five cards of your library. An opponent chooses a creature card from among them. Put that card onto the battlefield and the rest into your graveyard.",
             "colours": [
@@ -9562,7 +9562,7 @@
         },
         {
             "id": "465133cf-04e8-5af1-bc51-902e76bd07df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6b1fd8-7c0b-4736-a100-cabd82052227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6b1fd8-7c0b-4736-a100-cabd82052227.jpg?1",
             "name": "Arachnogenesis",
             "text": "Create X 1/2 green Spider creature tokens with reach, where X is the number of creatures attacking you. Prevent all combat damage that would be dealt this turn by non-Spider creatures.",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "c6796791-19fa-537c-a5fa-00c5d00322b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b76074c-65ca-40e9-b125-4668d3431820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b76074c-65ca-40e9-b125-4668d3431820.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -9632,7 +9632,7 @@
         },
         {
             "id": "be4ccc29-2e1a-55e6-a4c2-6918dfa38580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe97fbe-a6d6-4e96-8c26-f81bcdf579a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe97fbe-a6d6-4e96-8c26-f81bcdf579a1.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "764674fe-532b-53fe-b080-15bbdfe96041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Beanstalk Giant's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "ead99fc7-12b0-574e-9e11-69f250ccac15",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/dfd6b4bc-70da-4d93-bdf7-78ba176a764f.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "d1504c58-633c-5a33-8327-5e5c830f4916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efe9126-15ba-468e-a15a-7f9cbb779cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efe9126-15ba-468e-a15a-7f9cbb779cf6.jpg?1",
             "name": "Bloodspore Thrinax",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nEach other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on Bloodspore Thrinax.",
             "colours": [
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "973f756e-7248-5f45-b133-bb231f3022f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e5d6f-c050-44d9-8a5c-09c07786b6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e5d6f-c050-44d9-8a5c-09c07786b6ab.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -9808,7 +9808,7 @@
         },
         {
             "id": "01cf163b-b021-59fa-949d-7664c65a01bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b836b0a9-c38b-423a-bf22-c9041acf1952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b836b0a9-c38b-423a-bf22-c9041acf1952.jpg?1",
             "name": "Courage in Crisis",
             "text": "Put a +1/+1 counter on target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "683473e2-ac10-53aa-8d92-09a4d007b14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b17222-db06-41cc-a4d2-aae625cb1929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b17222-db06-41cc-a4d2-aae625cb1929.jpg?1",
             "name": "Crash of Rhino Beetles",
             "text": "Trample\nCrash of Rhino Beetles gets +10/+10 as long as you control ten or more lands.",
             "colours": [
@@ -9874,7 +9874,7 @@
         },
         {
             "id": "3197d177-fc7d-543a-8476-36943b206d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f4435a-8604-45b5-a537-dfdfcb922e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f4435a-8604-45b5-a537-dfdfcb922e16.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -9910,7 +9910,7 @@
         },
         {
             "id": "5140cff1-4e42-5095-a8b6-3436771d0513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a404d9b-02dd-45bc-b3eb-bc28452da22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a404d9b-02dd-45bc-b3eb-bc28452da22e.jpg?1",
             "name": "Crawling Infestation",
             "text": "At the beginning of your upkeep, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nWhenever one or more creature cards are put into your graveyard from anywhere during your turn, create a 1/1 green Insect creature token. This ability triggers only once each turn.",
             "colours": [
@@ -9942,7 +9942,7 @@
         },
         {
             "id": "c436ccd3-bfe1-519e-b766-ec6ee77ab135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d432d17e-052b-4a81-bad8-14babf6e593f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d432d17e-052b-4a81-bad8-14babf6e593f.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach, deathtouch",
             "colours": [
@@ -9976,7 +9976,7 @@
         },
         {
             "id": "acfb59a2-0430-55c6-84bb-fd78dd2e4f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdd8e69-5a71-4933-914e-dfede7b1ac93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdd8e69-5a71-4933-914e-dfede7b1ac93.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -10010,7 +10010,7 @@
         },
         {
             "id": "0ad90a3e-a850-554b-bfb0-e8d06cf9dfe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75918859-c93f-41b4-9ad0-a4a96c389f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75918859-c93f-41b4-9ad0-a4a96c389f0d.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "004ac549-3b39-5821-ad89-8095dd63669e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78075b31-8145-4053-90dd-6a34bd48fa7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78075b31-8145-4053-90dd-6a34bd48fa7c.jpg?1",
             "name": "Entourage of Trest",
             "text": "When Entourage of Trest enters the battlefield, you become the monarch.\nEntourage of Trest can block an additional creature each combat as long as you're the monarch.",
             "colours": [
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "4b565a55-06b2-5d57-a734-6d4a557bd0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39704000-65d3-4d39-849e-a3b617376bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39704000-65d3-4d39-849e-a3b617376bbc.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "f2d7ee8f-f031-5fda-ae70-2ca615da2989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea020a19-2907-4627-8a3b-d481404f5aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea020a19-2907-4627-8a3b-d481404f5aca.jpg?1",
             "name": "Ezuri's Predation",
             "text": "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures.",
             "colours": [
@@ -10151,7 +10151,7 @@
         },
         {
             "id": "7969dd80-f378-535d-8c1e-39f522558687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a8684b-5164-4313-ab3e-4c5b4f52bc7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a8684b-5164-4313-ab3e-4c5b4f52bc7e.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with mana value 6 or greater, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "b5f945c6-379f-5502-995c-6beb3310e3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10d99bf-b2ce-4443-b924-ff0eb8be1033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10d99bf-b2ce-4443-b924-ff0eb8be1033.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -10220,7 +10220,7 @@
         },
         {
             "id": "ea0d6426-7ccd-5e16-9faa-9511777e36a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52311be7-b484-4b14-a091-904c6b0c83d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52311be7-b484-4b14-a091-904c6b0c83d1.jpg?1",
             "name": "Freyalise, Llanowar's Fury",
             "text": "+2: Create a 1/1 green Elf Druid creature token with \"{T}: Add {G}.\"\n\u22122: Destroy target artifact or enchantment.\n\u22126: Draw a card for each green creature you control.\nFreyalise, Llanowar's Fury can be your commander.",
             "colours": [
@@ -10258,7 +10258,7 @@
         },
         {
             "id": "d0fb42b5-cabd-5cb7-8f8b-2ca882b6395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fb92d-6de6-49f5-a204-5bcf577c9640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fb92d-6de6-49f5-a204-5bcf577c9640.jpg?1",
             "name": "Fungal Plots",
             "text": "{1}{G}, Exile a creature card from your graveyard: Create a 1/1 green Saproling creature token.\nSacrifice two Saprolings: You gain 2 life and draw a card.",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "e0a20e88-f4f2-5855-b202-97192e6a5c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54872e72-41dc-4092-8169-ce13498beb30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54872e72-41dc-4092-8169-ce13498beb30.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "3dcc21c0-e898-5fc9-b5f7-9ee0179021b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee47f23a-3ba9-4615-b170-c89d8ab99d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee47f23a-3ba9-4615-b170-c89d8ab99d78.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "Creature spells you cast with power 4 or greater cost {2} less to cast.\nWhenever Goreclaw, Terror of Qal Sisma attacks, each creature you control with power 4 or greater gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -10365,7 +10365,7 @@
         },
         {
             "id": "8e764183-99b2-5032-b78b-b71718414b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6340e0f3-7f9c-4d71-8daf-e1be5505eb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6340e0f3-7f9c-4d71-8daf-e1be5505eb5b.jpg?1",
             "name": "The Great Henge",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\n{T}: Add {G}{G}. You gain 2 life.\nWhenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "61d247fa-9e29-5d63-8d0d-543c88100bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32c67d1-187f-40df-b3b3-6036f5c92834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32c67d1-187f-40df-b3b3-6036f5c92834.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -10435,7 +10435,7 @@
         },
         {
             "id": "4fcbb2ca-213d-5b00-a383-882d2b876ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de399acd-e792-4f4a-8025-434f1080c0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de399acd-e792-4f4a-8025-434f1080c0fc.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -10467,7 +10467,7 @@
         },
         {
             "id": "c8b425bf-c4e9-5b16-920c-e0aefa6c7252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65137-c9d6-4352-b7a0-f3968b167233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65137-c9d6-4352-b7a0-f3968b167233.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "4693bf2c-13c8-54f5-b73a-03a21941296f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995140fa-dc1f-4b75-9cea-079ea03c485f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995140fa-dc1f-4b75-9cea-079ea03c485f.jpg?1",
             "name": "Jade Mage",
             "text": "{2}{G}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -10536,7 +10536,7 @@
         },
         {
             "id": "1f0571cf-6e01-5af8-b4a6-80d6d303bf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c66316-a4cc-43e9-b354-03a34c1b12a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c66316-a4cc-43e9-b354-03a34c1b12a7.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -10575,7 +10575,7 @@
         },
         {
             "id": "e3d1ca10-7a79-53c7-be8e-036082d28142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ababe16b-9359-44cb-81fb-e0b3a42b46bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ababe16b-9359-44cb-81fb-e0b3a42b46bd.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -10611,7 +10611,7 @@
         },
         {
             "id": "4b109ba8-e5bb-5150-9ded-74efc76af3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa828bc7-0f5a-45de-9608-da42dda8f3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa828bc7-0f5a-45de-9608-da42dda8f3f9.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -10646,7 +10646,7 @@
         },
         {
             "id": "b2d35251-6ad6-51eb-93c3-e4f17a4cb850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a368f72-cc88-4f32-aad4-22d92c4d032d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a368f72-cc88-4f32-aad4-22d92c4d032d.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle. (Do this before you draw.)",
             "colours": [
@@ -10681,7 +10681,7 @@
         },
         {
             "id": "49d93c76-d786-55b2-8de3-3b4ad8b1ea78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b726c03-07e8-4a9b-bdac-dc50218626a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b726c03-07e8-4a9b-bdac-dc50218626a3.jpg?1",
             "name": "Lifeblood Hydra",
             "text": "Trample\nLifeblood Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Lifeblood Hydra dies, you gain life and draw cards equal to its power.",
             "colours": [
@@ -10717,7 +10717,7 @@
         },
         {
             "id": "c71b4a1a-aafa-5d6e-8e83-8b4c0197f9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08edd941-5ecc-4015-bd5d-e2eebfbf2ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08edd941-5ecc-4015-bd5d-e2eebfbf2ba6.jpg?1",
             "name": "Loyal Guardian",
             "text": "Trample\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10751,7 +10751,7 @@
         },
         {
             "id": "83305056-aadf-5ea6-b133-08c8b818bb6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5d3eba-e456-47c2-992b-a97ba66e9676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5d3eba-e456-47c2-992b-a97ba66e9676.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -10787,7 +10787,7 @@
         },
         {
             "id": "cee9bc62-848d-5d32-b14e-0bd93a065917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e50ae-39e6-435b-95e7-885f2b314ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e50ae-39e6-435b-95e7-885f2b314ecf.jpg?1",
             "name": "Mowu, Loyal Companion",
             "text": "Vigilance, trample\nIf one or more +1/+1 counters would be put on Mowu, Loyal Companion, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -10823,7 +10823,7 @@
         },
         {
             "id": "08460125-cd86-5631-862b-04f2a6a6e587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60e3465-46ae-486f-8deb-6e2f1ac71a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60e3465-46ae-486f-8deb-6e2f1ac71a1b.jpg?1",
             "name": "Nemata, Grove Guardian",
             "text": "{2}{G}: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Saproling creatures get +1/+1 until end of turn.",
             "colours": [
@@ -10859,7 +10859,7 @@
         },
         {
             "id": "3fa38898-63f8-5b84-ad85-860285d33f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8e59c-edf1-4b4d-982d-3c891e7b96ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8e59c-edf1-4b4d-982d-3c891e7b96ba.jpg?1",
             "name": "Obscuring Haze",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nPrevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -10894,7 +10894,7 @@
         },
         {
             "id": "b24cc349-a11b-5a42-8d5c-4d38a6acd7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2fbeb1-6446-48ca-afe1-d1869a36e389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2fbeb1-6446-48ca-afe1-d1869a36e389.jpg?1",
             "name": "Ohran Frostfang",
             "text": "Attacking creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -10933,7 +10933,7 @@
         },
         {
             "id": "f737f745-8bb8-5d89-baac-31d45ff83213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cab3-da50-4561-8797-cd179af39216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cab3-da50-4561-8797-cd179af39216.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "2ea9fcc8-964b-570a-b356-c95e5ab442c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7938b15-7585-43fb-897f-a57e820665b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7938b15-7585-43fb-897f-a57e820665b3.jpg?1",
             "name": "Oviya Pashiri, Sage Lifecrafter",
             "text": "{2}{G}, {T}: Create a 1/1 colorless Servo artifact creature token.\n{4}{G}, {T}: Create an X/X colorless Construct artifact creature token, where X is the number of creatures you control.",
             "colours": [
@@ -11010,7 +11010,7 @@
         },
         {
             "id": "7482a379-28c9-5682-b2a5-561eee54cbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8215686-bf19-4090-87c1-dd4f691f2ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8215686-bf19-4090-87c1-dd4f691f2ae7.jpg?1",
             "name": "Pollenbright Druid",
             "text": "When Pollenbright Druid enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11045,7 +11045,7 @@
         },
         {
             "id": "d1da6370-bbd1-582c-9e50-578c3b6d3bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2078908d-63ab-47f3-b01c-7c84e3f578b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2078908d-63ab-47f3-b01c-7c84e3f578b8.jpg?1",
             "name": "Predatory Rampage",
             "text": "Creatures you control get +3/+3 until end of turn. Each creature your opponents control blocks this turn if able.",
             "colours": [
@@ -11077,7 +11077,7 @@
         },
         {
             "id": "5f20ff8f-cf45-5b73-bb8b-aec8fd31a25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44063a90-e4cf-4bcd-a128-792de15371a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44063a90-e4cf-4bcd-a128-792de15371a7.jpg?1",
             "name": "Ram Through",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "116c8868-64c6-5e34-aaef-6723adc34110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961e92f3-2e58-49ad-9bd6-4e3c58dd26dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961e92f3-2e58-49ad-9bd6-4e3c58dd26dc.jpg?1",
             "name": "Rampaging Brontodon",
             "text": "Trample\nWhenever Rampaging Brontodon attacks, it gets +1/+1 until end of turn for each land you control.",
             "colours": [
@@ -11143,7 +11143,7 @@
         },
         {
             "id": "4ad2df37-9b42-5f40-ac87-a4dd89634c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9510e5ff-901a-42c9-b11f-5f71e2475504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9510e5ff-901a-42c9-b11f-5f71e2475504.jpg?1",
             "name": "Regal Behemoth",
             "text": "Trample\nWhen Regal Behemoth enters the battlefield, you become the monarch.\nWhenever you tap a land for mana while you're the monarch, add an additional one mana of any color.",
             "colours": [
@@ -11180,7 +11180,7 @@
         },
         {
             "id": "39e46a1b-73e4-5444-a399-cf010039abc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f4aecc-b728-4960-8131-1e5aa6c3c030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f4aecc-b728-4960-8131-1e5aa6c3c030.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -11217,7 +11217,7 @@
         },
         {
             "id": "df9b51de-5b1e-5f32-a845-acd1eb4b28c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e13e1c2-376f-4ce6-bdc0-e000e99e5b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e13e1c2-376f-4ce6-bdc0-e000e99e5b9c.jpg?1",
             "name": "Rot Shambler",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Rot Shambler.",
             "colours": [
@@ -11251,7 +11251,7 @@
         },
         {
             "id": "a479ed18-533c-547e-97db-c5ca433f5083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdb5f5-cd6e-47cd-b83d-ff71b00c369e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdb5f5-cd6e-47cd-b83d-ff71b00c369e.jpg?1",
             "name": "Sakiko, Mother of Summer",
             "text": "Whenever a creature you control deals combat damage to a player, add that much {G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -11290,7 +11290,7 @@
         },
         {
             "id": "c0586aac-4cc7-5627-a191-42a26732210d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d711cb2-4f34-4792-90d7-2be5d329a347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d711cb2-4f34-4792-90d7-2be5d329a347.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -11331,7 +11331,7 @@
         },
         {
             "id": "1df6b182-e3c7-5010-b4a8-9e5f9a207cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e12f0e-ab41-4413-8b88-9bde907fab22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e12f0e-ab41-4413-8b88-9bde907fab22.jpg?1",
             "name": "Skyshroud Claim",
             "text": "Search your library for up to two Forest cards, put them onto the battlefield, then shuffle.",
             "colours": [
@@ -11363,7 +11363,7 @@
         },
         {
             "id": "23d4d870-6d36-5e82-acbd-e17aa80605db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff737c53-9489-4a8c-8fa1-5d108222ae3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff737c53-9489-4a8c-8fa1-5d108222ae3f.jpg?1",
             "name": "Skysnare Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -11397,7 +11397,7 @@
         },
         {
             "id": "4f1e16d5-95ef-5b80-a92c-3abb5b30febc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad012c2-e6d9-448f-b204-14a2c55ff74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad012c2-e6d9-448f-b204-14a2c55ff74f.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -11429,7 +11429,7 @@
         },
         {
             "id": "c769a5e3-03db-5606-a324-e558903190e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/161e66e3-0339-495c-bd06-0a799a254906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/161e66e3-0339-495c-bd06-0a799a254906.jpg?1",
             "name": "Song of the Dryads",
             "text": "Enchant permanent\nEnchanted permanent is a colorless Forest land.",
             "colours": [
@@ -11465,7 +11465,7 @@
         },
         {
             "id": "ef3ad082-8864-5f72-bb4b-332312cfe328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3451dd0f-8cea-409f-8d56-f13e6aa424f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3451dd0f-8cea-409f-8d56-f13e6aa424f6.jpg?1",
             "name": "Stonehoof Chieftain",
             "text": "Trample, indestructible\nWhenever another creature you control attacks, it gains trample and indestructible until end of turn.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "154ad801-002d-5091-9bd7-465695a70542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71590b6f-9f38-4c5d-8431-50e5f02f8c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71590b6f-9f38-4c5d-8431-50e5f02f8c93.jpg?1",
             "name": "Surrak, the Hunt Caller",
             "text": "Formidable \u2014 At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn.",
             "colours": [
@@ -11539,7 +11539,7 @@
         },
         {
             "id": "429c70b8-258f-549a-b749-a8ceb349407a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df359b98-9f8f-4f32-82c6-f10ca0f81032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df359b98-9f8f-4f32-82c6-f10ca0f81032.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014\n\u2022 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n\u2022 Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "247b8e5f-1907-5628-b36b-df3a7a73c5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1165a2-e697-4ceb-91ba-693a3a006f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1165a2-e697-4ceb-91ba-693a3a006f27.jpg?1",
             "name": "Tuskguard Captain",
             "text": "Outlast {G} ({G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -11609,7 +11609,7 @@
         },
         {
             "id": "9f7a0bab-8f82-5bbe-a670-c55bea5908c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f3b28-ea20-4bad-8fab-5996e0fc1b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f3b28-ea20-4bad-8fab-5996e0fc1b62.jpg?1",
             "name": "Verdant Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Return target permanent card from your graveyard to your hand.\n\u2022 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -11643,7 +11643,7 @@
         },
         {
             "id": "9396d50f-8ad5-5e75-92f0-cc9665807518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b31eb-a9cd-44d2-8755-9323bb4de2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b31eb-a9cd-44d2-8755-9323bb4de2f0.jpg?1",
             "name": "Verdeloth the Ancient",
             "text": "Kicker {X} (You may pay an additional {X} as you cast this spell.)\nSaproling creatures and other Treefolk creatures get +1/+1.\nWhen Verdeloth the Ancient enters the battlefield, if it was kicked, create X 1/1 green Saproling creature tokens.",
             "colours": [
@@ -11679,7 +11679,7 @@
         },
         {
             "id": "4883e2e1-8725-5d07-9667-eb13bbbfb01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b4ee8-2457-4db4-a8fa-c87e2db0c265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b4ee8-2457-4db4-a8fa-c87e2db0c265.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.",
             "colours": [
@@ -11715,7 +11715,7 @@
         },
         {
             "id": "e2350dfd-0b79-5125-a9c9-e4d7ecd3afb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb35e40f-bbcf-4e2b-9603-7719c74dc076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb35e40f-bbcf-4e2b-9603-7719c74dc076.jpg?1",
             "name": "Wildwood Scourge",
             "text": "Wildwood Scourge enters the battlefield with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on Wildwood Scourge.",
             "colours": [
@@ -11749,7 +11749,7 @@
         },
         {
             "id": "d2f54503-d0eb-5a45-853a-91020c3183a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9808d-1d47-417d-bba8-06694a83d88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9808d-1d47-417d-bba8-06694a83d88e.jpg?1",
             "name": "Yedora, Grave Gardener",
             "text": "Whenever another nontoken creature you control dies, you may return it to the battlefield face down under its owner's control. It's a Forest land. (It has no other types or abilities.)",
             "colours": [
@@ -11786,7 +11786,7 @@
         },
         {
             "id": "418ce8bd-a1c3-5344-8006-fbdf22de24b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e3a130-deeb-4bf4-a1f6-9219c3d8c373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e3a130-deeb-4bf4-a1f6-9219c3d8c373.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "{2}{G}, {T}, Put a verse counter on Yisan, the Wanderer Bard: Search your library for a creature card with mana value equal to the number of verse counters on Yisan, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -11826,7 +11826,7 @@
         },
         {
             "id": "89dcd821-c2ab-529d-9848-f889eaa69e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa135775-abcd-4a21-abb7-3aeb5a39df28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa135775-abcd-4a21-abb7-3aeb5a39df28.jpg?1",
             "name": "Akiri, Fearless Voyager",
             "text": "Whenever you attack a player with one or more equipped creatures, draw a card.\n{W}: You may unattach an Equipment from a creature you control. If you do, tap that creature and it gains indestructible until end of turn.",
             "colours": [
@@ -11865,7 +11865,7 @@
         },
         {
             "id": "dd959064-26ef-5a88-a335-249e4adc76c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216d7afe-3acf-4293-b474-8b27730cdefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216d7afe-3acf-4293-b474-8b27730cdefb.jpg?1",
             "name": "Aryel, Knight of Windgrace",
             "text": "Vigilance\n{2}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.\n{B}, {T}, Tap X untapped Knights you control: Destroy target creature with power X or less.",
             "colours": [
@@ -11904,7 +11904,7 @@
         },
         {
             "id": "39e21815-1140-5718-9391-86c4e601989b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d938197-2557-421a-985e-5add932d4bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d938197-2557-421a-985e-5add932d4bac.jpg?1",
             "name": "Experiment Kraj",
             "text": "Experiment Kraj has all activated abilities of each other creature with a +1/+1 counter on it.\n{T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -11945,7 +11945,7 @@
         },
         {
             "id": "89c6ba4d-0bd0-5b51-bf0c-42b63d74dfeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40ba800-4423-4fd9-94c7-a9019c857af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40ba800-4423-4fd9-94c7-a9019c857af6.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -11986,7 +11986,7 @@
         },
         {
             "id": "83dd3aef-7a87-576b-ad74-14ef3e14de10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7f8f3-140d-4dd0-aacc-b81b2b93eb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc7f8f3-140d-4dd0-aacc-b81b2b93eb67.jpg?1",
             "name": "Hamza, Guardian of Arashin",
             "text": "This spell costs {1} less to cast for each creature you control with a +1/+1 counter on it.\nCreature spells you cast cost {1} less to cast for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -12025,7 +12025,7 @@
         },
         {
             "id": "cbe4b3ee-2fe0-52e5-834c-f195594f7ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b41982-6e79-4e04-a0f3-d985da92e8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b41982-6e79-4e04-a0f3-d985da92e8c1.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -12066,7 +12066,7 @@
         },
         {
             "id": "c42518fc-ab78-5c5f-8473-40ae6cd74b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb929c-1b8d-4d1d-aa69-ac6189cd7ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb929c-1b8d-4d1d-aa69-ac6189cd7ebf.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -12105,7 +12105,7 @@
         },
         {
             "id": "72e81d7b-1547-5a73-b895-1eda35a1e378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d128887-13fb-4e54-90f2-d3c46b7b29d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d128887-13fb-4e54-90f2-d3c46b7b29d7.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -12148,7 +12148,7 @@
         },
         {
             "id": "f3f719fd-4771-5651-855e-0aeb3460a548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb034c8-bae0-4f66-98f1-1b3cdc072f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb034c8-bae0-4f66-98f1-1b3cdc072f17.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -12192,7 +12192,7 @@
         },
         {
             "id": "dc12a595-46ae-5bc5-aecb-82961a562888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c58b3-180f-420b-b091-114fda000360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c58b3-180f-420b-b091-114fda000360.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -12235,7 +12235,7 @@
         },
         {
             "id": "6edbda1a-7894-5dcd-88d5-126ed55fe657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66011fe8-8c5d-4990-a324-5839515dcacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66011fe8-8c5d-4990-a324-5839515dcacb.jpg?1",
             "name": "Melek, Izzet Paragon",
             "text": "Play with the top card of your library revealed.\nYou may cast instant and sorcery spells from the top of your library.\nWhenever you cast an instant or sorcery spell from your library, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -12274,7 +12274,7 @@
         },
         {
             "id": "04d63900-ba1a-5237-a697-1f18d1a164bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d627b3-a6d0-4f5f-b7c2-351a07318966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d627b3-a6d0-4f5f-b7c2-351a07318966.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "Whenever another creature you control dies, you get an experience counter.\nAt the beginning of your end step, choose target creature card in your graveyard. If that card's mana value is less than or equal to the number of experience counters you have, return it to the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -12316,7 +12316,7 @@
         },
         {
             "id": "11fb80e5-d5d8-5b9f-bd9f-2500b6203846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db44fe95-6a32-4d6f-a32f-72491381f495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db44fe95-6a32-4d6f-a32f-72491381f495.jpg?1",
             "name": "Mirri, Weatherlight Duelist",
             "text": "First strike\nWhenever Mirri, Weatherlight Duelist attacks, each opponent can't block with more than one creature this combat.\nAs long as Mirri, Weatherlight Duelist is tapped, no more than one creature can attack you each combat.",
             "colours": [
@@ -12357,7 +12357,7 @@
         },
         {
             "id": "f644a4c4-98bd-556f-b2bd-e7185cb0db6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f949d0-41a0-4491-9057-bfb2bb20bdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f949d0-41a0-4491-9057-bfb2bb20bdb3.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -12398,7 +12398,7 @@
         },
         {
             "id": "0312d1b7-934a-5074-9154-27aa75df52f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afdc65d-3c97-47af-83fa-df340389802e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afdc65d-3c97-47af-83fa-df340389802e.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nWhenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "773d700c-d34f-502d-ac8e-ebdb066a84a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567697db-8d47-404f-b0da-b00409431f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567697db-8d47-404f-b0da-b00409431f28.jpg?1",
             "name": "Queen Marchesa",
             "text": "Deathtouch, haste\nWhen Queen Marchesa enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with deathtouch and haste.",
             "colours": [
@@ -12484,7 +12484,7 @@
         },
         {
             "id": "ab8f58fa-6f9d-5661-8238-f54a6892cb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c681e33b-3d60-4aaa-8186-51866d8b79d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c681e33b-3d60-4aaa-8186-51866d8b79d1.jpg?1",
             "name": "Raff Capashen, Ship's Mage",
             "text": "Flash\nFlying\nYou may cast historic spells as though they had flash. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -12523,7 +12523,7 @@
         },
         {
             "id": "f3bbc8e8-7571-5439-9482-4370e7a05e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdd967d-b364-47ad-a1c2-49b155f72c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdd967d-b364-47ad-a1c2-49b155f72c5b.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "fc30a1d0-e861-5e13-9956-195eb16268f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f414ef-84a2-4694-9e98-51bee4576c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f414ef-84a2-4694-9e98-51bee4576c84.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -12606,7 +12606,7 @@
         },
         {
             "id": "13e88c76-9ab7-5da7-939b-6812bc95530b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873dbe5-d95a-4ecb-ac0a-8dc6c40f3576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873dbe5-d95a-4ecb-ac0a-8dc6c40f3576.jpg?1",
             "name": "Sek'Kuar, Deathkeeper",
             "text": "Whenever another nontoken creature you control dies, create a 3/1 black and red Graveborn creature token with haste.",
             "colours": [
@@ -12649,7 +12649,7 @@
         },
         {
             "id": "3324a005-1119-5195-afa4-0023a257cfd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8e44d4-db67-4bf4-97c0-ffe6a0eb2954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8e44d4-db67-4bf4-97c0-ffe6a0eb2954.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -12692,7 +12692,7 @@
         },
         {
             "id": "9b955b3f-2232-5165-841c-cacd3f47336d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb12173d-3afb-4e8b-b612-fa7737a8c6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb12173d-3afb-4e8b-b612-fa7737a8c6c2.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -12732,7 +12732,7 @@
         },
         {
             "id": "ce94e4f5-fab5-5c69-a14b-72f58755299b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6336b0af-3c7d-4b8e-a0e7-d4d15078fc04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6336b0af-3c7d-4b8e-a0e7-d4d15078fc04.jpg?1",
             "name": "Taigam, Sidisi's Hand",
             "text": "Skip your draw step.\nAt the beginning of your upkeep, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n{B}, {T}, Exile X cards from your graveyard: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -12771,7 +12771,7 @@
         },
         {
             "id": "ff4a112d-29cc-59e3-88ce-a426ea7af4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd82bff9-8061-48c0-a7c3-fee17acee22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd82bff9-8061-48c0-a7c3-fee17acee22a.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -12812,7 +12812,7 @@
         },
         {
             "id": "36a9af11-0631-52a3-9ae6-921feca3fca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd14f1ce-7fcd-485c-b7ca-01c5b45fdc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd14f1ce-7fcd-485c-b7ca-01c5b45fdc01.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -12854,7 +12854,7 @@
         },
         {
             "id": "9321d260-7794-577f-868b-6d98ce6a337d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146e10c-3104-442d-9383-0f670960180d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146e10c-3104-442d-9383-0f670960180d.jpg?1",
             "name": "Tuya Bearclaw",
             "text": "Whenever Tuya Bearclaw attacks, it gets +X/+X until end of turn, where X is the greatest power among other creatures you control.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "fd8576b0-4ebe-58f3-8f01-93f15f751f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d42b35-844f-4a64-9981-c6118d45e826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d42b35-844f-4a64-9981-c6118d45e826.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -12942,7 +12942,7 @@
         },
         {
             "id": "dc56dd69-b320-5f8d-ae34-073470c506da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91316746-ec2b-4c1a-b9c4-a870d6318c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91316746-ec2b-4c1a-b9c4-a870d6318c33.jpg?1",
             "name": "Xantcha, Sleeper Agent",
             "text": "Xantcha, Sleeper Agent enters the battlefield under the control of an opponent of your choice.\nXantcha attacks each combat if able and can't attack its owner or planeswalkers its owner controls.\n{3}: Xantcha's controller loses 2 life and you draw a card. Any player may activate this ability.",
             "colours": [
@@ -12983,7 +12983,7 @@
         },
         {
             "id": "6ff5fbfc-b048-5bb3-a1ae-af219563ec5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee11c9-fa23-4863-8a18-25a008f18da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee11c9-fa23-4863-8a18-25a008f18da5.jpg?1",
             "name": "Yennett, Cryptic Sovereign",
             "text": "Flying, vigilance, menace\nWhenever Yennett, Cryptic Sovereign attacks, reveal the top card of your library. You may cast it without paying its mana cost if its mana value is odd. If you don't cast it, draw a card.",
             "colours": [
@@ -13025,7 +13025,7 @@
         },
         {
             "id": "3d7a32d2-75fb-5bb3-9e6e-7704dd6655bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9be3e0-076c-4703-9750-2a6b0a178bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9be3e0-076c-4703-9750-2a6b0a178bc9.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's mana value.",
             "colours": [
@@ -13067,7 +13067,7 @@
         },
         {
             "id": "db36370b-bfc2-5e54-9619-f39e72461825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9224660-d547-4373-8493-42ffb364ee0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9224660-d547-4373-8493-42ffb364ee0b.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -13111,7 +13111,7 @@
         },
         {
             "id": "ca5e7e6d-850d-540a-a747-9867dda8706d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4e130-df21-4491-97c3-1b643d7e57ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4e130-df21-4491-97c3-1b643d7e57ef.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "Trample\nLethal damage dealt to creatures you control is determined by their power rather than their toughness.",
             "colours": [
@@ -13151,7 +13151,7 @@
         },
         {
             "id": "a40e0401-d3f5-5dc4-b645-a3f02c4dd4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b83c-4459-41b5-a001-d15a1c9ddf23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b83c-4459-41b5-a001-d15a1c9ddf23.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "de6eb217-97cb-51cb-b901-471a9a3be4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f7157-a375-499c-92c7-d47d2e95dbad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f7157-a375-499c-92c7-d47d2e95dbad.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add {C}{C}.",
             "colours": [],
@@ -13209,7 +13209,7 @@
         },
         {
             "id": "851e14b7-66a9-5a53-8181-71730e1f7941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b22076-b04e-4d65-9d9c-d3e4c7a3cf1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b22076-b04e-4d65-9d9c-d3e4c7a3cf1c.jpg?1",
             "name": "Assault Suit",
             "text": "Equipped creature gets +2/+2, has haste, can't attack you or planeswalkers you control, and can't be sacrificed.\nAt the beginning of each opponent's upkeep, you may have that player gain control of equipped creature until end of turn. If you do, untap it.\nEquip {3}",
             "colours": [],
@@ -13239,7 +13239,7 @@
         },
         {
             "id": "4f2315ad-cb56-54fe-9c7b-d78fc7a9a004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89486719-4aba-4465-986b-fecbe4d409a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89486719-4aba-4465-986b-fecbe4d409a1.jpg?1",
             "name": "Bonder's Ornament",
             "text": "{T}: Add one mana of any color.\n{4}, {T}: Each player who controls a permanent named Bonder's Ornament draws a card.",
             "colours": [],
@@ -13267,7 +13267,7 @@
         },
         {
             "id": "614368b1-f583-540d-93c9-583a6b017c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe710f-5e92-4be9-9f2f-363af767a91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe710f-5e92-4be9-9f2f-363af767a91e.jpg?1",
             "name": "Boompile",
             "text": "{T}: Flip a coin. If you win the flip, destroy all nonland permanents.",
             "colours": [],
@@ -13297,7 +13297,7 @@
         },
         {
             "id": "100b3b9b-9de2-54ff-a388-89918ae874fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f4448c-a946-45a3-9bce-0d82105e7cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f4448c-a946-45a3-9bce-0d82105e7cc1.jpg?1",
             "name": "Brass Knuckles",
             "text": "When you cast this spell, copy it. (The copy becomes a token.)\nEquipped creature has double strike as long as two or more Equipment are attached to it.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13327,7 +13327,7 @@
         },
         {
             "id": "532c9846-da35-53e2-961f-a6b55df26883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a97d2d-a5b7-4424-a703-c43ed887c888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a97d2d-a5b7-4424-a703-c43ed887c888.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -13358,7 +13358,7 @@
         },
         {
             "id": "1ab353e3-b780-52af-bf57-849707066c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b64d10-c012-4370-b475-755c4025a348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b64d10-c012-4370-b475-755c4025a348.jpg?1",
             "name": "Campfire",
             "text": "{1}, {T}: You gain 2 life.\n{2}, {T}, Exile Campfire: Put all commanders you own from the command zone and from your graveyard into your hand. Then shuffle your graveyard into your library.",
             "colours": [],
@@ -13386,7 +13386,7 @@
         },
         {
             "id": "5b2ad845-619b-56fb-bd0d-1d021f242c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6548a30-577a-47e7-aa6e-8f6db1f7b78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6548a30-577a-47e7-aa6e-8f6db1f7b78e.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -13419,7 +13419,7 @@
         },
         {
             "id": "5b1941f4-12b5-51d2-b51e-ce26a140e6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3969c209-09f3-4429-91c1-d5aeab9de2ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3969c209-09f3-4429-91c1-d5aeab9de2ec.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
             "colours": [],
@@ -13449,7 +13449,7 @@
         },
         {
             "id": "ae8b4a98-e59d-5662-b5b7-91a582467ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f432741-54b3-499e-9809-5a670433a297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f432741-54b3-499e-9809-5a670433a297.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -13479,7 +13479,7 @@
         },
         {
             "id": "5531d239-ee22-59b8-8afa-eee14739bdf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc439e0-59a8-4eb3-ac54-ab908c4ec50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc439e0-59a8-4eb3-ac54-ab908c4ec50b.jpg?1",
             "name": "Darksteel Ingot",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.)\n{T}: Add one mana of any color.",
             "colours": [],
@@ -13507,7 +13507,7 @@
         },
         {
             "id": "afd1bf73-4125-5d06-860a-60d823074d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba578d94-6f49-45f5-b6e2-1090c05acc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba578d94-6f49-45f5-b6e2-1090c05acc4a.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -13537,7 +13537,7 @@
         },
         {
             "id": "f10f1bd7-c102-50c6-acce-d4cee5d16797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be120499-fe2f-4c21-982c-566d0dbbddff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be120499-fe2f-4c21-982c-566d0dbbddff.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13567,7 +13567,7 @@
         },
         {
             "id": "5cf977d2-fd09-5d3d-829c-ca01acecae4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f050a675-c6a2-4d0d-bac6-1d8c51ecf824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f050a675-c6a2-4d0d-bac6-1d8c51ecf824.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint \u2014 When Extraplanar Lens enters the battlefield, you may exile target land you control.\nWhenever a land with the same name as the exiled card is tapped for mana, its controller adds one mana of any type that land produced.",
             "colours": [],
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "8bd5b29e-3f81-5c4a-b37c-366fa7cc5adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad9cac1-8b2b-42d6-9f0b-d679689ba862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad9cac1-8b2b-42d6-9f0b-d679689ba862.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -13628,7 +13628,7 @@
         },
         {
             "id": "bc25aa62-7f9b-5beb-b5c0-30b2bcbef444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165eee28-202d-4543-87b4-b9d39e8c8472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165eee28-202d-4543-87b4-b9d39e8c8472.jpg?1",
             "name": "Firemind Vessel",
             "text": "Firemind Vessel enters the battlefield tapped.\n{T}: Add two mana of different colors.",
             "colours": [],
@@ -13656,7 +13656,7 @@
         },
         {
             "id": "0cca8b99-5566-5808-ba2c-848fabda4f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2570fb88-358f-4f36-87e3-d8375824d126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2570fb88-358f-4f36-87e3-d8375824d126.jpg?1",
             "name": "Forebear's Blade",
             "text": "Equipped creature gets +3/+0 and has vigilance and trample.\nWhenever equipped creature dies, attach Forebear's Blade to target creature you control.\nEquip {3}",
             "colours": [],
@@ -13686,7 +13686,7 @@
         },
         {
             "id": "8775ed15-5c2f-50a6-bc42-d8a32f18974d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16debeb1-fb2b-4172-b6da-726416d4fb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16debeb1-fb2b-4172-b6da-726416d4fb38.jpg?1",
             "name": "Foundry Inspector",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [],
@@ -13717,7 +13717,7 @@
         },
         {
             "id": "e40c59ea-5df8-5f4d-a5cc-6636b7416ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa912283-c28e-4594-aca9-21d82d8cf006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa912283-c28e-4594-aca9-21d82d8cf006.jpg?1",
             "name": "Geode Golem",
             "text": "Trample\nWhenever Geode Golem deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost. (You still pay any additional costs.)",
             "colours": [],
@@ -13748,7 +13748,7 @@
         },
         {
             "id": "442e2f90-894b-5bdf-848c-1258686ae523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7554e-be86-4d0f-8e80-0ccb4c2cd2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7554e-be86-4d0f-8e80-0ccb4c2cd2f1.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -13778,7 +13778,7 @@
         },
         {
             "id": "ebdce1cd-a426-5a33-8f36-6ea2c57d5593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8ac1-f40d-423e-a0b3-0a8e236a6c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8ac1-f40d-423e-a0b3-0a8e236a6c1e.jpg?1",
             "name": "Hammer of Nazahn",
             "text": "Whenever Hammer of Nazahn or another Equipment enters the battlefield under your control, you may attach that Equipment to target creature you control.\nEquipped creature gets +2/+0 and has indestructible.\nEquip {4}",
             "colours": [],
@@ -13812,7 +13812,7 @@
         },
         {
             "id": "ccbd603f-ac26-5584-bf52-7f4abdea564a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abffd0a3-ea7a-43cf-b92d-d9f436bef58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abffd0a3-ea7a-43cf-b92d-d9f436bef58e.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13842,7 +13842,7 @@
         },
         {
             "id": "c54cdd5f-f61e-5dd0-a95f-98decf46d406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a42c6-fc98-4993-891c-7ac6a0735543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a42c6-fc98-4993-891c-7ac6a0735543.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -13872,7 +13872,7 @@
         },
         {
             "id": "32494c60-5702-5097-9901-510a201c40a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da612ec-983b-4a7b-8d52-b853a4c565de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da612ec-983b-4a7b-8d52-b853a4c565de.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4}",
             "colours": [],
@@ -13902,7 +13902,7 @@
         },
         {
             "id": "71cd4003-c6bf-52f9-932c-f78edec24e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8235349d-0f92-4af4-ab8d-2f645fe32934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8235349d-0f92-4af4-ab8d-2f645fe32934.jpg?1",
             "name": "Idol of Oblivion",
             "text": "{T}: Draw a card. Activate only if you created a token this turn.\n{8}, {T}, Sacrifice Idol of Oblivion: Create a 10/10 colorless Eldrazi creature token.",
             "colours": [],
@@ -13932,7 +13932,7 @@
         },
         {
             "id": "f6033118-a5a1-5411-99de-fc8690d5d02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f68d45-a6cd-437d-a4b1-2787891f0128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f68d45-a6cd-437d-a4b1-2787891f0128.jpg?1",
             "name": "The Immortal Sun",
             "text": "Players can't activate planeswalkers' loyalty abilities.\nAt the beginning of your draw step, draw an additional card.\nSpells you cast cost {1} less to cast.\nCreatures you control get +1/+1.",
             "colours": [],
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "53c83162-2fc7-5ff6-a787-be6a629e0403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18446a7-68db-4a0a-9f36-ddf840c3e2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18446a7-68db-4a0a-9f36-ddf840c3e2c8.jpg?1",
             "name": "Inspiring Statuary",
             "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -13994,7 +13994,7 @@
         },
         {
             "id": "2580d6a1-4ae0-5535-a199-92c23f343169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58662f26-dd75-45a0-86cf-5949fbb76210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58662f26-dd75-45a0-86cf-5949fbb76210.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14024,7 +14024,7 @@
         },
         {
             "id": "6745f76e-60bb-5d27-9f55-85522c1846c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7183700-6941-4a3d-a581-4f33bea795e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7183700-6941-4a3d-a581-4f33bea795e9.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -14056,7 +14056,7 @@
         },
         {
             "id": "e232640e-bc27-51a6-a298-9d5f3004ed09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae094ace-1760-4bdd-a513-04616fb0deeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae094ace-1760-4bdd-a513-04616fb0deeb.jpg?1",
             "name": "Letter of Acceptance",
             "text": "{T}: Add one mana of any color.\n{2}, {T}, Sacrifice Letter of Acceptance: Draw a card.",
             "colours": [],
@@ -14084,7 +14084,7 @@
         },
         {
             "id": "3114c290-1673-526d-8675-d665e77a38d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331013f6-976a-4dac-9939-1006e474e108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331013f6-976a-4dac-9939-1006e474e108.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -14114,7 +14114,7 @@
         },
         {
             "id": "c780ee62-83c6-5dbe-819c-9014c3205687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7af704-a770-4f90-8fe8-a45457785a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7af704-a770-4f90-8fe8-a45457785a35.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -14145,7 +14145,7 @@
         },
         {
             "id": "1e88d648-6e90-582d-8fe3-f18b43a6b527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ba43d1-e879-40e0-b49c-e009deb7e3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ba43d1-e879-40e0-b49c-e009deb7e3aa.jpg?1",
             "name": "Myr Sire",
             "text": "When Myr Sire dies, create a 1/1 colorless Phyrexian Myr artifact creature token.",
             "colours": [],
@@ -14177,7 +14177,7 @@
         },
         {
             "id": "aa3bc273-6781-51e4-9b97-2293fc57a02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f256e868-92b5-4506-b409-9e1190b049dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f256e868-92b5-4506-b409-9e1190b049dd.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "db019a90-80d6-57c6-9bd0-e3992dda3089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc25b-f73c-431c-b173-adcd65c5d491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc25b-f73c-431c-b173-adcd65c5d491.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "c5acc23e-cbdd-5798-bfa6-e937e4fca51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8768a5-eba6-4585-a59b-19d1036cbfc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8768a5-eba6-4585-a59b-19d1036cbfc0.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -14266,7 +14266,7 @@
         },
         {
             "id": "704c28ae-2939-5c29-b1cf-3176e2dd0804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbd46d2-b4f2-48d0-a1c4-87ea625ec8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbd46d2-b4f2-48d0-a1c4-87ea625ec8bc.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "39f2878d-fe47-570b-8db9-8dbe01cdc843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2feac9d-560e-4854-82ed-78a3088c3788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2feac9d-560e-4854-82ed-78a3088c3788.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14324,7 +14324,7 @@
         },
         {
             "id": "19308bb9-982e-54b8-a791-550e8f409a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7333ea3-2c98-405a-a5cc-eecba9b14a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7333ea3-2c98-405a-a5cc-eecba9b14a00.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "768425b7-a38d-5c4b-9673-b6e45aa26118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed34e8de-d63a-4e4f-b9d4-80f66bb20641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed34e8de-d63a-4e4f-b9d4-80f66bb20641.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -14385,7 +14385,7 @@
         },
         {
             "id": "d6c95194-8005-5b27-9655-494ae3eb6949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fc07f5-170f-43a1-9f65-a3f702655226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fc07f5-170f-43a1-9f65-a3f702655226.jpg?1",
             "name": "Scytheclaw",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, that player loses half their life, rounded up.\nEquip {3}",
             "colours": [],
@@ -14417,7 +14417,7 @@
         },
         {
             "id": "48f9b3d5-706b-56e8-ac84-c2323c36ddef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f61479b-05e1-4c89-bf11-b79c06ace5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f61479b-05e1-4c89-bf11-b79c06ace5e2.jpg?1",
             "name": "Shimmer Myr",
             "text": "Flash\nYou may cast artifact spells as though they had flash.",
             "colours": [],
@@ -14448,7 +14448,7 @@
         },
         {
             "id": "01b47f91-ffff-5954-af7a-add84b7c513c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ca0b66-a000-4483-b916-f5b89e710244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ca0b66-a000-4483-b916-f5b89e710244.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -14478,7 +14478,7 @@
         },
         {
             "id": "c764bed0-10c2-5b37-9b4c-975b4ab1b534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542eed4a-8a15-4829-8bc3-5637574e1398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542eed4a-8a15-4829-8bc3-5637574e1398.jpg?1",
             "name": "Spectral Searchlight",
             "text": "{T}: Choose a player. That player adds one mana of any color they choose.",
             "colours": [],
@@ -14506,7 +14506,7 @@
         },
         {
             "id": "f20b0218-6773-50e5-ada3-0cc1f38e8d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60160a6-8786-4488-b373-6599221341e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60160a6-8786-4488-b373-6599221341e5.jpg?1",
             "name": "Staunch Throneguard",
             "text": "Vigilance\nWhen Staunch Throneguard enters the battlefield, you become the monarch.",
             "colours": [],
@@ -14537,7 +14537,7 @@
         },
         {
             "id": "69fa3d87-fe94-565f-816f-9493e9e519b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64401acc-d080-4763-b67a-95164c11c69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64401acc-d080-4763-b67a-95164c11c69e.jpg?1",
             "name": "Sword of the Animist",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nEquip {2}",
             "colours": [],
@@ -14571,7 +14571,7 @@
         },
         {
             "id": "3e082326-5f7b-56ef-9e79-f980ab8b0e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfc5847-c3b4-41e7-8087-73ac4850bc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfc5847-c3b4-41e7-8087-73ac4850bc1b.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -14599,7 +14599,7 @@
         },
         {
             "id": "8cea0a37-a620-5baf-bd2f-39c29971c777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce5f12e-fc02-42f8-a5ca-b523050d4650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce5f12e-fc02-42f8-a5ca-b523050d4650.jpg?1",
             "name": "Thran Dynamo",
             "text": "{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -14629,7 +14629,7 @@
         },
         {
             "id": "005cbc0b-840c-54b5-a81d-1bfe7ca1f9cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eba26e-7c9e-46f3-ad13-aa684f3365cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eba26e-7c9e-46f3-ad13-aa684f3365cb.jpg?1",
             "name": "Unstable Obelisk",
             "text": "{T}: Add {C}.\n{7}, {T}, Sacrifice Unstable Obelisk: Destroy target permanent.",
             "colours": [],
@@ -14657,7 +14657,7 @@
         },
         {
             "id": "0e959712-a21f-5df8-bd5d-de2e1eb2be97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c924502b-a49e-4bf6-9e1a-9aa83f279228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c924502b-a49e-4bf6-9e1a-9aa83f279228.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.",
             "colours": [],
@@ -14685,7 +14685,7 @@
         },
         {
             "id": "1acf4647-3594-5474-9b3b-719b9ed1cdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363acf3-eff9-4f57-8b8a-683256d279e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8363acf3-eff9-4f57-8b8a-683256d279e0.jpg?1",
             "name": "Vulshok Battlegear",
             "text": "Equipped creature gets +3/+3.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "2f3d3170-7866-547d-b0fd-0f8ed40ac554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0693ae-55f9-4864-b5db-383715a04d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0693ae-55f9-4864-b5db-383715a04d21.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "2c57ec2f-0b3d-5dba-9a34-2d11e698cba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14019383-0327-404b-ab4d-c65c3fa8c50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14019383-0327-404b-ab4d-c65c3fa8c50d.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -14773,7 +14773,7 @@
         },
         {
             "id": "161f91d3-00fd-53dc-b286-a4729a53dc02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643f0ee9-9eba-4aa8-9f68-1f57313fc030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643f0ee9-9eba-4aa8-9f68-1f57313fc030.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -14803,7 +14803,7 @@
         },
         {
             "id": "704c14dd-3a00-5939-948d-ab64b44d6ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ed120-1e33-4e31-8f16-ba56497c3c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64ed120-1e33-4e31-8f16-ba56497c3c84.jpg?1",
             "name": "Opal Palace",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
             "colours": [],
@@ -14831,7 +14831,7 @@
         },
         {
             "id": "10ddeaf2-e40d-55c7-bbf0-017edc60c2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42522c12-874e-450f-bdea-901646eb2821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42522c12-874e-450f-bdea-901646eb2821.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -14861,7 +14861,7 @@
         },
         {
             "id": "044dd684-f0fc-5014-9951-597c868d8149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455be293-80cf-4bc6-8904-8dd21a2b9d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455be293-80cf-4bc6-8904-8dd21a2b9d19.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -14895,7 +14895,7 @@
         },
         {
             "id": "04ba8c90-9c0d-515d-a8af-17ef83aa6710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1d8a99-8a06-4e51-9277-96edb6899b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1d8a99-8a06-4e51-9277-96edb6899b29.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -14925,7 +14925,7 @@
         },
         {
             "id": "3bd6b564-00c2-59f5-9f03-bf2008dc0898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c877e-0188-427f-8de2-25ad82d7cadb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c877e-0188-427f-8de2-25ad82d7cadb.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -14953,7 +14953,7 @@
         },
         {
             "id": "5d0f837e-da40-5960-9850-a6c5762a4585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3140f-d5c8-45ff-8be4-622b1a129b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3140f-d5c8-45ff-8be4-622b1a129b3d.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -14987,7 +14987,7 @@
         },
         {
             "id": "edf8948d-988b-52b7-ba5b-1349a53c38e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04f0013-097c-46ec-9424-d5f417e6a9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04f0013-097c-46ec-9424-d5f417e6a9cf.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -15015,7 +15015,7 @@
         },
         {
             "id": "e41bc507-f77e-5571-b0bd-5c3819e75742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1270be49-a0d7-46cc-bf53-8172a3b5c6a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1270be49-a0d7-46cc-bf53-8172a3b5c6a6.jpg?1",
             "name": "Thriving Bluff",
             "text": "Thriving Bluff enters the battlefield tapped.\nAs Thriving Bluff enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -15045,7 +15045,7 @@
         },
         {
             "id": "01e65175-c64b-5344-89e6-85092c7b9aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343a1153-03d7-46d5-ad9a-65760eabed55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343a1153-03d7-46d5-ad9a-65760eabed55.jpg?1",
             "name": "Thriving Grove",
             "text": "Thriving Grove enters the battlefield tapped.\nAs Thriving Grove enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -15075,7 +15075,7 @@
         },
         {
             "id": "cd05ab9b-ceb6-566a-b758-ebbb9afc39a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f9b70-998c-4ecd-9094-f505692070de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f9b70-998c-4ecd-9094-f505692070de.jpg?1",
             "name": "Thriving Heath",
             "text": "Thriving Heath enters the battlefield tapped.\nAs Thriving Heath enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -15105,7 +15105,7 @@
         },
         {
             "id": "4d413f2d-a6b6-5a33-96d2-67afe3ba19f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2592bd6b-aea8-4fac-ad52-1801fcc7abe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2592bd6b-aea8-4fac-ad52-1801fcc7abe5.jpg?1",
             "name": "Thriving Isle",
             "text": "Thriving Isle enters the battlefield tapped.\nAs Thriving Isle enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -15135,7 +15135,7 @@
         },
         {
             "id": "3e7df581-2adf-5fa8-8844-04ee8cae0c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80fcc-b457-49c6-8c3a-0c5f58d74b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80fcc-b457-49c6-8c3a-0c5f58d74b2d.jpg?1",
             "name": "Thriving Moor",
             "text": "Thriving Moor enters the battlefield tapped.\nAs Thriving Moor enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -15165,7 +15165,7 @@
         },
         {
             "id": "582c07d9-b5ab-5759-8e49-e625c0ff7a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a39d22-5e3b-4ba0-b728-dbf16b61fc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a39d22-5e3b-4ba0-b728-dbf16b61fc8f.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -15199,7 +15199,7 @@
         },
         {
             "id": "eeda77e2-8b4a-51ba-84a1-92848a342c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae16c7da-912c-4d66-b1e7-17480cd3af99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae16c7da-912c-4d66-b1e7-17480cd3af99.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -15233,7 +15233,7 @@
         },
         {
             "id": "0da0740b-f737-5c91-b61b-5b79a36778c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafd7db6-b04e-4fa2-bccd-981211132a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafd7db6-b04e-4fa2-bccd-981211132a93.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -15267,7 +15267,7 @@
         },
         {
             "id": "5cdf576f-0b27-584e-bffb-00bb49afeb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614c9269-77c6-4cef-a987-8ef4c14fcebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614c9269-77c6-4cef-a987-8ef4c14fcebc.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15309,7 +15309,7 @@
         },
         {
             "id": "75afbeca-d7f8-562e-a4af-0ed77fa1e2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3344d18-e7b6-43ad-ab59-9ceaf49269f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3344d18-e7b6-43ad-ab59-9ceaf49269f7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15351,7 +15351,7 @@
         },
         {
             "id": "2829c6c7-1491-599c-bcc0-42968740f097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3036bd-95f0-403f-a6ba-b3b05f81a3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3036bd-95f0-403f-a6ba-b3b05f81a3c9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15393,7 +15393,7 @@
         },
         {
             "id": "ff920770-0574-5bb4-9055-34ba3fdc95c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63d4b-0bca-4b8e-bed0-0dc29ad0bac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63d4b-0bca-4b8e-bed0-0dc29ad0bac3.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15433,7 +15433,7 @@
         },
         {
             "id": "c19d92b6-5318-5a23-9501-5dd4fc934c60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75edde64-3589-424d-bfe1-714c4eaba019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75edde64-3589-424d-bfe1-714c4eaba019.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15473,7 +15473,7 @@
         },
         {
             "id": "9e7a56e1-3201-5346-b986-0e4c589a4816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b28bdb-e0d1-4d24-8199-8cd7ac12c30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b28bdb-e0d1-4d24-8199-8cd7ac12c30f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "0e6499ee-81e4-5c17-89fa-52202a9f461c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490452a3-22fb-4c75-9bf2-5cd6d6719446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490452a3-22fb-4c75-9bf2-5cd6d6719446.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15553,7 +15553,7 @@
         },
         {
             "id": "4e0477df-0e91-5cdd-8e7a-e907851f4688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e5571-866b-4b19-b786-e57781353913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e5571-866b-4b19-b786-e57781353913.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15593,7 +15593,7 @@
         },
         {
             "id": "eea131a5-5f7d-5129-abaf-18d5d1b99fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71891b-9980-4b71-8301-e92288d33235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c71891b-9980-4b71-8301-e92288d33235.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15633,7 +15633,7 @@
         },
         {
             "id": "923778fe-8050-56c2-a816-bd40a23f75a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836071c-9ee3-4dc0-95b6-28d0c5de76f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836071c-9ee3-4dc0-95b6-28d0c5de76f3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15673,7 +15673,7 @@
         },
         {
             "id": "98f12d1c-c3f5-555f-999c-eb7c1a38849e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95315204-a5f7-4d20-bda3-957029da29fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95315204-a5f7-4d20-bda3-957029da29fe.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15713,7 +15713,7 @@
         },
         {
             "id": "fc17f8e8-13bb-5cf8-8646-e6148b76a84f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbecd1f-81ad-427e-a50d-64b9ec029c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbecd1f-81ad-427e-a50d-64b9ec029c3c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15753,7 +15753,7 @@
         },
         {
             "id": "fff69c55-d36f-56e7-94f6-4d8fe36bffa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974535c-d99b-4d69-a21d-63359e40d385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7974535c-d99b-4d69-a21d-63359e40d385.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "2f46f9f0-f6bc-5a2a-9a29-dcfa7e237f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e574ee5-d33d-4054-9884-fdb5fe9d73bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e574ee5-d33d-4054-9884-fdb5fe9d73bd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15833,7 +15833,7 @@
         },
         {
             "id": "253cfd47-8ca4-55ed-aa12-9d2cab62e8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be6c40e-5669-417e-a655-b32b5f2bfd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be6c40e-5669-417e-a655-b32b5f2bfd11.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15873,7 +15873,7 @@
         },
         {
             "id": "7ac39b70-ce8c-5ec1-aa4c-c1568d881821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1185bb-b12e-47b5-9230-368ac9c91c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1185bb-b12e-47b5-9230-368ac9c91c1d.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -15908,7 +15908,7 @@
         },
         {
             "id": "0d5918a8-24cd-57dc-877d-17028d53f18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf0e27d-9b68-44dc-82ff-53d6817fb9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf0e27d-9b68-44dc-82ff-53d6817fb9d5.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -15949,7 +15949,7 @@
         },
         {
             "id": "5da69907-dedd-5991-824c-7c5ace6e8008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c90289-05ba-45fc-8f60-7e200cb11762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c90289-05ba-45fc-8f60-7e200cb11762.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -15984,7 +15984,7 @@
         },
         {
             "id": "6e3ea000-018e-5c20-b391-8a52759e6018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483b3056-8ced-4ec1-9182-e7b8183f1939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483b3056-8ced-4ec1-9182-e7b8183f1939.jpg?1",
             "name": "Alms Collector",
             "text": "Flash\nIf an opponent would draw two or more cards, instead you and that player each draw a card.",
             "colours": [
@@ -16020,7 +16020,7 @@
         },
         {
             "id": "181a97f6-4703-5335-934e-5c9e5f45383c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b9c34-48f1-475c-81f8-a74672ed5c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116b9c34-48f1-475c-81f8-a74672ed5c89.jpg?1",
             "name": "Angelic Field Marshal",
             "text": "Flying\nLieutenant \u2014 As long as you control your commander, Angelic Field Marshal gets +2/+2 and creatures you control have vigilance.",
             "colours": [
@@ -16055,7 +16055,7 @@
         },
         {
             "id": "11752a33-ba97-548c-9742-ecb8fcbe2a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fbdbe3-04d3-45e2-bff3-60349552f127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fbdbe3-04d3-45e2-bff3-60349552f127.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -16092,7 +16092,7 @@
         },
         {
             "id": "5f1a19d9-e36b-5ebf-8344-ac24f0fa6f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ed2bf7-23d1-47a2-90c8-ae00d596a392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ed2bf7-23d1-47a2-90c8-ae00d596a392.jpg?1",
             "name": "Balan, Wandering Knight",
             "text": "First strike\nBalan, Wandering Knight has double strike as long as two or more Equipment are attached to it.\n{1}{W}: Attach all Equipment you control to Balan.",
             "colours": [
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "ca6a2a9f-5228-5aa2-a97a-fc79a5b57e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2129252-fa14-49d2-9662-8dc804ddf4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2129252-fa14-49d2-9662-8dc804ddf4fb.jpg?1",
             "name": "Flawless Maneuver",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCreatures you control gain indestructible until end of turn.",
             "colours": [
@@ -16164,7 +16164,7 @@
         },
         {
             "id": "a440db6e-5990-5789-9edd-7a488ecc46e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565b0c50-4754-4867-a38d-e7d6b6475793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565b0c50-4754-4867-a38d-e7d6b6475793.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "1f38bfe4-d51d-53a6-8d08-a34dedbe01b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacd747-e422-47c0-8022-075f01390663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacd747-e422-47c0-8022-075f01390663.jpg?1",
             "name": "Heavenly Blademaster",
             "text": "Flying, double strike\nWhen Heavenly Blademaster enters the battlefield, you may attach any number of Auras and Equipment you control to it.\nOther creatures you control get +1/+1 for each Aura and Equipment attached to Heavenly Blademaster.",
             "colours": [
@@ -16236,7 +16236,7 @@
         },
         {
             "id": "5b525cd1-64d9-52c5-94d3-a83eb62eb4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b82143-e721-40c4-b67a-5430824f0eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b82143-e721-40c4-b67a-5430824f0eed.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nWhenever you gain life, put a +1/+1 counter on target creature or enchantment you control.\n{1}{W}: Another target creature gains lifelink until end of turn.",
             "colours": [
@@ -16274,7 +16274,7 @@
         },
         {
             "id": "7203910b-4f87-589c-8cbe-c19e7a6b846c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83ab91c-6e82-4a97-b602-40826d73b2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83ab91c-6e82-4a97-b602-40826d73b2ae.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -16312,7 +16312,7 @@
         },
         {
             "id": "285c3cf1-8e67-5cd0-b640-3c263edcd203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9071c93f-d5c6-4ca2-bac6-15fe96d03178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9071c93f-d5c6-4ca2-bac6-15fe96d03178.jpg?1",
             "name": "Land Tax",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -16345,7 +16345,7 @@
         },
         {
             "id": "88292ef4-309b-5759-8b31-ab4303d51cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097705d-af48-44d7-9ae7-21c4f4df55cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8097705d-af48-44d7-9ae7-21c4f4df55cd.jpg?1",
             "name": "Loyal Retainers",
             "text": "Sacrifice Loyal Retainers: Return target legendary creature card from your graveyard to the battlefield. Activate only during your turn, before attackers are declared.",
             "colours": [
@@ -16381,7 +16381,7 @@
         },
         {
             "id": "ad7ea748-75bf-5458-853b-fff899ab0885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f14e5-6d0b-4687-a4c7-5f199ba24a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f14e5-6d0b-4687-a4c7-5f199ba24a55.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -16419,7 +16419,7 @@
         },
         {
             "id": "46090dc1-251f-5fa4-8760-3db71dd1e64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b60107-441d-4390-b433-adb6ce1e616d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b60107-441d-4390-b433-adb6ce1e616d.jpg?1",
             "name": "Nahiri, the Lithomancer",
             "text": "+2: Create a 1/1 white Kor Soldier creature token. You may attach an Equipment you control to it.\n\u22122: You may put an Equipment card from your hand or graveyard onto the battlefield.\n\u221210: Create a colorless Equipment artifact token named Stoneforged Blade. It has indestructible, \"Equipped creature gets +5/+5 and has double strike,\" and equip {0}.\nNahiri, the Lithomancer can be your commander.",
             "colours": [
@@ -16456,7 +16456,7 @@
         },
         {
             "id": "c56a3634-7dcf-5aeb-ab45-79ef7ce30562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765f5235-a2f0-4402-8630-ca701ad7f540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765f5235-a2f0-4402-8630-ca701ad7f540.jpg?1",
             "name": "Odric, Master Tactician",
             "text": "First strike\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
             "colours": [
@@ -16494,7 +16494,7 @@
         },
         {
             "id": "3ff589e5-29b4-5496-a541-9c577b032301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43eb2ff-a3c4-449d-8ad3-17c41d5c764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43eb2ff-a3c4-449d-8ad3-17c41d5c764b.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -16531,7 +16531,7 @@
         },
         {
             "id": "bfbb1943-836e-5270-8af9-25d4e392ecf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7c2bb4-3156-4563-be23-65139fbad96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7c2bb4-3156-4563-be23-65139fbad96c.jpg?1",
             "name": "Righteous Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Create a 2/2 white Knight creature token with vigilance.\n\u2022 Exile target enchantment.\n\u2022 You gain 5 life.",
             "colours": [
@@ -16564,7 +16564,7 @@
         },
         {
             "id": "1a3a6f6a-b734-5a52-abeb-96a3f7c67e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781a59d4-383a-4251-a3d8-a1d233688661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781a59d4-383a-4251-a3d8-a1d233688661.jpg?1",
             "name": "Sephara, Sky's Blade",
             "text": "You may pay {W} and tap four untapped creatures you control with flying rather than pay this spell's mana cost.\nFlying, lifelink\nOther creatures you control with flying have indestructible.",
             "colours": [
@@ -16601,7 +16601,7 @@
         },
         {
             "id": "12dc3b20-84b2-54b0-91c1-714818bc9517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18140c53-e8ce-4fce-b302-f56fb0e87380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18140c53-e8ce-4fce-b302-f56fb0e87380.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -16634,7 +16634,7 @@
         },
         {
             "id": "5c23cf65-990f-5393-b2cc-6893085f76f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2309fb66-3aa0-4ec5-9a8e-5a0caa19c270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2309fb66-3aa0-4ec5-9a8e-5a0caa19c270.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -16668,7 +16668,7 @@
         },
         {
             "id": "9e8c4193-344c-564f-a72e-42af3bff8577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db6b514-2a89-425d-aef3-b338ce971763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db6b514-2a89-425d-aef3-b338ce971763.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -16702,7 +16702,7 @@
         },
         {
             "id": "58217a77-ab36-5cd0-bd01-3611ceb6d84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb014a3-2e76-41ce-9e26-401a05609975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb014a3-2e76-41ce-9e26-401a05609975.jpg?1",
             "name": "Sublime Exhalation",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy all creatures.",
             "colours": [
@@ -16735,7 +16735,7 @@
         },
         {
             "id": "0bb928fc-98b7-5f5b-a7c6-debd2500413c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a38d3-9adf-43c4-9fc5-8791ce7d4579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a38d3-9adf-43c4-9fc5-8791ce7d4579.jpg?1",
             "name": "Wakening Sun's Avatar",
             "text": "When Wakening Sun's Avatar enters the battlefield, if you cast it from your hand, destroy all non-Dinosaur creatures.",
             "colours": [
@@ -16771,7 +16771,7 @@
         },
         {
             "id": "2cd442d1-40ed-5fe5-8d7d-dae7bffb393d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc86f1d-577b-4ae0-89ec-04f5f647dacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc86f1d-577b-4ae0-89ec-04f5f647dacb.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -16804,7 +16804,7 @@
         },
         {
             "id": "5952db9b-b41e-5776-99aa-3d1669bfa728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e0232d-5eec-4ff1-93db-1adad8167c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e0232d-5eec-4ff1-93db-1adad8167c3a.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -16842,7 +16842,7 @@
         },
         {
             "id": "b0172dfd-7de5-5e26-907a-a4ceaa09ec51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f6663e-3ac0-40da-a27f-90b25488881f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f6663e-3ac0-40da-a27f-90b25488881f.jpg?1",
             "name": "Aminatou's Augury",
             "text": "Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a spell of that type from among the exiled cards without paying its mana cost.",
             "colours": [
@@ -16875,7 +16875,7 @@
         },
         {
             "id": "627d5e63-adc2-516c-90f5-03fbdc2368a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af3dc3b-18c6-4446-a2f8-1f13edc2a650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af3dc3b-18c6-4446-a2f8-1f13edc2a650.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -16914,7 +16914,7 @@
         },
         {
             "id": "dcf2ea18-e15a-51a0-b3d6-6db3c8df1076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5db271-9b38-44ad-943f-785c8f4d04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5db271-9b38-44ad-943f-785c8f4d04a0.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from their hand onto the battlefield.",
             "colours": [
@@ -16952,7 +16952,7 @@
         },
         {
             "id": "8c439562-b548-5d2e-a8f2-37938d0a9579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70f54e4-3297-4bf4-8aa8-e4be4965e961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70f54e4-3297-4bf4-8aa8-e4be4965e961.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -16985,7 +16985,7 @@
         },
         {
             "id": "0661035f-c5fb-524b-a7a4-fee14ddcce4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0776e0fa-1d9c-4721-99c6-a04eabec84d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0776e0fa-1d9c-4721-99c6-a04eabec84d0.jpg?1",
             "name": "Capture of Jingzhou",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -17018,7 +17018,7 @@
         },
         {
             "id": "45adaaa0-1e4a-5657-a1a6-a7129714b776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43836f8b-bf83-4d33-a244-c1713175dc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43836f8b-bf83-4d33-a244-c1713175dc28.jpg?1",
             "name": "Commandeer",
             "text": "You may exile two blue cards from your hand rather than pay this spell's mana cost.\nGain control of target noncreature spell. You may choose new targets for it.",
             "colours": [
@@ -17051,7 +17051,7 @@
         },
         {
             "id": "b6ea4c10-fb9d-54bc-a45c-f947c44fe22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810a95a-e1e1-4655-a508-dfbc83d4d527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7810a95a-e1e1-4655-a508-dfbc83d4d527.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -17084,7 +17084,7 @@
         },
         {
             "id": "0701e50d-c0a4-5fd5-aef3-766ca674e739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a82c8-3d6f-483a-96c3-38baf54390b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a82c8-3d6f-483a-96c3-38baf54390b4.jpg?1",
             "name": "Day's Undoing",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities from the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -17117,7 +17117,7 @@
         },
         {
             "id": "4c63893e-477e-5fa5-9b3f-7746e240eb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad123d-36cd-4b97-9e1c-eec2fa3bd4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad123d-36cd-4b97-9e1c-eec2fa3bd4c3.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to their owners' hands.",
             "colours": [
@@ -17150,7 +17150,7 @@
         },
         {
             "id": "c91cbcd7-8727-5f1d-b5ab-0e41d72ec939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdd3fd7-1a91-411c-a747-68942d2ad5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdd3fd7-1a91-411c-a747-68942d2ad5b9.jpg?1",
             "name": "Faerie Artisans",
             "text": "Flying\nWhenever a nontoken creature enters the battlefield under an opponent's control, create a token that's a copy of that creature except it's an artifact in addition to its other types. Then exile all other tokens created with Faerie Artisans.",
             "colours": [
@@ -17186,7 +17186,7 @@
         },
         {
             "id": "5f2d1478-f355-5f55-8da1-43cdf69a2361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8678852-7f4a-4b30-9f0b-0719489f442e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8678852-7f4a-4b30-9f0b-0719489f442e.jpg?1",
             "name": "Fierce Guardianship",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCounter target noncreature spell.",
             "colours": [
@@ -17220,7 +17220,7 @@
         },
         {
             "id": "f5e8be45-27e6-59d6-85b1-9e346ce4c41e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18c9963-c3e1-4877-9df5-18f52e287206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18c9963-c3e1-4877-9df5-18f52e287206.jpg?1",
             "name": "Lorthos, the Tidemaker",
             "text": "Whenever Lorthos, the Tidemaker attacks, you may pay {8}. If you do, tap up to eight target permanents. Those permanents don't untap during their controllers' next untap steps.",
             "colours": [
@@ -17257,7 +17257,7 @@
         },
         {
             "id": "d27fe5b9-1f38-5148-a56a-ed342faacd3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6305be5e-9b96-4132-b240-432549af999e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6305be5e-9b96-4132-b240-432549af999e.jpg?1",
             "name": "Minds Aglow",
             "text": "Join forces \u2014 Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way.",
             "colours": [
@@ -17290,7 +17290,7 @@
         },
         {
             "id": "e128863b-de5c-5ab3-91e8-96f7acd306c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dd8d84-2bbc-4068-9b93-0250b793b622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dd8d84-2bbc-4068-9b93-0250b793b622.jpg?1",
             "name": "Mystic Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Return target creature to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -17323,7 +17323,7 @@
         },
         {
             "id": "4a21d861-d14d-5094-91f9-453b8b4fe119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893944f-35f1-47d2-87e1-c24a1d1938bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893944f-35f1-47d2-87e1-c24a1d1938bc.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -17357,7 +17357,7 @@
         },
         {
             "id": "73f69044-197c-5409-9c37-33e12fa32bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c2725-afd6-480d-bd6b-3dc30f76248d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c2725-afd6-480d-bd6b-3dc30f76248d.jpg?1",
             "name": "Sai, Master Thopterist",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{U}, Sacrifice two artifacts: Draw a card.",
             "colours": [
@@ -17395,7 +17395,7 @@
         },
         {
             "id": "1d4d1ba7-911f-538b-a5d3-28f6572e05df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae281cc-cd22-4e14-a80c-08777e1703ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae281cc-cd22-4e14-a80c-08777e1703ae.jpg?1",
             "name": "Spellseeker",
             "text": "When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with mana value 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -17432,7 +17432,7 @@
         },
         {
             "id": "faaeabfd-ac34-501f-8385-43eec0071813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef3fec7-2d32-439d-a956-1982d82f1450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef3fec7-2d32-439d-a956-1982d82f1450.jpg?1",
             "name": "Stitcher Geralf",
             "text": "{2}{U}, {T}: Each player mills three cards. Exile up to two creature cards put into graveyards this way. Create an X/X blue Zombie creature token, where X is the total power of the cards exiled this way.",
             "colours": [
@@ -17470,7 +17470,7 @@
         },
         {
             "id": "e20cd3cb-d0fb-58d3-81c8-14bc624f7d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9056efed-307d-4986-9cf1-f7bf34e18fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9056efed-307d-4986-9cf1-f7bf34e18fc1.jpg?1",
             "name": "Stormsurge Kraken",
             "text": "Hexproof\nLieutenant \u2014 As long as you control your commander, Stormsurge Kraken gets +2/+2 and has \"Whenever Stormsurge Kraken becomes blocked, you may draw two cards.\"",
             "colours": [
@@ -17505,7 +17505,7 @@
         },
         {
             "id": "a8c5d58f-c03a-57c5-b1f3-855d9249b2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf311a8-5c3b-4473-9732-d0ddb1d42644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf311a8-5c3b-4473-9732-d0ddb1d42644.jpg?1",
             "name": "Sun Quan, Lord of Wu",
             "text": "Creatures you control have horsemanship. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [
@@ -17543,7 +17543,7 @@
         },
         {
             "id": "c5c7fd34-0069-5efb-9ffc-0bb079b82304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df88b6-f7a4-49a9-a93a-9f6cb83fd8da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df88b6-f7a4-49a9-a93a-9f6cb83fd8da.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -17582,7 +17582,7 @@
         },
         {
             "id": "a44cc9f7-d0c5-5a2f-a005-28410e25c7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba86947e-5d7c-4cf1-9d33-98b289d56108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba86947e-5d7c-4cf1-9d33-98b289d56108.jpg?1",
             "name": "Teferi, Temporal Archmage",
             "text": "+1: Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\n\u22121: Untap up to four target permanents.\n\u221210: You get an emblem with \"You may activate loyalty abilities of planeswalkers you control on any player's turn any time you could cast an instant.\"\nTeferi, Temporal Archmage can be your commander.",
             "colours": [
@@ -17619,7 +17619,7 @@
         },
         {
             "id": "60898550-2b90-5315-839c-5809c3d01e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa9a1-1e34-48d6-a6ec-244844810f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa9a1-1e34-48d6-a6ec-244844810f87.jpg?1",
             "name": "Torrential Gearhulk",
             "text": "Flash\nWhen Torrential Gearhulk enters the battlefield, you may cast target instant card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -17655,7 +17655,7 @@
         },
         {
             "id": "026f6621-ec0f-538e-89dd-cf40f71b8bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ab9672-8d85-41f6-9016-20c2988b037c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ab9672-8d85-41f6-9016-20c2988b037c.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -17695,7 +17695,7 @@
         },
         {
             "id": "b43f0bcb-2434-5c51-8f60-c13416e186bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afce9284-9d3a-4ab9-8dd0-8fda1ee0c64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afce9284-9d3a-4ab9-8dd0-8fda1ee0c64f.jpg?1",
             "name": "Archfiend of Despair",
             "text": "Flying\nYour opponents can't gain life.\nAt the beginning of each end step, each opponent loses life equal to the life that player lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -17730,7 +17730,7 @@
         },
         {
             "id": "162f6861-97d3-5e37-88f5-59a13090c5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dd3973-d029-4ec9-b52d-c26f1e7333ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dd3973-d029-4ec9-b52d-c26f1e7333ad.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -17764,7 +17764,7 @@
         },
         {
             "id": "a3fe5fe2-c26f-5825-a8e9-9740782ba2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f59ff-b72b-4113-8d7c-3d820b2f8549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f59ff-b72b-4113-8d7c-3d820b2f8549.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -17802,7 +17802,7 @@
         },
         {
             "id": "7b5ce7ae-8a85-54dd-9835-9a4622e2d336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16d6716-c8f8-4743-9a77-af8e15818690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16d6716-c8f8-4743-9a77-af8e15818690.jpg?1",
             "name": "Curtains' Call",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nDestroy two target creatures.",
             "colours": [
@@ -17835,7 +17835,7 @@
         },
         {
             "id": "0a164751-e60c-5016-a4d1-dde754119742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fc8546-60a7-470b-942a-189850eea15f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fc8546-60a7-470b-942a-189850eea15f.jpg?1",
             "name": "Deadly Rollick",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nExile target creature.",
             "colours": [
@@ -17869,7 +17869,7 @@
         },
         {
             "id": "e9e360c5-80a3-5e2a-a343-70ea7dc3d121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74c32e0-769c-401b-a35c-672973ed49f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74c32e0-769c-401b-a35c-672973ed49f3.jpg?1",
             "name": "Decree of Pain",
             "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B} ({3}{B}{B}, Discard this card: Draw a card.)\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
             "colours": [
@@ -17902,7 +17902,7 @@
         },
         {
             "id": "dbebd322-bd7b-5192-aa42-d50e91bc4991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89153e75-2333-42e8-bc28-1b3d1e4726dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89153e75-2333-42e8-bc28-1b3d1e4726dd.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -17936,7 +17936,7 @@
         },
         {
             "id": "9ec1fb8a-1257-5821-85f7-138ff370ccd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b9933d-5c10-4fca-988e-3f00d7356231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b9933d-5c10-4fca-988e-3f00d7356231.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "Flying, trample\nWhen Demonlord Belzenlok enters the battlefield, exile cards from the top of your library until you exile a nonland card, then put that card into your hand. If the card's mana value is 4 or greater, repeat this process. Demonlord Belzenlok deals 1 damage to you for each card put into your hand this way.",
             "colours": [
@@ -17974,7 +17974,7 @@
         },
         {
             "id": "c4fe4ac5-1145-52ab-ac71-30ecd1a29fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227276da-caa5-4b24-a534-48a7ca650c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227276da-caa5-4b24-a534-48a7ca650c2b.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you cast a creature spell, create X 1/1 black Thrull creature tokens, where X is that spell's mana value.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -18012,7 +18012,7 @@
         },
         {
             "id": "c055e72c-5a52-5172-8ef7-6ab55a48c9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5219ed86-eb4e-43f5-9c75-f3b24abe42a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5219ed86-eb4e-43f5-9c75-f3b24abe42a5.jpg?1",
             "name": "Ghoulcaller Gisa",
             "text": "{B}, {T}, Sacrifice another creature: Create X 2/2 black Zombie creature tokens, where X is the sacrificed creature's power.",
             "colours": [
@@ -18050,7 +18050,7 @@
         },
         {
             "id": "3f875b22-38a2-5756-96b0-ba54073326a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a394c-aa7e-40a7-958d-ed89e82bd473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a394c-aa7e-40a7-958d-ed89e82bd473.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -18084,7 +18084,7 @@
         },
         {
             "id": "daa14381-82d5-5a59-81ba-ad057ae15f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46c03ac-5efb-4d5d-9987-aa5e4da0a9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46c03ac-5efb-4d5d-9987-aa5e4da0a9c4.jpg?1",
             "name": "Imp's Mischief",
             "text": "Change the target of target spell with a single target. You lose life equal to that spell's mana value.",
             "colours": [
@@ -18117,7 +18117,7 @@
         },
         {
             "id": "261277de-b881-59b4-a0aa-d5269da56c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a495624a-2877-4e04-89da-9ef52569b7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a495624a-2877-4e04-89da-9ef52569b7c6.jpg?1",
             "name": "Kindred Dominance",
             "text": "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
             "colours": [
@@ -18151,7 +18151,7 @@
         },
         {
             "id": "f08e9fdd-bac1-5bc5-9121-da5008563be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e40f1c-e67e-4c21-8704-f6b723771bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e40f1c-e67e-4c21-8704-f6b723771bf3.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -18191,7 +18191,7 @@
         },
         {
             "id": "2d169a4f-70fd-506a-99a2-200071fbe633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf7f29-c53a-4567-aa13-ea0e3ad8f857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bf7f29-c53a-4567-aa13-ea0e3ad8f857.jpg?1",
             "name": "Ob Nixilis of the Black Oath",
             "text": "+2: Each opponent loses 1 life. You gain life equal to the life lost this way.\n\u22122: Create a 5/5 black Demon creature token with flying. You lose 2 life.\n\u22128: You get an emblem with \"{1}{B}, Sacrifice a creature: You gain X life and draw X cards, where X is the sacrificed creature's power.\"\nOb Nixilis of the Black Oath can be your commander.",
             "colours": [
@@ -18228,7 +18228,7 @@
         },
         {
             "id": "0ab84ae3-281b-559e-9305-7fd9e10c5a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f88ed-b3bb-4cdf-a9dd-2ef79a84fd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f88ed-b3bb-4cdf-a9dd-2ef79a84fd29.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -18264,7 +18264,7 @@
         },
         {
             "id": "dd28adea-38d9-51e2-8aad-9b9a809ee6c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e793c0f-22f9-4ed5-9fb8-bd29f540ee7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e793c0f-22f9-4ed5-9fb8-bd29f540ee7c.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "Flying, haste\nWhenever Rankle, Master of Pranks deals combat damage to a player, choose any number \u2014\n\u2022 Each player discards a card.\n\u2022 Each player loses 1 life and draws a card.\n\u2022 Each player sacrifices a creature.",
             "colours": [
@@ -18302,7 +18302,7 @@
         },
         {
             "id": "67fc6663-3658-574b-b9f9-21e50523decd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411091f6-45c3-4d7e-a7a6-4c65e4571c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411091f6-45c3-4d7e-a7a6-4c65e4571c11.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "Flying, trample\nPay 2 life, Sacrifice another creature: Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -18339,7 +18339,7 @@
         },
         {
             "id": "5da29731-ff5c-5ad8-a4b3-0a40705dc4e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248db43d-8432-47c9-ab01-ce476377cdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248db43d-8432-47c9-ab01-ce476377cdb3.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -18374,7 +18374,7 @@
         },
         {
             "id": "b7212092-c02c-5827-b351-fc3c900ab226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa4b610-f138-4383-acf4-c4170648022c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa4b610-f138-4383-acf4-c4170648022c.jpg?1",
             "name": "Sower of Discord",
             "text": "Flying\nAs Sower of Discord enters the battlefield, choose two players.\nWhenever damage is dealt to one of the chosen players, the other chosen player also loses that much life.",
             "colours": [
@@ -18409,7 +18409,7 @@
         },
         {
             "id": "8c0b270e-1510-500a-b8ee-9eef054b9b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7c713e-0ec3-44c8-8643-dba5a130d6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7c713e-0ec3-44c8-8643-dba5a130d6b0.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -18442,7 +18442,7 @@
         },
         {
             "id": "cab85137-5f4e-5ef1-af09-17eaf29b0ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbb9ce0-8701-4400-8569-642ce5a0dbff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbb9ce0-8701-4400-8569-642ce5a0dbff.jpg?1",
             "name": "Twilight Prophet",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, if you have the city's blessing, reveal the top card of your library and put it into your hand. Each opponent loses X life and you gain X life, where X is that card's mana value.",
             "colours": [
@@ -18478,7 +18478,7 @@
         },
         {
             "id": "a06a3b13-acb5-55e8-8f22-0577f442aee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd338362-b793-431f-9a03-84693ec45883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd338362-b793-431f-9a03-84693ec45883.jpg?1",
             "name": "Vindictive Lich",
             "text": "When Vindictive Lich dies, choose one or more. Each mode must target a different player.\n\u2022 Target opponent sacrifices a creature.\n\u2022 Target opponent discards two cards.\n\u2022 Target opponent loses 5 life.",
             "colours": [
@@ -18514,7 +18514,7 @@
         },
         {
             "id": "c99e6976-4531-55f6-8ee4-eecd78cd9e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9baedc-84ea-43ef-877d-f88209bb3fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9baedc-84ea-43ef-877d-f88209bb3fba.jpg?1",
             "name": "Wake the Dead",
             "text": "Cast this spell only during combat on an opponent's turn.\nReturn X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step.",
             "colours": [
@@ -18547,7 +18547,7 @@
         },
         {
             "id": "0658653b-dc74-5d5a-8b0e-5549ca502139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800bfbbe-9d63-49f9-8e19-793afb1c29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800bfbbe-9d63-49f9-8e19-793afb1c29c2.jpg?1",
             "name": "Wretched Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target creature gets -2/-2 until end of turn.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -18580,7 +18580,7 @@
         },
         {
             "id": "522b8709-6788-5be1-81b9-628f223802fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b0e93-b8ae-49b3-9ddb-c1b66313c535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b0e93-b8ae-49b3-9ddb-c1b66313c535.jpg?1",
             "name": "Ashling the Pilgrim",
             "text": "{1}{R}: Put a +1/+1 counter on Ashling the Pilgrim. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling the Pilgrim, and it deals that much damage to each creature and each player.",
             "colours": [
@@ -18618,7 +18618,7 @@
         },
         {
             "id": "83d5d774-c5e4-5f83-87e5-2fbdcb0f647c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831b5124-e5cf-463d-b58e-f03b63ce495b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831b5124-e5cf-463d-b58e-f03b63ce495b.jpg?1",
             "name": "Avatar of Slaughter",
             "text": "All creatures have double strike and attack each combat if able.",
             "colours": [
@@ -18653,7 +18653,7 @@
         },
         {
             "id": "14c3a714-3d49-52d8-a952-60bed649aba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc65edbb-9690-4dd9-8542-10419729b92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc65edbb-9690-4dd9-8542-10419729b92a.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -18689,7 +18689,7 @@
         },
         {
             "id": "2f668c0a-63cf-5925-8e80-0800e231ee09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e32a0f-a9ce-4c0e-a305-bf3fa783ce4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e32a0f-a9ce-4c0e-a305-bf3fa783ce4f.jpg?1",
             "name": "Daretti, Scrap Savant",
             "text": "+2: Discard up to two cards, then draw that many cards.\n\u22122: Sacrifice an artifact. If you do, return target artifact card from your graveyard to the battlefield.\n\u221210: You get an emblem with \"Whenever an artifact is put into your graveyard from the battlefield, return that card to the battlefield at the beginning of the next end step.\"\nDaretti, Scrap Savant can be your commander.",
             "colours": [
@@ -18726,7 +18726,7 @@
         },
         {
             "id": "7e976ebb-95b4-549c-ae59-b16f5d2425d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a7ae1-467c-4eca-9ce2-39692804e492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a7ae1-467c-4eca-9ce2-39692804e492.jpg?1",
             "name": "Deflecting Swat",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nYou may choose new targets for target spell or ability.",
             "colours": [
@@ -18760,7 +18760,7 @@
         },
         {
             "id": "b905e0eb-f35d-56a9-828e-8f4a6775cb4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165796ce-6f0c-4af6-bb0c-a8b1160e0a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165796ce-6f0c-4af6-bb0c-a8b1160e0a76.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)",
             "colours": [
@@ -18794,7 +18794,7 @@
         },
         {
             "id": "530e2aff-f50e-5feb-99b6-6cfb0341bd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86b6e0-782c-49ce-8c99-133eb9192572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86b6e0-782c-49ce-8c99-133eb9192572.jpg?1",
             "name": "Divergent Transformations",
             "text": "Undaunted (This spell costs {1} less to cast for each opponent.)\nExile two target creatures. For each of those creatures, its controller reveals cards from the top of their library until they reveal a creature card, puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -18827,7 +18827,7 @@
         },
         {
             "id": "c8d2a5c5-bc0e-5433-98f3-bf4a8748aedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34ec655-4210-4237-92e4-c9adf207e2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34ec655-4210-4237-92e4-c9adf207e2e0.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -18864,7 +18864,7 @@
         },
         {
             "id": "f2fbcbf5-e74b-52d0-aea0-a3dd5623f09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01299fc5-6143-47ab-a63d-f3f1fe21de10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01299fc5-6143-47ab-a63d-f3f1fe21de10.jpg?1",
             "name": "Fiery Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Fiery Confluence deals 1 damage to each creature.\n\u2022 Fiery Confluence deals 2 damage to each opponent.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -18897,7 +18897,7 @@
         },
         {
             "id": "6c5ef5e8-797b-5114-a4e4-0282e57d6aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d51f68-c5b7-4304-b777-97bf7df0492c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d51f68-c5b7-4304-b777-97bf7df0492c.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card, put it onto the battlefield, then shuffle.\nWhenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -18935,7 +18935,7 @@
         },
         {
             "id": "3387fed6-250a-580e-b3e8-9f295158590c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c73420-c36c-4bec-8ea9-192552fc5e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c73420-c36c-4bec-8ea9-192552fc5e4c.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "Whenever a creature you control deals combat damage to a player, choose one \u2014\n\u2022 Goad target creature that player controls.\n\u2022 Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -18974,7 +18974,7 @@
         },
         {
             "id": "3ab3fb5e-1260-56f1-9d78-237e12dfcee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe4a513-3e64-4452-aff6-b990ece58f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe4a513-3e64-4452-aff6-b990ece58f38.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "{T}: Heartless Hidetsugu deals damage to each player equal to half that player's life total, rounded down.",
             "colours": [
@@ -19012,7 +19012,7 @@
         },
         {
             "id": "efe632c1-e2af-5c25-9fc4-fd870f7f51f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95300918-0273-4066-9a58-38ca77fc8b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95300918-0273-4066-9a58-38ca77fc8b5a.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -19047,7 +19047,7 @@
         },
         {
             "id": "618f05c2-ed78-522f-bdf8-ea87c4435b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31adaa1-6211-4bd3-9705-6dead01597d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31adaa1-6211-4bd3-9705-6dead01597d0.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -19082,7 +19082,7 @@
         },
         {
             "id": "0f5c8f32-0734-5829-a30b-e55325afa590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129ac8-4f35-4372-95e4-bde2ce62c189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129ac8-4f35-4372-95e4-bde2ce62c189.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -19116,7 +19116,7 @@
         },
         {
             "id": "8459b065-732b-5672-98dc-723d4108f75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae883514-2e5f-4ea3-bccc-3c475f70121a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae883514-2e5f-4ea3-bccc-3c475f70121a.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -19154,7 +19154,7 @@
         },
         {
             "id": "64721cc9-8da6-5248-9a42-29fa3bb97cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fef3784-5890-4e91-a881-a6be888f9b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fef3784-5890-4e91-a881-a6be888f9b90.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards their hand, then draws seven cards.",
             "colours": [
@@ -19191,7 +19191,7 @@
         },
         {
             "id": "0efe1fb6-97d3-530d-9b5a-d2ba79a4dbe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb971063-5415-49d5-87c2-9ff4e88c71e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb971063-5415-49d5-87c2-9ff4e88c71e1.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -19232,7 +19232,7 @@
         },
         {
             "id": "39f0f138-76f0-54e4-9285-63b3b4ed8f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44217db3-5fd8-4bb1-b004-60d8b179e5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44217db3-5fd8-4bb1-b004-60d8b179e5f4.jpg?1",
             "name": "Nesting Dragon",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, create a 0/2 red Dragon Egg creature token with defender and \"When this creature dies, create a 2/2 red Dragon creature token with flying and \u2018{R}: This creature gets +1/+0 until end of turn.'\"",
             "colours": [
@@ -19267,7 +19267,7 @@
         },
         {
             "id": "d608b768-7898-5bbf-98a8-66a46db4d8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf0b1b-bf8b-4dba-8ea9-5b6480897323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf0b1b-bf8b-4dba-8ea9-5b6480897323.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -19305,7 +19305,7 @@
         },
         {
             "id": "426a5e13-95f6-5f55-ac61-1fbcaca3090c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c85575a-8a56-4ce2-8ca9-7b404408dcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c85575a-8a56-4ce2-8ca9-7b404408dcc5.jpg?1",
             "name": "Savage Beating",
             "text": "Cast this spell only during your turn and only during combat.\nChoose one \u2014\n\u2022 Creatures you control gain double strike until end of turn.\n\u2022 Untap all creatures you control. After this phase, there is an additional combat phase.\nEntwine {1}{R}",
             "colours": [
@@ -19338,7 +19338,7 @@
         },
         {
             "id": "6597de4b-4d40-5d42-a438-e963037b91b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505efa34-72ff-4ecd-a662-7fbb5a86321f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505efa34-72ff-4ecd-a662-7fbb5a86321f.jpg?1",
             "name": "Scourge of the Throne",
             "text": "Flying\nDethrone (Whenever this creature attacks the player with the most life or tied for most life, put a +1/+1 counter on it.)\nWhenever Scourge of the Throne attacks for the first time each turn, if it's attacking the player with the most life or tied for most life, untap all attacking creatures. After this phase, there is an additional combat phase.",
             "colours": [
@@ -19373,7 +19373,7 @@
         },
         {
             "id": "835974fa-cadd-56f8-81c2-146d0b4589e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c516be1-ecdf-469f-9d7f-3eeeed962777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c516be1-ecdf-469f-9d7f-3eeeed962777.jpg?1",
             "name": "Star of Extinction",
             "text": "Destroy target land. Star of Extinction deals 20 damage to each creature and each planeswalker.",
             "colours": [
@@ -19406,7 +19406,7 @@
         },
         {
             "id": "eb6f59f0-a46a-5283-8ba2-6ecf3487ee36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc2ebdd-aec1-49f0-89c9-1008abfd999b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc2ebdd-aec1-49f0-89c9-1008abfd999b.jpg?1",
             "name": "Tempt with Vengeance",
             "text": "Tempting offer \u2014 Create X 1/1 red Elemental creature tokens with haste. Each opponent may create X 1/1 red Elemental creature tokens with haste. For each opponent who does, create X 1/1 red Elemental creature tokens with haste.",
             "colours": [
@@ -19439,7 +19439,7 @@
         },
         {
             "id": "bba256d0-e2aa-5f88-8941-bd23bae9ec1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77e0e6-b79e-4950-8011-10a37d6e84a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c77e0e6-b79e-4950-8011-10a37d6e84a2.jpg?1",
             "name": "Treasure Nabber",
             "text": "Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.",
             "colours": [
@@ -19476,7 +19476,7 @@
         },
         {
             "id": "89c7b358-5b16-5d04-a7ba-eed2dc3b4aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df244eab-9631-4c84-b8d6-0f62ace60b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df244eab-9631-4c84-b8d6-0f62ace60b83.jpg?1",
             "name": "Arachnogenesis",
             "text": "Create X 1/2 green Spider creature tokens with reach, where X is the number of creatures attacking you. Prevent all combat damage that would be dealt this turn by non-Spider creatures.",
             "colours": [
@@ -19510,7 +19510,7 @@
         },
         {
             "id": "fefcec91-fd44-5326-a16c-3ed7c79be3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeb09a-8782-4390-840e-9b1b5c02f319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeb09a-8782-4390-840e-9b1b5c02f319.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -19549,7 +19549,7 @@
         },
         {
             "id": "b5aab904-2655-57f3-aa07-eb16198c48ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e07f2a-ca6f-4f56-b251-ef5ab1ee0146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e07f2a-ca6f-4f56-b251-ef5ab1ee0146.jpg?1",
             "name": "Bloodspore Thrinax",
             "text": "Devour 1 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it.)\nEach other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on Bloodspore Thrinax.",
             "colours": [
@@ -19584,7 +19584,7 @@
         },
         {
             "id": "63b75d51-338f-57e9-ab6e-c1363634a78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f9ba6-6bd1-4be8-b584-f67308e8c60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036f9ba6-6bd1-4be8-b584-f67308e8c60d.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -19619,7 +19619,7 @@
         },
         {
             "id": "144bffdb-9667-579d-ab23-7b6531c4eed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f161997-ef21-4e90-b373-1d9e4402bf21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f161997-ef21-4e90-b373-1d9e4402bf21.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -19652,7 +19652,7 @@
         },
         {
             "id": "8255e540-f5c9-5210-8e98-d2d8ca394bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f07cc-eea4-4ad7-aabf-dab090327cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4f07cc-eea4-4ad7-aabf-dab090327cbe.jpg?1",
             "name": "Ezuri's Predation",
             "text": "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures.",
             "colours": [
@@ -19685,7 +19685,7 @@
         },
         {
             "id": "01359a41-06e6-5262-9fd0-ccad985803a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ebbacf-4caf-47e5-8ce1-3b02b447ba7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ebbacf-4caf-47e5-8ce1-3b02b447ba7a.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -19719,7 +19719,7 @@
         },
         {
             "id": "acc714cc-b5f9-5589-96c4-30645c15a2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6160f7-00da-453b-a161-cb06a40b0b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6160f7-00da-453b-a161-cb06a40b0b62.jpg?1",
             "name": "Freyalise, Llanowar's Fury",
             "text": "+2: Create a 1/1 green Elf Druid creature token with \"{T}: Add {G}.\"\n\u22122: Destroy target artifact or enchantment.\n\u22126: Draw a card for each green creature you control.\nFreyalise, Llanowar's Fury can be your commander.",
             "colours": [
@@ -19756,7 +19756,7 @@
         },
         {
             "id": "f7750054-6efc-51bb-938e-52856de9587c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbd1d5-f0b1-4656-ad17-50b664230415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbd1d5-f0b1-4656-ad17-50b664230415.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -19794,7 +19794,7 @@
         },
         {
             "id": "ab206ddf-3138-5e53-a466-10e7dcffe971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1921b08-a3b3-422d-a82d-49af9149aee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1921b08-a3b3-422d-a82d-49af9149aee7.jpg?1",
             "name": "The Great Henge",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\n{T}: Add {G}{G}. You gain 2 life.\nWhenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.",
             "colours": [
@@ -19829,7 +19829,7 @@
         },
         {
             "id": "492c85f1-2e8c-51c5-9fe3-6dc6559081c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5c1e29-4b8e-4783-8bc7-163670face9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5c1e29-4b8e-4783-8bc7-163670face9d.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -19862,7 +19862,7 @@
         },
         {
             "id": "a1b1133b-3baf-50ec-b5ac-7c8ccd960638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cc65b2-4b31-40d7-8ea9-5435b6f5d4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cc65b2-4b31-40d7-8ea9-5435b6f5d4b5.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -19900,7 +19900,7 @@
         },
         {
             "id": "190681d2-4e50-5a4a-bdc9-72bd442e6ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b51f51-45ee-4b73-9550-c1104b0eb628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b51f51-45ee-4b73-9550-c1104b0eb628.jpg?1",
             "name": "Lifeblood Hydra",
             "text": "Trample\nLifeblood Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Lifeblood Hydra dies, you gain life and draw cards equal to its power.",
             "colours": [
@@ -19935,7 +19935,7 @@
         },
         {
             "id": "7ba54306-9e86-57e8-9acb-ab8b0cb97eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b12bb2e-3c75-4f23-a931-1735a28d954a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b12bb2e-3c75-4f23-a931-1735a28d954a.jpg?1",
             "name": "Obscuring Haze",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nPrevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -19969,7 +19969,7 @@
         },
         {
             "id": "2866c61f-2a51-50a4-a3c1-3a584f6f4ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08736a3-2a53-45c0-8ede-5207ffbea32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08736a3-2a53-45c0-8ede-5207ffbea32c.jpg?1",
             "name": "Ohran Frostfang",
             "text": "Attacking creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -20007,7 +20007,7 @@
         },
         {
             "id": "7b0ebed9-445e-553f-8211-9adb61f34779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f725636-8947-4232-a2fb-5c85d7fbcd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f725636-8947-4232-a2fb-5c85d7fbcd1b.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -20046,7 +20046,7 @@
         },
         {
             "id": "da356044-788a-5a0d-8598-f1f9b729df1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017c271-6c8d-4f4d-9507-f79ffc265376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017c271-6c8d-4f4d-9507-f79ffc265376.jpg?1",
             "name": "Regal Behemoth",
             "text": "Trample\nWhen Regal Behemoth enters the battlefield, you become the monarch.\nWhenever you tap a land for mana while you're the monarch, add an additional one mana of any color.",
             "colours": [
@@ -20082,7 +20082,7 @@
         },
         {
             "id": "11f7c426-6e1b-50e4-9fe8-6276d28d8633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c703c7de-4d20-4921-880b-da7d0f986164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c703c7de-4d20-4921-880b-da7d0f986164.jpg?1",
             "name": "Sakiko, Mother of Summer",
             "text": "Whenever a creature you control deals combat damage to a player, add that much {G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -20120,7 +20120,7 @@
         },
         {
             "id": "628e5170-d7ea-5857-bdd9-c0767fdf36a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc3323f-cdc7-4368-9ab9-ce8a41085bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc3323f-cdc7-4368-9ab9-ce8a41085bca.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -20160,7 +20160,7 @@
         },
         {
             "id": "eb418969-2a0c-5b32-a88a-ceb0b03f9db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce1130c-fc27-4508-a621-5d720a4df4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce1130c-fc27-4508-a621-5d720a4df4ea.jpg?1",
             "name": "Song of the Dryads",
             "text": "Enchant permanent\nEnchanted permanent is a colorless Forest land.",
             "colours": [
@@ -20195,7 +20195,7 @@
         },
         {
             "id": "63ab07c1-302e-5a10-9501-48f9da4d9f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7560722-3481-4866-a86d-5df837e30d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7560722-3481-4866-a86d-5df837e30d43.jpg?1",
             "name": "Stonehoof Chieftain",
             "text": "Trample, indestructible\nWhenever another creature you control attacks, it gains trample and indestructible until end of turn.",
             "colours": [
@@ -20231,7 +20231,7 @@
         },
         {
             "id": "fa211ca3-520f-588a-ba26-cd5e7d1a80f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39691b12-9a01-46a1-bbb7-458a79a4f115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39691b12-9a01-46a1-bbb7-458a79a4f115.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014\n\u2022 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n\u2022 Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -20265,7 +20265,7 @@
         },
         {
             "id": "f9feeb24-4206-573a-8e3f-fa908489400c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa64560b-773c-4a93-b28d-cf317c78da09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa64560b-773c-4a93-b28d-cf317c78da09.jpg?1",
             "name": "Verdant Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Return target permanent card from your graveyard to your hand.\n\u2022 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -20298,7 +20298,7 @@
         },
         {
             "id": "0574a7f9-d606-5092-8c81-e596afb6f2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abbe-871e-468c-8d37-fc0de030d735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab3abbe-871e-468c-8d37-fc0de030d735.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.",
             "colours": [
@@ -20333,7 +20333,7 @@
         },
         {
             "id": "410fe4ac-9da8-503a-b53d-c40041f8c2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a76f047-0143-4485-bb37-3a0159f4d5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a76f047-0143-4485-bb37-3a0159f4d5fa.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "{2}{G}, {T}, Put a verse counter on Yisan, the Wanderer Bard: Search your library for a creature card with mana value equal to the number of verse counters on Yisan, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -20372,7 +20372,7 @@
         },
         {
             "id": "9b74c8d4-0d15-5e15-92e0-ce90a014e6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3827786f-c47b-409b-998f-1f3fee8e5eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3827786f-c47b-409b-998f-1f3fee8e5eca.jpg?1",
             "name": "Experiment Kraj",
             "text": "Experiment Kraj has all activated abilities of each other creature with a +1/+1 counter on it.\n{T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -20412,7 +20412,7 @@
         },
         {
             "id": "57cd427d-221a-5397-b8c6-e3eb7dfd908d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eab50d6-8282-445b-8fd7-64ce52554a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eab50d6-8282-445b-8fd7-64ce52554a06.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -20452,7 +20452,7 @@
         },
         {
             "id": "f37d7f4d-e128-52af-ae40-4ae718b93ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbe7958-0647-4c89-bbb3-939124423c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbe7958-0647-4c89-bbb3-939124423c19.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "{1}{W}{U}, {T}: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -20492,7 +20492,7 @@
         },
         {
             "id": "a0b32d9c-4a35-51c0-b808-ad35e6bfd8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a008a-df2e-438d-9bdf-a7d007179372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a008a-df2e-438d-9bdf-a7d007179372.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nOnce during each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -20534,7 +20534,7 @@
         },
         {
             "id": "1f2bf70d-a614-5d2f-bef7-3e55c3fdbaa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8cf137-49a9-4705-b0ae-5cb42e0778a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8cf137-49a9-4705-b0ae-5cb42e0778a4.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -20577,7 +20577,7 @@
         },
         {
             "id": "1ed20728-7561-5016-848b-990339114e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4178d93f-72fa-43a1-b6aa-35f1b4a597a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4178d93f-72fa-43a1-b6aa-35f1b4a597a7.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -20619,7 +20619,7 @@
         },
         {
             "id": "d0fd0961-6694-5d21-9ce4-1b239182d693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4bd2d3-ab54-432a-b617-247771b9c22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4bd2d3-ab54-432a-b617-247771b9c22b.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "Whenever another creature you control dies, you get an experience counter.\nAt the beginning of your end step, choose target creature card in your graveyard. If that card's mana value is less than or equal to the number of experience counters you have, return it to the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -20660,7 +20660,7 @@
         },
         {
             "id": "3f603149-cc27-55df-b24d-a4930f8b572a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8c051d-3ff7-478c-89af-3691610c0adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8c051d-3ff7-478c-89af-3691610c0adf.jpg?1",
             "name": "Mirri, Weatherlight Duelist",
             "text": "First strike\nWhenever Mirri, Weatherlight Duelist attacks, each opponent can't block with more than one creature this combat.\nAs long as Mirri, Weatherlight Duelist is tapped, no more than one creature can attack you each combat.",
             "colours": [
@@ -20700,7 +20700,7 @@
         },
         {
             "id": "356efd14-aa92-508e-a41d-20d7a54b9bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c74-6aec-4d66-b9ff-7270ce27920f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c74-6aec-4d66-b9ff-7270ce27920f.jpg?1",
             "name": "Mizzix of the Izmagnus",
             "text": "Whenever you cast an instant or sorcery spell with mana value greater than the number of experience counters you have, you get an experience counter.\nInstant and sorcery spells you cast cost {1} less to cast for each experience counter you have.",
             "colours": [
@@ -20740,7 +20740,7 @@
         },
         {
             "id": "0266043b-60d8-512c-8369-e6a4c0a088e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4df0f7-68c4-48e4-adc9-32d2af9dc206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4df0f7-68c4-48e4-adc9-32d2af9dc206.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nWhenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",
             "colours": [
@@ -20782,7 +20782,7 @@
         },
         {
             "id": "4ac2ac2a-40a6-5b13-a415-65a474757aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a626cee3-156f-4f5f-990d-4309f3a94d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a626cee3-156f-4f5f-990d-4309f3a94d7a.jpg?1",
             "name": "Queen Marchesa",
             "text": "Deathtouch, haste\nWhen Queen Marchesa enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with deathtouch and haste.",
             "colours": [
@@ -20824,7 +20824,7 @@
         },
         {
             "id": "a9735926-8bfb-5b14-ab5b-1b77d39bfd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361087ea-16f9-4d93-b720-1ebaa05bc281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361087ea-16f9-4d93-b720-1ebaa05bc281.jpg?1",
             "name": "Rafiq of the Many",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains double strike until end of turn.",
             "colours": [
@@ -20866,7 +20866,7 @@
         },
         {
             "id": "7992fee5-8c8c-53b2-b79f-7d134b4db281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff8244-ec3b-41bd-a007-bbd403a96e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff8244-ec3b-41bd-a007-bbd403a96e96.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -20905,7 +20905,7 @@
         },
         {
             "id": "58710689-7b14-5afc-a917-1afd645c9c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d86df-388d-421d-b904-d563e81727ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d86df-388d-421d-b904-d563e81727ad.jpg?1",
             "name": "Sek'Kuar, Deathkeeper",
             "text": "Whenever another nontoken creature you control dies, create a 3/1 black and red Graveborn creature token with haste.",
             "colours": [
@@ -20947,7 +20947,7 @@
         },
         {
             "id": "ab18b3d8-d0b3-530d-a9cc-20e0bc8a86e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc3be0-6159-4cda-8785-b0bec7f4b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc3be0-6159-4cda-8785-b0bec7f4b69f.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, mill three cards.\nWhenever one or more creature cards are put into your graveyard from your library, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -20989,7 +20989,7 @@
         },
         {
             "id": "3354747a-e4f7-5b66-a5eb-8d4f31a59c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385001c7-b39d-4654-9f6e-8d31ade506a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385001c7-b39d-4654-9f6e-8d31ade506a1.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -21030,7 +21030,7 @@
         },
         {
             "id": "572fcaf0-38c9-5f09-a48b-f377d18b9925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0192cd-9c14-4f24-bc31-febfb135f707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0192cd-9c14-4f24-bc31-febfb135f707.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -21078,7 +21078,7 @@
         },
         {
             "id": "0ac8e62f-9308-5936-b519-02b4c6ff73a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b87861-6262-4be4-9995-9016bca4fb6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b87861-6262-4be4-9995-9016bca4fb6e.jpg?1",
             "name": "Xantcha, Sleeper Agent",
             "text": "Xantcha, Sleeper Agent enters the battlefield under the control of an opponent of your choice.\nXantcha attacks each combat if able and can't attack its owner or planeswalkers its owner controls.\n{3}: Xantcha's controller loses 2 life and you draw a card. Any player may activate this ability.",
             "colours": [
@@ -21118,7 +21118,7 @@
         },
         {
             "id": "a46cd09d-8424-5fbb-b872-1257332e03f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4484804-a98d-440c-bb67-07714de2bef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4484804-a98d-440c-bb67-07714de2bef3.jpg?1",
             "name": "Yennett, Cryptic Sovereign",
             "text": "Flying, vigilance, menace\nWhenever Yennett, Cryptic Sovereign attacks, reveal the top card of your library. You may cast it without paying its mana cost if its mana value is odd. If you don't cast it, draw a card.",
             "colours": [
@@ -21159,7 +21159,7 @@
         },
         {
             "id": "025a5abb-a07a-50da-8b88-11a700a22177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f058f8e8-aa01-4dc0-a6a5-0490521b83d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f058f8e8-aa01-4dc0-a6a5-0490521b83d4.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's mana value.",
             "colours": [
@@ -21200,7 +21200,7 @@
         },
         {
             "id": "c2d78a88-cf0f-52e8-a0c5-7f02f1eba1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98c92cc-44c7-4555-8832-98c5b526c43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98c92cc-44c7-4555-8832-98c5b526c43a.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -21243,7 +21243,7 @@
         },
         {
             "id": "86ec5053-1eb0-55c3-b32d-b9e029253f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd12285b-12f8-42f5-bff1-2b66c4f5c568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd12285b-12f8-42f5-bff1-2b66c4f5c568.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "Trample\nLethal damage dealt to creatures you control is determined by their power rather than their toughness.",
             "colours": [
@@ -21282,7 +21282,7 @@
         },
         {
             "id": "c7dfe00d-5136-5047-b1f0-be1205bea62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac12f5-5198-447e-ac67-fdc4e876571d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac12f5-5198-447e-ac67-fdc4e876571d.jpg?1",
             "name": "Boompile",
             "text": "{T}: Flip a coin. If you win the flip, destroy all nonland permanents.",
             "colours": [],
@@ -21311,7 +21311,7 @@
         },
         {
             "id": "3ad7fa28-edc2-5a24-993d-d092aaabce27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5758df-adf9-4d78-8fae-d300a20a49a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5758df-adf9-4d78-8fae-d300a20a49a6.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -21343,7 +21343,7 @@
         },
         {
             "id": "a4f69fa3-b78e-59ba-bc74-5c0d9a643f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc68acfb-758d-4466-b4f2-c12ce2d8b6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc68acfb-758d-4466-b4f2-c12ce2d8b6d8.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
             "colours": [],
@@ -21372,7 +21372,7 @@
         },
         {
             "id": "949bb0f2-aae3-519b-9b2c-8ffe99308ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d53713-c489-4f77-96d6-c499fd6161d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d53713-c489-4f77-96d6-c499fd6161d6.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21401,7 +21401,7 @@
         },
         {
             "id": "7f476efd-a1ba-5997-888a-102b2fce3146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ec784-8c10-49f5-831b-309c383be4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ec784-8c10-49f5-831b-309c383be4ca.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint \u2014 When Extraplanar Lens enters the battlefield, you may exile target land you control.\nWhenever a land with the same name as the exiled card is tapped for mana, its controller adds one mana of any type that land produced.",
             "colours": [],
@@ -21431,7 +21431,7 @@
         },
         {
             "id": "0402b90b-778a-5483-b21e-8089eafdce7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929ec761-fcc6-473d-b160-0feff6cdf7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929ec761-fcc6-473d-b160-0feff6cdf7d0.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -21460,7 +21460,7 @@
         },
         {
             "id": "2cc9856d-ca56-539b-8bbe-9067e2490167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe0ad2c-9553-4f55-8e8a-f593971bf601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe0ad2c-9553-4f55-8e8a-f593971bf601.jpg?1",
             "name": "Hammer of Nazahn",
             "text": "Whenever Hammer of Nazahn or another Equipment enters the battlefield under your control, you may attach that Equipment to target creature you control.\nEquipped creature gets +2/+0 and has indestructible.\nEquip {4}",
             "colours": [],
@@ -21493,7 +21493,7 @@
         },
         {
             "id": "6ba1443b-fe35-5a31-85e4-d089b3c55d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a4b5-cdec-47bb-824f-4390abe832d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a4b5-cdec-47bb-824f-4390abe832d0.jpg?1",
             "name": "Idol of Oblivion",
             "text": "{T}: Draw a card. Activate only if you created a token this turn.\n{8}, {T}, Sacrifice Idol of Oblivion: Create a 10/10 colorless Eldrazi creature token.",
             "colours": [],
@@ -21522,7 +21522,7 @@
         },
         {
             "id": "79e9a505-77bf-59a1-b27d-0c9e69b32000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ae427-a727-48cb-9398-886b1dbd477c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ae427-a727-48cb-9398-886b1dbd477c.jpg?1",
             "name": "The Immortal Sun",
             "text": "Players can't activate planeswalkers' loyalty abilities.\nAt the beginning of your draw step, draw an additional card.\nSpells you cast cost {1} less to cast.\nCreatures you control get +1/+1.",
             "colours": [],
@@ -21553,7 +21553,7 @@
         },
         {
             "id": "8a761b7f-dbe2-5e0b-8268-1dc1ac88c817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae2050-764d-49aa-83db-aca6a46e4e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae2050-764d-49aa-83db-aca6a46e4e6f.jpg?1",
             "name": "Inspiring Statuary",
             "text": "Nonartifact spells you cast have improvise. (Your artifacts can help cast those spells. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -21582,7 +21582,7 @@
         },
         {
             "id": "d09a2865-0e13-5142-a118-e909bf7fa552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3469311-29a0-42bc-8643-70a961d24c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3469311-29a0-42bc-8643-70a961d24c23.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21611,7 +21611,7 @@
         },
         {
             "id": "7dc7f659-6dd5-5569-a106-ba331367c3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af70720-ba91-41b0-ba4a-ff2035afdb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af70720-ba91-41b0-ba4a-ff2035afdb0e.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -21642,7 +21642,7 @@
         },
         {
             "id": "6e3db26f-83da-5a4e-a934-a9726324afc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eec8c7-0391-4d9d-a388-d4bbd11abf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eec8c7-0391-4d9d-a388-d4bbd11abf03.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21671,7 +21671,7 @@
         },
         {
             "id": "e501c976-252b-5f6d-86d9-c680aaca18a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f58a480-1b01-4974-b859-2d6b6bfce463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f58a480-1b01-4974-b859-2d6b6bfce463.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21700,7 +21700,7 @@
         },
         {
             "id": "bb3b489e-3086-58f6-b68b-2d2de2eba279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af60a5d2-d8e9-4fea-9edc-1fbe6dd190a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af60a5d2-d8e9-4fea-9edc-1fbe6dd190a9.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -21729,7 +21729,7 @@
         },
         {
             "id": "7fb44c0c-9b8a-5906-9e24-6c9c53f1e5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1b6402-c054-4dd5-a9d5-3d218270e8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1b6402-c054-4dd5-a9d5-3d218270e8ba.jpg?1",
             "name": "Scytheclaw",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, that player loses half their life, rounded up.\nEquip {3}",
             "colours": [],
@@ -21760,7 +21760,7 @@
         },
         {
             "id": "93d9bbc0-1e6a-5ba4-af38-f081388d23e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01048220-cef3-47ee-8d68-d01d324ad8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01048220-cef3-47ee-8d68-d01d324ad8af.jpg?1",
             "name": "Sword of the Animist",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nEquip {2}",
             "colours": [],
@@ -21793,7 +21793,7 @@
         },
         {
             "id": "7aeec5f2-67cf-5730-97e7-db154186c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaabadb6-fa93-4128-af87-1803e4b33040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaabadb6-fa93-4128-af87-1803e4b33040.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -21826,7 +21826,7 @@
         },
         {
             "id": "2c5fac9c-debd-5e37-ac26-29c1e28b8038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad21db5-5189-4d57-b399-0d1c415c0922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ad21db5-5189-4d57-b399-0d1c415c0922.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -21859,7 +21859,7 @@
         },
         {
             "id": "2f2c44fa-03f3-52b4-9656-a970b15f153e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda58e50-9fce-46a6-989d-ee855e7369c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda58e50-9fce-46a6-989d-ee855e7369c3.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -21892,7 +21892,7 @@
         },
         {
             "id": "9d0c12e7-a614-51c7-b341-9315bf434284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a8afb-39f8-4e5a-88ca-2d8ad9ed4019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988a8afb-39f8-4e5a-88ca-2d8ad9ed4019.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -21925,7 +21925,7 @@
         },
         {
             "id": "df681d9a-eab1-5682-858b-a43d64b6d099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f6c0a-5dad-4b9a-89cf-757c7e26e7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f6c0a-5dad-4b9a-89cf-757c7e26e7c4.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -21958,7 +21958,7 @@
         },
         {
             "id": "45d418cc-7d3c-5286-9a96-76efd8066db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b2bf55-6b24-4f63-bbb0-98471c167405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b2bf55-6b24-4f63-bbb0-98471c167405.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -21994,7 +21994,7 @@
         },
         {
             "id": "c7cfb1ee-675f-513b-b214-3503e2fe0c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08605ffa-de04-4831-a078-5b3d65c2526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08605ffa-de04-4831-a078-5b3d65c2526f.jpg?1",
             "name": "Darksteel Mutation",
             "text": "Enchant creature\nEnchanted creature is an Insect artifact creature with base power and toughness 0/1 and has indestructible, and it loses all other abilities, card types, and creature types.",
             "colours": [
@@ -22030,7 +22030,7 @@
         },
         {
             "id": "29e26b93-2a0c-54d1-bc5d-21cbaeeb4ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd4438-a25d-4618-9e93-2c62f6bfc5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cd4438-a25d-4618-9e93-2c62f6bfc5f5.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -22064,7 +22064,7 @@
         },
         {
             "id": "7f93a84f-b52b-5337-86c4-c867aaf5622a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d28118-eddb-4ee3-a425-eadb1a1649a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d28118-eddb-4ee3-a425-eadb1a1649a8.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -22102,7 +22102,7 @@
         },
         {
             "id": "9a5d1d3b-484b-56a9-a812-ed242807b148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c2a76-b9f5-42f2-8652-dafa5bd132cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14c2a76-b9f5-42f2-8652-dafa5bd132cb.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22136,7 +22136,7 @@
         },
         {
             "id": "f68050d1-1cc2-531b-9a53-6ca87b93780a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a89d111-1a7c-4446-9a53-99d5d68099cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a89d111-1a7c-4446-9a53-99d5d68099cf.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -22174,7 +22174,7 @@
         },
         {
             "id": "7c08caa3-2b34-5525-8ed3-995ad78b1af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba852b68-eeb7-4023-898c-0722a82d4cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba852b68-eeb7-4023-898c-0722a82d4cff.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -22208,7 +22208,7 @@
         },
         {
             "id": "c78fa4f0-c26b-5fe4-abee-a0457c491c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80b956-24a4-4b22-b483-4e3fc66b7662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80b956-24a4-4b22-b483-4e3fc66b7662.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "Search your library for an Equipment card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -22243,7 +22243,7 @@
         },
         {
             "id": "e555abc7-47d6-5fed-b063-27b319b44b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e47212d-399e-4121-92d4-9fb0d85767cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e47212d-399e-4121-92d4-9fb0d85767cb.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -22277,7 +22277,7 @@
         },
         {
             "id": "430eb908-4e71-5dfc-9c7f-5dc63e513346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf26a2f-376e-4437-b2b4-78f8c512fb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf26a2f-376e-4437-b2b4-78f8c512fb13.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -22311,7 +22311,7 @@
         },
         {
             "id": "6a493cf1-2547-5971-a8f4-38a54b4137f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2a4ce-a44b-480b-b1a2-94fb2514c082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2a4ce-a44b-480b-b1a2-94fb2514c082.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -22345,7 +22345,7 @@
         },
         {
             "id": "a8a1b467-1a71-5154-afa2-a6f1382959db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c1fd2-ddb9-4454-ae24-de8e69437ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c1fd2-ddb9-4454-ae24-de8e69437ad1.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your library for a sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -22380,7 +22380,7 @@
         },
         {
             "id": "1396a2eb-6f2f-53e0-8bd7-725844c2f077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9fe9db-21c0-405b-b10e-11cb08e6a8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9fe9db-21c0-405b-b10e-11cb08e6a8fb.jpg?1",
             "name": "Reality Shift",
             "text": "Exile target creature. Its controller manifests the top card of their library.",
             "colours": [
@@ -22414,7 +22414,7 @@
         },
         {
             "id": "763add5a-8e48-5f95-85f8-d30743986ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2519c60-d0af-4df7-aa41-2624ce8af668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2519c60-d0af-4df7-aa41-2624ce8af668.jpg?1",
             "name": "Spellseeker",
             "text": "When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with mana value 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -22452,7 +22452,7 @@
         },
         {
             "id": "4b38949e-98c1-50f0-a9d3-2eba278774b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab9c69f-cb12-4095-af83-89319f00a3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab9c69f-cb12-4095-af83-89319f00a3fa.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension.\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -22487,7 +22487,7 @@
         },
         {
             "id": "10b3d66c-5392-51db-a257-cbf2c206c76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721aff76-9f80-4ec2-ae29-2dc8494a1a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721aff76-9f80-4ec2-ae29-2dc8494a1a06.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures.",
             "colours": [
@@ -22521,7 +22521,7 @@
         },
         {
             "id": "5d3fd16a-a936-5233-9923-0882df91bbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9bb677-6b9a-4ccf-accc-b1a91be85b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9bb677-6b9a-4ccf-accc-b1a91be85b70.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -22555,7 +22555,7 @@
         },
         {
             "id": "95550d09-78ac-5c2f-989e-a4d8a6c6f97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9d2a9b-daf2-4ebe-bb8c-0b1d4dfa9e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9d2a9b-daf2-4ebe-bb8c-0b1d4dfa9e35.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever a creature you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -22590,7 +22590,7 @@
         },
         {
             "id": "b325dc42-768c-5e3f-b7c2-029332c11821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada27732-0491-4c99-980d-2f3c3230f220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada27732-0491-4c99-980d-2f3c3230f220.jpg?1",
             "name": "Kindred Dominance",
             "text": "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
             "colours": [
@@ -22625,7 +22625,7 @@
         },
         {
             "id": "e842dba1-26c1-59c4-a8ea-b14bed6799f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0a988-5aee-4f4c-8efe-4c2a392702b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b0a988-5aee-4f4c-8efe-4c2a392702b1.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -22662,7 +22662,7 @@
         },
         {
             "id": "b2eb3cc1-f5c9-568d-85be-ec8c40169e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65879a80-b656-412f-8b90-aa6d4f36a43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65879a80-b656-412f-8b90-aa6d4f36a43c.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R}",
             "colours": [
@@ -22696,7 +22696,7 @@
         },
         {
             "id": "847531bb-d26d-584a-aa56-d16a90c3b5fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d84eb6f-2675-436c-885e-207468110d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d84eb6f-2675-436c-885e-207468110d76.jpg?1",
             "name": "Magus of the Wheel",
             "text": "{1}{R}, {T}, Sacrifice Magus of the Wheel: Each player discards their hand, then draws seven cards.",
             "colours": [
@@ -22734,7 +22734,7 @@
         },
         {
             "id": "65620183-c8af-5177-8f31-01f183542d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c896fe-c208-41ec-aad8-fe56c7858942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c896fe-c208-41ec-aad8-fe56c7858942.jpg?1",
             "name": "Storm-Kiln Artist",
             "text": "Storm-Kiln Artist gets +1/+0 for each artifact you control.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a Treasure token.",
             "colours": [
@@ -22771,7 +22771,7 @@
         },
         {
             "id": "5067423e-74e4-52e3-9eb0-f9c554bf093f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9e634-1d92-4c5e-b371-593f695e48bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9e634-1d92-4c5e-b371-593f695e48bf.jpg?1",
             "name": "Treasure Nabber",
             "text": "Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.",
             "colours": [
@@ -22809,7 +22809,7 @@
         },
         {
             "id": "d0e9f6e8-09f6-5b0a-a910-21479128797e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd4b96-72d4-4eab-9a8d-90c8b3510250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd4b96-72d4-4eab-9a8d-90c8b3510250.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R}",
             "colours": [
@@ -22843,7 +22843,7 @@
         },
         {
             "id": "8e5475aa-b645-5b10-917e-fbeeadda7d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d3b29-ab35-4c61-82b8-bb5d481c738a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8d3b29-ab35-4c61-82b8-bb5d481c738a.jpg?1",
             "name": "Arachnogenesis",
             "text": "Create X 1/2 green Spider creature tokens with reach, where X is the number of creatures attacking you. Prevent all combat damage that would be dealt this turn by non-Spider creatures.",
             "colours": [
@@ -22878,7 +22878,7 @@
         },
         {
             "id": "cde35dd3-ec4a-53fb-ac02-4a8445df874e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ba531-ab3b-4d00-af2c-2d4914c68cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ba531-ab3b-4d00-af2c-2d4914c68cd8.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -22915,7 +22915,7 @@
         },
         {
             "id": "3004378f-90c5-5906-9b21-c0109f2241b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0506e30-ed0d-4838-97b1-55900ad633b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0506e30-ed0d-4838-97b1-55900ad633b5.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -22951,7 +22951,7 @@
         },
         {
             "id": "f95fe532-f61a-5034-b96a-12f5de99a2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b5e975-bd75-4f7c-829d-e87f8b24bc2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b5e975-bd75-4f7c-829d-e87f8b24bc2f.jpg?1",
             "name": "Ohran Frostfang",
             "text": "Attacking creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -22990,7 +22990,7 @@
         },
         {
             "id": "580b4587-939d-5e98-9172-39e0fdb0cfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ff72b-30cf-44e8-a592-540a501589e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ff72b-30cf-44e8-a592-540a501589e8.jpg?1",
             "name": "Regal Behemoth",
             "text": "Trample\nWhen Regal Behemoth enters the battlefield, you become the monarch.\nWhenever you tap a land for mana while you're the monarch, add an additional one mana of any color.",
             "colours": [
@@ -23027,7 +23027,7 @@
         },
         {
             "id": "eb287912-c6f4-52a3-83b0-704a3341ad1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78e78d6-ef31-4343-91cc-c148e86f8497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78e78d6-ef31-4343-91cc-c148e86f8497.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014\n\u2022 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n\u2022 Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -23062,7 +23062,7 @@
         },
         {
             "id": "306bac0e-10b2-5db3-9e4b-a36dea8336ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1836b8a6-c616-4793-933b-b38296d70e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1836b8a6-c616-4793-933b-b38296d70e72.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -23092,7 +23092,7 @@
         },
         {
             "id": "deef6d2c-d636-5a95-89e9-bade7a110ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147b0d7d-3657-4521-b370-3a4f3a419313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147b0d7d-3657-4521-b370-3a4f3a419313.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -23125,7 +23125,7 @@
         },
         {
             "id": "6481991f-193f-552b-82dc-6924d697fa9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516692b8-fbaf-4698-864b-5363aafc95b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516692b8-fbaf-4698-864b-5363aafc95b9.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -23155,7 +23155,7 @@
         },
         {
             "id": "28bd87e7-a2cb-5256-980e-084d49eca972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8390737-edfe-459e-9f1e-bdec2d95057a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8390737-edfe-459e-9f1e-bdec2d95057a.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint \u2014 When Extraplanar Lens enters the battlefield, you may exile target land you control.\nWhenever a land with the same name as the exiled card is tapped for mana, its controller adds one mana of any type that land produced.",
             "colours": [],
@@ -23186,7 +23186,7 @@
         },
         {
             "id": "19ec5569-c4bf-58ed-b2bc-480b6b8f87af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa15d3b3-c709-4d9b-a9ec-c8d68f805ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa15d3b3-c709-4d9b-a9ec-c8d68f805ebf.jpg?1",
             "name": "Fellwar Stone",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -23216,7 +23216,7 @@
         },
         {
             "id": "dd0cb906-b442-5c95-b0bd-d32093b0d9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428fe419-358d-4a36-89d8-bde0622beb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428fe419-358d-4a36-89d8-bde0622beb74.jpg?1",
             "name": "Thran Dynamo",
             "text": "{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -23246,7 +23246,7 @@
         },
         {
             "id": "d10f4df1-8e7a-5aa3-8d90-f2bd793c00d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24179418-d92c-43eb-a8f6-b8ea83f8c80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24179418-d92c-43eb-a8f6-b8ea83f8c80f.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -23276,7 +23276,7 @@
         },
         {
             "id": "baf97dee-78dc-568d-b80c-7a1a6acc6474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb9b5a-f904-4934-9530-87d752eeae75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efb9b5a-f904-4934-9530-87d752eeae75.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -23306,7 +23306,7 @@
         },
         {
             "id": "efb33c58-bbea-5a36-a21a-d28efb821336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d574a-72b5-43be-b4b5-87865bbc7b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d574a-72b5-43be-b4b5-87865bbc7b5c.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -23336,7 +23336,7 @@
         },
         {
             "id": "385fcea3-2628-543e-9f15-ce47d594d600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a392e-ea3b-4de2-beeb-72772a546070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a392e-ea3b-4de2-beeb-72772a546070.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -23370,7 +23370,7 @@
         },
         {
             "id": "09c11b11-1fa0-5e72-b237-ad6ec5477abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2370ea-9bb8-496f-aaf5-f0bb3bb55f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2370ea-9bb8-496f-aaf5-f0bb3bb55f9b.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -23400,7 +23400,7 @@
         },
         {
             "id": "9a01cc57-e9d2-5119-bb45-8a734b2fe26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126484c-c3eb-484d-95a1-83eebb115b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126484c-c3eb-484d-95a1-83eebb115b83.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -23434,7 +23434,7 @@
         },
         {
             "id": "2b872d12-1cca-5df8-bfb5-5c0ec7ec09b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e601d1-cf31-4077-b3ad-e13dfce4dac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e601d1-cf31-4077-b3ad-e13dfce4dac3.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -23468,7 +23468,7 @@
         },
         {
             "id": "fc6bfd40-5525-530f-995a-9b2318b21bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84964ae0-5284-483c-8372-18bb485a25b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84964ae0-5284-483c-8372-18bb485a25b5.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -23502,7 +23502,7 @@
         },
         {
             "id": "cb70279f-d8e5-59e2-90c9-cc09b8d7cc34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be7c23e-312d-4b20-9bb7-0344a73acac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be7c23e-312d-4b20-9bb7-0344a73acac9.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -23536,7 +23536,7 @@
         },
         {
             "id": "04ef11e8-3918-5332-9f7c-3dc29d972c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fe08-37d1-40bb-bb64-af41b025314b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fe08-37d1-40bb-bb64-af41b025314b.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -23572,7 +23572,7 @@
         },
         {
             "id": "41708cad-0cbf-5648-a5bf-fc8f0316300f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2cfd10-37d9-4429-842e-f5a4c9abe3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2cfd10-37d9-4429-842e-f5a4c9abe3a4.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -23614,7 +23614,7 @@
         },
         {
             "id": "3bcc2d2e-f332-5087-963e-f7147a10500f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1571f-d73f-48ed-b6e2-f1388c410506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1571f-d73f-48ed-b6e2-f1388c410506.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -23650,7 +23650,7 @@
         },
         {
             "id": "c2656ebb-1210-554e-bc6d-5215765581db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae202c-21bf-4142-a8f0-89a13c25f9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae202c-21bf-4142-a8f0-89a13c25f9f9.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, create a 2/2 white Cat creature token for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -23689,7 +23689,7 @@
         },
         {
             "id": "52ad7e59-6f34-5df4-8a3b-2bdd5ff98256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6c234e-ce4a-4556-bfaf-9b3f53c92568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6c234e-ce4a-4556-bfaf-9b3f53c92568.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "Tap an untapped Wizard you control: Draw a card.",
             "colours": [
@@ -23729,7 +23729,7 @@
         },
         {
             "id": "76774687-ebed-55ab-ab24-1437697142a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbfc7f-51b6-4925-a0f7-b2873366653e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbbfc7f-51b6-4925-a0f7-b2873366653e.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -23769,7 +23769,7 @@
         },
         {
             "id": "3807363e-370d-5f54-b818-2de66a27f433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c6f09-a0b2-46c9-a291-59408dfa52b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c6f09-a0b2-46c9-a291-59408dfa52b0.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -23810,7 +23810,7 @@
         },
         {
             "id": "1407f184-0d3c-5fbd-b3d4-34c214a33ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffde74fb-cc20-4d82-bf6a-b18081047b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffde74fb-cc20-4d82-bf6a-b18081047b0a.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -23851,7 +23851,7 @@
         },
         {
             "id": "23ff6fd3-4760-51f9-85bd-f07ddf769796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25def92-c566-4ca9-8bda-e8917fc6582c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25def92-c566-4ca9-8bda-e8917fc6582c.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from the battlefield, you may return that card to the battlefield at the beginning of the next end step if Shirei, Shizo's Caretaker is still on the battlefield.",
             "colours": [
@@ -23889,7 +23889,7 @@
         },
         {
             "id": "1c31a72c-d957-51fa-9157-c8e693bcc79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6ab04e-f41f-487a-9c7e-4fb836c8b96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6ab04e-f41f-487a-9c7e-4fb836c8b96e.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "Whenever a creature you control deals combat damage to a player, choose one \u2014\n\u2022 Goad target creature that player controls.\n\u2022 Exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -23929,7 +23929,7 @@
         },
         {
             "id": "516ab140-0bf3-535b-b836-313366cfe214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bf045f-9872-4af2-a067-ee59898545da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bf045f-9872-4af2-a067-ee59898545da.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -23971,7 +23971,7 @@
         },
         {
             "id": "6501ca61-0294-50ff-beb4-fb265609b198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2184e61d-6f25-425a-b914-b7d6ecd002c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2184e61d-6f25-425a-b914-b7d6ecd002c2.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -24011,7 +24011,7 @@
         },
         {
             "id": "a431efa7-6a68-5ca5-b504-fe35c4fd9111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fe30b-954a-4abf-aa18-4107683ad868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5fe30b-954a-4abf-aa18-4107683ad868.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -24051,7 +24051,7 @@
         },
         {
             "id": "39bcdfb8-6f46-5965-9eb7-5b7a4a380742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088aed3-4568-4978-ac4c-6c435b65c083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088aed3-4568-4978-ac4c-6c435b65c083.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -24092,7 +24092,7 @@
         },
         {
             "id": "eee2a568-149d-5e9c-b596-17123eb5d492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477f06ee-b986-4de2-97e9-97ba7ec7c45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477f06ee-b986-4de2-97e9-97ba7ec7c45d.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "Flying, first strike\nIf a source would deal damage to an opponent or a permanent an opponent controls, that source deals double that damage to that player or permanent instead.\nIf a source would deal damage to you or a permanent you control, prevent half that damage, rounded up.",
             "colours": [
@@ -24133,7 +24133,7 @@
         },
         {
             "id": "b6959f17-31a5-52a6-a566-ec127fb236a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01e857d-cc78-4364-9f31-6879d4ec74e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01e857d-cc78-4364-9f31-6879d4ec74e1.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -24177,7 +24177,7 @@
         },
         {
             "id": "99251cea-863f-57c1-9b91-fc5b89aac82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8bb9c1-4b20-4fd9-b0c4-b1f74f0fb6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8bb9c1-4b20-4fd9-b0c4-b1f74f0fb6fd.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -24220,7 +24220,7 @@
         },
         {
             "id": "86d800bc-428c-5399-88a5-7f78471b018c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7ef286-666f-4a35-9d3f-12a0e888e35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7ef286-666f-4a35-9d3f-12a0e888e35a.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "Whenever another creature you control dies, you get an experience counter.\nAt the beginning of your end step, choose target creature card in your graveyard. If that card's mana value is less than or equal to the number of experience counters you have, return it to the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -24262,7 +24262,7 @@
         },
         {
             "id": "999c43e1-7dd5-56cc-ae97-afbdd824042e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c649e923-dcd1-45d7-90bd-4e2fe55c8ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c649e923-dcd1-45d7-90bd-4e2fe55c8ce7.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -24302,7 +24302,7 @@
         },
         {
             "id": "f8cbb75c-aebc-5acb-b48e-c06302d8daae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f8d9d-422a-43c8-903e-9b3e87142bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402f8d9d-422a-43c8-903e-9b3e87142bb3.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -24343,7 +24343,7 @@
         },
         {
             "id": "bd618df2-7374-5233-91fe-08d5459b4ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581a2da7-80d3-409a-8a6c-aa6e9ccc1568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581a2da7-80d3-409a-8a6c-aa6e9ccc1568.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -24385,7 +24385,7 @@
         },
         {
             "id": "b809d179-e4f4-5691-82cb-0dd32a28dd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270c798-a3ba-4826-b0a9-82f7e12890f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270c798-a3ba-4826-b0a9-82f7e12890f6.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -24434,7 +24434,7 @@
         },
         {
             "id": "3a7e86b6-c5af-56b6-8718-d752d074f063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe61f-513e-4308-8194-99f73c6fa972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fe61f-513e-4308-8194-99f73c6fa972.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's mana value.",
             "colours": [
@@ -24476,7 +24476,7 @@
         },
         {
             "id": "2a175a9d-8cb7-5ae7-b10e-2d488694b1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d59045-12b9-47aa-b1d5-15a07b4b931a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d59045-12b9-47aa-b1d5-15a07b4b931a.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -24520,7 +24520,7 @@
         },
         {
             "id": "7d55da97-31f0-5388-a85d-bd9ea2e3d612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bf400-31c0-4ae4-8429-0f6fb92cbe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bf400-31c0-4ae4-8429-0f6fb92cbe9e.jpg?1",
             "name": "Flawless Maneuver",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCreatures you control gain indestructible until end of turn.",
             "colours": [
@@ -24555,7 +24555,7 @@
         },
         {
             "id": "73b1087c-0842-592d-9c59-38bdbb0fe853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65d83c-67bd-4d54-9c9a-50d57ca115bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da65d83c-67bd-4d54-9c9a-50d57ca115bb.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token.",
             "colours": [
@@ -24590,7 +24590,7 @@
         },
         {
             "id": "99971445-b296-5e06-a1d6-b2408ae0b7fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103c4d8-5a3c-443b-9caf-f41f8b61e73f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103c4d8-5a3c-443b-9caf-f41f8b61e73f.jpg?1",
             "name": "Fierce Guardianship",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nCounter target noncreature spell.",
             "colours": [
@@ -24625,7 +24625,7 @@
         },
         {
             "id": "8ffa339e-baad-568b-a825-17eca245fd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c266d-579e-4757-a4d6-6722fa343a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c266d-579e-4757-a4d6-6722fa343a6c.jpg?1",
             "name": "Deadly Rollick",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nExile target creature.",
             "colours": [
@@ -24660,7 +24660,7 @@
         },
         {
             "id": "8e32d80d-dcc3-5bfa-92ee-118b7761a0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb8533-9404-4af0-a14a-1e136eacdb3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb8533-9404-4af0-a14a-1e136eacdb3a.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -24695,7 +24695,7 @@
         },
         {
             "id": "11c42b94-4cb2-509b-9fe0-045f9344f682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782653e-9d8c-485b-b152-9353cd4f6ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782653e-9d8c-485b-b152-9353cd4f6ec8.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -24732,7 +24732,7 @@
         },
         {
             "id": "847a524f-2c1c-5573-ad73-8dba2754dff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e70109-0352-45fc-a2fd-892ca65cac2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e70109-0352-45fc-a2fd-892ca65cac2f.jpg?1",
             "name": "Deflecting Swat",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nYou may choose new targets for target spell or ability.",
             "colours": [
@@ -24767,7 +24767,7 @@
         },
         {
             "id": "5f95d778-14d8-5b7a-a725-a1786223f1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8997b72-65cd-4584-8089-d2be620cc3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8997b72-65cd-4584-8089-d2be620cc3cb.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -24802,7 +24802,7 @@
         },
         {
             "id": "74a42419-5500-50e1-86e1-8955eac4d072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67d30b-7a4f-49b4-bf8b-e9cf8c248e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67d30b-7a4f-49b4-bf8b-e9cf8c248e4d.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -24837,7 +24837,7 @@
         },
         {
             "id": "37ca511f-63f0-5eb8-a297-13eed5449d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0ca66a-4dbd-4682-8f0a-3a3d3941a123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0ca66a-4dbd-4682-8f0a-3a3d3941a123.jpg?1",
             "name": "Obscuring Haze",
             "text": "If you control a commander, you may cast this spell without paying its mana cost.\nPrevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -24872,7 +24872,7 @@
         },
         {
             "id": "ca89c3a8-a05c-5f16-bc1c-37cfe1c9ace7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e934462-bf6c-48ff-92a4-1df476c420b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e934462-bf6c-48ff-92a4-1df476c420b7.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -24904,7 +24904,7 @@
         },
         {
             "id": "2d0782b9-dfe7-56d5-84aa-bd4441628bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7454e0cc-98c2-48a1-b2c9-49908d2aedcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7454e0cc-98c2-48a1-b2c9-49908d2aedcc.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -24934,7 +24934,7 @@
         },
         {
             "id": "36582a99-0cc8-53a5-be8d-f9f106bbbfec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015461d-4214-4feb-8b04-519c537759eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015461d-4214-4feb-8b04-519c537759eb.jpg?1",
             "name": "Zhulodok, Void Gorger",
             "text": "Colorless spells you cast from your hand with mana value 7 or greater have \"Cascade, cascade.\" (When you cast one, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [],
@@ -24968,7 +24968,7 @@
         },
         {
             "id": "59191cfc-be27-5744-8c87-1aa61b09430a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b796a56-1611-4835-ac5b-48b4e9263685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b796a56-1611-4835-ac5b-48b4e9263685.jpg?1",
             "name": "Anikthea, Hand of Erebos",
             "text": "Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters the battlefield or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.",
             "colours": [
@@ -25011,7 +25011,7 @@
         },
         {
             "id": "2ac0d6ab-013a-5d3f-9a12-20727771c7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92870fc6-a6bc-4198-bb31-397e07e0e835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92870fc6-a6bc-4198-bb31-397e07e0e835.jpg?1",
             "name": "Commodore Guff",
             "text": "At the beginning of your end step, put a loyalty counter on another target planeswalker you control.\n+1: Create a 1/1 red Wizard creature token with \"{T}: Add {R}. Spend this mana only to cast a planeswalker spell.\"\n\u22123: You draw X cards and Commodore Guff deals X damage to each opponent, where X is the number of planeswalkers you control.\nCommodore Guff can be your commander.",
             "colours": [
@@ -25052,7 +25052,7 @@
         },
         {
             "id": "3f469657-c54d-534c-b8f3-28da92a169a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5d253e-9eb2-423c-90ee-68f27ec6bf88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5d253e-9eb2-423c-90ee-68f27ec6bf88.jpg?1",
             "name": "Sliver Gravemother",
             "text": "The \"legend rule\" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5} ({5}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -25098,7 +25098,7 @@
         },
         {
             "id": "c3395fb9-ca6e-57bf-acf0-389bd0e2398a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e16ac-8e0f-4e2e-9b74-d6a77dddf274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e16ac-8e0f-4e2e-9b74-d6a77dddf274.jpg?1",
             "name": "Omarthis, Ghostfire Initiate",
             "text": "Omarthis, Ghostfire Initiate enters the battlefield with X +1/+1 counters on it.\nWhenever you put one or more +1/+1 counters on another colorless creature, you may put a +1/+1 counter on Omarthis.\nWhen Omarthis dies, manifest a number of cards from the top of your library equal to the number of counters on it.",
             "colours": [],
@@ -25132,7 +25132,7 @@
         },
         {
             "id": "6b24745d-dd06-5f50-8ff7-3db84d3fb78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342979de-041e-4026-94c5-fc457ecde95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342979de-041e-4026-94c5-fc457ecde95d.jpg?1",
             "name": "Leori, Sparktouched Hunter",
             "text": "Flying, vigilance\nWhenever Leori, Sparktouched Hunter deals combat damage to a player, choose a planeswalker type. Until end of turn, whenever you activate an ability of a planeswalker of that type, copy that ability. You may choose new targets for the copies.",
             "colours": [
@@ -25174,7 +25174,7 @@
         },
         {
             "id": "a5021eab-b186-527e-95b9-da5b2474023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a2fa9-82d6-4cf7-adb4-65b187cd9cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a2fa9-82d6-4cf7-adb4-65b187cd9cda.jpg?1",
             "name": "Narci, Fable Singer",
             "text": "Lifelink\nWhenever you sacrifice an enchantment, draw a card.\nWhenever the final chapter ability of a Saga you control resolves, each opponent loses X life and you gain X life, where X is that Saga's mana value.",
             "colours": [
@@ -25216,7 +25216,7 @@
         },
         {
             "id": "0c04a6ce-ddbe-58d5-ae1d-fe31b2174b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f7397-9d75-4667-8872-e58a39512583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f7397-9d75-4667-8872-e58a39512583.jpg?1",
             "name": "Rukarumel, Biologist",
             "text": "As Rukarumel, Biologist enters the battlefield, choose a creature type.\nSlivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 1/1 colorless Sliver creature token.",
             "colours": [
@@ -25262,7 +25262,7 @@
         },
         {
             "id": "59fb32ea-a86a-56bd-8745-b4937c5015bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc2871b-c685-4951-b8e2-7370b9668f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc2871b-c685-4951-b8e2-7370b9668f7e.jpg?1",
             "name": "Abstruse Archaic",
             "text": "Vigilance\n{1}, {T}: Copy target activated or triggered ability you control from a colorless source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
             "colours": [],
@@ -25293,7 +25293,7 @@
         },
         {
             "id": "8a3c6366-a69a-532a-b015-b895dba3c6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a3a89-a87e-4108-87c5-74f656a6249f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839a3a89-a87e-4108-87c5-74f656a6249f.jpg?1",
             "name": "Calamity of the Titans",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile each creature and planeswalker with mana value less than the revealed card's mana value.",
             "colours": [],
@@ -25322,7 +25322,7 @@
         },
         {
             "id": "f9c1da8e-a607-5fd9-b313-7ea1b5d7b067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396db2cb-8fa0-436a-993d-de8bb13b848f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396db2cb-8fa0-436a-993d-de8bb13b848f.jpg?1",
             "name": "Desecrate Reality",
             "text": "For each opponent, exile up to one target permanent that player controls with an even mana value. (Zero is even.)\nAdamant \u2014 If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.",
             "colours": [],
@@ -25351,7 +25351,7 @@
         },
         {
             "id": "056f05ba-6356-55a2-8790-3d8039c07253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f3ee0c-1e73-42b6-841d-0a878a80002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f3ee0c-1e73-42b6-841d-0a878a80002a.jpg?1",
             "name": "Flayer of Loyalties",
             "text": "When you cast this spell, gain control of target creature until end of turn. Untap that creature. Until end of turn, it has base power and toughness 10/10 and gains trample, annihilator 2, and haste.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nTrample",
             "colours": [],
@@ -25382,7 +25382,7 @@
         },
         {
             "id": "68b4200b-8673-5ae7-90a2-f4effb6ac16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4d851b-1fa9-4f5d-a8f6-6967b1ee5b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4d851b-1fa9-4f5d-a8f6-6967b1ee5b50.jpg?1",
             "name": "Rise of the Eldrazi",
             "text": "This spell can't be countered.\nDestroy target permanent. Target player draws four cards. Take an extra turn after this one.\nExile Rise of the Eldrazi.",
             "colours": [],
@@ -25411,7 +25411,7 @@
         },
         {
             "id": "18cf538b-15c5-53e2-bcea-004c1a1caeb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a83be9-856d-4c30-95f5-da72a5ac8263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a83be9-856d-4c30-95f5-da72a5ac8263.jpg?1",
             "name": "Skittering Cicada",
             "text": "Flash\nYou may cast colorless spells as though they had flash.\nWhenever you cast a colorless spell, until end of turn, Skittering Cicada gains trample and gets +X/+X, where X is that spell's mana value.",
             "colours": [],
@@ -25442,7 +25442,7 @@
         },
         {
             "id": "dfb100fa-7984-5121-ba12-068c60fdc9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42991890-731c-4e6a-b0c5-57d6217029ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42991890-731c-4e6a-b0c5-57d6217029ab.jpg?1",
             "name": "Ugin's Mastery",
             "text": "Whenever you cast a colorless creature spell, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever you attack with creatures with total power 6 or greater, you may turn a face-down creature you control face up.",
             "colours": [],
@@ -25471,7 +25471,7 @@
         },
         {
             "id": "0ba1836c-3ba0-5fa1-94c7-b546b818d691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0eaeb-9b62-427d-9873-d84de1740ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0eaeb-9b62-427d-9873-d84de1740ddc.jpg?1",
             "name": "Battle at the Helvault",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 For each player, exile up to one target non-Saga, nonland permanent that player controls until Battle at the Helvault leaves the battlefield.\nIII \u2014 Create Avacyn, a legendary 8/8 white Angel creature token with flying, vigilance, and indestructible.",
             "colours": [
@@ -25504,7 +25504,7 @@
         },
         {
             "id": "0c90917f-ac85-5130-bba5-90aac3380d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a588fc39-ed88-4262-96cd-908fadc7f049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a588fc39-ed88-4262-96cd-908fadc7f049.jpg?1",
             "name": "Boon of the Spirit Realm",
             "text": "Constellation \u2014 Whenever Boon of the Spirit Realm or another enchantment enters the battlefield under your control, put a blessing counter on Boon of the Spirit Realm.\nCreatures you control get +1/+1 for each blessing counter on Boon of the Spirit Realm.",
             "colours": [
@@ -25537,7 +25537,7 @@
         },
         {
             "id": "27ff7071-17ed-5461-a603-158aaeeed4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b3a1bb-1191-4484-80b0-71cf9f8e510b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b3a1bb-1191-4484-80b0-71cf9f8e510b.jpg?1",
             "name": "Gatewatch Beacon",
             "text": "Gatewatch Beacon enters the battlefield with three loyalty counters on it.\n{T}: Add {W}.\nWhenever a planeswalker enters the battlefield under your control, if Gatewatch Beacon has loyalty counters on it, you may move a loyalty counter from Gatewatch Beacon onto that planeswalker.",
             "colours": [
@@ -25570,7 +25570,7 @@
         },
         {
             "id": "6f289a6b-e970-5c13-9966-982ead7fbd24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d0caac-50c0-434e-af77-9ebd2a466415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d0caac-50c0-434e-af77-9ebd2a466415.jpg?1",
             "name": "Onakke Oathkeeper",
             "text": "Creatures can't attack planeswalkers you control unless their controller pays {1} for each creature they control that's attacking a planeswalker you control.\n{4}{W}{W}, Exile Onakke Oathkeeper from your graveyard: Return target planeswalker card from your graveyard to the battlefield.",
             "colours": [
@@ -25606,7 +25606,7 @@
         },
         {
             "id": "d769ff3e-ccc8-58ab-a18c-2958bcb8493d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71991921-a860-44fe-9005-bf604c723167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71991921-a860-44fe-9005-bf604c723167.jpg?1",
             "name": "Ondu Spiritdancer",
             "text": "Whenever an enchantment enters the battlefield under your control, you may create a token that's a copy of it. Do this only once each turn.",
             "colours": [
@@ -25642,7 +25642,7 @@
         },
         {
             "id": "0fca5628-5a40-52a5-8b78-4ca1afbe51b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b081723-41a1-4139-88ee-01c0238e50c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b081723-41a1-4139-88ee-01c0238e50c3.jpg?1",
             "name": "Regal Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch.\"",
             "colours": [
@@ -25677,7 +25677,7 @@
         },
         {
             "id": "98ad33fa-bf87-527b-b40f-29dd47b00b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66fa93a-6888-4297-b22e-7d69fd25c0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66fa93a-6888-4297-b22e-7d69fd25c0d7.jpg?1",
             "name": "Teyo, Geometric Tactician",
             "text": "When Teyo, Geometric Tactician enters the battlefield, create a 0/4 white Wall creature token with defender and flying.\n+1: You and target opponent each draw a card.\n\u22122: Choose left or right. Until your next turn, each player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.",
             "colours": [
@@ -25712,7 +25712,7 @@
         },
         {
             "id": "fb1b84b2-fb5d-52b2-ba1e-7def7913ca22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e941849-033b-499b-b691-6ad9250d9ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e941849-033b-499b-b691-6ad9250d9ecd.jpg?1",
             "name": "Sparkshaper Visionary",
             "text": "At the beginning of combat on your turn, choose any number of target planeswalkers you control. Until end of turn, they become 3/3 blue Bird creatures with flying, hexproof, and \"Whenever this creature deals combat damage to a player, scry 1.\" (They're no longer planeswalkers. Loyalty abilities can still be activated.)",
             "colours": [
@@ -25748,7 +25748,7 @@
         },
         {
             "id": "589e22e7-da58-5f94-a680-8f2bb16c7059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8a900-b15a-42eb-a240-35764d57c155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db8a900-b15a-42eb-a240-35764d57c155.jpg?1",
             "name": "Taunting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, goad target creature an opponent controls.\" (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -25783,7 +25783,7 @@
         },
         {
             "id": "da0ec155-2705-5c26-b62e-520a64b839f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62807f83-b219-4769-afdd-2870deeb93c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62807f83-b219-4769-afdd-2870deeb93c0.jpg?1",
             "name": "Titan of Littjara",
             "text": "As Titan of Littjara enters the battlefield, choose a creature type.\nTitan of Littjara is the chosen type in addition to its other types.\nWhenever Titan of Littjara enters the battlefield or attacks, you may draw a card for each other creature you control that shares a creature type with it. If you do, discard a card.",
             "colours": [
@@ -25818,7 +25818,7 @@
         },
         {
             "id": "ba69ca2b-a70d-5450-90ce-6699a0326e0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd2504b-ff9b-464c-9595-7dffab3bc5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd2504b-ff9b-464c-9595-7dffab3bc5b9.jpg?1",
             "name": "Vronos, Masked Inquisitor",
             "text": "+1: Up to two other target planeswalkers you control phase out at the beginning of the next end step. (Treat them and anything attached to them as though they don't exist until your next turn.)\n\u22122: For each opponent, return up to one target nonland permanent that player controls to its owner's hand.\n\u22127: Target artifact you control becomes a 9/9 Construct artifact creature and gains vigilance, indestructible, and \"This creature can't be blocked.\"",
             "colours": [
@@ -25853,7 +25853,7 @@
         },
         {
             "id": "1da1249b-64cf-52a5-951d-5b6330d1550f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908d9aa5-818c-4651-b135-cc6d1983ad99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908d9aa5-818c-4651-b135-cc6d1983ad99.jpg?1",
             "name": "Cacophony Unleashed",
             "text": "When Cacophony Unleashed enters the battlefield, if you cast it, destroy all nonenchantment creatures.\nWhenever Cacophony Unleashed or another enchantment enters the battlefield under your control, until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment.",
             "colours": [
@@ -25886,7 +25886,7 @@
         },
         {
             "id": "ca138f19-dda8-5037-a1a5-37fe6ce64740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aac73-bcbb-4332-940b-96e1e312bbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aac73-bcbb-4332-940b-96e1e312bbf8.jpg?1",
             "name": "Demon of Fate's Design",
             "text": "Flying, trample\nOnce during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.\n{2}{B}, Sacrifice another enchantment: Demon of Fate's Design gets +X/+0 until end of turn, where X is the sacrificed enchantment's mana value.",
             "colours": [
@@ -25922,7 +25922,7 @@
         },
         {
             "id": "fbd47920-61c2-5703-9955-51838c72a8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe9d991-0abb-47c1-810d-fa44c1820063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe9d991-0abb-47c1-810d-fa44c1820063.jpg?1",
             "name": "Ghoulish Impetus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1, has deathtouch, and is goaded.\nWhen enchanted creature dies, return Ghoulish Impetus to the battlefield at the beginning of the next end step.",
             "colours": [
@@ -25957,7 +25957,7 @@
         },
         {
             "id": "74b2a189-1d1a-5dcc-8dec-fd0eddaddb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f7b4d-2997-412b-8e25-315d93d1603a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f7b4d-2997-412b-8e25-315d93d1603a.jpg?1",
             "name": "Lazotep Sliver",
             "text": "Sliver creatures you control have afflict 2. (Whenever a creature with afflict 2 becomes blocked, defending player loses 2 life.)\nWhenever a nontoken Sliver you control dies, amass Slivers 2. (Put two +1/+1 counters on an Army you control. It's also a Sliver. If you don't control an Army, create a 0/0 black Sliver Army creature token first.)",
             "colours": [
@@ -25993,7 +25993,7 @@
         },
         {
             "id": "5238fa68-2571-5e7c-b95f-313f2d548441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48938cd4-9158-4eb8-acb7-21ce7a11cfa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48938cd4-9158-4eb8-acb7-21ce7a11cfa7.jpg?1",
             "name": "Capricious Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"",
             "colours": [
@@ -26028,7 +26028,7 @@
         },
         {
             "id": "88290daa-b38d-5ca1-9731-dda472be6b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b764e0d-ded0-4036-83b1-de49c6ee8f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b764e0d-ded0-4036-83b1-de49c6ee8f7e.jpg?1",
             "name": "Chandra, Legacy of Fire",
             "text": "At the beginning of your end step, Chandra, Legacy of Fire deals X damage to each opponent, where X is the number of planeswalkers you control.\n+1: Add {R} for each planeswalker you control.\n0: Remove a loyalty counter from each of any number of permanents you control. Exile that many cards from the top of your library. You may play them this turn.",
             "colours": [
@@ -26063,7 +26063,7 @@
         },
         {
             "id": "0b4754a2-91e4-5b77-8565-12121cfb94bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53117fac-5bb0-4bc3-b9ec-f0453c38d7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53117fac-5bb0-4bc3-b9ec-f0453c38d7f8.jpg?1",
             "name": "Descendants' Fury",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may sacrifice one of them. If you do, reveal cards from the top of your library until you reveal a creature card that shares a creature type with the sacrificed creature. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -26096,7 +26096,7 @@
         },
         {
             "id": "d6546644-755c-561f-8ca6-b86f0e8b5c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c6ab7-cab9-4ee3-9f17-d6817f61efcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c6ab7-cab9-4ee3-9f17-d6817f61efcc.jpg?1",
             "name": "Guff Rewrites History",
             "text": "For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost.",
             "colours": [
@@ -26129,7 +26129,7 @@
         },
         {
             "id": "f269565c-1b13-5518-b6e8-a9a8010f6655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca45c6b-8cce-44db-9f5b-fa66075db6f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca45c6b-8cce-44db-9f5b-fa66075db6f6.jpg?1",
             "name": "Jaya's Phoenix",
             "text": "Flying, haste\nWhenever Jaya's Phoenix deals combat damage to a player or planeswalker, copy the next loyalty ability you activate this turn when you activate it. You may choose new targets for the copy.\nWhenever you cast a planeswalker spell, you may return Jaya's Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -26164,7 +26164,7 @@
         },
         {
             "id": "dc0b77e4-4373-5590-bdf4-93eac5dbbace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e06f8-e542-47d4-b527-7d8fc3dec38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e06f8-e542-47d4-b527-7d8fc3dec38c.jpg?1",
             "name": "Composer of Spring",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may put a land card from your hand onto the battlefield tapped. If you control six or more enchantments, instead you may put a creature or land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -26200,7 +26200,7 @@
         },
         {
             "id": "db3493e8-df3c-5980-9faa-e2c7e5c0d073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1b0a5-b6ca-41f8-be1c-05a56383c9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1b0a5-b6ca-41f8-be1c-05a56383c9a9.jpg?1",
             "name": "For the Ancestors",
             "text": "Choose a creature type. Look at the top six cards of your library. You may reveal any number of cards of the chosen type from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -26233,7 +26233,7 @@
         },
         {
             "id": "f7f72ee1-03b4-5376-a7c7-360ac76fd11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2737c-d8ef-4b03-9316-be3f61288d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d2737c-d8ef-4b03-9316-be3f61288d3c.jpg?1",
             "name": "Hatchery Sliver",
             "text": "Replicate {1}{G} (When you cast this spell, copy it for each time you paid its replicate cost.)\nEach Sliver spell you cast has replicate. The replicate cost is equal to its mana cost. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -26268,7 +26268,7 @@
         },
         {
             "id": "c466c3f3-f88f-5221-bed0-824e13e0d384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f1dbdc-e590-48a4-bc52-e9e4e907fb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f1dbdc-e590-48a4-bc52-e9e4e907fb82.jpg?1",
             "name": "Nyxborn Behemoth",
             "text": "This spell costs {X} less to cast, where X is the total mana value of noncreature enchantments you control.\nTrample\n{1}{G}, Sacrifice another enchantment: Nyxborn Behemoth gains indestructible until end of turn.",
             "colours": [
@@ -26304,7 +26304,7 @@
         },
         {
             "id": "53e7c41b-2d26-5b37-919c-fa570ad18887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b7d3df-4e9b-422b-a88c-43650a67a9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b7d3df-4e9b-422b-a88c-43650a67a9c6.jpg?1",
             "name": "Darksteel Monolith",
             "text": "Indestructible\nOnce each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.",
             "colours": [],
@@ -26333,7 +26333,7 @@
         },
         {
             "id": "5c965485-0278-5b3a-8988-30f0514f50a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687c808-84de-4f16-afb9-a0c6c7f10ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f687c808-84de-4f16-afb9-a0c6c7f10ab9.jpg?1",
             "name": "Abstruse Archaic",
             "text": "Vigilance\n{1}, {T}: Copy target activated or triggered ability you control from a colorless source. You may choose new targets for the copy.",
             "colours": [],
@@ -26365,7 +26365,7 @@
         },
         {
             "id": "8f73664a-9683-59f3-aa22-b41dd611b193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1ac650-b7b6-4d1f-a594-66cb3b58e696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1ac650-b7b6-4d1f-a594-66cb3b58e696.jpg?1",
             "name": "Calamity of the Titans",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile each creature and planeswalker with mana value less than the revealed card's mana value.",
             "colours": [],
@@ -26395,7 +26395,7 @@
         },
         {
             "id": "b23ebeec-ac70-5da2-9d78-4345f9aa5a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6957c952-e501-4ac3-839b-8a16f802b5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6957c952-e501-4ac3-839b-8a16f802b5fe.jpg?1",
             "name": "Desecrate Reality",
             "text": "For each opponent, exile up to one target permanent that player controls with an even mana value. (Zero is even.)\nAdamant \u2014 If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.",
             "colours": [],
@@ -26425,7 +26425,7 @@
         },
         {
             "id": "5e760f05-311c-5287-89be-39c0531f8c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d322c86-ffdd-4c39-8444-4dfca13c16ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d322c86-ffdd-4c39-8444-4dfca13c16ce.jpg?1",
             "name": "Flayer of Loyalties",
             "text": "When you cast this spell, gain control of target creature until end of turn. Untap that creature. Until end of turn, it has base power and toughness 10/10 and gains trample, annihilator 2, and haste.\nTrample, annihilator 2",
             "colours": [],
@@ -26457,7 +26457,7 @@
         },
         {
             "id": "44e9f29e-1387-5ac3-83b6-f1ee906b0197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b7f6e-cd93-4b59-a574-7faa65eb8596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b7f6e-cd93-4b59-a574-7faa65eb8596.jpg?1",
             "name": "Omarthis, Ghostfire Initiate",
             "text": "Omarthis, Ghostfire Initiate enters the battlefield with X +1/+1 counters on it.\nWhenever you put one or more +1/+1 counters on another colorless creature, you may put a +1/+1 counter on Omarthis.\nWhen Omarthis dies, manifest a number of cards from the top of your library equal to the number of counters on it.",
             "colours": [],
@@ -26492,7 +26492,7 @@
         },
         {
             "id": "f33fdc4a-6417-5a03-be89-5a856aa854cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8914ba3-5e76-4392-bc8d-05d14585918a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8914ba3-5e76-4392-bc8d-05d14585918a.jpg?1",
             "name": "Rise of the Eldrazi",
             "text": "This spell can't be countered.\nDestroy target permanent. Target player draws four cards. Take an extra turn after this one.\nExile Rise of the Eldrazi.",
             "colours": [],
@@ -26522,7 +26522,7 @@
         },
         {
             "id": "6f7b8a00-acdd-59ca-b194-9de59f656704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a430137-70d9-45fc-acaa-87b29ea0d588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a430137-70d9-45fc-acaa-87b29ea0d588.jpg?1",
             "name": "Skittering Cicada",
             "text": "Flash\nYou may cast colorless spells as though they had flash.\nWhenever you cast a colorless spell, until end of turn, Skittering Cicada gains trample and gets +X/+X, where X is that spell's mana value.",
             "colours": [],
@@ -26554,7 +26554,7 @@
         },
         {
             "id": "d6aa8f3f-5a4c-5aff-9af2-8ed8ea8af088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def39c7f-cccb-49ce-9096-e051f3bcdebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def39c7f-cccb-49ce-9096-e051f3bcdebe.jpg?1",
             "name": "Ugin's Mastery",
             "text": "Whenever you cast a colorless creature spell, manifest the top card of your library.\nWhenever you attack with creatures with total power 6 or greater, you may turn a face-down creature you control face up.",
             "colours": [],
@@ -26584,7 +26584,7 @@
         },
         {
             "id": "c06ac9e9-24a5-51f2-b85a-4d1c84e09b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59ba1ee-8080-4f3e-a9a0-fa7b8b049e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59ba1ee-8080-4f3e-a9a0-fa7b8b049e34.jpg?1",
             "name": "Zhulodok, Void Gorger",
             "text": "Colorless spells you cast from your hand with mana value 7 or greater have \"Cascade, cascade.\"",
             "colours": [],
@@ -26619,7 +26619,7 @@
         },
         {
             "id": "3e64ec7f-347d-5cec-a103-034a57117238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52906cd4-3877-4554-8bf9-1d082cdfd331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52906cd4-3877-4554-8bf9-1d082cdfd331.jpg?1",
             "name": "Boon of the Spirit Realm",
             "text": "Constellation \u2014 Whenever Boon of the Spirit Realm or another enchantment enters the battlefield under your control, put a blessing counter on Boon of the Spirit Realm.\nCreatures you control get +1/+1 for each blessing counter on Boon of the Spirit Realm.",
             "colours": [
@@ -26653,7 +26653,7 @@
         },
         {
             "id": "b46a684d-84ca-5185-a221-a0ee653ed20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca467a-40d2-4f15-a314-76016fb027c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca467a-40d2-4f15-a314-76016fb027c3.jpg?1",
             "name": "Gatewatch Beacon",
             "text": "Gatewatch Beacon enters the battlefield with three loyalty counters on it.\n{T}: Add {W}.\nWhenever a planeswalker enters the battlefield under your control, if Gatewatch Beacon has loyalty counters on it, you may move a loyalty counter from Gatewatch Beacon onto that planeswalker.",
             "colours": [
@@ -26687,7 +26687,7 @@
         },
         {
             "id": "4244ae0a-b3ed-5417-b94a-0e919c33fba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340093f-a8b2-4bd7-b7bf-32ddede628b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340093f-a8b2-4bd7-b7bf-32ddede628b1.jpg?1",
             "name": "Onakke Oathkeeper",
             "text": "Creatures can't attack planeswalkers you control unless their controller pays {1} for each creature they control that's attacking a planeswalker you control.\n{4}{W}{W}, Exile Onakke Oathkeeper from your graveyard: Return target planeswalker card from your graveyard to the battlefield.",
             "colours": [
@@ -26724,7 +26724,7 @@
         },
         {
             "id": "984247d8-2998-5b46-8624-200e2a7d29f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30e4bf-ac1a-4670-ad73-84ba70e48a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30e4bf-ac1a-4670-ad73-84ba70e48a72.jpg?1",
             "name": "Ondu Spiritdancer",
             "text": "Whenever an enchantment enters the battlefield under your control, you may create a token that's a copy of it. Do this only once each turn.",
             "colours": [
@@ -26761,7 +26761,7 @@
         },
         {
             "id": "137d6f46-4603-542d-928c-1fe56dd47e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b23e2e0-b7d8-41fa-8441-118c552cd872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b23e2e0-b7d8-41fa-8441-118c552cd872.jpg?1",
             "name": "Regal Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, Slivers you control get +1/+1 until end of turn if you're the monarch. Otherwise, you become the monarch.\"",
             "colours": [
@@ -26797,7 +26797,7 @@
         },
         {
             "id": "179b1d2e-890c-589d-9200-aac1ba3b323e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb6fc77-28f2-4ead-8561-1d46d7aa5878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb6fc77-28f2-4ead-8561-1d46d7aa5878.jpg?1",
             "name": "Sparkshaper Visionary",
             "text": "At the beginning of combat on your turn, choose any number of target planeswalkers you control. Until end of turn, they become 3/3 blue Bird creatures with flying, hexproof, and \"Whenever this creature deals combat damage to a player, scry 1.\" (They're no longer planeswalkers. Loyalty abilities can still be activated.)",
             "colours": [
@@ -26834,7 +26834,7 @@
         },
         {
             "id": "ee51daf6-563a-5686-bdfb-a3cc0db32f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d40ff-40a5-42cd-b699-764b3abf0d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d40ff-40a5-42cd-b699-764b3abf0d4c.jpg?1",
             "name": "Taunting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, goad target creature an opponent controls.\"",
             "colours": [
@@ -26870,7 +26870,7 @@
         },
         {
             "id": "063a0981-78a8-579b-99a4-189afce5263b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3c52d-8e38-4642-a28b-baa533b12c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3c52d-8e38-4642-a28b-baa533b12c8f.jpg?1",
             "name": "Titan of Littjara",
             "text": "As Titan of Littjara enters the battlefield, choose a creature type.\nTitan of Littjara is the chosen type in addition to its other types.\nWhenever Titan of Littjara enters the battlefield or attacks, you may draw a card for each other creature you control that shares a creature type with it. If you do, discard a card.",
             "colours": [
@@ -26906,7 +26906,7 @@
         },
         {
             "id": "85015b11-9b65-5a93-9908-1c4f26ef0491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d89a0-fa7f-4c56-a262-f8eac8aa892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d89a0-fa7f-4c56-a262-f8eac8aa892c.jpg?1",
             "name": "Cacophony Unleashed",
             "text": "When Cacophony Unleashed enters the battlefield, if you cast it, destroy all nonenchantment creatures.\nWhenever Cacophony Unleashed or another enchantment enters the battlefield under your control, until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment.",
             "colours": [
@@ -26940,7 +26940,7 @@
         },
         {
             "id": "96f9550f-375b-5e98-9669-7f0896c9d7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c242-cf50-4c0e-9ea9-ce6614be045e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c242-cf50-4c0e-9ea9-ce6614be045e.jpg?1",
             "name": "Demon of Fate's Design",
             "text": "Flying, trample\nOnce during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.\n{2}{B}, Sacrifice another enchantment: Demon of Fate's Design gets +X/+0 until end of turn, where X is the sacrificed enchantment's mana value.",
             "colours": [
@@ -26977,7 +26977,7 @@
         },
         {
             "id": "7b970425-8df6-5d51-830f-bddfbc9934ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072c852b-b078-4064-98c8-3ab011676e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072c852b-b078-4064-98c8-3ab011676e79.jpg?1",
             "name": "Ghoulish Impetus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1, has deathtouch, and is goaded.\nWhen enchanted creature dies, return Ghoulish Impetus to the battlefield at the beginning of the next end step.",
             "colours": [
@@ -27013,7 +27013,7 @@
         },
         {
             "id": "7ac0f5d4-af3b-5857-b74d-065657193f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b72fb20-4d91-40b0-9dc5-24924e758925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b72fb20-4d91-40b0-9dc5-24924e758925.jpg?1",
             "name": "Lazotep Sliver",
             "text": "Sliver creatures you control have afflict 2.\nWhenever a nontoken Sliver you control dies, amass Slivers 2.",
             "colours": [
@@ -27050,7 +27050,7 @@
         },
         {
             "id": "4d52dbb4-1ef4-5e6d-8ab8-c1058f1db9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a04e11-23e3-49f4-ba64-c8f35c419ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a04e11-23e3-49f4-ba64-c8f35c419ccd.jpg?1",
             "name": "Capricious Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"",
             "colours": [
@@ -27086,7 +27086,7 @@
         },
         {
             "id": "f9dc96f5-a8ea-5958-b02b-846638988c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce28dd7-56d0-4801-855f-ddebf81adf6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce28dd7-56d0-4801-855f-ddebf81adf6e.jpg?1",
             "name": "Descendants' Fury",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may sacrifice one of them. If you do, reveal cards from the top of your library until you reveal a creature card that shares a creature type with the sacrificed creature. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -27120,7 +27120,7 @@
         },
         {
             "id": "fbe9bcd8-c394-5930-8a05-f3584d56e791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4511a6f6-1cdf-4bff-abea-d43b257e6d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4511a6f6-1cdf-4bff-abea-d43b257e6d50.jpg?1",
             "name": "Guff Rewrites History",
             "text": "For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost.",
             "colours": [
@@ -27154,7 +27154,7 @@
         },
         {
             "id": "66f00553-c490-5bed-a111-2a6d2a6e0efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22009c47-3b0e-41f9-843d-f670d8afda23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22009c47-3b0e-41f9-843d-f670d8afda23.jpg?1",
             "name": "Jaya's Phoenix",
             "text": "Flying, haste\nWhenever Jaya's Phoenix deals combat damage to a player or planeswalker, copy the next loyalty ability you activate this turn when you activate it. You may choose new targets for the copy.\nWhenever you cast a planeswalker spell, you may return Jaya's Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -27190,7 +27190,7 @@
         },
         {
             "id": "c36d5351-5e81-52b5-9cad-4416508b7e49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bb4ab9-386f-4099-a3aa-87dab8611164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bb4ab9-386f-4099-a3aa-87dab8611164.jpg?1",
             "name": "Composer of Spring",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may put a land card from your hand onto the battlefield tapped. If you control six or more enchantments, instead you may put a creature or land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -27227,7 +27227,7 @@
         },
         {
             "id": "046e3a77-4aca-5774-809c-73b075800fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd5c87c-1514-467d-bc3f-b9dd6a582f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd5c87c-1514-467d-bc3f-b9dd6a582f71.jpg?1",
             "name": "For the Ancestors",
             "text": "Choose a creature type. Look at the top six cards of your library. You may reveal any number of cards of the chosen type from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{G}",
             "colours": [
@@ -27261,7 +27261,7 @@
         },
         {
             "id": "0e7d7808-85ad-5f37-9cbd-9f873587ee48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f4b12a-aec7-4b6b-b5d5-53ca1c2b7054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f4b12a-aec7-4b6b-b5d5-53ca1c2b7054.jpg?1",
             "name": "Hatchery Sliver",
             "text": "Replicate {1}{G}\nEach Sliver spell you cast has replicate. The replicate cost is equal to its mana cost.",
             "colours": [
@@ -27297,7 +27297,7 @@
         },
         {
             "id": "b172c687-7e04-5f98-9d12-4773f832e122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3b3e50-0292-47c8-940e-9cb5d47896f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3b3e50-0292-47c8-940e-9cb5d47896f8.jpg?1",
             "name": "Nyxborn Behemoth",
             "text": "This spell costs {X} less to cast, where X is the total mana value of noncreature enchantments you control.\nTrample\n{1}{G}, Sacrifice another enchantment: Nyxborn Behemoth gains indestructible until end of turn.",
             "colours": [
@@ -27334,7 +27334,7 @@
         },
         {
             "id": "7742f4e0-3226-5847-be49-7beeced3c689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71221a0-c474-4da1-9970-bb5adaad4f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71221a0-c474-4da1-9970-bb5adaad4f4d.jpg?1",
             "name": "Anikthea, Hand of Erebos",
             "text": "Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters the battlefield or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.",
             "colours": [
@@ -27378,7 +27378,7 @@
         },
         {
             "id": "fec45a30-f6b5-575d-a54c-f5c0db6581c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d2988e-a855-4bfd-8367-f5cbc4eb8560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d2988e-a855-4bfd-8367-f5cbc4eb8560.jpg?1",
             "name": "Leori, Sparktouched Hunter",
             "text": "Flying, vigilance\nWhenever Leori, Sparktouched Hunter deals combat damage to a player, choose a planeswalker type. Until end of turn, whenever you activate an ability of a planeswalker of that type, copy that ability. You may choose new targets for the copies.",
             "colours": [
@@ -27421,7 +27421,7 @@
         },
         {
             "id": "51620f24-a216-5457-ad0d-6b98c0fae876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff756c-0d65-44a9-8a43-bd0011f92383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ff756c-0d65-44a9-8a43-bd0011f92383.jpg?1",
             "name": "Narci, Fable Singer",
             "text": "Lifelink\nWhenever you sacrifice an enchantment, draw a card.\nWhenever the final chapter ability of a Saga you control resolves, each opponent loses X life and you gain X life, where X is that Saga's mana value.",
             "colours": [
@@ -27464,7 +27464,7 @@
         },
         {
             "id": "71eeed46-2229-5b4c-a507-decc541b7ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad9b2c-4616-4c94-a9f4-006ccb4c4cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad9b2c-4616-4c94-a9f4-006ccb4c4cf5.jpg?1",
             "name": "Rukarumel, Biologist",
             "text": "As Rukarumel, Biologist enters the battlefield, choose a creature type.\nSlivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 1/1 colorless Sliver creature token.",
             "colours": [
@@ -27511,7 +27511,7 @@
         },
         {
             "id": "9b807668-b443-54ef-92e7-a59465350e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca55a2b4-f53a-4c76-bd28-8ce49108a322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca55a2b4-f53a-4c76-bd28-8ce49108a322.jpg?1",
             "name": "Sliver Gravemother",
             "text": "The \"legend rule\" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5}",
             "colours": [
@@ -27558,7 +27558,7 @@
         },
         {
             "id": "5fa94a3a-3480-5ec0-91da-d39cb5d03051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07f838-a813-43aa-9bcf-9f62797d7313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07f838-a813-43aa-9bcf-9f62797d7313.jpg?1",
             "name": "Darksteel Monolith",
             "text": "Indestructible\nOnce each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.",
             "colours": [],
@@ -27588,7 +27588,7 @@
         },
         {
             "id": "fd050589-f035-5ff4-a2dc-db3c8c8248b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4424b9ec-70d8-4b32-931f-fac1516f8472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4424b9ec-70d8-4b32-931f-fac1516f8472.jpg?1",
             "name": "Zhulodok, Void Gorger",
             "text": "Colorless spells you cast from your hand with mana value 7 or greater have \"Cascade, cascade.\" (When you cast one, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [],
@@ -27622,7 +27622,7 @@
         },
         {
             "id": "ffe434d9-65a5-5182-847a-caf8c4323443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f1c77c-07e6-4886-9b71-b556642f31cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f1c77c-07e6-4886-9b71-b556642f31cf.jpg?1",
             "name": "Anikthea, Hand of Erebos",
             "text": "Menace\nOther enchantment creatures you control have menace.\nWhenever Anikthea enters the battlefield or attacks, exile up to one target non-Aura enchantment card from your graveyard. Create a token that's a copy of that card, except it's a 3/3 black Zombie creature in addition to its other types.",
             "colours": [
@@ -27665,7 +27665,7 @@
         },
         {
             "id": "65eca6b6-8a34-5067-909b-660d18009cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5bb122-19f3-4e46-a71c-b8a53e9aacc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5bb122-19f3-4e46-a71c-b8a53e9aacc7.jpg?1",
             "name": "Commodore Guff",
             "text": "At the beginning of your end step, put a loyalty counter on another target planeswalker you control.\n+1: Create a 1/1 red Wizard creature token with \"{T}: Add {R}. Spend this mana only to cast a planeswalker spell.\"\n\u22123: You draw X cards and Commodore Guff deals X damage to each opponent, where X is the number of planeswalkers you control.\nCommodore Guff can be your commander.",
             "colours": [
@@ -27706,7 +27706,7 @@
         },
         {
             "id": "0e26bc84-e053-5231-84cb-23cf2b849208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e899ba84-d940-468a-8f18-5282b51b797e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e899ba84-d940-468a-8f18-5282b51b797e.jpg?1",
             "name": "Sliver Gravemother",
             "text": "The \"legend rule\" doesn't apply to Slivers you control.\nEach Sliver creature card in your graveyard has encore {X}, where X is its mana value.\nEncore {5} ({5}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -27752,7 +27752,7 @@
         },
         {
             "id": "4dabadf1-2c7b-5548-bb92-479064eec72f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab98b67-3450-4cb2-9d2d-b4e3448dcd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab98b67-3450-4cb2-9d2d-b4e3448dcd73.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27793,7 +27793,7 @@
         },
         {
             "id": "72573adb-e6f3-58a9-89aa-0cfb082654c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e0813-96e9-40c3-8e7c-bee8bef27585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859e0813-96e9-40c3-8e7c-bee8bef27585.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27834,7 +27834,7 @@
         },
         {
             "id": "e9efaead-54c5-5a41-a845-ee604230a27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cfdbd6-00c3-4eac-acd3-b058b82ff947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cfdbd6-00c3-4eac-acd3-b058b82ff947.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27875,7 +27875,7 @@
         },
         {
             "id": "8a39ac39-fa33-56f4-8573-d65576ea7a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7744562-1df1-4aea-ba15-5aa1e50e26a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7744562-1df1-4aea-ba15-5aa1e50e26a0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27916,7 +27916,7 @@
         },
         {
             "id": "b06c543e-5fcd-586d-b20f-1075ff3fa496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b1c00c-c292-44c7-a6c9-0dcdb00581aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b1c00c-c292-44c7-a6c9-0dcdb00581aa.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -27957,7 +27957,7 @@
         },
         {
             "id": "e6266e24-09cd-523b-8cbe-e08580d7c230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f21ed59-a8c8-46fc-ac20-2b351fffd36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f21ed59-a8c8-46fc-ac20-2b351fffd36c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -27996,7 +27996,7 @@
         },
         {
             "id": "3b9ea227-a2d3-53c9-b38e-f4b833dc4169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd42c61-1e41-4df9-aa70-a39cc20dff51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd42c61-1e41-4df9-aa70-a39cc20dff51.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -28035,7 +28035,7 @@
         },
         {
             "id": "ffee0e42-5651-5a4e-81b1-677f486a51ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03438868-e177-46af-9ae8-edc4a991f18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03438868-e177-46af-9ae8-edc4a991f18c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -28074,7 +28074,7 @@
         },
         {
             "id": "7a23f450-efcf-51af-8d50-97818186198b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f0063-9a59-4ce1-90b5-e45921d5cc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f0063-9a59-4ce1-90b5-e45921d5cc3c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -28113,7 +28113,7 @@
         },
         {
             "id": "69f1dbea-4b04-5b36-a094-db9457a49116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e7f83-4a77-4544-ac4f-53b8c993724d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e7f83-4a77-4544-ac4f-53b8c993724d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -28152,7 +28152,7 @@
         },
         {
             "id": "3ab4754a-a7d2-5150-91f6-c5660f02ed98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63803c6b-144c-4c11-b8c1-4a1861085ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63803c6b-144c-4c11-b8c1-4a1861085ab7.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -28191,7 +28191,7 @@
         },
         {
             "id": "6c6f4a72-f149-5444-b1b2-b79ffa8917d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f08835-74ca-4ac5-980e-e802aada2bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f08835-74ca-4ac5-980e-e802aada2bb7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -28230,7 +28230,7 @@
         },
         {
             "id": "a1de425b-8f95-5e23-bfdc-69656fc7b519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748b9a1d-0fa3-41bc-beb0-7e3cf2eb33ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748b9a1d-0fa3-41bc-beb0-7e3cf2eb33ed.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -28269,7 +28269,7 @@
         },
         {
             "id": "d21de1cf-6f2b-5e90-9633-40d5e0c0d912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f64898e-d561-402e-8e4f-dda1ce241869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f64898e-d561-402e-8e4f-dda1ce241869.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -28308,7 +28308,7 @@
         },
         {
             "id": "dc901003-0852-5230-b658-4daf741f7fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db81be-753b-4d0e-9d66-9292364d2a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db81be-753b-4d0e-9d66-9292364d2a60.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -28347,7 +28347,7 @@
         },
         {
             "id": "b78e819d-73ff-5cda-98a2-644e1fac7757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08f11e-0f3f-464e-abe9-20f18de237d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08f11e-0f3f-464e-abe9-20f18de237d8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -28386,7 +28386,7 @@
         },
         {
             "id": "9595e31a-9567-570d-8aa2-02beaac5e9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a028172-c148-46fa-9afa-c5fdc7f9ba9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a028172-c148-46fa-9afa-c5fdc7f9ba9e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -28425,7 +28425,7 @@
         },
         {
             "id": "2c10bec7-d836-55c3-b43e-7d5808960f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210c54e-89fd-4971-ab6a-ca8f4e7fe97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210c54e-89fd-4971-ab6a-ca8f4e7fe97a.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all permanents they control that are one or more colors.",
             "colours": [],
@@ -28455,7 +28455,7 @@
         },
         {
             "id": "ec82ea26-67cc-599b-9d29-ff7e26c2e84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312fada-fc31-46ac-b6a1-cfffd776856f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312fada-fc31-46ac-b6a1-cfffd776856f.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast this spell, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -28484,7 +28484,7 @@
         },
         {
             "id": "ec657475-626e-5573-b0cd-c5c93c582a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb0fff-da50-40b9-9839-68cdf25a0193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb0fff-da50-40b9-9839-68cdf25a0193.jpg?1",
             "name": "Bane of Bala Ged",
             "text": "Whenever Bane of Bala Ged attacks, defending player exiles two permanents they control.",
             "colours": [],
@@ -28513,7 +28513,7 @@
         },
         {
             "id": "e345f2ac-c119-51f6-b026-4ba7fa59367d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ecacf-f036-45ea-8aa7-f012120429d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ecacf-f036-45ea-8aa7-f012120429d3.jpg?1",
             "name": "Endbringer",
             "text": "Untap Endbringer during each other player's untap step.\n{T}: Endbringer deals 1 damage to any target.\n{C}, {T}: Target creature can't attack or block this turn.\n{C}{C}, {T}: Draw a card.",
             "colours": [],
@@ -28542,7 +28542,7 @@
         },
         {
             "id": "8c87f05b-6db5-5c8d-adb3-904212022b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b3c10a-799f-4922-bb0a-44981b13203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b3c10a-799f-4922-bb0a-44981b13203b.jpg?1",
             "name": "Endless One",
             "text": "Endless One enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -28571,7 +28571,7 @@
         },
         {
             "id": "8360c19e-e299-57ad-8339-da401d9156f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08b369-783d-4fe4-8fc8-9cd595638550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08b369-783d-4fe4-8fc8-9cd595638550.jpg?1",
             "name": "It That Betrays",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nWhenever an opponent sacrifices a nontoken permanent, put that card onto the battlefield under your control.",
             "colours": [],
@@ -28600,7 +28600,7 @@
         },
         {
             "id": "01ad6c61-d28f-5b18-afbc-105753c6b14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e6e9aa-2e5f-49f7-beef-b876c070d72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e6e9aa-2e5f-49f7-beef-b876c070d72d.jpg?1",
             "name": "Matter Reshaper",
             "text": "When Matter Reshaper dies, reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with mana value 3 or less. Otherwise, put that card into your hand.",
             "colours": [],
@@ -28629,7 +28629,7 @@
         },
         {
             "id": "ecfe293a-084f-56b4-b357-b2c31e1d4d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18ce39e-211d-460b-a200-a26c17aeeb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18ce39e-211d-460b-a200-a26c17aeeb12.jpg?1",
             "name": "Not of This World",
             "text": "Counter target spell or ability that targets a permanent you control.\nThis spell costs {7} less to cast if it targets a spell or ability that targets a creature you control with power 7 or greater.",
             "colours": [],
@@ -28659,7 +28659,7 @@
         },
         {
             "id": "aff894a6-8724-5d62-8128-e9771200dda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef15a89-8df8-48f6-9fbf-0117efde9fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef15a89-8df8-48f6-9fbf-0117efde9fe0.jpg?1",
             "name": "Oblivion Sower",
             "text": "When you cast this spell, target opponent exiles the top four cards of their library, then you may put any number of land cards that player owns from exile onto the battlefield under your control.",
             "colours": [],
@@ -28688,7 +28688,7 @@
         },
         {
             "id": "7693c429-17f8-5da0-8a7e-ee3a836a5271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd2f8b3-62f3-4e52-ae17-dd0a61bc0e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd2f8b3-62f3-4e52-ae17-dd0a61bc0e26.jpg?1",
             "name": "Spatial Contortion",
             "text": "Target creature gets +3/-3 until end of turn.",
             "colours": [],
@@ -28715,7 +28715,7 @@
         },
         {
             "id": "e0a4fb96-ce05-515a-9a66-781917d962c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8cf3f-1ca8-41e4-b0f7-ea9d61f731d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8cf3f-1ca8-41e4-b0f7-ea9d61f731d7.jpg?1",
             "name": "Titan's Presence",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
             "colours": [],
@@ -28742,7 +28742,7 @@
         },
         {
             "id": "9a85178e-805e-57b6-8768-365109646cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb7e322-aba0-42f5-80a1-267f3444ac4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb7e322-aba0-42f5-80a1-267f3444ac4d.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "Colorless spells you cast cost {2} less to cast.\n+1: Exile the top card of your library face down and look at it. Create a 2/2 colorless Spirit creature token. When that token leaves the battlefield, put the exiled card into your hand.\n\u22123: Destroy target permanent that's one or more colors.",
             "colours": [],
@@ -28773,7 +28773,7 @@
         },
         {
             "id": "39ee95e8-84c7-554c-a3aa-0d90b1382694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcc9c88-836b-48b6-9d81-5a6844a6b70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcc9c88-836b-48b6-9d81-5a6844a6b70f.jpg?1",
             "name": "Warping Wail",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power or toughness 1 or less.\n\u2022 Counter target sorcery spell.\n\u2022 Create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -28800,7 +28800,7 @@
         },
         {
             "id": "b62b819b-419b-53ef-b9fd-49487ab6b366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51825d35-cdb2-40fa-ab89-1625161b04af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51825d35-cdb2-40fa-ab89-1625161b04af.jpg?1",
             "name": "Ajani Steadfast",
             "text": "+1: Until end of turn, up to one target creature gets +1/+1 and gains first strike, vigilance, and lifelink.\n\u22122: Put a +1/+1 counter on each creature you control and a loyalty counter on each other planeswalker you control.\n\u22127: You get an emblem with \"If a source would deal damage to you or a planeswalker you control, prevent all but 1 of that damage.\"",
             "colours": [
@@ -28835,7 +28835,7 @@
         },
         {
             "id": "1ae4beb2-9ee4-5365-a1f8-3a45e8cf6380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d10ba2-0408-47a2-bb6f-9e12541fe100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d10ba2-0408-47a2-bb6f-9e12541fe100.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, create a 2/2 white Pegasus creature token with flying.",
             "colours": [
@@ -28868,7 +28868,7 @@
         },
         {
             "id": "6447e75f-7cd7-5c6f-9134-fd319f911bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae24f37-0788-4f53-af5a-c6c1f2b64894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae24f37-0788-4f53-af5a-c6c1f2b64894.jpg?1",
             "name": "Bonescythe Sliver",
             "text": "Sliver creatures you control have double strike.",
             "colours": [
@@ -28901,7 +28901,7 @@
         },
         {
             "id": "03967130-0007-57ff-bc99-54a001b9b1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ea506-262b-415f-86f2-d70ddfd15a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ea506-262b-415f-86f2-d70ddfd15a8d.jpg?1",
             "name": "Cast Out",
             "text": "Flash\nWhen Cast Out enters the battlefield, exile target nonland permanent an opponent controls until Cast Out leaves the battlefield.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -28932,7 +28932,7 @@
         },
         {
             "id": "cb902b43-357b-5b41-9afa-2818f010a5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167d2e51-eb69-488c-a6b6-042a7b0e1744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167d2e51-eb69-488c-a6b6-042a7b0e1744.jpg?1",
             "name": "Cleansing Nova",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all artifacts and enchantments.",
             "colours": [
@@ -28963,7 +28963,7 @@
         },
         {
             "id": "3542fc4a-313e-53d5-a542-0caa6681d396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7d8e62-9bc0-4064-81c5-919c076de086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7d8e62-9bc0-4064-81c5-919c076de086.jpg?1",
             "name": "Constricting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, you may exile target creature an opponent controls until this creature leaves the battlefield.\"",
             "colours": [
@@ -28996,7 +28996,7 @@
         },
         {
             "id": "e42db91d-146e-5104-83e6-10390e05e073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f4c453-97b4-4cd5-a766-85e5647f71d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f4c453-97b4-4cd5-a766-85e5647f71d5.jpg?1",
             "name": "Deploy the Gatewatch",
             "text": "Look at the top seven cards of your library. Put up to two planeswalker cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -29027,7 +29027,7 @@
         },
         {
             "id": "74e3af1d-6215-5161-9668-6781663c09d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08382257-68d5-493e-8754-2ff72e9321e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08382257-68d5-493e-8754-2ff72e9321e9.jpg?1",
             "name": "Elspeth, Sun's Champion",
             "text": "+1: Create three 1/1 white Soldier creature tokens.\n\u22123: Destroy all creatures with power 4 or greater.\n\u22127: You get an emblem with \"Creatures you control get +2/+2 and have flying.\"",
             "colours": [
@@ -29062,7 +29062,7 @@
         },
         {
             "id": "4517ff3c-0099-5a89-b853-e7838cfe1e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c11ef-e036-4c54-98b7-83b7b25e7c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c11ef-e036-4c54-98b7-83b7b25e7c1b.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -29093,7 +29093,7 @@
         },
         {
             "id": "2e87414b-04a9-563a-b9c1-132dd840b118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d608df31-bcc6-4fec-89f1-5cefe5c2ec99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d608df31-bcc6-4fec-89f1-5cefe5c2ec99.jpg?1",
             "name": "Gideon Jura",
             "text": "+2: During target opponent's next turn, creatures that player controls attack Gideon Jura if able.\n\u22122: Destroy target tapped creature.\n0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -29128,7 +29128,7 @@
         },
         {
             "id": "ed84f9f2-9a13-52f8-8164-340097ad2bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787574-7700-47ab-b57c-98ef968cce71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43787574-7700-47ab-b57c-98ef968cce71.jpg?1",
             "name": "Grasp of Fate",
             "text": "When Grasp of Fate enters the battlefield, for each opponent, exile up to one target nonland permanent that player controls until Grasp of Fate leaves the battlefield. (Those permanents return under their owners' control.)",
             "colours": [
@@ -29159,7 +29159,7 @@
         },
         {
             "id": "213c9141-e1dc-50f8-b980-c6ed58d6fe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1cf888-dd41-4cc2-a16e-3414ef7a78ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1cf888-dd41-4cc2-a16e-3414ef7a78ed.jpg?1",
             "name": "Grateful Apparition",
             "text": "Flying\nWhenever Grateful Apparition deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -29192,7 +29192,7 @@
         },
         {
             "id": "6e6fc3ad-78fb-5c62-b4f7-bcaabd259c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1448ffd-42af-475c-8883-1933508a8a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1448ffd-42af-475c-8883-1933508a8a6a.jpg?1",
             "name": "Harsh Mercy",
             "text": "Each player chooses a creature type. Destroy all creatures that aren't of a type chosen this way. They can't be regenerated.",
             "colours": [
@@ -29223,7 +29223,7 @@
         },
         {
             "id": "fe2a0a09-4902-51f9-b1a7-344fc6488bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e9693-4996-498c-95f7-884d40341298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e9693-4996-498c-95f7-884d40341298.jpg?1",
             "name": "Heliod, God of the Sun",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nOther creatures you control have vigilance.\n{2}{W}{W}: Create a 2/1 white Cleric enchantment creature token.",
             "colours": [
@@ -29259,7 +29259,7 @@
         },
         {
             "id": "e58450be-810f-53a3-bf39-7d8512517d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1096cb83-a192-406a-9b95-d7cbb1a0df84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1096cb83-a192-406a-9b95-d7cbb1a0df84.jpg?1",
             "name": "Love Song of Night and Day",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You and target opponent each draw two cards.\nII \u2014 Create a 1/1 white Bird creature token with flying.\nIII \u2014 Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -29292,7 +29292,7 @@
         },
         {
             "id": "1300d9ee-4858-5ec8-8148-a6a968e28733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c0ee3e-054e-4b01-b333-4ef3bc904750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c0ee3e-054e-4b01-b333-4ef3bc904750.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -29326,7 +29326,7 @@
         },
         {
             "id": "c4fd3dc6-e589-5a6c-98a4-f371aa4bf87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25bbe18-709c-4ed3-a047-5578ecfaaba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25bbe18-709c-4ed3-a047-5578ecfaaba7.jpg?1",
             "name": "Norn's Annex",
             "text": "({PW} can be paid with either {W} or 2 life.)\nCreatures can't attack you or planeswalkers you control unless their controller pays {PW} for each of those creatures.",
             "colours": [
@@ -29357,7 +29357,7 @@
         },
         {
             "id": "22bf6135-40b8-51e3-8f64-916cff996c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3f02b-9408-46a5-8d25-f5cec553d600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3f02b-9408-46a5-8d25-f5cec553d600.jpg?1",
             "name": "Oath of Gideon",
             "text": "When Oath of Gideon enters the battlefield, create two 1/1 white Kor Ally creature tokens.\nEach planeswalker you control enters the battlefield with an additional loyalty counter on it.",
             "colours": [
@@ -29390,7 +29390,7 @@
         },
         {
             "id": "acdee86e-3678-5a40-8cf9-366d3b9d9e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e4f28-d1b1-41e4-a2f1-6613a952bca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157e4f28-d1b1-41e4-a2f1-6613a952bca2.jpg?1",
             "name": "Omen of the Sun",
             "text": "Flash\nWhen Omen of the Sun enters the battlefield, create two 1/1 white Human Soldier creature tokens and you gain 2 life.\n{2}{W}, Sacrifice Omen of the Sun: Scry 2.",
             "colours": [
@@ -29421,7 +29421,7 @@
         },
         {
             "id": "94b37152-c741-56f1-b37d-4625b60884be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebabe38-a035-4c2d-89b5-760712f311b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebabe38-a035-4c2d-89b5-760712f311b8.jpg?1",
             "name": "Oreskos Explorer",
             "text": "When Oreskos Explorer enters the battlefield, search your library for up to X Plains cards, where X is the number of players who control more lands than you. Reveal those cards, put them into your hand, then shuffle.",
             "colours": [
@@ -29455,7 +29455,7 @@
         },
         {
             "id": "0dd0c508-7093-5adc-ad93-07eef2573d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ae3bb-c22f-495f-82e3-cf909e8a8e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ae3bb-c22f-495f-82e3-cf909e8a8e49.jpg?1",
             "name": "Promise of Loyalty",
             "text": "Each player puts a vow counter on a creature they control and sacrifices the rest. Each of those creatures can't attack you or planeswalkers you control for as long as it has a vow counter on it.",
             "colours": [
@@ -29486,7 +29486,7 @@
         },
         {
             "id": "f106958a-f070-56e2-84a7-ce3d47aec54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2bb091-ac6d-4c99-bdf6-70ffb6291ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2bb091-ac6d-4c99-bdf6-70ffb6291ef0.jpg?1",
             "name": "Semester's End",
             "text": "Exile any number of target creatures and/or planeswalkers you control. At the beginning of the next end step, return each of them to the battlefield under its owner's control. Each of them enters the battlefield with an additional +1/+1 counter on it if it's a creature and an additional loyalty counter on it if it's a planeswalker.",
             "colours": [
@@ -29517,7 +29517,7 @@
         },
         {
             "id": "15251510-2b32-5416-af89-87c5ebf1c6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb2cc85-f4a6-47ad-b94e-f16534d02ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb2cc85-f4a6-47ad-b94e-f16534d02ae2.jpg?1",
             "name": "Sentinel Sliver",
             "text": "Sliver creatures you control have vigilance.",
             "colours": [
@@ -29550,7 +29550,7 @@
         },
         {
             "id": "4d9e26e2-0528-5a11-9d8d-458165ccbc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394fad93-ecdf-4f05-be17-291ca246262f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394fad93-ecdf-4f05-be17-291ca246262f.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -29581,7 +29581,7 @@
         },
         {
             "id": "f9eac973-33bc-5c1b-a64d-15dff9ff82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc983e-bbe3-4bc1-97e9-e40ead987ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc983e-bbe3-4bc1-97e9-e40ead987ef0.jpg?1",
             "name": "Sinew Sliver",
             "text": "All Sliver creatures get +1/+1.",
             "colours": [
@@ -29614,7 +29614,7 @@
         },
         {
             "id": "e7043888-c45b-58ca-8d6a-518ded5ebeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e038684-c476-41db-a1b1-57c46e5b4c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e038684-c476-41db-a1b1-57c46e5b4c9a.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -29648,7 +29648,7 @@
         },
         {
             "id": "a12889a8-71bf-5fd7-b6d6-f8ff045e410c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15b82ed-0c5c-4cc8-84ee-ce8e3b630c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15b82ed-0c5c-4cc8-84ee-ce8e3b630c86.jpg?1",
             "name": "Starfield Mystic",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Starfield Mystic.",
             "colours": [
@@ -29682,7 +29682,7 @@
         },
         {
             "id": "a50dbd25-658a-5d98-b40c-013d09f73745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e1cb-ceee-46aa-96d1-f3f26516cd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e1cb-ceee-46aa-96d1-f3f26516cd77.jpg?1",
             "name": "Starfield of Nyx",
             "text": "At the beginning of your upkeep, you may return target enchantment card from your graveyard to the battlefield.\nAs long as you control five or more enchantments, each other non-Aura enchantment you control is a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -29713,7 +29713,7 @@
         },
         {
             "id": "12a1b1ab-1a98-5018-a14f-b25c160563a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ecba4b-9624-428f-a8af-dd88139ab13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ecba4b-9624-428f-a8af-dd88139ab13c.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -29744,7 +29744,7 @@
         },
         {
             "id": "0ad2ed3a-6204-5189-93b3-4f96f8082ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b10977-64eb-4a50-a481-d67cc2950f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b10977-64eb-4a50-a481-d67cc2950f56.jpg?1",
             "name": "Urza's Ruinous Blast",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nExile all nonland permanents that aren't legendary.",
             "colours": [
@@ -29777,7 +29777,7 @@
         },
         {
             "id": "9c883e95-5e46-5656-a5cb-f448c2fbe7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ec3686-cecd-4dee-8a68-c3e4baec25ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ec3686-cecd-4dee-8a68-c3e4baec25ca.jpg?1",
             "name": "The Wanderer",
             "text": "Prevent all noncombat damage that would be dealt to you and other permanents you control.\n\u22122: Exile target creature with power 4 or greater.",
             "colours": [
@@ -29810,7 +29810,7 @@
         },
         {
             "id": "169de5a9-38b0-5b44-9db8-415a3aaf5992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e8e7b9-042e-4d01-87dd-27dc95257113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e8e7b9-042e-4d01-87dd-27dc95257113.jpg?1",
             "name": "Deepglow Skate",
             "text": "When Deepglow Skate enters the battlefield, double the number of each kind of counter on any number of target permanents.",
             "colours": [
@@ -29843,7 +29843,7 @@
         },
         {
             "id": "db705e5b-06a7-5fef-b8cf-1d7b10654ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5994259-8d16-4f12-b528-1821005f79af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5994259-8d16-4f12-b528-1821005f79af.jpg?1",
             "name": "Diffusion Sliver",
             "text": "Whenever a Sliver creature you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.",
             "colours": [
@@ -29876,7 +29876,7 @@
         },
         {
             "id": "96687795-67ab-51dd-984f-0ada82152627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73c83b5-3a91-4495-b6fb-20cdc6edd07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73c83b5-3a91-4495-b6fb-20cdc6edd07b.jpg?1",
             "name": "Distant Melody",
             "text": "Choose a creature type. Draw a card for each permanent you control of that type.",
             "colours": [
@@ -29907,7 +29907,7 @@
         },
         {
             "id": "689de23c-4c45-5472-84cf-5c6e65b4b889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c520263-6bad-4521-ba9e-192ca8223b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c520263-6bad-4521-ba9e-192ca8223b07.jpg?1",
             "name": "Flux Channeler",
             "text": "Whenever you cast a noncreature spell, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -29941,7 +29941,7 @@
         },
         {
             "id": "e605c5d8-29cf-55b0-8f41-084d66fe044f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14fb062-ff43-43eb-aaaf-304a876d5962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14fb062-ff43-43eb-aaaf-304a876d5962.jpg?1",
             "name": "Fog Bank",
             "text": "Defender, flying\nPrevent all combat damage that would be dealt to and dealt by Fog Bank.",
             "colours": [
@@ -29974,7 +29974,7 @@
         },
         {
             "id": "e7144a08-5077-5613-8b3e-18d4682c7009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dc671-b666-4003-a3a6-ff5b081bca54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dc671-b666-4003-a3a6-ff5b081bca54.jpg?1",
             "name": "Galerider Sliver",
             "text": "Sliver creatures you control have flying.",
             "colours": [
@@ -30007,7 +30007,7 @@
         },
         {
             "id": "3b665e6a-2751-518d-b54f-c778f0df71ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d4e61-004f-4e52-b2e8-ba11b922cc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/806d4e61-004f-4e52-b2e8-ba11b922cc7d.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n\u22121: Target player draws a card.\n\u221210: Target player mills twenty cards.",
             "colours": [
@@ -30042,7 +30042,7 @@
         },
         {
             "id": "d2f1f550-b13a-558b-96af-d9f06aec0f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7051cdfa-509e-4d84-bbae-f77556c861e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7051cdfa-509e-4d84-bbae-f77556c861e4.jpg?1",
             "name": "Jace, Architect of Thought",
             "text": "+1: Until your next turn, whenever a creature an opponent controls attacks, it gets -1/-0 until end of turn.\n\u22122: Reveal the top three cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other on the bottom of your library in any order.\n\u22128: For each player, search that player's library for a nonland card and exile it, then that player shuffles. You may cast those cards without paying their mana costs.",
             "colours": [
@@ -30077,7 +30077,7 @@
         },
         {
             "id": "f764ad80-2af5-59e6-bbcb-e2ca4e677905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d34cbf-e424-461a-adf3-003d556a7859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d34cbf-e424-461a-adf3-003d556a7859.jpg?1",
             "name": "Jace, Mirror Mage",
             "text": "Kicker {2}\nWhen Jace, Mirror Mage enters the battlefield, if Jace was kicked, create a token that's a copy of Jace, Mirror Mage, except it's not legendary and its starting loyalty is 1.\n+1: Scry 2.\n0: Draw a card and reveal it. Remove a number of loyalty counters equal to that card's mana value from Jace, Mirror Mage.",
             "colours": [
@@ -30112,7 +30112,7 @@
         },
         {
             "id": "43ee97f6-2c73-5c3f-83d4-c684f056056a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6e5c63-b6e5-4756-bf23-6c6f8669442d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6e5c63-b6e5-4756-bf23-6c6f8669442d.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "Each opponent can't draw more than one card each turn.\n\u22122: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -30147,7 +30147,7 @@
         },
         {
             "id": "d237c1c2-256a-59a7-bd4c-a282cd26c641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62e9a8-d1aa-4fea-abb7-50c10d40fa6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da62e9a8-d1aa-4fea-abb7-50c10d40fa6a.jpg?1",
             "name": "Oath of Jace",
             "text": "When Oath of Jace enters the battlefield, draw three cards, then discard two cards.\nAt the beginning of your upkeep, scry X, where X is the number of planeswalkers you control.",
             "colours": [
@@ -30180,7 +30180,7 @@
         },
         {
             "id": "f0df9618-90c7-5aef-897b-025389f56244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d3b30b-d4c4-4f60-a7b3-e8854bd203d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d3b30b-d4c4-4f60-a7b3-e8854bd203d5.jpg?1",
             "name": "Shifting Sliver",
             "text": "Slivers can't be blocked except by Slivers.",
             "colours": [
@@ -30213,7 +30213,7 @@
         },
         {
             "id": "c810fc9e-78f4-552c-9225-0c525cf6cc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbb32db-fb1d-4f47-a258-fa1a0a00bd76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbb32db-fb1d-4f47-a258-fa1a0a00bd76.jpg?1",
             "name": "Spark Double",
             "text": "You may have Spark Double enter the battlefield as a copy of a creature or planeswalker you control, except it enters with an additional +1/+1 counter on it if it's a creature, it enters with an additional loyalty counter on it if it's a planeswalker, and it isn't legendary.",
             "colours": [
@@ -30246,7 +30246,7 @@
         },
         {
             "id": "bc47336c-d4c4-5a1c-b605-e83fa59bc1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c458a0f-0e63-417f-b51e-8491822835b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c458a0f-0e63-417f-b51e-8491822835b0.jpg?1",
             "name": "Synapse Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may draw a card.",
             "colours": [
@@ -30279,7 +30279,7 @@
         },
         {
             "id": "ccf95c65-1663-5c6e-bb76-a6cda4a28209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff84d8-1b89-42cc-a8c0-4ac6fa26ce65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff84d8-1b89-42cc-a8c0-4ac6fa26ce65.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -30314,7 +30314,7 @@
         },
         {
             "id": "69e05402-e64f-5bd8-9856-90db6ecedd58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4448fa01-1f81-41dc-9046-cfae41601bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4448fa01-1f81-41dc-9046-cfae41601bc4.jpg?1",
             "name": "Windfall",
             "text": "Each player discards their hand, then draws cards equal to the greatest number of cards a player discarded this way.",
             "colours": [
@@ -30345,7 +30345,7 @@
         },
         {
             "id": "b5272cb6-5c8d-5cc9-9936-d350d7c0e38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1fcaf2-fee3-4088-83e1-bcb72e8c0e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1fcaf2-fee3-4088-83e1-bcb72e8c0e88.jpg?1",
             "name": "Winged Sliver",
             "text": "All Sliver creatures have flying.",
             "colours": [
@@ -30378,7 +30378,7 @@
         },
         {
             "id": "39775821-9db7-5ebc-bb21-edf6aeb946a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fb777-0cbb-4c04-8b30-f2806366a957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fb777-0cbb-4c04-8b30-f2806366a957.jpg?1",
             "name": "Clot Sliver",
             "text": "All Slivers have \"{2}: Regenerate this permanent.\" (The next time this permanent would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -30411,7 +30411,7 @@
         },
         {
             "id": "a66ef8d7-3d26-593a-9e09-c332013a0ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a28c0-0d12-4c62-bc91-59c2ddfc9ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a28c0-0d12-4c62-bc91-59c2ddfc9ef8.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -30442,7 +30442,7 @@
         },
         {
             "id": "4735b657-5a8d-5273-97f1-cea5ca94ccbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90c9a9-098b-463a-8588-b078fb0364dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90c9a9-098b-463a-8588-b078fb0364dd.jpg?1",
             "name": "Crypt Sliver",
             "text": "All Slivers have \"{T}: Regenerate target Sliver.\" (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -30475,7 +30475,7 @@
         },
         {
             "id": "8c2bd9c7-92ac-5b92-83a5-eb19c6a7d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873ad15-e633-4858-8f6b-4cc3e561725f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1873ad15-e633-4858-8f6b-4cc3e561725f.jpg?1",
             "name": "Cunning Rhetoric",
             "text": "Whenever an opponent attacks you and/or one or more planeswalkers you control, exile the top card of that player's library. You may play that card for as long as it remains exiled, and mana of any type can be spent to cast it.",
             "colours": [
@@ -30506,7 +30506,7 @@
         },
         {
             "id": "251875a4-0df6-5eb3-abde-535979d4e3c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082ddc9-f20c-4d33-8db4-baba03ef22b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082ddc9-f20c-4d33-8db4-baba03ef22b9.jpg?1",
             "name": "Doomwake Giant",
             "text": "Constellation \u2014 Whenever Doomwake Giant or another enchantment enters the battlefield under your control, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -30540,7 +30540,7 @@
         },
         {
             "id": "f422725e-b808-5c84-bbb5-c53fdeedad09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a6a3b-8809-4d22-bf1e-c4620c609aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a6a3b-8809-4d22-bf1e-c4620c609aba.jpg?1",
             "name": "Dreadhorde Invasion",
             "text": "At the beginning of your upkeep, you lose 1 life and amass Zombies 1. (Put a +1/+1 counter on an Army you control. It's also a Zombie. If you don't control an Army, create a 0/0 black Zombie Army creature token first.)\nWhenever a Zombie token you control with power 6 or greater attacks, it gains lifelink until end of turn.",
             "colours": [
@@ -30571,7 +30571,7 @@
         },
         {
             "id": "530d16ca-c4b4-5f5e-b591-246a5f8482e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06831e80-845d-4bd7-8fdc-8140eb606fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06831e80-845d-4bd7-8fdc-8140eb606fe4.jpg?1",
             "name": "The Eldest Reborn",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each opponent sacrifices a creature or planeswalker.\nII \u2014 Each opponent discards a card.\nIII \u2014 Put target creature or planeswalker card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -30604,7 +30604,7 @@
         },
         {
             "id": "553a8d9b-be0d-576b-95e2-1e882b21630d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84701927-799f-4af4-85b8-389f903c5bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84701927-799f-4af4-85b8-389f903c5bc0.jpg?1",
             "name": "Erebos, Bleak-Hearted",
             "text": "Indestructible\nAs long as your devotion to black is less than five, Erebos isn't a creature.\nWhenever another creature you control dies, you may pay 2 life. If you do, draw a card.\n{1}{B}, Sacrifice another creature: Target creature gets -2/-1 until end of turn.",
             "colours": [
@@ -30640,7 +30640,7 @@
         },
         {
             "id": "f488a19b-fa2f-5927-8919-d407e24a4001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dabd3ef-eac8-48ed-b2c1-f4ce8adcedf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dabd3ef-eac8-48ed-b2c1-f4ce8adcedf5.jpg?1",
             "name": "Mindwrack Harpy",
             "text": "Flying\nAt the beginning of combat on your turn, each player mills three cards. (They each put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -30674,7 +30674,7 @@
         },
         {
             "id": "c27d8e85-5cbb-5b27-a987-976db81ef23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222985-759c-4fdc-82ba-d970ef789b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222985-759c-4fdc-82ba-d970ef789b35.jpg?1",
             "name": "Syphon Sliver",
             "text": "Sliver creatures you control have lifelink.",
             "colours": [
@@ -30707,7 +30707,7 @@
         },
         {
             "id": "a7f8ea77-80b3-5d40-ad08-ffcf0a90937f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1165c2-9ea9-459b-a56a-5c0d0e9ae66a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1165c2-9ea9-459b-a56a-5c0d0e9ae66a.jpg?1",
             "name": "Blade Sliver",
             "text": "All Sliver creatures get +1/+0.",
             "colours": [
@@ -30740,7 +30740,7 @@
         },
         {
             "id": "e6d43e4b-29ce-5394-8de6-a94e77ff4d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd15a627-f7a6-4d66-abb5-5aaa167b41a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd15a627-f7a6-4d66-abb5-5aaa167b41a9.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -30771,7 +30771,7 @@
         },
         {
             "id": "18ed9705-746a-5a9d-beed-519941cdff11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44db4fa-8b13-4eb2-a66e-a55b2e0c0fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44db4fa-8b13-4eb2-a66e-a55b2e0c0fb3.jpg?1",
             "name": "Blur Sliver",
             "text": "Sliver creatures you control have haste.",
             "colours": [
@@ -30804,7 +30804,7 @@
         },
         {
             "id": "35ad6128-5139-52c6-864b-c843876dec1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83327f18-f9f6-4f9b-b72a-68f85ad96b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83327f18-f9f6-4f9b-b72a-68f85ad96b00.jpg?1",
             "name": "Bonesplitter Sliver",
             "text": "All Sliver creatures get +2/+0.",
             "colours": [
@@ -30837,7 +30837,7 @@
         },
         {
             "id": "7dce48f7-be41-5afa-8c64-0cfdf320fb8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4fb926-fe8c-4640-ac8d-ef418b8945d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4fb926-fe8c-4640-ac8d-ef418b8945d5.jpg?1",
             "name": "Chandra, Awakened Inferno",
             "text": "This spell can't be countered.\n+2: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n\u22123: Chandra, Awakened Inferno deals 3 damage to each non-Elemental creature.\n\u2212X: Chandra, Awakened Inferno deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -30872,7 +30872,7 @@
         },
         {
             "id": "dccde01c-2c7d-5659-9fbb-5628d2997d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eac0eaa-55b2-444a-863d-c66769aab4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eac0eaa-55b2-444a-863d-c66769aab4ee.jpg?1",
             "name": "Chandra, Torch of Defiance",
             "text": "+1: Exile the top card of your library. You may cast that card. If you don't, Chandra, Torch of Defiance deals 2 damage to each opponent.\n+1: Add {R}{R}.\n\u22123: Chandra, Torch of Defiance deals 4 damage to target creature.\n\u22127: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to any target.\"",
             "colours": [
@@ -30907,7 +30907,7 @@
         },
         {
             "id": "7680cd89-5c34-51b1-9047-41f346bead26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023dd90c-eb55-4876-94c9-b8058c80e82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023dd90c-eb55-4876-94c9-b8058c80e82d.jpg?1",
             "name": "Cleaving Sliver",
             "text": "Sliver creatures you control get +2/+0.",
             "colours": [
@@ -30940,7 +30940,7 @@
         },
         {
             "id": "b6a58643-390e-5bbf-a3c1-edc47dfe6079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c444a566-bcb1-424b-b66b-55ce87e4d98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c444a566-bcb1-424b-b66b-55ce87e4d98f.jpg?1",
             "name": "Hollowhead Sliver",
             "text": "Sliver creatures you control have \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -30973,7 +30973,7 @@
         },
         {
             "id": "d306cb4b-f60d-5280-ae1a-be36a562f035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb03593-9369-4c26-bfcc-8819648dc018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb03593-9369-4c26-bfcc-8819648dc018.jpg?1",
             "name": "Repeated Reverberation",
             "text": "When you next cast an instant spell, cast a sorcery spell, or activate a loyalty ability this turn, copy that spell or ability twice. You may choose new targets for the copies.",
             "colours": [
@@ -31004,7 +31004,7 @@
         },
         {
             "id": "655e29c6-baaa-5d3e-b3f4-7843f6692f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aced16a-ebbd-47bb-a4c4-9454afa9971c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aced16a-ebbd-47bb-a4c4-9454afa9971c.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "Whenever a creature attacks you or a planeswalker you control, each Dragon you control deals 1 damage to that creature.\n+1: Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.\n\u22123: Create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -31039,7 +31039,7 @@
         },
         {
             "id": "bce3d33f-bba5-56f8-a32b-ef4a670bde68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fb60c9-d10d-4966-b9bd-788fabc182d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fb60c9-d10d-4966-b9bd-788fabc182d2.jpg?1",
             "name": "Spiteful Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker.\"",
             "colours": [
@@ -31072,7 +31072,7 @@
         },
         {
             "id": "352d1ce7-8d28-582f-8c29-5fb9317988c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4652793-6f02-4bb6-8f71-eef302a001c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4652793-6f02-4bb6-8f71-eef302a001c6.jpg?1",
             "name": "Striking Sliver",
             "text": "Sliver creatures you control have first strike.",
             "colours": [
@@ -31105,7 +31105,7 @@
         },
         {
             "id": "79939c6e-9e59-5712-aef8-97c8297010e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd73d00-feb0-4ec6-8031-6af5b334bba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd73d00-feb0-4ec6-8031-6af5b334bba3.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -31138,7 +31138,7 @@
         },
         {
             "id": "9aa887c3-3206-5055-8e87-9f8803c56532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc359b0-8886-415b-a497-e98a2241084e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc359b0-8886-415b-a497-e98a2241084e.jpg?1",
             "name": "Abundance",
             "text": "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -31169,7 +31169,7 @@
         },
         {
             "id": "849629b1-b09f-5e6c-8d8c-91174463f3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882be812-fc76-4493-abe2-2101603399ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882be812-fc76-4493-abe2-2101603399ce.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -31205,7 +31205,7 @@
         },
         {
             "id": "fe412c9a-fd5b-506d-ba5d-548064926e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c03969-db08-4af3-8c83-b13750e8b20a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c03969-db08-4af3-8c83-b13750e8b20a.jpg?1",
             "name": "The Binding of the Titans",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player mills three cards.\nII \u2014 Exile up to two target cards from graveyards. For each creature card exiled this way, you gain 1 life.\nIII \u2014 Return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -31238,7 +31238,7 @@
         },
         {
             "id": "8a56bdee-f6b6-5989-949c-f2bcafa6787e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a387b-e18a-41c7-84bb-bb7e354f4f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a387b-e18a-41c7-84bb-bb7e354f4f2d.jpg?1",
             "name": "Brood Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may create a 1/1 colorless Sliver creature token.",
             "colours": [
@@ -31271,7 +31271,7 @@
         },
         {
             "id": "8e641b8e-ded0-5f27-8a63-94bf877d3f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc63d2ea-a980-466e-9ebb-f28008f84c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc63d2ea-a980-466e-9ebb-f28008f84c3d.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play lands from the top of your library.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -31305,7 +31305,7 @@
         },
         {
             "id": "24309bc2-3212-51ea-b247-e8db65fc3a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34b52-7a67-44b4-82e7-2860729ba410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34b52-7a67-44b4-82e7-2860729ba410.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -31336,7 +31336,7 @@
         },
         {
             "id": "5d53e26e-2029-5e49-ad86-84e6bed88142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc3804b-3304-4add-81b4-0482bfed8074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc3804b-3304-4add-81b4-0482bfed8074.jpg?1",
             "name": "Destiny Spinner",
             "text": "Creature and enchantment spells you control can't be countered.\n{3}{G}: Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.",
             "colours": [
@@ -31370,7 +31370,7 @@
         },
         {
             "id": "a7e8b8b3-dbfc-566a-a5ce-dd1e5b9408b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43be1363-7e73-4862-b45f-07f490ab46be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43be1363-7e73-4862-b45f-07f490ab46be.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "You may play an additional land on each of your turns.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -31405,7 +31405,7 @@
         },
         {
             "id": "7ac8331c-35d2-5d4c-9957-04855cb4a3c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f882aa63-d43c-4359-9de6-77231500a08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f882aa63-d43c-4359-9de6-77231500a08e.jpg?1",
             "name": "Eidolon of Blossoms",
             "text": "Constellation \u2014 Whenever Eidolon of Blossoms or another enchantment enters the battlefield under your control, draw a card.",
             "colours": [
@@ -31439,7 +31439,7 @@
         },
         {
             "id": "13776945-ac33-53d1-b439-c0f528b3c9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50538b-f866-4e75-8856-2ad8af635011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50538b-f866-4e75-8856-2ad8af635011.jpg?1",
             "name": "Enchantress's Presence",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -31470,7 +31470,7 @@
         },
         {
             "id": "322cb64e-7cba-5849-b84c-ae27a4e7348e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b7c0df-5af2-4a01-86b3-b2ed5d60e613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b7c0df-5af2-4a01-86b3-b2ed5d60e613.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31501,7 +31501,7 @@
         },
         {
             "id": "202cc22e-9155-5e22-806a-dd68756a4de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e85cd4-c116-42e2-a94b-2c04b06c4e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e85cd4-c116-42e2-a94b-2c04b06c4e2b.jpg?1",
             "name": "Font of Fertility",
             "text": "{1}{G}, Sacrifice Font of Fertility: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31532,7 +31532,7 @@
         },
         {
             "id": "cc2c7a24-d070-5c54-9bb9-664ba5acdad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224af68a-41a6-4e4e-94d0-130be341b788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224af68a-41a6-4e4e-94d0-130be341b788.jpg?1",
             "name": "Gemhide Sliver",
             "text": "All Slivers have \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -31565,7 +31565,7 @@
         },
         {
             "id": "37c8d7c3-c0f2-556d-88da-d5fc6184fe3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb4b3-9926-4e06-b107-a7a39584fa7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb4b3-9926-4e06-b107-a7a39584fa7a.jpg?1",
             "name": "Greater Tanuki",
             "text": "Trample\nChannel \u2014 {2}{G}, Discard Greater Tanuki: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31599,7 +31599,7 @@
         },
         {
             "id": "9f3452fb-7d03-5c74-8f69-8963e8448d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360af3e-626d-46c9-99cf-6c85921f5d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360af3e-626d-46c9-99cf-6c85921f5d26.jpg?1",
             "name": "Herald of the Pantheon",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life.",
             "colours": [
@@ -31633,7 +31633,7 @@
         },
         {
             "id": "14478ed3-a11f-569b-8db6-235d331ca15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159c309c-568d-4780-9db5-b50a997e7bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159c309c-568d-4780-9db5-b50a997e7bb2.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31664,7 +31664,7 @@
         },
         {
             "id": "9737d763-aaec-53d4-aca2-50e1a5d54179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51629ac-51d5-47cb-a7fc-315b34dd82ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51629ac-51d5-47cb-a7fc-315b34dd82ce.jpg?1",
             "name": "Manaweft Sliver",
             "text": "Sliver creatures you control have \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -31697,7 +31697,7 @@
         },
         {
             "id": "b676f0f0-7fe2-5c5f-96d7-77925dd0b9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1afd5-d1d3-42b7-8417-bb05c91ef822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c1afd5-d1d3-42b7-8417-bb05c91ef822.jpg?1",
             "name": "Megantic Sliver",
             "text": "Sliver creatures you control get +3/+3.",
             "colours": [
@@ -31730,7 +31730,7 @@
         },
         {
             "id": "2289de55-94f3-5ab5-b49f-5e2a1f42bb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf47fb5-2072-473d-96f9-5cdb7840f887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf47fb5-2072-473d-96f9-5cdb7840f887.jpg?1",
             "name": "The Mending of Dominaria",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Mill two cards, then you may return a creature card from your graveyard to your hand.\nIII \u2014 Return all land cards from your graveyard to the battlefield, then shuffle your graveyard into your library.",
             "colours": [
@@ -31763,7 +31763,7 @@
         },
         {
             "id": "4365ee29-e745-5279-9446-d88f8bdd080c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c783dfd2-a935-41e0-bd8e-97ac81f771b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c783dfd2-a935-41e0-bd8e-97ac81f771b2.jpg?1",
             "name": "Might Sliver",
             "text": "All Sliver creatures get +2/+2.",
             "colours": [
@@ -31796,7 +31796,7 @@
         },
         {
             "id": "440945e0-989d-55f9-a600-6dd221ca13b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78584e8-bb82-4977-a27d-68b1befe9b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78584e8-bb82-4977-a27d-68b1befe9b3b.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -31827,7 +31827,7 @@
         },
         {
             "id": "dbf8d5a1-7704-568e-a6c8-e46762347a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4789a2-f201-4b05-954d-527d169de091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4789a2-f201-4b05-954d-527d169de091.jpg?1",
             "name": "Nessian Wanderer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, look at the top three cards of your library. You may reveal a land card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -31861,7 +31861,7 @@
         },
         {
             "id": "82e23831-946c-5355-9a26-2acdc27891f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d5877d-fa0f-4117-adc1-9153aeba4777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d5877d-fa0f-4117-adc1-9153aeba4777.jpg?1",
             "name": "Omen of the Hunt",
             "text": "Flash\nWhen Omen of the Hunt enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{2}{G}, Sacrifice Omen of the Hunt: Scry 2.",
             "colours": [
@@ -31892,7 +31892,7 @@
         },
         {
             "id": "83fbf8d1-0d2f-5e87-ab39-94abca3884df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7749b2d-05a6-40ec-8d6a-8c1223cd5a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7749b2d-05a6-40ec-8d6a-8c1223cd5a09.jpg?1",
             "name": "Quick Sliver",
             "text": "Flash\nAny player may cast Sliver spells as though they had flash.",
             "colours": [
@@ -31925,7 +31925,7 @@
         },
         {
             "id": "e1292f93-5b7a-5d8a-b38d-5ab460ae1404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f4640f-563d-48a7-86d1-42737570121d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f4640f-563d-48a7-86d1-42737570121d.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -31956,7 +31956,7 @@
         },
         {
             "id": "c55ee0b9-576a-5b63-8732-36f1284199d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c65ef6-93b4-448b-bf1c-01fe263cc39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c65ef6-93b4-448b-bf1c-01fe263cc39d.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling (This card is every creature type.)\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -31989,7 +31989,7 @@
         },
         {
             "id": "c4da421d-0399-5272-8052-efa8bc7d3da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9ac089-6962-48fd-bf67-f041ece27fa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9ac089-6962-48fd-bf67-f041ece27fa9.jpg?1",
             "name": "Sanctum Weaver",
             "text": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
             "colours": [
@@ -32023,7 +32023,7 @@
         },
         {
             "id": "71fbb42c-2974-5a7c-b3b3-59ee9b1662ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e64ba-5501-4212-b0b6-2a47f64d226a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e64ba-5501-4212-b0b6-2a47f64d226a.jpg?1",
             "name": "Sandwurm Convergence",
             "text": "Creatures with flying can't attack you or planeswalkers you control.\nAt the beginning of your end step, create a 5/5 green Wurm creature token.",
             "colours": [
@@ -32054,7 +32054,7 @@
         },
         {
             "id": "c9d5abc5-9439-541b-ae89-b246a7c252cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7680a8e1-cd59-43c5-8f06-426b918692c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7680a8e1-cd59-43c5-8f06-426b918692c8.jpg?1",
             "name": "Setessan Champion",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, put a +1/+1 counter on Setessan Champion and draw a card.",
             "colours": [
@@ -32088,7 +32088,7 @@
         },
         {
             "id": "b4eb80ef-2a6a-5f6d-969c-fc041f2df17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b6126-c134-4d7d-aa06-ac0f409a9f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b6126-c134-4d7d-aa06-ac0f409a9f74.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -32119,7 +32119,7 @@
         },
         {
             "id": "a62a4b67-e9a4-5711-93b7-ffd04b3bb727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8f9e9-4505-485a-b6c6-a92a4da5155a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8f9e9-4505-485a-b6c6-a92a4da5155a.jpg?1",
             "name": "Venom Sliver",
             "text": "Sliver creatures you control have deathtouch.",
             "colours": [
@@ -32152,7 +32152,7 @@
         },
         {
             "id": "74b0debf-a529-5aa4-bc9d-e4384e4f51e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722a73a1-9497-4d8d-850c-ec6c6ab1b8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722a73a1-9497-4d8d-850c-ec6c6ab1b8d3.jpg?1",
             "name": "Verduran Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -32186,7 +32186,7 @@
         },
         {
             "id": "56b48708-6318-52c6-8874-bf0ae02b1c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83e860a-6dd5-4522-8b2b-b730934f59f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83e860a-6dd5-4522-8b2b-b730934f59f7.jpg?1",
             "name": "Battle for Bretagard",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human Warrior creature token.\nII \u2014 Create a 1/1 green Elf Warrior creature token.\nIII \u2014 Choose any number of artifact tokens and/or creature tokens you control with different names. For each of them, create a token that's a copy of it.",
             "colours": [
@@ -32221,7 +32221,7 @@
         },
         {
             "id": "bbe70e07-aaf5-55de-98cd-d7d323c3f195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0297fc9-9070-41cc-83fd-0dea2a65c263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0297fc9-9070-41cc-83fd-0dea2a65c263.jpg?1",
             "name": "Binding the Old Gods",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target nonland permanent an opponent controls.\nII \u2014 Search your library for a Forest card, put it onto the battlefield tapped, then shuffle.\nIII \u2014 Creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -32256,7 +32256,7 @@
         },
         {
             "id": "a1bdaca7-d979-5f20-b48f-707063d09821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec142a-81c0-43e3-bf37-bdc18d7b780e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec142a-81c0-43e3-bf37-bdc18d7b780e.jpg?1",
             "name": "Calix, Destiny's Hand",
             "text": "+1: Look at the top four cards of your library. You may reveal an enchantment card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Exile target creature or enchantment you don't control until target enchantment you control leaves the battlefield.\n\u22127: Return all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -32293,7 +32293,7 @@
         },
         {
             "id": "9c836ebc-1b70-5d83-966d-95cc925726df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f523765-7704-4faf-a72b-8a2c414bb179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f523765-7704-4faf-a72b-8a2c414bb179.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "Sliver creatures you control have flying and haste.",
             "colours": [
@@ -32328,7 +32328,7 @@
         },
         {
             "id": "2f454f24-910f-5330-a1f6-ba40b6f7ed8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c7f341-c61e-491d-850a-221c6a57ac64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c7f341-c61e-491d-850a-221c6a57ac64.jpg?1",
             "name": "Crystalline Sliver",
             "text": "All Slivers have shroud. (They can't be the targets of spells or abilities.)",
             "colours": [
@@ -32363,7 +32363,7 @@
         },
         {
             "id": "2fc31b5c-187c-5b92-8d3c-e5e822c567ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422a569-d94e-41e7-b9e1-78b2e9fe505f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422a569-d94e-41e7-b9e1-78b2e9fe505f.jpg?1",
             "name": "Culling Ritual",
             "text": "Destroy each nonland permanent with mana value 2 or less. Add {B} or {G} for each permanent destroyed this way.",
             "colours": [
@@ -32396,7 +32396,7 @@
         },
         {
             "id": "8568bc28-050e-5aad-ab52-9ea235dcea42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc34be-e274-436a-81dd-ced0f90e657c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc34be-e274-436a-81dd-ced0f90e657c.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -32429,7 +32429,7 @@
         },
         {
             "id": "dec67b98-2d2c-582a-9a57-ba63a1524d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6201bcd-1009-4753-b7ac-5c25cc1a4d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6201bcd-1009-4753-b7ac-5c25cc1a4d79.jpg?1",
             "name": "Firewake Sliver",
             "text": "All Sliver creatures have haste.\nAll Slivers have \"{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn.\"",
             "colours": [
@@ -32464,7 +32464,7 @@
         },
         {
             "id": "118546c4-841b-5760-9048-105352e69e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1228d068-a5cb-4fd5-9e6a-5dc6ac9376a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1228d068-a5cb-4fd5-9e6a-5dc6ac9376a4.jpg?1",
             "name": "Harmonic Sliver",
             "text": "All Slivers have \"When this permanent enters the battlefield, destroy target artifact or enchantment.\"",
             "colours": [
@@ -32499,7 +32499,7 @@
         },
         {
             "id": "0933a754-a4b3-5c73-9346-d18ab4b92d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e224cfb-5bc1-490c-ab1e-f5405dc2fa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e224cfb-5bc1-490c-ab1e-f5405dc2fa0b.jpg?1",
             "name": "Hibernation Sliver",
             "text": "All Slivers have \"Pay 2 life: Return this permanent to its owner's hand.\"",
             "colours": [
@@ -32534,7 +32534,7 @@
         },
         {
             "id": "c5bd20c0-aa2d-5fd1-b867-8bbed120131b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ff517f-5c31-46e9-9efb-52bc9ec9298d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ff517f-5c31-46e9-9efb-52bc9ec9298d.jpg?1",
             "name": "Jukai Naturalist",
             "text": "Lifelink\nEnchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -32571,7 +32571,7 @@
         },
         {
             "id": "909d15e8-89d4-5179-9b15-2b30a107d3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0de3c85-0662-4374-bd21-65d3a34f2263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0de3c85-0662-4374-bd21-65d3a34f2263.jpg?1",
             "name": "Lavabelly Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, it deals 1 damage to target player or planeswalker and you gain 1 life.\"",
             "colours": [
@@ -32606,7 +32606,7 @@
         },
         {
             "id": "846627b3-c91f-5271-be98-ac17a3d8073f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4fa4e8-39e8-47a6-b975-ff5d46e59edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4fa4e8-39e8-47a6-b975-ff5d46e59edd.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -32639,7 +32639,7 @@
         },
         {
             "id": "4ab5518d-7f27-5242-810a-58952639120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b2cc03-5d07-43e1-a8d9-298d17a5af44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b2cc03-5d07-43e1-a8d9-298d17a5af44.jpg?1",
             "name": "Nahiri, the Harbinger",
             "text": "+2: You may discard a card. If you do, draw a card.\n\u22122: Exile target enchantment, tapped artifact, or tapped creature.\n\u22128: Search your library for an artifact or creature card, put it onto the battlefield, then shuffle. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -32676,7 +32676,7 @@
         },
         {
             "id": "51eebfd4-09fc-501e-9542-60b280d9f1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f766f-9609-4105-9ed5-4299c48f7fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300f766f-9609-4105-9ed5-4299c48f7fa7.jpg?1",
             "name": "Narset of the Ancient Way",
             "text": "+1: You gain 2 life. Add {U}, {R}, or {W}. Spend this mana only to cast a noncreature spell.\n\u22122: Draw a card, then you may discard a card. When you discard a nonland card this way, Narset of the Ancient Way deals damage equal to that card's mana value to target creature or planeswalker.\n\u22126: You get an emblem with \"Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.\"",
             "colours": [
@@ -32715,7 +32715,7 @@
         },
         {
             "id": "8880a669-43a2-5cb3-905a-a06a8ba823e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b0d5f-1071-4030-be16-2b4dadbdf9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b0d5f-1071-4030-be16-2b4dadbdf9e9.jpg?1",
             "name": "Narset, Enlightened Master",
             "text": "First strike, hexproof\nWhenever Narset, Enlightened Master attacks, exile the top four cards of your library. Until end of turn, you may cast noncreature spells from among those cards without paying their mana costs.",
             "colours": [
@@ -32755,7 +32755,7 @@
         },
         {
             "id": "973b8391-0a20-554f-b1fa-ff113ae73e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f4e782-5503-4698-a1ba-0f30e443f14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f4e782-5503-4698-a1ba-0f30e443f14c.jpg?1",
             "name": "Necrotic Sliver",
             "text": "All Slivers have \"{3}, Sacrifice this permanent: Destroy target permanent.\"",
             "colours": [
@@ -32790,7 +32790,7 @@
         },
         {
             "id": "7164ac2b-30d1-56fd-b0ee-b3a937eaf82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec67424e-718d-49d6-86b0-cf979530a830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec67424e-718d-49d6-86b0-cf979530a830.jpg?1",
             "name": "Nyx Weaver",
             "text": "Reach\nAt the beginning of your upkeep, mill two cards. (Put the top two cards of your library into your graveyard.)\n{1}{B}{G}, Exile Nyx Weaver: Return target card from your graveyard to your hand.",
             "colours": [
@@ -32826,7 +32826,7 @@
         },
         {
             "id": "779cc61b-f1f7-5c57-affe-8d1bdd5770f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7474f9e-a994-4ed7-83df-22edd8219e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7474f9e-a994-4ed7-83df-22edd8219e24.jpg?1",
             "name": "Oath of Teferi",
             "text": "When Oath of Teferi enters the battlefield, exile another target permanent you control. Return it to the battlefield under its owner's control at the beginning of the next end step.\nYou may activate the loyalty abilities of planeswalkers you control twice each turn rather than only once.",
             "colours": [
@@ -32861,7 +32861,7 @@
         },
         {
             "id": "9caca301-6f09-523e-9347-baa7d762c008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35a39a-6dcd-4bbc-b43b-bd1a5425cb05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35a39a-6dcd-4bbc-b43b-bd1a5425cb05.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "Whenever you cast a noncreature spell, create a 1/1 colorless Servo artifact creature token.\n\u22122: Target artifact you control becomes a copy of another target artifact or creature you control until end of turn, except it's an artifact in addition to its other types.",
             "colours": [
@@ -32898,7 +32898,7 @@
         },
         {
             "id": "edbea62b-4fa1-55b2-a134-68228757c36b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df83d28d-bb0b-4f3d-a16f-8ee8bf452e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df83d28d-bb0b-4f3d-a16f-8ee8bf452e10.jpg?1",
             "name": "Satyr Enchanter",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -32934,7 +32934,7 @@
         },
         {
             "id": "b7bd9379-9347-5983-9957-b2d7536c057c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b902f64-7795-4f1f-81e6-26db7c78a10c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b902f64-7795-4f1f-81e6-26db7c78a10c.jpg?1",
             "name": "Sliver Hivelord",
             "text": "Sliver creatures you control have indestructible.",
             "colours": [
@@ -32977,7 +32977,7 @@
         },
         {
             "id": "4a9c963b-70ed-5d3a-9605-330264cc6826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89511ab5-8ea6-4f07-a80b-c1ec7e89924e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89511ab5-8ea6-4f07-a80b-c1ec7e89924e.jpg?1",
             "name": "Sythis, Harvest's Hand",
             "text": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
             "colours": [
@@ -33015,7 +33015,7 @@
         },
         {
             "id": "995f303b-f2d1-57b3-ad83-3779c1c14d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ce45b-ab07-4bce-bb4a-83f5720b6ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049ce45b-ab07-4bce-bb4a-83f5720b6ee7.jpg?1",
             "name": "Wall of Denial",
             "text": "Defender, flying\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -33050,7 +33050,7 @@
         },
         {
             "id": "b4a2a6fd-ed3a-534f-ae5d-e95b7c3f82cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed089db-54b9-40d7-9a91-19f0bab44303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed089db-54b9-40d7-9a91-19f0bab44303.jpg?1",
             "name": "Ancient Stone Idol",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature.\nTrample\nWhen Ancient Stone Idol dies, create a 6/12 colorless Construct artifact creature token with trample.",
             "colours": [],
@@ -33080,7 +33080,7 @@
         },
         {
             "id": "4d51db2b-b719-52f4-afc5-ca7e0a21e254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f012f5c8-a974-40a4-9375-071e4d95182a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f012f5c8-a974-40a4-9375-071e4d95182a.jpg?1",
             "name": "Azorius Signet",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -33110,7 +33110,7 @@
         },
         {
             "id": "f12234aa-1ca7-5a22-b248-2089b64ab9a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6e02b3-be4c-45b8-9cb8-6b3142b30c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6e02b3-be4c-45b8-9cb8-6b3142b30c6b.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -33140,7 +33140,7 @@
         },
         {
             "id": "36616551-37c0-53a8-9c12-1b9eb3d9bda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca66955-d900-45b6-9a40-38467689a68d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca66955-d900-45b6-9a40-38467689a68d.jpg?1",
             "name": "The Chain Veil",
             "text": "At the beginning of your end step, if you didn't activate a loyalty ability of a planeswalker this turn, you lose 2 life.\n{4}, {T}: For each planeswalker you control, you may activate one of its loyalty abilities once this turn as though none of its loyalty abilities have been activated this turn.",
             "colours": [],
@@ -33169,7 +33169,7 @@
         },
         {
             "id": "08a934e6-5382-54de-b640-92b856716998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e81f3-b456-4fe6-941d-a7f2bf4aa844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e81f3-b456-4fe6-941d-a7f2bf4aa844.jpg?1",
             "name": "Crashing Drawbridge",
             "text": "Defender\n{T}: Creatures you control gain haste until end of turn.",
             "colours": [],
@@ -33199,7 +33199,7 @@
         },
         {
             "id": "25e373e3-32b9-57cb-8b00-177f5b6de67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a27816-7ee9-4fa1-aa01-78796ad62337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a27816-7ee9-4fa1-aa01-78796ad62337.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {C}{C}{C}.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -33226,7 +33226,7 @@
         },
         {
             "id": "943bcc13-e688-5116-9012-29a70f2ca922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecb184f-c282-42f3-9576-09781a116352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecb184f-c282-42f3-9576-09781a116352.jpg?1",
             "name": "Duplicant",
             "text": "Imprint \u2014 When Duplicant enters the battlefield, you may exile target nontoken creature.\nAs long as a card exiled with Duplicant is a creature card, Duplicant has the power, toughness, and creature types of the last creature card exiled with Duplicant. It's still a Shapeshifter.",
             "colours": [],
@@ -33256,7 +33256,7 @@
         },
         {
             "id": "3189caed-2af7-5ead-a6a2-b6955e21d81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c2025-03cf-4c3d-9dd5-0d25f7019d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30c2025-03cf-4c3d-9dd5-0d25f7019d25.jpg?1",
             "name": "Endless Atlas",
             "text": "{2}, {T}: Draw a card. Activate only if you control three or more lands with the same name.",
             "colours": [],
@@ -33283,7 +33283,7 @@
         },
         {
             "id": "c4741075-b6e7-5c95-9aee-afcedf95ee9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c18d57-16a7-4cc0-b086-81c4b9a166c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c18d57-16a7-4cc0-b086-81c4b9a166c7.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -33310,7 +33310,7 @@
         },
         {
             "id": "a3fe598c-6090-5307-851c-94a0f9b72782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43291d-87c8-4773-99b0-6b7a9d302cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43291d-87c8-4773-99b0-6b7a9d302cd8.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -33339,7 +33339,7 @@
         },
         {
             "id": "774a50f7-1e04-563e-a4cb-6a97b86305d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dfdb91-aa69-45a1-adcc-9fcd85f84ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dfdb91-aa69-45a1-adcc-9fcd85f84ccf.jpg?1",
             "name": "Forsaken Monument",
             "text": "Colorless creatures you control get +2/+2.\nWhenever you tap a permanent for {C}, add an additional {C}.\nWhenever you cast a colorless spell, you gain 2 life.",
             "colours": [],
@@ -33368,7 +33368,7 @@
         },
         {
             "id": "bec6e72d-96ab-5c4e-a73e-0940b35dec48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c323f-eecd-4560-a128-ab513d231552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c323f-eecd-4560-a128-ab513d231552.jpg?1",
             "name": "Hangarback Walker",
             "text": "Hangarback Walker enters the battlefield with X +1/+1 counters on it.\nWhen Hangarback Walker dies, create a 1/1 colorless Thopter artifact creature token with flying for each +1/+1 counter on Hangarback Walker.\n{1}, {T}: Put a +1/+1 counter on Hangarback Walker.",
             "colours": [],
@@ -33398,7 +33398,7 @@
         },
         {
             "id": "52224ec4-0b6d-5026-823a-0b9ee8ffc0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad69703c-637f-44c6-bc84-c1f60d9d9062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad69703c-637f-44c6-bc84-c1f60d9d9062.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -33425,7 +33425,7 @@
         },
         {
             "id": "4c29cc7e-6c91-5493-ae7a-4c3285c3fc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cc583b-4ca1-4e34-bf66-693d69e4f77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cc583b-4ca1-4e34-bf66-693d69e4f77e.jpg?1",
             "name": "Herald's Horn",
             "text": "As Herald's Horn enters the battlefield, choose a creature type.\nCreature spells you cast of the chosen type cost {1} less to cast.\nAt the beginning of your upkeep, look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand.",
             "colours": [],
@@ -33452,7 +33452,7 @@
         },
         {
             "id": "68fbe194-5ecd-505b-a735-1b52eec2ba00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39f563-2ea9-4ddd-8d76-900fa14b480c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39f563-2ea9-4ddd-8d76-900fa14b480c.jpg?1",
             "name": "Honor-Worn Shaku",
             "text": "{T}: Add {C}.\nTap an untapped legendary permanent you control: Untap Honor-Worn Shaku.",
             "colours": [],
@@ -33479,7 +33479,7 @@
         },
         {
             "id": "42ed4d9c-b89f-5f92-8bb6-d2a03611ffd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac115db-9a35-41da-bb77-a61ef6c73b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac115db-9a35-41da-bb77-a61ef6c73b6f.jpg?1",
             "name": "Icon of Ancestry",
             "text": "As Icon of Ancestry enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{3}, {T}: Look at the top three cards of your library. You may reveal a creature card of the chosen type from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -33506,7 +33506,7 @@
         },
         {
             "id": "df465b54-4788-5939-98cd-79714cbf661e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2e3c71-16ee-4521-ba3f-7b8cbba2ace2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2e3c71-16ee-4521-ba3f-7b8cbba2ace2.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -33535,7 +33535,7 @@
         },
         {
             "id": "fced9671-bc68-5b96-bc3c-8257a443bbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e894c45f-30fa-493c-af9e-20261c37d1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e894c45f-30fa-493c-af9e-20261c37d1e1.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -33565,7 +33565,7 @@
         },
         {
             "id": "5e4ef810-9f13-5d7b-8599-d125c0c5edc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572fb0dc-d876-4e1b-91d1-9c595f6f6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572fb0dc-d876-4e1b-91d1-9c595f6f6f04.jpg?1",
             "name": "Kaldra Compleat",
             "text": "Living weapon\nIndestructible\nEquipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"\nEquip {7}",
             "colours": [],
@@ -33596,7 +33596,7 @@
         },
         {
             "id": "bcd84aca-0519-5a82-8d4e-ef401b85b8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1880f-7ac9-45a8-b4cd-a89956078a45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da1880f-7ac9-45a8-b4cd-a89956078a45.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on Mazemind Tome: Scry 1.\n{2}, {T}, Put a page counter on Mazemind Tome: Draw a card.\nWhen there are four or more page counters on Mazemind Tome, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -33623,7 +33623,7 @@
         },
         {
             "id": "40c7e175-2330-5ed5-abeb-51e9a59d3e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f61e807-aa79-41b1-b785-24dddad28021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f61e807-aa79-41b1-b785-24dddad28021.jpg?1",
             "name": "Metalwork Colossus",
             "text": "This spell costs {X} less to cast, where X is the total mana value of noncreature artifacts you control.\nSacrifice two artifacts: Return Metalwork Colossus from your graveyard to your hand.",
             "colours": [],
@@ -33653,7 +33653,7 @@
         },
         {
             "id": "067ecda7-cf7d-5a1d-8733-e55dae84b63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaf1f56-de96-480a-a0c4-0a06d4daf149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaf1f56-de96-480a-a0c4-0a06d4daf149.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -33680,7 +33680,7 @@
         },
         {
             "id": "07b08f98-ead6-5c82-bd95-491140e87853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1252c2-b951-4125-93a2-9282b607b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1252c2-b951-4125-93a2-9282b607b6a4.jpg?1",
             "name": "Mirage Mirror",
             "text": "{2}: Mirage Mirror becomes a copy of target artifact, creature, enchantment, or land until end of turn.",
             "colours": [],
@@ -33707,7 +33707,7 @@
         },
         {
             "id": "eaddf55f-b794-58e6-85ee-ec75be180ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe102126-9aee-4b50-8bc6-1e979132eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe102126-9aee-4b50-8bc6-1e979132eb3e.jpg?1",
             "name": "Myriad Construct",
             "text": "Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.",
             "colours": [],
@@ -33737,7 +33737,7 @@
         },
         {
             "id": "9b938a27-470d-581f-8a3a-4ddf6c565313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0de77a-c503-4000-9eb5-aa28a5e91082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0de77a-c503-4000-9eb5-aa28a5e91082.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast artifact spells and colorless spells from the top of your library.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -33764,7 +33764,7 @@
         },
         {
             "id": "31451d2a-900e-5030-86af-9c5a60f437d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fb6ee3-bd54-4e5b-b055-c2c42515c162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fb6ee3-bd54-4e5b-b055-c2c42515c162.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -33791,7 +33791,7 @@
         },
         {
             "id": "ecce46c3-b2af-543d-94ca-6d7e95984b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bbdc6c-b6c9-4f89-8f0a-6266e53c1fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bbdc6c-b6c9-4f89-8f0a-6266e53c1fb9.jpg?1",
             "name": "Ornithopter of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [],
@@ -33821,7 +33821,7 @@
         },
         {
             "id": "1e59b3b2-61ac-5036-bebd-0952cee58196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c6aba3-38c3-45d1-83e1-40829eb07862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c6aba3-38c3-45d1-83e1-40829eb07862.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -33851,7 +33851,7 @@
         },
         {
             "id": "65ad98c0-6744-51bc-9dba-799133c346c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f747fa8-515c-4c79-8d2e-f1bbab2e4602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f747fa8-515c-4c79-8d2e-f1bbab2e4602.jpg?1",
             "name": "Perilous Vault",
             "text": "{5}, {T}, Exile Perilous Vault: Exile all nonland permanents.",
             "colours": [],
@@ -33878,7 +33878,7 @@
         },
         {
             "id": "c53f5e61-8793-51f2-b2a7-8c55690b7155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55fcddd-e7c8-4f57-8f49-dd86e2d5fe49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55fcddd-e7c8-4f57-8f49-dd86e2d5fe49.jpg?1",
             "name": "Phyrexian Triniform",
             "text": "When Phyrexian Triniform dies, create three 3/3 colorless Phyrexian Golem artifact creature tokens.\nEncore {1}2 ({1}2, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [],
@@ -33909,7 +33909,7 @@
         },
         {
             "id": "706bfab4-a89f-5d97-8049-b51baaacd08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92c8c43-e7b5-4339-8926-1268a89bb2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92c8c43-e7b5-4339-8926-1268a89bb2da.jpg?1",
             "name": "Pillar of Origins",
             "text": "As Pillar of Origins enters the battlefield, choose a creature type.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -33936,7 +33936,7 @@
         },
         {
             "id": "d1711f09-65ee-5b5d-9010-28756da2edb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45c22ca-28fa-47ed-90bc-57a86ed31929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45c22ca-28fa-47ed-90bc-57a86ed31929.jpg?1",
             "name": "Scaretiller",
             "text": "Whenever Scaretiller becomes tapped, choose one \u2014\n\u2022 You may put a land card from your hand onto the battlefield tapped.\n\u2022 Return target land card from your graveyard to the battlefield tapped.",
             "colours": [],
@@ -33966,7 +33966,7 @@
         },
         {
             "id": "1ee96641-ee37-5046-ba28-9c4af1049ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f42cc9-8b7f-4f8a-8d68-8480e668c239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f42cc9-8b7f-4f8a-8d68-8480e668c239.jpg?1",
             "name": "Silent Arbiter",
             "text": "No more than one creature can attack each combat.\nNo more than one creature can block each combat.",
             "colours": [],
@@ -33996,7 +33996,7 @@
         },
         {
             "id": "372fec3e-98da-5654-b190-8ad7f8bb24c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d290747-3b54-4e40-baac-b64cb7ef7787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d290747-3b54-4e40-baac-b64cb7ef7787.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -34026,7 +34026,7 @@
         },
         {
             "id": "d8057f28-43b7-5148-bc7f-e6f9da4fec76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b6480a-9b25-42a2-b62c-1f375216b211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b6480a-9b25-42a2-b62c-1f375216b211.jpg?1",
             "name": "Soul of New Phyrexia",
             "text": "Trample\n{5}: Permanents you control gain indestructible until end of turn.\n{5}, Exile Soul of New Phyrexia from your graveyard: Permanents you control gain indestructible until end of turn.",
             "colours": [],
@@ -34057,7 +34057,7 @@
         },
         {
             "id": "3ff0b6bd-8da1-56b9-8e9b-13dba8d27af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9582e2e-f170-4060-b364-0a2dd23b8e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9582e2e-f170-4060-b364-0a2dd23b8e62.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: Steel Hellkite gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with mana value X whose controller was dealt combat damage by Steel Hellkite this turn. Activate only once each turn.",
             "colours": [],
@@ -34087,7 +34087,7 @@
         },
         {
             "id": "77dbfdc6-63d2-5eec-91c4-f60f737a6e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354456dc-81da-4cd1-b7b1-7ea1ce1bcc9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354456dc-81da-4cd1-b7b1-7ea1ce1bcc9f.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "Reach, trample, protection from multicolored\nStonecoil Serpent enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -34117,7 +34117,7 @@
         },
         {
             "id": "33a65ab3-80a5-5df1-a679-cfb1d77ae8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3803dd5f-32cb-45c3-ab0b-55a706549ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3803dd5f-32cb-45c3-ab0b-55a706549ba5.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -34147,7 +34147,7 @@
         },
         {
             "id": "29f493a7-b47a-50af-9c24-4638fbcfa2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a58b9-2cf5-4898-8261-b7c51edc2051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a58b9-2cf5-4898-8261-b7c51edc2051.jpg?1",
             "name": "Talisman of Conviction",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Talisman of Conviction deals 1 damage to you.",
             "colours": [],
@@ -34177,7 +34177,7 @@
         },
         {
             "id": "cc947e32-1ebf-5504-940d-08b6deb51287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebb2086-3d9c-4322-bd3f-1366a4354578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebb2086-3d9c-4322-bd3f-1366a4354578.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -34207,7 +34207,7 @@
         },
         {
             "id": "54040674-44d1-53ae-90b7-ce40743285d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c406a0-607a-49eb-b506-bee60234fe6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c406a0-607a-49eb-b506-bee60234fe6d.jpg?1",
             "name": "Talisman of Progress",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Talisman of Progress deals 1 damage to you.",
             "colours": [],
@@ -34237,7 +34237,7 @@
         },
         {
             "id": "a46fb681-4b28-5716-8f6a-a7136104d01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bbb789-82e3-4c41-997f-2dc829e2a29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bbb789-82e3-4c41-997f-2dc829e2a29d.jpg?1",
             "name": "Transmogrifying Wand",
             "text": "Transmogrifying Wand enters the battlefield with three charge counters on it.\n{1}, {T}, Remove a charge counter from Transmogrifying Wand: Destroy target creature. Its controller creates a 2/4 white Ox creature token. Activate only as a sorcery.",
             "colours": [],
@@ -34264,7 +34264,7 @@
         },
         {
             "id": "a62ebd0e-9c63-5032-b7d9-6ec7712f256e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8162961c-bfe0-4e30-bad4-f473bf582f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8162961c-bfe0-4e30-bad4-f473bf582f21.jpg?1",
             "name": "Vanquisher's Banner",
             "text": "As Vanquisher's Banner enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\nWhenever you cast a creature spell of the chosen type, draw a card.",
             "colours": [],
@@ -34291,7 +34291,7 @@
         },
         {
             "id": "9184a7c6-c49d-50ef-a889-2877ca43753a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61a30eb-66b2-4a59-ada3-400580cc9c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61a30eb-66b2-4a59-ada3-400580cc9c36.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -34318,7 +34318,7 @@
         },
         {
             "id": "48ab8ff6-9ee9-5484-8553-95dffb177064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f3445a-3488-4367-a6f3-fd1904b11148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f3445a-3488-4367-a6f3-fd1904b11148.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone enters the battlefield tapped.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -34345,7 +34345,7 @@
         },
         {
             "id": "5dd2d64f-8aa6-5cf4-ad82-cfaedf66a5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c247fd6-09f3-40cd-b3fb-53b6526e1dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c247fd6-09f3-40cd-b3fb-53b6526e1dcf.jpg?1",
             "name": "Arcane Lighthouse",
             "text": "{T}: Add {C}.\n{1}, {T}: Until end of turn, creatures your opponents control lose hexproof and shroud and can't have hexproof or shroud.",
             "colours": [],
@@ -34372,7 +34372,7 @@
         },
         {
             "id": "0f4514fc-472e-5146-b662-777cd4095e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4046d8-9f53-4b33-b76c-54bc5e83f496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4046d8-9f53-4b33-b76c-54bc5e83f496.jpg?1",
             "name": "Arch of Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C}.\n{5}, {T}: Draw a card. Activate only if you have the city's blessing.",
             "colours": [],
@@ -34399,7 +34399,7 @@
         },
         {
             "id": "dcd95a68-a392-552e-92d7-1f08e3b747f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad14f1-d541-4e58-af9f-f8e587fca05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad14f1-d541-4e58-af9f-f8e587fca05f.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with mana value equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -34426,7 +34426,7 @@
         },
         {
             "id": "f18af6d8-cad0-5400-bf08-b0eec5782cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b6aca8-190e-49b0-9185-2c72bd3fda7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b6aca8-190e-49b0-9185-2c72bd3fda7d.jpg?1",
             "name": "Bonders' Enclave",
             "text": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater.",
             "colours": [],
@@ -34453,7 +34453,7 @@
         },
         {
             "id": "73a1989b-204a-5f91-a4fc-b7b7dd4134a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b99bb11-bec7-4c50-a0c8-49740655f725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b99bb11-bec7-4c50-a0c8-49740655f725.jpg?1",
             "name": "Canopy Vista",
             "text": "({T}: Add {G} or {W}.)\nCanopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -34486,7 +34486,7 @@
         },
         {
             "id": "bf7d602d-eeb4-50e9-ba5f-b66a05fdcae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15406173-530f-4f4f-82f3-f3e193979fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15406173-530f-4f4f-82f3-f3e193979fd7.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {C}.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R}.",
             "colours": [],
@@ -34516,7 +34516,7 @@
         },
         {
             "id": "70f33f5e-2bfb-5e94-b534-3ac9fa1a2aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c02660c-a9ff-4f6e-9a0b-975b20afaff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c02660c-a9ff-4f6e-9a0b-975b20afaff3.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G}.)\nCinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -34549,7 +34549,7 @@
         },
         {
             "id": "5b0c991c-5d28-50c6-b31f-7a663cb0f626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbab7e1f-305e-4733-aa70-b27285740925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbab7e1f-305e-4733-aa70-b27285740925.jpg?1",
             "name": "Eldrazi Temple",
             "text": "{T}: Add {C}.\n{T}: Add {C}{C}. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
             "colours": [],
@@ -34576,7 +34576,7 @@
         },
         {
             "id": "d2c5cbcd-e870-5bf8-86cd-f059ca24cc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63325755-47d5-4bb2-a21c-f324c27e1bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63325755-47d5-4bb2-a21c-f324c27e1bbd.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -34603,7 +34603,7 @@
         },
         {
             "id": "541877c5-4d7e-5875-b8b0-31a6de99febd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc0fba-c285-4fad-85a6-79fd7f3f9c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fc0fba-c285-4fad-85a6-79fd7f3f9c35.jpg?1",
             "name": "Flood Plain",
             "text": "Flood Plain enters the battlefield tapped.\n{T}, Sacrifice Flood Plain: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -34630,7 +34630,7 @@
         },
         {
             "id": "f4f18637-7458-58f3-9a68-e22a4bce65f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f11f053-5150-4a76-b2ca-9df3a0629911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f11f053-5150-4a76-b2ca-9df3a0629911.jpg?1",
             "name": "Forge of Heroes",
             "text": "{T}: Add {C}.\n{T}: Choose target commander that entered the battlefield this turn. Put a +1/+1 counter on it if it's a creature and a loyalty counter on it if it's a planeswalker.",
             "colours": [],
@@ -34657,7 +34657,7 @@
         },
         {
             "id": "4b0f1b49-cc18-5fa0-99e6-002b3f1bc39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedc3df-3ee0-4622-b103-701c45f331d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cedc3df-3ee0-4622-b103-701c45f331d5.jpg?1",
             "name": "Fortified Village",
             "text": "As Fortified Village enters the battlefield, you may reveal a Forest or Plains card from your hand. If you don't, Fortified Village enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -34687,7 +34687,7 @@
         },
         {
             "id": "fdc46066-77d8-5604-ab52-a27af7cc612e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c4f254-1109-4aaf-a33c-ae59795b1c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c4f254-1109-4aaf-a33c-ae59795b1c20.jpg?1",
             "name": "Frontier Bivouac",
             "text": "Frontier Bivouac enters the battlefield tapped.\n{T}: Add {G}, {U}, or {R}.",
             "colours": [],
@@ -34718,7 +34718,7 @@
         },
         {
             "id": "12d78622-a060-5d92-8dac-f234d7e47088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c295e4b-0b52-4422-85bc-e631a93d9e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c295e4b-0b52-4422-85bc-e631a93d9e5f.jpg?1",
             "name": "Frostboil Snarl",
             "text": "As Frostboil Snarl enters the battlefield, you may reveal an Island or Mountain card from your hand. If you don't, Frostboil Snarl enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -34748,7 +34748,7 @@
         },
         {
             "id": "d0a92bb8-4ec3-5a3a-9e1d-6aa7e8b7bc92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703f058c-6fc4-4e06-8570-a094ffe44574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703f058c-6fc4-4e06-8570-a094ffe44574.jpg?1",
             "name": "Furycalm Snarl",
             "text": "As Furycalm Snarl enters the battlefield, you may reveal a Mountain or Plains card from your hand. If you don't, Furycalm Snarl enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -34778,7 +34778,7 @@
         },
         {
             "id": "66bee094-7386-515a-b0a6-8c7bf7642f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4d0772-35a3-434f-afb5-2137aa4f3dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4d0772-35a3-434f-afb5-2137aa4f3dec.jpg?1",
             "name": "Geier Reach Sanitarium",
             "text": "{T}: Add {C}.\n{2}, {T}: Each player draws a card, then discards a card.",
             "colours": [],
@@ -34807,7 +34807,7 @@
         },
         {
             "id": "84c18a8a-9136-59c6-9568-d1ccd1083091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ac08c9-e55e-4e4b-9170-0a82344cfbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ac08c9-e55e-4e4b-9170-0a82344cfbc1.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G}.",
             "colours": [],
@@ -34837,7 +34837,7 @@
         },
         {
             "id": "5d9419f5-4d67-51aa-bddd-4838b98c1318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf52798-b2e0-4d0a-a41b-8927bfa60375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf52798-b2e0-4d0a-a41b-8927bfa60375.jpg?1",
             "name": "Grasslands",
             "text": "Grasslands enters the battlefield tapped.\n{T}, Sacrifice Grasslands: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -34864,7 +34864,7 @@
         },
         {
             "id": "fbf1d544-2ec1-5cce-9093-b1958c974ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f943d5d-e8a1-4fe1-aad5-80c7ccf15435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f943d5d-e8a1-4fe1-aad5-80c7ccf15435.jpg?1",
             "name": "Guildless Commons",
             "text": "Guildless Commons enters the battlefield tapped.\nWhen Guildless Commons enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -34891,7 +34891,7 @@
         },
         {
             "id": "46164d32-6c41-51d7-a120-46247bc7d0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1bed72-2440-4364-a69f-a9d7c4fe3fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1bed72-2440-4364-a69f-a9d7c4fe3fea.jpg?1",
             "name": "Interplanar Beacon",
             "text": "Whenever you cast a planeswalker spell, you gain 1 life.\n{T}: Add {C}.\n{1}, {T}: Add two mana of different colors. Spend this mana only to cast planeswalker spells.",
             "colours": [],
@@ -34918,7 +34918,7 @@
         },
         {
             "id": "deb85562-db83-5ddc-bd6c-f4178d51e8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e428c9d-f70f-4777-8aab-3db7a4140742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e428c9d-f70f-4777-8aab-3db7a4140742.jpg?1",
             "name": "Irrigated Farmland",
             "text": "({T}: Add {W} or {U}.)\nIrrigated Farmland enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -34951,7 +34951,7 @@
         },
         {
             "id": "39aa808c-6f80-53a1-9453-556aa78cf274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7f64d5-3e54-4640-a0e4-1fea6ffb67eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7f64d5-3e54-4640-a0e4-1fea6ffb67eb.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine enters the battlefield tapped.\n{T}: Add {R}, {G}, or {W}.",
             "colours": [],
@@ -34982,7 +34982,7 @@
         },
         {
             "id": "09ddf326-7d37-5114-bc4c-5796a3713439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875ca80a-3eb8-434c-8114-536caab23211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875ca80a-3eb8-434c-8114-536caab23211.jpg?1",
             "name": "Karn's Bastion",
             "text": "{T}: Add {C}.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -35009,7 +35009,7 @@
         },
         {
             "id": "fd785bee-c498-5a94-97af-de041004aec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5ca583-38f2-4692-a29c-326510be5bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5ca583-38f2-4692-a29c-326510be5bb8.jpg?1",
             "name": "Krosan Verge",
             "text": "Krosan Verge enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Krosan Verge: Search your library for a Forest card and a Plains card, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -35036,7 +35036,7 @@
         },
         {
             "id": "2a362038-8c2d-5789-b1c4-a69c3eee968b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f060ea2b-717a-47ae-a4d6-b0594e838459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f060ea2b-717a-47ae-a4d6-b0594e838459.jpg?1",
             "name": "Mage-Ring Network",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Mage-Ring Network.\n{T}, Remove any number of storage counters from Mage-Ring Network: Add {C} for each storage counter removed this way.",
             "colours": [],
@@ -35063,7 +35063,7 @@
         },
         {
             "id": "a5e62f45-06ef-5386-a9bc-4cc782e27870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0441cd2c-3646-4c69-ae97-ad3bcea7466f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0441cd2c-3646-4c69-ae97-ad3bcea7466f.jpg?1",
             "name": "Mirrorpool",
             "text": "Mirrorpool enters the battlefield tapped.\n{T}: Add {C}.\n{2}{C}, {T}, Sacrifice Mirrorpool: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}{C}, {T}, Sacrifice Mirrorpool: Create a token that's a copy of target creature you control.",
             "colours": [],
@@ -35090,7 +35090,7 @@
         },
         {
             "id": "42bb7211-b22e-5bd9-b446-d04313d0392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7921b97-083b-480a-a7df-f2ab82e6f8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7921b97-083b-480a-a7df-f2ab82e6f8fb.jpg?1",
             "name": "Mobilized District",
             "text": "{T}: Add {C}.\n{4}: Mobilized District becomes a 3/3 Citizen creature with vigilance until end of turn. It's still a land. This ability costs {1} less to activate for each legendary creature and planeswalker you control.",
             "colours": [],
@@ -35117,7 +35117,7 @@
         },
         {
             "id": "ba4447f1-62ad-5fe2-8d55-07b4c7d5c9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86f172-4f6f-4f9e-9ae0-ca5c489cd671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86f172-4f6f-4f9e-9ae0-ca5c489cd671.jpg?1",
             "name": "Mountain Valley",
             "text": "Mountain Valley enters the battlefield tapped.\n{T}, Sacrifice Mountain Valley: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -35144,7 +35144,7 @@
         },
         {
             "id": "ed1d2d46-1950-5815-a5da-006f1a7146db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f99714f-43bc-4048-b650-97dfef4c10fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f99714f-43bc-4048-b650-97dfef4c10fe.jpg?1",
             "name": "Mystic Gate",
             "text": "{T}: Add {C}.\n{WU}, {T}: Add {W}{W}, {W}{U}, or {U}{U}.",
             "colours": [],
@@ -35174,7 +35174,7 @@
         },
         {
             "id": "047c163b-849b-532a-a2e7-6653f420570c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d3961-cc3f-408a-821e-2d9ea025c51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d3961-cc3f-408a-821e-2d9ea025c51e.jpg?1",
             "name": "Mystic Monastery",
             "text": "Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W}.",
             "colours": [],
@@ -35205,7 +35205,7 @@
         },
         {
             "id": "d3c3ab3d-dffc-5c1b-9f58-a00cf482fd7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734f816-2065-4741-a5c4-be9a7ebfae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2734f816-2065-4741-a5c4-be9a7ebfae8f.jpg?1",
             "name": "Necroblossom Snarl",
             "text": "As Necroblossom Snarl enters the battlefield, you may reveal a Swamp or Forest card from your hand. If you don't, Necroblossom Snarl enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -35235,7 +35235,7 @@
         },
         {
             "id": "ec5f3a0b-a24e-56ce-ba60-058d472c33ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acb9c2c-8fdb-49da-b792-3e21c4274364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acb9c2c-8fdb-49da-b792-3e21c4274364.jpg?1",
             "name": "Nomad Outpost",
             "text": "Nomad Outpost enters the battlefield tapped.\n{T}: Add {R}, {W}, or {B}.",
             "colours": [],
@@ -35266,7 +35266,7 @@
         },
         {
             "id": "acc92766-d568-5f0c-a29e-fddf13ed903e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacdb4a4-10f8-45d8-abc7-d8b72f1ab0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacdb4a4-10f8-45d8-abc7-d8b72f1ab0ed.jpg?1",
             "name": "Opulent Palace",
             "text": "Opulent Palace enters the battlefield tapped.\n{T}: Add {B}, {G}, or {U}.",
             "colours": [],
@@ -35297,7 +35297,7 @@
         },
         {
             "id": "876ca65d-49d5-5617-af0d-406ad6b091db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149f23-9347-4343-a49f-9524e404fc43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149f23-9347-4343-a49f-9524e404fc43.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B}.",
             "colours": [],
@@ -35327,7 +35327,7 @@
         },
         {
             "id": "b79c68e2-ce3e-5a69-b4af-f8fcb68f6941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c035d-1309-4286-a758-07517f323f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c035d-1309-4286-a758-07517f323f34.jpg?1",
             "name": "Port Town",
             "text": "As Port Town enters the battlefield, you may reveal a Plains or Island card from your hand. If you don't, Port Town enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -35357,7 +35357,7 @@
         },
         {
             "id": "875de984-904a-569b-b5f5-0476b873292e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac634a-d792-4cca-8735-41a9a663f775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac634a-d792-4cca-8735-41a9a663f775.jpg?1",
             "name": "Prairie Stream",
             "text": "({T}: Add {W} or {U}.)\nPrairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -35390,7 +35390,7 @@
         },
         {
             "id": "7c464d23-51ce-5382-9110-c6f4c9cfc698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa3e6c-c37b-4e6e-9246-18ff9b36508d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa3e6c-c37b-4e6e-9246-18ff9b36508d.jpg?1",
             "name": "Rocky Tar Pit",
             "text": "Rocky Tar Pit enters the battlefield tapped.\n{T}, Sacrifice Rocky Tar Pit: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -35417,7 +35417,7 @@
         },
         {
             "id": "5866bbbc-86bb-5fc9-939d-676b6e757abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec2908-0b96-4b91-a269-3d7bc75be168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec2908-0b96-4b91-a269-3d7bc75be168.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {C}.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W}.",
             "colours": [],
@@ -35447,7 +35447,7 @@
         },
         {
             "id": "03d72a6e-297e-5945-bf9d-d41121732c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1159ef6-f3ac-42a0-ae46-7d5eb9b3a6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1159ef6-f3ac-42a0-ae46-7d5eb9b3a6eb.jpg?1",
             "name": "Ruins of Oran-Rief",
             "text": "Ruins of Oran-Rief enters the battlefield tapped.\n{T}: Add {C}.\n{T}: Put a +1/+1 counter on target colorless creature that entered the battlefield this turn.",
             "colours": [],
@@ -35474,7 +35474,7 @@
         },
         {
             "id": "be409be3-a158-514f-b88d-d65663af4167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f7d30c-91ec-4d02-9ee0-ed4de495cbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f7d30c-91ec-4d02-9ee0-ed4de495cbf5.jpg?1",
             "name": "Sandsteppe Citadel",
             "text": "Sandsteppe Citadel enters the battlefield tapped.\n{T}: Add {W}, {B}, or {G}.",
             "colours": [],
@@ -35505,7 +35505,7 @@
         },
         {
             "id": "e2f4b860-af59-524c-9025-de4e6a30316b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8502d1e6-86f1-40d8-8d3b-20d47e57bccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8502d1e6-86f1-40d8-8d3b-20d47e57bccb.jpg?1",
             "name": "Savage Lands",
             "text": "Savage Lands enters the battlefield tapped.\n{T}: Add {B}, {R}, or {G}.",
             "colours": [],
@@ -35536,7 +35536,7 @@
         },
         {
             "id": "cdfb8e71-9527-5add-a85c-f2df15bf7bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebce2f7a-1879-49f1-b4f7-98e5931c5fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebce2f7a-1879-49f1-b4f7-98e5931c5fb9.jpg?1",
             "name": "Scattered Groves",
             "text": "({T}: Add {G} or {W}.)\nScattered Groves enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -35569,7 +35569,7 @@
         },
         {
             "id": "ab576b8f-c4e5-56c3-b333-8f8714821902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c42d13-3ef6-4baf-81d0-766a6df1e712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c42d13-3ef6-4baf-81d0-766a6df1e712.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all graveyards.",
             "colours": [],
@@ -35598,7 +35598,7 @@
         },
         {
             "id": "21eba8a4-dcb3-5f1d-a812-92cd5f43d59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c137634-7531-4573-9bfa-623d8edf839c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c137634-7531-4573-9bfa-623d8edf839c.jpg?1",
             "name": "Sea Gate Wreckage",
             "text": "{T}: Add {C}.\n{2}{C}, {T}: Draw a card. Activate only if you have no cards in hand.",
             "colours": [],
@@ -35625,7 +35625,7 @@
         },
         {
             "id": "244b8806-aa13-5ce9-917f-d451e9838c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b198fc2c-9610-4564-a228-bd8cc01eddfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b198fc2c-9610-4564-a228-bd8cc01eddfe.jpg?1",
             "name": "Seaside Citadel",
             "text": "Seaside Citadel enters the battlefield tapped.\n{T}: Add {G}, {W}, or {U}.",
             "colours": [],
@@ -35656,7 +35656,7 @@
         },
         {
             "id": "4ce16d5a-9eca-51de-9525-03c86b447975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0da3a5-12fb-4ff0-9894-fdabdfa4d860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0da3a5-12fb-4ff0-9894-fdabdfa4d860.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As Secluded Courtyard enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature or creature card of the chosen type.",
             "colours": [],
@@ -35683,7 +35683,7 @@
         },
         {
             "id": "abebacdb-7f4e-512b-a738-e6e61ba2e0c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5bb089-a231-4d8a-a02a-296152cf5b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5bb089-a231-4d8a-a02a-296152cf5b4d.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W}.",
             "colours": [],
@@ -35713,7 +35713,7 @@
         },
         {
             "id": "0e05dd5b-dbc0-50c3-b7f4-f09a9258fdec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705cc0f7-9817-4e00-a926-f3b6e8e8cace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705cc0f7-9817-4e00-a926-f3b6e8e8cace.jpg?1",
             "name": "Sheltered Thicket",
             "text": "({T}: Add {R} or {G}.)\nSheltered Thicket enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -35746,7 +35746,7 @@
         },
         {
             "id": "1cc9a571-1b6d-5205-b402-4dbdd72d4184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492354e6-fe48-43f6-b86c-ac6bc64985f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492354e6-fe48-43f6-b86c-ac6bc64985f0.jpg?1",
             "name": "Shineshadow Snarl",
             "text": "As Shineshadow Snarl enters the battlefield, you may reveal a Plains or Swamp card from your hand. If you don't, Shineshadow Snarl enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -35776,7 +35776,7 @@
         },
         {
             "id": "40334f82-1235-5a49-a8a2-fe3071e3d01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0467d06a-2218-4824-a89e-7fb4cc9e04eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0467d06a-2218-4824-a89e-7fb4cc9e04eb.jpg?1",
             "name": "Shrine of the Forsaken Gods",
             "text": "{T}: Add {C}.\n{T}: Add {C}{C}. Spend this mana only to cast colorless spells. Activate only if you control seven or more lands.",
             "colours": [],
@@ -35803,7 +35803,7 @@
         },
         {
             "id": "bef80faa-9d04-5172-963b-85ebbc94fcba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1c9810-c6bf-4bce-b131-37ea34f3f840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1c9810-c6bf-4bce-b131-37ea34f3f840.jpg?1",
             "name": "Skycloud Expanse",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -35833,7 +35833,7 @@
         },
         {
             "id": "0ca1abeb-b171-5f08-be92-3934ded76d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66431343-b325-4477-a158-25f0e25fdb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66431343-b325-4477-a158-25f0e25fdb8e.jpg?1",
             "name": "Smoldering Marsh",
             "text": "({T}: Add {B} or {R}.)\nSmoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -35866,7 +35866,7 @@
         },
         {
             "id": "b4cb7e51-b461-5b59-93ed-07cc5a47404e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f0dd35-3732-429f-97e1-2ecfe872d404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f0dd35-3732-429f-97e1-2ecfe872d404.jpg?1",
             "name": "Sungrass Prairie",
             "text": "{1}, {T}: Add {G}{W}.",
             "colours": [],
@@ -35896,7 +35896,7 @@
         },
         {
             "id": "8eaf8f70-6621-52e7-8a31-fa99c18b2496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a82e6dd-f591-4e71-a1ae-ec24e5b97751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a82e6dd-f591-4e71-a1ae-ec24e5b97751.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B}.)\nSunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -35929,7 +35929,7 @@
         },
         {
             "id": "9b3b544b-2b8d-573b-9a1d-592f49bb4102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a1e07c-314c-4a7f-bd8f-97cdde1f0791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a1e07c-314c-4a7f-bd8f-97cdde1f0791.jpg?1",
             "name": "Tainted Field",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -35959,7 +35959,7 @@
         },
         {
             "id": "01554e83-4727-54ed-aac5-5abf36b08567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40830022-4e9d-4195-bf52-d4ed2eb58b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40830022-4e9d-4195-bf52-d4ed2eb58b3f.jpg?1",
             "name": "Tainted Wood",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Activate only if you control a Swamp.",
             "colours": [],
@@ -35989,7 +35989,7 @@
         },
         {
             "id": "f1394949-5419-52f9-893b-42c7aa346477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef1c3e3-f038-4ec3-84a1-756c52b5dbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef1c3e3-f038-4ec3-84a1-756c52b5dbe1.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -36019,7 +36019,7 @@
         },
         {
             "id": "6ce18af7-9de1-51ed-ac06-d2b55e9d0f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77363b9-276b-421d-b422-8c9a3838d118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77363b9-276b-421d-b422-8c9a3838d118.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -36049,7 +36049,7 @@
         },
         {
             "id": "29d445b8-3e69-5199-963d-8fc4b07e90ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c9c7cb-4e2d-4dd1-a3ed-49caab45aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c9c7cb-4e2d-4dd1-a3ed-49caab45aacb.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -36079,7 +36079,7 @@
         },
         {
             "id": "0b97ef34-15b9-5f48-8320-fdfdbfa678aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5de86-33fb-476e-a1ec-25a215401c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5de86-33fb-476e-a1ec-25a215401c41.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -36109,7 +36109,7 @@
         },
         {
             "id": "5718bd73-4739-56df-a89a-51929936473a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defc55e7-661b-4803-b581-eaa363c70f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defc55e7-661b-4803-b581-eaa363c70f04.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -36139,7 +36139,7 @@
         },
         {
             "id": "0ec67a9f-caa6-5c0d-bd5d-4366b37d5255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfdec59-36e0-4280-946f-cded4b600883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfdec59-36e0-4280-946f-cded4b600883.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {C}{C}. Activate only if you control five or more lands.",
             "colours": [],
@@ -36166,7 +36166,7 @@
         },
         {
             "id": "531f4bb1-298f-5cf6-9424-d968a20ee5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ead529-accb-4b6f-ab60-d715d80b3c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ead529-accb-4b6f-ab60-d715d80b3c99.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -36196,7 +36196,7 @@
         },
         {
             "id": "a51b71b9-93bb-5299-a69a-7d6a0920f735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824bf3cc-fb35-4bc1-998c-6758b1eed2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824bf3cc-fb35-4bc1-998c-6758b1eed2ca.jpg?1",
             "name": "Tomb of the Spirit Dragon",
             "text": "{T}: Add {C}.\n{2}, {T}: You gain 1 life for each colorless creature you control.",
             "colours": [],
@@ -36223,7 +36223,7 @@
         },
         {
             "id": "e03a34b7-8761-55c0-9405-5550b7107254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27906645-7d43-4c18-a20b-8d683069351e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27906645-7d43-4c18-a20b-8d683069351e.jpg?1",
             "name": "Tyrite Sanctum",
             "text": "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice Tyrite Sanctum: Put an indestructible counter on target God.",
             "colours": [],
@@ -36250,7 +36250,7 @@
         },
         {
             "id": "e3e4052c-b7b6-5b19-b9f6-b6440b467032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29e1761-87e6-448d-a901-1a6c5329e195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29e1761-87e6-448d-a901-1a6c5329e195.jpg?1",
             "name": "Unclaimed Territory",
             "text": "As Unclaimed Territory enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -36277,7 +36277,7 @@
         },
         {
             "id": "ad145d0c-c966-5921-95a5-37730cbf91c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bbb7d-ae61-4d8d-b931-9ed2f712832e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bbb7d-ae61-4d8d-b931-9ed2f712832e.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -36307,7 +36307,7 @@
         },
         {
             "id": "56126a13-325b-56a4-af5b-51427a1669c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0449a19-37f7-4169-9e32-928db5ec76fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0449a19-37f7-4169-9e32-928db5ec76fe.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -36337,7 +36337,7 @@
         },
         {
             "id": "6ebf0a67-06b0-5357-9241-6e26e5e7e03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f09b3-dd2d-4ba9-a57e-4f3c1793f752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f09b3-dd2d-4ba9-a57e-4f3c1793f752.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -36367,7 +36367,7 @@
         },
         {
             "id": "f1009aa3-979d-5eb5-bd66-dacbbc870a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2f5f65-4ab7-43c8-8a14-422fcfac80df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2f5f65-4ab7-43c8-8a14-422fcfac80df.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -36394,7 +36394,7 @@
         },
         {
             "id": "5ebcc232-4b93-54af-bc8d-7784607b1fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d479a83-16f7-425c-9873-b900f39ed620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d479a83-16f7-425c-9873-b900f39ed620.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -36425,7 +36425,7 @@
         },
         {
             "id": "2a595cdf-4bba-5349-9a1d-ee1a99d25a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2585d250-1cce-431c-a9d1-a3adce9d70cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2585d250-1cce-431c-a9d1-a3adce9d70cd.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -36456,7 +36456,7 @@
         },
         {
             "id": "f85354c3-9c15-53a3-8110-61aec8b37af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1471f611-1352-4c4a-aacd-57b27a996d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1471f611-1352-4c4a-aacd-57b27a996d2c.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast this spell, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with mana value X: Counter target spell with mana value X.",
             "colours": [],
@@ -36491,7 +36491,7 @@
         },
         {
             "id": "66b76e73-12fc-5d65-aadf-3a2eab13370b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21e1de9-7128-4797-8483-86ac826ab1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21e1de9-7128-4797-8483-86ac826ab1e4.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -36532,7 +36532,7 @@
         },
         {
             "id": "978ad978-84de-53f4-81d8-d78476628659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe88719-d081-49f7-9505-f69a2694c0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe88719-d081-49f7-9505-f69a2694c0e7.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger",
             "text": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog, the Ceaseless Hunger attacks, defending player exiles the top twenty cards of their library.",
             "colours": [],
@@ -36567,7 +36567,7 @@
         },
         {
             "id": "2476658f-9433-5aca-b14e-0ed1f476e8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e286a7c-9643-492f-8ce9-255499dfd1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e286a7c-9643-492f-8ce9-255499dfd1a7.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -36607,7 +36607,7 @@
         },
         {
             "id": "4628edce-fa74-54e5-a2d3-946f645f4760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b831b17a-396f-4242-8e98-1a60abb75c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b831b17a-396f-4242-8e98-1a60abb75c41.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -36647,7 +36647,7 @@
         },
         {
             "id": "5ee28824-3a1f-502c-87e9-d66116e9061c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd74a-0d9d-4c56-a167-dcff58e5ab26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd74a-0d9d-4c56-a167-dcff58e5ab26.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -36688,7 +36688,7 @@
         },
         {
             "id": "84e5604e-2327-5c13-a876-8d2c629ffd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5be1b6-3a6a-4601-914b-7f4b99629a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5be1b6-3a6a-4601-914b-7f4b99629a7f.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "You don't lose unspent green mana as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each unspent green mana you have.",
             "colours": [
@@ -36727,7 +36727,7 @@
         },
         {
             "id": "ba01d9b9-dfa4-5d61-8c8a-36c85b8fc58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2253ed0b-380e-40b9-bbf9-ff14b80dc272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2253ed0b-380e-40b9-bbf9-ff14b80dc272.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -36767,7 +36767,7 @@
         },
         {
             "id": "ac5f08e2-2619-5ff8-9141-f6bd2056d198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2763752-57af-4d4a-a0e5-5a496985b8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2763752-57af-4d4a-a0e5-5a496985b8bf.jpg?1",
             "name": "The Ur-Dragon",
             "text": "Eminence \u2014 As long as The Ur-Dragon is in the command zone or on the battlefield, other Dragon spells you cast cost {1} less to cast.\nFlying\nWhenever one or more Dragons you control attack, draw that many cards, then you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -36815,7 +36815,7 @@
         },
         {
             "id": "6a0a0403-0b51-54bd-ad46-d124402cc927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99192884-b279-483e-a48a-3724f2e594bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99192884-b279-483e-a48a-3724f2e594bd.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -36846,7 +36846,7 @@
         },
         {
             "id": "2b90f16a-ce37-56a1-b7b0-47aeeee18710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ac73d8-9bd4-4bd1-98f5-4b1dd325b86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ac73d8-9bd4-4bd1-98f5-4b1dd325b86f.jpg?1",
             "name": "Disrupt Decorum",
             "text": "Goad all creatures you don't control.",
             "colours": [
@@ -36880,7 +36880,7 @@
         },
         {
             "id": "a3030333-67fe-5f9b-a27a-139bb63040b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f00da-1c4d-45d4-af34-9216a34bff2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f00da-1c4d-45d4-af34-9216a34bff2a.jpg?1",
             "name": "Eldrazi",
             "text": "",
             "colours": [],
@@ -36911,7 +36911,7 @@
         },
         {
             "id": "1bc18505-8bd3-53e1-9d39-e79ced90f8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7df0d-d7d6-463d-b452-32666973234a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef7df0d-d7d6-463d-b452-32666973234a.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -36943,7 +36943,7 @@
         },
         {
             "id": "07a7888c-27d3-5ab8-b2d2-db057d4610d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e820258-933f-4ad2-b63b-c6cd7f5bddf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e820258-933f-4ad2-b63b-c6cd7f5bddf3.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -36975,7 +36975,7 @@
         },
         {
             "id": "1e454e40-0232-5241-bafc-e32bbad90511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7ca733-6947-4e09-953e-d8b37b799e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7ca733-6947-4e09-953e-d8b37b799e6a.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -37010,7 +37010,7 @@
         },
         {
             "id": "edc00932-5ffc-5f52-8da6-d5298d564464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b3ed0c-1044-4662-9785-04d8503f1fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b3ed0c-1044-4662-9785-04d8503f1fbf.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -37045,7 +37045,7 @@
         },
         {
             "id": "6694c9b2-2bb0-5d4e-abab-ced0cb58da77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29dd78-a059-4aad-8627-9c783f245a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de29dd78-a059-4aad-8627-9c783f245a91.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -37081,7 +37081,7 @@
         },
         {
             "id": "40127fba-2bcb-55f9-ad23-9d2b375c5933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df61c33-38b3-4549-9e5d-ae1b5c1afd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df61c33-38b3-4549-9e5d-ae1b5c1afd62.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -37116,7 +37116,7 @@
         },
         {
             "id": "a0cf69b8-6092-5687-85fa-a4402bd43e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8907c15d-831b-47d5-b2b5-7759876b8f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8907c15d-831b-47d5-b2b5-7759876b8f33.jpg?1",
             "name": "Kor Soldier",
             "text": "",
             "colours": [
@@ -37152,7 +37152,7 @@
         },
         {
             "id": "380b1a95-dd79-57f7-9f37-20c2d72ef53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10322962-5b45-438f-9d28-225414721c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10322962-5b45-438f-9d28-225414721c34.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -37187,7 +37187,7 @@
         },
         {
             "id": "920fc4a1-1aac-564d-bd72-e727b4586621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8ba2be-4e95-4d10-b866-9fde3f8c8a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8ba2be-4e95-4d10-b866-9fde3f8c8a3f.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -37222,7 +37222,7 @@
         },
         {
             "id": "4a62e0c4-bf54-5c81-9dcb-24ac27b2b7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70faf3a-adf6-482c-9f7d-7f254d5f8bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70faf3a-adf6-482c-9f7d-7f254d5f8bec.jpg?1",
             "name": "Bird Illusion",
             "text": "",
             "colours": [
@@ -37258,7 +37258,7 @@
         },
         {
             "id": "28c7e87c-3eda-52f4-aa11-ebb0880e2bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3a91bf-daa1-4bba-a052-d868700c610c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3a91bf-daa1-4bba-a052-d868700c610c.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -37293,7 +37293,7 @@
         },
         {
             "id": "12ea9ae7-f2ee-5e08-ba1e-68890a67cd4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ee09ec-0d88-469d-b61c-976f3be47766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ee09ec-0d88-469d-b61c-976f3be47766.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -37328,7 +37328,7 @@
         },
         {
             "id": "0fa7ebcf-46e9-5f3c-b8a0-06203060b81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57891433-318b-48a6-a73b-151a81ad3796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57891433-318b-48a6-a73b-151a81ad3796.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -37363,7 +37363,7 @@
         },
         {
             "id": "b4b23663-c2a0-555c-9c1a-a6e67b7858bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad40060-02a3-4044-9006-2c36f3d78e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad40060-02a3-4044-9006-2c36f3d78e16.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -37398,7 +37398,7 @@
         },
         {
             "id": "65313366-37ce-5d33-a1f4-a4e4d0de2f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc375fe9-e8aa-4b7d-b439-a67c0b61beaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc375fe9-e8aa-4b7d-b439-a67c0b61beaf.jpg?1",
             "name": "Phyrexian Germ",
             "text": "",
             "colours": [
@@ -37434,7 +37434,7 @@
         },
         {
             "id": "189e8d27-7f5b-50ab-ade5-914ef5f89753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5328e78-65c5-46e8-8980-3075ece0fa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5328e78-65c5-46e8-8980-3075ece0fa99.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -37469,7 +37469,7 @@
         },
         {
             "id": "d6c4e71a-968f-5b56-8ca9-d1c03571e79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5604c5-4fff-4bb6-bf6d-69027e4eeb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5604c5-4fff-4bb6-bf6d-69027e4eeb21.jpg?1",
             "name": "Thrull",
             "text": "",
             "colours": [
@@ -37504,7 +37504,7 @@
         },
         {
             "id": "0f223254-88df-5e76-be23-7a03641dd1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9feeb-23c3-4c3b-bc04-f50380d20197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9feeb-23c3-4c3b-bc04-f50380d20197.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -37539,7 +37539,7 @@
         },
         {
             "id": "c74d48b9-cea6-56a2-a18d-f36f3918bac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b11035-f651-427f-aad7-deb870d47c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b11035-f651-427f-aad7-deb870d47c10.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -37574,7 +37574,7 @@
         },
         {
             "id": "97cfd4de-c52d-52aa-81bb-d1586c413a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faee2063-b47e-4342-af98-0037b3e8e80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faee2063-b47e-4342-af98-0037b3e8e80f.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -37609,7 +37609,7 @@
         },
         {
             "id": "31bc6cfc-4bac-58b4-bec3-b2d2c99a0eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df0b0ed-b82a-4204-8e2c-9d297b29bf9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df0b0ed-b82a-4204-8e2c-9d297b29bf9a.jpg?1",
             "name": "Dragon Egg",
             "text": "",
             "colours": [
@@ -37645,7 +37645,7 @@
         },
         {
             "id": "58592a45-5fc9-5e4a-8134-4c88f4bf270a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d82864-0286-4511-9e80-a154bec2757f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d82864-0286-4511-9e80-a154bec2757f.jpg?1",
             "name": "Dwarf Berserker",
             "text": "",
             "colours": [
@@ -37681,7 +37681,7 @@
         },
         {
             "id": "b128a11f-f3e0-5829-bef5-cc3d6a662bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a214f-1b12-4d2c-9cc0-f0c5f4a6e7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a214f-1b12-4d2c-9cc0-f0c5f4a6e7a6.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -37716,7 +37716,7 @@
         },
         {
             "id": "1231b97d-bcc3-5c3c-a4e2-35866ffeb999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9051b-f964-43f9-877b-ea4f17620ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9051b-f964-43f9-877b-ea4f17620ecb.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -37751,7 +37751,7 @@
         },
         {
             "id": "0acacbab-00bf-5a8c-9cfd-bed5da4ddeb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d461a38d-761b-47bb-b49d-1b2522cf2f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d461a38d-761b-47bb-b49d-1b2522cf2f6e.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -37786,7 +37786,7 @@
         },
         {
             "id": "c2a8eed6-9133-56db-acbb-e5d14d3b94e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419c1799-1525-44ec-9f6c-dfc290f04ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419c1799-1525-44ec-9f6c-dfc290f04ba7.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -37821,7 +37821,7 @@
         },
         {
             "id": "f3277c26-3d25-511e-aa27-3fcb844aad5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81218951-e61f-43e6-802d-3820725e6f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81218951-e61f-43e6-802d-3820725e6f23.jpg?1",
             "name": "Ogre",
             "text": "",
             "colours": [
@@ -37856,7 +37856,7 @@
         },
         {
             "id": "29d32a74-4bc4-58c4-8441-257804031d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bdae00-bcbd-4238-87d6-7e12ff7ffd83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bdae00-bcbd-4238-87d6-7e12ff7ffd83.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -37891,7 +37891,7 @@
         },
         {
             "id": "d5685814-ee19-5b04-b4ef-bb83165c7c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf66184-0df9-4a6b-bf4a-c5bd0d21b5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf66184-0df9-4a6b-bf4a-c5bd0d21b5b6.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -37926,7 +37926,7 @@
         },
         {
             "id": "615aac95-5f4f-5106-bddf-b7f4aa696a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9a8f49-5b72-4480-ac58-904b7707ac0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9a8f49-5b72-4480-ac58-904b7707ac0b.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -37961,7 +37961,7 @@
         },
         {
             "id": "534409fb-bbd8-5199-ba67-c6bc2d5fdc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348b9211-e189-4c62-abdd-9778cfb84e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348b9211-e189-4c62-abdd-9778cfb84e16.jpg?1",
             "name": "Elf Druid",
             "text": "",
             "colours": [
@@ -37997,7 +37997,7 @@
         },
         {
             "id": "7dbc9f3e-6fc6-5bd2-a71f-0c503e2c12ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f07b07-e1d7-4a9b-bfa7-5566bbe43fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f07b07-e1d7-4a9b-bfa7-5566bbe43fd9.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -38032,7 +38032,7 @@
         },
         {
             "id": "f75de806-33e5-5836-abd6-6cf57f66241e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e981bbc-7690-4020-aa28-f06295ee8ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e981bbc-7690-4020-aa28-f06295ee8ff8.jpg?1",
             "name": "Phyrexian Beast",
             "text": "",
             "colours": [
@@ -38068,7 +38068,7 @@
         },
         {
             "id": "0fd11f84-7a70-5926-8f19-0fabafc4c440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f710ed-fda6-44dd-9a42-d5b37656307d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f710ed-fda6-44dd-9a42-d5b37656307d.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -38103,7 +38103,7 @@
         },
         {
             "id": "78cd88b3-b790-5832-b73c-d2600bd03add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d675b-1124-4a90-b270-39c52fdffc1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d675b-1124-4a90-b270-39c52fdffc1f.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -38138,7 +38138,7 @@
         },
         {
             "id": "1ab286c4-c46f-57b2-9941-2613eb74cc93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c88b9d-6ac2-4d38-8551-23998d76e6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c88b9d-6ac2-4d38-8551-23998d76e6ee.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -38175,7 +38175,7 @@
         },
         {
             "id": "8dabeaa9-2612-59dd-8e5f-6d070f22117f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab0fbc-293e-4917-9792-fdc9b512713d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ab0fbc-293e-4917-9792-fdc9b512713d.jpg?1",
             "name": "Graveborn",
             "text": "",
             "colours": [
@@ -38212,7 +38212,7 @@
         },
         {
             "id": "6e925641-f72a-56fc-a91a-af67effb8d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d196a-eaf5-42b0-aa76-f30a75a74e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d196a-eaf5-42b0-aa76-f30a75a74e3a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -38249,7 +38249,7 @@
         },
         {
             "id": "b59f8820-344a-593d-8800-afdc93753a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adbbaa4-b1e3-4c5f-a1c7-aa294f838c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adbbaa4-b1e3-4c5f-a1c7-aa294f838c54.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -38280,7 +38280,7 @@
         },
         {
             "id": "230b6574-5ce0-5c34-96c1-7efa9a6d3f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fdadab-af27-46d3-bcf6-35e7affb1e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fdadab-af27-46d3-bcf6-35e7affb1e43.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -38312,7 +38312,7 @@
         },
         {
             "id": "f4260a65-d274-5382-b397-cdb68ddf0a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3954f9-776d-4a8d-a032-724c4eae0e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3954f9-776d-4a8d-a032-724c4eae0e13.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -38344,7 +38344,7 @@
         },
         {
             "id": "9cb97a78-9585-5641-96fd-d3e83ef9174b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b911529-052a-457b-b1a0-b3f498c2cbe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b911529-052a-457b-b1a0-b3f498c2cbe0.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -38376,7 +38376,7 @@
         },
         {
             "id": "d77d05bf-98a5-571f-8289-2debf071baae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ef9889-e61d-4733-b27c-9e78aea8e84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ef9889-e61d-4733-b27c-9e78aea8e84b.jpg?1",
             "name": "Phyrexian Myr",
             "text": "",
             "colours": [],
@@ -38408,7 +38408,7 @@
         },
         {
             "id": "fe5ab9c4-4f95-552e-a051-6a032351a716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a5faa3-b86e-4e05-93db-5db9507ae7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a5faa3-b86e-4e05-93db-5db9507ae7d0.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -38440,7 +38440,7 @@
         },
         {
             "id": "45302479-5f48-53e1-aa27-c60ddfebc93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f2a88f-ff00-4ef7-a9ed-e8457df2c9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f2a88f-ff00-4ef7-a9ed-e8457df2c9d3.jpg?1",
             "name": "Stoneforged Blade",
             "text": "",
             "colours": [],
@@ -38471,7 +38471,7 @@
         },
         {
             "id": "003cfec6-d5a5-5426-8943-9991e8c8195f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a94450-ebe4-49c6-b2b0-bf335880f44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a94450-ebe4-49c6-b2b0-bf335880f44f.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -38503,7 +38503,7 @@
         },
         {
             "id": "bf235272-bd80-5c56-8fa6-d355103fdf8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b5024-3a0b-4f14-977e-ba6c4c2567c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b5024-3a0b-4f14-977e-ba6c4c2567c9.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -38534,7 +38534,7 @@
         },
         {
             "id": "25237fb4-0549-5153-9a10-3884bc321241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49de1576-1c82-4e8c-b492-5097ca7b8819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49de1576-1c82-4e8c-b492-5097ca7b8819.jpg?1",
             "name": "City's Blessing",
             "text": "",
             "colours": [],
@@ -38562,7 +38562,7 @@
         },
         {
             "id": "b527d347-4d00-5772-881c-142aec24dabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9c491-6ba0-4484-822c-73bcbe9b0c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9c491-6ba0-4484-822c-73bcbe9b0c49.jpg?1",
             "name": "The Monarch",
             "text": "",
             "colours": [],
@@ -38590,7 +38590,7 @@
         },
         {
             "id": "38026e58-9e13-51f6-a006-f46ded9dc0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ace1f4-51b5-4a6a-a730-859717efbd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ace1f4-51b5-4a6a-a730-859717efbd6d.jpg?1",
             "name": "Daretti, Scrap Savant Emblem",
             "text": "",
             "colours": [],
@@ -38620,7 +38620,7 @@
         },
         {
             "id": "f9dd2167-6848-51b7-81f6-fb8e06b6d099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4bd21-2ab7-48cf-bc46-b67093b99421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4bd21-2ab7-48cf-bc46-b67093b99421.jpg?1",
             "name": "Ob Nixilis of the Black Oath Emblem",
             "text": "",
             "colours": [],
@@ -38650,7 +38650,7 @@
         },
         {
             "id": "d9f8696c-8329-5086-b268-b11a48908d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db0562-982a-43df-b7b3-4a51c4710757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db0562-982a-43df-b7b3-4a51c4710757.jpg?1",
             "name": "Teferi, Temporal Archmage Emblem",
             "text": "",
             "colours": [],
@@ -38680,7 +38680,7 @@
         },
         {
             "id": "a9151359-5f58-58f8-85af-53f0d6bb35b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305c212-148d-48dc-9e9b-cfeadd378eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305c212-148d-48dc-9e9b-cfeadd378eb5.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -38708,7 +38708,7 @@
         },
         {
             "id": "5a9097cb-1a78-558b-90d2-217688ef45d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfca87-fc37-46cc-8236-73bc5c0e5755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfca87-fc37-46cc-8236-73bc5c0e5755.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -38736,7 +38736,7 @@
         },
         {
             "id": "16742551-85da-5bbd-9c74-a21b7d5e505e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ae2eb8-5090-412a-ad72-46ec4861d599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ae2eb8-5090-412a-ad72-46ec4861d599.jpg?1",
             "name": "Manifest",
             "text": "",
             "colours": [],
@@ -38764,7 +38764,7 @@
         },
         {
             "id": "2246f5aa-0fa7-5864-a50e-2a7e2467f90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f50b09-3253-46a5-8639-5bc90c84b8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f50b09-3253-46a5-8639-5bc90c84b8e1.jpg?1",
             "name": "Sliver",
             "text": "",
             "colours": [],
@@ -38795,7 +38795,7 @@
         },
         {
             "id": "07423f39-2fad-5db8-82bc-d412819f923c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570a8272-7ca1-47db-834b-82f603d1417a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570a8272-7ca1-47db-834b-82f603d1417a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -38826,7 +38826,7 @@
         },
         {
             "id": "9357fc39-9ece-5ac2-b009-dac376c2db85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e56eac-93d5-4ed3-af8f-2c77f0071e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e56eac-93d5-4ed3-af8f-2c77f0071e16.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -38861,7 +38861,7 @@
         },
         {
             "id": "3577bc65-6b94-513e-8f41-242ee84ee921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8730fb-59ca-4cf7-96a4-d6ba3f6f2fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8730fb-59ca-4cf7-96a4-d6ba3f6f2fbe.jpg?1",
             "name": "Avacyn",
             "text": "",
             "colours": [
@@ -38898,7 +38898,7 @@
         },
         {
             "id": "662edb88-123c-5e71-9abd-6e900d27a110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33d9cf0-8138-4ae6-bbfe-02d48a4634c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33d9cf0-8138-4ae6-bbfe-02d48a4634c1.jpg?1",
             "name": "Cat Beast",
             "text": "",
             "colours": [
@@ -38934,7 +38934,7 @@
         },
         {
             "id": "5d1f37cc-0fb5-5426-94f9-1f7bd659d513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a72ad3d-8660-4be4-9f9b-7d2f6b8ee82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a72ad3d-8660-4be4-9f9b-7d2f6b8ee82b.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -38970,7 +38970,7 @@
         },
         {
             "id": "ade785de-89fd-5dc8-a159-d00d8089a9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d88db82-009a-4371-a91e-9083b561e80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d88db82-009a-4371-a91e-9083b561e80f.jpg?1",
             "name": "Human Warrior",
             "text": "",
             "colours": [
@@ -39006,7 +39006,7 @@
         },
         {
             "id": "63dca1e1-3f56-5848-8e1b-736fd6390f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820517-9895-47ba-a9d7-11ed807dcc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820517-9895-47ba-a9d7-11ed807dcc6d.jpg?1",
             "name": "Kor Ally",
             "text": "",
             "colours": [
@@ -39042,7 +39042,7 @@
         },
         {
             "id": "567a38ed-7707-5da2-9cde-e77e3fc37778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e94825-98a8-40f1-8f61-83c79885fec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e94825-98a8-40f1-8f61-83c79885fec0.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -39077,7 +39077,7 @@
         },
         {
             "id": "7da7b9ea-5d41-5cff-9d28-7f32e8570f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2f9b68-07a4-4502-9cf8-de8583b5cdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2f9b68-07a4-4502-9cf8-de8583b5cdd0.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -39112,7 +39112,7 @@
         },
         {
             "id": "e9b6acba-776c-5ba9-8353-51ce96738219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e421a-49ef-448c-9e04-9c5a7e5c071c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e421a-49ef-448c-9e04-9c5a7e5c071c.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -39147,7 +39147,7 @@
         },
         {
             "id": "00d52cd6-c646-5765-94f3-27ce41227c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9821f26-04b4-460b-880e-5052122b21ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9821f26-04b4-460b-880e-5052122b21ae.jpg?1",
             "name": "Sliver Army",
             "text": "",
             "colours": [
@@ -39183,7 +39183,7 @@
         },
         {
             "id": "0679e3b4-11e2-56ec-b9cc-c4501fe7885e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ce07c-d61c-4334-9ca8-bdf6ed9bee4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6ce07c-d61c-4334-9ca8-bdf6ed9bee4f.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -39219,7 +39219,7 @@
         },
         {
             "id": "579da764-c50d-5b64-ac48-1be6f9f3dd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3ed483-a6c9-4f12-bd76-e205ffb8afd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3ed483-a6c9-4f12-bd76-e205ffb8afd4.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -39254,7 +39254,7 @@
         },
         {
             "id": "3cf5972f-8201-53a4-a77e-05a0951a0d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5b65c-00c7-415a-92f3-cd1177372956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5b65c-00c7-415a-92f3-cd1177372956.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -39289,7 +39289,7 @@
         },
         {
             "id": "bd185148-6d5c-5189-b44e-3737f6905b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e050305-6f8b-4261-a4b4-c9fa1dc99b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e050305-6f8b-4261-a4b4-c9fa1dc99b0f.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -39325,7 +39325,7 @@
         },
         {
             "id": "1e97e854-0f35-5cef-aefd-c9d0423e193a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a5c52e-c225-414c-93d9-e014c5aec465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a5c52e-c225-414c-93d9-e014c5aec465.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -39360,7 +39360,7 @@
         },
         {
             "id": "f6c6b3c2-81d6-5689-9af9-f6401738cf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f695aef-e30a-4289-a9b8-24b5495c344e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f695aef-e30a-4289-a9b8-24b5495c344e.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -39392,7 +39392,7 @@
         },
         {
             "id": "b2970797-bc7f-5474-b5f7-0343b1a7791f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6c1ca-e945-4ab2-b177-04e900a8e231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6c1ca-e945-4ab2-b177-04e900a8e231.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -39424,7 +39424,7 @@
         },
         {
             "id": "055887a7-b876-5001-8b42-2829d6ec9ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a91956-e351-4533-9f0d-4a578617f88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a91956-e351-4533-9f0d-4a578617f88b.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -39457,7 +39457,7 @@
         },
         {
             "id": "24629700-a5ac-54a5-b42f-d25c8e144ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f9aebc-6eb8-4325-801f-ad2fbbf391b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f9aebc-6eb8-4325-801f-ad2fbbf391b2.jpg?1",
             "name": "Ajani Steadfast Emblem",
             "text": "",
             "colours": [],
@@ -39487,7 +39487,7 @@
         },
         {
             "id": "7b18c822-3a82-5c0f-8524-53aae9fd1230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02347c41-407f-4388-9d9b-263ddf8b4e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02347c41-407f-4388-9d9b-263ddf8b4e11.jpg?1",
             "name": "Chandra, Awakened Inferno Emblem",
             "text": "",
             "colours": [],
@@ -39515,7 +39515,7 @@
         },
         {
             "id": "4dd29c6f-a26a-5b9b-a2cc-69e2cd425a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143984b-9798-4062-9a91-8ee139c3448e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143984b-9798-4062-9a91-8ee139c3448e.jpg?1",
             "name": "Chandra, Torch of Defiance Emblem",
             "text": "",
             "colours": [],
@@ -39545,7 +39545,7 @@
         },
         {
             "id": "a9a78d67-30a6-5827-85ef-e68e7bfa6256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffbc23b-23d3-4cc5-9ea2-fa3aab785ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffbc23b-23d3-4cc5-9ea2-fa3aab785ffe.jpg?1",
             "name": "Elspeth, Sun's Champion Emblem",
             "text": "",
             "colours": [],
@@ -39575,7 +39575,7 @@
         },
         {
             "id": "c3aa13d9-77c6-5143-a6a1-3a3fc605c505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ea709d-2470-4552-92b3-25d617155e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ea709d-2470-4552-92b3-25d617155e51.jpg?1",
             "name": "Narset of the Ancient Way Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/CMR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/CMR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9944c9b8-0847-5dc1-a55d-1032bb464da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e6d8f-f742-4508-a83a-38ae84be228c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e6d8f-f742-4508-a83a-38ae84be228c.jpg?1",
             "name": "The Prismatic Piper",
             "text": "If The Prismatic Piper is your commander, choose a color before the game begins. The Prismatic Piper is the chosen color.\nPartner (You can have two commanders if both have partner.)",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "4695aee9-5eac-5750-ba4f-a21691057ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bdd07d-9fb9-4ee4-80db-494ee0cba58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bdd07d-9fb9-4ee4-80db-494ee0cba58d.jpg?1",
             "name": "Akroma, Vision of Ixidor",
             "text": "Flying, first strike, vigilance, trample\nAt the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.\nPartner",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "f5ba0667-8366-5b3b-b46c-a6a53d4a72f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c281997b-1566-4469-a14c-6645f81ab023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c281997b-1566-4469-a14c-6645f81ab023.jpg?1",
             "name": "Akroma's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Creatures you control gain flying, vigilance, and double strike until end of turn.\n\u2022 Creatures you control gain lifelink, indestructible, and protection from all colors until end of turn.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "9b2af9c3-2a03-5b75-ab02-856f2b697b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047bfa4-3f4d-47bd-9484-545686f15b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047bfa4-3f4d-47bd-9484-545686f15b75.jpg?1",
             "name": "Alharu, Solemn Ritualist",
             "text": "When Alharu, Solemn Ritualist enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.\nWhenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white Spirit creature token with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -149,7 +149,7 @@
         },
         {
             "id": "870f507d-1f99-599a-b29a-462dd73a1f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8461c3-6e80-403a-b3eb-01882c841d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8461c3-6e80-403a-b3eb-01882c841d7a.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -183,7 +183,7 @@
         },
         {
             "id": "df6c7d71-f9ba-5437-bfff-27d93bc8a48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00ffeb5-195c-45ad-a791-ec67f463d552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00ffeb5-195c-45ad-a791-ec67f463d552.jpg?1",
             "name": "Angel of the Dawn",
             "text": "Flying\nWhen Angel of the Dawn enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "2259b514-d7ba-53a3-b89c-5d378cce3175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0775f2-3fd9-42aa-80e3-edac67764fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0775f2-3fd9-42aa-80e3-edac67764fa2.jpg?1",
             "name": "Angelic Gift",
             "text": "Enchant creature\nWhen Angelic Gift enters the battlefield, draw a card.\nEnchanted creature has flying.",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "9a7a3f7d-297e-5930-a817-6e2170f52e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66fcbb8-0fa5-48a9-b40c-d5a12f09a858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66fcbb8-0fa5-48a9-b40c-d5a12f09a858.jpg?1",
             "name": "Anointer of Valor",
             "text": "Flying\nWhenever a creature attacks, you may pay {3}. When you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "35b652cb-b83b-5a57-a1a8-10f38fa7914e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e367c30-3b77-445e-a1fb-78f6c5971826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e367c30-3b77-445e-a1fb-78f6c5971826.jpg?1",
             "name": "Archon of Coronation",
             "text": "Flying\nWhen Archon of Coronation enters the battlefield, you become the monarch.\nAs long as you're the monarch, damage doesn't cause you to lose life. (When a creature deals combat damage to you, its controller still becomes the monarch.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "99b4f253-6462-529e-b504-ef73f8514414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b802c-969b-4865-b7a0-871c585d097a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728b802c-969b-4865-b7a0-871c585d097a.jpg?1",
             "name": "Ardenn, Intrepid Archaeologist",
             "text": "At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -360,7 +360,7 @@
         },
         {
             "id": "f99ce916-ba6b-5a82-a2d4-c0e7385697ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf63241-9091-42f5-b997-9ce5aa3484f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf63241-9091-42f5-b997-9ce5aa3484f1.jpg?1",
             "name": "Armored Skyhunter",
             "text": "Flying\nWhenever Armored Skyhunter attacks, look at the top six cards of your library. You may put an Aura or Equipment card from among them onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control. Put the rest of those cards on the bottom of your library in a random order.",
             "colours": [
@@ -397,7 +397,7 @@
         },
         {
             "id": "80a3d83b-d069-50ba-877d-28a9fd468860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ec853-411d-40a3-84a7-a62b3cb57cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4ec853-411d-40a3-84a7-a62b3cb57cb3.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -431,7 +431,7 @@
         },
         {
             "id": "69588f7f-dc6c-5642-b6c9-0e966052c318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5c2401-da2c-46f9-b850-f37edcbb85cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5c2401-da2c-46f9-b850-f37edcbb85cd.jpg?1",
             "name": "Benevolent Blessing",
             "text": "Flash\nEnchant creature\nAs Benevolent Blessing enters the battlefield, choose a color.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Auras and Equipment you control that are already attached to it.",
             "colours": [
@@ -465,7 +465,7 @@
         },
         {
             "id": "17499f85-2f95-5e1e-8230-038e0cb9140b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655aefd8-8b0b-4c65-9973-376bbf05375b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655aefd8-8b0b-4c65-9973-376bbf05375b.jpg?1",
             "name": "Cage of Hands",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.",
             "colours": [
@@ -499,7 +499,7 @@
         },
         {
             "id": "08b98790-3425-5e61-8c01-3214bccbfc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac907330-492d-4705-bb8a-1fdb080632e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac907330-492d-4705-bb8a-1fdb080632e1.jpg?1",
             "name": "Captain's Call",
             "text": "Create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -531,7 +531,7 @@
         },
         {
             "id": "09a62abf-030f-5190-b06c-b03e0498e354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0be1b-554e-4b61-b495-6e2a7369cdb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0be1b-554e-4b61-b495-6e2a7369cdb1.jpg?1",
             "name": "Court of Grace",
             "text": "When Court of Grace enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, create a 1/1 white Spirit creature token with flying. If you're the monarch, create a 4/4 white Angel creature token with flying instead.",
             "colours": [
@@ -565,7 +565,7 @@
         },
         {
             "id": "a669993e-0c79-5067-9a92-6a4166fcb558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45b1d32-5a3a-4ec3-af11-d0ba947de175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45b1d32-5a3a-4ec3-af11-d0ba947de175.jpg?1",
             "name": "Court Street Denizen",
             "text": "Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "6223c0b1-e9f7-5f65-8d68-8eb5140991b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b717e3-4dc6-4a7d-928a-2111c8199177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b717e3-4dc6-4a7d-928a-2111c8199177.jpg?1",
             "name": "Dispeller's Capsule",
             "text": "{2}{W}, {T}, Sacrifice Dispeller's Capsule: Destroy target artifact or enchantment.",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "028682c8-bfca-5ccb-9935-f8cd0573182d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4573af-feba-4c9d-b24b-3d15888a5ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4573af-feba-4c9d-b24b-3d15888a5ce2.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "ffd453ea-df8c-5d20-af5d-1ce0c3fde563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a7da8c-a444-4deb-89b9-2fc9e5475bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a7da8c-a444-4deb-89b9-2fc9e5475bff.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -701,7 +701,7 @@
         },
         {
             "id": "24ffae73-bbcb-57a6-9bd9-d812b74a0840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8754c-816f-4d07-8dcd-9611bf0beb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d8754c-816f-4d07-8dcd-9611bf0beb87.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "f4d069fb-3889-5c67-9190-c70b6a0fa48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0270f9f2-9afe-4bbb-b14c-0e2da7f54dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0270f9f2-9afe-4bbb-b14c-0e2da7f54dfc.jpg?1",
             "name": "First Response",
             "text": "At the beginning of each upkeep, if you lost life last turn, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "fe31d5b5-7951-594c-be8a-e4df90a21344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1287d422-d6b0-43eb-8e89-3d6a0201100d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1287d422-d6b0-43eb-8e89-3d6a0201100d.jpg?1",
             "name": "Inspiring Roar",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "8b932259-cabf-5f16-a1af-de60e86b5fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535764b9-67b2-4123-a4be-2aa72fcd8a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535764b9-67b2-4123-a4be-2aa72fcd8a33.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "dac8b89e-6578-5b10-a42a-d4e632fb69f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e792e689-0cf8-4bd0-b2f1-4edff9972e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e792e689-0cf8-4bd0-b2f1-4edff9972e18.jpg?1",
             "name": "Iona's Judgment",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "8b758c5d-c7e2-58ab-92c8-a052e9535913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f431b3-6f4e-40a5-b9d1-f2c67b70544d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f431b3-6f4e-40a5-b9d1-f2c67b70544d.jpg?1",
             "name": "Kangee's Lieutenant",
             "text": "Flying\nWhenever Kangee's Lieutenant attacks, attacking creatures with flying get +1/+1 until end of turn.\nEncore {5}{W} ({5}{W}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -899,7 +899,7 @@
         },
         {
             "id": "c0fbc7cc-c6b9-50c6-b437-58eb30871bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eec618-2c3d-423b-bbb7-72ef7deb38fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eec618-2c3d-423b-bbb7-72ef7deb38fc.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "962a7bff-8967-5f15-b174-16f5963b83f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba512-b6c3-4931-be05-cb6bd03a4b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0ba512-b6c3-4931-be05-cb6bd03a4b7c.jpg?1",
             "name": "Keleth, Sunmane Familiar",
             "text": "Whenever a commander you control attacks, put a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -974,7 +974,7 @@
         },
         {
             "id": "d68012fd-e6c8-52e8-8003-3a28d7f039d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2b413-e00f-440d-9d27-92eb069b8c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2b413-e00f-440d-9d27-92eb069b8c71.jpg?1",
             "name": "Kinsbaile Courier",
             "text": "When Kinsbaile Courier enters the battlefield, put a +1/+1 counter on target creature.\nEncore {2}{W} ({2}{W}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "92986004-21e7-5f39-9194-0fdd7b9f4307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef638-1ea1-4301-bb86-78cb2b5f3aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583ef638-1ea1-4301-bb86-78cb2b5f3aab.jpg?1",
             "name": "Kor Cartographer",
             "text": "When Kor Cartographer enters the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -1046,7 +1046,7 @@
         },
         {
             "id": "cd9dc06b-6a37-550c-be22-4355f0841452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bce846-8049-4d5c-b0ad-8abd484e5a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bce846-8049-4d5c-b0ad-8abd484e5a27.jpg?1",
             "name": "Livio, Oathsworn Sentinel",
             "text": "{1}{W}: Choose another target creature. Its controller may exile it with an aegis counter on it.\n{2}{W}, {T}: Return all exiled cards with aegis counters on them to the battlefield under their owners' control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "f7d68027-2773-5c53-b295-376cd358f16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a948ef4-145f-4bea-b4af-5daa951b338c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a948ef4-145f-4bea-b4af-5daa951b338c.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "002cd341-e050-528c-8e73-18a96dd9eaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9555fe-fa1d-4af9-90a4-c3f91e0edd9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9555fe-fa1d-4af9-90a4-c3f91e0edd9b.jpg?1",
             "name": "Ninth Bridge Patrol",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Ninth Bridge Patrol.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "200a9f46-ed7e-552a-9acc-946966f0c6fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db45698-9da9-4cea-b9bf-0f84ab276b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db45698-9da9-4cea-b9bf-0f84ab276b51.jpg?1",
             "name": "Open the Armory",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "98dab3aa-6137-5545-8c5f-8e136cef7c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96017805-0a26-4beb-8de3-6779c4e5633d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96017805-0a26-4beb-8de3-6779c4e5633d.jpg?1",
             "name": "Orzhov Advokist",
             "text": "At the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. If a player does, creatures that player controls can't attack you or a planeswalker you control until your next turn.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "f9c67574-4492-5c06-bc9c-a59dc5f40d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd0e9a0-f974-412a-aba1-c4fb68351149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd0e9a0-f974-412a-aba1-c4fb68351149.jpg?1",
             "name": "Palace Sentinels",
             "text": "When Palace Sentinels enters the battlefield, you become the monarch.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "85cd19a8-41ce-5fe9-9ea1-2d665d3f4587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db1e841-04e9-49ab-acbf-defd6d82140a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db1e841-04e9-49ab-acbf-defd6d82140a.jpg?1",
             "name": "Patron of the Valiant",
             "text": "Flying\nWhen Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "e127fbfe-1e0f-57aa-a205-2f2a41de09e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e40e2a-e447-4754-a98b-5521e546781f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e40e2a-e447-4754-a98b-5521e546781f.jpg?1",
             "name": "Prava of the Steel Legion",
             "text": "As long as it's your turn, creature tokens you control get +1/+4.\n{3}{W}: Create a 1/1 white Soldier creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1327,7 +1327,7 @@
         },
         {
             "id": "d3b3c586-1c17-5c38-ab7f-e7fc6fa022f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccffa9d-8896-4364-bc5c-37592d2714f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccffa9d-8896-4364-bc5c-37592d2714f9.jpg?1",
             "name": "Promise of Tomorrow",
             "text": "Whenever a creature you control dies, exile it.\nAt the beginning of each end step, if you control no creatures, sacrifice Promise of Tomorrow and return all cards exiled with it to the battlefield under your control.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "9d0e9ec7-04d5-5634-b73c-5825eea62806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b00110-e3de-40ce-b2bd-9466fe9e53a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b00110-e3de-40ce-b2bd-9466fe9e53a3.jpg?1",
             "name": "Radiant, Serra Archangel",
             "text": "Flying\nTap another untapped creature you control with flying: Radiant, Serra Archangel gains protection from the color of your choice until end of turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "79c9d62d-f16c-5122-a837-8cffbb9bcca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c8527-55f6-494d-b4f7-c427a5735053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c8527-55f6-494d-b4f7-c427a5735053.jpg?1",
             "name": "Raise the Alarm",
             "text": "Create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "dc7fa984-26d6-5d56-b9ca-1020b0737c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46975250-950f-4f5d-a7c5-f61aec8e40ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46975250-950f-4f5d-a7c5-f61aec8e40ad.jpg?1",
             "name": "Rebbec, Architect of Ascension",
             "text": "Artifacts you control have protection from each converted mana cost among artifacts you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "0dfd6f8d-f7e6-5aba-ab2b-88fb15e8aeb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f5785-36d8-473c-b2de-0b4635388d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f5785-36d8-473c-b2de-0b4635388d7e.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "e7da3691-5c28-5b41-8169-9dfb214e3463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bf33ea-2d2d-476d-ab1d-fba204fd034b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bf33ea-2d2d-476d-ab1d-fba204fd034b.jpg?1",
             "name": "Seraph of Dawn",
             "text": "Flying, lifelink",
             "colours": [
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "3ba7ddc1-7e26-5868-bbfc-70af7e1aeca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9b6e59-8e95-413d-825e-f1dc8874eaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9b6e59-8e95-413d-825e-f1dc8874eaa9.jpg?1",
             "name": "Seraphic Greatsword",
             "text": "Equipped creature gets +2/+2.\nWhenever equipped creature attacks the player with the most life or tied for most life, create a 4/4 white Angel creature token with flying that's tapped and attacking that player.\nEquip {4}",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "0b34259a-79e5-5707-9113-7f547818c8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5013-523f-42b2-b947-abe304a6cb84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5013-523f-42b2-b947-abe304a6cb84.jpg?1",
             "name": "Skywhaler's Shot",
             "text": "Destroy target creature with power 3 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "a43375a5-ed73-5c16-8c02-b50fab0b0fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0913a5e8-7f77-44f2-a7cf-c8c0d6270a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0913a5e8-7f77-44f2-a7cf-c8c0d6270a86.jpg?1",
             "name": "Slash the Ranks",
             "text": "Destroy all creatures and planeswalkers except for commanders.",
             "colours": [
@@ -1641,7 +1641,7 @@
         },
         {
             "id": "e974b61a-6109-5c7f-9f70-bef30b0f1d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d986177-3814-4069-bce5-f9e54c528e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d986177-3814-4069-bce5-f9e54c528e85.jpg?1",
             "name": "Slaughter the Strong",
             "text": "Each player chooses any number of creatures they control with total power 4 or less, then sacrifices all other creatures they control.",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "38f8ee4c-9327-57f8-8a0a-12d9bfbdc1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90157f8-ba3c-479e-80d8-8f9e042c540c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90157f8-ba3c-479e-80d8-8f9e042c540c.jpg?1",
             "name": "Slith Ascendant",
             "text": "Flying\nWhenever Slith Ascendant deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1707,7 +1707,7 @@
         },
         {
             "id": "b3a69571-9f37-5396-a210-26c9ad32de11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08241f94-8b5e-4f9b-8120-8175e3256e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08241f94-8b5e-4f9b-8120-8175e3256e35.jpg?1",
             "name": "Soul of Eternity",
             "text": "Soul of Eternity's power and toughness are each equal to your life total.\nEncore {7}{W}{W} ({7}{W}{W}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "316db31e-93b0-526e-a394-a4d149e05d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c98bc7-f6a9-4aaf-a6dc-7067c3d8a41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c98bc7-f6a9-4aaf-a6dc-7067c3d8a41a.jpg?1",
             "name": "Squad Captain",
             "text": "Vigilance\nSquad Captain enters the battlefield with a +1/+1 counter on it for each other creature you control.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "cc2ef946-184f-5a6c-a7ad-da43e5855f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db8e30-e3a4-4141-9ea3-7db4a060ec8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db8e30-e3a4-4141-9ea3-7db4a060ec8e.jpg?1",
             "name": "Triumphant Reckoning",
             "text": "Return all artifact, enchantment, and planeswalker cards from your graveyard to the battlefield.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "6e40e512-6013-57f8-a027-3561f7452dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcfe1b5-e35b-4a23-8ca8-4dee2ef94f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcfe1b5-e35b-4a23-8ca8-4dee2ef94f32.jpg?1",
             "name": "Trusty Packbeast",
             "text": "When Trusty Packbeast enters the battlefield, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "0686b9fb-0a0a-5f09-afb9-67de3695e27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c1b3f-1aab-48a1-a651-8302bc8682f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107c1b3f-1aab-48a1-a651-8302bc8682f9.jpg?1",
             "name": "Vow of Duty",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has vigilance, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "4305dd7a-29b4-5d49-bede-a662471f170b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be9d06-3651-47f4-9e44-00ecd4a15e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be9d06-3651-47f4-9e44-00ecd4a15e3c.jpg?1",
             "name": "Amphin Mutineer",
             "text": "When Amphin Mutineer enters the battlefield, exile up to one target non-Salamander creature. That creature's controller creates a 4/3 blue Salamander Warrior creature token.\nEncore {4}{U}{U} ({4}{U}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "a7dd808f-2422-5d90-92c4-5e259211d814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859f7cb-ac12-490e-b769-6f019791f2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859f7cb-ac12-490e-b769-6f019791f2a5.jpg?1",
             "name": "Aqueous Form",
             "text": "Enchant creature\nEnchanted creature can't be blocked.\nWhenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "6e70194b-58f3-58f2-a2a4-4cd21d0342cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4981d99-c33d-4451-8f6a-28fffb3dcd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4981d99-c33d-4451-8f6a-28fffb3dcd1c.jpg?1",
             "name": "Aven Surveyor",
             "text": "Flying\nWhen Aven Surveyor enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Aven Surveyor.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "aa75b6c7-4797-5706-884f-c97762a11e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0889e22-deab-48ba-bbd6-f0d49bee5d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0889e22-deab-48ba-bbd6-f0d49bee5d9c.jpg?1",
             "name": "Azure Fleet Admiral",
             "text": "When Azure Fleet Admiral enters the battlefield, you become the monarch.\nAzure Fleet Admiral can't be blocked by creatures the monarch controls.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "8a889469-5251-5128-b360-44a080a9411e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786ae686-0790-4ba1-927f-523984331549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786ae686-0790-4ba1-927f-523984331549.jpg?1",
             "name": "Body of Knowledge",
             "text": "Body of Knowledge's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhenever Body of Knowledge is dealt damage, draw that many cards.",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "3ff11d11-a57e-503f-a724-da2b7b012051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b063dfd-5a80-48c9-8f7b-48d21a129a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b063dfd-5a80-48c9-8f7b-48d21a129a76.jpg?1",
             "name": "Brinelin, the Moon Kraken",
             "text": "When Brinelin, the Moon Kraken enters the battlefield or whenever you cast a spell with converted mana cost 6 or greater, you may return target nonland permanent to its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "5245c577-49df-5731-90ca-82332b5d4ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14a5b69-ce04-40fc-9933-20b16537de24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14a5b69-ce04-40fc-9933-20b16537de24.jpg?1",
             "name": "Flood of Recollection",
             "text": "Return target instant or sorcery card from your graveyard to your hand. Exile Flood of Recollection.",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "51a8cfbf-81eb-5962-8baf-ed738980b8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e4a88d-670b-4332-bf36-41c2e2492424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e4a88d-670b-4332-bf36-41c2e2492424.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -2161,7 +2161,7 @@
         },
         {
             "id": "c5152fdf-1e0c-5de7-a117-87ce9941586b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f585f52-7b07-4453-b543-9654d314aa36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f585f52-7b07-4453-b543-9654d314aa36.jpg?1",
             "name": "Court of Cunning",
             "text": "When Court of Cunning enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, any number of target players each mill two cards. If you're the monarch, each of those players mills ten cards instead. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -2195,7 +2195,7 @@
         },
         {
             "id": "e00873c3-09b8-5e97-8c6f-2c2b0770e3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bcccf7-cec0-4507-b941-e47873861d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bcccf7-cec0-4507-b941-e47873861d20.jpg?1",
             "name": "Daring Saboteur",
             "text": "{2}{U}: Daring Saboteur can't be blocked this turn.\nWhenever Daring Saboteur deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "8fe1d06a-2e8d-5352-8459-58ed34475b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73373421-c43d-4152-818a-55abc85b477a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73373421-c43d-4152-818a-55abc85b477a.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -2265,7 +2265,7 @@
         },
         {
             "id": "b3aaf6e3-840b-597b-b91c-b34547929164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0adf34-1a2b-497b-aaab-4b2b998ed8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0adf34-1a2b-497b-aaab-4b2b998ed8b3.jpg?1",
             "name": "Eligeth, Crossroads Augur",
             "text": "Flying\nIf you would scry a number of cards, draw that many cards instead.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "a2968510-709d-54fe-b793-60f03b8301c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86958821-76eb-43a5-974b-7c945e826a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86958821-76eb-43a5-974b-7c945e826a66.jpg?1",
             "name": "Esior, Wardwing Familiar",
             "text": "Flying\nSpells your opponents cast that target one or more commanders you control cost {3} more to cast.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "98a40435-c77f-5972-b8cc-02cfd856bac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709a18f-b99d-4fa1-ae5c-7f22abd02c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709a18f-b99d-4fa1-ae5c-7f22abd02c0a.jpg?1",
             "name": "Fall from Favor",
             "text": "Enchant creature\nWhen Fall from Favor enters the battlefield, tap enchanted creature and you become the monarch.\nEnchanted creature doesn't untap during its controller's untap step unless that player is the monarch.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "be906dc5-c97d-5a53-b4ba-42acc0c72f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c75157-2670-4804-8853-a6867c83c40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c75157-2670-4804-8853-a6867c83c40a.jpg?1",
             "name": "Forceful Denial",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nCounter target spell.",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "e3592670-2fe3-55dc-a534-b30fd46e1f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cdb0e-2684-4ad1-b7dd-e355e3e9a221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23cdb0e-2684-4ad1-b7dd-e355e3e9a221.jpg?1",
             "name": "Galestrike",
             "text": "Return target tapped creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "1bba7865-a3fe-5c7e-9364-b0c3ec5d14a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a41506-85c6-4362-b983-36df13db09d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a41506-85c6-4362-b983-36df13db09d9.jpg?1",
             "name": "Ghost of Ramirez DePietro",
             "text": "Ghost of Ramirez DePietro can't be blocked by creatures with toughness 3 or greater.\nWhenever Ghost of Ramirez DePietro deals combat damage to a player, choose up to one target card in a graveyard that was discarded or put there from a library this turn. Put that card into its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2478,7 +2478,7 @@
         },
         {
             "id": "67869983-0d49-5922-aa93-6f7c0cdeaff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a736df42-18e9-4259-b0b8-54d21143e72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a736df42-18e9-4259-b0b8-54d21143e72e.jpg?1",
             "name": "Glacian, Powerstone Engineer",
             "text": "{T}, Tap X untapped artifacts you control: Look at the top X cards of your library. Put one of those cards into your hand and the rest into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "63265e24-1179-5617-8ed6-711b28b50c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c21aa7-678e-4998-9061-a13d04d92842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c21aa7-678e-4998-9061-a13d04d92842.jpg?1",
             "name": "Horizon Scholar",
             "text": "Flying\nWhen Horizon Scholar enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2551,7 +2551,7 @@
         },
         {
             "id": "96d97be2-9f7f-59ff-9584-91caf1920f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df8aabc-7fcb-4b7b-980b-18f499e6c170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df8aabc-7fcb-4b7b-980b-18f499e6c170.jpg?1",
             "name": "Hullbreacher",
             "text": "Flash\nIf an opponent would draw a card except the first one they draw in each of their draw steps, instead you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "dab9df6e-9344-5419-bd9d-56aab70c6617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbf049-5c02-4038-86de-fa6b5110cf7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbf049-5c02-4038-86de-fa6b5110cf7e.jpg?1",
             "name": "Interpret the Signs",
             "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's converted mana cost. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2620,7 +2620,7 @@
         },
         {
             "id": "c6c52721-af48-5268-8c84-26d9e1bafbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4534ffdd-9965-4e55-9c25-04123720cbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4534ffdd-9965-4e55-9c25-04123720cbba.jpg?1",
             "name": "Kitesail Corsair",
             "text": "Kitesail Corsair has flying as long as it's attacking.",
             "colours": [
@@ -2655,7 +2655,7 @@
         },
         {
             "id": "e4376c66-ff5e-531b-bb4e-4ca807489a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd356b3-29a9-4526-93a0-33375f65744b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd356b3-29a9-4526-93a0-33375f65744b.jpg?1",
             "name": "Kitesail Skirmisher",
             "text": "Flying\nWhenever Kitesail Skirmisher attacks, another target creature attacking the same player or planeswalker gains flying until end of turn.\nEncore {4}{U} ({4}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "0ac45d99-6b93-595a-963f-51aa4f433344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1d1e2-caea-4e64-8a3a-740f62b36853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1d1e2-caea-4e64-8a3a-740f62b36853.jpg?1",
             "name": "Laboratory Drudge",
             "text": "At the beginning of each end step, draw a card if you've cast a spell from a graveyard or activated an ability of a card in a graveyard this turn.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "bc1239f8-8007-5db7-a11e-a5dd47b51a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3bbda-a4bc-4302-a3fc-b1c89f0f5461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3bbda-a4bc-4302-a3fc-b1c89f0f5461.jpg?1",
             "name": "Malcolm, Keen-Eyed Navigator",
             "text": "Flying\nWhenever one or more Pirates you control deal damage to your opponents, you create a Treasure token for each opponent dealt damage. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "ad5c9ed1-51b1-5f48-a4d4-47e4a92b5247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba874c0c-f66f-4edc-9859-40273487aef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba874c0c-f66f-4edc-9859-40273487aef0.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's converted mana cost.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "68acd0e9-a567-5131-961b-02ec0e6c62ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad152da-057d-4805-9e0c-3842ad43e336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad152da-057d-4805-9e0c-3842ad43e336.jpg?1",
             "name": "Merchant Raiders",
             "text": "Whenever Merchant Raiders or another Pirate enters the battlefield under your control, tap up to one target creature. That creature doesn't untap during its controller's untap step for as long as you control Merchant Raiders.",
             "colours": [
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "67acb7b1-7f34-54f7-980b-78842c9fa81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e725b-2250-4189-9682-73461b5cfed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e725b-2250-4189-9682-73461b5cfed2.jpg?1",
             "name": "Mnemonic Deluge",
             "text": "Exile target instant or sorcery card from a graveyard. Copy that card three times. You may cast the copies without paying their mana costs. Exile Mnemonic Deluge.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "b83d288d-7839-5a9b-a9df-ec8d20375e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b635abe-ad7e-44b8-b3fe-6e365db87c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b635abe-ad7e-44b8-b3fe-6e365db87c29.jpg?1",
             "name": "Omenspeaker",
             "text": "When Omenspeaker enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "06bcfd09-c59e-5aed-9f38-f2ae5cf71787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1453f92e-df2d-4789-aa1b-a5b5c51567d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1453f92e-df2d-4789-aa1b-a5b5c51567d4.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "2c7dd25f-5051-5616-bec1-f67cb5163fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778bde-f927-419e-8052-6230562bdedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778bde-f927-419e-8052-6230562bdedd.jpg?1",
             "name": "Prosperous Pirates",
             "text": "When Prosperous Pirates enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "11b08bde-4481-5742-985d-08c5008dcd1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb58d7ba-ba86-433e-8f1e-3f492c380796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb58d7ba-ba86-433e-8f1e-3f492c380796.jpg?1",
             "name": "Prying Eyes",
             "text": "Draw four cards, then discard two cards.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "eb77ed7b-9196-5d16-b6d5-f52aca213dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d747d5f2-d3b0-44f9-92f0-781839386850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d747d5f2-d3b0-44f9-92f0-781839386850.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "7508e6bf-a8a9-5ba7-9afe-53a0542edf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e9011-a9b7-4a60-bb47-ce5c3c147280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e9011-a9b7-4a60-bb47-ce5c3c147280.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "009e6685-ebc6-5091-8c91-9fb33307ed1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/714c3a1f-7b30-4ed8-8f38-6176758741fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/714c3a1f-7b30-4ed8-8f38-6176758741fb.jpg?1",
             "name": "Sakashima of a Thousand Faces",
             "text": "You may have Sakashima of a Thousand Faces enter the battlefield as a copy of another creature you control, except it has Sakashima of a Thousand Faces's other abilities.\nThe \"legend rule\" doesn't apply to permanents you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "f6734b0c-60f5-5e71-94a0-fcd9bfa218e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce06cd4-099b-445f-af95-76564ee24668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce06cd4-099b-445f-af95-76564ee24668.jpg?1",
             "name": "Sakashima's Protege",
             "text": "Flash\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nYou may have Sakashima's Protege enter the battlefield as a copy of any permanent that entered the battlefield this turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "e3445734-f4f1-5b99-ac17-ba14aad21a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9fd318-ffb2-40d0-b1e0-e951d7735f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9fd318-ffb2-40d0-b1e0-e951d7735f78.jpg?1",
             "name": "Sakashima's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Target opponent chooses a creature they control. You gain control of it.\n\u2022 Choose a creature you control. Each other creature you control becomes a copy of that creature until end of turn.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "1ba8cb45-5f4d-5991-9c2b-e3037c3c1b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc4498e-24e6-40e9-8cd5-f42220366664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc4498e-24e6-40e9-8cd5-f42220366664.jpg?1",
             "name": "Scholar of Stars",
             "text": "When Scholar of Stars enters the battlefield, if you control an artifact, draw a card.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "275fc406-edbd-5f3e-8e9f-8289b92041f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfa31b5-8a4f-4766-9606-648cb8ee2916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfa31b5-8a4f-4766-9606-648cb8ee2916.jpg?1",
             "name": "Scholar of the Ages",
             "text": "When Scholar of the Ages enters the battlefield, return up to two target instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "75f2c848-eceb-56c2-bbe1-815fa1e86b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3ba315-f4da-4022-9251-961a378b35ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3ba315-f4da-4022-9251-961a378b35ce.jpg?1",
             "name": "Scrapdiver Serpent",
             "text": "Scrapdiver Serpent can't be blocked as long as defending player controls an artifact.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "6c054fa9-eb18-5f36-80c0-a07f90d7341a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8812e448-241e-4640-9cb6-0cdbe1ad2fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8812e448-241e-4640-9cb6-0cdbe1ad2fcc.jpg?1",
             "name": "Siani, Eye of the Storm",
             "text": "Flying\nWhenever Siani, Eye of the Storm attacks, scry X, where X is the number of attacking creatures with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "fa42999a-5ff1-5dc9-9c4b-44c94f5b6b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e5f191-0b20-4bc4-b41e-36c53a182f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e5f191-0b20-4bc4-b41e-36c53a182f85.jpg?1",
             "name": "Siren Stormtamer",
             "text": "Flying\n{U}, Sacrifice Siren Stormtamer: Counter target spell or ability that targets you or a creature you control.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "aabcf728-8f78-5eb2-bb5c-6af884a7e47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151fe63-3b3a-4cd4-9a2d-d80e7434e63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151fe63-3b3a-4cd4-9a2d-d80e7434e63c.jpg?1",
             "name": "Skaab Goliath",
             "text": "As an additional cost to cast this spell, exile two creature cards from your graveyard.\nTrample",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "8ce7c6d8-c561-5323-96ad-e224bdcba243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc396c69-9773-4d57-a955-280742a10a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc396c69-9773-4d57-a955-280742a10a91.jpg?1",
             "name": "Skilled Animator",
             "text": "When Skilled Animator enters the battlefield, target artifact you control becomes an artifact creature with base power and toughness 5/5 for as long as Skilled Animator remains on the battlefield.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "1b1d8fdc-c550-5bf5-b4b2-5e90e0c98e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b70a6-a150-4d81-921c-9b178fe0037d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68b70a6-a150-4d81-921c-9b178fe0037d.jpg?1",
             "name": "Sphinx of the Second Sun",
             "text": "Flying\nAt the beginning of your postcombat main phase, you get an additional beginning phase after this phase. (The beginning phase includes the untap, upkeep, and draw steps.)",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "212274ce-ba77-524d-bf75-b1399655913b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6919154c-154e-4430-b7fd-ab9fe70326dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6919154c-154e-4430-b7fd-ab9fe70326dc.jpg?1",
             "name": "Spontaneous Mutation",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "fb2dad00-febe-53f0-bc43-1ce2410b1f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e14952-1a6a-4c6a-8def-54846108b542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e14952-1a6a-4c6a-8def-54846108b542.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "f803f528-afbe-5cf6-8787-3c9f9ecc026a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf7fd8a-adc3-4099-8e30-08375f263446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf7fd8a-adc3-4099-8e30-08375f263446.jpg?1",
             "name": "Supreme Will",
             "text": "Choose one \u2014\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "f2811ce8-08b1-5742-81d2-b549d0dd8491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8173ac-bd9c-4748-9a6a-e5556d74d754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8173ac-bd9c-4748-9a6a-e5556d74d754.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "c0a824c8-b0e8-53e4-9ec8-1bfc537c91bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b74135-b8db-4485-a4b1-7aaa3ef28072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b74135-b8db-4485-a4b1-7aaa3ef28072.jpg?1",
             "name": "Trove Tracker",
             "text": "When Trove Tracker dies, draw a card.\nEncore {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "9f5414a0-6d3a-5fec-a968-03fe8acd17d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9887121-6206-44bb-a1b4-520f28a61a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9887121-6206-44bb-a1b4-520f28a61a17.jpg?1",
             "name": "Vow of Flight",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has flying, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "88bf76f1-71d7-56a1-b3b6-620488cba105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfc5cef-aa9b-45d4-a9c3-4b157e4ed193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfc5cef-aa9b-45d4-a9c3-4b157e4ed193.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "032f2134-369e-5222-81d1-f483921780ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69687d-191a-4bca-b1f7-eea27847c1af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69687d-191a-4bca-b1f7-eea27847c1af.jpg?1",
             "name": "Wrong Turn",
             "text": "Target opponent gains control of target creature. (If an attacking or blocking creature changes controllers, it's removed from combat.)",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "9876a63e-e2c2-5cd1-9f97-6fafea992f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f69e24-6b5c-4a9a-af5b-1ce88efdc0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f69e24-6b5c-4a9a-af5b-1ce88efdc0aa.jpg?1",
             "name": "Armix, Filigree Thrasher",
             "text": "Whenever Armix, Filigree Thrasher attacks, you may discard a card. When you do, target creature defending player controls gets -X/-X until end of turn, where X is the number of artifacts you control plus the number of artifact cards in your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "148a8921-98e5-5038-83f9-7c5d0a7eff66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25657da2-e7bc-4e9b-8ec2-5a5779738436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25657da2-e7bc-4e9b-8ec2-5a5779738436.jpg?1",
             "name": "Bitter Revelation",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "e110ea55-5ffc-5d63-84ce-5d29c3220b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb59ce-7d40-4784-b96d-2d5a25a8e531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb59ce-7d40-4784-b96d-2d5a25a8e531.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "e40b5228-d3db-5173-8bc1-9d72d582b822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fb5f1-baf5-4934-aac7-ffbaa85b2428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fb5f1-baf5-4934-aac7-ffbaa85b2428.jpg?1",
             "name": "Briarblade Adept",
             "text": "Whenever Briarblade Adept attacks, target creature an opponent controls gets -1/-1 until end of turn.\nEncore {3}{B} ({3}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "2c8ae79f-c5d0-55b7-b701-101f65a01cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8426e-476a-45e4-b3a9-841da54d966c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8426e-476a-45e4-b3a9-841da54d966c.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -3904,7 +3904,7 @@
         },
         {
             "id": "f9c24a73-aee1-5daf-a20c-894f4f5b49a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fedb37f-4f3c-477c-84c0-aa864e87c111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fedb37f-4f3c-477c-84c0-aa864e87c111.jpg?1",
             "name": "Corpse Churn",
             "text": "Mill three cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "071b8b42-3008-5819-983b-f1a7015f86c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5deb0185-62b3-474b-83a1-25473fdae4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5deb0185-62b3-474b-83a1-25473fdae4fa.jpg?1",
             "name": "Court of Ambition",
             "text": "When Court of Ambition enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, each opponent loses 3 life unless they discard a card. If you're the monarch, instead each opponent loses 6 life unless they discard two cards.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "fda2a654-5e63-55ad-9026-313a902898d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e0654c-8c84-47a7-ba0b-de5b1268c27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e0654c-8c84-47a7-ba0b-de5b1268c27b.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "004e5214-641b-582f-b006-65ceed7107a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a26e910-275a-4981-831b-bfed936a7e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a26e910-275a-4981-831b-bfed936a7e3f.jpg?1",
             "name": "Cuombajj Witches",
             "text": "{T}: Cuombajj Witches deals 1 damage to any target and 1 damage to any target of an opponent's choice.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "b4323a2b-ed3e-50d2-8a63-4649f165d7ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1c30e-e539-4382-b0fd-724a502a4b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1c30e-e539-4382-b0fd-724a502a4b7e.jpg?1",
             "name": "Defiant Salvager",
             "text": "Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "ae68a23a-3d9d-57bf-95b0-d220d9293c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47733f20-f7b2-4a01-b429-0ec49b230fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47733f20-f7b2-4a01-b429-0ec49b230fd9.jpg?1",
             "name": "Demonic Lore",
             "text": "When Demonic Lore enters the battlefield, draw three cards.\nAt the beginning of your end step, you lose 2 life for each card in your hand.",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "a9aababf-9e4d-5595-a001-098b7e3d87a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0efe5b1-c515-4642-aca2-3eba68fe63ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0efe5b1-c515-4642-aca2-3eba68fe63ff.jpg?1",
             "name": "Dhund Operative",
             "text": "As long as you control an artifact, Dhund Operative gets +1/+0 and has deathtouch.",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "ecc9679d-638e-56bd-b8cc-6348d638fea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1264d2-c7c8-477f-84f6-c17b422aa45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1264d2-c7c8-477f-84f6-c17b422aa45e.jpg?1",
             "name": "Elvish Doomsayer",
             "text": "When Elvish Doomsayer dies, each opponent discards a card.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "f72ab129-3420-5389-b43d-4a4a088d56aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f452927-4d04-4c1d-9d88-19901fd06937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f452927-4d04-4c1d-9d88-19901fd06937.jpg?1",
             "name": "Elvish Dreadlord",
             "text": "Deathtouch\nWhen Elvish Dreadlord dies, non-Elf creatures get -3/-3 until end of turn.\nEncore {5}{B}{B} ({5}{B}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "e4332a04-61d0-53a4-8aad-8be7b2e5768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b75d9-f7c7-4a13-9318-02d7bbd80c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b75d9-f7c7-4a13-9318-02d7bbd80c9c.jpg?1",
             "name": "Exquisite Huntmaster",
             "text": "When Exquisite Huntmaster dies, create a 1/1 green Elf Warrior creature token.\nEncore {4}{B} ({4}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -4251,7 +4251,7 @@
         },
         {
             "id": "023604c7-0ec4-5ac9-976f-5db53761336e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a480da7-1b5d-41a5-b603-e63af100724a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a480da7-1b5d-41a5-b603-e63af100724a.jpg?1",
             "name": "Eyeblight Assassin",
             "text": "When Eyeblight Assassin enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "82511c0b-fea7-5fc8-836a-5ed5347772b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da777e75-6f1f-4e07-a5ec-e25454a0636c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da777e75-6f1f-4e07-a5ec-e25454a0636c.jpg?1",
             "name": "Eyeblight Cullers",
             "text": "When Eyeblight Cullers dies, create three 1/1 green Elf Warrior creature tokens, then mill three cards. (Put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "419b4870-1cd1-5c0b-bf04-ab5d29d58f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00670b-64a8-428a-8db0-9119efddaa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be00670b-64a8-428a-8db0-9119efddaa1b.jpg?1",
             "name": "Eyeblight Massacre",
             "text": "Non-Elf creatures get -2/-2 until end of turn.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "91496316-74be-5a0b-b418-e7d45e467274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84537fea-ad81-4a9a-99d4-722a938adc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84537fea-ad81-4a9a-99d4-722a938adc7d.jpg?1",
             "name": "Falthis, Shadowcat Familiar",
             "text": "Commanders you control have menace and deathtouch.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "00965ce4-ece7-5bf8-9658-ca84558e2924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83f97d-c8c9-480c-a32c-918035673ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83f97d-c8c9-480c-a32c-918035673ab4.jpg?1",
             "name": "Feast of Succession",
             "text": "All creatures get -4/-4 until end of turn. You become the monarch.",
             "colours": [
@@ -4424,7 +4424,7 @@
         },
         {
             "id": "caee2044-7328-5a13-a8c8-030300a49ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4002b3a4-e00e-44ed-8989-d553e5d7d6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4002b3a4-e00e-44ed-8989-d553e5d7d6c8.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "6cbe6d84-dcdf-56e6-aeb6-33c5eb8c22a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe11a-fcc9-41e1-91ef-755bb4e22389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfe11a-fcc9-41e1-91ef-755bb4e22389.jpg?1",
             "name": "Ghastly Demise",
             "text": "Destroy target nonblack creature if its toughness is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -4493,7 +4493,7 @@
         },
         {
             "id": "557722d1-bcb1-5cc3-9d7d-9912170894e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fbfc-c17d-4a5b-863e-842d4040200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7fbfc-c17d-4a5b-863e-842d4040200a.jpg?1",
             "name": "Gilt-Leaf Winnower",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Gilt-Leaf Winnower enters the battlefield, you may destroy target non-Elf creature whose power and toughness aren't equal.",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "bdd9052c-faea-54ee-b3a3-e580de04706f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5ffe8-b4ed-4db8-8f0f-97aaeb659689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5ffe8-b4ed-4db8-8f0f-97aaeb659689.jpg?1",
             "name": "Keskit, the Flesh Sculptor",
             "text": "{T}, Sacrifice three other artifacts and/or creatures: Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "6dfed578-ce21-5a94-9b45-8a10d804cec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa715fde-8339-447b-8ac8-3126830bece8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa715fde-8339-447b-8ac8-3126830bece8.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When Maalfeld Twins dies, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "7e68a0b5-e3bc-5e34-bdec-c6c7f5aaa6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a76adc-42e1-4f65-940c-d0a5555c0633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a76adc-42e1-4f65-940c-d0a5555c0633.jpg?1",
             "name": "Miara, Thorn of the Glade",
             "text": "Whenever Miara, Thorn of the Glade or another Elf you control dies, you may pay {1} and 1 life. If you do, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "a8b5f870-8abd-5029-9e90-0897ff8a80e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440bfb8c-f29a-4c11-9fcb-ee935dead03f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440bfb8c-f29a-4c11-9fcb-ee935dead03f.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "d19616df-f0da-5d66-b81a-7c75fd08c01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c5948b-b021-4d07-8003-9c11db690bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c5948b-b021-4d07-8003-9c11db690bc0.jpg?1",
             "name": "Nadier, Agent of the Duskenel",
             "text": "Whenever a token you control leaves the battlefield, put a +1/+1 counter on Nadier, Agent of the Duskenel.\nWhen Nadier leaves the battlefield, create a number of 1/1 green Elf Warrior creature tokens equal to its power.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "6444d869-8b04-5a94-8c29-5db64d1e4695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbba08-0d93-4750-9dd6-d6a2779c6cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbba08-0d93-4750-9dd6-d6a2779c6cf3.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "6e05f526-4115-51b1-b4d0-37d83c2e14b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009d2fb8-6144-46d9-9085-26232c174109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009d2fb8-6144-46d9-9085-26232c174109.jpg?1",
             "name": "Necrotic Hex",
             "text": "Each player sacrifices six creatures. You create six tapped 2/2 black Zombie creature tokens.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "d326b8e9-30b3-57ec-89df-16ae1b409d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297ab13-d6f3-487b-86ec-6eb299eb0614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297ab13-d6f3-487b-86ec-6eb299eb0614.jpg?1",
             "name": "Nightshade Harvester",
             "text": "Whenever a land enters the battlefield under an opponent's control, that player loses 1 life. Put a +1/+1 counter on Nightshade Harvester.",
             "colours": [
@@ -4818,7 +4818,7 @@
         },
         {
             "id": "ce836168-bf2b-50ce-b9b7-55b8d126eba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01afdb32-d9a8-42d4-9ad2-4608ffd661f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01afdb32-d9a8-42d4-9ad2-4608ffd661f0.jpg?1",
             "name": "Noxious Dragon",
             "text": "Flying\nWhen Noxious Dragon dies, you may destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -4852,7 +4852,7 @@
         },
         {
             "id": "ce441784-d2a7-5f89-a224-da2353c149ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde7ecbc-b277-437c-ac94-4c3e89f1bda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde7ecbc-b277-437c-ac94-4c3e89f1bda6.jpg?1",
             "name": "Null Caller",
             "text": "{3}{B}, Exile a creature card from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "a47a987b-dc8c-5744-8893-4fdf27b8476f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f97e9-8b62-44f3-b467-149c2ac5ca78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f97e9-8b62-44f3-b467-149c2ac5ca78.jpg?1",
             "name": "Opposition Agent",
             "text": "Flash\nYou control your opponents while they're searching their libraries.\nWhile an opponent is searching their library, they exile each card they find. You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "815cfbec-2a77-5d3a-a106-fd9a4e917ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0d354e-3a63-4dfe-ae6d-5e82cbf419ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0d354e-3a63-4dfe-ae6d-5e82cbf419ac.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "393fe654-0072-5285-8a0e-cd8dc36c6c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9bc8-29c8-49cb-b4f5-1aceeda8bf45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230b9bc8-29c8-49cb-b4f5-1aceeda8bf45.jpg?1",
             "name": "Plague Reaver",
             "text": "At the beginning of your end step, sacrifice each other creature you control.\nDiscard two cards, Sacrifice Plague Reaver: Choose target opponent. Return Plague Reaver to the battlefield under that player's control at the beginning of their next upkeep.",
             "colours": [
@@ -4995,7 +4995,7 @@
         },
         {
             "id": "5bf7c6e3-87da-51bd-87ed-bf5add6dc612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30272e6d-683d-4c9a-90d6-ea7908943267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30272e6d-683d-4c9a-90d6-ea7908943267.jpg?1",
             "name": "Pride of the Perfect",
             "text": "Elves you control get +2/+0.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "aad3b32f-9ec2-5cb4-95e5-33f44999cb18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04d8edb-7350-4ab5-b721-390784c66329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04d8edb-7350-4ab5-b721-390784c66329.jpg?1",
             "name": "Profane Transfusion",
             "text": "Two target players exchange life totals. You create an X/X colorless Horror artifact creature token, where X is the difference between those players' life totals.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "f538e1c1-2b85-5535-9764-43b0b5b78379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31fd23d-e6b2-412b-b2ff-c99812365001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31fd23d-e6b2-412b-b2ff-c99812365001.jpg?1",
             "name": "Rakshasa Debaser",
             "text": "Whenever Rakshasa Debaser attacks, put target creature card from defending player's graveyard onto the battlefield under your control.\nEncore {6}{B}{B} ({6}{B}{B}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "1356b24f-070f-57d0-98fd-46ee49c7239e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307a8465-9e33-4441-b512-a112e8524328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307a8465-9e33-4441-b512-a112e8524328.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "6a04afce-2a17-55e5-82f6-1b27bbb52f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c33d20d-8d1c-4cf7-a7ad-3dab9758fafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c33d20d-8d1c-4cf7-a7ad-3dab9758fafe.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -5166,7 +5166,7 @@
         },
         {
             "id": "738e4e5c-64ca-5eed-9394-a48916e3de8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d51a22e-74fc-442e-945a-56d02ca12713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d51a22e-74fc-442e-945a-56d02ca12713.jpg?1",
             "name": "Sengir, the Dark Baron",
             "text": "Flying\nWhenever another creature dies, put two +1/+1 counters on Sengir, the Dark Baron.\nWhenever another player loses the game, you gain life equal to that player's life total as the turn began.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "73de3286-f5f8-5c6c-9ee3-82fed95d0408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d42177-dd1b-482c-a549-6f563b3f3249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d42177-dd1b-482c-a549-6f563b3f3249.jpg?1",
             "name": "Spark Harvest",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "ab29f403-8c13-5afa-bb0d-25dc2d9b22ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce15ab0b-c70d-4ac0-a6ee-dbd31736ce1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce15ab0b-c70d-4ac0-a6ee-dbd31736ce1f.jpg?1",
             "name": "Supernatural Stamina",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -5270,7 +5270,7 @@
         },
         {
             "id": "5175b4b5-a435-5fc0-8dcc-1dd30735ac54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9828be7b-1eae-4718-9e71-2f625121b00b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9828be7b-1eae-4718-9e71-2f625121b00b.jpg?1",
             "name": "Szat's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Each opponent sacrifices a creature they control with the greatest power.\n\u2022 Exile all cards from all opponents' graveyards, then create X 0/1 black Thrull creature tokens, where X is the greatest power among creature cards exiled this way.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "9ae329c0-7f18-5139-b229-89dadbe595ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f244716-78ab-46f5-b6e9-fc1e6db28052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f244716-78ab-46f5-b6e9-fc1e6db28052.jpg?1",
             "name": "Tevesh Szat, Doom of Fools",
             "text": "+2: Create two 0/1 black Thrull creature tokens.\n+1: You may sacrifice another creature or planeswalker. If you do, draw two cards, then draw another card if the sacrificed permanent was a commander.\n\u221210: Gain control of all commanders. Put all commanders from the command zone onto the battlefield under your control.\nTevesh Szat, Doom of Fools can be your commander.\nPartner",
             "colours": [
@@ -5342,7 +5342,7 @@
         },
         {
             "id": "eb463207-cef8-5b62-a757-d07df4193fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7538ad-cc41-4229-8a39-c1db21f2899a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7538ad-cc41-4229-8a39-c1db21f2899a.jpg?1",
             "name": "Thorn of the Black Rose",
             "text": "Deathtouch\nWhen Thorn of the Black Rose enters the battlefield, you become the monarch.",
             "colours": [
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "3b193a3f-155e-59dc-8832-c0b5a620bd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89903d5e-241f-477e-a336-2abe0232c04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89903d5e-241f-477e-a336-2abe0232c04a.jpg?1",
             "name": "Tormod, the Desecrator",
             "text": "Whenever one or more cards leave your graveyard, create a tapped 2/2 black Zombie creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "8869e593-8d6e-5da1-9520-f141754a4533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bd50f2-c3ba-4217-a2d5-bb771e199706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bd50f2-c3ba-4217-a2d5-bb771e199706.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "20fa0466-f5ef-5e4c-885e-ec8486613b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855e9253-2219-4c43-8131-47633c564ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855e9253-2219-4c43-8131-47633c564ee2.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -5484,7 +5484,7 @@
         },
         {
             "id": "c96c9904-5765-501f-a39b-84029fb08a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49203dd-89b6-4e91-b3ff-5f9f5ce981f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49203dd-89b6-4e91-b3ff-5f9f5ce981f8.jpg?1",
             "name": "Viscera Seer",
             "text": "Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "4fcc34d6-bdf3-5efc-bab6-9655092b696c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae74624e-3850-4153-b682-d044272269c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae74624e-3850-4153-b682-d044272269c1.jpg?1",
             "name": "Vow of Torment",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has menace, and can't attack you or a planeswalker you control. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "d6a21294-4584-5d5d-998a-cb0c4cd2117d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c51949-b1ef-4c6e-98b0-4fb33a81db24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c51949-b1ef-4c6e-98b0-4fb33a81db24.jpg?1",
             "name": "Alena, Kessig Trapper",
             "text": "First strike\n{T}: Add an amount of {R} equal to the greatest power among creatures you control that entered the battlefield this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "01582551-627f-59c3-aa7c-7f94dc86e232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3841b5f9-f9a3-433d-bcdc-f2aa5c783b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3841b5f9-f9a3-433d-bcdc-f2aa5c783b6d.jpg?1",
             "name": "Aurora Phoenix",
             "text": "Flying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nWhenever you cast a spell with cascade, return Aurora Phoenix from your graveyard to your hand.",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "19840dd3-0f91-507d-8753-9d2fd92944e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1ef14-cb26-486e-9b54-0b532f5b7435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1ef14-cb26-486e-9b54-0b532f5b7435.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "b288bdfc-b88a-5e56-ab2b-60fa3485d489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186adacf-434b-475b-9b85-749615ae002b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186adacf-434b-475b-9b85-749615ae002b.jpg?1",
             "name": "Boarding Party",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "3598e199-097c-52b0-82b6-47c845ab0445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45657345-b564-4e5f-a57a-01dc54df7e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45657345-b564-4e5f-a57a-01dc54df7e7c.jpg?1",
             "name": "Brazen Freebooter",
             "text": "When Brazen Freebooter enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5734,7 +5734,7 @@
         },
         {
             "id": "651b7da2-c120-5876-b644-ea0de93ff480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e8fe2e-ec6c-47fc-85c0-6eec185ecdce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e8fe2e-ec6c-47fc-85c0-6eec185ecdce.jpg?1",
             "name": "Breeches, Brazen Plunderer",
             "text": "Menace\nWhenever one or more Pirates you control deal damage to your opponents, exile the top card of each of those opponents' libraries. You may play those cards this turn, and you may spend mana as though it were mana of any color to cast those spells.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "ddbab1e1-284f-524f-b523-7975baaecf24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a8f92-4418-4993-9f56-0b2f5069597c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5a8f92-4418-4993-9f56-0b2f5069597c.jpg?1",
             "name": "Burning Anger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to any target.\"",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "d3241a14-eb0c-52fb-83a9-cffa7c5f9a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a248363d-40a0-4dc5-a0bb-a826c3ba4499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a248363d-40a0-4dc5-a0bb-a826c3ba4499.jpg?1",
             "name": "Champion of the Flame",
             "text": "Trample\nChampion of the Flame gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "61075dde-1e37-5814-b5a4-131e97ba6587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47e6bc-422a-4627-b21e-5a042193bed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a47e6bc-422a-4627-b21e-5a042193bed0.jpg?1",
             "name": "Coastline Marauders",
             "text": "Trample\nWhenever Coastline Marauders attacks, it gets +1/+0 until end of turn for each land defending player controls.\nEncore {4}{R}{R} ({4}{R}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -5877,7 +5877,7 @@
         },
         {
             "id": "fcfb2216-2214-59a6-b2c5-024e0c1b03ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a02f1b-4f41-4285-a331-7211f4e6e2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a02f1b-4f41-4285-a331-7211f4e6e2b4.jpg?1",
             "name": "Coercive Recruiter",
             "text": "Whenever Coercive Recruiter or another Pirate enters the battlefield under your control, gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and becomes a Pirate in addition to its other types.",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "15c52b31-ad0c-5206-8667-ca185458b6d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca0dcc-7a87-49da-8011-8c11a8835df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca0dcc-7a87-49da-8011-8c11a8835df2.jpg?1",
             "name": "Court of Ire",
             "text": "When Court of Ire enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, Court of Ire deals 2 damage to any target. If you're the monarch, it deals 7 damage instead.",
             "colours": [
@@ -5948,7 +5948,7 @@
         },
         {
             "id": "305ce1cf-6bb1-5e91-a9b6-b0eedf67b6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90fdccf-30a6-40ee-9b35-83a6ee5c0681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90fdccf-30a6-40ee-9b35-83a6ee5c0681.jpg?1",
             "name": "Crimson Fleet Commodore",
             "text": "Trample\nWhen Crimson Fleet Commodore enters the battlefield, you become the monarch.",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "f02ab4c4-b512-53e7-b961-1e3c3fc5e942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd87cf8-4d5d-4aba-8dfa-800b1fb3799b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd87cf8-4d5d-4aba-8dfa-800b1fb3799b.jpg?1",
             "name": "Dargo, the Shipwrecker",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of artifacts and/or creatures. This spell costs {2} less to cast for each permanent sacrificed this way and {2} less to cast for each other artifact or creature you've sacrificed this turn.\nTrample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6022,7 +6022,7 @@
         },
         {
             "id": "1d54b6cc-3d3b-5be2-966b-21c75e788bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300761b6-9943-4251-9b1a-96a940f3334b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300761b6-9943-4251-9b1a-96a940f3334b.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -6057,7 +6057,7 @@
         },
         {
             "id": "b9ca2d56-8ee5-5162-8375-d100c29585d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca32fd66-f7f1-4e50-817f-bb259f690f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca32fd66-f7f1-4e50-817f-bb259f690f00.jpg?1",
             "name": "Dragon Mantle",
             "text": "Enchant creature\nWhen Dragon Mantle enters the battlefield, draw a card.\nEnchanted creature has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -6091,7 +6091,7 @@
         },
         {
             "id": "f1932cb1-b121-51a2-ac49-564dc9aa1960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362850cd-d33c-4f61-9b3a-5de748adee7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362850cd-d33c-4f61-9b3a-5de748adee7c.jpg?1",
             "name": "Emberwilde Captain",
             "text": "When Emberwilde Captain enters the battlefield, you become the monarch.\nWhenever an opponent attacks you while you're the monarch, Emberwilde Captain deals damage to that player equal to the number of cards in their hand.",
             "colours": [
@@ -6128,7 +6128,7 @@
         },
         {
             "id": "8fee2692-e949-57ca-9cb4-0d3a85641d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2f3dd5-a943-447b-8c76-8f69f06cefa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2f3dd5-a943-447b-8c76-8f69f06cefa4.jpg?1",
             "name": "Explosion of Riches",
             "text": "Draw a card, then each other player may draw a card. Whenever a card is drawn this way, Explosion of Riches deals 5 damage to target opponent chosen at random from among your opponents.",
             "colours": [
@@ -6160,7 +6160,7 @@
         },
         {
             "id": "2c18cae7-98d9-57f5-91fd-f21563f5e593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c267b7-dbd6-43c5-9741-10f635bff4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c267b7-dbd6-43c5-9741-10f635bff4b1.jpg?1",
             "name": "Fathom Fleet Swordjack",
             "text": "Whenever Fathom Fleet Swordjack attacks, it deals damage to the player or planeswalker it's attacking equal to the number of artifacts you control.\nEncore {5}{R} ({5}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "105036aa-f949-5e6a-b7c3-f009e8034d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f1cdf-712b-4518-a0e8-0039303dccdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396f1cdf-712b-4518-a0e8-0039303dccdc.jpg?1",
             "name": "Fiery Cannonade",
             "text": "Fiery Cannonade deals 2 damage to each non-Pirate creature.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "5d5f0211-9541-54c6-95de-a9812699fecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2616030-01f2-43b1-98ba-f7e5a5a75379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2616030-01f2-43b1-98ba-f7e5a5a75379.jpg?1",
             "name": "Flamekin Herald",
             "text": "Commander spells you cast have cascade. (Whenever you cast a commander, exile cards from the top of your library until you exile a nonland card with lesser converted mana cost. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "27ee3059-6271-5008-89fc-d2d6b46d12e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518fffb-542f-4752-be05-d0dbcf4dd6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518fffb-542f-4752-be05-d0dbcf4dd6c2.jpg?1",
             "name": "Frenzied Saddlebrute",
             "text": "Haste\nAll creatures can attack your opponents and planeswalkers your opponents control as though those creatures had haste.",
             "colours": [
@@ -6299,7 +6299,7 @@
         },
         {
             "id": "dd73975b-04f7-5e2a-8e81-95ead26b2294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7f79-fc49-4d1e-a84f-c630ba238e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7f79-fc49-4d1e-a84f-c630ba238e83.jpg?1",
             "name": "Furnace Celebration",
             "text": "Whenever you sacrifice another permanent, you may pay {2}. If you do, Furnace Celebration deals 2 damage to any target.",
             "colours": [
@@ -6331,7 +6331,7 @@
         },
         {
             "id": "1cf9407c-da88-531c-bbbb-f886e7ad74f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca382425-2454-4300-b903-fdefd31582d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca382425-2454-4300-b903-fdefd31582d3.jpg?1",
             "name": "Goblin Trailblazer",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "fd9cdcab-4aaa-50dd-9541-4aece93b3543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45122e-b5ef-487b-8ea9-59ea066d3c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45122e-b5ef-487b-8ea9-59ea066d3c88.jpg?1",
             "name": "Hellkite Courser",
             "text": "Flying\nWhen Hellkite Courser enters the battlefield, you may put a commander you own from the command zone onto the battlefield. It gains haste. Return it to the command zone at the beginning of the next end step.",
             "colours": [
@@ -6402,7 +6402,7 @@
         },
         {
             "id": "321e56b9-d436-5b9e-8555-1b051e091079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6539ca2d-e577-43f7-9f0c-bd25599dcb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6539ca2d-e577-43f7-9f0c-bd25599dcb8c.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "a67ec8aa-00a5-5f54-aca7-3b3ec4e8ad1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ba9bea-5549-45cf-896c-501a1c81fd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ba9bea-5549-45cf-896c-501a1c81fd5a.jpg?1",
             "name": "Impulsive Pilferer",
             "text": "When Impulsive Pilferer dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEncore {3}{R} ({3}{R}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "dc7953a6-d2d2-5db6-bf30-9e5902c8c0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48caf4c4-745c-4072-bf3d-1a3fa7c3bc9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48caf4c4-745c-4072-bf3d-1a3fa7c3bc9c.jpg?1",
             "name": "Jeska, Thrice Reborn",
             "text": "Jeska, Thrice Reborn enters the battlefield with a loyalty counter on it for each time you've cast a commander from the command zone this game.\n0: Choose target creature. Until your next turn, if that creature would deal combat damage to one of your opponents, it deals triple that damage to that player instead.\n\u2212X: Jeska, Thrice Reborn deals X damage to each of up to three targets.\nJeska, Thrice Reborn can be your commander.\nPartner",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "29c8038d-3b3c-5092-b618-75ab4487ed9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e91d96d-cc69-439b-b876-a7d57039022c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e91d96d-cc69-439b-b876-a7d57039022c.jpg?1",
             "name": "Jeska's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Add {R} for each card in target opponent's hand.\n\u2022 Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "f3f5f0de-68c9-59e4-ab61-77b58b2afb1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f606ebf1-483d-4331-b16a-9fb6f591a39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f606ebf1-483d-4331-b16a-9fb6f591a39f.jpg?1",
             "name": "Kediss, Emberclaw Familiar",
             "text": "Whenever a commander you control deals combat damage to an opponent, it deals that much damage to each other opponent.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6585,7 +6585,7 @@
         },
         {
             "id": "2704f6ad-6741-5194-9bf7-459d6b4c5b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a981cd-1951-438e-95c9-68294795638e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a981cd-1951-438e-95c9-68294795638e.jpg?1",
             "name": "Krark, the Thumbless",
             "text": "Whenever you cast an instant or sorcery spell, flip a coin. If you lose the flip, return that spell to its owner's hand. If you win the flip, copy that spell, and you may choose new targets for the copy.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6624,7 +6624,7 @@
         },
         {
             "id": "da151ce0-f377-5d8f-ab43-620b2d7269e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa676ef-3f26-43bb-98f9-9b0b9681a7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa676ef-3f26-43bb-98f9-9b0b9681a7fe.jpg?1",
             "name": "Lightning-Rig Crew",
             "text": "{T}: Lightning-Rig Crew deals 1 damage to each opponent.\nWhenever you cast a Pirate spell, untap Lightning-Rig Crew.",
             "colours": [
@@ -6659,7 +6659,7 @@
         },
         {
             "id": "7b69f1c2-3187-5c22-9ac8-ec2f5b45103a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1ad9f-e217-49fb-8b27-025ca133b6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1ad9f-e217-49fb-8b27-025ca133b6c9.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.",
             "colours": [
@@ -6691,7 +6691,7 @@
         },
         {
             "id": "c9084657-d201-5564-87cf-ddca6dafabc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb7e94-01df-4e80-9b24-bc303a27ffd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb7e94-01df-4e80-9b24-bc303a27ffd6.jpg?1",
             "name": "Meteoric Mace",
             "text": "Equipped creature gets +4/+0 and has trample.\nEquip {4}\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "9cf3abe2-d6ce-5e6a-9bfe-a8c76ef73511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0527b-bb28-4986-9843-040d06bd9def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0527b-bb28-4986-9843-040d06bd9def.jpg?1",
             "name": "Port Razer",
             "text": "Whenever Port Razer deals combat damage to a player, untap each creature you control. After this combat phase, there is an additional combat phase.\nPort Razer can't attack a player it has already attacked this turn.",
             "colours": [
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "74479dc6-c690-544b-be80-66ff17a14370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288606e-182a-4260-bbe9-3f8f09c2f33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6288606e-182a-4260-bbe9-3f8f09c2f33c.jpg?1",
             "name": "Portent of Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "adad3014-25bb-53c7-8cb9-7d0482461c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfa0e65-1ce0-4f8e-a78b-2ade2d25e748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfa0e65-1ce0-4f8e-a78b-2ade2d25e748.jpg?1",
             "name": "Renegade Tactics",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "48448b61-5f31-53a2-9bbe-66293104501b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00924a16-fb85-41a4-bd7a-88f51f728333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00924a16-fb85-41a4-bd7a-88f51f728333.jpg?1",
             "name": "Ripscale Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "379be6bc-f2ec-50ef-b815-f2c1d3ff867f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fab67f-00c2-4125-9262-d21a29411797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4fab67f-00c2-4125-9262-d21a29411797.jpg?1",
             "name": "Rograkh, Son of Rohgahh",
             "text": "First strike, menace, trample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -6899,7 +6899,7 @@
         },
         {
             "id": "2e4a7cef-8462-5557-8cf6-5fc2a3b93113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254391a3-c12a-4944-9da5-ae166094480f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254391a3-c12a-4944-9da5-ae166094480f.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "b97549e9-0b87-5b96-9ea1-1b3495dcb6f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eed5cc-e5e8-476d-bdd7-c51233359a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eed5cc-e5e8-476d-bdd7-c51233359a48.jpg?1",
             "name": "Skyraker Giant",
             "text": "Reach",
             "colours": [
@@ -6968,7 +6968,7 @@
         },
         {
             "id": "b160d3a5-222a-562b-a182-4cdb4f510d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239a9f2e-145b-4f31-8128-4d376af1079d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239a9f2e-145b-4f31-8128-4d376af1079d.jpg?1",
             "name": "Soul's Fire",
             "text": "Target creature you control deals damage equal to its power to any target.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "bd128f43-2826-5813-8e4d-3cd710182ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2def4384-7175-4a26-a5a0-8f2c5b5ad71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2def4384-7175-4a26-a5a0-8f2c5b5ad71c.jpg?1",
             "name": "Soulfire Eruption",
             "text": "Choose any number of target creatures, planeswalkers, and/or players. For each of them, exile the top card of your library, then Soulfire Eruption deals damage equal to that card's converted mana cost to that permanent or player. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "e9f86bef-9987-5108-95c1-9d189c4c5e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a3c60-c740-4e2e-a622-a749ed230c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a3c60-c740-4e2e-a622-a749ed230c5b.jpg?1",
             "name": "Sparktongue Dragon",
             "text": "Flying\nWhen Sparktongue Dragon enters the battlefield, you may pay {2}{R}. When you do, it deals 3 damage to any target.",
             "colours": [
@@ -7068,7 +7068,7 @@
         },
         {
             "id": "82398377-5edb-5600-bbab-c64d6480b4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c111bf0-dedb-48eb-982c-f877120f12c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c111bf0-dedb-48eb-982c-f877120f12c3.jpg?1",
             "name": "Stonefury",
             "text": "Stonefury deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "a2eaff0d-7ba6-544c-875c-02c26001a887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a05b3e2-259e-4fce-92ee-c00660e22ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a05b3e2-259e-4fce-92ee-c00660e22ae7.jpg?1",
             "name": "Toggo, Goblin Weaponsmith",
             "text": "Whenever a land enters the battlefield under your control, create a colorless Equipment artifact token named Rock with \"Equipped creature has \u2018{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any target'\" and equip {1}.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "737853fe-4f6d-5c9d-8509-f9dbb6a391da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db7aa92-d86a-4986-a661-f3025ca79d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db7aa92-d86a-4986-a661-f3025ca79d3d.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -7173,7 +7173,7 @@
         },
         {
             "id": "c05bcc98-c211-5784-ae4b-50aa6a3a2eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8000d86-60e7-4edd-b685-14ade08b76f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8000d86-60e7-4edd-b685-14ade08b76f2.jpg?1",
             "name": "Valakut Invoker",
             "text": "{8}: Valakut Invoker deals 3 damage to any target.",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "d4ef1d4e-233e-5a2c-a4d0-0ceac8ae48db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419d29-21a1-4753-a2f0-1d0d996ec54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46419d29-21a1-4753-a2f0-1d0d996ec54e.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying, haste",
             "colours": [
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "9b23d590-3945-5c74-9b3b-e0693e643fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb586da6-670d-4c50-9d9b-f320f1c288d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb586da6-670d-4c50-9d9b-f320f1c288d7.jpg?1",
             "name": "Volcanic Torrent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nVolcanic Torrent deals X damage to each creature and planeswalker your opponents control, where X is the number of spells you've cast this turn.",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "00b8b8c0-6c64-52f6-b7cf-297260191f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71218cff-7e57-40dd-83c2-d06b284a63fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71218cff-7e57-40dd-83c2-d06b284a63fd.jpg?1",
             "name": "Vow of Lightning",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has first strike, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -7308,7 +7308,7 @@
         },
         {
             "id": "9dba227d-910e-5b97-ab60-b4f7cb4d91a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cc190-6825-4226-8ea5-71abe788454d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cc190-6825-4226-8ea5-71abe788454d.jpg?1",
             "name": "Welding Sparks",
             "text": "Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.",
             "colours": [
@@ -7340,7 +7340,7 @@
         },
         {
             "id": "40b8812e-003d-56c3-a181-d47a090c0d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74177b51-a300-49d9-8ea7-557b19cf80c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74177b51-a300-49d9-8ea7-557b19cf80c7.jpg?1",
             "name": "Wheel of Misfortune",
             "text": "Each player secretly chooses a number 0 or greater, then all players reveal those numbers simultaneously and determine the highest and lowest numbers revealed this way. Wheel of Misfortune deals damage equal to the highest number to each player who chose that number. Each player who didn't choose the lowest number discards their hand, then draws seven cards.",
             "colours": [
@@ -7374,7 +7374,7 @@
         },
         {
             "id": "66a81257-2961-582a-9fb3-46224bb052cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9e72f4-0087-4a79-b9af-296c8b930a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9e72f4-0087-4a79-b9af-296c8b930a25.jpg?1",
             "name": "Wild Celebrants",
             "text": "When Wild Celebrants enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -7408,7 +7408,7 @@
         },
         {
             "id": "8d167cba-ebfd-5f2d-86cb-bccbbba625fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e386888-57f5-4eb6-88e8-5679bb8eb290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e386888-57f5-4eb6-88e8-5679bb8eb290.jpg?1",
             "name": "Ambush Viper",
             "text": "Flash\nDeathtouch",
             "colours": [
@@ -7442,7 +7442,7 @@
         },
         {
             "id": "a6643f91-5c8f-549b-b955-12a83d1560d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67cfaa-990c-4dcb-97a9-9c5d7316cabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a67cfaa-990c-4dcb-97a9-9c5d7316cabe.jpg?1",
             "name": "Anara, Wolvid Familiar",
             "text": "As long as it's your turn, commanders you control have indestructible. (Effects that say \"destroy\" don't destroy them. A creature with indestructible can't be destroyed by damage.)\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "b48b8938-8fcb-52ab-b4f3-54be2b611105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee76006-5272-400d-b6b2-e1548bca9dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee76006-5272-400d-b6b2-e1548bca9dbf.jpg?1",
             "name": "Ancient Animus",
             "text": "Put a +1/+1 counter on target creature you control if it's legendary. Then it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "09038313-4035-5441-8f9b-f47d706a5988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536d618-0c98-45bb-913b-b8117b4acf87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7536d618-0c98-45bb-913b-b8117b4acf87.jpg?1",
             "name": "Annoyed Altisaur",
             "text": "Reach, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "0973d08b-c588-5be8-882b-abb9631eb700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa281e1-5c48-4bba-b8e9-88c6f5f53abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa281e1-5c48-4bba-b8e9-88c6f5f53abb.jpg?1",
             "name": "Apex Devastator",
             "text": "Cascade, cascade, cascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Multiple instances of cascade each trigger separately.)",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "0ec1a938-e29f-5347-8071-d0a2ff6de6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1483d4-bb91-4bf9-a57f-dd46fa31056b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1483d4-bb91-4bf9-a57f-dd46fa31056b.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "576fe942-7f63-59af-92d1-eee987c9e8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf476f-ccc8-42ac-8d01-64bb85552acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf476f-ccc8-42ac-8d01-64bb85552acd.jpg?1",
             "name": "Biowaste Blob",
             "text": "Oozes you control get +1/+1.\nAt the beginning of your upkeep, if you control a commander, create a token that's a copy of Biowaste Blob.",
             "colours": [
@@ -7655,7 +7655,7 @@
         },
         {
             "id": "d2a4d2a9-c38c-513e-910f-0ac406aba2a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcffbea4-0126-483d-87da-b20e3c0b88a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcffbea4-0126-483d-87da-b20e3c0b88a7.jpg?1",
             "name": "Court of Bounty",
             "text": "When Court of Bounty enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, you may put a land card from your hand onto the battlefield. If you're the monarch, instead you may put a creature or land card from your hand onto the battlefield.",
             "colours": [
@@ -7689,7 +7689,7 @@
         },
         {
             "id": "59e2d2d9-a442-5c76-8c05-7d2cf75a32bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7adf3cb-2834-49fc-bdd0-9b939a20915c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7adf3cb-2834-49fc-bdd0-9b939a20915c.jpg?1",
             "name": "Crushing Vines",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -7721,7 +7721,7 @@
         },
         {
             "id": "9d462bb8-e690-55bf-9a77-8439b168fef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26025f0-72c0-4875-b2d7-916666b835d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26025f0-72c0-4875-b2d7-916666b835d9.jpg?1",
             "name": "Dawnglade Regent",
             "text": "When Dawnglade Regent enters the battlefield, you become the monarch.\nAs long as you're the monarch, permanents you control have hexproof.",
             "colours": [
@@ -7757,7 +7757,7 @@
         },
         {
             "id": "1af9ac64-e096-5e46-b7b3-ec69b713317f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f174e6-9532-4fc3-815b-2dc3966c6523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f174e6-9532-4fc3-815b-2dc3966c6523.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -7792,7 +7792,7 @@
         },
         {
             "id": "b10e39b4-7f2b-5f85-a796-8103bdf90bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e65427-1191-4f5a-b4ca-c383eecd274e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e65427-1191-4f5a-b4ca-c383eecd274e.jpg?1",
             "name": "Entourage of Trest",
             "text": "When Entourage of Trest enters the battlefield, you become the monarch.\nEntourage of Trest can block an additional creature each combat as long as you're the monarch.",
             "colours": [
@@ -7827,7 +7827,7 @@
         },
         {
             "id": "826db393-02de-539a-a5b8-5386d6054628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db681025-f912-4cba-8b89-c57cda2e6d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db681025-f912-4cba-8b89-c57cda2e6d53.jpg?1",
             "name": "Farhaven Elf",
             "text": "When Farhaven Elf enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7862,7 +7862,7 @@
         },
         {
             "id": "a28cd052-a52e-5a1e-8e70-ebe32d90264c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d56da0-6f37-4bd5-8982-940e80bd4282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d56da0-6f37-4bd5-8982-940e80bd4282.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles their library.",
             "colours": [
@@ -7896,7 +7896,7 @@
         },
         {
             "id": "5441780c-3567-5306-91ec-f7d9b3966d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb7af70-e024-44bf-a52b-209074b005a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb7af70-e024-44bf-a52b-209074b005a3.jpg?1",
             "name": "Fin-Clade Fugitives",
             "text": "Fin-Clade Fugitives can't be blocked by creatures with power 2 or less.\nEncore {4}{G} ({4}{G}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "4aa94472-4ade-5c48-9958-e09629e9263b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450744cf-7eba-491b-97b0-ca80c6368bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450744cf-7eba-491b-97b0-ca80c6368bbb.jpg?1",
             "name": "Fyndhorn Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -7969,7 +7969,7 @@
         },
         {
             "id": "5e6213d4-bdea-5195-b6d5-360fa1a715b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b361e3-8aaa-4194-8ae8-45bdb70c97bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b361e3-8aaa-4194-8ae8-45bdb70c97bb.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "55b71f80-36b8-57ba-8b2f-2d4db81c9b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745d297d-4bb4-40cf-bb9c-99dac04e5069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745d297d-4bb4-40cf-bb9c-99dac04e5069.jpg?1",
             "name": "Gilanra, Caller of Wirewood",
             "text": "{T}: Add {G}. When you spend this mana to cast a spell with converted mana cost 6 or greater, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "a836295d-4af9-5590-a83c-49b39abde7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee6eb2-2708-4596-86ad-40eea88dbb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee6eb2-2708-4596-86ad-40eea88dbb6b.jpg?1",
             "name": "Halana, Kessig Ranger",
             "text": "Reach\nWhenever another creature enters the battlefield under your control, you may pay {2}. When you do, that creature deals damage equal to its power to target creature.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "8bd56d7f-05e8-5d3e-b534-f27bca5b9a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1448cf-3ddc-437b-a21e-4f4086492ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1448cf-3ddc-437b-a21e-4f4086492ec6.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -8114,7 +8114,7 @@
         },
         {
             "id": "9767c0a3-2584-5383-8eeb-6873f4f20ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409a15a-7cf6-43e5-958c-d23da4304f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409a15a-7cf6-43e5-958c-d23da4304f29.jpg?1",
             "name": "Ich-Tekik, Salvage Splicer",
             "text": "When Ich-Tekik, Salvage Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nWhenever an artifact is put into a graveyard from the battlefield, put a +1/+1 counter on Ich-Tekik and a +1/+1 counter on each Golem you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "3a2fc10e-7f58-5922-948c-71903dc62f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9208db8-1ba5-4f9c-90a4-03e377ae6f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9208db8-1ba5-4f9c-90a4-03e377ae6f86.jpg?1",
             "name": "Immaculate Magistrate",
             "text": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
             "colours": [
@@ -8191,7 +8191,7 @@
         },
         {
             "id": "3b6d43d9-d72e-5f43-bb47-84b62b981baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef8940a-d1d9-460e-9949-89bb30f9e6d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef8940a-d1d9-460e-9949-89bb30f9e6d6.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elves you control get +1/+1.\n{G}, {T}: Create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "c3d57d00-2cf2-5810-9dab-16ee46f17339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bea375-8af3-4425-a418-bb5503e2dfb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bea375-8af3-4425-a418-bb5503e2dfb7.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "81a66020-9905-509d-8285-acb9d3bda6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3560ae-b1f6-4269-a9eb-1a45247b6232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3560ae-b1f6-4269-a9eb-1a45247b6232.jpg?1",
             "name": "Kamahl, Heart of Krosa",
             "text": "At the beginning of combat on your turn, creatures you control get +3/+3 and gain trample until end of turn.\n{1}{G}: Until end of turn, target land you control becomes a 1/1 Elemental creature with vigilance, indestructible, and haste. It's still a land.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "1f2ddca9-f0b3-5afc-bdf6-2a527ba198c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fe007f-fddf-4b3a-b336-0a88df95cb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fe007f-fddf-4b3a-b336-0a88df95cb14.jpg?1",
             "name": "Kamahl's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Until end of turn, any number of target lands you control become 1/1 Elemental creatures with vigilance, indestructible, and haste. They're still lands.\n\u2022 Choose target creature you don't control. Each creature you control deals damage equal to its power to that creature.",
             "colours": [
@@ -8334,7 +8334,7 @@
         },
         {
             "id": "472d5072-f952-5115-81f5-5d0d3d1adf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5105ee-09e2-4344-ab39-00f0e9034c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5105ee-09e2-4344-ab39-00f0e9034c47.jpg?1",
             "name": "Kodama of the East Tree",
             "text": "Reach\nWhenever another permanent enters the battlefield under your control, if it wasn't put onto the battlefield with this ability, you may put a permanent card with equal or lesser converted mana cost from your hand onto the battlefield.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8372,7 +8372,7 @@
         },
         {
             "id": "3d7085d6-735c-5c39-b0a4-54b8c1e0e322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa000086-e4aa-4bb6-8e66-f4c96e875749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa000086-e4aa-4bb6-8e66-f4c96e875749.jpg?1",
             "name": "Lifecrafter's Gift",
             "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -8404,7 +8404,7 @@
         },
         {
             "id": "e0abfa60-b253-5595-8fef-d227960f0e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888e2f0-223b-4509-8071-fe1b87a65b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888e2f0-223b-4509-8071-fe1b87a65b72.jpg?1",
             "name": "Lys Alana Bowmaster",
             "text": "Reach\nWhenever you cast an Elf spell, you may have Lys Alana Bowmaster deal 2 damage to target creature with flying.",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "14d81244-e39b-5e18-966b-177b6c603a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e5fa9-cfe3-487b-af77-0dbf6c68ee04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e5fa9-cfe3-487b-af77-0dbf6c68ee04.jpg?1",
             "name": "Magus of the Order",
             "text": "{G}, {T}, Sacrifice Magus of the Order and another green creature: Search your library for a green creature card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "28682398-1b11-5f20-b87c-d2d57835060e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636f571-43ed-4b60-b5d9-129ff94dd0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636f571-43ed-4b60-b5d9-129ff94dd0fa.jpg?1",
             "name": "Molder Beast",
             "text": "Trample\nWhenever an artifact is put into a graveyard from the battlefield, Molder Beast gets +2/+0 until end of turn.",
             "colours": [
@@ -8510,7 +8510,7 @@
         },
         {
             "id": "8da9d3d9-00f5-5605-8e9a-ddb17e81112d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc27f7f-5dd4-4f1d-ba3f-a4b0400cdc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc27f7f-5dd4-4f1d-ba3f-a4b0400cdc72.jpg?1",
             "name": "Monstrous Onslaught",
             "text": "Monstrous Onslaught deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast this spell.",
             "colours": [
@@ -8542,7 +8542,7 @@
         },
         {
             "id": "9f8f9a52-51f2-595c-80b7-b5332b075c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98fb7c-6962-4b57-b7b7-c71899564002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98fb7c-6962-4b57-b7b7-c71899564002.jpg?1",
             "name": "Natural Reclamation",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "02dc8039-bc77-5c65-9654-8cdffc350880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9465d118-5ad5-42c5-a512-7aca5f7b905d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9465d118-5ad5-42c5-a512-7aca5f7b905d.jpg?1",
             "name": "Numa, Joraga Chieftain",
             "text": "At the beginning of combat on your turn, you may pay {X}{X}. When you do, distribute X +1/+1 counters among any number of target Elves.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "ea6c5d30-8bba-5d0c-9d90-a9bb40c3f93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea175de9-15c2-4d08-ae0e-0427a0b8069b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea175de9-15c2-4d08-ae0e-0427a0b8069b.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea.\nWhen you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "56c27653-711b-5cdc-a751-38b68396d3f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b800bb44-3594-4fb7-b007-10732632b51a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b800bb44-3594-4fb7-b007-10732632b51a.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "5d6514c4-af2b-5417-ae1c-bfbe1d6bb918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada14bc8-4549-4a73-8cbb-9a43698deb36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada14bc8-4549-4a73-8cbb-9a43698deb36.jpg?1",
             "name": "Reshape the Earth",
             "text": "Search your library for up to ten land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "4c489f93-db86-584a-aabe-23bcbf619ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987e0ffe-ea75-4985-b6a3-b874bef78719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987e0ffe-ea75-4985-b6a3-b874bef78719.jpg?1",
             "name": "Rootweaver Druid",
             "text": "When Rootweaver Druid enters the battlefield, each opponent may search their library for up to three basic land cards. They each put one of those cards onto the battlefield tapped under your control and the rest onto the battlefield tapped under their control. Then each player who searched their library this way shuffles it.",
             "colours": [
@@ -8755,7 +8755,7 @@
         },
         {
             "id": "fcb66348-e4ff-5735-b140-9eaa2936c1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017ef6eb-7a2b-4730-bf21-a2289d4c07ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017ef6eb-7a2b-4730-bf21-a2289d4c07ad.jpg?1",
             "name": "Scaled Behemoth",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -8789,7 +8789,7 @@
         },
         {
             "id": "b6933827-f667-539f-bed8-6bf3a0719a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c8aab5-ed0d-489d-87af-7eb3193b75db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c8aab5-ed0d-489d-87af-7eb3193b75db.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -8824,7 +8824,7 @@
         },
         {
             "id": "b00630a0-5802-552f-8e9c-629a386e8b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e7af76-e505-49ca-a91e-8167027560ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e7af76-e505-49ca-a91e-8167027560ff.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "b95bd260-f247-551d-a5fa-419aa3d8831f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ff217-1bf6-4942-8d2f-8ddd71da683f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ff217-1bf6-4942-8d2f-8ddd71da683f.jpg?1",
             "name": "Sifter Wurm",
             "text": "Trample\nWhen Sifter Wurm enters the battlefield, scry 3, then reveal the top card of your library. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "ffeda675-671f-5194-a5dd-daff38581235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8048bab7-8fd1-446c-80e9-cc2ffb154295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8048bab7-8fd1-446c-80e9-cc2ffb154295.jpg?1",
             "name": "Silverback Shaman",
             "text": "Trample\nWhen Silverback Shaman dies, draw a card.",
             "colours": [
@@ -8927,7 +8927,7 @@
         },
         {
             "id": "cee16c13-ece0-5b53-83bc-bcbeb211fe98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da14a82-0c33-4319-9af5-390013ccbe19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da14a82-0c33-4319-9af5-390013ccbe19.jpg?1",
             "name": "Slurrk, All-Ingesting",
             "text": "Slurrk, All-Ingesting enters the battlefield with five +1/+1 counters on it.\nWhenever Slurrk or another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on each creature you control that has a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "b1ab4c62-4459-55a4-8119-8dac01571a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd32c85-3cc5-4987-8156-4def6d0004d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd32c85-3cc5-4987-8156-4def6d0004d6.jpg?1",
             "name": "Soul's Might",
             "text": "Put X +1/+1 counters on target creature, where X is that creature's power.",
             "colours": [
@@ -8997,7 +8997,7 @@
         },
         {
             "id": "2d335255-a266-5e2f-8420-c6e0ae86558d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f45424-2c26-43fa-9afe-eeb22ce772e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f45424-2c26-43fa-9afe-eeb22ce772e1.jpg?1",
             "name": "Stingerfling Spider",
             "text": "Reach\nWhen Stingerfling Spider enters the battlefield, you may destroy target creature with flying.",
             "colours": [
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "5e6549b6-5b43-5da1-8597-d7109b9befe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1ba0c-1131-4b16-9a11-90947cdb6292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1ba0c-1131-4b16-9a11-90947cdb6292.jpg?1",
             "name": "Strength of the Pack",
             "text": "Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -9063,7 +9063,7 @@
         },
         {
             "id": "89247cf6-b39b-58dc-8c77-1d41ac1b26b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd331b3-43cd-421a-964d-d3b35bb8abcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd331b3-43cd-421a-964d-d3b35bb8abcb.jpg?1",
             "name": "Sweet-Gum Recluse",
             "text": "Flash\nCascade\nReach\nWhen Sweet-Gum Recluse enters the battlefield, put three +1/+1 counters on each of any number of target creatures that entered the battlefield this turn.",
             "colours": [
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "e7ec28f5-cc4c-5a37-a8eb-6cb630e9a26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9307ec-987b-4bbf-a679-cfaabe283a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9307ec-987b-4bbf-a679-cfaabe283a80.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "ca3439c9-e3e9-585a-9864-ab2d22bfffa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764fa7f1-b92b-42cc-983e-e0b5457369a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764fa7f1-b92b-42cc-983e-e0b5457369a7.jpg?1",
             "name": "Vow of Wildness",
             "text": "Enchant creature\nEnchanted creature gets +3/+3, has trample, and can't attack you or a planeswalker you control.",
             "colours": [
@@ -9167,7 +9167,7 @@
         },
         {
             "id": "a6d94b84-6645-5581-a284-1aff926ee00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143231b3-23c4-4c6d-8b58-e401e1ac6e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143231b3-23c4-4c6d-8b58-e401e1ac6e29.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -9202,7 +9202,7 @@
         },
         {
             "id": "88e3b8fc-b697-541a-8741-d6afa74c21e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e640d-9a24-471e-8092-0177ec8d824e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e640d-9a24-471e-8092-0177ec8d824e.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "825c7b44-9ad0-57c6-ae6e-cc2213fb027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567dbc64-4d59-4bab-a551-08fc66c085fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567dbc64-4d59-4bab-a551-08fc66c085fa.jpg?1",
             "name": "Abomination of Llanowar",
             "text": "Vigilance; menace (This creature can't be blocked except by two or more creatures.)\nAbomination of Llanowar's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.",
             "colours": [
@@ -9275,7 +9275,7 @@
         },
         {
             "id": "9f3f136a-5fcd-5862-aa93-446131f59c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbea010-de77-468e-be39-1717070c9303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbea010-de77-468e-be39-1717070c9303.jpg?1",
             "name": "Amareth, the Lustrous",
             "text": "Flying\nWhenever another permanent enters the battlefield under your control, look at the top card of your library. If it shares a card type with that permanent, you may reveal that card and put it into your hand.",
             "colours": [
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "ca25fdd8-2459-59b5-ad06-c7576a46e6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b597dd-f6eb-45da-977d-453e8c1433cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b597dd-f6eb-45da-977d-453e8c1433cc.jpg?1",
             "name": "Araumi of the Dead Tide",
             "text": "{T}, Exile cards from your graveyard equal to the number of opponents you have: Target creature card in your graveyard gains encore until end of turn. The encore cost is equal to its mana cost. (Exile the creature card and pay its mana cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -9358,7 +9358,7 @@
         },
         {
             "id": "b772f271-3685-5b83-bf3c-d2f1e0f11b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafb8740-1bab-4f5e-96d1-79f1f04cc0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafb8740-1bab-4f5e-96d1-79f1f04cc0d8.jpg?1",
             "name": "Archelos, Lagoon Mystic",
             "text": "As long as Archelos, Lagoon Mystic is tapped, other permanents enter the battlefield tapped.\nAs long as Archelos is untapped, other permanents enter the battlefield untapped.",
             "colours": [
@@ -9401,7 +9401,7 @@
         },
         {
             "id": "92f9d565-c101-5788-8aff-77ab21e0e60d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46b3ef3-3ba9-4da7-a675-86468a8da4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46b3ef3-3ba9-4da7-a675-86468a8da4c7.jpg?1",
             "name": "Averna, the Chaos Bloom",
             "text": "As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)",
             "colours": [
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "ed1fe3f2-0fa2-5ab3-b691-272f4fcb2389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4427e73-8c60-490d-8ae3-53e872a5163e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4427e73-8c60-490d-8ae3-53e872a5163e.jpg?1",
             "name": "Belbe, Corrupted Observer",
             "text": "At the beginning of each player's postcombat main phase, that player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)",
             "colours": [
@@ -9486,7 +9486,7 @@
         },
         {
             "id": "8f8bc5cc-80a6-5591-a149-15dfdac5acee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602cf54-3c34-4f86-8440-13ac28ace68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602cf54-3c34-4f86-8440-13ac28ace68c.jpg?1",
             "name": "Bell Borca, Spectral Sergeant",
             "text": "Note the converted mana cost of each card as it's put into exile.\nBell Borca, Spectral Sergeant's power is equal to the greatest number noted for it this turn.\nAt the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -9527,7 +9527,7 @@
         },
         {
             "id": "316658fe-3692-5597-9f3b-e0f480048c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8cd7dc-028a-4da2-b2a1-435d40cf48ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8cd7dc-028a-4da2-b2a1-435d40cf48ca.jpg?1",
             "name": "Blim, Comedic Genius",
             "text": "Flying\nWhenever Blim, Comedic Genius deals combat damage to a player, that player gains control of target permanent you control. Then each player loses life and discards cards equal to the number of permanents they control but don't own.",
             "colours": [
@@ -9567,7 +9567,7 @@
         },
         {
             "id": "dfc36f44-84ca-5336-893c-f9ad2f4473dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beafec9-24db-4903-97c1-c5fe740ada83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beafec9-24db-4903-97c1-c5fe740ada83.jpg?1",
             "name": "Captain Vargus Wrath",
             "text": "Whenever Captain Vargus Wrath attacks, Pirates you control get +1/+1 until end of turn for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -9608,7 +9608,7 @@
         },
         {
             "id": "82e67a3d-7767-59df-b2d2-1dcdb22b94ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa3b31a-b52a-43c0-9084-e0535e1bd871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa3b31a-b52a-43c0-9084-e0535e1bd871.jpg?1",
             "name": "Colfenor, the Last Yew",
             "text": "Vigilance, reach\nWhenever Colfenor, the Last Yew or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.",
             "colours": [
@@ -9651,7 +9651,7 @@
         },
         {
             "id": "044a4d3a-f1bc-5be9-9425-729a251286b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b335496-05d2-40f5-a52c-10029f7fa008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b335496-05d2-40f5-a52c-10029f7fa008.jpg?1",
             "name": "Ghen, Arcanum Weaver",
             "text": "{R}{W}{B}, {T}, Sacrifice an enchantment: Return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -9694,7 +9694,7 @@
         },
         {
             "id": "899bbb9b-a96a-5e0e-83f6-4f1e10f9298e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c171f179-9ccf-4819-915c-7f2cd3a91ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c171f179-9ccf-4819-915c-7f2cd3a91ad8.jpg?1",
             "name": "Gnostro, Voice of the Crags",
             "text": "{T}: Choose one. X is the number of spells you've cast this turn.\n\u2022 Scry X.\n\u2022 Gnostro, Voice of the Crags deals X damage to target creature.\n\u2022 You gain X life.",
             "colours": [
@@ -9736,7 +9736,7 @@
         },
         {
             "id": "27963f4c-79ea-5ffc-b78f-9c2750b6fddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b006f9-a287-4e64-915f-ca71712b8d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b006f9-a287-4e64-915f-ca71712b8d27.jpg?1",
             "name": "Gor Muldrak, Amphinologist",
             "text": "You and permanents you control have protection from Salamanders.\nAt the beginning of your end step, each player who controls the fewest creatures creates a 4/3 blue Salamander Warrior creature token.",
             "colours": [
@@ -9777,7 +9777,7 @@
         },
         {
             "id": "0b00d61f-7dab-50ae-87f1-61f49a66c0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c793d594-c319-4e97-8620-de8eddaf247d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c793d594-c319-4e97-8620-de8eddaf247d.jpg?1",
             "name": "Hamza, Guardian of Arashin",
             "text": "This spell costs {1} less to cast for each creature you control with a +1/+1 counter on it.\nCreature spells you cast cost {1} less to cast for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -9818,7 +9818,7 @@
         },
         {
             "id": "5aa3b5e8-0c4d-50fd-b42b-359987aceabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0babe-8da4-4c95-9cdf-626a5c5e2e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0babe-8da4-4c95-9cdf-626a5c5e2e5c.jpg?1",
             "name": "Hans Eriksson",
             "text": "Whenever Hans Eriksson attacks, reveal the top card of your library. If it's a creature card, put it onto the battlefield tapped and attacking defending player or a planeswalker they control. Otherwise, put that card into your hand. When you put a creature card onto the battlefield this way, it fights Hans Eriksson.",
             "colours": [
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "dea1a751-fed6-5028-8080-fcf4f4fa941b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afceb13-877a-4256-9ba6-851b6924ffd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afceb13-877a-4256-9ba6-851b6924ffd9.jpg?1",
             "name": "Imoti, Celebrant of Bounty",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nSpells you cast with converted mana cost 6 or greater have cascade.",
             "colours": [
@@ -9900,7 +9900,7 @@
         },
         {
             "id": "90ce43e8-9fb5-5ae7-90d0-410589863c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bd293b-07b9-4d7c-826a-948d5b01ab5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bd293b-07b9-4d7c-826a-948d5b01ab5e.jpg?1",
             "name": "Jared Carthalion, True Heir",
             "text": "When Jared Carthalion, True Heir enters the battlefield, target opponent becomes the monarch. You can't become the monarch this turn.\nIf damage would be dealt to Jared Carthalion while you're the monarch, prevent that damage and put that many +1/+1 counters on it.",
             "colours": [
@@ -9943,7 +9943,7 @@
         },
         {
             "id": "cefab359-da22-5336-9825-4d29307f191c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec6b2b7-625a-451d-bc0b-4456f5bf2719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec6b2b7-625a-451d-bc0b-4456f5bf2719.jpg?1",
             "name": "Juri, Master of the Revue",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Juri, Master of the Revue.\nWhen Juri dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "30a83050-6532-5c15-a64f-10d4c87ef12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99988f41-99b4-4423-be5f-9dc4ec7d813b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99988f41-99b4-4423-be5f-9dc4ec7d813b.jpg?1",
             "name": "Kangee, Sky Warden",
             "text": "Flying, vigilance\nWhenever Kangee, Sky Warden attacks, attacking creatures with flying get +2/+0 until end of turn.\nWhenever Kangee blocks, blocking creatures with flying get +0/+2 until end of turn.",
             "colours": [
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "73a0eba2-d474-56e7-bcdd-6bbec7216379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f571fef1-1fd2-4355-b803-5edccb6f4b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f571fef1-1fd2-4355-b803-5edccb6f4b94.jpg?1",
             "name": "Kwain, Itinerant Meddler",
             "text": "{T}: Each player may draw a card, then each player who drew a card this way gains 1 life.",
             "colours": [
@@ -10066,7 +10066,7 @@
         },
         {
             "id": "8003cd1e-c697-556a-b093-e95035447b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d3484f-abd1-43fe-99f8-e0fa0a7b6692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d3484f-abd1-43fe-99f8-e0fa0a7b6692.jpg?1",
             "name": "Lathiel, the Bounteous Dawn",
             "text": "Lifelink\nAt the beginning of each end step, if you gained life this turn, distribute up to that many +1/+1 counters among any number of other target creatures.",
             "colours": [
@@ -10106,7 +10106,7 @@
         },
         {
             "id": "c3d19769-e390-5ce3-aa5b-18a978fd310b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32453a1-1fd9-4bda-aaa8-7c287e4c2587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32453a1-1fd9-4bda-aaa8-7c287e4c2587.jpg?1",
             "name": "Liesa, Shroud of Dusk",
             "text": "Rather than pay {2} for each previous time you've cast this spell from the command zone this game, pay 2 life that many times.\nFlying, lifelink\nWhenever a player casts a spell, they lose 2 life.",
             "colours": [
@@ -10146,7 +10146,7 @@
         },
         {
             "id": "c380b206-8845-5af8-9c9d-2bc89df9089b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255848-3112-4508-a66a-d3101a53057e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73255848-3112-4508-a66a-d3101a53057e.jpg?1",
             "name": "Nevinyrral, Urborg Tyrant",
             "text": "Hexproof from artifacts, creatures, and enchantments\nWhen Nevinyrral, Urborg Tyrant enters the battlefield, create a tapped 2/2 black Zombie creature token for each creature that died this turn.\nWhen Nevinyrral dies, you may pay {1}. When you do, destroy all artifacts, creatures, and enchantments.",
             "colours": [
@@ -10189,7 +10189,7 @@
         },
         {
             "id": "08fcc5d2-bbcf-56a9-946f-9417f92d44e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cfc97a-3c8a-4d44-846b-7a523dc11878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cfc97a-3c8a-4d44-846b-7a523dc11878.jpg?1",
             "name": "Nymris, Oona's Trickster",
             "text": "Flash\nFlying\nWhenever you cast your first spell during each opponent's turn, look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
             "colours": [
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "518599e3-c707-5600-973d-da0ad158efeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdb335d-3e45-4dd5-9e3e-c50ca0a4dfb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdb335d-3e45-4dd5-9e3e-c50ca0a4dfb6.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "{T}: The player whose turn it is may end the turn. (Exile all spells and abilities from the stack. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -10273,7 +10273,7 @@
         },
         {
             "id": "5d5612f7-e556-550a-9de9-8ed745b35f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90307dd6-196d-4d51-9b3f-6ff339882d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90307dd6-196d-4d51-9b3f-6ff339882d31.jpg?1",
             "name": "Reyav, Master Smith",
             "text": "Whenever a creature you control that's enchanted or equipped attacks, that creature gains double strike until end of turn.",
             "colours": [
@@ -10314,7 +10314,7 @@
         },
         {
             "id": "fd1322ce-57b8-511e-9b39-64ff84ebda86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d6363-ebe1-4a1a-b4e6-7bd53d878527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d6363-ebe1-4a1a-b4e6-7bd53d878527.jpg?1",
             "name": "Thalisse, Reverent Medium",
             "text": "At the beginning of each end step, create X 1/1 white Spirit creature tokens with flying, where X is the number of tokens you created this turn.",
             "colours": [
@@ -10355,7 +10355,7 @@
         },
         {
             "id": "d2db6a5d-bf0a-5683-81a7-10a34da2bfe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf6b42f-8eb7-4b40-a4e6-8775ee208f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf6b42f-8eb7-4b40-a4e6-8775ee208f7e.jpg?1",
             "name": "Tuya Bearclaw",
             "text": "Whenever Tuya Bearclaw attacks, it gets +X/+X until end of turn, where X is the greatest power among other creatures you control.",
             "colours": [
@@ -10396,7 +10396,7 @@
         },
         {
             "id": "0fba90e8-f8a6-534b-8d0c-096f5ff4d116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8a1f5-6260-47fa-a649-43711ec5bbeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8a1f5-6260-47fa-a649-43711ec5bbeb.jpg?1",
             "name": "Yurlok of Scorch Thrash",
             "text": "Vigilance\nA player losing unspent mana causes that player to lose that much life.\n{1}, {T}: Each player adds {B}{R}{G}.",
             "colours": [
@@ -10439,7 +10439,7 @@
         },
         {
             "id": "602a6f5f-f8f6-5ae9-804b-7ef20433169e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b1455e-b9c2-4501-a24f-b50534466c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b1455e-b9c2-4501-a24f-b50534466c31.jpg?1",
             "name": "Zara, Renegade Recruiter",
             "text": "Flying\nWhenever Zara, Renegade Recruiter attacks, look at defending player's hand. You may put a creature card from it onto the battlefield under your control tapped and attacking that player or a planeswalker they control. Return that creature to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -10480,7 +10480,7 @@
         },
         {
             "id": "f9bb6a1c-9ef8-5e4d-be64-42292affdba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de53345-5809-4704-bd60-682b0c3c3999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de53345-5809-4704-bd60-682b0c3c3999.jpg?1",
             "name": "Amorphous Axe",
             "text": "Equipped creature gets +3/+0 and is every creature type.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10510,7 +10510,7 @@
         },
         {
             "id": "41fe3375-7a5f-5577-8d74-20b70bf358cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92824de1-23f2-44c6-b8ab-46db94b8f79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92824de1-23f2-44c6-b8ab-46db94b8f79e.jpg?1",
             "name": "Angelic Armaments",
             "text": "Equipped creature gets +2/+2, has flying, and is a white Angel in addition to its other colors and types.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10540,7 +10540,7 @@
         },
         {
             "id": "811f0a64-cff0-5a50-817d-b9f26b22b409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40458c-7f3a-4fa6-976f-be1f7a336fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40458c-7f3a-4fa6-976f-be1f7a336fdc.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -10570,7 +10570,7 @@
         },
         {
             "id": "506cecee-cca4-5a17-8f7e-53266ee7016a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ae93e-6094-483d-b2c0-ae117ad01293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ae93e-6094-483d-b2c0-ae117ad01293.jpg?1",
             "name": "Armillary Sphere",
             "text": "{2}, {T}, Sacrifice Armillary Sphere: Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library.",
             "colours": [],
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "2a10aa59-98a1-5f53-bb5e-37559cbf1f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703a03ac-5bb5-4e36-ab9b-a5c007ffc03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703a03ac-5bb5-4e36-ab9b-a5c007ffc03d.jpg?1",
             "name": "Armory of Iroas",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "b3f6eea3-30c4-574b-9a21-b2334e3400c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c9b4fb-cfb6-4e5a-b23a-9aad9f69710e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c9b4fb-cfb6-4e5a-b23a-9aad9f69710e.jpg?1",
             "name": "Bladegriff Prototype",
             "text": "Flying\nWhenever Bladegriff Prototype deals combat damage to a player, destroy target nonland permanent of that player's choice that one of your opponents controls.",
             "colours": [],
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "650064ff-f6c6-5209-aed8-b2253ae15fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0380a4-225f-4a80-8c8b-d0f7e54f1626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0380a4-225f-4a80-8c8b-d0f7e54f1626.jpg?1",
             "name": "Brass Herald",
             "text": "As Brass Herald enters the battlefield, choose a creature type.\nWhen Brass Herald enters the battlefield, reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order.\nCreatures of the chosen type get +1/+1.",
             "colours": [],
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "322ac615-27a4-5378-b38a-b4c958ca1f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccb765-8f97-4806-87ef-55415ab09d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dccb765-8f97-4806-87ef-55415ab09d9b.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "228dd3fc-8049-5f9a-beb1-671c8b93be32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99f4cd-7f6d-4f1a-a1d9-f8c3b6645038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d99f4cd-7f6d-4f1a-a1d9-f8c3b6645038.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -10755,7 +10755,7 @@
         },
         {
             "id": "07390793-a3da-5efc-9fcc-a74ea8ada2fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5a3293-f3e7-4f68-af6a-b478959226c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5a3293-f3e7-4f68-af6a-b478959226c1.jpg?1",
             "name": "Codex Shredder",
             "text": "{T}: Target player mills a card. (They put the top card of their library into their graveyard.)\n{5}, {T}, Sacrifice Codex Shredder: Return target card from your graveyard to your hand.",
             "colours": [],
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "d46eaf32-3cb7-5892-ab91-bf1d8c8e9337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19992dbd-7a6a-43d3-b1db-01716b2eed27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19992dbd-7a6a-43d3-b1db-01716b2eed27.jpg?1",
             "name": "Commander's Plate",
             "text": "Equipped creature gets +3/+3 and has protection from each color that's not in your commander's color identity.\nEquip commander {3}\nEquip {5}",
             "colours": [],
@@ -10815,7 +10815,7 @@
         },
         {
             "id": "8236412e-3921-5f02-b5e6-04af3d78c402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c16a5-bc50-406f-9ab1-e8346acffbca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c16a5-bc50-406f-9ab1-e8346acffbca.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -10845,7 +10845,7 @@
         },
         {
             "id": "05a374b3-06d3-53cb-bcd7-bcec2d670546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a0b45f-d044-4d59-81fd-c2683beca401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a0b45f-d044-4d59-81fd-c2683beca401.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {C}{C}{C}.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "b845b1d7-5205-5424-9642-549635b88b39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875df3ef-fab4-455f-bfdb-8f6361b27bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875df3ef-fab4-455f-bfdb-8f6361b27bf6.jpg?1",
             "name": "Filigree Familiar",
             "text": "When Filigree Familiar enters the battlefield, you gain 2 life.\nWhen Filigree Familiar dies, draw a card.",
             "colours": [],
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "a87daf0e-14b7-5446-889d-157b129cfbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65f1fa-4196-40ba-8ca3-e68560fef392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65f1fa-4196-40ba-8ca3-e68560fef392.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -10934,7 +10934,7 @@
         },
         {
             "id": "dfc82532-0638-5003-ac71-b8d65a7dcdb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca62547-7dd3-4bb7-be5f-92c4fa51904d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca62547-7dd3-4bb7-be5f-92c4fa51904d.jpg?1",
             "name": "Foundry Inspector",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [],
@@ -10965,7 +10965,7 @@
         },
         {
             "id": "02a4bb24-63d8-5396-aefe-41810824f63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a3345-2507-46ed-bdb3-c5c45d17da51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441a3345-2507-46ed-bdb3-c5c45d17da51.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -10996,7 +10996,7 @@
         },
         {
             "id": "b177ef11-5e07-51b5-8b10-d364dbc9ee74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d023d44-482e-4f60-b9b1-eede9bfb732f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d023d44-482e-4f60-b9b1-eede9bfb732f.jpg?1",
             "name": "Grafted Wargear",
             "text": "Equipped creature gets +3/+2.\nWhenever Grafted Wargear becomes unattached from a permanent, sacrifice that permanent.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11026,7 +11026,7 @@
         },
         {
             "id": "f8092d75-5b2c-5e4f-888a-f3c133706334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9a637-352a-45bd-a43a-6406f9da56af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9a637-352a-45bd-a43a-6406f9da56af.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "eb02e267-3318-5cb8-bdf2-f518ff2dfcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e982c4-19ef-40d6-a807-fd16c31e63db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e982c4-19ef-40d6-a807-fd16c31e63db.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11090,7 +11090,7 @@
         },
         {
             "id": "986d7e12-0a99-5049-b12e-fa1208b85ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6affd9c6-f7ab-488e-85fa-2a3a48383414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6affd9c6-f7ab-488e-85fa-2a3a48383414.jpg?1",
             "name": "Horizon Stone",
             "text": "If you would lose unspent mana, that mana becomes colorless instead.",
             "colours": [],
@@ -11120,7 +11120,7 @@
         },
         {
             "id": "93ec73ac-b93a-5d07-8c1b-64458ea1bdd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b54aaa-93e2-4f8b-8d06-2a848498d1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b54aaa-93e2-4f8b-8d06-2a848498d1fd.jpg?1",
             "name": "Howling Golem",
             "text": "Whenever Howling Golem attacks or blocks, each player draws a card.",
             "colours": [],
@@ -11151,7 +11151,7 @@
         },
         {
             "id": "62f9a316-960e-5163-97ff-3ea4936feb07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255db4-9c46-4971-bf89-f9014602999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255db4-9c46-4971-bf89-f9014602999c.jpg?1",
             "name": "Ingenuity Engine",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\n{1}, {T}, Sacrifice an artifact: Return target artifact you control to its owner's hand.",
             "colours": [],
@@ -11179,7 +11179,7 @@
         },
         {
             "id": "bd5fdd3b-f2c5-530f-a6c0-dc527369e384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24814552-c407-447a-a782-22c69c5b912b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24814552-c407-447a-a782-22c69c5b912b.jpg?1",
             "name": "Jalum Tome",
             "text": "{2}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -11207,7 +11207,7 @@
         },
         {
             "id": "10008e9d-123f-5892-898d-31393dd8762f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7de64b-3dc8-47dd-8999-4353b5a3a06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7de64b-3dc8-47dd-8999-4353b5a3a06f.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -11237,7 +11237,7 @@
         },
         {
             "id": "d6d1c9d0-d3b1-5aed-bbdf-0acd89395d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e95365a8-514a-4212-9d65-b0cdf2cd06e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e95365a8-514a-4212-9d65-b0cdf2cd06e5.jpg?1",
             "name": "Loreseeker's Stone",
             "text": "{3}, {T}: Draw three cards. This ability costs {1} more to activate for each card in your hand.",
             "colours": [],
@@ -11265,7 +11265,7 @@
         },
         {
             "id": "ae26004a-a9be-5f2e-a23e-b4472401e82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c200239c-d28e-4c55-a7bc-64a1d138cc2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c200239c-d28e-4c55-a7bc-64a1d138cc2f.jpg?1",
             "name": "Lumengrid Gargoyle",
             "text": "Flying",
             "colours": [],
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "a681056b-3fcb-545b-bc65-10a4b7ec63b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322491d2-d082-4d38-8d81-8588c011e725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322491d2-d082-4d38-8d81-8588c011e725.jpg?1",
             "name": "Maelstrom Colossus",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [],
@@ -11327,7 +11327,7 @@
         },
         {
             "id": "1ffe42ea-3d56-5b5e-9173-db0ed39736f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72125260-f4b7-4317-99f1-cbb78646296d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72125260-f4b7-4317-99f1-cbb78646296d.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -11357,7 +11357,7 @@
         },
         {
             "id": "7c6c03b9-3ba9-5b06-abef-e917bef1ae62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba275c02-8581-46a0-9c7c-8baa0fdb4982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba275c02-8581-46a0-9c7c-8baa0fdb4982.jpg?1",
             "name": "Mask of Memory",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw two cards. If you do, discard a card.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "23643e6e-5a26-50c4-b09f-743c73e9f584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b5324-bd25-4651-bcbc-5439b74df361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4b5324-bd25-4651-bcbc-5439b74df361.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -11420,7 +11420,7 @@
         },
         {
             "id": "f1d1aaef-7339-5bde-b728-135b7ea4c7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a167f09d-b2dd-4365-8217-e7138d96304a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a167f09d-b2dd-4365-8217-e7138d96304a.jpg?1",
             "name": "Mindless Automaton",
             "text": "Mindless Automaton enters the battlefield with two +1/+1 counters on it.\n{1}, Discard a card: Put a +1/+1 counter on Mindless Automaton.\nRemove two +1/+1 counters from Mindless Automaton: Draw a card.",
             "colours": [],
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "b5a7a6ec-7dd2-53b3-a55f-876e9c688b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8ea247-5529-4948-8c81-0f413aedc82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8ea247-5529-4948-8c81-0f413aedc82e.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -11481,7 +11481,7 @@
         },
         {
             "id": "bb446cac-0880-5607-b928-af497264b1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7c8a-ed88-4f4f-9e1c-d97bde20e40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7c8a-ed88-4f4f-9e1c-d97bde20e40c.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -11511,7 +11511,7 @@
         },
         {
             "id": "6f6a14f6-298c-55f0-b416-758f171a9651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc89a7c-cdb9-45cd-a9e7-d66dd2066d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc89a7c-cdb9-45cd-a9e7-d66dd2066d1d.jpg?1",
             "name": "Pennon Blade",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "47b367b0-ffea-514a-8ccc-7474cb2c23df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a15c8ef-04ad-4aab-a7f1-c7a90c10eb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a15c8ef-04ad-4aab-a7f1-c7a90c10eb50.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr dies, it deals 2 damage to any target.",
             "colours": [],
@@ -11573,7 +11573,7 @@
         },
         {
             "id": "8205c799-9253-5d4c-8d19-483aa6323015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a6582-2281-4f75-8103-80fcb2846805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a6582-2281-4f75-8103-80fcb2846805.jpg?1",
             "name": "Phyrexian Triniform",
             "text": "When Phyrexian Triniform dies, create three 3/3 colorless Golem artifact creature tokens.\nEncore {1}2 ({1}2, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [],
@@ -11607,7 +11607,7 @@
         },
         {
             "id": "efbcff07-a0d4-5b6e-8f86-7bd317096f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f48d5f-7e01-424d-8e86-1d4a32f0ef34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f48d5f-7e01-424d-8e86-1d4a32f0ef34.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -11638,7 +11638,7 @@
         },
         {
             "id": "89f20dea-a7d4-54d7-80bd-7a98b03d7eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dc0635-0cc4-419e-ab64-c07a69f34f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dc0635-0cc4-419e-ab64-c07a69f34f75.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When Pirate's Cutlass enters the battlefield, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11668,7 +11668,7 @@
         },
         {
             "id": "e64b8c38-e501-53e7-b827-f636e3e4bb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14602fed-8666-4884-8fca-13529578f9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14602fed-8666-4884-8fca-13529578f9e2.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -11696,7 +11696,7 @@
         },
         {
             "id": "adc51a59-4f28-597f-8b6f-cde3abc3be31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838ffc87-517a-4d94-8ce0-bc9ed01ecc52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838ffc87-517a-4d94-8ce0-bc9ed01ecc52.jpg?1",
             "name": "Rings of Brighthearth",
             "text": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [],
@@ -11726,7 +11726,7 @@
         },
         {
             "id": "cc14b4b1-3ee2-5a66-839a-97f69946a307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b7213-f0db-4ef9-aab7-37028f9479af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b7213-f0db-4ef9-aab7-37028f9479af.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "23945b88-8eac-5d21-9437-7a927abfbbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaaa58d-89bb-4cb3-96a6-b480e6f6954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaaa58d-89bb-4cb3-96a6-b480e6f6954e.jpg?1",
             "name": "Scroll Rack",
             "text": "{1}, {T}: Exile any number of cards from your hand face down. Put that many cards from the top of your library into your hand. Then look at the exiled cards and put them on top of your library in any order.",
             "colours": [],
@@ -11787,7 +11787,7 @@
         },
         {
             "id": "d2bab3b4-c3c6-597a-9bf6-9446f1aca0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09bcfd12-6b50-4fdf-9bda-6d52bba2f897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09bcfd12-6b50-4fdf-9bda-6d52bba2f897.jpg?1",
             "name": "Seer's Lantern",
             "text": "{T}: Add {C}.\n{2}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -11815,7 +11815,7 @@
         },
         {
             "id": "aaad3862-c813-5fbc-bd42-252b68289e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7647cc5e-67c4-44e6-8674-f980de482a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7647cc5e-67c4-44e6-8674-f980de482a37.jpg?1",
             "name": "Shimmer Myr",
             "text": "Flash\nYou may cast artifact spells as though they had flash.",
             "colours": [],
@@ -11846,7 +11846,7 @@
         },
         {
             "id": "bf899cdf-63a5-55d9-a2d4-9ea40473e9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c0e608-0208-408a-b473-1e54caa96cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c0e608-0208-408a-b473-1e54caa96cea.jpg?1",
             "name": "Sisay's Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -11874,7 +11874,7 @@
         },
         {
             "id": "3f623eaa-3345-54df-b6eb-dfa720e2e4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc62a1e-830b-4b07-91e4-303e66d93648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc62a1e-830b-4b07-91e4-303e66d93648.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -11904,7 +11904,7 @@
         },
         {
             "id": "8d3061b0-d32b-5f08-b5dd-5e050e03b370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dd6c9-628b-4dde-a385-604501dd0979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dd6c9-628b-4dde-a385-604501dd0979.jpg?1",
             "name": "Spectral Searchlight",
             "text": "{T}: Choose a player. That player adds one mana of any color they choose.",
             "colours": [],
@@ -11932,7 +11932,7 @@
         },
         {
             "id": "44832978-c6af-5ca4-9ef6-15a204d31089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde838c8-2f32-4e7d-a236-0bc42dd7abd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde838c8-2f32-4e7d-a236-0bc42dd7abd9.jpg?1",
             "name": "Staff of Domination",
             "text": "{1}: Untap Staff of Domination.\n{2}, {T}: You gain 1 life.\n{3}, {T}: Untap target creature.\n{4}, {T}: Tap target creature.\n{5}, {T}: Draw a card.",
             "colours": [],
@@ -11962,7 +11962,7 @@
         },
         {
             "id": "0cb7e675-9419-53fa-9208-4bc311dce5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41017b24-957b-403d-b417-d84ad2624794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41017b24-957b-403d-b417-d84ad2624794.jpg?1",
             "name": "Staunch Throneguard",
             "text": "Vigilance\nWhen Staunch Throneguard enters the battlefield, you become the monarch.",
             "colours": [],
@@ -11993,7 +11993,7 @@
         },
         {
             "id": "3bfe1300-4f02-5fd5-83c3-42257c2e54b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d346c67-744c-4605-be62-18d794e83049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d346c67-744c-4605-be62-18d794e83049.jpg?1",
             "name": "Sunset Pyramid",
             "text": "Sunset Pyramid enters the battlefield with three brick counters on it.\n{2}, {T}, Remove a brick counter from Sunset Pyramid: Draw a card.\n{2}, {T}: Scry 1.",
             "colours": [],
@@ -12021,7 +12021,7 @@
         },
         {
             "id": "47272c45-37bb-52ed-a8a6-2e570670a6b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58ab310-cbee-4f0c-9819-a2e2121932ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58ab310-cbee-4f0c-9819-a2e2121932ff.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -12051,7 +12051,7 @@
         },
         {
             "id": "4ddd4686-06b0-5eac-9138-e83885d0f075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe257c5-d2f8-4a4f-bf74-f6dc4b6861e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe257c5-d2f8-4a4f-bf74-f6dc4b6861e4.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -12079,7 +12079,7 @@
         },
         {
             "id": "aaba24c3-78f5-5e6a-aa61-737df54716de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9387e8f-0e72-4212-81c8-e64050700c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9387e8f-0e72-4212-81c8-e64050700c52.jpg?1",
             "name": "Workshop Assistant",
             "text": "When Workshop Assistant dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -12110,7 +12110,7 @@
         },
         {
             "id": "da0dcbf5-7187-550a-bce0-8608e701133b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bec6181-e214-4833-8c2f-8a10d59b2879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bec6181-e214-4833-8c2f-8a10d59b2879.jpg?1",
             "name": "Command Beacon",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Command Beacon: Put your commander into your hand from the command zone.",
             "colours": [],
@@ -12140,7 +12140,7 @@
         },
         {
             "id": "d6d8df83-6867-5a62-b9ce-ea4a147b89e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86424491-a372-40c4-bfb5-faa2b2d41d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86424491-a372-40c4-bfb5-faa2b2d41d4c.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -12171,7 +12171,7 @@
         },
         {
             "id": "26b6712d-7345-5472-b8e0-6c15088f79d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c8d290-b5d2-412c-8db9-5a6246f430e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c8d290-b5d2-412c-8db9-5a6246f430e8.jpg?1",
             "name": "Guildless Commons",
             "text": "Guildless Commons enters the battlefield tapped.\nWhen Guildless Commons enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "b81dff1b-08f9-5e26-8438-eb8f53a38034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d68a79-00b5-453f-9fdc-92d9dbfb90b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d68a79-00b5-453f-9fdc-92d9dbfb90b2.jpg?1",
             "name": "Opal Palace",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
             "colours": [],
@@ -12229,7 +12229,7 @@
         },
         {
             "id": "3170b46a-6136-5829-89bf-9ba80ef1d5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1852c1e1-fbea-4b14-9927-4b1849f9b8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1852c1e1-fbea-4b14-9927-4b1849f9b8a3.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -12259,7 +12259,7 @@
         },
         {
             "id": "7ab9b79e-6510-5d02-95ce-97167a40c539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e69910-0d90-48a0-af29-3cddaeec5151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e69910-0d90-48a0-af29-3cddaeec5151.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "9da2c892-df79-5164-8ec9-c782fa51a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef4b15-efab-4255-ac2d-7794f253aa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ef4b15-efab-4255-ac2d-7794f253aa52.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -12322,7 +12322,7 @@
         },
         {
             "id": "5e2abcdd-aa15-54e0-b70e-c9e656f80835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6f1453-fe93-4a29-965c-5f867a81e8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6f1453-fe93-4a29-965c-5f867a81e8b3.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -12355,7 +12355,7 @@
         },
         {
             "id": "06e49e8e-e561-5fb3-8f55-b9bcb7762fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8b3d63-db84-4aa0-a529-f3c128fae964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8b3d63-db84-4aa0-a529-f3c128fae964.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -12386,7 +12386,7 @@
         },
         {
             "id": "d6824f27-3f75-5012-8d4d-295e3f1cf0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15c58c0-4d42-488e-bb9d-7a550d9ea5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15c58c0-4d42-488e-bb9d-7a550d9ea5e6.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -12419,7 +12419,7 @@
         },
         {
             "id": "f8aa961e-8cf6-5446-b900-a576455f4290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df64c9cf-17de-44f3-831d-ba09661f2308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df64c9cf-17de-44f3-831d-ba09661f2308.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -12452,7 +12452,7 @@
         },
         {
             "id": "8ee91575-6005-5571-940f-8bb02226ade8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e144ae1-500d-4485-b476-5783b14380d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e144ae1-500d-4485-b476-5783b14380d9.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -12485,7 +12485,7 @@
         },
         {
             "id": "655bd629-d140-5cfc-925c-a39f2487a197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d6ce7c-5dc8-449b-acbd-db259ae687ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d6ce7c-5dc8-449b-acbd-db259ae687ed.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -12515,7 +12515,7 @@
         },
         {
             "id": "e09f4e6f-a618-5a8d-814e-8391cdec5566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5ada8c-98f2-4f9c-bcb5-dfa4f804fbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5ada8c-98f2-4f9c-bcb5-dfa4f804fbe6.jpg?1",
             "name": "Wyleth, Soul of Steel",
             "text": "Trample\nWhenever Wyleth, Soul of Steel attacks, draw a card for each Aura and Equipment attached to it.",
             "colours": [
@@ -12553,7 +12553,7 @@
         },
         {
             "id": "9dd97b88-1a61-571b-ae64-9f244c95d51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de08a92-9b60-4672-9f3b-3ceb53ca82ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de08a92-9b60-4672-9f3b-3ceb53ca82ca.jpg?1",
             "name": "Timely Ward",
             "text": "You may cast this spell as though it had flash if it targets a commander.\nEnchant creature\nEnchanted creature has indestructible.",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "b7a0fdce-ec99-517f-8950-16a8f98a1d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d276fe-5f2b-41aa-80fa-64d3b60fd54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d276fe-5f2b-41aa-80fa-64d3b60fd54f.jpg?1",
             "name": "Blazing Sunsteel",
             "text": "Equipped creature gets +1/+0 for each opponent you have.\nWhenever equipped creature is dealt damage, it deals that much damage to any target.\nEquip {4}",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "e183c2a8-549b-59d5-9063-f14bb619ca65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d607b003-6b48-429c-a7fd-45b8dd1bb4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d607b003-6b48-429c-a7fd-45b8dd1bb4f9.jpg?1",
             "name": "Aesi, Tyrant of Gyre Strait",
             "text": "You may play an additional land on each of your turns.\nWhenever a land enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "cb556a9c-201f-530c-a2c7-b76e27961a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909dc123-8234-4e81-bb7b-77404d94a87c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909dc123-8234-4e81-bb7b-77404d94a87c.jpg?1",
             "name": "Trench Behemoth",
             "text": "Return a land you control to its owner's hand: Untap Trench Behemoth. It gains hexproof until end of turn.\nWhenever a land enters the battlefield under your control, target creature an opponent controls attacks during its controller's next combat phase if able.",
             "colours": [
@@ -12689,7 +12689,7 @@
         },
         {
             "id": "cbfc34e7-8a55-564e-86b4-1de50f6417db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe8096b-332a-4832-b957-7a35bb350e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe8096b-332a-4832-b957-7a35bb350e4e.jpg?1",
             "name": "Stumpsquall Hydra",
             "text": "When Stumpsquall Hydra enters the battlefield, distribute X +1/+1 counters among it and any number of commanders.",
             "colours": [
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "9cf27b96-3144-50a5-a2f3-0d689e8816fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cffed4c-4e2b-414a-9b20-90ce21b47d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cffed4c-4e2b-414a-9b20-90ce21b47d16.jpg?1",
             "name": "Elder Deep-Fiend",
             "text": "Flash\nEmerge {5}{U}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast this spell, tap up to four target permanents.",
             "colours": [],
@@ -12754,7 +12754,7 @@
         },
         {
             "id": "d3d0b30f-de8c-5864-badf-ae741ea32b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dab28f-d0d0-49ef-9326-34fb348a7853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dab28f-d0d0-49ef-9326-34fb348a7853.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -12785,7 +12785,7 @@
         },
         {
             "id": "4f9a31e4-172c-515f-b7ce-149029521873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5391bc-6b50-49b0-96a1-df944a55d62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5391bc-6b50-49b0-96a1-df944a55d62e.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "c051fd0a-145f-5cd4-85dc-b1da6904cd4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc47e26a-2ba6-4b7a-bb03-43f7ecb9012e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc47e26a-2ba6-4b7a-bb03-43f7ecb9012e.jpg?1",
             "name": "Dawn Charm",
             "text": "Choose one \u2014\n\u2022 Prevent all combat damage that would be dealt this turn.\n\u2022 Regenerate target creature. (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)\n\u2022 Counter target spell that targets you.",
             "colours": [
@@ -12852,7 +12852,7 @@
         },
         {
             "id": "da5f979f-17da-5711-ad9c-c16e281b5536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba38105-bada-449a-ab2f-3d6db2764a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba38105-bada-449a-ab2f-3d6db2764a06.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -12883,7 +12883,7 @@
         },
         {
             "id": "649121d0-95d8-5c2f-9e4a-f066d528d6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eaee28-b7c6-4d5f-b181-61e0c68988aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eaee28-b7c6-4d5f-b181-61e0c68988aa.jpg?1",
             "name": "Faith Unbroken",
             "text": "Enchant creature you control\nWhen Faith Unbroken enters the battlefield, exile target creature an opponent controls until Faith Unbroken leaves the battlefield.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -12916,7 +12916,7 @@
         },
         {
             "id": "be9daf30-1883-5434-88c7-8e139f0511cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6501e4e-8188-44ed-b661-55fe32bc7fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6501e4e-8188-44ed-b661-55fe32bc7fec.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -12949,7 +12949,7 @@
         },
         {
             "id": "039b4036-830a-5d41-ac0e-8291aa771712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26296a96-bdca-405f-ab06-e280b42c4ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26296a96-bdca-405f-ab06-e280b42c4ab9.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -12982,7 +12982,7 @@
         },
         {
             "id": "0061f6d5-7e4d-5314-83db-dd9c2914ef24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2841f538-9686-423f-ac30-0580665112e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2841f538-9686-423f-ac30-0580665112e5.jpg?1",
             "name": "Ironclad Slayer",
             "text": "When Ironclad Slayer enters the battlefield, you may return target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -13016,7 +13016,7 @@
         },
         {
             "id": "a8fc49e5-c3f4-5b67-b254-bc2935e09391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e2670-90ff-4b26-a5d6-b74f465b6c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e2670-90ff-4b26-a5d6-b74f465b6c9c.jpg?1",
             "name": "Kor Cartographer",
             "text": "When Kor Cartographer enters the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -13052,7 +13052,7 @@
         },
         {
             "id": "d91c98d0-0d94-58c0-b2a1-c1050d74fc39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f30b99-5177-48e9-be0a-ab04bbc4586b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f30b99-5177-48e9-be0a-ab04bbc4586b.jpg?1",
             "name": "Martial Coup",
             "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -13083,7 +13083,7 @@
         },
         {
             "id": "72d899dd-028f-50e6-bf1d-a690a4e03648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b429bd-d7da-45f5-988b-7eed0d3efeaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b429bd-d7da-45f5-988b-7eed0d3efeaa.jpg?1",
             "name": "Odric, Lunarch Marshal",
             "text": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
             "colours": [
@@ -13119,7 +13119,7 @@
         },
         {
             "id": "9821aa88-2d69-5585-8897-548a160a9d04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57c65-5010-4472-b877-42daf2f15af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57c65-5010-4472-b877-42daf2f15af2.jpg?1",
             "name": "On Serra's Wings",
             "text": "Enchant creature\nEnchanted creature is legendary, gets +1/+1, and has flying, vigilance, and lifelink.",
             "colours": [
@@ -13154,7 +13154,7 @@
         },
         {
             "id": "1652156f-edf3-5f21-b137-adf2758d1fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cf5b23-dad0-4d4f-bd73-0133dbc9f8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cf5b23-dad0-4d4f-bd73-0133dbc9f8e1.jpg?1",
             "name": "Oreskos Explorer",
             "text": "When Oreskos Explorer enters the battlefield, search your library for up to X Plains cards, where X is the number of players who control more lands than you. Reveal those cards, put them into your hand, then shuffle your library.",
             "colours": [
@@ -13188,7 +13188,7 @@
         },
         {
             "id": "a93967b3-2a61-594a-97b7-65002f01d271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae71b0a7-90c6-48cd-808c-c6c430dcba9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae71b0a7-90c6-48cd-808c-c6c430dcba9c.jpg?1",
             "name": "Relic Seeker",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhen Relic Seeker becomes renowned, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -13222,7 +13222,7 @@
         },
         {
             "id": "5d1ddb47-9191-5527-a695-458bf67ec2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c342d-ae5e-492e-87e2-1149457b80ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c342d-ae5e-492e-87e2-1149457b80ab.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -13256,7 +13256,7 @@
         },
         {
             "id": "2dacceab-8ccd-52cc-a7bb-ec0a90bc79a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531da950-dc96-4050-94a8-e01b73ddd965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531da950-dc96-4050-94a8-e01b73ddd965.jpg?1",
             "name": "Sigarda's Aid",
             "text": "You may cast Aura and Equipment spells as though they had flash.\nWhenever an Equipment enters the battlefield under your control, you may attach it to target creature you control.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "cd91f13c-1354-57c8-9018-07bbb5354e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5fdaa3-7879-4fa3-a157-60c7890a660a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5fdaa3-7879-4fa3-a157-60c7890a660a.jpg?1",
             "name": "Spirit Mantle",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has protection from creatures.",
             "colours": [
@@ -13320,7 +13320,7 @@
         },
         {
             "id": "f9b5b1df-a6cc-5bd0-a53c-925a6263325c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ab1ef1-f4e8-461e-801a-a498e4946fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ab1ef1-f4e8-461e-801a-a498e4946fa1.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
             "colours": [
@@ -13356,7 +13356,7 @@
         },
         {
             "id": "92c30360-e72a-5eb6-8148-44eba77bbe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b4177-e47c-4dde-9ead-31b7602065ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b4177-e47c-4dde-9ead-31b7602065ec.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -13389,7 +13389,7 @@
         },
         {
             "id": "46909e73-9dd9-5f7c-8ac0-083024bc7e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2b5f7d-7105-4af3-aa0b-6f3cfb986ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2b5f7d-7105-4af3-aa0b-6f3cfb986ae0.jpg?1",
             "name": "Unbreakable Formation",
             "text": "Creatures you control gain indestructible until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, put a +1/+1 counter on each of those creatures and they gain vigilance until end of turn.",
             "colours": [
@@ -13420,7 +13420,7 @@
         },
         {
             "id": "af88e2d0-5875-5485-b296-62b21d010f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829710f9-6554-4391-bdb1-2ccdefc2caf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829710f9-6554-4391-bdb1-2ccdefc2caf5.jpg?1",
             "name": "Unquestioned Authority",
             "text": "Enchant creature\nWhen Unquestioned Authority enters the battlefield, draw a card.\nEnchanted creature has protection from creatures.",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "78391deb-ee03-5958-a30d-a61b42fbf653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87066f6-a5c3-4855-bee5-05931f421d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87066f6-a5c3-4855-bee5-05931f421d34.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -13484,7 +13484,7 @@
         },
         {
             "id": "352a2539-555e-5079-b77c-842faa7c7be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029e0450-ceb1-484d-8a18-e769defac428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029e0450-ceb1-484d-8a18-e769defac428.jpg?1",
             "name": "White Sun's Zenith",
             "text": "Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its owner's library.",
             "colours": [
@@ -13515,7 +13515,7 @@
         },
         {
             "id": "69059008-b6c9-5e0c-9de7-38b3cc4ffcc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b91ab9-a03b-4036-9ad4-5c9f7743cd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b91ab9-a03b-4036-9ad4-5c9f7743cd52.jpg?1",
             "name": "Winds of Rath",
             "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
             "colours": [
@@ -13546,7 +13546,7 @@
         },
         {
             "id": "57b292e9-3fc6-54e3-90a4-902a7fb5365b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a531642c-58dd-4f72-ae2b-38e005ae3a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a531642c-58dd-4f72-ae2b-38e005ae3a6b.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -13579,7 +13579,7 @@
         },
         {
             "id": "78731243-149d-5a54-a75d-23c20a91fe89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fcefbc-211f-4ad2-8866-9514f09cd3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fcefbc-211f-4ad2-8866-9514f09cd3b3.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless they discard a land card.",
             "colours": [
@@ -13610,7 +13610,7 @@
         },
         {
             "id": "d4b95cdb-1704-5939-b4e7-c0dca75555a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce30f926-bc06-46ee-9f35-0cdf09a67043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce30f926-bc06-46ee-9f35-0cdf09a67043.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -13643,7 +13643,7 @@
         },
         {
             "id": "f9004630-d64f-56ec-b0f1-3e71af0c50a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b41cb3-ca3d-4389-8f66-e1f77f5fb683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b41cb3-ca3d-4389-8f66-e1f77f5fb683.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -13676,7 +13676,7 @@
         },
         {
             "id": "18aab64b-89f8-580b-8521-e4bcab8843af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3463be0-df9e-4cb9-a90f-5d9d2ee729e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3463be0-df9e-4cb9-a90f-5d9d2ee729e0.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -13707,7 +13707,7 @@
         },
         {
             "id": "7d06b57f-7b21-5748-970d-f44bc39c6514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd466b20-d11d-419e-8765-9befb9590299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd466b20-d11d-419e-8765-9befb9590299.jpg?1",
             "name": "Ior Ruin Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Ior Ruin Expedition.\nRemove three quest counters from Ior Ruin Expedition and sacrifice it: Draw two cards.",
             "colours": [
@@ -13738,7 +13738,7 @@
         },
         {
             "id": "a3104aba-3b79-579f-9c75-565168133044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b9db96-a6ab-454b-99a7-910ef77560d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b9db96-a6ab-454b-99a7-910ef77560d7.jpg?1",
             "name": "Meloku the Clouded Mirror",
             "text": "Flying\n{1}, Return a land you control to its owner's hand: Create a 1/1 blue Illusion creature token with flying.",
             "colours": [
@@ -13774,7 +13774,7 @@
         },
         {
             "id": "957529d5-2595-55b0-afb9-aef820de4df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e06fc13-6a58-40f8-a3e6-5558a7a0d18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e06fc13-6a58-40f8-a3e6-5558a7a0d18f.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -13809,7 +13809,7 @@
         },
         {
             "id": "0da28cae-c6ec-5f43-8015-cdac21058bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a959b40d-dd8c-49d8-8003-744d0c877b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a959b40d-dd8c-49d8-8003-744d0c877b04.jpg?1",
             "name": "Nezahal, Primal Tide",
             "text": "This spell can't be countered.\nYou have no maximum hand size.\nWhenever an opponent casts a noncreature spell, draw a card.\nDiscard three cards: Exile Nezahal, Primal Tide. Return it to the battlefield tapped under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "9116558e-1281-5b70-b658-7d72b40eb65c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aec3bd-b52f-4b23-a86a-429fa78a5a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55aec3bd-b52f-4b23-a86a-429fa78a5a6a.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -13876,7 +13876,7 @@
         },
         {
             "id": "0c6c2137-e578-5084-85a6-c603db958389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79471f9-5cc0-48f5-9fa4-1f1374993825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79471f9-5cc0-48f5-9fa4-1f1374993825.jpg?1",
             "name": "Scourge of Fleets",
             "text": "When Scourge of Fleets enters the battlefield, return each creature your opponents control with toughness X or less to its owner's hand, where X is the number of Islands you control.",
             "colours": [
@@ -13909,7 +13909,7 @@
         },
         {
             "id": "bdea1a39-d976-581a-8182-dc59ce916824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e558f0a-f921-4ecf-b1c9-2c93aa2d3fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e558f0a-f921-4ecf-b1c9-2c93aa2d3fd9.jpg?1",
             "name": "Shipbreaker Kraken",
             "text": "{6}{U}{U}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)\nWhen Shipbreaker Kraken becomes monstrous, tap up to four target creatures. Those creatures don't untap during their controllers' untap steps for as long as you control Shipbreaker Kraken.",
             "colours": [
@@ -13942,7 +13942,7 @@
         },
         {
             "id": "00ad5bf1-ebd6-54cc-b5bd-9cbba4eb101d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebf2c16-bd9d-4a8f-a1b6-6e0c393178bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebf2c16-bd9d-4a8f-a1b6-6e0c393178bc.jpg?1",
             "name": "Slinn Voda, the Rising Deep",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nWhen Slinn Voda, the Rising Deep enters the battlefield, if it was kicked, return all creatures to their owners' hands except for Merfolk, Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -13977,7 +13977,7 @@
         },
         {
             "id": "ff27a893-1385-5378-9f83-84a859e6ff06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5cd33-20e2-4063-b422-2bde13021888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5cd33-20e2-4063-b422-2bde13021888.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "5fdcf716-668c-5bd4-8350-254262927731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996bb4c0-dc72-4233-9f44-2e25aef71ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996bb4c0-dc72-4233-9f44-2e25aef71ad7.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -14043,7 +14043,7 @@
         },
         {
             "id": "f82ef462-e5e0-540b-9ef2-5587ead1cce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160686f3-44fd-4f7a-81cf-d3b5b964bfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160686f3-44fd-4f7a-81cf-d3b5b964bfba.jpg?1",
             "name": "Tromokratis",
             "text": "Tromokratis has hexproof unless it's attacking or blocking.\nTromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "236c6bd0-4a38-59f4-b02c-46a2a25da3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb863a0-3ff8-42a3-a151-4ea9aa433336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb863a0-3ff8-42a3-a151-4ea9aa433336.jpg?1",
             "name": "Whelming Wave",
             "text": "Return all creatures to their owners' hands except for Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -14109,7 +14109,7 @@
         },
         {
             "id": "125ef715-deea-5523-a7c7-d21250396a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d5b87-6dfc-4b99-822b-f6f8489ad275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27d5b87-6dfc-4b99-822b-f6f8489ad275.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -14142,7 +14142,7 @@
         },
         {
             "id": "56b73fde-d0e9-557e-b9b5-737107c3d03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5f586d-6bf0-4590-ad73-2d46b2a45b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb5f586d-6bf0-4590-ad73-2d46b2a45b1a.jpg?1",
             "name": "Comet Storm",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose any target, then choose another target for each time this spell was kicked. Comet Storm deals X damage to each of them.",
             "colours": [
@@ -14173,7 +14173,7 @@
         },
         {
             "id": "cd19793c-bad8-53af-baf6-c595d5ca5797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1371d7cb-3839-46e9-a02d-2253e18d2029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1371d7cb-3839-46e9-a02d-2253e18d2029.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "205b9d40-384d-5aee-959c-c4be94c855ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86c0628-0b61-44f2-91cc-1c3c309631ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86c0628-0b61-44f2-91cc-1c3c309631ce.jpg?1",
             "name": "Expedite",
             "text": "Target creature gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "38cf19ad-798b-5cfd-8792-0c0f2b7de865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1897b60d-7e15-488c-84d5-505187739b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1897b60d-7e15-488c-84d5-505187739b00.jpg?1",
             "name": "Fists of Flame",
             "text": "Draw a card. Until end of turn, target creature gains trample and gets +1/+0 for each card you've drawn this turn.",
             "colours": [
@@ -14269,7 +14269,7 @@
         },
         {
             "id": "29abdda7-b4f3-5c01-a111-7c70f7d81cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365336b4-92ee-429d-8f18-4624cba5469d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365336b4-92ee-429d-8f18-4624cba5469d.jpg?1",
             "name": "Jaya's Immolating Inferno",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nJaya's Immolating Inferno deals X damage to each of up to three targets.",
             "colours": [
@@ -14302,7 +14302,7 @@
         },
         {
             "id": "b98497be-5df9-5882-a86f-eed03c62e206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97622209-9357-4347-8961-f77f8d2389d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97622209-9357-4347-8961-f77f8d2389d8.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -14333,7 +14333,7 @@
         },
         {
             "id": "1224f525-f8d2-5475-a827-e75ae82d5ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d344f38d-0ef2-434b-914c-934c639e7e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d344f38d-0ef2-434b-914c-934c639e7e18.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -14366,7 +14366,7 @@
         },
         {
             "id": "dde7bc68-d46b-5121-9ec8-00aadc79d331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109c345-ce73-44b6-9228-5c4882764fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109c345-ce73-44b6-9228-5c4882764fab.jpg?1",
             "name": "Volcanic Fallout",
             "text": "This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
             "colours": [
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "31516e9e-f401-5c5a-9b3e-92987531377d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3dddfa-9579-42d7-867b-7e37b83b3eeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3dddfa-9579-42d7-867b-7e37b83b3eeb.jpg?1",
             "name": "Wild Ricochet",
             "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -14428,7 +14428,7 @@
         },
         {
             "id": "d759aa17-2785-583f-ab60-48d19e46bd40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa93215-9848-42d4-a386-6a248c2a1742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa93215-9848-42d4-a386-6a248c2a1742.jpg?1",
             "name": "Word of Seizing",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
             "colours": [
@@ -14459,7 +14459,7 @@
         },
         {
             "id": "cc3d585e-6835-5442-a227-7cdc23b6a839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea04b4f0-b8c4-43aa-8a2b-b72c22fb4517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea04b4f0-b8c4-43aa-8a2b-b72c22fb4517.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -14494,7 +14494,7 @@
         },
         {
             "id": "005a1089-8864-5f4b-a170-95d41d665335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dea775-bbb3-4e9c-8514-0605b5ad2e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dea775-bbb3-4e9c-8514-0605b5ad2e8b.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -14527,7 +14527,7 @@
         },
         {
             "id": "2ee57633-9301-5baa-b882-de8199bd8ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e228bede-5972-4381-969b-9de26e570117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e228bede-5972-4381-969b-9de26e570117.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Beast creature token.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "5d4e124d-6f6e-50f9-a211-f432c266f988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a108064-8143-4b20-a5a2-eeb3b80af82f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a108064-8143-4b20-a5a2-eeb3b80af82f.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -14589,7 +14589,7 @@
         },
         {
             "id": "54322c2b-676e-565c-bb88-d5e70dec8c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e7ded-d063-4d90-a9ff-91c44a8098d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e7ded-d063-4d90-a9ff-91c44a8098d7.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -14623,7 +14623,7 @@
         },
         {
             "id": "341529fa-baf1-5bd9-9a35-7656ddea84b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405ac8-a8e3-4c65-807e-6bfcfa162852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405ac8-a8e3-4c65-807e-6bfcfa162852.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -14654,7 +14654,7 @@
         },
         {
             "id": "b6fc8081-6d56-5e01-9a13-c6392b5bbe94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159e0372-de5e-4830-b690-f5154ed1036c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159e0372-de5e-4830-b690-f5154ed1036c.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -14685,7 +14685,7 @@
         },
         {
             "id": "2753979d-9d45-5e14-be5f-4f615bb652fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbbcfb-1b1b-4991-988d-17a22a08d5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cbbcfb-1b1b-4991-988d-17a22a08d5b0.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -14716,7 +14716,7 @@
         },
         {
             "id": "da546e04-15c3-5f95-a9d5-6240624a58a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cb953-0553-462c-bd7e-4193987d36c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cb953-0553-462c-bd7e-4193987d36c9.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -14751,7 +14751,7 @@
         },
         {
             "id": "86464b9f-56a3-56a9-8feb-023afc2dafc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321f68b5-42ad-4f71-8df4-78075bf68ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321f68b5-42ad-4f71-8df4-78075bf68ce5.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -14786,7 +14786,7 @@
         },
         {
             "id": "16a7f18b-29fc-592e-9fb6-95f4d344afd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766c7781-d94e-482d-98f0-9b135ec5b8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766c7781-d94e-482d-98f0-9b135ec5b8ae.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -14819,7 +14819,7 @@
         },
         {
             "id": "8039040e-b2ca-5961-bd9d-eade044551ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbceb9b-4212-40b4-913f-e4a19db00fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbceb9b-4212-40b4-913f-e4a19db00fae.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -14850,7 +14850,7 @@
         },
         {
             "id": "5dbb752e-17cf-5e62-9115-f2b3fa92a438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8870ef0b-cb1f-463b-8509-fece4743d3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8870ef0b-cb1f-463b-8509-fece4743d3d4.jpg?1",
             "name": "Ramunap Excavator",
             "text": "You may play lands from your graveyard.",
             "colours": [
@@ -14884,7 +14884,7 @@
         },
         {
             "id": "1699cbbc-0a15-56c1-94f0-f3c193a4d356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9574f30-5e9e-4d66-ab07-fc48299e42ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9574f30-5e9e-4d66-ab07-fc48299e42ee.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -14920,7 +14920,7 @@
         },
         {
             "id": "d3279d22-23f2-5c41-bfea-e7f6ae8cfc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ac818-f476-43fd-841c-c91d78c2506e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ac818-f476-43fd-841c-c91d78c2506e.jpg?1",
             "name": "Retreat to Kazandu",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 You gain 2 life.",
             "colours": [
@@ -14951,7 +14951,7 @@
         },
         {
             "id": "33a3f429-0ffd-5175-9504-9d4ab166ebf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b6d93-0f7a-4df4-8c01-96cbd5e03315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b6d93-0f7a-4df4-8c01-96cbd5e03315.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -14982,7 +14982,7 @@
         },
         {
             "id": "8cb912c4-6c34-5e33-93e1-98b3cead6af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092bfc5f-8002-43da-8e70-c19fccfe54ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092bfc5f-8002-43da-8e70-c19fccfe54ac.jpg?1",
             "name": "Sporemound",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -15015,7 +15015,7 @@
         },
         {
             "id": "1fb8daa4-ae40-52b2-b93e-0af23330c30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32141ae3-0c1c-480c-8f61-90a46d5ce54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32141ae3-0c1c-480c-8f61-90a46d5ce54c.jpg?1",
             "name": "Terastodon",
             "text": "When Terastodon enters the battlefield, you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -15048,7 +15048,7 @@
         },
         {
             "id": "e0b9105c-852c-526a-80fb-ffc3fba53772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2d03a9-815d-4662-a3ee-d6b24047128c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2d03a9-815d-4662-a3ee-d6b24047128c.jpg?1",
             "name": "Verdant Sun's Avatar",
             "text": "Whenever Verdant Sun's Avatar or another creature enters the battlefield under your control, you gain life equal to that creature's toughness.",
             "colours": [
@@ -15082,7 +15082,7 @@
         },
         {
             "id": "4d19970a-257c-50a4-b5f6-0a750cecc820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a969128b-e03d-4f35-bac3-6a852881d27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a969128b-e03d-4f35-bac3-6a852881d27a.jpg?1",
             "name": "Wickerbough Elder",
             "text": "Wickerbough Elder enters the battlefield with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from Wickerbough Elder: Destroy target artifact or enchantment.",
             "colours": [
@@ -15116,7 +15116,7 @@
         },
         {
             "id": "e96bd745-5119-55a5-bbc4-63a6d9735572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cfb9b-77bb-4e5a-be31-3a9984af1217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cfb9b-77bb-4e5a-be31-3a9984af1217.jpg?1",
             "name": "Yavimaya Elder",
             "text": "When Yavimaya Elder dies, you may search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library.\n{2}, Sacrifice Yavimaya Elder: Draw a card.",
             "colours": [
@@ -15150,7 +15150,7 @@
         },
         {
             "id": "1447d633-cb0b-54ae-9351-6fcb66c54149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c3288b-ab10-40df-a0ce-17ee4ecdb98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c3288b-ab10-40df-a0ce-17ee4ecdb98e.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014\n\u2022 Boros Charm deals 4 damage to target player or planeswalker.\n\u2022 Permanents you control gain indestructible until end of turn.\n\u2022 Target creature gains double strike until end of turn.",
             "colours": [
@@ -15185,7 +15185,7 @@
         },
         {
             "id": "1eb02d13-d71b-5c31-91ca-9abdce337368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42b8b16-dd09-466b-ba1e-979e963ea384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42b8b16-dd09-466b-ba1e-979e963ea384.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -15224,7 +15224,7 @@
         },
         {
             "id": "79bc5dcc-c731-5d52-bf7b-62762b5da28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5580886-a402-4048-b8b6-39e19479f491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5580886-a402-4048-b8b6-39e19479f491.jpg?1",
             "name": "Deflecting Palm",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. If damage is prevented this way, Deflecting Palm deals that much damage to that source's controller.",
             "colours": [
@@ -15257,7 +15257,7 @@
         },
         {
             "id": "f75905de-e27b-5f59-ab3f-796b81f809c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9c5be-4bca-4c59-bbfc-50378e0404df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9c5be-4bca-4c59-bbfc-50378e0404df.jpg?1",
             "name": "Fathom Mage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever a +1/+1 counter is put on Fathom Mage, you may draw a card.",
             "colours": [
@@ -15293,7 +15293,7 @@
         },
         {
             "id": "3131ddf1-c363-5cc0-818e-1d6596468c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0f0add-4ed5-4146-972f-ece8a19e567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0f0add-4ed5-4146-972f-ece8a19e567d.jpg?1",
             "name": "Growth Spiral",
             "text": "Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -15326,7 +15326,7 @@
         },
         {
             "id": "1649d1a1-ef5f-51ad-8d6d-2d8c76819f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95749cf-dd12-4bca-a74d-01301b9b76df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a95749cf-dd12-4bca-a74d-01301b9b76df.jpg?1",
             "name": "Master Warcraft",
             "text": "Cast this spell only before attackers are declared.\nYou choose which creatures attack this turn.\nYou choose which creatures block this turn and how those creatures block.",
             "colours": [
@@ -15359,7 +15359,7 @@
         },
         {
             "id": "8b4dde1f-0e45-5f74-8fb7-c48f714e76d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd7296c-ace8-43ea-8164-c69f8843d022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd7296c-ace8-43ea-8164-c69f8843d022.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -15394,7 +15394,7 @@
         },
         {
             "id": "02e11f9c-824f-5cd2-b72a-996ba0f6fe86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg?1",
             "name": "Response // Resurgence",
             "text": "Response deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -15427,7 +15427,7 @@
         },
         {
             "id": "8196f825-1f84-5957-90ad-97df5e765219",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e9b44a8e-34b1-4ee1-894a-968db6f724b6.jpg?1",
             "name": "Response // Resurgence",
             "text": "Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -15460,7 +15460,7 @@
         },
         {
             "id": "d12c9d5a-1625-51ec-a570-a97003b87acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db490f74-977f-476d-b8ee-da7b0a98b4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db490f74-977f-476d-b8ee-da7b0a98b4c4.jpg?1",
             "name": "Sharktocrab",
             "text": "{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Sharktocrab, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "47a128ab-cb69-5b17-bac5-970ac007d1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3384ee4e-738f-4442-bccd-4f96022b7219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3384ee4e-738f-4442-bccd-4f96022b7219.jpg?1",
             "name": "Simic Charm",
             "text": "Choose one \u2014\n\u2022 Target creature gets +3/+3 until end of turn.\n\u2022 Permanents you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -15530,7 +15530,7 @@
         },
         {
             "id": "4ff81946-5443-566a-a975-540d9b20f740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791b7fa-3d12-409d-b017-cb9fd8b71af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f791b7fa-3d12-409d-b017-cb9fd8b71af7.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -15565,7 +15565,7 @@
         },
         {
             "id": "bf8e7062-fe35-57d2-b986-00d8fd6c2b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51d5d93-e4f7-4c83-a89f-f600668d2c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51d5d93-e4f7-4c83-a89f-f600668d2c29.jpg?1",
             "name": "Spitting Image",
             "text": "Create a token that's a copy of target creature.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -15598,7 +15598,7 @@
         },
         {
             "id": "d8b615f2-706f-57e6-9574-524853668264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63852ffb-22ef-4b88-9cba-254291e978cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63852ffb-22ef-4b88-9cba-254291e978cd.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -15636,7 +15636,7 @@
         },
         {
             "id": "994e8e98-850d-58f8-a0c7-c634feb9eff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba443c5-ed9f-4bc0-8821-0053b536d648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba443c5-ed9f-4bc0-8821-0053b536d648.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -15669,7 +15669,7 @@
         },
         {
             "id": "221f4799-f84b-550c-82d0-4531e0b5d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target artifact.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -15701,7 +15701,7 @@
         },
         {
             "id": "5550c46f-63e3-5336-a819-101c93fcbd01",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f279560-7e9f-4a6d-9fd6-6c8c6bd94a1b.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target enchantment.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -15733,7 +15733,7 @@
         },
         {
             "id": "5fe5da36-2b34-5cd0-b217-ec06d2bab709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f192c3e-34ce-4857-82ef-a0423823220d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f192c3e-34ce-4857-82ef-a0423823220d.jpg?1",
             "name": "Blackblade Reforged",
             "text": "Equipped creature gets +1/+1 for each land you control.\nEquip legendary creature {3}\nEquip {7}",
             "colours": [],
@@ -15764,7 +15764,7 @@
         },
         {
             "id": "336d5a5e-3765-523f-94f5-faed8c99396f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690972a8-72df-4050-a353-16e45589167c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690972a8-72df-4050-a353-16e45589167c.jpg?1",
             "name": "Bonesplitter",
             "text": "Equipped creature gets +2/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "4a988092-c1e9-536a-807b-de684910fc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae6081-1876-42ea-a6f8-d18dbe55c4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae6081-1876-42ea-a6f8-d18dbe55c4c4.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -15823,7 +15823,7 @@
         },
         {
             "id": "d1eb2bd4-62ca-516e-83d5-0b308d399180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48010648-6f68-41aa-93ae-e02a7de6abb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48010648-6f68-41aa-93ae-e02a7de6abb8.jpg?1",
             "name": "Brass Squire",
             "text": "{T}: Attach target Equipment you control to target creature you control.",
             "colours": [],
@@ -15853,7 +15853,7 @@
         },
         {
             "id": "1dd4f291-85d9-55cc-a49d-1b0abaf94d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cf33f-ef8d-4d10-87fe-ab03b8525766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16cf33f-ef8d-4d10-87fe-ab03b8525766.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "c114a7ad-118e-5a38-b06d-88ff8345309c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0d12-5bd6-4d2f-8913-fe690c441104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0d12-5bd6-4d2f-8913-fe690c441104.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15911,7 +15911,7 @@
         },
         {
             "id": "03278e1b-47a4-5f54-81b8-942a11ec66cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ece771-d628-45e7-882d-a35f625d2e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ece771-d628-45e7-882d-a35f625d2e55.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15942,7 +15942,7 @@
         },
         {
             "id": "30646eeb-c012-5f22-935f-ea5763d6b40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd53b6a-6daf-436e-8069-270bed7b4b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd53b6a-6daf-436e-8069-270bed7b4b39.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15973,7 +15973,7 @@
         },
         {
             "id": "251fe08f-705e-5b6d-98cb-ca56175205e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ccdaf1-c491-4f87-94f8-d66e7e399681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ccdaf1-c491-4f87-94f8-d66e7e399681.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0 and has trample and lifelink.\nEquip {3}",
             "colours": [],
@@ -16002,7 +16002,7 @@
         },
         {
             "id": "49740c1c-bc8b-5827-8af9-320ad5319264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa1b193-c80e-4026-bd82-f16314e14431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa1b193-c80e-4026-bd82-f16314e14431.jpg?1",
             "name": "Mask of Avacyn",
             "text": "Equipped creature gets +1/+2 and has hexproof. (It can't be the target of spells or abilities your opponents control.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16031,7 +16031,7 @@
         },
         {
             "id": "69750e7f-5943-5766-a2c0-2ec3cca0b5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4894b26b-f1ee-4e08-8bab-082a8327c96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4894b26b-f1ee-4e08-8bab-082a8327c96f.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -16063,7 +16063,7 @@
         },
         {
             "id": "6f565827-0809-5faa-b124-b9d4b2b0d650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda91fbd-bf5b-46c4-bd96-037b507f3daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda91fbd-bf5b-46c4-bd96-037b507f3daa.jpg?1",
             "name": "Ring of Thune",
             "text": "Equipped creature has vigilance.\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's white.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16092,7 +16092,7 @@
         },
         {
             "id": "1e6cc958-5ae9-50f8-b565-cc19c84f9917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3c0bc4-6f89-48e2-b525-5efcb091bc5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3c0bc4-6f89-48e2-b525-5efcb091bc5e.jpg?1",
             "name": "Ring of Valkas",
             "text": "Equipped creature has haste.\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's red.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16121,7 +16121,7 @@
         },
         {
             "id": "9ede4cba-f622-5b39-bb15-15cdab1aa276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b8613-d5cd-4749-9c1b-d27a388c616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491b8613-d5cd-4749-9c1b-d27a388c616a.jpg?1",
             "name": "Seer's Sundial",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -16148,7 +16148,7 @@
         },
         {
             "id": "18de36b3-5bcf-5a5b-963f-32c1caf4266e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ce2ab-d3e6-486c-a577-2d4f2c750cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ce2ab-d3e6-486c-a577-2d4f2c750cde.jpg?1",
             "name": "Simic Signet",
             "text": "{1}, {T}: Add {G}{U}.",
             "colours": [],
@@ -16178,7 +16178,7 @@
         },
         {
             "id": "4b9e45eb-f62b-5728-820c-48a3e6623682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b26011-e103-45c4-a253-900f4e6b2eeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b26011-e103-45c4-a253-900f4e6b2eeb.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -16207,7 +16207,7 @@
         },
         {
             "id": "9bea7744-d60e-5e33-a139-ba54c42bce6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3e42ee-ab13-460b-90fd-86e677abce4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3e42ee-ab13-460b-90fd-86e677abce4f.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -16239,7 +16239,7 @@
         },
         {
             "id": "c1796ad3-42bc-5c85-945f-e5268f629e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c45f3d-cf12-4db7-b161-9539ed969ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c45f3d-cf12-4db7-b161-9539ed969ca7.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -16270,7 +16270,7 @@
         },
         {
             "id": "26f20bff-4655-5847-88b8-d5043af9efc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032af060-4d49-4a0a-8841-9eb2d45a4b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032af060-4d49-4a0a-8841-9eb2d45a4b77.jpg?1",
             "name": "Sword of Vengeance",
             "text": "Equipped creature gets +2/+0 and has first strike, vigilance, trample, and haste.\nEquip {3}",
             "colours": [],
@@ -16299,7 +16299,7 @@
         },
         {
             "id": "2dc2d6b3-0af9-5be9-bd8a-3fc04151e1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a949030-a46c-4bac-bedc-c07d5c8464af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a949030-a46c-4bac-bedc-c07d5c8464af.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {C}.\n{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16328,7 +16328,7 @@
         },
         {
             "id": "57e23be9-399f-5a9f-b1a9-f2d8b2d390e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba2ac2-15dc-4c43-bb57-9943444ce1d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba2ac2-15dc-4c43-bb57-9943444ce1d7.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W}.",
             "colours": [],
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "885e6a92-ab91-5671-8e1e-4194427094ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce912e1-73fe-41f3-a86c-4c19ff3f100f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce912e1-73fe-41f3-a86c-4c19ff3f100f.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -16390,7 +16390,7 @@
         },
         {
             "id": "c9e1aec9-1d9a-594e-a31a-1afd4ac3a457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e72ac3-2b4f-43d8-9708-afe1b67c5d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e72ac3-2b4f-43d8-9708-afe1b67c5d00.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -16420,7 +16420,7 @@
         },
         {
             "id": "f11d5ca9-9baa-54e8-aec6-c62b0740c6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e3ea71-ea9f-4bbf-93cb-0f6339f8a3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e3ea71-ea9f-4bbf-93cb-0f6339f8a3ab.jpg?1",
             "name": "Coral Atoll",
             "text": "Coral Atoll enters the battlefield tapped.\nWhen Coral Atoll enters the battlefield, sacrifice it unless you return an untapped Island you control to its owner's hand.\n{T}: Add {C}{U}.",
             "colours": [],
@@ -16449,7 +16449,7 @@
         },
         {
             "id": "2280a733-b06b-5d29-bab8-16c0758af93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a591bffd-2f03-48f4-a719-04f2142abd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a591bffd-2f03-48f4-a719-04f2142abd77.jpg?1",
             "name": "Encroaching Wastes",
             "text": "{T}: Add {C}.\n{4}, {T}, Sacrifice Encroaching Wastes: Destroy target nonbasic land.",
             "colours": [],
@@ -16476,7 +16476,7 @@
         },
         {
             "id": "28ec0c20-5d17-5568-b5c0-fbd90bc624b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a25c6-a1b7-4d6c-8a22-b407043a2280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a25c6-a1b7-4d6c-8a22-b407043a2280.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16503,7 +16503,7 @@
         },
         {
             "id": "dbeee0cd-a60c-599d-8b93-f77ad94aff2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084bf9fe-78d2-4fef-8514-ed64d6c771e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084bf9fe-78d2-4fef-8514-ed64d6c771e6.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave enters the battlefield tapped.\n{T}: Add {R}.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -16532,7 +16532,7 @@
         },
         {
             "id": "684be8a4-442d-589d-ba3f-507d3eb07626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4929e39-fccc-450b-bb18-f5ad56a397bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4929e39-fccc-450b-bb18-f5ad56a397bd.jpg?1",
             "name": "Jungle Basin",
             "text": "Jungle Basin enters the battlefield tapped.\nWhen Jungle Basin enters the battlefield, sacrifice it unless you return an untapped Forest you control to its owner's hand.\n{T}: Add {C}{G}.",
             "colours": [],
@@ -16561,7 +16561,7 @@
         },
         {
             "id": "9a1f0d81-e56d-55eb-8074-65ba5922d6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d1438-95d3-4c2c-8011-7970cbf6fe88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d1438-95d3-4c2c-8011-7970cbf6fe88.jpg?1",
             "name": "Memorial to Genius",
             "text": "Memorial to Genius enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards.",
             "colours": [],
@@ -16590,7 +16590,7 @@
         },
         {
             "id": "f8d2af64-34c3-5f47-afe5-97fdd20a395e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fe9351-82ad-47b0-b30c-208effbb9f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fe9351-82ad-47b0-b30c-208effbb9f3d.jpg?1",
             "name": "Memorial to War",
             "text": "Memorial to War enters the battlefield tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice Memorial to War: Destroy target land.",
             "colours": [],
@@ -16619,7 +16619,7 @@
         },
         {
             "id": "e98bb4ca-031b-50d6-8d94-d238243ee340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538f54e-81dc-4396-9d47-3087df16b630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538f54e-81dc-4396-9d47-3087df16b630.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16648,7 +16648,7 @@
         },
         {
             "id": "5c9bcdfa-dae6-5c2f-854a-28583afb8ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdf72b4-d188-4d16-a1a9-943cbe3157d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdf72b4-d188-4d16-a1a9-943cbe3157d6.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -16677,7 +16677,7 @@
         },
         {
             "id": "e8bfd25f-3983-51b1-88c5-9d14e407ee32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbfd91-40d7-4cb4-ac82-27c50d872cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bbfd91-40d7-4cb4-ac82-27c50d872cf5.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -16704,7 +16704,7 @@
         },
         {
             "id": "f13541fc-ac4d-5100-a800-a191623c8098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8340aa81-7c7f-4b0b-8d98-d3414cac331c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8340aa81-7c7f-4b0b-8d98-d3414cac331c.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -16733,7 +16733,7 @@
         },
         {
             "id": "02172589-7380-5029-9adb-0f3fb3c1b267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c536cbd-3e81-4c6a-a4e1-02fbd2776706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c536cbd-3e81-4c6a-a4e1-02fbd2776706.jpg?1",
             "name": "Secluded Steppe",
             "text": "Secluded Steppe enters the battlefield tapped.\n{T}: Add {W}.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "5b66f87c-9618-5e71-a6eb-8b18c5a7ccf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b84ef6-ba13-4c65-987e-cc6aa750086c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b84ef6-ba13-4c65-987e-cc6aa750086c.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U}.",
             "colours": [],
@@ -16792,7 +16792,7 @@
         },
         {
             "id": "c95315f0-4626-5072-9056-9abf1dd29297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93f0124-eb83-4261-8ad2-5590155274a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93f0124-eb83-4261-8ad2-5590155274a4.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -16824,7 +16824,7 @@
         },
         {
             "id": "24aed73f-08ad-5f8d-8a36-a8f67293e7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402bc1b6-f2f7-4bb7-954a-8579e43f612f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402bc1b6-f2f7-4bb7-954a-8579e43f612f.jpg?1",
             "name": "Slayers' Stronghold",
             "text": "{T}: Add {C}.\n{R}{W}, {T}: Target creature gets +2/+0 and gains vigilance and haste until end of turn.",
             "colours": [],
@@ -16854,7 +16854,7 @@
         },
         {
             "id": "38cf86b5-1c4e-5239-920a-e8bf51ad8ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3575e1-7d2c-4777-b469-16f7483bb8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3575e1-7d2c-4777-b469-16f7483bb8e7.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -16884,7 +16884,7 @@
         },
         {
             "id": "92163e05-711a-5cbb-86ae-269df5a2b156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7071a2-2ff2-405b-9052-f902dee820a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7071a2-2ff2-405b-9052-f902dee820a7.jpg?1",
             "name": "Sunhome, Fortress of the Legion",
             "text": "{T}: Add {C}.\n{2}{R}{W}, {T}: Target creature gains double strike until end of turn.",
             "colours": [],
@@ -16914,7 +16914,7 @@
         },
         {
             "id": "9da815e1-3345-5dc5-bcc4-05068fb2e4d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7a200-3da0-4714-ae1c-2e4847725416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7a200-3da0-4714-ae1c-2e4847725416.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -16944,7 +16944,7 @@
         },
         {
             "id": "0d9bb632-6c40-578f-9a7f-df632bf4f3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e918f01a-3c24-440c-9e5b-c8cf47d81a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e918f01a-3c24-440c-9e5b-c8cf47d81a82.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -16974,7 +16974,7 @@
         },
         {
             "id": "8b4f9d6e-9cf7-5f4e-bea9-c0830bafb2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0baaa39-7fce-4feb-9118-b1d6bc24f548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0baaa39-7fce-4feb-9118-b1d6bc24f548.jpg?1",
             "name": "Transguild Promenade",
             "text": "Transguild Promenade enters the battlefield tapped.\nWhen Transguild Promenade enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -17001,7 +17001,7 @@
         },
         {
             "id": "9375f341-c019-5790-b335-e286d939199d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fde8caf-975e-4d43-b994-27199e0557fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fde8caf-975e-4d43-b994-27199e0557fa.jpg?1",
             "name": "Vivid Creek",
             "text": "Vivid Creek enters the battlefield tapped with two charge counters on it.\n{T}: Add {U}.\n{T}, Remove a charge counter from Vivid Creek: Add one mana of any color.",
             "colours": [],
@@ -17030,7 +17030,7 @@
         },
         {
             "id": "e93c81b0-38d1-5727-be75-19f6584b4511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdfbba9-c5f7-426b-8219-8661304ea588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdfbba9-c5f7-426b-8219-8661304ea588.jpg?1",
             "name": "Vivid Grove",
             "text": "Vivid Grove enters the battlefield tapped with two charge counters on it.\n{T}: Add {G}.\n{T}, Remove a charge counter from Vivid Grove: Add one mana of any color.",
             "colours": [],
@@ -17059,7 +17059,7 @@
         },
         {
             "id": "a00e4ed7-dc83-5435-90e4-4ab47e52880f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf1fd55-9e9f-49c2-bf4f-439a18f7f36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf1fd55-9e9f-49c2-bf4f-439a18f7f36a.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -17089,7 +17089,7 @@
         },
         {
             "id": "aa034fea-624f-53b3-ba28-7b8af975f5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77619840-963f-4ff7-9a42-b36e3d53646d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77619840-963f-4ff7-9a42-b36e3d53646d.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -17119,7 +17119,7 @@
         },
         {
             "id": "a5df25d6-c181-5800-bc89-efc959d6f904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e4d2b-2ba7-492f-9f0f-b2b2a2e4c049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e4d2b-2ba7-492f-9f0f-b2b2a2e4c049.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -17154,7 +17154,7 @@
         },
         {
             "id": "cac70c4e-cabc-5a8b-84d0-d4f3a7073a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0491b4f7-9722-4f7e-932c-e19dc0fdf6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0491b4f7-9722-4f7e-932c-e19dc0fdf6d2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -17189,7 +17189,7 @@
         },
         {
             "id": "adc096fe-4ff7-5898-b344-c6da1b609622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb15b40c-9795-42ae-9f88-8b8023b6c010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb15b40c-9795-42ae-9f88-8b8023b6c010.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -17224,7 +17224,7 @@
         },
         {
             "id": "552f4182-0e63-5edf-9483-54da4e322d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e905b6c5-1874-4d3b-8181-bc4bfab73bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e905b6c5-1874-4d3b-8181-bc4bfab73bd7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -17259,7 +17259,7 @@
         },
         {
             "id": "510a6b3b-0045-570b-9270-5fba1692be08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1baebba-a975-45b1-bbcb-f4ce1ba682b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1baebba-a975-45b1-bbcb-f4ce1ba682b5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17294,7 +17294,7 @@
         },
         {
             "id": "c3626c1a-5f8f-5279-9e7e-6c7eeec37851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3346e6-f8ca-45fa-944c-055ac038e828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3346e6-f8ca-45fa-944c-055ac038e828.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -17329,7 +17329,7 @@
         },
         {
             "id": "f3ec19b4-64cc-5e4d-abdf-e2fd4db94803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845057a1-4da1-4a32-9bb2-bbf8502acd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845057a1-4da1-4a32-9bb2-bbf8502acd37.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17364,7 +17364,7 @@
         },
         {
             "id": "7d46dd9f-c4d0-57f0-927e-89f9862739b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eea1d-4d57-4aee-9ebe-a8eb594d319b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eea1d-4d57-4aee-9ebe-a8eb594d319b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -17399,7 +17399,7 @@
         },
         {
             "id": "00396ed6-b91d-5c78-8760-bb22d8f3e9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f68b4de-271b-415f-ad8f-104981bb12ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f68b4de-271b-415f-ad8f-104981bb12ab.jpg?1",
             "name": "Tevesh Szat, Doom of Fools",
             "text": "+2: Create two 0/1 black Thrull creature tokens.\n+1: You may sacrifice another creature or planeswalker. If you do, draw two cards, then draw another card if the sacrificed permanent was a commander.\n\u221210: Gain control of all commanders. Put all commanders from the command zone onto the battlefield under your control.\nTevesh Szat, Doom of Fools can be your commander.\nPartner",
             "colours": [
@@ -17437,7 +17437,7 @@
         },
         {
             "id": "0732d9c5-ded3-58ee-88dc-1331769cc554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de336a3-224f-49e0-b4ff-34bf3de398bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de336a3-224f-49e0-b4ff-34bf3de398bf.jpg?1",
             "name": "Jeska, Thrice Reborn",
             "text": "Jeska, Thrice Reborn enters the battlefield with a loyalty counter on it for each time you've cast a commander from the command zone this game.\n0: Choose target creature. Until your next turn, if that creature would deal combat damage to one of your opponents, it deals triple that damage to that player instead.\n\u2212X: Jeska, Thrice Reborn deals X damage to each of up to three targets.\nJeska, Thrice Reborn can be your commander.\nPartner",
             "colours": [
@@ -17475,7 +17475,7 @@
         },
         {
             "id": "52201a8d-2650-509e-802b-7947489d1a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be898edb-35dd-4896-96d9-323aca64a2ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be898edb-35dd-4896-96d9-323aca64a2ce.jpg?1",
             "name": "Najeela, the Blade-Blossom",
             "text": "Whenever a Warrior attacks, you may have its controller create a 1/1 white Warrior creature token that's tapped and attacking.\n{W}{U}{B}{R}{G}: Untap all attacking creatures. They gain trample, lifelink, and haste until end of turn. After this phase, there is an additional combat phase. Activate this ability only during combat.",
             "colours": [
@@ -17515,7 +17515,7 @@
         },
         {
             "id": "9ae62129-9742-5258-b7fb-526d95f646f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9923a-ad50-49e5-bf96-c669a39b84fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9923a-ad50-49e5-bf96-c669a39b84fd.jpg?1",
             "name": "Akiri, Line-Slinger",
             "text": "First strike, vigilance\nAkiri, Line-Slinger gets +1/+0 for each artifact you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17554,7 +17554,7 @@
         },
         {
             "id": "51036a18-d7f7-5e0a-afd0-a83ba234db0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8bb45f-5f65-4ee4-a64e-d5e8f758d9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8bb45f-5f65-4ee4-a64e-d5e8f758d9e9.jpg?1",
             "name": "Brago, King Eternal",
             "text": "Flying\nWhenever Brago, King Eternal deals combat damage to a player, exile any number of target nonland permanents you control, then return those cards to the battlefield under their owner's control.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "9d70f008-2465-5665-bb3f-8eb9c751508b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816c031-8816-4f52-b1db-590f0688d801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816c031-8816-4f52-b1db-590f0688d801.jpg?1",
             "name": "Bruse Tarl, Boorish Herder",
             "text": "Whenever Bruse Tarl, Boorish Herder enters the battlefield or attacks, target creature you control gains double strike and lifelink until end of turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17630,7 +17630,7 @@
         },
         {
             "id": "7346cff6-ee3b-5890-ad75-dc70ba9ad32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a1707-1cda-4121-a3d1-55a7604bbd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a1707-1cda-4121-a3d1-55a7604bbd77.jpg?1",
             "name": "Derevi, Empyrial Tactician",
             "text": "Flying\nWhenever Derevi, Empyrial Tactician enters the battlefield or a creature you control deals combat damage to a player, you may tap or untap target permanent.\n{1}{G}{W}{U}: Put Derevi onto the battlefield from the command zone.",
             "colours": [
@@ -17670,7 +17670,7 @@
         },
         {
             "id": "3d7a2d70-d30e-5bc4-8d9f-12efc47bdbce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb98089-11b8-4afd-9724-e488d864b4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb98089-11b8-4afd-9724-e488d864b4dc.jpg?1",
             "name": "Ikra Shidiqi, the Usurper",
             "text": "Menace\nWhenever a creature you control deals combat damage to a player, you gain life equal to that creature's toughness.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17708,7 +17708,7 @@
         },
         {
             "id": "38380e04-8d4f-5f33-b86a-ab667e98949f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35eb2a8-ecdc-4ce3-a628-e031141645e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35eb2a8-ecdc-4ce3-a628-e031141645e6.jpg?1",
             "name": "Ishai, Ojutai Dragonspeaker",
             "text": "Flying\nWhenever an opponent casts a spell, put a +1/+1 counter on Ishai, Ojutai Dragonspeaker.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17746,7 +17746,7 @@
         },
         {
             "id": "c81dde4a-5cee-54b7-9d80-9284962eacd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61a6018-7f07-4623-b981-9516b53b8534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61a6018-7f07-4623-b981-9516b53b8534.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nDuring each of your turns, you may cast a creature spell from your graveyard.",
             "colours": [
@@ -17786,7 +17786,7 @@
         },
         {
             "id": "656cda09-102e-50d3-868c-cb6fe10cf496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb07085-0dcd-43c9-8355-270a77c573e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb07085-0dcd-43c9-8355-270a77c573e1.jpg?1",
             "name": "Karametra, God of Harvests",
             "text": "Indestructible\nAs long as your devotion to green and white is less than seven, Karametra isn't a creature.\nWhenever you cast a creature spell, you may search your library for a Forest or Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -17824,7 +17824,7 @@
         },
         {
             "id": "c66457a3-0855-5de4-ae94-1ac5215e5432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e13fc2-c4dd-4875-be32-e04d954e658d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e13fc2-c4dd-4875-be32-e04d954e658d.jpg?1",
             "name": "Kraum, Ludevic's Opus",
             "text": "Flying, haste\nWhenever an opponent casts their second spell each turn, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17862,7 +17862,7 @@
         },
         {
             "id": "13f6bab7-2dc2-5058-be50-b39ceae200b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eee902-dc0b-48d0-a8db-7e6de89977ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eee902-dc0b-48d0-a8db-7e6de89977ef.jpg?1",
             "name": "Kydele, Chosen of Kruphix",
             "text": "{T}: Add {C} for each card you've drawn this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17900,7 +17900,7 @@
         },
         {
             "id": "2f1ee9dd-cb59-50e8-8e03-1d2795a1472d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6724f-f781-446b-be69-5c6949f9bbaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d6724f-f781-446b-be69-5c6949f9bbaa.jpg?1",
             "name": "Ludevic, Necro-Alchemist",
             "text": "At the beginning of each player's end step, that player may draw a card if a player other than you lost life this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -17938,7 +17938,7 @@
         },
         {
             "id": "60d95ef5-9ec3-54bc-b2b3-8f30e4ba0332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a75062-b5e3-4942-af64-12f43101c294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a75062-b5e3-4942-af64-12f43101c294.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order. Then do it again.)",
             "colours": [
@@ -17977,7 +17977,7 @@
         },
         {
             "id": "cded5e1a-95d2-5816-a046-059d9acc66a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e1033e-3d7e-451a-8e0f-1ae7f3de925a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e1033e-3d7e-451a-8e0f-1ae7f3de925a.jpg?1",
             "name": "Marath, Will of the Wild",
             "text": "Marath, Will of the Wild enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.\n{X}, Remove X +1/+1 counters from Marath: Choose one. X can't be 0.\n\u2022 Put X +1/+1 counters on target creature.\n\u2022 Marath deals X damage to any target.\n\u2022 Create an X/X green Elemental creature token.",
             "colours": [
@@ -18017,7 +18017,7 @@
         },
         {
             "id": "fce4bdd6-a05f-5076-aabb-770818d61c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c19629-b129-4c8b-9456-c38309248189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c19629-b129-4c8b-9456-c38309248189.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -18057,7 +18057,7 @@
         },
         {
             "id": "ba3833c2-d289-5aae-a8c6-d4f9b222635e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1691bd-5194-4f1e-981f-6d5ef808ed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1691bd-5194-4f1e-981f-6d5ef808ed4e.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nWhenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",
             "colours": [
@@ -18097,7 +18097,7 @@
         },
         {
             "id": "c8867a01-8d85-5829-a231-b8ecc5e309d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d5e58-f06e-43bb-8e3c-bbf241cc2de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d5e58-f06e-43bb-8e3c-bbf241cc2de6.jpg?1",
             "name": "Prossh, Skyraider of Kher",
             "text": "When you cast this spell, create X 0/1 red Kobold creature tokens named Kobolds of Kher Keep, where X is the amount of mana spent to cast it.\nFlying\nSacrifice another creature: Prossh, Skyraider of Kher gets +1/+0 until end of turn.",
             "colours": [
@@ -18136,7 +18136,7 @@
         },
         {
             "id": "cfc5a50a-a945-5f2c-8e5d-a4d1fd5b8831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c04d8d-f552-4af3-b014-efb7a1c577f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c04d8d-f552-4af3-b014-efb7a1c577f8.jpg?1",
             "name": "Queen Marchesa",
             "text": "Deathtouch, haste\nWhen Queen Marchesa enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with deathtouch and haste.",
             "colours": [
@@ -18176,7 +18176,7 @@
         },
         {
             "id": "0211c102-fc7f-5033-b372-782d1be6e145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f275-6d3e-4040-a60e-8259a82befdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2143f275-6d3e-4040-a60e-8259a82befdb.jpg?1",
             "name": "Rakdos, Lord of Riots",
             "text": "You can't cast this spell unless an opponent lost life this turn.\nFlying, trample\nCreature spells you cast cost {1} less to cast for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -18213,7 +18213,7 @@
         },
         {
             "id": "40946f30-4037-5350-8df6-f349cb7fb12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde62b0c-ea15-4b25-9cb1-697cc2e459c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde62b0c-ea15-4b25-9cb1-697cc2e459c0.jpg?1",
             "name": "Ravos, Soultender",
             "text": "Flying\nOther creatures you control get +1/+1.\nAt the beginning of your upkeep, you may return target creature card from your graveyard to your hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18251,7 +18251,7 @@
         },
         {
             "id": "6ec1302e-c70e-558d-8af7-e03630e23bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a34158d-9925-4de8-b862-d1cc06bbae60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a34158d-9925-4de8-b862-d1cc06bbae60.jpg?1",
             "name": "Reyhan, Last of the Abzan",
             "text": "Reyhan, Last of the Abzan enters the battlefield with three +1/+1 counters on it.\nWhenever a creature you control dies or is put into the command zone, if it had one or more +1/+1 counters on it, you may put that many +1/+1 counters on target creature.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18289,7 +18289,7 @@
         },
         {
             "id": "c9da1a6f-469a-583d-a26a-307c143eb94b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6593325-d279-43ca-a3bc-576852aaa4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6593325-d279-43ca-a3bc-576852aaa4f6.jpg?1",
             "name": "Sidar Kondo of Jamuraa",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nCreatures your opponents control without flying or reach can't block creatures with power 2 or less.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18327,7 +18327,7 @@
         },
         {
             "id": "94bf42da-623c-502c-8abc-9b725be98d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5e4382-3f5c-46c7-915f-df9373d316bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5e4382-3f5c-46c7-915f-df9373d316bf.jpg?1",
             "name": "Silas Renn, Seeker Adept",
             "text": "Deathtouch\nWhenever Silas Renn, Seeker Adept deals combat damage to a player, choose target artifact card in your graveyard. You may cast that card this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18365,7 +18365,7 @@
         },
         {
             "id": "945bf5ca-378e-53f6-a96a-4124e4ae11a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505876d-217f-43cb-b0cb-bf19208b98d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505876d-217f-43cb-b0cb-bf19208b98d2.jpg?1",
             "name": "Tana, the Bloodsower",
             "text": "Trample\nWhenever Tana, the Bloodsower deals combat damage to a player, create that many 1/1 green Saproling creature tokens.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18403,7 +18403,7 @@
         },
         {
             "id": "0ef6dc05-1c1d-5348-bd67-5d98f185b323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845bf543-0367-4d2c-81ba-e424bfbfb7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845bf543-0367-4d2c-81ba-e424bfbfb7de.jpg?1",
             "name": "Thrasios, Triton Hero",
             "text": "{4}: Scry 1, then reveal the top card of your library. If it's a land card, put it onto the battlefield tapped. Otherwise, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18441,7 +18441,7 @@
         },
         {
             "id": "12c42900-7a94-5f42-b9aa-7ac6b5e0056a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec4983f-c2ec-4bf5-9f14-e75f0a2788a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec4983f-c2ec-4bf5-9f14-e75f0a2788a6.jpg?1",
             "name": "Tymna the Weaver",
             "text": "Lifelink\nAt the beginning of your postcombat main phase, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18479,7 +18479,7 @@
         },
         {
             "id": "03512c0d-851c-5d6a-90a5-b17fc02345cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4dc32ca-89c9-4d3a-8809-846c34ef3592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4dc32ca-89c9-4d3a-8809-846c34ef3592.jpg?1",
             "name": "Vial Smasher the Fierce",
             "text": "Whenever you cast your first spell each turn, choose an opponent at random. Vial Smasher the Fierce deals damage equal to that spell's converted mana cost to that player or a planeswalker that player controls.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18517,7 +18517,7 @@
         },
         {
             "id": "0ac2867f-454d-568c-a5a3-8a1d180710a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5943d27d-6db2-422d-97f5-ae98270a2556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5943d27d-6db2-422d-97f5-ae98270a2556.jpg?1",
             "name": "Xenagos, God of Revels",
             "text": "Indestructible\nAs long as your devotion to red and green is less than seven, Xenagos isn't a creature.\nAt the beginning of combat on your turn, another target creature you control gains haste and gets +X/+X until end of turn, where X is that creature's power.",
             "colours": [
@@ -18555,7 +18555,7 @@
         },
         {
             "id": "f971607e-dbad-5646-aa12-a1fe5fd1e9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af7847e-82e6-45ed-834d-6f3bcba44017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af7847e-82e6-45ed-834d-6f3bcba44017.jpg?1",
             "name": "Yuriko, the Tiger's Shadow",
             "text": "Commander ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's converted mana cost.",
             "colours": [
@@ -18593,7 +18593,7 @@
         },
         {
             "id": "7ecb7a65-90b4-5bfb-ad56-d142459d269d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f49150-9977-4ccb-b6cb-f89f7da9bf85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f49150-9977-4ccb-b6cb-f89f7da9bf85.jpg?1",
             "name": "Zedruu the Greathearted",
             "text": "At the beginning of your upkeep, you gain X life and draw X cards, where X is the number of permanents you own that your opponents control.\n{U}{R}{W}: Target opponent gains control of target permanent you control.",
             "colours": [
@@ -18633,7 +18633,7 @@
         },
         {
             "id": "f8103731-7410-5f6e-aec4-82e58d00bd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a9385e-fe0f-41d0-8415-123431aa1fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a9385e-fe0f-41d0-8415-123431aa1fee.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with converted mana cost 3 or less and put it onto the battlefield. If you do, shuffle your library.",
             "colours": [
@@ -18673,7 +18673,7 @@
         },
         {
             "id": "e5cc5804-fd79-5619-9eaf-9cb1b0cba522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865c39e-847e-4dc6-8e6c-a4200124f21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865c39e-847e-4dc6-8e6c-a4200124f21f.jpg?1",
             "name": "Ramos, Dragon Engine",
             "text": "Flying\nWhenever you cast a spell, put a +1/+1 counter on Ramos, Dragon Engine for each of that spell's colors.\nRemove five +1/+1 counters from Ramos: Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Activate this ability only once each turn.",
             "colours": [],
@@ -18711,7 +18711,7 @@
         },
         {
             "id": "38cea5f8-c06a-5b0d-a736-a27027d723ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a221ac-2022-49b6-929e-91db38929a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a221ac-2022-49b6-929e-91db38929a9f.jpg?1",
             "name": "The Prismatic Piper",
             "text": "If The Prismatic Piper is your commander, choose a color before the game begins. The Prismatic Piper is the chosen color.\nPartner (You can have two commanders if both have partner.)",
             "colours": [],
@@ -18744,7 +18744,7 @@
         },
         {
             "id": "e3eb9426-cb43-5074-aae4-689c887b7a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a9ba3-1aaf-4422-9b24-7e388b9a6f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a9ba3-1aaf-4422-9b24-7e388b9a6f45.jpg?1",
             "name": "Akroma, Vision of Ixidor",
             "text": "Flying, first strike, vigilance, trample\nAt the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.\nPartner",
             "colours": [
@@ -18781,7 +18781,7 @@
         },
         {
             "id": "3ac00442-4f77-57fe-8a88-2cca65157ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee8919-65f7-475c-972a-36d9c8d063fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee8919-65f7-475c-972a-36d9c8d063fc.jpg?1",
             "name": "Alharu, Solemn Ritualist",
             "text": "When Alharu, Solemn Ritualist enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.\nWhenever a nontoken creature you control with a +1/+1 counter on it dies, create a 1/1 white Spirit creature token with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18819,7 +18819,7 @@
         },
         {
             "id": "15436eaf-5ee6-582e-8389-9715e5aa93ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb712a0-b648-460b-8d3d-7d920ed11a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb712a0-b648-460b-8d3d-7d920ed11a8c.jpg?1",
             "name": "Ardenn, Intrepid Archaeologist",
             "text": "At the beginning of combat on your turn, you may attach any number of Auras and Equipment you control to target permanent or player.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18857,7 +18857,7 @@
         },
         {
             "id": "3de3af53-1515-57fb-9418-5273dfc991fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7e280f-1f41-4d70-8f8c-bb77c66bcf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7e280f-1f41-4d70-8f8c-bb77c66bcf8b.jpg?1",
             "name": "Keleth, Sunmane Familiar",
             "text": "Whenever a commander you control attacks, put a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18894,7 +18894,7 @@
         },
         {
             "id": "db56c42d-edef-5c80-b574-9ff09b745c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba508669-c15d-4194-ac37-236d4fd3ece7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba508669-c15d-4194-ac37-236d4fd3ece7.jpg?1",
             "name": "Livio, Oathsworn Sentinel",
             "text": "{1}{W}: Choose another target creature. Its controller may exile it with an aegis counter on it.\n{2}{W}, {T}: Return all exiled cards with aegis counters on them to the battlefield under their owners' control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18932,7 +18932,7 @@
         },
         {
             "id": "aa93cc81-f25f-5f16-86b0-c88592e33a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c33648-fb0e-4460-aae6-f3793d86e689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c33648-fb0e-4460-aae6-f3793d86e689.jpg?1",
             "name": "Prava of the Steel Legion",
             "text": "As long as it's your turn, creature tokens you control get +1/+4.\n{3}{W}: Create a 1/1 white Soldier creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -18970,7 +18970,7 @@
         },
         {
             "id": "0dc11627-6034-58ac-b7c8-75c79cb97224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc74d047-9fcc-476f-bd4a-a74e52785ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc74d047-9fcc-476f-bd4a-a74e52785ebb.jpg?1",
             "name": "Radiant, Serra Archangel",
             "text": "Flying\nTap another untapped creature you control with flying: Radiant, Serra Archangel gains protection from the color of your choice until end of turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19007,7 +19007,7 @@
         },
         {
             "id": "0b33a208-9536-5074-ac6a-42843712d0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cfe1a-3ddd-481a-80d3-02504d3004dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936cfe1a-3ddd-481a-80d3-02504d3004dc.jpg?1",
             "name": "Rebbec, Architect of Ascension",
             "text": "Artifacts you control have protection from each converted mana cost among artifacts you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19045,7 +19045,7 @@
         },
         {
             "id": "dba1cfab-54ae-520e-b039-b9de25e8de72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af2dc41-202e-4aec-ba58-f5dec01eaf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af2dc41-202e-4aec-ba58-f5dec01eaf27.jpg?1",
             "name": "Brinelin, the Moon Kraken",
             "text": "When Brinelin, the Moon Kraken enters the battlefield or whenever you cast a spell with converted mana cost 6 or greater, you may return target nonland permanent to its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19082,7 +19082,7 @@
         },
         {
             "id": "90ff325e-8fa5-564e-9e8b-fddf69077751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c163d7-8e63-42d0-a943-7cea3771fd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c163d7-8e63-42d0-a943-7cea3771fd87.jpg?1",
             "name": "Eligeth, Crossroads Augur",
             "text": "Flying\nIf you would scry a number of cards, draw that many cards instead.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19119,7 +19119,7 @@
         },
         {
             "id": "5f878cba-e502-522a-a614-84a04d346abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae854d22-f511-4bed-b30f-b3b52aed50a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae854d22-f511-4bed-b30f-b3b52aed50a4.jpg?1",
             "name": "Esior, Wardwing Familiar",
             "text": "Flying\nSpells your opponents cast that target one or more commanders you control cost {3} more to cast.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19156,7 +19156,7 @@
         },
         {
             "id": "7c884200-85e3-5e39-8a91-7a909a12529e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4cf323-e645-4db2-82c3-6860ea8aa9a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4cf323-e645-4db2-82c3-6860ea8aa9a3.jpg?1",
             "name": "Ghost of Ramirez DePietro",
             "text": "Ghost of Ramirez DePietro can't be blocked by creatures with toughness 3 or greater.\nWhenever Ghost of Ramirez DePietro deals combat damage to a player, choose up to one target card in a graveyard that was discarded or put there from a library this turn. Put that card into its owner's hand.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19194,7 +19194,7 @@
         },
         {
             "id": "8973bfb0-98f1-55b5-a6d8-77d2ffa65a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81668017-5ba4-4f62-9e21-41de7a13ad76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81668017-5ba4-4f62-9e21-41de7a13ad76.jpg?1",
             "name": "Glacian, Powerstone Engineer",
             "text": "{T}, Tap X untapped artifacts you control: Look at the top X cards of your library. Put one of those cards into your hand and the rest into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19232,7 +19232,7 @@
         },
         {
             "id": "617d25f3-d774-5390-a50c-50d0412bbc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd85fd88-7e5b-494a-9106-c78602604a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd85fd88-7e5b-494a-9106-c78602604a1d.jpg?1",
             "name": "Malcolm, Keen-Eyed Navigator",
             "text": "Flying\nWhenever one or more Pirates you control deal damage to your opponents, you create a Treasure token for each opponent dealt damage. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19270,7 +19270,7 @@
         },
         {
             "id": "7009c686-a8bb-50b1-9aa8-078b1b632695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69639b23-9975-4356-ab7d-0aa3387e02c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69639b23-9975-4356-ab7d-0aa3387e02c7.jpg?1",
             "name": "Sakashima of a Thousand Faces",
             "text": "You may have Sakashima of a Thousand Faces enter the battlefield as a copy of another creature you control, except it has Sakashima of a Thousand Faces's other abilities.\nThe \"legend rule\" doesn't apply to permanents you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19308,7 +19308,7 @@
         },
         {
             "id": "cc22f482-ed44-5297-810e-fae2fcf4675c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3d31f8-f726-4b81-840b-c8ba2944d711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3d31f8-f726-4b81-840b-c8ba2944d711.jpg?1",
             "name": "Siani, Eye of the Storm",
             "text": "Flying\nWhenever Siani, Eye of the Storm attacks, scry X, where X is the number of attacking creatures with flying.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19346,7 +19346,7 @@
         },
         {
             "id": "141992f9-3a53-5581-a0b4-d88a541303be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a678a-d81a-4994-a864-0b1af80a39ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a678a-d81a-4994-a864-0b1af80a39ca.jpg?1",
             "name": "Armix, Filigree Thrasher",
             "text": "Whenever Armix, Filigree Thrasher attacks, you may discard a card. When you do, target creature defending player controls gets -X/-X until end of turn, where X is the number of artifacts you control plus the number of artifact cards in your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19384,7 +19384,7 @@
         },
         {
             "id": "3cf4e98f-3bb5-5dfa-a31c-6b7a8ddb81f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb45a20-bfcc-45e2-9863-da58f5e9a0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb45a20-bfcc-45e2-9863-da58f5e9a0e0.jpg?1",
             "name": "Falthis, Shadowcat Familiar",
             "text": "Commanders you control have menace and deathtouch.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19422,7 +19422,7 @@
         },
         {
             "id": "963a46b5-3128-5d69-a654-760b8d86235c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6448e6e-f625-4dce-a7b9-01fee55cce6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6448e6e-f625-4dce-a7b9-01fee55cce6f.jpg?1",
             "name": "Keskit, the Flesh Sculptor",
             "text": "{T}, Sacrifice three other artifacts and/or creatures: Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19461,7 +19461,7 @@
         },
         {
             "id": "ab5d353b-ae7c-5063-bd60-3bb136bada04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d1cf4-bdf2-4ed3-8583-38309807ce93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d1cf4-bdf2-4ed3-8583-38309807ce93.jpg?1",
             "name": "Miara, Thorn of the Glade",
             "text": "Whenever Miara, Thorn of the Glade or another Elf you control dies, you may pay {1} and 1 life. If you do, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19499,7 +19499,7 @@
         },
         {
             "id": "2cc432ba-3b54-57e8-95e3-f46dc8462624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706b078f-0355-45cd-94db-26b925777efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706b078f-0355-45cd-94db-26b925777efe.jpg?1",
             "name": "Nadier, Agent of the Duskenel",
             "text": "Whenever a token you control leaves the battlefield, put a +1/+1 counter on Nadier, Agent of the Duskenel.\nWhen Nadier leaves the battlefield, create a number of 1/1 green Elf Warrior creature tokens equal to its power.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19537,7 +19537,7 @@
         },
         {
             "id": "e511d4fa-81ee-5879-a9fd-fe2217aba7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e44b5ff-450b-4345-902e-5721af142cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e44b5ff-450b-4345-902e-5721af142cdb.jpg?1",
             "name": "Sengir, the Dark Baron",
             "text": "Flying\nWhenever another creature dies, put two +1/+1 counters on Sengir, the Dark Baron.\nWhenever another player loses the game, you gain life equal to that player's life total as the turn began.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19576,7 +19576,7 @@
         },
         {
             "id": "075d381a-35ff-583a-91ad-94570f6b8260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aab532-0f3e-4569-9bef-18ce90654e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aab532-0f3e-4569-9bef-18ce90654e5d.jpg?1",
             "name": "Tormod, the Desecrator",
             "text": "Whenever one or more cards leave your graveyard, create a tapped 2/2 black Zombie creature token.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19614,7 +19614,7 @@
         },
         {
             "id": "2a82d516-e291-530b-8a0a-9ff0846e419c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011dc183-eb83-4c66-9604-63d9ecf33705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011dc183-eb83-4c66-9604-63d9ecf33705.jpg?1",
             "name": "Alena, Kessig Trapper",
             "text": "First strike\n{T}: Add an amount of {R} equal to the greatest power among creatures you control that entered the battlefield this turn.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19652,7 +19652,7 @@
         },
         {
             "id": "ed8f3f3a-9ef7-5e67-a8aa-a2957bafcd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef509abb-55d8-4c5c-b8c0-eec424665b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef509abb-55d8-4c5c-b8c0-eec424665b1e.jpg?1",
             "name": "Breeches, Brazen Plunderer",
             "text": "Menace\nWhenever one or more Pirates you control deal damage to your opponents, exile the top card of each of those opponents' libraries. You may play those cards this turn, and you may spend mana as though it were mana of any color to cast those spells.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19690,7 +19690,7 @@
         },
         {
             "id": "fda46d24-dd16-59a7-a28f-af631fde890d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf0cc0f-84fd-420e-ac90-b3f0bd49e2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf0cc0f-84fd-420e-ac90-b3f0bd49e2bb.jpg?1",
             "name": "Dargo, the Shipwrecker",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of artifacts and/or creatures. This spell costs {2} less to cast for each permanent sacrificed this way and {2} less to cast for each other artifact or creature you've sacrificed this turn.\nTrample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19728,7 +19728,7 @@
         },
         {
             "id": "60e88338-8476-5b95-98e2-71956ba8be9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23766fa0-e673-46c7-a29f-3fb140844b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23766fa0-e673-46c7-a29f-3fb140844b1c.jpg?1",
             "name": "Kediss, Emberclaw Familiar",
             "text": "Whenever a commander you control deals combat damage to an opponent, it deals that much damage to each other opponent.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19766,7 +19766,7 @@
         },
         {
             "id": "6203bb3b-66f7-5c12-9a4c-626afe64d6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69482de1-4959-4fd5-a314-983bde659c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69482de1-4959-4fd5-a314-983bde659c5d.jpg?1",
             "name": "Krark, the Thumbless",
             "text": "Whenever you cast an instant or sorcery spell, flip a coin. If you lose the flip, return that spell to its owner's hand. If you win the flip, copy that spell, and you may choose new targets for the copy.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19804,7 +19804,7 @@
         },
         {
             "id": "aa96aa16-62a1-5296-a061-acc38bb24417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7c27a-47e4-47d1-90b3-88a936839cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e7c27a-47e4-47d1-90b3-88a936839cbc.jpg?1",
             "name": "Rograkh, Son of Rohgahh",
             "text": "First strike, menace, trample\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19842,7 +19842,7 @@
         },
         {
             "id": "59834830-9c2e-5f8a-af60-86c412db4a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a097ba-6242-4a28-a6f1-72a5b3ec3a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a097ba-6242-4a28-a6f1-72a5b3ec3a8f.jpg?1",
             "name": "Toggo, Goblin Weaponsmith",
             "text": "Whenever a land enters the battlefield under your control, create a colorless Equipment artifact token named Rock with \"Equipped creature has \u2018{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any target'\" and equip {1}.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19880,7 +19880,7 @@
         },
         {
             "id": "2b59cb18-f6f1-5f80-8a36-3ac26caae6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2aadfd-e35a-4a00-9d64-265b57526d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2aadfd-e35a-4a00-9d64-265b57526d05.jpg?1",
             "name": "Anara, Wolvid Familiar",
             "text": "As long as it's your turn, commanders you control have indestructible.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19918,7 +19918,7 @@
         },
         {
             "id": "a76c76cd-b1ed-50e3-aba4-069893af8654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a65e24-08f1-4006-9547-804751e8959c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a65e24-08f1-4006-9547-804751e8959c.jpg?1",
             "name": "Gilanra, Caller of Wirewood",
             "text": "{T}: Add {G}. When you spend this mana to cast a spell with converted mana cost 6 or greater, draw a card.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19956,7 +19956,7 @@
         },
         {
             "id": "a924a670-a7ae-56bc-95c2-fa6a8e5a3617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ad87f5-26da-445e-bdaa-8768d885444e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ad87f5-26da-445e-bdaa-8768d885444e.jpg?1",
             "name": "Halana, Kessig Ranger",
             "text": "Reach\nWhenever another creature enters the battlefield under your control, you may pay {2}. When you do, that creature deals damage equal to its power to target creature.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -19995,7 +19995,7 @@
         },
         {
             "id": "03d63500-e56a-518f-9c61-56f97767701f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77faeb0-f0f3-4934-bb39-808db8002efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77faeb0-f0f3-4934-bb39-808db8002efd.jpg?1",
             "name": "Ich-Tekik, Salvage Splicer",
             "text": "When Ich-Tekik, Salvage Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nWhenever an artifact is put into a graveyard from the battlefield, put a +1/+1 counter on Ich-Tekik and a +1/+1 counter on each Golem you control.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20034,7 +20034,7 @@
         },
         {
             "id": "e94e3646-a032-5666-89b2-0f2222ff3d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9848a1d6-ffb5-4961-80f9-38de374dc707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9848a1d6-ffb5-4961-80f9-38de374dc707.jpg?1",
             "name": "Kamahl, Heart of Krosa",
             "text": "At the beginning of combat on your turn, creatures you control get +3/+3 and gain trample until end of turn.\n{1}{G}: Until end of turn, target land you control becomes a 1/1 Elemental creature with vigilance, indestructible, and haste. It's still a land.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20072,7 +20072,7 @@
         },
         {
             "id": "fcb5400e-fd19-5847-b7bd-a29f6fd1decb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896f357e-38e6-4259-91bc-1c2e7119d1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896f357e-38e6-4259-91bc-1c2e7119d1d5.jpg?1",
             "name": "Kodama of the East Tree",
             "text": "Reach\nWhenever another permanent enters the battlefield under your control, if it wasn't put onto the battlefield with this ability, you may put a permanent card with equal or lesser converted mana cost from your hand onto the battlefield.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20109,7 +20109,7 @@
         },
         {
             "id": "a4d0dd35-2544-5731-b6f2-62e8f0f54b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1706a2-7dbe-405f-a435-d9f3a0c06760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1706a2-7dbe-405f-a435-d9f3a0c06760.jpg?1",
             "name": "Numa, Joraga Chieftain",
             "text": "At the beginning of combat on your turn, you may pay {X}{X}. When you do, distribute X +1/+1 counters among any number of target Elves.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20147,7 +20147,7 @@
         },
         {
             "id": "5c221d09-5aa7-54d5-b99e-968ab123f7c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1783d-751a-490f-abe3-4661a76fce9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc1783d-751a-490f-abe3-4661a76fce9e.jpg?1",
             "name": "Slurrk, All-Ingesting",
             "text": "Slurrk, All-Ingesting enters the battlefield with five +1/+1 counters on it.\nWhenever Slurrk or another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on each creature you control that has a +1/+1 counter on it.\nPartner (You can have two commanders if both have partner.)",
             "colours": [
@@ -20184,7 +20184,7 @@
         },
         {
             "id": "c8fcb117-3840-5111-ae06-24024c934ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53229b5c-20d9-4abb-b7be-fd58acdb4747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53229b5c-20d9-4abb-b7be-fd58acdb4747.jpg?1",
             "name": "Abomination of Llanowar",
             "text": "Vigilance, menace\nAbomination of Llanowar's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.",
             "colours": [
@@ -20224,7 +20224,7 @@
         },
         {
             "id": "9850d3e4-3788-5d89-85dc-10f5f5742435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31ad3a5-4e42-4f2c-badf-4cef2a39be41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31ad3a5-4e42-4f2c-badf-4cef2a39be41.jpg?1",
             "name": "Amareth, the Lustrous",
             "text": "Flying\nWhenever another permanent enters the battlefield under your control, look at the top card of your library. If it shares a card type with that permanent, you may reveal that card and put it into your hand.",
             "colours": [
@@ -20265,7 +20265,7 @@
         },
         {
             "id": "ff96aca5-7d64-5e7f-99e2-a6dda3f97daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750f26c2-d7ea-4d39-bef0-f1f84c631265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750f26c2-d7ea-4d39-bef0-f1f84c631265.jpg?1",
             "name": "Araumi of the Dead Tide",
             "text": "{T}, Exile cards from your graveyard equal to the number of opponents you have: Target creature card in your graveyard gains encore until end of turn. The encore cost is equal to its mana cost. (Exile the creature card and pay its mana cost: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)",
             "colours": [
@@ -20305,7 +20305,7 @@
         },
         {
             "id": "3ed262af-85a7-53be-9290-98f74498db65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5643c-26d9-4ada-bc03-cafda0f64f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5643c-26d9-4ada-bc03-cafda0f64f40.jpg?1",
             "name": "Archelos, Lagoon Mystic",
             "text": "As long as Archelos, Lagoon Mystic is tapped, other permanents enter the battlefield tapped.\nAs long as Archelos is untapped, other permanents enter the battlefield untapped.",
             "colours": [
@@ -20347,7 +20347,7 @@
         },
         {
             "id": "fe930e86-1cbd-551b-9acf-6452f80536c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17aa3ad-8f84-400e-ad73-e73ebcd5a4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17aa3ad-8f84-400e-ad73-e73ebcd5a4b0.jpg?1",
             "name": "Averna, the Chaos Bloom",
             "text": "As you cascade, you may put a land card from among the exiled cards onto the battlefield tapped. (Do this after the last card is exiled but before deciding whether to cast a nonland card.)",
             "colours": [
@@ -20389,7 +20389,7 @@
         },
         {
             "id": "7f2f9067-df5f-5353-a9af-d83493c371cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6c3f6e-3c46-47b2-abcc-8aeb2f12d2fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6c3f6e-3c46-47b2-abcc-8aeb2f12d2fa.jpg?1",
             "name": "Belbe, Corrupted Observer",
             "text": "At the beginning of each player's postcombat main phase, that player adds {C}{C} for each of your opponents who lost life this turn. (Damage causes loss of life.)",
             "colours": [
@@ -20430,7 +20430,7 @@
         },
         {
             "id": "a0e80e89-63e3-5b8f-88ac-fbf7adf7f469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88418f5-8f75-4144-b8f6-e1e5009fa341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88418f5-8f75-4144-b8f6-e1e5009fa341.jpg?1",
             "name": "Bell Borca, Spectral Sergeant",
             "text": "Note the converted mana cost of each card as it's put into exile.\nBell Borca, Spectral Sergeant's power is equal to the greatest number noted for it this turn.\nAt the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -20470,7 +20470,7 @@
         },
         {
             "id": "4693e4e3-886e-57d2-92b6-04e9db178d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7954777c-34c1-43c2-83e2-db2dbb82329c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7954777c-34c1-43c2-83e2-db2dbb82329c.jpg?1",
             "name": "Blim, Comedic Genius",
             "text": "Flying\nWhenever Blim, Comedic Genius deals combat damage to a player, that player gains control of target permanent you control. Then each player loses life and discards cards equal to the number of permanents they control but don't own.",
             "colours": [
@@ -20509,7 +20509,7 @@
         },
         {
             "id": "1b5d31f2-fc2e-5217-bc8c-263b4b86c1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7502db-947b-49ca-968c-58ee83bd19b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7502db-947b-49ca-968c-58ee83bd19b3.jpg?1",
             "name": "Captain Vargus Wrath",
             "text": "Whenever Captain Vargus Wrath attacks, Pirates you control get +1/+1 until end of turn for each time you've cast a commander from the command zone this game.",
             "colours": [
@@ -20549,7 +20549,7 @@
         },
         {
             "id": "41fa0c57-cc60-5ebf-a68f-33e968a7c4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2c725-6133-4264-96ac-d80fe85b3632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2c725-6133-4264-96ac-d80fe85b3632.jpg?1",
             "name": "Colfenor, the Last Yew",
             "text": "Vigilance, reach\nWhenever Colfenor, the Last Yew or another creature you control dies, return up to one other target creature card with lesser toughness from your graveyard to your hand.",
             "colours": [
@@ -20591,7 +20591,7 @@
         },
         {
             "id": "5b53ca44-d26f-5092-9598-0497f0c1f8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804a7bac-0425-4cab-817a-5cb3686ef5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804a7bac-0425-4cab-817a-5cb3686ef5bb.jpg?1",
             "name": "Ghen, Arcanum Weaver",
             "text": "{R}{W}{B}, {T}, Sacrifice an enchantment: Return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -20633,7 +20633,7 @@
         },
         {
             "id": "bfa34682-ed6d-59af-ad9e-1868624d8780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d14b74-437e-4421-b5da-efbad2e70adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d14b74-437e-4421-b5da-efbad2e70adb.jpg?1",
             "name": "Gnostro, Voice of the Crags",
             "text": "{T}: Choose one. X is the number of spells you've cast this turn.\n\u2022 Scry X.\n\u2022 Gnostro, Voice of the Crags deals X damage to target creature.\n\u2022 You gain X life.",
             "colours": [
@@ -20674,7 +20674,7 @@
         },
         {
             "id": "3588b4b8-9c57-5821-8420-908a3afc608d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ff4985-981c-4748-b6f4-5d0dab6c787b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ff4985-981c-4748-b6f4-5d0dab6c787b.jpg?1",
             "name": "Gor Muldrak, Amphinologist",
             "text": "You and permanents you control have protection from Salamanders.\nAt the beginning of your end step, each player who controls the fewest creatures creates a 4/3 blue Salamander Warrior creature token.",
             "colours": [
@@ -20714,7 +20714,7 @@
         },
         {
             "id": "74c6d5dc-3e25-5f73-9213-9d4b95827905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713cf745-c41a-4f37-94b3-1c5850b751f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713cf745-c41a-4f37-94b3-1c5850b751f4.jpg?1",
             "name": "Hamza, Guardian of Arashin",
             "text": "This spell costs {1} less to cast for each creature you control with a +1/+1 counter on it.\nCreature spells you cast cost {1} less to cast for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -20754,7 +20754,7 @@
         },
         {
             "id": "f0845468-53d5-5158-a234-ba7251777344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb5d3b3-d92f-4d2a-82cc-8cb166241dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb5d3b3-d92f-4d2a-82cc-8cb166241dc5.jpg?1",
             "name": "Hans Eriksson",
             "text": "Whenever Hans Eriksson attacks, reveal the top card of your library. If it's a creature card, put it onto the battlefield tapped and attacking defending player or a planeswalker they control. Otherwise, put that card into your hand. When you put a creature card onto the battlefield this way, it fights Hans Eriksson.",
             "colours": [
@@ -20794,7 +20794,7 @@
         },
         {
             "id": "05387126-ff2d-59b0-b7bc-2b05e6b8c50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d6f813-a1ff-49fe-9678-e0fcd12dea48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d6f813-a1ff-49fe-9678-e0fcd12dea48.jpg?1",
             "name": "Imoti, Celebrant of Bounty",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nSpells you cast with converted mana cost 6 or greater have cascade.",
             "colours": [
@@ -20834,7 +20834,7 @@
         },
         {
             "id": "7d2d6350-5ae5-5435-a773-05207066395f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b925277-89e7-4143-8985-46c2fe3aeb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b925277-89e7-4143-8985-46c2fe3aeb9c.jpg?1",
             "name": "Jared Carthalion, True Heir",
             "text": "When Jared Carthalion, True Heir enters the battlefield, target opponent becomes the monarch. You can't become the monarch this turn.\nIf damage would be dealt to Jared Carthalion while you're the monarch, prevent that damage and put that many +1/+1 counters on it.",
             "colours": [
@@ -20876,7 +20876,7 @@
         },
         {
             "id": "f92f2472-f08c-5007-8f53-b42f18bc4754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89552cac-5567-43f2-a566-be522f24c7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89552cac-5567-43f2-a566-be522f24c7b2.jpg?1",
             "name": "Juri, Master of the Revue",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Juri, Master of the Revue.\nWhen Juri dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -20916,7 +20916,7 @@
         },
         {
             "id": "e64848b0-cef8-5b52-9cea-6093cfe6d51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c614a61d-b988-40fb-9172-0f86a0e41997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c614a61d-b988-40fb-9172-0f86a0e41997.jpg?1",
             "name": "Kangee, Sky Warden",
             "text": "Flying, vigilance\nWhenever Kangee, Sky Warden attacks, attacking creatures with flying get +2/+0 until end of turn.\nWhenever Kangee blocks, blocking creatures with flying get +0/+2 until end of turn.",
             "colours": [
@@ -20956,7 +20956,7 @@
         },
         {
             "id": "272f6294-44b1-5836-95fd-a06335533556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d4b6e-44c3-4bf9-8edd-aebf97438f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30d4b6e-44c3-4bf9-8edd-aebf97438f19.jpg?1",
             "name": "Kwain, Itinerant Meddler",
             "text": "{T}: Each player may draw a card, then each player who drew a card this way gains 1 life.",
             "colours": [
@@ -20996,7 +20996,7 @@
         },
         {
             "id": "8a5ea143-6c6a-57e9-959e-fdcefa9413e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913752eb-b446-41f8-9914-f78f981b042b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913752eb-b446-41f8-9914-f78f981b042b.jpg?1",
             "name": "Lathiel, the Bounteous Dawn",
             "text": "Lifelink\nAt the beginning of each end step, if you gained life this turn, distribute up to that many +1/+1 counters among any number of other target creatures.",
             "colours": [
@@ -21035,7 +21035,7 @@
         },
         {
             "id": "8a1e924e-229b-56b8-8019-a98bd434005e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed90b377-8f27-47fc-a004-0f84f4ad6490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed90b377-8f27-47fc-a004-0f84f4ad6490.jpg?1",
             "name": "Liesa, Shroud of Dusk",
             "text": "Rather than pay {2} for each previous time you've cast this spell from the command zone this game, pay 2 life that many times.\nFlying, lifelink\nWhenever a player casts a spell, they lose 2 life.",
             "colours": [
@@ -21074,7 +21074,7 @@
         },
         {
             "id": "3777b628-6807-51dc-855a-12224af0f4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7247d7-fa1d-4d40-8630-e1874e41996b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7247d7-fa1d-4d40-8630-e1874e41996b.jpg?1",
             "name": "Nevinyrral, Urborg Tyrant",
             "text": "Hexproof from artifacts, creatures, and enchantments\nWhen Nevinyrral, Urborg Tyrant enters the battlefield, create a tapped 2/2 black Zombie creature token for each creature that died this turn.\nWhen Nevinyrral dies, you may pay {1}. When you do, destroy all artifacts, creatures, and enchantments.",
             "colours": [
@@ -21116,7 +21116,7 @@
         },
         {
             "id": "0982ee5b-de24-5872-92dd-1daace8f4d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f46923-2ffe-4bf8-8f19-ed3b60665426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f46923-2ffe-4bf8-8f19-ed3b60665426.jpg?1",
             "name": "Nymris, Oona's Trickster",
             "text": "Flash\nFlying\nWhenever you cast your first spell during each opponent's turn, look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
             "colours": [
@@ -21156,7 +21156,7 @@
         },
         {
             "id": "116e48fa-0c35-5fe9-9fa2-1fad0aeef52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa7030c-e3b8-4ea1-b245-60432ca6e303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa7030c-e3b8-4ea1-b245-60432ca6e303.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "{T}: The player whose turn it is may end the turn. (Exile all spells and abilities from the stack. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -21198,7 +21198,7 @@
         },
         {
             "id": "be8d49a5-7c34-51c9-b291-5d72d599a3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465c1e86-e828-44a0-802e-1cbba356c524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465c1e86-e828-44a0-802e-1cbba356c524.jpg?1",
             "name": "Reyav, Master Smith",
             "text": "Whenever a creature you control that's enchanted or equipped attacks, that creature gains double strike until end of turn.",
             "colours": [
@@ -21238,7 +21238,7 @@
         },
         {
             "id": "f3c2611f-afdf-5fbb-b185-982f74ba9d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4899773-c501-45e5-bf1f-8d818788d61f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4899773-c501-45e5-bf1f-8d818788d61f.jpg?1",
             "name": "Thalisse, Reverent Medium",
             "text": "At the beginning of each end step, create X 1/1 white Spirit creature tokens with flying, where X is the number of tokens you created this turn.",
             "colours": [
@@ -21278,7 +21278,7 @@
         },
         {
             "id": "dc7cd5cb-fda1-5fa4-9843-a3886e0a8442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491e74d-07e6-4467-90db-c5cb2627877f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491e74d-07e6-4467-90db-c5cb2627877f.jpg?1",
             "name": "Tuya Bearclaw",
             "text": "Whenever Tuya Bearclaw attacks, it gets +X/+X until end of turn, where X is the greatest power among other creatures you control.",
             "colours": [
@@ -21318,7 +21318,7 @@
         },
         {
             "id": "acaf7712-434a-5a18-a1c9-1f92081a7ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403b8d9c-da2e-4902-b198-edfcf16aea7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403b8d9c-da2e-4902-b198-edfcf16aea7f.jpg?1",
             "name": "Yurlok of Scorch Thrash",
             "text": "Vigilance\nA player losing unspent mana causes that player to lose that much life.\n{1}, {T}: Each player adds {B}{R}{G}.",
             "colours": [
@@ -21360,7 +21360,7 @@
         },
         {
             "id": "b9140d40-6aa5-5315-a1e0-c4e055b10bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9323237-9457-4751-8176-c322c9f6f9be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9323237-9457-4751-8176-c322c9f6f9be.jpg?1",
             "name": "Zara, Renegade Recruiter",
             "text": "Flying\nWhenever Zara, Renegade Recruiter attacks, look at defending player's hand. You may put a creature card from it onto the battlefield under your control tapped and attacking that player or a planeswalker they control. Return that creature to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -21400,7 +21400,7 @@
         },
         {
             "id": "fbb705d4-6133-562a-83fc-daca5013496c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e65d75-7fe1-4804-8cfa-d7a42bacacae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e65d75-7fe1-4804-8cfa-d7a42bacacae.jpg?1",
             "name": "Akroma's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Creatures you control gain flying, vigilance, and double strike until end of turn.\n\u2022 Creatures you control gain lifelink, indestructible, and protection from all colors until end of turn.",
             "colours": [
@@ -21434,7 +21434,7 @@
         },
         {
             "id": "e17b353f-1bd1-52e1-a901-dcb8f09fcd54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd14d110-185d-4812-a992-902e7b0ab880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd14d110-185d-4812-a992-902e7b0ab880.jpg?1",
             "name": "Archon of Coronation",
             "text": "Flying\nWhen Archon of Coronation enters the battlefield, you become the monarch.\nAs long as you're the monarch, damage doesn't cause you to lose life.",
             "colours": [
@@ -21470,7 +21470,7 @@
         },
         {
             "id": "17f9cd9e-46fe-5d72-9ebf-e4ba6621d7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255917-c54d-4569-b6f9-88a0e16c9064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac255917-c54d-4569-b6f9-88a0e16c9064.jpg?1",
             "name": "Armored Skyhunter",
             "text": "Flying\nWhenever Armored Skyhunter attacks, look at the top six cards of your library. You may put an Aura or Equipment card from among them onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control. Put the rest of those cards on the bottom of your library in a random order.",
             "colours": [
@@ -21507,7 +21507,7 @@
         },
         {
             "id": "9f63f232-d291-5f4f-840a-101cf9ab0323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5db772-5ced-485f-a559-81b4e41bbff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5db772-5ced-485f-a559-81b4e41bbff1.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -21541,7 +21541,7 @@
         },
         {
             "id": "5241d0f3-9356-56fe-a4eb-78cbeaf31c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059aef39-1d27-472e-8bb6-b6cd8dc8c45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059aef39-1d27-472e-8bb6-b6cd8dc8c45e.jpg?1",
             "name": "Court of Grace",
             "text": "When Court of Grace enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, create a 1/1 white Spirit creature token with flying. If you're the monarch, create a 4/4 white Angel creature token with flying instead.",
             "colours": [
@@ -21575,7 +21575,7 @@
         },
         {
             "id": "35227595-64ed-597d-a704-ca88b08dddc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8ca62e-a48c-4381-a100-7061a84d230e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8ca62e-a48c-4381-a100-7061a84d230e.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -21609,7 +21609,7 @@
         },
         {
             "id": "4841d914-ec0a-525a-9235-a01a8a8daf5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f50b6f-0049-4f2c-8a41-1345d1b88dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f50b6f-0049-4f2c-8a41-1345d1b88dae.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -21646,7 +21646,7 @@
         },
         {
             "id": "55402ce2-cf50-5acb-a895-6619552e43ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a307a1-d2b3-481b-92cd-14a2866a022d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a307a1-d2b3-481b-92cd-14a2866a022d.jpg?1",
             "name": "Promise of Tomorrow",
             "text": "Whenever a creature you control dies, exile it.\nAt the beginning of each end step, if you control no creatures, sacrifice Promise of Tomorrow and return all cards exiled with it to the battlefield under your control.",
             "colours": [
@@ -21680,7 +21680,7 @@
         },
         {
             "id": "57ec163e-2368-5a73-abef-f1851339ae58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02d7ad-51c1-4088-b55b-9cb2aa346dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02d7ad-51c1-4088-b55b-9cb2aa346dcb.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -21715,7 +21715,7 @@
         },
         {
             "id": "bd83e833-b993-5f36-ab96-3546fc401a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18fd49d-c91e-458e-9bf3-13724ec404f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18fd49d-c91e-458e-9bf3-13724ec404f4.jpg?1",
             "name": "Seraphic Greatsword",
             "text": "Equipped creature gets +2/+2.\nWhenever equipped creature attacks the player with the most life or tied for most life, create a 4/4 white Angel creature token with flying that's tapped and attacking that player.\nEquip {4}",
             "colours": [
@@ -21751,7 +21751,7 @@
         },
         {
             "id": "77b73017-2825-53d3-a000-b666f566fd26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528f9922-b0c3-410e-86ca-87495a4fbd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528f9922-b0c3-410e-86ca-87495a4fbd3d.jpg?1",
             "name": "Slash the Ranks",
             "text": "Destroy all creatures and planeswalkers except for commanders.",
             "colours": [
@@ -21785,7 +21785,7 @@
         },
         {
             "id": "d36682f6-cdfb-5389-a723-49a9be35f166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007f0aab-e4e1-48dd-b333-76dd5c7ebe67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007f0aab-e4e1-48dd-b333-76dd5c7ebe67.jpg?1",
             "name": "Soul of Eternity",
             "text": "Soul of Eternity's power and toughness are each equal to your life total.\nEncore {7}{W}{W}",
             "colours": [
@@ -21821,7 +21821,7 @@
         },
         {
             "id": "13f8f02e-4790-5862-83b9-440e6de052bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd33c0f5-5545-477a-9185-53c707983795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd33c0f5-5545-477a-9185-53c707983795.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -21855,7 +21855,7 @@
         },
         {
             "id": "3d4861f7-fa0a-5f35-bb0e-3c7da1660de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1dbbb8-c384-42fe-a9b3-ab94f18e360f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1dbbb8-c384-42fe-a9b3-ab94f18e360f.jpg?1",
             "name": "Triumphant Reckoning",
             "text": "Return all artifact, enchantment, and planeswalker cards from your graveyard to the battlefield.",
             "colours": [
@@ -21889,7 +21889,7 @@
         },
         {
             "id": "95692f70-b6be-5b17-9b74-1c0e4b77f333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b465a22b-6fea-4bf8-b290-fa3e1a4aa6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b465a22b-6fea-4bf8-b290-fa3e1a4aa6eb.jpg?1",
             "name": "Amphin Mutineer",
             "text": "When Amphin Mutineer enters the battlefield, exile up to one target non-Salamander creature. That creature's controller creates a 4/3 blue Salamander Warrior creature token.\nEncore {4}{U}{U}",
             "colours": [
@@ -21926,7 +21926,7 @@
         },
         {
             "id": "8adcb66a-79cd-54ff-b741-0014163140af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25532c00-d4c0-4f49-b306-6991e49d3c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25532c00-d4c0-4f49-b306-6991e49d3c4c.jpg?1",
             "name": "Arcane Denial",
             "text": "Counter target spell. Its controller may draw up to two cards at the beginning of the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -21960,7 +21960,7 @@
         },
         {
             "id": "9ad98a7e-b18a-5f9b-96c6-13985ed340d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0295f53a-0529-4809-9f57-0c3f747ca449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0295f53a-0529-4809-9f57-0c3f747ca449.jpg?1",
             "name": "Body of Knowledge",
             "text": "Body of Knowledge's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhenever Body of Knowledge is dealt damage, draw that many cards.",
             "colours": [
@@ -21996,7 +21996,7 @@
         },
         {
             "id": "4b20eacd-04cc-576e-a439-04b919f70cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c6f284-fc07-4849-8210-80f12f77f518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c6f284-fc07-4849-8210-80f12f77f518.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -22030,7 +22030,7 @@
         },
         {
             "id": "a80e8715-4688-52f7-8b7d-797ac61fe6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60d3606-6f90-43b4-b056-543f7245958f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60d3606-6f90-43b4-b056-543f7245958f.jpg?1",
             "name": "Court of Cunning",
             "text": "When Court of Cunning enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, any number of target players each mill two cards. If you're the monarch, each of those players mills ten cards instead.",
             "colours": [
@@ -22064,7 +22064,7 @@
         },
         {
             "id": "f28d126b-465c-5ecf-b778-055527dfd3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb642e0-a390-4079-b349-ff0ec29c610e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb642e0-a390-4079-b349-ff0ec29c610e.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -22098,7 +22098,7 @@
         },
         {
             "id": "e1aaa71d-c9fa-5aeb-9262-fcf933db3929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49d0990-2f3b-4fa9-a895-4148d65c3fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49d0990-2f3b-4fa9-a895-4148d65c3fff.jpg?1",
             "name": "Hullbreacher",
             "text": "Flash\nIf an opponent would draw a card except the first one they draw in each of their draw steps, instead you create a Treasure token.",
             "colours": [
@@ -22135,7 +22135,7 @@
         },
         {
             "id": "b66b75d8-3fa3-51ba-86c9-21670ac522be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850acddf-b3ec-4e6f-bd48-9d0a100d0df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850acddf-b3ec-4e6f-bd48-9d0a100d0df1.jpg?1",
             "name": "Laboratory Drudge",
             "text": "At the beginning of each end step, draw a card if you've cast a spell from a graveyard or activated an ability of a card in a graveyard this turn.",
             "colours": [
@@ -22172,7 +22172,7 @@
         },
         {
             "id": "06fa2550-a64d-5ae1-bcc2-abc2c7a2eaf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e351ec05-8c4d-4631-9dbf-7f85f664770b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e351ec05-8c4d-4631-9dbf-7f85f664770b.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's converted mana cost.",
             "colours": [
@@ -22206,7 +22206,7 @@
         },
         {
             "id": "9f22ea88-a94e-5654-98c7-8782f206be93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbba25f3-6258-43e7-a230-334de1c31dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbba25f3-6258-43e7-a230-334de1c31dc8.jpg?1",
             "name": "Mnemonic Deluge",
             "text": "Exile target instant or sorcery card from a graveyard. Copy that card three times. You may cast the copies without paying their mana costs. Exile Mnemonic Deluge.",
             "colours": [
@@ -22240,7 +22240,7 @@
         },
         {
             "id": "ef05f756-128e-59d5-b4fa-e48cb0bfc959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0e6ff7-eed1-4965-813f-00d92fb48a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0e6ff7-eed1-4965-813f-00d92fb48a1e.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U}",
             "colours": [
@@ -22276,7 +22276,7 @@
         },
         {
             "id": "9fcb6a1a-9d5f-516b-a8f8-59b5e28fbf47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab73a5-6c55-4c30-a965-8adf3dba2ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab73a5-6c55-4c30-a965-8adf3dba2ddd.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card.",
             "colours": [
@@ -22310,7 +22310,7 @@
         },
         {
             "id": "33d7199b-9b21-5459-8ec7-c0a804a3b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d313bc-2ae5-4f97-ae34-12da285d7fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d313bc-2ae5-4f97-ae34-12da285d7fa7.jpg?1",
             "name": "Sakashima's Protege",
             "text": "Flash\nCascade\nYou may have Sakashima's Protege enter the battlefield as a copy of any permanent that entered the battlefield this turn.",
             "colours": [
@@ -22346,7 +22346,7 @@
         },
         {
             "id": "d3d6b163-8f3e-5903-afc3-cf013460c433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d4d43-7a46-4f72-97a9-3958bf253a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d4d43-7a46-4f72-97a9-3958bf253a3a.jpg?1",
             "name": "Sakashima's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Target opponent chooses a creature they control. You gain control of it.\n\u2022 Choose a creature you control. Each other creature you control becomes a copy of that creature until end of turn.",
             "colours": [
@@ -22380,7 +22380,7 @@
         },
         {
             "id": "cb183b38-6074-5630-b5c6-8a67a010e49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d8061-e1f0-4bef-bf32-1e7358ae65b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d8061-e1f0-4bef-bf32-1e7358ae65b6.jpg?1",
             "name": "Sphinx of the Second Sun",
             "text": "Flying\nAt the beginning of your postcombat main phase, you get an additional beginning phase after this phase.",
             "colours": [
@@ -22416,7 +22416,7 @@
         },
         {
             "id": "d0980527-9733-5beb-a939-86b073fdfcbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068879c2-d923-414a-b2e8-0a80f2634865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068879c2-d923-414a-b2e8-0a80f2634865.jpg?1",
             "name": "Wrong Turn",
             "text": "Target opponent gains control of target creature.",
             "colours": [
@@ -22450,7 +22450,7 @@
         },
         {
             "id": "38904869-346f-5457-b269-0e7736472852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fcc6b0-778f-4dcd-874e-04549493a6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fcc6b0-778f-4dcd-874e-04549493a6ad.jpg?1",
             "name": "Court of Ambition",
             "text": "When Court of Ambition enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, each opponent loses 3 life unless they discard a card. If you're the monarch, instead each opponent loses 6 life unless they discard two cards.",
             "colours": [
@@ -22484,7 +22484,7 @@
         },
         {
             "id": "df7c81f1-5d60-50db-98ec-5c7054f68cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca318a56-f13e-46cb-819d-2cf8a2b16f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca318a56-f13e-46cb-819d-2cf8a2b16f0e.jpg?1",
             "name": "Cuombajj Witches",
             "text": "{T}: Cuombajj Witches deals 1 damage to any target and 1 damage to any target of an opponent's choice.",
             "colours": [
@@ -22521,7 +22521,7 @@
         },
         {
             "id": "521b70e2-1dba-5915-b2dc-268884f939c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5039df58-70f9-404e-8b18-d1169c77699c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5039df58-70f9-404e-8b18-d1169c77699c.jpg?1",
             "name": "Elvish Dreadlord",
             "text": "Deathtouch\nWhen Elvish Dreadlord dies, non-Elf creatures get -3/-3 until end of turn.\nEncore {5}{B}{B}",
             "colours": [
@@ -22558,7 +22558,7 @@
         },
         {
             "id": "3bbd4755-83d9-5ee1-a888-d2f783b90e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c8708-cd43-4f1e-b520-ef90cf2ba72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712c8708-cd43-4f1e-b520-ef90cf2ba72d.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -22595,7 +22595,7 @@
         },
         {
             "id": "aca7ab3f-e930-5727-8428-1370348e6c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d627c457-a1c2-451c-9ed8-ea55547e5b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d627c457-a1c2-451c-9ed8-ea55547e5b0d.jpg?1",
             "name": "Necrotic Hex",
             "text": "Each player sacrifices six creatures. You create six tapped 2/2 black Zombie creature tokens.",
             "colours": [
@@ -22629,7 +22629,7 @@
         },
         {
             "id": "32577336-fc50-5c2d-b86d-0d8abc257e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30039-580d-4ad0-a913-54298ceec42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30039-580d-4ad0-a913-54298ceec42e.jpg?1",
             "name": "Nightshade Harvester",
             "text": "Whenever a land enters the battlefield under an opponent's control, that player loses 1 life. Put a +1/+1 counter on Nightshade Harvester.",
             "colours": [
@@ -22666,7 +22666,7 @@
         },
         {
             "id": "a1506388-0629-5c52-b6d0-a420986be656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b218531-9f5c-4ffb-9d2f-f2ead5b9f221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b218531-9f5c-4ffb-9d2f-f2ead5b9f221.jpg?1",
             "name": "Opposition Agent",
             "text": "Flash\nYou control your opponents while they're searching their libraries.\nWhile an opponent is searching their library, they exile each card they find. You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them.",
             "colours": [
@@ -22703,7 +22703,7 @@
         },
         {
             "id": "8f32d0e2-a43d-5165-a54d-5450647fd3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b092685-b0c8-4977-a86a-a167f79eb6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b092685-b0c8-4977-a86a-a167f79eb6b2.jpg?1",
             "name": "Plague Reaver",
             "text": "At the beginning of your end step, sacrifice each other creature you control.\nDiscard two cards, Sacrifice Plague Reaver: Choose target opponent. Return Plague Reaver to the battlefield under that player's control at the beginning of their next upkeep.",
             "colours": [
@@ -22739,7 +22739,7 @@
         },
         {
             "id": "bead20d3-1ecc-59b9-9fca-093296e6aeca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3387cfc-2dbe-409e-bfc7-b399f05a817d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3387cfc-2dbe-409e-bfc7-b399f05a817d.jpg?1",
             "name": "Profane Transfusion",
             "text": "Two target players exchange life totals. You create an X/X colorless Horror artifact creature token, where X is the difference between those players' life totals.",
             "colours": [
@@ -22773,7 +22773,7 @@
         },
         {
             "id": "f67b5428-8925-5bf3-b0d2-7cf995f2e4f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d28b259-a368-484d-898f-ef29219a0135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d28b259-a368-484d-898f-ef29219a0135.jpg?1",
             "name": "Rakshasa Debaser",
             "text": "Whenever Rakshasa Debaser attacks, put target creature card from defending player's graveyard onto the battlefield under your control.\nEncore {6}{B}{B}",
             "colours": [
@@ -22810,7 +22810,7 @@
         },
         {
             "id": "8d8e65cd-2db5-541f-b1a8-c0c714146ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4eaff0d-678b-47ab-915d-12e4fa43bb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4eaff0d-678b-47ab-915d-12e4fa43bb6b.jpg?1",
             "name": "Szat's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Each opponent sacrifices a creature they control with the greatest power.\n\u2022 Exile all cards from all opponents' graveyards, then create X 0/1 black Thrull creature tokens, where X is the greatest power among creature cards exiled this way.",
             "colours": [
@@ -22844,7 +22844,7 @@
         },
         {
             "id": "9003521c-3006-5d46-97a9-3fa8ebc5372b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1b4cec-68e0-4259-9be5-565d927017d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1b4cec-68e0-4259-9be5-565d927017d9.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -22878,7 +22878,7 @@
         },
         {
             "id": "801a9ddb-d28a-5e9a-9cf4-2b0f74c24aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6eaeb18-a7e3-4b7d-b2c2-04a66a5b89d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6eaeb18-a7e3-4b7d-b2c2-04a66a5b89d6.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -22912,7 +22912,7 @@
         },
         {
             "id": "06675080-e645-5f6d-a357-9c37ff6981c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e1c1c3-641a-4cd5-b46d-e03e5e529cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e1c1c3-641a-4cd5-b46d-e03e5e529cc7.jpg?1",
             "name": "Viscera Seer",
             "text": "Sacrifice a creature: Scry 1.",
             "colours": [
@@ -22949,7 +22949,7 @@
         },
         {
             "id": "4986aa22-de4e-5f16-88bd-f378f8071905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f984662-8fe0-42eb-8031-89c80315dede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f984662-8fe0-42eb-8031-89c80315dede.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -22983,7 +22983,7 @@
         },
         {
             "id": "8901c5ba-b621-5987-a368-8c111ec2e279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af03a68-0746-4d9c-8b91-1305e2751700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af03a68-0746-4d9c-8b91-1305e2751700.jpg?1",
             "name": "Aurora Phoenix",
             "text": "Flying\nCascade\nWhenever you cast a spell with cascade, return Aurora Phoenix from your graveyard to your hand.",
             "colours": [
@@ -23019,7 +23019,7 @@
         },
         {
             "id": "f21cf086-968e-547c-a619-e01fe14759a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ddab6f-0d13-4ec7-908d-54edb09b5727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ddab6f-0d13-4ec7-908d-54edb09b5727.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -23053,7 +23053,7 @@
         },
         {
             "id": "c714eda0-6f34-55ec-8edd-70e40a0663ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daee74d-aaf9-41bb-96f4-6d967cd4faf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daee74d-aaf9-41bb-96f4-6d967cd4faf7.jpg?1",
             "name": "Coercive Recruiter",
             "text": "Whenever Coercive Recruiter or another Pirate enters the battlefield under your control, gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and becomes a Pirate in addition to its other types.",
             "colours": [
@@ -23090,7 +23090,7 @@
         },
         {
             "id": "fd87f93a-8202-5dc6-a66a-99a371bf9f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b67b7-900e-4b8b-a977-a96a71e198e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b67b7-900e-4b8b-a977-a96a71e198e1.jpg?1",
             "name": "Court of Ire",
             "text": "When Court of Ire enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, Court of Ire deals 2 damage to any target. If you're the monarch, it deals 7 damage to that player or permanent instead.",
             "colours": [
@@ -23124,7 +23124,7 @@
         },
         {
             "id": "c342285a-96e7-5613-8e6e-af78a119a889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1282-01fd-48a0-929f-356f6d7e201e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1282-01fd-48a0-929f-356f6d7e201e.jpg?1",
             "name": "Emberwilde Captain",
             "text": "When Emberwilde Captain enters the battlefield, you become the monarch.\nWhenever an opponent attacks you while you're the monarch, Emberwilde Captain deals damage to that player equal to the number of cards in their hand.",
             "colours": [
@@ -23161,7 +23161,7 @@
         },
         {
             "id": "0bc87a32-a633-5b53-b4f1-48bd3ad55343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f03399-c9f8-40ca-bee5-07217788c186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f03399-c9f8-40ca-bee5-07217788c186.jpg?1",
             "name": "Flamekin Herald",
             "text": "Commander spells you cast have cascade.",
             "colours": [
@@ -23198,7 +23198,7 @@
         },
         {
             "id": "d67b1870-6e98-5b94-b921-a03c7b064f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7f618-5757-4611-8689-e34690404992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea7f618-5757-4611-8689-e34690404992.jpg?1",
             "name": "Hellkite Courser",
             "text": "Flying\nWhen Hellkite Courser enters the battlefield, you may put a commander you own from the command zone onto the battlefield. It gains haste. Return it to the command zone at the beginning of the next end step.",
             "colours": [
@@ -23234,7 +23234,7 @@
         },
         {
             "id": "a4e8ee0f-69f7-564d-baed-72584bd0e10b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccce0e4-7f59-4ab8-86e7-1134226ed2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccce0e4-7f59-4ab8-86e7-1134226ed2de.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -23271,7 +23271,7 @@
         },
         {
             "id": "7002d446-9687-52b4-ab69-12540ea5986c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4d78f-af3e-4210-8886-231a40a6bd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4d78f-af3e-4210-8886-231a40a6bd98.jpg?1",
             "name": "Jeska's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Add {R} for each card in target opponent's hand.\n\u2022 Exile the top three cards of your library. You may play them this turn.",
             "colours": [
@@ -23305,7 +23305,7 @@
         },
         {
             "id": "c96fd644-4445-5bae-9ea8-5286fc93677a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77222431-9db0-4bc8-80be-7bfc7c48bc5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77222431-9db0-4bc8-80be-7bfc7c48bc5e.jpg?1",
             "name": "Port Razer",
             "text": "Whenever Port Razer deals combat damage to a player, untap each creature you control. After this combat phase, there is an additional combat phase.\nPort Razer can't attack a player it has already attacked this turn.",
             "colours": [
@@ -23342,7 +23342,7 @@
         },
         {
             "id": "5895f5b2-68b2-51db-9bf3-283abfd801ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6532b62a-3cc3-44ed-8eac-eaa091be3cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6532b62a-3cc3-44ed-8eac-eaa091be3cee.jpg?1",
             "name": "Soulfire Eruption",
             "text": "Choose any number of target creatures, planeswalkers, and/or players. For each of them, exile the top card of your library, then Soulfire Eruption deals damage equal to that card's converted mana cost to that permanent or player. You may play the exiled cards until the end of your next turn.",
             "colours": [
@@ -23376,7 +23376,7 @@
         },
         {
             "id": "190177ea-f4dd-59fa-a912-0487e3fb96aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796d5e7-78b9-419a-a04a-fa3232bd2906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796d5e7-78b9-419a-a04a-fa3232bd2906.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -23410,7 +23410,7 @@
         },
         {
             "id": "611f7491-a6e6-5130-856e-ec939e265070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943aa774-e149-431b-804a-310cca6de006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943aa774-e149-431b-804a-310cca6de006.jpg?1",
             "name": "Wheel of Misfortune",
             "text": "Each player secretly chooses a number 0 or greater, then all players reveal those numbers simultaneously and determine the highest and lowest numbers revealed this way. Wheel of Misfortune deals damage equal to the highest number to each player who chose that number. Each player who didn't choose the lowest number discards their hand, then draws seven cards.",
             "colours": [
@@ -23444,7 +23444,7 @@
         },
         {
             "id": "1a8abb85-2cc4-55c0-8edd-79b21688d0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551afb4c-17e8-424f-ace3-b2c184b16b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551afb4c-17e8-424f-ace3-b2c184b16b2a.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -23480,7 +23480,7 @@
         },
         {
             "id": "08471660-8ffa-5eb8-9152-1e34a2123fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b345eb6f-ef2e-4d24-964c-252956031e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b345eb6f-ef2e-4d24-964c-252956031e4f.jpg?1",
             "name": "Apex Devastator",
             "text": "Cascade, cascade, cascade, cascade",
             "colours": [
@@ -23517,7 +23517,7 @@
         },
         {
             "id": "26b3a9dd-b257-5736-b9be-b84f19d48e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699ee8a9-a06c-4f95-9308-f8f7fb272568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699ee8a9-a06c-4f95-9308-f8f7fb272568.jpg?1",
             "name": "Biowaste Blob",
             "text": "Oozes you control get +1/+1.\nAt the beginning of your upkeep, if you control a commander, create a token that's a copy of Biowaste Blob.",
             "colours": [
@@ -23553,7 +23553,7 @@
         },
         {
             "id": "a716295b-3a09-586a-9e3c-59c3af7b924f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c4205a-959d-4da8-b228-791fa1eed07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c4205a-959d-4da8-b228-791fa1eed07a.jpg?1",
             "name": "Court of Bounty",
             "text": "When Court of Bounty enters the battlefield, you become the monarch.\nAt the beginning of your upkeep, you may put a land card from your hand onto the battlefield. If you're the monarch, instead you may put a creature or land card from your hand onto the battlefield.",
             "colours": [
@@ -23587,7 +23587,7 @@
         },
         {
             "id": "82d5fc9c-ff48-598c-ad8a-97ae73bcd43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1c8567-9d47-433c-b8d6-101d43f62a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1c8567-9d47-433c-b8d6-101d43f62a9a.jpg?1",
             "name": "Dawnglade Regent",
             "text": "When Dawnglade Regent enters the battlefield, you become the monarch.\nAs long as you're the monarch, permanents you control have hexproof.",
             "colours": [
@@ -23623,7 +23623,7 @@
         },
         {
             "id": "83e0b92d-fc7e-5540-b644-d656e8bb80da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8bf526-1260-40a1-b007-10ff9340f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8bf526-1260-40a1-b007-10ff9340f10b.jpg?1",
             "name": "Fyndhorn Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -23660,7 +23660,7 @@
         },
         {
             "id": "a7829b39-4b1c-5d49-9b56-f78d51140ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3ae08c-aa65-441e-a1cd-8bcb8bda5e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3ae08c-aa65-441e-a1cd-8bcb8bda5e33.jpg?1",
             "name": "Immaculate Magistrate",
             "text": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
             "colours": [
@@ -23697,7 +23697,7 @@
         },
         {
             "id": "c2129743-d75b-51fc-92fc-b7850fe75715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98793-8bc0-419b-a1a9-7360f370bcdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98793-8bc0-419b-a1a9-7360f370bcdf.jpg?1",
             "name": "Kamahl's Will",
             "text": "Choose one. If you control a commander as you cast this spell, you may choose both.\n\u2022 Until end of turn, any number of target lands you control become 1/1 Elemental creatures with vigilance, indestructible, and haste. They're still lands.\n\u2022 Choose target creature you don't control. Each creature you control deals damage equal to its power to that creature.",
             "colours": [
@@ -23731,7 +23731,7 @@
         },
         {
             "id": "95cfab69-435d-57f5-bfc3-9c0f890a2cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3eec2c0-dfe4-489a-a3e3-1bdb94707305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3eec2c0-dfe4-489a-a3e3-1bdb94707305.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -23767,7 +23767,7 @@
         },
         {
             "id": "9e1a223e-5adc-5c12-a856-969e729d870d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c861f78-c04a-41a9-bfca-54f22656973f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c861f78-c04a-41a9-bfca-54f22656973f.jpg?1",
             "name": "Magus of the Order",
             "text": "{G}, {T}, Sacrifice Magus of the Order and another green creature: Search your library for a green creature card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -23804,7 +23804,7 @@
         },
         {
             "id": "b6d0578d-7895-54e3-bf09-f5848cc8e1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa9a70-1221-4dba-8c2c-9872913021cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa9a70-1221-4dba-8c2c-9872913021cd.jpg?1",
             "name": "Reshape the Earth",
             "text": "Search your library for up to ten land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -23838,7 +23838,7 @@
         },
         {
             "id": "43575fb6-03dc-5c19-a060-9c76e97e799d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bea124-3241-4c0a-8863-a2e603c66126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bea124-3241-4c0a-8863-a2e603c66126.jpg?1",
             "name": "Rootweaver Druid",
             "text": "When Rootweaver Druid enters the battlefield, each opponent may search their library for up to three basic land cards. They each put one of those cards onto the battlefield tapped under your control and the rest onto the battlefield tapped under their control. Then each player who searched their library this way shuffles it.",
             "colours": [
@@ -23875,7 +23875,7 @@
         },
         {
             "id": "4d0acc8c-96c6-568d-9e1f-7db90feec15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5ffa3d-ecff-457f-9216-f4e8d3202536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5ffa3d-ecff-457f-9216-f4e8d3202536.jpg?1",
             "name": "Sweet-Gum Recluse",
             "text": "Flash\nCascade\nReach\nWhen Sweet-Gum Recluse enters the battlefield, put three +1/+1 counters on each of any number of target creatures that entered the battlefield this turn.",
             "colours": [
@@ -23911,7 +23911,7 @@
         },
         {
             "id": "a2f30516-1d70-58cc-93c1-6166ef52334f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9037cf0e-6e5f-455f-941c-b909a03e770f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9037cf0e-6e5f-455f-941c-b909a03e770f.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -23945,7 +23945,7 @@
         },
         {
             "id": "e9dd7f93-cf24-50d9-aabf-c5094f6f77a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607d5bb1-001a-451a-8021-434f7c0eda93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607d5bb1-001a-451a-8021-434f7c0eda93.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014\n\u2022 Boros Charm deals 4 damage to target player or planeswalker.\n\u2022 Permanents you control gain indestructible until end of turn.\n\u2022 Target creature gains double strike until end of turn.",
             "colours": [
@@ -23981,7 +23981,7 @@
         },
         {
             "id": "089ecf05-d207-5b14-adb5-fdb44253bd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ddfce6-5b8c-4ce1-a329-6a4a4576ca9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ddfce6-5b8c-4ce1-a329-6a4a4576ca9c.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -24021,7 +24021,7 @@
         },
         {
             "id": "cc5a2db8-d84d-50b1-817a-e361018de80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40924da3-c974-4b37-ad35-e7d8e4cd3d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40924da3-c974-4b37-ad35-e7d8e4cd3d4a.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -24051,7 +24051,7 @@
         },
         {
             "id": "d67ea288-4eb1-50a4-8c7e-02a25191c4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d90634-df3f-470b-aa1e-833a3b7b42f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d90634-df3f-470b-aa1e-833a3b7b42f5.jpg?1",
             "name": "Bladegriff Prototype",
             "text": "Flying\nWhenever Bladegriff Prototype deals combat damage to a player, destroy target nonland permanent of that player's choice that one of your opponents controls.",
             "colours": [],
@@ -24084,7 +24084,7 @@
         },
         {
             "id": "c8f1705a-793d-569c-9f00-d8f598fa4b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dddd41-ae59-4e5e-bac5-3695ba09edfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dddd41-ae59-4e5e-bac5-3695ba09edfd.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -24117,7 +24117,7 @@
         },
         {
             "id": "49e5fa5f-8051-5b23-9327-e4c6e0ff9df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f520601f-c092-4f83-9c21-66e999a01c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f520601f-c092-4f83-9c21-66e999a01c16.jpg?1",
             "name": "Commander's Plate",
             "text": "Equipped creature gets +3/+3 and has protection from each color that's not in your commander's color identity.\nEquip commander {3}\nEquip {5}",
             "colours": [],
@@ -24149,7 +24149,7 @@
         },
         {
             "id": "01462197-c897-5e29-8401-ec5b71dd81f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e75bf0-7f26-4852-b9e8-9576773ce78a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e75bf0-7f26-4852-b9e8-9576773ce78a.jpg?1",
             "name": "Commander's Sphere",
             "text": "{T}: Add one mana of any color in your commander's color identity.\nSacrifice Commander's Sphere: Draw a card.",
             "colours": [],
@@ -24179,7 +24179,7 @@
         },
         {
             "id": "50350f43-4c4c-5153-9669-2b979c784539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba7f1a7-5e3a-4567-8f4e-176f6322f4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba7f1a7-5e3a-4567-8f4e-176f6322f4a8.jpg?1",
             "name": "Horizon Stone",
             "text": "If you would lose unspent mana, that mana becomes colorless instead.",
             "colours": [],
@@ -24209,7 +24209,7 @@
         },
         {
             "id": "7af2e34e-5ca7-525d-8a74-ec7a74dd7d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c44abab-85ff-4196-a739-8e363df84aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c44abab-85ff-4196-a739-8e363df84aef.jpg?1",
             "name": "Jeweled Lotus",
             "text": "{T}, Sacrifice Jeweled Lotus: Add three mana of any one color. Spend this mana only to cast your commander.",
             "colours": [],
@@ -24239,7 +24239,7 @@
         },
         {
             "id": "fc096036-c5a4-5aa7-92b3-3146fbbcb92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9fbe2-3961-4096-aec5-f5358fa4b9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd9fbe2-3961-4096-aec5-f5358fa4b9fc.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -24269,7 +24269,7 @@
         },
         {
             "id": "95f30b32-1d90-5bfd-8ee9-4ac6cbe1670a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2730b56a-47b9-4042-bf5b-463392807f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2730b56a-47b9-4042-bf5b-463392807f36.jpg?1",
             "name": "Phyrexian Triniform",
             "text": "When Phyrexian Triniform dies, create three 3/3 colorless Golem artifact creature tokens.\nEncore {1}2",
             "colours": [],
@@ -24303,7 +24303,7 @@
         },
         {
             "id": "fbd5b0a7-956d-592d-b164-b441e7e50a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc00c6-5df2-4953-95c2-6c79dc86f409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc00c6-5df2-4953-95c2-6c79dc86f409.jpg?1",
             "name": "Rings of Brighthearth",
             "text": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [],
@@ -24333,7 +24333,7 @@
         },
         {
             "id": "94c4d72b-260c-599d-a53f-e1670c6ad6bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3826d13f-e10f-4201-b680-51f826ff4ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3826d13f-e10f-4201-b680-51f826ff4ca9.jpg?1",
             "name": "Scroll Rack",
             "text": "{1}, {T}: Exile any number of cards from your hand face down. Put that many cards from the top of your library into your hand. Then look at the exiled cards and put them on top of your library in any order.",
             "colours": [],
@@ -24363,7 +24363,7 @@
         },
         {
             "id": "30a1baad-4ff6-513b-beb4-60ca98eda8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21fc27-42d0-456a-9882-34d7f404270b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21fc27-42d0-456a-9882-34d7f404270b.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -24393,7 +24393,7 @@
         },
         {
             "id": "d706d944-2f74-507b-a3e2-c1e0679a3148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea92a1b-1340-4777-9452-840e0aa9332d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea92a1b-1340-4777-9452-840e0aa9332d.jpg?1",
             "name": "Staff of Domination",
             "text": "{1}: Untap Staff of Domination.\n{2}, {T}: You gain 1 life.\n{3}, {T}: Untap target creature.\n{4}, {T}: Tap target creature.\n{5}, {T}: Draw a card.",
             "colours": [],
@@ -24423,7 +24423,7 @@
         },
         {
             "id": "02d6d445-1ac3-5dad-a9c5-0782fd513acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b216-d383-4212-981e-5bc277c962a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b216-d383-4212-981e-5bc277c962a9.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -24455,7 +24455,7 @@
         },
         {
             "id": "f8475342-6484-5974-aa45-556f101d9d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699f796-4721-4c2a-8834-ea2b2b5b74c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699f796-4721-4c2a-8834-ea2b2b5b74c7.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -24485,7 +24485,7 @@
         },
         {
             "id": "9c10290a-098f-5b03-a868-23264d42b0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dc9b78-d1c0-4473-acfc-75825a7f9bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dc9b78-d1c0-4473-acfc-75825a7f9bb8.jpg?1",
             "name": "Command Beacon",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Command Beacon: Put your commander into your hand from the command zone.",
             "colours": [],
@@ -24515,7 +24515,7 @@
         },
         {
             "id": "bffcebef-8cf7-5851-85cc-628a0f8da4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148abd94-e752-4394-abce-21d594318b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148abd94-e752-4394-abce-21d594318b41.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -24546,7 +24546,7 @@
         },
         {
             "id": "6b394450-2f23-5327-908a-f0d8a662908f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06906eb-a417-411d-bc66-854c9cf8056d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06906eb-a417-411d-bc66-854c9cf8056d.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -24576,7 +24576,7 @@
         },
         {
             "id": "73fcc9d5-37d3-5c5a-9878-f40f21a671f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb789935-b0ba-427c-a0d5-93b006a28312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb789935-b0ba-427c-a0d5-93b006a28312.jpg?1",
             "name": "Opal Palace",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color in your commander's color identity. If you spend this mana to cast your commander, it enters the battlefield with a number of additional +1/+1 counters on it equal to the number of times it's been cast from the command zone this game.",
             "colours": [],
@@ -24606,7 +24606,7 @@
         },
         {
             "id": "5c3247c9-fce4-5fd3-ac16-dea8d30373ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c198ffd-50c8-46ae-a4bd-75c9d39f40de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c198ffd-50c8-46ae-a4bd-75c9d39f40de.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1.",
             "colours": [],
@@ -24636,7 +24636,7 @@
         },
         {
             "id": "10559477-0100-59df-95c9-5c209acd8299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5888b82e-79e0-4b8e-9c16-07dddc2bfeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5888b82e-79e0-4b8e-9c16-07dddc2bfeff.jpg?1",
             "name": "Rejuvenating Springs",
             "text": "Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -24669,7 +24669,7 @@
         },
         {
             "id": "dcfbc284-5de9-56c0-9ae6-67ddb82dfde0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3f701-4783-42ef-bfe5-20606ada49f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3f701-4783-42ef-bfe5-20606ada49f7.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -24699,7 +24699,7 @@
         },
         {
             "id": "154a9e7a-4a5f-52d6-aa96-1218e7366e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16e9306-79bc-451a-9046-6a0f8d4b9606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16e9306-79bc-451a-9046-6a0f8d4b9606.jpg?1",
             "name": "Spectator Seating",
             "text": "Spectator Seating enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -24732,7 +24732,7 @@
         },
         {
             "id": "1ff6b267-c056-5a3c-a583-e05f59613818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92b751-6162-4293-953b-ec7190309a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92b751-6162-4293-953b-ec7190309a6a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -24763,7 +24763,7 @@
         },
         {
             "id": "8f375f11-3623-5815-9a46-cac6a94adc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0efa5-6559-446b-a4d9-47585f6e94fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a0efa5-6559-446b-a4d9-47585f6e94fb.jpg?1",
             "name": "Training Center",
             "text": "Training Center enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -24796,7 +24796,7 @@
         },
         {
             "id": "6c5c10a6-231c-56cd-b6a1-66a64104005a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bd7a70-0cd1-48f2-96b6-7869c003a8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bd7a70-0cd1-48f2-96b6-7869c003a8c7.jpg?1",
             "name": "Undergrowth Stadium",
             "text": "Undergrowth Stadium enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -24829,7 +24829,7 @@
         },
         {
             "id": "85838ea7-58ee-55b4-901c-813223f550c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695a48e-391a-4ac1-93d6-35373e13718f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695a48e-391a-4ac1-93d6-35373e13718f.jpg?1",
             "name": "Vault of Champions",
             "text": "Vault of Champions enters the battlefield tapped unless you have two or more opponents.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -24862,7 +24862,7 @@
         },
         {
             "id": "a8f63e24-9659-5bf3-a0f4-8d904315a5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79793d28-64e4-4372-a0f7-468264c554a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79793d28-64e4-4372-a0f7-468264c554a0.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -24892,7 +24892,7 @@
         },
         {
             "id": "0f8e79b8-c429-5e9d-bb51-849c114bf5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb8d03e-e1d2-451e-97a8-141082f92501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb8d03e-e1d2-451e-97a8-141082f92501.jpg?1",
             "name": "Mana Confluence",
             "text": "",
             "colours": [],
@@ -24919,7 +24919,7 @@
         },
         {
             "id": "3bf1d039-6a10-53db-a78f-74326fed49e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d6256a-42b5-40f8-92e6-878d7002768f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d6256a-42b5-40f8-92e6-878d7002768f.jpg?1",
             "name": "Sengir, the Dark Baron",
             "text": "",
             "colours": [
@@ -24958,7 +24958,7 @@
         },
         {
             "id": "73b213cd-451a-5b18-a272-8f776c0763d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c65b6a-9c63-4604-b7db-d75772799616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c65b6a-9c63-4604-b7db-d75772799616.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -24993,7 +24993,7 @@
         },
         {
             "id": "6d497450-2c88-5142-a03c-dbbe74227ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430ed737-b918-4485-a623-e781c0beb67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430ed737-b918-4485-a623-e781c0beb67b.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -25028,7 +25028,7 @@
         },
         {
             "id": "afdf1b42-a3f9-50a2-bdc1-3fdb2f1992ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e580cb-6092-48b7-ba3e-d64ec28860da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e580cb-6092-48b7-ba3e-d64ec28860da.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -25063,7 +25063,7 @@
         },
         {
             "id": "20871e74-cf51-5956-8184-09ff568097a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0a6832-677f-4226-bd8d-f93eeeffd02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0a6832-677f-4226-bd8d-f93eeeffd02d.jpg?1",
             "name": "Salamander Warrior",
             "text": "",
             "colours": [
@@ -25099,7 +25099,7 @@
         },
         {
             "id": "54bad504-6cbd-5cb9-b16b-a1d6a04c248b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3042b-784c-4006-9bf1-60a323e60c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3042b-784c-4006-9bf1-60a323e60c5c.jpg?1",
             "name": "Thrull",
             "text": "",
             "colours": [
@@ -25134,7 +25134,7 @@
         },
         {
             "id": "1822997f-1ab6-5ff4-81ce-5d9fce80086e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d62c8ad-af51-493c-aef1-fe7774156d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d62c8ad-af51-493c-aef1-fe7774156d4b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -25169,7 +25169,7 @@
         },
         {
             "id": "fc7beddd-3df3-5984-a6e3-c59fdcac7ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f350ecf-67fa-49c8-a47d-9e5573851d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f350ecf-67fa-49c8-a47d-9e5573851d62.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -25204,7 +25204,7 @@
         },
         {
             "id": "f4dab64a-6da3-510f-b9d3-824abba40954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2aea59-c5f1-4927-8534-2215ef79bec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2aea59-c5f1-4927-8534-2215ef79bec7.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -25240,7 +25240,7 @@
         },
         {
             "id": "cf9d2b91-1654-5beb-9411-47cb73ebbb3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -25272,7 +25272,7 @@
         },
         {
             "id": "1bd3ecd2-7048-548f-ae5a-6410354766b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [],
@@ -25304,7 +25304,7 @@
         },
         {
             "id": "1657233e-c9e1-54ff-aa5a-6e2e2846be42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661cbde4-9444-4259-b2cf-7c8f9814a071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661cbde4-9444-4259-b2cf-7c8f9814a071.jpg?1",
             "name": "Rock",
             "text": "",
             "colours": [],
@@ -25335,7 +25335,7 @@
         },
         {
             "id": "6b23ba7a-3a1a-57fe-8492-a65c078a4d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284ec798-2725-4741-8748-578c259d0623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284ec798-2725-4741-8748-578c259d0623.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -25366,7 +25366,7 @@
         },
         {
             "id": "6fb54d70-bb1b-58bd-9cfc-36b142373be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1420c92f-a3f5-461a-b342-3708fa2212d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1420c92f-a3f5-461a-b342-3708fa2212d7.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -25394,7 +25394,7 @@
         },
         {
             "id": "3b337520-35b7-5f89-ac00-459637962b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7f3fc9-35f1-4b8c-b02b-494c71f31107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7f3fc9-35f1-4b8c-b02b-494c71f31107.jpg?1",
             "name": "The Monarch",
             "text": "",
             "colours": [],
@@ -25422,7 +25422,7 @@
         },
         {
             "id": "e3ee3e66-6fe5-56ca-b82b-317d6bea3beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b2c60-c995-441a-a3d6-20220d6cb7f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b2c60-c995-441a-a3d6-20220d6cb7f1.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -25456,7 +25456,7 @@
         },
         {
             "id": "9a28c20d-86fe-57ac-a3c3-ab330ed62190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b4c4d7-5b53-417a-a61b-df56eec4a274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b4c4d7-5b53-417a-a61b-df56eec4a274.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -25490,7 +25490,7 @@
         },
         {
             "id": "a97eeb64-a72f-5e72-bc3f-9be5896404cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274e711-42fd-489e-809d-77d3bce24422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274e711-42fd-489e-809d-77d3bce24422.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -25524,7 +25524,7 @@
         },
         {
             "id": "8903fa50-695b-57a5-8f42-acdb65adce94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d59ee8-446e-427f-ac88-53f5fa378384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d59ee8-446e-427f-ac88-53f5fa378384.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -25558,7 +25558,7 @@
         },
         {
             "id": "cf393d4e-6e10-54a0-8923-a5e8f31bd3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d90039-6e75-4c76-893d-cd1686a36be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d90039-6e75-4c76-893d-cd1686a36be9.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -25592,7 +25592,7 @@
         },
         {
             "id": "17970de2-7d33-583c-9f8e-ad8e4842225b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d495a-b4b7-4119-ae2d-5b602a0b309f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d495a-b4b7-4119-ae2d-5b602a0b309f.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -25626,7 +25626,7 @@
         },
         {
             "id": "a26835e5-4e0d-56b4-aa70-d79f8ddb1ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a2d72-595e-4212-837b-07445a2175bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a2d72-595e-4212-837b-07445a2175bf.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -25660,7 +25660,7 @@
         },
         {
             "id": "dcc3c1d2-e043-52d1-9a69-8a053a2d3137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08074778-ce6d-4a49-a1fc-1391d55e89be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08074778-ce6d-4a49-a1fc-1391d55e89be.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -25694,7 +25694,7 @@
         },
         {
             "id": "cf04eb05-5d99-5015-921c-d7df230b0341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f834ec3-0901-455a-a32d-aa5d3fcdb247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f834ec3-0901-455a-a32d-aa5d3fcdb247.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/CONX.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/CONX.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1193bca9-122b-5360-b8d8-bf2a1d4cc45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e86a42-cc53-4731-819a-e76f203a742a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e86a42-cc53-4731-819a-e76f203a742a.jpg?1",
             "name": "Aerie Mystics",
             "text": "Flying\n{1}{G}{U}: Creatures you control gain shroud until end of turn.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "45566024-0e50-54fc-8255-130ad8ec4f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b817f7-ae05-4d31-8a2c-29d8082b4132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b817f7-ae05-4d31-8a2c-29d8082b4132.jpg?1",
             "name": "Asha's Favor",
             "text": "Enchant creature\nEnchanted creature has flying, first strike, and vigilance.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "8b0abea3-3bc5-5182-87a0-9ceae30db938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60301dbd-40d1-4af8-8e2b-797febfa859f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60301dbd-40d1-4af8-8e2b-797febfa859f.jpg?1",
             "name": "Aven Squire",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "11b45ee3-86f5-592a-a427-21b2934d8d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb032cd3-96a4-4cef-bb89-0843f2ed8189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb032cd3-96a4-4cef-bb89-0843f2ed8189.jpg?1",
             "name": "Aven Trailblazer",
             "text": "Flying\nDomain Aven Trailblazer's toughness is equal to the number of basic land types among lands you control.",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "97ab0a82-618d-5ae6-a8c5-3c70e5cd7ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c404e8-1241-4675-b259-fbbf1dba15c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c404e8-1241-4675-b259-fbbf1dba15c4.jpg?1",
             "name": "Celestial Purge",
             "text": "Remove target black or red permanent from the game.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "18bf9754-6218-5b93-990b-12ed61d08aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd20150c-ae49-457d-9f64-b72160745ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd20150c-ae49-457d-9f64-b72160745ff9.jpg?1",
             "name": "Court Homunculus",
             "text": "Court Homunculus gets +1/+1 as long as you control another artifact.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "9e83dce9-c047-5596-b580-7927ee42dd12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7162e5-8c56-457e-91eb-b8ae4d1b6adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7162e5-8c56-457e-91eb-b8ae4d1b6adb.jpg?1",
             "name": "Darklit Gargoyle",
             "text": "Flying\n{B}: Darklit Gargoyle gets +2/-1 until end of turn.",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "c7dea9e0-1826-5768-acc8-c2ec7d3fcf46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a8e0b-bee8-4b0d-b671-a5d8084d82ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a8e0b-bee8-4b0d-b671-a5d8084d82ee.jpg?1",
             "name": "Gleam of Resistance",
             "text": "Creatures you control get +1/+2 until end of turn. Untap those creatures.\nBasic landcycling {1}{W} ({1}{W}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "98b03e4e-1134-5bed-9992-a1449a3f3b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec609036-dfbf-47de-9a3a-762aea4196d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec609036-dfbf-47de-9a3a-762aea4196d4.jpg?1",
             "name": "Lapse of Certainty",
             "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "79555f4f-9bf9-57ea-aedd-21da59ce1d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9801e68-9a03-491f-be23-f0b830c4a0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9801e68-9a03-491f-be23-f0b830c4a0c5.jpg?1",
             "name": "Mark of Asylum",
             "text": "Prevent all noncombat damage that would be dealt to creatures you control.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "ae962ce9-8f56-5b1e-8dde-7794fef61227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4201385f-6f74-4e3d-aafb-0eff82cb24c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4201385f-6f74-4e3d-aafb-0eff82cb24c1.jpg?1",
             "name": "Martial Coup",
             "text": "Put X 1/1 white Soldier creature tokens into play. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "fbc8fc63-d6a7-57fd-9c64-12f819b41e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b3eec-7420-45fa-8750-7f01028836d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b3eec-7420-45fa-8750-7f01028836d3.jpg?1",
             "name": "Mirror-Sigil Sergeant",
             "text": "Trample\nAt the beginning of your upkeep, if you control a blue permanent, you may put a token into play that's a copy of Mirror-Sigil Sergeant.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "24eaccac-1788-573e-9e11-5be75576ae0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49096592-5bd8-4db7-b38b-dcb5dea8c088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49096592-5bd8-4db7-b38b-dcb5dea8c088.jpg?1",
             "name": "Nacatl Hunt-Pride",
             "text": "Vigilance\n{R}, {T}: Target creature can't block this turn.\n{G}, {T}: Target creature blocks this turn if able.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "586745fd-fdfe-533c-bc0a-e26bf597fd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c4772-fa03-4b71-a95e-1ad8466d25da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21c4772-fa03-4b71-a95e-1ad8466d25da.jpg?1",
             "name": "Paragon of the Amesha",
             "text": "First strike\n{W}{U}{B}{R}{G}: Until end of turn, Paragon of the Amesha becomes an Angel, gets +3/+3, and gains flying and lifelink.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "1d9219ed-87ea-5d7c-9e1e-61c430a13238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7a8b1-b98e-483a-87a4-73bd831c03d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b7a8b1-b98e-483a-87a4-73bd831c03d4.jpg?1",
             "name": "Path to Exile",
             "text": "Remove target creature from the game. Its controller may search his or her library for a basic land card, put that card into play tapped, then shuffle his or her library.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "c7c090ed-f44a-54fa-9abd-8edff9061721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f4f8d-2191-4743-aac6-cdcb4a68379c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f4f8d-2191-4743-aac6-cdcb4a68379c.jpg?1",
             "name": "Rhox Meditant",
             "text": "When Rhox Meditant comes into play, if you control a green permanent, draw a card.",
             "colours": [
@@ -554,7 +554,7 @@
         },
         {
             "id": "e09e59be-cf86-563e-a33f-ef1b394b45b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg?1",
             "name": "Scepter of Dominance",
             "text": "{W}, {T}: Tap target permanent.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "eacbf3ae-50e2-5622-891b-64bb949d101e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c451f63-2827-49fe-9d1d-87c87f7f5f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c451f63-2827-49fe-9d1d-87c87f7f5f8d.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you play an enchantment spell, put a 4/4 white Angel creature token with flying into play.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "83275a85-b57b-5002-a8a8-0a13215f32ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ec1486-900b-4763-9b5b-390cb00aff02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ec1486-900b-4763-9b5b-390cb00aff02.jpg?1",
             "name": "Valiant Guard",
             "text": "",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "62857712-0612-5df1-802c-27218f013fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fc82-fc5a-4f60-bcd6-363c2deb769d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa3fc82-fc5a-4f60-bcd6-363c2deb769d.jpg?1",
             "name": "Wall of Reverence",
             "text": "Defender, flying\nAt the end of your turn, you may gain life equal to the power of target creature you control.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "09ba2ff2-86b2-573c-b795-5bc831359bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e324d70f-a6ca-4003-8420-83035fd4cd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e324d70f-a6ca-4003-8420-83035fd4cd00.jpg?1",
             "name": "Brackwater Elemental",
             "text": "When Brackwater Elemental attacks or blocks, sacrifice it at end of turn.\nUnearth {2}{U} ({2}{U}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "64e5d197-29d2-5658-8f93-9f3636b717e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a110be3-93ec-40ef-94a6-e4c43f1ce211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a110be3-93ec-40ef-94a6-e4c43f1ce211.jpg?1",
             "name": "Constricting Tendrils",
             "text": "Target creature gets -3/-0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "b63b5ddc-b6cf-590e-b6c2-5e2a799506d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e58e8-cb01-49b0-89b7-26536eb44e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e58e8-cb01-49b0-89b7-26536eb44e97.jpg?1",
             "name": "Controlled Instincts",
             "text": "Enchant red or green creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "4aff25df-63c5-5d42-8233-1637a0c3db01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7963ff52-1897-4f62-a91d-b0eaf155fce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7963ff52-1897-4f62-a91d-b0eaf155fce9.jpg?1",
             "name": "Cumber Stone",
             "text": "Creatures your opponents control get -1/-0.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "a8949060-7828-5c80-903c-4eda1069b81d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def637cb-40b2-4715-9b43-872c8f9aaabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def637cb-40b2-4715-9b43-872c8f9aaabe.jpg?1",
             "name": "Esperzoa",
             "text": "Flying\nAt the beginning of your upkeep, return an artifact you control to its owner's hand.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "03eb8da5-beb8-5104-b45d-dc8cc67972cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a056c-1e38-416b-bf01-2a1762b08020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a056c-1e38-416b-bf01-2a1762b08020.jpg?1",
             "name": "Ethersworn Adjudicator",
             "text": "Flying\n{1}{W}{B}, {T}: Destroy target creature or enchantment.\n{2}{U}: Untap Ethersworn Adjudicator.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "9db55084-d9ba-55f2-b71c-7f22f9d710c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d350ebd7-afcf-4d67-8173-b07cad3fa9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d350ebd7-afcf-4d67-8173-b07cad3fa9bc.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist comes into play, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "33ca8028-3847-5d59-b522-01676fce3204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46acbabc-9d0a-4fba-9604-7d131c22cdeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46acbabc-9d0a-4fba-9604-7d131c22cdeb.jpg?1",
             "name": "Frontline Sage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "613ba1f2-f9a1-51b7-9268-1eb5cd0911f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48352b88-857d-4386-83c6-0e047d11c15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48352b88-857d-4386-83c6-0e047d11c15b.jpg?1",
             "name": "Grixis Illusionist",
             "text": "{T}: Target land you control becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -999,7 +999,7 @@
         },
         {
             "id": "4c97d231-a316-54c1-bcea-2d1c4f0b99d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb380a5a-a3f9-42fb-ac5c-f54afa3c1079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb380a5a-a3f9-42fb-ac5c-f54afa3c1079.jpg?1",
             "name": "Inkwell Leviathan",
             "text": "Islandwalk, trample, shroud",
             "colours": [
@@ -1034,7 +1034,7 @@
         },
         {
             "id": "0744e381-5572-5941-a3e3-8b996c531908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252482b2-aaa7-49f3-af8c-30923ca98994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252482b2-aaa7-49f3-af8c-30923ca98994.jpg?1",
             "name": "Master Transmuter",
             "text": "{U}, {T}, Return an artifact you control to its owner's hand: You may put an artifact card from your hand into play.",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "3fda44a8-4712-54e7-8e98-dd7209d414a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36cd0c3-1955-41b1-9a9c-b30b31a2f094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36cd0c3-1955-41b1-9a9c-b30b31a2f094.jpg?1",
             "name": "Parasitic Strix",
             "text": "Flying\nWhen Parasitic Strix comes into play, if you control a black permanent, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -1105,7 +1105,7 @@
         },
         {
             "id": "591a223f-a788-5c6a-bd61-d94fa68d3401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg?1",
             "name": "Scepter of Insight",
             "text": "{3}{U}, {T}: Draw a card.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "fc9ac68a-6c95-5c8b-8160-a5eaf3b1484b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cdb2ff-6e30-4766-9166-9036a0bdb809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cdb2ff-6e30-4766-9166-9036a0bdb809.jpg?1",
             "name": "Scornful Aether-Lich",
             "text": "{W}{B}: Scornful \u00c6ther-Lich gains fear and vigilance until end of turn.",
             "colours": [
@@ -1175,7 +1175,7 @@
         },
         {
             "id": "6d7e0e83-569b-557c-9679-ee73f0c22567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac0f1fb-0ada-4b3c-b9bd-654ffc0a167d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac0f1fb-0ada-4b3c-b9bd-654ffc0a167d.jpg?1",
             "name": "Telemin Performance",
             "text": "Target opponent reveals cards from the top of his or her library until he or she reveals a creature card. That player puts all noncreature cards revealed this way into his or her graveyard, then you put the creature card into play under your control.",
             "colours": [
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "2a6a1a8a-a980-5826-9896-15014792f7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e8b03d-9265-4699-b626-5efa73292d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e8b03d-9265-4699-b626-5efa73292d43.jpg?1",
             "name": "Traumatic Visions",
             "text": "Counter target spell.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "a6a22cf7-499b-596a-84ce-3c5884e5890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b16d7d-836c-4b15-921b-ebe53e31044e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b16d7d-836c-4b15-921b-ebe53e31044e.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "861d8c52-259a-523c-a145-b47f1aab8a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc73034-4886-4855-b6de-392fa053fe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc73034-4886-4855-b6de-392fa053fe9e.jpg?1",
             "name": "View from Above",
             "text": "Target creature gains flying until end of turn. If you control a white permanent, return View from Above to its owner's hand.",
             "colours": [
@@ -1303,7 +1303,7 @@
         },
         {
             "id": "ecb0c495-0a0b-5fbc-a611-ab84ab6c13fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b454cbdc-b2ff-4b6a-acaf-b7cf52359f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b454cbdc-b2ff-4b6a-acaf-b7cf52359f0b.jpg?1",
             "name": "Worldly Counsel",
             "text": "Domain Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "a3c9a2bf-d421-5916-bb47-8647090fdc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5528886e-3198-48b1-a3b0-6d41ba87bfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5528886e-3198-48b1-a3b0-6d41ba87bfd6.jpg?1",
             "name": "Absorb Vis",
             "text": "Target player loses 4 life and you gain 4 life.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "9f655f7b-a888-5f8a-a9ce-0707c545acdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a7fe66-db40-4eca-8953-0eb2cf98e4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a7fe66-db40-4eca-8953-0eb2cf98e4e8.jpg?1",
             "name": "Corrupted Roots",
             "text": "Enchant Forest or Plains\nWhenever enchanted land becomes tapped, its controller loses 2 life.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "4ea95e7e-917c-5a90-b2b3-1e9744640dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03eb2163-cce2-4d07-b7d7-9c70a41fa373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03eb2163-cce2-4d07-b7d7-9c70a41fa373.jpg?1",
             "name": "Drag Down",
             "text": "Domain Target creature gets -1/-1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "d149c57f-badf-5d95-b8f6-0e4d29554d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb997b6-d872-438f-bf8a-db976bc27a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb997b6-d872-438f-bf8a-db976bc27a2d.jpg?1",
             "name": "Dreadwing",
             "text": "{1}{U}{R}: Dreadwing gets +3/+0 and gains flying until end of turn.",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "ac484d2d-82c3-5cb3-b950-a7f45e6ddd21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a382a-04ef-49d1-8cd6-1f587faa43cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a382a-04ef-49d1-8cd6-1f587faa43cd.jpg?1",
             "name": "Extractor Demon",
             "text": "Flying\nWhenever another creature leaves play, you may have target player put the top two cards of his or her library into his or her graveyard.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "ee71282e-a6d4-50c3-b4d2-04a34a01ce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c57090-c1fe-4100-a03c-95607074280e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c57090-c1fe-4100-a03c-95607074280e.jpg?1",
             "name": "Fleshformer",
             "text": "{W}{U}{B}{R}{G}: Fleshformer gets +2/+2 and gains fear until end of turn. Target creature gets -2/-2 until end of turn. Play this ability only during your turn.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "a5842159-7ccd-59ff-b771-2d506361956e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4851f-35aa-47c3-94b2-cdc166f9036f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4851f-35aa-47c3-94b2-cdc166f9036f.jpg?1",
             "name": "Grixis Slavedriver",
             "text": "When Grixis Slavedriver leaves play, put a 2/2 black Zombie creature token into play.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "694da27d-cb29-5f3b-bbbf-68470da23c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb460855-f09d-4460-9d3f-1bfcc7f3e626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb460855-f09d-4460-9d3f-1bfcc7f3e626.jpg?1",
             "name": "Infectious Horror",
             "text": "Whenever Infectious Horror attacks, each opponent loses 2 life.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "4ddee491-40dc-5d89-9ec9-3662143fb2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878c7d8c-4df0-43ac-8197-d89c8be5e70d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878c7d8c-4df0-43ac-8197-d89c8be5e70d.jpg?1",
             "name": "Kederekt Parasite",
             "text": "Whenever an opponent draws a card, if you control a red permanent, you may have Kederekt Parasite deal 1 damage to that player.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "168ada62-5401-54ce-83c4-7dbbc0de05ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c706ef-5a31-419d-83a3-d60522c14451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c706ef-5a31-419d-83a3-d60522c14451.jpg?1",
             "name": "Nyxathid",
             "text": "As Nyxathid comes into play, choose an opponent.\nNyxathid gets -1/-1 for each card in the chosen player's hand.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "456e2565-1b2f-52a9-b0fa-5810f4b342a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba00df7-2c8d-435a-86d1-6bd7b7413585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba00df7-2c8d-435a-86d1-6bd7b7413585.jpg?1",
             "name": "Pestilent Kathari",
             "text": "Flying\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)\n{2}{R}: Pestilent Kathari gains first strike until end of turn.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "7e0f56bb-814d-5c41-80dc-57d742e355e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dea310-8738-4fd9-b790-0361afe1e150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34dea310-8738-4fd9-b790-0361afe1e150.jpg?1",
             "name": "Rotting Rats",
             "text": "When Rotting Rats comes into play, each player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "5046daee-1683-5d23-a1b8-e4e6e1e6952c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b0fd1-7445-4dba-bb90-ddd5f5ee8573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b0fd1-7445-4dba-bb90-ddd5f5ee8573.jpg?1",
             "name": "Salvage Slasher",
             "text": "Salvage Slasher gets +1/+0 for each artifact card in your graveyard.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "95c25019-0d24-56aa-81ee-332548022fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg?1",
             "name": "Scepter of Fugue",
             "text": "{1}{B}, {T}: Target player discards a card. Play this ability only during your turn.",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "3ae9daa4-b3e6-5141-be8b-7375848943a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbc5d7-86d0-4e09-b37c-e40eb88f3f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbc5d7-86d0-4e09-b37c-e40eb88f3f33.jpg?1",
             "name": "Sedraxis Alchemist",
             "text": "When Sedraxis Alchemist comes into play, if you control a blue permanent, return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "a076d053-e117-592c-8b29-9a64062eae45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf285d7-c414-48ab-ad1f-1f49e586c278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf285d7-c414-48ab-ad1f-1f49e586c278.jpg?1",
             "name": "Voices from the Void",
             "text": "Domain Target player discards a card for each basic land type among lands you control.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "8fbfd931-cdb5-576b-901e-564ef8922709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaf55b-2de3-4c8a-90ae-9c88c9d00fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaf55b-2de3-4c8a-90ae-9c88c9d00fd7.jpg?1",
             "name": "Wretched Banquet",
             "text": "Destroy target creature if it has the least power or is tied for least power among creatures in play.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "a5586b10-2c00-5855-87db-f7c8ec417b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4625e1-4ba4-43cd-8147-059e4d50fd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4625e1-4ba4-43cd-8147-059e4d50fd37.jpg?1",
             "name": "Yoke of the Damned",
             "text": "Enchant creature\nWhen a creature is put into a graveyard from play, destroy enchanted creature.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "64f7436b-3261-5dae-8feb-110ee33361e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188c68a-e9df-4803-a722-1993dd88f833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b188c68a-e9df-4803-a722-1993dd88f833.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "78900170-2958-568d-9f38-f0cc348aaca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b7208e-aa64-43fa-b7f8-8d40d7005358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b7208e-aa64-43fa-b7f8-8d40d7005358.jpg?1",
             "name": "Bloodhall Ooze",
             "text": "At the beginning of your upkeep, if you control a black permanent, you may put a +1/+1 counter on Bloodhall Ooze.\nAt the beginning of your upkeep, if you control a green permanent, you may put a +1/+1 counter on Bloodhall Ooze.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "9d52d655-f845-55da-9612-0f9fe6d2263a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b200790-43c7-42ae-9edf-89c8198a385b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b200790-43c7-42ae-9edf-89c8198a385b.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -2053,7 +2053,7 @@
         },
         {
             "id": "46ff9f22-1fd9-5bf8-87bf-318f18611e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3209997-8cdc-40e9-9e95-92a0f33e7f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3209997-8cdc-40e9-9e95-92a0f33e7f8e.jpg?1",
             "name": "Dark Temper",
             "text": "Dark Temper deals 2 damage to target creature. If you control a black permanent, destroy the creature instead.",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "0b0384a2-b48d-54d1-9dd1-be1c6af8562d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14674d80-2571-4794-863e-247c2e2cfc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14674d80-2571-4794-863e-247c2e2cfc3e.jpg?1",
             "name": "Dragonsoul Knight",
             "text": "First strike\n{W}{U}{B}{R}{G}: Until end of turn, Dragonsoul Knight becomes a Dragon, gets +5/+3, and gains flying and trample.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "7cd01590-ac19-5f61-863d-9cdebc416f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687bb467-b447-4901-8a65-cd91fd3aa15d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687bb467-b447-4901-8a65-cd91fd3aa15d.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "7de420db-829b-5ca8-a006-82a2fbdf5e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ec933c-ee56-4b23-baba-699286984dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ec933c-ee56-4b23-baba-699286984dee.jpg?1",
             "name": "Goblin Razerunners",
             "text": "{1}{R}, Sacrifice a land: Put a +1/+1 counter on Goblin Razerunners.\nAt the end of your turn, you may have Goblin Razerunners deal damage equal to the number of +1/+1 counters on it to target player.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "86727832-0334-561d-bcac-e03dc2871d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a861a-c488-4834-a419-5bd1eeba6873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a861a-c488-4834-a419-5bd1eeba6873.jpg?1",
             "name": "Hellspark Elemental",
             "text": "Trample, haste\nAt end of turn, sacrifice Hellspark Elemental.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -2225,7 +2225,7 @@
         },
         {
             "id": "10f950d2-1af0-5c7b-b398-13eaa223d4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38419d9-e321-4642-aad4-99c5489f8fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38419d9-e321-4642-aad4-99c5489f8fa8.jpg?1",
             "name": "Ignite Disorder",
             "text": "Ignite Disorder deals 3 damage divided as you choose among any number of target white and/or blue creatures.",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "5f4a6e66-2b2f-5c4a-bebd-1d3ccf189f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aece74-cc1f-4f32-ad1f-00733eb79007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aece74-cc1f-4f32-ad1f-00733eb79007.jpg?1",
             "name": "Kranioceros",
             "text": "{1}{W}: Kranioceros gets +0/+3 until end of turn.",
             "colours": [
@@ -2292,7 +2292,7 @@
         },
         {
             "id": "ac5f2a3d-a266-5895-90bb-60a33aef5600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd98218-8318-40e7-8f36-68acce5d23a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd98218-8318-40e7-8f36-68acce5d23a1.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -2326,7 +2326,7 @@
         },
         {
             "id": "a787475d-3808-5339-a4bf-3d5b25e78fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58356504-e28e-456c-b1d3-e6232f4d78a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58356504-e28e-456c-b1d3-e6232f4d78a6.jpg?1",
             "name": "Molten Frame",
             "text": "Destroy target artifact creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "72f11c48-6838-50fb-81d7-b07ddf4a6700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1c0ded-2a80-4ed4-b9fc-3a18bf5c3239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1c0ded-2a80-4ed4-b9fc-3a18bf5c3239.jpg?1",
             "name": "Quenchable Fire",
             "text": "Quenchable Fire deals 3 damage to target player. It deals an additional 3 damage to that player at the beginning of your next upkeep step unless he or she pays {U} before that step.",
             "colours": [
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "e9f258bf-24b5-5e2d-8614-4fae477e7ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg?1",
             "name": "Rakka Mar",
             "text": "Haste\n{R}, {T}: Put a 3/1 red Elemental creature token with haste into play.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "8307d5bf-42a0-556a-8157-333299c51145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fd2dce-b91f-441f-a3ea-af87cc925713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fd2dce-b91f-441f-a3ea-af87cc925713.jpg?1",
             "name": "Toxic Iguanar",
             "text": "Toxic Iguanar has deathtouch as long as you control a green permanent. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "e3e22821-fbc9-5b67-98eb-a0488025be17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c30ee-616b-4b7d-97f9-cab1d6218e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c30ee-616b-4b7d-97f9-cab1d6218e3a.jpg?1",
             "name": "Viashino Slaughtermaster",
             "text": "Double strike\n{B}{G}: Viashino Slaughtermaster gets +1/+1 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "68c578dc-e1f9-5fbe-9252-4d2def14c067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65536d12-e75c-42b5-b592-a3ad4f550a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65536d12-e75c-42b5-b592-a3ad4f550a71.jpg?1",
             "name": "Volcanic Fallout",
             "text": "Volcanic Fallout can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
             "colours": [
@@ -2531,7 +2531,7 @@
         },
         {
             "id": "f979b0af-1625-5bbc-96f8-e999cf6901fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2ab319-bad8-4695-b56c-3654ba3389c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2ab319-bad8-4695-b56c-3654ba3389c5.jpg?1",
             "name": "Voracious Dragon",
             "text": "Flying\nDevour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nWhen Voracious Dragon comes into play, it deals damage to target creature or player equal to twice the number of Goblins it devoured.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "52105f00-802e-5ae3-b412-e77e9462cc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217281d9-a8f4-4e7a-987f-7ece0ae15eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217281d9-a8f4-4e7a-987f-7ece0ae15eba.jpg?1",
             "name": "Wandering Goblins",
             "text": "Domain {3}: Wandering Goblins gets +1/+0 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "cb70bfff-3765-51dd-b458-f8827592330f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73922629-5e85-451f-8ad6-4c8a60aab935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73922629-5e85-451f-8ad6-4c8a60aab935.jpg?1",
             "name": "Worldheart Phoenix",
             "text": "Flying\nYou may play Worldheart Phoenix from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost. If you do, it comes into play with two +1/+1 counters on it.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "1740bb83-e7c1-587d-978a-fedaee2fa137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc42e33-7489-4a32-bb30-adc80ec13521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc42e33-7489-4a32-bb30-adc80ec13521.jpg?1",
             "name": "Beacon Behemoth",
             "text": "{1}: Target creature with power 5 or greater gains vigilance until end of turn.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "a9c48537-707e-59a7-a57e-7dbfc07b9966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg?1",
             "name": "Cliffrunner Behemoth",
             "text": "Cliffrunner Behemoth has haste as long as you control a red permanent.\nCliffrunner Behemoth has lifelink as long as you control a white permanent.",
             "colours": [
@@ -2707,7 +2707,7 @@
         },
         {
             "id": "dc31bdcc-120d-50a7-80c3-2d18aaf796dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90665426-118e-4f0b-8222-1b516678a2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90665426-118e-4f0b-8222-1b516678a2f5.jpg?1",
             "name": "Cylian Sunsinger",
             "text": "{R}{G}{W}: Cylian Sunsinger and each other creature with the same name as it get +3/+3 until end of turn.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "832417c3-e252-5f3b-98e5-8ebc0b281dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10effbe2-fd8e-44b6-a08c-3984a92254d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10effbe2-fd8e-44b6-a08c-3984a92254d9.jpg?1",
             "name": "Ember Weaver",
             "text": "Reach (This can block creatures with flying.)\nAs long as you control a red permanent, Ember Weaver gets +1/+0 and has first strike.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "740001fa-af8c-583a-b5cf-8286f5a69bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65075828-d685-4107-866e-75a53cbc6414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65075828-d685-4107-866e-75a53cbc6414.jpg?1",
             "name": "Filigree Fracture",
             "text": "Destroy target artifact or enchantment. If that permanent was blue or black, draw a card.",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "9efa8adb-3e5b-5dcf-a15d-d51f357ac352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c7201-02b0-4e16-9fa6-0a79631e7724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258c7201-02b0-4e16-9fa6-0a79631e7724.jpg?1",
             "name": "Gluttonous Slime",
             "text": "Flash\nDevour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "c70c39be-5129-5983-a538-afc5a4ed9e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32dcf7d-ac19-45c5-8c3a-1155bf25b216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32dcf7d-ac19-45c5-8c3a-1155bf25b216.jpg?1",
             "name": "Matca Rioters",
             "text": "Domain Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "7dd511d5-bbc1-5c44-820c-358ffb585261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514c013-bc11-4cc5-af8c-f82fd4098bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514c013-bc11-4cc5-af8c-f82fd4098bcf.jpg?1",
             "name": "Might of Alara",
             "text": "Domain Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "c9f7a241-a476-5e67-ba58-887b048e7e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad602fba-6a73-4fd0-aff5-802c3be3100e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad602fba-6a73-4fd0-aff5-802c3be3100e.jpg?1",
             "name": "Nacatl Savage",
             "text": "Protection from artifacts",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "7d6580e5-185b-5dff-a1fb-452a310e58e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adfe928-1305-444d-b709-1e714544daaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adfe928-1305-444d-b709-1e714544daaf.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "27d69eb4-f861-51cd-90ee-ca60e54e5ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg?1",
             "name": "Paleoloth",
             "text": "Whenever another creature with power 5 or greater comes into play under your control, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "8a575573-5ad0-559a-aca4-636a0bf81bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160335df-8377-4f72-9d3f-4b1492bd23ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160335df-8377-4f72-9d3f-4b1492bd23ea.jpg?1",
             "name": "Sacellum Archers",
             "text": "{R}{W}, {T}: Sacellum Archers deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "1ee95db7-76c7-5b32-b66c-baa5d854e033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74d6cdb-a087-4b3d-bf25-509200ed6d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74d6cdb-a087-4b3d-bf25-509200ed6d93.jpg?1",
             "name": "Scattershot Archer",
             "text": "{T}: Scattershot Archer deals 1 damage to each creature with flying.",
             "colours": [
@@ -3089,7 +3089,7 @@
         },
         {
             "id": "3aef6f3f-13b3-5a65-a69e-9b668eca09c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285beca0-4876-426f-a4b4-ecefe79ad55d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285beca0-4876-426f-a4b4-ecefe79ad55d.jpg?1",
             "name": "Shard Convergence",
             "text": "Search your library for a Plains card, an Island card, a Swamp card, and a Mountain card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "c65028fa-553f-5144-91ec-547ee69158a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0d50f-7c2b-4d01-8ae0-8d945e726874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0d50f-7c2b-4d01-8ae0-8d945e726874.jpg?1",
             "name": "Soul's Majesty",
             "text": "Draw cards equal to the power of target creature you control.",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "92d30065-2098-5217-9e2d-37048eb69253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fab6e3-29a5-42e0-872e-5c2f4f72bfc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fab6e3-29a5-42e0-872e-5c2f4f72bfc5.jpg?1",
             "name": "Spore Burst",
             "text": "Domain Put a 1/1 green Saproling creature token into play for each basic land type among lands you control.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "fd8ead0f-5f40-5247-8fdb-4e68a6af5798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717c573-e448-400e-a228-d438491f1754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717c573-e448-400e-a228-d438491f1754.jpg?1",
             "name": "Sylvan Bounty",
             "text": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "19e5d417-d84b-590c-b531-4cfa3bfb29c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg?1",
             "name": "Thornling",
             "text": "{G}: Thornling gains haste until end of turn.\n{G}: Thornling gains trample until end of turn.\n{G}: Thornling is indestructible this turn.\n{1}: Thornling gets +1/-1 until end of turn.\n{1}: Thornling gets -1/+1 until end of turn.",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "895f66b7-2733-57ec-890a-690f2b79b938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84666a8-4ce5-46e7-9a39-f64a392515e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84666a8-4ce5-46e7-9a39-f64a392515e7.jpg?1",
             "name": "Tukatongue Thallid",
             "text": "When Tukatongue Thallid is put into a graveyard from play, put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "a7fec3c6-bd2b-5c51-b651-54f1421faff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bc387-ac1a-42b4-9427-fc944094b3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bc387-ac1a-42b4-9427-fc944094b3a1.jpg?1",
             "name": "Wild Leotau",
             "text": "At the beginning of your upkeep, sacrifice Wild Leotau unless you pay {G}.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "186a7b8f-34c4-5b0b-a05f-a3e5bf09fef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc4bf11-dece-4cb7-bef1-69391488f987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc4bf11-dece-4cb7-bef1-69391488f987.jpg?1",
             "name": "Apocalypse Hydra",
             "text": "Apocalypse Hydra comes into play with X +1/+1 counters on it. If X is 5 or more, it comes into play with an additional X +1/+1 counters on it.\n{1}{R}, Remove a +1/+1 counter from Apocalypse Hydra: Apocalypse Hydra deals 1 damage to target creature or player.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "0137ced5-e397-5823-86c8-6efe74e7ff46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a235f619-6b44-4e60-ac16-0038b7531b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a235f619-6b44-4e60-ac16-0038b7531b77.jpg?1",
             "name": "Blood Tyrant",
             "text": "Flying, trample\nAt the beginning of your upkeep, each player loses 1 life. Put a +1/+1 counter on Blood Tyrant for each 1 life lost this way.\nWhenever a player loses the game, put five +1/+1 counters on Blood Tyrant.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "5d51c5a7-726c-5cbe-b8c6-bf263d2769d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb7e1ec-572f-4e78-8f12-0a8034e9d0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb7e1ec-572f-4e78-8f12-0a8034e9d0f6.jpg?1",
             "name": "Charnelhoard Wurm",
             "text": "Trample\nWhenever Charnelhoard Wurm deals damage to an opponent, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "6914e671-7167-5ad7-a7e8-9dcaf2895c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f701f-fba2-48db-95ef-0926986cdac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f701f-fba2-48db-95ef-0926986cdac9.jpg?1",
             "name": "Child of Alara",
             "text": "Trample\nWhen Child of Alara is put into a graveyard from play, destroy all nonland permanents. They can't be regenerated.",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "e7ce144c-4476-54cd-8226-e5b04836e56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db21da75-8d6a-4c8c-a83b-aab8290b586f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db21da75-8d6a-4c8c-a83b-aab8290b586f.jpg?1",
             "name": "Conflux",
             "text": "Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -3516,7 +3516,7 @@
         },
         {
             "id": "43d8515b-01ff-59f3-a0cd-5a8c2ff9bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec16e216-95e1-41f7-87e0-78b6ac3fe1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec16e216-95e1-41f7-87e0-78b6ac3fe1df.jpg?1",
             "name": "Countersquall",
             "text": "Counter target noncreature spell. Its controller loses 2 life.",
             "colours": [
@@ -3550,7 +3550,7 @@
         },
         {
             "id": "229e6fe5-da39-5e47-93d3-1a202194c5ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dfa8c-9068-4373-a9ae-fd0c63eeda44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dfa8c-9068-4373-a9ae-fd0c63eeda44.jpg?1",
             "name": "Elder Mastery",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has flying.\nWhenever enchanted creature deals damage to a player, that player discards two cards.",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "7095cee8-9ffe-59d0-ab79-f2fcb696bcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5068ed-8477-4d8d-9e37-c72474208e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5068ed-8477-4d8d-9e37-c72474208e2d.jpg?1",
             "name": "Esper Cormorants",
             "text": "Flying",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "186ea9aa-9c4f-52f3-bcc1-5e36fed2bec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f247aaaf-4d65-4dfc-bab2-3c1331762647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f247aaaf-4d65-4dfc-bab2-3c1331762647.jpg?1",
             "name": "Exploding Borders",
             "text": "Domain Search your library for a basic land card, put that card into play tapped, then shuffle your library. Exploding Borders deals X damage to target player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -3659,7 +3659,7 @@
         },
         {
             "id": "b7382cbe-c775-565c-88da-2b52c451aa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6712dbd-ee54-4fb7-93ab-64f8f07350f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6712dbd-ee54-4fb7-93ab-64f8f07350f1.jpg?1",
             "name": "Fusion Elemental",
             "text": "",
             "colours": [
@@ -3701,7 +3701,7 @@
         },
         {
             "id": "d76821b2-6f79-5093-861c-95fbb5cf5ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a67fd-6736-4f2b-8ed3-57a0a6afb98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a67fd-6736-4f2b-8ed3-57a0a6afb98f.jpg?1",
             "name": "Giltspire Avenger",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Destroy target creature that dealt damage to you this turn.",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "133bfb69-5ca2-55cb-a2c7-eecc3f10c2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33683b-8bda-4bb9-beb4-fc0cd5ed79ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33683b-8bda-4bb9-beb4-fc0cd5ed79ae.jpg?1",
             "name": "Goblin Outlander",
             "text": "Protection from white",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "948e81b6-43f9-5e85-bc69-b3be8eb19578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4d72b0-34be-497b-8bef-4bd045830917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4d72b0-34be-497b-8bef-4bd045830917.jpg?1",
             "name": "Gwafa Hazid, Profiteer",
             "text": "{W}{U}, {T}: Put a bribery counter on target creature you don't control. Its controller draws a card.\nCreatures with bribery counters on them can't attack or block.",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "aceb745c-1c36-5cb0-af0f-43d26799e585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09a3b69-1214-420d-984f-0b2a043a9dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09a3b69-1214-420d-984f-0b2a043a9dc2.jpg?1",
             "name": "Hellkite Hatchling",
             "text": "Devour 1 (As this comes into play, you may sacrifice any number of creatures. This creature comes into play with that many +1/+1 counters on it.)\nHellkite Hatchling has flying and trample if it devoured a creature.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "4652658a-e661-527d-a581-4dcaa1c1f07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e638e38-15b9-4081-8340-985d4646e3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e638e38-15b9-4081-8340-985d4646e3d7.jpg?1",
             "name": "Jhessian Balmgiver",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\n{T}: Target creature is unblockable this turn.",
             "colours": [
@@ -3889,7 +3889,7 @@
         },
         {
             "id": "6fa091cb-29d0-5103-9f89-824133900285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b8518-c09e-4cb7-95b2-08e4e370d89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b8518-c09e-4cb7-95b2-08e4e370d89c.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it into play, then shuffle your library.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "37fc686f-b695-5f77-84b9-ce38b684e99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6372fa0-e9c8-45d0-a3b8-72eb191c6b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6372fa0-e9c8-45d0-a3b8-72eb191c6b26.jpg?1",
             "name": "Knotvine Mystic",
             "text": "{1}, {T}: Add {R}{G}{W} to your mana pool.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "cc131651-4999-5481-b66a-3f79b5daee62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92ecfaa-2d8e-4352-b8ec-287da7ba0b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92ecfaa-2d8e-4352-b8ec-287da7ba0b78.jpg?1",
             "name": "Maelstrom Archangel",
             "text": "Flying\nWhenever Maelstrom Archangel deals combat damage to a player, you may play a nonland card from your hand without paying its mana cost.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "6ff0ce2b-990f-59a6-a321-7dfd8b8d53e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2abff9-6927-42cc-8cf1-a0876d3a45d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2abff9-6927-42cc-8cf1-a0876d3a45d7.jpg?1",
             "name": "Magister Sphinx",
             "text": "Flying\nWhen Magister Sphinx comes into play, target player's life total becomes 10.",
             "colours": [
@@ -4046,7 +4046,7 @@
         },
         {
             "id": "6ffaa8eb-2538-5dfa-b979-163070b64c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84de2e-3676-4112-823b-549c4d132280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84de2e-3676-4112-823b-549c4d132280.jpg?1",
             "name": "Malfegor",
             "text": "Flying\nWhen Malfegor comes into play, discard your hand. Each opponent sacrifices a creature for each card discarded this way.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "93f4c01c-a711-5c87-a856-979646e1e9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e32b7-87d6-44a8-a544-5dabcd64c9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69e32b7-87d6-44a8-a544-5dabcd64c9f3.jpg?1",
             "name": "Meglonoth",
             "text": "Vigilance, trample\nWhenever Meglonoth blocks a creature, Meglonoth deals damage to that creature's controller equal to Meglonoth's power.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "a39b5b42-3852-512c-aa93-0d281f9468bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5b694-46c8-4cb0-ab6b-4bc67c04cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5b694-46c8-4cb0-ab6b-4bc67c04cc7f.jpg?1",
             "name": "Nacatl Outlander",
             "text": "Protection from blue",
             "colours": [
@@ -4160,7 +4160,7 @@
         },
         {
             "id": "738a5682-4459-545e-be8c-9e2c23c77204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ee3939-bc12-4275-a446-9de36f0b4672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ee3939-bc12-4275-a446-9de36f0b4672.jpg?1",
             "name": "Nicol Bolas, Planeswalker",
             "text": "+3: Destroy target noncreature permanent.\n-2: Gain control of target creature.\n-9: Nicol Bolas, Planeswalker deals 7 damage to target player. That player discards seven cards, then sacrifices seven permanents.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "83704f1a-b85d-5671-9d82-d6066c01201c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc764b0-3046-4bde-b424-c0f4e1a6169b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc764b0-3046-4bde-b424-c0f4e1a6169b.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "0f555141-8777-5061-ab21-ed513071b641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f43c8-9df6-49df-b145-4a19bc55e8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9f43c8-9df6-49df-b145-4a19bc55e8f4.jpg?1",
             "name": "Rhox Bodyguard",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhen Rhox Bodyguard comes into play, you gain 3 life.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "5deb3c52-01e8-5cf9-adc8-3b0a46b291f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a179b9-e962-49a4-ad92-8cd0291296c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a179b9-e962-49a4-ad92-8cd0291296c1.jpg?1",
             "name": "Scarland Thrinax",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Scarland Thrinax.",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "4daf8422-88cc-5d17-a47b-90c9858618b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183e0fd7-ed58-46e5-86ce-f17d8657417d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183e0fd7-ed58-46e5-86ce-f17d8657417d.jpg?1",
             "name": "Shambling Remains",
             "text": "Shambling Remains can't block.\nUnearth {B}{R} ({B}{R}: Return this card from your graveyard to play. It gains haste. Remove it from the game at end of turn or if it would leave play. Unearth only as a sorcery.)",
             "colours": [
@@ -4358,7 +4358,7 @@
         },
         {
             "id": "f702b291-0ec6-5191-b2ae-f57cfd91c90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8125473-a296-4032-bacd-1c1b96819cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8125473-a296-4032-bacd-1c1b96819cf9.jpg?1",
             "name": "Skyward Eye Prophets",
             "text": "Vigilance\n{T}: Reveal the top card of your library. If it's a land card, put it into play. Otherwise, put it into your hand.",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "080010f0-a7e5-5d17-8ab9-cefe459c0d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8339ca-2971-4c5a-83ed-2682e5b3838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8339ca-2971-4c5a-83ed-2682e5b3838d.jpg?1",
             "name": "Sludge Strider",
             "text": "Whenever another artifact comes into play under your control or another artifact you control leaves play, you may pay {1}. If you do, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -4436,7 +4436,7 @@
         },
         {
             "id": "d1b2b51e-8e19-57b5-a88f-5b4c41e7d43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006b5000-2a8f-4020-9dbf-7170da13b54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006b5000-2a8f-4020-9dbf-7170da13b54e.jpg?1",
             "name": "Sphinx Summoner",
             "text": "Flying\nWhen Sphinx Summoner comes into play, you may search your library for an artifact creature card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "f5a18f7e-ef35-54ec-9714-126bab4655d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9375d8c-b429-4349-bc4d-cb08799bdb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9375d8c-b429-4349-bc4d-cb08799bdb58.jpg?1",
             "name": "Suicidal Charge",
             "text": "Sacrifice Suicidal Charge: Creatures your opponents control get -1/-1 until end of turn. Those creatures attack this turn if able.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "fd0950ca-d50d-58ea-91cb-9f4099f7b875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546b0a74-ebef-4596-b730-2190e20b2e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546b0a74-ebef-4596-b730-2190e20b2e66.jpg?1",
             "name": "Vagrant Plowbeasts",
             "text": "{1}: Regenerate target creature with power 5 or greater.",
             "colours": [
@@ -4543,7 +4543,7 @@
         },
         {
             "id": "17788d8c-8dad-5892-ab3c-76861475443e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e73cd46-0dec-441b-bb91-ec6defb3355e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e73cd46-0dec-441b-bb91-ec6defb3355e.jpg?1",
             "name": "Valeron Outlander",
             "text": "Protection from black",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "3391107f-a534-5e4f-8d41-5e8701083d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ac1be-43e4-4535-8633-730f306c0d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ac1be-43e4-4535-8633-730f306c0d00.jpg?1",
             "name": "Vectis Agents",
             "text": "{U}{B}: Vectis Agents gets -2/-0 until end of turn and is unblockable this turn.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "d7f5e8b7-8bab-56bd-8f0b-4ad8f2cc25ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7314-39f2-4e32-a5b0-ac1761b6d238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7314-39f2-4e32-a5b0-ac1761b6d238.jpg?1",
             "name": "Vedalken Outlander",
             "text": "Protection from red",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "c63471c7-f79f-547f-a1c6-25f9e92acb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27c2690-5121-452b-b82a-72acb8be6878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27c2690-5121-452b-b82a-72acb8be6878.jpg?1",
             "name": "Zombie Outlander",
             "text": "Protection from green",
             "colours": [
@@ -4693,7 +4693,7 @@
         },
         {
             "id": "cda01087-3785-507a-8864-d66871b99027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06cdd3b-3f8d-4b5e-882b-130b1db750a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06cdd3b-3f8d-4b5e-882b-130b1db750a0.jpg?1",
             "name": "Armillary Sphere",
             "text": "{2}, {T}, Sacrifice Armillary Sphere: Search your library for up to two basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [],
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "eb975bfd-a4c9-5b2f-8e0f-2738ed090ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bf79d6-4b4a-4fdd-a831-36eff2523661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bf79d6-4b4a-4fdd-a831-36eff2523661.jpg?1",
             "name": "Bone Saw",
             "text": "Equipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "d9055197-f01c-5fb9-bb4c-e7c1329bf837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c198caf8-27ab-4300-841b-507e1b0ce9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c198caf8-27ab-4300-841b-507e1b0ce9b3.jpg?1",
             "name": "Font of Mythos",
             "text": "At the beginning of each player's draw step, that player draws two additional cards.",
             "colours": [],
@@ -4779,7 +4779,7 @@
         },
         {
             "id": "533b23ea-2be7-5d55-984c-f424808e94d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79826f7f-e46b-489d-8fcb-1712d36e8f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79826f7f-e46b-489d-8fcb-1712d36e8f60.jpg?1",
             "name": "Kaleidostone",
             "text": "When Kaleidostone comes into play, draw a card.\n{5}, {T}, Sacrifice Kaleidostone: Add {W}{U}{B}{R}{G} to your mana pool.",
             "colours": [],
@@ -4813,7 +4813,7 @@
         },
         {
             "id": "c0e8a020-1698-5c8a-8ad1-18aef60712a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e25c75-5e20-4990-9b7e-9d04c94fee9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e25c75-5e20-4990-9b7e-9d04c94fee9f.jpg?1",
             "name": "Mana Cylix",
             "text": "{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "4ee5f243-74b5-5adf-bec4-cd23837e38f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60e11f-ea7c-4d87-bc82-9e7f4eaeef5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60e11f-ea7c-4d87-bc82-9e7f4eaeef5a.jpg?1",
             "name": "Manaforce Mace",
             "text": "Domain Equipped creature gets +1/+1 for each basic land type among lands you control.\nEquip {3}",
             "colours": [],
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "593355f4-f874-56d1-a926-7a48ee89c378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc12ebe-54d8-4b91-8c68-3cde5690e26a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc12ebe-54d8-4b91-8c68-3cde5690e26a.jpg?1",
             "name": "Obelisk of Alara",
             "text": "{1}{W}, {T}: You gain 5 life.\n{1}{U}, {T}: Draw a card, then discard a card.\n{1}{B}, {T}: Target creature gets -2/-2 until end of turn.\n{1}{R}, {T}: Obelisk of Alara deals 3 damage to target player.\n{1}{G}, {T}: Target creature gets +4/+4 until end of turn.",
             "colours": [],
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "1c3f3211-7b81-5d89-81cf-6892871517a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348247d-0a70-4961-8590-9de41386c69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348247d-0a70-4961-8590-9de41386c69b.jpg?1",
             "name": "Ancient Ziggurat",
             "text": "{T}: Add one mana of any color to your mana pool. Spend this mana only to play creature spells.",
             "colours": [],
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "df220e74-4b35-5fde-b8b5-dbb5c3f2057e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aae6480-4e71-4d94-a648-f80d3849d792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aae6480-4e71-4d94-a648-f80d3849d792.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "180813e7-ad29-5870-9b03-0c430edd6ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0c1a5-dce7-4c7d-8a5b-0bf93ba68ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0c1a5-dce7-4c7d-8a5b-0bf93ba68ace.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "4fb21440-637c-565f-b0a5-1592ec05da42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568df642-3ad7-401c-a133-edb56970c3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568df642-3ad7-401c-a133-edb56970c3a1.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire comes into play tapped.\nWhen Rupture Spire comes into play, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "8a97d60e-a4ec-516d-994a-14483c8faecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97e739f-8675-488e-be2b-4e455fbe390b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97e739f-8675-488e-be2b-4e455fbe390b.jpg?1",
             "name": "Unstable Frontier",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Target land you control becomes the basic land type of your choice until end of turn.",
             "colours": [],
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "dc610050-0e01-5692-847c-e6955a1a93e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902520e-b4ed-4805-9f64-096acf7c5f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902520e-b4ed-4805-9f64-096acf7c5f31.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "8f415ec3-6027-5569-828e-7555c462953c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf56553-2ecc-4fe8-8730-917d891f6882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf56553-2ecc-4fe8-8730-917d891f6882.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/CSP.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/CSP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ca7351d1-ab64-595a-8376-10e3c2f54535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4336a9-c904-44a3-8cbd-a1fd5fdbcd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4336a9-c904-44a3-8cbd-a1fd5fdbcd74.jpg?1",
             "name": "Adarkar Valkyrie",
             "text": "Flying, vigilance\n{T}: When target creature other than Adarkar Valkyrie is put into a graveyard this turn, return that card to play under your control.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "f2567096-25a2-569d-bcdd-eace03ad649b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36638e20-0a1d-4ea3-936c-2ea74add868a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36638e20-0a1d-4ea3-936c-2ea74add868a.jpg?1",
             "name": "Boreal Griffin",
             "text": "Flying\n{S}: Boreal Griffin gains first strike until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "aa622011-fd2b-589e-8fee-80d7b93adac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d9bb89-d8f8-4dff-8b94-3f7b8aa8f299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d9bb89-d8f8-4dff-8b94-3f7b8aa8f299.jpg?1",
             "name": "Cover of Winter",
             "text": "Cumulative upkeep {S} ({S} can be paid with one mana from a snow permanent.)\nIf a creature would deal combat damage to you and/or one or more creatures you control, prevent X of that damage, where X is the number of age counters on Cover of Winter.\n{S}: Put an age counter on Cover of Winter.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "efbec2be-9858-56a0-b0ba-8cb266319b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea571ae-b9bd-4bd2-9357-52915f0d2f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea571ae-b9bd-4bd2-9357-52915f0d2f15.jpg?1",
             "name": "Darien, King of Kjeldor",
             "text": "Whenever you're dealt damage, you may put that many 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "cf1f188d-d539-5ac2-b18b-14526b80705c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421648a0-51c8-45c4-9771-0fd3ccdc69c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421648a0-51c8-45c4-9771-0fd3ccdc69c9.jpg?1",
             "name": "Field Marshal",
             "text": "Other Soldiers get +1/+1 and have first strike.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "ce6e511f-ab1f-586b-b9a1-1c0436113eee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d372bb70-2d2a-4c44-8f69-4abff8ba7c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d372bb70-2d2a-4c44-8f69-4abff8ba7c2a.jpg?1",
             "name": "Gelid Shackles",
             "text": "Enchant creature\nEnchanted creature can't block and its activated abilities can't be played.\n{S}: Enchanted creature gains defender until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -218,7 +218,7 @@
         },
         {
             "id": "ad2de8c9-855b-539c-aeda-402693fab29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55742f0f-a894-48c3-82b1-dfc3d8390dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55742f0f-a894-48c3-82b1-dfc3d8390dc3.jpg?1",
             "name": "Glacial Plating",
             "text": "Enchant creature\nCumulative upkeep {S} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it. {S} can be paid with one mana from a snow permanent.)\nEnchanted creature gets +3/+3 for each age counter on Glacial Plating.",
             "colours": [
@@ -254,7 +254,7 @@
         },
         {
             "id": "f37bb3ba-1796-5a40-893e-55222129cac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526c510-bd33-4fac-8941-f19bd0997557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5526c510-bd33-4fac-8941-f19bd0997557.jpg?1",
             "name": "J\u00f6tun Grunt",
             "text": "Cumulative upkeep\u2014\nPut two cards in a single graveyard on the bottom of their owner's library. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "724ed0bc-5ee8-58f8-ad66-84d1888bee02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1566c8a2-aaca-4ce0-a36b-620ea6f135cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1566c8a2-aaca-4ce0-a36b-620ea6f135cb.jpg?1",
             "name": "J\u00f6tun Owl Keeper",
             "text": "Cumulative upkeep {W} or {U} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen J\u00f6tun Owl Keeper is put into a graveyard from play, put a 1/1 white Bird creature token with flying into play for each age counter on it.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "54689944-a00e-51ac-9cd1-287a9b625d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a4892-fba0-459d-9e72-e82f7e079d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484a4892-fba0-459d-9e72-e82f7e079d78.jpg?1",
             "name": "Kjeldoran Gargoyle",
             "text": "Flying, first strike\nWhenever Kjeldoran Gargoyle deals damage, you gain that much life.",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "5d159049-750a-5968-bb04-29e0701cc130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b0776b-d1ed-4b0d-9684-99978e3e3b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b0776b-d1ed-4b0d-9684-99978e3e3b46.jpg?1",
             "name": "Kjeldoran Javelineer",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\n{T}: Kjeldoran Javelineer deals damage to target attacking or blocking creature equal to the number of age counters on Kjeldoran Javelineer.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "52c5a6d2-45ea-5543-a0b2-c5efcc92a7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd641b1d-dab8-415b-9655-09e033df761d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd641b1d-dab8-415b-9655-09e033df761d.jpg?1",
             "name": "Kjeldoran Outrider",
             "text": "{W}: Kjeldoran Outrider gets +0/+1 until end of turn.",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "92749b94-d614-5a28-b4ec-541a711345be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320b2b02-a3ff-4f68-93e6-8539d7caa005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320b2b02-a3ff-4f68-93e6-8539d7caa005.jpg?1",
             "name": "Kjeldoran War Cry",
             "text": "Creatures you control get +X/+X until end of turn, where X is 1 plus the number of cards named Kjeldoran War Cry in all graveyards.",
             "colours": [
@@ -460,7 +460,7 @@
         },
         {
             "id": "1357940d-4137-5cfc-bb3c-bd5c53d1be71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e8fe10-a4b7-4504-849f-a5c8379e587d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e8fe10-a4b7-4504-849f-a5c8379e587d.jpg?1",
             "name": "Luminesce",
             "text": "Prevent all damage that black and/or red sources would deal this turn.",
             "colours": [
@@ -492,7 +492,7 @@
         },
         {
             "id": "2d977a95-4ea8-544e-a02f-692f0253fdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c55105-bffc-43dc-b5f3-2e6bb9323230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c55105-bffc-43dc-b5f3-2e6bb9323230.jpg?1",
             "name": "Martyr of Sands",
             "text": "{1}, Reveal X white cards from your hand, Sacrifice Martyr of Sands: You gain three times X life.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "cf6a3696-d1df-534f-b3d8-4a4d8a80df06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4764e1-e47c-4934-86a5-9b432c29a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4764e1-e47c-4934-86a5-9b432c29a158.jpg?1",
             "name": "Ronom Unicorn",
             "text": "Sacrifice Ronom Unicorn: Destroy target enchantment.",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "cea59ff5-64e7-5bbe-a7d5-c65e1c349b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ecb728-4b54-47d0-bbef-d39e5f7d172f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ecb728-4b54-47d0-bbef-d39e5f7d172f.jpg?1",
             "name": "Squall Drifter",
             "text": "Flying\n{W}, {T}: Tap target creature.",
             "colours": [
@@ -597,7 +597,7 @@
         },
         {
             "id": "49b3841d-91fe-574e-b018-7c98565287f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde59b0e-c75e-455b-b375-e0dac430a6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde59b0e-c75e-455b-b375-e0dac430a6d1.jpg?1",
             "name": "Sun's Bounty",
             "text": "You gain 4 life.\nRecover {1}{W} (When a creature is put into your graveyard from play, you may pay {1}{W}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -629,7 +629,7 @@
         },
         {
             "id": "a7d384e6-f114-53a5-ae2e-6ea50b4f83d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c726db-a30a-4e76-9fbf-ec6d5cd7a1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c726db-a30a-4e76-9fbf-ec6d5cd7a1ba.jpg?1",
             "name": "Sunscour",
             "text": "You may remove two white cards in your hand from the game rather than pay Sunscour's mana cost.\nDestroy all creatures.",
             "colours": [
@@ -661,7 +661,7 @@
         },
         {
             "id": "0ccaf773-319c-5a99-b30d-d62b092ac90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264d120a-d7e2-4b9e-ac85-c66e976c577b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264d120a-d7e2-4b9e-ac85-c66e976c577b.jpg?1",
             "name": "Surging Sentinels",
             "text": "First strike\nRipple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "d263e698-e07d-5105-8126-b4dfa2a090de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f97ef40-9d07-47fa-ad4b-45f26f7351c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f97ef40-9d07-47fa-ad4b-45f26f7351c9.jpg?1",
             "name": "Swift Maneuver",
             "text": "Prevent the next 2 damage that would be dealt to target creature or player this turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "e96fe0ff-6bd5-5598-a533-09b8a976e74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7c141-2e20-4891-93a8-1cf309d3b979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7c141-2e20-4891-93a8-1cf309d3b979.jpg?1",
             "name": "Ursine Fylgja",
             "text": "Ursine Fylgja comes into play with four healing counters on it.\nRemove a healing counter from Ursine Fylgja: Prevent the next 1 damage that would be dealt to Ursine Fylgja this turn.\n{2}{W}: Put a healing counter on Ursine Fylgja.",
             "colours": [
@@ -763,7 +763,7 @@
         },
         {
             "id": "db3c404e-28ac-54d9-ab4d-4171025b53aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884ee8d8-4c0d-4e44-8321-bccd18195693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884ee8d8-4c0d-4e44-8321-bccd18195693.jpg?1",
             "name": "Wall of Shards",
             "text": "Defender, flying\nCumulative upkeep\u2014\nAn opponent gains 1 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "535f3001-3391-59ae-9f19-789c95025f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368322d7-d399-45e1-8d7f-8001d048071e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368322d7-d399-45e1-8d7f-8001d048071e.jpg?1",
             "name": "White Shield Crusader",
             "text": "Protection from black\n{W}: White Shield Crusader gains flying until end of turn.\n{W}{W}: White Shield Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -834,7 +834,7 @@
         },
         {
             "id": "e09b89fd-b378-5c16-8dbd-ab7d1eec97a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ed6354-161e-496e-9ac7-74432f9b0818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ed6354-161e-496e-9ac7-74432f9b0818.jpg?1",
             "name": "Woolly Razorback",
             "text": "Woolly Razorback comes into play with three ice counters on it.\nAs long as Woolly Razorback has an ice counter on it, it has defender and any combat damage it would deal is prevented.\nWhenever Woolly Razorback blocks, remove an ice counter from it.",
             "colours": [
@@ -869,7 +869,7 @@
         },
         {
             "id": "1f272154-ad59-5365-8aaa-a04ad6228176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18bce4a-9afb-4b91-bc9a-d62634b0f8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18bce4a-9afb-4b91-bc9a-d62634b0f8dd.jpg?1",
             "name": "Adarkar Windform",
             "text": "Flying\n{1}{S}: Target creature loses flying until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "192f3473-1028-5ad2-93fd-446029642a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9d3ce7-53db-4808-88bc-03c120211f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9d3ce7-53db-4808-88bc-03c120211f81.jpg?1",
             "name": "Arcum Dagsson",
             "text": "{T}: Target artifact creature's controller sacrifices it. That player may search his or her library for a noncreature artifact card, put it into play, then shuffle his or her library.",
             "colours": [
@@ -942,7 +942,7 @@
         },
         {
             "id": "9c14b67d-5f7b-538a-a490-7d009ebd891c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18096cdb-0ba9-41e0-b597-c5ed819e7497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18096cdb-0ba9-41e0-b597-c5ed819e7497.jpg?1",
             "name": "Balduvian Frostwaker",
             "text": "{U}, {T}: Target snow land becomes a 2/2 blue Elemental creature with flying. It's still a land.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "9b78a70c-1331-5a17-8817-a9164c0af1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e6204-c622-4efe-ac4f-8195528cec9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e6204-c622-4efe-ac4f-8195528cec9c.jpg?1",
             "name": "Commandeer",
             "text": "You may remove two blue cards in your hand from the game rather than pay Commandeer's mana cost.\nGain control of target noncreature spell. You may choose new targets for it. (If that spell is an artifact or enchantment, the permanent comes into play under your control.)",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "72a5f639-36c5-505a-b55c-674d6cb890e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e670f6b-d16e-47fc-a5b7-7ca0d8763644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e670f6b-d16e-47fc-a5b7-7ca0d8763644.jpg?1",
             "name": "Controvert",
             "text": "Counter target spell.\nRecover {2}{U}{U} (When a creature is put into your graveyard from play, you may pay {2}{U}{U}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -1041,7 +1041,7 @@
         },
         {
             "id": "b0c88ccc-bbe9-5fa0-9cb3-09237a6a41f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c329ff2b-0331-4934-a8df-870dd7bf402b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c329ff2b-0331-4934-a8df-870dd7bf402b.jpg?1",
             "name": "Counterbalance",
             "text": "Whenever an opponent plays a spell, you may reveal the top card of your library. If you do, counter that spell if it has the same converted mana cost as the revealed card.",
             "colours": [
@@ -1073,7 +1073,7 @@
         },
         {
             "id": "a93bda8d-03c3-5f59-b207-5be2c96ee84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954a1e9c-ed2f-4774-b2b7-166052a5c59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954a1e9c-ed2f-4774-b2b7-166052a5c59a.jpg?1",
             "name": "Drelnoch",
             "text": "Whenever Drelnoch becomes blocked, you may draw two cards.",
             "colours": [
@@ -1108,7 +1108,7 @@
         },
         {
             "id": "9400ef04-7331-5768-8e39-953f55fa60b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefd9955-a195-4855-a00e-3809b96ca92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefd9955-a195-4855-a00e-3809b96ca92b.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1140,7 +1140,7 @@
         },
         {
             "id": "b1d26c58-2893-591a-aace-467aa919e402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab2f81a-fcbe-44d1-8281-04dd78bb9ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab2f81a-fcbe-44d1-8281-04dd78bb9ea3.jpg?1",
             "name": "Frost Raptor",
             "text": "Flying\n{S}{S}: Frost Raptor can't be the target of spells or abilities this turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -1176,7 +1176,7 @@
         },
         {
             "id": "8138fa39-effb-5ba4-9297-fa2fe306e31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c00743-d208-4aed-939a-d70de2d759b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c00743-d208-4aed-939a-d70de2d759b9.jpg?1",
             "name": "Frozen Solid",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nWhen damage is dealt to enchanted creature, destroy it.",
             "colours": [
@@ -1210,7 +1210,7 @@
         },
         {
             "id": "8c9aefc3-15d3-5c95-87fa-75576e09d582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39916d65-60a6-4da6-8675-8a8ef9505772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39916d65-60a6-4da6-8675-8a8ef9505772.jpg?1",
             "name": "Heidar, Rimewind Master",
             "text": "{2}, {T}: Return target permanent to its owner's hand. Play this ability only if you control four or more snow permanents.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "62b76bca-4311-5708-93f1-b930faf3383e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bd1c2f-dab8-4f22-9400-a0e45618757a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bd1c2f-dab8-4f22-9400-a0e45618757a.jpg?1",
             "name": "Jokulmorder",
             "text": "Trample\nJokulmorder comes into play tapped.\nWhen Jokulmorder comes into play, sacrifice it unless you sacrifice five lands.\nJokulmorder doesn't untap during your untap step.\nWhenever you play an Island, you may untap Jokulmorder.",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "61304e4f-39dc-5a49-9fb7-459050d14e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e09469-205d-4a60-821c-ceb7ae2e01be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e09469-205d-4a60-821c-ceb7ae2e01be.jpg?1",
             "name": "Krovikan Mist",
             "text": "Flying\nKrovikan Mist's power and toughness are each equal to the number of Illusions in play.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "7ac542e9-a0ed-5846-a052-eee535275648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac2469-db92-44e4-8930-96f2c40c60f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac2469-db92-44e4-8930-96f2c40c60f1.jpg?1",
             "name": "Krovikan Whispers",
             "text": "Enchant creature\nCumulative upkeep {U} or {B}\nYou control enchanted creature.\nWhen Krovikan Whispers is put into a graveyard from play, you lose 2 life for each age counter on it.",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "25435350-2b3b-5aa9-bae7-2d8f43cd94a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249136c-94d4-4f65-95a4-d45b4f20429b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249136c-94d4-4f65-95a4-d45b4f20429b.jpg?1",
             "name": "Martyr of Frost",
             "text": "{2}, Reveal X blue cards from your hand, Sacrifice Martyr of Frost: Counter target spell unless its controller pays {X}.",
             "colours": [
@@ -1385,7 +1385,7 @@
         },
         {
             "id": "3ec32c53-c7b5-57a9-b35d-90b6b9f29fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669285c-5560-4f49-8d0a-44b8c33e23d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669285c-5560-4f49-8d0a-44b8c33e23d0.jpg?1",
             "name": "Perilous Research",
             "text": "Draw two cards, then sacrifice a permanent.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "2405ad64-89ac-5f66-bee6-543ff4c3707a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e3552-a251-4a80-b0bb-a96a9f8a4c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8e3552-a251-4a80-b0bb-a96a9f8a4c56.jpg?1",
             "name": "Rimefeather Owl",
             "text": "Flying\nRimefeather Owl's power and toughness are each equal to the number of snow permanents in play.\n{1}{S}: Put an ice counter on target permanent.\nPermanents with ice counters on them are snow.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "d671b32a-31e6-5bb7-8afb-0991b1459ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433653d-5ba9-4cdb-8a0b-69026301bc6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4433653d-5ba9-4cdb-8a0b-69026301bc6f.jpg?1",
             "name": "Rimewind Cryomancer",
             "text": "{1}, {T}: Counter target activated ability. Play this ability only if you control four or more snow permanents. (Mana abilities can't be targeted.)",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "8fc9f2ef-2c1d-5da6-ae09-5cc91ded2d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cdc06e-1458-4b19-a272-28a3d0453643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9cdc06e-1458-4b19-a272-28a3d0453643.jpg?1",
             "name": "Rimewind Taskmage",
             "text": "{1}, {T}: Tap or untap target permanent. Play this ability only if you control four or more snow permanents.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "a5d21bea-2c59-5548-9dbd-9df272bf3c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf81a39-0a6e-4253-81eb-a24f48253343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf81a39-0a6e-4253-81eb-a24f48253343.jpg?1",
             "name": "Ronom Serpent",
             "text": "Ronom Serpent can't attack unless defending player controls a snow land.\nWhen you control no snow lands, sacrifice Ronom Serpent.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "cee8cfd4-2302-575a-8c60-7319d6aca21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b6cadf-1974-47c8-98d8-ba413486c3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b6cadf-1974-47c8-98d8-ba413486c3b5.jpg?1",
             "name": "Rune Snag",
             "text": "Counter target spell unless its controller pays {2} plus an additional {2} for each card named Rune Snag in each graveyard.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "d5210648-65ab-569a-a13d-6c342ee19a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfba9fc2-8746-4693-bb75-01b5d78f7fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfba9fc2-8746-4693-bb75-01b5d78f7fee.jpg?1",
             "name": "Surging Aether",
             "text": "Ripple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "14de0091-75e3-51ec-b90e-94ce506ba366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a28c9cb-ae41-4f9c-b3f6-151ef95c81b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a28c9cb-ae41-4f9c-b3f6-151ef95c81b3.jpg?1",
             "name": "Survivor of the Unseen",
             "text": "Cumulative upkeep {2} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\n{T}: Draw two cards, then put a card from your hand on top of your library.",
             "colours": [
@@ -1658,7 +1658,7 @@
         },
         {
             "id": "271b985c-d857-5621-936d-2b346bdd552d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab8a0-906a-43b3-a554-db0d3dcd62d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab8a0-906a-43b3-a554-db0d3dcd62d3.jpg?1",
             "name": "Thermal Flux",
             "text": "Choose one Target nonsnow permanent becomes snow until end of turn; or target snow permanent isn't snow until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "afb8a88f-dc61-56b3-82d1-d9b4f2c3e9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cc1248-85c8-428f-ba08-96d188167eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cc1248-85c8-428f-ba08-96d188167eaa.jpg?1",
             "name": "Vexing Sphinx",
             "text": "Flying\nCumulative upkeep\u2014\nDiscard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Vexing Sphinx is put into a graveyard from play, draw a card for each age counter on it.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "83bf64c1-b589-51d9-9366-90dc739c23f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a52b952-6e3b-403b-b355-2af47a282ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a52b952-6e3b-403b-b355-2af47a282ab6.jpg?1",
             "name": "Balduvian Fallen",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever Balduvian Fallen's cumulative upkeep is paid, it gets +1/+0 until end of turn for each {B} or {R} spent this way.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "53242d6c-d177-5837-9a1c-326e72a856be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312505d7-362e-43cf-bd23-28c248a8b7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312505d7-362e-43cf-bd23-28c248a8b7e1.jpg?1",
             "name": "Chill to the Bone",
             "text": "Destroy target nonsnow creature.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "9b131f33-79aa-522b-ad36-26ee4a36f522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d050c8b9-2b5a-4025-9886-73c418f4e22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d050c8b9-2b5a-4025-9886-73c418f4e22f.jpg?1",
             "name": "Chilling Shade",
             "text": "Flying\n{S}: Chilling Shade gets +1/+1 until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "340deaa2-47b8-5689-a563-da9a4852960b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e8728-d0a0-4ee5-87c3-092ca94225e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e8728-d0a0-4ee5-87c3-092ca94225e0.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "746f0cb8-752a-575a-a5d5-505c82beb10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99ec07-8af7-4e80-9f0e-fa304a94d4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99ec07-8af7-4e80-9f0e-fa304a94d4b4.jpg?1",
             "name": "Disciple of Tevesh Szat",
             "text": "{T}: Target creature gets -1/-1 until end of turn.\n{4}{B}{B}, {T}, Sacrifice Disciple of Tevesh Szat: Target creature gets -6/-6 until end of turn.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "1fb9c09e-e036-579e-a7a9-897a61c3f5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d344791-5d5c-40c5-99c7-931954ea39d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d344791-5d5c-40c5-99c7-931954ea39d1.jpg?1",
             "name": "Feast of Flesh",
             "text": "Feast of Flesh deals X damage to target creature and you gain X life, where X is 1 plus the number of cards named Feast of Flesh in all graveyards.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "a49f3a52-aa88-598a-818b-23b314cfc33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3407ccbd-788d-4fe3-a039-0497724a94b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3407ccbd-788d-4fe3-a039-0497724a94b5.jpg?1",
             "name": "Garza's Assassin",
             "text": "Sacrifice Garza's Assassin: Destroy target nonblack creature.\nRecover\u2014\nPay half your life, rounded up. (When another creature is put into your graveyard from play, you may pay half your life, rounded up. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "5eb15421-57b2-5c71-b4d7-7a3157be63fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb1972f-2ef7-4fe2-8c8e-ab07f48a3176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb1972f-2ef7-4fe2-8c8e-ab07f48a3176.jpg?1",
             "name": "Grim Harvest",
             "text": "Return target creature card from your graveyard to your hand.\nRecover {2}{B} (When a creature is put into your graveyard from play, you may pay {2}{B}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "5cf1748f-cdc6-510f-852c-451bf339050b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8b607d-56c5-4a18-88b5-d5d0f50ef403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8b607d-56c5-4a18-88b5-d5d0f50ef403.jpg?1",
             "name": "Gristle Grinner",
             "text": "Whenever a creature is put into a graveyard from play, Gristle Grinner gets +2/+2 until end of turn.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "9fa970f0-4fad-5186-91c9-403d8fd4134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bb97ce-d9cf-47db-93cb-02745ebeb05e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bb97ce-d9cf-47db-93cb-02745ebeb05e.jpg?1",
             "name": "Gutless Ghoul",
             "text": "{1}, Sacrifice a creature: You gain 2 life.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "b9f9e43d-a9fb-585b-bf9f-f6c2924b17c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a7101e-e6c7-40d6-82cb-daa84701d1f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a7101e-e6c7-40d6-82cb-daa84701d1f8.jpg?1",
             "name": "Haakon, Stromgald Scourge",
             "text": "You may play Haakon, Stromgald Scourge from your graveyard, but not from anywhere else.\nAs long as Haakon is in play, you may play Knight cards from your graveyard.\nWhen Haakon is put into a graveyard from play, you lose 2 life.",
             "colours": [
@@ -2100,7 +2100,7 @@
         },
         {
             "id": "39b6fbda-c995-5f3a-98e8-86346275cf5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6080b1-b032-4172-8594-4d894a60a80d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6080b1-b032-4172-8594-4d894a60a80d.jpg?1",
             "name": "Herald of Leshrac",
             "text": "Flying\nCumulative upkeep\u2014\nGain control of a land you don't control.\nHerald of Leshrac gets +1/+1 for each land you control but don't own.\nWhen Herald of Leshrac leaves play, each player gains control of each land he or she owns that you control.",
             "colours": [
@@ -2134,7 +2134,7 @@
         },
         {
             "id": "c6e30e4d-503d-5cdb-8a1f-6630848a2ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17597c66-0d9f-41af-9160-0d92be88f450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17597c66-0d9f-41af-9160-0d92be88f450.jpg?1",
             "name": "Krovikan Rot",
             "text": "Destroy target creature with power 2 or less.\nRecover {1}{B}{B} (When a creature is put into your graveyard from play, you may pay {1}{B}{B}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "b2ddc6e9-83b3-5cc8-bb3b-6fb2c776efc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f046c-b416-4d80-8998-047b98361352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f046c-b416-4d80-8998-047b98361352.jpg?1",
             "name": "Krovikan Scoundrel",
             "text": "",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "b01b5982-8ec6-52a1-8117-52f439f84fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba602e-5a81-4da2-99c0-6082f8a981e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba602e-5a81-4da2-99c0-6082f8a981e1.jpg?1",
             "name": "Martyr of Bones",
             "text": "{1}, Reveal X black cards from your hand, Sacrifice Martyr of Bones: Remove up to X target cards in a single graveyard from the game.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "50813679-9391-5964-89f8-14733fdb3b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14802be-f9d4-4984-86e0-537467f37fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14802be-f9d4-4984-86e0-537467f37fd7.jpg?1",
             "name": "Phobian Phantasm",
             "text": "Flying, fear\nCumulative upkeep {B} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "bad9c827-bc15-557b-a1a4-dde6b2bb8c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978dbf63-0842-4abd-9950-a33aa080971c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978dbf63-0842-4abd-9950-a33aa080971c.jpg?1",
             "name": "Phyrexian Etchings",
             "text": "Cumulative upkeep {B} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the end of your turn, draw a card for each age counter on Phyrexian Etchings.\nWhen Phyrexian Etchings is put into a graveyard from play, you lose 2 life for each age counter on it.",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "03fc2f0c-7d5d-523b-a07d-7d05d0b8b56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18318fe-b429-459f-9b70-d444b48b8dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18318fe-b429-459f-9b70-d444b48b8dc7.jpg?1",
             "name": "Rime Transfusion",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has \"{S}: This creature can't be blocked this turn except by snow creatures.\" ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "c812971d-1ca3-5c4e-b368-cce0a84346d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6877469b-f14e-4121-aa5d-6cea92ab7278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6877469b-f14e-4121-aa5d-6cea92ab7278.jpg?1",
             "name": "Rimebound Dead",
             "text": "{S}: Regenerate Rimebound Dead. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "fc5bf077-a943-5f3e-b653-0cd16cccfbfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b14b97d-122b-453a-9e5f-129404f96440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b14b97d-122b-453a-9e5f-129404f96440.jpg?1",
             "name": "Soul Spike",
             "text": "You may remove two black cards in your hand from the game rather than pay Soul Spike's mana cost.\nSoul Spike deals 4 damage to target creature or player and you gain 4 life.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "81c2fc36-cf69-5291-8a86-8770fcf93b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5baeff5-40e9-47b6-85a8-3a6548565b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5baeff5-40e9-47b6-85a8-3a6548565b5f.jpg?1",
             "name": "Stromgald Crusader",
             "text": "Protection from white\n{B}: Stromgald Crusader gains flying until end of turn.\n{B}{B}: Stromgald Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "6d423e44-ab9a-5bce-a693-a4e4ee2c1e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb7cb72-24f7-433b-9858-26009189daaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb7cb72-24f7-433b-9858-26009189daaa.jpg?1",
             "name": "Surging Dementia",
             "text": "Ripple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)\nTarget player discards a card.",
             "colours": [
@@ -2473,7 +2473,7 @@
         },
         {
             "id": "f206e6af-87fb-53e7-973c-afc1d74cd327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b852d9f9-069d-419a-b8d1-db30c72aaac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b852d9f9-069d-419a-b8d1-db30c72aaac6.jpg?1",
             "name": "Tresserhorn Skyknight",
             "text": "Flying\nPrevent all damage that would be dealt to Tresserhorn Skyknight by creatures with first strike.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "236f73c1-0203-50b5-8365-0e97ff435887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba464b81-2633-4422-a4b5-3593dfb7e7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba464b81-2633-4422-a4b5-3593dfb7e7aa.jpg?1",
             "name": "Void Maw",
             "text": "Trample\nIf another creature would be put into a graveyard from play, remove it from the game instead.\nPut a card removed from the game with Void Maw into its owner's graveyard: Void Maw gets +2/+2 until end of turn.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "cdc8a082-a692-5ea9-b26d-5308384c1eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cf9ade-1c3d-4104-98fa-3c6a8cccc088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cf9ade-1c3d-4104-98fa-3c6a8cccc088.jpg?1",
             "name": "Zombie Musher",
             "text": "Snow landwalk\n{S}: Regenerate Zombie Musher. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "1a62583b-efd8-537d-bbe1-fe2427641faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716c980-bd89-4297-a843-9c3e18178b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716c980-bd89-4297-a843-9c3e18178b47.jpg?1",
             "name": "Balduvian Rage",
             "text": "Target attacking creature gets +X/+0 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "92d7336b-490b-515f-a206-7d5fff2fb27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3286dbd-c8b8-45cb-98e4-d572289f2c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3286dbd-c8b8-45cb-98e4-d572289f2c14.jpg?1",
             "name": "Balduvian Warlord",
             "text": "{T}: Remove target blocking creature from combat. Creatures it blocked that no other creature blocked this combat become unblocked, then it blocks an attacking creature of your choice. Play this ability only during the declare blockers step.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "a98acb15-a709-5505-ab06-f2a70e508bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bab8de-6e0f-4ccd-a303-01e9c8c82d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bab8de-6e0f-4ccd-a303-01e9c8c82d3f.jpg?1",
             "name": "Braid of Fire",
             "text": "Cumulative upkeep\u2014\nAdd {R} to your mana pool. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "365fc9ca-cb22-5867-860f-4757503d7e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a892711-a1a4-4402-957f-92077d00320d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a892711-a1a4-4402-957f-92077d00320d.jpg?1",
             "name": "Cryoclasm",
             "text": "Destroy target Plains or Island. Cryoclasm deals 3 damage to that land's controller.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "37ed7358-14d4-5f4a-8d2f-e500d31f760b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b347f1bf-6167-4c59-bfa6-3e921874ab9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b347f1bf-6167-4c59-bfa6-3e921874ab9a.jpg?1",
             "name": "Earthen Goo",
             "text": "Trample\nCumulative upkeep {R} or {G} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nEarthen Goo gets +1/+1 for each age counter on it.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "7c4c2699-4b6e-5724-9c9f-78ed27c89ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3223ef9-787a-40ac-8ab2-79ac75664aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3223ef9-787a-40ac-8ab2-79ac75664aa2.jpg?1",
             "name": "Fury of the Horde",
             "text": "You may remove two red cards in your hand from the game rather than pay Fury of the Horde's mana cost.\nUntap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "3aac646a-8bcc-5b47-b147-6df99991084d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8ec9c1-da73-44fb-9e30-5279a7ed4e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8ec9c1-da73-44fb-9e30-5279a7ed4e7e.jpg?1",
             "name": "Goblin Furrier",
             "text": "Prevent all damage that Goblin Furrier would deal to snow creatures.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "ad994c60-4a70-53b2-90d0-192feddf45cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254a437-5240-40ca-bf7b-d30b95942bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254a437-5240-40ca-bf7b-d30b95942bf5.jpg?1",
             "name": "Goblin Rimerunner",
             "text": "{T}: Target creature can't block this turn.\n{S}: Goblin Rimerunner gains haste until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "0a57993a-471c-59e7-94ea-3d3ece8e784a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77697b16-7faa-400d-a865-732c8b0d3d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77697b16-7faa-400d-a865-732c8b0d3d41.jpg?1",
             "name": "Greater Stone Spirit",
             "text": "Greater Stone Spirit can't be blocked by creatures with flying.\n{2}{R}: Until end of turn, target creature gets +0/+2 and gains \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "7d4885ac-83b2-5864-aa59-5844e7cd7d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf90fc3-b08b-4261-a194-d6b06fdd59d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf90fc3-b08b-4261-a194-d6b06fdd59d8.jpg?1",
             "name": "Icefall",
             "text": "Destroy target artifact or land.\nRecover {R}{R} (When a creature is put into your graveyard from play, you may pay {R}{R}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "4d472d62-c113-5877-9fa2-2cd9d1f0ea0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963f45d7-ce84-47af-ae1c-727172a31f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963f45d7-ce84-47af-ae1c-727172a31f0f.jpg?1",
             "name": "Karplusan Minotaur",
             "text": "Cumulative upkeep\u2014\nFlip a coin.\nWhenever you win a coin flip, Karplusan Minotaur deals 1 damage to target creature or player.\nWhenever you lose a coin flip, Karplusan Minotaur deals 1 damage to target creature or player of an opponent's choice.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "d3dd0086-e3f8-59ed-a617-7fbfb4edbdea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602610ce-8f42-4a1d-8f6e-92424d9d637c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602610ce-8f42-4a1d-8f6e-92424d9d637c.jpg?1",
             "name": "Karplusan Wolverine",
             "text": "Whenever Karplusan Wolverine becomes blocked, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "3f6f9209-cfc3-5efe-aeb4-8e0c8585cfb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b4f4b6-51cd-4ae0-9585-82ad964853ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b4f4b6-51cd-4ae0-9585-82ad964853ba.jpg?1",
             "name": "Lightning Serpent",
             "text": "Trample, haste\nLightning Serpent comes into play with X +1/+0 counters on it.\nAt end of turn, sacrifice Lightning Serpent.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "bcecfad9-04d1-588a-b745-7958c5599d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0388e-a04c-4757-a06d-8e8046f5a783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0388e-a04c-4757-a06d-8e8046f5a783.jpg?1",
             "name": "Lightning Storm",
             "text": "Lightning Storm deals X damage to target creature or player, where X is 3 plus the number of charge counters on it.\nDiscard a land card: Put two charge counters on Lightning Storm. You may choose a new target for it. Any player may play this ability but only if Lightning Storm is on the stack.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "aed8cb47-47e7-5572-88e1-f01f4cee41ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd7d-0b85-4b63-89c9-9e865c680bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11bdd7d-0b85-4b63-89c9-9e865c680bd4.jpg?1",
             "name": "Lovisa Coldeyes",
             "text": "Barbarians, Warriors, and Berserkers get +2/+2 and have haste.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "1c97fdfe-0f15-5de4-9ec5-d8ec93542f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db70f9-1feb-4932-97be-02db824eda70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db70f9-1feb-4932-97be-02db824eda70.jpg?1",
             "name": "Magmatic Core",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nAt the end of your turn, Magmatic Core deals X damage divided as you choose among any number of target creatures, where X is the number of age counters on it.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "187faff5-a906-58a1-8f17-5891a4bc1df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600a2cd2-166a-4fd8-838d-e513534b7cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600a2cd2-166a-4fd8-838d-e513534b7cb0.jpg?1",
             "name": "Martyr of Ashes",
             "text": "{2}, Reveal X red cards from your hand, Sacrifice Martyr of Ashes: Martyr of Ashes deals X damage to each creature without flying.",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "064a5b86-88aa-5e20-a169-900a82098dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6cfa21-75b1-4380-b0fc-a7450699660f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6cfa21-75b1-4380-b0fc-a7450699660f.jpg?1",
             "name": "Ohran Yeti",
             "text": "{2}{S}: Target snow creature gains first strike until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "fc825ac8-88ec-5b43-8b97-f89df59fdbc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746eaf30-3ded-4a9f-a4ec-1925edcc8e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746eaf30-3ded-4a9f-a4ec-1925edcc8e94.jpg?1",
             "name": "Orcish Bloodpainter",
             "text": "{T}, Sacrifice a creature: Orcish Bloodpainter deals 1 damage to target creature or player.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "fcc40386-5897-5f8e-9a6e-2a2ef453ee50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d0342-0ba2-46b0-bda5-6a9fe4dcad3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113d0342-0ba2-46b0-bda5-6a9fe4dcad3e.jpg?1",
             "name": "Rimescale Dragon",
             "text": "Flying\n{2}{S}: Tap target creature and put an ice counter on it. ({S} can be paid with one mana from a snow permanent.)\nCreatures with ice counters on them don't untap during their controllers' untap steps.",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "af228d13-6d11-5ec4-a0e3-b6b69df2e0b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062caf7-f0eb-44db-9f74-e6711a13fada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062caf7-f0eb-44db-9f74-e6711a13fada.jpg?1",
             "name": "Rite of Flame",
             "text": "Add {R}{R} to your mana pool, then add {R} to your mana pool for each card named Rite of Flame in each graveyard.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "ec5f6665-a935-51f1-8ab4-687f3cab250d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6d42a-7607-4361-acc4-7f3cb956bfc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6d42a-7607-4361-acc4-7f3cb956bfc9.jpg?1",
             "name": "Skred",
             "text": "Skred deals damage to target creature equal to the number of snow permanents you control.",
             "colours": [
@@ -3328,7 +3328,7 @@
         },
         {
             "id": "aa6dd436-ffc4-594b-8975-16689213c1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af53d0b-ac60-4519-a6f4-c67899bcfdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af53d0b-ac60-4519-a6f4-c67899bcfdd6.jpg?1",
             "name": "Stalking Yeti",
             "text": "When Stalking Yeti comes into play, if it's in play, it deals damage equal to its power to target creature an opponent controls and that creature deals damage equal to its power to Stalking Yeti.\n{2}{S}: Return Stalking Yeti to its owner's hand. Play this ability only any time you could play a sorcery. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -3364,7 +3364,7 @@
         },
         {
             "id": "644c152c-f5cf-535a-a001-464fb2f9cade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9974a543-7429-458b-a24f-c84cbffbb54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9974a543-7429-458b-a24f-c84cbffbb54d.jpg?1",
             "name": "Surging Flame",
             "text": "Ripple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)\nSurging Flame deals 2 damage to target creature or player.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "e3bb2e50-a85f-57c4-9f83-4691a54daa7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09475e9-d6c1-4d4b-905e-40bc30405725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09475e9-d6c1-4d4b-905e-40bc30405725.jpg?1",
             "name": "Thermopod",
             "text": "{S}: Thermopod gains haste until end of turn. ({S} can be paid with one mana from a snow permanent.)\nSacrifice a creature: Add {R} to your mana pool.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "94c73448-8293-56fc-8efd-603c8628632b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3ba39-5b4d-4a7c-9215-7e349aecbeb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3ba39-5b4d-4a7c-9215-7e349aecbeb3.jpg?1",
             "name": "Allosaurus Rider",
             "text": "You may remove two green cards in your hand from the game rather than pay Allosaurus Rider's mana cost.\nAllosaurus Rider's power and toughness are each equal to 1 plus the number of lands you control.",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "ca489bd9-49f0-5fa9-8587-cf940dfd204f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da62ada-b7cd-4110-a213-281f00fca3e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da62ada-b7cd-4110-a213-281f00fca3e7.jpg?1",
             "name": "Arctic Nishoba",
             "text": "Trample\nCumulative upkeep {G} or {W} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Arctic Nishoba is put into a graveyard from play, you gain 2 life for each age counter on it.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "019f1759-374d-5beb-a81d-77e8dc2a2f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757b3ad-b808-4506-934e-727e065f66c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757b3ad-b808-4506-934e-727e065f66c1.jpg?1",
             "name": "Aurochs Herd",
             "text": "Trample\nWhen Aurochs Herd comes into play, you may search your library for an Aurochs card, reveal it, and put it into your hand. If you do, shuffle your library.\nWhenever Aurochs Herd attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.",
             "colours": [
@@ -3537,7 +3537,7 @@
         },
         {
             "id": "37de099c-0c8b-54f0-b95f-9affb82b68b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05231fa1-47b8-49aa-9393-ec4d8384c41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05231fa1-47b8-49aa-9393-ec4d8384c41b.jpg?1",
             "name": "Boreal Centaur",
             "text": "{S}: Boreal Centaur gets +1/+1 until end of turn. Play this ability only once each turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "e27cda31-285f-5c81-8cb7-058f1e68d5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d3633-6dc7-4026-a50e-3ea76b9e8c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d3633-6dc7-4026-a50e-3ea76b9e8c20.jpg?1",
             "name": "Boreal Druid",
             "text": "{T}: Add {1} to your mana pool.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "ebf5a64a-0851-5293-bdf0-313c3b3e214f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252ef807-f861-4dcf-8e52-9260301c729a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252ef807-f861-4dcf-8e52-9260301c729a.jpg?1",
             "name": "Brooding Saurian",
             "text": "At the end of each turn, each player gains control of all nontoken permanents he or she owns.",
             "colours": [
@@ -3645,7 +3645,7 @@
         },
         {
             "id": "c111a6ca-5fe9-5d58-876a-cc86922ac951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d59bd4a-006b-4dd8-ab33-d931196f3a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d59bd4a-006b-4dd8-ab33-d931196f3a8a.jpg?1",
             "name": "Bull Aurochs",
             "text": "Trample\nWhenever Bull Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "63d94faa-a602-57e1-a854-1337445b97d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafb0b4-9f01-4c67-add4-a0ffe0a3a691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafb0b4-9f01-4c67-add4-a0ffe0a3a691.jpg?1",
             "name": "Freyalise's Radiance",
             "text": "Cumulative upkeep {2} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nSnow permanents don't untap during their controllers' untap steps.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "ac984b9f-458f-57e5-8bbe-7d7505d9811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48574974-bdbb-40e8-916a-44c54b08b501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48574974-bdbb-40e8-916a-44c54b08b501.jpg?1",
             "name": "Frostweb Spider",
             "text": "Frostweb Spider can block as though it had flying.\nWhenever Frostweb Spider blocks a creature with flying, put a +1/+1 counter on Frostweb Spider at end of combat.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "315c6fa7-2abc-543b-9c72-95f4d33e04e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ab03a-99e3-4596-a19a-033845f77a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ab03a-99e3-4596-a19a-033845f77a93.jpg?1",
             "name": "Hibernation's End",
             "text": "Cumulative upkeep {1}\nWhenever you pay Hibernation's End's cumulative upkeep, you may search your library for a creature card with converted mana cost equal to the number of age counters on Hibernation's End and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -3779,7 +3779,7 @@
         },
         {
             "id": "98d73439-b7d2-5d35-a5c4-1d7d30bcf55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cea55d-8ef3-44a5-894e-967f1e97fc02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cea55d-8ef3-44a5-894e-967f1e97fc02.jpg?1",
             "name": "Into the North",
             "text": "Search your library for a snow land card and put it into play tapped. Then shuffle your library.",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "e42aa9b5-dafd-5930-982c-8371a5ba4cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d27fdf-690b-4e93-8412-4f6fb0ed43db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d27fdf-690b-4e93-8412-4f6fb0ed43db.jpg?1",
             "name": "Karplusan Strider",
             "text": "Karplusan Strider can't be the target of blue or black spells.",
             "colours": [
@@ -3845,7 +3845,7 @@
         },
         {
             "id": "c5197664-72ac-5dd8-a976-d23be4ed6025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fc47b-9a1b-4540-9c07-09e4e92ab974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fc47b-9a1b-4540-9c07-09e4e92ab974.jpg?1",
             "name": "Martyr of Spores",
             "text": "{1}, Reveal X green cards from your hand, Sacrifice Martyr of Spores: Target creature gets +X/+X until end of turn.",
             "colours": [
@@ -3880,7 +3880,7 @@
         },
         {
             "id": "c8429f16-03dc-5862-b844-c6c2a27aaf03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ff91d-acc1-4be7-a327-58fcb036b452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ff91d-acc1-4be7-a327-58fcb036b452.jpg?1",
             "name": "Mystic Melting",
             "text": "Destroy target artifact or enchantment.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "d5343316-66d2-59af-9022-3cdc2f858e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fd0ee-2350-4eb0-8417-700459879f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fd0ee-2350-4eb0-8417-700459879f74.jpg?1",
             "name": "Ohran Viper",
             "text": "Whenever Ohran Viper deals combat damage to a creature, destroy that creature at the end of combat.\nWhenever Ohran Viper deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "dac26bf3-c449-5995-84b1-16828e6ccdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063bb28b-5e32-4f31-a208-16b653edf413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063bb28b-5e32-4f31-a208-16b653edf413.jpg?1",
             "name": "Panglacial Wurm",
             "text": "Trample\nWhile you're searching your library, you may play Panglacial Wurm from your library.",
             "colours": [
@@ -3982,7 +3982,7 @@
         },
         {
             "id": "107b7135-3aee-51af-b439-25e2a7bbc895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dded16-e516-430e-a528-c49a483f03b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dded16-e516-430e-a528-c49a483f03b4.jpg?1",
             "name": "Resize",
             "text": "Target creature gets +3/+3 until end of turn.\nRecover {1}{G} (When a creature is put into your graveyard from play, you may pay {1}{G}. If you do, return this card from your graveyard to your hand. Otherwise, remove this card from the game.)",
             "colours": [
@@ -4014,7 +4014,7 @@
         },
         {
             "id": "73630d6d-80d4-561a-ba7e-bfc79c04b2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3844b3f8-2d42-4265-b2dd-fa888492efff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3844b3f8-2d42-4265-b2dd-fa888492efff.jpg?1",
             "name": "Rimehorn Aurochs",
             "text": "Trample\nWhenever Rimehorn Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.\n{2}{S}: Target creature blocks target creature this turn if able. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "b0262578-d834-5c53-ac41-c25c1c21b6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b4b14c-e6fa-4cd2-9be7-fa2a2df05de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b4b14c-e6fa-4cd2-9be7-fa2a2df05de1.jpg?1",
             "name": "Ronom Hulk",
             "text": "Protection from snow\nCumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "bc68c16f-f1e3-592e-842a-a77a301a366d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5436d55d-d2d0-4f22-b399-93f1d48e080f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5436d55d-d2d0-4f22-b399-93f1d48e080f.jpg?1",
             "name": "Shape of the Wiitigo",
             "text": "Enchant creature\nWhen Shape of the Wiitigo comes into play, put six +1/+1 counters on enchanted creature.\nAt the beginning of your upkeep, put a +1/+1 counter on enchanted creature if it attacked or blocked since your last upkeep. Otherwise, remove a +1/+1 counter from it.",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "dffc0883-7177-5f0d-b9af-30a025c84545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16535ae-6e03-4992-9459-d31626a3222e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16535ae-6e03-4992-9459-d31626a3222e.jpg?1",
             "name": "Sheltering Ancient",
             "text": "Trample\nCumulative upkeep\u2014\nPut a +1/+1 counter on a creature an opponent controls. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "608afc24-b9af-58db-a80e-c46d7c254d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2ed9f3-50b1-493b-9c14-0f8ddb4d8c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2ed9f3-50b1-493b-9c14-0f8ddb4d8c57.jpg?1",
             "name": "Simian Brawler",
             "text": "Discard a land card: Simian Brawler gets +1/+1 until end of turn.",
             "colours": [
@@ -4187,7 +4187,7 @@
         },
         {
             "id": "0f0445c3-4b42-5e40-a0be-9151ecd3e421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae586221-c13c-4f4e-83ae-9b1ab0aeae61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae586221-c13c-4f4e-83ae-9b1ab0aeae61.jpg?1",
             "name": "Sound the Call",
             "text": "Put a 1/1 green Wolf creature token into play with \"This creature gets +1/+1 for each card named Sound the Call in each graveyard.\"",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "b25af5de-ff93-5b0b-ac27-6b3a2421f80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa585b7-cf7e-4f04-9490-1e6c53631647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa585b7-cf7e-4f04-9490-1e6c53631647.jpg?1",
             "name": "Steam Spitter",
             "text": "Steam Spitter can block as though it had flying.\n{R}: Steam Spitter gets +1/+0 until end of turn.",
             "colours": [
@@ -4254,7 +4254,7 @@
         },
         {
             "id": "b2d20dfb-c4c6-515d-944a-9f9217450a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa51adee-b343-4a03-8fa0-0d86244db5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa51adee-b343-4a03-8fa0-0d86244db5b7.jpg?1",
             "name": "Surging Might",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nRipple 4 (When you play this spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as this spell without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "b6e636e0-9849-5048-ae5e-f1dac085de3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d925746c-4bba-4d50-aeee-3a3bfd165a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d925746c-4bba-4d50-aeee-3a3bfd165a2e.jpg?1",
             "name": "Blizzard Specter",
             "text": "Flying\nWhenever Blizzard Specter deals combat damage to a player, choose one That player returns a permanent he or she controls to its owner's hand; or that player discards a card.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "ecd3af67-2fb7-56cf-9793-b9d8ed5d634b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26cf431-b79b-4619-9d19-bc4557f2f9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26cf431-b79b-4619-9d19-bc4557f2f9bf.jpg?1",
             "name": "Deepfire Elemental",
             "text": "{X}{X}{1}: Destroy target artifact or creature with converted mana cost X.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "6eecbfa5-c416-5d4b-8d35-5d0a59b92e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072cf13-284b-4fb8-ab2c-b2e15388a30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072cf13-284b-4fb8-ab2c-b2e15388a30a.jpg?1",
             "name": "Diamond Faerie",
             "text": "Flying\n{1}{S}: Snow creatures you control get +1/+1 until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -4402,7 +4402,7 @@
         },
         {
             "id": "d143e995-4826-5bc8-8ac4-62cec6c92df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570143b-183b-4ae2-8806-3d0c4cd7406e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570143b-183b-4ae2-8806-3d0c4cd7406e.jpg?1",
             "name": "Garza Zol, Plague Queen",
             "text": "Flying, haste\nWhenever a creature dealt damage by Garza Zol, Plague Queen this turn is put into a graveyard, put a +1/+1 counter on Garza Zol.\nWhenever Garza Zol deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "09fe7c45-359d-5770-80f9-ac22e93b3ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce582ff6-6a21-418d-b72c-4402a43be7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce582ff6-6a21-418d-b72c-4402a43be7dc.jpg?1",
             "name": "Juniper Order Ranger",
             "text": "Whenever another creature comes into play under your control, put a +1/+1 counter on that creature and a +1/+1 counter on Juniper Order Ranger.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "7e4c6d00-b464-599e-be8b-12ab02f4134d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9257bb20-de32-460c-96cf-375acb6a0b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9257bb20-de32-460c-96cf-375acb6a0b1d.jpg?1",
             "name": "Sek'Kuar, Deathkeeper",
             "text": "Whenever another nontoken creature you control is put into a graveyard from play, put a 3/1 black and red Graveborn creature token with haste into play.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "75a84e74-668d-5091-ad49-273db8a77269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32955b-cbf6-429b-9513-17ca75d4ec2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32955b-cbf6-429b-9513-17ca75d4ec2c.jpg?1",
             "name": "Tamanoa",
             "text": "Whenever a noncreature source you control deals damage, you gain that much life.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "d455367c-98d1-5ba8-9f7b-56bc4d1487b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da89cfe-274f-452d-a5ca-b034534898c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da89cfe-274f-452d-a5ca-b034534898c7.jpg?1",
             "name": "Vanish into Memory",
             "text": "Remove target creature from the game. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to play under its owner's control. If you do, discard cards equal to its toughness.",
             "colours": [
@@ -4594,7 +4594,7 @@
         },
         {
             "id": "fe2d1b88-87fc-5e32-b68a-fc1becd19eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63632a0-1493-4a72-917c-aae1600c6230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63632a0-1493-4a72-917c-aae1600c6230.jpg?1",
             "name": "Wilderness Elemental",
             "text": "Trample\nWilderness Elemental's power is equal to the number of nonbasic lands your opponents control.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "a95c66af-5603-58a2-a8da-5c3e94326b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1255e9-c0b8-4757-a857-b27a99dd4930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1255e9-c0b8-4757-a857-b27a99dd4930.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with converted mana cost 3 or less and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "bb73ac80-704a-50a9-8c05-ef78f8f64640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd5015e-fe31-42e3-923d-44b9cdece273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd5015e-fe31-42e3-923d-44b9cdece273.jpg?1",
             "name": "Coldsteel Heart",
             "text": "Coldsteel Heart comes into play tapped.\nAs Coldsteel Heart comes into play, choose a color.\n{T}: Add one mana of the chosen color to your mana pool.",
             "colours": [],
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "2379c5e6-fd3e-5213-8e54-78409c1c402a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7118c2e0-04d6-4a71-8ffd-b9365b154050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7118c2e0-04d6-4a71-8ffd-b9365b154050.jpg?1",
             "name": "Jester's Scepter",
             "text": "When Jester's Scepter comes into play, remove the top five cards of target player's library from the game face down. You may look at those cards as long as they remain removed from the game.\n{2}, {T}, Put a card removed from the game with Jester's Scepter into its owner's graveyard: Counter target spell if it has the same name as that card.",
             "colours": [],
@@ -4729,7 +4729,7 @@
         },
         {
             "id": "f91a8a7d-89df-5c91-9137-07640a16ccbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a720448-017f-4f4a-9501-678245eaed17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a720448-017f-4f4a-9501-678245eaed17.jpg?1",
             "name": "Mishra's Bauble",
             "text": "{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -4757,7 +4757,7 @@
         },
         {
             "id": "e4883f27-3886-5e94-a450-acba4a809301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ff9859-92a4-4732-94bf-6c02b0a57338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ff9859-92a4-4732-94bf-6c02b0a57338.jpg?1",
             "name": "Phyrexian Ironfoot",
             "text": "Phyrexian Ironfoot doesn't untap during your untap step.\n{1}{S}: Untap Phyrexian Ironfoot. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "aef2e11d-3053-58d8-8c10-c67e8a04515c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3cf3d3-101e-4649-9495-8a95507d0283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3cf3d3-101e-4649-9495-8a95507d0283.jpg?1",
             "name": "Phyrexian Snowcrusher",
             "text": "Phyrexian Snowcrusher attacks each turn if able.\n{1}{S}: Phyrexian Snowcrusher gets +1/+0 until end of turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -4825,7 +4825,7 @@
         },
         {
             "id": "f633078a-defc-56cf-bc99-83e2d62e8d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4325ea-2e84-4871-a8d6-a42b1d3d6765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4325ea-2e84-4871-a8d6-a42b1d3d6765.jpg?1",
             "name": "Phyrexian Soulgorger",
             "text": "Cumulative upkeep\u2014\nSacrifice a creature. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
             "colours": [],
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "503396d5-3a3c-5282-a1ac-2afc344fc7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31412335-110c-449a-9c2f-bff8763a6504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31412335-110c-449a-9c2f-bff8763a6504.jpg?1",
             "name": "Thrumming Stone",
             "text": "Spells you control have ripple 4. (Whenever you play a spell, you may reveal the top four cards of your library. You may play any revealed cards with the same name as the spell without paying their mana costs. Put the rest on the bottom of your library.)",
             "colours": [],
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "6ed6c742-e486-52a0-a7e7-16cca830f6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b15f6-e65b-46d6-95e8-dc39f25d7efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609b15f6-e65b-46d6-95e8-dc39f25d7efa.jpg?1",
             "name": "Arctic Flats",
             "text": "Arctic Flats comes into play tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "13437e6d-e9fa-5bb1-b1f9-8c18174393cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8396-72ab-4387-9276-987836427107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2f8396-72ab-4387-9276-987836427107.jpg?1",
             "name": "Boreal Shelf",
             "text": "Boreal Shelf comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "7a1aab33-99c6-5756-8f30-832f2e11bc67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92409c3a-fb1a-4205-9fe1-0f5affc7b21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92409c3a-fb1a-4205-9fe1-0f5affc7b21d.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths comes into play with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, put an indestructible legendary 20/20 black Avatar creature token with flying named Marit Lage into play.",
             "colours": [],
@@ -4986,7 +4986,7 @@
         },
         {
             "id": "ed90a13f-fe30-542a-b6e2-81f1fbdf507b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9320033-d8d7-4a01-80db-60de222040e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9320033-d8d7-4a01-80db-60de222040e6.jpg?1",
             "name": "Frost Marsh",
             "text": "Frost Marsh comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "1cfbe1be-e78b-5102-be73-402f0cb04bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bcd111-0830-4fc0-a113-37eb306fb1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bcd111-0830-4fc0-a113-37eb306fb1a0.jpg?1",
             "name": "Highland Weald",
             "text": "Highland Weald comes into play tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5052,7 +5052,7 @@
         },
         {
             "id": "4ea40f2d-5c1b-53e5-a81e-a3265b77f407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8f7396-23d3-48e2-8686-2b59ccbfc7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8f7396-23d3-48e2-8686-2b59ccbfc7e5.jpg?1",
             "name": "Mouth of Ronom",
             "text": "{T}: Add {1} to your mana pool.\n{4}{S}, {T}, Sacrifice Mouth of Ronom: Mouth of Ronom deals 4 damage to target creature. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -5082,7 +5082,7 @@
         },
         {
             "id": "0d734f03-5b93-594e-8f0d-efb6406d0115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e95422-c6fe-4750-916b-43bf22ae193a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e95422-c6fe-4750-916b-43bf22ae193a.jpg?1",
             "name": "Scrying Sheets",
             "text": "{T}: Add {1} to your mana pool.\n{1}{S}, {T}: Look at the top card of your library. If that card is snow, you may reveal it and put it into your hand. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "db8f4791-cd61-5534-b120-94df11ecb15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8fe2c-2297-4e19-8a87-01eb99b8c6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd8fe2c-2297-4e19-8a87-01eb99b8c6dc.jpg?1",
             "name": "Tresserhorn Sinks",
             "text": "Tresserhorn Sinks comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "04d47c59-e710-5b59-982d-9473cb3ba4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3a010-dae3-41b6-8dd8-e31d14c3ac4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e3a010-dae3-41b6-8dd8-e31d14c3ac4a.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "W",
             "colours": [],
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "159e7a7b-f1f0-558a-a0cd-066408fff13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abf0692-07d1-4b72-af06-93d0e338589d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abf0692-07d1-4b72-af06-93d0e338589d.jpg?1",
             "name": "Snow-Covered Island",
             "text": "U",
             "colours": [],
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "e06fd9e6-9d48-55a5-80c5-0e1d3756f686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dacaf1-09b8-42bb-8064-990190fdaf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dacaf1-09b8-42bb-8064-990190fdaf81.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "B",
             "colours": [],
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "a80f4058-ccc2-5d6e-b8e9-2b3706687ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc9a6d1-a1ca-4b8f-894d-71c2a9933f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc9a6d1-a1ca-4b8f-894d-71c2a9933f79.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "R",
             "colours": [],
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "dd51a4c5-3cea-5fea-a9d8-719f1ca52a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838c915d-8153-43c2-b513-dfbe4e9388a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838c915d-8153-43c2-b513-dfbe4e9388a5.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DFT.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DFT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6aecfdb4-c13d-5264-8d42-eb73598c0319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c8e29-de24-4664-baf8-959608dd99ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77c8e29-de24-4664-baf8-959608dd99ca.jpg?1",
             "name": "Air Response Unit",
             "text": "Flying, vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "1e8bcc6d-783f-52fb-a50d-6c119fd63e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39f7f98-ad5e-4e5e-9f7b-abe0984ffe17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39f7f98-ad5e-4e5e-9f7b-abe0984ffe17.jpg?1",
             "name": "Alacrian Armory",
             "text": "Creatures you control get +0/+1 and have vigilance.\nAt the beginning of combat on your turn, choose up to one target Mount or Vehicle you control. Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact creature if it's a Vehicle.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "a15aaad0-a878-5436-a7db-3a6182f112e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg?1",
             "name": "Basri, Tomorrow's Champion",
             "text": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink. (An exerted creature won't untap during your next untap step.)\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "b80d4a32-78a1-5a14-a94e-b8123bff492e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb819eb-ba5c-4449-87b5-3894380558bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb819eb-ba5c-4449-87b5-3894380558bc.jpg?1",
             "name": "Brightfield Glider",
             "text": "Vigilance\nWhenever this creature attacks while saddled, it gets +1/+2 and gains flying until end of turn.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "667254d6-20b4-564d-883c-cd9b1464ac0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7cacc-f15e-46c1-9c25-b567bb3e8680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7cacc-f15e-46c1-9c25-b567bb3e8680.jpg?1",
             "name": "Brightfield Mustang",
             "text": "Whenever this creature attacks while saddled, untap it and put a +1/+1 counter on it.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "95937bd0-9175-5c65-bee8-ee9e5da7b0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ce2385-e33d-47b3-96c8-5a4672d9df7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ce2385-e33d-47b3-96c8-5a4672d9df7c.jpg?1",
             "name": "Broadcast Rambler",
             "text": "When this Vehicle enters, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -218,7 +218,7 @@
         },
         {
             "id": "cad506a8-9c0f-583a-86d7-6e4e856827b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106944b2-f3ae-4350-be33-61b9f92fc92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106944b2-f3ae-4350-be33-61b9f92fc92f.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "33e98556-7504-517e-a7ca-db3cd9703d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0b15da-a45c-42f5-aafc-20ad9e38bf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0b15da-a45c-42f5-aafc-20ad9e38bf24.jpg?1",
             "name": "Canyon Vaulter",
             "text": "Whenever this creature saddles a Mount or crews a Vehicle during your main phase, that Mount or Vehicle gains flying until end of turn.",
             "colours": [
@@ -292,7 +292,7 @@
         },
         {
             "id": "a70988e3-d9b5-58da-87a4-9c206952796b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380d87a-c460-409c-8d47-9b2fc5ddd2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380d87a-c460-409c-8d47-9b2fc5ddd2ea.jpg?1",
             "name": "Cloudspire Captain",
             "text": "Mounts and Vehicles you control get +1/+1.\nThis creature saddles Mounts and crews Vehicles as though its power were 2 greater.",
             "colours": [
@@ -327,7 +327,7 @@
         },
         {
             "id": "34a67cda-6a32-5b7c-9b00-c5ddd669bec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b60da34-b622-42de-a249-79545bcbf30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b60da34-b622-42de-a249-79545bcbf30d.jpg?1",
             "name": "Collision Course",
             "text": "Choose one \u2014\n\u2022 Collision Course deals X damage to target creature, where X is the number of permanents you control that are creatures and/or Vehicles.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "ad3d8549-f3f4-5d52-86eb-251249206fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382552c-2740-409a-83a1-80b60627beb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382552c-2740-409a-83a1-80b60627beb8.jpg?1",
             "name": "Daring Mechanic",
             "text": "{3}{W}: Put a +1/+1 counter on target Mount or Vehicle.",
             "colours": [
@@ -394,7 +394,7 @@
         },
         {
             "id": "68f0abf6-6e72-5574-b0ec-9c3d00aeb482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5e64f-7af2-4cb4-abd1-23992e346bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5e64f-7af2-4cb4-abd1-23992e346bee.jpg?1",
             "name": "Detention Chariot",
             "text": "When this Vehicle enters, exile target artifact or creature an opponent controls until this Vehicle leaves the battlefield.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "0c3b8632-59c9-51c0-98b5-d4cf0d86e711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdb58b7-e1ef-496b-b8dd-d1fabf3d2e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdb58b7-e1ef-496b-b8dd-d1fabf3d2e7a.jpg?1",
             "name": "Gallant Strike",
             "text": "Destroy target creature with toughness 4 or greater.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "2d27a571-5383-598a-a964-0c8cc45152e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ac678-8b74-4865-a896-c42692c02341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ac678-8b74-4865-a896-c42692c02341.jpg?1",
             "name": "Gloryheath Lynx",
             "text": "Lifelink\nWhenever this creature attacks while saddled, search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "11a07566-145e-5311-a92a-9abff92f24d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -536,7 +536,7 @@
         },
         {
             "id": "ba1664f3-0775-50bc-aada-17d1cc198374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeea2c-d8aa-416f-95d6-6af888591fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaeea2c-d8aa-416f-95d6-6af888591fdf.jpg?1",
             "name": "Guidelight Synergist",
             "text": "Flying\nThis creature gets +1/+0 for each artifact you control.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "5171c0fd-cb7c-5ef9-b6a9-5e773a4f697d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd487a-a9e6-44e3-80af-bc384316106f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd487a-a9e6-44e3-80af-bc384316106f.jpg?1",
             "name": "Interface Ace",
             "text": "This creature saddles Mounts and crews Vehicles using its toughness rather than its power.\nWhenever this creature becomes tapped during your turn, untap it. This ability triggers only once each turn.",
             "colours": [
@@ -608,7 +608,7 @@
         },
         {
             "id": "515c6f6e-9114-53bd-97f3-e50555ae5205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e4107-213f-491b-a032-8e3367009ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e4107-213f-491b-a032-8e3367009ba8.jpg?1",
             "name": "Leonin Surveyor",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nDuring your turn, this creature has first strike.\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "fb18361d-7b50-51b4-8ff5-f37f498b520e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf6a0e7-1fd4-425f-b634-c93236daea35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf6a0e7-1fd4-425f-b634-c93236daea35.jpg?1",
             "name": "Lightshield Parry",
             "text": "Target creature gets +2/+2 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "1b7bae84-d1ee-5bdf-9d37-99ea75155816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab169c1-4e25-4a5d-8961-4f06298c3781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab169c1-4e25-4a5d-8961-4f06298c3781.jpg?1",
             "name": "Lightwheel Enhancements",
             "text": "Enchant creature or Vehicle\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nEnchanted permanent gets +1/+1 and has vigilance.\nMax speed \u2014 You may cast this card from your graveyard.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "5b90fb65-d2ed-5c69-a09e-42b0a33b3776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80645651-3804-481f-8f8f-ade762a011e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80645651-3804-481f-8f8f-ade762a011e1.jpg?1",
             "name": "Lotusguard Disciple",
             "text": "Flying\nWhen this creature enters, target creature or Vehicle gains lifelink and indestructible until end of turn.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "2396eeab-94ff-5384-b9e5-c5e1acc413d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829c0ae-f72f-4195-ad43-775d7218565c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829c0ae-f72f-4195-ad43-775d7218565c.jpg?1",
             "name": "Nesting Bot",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature dies, create a 1/1 colorless Servo artifact creature token.\nMax speed \u2014 This creature gets +1/+0.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "62ac529d-8776-597a-b701-d64454e4ad73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg?1",
             "name": "Perilous Snare",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed \u2014 {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "39d13575-1740-5b5c-8fbc-dad3cf1f65be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4172222f-d871-4354-9a02-7af0001d8956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4172222f-d871-4354-9a02-7af0001d8956.jpg?1",
             "name": "Pride of the Road",
             "text": "Vigilance\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 At the beginning of combat on your turn, target creature or Vehicle you control gains double strike until end of turn.",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "0952d25c-716a-5a37-8285-2929d3f40ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f96b33b-c952-45ac-9626-40169b2bd4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f96b33b-c952-45ac-9626-40169b2bd4ef.jpg?1",
             "name": "Ride's End",
             "text": "This spell costs {3} less to cast if it targets a tapped permanent.\nExile target creature or Vehicle.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "b36305b4-3076-5eb6-af7e-bb7438b69bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2a9154-7b43-4b8d-9d81-d11cfda5d597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2a9154-7b43-4b8d-9d81-d11cfda5d597.jpg?1",
             "name": "Roadside Assistance",
             "text": "Enchant creature or Vehicle\nWhen this Aura enters, create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"\nEnchanted permanent gets +1/+1 and has lifelink.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "ebc8962e-9cde-5a95-bea2-cb40bd8ff85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ed1bf2-0f3c-4528-b570-e5bdcd7ffda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ed1bf2-0f3c-4528-b570-e5bdcd7ffda9.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "cacc7245-c05e-583b-b140-e53dca3d8261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "2af2fffd-a539-5c14-8bc0-fa54e044d224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24a6309-0e69-45f0-a9ff-44d4997e7e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24a6309-0e69-45f0-a9ff-44d4997e7e4d.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "ebe644fa-fc6d-5cb7-850f-7201b3e262dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0489108-75b7-441c-888d-12987c0c1080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0489108-75b7-441c-888d-12987c0c1080.jpg?1",
             "name": "Spotcycle Scouter",
             "text": "When this Vehicle enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -1067,7 +1067,7 @@
         },
         {
             "id": "7cfa0e5c-471b-580c-a5e2-9320f125dd63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5435c-52f3-42d7-bcee-5aa13afd6626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5435c-52f3-42d7-bcee-5aa13afd6626.jpg?1",
             "name": "Sundial, Dawn Tyrant",
             "text": "",
             "colours": [
@@ -1104,7 +1104,7 @@
         },
         {
             "id": "f392deed-944c-5af8-abe5-298e4f67f0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db9bb9-d930-40e5-b144-01ebfd377996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72db9bb9-d930-40e5-b144-01ebfd377996.jpg?1",
             "name": "Swiftwing Assailant",
             "text": "Flying\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 This creature gets +0/+1 and has vigilance.",
             "colours": [
@@ -1139,7 +1139,7 @@
         },
         {
             "id": "7dada4b5-ee3a-57fa-a464-159e45db71a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bddc5f-8f25-4313-b5bb-e5eae2923878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bddc5f-8f25-4313-b5bb-e5eae2923878.jpg?1",
             "name": "Tune Up",
             "text": "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.",
             "colours": [
@@ -1173,7 +1173,7 @@
         },
         {
             "id": "90a8de74-d829-5373-9716-35bbf3e25c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12296a74-5d60-4ee3-aa53-2289f84da776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12296a74-5d60-4ee3-aa53-2289f84da776.jpg?1",
             "name": "Unswerving Sloth",
             "text": "Whenever this creature attacks while saddled, it gains indestructible until end of turn. Untap all creatures you control.\nSaddle 4 (Tap any number of other creatures you control with total power 4 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "1acc5cf4-6e6f-5116-8e56-448f4e15ace8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W} ({X}{2}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "6bd581d3-be0f-59fc-b839-9a5226f24568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "e35e26cb-14a0-5dae-a03e-a2abba9a29f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcdc8c-fba1-4ea1-bf93-65072d10f0da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcdc8c-fba1-4ea1-bf93-65072d10f0da.jpg?1",
             "name": "Voyager Quickwelder",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "327b55b6-813f-5001-83cd-952adf695544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7033739-4cd8-4727-b9b5-099fb597006b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7033739-4cd8-4727-b9b5-099fb597006b.jpg?1",
             "name": "Aether Syphon",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}, {T}: Draw a card.\nMax speed \u2014 Whenever you draw a card, each opponent mills two cards. (Each opponent puts the top two cards of their library into their graveyard.)",
             "colours": [
@@ -1354,7 +1354,7 @@
         },
         {
             "id": "eec8d82b-776d-5f5d-9a96-bfe4cce55516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c8dda-2405-4879-8dd1-e790a833c42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c8dda-2405-4879-8dd1-e790a833c42d.jpg?1",
             "name": "Bounce Off",
             "text": "Return target creature or Vehicle to its owner's hand.",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "d05c7dbd-6f18-5aa2-b4cc-5dbce1302bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8654e38-4230-4094-b815-778bfb5d06f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8654e38-4230-4094-b815-778bfb5d06f2.jpg?1",
             "name": "Caelorna, Coral Tyrant",
             "text": "",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "0a40ba66-92a2-5e5f-97e2-dc11767543bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d4fa6-1fa3-4bfd-a462-47c23ccf9124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d4fa6-1fa3-4bfd-a462-47c23ccf9124.jpg?1",
             "name": "Diversion Unit",
             "text": "Flying\n{U}, Sacrifice this creature: Counter target instant or sorcery spell unless its controller pays {3}.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "0bd790e1-5a03-5f55-b561-31f3fb7b8516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57402f7c-5d4c-4f1e-8bce-a2328a297111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57402f7c-5d4c-4f1e-8bce-a2328a297111.jpg?1",
             "name": "Flood the Engine",
             "text": "Enchant creature or Vehicle\nWhen this Aura enters, tap enchanted permanent.\nEnchanted permanent loses all abilities and doesn't untap during its controller's untap step.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "a8406742-cf37-55fd-98ad-a2d2144148e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dca0007-42d3-4ee2-8e88-361d80a7103c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dca0007-42d3-4ee2-8e88-361d80a7103c.jpg?1",
             "name": "Gearseeker Serpent",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{5}{U}: This creature can't be blocked this turn.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "fa80c148-0142-574e-acb2-a88cd0105200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bb89b9-50dd-4b36-aa10-aba585e50246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bb89b9-50dd-4b36-aa10-aba585e50246.jpg?1",
             "name": "Glitch Ghost Surveyor",
             "text": "Flying\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -1560,7 +1560,7 @@
         },
         {
             "id": "d32140c1-e977-54a6-96a9-9eedc59f5614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fc07dd-05b1-49ed-a3ee-46c31b8e0a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fc07dd-05b1-49ed-a3ee-46c31b8e0a3d.jpg?1",
             "name": "Guidelight Optimizer",
             "text": "{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "71bc9467-8e35-5d5c-8a47-f10cc1333884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbd7758-59c7-4ae1-9af8-c3580f4aa958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbd7758-59c7-4ae1-9af8-c3580f4aa958.jpg?1",
             "name": "Howler's Heavy",
             "text": "Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle this card, target creature or Vehicle an opponent controls gets -3/-0 until end of turn.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "dba0ea70-2d45-5881-a372-beb8d2185d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402666f8-c9cc-4e8f-abaa-6c38be90cdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402666f8-c9cc-4e8f-abaa-6c38be90cdd2.jpg?1",
             "name": "Hulldrifter",
             "text": "Flying\nWhen this Vehicle enters, draw two cards.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -1666,7 +1666,7 @@
         },
         {
             "id": "e5bccfb5-45ed-57cb-bdad-a09c5f4930e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed90a63-5aca-470a-8e1e-518d8aeb6d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed90a63-5aca-470a-8e1e-518d8aeb6d91.jpg?1",
             "name": "Keen Buccaneer",
             "text": "Vigilance\nExhaust \u2014 {1}{U}: Draw a card, then discard a card. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -1701,7 +1701,7 @@
         },
         {
             "id": "2ad38154-bbe1-5fd0-821b-8f31abed0788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199ce2-0ea0-47e5-a36c-36373be53fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199ce2-0ea0-47e5-a36c-36373be53fec.jpg?1",
             "name": "Memory Guardian",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "77fee2dc-125d-5f58-8922-6dc16643bed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237568e3-7331-4bbb-a091-a766723134fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237568e3-7331-4bbb-a091-a766723134fc.jpg?1",
             "name": "Midnight Mangler",
             "text": "During turns other than yours, this Vehicle is an artifact creature.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -1773,7 +1773,7 @@
         },
         {
             "id": "8d351e6c-0ec2-5a54-bef7-c74593426bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control. (Activate each exhaust ability only once.)",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "38d80993-9c70-5d49-a493-31f6b2bb67a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "961b7322-bf7a-5120-9417-c75ee7d06631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47717312-f6c6-4e86-ba6a-a30698962430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47717312-f6c6-4e86-ba6a-a30698962430.jpg?1",
             "name": "Nimble Thopterist",
             "text": "When this creature enters, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "e18ff3d1-e51b-53b2-99f9-92f1b3e52136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -1928,7 +1928,7 @@
         },
         {
             "id": "b690d6a7-9d70-5846-a085-f0bcbabe1673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d2d713-8acb-4e3d-bd1d-0416fe9b9ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d2d713-8acb-4e3d-bd1d-0416fe9b9ef6.jpg?1",
             "name": "Rangers' Refueler",
             "text": "Whenever you activate an exhaust ability, draw a card.\nExhaust \u2014 {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. (Activate each exhaust ability only once.)\nCrew 2",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "20eee566-d709-54d6-b909-ef72dc40869f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg?1",
             "name": "Repurposing Bay",
             "text": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "57be02a5-3be2-5333-add6-1cf35b952e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg?1",
             "name": "Riverchurn Monument",
             "text": "{1}, {T}: Any number of target players each mill two cards. (Each of them puts the top two cards of their library into their graveyard.)\nExhaust \u2014 {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard. (Activate each exhaust ability only once.)",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "96160413-b40d-5aca-8a01-9cd5b7a60322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6153a76-56f7-46ee-bba5-b62c0143388a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6153a76-56f7-46ee-bba5-b62c0143388a.jpg?1",
             "name": "Roadside Blowout",
             "text": "This spell costs {2} less to cast if it targets a permanent with mana value 1.\nReturn target creature or Vehicle an opponent controls to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "2a003ce3-122c-5517-955d-26ff82f318d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bb15e2-e1ad-4645-aab0-df4a1a68563d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bb15e2-e1ad-4645-aab0-df4a1a68563d.jpg?1",
             "name": "Sabotage Strategist",
             "text": "Flying, vigilance\nWhenever one or more creatures attack you, those creatures get -1/-0 until end of turn.\nExhaust \u2014 {5}{U}{U}: Put three +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "f4ff3b77-9882-5792-9c3e-4c15a83bcf25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60bece3-6f63-4d9e-bca0-cef2d38f1472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60bece3-6f63-4d9e-bca0-cef2d38f1472.jpg?1",
             "name": "Scrounging Skyray",
             "text": "Flying\nWhenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "838258e5-d677-58b0-b9c8-bad18c501c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9c501-098d-4560-9826-329b05689e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc9c501-098d-4560-9826-329b05689e0f.jpg?1",
             "name": "Skystreak Engineer",
             "text": "Flying\nExhaust \u2014 {4}{U}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "7bc06d0f-3783-55d4-857d-f3adf98a4253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e86ef50-4939-4e7c-853d-438f0f3e0411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e86ef50-4939-4e7c-853d-438f0f3e0411.jpg?1",
             "name": "Slick Imitator",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {1}, Sacrifice this creature: Copy target spell you control. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "32e94b6f-9296-58d4-94c5-4f8a79ca1124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860cb8af-a5f6-47e7-a34b-7b9f11ddc8c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860cb8af-a5f6-47e7-a34b-7b9f11ddc8c6.jpg?1",
             "name": "Spectral Interference",
             "text": "Counter target artifact or creature spell unless its controller pays {4}.",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "f3c70910-6c9f-57ec-8c2e-9ecf10078dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4374f-0301-4b2e-bc99-2cd19568cb3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4374f-0301-4b2e-bc99-2cd19568cb3b.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "758bcfad-dd54-5ea8-bbe5-be2be8fbc76a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1ece22-ca32-45bb-b5f4-480f9b366cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1ece22-ca32-45bb-b5f4-480f9b366cb5.jpg?1",
             "name": "Spikeshell Harrier",
             "text": "When this creature enters, return target creature or Vehicle an opponent controls to its owner's hand. If that opponent's speed is greater than each other player's speed, reduce that opponent's speed by 1. This effect can't reduce their speed below 1.",
             "colours": [
@@ -2305,7 +2305,7 @@
         },
         {
             "id": "22f1e890-e596-51c2-a699-5834d0f55f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea0e0d3-833f-4353-b648-57b0b657cc1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea0e0d3-833f-4353-b648-57b0b657cc1c.jpg?1",
             "name": "Stall Out",
             "text": "Tap target creature or Vehicle, then put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "f9e54eed-c35e-57fd-b76b-5c662c3cae79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a786855-6eb4-42c0-a528-4842db46809d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a786855-6eb4-42c0-a528-4842db46809d.jpg?1",
             "name": "Stock Up",
             "text": "Look at the top five cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "26a7bb43-08a1-58f4-b5ff-5b3714f1c7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "5241f0d4-844f-55c2-bd32-2203642ba895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0b5c09-6c21-4080-81c4-a8376deb729f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0b5c09-6c21-4080-81c4-a8376deb729f.jpg?1",
             "name": "Trade the Helm",
             "text": "Exchange control of target artifact or creature you control and target artifact or creature an opponent controls.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "bc3fce6f-bd7a-5b14-bcd6-1c83985a80eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6727169f-c33a-4ca5-889d-a63bcfc5a3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6727169f-c33a-4ca5-889d-a63bcfc5a3f0.jpg?1",
             "name": "Transit Mage",
             "text": "When this creature enters, you may search your library for an artifact card with mana value 4 or 5, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "6ab9aaeb-4e71-5fd7-a596-2f9a9973c31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273061f3-7aa7-4cb0-afd6-616252b88948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273061f3-7aa7-4cb0-afd6-616252b88948.jpg?1",
             "name": "Trip Up",
             "text": "Target nonland permanent's owner puts it on their choice of the top or bottom of their library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "9a7b3939-66c3-52bd-87e1-aa6e8eb928dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg?1",
             "name": "Unstoppable Plan",
             "text": "At the beginning of your end step, untap all nonland permanents you control.",
             "colours": [
@@ -2541,7 +2541,7 @@
         },
         {
             "id": "161516ee-035c-539d-8fd3-bd47ebde1d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg?1",
             "name": "Vnwxt, Verbose Host",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nYou have no maximum hand size.\nMax speed \u2014 If you would draw a card, draw two cards instead.",
             "colours": [
@@ -2580,7 +2580,7 @@
         },
         {
             "id": "33ffd84d-be0f-582d-9136-37cd4b22a1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "dec25922-9108-5ded-b1f1-c3e799b4fb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230301f2-f288-4b13-9f62-e649ad8357bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230301f2-f288-4b13-9f62-e649ad8357bb.jpg?1",
             "name": "Ancient Vendetta",
             "text": "Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. Then that player shuffles.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "96385267-f5a5-56c4-8252-2e9ae7e21666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c0032-9c62-4028-a55f-6a3da2545654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c0032-9c62-4028-a55f-6a3da2545654.jpg?1",
             "name": "Back on Track",
             "text": "Return target creature or Vehicle card from your graveyard to the battlefield. Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "5ad3166a-1694-5462-9c92-61c26dd4cfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdceefe6-f083-4955-b53a-8e6f8aeb2083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdceefe6-f083-4955-b53a-8e6f8aeb2083.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "e940f5d9-ffe8-5b34-b665-bc74df157d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fdee-3d24-4360-a4d2-ffd3c08a462d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fdee-3d24-4360-a4d2-ffd3c08a462d.jpg?1",
             "name": "Carrion Cruiser",
             "text": "When this Vehicle enters, mill two cards. Then return a creature or Vehicle card from your graveyard to your hand. (To mill two cards, put the top two cards of your library into your graveyard.)\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "c341e07c-b470-5e9b-93cc-9fa8676cfd6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4141-04a3-44c4-9d3e-aa2a773d9883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4141-04a3-44c4-9d3e-aa2a773d9883.jpg?1",
             "name": "Chitin Gravestalker",
             "text": "This spell costs {1} less to cast for each artifact and/or creature card in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e74608ea-afde-5bf5-a668-b566951d7c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "a26d134b-0d6f-544d-954d-965c090293ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5803b32-4a81-46c2-9b10-3198a709611d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5803b32-4a81-46c2-9b10-3198a709611d.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost. (Exile that card and pay its embalm cost: Create a token that's a copy of it, except it's a white Zombie in addition to its other types and has no mana cost. Embalm only as a sorcery.)",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "b668dc0b-ee57-59af-bf06-3359384b633c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e704fb95-17b7-432a-831c-18abe7d9cc73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e704fb95-17b7-432a-831c-18abe7d9cc73.jpg?1",
             "name": "Deathless Pilot",
             "text": "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\n{3}{B}: Return this card from your graveyard to your hand.",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "c6c5b2d7-3334-510c-943a-ead373f6548a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "1f02ee50-90a0-52d6-8809-7dfb091568fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949d6137-98d3-4f46-ab1e-08d7492af307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949d6137-98d3-4f46-ab1e-08d7492af307.jpg?1",
             "name": "Engine Rat",
             "text": "Deathtouch\n{5}{B}: Each opponent loses 2 life.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "5606158b-fb82-59c1-a05e-5c5f69b57f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -3014,7 +3014,7 @@
         },
         {
             "id": "bf28e57c-bd11-59cd-9bcd-217c480e2499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4877b5-4ce5-466a-810f-6501f2a0f217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4877b5-4ce5-466a-810f-6501f2a0f217.jpg?1",
             "name": "Gastal Raider",
             "text": "Start your engines\nWhen this creature enters, target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.\nMax speed \u2014 This creature gets +1/+1 and has menace.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "6f8a99f7-c4ac-53af-8474-35090312a16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ca40a-e5c0-4956-8df0-ecbd2a25656f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79ca40a-e5c0-4956-8df0-ecbd2a25656f.jpg?1",
             "name": "Gonti, Night Minister",
             "text": "Whenever a player casts a spell they don't own, that player creates a Treasure token.\nWhenever a creature deals combat damage to one of your opponents, its controller looks at the top card of that opponent's library and exiles it face down. They may play that card for as long as it remains exiled. Mana of any type can be spent to cast a spell this way.",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "5a143700-31bd-579e-900a-775b99c28e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdf60a-6f67-4872-8961-d63776b192c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdf60a-6f67-4872-8961-d63776b192c3.jpg?1",
             "name": "Grim Bauble",
             "text": "When this artifact enters, target creature an opponent controls gets -2/-2 until end of turn.\n{2}{B}, {T}, Sacrifice this artifact: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "57f29bdd-4494-5172-8ec7-7f0b7121f16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87154116-e306-4e15-bd5a-dcdb5ddbcd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87154116-e306-4e15-bd5a-dcdb5ddbcd36.jpg?1",
             "name": "Grim Javelineer",
             "text": "Whenever you attack, target attacking creature gets +1/+0 until end of turn. When that creature dies this turn, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "30a99c3d-823c-5e69-8235-e7d587a1ea59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9db650-47f9-46d7-ac17-8d19fef6d6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9db650-47f9-46d7-ac17-8d19fef6d6b0.jpg?1",
             "name": "Hellish Sideswipe",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDestroy target creature or Vehicle. If the sacrificed permanent was a Vehicle, draw a card.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "648e912b-7ddf-5362-b0bb-90160d199458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9192abc8-05a3-4e72-a634-fc5acbe97b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9192abc8-05a3-4e72-a634-fc5acbe97b26.jpg?1",
             "name": "Hour of Victory",
             "text": "Start your engines\nWhen this enchantment enters, create a 2/2 black Zombie creature token.\nMax speed \u2014 {1}{B}, Sacrifice this enchantment: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "3f0934f7-1ec0-50c0-8883-1a5bb1b27bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e6022-44d2-4dfe-8f7a-51581e298f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e6022-44d2-4dfe-8f7a-51581e298f23.jpg?1",
             "name": "Intimidation Tactics",
             "text": "Target opponent reveals their hand. You choose an artifact or creature card from it. Exile that card.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "0a8740a9-040a-5a10-9710-54c1cf338b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1214fc6d-ae47-418d-88cc-58633ec2ac7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1214fc6d-ae47-418d-88cc-58633ec2ac7a.jpg?1",
             "name": "Kalakscion, Hunger Tyrant",
             "text": "",
             "colours": [
@@ -3290,7 +3290,7 @@
         },
         {
             "id": "26218079-9a28-5e9a-b322-80ff84a92a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbb7b4e-bd32-44a0-9396-16738c5e4381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbb7b4e-bd32-44a0-9396-16738c5e4381.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "261c7bf3-b567-5004-935f-638b98755eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b3a547-6f74-4cb4-ad98-7e1b75f1a120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b3a547-6f74-4cb4-ad98-7e1b75f1a120.jpg?1",
             "name": "Locust Spray",
             "text": "Target creature gets -1/-1 until end of turn.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3362,7 +3362,7 @@
         },
         {
             "id": "3c59331b-74e7-5431-97bd-6240d6ab7011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e5bb2-cfe9-48e5-86f9-e21f3d328327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e5bb2-cfe9-48e5-86f9-e21f3d328327.jpg?1",
             "name": "Maximum Overdrive",
             "text": "Put a +1/+1 counter on target creature. It gains deathtouch and indestructible until end of turn.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "7c73bb8e-a38c-5b22-8934-23831ff6e479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38513b53-384f-45e7-9905-80dd2c3c4918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38513b53-384f-45e7-9905-80dd2c3c4918.jpg?1",
             "name": "Momentum Breaker",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, each opponent sacrifices a creature or Vehicle of their choice. Each opponent who can't discards a card.\n{2}, Sacrifice this enchantment: You gain life equal to your speed.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "2228a495-e14e-51ea-aeab-4bac8aec60a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cec5105-3907-40d2-8e46-95acfaaaa0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cec5105-3907-40d2-8e46-95acfaaaa0cc.jpg?1",
             "name": "Mutant Surveyor",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}: This creature gets +1/+1 until end of turn.\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "7a916339-5e81-5c09-902b-5b2bc7d14e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70226354-47b7-4f9d-a5a8-559d17f07720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70226354-47b7-4f9d-a5a8-559d17f07720.jpg?1",
             "name": "Pactdoll Terror",
             "text": "Whenever this creature or another artifact you control enters, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3496,7 +3496,7 @@
         },
         {
             "id": "f9aca8ad-deb4-592d-87e3-68bfdfb4d21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8b6033-63e6-484e-8efb-a4eb9ca59fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8b6033-63e6-484e-8efb-a4eb9ca59fbf.jpg?1",
             "name": "Quag Feast",
             "text": "Choose target creature, planeswalker, or Vehicle. Mill two cards, then destroy the chosen permanent if its mana value is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "552071c2-998f-5d74-bc05-145e125a6ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4981a4a-6eca-4f84-8715-8e2672507b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4981a4a-6eca-4f84-8715-8e2672507b59.jpg?1",
             "name": "Ripclaw Wrangler",
             "text": "When this Vehicle enters, each opponent discards a card.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "1a4bb799-99f1-570d-8ddf-b726240ef663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a68482a-401d-48e7-854e-46e3db07ff35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a68482a-401d-48e7-854e-46e3db07ff35.jpg?1",
             "name": "Risen Necroregent",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 At the beginning of your end step, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "30fd615c-f6c0-56ce-bb7f-3484dbe15a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80aa587-4445-43d7-abc0-654d94ff4cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80aa587-4445-43d7-abc0-654d94ff4cda.jpg?1",
             "name": "Risky Shortcut",
             "text": "Draw two cards. Each player loses 2 life.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "e40b50fd-b83b-5cd3-b57a-d53bfb9bb16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079dc8d2-0de3-415e-8af8-b8dec669368a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079dc8d2-0de3-415e-8af8-b8dec669368a.jpg?1",
             "name": "Shefet Archfiend",
             "text": "Flying\nWhen this creature enters, all other creatures get -2/-2 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "7091907f-c236-50a7-bf59-413cbf40464e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -3709,7 +3709,7 @@
         },
         {
             "id": "0a98382c-17fe-56ad-8ab7-eafe2f5923c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be722ac5-e8c4-4180-aed0-7c28895afc0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be722ac5-e8c4-4180-aed0-7c28895afc0d.jpg?1",
             "name": "Spin Out",
             "text": "Destroy target creature or Vehicle.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "c9eb5fae-ed38-5cdc-8d81-928a7b982a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff120a2-e2bb-42a2-bcb7-a48eb7a6d9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff120a2-e2bb-42a2-bcb7-a48eb7a6d9b2.jpg?1",
             "name": "Streaking Oilgorger",
             "text": "Flying, haste\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 This creature has lifelink.",
             "colours": [
@@ -3775,7 +3775,7 @@
         },
         {
             "id": "eb4ffc0e-b40b-5fe0-b921-e89b216c9ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af17ae0-1035-4cb2-8974-98b377bfaa48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af17ae0-1035-4cb2-8974-98b377bfaa48.jpg?1",
             "name": "Syphon Fuel",
             "text": "Target creature gets -6/-6 until end of turn. You gain 2 life.",
             "colours": [
@@ -3807,7 +3807,7 @@
         },
         {
             "id": "6ff56e65-f50a-528a-bc0c-bc0c395d142a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba78e076-8962-4b3f-b86f-04400b062951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba78e076-8962-4b3f-b86f-04400b062951.jpg?1",
             "name": "Wickerfolk Indomitable",
             "text": "You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "8ca67537-927a-51d7-8639-d9f3759b4ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeff3db7-81ac-4c51-9954-bc1dbcb8c4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeff3db7-81ac-4c51-9954-bc1dbcb8c4e3.jpg?1",
             "name": "Wreckage Wickerfolk",
             "text": "Flying\nWhen this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "c6ac77c7-a26e-503b-8934-d85f564b7ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4983177d-fbf4-47fa-997f-9d08294870f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4983177d-fbf4-47fa-997f-9d08294870f2.jpg?1",
             "name": "Wretched Doll",
             "text": "{B}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "80558364-dbb1-5ddd-b933-52746710430c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8655373-320d-440d-b700-d03413f743fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8655373-320d-440d-b700-d03413f743fd.jpg?1",
             "name": "Adrenaline Jockey",
             "text": "Whenever a player casts a spell, if it's not their turn, this creature deals 4 damage to them.\nWhenever you activate an exhaust ability, put a +1/+1 counter on this creature.",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "f2b96ac0-a174-5bed-b463-3bfc74f6abd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle. (Activate each exhaust ability only once.)\nCrew 2",
             "colours": [
@@ -3985,7 +3985,7 @@
         },
         {
             "id": "6f5ee150-c62f-5938-8f92-ed81a8007d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecee6509-1103-4ae5-a2e7-0441f5d4a872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecee6509-1103-4ae5-a2e7-0441f5d4a872.jpg?1",
             "name": "Burner Rocket",
             "text": "Flash\nWhen this Vehicle enters, target creature you control gets +2/+0 and gains trample until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "804338dc-15f0-546a-b673-5e05b721a8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db66e7b-cb7a-4d86-a563-d570946aeb0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db66e7b-cb7a-4d86-a563-d570946aeb0d.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "12f091b0-4f2d-5717-830f-e878bbbb1c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n\u22127: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "bc9ef912-e7fc-5e25-b409-2a16b3c9cd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4701da52-b9c8-4ce9-9d57-53e10899f19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4701da52-b9c8-4ce9-9d57-53e10899f19d.jpg?1",
             "name": "Clamorous Ironclad",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "1e8e0d38-5a88-5103-aab9-6cadbe3b2826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f31beae-9b8f-4c32-af84-9f3ee767ba1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f31beae-9b8f-4c32-af84-9f3ee767ba1d.jpg?1",
             "name": "Count on Luck",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "e5d3ef64-0069-5fd3-a63d-0225791b4270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a41a1-b36f-4b81-b74c-220d279c0e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a41a1-b36f-4b81-b74c-220d279c0e26.jpg?1",
             "name": "Crash and Burn",
             "text": "Choose one \u2014\n\u2022 Destroy target Vehicle.\n\u2022 Crash and Burn deals 6 damage to target creature or planeswalker.",
             "colours": [
@@ -4203,7 +4203,7 @@
         },
         {
             "id": "a944eade-8ed0-5451-85c5-bd40ea2e54ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg?1",
             "name": "Daretti, Rocketeer Engineer",
             "text": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "651f6dee-6355-51f4-ba96-a9af3fc62326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44440be-e611-4e70-9919-b08e2354b7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44440be-e611-4e70-9919-b08e2354b7ad.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "4db9fea1-b7ff-5d76-a662-fbf55497b421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf800b8c-d08e-4644-8ed2-11b839153861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf800b8c-d08e-4644-8ed2-11b839153861.jpg?1",
             "name": "Dracosaur Auxiliary",
             "text": "Flying, haste\nWhenever this creature attacks while saddled, it deals 2 damage to any target.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4318,7 +4318,7 @@
         },
         {
             "id": "81521594-ae43-54fb-bc34-74dbf1f9aad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4f96f6-dd91-4357-ae19-1c35db2c2bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4f96f6-dd91-4357-ae19-1c35db2c2bcb.jpg?1",
             "name": "Dynamite Diver",
             "text": "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\nWhen this creature dies, it deals 1 damage to any target.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "c81d00ef-bf54-5d1c-9cbd-865114f618db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5a67b-d969-4ba4-9dcc-32d0c2e5c04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5a67b-d969-4ba4-9dcc-32d0c2e5c04a.jpg?1",
             "name": "Endrider Catalyzer",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {T}: Add {R}{R}.",
             "colours": [
@@ -4388,7 +4388,7 @@
         },
         {
             "id": "dcca8315-c40b-570b-8987-4a7209877326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e58cb18-f216-4248-8f0d-65b0263c5c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e58cb18-f216-4248-8f0d-65b0263c5c28.jpg?1",
             "name": "Endrider Spikespitter",
             "text": "Reach\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "5c0cf323-8c64-53b2-bb49-707cb6defde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624335fb-8a0b-4fa9-aefb-60ac641a7934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624335fb-8a0b-4fa9-aefb-60ac641a7934.jpg?1",
             "name": "Fuel the Flames",
             "text": "Fuel the Flames deals 2 damage to each creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "a32adc12-99e2-5d1c-bcbf-2ba53f020836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg?1",
             "name": "Full Throttle",
             "text": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
             "colours": [
@@ -4490,7 +4490,7 @@
         },
         {
             "id": "e9a246fc-9afd-547f-806f-11f83485cde2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca41ec6-8f8f-42ef-abac-cc645c6440b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca41ec6-8f8f-42ef-abac-cc645c6440b7.jpg?1",
             "name": "Gastal Blockbuster",
             "text": "When this creature enters, you may sacrifice a creature or Vehicle. When you do, destroy target artifact an opponent controls.",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "c4e88a27-1752-599c-9ca5-cda0770869c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "c08179a3-710c-5dd6-8c58-b4a2f2e822b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55685602-a18c-43a4-ac60-13b039672fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55685602-a18c-43a4-ac60-13b039672fa4.jpg?1",
             "name": "Gilded Ghoda",
             "text": "Whenever this creature attacks while saddled, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "752f10d6-6f5d-5552-9134-328cdf92c6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efffe9-00f8-4177-a9e6-4ad62887d32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efffe9-00f8-4177-a9e6-4ad62887d32f.jpg?1",
             "name": "Goblin Surveyor",
             "text": "Trample\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "94ba0acd-9598-5224-a512-141e0338d6db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f0b123-fdb0-4f3e-ba78-fa155c227e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f0b123-fdb0-4f3e-ba78-fa155c227e20.jpg?1",
             "name": "Greasewrench Goblin",
             "text": "Exhaust \u2014 {2}{R}: Discard up to two cards, then draw that many cards. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "28f1d519-6f5d-5023-8964-aed9b62bb816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "30e96ef9-6a7f-5f17-9ea7-85e39da2013c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "18fd6e55-3111-51de-ad08-52ee2e0ffe02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5590e1-0ac0-4bdd-815b-136bf24ced03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5590e1-0ac0-4bdd-815b-136bf24ced03.jpg?1",
             "name": "Kickoff Celebrations",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, you may discard a card. If you do, draw two cards.\nMax speed \u2014 Sacrifice this enchantment: Creatures and Vehicles you control gain haste until end of turn.",
             "colours": [
@@ -4779,7 +4779,7 @@
         },
         {
             "id": "9286c27c-19d7-5fdf-a97e-ff4e325a47df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30077b49-b825-4dbb-a0c7-f3992f647df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30077b49-b825-4dbb-a0c7-f3992f647df0.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "48e6b39b-92f6-565d-bafe-a2377cdcfffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac26341-a100-424d-be84-33fbbf1b4078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac26341-a100-424d-be84-33fbbf1b4078.jpg?1",
             "name": "Magmakin Artillerist",
             "text": "Whenever you discard one or more cards, this creature deals that much damage to each opponent.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle this card, it deals 1 damage to each opponent.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "3e8b2550-5520-5f87-a362-5ae234090def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efbfd67-e0f5-43e0-9fff-1eb4a2bed0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efbfd67-e0f5-43e0-9fff-1eb4a2bed0d8.jpg?1",
             "name": "Marauding Mako",
             "text": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "b0e272c3-4d61-596f-a5fe-a873bf76fafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e415f-636f-4394-9b21-600ab720ac98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e415f-636f-4394-9b21-600ab720ac98.jpg?1",
             "name": "Outpace Oblivion",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, it deals 5 damage to up to one target creature or planeswalker.\n{2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "2245f6dd-7fe3-5adf-afad-7d0c63e2a64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364b4dc-8cce-498d-a62e-eabc612b062a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364b4dc-8cce-498d-a62e-eabc612b062a.jpg?1",
             "name": "Pacesetter Paragon",
             "text": "Exhaust \u2014 {2}{R}: Put a +1/+1 counter on this creature. It gains double strike until end of turn. (Activate each exhaust ability only once.)",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "64e99559-f3db-5070-82e7-cdfb6088a3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d07295-78b7-4f90-82c7-e7a639db9993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d07295-78b7-4f90-82c7-e7a639db9993.jpg?1",
             "name": "Pedal to the Metal",
             "text": "Target creature gets +X/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "2961a452-e159-5e46-8d50-c0dbb7f1a5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affbc8db-4ff7-4a86-954a-910493e5a2ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affbc8db-4ff7-4a86-954a-910493e5a2ef.jpg?1",
             "name": "Prowcatcher Specialist",
             "text": "Haste\nExhaust \u2014 {3}{R}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "fdc33587-b433-5548-87ee-75ef14811191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de84a2-2654-4e1a-a569-bf385bb43685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de84a2-2654-4e1a-a569-bf385bb43685.jpg?1",
             "name": "Push the Limit",
             "text": "Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at the beginning of the next end step.\nVehicles you control become artifact creatures until end of turn. Creatures you control gain haste until end of turn.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "158740af-c84b-57ac-8d27-9b5ff922d4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edd18be-3861-4510-ba6d-38ccba60bb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edd18be-3861-4510-ba6d-38ccba60bb5b.jpg?1",
             "name": "Reckless Velocitaur",
             "text": "Whenever this creature saddles a Mount or crews a Vehicle during your main phase, that Mount or Vehicle gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -5084,7 +5084,7 @@
         },
         {
             "id": "2fb8b609-1110-57f9-acd5-d1688ad3b2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca022de-0c7b-48ea-b3b5-af28987a5070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca022de-0c7b-48ea-b3b5-af28987a5070.jpg?1",
             "name": "Road Rage",
             "text": "Road Rage deals X damage to target creature or planeswalker, where X is 2 plus the number of Mounts and Vehicles you control.",
             "colours": [
@@ -5116,7 +5116,7 @@
         },
         {
             "id": "041166f6-7c28-5a78-9144-161764b23abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e82be6-d2b4-4c95-8466-477e8c6832e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e82be6-d2b4-4c95-8466-477e8c6832e9.jpg?1",
             "name": "Skycrash",
             "text": "Destroy target artifact.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -5148,7 +5148,7 @@
         },
         {
             "id": "c234dcbe-4605-54cd-8c76-fb816b4c160b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f483debe-9c54-4323-aec5-226587ece2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f483debe-9c54-4323-aec5-226587ece2c9.jpg?1",
             "name": "Spire Mechcycle",
             "text": "Haste\nExhaust \u2014 Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle. (Activate each exhaust ability only once.)\nCrew 2",
             "colours": [
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "a467834b-92fd-5313-b5ae-dfd75669cb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef537868-b2cb-4bbd-a935-b7f73f19bd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef537868-b2cb-4bbd-a935-b7f73f19bd06.jpg?1",
             "name": "Thunderhead Gunner",
             "text": "Reach\nDiscard a card: Draw a card. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "73ee487f-2979-5a2e-b302-a6f6aea4b30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159dc5a8-5cba-4c20-8c07-28a3d86c8411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159dc5a8-5cba-4c20-8c07-28a3d86c8411.jpg?1",
             "name": "Tyrox, Saurid Tyrant",
             "text": "",
             "colours": [
@@ -5256,7 +5256,7 @@
         },
         {
             "id": "b65bdac2-8b3a-548c-9fce-a444c6b843b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg?1",
             "name": "Afterburner Expert",
             "text": "Exhaust \u2014 {2}{G}{G}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "19227e47-9e31-5d87-9daf-3791136a07ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -5332,7 +5332,7 @@
         },
         {
             "id": "4fd9b256-cc61-541b-b117-41a58ce5e09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd40bca-aa54-4e52-8d48-b3709a11e633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd40bca-aa54-4e52-8d48-b3709a11e633.jpg?1",
             "name": "Alacrian Jaguar",
             "text": "Vigilance\nWhenever this creature attacks while saddled, it gets +2/+2 until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "eb8225e9-5a84-571f-9b0a-57e3dbf5d6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d313ea7-2456-48f3-8b12-97d8e8c2a5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d313ea7-2456-48f3-8b12-97d8e8c2a5b3.jpg?1",
             "name": "Autarch Mammoth",
             "text": "When this creature enters and whenever it attacks while saddled, create a 3/3 green Elephant creature token.\nSaddle 5 (Tap any number of other creatures you control with total power 5 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "299ca8b5-2240-5085-be98-66a80b0b937a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b99a61-49f1-46a2-9eb7-b6c88c236215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b99a61-49f1-46a2-9eb7-b6c88c236215.jpg?1",
             "name": "Beastrider Vanguard",
             "text": "{4}{G}: Look at the top three cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "db54cfbc-3da6-53d9-8303-156dba802113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a5adee-3482-4c5b-9260-58efa8fec5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a5adee-3482-4c5b-9260-58efa8fec5ba.jpg?1",
             "name": "Bestow Greatness",
             "text": "Target creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "8d6d43eb-0742-59c5-8ff5-8a54872cd408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7d5b71-7c1b-4fc2-a5ec-7285e17ffe0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7d5b71-7c1b-4fc2-a5ec-7285e17ffe0f.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -5501,7 +5501,7 @@
         },
         {
             "id": "28e53dc5-30d6-54c4-82b2-32aa0d8b0322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ed23a2-6153-47b2-ab73-062195cafb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ed23a2-6153-47b2-ab73-062195cafb74.jpg?1",
             "name": "Defend the Rider",
             "text": "Choose one \u2014\n\u2022 Target permanent you control gains hexproof and indestructible until end of turn.\n\u2022 Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "5a301449-9468-59b8-bca9-0a31f3801524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3171b16f-cd67-416d-be5e-5d9cccb8d0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3171b16f-cd67-416d-be5e-5d9cccb8d0a0.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "ba87925c-6802-5a8b-a224-565046b22e11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148400a0-7819-4551-9815-9357eed1db4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148400a0-7819-4551-9815-9357eed1db4d.jpg?1",
             "name": "Dredger's Insight",
             "text": "Whenever one or more artifact and/or creature cards leave your graveyard, you gain 1 life.\nWhen this enchantment enters, mill four cards. You may put an artifact, creature, or land card from among the milled cards into your hand. (To mill four cards, put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "ea8ee3e2-48cc-5105-96b7-33869a03f898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee386cd0-934a-4b33-9db3-0a9033ab577e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee386cd0-934a-4b33-9db3-0a9033ab577e.jpg?1",
             "name": "Earthrumbler",
             "text": "Vigilance, trample\nExile an artifact or creature card from your graveyard: This Vehicle becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "93cd15f7-72f5-5e7a-8e55-f431a9e45150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25dfbcb6-9b67-4151-b10f-dde70c5fd16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25dfbcb6-9b67-4151-b10f-dde70c5fd16d.jpg?1",
             "name": "Elvish Refueler",
             "text": "During your turn, as long as you haven't activated an exhaust ability this turn, you may activate exhaust abilities as though they haven't been activated.\nExhaust \u2014 {1}{G}: Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "821561cc-cbec-5376-9b76-86d0595503fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db483a7-c9f0-449d-be97-77dbd6d3a27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db483a7-c9f0-449d-be97-77dbd6d3a27a.jpg?1",
             "name": "Fang Guardian",
             "text": "Flash\nWhen this creature enters, another target creature or Vehicle you control gets +2/+2 until end of turn.",
             "colours": [
@@ -5710,7 +5710,7 @@
         },
         {
             "id": "f6704480-5cda-548d-a810-acda844075c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496442f6-48c7-464e-bcf3-4c14f49fa065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496442f6-48c7-464e-bcf3-4c14f49fa065.jpg?1",
             "name": "Fang-Druid Summoner",
             "text": "Reach\nWhen this creature enters, you may search your library and/or graveyard for a creature card with no abilities, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "b34c09aa-21b4-5504-9cfe-be5bd0204665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0000-5fd3-483b-bac5-f9b888d8755b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b0000-5fd3-483b-bac5-f9b888d8755b.jpg?1",
             "name": "Greenbelt Guardian",
             "text": "{G}: Target creature gains trample until end of turn.\nExhaust \u2014 {3}{G}: Put three +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "3ed184af-1051-5cd9-8dbb-5f6ec5f724ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fbee7a-7e73-43cf-bc39-ccb1c63bf837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3fbee7a-7e73-43cf-bc39-ccb1c63bf837.jpg?1",
             "name": "Hazard of the Dunes",
             "text": "Trample, reach\nExhaust \u2014 {6}{G}: Put three +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "aaea7beb-b0a4-5993-91ed-9365a28fdb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a0569b-65c8-49ce-91ac-e639b8faf939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a0569b-65c8-49ce-91ac-e639b8faf939.jpg?1",
             "name": "Jibbirik Omnivore",
             "text": "",
             "colours": [
@@ -5848,7 +5848,7 @@
         },
         {
             "id": "da6baaca-a7c2-51f8-9636-2c0cd1a2ca48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1cecb1-6776-4495-be56-b7dde65453f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1cecb1-6776-4495-be56-b7dde65453f1.jpg?1",
             "name": "Loxodon Surveyor",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 {3}, Exile this card from your graveyard: Draw a card.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "389934f6-0c3b-511a-ac72-f86c6c4752e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -5922,7 +5922,7 @@
         },
         {
             "id": "646a0817-0a5e-57ab-832e-5a594bd78ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "75f917eb-1ccd-59d7-8261-4f1aa6095164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba2219-8184-4141-8708-845cb0957299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba2219-8184-4141-8708-845cb0957299.jpg?1",
             "name": "Migrating Ketradon",
             "text": "Reach\nWhen this creature enters, you gain 4 life.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5993,7 +5993,7 @@
         },
         {
             "id": "0dec66af-3578-5d74-8ff1-804cf56d750a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f800bf4e-4bfb-45b6-950b-c76952f52bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f800bf4e-4bfb-45b6-950b-c76952f52bb1.jpg?1",
             "name": "Molt Tender",
             "text": "{T}: Mill a card. (Put the top card of your library into your graveyard.)\n{T}, Exile a card from your graveyard: Add one mana of any color.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "2052eff1-f8ab-514b-9dbe-03885fefe87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101d22c6-830d-4908-9003-6b206f694eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101d22c6-830d-4908-9003-6b206f694eba.jpg?1",
             "name": "Ooze Patrol",
             "text": "When this creature enters, mill two cards, then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard. (To mill two cards, put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -6062,7 +6062,7 @@
         },
         {
             "id": "8e0841ca-9fae-559e-bcd4-937568c3d34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg?1",
             "name": "Oviya, Automech Artisan",
             "text": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "0a9b1498-d888-5a57-874a-b946986691c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a311d4b3-ab2a-43c2-8480-6c5daac41178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a311d4b3-ab2a-43c2-8480-6c5daac41178.jpg?1",
             "name": "Plow Through",
             "text": "Choose one \u2014\n\u2022 Target creature you control fights target creature an opponent controls. (Each deals damage equal to its power to the other.)\n\u2022 Destroy target Vehicle.",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "65ae3393-4b5e-5ec9-9105-4dd2d9835c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd4c73d-0e9a-4ffe-8062-f2f4d0e601fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd4c73d-0e9a-4ffe-8062-f2f4d0e601fe.jpg?1",
             "name": "Point the Way",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{3}{G}, Sacrifice this enchantment: Search your library for up to X basic land cards, where X is your speed. Put those cards onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "b71819a2-cd8b-56f5-bbae-04e1a970655c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7b59f-fdae-4a11-9784-497a8165d75a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7b59f-fdae-4a11-9784-497a8165d75a.jpg?1",
             "name": "Pothole Mole",
             "text": "When this creature enters, mill three cards, then you may return a land card from your graveyard to your hand. (To mill three cards, put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -6200,7 +6200,7 @@
         },
         {
             "id": "1bed67ca-7a59-512d-894d-4c8d5e1eb420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f569cc-ed09-4c27-b753-18b22ad7f425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f569cc-ed09-4c27-b753-18b22ad7f425.jpg?1",
             "name": "Regal Imperiosaur",
             "text": "Other Dinosaurs you control get +1/+1.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "3652e425-23b8-52aa-b7d5-d9732da54c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6ac32-a7a4-4c15-81b0-8485d6a0e7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6ac32-a7a4-4c15-81b0-8485d6a0e7ca.jpg?1",
             "name": "Rise from the Wreck",
             "text": "Return up to one target creature card, up to one target Mount card, up to one target Vehicle card, and up to one target creature card with no abilities from your graveyard to your hand.",
             "colours": [
@@ -6269,7 +6269,7 @@
         },
         {
             "id": "333b5768-bbf7-5701-b86d-e5766fc696de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642f8fdd-6c58-49a3-904c-27f717cae980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642f8fdd-6c58-49a3-904c-27f717cae980.jpg?1",
             "name": "Run Over",
             "text": "This spell costs {1} less to cast if it targets a Mount or Vehicle you control.\nTarget creature you control deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "6ddd6868-7a83-51e7-adba-1c7b5ad98794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e1ded-9b00-4d7b-884c-70a429783b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e1ded-9b00-4d7b-884c-70a429783b1f.jpg?1",
             "name": "Silken Strength",
             "text": "Flash\nEnchant creature or Vehicle\nWhen this Aura enters, untap enchanted permanent.\nEnchanted permanent gets +1/+2 and has reach.",
             "colours": [
@@ -6335,7 +6335,7 @@
         },
         {
             "id": "1c10be07-bff5-5009-b9dd-e57cf3795ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc713d7-4a7e-4f1f-b461-e89bb1457d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc713d7-4a7e-4f1f-b461-e89bb1457d7d.jpg?1",
             "name": "Stampeding Scurryfoot",
             "text": "Exhaust \u2014 {3}{G}: Put a +1/+1 counter on this creature. Create a 3/3 green Elephant creature token. (Activate each exhaust ability only once.)",
             "colours": [
@@ -6369,7 +6369,7 @@
         },
         {
             "id": "1b64c115-096b-5532-9112-ef0e3d8c1c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44255cf-5264-4ead-9de0-20cc0f7cac6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44255cf-5264-4ead-9de0-20cc0f7cac6f.jpg?1",
             "name": "Terrian, World Tyrant",
             "text": "",
             "colours": [
@@ -6406,7 +6406,7 @@
         },
         {
             "id": "80337f0d-630d-568d-a133-fbdbb3aa3ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "fb942058-367c-5338-a83a-62498d23e931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edde1a-f05c-4ce8-bedd-88359647aa0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edde1a-f05c-4ce8-bedd-88359647aa0d.jpg?1",
             "name": "Veloheart Bike",
             "text": "When this Vehicle enters, you gain 2 life.\n{T}: Add one mana of any color.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6480,7 +6480,7 @@
         },
         {
             "id": "892e9f61-e987-5f8e-9074-73c9c9aafd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9142b1c9-09d7-42e4-8138-6c15d31f2470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9142b1c9-09d7-42e4-8138-6c15d31f2470.jpg?1",
             "name": "Venomsac Lagac",
             "text": "Deathtouch\nWhenever this creature attacks while saddled, it gets +0/+3 until end of turn.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "06bad981-0634-596c-bcc2-644586843f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G} ({X}{G}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "7b00c266-61f7-5222-9251-6a2e1a7bb5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdaa29b-85ff-4a06-b27e-fcdbdfd4a3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdaa29b-85ff-4a06-b27e-fcdbdfd4a3fe.jpg?1",
             "name": "Aatchik, Emerald Radian",
             "text": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
             "colours": [
@@ -6596,7 +6596,7 @@
         },
         {
             "id": "ec28eb66-52ad-5d55-bc62-0e9dd5f64fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971286f5-77ea-4824-91de-f0ac88c46238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971286f5-77ea-4824-91de-f0ac88c46238.jpg?1",
             "name": "Apocalypse Runner",
             "text": "{T}: Target creature you control with power 2 or less gains lifelink until end of turn and can't be blocked this turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6634,7 +6634,7 @@
         },
         {
             "id": "375b8517-d702-5fab-9305-8ce4cfbb3424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b84684-10c9-4635-a922-620f04809bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b84684-10c9-4635-a922-620f04809bb1.jpg?1",
             "name": "Boom Scholar",
             "text": "Exhaust abilities of other permanents you control cost {2} less to activate.\nExhaust \u2014 {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "14443392-0bee-5af6-a378-16b0d3363988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563cb48-9dcb-4b92-af3a-4793adf03125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563cb48-9dcb-4b92-af3a-4793adf03125.jpg?1",
             "name": "Boosted Sloop",
             "text": "Menace\nWhenever you attack, draw a card, then discard a card.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6709,7 +6709,7 @@
         },
         {
             "id": "7aabc830-06cc-5b41-8a4d-a73e1f9bb0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dea5b45-925c-4732-8e9d-fa8232792736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dea5b45-925c-4732-8e9d-fa8232792736.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -6750,7 +6750,7 @@
         },
         {
             "id": "f20ebf95-0356-508b-b731-57950cb1239d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d086e4e5-98fa-437e-85aa-d8849c94ce94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d086e4e5-98fa-437e-85aa-d8849c94ce94.jpg?1",
             "name": "Broadside Barrage",
             "text": "Broadside Barrage deals 5 damage to target creature or planeswalker. Draw a card, then discard a card.",
             "colours": [
@@ -6784,7 +6784,7 @@
         },
         {
             "id": "1d0d7d4b-e419-52c5-9153-06fdb15deea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed09139b-a66e-4cd1-b45a-23a4648d3401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed09139b-a66e-4cd1-b45a-23a4648d3401.jpg?1",
             "name": "Broodheart Engine",
             "text": "At the beginning of your upkeep, surveil 1.\n{2}{B}{G}, {T}, Sacrifice this artifact: Return target creature or Vehicle card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "4c5afef1-764b-5ded-8b40-5e68a588a890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957c90f-e10d-40f8-a4be-9e9ef623dd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0957c90f-e10d-40f8-a4be-9e9ef623dd43.jpg?1",
             "name": "Captain Howler, Sea Scourge",
             "text": "Ward\u2014{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "74066a51-c520-54aa-bf45-099ad6e7f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1256d22d-a2a9-41fb-b669-0661ba230bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1256d22d-a2a9-41fb-b669-0661ba230bc7.jpg?1",
             "name": "Caradora, Heart of Alacria",
             "text": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "a4a69363-5e9a-5a38-b3a6-6220dc0546c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef16cda-9150-4e7d-8490-d9f287b81b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef16cda-9150-4e7d-8490-d9f287b81b62.jpg?1",
             "name": "Cloudspire Coordinator",
             "text": "When this creature enters, scry 2.\n{T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts and/or Vehicles that entered the battlefield under your control this turn. The tokens have \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -6939,7 +6939,7 @@
         },
         {
             "id": "c0f9723f-6ce7-5dc7-b45d-c97273ff6deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f01a4-a923-4d56-bacb-984a389296fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f01a4-a923-4d56-bacb-984a389296fa.jpg?1",
             "name": "Cloudspire Skycycle",
             "text": "Flying\nWhen this Vehicle enters, distribute two +1/+1 counters among one or two other target Vehicles and/or creatures you control.\nCrew 1",
             "colours": [
@@ -6977,7 +6977,7 @@
         },
         {
             "id": "aca454af-970c-554f-a92c-eb472d9ba047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73431628-b9b0-41e6-8e9b-8a090939b0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73431628-b9b0-41e6-8e9b-8a090939b0c1.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "c8142d70-6307-59ec-a2bf-85595f3d7a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405e7900-f6df-4033-b70b-b1d2a8b6d7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405e7900-f6df-4033-b70b-b1d2a8b6d7c8.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "c110d2ea-524d-50cf-897d-c62e96a1e218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36185de4-55c2-4e5d-9bcc-ea12b7052728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36185de4-55c2-4e5d-9bcc-ea12b7052728.jpg?1",
             "name": "Dune Drifter",
             "text": "When this Vehicle enters, return target artifact or creature card with mana value X or less from your graveyard to the battlefield.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "eaeb0d00-5334-5dbb-aa44-2e27e7bfdb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf181ae-daa7-42f9-b667-5e679d80cf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf181ae-daa7-42f9-b667-5e679d80cf34.jpg?1",
             "name": "Embalmed Ascendant",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature enters, create a 2/2 black Zombie creature token.\nMax speed \u2014 Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "fe452cd5-75f4-5f10-b1f2-b3bc9c0ec289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a876edac-b8c8-4994-94f5-548e0fe70fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a876edac-b8c8-4994-94f5-548e0fe70fe4.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -7171,7 +7171,7 @@
         },
         {
             "id": "e20b85e5-5ab1-57f5-93c3-fbc62eb814e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f523e96d-9df1-4854-accb-9876aef787e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f523e96d-9df1-4854-accb-9876aef787e5.jpg?1",
             "name": "Far Fortune, End Boss",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed \u2014 If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -7213,7 +7213,7 @@
         },
         {
             "id": "a1fcb189-3b9a-5c4a-970d-c4f41982d562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d86d66b-481f-44ec-86d8-6fc91b52ef38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d86d66b-481f-44ec-86d8-6fc91b52ef38.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "fda38227-6be9-53df-b1a1-f0b941f8ae1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e5205d-d734-4292-a3c8-70cf5f131289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e5205d-d734-4292-a3c8-70cf5f131289.jpg?1",
             "name": "Gastal Thrillseeker",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature enters, it deals 1 damage to target opponent and you gain 1 life.\nMax speed \u2014 This creature has deathtouch and haste.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "9c12bccd-99d5-504d-8800-e0084e3efb58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e00cd7-925e-4bab-b064-c96aa2935f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e00cd7-925e-4bab-b064-c96aa2935f8c.jpg?1",
             "name": "Guidelight Pathmaker",
             "text": "Vigilance\nWhen this Vehicle enters, you may search your library for an artifact card and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. Then shuffle.\nCrew 2",
             "colours": [
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "381a1b61-890e-58f5-8747-a3a04cf6f530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478d236c-9778-435a-ac21-bd0017a17d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478d236c-9778-435a-ac21-bd0017a17d5b.jpg?1",
             "name": "Haunt the Network",
             "text": "Choose target opponent. Create two 1/1 colorless Thopter artifact creature tokens with flying. Then the chosen player loses X life and you gain X life, where X is the number of artifacts you control.",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "2e032a05-a9e8-52b0-8627-16e94b96e30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ce0d37-d5d7-49dd-885e-9998bb8abede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ce0d37-d5d7-49dd-885e-9998bb8abede.jpg?1",
             "name": "Haunted Hellride",
             "text": "Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of turn. Untap it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "0bd1bb94-7b76-5ae8-a47e-17e754f4d37f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffae8d0-7b4e-42ed-8124-24a86b38f490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffae8d0-7b4e-42ed-8124-24a86b38f490.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "219d8ecc-12aa-5357-ba67-e33d5a604b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd476-a236-4434-b191-5c8b6fa7be7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd476-a236-4434-b191-5c8b6fa7be7b.jpg?1",
             "name": "Kolodin, Triumph Caster",
             "text": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
             "colours": [
@@ -7485,7 +7485,7 @@
         },
         {
             "id": "e2142849-652f-5edc-a720-21b126142328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b04e3f4-103b-4845-b3f0-5417971c7666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b04e3f4-103b-4845-b3f0-5417971c7666.jpg?1",
             "name": "Lagorin, Soul of Alacria",
             "text": "Flying\nWhenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two target Mounts and/or Vehicles.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "47ea0a8d-a316-5cbd-9a43-05aa3e9e4bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c59c04-4c0b-4a60-826e-3a7757d0b2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c59c04-4c0b-4a60-826e-3a7757d0b2a2.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color. (Activate each exhaust ability only once.)\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "49ff9665-07de-5a69-a4ca-32500d5ce204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f434b103-490f-424e-a0a1-efb1b931c8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f434b103-490f-424e-a0a1-efb1b931c8e6.jpg?1",
             "name": "Mendicant Core, Guidelight",
             "text": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 Whenever you cast an artifact spell, you may pay {1}. If you do, copy it. (The copy becomes a token.)",
             "colours": [
@@ -7612,7 +7612,7 @@
         },
         {
             "id": "296fae2e-7721-5b38-9691-ab816585f9e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e4c342-dc22-4e9c-81fc-a691ae9e21c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e4c342-dc22-4e9c-81fc-a691ae9e21c1.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -7657,7 +7657,7 @@
         },
         {
             "id": "9c5b6427-08ca-5e33-a06e-44de4f37e249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e2d09e-b9f5-4a0d-96d3-984b5c2c387d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e2d09e-b9f5-4a0d-96d3-984b5c2c387d.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "b80605d6-e25f-5f4d-b710-9ce063497ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8493ee-bd06-4583-9908-a0dbcc5be6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8493ee-bd06-4583-9908-a0dbcc5be6d7.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -7739,7 +7739,7 @@
         },
         {
             "id": "0ed3224c-2d8d-5df8-88ef-99cf5a508a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238d2c-d10f-496d-aa34-5a1536e056b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b238d2c-d10f-496d-aa34-5a1536e056b5.jpg?1",
             "name": "Rangers' Aetherhive",
             "text": "Vigilance\nWhenever you activate an exhaust ability, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "2af22d4f-529b-5676-9727-1412746fe804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fba3820-32ba-47e9-9fa8-f985ff471b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fba3820-32ba-47e9-9fa8-f985ff471b3f.jpg?1",
             "name": "Redshift, Rocketeer Chief",
             "text": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust \u2014 {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield. (Activate each exhaust ability only once.)",
             "colours": [
@@ -7819,7 +7819,7 @@
         },
         {
             "id": "7f9f4948-b218-5116-a548-3fee1f128fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfb0f7-18ca-4f6e-ba64-92120010456e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfb0f7-18ca-4f6e-ba64-92120010456e.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -7860,7 +7860,7 @@
         },
         {
             "id": "c2f0480c-3b13-53ce-8437-164ec13a9818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80c91e-dd3d-4c7b-89e4-bfb253eeaee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80c91e-dd3d-4c7b-89e4-bfb253eeaee2.jpg?1",
             "name": "Rocketeer Boostbuggy",
             "text": "Whenever this Vehicle attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nExhaust \u2014 {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. (Activate each exhaust ability only once.)\nCrew 1",
             "colours": [
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "bd7a3e6f-eb6d-5077-b1c8-d520244747c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef555b1-666d-4386-8983-0e88f9b6cdec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef555b1-666d-4386-8983-0e88f9b6cdec.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "d79955bc-eb17-564c-b6a2-01cc261c1042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efd8222-5c37-46d8-a2ec-1d7aae25320b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8efd8222-5c37-46d8-a2ec-1d7aae25320b.jpg?1",
             "name": "Samut, the Driving Force",
             "text": "First strike, vigilance, haste\nStart your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
             "colours": [
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "6d3c6f65-653d-5c1a-aca8-109ab576876a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb523c06-6f3e-4e19-b777-19aefc4a4e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb523c06-6f3e-4e19-b777-19aefc4a4e02.jpg?1",
             "name": "Sita Varma, Masked Racer",
             "text": "Exhaust \u2014 {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn. (Activate each exhaust ability only once.)",
             "colours": [
@@ -8027,7 +8027,7 @@
         },
         {
             "id": "f1215e45-e215-5a18-a7c8-7c0517d0d5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbd9fc0-c0df-4119-a0d3-2e1790998c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbd9fc0-c0df-4119-a0d3-2e1790998c21.jpg?1",
             "name": "Skyserpent Seeker",
             "text": "Flying, deathtouch\nExhaust \u2014 {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
             "colours": [
@@ -8065,7 +8065,7 @@
         },
         {
             "id": "ee1a5e5f-1d0e-5094-9558-004eb11cdaf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1576d4-15a3-4e91-84ef-e71e258185e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1576d4-15a3-4e91-84ef-e71e258185e7.jpg?1",
             "name": "Thundering Broodwagon",
             "text": "Menace, reach\nWhen this Vehicle enters, destroy target nonland permanent an opponent controls with mana value 4 or less.\nCrew 3\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -8103,7 +8103,7 @@
         },
         {
             "id": "58449cdb-d739-55bc-b809-85c2ddb1e194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab38f35-b60c-464c-a0b5-9d5f2dc6de7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab38f35-b60c-464c-a0b5-9d5f2dc6de7f.jpg?1",
             "name": "Veteran Beastrider",
             "text": "At the beginning of your end step, untap each creature you control.\n{2}{G}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8140,7 +8140,7 @@
         },
         {
             "id": "c5f367d1-e758-5baf-91b3-fb480c05656c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba835da-0247-4716-9079-1b605297f6d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba835da-0247-4716-9079-1b605297f6d5.jpg?1",
             "name": "Voyage Home",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nYou draw three cards and gain 3 life.",
             "colours": [
@@ -8176,7 +8176,7 @@
         },
         {
             "id": "376d210f-2c8a-5741-8326-16c5395ea024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d46d0e-3161-45b5-a49e-5cd592c67ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d46d0e-3161-45b5-a49e-5cd592c67ddd.jpg?1",
             "name": "Winter, Cursed Rider",
             "text": "Ward\u2014\nPay 2 life.\nArtifacts you control have \"Ward\u2014\nPay 2 life.\"\nExhaust \u2014 {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn. (Activate each exhaust ability only once.)",
             "colours": [
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "f601065b-7a04-5d51-89fe-9b90737a960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31944ea5-045d-481d-9aff-3c7ed663813a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31944ea5-045d-481d-9aff-3c7ed663813a.jpg?1",
             "name": "Zahur, Glory's Past",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed \u2014 Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "779e4b2c-c4bb-5e2e-9b1c-d6233b91893d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a29c8a5-fd98-422c-9518-2db0993495e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a29c8a5-fd98-422c-9518-2db0993495e5.jpg?1",
             "name": "Aetherjacket",
             "text": "Flying, vigilance\n{2}, {T}, Sacrifice this creature: Destroy another target artifact. Activate only as a sorcery.",
             "colours": [],
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "ca43c835-d9a9-5003-b8de-76cd7d6bb170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05690d52-06c4-40b1-8360-380418a83250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05690d52-06c4-40b1-8360-380418a83250.jpg?1",
             "name": "The Aetherspark",
             "text": "As long as The Aetherspark is attached to a creature, The Aetherspark can't be attacked and has \"Whenever equipped creature deals combat damage during your turn, put that many loyalty counters on The Aetherspark.\"\n+1: Attach The Aetherspark to up to one target creature you control. Put a +1/+1 counter on that creature.\n\u22125: Draw two cards.\n\u221210: Add ten mana of any one color.",
             "colours": [],
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "fae595cf-1e6b-5001-a369-7aa67e5b5d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968651db-92fb-46cd-acda-9e097668b7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968651db-92fb-46cd-acda-9e097668b7c9.jpg?1",
             "name": "Camera Launcher",
             "text": "Exhaust \u2014 {3}: Put a +1/+1 counter on this creature. Create a 1/1 colorless Thopter artifact creature token with flying. (Activate each exhaust ability only once.)",
             "colours": [],
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "217e4a3e-1752-55c8-b2c2-2fe01226afcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccf7fb5-c043-4a1f-ad2f-edb280cb5037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccf7fb5-c043-4a1f-ad2f-edb280cb5037.jpg?1",
             "name": "Guidelight Matrix",
             "text": "When this artifact enters, draw a card.\n{2}, {T}: Target Mount you control becomes saddled until end of turn. Activate only as a sorcery.\n{2}, {T}: Target Vehicle you control becomes an artifact creature until end of turn.",
             "colours": [],
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "c5a50588-637b-5c31-b108-86e9c4713ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c92203-17df-4f10-92c6-ebcc79f01357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c92203-17df-4f10-92c6-ebcc79f01357.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -8422,7 +8422,7 @@
         },
         {
             "id": "335d860c-472f-5152-bf2b-92777b378b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2152030-6007-493f-a616-545723a00249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2152030-6007-493f-a616-545723a00249.jpg?1",
             "name": "Marketback Walker",
             "text": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
             "colours": [],
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "5a85f0cd-0271-5632-8011-784ebc09e663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f920f83-6380-4e4f-be68-6bf9df3110d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f920f83-6380-4e4f-be68-6bf9df3110d8.jpg?1",
             "name": "Marshals' Pathcruiser",
             "text": "When this Vehicle enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nExhaust \u2014 {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it. (Activate each exhaust ability only once.)\nCrew 5",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "a4798ef1-6df3-5748-b596-289a8ef075ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21433ba-0a14-42bc-ad0b-a4ef823a3295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21433ba-0a14-42bc-ad0b-a4ef823a3295.jpg?1",
             "name": "Monument to Endurance",
             "text": "Whenever you discard a card, choose one that hasn't been chosen this turn \u2014\n\u2022 Draw a card.\n\u2022 Create a Treasure token.\n\u2022 Each opponent loses 3 life.",
             "colours": [],
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "4ec21929-6bd6-5ce6-b5c9-a18ec55ace40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72527ef-ac05-44c8-8c76-10532ce3da6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72527ef-ac05-44c8-8c76-10532ce3da6e.jpg?1",
             "name": "Pit Automaton",
             "text": "Defender\n{T}: Add {C}{C}. Spend this mana only to activate abilities.\n{2}, {T}: When you next activate an exhaust ability this turn, copy it. You may choose new targets for the copy.",
             "colours": [],
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "8e115f15-2135-5b83-85af-a2c5d2a24326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg?1",
             "name": "Racers' Scoreboard",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this artifact enters, draw two cards, then discard a card.\nMax speed \u2014 Spells you cast cost {1} less to cast.",
             "colours": [],
@@ -8584,7 +8584,7 @@
         },
         {
             "id": "4f836cc8-241a-57cf-a2f9-dde7c21638de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6dac83-39c2-40dc-a322-76a3ea4e7aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6dac83-39c2-40dc-a322-76a3ea4e7aee.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -8617,7 +8617,7 @@
         },
         {
             "id": "61bc64b5-b6e5-5ef3-8160-6a2308bcf03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855a999-83f6-4c0d-9444-3ff292f77d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855a999-83f6-4c0d-9444-3ff292f77d58.jpg?1",
             "name": "Rover Blades",
             "text": "Double strike\nEquipped creature has double strike.\nEquip {4}\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn. Creatures can't be attached to other permanents.)",
             "colours": [],
@@ -8650,7 +8650,7 @@
         },
         {
             "id": "d8883922-7652-5916-99d0-5421c4075d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg?1",
             "name": "Scrap Compactor",
             "text": "{3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.\n{6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle.",
             "colours": [],
@@ -8678,7 +8678,7 @@
         },
         {
             "id": "df62c122-01f5-5b32-88ce-bcc136b4c18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d9ef34-ae95-4465-a30c-372e231bd733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d9ef34-ae95-4465-a30c-372e231bd733.jpg?1",
             "name": "Skybox Ferry",
             "text": "Flying\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "4019fc70-e890-536d-b586-6d8936219a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0530b343-98c2-440a-b32e-d1566d318c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0530b343-98c2-440a-b32e-d1566d318c3b.jpg?1",
             "name": "Starting Column",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add one mana of any color.\nMax speed \u2014 {T}, Sacrifice this artifact: Draw two cards, then discard a card.",
             "colours": [],
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "091973ec-386c-59c0-9a67-8747e221fe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa178ed7-8f3a-45f0-817d-5fbc7993b04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa178ed7-8f3a-45f0-817d-5fbc7993b04a.jpg?1",
             "name": "Ticket Tortoise",
             "text": "Defender\nWhen this creature enters, if an opponent controls more lands than you, you create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [],
@@ -8769,7 +8769,7 @@
         },
         {
             "id": "9138f474-673a-51ca-a4b1-93c9ce53b4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ccbd73-9414-48a3-bdcf-e838fcffc08f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ccbd73-9414-48a3-bdcf-e838fcffc08f.jpg?1",
             "name": "Walking Sarcophagus",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed \u2014 This creature gets +1/+2.",
             "colours": [],
@@ -8801,7 +8801,7 @@
         },
         {
             "id": "2f2b7f96-69d7-56c1-9e00-5cb274888b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3151960-cc0c-47b5-b476-295d7a17ae14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3151960-cc0c-47b5-b476-295d7a17ae14.jpg?1",
             "name": "Wreck Remover",
             "text": "Whenever this creature enters or attacks, exile up to one target card from a graveyard. You gain 1 life.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8832,7 +8832,7 @@
         },
         {
             "id": "23dec1bc-a75c-512a-a1c4-63a43553799f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312807-ea2a-4385-8774-4e23b4a5d4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312807-ea2a-4385-8774-4e23b4a5d4a6.jpg?1",
             "name": "Amonkhet Raceway",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed \u2014 {T}: Target creature gains haste until end of turn.",
             "colours": [],
@@ -8862,7 +8862,7 @@
         },
         {
             "id": "6a54290d-117c-50e2-85c9-74b9c13b9aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a6b378-c7fa-4226-a310-4ee7e550b4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a6b378-c7fa-4226-a310-4ee7e550b4d6.jpg?1",
             "name": "Avishkar Raceway",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed \u2014 {3}, {T}, Discard a card: Draw a card.",
             "colours": [],
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "4b958d55-9000-56a1-84e0-fc9829abe54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dcdabd-a186-45fe-9fee-6c0f1afeaf16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dcdabd-a186-45fe-9fee-6c0f1afeaf16.jpg?1",
             "name": "Bleachbone Verge",
             "text": "{T}: Add {B}.\n{T}: Add {W}. Activate only if you control a Plains or a Swamp.",
             "colours": [],
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "ea07bd64-eea3-53c2-a049-bb356fd927bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49195d90-de0c-4290-aa1c-9f4d948b5521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49195d90-de0c-4290-aa1c-9f4d948b5521.jpg?1",
             "name": "Bloodfell Caves",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "fadad1b4-62b8-51fb-94e2-1c01380aa7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69949863-2510-4fe2-a815-0682beeb08a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69949863-2510-4fe2-a815-0682beeb08a3.jpg?1",
             "name": "Blossoming Sands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "ed17d20d-0fa8-5445-8405-99e8708a7f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897acd91-12ba-4fa8-a26e-c09f009167a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897acd91-12ba-4fa8-a26e-c09f009167a8.jpg?1",
             "name": "Country Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {W}.\n{1}{W}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "4ae059e6-577a-5e19-8a9a-152898481c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20aef3f-79f6-4357-8631-1d141f437def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20aef3f-79f6-4357-8631-1d141f437def.jpg?1",
             "name": "Dismal Backwater",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9049,7 +9049,7 @@
         },
         {
             "id": "7504c04e-7bb0-5b0f-a3a8-4d040dbcaf3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c026a-c89f-41f3-8812-424124dd3760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37c026a-c89f-41f3-8812-424124dd3760.jpg?1",
             "name": "Foul Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {B}.\n{1}{B}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9079,7 +9079,7 @@
         },
         {
             "id": "cac5e033-06bc-5d66-a2da-fa404b11d0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd24a1a-08db-4fa7-8939-f5541677327e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd24a1a-08db-4fa7-8939-f5541677327e.jpg?1",
             "name": "Jungle Hollow",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9110,7 +9110,7 @@
         },
         {
             "id": "eb15491c-79af-584a-bc46-b5e9c9560354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041ae16-29ff-4ad5-8a37-4736e9409294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041ae16-29ff-4ad5-8a37-4736e9409294.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "5a719845-3b75-5f8f-8258-c581ec21ed87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c1dce3-6136-4294-9d2b-5ef8527d733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c1dce3-6136-4294-9d2b-5ef8527d733b.jpg?1",
             "name": "Night Market",
             "text": "This land enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9170,7 +9170,7 @@
         },
         {
             "id": "aedea0fe-2e14-5eb5-b9bd-8e9b405cf185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8171a-2629-4356-ae86-b4d03aa14bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8171a-2629-4356-ae86-b4d03aa14bd3.jpg?1",
             "name": "Reef Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {U}.\n{1}{U}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9200,7 +9200,7 @@
         },
         {
             "id": "d94fd995-b642-5984-883a-a710a389e351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a93a71-d77c-417f-85d0-cd420f573331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a93a71-d77c-417f-85d0-cd420f573331.jpg?1",
             "name": "Riverpyre Verge",
             "text": "{T}: Add {R}.\n{T}: Add {U}. Activate only if you control an Island or a Mountain.",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "7a520cf1-38ac-50e3-bc48-b78262b02161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0d4e8a-aab5-458e-bc0e-2b6b0054646a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0d4e8a-aab5-458e-bc0e-2b6b0054646a.jpg?1",
             "name": "Rocky Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {R}.\n{1}{R}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9264,7 +9264,7 @@
         },
         {
             "id": "953f010e-e999-5245-94b0-abcec5cb4061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b7484f-923c-46c5-95bf-c2c6706c0d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b7484f-923c-46c5-95bf-c2c6706c0d48.jpg?1",
             "name": "Rugged Highlands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9295,7 +9295,7 @@
         },
         {
             "id": "d46acf94-f63d-51f1-8306-3144d05c2354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac52be0c-49f4-4956-820e-bdd7d2744d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac52be0c-49f4-4956-820e-bdd7d2744d2f.jpg?1",
             "name": "Scoured Barrens",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "2ab16da7-2e3f-5658-810d-eee8e22fe15f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed132f-b818-4dbf-9b4a-e5acb067e0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed132f-b818-4dbf-9b4a-e5acb067e0a4.jpg?1",
             "name": "Sunbillow Verge",
             "text": "{T}: Add {W}.\n{T}: Add {R}. Activate only if you control a Mountain or a Plains.",
             "colours": [],
@@ -9360,7 +9360,7 @@
         },
         {
             "id": "44beb8b6-d27c-5e9d-805f-a3ce062212e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949bf6bb-1e97-48a3-8547-0a780664c275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949bf6bb-1e97-48a3-8547-0a780664c275.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9391,7 +9391,7 @@
         },
         {
             "id": "12eae30e-9493-500a-baed-50e1fe179892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4723a303-7f20-4399-8bc6-6a27a61a3532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4723a303-7f20-4399-8bc6-6a27a61a3532.jpg?1",
             "name": "Thornwood Falls",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9422,7 +9422,7 @@
         },
         {
             "id": "1d427b10-199f-51d7-85ab-f3368a5cf927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70688800-7675-4e75-bb3c-9e05b95a685c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70688800-7675-4e75-bb3c-9e05b95a685c.jpg?1",
             "name": "Tranquil Cove",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9453,7 +9453,7 @@
         },
         {
             "id": "7bac7d37-f51c-5586-8fb5-c4a739b6d029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ceacc7d-d407-4f82-af58-9bdf8426924e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ceacc7d-d407-4f82-af58-9bdf8426924e.jpg?1",
             "name": "Wastewood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {B}. Activate only if you control a Swamp or a Forest.",
             "colours": [],
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "41dac39d-fe35-5440-8de3-38b023a7b157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3d48d1-a98e-40af-b04c-c40b9d52e9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3d48d1-a98e-40af-b04c-c40b9d52e9ee.jpg?1",
             "name": "Wild Roads",
             "text": "This land enters tapped unless you control a Mount or Vehicle.\n{T}: Add {G}.\n{1}{G}, {T}, Sacrifice this land: Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "e93ffe60-3db8-5bae-964b-815c6ae60c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758d93d5-3f66-4395-a928-000485396c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758d93d5-3f66-4395-a928-000485396c87.jpg?1",
             "name": "Willowrush Verge",
             "text": "{T}: Add {U}.\n{T}: Add {G}. Activate only if you control a Forest or an Island.",
             "colours": [],
@@ -9551,7 +9551,7 @@
         },
         {
             "id": "afd59654-913a-57e7-8711-2e5bdd7f60a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882969d8-7e3e-4f32-858a-00da20c67b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882969d8-7e3e-4f32-858a-00da20c67b83.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "765bd05c-7733-59ad-a04b-b6846e25b83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2da8b9-797f-46e8-a15d-a86c7c56dc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2da8b9-797f-46e8-a15d-a86c7c56dc84.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9622,7 +9622,7 @@
         },
         {
             "id": "8b8bfdb6-036f-58d5-9d5c-72d6d4a54339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53ed206-8ec4-46a6-8603-c819682e1433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53ed206-8ec4-46a6-8603-c819682e1433.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "6cf53345-398a-547d-a4c6-c988b0ab6631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e969e168-e74c-4608-9fa0-a5660bf7fa02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e969e168-e74c-4608-9fa0-a5660bf7fa02.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "f200e2b8-4b95-5fb6-86df-e574e917fefb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50748a4c-43a0-4274-9a84-046d76027166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50748a4c-43a0-4274-9a84-046d76027166.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9742,7 +9742,7 @@
         },
         {
             "id": "cb2a03c5-55e6-5b5f-87dc-62d2ad0f48fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777e868d-cb88-4b8e-99d1-12ff67f5eae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777e868d-cb88-4b8e-99d1-12ff67f5eae2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "b214a017-5a4c-5ed9-9a47-2ff50503c511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9822,7 +9822,7 @@
         },
         {
             "id": "07991926-f94c-51c5-9223-4e2aabfd043b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b97d2f5-498c-42db-95d9-f9002d4dfcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b97d2f5-498c-42db-95d9-f9002d4dfcc5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9862,7 +9862,7 @@
         },
         {
             "id": "15d8b1b8-6939-5b78-a32e-ea13b4dd62c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cf2f81-3041-4349-9b37-f215c4e38c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cf2f81-3041-4349-9b37-f215c4e38c5b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9902,7 +9902,7 @@
         },
         {
             "id": "5f282781-a01b-563b-a237-7d25c53843c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9942,7 +9942,7 @@
         },
         {
             "id": "b73151b0-e042-59df-9f0e-253c2536e672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9369d0a-87c0-4c29-b43c-cd45c007f8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9369d0a-87c0-4c29-b43c-cd45c007f8d6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "f88b246d-f43e-55e3-80d4-aa56573f1cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3c4a9d-48db-474f-aeb6-8b4fa08ce6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3c4a9d-48db-474f-aeb6-8b4fa08ce6fa.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "f2c06bb1-cdca-5cb9-9e3f-239ad7063640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10062,7 +10062,7 @@
         },
         {
             "id": "ac63e212-f348-5080-a9de-b28bfcd60a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e124b6-3af7-41c0-b829-ff85aa0c3782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e124b6-3af7-41c0-b829-ff85aa0c3782.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10102,7 +10102,7 @@
         },
         {
             "id": "525511d1-4847-5d87-9d88-d2d23809458f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85288987-6f3f-4b7b-9ecc-9393dd37f115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85288987-6f3f-4b7b-9ecc-9393dd37f115.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "d85a3d1e-caa7-5bcf-a88d-e236f5a15ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10182,7 +10182,7 @@
         },
         {
             "id": "ff59fc34-ccfe-555f-8690-be6cdbe7a86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e70c-626f-4d2c-b26b-d94f815fceea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e70c-626f-4d2c-b26b-d94f815fceea.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "1772f4e7-d5fa-5960-89d2-d6592aa212d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e2393-30a7-4e0c-bd20-f05ca0ba3cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e2393-30a7-4e0c-bd20-f05ca0ba3cb6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "4f504ddd-dc7c-56ac-ad68-0b00ca8236a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10302,7 +10302,7 @@
         },
         {
             "id": "5fdc9723-d72b-577b-8f56-4094b502e69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6472e2a6-287f-4e7c-ad85-1454e40d4a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6472e2a6-287f-4e7c-ad85-1454e40d4a46.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10342,7 +10342,7 @@
         },
         {
             "id": "86f19aff-c504-5870-917f-6b8b62ab6290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562b16ae-8ae7-4b2d-9098-bf3ff1429f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562b16ae-8ae7-4b2d-9098-bf3ff1429f7b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10382,7 +10382,7 @@
         },
         {
             "id": "24f5ad36-4ef6-5a99-a1e1-62faf433efa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e66d63-56be-46f5-b0df-e1350106ba45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e66d63-56be-46f5-b0df-e1350106ba45.jpg?1",
             "name": "Air Response Unit",
             "text": "Flying, vigilance\nCrew 1",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "1e5d50b2-4431-55f8-8799-b23ac10b75df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6118bb1-9530-487b-a211-7cc56cef3fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6118bb1-9530-487b-a211-7cc56cef3fbb.jpg?1",
             "name": "Broadcast Rambler",
             "text": "When this Vehicle enters, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "cecc7e26-fa56-51f0-b9e2-b66f548c9ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e45f00e-2156-4e8c-813c-0e36ab34982e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e45f00e-2156-4e8c-813c-0e36ab34982e.jpg?1",
             "name": "Detention Chariot",
             "text": "When this Vehicle enters, exile target artifact or creature an opponent controls until this Vehicle leaves the battlefield.\nCrew 3\nCycling {W}",
             "colours": [
@@ -10490,7 +10490,7 @@
         },
         {
             "id": "019af060-3b53-5954-8007-8ca616e9fbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2e68f-3f40-45b1-9afe-cc1c5fb41203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2e68f-3f40-45b1-9afe-cc1c5fb41203.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -10530,7 +10530,7 @@
         },
         {
             "id": "9cffcdeb-50f5-53fb-acc0-3aa1d64bd33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0eb86e-371c-46fd-a261-384b2a603b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0eb86e-371c-46fd-a261-384b2a603b36.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "e9b35241-8d86-54d0-95f6-baa3325b355c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0303505-d6f1-4626-a932-0e577d9572fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0303505-d6f1-4626-a932-0e577d9572fe.jpg?1",
             "name": "Spotcycle Scouter",
             "text": "When this Vehicle enters, scry 2.\nCrew 1",
             "colours": [
@@ -10604,7 +10604,7 @@
         },
         {
             "id": "81e90d5a-03e1-562a-a7db-639eb319c146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f142d6c1-90f6-49d6-861e-36e9a6fac958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f142d6c1-90f6-49d6-861e-36e9a6fac958.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W}\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -10644,7 +10644,7 @@
         },
         {
             "id": "86bc7a75-3afd-5b8a-80a9-7837653de8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7da86-902a-4d40-a230-4d22d4b2df59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7da86-902a-4d40-a230-4d22d4b2df59.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -10682,7 +10682,7 @@
         },
         {
             "id": "0d4c304d-4570-5209-a847-fd07986a604f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279171d-1623-438c-b796-d294c6675604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0279171d-1623-438c-b796-d294c6675604.jpg?1",
             "name": "Hulldrifter",
             "text": "Flying\nWhen this Vehicle enters, draw two cards.\nCrew 3",
             "colours": [
@@ -10718,7 +10718,7 @@
         },
         {
             "id": "8ec28bc7-b5c8-5135-ab28-3c0a11c2b72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aeb6fa4-569e-4ede-94c5-a8f3c28f55e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aeb6fa4-569e-4ede-94c5-a8f3c28f55e4.jpg?1",
             "name": "Midnight Mangler",
             "text": "During turns other than yours, this Vehicle is an artifact creature.\nCrew 2",
             "colours": [
@@ -10754,7 +10754,7 @@
         },
         {
             "id": "64a82a5e-60c8-5c53-94f9-ff0b33c680d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821045bd-c8e4-40fb-babd-5d13b64a71ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821045bd-c8e4-40fb-babd-5d13b64a71ec.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -10792,7 +10792,7 @@
         },
         {
             "id": "9db68664-60d8-58ad-a656-4d9b6e525ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530159a6-0672-485a-867c-aa0bac961765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530159a6-0672-485a-867c-aa0bac961765.jpg?1",
             "name": "Rangers' Refueler",
             "text": "Whenever you activate an exhaust ability, draw a card.\nExhaust \u2014 {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.\nCrew 2",
             "colours": [
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "0ac18fb9-8ab1-560c-ac36-4eb81699374d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd26a5a-ca58-4cb6-b599-7c84d601dc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd26a5a-ca58-4cb6-b599-7c84d601dc07.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -10866,7 +10866,7 @@
         },
         {
             "id": "848d8a3a-cb93-5432-82ca-07cb691e2e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818931d1-258d-4dda-9d0a-2015ec330bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818931d1-258d-4dda-9d0a-2015ec330bab.jpg?1",
             "name": "Carrion Cruiser",
             "text": "When this Vehicle enters, mill two cards. Then return a creature or Vehicle card from your graveyard to your hand.\nCrew 1",
             "colours": [
@@ -10902,7 +10902,7 @@
         },
         {
             "id": "739a238b-a842-576a-a530-6cd47edf1aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f4e3c-2729-488b-883f-7657deea39c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f4e3c-2729-488b-883f-7657deea39c8.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -10940,7 +10940,7 @@
         },
         {
             "id": "bb5327c4-a2b9-5e93-8fd8-71b96341be32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c322936f-3b56-454c-a89e-fa53faab6a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c322936f-3b56-454c-a89e-fa53faab6a33.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -10978,7 +10978,7 @@
         },
         {
             "id": "41327ee8-2370-57e7-8469-03c6a1480dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d563b1-f03b-4ce3-9de0-05dab257b67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d563b1-f03b-4ce3-9de0-05dab257b67c.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -11018,7 +11018,7 @@
         },
         {
             "id": "e42f497a-6c95-504c-9bd6-b60cc44b0028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba1b096-7424-4ce9-8dfd-56a86fe612e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba1b096-7424-4ce9-8dfd-56a86fe612e4.jpg?1",
             "name": "Ripclaw Wrangler",
             "text": "When this Vehicle enters, each opponent discards a card.\nCrew 2",
             "colours": [
@@ -11054,7 +11054,7 @@
         },
         {
             "id": "0cfc7ae0-8fb9-5c7f-8093-893daf3943ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3501b938-7a25-43c7-b1c5-03cd9b690930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3501b938-7a25-43c7-b1c5-03cd9b690930.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.\nCrew 2",
             "colours": [
@@ -11092,7 +11092,7 @@
         },
         {
             "id": "98b199fd-3900-5022-808e-46139d02743f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c93bd-1313-4c7b-bd6f-91e329932dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c93bd-1313-4c7b-bd6f-91e329932dea.jpg?1",
             "name": "Burner Rocket",
             "text": "Flash\nWhen this Vehicle enters, target creature you control gets +2/+0 and gains trample until end of turn.\nCrew 1",
             "colours": [
@@ -11128,7 +11128,7 @@
         },
         {
             "id": "89ba83ae-e40f-5578-a21e-9da9fd8f2a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d3c041-976c-41e2-9ce6-4b292e499526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d3c041-976c-41e2-9ce6-4b292e499526.jpg?1",
             "name": "Clamorous Ironclad",
             "text": "Menace\nCrew 3\nCycling {R}",
             "colours": [
@@ -11164,7 +11164,7 @@
         },
         {
             "id": "6aa8abda-bc03-529c-9d7c-bee4070ae343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a07256-3305-4178-bd4f-d1583d23106d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a07256-3305-4178-bd4f-d1583d23106d.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -11202,7 +11202,7 @@
         },
         {
             "id": "8b875666-c29b-5c3a-b644-6459e0453a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c0a-41f3-4d88-be1d-19c0821f158e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c0a-41f3-4d88-be1d-19c0821f158e.jpg?1",
             "name": "Spire Mechcycle",
             "text": "Haste\nExhaust \u2014 Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle.\nCrew 2",
             "colours": [
@@ -11238,7 +11238,7 @@
         },
         {
             "id": "65193ca8-fcdd-5769-a385-ac28e55a61de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95a5f3-7f14-4d59-8329-559ed4ff0491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95a5f3-7f14-4d59-8329-559ed4ff0491.jpg?1",
             "name": "Earthrumbler",
             "text": "Vigilance, trample\nExile an artifact or creature card from your graveyard: This Vehicle becomes an artifact creature until end of turn.\nCrew 3",
             "colours": [
@@ -11274,7 +11274,7 @@
         },
         {
             "id": "fb7307e1-e769-5e6d-89d9-900493a7270d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c196dd-61a9-4e75-bd43-9531ba3dc961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c196dd-61a9-4e75-bd43-9531ba3dc961.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -11313,7 +11313,7 @@
         },
         {
             "id": "429cdee2-c664-5173-9f21-09535698d991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f6a1c-7b34-4c23-8172-5b869c96eb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f6a1c-7b34-4c23-8172-5b869c96eb65.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -11351,7 +11351,7 @@
         },
         {
             "id": "e30317da-f08a-5a7f-81e1-8a47fe580faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdffb27-5035-49c2-b214-abe46a17433d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdffb27-5035-49c2-b214-abe46a17433d.jpg?1",
             "name": "Veloheart Bike",
             "text": "When this Vehicle enters, you gain 2 life.\n{T}: Add one mana of any color.\nCrew 2",
             "colours": [
@@ -11387,7 +11387,7 @@
         },
         {
             "id": "a6f27e3c-ad76-5ee7-9219-a39a10766537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55a6ec-634c-4590-9875-db4e5b81795d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55a6ec-634c-4590-9875-db4e5b81795d.jpg?1",
             "name": "Apocalypse Runner",
             "text": "{T}: Target creature you control with power 2 or less gains lifelink until end of turn and can't be blocked this turn.\nCrew 3",
             "colours": [
@@ -11425,7 +11425,7 @@
         },
         {
             "id": "d95f156a-6d05-58d0-8369-b03649acc624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bb2217-d3e1-4638-9a14-bb72bfedd18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bb2217-d3e1-4638-9a14-bb72bfedd18c.jpg?1",
             "name": "Boosted Sloop",
             "text": "Menace\nWhenever you attack, draw a card, then discard a card.\nCrew 1",
             "colours": [
@@ -11463,7 +11463,7 @@
         },
         {
             "id": "2a9300df-318a-5387-ac58-c85f3693e8f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73918759-b7b6-4a09-baa1-7f660ecef42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73918759-b7b6-4a09-baa1-7f660ecef42e.jpg?1",
             "name": "Cloudspire Skycycle",
             "text": "Flying\nWhen this Vehicle enters, distribute two +1/+1 counters among one or two other target Vehicles and/or creatures you control.\nCrew 1",
             "colours": [
@@ -11501,7 +11501,7 @@
         },
         {
             "id": "2fe26bed-535c-542a-b8ee-7df3dad39d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe7293-2d85-42dd-b6a1-21e98487cbfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe7293-2d85-42dd-b6a1-21e98487cbfa.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "d3bde68a-93f6-587e-810a-3c4f8011b51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71586675-e9f5-4bec-984d-8683b2494b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71586675-e9f5-4bec-984d-8683b2494b35.jpg?1",
             "name": "Dune Drifter",
             "text": "When this Vehicle enters, return target artifact or creature card with mana value X or less from your graveyard to the battlefield.\nCrew 2",
             "colours": [
@@ -11579,7 +11579,7 @@
         },
         {
             "id": "5b5b65a1-fac3-582f-af22-6bc74bfb4f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83566cd0-2253-477e-ae99-4c0c4902ad6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83566cd0-2253-477e-ae99-4c0c4902ad6e.jpg?1",
             "name": "Guidelight Pathmaker",
             "text": "Vigilance\nWhen this Vehicle enters, you may search your library for an artifact card and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. Then shuffle.\nCrew 2",
             "colours": [
@@ -11617,7 +11617,7 @@
         },
         {
             "id": "4cf75816-d11c-5ad3-90f7-8aeb56937e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68c20a-f377-4613-8771-cdda1745cdff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68c20a-f377-4613-8771-cdda1745cdff.jpg?1",
             "name": "Haunted Hellride",
             "text": "Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of turn. Untap it.\nCrew 1",
             "colours": [
@@ -11655,7 +11655,7 @@
         },
         {
             "id": "9c0e3417-d672-58fd-85a0-5c948b482c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0d5c5c-d3d6-48ae-9775-fcd2cd9a0c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0d5c5c-d3d6-48ae-9775-fcd2cd9a0c65.jpg?1",
             "name": "Rangers' Aetherhive",
             "text": "Vigilance\nWhenever you activate an exhaust ability, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1",
             "colours": [
@@ -11693,7 +11693,7 @@
         },
         {
             "id": "2b6349bc-2fb4-56c2-a09a-fbb63d033b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db27c67-0462-474c-844b-4f69d8fe6734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db27c67-0462-474c-844b-4f69d8fe6734.jpg?1",
             "name": "Rocketeer Boostbuggy",
             "text": "Whenever this Vehicle attacks, create a Treasure token.\nExhaust \u2014 {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -11731,7 +11731,7 @@
         },
         {
             "id": "4a54d6ad-eeff-5d14-aeb1-f012e0a17937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4adfba1-c73a-43b4-8400-e11617958f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4adfba1-c73a-43b4-8400-e11617958f7f.jpg?1",
             "name": "Thundering Broodwagon",
             "text": "Menace, reach\nWhen this Vehicle enters, destroy target nonland permanent an opponent controls with mana value 4 or less.\nCrew 3\nCycling {2}",
             "colours": [
@@ -11769,7 +11769,7 @@
         },
         {
             "id": "e0d94e41-ed04-5a12-99a1-ea52174b3673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0aa565-1ef0-41f5-a86d-0701e357cde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0aa565-1ef0-41f5-a86d-0701e357cde9.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -11804,7 +11804,7 @@
         },
         {
             "id": "e668b265-7413-5e46-af0e-075116a77180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e88ae-7f5c-4dea-add0-a53a6a9bd8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e88ae-7f5c-4dea-add0-a53a6a9bd8e4.jpg?1",
             "name": "Marshals' Pathcruiser",
             "text": "When this Vehicle enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nExhaust \u2014 {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it.\nCrew 5",
             "colours": [],
@@ -11842,7 +11842,7 @@
         },
         {
             "id": "18feb146-707b-5548-8c93-67c72c11b72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3b07b7-8d51-428e-a399-61da45529c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3b07b7-8d51-428e-a399-61da45529c8f.jpg?1",
             "name": "Rover Blades",
             "text": "Double strike\nEquipped creature has double strike.\nEquip {4}\nCrew 2",
             "colours": [],
@@ -11875,7 +11875,7 @@
         },
         {
             "id": "86afbbc0-5f93-533d-a353-4ffa861f3333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9e294e-cdb2-423d-a034-f68f673b5973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9e294e-cdb2-423d-a034-f68f673b5973.jpg?1",
             "name": "Skybox Ferry",
             "text": "Flying\nCrew 2\nCycling {2}",
             "colours": [],
@@ -11907,7 +11907,7 @@
         },
         {
             "id": "13b20ccb-9db9-54c8-b59f-f5a775d036c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27736f40-a87b-45e4-a0da-accf9433c1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27736f40-a87b-45e4-a0da-accf9433c1fc.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1",
             "colours": [
@@ -11946,7 +11946,7 @@
         },
         {
             "id": "f7ee6ef6-5fc4-502e-b131-94c574f876b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309072be-b813-42bd-adaf-7d45053029c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309072be-b813-42bd-adaf-7d45053029c0.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -11985,7 +11985,7 @@
         },
         {
             "id": "ba30c761-8185-5f2b-be4f-056b435603cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcda94fc-43f0-4fa6-b38b-bb8c4c26d9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcda94fc-43f0-4fa6-b38b-bb8c4c26d9a1.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.",
             "colours": [
@@ -12024,7 +12024,7 @@
         },
         {
             "id": "b99a8002-88a3-5739-ba02-2f239b0c5d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc820fb-eec2-4873-a272-68e8379470fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc820fb-eec2-4873-a272-68e8379470fc.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2}",
             "colours": [
@@ -12062,7 +12062,7 @@
         },
         {
             "id": "4f97530a-3940-5a32-b102-de1681b3b9ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560bd1f-eb63-45bc-a8c7-b5de200facc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560bd1f-eb63-45bc-a8c7-b5de200facc9.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -12101,7 +12101,7 @@
         },
         {
             "id": "4903cc32-86b7-51df-ae95-42c8d009a70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3150199e-9e4f-486d-bfb0-fc2a9feb8536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3150199e-9e4f-486d-bfb0-fc2a9feb8536.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -12140,7 +12140,7 @@
         },
         {
             "id": "0c8e02d6-dd2d-511a-bafe-449559b1a9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4045e7-6d2c-4ef9-922e-3681fa820c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4045e7-6d2c-4ef9-922e-3681fa820c4b.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -12180,7 +12180,7 @@
         },
         {
             "id": "abdf05e4-5249-57c7-88b1-9a2c7cef2f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ffa8e-2794-4f11-8351-42f1a0f26831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ffa8e-2794-4f11-8351-42f1a0f26831.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -12219,7 +12219,7 @@
         },
         {
             "id": "43b21249-0f15-588b-9f91-a6599032a48d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4712279a-ae45-488c-870a-0187201c860f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4712279a-ae45-488c-870a-0187201c860f.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature.\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -12258,7 +12258,7 @@
         },
         {
             "id": "532095d3-6343-5cfa-ba08-e2dcfa429e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a758d38-adfe-4894-bf27-d988a228e944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a758d38-adfe-4894-bf27-d988a228e944.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -12297,7 +12297,7 @@
         },
         {
             "id": "3109baae-41da-5a46-bef1-f2072259b7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d60a4-af43-4a2e-98b5-1098478eeb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d60a4-af43-4a2e-98b5-1098478eeb02.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G}\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "ba65cbb8-1ac2-582b-be80-5c06b87e3a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f978b9-d464-42f7-ba8b-0c0795d54cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f978b9-d464-42f7-ba8b-0c0795d54cb5.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "7a90bef0-0807-5a74-aa5d-6895b3029592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8e016-2b68-43d1-b25a-553bad97e431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8e016-2b68-43d1-b25a-553bad97e431.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G}\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -12413,7 +12413,7 @@
         },
         {
             "id": "6bebfc53-0e12-55e1-ab3b-e44393232187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8aff7b-bcf4-46a2-a8f5-dc00394a84da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8aff7b-bcf4-46a2-a8f5-dc00394a84da.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -12454,7 +12454,7 @@
         },
         {
             "id": "47465391-d891-5ee4-b16e-4ec4654be643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6cbde-ce5b-4c25-9a27-715fe7abe4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6cbde-ce5b-4c25-9a27-715fe7abe4e4.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -12494,7 +12494,7 @@
         },
         {
             "id": "b49e1057-3ca1-53d6-8312-51ae49f777e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82000701-d4a8-4f9f-a4b0-236858c84954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82000701-d4a8-4f9f-a4b0-236858c84954.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -12535,7 +12535,7 @@
         },
         {
             "id": "ffc6ed37-193e-5c7c-879f-9e5793f6228b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4574869-9598-4295-bd43-ce3633e0d8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4574869-9598-4295-bd43-ce3633e0d8e6.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -12576,7 +12576,7 @@
         },
         {
             "id": "c3b37d34-addd-5d3b-a78e-cc94ed54239e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a81bf-f63c-40ca-a4da-db68df3f3e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a81bf-f63c-40ca-a4da-db68df3f3e1a.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -12618,7 +12618,7 @@
         },
         {
             "id": "117fe230-6a8a-5fc1-aa6e-b09932932a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ead92-1d35-495c-8ee8-14d73e9f1437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099ead92-1d35-495c-8ee8-14d73e9f1437.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -12659,7 +12659,7 @@
         },
         {
             "id": "db81021e-356c-5d8c-8b25-0efb2284bd89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa0bc1-3c31-4886-bfd2-f1ab6e048559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa0bc1-3c31-4886-bfd2-f1ab6e048559.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -12700,7 +12700,7 @@
         },
         {
             "id": "e8cd8100-61bb-5e57-b6e5-cdd67635354b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cdbb98-a5b8-4b9e-aaaa-457eb9d4041e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cdbb98-a5b8-4b9e-aaaa-457eb9d4041e.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike, prowess\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -12741,7 +12741,7 @@
         },
         {
             "id": "21ace97a-136d-506b-9ef9-a68c8afef57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43655ecc-af27-494f-bee7-a5542cae9b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43655ecc-af27-494f-bee7-a5542cae9b54.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -12783,7 +12783,7 @@
         },
         {
             "id": "f4288e40-47be-51d3-aa4c-8046625be5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440766a6-5820-4248-ad91-4d946235e136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440766a6-5820-4248-ad91-4d946235e136.jpg?1",
             "name": "Basri, Tomorrow's Champion",
             "text": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink.\nCycling {2}{W}\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -12823,7 +12823,7 @@
         },
         {
             "id": "11409dde-0316-581c-a7bd-74f32d628c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d0d849-d400-43fc-a42a-0eeb27131d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d0d849-d400-43fc-a42a-0eeb27131d1b.jpg?1",
             "name": "Vnwxt, Verbose Host",
             "text": "Start your engines\nYou have no maximum hand size.\nMax speed \u2014 If you would draw a card, draw two cards instead.",
             "colours": [
@@ -12862,7 +12862,7 @@
         },
         {
             "id": "dff1c1f2-17e9-562e-9f6e-5fb252eed582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a867af-cf5d-4e3d-bba1-361e3cfeca82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a867af-cf5d-4e3d-bba1-361e3cfeca82.jpg?1",
             "name": "Gonti, Night Minister",
             "text": "Whenever a player casts a spell they don't own, that player creates a Treasure token.\nWhenever a creature deals combat damage to one of your opponents, its controller looks at the top card of that opponent's library and exiles it face down. They may play that card for as long as it remains exiled. Mana of any type can be spent to cast a spell this way.",
             "colours": [
@@ -12902,7 +12902,7 @@
         },
         {
             "id": "4589f7f6-a0de-5051-b802-e4fc829707b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993ac84-304a-4e42-aa39-b72be30471ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993ac84-304a-4e42-aa39-b72be30471ea.jpg?1",
             "name": "Daretti, Rocketeer Engineer",
             "text": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
             "colours": [
@@ -12942,7 +12942,7 @@
         },
         {
             "id": "d30a4627-9918-59bb-8cd3-f85575583107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b47651-5607-40b0-9e73-ad356b10acc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b47651-5607-40b0-9e73-ad356b10acc9.jpg?1",
             "name": "Oviya, Automech Artisan",
             "text": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
             "colours": [
@@ -12982,7 +12982,7 @@
         },
         {
             "id": "365b3890-cb47-52f4-b57a-1e297772b34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789df76-d658-47a4-9efb-74da6bd8821c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789df76-d658-47a4-9efb-74da6bd8821c.jpg?1",
             "name": "Aatchik, Emerald Radian",
             "text": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
             "colours": [
@@ -13024,7 +13024,7 @@
         },
         {
             "id": "357b6e6d-4253-53bb-a7b8-f17339bf0a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0f937-5519-4d38-9fc3-46460669bb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0f937-5519-4d38-9fc3-46460669bb86.jpg?1",
             "name": "Captain Howler, Sea Scourge",
             "text": "Ward\u2014{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
             "colours": [
@@ -13066,7 +13066,7 @@
         },
         {
             "id": "7b99ba9c-d314-5084-b592-01bcb81af155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bca478-48c0-4c39-95ae-ba8afb207153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bca478-48c0-4c39-95ae-ba8afb207153.jpg?1",
             "name": "Caradora, Heart of Alacria",
             "text": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -13108,7 +13108,7 @@
         },
         {
             "id": "cb779f42-dafb-5a85-97f9-583717600d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0bd239-25ae-496e-9be2-c2d968dc9346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0bd239-25ae-496e-9be2-c2d968dc9346.jpg?1",
             "name": "Far Fortune, End Boss",
             "text": "Start your engines\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed \u2014 If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -13150,7 +13150,7 @@
         },
         {
             "id": "c1cefff2-5707-54c4-996e-27a0bec43515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33887384-a2bb-4daf-b932-a4259c93b808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33887384-a2bb-4daf-b932-a4259c93b808.jpg?1",
             "name": "Kolodin, Triumph Caster",
             "text": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "e99b7dda-d75c-5141-9cf7-c42967efc2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11d7a7-72e9-406e-a701-5c3a556a43e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11d7a7-72e9-406e-a701-5c3a556a43e0.jpg?1",
             "name": "Mendicant Core, Guidelight",
             "text": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines\nMax speed \u2014 Whenever you cast an artifact spell, you may pay {1}. If you do, copy it.",
             "colours": [
@@ -13234,7 +13234,7 @@
         },
         {
             "id": "6b056c38-9bca-585c-94ca-e27c6f3c223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56bc66f-12d1-4eae-8de7-2fae34976d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56bc66f-12d1-4eae-8de7-2fae34976d6b.jpg?1",
             "name": "Redshift, Rocketeer Chief",
             "text": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust \u2014 {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield.",
             "colours": [
@@ -13276,7 +13276,7 @@
         },
         {
             "id": "45ef62c7-8cae-50fb-b79e-1fbcc24511cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227036a1-7570-4657-9c0a-635dd6d889e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227036a1-7570-4657-9c0a-635dd6d889e9.jpg?1",
             "name": "Samut, the Driving Force",
             "text": "First strike, vigilance, haste\nStart your engines\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
             "colours": [
@@ -13321,7 +13321,7 @@
         },
         {
             "id": "77ebecd0-c6a4-5139-ad86-c4ef809b7100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119a39ce-80f6-48b3-b159-e5d919d3b617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119a39ce-80f6-48b3-b159-e5d919d3b617.jpg?1",
             "name": "Sita Varma, Masked Racer",
             "text": "Exhaust \u2014 {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.",
             "colours": [
@@ -13363,7 +13363,7 @@
         },
         {
             "id": "1f0e5d5e-71e8-5456-95ee-3bac4c5c9f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa759b-a940-4071-9373-13e6aef62fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa759b-a940-4071-9373-13e6aef62fe4.jpg?1",
             "name": "Winter, Cursed Rider",
             "text": "Ward\u2014\nPay 2 life.\nArtifacts you control have \"Ward\u2014\nPay 2 life.\"\nExhaust \u2014 {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "a6b1ddcb-b64a-533e-b1f2-7e659a32747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004f64-5052-4b1e-8fd8-eda463fbd9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1004f64-5052-4b1e-8fd8-eda463fbd9b7.jpg?1",
             "name": "Zahur, Glory's Past",
             "text": "Start your engines\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed \u2014 Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -13448,7 +13448,7 @@
         },
         {
             "id": "1f5cc599-e2d7-5d1c-bd61-7f562c1ccac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba2edc7-dbc0-4948-9f37-a27a91bdf7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba2edc7-dbc0-4948-9f37-a27a91bdf7b9.jpg?1",
             "name": "Bleachbone Verge",
             "text": "{T}: Add {B}.\n{T}: Add {W}. Activate only if you control a Plains or a Swamp.",
             "colours": [],
@@ -13482,7 +13482,7 @@
         },
         {
             "id": "17d4f88d-be53-5fce-b5be-a59483725941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc6f3-2fdc-4629-84b9-f3707b799460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc6f3-2fdc-4629-84b9-f3707b799460.jpg?1",
             "name": "Riverpyre Verge",
             "text": "{T}: Add {R}.\n{T}: Add {U}. Activate only if you control an Island or a Mountain.",
             "colours": [],
@@ -13516,7 +13516,7 @@
         },
         {
             "id": "bab02f65-4117-5500-8226-60fc2a6d81ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92a7ca5-a25b-4888-a319-6e176ab4d0ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92a7ca5-a25b-4888-a319-6e176ab4d0ce.jpg?1",
             "name": "Sunbillow Verge",
             "text": "{T}: Add {W}.\n{T}: Add {R}. Activate only if you control a Mountain or a Plains.",
             "colours": [],
@@ -13550,7 +13550,7 @@
         },
         {
             "id": "41f1ce00-d0c3-578d-abba-3317eccc5b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ab2fc7-7945-4b49-8ad0-223815d0d2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ab2fc7-7945-4b49-8ad0-223815d0d2c2.jpg?1",
             "name": "Wastewood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {B}. Activate only if you control a Swamp or a Forest.",
             "colours": [],
@@ -13584,7 +13584,7 @@
         },
         {
             "id": "6dfee968-6cba-557b-8cbb-bbd013fba9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38218d0f-4b70-45eb-a753-cdb44f94271c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38218d0f-4b70-45eb-a753-cdb44f94271c.jpg?1",
             "name": "Willowrush Verge",
             "text": "{T}: Add {U}.\n{T}: Add {G}. Activate only if you control a Forest or an Island.",
             "colours": [],
@@ -13618,7 +13618,7 @@
         },
         {
             "id": "b77bd321-60d8-52c4-a45a-313624edc21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934cc1ca-2ce8-4062-b1b7-1976e76da8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934cc1ca-2ce8-4062-b1b7-1976e76da8b6.jpg?1",
             "name": "The Aetherspark",
             "text": "",
             "colours": [],
@@ -13653,7 +13653,7 @@
         },
         {
             "id": "0368dc3f-fc0b-5c37-abfd-7004e629cb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1edff87-8563-4cb5-ab9b-7696e920346a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1edff87-8563-4cb5-ab9b-7696e920346a.jpg?1",
             "name": "Perilous Snare",
             "text": "Start your engines\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed \u2014 {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "605c7dd2-4597-5954-a077-dfb07363a5b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b513dfeb-d7c8-4e4d-b419-f67b45608b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b513dfeb-d7c8-4e4d-b419-f67b45608b4b.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2}",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "70059c65-75a0-57ae-8c75-e53a692ac49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4797dcb-507f-4219-95ff-994e2c0d251b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4797dcb-507f-4219-95ff-994e2c0d251b.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -13768,7 +13768,7 @@
         },
         {
             "id": "a8e34bf7-0b0d-5a42-9631-7a7681302454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231c4f52-5a12-407f-9917-d2ca91ba4706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231c4f52-5a12-407f-9917-d2ca91ba4706.jpg?1",
             "name": "Repurposing Bay",
             "text": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -13803,7 +13803,7 @@
         },
         {
             "id": "59a8950d-31df-565f-8a00-a5652dc01ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131df43b-2a72-4ca3-8aae-c0dca2eca8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131df43b-2a72-4ca3-8aae-c0dca2eca8fc.jpg?1",
             "name": "Riverchurn Monument",
             "text": "{1}, {T}: Any number of target players each mill two cards.\nExhaust \u2014 {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard.",
             "colours": [
@@ -13838,7 +13838,7 @@
         },
         {
             "id": "70af41fe-900e-5972-9c4f-0cd4f8940467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce40ff0e-04ae-4786-ac0c-54a66ffb48a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce40ff0e-04ae-4786-ac0c-54a66ffb48a6.jpg?1",
             "name": "Unstoppable Plan",
             "text": "At the beginning of your end step, untap all nonland permanents you control.",
             "colours": [
@@ -13873,7 +13873,7 @@
         },
         {
             "id": "8928f818-9372-5d3e-bcb8-b578e9e6ee12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57479-6409-49e1-8896-2bd3e88d554d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a57479-6409-49e1-8896-2bd3e88d554d.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
             "colours": [
@@ -13910,7 +13910,7 @@
         },
         {
             "id": "01036828-d5f6-550c-81b7-b26d3093fe99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6498f0-5ebd-441a-a851-461b0460e7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6498f0-5ebd-441a-a851-461b0460e7d5.jpg?1",
             "name": "Quag Feast",
             "text": "Choose target creature, planeswalker, or Vehicle. Mill two cards, then destroy the chosen permanent if its mana value is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "f50fe125-7ff3-53aa-a7f7-f3bdfa379546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2abab5-c4f0-41ec-ae6f-e42721ca2cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2abab5-c4f0-41ec-ae6f-e42721ca2cfd.jpg?1",
             "name": "Count on Luck",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "166736d6-cbf8-5f4f-92c1-57e816ba8caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7967282-ae00-4fdd-85c6-bcc8bc9b790b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7967282-ae00-4fdd-85c6-bcc8bc9b790b.jpg?1",
             "name": "Full Throttle",
             "text": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
             "colours": [
@@ -14015,7 +14015,7 @@
         },
         {
             "id": "817b6ed1-d9e5-5b7a-a42d-66e141d7b1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe531a-f1f9-46d4-aff4-2b0df789be66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe531a-f1f9-46d4-aff4-2b0df789be66.jpg?1",
             "name": "Afterburner Expert",
             "text": "Exhaust \u2014 {2}{G}{G}: Put two +1/+1 counters on this creature.\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -14053,7 +14053,7 @@
         },
         {
             "id": "6533486e-e2fd-577a-a51c-5356aea4d95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615e3ebb-c41a-497a-b71b-6549366e5b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615e3ebb-c41a-497a-b71b-6549366e5b07.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -14090,7 +14090,7 @@
         },
         {
             "id": "ab5a75bd-b6e2-5d9c-a5dd-4e44047e8545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a198715-4f82-409d-add0-e0200a88d708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a198715-4f82-409d-add0-e0200a88d708.jpg?1",
             "name": "Regal Imperiosaur",
             "text": "Other Dinosaurs you control get +1/+1.",
             "colours": [
@@ -14127,7 +14127,7 @@
         },
         {
             "id": "64de4cf4-60bb-5254-b3ca-6a6076bdc2f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258dcf4-b481-4ad5-96ef-2a42de8c9c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258dcf4-b481-4ad5-96ef-2a42de8c9c2a.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -14166,7 +14166,7 @@
         },
         {
             "id": "1bf08fd4-ddbc-5211-ac44-05ef10177d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2528d058-5ca3-4671-8bf1-c8161872cd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2528d058-5ca3-4671-8bf1-c8161872cd36.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color.\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -14212,7 +14212,7 @@
         },
         {
             "id": "1c372a2f-2d80-578c-ba48-968899d76fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115088f3-9fca-4120-8ca5-c124c3d32975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115088f3-9fca-4120-8ca5-c124c3d32975.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -14257,7 +14257,7 @@
         },
         {
             "id": "d5ecbb84-6325-558b-a583-d572293662bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93211140-5aa7-4700-804d-aa46a8b141d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93211140-5aa7-4700-804d-aa46a8b141d7.jpg?1",
             "name": "Marketback Walker",
             "text": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
             "colours": [],
@@ -14291,7 +14291,7 @@
         },
         {
             "id": "cb1e4f3d-0665-5fa1-aeb3-d67a636828eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cbdac-1d15-40f5-b76f-6f21b917abbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66cbdac-1d15-40f5-b76f-6f21b917abbc.jpg?1",
             "name": "Monument to Endurance",
             "text": "Whenever you discard a card, choose one that hasn't been chosen this turn \u2014\n\u2022 Draw a card.\n\u2022 Create a Treasure token.\n\u2022 Each opponent loses 3 life.",
             "colours": [],
@@ -14322,7 +14322,7 @@
         },
         {
             "id": "fc0d11c8-6e5a-5a8e-a0f6-bd55c991dfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef84601-6ace-4847-abeb-16dcfdba5c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef84601-6ace-4847-abeb-16dcfdba5c89.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "3879cbbd-ef4c-53d8-a8c5-a72db0705999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b87e12-bd95-450e-a528-a44c76dbfae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b87e12-bd95-450e-a528-a44c76dbfae5.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -14387,7 +14387,7 @@
         },
         {
             "id": "b61a5c3a-ae15-5303-98a9-fb70813bd842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cb1b9-38b7-42ad-b176-dc265bc8abe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cb1b9-38b7-42ad-b176-dc265bc8abe0.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -14426,7 +14426,7 @@
         },
         {
             "id": "ef20d586-edbb-51da-a771-93ec5078a65a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec93ed6d-a840-477d-a16c-ffd15a52c941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec93ed6d-a840-477d-a16c-ffd15a52c941.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2}",
             "colours": [
@@ -14462,7 +14462,7 @@
         },
         {
             "id": "8cf3bb04-f511-5fa0-8391-ede619f502d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe19f52-ae23-4a23-800d-f3cf186279f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe19f52-ae23-4a23-800d-f3cf186279f2.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -14504,7 +14504,7 @@
         },
         {
             "id": "d7b97010-f41a-5bc5-ad3f-4193bc62eece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5280941-bcda-4ac7-97d1-db02c7a18ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5280941-bcda-4ac7-97d1-db02c7a18ef9.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
             "colours": [
@@ -14540,7 +14540,7 @@
         },
         {
             "id": "7424b09b-9029-5111-bc05-5a92a454c239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1864b99-6893-4e4d-94de-641837c05da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1864b99-6893-4e4d-94de-641837c05da3.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n\u22127: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
             "colours": [
@@ -14579,7 +14579,7 @@
         },
         {
             "id": "d33b8330-0780-5814-9ecb-c6ae7a45b03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455027f1-26a4-464b-a456-271a6ec88669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455027f1-26a4-464b-a456-271a6ec88669.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -14615,7 +14615,7 @@
         },
         {
             "id": "fbd8f46d-b5ec-5dfa-9497-51595884ab97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a81f86-e80f-47f7-81cd-0c4b9330e646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a81f86-e80f-47f7-81cd-0c4b9330e646.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -14653,7 +14653,7 @@
         },
         {
             "id": "dedd5e67-16aa-5bf4-97e3-05659672991f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b04ab-4c61-47f5-88e4-c5c2f93edc11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b04ab-4c61-47f5-88e4-c5c2f93edc11.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color.\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -14698,7 +14698,7 @@
         },
         {
             "id": "2abd36d5-1c61-5319-8720-1c1991931acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8caa7-714e-4987-8d44-04fbe5a77c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8caa7-714e-4987-8d44-04fbe5a77c6d.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -14742,7 +14742,7 @@
         },
         {
             "id": "a02dfc12-6ed0-5357-892e-21e028cb3bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb85966-66a2-4fb7-b89d-05db7f4e2cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb85966-66a2-4fb7-b89d-05db7f4e2cb8.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -14774,7 +14774,7 @@
         },
         {
             "id": "1192181e-cce4-5dfe-8c23-d3fb989e806f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e73d4ed-def7-4456-a750-74fb2bf10f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e73d4ed-def7-4456-a750-74fb2bf10f9f.jpg?1",
             "name": "Salvation Engine",
             "text": "",
             "colours": [
@@ -14813,7 +14813,7 @@
         },
         {
             "id": "1652d071-0aba-5b4f-b34c-492c6ee3d62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fd4f1b-afbd-41a5-a76a-f9788e0cec9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fd4f1b-afbd-41a5-a76a-f9788e0cec9d.jpg?1",
             "name": "Spectacular Pileup",
             "text": "",
             "colours": [
@@ -14849,7 +14849,7 @@
         },
         {
             "id": "2cb62647-8d17-5a1c-ae86-f6878be72004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8327b4b6-058e-448b-99ca-7d2de52d3b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8327b4b6-058e-448b-99ca-7d2de52d3b4c.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "",
             "colours": [
@@ -14891,7 +14891,7 @@
         },
         {
             "id": "9b47cfe0-e540-59cf-83ba-11b7d41da39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c15a04e-b0a7-4560-a838-94213dbb2336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c15a04e-b0a7-4560-a838-94213dbb2336.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "",
             "colours": [
@@ -14927,7 +14927,7 @@
         },
         {
             "id": "3441bfa2-d573-52be-8a10-57e817efd8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a40fa6-4378-413b-bed8-7eb0d61b70ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a40fa6-4378-413b-bed8-7eb0d61b70ad.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "",
             "colours": [
@@ -14966,7 +14966,7 @@
         },
         {
             "id": "03f0456c-5e60-5523-a8a2-1d6feda7b2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9fbbfc-8920-46cd-95cd-2372feb4617a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9fbbfc-8920-46cd-95cd-2372feb4617a.jpg?1",
             "name": "March of the World Ooze",
             "text": "",
             "colours": [
@@ -15002,7 +15002,7 @@
         },
         {
             "id": "fc1da485-5e29-52de-beee-b18e587a2296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd66b9-f292-4b10-b753-2df112f6f714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd66b9-f292-4b10-b753-2df112f6f714.jpg?1",
             "name": "Explosive Getaway",
             "text": "",
             "colours": [
@@ -15040,7 +15040,7 @@
         },
         {
             "id": "5766cde6-8c88-5510-95be-d962530575bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fba04a-20ab-40eb-9edf-89fdd03bfb7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fba04a-20ab-40eb-9edf-89fdd03bfb7e.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "",
             "colours": [
@@ -15085,7 +15085,7 @@
         },
         {
             "id": "ea185248-b981-57fc-a31c-d8af2ddf7aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b243165-79ad-4193-af89-2ad5e34fc415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b243165-79ad-4193-af89-2ad5e34fc415.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "",
             "colours": [
@@ -15129,7 +15129,7 @@
         },
         {
             "id": "0fc05fc9-27e0-5827-b6b0-168f543416b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656ba742-b00f-4fce-8418-987226c25a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/656ba742-b00f-4fce-8418-987226c25a81.jpg?1",
             "name": "Radiant Lotus",
             "text": "",
             "colours": [],
@@ -15161,7 +15161,7 @@
         },
         {
             "id": "3f3f4e7b-2cd5-5417-ac88-71adb7c65508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b832719-ac31-470f-9d50-0b514ecc6845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b832719-ac31-470f-9d50-0b514ecc6845.jpg?1",
             "name": "Tune Up",
             "text": "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.",
             "colours": [
@@ -15195,7 +15195,7 @@
         },
         {
             "id": "37fa87a1-c41f-5ff0-b2da-299fe2a6d45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b12dd-2ce3-48a6-9ea7-7d5f155164c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b12dd-2ce3-48a6-9ea7-7d5f155164c9.jpg?1",
             "name": "Gastal Raider",
             "text": "Start your engines\nWhen this creature enters, target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.\nMax speed \u2014 This creature gets +1/+1 and has menace.",
             "colours": [
@@ -15232,7 +15232,7 @@
         },
         {
             "id": "5dbbaccc-07d5-5008-b481-fd653d9663ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ebb23-fecd-4aa5-96b7-447c9768794e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ebb23-fecd-4aa5-96b7-447c9768794e.jpg?1",
             "name": "Marauding Mako",
             "text": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2}",
             "colours": [
@@ -15269,7 +15269,7 @@
         },
         {
             "id": "5db03f2f-b157-5264-ad15-3ae90190db33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7de8c7e-7270-4a4f-af03-9f088b04c05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7de8c7e-7270-4a4f-af03-9f088b04c05b.jpg?1",
             "name": "Skyserpent Seeker",
             "text": "Flying, deathtouch\nExhaust \u2014 {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature.",
             "colours": [
@@ -15307,7 +15307,7 @@
         },
         {
             "id": "44b18675-2107-5b70-86a1-5bdd5e14911f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30789c9b-7b4b-43e7-a161-aa6595ea9dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30789c9b-7b4b-43e7-a161-aa6595ea9dee.jpg?1",
             "name": "Voyage Home",
             "text": "Affinity for artifacts\nYou draw three cards and gain 3 life.",
             "colours": [
@@ -15343,7 +15343,7 @@
         },
         {
             "id": "3393a82d-6427-5e80-ac12-c9838730bbc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a85032-0c45-40f7-901a-3fd77ff212a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a85032-0c45-40f7-901a-3fd77ff212a4.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -15381,7 +15381,7 @@
         },
         {
             "id": "01165481-6e23-53db-8a2b-281c7a4e3310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eda600-af1e-4444-a822-830037133c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eda600-af1e-4444-a822-830037133c0d.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -15415,7 +15415,7 @@
         },
         {
             "id": "50bdfb6b-bcda-5b60-b015-5289fc10d493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37d984-5a9c-45e3-8213-4af93872d512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37d984-5a9c-45e3-8213-4af93872d512.jpg?1",
             "name": "Amonkhet Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Target creature gains haste until end of turn.",
             "colours": [],
@@ -15444,7 +15444,7 @@
         },
         {
             "id": "a42e0ca9-0b7d-5fb9-b0b9-64d92a391a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e9b236-f0e5-4e9d-a9c9-7d625e8412f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e9b236-f0e5-4e9d-a9c9-7d625e8412f2.jpg?1",
             "name": "Avishkar Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {3}, {T}, Discard a card: Draw a card.",
             "colours": [],
@@ -15473,7 +15473,7 @@
         },
         {
             "id": "5b99b7b2-8062-5bc8-aad2-57df0122ffe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db48a2f-5110-431e-8d72-b70bd2e9d887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db48a2f-5110-431e-8d72-b70bd2e9d887.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -15504,7 +15504,7 @@
         },
         {
             "id": "9f7491e8-6740-5884-9804-9e075d0ee351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d4e0c-2653-4353-8e70-b7cf0f6808ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d4e0c-2653-4353-8e70-b7cf0f6808ed.jpg?1",
             "name": "Basri, Tomorrow's Champion",
             "text": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink.\nCycling {2}{W}\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -15543,7 +15543,7 @@
         },
         {
             "id": "eaf1cb6a-f25c-53b2-ad79-80cd006db322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146670b1-0b6d-4d9b-b931-137c508309a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146670b1-0b6d-4d9b-b931-137c508309a9.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1",
             "colours": [
@@ -15581,7 +15581,7 @@
         },
         {
             "id": "93dbab40-85e3-590f-8291-d1fc6f2dabf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6b0d3e-0d3e-44a7-99e3-4ccba6c832e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6b0d3e-0d3e-44a7-99e3-4ccba6c832e1.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -15619,7 +15619,7 @@
         },
         {
             "id": "7ee2b117-1049-5399-859e-16f0a1bb06af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87181867-f63d-4642-875f-001c1ed7912f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87181867-f63d-4642-875f-001c1ed7912f.jpg?1",
             "name": "Perilous Snare",
             "text": "Start your engines\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed \u2014 {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
             "colours": [
@@ -15653,7 +15653,7 @@
         },
         {
             "id": "3cd3ba2e-febf-5fc6-b00f-416088e948df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f338af2-f173-45a0-bbea-02517d41bef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f338af2-f173-45a0-bbea-02517d41bef2.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "4cd356ef-524b-5213-9ca6-a1ef278cd39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a062cbd-b769-49d3-a9fd-7aeb414f44d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a062cbd-b769-49d3-a9fd-7aeb414f44d6.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -15729,7 +15729,7 @@
         },
         {
             "id": "9b1c54f6-abcd-50bc-bb37-b4596730080b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21406e-0c00-4501-a93e-ccd8172314e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21406e-0c00-4501-a93e-ccd8172314e8.jpg?1",
             "name": "Spectacular Pileup",
             "text": "All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.\nCycling {2}",
             "colours": [
@@ -15765,7 +15765,7 @@
         },
         {
             "id": "499c4ca8-f64e-5e3c-9b68-707ad756020d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f73b484-1503-4899-8b6a-076e8b087810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f73b484-1503-4899-8b6a-076e8b087810.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W}\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -15804,7 +15804,7 @@
         },
         {
             "id": "b43f2389-8af6-5b4d-b5fb-2630fd45cde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559dd83b-f24a-43e7-9195-9fcbe6c0c64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559dd83b-f24a-43e7-9195-9fcbe6c0c64b.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -15841,7 +15841,7 @@
         },
         {
             "id": "a94fd4a7-033a-5890-8320-3bdbd8f955a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e15402-8cc6-4ad2-8088-4df92fa20d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e15402-8cc6-4ad2-8088-4df92fa20d8e.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.",
             "colours": [
@@ -15879,7 +15879,7 @@
         },
         {
             "id": "f258d2ee-201e-5281-9154-bd5d1d863751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d45912-7b8d-416e-893b-1d103492a5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d45912-7b8d-416e-893b-1d103492a5a1.jpg?1",
             "name": "Mu Yanling, Wind Rider",
             "text": "When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
             "colours": [
@@ -15921,7 +15921,7 @@
         },
         {
             "id": "f26b3b72-5424-5e23-8984-dd562986bb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858dc258-965a-4d1a-aab5-447e0fecbf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858dc258-965a-4d1a-aab5-447e0fecbf81.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -15958,7 +15958,7 @@
         },
         {
             "id": "0fff5efd-bdc2-55ca-8064-72d1caf341a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277eeef-50af-4654-9216-caf0c37c27d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277eeef-50af-4654-9216-caf0c37c27d7.jpg?1",
             "name": "Repurposing Bay",
             "text": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -15992,7 +15992,7 @@
         },
         {
             "id": "6ec90c7a-ebbe-5937-9e56-455f3c9a5e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d22866-07ac-4aef-b43e-29a37f3db1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d22866-07ac-4aef-b43e-29a37f3db1c0.jpg?1",
             "name": "Riverchurn Monument",
             "text": "{1}, {T}: Any number of target players each mill two cards.\nExhaust \u2014 {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard.",
             "colours": [
@@ -16026,7 +16026,7 @@
         },
         {
             "id": "2c581cad-8fb0-5fd8-b46f-5695bd76fae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98ff182-4a84-4d69-83ce-57a7e5b18ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98ff182-4a84-4d69-83ce-57a7e5b18ebb.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -16063,7 +16063,7 @@
         },
         {
             "id": "f14b0e16-2ca0-5ee8-b819-29658268a1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a95aeb-b1b0-42cd-ad67-fd13717d3c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a95aeb-b1b0-42cd-ad67-fd13717d3c6c.jpg?1",
             "name": "Unstoppable Plan",
             "text": "At the beginning of your end step, untap all nonland permanents you control.",
             "colours": [
@@ -16097,7 +16097,7 @@
         },
         {
             "id": "54d12e04-49be-57fc-b826-3583916f9d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642f9db-3eee-471d-ada6-60e990ec3fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642f9db-3eee-471d-ada6-60e990ec3fab.jpg?1",
             "name": "Vnwxt, Verbose Host",
             "text": "Start your engines\nYou have no maximum hand size.\nMax speed \u2014 If you would draw a card, draw two cards instead.",
             "colours": [
@@ -16135,7 +16135,7 @@
         },
         {
             "id": "0c495b6a-4c77-522a-bcd8-310f0d8a1645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb17c37c-907d-4416-b8c1-d6a6f4e312f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb17c37c-907d-4416-b8c1-d6a6f4e312f3.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2}",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "aa1438ab-d452-567a-8236-a692731bfeb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77534750-fa92-42b4-8f32-be437eca64ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77534750-fa92-42b4-8f32-be437eca64ad.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -16210,7 +16210,7 @@
         },
         {
             "id": "7924ab03-b7d8-5400-ba1d-40b1d9f67026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de65f4cd-3ba4-4e1a-8810-e43cf26b38a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de65f4cd-3ba4-4e1a-8810-e43cf26b38a4.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -16247,7 +16247,7 @@
         },
         {
             "id": "8ffce128-74b8-59df-b182-124b95dc5b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b283c18-abe7-4b73-8532-dd76a85fabd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b283c18-abe7-4b73-8532-dd76a85fabd6.jpg?1",
             "name": "Cursecloth Wrappings",
             "text": "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
             "colours": [
@@ -16283,7 +16283,7 @@
         },
         {
             "id": "506e773c-c136-551e-8fd2-1a0a238f81e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0eb3de-796d-4da3-aab3-08c2b5b6943d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0eb3de-796d-4da3-aab3-08c2b5b6943d.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -16320,7 +16320,7 @@
         },
         {
             "id": "5be6a922-1230-5d5a-80d3-b767d1d310a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e8e6d0-d155-49da-ac5b-47fb408202e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e8e6d0-d155-49da-ac5b-47fb408202e6.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "88b66702-7b5f-56bb-943d-a872aca52579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed5dd3-e67b-4425-bb98-6b07db1e9d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ed5dd3-e67b-4425-bb98-6b07db1e9d1f.jpg?1",
             "name": "Gonti, Night Minister",
             "text": "Whenever a player casts a spell they don't own, that player creates a Treasure token.\nWhenever a creature deals combat damage to one of your opponents, its controller looks at the top card of that opponent's library and exiles it face down. They may play that card for as long as it remains exiled. Mana of any type can be spent to cast a spell this way.",
             "colours": [
@@ -16397,7 +16397,7 @@
         },
         {
             "id": "8c87ab57-75f2-580f-b5a3-c0fe76195750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a901a616-b8bb-4e10-9886-ee9c6fdc6435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a901a616-b8bb-4e10-9886-ee9c6fdc6435.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -16436,7 +16436,7 @@
         },
         {
             "id": "596ff515-107e-59e1-9dca-e7b6b586bcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8684d080-070c-4419-9cc8-777500573f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8684d080-070c-4419-9cc8-777500573f55.jpg?1",
             "name": "Quag Feast",
             "text": "Choose target creature, planeswalker, or Vehicle. Mill two cards, then destroy the chosen permanent if its mana value is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -16470,7 +16470,7 @@
         },
         {
             "id": "b5a3d74f-2f9c-5173-a457-2903ae53c927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8a7c1f-9d05-4a4c-bdf2-cd9ee7ed18a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8a7c1f-9d05-4a4c-bdf2-cd9ee7ed18a5.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -16509,7 +16509,7 @@
         },
         {
             "id": "816f79b9-690f-513e-b57a-37e0e3cf29a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1bff20-0b7a-49f9-b967-773f3043be13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1bff20-0b7a-49f9-b967-773f3043be13.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.\nCrew 2",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "14c886ae-918a-5d62-a08c-b2716f2ccb95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c9b613-1494-4df0-9a38-cc0a69fd3945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c9b613-1494-4df0-9a38-cc0a69fd3945.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -16584,7 +16584,7 @@
         },
         {
             "id": "d7c1e945-c039-5422-9957-b7ef7fddb860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b175a-b63f-46d1-a7e1-95dfc7c03e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b175a-b63f-46d1-a7e1-95dfc7c03e3f.jpg?1",
             "name": "Chandra, Spark Hunter",
             "text": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n\u22127: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
             "colours": [
@@ -16623,7 +16623,7 @@
         },
         {
             "id": "a4bbe32a-5d47-5bc8-a9c8-a5961b14ae17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee38fa7-d5c8-4f76-92f8-4c5cb5bae5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee38fa7-d5c8-4f76-92f8-4c5cb5bae5e7.jpg?1",
             "name": "Count on Luck",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "dee704a2-d026-500e-b873-886e8d19a73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a17ef59-177c-4c39-8cbb-efa8ab7ac24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a17ef59-177c-4c39-8cbb-efa8ab7ac24a.jpg?1",
             "name": "Daretti, Rocketeer Engineer",
             "text": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
             "colours": [
@@ -16696,7 +16696,7 @@
         },
         {
             "id": "f3095a82-d848-591d-a7ca-d60be8bbcd25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7758b89f-9629-45f9-ad37-6435dba37997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7758b89f-9629-45f9-ad37-6435dba37997.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature.\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -16734,7 +16734,7 @@
         },
         {
             "id": "1491d161-8e33-5074-a1e4-2bd1e29f2ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf1b29-5a8a-4ac1-aa17-58fcbda969a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bf1b29-5a8a-4ac1-aa17-58fcbda969a2.jpg?1",
             "name": "Full Throttle",
             "text": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
             "colours": [
@@ -16768,7 +16768,7 @@
         },
         {
             "id": "cce2a720-6e6b-5b60-af5c-d1aff59e8201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a80bb9d-da0d-4f98-8946-43513db4aef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a80bb9d-da0d-4f98-8946-43513db4aef6.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -16805,7 +16805,7 @@
         },
         {
             "id": "58b21b6d-05c0-5984-9b2b-1c0abb586551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bbbcb2-822f-4729-872b-20638e7ad155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bbbcb2-822f-4729-872b-20638e7ad155.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -16844,7 +16844,7 @@
         },
         {
             "id": "80e96d18-e02d-5933-86f4-3baeeb3ba42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28b514a-29a1-4d85-8eaa-279f3d7e09c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28b514a-29a1-4d85-8eaa-279f3d7e09c1.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -16882,7 +16882,7 @@
         },
         {
             "id": "e682bb5f-b1ee-5a5f-af9a-c1c3ab2c0a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985ee93-3aeb-4f0d-a6af-686efbcadda4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985ee93-3aeb-4f0d-a6af-686efbcadda4.jpg?1",
             "name": "Afterburner Expert",
             "text": "Exhaust \u2014 {2}{G}{G}: Put two +1/+1 counters on this creature.\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -16919,7 +16919,7 @@
         },
         {
             "id": "9968e5fa-c5f9-574c-9c36-986894cf3906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc56fc-8c82-4d74-8119-5d260c691b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fc56fc-8c82-4d74-8119-5d260c691b36.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G}\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -16956,7 +16956,7 @@
         },
         {
             "id": "b863bdbf-bf3e-588d-8224-81f674befe40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7926c8-1a46-4edb-950b-2c8bac91b476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7926c8-1a46-4edb-950b-2c8bac91b476.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -16994,7 +16994,7 @@
         },
         {
             "id": "02cbe60c-c728-5ede-977a-e4cafaa2deea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb97f9f-e7be-4794-a3a0-a0d73445c8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb97f9f-e7be-4794-a3a0-a0d73445c8fe.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -17032,7 +17032,7 @@
         },
         {
             "id": "bacae49a-b8fa-5477-89cf-fe04b05576f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89e403b-9653-493f-a3ac-e01aa6f006e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89e403b-9653-493f-a3ac-e01aa6f006e2.jpg?1",
             "name": "March of the World Ooze",
             "text": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
             "colours": [
@@ -17068,7 +17068,7 @@
         },
         {
             "id": "6a8f7602-4bb0-554b-a17d-5b4cc36a9f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6eae8b-73de-4d79-bbe5-2921db1987b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6eae8b-73de-4d79-bbe5-2921db1987b2.jpg?1",
             "name": "Oviya, Automech Artisan",
             "text": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
             "colours": [
@@ -17107,7 +17107,7 @@
         },
         {
             "id": "2b2caa84-f296-5c04-bf94-6de45f583b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72328b4-19d1-4855-aa0d-331321eb9945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72328b4-19d1-4855-aa0d-331321eb9945.jpg?1",
             "name": "Regal Imperiosaur",
             "text": "Other Dinosaurs you control get +1/+1.",
             "colours": [
@@ -17143,7 +17143,7 @@
         },
         {
             "id": "d28e44d9-155a-5935-b2f7-b45a620b5711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63dc8cd-34a7-43ea-a422-3ced3c11f5be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63dc8cd-34a7-43ea-a422-3ced3c11f5be.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -17180,7 +17180,7 @@
         },
         {
             "id": "0b3f221b-3446-5ff0-878f-fbf6294ed42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c14636-3ff0-4fbf-9df1-1b6d3d52e29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c14636-3ff0-4fbf-9df1-1b6d3d52e29e.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G}\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -17218,7 +17218,7 @@
         },
         {
             "id": "543b5be7-6f39-550d-a58a-f29d1fa24e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71074080-d83d-4b4a-b385-f918186530b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71074080-d83d-4b4a-b385-f918186530b4.jpg?1",
             "name": "Aatchik, Emerald Radian",
             "text": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
             "colours": [
@@ -17259,7 +17259,7 @@
         },
         {
             "id": "08c32327-8cd6-5e82-b598-10d47f822511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e29a88-34b6-4c3d-9956-b7eb8d5ef591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e29a88-34b6-4c3d-9956-b7eb8d5ef591.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -17299,7 +17299,7 @@
         },
         {
             "id": "f70d35dd-3629-587c-a211-19aad1a818fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48629b-dc1b-4609-aea2-e4833f66d894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db48629b-dc1b-4609-aea2-e4833f66d894.jpg?1",
             "name": "Captain Howler, Sea Scourge",
             "text": "Ward\u2014{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
             "colours": [
@@ -17340,7 +17340,7 @@
         },
         {
             "id": "afc39f60-209b-5e1a-a746-ea377e038010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bc2ca6-427f-4f07-88b0-cf57a1fe74ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bc2ca6-427f-4f07-88b0-cf57a1fe74ab.jpg?1",
             "name": "Caradora, Heart of Alacria",
             "text": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -17381,7 +17381,7 @@
         },
         {
             "id": "53d2fe86-7a9b-5daf-8370-e22be58f318f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cf7eba-b917-4f14-8bf4-420bb919b7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cf7eba-b917-4f14-8bf4-420bb919b7e5.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -17421,7 +17421,7 @@
         },
         {
             "id": "2d8c7cdd-a810-5473-be9a-bd9de72c250e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92766c53-703d-41a2-ad13-8c366dcf25ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92766c53-703d-41a2-ad13-8c366dcf25ec.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -17460,7 +17460,7 @@
         },
         {
             "id": "141bd371-d840-5aa9-8203-bd85288c0164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a556367e-7db7-47ad-9f10-37d277d80e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a556367e-7db7-47ad-9f10-37d277d80e77.jpg?1",
             "name": "Explosive Getaway",
             "text": "Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nExplosive Getaway deals 4 damage to each creature.",
             "colours": [
@@ -17498,7 +17498,7 @@
         },
         {
             "id": "62a64af1-e9d5-5b50-80aa-50e5af931f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655e0a5-af3e-4720-b4cf-c93ae9c10cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655e0a5-af3e-4720-b4cf-c93ae9c10cac.jpg?1",
             "name": "Far Fortune, End Boss",
             "text": "Start your engines\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed \u2014 If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -17539,7 +17539,7 @@
         },
         {
             "id": "d24e8947-0e19-58c8-86f6-4ebed1f3cd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb615c-e142-4a6e-8d7a-f0a7a3b30568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb615c-e142-4a6e-8d7a-f0a7a3b30568.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -17579,7 +17579,7 @@
         },
         {
             "id": "4aae21bd-7d0d-50e5-ba7b-e651bebac4d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a86678f-e4b4-4c40-9a99-83029fd97730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a86678f-e4b4-4c40-9a99-83029fd97730.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -17620,7 +17620,7 @@
         },
         {
             "id": "7862b83b-8117-5232-be6a-1fbf032305db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46164400-0557-4c99-83d5-194dc814b46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46164400-0557-4c99-83d5-194dc814b46a.jpg?1",
             "name": "Kolodin, Triumph Caster",
             "text": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
             "colours": [
@@ -17661,7 +17661,7 @@
         },
         {
             "id": "e37bbc9c-7c1f-5312-af15-c3bf0ee65e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542fe4ca-d3d8-469c-b5cb-4d0824ba514b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542fe4ca-d3d8-469c-b5cb-4d0824ba514b.jpg?1",
             "name": "Loot, the Pathfinder",
             "text": "Double strike, vigilance, haste\nExhaust \u2014 {G}, {T}: Add three mana of any one color.\nExhaust \u2014 {U}, {T}: Draw three cards.\nExhaust \u2014 {R}, {T}: Loot deals 3 damage to any target.",
             "colours": [
@@ -17706,7 +17706,7 @@
         },
         {
             "id": "20e030f3-dfc8-5099-99a1-b25538b5217b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec057f26-8d14-463b-84ce-cce82b95b08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec057f26-8d14-463b-84ce-cce82b95b08e.jpg?1",
             "name": "Mendicant Core, Guidelight",
             "text": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines\nMax speed \u2014 Whenever you cast an artifact spell, you may pay {1}. If you do, copy it.",
             "colours": [
@@ -17747,7 +17747,7 @@
         },
         {
             "id": "a635fa69-4ac7-550d-9faa-40549dad22b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2976e7e4-c53f-47d5-9890-cd30acad4f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2976e7e4-c53f-47d5-9890-cd30acad4f68.jpg?1",
             "name": "Mimeoplasm, Revered One",
             "text": "As Mimeoplasm enters, exile up to X creature cards from your graveyard. It enters with three +1/+1 counters on it for each creature card exiled this way.\n{2}: Mimeoplasm becomes a copy of target creature card exiled with it, except it's 0/0 and has this ability.",
             "colours": [
@@ -17791,7 +17791,7 @@
         },
         {
             "id": "aa7edc95-ae01-578b-8cce-28734cf8700c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749306b-26ce-4c71-8586-a1ef9788c286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a749306b-26ce-4c71-8586-a1ef9788c286.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -17831,7 +17831,7 @@
         },
         {
             "id": "fc9999a4-a2c4-53cf-937c-0eab0c643884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794b7a29-eb42-4c52-a4d9-3976611efdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794b7a29-eb42-4c52-a4d9-3976611efdd7.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -17871,7 +17871,7 @@
         },
         {
             "id": "b094e30e-ee9c-55ca-bc2f-e31b859f4548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea12cb-c927-44f4-b304-f24919b1104e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea12cb-c927-44f4-b304-f24919b1104e.jpg?1",
             "name": "Redshift, Rocketeer Chief",
             "text": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust \u2014 {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield.",
             "colours": [
@@ -17912,7 +17912,7 @@
         },
         {
             "id": "52d61f58-acba-523b-8414-8e58a3f1853d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d5d0a0-b0ae-4a5c-ace6-77d87fcc8563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d5d0a0-b0ae-4a5c-ace6-77d87fcc8563.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike, prowess\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -17952,7 +17952,7 @@
         },
         {
             "id": "0ab1f293-0d4e-5892-b41f-e65aa377de91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36581aa3-8970-40cc-bd1c-e78787ebe441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36581aa3-8970-40cc-bd1c-e78787ebe441.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -17993,7 +17993,7 @@
         },
         {
             "id": "398586e8-6682-5458-911c-dbce41d2017e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd0f7d-1686-42ae-9bea-66b96309f322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd0f7d-1686-42ae-9bea-66b96309f322.jpg?1",
             "name": "Samut, the Driving Force",
             "text": "First strike, vigilance, haste\nStart your engines\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
             "colours": [
@@ -18037,7 +18037,7 @@
         },
         {
             "id": "fb532920-801a-5bb7-8308-505513869333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d595f-7efe-4004-9bbc-390b5a6eb734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321d595f-7efe-4004-9bbc-390b5a6eb734.jpg?1",
             "name": "Sita Varma, Masked Racer",
             "text": "Exhaust \u2014 {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.",
             "colours": [
@@ -18078,7 +18078,7 @@
         },
         {
             "id": "743213bd-a711-5c0b-9168-000601948c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f93e48d-4681-4354-aa85-493a48287233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f93e48d-4681-4354-aa85-493a48287233.jpg?1",
             "name": "Winter, Cursed Rider",
             "text": "Ward\u2014\nPay 2 life.\nArtifacts you control have \"Ward\u2014\nPay 2 life.\"\nExhaust \u2014 {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.",
             "colours": [
@@ -18119,7 +18119,7 @@
         },
         {
             "id": "42517269-8271-5a3d-8089-0d514ae2213c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10ee92a-85cc-48cb-b0b5-8e5185781fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10ee92a-85cc-48cb-b0b5-8e5185781fb2.jpg?1",
             "name": "Zahur, Glory's Past",
             "text": "Start your engines\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed \u2014 Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -18161,7 +18161,7 @@
         },
         {
             "id": "5f719f2c-fb50-574c-9157-69c700c0b2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea3cfc-64f1-4289-ac6c-82d55bab65de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ea3cfc-64f1-4289-ac6c-82d55bab65de.jpg?1",
             "name": "The Aetherspark",
             "text": "As long as The Aetherspark is attached to a creature, The Aetherspark can't be attacked and has \"Whenever equipped creature deals combat damage during your turn, put that many loyalty counters on The Aetherspark.\"\n+1: Attach The Aetherspark to up to one target creature you control. Put a +1/+1 counter on that creature.\n\u22125: Draw two cards.\n\u221210: Add ten mana of any one color.",
             "colours": [],
@@ -18196,7 +18196,7 @@
         },
         {
             "id": "3a7a00b7-6660-5c3b-ae57-a11a357cd5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c14d4cc-79c3-4934-b7a8-25e1973ffea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c14d4cc-79c3-4934-b7a8-25e1973ffea3.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -18230,7 +18230,7 @@
         },
         {
             "id": "084da9f5-aa42-5867-a0c5-8f024c15a080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20419718-d922-4f3c-aeb2-30ffb2ff7cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20419718-d922-4f3c-aeb2-30ffb2ff7cbb.jpg?1",
             "name": "Marketback Walker",
             "text": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
             "colours": [],
@@ -18263,7 +18263,7 @@
         },
         {
             "id": "74c4f5fb-876d-5dad-87da-8c983d4f5b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75f3b27-7c08-4e92-ae9a-6208aa9aec0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75f3b27-7c08-4e92-ae9a-6208aa9aec0c.jpg?1",
             "name": "Monument to Endurance",
             "text": "Whenever you discard a card, choose one that hasn't been chosen this turn \u2014\n\u2022 Draw a card.\n\u2022 Create a Treasure token.\n\u2022 Each opponent loses 3 life.",
             "colours": [],
@@ -18293,7 +18293,7 @@
         },
         {
             "id": "25621873-eb0c-5926-92c6-95dc20cc8250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333039ef-b328-4082-85ae-162caed5612e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333039ef-b328-4082-85ae-162caed5612e.jpg?1",
             "name": "Radiant Lotus",
             "text": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
             "colours": [],
@@ -18325,7 +18325,7 @@
         },
         {
             "id": "6d99124d-9d48-5791-a1f4-f544956b3baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712aab40-5452-4d62-8ad3-fec96d03db98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712aab40-5452-4d62-8ad3-fec96d03db98.jpg?1",
             "name": "Bleachbone Verge",
             "text": "{T}: Add {B}.\n{T}: Add {W}. Activate only if you control a Plains or a Swamp.",
             "colours": [],
@@ -18358,7 +18358,7 @@
         },
         {
             "id": "79921819-a4c5-59eb-bc21-f45ba3bbf647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6457d47-8e68-42db-85c9-e0f981c53aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6457d47-8e68-42db-85c9-e0f981c53aa4.jpg?1",
             "name": "Muraganda Raceway",
             "text": "Start your engines\n{T}: Add {C}.\nMax speed \u2014 {T}: Add {C}{C}.",
             "colours": [],
@@ -18389,7 +18389,7 @@
         },
         {
             "id": "b8f0e01c-0c26-5f61-be74-ca377a4129fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21462ee-76d7-4910-9a0c-b470f96b8b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21462ee-76d7-4910-9a0c-b470f96b8b51.jpg?1",
             "name": "Riverpyre Verge",
             "text": "{T}: Add {R}.\n{T}: Add {U}. Activate only if you control an Island or a Mountain.",
             "colours": [],
@@ -18422,7 +18422,7 @@
         },
         {
             "id": "913467d6-ab70-54e5-8d33-a528331f093d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff03662-3879-4ca8-b73c-34918194203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff03662-3879-4ca8-b73c-34918194203b.jpg?1",
             "name": "Sunbillow Verge",
             "text": "{T}: Add {W}.\n{T}: Add {R}. Activate only if you control a Mountain or a Plains.",
             "colours": [],
@@ -18455,7 +18455,7 @@
         },
         {
             "id": "7c2d01fa-5309-5135-8f2c-5c406da359da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0c9044-13ae-465e-a9d1-7dc63827540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0c9044-13ae-465e-a9d1-7dc63827540d.jpg?1",
             "name": "Wastewood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {B}. Activate only if you control a Swamp or a Forest.",
             "colours": [],
@@ -18488,7 +18488,7 @@
         },
         {
             "id": "08f64040-3cbb-5df4-a517-60f135f932e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e928cc4-be33-4c99-b0d0-c808c225e3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e928cc4-be33-4c99-b0d0-c808c225e3ab.jpg?1",
             "name": "Willowrush Verge",
             "text": "{T}: Add {U}.\n{T}: Add {G}. Activate only if you control a Forest or an Island.",
             "colours": [],
@@ -18521,7 +18521,7 @@
         },
         {
             "id": "8431bf90-9e80-5738-a1b1-0ba34f0c159b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e196d67-1923-459d-98cf-646337914d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e196d67-1923-459d-98cf-646337914d3b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18560,7 +18560,7 @@
         },
         {
             "id": "e3c6470b-4963-5991-9cea-e15091150e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33841e-7006-41d4-98b0-313ab151c9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33841e-7006-41d4-98b0-313ab151c9ec.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18599,7 +18599,7 @@
         },
         {
             "id": "c5c24078-b9d6-5cd3-88e4-0dd91ac1cea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba042d60-b1e8-44ad-9103-f40588a0b29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba042d60-b1e8-44ad-9103-f40588a0b29c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -18638,7 +18638,7 @@
         },
         {
             "id": "6cb2250b-64d0-5aa4-8421-15a5b7705ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7533cbb-ab73-4a0c-9ea0-baa97c4665b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7533cbb-ab73-4a0c-9ea0-baa97c4665b8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -18677,7 +18677,7 @@
         },
         {
             "id": "e10a8e67-02f4-5357-88d6-fc64531070bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1b6c5c-4585-47c1-82eb-a324189f3ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1b6c5c-4585-47c1-82eb-a324189f3ebd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -18716,7 +18716,7 @@
         },
         {
             "id": "033b03c4-d2a2-50b4-b4cc-db17f0d7b46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd76e71-df9b-4fd2-b534-d3f724a56a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd76e71-df9b-4fd2-b534-d3f724a56a91.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18755,7 +18755,7 @@
         },
         {
             "id": "ffb2e2ed-b892-5482-adfa-19f1ddefaae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13bb767-1123-48d2-960f-b90b6db3f6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13bb767-1123-48d2-960f-b90b6db3f6ed.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18794,7 +18794,7 @@
         },
         {
             "id": "dddedbb1-81e5-5bd8-b2ed-921b202b32a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d198b3-2ff5-484a-905f-c272de7c139d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d198b3-2ff5-484a-905f-c272de7c139d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -18833,7 +18833,7 @@
         },
         {
             "id": "a7c67b15-03d7-5579-ad52-f7ae7a9f5f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4952a8-4e1f-4a74-8a06-c9d633b25dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4952a8-4e1f-4a74-8a06-c9d633b25dcd.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -18872,7 +18872,7 @@
         },
         {
             "id": "c9612053-7eb0-507c-82ac-033d1ce7bbd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7aba60-d300-4c33-9e1e-846d6167dc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7aba60-d300-4c33-9e1e-846d6167dc50.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -18911,7 +18911,7 @@
         },
         {
             "id": "d729bc4f-936b-5d6f-b924-b3c8f04254b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c7805b-c952-4847-b321-e0567923c80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c7805b-c952-4847-b321-e0567923c80e.jpg?1",
             "name": "Salvation Engine",
             "text": "Other artifact creatures you control get +2/+2.\nWhenever this Vehicle attacks, return up to one target artifact card from your graveyard to the battlefield.\nCrew 6",
             "colours": [
@@ -18950,7 +18950,7 @@
         },
         {
             "id": "b4d4893a-89ef-5d57-914c-cc266791c98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d5057-39f7-42aa-9dd5-ecc52f861366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d5057-39f7-42aa-9dd5-ecc52f861366.jpg?1",
             "name": "Skyseer's Chariot",
             "text": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2",
             "colours": [
@@ -18987,7 +18987,7 @@
         },
         {
             "id": "166db6a6-ba9d-5883-b6df-658efdfddf74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4d35a-1f7e-4c5e-a999-09ad42f8b4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4d35a-1f7e-4c5e-a999-09ad42f8b4e2.jpg?1",
             "name": "Valor's Flagship",
             "text": "Flying, first strike, lifelink\nCrew 3\nCycling {X}{2}{W}\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -19026,7 +19026,7 @@
         },
         {
             "id": "819bb46f-42fd-5ec3-92f0-a36f0ffe3e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3666b4e-d6a4-41be-a529-4a577e75c86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3666b4e-d6a4-41be-a529-4a577e75c86d.jpg?1",
             "name": "Voyager Glidecar",
             "text": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1",
             "colours": [
@@ -19063,7 +19063,7 @@
         },
         {
             "id": "f922593f-3e51-503a-994e-402102504a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0c1eb-603e-4e3e-b40b-65662c22d72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f0c1eb-603e-4e3e-b40b-65662c22d72d.jpg?1",
             "name": "Possession Engine",
             "text": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3",
             "colours": [
@@ -19100,7 +19100,7 @@
         },
         {
             "id": "45b79684-e3f5-582b-a3a1-64d551da982c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f1f362-fa4a-49e6-baa5-6797a9408cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f1f362-fa4a-49e6-baa5-6797a9408cad.jpg?1",
             "name": "Thopter Fabricator",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2",
             "colours": [
@@ -19137,7 +19137,7 @@
         },
         {
             "id": "70f1fcee-51b9-5d37-b845-3ab25eec30b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56ae43-4a6b-4af6-9707-679068bd0934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa56ae43-4a6b-4af6-9707-679068bd0934.jpg?1",
             "name": "Cryptcaller Chariot",
             "text": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
             "colours": [
@@ -19174,7 +19174,7 @@
         },
         {
             "id": "98845a3e-3a88-5169-a7bc-5c2c077e3ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9747c8c-024f-417f-86ad-ee7c6f756aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9747c8c-024f-417f-86ad-ee7c6f756aa2.jpg?1",
             "name": "Demonic Junker",
             "text": "Affinity for artifacts\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2",
             "colours": [
@@ -19211,7 +19211,7 @@
         },
         {
             "id": "23591dcd-606a-5bf7-b436-faf3f745f576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85dac5a-c6fa-4a86-9fe3-7a17db06f07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85dac5a-c6fa-4a86-9fe3-7a17db06f07c.jpg?1",
             "name": "The Last Ride",
             "text": "The Last Ride gets -X/-X, where X is your life total.\n{2}{B}, Pay 2 life: Draw a card.\nCrew 2",
             "colours": [
@@ -19250,7 +19250,7 @@
         },
         {
             "id": "c9a6dc10-0448-5b80-b2b2-aa065e5ce9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62d070e-52b7-4d7f-bd98-13622d859a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62d070e-52b7-4d7f-bd98-13622d859a7b.jpg?1",
             "name": "Boommobile",
             "text": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust \u2014 {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.\nCrew 2",
             "colours": [
@@ -19287,7 +19287,7 @@
         },
         {
             "id": "062f8687-754b-562d-a697-9d9f07cca6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b39bc-8eda-4c5a-8705-5416cdb24f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b39bc-8eda-4c5a-8705-5416cdb24f0d.jpg?1",
             "name": "Gastal Thrillroller",
             "text": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
             "colours": [
@@ -19324,7 +19324,7 @@
         },
         {
             "id": "f2dac19f-37ad-5f6f-80f7-417a881aa8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83725fcd-d5ec-4b99-b3f6-e7f5325c766e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83725fcd-d5ec-4b99-b3f6-e7f5325c766e.jpg?1",
             "name": "Lumbering Worldwagon",
             "text": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
             "colours": [
@@ -19362,7 +19362,7 @@
         },
         {
             "id": "7948eca2-288e-59b4-bf08-6a4cb5838ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ff9fc-5c34-4a07-a1f3-35c21a3323b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4ff9fc-5c34-4a07-a1f3-35c21a3323b0.jpg?1",
             "name": "Thunderous Velocipede",
             "text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
             "colours": [
@@ -19399,7 +19399,7 @@
         },
         {
             "id": "923606bb-b007-5b33-91a8-30b0d8b22e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efa1ade-00f9-4736-8397-11d4faf65b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efa1ade-00f9-4736-8397-11d4faf65b7b.jpg?1",
             "name": "Debris Beetle",
             "text": "Trample\nWhen this Vehicle enters, each opponent loses 3 life and you gain 3 life.\nCrew 2",
             "colours": [
@@ -19438,7 +19438,7 @@
         },
         {
             "id": "c579387c-b8c9-5bc2-ab13-2390a40b4e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91496c82-44bc-4bb7-9e2a-5f4a3a199f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91496c82-44bc-4bb7-9e2a-5f4a3a199f4c.jpg?1",
             "name": "Lifecraft Engine",
             "text": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
             "colours": [],
@@ -19472,7 +19472,7 @@
         },
         {
             "id": "a253440d-26cc-5776-8bdf-6fc899458b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e8762-0aed-4009-86f0-7935a1d12b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e8762-0aed-4009-86f0-7935a1d12b52.jpg?1",
             "name": "Bulwark Ox",
             "text": "Whenever this creature attacks while saddled, put a +1/+1 counter on target creature.\nSacrifice this creature: Creatures you control with counters on them gain hexproof and indestructible until end of turn.\nSaddle 1",
             "colours": [
@@ -19510,7 +19510,7 @@
         },
         {
             "id": "4a64fcc4-b3bb-5ee4-94ed-78de0eee9bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb0c5b-ef3f-42db-9f40-0463cacd548d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb0c5b-ef3f-42db-9f40-0463cacd548d.jpg?1",
             "name": "Guardian Sunmare",
             "text": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4",
             "colours": [
@@ -19548,7 +19548,7 @@
         },
         {
             "id": "481fed5f-fbb4-5f19-b6a2-35819351280b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1191c3a-a6eb-4765-bb79-2f0d920899f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1191c3a-a6eb-4765-bb79-2f0d920899f9.jpg?1",
             "name": "Mindspring Merfolk",
             "text": "Exhaust \u2014 {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.",
             "colours": [
@@ -19586,7 +19586,7 @@
         },
         {
             "id": "b90d8f9b-c22e-5497-af42-532af9bf271e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7ee49c-1e5d-4b3a-8e0a-59a0d258e804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7ee49c-1e5d-4b3a-8e0a-59a0d258e804.jpg?1",
             "name": "Waxen Shapethief",
             "text": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2}",
             "colours": [
@@ -19623,7 +19623,7 @@
         },
         {
             "id": "3840ef31-c6a8-5475-89ea-4a65ac787b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489de46-e90c-483e-ac2b-547497f64e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489de46-e90c-483e-ac2b-547497f64e82.jpg?1",
             "name": "Bloodghast",
             "text": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
             "colours": [
@@ -19661,7 +19661,7 @@
         },
         {
             "id": "6e2995f3-cbcc-54d4-982a-54f060b0faec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b75e83-2ed5-48c9-881a-da3d77bdef99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b75e83-2ed5-48c9-881a-da3d77bdef99.jpg?1",
             "name": "Gas Guzzler",
             "text": "Start your engines\nThis creature enters tapped.\nMax speed \u2014 {B}, Sacrifice another creature or Vehicle: Draw a card.",
             "colours": [
@@ -19699,7 +19699,7 @@
         },
         {
             "id": "086c581d-43e8-5a4e-8ee2-2f6dfcf1ba7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bd51bd-e451-4f1d-af19-bb777ec1a85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bd51bd-e451-4f1d-af19-bb777ec1a85c.jpg?1",
             "name": "The Speed Demon",
             "text": "Flying, trample\nStart your engines\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
             "colours": [
@@ -19738,7 +19738,7 @@
         },
         {
             "id": "608bfc8c-7372-531a-a5e2-63734257847e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2151639-5621-4ffa-9374-3a1c48a635d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2151639-5621-4ffa-9374-3a1c48a635d9.jpg?1",
             "name": "Burnout Bashtronaut",
             "text": "Menace\nStart your engines\n{2}: This creature gets +1/+0 until end of turn.\nMax speed \u2014 This creature has double strike.",
             "colours": [
@@ -19776,7 +19776,7 @@
         },
         {
             "id": "949b3dba-5ca3-56f1-8184-c27732f880f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9419e00b-062b-4bb2-9203-f2f86b502371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9419e00b-062b-4bb2-9203-f2f86b502371.jpg?1",
             "name": "Draconautics Engineer",
             "text": "Exhaust \u2014 {R}: Other creatures you control gain haste until end of turn. Put a +1/+1 counter on this creature.\nExhaust \u2014 {3}{R}: Create a 4/4 red Dinosaur Dragon creature token with flying.",
             "colours": [
@@ -19814,7 +19814,7 @@
         },
         {
             "id": "adb029b3-686d-5e26-805d-e48c3cbcfd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf709cb6-8953-40ce-9fcc-396b6c0ab37a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf709cb6-8953-40ce-9fcc-396b6c0ab37a.jpg?1",
             "name": "Howlsquad Heavy",
             "text": "Start your engines\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed \u2014 {T}: Add {R} for each Goblin you control.",
             "colours": [
@@ -19852,7 +19852,7 @@
         },
         {
             "id": "46f0d9cb-8143-5384-9b5e-6e15be0717c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d815a94-cdf0-4a19-ad06-4292efbb7105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d815a94-cdf0-4a19-ad06-4292efbb7105.jpg?1",
             "name": "Agonasaur Rex",
             "text": "Trample\nCycling {2}{G}\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
             "colours": [
@@ -19889,7 +19889,7 @@
         },
         {
             "id": "334433e5-e370-5817-9e44-9b7881c23950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ad303-505d-4e2a-9380-80ab9f91a0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ad303-505d-4e2a-9380-80ab9f91a0a3.jpg?1",
             "name": "District Mascot",
             "text": "This creature enters with a +1/+1 counter on it.\n{1}{G}, Remove two +1/+1 counters from this creature: Destroy target artifact.\nWhenever this creature attacks while saddled, put a +1/+1 counter on it.\nSaddle 1",
             "colours": [
@@ -19927,7 +19927,7 @@
         },
         {
             "id": "3868483a-bb65-54c3-aa2a-505a681fc279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf3bcd2-fdc6-4490-858d-3334437a3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf3bcd2-fdc6-4490-858d-3334437a3148.jpg?1",
             "name": "Webstrike Elite",
             "text": "Reach\nCycling {X}{G}{G}\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
             "colours": [
@@ -19965,7 +19965,7 @@
         },
         {
             "id": "f853193f-5a3e-5fc4-b128-e5746b0572bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c8f0f0-f2d0-44fa-8163-41a8e35952fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c8f0f0-f2d0-44fa-8163-41a8e35952fd.jpg?1",
             "name": "Fearless Swashbuckler",
             "text": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
             "colours": [
@@ -20005,7 +20005,7 @@
         },
         {
             "id": "b958e8e0-2289-5517-a027-912bcab0768e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e0ead2-933a-41ad-b1c3-0aa79cc41e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e0ead2-933a-41ad-b1c3-0aa79cc41e93.jpg?1",
             "name": "Hazoret, Godseeker",
             "text": "Indestructible, haste\nStart your engines\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
             "colours": [
@@ -20044,7 +20044,7 @@
         },
         {
             "id": "2f703045-e00b-5e9a-8dc7-978f75733eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b787e28-a6bf-489c-affb-4043845c9769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b787e28-a6bf-489c-affb-4043845c9769.jpg?1",
             "name": "Brightglass Gearhulk",
             "text": "First strike, trample\nWhen this creature enters, you may search your library for up to two artifact, creature, and/or enchantment cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -20084,7 +20084,7 @@
         },
         {
             "id": "9bdfc60b-1a4a-5793-a56a-d704ed8068b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4363ec0d-a473-4afc-9ae5-4feed762a630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4363ec0d-a473-4afc-9ae5-4feed762a630.jpg?1",
             "name": "Coalstoke Gearhulk",
             "text": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
             "colours": [
@@ -20124,7 +20124,7 @@
         },
         {
             "id": "9c118ec8-e771-5626-b053-9fe695fe478e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1688041b-a654-493e-bfac-247fdca68b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1688041b-a654-493e-bfac-247fdca68b22.jpg?1",
             "name": "Ketramose, the New Dawn",
             "text": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
             "colours": [
@@ -20165,7 +20165,7 @@
         },
         {
             "id": "0c4047dd-5440-5fee-8667-a1398ecb29bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd7467-4e77-4fad-b8e9-b258fa6254f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd7467-4e77-4fad-b8e9-b258fa6254f3.jpg?1",
             "name": "Oildeep Gearhulk",
             "text": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -20205,7 +20205,7 @@
         },
         {
             "id": "ac6b81f7-7ed2-595f-9ac8-a3b811da16d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50050d-1da8-4f37-a975-f81d5684a619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50050d-1da8-4f37-a975-f81d5684a619.jpg?1",
             "name": "Pyrewood Gearhulk",
             "text": "Vigilance, menace\nWhen this creature enters, other creatures you control get +2/+2 and gain vigilance and menace until end of turn. Damage can't be prevented this turn.",
             "colours": [
@@ -20245,7 +20245,7 @@
         },
         {
             "id": "7dca3711-8bd3-58cb-a93b-d1c8c821c8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6127cd9e-5785-4ba5-89d0-5eeb0d8aaa0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6127cd9e-5785-4ba5-89d0-5eeb0d8aaa0e.jpg?1",
             "name": "Riptide Gearhulk",
             "text": "Double strike, prowess\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
             "colours": [
@@ -20285,7 +20285,7 @@
         },
         {
             "id": "25ace84a-3371-52b1-839f-d4eff375cc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f9907-e187-4c01-964c-24b3d27948b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f9907-e187-4c01-964c-24b3d27948b5.jpg?1",
             "name": "Sab-Sunen, Luxa Embodied",
             "text": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
             "colours": [
@@ -20326,7 +20326,7 @@
         },
         {
             "id": "648bee61-604f-58a2-8beb-11faa77a89af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1",
             "name": "Pilot",
             "text": "",
             "colours": [],
@@ -20357,7 +20357,7 @@
         },
         {
             "id": "e79827a9-d8b8-5a7c-a9ae-ff706794fd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -20392,7 +20392,7 @@
         },
         {
             "id": "80e85df7-9984-55a2-a99c-245a54b062df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -20427,7 +20427,7 @@
         },
         {
             "id": "eca095c0-5330-5c63-a18e-b4c46ac5d6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932aac56-2afa-4431-96fa-bd55d8bba983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932aac56-2afa-4431-96fa-bd55d8bba983.jpg?1",
             "name": "Dinosaur Dragon",
             "text": "",
             "colours": [
@@ -20463,7 +20463,7 @@
         },
         {
             "id": "ab1efd04-449e-5744-9042-1f201280fc70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -20498,7 +20498,7 @@
         },
         {
             "id": "b804cdc2-1aaf-5dee-9760-fc9e88a37542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecb6655-2aa0-4622-ae9a-21dfffa7625e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecb6655-2aa0-4622-ae9a-21dfffa7625e.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -20533,7 +20533,7 @@
         },
         {
             "id": "25b7d586-b387-5362-bac0-94259e7553b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d855d-93a1-4ec4-af19-e544f271ae10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d855d-93a1-4ec4-af19-e544f271ae10.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -20568,7 +20568,7 @@
         },
         {
             "id": "cc281264-7f00-5567-bb0e-c14f40c41490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10de413b-3307-4bc7-bb21-f177543d7e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10de413b-3307-4bc7-bb21-f177543d7e21.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -20600,7 +20600,7 @@
         },
         {
             "id": "c2d963e3-a4f2-52be-b254-d7ebbfdc4244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -20632,7 +20632,7 @@
         },
         {
             "id": "d0ddfd70-ed9e-56db-8424-5a30af6d2425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e52380-13a1-44fe-b762-e71261cac3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e52380-13a1-44fe-b762-e71261cac3d0.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -20664,7 +20664,7 @@
         },
         {
             "id": "79b7a1b8-532b-580f-ad16-5a2dcd304e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7638ef-114b-4055-9855-390f82b7d5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7638ef-114b-4055-9855-390f82b7d5c5.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -20695,7 +20695,7 @@
         },
         {
             "id": "64d3c795-19c6-599b-be5b-4a7073b41588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3803365-ed78-409f-8ca5-7aa3634faf76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3803365-ed78-409f-8ca5-7aa3634faf76.jpg?1",
             "name": "Vehicle",
             "text": "",
             "colours": [],
@@ -20726,7 +20726,7 @@
         },
         {
             "id": "352f5ba4-3a9e-5f6a-8eb3-33b29f216a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343d2622-a5a6-4195-ab41-c6bd17e334a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343d2622-a5a6-4195-ab41-c6bd17e334a2.jpg?1",
             "name": "Chandra, Spark Hunter Emblem",
             "text": "",
             "colours": [],
@@ -20754,7 +20754,7 @@
         },
         {
             "id": "04c42b99-db90-5f19-a978-41d095cc6de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg?1",
             "name": "Start Your Engines! // Max Speed",
             "text": "",
             "colours": [],
@@ -20782,7 +20782,7 @@
         },
         {
             "id": "08f43e68-5c13-5827-8de5-471f10fd6a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82613de6-ed37-48c1-8d2f-d91a3f496794.jpg?1",
             "name": "Start Your Engines! // Max Speed",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DGM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DGM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5db3baa0-26d0-5b08-90b9-35ee765aaa9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a3bfb6-3843-4bda-bbcb-905e4b351dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a3bfb6-3843-4bda-bbcb-905e4b351dea.jpg?1",
             "name": "Boros Mastiff",
             "text": "Battalion \u2014 Whenever Boros Mastiff and at least two other creatures attack, Boros Mastiff gains lifelink until end of turn. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "f7ce9f7a-902b-5469-9558-03d4aee2a28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3c012-f356-424d-a960-60e95f395134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3c012-f356-424d-a960-60e95f395134.jpg?1",
             "name": "Haazda Snare Squad",
             "text": "Whenever Haazda Snare Squad attacks, you may pay {W}. If you do, tap target creature an opponent controls.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "04a07512-1195-5a45-9307-2469af674823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773cf2aa-4337-4d14-8a8e-ff8b1fdec1b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773cf2aa-4337-4d14-8a8e-ff8b1fdec1b5.jpg?1",
             "name": "Lyev Decree",
             "text": "Detain up to two target creatures your opponents control. (Until your next turn, those creatures can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "a704dbbd-b2ea-5e97-b782-f9d11fa02977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a977e2d-a2bc-42d1-be7d-36a822c6a66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a977e2d-a2bc-42d1-be7d-36a822c6a66e.jpg?1",
             "name": "Maze Sentinel",
             "text": "Vigilance\nMulticolored creatures you control have vigilance.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "8a3b9683-a45d-5df6-8aa5-f296db8c6fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9acc14-24e0-4c03-a09a-2afee351f2cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9acc14-24e0-4c03-a09a-2afee351f2cc.jpg?1",
             "name": "Renounce the Guilds",
             "text": "Each player sacrifices a multicolored permanent.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "93c3532d-c8b9-5a0f-a013-0c7f256797e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7886607-86db-4221-8752-296104aaaef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7886607-86db-4221-8752-296104aaaef2.jpg?1",
             "name": "Riot Control",
             "text": "You gain 1 life for each creature your opponents control. Prevent all damage that would be dealt to you this turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "ecf64b9a-8ee3-58c8-abdb-748e70c50096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd20865-0a9a-4a72-92f9-77c8d6384b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd20865-0a9a-4a72-92f9-77c8d6384b46.jpg?1",
             "name": "Scion of Vitu-Ghazi",
             "text": "When Scion of Vitu-Ghazi enters the battlefield, if you cast it from your hand, put a 1/1 white Bird creature token with flying onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "39fb83e6-3830-5dea-9bee-8661da390142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecafab-97f4-40ed-bc43-d186eb2f3af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecafab-97f4-40ed-bc43-d186eb2f3af6.jpg?1",
             "name": "Steeple Roc",
             "text": "Flying, first strike",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "2f4a4c5a-beb4-5e10-baa2-e8119a8e1196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3bc6b9-475b-4257-a3bc-1a0b70d45f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3bc6b9-475b-4257-a3bc-1a0b70d45f79.jpg?1",
             "name": "Sunspire Gatekeepers",
             "text": "When Sunspire Gatekeepers enters the battlefield, if you control two or more Gates, put a 2/2 white Knight creature token with vigilance onto the battlefield.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "4f9f1b00-561c-59af-9234-de3febf6dd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db0074c-95cf-4d15-8fe1-7282803ec757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db0074c-95cf-4d15-8fe1-7282803ec757.jpg?1",
             "name": "Wake the Reflections",
             "text": "Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "fe48f6cf-572c-5cd9-a1f9-42ef54b70166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c93313b-cf43-47e9-a911-717b4d14b0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c93313b-cf43-47e9-a911-717b4d14b0b5.jpg?1",
             "name": "Aetherling",
             "text": "{U}: Exile \u00c6therling. Return it to the battlefield under its owner's control at the beginning of the next end step.\n{U}: \u00c6therling is unblockable this turn.\n{1}: \u00c6therling gets +1/-1 until end of turn.\n{1}: \u00c6therling gets -1/+1 until end of turn.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "87a85cb6-be61-5981-8cbd-b018c07713ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216e8047-6f54-49ce-bf86-27dc8fc8c8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216e8047-6f54-49ce-bf86-27dc8fc8c8f7.jpg?1",
             "name": "Hidden Strings",
             "text": "You may tap or untap target permanent, then you may tap or untap another target permanent.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "dd6d23eb-ae26-5cb6-b0c8-194898012f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d20281-49c0-4fd0-91f2-390506ac33f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d20281-49c0-4fd0-91f2-390506ac33f6.jpg?1",
             "name": "Maze Glider",
             "text": "Flying\nMulticolored creatures you control have flying.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "bc2619f0-9a21-516e-969c-d5af5b6b23ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d3fad5-a12a-4b41-9c7b-c1af5e0b5ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d3fad5-a12a-4b41-9c7b-c1af5e0b5ca8.jpg?1",
             "name": "Mindstatic",
             "text": "Counter target spell unless its controller pays {6}.",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "1aa7fbb7-65de-5a5e-90fe-de7cd89682d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9752644c-7c43-429e-a79c-1239b9a0bc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9752644c-7c43-429e-a79c-1239b9a0bc8a.jpg?1",
             "name": "Murmuring Phantasm",
             "text": "Defender",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "e0ac8b1d-2c92-52d5-ac32-0929096b8fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43ac38f-5cd0-46cf-8623-d82cb8fb719b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43ac38f-5cd0-46cf-8623-d82cb8fb719b.jpg?1",
             "name": "Opal Lake Gatekeepers",
             "text": "When Opal Lake Gatekeepers enters the battlefield, if you control two or more Gates, you may draw a card.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "f978fb16-4e27-53ef-9a54-1d9c8d367049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696b5a6-edfd-445e-ac80-64c1be94fbfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696b5a6-edfd-445e-ac80-64c1be94fbfc.jpg?1",
             "name": "Runner's Bane",
             "text": "Enchant creature with power 3 or less\nWhen Runner's Bane enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "452f75b4-69d3-567a-9cf4-2048e0c8876c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a7981-5940-4b75-907f-7600a742f946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a7981-5940-4b75-907f-7600a742f946.jpg?1",
             "name": "Trait Doctoring",
             "text": "Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another until end of turn.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -605,7 +605,7 @@
         },
         {
             "id": "5871e9fa-7750-5c7d-8ee0-0ec529bf2da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd24556-994f-4480-835e-11d4443f0700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd24556-994f-4480-835e-11d4443f0700.jpg?1",
             "name": "Uncovered Clues",
             "text": "Look at the top four cards of your library. You may reveal up to two instant and/or sorcery cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -637,7 +637,7 @@
         },
         {
             "id": "fc3ed198-3360-5e0e-b9a1-d7a5ce7ccc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ea454f-b640-4a89-937f-bae05556292a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ea454f-b640-4a89-937f-bae05556292a.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -671,7 +671,7 @@
         },
         {
             "id": "9f8d230e-8219-5863-b6ec-a2b56f32d8f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fcad03-4567-4f96-976e-01a07d8ab050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fcad03-4567-4f96-976e-01a07d8ab050.jpg?1",
             "name": "Bane Alley Blackguard",
             "text": "",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "dc3258be-efad-5e70-b059-bf5117d84fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea8179a-d3c9-4cdc-a5b5-68cc73279050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea8179a-d3c9-4cdc-a5b5-68cc73279050.jpg?1",
             "name": "Blood Scrivener",
             "text": "If you would draw a card while you have no cards in hand, instead draw two cards and lose 1 life.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "f22e3ffa-3d2b-5385-8d79-2beb2ffa3595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b71cc5-0a81-4cab-bae3-49335c04aaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b71cc5-0a81-4cab-bae3-49335c04aaaa.jpg?1",
             "name": "Crypt Incursion",
             "text": "Exile all creature cards from target player's graveyard. You gain 3 life for each card exiled this way.",
             "colours": [
@@ -773,7 +773,7 @@
         },
         {
             "id": "776fd41a-922f-5061-801d-b63199445fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967aa636-a11d-4c5c-ba85-648734b295c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967aa636-a11d-4c5c-ba85-648734b295c2.jpg?1",
             "name": "Fatal Fumes",
             "text": "Target creature gets -4/-2 until end of turn.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "f83682a3-2d7f-5f47-9e92-9e25bc8bacca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e9f79e-6606-4c9b-838c-eda5d8cc612c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e9f79e-6606-4c9b-838c-eda5d8cc612c.jpg?1",
             "name": "Hired Torturer",
             "text": "Defender\n{3}{B}, {T}: Target opponent loses 2 life, then reveals a card at random from his or her hand.",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "1e88221c-6ff6-56f6-bc65-694a514d2918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84659f-4209-42a2-800a-61706470ce54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd84659f-4209-42a2-800a-61706470ce54.jpg?1",
             "name": "Maze Abomination",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nMulticolored creatures you control have deathtouch.",
             "colours": [
@@ -874,7 +874,7 @@
         },
         {
             "id": "ca9e4874-ac7d-525c-8ef8-7762c80913f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e5291f-9281-4cb7-9158-54b7cb336b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e5291f-9281-4cb7-9158-54b7cb336b93.jpg?1",
             "name": "Pontiff of Blight",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nOther creatures you control have extort. (If a creature has multiple instances of extort, each triggers separately.)",
             "colours": [
@@ -909,7 +909,7 @@
         },
         {
             "id": "e43007c4-a3d6-5ef5-855f-36319cd216d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c1bfd7-b8b2-4db7-9ea7-a2d643a83589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c1bfd7-b8b2-4db7-9ea7-a2d643a83589.jpg?1",
             "name": "Rakdos Drake",
             "text": "Flying\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "88ca6fe4-901e-5198-8e06-412f9a064be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f54c15b-fec0-49a6-8a49-d1af4eeee40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f54c15b-fec0-49a6-8a49-d1af4eeee40e.jpg?1",
             "name": "Sinister Possession",
             "text": "Enchant creature\nWhenever enchanted creature attacks or blocks, its controller loses 2 life.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "c020d22f-dcd1-57ae-8742-adf12efba087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2e327-adfd-459b-8d18-faa39d88b5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2e327-adfd-459b-8d18-faa39d88b5de.jpg?1",
             "name": "Ubul Sar Gatekeepers",
             "text": "When Ubul Sar Gatekeepers enters the battlefield, if you control two or more Gates, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -1012,7 +1012,7 @@
         },
         {
             "id": "e566bf73-f360-5a9f-825d-e84eb9dabf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec644ac3-07a2-43de-8173-9cc18e2ea2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec644ac3-07a2-43de-8173-9cc18e2ea2d9.jpg?1",
             "name": "Awe for the Guilds",
             "text": "Monocolored creatures can't block this turn.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "59732c01-393c-5b07-8040-309e875973e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8f904b-a9a3-4bae-9284-4e9cbe7592ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8f904b-a9a3-4bae-9284-4e9cbe7592ee.jpg?1",
             "name": "Clear a Path",
             "text": "Destroy target creature with defender.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "fc807797-1578-53fc-843a-02fef7a8f2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d2eb8-e27f-4f84-9725-d2ae6446e217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d2eb8-e27f-4f84-9725-d2ae6446e217.jpg?1",
             "name": "Maze Rusher",
             "text": "Haste\nMulticolored creatures you control have haste.",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "cfcb67f8-0b44-5ee4-a0ad-b136f5bb2622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858aa831-b491-4f1e-bb56-33eeca14771d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858aa831-b491-4f1e-bb56-33eeca14771d.jpg?1",
             "name": "Possibility Storm",
             "text": "Whenever a player casts a spell from his or her hand, that player exiles it, then exiles cards from the top of his or her library until he or she exiles a card that shares a card type with it. That player may cast that card without paying its mana cost. Then he or she puts all cards exiled with Possibility Storm on the bottom of his or her library in a random order.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "1567336d-421d-596b-a754-1102920d37bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4179a72b-8482-46ec-9815-f5d6d94b5aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4179a72b-8482-46ec-9815-f5d6d94b5aa5.jpg?1",
             "name": "Punish the Enemy",
             "text": "Punish the Enemy deals 3 damage to target player and 3 damage to target creature.",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "e40e3ae9-d2e2-5dfc-a554-ea18d188aa90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f6e45-f613-420d-83d2-d93c643265ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6f6e45-f613-420d-83d2-d93c643265ee.jpg?1",
             "name": "Pyrewild Shaman",
             "text": "Bloodrush \u2014 {1}{R}, Discard Pyrewild Shaman: Target attacking creature gets +3/+1 until end of turn.\nWhenever one or more creatures you control deal combat damage to a player, if Pyrewild Shaman is in your graveyard, you may pay {3}. If you do, return Pyrewild Shaman to your hand.",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "35798183-bb15-566d-83b1-bbd6d2b2bc51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daaccd2-733c-4b3b-aa3f-cc825bcc3e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daaccd2-733c-4b3b-aa3f-cc825bcc3e53.jpg?1",
             "name": "Riot Piker",
             "text": "First strike\nRiot Piker attacks each turn if able.",
             "colours": [
@@ -1244,7 +1244,7 @@
         },
         {
             "id": "c1865fa7-eea0-5c82-9666-589abdd39806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc802d62-6559-45b9-ad11-de5887aece2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc802d62-6559-45b9-ad11-de5887aece2b.jpg?1",
             "name": "Rubblebelt Maaka",
             "text": "Bloodrush \u2014 {R}, Discard Rubblebelt Maaka: Target attacking creature gets +3/+3 until end of turn.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "89061cb4-4ba7-5903-a79a-f7cd8ea8f682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8237b11f-36d2-4624-a0ef-520663385891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8237b11f-36d2-4624-a0ef-520663385891.jpg?1",
             "name": "Smelt-Ward Gatekeepers",
             "text": "When Smelt-Ward Gatekeepers enters the battlefield, if you control two or more Gates, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "3c884a7f-d6dc-5ede-9840-38bd9cbf547a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28df164-8bff-4428-b7dd-2974c288f1d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28df164-8bff-4428-b7dd-2974c288f1d3.jpg?1",
             "name": "Weapon Surge",
             "text": "Target creature you control gets +1/+0 and gains first strike until end of turn.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1345,7 +1345,7 @@
         },
         {
             "id": "5e0756d4-cf3a-5f92-ac88-8757eb8243f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9aa740-9adf-412a-b6ec-0b9bb1b4618b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9aa740-9adf-412a-b6ec-0b9bb1b4618b.jpg?1",
             "name": "Battering Krasis",
             "text": "Trample\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "e44750f0-79c2-57ad-8816-3d72090c1684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71da8cc-8773-4dcb-aca8-50a000142218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71da8cc-8773-4dcb-aca8-50a000142218.jpg?1",
             "name": "Kraul Warrior",
             "text": "{5}{G}: Kraul Warrior gets +3/+3 until end of turn.",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "1ade9f34-23c5-5506-acd6-82fd3bab8137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9678-dea7-4219-bac0-9e1cef531f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9678-dea7-4219-bac0-9e1cef531f54.jpg?1",
             "name": "Maze Behemoth",
             "text": "Trample\nMulticolored creatures you control have trample.",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "f0e314ed-720b-5707-a260-5d640c82bd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c042c7ee-0e74-4ca5-bbb9-2898b0576f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c042c7ee-0e74-4ca5-bbb9-2898b0576f0a.jpg?1",
             "name": "Mending Touch",
             "text": "Regenerate target creature.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "8802c1d5-f188-57e7-bc2d-f5d6d3f05f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e32d47-2796-4eac-b373-a93506d8d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e32d47-2796-4eac-b373-a93506d8d6b7.jpg?1",
             "name": "Mutant's Prey",
             "text": "Target creature you control with a +1/+1 counter on it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "3ba65ebb-18ee-586b-8d29-eb73e83df87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7507afc4-f504-4eb2-a86d-f99bc2860838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7507afc4-f504-4eb2-a86d-f99bc2860838.jpg?1",
             "name": "Phytoburst",
             "text": "Target creature gets +5/+5 until end of turn.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "c8af3b68-2d5a-5c24-8870-ee43cd4b45b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b68921-0c34-4d92-83c3-21542f62c7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b68921-0c34-4d92-83c3-21542f62c7f6.jpg?1",
             "name": "Renegade Krasis",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever Renegade Krasis evolves, put a +1/+1 counter on each other creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "706aabda-3b12-5405-b102-1d843b5ebf12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471a5b1d-e2e5-4d90-b72a-ffae81ad6602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471a5b1d-e2e5-4d90-b72a-ffae81ad6602.jpg?1",
             "name": "Saruli Gatekeepers",
             "text": "When Saruli Gatekeepers enters the battlefield, if you control two or more Gates, you gain 7 life.",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "dfced25d-a029-5fa6-ae16-7f651e13882e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c2069-deb1-4e56-8069-170c4f495944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c2069-deb1-4e56-8069-170c4f495944.jpg?1",
             "name": "Skylasher",
             "text": "Flash\nSkylasher can't be countered.\nReach, protection from blue",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "2ef21462-163f-5d23-8784-3c12045084f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0d63a-d947-4ce4-8e34-5c1521955b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd0d63a-d947-4ce4-8e34-5c1521955b18.jpg?1",
             "name": "Thrashing Mossdog",
             "text": "Reach (This creature can block creatures with flying.)\nScavenge {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "0107c4be-08d3-5182-a283-505dbbe0866d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40284e6-01a1-4372-a92c-940e5732607e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40284e6-01a1-4372-a92c-940e5732607e.jpg?1",
             "name": "Advent of the Wurm",
             "text": "Put a 5/5 green Wurm creature token with trample onto the battlefield.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "c3d9dc7c-14c2-5d65-8035-5508c7d8bc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43d959f-6055-4578-a69a-0ec93e993e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43d959f-6055-4578-a69a-0ec93e993e21.jpg?1",
             "name": "Armored Wolf-Rider",
             "text": "",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "203185c1-d233-50c1-ac0b-e59e615fa927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f00799-80ce-431e-97bb-8bb4e0e8ba49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f00799-80ce-431e-97bb-8bb4e0e8ba49.jpg?1",
             "name": "Ascended Lawmage",
             "text": "Flying, hexproof",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "013e365b-754c-52f4-8377-0f566ffcb0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2f7d7f-4097-419b-8de0-b7bf28fc3a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2f7d7f-4097-419b-8de0-b7bf28fc3a4b.jpg?1",
             "name": "Beetleform Mage",
             "text": "{G}{U}: Beetleform Mage gets +2/+2 and gains flying until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "c2a6a168-d35d-5836-b4f6-99bb20b986e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ff592c-bd35-4947-ba17-8b6170d5388e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ff592c-bd35-4947-ba17-8b6170d5388e.jpg?1",
             "name": "Blast of Genius",
             "text": "Choose target creature or player. Draw three cards, then discard a card. Blast of Genius deals damage equal to the discarded card's converted mana cost to that creature or player.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "da92caf3-68ab-58ac-bc04-04213e7f6299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e179f0d-2965-44e4-8483-67b330a8608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e179f0d-2965-44e4-8483-67b330a8608c.jpg?1",
             "name": "Blaze Commando",
             "text": "Whenever an instant or sorcery spell you control deals damage, put two 1/1 red and white Soldier creature tokens with haste onto the battlefield.",
             "colours": [
@@ -1901,7 +1901,7 @@
         },
         {
             "id": "d90db469-0bc7-5143-a4f5-56968b9d20d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4edad09-bf7b-40e9-ac2a-100da8a43274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4edad09-bf7b-40e9-ac2a-100da8a43274.jpg?1",
             "name": "Blood Baron of Vizkopa",
             "text": "Lifelink, protection from white and from black\nAs long as you have 30 or more life and an opponent has 10 or less life, Blood Baron of Vizkopa gets +6/+6 and has flying.",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "8642dd92-1a2e-589e-8793-e7fd202d7634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c43e449-acf2-4e94-b7cf-8c84d70191da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c43e449-acf2-4e94-b7cf-8c84d70191da.jpg?1",
             "name": "Boros Battleshaper",
             "text": "At the beginning of each combat, up to one target creature attacks or blocks this combat if able and up to one target creature can't attack or block this combat.",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "4c64b7ee-dd11-57ba-b5f6-ee42b7cd13e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258a536-2275-45e8-8833-e921ca15c5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258a536-2275-45e8-8833-e921ca15c5a7.jpg?1",
             "name": "Bred for the Hunt",
             "text": "Whenever a creature you control with a +1/+1 counter on it deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "c59828b2-074c-526f-8cdf-33bda527b688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291c0ebc-d489-42c7-8d8a-9216c333412f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291c0ebc-d489-42c7-8d8a-9216c333412f.jpg?1",
             "name": "Bronzebeak Moa",
             "text": "Whenever another creature enters the battlefield under your control, Bronzebeak Moa gets +3/+3 until end of turn.",
             "colours": [
@@ -2044,7 +2044,7 @@
         },
         {
             "id": "b170011c-cd9b-5926-b58b-a71bd2fba0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bde6c1-917c-4860-a8d0-a9d7c461f8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bde6c1-917c-4860-a8d0-a9d7c461f8d2.jpg?1",
             "name": "Carnage Gladiator",
             "text": "Whenever a creature blocks, that creature's controller loses 1 life.\n{1}{B}{R}: Regenerate Carnage Gladiator.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "047df831-8637-52d9-81b7-6e2a75e13b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a6a5-0042-40ae-bd33-a6d5a65a9944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a6a5-0042-40ae-bd33-a6d5a65a9944.jpg?1",
             "name": "Council of the Absolute",
             "text": "As Council of the Absolute enters the battlefield, name a card other than a creature or land card.\nYour opponents can't cast cards with the chosen name.\nSpells with the chosen name you cast cost {2} less to cast.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "a833c7c5-024e-517e-b61b-33dab4201af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26417a58-b0c9-49fa-956c-794ee1c09a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26417a58-b0c9-49fa-956c-794ee1c09a4f.jpg?1",
             "name": "Deadbridge Chant",
             "text": "When Deadbridge Chant enters the battlefield, put the top ten cards of your library into your graveyard.\nAt the beginning of your upkeep, choose a card at random in your graveyard. If it's a creature card, put it onto the battlefield. Otherwise, put it into your hand.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "c046f9fb-51f4-5213-a228-ac32ff307890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610e5a91-857b-4121-8b75-dbbea27aa0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610e5a91-857b-4121-8b75-dbbea27aa0aa.jpg?1",
             "name": "Debt to the Deathless",
             "text": "Each opponent loses two times X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "eb570b20-5c8e-5131-b715-9733eba5da62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b555888-21b1-4c45-966d-d98f32460d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b555888-21b1-4c45-966d-d98f32460d4e.jpg?1",
             "name": "Deputy of Acquittals",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Deputy of Acquittals enters the battlefield, you may return another target creature you control to its owner's hand.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "0285cea3-8c5f-582e-aea8-f844fc750d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c046e4e-810c-4123-bb1a-4f97e0cd43d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c046e4e-810c-4123-bb1a-4f97e0cd43d1.jpg?1",
             "name": "Dragonshift",
             "text": "Until end of turn, target creature you control becomes a 4/4 blue and red Dragon, loses all abilities, and gains flying.\nOverload {3}{U}{U}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "d8aed26a-409f-5432-9136-59096cfde1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22feacda-01e0-4f0d-a3c7-a22e3d40bf4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22feacda-01e0-4f0d-a3c7-a22e3d40bf4e.jpg?1",
             "name": "Drown in Filth",
             "text": "Choose target creature. Put the top four cards of your library into your graveyard, then that creature gets -1/-1 until end of turn for each land card in your graveyard.",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "10da6c92-240a-5edd-833e-9a9b4c00b574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c91a0a-2f14-4131-8ca7-1d0046a8edd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c91a0a-2f14-4131-8ca7-1d0046a8edd2.jpg?1",
             "name": "Emmara Tandris",
             "text": "Prevent all damage that would be dealt to creature tokens you control.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "751a3d4e-38cd-5644-ac5a-605b377f38fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb72a64-89e7-4b0e-a3d3-1309829071d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb72a64-89e7-4b0e-a3d3-1309829071d2.jpg?1",
             "name": "Exava, Rakdos Blood Witch",
             "text": "First strike, haste\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\nEach other creature you control with a +1/+1 counter on it has haste.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "c9217e7a-4d00-56fb-9a00-92ecf9dde9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108a9ef2-c74a-450b-8148-4fdf9f09843f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108a9ef2-c74a-450b-8148-4fdf9f09843f.jpg?1",
             "name": "Feral Animist",
             "text": "{3}: Feral Animist gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "dc77a9cf-61f3-54f0-9713-4bd72909c2ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c58f6ed-2544-4b58-8dc0-a0a37b9547e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c58f6ed-2544-4b58-8dc0-a0a37b9547e6.jpg?1",
             "name": "Fluxcharger",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, you may switch Fluxcharger's power and toughness until end of turn.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "44c30cd3-2e8a-5169-a16e-a6c8855f460e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9ac10-d114-4aa5-87ac-f1069cde8e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9ac10-d114-4aa5-87ac-f1069cde8e40.jpg?1",
             "name": "Gaze of Granite",
             "text": "Destroy each nonland permanent with converted mana cost X or less.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "febcfa69-6d75-5461-b4b5-fb06c367d70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f0feef-1a71-4c8c-9fd1-f5cbe718a988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f0feef-1a71-4c8c-9fd1-f5cbe718a988.jpg?1",
             "name": "Gleam of Battle",
             "text": "Whenever a creature you control attacks, put a +1/+1 counter on it.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "331142d0-c74c-5ce8-a03e-e12106cdb09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8dbb9aa-1bf8-447d-a96c-33e2248bfb01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8dbb9aa-1bf8-447d-a96c-33e2248bfb01.jpg?1",
             "name": "Goblin Test Pilot",
             "text": "Flying\n{T}: Goblin Test Pilot deals 2 damage to target creature or player chosen at random.",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "3cbae5d1-f120-5e80-9495-12625953a982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df383a6a-5eb1-48e8-a5f3-f4731ddb871b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df383a6a-5eb1-48e8-a5f3-f4731ddb871b.jpg?1",
             "name": "Gruul War Chant",
             "text": "Each attacking creature you control gets +1/+0 and can't be blocked except by two or more creatures.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "b5765712-0b42-5384-ac52-9114257b978d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438683f5-adfa-42ae-a6fb-c4649a8a30ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438683f5-adfa-42ae-a6fb-c4649a8a30ab.jpg?1",
             "name": "Haunter of Nightveil",
             "text": "Creatures your opponents control get -1/-0.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "6b751b88-1f4b-5271-8280-59313c5b758f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c89eb-d7c6-4945-9689-2f2c0e428b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c89eb-d7c6-4945-9689-2f2c0e428b84.jpg?1",
             "name": "Jelenn Sphinx",
             "text": "Flying, vigilance\nWhenever Jelenn Sphinx attacks, other attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "01e4b497-4859-5a75-84c2-53cb31f249a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7006e5b9-d6a3-43ce-904b-b2ac0fea67e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7006e5b9-d6a3-43ce-904b-b2ac0fea67e5.jpg?1",
             "name": "Korozda Gorgon",
             "text": "Deathtouch\n{2}, Remove a +1/+1 counter from a creature you control: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "d1cb3557-e9fc-5155-8ab9-080a1683ec77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da986da-e8ee-4b53-8bbd-9285d0f7f3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da986da-e8ee-4b53-8bbd-9285d0f7f3cb.jpg?1",
             "name": "Krasis Incubation",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\n{1}{G}{U}, Return Krasis Incubation to its owner's hand: Put two +1/+1 counters on enchanted creature.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "d93b6059-40e4-5833-96ee-148e056c1547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813f1967-c048-4e6e-9720-216773fde47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813f1967-c048-4e6e-9720-216773fde47e.jpg?1",
             "name": "Lavinia of the Tenth",
             "text": "Protection from red\nWhen Lavinia of the Tenth enters the battlefield, detain each nonland permanent your opponents control with converted mana cost 4 or less. (Until your next turn, those permanents can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "58b194d8-3f85-59cf-b0f5-1ad36ad96b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672051a6-d232-4546-842a-369d412c38d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672051a6-d232-4546-842a-369d412c38d2.jpg?1",
             "name": "Legion's Initiative",
             "text": "Red creatures you control get +1/+0.\nWhite creatures you control get +0/+1.\n{R}{W}, Exile Legion's Initiative: Exile all creatures you control. At the beginning of the next combat, return those cards to the battlefield under their owner's control and those creatures gain haste until end of turn.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "125bc380-18f3-5a64-be46-a333bb0bdc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4d8ab5-252c-4727-817d-6f18cbaedd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4d8ab5-252c-4727-817d-6f18cbaedd91.jpg?1",
             "name": "Master of Cruelties",
             "text": "First strike, deathtouch\nMaster of Cruelties can only attack alone.\nWhenever Master of Cruelties attacks a player and isn't blocked, that player's life total becomes 1. Master of Cruelties assigns no combat damage this combat.",
             "colours": [
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "82a68eac-1213-5c42-a7ab-48028ddb143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1131c6-04da-4c4d-ab61-874ac5be7087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1131c6-04da-4c4d-ab61-874ac5be7087.jpg?1",
             "name": "Maw of the Obzedat",
             "text": "Sacrifice a creature: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "10ec3ff3-a4b3-5f66-b7ba-c5b8625ac81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e892d86-f443-4846-8049-40ec6b8c22b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e892d86-f443-4846-8049-40ec6b8c22b4.jpg?1",
             "name": "Melek, Izzet Paragon",
             "text": "Play with the top card of your library revealed.\nYou may cast the top card of your library if it's an instant or sorcery card.\nWhenever you cast an instant or sorcery spell from your library, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -2910,7 +2910,7 @@
         },
         {
             "id": "659ff13f-3a4b-5e7b-96a2-1091ba0d293c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37cdd3e-4303-4391-aff4-4a543e65a836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37cdd3e-4303-4391-aff4-4a543e65a836.jpg?1",
             "name": "Mirko Vosk, Mind Drinker",
             "text": "Flying\nWhenever Mirko Vosk, Mind Drinker deals combat damage to a player, that player reveals cards from the top of his or her library until he or she reveals four land cards, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2948,7 +2948,7 @@
         },
         {
             "id": "768aea19-db3b-58b4-a6a8-a0eb3669dbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c2909-87ab-4027-9b56-58a2abae3fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c2909-87ab-4027-9b56-58a2abae3fa3.jpg?1",
             "name": "Morgue Burst",
             "text": "Return target creature card from your graveyard to your hand. Morgue Burst deals damage to target creature or player equal to the power of the card returned this way.",
             "colours": [
@@ -2982,7 +2982,7 @@
         },
         {
             "id": "1ec7016b-8b75-55cc-8c05-4964cbd1c331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7a0e26-8cd4-4f53-8922-93ca28b1879b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7a0e26-8cd4-4f53-8922-93ca28b1879b.jpg?1",
             "name": "Nivix Cyclops",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, Nivix Cyclops gets +3/+0 until end of turn and can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "aed7f997-c431-5032-9f42-4fcb63b04d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e660b-ad8b-49d2-a7e5-6588e496519b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728e660b-ad8b-49d2-a7e5-6588e496519b.jpg?1",
             "name": "Notion Thief",
             "text": "Flash\nIf an opponent would draw a card except the first one he or she draws in each of his or her draw steps, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "5c62efa6-2d16-58d9-b3b6-6ed790c3c1cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b846ba99-81ba-424a-98eb-f9f69c40f984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b846ba99-81ba-424a-98eb-f9f69c40f984.jpg?1",
             "name": "Obzedat's Aid",
             "text": "Return target permanent card from your graveyard to the battlefield.",
             "colours": [
@@ -3089,7 +3089,7 @@
         },
         {
             "id": "5ef35577-cd4b-523a-91b9-4889010ad3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3475fcc6-ee53-48da-89d2-80685a584e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3475fcc6-ee53-48da-89d2-80685a584e6a.jpg?1",
             "name": "Pilfered Plans",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard. Draw two cards.",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "978d1a92-eaa2-5044-af7e-4ff184d24af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe8485-d5fb-47cc-af53-6e0fd062b7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe8485-d5fb-47cc-af53-6e0fd062b7a2.jpg?1",
             "name": "Plasm Capture",
             "text": "Counter target spell. At the beginning of your next precombat main phase, add X mana in any combination of colors to your mana pool, where X is that spell's converted mana cost.",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "d8d14e18-5d7a-582d-a238-b7e2a8f91362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad76314-b5d5-4353-86aa-e899e0d757a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad76314-b5d5-4353-86aa-e899e0d757a5.jpg?1",
             "name": "Progenitor Mimic",
             "text": "You may have Progenitor Mimic enter the battlefield as a copy of any creature on the battlefield except it gains \"At the beginning of your upkeep, if this creature isn't a token, put a token onto the battlefield that's a copy of this creature.\"",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "68d2c7fe-4f24-50cc-8b6b-288cab25b00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d43a0b6-2a5c-4959-96ee-6e570949dfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d43a0b6-2a5c-4959-96ee-6e570949dfed.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "9a8136f4-5220-5b76-bdfb-d5f35ad8275a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdbb062-0b0b-4b4c-b4db-dd149f744baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdbb062-0b0b-4b4c-b4db-dd149f744baa.jpg?1",
             "name": "Ral Zarek",
             "text": "+1: Tap target permanent, then untap another target permanent.\n-2: Ral Zarek deals 3 damage to target creature or player.\n-7: Flip five coins. Take an extra turn after this one for each coin that comes up heads.",
             "colours": [
@@ -3265,7 +3265,7 @@
         },
         {
             "id": "8568c0a5-3aec-54fe-a2ad-19c178402a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6297df2-c67a-4054-9617-5c6202c76de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6297df2-c67a-4054-9617-5c6202c76de8.jpg?1",
             "name": "Reap Intellect",
             "text": "Target opponent reveals his or her hand. You choose up to X nonland cards from it and exile them. For each card exiled this way, search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "cd83f152-6819-5734-946d-0f46bcc570a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f3d6e4-0abe-4042-a7f6-0395683e8582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f3d6e4-0abe-4042-a7f6-0395683e8582.jpg?1",
             "name": "Render Silent",
             "text": "Counter target spell. Its controller can't cast spells this turn.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "be66c38d-ca82-56f0-8d8c-9e68757aca7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105902f6-99d0-4bee-9dfd-87a92ac04d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105902f6-99d0-4bee-9dfd-87a92ac04d91.jpg?1",
             "name": "Restore the Peace",
             "text": "Return each creature that dealt damage this turn to its owner's hand.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "ac779edf-e69a-5fa7-9f42-5442f6085d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5af2dd-75c7-402c-be9a-3d0d4290520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5af2dd-75c7-402c-be9a-3d0d4290520c.jpg?1",
             "name": "Rot Farm Skeleton",
             "text": "Rot Farm Skeleton can't block.\n{2}{B}{G}, Put the top four cards of your library into your graveyard: Return Rot Farm Skeleton from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "4e92b500-0869-5cbc-b699-fc193feb9c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dd3586-7c3b-4f9c-a1eb-7745b75339b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dd3586-7c3b-4f9c-a1eb-7745b75339b0.jpg?1",
             "name": "Ruric Thar, the Unbowed",
             "text": "Vigilance, reach\nRuric Thar, the Unbowed attacks each turn if able.\nWhenever a player casts a noncreature spell, Ruric Thar deals 6 damage to that player.",
             "colours": [
@@ -3443,7 +3443,7 @@
         },
         {
             "id": "ed6fc784-532d-583c-b817-69b017666cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b73cd-6179-4885-9d92-1782d0b492c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2b73cd-6179-4885-9d92-1782d0b492c1.jpg?1",
             "name": "Savageborn Hydra",
             "text": "Double strike\nSavageborn Hydra enters the battlefield with X +1/+1 counters on it.\n{1}{RG}: Put a +1/+1 counter on Savageborn Hydra. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "91eedeef-8ebd-5b6b-bf1d-241a8e289c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e360ae-4c78-47a9-81d4-1849cfa518b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e360ae-4c78-47a9-81d4-1849cfa518b7.jpg?1",
             "name": "Scab-Clan Giant",
             "text": "When Scab-Clan Giant enters the battlefield, it fights target creature an opponent controls chosen at random.",
             "colours": [
@@ -3516,7 +3516,7 @@
         },
         {
             "id": "b56c828e-2114-57dc-bad3-6fbfb6c16b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd1f68b-3f16-484e-95c9-5cfa8da218c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd1f68b-3f16-484e-95c9-5cfa8da218c9.jpg?1",
             "name": "Showstopper",
             "text": "Until end of turn, creatures you control gain \"When this creature dies, it deals 2 damage to target creature an opponent controls.\"",
             "colours": [
@@ -3550,7 +3550,7 @@
         },
         {
             "id": "d3d51757-20b7-598f-9db9-6cd894669c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305a3feb-df49-486c-a3b4-ff2721d60019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305a3feb-df49-486c-a3b4-ff2721d60019.jpg?1",
             "name": "Sin Collector",
             "text": "When Sin Collector enters the battlefield, target opponent reveals his or her hand. You choose an instant or sorcery card from it and exile that card.",
             "colours": [
@@ -3587,7 +3587,7 @@
         },
         {
             "id": "af1f641f-2934-5bb9-85ef-c48c4f31389a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3665cfb7-51b6-4083-8eae-fbd3fa6c3554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3665cfb7-51b6-4083-8eae-fbd3fa6c3554.jpg?1",
             "name": "Sire of Insanity",
             "text": "At the beginning of each end step, each player discards his or her hand.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "49766be6-bc26-5303-9df2-d5add9134124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0087a98-55cf-4c8b-a180-fb0d9c336eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0087a98-55cf-4c8b-a180-fb0d9c336eb2.jpg?1",
             "name": "Species Gorger",
             "text": "At the beginning of your upkeep, return a creature you control to its owner's hand.",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "7bde76de-2130-566f-b4df-3e55fa4ba832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec50499-70d4-4dc1-9cae-abbecfc8e87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec50499-70d4-4dc1-9cae-abbecfc8e87d.jpg?1",
             "name": "Spike Jester",
             "text": "Haste",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "effd998a-2628-5543-83fb-3427e5468ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5717c1-338e-446c-aa7e-93e79e4abb72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5717c1-338e-446c-aa7e-93e79e4abb72.jpg?1",
             "name": "Tajic, Blade of the Legion",
             "text": "Tajic, Blade of the Legion is indestructible.\nBattalion \u2014 Whenever Tajic and at least two other creatures attack, Tajic gets +5/+5 until end of turn.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "1e238e23-c947-5974-af2a-5c2cdd6412e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd8183c-6967-4332-b822-02b82c14ef2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd8183c-6967-4332-b822-02b82c14ef2d.jpg?1",
             "name": "Teysa, Envoy of Ghosts",
             "text": "Vigilance, protection from creatures\nWhenever a creature deals combat damage to you, destroy that creature. Put a 1/1 white and black Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -3775,7 +3775,7 @@
         },
         {
             "id": "bb490f68-a110-5e9a-b4c4-67a3605202cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069aa06-35b0-4af8-89cb-af653708ed32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069aa06-35b0-4af8-89cb-af653708ed32.jpg?1",
             "name": "Tithe Drinker",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "f03666b0-aa28-5627-929d-707d0345cce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921fa4e-2256-4ef1-b2fe-874f9fbbcdf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921fa4e-2256-4ef1-b2fe-874f9fbbcdf3.jpg?1",
             "name": "Trostani's Summoner",
             "text": "When Trostani's Summoner enters the battlefield, put a 2/2 white Knight creature token with vigilance, a 3/3 green Centaur creature token, and a 4/4 green Rhino creature token with trample onto the battlefield.",
             "colours": [
@@ -3848,7 +3848,7 @@
         },
         {
             "id": "05ef566c-a1e1-53f2-9563-9c897db39ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35952c24-d728-4ec6-b0d1-b8183a18554a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35952c24-d728-4ec6-b0d1-b8183a18554a.jpg?1",
             "name": "Unflinching Courage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample and lifelink.",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "f1472ab6-d72b-566b-b6a2-e95b82331c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3ae3db-c14a-4ffc-805c-a3a51da9370d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3ae3db-c14a-4ffc-805c-a3a51da9370d.jpg?1",
             "name": "Varolz, the Scar-Striped",
             "text": "Each creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.)\nSacrifice another creature: Regenerate Varolz, the Scar-Striped.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "b3d46c7c-7eea-5fe9-977d-3168a50aab6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0c21c-bdf1-478a-9ad8-6c6bda6ffb0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0c21c-bdf1-478a-9ad8-6c6bda6ffb0f.jpg?1",
             "name": "Viashino Firstblade",
             "text": "Haste\nWhen Viashino Firstblade enters the battlefield, it gets +2/+2 until end of turn.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "0ca44f26-1a27-5369-a0a0-e260f4d800ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07246783-d475-4f61-99ac-e2b574072349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07246783-d475-4f61-99ac-e2b574072349.jpg?1",
             "name": "Voice of Resurgence",
             "text": "Whenever an opponent casts a spell during your turn or when Voice of Resurgence dies, put a green and white Elemental creature token onto the battlefield with \"This creature's power and toughness are each equal to the number of creatures you control.\"",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "4dec73e5-557e-5069-8683-e69b1407bfed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0665d4-d974-4d5e-ba29-7bf40cbbe29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0665d4-d974-4d5e-ba29-7bf40cbbe29c.jpg?1",
             "name": "Vorel of the Hull Clade",
             "text": "{G}{U}, {T}: For each counter on target artifact, creature, or land, put another of those counters on that permanent.",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "32a64f45-26a5-57c0-8cc8-5e314f4c0f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e474ac-54f7-43f9-8af9-2f1adf258b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e474ac-54f7-43f9-8af9-2f1adf258b15.jpg?1",
             "name": "Warleader's Helix",
             "text": "Warleader's Helix deals 4 damage to target creature or player and you gain 4 life.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "f82deb2f-647e-5405-81bd-cb5048d0c392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134802b2-7c5c-4eda-a879-b29bc06faaed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134802b2-7c5c-4eda-a879-b29bc06faaed.jpg?1",
             "name": "Warped Physique",
             "text": "Target creature gets +X/-X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "54b3c131-3460-580b-9c71-45a215fd8d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1e6fe-e959-4030-9925-9ccc27040275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1e6fe-e959-4030-9925-9ccc27040275.jpg?1",
             "name": "Woodlot Crawler",
             "text": "Forestwalk, protection from green",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "5ff9ce34-59d2-5bb0-a907-19db98c77887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2076308f-0f4e-4b31-9e75-c2965942e7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2076308f-0f4e-4b31-9e75-c2965942e7d1.jpg?1",
             "name": "Zhur-Taa Ancient",
             "text": "Whenever a player taps a land for mana, that player adds one mana to his or her mana pool of any type that land produced.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "63b65db7-b1c0-5c6e-a941-974f0168467e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd565782-8b2f-4b9f-a62d-4af60af20a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd565782-8b2f-4b9f-a62d-4af60af20a82.jpg?1",
             "name": "Zhur-Taa Druid",
             "text": "{T}: Add {G} to your mana pool.\nWhenever you tap Zhur-Taa Druid for mana, it deals 1 damage to each opponent.",
             "colours": [
@@ -4212,7 +4212,7 @@
         },
         {
             "id": "7f5f719b-947a-50b0-834b-693f59fc0bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg?1",
             "name": "Alive // Well",
             "text": "Put a 3/3 green Centaur creature token onto the battlefield.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "9e4f170e-6610-5655-827f-25550996d0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db84415e-048a-4cfc-9121-5ae17a412198.jpg?1",
             "name": "Alive // Well",
             "text": "You gain 2 life for each creature you control.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4278,7 +4278,7 @@
         },
         {
             "id": "d0a285c2-890f-55e9-b208-7a58b621c423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg?1",
             "name": "Armed // Dangerous",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "56488133-3089-5ca0-ad07-f6a926e3feb9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff7f4fc2-6f76-44e7-a30b-7166a0d10d2a.jpg?1",
             "name": "Armed // Dangerous",
             "text": "All creatures able to block target creature this turn do so.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "85c87a3f-ab18-5135-8e8a-b7f0bb2f30b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg?1",
             "name": "Beck // Call",
             "text": "Whenever a creature enters the battlefield this turn, you may draw a card.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "7ee5faec-ccc1-5e35-84fa-d0dbbbdb778f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/0/a01d6540-9eaf-4e08-a62d-682551ee78e9.jpg?1",
             "name": "Beck // Call",
             "text": "Put four 1/1 white Bird creature tokens with flying onto the battlefield.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "330afd68-39e8-544e-8ce2-d4d4a6c4fac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg?1",
             "name": "Breaking // Entering",
             "text": "Target player puts the top eight cards of his or her library into his or her graveyard.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "97bada65-7590-55d1-900a-ee8488d8cadb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66724f4e-59dd-4c70-b09b-49947320e6d1.jpg?1",
             "name": "Breaking // Entering",
             "text": "Put a creature card from a graveyard onto the battlefield under your control. It gains haste until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "ed55a9ee-f1bb-5178-9259-3160b7c65c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg?1",
             "name": "Catch // Release",
             "text": "Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "44a70943-7e2e-5c3b-9453-5a085dced28f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29968873-56f3-4528-ab0b-f11dd67dd162.jpg?1",
             "name": "Catch // Release",
             "text": "Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "25a0a5e8-794c-50a2-a2c3-b18c9a349c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg?1",
             "name": "Down // Dirty",
             "text": "Target player discards two cards.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "c1a29064-f090-503c-9578-015a9d2bbff2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c35c63c1-6344-4d8c-8f7d-cd253d12f9ae.jpg?1",
             "name": "Down // Dirty",
             "text": "Return target card from your graveyard to your hand.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "cbf4d6cd-1341-5841-89ed-f996b99fad8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg?1",
             "name": "Far // Away",
             "text": "Return target creature to its owner's hand.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4653,7 +4653,7 @@
         },
         {
             "id": "2a4f4e5a-6a38-5880-8bf8-b0c1b0045ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d13cdb71-a499-41db-84e6-95f84650c524.jpg?1",
             "name": "Far // Away",
             "text": "Target player sacrifices a creature.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4686,7 +4686,7 @@
         },
         {
             "id": "cc068d00-3075-5217-8896-c32caefc69e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg?1",
             "name": "Flesh // Blood",
             "text": "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "2c3149d4-1e00-5851-bcdc-8118f91b5e36",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02b40fe4-901a-4832-8d52-a6bb5cc07b63.jpg?1",
             "name": "Flesh // Blood",
             "text": "Target creature you control deals damage equal to its power to target creature or player.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "3c0a1207-b39f-5caa-85e9-72f07a83cf56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg?1",
             "name": "Give // Take",
             "text": "Put three +1/+1 counters on target creature.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4789,7 +4789,7 @@
         },
         {
             "id": "073efd6b-4cfa-52ba-b209-8a20a8337688",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9af07d28-45a2-45d6-b1cb-0858c609a881.jpg?1",
             "name": "Give // Take",
             "text": "Remove all +1/+1 counters from target creature you control. Draw that many cards.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "a15ef45d-90c8-5380-b703-bca06d570109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg?1",
             "name": "Profit // Loss",
             "text": "Creatures you control get +1/+1 until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "39f7e585-dabf-5fd0-9026-dbc7ac816af5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0eb3ce46-ddd2-43b3-9e45-019ae91df686.jpg?1",
             "name": "Profit // Loss",
             "text": "Creatures your opponents control get -1/-1 until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "10d7aced-4982-50bc-b66a-784382e63687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg?1",
             "name": "Protect // Serve",
             "text": "Target creature gets +2/+4 until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "9e8cf6c1-e78c-51f5-afc9-8f953cbc7b45",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b8acd7d-f3e2-4358-91ab-40901b68d64c.jpg?1",
             "name": "Protect // Serve",
             "text": "Target creature gets -6/-0 until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "b9834378-cf65-5b1f-af7c-0498821613ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg?1",
             "name": "Ready // Willing",
             "text": "Creatures you control are indestructible this turn. Untap each creature you control.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "6ce4f670-203d-5abc-af0c-45ec21b061d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22081f95-dc8e-41ed-b609-b6a22ee5428b.jpg?1",
             "name": "Ready // Willing",
             "text": "Creatures you control gain deathtouch and lifelink until end of turn.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "ab2c4624-e208-53a6-beba-e85aa46b9222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg?1",
             "name": "Toil // Trouble",
             "text": "Target player draws two cards and loses 2 life.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "3188266a-9cf6-5037-b7bc-bf137ccb9a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15bb3454-e3bb-4af9-9e93-461e210c26b7.jpg?1",
             "name": "Toil // Trouble",
             "text": "Trouble deals damage to target player equal to the number of cards in that player's hand.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "0d576072-ff48-50bc-b7b4-e434daf9f636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg?1",
             "name": "Turn // Burn",
             "text": "Target creature loses all abilities and becomes a 0/1 red Weird until end of turn.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5123,7 +5123,7 @@
         },
         {
             "id": "7fd108ce-4422-5d0a-a5cf-cebb9eefcc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d7fdd59-6d76-4a0c-ac75-816345ef4a39.jpg?1",
             "name": "Turn // Burn",
             "text": "Burn deals 2 damage to target creature or player.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "00e889ab-c5ba-5941-a50c-2f654e9390c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target artifact.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "838d6449-7190-56d8-bc7c-1e23c1cc20c0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d169a3b2-18ae-4414-98ef-d879676fdcc0.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target enchantment.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "2da9b6a4-e63d-5ca2-bffb-a88944e0eaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb301-bc28-4515-ad69-0b1b5164a5bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb301-bc28-4515-ad69-0b1b5164a5bc.jpg?1",
             "name": "Azorius Cluestone",
             "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}, {T}, Sacrifice Azorius Cluestone: Draw a card.",
             "colours": [],
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "0b24ed80-30c0-5e7b-873a-aeaa91700528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87252577-3e7b-4ea2-b0ac-3ba3f0eaac40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87252577-3e7b-4ea2-b0ac-3ba3f0eaac40.jpg?1",
             "name": "Boros Cluestone",
             "text": "{T}: Add {R} or {W} to your mana pool.\n{R}{W}, {T}, Sacrifice Boros Cluestone: Draw a card.",
             "colours": [],
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "ccb97dc5-383b-5e74-93d3-c24923b4c3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8ac24f-3309-453a-b2d6-6363df9a1ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8ac24f-3309-453a-b2d6-6363df9a1ddd.jpg?1",
             "name": "Dimir Cluestone",
             "text": "{T}: Add {U} or {B} to your mana pool.\n{U}{B}, {T}, Sacrifice Dimir Cluestone: Draw a card.",
             "colours": [],
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "94e2d452-b13d-5b5e-b92f-826799db405e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff77e1ee-7fa3-4370-a0c9-ec008b63302f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff77e1ee-7fa3-4370-a0c9-ec008b63302f.jpg?1",
             "name": "Golgari Cluestone",
             "text": "{T}: Add {B} or {G} to your mana pool.\n{B}{G}, {T}, Sacrifice Golgari Cluestone: Draw a card.",
             "colours": [],
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "78f0320a-d4d4-5200-b199-237600d61499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc47d1fe-8ab2-42f6-bcab-4bc2084ceba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc47d1fe-8ab2-42f6-bcab-4bc2084ceba7.jpg?1",
             "name": "Gruul Cluestone",
             "text": "{T}: Add {R} or {G} to your mana pool.\n{R}{G}, {T}, Sacrifice Gruul Cluestone: Draw a card.",
             "colours": [],
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "8a5722ac-5410-5b35-a3e7-2829fbdc0c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf63def-e2cc-48c7-8409-c08a36eddf93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf63def-e2cc-48c7-8409-c08a36eddf93.jpg?1",
             "name": "Izzet Cluestone",
             "text": "{T}: Add {U} or {R} to your mana pool.\n{U}{R}, {T}, Sacrifice Izzet Cluestone: Draw a card.",
             "colours": [],
@@ -5408,7 +5408,7 @@
         },
         {
             "id": "45fac33e-c179-5728-b5ba-922b5346925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4823f904-1c41-42cf-aef7-db0dcf82b10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4823f904-1c41-42cf-aef7-db0dcf82b10b.jpg?1",
             "name": "Orzhov Cluestone",
             "text": "{T}: Add {W} or {B} to your mana pool.\n{W}{B}, {T}, Sacrifice Orzhov Cluestone: Draw a card.",
             "colours": [],
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "e1dc971c-0450-5707-a7df-55ab648c15f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef43817-1813-4608-8e3d-3c14321ab736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef43817-1813-4608-8e3d-3c14321ab736.jpg?1",
             "name": "Rakdos Cluestone",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{B}{R}, {T}, Sacrifice Rakdos Cluestone: Draw a card.",
             "colours": [],
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "3b045440-a0c0-5b25-b8ab-8e887f28a5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad5631-439a-43e2-b00a-04f78d66b8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad5631-439a-43e2-b00a-04f78d66b8e6.jpg?1",
             "name": "Selesnya Cluestone",
             "text": "{T}: Add {G} or {W} to your mana pool.\n{G}{W}, {T}, Sacrifice Selesnya Cluestone: Draw a card.",
             "colours": [],
@@ -5501,7 +5501,7 @@
         },
         {
             "id": "0f32ffc0-b18f-5e68-b533-4e83af3f57e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c47552-afed-463d-bd24-13eb1cd724fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c47552-afed-463d-bd24-13eb1cd724fc.jpg?1",
             "name": "Simic Cluestone",
             "text": "{T}: Add {G} or {U} to your mana pool.\n{G}{U}, {T}, Sacrifice Simic Cluestone: Draw a card.",
             "colours": [],
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "5ba0dcdf-f7a3-5636-bc9c-0422729a6821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bbe27d-c92a-4c65-a997-b21536d7667e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bbe27d-c92a-4c65-a997-b21536d7667e.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "b423fa16-eb47-5ae4-8e11-23c210877650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94cc167-a6da-4404-88aa-61eee8b4b9e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94cc167-a6da-4404-88aa-61eee8b4b9e8.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "e59027bb-8737-5b1b-bb51-fb0a7effc50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627f9eb-c3fc-4517-9d65-132fdcc217d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627f9eb-c3fc-4517-9d65-132fdcc217d7.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "68207548-c302-5a28-b6a2-76ec2e55000d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0248cc88-e95c-4667-82a2-40e881acabc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0248cc88-e95c-4667-82a2-40e881acabc2.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "3ed109b1-8af3-556a-aad0-c4f02caddc35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24221b9a-5ff1-43f8-b409-c56967f8308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24221b9a-5ff1-43f8-b409-c56967f8308d.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "0e5950e3-57a8-591c-abdc-647e089cac03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165ee8d7-d509-41d4-abd2-298b3db3ca46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165ee8d7-d509-41d4-abd2-298b3db3ca46.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "9b52754e-74f8-5a3d-b296-67fd7cde9877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f7042-24fd-42a0-ae7c-e6b7de1aa446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401f7042-24fd-42a0-ae7c-e6b7de1aa446.jpg?1",
             "name": "Maze's End",
             "text": "Maze's End enters the battlefield tapped.\n{T}: Add {1} to your mana pool.\n{3}, {T}, Return Maze's End to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle your library. If you control ten or more Gates with different names, you win the game.",
             "colours": [],
@@ -5758,7 +5758,7 @@
         },
         {
             "id": "5479b6cf-816f-5c44-a972-304eb87cfc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e2006-5bff-4e91-862b-aa76521a99c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e2006-5bff-4e91-862b-aa76521a99c3.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "df5f7ebf-422e-52a3-bc12-19bf116484dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1368e7c6-2220-4dad-8129-68336f261af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1368e7c6-2220-4dad-8129-68336f261af0.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "9c6871ce-a971-5a9a-b63c-8afa747c90ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90198725-0cd3-4650-9575-c22674aa4185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90198725-0cd3-4650-9575-c22674aa4185.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "c7a4cb9a-a976-53e5-94cc-f54f48eb668a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee34fcb-0158-4741-9292-513fed9684cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee34fcb-0158-4741-9292-513fed9684cb.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -5890,7 +5890,7 @@
         },
         {
             "id": "c24dadf0-35cd-5122-91a2-c6744ff64ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfb1440-d4c1-42cf-a777-ee1644dbbac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfb1440-d4c1-42cf-a777-ee1644dbbac7.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/DIS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DIS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9cbfe285-ce53-5b65-8c65-d56215c9d65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb3d0b-8630-4373-b863-bc831cf08098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb3d0b-8630-4373-b863-bc831cf08098.jpg?1",
             "name": "Aurora Eidolon",
             "text": "{W}, Sacrifice Aurora Eidolon: Prevent the next 3 damage that would be dealt to target creature or player this turn.\nWhenever you play a multicolored spell, you may return Aurora Eidolon from your graveyard to your hand.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "5df9324a-27bf-53ba-a867-0d8aa26f4434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1923ffb2-1fab-475a-914a-120312e26628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1923ffb2-1fab-475a-914a-120312e26628.jpg?1",
             "name": "Azorius Herald",
             "text": "Azorius Herald is unblockable.\nWhen Azorius Herald comes into play, you gain 4 life.\nWhen Azorius Herald comes into play, sacrifice it unless {U} was spent to play it.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "97b24743-a520-571e-9198-cc015ca5971c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ea4a-087e-4a6d-9973-0778a1ed2b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be04ea4a-087e-4a6d-9973-0778a1ed2b7e.jpg?1",
             "name": "Beacon Hawk",
             "text": "Flying\nWhenever Beacon Hawk deals combat damage to a player, you may untap target creature.\n{W}: Beacon Hawk gets +0/+1 until end of turn.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "e8bc3aea-ebee-5fc5-a309-bd181b2b7905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689b4ba1-5bb5-458d-8900-19a330e0093c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689b4ba1-5bb5-458d-8900-19a330e0093c.jpg?1",
             "name": "Blessing of the Nephilim",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each of its colors.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "ae6ab120-5a88-5aea-baee-eda4929761a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1f1c57-693f-452b-951f-8c8c23f2ee99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1f1c57-693f-452b-951f-8c8c23f2ee99.jpg?1",
             "name": "Brace for Impact",
             "text": "Prevent all damage that would be dealt to target multicolored creature this turn. For each 1 damage prevented this way, put a +1/+1 counter on that creature.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "381ef883-10d9-5ab6-a98a-abef28b7b856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184e0964-1e04-49f9-bb76-0a6e682c52f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184e0964-1e04-49f9-bb76-0a6e682c52f5.jpg?1",
             "name": "Carom",
             "text": "The next 1 damage that would be dealt to target creature this turn is dealt to another target creature instead.\nDraw a card.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "9ab40ad1-e2f2-5dfe-90cb-006f74921008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012fb3a6-99ff-4b5e-96e3-0a2eeca36bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012fb3a6-99ff-4b5e-96e3-0a2eeca36bdb.jpg?1",
             "name": "Celestial Ancient",
             "text": "Flying\nWhenever you play an enchantment spell, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "1b80696b-dde2-50fe-90e5-4c0943abb088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4f5a0-b2d0-4a60-b1e1-bb2140abfd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d4f5a0-b2d0-4a60-b1e1-bb2140abfd6d.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "6b730b4f-63f9-5691-aa75-edb4c618ad5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b82b76d-697b-4312-aab5-bf741c207438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b82b76d-697b-4312-aab5-bf741c207438.jpg?1",
             "name": "Freewind Equenaut",
             "text": "Flying\nAs long as Freewind Equenaut is enchanted, it has \"{T}: Freewind Equenaut deals 2 damage to target attacking or blocking creature.\"",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "b87fb0d8-5b16-5b57-a0c7-d8b867b0990d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8dd004b-01e4-4fe1-a164-9f2ea8d7d88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8dd004b-01e4-4fe1-a164-9f2ea8d7d88e.jpg?1",
             "name": "Guardian of the Guildpact",
             "text": "Protection from monocolored",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "7847de2e-431d-5223-ab05-755b319a6191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca97f2-cf38-4d68-80a9-f4e890271e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca97f2-cf38-4d68-80a9-f4e890271e5c.jpg?1",
             "name": "Haazda Exonerator",
             "text": "{T}, Sacrifice Haazda Exonerator: Destroy target Aura.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "c61c66fb-3344-537e-9e01-ba20567b0996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940e8c6-1423-4dbf-89c8-9055bf15d4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940e8c6-1423-4dbf-89c8-9055bf15d4ec.jpg?1",
             "name": "Haazda Shield Mate",
             "text": "At the beginning of your upkeep, sacrifice Haazda Shield Mate unless you pay {W}{W}.\n{W}: The next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "ba2f7af2-d446-5ae6-b585-c16ff7d54106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19db5386-3ef1-4654-8494-6e7949ed7234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19db5386-3ef1-4654-8494-6e7949ed7234.jpg?1",
             "name": "Mistral Charger",
             "text": "Flying",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "05732b9b-d508-5481-a9a6-ca3090f0ca33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c1dc-e676-4c24-93b0-db2aae663ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c1dc-e676-4c24-93b0-db2aae663ea2.jpg?1",
             "name": "Paladin of Prahv",
             "text": "Whenever Paladin of Prahv deals damage, you gain that much life.\nForecast {1}{W}, Reveal Paladin of Prahv from your hand: Whenever target creature deals damage this turn, you gain that much life. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "ecc2a3ff-56ba-59f6-8e0d-80e0bc180786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc799c97-3df1-4194-b220-6cf862ce3810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc799c97-3df1-4194-b220-6cf862ce3810.jpg?1",
             "name": "Proclamation of Rebirth",
             "text": "Return up to three target creature cards with converted mana cost 1 or less from your graveyard to play.\nForecast {5}{W}, Reveal Proclamation of Rebirth from your hand: Return target creature card with converted mana cost 1 or less from your graveyard to play. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "c5921d8f-9459-5f35-85fc-6f0543fd713b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a4756-d82b-4c6d-b652-5c3722d3edec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a4756-d82b-4c6d-b652-5c3722d3edec.jpg?1",
             "name": "Proper Burial",
             "text": "Whenever a creature you control is put into a graveyard from play, you gain life equal to that creature's toughness.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "129b97e1-93a2-5506-9dac-e61d92f9f405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668c4e40-0035-44e0-8401-dd17fa11ecd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668c4e40-0035-44e0-8401-dd17fa11ecd4.jpg?1",
             "name": "Soulsworn Jury",
             "text": "Defender (This creature can't attack.)\n{1}{U}, Sacrifice Soulsworn Jury: Counter target creature spell.",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "495d4524-adf3-527a-aa17-d242cbe88749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f89bd01-310e-4ec2-8d42-052c66ff8d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f89bd01-310e-4ec2-8d42-052c66ff8d0f.jpg?1",
             "name": "Steeling Stance",
             "text": "Creatures you control get +1/+1 until end of turn.\nForecast {W}, Reveal Steeling Stance from your hand: Target creature gets +1/+1 until end of turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "1f125c37-e38b-5c6f-92fe-cc8614c2c51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bff58-e7cd-4787-a2c1-1afd6ed1b4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bff58-e7cd-4787-a2c1-1afd6ed1b4ff.jpg?1",
             "name": "Stoic Ephemera",
             "text": "Defender (This creature can't attack.)\nFlying\nWhen Stoic Ephemera blocks, sacrifice it at end of combat.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "ee5c6d40-c62b-5f23-ae2c-edc576c0d51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3554f9e9-3f09-490a-9284-28c7aefc70d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3554f9e9-3f09-490a-9284-28c7aefc70d0.jpg?1",
             "name": "Valor Made Real",
             "text": "Target creature can block any number of creatures this turn.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "edd870f6-5e23-5c91-80ef-fbd9f9974ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52bdb-81a6-45c6-942c-373f1dabc8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52bdb-81a6-45c6-942c-373f1dabc8d8.jpg?1",
             "name": "Wakestone Gargoyle",
             "text": "Defender (This creature can't attack.)\nFlying\n{1}{W}: Creatures you control with defender can attack this turn as though they didn't have defender.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "0d66306a-3908-56ed-aa0c-0e90290d91b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970f492-d4fc-4833-a083-05e422a3c456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4970f492-d4fc-4833-a083-05e422a3c456.jpg?1",
             "name": "Court Hussar",
             "text": "Vigilance\nWhen Court Hussar comes into play, look at the top three cards of your library, then put one of them into your hand and the rest on the bottom of your library in any order.\nWhen Court Hussar comes into play, sacrifice it unless {W} was spent to play it.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "d275f26a-702c-50d8-954e-b79c00fc662e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb6b06d-b132-44e9-a743-61187afb6152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb6b06d-b132-44e9-a743-61187afb6152.jpg?1",
             "name": "Cytoplast Manipulator",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{U}, {T}: Gain control of target creature with a +1/+1 counter on it as long as Cytoplast Manipulator remains in play.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "b141e78f-fe0e-58df-ad03-ad9963213ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814a1082-6e2c-46d3-9b45-12dab7006c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814a1082-6e2c-46d3-9b45-12dab7006c0f.jpg?1",
             "name": "Enigma Eidolon",
             "text": "{U}, Sacrifice Enigma Eidolon: Target player puts the top three cards of his or her library into his or her graveyard.\nWhenever you play a multicolored spell, you may return Enigma Eidolon from your graveyard to your hand.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "d5fca825-58c9-50ba-91bf-511b74b8aa4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23106341-9200-4eee-93d0-d6173b0b39c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23106341-9200-4eee-93d0-d6173b0b39c4.jpg?1",
             "name": "Govern the Guildless",
             "text": "Gain control of target monocolored creature.\nForecast {1}{U}, Reveal Govern the Guildless from your hand: Target creature becomes the color or colors of your choice until end of turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "dcc5fe9b-d008-5f8c-b7fb-babaffba1484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764e3d28-1876-46da-b927-b98089d62776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764e3d28-1876-46da-b927-b98089d62776.jpg?1",
             "name": "Helium Squirter",
             "text": "Graft 3 (This creature comes into play with three +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}: Target creature with a +1/+1 counter on it gains flying until end of turn.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "ba669c21-cac1-51c1-90ef-e305f2ddea48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ec467e-5d4a-4941-ac30-801ed681da54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ec467e-5d4a-4941-ac30-801ed681da54.jpg?1",
             "name": "Novijen Sages",
             "text": "Graft 4 (This creature comes into play with four +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}, Remove two +1/+1 counters from among creatures you control: Draw a card.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "612a12b3-717a-5c3e-bfa6-c5464c4fe195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c883e75-5c37-44bb-a6c8-f97aa704c739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c883e75-5c37-44bb-a6c8-f97aa704c739.jpg?1",
             "name": "Ocular Halo",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Draw a card.\"\n{W}: Enchanted creature gains vigilance until end of turn.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "84388715-61f0-5602-abfe-9c3e6aae43a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae3598d-4d76-45ac-ab96-00d27a8de6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae3598d-4d76-45ac-ab96-00d27a8de6c8.jpg?1",
             "name": "Plaxmanta",
             "text": "You may play Plaxmanta any time you could play an instant.\nWhen Plaxmanta comes into play, creatures you control can't be the targets of spells or abilities this turn.\nWhen Plaxmanta comes into play, sacrifice it unless {G} was spent to play it.",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "40011488-1981-5725-ac9c-8bf412d10a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8364ce0-4c11-4af0-9f4b-e4c20d640dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8364ce0-4c11-4af0-9f4b-e4c20d640dfc.jpg?1",
             "name": "Psychic Possession",
             "text": "Enchant opponent\nSkip your draw step.\nWhenever enchanted opponent draws a card, you may draw a card.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "99126da8-1c43-5134-8e6f-8c1d1489b7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f165aa-2986-47d1-912d-d50490a15c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f165aa-2986-47d1-912d-d50490a15c0b.jpg?1",
             "name": "Silkwing Scout",
             "text": "Flying\n{G}, Sacrifice Silkwing Scout: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "c49d452a-f380-5b81-8fdf-fc505d9cd19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa63967-5422-4db5-9dba-8ab6f9b18d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa63967-5422-4db5-9dba-8ab6f9b18d60.jpg?1",
             "name": "Skyscribing",
             "text": "Each player draws X cards.\nForecast {2}{U}, Reveal Skyscribing from your hand: Each player draws a card. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "e83f40dd-591b-5a97-8bbb-d6ad0e851490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35554fdf-c70a-4baa-a35a-414caa9978be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35554fdf-c70a-4baa-a35a-414caa9978be.jpg?1",
             "name": "Spell Snare",
             "text": "Counter target spell with converted mana cost 2.",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "ef9601d2-de87-5bad-b1ce-a19c2f958ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44865244-2b9f-4734-a4da-49613b23ee4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44865244-2b9f-4734-a4da-49613b23ee4d.jpg?1",
             "name": "Tidespout Tyrant",
             "text": "Flying\nWhenever you play a spell, return target permanent to its owner's hand.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "5bc056c3-421e-5683-b35b-577b0e1a6816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c75901c-fe69-49b8-b491-879e9adf7902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c75901c-fe69-49b8-b491-879e9adf7902.jpg?1",
             "name": "Vigean Graftmage",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}{U}: Untap target creature with a +1/+1 counter on it.",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "c5f468fc-b83c-543b-a6db-61e0c932fbda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e632566-1f58-4439-983a-a25c06b7196c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e632566-1f58-4439-983a-a25c06b7196c.jpg?1",
             "name": "Vision Skeins",
             "text": "Each player draws two cards.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "15dbe322-452a-5565-b871-b5daf7200ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd58eee-1108-49be-9ae7-da179fb081c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd58eee-1108-49be-9ae7-da179fb081c2.jpg?1",
             "name": "Writ of Passage",
             "text": "Enchant creature\nWhenever enchanted creature attacks, if its power is 2 or less, it's unblockable this turn.\nForecast {1}{U}, Reveal Writ of Passage from your hand: Target creature with power 2 or less is unblockable this turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "c6fa7a15-ab2c-57fc-b23e-b4b52c733c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832acb3f-4dd4-4bf1-b990-7cc7a68a1d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832acb3f-4dd4-4bf1-b990-7cc7a68a1d57.jpg?1",
             "name": "Bond of Agony",
             "text": "As an additional cost to play Bond of Agony, pay X life.\nEach other player loses X life.",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "bcfd453b-2323-50c1-9f8f-55003824978d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65692f-fabc-4b56-a0f6-d623ed069cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65692f-fabc-4b56-a0f6-d623ed069cb8.jpg?1",
             "name": "Brain Pry",
             "text": "Name a nonland card. Target player reveals his or her hand. That player discards a card with that name. If he or she can't, you draw a card.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "72cee6ae-f7ee-5573-a062-fec8940fd055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed424a46-8bac-4a3c-a6e6-87d02a20b292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed424a46-8bac-4a3c-a6e6-87d02a20b292.jpg?1",
             "name": "Crypt Champion",
             "text": "Double strike\nWhen Crypt Champion comes into play, each player puts a creature card with converted mana cost 3 or less from his or her graveyard into play.\nWhen Crypt Champion comes into play, sacrifice it unless {R} was spent to play it.",
             "colours": [
@@ -1358,7 +1358,7 @@
         },
         {
             "id": "223e15f2-39f8-545b-8beb-46e453266314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a480f1d-1959-4318-bf66-680266fcefd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a480f1d-1959-4318-bf66-680266fcefd0.jpg?1",
             "name": "Delirium Skeins",
             "text": "Each player discards three cards.",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "1825f4b7-e7e9-5f70-a927-f438a84fca76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a3f694-0cf3-4d25-8ab0-36a3f637ff9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a3f694-0cf3-4d25-8ab0-36a3f637ff9a.jpg?1",
             "name": "Demon's Jester",
             "text": "Flying\nHellbent Demon's Jester gets +2/+1 as long as you have no cards in hand.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "936dfc83-47c4-5fc5-86f0-3c476993c681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459d8cb7-cbb8-4e73-9571-44277f1d1be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459d8cb7-cbb8-4e73-9571-44277f1d1be2.jpg?1",
             "name": "Drekavac",
             "text": "When Drekavac comes into play, sacrifice it unless you discard a noncreature card.",
             "colours": [
@@ -1458,7 +1458,7 @@
         },
         {
             "id": "160aee45-c334-5432-8330-758632416a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc7d53-2510-4322-969c-1e138287562c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc7d53-2510-4322-969c-1e138287562c.jpg?1",
             "name": "Enemy of the Guildpact",
             "text": "Protection from multicolored",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "0bd9765e-8c22-55be-9166-c17ff6466f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5998cab0-77cd-4a22-8049-37d39928df6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5998cab0-77cd-4a22-8049-37d39928df6d.jpg?1",
             "name": "Entropic Eidolon",
             "text": "{B}, Sacrifice Entropic Eidolon: Target player loses 1 life and you gain 1 life.\nWhenever you play a multicolored spell, you may return Entropic Eidolon from your graveyard to your hand.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "60f21863-44e2-51b2-9d2b-0f529937f96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4e4be5-e057-4b50-9f86-76bc0b9987de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4e4be5-e057-4b50-9f86-76bc0b9987de.jpg?1",
             "name": "Infernal Tutor",
             "text": "Reveal a card from your hand. Search your library for a card with the same name as that card, reveal it, put it into your hand, then shuffle your library.\nHellbent If you have no cards in hand, instead search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "d0817602-6dcd-53a7-9cdc-d3e2736413f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cd7bc3-73ba-4364-84b2-9954648cd8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cd7bc3-73ba-4364-84b2-9954648cd8a9.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "53acd9c7-608a-5e88-8636-207ead902483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bf458c-9e2c-4d36-90c5-d9b772f99d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bf458c-9e2c-4d36-90c5-d9b772f99d3c.jpg?1",
             "name": "Nettling Curse",
             "text": "Enchant creature\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.\n{1}{R}: Enchanted creature attacks this turn if able.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "879dc1f4-4d43-56a6-b9f2-96b6cb03818b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f7f7f7-c7eb-466c-bfe6-0ef586284ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f7f7f7-c7eb-466c-bfe6-0ef586284ee9.jpg?1",
             "name": "Nightcreep",
             "text": "Until end of turn, all creatures become black and all lands become Swamps.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "aed9cd87-e3b5-57b1-a0ca-4345b35c08b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603486d-c8d7-4a02-bdb3-c25d2bc62ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603486d-c8d7-4a02-bdb3-c25d2bc62ba6.jpg?1",
             "name": "Nihilistic Glee",
             "text": "{2}{B}, Discard a card: Target opponent loses 1 life and you gain 1 life.\nHellbent {1}, Pay 2 life: Draw a card. Play this ability only if you have no cards in hand.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "33863321-797d-57e2-ad9c-b3f0ef819b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db5cccc-e9e4-4db8-affb-93d629d67b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db5cccc-e9e4-4db8-affb-93d629d67b91.jpg?1",
             "name": "Ragamuffyn",
             "text": "Hellbent {T}, Sacrifice a creature or land: Draw a card. Play this ability only if you have no cards in hand.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "2a6ac14f-5d27-5460-8957-8fa21bea68c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0cd9c-48ec-4914-9502-afacc58ce5fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0cd9c-48ec-4914-9502-afacc58ce5fd.jpg?1",
             "name": "Ratcatcher",
             "text": "Fear\nAt the beginning of your upkeep, you may search your library for a Rat card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "2bf76404-ff16-5360-a716-89f5a8e8d89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f85644-d8c6-4680-a417-08aa863ad4bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f85644-d8c6-4680-a417-08aa863ad4bb.jpg?1",
             "name": "Seal of Doom",
             "text": "Sacrifice Seal of Doom: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "d47bce68-1787-5f9b-9e98-b5963e9e2a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e71c1-5d95-44f3-99f1-b3b6eda8b26c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e71c1-5d95-44f3-99f1-b3b6eda8b26c.jpg?1",
             "name": "Slaughterhouse Bouncer",
             "text": "Hellbent When Slaughterhouse Bouncer is put into a graveyard from play, if you have no cards in hand, target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "30d09a0b-100d-54d8-a511-b9ff1eacfe87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c216194-0c6b-4c03-9262-bd2613e17d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c216194-0c6b-4c03-9262-bd2613e17d9a.jpg?1",
             "name": "Slithering Shade",
             "text": "Defender (This creature can't attack.)\n{B}: Slithering Shade gets +1/+1 until end of turn.\nHellbent Slithering Shade can attack as though it didn't have defender as long as you have no cards in hand.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "6ef3ff32-b6c8-59af-a295-46a5f4f162c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694bbf39-fd66-4ff4-9cc3-ec75b1fb3a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694bbf39-fd66-4ff4-9cc3-ec75b1fb3a51.jpg?1",
             "name": "Unliving Psychopath",
             "text": "{B}: Unliving Psychopath gets +1/-1 until end of turn.\n{B}, {T}: Destroy target creature with power less than Unliving Psychopath's power.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "577c0d73-ee06-5466-9d86-081893fd1508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669efa40-be9a-4475-9bcb-3325518403b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669efa40-be9a-4475-9bcb-3325518403b5.jpg?1",
             "name": "Vesper Ghoul",
             "text": "{T}, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "2edbdbb5-7dcb-5c1e-9e9e-dd4608ef92b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f8e20c-6d8e-45a1-aabd-176d8df843db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f8e20c-6d8e-45a1-aabd-176d8df843db.jpg?1",
             "name": "Wit's End",
             "text": "Target player discards his or her hand.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "0237c517-b61d-5c1a-ab61-5798f1e2a6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a371e-fb82-41f1-892c-975f932b668e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a371e-fb82-41f1-892c-975f932b668e.jpg?1",
             "name": "Cackling Flames",
             "text": "Cackling Flames deals 3 damage to target creature or player.\nHellbent Cackling Flames deals 5 damage to that creature or player instead if you have no cards in hand.",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "0e752030-5a7b-5b17-b68a-e54706dd4baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2ad333-722e-4d7e-972a-903c24068931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2ad333-722e-4d7e-972a-903c24068931.jpg?1",
             "name": "Demonfire",
             "text": "Demonfire deals X damage to target creature or player. If a creature dealt damage this way would be put into a graveyard this turn, remove it from the game instead.\nHellbent If you have no cards in hand, Demonfire can't be countered by spells or abilities and the damage can't be prevented.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "42748102-0ee5-5276-a0ae-897e0a3d55cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8092518-99ba-43b8-b5e9-8b46f1679696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8092518-99ba-43b8-b5e9-8b46f1679696.jpg?1",
             "name": "Flame-Kin War Scout",
             "text": "When another creature comes into play, sacrifice Flame-Kin War Scout. If you do, Flame-Kin War Scout deals 4 damage to that creature.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "a172c415-e2ee-56bb-ad04-664dd7910343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98a6c69-4100-42fc-b71e-381696f73852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98a6c69-4100-42fc-b71e-381696f73852.jpg?1",
             "name": "Flaring Flame-Kin",
             "text": "As long as Flaring Flame-Kin is enchanted, it gets +2/+2, has trample, and has \"{R}: Flaring Flame-Kin gets +1/+0 until end of turn.\"",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "1a63f041-c541-59fb-8372-39de9c8576cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccf9c8b-8a03-4ef8-8267-af57ac35fe02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccf9c8b-8a03-4ef8-8267-af57ac35fe02.jpg?1",
             "name": "Gnat Alley Creeper",
             "text": "Gnat Alley Creeper can't be blocked by creatures with flying.",
             "colours": [
@@ -2131,7 +2131,7 @@
         },
         {
             "id": "bea68cd8-38c9-5ddf-a3eb-2a9225ec59f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2db886-d394-4a8b-8fe0-dc2613500adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2db886-d394-4a8b-8fe0-dc2613500adc.jpg?1",
             "name": "Ignorant Bliss",
             "text": "Remove all cards in your hand from the game face down. At end of turn, return those cards to your hand, then draw a card.",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "bbec0e9e-c602-5745-a669-66161459e24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c96bb-6844-4c73-8b32-099bde7bd9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c96bb-6844-4c73-8b32-099bde7bd9f1.jpg?1",
             "name": "Kill-Suit Cultist",
             "text": "Kill-Suit Cultist attacks each turn if able.\n{B}, Sacrifice Kill-Suit Cultist: The next time damage would be dealt to target creature this turn, destroy that creature instead.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "93b8a058-b34d-54a4-8a51-83d45fc503d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5dfa91-8f93-41b7-95e9-3374550f1617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5dfa91-8f93-41b7-95e9-3374550f1617.jpg?1",
             "name": "Kindle the Carnage",
             "text": "Discard a card at random. If you do, Kindle the Carnage deals damage equal to that card's converted mana cost to each creature. You may repeat this process any number of times.",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "69f467a2-40d7-5522-83f0-253221cf00bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffddd4e2-e98c-4535-bac2-0af73f1535c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffddd4e2-e98c-4535-bac2-0af73f1535c5.jpg?1",
             "name": "Ogre Gatecrasher",
             "text": "When Ogre Gatecrasher comes into play, destroy target creature with defender.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "95406662-96bb-596e-8f80-68b5516fc735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f626c70-1ede-4b00-bd95-d6ee26371131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f626c70-1ede-4b00-bd95-d6ee26371131.jpg?1",
             "name": "Psychotic Fury",
             "text": "Target multicolored creature gains double strike until end of turn.\nDraw a card.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "2ce2af55-0082-5c8c-9203-0df92ae3231f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bdc80-26e9-4119-9dda-476aac8447ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47bdc80-26e9-4119-9dda-476aac8447ba.jpg?1",
             "name": "Rakdos Pit Dragon",
             "text": "{R}{R}: Rakdos Pit Dragon gains flying until end of turn.\n{R}: Rakdos Pit Dragon gets +1/+0 until end of turn.\nHellbent Rakdos Pit Dragon has double strike as long as you have no cards in hand.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "d8ac59bb-783f-563e-9811-bc7a3f48c90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e61ce3-e2cc-401c-b998-8baf8836e83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e61ce3-e2cc-401c-b998-8baf8836e83a.jpg?1",
             "name": "Sandstorm Eidolon",
             "text": "{R}, Sacrifice Sandstorm Eidolon: Target creature can't block this turn.\nWhenever you play a multicolored spell, you may return Sandstorm Eidolon from your graveyard to your hand.",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "d5923e41-af43-565c-a25e-94bcd6d47b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff3740-93e2-454a-8e6b-e29d0c9d0fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff3740-93e2-454a-8e6b-e29d0c9d0fc2.jpg?1",
             "name": "Seal of Fire",
             "text": "Sacrifice Seal of Fire: Seal of Fire deals 2 damage to target creature or player.",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "27c4a221-9b1c-55c6-ae66-6066cfd6746a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b445a0e-798d-4f82-88cc-04f600d38e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b445a0e-798d-4f82-88cc-04f600d38e49.jpg?1",
             "name": "Squealing Devil",
             "text": "Fear\nWhen Squealing Devil comes into play, you may pay {X}. If you do, target creature gets +X/+0 until end of turn.\nWhen Squealing Devil comes into play, sacrifice it unless {B} was spent to play it.",
             "colours": [
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "717c72e3-4265-5452-9d4e-53da2bad7b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3585709-db2b-4f0a-98a4-4a07c6467ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3585709-db2b-4f0a-98a4-4a07c6467ca3.jpg?1",
             "name": "Stalking Vengeance",
             "text": "Haste\nWhenever another creature you control is put into a graveyard from play, it deals damage equal to its power to target player.",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "d2f7848b-457c-579c-a450-6065661a74a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dbd0ef-9888-4489-ba4a-65128308fb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dbd0ef-9888-4489-ba4a-65128308fb11.jpg?1",
             "name": "Stormscale Anarch",
             "text": "{2}{R}, Discard a card at random: Stormscale Anarch deals 2 damage to target creature or player. If the discarded card was multicolored, Stormscale Anarch deals 4 damage to that creature or player instead.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "02a83f27-30bb-5ff6-ba02-757c6790c210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fbb2eb-5738-46e5-a0a6-8ee98c7c8cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fbb2eb-5738-46e5-a0a6-8ee98c7c8cfb.jpg?1",
             "name": "Taste for Mayhem",
             "text": "Enchant creature\nEnchanted creature gets +2/+0.\nHellbent Enchanted creature gets an additional +2/+0 as long as you have no cards in hand.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "cf26d591-9ea1-5efd-98dc-84db9de8a114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0a5aa2-f33a-4976-88b1-f424243016da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0a5aa2-f33a-4976-88b1-f424243016da.jpg?1",
             "name": "Utvara Scalper",
             "text": "Flying\nUtvara Scalper attacks each turn if able.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "93bd4948-5cca-5910-981a-31ce51481ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5f6c39-55eb-4d8d-83cf-94652b07bc46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5f6c39-55eb-4d8d-83cf-94652b07bc46.jpg?1",
             "name": "War's Toll",
             "text": "Whenever an opponent taps a land for mana, tap all lands that player controls.\nIf a creature an opponent controls attacks, all creatures that opponent controls attack if able.",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "8f47eedc-cfcb-5b65-b166-b75dc525292e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f26a87-4562-450c-800b-7d4acc1ae17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f26a87-4562-450c-800b-7d4acc1ae17b.jpg?1",
             "name": "Weight of Spires",
             "text": "Weight of Spires deals damage to target creature equal to the number of nonbasic lands that creature's controller controls.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "99570474-c065-521b-920e-e4c13bf06c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd8e674-49be-47b7-910d-736c9acfa916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd8e674-49be-47b7-910d-736c9acfa916.jpg?1",
             "name": "Whiptail Moloch",
             "text": "When Whiptail Moloch comes into play, it deals 3 damage to target creature you control.",
             "colours": [
@@ -2669,7 +2669,7 @@
         },
         {
             "id": "59b15f26-5e8e-56b9-965e-df35364c3c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bec131-e34e-473b-8792-1a8d53a03fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bec131-e34e-473b-8792-1a8d53a03fa6.jpg?1",
             "name": "Aquastrand Spider",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it can block as though it had flying this turn.",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "4f3bd17e-9972-504d-a0f1-57ce8fa796f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83483c-95d0-4db8-b4d4-c6db400ebc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83483c-95d0-4db8-b4d4-c6db400ebc97.jpg?1",
             "name": "Cytoplast Root-Kin",
             "text": "Graft 4 (This creature comes into play with four +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\nWhen Cytoplast Root-Kin comes into play, put a +1/+1 counter on each other creature you control that has a +1/+1 counter on it.\n{2}: Move a +1/+1 counter from target creature you control onto Cytoplast Root-Kin.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "c68ae8f1-235b-5d96-80c0-8b229439e69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c87c15-742b-47fb-9d4c-0a985cc1e15a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c87c15-742b-47fb-9d4c-0a985cc1e15a.jpg?1",
             "name": "Cytospawn Shambler",
             "text": "Graft 6 (This creature comes into play with six +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it gains trample until end of turn.",
             "colours": [
@@ -2774,7 +2774,7 @@
         },
         {
             "id": "47308a89-09aa-5dd1-9cfe-a1db3a7deeaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757631a-c505-4a16-94c1-8bb609ce7bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757631a-c505-4a16-94c1-8bb609ce7bc5.jpg?1",
             "name": "Elemental Resonance",
             "text": "Enchant permanent\nAt the beginning of your precombat main phase, add mana equal to enchanted permanent's mana cost to your mana pool. (Mana cost includes color. If a mana symbol has multiple colors, choose one.)",
             "colours": [
@@ -2808,7 +2808,7 @@
         },
         {
             "id": "12ed5514-b5db-5248-b7b4-c70bb733e165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c879af-a092-4cc4-a53d-760553d94864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c879af-a092-4cc4-a53d-760553d94864.jpg?1",
             "name": "Fertile Imagination",
             "text": "Choose a card type. Target opponent reveals his or her hand. Put two 1/1 green Saproling creature tokens into play for each card of the chosen type revealed this way. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "5e8de53e-216b-5b13-aa1a-51959d58b135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c63da-dfe3-475f-88d9-20008c01163a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c63da-dfe3-475f-88d9-20008c01163a.jpg?1",
             "name": "Flash Foliage",
             "text": "Put a 1/1 green Saproling creature token into play blocking target creature attacking you.\nDraw a card.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "7ca3703d-370c-5e49-9840-004b9fcdf76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe57b3a2-0fd9-4f99-bb2b-828979dbcfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe57b3a2-0fd9-4f99-bb2b-828979dbcfc3.jpg?1",
             "name": "Indrik Stomphowler",
             "text": "When Indrik Stomphowler comes into play, destroy target artifact or enchantment.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "d882959c-5eed-51aa-a130-3e8de6a38e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34b3f97-1c00-4ad2-a28d-6f064f499761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34b3f97-1c00-4ad2-a28d-6f064f499761.jpg?1",
             "name": "Loaming Shaman",
             "text": "When Loaming Shaman comes into play, target player shuffles any number of target cards from his or her graveyard into his or her library.",
             "colours": [
@@ -2941,7 +2941,7 @@
         },
         {
             "id": "543a292b-fc6f-52b1-b364-1fcdf8e1f43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5c4a29-0650-4b9e-af6b-39bee19167ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5c4a29-0650-4b9e-af6b-39bee19167ad.jpg?1",
             "name": "Might of the Nephilim",
             "text": "Target creature gets +2/+2 until end of turn for each of its colors.",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "72d3328a-fe45-5bc7-a65f-1daa7962feab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78031831-f773-489f-b1c2-c8f5537f2286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78031831-f773-489f-b1c2-c8f5537f2286.jpg?1",
             "name": "Patagia Viper",
             "text": "Flying\nWhen Patagia Viper comes into play, put two 1/1 green and blue Snake creature tokens into play.\nWhen Patagia Viper comes into play, sacrifice it unless {U} was spent to play it.",
             "colours": [
@@ -3008,7 +3008,7 @@
         },
         {
             "id": "80665f2a-2b0d-588b-9a98-01879cffbc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d978332-95bf-4f86-9e67-06f10983c267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d978332-95bf-4f86-9e67-06f10983c267.jpg?1",
             "name": "Protean Hulk",
             "text": "When Protean Hulk is put into a graveyard from play, search your library for any number of creature cards with total converted mana cost 6 or less and put them into play. Then shuffle your library.",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "74d781f1-bc45-5709-ab68-4f742b57ddc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e7af53-62d8-45b8-829f-c575dda53e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e7af53-62d8-45b8-829f-c575dda53e25.jpg?1",
             "name": "Simic Basilisk",
             "text": "Graft 3 (This creature comes into play with three +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}{G}: Until end of turn, target creature with a +1/+1 counter on it gains \"Whenever this creature deals combat damage to a creature, destroy that creature at end of combat.\"",
             "colours": [
@@ -3077,7 +3077,7 @@
         },
         {
             "id": "cdd52f1c-88e0-517e-81cb-117039aa85c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6602c592-3cde-4e73-919c-1d3f3df22092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6602c592-3cde-4e73-919c-1d3f3df22092.jpg?1",
             "name": "Simic Initiate",
             "text": "Graft 1 (This creature comes into play with a +1/+1 counter on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "a8bdafa1-13d7-5625-bb2e-7e4049302661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1f4b84-dd5d-4f5f-808e-26ef9414b38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1f4b84-dd5d-4f5f-808e-26ef9414b38a.jpg?1",
             "name": "Simic Ragworm",
             "text": "{U}: Untap Simic Ragworm.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "77b70826-c346-547d-ad0c-4a154c1aa078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bdca24-3beb-4d0d-b3bc-b98c23316fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bdca24-3beb-4d0d-b3bc-b98c23316fe7.jpg?1",
             "name": "Sporeback Troll",
             "text": "Graft 2 (This creature comes into play with two +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{1}{G}: Regenerate target creature with a +1/+1 counter on it.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "73255f78-5697-5f7a-b9b3-c25667c4a778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a478eaa-2658-49db-965f-db25fc1d720e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a478eaa-2658-49db-965f-db25fc1d720e.jpg?1",
             "name": "Sprouting Phytohydra",
             "text": "Defender (This creature can't attack.)\nWhenever Sprouting Phytohydra is dealt damage, you may put a token into play that's a copy of Sprouting Phytohydra.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "9fafcd27-14f0-5186-823a-177bd39858be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be523140-7c68-4231-a692-7b3af417d858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be523140-7c68-4231-a692-7b3af417d858.jpg?1",
             "name": "Stomp and Howl",
             "text": "Destroy target artifact and target enchantment.",
             "colours": [
@@ -3249,7 +3249,7 @@
         },
         {
             "id": "ba755f23-218e-538c-a6fb-778f4cf73271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5b4fc-e1de-4520-9524-f9c4aa89b252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5b4fc-e1de-4520-9524-f9c4aa89b252.jpg?1",
             "name": "Street Savvy",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and can block creatures with landwalk abilities as though they didn't have those abilities.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "1912983b-4be5-54e6-a56a-139d1bd73fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce041c2-5a63-4007-a0fa-f0a6f4b39c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce041c2-5a63-4007-a0fa-f0a6f4b39c16.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "29e6576c-936e-5631-96c3-33d8f830629d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5047e271-fbf1-402c-9eb9-0806e5988f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5047e271-fbf1-402c-9eb9-0806e5988f76.jpg?1",
             "name": "Utopia Sprawl",
             "text": "Enchant Forest\nAs Utopia Sprawl comes into play, choose a color.\nWhenever enchanted Forest is tapped for mana, its controller adds one mana of the chosen color to his or her mana pool.",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "12589186-2b33-5a94-9178-379535d4f806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8120d141-2759-49d4-bed9-e20617a0b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8120d141-2759-49d4-bed9-e20617a0b009.jpg?1",
             "name": "Verdant Eidolon",
             "text": "{G}, Sacrifice Verdant Eidolon: Add three mana of any one color to your mana pool.\nWhenever you play a multicolored spell, you may return Verdant Eidolon from your graveyard to your hand.",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "5c85f117-628a-55a6-bee0-c4ccaf1170c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5debdea2-538f-405b-87b0-3789dba95e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5debdea2-538f-405b-87b0-3789dba95e8e.jpg?1",
             "name": "Aethermage's Touch",
             "text": "Reveal the top four cards of your library. You may put a creature card from among them into play with \"At the end of your turn, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "94c46b30-3147-557b-acf4-b7b8d7cde50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea00d757-0ea9-4123-89f6-0a437d7fd33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea00d757-0ea9-4123-89f6-0a437d7fd33d.jpg?1",
             "name": "Anthem of Rakdos",
             "text": "Whenever a creature you control attacks, it gets +2/+0 until end of turn and Anthem of Rakdos deals 1 damage to you.\nHellbent As long as you have no cards in hand, if a source you control would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "f15dee97-e4a0-5c08-89b8-c837c72079d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6443-c941-418a-a766-05bba088a117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6443-c941-418a-a766-05bba088a117.jpg?1",
             "name": "Assault Zeppelid",
             "text": "Flying, trample",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "cbc05314-bd4b-5d9e-b787-7c9793f20d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b640ff8-8baa-4069-b5a9-8a4fb22a056e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b640ff8-8baa-4069-b5a9-8a4fb22a056e.jpg?1",
             "name": "Azorius Aethermage",
             "text": "Whenever a permanent is returned to your hand, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "b463a2aa-5616-5f86-b6ee-c787e02c9c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675c1e6-add5-4959-a5be-f2571ccebcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675c1e6-add5-4959-a5be-f2571ccebcb4.jpg?1",
             "name": "Azorius First-Wing",
             "text": "Flying, protection from enchantments",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "51175d7b-537c-5047-9a57-be6febd005c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763f2c68-77a9-43e9-8f9b-2f318afcd686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763f2c68-77a9-43e9-8f9b-2f318afcd686.jpg?1",
             "name": "Azorius Ploy",
             "text": "Prevent all combat damage target creature would deal this turn.\nPrevent all combat damage that would be dealt to target creature this turn.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "cb17d663-dc0a-55dc-b72a-065dcb1a88b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a6ba2a-b372-4b15-9a1e-09b41316eab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a6ba2a-b372-4b15-9a1e-09b41316eab7.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle comes into play, reveal the top card of your library. If it's a land card, put it into play. Otherwise, put that card into your hand.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "180bad9b-1a4b-5cc4-acc3-bc18609b3c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758023cb-548a-4a98-a355-f5c6e9eab5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758023cb-548a-4a98-a355-f5c6e9eab5ff.jpg?1",
             "name": "Cytoshape",
             "text": "Choose a nonlegendary creature in play. Target creature becomes a copy of that creature until end of turn.",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "7bbedeff-fd83-5568-a8fd-817f739975b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cdad60-3a73-49ac-bbbd-679254b6ba9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cdad60-3a73-49ac-bbbd-679254b6ba9e.jpg?1",
             "name": "Dread Slag",
             "text": "Trample\nDread Slag gets -4/-4 for each card in your hand.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "4e093663-4be6-5948-9812-f3ad079e4d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f42a1-0996-4799-ad3a-9525c8e31343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f42a1-0996-4799-ad3a-9525c8e31343.jpg?1",
             "name": "Experiment Kraj",
             "text": "Experiment Kraj has all activated abilities of each other creature with a +1/+1 counter on it.\n{T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "90ade948-99e0-57c0-a084-3c19a7843b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae123ca6-2b96-4bbe-82b2-0be294edff80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae123ca6-2b96-4bbe-82b2-0be294edff80.jpg?1",
             "name": "Gobhobbler Rats",
             "text": "Hellbent Gobhobbler Rats gets +1/+0 and has \"{B}: Regenerate Gobhobbler Rats\" as long as you have no cards in hand.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "ba510206-0770-5515-8a74-f2efc3e6d435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ac328b-923f-48dd-a4f5-de389ade9125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ac328b-923f-48dd-a4f5-de389ade9125.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you play cost {1} less to play.\nBlue spells you play cost {1} less to play.\nSpells your opponents play cost {1} more to play.",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "bdac6ff0-ff85-54b1-94d4-e9df619b1817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eb937-21d4-44b1-85e7-b95995865f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eb937-21d4-44b1-85e7-b95995865f44.jpg?1",
             "name": "Hellhole Rats",
             "text": "Haste\nWhen Hellhole Rats comes into play, target player discards a card. Hellhole Rats deals damage to that player equal to that card's converted mana cost.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "88892ec6-6a6c-5c5d-9e96-e376ec329016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b365b0-6949-41d2-be60-eb2162b1f882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b365b0-6949-41d2-be60-eb2162b1f882.jpg?1",
             "name": "Isperia the Inscrutable",
             "text": "Flying\nWhenever Isperia the Inscrutable deals combat damage to a player, name a card. That player reveals his or her hand. If he or she reveals the named card, search your library for a creature card with flying, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "6081e956-5b9e-580c-99ce-2097947fa056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796a838-3599-4769-b90b-9bbbaad76fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796a838-3599-4769-b90b-9bbbaad76fcb.jpg?1",
             "name": "Jagged Poppet",
             "text": "Whenever Jagged Poppet is dealt damage, discard that many cards.\nHellbent Whenever Jagged Poppet deals combat damage to a player, if you have no cards in hand, that player discards cards equal to the damage.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "d9bc4ae8-5dd2-52b7-b92f-b41b697a05fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9cb544-fa42-4671-917d-e08c582f7657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9cb544-fa42-4671-917d-e08c582f7657.jpg?1",
             "name": "Leafdrake Roost",
             "text": "Enchant land\nEnchanted land has \"{G}{U}, {T}: Put a 2/2 green and blue Drake creature token with flying into play.\"",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "8ec2bbc8-15e2-5571-b0dc-396cf26abea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18df285f-4cb9-4998-bd26-eefbe28f80c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18df285f-4cb9-4998-bd26-eefbe28f80c7.jpg?1",
             "name": "Lyzolda, the Blood Witch",
             "text": "{2}, Sacrifice a creature: Lyzolda, the Blood Witch deals 2 damage to target creature or player if the sacrificed creature was red. Draw a card if the sacrificed creature was black.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "eb690538-0945-5fd9-a83d-7a9eb97bd752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a8c801-df0c-402b-a41c-4703a2abfb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a8c801-df0c-402b-a41c-4703a2abfb66.jpg?1",
             "name": "Momir Vig, Simic Visionary",
             "text": "Whenever you play a green creature spell, you may search your library for a creature card and reveal it. If you do, shuffle your library and put that card on top of it.\nWhenever you play a blue creature spell, reveal the top card of your library. If it's a creature card, put that card into your hand.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "f7b2e2db-5571-5555-8623-c4d9c021db5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a5a212-395c-427e-81b8-893745274068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a5a212-395c-427e-81b8-893745274068.jpg?1",
             "name": "Omnibian",
             "text": "{T}: Target creature becomes a 3/3 Frog until end of turn.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "b7fc625a-8593-55c6-ab7a-1675a2b33d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b83a31-f974-4a49-b9ee-92f7767f11e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b83a31-f974-4a49-b9ee-92f7767f11e0.jpg?1",
             "name": "Overrule",
             "text": "Counter target spell unless its controller pays {X}. You gain X life.",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "4599df76-1112-5122-8244-4c7ce7c82c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844801e4-cf37-4f20-9149-b58a57b9276e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844801e4-cf37-4f20-9149-b58a57b9276e.jpg?1",
             "name": "Pain Magnification",
             "text": "Whenever an opponent is dealt 3 or more damage by a single source, that player discards a card.",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "7e4c2c57-9ea0-5e3e-8b8c-18b49d73cf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda10c3b-ee16-4de5-9e54-d0187cd5cc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda10c3b-ee16-4de5-9e54-d0187cd5cc80.jpg?1",
             "name": "Palliation Accord",
             "text": "Whenever a creature an opponent controls becomes tapped, put a shield counter on Palliation Accord.\nRemove a shield counter from Palliation Accord: Prevent the next 1 damage that would be dealt to you this turn.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "609b9ef8-5b71-59fe-a9a5-902674dc7b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bb1946-8057-4a31-9de7-4bd1a9845165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bb1946-8057-4a31-9de7-4bd1a9845165.jpg?1",
             "name": "Plaxcaster Frogling",
             "text": "Graft 3 (This creature comes into play with three +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\n{2}: Target creature with a +1/+1 counter on it can't be the target of spells or abilities this turn.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "40be2025-3dd6-5bb8-882e-aa2bdcbf295a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02dcf40-03ad-463c-a14a-5dfc886dea4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02dcf40-03ad-463c-a14a-5dfc886dea4c.jpg?1",
             "name": "Plumes of Peace",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nForecast {W}{U}, Reveal Plumes of Peace from your hand: Tap target creature. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "5543fbfa-20c0-5633-8767-411c34a43b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a029-6e64-4b6d-9d82-afc319dbc57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a029-6e64-4b6d-9d82-afc319dbc57a.jpg?1",
             "name": "Pride of the Clouds",
             "text": "Flying\nPride of the Clouds gets +1/+1 for each other creature in play with flying.\nForecast {2}{W}{U}, Reveal Pride of the Clouds from your hand: Put a 1/1 white and blue Bird creature token with flying into play. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "b6f39f92-1987-54de-bfe2-351ed3ebac39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd62003-e345-48b6-9f93-fc111924c318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd62003-e345-48b6-9f93-fc111924c318.jpg?1",
             "name": "Rain of Gore",
             "text": "If a spell or ability would cause its controller to gain life, that player loses that much life instead.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "acd8bebf-9f3d-56b4-94dc-7efd64717bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5507ec6-430e-41bf-8ac8-42a79f11012d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5507ec6-430e-41bf-8ac8-42a79f11012d.jpg?1",
             "name": "Rakdos Augermage",
             "text": "First strike\n{T}: Reveal your hand and discard a card of target opponent's choice. Then that player reveals his or her hand and discards a card of your choice. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "05ffd5d6-0422-5e9b-ab45-b8b9aadc6cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c007b10b-2701-4bac-8b95-8fc7dcfb9e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c007b10b-2701-4bac-8b95-8fc7dcfb9e21.jpg?1",
             "name": "Rakdos Ickspitter",
             "text": "{T}: Rakdos Ickspitter deals 1 damage to target creature and that creature's controller loses 1 life.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "ef13020e-203b-5ae3-9423-fd70c1a693d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c4be4-06ae-4737-a3b0-818edadaf2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c4be4-06ae-4737-a3b0-818edadaf2e0.jpg?1",
             "name": "Rakdos the Defiler",
             "text": "Flying, trample\nWhenever Rakdos the Defiler attacks, sacrifice half the non-Demon permanents you control, rounded up.\nWhenever Rakdos deals combat damage to a player, that player sacrifices half the non-Demon permanents he or she controls, rounded up.",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "da6b2342-b9e1-50f5-8c84-17bcad9cf833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f625b270-f560-402b-b253-51951822ce42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f625b270-f560-402b-b253-51951822ce42.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nSimic Sky Swallower can't be the target of spells or abilities.",
             "colours": [
@@ -4470,7 +4470,7 @@
         },
         {
             "id": "8227868c-ce2c-5cb7-8259-fb74b9fc1b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a795ea0-5a8f-4dc2-863b-d3c00844d873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a795ea0-5a8f-4dc2-863b-d3c00844d873.jpg?1",
             "name": "Sky Hussar",
             "text": "Flying\nWhen Sky Hussar comes into play, untap all creatures you control.\nForecast Tap two untapped white and/or blue creatures you control, Reveal Sky Hussar from your hand: Draw a card. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "e31e7181-db17-5323-b92b-c1a6d284c2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c5f733-e126-4c22-b528-18bdb90b509b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c5f733-e126-4c22-b528-18bdb90b509b.jpg?1",
             "name": "Swift Silence",
             "text": "Counter all other spells. Draw a card for each spell countered this way.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "e09d70dc-409f-5d98-ab87-1d212d23936e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f54bf-7bf0-48f0-853d-1468713784eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f54bf-7bf0-48f0-853d-1468713784eb.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -4577,7 +4577,7 @@
         },
         {
             "id": "c338e47f-6631-56da-9486-9afa2fa5a43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfc8ebe-58f4-450f-abdc-8d558f6f5551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfc8ebe-58f4-450f-abdc-8d558f6f5551.jpg?1",
             "name": "Twinstrike",
             "text": "Twinstrike deals 2 damage to each of two target creatures.\nHellbent Destroy those creatures instead if you have no cards in hand.",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "c728b57f-005e-5bf5-872a-e01310ba3eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6373aedc-4385-4608-bfbc-1937d6528d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6373aedc-4385-4608-bfbc-1937d6528d28.jpg?1",
             "name": "Vigean Hydropon",
             "text": "Graft 5 (This creature comes into play with five +1/+1 counters on it. Whenever another creature comes into play, you may move a +1/+1 counter from this creature onto it.)\nVigean Hydropon can't attack or block.",
             "colours": [
@@ -4648,7 +4648,7 @@
         },
         {
             "id": "5bd6fbb0-046c-5f1c-8548-7b3cc6b8e182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be493737-0457-447b-802b-043d7a77f389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be493737-0457-447b-802b-043d7a77f389.jpg?1",
             "name": "Vigean Intuition",
             "text": "Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "dbf7493e-b804-5d92-b7fd-ef7a7d56efcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97121d5a-18ab-47cd-808f-562cd865955a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97121d5a-18ab-47cd-808f-562cd865955a.jpg?1",
             "name": "Voidslime",
             "text": "Counter target spell, activated ability, or triggered ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "0c329198-bbe5-5c1d-9556-4eee579603f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af5727-5348-4e2e-8a00-10f6983edce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af5727-5348-4e2e-8a00-10f6983edce8.jpg?1",
             "name": "Windreaver",
             "text": "Flying\n{W}: Windreaver gains vigilance until end of turn.\n{W}: Windreaver gets +0/+1 until end of turn.\n{U}: Switch Windreaver's power and toughness until end of turn.\n{U}: Return Windreaver to its owner's hand.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "2c1348bc-e003-5f0b-8400-f5db11cee56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1182e0cf-475e-4cb9-a00a-c9a4032f51e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1182e0cf-475e-4cb9-a00a-c9a4032f51e4.jpg?1",
             "name": "Wrecking Ball",
             "text": "Destroy target creature or land.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "8036c0cd-686f-58b3-9721-e1ba29db0a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06824d21-600b-44cd-8b51-0d8379cb0b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06824d21-600b-44cd-8b51-0d8379cb0b47.jpg?1",
             "name": "Avatar of Discord",
             "text": "({BR} can be paid with either {B} or {R}.)\nFlying\nWhen Avatar of Discord comes into play, sacrifice it unless you discard two cards.",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "34293e7c-7974-56ef-ad2d-29583740bc8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0f0ce-7c23-444c-9d9f-bfa9c8705fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0f0ce-7c23-444c-9d9f-bfa9c8705fd5.jpg?1",
             "name": "Azorius Guildmage",
             "text": "({WU} can be paid with either {W} or {U}.)\n{2}{W}: Tap target creature.\n{2}{U}: Counter target activated ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "964eb375-3ad8-5c76-9fc2-5a09d40efc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feb398e-069a-4c30-884c-67292a56ca45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feb398e-069a-4c30-884c-67292a56ca45.jpg?1",
             "name": "Biomantic Mastery",
             "text": "({GW} can be paid with either {G} or {U}.)\nDraw a card for each creature target player controls, then draw a card for each creature another target player controls.",
             "colours": [
@@ -4893,7 +4893,7 @@
         },
         {
             "id": "be2dc7b0-d699-5be4-ae98-043270fa9cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e3d6e6-ac17-4d73-acac-089442de4af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e3d6e6-ac17-4d73-acac-089442de4af6.jpg?1",
             "name": "Dovescape",
             "text": "({WU} can be paid with either {W} or {U}.)\nWhenever a player plays a noncreature spell, counter that spell. That player puts X 1/1 white and blue Bird creature tokens with flying into play, where X is the spell's converted mana cost.",
             "colours": [
@@ -4927,7 +4927,7 @@
         },
         {
             "id": "c9954033-44cc-537f-b1de-5ce608caf523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aada87-a880-4d33-8694-9fbc74211755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96aada87-a880-4d33-8694-9fbc74211755.jpg?1",
             "name": "Minister of Impediments",
             "text": "({WU} can be paid with either {W} or {U}.)\n{T}: Tap target creature.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "1970dc14-7156-5e41-b66f-ed277ed56dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e01fef8-5563-4dec-ab8e-e486e19e202c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e01fef8-5563-4dec-ab8e-e486e19e202c.jpg?1",
             "name": "Rakdos Guildmage",
             "text": "({BR} can be paid with either {B} or {R}.)\n{3}{B}, Discard a card: Target creature gets -2/-2 until end of turn.\n{3}{R}: Put a 2/1 red Goblin creature token with haste into play. Remove it from the game at end of turn.",
             "colours": [
@@ -5001,7 +5001,7 @@
         },
         {
             "id": "46705f3c-34a1-58fa-92b5-f2220023820c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f909-9906-4ff7-9b10-9d817f20d8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f909-9906-4ff7-9b10-9d817f20d8a9.jpg?1",
             "name": "Riot Spikes",
             "text": "({BR} can be paid with either {B} or {R}.)\nEnchant creature\nEnchanted creature gets +2/-1.",
             "colours": [
@@ -5037,7 +5037,7 @@
         },
         {
             "id": "7c5905c3-2bbe-5478-9e11-ec12210988ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2f90be-e76c-4e74-898e-d2848e345599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2f90be-e76c-4e74-898e-d2848e345599.jpg?1",
             "name": "Shielding Plax",
             "text": "({GW} can be paid with either {G} or {U}.)\nEnchant creature\nWhen Shielding Plax comes into play, draw a card.\nEnchanted creature can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "ff614e7f-f896-577d-976c-4553a444517c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77d4ffb-a829-49ca-9c37-c60ba467852c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77d4ffb-a829-49ca-9c37-c60ba467852c.jpg?1",
             "name": "Simic Guildmage",
             "text": "({GW} can be paid with either {G} or {U}.)\n{1}{G}: Move a +1/+1 counter from target creature onto another target creature with the same controller.\n{1}{U}: Attach target Aura enchanting a permanent to another permanent with the same controller.",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "3c6f89e6-cc4a-5340-9fed-f5d23e798d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg?1",
             "name": "Bound // Determined",
             "text": "Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was. Then remove this card from the game.",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "eca14704-9044-5e15-bb68-01a433f65bad",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dc20e14-e304-4c14-a87b-322a76e214d5.jpg?1",
             "name": "Bound // Determined",
             "text": "Other spells you control can't be countered by spells or abilities this turn.\nDraw a card.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "54a0d6ee-191a-52b0-aab9-bdf0945eafe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg?1",
             "name": "Crime // Punishment",
             "text": "Put target creature or enchantment card in an opponent's graveyard into play under your control.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "64d4699a-aaa8-5503-8f5c-dfb312ed4f37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2edeab08-86eb-4fa8-ba24-23dacb32e0fd.jpg?1",
             "name": "Crime // Punishment",
             "text": "Destroy each artifact, creature, and enchantment with converted mana cost X.",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "4c3f9a88-f6df-5d9a-83cc-20c7366356f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg?1",
             "name": "Hide // Seek",
             "text": "Put target artifact or enchantment on the bottom of its owner's library.",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "64a5acc6-f96a-5178-bfe9-97c791a7e6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac347ec8-4537-4cdf-aeff-44da1f7be01b.jpg?1",
             "name": "Hide // Seek",
             "text": "Search target opponent's library for a card and remove that card from the game. You gain life equal to its converted mana cost. Then that player shuffles his or her library.",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "c8179183-e9d1-5532-b920-1a6ffd822736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg?1",
             "name": "Hit // Run",
             "text": "Target player sacrifices an artifact or creature. Hit deals damage to that player equal to that permanent's converted mana cost.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "ae71a824-bd09-5c14-b60e-9279b2578d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b44c30a9-1af4-4287-a809-d2de4e8b4070.jpg?1",
             "name": "Hit // Run",
             "text": "Attacking creatures you control get +1/+0 until end of turn for each other attacking creature.",
             "colours": [
@@ -5390,7 +5390,7 @@
         },
         {
             "id": "8627334a-4c13-5373-a44f-68ab068c4807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg?1",
             "name": "Odds // Ends",
             "text": "Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy.",
             "colours": [
@@ -5425,7 +5425,7 @@
         },
         {
             "id": "a3edef48-0c50-56cb-a287-01b4bf7e3897",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4bb07091-86d6-4735-82b6-6e71e26710f4.jpg?1",
             "name": "Odds // Ends",
             "text": "Target player sacrifices two attacking creatures.",
             "colours": [
@@ -5460,7 +5460,7 @@
         },
         {
             "id": "e4c0da91-2ee6-51fb-90d9-d4dba59d03dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg?1",
             "name": "Pure // Simple",
             "text": "Destroy target multicolored permanent.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "66069159-702f-52e9-8d94-d71f193d52a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3a5d913-0b78-4918-87cf-0bb33b9d120e.jpg?1",
             "name": "Pure // Simple",
             "text": "Destroy all Auras and Equipment.",
             "colours": [
@@ -5530,7 +5530,7 @@
         },
         {
             "id": "c46d48b7-b4d1-5347-9ef4-561c0e3a0645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg?1",
             "name": "Research // Development",
             "text": "Choose up to four cards you own from outside the game and shuffle them into your library.",
             "colours": [
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "b5160299-e1b9-52e4-b52e-ed53bf996067",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d48ee48-aaeb-4907-b9dc-32f22e95ae4c.jpg?1",
             "name": "Research // Development",
             "text": "Put a 3/1 red Elemental creature token into play unless an opponent lets you draw a card. Repeat this process two more times.",
             "colours": [
@@ -5600,7 +5600,7 @@
         },
         {
             "id": "a5d77fcb-9642-5c00-b13e-6f447f1a2400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg?1",
             "name": "Rise // Fall",
             "text": "Return target creature card in a graveyard and target creature in play to their owners' hands.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "681fbbc6-2aa8-54a6-a902-5ef1ef5e780a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a6bd585d-0155-4ed8-8b8a-9c0b7604e942.jpg?1",
             "name": "Rise // Fall",
             "text": "Target player reveals two cards at random from his or her hand, then discards each nonland card revealed this way.",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "20fcadf6-c98d-5580-af3f-94b1f9e4f01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg?1",
             "name": "Supply // Demand",
             "text": "Put X 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -5705,7 +5705,7 @@
         },
         {
             "id": "59ac62e1-c8cc-5d49-a691-2d4d65ad8832",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4628887-bda4-47e4-84d1-d31a8298f9e5.jpg?1",
             "name": "Supply // Demand",
             "text": "Search your library for a multicolored card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "149ef71c-0de7-5f02-98d9-e129a24ac2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg?1",
             "name": "Trial // Error",
             "text": "Return all creatures blocking or blocked by target creature to their owner's hand.",
             "colours": [
@@ -5775,7 +5775,7 @@
         },
         {
             "id": "b8ba11ab-65d5-5514-a707-6a3ea51ca980",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/553028fc-eeab-42e2-9887-cf45ea3f01a6.jpg?1",
             "name": "Trial // Error",
             "text": "Counter target multicolored spell.",
             "colours": [
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "6d772ea4-e180-52a8-8a90-59a574980745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91a527d-51f1-4fb1-9016-fc923fd43a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91a527d-51f1-4fb1-9016-fc923fd43a6a.jpg?1",
             "name": "Azorius Signet",
             "text": "{1}, {T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -5841,7 +5841,7 @@
         },
         {
             "id": "12223ed8-b850-5189-8bf7-70e97a9c0f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ec20d-b862-4f13-989c-aa88efa51cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2ec20d-b862-4f13-989c-aa88efa51cdf.jpg?1",
             "name": "Bronze Bombshell",
             "text": "When a player other than Bronze Bombshell's owner controls it, that player sacrifices it. If the player does, Bronze Bombshell deals 7 damage to him or her.",
             "colours": [],
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "5904a26e-8216-538c-8d9f-2825c5e767ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed874e4-87ca-41f0-af0a-a803194d78c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed874e4-87ca-41f0-af0a-a803194d78c9.jpg?1",
             "name": "Evolution Vat",
             "text": "{3}, {T}: Tap target creature and put a +1/+1 counter on it. Until end of turn, that creature gains \"{2}{G}{U}: Double the number of +1/+1 counters on this creature.\"",
             "colours": [],
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "ba358c83-f9e9-5fe1-8b25-92e9cfc81f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e8442-91ce-4106-bfc6-a1f6e0e34c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27e8442-91ce-4106-bfc6-a1f6e0e34c2d.jpg?1",
             "name": "Magewright's Stone",
             "text": "{1}, {T}: Untap target creature that has an activated ability with {T} in its cost.",
             "colours": [],
@@ -5931,7 +5931,7 @@
         },
         {
             "id": "8b26b036-9d33-5a2f-9fc8-548580548e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10482209-19b1-4941-9133-f2764eeba092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10482209-19b1-4941-9133-f2764eeba092.jpg?1",
             "name": "Muse Vessel",
             "text": "{3}, {T}: Target player removes a card in his or her hand from the game. Play this ability only any time you could play a sorcery.\n{1}: Choose a card removed from the game with Muse Vessel. You may play that card this turn.",
             "colours": [],
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "72d2a9b0-df9f-59ba-b410-b4791819f09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6e10a-3df1-4c6f-bf4c-d4a2a0467c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6e10a-3df1-4c6f-bf4c-d4a2a0467c60.jpg?1",
             "name": "Rakdos Riteknife",
             "text": "Equipped creature gets +1/+0 for each blood counter on Rakdos Riteknife and has \"{T}, Sacrifice a creature: Put a blood counter on Rakdos Riteknife.\"\n{B}{R}, Sacrifice Rakdos Riteknife: Target player sacrifices a permanent for each blood counter on Rakdos Riteknife.\nEquip {2}",
             "colours": [],
@@ -5992,7 +5992,7 @@
         },
         {
             "id": "666410cb-14db-5758-b265-0cf0e1f6cdb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a3f95c-5a05-46ea-8dc6-b77b59324035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a3f95c-5a05-46ea-8dc6-b77b59324035.jpg?1",
             "name": "Rakdos Signet",
             "text": "{1}, {T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "1a35310d-953d-511b-8801-135290477a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90107d10-e2aa-4cb7-a000-039f0c581b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90107d10-e2aa-4cb7-a000-039f0c581b47.jpg?1",
             "name": "Simic Signet",
             "text": "{1}, {T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "cefc3f86-234e-5463-abee-b5941de33164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8567c5-d068-42bb-a593-3849e65e29c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8567c5-d068-42bb-a593-3849e65e29c0.jpg?1",
             "name": "Skullmead Cauldron",
             "text": "{T}: You gain 1 life.\n{T}, Discard a card: You gain 3 life.",
             "colours": [],
@@ -6082,7 +6082,7 @@
         },
         {
             "id": "6ed8ddf5-f3ff-5249-9752-bcc116c8266e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449a9db4-f219-4a6a-b9a3-3dd3edec2a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449a9db4-f219-4a6a-b9a3-3dd3edec2a16.jpg?1",
             "name": "Transguild Courier",
             "text": "Transguild Courier is all colors (even if this card isn't in play).",
             "colours": [
@@ -6125,7 +6125,7 @@
         },
         {
             "id": "03573100-489d-5b02-8daf-2f5c25079159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c390e074-bd30-4564-a39a-176af7df79f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c390e074-bd30-4564-a39a-176af7df79f4.jpg?1",
             "name": "Walking Archive",
             "text": "Defender (This creature can't attack.)\nWalking Archive comes into play with a +1/+1 counter on it.\nAt the beginning of each player's upkeep, that player draws a card for each +1/+1 counter on Walking Archive.\n{2}{W}{U}: Put a +1/+1 counter on Walking Archive.",
             "colours": [],
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "5e69a6ae-f9ca-5bf7-94a8-e582f7d2dda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58365d2-e4db-444b-b1a9-795668ad3038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58365d2-e4db-444b-b1a9-795668ad3038.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery comes into play tapped.\nWhen Azorius Chancery comes into play, return a land you control to its owner's hand.\n{T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "c5867684-80f1-54b5-936e-e6a964176b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f281e16f-0fe1-4095-bd63-0a4479f75c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f281e16f-0fe1-4095-bd63-0a4479f75c11.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R} to your mana pool.)\nAs Blood Crypt comes into play, you may pay 2 life. If you don't, Blood Crypt comes into play tapped instead.",
             "colours": [],
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "27f5c620-9b05-5973-ba56-41a350eaad9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98b2a35-ec2b-47fe-903d-dd292e469a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98b2a35-ec2b-47fe-903d-dd292e469a3c.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U} to your mana pool.)\nAs Breeding Pool comes into play, you may pay 2 life. If you don't, Breeding Pool comes into play tapped instead.",
             "colours": [],
@@ -6258,7 +6258,7 @@
         },
         {
             "id": "170eacc5-6cdd-5635-a1ce-d1c3050c6ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893eb7e4-5d8d-477b-aaa7-fb85ef2a54fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893eb7e4-5d8d-477b-aaa7-fb85ef2a54fc.jpg?1",
             "name": "Ghost Quarter",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it into play, then shuffle his or her library.",
             "colours": [],
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "ca2170eb-1906-5bf6-8641-3202f6b9cddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28aea19-2a39-4934-afda-909e234fa3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28aea19-2a39-4934-afda-909e234fa3ba.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U} to your mana pool.)\nAs Hallowed Fountain comes into play, you may pay 2 life. If you don't, Hallowed Fountain comes into play tapped instead.",
             "colours": [],
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "74313a58-fb5b-5b9c-a252-c7fda27dc4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed595b59-b5c7-4335-a3c4-1c24c5a9cba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed595b59-b5c7-4335-a3c4-1c24c5a9cba2.jpg?1",
             "name": "Novijen, Heart of Progress",
             "text": "{T}: Add {1} to your mana pool.\n{G}{U}, {T}: Put a +1/+1 counter on each creature that came into play this turn.",
             "colours": [],
@@ -6351,7 +6351,7 @@
         },
         {
             "id": "228cac8b-0f8c-54ab-b50d-b1dba428cb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dcb39-b81e-4ae2-b153-01be0577ed93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dcb39-b81e-4ae2-b153-01be0577ed93.jpg?1",
             "name": "Pillar of the Paruns",
             "text": "{T}: Add one mana of any color to your mana pool. Spend this mana only to play a multicolored spell.",
             "colours": [],
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "bbf1cfec-7a62-5a7e-9bc4-16663da660f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a315f63-96ad-4a5f-8eb4-d81361797348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a315f63-96ad-4a5f-8eb4-d81361797348.jpg?1",
             "name": "Prahv, Spires of Order",
             "text": "{T}: Add {1} to your mana pool.\n{4}{W}{U}, {T}: Prevent all damage a source of your choice would deal this turn.",
             "colours": [],
@@ -6410,7 +6410,7 @@
         },
         {
             "id": "ae9fc745-fc05-5880-8287-d44b78a60577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f146f3-6541-4d2a-96e3-a3cd680c0a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f146f3-6541-4d2a-96e3-a3cd680c0a1e.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium comes into play tapped.\nWhen Rakdos Carnarium comes into play, return a land you control to its owner's hand.\n{T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "42e26432-0cfe-5d38-a98a-d1dcf7eadbb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f56ce7-1974-417e-a4cb-c9d9a9509039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f56ce7-1974-417e-a4cb-c9d9a9509039.jpg?1",
             "name": "Rix Maadi, Dungeon Palace",
             "text": "{T}: Add {1} to your mana pool.\n{1}{B}{R}, {T}: Each player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [],
@@ -6472,7 +6472,7 @@
         },
         {
             "id": "cdae08df-bd11-5385-bf56-1b961c8ec5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d0a0c-a6be-4bd5-8355-1715698c6bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d0a0c-a6be-4bd5-8355-1715698c6bde.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber comes into play tapped.\nWhen Simic Growth Chamber comes into play, return a land you control to its owner's hand.\n{T}: Add {G}{U} to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DKA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DKA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f432ef1a-3db0-57a9-9e18-5573df9ae065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99837b3-b487-43bb-846b-7a0e8afb6eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99837b3-b487-43bb-846b-7a0e8afb6eef.jpg?1",
             "name": "Archangel's Light",
             "text": "You gain 2 life for each card in your graveyard, then shuffle your graveyard into your library.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "3d648f9e-b244-590e-859c-8d4a76dd685c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b593f544-2d82-4237-b9a9-88503b5036cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b593f544-2d82-4237-b9a9-88503b5036cc.jpg?1",
             "name": "Bar the Door",
             "text": "Creatures you control get +0/+4 until end of turn.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "f6fa417d-da84-5125-8e74-9aa72394e5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e39da2a-814a-46bb-a1ca-fc5532ece842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e39da2a-814a-46bb-a1ca-fc5532ece842.jpg?1",
             "name": "Break of Day",
             "text": "Creatures you control get +1/+1 until end of turn.\nFateful hour \u2014 If you have 5 or less life, those creatures also are indestructible this turn. (Lethal damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -100,7 +100,7 @@
         },
         {
             "id": "8007507d-322d-5ddb-9ce4-2da1890c4658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7440288-6c55-4502-bf20-3c5b50a2de5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7440288-6c55-4502-bf20-3c5b50a2de5a.jpg?1",
             "name": "Burden of Guilt",
             "text": "Enchant creature\n{1}: Tap enchanted creature.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "2755ff07-9120-5fe1-94fb-afadce7a30d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b737a959-e974-4b2a-8dca-a257da6084b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b737a959-e974-4b2a-8dca-a257da6084b0.jpg?1",
             "name": "Curse of Exhaustion",
             "text": "Enchant player\nEnchanted player can't cast more than one spell each turn.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "e73ede92-2df9-53d7-9d6e-1b654013cf1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342e1da-7ab9-4e29-96e6-77d820a45ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342e1da-7ab9-4e29-96e6-77d820a45ede.jpg?1",
             "name": "Elgaud Inquisitor",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen Elgaud Inquisitor dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -204,7 +204,7 @@
         },
         {
             "id": "df43d3b7-d053-5b97-b77b-6f2abbab29bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb5920-3b03-4300-bc77-0fba5e6abe69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb5920-3b03-4300-bc77-0fba5e6abe69.jpg?1",
             "name": "Faith's Shield",
             "text": "Target permanent you control gains protection from the color of your choice until end of turn.\nFateful hour \u2014 If you have 5 or less life, instead you and each permanent you control gain protection from the color of your choice until end of turn.",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "8cbabfcb-8c9b-500d-888a-e4ab3d4b4cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfa554b-ee6d-4d4e-aabc-fe7bc6b25236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfa554b-ee6d-4d4e-aabc-fe7bc6b25236.jpg?1",
             "name": "Gather the Townsfolk",
             "text": "Put two 1/1 white Human creature tokens onto the battlefield.\nFateful hour \u2014 If you have 5 or less life, put five of those tokens onto the battlefield instead.",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "e30ed83c-fe32-5d1a-b6dd-16ec99e9849c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d8de75-b169-4426-94a4-b19cdfdffd89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d8de75-b169-4426-94a4-b19cdfdffd89.jpg?1",
             "name": "Gavony Ironwright",
             "text": "Fateful hour \u2014 As long as you have 5 or less life, other creatures you control get +1/+4.",
             "colours": [
@@ -303,7 +303,7 @@
         },
         {
             "id": "01145c58-70d0-500c-b78a-b8a1ab2b8e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1be91a-cdec-4933-b834-0a7838abb9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1be91a-cdec-4933-b834-0a7838abb9b8.jpg?1",
             "name": "Hollowhenge Spirit",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhen Hollowhenge Spirit enters the battlefield, remove target attacking or blocking creature from combat.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "4b491bf9-4f79-52cb-b26d-ced5942e1a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b5de81-65a6-4a74-8a71-767b92e89e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b5de81-65a6-4a74-8a71-767b92e89e91.jpg?1",
             "name": "Increasing Devotion",
             "text": "Put five 1/1 white Human creature tokens onto the battlefield. If Increasing Devotion was cast from a graveyard, put ten of those tokens onto the battlefield instead.\nFlashback {7}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "59a255f2-b0fc-5385-8e8e-9aeddbcc3f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891a92d7-9ccf-4de1-8286-aa5254f27ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891a92d7-9ccf-4de1-8286-aa5254f27ba9.jpg?1",
             "name": "Lingering Souls",
             "text": "Put two 1/1 white Spirit creature tokens with flying onto the battlefield.\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "9e581220-877d-50ac-878d-7806094e933c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg?1",
             "name": "Loyal Cathar // Unhallowed Cathar",
             "text": "Vigilance\nWhen Loyal Cathar dies, return it to the battlefield transformed under your control at the beginning of the next end step.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "3cf1fc99-a10e-5190-a253-18c416e921cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb09041b-4d09-4cae-9e85-b859edae885b.jpg?1",
             "name": "Loyal Cathar // Unhallowed Cathar",
             "text": "Unhallowed Cathar can't block.",
             "colours": [
@@ -474,7 +474,7 @@
         },
         {
             "id": "81c9c2c2-195d-5420-8fe3-2892c33ec654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2264b760-c527-470d-bad0-d8baaf543631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2264b760-c527-470d-bad0-d8baaf543631.jpg?1",
             "name": "Midnight Guard",
             "text": "Whenever another creature enters the battlefield, untap Midnight Guard.",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "e2c7adde-a7a3-56f2-a2b5-1be205967782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08aea6e3-c8a8-4964-b95d-4c639da55de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08aea6e3-c8a8-4964-b95d-4c639da55de1.jpg?1",
             "name": "Niblis of the Mist",
             "text": "Flying\nWhen Niblis of the Mist enters the battlefield, you may tap target creature.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "c04917fc-6e56-5a2e-a5c5-ce8c44dcc28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2ff7-0f8d-47ea-adfd-af299e793a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf2ff7-0f8d-47ea-adfd-af299e793a37.jpg?1",
             "name": "Niblis of the Urn",
             "text": "Flying\nWhenever Niblis of the Urn attacks, you may tap target creature.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "a8138242-15a4-50de-804c-281ff672ea56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e2c5a4-cf92-46bd-9033-8036436488cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e2c5a4-cf92-46bd-9033-8036436488cb.jpg?1",
             "name": "Ray of Revelation",
             "text": "Destroy target enchantment.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "e36410e4-f8e0-5ca2-a992-35d8f4ee3cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5385925d-05ad-4f2e-bd2c-8de6c088ed05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5385925d-05ad-4f2e-bd2c-8de6c088ed05.jpg?1",
             "name": "Requiem Angel",
             "text": "Flying\nWhenever another non-Spirit creature you control dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "d1226750-ce73-5951-ab86-aa3c50565710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96865440-01ad-40f2-90d7-9ecd0b4efecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96865440-01ad-40f2-90d7-9ecd0b4efecc.jpg?1",
             "name": "Sanctuary Cat",
             "text": "",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "18ef4109-9cae-5ea5-807a-15001000470b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ae92c-af6d-4a00-b102-c6d3bcc394b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ae92c-af6d-4a00-b102-c6d3bcc394b4.jpg?1",
             "name": "S\u00e9ance",
             "text": "At the beginning of each upkeep, you may exile target creature card from your graveyard. If you do, put a token onto the battlefield that's a copy of that card except it's a Spirit in addition to its other types. Exile it at the beginning of the next end step.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "7ba961b7-a7cf-572c-a62c-a5e407ca65af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54528722-a6aa-4567-9cd1-e4a97adec7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54528722-a6aa-4567-9cd1-e4a97adec7d0.jpg?1",
             "name": "Silverclaw Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "73f6d10c-37d2-5c81-a222-7e9d4ccf1195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a28abc1-3e75-4db4-baa1-b47abdb7453b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a28abc1-3e75-4db4-baa1-b47abdb7453b.jpg?1",
             "name": "Skillful Lunge",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "5b095452-8c3c-508a-98ce-928199377ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51b792c-b987-49b6-9cc6-80d613c7d065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51b792c-b987-49b6-9cc6-80d613c7d065.jpg?1",
             "name": "Sudden Disappearance",
             "text": "Exile all nonland permanents target player controls. Return the exiled cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "d55fe93f-58f3-5fb1-862b-1a9615f3c040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824423ff-6441-4be6-b754-810adf9ca6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824423ff-6441-4be6-b754-810adf9ca6a2.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "f400481b-5894-5c65-b1b9-6d343a9f973e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a9312-a5b2-4fc5-b46d-e0c9020583a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066a9312-a5b2-4fc5-b46d-e0c9020583a5.jpg?1",
             "name": "Thraben Doomsayer",
             "text": "{T}: Put a 1/1 white Human creature token onto the battlefield.\nFateful hour \u2014 As long as you have 5 or less life, other creatures you control get +2/+2.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "81558520-5d3a-5ed7-9467-95fca3cea09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cc36df-040b-4f29-bcc1-f5600803f71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cc36df-040b-4f29-bcc1-f5600803f71d.jpg?1",
             "name": "Thraben Heretic",
             "text": "{T}: Exile target creature card from a graveyard.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "d00d36f9-9f33-5d3f-a2e8-26f187ac2106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ce6aa-e19f-4299-9807-e68920e63c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ce6aa-e19f-4299-9807-e68920e63c73.jpg?1",
             "name": "Artful Dodge",
             "text": "Target creature is unblockable this turn.\nFlashback {U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "49a39b51-2346-583f-8e52-1f36edce75cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ae024-d565-48a1-8004-5aa320a5d24d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21ae024-d565-48a1-8004-5aa320a5d24d.jpg?1",
             "name": "Beguiler of Wills",
             "text": "{T}: Gain control of target creature with power less than or equal to the number of creatures you control.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "e22341a9-d0e5-5499-b1e2-ae0b2f3b8f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a75cef-9551-45e2-b1ff-80662c76ec20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a75cef-9551-45e2-b1ff-80662c76ec20.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "8739a6dd-2182-53b2-8dae-f159085e044f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee35f96c-6060-4456-897e-27b74c8c2137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee35f96c-6060-4456-897e-27b74c8c2137.jpg?1",
             "name": "Call to the Kindred",
             "text": "Enchant creature\nAt the beginning of your upkeep, you may look at the top five cards of your library. If you do, you may put a creature card that shares a creature type with enchanted creature from among them onto the battlefield, then you put the rest of those cards on the bottom of your library in any order.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "b642eefe-a338-5432-b5e5-affa74182681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e604b2e-f257-465d-9342-6eb55b2334c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e604b2e-f257-465d-9342-6eb55b2334c5.jpg?1",
             "name": "Chant of the Skifsang",
             "text": "Enchant creature\nEnchanted creature gets -13/-0.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "0b4be7e4-9b92-5831-8231-f3ef22f49356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abd6534-92bb-44e3-88c2-6709f1a4f29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0abd6534-92bb-44e3-88c2-6709f1a4f29c.jpg?1",
             "name": "Chill of Foreboding",
             "text": "Each player puts the top five cards of his or her library into his or her graveyard.\nFlashback {7}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "abf8da06-1649-5a6b-bd78-815340e29924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec2c57-8e67-472d-8f2e-0492d311f130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec2c57-8e67-472d-8f2e-0492d311f130.jpg?1",
             "name": "Counterlash",
             "text": "Counter target spell. You may cast a nonland card in your hand that shares a card type with that spell without paying its mana cost.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "72b2ba8d-a9c6-5da3-b059-ce66a6a8fdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147dbe42-665a-4e21-b405-d17554d5efcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147dbe42-665a-4e21-b405-d17554d5efcf.jpg?1",
             "name": "Curse of Echoes",
             "text": "Enchant player\nWhenever enchanted player casts an instant or sorcery spell, each other player may copy that spell and may choose new targets for the copy he or she controls.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "2815ee52-5fc1-5e69-8a22-a781ae42efb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1340f1-85a4-4551-9871-bb00db6d97a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1340f1-85a4-4551-9871-bb00db6d97a8.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1213,7 +1213,7 @@
         },
         {
             "id": "84b03fd3-829c-5b35-a55c-5350669762c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715da2e-c816-4c14-8522-811c97c66fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715da2e-c816-4c14-8522-811c97c66fed.jpg?1",
             "name": "Dungeon Geists",
             "text": "Flying\nWhen Dungeon Geists enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Dungeon Geists.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "c4655460-de98-5512-b222-cbcf0cf0a3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac8b5f-4d95-43fc-bf23-10247986a746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ac8b5f-4d95-43fc-bf23-10247986a746.jpg?1",
             "name": "Geralf's Mindcrusher",
             "text": "When Geralf's Mindcrusher enters the battlefield, target player puts the top five cards of his or her library into his or her graveyard.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1282,7 +1282,7 @@
         },
         {
             "id": "b5d26202-03ed-58dc-a1bc-169036804ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f92b74-86bb-4bb3-8f78-640984698f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f92b74-86bb-4bb3-8f78-640984698f28.jpg?1",
             "name": "Griptide",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -1314,7 +1314,7 @@
         },
         {
             "id": "e56c0679-17f5-5e5b-8d86-d342123925bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de766c12-eb2c-466a-8630-8242a153eb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de766c12-eb2c-466a-8630-8242a153eb1f.jpg?1",
             "name": "Havengul Runebinder",
             "text": "{2}{U}, {T}, Exile a creature card from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield, then put a +1/+1 counter on each Zombie creature you control.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "bd35948e-0f2a-5b0f-bc4a-23a215be8174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca63f9a2-381e-4c84-b0bb-3acd9445b4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca63f9a2-381e-4c84-b0bb-3acd9445b4db.jpg?1",
             "name": "Headless Skaab",
             "text": "As an additional cost to cast Headless Skaab, exile a creature card from your graveyard.\nHeadless Skaab enters the battlefield tapped.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "da62503e-cc29-5ec2-9613-1615beda0e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f5bcdc-70bb-4d67-99e1-282f166ee4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f5bcdc-70bb-4d67-99e1-282f166ee4bf.jpg?1",
             "name": "Increasing Confusion",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard. If Increasing Confusion was cast from a graveyard, that player puts twice that many cards into his or her graveyard instead.\nFlashback {X}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1416,7 +1416,7 @@
         },
         {
             "id": "52e7d095-e8c2-58c5-b2df-ab8e25086c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a685a-bd02-43bf-8700-2207c65bbbb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281a685a-bd02-43bf-8700-2207c65bbbb1.jpg?1",
             "name": "Mystic Retrieval",
             "text": "Return target instant or sorcery card from your graveyard to your hand.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "814941ea-a079-5cf0-b4e7-dfd8001abccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174a1d08-cd79-43d6-897f-3ee9a682d15e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174a1d08-cd79-43d6-897f-3ee9a682d15e.jpg?1",
             "name": "Nephalia Seakite",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "bab62d12-98aa-52bc-8ef3-735908674fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686843d-6d1e-4488-8c17-7c986a154195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686843d-6d1e-4488-8c17-7c986a154195.jpg?1",
             "name": "Niblis of the Breath",
             "text": "Flying\n{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "ee98734f-f54d-51ea-8fe5-97515b829fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg?1",
             "name": "Relentless Skaabs",
             "text": "As an additional cost to cast Relentless Skaabs, exile a creature card from your graveyard.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "eaff75b5-af38-5501-859d-c6ea9a1c5417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914837df-c255-4cea-9255-b05f218fd9f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914837df-c255-4cea-9255-b05f218fd9f8.jpg?1",
             "name": "Saving Grasp",
             "text": "Return target creature you own to your hand.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1584,7 +1584,7 @@
         },
         {
             "id": "5922c93f-1461-5229-80c8-a4086af2840f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c40a2c7-df7a-41a6-a49e-5f7db808b810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c40a2c7-df7a-41a6-a49e-5f7db808b810.jpg?1",
             "name": "Screeching Skaab",
             "text": "When Screeching Skaab enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "d40d69b0-ddc2-5808-88af-370fda127ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c982d679-581d-43e1-acd0-db77eb0987c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c982d679-581d-43e1-acd0-db77eb0987c2.jpg?1",
             "name": "Secrets of the Dead",
             "text": "Whenever you cast a spell from your graveyard, draw a card.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "8483679b-f851-5e55-ba55-747b94aef353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435c5218-46b3-456a-aedf-d9586a4bd0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435c5218-46b3-456a-aedf-d9586a4bd0a3.jpg?1",
             "name": "Shriekgeist",
             "text": "Flying\nWhenever Shriekgeist deals combat damage to a player, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "e8b267a0-3755-51af-95a9-bed1ac7aa88d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg?1",
             "name": "Soul Seizer // Ghastly Haunting",
             "text": "Flying\nWhen Soul Seizer deals combat damage to a player, you may transform it. If you do, attach it to target creature that player controls.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "6950f8fc-b5a6-53e5-9cfa-3555e1edfaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f500cb95-d5ea-4cf2-920a-f1df45a9059b.jpg?1",
             "name": "Soul Seizer // Ghastly Haunting",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -1752,7 +1752,7 @@
         },
         {
             "id": "40a9c798-43c7-5a2b-b2de-a67c99e441c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040eddb0-fca2-41eb-ab07-c48d49385973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040eddb0-fca2-41eb-ab07-c48d49385973.jpg?1",
             "name": "Stormbound Geist",
             "text": "Flying\nStormbound Geist can block only creatures with flying.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "0be9fd72-98ad-507d-ab8c-c2a000357289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1ebb-9d85-4b9b-a614-c7f965c0893d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1ebb-9d85-4b9b-a614-c7f965c0893d.jpg?1",
             "name": "Thought Scour",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard.\nDraw a card.",
             "colours": [
@@ -1818,7 +1818,7 @@
         },
         {
             "id": "081a5f59-f5dd-566c-840d-eef95de89aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e9f552-34b6-43a5-8ef8-9d5208f4cae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e9f552-34b6-43a5-8ef8-9d5208f4cae0.jpg?1",
             "name": "Tower Geist",
             "text": "Flying\nWhen Tower Geist enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "5582242e-08e0-567f-a6fb-f8057d1f3593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1c6379-69d5-48aa-8d06-257c0592794e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1c6379-69d5-48aa-8d06-257c0592794e.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "7cead567-4bf7-5d80-80cd-f3336aa5d5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg?1",
             "name": "Chosen of Markov // Markov's Servant",
             "text": "{T}, Tap an untapped Vampire you control: Transform Chosen of Markov.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "28d7d7f0-b651-55bf-b4b9-7b9a4a48d863",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c5a3c09-5656-4975-ba03-2d809903ed18.jpg?1",
             "name": "Chosen of Markov // Markov's Servant",
             "text": "",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "c0a1b7b7-742b-5663-b517-072647b5de05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c531d218-ff1c-4333-a19d-446d709b1e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c531d218-ff1c-4333-a19d-446d709b1e28.jpg?1",
             "name": "Curse of Misfortunes",
             "text": "Enchant player\nAt the beginning of your upkeep, you may search your library for a Curse card that doesn't have the same name as a Curse attached to enchanted player, put it onto the battlefield attached to that player, then shuffle your library.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "15dc8a56-5075-5be0-8d41-fea655b39ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ed5d1-44dc-4733-9e01-65fbc5dc02f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23ed5d1-44dc-4733-9e01-65fbc5dc02f2.jpg?1",
             "name": "Curse of Thirst",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, Curse of Thirst deals damage to that player equal to the number of Curses attached to him or her.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "0bf450c7-643e-5fea-a14f-f8e90dd506b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271bc29e-d33f-4c21-a3ee-b2c6b5c9015e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271bc29e-d33f-4c21-a3ee-b2c6b5c9015e.jpg?1",
             "name": "Deadly Allure",
             "text": "Target creature gains deathtouch until end of turn and must be blocked this turn if able.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2058,7 +2058,7 @@
         },
         {
             "id": "e6e1d6ac-5159-54b9-8f50-0372f44740ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0643fb9a-8284-4dfc-836a-c2c69ef09f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0643fb9a-8284-4dfc-836a-c2c69ef09f32.jpg?1",
             "name": "Death's Caress",
             "text": "Destroy target creature. If that creature was a Human, you gain life equal to its toughness.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "bacf974f-190b-5144-8c89-7a7f06978b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e81d6ed-2141-4177-9ded-680fff65b39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e81d6ed-2141-4177-9ded-680fff65b39e.jpg?1",
             "name": "Falkenrath Torturer",
             "text": "Sacrifice a creature: Falkenrath Torturer gains flying until end of turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Torturer.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "c499a97e-b7fc-5585-8b83-43f9267ec3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d45316-b44a-4cf6-8cbe-b02fe6545141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d45316-b44a-4cf6-8cbe-b02fe6545141.jpg?1",
             "name": "Farbog Boneflinger",
             "text": "When Farbog Boneflinger enters the battlefield, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2158,7 +2158,7 @@
         },
         {
             "id": "4ab11688-fa02-5e83-9343-5eb2d59659e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38167118-f5b3-4e07-8060-b170b49cff9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38167118-f5b3-4e07-8060-b170b49cff9e.jpg?1",
             "name": "Fiend of the Shadows",
             "text": "Flying\nWhenever Fiend of the Shadows deals combat damage to a player, that player exiles a card from his or her hand. You may play that card for as long as it remains exiled.\nSacrifice a Human: Regenerate Fiend of the Shadows.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "7a8a91f7-abf8-5d5b-9c32-495cde7f628b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffaad78-97ff-431f-bfb0-e96c7558f974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffaad78-97ff-431f-bfb0-e96c7558f974.jpg?1",
             "name": "Geralf's Messenger",
             "text": "Geralf's Messenger enters the battlefield tapped.\nWhen Geralf's Messenger enters the battlefield, target opponent loses 2 life.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "bfc4b3f8-b6e0-59c6-8600-007f146bc554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d73cb5-22ac-43df-9c4b-0c860bb80b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d73cb5-22ac-43df-9c4b-0c860bb80b3e.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -2261,7 +2261,7 @@
         },
         {
             "id": "1988e713-9ce6-5117-938f-6bdc97fa0fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0c266b-9ef5-4de2-a358-65739de41491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0c266b-9ef5-4de2-a358-65739de41491.jpg?1",
             "name": "Gravepurge",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "8ee9a022-4f38-5a25-85d5-4875a1a1b81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9d733-24b6-49ed-a15a-c00285eea4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9d733-24b6-49ed-a15a-c00285eea4b2.jpg?1",
             "name": "Gruesome Discovery",
             "text": "Target player discards two cards.\nMorbid \u2014 If a creature died this turn, instead that player reveals his or her hand, you choose two cards from it, then that player discards those cards.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "14902953-83d9-53cb-b856-2e7e1a96ae9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf96a6c-8481-4954-b149-7153b80480be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf96a6c-8481-4954-b149-7153b80480be.jpg?1",
             "name": "Harrowing Journey",
             "text": "Target player draws three cards and loses 3 life.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "41e6e1c5-e8c4-5181-acb9-43c5c120547c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe999ed-b419-440c-9189-1046f43d7b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe999ed-b419-440c-9189-1046f43d7b87.jpg?1",
             "name": "Highborn Ghoul",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "4100b2d5-e735-57a9-9b1a-741e4c146928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f508dc-7c7d-47e8-a4ef-0e8fd99cbd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f508dc-7c7d-47e8-a4ef-0e8fd99cbd74.jpg?1",
             "name": "Increasing Ambition",
             "text": "Search your library for a card and put that card into your hand. If Increasing Ambition was cast from a graveyard, instead search your library for two cards and put those cards into your hand. Then shuffle your library.\nFlashback {7}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "7c57482e-4f47-5adc-b614-aa1be6ee50df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b124d-3546-4882-a6e1-c9c353628a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b124d-3546-4882-a6e1-c9c353628a18.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "43aa4d36-9514-554e-bd91-157707b87b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg?1",
             "name": "Ravenous Demon // Archdemon of Greed",
             "text": "Sacrifice a Human: Transform Ravenous Demon. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "d0aa4bb6-bff1-51ba-b9ae-fb5c35239b3b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6aef77b3-4b38-4902-9f7a-dc18b5bb9da9.jpg?1",
             "name": "Ravenous Demon // Archdemon of Greed",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a Human. If you can't, tap Archdemon of Greed and it deals 9 damage to you.",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "f8620697-3a95-5fa7-899e-7b7626d10df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4defdead-19fa-4535-9f71-8808388b0332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4defdead-19fa-4535-9f71-8808388b0332.jpg?1",
             "name": "Reap the Seagraf",
             "text": "Put a 2/2 black Zombie creature token onto the battlefield.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "7a5885cf-bb5c-5bac-b036-caa10193e7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018bd4ae-cdea-410d-9ce6-6a70f12de966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018bd4ae-cdea-410d-9ce6-6a70f12de966.jpg?1",
             "name": "Sightless Ghoul",
             "text": "Sightless Ghoul can't block.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "6a341ff4-00e8-5216-aa0a-2f57c86dab6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274976b0-2bb5-46e6-b62e-b50d80a77e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274976b0-2bb5-46e6-b62e-b50d80a77e28.jpg?1",
             "name": "Skirsdag Flayer",
             "text": "{3}{B}, {T}, Sacrifice a Human: Destroy target creature.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "a0ed4512-ab21-5dbf-b450-bb632e0f68f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0a94fe-11d6-48a7-9195-2cb5eff4b962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0a94fe-11d6-48a7-9195-2cb5eff4b962.jpg?1",
             "name": "Spiteful Shadows",
             "text": "Enchant creature\nWhenever enchanted creature is dealt damage, it deals that much damage to its controller.",
             "colours": [
@@ -2665,7 +2665,7 @@
         },
         {
             "id": "05f97900-7f22-5aa7-8dc9-9efe96c6166b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09666671-601e-4fca-bdfb-fb288bf2672c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09666671-601e-4fca-bdfb-fb288bf2672c.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "25a231f7-2b67-5df4-92cd-37288ae4217e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f2243-54fd-484b-a742-166cea7ec179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f2243-54fd-484b-a742-166cea7ec179.jpg?1",
             "name": "Undying Evil",
             "text": "Target creature gains undying until end of turn. (When it dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "0a057fd9-bf97-5e0f-93aa-e6c2295fad35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03c64a7-37d2-4d8f-bd7a-9435bc2f4101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03c64a7-37d2-4d8f-bd7a-9435bc2f4101.jpg?1",
             "name": "Vengeful Vampire",
             "text": "Flying\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "d176b196-4f6f-5ee4-be0e-c5cceebe70ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f533fbfa-42ae-4e27-92a4-9936bcd2a5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f533fbfa-42ae-4e27-92a4-9936bcd2a5f4.jpg?1",
             "name": "Wakedancer",
             "text": "Morbid \u2014 When Wakedancer enters the battlefield, if a creature died this turn, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -2798,7 +2798,7 @@
         },
         {
             "id": "6d6004a3-8a92-53fc-8f17-9d4d36c6835a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe662a08-a8b1-4f25-b7c0-dca1c7ad7271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe662a08-a8b1-4f25-b7c0-dca1c7ad7271.jpg?1",
             "name": "Zombie Apocalypse",
             "text": "Return all Zombie creature cards from your graveyard to the battlefield tapped, then destroy all Humans.",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "925aef52-b1b5-5493-a88a-74f42fbd0ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg?1",
             "name": "Afflicted Deserter // Werewolf Ransacker",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Afflicted Deserter.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "f40dda4a-0d51-5a68-b310-21b8b0ec5b37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2c044c0-3625-4bdf-9445-b462394cecae.jpg?1",
             "name": "Afflicted Deserter // Werewolf Ransacker",
             "text": "Whenever this creature transforms into Werewolf Ransacker, you may destroy target artifact. If that artifact is put into a graveyard this way, Werewolf Ransacker deals 3 damage to that artifact's controller.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Werewolf Ransacker.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "7e84abf0-a001-517d-ad16-b5b153bd8483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ec168a-3e4f-4527-901a-bc28cc28d125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ec168a-3e4f-4527-901a-bc28cc28d125.jpg?1",
             "name": "Alpha Brawl",
             "text": "Target creature an opponent controls deals damage equal to its power to each other creature that player controls, then each of those creatures deals damage equal to its power to that creature.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "e2d33f4d-458f-5ad8-8c71-f67415e9660b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634d59b8-6046-4796-95c5-eec75a239986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634d59b8-6046-4796-95c5-eec75a239986.jpg?1",
             "name": "Blood Feud",
             "text": "Target creature fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "3fd37123-94ae-572d-9d97-86627ca854da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47773da8-afe4-43e1-8355-6ab51451ee00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47773da8-afe4-43e1-8355-6ab51451ee00.jpg?1",
             "name": "Burning Oil",
             "text": "Burning Oil deals 3 damage to target attacking or blocking creature.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "d822db94-b23d-56b4-8fdc-5befa6a01bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4ac6f-0005-47f8-bee9-10429cc542e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4ac6f-0005-47f8-bee9-10429cc542e4.jpg?1",
             "name": "Curse of Bloodletting",
             "text": "Enchant player\nIf a source would deal damage to enchanted player, it deals double that damage to that player instead.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "fd5af8a8-9fd4-5a2f-9c3d-a4a173938ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ea5e9-6d05-4bc6-8f14-00eb2532c8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ea5e9-6d05-4bc6-8f14-00eb2532c8b5.jpg?1",
             "name": "Erdwal Ripper",
             "text": "Haste\nWhenever Erdwal Ripper deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "8e1e236b-0e80-55b9-ac30-a52a7181807b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b0da17-d595-441d-811c-a2d28d2bb232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b0da17-d595-441d-811c-a2d28d2bb232.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "721e5822-27a1-504b-92bc-548f227184ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d94aaa4-c2fd-4714-9198-8415158b9c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d94aaa4-c2fd-4714-9198-8415158b9c4d.jpg?1",
             "name": "Fires of Undeath",
             "text": "Fires of Undeath deals 2 damage to target creature or player.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "990c5cec-8bde-5bf1-b8a3-42f410f06184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb17c3f-0154-49ee-bb5f-cd1df8546871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb17c3f-0154-49ee-bb5f-cd1df8546871.jpg?1",
             "name": "Flayer of the Hatebound",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)\nWhenever Flayer of the Hatebound or another creature enters the battlefield from your graveyard, that creature deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "de51396c-5b83-56f0-ae68-79f7f4e4c2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1ab466-44bb-45d5-a94f-21b8924f0d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1ab466-44bb-45d5-a94f-21b8924f0d89.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "efd01986-0971-51ec-a174-47b6870014f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b565a5-d706-47b4-bfa2-deebcc0e2e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b565a5-d706-47b4-bfa2-deebcc0e2e60.jpg?1",
             "name": "Forge Devil",
             "text": "When Forge Devil enters the battlefield, it deals 1 damage to target creature and 1 damage to you.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "a6bd1f34-29f9-5f3b-a89d-d3d4eecf93fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fd8895-9282-44d3-969f-b0529eb3bc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fd8895-9282-44d3-969f-b0529eb3bc07.jpg?1",
             "name": "Heckling Fiends",
             "text": "{2}{R}: Target creature attacks this turn if able.",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "0a0c3751-69b7-5942-a17c-7b49085891e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec8d800-7f06-44e0-b22d-cdff0a9b153d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec8d800-7f06-44e0-b22d-cdff0a9b153d.jpg?1",
             "name": "Hellrider",
             "text": "Haste\nWhenever a creature you control attacks, Hellrider deals 1 damage to defending player.",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "f2401a1b-10da-5ec6-843a-015d972dcabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg?1",
             "name": "Hinterland Hermit // Hinterland Scourge",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Hinterland Hermit.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "7dddff97-6436-5e71-8e1e-abbe2af9154f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6edac85-78e7-4e90-b538-b67c88bb5c62.jpg?1",
             "name": "Hinterland Hermit // Hinterland Scourge",
             "text": "Hinterland Scourge must be blocked if able.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Hinterland Scourge.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "745aef19-1b77-5266-ad5f-b32f0781ec90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13afe4a-4a3d-42ae-ac0a-b789364c7e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13afe4a-4a3d-42ae-ac0a-b789364c7e7e.jpg?1",
             "name": "Increasing Vengeance",
             "text": "Copy target instant or sorcery spell you control. If Increasing Vengeance was cast from a graveyard, copy that spell twice instead. You may choose new targets for the copies.\nFlashback {3}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3399,7 +3399,7 @@
         },
         {
             "id": "1c5c95c0-31a0-5865-9527-7aad5967e501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122163dd-e070-48af-8036-e9850541d138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122163dd-e070-48af-8036-e9850541d138.jpg?1",
             "name": "Markov Blademaster",
             "text": "Double strike\nWhenever Markov Blademaster deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "963448b6-7f6f-5503-86c3-abe5a01a5824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5035276f-31b9-4dd3-9ec8-42a664bdbd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5035276f-31b9-4dd3-9ec8-42a664bdbd5c.jpg?1",
             "name": "Markov Warlord",
             "text": "Haste\nWhen Markov Warlord enters the battlefield, up to two target creatures can't block this turn.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "fc85f238-6fc8-5300-af37-4153fc2f806d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg?1",
             "name": "Mondronen Shaman // Tovolar's Magehunter",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Mondronen Shaman.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "0a0444ca-b731-5818-bd39-8c7094c7ef87",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b150d71f-11c9-40d6-a461-4967ef437315.jpg?1",
             "name": "Mondronen Shaman // Tovolar's Magehunter",
             "text": "Whenever an opponent casts a spell, Tovolar's Magehunter deals 2 damage to that player.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Tovolar's Magehunter.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "6563d0ea-11d4-548e-a3ba-03a4fe408a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92503118-b37b-4c52-b40a-487f6ad695ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92503118-b37b-4c52-b40a-487f6ad695ef.jpg?1",
             "name": "Moonveil Dragon",
             "text": "Flying\n{R}: Each creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "b2e2a074-458b-5310-820e-05474ed63388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4cdf4a-2d55-4769-8c51-bc86c13000ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4cdf4a-2d55-4769-8c51-bc86c13000ef.jpg?1",
             "name": "Nearheath Stalker",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3608,7 +3608,7 @@
         },
         {
             "id": "a58e8f31-ec50-516c-ae68-4546712c0032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9722f20c-e0d9-4165-8cd5-4abadc5378eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9722f20c-e0d9-4165-8cd5-4abadc5378eb.jpg?1",
             "name": "Pyreheart Wolf",
             "text": "Whenever Pyreheart Wolf attacks, each creature you control can't be blocked this turn except by two or more creatures.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "b0610b09-71c7-53f9-b411-603a8113b485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c7c972-5a11-4709-b3ef-e2acb3b51dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c7c972-5a11-4709-b3ef-e2acb3b51dd9.jpg?1",
             "name": "Russet Wolves",
             "text": "",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "eaeb1611-70f6-5482-b2b1-c30224b5494a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4338d-e5c0-46b4-ab16-1f9aa97b4026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4338d-e5c0-46b4-ab16-1f9aa97b4026.jpg?1",
             "name": "Scorch the Fields",
             "text": "Destroy target land. Scorch the Fields deals 1 damage to each Human creature.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "53696378-2cd9-5b83-a0e5-22829905fbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5223b4-e0d1-4fc6-a363-ebcdfeee56d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5223b4-e0d1-4fc6-a363-ebcdfeee56d1.jpg?1",
             "name": "Shattered Perception",
             "text": "Discard all the cards in your hand, then draw that many cards.\nFlashback {5}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "4f8a49c1-cdb2-5ae0-a020-93a555cf3176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e38239-a9ec-4149-9c90-74dcd46ed95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e38239-a9ec-4149-9c90-74dcd46ed95d.jpg?1",
             "name": "Talons of Falkenrath",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature has \"{1}{R}: This creature gets +2/+0 until end of turn.\"",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "7f5e490f-f76d-5ba7-a3d9-2ce3cff03a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d596feee-6ccc-4648-884b-ed2eeb1cffc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d596feee-6ccc-4648-884b-ed2eeb1cffc0.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "d8a4b79a-a065-5d9c-a5f2-49eac1adddb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f27ee20-b5c5-4867-b832-9cdade0eda03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f27ee20-b5c5-4867-b832-9cdade0eda03.jpg?1",
             "name": "Wrack with Madness",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "764b967b-7011-5260-a8f1-190538804b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a052e945-7535-4b0a-b580-cf76377633f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a052e945-7535-4b0a-b580-cf76377633f3.jpg?1",
             "name": "Briarpack Alpha",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Briarpack Alpha enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "eef62138-eda3-5968-acc0-7dd9c5201312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0152975-790a-40e4-993e-a970676a2d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0152975-790a-40e4-993e-a970676a2d32.jpg?1",
             "name": "Clinging Mists",
             "text": "Prevent all combat damage that would be dealt this turn.\nFateful hour \u2014 If you have 5 or less life, tap all attacking creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "48c15384-a2f8-5ea2-aa43-4bb1cc1fde53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59b3653-5a50-48f2-bcf1-ab305ef30902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59b3653-5a50-48f2-bcf1-ab305ef30902.jpg?1",
             "name": "Crushing Vines",
             "text": "Choose one \u2014 Destroy target creature with flying; or destroy target artifact.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "4574fdb2-dfec-5641-9b30-fe8ca634b0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127c969b-1c9a-4265-af0e-5b9dbe136064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127c969b-1c9a-4265-af0e-5b9dbe136064.jpg?1",
             "name": "Dawntreader Elk",
             "text": "{G}, Sacrifice Dawntreader Elk: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "51f98648-7a55-51f9-8fdc-0d89dac5ea5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b35fee-8e24-4d89-ad77-d55d06bb1d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b35fee-8e24-4d89-ad77-d55d06bb1d7f.jpg?1",
             "name": "Deranged Outcast",
             "text": "{1}{G}, Sacrifice a Human: Put two +1/+1 counters on target creature.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "4deda099-27da-5c25-8632-205e85c738d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0e760a-241b-40c5-b201-bfc03effed2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0e760a-241b-40c5-b201-bfc03effed2e.jpg?1",
             "name": "Favor of the Woods",
             "text": "Enchant creature\nWhenever enchanted creature blocks, you gain 3 life.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "b279c94a-e357-5105-8f53-24b6cbd6688c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831e3cc-659b-4408-b5d8-a27ae2738680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831e3cc-659b-4408-b5d8-a27ae2738680.jpg?1",
             "name": "Feed the Pack",
             "text": "At the beginning of your end step, you may sacrifice a nontoken creature. If you do, put X 2/2 green Wolf creature tokens onto the battlefield, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "358c2525-6036-5505-8b09-a1edad1afbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a413c65e-5965-429b-8c25-11f8b73cba03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a413c65e-5965-429b-8c25-11f8b73cba03.jpg?1",
             "name": "Ghoultree",
             "text": "Ghoultree costs {1} less to cast for each creature card in your graveyard.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "1517c2ee-55ea-50fa-bcf3-3947bc926931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9fe36-2eac-49e3-8f89-810009ba8a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9fe36-2eac-49e3-8f89-810009ba8a4b.jpg?1",
             "name": "Gravetiller Wurm",
             "text": "Trample\nMorbid \u2014 Gravetiller Wurm enters the battlefield with four +1/+1 counters on it if a creature died this turn.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "aa78de56-3934-5cb2-82c9-7e8a66cadd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3e2ad-7a04-4735-ba73-576e32249ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3e2ad-7a04-4735-ba73-576e32249ba3.jpg?1",
             "name": "Grim Flowering",
             "text": "Draw a card for each creature card in your graveyard.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "7f609a29-9438-5203-8ea4-e67cddd29c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab91f-ac01-43f4-9276-9af35dbfbf71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab91f-ac01-43f4-9276-9af35dbfbf71.jpg?1",
             "name": "Hollowhenge Beast",
             "text": "",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "0e06c6a6-6913-51ef-87e2-5b8cd4cd5eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38a0dbc-3ebd-4f87-a5fb-bc2ee8a48a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38a0dbc-3ebd-4f87-a5fb-bc2ee8a48a8d.jpg?1",
             "name": "Hunger of the Howlpack",
             "text": "Put a +1/+1 counter on target creature.\nMorbid \u2014 Put three +1/+1 counters on that creature instead if a creature died this turn.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "83bfb8d9-0126-5e05-a7d1-4eeb42470c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ab8737-151f-4702-a95d-7f7b60a5ee8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ab8737-151f-4702-a95d-7f7b60a5ee8a.jpg?1",
             "name": "Increasing Savagery",
             "text": "Put five +1/+1 counters on target creature. If Increasing Savagery was cast from a graveyard, put ten +1/+1 counters on that creature instead.\nFlashback {5}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "0e05dd3f-75da-5ade-b4fb-42ad45820ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695b8abe-796e-4d9b-aad3-4e03e925d2a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695b8abe-796e-4d9b-aad3-4e03e925d2a7.jpg?1",
             "name": "Kessig Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "c5a8dd6c-a086-586d-9756-cd5b44a39d80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg?1",
             "name": "Lambholt Elder // Silverpelt Werewolf",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Lambholt Elder.",
             "colours": [
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "da5ed573-adba-58da-ae0f-08b38fafae9c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/932d753d-9584-4ad8-9a5e-a3524184f961.jpg?1",
             "name": "Lambholt Elder // Silverpelt Werewolf",
             "text": "Whenever Silverpelt Werewolf deals combat damage to a player, draw a card.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Silverpelt Werewolf.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "cb87f8b8-24b7-57b8-b6cd-168c96ece3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865603c-0a5e-45c3-84e3-2dc3b4cf0cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865603c-0a5e-45c3-84e3-2dc3b4cf0cf7.jpg?1",
             "name": "Lost in the Woods",
             "text": "Whenever a creature attacks you or a planeswalker you control, reveal the top card of your library. If it's a Forest card, remove that creature from combat. Then put the revealed card on the bottom of your library.",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "e3bf560d-4aac-5668-979e-ee1acaddce2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c71457-f7c9-4ab4-b89d-e235e3f15e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c71457-f7c9-4ab4-b89d-e235e3f15e16.jpg?1",
             "name": "Predator Ooze",
             "text": "Predator Ooze is indestructible.\nWhenever Predator Ooze attacks, put a +1/+1 counter on it.\nWhenever a creature dealt damage by Predator Ooze this turn dies, put a +1/+1 counter on Predator Ooze.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "423395c8-4bd3-512e-9172-1c71c47925b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1",
             "name": "Scorned Villager // Moonscarred Werewolf",
             "text": "{T}: Add {G} to your mana pool.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Scorned Villager.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "dc98dce3-262d-5788-a15f-5839588393dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1",
             "name": "Scorned Villager // Moonscarred Werewolf",
             "text": "Vigilance\n{T}: Add {G}{G} to your mana pool.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Moonscarred Werewolf.",
             "colours": [
@@ -4510,7 +4510,7 @@
         },
         {
             "id": "4c00c2b9-4ff5-5194-828c-274886dbdea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307edca0-769d-4071-9654-3537341e96bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307edca0-769d-4071-9654-3537341e96bd.jpg?1",
             "name": "Somberwald Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -4544,7 +4544,7 @@
         },
         {
             "id": "9f17556a-21be-5322-87f7-6e1b11b3dad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1fb137-205c-480f-b6dc-dfa137793ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1fb137-205c-480f-b6dc-dfa137793ae3.jpg?1",
             "name": "Strangleroot Geist",
             "text": "Haste\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4578,7 +4578,7 @@
         },
         {
             "id": "cf20c231-6171-5ae0-948d-d3ee99b3fe89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59960387-3adf-4b9a-b0e6-c441579f7388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59960387-3adf-4b9a-b0e6-c441579f7388.jpg?1",
             "name": "Tracker's Instincts",
             "text": "Reveal the top four cards of your library. Put a creature card from among them into your hand and the rest into your graveyard.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "ac6b9db9-9a63-51e3-9dc3-813891980745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3837a7-854a-440d-93d7-d36f50149346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3837a7-854a-440d-93d7-d36f50149346.jpg?1",
             "name": "Ulvenwald Bear",
             "text": "Morbid \u2014 When Ulvenwald Bear enters the battlefield, if a creature died this turn, put two +1/+1 counters on target creature.",
             "colours": [
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "35a3c35b-a8fa-57a3-8f8f-671e27ac8339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c0e852-9966-4145-b7c3-ac957f729376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c0e852-9966-4145-b7c3-ac957f729376.jpg?1",
             "name": "Village Survivors",
             "text": "Vigilance\nFateful hour \u2014 As long as you have 5 or less life, other creatures you control have vigilance.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "aad45fe9-c4ba-51b2-8405-7c6858eb64d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1348aa65-85e7-4ac7-bcdb-a83f2c3aa1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1348aa65-85e7-4ac7-bcdb-a83f2c3aa1a6.jpg?1",
             "name": "Vorapede",
             "text": "Vigilance, trample\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "e20b8a72-59e1-5a98-b1a8-9e3a281deb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a564e8d4-4111-4d8e-897d-523bc4cfef94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a564e8d4-4111-4d8e-897d-523bc4cfef94.jpg?1",
             "name": "Wild Hunger",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "8a054acd-2001-5ece-9d72-6d49168192d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg?1",
             "name": "Wolfbitten Captive // Krallenhorde Killer",
             "text": "{1}{G}: Wolfbitten Captive gets +2/+2 until end of turn. Activate this ability only once each turn.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Wolfbitten Captive.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "e9a348e6-d996-5ddf-bbef-598adb934794",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/1303e02a-ef69-4817-bca5-02c74774b811.jpg?1",
             "name": "Wolfbitten Captive // Krallenhorde Killer",
             "text": "{3}{G}: Krallenhorde Killer gets +4/+4 until end of turn. Activate this ability only once each turn.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Krallenhorde Killer.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "85f6f5ec-f3cc-5523-a53a-76523a9e5b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39aa40-ef5f-40f1-a6dd-fbce91172c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c39aa40-ef5f-40f1-a6dd-fbce91172c50.jpg?1",
             "name": "Young Wolf",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "c814c42a-8193-50a0-85d1-b018dd556261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e5f41eb-609b-4882-af9e-904daa717484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e5f41eb-609b-4882-af9e-904daa717484.jpg?1",
             "name": "Diregraf Captain",
             "text": "Deathtouch\nOther Zombie creatures you control get +1/+1.\nWhenever another Zombie you control dies, target opponent loses 1 life.",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "d5950c10-b773-5cb0-b886-0e26152464be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8238e36-625f-460d-9e39-fd501e65490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8238e36-625f-460d-9e39-fd501e65490c.jpg?1",
             "name": "Drogskol Captain",
             "text": "Flying\nOther Spirit creatures you control get +1/+1 and have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -4923,7 +4923,7 @@
         },
         {
             "id": "f4e7b75d-57c7-5f53-8c64-12f978c6ac96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d9e0b-6433-40a2-9847-9fa4e3c008c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d9e0b-6433-40a2-9847-9fa4e3c008c4.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying, double strike, lifelink\nWhenever you gain life, draw a card.",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "2667f661-15ee-5024-bca5-4d486858a371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397388e-ebe2-4034-83b7-a7c0df1af78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397388e-ebe2-4034-83b7-a7c0df1af78f.jpg?1",
             "name": "Falkenrath Aristocrat",
             "text": "Flying, haste\nSacrifice a creature: Falkenrath Aristocrat is indestructible this turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "56103b7d-428f-5aba-8df3-7a4dc2ca2bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321077a4-e468-4e74-94f7-80c83790e0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321077a4-e468-4e74-94f7-80c83790e0d9.jpg?1",
             "name": "Havengul Lich",
             "text": "{1}: You may cast target creature card in a graveyard this turn. When you cast that card this turn, Havengul Lich gains all activated abilities of that card until end of turn.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "d7eb7756-fc8f-5e70-b86d-db6446361748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "Whenever this creature enters the battlefield or transforms into Huntmaster of the Fells, put a 2/2 green Wolf creature token onto the battlefield and you gain 2 life.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Huntmaster of the Fells.",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "9e35bea5-695f-54ad-affc-c75ac7cde0d2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "Trample\nWhenever this creature transforms into Ravager of the Fells, it deals 2 damage to target opponent and 2 damage to up to one target creature that player controls.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ravager of the Fells.",
             "colours": [
@@ -5106,7 +5106,7 @@
         },
         {
             "id": "1c8671ee-d281-5b36-b8c8-9d98c502c650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9326061f-ea76-4be7-a06f-aefb63454777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9326061f-ea76-4be7-a06f-aefb63454777.jpg?1",
             "name": "Immerwolf",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nOther Wolf and Werewolf creatures you control get +1/+1.\nNon-Human Werewolves you control can't transform.",
             "colours": [
@@ -5142,7 +5142,7 @@
         },
         {
             "id": "37351af6-9659-599b-a519-be9ddec8e09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bb371f-d49f-41bd-bbe0-d5e1e2067e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bb371f-d49f-41bd-bbe0-d5e1e2067e36.jpg?1",
             "name": "Sorin, Lord of Innistrad",
             "text": "+1: Put a 1/1 black Vampire creature token with lifelink onto the battlefield.\n-2: You get an emblem with \"Creatures you control get +1/+0.\"\n-6: Destroy up to three target creatures and/or other planeswalkers. Return each card put into a graveyard this way to the battlefield under your control.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "9d9cc499-3672-5600-aefd-45db63e3d51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfcca87-04f8-480a-bae6-ae87f7afb7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfcca87-04f8-480a-bae6-ae87f7afb7e1.jpg?1",
             "name": "Stromkirk Captain",
             "text": "First strike\nOther Vampire creatures you control get +1/+1 and have first strike.",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "b295314f-1ae4-533e-96c7-63f93dcdc866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e5322-1b41-488d-94b1-7742fbd983d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e5322-1b41-488d-94b1-7742fbd983d4.jpg?1",
             "name": "Altar of the Lost",
             "text": "Altar of the Lost enters the battlefield tapped.\n{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast spells with flashback from a graveyard.",
             "colours": [],
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "a3cbc6b4-34fb-5906-93b0-804c58eca3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9a78-204b-4012-b394-b40fd0edac4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9a78-204b-4012-b394-b40fd0edac4c.jpg?1",
             "name": "Avacyn's Collar",
             "text": "Equipped creature gets +1/+0 and has vigilance.\nWhenever equipped creature dies, if it was a Human, put a 1/1 white Spirit creature token with flying onto the battlefield.\nEquip {2}",
             "colours": [],
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "34b16f70-2dd9-5843-b680-0a40a4b68e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1",
             "name": "Chalice of Life // Chalice of Death",
             "text": "{T}: You gain 1 life. Then if you have at least 10 life more than your starting life total, transform Chalice of Life.",
             "colours": [],
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "429cf546-1ea8-5acf-9f3c-9d17394a1875",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1",
             "name": "Chalice of Life // Chalice of Death",
             "text": "{T}: Target player loses 5 life.",
             "colours": [],
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "56463017-ab81-5be0-bbdb-54c74cafaf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg?1",
             "name": "Elbrus, the Binding Blade // Withengar Unbound",
             "text": "Equipped creature gets +1/+0.\nWhen equipped creature deals combat damage to a player, unattach Elbrus, the Binding Blade, then transform it.\nEquip {1}",
             "colours": [],
@@ -5365,7 +5365,7 @@
         },
         {
             "id": "5b2da00b-8ae3-5a52-b377-163555853a69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683af377-c491-4f62-900c-6b83d75c33c9.jpg?1",
             "name": "Elbrus, the Binding Blade // Withengar Unbound",
             "text": "Flying, intimidate, trample\nWhenever a player loses the game, put thirteen +1/+1 counters on Withengar Unbound.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "5e2680da-81b0-590c-991b-d5f7ebf21192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7447d115-9b29-4086-8435-40c7c957f242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7447d115-9b29-4086-8435-40c7c957f242.jpg?1",
             "name": "Executioner's Hood",
             "text": "Equipped creature has intimidate. (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5431,7 +5431,7 @@
         },
         {
             "id": "76fbb5ac-829d-5f43-9f79-a5392d7c944c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6240e7-d3aa-40e9-a627-58e7bf62525c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6240e7-d3aa-40e9-a627-58e7bf62525c.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "Creature cards can't enter the battlefield from graveyards or libraries.\nPlayers can't cast cards in graveyards or libraries.",
             "colours": [],
@@ -5459,7 +5459,7 @@
         },
         {
             "id": "8ea7c557-99df-537d-97d3-1cea1ea2236e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b09df01-0b3e-463e-bf00-0a9f1822261a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b09df01-0b3e-463e-bf00-0a9f1822261a.jpg?1",
             "name": "Heavy Mattock",
             "text": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human, it gets an additional +1/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5489,7 +5489,7 @@
         },
         {
             "id": "9d55721e-5345-5a3a-8acc-711df27a0166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2448c-1b2e-466a-a0ab-e20ba1de6bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2448c-1b2e-466a-a0ab-e20ba1de6bc9.jpg?1",
             "name": "Helvault",
             "text": "{1}, {T}: Exile target creature you control.\n{7}, {T}: Exile target creature you don't control.\nWhen Helvault is put into a graveyard from the battlefield, return all cards exiled with it to the battlefield under their owners' control.",
             "colours": [],
@@ -5519,7 +5519,7 @@
         },
         {
             "id": "644ff745-3b5f-5f7c-8880-ed5434937d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72825270-d5c1-4ab1-903a-e2868ade17f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72825270-d5c1-4ab1-903a-e2868ade17f2.jpg?1",
             "name": "Jar of Eyeballs",
             "text": "Whenever a creature you control dies, put two eyeball counters on Jar of Eyeballs.\n{3}, {T}, Remove all eyeball counters from Jar of Eyeballs: Look at the top X cards of your library, where X is the number of eyeball counters removed this way. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [],
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "170f00bc-d1a6-5f78-b909-a01ece5545bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1a1f48-d46b-4b8e-a642-fc70fd9ef7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1a1f48-d46b-4b8e-a642-fc70fd9ef7df.jpg?1",
             "name": "Warden of the Wall",
             "text": "Warden of the Wall enters the battlefield tapped.\n{T}: Add {1} to your mana pool.\nAs long as it's not your turn, Warden of the Wall is a 2/3 Gargoyle artifact creature with flying.",
             "colours": [],
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "1bfe8246-2fa6-54b8-aee1-62474a1401b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84c9b19-9b4d-4a60-984f-636b749c8bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84c9b19-9b4d-4a60-984f-636b749c8bcc.jpg?1",
             "name": "Wolfhunter's Quiver",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target creature or player\" and \"{T}: This creature deals 3 damage to target Werewolf creature.\"\nEquip {5}",
             "colours": [],
@@ -5605,7 +5605,7 @@
         },
         {
             "id": "0dd27d0a-2a8b-5325-b46f-545c3e7f32fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30066306-f943-44c1-8814-b8b60388c26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30066306-f943-44c1-8814-b8b60388c26d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "67517604-4b50-57ae-b3a0-c7f54bfea63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045abeeb-f5e5-4f3f-9836-5b1553e03f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045abeeb-f5e5-4f3f-9836-5b1553e03f11.jpg?1",
             "name": "Grim Backwoods",
             "text": "{T}: Add {1} to your mana pool.\n{2}{B}{G}, {T}, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "c80a61c9-7d6f-5e4b-b8ab-cbae6fac2985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bca9e1-c0b7-4dce-9ee4-370db2c322b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bca9e1-c0b7-4dce-9ee4-370db2c322b6.jpg?1",
             "name": "Haunted Fengraf",
             "text": "{T}: Add {1} to your mana pool.\n{3}, {T}, Sacrifice Haunted Fengraf: Return a creature card at random from your graveyard to your hand.",
             "colours": [],
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "86bcb705-43f2-5348-8b39-97c7ba5a0e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a65437-430a-42ef-854f-6e66f8e1a04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a65437-430a-42ef-854f-6e66f8e1a04a.jpg?1",
             "name": "Vault of the Archangel",
             "text": "{T}: Add {1} to your mana pool.\n{2}{W}{B}, {T}: Creatures you control gain deathtouch and lifelink until end of turn.",
             "colours": [],
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "5b9a227b-eac7-53f0-bd82-e1837d0bbe79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5cd362-34f9-445f-85e1-9f6694f0f90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5cd362-34f9-445f-85e1-9f6694f0f90a.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -5757,7 +5757,7 @@
         },
         {
             "id": "d22c8edf-740f-5145-9b41-f1f786a968c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6abdaa-7be5-48a1-acc9-b3cba4c10619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6abdaa-7be5-48a1-acc9-b3cba4c10619.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "1d0792f5-6ed6-5385-9a96-87b472909d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddaaf-b6a7-4c80-9b38-5ab68181b3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327ddaaf-b6a7-4c80-9b38-5ab68181b3d6.jpg?1",
             "name": "Sorin, Lord of Innistrad Emblem",
             "text": "",
             "colours": [],
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "098155d6-fa7c-5b32-8921-9d3c17840552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c61e7-bf33-45ea-af78-97ab3bc96753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c61e7-bf33-45ea-af78-97ab3bc96753.jpg?1",
             "name": "Dark Ascension Checklist",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DMR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DMR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7c746310-21dd-5fe5-89df-cc81b8016a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe359e9-2ac8-48ae-9a43-e2f12fd4a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe359e9-2ac8-48ae-9a43-e2f12fd4a785.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "9f6b8cdd-0e8d-5767-b12b-0f52c1fbd4a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a21cf44-4d8e-4b24-a1fe-4222c857f0ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a21cf44-4d8e-4b24-a1fe-4222c857f0ef.jpg?1",
             "name": "Battle Screech",
             "text": "Create two 1/1 white Bird creature tokens with flying.\nFlashback\u2014\nTap three untapped white creatures you control. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "eb79745a-b32d-5032-bfff-a4691960a9cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b24ae-590f-4a79-8aeb-b006de6545ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b24ae-590f-4a79-8aeb-b006de6545ca.jpg?1",
             "name": "Cleric of the Forward Order",
             "text": "When Cleric of the Forward Order enters the battlefield, you gain 2 life for each creature you control named Cleric of the Forward Order.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "f932ba62-b536-536a-bc5d-1401b4e2884e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89396f5e-5bc3-4c8a-976b-2cb2946eb35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89396f5e-5bc3-4c8a-976b-2cb2946eb35d.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "bbf92633-3ae0-5f1c-94db-b8105d80f7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d4044-f2bd-470a-8468-a319e0a21d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d4044-f2bd-470a-8468-a319e0a21d8d.jpg?1",
             "name": "Divine Sacrament",
             "text": "White creatures get +1/+1.\nThreshold \u2014 White creatures get an additional +1/+1 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "3faa652f-b9e1-51c3-ae4a-4dc6aedb4042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9675fb-1a89-420f-aea8-50e0642f549c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9675fb-1a89-420f-aea8-50e0642f549c.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "60988864-36c2-59d5-9d0b-08a97a1fe5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b01ebcf-8451-486e-84f6-8e6e1bb9d6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b01ebcf-8451-486e-84f6-8e6e1bb9d6e3.jpg?1",
             "name": "Glory",
             "text": "Flying\n{2}{W}: Choose a color. Creatures you control gain protection from the chosen color until end of turn. Activate only if Glory is in your graveyard.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "dcfc78db-777b-50a2-a389-5ef828bb9934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf5e-10f6-49aa-82eb-2f56cc29d393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf5e-10f6-49aa-82eb-2f56cc29d393.jpg?1",
             "name": "Griffin Guide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\nWhen enchanted creature dies, create a 2/2 white Griffin creature token with flying.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "c0a52805-c0e7-52d5-be95-51d95e3f9168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccce13a-77e6-4c74-9acc-d5e7c271872a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccce13a-77e6-4c74-9acc-d5e7c271872a.jpg?1",
             "name": "Icatian Javelineers",
             "text": "Icatian Javelineers enters the battlefield with a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: It deals 1 damage to any target.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "7a62762f-5c46-5fff-8c01-eade42eaa0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c205ba-cafb-4afc-83fe-09fff38130d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c205ba-cafb-4afc-83fe-09fff38130d7.jpg?1",
             "name": "Improvised Armor",
             "text": "Enchant creature\nEnchanted creature gets +2/+5.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "ac3db2ae-f541-5f56-a088-6b63729283cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c090af7-3f75-4c14-9ab5-1f409dfd6de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c090af7-3f75-4c14-9ab5-1f409dfd6de1.jpg?1",
             "name": "Kjeldoran Gargoyle",
             "text": "Flying, first strike\nWhenever Kjeldoran Gargoyle deals damage, you gain that much life.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "0bff34c9-6f97-51ae-a150-4a156772985a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba0c3-237e-4349-85e9-c31b016f609b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba0c3-237e-4349-85e9-c31b016f609b.jpg?1",
             "name": "Lieutenant Kirtar",
             "text": "Flying\n{1}{W}, Sacrifice Lieutenant Kirtar: Exile target attacking creature.",
             "colours": [
@@ -419,7 +419,7 @@
         },
         {
             "id": "82d7d15f-bc46-5804-9dce-ed8c902628cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e0c8c5-ea0e-4347-b5cb-b7b1801a523b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e0c8c5-ea0e-4347-b5cb-b7b1801a523b.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "ccb69180-b368-50a9-8d88-8756f8c4fb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d9309f-497e-4807-a9cc-f41887a73ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d9309f-497e-4807-a9cc-f41887a73ca0.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "58f11500-47fc-5129-8823-99295ec70482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619c620d-1920-40d1-98d4-df5607f84d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619c620d-1920-40d1-98d4-df5607f84d26.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "cd234c85-b18b-5574-91dc-63f82fe39920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc955bd-b998-44b9-918f-84b96cf5e915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc955bd-b998-44b9-918f-84b96cf5e915.jpg?1",
             "name": "Mystic Zealot",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Mystic Zealot gets +1/+1 and has flying.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "5f802dcb-ddc3-525a-9d9d-7efa48aeeec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da039589-f3ee-4aff-b8b0-e5fda13ebe97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da039589-f3ee-4aff-b8b0-e5fda13ebe97.jpg?1",
             "name": "Nomad Decoy",
             "text": "{W}, {T}: Tap target creature.\nThreshold \u2014 {W}{W}, {T}: Tap two target creatures. Activate only if seven or more cards are in your graveyard.",
             "colours": [
@@ -601,7 +601,7 @@
         },
         {
             "id": "104a3f1d-84d3-5492-b6f2-95c07def9ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f86bba5-e203-4a86-a415-ce748f6d1f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f86bba5-e203-4a86-a415-ce748f6d1f6f.jpg?1",
             "name": "Orim's Thunder",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nDestroy target artifact or enchantment. If this spell was kicked, it deals damage equal to that permanent's mana value to target creature.",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "9aea009d-4b67-5bc2-a320-8caf339c5115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5242a576-4d35-4f29-8d40-9a7179e51d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5242a576-4d35-4f29-8d40-9a7179e51d0c.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "95080914-3e05-53de-bc7d-e3773101a547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314602ae-fb42-4afe-9fab-fa6976db39ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314602ae-fb42-4afe-9fab-fa6976db39ad.jpg?1",
             "name": "Phantom Flock",
             "text": "Flying\nPhantom Flock enters the battlefield with three +1/+1 counters on it.\nIf damage would be dealt to Phantom Flock, prevent that damage. Remove a +1/+1 counter from Phantom Flock.",
             "colours": [
@@ -704,7 +704,7 @@
         },
         {
             "id": "06d5fb55-f048-5beb-8efb-adeacc33563a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5abbdd37-dc24-4bf7-808e-6354af7d7ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5abbdd37-dc24-4bf7-808e-6354af7d7ec6.jpg?1",
             "name": "Radiant's Judgment",
             "text": "Destroy target creature with power 4 or greater.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "7d9f5490-5ec8-5b75-bc77-5dfd6dd25f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9700fe0e-bf71-463b-ad7b-34831c7f9e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9700fe0e-bf71-463b-ad7b-34831c7f9e99.jpg?1",
             "name": "Remedy",
             "text": "Prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "7f573fd2-8251-5ad7-8ea2-f6cd8957b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d66dd3-330f-4b12-81f6-52d7a31013a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d66dd3-330f-4b12-81f6-52d7a31013a9.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "c80dbd6a-f50b-59b2-a957-14e88fc29aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e770d089-9957-412c-a51f-3f11b6b9692a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e770d089-9957-412c-a51f-3f11b6b9692a.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -838,7 +838,7 @@
         },
         {
             "id": "a9cf4a26-4025-5e11-8760-3ec4c96caa6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f949cbb1-c8a8-4f26-b12d-c58a0605cb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f949cbb1-c8a8-4f26-b12d-c58a0605cb14.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -874,7 +874,7 @@
         },
         {
             "id": "5cf3532b-eb44-5a92-b50f-3638adbf3b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041dcfd-c1af-448c-91f7-75fd1d34e93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041dcfd-c1af-448c-91f7-75fd1d34e93e.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar's power and toughness are each equal to your life total.\nWhen Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "9452982f-c6c0-58d3-ae37-f5efaa551f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b272b9a-9348-4eaa-8978-2fe549182c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b272b9a-9348-4eaa-8978-2fe549182c84.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "bffd7db1-59ed-5484-96b2-5652730ec6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa545eb-aa45-4085-8472-676f5d5e1c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa545eb-aa45-4085-8472-676f5d5e1c48.jpg?1",
             "name": "Spectral Lynx",
             "text": "Protection from green\n{B}: Regenerate Spectral Lynx. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "0636f33e-e5c4-5840-9d56-17290e39615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc046a97-4699-438d-8da4-022560a18564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc046a97-4699-438d-8da4-022560a18564.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "c75a09e5-5995-5150-85f5-8f943a205b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e33908-cf4f-45b4-8d97-a117308187f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e33908-cf4f-45b4-8d97-a117308187f7.jpg?1",
             "name": "Sun Clasp",
             "text": "Enchant creature\nEnchanted creature gets +1/+3.\n{W}: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "2bc3fd8b-8f58-517f-858e-83bd754fa21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d839f21-68c7-47db-8407-ff3e2c3e13b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d839f21-68c7-47db-8407-ff3e2c3e13b4.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "a0dd5b1d-9107-581d-abfb-59541260cc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76841945-8ff1-4c2d-895e-d1e2cf468cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76841945-8ff1-4c2d-895e-d1e2cf468cff.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "f08556f6-181b-54a3-a70e-eea1b1b1806b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75772e5-257e-4b08-90a4-492a43f229b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75772e5-257e-4b08-90a4-492a43f229b3.jpg?1",
             "name": "Vigilant Sentry",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Vigilant Sentry gets +1/+1 and has \"{T}: Target attacking or blocking creature gets +3/+3 until end of turn.\"",
             "colours": [
@@ -1154,7 +1154,7 @@
         },
         {
             "id": "94ccc284-8595-5253-a266-07e25329f9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1c31-fb33-4f5c-b766-6ca8ad6e0976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1c31-fb33-4f5c-b766-6ca8ad6e0976.jpg?1",
             "name": "Voice of All",
             "text": "Flying\nAs Voice of All enters the battlefield, choose a color.\nVoice of All has protection from the chosen color.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "81cf3d9e-bfb0-5992-b7ca-11d3700e6c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a358def9-65a0-4741-896c-b2a8c8947768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a358def9-65a0-4741-896c-b2a8c8947768.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "7e803ebf-4035-502f-b7b1-35e97b250c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b72ba3c-12f5-47d0-adaa-f470ad3a416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b72ba3c-12f5-47d0-adaa-f470ad3a416c.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "88940600-d5cb-5450-8556-abd1ca1a2899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3700519-b74c-4445-b42e-03690b8d4463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3700519-b74c-4445-b42e-03690b8d4463.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "0f87776b-fdb2-59fe-8c7a-6d031caa1f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62721a55-37c6-4c05-aedf-0aa203045afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62721a55-37c6-4c05-aedf-0aa203045afa.jpg?1",
             "name": "Aquamoeba",
             "text": "Discard a card: Switch Aquamoeba's power and toughness until end of turn.",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "b1d2c640-f7c9-5aaf-bb70-a75205fe2567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2074ed36-fbae-4886-b3ad-360fdfbb69cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2074ed36-fbae-4886-b3ad-360fdfbb69cd.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "5faa0dae-6c8d-5a44-9c9e-0433351448b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9ed6d-2c26-4cb8-8ecf-8c02a534b9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f9ed6d-2c26-4cb8-8ecf-8c02a534b9eb.jpg?1",
             "name": "Aven Fateshaper",
             "text": "Flying\nWhen Aven Fateshaper enters the battlefield, look at the top four cards of your library, then put them back in any order.\n{4}{U}: Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "469f066a-c49b-57e0-9f0f-0c728433e5ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8cd57-df68-4f6d-9612-21e66b9f0190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8cd57-df68-4f6d-9612-21e66b9f0190.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying\nWhen Aven Fisher dies, you may draw a card.",
             "colours": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "f3c04e55-eb98-50ee-a7b2-140fce6b44c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b19fdac-da3e-4ebd-ae7b-6f31a97b2a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b19fdac-da3e-4ebd-ae7b-6f31a97b2a0f.jpg?1",
             "name": "Circular Logic",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "b1c671b3-47b2-52d1-8312-fe3e7aff91ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed95f539-1d8b-408b-9af2-8c6f93fb98c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed95f539-1d8b-408b-9af2-8c6f93fb98c8.jpg?1",
             "name": "Cloud of Faeries",
             "text": "Flying\nWhen Cloud of Faeries enters the battlefield, untap up to two lands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "a264aa90-bb40-5a33-9675-1ebaab7800b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dca85-a880-4ea2-a483-072bb50b7aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581dca85-a880-4ea2-a483-072bb50b7aee.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "ca9ea15a-862b-5343-baa8-ef27230a4614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02da8709-4228-4fed-9d2d-781e686661df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02da8709-4228-4fed-9d2d-781e686661df.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "2375b191-8ffc-5997-90a2-3d0cea4bab70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d675e0-0e79-4f90-b3d7-d4bfaedd4719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d675e0-0e79-4f90-b3d7-d4bfaedd4719.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1606,7 +1606,7 @@
         },
         {
             "id": "923eb364-1ba7-534c-8ab1-c920c6668cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7959e9-8ae7-49f7-acf9-a0fc2afa219e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7959e9-8ae7-49f7-acf9-a0fc2afa219e.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep enters the battlefield, return each other creature you control to its owner's hand.",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "e0a45f40-dcf6-5823-9a29-ba5972a913ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758a8b6-f586-4d27-9379-8f7c4a78d90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758a8b6-f586-4d27-9379-8f7c4a78d90c.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "b4a29ef8-f460-5d4e-901e-f950faaa034f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600b315b-58f8-4b1b-b210-f09e3e5e3b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600b315b-58f8-4b1b-b210-f09e3e5e3b27.jpg?1",
             "name": "Floodgate",
             "text": "Defender\nWhen Floodgate has flying, sacrifice it.\nWhen Floodgate leaves the battlefield, it deals damage to each nonblue creature without flying equal to half the number of Islands you control, rounded down.",
             "colours": [
@@ -1711,7 +1711,7 @@
         },
         {
             "id": "798f944f-a711-584d-a15b-d8ee886f68c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f612d6-7c59-4a7b-a87d-45f789e88ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f612d6-7c59-4a7b-a87d-45f789e88ba5.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "37c2a404-e90f-5e7c-b241-dff600105c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cceaa53-5cac-415c-ad52-6299d6934ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cceaa53-5cac-415c-ad52-6299d6934ba0.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "617a1e98-5b17-5e79-96c3-1275b79d3690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b26379-0007-450e-9b94-2932eef6ac2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b26379-0007-450e-9b94-2932eef6ac2c.jpg?1",
             "name": "Glintwing Invoker",
             "text": "{7}{U}: Glintwing Invoker gets +3/+3 and gains flying until end of turn.",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "174429bf-31c1-58b9-95d6-bc6708012f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50762ad-494a-46fa-811f-4e472de8cebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50762ad-494a-46fa-811f-4e472de8cebd.jpg?1",
             "name": "Hermetic Study",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to any target.\"",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "82b89a01-d566-5e62-a707-9a1b63459823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babd2248-5517-4b7b-a159-9a1f7b5583c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babd2248-5517-4b7b-a159-9a1f7b5583c8.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "fa2cbcd5-37d8-57f8-a1c5-10f3b462dbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8ba7cc-2586-497a-8b62-4342a3f19506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8ba7cc-2586-497a-8b62-4342a3f19506.jpg?1",
             "name": "Horseshoe Crab",
             "text": "{U}: Untap Horseshoe Crab.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "1bca0f5b-5d8e-5a7e-ab39-a460c2a98021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec50625-5e14-4fd0-9a96-86f195342695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec50625-5e14-4fd0-9a96-86f195342695.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "9dd06365-457a-5758-ba64-c8f76076578b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49427c35-7d24-4047-94f6-070d0084ee31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49427c35-7d24-4047-94f6-070d0084ee31.jpg?1",
             "name": "Leaden Fists",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +3/+3 and doesn't untap during its controller's untap step.",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "f972fb8e-faa6-5147-baa3-92d71f0cd83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ef40d5-c287-4229-8059-3505d9f251ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ef40d5-c287-4229-8059-3505d9f251ca.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "acc99cd5-e276-5be3-87d9-632e5fe7fcda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40140991-cffa-4b52-9a25-37e9a8aa9ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40140991-cffa-4b52-9a25-37e9a8aa9ddd.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "7c1d9e74-e795-524c-8eb9-50d5d077b46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fa9a0b-b0c9-43ea-ba11-99d7982f974e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fa9a0b-b0c9-43ea-ba11-99d7982f974e.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -2091,7 +2091,7 @@
         },
         {
             "id": "32cdcefa-74d6-56c9-a61a-b10c481a553d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d97436e-329a-49a4-a7c9-671ec9ba90cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d97436e-329a-49a4-a7c9-671ec9ba90cc.jpg?1",
             "name": "Obsessive Search",
             "text": "Draw a card.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "b3941729-06de-5963-a074-cece40ba1b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae14acde-8a5c-4f0e-8e68-b799a363b9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae14acde-8a5c-4f0e-8e68-b799a363b9f7.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "0ad7a2bf-68c4-5c5d-816e-e36272f9a92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92204e3-2c98-4834-a838-ddc9f85fdeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92204e3-2c98-4834-a838-ddc9f85fdeea.jpg?1",
             "name": "Ovinize",
             "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "5b48d071-e765-512c-b989-3fd3aa2e5a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af3166-6338-4fac-bfa6-cea19daefc62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af3166-6338-4fac-bfa6-cea19daefc62.jpg?1",
             "name": "Ovinomancer",
             "text": "When Ovinomancer enters the battlefield, sacrifice it unless you return three basic lands you control to their owner's hand.\n{T}, Return Ovinomancer to its owner's hand: Destroy target creature. It can't be regenerated. That creature's controller creates a 0/1 green Sheep creature token.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "626c4a72-1086-5986-b135-be3cc2200041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611c8fa2-b53f-483b-9efa-759ac59dc30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611c8fa2-b53f-483b-9efa-759ac59dc30f.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake enters the battlefield, untap up to five lands.",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "45c8e4c7-9e6d-5396-b45d-23b8519a0fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13406c6-f208-402a-94d3-a94a24f03563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13406c6-f208-402a-94d3-a94a24f03563.jpg?1",
             "name": "Snap",
             "text": "Return target creature to its owner's hand. Untap up to two lands.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "8e384ef9-0ba5-5ccc-97d6-181089481b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5b8542-f8b9-4b98-89ee-ce577b862bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5b8542-f8b9-4b98-89ee-ce577b862bce.jpg?1",
             "name": "Stroke of Genius",
             "text": "Target player draws X cards.",
             "colours": [
@@ -2328,7 +2328,7 @@
         },
         {
             "id": "0c50a4ef-a68f-56aa-a637-3038d3b3dd79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9a1760-d681-471d-b3a2-ca5051b8bed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9a1760-d681-471d-b3a2-ca5051b8bed3.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying\nWhenever Thieving Magpie deals damage to an opponent, draw a card.",
             "colours": [
@@ -2362,7 +2362,7 @@
         },
         {
             "id": "e6af1e0c-7eff-54ac-91d2-dcb959675894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc791fd-d49c-4c66-b8fb-6b54ce842e90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc791fd-d49c-4c66-b8fb-6b54ce842e90.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "5a383838-7b7b-5b70-99fa-911f2055be5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cfc84b-88ae-4fb8-b568-e0635e2a194a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cfc84b-88ae-4fb8-b568-e0635e2a194a.jpg?1",
             "name": "Turnabout",
             "text": "Choose artifact, creature, or land. Tap all untapped permanents of the chosen type target player controls, or untap all tapped permanents of that type that player controls.",
             "colours": [
@@ -2431,7 +2431,7 @@
         },
         {
             "id": "13f19804-433b-554e-9033-1928602c20fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b26e53-1fc2-4d07-a56f-9000ed25580d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b26e53-1fc2-4d07-a56f-9000ed25580d.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "48182289-e848-585e-ba95-5dff6228e9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1964316-82c7-4ee1-a7cc-d969c6254ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1964316-82c7-4ee1-a7cc-d969c6254ace.jpg?1",
             "name": "Veiled Serpent",
             "text": "When an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature with \"This creature can't attack unless defending player controls an Island.\" (It's no longer an enchantment.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "381fa687-b00f-598a-a85f-9dcf8b259531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c75f806-b900-403c-8de1-cc3173afc8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c75f806-b900-403c-8de1-cc3173afc8f0.jpg?1",
             "name": "Vexing Sphinx",
             "text": "Flying\nCumulative upkeep\u2014\nDiscard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Vexing Sphinx dies, draw a card for each age counter on it.",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "998245da-d41b-572b-96f4-8e7ca3561bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501128c7-c541-4de8-a041-9367c032dbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501128c7-c541-4de8-a041-9367c032dbb3.jpg?1",
             "name": "Wormfang Drake",
             "text": "Flying\nWhen Wormfang Drake enters the battlefield, sacrifice it unless you exile a creature you control other than Wormfang Drake.\nWhen Wormfang Drake leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "caa8a50c-492b-546c-bce8-83ad8face919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7d83a8-3bad-40cf-991c-fc7f8e399c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7d83a8-3bad-40cf-991c-fc7f8e399c42.jpg?1",
             "name": "Body Snatcher",
             "text": "When Body Snatcher enters the battlefield, exile it unless you discard a creature card.\nWhen Body Snatcher dies, exile it and return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -2611,7 +2611,7 @@
         },
         {
             "id": "93e3b7d2-0a5f-560c-859b-4c3f7bdea49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4fa7f-a5d7-46cd-bc46-d3d231235460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4fa7f-a5d7-46cd-bc46-d3d231235460.jpg?1",
             "name": "Cackling Fiend",
             "text": "When Cackling Fiend enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "54d6f61c-843f-542e-a6d3-e1cc31ba0c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c294695b-a096-441a-9034-91ca74763903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c294695b-a096-441a-9034-91ca74763903.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "95aabd08-cbe8-5145-a813-1e97dd46114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c204471-d908-4a08-83e4-cf38999fa80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c204471-d908-4a08-83e4-cf38999fa80f.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2720,7 +2720,7 @@
         },
         {
             "id": "6104f20c-f86c-5ce7-8296-5f708e0367ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6996d612-28a5-4515-baba-9aad65bf4b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6996d612-28a5-4515-baba-9aad65bf4b28.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "329ff93d-ef34-5d0c-b28b-7c6108ce0925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb7707b-e779-4429-b741-5d3b842a50cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb7707b-e779-4429-b741-5d3b842a50cb.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "0d2228c1-cbb1-5355-bab5-eb36a2fc1044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cd43ba-646b-44b3-a1a5-0e6b6ceca866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cd43ba-646b-44b3-a1a5-0e6b6ceca866.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "30c197be-13af-50dd-96f3-c362d9e92b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caa9c55-5e3b-436b-84a9-b7ccebf63799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caa9c55-5e3b-436b-84a9-b7ccebf63799.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "bab9570c-76bc-54a1-ba9c-d46fbea1d2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3dbd4-7c3d-49df-98b0-068db5399083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b3dbd4-7c3d-49df-98b0-068db5399083.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "Non-Eye creatures you control can't attack.\nEvil Eye of Orms-by-Gore can't be blocked except by Walls.",
             "colours": [
@@ -2891,7 +2891,7 @@
         },
         {
             "id": "f1a63607-77d4-5afc-b20e-7870200795ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5511e2-a218-411e-aea3-96461e9c5fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5511e2-a218-411e-aea3-96461e9c5fdd.jpg?1",
             "name": "Faceless Butcher",
             "text": "When Faceless Butcher enters the battlefield, exile another target creature.\nWhen Faceless Butcher leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "380fe0cd-c965-5783-a88b-d43da8a82ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b039f65e-1287-4c6e-a1c2-773a008fc0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b039f65e-1287-4c6e-a1c2-773a008fc0a3.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin dies, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2961,7 +2961,7 @@
         },
         {
             "id": "aa17bc11-67e4-55c0-a2af-33f96ddcc6a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d56f46a-7327-4d98-b194-272333c8171e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d56f46a-7327-4d98-b194-272333c8171e.jpg?1",
             "name": "Flesh Reaver",
             "text": "Whenever Flesh Reaver deals damage to a creature or opponent, Flesh Reaver deals that much damage to you.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "74bdee4f-e916-5dc5-8a46-77c8f1578d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9e49ee-9103-4340-bf92-f888c722af47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9e49ee-9103-4340-bf92-f888c722af47.jpg?1",
             "name": "Goblin Turncoat",
             "text": "Sacrifice a Goblin: Regenerate Goblin Turncoat. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "95804fc4-b89c-5a22-9471-d6278bf56be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ef6b1c-2a86-415f-a5e3-c4b4f73a4de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ef6b1c-2a86-415f-a5e3-c4b4f73a4de0.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "8054f3d1-ae77-55ed-a0cd-7937b0deeaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875b7d0b-8354-41a0-9a53-8bc19ffdc016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875b7d0b-8354-41a0-9a53-8bc19ffdc016.jpg?1",
             "name": "Hyalopterous Lemure",
             "text": "{0}: Hyalopterous Lemure gets -1/-0 and gains flying until end of turn.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "2eea4284-cba4-577f-91be-1fc07c4b18b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db67828-5697-45fd-87db-ff27ef9cec5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db67828-5697-45fd-87db-ff27ef9cec5a.jpg?1",
             "name": "Ichor Slick",
             "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "b3add679-aa1e-5893-9e2b-873664a2d281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc86134-8af6-4355-b1ad-96917c99ff3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc86134-8af6-4355-b1ad-96917c99ff3c.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer dies, each player discards their hand.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "97e9281b-98c3-5ac6-8188-f073b558292f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4c5dd4-79dc-4bd2-8c18-897924a4a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4c5dd4-79dc-4bd2-8c18-897924a4a959.jpg?1",
             "name": "Nantuko Shade",
             "text": "{B}: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "31694a90-2e78-55dc-ac15-01f8bdbd35fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ce2548-38d3-4763-960a-d5d802094a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ce2548-38d3-4763-960a-d5d802094a0c.jpg?1",
             "name": "Necrosavant",
             "text": "{3}{B}{B}, Sacrifice a creature: Return Necrosavant from your graveyard to the battlefield. Activate only during your upkeep.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "a1e41437-34d6-5ce9-b074-4bfae788f3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1918f-ad58-4f62-bd8c-649919de0e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1918f-ad58-4f62-bd8c-649919de0e75.jpg?1",
             "name": "Nightscape Familiar",
             "text": "Blue spells and red spells you cast cost {1} less to cast.\n{1}{B}: Regenerate Nightscape Familiar. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "c56f9b73-3761-5ff8-9bd6-5788d4761c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c5e1dd-2fe6-4734-8406-7bcdf17aa60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c5e1dd-2fe6-4734-8406-7bcdf17aa60c.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature deals damage to you, destroy it.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "a2a18633-4ca5-5ab0-a265-f0a1fb9b16ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b7312a-c775-4fa8-ba62-c84ff38459e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b7312a-c775-4fa8-ba62-c84ff38459e8.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "bfab7167-512b-57e0-98bf-5f96bd0dee13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e2c6ac-455e-4d99-983b-1b154fd8bb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e2c6ac-455e-4d99-983b-1b154fd8bb24.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\n{T}, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "dea8d864-3287-5543-bcde-b397d15e5221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08586285-9a42-48ef-9188-0dd5d7294ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08586285-9a42-48ef-9188-0dd5d7294ad2.jpg?1",
             "name": "Phyrexian Ghoul",
             "text": "Sacrifice a creature: Phyrexian Ghoul gets +2/+2 until end of turn.",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "0aa04796-0164-5750-b8c1-c9facdac26c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db97152-afd5-4190-8bf1-1276b0fcf005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db97152-afd5-4190-8bf1-1276b0fcf005.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "e43604dd-03bb-5e41-8273-60dea33c35c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5b3b5c-121a-406e-a31a-537991309399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5b3b5c-121a-406e-a31a-537991309399.jpg?1",
             "name": "Phyrexian Scuta",
             "text": "Kicker\u2014\nPay 3 life. (You may pay 3 life in addition to any other costs as you cast this spell.)\nIf Phyrexian Scuta was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "66bf9da7-3bb9-5163-8225-f5674945476d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef9842-7142-4c63-8aea-fa73f02722a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef9842-7142-4c63-8aea-fa73f02722a5.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "561ffd1d-f062-5a80-9381-b924781c9ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d09cc57-2275-4b6b-aaf6-a6d781cd9365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d09cc57-2275-4b6b-aaf6-a6d781cd9365.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3557,7 +3557,7 @@
         },
         {
             "id": "74a571c0-938c-5c45-8148-a6ca2661a4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3870eba-4e8f-414d-817c-14ec97f6a93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3870eba-4e8f-414d-817c-14ec97f6a93c.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "8eb3812f-c912-53da-8823-1c618a726e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c26af-2b73-48fd-b7e3-ba217c9853d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c26af-2b73-48fd-b7e3-ba217c9853d3.jpg?1",
             "name": "Twisted Experiment",
             "text": "Enchant creature\nEnchanted creature gets +3/-1.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "e5692ad0-71a5-5d1d-a5ae-305d2c3ca772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a3d34-4e4e-4545-8e2e-6977eb754270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a3d34-4e4e-4545-8e2e-6977eb754270.jpg?1",
             "name": "Undead Gladiator",
             "text": "{1}{B}, Discard a card: Return Undead Gladiator from your graveyard to your hand. Activate only during your upkeep.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "08e871e9-3f50-5fd8-9f6a-fd783452b646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857d76-f2ca-4323-9611-cb20b9615202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857d76-f2ca-4323-9611-cb20b9615202.jpg?1",
             "name": "Urborg Syphon-Mage",
             "text": "{2}{B}, {T}, Discard a card: Each other player loses 2 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "6e84a56b-85f7-5e7a-9d36-c9633f36faed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497dedba-909a-4f1d-8b05-39c512007fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497dedba-909a-4f1d-8b05-39c512007fbd.jpg?1",
             "name": "Urborg Uprising",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "9b7ad9b0-40b5-5758-a525-c707015c5e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0203f-9cce-43a4-9cb7-8ce6647895cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a0203f-9cce-43a4-9cb7-8ce6647895cd.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "7dc01727-9e47-5ce9-85fe-eb61ee65decf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8635a8-9e12-4e15-b757-892d0154caea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8635a8-9e12-4e15-b757-892d0154caea.jpg?1",
             "name": "Wretched Anurid",
             "text": "Whenever another creature enters the battlefield, you lose 1 life.",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "7fb06063-3cbb-56de-811d-eab8e92698ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a79f5d-d0df-4799-ac3a-84305e3af0c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a79f5d-d0df-4799-ac3a-84305e3af0c9.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "a6c0f5ee-8810-5b15-9bc3-032ab554dd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2c8aca-3ade-46b0-8366-ab3b244eca01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2c8aca-3ade-46b0-8366-ab3b244eca01.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards: Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "3f279845-042a-5343-995d-8b4f59d4f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895ddf9-7d94-411c-ad2e-90d47e51810d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895ddf9-7d94-411c-ad2e-90d47e51810d.jpg?1",
             "name": "Avarax",
             "text": "Haste\nWhen Avarax enters the battlefield, you may search your library for a card named Avarax, reveal it, put it into your hand, then shuffle.\n{1}{R}: Avarax gets +1/+0 until end of turn.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "295c2d3b-405a-51da-97fd-62fae4e8862c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2105a0d9-ea2e-4ffc-be08-424b5617205d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2105a0d9-ea2e-4ffc-be08-424b5617205d.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "0bcab18c-3b64-5699-982d-b77aad60e7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c8578e-052f-4182-9bb1-fb35450d22c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c8578e-052f-4182-9bb1-fb35450d22c0.jpg?1",
             "name": "Coal Stoker",
             "text": "When Coal Stoker enters the battlefield, if you cast it from your hand, add {R}{R}{R}.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "267bcf00-11de-5d81-997e-155e23b3d6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f9cb4d-5ee2-4934-a0ca-43148491ae35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f9cb4d-5ee2-4934-a0ca-43148491ae35.jpg?1",
             "name": "Deadapult",
             "text": "{R}, Sacrifice a Zombie: Deadapult deals 2 damage to any target.",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "d09b96de-fdc8-5cd0-a1aa-7e87d383da95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7520ad-3b13-41a6-82b2-fef562545f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7520ad-3b13-41a6-82b2-fef562545f1c.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice Dragon Whelp at the beginning of the next end step.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "ebbc1129-2af1-5291-923f-e095eaa94d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75faca7-cfcf-4c3b-a507-c89659cce93a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75faca7-cfcf-4c3b-a507-c89659cce93a.jpg?1",
             "name": "Ember Beast",
             "text": "Ember Beast can't attack or block alone.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "778c4a7a-2cec-54e8-8ce3-bf256c05d1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939d765a-aefb-4393-8808-98b1bbd7e803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939d765a-aefb-4393-8808-98b1bbd7e803.jpg?1",
             "name": "Empty the Warrens",
             "text": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -4110,7 +4110,7 @@
         },
         {
             "id": "33933583-a8ad-5c17-9e50-764c214f90ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ab67cc-b553-4451-9cda-0e5fe3303940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ab67cc-b553-4451-9cda-0e5fe3303940.jpg?1",
             "name": "Fireblast",
             "text": "You may sacrifice two Mountains rather than pay this spell's mana cost.\nFireblast deals 4 damage to any target.",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "6669faa9-4639-5051-936f-336f25e74f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3a5139-3341-409e-be33-184897c7398e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3a5139-3341-409e-be33-184897c7398e.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -4181,7 +4181,7 @@
         },
         {
             "id": "999d6866-ec64-528d-8832-e883608ff5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e37fae5-ddd0-4e16-8581-71579f89d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e37fae5-ddd0-4e16-8581-71579f89d9c5.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "8f2a267a-2fa7-5f76-8975-2b17dba8bf00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c231e3-10ec-458b-bba1-891812e000f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c231e3-10ec-458b-bba1-891812e000f6.jpg?1",
             "name": "Gempalm Incinerator",
             "text": "Cycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins on the battlefield.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "33ea8c4c-f227-5e2b-9808-02303997a586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521a254-c484-4d59-bb7e-8745e96d4bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a521a254-c484-4d59-bb7e-8745e96d4bbf.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "45ba6755-1d4f-5d1b-aa17-2f0a6a86f2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980d45cb-e9e6-4f09-9275-c3f2c538b57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980d45cb-e9e6-4f09-9275-c3f2c538b57c.jpg?1",
             "name": "Goblin Medics",
             "text": "Whenever Goblin Medics becomes tapped, it deals 1 damage to any target.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "74d61fc1-bd4f-5c3d-816e-cf3d673b05d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923e1291-3999-4f81-ade4-073fb982143f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923e1291-3999-4f81-ade4-073fb982143f.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to any target.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "0a0610e7-3059-5fa0-9e34-7847292711fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6ffe8-e1ad-4db9-98f7-d6038f271866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6ffe8-e1ad-4db9-98f7-d6038f271866.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "6a3a4199-778d-5f17-ba0b-d67caac3617b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efb595-d407-4389-a99d-d97c4d6bdcd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efb595-d407-4389-a99d-d97c4d6bdcd0.jpg?1",
             "name": "Last Chance",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -4428,7 +4428,7 @@
         },
         {
             "id": "0891d4f8-d695-5ae0-9ad1-46016c4fc947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9653f159-3f56-4446-bb6d-b4b4ee0cd61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9653f159-3f56-4446-bb6d-b4b4ee0cd61d.jpg?1",
             "name": "Lightning Reflexes",
             "text": "You may cast Lightning Reflexes as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nEnchant creature\nEnchanted creature gets +1/+0 and has first strike.",
             "colours": [
@@ -4462,7 +4462,7 @@
         },
         {
             "id": "47e001fa-2dea-5c34-bf75-7ece31e00219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b731b2-70cb-4e94-8c9a-d694f617a521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b731b2-70cb-4e94-8c9a-d694f617a521.jpg?1",
             "name": "Lightning Rift",
             "text": "Whenever a player cycles a card, you may pay {1}. If you do, Lightning Rift deals 2 damage to any target.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "d4c8b239-71b4-5f9e-9da0-ee8529f943cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c750f7d7-25b8-433f-b3a8-0d842b99276f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c750f7d7-25b8-433f-b3a8-0d842b99276f.jpg?1",
             "name": "Macetail Hystrodon",
             "text": "First strike, haste\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "8468b70c-c76d-56e1-b962-36f9eacd8868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7f39c-94a0-4ccb-b658-23095ada4005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7f39c-94a0-4ccb-b658-23095ada4005.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "7f27b517-9f82-536a-8223-260bc2bb027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e812a8-66cf-4005-a647-780d49aa74a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e812a8-66cf-4005-a647-780d49aa74a4.jpg?1",
             "name": "Overmaster",
             "text": "The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "603996b8-8bf3-5b93-a2e5-0ff2e46825e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20a650-65b0-4714-b7ce-0481af3db377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20a650-65b0-4714-b7ce-0481af3db377.jpg?1",
             "name": "Pashalik Mons",
             "text": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "e37c2617-c8e1-5492-8501-09f294711efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720a0e44-0675-488e-bfa5-ae557337e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720a0e44-0675-488e-bfa5-ae557337e9c4.jpg?1",
             "name": "Ridgetop Raptor",
             "text": "Double strike",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "2e4ecd80-86dc-56e8-9a03-8db48b42bae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b78eb49-bd68-47e6-90a3-83ec2eeb4312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b78eb49-bd68-47e6-90a3-83ec2eeb4312.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "49da47da-3fa9-5a61-a6ed-fb850fb45ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd6a913-88df-4fbc-964e-a8fec3ad989f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd6a913-88df-4fbc-964e-a8fec3ad989f.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "509b40e2-975a-5e1e-9bdf-73d5ce802b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc508b3-8b38-4cf0-89a7-a2cb247ed083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc508b3-8b38-4cf0-89a7-a2cb247ed083.jpg?1",
             "name": "Skirk Prospector",
             "text": "Sacrifice a Goblin: Add {R}.",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "3b775278-1076-56e8-9ecf-bb5fe3c39efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521e68e-b3dd-4cb4-a7fb-0f74c40f917b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521e68e-b3dd-4cb4-a7fb-0f74c40f917b.jpg?1",
             "name": "Slice and Dice",
             "text": "Slice and Dice deals 4 damage to each creature.\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
             "colours": [
@@ -4812,7 +4812,7 @@
         },
         {
             "id": "4c973c8e-8497-5dc7-bd51-bbc799df61be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b4ca9-4355-4690-84c3-a7d44c367dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b4ca9-4355-4690-84c3-a7d44c367dbf.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "d884b2f9-116d-562b-b6f7-0f2d042383d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87202a72-72aa-46d3-ba16-10a180276905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87202a72-72aa-46d3-ba16-10a180276905.jpg?1",
             "name": "Solar Blast",
             "text": "Solar Blast deals 3 damage to any target.\nCycling {1}{R}{R} ({1}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to any target.",
             "colours": [
@@ -4878,7 +4878,7 @@
         },
         {
             "id": "5d9dad62-d168-5571-9896-b5f646c4a30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22844a75-7064-4108-921f-6a590aa2e71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22844a75-7064-4108-921f-6a590aa2e71c.jpg?1",
             "name": "Spark Spray",
             "text": "Spark Spray deals 1 damage to any target.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -4910,7 +4910,7 @@
         },
         {
             "id": "e2020f48-c8b0-5dbe-a763-598a3a96799a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701f0a77-28df-4f58-8577-1923bb9a2f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701f0a77-28df-4f58-8577-1923bb9a2f58.jpg?1",
             "name": "Storm Entity",
             "text": "Haste\nStorm Entity enters the battlefield with a +1/+1 counter on it for each other spell cast this turn.",
             "colours": [
@@ -4944,7 +4944,7 @@
         },
         {
             "id": "7cbf88eb-c98e-574d-b9cb-e63afd5c434c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6c26c-84f8-46dd-bb32-b3fc57e172c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6c26c-84f8-46dd-bb32-b3fc57e172c0.jpg?1",
             "name": "Subterranean Scout",
             "text": "When Subterranean Scout enters the battlefield, target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4979,7 +4979,7 @@
         },
         {
             "id": "da699b6a-ad1a-572a-bfbe-5bf047146118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3253a624-50cc-4a8a-9b0c-9902aa53775f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3253a624-50cc-4a8a-9b0c-9902aa53775f.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "287325e6-4c1f-5e08-84c4-e7b3f7478527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd519a-c6f4-47a8-b773-a058e50e4440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd519a-c6f4-47a8-b773-a058e50e4440.jpg?1",
             "name": "Suq'Ata Lancer",
             "text": "Haste\nFlanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "3c0237fa-4d3c-586d-9c4e-9b31f59303b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2072badc-d4ec-469b-b3cd-6977cbe42fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2072badc-d4ec-469b-b3cd-6977cbe42fbd.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -5082,7 +5082,7 @@
         },
         {
             "id": "f6fe0692-4795-5ef9-914f-b774ea386b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba207cd-b22e-4c82-b2b0-0ef57afa1117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba207cd-b22e-4c82-b2b0-0ef57afa1117.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "01d6a74b-023b-5720-bfe8-a66d8a3e262c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dde6e0-d0a7-4432-a3f4-b48234f4e055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dde6e0-d0a7-4432-a3f4-b48234f4e055.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "07a22afb-0b5c-5c50-8dae-220a3cfad2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18f4de2-adfe-4784-bd57-9e2ad9088825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18f4de2-adfe-4784-bd57-9e2ad9088825.jpg?1",
             "name": "Arboria",
             "text": "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "47ae7586-7987-585c-a5b6-5291bdd019d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f234-c1c1-4b4b-8385-6e0ced9977f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f234-c1c1-4b4b-8385-6e0ced9977f1.jpg?1",
             "name": "Battlefield Scrounger",
             "text": "Threshold \u2014 Put three cards from your graveyard on the bottom of your library: Battlefield Scrounger gets +3/+3 until end of turn. Activate only once each turn and only if seven or more cards are in your graveyard.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "05a5be6d-0ded-5fd7-9fe6-8013ac6633e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496849a5-4b24-4eae-8bfb-d46f645d85ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496849a5-4b24-4eae-8bfb-d46f645d85ea.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [
@@ -5267,7 +5267,7 @@
         },
         {
             "id": "861aee3c-d9f9-57b1-89a1-7f3534b406ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f334d2-d450-4a36-9b2e-ce81297b22e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f334d2-d450-4a36-9b2e-ce81297b22e3.jpg?1",
             "name": "Break Asunder",
             "text": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "a0d90e3c-2abe-5019-b864-cdf6e5349192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680bc22c-a80c-44db-aacd-aa80982202b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680bc22c-a80c-44db-aacd-aa80982202b9.jpg?1",
             "name": "Call of the Herd",
             "text": "Create a 3/3 green Elephant creature token.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "1c5ab726-a6d9-503e-bdb5-3890969fa7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523414cb-f8db-407a-808a-01454e03d8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523414cb-f8db-407a-808a-01454e03d8b9.jpg?1",
             "name": "Crop Rotation",
             "text": "As an additional cost to cast this spell, sacrifice a land.\nSearch your library for a land card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "4f2f1d06-3402-5c17-bf1f-d3dbe58b072e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba393aa0-06d3-4811-85f5-a812c6ac5acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba393aa0-06d3-4811-85f5-a812c6ac5acf.jpg?1",
             "name": "Deadwood Treefolk",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk enters or leaves the battlefield, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -5399,7 +5399,7 @@
         },
         {
             "id": "8d0e6196-4ba3-59f3-ace2-da8f1e731fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd91d0d-bc6c-41a1-aecf-d31465717182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd91d0d-bc6c-41a1-aecf-d31465717182.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G}.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "15f79180-1b65-5bcd-b726-6f2376199969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aded92-f934-441f-8e48-d68d471e70d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aded92-f934-441f-8e48-d68d471e70d8.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "Exile Elvish Spirit Guide from your hand: Add {G}.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "5b46f1b7-e660-544a-9084-8ff570acdd17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5862e38-b48b-45e1-b0f6-d1d0d1124e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5862e38-b48b-45e1-b0f6-d1d0d1124e50.jpg?1",
             "name": "Emerald Charm",
             "text": "Choose one \u2014\n\u2022 Untap target permanent.\n\u2022 Destroy target non-Aura enchantment.\n\u2022 Target creature loses flying until end of turn.",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "1ed73d89-ac92-56a0-9a1d-3974989b3f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b372045-a4a0-44c8-96ec-1e201d61ed26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b372045-a4a0-44c8-96ec-1e201d61ed26.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "497e1eb2-c8bf-5659-bc16-bfc451de06c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d717a50-6409-462e-9643-4427d754c773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d717a50-6409-462e-9643-4427d754c773.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "ed9f9930-4578-53f5-b150-0212d26551bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d79e492-993e-4305-bff2-b45f6b2536c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d79e492-993e-4305-bff2-b45f6b2536c8.jpg?1",
             "name": "Forgotten Ancient",
             "text": "Whenever a player casts a spell, you may put a +1/+1 counter on Forgotten Ancient.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Forgotten Ancient onto other creatures.",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "47dfd36e-b806-52f4-9259-475ea6768bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba14c0-18c0-4ded-ae56-5a689106f1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dba14c0-18c0-4ded-ae56-5a689106f1a1.jpg?1",
             "name": "Gamekeeper",
             "text": "When Gamekeeper dies, you may exile it. If you do, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and put all other cards revealed this way into your graveyard.",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "96d6e82d-a9c0-5d2b-b2b5-1ddd83432e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213c9202-b6f4-43ab-b57f-b97a1da5e263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213c9202-b6f4-43ab-b57f-b97a1da5e263.jpg?1",
             "name": "Giant Spider",
             "text": "Reach",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "5d4a5b00-f513-53c2-811f-183f5cbc4faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb5124d-bcd6-4aa4-8fd2-f49c8dc6765a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb5124d-bcd6-4aa4-8fd2-f49c8dc6765a.jpg?1",
             "name": "Invigorating Boon",
             "text": "Whenever a player cycles a card, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "a3b53ad5-9810-57f8-b627-c57e6777e06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65852aa0-98f4-4b38-89f1-96062677e590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65852aa0-98f4-4b38-89f1-96062677e590.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "75e3700d-abe7-5e0d-8936-a80c92959359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c960672d-06ad-4d41-8904-9c007f824756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c960672d-06ad-4d41-8904-9c007f824756.jpg?1",
             "name": "Kamahl, Fist of Krosa",
             "text": "{G}: Target land becomes a 1/1 creature until end of turn. It's still a land.\n{2}{G}{G}{G}: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "abd9b172-e755-5663-b95e-745673de9f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53cbda8-805f-42a4-aba4-9939b08e37ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53cbda8-805f-42a4-aba4-9939b08e37ca.jpg?1",
             "name": "Kavu Primarch",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf Kavu Primarch was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "3648e6b5-d6c0-580c-bd9d-5fd8d1205acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12508498-ecb7-4df9-b83f-87ef3bc2f4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12508498-ecb7-4df9-b83f-87ef3bc2f4e2.jpg?1",
             "name": "Krosan Restorer",
             "text": "{T}: Untap target land.\nThreshold \u2014 {T}: Untap up to three target lands. Activate only if seven or more cards are in your graveyard.",
             "colours": [
@@ -5859,7 +5859,7 @@
         },
         {
             "id": "fd8b8f02-b73b-5113-9498-e0336ca0353e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24540d-28e6-4e49-acd4-216b1ef27e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24540d-28e6-4e49-acd4-216b1ef27e7f.jpg?1",
             "name": "Lull",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "7b224258-add9-5592-a4b9-804e513ebeea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761adafd-0bf5-4bab-95d4-8362954c1019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761adafd-0bf5-4bab-95d4-8362954c1019.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "eefdfb9e-ac87-5a91-b5d5-5830b9640d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32980fc5-32ef-4f6d-8972-7a9e122c02e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32980fc5-32ef-4f6d-8972-7a9e122c02e2.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may create a 1/1 green Squirrel creature token.\nThreshold \u2014 All Squirrels get +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -5965,7 +5965,7 @@
         },
         {
             "id": "434ab927-1bda-565a-bb69-bbdb27ca9d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359fbd40-0f61-4ec7-872c-228a476c7ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359fbd40-0f61-4ec7-872c-228a476c7ad5.jpg?1",
             "name": "Penumbra Bobcat",
             "text": "When Penumbra Bobcat dies, create a 2/1 black Cat creature token.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "51486cbb-1afe-5f84-8346-b88f7a23b1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f93eb0-cb0c-4ee0-8006-3d3c7515d254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f93eb0-cb0c-4ee0-8006-3d3c7515d254.jpg?1",
             "name": "Primal Boost",
             "text": "Target creature gets +4/+4 until end of turn.\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Primal Boost, you may have target creature get +1/+1 until end of turn.",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "9abb2c14-8ffa-5a5c-ac9b-f439d4e01269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fb3d07-a128-455a-a632-c1aba4a4ceb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fb3d07-a128-455a-a632-c1aba4a4ceb8.jpg?1",
             "name": "Sandstorm",
             "text": "Sandstorm deals 1 damage to each attacking creature.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "17366eec-ba38-51f5-bade-0485dcbad7a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae774a-c1de-4c9e-a2ec-86d71cb2d1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae774a-c1de-4c9e-a2ec-86d71cb2d1db.jpg?1",
             "name": "Saproling Symbiosis",
             "text": "You may cast Saproling Symbiosis as though it had flash if you pay {2} more to cast it.\nCreate a 1/1 green Saproling creature token for each creature you control.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "ab8a8f37-11e9-51ee-b14e-4dc6ed17e485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c7f922-c334-4a75-9f5a-e68595049318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c7f922-c334-4a75-9f5a-e68595049318.jpg?1",
             "name": "Seton's Desire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nThreshold \u2014 As long as seven or more cards are in your graveyard, all creatures able to block enchanted creature do so.",
             "colours": [
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "f0c9b5f0-10ee-5f05-a39e-e3b02cf2a227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2aa025-e041-4ed5-a046-9debc474fda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2aa025-e041-4ed5-a046-9debc474fda0.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "44f527ec-4f8b-565a-b846-cb56f31fe52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ea6aac-d42b-4522-b7a9-4c99ed9c14bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ea6aac-d42b-4522-b7a9-4c99ed9c14bd.jpg?1",
             "name": "Stonewood Invoker",
             "text": "{7}{G}: Stonewood Invoker gets +5/+5 until end of turn.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "76fcdadd-5861-54d8-9d3a-38855a19f59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ada256f-2e55-4c1f-b4d3-d7b10b498956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ada256f-2e55-4c1f-b4d3-d7b10b498956.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "155d5211-8561-5d6d-94e0-47abbd28307c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf013aa4-76d6-4378-8916-d10f591f225a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf013aa4-76d6-4378-8916-d10f591f225a.jpg?1",
             "name": "Symbiotic Beast",
             "text": "When Symbiotic Beast dies, create four 1/1 green Insect creature tokens.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "8829ed6d-8bb6-5e07-b371-ba9b14bcf2dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70fbe1c-d3f4-4e28-a830-2072dee1b7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70fbe1c-d3f4-4e28-a830-2072dee1b7b5.jpg?1",
             "name": "Terravore",
             "text": "Trample\nTerravore's power and toughness are each equal to the number of land cards in all graveyards.",
             "colours": [
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "6d4e95b5-439a-5367-90b4-c6718c307faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973310bb-ab32-46dc-8f59-8a5d3e1c58cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973310bb-ab32-46dc-8f59-8a5d3e1c58cc.jpg?1",
             "name": "Werebear",
             "text": "{T}: Add {G}.\nThreshold \u2014 Werebear gets +3/+3 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -6342,7 +6342,7 @@
         },
         {
             "id": "155ff3af-2187-5001-adaf-cef1ee83d8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa526aa-f569-486a-8712-47c972481cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa526aa-f569-486a-8712-47c972481cd4.jpg?1",
             "name": "Wild Dogs",
             "text": "At the beginning of your upkeep, if a player has more life than each other player, the player with the most life gains control of Wild Dogs.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "b28592d2-259f-52b2-b834-b5c0495d042b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61429340-15fa-4a70-aac3-3e358b23b02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61429340-15fa-4a70-aac3-3e358b23b02c.jpg?1",
             "name": "Wild Growth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.",
             "colours": [
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "f71e6284-26da-59f8-ac75-2738412d3926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39aa2e9-e294-4ce6-bf5e-e1f579101a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39aa2e9-e294-4ce6-bf5e-e1f579101a7a.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card, reveal it, then shuffle and put the card on top.",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "af9aa5df-af41-5daa-9ad7-d6ad2916dcf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21892cbc-1af2-4ea1-8907-cec514b53004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21892cbc-1af2-4ea1-8907-cec514b53004.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "8142dc35-fb2e-55bc-99a5-5d7d94b39675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175695bb-2630-4269-a407-9138c7008e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175695bb-2630-4269-a407-9138c7008e81.jpg?1",
             "name": "Arcades Sabboth",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Arcades Sabboth unless you pay {G}{W}{U}.\nEach untapped creature you control gets +0/+2 as long as it's not attacking.\n{W}: Arcades Sabboth gets +0/+1 until end of turn.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "33c150bf-bff8-545f-af0f-de941c061f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8931725a-8034-4ecc-ac44-3f09ded677d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8931725a-8034-4ecc-ac44-3f09ded677d7.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -6566,7 +6566,7 @@
         },
         {
             "id": "2fe271d5-72d5-5ad8-8dd9-80327a82afe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844976c7-c8f7-435a-9bd4-1fea3c635030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844976c7-c8f7-435a-9bd4-1fea3c635030.jpg?1",
             "name": "Dralnu's Crusade",
             "text": "All Goblins get +1/+1.\nAll Goblins are black and are Zombies in addition to their other creature types.",
             "colours": [
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "b20ab15c-74e1-5bf5-939a-6c1dcc786100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d9d3be-0a66-4871-9d60-d253d3a37a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d9d3be-0a66-4871-9d60-d253d3a37a13.jpg?1",
             "name": "Gerrard's Verdict",
             "text": "Target player discards two cards. You gain 3 life for each land card discarded this way.",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "ed394b92-600c-5aec-b77d-ff332cc7976f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e544772-5ab8-47dd-8a6e-686d385a6ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e544772-5ab8-47dd-8a6e-686d385a6ee7.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Hunting Grounds has \"Whenever an opponent casts a spell, you may put a creature card from your hand onto the battlefield.\"",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "c69e44ed-8c93-5425-88ed-f4313d9d33e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187ebb67-1bdd-4a9c-aeeb-554e7580ce24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187ebb67-1bdd-4a9c-aeeb-554e7580ce24.jpg?1",
             "name": "Mystic Enforcer",
             "text": "Protection from black\nThreshold \u2014 As long as seven or more cards are in your graveyard, Mystic Enforcer gets +3/+3 and has flying.",
             "colours": [
@@ -6715,7 +6715,7 @@
         },
         {
             "id": "a146afa6-a294-5128-b9dd-b0eda774dbec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2281a21b-fc68-46ad-b340-eb13ca0165ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2281a21b-fc68-46ad-b340-eb13ca0165ec.jpg?1",
             "name": "Phantom Nishoba",
             "text": "Trample\nPhantom Nishoba enters the battlefield with seven +1/+1 counters on it.\nWhenever Phantom Nishoba deals damage, you gain that much life.\nIf damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.",
             "colours": [
@@ -6755,7 +6755,7 @@
         },
         {
             "id": "c869964b-b697-547d-b0dc-3faa1655d565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2db45-0ef7-45c8-ac65-eb785c173bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2db45-0ef7-45c8-ac65-eb785c173bd7.jpg?1",
             "name": "Pyre Zombie",
             "text": "At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay {1}{B}{B}. If you do, return Pyre Zombie to your hand.\n{1}{R}{R}, Sacrifice Pyre Zombie: It deals 2 damage to any target.",
             "colours": [
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "c09d8eb9-53e7-5f92-8a28-ed9733c979ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138d2d9d-d5ab-400f-a714-cd38212a0dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/138d2d9d-d5ab-400f-a714-cd38212a0dae.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target player or planeswalker. You draw a card.\"",
             "colours": [
@@ -6831,7 +6831,7 @@
         },
         {
             "id": "727e91d0-105f-5f4c-a03e-83e75c1ec020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb7c19a-b4af-405d-b016-a546ed12a99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb7c19a-b4af-405d-b016-a546ed12a99d.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "6270b83a-62a8-5583-a2da-dc527591d1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9035dda8-5ad3-4169-b281-83d6ca55b71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9035dda8-5ad3-4169-b281-83d6ca55b71e.jpg?1",
             "name": "Recoil",
             "text": "Return target permanent to its owner's hand. Then that player discards a card.",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "f32b9f74-eba6-5b33-9ce1-8c6ca4386256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a75961-39a3-4221-9367-a763cf871d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a75961-39a3-4221-9367-a763cf871d42.jpg?1",
             "name": "Rith, the Awakener",
             "text": "Flying\nWhenever Rith, the Awakener deals combat damage to a player, you may pay {2}{G}. If you do, choose a color, then create a 1/1 green Saproling creature token for each permanent of that color.",
             "colours": [
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "7766f4da-afa3-5d7d-8c34-80fc605e7c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5882a5-ea4c-4b2b-bcf9-7d15087d8bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5882a5-ea4c-4b2b-bcf9-7d15087d8bd4.jpg?1",
             "name": "Sawtooth Loon",
             "text": "Flying\nWhen Sawtooth Loon enters the battlefield, return a white or blue creature you control to its owner's hand.\nWhen Sawtooth Loon enters the battlefield, draw two cards, then put two cards from your hand on the bottom of your library.",
             "colours": [
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "421795b1-1c5c-51ce-a80a-de18583ce15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b4cb6a-ac4f-48ac-8c94-ba2b8e6b32a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b4cb6a-ac4f-48ac-8c94-ba2b8e6b32a8.jpg?1",
             "name": "Sol'kanar the Swamp King",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nWhenever a player casts a black spell, you gain 1 life.",
             "colours": [
@@ -7031,7 +7031,7 @@
         },
         {
             "id": "549b0bc9-5fdd-556b-a489-314c7fd90ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12b2d6-3940-4d47-8c76-ae73b8a14b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12b2d6-3940-4d47-8c76-ae73b8a14b15.jpg?1",
             "name": "Spinal Embrace",
             "text": "Cast this spell only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "2359de9d-ff5a-58b7-b7d9-629e750939aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da7739e-8413-45b6-8539-fde2021b06a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da7739e-8413-45b6-8539-fde2021b06a7.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\n{B}: Regenerate Spiritmonger.\n{G}: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "e4fceb06-8a99-509e-83f1-71eeb354ca71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8953672-b1ae-4f0a-8107-e28322fc16b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8953672-b1ae-4f0a-8107-e28322fc16b7.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "83b8ff45-87d3-5bc2-9e45-7f3935d741db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8030dc33-bead-4b1a-9270-fe19809044b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8030dc33-bead-4b1a-9270-fe19809044b9.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -7187,7 +7187,7 @@
         },
         {
             "id": "16bec147-39c1-506f-adf3-27d1d883aaa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce050d13-7897-4889-a514-a7617a1ed686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce050d13-7897-4889-a514-a7617a1ed686.jpg?1",
             "name": "Xira Arien",
             "text": "Flying\n{B}{R}{G}, {T}: Target player draws a card.",
             "colours": [
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "fc89da4a-5786-5e5f-b029-dbc0ebb1603f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cfc04-65ea-49a4-8638-b4631a7cf828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cfc04-65ea-49a4-8638-b4631a7cf828.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "11f13ccc-a479-5b2f-a51b-9c0998431b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg?1",
             "name": "Stand // Deliver",
             "text": "",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "3e799e34-3b98-5ff6-ac4a-00cb2ec8f565",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c9c00a1-8c24-4f35-aac9-00304687ee2b.jpg?1",
             "name": "Stand // Deliver",
             "text": "",
             "colours": [
@@ -7339,7 +7339,7 @@
         },
         {
             "id": "1ffb2e80-93e2-519e-b9cf-157badc50aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg?1",
             "name": "Spite // Malice",
             "text": "",
             "colours": [
@@ -7372,7 +7372,7 @@
         },
         {
             "id": "7a283c06-3cc9-50c5-8504-fa00dc18f4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a83658a-8820-4b71-838f-fe1c2ef822d0.jpg?1",
             "name": "Spite // Malice",
             "text": "",
             "colours": [
@@ -7405,7 +7405,7 @@
         },
         {
             "id": "13c07799-78e1-5393-87c3-eb35bf5d8a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg?1",
             "name": "Pain // Suffering",
             "text": "",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "a06453d3-f4c5-53d7-9b7d-2c2fe86e6582",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d11164c-f27b-4cad-8620-d97ed384f0e6.jpg?1",
             "name": "Pain // Suffering",
             "text": "",
             "colours": [
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "ddb3ba26-b6ac-5159-9e0b-a4bae6cccbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg?1",
             "name": "Assault // Battery",
             "text": "",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "161687e8-00bd-579f-861a-8729fb050124",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b2ca0a2-0a18-4d9e-b953-52018af3c65b.jpg?1",
             "name": "Assault // Battery",
             "text": "",
             "colours": [
@@ -7537,7 +7537,7 @@
         },
         {
             "id": "5c1e0dc3-d9e9-5aad-b09a-d42c2d70bfcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg?1",
             "name": "Wax // Wane",
             "text": "",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "85a09902-fc04-58f6-b39d-8214d7ea806b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93b22de-93f3-4f05-8960-fa6a539ea882.jpg?1",
             "name": "Wax // Wane",
             "text": "",
             "colours": [
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "489580b9-5c37-5451-9d08-37232b283341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg?1",
             "name": "Order // Chaos",
             "text": "",
             "colours": [
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "d282ea7e-41f3-5ef5-8d4e-f15b0471dc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4f2486-1a6f-414f-9122-134390fe3b0d.jpg?1",
             "name": "Order // Chaos",
             "text": "",
             "colours": [
@@ -7669,7 +7669,7 @@
         },
         {
             "id": "2f096046-75d5-53c2-9f56-fb54c78984b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg?1",
             "name": "Illusion // Reality",
             "text": "",
             "colours": [
@@ -7702,7 +7702,7 @@
         },
         {
             "id": "b4e6965a-af9a-551f-a321-315eae2e9630",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba6ea373-65ea-45a8-8fed-31c482ba8387.jpg?1",
             "name": "Illusion // Reality",
             "text": "",
             "colours": [
@@ -7735,7 +7735,7 @@
         },
         {
             "id": "b048e268-99f2-50d9-bccb-68ecf7ec3e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg?1",
             "name": "Night // Day",
             "text": "",
             "colours": [
@@ -7768,7 +7768,7 @@
         },
         {
             "id": "a5555d4e-9740-5549-b286-f09667dd6f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/eccff9be-a18d-4fad-b23a-7f66ae9dbfed.jpg?1",
             "name": "Night // Day",
             "text": "",
             "colours": [
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "1f570290-38b9-5b62-ba96-f1199645ec10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18303862-4726-4136-814f-157aa7006579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18303862-4726-4136-814f-157aa7006579.jpg?1",
             "name": "Fire // Ice",
             "text": "",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "7b02cf06-6df4-573a-86ec-18c88fc8891b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18303862-4726-4136-814f-157aa7006579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18303862-4726-4136-814f-157aa7006579.jpg?1",
             "name": "Fire // Ice",
             "text": "",
             "colours": [
@@ -7867,7 +7867,7 @@
         },
         {
             "id": "8730efc0-f216-5208-b94f-928293e2a55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg?1",
             "name": "Life // Death",
             "text": "",
             "colours": [
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "870eee8f-449f-5a8c-977d-a906f82f740c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e16d52ca-f8de-4852-9bff-9d208e5f678f.jpg?1",
             "name": "Life // Death",
             "text": "",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "78e1c040-fa8c-5f3f-bd16-fa9365a1a313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8e092a-610d-4cea-bb92-65e01954b5c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8e092a-610d-4cea-bb92-65e01954b5c4.jpg?1",
             "name": "Crawlspace",
             "text": "No more than two creatures can attack you each combat.",
             "colours": [],
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "83edfcd7-1045-5da2-9364-3e50e0101287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e2b4-3ca9-4649-b863-17c0c4065f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c872e2b4-3ca9-4649-b863-17c0c4065f63.jpg?1",
             "name": "Cryptic Gateway",
             "text": "Tap two untapped creatures you control: You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield.",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "d867cd4a-a0a9-5993-9c27-e00b6d1c121d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550860b4-887d-423a-8add-816c2a8da615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550860b4-887d-423a-8add-816c2a8da615.jpg?1",
             "name": "Damping Sphere",
             "text": "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
             "colours": [],
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "e7928086-336d-54c8-8bbd-67cd0d8ae756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156afb5a-df38-4555-b59b-f3fa64ce5bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156afb5a-df38-4555-b59b-f3fa64ce5bff.jpg?1",
             "name": "Dodecapod",
             "text": "If a spell or ability an opponent controls causes you to discard Dodecapod, put it onto the battlefield with two +1/+1 counters on it instead of putting it into your graveyard.",
             "colours": [],
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "eaaa7065-8c62-5e39-b343-e1add7bfdfad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4398ae9c-4177-4fee-95ba-e98b7f514f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4398ae9c-4177-4fee-95ba-e98b7f514f57.jpg?1",
             "name": "Dragon Blood",
             "text": "{3}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "70e4dd98-8133-5041-a3eb-063e6bea21b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045f373e-510f-4552-9859-884f6ce4cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045f373e-510f-4552-9859-884f6ce4cc59.jpg?1",
             "name": "Dragon Engine",
             "text": "{2}: Dragon Engine gets +1/+0 until end of turn.",
             "colours": [],
@@ -8113,7 +8113,7 @@
         },
         {
             "id": "cb952962-53a2-5f59-9a56-8f2e483f7e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d153663f-f08a-483e-92c9-82b5a9723807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d153663f-f08a-483e-92c9-82b5a9723807.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "99295c92-8212-5b5c-a10f-d04f7304027d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e4ff9c-6244-43e1-b569-32a270c4e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e4ff9c-6244-43e1-b569-32a270c4e014.jpg?1",
             "name": "Helm of Awakening",
             "text": "Spells cost {1} less to cast.",
             "colours": [],
@@ -8175,7 +8175,7 @@
         },
         {
             "id": "10633941-a0f8-5743-b605-6dffef343353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5a54ca-f175-4005-895f-d76effd6178e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5a54ca-f175-4005-895f-d76effd6178e.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -8205,7 +8205,7 @@
         },
         {
             "id": "d0086754-7f95-5ed1-93b9-80629ac53c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2db45f-4cdb-4b7f-a270-44b2b1482f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2db45f-4cdb-4b7f-a270-44b2b1482f69.jpg?1",
             "name": "Jalum Tome",
             "text": "{2}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -8233,7 +8233,7 @@
         },
         {
             "id": "da030af0-9737-5260-b4b7-403735753b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b364e7e7-83e5-474b-9768-8b70a77e5ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b364e7e7-83e5-474b-9768-8b70a77e5ffa.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and exile them. Then that player shuffles.",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "d19b4714-e5b6-596c-b911-30371d78a9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211ba3e4-8979-4dd1-b1a0-1d8a19969349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211ba3e4-8979-4dd1-b1a0-1d8a19969349.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "c5ec9f91-ef5d-56a7-82fd-78052e0b4d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd35d5c-7f28-4842-85e8-692d6c391c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd35d5c-7f28-4842-85e8-692d6c391c3a.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Exile target permanent.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "290c0682-9913-5d34-9601-c124b31fa90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b92fd6-e3a7-4d50-b94f-1508a830b799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b92fd6-e3a7-4d50-b94f-1508a830b799.jpg?1",
             "name": "Lotus Blossom",
             "text": "At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.\n{T}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.",
             "colours": [],
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "5e36b80e-ed15-51bc-8121-fdeca5ab92e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad71523-a88a-4239-ba3d-3b79f526964e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad71523-a88a-4239-ba3d-3b79f526964e.jpg?1",
             "name": "Millikin",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "0fd8f9cf-a2c9-5d02-8456-a6a4201c34e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cef8f31-a95e-49d0-ba75-7a639fcaa649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cef8f31-a95e-49d0-ba75-7a639fcaa649.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -8428,7 +8428,7 @@
         },
         {
             "id": "d36cdc58-1524-5baa-a16d-4f0353fc3732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305078a5-ac18-4721-bba2-3434eba5b1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305078a5-ac18-4721-bba2-3434eba5b1cf.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "2fa84bf9-74e5-5302-899d-db6c2150c70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ea19b9-d25e-4d46-a7ea-059a3a2fceb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ea19b9-d25e-4d46-a7ea-059a3a2fceb1.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "078f59d3-ff88-5371-b53f-5d5cea2827f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf493-5839-47e8-95f2-6d8201907428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf493-5839-47e8-95f2-6d8201907428.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile target player's graveyard.",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "92e0cd6f-a2cd-5aa0-88ff-3075ad685454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151a1d7-bf4a-4615-8bf1-37d1e406a708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3151a1d7-bf4a-4615-8bf1-37d1e406a708.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "b5e9c1c3-0a1b-55ae-9d1c-64f17772301d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556ed8e-2ad9-4135-902a-24f8e327584b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6556ed8e-2ad9-4135-902a-24f8e327584b.jpg?1",
             "name": "Umbilicus",
             "text": "At the beginning of each player's upkeep, that player may pay 2 life. If they don't, they return a permanent they control to its owner's hand.",
             "colours": [],
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "550e79ac-3b00-5c12-87d7-420ea16f465e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2b6a7-b93a-42d3-b66a-a70b573fc58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2b6a7-b93a-42d3-b66a-a70b573fc58a.jpg?1",
             "name": "Urza's Blueprints",
             "text": "Echo {6} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{T}: Draw a card.",
             "colours": [],
@@ -8618,7 +8618,7 @@
         },
         {
             "id": "60e0cffb-231d-5b19-9b70-3faa7b757b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8122161-1608-4af4-9aca-7f22c2f746aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8122161-1608-4af4-9aca-7f22c2f746aa.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -8649,7 +8649,7 @@
         },
         {
             "id": "4a7cb0b6-b689-57eb-982b-b8817c805707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f19832-0c66-4f06-8110-ce4b2a3d8346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f19832-0c66-4f06-8110-ce4b2a3d8346.jpg?1",
             "name": "Wall of Junk",
             "text": "Defender\nWhen Wall of Junk blocks, return it to its owner's hand at end of combat. (Return it only if it's on the battlefield.)",
             "colours": [],
@@ -8680,7 +8680,7 @@
         },
         {
             "id": "9b236327-a957-547c-a7b7-083defd13f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f775a-2eb3-4151-b21d-9fe62ae17f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5f775a-2eb3-4151-b21d-9fe62ae17f54.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8713,7 +8713,7 @@
         },
         {
             "id": "5a750431-719d-5190-b4da-ea7a586fbefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce462b-e4de-4972-9e96-2e3d3a20d1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce462b-e4de-4972-9e96-2e3d3a20d1fc.jpg?1",
             "name": "Crosis's Catacombs",
             "text": "When Crosis's Catacombs enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {U}, {B}, or {R}.",
             "colours": [],
@@ -8747,7 +8747,7 @@
         },
         {
             "id": "50d07ba4-8407-5d74-bb55-8b2b79e536a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b1ad2d-f02e-4e6b-a49a-f65d174bb0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b1ad2d-f02e-4e6b-a49a-f65d174bb0fc.jpg?1",
             "name": "Darigaaz's Caldera",
             "text": "When Darigaaz's Caldera enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {B}, {R}, or {G}.",
             "colours": [],
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "0cfa9389-9cd7-517b-9f13-b2b0de54546f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b11ad-d077-40b6-988c-0462e118fe3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b11ad-d077-40b6-988c-0462e118fe3d.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "2eeb6b84-7458-5fdd-b014-23c74a4aeacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb024fa-2df1-4414-b0d7-6f700d152c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb024fa-2df1-4414-b0d7-6f700d152c51.jpg?1",
             "name": "Drifting Meadow",
             "text": "Drifting Meadow enters the battlefield tapped.\n{T}: Add {W}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8845,7 +8845,7 @@
         },
         {
             "id": "513963ac-dcbb-5459-b3e9-630a0313a4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10380662-88bd-4bc5-b8c3-14af425fc5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10380662-88bd-4bc5-b8c3-14af425fc5a5.jpg?1",
             "name": "Dromar's Cavern",
             "text": "When Dromar's Cavern enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {W}, {U}, or {B}.",
             "colours": [],
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "f116d248-3c5d-546f-87e1-129f2ff6d74b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee152618-761f-43b4-942a-f63b16c182cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee152618-761f-43b4-942a-f63b16c182cc.jpg?1",
             "name": "Gemstone Mine",
             "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color. If there are no mining counters on Gemstone Mine, sacrifice it.",
             "colours": [],
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "d5b0b125-a0c8-5692-a849-2b7a90d1758d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da629db7-c200-43ed-8de2-a5859b639a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da629db7-c200-43ed-8de2-a5859b639a6d.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "cc3e4a54-b2ed-529a-a863-6a622a9a00ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d359281b-b509-41be-a820-c7ac9f36f27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d359281b-b509-41be-a820-c7ac9f36f27f.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "8b8364c2-0c2e-5c31-aebe-ded112eecc15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5889fde1-730d-43d0-aaa4-499784a80530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5889fde1-730d-43d0-aaa4-499784a80530.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "bf7bc8e2-92a3-56c4-a96d-ff085d9dc9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9fec20-a52c-42c0-9928-c572d9e1b21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9fec20-a52c-42c0-9928-c572d9e1b21f.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -9037,7 +9037,7 @@
         },
         {
             "id": "1bacbaa5-1ee7-59c9-aa09-a4d17edbe4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4188a561-46e3-4ddd-8797-f33c37e9adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4188a561-46e3-4ddd-8797-f33c37e9adb2.jpg?1",
             "name": "Nantuko Monastery",
             "text": "{T}: Add {C}.\nThreshold \u2014 {G}{W}: Nantuko Monastery becomes a 4/4 green and white Insect Monk creature with first strike until end of turn. It's still a land. Activate only if seven or more cards are in your graveyard.",
             "colours": [],
@@ -9068,7 +9068,7 @@
         },
         {
             "id": "921da358-df89-58b2-a8aa-27a2b46cfa3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb724bec-3509-4f5f-84c0-b1b54063d06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb724bec-3509-4f5f-84c0-b1b54063d06f.jpg?1",
             "name": "Polluted Mire",
             "text": "Polluted Mire enters the battlefield tapped.\n{T}: Add {B}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9098,7 +9098,7 @@
         },
         {
             "id": "d72472d9-9ae1-53b0-83d6-51a9f97e6931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a340af37-c0a7-4f26-974b-95397b5c32f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a340af37-c0a7-4f26-974b-95397b5c32f7.jpg?1",
             "name": "Remote Isle",
             "text": "Remote Isle enters the battlefield tapped.\n{T}: Add {U}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9128,7 +9128,7 @@
         },
         {
             "id": "85685c04-f498-5161-a8fc-cb2b0528cd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a605ce4-ede6-44dd-a2ea-e953902be6bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a605ce4-ede6-44dd-a2ea-e953902be6bd.jpg?1",
             "name": "Rith's Grove",
             "text": "When Rith's Grove enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {R}, {G}, or {W}.",
             "colours": [],
@@ -9162,7 +9162,7 @@
         },
         {
             "id": "40985ee8-d2ed-5a06-853b-aeed4918a51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41073e8-01cc-4d19-acb5-caaf2861bc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41073e8-01cc-4d19-acb5-caaf2861bc6a.jpg?1",
             "name": "Slippery Karst",
             "text": "Slippery Karst enters the battlefield tapped.\n{T}: Add {G}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9192,7 +9192,7 @@
         },
         {
             "id": "b660ac75-7c2b-54c7-a4a4-36820e143e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcfaaed-c139-4787-946f-59800bde71e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcfaaed-c139-4787-946f-59800bde71e4.jpg?1",
             "name": "Smoldering Crater",
             "text": "Smoldering Crater enters the battlefield tapped.\n{T}: Add {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9222,7 +9222,7 @@
         },
         {
             "id": "67b9648d-7459-5b68-945e-d0632d92fca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e12e4-6122-41d8-8ffb-a883d02d3278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e12e4-6122-41d8-8ffb-a883d02d3278.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9255,7 +9255,7 @@
         },
         {
             "id": "154419b9-f97a-5dd7-84f1-d421507b998f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9029f22b-f153-4f9a-a60f-ba2d0b6e0a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9029f22b-f153-4f9a-a60f-ba2d0b6e0a1d.jpg?1",
             "name": "Terminal Moraine",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Terminal Moraine: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9283,7 +9283,7 @@
         },
         {
             "id": "e826a187-31e5-5c72-a5f3-917688f925d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f39366c-00df-4528-a324-6a89d0c53f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f39366c-00df-4528-a324-6a89d0c53f0a.jpg?1",
             "name": "Treva's Ruins",
             "text": "When Treva's Ruins enters the battlefield, sacrifice it unless you return a non-Lair land you control to its owner's hand.\n{T}: Add {G}, {W}, or {U}.",
             "colours": [],
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "0cb82c34-6f54-59bf-8f2e-e7520a3b9049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100b00b-a7de-4e36-a83b-1ce1fa427cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2100b00b-a7de-4e36-a83b-1ce1fa427cc2.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9350,7 +9350,7 @@
         },
         {
             "id": "1e7f9c15-861a-5059-820d-f2948296de62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27840eab-9262-49d8-8007-033d42afcad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27840eab-9262-49d8-8007-033d42afcad7.jpg?1",
             "name": "Divine Sacrament",
             "text": "White creatures get +1/+1.\nThreshold \u2014 White creatures get an additional +1/+1 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -9384,7 +9384,7 @@
         },
         {
             "id": "7c671f47-bc1a-5610-a483-42c169ecbab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecea08d-7d65-4d61-a34d-2f8976af5f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecea08d-7d65-4d61-a34d-2f8976af5f5e.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "9babea33-5571-5d39-80e4-1de794d0547e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ada52e-073c-4775-a190-310d51569682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ada52e-073c-4775-a190-310d51569682.jpg?1",
             "name": "Glory",
             "text": "Flying\n{2}{W}: Choose a color. Creatures you control gain protection from the chosen color until end of turn. Activate only if Glory is in your graveyard.",
             "colours": [
@@ -9455,7 +9455,7 @@
         },
         {
             "id": "c31360d1-2a59-5c6f-afcb-656488fbaee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f40d25a-6966-4a5c-83d8-01d37a8379c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f40d25a-6966-4a5c-83d8-01d37a8379c6.jpg?1",
             "name": "Lieutenant Kirtar",
             "text": "Flying\n{1}{W}, Sacrifice Lieutenant Kirtar: Exile target attacking creature.",
             "colours": [
@@ -9494,7 +9494,7 @@
         },
         {
             "id": "c48ca885-54f0-583c-bd95-4d6c5d5953c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da75521-e2f0-4064-8abe-0565353df7c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da75521-e2f0-4064-8abe-0565353df7c5.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -9533,7 +9533,7 @@
         },
         {
             "id": "eb9aad01-dbf9-5444-ac2e-1ca14daa72b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811043f5-b2eb-4983-a8d6-85c3912e6d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811043f5-b2eb-4983-a8d6-85c3912e6d99.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "f3d14e0d-634f-51ac-ac18-288913503c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd5aa4-b920-4aff-ba0d-2d4777ebbf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd5aa4-b920-4aff-ba0d-2d4777ebbf66.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "f28f5517-1b62-5029-9504-e349c91b0098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df3e4d-d8a5-417b-a765-351564f0c38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1df3e4d-d8a5-417b-a765-351564f0c38f.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "a440c6f0-681b-560f-a649-52683e1f8e11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d52e0-dfa6-4ac0-909e-81d1a16b84b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d52e0-dfa6-4ac0-909e-81d1a16b84b4.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -9675,7 +9675,7 @@
         },
         {
             "id": "2098b071-4c7a-5676-942d-25c271cbcc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e430b8c9-9439-4256-9066-e9b57f257fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e430b8c9-9439-4256-9066-e9b57f257fe7.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -9711,7 +9711,7 @@
         },
         {
             "id": "a6cc7d87-b04f-526b-8d7f-2d8d3bf73ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f0108-e936-4286-95a9-f11b679ebaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f0108-e936-4286-95a9-f11b679ebaa0.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar's power and toughness are each equal to your life total.\nWhen Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "7c32fff9-5c9c-5d98-826b-8c1fb3e7e522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec5dc4-a40d-41d4-ba50-47c494632037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec5dc4-a40d-41d4-ba50-47c494632037.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9781,7 +9781,7 @@
         },
         {
             "id": "a0eed162-97bb-5175-b7bf-ce12bb32eaf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6aa4e90-1bb0-445f-a321-caaa69372d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6aa4e90-1bb0-445f-a321-caaa69372d53.jpg?1",
             "name": "Spirit Link",
             "text": "Enchant creature\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -9817,7 +9817,7 @@
         },
         {
             "id": "0f44164d-a241-59cc-9e07-0846b24fbac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3067d-768b-40e7-80d6-08cc42f162b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3067d-768b-40e7-80d6-08cc42f162b6.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "d02b584d-d4e4-534d-a26d-e2743c74f8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b65824-f3d8-4f01-ad8a-ebd19ce5062e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b65824-f3d8-4f01-ad8a-ebd19ce5062e.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "83e52c69-f8df-56de-ba42-a199d116c85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe919e-13c8-44de-a778-8e6ce0b16a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe919e-13c8-44de-a778-8e6ce0b16a58.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "af18e638-c0d3-58d1-904a-a107527063b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1649d-85c9-4f69-8850-2e4df6f8fc9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1649d-85c9-4f69-8850-2e4df6f8fc9c.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -9959,7 +9959,7 @@
         },
         {
             "id": "a7b94a6a-d732-5c3b-a4fe-4672f04ff9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8603c3b-9a10-4a04-b417-284a8e3925a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8603c3b-9a10-4a04-b417-284a8e3925a9.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "47ebb575-1c4f-5a19-bc0b-0adeb5b0b4e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2c1c92-3da1-4f7e-a02c-831311115a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2c1c92-3da1-4f7e-a02c-831311115a5d.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -10032,7 +10032,7 @@
         },
         {
             "id": "62bb67cb-120f-5262-815c-39d8228bc1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14d5ff3-40c0-4f22-91ad-d6c8447cb9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14d5ff3-40c0-4f22-91ad-d6c8447cb9e0.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -10067,7 +10067,7 @@
         },
         {
             "id": "fd1a87b6-8a32-50ea-af0e-3fa35648021b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89882438-6357-4ef9-9a52-f1ff49952c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89882438-6357-4ef9-9a52-f1ff49952c10.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep enters the battlefield, return each other creature you control to its owner's hand.",
             "colours": [
@@ -10104,7 +10104,7 @@
         },
         {
             "id": "e0b77f4f-c80a-57e8-a461-7031ab60a361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3e09f-f9a1-4618-9ec6-ee91e1398522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3e09f-f9a1-4618-9ec6-ee91e1398522.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "de866bb1-814b-5b05-9235-cca64f1ef97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83240eaa-edb4-4bd3-b193-29470cf46828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83240eaa-edb4-4bd3-b193-29470cf46828.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -10173,7 +10173,7 @@
         },
         {
             "id": "05d9b0c7-f50a-5ccd-8f38-8fb0c0b0e5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad4d49f-2505-43b7-b5fb-58bf1b8fcc71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad4d49f-2505-43b7-b5fb-58bf1b8fcc71.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -10207,7 +10207,7 @@
         },
         {
             "id": "7a6a49eb-d8ba-56f9-9374-0769a2a7ea1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f3e6df-33c0-4d0d-b382-58d00be2051a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f3e6df-33c0-4d0d-b382-58d00be2051a.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.",
             "colours": [
@@ -10242,7 +10242,7 @@
         },
         {
             "id": "95d359ee-c93f-5516-9a7b-fa1349d53757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4880c0ca-7127-4d8d-ade7-2459e4acd706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4880c0ca-7127-4d8d-ade7-2459e4acd706.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -10276,7 +10276,7 @@
         },
         {
             "id": "75e3585b-f700-5b5c-8a0f-f8b374a3b252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87c041-c516-4911-ad28-1fb961c0d3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87c041-c516-4911-ad28-1fb961c0d3dc.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
             "colours": [
@@ -10311,7 +10311,7 @@
         },
         {
             "id": "ebc62c21-9daf-557f-b78c-14696c13b4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7331aade-3b7f-4b4d-b198-2e0b6b80895c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7331aade-3b7f-4b4d-b198-2e0b6b80895c.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -10346,7 +10346,7 @@
         },
         {
             "id": "7d3365fd-6955-5cab-9a68-a5cbbed3bb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de069a00-be1f-4762-b511-bb9211bf2cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de069a00-be1f-4762-b511-bb9211bf2cc8.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -10380,7 +10380,7 @@
         },
         {
             "id": "ff34c368-03e2-513e-ab07-c0a59658f371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d72f51a-3615-4b98-acaa-7d55aabb6c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d72f51a-3615-4b98-acaa-7d55aabb6c10.jpg?1",
             "name": "Ovinize",
             "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
             "colours": [
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "9d347321-ebae-5e66-be8a-ff3c4a2040b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb4952-593b-4cdf-97b8-d3cdbe424ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb4952-593b-4cdf-97b8-d3cdbe424ba6.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake enters the battlefield, untap up to five lands.",
             "colours": [
@@ -10450,7 +10450,7 @@
         },
         {
             "id": "357908f7-1261-5372-a22c-c818ed14e8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906569a3-1750-41af-8d83-a5354500c850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906569a3-1750-41af-8d83-a5354500c850.jpg?1",
             "name": "Stroke of Genius",
             "text": "Target player draws X cards.",
             "colours": [
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "e8f2e1df-dc93-508e-b1be-cd02d2f3596b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa810491-ce45-4a87-b3ec-85ec340e33a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa810491-ce45-4a87-b3ec-85ec340e33a4.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -10519,7 +10519,7 @@
         },
         {
             "id": "80d26865-28b8-5c12-b340-8d9d76f8d954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22702a76-f8ed-4a73-ba9d-f928add32d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22702a76-f8ed-4a73-ba9d-f928add32d85.jpg?1",
             "name": "Turnabout",
             "text": "Choose artifact, creature, or land. Tap all untapped permanents of the chosen type target player controls, or untap all tapped permanents of that type that player controls.",
             "colours": [
@@ -10553,7 +10553,7 @@
         },
         {
             "id": "55bd5802-5f1a-578c-9a7d-13b6fa1cf73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81329329-0154-4f89-a476-a54112dfa0b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81329329-0154-4f89-a476-a54112dfa0b7.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -10593,7 +10593,7 @@
         },
         {
             "id": "6a1a16a6-d42e-5dbc-b995-d1faf1172c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a53a7e-f54c-410c-8cd2-7d3e0347bc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a53a7e-f54c-410c-8cd2-7d3e0347bc6b.jpg?1",
             "name": "Vexing Sphinx",
             "text": "Flying\nCumulative upkeep\u2014\nDiscard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen Vexing Sphinx dies, draw a card for each age counter on it.",
             "colours": [
@@ -10629,7 +10629,7 @@
         },
         {
             "id": "43862451-5ce4-534d-bad0-262156811ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd51f0b-3c8a-4b2e-a0b6-7fa98c3ba678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd51f0b-3c8a-4b2e-a0b6-7fa98c3ba678.jpg?1",
             "name": "Body Snatcher",
             "text": "When Body Snatcher enters the battlefield, exile it unless you discard a creature card.\nWhen Body Snatcher dies, exile it and return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -10666,7 +10666,7 @@
         },
         {
             "id": "49c61ff8-f35e-57c4-bd7e-5f7866b43182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f85a4be-fa18-47ce-b24d-8cac718227ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f85a4be-fa18-47ce-b24d-8cac718227ef.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -10706,7 +10706,7 @@
         },
         {
             "id": "924aaf13-0817-5ee5-8a9a-a63dc67c1afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63416b41-7791-48ff-bcdc-54101afbea31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63416b41-7791-48ff-bcdc-54101afbea31.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10741,7 +10741,7 @@
         },
         {
             "id": "5aef892e-018d-569d-bb7d-0e33df2b245a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc427d9-2697-4e60-b1eb-948a6556f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc427d9-2697-4e60-b1eb-948a6556f1ad.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "b48f67b9-1999-5b02-972c-4d5808e23255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dc1ce-a224-4271-86f1-31b3fe53405c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dc1ce-a224-4271-86f1-31b3fe53405c.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10809,7 +10809,7 @@
         },
         {
             "id": "efe79a95-6053-5821-bc90-713ea3cd9515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e533c49-35a5-4c78-a27c-d3e6f9355d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e533c49-35a5-4c78-a27c-d3e6f9355d37.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -10843,7 +10843,7 @@
         },
         {
             "id": "165805e1-87a8-5cd6-9448-f8defca4a8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750820a5-b03f-46ee-970a-b66845176853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750820a5-b03f-46ee-970a-b66845176853.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "63958091-2565-55e2-b359-90466d70d0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93e4486-aaf3-4f56-ab34-1ff1aeebb021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93e4486-aaf3-4f56-ab34-1ff1aeebb021.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer dies, each player discards their hand.",
             "colours": [
@@ -10914,7 +10914,7 @@
         },
         {
             "id": "f64e97a8-a397-5093-908b-48020317ceba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48375e7-46b6-45a7-9d19-f7b7de85fe55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48375e7-46b6-45a7-9d19-f7b7de85fe55.jpg?1",
             "name": "Nantuko Shade",
             "text": "{B}: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -10951,7 +10951,7 @@
         },
         {
             "id": "4d555380-3191-592d-b25b-1f45f094c641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f7677-5f35-4cb9-a938-dba13fb7863a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541f7677-5f35-4cb9-a938-dba13fb7863a.jpg?1",
             "name": "Necrosavant",
             "text": "{3}{B}{B}, Sacrifice a creature: Return Necrosavant from your graveyard to the battlefield. Activate only during your upkeep.",
             "colours": [
@@ -10988,7 +10988,7 @@
         },
         {
             "id": "346539f1-db61-5bb0-9458-dd851c13842c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2598da4-0764-440a-9e9d-0161e68667fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2598da4-0764-440a-9e9d-0161e68667fb.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature deals damage to you, destroy it.",
             "colours": [
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "a029795a-1a00-5538-b55c-df567b1a141a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f95c0-1470-4282-ba26-4908ed36a557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f95c0-1470-4282-ba26-4908ed36a557.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "fee0cabc-081d-56b8-b882-4b31b6a62753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0035cade-d84c-4978-8c9f-560893f07c27.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -11095,7 +11095,7 @@
         },
         {
             "id": "9e2ddfcc-336d-5fad-9232-fb0a1b153159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a06831-0cbd-48f9-a817-4c5a36fa782a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a06831-0cbd-48f9-a817-4c5a36fa782a.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "175b0aa7-ca62-5e1a-8404-16fc158bcf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9040f60a-03a5-4410-b6f8-92620ff91af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9040f60a-03a5-4410-b6f8-92620ff91af4.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "c80de890-7b29-5d4a-a8dd-5cdb81fff684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ca0c3-3308-4ebd-a0ce-f90eb605b0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ca0c3-3308-4ebd-a0ce-f90eb605b0f5.jpg?1",
             "name": "Undead Gladiator",
             "text": "{1}{B}, Discard a card: Return Undead Gladiator from your graveyard to your hand. Activate only during your upkeep.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [
@@ -11203,7 +11203,7 @@
         },
         {
             "id": "7bee703b-1f5d-53b9-99b4-d4c956ad68a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ad722a-d6f3-483e-bd13-e0923cc8a265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ad722a-d6f3-483e-bd13-e0923cc8a265.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -11238,7 +11238,7 @@
         },
         {
             "id": "4b1b6ddb-8eeb-573b-8a4e-c56940fc8e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef603c2-b09c-40e9-b3ab-fceb4964aafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef603c2-b09c-40e9-b3ab-fceb4964aafd.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "307645c3-aec3-524f-a562-0ce951d88e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfc299-0cf5-40ab-9f50-11408ff82282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfc299-0cf5-40ab-9f50-11408ff82282.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -11312,7 +11312,7 @@
         },
         {
             "id": "526aa76c-02d4-5611-a514-9cba67d33f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190f2d1-e7e5-4cf7-8227-c2690568d159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190f2d1-e7e5-4cf7-8227-c2690568d159.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice Dragon Whelp at the beginning of the next end step.",
             "colours": [
@@ -11348,7 +11348,7 @@
         },
         {
             "id": "1a0fab57-22ea-5298-9a19-b1193fbe1f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd81c2e-9c0d-47b2-ba02-6f1dca1d96dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd81c2e-9c0d-47b2-ba02-6f1dca1d96dc.jpg?1",
             "name": "Empty the Warrens",
             "text": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -11382,7 +11382,7 @@
         },
         {
             "id": "f7a92945-b98c-56fd-9f47-098a63bf12d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d80d765-70bf-4eb5-ae55-fe459e96caf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d80d765-70bf-4eb5-ae55-fe459e96caf8.jpg?1",
             "name": "Fireblast",
             "text": "You may sacrifice two Mountains rather than pay this spell's mana cost.\nFireblast deals 4 damage to any target.",
             "colours": [
@@ -11416,7 +11416,7 @@
         },
         {
             "id": "d85e1d81-e9e4-5878-ab97-fd192d28dfb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f601db5-e522-48d2-a0df-ff3192f8d38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f601db5-e522-48d2-a0df-ff3192f8d38d.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -11453,7 +11453,7 @@
         },
         {
             "id": "3ef798f9-39a9-5dc6-a325-3774f61cf17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa5f934-5407-4844-9cd5-9ba5fa7c4748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa5f934-5407-4844-9cd5-9ba5fa7c4748.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle.",
             "colours": [
@@ -11488,7 +11488,7 @@
         },
         {
             "id": "f31a086d-2e87-52e2-acd3-63b4d28a0cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce01c9-f6f3-49e3-ac2c-10613eba0ed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ce01c9-f6f3-49e3-ac2c-10613eba0ed6.jpg?1",
             "name": "Gempalm Incinerator",
             "text": "Cycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins on the battlefield.",
             "colours": [
@@ -11524,7 +11524,7 @@
         },
         {
             "id": "5287e7f6-1291-5464-b4bb-0d45ca42c1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ec4b08-6df1-4e92-8b7c-1450a4d033bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ec4b08-6df1-4e92-8b7c-1450a4d033bf.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -11560,7 +11560,7 @@
         },
         {
             "id": "e3347fab-cbf6-56c1-9b8d-54120529a967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59035b53-e374-49f6-8b02-8b54f6df45d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59035b53-e374-49f6-8b02-8b54f6df45d2.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "19d294d9-24a5-5897-bfe3-16b303285710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585be7c2-b303-4612-bafa-ca7a555212aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585be7c2-b303-4612-bafa-ca7a555212aa.jpg?1",
             "name": "Last Chance",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "640ab42b-198b-55c1-9666-242ebca05f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027246-1dd3-4be0-bea6-3a7476a833ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc027246-1dd3-4be0-bea6-3a7476a833ce.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11670,7 +11670,7 @@
         },
         {
             "id": "65553096-a5c5-5845-bc81-d2c02bc7966d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3725a437-d853-4231-b669-c97f6a6666e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3725a437-d853-4231-b669-c97f6a6666e1.jpg?1",
             "name": "Overmaster",
             "text": "The next instant or sorcery spell you cast this turn can't be countered.\nDraw a card.",
             "colours": [
@@ -11704,7 +11704,7 @@
         },
         {
             "id": "bf0604d2-bc6c-58d1-a0cf-3f81304abf3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62b7671-efde-40b2-9cb1-76339d614d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62b7671-efde-40b2-9cb1-76339d614d29.jpg?1",
             "name": "Pashalik Mons",
             "text": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -11743,7 +11743,7 @@
         },
         {
             "id": "92b16033-406b-5bcc-9715-98361220bdd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f8025-95ff-431a-a33c-4e2e7366633f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f8025-95ff-431a-a33c-4e2e7366633f.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -11779,7 +11779,7 @@
         },
         {
             "id": "e92c013c-aef8-54f1-b177-e17c298f85c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bea810-1566-4132-bfb3-611f9b6b3333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bea810-1566-4132-bfb3-611f9b6b3333.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -11816,7 +11816,7 @@
         },
         {
             "id": "f8a93e23-7769-5e63-b76b-cff3100973aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2418b3d-574a-40e7-9b6b-1bc4a8199105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2418b3d-574a-40e7-9b6b-1bc4a8199105.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -11850,7 +11850,7 @@
         },
         {
             "id": "18cd090f-530a-57b8-a687-6f5f0a1ac966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d446b8b-1b09-4fef-8454-95ad272503c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d446b8b-1b09-4fef-8454-95ad272503c0.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -11884,7 +11884,7 @@
         },
         {
             "id": "a807d6a9-2145-5dec-82f4-528fd27dffaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9abfd4d-8f7d-4739-8416-2c03bc1c7a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9abfd4d-8f7d-4739-8416-2c03bc1c7a04.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "fe3fb83c-d2d1-5c09-8ea6-56d391dfcd2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed63bcc-4cdd-4b4e-af7f-f5ff71a4ef14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed63bcc-4cdd-4b4e-af7f-f5ff71a4ef14.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -11961,7 +11961,7 @@
         },
         {
             "id": "af9f30c5-08fc-5782-ab49-255c218752b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b991e-b5c1-4d23-ba3a-4554c272a41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b991e-b5c1-4d23-ba3a-4554c272a41f.jpg?1",
             "name": "Arboria",
             "text": "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn.",
             "colours": [
@@ -11998,7 +11998,7 @@
         },
         {
             "id": "72d94a98-5149-519e-97a6-cd3fbca71fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef6d6c-db50-4d24-8ebd-311613ddef06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef6d6c-db50-4d24-8ebd-311613ddef06.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [
@@ -12035,7 +12035,7 @@
         },
         {
             "id": "ba3bd9f2-0852-553a-9cc2-905687c51a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a39ab84-1f0f-4b4f-a13d-301960bbc971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a39ab84-1f0f-4b4f-a13d-301960bbc971.jpg?1",
             "name": "Deadwood Treefolk",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk enters or leaves the battlefield, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "5d1860a2-3d46-5955-82ae-356b69905cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02805527-943c-4d88-9d80-50ed71a14af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02805527-943c-4d88-9d80-50ed71a14af2.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "Exile Elvish Spirit Guide from your hand: Add {G}.",
             "colours": [
@@ -12108,7 +12108,7 @@
         },
         {
             "id": "0f6184cf-27b5-5b7d-8bb3-d8975d99bc31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbcd04-aabf-420e-9bc8-4270f78e25d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbcd04-aabf-420e-9bc8-4270f78e25d7.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land on each of your turns.",
             "colours": [
@@ -12142,7 +12142,7 @@
         },
         {
             "id": "8dbbde62-9c02-5b0a-84a4-398517ec336c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095eda4-7a9c-4161-a775-4dbfac32dbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095eda4-7a9c-4161-a775-4dbfac32dbab.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "76d13fb6-e011-57f6-b280-b39d1aef055c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afea4ea-02f2-47ca-b690-864a5663eecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afea4ea-02f2-47ca-b690-864a5663eecc.jpg?1",
             "name": "Forgotten Ancient",
             "text": "Whenever a player casts a spell, you may put a +1/+1 counter on Forgotten Ancient.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Forgotten Ancient onto other creatures.",
             "colours": [
@@ -12215,7 +12215,7 @@
         },
         {
             "id": "d5958393-2ca3-5cbc-8299-770fb24d17c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13286ebf-e4dd-48be-82e7-9057755027ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13286ebf-e4dd-48be-82e7-9057755027ec.jpg?1",
             "name": "Invigorating Boon",
             "text": "Whenever a player cycles a card, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -12249,7 +12249,7 @@
         },
         {
             "id": "824e146e-b100-5813-a776-6c62eff7c66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888c4cd-8cdf-442f-838c-dc1e4d696998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888c4cd-8cdf-442f-838c-dc1e4d696998.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -12288,7 +12288,7 @@
         },
         {
             "id": "715f59f7-1d87-5abd-b12c-b74e932b40c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ef4c48-978c-41f5-b347-230433326f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ef4c48-978c-41f5-b347-230433326f7c.jpg?1",
             "name": "Kamahl, Fist of Krosa",
             "text": "{G}: Target land becomes a 1/1 creature until end of turn. It's still a land.\n{2}{G}{G}{G}: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -12327,7 +12327,7 @@
         },
         {
             "id": "d7025c46-a717-53c2-b0b6-7a83f01f58e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9cbb7f-8745-4ec4-8d8a-efd1f7e93b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9cbb7f-8745-4ec4-8d8a-efd1f7e93b1e.jpg?1",
             "name": "Lull",
             "text": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -12361,7 +12361,7 @@
         },
         {
             "id": "febcd3dc-9c0e-569c-91a5-0e4dd6634bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3e1d00-effa-46ac-a899-030c0eb149ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3e1d00-effa-46ac-a899-030c0eb149ac.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a Forest card, put that card onto the battlefield, then shuffle.",
             "colours": [
@@ -12395,7 +12395,7 @@
         },
         {
             "id": "4d43130f-2fee-54b6-bc94-588711280c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa53cbd-efe8-4ca8-8c1c-664de27d1b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa53cbd-efe8-4ca8-8c1c-664de27d1b69.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may create a 1/1 green Squirrel creature token.\nThreshold \u2014 All Squirrels get +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -12433,7 +12433,7 @@
         },
         {
             "id": "292a9422-2257-5f37-a3c7-5c38951b7988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8253dab6-d6a7-4a1c-b5f6-5a2ee051a128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8253dab6-d6a7-4a1c-b5f6-5a2ee051a128.jpg?1",
             "name": "Saproling Symbiosis",
             "text": "You may cast Saproling Symbiosis as though it had flash if you pay {2} more to cast it.\nCreate a 1/1 green Saproling creature token for each creature you control.",
             "colours": [
@@ -12467,7 +12467,7 @@
         },
         {
             "id": "524e3bcf-c543-52bd-b90d-3038ca25cecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4112147-5609-484f-b303-c34df2f315ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4112147-5609-484f-b303-c34df2f315ce.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -12503,7 +12503,7 @@
         },
         {
             "id": "0403cf30-a565-557b-8bab-7a2683a246f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17788434-47c5-4290-8555-adc8171d55cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17788434-47c5-4290-8555-adc8171d55cd.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -12538,7 +12538,7 @@
         },
         {
             "id": "8506584d-e422-588e-8992-d5af6b47c8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ea0b6a-c0f1-49f8-bbd1-fed61ef0c0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ea0b6a-c0f1-49f8-bbd1-fed61ef0c0f3.jpg?1",
             "name": "Wild Dogs",
             "text": "At the beginning of your upkeep, if a player has more life than each other player, the player with the most life gains control of Wild Dogs.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -12574,7 +12574,7 @@
         },
         {
             "id": "cbc1c62b-17b3-5c73-91fa-e11397007a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7246bde-9298-4386-ac4f-1d79f7f0cca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7246bde-9298-4386-ac4f-1d79f7f0cca5.jpg?1",
             "name": "Wild Growth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.",
             "colours": [
@@ -12610,7 +12610,7 @@
         },
         {
             "id": "d5e87e86-5788-5eed-93b6-7faa9341c9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6706ed-f05b-411f-afa5-f6154f718c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6706ed-f05b-411f-afa5-f6154f718c80.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card, reveal it, then shuffle and put the card on top.",
             "colours": [
@@ -12645,7 +12645,7 @@
         },
         {
             "id": "a7ea10dc-d112-5f12-b886-b34527e3ae46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5f70fa-7f96-4b7e-a1cf-56a053f0bff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5f70fa-7f96-4b7e-a1cf-56a053f0bff6.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -12682,7 +12682,7 @@
         },
         {
             "id": "e68121ef-8d75-5a60-932c-2b9202ddd3ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f75fe15-5499-4dfe-917d-adfeccd6838a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f75fe15-5499-4dfe-917d-adfeccd6838a.jpg?1",
             "name": "Arcades Sabboth",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Arcades Sabboth unless you pay {G}{W}{U}.\nEach untapped creature you control gets +0/+2 as long as it's not attacking.\n{W}: Arcades Sabboth gets +0/+1 until end of turn.",
             "colours": [
@@ -12725,7 +12725,7 @@
         },
         {
             "id": "fc079c17-d2b5-52d0-9c2e-4c5b23899a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18445778-6176-40f6-a396-05e85579e85e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18445778-6176-40f6-a396-05e85579e85e.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -12762,7 +12762,7 @@
         },
         {
             "id": "92a98cf0-cbf0-5e45-b580-b4cf6f91558b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46db87-f1b2-4c04-a9f2-642571a8d81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46db87-f1b2-4c04-a9f2-642571a8d81b.jpg?1",
             "name": "Dralnu's Crusade",
             "text": "All Goblins get +1/+1.\nAll Goblins are black and are Zombies in addition to their other creature types.",
             "colours": [
@@ -12798,7 +12798,7 @@
         },
         {
             "id": "1dde490d-7fa0-557b-92d5-447c7fbbd1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4057a41-c8d1-40dd-ac38-abfe6564c8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4057a41-c8d1-40dd-ac38-abfe6564c8bc.jpg?1",
             "name": "Gerrard's Verdict",
             "text": "Target player discards two cards. You gain 3 life for each land card discarded this way.",
             "colours": [
@@ -12834,7 +12834,7 @@
         },
         {
             "id": "268cd2e2-1647-5b7a-a3da-8146f3d22c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0d5a1-1a2e-449f-a9b5-14bf2061529c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c0d5a1-1a2e-449f-a9b5-14bf2061529c.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Hunting Grounds has \"Whenever an opponent casts a spell, you may put a creature card from your hand onto the battlefield.\"",
             "colours": [
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "144cd87e-177e-5b54-91ba-6b6ccf431e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31318a5f-6758-45a6-930f-ba6b1e812af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31318a5f-6758-45a6-930f-ba6b1e812af1.jpg?1",
             "name": "Mystic Enforcer",
             "text": "Protection from black\nThreshold \u2014 As long as seven or more cards are in your graveyard, Mystic Enforcer gets +3/+3 and has flying.",
             "colours": [
@@ -12911,7 +12911,7 @@
         },
         {
             "id": "bcfbadc8-abce-53b2-94df-8b5fb0eccd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000f904-be97-4ad6-825a-0b05c31c3362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000f904-be97-4ad6-825a-0b05c31c3362.jpg?1",
             "name": "Phantom Nishoba",
             "text": "Trample\nPhantom Nishoba enters the battlefield with seven +1/+1 counters on it.\nWhenever Phantom Nishoba deals damage, you gain that much life.\nIf damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.",
             "colours": [
@@ -12951,7 +12951,7 @@
         },
         {
             "id": "aee189d7-579c-501f-a5d7-272007d7c9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8279d133-ae1a-4389-8c20-1d7ca2f121b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8279d133-ae1a-4389-8c20-1d7ca2f121b1.jpg?1",
             "name": "Pyre Zombie",
             "text": "At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay {1}{B}{B}. If you do, return Pyre Zombie to your hand.\n{1}{R}{R}, Sacrifice Pyre Zombie: It deals 2 damage to any target.",
             "colours": [
@@ -12989,7 +12989,7 @@
         },
         {
             "id": "f19ab45c-b168-5e7d-b4d5-649a81ebb697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07be7455-7ead-4ba5-b694-e021b28687d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07be7455-7ead-4ba5-b694-e021b28687d9.jpg?1",
             "name": "Quicksilver Dagger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target player or planeswalker. You draw a card.\"",
             "colours": [
@@ -13027,7 +13027,7 @@
         },
         {
             "id": "dee76714-6d4a-5068-bfbd-66680a801119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27600b4d-ade5-428a-8eb7-d7c387573a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27600b4d-ade5-428a-8eb7-d7c387573a91.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "b206ffce-6629-56ce-a5cd-dfbddc318dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669ad7e-8366-4fec-8151-ded41a9c4548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0669ad7e-8366-4fec-8151-ded41a9c4548.jpg?1",
             "name": "Recoil",
             "text": "Return target permanent to its owner's hand. Then that player discards a card.",
             "colours": [
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "e71d4c7f-7dbb-5f22-9c43-be8c5faea2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0a3c92-826e-491a-8e80-7861e5b199c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0a3c92-826e-491a-8e80-7861e5b199c2.jpg?1",
             "name": "Rith, the Awakener",
             "text": "Flying\nWhenever Rith, the Awakener deals combat damage to a player, you may pay {2}{G}. If you do, choose a color, then create a 1/1 green Saproling creature token for each permanent of that color.",
             "colours": [
@@ -13147,7 +13147,7 @@
         },
         {
             "id": "4038fd6b-d213-56dc-8e8a-918cac806116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f856897c-fb63-4ba2-a1ce-9a8a0bf67072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f856897c-fb63-4ba2-a1ce-9a8a0bf67072.jpg?1",
             "name": "Sawtooth Loon",
             "text": "Flying\nWhen Sawtooth Loon enters the battlefield, return a white or blue creature you control to its owner's hand.\nWhen Sawtooth Loon enters the battlefield, draw two cards, then put two cards from your hand on the bottom of your library.",
             "colours": [
@@ -13185,7 +13185,7 @@
         },
         {
             "id": "6c2670a5-8e56-51cb-94ef-495716ffb3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b989b3f-2eec-4593-ac39-daa8e9ca0daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b989b3f-2eec-4593-ac39-daa8e9ca0daa.jpg?1",
             "name": "Sol'kanar the Swamp King",
             "text": "Swampwalk\nWhenever a player casts a black spell, you gain 1 life.",
             "colours": [
@@ -13227,7 +13227,7 @@
         },
         {
             "id": "2cd7a713-fed0-5762-8824-0550c6705704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa304be0-3944-42c3-94cd-6568db8a661e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa304be0-3944-42c3-94cd-6568db8a661e.jpg?1",
             "name": "Spinal Embrace",
             "text": "Cast this spell only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At the beginning of the next end step, sacrifice it. If you do, you gain life equal to its toughness.",
             "colours": [
@@ -13263,7 +13263,7 @@
         },
         {
             "id": "228a8d3e-a2d9-5ea9-8066-3024e94ca441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e366f-6c64-423d-92fc-1a1e2806e4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e366f-6c64-423d-92fc-1a1e2806e4c3.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\n{B}: Regenerate Spiritmonger.\n{G}: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -13301,7 +13301,7 @@
         },
         {
             "id": "c9c87ea9-29f0-5bcf-a377-6690dfd0f5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32efed1-73ed-49bc-a1e1-53520ddd5d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32efed1-73ed-49bc-a1e1-53520ddd5d43.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -13342,7 +13342,7 @@
         },
         {
             "id": "8f6c2e82-8de8-5886-98d2-72846dd3df54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58dcad2-2e38-46d1-bab7-beddd3600a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58dcad2-2e38-46d1-bab7-beddd3600a1c.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -13383,7 +13383,7 @@
         },
         {
             "id": "8ebdbe8f-41ad-5b6c-8d35-3d0e14ab5941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5de65-5b64-4a32-8c7c-8a7c84f406a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5de65-5b64-4a32-8c7c-8a7c84f406a8.jpg?1",
             "name": "Xira Arien",
             "text": "Flying\n{B}{R}{G}, {T}: Target player draws a card.",
             "colours": [
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "0a769a21-1484-5015-9671-a3a01bcd7944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17188ab9-0fd1-43af-be3b-6e37c55cda9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17188ab9-0fd1-43af-be3b-6e37c55cda9c.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with mana value 3 or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -13469,7 +13469,7 @@
         },
         {
             "id": "f17eff03-0745-5649-9215-8c7b62cc239d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c628d-ae86-4a87-94bb-d06574cda9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c628d-ae86-4a87-94bb-d06574cda9ce.jpg?1",
             "name": "Crawlspace",
             "text": "No more than two creatures can attack you each combat.",
             "colours": [],
@@ -13499,7 +13499,7 @@
         },
         {
             "id": "07293060-21c9-5e70-a037-0c127cb46d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7280d-3727-4c96-bd7a-ae699d007469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7280d-3727-4c96-bd7a-ae699d007469.jpg?1",
             "name": "Cryptic Gateway",
             "text": "Tap two untapped creatures you control: You may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield.",
             "colours": [],
@@ -13529,7 +13529,7 @@
         },
         {
             "id": "5d44f9fa-e211-5e13-a324-256d64f6b6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c178d4c-bce9-4165-af1c-6075a94c84e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c178d4c-bce9-4165-af1c-6075a94c84e4.jpg?1",
             "name": "Damping Sphere",
             "text": "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
             "colours": [],
@@ -13559,7 +13559,7 @@
         },
         {
             "id": "df673a80-8855-5473-8fd3-355594325fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9649b3-0159-426c-838d-d649c6dbe147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9649b3-0159-426c-838d-d649c6dbe147.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -13590,7 +13590,7 @@
         },
         {
             "id": "adc8578d-cd9d-58f7-84d7-ba56d283f68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571bf6-44e1-4975-999d-c44e6709dd5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571bf6-44e1-4975-999d-c44e6709dd5d.jpg?1",
             "name": "Helm of Awakening",
             "text": "Spells cost {1} less to cast.",
             "colours": [],
@@ -13621,7 +13621,7 @@
         },
         {
             "id": "4c51539f-4dde-56b2-9bde-11a4e3730447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e416c68f-433c-44f9-8fcc-043b3919a312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e416c68f-433c-44f9-8fcc-043b3919a312.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -13651,7 +13651,7 @@
         },
         {
             "id": "d26d54d4-8d09-5af7-81ca-8fe161dcdea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f036d2-81ce-490c-b8a0-ab5dc29148ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f036d2-81ce-490c-b8a0-ab5dc29148ec.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and exile them. Then that player shuffles.",
             "colours": [],
@@ -13682,7 +13682,7 @@
         },
         {
             "id": "1ab34cb3-b470-5a2a-bded-e492e37d375d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3468f8d1-4373-4df4-9bbe-3c61a840b23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3468f8d1-4373-4df4-9bbe-3c61a840b23b.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -13715,7 +13715,7 @@
         },
         {
             "id": "c1f2eac6-4f0f-5f95-97ac-eae6735a3607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17f9e1-341f-4649-9e8a-728ef67f875c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17f9e1-341f-4649-9e8a-728ef67f875c.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Exile target permanent.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -13754,7 +13754,7 @@
         },
         {
             "id": "58d138be-855c-55e7-8aa4-66db80663fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67680b01-648a-4056-b117-3ba22ee00051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67680b01-648a-4056-b117-3ba22ee00051.jpg?1",
             "name": "Lotus Blossom",
             "text": "At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.\n{T}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.",
             "colours": [],
@@ -13785,7 +13785,7 @@
         },
         {
             "id": "36213d55-410f-529e-96db-bcd1a35abc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d470d-e0f0-44c2-97f7-f31c02cdfbd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d470d-e0f0-44c2-97f7-f31c02cdfbd3.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -13815,7 +13815,7 @@
         },
         {
             "id": "6873d365-c51e-5f22-87f3-4b1cabc8757c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051386e0-4c1c-48ed-8883-664c719cf0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051386e0-4c1c-48ed-8883-664c719cf0fe.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -13848,7 +13848,7 @@
         },
         {
             "id": "a6593936-d28f-5075-82a7-aff08a28bd3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ee8a2a-7ee8-4017-97b6-799fdb3ce4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ee8a2a-7ee8-4017-97b6-799fdb3ce4f7.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -13881,7 +13881,7 @@
         },
         {
             "id": "002dcca6-d9d7-52a9-8153-05db5d099a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23814c0-f9da-49c4-bfff-69786a5d651b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23814c0-f9da-49c4-bfff-69786a5d651b.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile target player's graveyard.",
             "colours": [],
@@ -13911,7 +13911,7 @@
         },
         {
             "id": "758f67c2-633a-52f6-83cb-ebb018ceb29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5adfe0f-496a-4d56-8c8b-6b58cc827339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5adfe0f-496a-4d56-8c8b-6b58cc827339.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "d3e5e36b-9b94-57b2-b2d3-aef88552e694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c5666-5373-4c81-802a-782a150d70ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79c5666-5373-4c81-802a-782a150d70ad.jpg?1",
             "name": "Umbilicus",
             "text": "At the beginning of each player's upkeep, that player may pay 2 life. If they don't, they return a permanent they control to its owner's hand.",
             "colours": [],
@@ -13975,7 +13975,7 @@
         },
         {
             "id": "b9bba509-75a1-5801-b2fe-61874c7b0d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2c48-c1ad-4148-bf68-803d2c33ee0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2c48-c1ad-4148-bf68-803d2c33ee0e.jpg?1",
             "name": "Urza's Blueprints",
             "text": "Echo {6} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{T}: Draw a card.",
             "colours": [],
@@ -14005,7 +14005,7 @@
         },
         {
             "id": "97233505-7197-52a5-90e5-d4df9215a9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd254044-2b66-4fd8-9f72-3c30226c2a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd254044-2b66-4fd8-9f72-3c30226c2a9c.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -14036,7 +14036,7 @@
         },
         {
             "id": "4ca544a9-bd6f-54c2-b9c4-c4e5104fd8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c177316-31b5-4b73-8cab-eef9d8cbb2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c177316-31b5-4b73-8cab-eef9d8cbb2d1.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -14069,7 +14069,7 @@
         },
         {
             "id": "937057f8-97d2-5d56-b98f-37066a712e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78398af-06b7-41f8-8aaa-81800f490121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78398af-06b7-41f8-8aaa-81800f490121.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -14103,7 +14103,7 @@
         },
         {
             "id": "91c5d98b-ebd9-5b94-aed1-699af9c76de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0961cc70-6069-41b1-8fd4-befc4efa5143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0961cc70-6069-41b1-8fd4-befc4efa5143.jpg?1",
             "name": "Gemstone Mine",
             "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color. If there are no mining counters on Gemstone Mine, sacrifice it.",
             "colours": [],
@@ -14134,7 +14134,7 @@
         },
         {
             "id": "7f487c88-6c7c-5d02-8c79-200e3d8004ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0678705f-708e-44ab-9e85-76df13bea694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0678705f-708e-44ab-9e85-76df13bea694.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -14167,7 +14167,7 @@
         },
         {
             "id": "6e5bce18-5599-5bd3-a6b2-27446adb960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc6c906-9013-4840-9cda-d85ad72c04b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc6c906-9013-4840-9cda-d85ad72c04b0.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -14200,7 +14200,7 @@
         },
         {
             "id": "ee9ad085-db2f-502e-ad27-e6dbb612d9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202554-88a7-4b7f-b20f-d034997dbd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202554-88a7-4b7f-b20f-d034997dbd02.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -14231,7 +14231,7 @@
         },
         {
             "id": "bbddf23f-a602-57d9-9d31-64117c470b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88a1690-111e-4e8f-a896-890e793e8a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88a1690-111e-4e8f-a896-890e793e8a9f.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -14261,7 +14261,7 @@
         },
         {
             "id": "7d062993-dd76-5daf-8256-ae68fe4cbbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4ee66c-1c3f-4ece-8c0a-4f0c259c5142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4ee66c-1c3f-4ece-8c0a-4f0c259c5142.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "e8a49df9-745a-5968-ae52-2bab05e652b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16761d3b-3507-47ee-acff-54b426164d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16761d3b-3507-47ee-acff-54b426164d89.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -14327,7 +14327,7 @@
         },
         {
             "id": "51fbfb6f-cd05-516d-8999-ffa04f1bcb70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac23c5e-a489-4fba-b14f-a968b202ac22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac23c5e-a489-4fba-b14f-a968b202ac22.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14363,7 +14363,7 @@
         },
         {
             "id": "ddd119ae-4ef2-5200-bdde-7a68009bc010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8b581b-5177-4cea-8021-42f4d21583ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8b581b-5177-4cea-8021-42f4d21583ad.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14399,7 +14399,7 @@
         },
         {
             "id": "42be320c-9b10-5d4b-82ad-7525ea8fe8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c4ab8b-9f84-4b92-a114-93b082c15080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c4ab8b-9f84-4b92-a114-93b082c15080.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14435,7 +14435,7 @@
         },
         {
             "id": "f2073f3f-90e7-592a-b658-2b069274872d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0473605a-6c6a-433e-b828-933544472a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0473605a-6c6a-433e-b828-933544472a3d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14471,7 +14471,7 @@
         },
         {
             "id": "9d1f23ee-5502-5edc-a0ea-2eb726ff0589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cf978-7492-4bf9-9b20-a91c21008841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cf978-7492-4bf9-9b20-a91c21008841.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14507,7 +14507,7 @@
         },
         {
             "id": "7b21647a-c516-5e08-9a5e-58a1d9492331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c46b9a-07ea-40ab-9a2b-5bee8e7d3496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c46b9a-07ea-40ab-9a2b-5bee8e7d3496.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14543,7 +14543,7 @@
         },
         {
             "id": "e9c147d3-7034-52db-ba75-b4f57058f8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad7ef0-101c-436e-a41a-cdc8e91d2f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad7ef0-101c-436e-a41a-cdc8e91d2f2a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14579,7 +14579,7 @@
         },
         {
             "id": "cdf2570d-8f01-52fb-a24c-82b3be4183ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5fb3d-2c9e-4cdb-a202-ad5955eae42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5fb3d-2c9e-4cdb-a202-ad5955eae42c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14615,7 +14615,7 @@
         },
         {
             "id": "eca9c920-3e02-5e39-baf6-29cbf64104d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941546b8-8540-40dd-bacc-9b11f3d63033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941546b8-8540-40dd-bacc-9b11f3d63033.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14651,7 +14651,7 @@
         },
         {
             "id": "b2c70ad6-1914-54b6-928d-f39cc1188413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae0bd2b-6875-4823-b596-f5c7c0a0809e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae0bd2b-6875-4823-b596-f5c7c0a0809e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14687,7 +14687,7 @@
         },
         {
             "id": "bd8dcfc3-f5e4-5c44-9ac1-360ef38003fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f690bd2a-e565-4316-8312-3d0386c8ba36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f690bd2a-e565-4316-8312-3d0386c8ba36.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -14722,7 +14722,7 @@
         },
         {
             "id": "df0999ba-c2d2-5d94-aac7-13caa635a1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44899568-7aac-47ae-9f7d-b5414f65625b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44899568-7aac-47ae-9f7d-b5414f65625b.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -14761,7 +14761,7 @@
         },
         {
             "id": "17f52524-e247-5cc4-9561-b5541d60480a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5bfae8-f789-445e-bc60-a4eead19caec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5bfae8-f789-445e-bc60-a4eead19caec.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "b098029d-5f68-5a72-9ef2-2c83ffe09e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6939e631-91b7-4d58-b15d-ae588e73259c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6939e631-91b7-4d58-b15d-ae588e73259c.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "7bb5fdc0-961e-5ee8-9bb0-2d81eee99541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b24aeb-afba-4215-bf3e-61e581eb412c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b24aeb-afba-4215-bf3e-61e581eb412c.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -14868,7 +14868,7 @@
         },
         {
             "id": "4315d483-782d-5c7c-85b5-5c08c55c7bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd2427a-9b63-4345-af20-46e2f530bab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd2427a-9b63-4345-af20-46e2f530bab0.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep enters the battlefield, return each other creature you control to its owner's hand.",
             "colours": [
@@ -14905,7 +14905,7 @@
         },
         {
             "id": "31d0c9be-88e5-5d51-ac06-5b8844c0a357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7b0e29-09d9-4b3e-ab94-f1f4a61d9159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7b0e29-09d9-4b3e-ab94-f1f4a61d9159.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -14940,7 +14940,7 @@
         },
         {
             "id": "62418702-e99e-56fe-b679-d5f138388ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2400cc-987b-49de-8ac7-3d4b12c4200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2400cc-987b-49de-8ac7-3d4b12c4200a.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, whenever a player taps an Island for mana, that player adds an additional {U}.",
             "colours": [
@@ -14975,7 +14975,7 @@
         },
         {
             "id": "c1faaac4-1f2c-5cd3-ac49-0249f4a06edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff393aab-0b02-496c-97df-0ffa0f8b1ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff393aab-0b02-496c-97df-0ffa0f8b1ec9.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative upkeep {1} (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhenever an opponent casts a noncreature spell, you may draw a card unless that player pays {4}.",
             "colours": [
@@ -15010,7 +15010,7 @@
         },
         {
             "id": "380609c6-a4c2-5972-a00a-256d2f95520a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000a5154-90ba-459e-b122-d6893dfdb56f.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -15045,7 +15045,7 @@
         },
         {
             "id": "5ac81cb7-cc4e-59b1-9de3-fb7600ff4fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8318aa5-6a08-4e92-afae-ff07a3f0ae5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8318aa5-6a08-4e92-afae-ff07a3f0ae5e.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -15080,7 +15080,7 @@
         },
         {
             "id": "f9fad058-2af3-5ba7-9cf4-6a8b875b4150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e626cc-b01a-4e20-9414-8ba6347041f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e626cc-b01a-4e20-9414-8ba6347041f0.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -15120,7 +15120,7 @@
         },
         {
             "id": "f72a5d05-102d-563e-ae1a-3aa746663106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46958867-db3b-416f-afc5-fbf241c29b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46958867-db3b-416f-afc5-fbf241c29b7d.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\n{B}{B}{B}, Pay 3 life: Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types.\nWhen Chainer, Dementia Master leaves the battlefield, exile all Nightmares.",
             "colours": [
@@ -15160,7 +15160,7 @@
         },
         {
             "id": "bd6273a0-c7a6-5c74-aa6e-3cb1e98ee7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1962-f4ad-4d76-a00a-f363e102018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1962-f4ad-4d76-a00a-f363e102018e.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B}",
             "colours": [
@@ -15195,7 +15195,7 @@
         },
         {
             "id": "3af33503-8788-5882-9b6d-dc824196acf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baede1c0-5bd0-4a3b-af3c-32fbb14033e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baede1c0-5bd0-4a3b-af3c-32fbb14033e8.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -15230,7 +15230,7 @@
         },
         {
             "id": "6cbae0a3-f0d6-504f-bb3f-fb3e1e36e33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7295eb82-8785-4a5f-ba64-0a0b5cb77d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7295eb82-8785-4a5f-ba64-0a0b5cb77d3f.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature deals damage to you, destroy it.",
             "colours": [
@@ -15265,7 +15265,7 @@
         },
         {
             "id": "a92cb3c1-4c26-5e17-a300-249000777826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29220f44-aa0f-4819-8873-c7a313a8d159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29220f44-aa0f-4819-8873-c7a313a8d159.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15300,7 +15300,7 @@
         },
         {
             "id": "80854bfe-9e54-5bcd-ae96-79a42fc7615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d645f8b-8aad-4633-b021-dc8ed870d8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d645f8b-8aad-4633-b021-dc8ed870d8e8.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life.",
             "colours": [
@@ -15337,7 +15337,7 @@
         },
         {
             "id": "1b0c00d2-fe86-5062-a86b-559e91282f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c04bbbe-cae0-4ac5-8bd3-ecc95a2b6bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c04bbbe-cae0-4ac5-8bd3-ecc95a2b6bd8.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
             "colours": [
@@ -15372,7 +15372,7 @@
         },
         {
             "id": "ba55edb1-c9c2-5f74-b7a1-27853b0e84ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed98e1-898b-494b-a27d-7c1ab28cd9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed98e1-898b-494b-a27d-7c1ab28cd9f1.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate.",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "edbfee1a-7405-5e46-9f07-837bfb3e3231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150047e1-32f8-4aff-b311-0f6d58ce36fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150047e1-32f8-4aff-b311-0f6d58ce36fe.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -15449,7 +15449,7 @@
         },
         {
             "id": "173af9fe-dc10-5cd4-8d22-51957758dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bc7576-233f-4267-9943-d831a5b2c233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bc7576-233f-4267-9943-d831a5b2c233.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle.",
             "colours": [
@@ -15484,7 +15484,7 @@
         },
         {
             "id": "e63064fa-1153-5b5d-bd85-2beb0dc8a068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ae5aec-1341-439b-aae7-83cb69e8c1d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ae5aec-1341-439b-aae7-83cb69e8c1d4.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -15522,7 +15522,7 @@
         },
         {
             "id": "a2bc1345-85a5-5d01-93e1-0db3bc0ff96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c76b986-30e5-440c-a30c-ef3d77cace1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c76b986-30e5-440c-a30c-ef3d77cace1e.jpg?1",
             "name": "Last Chance",
             "text": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -15557,7 +15557,7 @@
         },
         {
             "id": "e0137a81-cf7c-5c54-8b79-0ca060b4a607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf33009-b795-4097-a77c-08be7dce90cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf33009-b795-4097-a77c-08be7dce90cc.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -15594,7 +15594,7 @@
         },
         {
             "id": "25194d6a-653b-5b03-878e-8076ea5268cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3b30d4-5f8b-40fe-b446-b929a1b1e368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3b30d4-5f8b-40fe-b446-b929a1b1e368.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -15632,7 +15632,7 @@
         },
         {
             "id": "3a4be5ec-853e-5e93-be2d-5ad91080f2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a834bdb8-6c4f-4ca4-a097-27411d66e797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a834bdb8-6c4f-4ca4-a097-27411d66e797.jpg?1",
             "name": "Arboria",
             "text": "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn.",
             "colours": [
@@ -15669,7 +15669,7 @@
         },
         {
             "id": "16fbfae8-7318-53a6-8832-d8e4a3f218f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0e2b-1ff1-494a-8bc9-9741d6bb5590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0e2b-1ff1-494a-8bc9-9741d6bb5590.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [
@@ -15706,7 +15706,7 @@
         },
         {
             "id": "7acca04c-a4ea-59f3-a224-6a8c967993a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61af26f-bab1-412d-8849-0d7c3c304950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61af26f-bab1-412d-8849-0d7c3c304950.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may create a 1/1 green Squirrel creature token.\nThreshold \u2014 All Squirrels get +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -15744,7 +15744,7 @@
         },
         {
             "id": "a1f0f828-e954-593f-9e36-e7c2fdcd9ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49129453-1fe8-47de-b6aa-5b92d3d74c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49129453-1fe8-47de-b6aa-5b92d3d74c99.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -15779,7 +15779,7 @@
         },
         {
             "id": "125c584f-69c7-5901-a523-de932ccf0556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4d0a8-3270-4e53-9f1d-90f995c3b712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b4d0a8-3270-4e53-9f1d-90f995c3b712.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card, reveal it, then shuffle and put the card on top.",
             "colours": [
@@ -15814,7 +15814,7 @@
         },
         {
             "id": "19fecd5b-3615-5eb1-a3a5-36468a6ee114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a7ff06-32b7-48cd-99bb-a91f7f43538d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a7ff06-32b7-48cd-99bb-a91f7f43538d.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "03fee19a-dbbc-5ba6-93b9-ac5a49178811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3fc84d-dbae-40a2-bb95-abedbc83c0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3fc84d-dbae-40a2-bb95-abedbc83c0cd.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -15888,7 +15888,7 @@
         },
         {
             "id": "64f1b70c-28ba-5b93-a172-05f321a075e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea268a6-cf0a-4912-b1eb-47a99ff8c10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea268a6-cf0a-4912-b1eb-47a99ff8c10e.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Hunting Grounds has \"Whenever an opponent casts a spell, you may put a creature card from your hand onto the battlefield.\"",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "f14f0cc9-7ac2-58e5-ad33-e88da076d77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6accaee3-8941-4409-bc1e-46a5b653d411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6accaee3-8941-4409-bc1e-46a5b653d411.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -15967,7 +15967,7 @@
         },
         {
             "id": "2d98ac8a-7141-53fa-b7e2-77d52131cacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b98e9c2-8843-4b59-828c-af54e1628e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b98e9c2-8843-4b59-828c-af54e1628e98.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -15998,7 +15998,7 @@
         },
         {
             "id": "ab1410e8-3e98-546e-aa57-22c392df7c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b94aed3-a5c0-4573-a6d5-29a04ac522b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b94aed3-a5c0-4573-a6d5-29a04ac522b2.jpg?1",
             "name": "Helm of Awakening",
             "text": "Spells cost {1} less to cast.",
             "colours": [],
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "100ab5d8-7290-528e-aa73-c1d3ab5b6976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffa2589-006a-4f60-a7e9-3a1e00d8fa91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffa2589-006a-4f60-a7e9-3a1e00d8fa91.jpg?1",
             "name": "Jester's Cap",
             "text": "{2}, {T}, Sacrifice Jester's Cap: Search target player's library for three cards and exile them. Then that player shuffles.",
             "colours": [],
@@ -16060,7 +16060,7 @@
         },
         {
             "id": "09727967-aaa9-5e58-b34d-810f8d7fa054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbecc305-a35a-47b2-a825-f48ce1171b79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbecc305-a35a-47b2-a825-f48ce1171b79.jpg?1",
             "name": "Legacy Weapon",
             "text": "{W}{U}{B}{R}{G}: Exile target permanent.\nIf Legacy Weapon would be put into a graveyard from anywhere, reveal Legacy Weapon and shuffle it into its owner's library instead.",
             "colours": [],
@@ -16099,7 +16099,7 @@
         },
         {
             "id": "cbb5ea00-3943-50f5-94fa-3ca9d6636ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45d36d0-7706-4e36-a5ed-d32c22c67eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45d36d0-7706-4e36-a5ed-d32c22c67eae.jpg?1",
             "name": "Lotus Blossom",
             "text": "At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.\n{T}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.",
             "colours": [],
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "1cbf352c-293c-5bef-be06-347651ede58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3e03a3-0082-4d4e-8891-8c8dcc8f1cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3e03a3-0082-4d4e-8891-8c8dcc8f1cbf.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -16164,7 +16164,7 @@
         },
         {
             "id": "79196b53-0f9f-516b-856c-b8f25d34f724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87830ee-c6b9-4c68-bc04-74987b03858d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87830ee-c6b9-4c68-bc04-74987b03858d.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -16195,7 +16195,7 @@
         },
         {
             "id": "80cd91fb-bb57-5d78-8378-01d0b7a3d926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ebe92-1ea2-4bfa-8464-851b808fef0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ebe92-1ea2-4bfa-8464-851b808fef0b.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -16229,7 +16229,7 @@
         },
         {
             "id": "2570050e-59de-532e-85c2-ad9f5e84081f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65b459e-2756-4f66-b80d-4bdc1c1c9bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65b459e-2756-4f66-b80d-4bdc1c1c9bae.jpg?1",
             "name": "Gemstone Mine",
             "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color. If there are no mining counters on Gemstone Mine, sacrifice it.",
             "colours": [],
@@ -16260,7 +16260,7 @@
         },
         {
             "id": "57153149-5207-5b42-8f71-8527d606e0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286bd95-0d8e-4b1a-b319-052fe2ae1951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286bd95-0d8e-4b1a-b319-052fe2ae1951.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -16291,7 +16291,7 @@
         },
         {
             "id": "b9deb2bb-c641-54a1-b5f5-5eedfe2a2f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b73577a-8ca1-41d7-9b2b-7300286fde43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b73577a-8ca1-41d7-9b2b-7300286fde43.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -16325,7 +16325,7 @@
         },
         {
             "id": "3375837a-9a31-52fe-9903-1fcf6bf2236a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fdde92-dc2c-4ed0-b092-926ef9c091ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fdde92-dc2c-4ed0-b092-926ef9c091ad.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16360,7 +16360,7 @@
         },
         {
             "id": "4413b219-26dc-51cc-8f16-20bac10a1052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeea28b-c11b-4fa0-a64c-637bc58171cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeea28b-c11b-4fa0-a64c-637bc58171cc.jpg?1",
             "name": "Griffin",
             "text": "",
             "colours": [
@@ -16395,7 +16395,7 @@
         },
         {
             "id": "0f3003cf-a33a-5216-8b38-469f62b51d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a61555-ddb9-4d55-b637-a219d772033d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a61555-ddb9-4d55-b637-a219d772033d.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16430,7 +16430,7 @@
         },
         {
             "id": "e2eaae22-fda0-5aa8-99a9-70df43af1258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34db5e62-4792-4207-b008-7d62bae683a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34db5e62-4792-4207-b008-7d62bae683a7.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -16467,7 +16467,7 @@
         },
         {
             "id": "58d92f0f-82b7-5d95-9f0c-2205689ffae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700cb99-1cee-455f-9a36-d7d9a79fed06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700cb99-1cee-455f-9a36-d7d9a79fed06.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -16502,7 +16502,7 @@
         },
         {
             "id": "097997f7-05b7-5199-9b99-54cca98c6d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae1be7-f2f6-4aef-8764-4af5ca963c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae1be7-f2f6-4aef-8764-4af5ca963c9e.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16537,7 +16537,7 @@
         },
         {
             "id": "a82aa998-5fbf-5125-ac16-b9d57f944875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8316a-ec6d-43de-a1c5-6ef3c5c53146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8316a-ec6d-43de-a1c5-6ef3c5c53146.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16572,7 +16572,7 @@
         },
         {
             "id": "196e0c7e-1e9d-5995-8b94-28ce63b5cdcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b58d5f-8a9f-4fd6-83d6-efe3a92e89b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b58d5f-8a9f-4fd6-83d6-efe3a92e89b2.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16607,7 +16607,7 @@
         },
         {
             "id": "ed4b719a-b918-59b4-ba00-ecf427f0643f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05000b-0ac3-4856-b25d-c87c19bda451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05000b-0ac3-4856-b25d-c87c19bda451.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -16642,7 +16642,7 @@
         },
         {
             "id": "74c9115b-2802-5edb-939e-fd3d82713790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662eefb-c454-44b9-8270-f2229e20024e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662eefb-c454-44b9-8270-f2229e20024e.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16677,7 +16677,7 @@
         },
         {
             "id": "77dd8f14-31ba-5a86-9c5e-c93a4b7ca682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb00e4-7eb0-4f7d-b2c3-8995959a6e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb00e4-7eb0-4f7d-b2c3-8995959a6e6a.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -16712,7 +16712,7 @@
         },
         {
             "id": "0c552176-fe45-5ad4-91e6-c810444fa78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acb4442-e7e5-482b-9ce8-f1af8069114e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acb4442-e7e5-482b-9ce8-f1af8069114e.jpg?1",
             "name": "Sheep",
             "text": "",
             "colours": [
@@ -16747,7 +16747,7 @@
         },
         {
             "id": "65bd5d1c-a5cf-5b9f-b5c6-671338f887e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ccb9-32b2-4562-a60f-843e82795984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ccb9-32b2-4562-a60f-843e82795984.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -16782,7 +16782,7 @@
         },
         {
             "id": "3df82ae6-2a99-52b1-a4da-a34ae0c882a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1fd1a-9c1e-4b01-974e-84f18d325cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1fd1a-9c1e-4b01-974e-84f18d325cfc.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DMU.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DMU.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c55d896f-66d1-5e26-ac69-049d5d996a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83b1b87-01d5-4624-8a2b-4b771e13e59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83b1b87-01d5-4624-8a2b-4b771e13e59c.jpg?1",
             "name": "Karn, Living Legacy",
             "text": "+1: Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n\u22121: Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Tap an untapped artifact you control: This emblem deals 1 damage to any target.\"",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "77c57a1e-026b-5304-9f6d-c3ca7bfb368d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8127b5-3a65-411a-84bc-54e5c1be1477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8127b5-3a65-411a-84bc-54e5c1be1477.jpg?1",
             "name": "Anointed Peacekeeper",
             "text": "Vigilance\nAs Anointed Peacekeeper enters the battlefield, look at an opponent's hand, then choose any card name.\nSpells your opponents cast with the chosen name cost {2} more to cast.\nActivated abilities of sources with the chosen name cost {2} more to activate unless they're mana abilities.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "4615643e-64a9-5a0d-8da1-c0edfb4ae291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d00bab2-e95d-4296-a805-2a05e7640efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d00bab2-e95d-4296-a805-2a05e7640efb.jpg?1",
             "name": "Archangel of Wrath",
             "text": "Kicker {B} and/or {R} (You may pay an additional {B} and/or {R} as you cast this spell.)\nFlying, lifelink\nWhen Archangel of Wrath enters the battlefield, if it was kicked, it deals 2 damage to any target.\nWhen Archangel of Wrath enters the battlefield, if it was kicked twice, it deals 2 damage to any target.",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "70e7b490-3f26-58c3-878d-ae20f345121a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57746e72-ba9f-4717-a4a2-6c6a039080c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57746e72-ba9f-4717-a4a2-6c6a039080c3.jpg?1",
             "name": "Argivian Cavalier",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhen Argivian Cavalier enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "cd9efe31-9150-5501-b355-450324c03ea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbadc37-1b4f-4237-a3c0-772bafb18aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbadc37-1b4f-4237-a3c0-772bafb18aa0.jpg?1",
             "name": "Argivian Phalanx",
             "text": "This spell costs {1} less to cast for each creature you control.\nVigilance",
             "colours": [
@@ -184,7 +184,7 @@
         },
         {
             "id": "db0b6377-ae7d-5bf7-b50b-33c74ebd8b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d7293-657f-48ac-931b-fb6a44128e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4d7293-657f-48ac-931b-fb6a44128e6d.jpg?1",
             "name": "Artillery Blast",
             "text": "Domain \u2014 Artillery Blast deals X damage to target tapped creature, where X is 1 plus the number of basic land types among lands you control.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "247341b0-f5b1-5a3a-bb90-ce3c4850edba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d77df-a899-406f-9d79-e3fa3abeaebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d77df-a899-406f-9d79-e3fa3abeaebc.jpg?1",
             "name": "Benalish Faithbonder",
             "text": "Vigilance\nEnlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "167c4307-d634-5b5a-ae22-097897f3a6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96089ea-20cf-496d-84a6-9b660c2ef672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96089ea-20cf-496d-84a6-9b660c2ef672.jpg?1",
             "name": "Benalish Sleeper",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen Benalish Sleeper enters the battlefield, if it was kicked, each player sacrifices a creature.",
             "colours": [
@@ -288,7 +288,7 @@
         },
         {
             "id": "7c90ec50-e572-514a-9efe-bfc4b58c4c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ed7e0-0e80-44d3-a7af-b4c321239df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ed7e0-0e80-44d3-a7af-b4c321239df8.jpg?1",
             "name": "Captain's Call",
             "text": "Create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "7377a85f-bd4d-56d3-b271-521f3f2cfcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51764fe-0d75-4cfa-a699-0d9e7ffb7843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51764fe-0d75-4cfa-a699-0d9e7ffb7843.jpg?1",
             "name": "Charismatic Vanguard",
             "text": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "d11fa83c-a01a-5005-84e6-40714e85d5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9806370b-51e3-4144-a847-6b367fb937ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9806370b-51e3-4144-a847-6b367fb937ef.jpg?1",
             "name": "Citizen's Arrest",
             "text": "When Citizen's Arrest enters the battlefield, exile target creature or planeswalker an opponent controls until Citizen's Arrest leaves the battlefield.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "7527d6d7-4adc-5818-a4b1-bc4f674bea93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6544a289-3b27-4980-8ed7-22f50ae92c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6544a289-3b27-4980-8ed7-22f50ae92c1a.jpg?1",
             "name": "Cleaving Skyrider",
             "text": "Flash\nKicker {2}{R} (You may pay an additional {2}{R} as you cast this spell.)\nFlying\nWhen Cleaving Skyrider enters the battlefield, if it was kicked, it deals X damage to any target, where X is the number of attacking creatures.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "a52e5e51-98ae-5d07-b5ff-629c8d249ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cb79c-163d-4b36-bd93-954eca8fe26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037cb79c-163d-4b36-bd93-954eca8fe26e.jpg?1",
             "name": "Clockwork Drawbridge",
             "text": "Defender\n{2}{W}, {T}: Tap target creature.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "58ec0539-39fe-5002-814b-c38aa6e1d3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12da45-aff4-406d-83a3-39ecaff6ff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12da45-aff4-406d-83a3-39ecaff6ff56.jpg?1",
             "name": "Coalition Skyknight",
             "text": "Flying\nEnlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "6f933a66-8049-564c-adda-9d04d22b68b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845e5663-2959-44ae-b4c6-d6ea41f01d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845e5663-2959-44ae-b4c6-d6ea41f01d6e.jpg?1",
             "name": "Danitha, Benalia's Hope",
             "text": "First strike, vigilance, lifelink\nWhen Danitha, Benalia's Hope enters the battlefield, you may put an Aura or Equipment card from your hand or graveyard onto the battlefield attached to Danitha.",
             "colours": [
@@ -533,7 +533,7 @@
         },
         {
             "id": "77403f19-61f2-55db-87fd-a93eb5671d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfe404d-1a27-4627-9284-56188d92d5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfe404d-1a27-4627-9284-56188d92d5d5.jpg?1",
             "name": "Defiler of Faith",
             "text": "Vigilance\nAs an additional cost to cast white permanent spells, you may pay 2 life. Those spells cost {W} less to cast if you paid life this way. This effect reduces only the amount of white mana you pay.\nWhenever you cast a white permanent spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -570,7 +570,7 @@
         },
         {
             "id": "c2d03344-53f6-511f-8299-64e8c8c5f823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7862ef-2c8d-4d28-9e50-7cc41861f245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7862ef-2c8d-4d28-9e50-7cc41861f245.jpg?1",
             "name": "Destroy Evil",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with toughness 4 or greater.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "74d0d38f-8276-58de-95ea-a471a7b35a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d1d701-841c-4bf3-9122-b01842a22ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d1d701-841c-4bf3-9122-b01842a22ac6.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -636,7 +636,7 @@
         },
         {
             "id": "b0e7e1c5-d5ae-566e-a489-0750d039b677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da76ee-fec3-4b2e-915d-10cf8d518d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da76ee-fec3-4b2e-915d-10cf8d518d2c.jpg?1",
             "name": "Guardian of New Benalia",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhenever Guardian of New Benalia enlists a creature, scry 2.\nDiscard a card: Guardian of New Benalia gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "0d120cd9-e2b2-5f6f-a4ff-6672ded79d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aab611c-64e0-4b38-97b9-b29a1c6a79b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aab611c-64e0-4b38-97b9-b29a1c6a79b7.jpg?1",
             "name": "Heroic Charge",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nCreatures you control get +2/+1 until end of turn. If this spell was kicked, those creatures also gain trample until end of turn.",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "f04462f9-cb41-5aba-bbc4-d6a443e7f95b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dce5e7-c864-4239-bab7-af6a3adcb731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dce5e7-c864-4239-bab7-af6a3adcb731.jpg?1",
             "name": "Join Forces",
             "text": "Untap up to two target creatures. They each get +2/+2 until end of turn.",
             "colours": [
@@ -738,7 +738,7 @@
         },
         {
             "id": "96377cf8-c0d7-5d23-8233-7e6c5471cf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56cf82f-8bbb-49ae-ad93-291cbec9126e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56cf82f-8bbb-49ae-ad93-291cbec9126e.jpg?1",
             "name": "Juniper Order Rootweaver",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nWhen Juniper Order Rootweaver enters the battlefield, if it was kicked, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "e5e80711-3836-5081-8000-5199f08b2309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c7a54e-4df6-4745-8bae-aeefda934d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c7a54e-4df6-4745-8bae-aeefda934d82.jpg?1",
             "name": "Knight of Dawn's Light",
             "text": "First strike\nIf you would gain life, you gain that much life plus 1 instead.\n{1}{W}: Knight of Dawn's Light gets +1/+1 until end of turn.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "ed16b24f-2e06-55e1-85a8-06abae69424b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3ac3dd-35db-447f-8674-37b4680a1ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3ac3dd-35db-447f-8674-37b4680a1ef7.jpg?1",
             "name": "Leyline Binding",
             "text": "Flash\nDomain \u2014 This spell costs {1} less to cast for each basic land type among lands you control.\nWhen Leyline Binding enters the battlefield, exile target nonland permanent an opponent controls until Leyline Binding leaves the battlefield.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "73e33c97-d77d-5023-8265-4fa7f48df847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e08d288-2f09-4856-a9ed-cc8aa8d953d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e08d288-2f09-4856-a9ed-cc8aa8d953d7.jpg?1",
             "name": "Love Song of Night and Day",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You and target opponent each draw two cards.\nII \u2014 Create a 1/1 white Bird creature token with flying.\nIII \u2014 Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "e492e6bb-f0a7-5ff4-b9bf-d317108c003a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeec740-7ffc-4f57-b52c-92209da91d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeec740-7ffc-4f57-b52c-92209da91d69.jpg?1",
             "name": "Mesa Cavalier",
             "text": "Flying\nWhen Mesa Cavalier enters the battlefield, you gain 2 life.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "7524bc19-2a3b-5bd8-8e4a-4fe367787c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f22fcfa-a5f0-4fae-b578-cdfd7d46a4c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f22fcfa-a5f0-4fae-b578-cdfd7d46a4c8.jpg?1",
             "name": "Phyrexian Missionary",
             "text": "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nLifelink\nWhen Phyrexian Missionary enters the battlefield, if it was kicked, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "f8c05897-9041-5574-a02d-5cfb15da3625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322f90b6-6b49-458d-9d5b-b601bfdd0af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322f90b6-6b49-458d-9d5b-b601bfdd0af8.jpg?1",
             "name": "Prayer of Binding",
             "text": "Flash\nWhen Prayer of Binding enters the battlefield, exile up to one target nonland permanent an opponent controls until Prayer of Binding leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "c886886a-810c-5a5a-a8bd-7a6d4b152c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e11ad33-b9d7-43ef-840a-61955683b599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e11ad33-b9d7-43ef-840a-61955683b599.jpg?1",
             "name": "Resolute Reinforcements",
             "text": "Flash\nWhen Resolute Reinforcements enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "a44434e3-fab9-5ce5-a979-74b887aa3d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54413be-7d73-478d-a25a-8fe06f6491a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54413be-7d73-478d-a25a-8fe06f6491a5.jpg?1",
             "name": "Runic Shot",
             "text": "Kicker {U} (You may pay an additional {U} as you cast this spell.)\nDestroy target tapped creature. If this spell was kicked, scry 2.",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "d5ff4cfb-3d38-5261-abd1-42ac1530e157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409189da-53c9-4daf-b6b2-d155fc14f91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409189da-53c9-4daf-b6b2-d155fc14f91a.jpg?1",
             "name": "Samite Herbalist",
             "text": "Whenever Samite Herbalist becomes tapped, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "902d10c4-03fa-59b9-ad5d-46ce3898e3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce295f1e-fb31-4275-a5d3-8c6f29afff40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce295f1e-fb31-4275-a5d3-8c6f29afff40.jpg?1",
             "name": "Serra Paragon",
             "text": "Flying\nOnce during each of your turns, you may play a land from your graveyard or cast a permanent spell with mana value 3 or less from your graveyard. If you do, it gains \"When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life.\"",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "56700267-e56f-54f5-9558-31ffd2c75ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39996722-e7f2-41e4-aa1e-2b6778d7b535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39996722-e7f2-41e4-aa1e-2b6778d7b535.jpg?1",
             "name": "Shalai's Acolyte",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nFlying\nIf Shalai's Acolyte was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "a674349e-fe46-57f8-be5e-a60c66864337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346defa-ee4a-404e-8154-0e33ebe9102c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346defa-ee4a-404e-8154-0e33ebe9102c.jpg?1",
             "name": "Stall for Time",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nTap up to two target creatures. If this spell was kicked, put a stun counter on each of those creatures. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nDraw a card.",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "c68e07dc-166f-5e70-9823-f040a0626e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851e842e-a497-4c36-90ee-8d64f806c378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851e842e-a497-4c36-90ee-8d64f806c378.jpg?1",
             "name": "Take Up the Shield",
             "text": "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "1252c2e5-5728-5057-b5e7-2299260b8492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b3088f-7b49-45e9-b447-129a597ceb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b3088f-7b49-45e9-b447-129a597ceb75.jpg?1",
             "name": "Temporary Lockdown",
             "text": "When Temporary Lockdown enters the battlefield, exile each nonland permanent with mana value 2 or less until Temporary Lockdown leaves the battlefield.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "d8031971-fd92-50bc-809c-c21ac9397daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a544d7-ead7-42fd-a35a-c1b672771d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a544d7-ead7-42fd-a35a-c1b672771d5b.jpg?1",
             "name": "Urza Assembles the Titans",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Scry 4, then you may reveal the top card of your library. If a planeswalker card is revealed this way, put it into your hand.\nII \u2014 You may put a planeswalker card with mana value 6 or less from your hand onto the battlefield.\nIII \u2014 You may activate the loyalty abilities of planeswalkers you control twice this turn rather than only once.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "a2d1a644-479c-5974-8b63-9bf88c489d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b1a4ee-437f-4a08-b176-8342d526143f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b1a4ee-437f-4a08-b176-8342d526143f.jpg?1",
             "name": "Valiant Veteran",
             "text": "Other Soldiers you control get +1/+1.\n{3}{W}{W}, Exile Valiant Veteran from your graveyard: Put a +1/+1 counter on each Soldier you control.",
             "colours": [
@@ -1327,7 +1327,7 @@
         },
         {
             "id": "4aeb1490-7fe3-5b2c-ab0c-6ffd8816d42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5800f3d-b2e0-4c74-94bf-f29b27f82130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5800f3d-b2e0-4c74-94bf-f29b27f82130.jpg?1",
             "name": "Wingmantle Chaplain",
             "text": "Defender\nWhen Wingmantle Chaplain enters the battlefield, create a 1/1 white Bird creature token with flying for each creature with defender you control.\nWhenever another creature with defender enters the battlefield under your control, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "d4a2c823-c95b-5bf1-b30c-958b73244f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fca4c4f-a77b-483e-9da4-574ba2e3d179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fca4c4f-a77b-483e-9da4-574ba2e3d179.jpg?1",
             "name": "Academy Loremaster",
             "text": "At the beginning of each player's draw step, that player may draw an additional card. If they do, spells they cast this turn cost {2} more to cast.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "8ff06a3c-b956-5f31-8df6-6ec20c57d72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2028115-f0de-4e8b-99bc-7369352e1e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2028115-f0de-4e8b-99bc-7369352e1e07.jpg?1",
             "name": "Academy Wall",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "5029812a-03c4-5e9d-a171-b89ba78207e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60afeb75-2c1e-4634-8c83-88b1dddb77c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60afeb75-2c1e-4634-8c83-88b1dddb77c2.jpg?1",
             "name": "Aether Channeler",
             "text": "When Aether Channeler enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 white Bird creature token with flying.\n\u2022 Return another target nonland permanent to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "cd16d4c5-ee04-5e30-8818-cf9e82cf34a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000376ef-8b6c-490d-98cb-d6de15b2e585.jpg?1",
             "name": "Battlewing Mystic",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nFlying\nWhen Battlewing Mystic enters the battlefield, if it was kicked, discard your hand, then draw two cards.",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "ea0bf2ff-e4f0-56ab-8658-a9ca13671148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44738c-706f-40b2-a09d-b21cd0889049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44738c-706f-40b2-a09d-b21cd0889049.jpg?1",
             "name": "Combat Research",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, draw a card.\"\nAs long as enchanted creature is legendary, it gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "e4edb9eb-0487-5400-bc22-06210caf0b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e3882-1f97-48eb-b9e3-2f9683ff5897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0e3882-1f97-48eb-b9e3-2f9683ff5897.jpg?1",
             "name": "Coral Colony",
             "text": "Defender\n{1}{U}, {T}: Target player mills X cards, where X is the number of creatures you control with defender. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "47ab9225-7054-5d17-8b37-3477d7350991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881cc4a3-252b-4155-a34f-63d4b4f44442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881cc4a3-252b-4155-a34f-63d4b4f44442.jpg?1",
             "name": "Defiler of Dreams",
             "text": "Flying\nAs an additional cost to cast blue permanent spells, you may pay 2 life. Those spells cost {U} less to cast if you paid life this way. This effect reduces only the amount of blue mana you pay.\nWhenever you cast a blue permanent spell, draw a card.",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "cde032cf-96a9-5ea9-94f4-8dc30ae3926a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55606da-de3e-4375-925b-cc16b03b6365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55606da-de3e-4375-925b-cc16b03b6365.jpg?1",
             "name": "Djinn of the Fountain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, choose one \u2014\n\u2022 Djinn of the Fountain gets +1/+1 until end of turn.\n\u2022 Exile Djinn of the Fountain. Return it to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Scry 1.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "4b2fa8c4-fd42-50a1-80f3-f848a8105dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6129b0d3-b50a-4a4b-9111-39f8fc6718dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6129b0d3-b50a-4a4b-9111-39f8fc6718dd.jpg?1",
             "name": "Ertai's Scorn",
             "text": "This spell costs {U} less to cast if an opponent cast two or more spells this turn.\nCounter target spell.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "1d7228c1-9f20-50b5-8c93-5589d56e4fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad4441-e300-4267-bedb-4ae6a64f59cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad4441-e300-4267-bedb-4ae6a64f59cd.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "8059c4c4-825f-560f-88ec-2caab2ab3079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d841faa-9e0b-45ff-9dfd-f8a169d9af76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d841faa-9e0b-45ff-9dfd-f8a169d9af76.jpg?1",
             "name": "Founding the Third Path",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You may cast an instant or sorcery spell with mana value 1 or 2 from your hand without paying its mana cost.\nII \u2014 Target player mills four cards.\nIII \u2014 Exile target instant or sorcery card from your graveyard. Copy it. You may cast the copy.",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "a2d504b1-e8cb-5bb8-a6d8-fdb868fa599a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40141353-c0d6-4529-b26a-34dfccbcf231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40141353-c0d6-4529-b26a-34dfccbcf231.jpg?1",
             "name": "Frostfist Strider",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Frostfist Strider enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "1f8955a0-3406-5d6c-a7ee-bbaf446efc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35095a68-b7c0-4805-b0b6-6ca15a338692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35095a68-b7c0-4805-b0b6-6ca15a338692.jpg?1",
             "name": "Haughty Djinn",
             "text": "Flying\nHaughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "8aae24ec-32e1-542d-97be-d027c0e26b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14b07ea-18e4-41fb-8136-759d5349e88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14b07ea-18e4-41fb-8136-759d5349e88a.jpg?1",
             "name": "Haunting Figment",
             "text": "Vigilance\nHaunting Figment can't be blocked as long as you've cast an instant or sorcery spell this turn.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "f4abebf3-6ef3-5e03-9f67-2af3287ed4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259c04f7-86f2-4584-97fb-8278dca9a213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259c04f7-86f2-4584-97fb-8278dca9a213.jpg?1",
             "name": "Impede Momentum",
             "text": "Tap target creature and put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "64c40e9f-024c-5f55-ae43-4da7f2c42321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aec2b2c-0764-4869-814d-aad921122af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aec2b2c-0764-4869-814d-aad921122af9.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1912,7 +1912,7 @@
         },
         {
             "id": "7f2ff2ea-4328-5ff7-9d30-f79e82e024a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25ab334-1060-457e-b212-3d7a697c545e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25ab334-1060-457e-b212-3d7a697c545e.jpg?1",
             "name": "Joint Exploration",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nScry 2, then draw a card. If this spell was kicked, you may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -1945,7 +1945,7 @@
         },
         {
             "id": "df06e121-94e3-5107-8ee2-c3badb79e2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21203c8-a935-4ce0-a742-148587e32145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21203c8-a935-4ce0-a742-148587e32145.jpg?1",
             "name": "Micromancer",
             "text": "When Micromancer enters the battlefield, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "66766b66-2524-51ae-b397-91ed7c2b4a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016c6f7-7cb4-46c2-af73-3bd6d682ea5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016c6f7-7cb4-46c2-af73-3bd6d682ea5e.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "b0a93b6d-c2c3-5f67-baf7-ccf7c2667f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770eb6a-4f01-4677-a401-14c1b30692c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0770eb6a-4f01-4677-a401-14c1b30692c9.jpg?1",
             "name": "The Phasing of Zhalfir",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI, II \u2014 Another target nonland permanent phases out. It can't phase in for as long as you control The Phasing of Zhalfir.\nIII \u2014 Destroy all creatures. For each creature destroyed this way, its controller creates a 2/2 black Phyrexian creature token.",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "98293818-1285-5ac7-a5a9-5488cca6bc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b983366-385f-41a3-aa46-20151e68d140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b983366-385f-41a3-aa46-20151e68d140.jpg?1",
             "name": "Phyrexian Espionage",
             "text": "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nDraw two cards. If this spell was kicked, each opponent discards a card.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "f656a571-0fab-58cb-a618-39a6ce62e8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171bfcb2-dd43-4d63-b2e2-6ca594c2ec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171bfcb2-dd43-4d63-b2e2-6ca594c2ec40.jpg?1",
             "name": "Pixie Illusionist",
             "text": "Kicker {3}{G} (You may pay an additional {3}{G} as you cast this spell.)\nFlying\nIf Pixie Illusionist was kicked, it enters the battlefield with two +1/+1 counters on it.\n{T}: Target land you control becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -2117,7 +2117,7 @@
         },
         {
             "id": "f401f2f5-d13e-5f38-a6b7-894877791632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6db604-8bbe-4719-88bd-f3cad8c4725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6db604-8bbe-4719-88bd-f3cad8c4725d.jpg?1",
             "name": "Protect the Negotiators",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nIf this spell was kicked, create a 1/1 white Soldier creature token.\nCounter target spell unless its controller pays {1} for each creature you control.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "fea0f6b4-f86a-5cef-9aff-92bdd8f4d3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96533-f28a-4465-893b-0c9394d5b8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96533-f28a-4465-893b-0c9394d5b8d7.jpg?1",
             "name": "Rona's Vortex",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nReturn target creature or planeswalker you don't control to its owner's hand. If this spell was kicked, put that permanent on the bottom of its owner's library instead.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "3a2e73fb-71b1-56ad-9d1d-169981db6c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d933bf1-14f0-4150-a0d2-6b845b9624cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d933bf1-14f0-4150-a0d2-6b845b9624cf.jpg?1",
             "name": "Shore Up",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. Untap it. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "38f09b3d-55b5-51d7-81d2-4243810aeac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b650ab6-9c22-424f-99e5-8ef5235a18a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b650ab6-9c22-424f-99e5-8ef5235a18a3.jpg?1",
             "name": "Silver Scrutiny",
             "text": "You may cast Silver Scrutiny as though it had flash if X is 3 or less.\nDraw X cards.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "2758d906-f551-5c62-8069-fc7f9ced5914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0979f9-aae3-4fc7-beae-c8c6637ae596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0979f9-aae3-4fc7-beae-c8c6637ae596.jpg?1",
             "name": "Soaring Drake",
             "text": "Flying",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "2a8db1da-eeee-57a3-a7f7-ffa21d13499c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974c9e0c-07b2-4535-a3d0-bb827b651075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974c9e0c-07b2-4535-a3d0-bb827b651075.jpg?1",
             "name": "Sphinx of Clear Skies",
             "text": "Flying, ward {2}\nDomain \u2014 Whenever Sphinx of Clear Skies deals combat damage to a player, reveal the top X cards of your library, where X is the number of basic land types among lands you control. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard. (Piles can be empty.)",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "43b20c58-7366-595a-b846-24930b1f2406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4b9afe-aeb7-4c56-8a22-96e19a7a938c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4b9afe-aeb7-4c56-8a22-96e19a7a938c.jpg?1",
             "name": "Talas Lookout",
             "text": "Flying\nWhen Talas Lookout dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "3e77d8e8-db3b-5ae3-bd5f-0250b672e117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397fb84-8573-4b2c-be2c-f8fd820342f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d397fb84-8573-4b2c-be2c-f8fd820342f0.jpg?1",
             "name": "Tidepool Turtle",
             "text": "{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "1e88c6c8-1e7f-5d5e-9d91-37f398d0fe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017a3c6b-9a1e-403a-9c20-2360090d39ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017a3c6b-9a1e-403a-9c20-2360090d39ee.jpg?1",
             "name": "Timely Interference",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nTarget creature gets -1/-0 until end of turn. If this spell was kicked, that creature blocks this turn if able.\nDraw a card.",
             "colours": [
@@ -2421,7 +2421,7 @@
         },
         {
             "id": "d25a1cfc-c7eb-5028-9951-89e945338164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd5f389-fea2-4aed-a218-eca162902775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd5f389-fea2-4aed-a218-eca162902775.jpg?1",
             "name": "Tolarian Geyser",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nReturn target creature to its owner's hand. Draw a card. If this spell was kicked, you gain 3 life.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "10c88fdc-6c79-5a57-83a2-509a51c74fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01cba-43d4-46ad-b7a5-d7631b0e1347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01cba-43d4-46ad-b7a5-d7631b0e1347.jpg?1",
             "name": "Tolarian Terror",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -2488,7 +2488,7 @@
         },
         {
             "id": "84cc007a-da37-50e5-9c1d-eacb5febf7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2119bc-a377-4156-89d4-56e7b5b494a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2119bc-a377-4156-89d4-56e7b5b494a8.jpg?1",
             "name": "Vesuvan Duplimancy",
             "text": "Whenever you cast a spell that targets only a single artifact or creature you control, create a token that's a copy of that artifact or creature, except it's not legendary.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "49a63af4-8185-5b15-8707-35a68a874585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3cc789-cbb8-4dae-a749-af169832dd7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3cc789-cbb8-4dae-a749-af169832dd7b.jpg?1",
             "name": "Voda Sea Scavenger",
             "text": "Domain \u2014 When Voda Sea Scavenger enters the battlefield, look at the top X cards of your library, where X is the number of basic land types among lands you control. You may put one of those cards on top of your library. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "d6837816-e595-597e-bbf0-d0736de595fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec464dc-b1dd-4e45-b093-c3ad65a74050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec464dc-b1dd-4e45-b093-c3ad65a74050.jpg?1",
             "name": "Vodalian Hexcatcher",
             "text": "Flash\nOther Merfolk you control get +1/+1.\nSacrifice a Merfolk: Counter target noncreature spell unless its controller pays {1}.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "f8032bde-7daa-58d1-857d-8551543cebb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211a9db2-8b5f-419d-8032-ac2a571dbb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211a9db2-8b5f-419d-8032-ac2a571dbb53.jpg?1",
             "name": "Vodalian Mindsinger",
             "text": "Kicker {1}{R} and/or {1}{G}\nVodalian Mindsinger enters the battlefield with two +1/+1 counters on it for each time it was kicked.\nWhen Vodalian Mindsinger enters the battlefield, gain control of target creature with power less than Vodalian Mindsinger's power for as long as you control Vodalian Mindsinger.",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "df28712b-f18e-5147-a161-96ad530b0328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61871b-9295-4ea0-86ef-e7a11e23bda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61871b-9295-4ea0-86ef-e7a11e23bda8.jpg?1",
             "name": "Volshe Tideturner",
             "text": "{T}: Add {U}. Spend this mana only to cast an instant or sorcery spell or a kicked spell.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "6b112088-7ce6-5d94-ba48-864c4652686c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac809fca-664a-4e7d-a39f-2bc1dea0fbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac809fca-664a-4e7d-a39f-2bc1dea0fbd8.jpg?1",
             "name": "Aggressive Sabotage",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTarget player discards two cards. If this spell was kicked, it deals 3 damage to that player.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "4f8ec569-ad9c-544b-87e1-f0d209f80a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365333c4-59a0-4365-b242-a67b6224c1b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365333c4-59a0-4365-b242-a67b6224c1b8.jpg?1",
             "name": "Balduvian Atrocity",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nMenace\nWhen Balduvian Atrocity enters the battlefield, if it was kicked, return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2737,7 +2737,7 @@
         },
         {
             "id": "67160731-f865-519a-92c9-8bf8acb51972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc631b-49d1-4f1c-adac-5b07a2ccd06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc631b-49d1-4f1c-adac-5b07a2ccd06f.jpg?1",
             "name": "Battle-Rage Blessing",
             "text": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "6dee9d1a-7504-57fd-9654-fc2ecedb9b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6b4a2d-0bc0-4a54-9c78-712b48ad6be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6b4a2d-0bc0-4a54-9c78-712b48ad6be1.jpg?1",
             "name": "Battlefly Swarm",
             "text": "Flying\n{B}: Battlefly Swarm gains deathtouch until end of turn.",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "4dd6ad79-f460-50b7-bb3c-70830dd1c483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc2699-03e6-47d1-b976-1453fe9d27b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc2699-03e6-47d1-b976-1453fe9d27b7.jpg?1",
             "name": "Blight Pile",
             "text": "Defender\n{2}{B}, {T}: Each opponent loses X life, where X is the number of creatures with defender you control.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "6183cba4-c188-5829-85e6-1f36e1455fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106b5c96-d1bd-433d-955e-ace0b60d3bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106b5c96-d1bd-433d-955e-ace0b60d3bc3.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "0bf470a2-5d71-5df4-bd0a-d9331d1f791b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff97c69-6a6b-401c-b0a1-55fa81045d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff97c69-6a6b-401c-b0a1-55fa81045d19.jpg?1",
             "name": "Braids, Arisen Nightmare",
             "text": "At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.",
             "colours": [
@@ -2909,7 +2909,7 @@
         },
         {
             "id": "823adee3-3e64-55b7-a02f-5cf65e554765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aa8d4c-04e9-4f38-9786-2c9ad735dd72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aa8d4c-04e9-4f38-9786-2c9ad735dd72.jpg?1",
             "name": "Braids's Frightful Return",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 You may sacrifice a creature. If you do, each opponent discards a card.\nII \u2014 Return target creature card from your graveyard to your hand.\nIII \u2014 Target opponent may sacrifice a nonland, nontoken permanent. If they don't, they lose 2 life and you draw a card.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "6ea3bd25-3601-58b8-99ac-ebe81e3db487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba537452-3dab-4ecd-b65f-9e311a130d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba537452-3dab-4ecd-b65f-9e311a130d31.jpg?1",
             "name": "Choking Miasma",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nIf this spell was kicked, put a +1/+1 counter on a creature you control.\nAll creatures get -2/-2 until end of turn.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "39faf307-25d2-5c54-a852-16f7cc0a0ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6e5eb3-25ab-4e9e-96e8-655e0ce74675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6e5eb3-25ab-4e9e-96e8-655e0ce74675.jpg?1",
             "name": "The Cruelty of Gix",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Target opponent reveals their hand. You choose a creature or planeswalker card from it. That player discards that card.\nII \u2014 Search your library for a card, put that card into your hand, then shuffle. You lose 3 life.\nIII \u2014 Put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "b3f598df-fe18-5b24-a3b9-b1e37469463b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed77513-94ab-44e2-b9a1-30ba927cd6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed77513-94ab-44e2-b9a1-30ba927cd6ee.jpg?1",
             "name": "Cult Conscript",
             "text": "Cult Conscript enters the battlefield tapped.\n{1}{B}: Return Cult Conscript from your graveyard to the battlefield. Activate only if a non-Skeleton creature died under your control this turn.",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "472fa0d9-aedb-5fd6-a3b9-89b784208904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753db072-5d6a-4f37-8f7d-255572ecd3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753db072-5d6a-4f37-8f7d-255572ecd3bd.jpg?1",
             "name": "Cut Down",
             "text": "Destroy target creature with total power and toughness 5 or less.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "3c8407c4-9fa9-5f14-b031-af68a85d45e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a4dd11-6166-4a54-95c0-728c623d0fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a4dd11-6166-4a54-95c0-728c623d0fbc.jpg?1",
             "name": "Defiler of Flesh",
             "text": "Menace\nAs an additional cost to cast black permanent spells, you may pay 2 life. Those spells cost {B} less to cast if you paid life this way. This effect reduces only the amount of black mana you pay.\nWhenever you cast a black permanent spell, target creature you control gets +1/+1 and gains menace until end of turn.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "a91edcde-c241-59a1-b726-d8e151e5eec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d243099-94b1-4571-96af-4c5a34241911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d243099-94b1-4571-96af-4c5a34241911.jpg?1",
             "name": "Drag to the Bottom",
             "text": "Domain \u2014 Each creature gets -X/-X until end of turn, where X is 1 plus the number of basic land types among lands you control.",
             "colours": [
@@ -3150,7 +3150,7 @@
         },
         {
             "id": "2c0461d7-b84e-5f69-876c-803c41683731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335f3146-743c-4a25-86b5-c45e9c66eb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335f3146-743c-4a25-86b5-c45e9c66eb15.jpg?1",
             "name": "Eerie Soultender",
             "text": "When Eerie Soultender enters the battlefield, mill three cards. (To mill a card, put the top card of your library into your graveyard.)\n{4}{B}, Exile Eerie Soultender from your graveyard: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "66665ece-84f7-51c5-834e-5c09bcb2eea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebeafbc2-0399-4335-8f63-76a3e085e8c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebeafbc2-0399-4335-8f63-76a3e085e8c6.jpg?1",
             "name": "Evolved Sleeper",
             "text": "{B}: Evolved Sleeper becomes a Human Cleric with base power and toughness 2/2.\n{1}{B}: If Evolved Sleeper is a Cleric, put a deathtouch counter on it and it becomes a Phyrexian Human Cleric with base power and toughness 3/3.\n{1}{B}{B}: If Evolved Sleeper is a Phyrexian, put a +1/+1 counter on it, then you draw a card and you lose 1 life.",
             "colours": [
@@ -3221,7 +3221,7 @@
         },
         {
             "id": "9a8d75dc-0f19-5771-8cf2-ea43d8727028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a51d08-f90e-4b72-8dce-fb2a6c72f181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a51d08-f90e-4b72-8dce-fb2a6c72f181.jpg?1",
             "name": "Extinguish the Light",
             "text": "Destroy target creature or planeswalker. If its mana value was 3 or less, you gain 3 life.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "7acf0f67-d1ac-573d-a0b4-b79db34e9ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0674b340-420d-4864-92fe-7b268fe0874c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0674b340-420d-4864-92fe-7b268fe0874c.jpg?1",
             "name": "Gibbering Barricade",
             "text": "Defender\n{2}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "715a05c4-7274-5eb1-879f-57786d1f1bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dfd2fe-e0e0-465c-b730-a30e6f5c271c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dfd2fe-e0e0-465c-b730-a30e6f5c271c.jpg?1",
             "name": "Knight of Dusk's Shadow",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nYour opponents can't gain life.\n{1}{B}: Knight of Dusk's Shadow gets +1/+1 until end of turn.",
             "colours": [
@@ -3323,7 +3323,7 @@
         },
         {
             "id": "039c2d6f-6647-5d1a-941a-5b838412c7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12c8c97-6491-452c-811d-943441a7ef9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12c8c97-6491-452c-811d-943441a7ef9f.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "2a623232-93c4-5a7d-bdf6-162bcfc37efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660d7983-b335-48b4-898d-f182effcf2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660d7983-b335-48b4-898d-f182effcf2de.jpg?1",
             "name": "Monstrous War-Leech",
             "text": "Kicker {U} (You may pay an additional {U} as you cast this spell.)\nAs Monstrous War-Leech enters the battlefield, if it was kicked, mill four cards. (To mill a card, put the top card of your library into your graveyard.)\nMonstrous War-Leech's power and toughness are each equal to the highest mana value among cards in your graveyard.",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "45244e11-d857-5241-9b94-ea585fdf28f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd574e7-705f-4a65-aad0-68ff6d63bf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd574e7-705f-4a65-aad0-68ff6d63bf0f.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "13d410bd-a829-547a-8205-147ba4c00607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65617a8f-4bd8-4edb-b5ec-e20b4482390b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65617a8f-4bd8-4edb-b5ec-e20b4482390b.jpg?1",
             "name": "Phyrexian Vivisector",
             "text": "Whenever a creature you control dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "1c44a1b3-c409-5088-a744-9a3c4525ef66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42167ef-7858-4c66-b1bc-41c3288a8ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42167ef-7858-4c66-b1bc-41c3288a8ee8.jpg?1",
             "name": "Phyrexian Warhorse",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nWhen Phyrexian Warhorse enters the battlefield, if it was kicked, create a 1/1 white Soldier creature token.\n{1}, Sacrifice another creature: Phyrexian Warhorse gets +2/+1 until end of turn.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "23dc7046-5c89-55d3-afc6-03091df8be22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d872c10-4126-4130-a74a-1331ed418ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d872c10-4126-4130-a74a-1331ed418ca8.jpg?1",
             "name": "Pilfer",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "e3cc8442-68cb-56e0-aaa7-59cae59d51a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e761fb2-ae4f-4d72-a142-f7e9bd681303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e761fb2-ae4f-4d72-a142-f7e9bd681303.jpg?1",
             "name": "The Raven Man",
             "text": "At the beginning of each end step, if a player discarded a card this turn, create a 1/1 black Bird creature token with flying and \"This creature can't block.\"\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "af541e77-516e-599e-9a00-75af7681da0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9231f0-7733-46d9-b9c6-c6c5b7fe65dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9231f0-7733-46d9-b9c6-c6c5b7fe65dd.jpg?1",
             "name": "Sengir Connoisseur",
             "text": "Flying\nWhenever one or more other creatures die, put a +1/+1 counter on Sengir Connoisseur. This ability triggers only once each turn.",
             "colours": [
@@ -3609,7 +3609,7 @@
         },
         {
             "id": "ab2e80cf-e6e6-5397-92e4-ae90aa039528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb078448-9e9f-4994-8aff-7e7c4fb62efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb078448-9e9f-4994-8aff-7e7c4fb62efc.jpg?1",
             "name": "Shadow Prophecy",
             "text": "Domain \u2014 Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to two of them into your hand and the rest into your graveyard. You lose 2 life.",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "9cd26ae5-037f-5c85-acf9-317f83f8ba2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg?1",
             "name": "Shadow-Rite Priest",
             "text": "Other Clerics you control get +1/+1.\n{3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "9408edd9-f629-5231-b827-1ea1211d1d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67be074-cdd4-41d9-ac89-0a0456c4e4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67be074-cdd4-41d9-ac89-0a0456c4e4b2.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "5e5775f0-c4bc-541b-8180-9a88cb0e7586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed719f25-1aab-4a1e-8c9f-dd574db5de0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed719f25-1aab-4a1e-8c9f-dd574db5de0c.jpg?1",
             "name": "Sheoldred's Restoration",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nReturn target creature card from your graveyard to the battlefield. If this spell was kicked, you gain life equal to that card's mana value. Otherwise, you lose that much life.\nExile Sheoldred's Restoration.",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "f4c630f4-088d-5802-b6dd-d54d64fd14ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5045027d-0ff4-484c-b4cb-e0b61885d428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5045027d-0ff4-484c-b4cb-e0b61885d428.jpg?1",
             "name": "Splatter Goblin",
             "text": "When Splatter Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "f3a6c49f-8da2-57c8-882b-06873fb5fed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb64b0a7-3e9a-490f-bf02-c62fc8cf750d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb64b0a7-3e9a-490f-bf02-c62fc8cf750d.jpg?1",
             "name": "Stronghold Arena",
             "text": "Kicker {G} and/or {W} (You may pay an additional {G} and/or {W} as you cast this spell.)\nWhen Stronghold Arena enters the battlefield, you gain 3 life for each time it was kicked.\nWhenever one or more creatures you control deal combat damage to a player, you may reveal the top card of your library and put it into your hand. If you do, you lose life equal to its mana value.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "4ab5978e-80f5-5089-9cd3-ecfe22d36fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0368e91c-31ee-4b81-a361-30a4555b1a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0368e91c-31ee-4b81-a361-30a4555b1a42.jpg?1",
             "name": "Tattered Apparition",
             "text": "Flying\n{1}{B}: Tattered Apparition gets +1/+1 until end of turn.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "a4c71098-3f44-5e6e-8778-1d1797d42136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f435329e-6de7-4b05-ba70-cb63d121116e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f435329e-6de7-4b05-ba70-cb63d121116e.jpg?1",
             "name": "Toxic Abomination",
             "text": "When Toxic Abomination enters the battlefield, you lose 2 life.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "0492e300-fd38-5428-8b93-494982c64fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31274707-3e16-4f46-8450-6927d936064b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31274707-3e16-4f46-8450-6927d936064b.jpg?1",
             "name": "Tribute to Urborg",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets an additional -1/-1 until end of turn for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "f6df6e5f-82e4-54de-8bd5-fa94fb4c24c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb8dab0-ecce-4321-b382-c58b296c2fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb8dab0-ecce-4321-b382-c58b296c2fd3.jpg?1",
             "name": "Urborg Repossession",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nReturn target creature card from your graveyard to your hand. You gain 2 life. If this spell was kicked, return another target permanent card from your graveyard to your hand.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "4e414276-e1bf-5489-8eb4-b87ba30ddc33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a166abef-f068-47e9-8a65-43ebf4b015bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a166abef-f068-47e9-8a65-43ebf4b015bd.jpg?1",
             "name": "Writhing Necromass",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nDeathtouch",
             "colours": [
@@ -3995,7 +3995,7 @@
         },
         {
             "id": "b3818efd-0067-5935-8f21-ce28e2c85551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35bab2f-8464-4968-8c50-8807638d687b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35bab2f-8464-4968-8c50-8807638d687b.jpg?1",
             "name": "Balduvian Berserker",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhen Balduvian Berserker dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "95569009-36c5-5baa-a2fb-7640b3105328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfb44f1-e366-437a-bde3-59bfdb362864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfb44f1-e366-437a-bde3-59bfdb362864.jpg?1",
             "name": "Chaotic Transformation",
             "text": "Exile up to one target artifact, up to one target creature, up to one target enchantment, up to one target planeswalker, and/or up to one target land. For each permanent exiled this way, its controller reveals cards from the top of their library until they reveal a card that shares a card type with it, puts that card onto the battlefield, then shuffles.",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "b83919af-1c51-5881-8831-8a4c185377fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c422f-2a1b-47c0-9358-42b85cdbb84e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c422f-2a1b-47c0-9358-42b85cdbb84e.jpg?1",
             "name": "Coalition Warbrute",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nTrample",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "25fe0c1d-03e2-51d1-babe-5b7b3aa86b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e76e0cc-caff-4b15-b550-39e2324c8c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e76e0cc-caff-4b15-b550-39e2324c8c95.jpg?1",
             "name": "Defiler of Instinct",
             "text": "First strike\nAs an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.\nWhenever you cast a red permanent spell, Defiler of Instinct deals 1 damage to any target.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "743bec4c-81a5-57f4-a5c2-bcf2b46400e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13d40b9-319b-4630-a5cd-228ff2f24367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13d40b9-319b-4630-a5cd-228ff2f24367.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice Dragon Whelp at the beginning of the next end step.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "5ce2110b-fa4a-5826-9a84-bec4cc9c77fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c52c7d4-a350-4518-8c9a-72cf7b14603d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c52c7d4-a350-4518-8c9a-72cf7b14603d.jpg?1",
             "name": "The Elder Dragon War",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 The Elder Dragon War deals 2 damage to each creature and each opponent.\nII \u2014 Discard any number of cards, then draw that many cards.\nIII \u2014 Create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "dec6252f-610c-58de-8ab1-6b14a1445ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2d72f-f1cf-45a7-adf7-969f531721ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2d72f-f1cf-45a7-adf7-969f531721ce.jpg?1",
             "name": "Electrostatic Infantry",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on Electrostatic Infantry.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "382ac095-1215-5938-b50d-ea2ceae6d3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58096e5-3cd4-4edd-b71a-3bdb47ab2536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58096e5-3cd4-4edd-b71a-3bdb47ab2536.jpg?1",
             "name": "Fires of Victory",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nIf this spell was kicked, draw a card. Fires of Victory deals damage to target creature or planeswalker equal to the number of cards in your hand.",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "3f73b267-126f-55de-9c1a-64d4349d5937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57c3674-9a31-4418-b306-e6b0a2514d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57c3674-9a31-4418-b306-e6b0a2514d8f.jpg?1",
             "name": "Flowstone Infusion",
             "text": "Target creature gets +2/-2 until end of turn.",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "0e69a5c7-a746-57e5-a19f-7ce684d793fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e40916-3502-448a-a509-f6a6ff3cd73d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e40916-3502-448a-a509-f6a6ff3cd73d.jpg?1",
             "name": "Flowstone Kavu",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{R}: Flowstone Kavu gets +1/-1 until end of turn.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "705711cf-c814-54ea-973e-447a16f04f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d05659-bfff-4b73-80f7-a9f31a7ef957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d05659-bfff-4b73-80f7-a9f31a7ef957.jpg?1",
             "name": "Furious Bellow",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "a79d53f2-d94c-5807-b23b-2a3dc8a1b917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1845806-7585-40d5-9d3a-f13667e6a9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1845806-7585-40d5-9d3a-f13667e6a9d2.jpg?1",
             "name": "Ghitu Amplifier",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nWhen Ghitu Amplifier enters the battlefield, if it was kicked, return target creature an opponent controls to its owner's hand.\nWhenever you cast an instant or sorcery spell, Ghitu Amplifier gets +2/+0 until end of turn.",
             "colours": [
@@ -4406,7 +4406,7 @@
         },
         {
             "id": "e489e427-87e8-5cde-94a8-47b0404a04a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f1f06-dde5-41f2-923c-67d1d4d13fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f1f06-dde5-41f2-923c-67d1d4d13fab.jpg?1",
             "name": "Goblin Picker",
             "text": "{R}, {T}, Discard a card: Draw a card.",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "82aa51bb-72f3-50da-a15e-4a7d542dbe17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d858e9e-452b-4281-9379-641ef6ebef39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d858e9e-452b-4281-9379-641ef6ebef39.jpg?1",
             "name": "Hammerhand",
             "text": "Enchant creature\nWhen Hammerhand enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "2bac4684-abd4-5847-9f83-b3b20798e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f2cf2-5908-4f49-9c5c-6c9e22a65a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f2cf2-5908-4f49-9c5c-6c9e22a65a4d.jpg?1",
             "name": "Hurler Cyclops",
             "text": "{1}, Sacrifice another creature: Hurler Cyclops deals 1 damage to any target.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "c92e2986-927f-5009-a210-a2a4c64747b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff252e80-c155-467b-8df3-9bddc5cc45c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff252e80-c155-467b-8df3-9bddc5cc45c3.jpg?1",
             "name": "Hurloon Battle Hymn",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nHurloon Battle Hymn deals 4 damage to target creature or planeswalker. If this spell was kicked, you gain 4 life.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "013b4307-b052-5a9b-8b5e-68021c24284a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33284f-bdb1-4982-8636-8f2e12896053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33284f-bdb1-4982-8636-8f2e12896053.jpg?1",
             "name": "In Thrall to the Pit",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If this spell was kicked, sacrifice that creature at the beginning of the next end step.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "b797ce1d-974d-59cc-b407-91081e35a039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9f54f0-4368-4d28-aa21-3f1e7be1b23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9f54f0-4368-4d28-aa21-3f1e7be1b23a.jpg?1",
             "name": "Jaya, Fiery Negotiator",
             "text": "+1: Create a 1/1 red Monk creature token with prowess.\n\u22121: Exile the top two cards of your library. Choose one of them. You may play that card this turn.\n\u22122: Choose target creature an opponent controls. Whenever you attack this turn, Jaya, Fiery Negotiator deals damage equal to the number of attacking creatures to that creature.\n\u22128: You get an emblem with \"Whenever you cast a red instant or sorcery spell, copy it twice. You may choose new targets for the copies.\"",
             "colours": [
@@ -4612,7 +4612,7 @@
         },
         {
             "id": "b8572a21-2e62-5bb5-bd24-bd100badb246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b78eaab-819c-4f06-b3b1-a25c17ab2235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b78eaab-819c-4f06-b3b1-a25c17ab2235.jpg?1",
             "name": "Jaya's Firenado",
             "text": "Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4644,7 +4644,7 @@
         },
         {
             "id": "5eb122b6-018f-5cad-bc79-91a5e935a805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2a3c-63a7-4e33-9ae3-21fb6b3d8326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2a3c-63a7-4e33-9ae3-21fb6b3d8326.jpg?1",
             "name": "Keldon Flamesage",
             "text": "Enlist\nWhenever Keldon Flamesage attacks, look at the top X cards of your library, where X is Keldon Flamesage's power. You may exile an instant or sorcery card with mana value X or less from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -4681,7 +4681,7 @@
         },
         {
             "id": "a7f0d552-ced6-5a66-b541-4bf9e5f76e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af4031e-b14e-4568-b047-b3d470d9b18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af4031e-b14e-4568-b047-b3d470d9b18e.jpg?1",
             "name": "Keldon Strike Team",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nWhen Keldon Strike Team enters the battlefield, if it was kicked, create two 1/1 white Soldier creature tokens.\nAs long as Keldon Strike Team entered the battlefield this turn, creatures you control have haste.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "b83e1618-3bf5-570b-96d4-8403eeb6ee6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d541125-bfb8-4f88-8bf3-ad7b6af7ad1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d541125-bfb8-4f88-8bf3-ad7b6af7ad1d.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "6b64141a-a78f-5144-840b-a2c8f1cf1b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48aa964f-99b5-4b6b-b158-42f39514c910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48aa964f-99b5-4b6b-b158-42f39514c910.jpg?1",
             "name": "Meria's Outrider",
             "text": "Reach\nDomain \u2014 When Meria's Outrider enters the battlefield, it deals damage to each opponent equal to the number of basic land types among lands you control.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "5b324bd9-d0e5-5a04-8a1d-afbbec99e5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240957e5-ab0a-443f-92de-ae999b08c44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240957e5-ab0a-443f-92de-ae999b08c44f.jpg?1",
             "name": "Molten Monstrosity",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nTrample",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "ea192a33-d92d-5225-9ac7-2d8755ebdd2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bdc912-61da-428d-b0d7-3a38676a402a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bdc912-61da-428d-b0d7-3a38676a402a.jpg?1",
             "name": "Phoenix Chick",
             "text": "Flying, haste\nPhoenix Chick can't block.\nWhenever you attack with three or more creatures, you may pay {R}{R}. If you do, return Phoenix Chick from your graveyard to the battlefield tapped and attacking with a +1/+1 counter on it.",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "6c902234-0629-5a47-8038-8269fb722ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a90c4-4a79-49e7-9fab-076b35d28adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a90c4-4a79-49e7-9fab-076b35d28adb.jpg?1",
             "name": "Radha's Firebrand",
             "text": "Whenever Radha's Firebrand attacks, target creature defending player controls with power less than Radha's Firebrand's power can't block this turn.\nDomain \u2014 {5}{R}: Radha's Firebrand gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.",
             "colours": [
@@ -4891,7 +4891,7 @@
         },
         {
             "id": "a68fb89c-70d0-544f-84ae-08ec55676baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffee9dbe-af90-4e19-844d-4df1180f24c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffee9dbe-af90-4e19-844d-4df1180f24c4.jpg?1",
             "name": "Rundvelt Hordemaster",
             "text": "Other Goblins you control get +1/+1.\nWhenever Rundvelt Hordemaster or another Goblin you control dies, exile the top card of your library. If it's a Goblin creature card, you may cast that card until the end of your next turn.",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "9530479f-e32e-5d11-af58-16d3e794f654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5d274c-3a03-4f0d-97e8-7eef6508105d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5d274c-3a03-4f0d-97e8-7eef6508105d.jpg?1",
             "name": "Shivan Devastator",
             "text": "Flying, haste\nShivan Devastator enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "1b21275d-fc01-554e-ae39-37d5c3e58368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747881c7-3788-4dd6-b78d-b2a5ded20e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747881c7-3788-4dd6-b78d-b2a5ded20e14.jpg?1",
             "name": "Smash to Dust",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature with defender.\n\u2022 Smash to Dust deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "da97b9ef-95ee-52b3-a164-852cd6042c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602f5370-d096-4765-b612-16bcec3aafa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602f5370-d096-4765-b612-16bcec3aafa7.jpg?1",
             "name": "Sprouting Goblin",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nWhen Sprouting Goblin enters the battlefield, if it was kicked, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.\n{R}, {T}, Sacrifice a land: Draw a card.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "9ca7f193-71d3-5e5e-a802-5026846344e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd907ed-9c68-4bd6-af92-6244909fdf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd907ed-9c68-4bd6-af92-6244909fdf8b.jpg?1",
             "name": "Squee, Dubious Monarch",
             "text": "Haste\nWhenever Squee, Dubious Monarch attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\nYou may cast Squee, Dubious Monarch from your graveyard by paying {3}{R} and exiling four other cards from your graveyard rather than paying its mana cost.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "f5e410c0-ce36-52d1-a578-26c63f194176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d690340-75f1-4733-bde5-2d60fd02f060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d690340-75f1-4733-bde5-2d60fd02f060.jpg?1",
             "name": "Temporal Firestorm",
             "text": "Kicker {1}{W} and/or {1}{U} (You may pay an additional {1}{W} and/or {1}{U} as you cast this spell.)\nChoose up to X creatures and/or planeswalkers you control, where X is the number of times this spell was kicked. Those permanents phase out.\nTemporal Firestorm deals 5 damage to each creature and each planeswalker.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "b03f4111-007b-5c13-af38-05feef7d0289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5dc88-9573-4eaa-bd37-eb0dee4add03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e5dc88-9573-4eaa-bd37-eb0dee4add03.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "3aae8e92-b516-56ad-b3db-bd263f845f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc531409-26cb-4c58-ba69-f39dd8aee3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc531409-26cb-4c58-ba69-f39dd8aee3d1.jpg?1",
             "name": "Twinferno",
             "text": "Choose one \u2014\n\u2022 When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\n\u2022 Target creature you control gains double strike until end of turn.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "e63b0310-92ea-53df-8394-92c0b398be6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f08749e-05e0-4fb4-a4ae-35e7187584ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f08749e-05e0-4fb4-a4ae-35e7187584ab.jpg?1",
             "name": "Viashino Branchrider",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nHaste\nIf Viashino Branchrider was kicked, it enters the battlefield with two +1/+1 counters on it.\n{2}{R}: Viashino Branchrider gets +2/+0 until end of turn.",
             "colours": [
@@ -5209,7 +5209,7 @@
         },
         {
             "id": "ceaee314-aa0a-5659-aeff-69b8a5484a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83d571b-ad91-43f5-8498-115cede4867d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83d571b-ad91-43f5-8498-115cede4867d.jpg?1",
             "name": "Warhost's Frenzy",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nCreatures you control get +2/+0 until end of turn. If this spell was kicked, whenever a creature you control dies this turn, draw a card.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "2caafa8e-412b-5f72-8550-db8da65cf6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25175622-7b68-4916-adf2-3bf2d82e8356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25175622-7b68-4916-adf2-3bf2d82e8356.jpg?1",
             "name": "Yavimaya Steelcrusher",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\n{1}, Sacrifice Yavimaya Steelcrusher: Destroy target artifact.",
             "colours": [
@@ -5277,7 +5277,7 @@
         },
         {
             "id": "15f41f31-e87d-50e1-b7a2-657e77d84f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd9e99a-ae8c-4323-aa86-b19288c877d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd9e99a-ae8c-4323-aa86-b19288c877d4.jpg?1",
             "name": "Yotia Declares War",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Create a 0/2 colorless Thopter artifact creature token with flying named Ornithopter.\nII \u2014 Tap any number of untapped artifacts you control. When you do, Yotia Declares War deals that much damage to target creature or planeswalker.\nIII \u2014 Up to one target artifact you control becomes a creature with base power and toughness 4/4 until end of turn.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "5947e8b0-7528-5bb3-8338-8ab93b657d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c62c55-7b04-4987-9047-1322c842bb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c62c55-7b04-4987-9047-1322c842bb59.jpg?1",
             "name": "Barkweave Crusher",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "4ea28ed4-6096-5661-8b4c-edfb744906df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eacd3de-b803-4322-8d88-d533761aa748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eacd3de-b803-4322-8d88-d533761aa748.jpg?1",
             "name": "Bite Down",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "fbafdd06-9f0f-5071-9a33-f2f6a9a72c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d31d878-9114-4205-b7a9-bb13ce6aedd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d31d878-9114-4205-b7a9-bb13ce6aedd2.jpg?1",
             "name": "Bog Badger",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen Bog Badger enters the battlefield, if it was kicked, creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "4d1f2203-341d-50ec-b03f-ce512af86f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ced8d87-ac22-41b0-a632-298159cbb316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ced8d87-ac22-41b0-a632-298159cbb316.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -5445,7 +5445,7 @@
         },
         {
             "id": "1513c706-2ba5-5cae-a434-e9b67221011f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9142f35-75f4-44c7-b03c-79c4a2d43c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9142f35-75f4-44c7-b03c-79c4a2d43c88.jpg?1",
             "name": "Colossal Growth",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTarget creature gets +3/+3 until end of turn. If this spell was kicked, instead that creature gets +4/+4 and gains trample and haste until end of turn.",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "5bbae107-15f5-5edd-a910-c670cfaf44c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dee3d1-0496-40ea-b208-7362a932f531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dee3d1-0496-40ea-b208-7362a932f531.jpg?1",
             "name": "Deathbloom Gardener",
             "text": "Deathtouch\n{T}: Add one mana of any color.",
             "colours": [
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "9b1c5b2c-e5f4-543b-9ee1-1b1bae6e7ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0896860c-d028-4193-89a5-97e05c12a1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0896860c-d028-4193-89a5-97e05c12a1e7.jpg?1",
             "name": "Defiler of Vigor",
             "text": "Trample\nAs an additional cost to cast green permanent spells, you may pay 2 life. Those spells cost {G} less to cast if you paid life this way. This effect reduces only the amount of green mana you pay.\nWhenever you cast a green permanent spell, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -5550,7 +5550,7 @@
         },
         {
             "id": "0862f24d-c020-5bfd-b33f-4617733b4d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2dc99b-083d-473e-b352-e8264353e85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2dc99b-083d-473e-b352-e8264353e85b.jpg?1",
             "name": "Elfhame Wurm",
             "text": "Vigilance, trample",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "ec731574-0217-5fab-993f-4552dcf9e86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dc4122-4f7a-4d9f-8427-de36e3e8a913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dc4122-4f7a-4d9f-8427-de36e3e8a913.jpg?1",
             "name": "Elvish Hydromancer",
             "text": "Kicker {3}{U} (You may pay an additional {3}{U} as you cast this spell.)\nWhen Elvish Hydromancer enters the battlefield, if it was kicked, create a token that's a copy of target creature you control.",
             "colours": [
@@ -5620,7 +5620,7 @@
         },
         {
             "id": "098eee21-80ef-5fa3-a33b-5f1e4c9d660f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8382b7c7-762e-43f6-b285-e0cebe749fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8382b7c7-762e-43f6-b285-e0cebe749fab.jpg?1",
             "name": "Floriferous Vinewall",
             "text": "Defender\nWhen Floriferous Vinewall enters the battlefield, look at the top six cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "f6da7e2f-0a32-544d-9f39-b533a5375a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c46e9c-ae7c-466c-bb11-4f4d01ea7a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c46e9c-ae7c-466c-bb11-4f4d01ea7a63.jpg?1",
             "name": "Gaea's Might",
             "text": "Domain \u2014 Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -5687,7 +5687,7 @@
         },
         {
             "id": "5a1ab7c0-49b5-5047-9af6-4177832d89af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0244a1f-e696-4223-9c14-22c2ca3cb738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0244a1f-e696-4223-9c14-22c2ca3cb738.jpg?1",
             "name": "Herd Migration",
             "text": "Domain \u2014 Create a 3/3 green Beast creature token for each basic land type among lands you control.\n{1}{G}, Discard Herd Migration: Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "cc69ffcb-2a5c-5cec-a768-9eacda3a9f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd5a635-bcf5-4a05-b00b-bf40322823fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd5a635-bcf5-4a05-b00b-bf40322823fe.jpg?1",
             "name": "Hexbane Tortoise",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nEnlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "a920b7d5-ab85-5844-a743-464942470011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg?1",
             "name": "Leaf-Crowned Visionary",
             "text": "Other Elves you control get +1/+1.\nWhenever you cast an Elf spell, you may pay {G}. If you do, draw a card.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "8611289d-4af4-5fb2-b32d-095209b71b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15cc59c7-6478-4f84-898a-7e0fed10f004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15cc59c7-6478-4f84-898a-7e0fed10f004.jpg?1",
             "name": "Linebreaker Baloth",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nLinebreaker Baloth can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "c3d87915-2115-5e38-a283-02c26b951e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f90e4d-f60f-4175-830f-c2ce04c5a945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f90e4d-f60f-4175-830f-c2ce04c5a945.jpg?1",
             "name": "Llanowar Greenwidow",
             "text": "Reach, trample\nDomain \u2014 {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. It gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\" This ability costs {1} less to activate for each basic land type among lands you control.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "21fa8ab2-4ac5-5771-b06b-d66854f21911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5611db-82dd-464d-8b03-70d7619dcefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5611db-82dd-464d-8b03-70d7619dcefe.jpg?1",
             "name": "Llanowar Loamspeaker",
             "text": "{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "c57a8e87-707a-54ff-a01d-5e127cac7ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d714d8-0e9b-4761-a0ef-3429b4e2f5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d714d8-0e9b-4761-a0ef-3429b4e2f5b7.jpg?1",
             "name": "Llanowar Stalker",
             "text": "Whenever another creature enters the battlefield under your control, Llanowar Stalker gets +1/+0 until end of turn.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "42955759-64d0-5ab0-8ac5-e6b3783226f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d939d4bc-b7e8-4ee8-b904-68f0bff0fde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d939d4bc-b7e8-4ee8-b904-68f0bff0fde1.jpg?1",
             "name": "Magnigoth Sentry",
             "text": "Reach",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "578dce8e-6929-5d72-91e6-242ed50d6bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e528d36-cea6-4013-83d5-ba837d570713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e528d36-cea6-4013-83d5-ba837d570713.jpg?1",
             "name": "Mossbeard Ancient",
             "text": "Trample\nWhen Mossbeard Ancient enters the battlefield, you gain 5 life.",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "27a4cb61-bead-52c0-988d-ffe9c2b1e44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef6cb5f-0ab3-4652-9b39-c2cbf6d693d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef6cb5f-0ab3-4652-9b39-c2cbf6d693d5.jpg?1",
             "name": "Nishoba Brawler",
             "text": "Trample\nDomain \u2014 Nishoba Brawler's power is equal to the number of basic land types among lands you control.",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "6bb27875-aace-54cf-b5e0-293c6a68e0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a501319-59a7-45d4-a6ca-666276095f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a501319-59a7-45d4-a6ca-666276095f87.jpg?1",
             "name": "Quirion Beastcaller",
             "text": "Whenever you cast a creature spell, put a +1/+1 counter on Quirion Beastcaller.\nWhen Quirion Beastcaller dies, distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on Quirion Beastcaller.",
             "colours": [
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "91e2fc9b-4818-5360-ade7-4026c9962bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccd67d4-1a22-4378-804d-6e2c93dc4938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ccd67d4-1a22-4378-804d-6e2c93dc4938.jpg?1",
             "name": "Scout the Wilderness",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nSearch your library for a basic land card, put it onto the battlefield tapped, then shuffle. If this spell was kicked, create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -6111,7 +6111,7 @@
         },
         {
             "id": "eb457a4c-d1ef-5549-89a3-1fe4bc313db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b987664f-0b74-4c0a-b306-14767a55559a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b987664f-0b74-4c0a-b306-14767a55559a.jpg?1",
             "name": "Silverback Elder",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "aa0f861f-f4c0-58b8-be63-76d9c266b987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622f96fc-179a-4ff6-95a5-de721492f7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622f96fc-179a-4ff6-95a5-de721492f7eb.jpg?1",
             "name": "Slimefoot's Survey",
             "text": "Domain \u2014 Search your library for up to two land cards that each have a basic land type, put them onto the battlefield tapped, then shuffle. Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "25de3bca-4d98-5b42-8935-0f6e9107d187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51c3b5-db70-4976-986d-ed3fc8584d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51c3b5-db70-4976-986d-ed3fc8584d1a.jpg?1",
             "name": "Snarespinner",
             "text": "Reach\nWhenever Snarespinner blocks a creature with flying, Snarespinner gets +2/+0 until end of turn.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "307dcaf1-8106-543d-b6ca-ba15f1462267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8418c504-24fe-470f-8102-dcad68ba1520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8418c504-24fe-470f-8102-dcad68ba1520.jpg?1",
             "name": "Strength of the Coalition",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nTarget creature you control gets +2/+2 until end of turn. If this spell was kicked, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "148b963d-f2c0-51bf-8341-f5ecf4cbb0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6f015-2ad6-4b8e-8590-c2c2d01b6d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6f015-2ad6-4b8e-8590-c2c2d01b6d98.jpg?1",
             "name": "Sunbathing Rootwalla",
             "text": "Domain \u2014 {3}{G}: Until end of turn, Sunbathing Rootwalla gets +1/+1 for each basic land type among lands you control. Activate only once each turn.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "3f49d710-c10d-5d79-a011-89f1248ab474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a39b26-8c83-40ea-b492-036251366d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a39b26-8c83-40ea-b492-036251366d73.jpg?1",
             "name": "Tail Swipe",
             "text": "Choose target creature you control and target creature you don't control. If you cast this spell during your main phase, the creature you control gets +1/+1 until end of turn. Then those creatures fight each other. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6313,7 +6313,7 @@
         },
         {
             "id": "178e241f-3f0f-5645-b821-31aab8cfd945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629aa907-9533-4681-9bf2-9e56450a4cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629aa907-9533-4681-9bf2-9e56450a4cc2.jpg?1",
             "name": "Tear Asunder",
             "text": "Kicker {1}{B} (You may pay an additional {1}{B} as you cast this spell.)\nExile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "e382d955-cfe0-5c9c-9b14-61cef061cdd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853ddf31-826b-411e-9b6d-75d53cdd1b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853ddf31-826b-411e-9b6d-75d53cdd1b84.jpg?1",
             "name": "Territorial Maro",
             "text": "Domain \u2014 Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control.",
             "colours": [
@@ -6380,7 +6380,7 @@
         },
         {
             "id": "4eeec8fc-85ea-5c45-8d42-4ee84c662831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99545c3e-0710-48d3-8558-046bd66f225c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99545c3e-0710-48d3-8558-046bd66f225c.jpg?1",
             "name": "Threats Undetected",
             "text": "Search your library for up to four creature cards with different powers and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest into your hand.",
             "colours": [
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "cf6e1271-b100-5d0c-9746-a81bb13ac9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f97236-1497-4811-8189-0545707451da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f97236-1497-4811-8189-0545707451da.jpg?1",
             "name": "Urborg Lhurgoyf",
             "text": "Kicker {U} and/or {B} (You may pay an additional {U} and/or {B} as you cast this spell.)\nAs Urborg Lhurgoyf enters the battlefield, mill three cards for each time it was kicked.\nUrborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -6452,7 +6452,7 @@
         },
         {
             "id": "4608b676-8f04-5e68-934b-69d37ac97c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545cddde-8018-4fdd-874d-b5193b73b414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545cddde-8018-4fdd-874d-b5193b73b414.jpg?1",
             "name": "Vineshaper Prodigy",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nWhen Vineshaper Prodigy enters the battlefield, if it was kicked, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "ba98fa51-4dcd-5817-9366-c9ccf449076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a54461-1f75-4304-b6d7-635171419456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a54461-1f75-4304-b6d7-635171419456.jpg?1",
             "name": "The Weatherseed Treaty",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI \u2014 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nII \u2014 Create a 1/1 green Saproling creature token.\nIII \u2014 Domain \u2014 Target creature you control gets +X/+X and gains trample until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -6522,7 +6522,7 @@
         },
         {
             "id": "a1a94d8a-499f-5cef-95ea-52eacc228adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a9112a-6a1d-4d89-9866-189b55cd326d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a9112a-6a1d-4d89-9866-189b55cd326d.jpg?1",
             "name": "The World Spell",
             "text": "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI, II \u2014 Look at the top seven cards of your library. You may reveal a non-Saga permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nIII \u2014 Put up to two non-Saga permanent cards from your hand onto the battlefield.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "74c004e7-ec16-5918-80f9-1837b21e1bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1af9be-7f5e-48e9-a6e7-9261e199812e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1af9be-7f5e-48e9-a6e7-9261e199812e.jpg?1",
             "name": "Yavimaya Iconoclast",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTrample\nWhen Yavimaya Iconoclast enters the battlefield, if it was kicked, it gets +1/+1 and gains haste until end of turn.",
             "colours": [
@@ -6591,7 +6591,7 @@
         },
         {
             "id": "357e3ea6-541c-55af-b177-5d36d2b92422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fdb424-4d2c-437e-b2a2-8bc56c028338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7fdb424-4d2c-437e-b2a2-8bc56c028338.jpg?1",
             "name": "Yavimaya Sojourner",
             "text": "Domain \u2014 This spell costs {1} less to cast for each basic land type among lands you control.",
             "colours": [
@@ -6625,7 +6625,7 @@
         },
         {
             "id": "d001f781-541d-5a02-a4d6-374e6c2b5bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7641f4d9-4614-41c8-87f5-4845bd78e9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7641f4d9-4614-41c8-87f5-4845bd78e9b3.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "c3381b00-0f11-505a-b30a-6377a5e58ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f8bf98-8911-4c86-978a-427377700544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f8bf98-8911-4c86-978a-427377700544.jpg?1",
             "name": "Aron, Benalia's Ruin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{W}{B}, {T}, Sacrifice another creature: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "b17be53d-16fb-5f03-9dd9-e5288b10aa82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f3a0ba-b917-488b-adbf-60a0d3c58a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f3a0ba-b917-488b-adbf-60a0d3c58a56.jpg?1",
             "name": "Astor, Bearer of Blades",
             "text": "When Astor, Bearer of Blades enters the battlefield, look at the top seven cards of your library. You may reveal an Equipment or Vehicle card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquipment you control have equip {1}.\nVehicles you control have crew 1.",
             "colours": [
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "96bf94ee-ffd3-5289-8649-e6fb52edb8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f643d78-d8d8-4645-9357-a68ebd0d3517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f643d78-d8d8-4645-9357-a68ebd0d3517.jpg?1",
             "name": "Baird, Argivian Recruiter",
             "text": "At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "db814f87-ed1c-5a7b-8090-c0cd6e88b87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ba62e-bb3a-49ad-8b1b-e787e413e5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959ba62e-bb3a-49ad-8b1b-e787e413e5d4.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "b6c1fa7d-57e3-5074-917b-2f8f80632232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25855f-abfc-482d-a36b-088b023a7df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25855f-abfc-482d-a36b-088b023a7df6.jpg?1",
             "name": "Bortuk Bonerattle",
             "text": "Domain \u2014 When Bortuk Bonerattle enters the battlefield, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.",
             "colours": [
@@ -6878,7 +6878,7 @@
         },
         {
             "id": "a89e8ae0-fd52-5b42-b900-25bcec075ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f0ffe-cf51-4c30-8cd5-9e3c7e92c019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f0ffe-cf51-4c30-8cd5-9e3c7e92c019.jpg?1",
             "name": "Elas il-Kor, Sadistic Pilgrim",
             "text": "Deathtouch\nWhenever another creature enters the battlefield under your control, you gain 1 life.\nWhenever another creature you control dies, each opponent loses 1 life.",
             "colours": [
@@ -6921,7 +6921,7 @@
         },
         {
             "id": "a9a13511-d259-5839-9aaf-ed4a85bb4ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e780e-fbc5-4dc0-b5c7-efcb8645c7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e780e-fbc5-4dc0-b5c7-efcb8645c7c6.jpg?1",
             "name": "Ertai Resurrected",
             "text": "Flash\nWhen Ertai Resurrected enters the battlefield, choose up to one \u2014\n\u2022 Counter target spell, activated ability, or triggered ability. Its controller draws a card.\n\u2022 Destroy another target creature or planeswalker. Its controller draws a card.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "11f9d48a-01ef-5e66-aa2c-d45df44a8efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c5f08-08e7-458f-8838-ff321dc5d9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294c5f08-08e7-458f-8838-ff321dc5d9f2.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.",
             "colours": [
@@ -7006,7 +7006,7 @@
         },
         {
             "id": "cc556787-ae3e-5cf6-8481-2d01f8b52d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94c15b7-6c8f-45a6-8734-975e3e3b790c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94c15b7-6c8f-45a6-8734-975e3e3b790c.jpg?1",
             "name": "Ivy, Gleeful Spellthief",
             "text": "Flying\nWhenever a player casts a spell that targets only a single creature other than Ivy, Gleeful Spellthief, you may copy that spell. The copy targets Ivy. (A copy of an Aura spell becomes a token.)",
             "colours": [
@@ -7048,7 +7048,7 @@
         },
         {
             "id": "e5a7a432-d7e7-54ef-84fb-847fd65ac0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd911900-1f5f-4420-96b8-1e4fe67e59f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd911900-1f5f-4420-96b8-1e4fe67e59f6.jpg?1",
             "name": "Jhoira, Ageless Innovator",
             "text": "{T}: Put two ingenuity counters on Jhoira, Ageless Innovator, then you may put an artifact card with mana value X or less from your hand onto the battlefield, where X is the number of ingenuity counters on Jhoira.",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "04fae974-50e6-55e2-b05b-a0302b35fc8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b1aa1e-b4e3-4346-8937-76b312501c70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b1aa1e-b4e3-4346-8937-76b312501c70.jpg?1",
             "name": "Jodah, the Unifier",
             "text": "Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.\nWhenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7138,7 +7138,7 @@
         },
         {
             "id": "43754f09-8bbf-5cd9-abe8-648ef6e85408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10eca3b1-f35a-4984-bfc0-818e619b1ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10eca3b1-f35a-4984-bfc0-818e619b1ece.jpg?1",
             "name": "King Darien XLVIII",
             "text": "Other creatures you control get +1/+1.\n{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token.\nSacrifice King Darien: Creature tokens you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -7180,7 +7180,7 @@
         },
         {
             "id": "bc675ae4-5c65-5527-8082-3fd61e096383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6bb0c2-1e3c-48cd-8f10-49f047e0514c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6bb0c2-1e3c-48cd-8f10-49f047e0514c.jpg?1",
             "name": "Lagomos, Hand of Hatred",
             "text": "At the beginning of combat on your turn, create a 2/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n{T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "45d837ea-3930-5c62-a339-53eb44ead006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eedd979-783d-4721-92de-965b77c20576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eedd979-783d-4721-92de-965b77c20576.jpg?1",
             "name": "Meria, Scholar of Antiquity",
             "text": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -7264,7 +7264,7 @@
         },
         {
             "id": "3f53c07f-19d2-5f4a-b62c-9b74d0463b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da59e8f-cbe5-4c14-a5a9-28d56048dc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da59e8f-cbe5-4c14-a5a9-28d56048dc23.jpg?1",
             "name": "Nael, Avizoa Aeronaut",
             "text": "Flying\nDomain \u2014 Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "9317ce97-3cba-565b-890d-34b60d218ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017ee70-761b-434e-bc44-705cf14336fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017ee70-761b-434e-bc44-705cf14336fa.jpg?1",
             "name": "Najal, the Storm Runner",
             "text": "You may cast sorcery spells as though they had flash.\nWhenever Najal, the Storm Runner attacks, you may pay {2}. If you do, when you cast your next instant or sorcery spell this turn, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -7348,7 +7348,7 @@
         },
         {
             "id": "3db7306a-656c-5c24-b56b-871adceddafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcd556d-351f-4faf-9456-0e47def69a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcd556d-351f-4faf-9456-0e47def69a69.jpg?1",
             "name": "Nemata, Primeval Warden",
             "text": "Reach\nIf a creature an opponent controls would die, exile it instead. When you do, create a 1/1 green Saproling creature token.\n{G}, Sacrifice a Saproling: Nemata, Primeval Warden gets +2/+2 until end of turn.\n{1}{B}, Sacrifice two Saprolings: Draw a card.",
             "colours": [
@@ -7389,7 +7389,7 @@
         },
         {
             "id": "14bf36aa-d92a-5f3e-9d60-016d4c839aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44b4e8b-7675-4c6a-a16a-92f8b6a0259f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44b4e8b-7675-4c6a-a16a-92f8b6a0259f.jpg?1",
             "name": "Queen Allenal of Ruadach",
             "text": "Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.\nIf one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "b4d62ee8-d114-5aed-9a66-e22c4926a76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec235e-7ce0-4947-b221-a555b2c865bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec235e-7ce0-4947-b221-a555b2c865bd.jpg?1",
             "name": "Radha, Coalition Warlord",
             "text": "Domain \u2014 Whenever Radha, Coalition Warlord becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "30d829e2-f260-51f7-a9b2-e33ae6b58b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0cba4c-d9f0-421f-acf4-ab1adcd59c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0cba4c-d9f0-421f-acf4-ab1adcd59c80.jpg?1",
             "name": "Raff, Weatherlight Stalwart",
             "text": "Whenever you cast an instant or sorcery spell, you may tap two untapped creatures you control. If you do, draw a card.\n{3}{W}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -7515,7 +7515,7 @@
         },
         {
             "id": "1b926df3-31db-5f00-9d0d-ebee0900e237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9315812d-03e8-4eb4-a693-e7adf281f7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9315812d-03e8-4eb4-a693-e7adf281f7fb.jpg?1",
             "name": "Ratadrabik of Urborg",
             "text": "Vigilance, ward {2}\nOther Zombies you control have vigilance.\nWhenever another legendary creature you control dies, create a token that's a copy of that creature, except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "e354a03e-f1e1-593a-a306-f1cff6b21e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac148784-b7b6-4aae-bffb-a4cf09f56971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac148784-b7b6-4aae-bffb-a4cf09f56971.jpg?1",
             "name": "Rith, Liberated Primeval",
             "text": "Flying, ward {2}\nOther Dragons you control have ward {2}.\nAt the beginning of your end step, if a creature or planeswalker an opponent controlled was dealt excess damage this turn, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "401078ca-59dd-5b6c-8440-51aa8c4ced2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47573a-601e-4738-acef-16118289f939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47573a-601e-4738-acef-16118289f939.jpg?1",
             "name": "Rivaz of the Claw",
             "text": "Menace\n{T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon creature spells.\nOnce during each of your turns, you may cast a Dragon creature spell from your graveyard.\nWhenever you cast a Dragon creature spell from your graveyard, it gains \"When this creature dies, exile it.\"",
             "colours": [
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "7229b499-1e54-56d3-b2e5-258055a9ed04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8331ab-adc9-45c6-9728-66afc72d901c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8331ab-adc9-45c6-9728-66afc72d901c.jpg?1",
             "name": "Rona, Sheoldred's Faithful",
             "text": "Whenever you cast an instant or sorcery spell, each opponent loses 1 life.\nYou may cast Rona, Sheoldred's Faithful from your graveyard by discarding two cards in addition to paying its other costs.",
             "colours": [
@@ -7684,7 +7684,7 @@
         },
         {
             "id": "54f495b1-417b-55bd-bb9e-ec820a6e1e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa49711-473d-4774-99b8-2bfbabc6b735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa49711-473d-4774-99b8-2bfbabc6b735.jpg?1",
             "name": "Rulik Mons, Warren Chief",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Rulik Mons, Warren Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -7725,7 +7725,7 @@
         },
         {
             "id": "0190263b-2d6d-5c93-890e-838e0d750288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261c443-8d27-4d85-8027-2a0271b85e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7261c443-8d27-4d85-8027-2a0271b85e07.jpg?1",
             "name": "Shanna, Purifying Blade",
             "text": "Lifelink\nAt the beginning of your end step, you may pay {X}. If you do, draw X cards. X can't be greater than the amount of life you gained this turn.",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "2b2a0002-21e2-5094-b373-b31ecd715423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027347d-5fd3-47cd-83d4-8c834e00794c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3027347d-5fd3-47cd-83d4-8c834e00794c.jpg?1",
             "name": "Sol'Kanar the Tainted",
             "text": "At the beginning of your end step, choose one that hasn't been chosen \u2014\n\u2022 Draw a card.\n\u2022 Each opponent loses 2 life and you gain 2 life.\n\u2022 Sol'kanar the Tainted deals 3 damage to up to one other target creature or planeswalker.\n\u2022 Exile Sol'kanar, then return it to the battlefield under an opponent's control.",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "67b05656-d6c5-595c-b4a1-534d10b9e431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e775a2e6-e701-4cb8-8c0b-718d3508f6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e775a2e6-e701-4cb8-8c0b-718d3508f6b6.jpg?1",
             "name": "Soul of Windgrace",
             "text": "Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "0534b8f1-fad8-5127-ba60-ba42825efaed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07177a8e-5ded-4084-a22f-2d8fe933de7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07177a8e-5ded-4084-a22f-2d8fe933de7a.jpg?1",
             "name": "Stenn, Paranoid Partisan",
             "text": "As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -7899,7 +7899,7 @@
         },
         {
             "id": "9b4a39bf-f899-5d44-9e01-8b6f9da1a0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d446cb9-519a-4889-b057-029db9400021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d446cb9-519a-4889-b057-029db9400021.jpg?1",
             "name": "Tatyova, Steward of Tides",
             "text": "Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "7cda1524-869e-50e3-86cf-2050e0daa532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c873c5b-61f6-49b9-8993-2d5e9823de62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c873c5b-61f6-49b9-8993-2d5e9823de62.jpg?1",
             "name": "Tori D'Avenant, Fury Rider",
             "text": "Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn. Untap each other white attacking creature you control.",
             "colours": [
@@ -7983,7 +7983,7 @@
         },
         {
             "id": "67d7c177-7515-5e93-b7ed-aa3e479b6203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c839d302-bf85-4a30-a49a-dbbd48695b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c839d302-bf85-4a30-a49a-dbbd48695b5c.jpg?1",
             "name": "Tura Kenner\u00fcd, Skyknight",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -8025,7 +8025,7 @@
         },
         {
             "id": "44dfa3f7-ec31-5304-af3c-c89201fc642d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3fc36c-682b-4352-a66f-eddd2baf0bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3fc36c-682b-4352-a66f-eddd2baf0bf6.jpg?1",
             "name": "Uurg, Spawn of Turg",
             "text": "Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\n{B}{G}, Sacrifice a land: You gain 2 life.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "5205b325-008a-5748-b721-3b966c4892ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807c7812-c108-45a7-a5b2-08cc693bc500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807c7812-c108-45a7-a5b2-08cc693bc500.jpg?1",
             "name": "Vohar, Vodalian Desecrator",
             "text": "{T}: Draw a card, then discard a card. If you discarded an instant or sorcery card this way, each opponent loses 1 life and you gain 1 life.\n{2}, Sacrifice Vohar, Vodalian Desecrator: You may cast target instant or sorcery card from your graveyard this turn. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "5fe183a4-2615-5d15-8958-54bd9243e232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c903e3-d622-415e-9144-a5b2f3f7b9ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c903e3-d622-415e-9144-a5b2f3f7b9ed.jpg?1",
             "name": "Zar Ojanen, Scion of Efrava",
             "text": "Domain \u2014 Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.",
             "colours": [
@@ -8152,7 +8152,7 @@
         },
         {
             "id": "b14f85a1-7f9e-5161-ad2f-5b62875bb23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d987435-2403-4e0f-b19d-693da923ba50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d987435-2403-4e0f-b19d-693da923ba50.jpg?1",
             "name": "Zur, Eternal Schemer",
             "text": "Flying\nEnchantment creatures you control have deathtouch, lifelink, and hexproof.\n{1}{W}: Target non-Aura enchantment you control becomes a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "402dc85b-aa54-51c6-bc9b-f477467bbfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3d7ece-0f57-4213-a0ab-a9d7c1536ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3d7ece-0f57-4213-a0ab-a9d7c1536ebb.jpg?1",
             "name": "Automatic Librarian",
             "text": "When Automatic Librarian enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [],
@@ -8227,7 +8227,7 @@
         },
         {
             "id": "0c67c061-a6f4-5384-9f60-cbe14eb16ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8611a53-e54e-4625-8e28-03511f1550e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8611a53-e54e-4625-8e28-03511f1550e8.jpg?1",
             "name": "Golden Argosy",
             "text": "Whenever Golden Argosy attacks, exile each creature that crewed it this turn. Return them to the battlefield tapped under their owner's control at the beginning of the next end step.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8259,7 +8259,7 @@
         },
         {
             "id": "e20ea3c4-0cc8-563f-91c4-e574ab870e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7c0d2d-7107-4599-8d49-c7c57d21e467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7c0d2d-7107-4599-8d49-c7c57d21e467.jpg?1",
             "name": "Hero's Heirloom",
             "text": "Equipped creature gets +2/+1.\nAs long as equipped creature is legendary, it has trample and haste.\nEquip {2}",
             "colours": [],
@@ -8289,7 +8289,7 @@
         },
         {
             "id": "bee500cc-58c9-54b1-b66f-38186df5e52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699d8655-d250-4ab6-92c5-376979bbabc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699d8655-d250-4ab6-92c5-376979bbabc7.jpg?1",
             "name": "Inscribed Tablet",
             "text": "{1}, {T}, Sacrifice Inscribed Tablet: Reveal the top five cards of your library. Put a land card from among them into your hand and the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, draw a card.",
             "colours": [],
@@ -8317,7 +8317,7 @@
         },
         {
             "id": "7ed4711e-7dc4-5abe-8923-d7f47ed8e2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da1e-4cc6-40a1-bd83-cc0dd761b1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636da1e-4cc6-40a1-bd83-cc0dd761b1cc.jpg?1",
             "name": "Jodah's Codex",
             "text": "Domain \u2014 {5}, {T}: Draw a card. This ability costs {1} less to activate for each basic land type among lands you control.",
             "colours": [],
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "09d4a04d-4fe3-5aa9-9406-8e9374a00c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a8676-0a93-4ca3-a786-63f138027e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a8676-0a93-4ca3-a786-63f138027e8a.jpg?1",
             "name": "Karn's Sylex",
             "text": "Karn's Sylex enters the battlefield tapped.\nPlayers can't pay life to cast spells or to activate abilities that aren't mana abilities.\n{X}, {T}, Exile Karn's Sylex: Destroy each nonland permanent with mana value X or less. Activate only as a sorcery.",
             "colours": [],
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "6ea672cd-d56c-5d8d-bbdc-81f95cf69a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eb2032-50af-4fd6-bdc7-7cae2211956c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33eb2032-50af-4fd6-bdc7-7cae2211956c.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to any target.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "055a1144-d6c0-5ad6-9b32-f08e59a5919e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2809e-c441-416c-90ff-6fb1e246dff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2809e-c441-416c-90ff-6fb1e246dff3.jpg?1",
             "name": "Relic of Legends",
             "text": "{T}: Add one mana of any color.\nTap an untapped legendary creature you control: Add one mana of any color.",
             "colours": [],
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "85683f98-7406-5fc7-a2b4-114c8f0689d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc22ecb-5d87-464e-8c7d-5d40a52e1e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc22ecb-5d87-464e-8c7d-5d40a52e1e4f.jpg?1",
             "name": "Salvaged Manaworker",
             "text": "{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -8462,7 +8462,7 @@
         },
         {
             "id": "79706b1f-4d87-52eb-975e-d98f4707676e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e57e1d7-da1d-4a2b-867f-85b8331b7bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e57e1d7-da1d-4a2b-867f-85b8331b7bbc.jpg?1",
             "name": "Shield-Wall Sentinel",
             "text": "Defender\nWhen Shield-Wall Sentinel enters the battlefield, you may search your library for a creature card with defender, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -8493,7 +8493,7 @@
         },
         {
             "id": "c861ffa3-56f7-53be-8786-7db69d2e2258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f566387-3342-4325-ba4c-eee7626072ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f566387-3342-4325-ba4c-eee7626072ac.jpg?1",
             "name": "Timeless Lotus",
             "text": "Timeless Lotus enters the battlefield tapped.\n{T}: Add {W}{U}{B}{R}{G}.",
             "colours": [],
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "5304745c-94d7-5d10-b3da-18140312fc49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef37244-deb9-464e-ab8c-4308369ae09b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef37244-deb9-464e-ab8c-4308369ae09b.jpg?1",
             "name": "Vanquisher's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8559,7 +8559,7 @@
         },
         {
             "id": "9d579c63-119d-5feb-9de4-980a8e461191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602d163c-d341-4b3b-9d3c-5d3419e9b10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602d163c-d341-4b3b-9d3c-5d3419e9b10b.jpg?1",
             "name": "Walking Bulwark",
             "text": "Defender\n{2}: Until end of turn, target creature with defender gains haste, can attack as though it didn't have defender, and assigns combat damage equal to its toughness rather than its power. Activate only as a sorcery.",
             "colours": [],
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "00605bc0-86d5-58bb-8007-1ef050832405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976fd9d9-a9b5-40b6-ad38-4b3b263e1ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976fd9d9-a9b5-40b6-ad38-4b3b263e1ebc.jpg?1",
             "name": "Weatherlight Compleated",
             "text": "Flying\nAs long as Weatherlight Compleated has four or more phyresis counters on it, it's a Phyrexian creature in addition to its other types.\nWhenever a creature you control dies, put a phyresis counter on Weatherlight Compleated. Then draw a card if it has seven or more phyresis counters on it. If it doesn't, scry 1.",
             "colours": [],
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "5b7b5bce-4f88-5071-bfe6-3e6030a659b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae1037-6f70-41a9-b75e-98fa9a2152c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae1037-6f70-41a9-b75e-98fa9a2152c8.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -8655,7 +8655,7 @@
         },
         {
             "id": "3d1a049a-6c28-5b81-acf7-871e39ca23d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99264beb-2149-4cd4-9880-f0dc5c570c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99264beb-2149-4cd4-9880-f0dc5c570c1b.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -8688,7 +8688,7 @@
         },
         {
             "id": "478dc640-76cd-5300-a016-f680285a1712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb570f4-de68-4d8c-a9f3-8a3294163aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb570f4-de68-4d8c-a9f3-8a3294163aa8.jpg?1",
             "name": "Contaminated Aquifer",
             "text": "({T}: Add {U} or {B}.)\nContaminated Aquifer enters the battlefield tapped.",
             "colours": [],
@@ -8722,7 +8722,7 @@
         },
         {
             "id": "775a3bd2-2e24-57d6-984c-90c9bcc98172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg?1",
             "name": "Crystal Grotto",
             "text": "When Crystal Grotto enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "d4c937e9-1219-5ee0-9135-3bb439649553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e62fe57-4fa4-4bfd-8e31-9f6db774d7e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e62fe57-4fa4-4bfd-8e31-9f6db774d7e2.jpg?1",
             "name": "Geothermal Bog",
             "text": "({T}: Add {B} or {R}.)\nGeothermal Bog enters the battlefield tapped.",
             "colours": [],
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "f23783ec-de54-5622-b167-7dcac60b76f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f5e958-56e6-4666-a534-24deba6f652d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f5e958-56e6-4666-a534-24deba6f652d.jpg?1",
             "name": "Haunted Mire",
             "text": "({T}: Add {B} or {G}.)\nHaunted Mire enters the battlefield tapped.",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "db466008-fd93-59e6-8099-8abede9d8911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50ec22c-decb-419f-ae52-78ea1706eb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50ec22c-decb-419f-ae52-78ea1706eb11.jpg?1",
             "name": "Idyllic Beachfront",
             "text": "({T}: Add {W} or {U}.)\nIdyllic Beachfront enters the battlefield tapped.",
             "colours": [],
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "2e22f220-e190-59ed-976c-fbe7e762032e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89b2c79-e3d3-4ef9-bfc8-f9c090975011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89b2c79-e3d3-4ef9-bfc8-f9c090975011.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {G}. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -8885,7 +8885,7 @@
         },
         {
             "id": "4f545707-f91d-529c-b6e1-a5304aac0297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aff4af-5128-432f-a8c8-65b6909d31ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aff4af-5128-432f-a8c8-65b6909d31ac.jpg?1",
             "name": "Molten Tributary",
             "text": "({T}: Add {U} or {R}.)\nMolten Tributary enters the battlefield tapped.",
             "colours": [],
@@ -8919,7 +8919,7 @@
         },
         {
             "id": "89d2b50a-5e60-5fee-976c-b61c00d859d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cfcf67-f83c-43af-9e2d-5513fcdde835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cfcf67-f83c-43af-9e2d-5513fcdde835.jpg?1",
             "name": "Plaza of Heroes",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a legendary spell.\n{T}: Add one mana of any color among legendary permanents you control.\n{3}, {T}, Exile Plaza of Heroes: Target legendary creature gains hexproof and indestructible until end of turn.",
             "colours": [],
@@ -8949,7 +8949,7 @@
         },
         {
             "id": "0a46cf8f-c403-5a1e-8901-12769faddec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f9dca6-e5ae-4714-8a59-2ef1d8f1e82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f9dca6-e5ae-4714-8a59-2ef1d8f1e82d.jpg?1",
             "name": "Radiant Grove",
             "text": "({T}: Add {G} or {W}.)\nRadiant Grove enters the battlefield tapped.",
             "colours": [],
@@ -8983,7 +8983,7 @@
         },
         {
             "id": "c55cbc0d-ea04-5101-8f0c-d038a3472595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24957d64-ad17-4d4f-8a00-3cdd83e1ce88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24957d64-ad17-4d4f-8a00-3cdd83e1ce88.jpg?1",
             "name": "Sacred Peaks",
             "text": "({T}: Add {R} or {W}.)\nSacred Peaks enters the battlefield tapped.",
             "colours": [],
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "6875db8f-16ae-58ad-8e6b-be7cd8e0965d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338107b-0960-4496-a9a5-f7b672e7c043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338107b-0960-4496-a9a5-f7b672e7c043.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -9050,7 +9050,7 @@
         },
         {
             "id": "1c625990-9930-5f6c-ab1a-81b50f421300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd5450a-6490-417f-9aea-b6fca6f380d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd5450a-6490-417f-9aea-b6fca6f380d7.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "a906989d-db7c-5539-896d-7aa176790ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0588fbf-3c05-452a-b3f7-67604c1f921d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0588fbf-3c05-452a-b3f7-67604c1f921d.jpg?1",
             "name": "Sunlit Marsh",
             "text": "({T}: Add {W} or {B}.)\nSunlit Marsh enters the battlefield tapped.",
             "colours": [],
@@ -9117,7 +9117,7 @@
         },
         {
             "id": "b9a185a2-c687-5b00-b5f7-a1fb815c68ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a325fb4-fe71-47f1-9a2f-05b8cfe88fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a325fb4-fe71-47f1-9a2f-05b8cfe88fe6.jpg?1",
             "name": "Tangled Islet",
             "text": "({T}: Add {G} or {U}.)\nTangled Islet enters the battlefield tapped.",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "bae7661f-7093-576d-a0b6-e4cc4e6fda36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef074a2e-a387-4af8-a180-74b145d93992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef074a2e-a387-4af8-a180-74b145d93992.jpg?1",
             "name": "Thran Portal",
             "text": "Thran Portal enters the battlefield tapped unless you control two or fewer other lands.\nAs Thran Portal enters the battlefield, choose a basic land type.\nThran Portal is the chosen type in addition to its other types.\nMana abilities of Thran Portal cost an additional 1 life to activate.",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "a55c6894-120c-5454-bc7d-8756438a281c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e31184-dca4-48b1-be9d-581247c41d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e31184-dca4-48b1-be9d-581247c41d99.jpg?1",
             "name": "Wooded Ridgeline",
             "text": "({T}: Add {R} or {G}.)\nWooded Ridgeline enters the battlefield tapped.",
             "colours": [],
@@ -9217,7 +9217,7 @@
         },
         {
             "id": "045fcf34-ec03-55d7-963e-08bdcb296c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed6c8b0-f154-4678-89d0-9869864ead8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed6c8b0-f154-4678-89d0-9869864ead8d.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -9250,7 +9250,7 @@
         },
         {
             "id": "a949620d-6fec-5115-b260-199c34f7f769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5822b027-369d-46da-b6dd-c31207e2f449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5822b027-369d-46da-b6dd-c31207e2f449.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9288,7 +9288,7 @@
         },
         {
             "id": "2067808d-9cfe-5de9-9c9a-8a7454932f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b364f40-c3c0-4e3a-8556-73f6fcc19eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b364f40-c3c0-4e3a-8556-73f6fcc19eec.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "c8e28bfc-c1db-57d1-bf77-02e6cbaebc2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be849ad5-9f96-4605-a0dc-8b9588ac7dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be849ad5-9f96-4605-a0dc-8b9588ac7dd6.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "db2b0bb2-19ec-565f-992b-4380a22e25d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafc217-3d83-4551-b2e3-3494ec14b2f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafc217-3d83-4551-b2e3-3494ec14b2f9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "4b32503f-a32b-54b3-a690-4cfd7877931f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec0f4f-e6f7-4a49-81a3-a1fbad102a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ec0f4f-e6f7-4a49-81a3-a1fbad102a9d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9440,7 +9440,7 @@
         },
         {
             "id": "f98d1399-b2f9-5142-ba80-a554f970768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e7580a-92bd-4b50-84fc-ee42e47c9014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e7580a-92bd-4b50-84fc-ee42e47c9014.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9478,7 +9478,7 @@
         },
         {
             "id": "9d8d4d04-3442-5608-822a-1b483a838d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a846f00-ccb9-4ee2-8358-7c7722258601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a846f00-ccb9-4ee2-8358-7c7722258601.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9516,7 +9516,7 @@
         },
         {
             "id": "fd2c888e-948a-5e66-b00b-5038192658b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00daa026-aba3-421e-9eaa-aa5649b36eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00daa026-aba3-421e-9eaa-aa5649b36eb2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "fcb3527f-bca1-5b83-aece-8381af4cca2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0306607d-2a42-4008-ac84-8d3ed91fe3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0306607d-2a42-4008-ac84-8d3ed91fe3aa.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9592,7 +9592,7 @@
         },
         {
             "id": "1ab4f93c-757e-5fbf-b107-f402b81d83d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82f782e-abc8-4b92-a193-17b2c383f765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82f782e-abc8-4b92-a193-17b2c383f765.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9630,7 +9630,7 @@
         },
         {
             "id": "2ae58685-1379-53be-b5c5-dd0642537872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72776f25-48f5-4d7f-84a9-310928b9d7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72776f25-48f5-4d7f-84a9-310928b9d7ad.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9668,7 +9668,7 @@
         },
         {
             "id": "8cfeb308-9ff8-51b1-bf69-953727aad77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d07155-d45d-4fec-a15e-525df5010af3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d07155-d45d-4fec-a15e-525df5010af3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "ed4fa28d-0be9-5a85-a4d9-355d7081bc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52097f6a-58d3-4176-b3bf-dc94f44adf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52097f6a-58d3-4176-b3bf-dc94f44adf30.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9744,7 +9744,7 @@
         },
         {
             "id": "6e13fde1-5cef-56fb-ae26-3e7100d0c1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b6004-6dda-4495-85f7-eb8fa29873e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1b6004-6dda-4495-85f7-eb8fa29873e9.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "6b5259df-3677-58cd-8890-0a122aefc38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279ebd05-229a-4a4a-a1c0-c5f24d16dee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279ebd05-229a-4a4a-a1c0-c5f24d16dee3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "413e9e4d-9d1b-5486-8551-b06236e7f4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eab93-7b1d-434b-ba92-844248e472d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eab93-7b1d-434b-ba92-844248e472d0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9858,7 +9858,7 @@
         },
         {
             "id": "2b02c3a5-2bc7-56da-8566-1688432e78ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67477a4-6878-4356-8037-807f41590ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67477a4-6878-4356-8037-807f41590ad1.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9896,7 +9896,7 @@
         },
         {
             "id": "1fcbadcb-600a-5553-9c52-86d2ee061a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8c9a6-62eb-436e-9277-e2b8075d482d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8c9a6-62eb-436e-9277-e2b8075d482d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "64d3d573-4513-5acf-9715-2f85641497c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf15b9-1bf5-424a-a994-67beaae29d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf15b9-1bf5-424a-a994-67beaae29d36.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9972,7 +9972,7 @@
         },
         {
             "id": "bb51b61e-943a-5c7c-a801-a4b276251f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e9959a-b422-4906-8d35-8b05c5dd6de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e9959a-b422-4906-8d35-8b05c5dd6de1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10010,7 +10010,7 @@
         },
         {
             "id": "c7eff468-154e-5848-b8a1-9b88080568f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b9cb5c-29f2-46ed-803e-c2170955217c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b9cb5c-29f2-46ed-803e-c2170955217c.jpg?1",
             "name": "Serra Redeemer",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, put two +1/+1 counters on that creature.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "b2e212ad-d8c0-52ce-b2ff-f02facd4bd31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79718dbe-d5d6-4f24-b514-5c392963f021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79718dbe-d5d6-4f24-b514-5c392963f021.jpg?1",
             "name": "Cosmic Epiphany",
             "text": "Draw cards equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "9e7bdc2d-d4c6-5bc6-b084-dd671681a852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027ef1fc-4a7a-465c-9c25-dc19c771b5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027ef1fc-4a7a-465c-9c25-dc19c771b5f5.jpg?1",
             "name": "Tyrannical Pitlord",
             "text": "Flying, trample\nAs Tyrannical Pitlord enters the battlefield, choose another creature you control.\nThe chosen creature gets +3/+3 and has flying.\nWhen Tyrannical Pitlord leaves the battlefield, sacrifice the chosen creature.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "5b2eac0a-56d8-5fca-9f99-0c8556176aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ccd68d-0162-4a4c-892e-1726b8b28612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ccd68d-0162-4a4c-892e-1726b8b28612.jpg?1",
             "name": "Ragefire Hellkite",
             "text": "Flying\nWhenever Ragefire Hellkite attacks, you may sacrifice another creature. If you do, Ragefire Hellkite gains double strike until end of turn.",
             "colours": [
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "5a8edb6d-3f60-5b77-847d-4cc87cecc89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390fd5d1-3ce9-456e-b130-30ad0557f4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390fd5d1-3ce9-456e-b130-30ad0557f4cf.jpg?1",
             "name": "Briar Hydra",
             "text": "Trample\nDomain \u2014 Whenever Briar Hydra deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -10190,7 +10190,7 @@
         },
         {
             "id": "e604e4d3-ff1d-5eb5-beba-23cf8337b065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9609d8-4dcf-4b70-b947-a4d62275f34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9609d8-4dcf-4b70-b947-a4d62275f34a.jpg?1",
             "name": "Danitha, Benalia's Hope",
             "text": "First strike, vigilance, lifelink\nWhen Danitha, Benalia's Hope enters the battlefield, you may put an Aura or Equipment card from your hand or graveyard onto the battlefield attached to Danitha.",
             "colours": [
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "5a044b9c-5baf-52eb-8628-23d843fdca82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2559ff7-a97c-40c6-942f-36998eafb050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2559ff7-a97c-40c6-942f-36998eafb050.jpg?1",
             "name": "Braids, Arisen Nightmare",
             "text": "At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.",
             "colours": [
@@ -10269,7 +10269,7 @@
         },
         {
             "id": "aec8ab8f-9561-5c51-ba1b-93493750e1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f4cca-90fa-4f53-8243-09d99823add3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9f4cca-90fa-4f53-8243-09d99823add3.jpg?1",
             "name": "The Raven Man",
             "text": "At the beginning of each end step, if a player discarded a card this turn, create a 1/1 black Bird creature token with flying and \"This creature can't block.\"\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "2dfde2ee-e093-558e-b1a1-2d018e80c6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc5be7df-16e0-494c-b960-19fd64d57b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc5be7df-16e0-494c-b960-19fd64d57b35.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -10352,7 +10352,7 @@
         },
         {
             "id": "992fa7bc-9e0b-5918-a920-b64864b2a1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f39ecc9-0a4c-47e7-b8e6-7e00d4cb61e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f39ecc9-0a4c-47e7-b8e6-7e00d4cb61e3.jpg?1",
             "name": "Squee, Dubious Monarch",
             "text": "Haste\nWhenever Squee, Dubious Monarch attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\nYou may cast Squee, Dubious Monarch from your graveyard by paying {3}{R} and exiling four other cards from your graveyard rather than paying its mana cost.",
             "colours": [
@@ -10392,7 +10392,7 @@
         },
         {
             "id": "a525521e-4c4c-5b12-91c7-c8dfa2cf3155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f36b9-9f43-4ace-8e60-4ba671b2655a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f36b9-9f43-4ace-8e60-4ba671b2655a.jpg?1",
             "name": "Aron, Benalia's Ruin",
             "text": "Menace\n{W}{B}, {T}, Sacrifice another creature: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10434,7 +10434,7 @@
         },
         {
             "id": "8e0bdf45-a7a5-50d8-b324-5399f48af377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ab2cad-ac4c-4b04-8724-c824b45db4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ab2cad-ac4c-4b04-8724-c824b45db4d0.jpg?1",
             "name": "Astor, Bearer of Blades",
             "text": "When Astor, Bearer of Blades enters the battlefield, look at the top seven cards of your library. You may reveal an Equipment or Vehicle card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquipment you control have equip {1}.\nVehicles you control have crew 1.",
             "colours": [
@@ -10476,7 +10476,7 @@
         },
         {
             "id": "f3ebeb9f-e5f5-561a-aba2-a8abcecd8afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7acac3-cb41-46bb-ae5e-98dc60620e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7acac3-cb41-46bb-ae5e-98dc60620e53.jpg?1",
             "name": "Baird, Argivian Recruiter",
             "text": "At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -10518,7 +10518,7 @@
         },
         {
             "id": "9aa13d14-1ae8-58d4-ad25-dd343d118cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e3ba0f-0879-4eea-9911-14b874f039b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e3ba0f-0879-4eea-9911-14b874f039b3.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -10560,7 +10560,7 @@
         },
         {
             "id": "4503050f-ed4d-533f-8755-4b32f6fd029b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f342de7-f179-4894-96e4-56339d32f801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f342de7-f179-4894-96e4-56339d32f801.jpg?1",
             "name": "Bortuk Bonerattle",
             "text": "Domain \u2014 When Bortuk Bonerattle enters the battlefield, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.",
             "colours": [
@@ -10602,7 +10602,7 @@
         },
         {
             "id": "4ec27c63-aed1-588f-85c4-30369448505b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552fbde6-515d-457e-81c9-d67157eaaf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552fbde6-515d-457e-81c9-d67157eaaf37.jpg?1",
             "name": "Elas il-Kor, Sadistic Pilgrim",
             "text": "Deathtouch\nWhenever another creature enters the battlefield under your control, you gain 1 life.\nWhenever another creature you control dies, each opponent loses 1 life.",
             "colours": [
@@ -10645,7 +10645,7 @@
         },
         {
             "id": "c49e2f04-4282-52e2-997e-871273d7608f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2185d26-05b7-4e8b-ab0a-4f9d1541d4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2185d26-05b7-4e8b-ab0a-4f9d1541d4c5.jpg?1",
             "name": "Ertai Resurrected",
             "text": "Flash\nWhen Ertai Resurrected enters the battlefield, choose up to one \u2014\n\u2022 Counter target spell, activated ability, or triggered ability. Its controller draws a card.\n\u2022 Destroy another target creature or planeswalker. Its controller draws a card.",
             "colours": [
@@ -10688,7 +10688,7 @@
         },
         {
             "id": "645598bf-3669-5e10-9418-4db7321f86bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8721c-371b-454c-8ccd-5e57779fc4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b8721c-371b-454c-8ccd-5e57779fc4d0.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.",
             "colours": [
@@ -10730,7 +10730,7 @@
         },
         {
             "id": "e787b03c-b705-5f5d-a952-b9ab05b129a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba0d0-ca77-47c0-8f77-7beedb6c557b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba0d0-ca77-47c0-8f77-7beedb6c557b.jpg?1",
             "name": "Ivy, Gleeful Spellthief",
             "text": "Flying\nWhenever a player casts a spell that targets only a single creature other than Ivy, Gleeful Spellthief, you may copy that spell. The copy targets Ivy.",
             "colours": [
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "33ada028-58ea-5b50-8f1b-b22e5fa49049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538eb568-23e7-49c6-855a-543a65fdae46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538eb568-23e7-49c6-855a-543a65fdae46.jpg?1",
             "name": "Jhoira, Ageless Innovator",
             "text": "{T}: Put two ingenuity counters on Jhoira, Ageless Innovator, then you may put an artifact card with mana value X or less from your hand onto the battlefield, where X is the number of ingenuity counters on Jhoira.",
             "colours": [
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "a3aaaaac-e972-5b7c-b9e5-2a5f998e8b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416429e0-4b7e-43d1-8126-16ab679b6e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416429e0-4b7e-43d1-8126-16ab679b6e39.jpg?1",
             "name": "Jodah, the Unifier",
             "text": "Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.\nWhenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10862,7 +10862,7 @@
         },
         {
             "id": "f44e9755-d844-5c62-ab31-da3083fc1116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47698a3-f7eb-42e4-8246-b657f487a5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47698a3-f7eb-42e4-8246-b657f487a5df.jpg?1",
             "name": "King Darien XLVIII",
             "text": "Other creatures you control get +1/+1.\n{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token.\nSacrifice King Darien: Creature tokens you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "136f7ecc-0d60-5d29-b422-5af886430d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dd512f-9f77-4f54-9081-f14ae0aa8c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dd512f-9f77-4f54-9081-f14ae0aa8c7a.jpg?1",
             "name": "Lagomos, Hand of Hatred",
             "text": "At the beginning of combat on your turn, create a 2/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n{T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.",
             "colours": [
@@ -10946,7 +10946,7 @@
         },
         {
             "id": "ee74d42f-bf36-5d69-87ee-198ff16b70c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378b99b7-9b7b-4596-b41e-641ff4630d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378b99b7-9b7b-4596-b41e-641ff4630d99.jpg?1",
             "name": "Meria, Scholar of Antiquity",
             "text": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -10988,7 +10988,7 @@
         },
         {
             "id": "b3877db5-b860-5950-bed0-ce075f8e3ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f81814-2870-4aab-9c50-bad78aad4e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f81814-2870-4aab-9c50-bad78aad4e36.jpg?1",
             "name": "Nael, Avizoa Aeronaut",
             "text": "Flying\nDomain \u2014 Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.",
             "colours": [
@@ -11030,7 +11030,7 @@
         },
         {
             "id": "abd1b607-1428-5927-ba2e-9f52cabbb2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf2ec7b-7cac-49aa-8fab-f9280548573b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf2ec7b-7cac-49aa-8fab-f9280548573b.jpg?1",
             "name": "Najal, the Storm Runner",
             "text": "You may cast sorcery spells as though they had flash.\nWhenever Najal, the Storm Runner attacks, you may pay {2}. If you do, when you cast your next instant or sorcery spell this turn, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "54dac28c-78d7-5523-a89c-afbfffa90348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706bc2aa-bc63-42b0-8735-486f80aaee17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706bc2aa-bc63-42b0-8735-486f80aaee17.jpg?1",
             "name": "Nemata, Primeval Warden",
             "text": "Reach\nIf a creature an opponent controls would die, exile it instead. When you do, create a 1/1 green Saproling creature token.\n{G}, Sacrifice a Saproling: Nemata, Primeval Warden gets +2/+2 until end of turn.\n{1}{B}, Sacrifice two Saprolings: Draw a card.",
             "colours": [
@@ -11113,7 +11113,7 @@
         },
         {
             "id": "78cae655-6d68-5183-bacc-44ce105043c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4101cf9-4e05-414a-843e-b2fda0db917c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4101cf9-4e05-414a-843e-b2fda0db917c.jpg?1",
             "name": "Queen Allenal of Ruadach",
             "text": "Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.\nIf one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.",
             "colours": [
@@ -11155,7 +11155,7 @@
         },
         {
             "id": "47af2b33-aa5c-5c10-924c-02a87a99a734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a42355-ead5-48b9-813a-1e9be9a45747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a42355-ead5-48b9-813a-1e9be9a45747.jpg?1",
             "name": "Radha, Coalition Warlord",
             "text": "Domain \u2014 Whenever Radha, Coalition Warlord becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "244ddfec-55d6-5abd-ad42-76f04a80267e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ed3b1-9c7d-44ff-8f0a-2a7a08313863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1ed3b1-9c7d-44ff-8f0a-2a7a08313863.jpg?1",
             "name": "Raff, Weatherlight Stalwart",
             "text": "Whenever you cast an instant or sorcery spell, you may tap two untapped creatures you control. If you do, draw a card.\n{3}{W}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -11239,7 +11239,7 @@
         },
         {
             "id": "92700201-0c62-5c93-be02-0c90c187b5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ebcd93-672f-404a-8e4d-28713e9e611b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ebcd93-672f-404a-8e4d-28713e9e611b.jpg?1",
             "name": "Ratadrabik of Urborg",
             "text": "Vigilance, ward {2}\nOther Zombies you control have vigilance.\nWhenever another legendary creature you control dies, create a token that's a copy of that creature, except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -11281,7 +11281,7 @@
         },
         {
             "id": "f51eec83-c686-50a5-a889-de9f89de38d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d804a-09ea-4339-aa89-0ff2a5f5d4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d804a-09ea-4339-aa89-0ff2a5f5d4eb.jpg?1",
             "name": "Rith, Liberated Primeval",
             "text": "Flying, ward {2}\nOther Dragons you control have ward {2}.\nAt the beginning of your end step, if a creature or planeswalker an opponent controlled was dealt excess damage this turn, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "3ab9cb12-82bf-53df-a554-9041baf54e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6e2336-5bb6-4ea8-9c0a-961777176464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6e2336-5bb6-4ea8-9c0a-961777176464.jpg?1",
             "name": "Rivaz of the Claw",
             "text": "Menace\n{T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon creature spells.\nOnce during each of your turns, you may cast a Dragon creature spell from your graveyard.\nWhenever you cast a Dragon creature spell from your graveyard, it gains \"When this creature dies, exile it.\"",
             "colours": [
@@ -11366,7 +11366,7 @@
         },
         {
             "id": "93992073-d078-528e-8d25-da7f8eabad02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af90bf02-5732-4666-8dfd-50370e478711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af90bf02-5732-4666-8dfd-50370e478711.jpg?1",
             "name": "Rona, Sheoldred's Faithful",
             "text": "Whenever you cast an instant or sorcery spell, each opponent loses 1 life.\nYou may cast Rona, Sheoldred's Faithful from your graveyard by discarding two cards in addition to paying its other costs.",
             "colours": [
@@ -11408,7 +11408,7 @@
         },
         {
             "id": "00948fb7-4532-5e04-be18-8339a826a49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be69f87e-3fbb-4b37-953f-623443573fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be69f87e-3fbb-4b37-953f-623443573fca.jpg?1",
             "name": "Rulik Mons, Warren Chief",
             "text": "Menace\nWhenever Rulik Mons, Warren Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11449,7 +11449,7 @@
         },
         {
             "id": "0ff6cfa5-b9f6-5f9b-8659-03ebbe8df81d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d5e4c-bc67-47a1-85d9-cf862a38edf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d5e4c-bc67-47a1-85d9-cf862a38edf5.jpg?1",
             "name": "Shanna, Purifying Blade",
             "text": "Lifelink\nAt the beginning of your end step, you may pay {X}. If you do, draw X cards. X can't be greater than the amount of life you gained this turn.",
             "colours": [
@@ -11493,7 +11493,7 @@
         },
         {
             "id": "ead2c629-7f7e-5cb4-8050-bbc4beaa0b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2ea06b-dd6f-472b-85db-e8474deee8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2ea06b-dd6f-472b-85db-e8474deee8c5.jpg?1",
             "name": "Sol'Kanar the Tainted",
             "text": "At the beginning of your end step, choose one that hasn't been chosen \u2014\n\u2022 Draw a card.\n\u2022 Each opponent loses 2 life and you gain 2 life.\n\u2022 Sol'kanar the Tainted deals 3 damage to up to one other target creature or planeswalker.\n\u2022 Exile Sol'kanar, then return it to the battlefield under an opponent's control.",
             "colours": [
@@ -11537,7 +11537,7 @@
         },
         {
             "id": "6a49541f-79f3-5035-a44f-da9c4abefcd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92b23d2-d18a-41f9-9f1e-6809e7e02342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92b23d2-d18a-41f9-9f1e-6809e7e02342.jpg?1",
             "name": "Soul of Windgrace",
             "text": "Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -11581,7 +11581,7 @@
         },
         {
             "id": "c2081236-fc80-5df4-a32e-c9db9b6d7610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f73077b-ab99-4008-b49f-0cac4754f2ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f73077b-ab99-4008-b49f-0cac4754f2ee.jpg?1",
             "name": "Stenn, Paranoid Partisan",
             "text": "As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -11623,7 +11623,7 @@
         },
         {
             "id": "9986f2ab-343d-5dd7-8d25-de7f83c2e313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3f2dd-8745-4e2e-b01c-6b692c6ff8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c3f2dd-8745-4e2e-b01c-6b692c6ff8af.jpg?1",
             "name": "Tatyova, Steward of Tides",
             "text": "Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -11665,7 +11665,7 @@
         },
         {
             "id": "3e2d9951-7661-5d4d-a980-ff15a9b9cba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676bc62e-f685-45cb-bcdd-d8adbe9c4ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676bc62e-f685-45cb-bcdd-d8adbe9c4ccb.jpg?1",
             "name": "Tori D'Avenant, Fury Rider",
             "text": "Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn. Untap each other white attacking creature you control.",
             "colours": [
@@ -11707,7 +11707,7 @@
         },
         {
             "id": "e94559fe-45f6-5bea-8f75-c1de0821ada6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d710ba7b-b0c9-4372-8f6e-1938bd114ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d710ba7b-b0c9-4372-8f6e-1938bd114ac4.jpg?1",
             "name": "Tura Kenner\u00fcd, Skyknight",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -11749,7 +11749,7 @@
         },
         {
             "id": "690003a6-c512-59ed-89af-dca3ce414206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216b4613-9b2a-472b-bc9a-49ad6c9b9f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216b4613-9b2a-472b-bc9a-49ad6c9b9f03.jpg?1",
             "name": "Uurg, Spawn of Turg",
             "text": "Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\n{B}{G}, Sacrifice a land: You gain 2 life.",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "fdb72bd7-a70b-59db-a517-9a6938f45929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a573c574-754a-4994-881c-ca5177727775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a573c574-754a-4994-881c-ca5177727775.jpg?1",
             "name": "Vohar, Vodalian Desecrator",
             "text": "{T}: Draw a card, then discard a card. If you discarded an instant or sorcery card this way, each opponent loses 1 life and you gain 1 life.\n{2}, Sacrifice Vohar, Vodalian Desecrator: You may cast target instant or sorcery card from your graveyard this turn. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -11834,7 +11834,7 @@
         },
         {
             "id": "fda9912d-ed0c-5392-bd18-b120f6163eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15e0c8b-3609-4a59-8e9b-bf2ce93d775f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15e0c8b-3609-4a59-8e9b-bf2ce93d775f.jpg?1",
             "name": "Zar Ojanen, Scion of Efrava",
             "text": "Domain \u2014 Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.",
             "colours": [
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "9046c10d-ad51-5b58-a142-8da558db0999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf4693-668e-4498-a652-a9d5eb77f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf4693-668e-4498-a652-a9d5eb77f9b7.jpg?1",
             "name": "Zur, Eternal Schemer",
             "text": "Flying\nEnchantment creatures you control have deathtouch, lifelink, and hexproof.\n{1}{W}: Target non-Aura enchantment you control becomes a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -11920,7 +11920,7 @@
         },
         {
             "id": "d10199d5-6b0a-530f-be61-ff7aaf9097a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26070716-4860-4137-8316-083baef1faad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26070716-4860-4137-8316-083baef1faad.jpg?1",
             "name": "Danitha, Benalia's Hope",
             "text": "First strike, vigilance, lifelink\nWhen Danitha, Benalia's Hope enters the battlefield, you may put an Aura or Equipment card from your hand or graveyard onto the battlefield attached to Danitha.",
             "colours": [
@@ -11959,7 +11959,7 @@
         },
         {
             "id": "cb854b94-706d-5250-b9b0-27a9da4199b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e20d56c-20df-4fe9-a329-df5768a180af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e20d56c-20df-4fe9-a329-df5768a180af.jpg?1",
             "name": "Braids, Arisen Nightmare",
             "text": "At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.",
             "colours": [
@@ -11997,7 +11997,7 @@
         },
         {
             "id": "21165149-8426-548e-b9a0-4949983acb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee62bdd-3e29-442b-9ce4-1c66d12a5877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee62bdd-3e29-442b-9ce4-1c66d12a5877.jpg?1",
             "name": "The Raven Man",
             "text": "At the beginning of each end step, if a player discarded a card this turn, create a 1/1 black Bird creature token with flying and \"This creature can't block.\"\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -12036,7 +12036,7 @@
         },
         {
             "id": "228e2ce5-f36d-5ac8-9ba3-cc2ad2c37745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9494e5f-bfd2-45b0-b324-fd1407d9b644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9494e5f-bfd2-45b0-b324-fd1407d9b644.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -12078,7 +12078,7 @@
         },
         {
             "id": "72b9fc47-3e96-569a-b8f4-8ed43fcd9f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a6d17-d48d-409c-abf7-40b0526eae7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897a6d17-d48d-409c-abf7-40b0526eae7a.jpg?1",
             "name": "Squee, Dubious Monarch",
             "text": "Haste\nWhenever Squee, Dubious Monarch attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\nYou may cast Squee, Dubious Monarch from your graveyard by paying {3}{R} and exiling four other cards from your graveyard rather than paying its mana cost.",
             "colours": [
@@ -12117,7 +12117,7 @@
         },
         {
             "id": "e7a69198-8b9b-58c2-907e-14889ee8e5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f83110c-d6d3-4824-8acd-96b068b7f0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f83110c-d6d3-4824-8acd-96b068b7f0a5.jpg?1",
             "name": "Aron, Benalia's Ruin",
             "text": "Menace\n{W}{B}, {T}, Sacrifice another creature: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -12158,7 +12158,7 @@
         },
         {
             "id": "f2ba3a8e-944c-5332-a018-69d77f33b2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e390bd-a1ad-4abe-b6a2-ab9ce8059193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e390bd-a1ad-4abe-b6a2-ab9ce8059193.jpg?1",
             "name": "Astor, Bearer of Blades",
             "text": "When Astor, Bearer of Blades enters the battlefield, look at the top seven cards of your library. You may reveal an Equipment or Vehicle card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquipment you control have equip {1}.\nVehicles you control have crew 1.",
             "colours": [
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "823cac09-cb3c-549d-a127-454f38e922d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba3078-c06e-41d1-a574-1a2ff09c63d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba3078-c06e-41d1-a574-1a2ff09c63d9.jpg?1",
             "name": "Baird, Argivian Recruiter",
             "text": "At the beginning of your end step, if you control a creature with power greater than its base power, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -12240,7 +12240,7 @@
         },
         {
             "id": "295106b1-ee37-548a-97de-040fc9df6ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07452998-e70a-4c15-9b09-6f33aa0d933d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07452998-e70a-4c15-9b09-6f33aa0d933d.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -12281,7 +12281,7 @@
         },
         {
             "id": "226e11b0-d139-59d2-ad7c-96e4c3aa52c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01f1f1f-e0b9-4640-ab5e-c2af4bf9df51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01f1f1f-e0b9-4640-ab5e-c2af4bf9df51.jpg?1",
             "name": "Bortuk Bonerattle",
             "text": "Domain \u2014 When Bortuk Bonerattle enters the battlefield, if you cast it, choose target creature card in your graveyard. Return that card to the battlefield if its mana value is less than or equal to the number of basic land types among lands you control. Otherwise, put it into your hand.",
             "colours": [
@@ -12322,7 +12322,7 @@
         },
         {
             "id": "31f81403-5240-5d53-8291-06d044f204cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e03e38f-cfbf-4e59-8639-d9f015714058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e03e38f-cfbf-4e59-8639-d9f015714058.jpg?1",
             "name": "Elas il-Kor, Sadistic Pilgrim",
             "text": "Deathtouch\nWhenever another creature enters the battlefield under your control, you gain 1 life.\nWhenever another creature you control dies, each opponent loses 1 life.",
             "colours": [
@@ -12364,7 +12364,7 @@
         },
         {
             "id": "443e5570-a0e5-5ce3-b169-2d30849f47b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46a2ca-27fd-44d4-80d0-7c83ed0a564e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46a2ca-27fd-44d4-80d0-7c83ed0a564e.jpg?1",
             "name": "Ertai Resurrected",
             "text": "Flash\nWhen Ertai Resurrected enters the battlefield, choose up to one \u2014\n\u2022 Counter target spell, activated ability, or triggered ability. Its controller draws a card.\n\u2022 Destroy another target creature or planeswalker. Its controller draws a card.",
             "colours": [
@@ -12406,7 +12406,7 @@
         },
         {
             "id": "0b87f85e-85fd-53de-82de-68f568ff73db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ab0eb2-1c6d-4117-b620-81ba324dd4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ab0eb2-1c6d-4117-b620-81ba324dd4c7.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.",
             "colours": [
@@ -12447,7 +12447,7 @@
         },
         {
             "id": "f0f79ddd-ed23-5531-affa-70ebd0a297b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9187f4ea-27f2-4f94-b783-6992087d64a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9187f4ea-27f2-4f94-b783-6992087d64a4.jpg?1",
             "name": "Ivy, Gleeful Spellthief",
             "text": "Flying\nWhenever a player casts a spell that targets only a single creature other than Ivy, Gleeful Spellthief, you may copy that spell. The copy targets Ivy.",
             "colours": [
@@ -12488,7 +12488,7 @@
         },
         {
             "id": "2420a537-a9a0-50e7-b5f1-33a0e9a25768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c24b7f-256b-4759-8627-a07c5cde52ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c24b7f-256b-4759-8627-a07c5cde52ad.jpg?1",
             "name": "Jhoira, Ageless Innovator",
             "text": "{T}: Put two ingenuity counters on Jhoira, Ageless Innovator, then you may put an artifact card with mana value X or less from your hand onto the battlefield, where X is the number of ingenuity counters on Jhoira.",
             "colours": [
@@ -12529,7 +12529,7 @@
         },
         {
             "id": "216e5340-238a-5c80-84db-9968ca5cb727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb2313a-e002-4b37-9ecb-20bfe1799157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb2313a-e002-4b37-9ecb-20bfe1799157.jpg?1",
             "name": "Jodah, the Unifier",
             "text": "Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.\nWhenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12576,7 +12576,7 @@
         },
         {
             "id": "9d1b4dad-d1e8-57ae-907d-d90a07ddc972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b1257-2766-45d3-abc9-97f0d85d7010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b1257-2766-45d3-abc9-97f0d85d7010.jpg?1",
             "name": "King Darien XLVIII",
             "text": "Other creatures you control get +1/+1.\n{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token.\nSacrifice King Darien: Creature tokens you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -12617,7 +12617,7 @@
         },
         {
             "id": "0fcbf11a-036e-5021-ac6a-b863f958610c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175746b-e98e-448c-b3ca-bcbcdf2817cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175746b-e98e-448c-b3ca-bcbcdf2817cf.jpg?1",
             "name": "Lagomos, Hand of Hatred",
             "text": "At the beginning of combat on your turn, create a 2/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n{T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.",
             "colours": [
@@ -12658,7 +12658,7 @@
         },
         {
             "id": "389b6102-2959-5e83-b705-edc572763bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d4f9f-3a32-4bab-baa4-baf8102a8787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d4f9f-3a32-4bab-baa4-baf8102a8787.jpg?1",
             "name": "Meria, Scholar of Antiquity",
             "text": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -12699,7 +12699,7 @@
         },
         {
             "id": "07fb3d40-3973-5626-87ee-b23d56bf9767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd2081c-d53b-4a5e-976b-0b28465c0be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd2081c-d53b-4a5e-976b-0b28465c0be8.jpg?1",
             "name": "Nael, Avizoa Aeronaut",
             "text": "Flying\nDomain \u2014 Whenever Nael, Avizoa Aeronaut deals combat damage to a player, look at the top X cards of your library, where X is the number of basic land types among lands you control. Put up to one of them on top of your library and the rest on the bottom in a random order. Then if there are five basic land types among lands you control, draw a card.",
             "colours": [
@@ -12740,7 +12740,7 @@
         },
         {
             "id": "6eca4c02-1e25-590e-ade0-d0d00191244e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686ec9c3-9549-42e6-8cb5-d00f8cae0f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686ec9c3-9549-42e6-8cb5-d00f8cae0f16.jpg?1",
             "name": "Najal, the Storm Runner",
             "text": "You may cast sorcery spells as though they had flash.\nWhenever Najal, the Storm Runner attacks, you may pay {2}. If you do, when you cast your next instant or sorcery spell this turn, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -12781,7 +12781,7 @@
         },
         {
             "id": "e01f5cd1-8202-5a2c-87f7-0be1533018aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739f7a27-93a6-4ebf-bc3c-e3caf49fce5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739f7a27-93a6-4ebf-bc3c-e3caf49fce5d.jpg?1",
             "name": "Nemata, Primeval Warden",
             "text": "Reach\nIf a creature an opponent controls would die, exile it instead. When you do, create a 1/1 green Saproling creature token.\n{G}, Sacrifice a Saproling: Nemata, Primeval Warden gets +2/+2 until end of turn.\n{1}{B}, Sacrifice two Saprolings: Draw a card.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "a05f975b-104c-5b95-8dd2-22afce65b643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d66aab-d99c-46de-ba72-b6b5fa0847c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d66aab-d99c-46de-ba72-b6b5fa0847c2.jpg?1",
             "name": "Queen Allenal of Ruadach",
             "text": "Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.\nIf one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.",
             "colours": [
@@ -12862,7 +12862,7 @@
         },
         {
             "id": "524eb6a0-2040-527b-a5dc-61ef692c09c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0336da59-a51a-4b23-965c-06532d1f3a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0336da59-a51a-4b23-965c-06532d1f3a23.jpg?1",
             "name": "Radha, Coalition Warlord",
             "text": "Domain \u2014 Whenever Radha, Coalition Warlord becomes tapped, another target creature you control gets +X/+X until end of turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -12903,7 +12903,7 @@
         },
         {
             "id": "0fbb959d-e4a2-5044-a11b-715d9047cf26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf938c0-b32f-4780-b628-457874eae638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf938c0-b32f-4780-b628-457874eae638.jpg?1",
             "name": "Raff, Weatherlight Stalwart",
             "text": "Whenever you cast an instant or sorcery spell, you may tap two untapped creatures you control. If you do, draw a card.\n{3}{W}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -12944,7 +12944,7 @@
         },
         {
             "id": "f1a207ba-33d3-51e8-91e2-c84edd007811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce0c81-1c30-4971-ae6f-a9c6a4dd017d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce0c81-1c30-4971-ae6f-a9c6a4dd017d.jpg?1",
             "name": "Ratadrabik of Urborg",
             "text": "Vigilance, ward {2}\nOther Zombies you control have vigilance.\nWhenever another legendary creature you control dies, create a token that's a copy of that creature, except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -12985,7 +12985,7 @@
         },
         {
             "id": "0c1b7f76-93ac-5ad4-a35c-096afae678d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5370c07-5158-4cd8-87d2-433f4b1f6e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5370c07-5158-4cd8-87d2-433f4b1f6e02.jpg?1",
             "name": "Rith, Liberated Primeval",
             "text": "Flying, ward {2}\nOther Dragons you control have ward {2}.\nAt the beginning of your end step, if a creature or planeswalker an opponent controlled was dealt excess damage this turn, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -13027,7 +13027,7 @@
         },
         {
             "id": "8c6afd10-a027-5587-8761-5b124118a114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8218a4-1861-4ac6-9e36-4d6ff4199f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8218a4-1861-4ac6-9e36-4d6ff4199f55.jpg?1",
             "name": "Rivaz of the Claw",
             "text": "Menace\n{T}: Add two mana in any combination of colors. Spend this mana only to cast Dragon creature spells.\nOnce during each of your turns, you may cast a Dragon creature spell from your graveyard.\nWhenever you cast a Dragon creature spell from your graveyard, it gains \"When this creature dies, exile it.\"",
             "colours": [
@@ -13068,7 +13068,7 @@
         },
         {
             "id": "6287aaef-d2ba-588d-ae9f-e8edfc973963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ed0d3c-def9-4ba5-98d4-5bf35d711ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ed0d3c-def9-4ba5-98d4-5bf35d711ec9.jpg?1",
             "name": "Rona, Sheoldred's Faithful",
             "text": "Whenever you cast an instant or sorcery spell, each opponent loses 1 life.\nYou may cast Rona, Sheoldred's Faithful from your graveyard by discarding two cards in addition to paying its other costs.",
             "colours": [
@@ -13109,7 +13109,7 @@
         },
         {
             "id": "e003c785-e861-5da0-afc7-bba89d71e69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c79f75-0389-4514-b86f-5ee353965c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c79f75-0389-4514-b86f-5ee353965c02.jpg?1",
             "name": "Rulik Mons, Warren Chief",
             "text": "Menace\nWhenever Rulik Mons, Warren Chief attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you didn't put a card onto the battlefield this way, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -13149,7 +13149,7 @@
         },
         {
             "id": "7c093216-3992-525f-a30e-ae5865c74e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b31f4-600c-4be6-a6db-b991447527ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b31f4-600c-4be6-a6db-b991447527ec.jpg?1",
             "name": "Shanna, Purifying Blade",
             "text": "Lifelink\nAt the beginning of your end step, you may pay {X}. If you do, draw X cards. X can't be greater than the amount of life you gained this turn.",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "9bdcf60e-d894-5cc8-9d6b-9bfbd93d1e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bccbe5e-4076-429d-96e4-a6dd14adcfa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bccbe5e-4076-429d-96e4-a6dd14adcfa1.jpg?1",
             "name": "Sol'Kanar the Tainted",
             "text": "At the beginning of your end step, choose one that hasn't been chosen \u2014\n\u2022 Draw a card.\n\u2022 Each opponent loses 2 life and you gain 2 life.\n\u2022 Sol'kanar the Tainted deals 3 damage to up to one other target creature or planeswalker.\n\u2022 Exile Sol'kanar, then return it to the battlefield under an opponent's control.",
             "colours": [
@@ -13235,7 +13235,7 @@
         },
         {
             "id": "5e774cfe-d40e-5b1b-883c-0d156d99a0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9ce534-4bd4-4ba1-b875-7f74dd5f712c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9ce534-4bd4-4ba1-b875-7f74dd5f712c.jpg?1",
             "name": "Soul of Windgrace",
             "text": "Whenever Soul of Windgrace enters the battlefield or attacks, you may put a land card from a graveyard onto the battlefield tapped under your control.\n{G}, Discard a land card: You gain 3 life.\n{1}{R}, Discard a land card: Draw a card.\n{2}{B}, Discard a land card: Soul of Windgrace gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -13278,7 +13278,7 @@
         },
         {
             "id": "979d5a36-747d-5e56-b242-70605b9ff8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb5bd07-b456-4f0e-9e39-2c4a89b32327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb5bd07-b456-4f0e-9e39-2c4a89b32327.jpg?1",
             "name": "Stenn, Paranoid Partisan",
             "text": "As Stenn, Paranoid Partisan enters the battlefield, choose a card type other than creature or land.\nSpells you cast of the chosen type cost {1} less to cast.\n{1}{W}{U}: Exile Stenn. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -13319,7 +13319,7 @@
         },
         {
             "id": "402c4f97-9f5f-5dff-85ec-667e2986e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3296c85f-01f6-42b4-96d6-0c576617dbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3296c85f-01f6-42b4-96d6-0c576617dbd8.jpg?1",
             "name": "Tatyova, Steward of Tides",
             "text": "Land creatures you control have flying.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, up to one target land you control becomes a 3/3 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -13360,7 +13360,7 @@
         },
         {
             "id": "1b7a5236-9697-57dc-b53f-f0714f615507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd8ea0-05be-4db1-8f7b-bccbb484d552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bd8ea0-05be-4db1-8f7b-bccbb484d552.jpg?1",
             "name": "Tori D'Avenant, Fury Rider",
             "text": "Vigilance, trample\nWhenever Tori D'Avenant, Fury Rider attacks, all other attacking creatures you control get +1/+1 until end of turn. Other red attacking creatures you control gain trample until end of turn. Untap each other white attacking creature you control.",
             "colours": [
@@ -13401,7 +13401,7 @@
         },
         {
             "id": "85789f92-f23d-5e60-b619-512a44d87c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaef59b-639c-4f97-addd-a32a523dd961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaef59b-639c-4f97-addd-a32a523dd961.jpg?1",
             "name": "Tura Kenner\u00fcd, Skyknight",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -13442,7 +13442,7 @@
         },
         {
             "id": "c6b4cab7-2ee4-5d6d-9a9d-d0f21f7a79c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98cc9a0-8c7e-435d-b041-63717e57ce1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98cc9a0-8c7e-435d-b041-63717e57ce1f.jpg?1",
             "name": "Uurg, Spawn of Turg",
             "text": "Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\n{B}{G}, Sacrifice a land: You gain 2 life.",
             "colours": [
@@ -13483,7 +13483,7 @@
         },
         {
             "id": "3f6ff04a-5649-53ab-a358-08b348609c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2124e308-091c-4a0d-8631-e3106636b59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2124e308-091c-4a0d-8631-e3106636b59b.jpg?1",
             "name": "Vohar, Vodalian Desecrator",
             "text": "{T}: Draw a card, then discard a card. If you discarded an instant or sorcery card this way, each opponent loses 1 life and you gain 1 life.\n{2}, Sacrifice Vohar, Vodalian Desecrator: You may cast target instant or sorcery card from your graveyard this turn. If that spell would be put into your graveyard, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -13525,7 +13525,7 @@
         },
         {
             "id": "2ae3e82d-7091-52ed-95ab-14b8749aebc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9afd7c2-fe9b-4ccd-bd55-a0f91c52fd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9afd7c2-fe9b-4ccd-bd55-a0f91c52fd29.jpg?1",
             "name": "Zar Ojanen, Scion of Efrava",
             "text": "Domain \u2014 Whenever Zar Ojanen, Scion of Efrava becomes tapped, put a +1/+1 counter on each creature you control with toughness less than the number of basic land types among lands you control.",
             "colours": [
@@ -13566,7 +13566,7 @@
         },
         {
             "id": "54d573d6-f0ea-58a7-a274-1b38fc463422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95979e43-7f1d-4c06-8f28-5ea378633c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95979e43-7f1d-4c06-8f28-5ea378633c14.jpg?1",
             "name": "Zur, Eternal Schemer",
             "text": "Flying\nEnchantment creatures you control have deathtouch, lifelink, and hexproof.\n{1}{W}: Target non-Aura enchantment you control becomes a creature in addition to its other types and has base power and base toughness each equal to its mana value.",
             "colours": [
@@ -13609,7 +13609,7 @@
         },
         {
             "id": "c0a8a0d5-4a99-52cb-bb9b-8faad45cb4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ebbb6d-04f8-42ec-a1b7-6ca67994b8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ebbb6d-04f8-42ec-a1b7-6ca67994b8d3.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "Deathtouch\nWhenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
             "colours": [
@@ -13652,7 +13652,7 @@
         },
         {
             "id": "b0ab486a-1e98-5e52-94b5-c76239dcdb74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2af6c1-fdf1-4d04-bd74-f07da939110a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2af6c1-fdf1-4d04-bd74-f07da939110a.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13695,7 +13695,7 @@
         },
         {
             "id": "2cca9e31-a1ec-5a14-b7c2-4c41ce876b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea352f02-de67-4da6-8049-d3031c0877ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea352f02-de67-4da6-8049-d3031c0877ae.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13738,7 +13738,7 @@
         },
         {
             "id": "cb6cd168-e0cf-560d-80a2-533afbb613aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493341c3-1f59-4d7e-b852-1449a2333be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493341c3-1f59-4d7e-b852-1449a2333be9.jpg?1",
             "name": "Karn, Living Legacy",
             "text": "+1: Create a tapped Powerstone token. (It's an artifact with \"{T}: Add {C}. This mana can't be spent to cast a nonartifact spell.\")\n\u22121: Pay any amount of mana. Look at that many cards from the top of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.\n\u22127: You get an emblem with \"Tap an untapped artifact you control: This emblem deals 1 damage to any target.\"",
             "colours": [],
@@ -13772,7 +13772,7 @@
         },
         {
             "id": "987670e7-5626-53b3-a110-c0ed6588f6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18b8768-4126-4636-990e-21b4308740dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18b8768-4126-4636-990e-21b4308740dc.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
             "colours": [
@@ -13810,7 +13810,7 @@
         },
         {
             "id": "e02c20d5-0dd0-5ffe-967e-f2e6b6cee355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a532c-94c3-4302-9fba-af8396329890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a532c-94c3-4302-9fba-af8396329890.jpg?1",
             "name": "Jaya, Fiery Negotiator",
             "text": "+1: Create a 1/1 red Monk creature token with prowess.\n\u22121: Exile the top two cards of your library. Choose one of them. You may play that card this turn.\n\u22122: Choose target creature an opponent controls. Whenever you attack this turn, Jaya, Fiery Negotiator deals damage equal to the number of attacking creatures to that creature.\n\u22128: You get an emblem with \"Whenever you cast a red instant or sorcery spell, copy it twice. You may choose new targets for the copies.\"",
             "colours": [
@@ -13848,7 +13848,7 @@
         },
         {
             "id": "b670515f-de66-567e-921d-ebfc7911664c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d14829d-3119-4c65-8e9a-5281771bbaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d14829d-3119-4c65-8e9a-5281771bbaf3.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13891,7 +13891,7 @@
         },
         {
             "id": "85c16d6e-21ce-57f0-9671-cb545d603836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894a44e-ac13-453f-b45a-ab6bec574197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6894a44e-ac13-453f-b45a-ab6bec574197.jpg?1",
             "name": "Ajani, Sleeper Agent",
             "text": "Compleated ({Phyrexian Mana} can be paid with {G}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Reveal the top card of your library. If it's a creature or planeswalker card, put it into your hand. Otherwise, you may put it on the bottom of your library.\n\u22123: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.\n\u22126: You get an emblem with \"Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters.\"",
             "colours": [
@@ -13934,7 +13934,7 @@
         },
         {
             "id": "941db312-aef6-586a-940d-94e19b221a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5764bd-712b-4e6b-b71e-5767d5613b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5764bd-712b-4e6b-b71e-5767d5613b1c.jpg?1",
             "name": "Adarkar Wastes",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "90205dbc-63ce-59ee-87b8-627811a2c4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7328a565-966d-4053-b32b-25bdce031d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7328a565-966d-4053-b32b-25bdce031d9f.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -14000,7 +14000,7 @@
         },
         {
             "id": "3b8734ef-2061-5938-b10f-5a3ef6f4b4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83eca4-b6ad-4ec4-91f2-b2a62b32b056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a83eca4-b6ad-4ec4-91f2-b2a62b32b056.jpg?1",
             "name": "Karplusan Forest",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {G}. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -14033,7 +14033,7 @@
         },
         {
             "id": "90ff98d7-1b4e-50e7-89c2-0064cd7112d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c11164-e98c-4f09-9840-825bd1f91247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c11164-e98c-4f09-9840-825bd1f91247.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -14066,7 +14066,7 @@
         },
         {
             "id": "01a11b62-380d-5ceb-8c9c-77c28f48498d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba5d3e7-afd9-40c5-8ee9-238ba47f0841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba5d3e7-afd9-40c5-8ee9-238ba47f0841.jpg?1",
             "name": "Sulfurous Springs",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -14099,7 +14099,7 @@
         },
         {
             "id": "82260831-cf64-5335-8ef8-8aa88eb9d0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa9c09-5eeb-466f-a8f5-9898de6e7c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa9c09-5eeb-466f-a8f5-9898de6e7c88.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -14132,7 +14132,7 @@
         },
         {
             "id": "e51899f5-2480-5e01-91a3-1bc6f0465173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aba15c0-fbc6-473f-8da9-522aa582b2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aba15c0-fbc6-473f-8da9-522aa582b2bf.jpg?1",
             "name": "Anointed Peacekeeper",
             "text": "Vigilance\nAs Anointed Peacekeeper enters the battlefield, look at an opponent's hand, then choose any card name.\nSpells your opponents cast with the chosen name cost {2} more to cast.\nActivated abilities of sources with the chosen name cost {2} more to activate unless they're mana abilities.",
             "colours": [
@@ -14169,7 +14169,7 @@
         },
         {
             "id": "31006dd0-e4b8-5c13-9ad4-efbee3de5874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9e837-a1eb-48d9-a8bd-94dd54ad97d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9e837-a1eb-48d9-a8bd-94dd54ad97d1.jpg?1",
             "name": "Archangel of Wrath",
             "text": "Kicker {B} and/or {R}\nFlying, lifelink\nWhen Archangel of Wrath enters the battlefield, if it was kicked, it deals 2 damage to any target.\nWhen Archangel of Wrath enters the battlefield, if it was kicked twice, it deals 2 damage to any target.",
             "colours": [
@@ -14207,7 +14207,7 @@
         },
         {
             "id": "c1972fad-ff9b-524b-9bee-22acf5191643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fa16ec-b4ab-4da8-a1fa-cf6c303edc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fa16ec-b4ab-4da8-a1fa-cf6c303edc7a.jpg?1",
             "name": "Defiler of Faith",
             "text": "Vigilance\nAs an additional cost to cast white permanent spells, you may pay 2 life. Those spells cost {W} less to cast if you paid life this way. This effect reduces only the amount of white mana you pay.\nWhenever you cast a white permanent spell, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "83f9c535-689f-52f1-bcc4-8e5ac9a59202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75168c8-6798-46cd-8dd7-22115203cb2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75168c8-6798-46cd-8dd7-22115203cb2b.jpg?1",
             "name": "Guardian of New Benalia",
             "text": "Enlist\nWhenever Guardian of New Benalia enlists a creature, scry 2.\nDiscard a card: Guardian of New Benalia gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -14281,7 +14281,7 @@
         },
         {
             "id": "0b7a6350-25f2-5dbe-aad4-f13e38ca3fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32da8479-7d0e-4eb1-b18c-66eb170e31a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32da8479-7d0e-4eb1-b18c-66eb170e31a5.jpg?1",
             "name": "Leyline Binding",
             "text": "Flash\nDomain \u2014 This spell costs {1} less to cast for each basic land type among lands you control.\nWhen Leyline Binding enters the battlefield, exile target nonland permanent an opponent controls until Leyline Binding leaves the battlefield.",
             "colours": [
@@ -14315,7 +14315,7 @@
         },
         {
             "id": "1f21ff2f-5fbe-588f-b909-511ca731ef9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69284b53-f712-418c-94a0-4e5638117256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69284b53-f712-418c-94a0-4e5638117256.jpg?1",
             "name": "Serra Paragon",
             "text": "Flying\nOnce during each of your turns, you may play a land from your graveyard or cast a permanent spell with mana value 3 or less from your graveyard. If you do, it gains \"When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life.\"",
             "colours": [
@@ -14351,7 +14351,7 @@
         },
         {
             "id": "eee091de-f5e8-540e-8937-9c5409250d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9672bc7-ccc9-4f89-ad92-60e130369336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9672bc7-ccc9-4f89-ad92-60e130369336.jpg?1",
             "name": "Temporary Lockdown",
             "text": "When Temporary Lockdown enters the battlefield, exile each nonland permanent with mana value 2 or less until Temporary Lockdown leaves the battlefield.",
             "colours": [
@@ -14385,7 +14385,7 @@
         },
         {
             "id": "9ef38776-95ae-52c1-a36f-3bd5a27badb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90492217-d6c1-4fc0-87b8-f66dc49c3265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90492217-d6c1-4fc0-87b8-f66dc49c3265.jpg?1",
             "name": "Valiant Veteran",
             "text": "Other Soldiers you control get +1/+1.\n{3}{W}{W}, Exile Valiant Veteran from your graveyard: Put a +1/+1 counter on each Soldier you control.",
             "colours": [
@@ -14422,7 +14422,7 @@
         },
         {
             "id": "2a259473-33e2-51e9-b56f-162a7e37e660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2aaf56-5597-47f3-bc7c-49943799d4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2aaf56-5597-47f3-bc7c-49943799d4de.jpg?1",
             "name": "Academy Loremaster",
             "text": "At the beginning of each player's draw step, that player may draw an additional card. If they do, spells they cast this turn cost {2} more to cast.",
             "colours": [
@@ -14459,7 +14459,7 @@
         },
         {
             "id": "e9483ecb-d2e6-58d7-8f1d-2de905ab3d31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2026190a-1463-4b55-923c-bc00c85ef3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2026190a-1463-4b55-923c-bc00c85ef3e0.jpg?1",
             "name": "Aether Channeler",
             "text": "When Aether Channeler enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 white Bird creature token with flying.\n\u2022 Return another target nonland permanent to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -14496,7 +14496,7 @@
         },
         {
             "id": "6f77c4c5-c1b8-5ec4-a40c-00fb5b2b78b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8640da59-6ff1-4171-9723-5ef56dc59fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8640da59-6ff1-4171-9723-5ef56dc59fbc.jpg?1",
             "name": "Defiler of Dreams",
             "text": "Flying\nAs an additional cost to cast blue permanent spells, you may pay 2 life. Those spells cost {U} less to cast if you paid life this way. This effect reduces only the amount of blue mana you pay.\nWhenever you cast a blue permanent spell, draw a card.",
             "colours": [
@@ -14533,7 +14533,7 @@
         },
         {
             "id": "4d39415c-4f85-5d18-a11d-24fe2a544d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e127cb-1d35-4851-93e2-66b42d58da8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e127cb-1d35-4851-93e2-66b42d58da8d.jpg?1",
             "name": "Haughty Djinn",
             "text": "Flying\nHaughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -14569,7 +14569,7 @@
         },
         {
             "id": "e6e32187-cc4b-5a5c-9999-c27feebd481a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cedd68-c170-4b97-9035-e0a6398482f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cedd68-c170-4b97-9035-e0a6398482f0.jpg?1",
             "name": "Silver Scrutiny",
             "text": "You may cast Silver Scrutiny as though it had flash if X is 3 or less.\nDraw X cards.",
             "colours": [
@@ -14603,7 +14603,7 @@
         },
         {
             "id": "eb0a61e0-e074-5614-8df0-529939e8c4a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf41d9-d44c-46f8-86e5-f4491541cea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf41d9-d44c-46f8-86e5-f4491541cea4.jpg?1",
             "name": "Sphinx of Clear Skies",
             "text": "Flying, ward {2}\nDomain \u2014 Whenever Sphinx of Clear Skies deals combat damage to a player, reveal the top X cards of your library, where X is the number of basic land types among lands you control. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -14639,7 +14639,7 @@
         },
         {
             "id": "e47cd188-c0cd-5392-a66c-35dcb7574fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ab9af3-718e-49fa-96d3-da67bc55c7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ab9af3-718e-49fa-96d3-da67bc55c7d4.jpg?1",
             "name": "Vesuvan Duplimancy",
             "text": "Whenever you cast a spell that targets only a single artifact or creature you control, create a token that's a copy of that artifact or creature, except it's not legendary.",
             "colours": [
@@ -14673,7 +14673,7 @@
         },
         {
             "id": "0518ecc2-4457-5538-803e-1217d13b89a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1198e0f9-7240-4eae-85d1-4b8ee5d61458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1198e0f9-7240-4eae-85d1-4b8ee5d61458.jpg?1",
             "name": "Vodalian Hexcatcher",
             "text": "Flash\nOther Merfolk you control get +1/+1.\nSacrifice a Merfolk: Counter target noncreature spell unless its controller pays {1}.",
             "colours": [
@@ -14710,7 +14710,7 @@
         },
         {
             "id": "31c7c708-b29e-58ef-9e39-944f8a4b905d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb97507-e332-410c-8f8c-3aa77c235742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb97507-e332-410c-8f8c-3aa77c235742.jpg?1",
             "name": "Vodalian Mindsinger",
             "text": "Kicker {1}{R} and/or {1}{G}\nVodalian Mindsinger enters the battlefield with two +1/+1 counters on it for each time it was kicked.\nWhen Vodalian Mindsinger enters the battlefield, gain control of target creature with power less than Vodalian Mindsinger's power for as long as you control Vodalian Mindsinger.",
             "colours": [
@@ -14749,7 +14749,7 @@
         },
         {
             "id": "299f6fc7-715e-5c54-9d99-202c84f196db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c27d94e-7dc8-45b4-aac6-b30a677b8ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c27d94e-7dc8-45b4-aac6-b30a677b8ad5.jpg?1",
             "name": "Defiler of Flesh",
             "text": "Menace\nAs an additional cost to cast black permanent spells, you may pay 2 life. Those spells cost {B} less to cast if you paid life this way. This effect reduces only the amount of black mana you pay.\nWhenever you cast a black permanent spell, target creature you control gets +1/+1 and gains menace until end of turn.",
             "colours": [
@@ -14786,7 +14786,7 @@
         },
         {
             "id": "0fab5150-9cd5-554e-8e51-e272c9d12b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f72da0d-f48d-438d-8bc8-23e509a47149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f72da0d-f48d-438d-8bc8-23e509a47149.jpg?1",
             "name": "Drag to the Bottom",
             "text": "Domain \u2014 Each creature gets -X/-X until end of turn, where X is 1 plus the number of basic land types among lands you control.",
             "colours": [
@@ -14820,7 +14820,7 @@
         },
         {
             "id": "679cb1cb-9ec8-53cd-9d34-eb2108520998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c7253c-eb58-4b89-b1ae-a025e8ad1c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c7253c-eb58-4b89-b1ae-a025e8ad1c20.jpg?1",
             "name": "Evolved Sleeper",
             "text": "{B}: Evolved Sleeper becomes a Human Cleric with base power and toughness 2/2.\n{1}{B}: If Evolved Sleeper is a Cleric, put a deathtouch counter on it and it becomes a Phyrexian Human Cleric with base power and toughness 3/3.\n{1}{B}{B}: If Evolved Sleeper is a Phyrexian, put a +1/+1 counter on it, then you draw a card and you lose 1 life.",
             "colours": [
@@ -14856,7 +14856,7 @@
         },
         {
             "id": "7126842e-207e-54d9-920e-3041de35e4ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac9e1a7-544b-4c13-8c41-8fecc0232446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac9e1a7-544b-4c13-8c41-8fecc0232446.jpg?1",
             "name": "Shadow-Rite Priest",
             "text": "Other Clerics you control get +1/+1.\n{3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "2fa00b00-908d-5f3d-8ab8-c458a2e6873c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c48497-7ef8-4b45-b160-8af28d8e61ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c48497-7ef8-4b45-b160-8af28d8e61ba.jpg?1",
             "name": "Stronghold Arena",
             "text": "Kicker {G} and/or {W}\nWhen Stronghold Arena enters the battlefield, you gain 3 life for each time it was kicked.\nWhenever one or more creatures you control deal combat damage to a player, you may reveal the top card of your library and put it into your hand. If you do, you lose life equal to its mana value.",
             "colours": [
@@ -14929,7 +14929,7 @@
         },
         {
             "id": "75af9d4b-f095-5081-b8db-14f66ea7fdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8995e45-3ff3-48d5-97ac-7c982f80f640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8995e45-3ff3-48d5-97ac-7c982f80f640.jpg?1",
             "name": "Chaotic Transformation",
             "text": "Exile up to one target artifact, up to one target creature, up to one target enchantment, up to one target planeswalker, and/or up to one target land. For each permanent exiled this way, its controller reveals cards from the top of their library until they reveal a card that shares a card type with it, puts that card onto the battlefield, then shuffles.",
             "colours": [
@@ -14963,7 +14963,7 @@
         },
         {
             "id": "69d2a70f-dca6-5520-95d9-5aeec202d289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cadcc4-ed5e-4396-9034-ffcce3a3ed82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cadcc4-ed5e-4396-9034-ffcce3a3ed82.jpg?1",
             "name": "Defiler of Instinct",
             "text": "First strike\nAs an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.\nWhenever you cast a red permanent spell, Defiler of Instinct deals 1 damage to any target.",
             "colours": [
@@ -15000,7 +15000,7 @@
         },
         {
             "id": "031b2f99-a5ed-5a6e-8bb5-98a5710f85dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dacef18-5c0d-4c99-8273-1f9c896552bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dacef18-5c0d-4c99-8273-1f9c896552bf.jpg?1",
             "name": "Keldon Flamesage",
             "text": "Enlist\nWhenever Keldon Flamesage attacks, look at the top X cards of your library, where X is Keldon Flamesage's power. You may exile an instant or sorcery card with mana value X or less from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -15037,7 +15037,7 @@
         },
         {
             "id": "1cb8bc21-0bdd-5064-bb2a-e20a45da3838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20e461-2850-4404-838a-ad2c810100b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20e461-2850-4404-838a-ad2c810100b5.jpg?1",
             "name": "Radha's Firebrand",
             "text": "Whenever Radha's Firebrand attacks, target creature defending player controls with power less than Radha's Firebrand's power can't block this turn.\nDomain \u2014 {5}{R}: Radha's Firebrand gets +2/+2 until end of turn. This ability costs {1} less to activate for each basic land type among lands you control. Activate only once each turn.",
             "colours": [
@@ -15074,7 +15074,7 @@
         },
         {
             "id": "b58d9a6e-cae1-560d-a318-0961c65c88fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060d14a4-e903-4c89-9c3a-baa91f125c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060d14a4-e903-4c89-9c3a-baa91f125c4e.jpg?1",
             "name": "Rundvelt Hordemaster",
             "text": "Other Goblins you control get +1/+1.\nWhenever Rundvelt Hordemaster or another Goblin you control dies, exile the top card of your library. If it's a Goblin creature card, you may cast that card until the end of your next turn.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "bc44b8ad-ebc9-5f87-a3bb-1fb30ada89e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaca6ca-58e0-4846-b9b7-5ac9547bcde5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaca6ca-58e0-4846-b9b7-5ac9547bcde5.jpg?1",
             "name": "Shivan Devastator",
             "text": "Flying, haste\nShivan Devastator enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "7ac31d7d-fb21-503e-9651-7d6378005b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3affc335-ebb4-46e4-8f84-ba204804100e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3affc335-ebb4-46e4-8f84-ba204804100e.jpg?1",
             "name": "Temporal Firestorm",
             "text": "Kicker {1}{W} and/or {1}{U}\nChoose up to X creatures and/or planeswalkers you control, where X is the number of times this spell was kicked. Those permanents phase out.\nTemporal Firestorm deals 5 damage to each creature and each planeswalker.",
             "colours": [
@@ -15184,7 +15184,7 @@
         },
         {
             "id": "5eed1a87-045c-533b-9986-9a335f6b4105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644ec3b-fa6e-4642-8367-35a3ba1f88de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644ec3b-fa6e-4642-8367-35a3ba1f88de.jpg?1",
             "name": "Defiler of Vigor",
             "text": "Trample\nAs an additional cost to cast green permanent spells, you may pay 2 life. Those spells cost {G} less to cast if you paid life this way. This effect reduces only the amount of green mana you pay.\nWhenever you cast a green permanent spell, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -15221,7 +15221,7 @@
         },
         {
             "id": "261f1b2c-5655-56b2-b3e6-a7c54bb73573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2ff77-09ac-4833-9d3a-47bac7428086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f2ff77-09ac-4833-9d3a-47bac7428086.jpg?1",
             "name": "Herd Migration",
             "text": "Domain \u2014 Create a 3/3 green Beast creature token for each basic land type among lands you control.\n{1}{G}, Discard Herd Migration: Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -15256,7 +15256,7 @@
         },
         {
             "id": "18b9b1b0-2770-5869-8005-2879d1022996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7bc1f4-a0f5-42ee-b9ee-499fed12f884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7bc1f4-a0f5-42ee-b9ee-499fed12f884.jpg?1",
             "name": "Leaf-Crowned Visionary",
             "text": "Other Elves you control get +1/+1.\nWhenever you cast an Elf spell, you may pay {G}. If you do, draw a card.",
             "colours": [
@@ -15293,7 +15293,7 @@
         },
         {
             "id": "be726bbe-560b-5a93-a130-656ae85cc22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8236d62a-bce3-4c5d-8224-f717188e34c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8236d62a-bce3-4c5d-8224-f717188e34c9.jpg?1",
             "name": "Llanowar Greenwidow",
             "text": "Reach, trample\nDomain \u2014 {7}{G}: Return Llanowar Greenwidow from your graveyard to the battlefield tapped. tapped. It gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\" This ability costs {1} less to activate for each basic land type among lands you control.",
             "colours": [
@@ -15329,7 +15329,7 @@
         },
         {
             "id": "7c97dfc9-e16d-522c-99e3-875a9efb0b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdb1dfd-6394-414f-959e-9f129a3ab1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdb1dfd-6394-414f-959e-9f129a3ab1a1.jpg?1",
             "name": "Llanowar Loamspeaker",
             "text": "{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.",
             "colours": [
@@ -15367,7 +15367,7 @@
         },
         {
             "id": "3862bd72-18ae-5550-9955-d50e6bf50436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba11bcd6-7ce1-410e-95df-7ab63116503a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba11bcd6-7ce1-410e-95df-7ab63116503a.jpg?1",
             "name": "Quirion Beastcaller",
             "text": "Whenever you cast a creature spell, put a +1/+1 counter on Quirion Beastcaller.\nWhen Quirion Beastcaller dies, distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on Quirion Beastcaller.",
             "colours": [
@@ -15404,7 +15404,7 @@
         },
         {
             "id": "4a4c94c5-bf23-550c-94ce-df7532213965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8efd65-65d0-47b9-beb3-dc895993af9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8efd65-65d0-47b9-beb3-dc895993af9a.jpg?1",
             "name": "Silverback Elder",
             "text": "Whenever you cast a creature spell, choose one \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\n\u2022 You gain 4 life.",
             "colours": [
@@ -15441,7 +15441,7 @@
         },
         {
             "id": "d04fbd21-d864-522e-ace9-af2187f56a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2bdf21-fad4-4c86-ba74-d5d262e46228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2bdf21-fad4-4c86-ba74-d5d262e46228.jpg?1",
             "name": "Threats Undetected",
             "text": "Search your library for up to four creature cards with different powers and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest into your hand.",
             "colours": [
@@ -15475,7 +15475,7 @@
         },
         {
             "id": "678e2596-7734-5713-ba4d-755b0e987ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c569975-5b7c-448a-889e-877f28989642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c569975-5b7c-448a-889e-877f28989642.jpg?1",
             "name": "Urborg Lhurgoyf",
             "text": "Kicker {U} and/or {B}\nAs Urborg Lhurgoyf enters the battlefield, mill three cards for each time it was kicked.\nUrborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "7dcf51ec-945c-59c9-aa07-f208d12fb9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9fc6ee-2205-4f77-8e14-313bfbe68c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9fc6ee-2205-4f77-8e14-313bfbe68c1e.jpg?1",
             "name": "Plaza of Heroes",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a legendary spell.\n{T}: Add one mana of any color among legendary permanents you control.\n{3}, {T}, Exile Plaza of Heroes: Target legendary creature gains hexproof and indestructible until end of turn.",
             "colours": [],
@@ -15543,7 +15543,7 @@
         },
         {
             "id": "8db190e7-e731-5997-a999-dcfa2ee9e7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba2995e-f255-46da-abcf-9a6f3996edb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba2995e-f255-46da-abcf-9a6f3996edb1.jpg?1",
             "name": "Thran Portal",
             "text": "Thran Portal enters the battlefield tapped unless you control two or fewer other lands.\nAs Thran Portal enters the battlefield, choose a basic land type.\nThran Portal is the chosen type in addition to its other types.\nMana abilities of Thran Portal cost an additional 1 life to activate.",
             "colours": [],
@@ -15575,7 +15575,7 @@
         },
         {
             "id": "9d08f8c5-6c99-522a-8d01-318e6f5839d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6395960-c48a-4098-91da-4ccfeddbaace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6395960-c48a-4098-91da-4ccfeddbaace.jpg?1",
             "name": "Serra Redeemer",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, put two +1/+1 counters on that creature.",
             "colours": [
@@ -15612,7 +15612,7 @@
         },
         {
             "id": "9312aaa2-e439-50da-b77b-bdfbe6d64150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefb7a2-95f9-4aa7-b2ef-8b91c018c504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefb7a2-95f9-4aa7-b2ef-8b91c018c504.jpg?1",
             "name": "Cosmic Epiphany",
             "text": "Draw cards equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -15646,7 +15646,7 @@
         },
         {
             "id": "bea063ea-57d3-5987-a357-8f9152fcac4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038c02-d792-407d-8aa6-8d279009a1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59038c02-d792-407d-8aa6-8d279009a1cb.jpg?1",
             "name": "Tyrannical Pitlord",
             "text": "Flying, trample\nAs Tyrannical Pitlord enters the battlefield, choose another creature you control.\nThe chosen creature gets +3/+3 and has flying.\nWhen Tyrannical Pitlord leaves the battlefield, sacrifice the chosen creature.",
             "colours": [
@@ -15682,7 +15682,7 @@
         },
         {
             "id": "2e5fe655-b8a4-5bc4-b55c-84eae66681f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2a8ebf-f882-43fa-9749-8b78fa7b5e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2a8ebf-f882-43fa-9749-8b78fa7b5e41.jpg?1",
             "name": "Ragefire Hellkite",
             "text": "Flying\nWhenever Ragefire Hellkite attacks, you may sacrifice another creature. If you do, Ragefire Hellkite gains double strike until end of turn.",
             "colours": [
@@ -15718,7 +15718,7 @@
         },
         {
             "id": "411ca805-9f0a-54f4-8873-5545ef62160f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df437db0-5f18-43ff-b0ff-e9cac4a6ee81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df437db0-5f18-43ff-b0ff-e9cac4a6ee81.jpg?1",
             "name": "Briar Hydra",
             "text": "Trample\nDomain \u2014 Whenever Briar Hydra deals combat damage to a player, put X +1/+1 counters on target creature you control, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -15755,7 +15755,7 @@
         },
         {
             "id": "28033089-b3df-5b42-b8c7-d8e494826e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a1c0d-23cf-472e-a6b3-fd0c3905b4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0a1c0d-23cf-472e-a6b3-fd0c3905b4e4.jpg?1",
             "name": "Llanowar Loamspeaker",
             "text": "{T}: Add one mana of any color.\n{T}: Target land you control becomes a 3/3 Elemental creature with haste until end of turn. It's still a land. Activate only as a sorcery.",
             "colours": [
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "283b9728-31bf-58c9-924f-2159b6432943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b91c26-26f3-45d6-bf7d-35a2963dde37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b91c26-26f3-45d6-bf7d-35a2963dde37.jpg?1",
             "name": "Herd Migration",
             "text": "Domain \u2014 Create a 3/3 green Beast creature token for each basic land type among lands you control.\n{1}{G}, Discard Herd Migration: Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -15827,7 +15827,7 @@
         },
         {
             "id": "a1969fd4-9b68-5ecd-b88f-7160a13b89b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25a8991-99ac-4fc5-97e2-4631ff234f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25a8991-99ac-4fc5-97e2-4631ff234f65.jpg?1",
             "name": "Resolute Reinforcements",
             "text": "Flash\nWhen Resolute Reinforcements enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -15864,7 +15864,7 @@
         },
         {
             "id": "f4c62340-15ae-57b9-ba90-68dfdc787ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287e20f-a161-4522-8a72-3f2b914019b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287e20f-a161-4522-8a72-3f2b914019b5.jpg?1",
             "name": "Micromancer",
             "text": "When Micromancer enters the battlefield, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -15901,7 +15901,7 @@
         },
         {
             "id": "15ab83ab-fa9e-582c-acae-901793489f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fdde82-6c4d-4e34-a15c-9756c834e9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fdde82-6c4d-4e34-a15c-9756c834e9a0.jpg?1",
             "name": "Cut Down",
             "text": "Destroy target creature with total power and toughness 5 or less.",
             "colours": [
@@ -15935,7 +15935,7 @@
         },
         {
             "id": "6a54c835-305b-5c3d-91d6-41dbe9d953a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93d0972-4043-4d86-8707-9f9ec5b6e770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93d0972-4043-4d86-8707-9f9ec5b6e770.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -15969,7 +15969,7 @@
         },
         {
             "id": "5fc06110-46a0-58b9-8bd6-48effea0e022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ed86e0-91d9-4ba3-8fd4-0f27d3095412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ed86e0-91d9-4ba3-8fd4-0f27d3095412.jpg?1",
             "name": "Nishoba Brawler",
             "text": "Trample\nDomain \u2014 Nishoba Brawler's power is equal to the number of basic land types among lands you control.",
             "colours": [
@@ -16006,7 +16006,7 @@
         },
         {
             "id": "1a21a7f0-f5f6-5107-906b-5a33b9f5532e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df6603a-38c1-4d18-8b84-6211e9a7cc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df6603a-38c1-4d18-8b84-6211e9a7cc09.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "",
             "colours": [
@@ -16049,7 +16049,7 @@
         },
         {
             "id": "8685cc2b-7f3e-5f8c-abec-836cd70f21de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee7c1b3-36c3-4f81-a45d-f34331db5b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee7c1b3-36c3-4f81-a45d-f34331db5b18.jpg?1",
             "name": "Sheoldred, the Apocalypse",
             "text": "",
             "colours": [
@@ -16091,7 +16091,7 @@
         },
         {
             "id": "01a47bde-4e4b-5439-abd8-fc553f88fe66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -16126,7 +16126,7 @@
         },
         {
             "id": "e1fe63ec-ea55-5052-a9ea-5517fa3c8ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3034f6-145f-4e60-9e55-c4054fd8e70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3034f6-145f-4e60-9e55-c4054fd8e70f.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16161,7 +16161,7 @@
         },
         {
             "id": "896fde15-0956-5a5c-94a9-575552322c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16196,7 +16196,7 @@
         },
         {
             "id": "d3eecb4c-1ec3-5770-893f-3e89c455ebe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b0257-2ca5-4015-9d63-d7cf6e87ab9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4b0257-2ca5-4015-9d63-d7cf6e87ab9d.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16231,7 +16231,7 @@
         },
         {
             "id": "62ef67bc-de90-56b8-b9fe-8995539dd8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -16266,7 +16266,7 @@
         },
         {
             "id": "abbfb88b-cb12-5377-b069-0aee675281de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce95d5-2ae7-4bd9-92f4-1cb3bed5f733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce95d5-2ae7-4bd9-92f4-1cb3bed5f733.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16301,7 +16301,7 @@
         },
         {
             "id": "60caed98-acff-565f-903e-bd854e08b427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41933b2-a91f-4c43-8734-08fc3a392ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41933b2-a91f-4c43-8734-08fc3a392ac2.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16336,7 +16336,7 @@
         },
         {
             "id": "596bc1a1-147e-514e-ba92-0786ac7f334e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a7b17-a65a-4c37-bc2b-8be5ff8ce692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a7b17-a65a-4c37-bc2b-8be5ff8ce692.jpg?1",
             "name": "Phyrexian",
             "text": "",
             "colours": [
@@ -16371,7 +16371,7 @@
         },
         {
             "id": "d79f7166-316f-52a4-94ed-dad69841437f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -16406,7 +16406,7 @@
         },
         {
             "id": "b880b621-4914-5e0c-a12a-c98553bc464b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cae334-1e24-48a3-83a2-0a27bc9d3b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cae334-1e24-48a3-83a2-0a27bc9d3b29.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -16441,7 +16441,7 @@
         },
         {
             "id": "57889f36-37eb-5bda-af92-8ac1cfd6a169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b2ff6f-d55a-4fa2-86be-e2e012267de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b2ff6f-d55a-4fa2-86be-e2e012267de4.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16476,7 +16476,7 @@
         },
         {
             "id": "2b1fa4b9-8203-524c-86b9-68b3cff120fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128511d0-bc4c-48d9-9e8e-9c7c945cfaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128511d0-bc4c-48d9-9e8e-9c7c945cfaeb.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16511,7 +16511,7 @@
         },
         {
             "id": "fc63ce2c-cc73-51d0-85b5-ce18e94ef10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "d8325e25-9412-589b-a884-ca3b1cb62825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388180bd-cc96-4b18-9ddd-18a3f7e06282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388180bd-cc96-4b18-9ddd-18a3f7e06282.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -16581,7 +16581,7 @@
         },
         {
             "id": "91e766ed-eeec-5fa4-a8db-2ae498ab82c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg?1",
             "name": "Badger",
             "text": "",
             "colours": [
@@ -16616,7 +16616,7 @@
         },
         {
             "id": "7b6f1fd3-ee74-5480-a579-c09bef46e563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/591cb5b2-6394-4c1a-b227-5c32e633b493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/591cb5b2-6394-4c1a-b227-5c32e633b493.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -16651,7 +16651,7 @@
         },
         {
             "id": "4603b26d-cc27-5fee-94af-ae77d0b684b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg?1",
             "name": "Cat Warrior",
             "text": "",
             "colours": [
@@ -16687,7 +16687,7 @@
         },
         {
             "id": "61621bc7-618c-5ec0-94f6-2f6fb504a640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a07153-9eb6-4366-aa09-ebe9b4868e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a07153-9eb6-4366-aa09-ebe9b4868e7f.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -16722,7 +16722,7 @@
         },
         {
             "id": "70231ceb-8114-5502-8272-aa843ca2f40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -16757,7 +16757,7 @@
         },
         {
             "id": "a0e3ae99-0632-5c22-870d-2944507a50bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg?1",
             "name": "Sand Warrior",
             "text": "",
             "colours": [
@@ -16797,7 +16797,7 @@
         },
         {
             "id": "1195abea-6b63-5e95-83df-0cfd89762e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg?1",
             "name": "Stangg Twin",
             "text": "",
             "colours": [
@@ -16837,7 +16837,7 @@
         },
         {
             "id": "ffd5d2be-da01-5e70-b2d5-4b607cd354ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63d3174-75af-4dfa-b2f9-c4330c755af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63d3174-75af-4dfa-b2f9-c4330c755af1.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -16869,7 +16869,7 @@
         },
         {
             "id": "f1369647-2863-5cc6-91b4-00d9c735e19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447af615-1e59-471f-886b-bf46007a938d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447af615-1e59-471f-886b-bf46007a938d.jpg?1",
             "name": "Powerstone",
             "text": "",
             "colours": [],
@@ -16900,7 +16900,7 @@
         },
         {
             "id": "6b012b36-d1d6-5d9d-a3f3-1f0ca2df04c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -16931,7 +16931,7 @@
         },
         {
             "id": "d98a1805-56ab-5ef2-b496-391468d5ff21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee46d-b2f4-4710-bf7d-1d7a5ec0aefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee46d-b2f4-4710-bf7d-1d7a5ec0aefe.jpg?1",
             "name": "Ajani, Sleeper Agent Emblem",
             "text": "",
             "colours": [],
@@ -16959,7 +16959,7 @@
         },
         {
             "id": "05d59711-8773-5466-b66a-902cf865cbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a5830-d7a0-46c9-98c0-4d1dfc3ebc8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243a5830-d7a0-46c9-98c0-4d1dfc3ebc8c.jpg?1",
             "name": "Jaya, Fiery Negotiator Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DOM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DOM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2888d633-3d08-59d5-981f-5ec5f010d1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a3d9e8-8597-498b-869c-cff79e0df516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a3d9e8-8597-498b-869c-cff79e0df516.jpg?1",
             "name": "Karn, Scion of Urza",
             "text": "+1: Reveal the top two cards of your library. An opponent chooses one of them. Put that card into your hand and exile the other with a silver counter on it.\n\u22121: Put a card you own with a silver counter on it from exile into your hand.\n\u22122: Create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "99057a3d-ca34-5b1d-b3f6-bdb870072010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8817-ca3c-44ba-92f2-e9d6294cd25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8817-ca3c-44ba-92f2-e9d6294cd25d.jpg?1",
             "name": "Adamant Will",
             "text": "Target creature gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "2c49879f-3a5c-5b8b-a6c1-e5c47a511912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf49e5bf-07fb-44b0-8e74-092088d9019f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf49e5bf-07fb-44b0-8e74-092088d9019f.jpg?1",
             "name": "Aven Sentry",
             "text": "Flying",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "f4eef77c-8c21-5aca-8fcc-05652e91df41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a9594e-edc9-42b2-ba8a-8298da9441fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a9594e-edc9-42b2-ba8a-8298da9441fb.jpg?1",
             "name": "Baird, Steward of Argive",
             "text": "Vigilance\nCreatures can't attack you or a planeswalker you control unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "9e80a9a7-607b-5d98-8819-f73b3c6f88c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a5ecf1-2063-4cb3-a4ab-a0601b28256a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a5ecf1-2063-4cb3-a4ab-a0601b28256a.jpg?1",
             "name": "Benalish Honor Guard",
             "text": "Benalish Honor Guard gets +1/+0 for each legendary creature you control.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "08aa3178-c059-5475-8b09-06733db40d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd1a7fc-5dbd-4ed2-9b02-9fd5c55bb629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd1a7fc-5dbd-4ed2-9b02-9fd5c55bb629.jpg?1",
             "name": "Benalish Marshal",
             "text": "Other creatures you control get +1/+1.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "95248d10-08a3-5713-b2ec-122b7fde43ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3eb65-0f52-49c1-8243-14ce05de9f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3eb65-0f52-49c1-8243-14ce05de9f3b.jpg?1",
             "name": "Blessed Light",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "9af8e98b-e576-57ba-8d9f-3f1859d3fe2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d10fa-d42d-4867-9e2f-fc8de582d5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d10fa-d42d-4867-9e2f-fc8de582d5e7.jpg?1",
             "name": "Board the Weatherlight",
             "text": "Look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "13156d51-08a9-560c-840f-438187e9897f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978a719-b159-4155-88d9-9c0b15183037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7978a719-b159-4155-88d9-9c0b15183037.jpg?1",
             "name": "Call the Cavalry",
             "text": "Create two 2/2 white Knight creature tokens with vigilance.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "55e5a91d-633f-500e-a9dc-b0e684884b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000eded9-854c-408a-aadf-c26209e27432.jpg?1",
             "name": "Charge",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "36e15cb4-e115-55fd-80f9-bc5a2935f421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5881ab3-566b-4999-997e-cd5ecb84282b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5881ab3-566b-4999-997e-cd5ecb84282b.jpg?1",
             "name": "D'Avenant Trapper",
             "text": "Whenever you cast a historic spell, tap target creature an opponent controls. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "865d468e-2035-5146-b547-639683002706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a2b53c-0bf2-4d3d-91c2-57a484ae4f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a2b53c-0bf2-4d3d-91c2-57a484ae4f6b.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "acd90712-69b1-5c9c-85e4-47a1333a3f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306ebfe1-428d-4f38-950e-b72a44262c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306ebfe1-428d-4f38-950e-b72a44262c25.jpg?1",
             "name": "Daring Archaeologist",
             "text": "When Daring Archaeologist enters the battlefield, you may return target artifact card from your graveyard to your hand.\nWhenever you cast a historic spell, put a +1/+1 counter on Daring Archaeologist. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "01f8b96f-38df-5503-8260-83f7eb92071a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f82012-5c33-47bc-a3c8-56ae2eea1fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f82012-5c33-47bc-a3c8-56ae2eea1fb9.jpg?1",
             "name": "Dauntless Bodyguard",
             "text": "As Dauntless Bodyguard enters the battlefield, choose another creature you control.\nSacrifice Dauntless Bodyguard: The chosen creature gains indestructible until end of turn.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "bb4bf965-1b69-5d15-b158-ffe9dc5e74b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca49646-970a-4b91-9cae-5dbdef9f7727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca49646-970a-4b91-9cae-5dbdef9f7727.jpg?1",
             "name": "Dub",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has first strike, and is a Knight in addition to its other types.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "f605ad25-b192-53d6-ba21-4841687a658e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f57a57-8ce8-4d01-9b91-99ec0623d1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f57a57-8ce8-4d01-9b91-99ec0623d1e9.jpg?1",
             "name": "Evra, Halcyon Witness",
             "text": "Lifelink\n{4}: Exchange your life total with Evra, Halcyon Witness's power.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "dca7a1de-09e8-5a71-8afa-55b9af000021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760ce08a-49d3-4cdf-bbe2-33dd8a6a7966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760ce08a-49d3-4cdf-bbe2-33dd8a6a7966.jpg?1",
             "name": "Excavation Elephant",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nWhen Excavation Elephant enters the battlefield, if it was kicked, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "63411faf-1a52-5f41-98fb-edc021c261f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a613a01-6145-4e34-987c-c9bdcb068370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a613a01-6145-4e34-987c-c9bdcb068370.jpg?1",
             "name": "Fall of the Thran",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy all lands.\nII, III \u2014 Each player returns two land cards from their graveyard to the battlefield.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "c31df3f9-5362-50c8-bc58-47b10b8eae6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg?1",
             "name": "Gideon's Reproach",
             "text": "Gideon's Reproach deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "ed58dc38-a96d-58cf-a4c9-d2198564d3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7512d31-dc35-4046-a1ba-49b74239c329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7512d31-dc35-4046-a1ba-49b74239c329.jpg?1",
             "name": "Healing Grace",
             "text": "Prevent the next 3 damage that would be dealt to any target this turn by a source of your choice. You gain 3 life.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "6baa61c2-ecc6-564b-a6cf-d1c44646fa0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d134385d-b01c-41c7-bb2d-30722b44dc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d134385d-b01c-41c7-bb2d-30722b44dc5a.jpg?1",
             "name": "History of Benalia",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a 2/2 white Knight creature token with vigilance.\nIII \u2014 Knights you control get +2/+1 until end of turn.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "d54faa21-61a3-5a42-8152-dc55123364e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe72ae-ea5c-4065-9f5b-3d931f72952d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe72ae-ea5c-4065-9f5b-3d931f72952d.jpg?1",
             "name": "Invoke the Divine",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "aaec2e0e-9257-5efb-8291-fad9f93bf4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbbddc0-f8b3-4255-bd82-d50f829ca009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbbddc0-f8b3-4255-bd82-d50f829ca009.jpg?1",
             "name": "Knight of Grace",
             "text": "First strike\nHexproof from black (This creature can't be the target of black spells or abilities your opponents control.)\nKnight of Grace gets +1/+0 as long as any player controls a black permanent.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "04d354cb-1190-5ac4-ac56-91f09c1d27cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c50c4b-a2c8-4cdc-a171-aa3ff9ef107f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c50c4b-a2c8-4cdc-a171-aa3ff9ef107f.jpg?1",
             "name": "Knight of New Benalia",
             "text": "",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "5086456d-1c92-518f-ac43-c4ef080a00bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3b6a8-3e4a-4e2b-900a-9a21fa0ced4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3b6a8-3e4a-4e2b-900a-9a21fa0ced4c.jpg?1",
             "name": "Kwende, Pride of Femeref",
             "text": "Double strike\nCreatures you control with first strike have double strike.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "1479ac5b-a67f-5816-8057-f6d79bb7e172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be6799-7b9d-44d4-84dc-2961692b5a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be6799-7b9d-44d4-84dc-2961692b5a85.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "f22cd70d-2155-5591-b52f-f3a9bef9e9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ed7b5-08ee-4d2c-9bf8-03a1b85b635a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ed7b5-08ee-4d2c-9bf8-03a1b85b635a.jpg?1",
             "name": "Mesa Unicorn",
             "text": "Lifelink",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "b2b30365-05ad-5ec5-8df7-d17667c474e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063b8d2c-862b-458e-8f7c-c3e29a98c234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063b8d2c-862b-458e-8f7c-c3e29a98c234.jpg?1",
             "name": "On Serra's Wings",
             "text": "Enchant creature\nEnchanted creature is legendary, gets +1/+1, and has flying, vigilance, and lifelink.",
             "colours": [
@@ -961,7 +961,7 @@
         },
         {
             "id": "884271cd-5fd1-5ed8-9645-1f5345793c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35263639-f09d-429f-bd99-09cfdee668e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35263639-f09d-429f-bd99-09cfdee668e8.jpg?1",
             "name": "Pegasus Courser",
             "text": "Flying\nWhenever Pegasus Courser attacks, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "1d44410b-5606-549a-8811-55e7edeb1189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4795dd-75d4-4ce5-87e7-fe892616e42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4795dd-75d4-4ce5-87e7-fe892616e42e.jpg?1",
             "name": "Sanctum Spirit",
             "text": "Lifelink\nDiscard a historic card: Sanctum Spirit gains indestructible until end of turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "ef953c62-d00a-5836-9d67-e54ec4c87540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8d6588-671d-4eb3-874f-f7139da2e05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8d6588-671d-4eb3-874f-f7139da2e05a.jpg?1",
             "name": "Seal Away",
             "text": "Flash\nWhen Seal Away enters the battlefield, exile target tapped creature an opponent controls until Seal Away leaves the battlefield.",
             "colours": [
@@ -1061,7 +1061,7 @@
         },
         {
             "id": "af0e106c-4a7f-5d6a-8ebd-1bf3f82860f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f70b1ee-47b6-4904-850d-8ea8064bd27d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f70b1ee-47b6-4904-850d-8ea8064bd27d.jpg?1",
             "name": "Sergeant-at-Arms",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nWhen Sergeant-at-Arms enters the battlefield, if it was kicked, create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "47e840f4-c8b5-5ab0-afa7-35b5d0269131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56b9131-4f7e-4912-ba47-63ed82f21d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56b9131-4f7e-4912-ba47-63ed82f21d1b.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "f09365cb-8e43-5218-a517-fde47750df22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8359c3a8-d826-4326-a899-9f60ca774308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8359c3a8-d826-4326-a899-9f60ca774308.jpg?1",
             "name": "Serra Disciple",
             "text": "Flying, first strike\nWhenever you cast a historic spell, Serra Disciple gets +1/+1 until end of turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "95b8b513-12eb-54ca-9ed8-9a62ab5a2f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db827ee7-6f2e-4e10-aac0-120fc2b69fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db827ee7-6f2e-4e10-aac0-120fc2b69fbd.jpg?1",
             "name": "Shalai, Voice of Plenty",
             "text": "Flying\nYou, planeswalkers you control, and other creatures you control have hexproof.\n{4}{G}{G}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "fc7a869c-82b4-58b9-9b02-0d6b01b40e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d115b4-51d5-4898-b56c-2729aa428018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d115b4-51d5-4898-b56c-2729aa428018.jpg?1",
             "name": "Teshar, Ancestor's Apostle",
             "text": "Flying\nWhenever you cast a historic spell, return target creature card with converted mana cost 3 or less from your graveyard to the battlefield. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "45502d58-d89c-5bf4-9b4b-c01ff3b6605b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f957b353-7765-4c16-9645-d41000154130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f957b353-7765-4c16-9645-d41000154130.jpg?1",
             "name": "Tragic Poet",
             "text": "{T}, Sacrifice Tragic Poet: Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "dcec35ca-747c-5b62-b2eb-00b8eb5b5b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416fae7-46a0-4048-b969-9cf95bac09db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3416fae7-46a0-4048-b969-9cf95bac09db.jpg?1",
             "name": "Triumph of Gerrard",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put a +1/+1 counter on target creature you control with the greatest power.\nIII \u2014 Target creature you control with the greatest power gains flying, first strike, and lifelink until end of turn.",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "ae09affb-34a1-5759-b960-2deda05b540e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b50a96-6221-44f0-b54a-76076621047e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b50a96-6221-44f0-b54a-76076621047e.jpg?1",
             "name": "Urza's Ruinous Blast",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nExile all nonland permanents that aren't legendary.",
             "colours": [
@@ -1341,7 +1341,7 @@
         },
         {
             "id": "40ea994b-f38a-51e9-8099-d6dace098ef8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bacb12-da46-4b00-804f-9ff6bff452bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bacb12-da46-4b00-804f-9ff6bff452bc.jpg?1",
             "name": "Academy Drake",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nFlying\nIf Academy Drake was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -1375,7 +1375,7 @@
         },
         {
             "id": "724a8e50-193c-5308-9c54-a12eabf81d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46a65e0-66a3-4896-8acc-0ad5e9927c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46a65e0-66a3-4896-8acc-0ad5e9927c40.jpg?1",
             "name": "Academy Journeymage",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nWhen Academy Journeymage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "6378d4a2-16bc-54c5-b81f-2c242a4e0720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda670a-00a7-419c-b4b5-bfdb323f006d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda670a-00a7-419c-b4b5-bfdb323f006d.jpg?1",
             "name": "The Antiquities War",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Look at the top five cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nIII \u2014 Artifacts you control become artifact creatures with base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "00e8e34a-6d00-5beb-b851-3b584710edaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fbb1c0-ba57-4a5a-8ad6-77fbc6aeeec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fbb1c0-ba57-4a5a-8ad6-77fbc6aeeec9.jpg?1",
             "name": "Arcane Flight",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "5f877fe0-cc63-5736-a5f1-f5eb4153572f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadf867-b999-49b2-88d8-91da975a3cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadf867-b999-49b2-88d8-91da975a3cc5.jpg?1",
             "name": "Artificer's Assistant",
             "text": "Flying\nWhenever you cast a historic spell, scry 1. (Artifacts, legendaries, and Sagas are historic. To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -1512,7 +1512,7 @@
         },
         {
             "id": "7c3df55e-9dc6-5ad3-8799-0bb92d8aac90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88858285-23ac-4d7e-b8dd-a20982d95a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88858285-23ac-4d7e-b8dd-a20982d95a2d.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "16241138-6d2a-52a1-8e04-2e76738c6bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab830392-4d7e-4b45-93cf-35ed1e935228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab830392-4d7e-4b45-93cf-35ed1e935228.jpg?1",
             "name": "Blink of an Eye",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "fba3b30f-97e7-557d-ab06-ce6041e77d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85a696-fa1a-4e05-b0aa-79b3381e849a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85a696-fa1a-4e05-b0aa-79b3381e849a.jpg?1",
             "name": "Cloudreader Sphinx",
             "text": "Flying\nWhen Cloudreader Sphinx enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "ac5a47b6-c8fa-593c-b126-2ed5f602ceff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339549-4325-40c6-adde-0cd31bb738e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339549-4325-40c6-adde-0cd31bb738e0.jpg?1",
             "name": "Cold-Water Snapper",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "a310d5f8-2654-5f35-8716-c8ca9f718d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cc417f-0ea7-47a8-b7d0-aa8d20168faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cc417f-0ea7-47a8-b7d0-aa8d20168faf.jpg?1",
             "name": "Curator's Ward",
             "text": "Enchant permanent\nEnchanted permanent has hexproof.\nWhen enchanted permanent leaves the battlefield, if it was historic, draw two cards. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "7c21710d-8fd8-51c4-a667-c1f35ae14311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51765d87-e842-4d84-aaf0-998737fe754c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51765d87-e842-4d84-aaf0-998737fe754c.jpg?1",
             "name": "Deep Freeze",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/4, has defender, loses all other abilities, and is a blue Wall in addition to its other colors and types.",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "6f793e92-2619-58f7-aac6-2913f079c461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65212970-770e-4110-aa86-c89128688867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65212970-770e-4110-aa86-c89128688867.jpg?1",
             "name": "Diligent Excavator",
             "text": "Whenever you cast a historic spell, target player puts the top two cards of their library into their graveyard. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "8806aa3a-befc-59b3-a354-696bdf9952bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f9daf0-dbfd-45b2-be35-9c2de9d1a56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f9daf0-dbfd-45b2-be35-9c2de9d1a56e.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "ff1ebedb-8150-5e44-8ad0-ebd507596a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7aa6-1897-4657-b3a6-991b05f7ea5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7aa6-1897-4657-b3a6-991b05f7ea5e.jpg?1",
             "name": "Homarid Explorer",
             "text": "When Homarid Explorer enters the battlefield, target player puts the top four cards of their library into their graveyard.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "aaf1bab8-c53a-5892-adfd-11be4c854ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72bf6b4-ac70-4be0-86de-cb3c47244dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72bf6b4-ac70-4be0-86de-cb3c47244dbc.jpg?1",
             "name": "In Bolas's Clutches",
             "text": "Enchant permanent\nYou control enchanted permanent.\nEnchanted permanent is legendary.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "ea29573e-bca1-5a4d-a017-000533b20f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a64c1a4-02ce-49d2-97f2-970b8c33672d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a64c1a4-02ce-49d2-97f2-970b8c33672d.jpg?1",
             "name": "Karn's Temporal Sundering",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nTarget player takes an extra turn after this one. Return up to one target nonland permanent to its owner's hand. Exile Karn's Temporal Sundering.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "d8978b89-416c-5463-b566-6e37ec0f406e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2f2b-7b58-47b6-b00c-8616f981e3a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2f2b-7b58-47b6-b00c-8616f981e3a3.jpg?1",
             "name": "Merfolk Trickster",
             "text": "Flash\nWhen Merfolk Trickster enters the battlefield, tap target creature an opponent controls. It loses all abilities until end of turn.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "88082e57-df1a-51bd-ab3e-0324c54c5d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c68954c-4bab-4973-9819-ecd084438303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c68954c-4bab-4973-9819-ecd084438303.jpg?1",
             "name": "The Mirari Conjecture",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Return target instant card from your graveyard to your hand.\nII \u2014 Return target sorcery card from your graveyard to your hand.\nIII \u2014 Until end of turn, whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "28ad8a7b-d96f-56de-8967-0a9bed57591e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f41175-880f-491e-96c3-bf52f3c0db5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f41175-880f-491e-96c3-bf52f3c0db5d.jpg?1",
             "name": "Naban, Dean of Iteration",
             "text": "If a Wizard entering the battlefield under your control causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "8de751f2-d146-5ec1-bcce-408ab15f430a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57168712-73dc-411c-9d13-f0c43202cb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57168712-73dc-411c-9d13-f0c43202cb9a.jpg?1",
             "name": "Naru Meha, Master Wizard",
             "text": "Flash\nWhen Naru Meha, Master Wizard enters the battlefield, copy target instant or sorcery spell you control. You may choose new targets for the copy.\nOther Wizards you control get +1/+1.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "9b69bb58-b2f0-5bf8-8f93-4ddf009861bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f2e4d0-effd-4e83-b7aa-1a0d8f120951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f2e4d0-effd-4e83-b7aa-1a0d8f120951.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "3e649656-3212-59f3-9e40-fa91cd09758a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a92ee-2b20-4299-84b2-b4963f4a42a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a92ee-2b20-4299-84b2-b4963f4a42a1.jpg?1",
             "name": "Precognition Field",
             "text": "You may look at the top card of your library. (You may do this at any time.)\nYou may cast the top card of your library if it's an instant or sorcery card.\n{3}: Exile the top card of your library.",
             "colours": [
@@ -2091,7 +2091,7 @@
         },
         {
             "id": "a78d8548-93c8-5d32-9689-a42537b0a371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5993e-f619-4de5-aa94-7569b0efe415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5993e-f619-4de5-aa94-7569b0efe415.jpg?1",
             "name": "Relic Runner",
             "text": "Relic Runner can't be blocked if you've cast a historic spell this turn. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "31a9a3f7-982a-52ce-bcc0-d4ce47042215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08050607-b558-4f99-b716-bbbab54e9b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08050607-b558-4f99-b716-bbbab54e9b68.jpg?1",
             "name": "Rescue",
             "text": "Return target permanent you control to its owner's hand.",
             "colours": [
@@ -2158,7 +2158,7 @@
         },
         {
             "id": "167f3d60-9168-510e-9585-e3627e67008a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7395b77-f7f7-404b-8639-9db6dc28d558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7395b77-f7f7-404b-8639-9db6dc28d558.jpg?1",
             "name": "Sage of Lat-Nam",
             "text": "{T}, Sacrifice an artifact: Draw a card.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "feb7d3fd-a421-5807-802b-800e7bb133a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da73230-2562-4e7d-9f03-b0508b9a31e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da73230-2562-4e7d-9f03-b0508b9a31e0.jpg?1",
             "name": "Sentinel of the Pearl Trident",
             "text": "Flash\nWhen Sentinel of the Pearl Trident enters the battlefield, you may exile target historic permanent you control. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "ec9b2d7a-bbc8-5238-b488-9da3c259d9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b4581-fe4a-498d-af58-c1e453235df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b4581-fe4a-498d-af58-c1e453235df8.jpg?1",
             "name": "Slinn Voda, the Rising Deep",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nWhen Slinn Voda, the Rising Deep enters the battlefield, if it was kicked, return all creatures to their owners' hands except for Merfolk, Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "e3f4d769-3769-5d30-aee8-37578ea0433b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81739a5-35a7-4812-a7af-e1951bf5579c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81739a5-35a7-4812-a7af-e1951bf5579c.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays {X}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "311f4fec-cf9e-5c1d-a3f9-b6f6579869bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc883b-3aea-4d0b-ae0f-00d4a08c47c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc883b-3aea-4d0b-ae0f-00d4a08c47c1.jpg?1",
             "name": "Tempest Djinn",
             "text": "Flying\nTempest Djinn gets +1/+0 for each basic Island you control.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "e3e15af8-c559-548a-b89d-1c40e6aa6a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16185c50-f7b8-4cea-a129-dfad8e9df781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16185c50-f7b8-4cea-a129-dfad8e9df781.jpg?1",
             "name": "Tetsuko Umezawa, Fugitive",
             "text": "Creatures you control with power or toughness 1 or less can't be blocked.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "788749aa-c94b-5420-ad28-8fb062d873d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcd0674-68b9-41ca-ab46-a73dfcbe4149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcd0674-68b9-41ca-ab46-a73dfcbe4149.jpg?1",
             "name": "Time of Ice",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Tap target creature an opponent controls. It doesn't untap during its controller's untap step for as long as you control Time of Ice.\nIII \u2014 Return all tapped creatures to their owners' hands.",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "0d2d9537-01ac-5965-93ee-51058589ac2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d89839-60d7-4de2-a78a-1afdcc21c053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d89839-60d7-4de2-a78a-1afdcc21c053.jpg?1",
             "name": "Tolarian Scholar",
             "text": "",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "9dee28a0-cd63-5bd5-915c-b410e6ab9e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97da6607-9131-4f8b-8af3-63439a59b78b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97da6607-9131-4f8b-8af3-63439a59b78b.jpg?1",
             "name": "Unwind",
             "text": "Counter target noncreature spell. Untap up to three lands.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "64c6aa6c-d14c-5945-93a9-4baf45e88dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7795fb-2995-4dff-bc1b-7809bfbb1657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7795fb-2995-4dff-bc1b-7809bfbb1657.jpg?1",
             "name": "Vodalian Arcanist",
             "text": "{T}: Add {C}. Spend this mana only to cast an instant or sorcery spell.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "1b5f754a-e0a1-5fad-8db0-1a02f3e73bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2359aa-9230-4519-b12e-ec395a8dd2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f2359aa-9230-4519-b12e-ec395a8dd2a0.jpg?1",
             "name": "Weight of Memory",
             "text": "Draw three cards. Target player puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "234ff821-6775-5639-9ef4-959d95ddeddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae30b7d-9306-46ef-adea-c4057f59c9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae30b7d-9306-46ef-adea-c4057f59c9c1.jpg?1",
             "name": "Wizard's Retort",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nCounter target spell.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "5bb2dcfc-5277-570c-99e9-6f0d69ad0f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ea0c1-cd97-4160-87df-646ad763f5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ea0c1-cd97-4160-87df-646ad763f5fc.jpg?1",
             "name": "Zahid, Djinn of the Lamp",
             "text": "You may pay {3}{U} and tap an untapped artifact you control rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "a85906bb-9288-50fb-93d3-cc719240e0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224940c-d87c-4317-9ca3-b704ef894a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224940c-d87c-4317-9ca3-b704ef894a7b.jpg?1",
             "name": "Blessing of Belzenlok",
             "text": "Target creature gets +2/+1 until end of turn. If it's legendary, it also gains lifelink until end of turn.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "810f1fff-568d-5583-adeb-4a0c38e0271f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d218d2a2-bb5d-4ea8-a131-341c574410b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d218d2a2-bb5d-4ea8-a131-341c574410b2.jpg?1",
             "name": "Cabal Evangel",
             "text": "",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "c9377e57-3a3f-5aae-8520-d1ca6fb809bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cff2cb9-f4e6-4fee-94ef-ad11e24525c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cff2cb9-f4e6-4fee-94ef-ad11e24525c1.jpg?1",
             "name": "Cabal Paladin",
             "text": "Whenever you cast a historic spell, Cabal Paladin deals 2 damage to each opponent. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "50f38924-adbf-5f22-b73c-7aaed4d93201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e23ee25-2005-4e81-a807-f52c0dbfb192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e23ee25-2005-4e81-a807-f52c0dbfb192.jpg?1",
             "name": "Caligo Skin-Witch",
             "text": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nWhen Caligo Skin-Witch enters the battlefield, if it was kicked, each opponent discards two cards.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "22926bdb-d96e-5947-aa15-47b423d260b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116ce944-6871-4f51-a889-d9c4a5d7cff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116ce944-6871-4f51-a889-d9c4a5d7cff2.jpg?1",
             "name": "Cast Down",
             "text": "Destroy target nonlegendary creature.",
             "colours": [
@@ -2772,7 +2772,7 @@
         },
         {
             "id": "3a0aeb64-f0fb-5cc8-a165-604abd522208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42beafb-2fba-482c-a86a-7d668fa7cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42beafb-2fba-482c-a86a-7d668fa7cb4b.jpg?1",
             "name": "Chainer's Torment",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Chainer's Torment deals 2 damage to each opponent and you gain 2 life.\nIII \u2014 Create an X/X black Nightmare Horror creature token, where X is half your life total, rounded up. It deals X damage to you.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "dfbf3e9e-23b9-51fb-bfec-253b91173a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cbedc6-482e-42de-b310-22d3a955ad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cbedc6-482e-42de-b310-22d3a955ad7e.jpg?1",
             "name": "Dark Bargain",
             "text": "Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard. Dark Bargain deals 2 damage to you.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "97687f1e-d093-5245-8b18-510dea5e0e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236ead00-d43e-4079-b74d-09be9875fd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236ead00-d43e-4079-b74d-09be9875fd2d.jpg?1",
             "name": "Deathbloom Thallid",
             "text": "When Deathbloom Thallid dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "5e1aad8d-a43d-53c8-ac33-bef7990a95dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09950456-09d6-4675-9995-0dc540ddb6e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09950456-09d6-4675-9995-0dc540ddb6e4.jpg?1",
             "name": "Demonic Vigor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nWhen enchanted creature dies, return that card to its owner's hand.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "196633b8-161d-5e23-82df-441d9c5e63ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4dbe8-15fa-467f-9366-66382b192113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb4dbe8-15fa-467f-9366-66382b192113.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "Flying, trample\nWhen Demonlord Belzenlok enters the battlefield, exile cards from the top of your library until you exile a nonland card, then put that card into your hand. If the card's converted mana cost is 4 or greater, repeat this process. Demonlord Belzenlok deals 1 damage to you for each card put into your hand this way.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "18a355bc-e825-5aa7-9709-5da60dd2d554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6619810-7933-4844-8556-2a575ed7f18a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6619810-7933-4844-8556-2a575ed7f18a.jpg?1",
             "name": "Divest",
             "text": "Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "d35e061a-bb4e-5d82-9f27-f35eec23a3f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b8b1d7-9d2b-4943-bb3b-238a6333ce93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b8b1d7-9d2b-4943-bb3b-238a6333ce93.jpg?1",
             "name": "Dread Shade",
             "text": "{B}: Dread Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "c6c86e6e-3d9c-5478-a9a3-d0c3583054d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9764a718-1748-4c2a-925c-370e22003b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9764a718-1748-4c2a-925c-370e22003b62.jpg?1",
             "name": "Drudge Sentinel",
             "text": "{3}: Tap Drudge Sentinel. It gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "049e434b-36f8-580f-8116-96bac5f14729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8318f40-ecd5-429e-8fe2-febf31f64841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8318f40-ecd5-429e-8fe2-febf31f64841.jpg?1",
             "name": "The Eldest Reborn",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each opponent sacrifices a creature or planeswalker.\nII \u2014 Each opponent discards a card.\nIII \u2014 Put target creature or planeswalker card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "715fa7f1-0987-55c2-8158-0ea9befbd13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ba90b8-3a30-4058-b8d3-72900b1f4fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ba90b8-3a30-4058-b8d3-72900b1f4fe0.jpg?1",
             "name": "Eviscerate",
             "text": "Destroy target creature.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "3c138e9b-68a0-531d-baeb-0fb93b56625e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3292e262-4409-4f31-9de2-a232817a0734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3292e262-4409-4f31-9de2-a232817a0734.jpg?1",
             "name": "Feral Abomination",
             "text": "Deathtouch",
             "colours": [
@@ -3144,7 +3144,7 @@
         },
         {
             "id": "a130d30d-3309-5c78-9347-ede28221ee1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8803f6-9efa-4323-b8c5-29bdd5a48f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8803f6-9efa-4323-b8c5-29bdd5a48f9a.jpg?1",
             "name": "Final Parting",
             "text": "Search your library for two cards. Put one into your hand and the other into your graveyard. Then shuffle your library.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "45e81e5c-e850-5d6d-9c15-4f92206a4f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6baa5-666d-40b0-82e8-b0df10ff3cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6baa5-666d-40b0-82e8-b0df10ff3cdd.jpg?1",
             "name": "Fungal Infection",
             "text": "Target creature gets -1/-1 until end of turn. Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -3208,7 +3208,7 @@
         },
         {
             "id": "e6987065-ae64-5b6c-a4ed-4f94bd196c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed6d088-db82-4648-a109-0e3fa1421847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed6d088-db82-4648-a109-0e3fa1421847.jpg?1",
             "name": "Josu Vess, Lich Knight",
             "text": "Kicker {5}{B} (You may pay an additional {5}{B} as you cast this spell.)\nMenace\nWhen Josu Vess, Lich Knight enters the battlefield, if it was kicked, create eight 2/2 black Zombie Knight creature tokens with menace.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "0ede6c77-0b09-5fc7-924a-d1ffb34ee0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff7077-496b-46ca-b9d7-a8c1772f9a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aff7077-496b-46ca-b9d7-a8c1772f9a91.jpg?1",
             "name": "Kazarov, Sengir Pureblood",
             "text": "Flying\nWhenever a creature an opponent controls is dealt damage, put a +1/+1 counter on Kazarov, Sengir Pureblood.\n{3}{R}: Kazarov deals 2 damage to target creature.",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "c4466355-75ac-5fb7-a52e-8342c475e554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45266f0-eb4f-4a06-bc64-8c2d774b4cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45266f0-eb4f-4a06-bc64-8c2d774b4cc5.jpg?1",
             "name": "Knight of Malice",
             "text": "First strike\nHexproof from white (This creature can't be the target of white spells or abilities your opponents control.)\nKnight of Malice gets +1/+0 as long as any player controls a white permanent.",
             "colours": [
@@ -3317,7 +3317,7 @@
         },
         {
             "id": "7f69ca3d-0276-53ab-a951-1e1648f6faaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f4c9cb-f364-4556-8673-4b19d52a2cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f4c9cb-f364-4556-8673-4b19d52a2cff.jpg?1",
             "name": "Lich's Mastery",
             "text": "Hexproof\nYou can't lose the game.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, for each 1 life you lost, exile a permanent you control or a card from your hand or graveyard.\nWhen Lich's Mastery leaves the battlefield, you lose the game.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "de2bc0fb-2248-56a6-9112-c8cfc817db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316239e-8fe6-467f-87e6-a3f4d19b860e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316239e-8fe6-467f-87e6-a3f4d19b860e.jpg?1",
             "name": "Lingering Phantom",
             "text": "Whenever you cast a historic spell, you may pay {B}. If you do, return Lingering Phantom from your graveyard to your hand. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "0bf538ed-8f69-5b3c-9fbd-dff7311ee4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3423d7-cb81-47bf-b9a6-a279ba6cedf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3423d7-cb81-47bf-b9a6-a279ba6cedf4.jpg?1",
             "name": "Phyrexian Scriptures",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Put a +1/+1 counter on up to one target creature. That creature becomes an artifact in addition to its other types.\nII \u2014 Destroy all nonartifact creatures.\nIII \u2014 Exile all cards from all opponents' graveyards.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "a48fd664-d71c-59d0-8a83-373d62905d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f618e07-f06f-45d2-8512-e6cef88c0434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f618e07-f06f-45d2-8512-e6cef88c0434.jpg?1",
             "name": "Rat Colony",
             "text": "Rat Colony gets +1/+0 for each other Rat you control.\nA deck can have any number of cards named Rat Colony.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "9d99018f-d158-5672-a110-d2c33ef34787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed7cca3-79be-44ca-bf10-2ae1c0835ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed7cca3-79be-44ca-bf10-2ae1c0835ed1.jpg?1",
             "name": "Rite of Belzenlok",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create two 0/1 black Cleric creature tokens.\nIII \u2014 Create a 6/6 black Demon creature token with flying, trample, and \"At the beginning of your upkeep, sacrifice another creature. If you can't, this creature deals 6 damage to you.\"",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "7ce557c0-4b17-54b3-819d-38f398330b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b18558f-6b40-4d1d-859a-3ba68950f064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b18558f-6b40-4d1d-859a-3ba68950f064.jpg?1",
             "name": "Settle the Score",
             "text": "Exile target creature. Put two loyalty counters on a planeswalker you control.",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "e6f697cc-1e44-5433-bca3-91769e4aa3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347060c0-fef7-45da-b42e-8e11051b2c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347060c0-fef7-45da-b42e-8e11051b2c69.jpg?1",
             "name": "Soul Salvage",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3551,7 +3551,7 @@
         },
         {
             "id": "be66609b-c32b-5af0-8c09-20837b12573e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3fcc43-839b-48c1-91e3-7cc80d8c7f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3fcc43-839b-48c1-91e3-7cc80d8c7f9a.jpg?1",
             "name": "Stronghold Confessor",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nMenace (This creature can't be blocked except by two or more creatures.)\nIf Stronghold Confessor was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "0990d6ff-1bf3-5685-979e-4bf064983505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b35391-f1dc-434b-b581-ca6cb6f3439f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b35391-f1dc-434b-b581-ca6cb6f3439f.jpg?1",
             "name": "Thallid Omnivore",
             "text": "{1}, Sacrifice another creature: Thallid Omnivore gets +2/+2 until end of turn. If a Saproling was sacrificed this way, you gain 2 life.",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "583da2fb-798c-59e5-8160-6b8beced5b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204173b6-ae51-49ca-bd67-0703e882bf9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204173b6-ae51-49ca-bd67-0703e882bf9e.jpg?1",
             "name": "Thallid Soothsayer",
             "text": "{2}, Sacrifice a creature: Draw a card.",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "02445867-2995-556f-badd-9155dba5a671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab46d5c-95dd-47a0-9f96-dde07d2f8b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab46d5c-95dd-47a0-9f96-dde07d2f8b81.jpg?1",
             "name": "Torgaar, Famine Incarnate",
             "text": "As an additional cost to cast this spell, you may sacrifice any number of creatures. This spell costs {2} less to cast for each creature sacrificed this way.\nWhen Torgaar, Famine Incarnate enters the battlefield, up to one target player's life total becomes half their starting life total, rounded down.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "64874af5-6870-5f5a-8431-d16c91556ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8652fb7-1bce-44ee-b75e-4c773ff8fdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8652fb7-1bce-44ee-b75e-4c773ff8fdb3.jpg?1",
             "name": "Urgoros, the Empty One",
             "text": "Flying\nWhenever Urgoros, the Empty One deals combat damage to a player, that player discards a card at random. If the player can't, you draw a card.",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "99201966-a64e-5358-9f28-895d073cb893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaed7828-57c1-4ad3-a91b-209c66f0876b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaed7828-57c1-4ad3-a91b-209c66f0876b.jpg?1",
             "name": "Vicious Offering",
             "text": "Kicker\u2014\nSacrifice a creature. (You may sacrifice a creature in addition to any other costs as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -5/-5 until end of turn instead.",
             "colours": [
@@ -3758,7 +3758,7 @@
         },
         {
             "id": "4ddaf474-149a-513e-b296-9773acc6e26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0647feeb-ad7a-40c7-830f-f307ba8339ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0647feeb-ad7a-40c7-830f-f307ba8339ad.jpg?1",
             "name": "Whisper, Blood Liturgist",
             "text": "{T}, Sacrifice two creatures: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "9ae92f82-607e-566e-a798-ceb5d60b4891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835285e-96d9-4574-a497-3b612cae8e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f835285e-96d9-4574-a497-3b612cae8e22.jpg?1",
             "name": "Windgrace Acolyte",
             "text": "Flying\nWhen Windgrace Acolyte enters the battlefield, put the top three cards of your library into your graveyard and you gain 3 life.",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "dbb7838c-60bf-5231-b6ba-73e2873656c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645cfc1b-76f2-4823-9fb0-03cb009f8b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645cfc1b-76f2-4823-9fb0-03cb009f8b32.jpg?1",
             "name": "Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "72ba3b47-48f7-595b-be4d-404780fa4fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9794a7-caf5-40b9-8046-67823ff64a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9794a7-caf5-40b9-8046-67823ff64a2c.jpg?1",
             "name": "Yawgmoth's Vile Offering",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nPut up to one target creature or planeswalker card from a graveyard onto the battlefield under your control. Destroy up to one target creature or planeswalker. Exile Yawgmoth's Vile Offering.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "7802bf42-8bc0-5b33-b968-56d8c7afc6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31adbfd4-56aa-4137-aeba-8720233260be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31adbfd4-56aa-4137-aeba-8720233260be.jpg?1",
             "name": "Bloodstone Goblin",
             "text": "Whenever you cast a spell, if that spell was kicked, Bloodstone Goblin gets +1/+1 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "a21754c1-0f9b-5e2e-8bd7-270e3348f346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460fa161-362f-406d-9149-d412bc51836c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460fa161-362f-406d-9149-d412bc51836c.jpg?1",
             "name": "Champion of the Flame",
             "text": "Trample\nChampion of the Flame gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "2fece7de-202b-560f-9e92-c769a386d36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f76e51-a726-4a5f-ae2b-2e826e89f5f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f76e51-a726-4a5f-ae2b-2e826e89f5f7.jpg?1",
             "name": "Fervent Strike",
             "text": "Target creature gets +1/+0 and gains first strike and haste until end of turn.",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "6de3607a-b301-50e9-aa22-c437ebcd5e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f36a25-3692-4f2e-a25e-84b90656e6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f36a25-3692-4f2e-a25e-84b90656e6a4.jpg?1",
             "name": "Fiery Intervention",
             "text": "Choose one \u2014\n\u2022 Fiery Intervention deals 5 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "8dce6e64-614b-5ac4-aaaa-14fcb391778b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c94d7a-cad7-438f-bc96-e6a7158ab0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c94d7a-cad7-438f-bc96-e6a7158ab0e6.jpg?1",
             "name": "Fight with Fire",
             "text": "Kicker {5}{R} (You may pay an additional {5}{R} as you cast this spell.)\nFight with Fire deals 5 damage to target creature. If this spell was kicked, it deals 10 damage divided as you choose among any number of targets instead. (Those targets can include players and planeswalkers.)",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "8f01a280-1357-5838-9c70-b673cea2bb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62405700-d42c-4c96-9678-dd72d7b7c807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62405700-d42c-4c96-9678-dd72d7b7c807.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "3234646e-b009-5eb9-9a18-5a6e64e389d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0569365d-9e50-436f-a8f3-90820ef06381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0569365d-9e50-436f-a8f3-90820ef06381.jpg?1",
             "name": "Firefist Adept",
             "text": "When Firefist Adept enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of Wizards you control.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "ec1a3c04-8561-5466-8169-3706a270c252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc241f-64b5-4e28-b14a-b3f19ca6e7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc241f-64b5-4e28-b14a-b3f19ca6e7b5.jpg?1",
             "name": "The First Eruption",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 The First Eruption deals 1 damage to each creature without flying.\nII \u2014 Add {R}{R}.\nIII \u2014 Sacrifice a Mountain. If you do, The First Eruption deals 3 damage to each creature.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "02c5c276-a312-5849-91a2-03ad459b57fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324399ed-3d6e-4b4c-8f3d-b7802e2ecadf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324399ed-3d6e-4b4c-8f3d-b7802e2ecadf.jpg?1",
             "name": "The Flame of Keld",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Discard your hand.\nII \u2014 Draw two cards.\nIII \u2014 If a red source you control would deal damage to a permanent or player this turn, it deals that much damage plus 2 to that permanent or player instead.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "3ee8a213-b5b6-5a12-81c2-b5e07e953ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca9c16-5720-4531-88ea-48b48d189479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca9c16-5720-4531-88ea-48b48d189479.jpg?1",
             "name": "Frenzied Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "7ae244ea-9ac6-5e02-a7a8-cf09ec0faeb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca6dd9-040a-4122-9308-8dcd0d506ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca6dd9-040a-4122-9308-8dcd0d506ada.jpg?1",
             "name": "Ghitu Chronicler",
             "text": "Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nWhen Ghitu Chronicler enters the battlefield, if it was kicked, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "b96649b4-c6c7-5b33-b766-322acb83cec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4360bc9-76f0-4e82-8968-4c6c62a35ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4360bc9-76f0-4e82-8968-4c6c62a35ed1.jpg?1",
             "name": "Ghitu Journeymage",
             "text": "When Ghitu Journeymage enters the battlefield, if you control another Wizard, Ghitu Journeymage deals 2 damage to each opponent.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "b2bfe7e7-75eb-5675-8936-ae77653b06a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c448ba82-a502-459f-9ebc-fc9e85674e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c448ba82-a502-459f-9ebc-fc9e85674e6c.jpg?1",
             "name": "Ghitu Lavarunner",
             "text": "As long as there are two or more instant and/or sorcery cards in your graveyard, Ghitu Lavarunner gets +1/+0 and has haste.",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "f41b11bb-1bba-5e23-a7c3-23bfc71b6696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849db5d-cd41-49f6-acd5-697cdc8263f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4849db5d-cd41-49f6-acd5-697cdc8263f6.jpg?1",
             "name": "Goblin Barrage",
             "text": "Kicker\u2014\nSacrifice an artifact or Goblin. (You may sacrifice an artifact or Goblin in addition to any other costs as you cast this spell.)\nGoblin Barrage deals 4 damage to target creature. If this spell was kicked, it also deals 4 damage to target player or planeswalker.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "4aa981fb-6c16-52fa-b046-9ea88b27974e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb2883-3cfd-4fb0-9f99-6a57277f7fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb2883-3cfd-4fb0-9f99-6a57277f7fe4.jpg?1",
             "name": "Goblin Chainwhirler",
             "text": "First strike\nWhen Goblin Chainwhirler enters the battlefield, it deals 1 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -4410,7 +4410,7 @@
         },
         {
             "id": "13c0d75f-a993-576a-9b16-b472c94b9777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac033c-dc4e-40a0-b103-4892e4b50249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac033c-dc4e-40a0-b103-4892e4b50249.jpg?1",
             "name": "Goblin Warchief",
             "text": "Goblin spells you cast cost {1} less to cast.\nGoblins you control have haste.",
             "colours": [
@@ -4445,7 +4445,7 @@
         },
         {
             "id": "6bbf251b-3237-553d-8958-a8c2a33a7fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e558a5bd-e8f9-477f-a514-1bf0708f4e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e558a5bd-e8f9-477f-a514-1bf0708f4e9e.jpg?1",
             "name": "Haphazard Bombardment",
             "text": "When Haphazard Bombardment enters the battlefield, choose four nonenchantment permanents you don't control and put an aim counter on each of them.\nAt the beginning of your end step, if two or more permanents you don't control have an aim counter on them, destroy one of those permanents at random.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "d7e471b0-04d4-5ee2-837a-b09411a5e596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa25fedc-6038-48c8-b42a-817ac186492e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa25fedc-6038-48c8-b42a-817ac186492e.jpg?1",
             "name": "Jaya Ballard",
             "text": "+1: Add {R}{R}{R}. Spend this mana only to cast instant or sorcery spells.\n+1: Discard up to three cards, then draw that many cards.\n\u22128: You get an emblem with \"You may cast instant and sorcery cards from your graveyard. If a card cast this way would be put into your graveyard, exile it instead.\"",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "00caa8b8-f5c3-57ed-b0bd-0267e3fcd77d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48268bb8-1326-451b-9fae-de6605eb6cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48268bb8-1326-451b-9fae-de6605eb6cfd.jpg?1",
             "name": "Jaya's Immolating Inferno",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nJaya's Immolating Inferno deals X damage to each of up to three targets.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "a373cfb7-72ad-5b62-89f6-7aa92d463af6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66b814-9c47-4d17-8c02-1d9be565c76c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66b814-9c47-4d17-8c02-1d9be565c76c.jpg?1",
             "name": "Keldon Overseer",
             "text": "Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nHaste\nWhen Keldon Overseer enters the battlefield, if it was kicked, gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4582,7 +4582,7 @@
         },
         {
             "id": "459035bf-ab59-52d8-842e-ad211aa42bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1245212-d081-4e95-a508-e1d3a7496473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1245212-d081-4e95-a508-e1d3a7496473.jpg?1",
             "name": "Keldon Raider",
             "text": "When Keldon Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "6bf88367-9864-57b5-abe7-96d425ef8266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2e230-2d60-402d-98e4-0f33d2f27c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2e230-2d60-402d-98e4-0f33d2f27c56.jpg?1",
             "name": "Keldon Warcaller",
             "text": "Whenever Keldon Warcaller attacks, put a lore counter on target Saga you control.",
             "colours": [
@@ -4652,7 +4652,7 @@
         },
         {
             "id": "9d18ac00-5330-5215-becb-e4afb5b05faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6192b4ea-f781-4c56-89bc-530f5388b6b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6192b4ea-f781-4c56-89bc-530f5388b6b5.jpg?1",
             "name": "Orcish Vandal",
             "text": "{T}, Sacrifice an artifact: Orcish Vandal deals 2 damage to any target.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "5b10ada4-a5e2-54ca-9f25-cdfbb3c60a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94454128-92f1-475d-abc4-c235f501eeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94454128-92f1-475d-abc4-c235f501eeb6.jpg?1",
             "name": "Radiating Lightning",
             "text": "Radiating Lightning deals 3 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "79d98aad-5998-5062-81c6-6f09558e3c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdac0c6-bf72-4a9b-9fad-ae7bc2632a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdac0c6-bf72-4a9b-9fad-ae7bc2632a4a.jpg?1",
             "name": "Rampaging Cyclops",
             "text": "Rampaging Cyclops gets -2/-0 as long as two or more creatures are blocking it.",
             "colours": [
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "3f2dc9e1-9abf-5f92-8f1b-bbcd3f6db850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f2aa2c-deec-4927-a2d6-f5dce5967e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f2aa2c-deec-4927-a2d6-f5dce5967e26.jpg?1",
             "name": "Run Amok",
             "text": "Target attacking creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "d68c8a1e-5dd3-5b64-a3f8-fcd6f410a6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad40a04-a026-4285-8c78-088a356652d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad40a04-a026-4285-8c78-088a356652d1.jpg?1",
             "name": "Seismic Shift",
             "text": "Destroy target land. Up to two target creatures can't block this turn.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "cdbe0606-3ea5-53c9-8bcc-089306c673ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b9d339-99ed-4923-8f56-be37f29a0bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b9d339-99ed-4923-8f56-be37f29a0bfa.jpg?1",
             "name": "Shivan Fire",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nShivan Fire deals 2 damage to target creature. If this spell was kicked, it deals 4 damage to that creature instead.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "da05ebc7-9418-5eb7-8582-388c858f8f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ff087-97e7-4946-871f-1833abb2558a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59ff087-97e7-4946-871f-1833abb2558a.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, create three 1/1 red Goblin creature tokens.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to any target.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "490588dd-7ea2-577d-804a-d5227d2ff717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg?1",
             "name": "Skirk Prospector",
             "text": "Sacrifice a Goblin: Add {R}.",
             "colours": [
@@ -4917,7 +4917,7 @@
         },
         {
             "id": "ee2f7181-0431-5f63-9eb1-6dfc9f260890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9d28-1639-47bd-b925-7f3d2eefd352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77af9d28-1639-47bd-b925-7f3d2eefd352.jpg?1",
             "name": "Skizzik",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nTrample, haste\nAt the beginning of the end step, if Skizzik wasn't kicked, sacrifice it.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "5e356aff-7c5d-5411-ad67-ecf143b03e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3974c62-a524-454e-9ce7-2c23b704e5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3974c62-a524-454e-9ce7-2c23b704e5cb.jpg?1",
             "name": "Squee, the Immortal",
             "text": "You may cast Squee, the Immortal from your graveyard or from exile.",
             "colours": [
@@ -4987,7 +4987,7 @@
         },
         {
             "id": "d6a8ddac-5644-5a6d-89f4-8b706fdd030e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f86c365-3ce5-45e5-b610-6f2587f99b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f86c365-3ce5-45e5-b610-6f2587f99b42.jpg?1",
             "name": "Two-Headed Giant",
             "text": "Whenever Two-Headed Giant attacks, flip two coins. If both coins come up heads, Two-Headed Giant gains double strike until end of turn. If both coins come up tails, Two-Headed Giant gains menace until end of turn.",
             "colours": [
@@ -5022,7 +5022,7 @@
         },
         {
             "id": "46a183c4-1b7c-5ebf-a738-73a5f8c98fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253f9e43-5bc6-4f26-a8e9-773cd0ca3d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253f9e43-5bc6-4f26-a8e9-773cd0ca3d02.jpg?1",
             "name": "Valduk, Keeper of the Flame",
             "text": "At the beginning of combat on your turn, for each Aura and Equipment attached to Valduk, Keeper of the Flame, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "7b8c02f7-dfc3-50a0-9c7f-f8c59480ea26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db785c-cf82-4caa-aef6-8c61d9bec7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db785c-cf82-4caa-aef6-8c61d9bec7c6.jpg?1",
             "name": "Verix Bladewing",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nFlying\nWhen Verix Bladewing enters the battlefield, if it was kicked, create Karox Bladewing, a legendary 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "edc6f6a4-9f03-50d5-a4d0-50667081a881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff561f01-8dbc-4988-be00-592d1e417396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff561f01-8dbc-4988-be00-592d1e417396.jpg?1",
             "name": "Warcry Phoenix",
             "text": "Flying, haste\nWhenever you attack with three or more creatures, you may pay {2}{R}. If you do, return Warcry Phoenix from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "c0b323f2-77ce-536f-a9bb-4d2eb015f533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd63cf-7e8c-4c8d-844d-98535d5f3039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd63cf-7e8c-4c8d-844d-98535d5f3039.jpg?1",
             "name": "Warlord's Fury",
             "text": "Creatures you control gain first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "2ae0aae0-9fc5-5ff5-8313-414534a23c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bf371a-164c-4db8-9207-197c2e7c3c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bf371a-164c-4db8-9207-197c2e7c3c10.jpg?1",
             "name": "Wizard's Lightning",
             "text": "This spell costs {2} less to cast if you control a Wizard.\nWizard's Lightning deals 3 damage to any target.",
             "colours": [
@@ -5193,7 +5193,7 @@
         },
         {
             "id": "4b8811e7-c3ad-5baa-90a2-659612f27486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426c92c-6e71-49f0-9a91-0d529bf8c17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426c92c-6e71-49f0-9a91-0d529bf8c17d.jpg?1",
             "name": "Adventurous Impulse",
             "text": "Look at the top three cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "ea78ae83-5070-5b41-920a-3e3997aaed67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a3b223-b232-4da3-9431-ccb4688d5941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a3b223-b232-4da3-9431-ccb4688d5941.jpg?1",
             "name": "Ancient Animus",
             "text": "Put a +1/+1 counter on target creature you control if it's legendary. Then it fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "f516535a-cef2-5b06-a78d-ddc4972be7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceb365c-5de6-47ae-b42d-7fbce7781f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bceb365c-5de6-47ae-b42d-7fbce7781f8e.jpg?1",
             "name": "Arbor Armament",
             "text": "Put a +1/+1 counter on target creature. That creature gains reach until end of turn.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "b8aab163-9206-5b4c-a3d7-5fc7aa4f0484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504090bb-d183-4833-aea5-d4193b5c57a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504090bb-d183-4833-aea5-d4193b5c57a1.jpg?1",
             "name": "Baloth Gorger",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nIf Baloth Gorger was kicked, it enters the battlefield with three +1/+1 counters on it.",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "b2472ccf-1b75-5056-bd33-edb9802c6217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dcb59f-2a47-4461-9831-204ad15696b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dcb59f-2a47-4461-9831-204ad15696b5.jpg?1",
             "name": "Broken Bond",
             "text": "Destroy target artifact or enchantment. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "d923a5bc-2cda-59d9-9151-dcfd8622f5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13deb9c-5985-4355-8716-ee1c7b54b8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13deb9c-5985-4355-8716-ee1c7b54b8e2.jpg?1",
             "name": "Corrosive Ooze",
             "text": "Whenever Corrosive Ooze blocks or becomes blocked by an equipped creature, destroy all Equipment attached to that creature at end of combat.",
             "colours": [
@@ -5389,7 +5389,7 @@
         },
         {
             "id": "69676074-6212-5bd8-8a2c-dcba66a26b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e62226e-3585-42d2-9b7a-2462fcd967f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e62226e-3585-42d2-9b7a-2462fcd967f5.jpg?1",
             "name": "Elfhame Druid",
             "text": "{T}: Add {G}.\n{T}: Add {G}{G}. Spend this mana only to cast kicked spells.",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "9c4905b4-f3a4-5955-8128-b9b56acb09ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419f2a-63cf-4ab7-bad0-b0f773fc0570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56419f2a-63cf-4ab7-bad0-b0f773fc0570.jpg?1",
             "name": "Fungal Plots",
             "text": "{1}{G}, Exile a creature card from your graveyard: Create a 1/1 green Saproling creature token.\nSacrifice two Saprolings: You gain 2 life and draw a card.",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "deae7ecf-43ca-50fb-a68f-613bd92fb3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23cf81ed-b86c-42b8-b796-2032b0a3654a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23cf81ed-b86c-42b8-b796-2032b0a3654a.jpg?1",
             "name": "Gaea's Blessing",
             "text": "Target player shuffles up to three target cards from their graveyard into their library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "95845410-5d79-564c-b01d-7ea5e48ca0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc5ce71-282c-43f9-b12a-edd8f4ab6006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc5ce71-282c-43f9-b12a-edd8f4ab6006.jpg?1",
             "name": "Gaea's Protector",
             "text": "Gaea's Protector must be blocked if able.",
             "colours": [
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "fa42977f-03b7-5678-951b-cfd51722ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8878-5928-47ec-bb31-f4ee24ad982b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8878-5928-47ec-bb31-f4ee24ad982b.jpg?1",
             "name": "Gift of Growth",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nUntap target creature. It gets +2/+2 until end of turn. If this spell was kicked, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "da5ba291-35e8-5738-a353-638b041c7d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4d1c2-671c-498c-a232-7d076e3dc3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4d1c2-671c-498c-a232-7d076e3dc3bb.jpg?1",
             "name": "Grow from the Ashes",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nSearch your library for a basic land card, put it onto the battlefield, then shuffle your library. If this spell was kicked, instead search your library for two basic land cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "93e541a0-8989-57de-a048-fdd72e06469f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a9aa5c-1501-4958-872a-39c512514033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a9aa5c-1501-4958-872a-39c512514033.jpg?1",
             "name": "Grunn, the Lonely King",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nIf Grunn, the Lonely King was kicked, it enters the battlefield with five +1/+1 counters on it.\nWhenever Grunn attacks alone, double its power and toughness until end of turn.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "e81c020e-00b0-5942-8bb5-a95c38f1195f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf95ef60-e67b-466d-a6cb-d487ffa88b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf95ef60-e67b-466d-a6cb-d487ffa88b72.jpg?1",
             "name": "Kamahl's Druidic Vow",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nLook at the top X cards of your library. You may put any number of land and/or legendary permanent cards with converted mana cost X or less from among them onto the battlefield. Put the rest into your graveyard.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "67a9a12d-bb34-575a-888c-8120d598685c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c332dc82-7664-44d0-b92a-a3d867399884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c332dc82-7664-44d0-b92a-a3d867399884.jpg?1",
             "name": "Krosan Druid",
             "text": "Kicker {4}{G} (You may pay an additional {4}{G} as you cast this spell.)\nWhen Krosan Druid enters the battlefield, if it was kicked, you gain 10 life.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "8e40b6d6-c40b-5ce9-91e1-9b8eb48e81f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581b7327-3215-4a4f-b4ae-d9d4002ba882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581b7327-3215-4a4f-b4ae-d9d4002ba882.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "5625a9dd-75f9-5f7a-ba0f-3be0f6650ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a667bba-ecf0-4212-8ca3-75d4db6abce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a667bba-ecf0-4212-8ca3-75d4db6abce2.jpg?1",
             "name": "Llanowar Envoy",
             "text": "{1}{G}: Add one mana of any color.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "1e425ff7-46ee-5fae-a5b2-12a9ab69709a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8026d80-2e91-46f9-ae97-1f137848236c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8026d80-2e91-46f9-ae97-1f137848236c.jpg?1",
             "name": "Llanowar Scout",
             "text": "{T}: You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -5798,7 +5798,7 @@
         },
         {
             "id": "cbe43d6e-45a2-5e6c-9d79-adb8ff859c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db18bbcd-527d-4134-a6ae-6f4381419867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db18bbcd-527d-4134-a6ae-6f4381419867.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach",
             "colours": [
@@ -5832,7 +5832,7 @@
         },
         {
             "id": "d0f214fe-fe7e-5314-8bc6-f2313cf03058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251613c0-2e72-4bd1-b3b5-69602b07b6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251613c0-2e72-4bd1-b3b5-69602b07b6f9.jpg?1",
             "name": "Marwyn, the Nurturer",
             "text": "Whenever another Elf enters the battlefield under your control, put a +1/+1 counter on Marwyn, the Nurturer.\n{T}: Add an amount of {G} equal to Marwyn's power.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "bcb48081-4b63-5a3e-949d-6ff77d39f790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5e4d9a-34e1-46eb-814b-8e3bd4475b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5e4d9a-34e1-46eb-814b-8e3bd4475b8a.jpg?1",
             "name": "The Mending of Dominaria",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put the top two cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.\nIII \u2014 Return all land cards from your graveyard to the battlefield, then shuffle your graveyard into your library.",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "e2c35a48-c336-5b62-82ec-d339fe7b1e0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233ad7b-2903-4736-b13a-5cd4a275eb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233ad7b-2903-4736-b13a-5cd4a275eb61.jpg?1",
             "name": "Multani, Yavimaya's Avatar",
             "text": "Reach, trample\nMultani, Yavimaya's Avatar gets +1/+1 for each land you control and each land card in your graveyard.\n{1}{G}, Return two lands you control to their owner's hand: Return Multani from your graveyard to your hand.",
             "colours": [
@@ -5940,7 +5940,7 @@
         },
         {
             "id": "8c0ae940-0926-5cc4-ba37-f5646d1f72cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6666b95e-80de-4bf7-bae6-8a7e991b38ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6666b95e-80de-4bf7-bae6-8a7e991b38ad.jpg?1",
             "name": "Nature's Spiral",
             "text": "Return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -5972,7 +5972,7 @@
         },
         {
             "id": "d8df9471-7b5d-517f-b4ba-d6c3cd81c039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df491512-ba8a-4ba5-ad42-338190201170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df491512-ba8a-4ba5-ad42-338190201170.jpg?1",
             "name": "Pierce the Sky",
             "text": "Pierce the Sky deals 7 damage to target creature with flying.",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "b991d060-061e-51ec-b0e0-a405d482493a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fb52be-0e17-437d-8583-af69cdfff87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fb52be-0e17-437d-8583-af69cdfff87b.jpg?1",
             "name": "Primordial Wurm",
             "text": "",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "7847c602-1d8c-5c3b-b5f7-732b2588397c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2578d25e-5f8d-42ff-90ce-4e7d100cbbb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2578d25e-5f8d-42ff-90ce-4e7d100cbbb6.jpg?1",
             "name": "Saproling Migration",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nCreate two 1/1 green Saproling creature tokens. If this spell was kicked, create four of those tokens instead.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "3d23afc2-8cb8-568c-aa91-220b444d3850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b534b-8442-4074-a8d2-f38e83f24868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45b534b-8442-4074-a8d2-f38e83f24868.jpg?1",
             "name": "Song of Freyalise",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Until your next turn, creatures you control gain \"{T}: Add one mana of any color.\"\nIII \u2014 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance, trample, and indestructible until end of turn.",
             "colours": [
@@ -6104,7 +6104,7 @@
         },
         {
             "id": "4fbb65be-ed32-558e-ba2c-1970fbd1e36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2314215-23af-4c8e-860f-b029e151af36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2314215-23af-4c8e-860f-b029e151af36.jpg?1",
             "name": "Spore Swarm",
             "text": "Create three 1/1 green Saproling creature tokens.",
             "colours": [
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "01b11482-8dc2-52e8-80a5-d5f4bdff4e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b93b5-e16a-4a1a-bd26-74a9f25caffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b93b5-e16a-4a1a-bd26-74a9f25caffe.jpg?1",
             "name": "Sporecrown Thallid",
             "text": "Each other creature you control that's a Fungus or Saproling gets +1/+1.",
             "colours": [
@@ -6170,7 +6170,7 @@
         },
         {
             "id": "0b7bb966-77d9-505b-afd1-f0cfa91e8f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8a688-79d4-49b9-ab0c-c7f5c9b551f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8a688-79d4-49b9-ab0c-c7f5c9b551f4.jpg?1",
             "name": "Steel Leaf Champion",
             "text": "Steel Leaf Champion can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "fb8b609f-76d7-5244-92e3-300888d5516e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ac4d3d-064e-459d-b3a4-6c0872a2da8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ac4d3d-064e-459d-b3a4-6c0872a2da8c.jpg?1",
             "name": "Sylvan Awakening",
             "text": "Until your next turn, all lands you control become 2/2 Elemental creatures with reach, indestructible, and haste. They're still lands.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "d4891502-9304-5ed6-818b-08a2ca4e9e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ac2b0-47ea-4aa3-bf24-c78227a0c913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8ac2b0-47ea-4aa3-bf24-c78227a0c913.jpg?1",
             "name": "Territorial Allosaurus",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nWhen Territorial Allosaurus enters the battlefield, if it was kicked, it fights another target creature.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "dc4ebc69-b63c-54ae-9105-0bb6ac20e2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da901037-20e6-4445-8e7e-1ccd2e8b13ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da901037-20e6-4445-8e7e-1ccd2e8b13ae.jpg?1",
             "name": "Thorn Elemental",
             "text": "You may have Thorn Elemental assign its combat damage as though it weren't blocked.",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "a3b3fb8c-e9cd-571a-89ba-54757978f450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4cf84a-2024-45bb-9e24-8a9a6d9ad247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4cf84a-2024-45bb-9e24-8a9a6d9ad247.jpg?1",
             "name": "Untamed Kavu",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nVigilance, trample\nIf Untamed Kavu was kicked, it enters the battlefield with three +1/+1 counters on it.",
             "colours": [
@@ -6339,7 +6339,7 @@
         },
         {
             "id": "8460f1c3-bc7e-57fd-9517-26e853b1d3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d972f97-1945-440b-8bd3-63038db22257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d972f97-1945-440b-8bd3-63038db22257.jpg?1",
             "name": "Verdant Force",
             "text": "At the beginning of each upkeep, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "65753422-5f54-510e-b6a1-c413eefa6744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb75cf21-08be-4b92-bdf6-014a36090738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb75cf21-08be-4b92-bdf6-014a36090738.jpg?1",
             "name": "Wild Onslaught",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nPut a +1/+1 counter on each creature you control. If this spell was kicked, put two +1/+1 counters on each creature you control instead.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "5fe08682-4f92-5905-af75-94487deb6044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef6b657-7273-4abe-92f4-e1e4cda78f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef6b657-7273-4abe-92f4-e1e4cda78f96.jpg?1",
             "name": "Yavimaya Sapherd",
             "text": "When Yavimaya Sapherd enters the battlefield, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "f8397d62-ca19-5877-9d62-fad9a78d0a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c950e2-a43b-47f8-9ad6-1909ccc7acbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c950e2-a43b-47f8-9ad6-1909ccc7acbf.jpg?1",
             "name": "Adeliz, the Cinder Wind",
             "text": "Flying, haste\nWhenever you cast an instant or sorcery spell, Wizards you control get +1/+1 until end of turn.",
             "colours": [
@@ -6478,7 +6478,7 @@
         },
         {
             "id": "e69167b7-de6e-5b2b-bb73-dc45979e2602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811f37a-f381-42e7-9b4a-15b2241eb10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811f37a-f381-42e7-9b4a-15b2241eb10d.jpg?1",
             "name": "Arvad the Cursed",
             "text": "Deathtouch, lifelink\nOther legendary creatures you control get +2/+2.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "48a70f50-f083-58d6-8b35-d3f97b3c132d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e2981b-bf25-4d9d-8811-5a1ff0b4d5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e2981b-bf25-4d9d-8811-5a1ff0b4d5d2.jpg?1",
             "name": "Aryel, Knight of Windgrace",
             "text": "Vigilance\n{2}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.\n{B}, {T}, Tap X untapped Knights you control: Destroy target creature with power X or less.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "54f30576-f4d3-5e68-a7a7-50fa2402e693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9459ffca-5a1f-4641-88d4-8a499b261faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9459ffca-5a1f-4641-88d4-8a499b261faa.jpg?1",
             "name": "Darigaaz Reincarnated",
             "text": "Flying, trample, haste\nIf Darigaaz Reincarnated would die, instead exile it with three egg counters on it.\nAt the beginning of your upkeep, if Darigaaz is exiled with an egg counter on it, remove an egg counter from it. Then if Darigaaz has no egg counters on it, return it to the battlefield.",
             "colours": [
@@ -6596,7 +6596,7 @@
         },
         {
             "id": "4164cd02-e4d0-5541-9f6c-1e38ed308af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9c1471-ae6f-4b66-9842-46f1a74e93b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9c1471-ae6f-4b66-9842-46f1a74e93b5.jpg?1",
             "name": "Garna, the Bloodflame",
             "text": "Flash\nWhen Garna, the Bloodflame enters the battlefield, return to your hand all creature cards in your graveyard that were put there from anywhere this turn.\nOther creatures you control have haste.",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "9e575e54-ded0-5a9b-bdad-adeb802b7c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986981fa-a744-45d8-81c7-68ef335c79e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986981fa-a744-45d8-81c7-68ef335c79e2.jpg?1",
             "name": "Grand Warlord Radha",
             "text": "Haste\nWhenever one or more creatures you control attack, add that much mana in any combination of {R} and/or {G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "33b59732-1aed-5237-9497-8cbce94c42a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c896643e-eeef-49a6-a1ca-2577b55af2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c896643e-eeef-49a6-a1ca-2577b55af2b0.jpg?1",
             "name": "Hallar, the Firefletcher",
             "text": "Trample\nWhenever you cast a spell, if that spell was kicked, put a +1/+1 counter on Hallar, the Firefletcher, then Hallar deals damage equal to the number of +1/+1 counters on it to each opponent.",
             "colours": [
@@ -6713,7 +6713,7 @@
         },
         {
             "id": "11f91e9f-ce4d-595c-8433-a4a49b650379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cf8c6b-1322-4bc5-a604-6e372607fae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cf8c6b-1322-4bc5-a604-6e372607fae4.jpg?1",
             "name": "Jhoira, Weatherlight Captain",
             "text": "Whenever you cast a historic spell, draw a card. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "9681ed19-7c25-530b-8485-fe1fec52136c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee86efa-248e-4251-b734-f8ad3e8a0344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee86efa-248e-4251-b734-f8ad3e8a0344.jpg?1",
             "name": "Jodah, Archmage Eternal",
             "text": "Flying\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -6795,7 +6795,7 @@
         },
         {
             "id": "f9aff7c9-eb03-5464-b07c-df3b04d353e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c654737d-34ac-42ff-ae27-3a3bbb930fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c654737d-34ac-42ff-ae27-3a3bbb930fc1.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play up to one permanent card of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "6e43cd0d-5c68-5278-b0e4-2598caa31deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7fadca-0a94-4624-ab95-2c2410829824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7fadca-0a94-4624-ab95-2c2410829824.jpg?1",
             "name": "Oath of Teferi",
             "text": "When Oath of Teferi enters the battlefield, exile another target permanent you control. Return it to the battlefield under its owner's control at the beginning of the next end step.\nYou may activate the loyalty abilities of planeswalkers you control twice each turn rather than only once.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "be7242ef-2621-5967-90aa-faffd5e58ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dd2950-502c-4859-85fe-9fbef09aef43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dd2950-502c-4859-85fe-9fbef09aef43.jpg?1",
             "name": "Primevals' Glorious Rebirth",
             "text": "(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)\nReturn all legendary permanent cards from your graveyard to the battlefield.",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "58732750-7552-5a15-b87e-fca46e7aaa1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674070e3-6efe-45e4-aff6-e4a49ec2106e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674070e3-6efe-45e4-aff6-e4a49ec2106e.jpg?1",
             "name": "Raff Capashen, Ship's Mage",
             "text": "Flash\nFlying\nYou may cast historic spells as though they had flash. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "66cacc14-33a7-57f4-81c5-d569de20d5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45420f5e-f7f8-4db7-9b54-e2fa1be22094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45420f5e-f7f8-4db7-9b54-e2fa1be22094.jpg?1",
             "name": "Rona, Disciple of Gix",
             "text": "When Rona, Disciple of Gix enters the battlefield, you may exile target historic card from your graveyard. (Artifacts, legendaries, and Sagas are historic.)\nYou may cast nonland cards exiled with Rona.\n{4}, {T}: Exile the top card of your library.",
             "colours": [
@@ -6986,7 +6986,7 @@
         },
         {
             "id": "887bc22b-2ced-5d22-bfc3-a527ed9cbc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90df81c-d738-46b3-8e96-9db0b3507ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90df81c-d738-46b3-8e96-9db0b3507ee0.jpg?1",
             "name": "Shanna, Sisay's Legacy",
             "text": "Shanna, Sisay's Legacy can't be the target of abilities your opponents control.\nShanna gets +1/+1 for each creature you control.",
             "colours": [
@@ -7025,7 +7025,7 @@
         },
         {
             "id": "f599550d-28ba-53ae-b725-20489667ad9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8815cd9-7032-445a-aebc-cfc19bd51ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8815cd9-7032-445a-aebc-cfc19bd51ee4.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "578a5f76-cfa5-58d6-9dc0-bb7d6c77bd7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93657aaa-7a0f-49ad-b026-6f79b3bd6768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93657aaa-7a0f-49ad-b026-6f79b3bd6768.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Whenever a land enters the battlefield under your control, you gain 1 life and draw a card.",
             "colours": [
@@ -7102,7 +7102,7 @@
         },
         {
             "id": "19a650ba-eba3-563b-b2a9-de5d4c21df28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d10b752-d9cb-419d-a5c4-d4ee1acb655e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d10b752-d9cb-419d-a5c4-d4ee1acb655e.jpg?1",
             "name": "Teferi, Hero of Dominaria",
             "text": "+1: Draw a card. At the beginning of the next end step, untap two lands.\n\u22123: Put target nonland permanent into its owner's library third from the top.\n\u22128: You get an emblem with \"Whenever you draw a card, exile target permanent an opponent controls.\"",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "6af3a8df-f7e1-5104-b35b-8b6cd2e559ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8aea2f-1e1d-4e0d-8370-207b6cae76e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8aea2f-1e1d-4e0d-8370-207b6cae76e3.jpg?1",
             "name": "Tiana, Ship's Caretaker",
             "text": "Flying, first strike\nWhenever an Aura or Equipment you control is put into a graveyard from the battlefield, you may return that card to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "ffa2e344-15c4-5c01-86da-fc0289be2ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25afd4a7-4253-4a4e-a105-e92f64460faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25afd4a7-4253-4a4e-a105-e92f64460faa.jpg?1",
             "name": "Aesthir Glider",
             "text": "Flying\nAesthir Glider can't block.",
             "colours": [],
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "068203a3-3d31-5968-8e3b-ab37831d8168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b49065-0a46-4813-a721-71d718e73d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b49065-0a46-4813-a721-71d718e73d18.jpg?1",
             "name": "Amaranthine Wall",
             "text": "Defender\n{2}: Amaranthine Wall gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [],
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "6cf56b29-9e5c-55ad-939d-03272ed13393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862d38d1-e3d0-47e1-a535-ff445b1c55c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862d38d1-e3d0-47e1-a535-ff445b1c55c6.jpg?1",
             "name": "Blackblade Reforged",
             "text": "Equipped creature gets +1/+1 for each land you control.\nEquip legendary creature {3}\nEquip {7}",
             "colours": [],
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "e1d07e0a-0ff6-5d9b-ab3b-1cc76247931e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8125b6-911e-4663-962a-d741984c927d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8125b6-911e-4663-962a-d741984c927d.jpg?1",
             "name": "Bloodtallow Candle",
             "text": "{6}, {T}, Sacrifice Bloodtallow Candle: Target creature gets -5/-5 until end of turn.",
             "colours": [],
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "4396c81b-9cea-5a94-bc34-e5ac6b9a894b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7d16b-8f4e-42b9-be24-3cb091932d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7d16b-8f4e-42b9-be24-3cb091932d7c.jpg?1",
             "name": "Damping Sphere",
             "text": "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
             "colours": [],
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "2a2fd78a-8917-521c-b73e-f8508b068f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52212fd5-551e-4bc1-9dac-6361e27c27ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52212fd5-551e-4bc1-9dac-6361e27c27ad.jpg?1",
             "name": "Forebear's Blade",
             "text": "Equipped creature gets +3/+0 and has vigilance and trample.\nWhenever equipped creature dies, attach Forebear's Blade to target creature you control.\nEquip {3}",
             "colours": [],
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "e3f30308-0d86-5d8e-a2ae-efeedb1726a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a487e208-8493-4bca-8c44-284d89c66b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a487e208-8493-4bca-8c44-284d89c66b15.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "8e1184b1-5a30-56f5-9ec9-a2ebf3400e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbc615a-708a-444b-acab-871cce22694d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbc615a-708a-444b-acab-871cce22694d.jpg?1",
             "name": "Guardians of Koilos",
             "text": "When Guardians of Koilos enters the battlefield, you may return another target historic permanent you control to its owner's hand. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "e71b8be6-2930-5b8d-95fd-7d665eef7e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d65d20c-09e5-4139-838b-7e0e48eb2b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d65d20c-09e5-4139-838b-7e0e48eb2b2b.jpg?1",
             "name": "Helm of the Host",
             "text": "At the beginning of combat on your turn, create a token that's a copy of equipped creature, except the token isn't legendary if equipped creature is legendary. That token gains haste.\nEquip {5}",
             "colours": [],
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "206c6974-dcee-503a-8bed-a825e42c1aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775ab60a-2dc1-44fc-8022-f7becd8ee195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775ab60a-2dc1-44fc-8022-f7becd8ee195.jpg?1",
             "name": "Howling Golem",
             "text": "Whenever Howling Golem attacks or blocks, each player draws a card.",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "fed701bb-70de-5810-9b33-108be935bc10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd9b205-817e-4ca4-8a29-3c2b6cbf7207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd9b205-817e-4ca4-8a29-3c2b6cbf7207.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "0511776a-2024-559f-9423-b46bb0d08408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3718761f-feb1-46c4-aaa3-7e07a3fa72fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3718761f-feb1-46c4-aaa3-7e07a3fa72fa.jpg?1",
             "name": "Jhoira's Familiar",
             "text": "Flying\nHistoric spells you cast cost {1} less to cast. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7541,7 +7541,7 @@
         },
         {
             "id": "ff2d77ff-fd4f-55f8-876c-dd1ad18212c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446579ab-5e36-44e2-84d7-cfa537619146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446579ab-5e36-44e2-84d7-cfa537619146.jpg?1",
             "name": "Jousting Lance",
             "text": "Equipped creature gets +2/+0.\nAs long as it's your turn, equipped creature has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7571,7 +7571,7 @@
         },
         {
             "id": "b871187c-e720-555c-8e4d-a8c0bc155f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfebeab7-44cf-4895-bdd5-04cbb2c700d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfebeab7-44cf-4895-bdd5-04cbb2c700d7.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "2c634452-6b48-5b27-977c-de75078e3fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f342b2-1ba6-4b72-9f03-bc076c795b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f342b2-1ba6-4b72-9f03-bc076c795b3d.jpg?1",
             "name": "Mishra's Self-Replicator",
             "text": "Whenever you cast a historic spell, you may pay {1}. If you do, create a token that's a copy of Mishra's Self-Replicator. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "e82dce50-0b88-5f60-be8c-fcf3ce71a910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66024e69-ad60-4c9a-a0ca-da138d33ad80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66024e69-ad60-4c9a-a0ca-da138d33ad80.jpg?1",
             "name": "Mox Amber",
             "text": "{T}: Add one mana of any color among legendary creatures and planeswalkers you control.",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "3cdf4d49-a47f-547c-8bc5-3b2e4a312232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a283135-7a51-4cf7-82a6-7e50894e64a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a283135-7a51-4cf7-82a6-7e50894e64a5.jpg?1",
             "name": "Navigator's Compass",
             "text": "When Navigator's Compass enters the battlefield, you gain 3 life.\n{T}: Until end of turn, target land you control becomes the basic land type of your choice in addition to its other types.",
             "colours": [],
@@ -7691,7 +7691,7 @@
         },
         {
             "id": "6bbdc05c-eebd-5302-a29b-b51da39ff33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fffe967-3a99-4f00-af46-f4e5567598df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fffe967-3a99-4f00-af46-f4e5567598df.jpg?1",
             "name": "Pardic Wanderer",
             "text": "Trample",
             "colours": [],
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "4f027779-6b52-56bc-9e83-20252d4cf95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62fd366-c287-48c3-9ded-5dc63a34518c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62fd366-c287-48c3-9ded-5dc63a34518c.jpg?1",
             "name": "Powerstone Shard",
             "text": "{T}: Add {C} for each artifact you control named Powerstone Shard.",
             "colours": [],
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "82831d1e-830b-535e-93b1-5cced9f27e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7207edf8-8534-4982-969f-df97febcb9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7207edf8-8534-4982-969f-df97febcb9fc.jpg?1",
             "name": "Shield of the Realm",
             "text": "If a source would deal damage to equipped creature, prevent 2 of that damage.\nEquip {1}",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "87857475-7975-50a0-99c4-f288945e66f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb79a623-21c3-4310-bc76-310935511d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb79a623-21c3-4310-bc76-310935511d45.jpg?1",
             "name": "Short Sword",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7810,7 +7810,7 @@
         },
         {
             "id": "598445f9-bace-5058-988d-01a6da322de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7bea0-79c9-4856-8279-cef7cee82fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c7bea0-79c9-4856-8279-cef7cee82fc1.jpg?1",
             "name": "Skittering Surveyor",
             "text": "When Skittering Surveyor enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "3745a8cf-9cd7-55f1-8510-8f8549412cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ee3692-54e3-42de-85c6-0a3b5c6a2402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ee3692-54e3-42de-85c6-0a3b5c6a2402.jpg?1",
             "name": "Sorcerer's Wand",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target player or planeswalker. If this creature is a Wizard, it deals 2 damage to that player or planeswalker instead.\"\nEquip {3}",
             "colours": [],
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "d1020a60-9528-572a-abef-4e9e4e4a5dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc7db8-386e-4fb6-aefa-591e99747eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc7db8-386e-4fb6-aefa-591e99747eb2.jpg?1",
             "name": "Sparring Construct",
             "text": "When Sparring Construct dies, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "21312047-dc36-5597-8f26-5c6cfb5469c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72806f4f-74e8-4621-92b0-5c63bb898884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72806f4f-74e8-4621-92b0-5c63bb898884.jpg?1",
             "name": "Thran Temporal Gateway",
             "text": "{4}, {T}: You may put a historic permanent card from your hand onto the battlefield. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "82f40e86-79cb-5b78-9375-b336f1dd334e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab80216-3df7-4e4f-8732-16dd6cac6bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dab80216-3df7-4e4f-8732-16dd6cac6bcf.jpg?1",
             "name": "Traxos, Scourge of Kroog",
             "text": "Trample\nTraxos, Scourge of Kroog enters the battlefield tapped and doesn't untap during your untap step.\nWhenever you cast a historic spell, untap Traxos. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7965,7 +7965,7 @@
         },
         {
             "id": "a2087b7c-7fc4-5390-a1c1-7d37a6c6566b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bead8b-a67f-4451-9d44-038f8688093f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bead8b-a67f-4451-9d44-038f8688093f.jpg?1",
             "name": "Urza's Tome",
             "text": "{3}, {T}: Draw a card. Then discard a card unless you exile a historic card from your graveyard. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "7e083d79-79e4-5156-ae10-3b4b3a89dda7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28564ac6-8b9b-4b99-9630-8fb3158d354c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28564ac6-8b9b-4b99-9630-8fb3158d354c.jpg?1",
             "name": "Voltaic Servant",
             "text": "At the beginning of your end step, untap target artifact.",
             "colours": [],
@@ -8024,7 +8024,7 @@
         },
         {
             "id": "7018d3b4-a50b-5dad-bedd-3c1c7e77784a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4581fc0-551c-4ee5-bde0-65c2b8cdf1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4581fc0-551c-4ee5-bde0-65c2b8cdf1b7.jpg?1",
             "name": "Weatherlight",
             "text": "Flying\nWhenever Weatherlight deals combat damage to a player, look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. (Artifacts, legendaries, and Sagas are historic.)\nCrew 3",
             "colours": [],
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "fb0481bd-0ad1-588e-9cd6-8661298171e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda51ef-ee3e-48d4-92e2-c9083bbe0f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda51ef-ee3e-48d4-92e2-c9083bbe0f80.jpg?1",
             "name": "Cabal Stronghold",
             "text": "{T}: Add {C}.\n{3}, {T}: Add {B} for each basic Swamp you control.",
             "colours": [],
@@ -8086,7 +8086,7 @@
         },
         {
             "id": "f369da12-cc76-513f-959f-93bedd009d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b52b9c-7278-46b4-9f3c-3a7fc0c7e526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b52b9c-7278-46b4-9f3c-3a7fc0c7e526.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "49b1b3a5-fcc4-5b83-b30d-f522b4dd2edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631d040-51e9-4540-91e7-aeb5ade84090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631d040-51e9-4540-91e7-aeb5ade84090.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "c0dfade1-3de9-5dc0-a5df-44417437c9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d95d37-5dbe-4a25-bc80-a4db08f3c63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d95d37-5dbe-4a25-bc80-a4db08f3c63a.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "8a86682c-2ebd-501b-b031-1bee916ae76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbe56f2-aec5-4e8b-8003-1bf1ca7f5659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbe56f2-aec5-4e8b-8003-1bf1ca7f5659.jpg?1",
             "name": "Memorial to Folly",
             "text": "Memorial to Folly enters the battlefield tapped.\n{T}: Add {B}.\n{2}{B}, {T}, Sacrifice Memorial to Folly: Return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -8209,7 +8209,7 @@
         },
         {
             "id": "5274537a-fc6c-5ff1-8879-a2b32a2d3ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97bb62e-45cf-4862-b181-5af463a442b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97bb62e-45cf-4862-b181-5af463a442b5.jpg?1",
             "name": "Memorial to Genius",
             "text": "Memorial to Genius enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards.",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "9df4981d-4a3a-5388-8211-c81647b8be39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564d6ff1-2be1-42f1-a919-fe8c2e148c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564d6ff1-2be1-42f1-a919-fe8c2e148c3f.jpg?1",
             "name": "Memorial to Glory",
             "text": "Memorial to Glory enters the battlefield tapped.\n{T}: Add {W}.\n{3}{W}, {T}, Sacrifice Memorial to Glory: Create two 1/1 white Soldier creature tokens.",
             "colours": [],
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "7956e732-51b6-59b6-9f8c-ccf153b5932f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994d903b-0d54-4af4-898f-213e716e9ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994d903b-0d54-4af4-898f-213e716e9ed4.jpg?1",
             "name": "Memorial to Unity",
             "text": "Memorial to Unity enters the battlefield tapped.\n{T}: Add {G}.\n{2}{G}, {T}, Sacrifice Memorial to Unity: Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Then put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "8ea9a20c-6708-52cf-a313-45253de5c5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53920ed7-fc9a-4b50-85c8-d62de05b2390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53920ed7-fc9a-4b50-85c8-d62de05b2390.jpg?1",
             "name": "Memorial to War",
             "text": "Memorial to War enters the battlefield tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice Memorial to War: Destroy target land.",
             "colours": [],
@@ -8329,7 +8329,7 @@
         },
         {
             "id": "6cf241f2-fba0-56ba-8756-1300b258b3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc412fc-e9d4-4283-bd4a-811384e79b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc412fc-e9d4-4283-bd4a-811384e79b5c.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8360,7 +8360,7 @@
         },
         {
             "id": "c639e2fa-87c3-5357-a1f8-01e1044d3e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05cf47-9823-41f9-b893-321ea89e473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05cf47-9823-41f9-b893-321ea89e473e.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "ccf89329-4e12-5be1-8d6b-d51a56d358ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f41f3-7304-4b45-bc16-fa1ddcc5eff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f41f3-7304-4b45-bc16-fa1ddcc5eff0.jpg?1",
             "name": "Zhalfirin Void",
             "text": "When Zhalfirin Void enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {C}.",
             "colours": [],
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "5b771097-73cc-55e4-ae61-3c82f878ccd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023d333b-14f2-40ad-bb76-8b9e38040f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023d333b-14f2-40ad-bb76-8b9e38040f89.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8457,7 +8457,7 @@
         },
         {
             "id": "30844257-fa7d-5454-abd2-39527a602158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f1d17a-c17c-4a27-97db-a37ee8c0e706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f1d17a-c17c-4a27-97db-a37ee8c0e706.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "bc124941-2502-5add-acba-b5611c757dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443d32d-0576-4666-8da8-241de446b7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443d32d-0576-4666-8da8-241de446b7db.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "2aa273a5-4859-5224-bde4-ab1be38b47cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17acb3-0765-4703-a03d-6867a2f59db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17acb3-0765-4703-a03d-6867a2f59db2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "a607c46a-777b-52df-a377-9ca1e7d225d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce67a27-aa80-46ac-955a-8fea336995d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce67a27-aa80-46ac-955a-8fea336995d9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8609,7 +8609,7 @@
         },
         {
             "id": "de94d1ad-c734-585b-90c8-fc459fda52bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54693eb8-bd68-4781-a60f-113adf947d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54693eb8-bd68-4781-a60f-113adf947d5d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "2e1410b5-1fe1-59d4-a19d-41b4b4045807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ee4f9-ca54-4cc1-ac2e-2a2ef5eea9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ee4f9-ca54-4cc1-ac2e-2a2ef5eea9ce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8685,7 +8685,7 @@
         },
         {
             "id": "ce47df56-badc-5f62-8e12-c0a95dfc824a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90520e73-5c7e-4735-a16d-f737e1a230cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90520e73-5c7e-4735-a16d-f737e1a230cf.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8723,7 +8723,7 @@
         },
         {
             "id": "166a204a-e494-50d7-adb6-d2e63d88d17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb6aa-45ac-4a0e-bab2-1a004aac841f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eeb6aa-45ac-4a0e-bab2-1a004aac841f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "1e201b24-b700-5de8-92ea-5ebb3d48cb27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44baaa0a-9951-4ee7-a9db-64f841bd1bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44baaa0a-9951-4ee7-a9db-64f841bd1bd0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "3833ab30-e75a-5854-927f-c7dc8303b56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc1392-7701-4f3e-b5af-d8756bef6d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc1392-7701-4f3e-b5af-d8756bef6d07.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8837,7 +8837,7 @@
         },
         {
             "id": "cb5b693c-afbb-5e7d-82ee-dda0da3dcae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ebefe-ad31-430b-b298-c9df929e03cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ebefe-ad31-430b-b298-c9df929e03cc.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "11378eb6-370a-5245-998a-a71db992db07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621aa8e1-aebf-4eea-beb5-7fb47700a87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621aa8e1-aebf-4eea-beb5-7fb47700a87a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8913,7 +8913,7 @@
         },
         {
             "id": "88ba47e5-5b95-5a66-8d1a-52b8a2a79793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7255ed-4fec-488e-b334-59d3c0f1acd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7255ed-4fec-488e-b334-59d3c0f1acd6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8951,7 +8951,7 @@
         },
         {
             "id": "01980ea4-a5ae-5636-9ad8-fdbbfb108471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6bb74-b58b-4019-bfa4-7325d70a2fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6bb74-b58b-4019-bfa4-7325d70a2fc2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "6cd09e64-a1bf-5977-b6b5-89041a871172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7b582-dc68-4d12-bebd-baf79fd226f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f7b582-dc68-4d12-bebd-baf79fd226f0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9027,7 +9027,7 @@
         },
         {
             "id": "e9284d61-d2f9-585b-a85a-109a0e9c4d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae21165c-cc6d-45cc-b5c1-97b73e85dddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae21165c-cc6d-45cc-b5c1-97b73e85dddd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9065,7 +9065,7 @@
         },
         {
             "id": "91e8ca13-bb2d-5972-9be9-336ede64f1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f48b35-5fe1-4090-ae9d-11955ee8099b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f48b35-5fe1-4090-ae9d-11955ee8099b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "674340b1-db35-559c-998f-fb9691af0bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45adf695-69f3-4d71-a0dd-70d302e2a119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45adf695-69f3-4d71-a0dd-70d302e2a119.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9141,7 +9141,7 @@
         },
         {
             "id": "18f89524-412e-56e5-8d1a-5a59d0252b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060fa791-ccae-42df-b01c-2d4446d78422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060fa791-ccae-42df-b01c-2d4446d78422.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "4e565392-2a01-5542-874d-4534d0fbcfa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2b7388-ac6b-45c0-a5cc-da6450724b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2b7388-ac6b-45c0-a5cc-da6450724b59.jpg?1",
             "name": "Teferi, Timebender",
             "text": "+2: Untap up to one target artifact or creature.\n\u22123: You gain 2 life and draw two cards.\n\u22129: Take an extra turn after this one.",
             "colours": [
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "98a2dfb8-14cf-5ed2-b1f9-553a6278a983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba8df17-ab81-4e28-b274-ad38aa2899b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba8df17-ab81-4e28-b274-ad38aa2899b3.jpg?1",
             "name": "Temporal Machinations",
             "text": "Return target creature to its owner's hand. If you control an artifact, draw a card.",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "4a0f1c43-f8a8-5c2f-b46b-310d3c4d5971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c638677c-2b92-4d0c-b61c-598b5a843844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c638677c-2b92-4d0c-b61c-598b5a843844.jpg?1",
             "name": "Niambi, Faithful Healer",
             "text": "When Niambi, Faithful Healer enters the battlefield, you may search your library and/or graveyard for a card named Teferi, Timebender, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9285,7 +9285,7 @@
         },
         {
             "id": "42c7424d-7b38-5722-86a1-2a7bf1ae1fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058304f4-f08a-4b3a-ae74-c06f4968c99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058304f4-f08a-4b3a-ae74-c06f4968c99a.jpg?1",
             "name": "Teferi's Sentinel",
             "text": "As long as you control a Teferi planeswalker, Teferi's Sentinel gets +4/+0.",
             "colours": [],
@@ -9315,7 +9315,7 @@
         },
         {
             "id": "260d4f75-30da-5dcc-9886-4642aa1e18ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4585bcf-288b-4251-b57f-9d7e50dffc7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4585bcf-288b-4251-b57f-9d7e50dffc7e.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9345,7 +9345,7 @@
         },
         {
             "id": "1ad0b2cc-22f5-5609-ad70-fd6899f7a93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d2384-5c3f-4eb1-86b4-26ee13f1c767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d2384-5c3f-4eb1-86b4-26ee13f1c767.jpg?1",
             "name": "Chandra, Bold Pyromancer",
             "text": "+1: Add {R}{R}. Chandra, Bold Pyromancer deals 2 damage to target player.\n\u22123: Chandra, Bold Pyromancer deals 3 damage to target creature or planeswalker.\n\u22127: Chandra, Bold Pyromancer deals 10 damage to target player and each creature and planeswalker they control.",
             "colours": [
@@ -9380,7 +9380,7 @@
         },
         {
             "id": "1823d18c-a697-5eef-9c0b-a661a77f49c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e849c3-f357-4e81-a580-be5056bed51b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e849c3-f357-4e81-a580-be5056bed51b.jpg?1",
             "name": "Chandra's Outburst",
             "text": "Chandra's Outburst deals 4 damage to target player or planeswalker.\nSearch your library and/or graveyard for a card named Chandra, Bold Pyromancer, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9411,7 +9411,7 @@
         },
         {
             "id": "993603d9-bd7c-5e1b-b897-020c6314dee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95179b31-8cb5-4dd9-ad93-782b8774534d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95179b31-8cb5-4dd9-ad93-782b8774534d.jpg?1",
             "name": "Karplusan Hound",
             "text": "Whenever Karplusan Hound attacks, if you control a Chandra planeswalker, this creature deals 2 damage to any target.",
             "colours": [
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "7928b4e9-8283-585d-95ad-bb222e3e8362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670d02b-9bfc-4671-97ed-59bfbe633d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670d02b-9bfc-4671-97ed-59bfbe633d82.jpg?1",
             "name": "Pyromantic Pilgrim",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -9478,7 +9478,7 @@
         },
         {
             "id": "1980d0d3-70f1-5adb-a77e-ab169f04bfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10f979-63e0-4999-9047-fdbd914cedf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10f979-63e0-4999-9047-fdbd914cedf4.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9508,7 +9508,7 @@
         },
         {
             "id": "66e338d4-7ed4-5737-a8ba-8c6ae36843ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3923708a-60b8-4fb0-beb2-9ab18f5fd381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3923708a-60b8-4fb0-beb2-9ab18f5fd381.jpg?1",
             "name": "Firesong and Sunspeaker",
             "text": "Red instant and sorcery spells you control have lifelink.\nWhenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.",
             "colours": [
@@ -9546,7 +9546,7 @@
         },
         {
             "id": "a2fb70d3-cec6-5ed9-8a5d-a66b8d8be9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bce908-fc95-40c6-a04a-752d56aca836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bce908-fc95-40c6-a04a-752d56aca836.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9580,7 +9580,7 @@
         },
         {
             "id": "86bb0387-4773-59b3-972f-53ba8518f3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7d137c-f6c0-44e5-af9f-a8bbd52d3b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7d137c-f6c0-44e5-af9f-a8bbd52d3b2a.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9614,7 +9614,7 @@
         },
         {
             "id": "d9f8aea6-4fd0-5f6c-9ebb-7f7aa2b03eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b56129-17a2-4512-a4d6-34779224473f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b56129-17a2-4512-a4d6-34779224473f.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9648,7 +9648,7 @@
         },
         {
             "id": "4c856b1d-64ea-5405-a1bf-cbb7182969cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74791ac4-7297-4731-aff8-20130da8b4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74791ac4-7297-4731-aff8-20130da8b4b7.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -9682,7 +9682,7 @@
         },
         {
             "id": "a0be967f-e97f-5b57-bd21-d711a9b0d50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b527bcd-0d37-495a-8457-8123388056b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b527bcd-0d37-495a-8457-8123388056b9.jpg?1",
             "name": "Zombie Knight",
             "text": "",
             "colours": [
@@ -9717,7 +9717,7 @@
         },
         {
             "id": "ac66aba2-a487-5025-8197-d9a268c36935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d33b752-c806-4932-ae0a-46f00ed937de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d33b752-c806-4932-ae0a-46f00ed937de.jpg?1",
             "name": "Nightmare Horror",
             "text": "",
             "colours": [
@@ -9752,7 +9752,7 @@
         },
         {
             "id": "70dc7182-d50b-5a6a-97e8-6dccdd600cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b858b5-803b-4bcf-99d6-8c20c8b37f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b858b5-803b-4bcf-99d6-8c20c8b37f07.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "07ab51c3-554b-5ab8-9505-0c54a3574489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9cc37a-b9c3-40c2-a3e4-abfec86e199b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9cc37a-b9c3-40c2-a3e4-abfec86e199b.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "244a91db-8c0d-56eb-8608-5cad324293d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79264f-0734-48b7-8333-4035e518d46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79264f-0734-48b7-8333-4035e518d46c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9854,7 +9854,7 @@
         },
         {
             "id": "e4dcfe4f-8441-5eec-9f74-a7b3672e90e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0cdb0d-f720-4ed2-af08-ced9b54f6702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0cdb0d-f720-4ed2-af08-ced9b54f6702.jpg?1",
             "name": "Karox Bladewing",
             "text": "",
             "colours": [
@@ -9890,7 +9890,7 @@
         },
         {
             "id": "245d1760-240f-562f-b461-255540830625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5371de1b-db33-4db4-a518-e35c71aa72b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5371de1b-db33-4db4-a518-e35c71aa72b7.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9924,7 +9924,7 @@
         },
         {
             "id": "892ec565-9a4c-5bfd-8c19-9aecdda1f2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b425bdc-b3d5-4825-9f97-a00e2d932438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b425bdc-b3d5-4825-9f97-a00e2d932438.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9958,7 +9958,7 @@
         },
         {
             "id": "99471feb-8fda-52ea-bfa7-db760334bc81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49da8fe-559f-4c34-b904-c285188fb98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49da8fe-559f-4c34-b904-c285188fb98d.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9992,7 +9992,7 @@
         },
         {
             "id": "58a0e346-16cd-5935-b222-66e48175d908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5eafa38-5333-4ef2-9661-08074c580a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5eafa38-5333-4ef2-9661-08074c580a32.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -10023,7 +10023,7 @@
         },
         {
             "id": "79823e1c-a618-5692-8b82-00ec1786c0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcdb224-d4b3-4d99-abea-467def65ef42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcdb224-d4b3-4d99-abea-467def65ef42.jpg?1",
             "name": "Jaya Ballard Emblem",
             "text": "",
             "colours": [],
@@ -10052,7 +10052,7 @@
         },
         {
             "id": "1e082e53-8e0e-5424-a063-c1b5a08a3aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82ac152-5df1-46c9-98e9-ad5585f7e799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82ac152-5df1-46c9-98e9-ad5585f7e799.jpg?1",
             "name": "Teferi, Hero of Dominaria Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DRK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DRK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "60d11d96-a614-5182-becf-b0b4f63b8ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e14db1c-0a05-47d2-9f27-df881f7f37ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e14db1c-0a05-47d2-9f27-df881f7f37ab.jpg?1",
             "name": "Angry Mob",
             "text": "Trample\nDuring your turn, the *s below are both equal to the total number of swamps all opponents control. During any other player's turn, * equals 0.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "985f4256-9b2e-5561-b8cc-67b11fb8f313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d4761d-acf2-4cb3-86a8-a3f30420a92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d4761d-acf2-4cb3-86a8-a3f30420a92e.jpg?1",
             "name": "Blood of the Martyr",
             "text": "For the remainder of the turn, you may redirect damage done to any number of creatures to yourself instead.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "af6e3d0a-8b31-50b7-bc23-30f5234eec9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da4fb5a-0d24-4bee-b3f5-535ba9fe6850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da4fb5a-0d24-4bee-b3f5-535ba9fe6850.jpg?1",
             "name": "Brainwash",
             "text": "Target creature may not attack unless its controller pays o3 in addition to any other costs required for the creature to attack.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "9aea78f5-d39f-5652-8d85-c801c1ffdfd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1973a3-1410-4c6d-9b09-bd9d18646a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1973a3-1410-4c6d-9b09-bd9d18646a1e.jpg?1",
             "name": "Cleansing",
             "text": "All land is destroyed. Players may prevent Cleansing from destroying specific lands by paying 1 life for each land they wish to protect. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -132,7 +132,7 @@
         },
         {
             "id": "11c9b608-2df1-5ce1-85e7-959fc671cc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade075fd-73ee-4d12-a2da-48e5938043af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade075fd-73ee-4d12-a2da-48e5938043af.jpg?1",
             "name": "Dust to Dust",
             "text": "Removes two target artifacts from the game.",
             "colours": [
@@ -163,7 +163,7 @@
         },
         {
             "id": "660a73d3-4164-5a88-a6fa-c507034f0101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg?1",
             "name": "Exorcist",
             "text": "o1o\nW, oc\nT: Target black creature is destroyed.",
             "colours": [
@@ -197,7 +197,7 @@
         },
         {
             "id": "6175ab78-9557-5c61-880f-add377daa651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da35f9f-e72c-4154-a212-7de98f84ad7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da35f9f-e72c-4154-a212-7de98f84ad7d.jpg?1",
             "name": "Fasting",
             "text": "You may choose to skip your draw phase; if you do so, you gain 2 life. If you draw a card for any reason, Fasting is destroyed. During your upkeep, put a hunger counter on Fasting. When Fasting has five hunger counters on it, it is destroyed.",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "c5cb0e84-933a-5689-a5d4-0cec01e95d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9357990-701a-4336-b545-ac5a24d89cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9357990-701a-4336-b545-ac5a24d89cad.jpg?1",
             "name": "Festival",
             "text": "Opponent may not declare an attack this turn. Play during opponent's upkeep phase.",
             "colours": [
@@ -259,7 +259,7 @@
         },
         {
             "id": "88fb1446-6e49-5b9b-856c-c59e5b2538b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5208dbb-63d2-4789-8ef9-f82499a43b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5208dbb-63d2-4789-8ef9-f82499a43b3a.jpg?1",
             "name": "Fire and Brimstone",
             "text": "Fire and Brimstone does 4 damage to target player and 4 damage to you. Can only be used during a turn in which target player has declared an attack.",
             "colours": [
@@ -290,7 +290,7 @@
         },
         {
             "id": "680f5452-1014-51a5-ae26-661e995bddb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c8a850-bc99-4679-a316-45ecdea696b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c8a850-bc99-4679-a316-45ecdea696b2.jpg?1",
             "name": "Holy Light",
             "text": "All non-white creatures get -1/-1 until end of turn.",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "27d476b9-5ad6-572c-ac34-438268db1d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg?1",
             "name": "Knights of Thorn",
             "text": "Protection from red, banding",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "f0911261-37c1-5895-aa4a-2c0bb7c04da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c9f463-d1cc-4f11-aad2-d4a4520aa978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c9f463-d1cc-4f11-aad2-d4a4520aa978.jpg?1",
             "name": "Martyr's Cry",
             "text": "All white creatures are removed from the game. Players must draw one card for each white creature they control that is lost in this manner.",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "a065eb66-5fe4-5b0c-93f7-5af0627b11c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d29bda-096c-44d4-b45e-c2c507f8efbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d29bda-096c-44d4-b45e-c2c507f8efbe.jpg?1",
             "name": "Miracle Worker",
             "text": "oc\nT: Destroy target enchantment card on a creature you control.",
             "colours": [
@@ -420,7 +420,7 @@
         },
         {
             "id": "b1a13008-0046-5d43-a927-616a7c1b584d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4104546-abd9-4bfb-a65e-5928cdd4522f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4104546-abd9-4bfb-a65e-5928cdd4522f.jpg?1",
             "name": "Morale",
             "text": "All attacking creatures gain +1/+1 until end of turn.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "245b93ee-c442-5212-a68b-8dc3e5245fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2f6936-b50c-4907-9b55-ebf8a3fba8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2f6936-b50c-4907-9b55-ebf8a3fba8f5.jpg?1",
             "name": "Pikemen",
             "text": "Banding, first strike",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "f54d3eb7-350c-5349-9496-e3deabab358d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e03d335-d259-4ab4-814f-9333cfd3afc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e03d335-d259-4ab4-814f-9333cfd3afc9.jpg?1",
             "name": "Preacher",
             "text": "oc\nT: Gain control of one of opponent's creatures. Opponent chooses which target creature you control. If Preacher becomes untapped, you lose control of this creature; you may choose not to untap Preacher as normal during your untap phase. You also lose control of the creature if Preacher leaves play or at end of game.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "6efd8cb3-756c-55f1-821a-233846fc722b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374df061-ebd2-4f1f-9a6e-7940a49197a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374df061-ebd2-4f1f-9a6e-7940a49197a9.jpg?1",
             "name": "Squire",
             "text": "",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "9621c7e9-f3ea-5007-932e-168a5b26eecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6da540-6803-47e5-9af0-7ae8e2f84b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6da540-6803-47e5-9af0-7ae8e2f84b6c.jpg?1",
             "name": "Tivadar's Crusade",
             "text": "All Goblins are destroyed.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "6ee3f11a-fcfd-51d2-b4f3-4ebcba840853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg?1",
             "name": "Witch Hunter",
             "text": "oc\nT: Witch Hunter does 1 damage to target player.\no1o\nWo\nW, oc\nT: Return target creature opponent controls from play to owner's hand. Enchantments on target creature are destroyed.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "f4633f0c-5f50-5772-96ab-e473fe076c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07df65c-ebcc-4873-b928-d99040d1f2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07df65c-ebcc-4873-b928-d99040d1f2f6.jpg?1",
             "name": "Amnesia",
             "text": "Look at target player's hand. Target player discards all non-land cards in his or her hand.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "742c1760-32be-5774-960d-c8fe36aff7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg?1",
             "name": "Apprentice Wizard",
             "text": "o\nU, oc\nT: Add o3 to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "ca304132-bcd6-5cf1-a1b4-07962a37dea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13453abe-3f05-4956-8493-382d7d2af699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13453abe-3f05-4956-8493-382d7d2af699.jpg?1",
             "name": "Dance of Many",
             "text": "When Dance of Many is brought into play, choose a target summon card in play. Then put a token creature in play and treat it as if you have just brought an exact copy of target summon card into play. If Dance of Many leaves play, remove token creature from game. If token creature leaves play, destroy Dance of Many. If you do not pay o\nUo\nU during your upkeep, Dance of Many is destroyed.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "22fc22cd-5b76-5f93-bbb2-e15af8c0768b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6a230-6bc0-499c-b7fd-4aaa2569f98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd6a230-6bc0-499c-b7fd-4aaa2569f98f.jpg?1",
             "name": "Deep Water",
             "text": "oo\nU All mana-producing lands you control provide o\nU instead of their normal mana until end of turn.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "d265e0a8-77de-5b0e-885c-755cb8f70fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg?1",
             "name": "Drowned",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "7da6bef5-4c15-5546-9030-9455571c5b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8834c18-0e4e-4785-9d15-b33345e3789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8834c18-0e4e-4785-9d15-b33345e3789b.jpg?1",
             "name": "Electric Eel",
             "text": "o\nRoo\nR +2/+0; Electric Eel does 1 damage to you. Electric Eel does 1 damage to you when it is brought into play.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "9a801da4-e614-5f06-8c8d-dde6e00f95a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b6507-89ee-482e-aafd-8e05ada8f1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b6507-89ee-482e-aafd-8e05ada8f1ce.jpg?1",
             "name": "Erosion",
             "text": "Target land is destroyed unless its controller pays o1 or pays 1 life during his or her upkeep. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "ae85935e-b55b-51c1-a9be-a5db09acb083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabc3267-b59b-4f36-8873-5b4b072711ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabc3267-b59b-4f36-8873-5b4b072711ca.jpg?1",
             "name": "Flood",
             "text": "o\nUoo\nU Target non-flying creature becomes tapped.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "6869e7dd-f681-585b-a058-c8387f86df7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db591b28-37e5-4e7c-ae4d-d761262b12d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db591b28-37e5-4e7c-ae4d-d761262b12d0.jpg?1",
             "name": "Ghost Ship",
             "text": "Flying, o\nUo\nUoo\nU Regenerates",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "d1f7d9e5-b393-5e43-a376-810fb55509bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4a19-0f2f-4713-a869-58832484648d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ec4a19-0f2f-4713-a869-58832484648d.jpg?1",
             "name": "Giant Shark",
             "text": "If Giant Shark blocks or is blocked by a creature that has taken damage this turn, Giant Shark gains +2/+0 and trample until end of turn. Giant Shark cannot attack unless opponent controls at least one island. Giant Shark is buried immediately if at any time controller controls no islands.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "e0151b5b-e8a7-5286-be0f-4f62b68f0e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b638d9be-c533-45c3-92f9-fabf56edc2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b638d9be-c533-45c3-92f9-fabf56edc2df.jpg?1",
             "name": "Leviathan",
             "text": "Trample\nLeviathan comes into play tapped, and does not untap as normal during your untap phase.\nSacrifice two islands during your upkeep phase to untap Leviathan.\nLeviathan may not attack unless you sacrifice two islands during your attack.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "b51efe73-7d7a-5ac4-805a-adc84f63b8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857a00a-82e0-4227-86ee-1f9c7ca232ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857a00a-82e0-4227-86ee-1f9c7ca232ae.jpg?1",
             "name": "Mana Vortex",
             "text": "Each player who controls land sacrifices one land during his or her upkeep. If at any time there are no lands in play, Mana Vortex is destroyed. If you do not sacrifice a land when Mana Vortex is cast, Mana Vortex is countered.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "2161112f-4077-50d0-808d-15243c08cd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36313dc7-6bf2-4d73-b696-969d984a7466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36313dc7-6bf2-4d73-b696-969d984a7466.jpg?1",
             "name": "Merfolk Assassin",
             "text": "oc\nT: Destroy target creature that has islandwalk.",
             "colours": [
@@ -1041,7 +1041,7 @@
         },
         {
             "id": "4b15e01a-1fe7-5668-84ae-e70c6bdb2a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee810a5-f0f9-4b73-8194-3d1344784050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee810a5-f0f9-4b73-8194-3d1344784050.jpg?1",
             "name": "Mind Bomb",
             "text": "Mind Bomb does 3 damage to each player. All players may discard up to three cards of their choice from their hands. Each card a player discards in this manner prevents 1 damage to that player from Mind Bomb.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "3af1aad7-27c3-513b-a4c4-33637938ad6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec3275e-4491-43a8-9f23-d7b48177c103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec3275e-4491-43a8-9f23-d7b48177c103.jpg?1",
             "name": "Psychic Allergy",
             "text": "Choose a color when casting Psychic Allergy. During opponent's upkeep, Psychic Allergy does 1 damage to opponent for each card of this color that he or she controls. Sacrifice two islands during your upkeep or Psychic Allergy is destroyed.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "fef800df-bb64-5e3e-ad3a-484cedc6760d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f11ae4-e30e-441d-bb64-439930d9997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f11ae4-e30e-441d-bb64-439930d9997c.jpg?1",
             "name": "Riptide",
             "text": "All blue creatures become tapped.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "89c3c711-a5e9-5d9e-a576-0a6b11eb171b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e0f9ec-2b06-4bda-8b80-a716d82d1f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e0f9ec-2b06-4bda-8b80-a716d82d1f13.jpg?1",
             "name": "Sunken City",
             "text": "All blue creatures gain +1/+1.\nIf you do not pay o\nUo\nU during your upkeep, Sunken City is destroyed.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "56a24040-5782-50f4-b10b-daab26fc1eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497bc42d-ab81-4d84-bdf7-e3a05a7c984d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497bc42d-ab81-4d84-bdf7-e3a05a7c984d.jpg?1",
             "name": "Tangle Kelp",
             "text": "Target creature does not untap during its controller's untap phase if it attacked during its controller's last turn. Target creature becomes tapped when Tangle Kelp is cast.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "f6a602ee-3c1c-5ef6-bf44-40276c9fa9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3da4a88-5225-467f-9240-f30bc1eee520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3da4a88-5225-467f-9240-f30bc1eee520.jpg?1",
             "name": "Water Wurm",
             "text": "Water Wurm gains +0/+1 if opponent controls at least one island.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "e2178fba-af5c-5936-8f6e-8e8b98b96180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825496e5-19c7-4f50-8070-0265a58608dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825496e5-19c7-4f50-8070-0265a58608dc.jpg?1",
             "name": "Ashes to Ashes",
             "text": "Ashes to Ashes removes two target non-artifact creatures from the game and does 5 damage to you.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "c24facd0-4b74-56d2-825c-0c9a8ba4206e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66eaa7d6-48b2-4b35-a834-790edd679e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66eaa7d6-48b2-4b35-a834-790edd679e0e.jpg?1",
             "name": "Banshee",
             "text": "o\nX, oc\nT: Banshee does X damage\u2014half (rounded up) to you and half (rounded down) to any one target.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "28a28373-86e2-538e-a4b7-a2fdaecb41ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb7271-634a-4612-9073-7a5438e8c2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bb7271-634a-4612-9073-7a5438e8c2b8.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "5d521295-e76f-50c6-9881-498e80555ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64c9153-bc6d-4a64-885f-c039a5487a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64c9153-bc6d-4a64-885f-c039a5487a31.jpg?1",
             "name": "Bog Rats",
             "text": "Cannot be blocked by walls.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "fa19bc8d-6b01-5a39-9317-bdb857ad2d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0d070-8a42-4d5e-8f2b-ceb59147de6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0d070-8a42-4d5e-8f2b-ceb59147de6f.jpg?1",
             "name": "Curse Artifact",
             "text": "During his or her upkeep, controller of target artifact may choose to bury target artifact. If controller chooses not to bury target artifact, Curse Artifact does 2 damage to him or her.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "5f25f4ce-bed0-5bf4-917f-ef1f51638171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89fe2be-bb7e-4bae-9b1f-9f0d58f20ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89fe2be-bb7e-4bae-9b1f-9f0d58f20ceb.jpg?1",
             "name": "Eater of the Dead",
             "text": "o0: Take one creature from any graveyard and remove it from the game. Untap Eater of the Dead.",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "7d58d12d-a310-557b-ac5c-a3aee3a51b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99894d-5ece-44f1-acce-474494ae2084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f99894d-5ece-44f1-acce-474494ae2084.jpg?1",
             "name": "Frankenstein's Monster",
             "text": "When Frankenstein's Monster is brought into play, if you do not take X creatures from your graveyard and remove them from the game, Frankenstein's Monster is countered. For each creature removed from your graveyard in this way, you may choose to give Frankenstein's Monster a permanent +2/+0, +1/+1, or +0/+2.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "23664438-d521-5f8c-8f4b-96d913cd27a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg?1",
             "name": "Grave Robbers",
             "text": "o\nB, oc\nT: Take one artifact from any graveyard and remove it from the game. Gain 2 life.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "bc68ffa9-0a53-5baa-91a2-583ab678f3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f133f06-6398-4db1-8577-66c16fd3e00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f133f06-6398-4db1-8577-66c16fd3e00d.jpg?1",
             "name": "Inquisition",
             "text": "Look at target player's hand. Inquisition does 1 damage to target player for each white card in his or her hand.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "69373057-60e2-562c-98f4-1b7278df491c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80ecb15-258b-4fc9-86e4-c2bf01891606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80ecb15-258b-4fc9-86e4-c2bf01891606.jpg?1",
             "name": "Marsh Gas",
             "text": "All creatures get -2/-0 until end of turn.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "a0741e02-1816-5ca6-b4a9-c9dc277def26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a213450f-02f4-4c08-8da8-891ebfa8e237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a213450f-02f4-4c08-8da8-891ebfa8e237.jpg?1",
             "name": "Murk Dwellers",
             "text": "When attacking, Murk Dwellers gain +2/+0 if not blocked.",
             "colours": [
@@ -1589,7 +1589,7 @@
         },
         {
             "id": "21c31892-344a-5ae4-b7ca-09187a9b6037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348a467a-4661-4fdb-af1d-9171a1a930d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348a467a-4661-4fdb-af1d-9171a1a930d9.jpg?1",
             "name": "Nameless Race",
             "text": "Trample\nPay * life when bringing Nameless Race into play. Effects that prevent or redirect damage may not be used to counter this loss of life. When Nameless Race is brought into play, * may not be greater than the total number of white cards all opponents have in play and in their graveyards.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "e0a7e0c3-d82c-56b8-94b0-1563386d7803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c133b8-8383-433f-be96-c47a937287b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c133b8-8383-433f-be96-c47a937287b7.jpg?1",
             "name": "Rag Man",
             "text": "o\nBo\nBo\nB, oc\nT: Look at opponent's hand.\nIf opponent has any creature cards in hand, he or she discards one of them at random. This ability can only be used during controller's turn.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "b0d49ef7-653f-52bd-a187-62ff922e0ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06900a71-34ca-48c6-94ac-fca744356829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06900a71-34ca-48c6-94ac-fca744356829.jpg?1",
             "name": "Season of the Witch",
             "text": "At the end of each player's turn, all of his or her untapped creatures that could have attacked but did not are destroyed. If you do not pay 2 life during your upkeep, Season of the Witch is destroyed. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "51debb8f-7f50-5c99-8775-47108bc09fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a176e1-b22b-4f36-ba7b-c506cb4e1bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a176e1-b22b-4f36-ba7b-c506cb4e1bed.jpg?1",
             "name": "The Fallen",
             "text": "During its controller's upkeep, The Fallen does 1 damage to each opponent it has previously damaged.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "eb9cf89f-8371-5be9-b9de-e6dcf19d66f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848ad6d5-3a7e-4d6b-9929-36465796871f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848ad6d5-3a7e-4d6b-9929-36465796871f.jpg?1",
             "name": "Uncle Istvan",
             "text": "All damage done to Uncle Istvan by creatures is reduced to 0.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "13b239a8-9a73-5193-8b1c-04ae2a8d2d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30efdb-f1f1-497f-80a6-ec961db67c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30efdb-f1f1-497f-80a6-ec961db67c1d.jpg?1",
             "name": "Word of Binding",
             "text": "X target creatures become tapped.",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "57fdddd7-ff03-569f-bf53-d813ab60b51e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a97821-ca5b-46fb-af08-86de81d0daac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a97821-ca5b-46fb-af08-86de81d0daac.jpg?1",
             "name": "Worms of the Earth",
             "text": "No new land may be brought into play. During any player's upkeep, any player may destroy Worms of the Earth by sacrificing two lands or taking 5 damage from Worms of the Earth.",
             "colours": [
@@ -1813,7 +1813,7 @@
         },
         {
             "id": "7c92ec59-0b8e-5010-b961-aed18bc39dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ba83ab-83f5-421d-bba1-0f925870b5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ba83ab-83f5-421d-bba1-0f925870b5c8.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample\nBall Lightning may attack on the turn during which it is summoned. Ball Lightning is buried at the end of the turn during which it is summoned.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "70b8059d-311f-5010-9d2b-cf8e4e0d3864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78373616-e2d6-4ccf-998f-09f02bea45b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78373616-e2d6-4ccf-998f-09f02bea45b4.jpg?1",
             "name": "Blood Moon",
             "text": "All non-basic lands are now basic mountains.",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "0b6cb935-8eaa-54d3-a663-7eb3cb115460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2cc4a6-fdcc-4082-801a-d2c50e560e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2cc4a6-fdcc-4082-801a-d2c50e560e8d.jpg?1",
             "name": "Brothers of Fire",
             "text": "o1o\nRoo\nR Brothers of Fire do 1 damage to any target and 1 damage to you.",
             "colours": [
@@ -1911,7 +1911,7 @@
         },
         {
             "id": "92c28d18-5b59-50e6-a330-66aa0f02a028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72746a5d-faa1-44b7-97b5-0ef9302a3c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72746a5d-faa1-44b7-97b5-0ef9302a3c13.jpg?1",
             "name": "Cave People",
             "text": "If declared as an attacker, Cave People get +1/-2 until end of turn.\no1o\nRo\nR, oc\nT: Target creature gains mountainwalk until end of turn.",
             "colours": [
@@ -1944,7 +1944,7 @@
         },
         {
             "id": "b0bd3dfb-4935-5698-bae0-48bd6928a12e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d646feea-3c20-4737-8d20-ffad42258ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d646feea-3c20-4737-8d20-ffad42258ced.jpg?1",
             "name": "Eternal Flame",
             "text": "Eternal Flame does an amount of damage to your opponent equal to the number of mountains you control, but it also does half that amount of damage to you, rounding up.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "42b0d781-a69e-5481-b498-92a93d763714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3419db6-1c38-4aa4-b953-1dde7d22b927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3419db6-1c38-4aa4-b953-1dde7d22b927.jpg?1",
             "name": "Fire Drake",
             "text": "Flying\noo\nR +1/+0 until end of turn. No more than o\nR may be spent in this way each turn.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "91b08c89-99f0-58fb-94bd-f11d75b3178c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2d778d-d74b-45ec-a86b-5d52ffad6ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2d778d-d74b-45ec-a86b-5d52ffad6ba5.jpg?1",
             "name": "Fissure",
             "text": "Target land or creature is buried.",
             "colours": [
@@ -2039,7 +2039,7 @@
         },
         {
             "id": "1e82f5d7-28b8-5d17-9475-f0aa33e63b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a415b0-00a2-4a65-8994-4a395c50ae2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a415b0-00a2-4a65-8994-4a395c50ae2d.jpg?1",
             "name": "Goblin Caves",
             "text": "If target land is a basic mountain, all Goblins gain +0/+2.",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "220cec60-5038-50d3-b59b-cabe5885f78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a538b9d-351e-40bb-be11-9ba08c16352b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a538b9d-351e-40bb-be11-9ba08c16352b.jpg?1",
             "name": "Goblin Digging Team",
             "text": "oc\nT: Sacrifice Goblin Digging Team to destroy target wall.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "ae64cf01-1062-5f0d-a8bb-fc7c72fdfc88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7135a569-e5d3-4a1f-924b-bdb86926b4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7135a569-e5d3-4a1f-924b-bdb86926b4e1.jpg?1",
             "name": "Goblin Hero",
             "text": "",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "7e2d3d69-6d2b-58de-9069-3c2e2910a16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0b59d-8f9b-4a76-9845-bcb0dc32523d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0b59d-8f9b-4a76-9845-bcb0dc32523d.jpg?1",
             "name": "Goblin Rock Sled",
             "text": "Trample\nRock Sled may not attack unless opponent controls at least one mountain. Rock Sled does not untap as normal during your untap phase if it attacked during your last turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "d3e530d4-363a-5b43-af8b-46254425646f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd69a6dc-27f3-42aa-9e63-4417796e4ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd69a6dc-27f3-42aa-9e63-4417796e4ef5.jpg?1",
             "name": "Goblin Shrine",
             "text": "If target land is a basic mountain, all Goblins gain +1/0. Goblin Shrine does 1 damage to all Goblins if it leaves play.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "23edced7-2dbc-51c5-9f85-fe20ba555af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b73dfb4-d930-4a89-b621-129dd9f6328c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b73dfb4-d930-4a89-b621-129dd9f6328c.jpg?1",
             "name": "Goblin Wizard",
             "text": "oc\nT: Take a Goblin from your hand and put it directly into play. Treat this goblin as if it were just summoned.\noo\nR Target Goblin gains protection from white until end of turn.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "ee6e7bb8-f9d0-53f2-b626-a75284e50f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd333b18-b896-4ab8-9c46-eed4efdd94f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd333b18-b896-4ab8-9c46-eed4efdd94f2.jpg?1",
             "name": "Goblins of the Flarg",
             "text": "Mountainwalk\nGoblins of the Flarg are buried if controller controls any Dwarves.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "76079bfe-ba8c-5657-ba4a-22597935f4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b61512-5b24-424c-966f-36b595781e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b61512-5b24-424c-966f-36b595781e14.jpg?1",
             "name": "Inferno",
             "text": "Inferno does 6 damage to all players and all creatures.",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "f505a90c-4d6c-5848-a4e8-9f5a83f0d717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72955141-d990-459f-adbe-7d3d0f5f6c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72955141-d990-459f-adbe-7d3d0f5f6c95.jpg?1",
             "name": "Mana Clash",
             "text": "You and target player each flip a coin. Mana Clash does 1 damage to any player whose coin comes up tails. Repeat this process until both players' coins come up heads at the same time.",
             "colours": [
@@ -2334,7 +2334,7 @@
         },
         {
             "id": "062d6ed0-82ff-5172-a1e3-461b852c91e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a10fd5-506e-46bf-87e6-fde134c0dc04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a10fd5-506e-46bf-87e6-fde134c0dc04.jpg?1",
             "name": "Orc General",
             "text": "oc\nT: Sacrifice one Orc or Goblin to give all Orcs +1/+1 until end of turn.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "d9372348-fefd-5998-ad1a-e664ff9053d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e0ccd-decb-48d2-981f-cefa8045340f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564e0ccd-decb-48d2-981f-cefa8045340f.jpg?1",
             "name": "Sisters of the Flame",
             "text": "oc\nT: Add o\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "b551e9aa-e3cf-5ec0-acd0-69240060b632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a615650-4da3-4efc-aa5e-c1f2c4f79478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a615650-4da3-4efc-aa5e-c1f2c4f79478.jpg?1",
             "name": "Carnivorous Plant",
             "text": "",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "37b5042e-09a1-56d4-80b3-d90b4437c4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f395278e-6d74-4f35-af9d-21bad7b19763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f395278e-6d74-4f35-af9d-21bad7b19763.jpg?1",
             "name": "Elves of Deep Shadow",
             "text": "oc\nT: Add o\nB to your mana pool, and Elves of Deep Shadow do 1 damage to you. This ability is played as an interrupt.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "766b09da-d1e1-568c-a543-88fc63f61896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1ae3d6-6d96-4db6-bbc4-cee91bae6cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1ae3d6-6d96-4db6-bbc4-cee91bae6cf7.jpg?1",
             "name": "Gaea's Touch",
             "text": "You may put one additional land in play during each of your turns, but that land must be a basic forest. You may sacrifice Gaea's Touch to add o\nGo\nG to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "e4a6ea15-93da-55fb-9afa-7252fd71ce99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7705328-4b5d-4383-9abe-75fca9c32c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7705328-4b5d-4383-9abe-75fca9c32c09.jpg?1",
             "name": "Gaea's Touch",
             "text": "",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "89663c71-b978-59a9-b142-ae95eeba7eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg?1",
             "name": "Hidden Path",
             "text": "All green creatures gain forestwalk.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "935267fb-334e-565e-b29c-527f49cf3eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff99543d-86a1-44f8-88ec-aaec071d6c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff99543d-86a1-44f8-88ec-aaec071d6c05.jpg?1",
             "name": "Land Leeches",
             "text": "First strike",
             "colours": [
@@ -2601,7 +2601,7 @@
         },
         {
             "id": "2decfffe-8a1e-530f-ae37-e57ee113bd12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39eb671-e17e-4c5a-8913-1e3be7faedfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39eb671-e17e-4c5a-8913-1e3be7faedfb.jpg?1",
             "name": "Lurker",
             "text": "Lurker may not be the target of any spell unless Lurker was declared as an attacker or blocker this turn.",
             "colours": [
@@ -2634,7 +2634,7 @@
         },
         {
             "id": "a96fe16b-d076-5b67-963e-6ce9c49a9346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109cce7a-96f7-4e67-878a-bd5c93ea8643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109cce7a-96f7-4e67-878a-bd5c93ea8643.jpg?1",
             "name": "Marsh Viper",
             "text": "If Marsh Viper damages opponent, opponent gets two poison counters. If opponent ever has ten or more poison counters, opponent loses game.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "5693598b-0831-54a6-8551-6403729a72b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg?1",
             "name": "Niall Silvain",
             "text": "o\nGo\nGo\nGo\nG, oc\nT: Target creature is regenerated.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "2dc1b1d7-5516-586f-a5c6-4c1b1b83f956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5926f-9988-4bc0-b2b7-e286db208310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb5926f-9988-4bc0-b2b7-e286db208310.jpg?1",
             "name": "People of the Woods",
             "text": "The * below represents the number of forests controlled by People of the Woods' controller.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "2c71635e-3235-51ca-a067-a15c5fcf3802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fb3014-f631-4a75-92cd-7e626b13a4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fb3014-f631-4a75-92cd-7e626b13a4c3.jpg?1",
             "name": "Savaen Elves",
             "text": "o\nGo\nG, oc\nT: Target enchant land is destroyed.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "b83586ae-a0b3-56a0-bfeb-a3aaecce77af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b762a7-a774-4cb4-8ecf-dd6486a066c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b762a7-a774-4cb4-8ecf-dd6486a066c3.jpg?1",
             "name": "Scarwood Bandits",
             "text": "Forestwalk\no2o\nG, oc\nT: Take control of target artifact. Opponent may counter this action by paying o2. You lose control of target artifact if Scarwood Bandits leave play or at end of game.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "b3c89730-d48d-5a30-8d85-934abe75d03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2655e4-3a4d-4f73-820a-02fab675d42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2655e4-3a4d-4f73-820a-02fab675d42e.jpg?1",
             "name": "Scarwood Hag",
             "text": "o\nGo\nGo\nGo\nG, oc\nT: Target creature gains forestwalk until end of turn.\noc\nT: Target creature loses forestwalk until end of turn.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "55e133c1-2c1a-54ea-8b90-80adb54c004d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e99870c-b2b9-431b-b8a8-3f4a80aa8fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e99870c-b2b9-431b-b8a8-3f4a80aa8fa5.jpg?1",
             "name": "Scavenger Folk",
             "text": "o\nG, oc\nT: Sacrifice Scavenger Folk to destroy target artifact.",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "7c7c6846-ec8e-5ba1-acbe-41b453be0ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7011356e-7516-4ca0-ac54-d30af7ce03a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7011356e-7516-4ca0-ac54-d30af7ce03a2.jpg?1",
             "name": "Spitting Slug",
             "text": "o1oo\nG Spitting Slug gains first strike until end of turn. If this ability is not activated, all creatures blocking or blocked by Spitting Slug gain first strike until end of turn.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "e9e305ae-06d1-52b0-ad91-b5450de69e11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffc69e-26f2-434f-8c89-2df108dd984a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffc69e-26f2-434f-8c89-2df108dd984a.jpg?1",
             "name": "Tracker",
             "text": "o\nGo\nG, oc\nT: Tracker does an amount of damage equal to its power to target creature. Target creature does an amount of damage equal to its power to Tracker.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "ac2bbd74-e4ec-52fa-aba6-080344997a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0480f5-6aae-4297-afa6-3f7a5801bf95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0480f5-6aae-4297-afa6-3f7a5801bf95.jpg?1",
             "name": "Venom",
             "text": "All non-wall creatures target creature blocks or is blocked by are destroyed at the end of combat.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "32cc7226-4a37-5dcc-a5d3-d67ad0c36e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56146bf-5db0-4bef-83bb-efa5ebec6684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56146bf-5db0-4bef-83bb-efa5ebec6684.jpg?1",
             "name": "Whippoorwill",
             "text": "o\nGo\nG, oc\nT: Until end of turn, target creature may not regenerate and damage done to target creature may not be prevented or redirected. If target creature goes to the graveyard, remove it from game.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "5ff3458b-d974-57e8-9a61-df376654776c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa20173-e88a-4b14-9c54-14567ca5571c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa20173-e88a-4b14-9c54-14567ca5571c.jpg?1",
             "name": "Wormwood Treefolk",
             "text": "o\nGoo\nG Wormwood Treefolk gains forestwalk until end of turn and does 2 damage to you.\no\nBoo\nB Wormwood Treefolk gains swampwalk until end of turn and does 2 damage to you.",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "bb85954c-b092-5ba8-b857-f4e5a7fb9ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aabd80f-a18a-4bc1-9f05-4c3a63de77ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aabd80f-a18a-4bc1-9f05-4c3a63de77ce.jpg?1",
             "name": "Marsh Goblins",
             "text": "Swampwalk\nCounts as both a black card and a red card.",
             "colours": [
@@ -3067,7 +3067,7 @@
         },
         {
             "id": "de4ddf02-868d-508b-90d9-42c3e14a3219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5542d236-af43-43b8-b30f-8980d74bbdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5542d236-af43-43b8-b30f-8980d74bbdd0.jpg?1",
             "name": "Scarwood Goblins",
             "text": "Counts as both a green card and a red card.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "521f6071-be1e-5440-8b3f-907bc504c289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d3df64-1e90-4aef-86ae-0062aa23ff30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d3df64-1e90-4aef-86ae-0062aa23ff30.jpg?1",
             "name": "Dark Heart of the Wood",
             "text": "You may sacrifice a forest to gain 3 life.\nCounts as both a black card and a green card.",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "3b344894-4e0c-55d0-a687-5bbddc1f44e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768a307-da2e-435e-8efd-72d82b4d4a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768a307-da2e-435e-8efd-72d82b4d4a2b.jpg?1",
             "name": "Barl's Cage",
             "text": "o3: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [],
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "297b4bf4-a5ab-5c3d-9576-3f2ee73185ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a31de0-d764-4ff6-a85f-027e1e58d86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a31de0-d764-4ff6-a85f-027e1e58d86c.jpg?1",
             "name": "Bone Flute",
             "text": "o2, oc\nT: All creatures get -1/-0 until end of turn.",
             "colours": [],
@@ -3189,7 +3189,7 @@
         },
         {
             "id": "9b5792de-8ba7-505e-9674-db65570cf772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a391ada-e9e3-45db-ae84-17421ac6b44d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a391ada-e9e3-45db-ae84-17421ac6b44d.jpg?1",
             "name": "Book of Rass",
             "text": "o2: Pay 2 life to draw one card. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [],
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "fb3a6f27-2d9b-5111-a1b2-6cf07609d1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg?1",
             "name": "Coal Golem",
             "text": "o3: Sacrifice Coal Golem to add o\nRo\nRo\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "1c6240ac-ffa7-56a4-a29b-046a71305dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cfe9b9-677d-4ecb-83ab-67fb6481371d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cfe9b9-677d-4ecb-83ab-67fb6481371d.jpg?1",
             "name": "Dark Sphere",
             "text": "oc\nT: Sacrifice Dark Sphere to prevent half of the damage done to you by a single source, rounded down.",
             "colours": [],
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "5586410b-e298-5068-a6fb-7290f7599a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b0f228-6b06-4426-a557-1225d547b908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b0f228-6b06-4426-a557-1225d547b908.jpg?1",
             "name": "Diabolic Machine",
             "text": "o3: Regenerates",
             "colours": [],
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "6722c0e0-13c7-5a24-bd60-f89836d48ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc47e322-f8b8-4685-b035-fda0cc433e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc47e322-f8b8-4685-b035-fda0cc433e6b.jpg?1",
             "name": "Fellwar Stone",
             "text": "oc\nT: Add 1 mana to your mana pool. This mana may be of any color that any of opponent's lands can produce. This ability is played as an interrupt.",
             "colours": [],
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "567535e1-09d0-5933-9493-5eb4ce41fae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60eb23-cb9a-4203-86fb-60e47dbd870b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b60eb23-cb9a-4203-86fb-60e47dbd870b.jpg?1",
             "name": "Fountain of Youth",
             "text": "o2, oc\nT: Gain 1 life.",
             "colours": [],
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "90e0d9fd-84da-5314-a5b1-a7e79c5445fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cca55-1ea7-4a11-8c5d-3d84c9af862f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56cca55-1ea7-4a11-8c5d-3d84c9af862f.jpg?1",
             "name": "Fountain of Youth",
             "text": "",
             "colours": [],
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "6f38331e-73ed-5d11-8946-05c70504ffcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31a957-ad1e-40cc-b3c4-2f4caa492b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31a957-ad1e-40cc-b3c4-2f4caa492b77.jpg?1",
             "name": "Living Armor",
             "text": "oc\nT: Sacrifice Living Armor to put a +0/+X counter on target creature, where X is target creature's casting cost.",
             "colours": [],
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "3c438f2e-fd90-5f5a-9787-58afbd4536c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893e8e9c-983e-4db1-8d93-10637025a559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893e8e9c-983e-4db1-8d93-10637025a559.jpg?1",
             "name": "Necropolis",
             "text": "Counts as a wall.\no0: Take a creature in your graveyard and remove it from the game. Put X +0/+1 counters on Necropolis, where X is the removed creature's casting cost.",
             "colours": [],
@@ -3447,7 +3447,7 @@
         },
         {
             "id": "b330c63d-c481-5c8d-98d2-cb8558fb5b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d551ff93-d8da-4c21-bc3c-6451c0dde07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d551ff93-d8da-4c21-bc3c-6451c0dde07e.jpg?1",
             "name": "Reflecting Mirror",
             "text": "o\nX, oc\nT: Target spell, which targets you, targets the player of your choice instead. X is twice the casting cost of target spell. This ability is played as an interrupt.",
             "colours": [],
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "2cebd997-e506-5c13-9be8-e505b7676a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741dbcf2-3372-45a8-b66f-d2ae12b4aac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741dbcf2-3372-45a8-b66f-d2ae12b4aac6.jpg?1",
             "name": "Runesword",
             "text": "o3, oc\nT: Target attacking creature gains +2/+0 until end of turn. Any creature damaged by target creature may not be regenerated this turn; if such a creature is placed in the graveyard this turn, remove it from the game. If target creature leaves play before end of turn, Runesword is buried.",
             "colours": [],
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "410e1ae0-5c06-540c-b450-063e1894bddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf27955f-015b-4d86-99b9-4c4f6fe2fa73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf27955f-015b-4d86-99b9-4c4f6fe2fa73.jpg?1",
             "name": "Runesword",
             "text": "",
             "colours": [],
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "3a04c9f5-5733-516b-8542-9870e6aaa8d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93850e74-744c-4261-a84e-01eaced6e49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93850e74-744c-4261-a84e-01eaced6e49a.jpg?1",
             "name": "Scarecrow",
             "text": "o6, oc\nT: Until end of turn, all damage done to you by flying creatures is reduced to 0.",
             "colours": [],
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "71604cf4-ad10-578e-918f-1003ff70d71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1d9bb5-972a-4705-bf22-0fa1e974dd26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1d9bb5-972a-4705-bf22-0fa1e974dd26.jpg?1",
             "name": "Skull of Orm",
             "text": "o5, oc\nT: Bring one enchantment card from your graveyard to your hand.",
             "colours": [],
@@ -3589,7 +3589,7 @@
         },
         {
             "id": "820172ea-0d6b-5360-adeb-c83c8dea3381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4c853e-2231-4af2-bcb0-1781c18ec3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4c853e-2231-4af2-bcb0-1781c18ec3be.jpg?1",
             "name": "Standing Stones",
             "text": "o1, oc\nT: Pay 1 life and add 1 mana of any color to your mana pool. This ability is played as an interrupt. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [],
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "e72ed6e0-8b58-59e8-ab2b-2cd33613d2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ba1a5-33b1-40f2-9780-26139ed829d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ba1a5-33b1-40f2-9780-26139ed829d7.jpg?1",
             "name": "Stone Calendar",
             "text": "Your spells cost up to 1 less to cast; casting cost of spells cannot go below 0.",
             "colours": [],
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "a2cf13ae-ac3d-5fcd-8b6e-253dd626e363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9668ba-d26d-4484-b4b8-6fb91fbfb617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9668ba-d26d-4484-b4b8-6fb91fbfb617.jpg?1",
             "name": "Tormod's Crypt",
             "text": "oc\nT: Sacrifice Tormod's Crypt to remove all cards in target player's graveyard from the game.",
             "colours": [],
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "f50d77ec-ddf1-52e1-8e80-62e22ab83022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c19977-ac7d-4ce7-925c-33a7503420f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c19977-ac7d-4ce7-925c-33a7503420f5.jpg?1",
             "name": "Tower of Coireall",
             "text": "oc\nT: Target creature cannot be blocked by walls until end of turn.",
             "colours": [],
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "34162dde-c972-5462-bcd2-a1c1a96349e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c9070a-8c70-480e-a476-e00f8e2c71b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c9070a-8c70-480e-a476-e00f8e2c71b9.jpg?1",
             "name": "Wand of Ith",
             "text": "o3, oc\nT: Look at one card at random from target player's hand. If the card is not a land, target player must choose either to discard it or pay an amount of life equal to its casting cost. If the card is a land, target player must choose either to discard it or pay 1 life. Effects that prevent or redirect damage may not be used to counter this loss of life. Can only be used during controller's turn.",
             "colours": [],
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "5e171ded-64bf-508e-a438-f2d419350307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9023c078-4169-498b-8626-a4862e0631f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9023c078-4169-498b-8626-a4862e0631f8.jpg?1",
             "name": "War Barge",
             "text": "o3: Target creature gains islandwalk until end of turn. If War Barge leaves play this turn, target creature is buried.",
             "colours": [],
@@ -3751,7 +3751,7 @@
         },
         {
             "id": "0ce7661e-5398-5b62-b5f6-6f44f68269a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5ee8a-34e5-4a2e-a04e-9fcdc7e53dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5ee8a-34e5-4a2e-a04e-9fcdc7e53dda.jpg?1",
             "name": "City of Shadows",
             "text": "oc\nT: Sacrifice one of your creatures, but remove it from the game instead of placing it in your graveyard. Put a counter on City of Shadows.\noc\nT: Add X colorless mana to your mana pool, where X is the number of counters on City of Shadows.",
             "colours": [],
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "0de59a71-9aef-5996-9670-84bf4605b28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dcceee-2a47-4eaa-a6a3-2931b3d50244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dcceee-2a47-4eaa-a6a3-2931b3d50244.jpg?1",
             "name": "Maze of Ith",
             "text": "oc\nT: Target attacking creature becomes untapped. This creature neither deals nor receives damage as a result of combat.",
             "colours": [],
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "28903892-7c61-5961-bba6-6c13b3d9a15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d48fb47-1bed-4791-a014-504515f3d36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d48fb47-1bed-4791-a014-504515f3d36f.jpg?1",
             "name": "Safe Haven",
             "text": "o2, oc\nT: Remove target creature you control from game. This ability is played as an interrupt.\nDuring your upkeep, sacrifice Safe Haven to return all creatures it has removed from game directly into play. Treat this as if they were just summoned.",
             "colours": [],
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "6c64fef3-580f-5281-b5d9-6d53db4555dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75946b-1690-43cc-993c-d4e451a1a41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75946b-1690-43cc-993c-d4e451a1a41c.jpg?1",
             "name": "Sorrow's Path",
             "text": "oc\nT: Exchange two of opponent's blocking creatures. This exchange may not cause an illegal block. Sorrow's Path does 2 damage to you and 2 damage to each creature you control whenever it is tapped.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DSK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DSK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a3523602-b7ee-58b6-99e5-c430fc4fd856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a7590-3eee-4803-b192-d4fb771e6a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a7590-3eee-4803-b192-d4fb771e6a86.jpg?1",
             "name": "Acrobatic Cheerleader",
             "text": "Survival \u2014 At the beginning of your second main phase, if Acrobatic Cheerleader is tapped, put a flying counter on it. This ability triggers only once.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "2607492c-0635-59f3-bc25-beba4c0bb1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b8fbe-8a5e-4b62-b53f-9ead8147bbbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b8fbe-8a5e-4b62-b53f-9ead8147bbbb.jpg?1",
             "name": "Cult Healer",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Cult Healer gains lifelink until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "6532323b-473a-5085-99ba-a29656a44344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "e6d2a89a-8797-5e30-87cf-099649a13761",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "",
             "colours": [
@@ -146,7 +146,7 @@
         },
         {
             "id": "e9ec6f85-fe3f-513c-9752-2a20b326ee1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "b03eb6db-5698-5935-b57e-144955934925",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "",
             "colours": [
@@ -218,7 +218,7 @@
         },
         {
             "id": "b2bebd44-e503-5760-af8f-5918a58dccd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba16fbf-2d44-4337-87cb-6ff6b84a258a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba16fbf-2d44-4337-87cb-6ff6b84a258a.jpg?1",
             "name": "Emerge from the Cocoon",
             "text": "Return target creature card from your graveyard to the battlefield. You gain 3 life.",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "5b69d554-246f-5f61-9a2d-8578e513c310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f79439-b8f8-418f-9772-26d81844749e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f79439-b8f8-418f-9772-26d81844749e.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -290,7 +290,7 @@
         },
         {
             "id": "b840a843-39b2-5528-b6bc-04c76ad231c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0e8a82-0201-483e-a976-5f29764b35a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0e8a82-0201-483e-a976-5f29764b35a4.jpg?1",
             "name": "Ethereal Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each enchantment you control and has first strike.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "c437115c-ca3c-5f1b-8a87-af8d4a592c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49006f2-a097-417d-8eb0-b8016ff2e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49006f2-a097-417d-8eb0-b8016ff2e0d5.jpg?1",
             "name": "Exorcise",
             "text": "Exile target artifact, enchantment, or creature with power 4 or greater.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "25291691-fdb6-599c-8349-8f06cacb3009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9374be-5e4b-4c23-8b6e-94c03d4f5ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9374be-5e4b-4c23-8b6e-94c03d4f5ef1.jpg?1",
             "name": "Fear of Abduction",
             "text": "As an additional cost to cast this spell, exile a creature you control.\nFlying\nWhen Fear of Abduction enters, exile target creature an opponent controls.\nWhen Fear of Abduction leaves the battlefield, put each card exiled with it into its owner's hand.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "2161aafe-876c-50aa-ba85-40e795350cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9220c8fa-6ef7-4bc1-acb9-fc54cc43e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9220c8fa-6ef7-4bc1-acb9-fc54cc43e498.jpg?1",
             "name": "Fear of Immobility",
             "text": "When Fear of Immobility enters, tap up to one target creature. If an opponent controls that creature, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -426,7 +426,7 @@
         },
         {
             "id": "41ca3da8-a526-599f-9076-b66a99004e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e98559d-d9fd-4bdf-8df9-389eee756a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e98559d-d9fd-4bdf-8df9-389eee756a3a.jpg?1",
             "name": "Fear of Surveillance",
             "text": "Vigilance\nWhenever Fear of Surveillance attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -461,7 +461,7 @@
         },
         {
             "id": "282d8066-e827-5b85-8100-4cf1f566ce7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e0dba2-d15c-4d55-9b68-00648175e760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e0dba2-d15c-4d55-9b68-00648175e760.jpg?1",
             "name": "Friendly Ghost",
             "text": "Flying\nWhen Friendly Ghost enters, target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "67188047-40fb-5dc1-aaaf-41380c549e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg?1",
             "name": "Ghostly Dancers",
             "text": "Flying\nWhen Ghostly Dancers enters, return an enchantment card from your graveyard to your hand or unlock a locked door of a Room you control.\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying.",
             "colours": [
@@ -531,7 +531,7 @@
         },
         {
             "id": "f0077f6c-6db5-523b-86be-75ea68b82223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f06bbb1-0c7d-4803-9b35-8a2206803eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f06bbb1-0c7d-4803-9b35-8a2206803eed.jpg?1",
             "name": "Glimmer Seeker",
             "text": "Survival \u2014 At the beginning of your second main phase, if Glimmer Seeker is tapped, draw a card if you control a Glimmer creature. If you don't control a Glimmer creature, create a 1/1 white Glimmer enchantment creature token.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "3eeeb333-471b-5101-917c-f054b818bc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "156244a2-6cd1-5de4-94ac-fe73b2541d59",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "",
             "colours": [
@@ -638,7 +638,7 @@
         },
         {
             "id": "dae79fcf-2649-512c-9db0-89b6547cd778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12054e10-46d6-4581-a7e5-ff277cb0e229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12054e10-46d6-4581-a7e5-ff277cb0e229.jpg?1",
             "name": "Hardened Escort",
             "text": "Whenever Hardened Escort attacks, another target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "ba660cb0-16b3-59ad-b105-81ce4a08244a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dd8903-31ca-470d-b2ff-280f6d40c794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dd8903-31ca-470d-b2ff-280f6d40c794.jpg?1",
             "name": "Jump Scare",
             "text": "Until end of turn, target creature gets +2/+2, gains flying, and becomes a Horror enchantment creature in addition to its other types.",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "6e522c94-1bb8-5104-a6de-3285a512bb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg?1",
             "name": "Leyline of Hope",
             "text": "If Leyline of Hope is in your opening hand, you may begin the game with it on the battlefield.\nIf you would gain life, you gain that much life plus 1 instead.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "c38dc3a9-5e5d-5f83-af4f-0fc6a3c4b018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e1c6f-331c-45f1-bf5d-9b9742aa8903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e1c6f-331c-45f1-bf5d-9b9742aa8903.jpg?1",
             "name": "Lionheart Glimmer",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhenever you attack, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "33aa95b9-93ee-5e98-8b15-1ad8da338cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8266f93b-f91c-4427-a222-075ceb0be3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8266f93b-f91c-4427-a222-075ceb0be3af.jpg?1",
             "name": "Living Phone",
             "text": "When Living Phone dies, look at the top five cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "7383c8f1-4cf0-5b23-a0cb-f102ab397c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c72fc6f-6a96-420d-812d-b5cf0f57cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c72fc6f-6a96-420d-812d-b5cf0f57cc7f.jpg?1",
             "name": "Optimistic Scavenger",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, put a +1/+1 counter on target creature.",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "fdea5842-b488-594a-b1bd-42ef7dbbcb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef4aab1-8bc0-4652-91d7-3e8b20b411ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef4aab1-8bc0-4652-91d7-3e8b20b411ad.jpg?1",
             "name": "Orphans of the Wheat",
             "text": "Whenever Orphans of the Wheat attacks, tap any number of untapped creatures you control. Orphans of the Wheat gets +1/+1 until end of turn for each creature tapped this way.",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "c80fdf27-bc65-51ea-b115-770821d565c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcafc2e-cef6-412d-8c5d-1658c3337292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcafc2e-cef6-412d-8c5d-1658c3337292.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -921,7 +921,7 @@
         },
         {
             "id": "c2ba8e64-5d98-513f-a415-1a65a0199636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513da431-4f3a-4f4a-8be4-7e162dd93307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513da431-4f3a-4f4a-8be4-7e162dd93307.jpg?1",
             "name": "Patched Plaything",
             "text": "Double strike\nPatched Plaything enters with two -1/-1 counters on it if you cast it from your hand.",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "a05f2933-2d68-54b5-9761-e73a07a90d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd02b8ff-ff65-4a38-b8fb-f8dd130edbf7.jpg?1",
             "name": "Possessed Goat",
             "text": "{3}, Discard a card: Put three +1/+1 counters on Possessed Goat and it becomes a black Demon in addition to its other colors and types. Activate only once.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "3c33d793-2a1f-5ddc-adba-4e33503b5664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg?1",
             "name": "Reluctant Role Model",
             "text": "Survival \u2014 At the beginning of your second main phase, if Reluctant Role Model is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever Reluctant Role Model or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "7d554eea-cb75-5dee-b9f2-b50f0bf398c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ed31ea-c278-4e8c-afa7-6d09af399345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ed31ea-c278-4e8c-afa7-6d09af399345.jpg?1",
             "name": "Savior of the Small",
             "text": "Survival \u2014 At the beginning of your second main phase, if Savior of the Small is tapped, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "6b874068-7cd3-5fe3-b80f-a2ef25a3452f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24456083-0c76-46c5-9b18-8d468702df69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24456083-0c76-46c5-9b18-8d468702df69.jpg?1",
             "name": "Seized from Slumber",
             "text": "This spell costs {3} less to cast if it targets a tapped creature.\nDestroy target creature.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "92074085-27bb-50cb-949c-6424cbe3f747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed0cafa-d701-4e1f-9773-abcf817c244c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed0cafa-d701-4e1f-9773-abcf817c244c.jpg?1",
             "name": "Shardmage's Rescue",
             "text": "Flash\nEnchant creature you control\nAs long as Shardmage's Rescue entered this turn, enchanted creature has hexproof.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "f953e6d8-a71d-5b94-bbea-95208df67a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f3f7b-be40-4a2d-b5cc-28471a577981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f3f7b-be40-4a2d-b5cc-28471a577981.jpg?1",
             "name": "Sheltered by Ghosts",
             "text": "Enchant creature you control\nWhen Sheltered by Ghosts enters, exile target nonland permanent an opponent controls until Sheltered by Ghosts leaves the battlefield.\nEnchanted creature gets +1/+0 and has lifelink and ward {2}.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "4b7e0601-7b4f-546c-8fe5-28077d2e0ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c02ab1-0fb2-4cb0-a871-bfad406726fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c02ab1-0fb2-4cb0-a871-bfad406726fc.jpg?1",
             "name": "Shepherding Spirits",
             "text": "Flying\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "de985ac6-9da0-59c6-a58e-097c69688b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb9a5b1-48d2-453e-8991-c788bc63e482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb9a5b1-48d2-453e-8991-c788bc63e482.jpg?1",
             "name": "Split Up",
             "text": "Choose one \u2014\n\u2022 Destroy all tapped creatures.\n\u2022 Destroy all untapped creatures.",
             "colours": [
@@ -1233,7 +1233,7 @@
         },
         {
             "id": "85a24de0-fe90-51eb-b65d-f07090efb7a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453be94-e59b-48f1-a488-7a9fd96a627e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0453be94-e59b-48f1-a488-7a9fd96a627e.jpg?1",
             "name": "Splitskin Doll",
             "text": "When Splitskin Doll enters, draw a card. Then discard a card unless you control another creature with power 2 or less.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "57ff9e80-9b4c-56ee-83af-4dac96b4aee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg?1",
             "name": "Surgical Suite // Hospital Room",
             "text": "When you unlock this door, return target creature card with mana value 3 or less from your graveyard to the battlefield.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "58653d19-4a11-5c4e-8c59-f2e6cc88ba28",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg?1",
             "name": "Surgical Suite // Hospital Room",
             "text": "Hospital Room\no3o\nW\nWhenever you attack, put a +1/+1 counter on target attacking creature.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "aa65592c-6bbe-5b75-b5d3-f7c1d683d71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg?1",
             "name": "Toby, Beastie Befriender",
             "text": "When Toby, Beastie Befriender enters, create a 4/4 white Beast creature token with \"This creature can't attack or block alone.\"\nAs long as you control four or more creature tokens, creature tokens you control have flying.",
             "colours": [
@@ -1375,7 +1375,7 @@
         },
         {
             "id": "cba1c2ae-cb22-5edf-99b0-982683ff9000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe95bfb-8ca7-434f-a2e7-a6b2e699584e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe95bfb-8ca7-434f-a2e7-a6b2e699584e.jpg?1",
             "name": "Trapped in the Screen",
             "text": "Ward {2} (Whenever this enchantment becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Trapped in the Screen enters, exile target artifact, creature, or enchantment an opponent controls until Trapped in the Screen leaves the battlefield.",
             "colours": [
@@ -1407,7 +1407,7 @@
         },
         {
             "id": "0531cf92-0c5c-55b3-92d6-435a60624d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg?1",
             "name": "Unidentified Hovership",
             "text": "Flying\nWhen Unidentified Hovership enters, exile up to one target creature with toughness 5 or less.\nWhen Unidentified Hovership leaves the battlefield, the exiled card's owner manifests dread.\nCrew 1",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "1c41ec1f-c4fd-5142-b744-ccf7f262c0d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da2e65-4e22-48b6-98ad-6969684d69e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da2e65-4e22-48b6-98ad-6969684d69e1.jpg?1",
             "name": "Unsettling Twins",
             "text": "When Unsettling Twins enters, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "17ed1f3a-0d13-5c6c-b058-f5c4c1cac3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b54447f-1daf-4352-b5c3-3c0ec8b8f4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b54447f-1daf-4352-b5c3-3c0ec8b8f4d0.jpg?1",
             "name": "Unwanted Remake",
             "text": "Destroy target creature. Its controller manifests dread. (That player looks at the top two cards of their library, then puts one onto the battlefield face down as a 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "b4fcd019-8f4d-5326-8570-6aad6a77c2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39368ea2-f665-40b1-b042-c0182f7c6df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39368ea2-f665-40b1-b042-c0182f7c6df0.jpg?1",
             "name": "Veteran Survivor",
             "text": "Survival \u2014 At the beginning of your second main phase, if Veteran Survivor is tapped, exile up to one target card from a graveyard.\nAs long as there are three or more cards exiled with Veteran Survivor, it gets +3/+3 and has hexproof. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "02c06897-69c5-5a92-bcb9-5121dbbb04b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ccca86-df8b-4fd9-8fdf-0a5a7b14cdee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ccca86-df8b-4fd9-8fdf-0a5a7b14cdee.jpg?1",
             "name": "The Wandering Rescuer",
             "text": "Flash\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDouble strike\nOther tapped creatures you control have hexproof.",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "43ec1283-25da-5505-aa46-0c12c514471b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg?1",
             "name": "Abhorrent Oculus",
             "text": "As an additional cost to cast this spell, exile six cards from your graveyard.\nFlying\nAt the beginning of each opponent's upkeep, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "3191ecdc-97a3-5eac-a808-b6c46be97082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg?1",
             "name": "Bottomless Pool // Locker Room",
             "text": "When you unlock this door, return up to one target creature to its owner's hand.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "5e157784-c31c-5fd3-8ac5-72fd101c943e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg?1",
             "name": "Bottomless Pool // Locker Room",
             "text": "Locker Room\no4o\nU\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "4f31f6f5-5e1e-57e4-8e27-c48c38c4a4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "f58a84bc-b347-599e-99c2-ddda8ddff696",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "af41bf7c-46ad-568d-8617-78f8c771203b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237f0b93-f12e-4c5f-a3d7-83e8f20f8493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237f0b93-f12e-4c5f-a3d7-83e8f20f8493.jpg?1",
             "name": "Clammy Prowler",
             "text": "Whenever Clammy Prowler attacks, another target attacking creature can't be blocked this turn.",
             "colours": [
@@ -1798,7 +1798,7 @@
         },
         {
             "id": "3fc15b6a-8d9b-57f9-b90a-1eba1ab0f680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad59368-1335-4d8e-a254-ccd889933e57.jpg?1",
             "name": "Creeping Peeper",
             "text": "{T}: Add {U}. Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "0facd25b-1943-5c07-98d7-6ed7941fb584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f651e216-f9da-4696-8a1d-6d674e9044c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f651e216-f9da-4696-8a1d-6d674e9044c0.jpg?1",
             "name": "Cursed Windbreaker",
             "text": "When Cursed Windbreaker enters, manifest dread, then attach Cursed Windbreaker to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature has flying.\nEquip {3}",
             "colours": [
@@ -1866,7 +1866,7 @@
         },
         {
             "id": "cb2d0175-e8d2-5e2c-9203-0ae57b33a133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a38b9-29aa-4804-ab27-4c40321f0bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a38b9-29aa-4804-ab27-4c40321f0bc3.jpg?1",
             "name": "Daggermaw Megalodon",
             "text": "Vigilance\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "388e81e6-6218-50e2-8a36-d5ea090fcd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f42e59-7315-41cb-9c41-346e44f0c5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f42e59-7315-41cb-9c41-346e44f0c5fb.jpg?1",
             "name": "Don't Make a Sound",
             "text": "Counter target spell unless its controller pays {2}. If they do, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "4543cdc1-d3ea-5f81-b2fa-ad987574e77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96dbc9-c2fd-42c1-9d55-5c14fa1c1c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96dbc9-c2fd-42c1-9d55-5c14fa1c1c6f.jpg?1",
             "name": "Duskmourn's Domination",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets -3/-0 and loses all abilities.",
             "colours": [
@@ -1966,7 +1966,7 @@
         },
         {
             "id": "0d2feb0c-2504-5890-98f6-1d1f417b9303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "05472b46-cd6a-593d-948d-efe44b04a2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5479c7-9e46-4a57-abe7-8cc670de89e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5479c7-9e46-4a57-abe7-8cc670de89e4.jpg?1",
             "name": "Enter the Enigma",
             "text": "Target creature can't be blocked this turn.\nDraw a card.",
             "colours": [
@@ -2038,7 +2038,7 @@
         },
         {
             "id": "b3165028-93b4-52bc-9c5e-302703d3ef88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae54d697-6d06-4af1-a617-8a47a6ab9c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae54d697-6d06-4af1-a617-8a47a6ab9c01.jpg?1",
             "name": "Entity Tracker",
             "text": "Flash\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "bfc31b69-73a8-5fb5-b175-688b149e4c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74fd612-2890-4333-a379-5bf7650fbb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74fd612-2890-4333-a379-5bf7650fbb87.jpg?1",
             "name": "Erratic Apparition",
             "text": "Flying, vigilance\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Erratic Apparition gets +1/+1 until end of turn.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "b9e9a01f-c7d5-57b7-908e-4ae668c95d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c39df-7636-454b-8485-a1cc9362fd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c39df-7636-454b-8485-a1cc9362fd84.jpg?1",
             "name": "Fear of Failed Tests",
             "text": "Whenever Fear of Failed Tests deals combat damage to a player, draw that many cards.",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "abc34ea5-d1e7-5931-947a-da18b4b550d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e814e48-cd9d-428f-90e2-74d97cb9c8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e814e48-cd9d-428f-90e2-74d97cb9c8f1.jpg?1",
             "name": "Fear of Falling",
             "text": "Flying\nWhenever Fear of Falling attacks, target creature defending player controls gets -2/-0 and loses flying until your next turn.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "707935d5-9157-59c4-a022-062915e17b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdee441e-14ab-42d1-b447-5a6488fd713a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdee441e-14ab-42d1-b447-5a6488fd713a.jpg?1",
             "name": "Fear of Impostors",
             "text": "Flash\nWhen Fear of Impostors enters, counter target spell. Its controller manifests dread. (That player looks at the top two cards of their library, then puts one onto the battlefield face down as a 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "df3297db-dba2-59ad-adc0-f650a0b66b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69aa6054-8c59-4bbc-a283-adb453639786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69aa6054-8c59-4bbc-a283-adb453639786.jpg?1",
             "name": "Fear of Isolation",
             "text": "As an additional cost to cast this spell, return a permanent you control to its owner's hand.\nFlying",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "9442b457-5a17-538e-9ec1-114cb4604b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62aa3-8edb-4000-8ebd-15ec4b00eed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a62aa3-8edb-4000-8ebd-15ec4b00eed7.jpg?1",
             "name": "Floodpits Drowner",
             "text": "Flash\nVigilance\nWhen Floodpits Drowner enters, tap target creature an opponent controls and put a stun counter on it.\n{1}{U}, {T}: Shuffle Floodpits Drowner and target creature with a stun counter on it into their owners' libraries.",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "83376425-0784-5ed8-a985-fbe941042cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9471c8-2db9-4ce3-a1e5-42b85134cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9471c8-2db9-4ce3-a1e5-42b85134cb8e.jpg?1",
             "name": "Get Out",
             "text": "Choose one \u2014\n\u2022 Counter target creature or enchantment spell.\n\u2022 Return one or two target creatures and/or enchantments you own to your hand.",
             "colours": [
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "5f0a392f-0a9c-5d50-8e86-b6edef4590b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d04a98-6997-4653-9719-e6b215567599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d04a98-6997-4653-9719-e6b215567599.jpg?1",
             "name": "Ghostly Keybearer",
             "text": "Flying\nWhenever Ghostly Keybearer deals combat damage to a player, unlock a locked door of up to one target Room you control.",
             "colours": [
@@ -2350,7 +2350,7 @@
         },
         {
             "id": "361795fb-b13a-5201-94c0-86b12a70f117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1ab8db-3994-4b6d-9eaf-75243a78b715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1ab8db-3994-4b6d-9eaf-75243a78b715.jpg?1",
             "name": "Glimmerburst",
             "text": "Draw two cards. Create a 1/1 white Glimmer enchantment creature token.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "74b1ac20-3da1-5e7d-98a8-d96e83d1294e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg?1",
             "name": "Leyline of Transformation",
             "text": "If Leyline of Transformation is in your opening hand, you may begin the game with it on the battlefield.\nAs Leyline of Transformation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "4761fe98-6f8d-5597-987d-0d8c73f27bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg?1",
             "name": "Marina Vendrell's Grimoire",
             "text": "When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.\nYou have no maximum hand size and don't lose the game for having 0 or less life.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "65435acc-204a-5d28-a50a-dccd4f2dd515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg?1",
             "name": "Meat Locker // Drowned Diner",
             "text": "When you unlock this door, tap up to one target creature and put two stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "6e02de34-e9dc-5784-938c-28df9f2cea71",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg?1",
             "name": "Meat Locker // Drowned Diner",
             "text": "Drowned Diner\no3o\nUo\nU\nWhen you unlock this door, draw three cards, then discard a card.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "ce687985-b6cf-501c-91d9-402a6f290f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg?1",
             "name": "The Mindskinner",
             "text": "The Mindskinner can't be blocked.\nIf a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "50603666-04c5-593e-bd2b-b020a5894311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "28480e8a-5f63-595a-b955-8ee21177f9a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "1ec3e707-ba67-5c0f-85e3-3c5e830f19b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5de8-9cda-4370-9f72-4462f8cfd696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5de8-9cda-4370-9f72-4462f8cfd696.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "0e30656c-1353-5250-b0fa-2279908195e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cf954a-5503-460c-8720-8960842eea47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cf954a-5503-460c-8720-8960842eea47.jpg?1",
             "name": "Paranormal Analyst",
             "text": "Whenever you manifest dread, put a card you put into your graveyard this way into your hand.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "aa18cb09-d403-58ca-a19b-59f6e6369f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd891675-12d4-40df-996a-97d694155227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd891675-12d4-40df-996a-97d694155227.jpg?1",
             "name": "Piranha Fly",
             "text": "Flying\nPiranha Fly enters tapped.",
             "colours": [
@@ -2741,7 +2741,7 @@
         },
         {
             "id": "ad48d027-a544-5def-b460-458617c489c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1017b8e-e7fa-41de-8eb2-2e4a59db5117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1017b8e-e7fa-41de-8eb2-2e4a59db5117.jpg?1",
             "name": "Scrabbling Skullcrab",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "a95265c6-c9b6-5fb1-ab8c-57f1dc87cb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg?1",
             "name": "Silent Hallcreeper",
             "text": "Silent Hallcreeper can't be blocked.\nWhenever Silent Hallcreeper deals combat damage to a player, choose one that hasn't been chosen \u2014\n\u2022 Put two +1/+1 counters on Silent Hallcreeper.\n\u2022 Draw a card.\n\u2022 Silent Hallcreeper becomes a copy of another target creature you control.",
             "colours": [
@@ -2813,7 +2813,7 @@
         },
         {
             "id": "da720467-e4d8-5d4b-aeea-8ef641d360ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26ccad-adfa-43cc-be4c-dc8dd584bca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a26ccad-adfa-43cc-be4c-dc8dd584bca3.jpg?1",
             "name": "Stalked Researcher",
             "text": "Defender\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Stalked Researcher can attack this turn as though it didn't have defender.",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "87371f12-904e-55d0-802d-8b68e0e2a4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661ffe7-4f58-43fe-a1f1-dd7a6d4d28a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661ffe7-4f58-43fe-a1f1-dd7a6d4d28a7.jpg?1",
             "name": "Stay Hidden, Stay Silent",
             "text": "Enchant creature\nWhen Stay Hidden, Stay Silent enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate only as a sorcery.",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "5204bcd4-945b-5415-a9b1-0e267d8ce576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeba193-05d3-4c2d-a304-bbe7114c2eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaeba193-05d3-4c2d-a304-bbe7114c2eef.jpg?1",
             "name": "The Tale of Tamiyo",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Mill two cards. If two cards that share a card type were milled this way, draw a card and repeat this process.\nIV \u2014 Exile any number of target instant, sorcery, and/or Tamiyo planeswalker cards from your graveyard. Copy them. You may cast any number of the copies.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "dcd569ea-9292-5bf1-9339-4c72d5ef74a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ee2690-f464-4a38-81e1-6dd2053a3327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ee2690-f464-4a38-81e1-6dd2053a3327.jpg?1",
             "name": "Tunnel Surveyor",
             "text": "When Tunnel Surveyor enters, create a 1/1 white Glimmer enchantment creature token.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "bd9c560a-952c-55a6-b6e4-4763aba09c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644714dd-7a0b-4d4b-9a61-8f6e505b1d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644714dd-7a0b-4d4b-9a61-8f6e505b1d22.jpg?1",
             "name": "Twist Reality",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "6d89cc57-a52c-557c-bcc5-59e19ba406d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c59e0cd-10a8-4a32-9c0a-a2c6ef1ed9a6.jpg?1",
             "name": "Unable to Scream",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a Toy artifact creature with base power and toughness 0/2 in addition to its other types.\nAs long as enchanted creature is face down, it can't be turned face up.",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "9693221c-41cf-517e-b1b5-0a6fe8cf1fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg?1",
             "name": "Underwater Tunnel // Slimy Aquarium",
             "text": "When you unlock this door, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "ad03ae0c-3e8a-529f-9e2c-dde9d0f294e7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg?1",
             "name": "Underwater Tunnel // Slimy Aquarium",
             "text": "Slimy Aquarium\no3o\nU\nWhen you unlock this door, manifest dread, then put a +1/+1 counter on that creature.",
             "colours": [
@@ -3089,7 +3089,7 @@
         },
         {
             "id": "c05e8344-1146-5b0c-9987-8e2f3bb33acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602756d-76d2-4502-965f-36fc44596123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602756d-76d2-4502-965f-36fc44596123.jpg?1",
             "name": "Unnerving Grasp",
             "text": "Return up to one target nonland permanent to its owner's hand. Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "daaa4fce-3ab4-51b7-a8b4-03c5b9957649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1758ed-fe33-4ead-8c83-e54fabcb4cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1758ed-fe33-4ead-8c83-e54fabcb4cfe.jpg?1",
             "name": "Unwilling Vessel",
             "text": "Vigilance\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, put a possession counter on Unwilling Vessel.\nWhen Unwilling Vessel dies, create an X/X blue Spirit creature token with flying, where X is the number of counters on Unwilling Vessel.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "ad63f21e-7f8f-5a76-b4a6-81354bfa681b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254988b-3113-42f7-b751-517ffb3b40f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254988b-3113-42f7-b751-517ffb3b40f0.jpg?1",
             "name": "Vanish from Sight",
             "text": "Target nonland permanent's owner puts it on the top or bottom of their library. Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3188,7 +3188,7 @@
         },
         {
             "id": "66a88902-be45-5772-812b-3f530bb6a8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16b3cf3-7b85-4153-b25a-e6b5fce725cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16b3cf3-7b85-4153-b25a-e6b5fce725cf.jpg?1",
             "name": "Appendage Amalgam",
             "text": "Flash\nWhenever Appendage Amalgam attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3223,7 +3223,7 @@
         },
         {
             "id": "0eddb098-53ff-5781-82c0-862e1a60a601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0621b32-95c5-4f70-96cf-d46d20efc85d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0621b32-95c5-4f70-96cf-d46d20efc85d.jpg?1",
             "name": "Balemurk Leech",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, each opponent loses 1 life.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "99cc53d5-babc-5834-8c48-a36f06e64b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269ccf-febf-42b0-8c20-21ccb731a3ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269ccf-febf-42b0-8c20-21ccb731a3ec.jpg?1",
             "name": "Cackling Slasher",
             "text": "Deathtouch\nCackling Slasher enters with a +1/+1 counter on it if a creature died this turn.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "d48b03c1-62b5-57f0-88fc-a0ec4da5bb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg?1",
             "name": "Come Back Wrong",
             "text": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "ce1fb39e-5391-5bd9-851b-89dd5a53c6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab94ebe-b51b-4c6f-af43-0ed80e2808a3.jpg?1",
             "name": "Commune with Evil",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. You gain 3 life.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "4081850c-8b02-5ad2-ad02-e1322fb5b3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7616ad5e-ed30-4876-8743-6f0f9f143ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7616ad5e-ed30-4876-8743-6f0f9f143ea1.jpg?1",
             "name": "Cracked Skull",
             "text": "Enchant creature\nWhen Cracked Skull enters, look at target player's hand. You may choose a nonland card from it. That player discards that card.\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "41714f54-9776-57fb-b78f-a4fd24c017a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc93bcb8-778d-491e-877b-e6ad432764cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc93bcb8-778d-491e-877b-e6ad432764cb.jpg?1",
             "name": "Cynical Loner",
             "text": "Cynical Loner can't be blocked by Glimmers.\nSurvival \u2014 At the beginning of your second main phase, if Cynical Loner is tapped, you may search your library for a card, put it into your graveyard, then shuffle.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "0597a0db-4bb7-5278-8928-a99d6a31d63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790a90cc-d36f-43b5-8423-89e30bdf7b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790a90cc-d36f-43b5-8423-89e30bdf7b9f.jpg?1",
             "name": "Dashing Bloodsucker",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Dashing Bloodsucker gets +2/+0 and gains lifelink until end of turn.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "3f9de0d7-102c-5022-bdd1-c33b5aaaf855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg?1",
             "name": "Defiled Crypt // Cadaver Lab",
             "text": "Whenever one or more cards leave your graveyard, create a 2/2 black Horror enchantment creature token. This ability triggers only once each turn.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "a45c2b4b-3301-532f-8963-810cbcc5e0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg?1",
             "name": "Defiled Crypt // Cadaver Lab",
             "text": "Cadaver Lab\no\nB\nWhen you unlock this door, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "c4516787-050f-5119-997b-1184ea631c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg?1",
             "name": "Demonic Counsel",
             "text": "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead search your library for any card, put it into your hand, then shuffle.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "d2118542-371c-58b1-8b50-c2609de58378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg?1",
             "name": "Derelict Attic // Widow's Walk",
             "text": "When you unlock this door, you draw two cards and you lose 2 life.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "911bec78-3d2e-5fd2-bc2e-66aa99fd5161",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg?1",
             "name": "Derelict Attic // Widow's Walk",
             "text": "Widow's Walk\no3o\nB\nWhenever a creature you control attacks alone, it gets +1/+0 and gains deathtouch until end of turn.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "9cb0e626-49d3-5712-addd-8c4217a816b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg?1",
             "name": "Doomsday Excruciator",
             "text": "Flying\nWhen Doomsday Excruciator enters, if it was cast, each player exiles all but the bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card.",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "23e13c55-b25d-552d-8c8f-2ff0ca6f2abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -3709,7 +3709,7 @@
         },
         {
             "id": "c6c68ca2-88af-5469-a647-76cff76ef9fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0acb05-91e0-4f7c-b48b-99e1068fad16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0acb05-91e0-4f7c-b48b-99e1068fad16.jpg?1",
             "name": "Fanatic of the Harrowing",
             "text": "When Fanatic of the Harrowing enters, each player discards a card. If you discarded a card this way, draw a card.",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "91d3f7ba-3cb7-55c5-84df-e82d0b0912c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259045fe-f349-4be1-bf29-465d084ed35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259045fe-f349-4be1-bf29-465d084ed35e.jpg?1",
             "name": "Fear of Lost Teeth",
             "text": "When Fear of Lost Teeth dies, it deals 1 damage to any target and you gain 1 life.",
             "colours": [
@@ -3779,7 +3779,7 @@
         },
         {
             "id": "ef5a843e-a238-5f16-952a-550c1ea13bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700eb8d-1cc0-45ff-b769-c875ee6500ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700eb8d-1cc0-45ff-b769-c875ee6500ea.jpg?1",
             "name": "Fear of the Dark",
             "text": "Whenever Fear of the Dark attacks, if defending player controls no Glimmer creatures, it gains menace and deathtouch until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3814,7 +3814,7 @@
         },
         {
             "id": "82dd2183-bd88-5c83-b887-9a5bec231a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648da934-71f6-4945-a08f-09698414417b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648da934-71f6-4945-a08f-09698414417b.jpg?1",
             "name": "Final Vengeance",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nExile target creature.",
             "colours": [
@@ -3846,7 +3846,7 @@
         },
         {
             "id": "878a8613-c5b1-5457-b3b7-d5b380afa44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "",
             "colours": [
@@ -3882,7 +3882,7 @@
         },
         {
             "id": "d9eb10f0-aa4c-556d-a5ce-9b4e42a0490a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "35bc3647-dee9-52eb-9fa6-669fd5c16aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ac1759-d4cc-41d5-a9b7-a89b80d2190c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ac1759-d4cc-41d5-a9b7-a89b80d2190c.jpg?1",
             "name": "Give In to Violence",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "9393364c-8562-50de-a7c4-b16d1fac0314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg?1",
             "name": "Grievous Wound",
             "text": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "f902c01c-118f-5815-8ec7-d36a25bfc7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94edbbc5-5673-4753-bfad-4432c4b7dca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94edbbc5-5673-4753-bfad-4432c4b7dca4.jpg?1",
             "name": "Innocuous Rat",
             "text": "When Innocuous Rat dies, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "6fcd8623-f829-5580-9fb8-439cb7852e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fc02ae-77b8-4e5e-94b4-22ecf7ae40ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fc02ae-77b8-4e5e-94b4-22ecf7ae40ae.jpg?1",
             "name": "Killer's Mask",
             "text": "When Killer's Mask enters, manifest dread, then attach Killer's Mask to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature has menace.\nEquip {2}",
             "colours": [
@@ -4055,7 +4055,7 @@
         },
         {
             "id": "6c915da5-868a-5eb1-b876-38180ca069a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645911b4-7728-4380-9097-e4139b986423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645911b4-7728-4380-9097-e4139b986423.jpg?1",
             "name": "Let's Play a Game",
             "text": "Delirium \u2014 Choose one. If there are four or more card types among cards in your graveyard, choose one or more instead.\n\u2022 Creatures your opponents control get -1/-1 until end of turn.\n\u2022 Each opponent discards two cards.\n\u2022 Each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "bc8493e4-b1fc-5dd9-adbe-78cd6b12a6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa3aff-608d-4723-bb7c-8daedebe9f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaa3aff-608d-4723-bb7c-8daedebe9f36.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "a300e157-cbfc-58bf-b5ef-cc3eb0b08bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81e438-e38f-42a1-b677-202dbcb3837c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd81e438-e38f-42a1-b677-202dbcb3837c.jpg?1",
             "name": "Live or Die",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to the battlefield.\n\u2022 Destroy target creature.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "0389e70c-50f3-52c5-b489-b52c2f8fe53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg?1",
             "name": "Meathook Massacre II",
             "text": "When Meathook Massacre II enters, each player sacrifices X creatures.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "ab320381-d909-5542-a7f9-7609091cfec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d167c00-75ff-4301-855a-8319b89e3689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d167c00-75ff-4301-855a-8319b89e3689.jpg?1",
             "name": "Miasma Demon",
             "text": "Flying\nWhen Miasma Demon enters, you may discard any number of cards. When you do, up to that many target creatures each get -2/-2 until end of turn.",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "510331ff-2cc0-50e7-87ab-4c8e713a0fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c249609-9cf7-46f1-b94c-9329add966bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c249609-9cf7-46f1-b94c-9329add966bb.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "4c26fbbc-0362-5071-b0e7-df3e1bed2442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee60e9d-9ee7-444a-88f3-c1929e1888fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee60e9d-9ee7-444a-88f3-c1929e1888fb.jpg?1",
             "name": "Nowhere to Run",
             "text": "Flash\nWhen Nowhere to Run enters, target creature an opponent controls gets -3/-3 until end of turn.\nCreatures your opponents control can be the targets of spells and abilities as though they didn't have hexproof. Ward abilities of those creatures don't trigger.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "f9b435a9-7c70-55ed-86ce-40386095a15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43473e-1302-4543-b331-1a86cfbc3ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43473e-1302-4543-b331-1a86cfbc3ced.jpg?1",
             "name": "Osseous Sticktwister",
             "text": "Lifelink\nDelirium \u2014 At the beginning of your end step, if there are four or more card types among cards in your graveyard, each opponent may sacrifice a nonland permanent or discard a card. Then Osseous Sticktwister deals damage equal to its power to each opponent who didn't sacrifice a permanent or discard a card this way.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "805bbd73-9501-527d-86be-bfb55e4abdd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911653-7b96-4cf3-a907-13c5c53a14f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911653-7b96-4cf3-a907-13c5c53a14f7.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B} (If you cast this spell for its impending cost, it enters with five time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "aa32279c-2646-5583-a80f-e1eaf6e834a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e64605-8edb-4def-9522-765e90d1f0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e64605-8edb-4def-9522-765e90d1f0f3.jpg?1",
             "name": "Popular Egotist",
             "text": "{1}{B}, Sacrifice another creature or enchantment: Popular Egotist gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)\nWhenever you sacrifice a permanent, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "5ecd3170-57a0-5ac7-8f51-54159f3daa94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41bd259-e81f-432a-bebf-4c6534f23db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41bd259-e81f-432a-bebf-4c6534f23db7.jpg?1",
             "name": "Resurrected Cultist",
             "text": "Delirium \u2014 {2}{B}{B}: Return Resurrected Cultist from your graveyard to the battlefield with a finality counter on it. Activate only if there are four or more card types among cards in your graveyard and only as a sorcery. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "2b90209a-7ad0-5228-909f-3a2961d64e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f90f57-94a0-4ee1-9383-093e8fca52ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f90f57-94a0-4ee1-9383-093e8fca52ea.jpg?1",
             "name": "Spectral Snatcher",
             "text": "Ward\u2014\nDiscard a card. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player discards a card.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "b6aac1cf-bc8f-57d0-b24d-30742f95cf6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae086e-0781-4f4d-bc9c-a98228bc380c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae086e-0781-4f4d-bc9c-a98228bc380c.jpg?1",
             "name": "Sporogenic Infection",
             "text": "Enchant creature\nWhen Sporogenic Infection enters, target player sacrifices a creature other than enchanted creature.\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "dc6e09c1-3382-5828-b620-72c87ca28bee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "3292acbe-1245-5f0d-b4fe-baba590d548c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "",
             "colours": [
@@ -4573,7 +4573,7 @@
         },
         {
             "id": "cb2f106e-42d8-5270-8270-9bbacf704193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78da035-6b5b-4136-9ab6-f622b64fdc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78da035-6b5b-4136-9ab6-f622b64fdc54.jpg?1",
             "name": "Unstoppable Slasher",
             "text": "Deathtouch\nWhenever Unstoppable Slasher deals combat damage to a player, they lose half their life, rounded up.\nWhen Unstoppable Slasher dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "5f7c6a59-2960-5adf-9089-8d38fd4dc5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg?1",
             "name": "Valgavoth, Terror Eater",
             "text": "Flying, lifelink\nWard\u2014\nSacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "e8d310a2-d17d-5328-8262-5f3fc1140c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995194a0-ceb7-48c2-be5d-a208b3971e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995194a0-ceb7-48c2-be5d-a208b3971e77.jpg?1",
             "name": "Valgavoth's Faithful",
             "text": "{3}{B}, Sacrifice Valgavoth's Faithful: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4688,7 +4688,7 @@
         },
         {
             "id": "10c6b3eb-94e4-535f-9c7a-17d06e92344c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383fe040-98bb-40f3-b809-48c429b83f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383fe040-98bb-40f3-b809-48c429b83f47.jpg?1",
             "name": "Vile Mutilator",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nFlying, trample\nWhen Vile Mutilator enters, each opponent sacrifices a nontoken enchantment, then sacrifices a nontoken creature.",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "3bc5bbb7-e0d4-571f-be41-15e6eb9d4182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d38fa-bbcf-4bcc-93a8-adbfd9c93faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d38fa-bbcf-4bcc-93a8-adbfd9c93faa.jpg?1",
             "name": "Winter's Intervention",
             "text": "Winter's Intervention deals 2 damage to target creature. You gain 2 life.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "15dcb36c-b915-5b55-8b6c-fb0f4ab272ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38048d14-3463-4157-951f-1d68ec78a64e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38048d14-3463-4157-951f-1d68ec78a64e.jpg?1",
             "name": "Withering Torment",
             "text": "Destroy target creature or enchantment. You lose 2 life.",
             "colours": [
@@ -4788,7 +4788,7 @@
         },
         {
             "id": "56ba778a-1869-5181-a63a-533baf88079d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c72b5b-dd81-4eb4-80d9-a0124e27e1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c72b5b-dd81-4eb4-80d9-a0124e27e1dc.jpg?1",
             "name": "Bedhead Beastie",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "7634134d-44a9-594d-bb87-1636291bf1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956ae00-8f0c-48f0-8110-19ff53863876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7956ae00-8f0c-48f0-8110-19ff53863876.jpg?1",
             "name": "Betrayer's Bargain",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment or pay {2}.\nBetrayer's Bargain deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "d5bec7c4-aeae-537a-a480-e402aebf58f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68009c-83cd-455f-81e9-bdd720d23a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68009c-83cd-455f-81e9-bdd720d23a43.jpg?1",
             "name": "Boilerbilges Ripper",
             "text": "When Boilerbilges Ripper enters, you may sacrifice another creature or enchantment. When you do, Boilerbilges Ripper deals 2 damage to any target.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "7e31cd17-674d-5fff-87ef-5c40b6317495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg?1",
             "name": "Chainsaw",
             "text": "When Chainsaw enters, it deals 3 damage to up to one target creature.\nWhenever one or more creatures die, put a rev counter on Chainsaw.\nEquipped creature gets +X/+0, where X is the number of rev counters on Chainsaw.\nEquip {3}",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "75ef0f5c-d3c2-50da-a516-90a1c221a90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "f38ff991-89ff-56d5-8786-a74815cd2877",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "abe77c3f-948b-5dfd-ba01-47247a2434be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10986e5a-9fc6-41e2-8352-289328245171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10986e5a-9fc6-41e2-8352-289328245171.jpg?1",
             "name": "Clockwork Percussionist",
             "text": "Haste\nWhen Clockwork Percussionist dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -5035,7 +5035,7 @@
         },
         {
             "id": "87346839-ed95-513f-bce2-f34394ae2fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg?1",
             "name": "Cursed Recording",
             "text": "Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "6e009fe2-7523-5a25-b426-0a2ec63325a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9b17c-4210-49f4-a920-b1dc9dfa950f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9b17c-4210-49f4-a920-b1dc9dfa950f.jpg?1",
             "name": "Diversion Specialist",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{1}, Sacrifice another creature or enchantment: Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "e6137a85-bbac-5828-ae0b-c2450f3d5315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46ac55f-d68e-4d5d-af0a-3879f97f705e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46ac55f-d68e-4d5d-af0a-3879f97f705e.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "a4006054-49cd-53ee-aee5-ecebcfa208d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a5e716-68c1-4fa0-aa08-5b08114e08d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a5e716-68c1-4fa0-aa08-5b08114e08d8.jpg?1",
             "name": "Fear of Being Hunted",
             "text": "Haste\nFear of Being Hunted must be blocked if able.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "93b09e32-c7b1-506f-b09a-5d571d9ca5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b282f8e3-8b79-47e9-8c18-62284211442b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b282f8e3-8b79-47e9-8c18-62284211442b.jpg?1",
             "name": "Fear of Burning Alive",
             "text": "When Fear of Burning Alive enters, it deals 4 damage to each opponent.\nDelirium \u2014 Whenever a source you control deals noncombat damage to an opponent, if there are four or more card types among cards in your graveyard, Fear of Burning Alive deals that amount of damage to target creature that player controls.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "e59f8b8e-3d1d-593d-8e4f-d8175d428e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg?1",
             "name": "Fear of Missing Out",
             "text": "When Fear of Missing Out enters, discard a card, then draw a card.\nDelirium \u2014 Whenever Fear of Missing Out attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.",
             "colours": [
@@ -5252,7 +5252,7 @@
         },
         {
             "id": "5d70128c-84ec-5d34-a8d9-aabeeb98bd75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg?1",
             "name": "Glassworks // Shattered Yard",
             "text": "When you unlock this door, this Room deals 4 damage to target creature an opponent controls.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "347b899b-e313-5ee1-afbf-7fe0142167d0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg?1",
             "name": "Glassworks // Shattered Yard",
             "text": "Shattered Yard\no4o\nR\nAt the beginning of your end step, this Room deals 1 damage to each opponent.",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "52094f45-38ba-5459-b580-bedde716c502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50895202-f1a1-4840-a11a-55b78b8b5929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50895202-f1a1-4840-a11a-55b78b8b5929.jpg?1",
             "name": "Grab the Prize",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards. If the discarded card wasn't a land card, Grab the Prize deals 2 damage to each opponent.",
             "colours": [
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "d0d74072-7041-5290-a556-c1ca8cf15f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c2860-5a68-4a18-a23a-ca5cfdfbcac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c2860-5a68-4a18-a23a-ca5cfdfbcac8.jpg?1",
             "name": "Hand That Feeds",
             "text": "Delirium \u2014 Whenever Hand That Feeds attacks while there are four or more card types among cards in your graveyard, it gets +2/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5386,7 +5386,7 @@
         },
         {
             "id": "60f5f62e-2600-52e2-8a4b-bcc404ef770d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35248f9-9a4e-4758-a4c1-0e0c83e3fd75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35248f9-9a4e-4758-a4c1-0e0c83e3fd75.jpg?1",
             "name": "Impossible Inferno",
             "text": "Impossible Inferno deals 6 damage to target creature.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "ed961de3-0a25-5644-b6fe-31e6ce8f1650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5999f-a185-4fc7-86fa-c4e5b091e768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5999f-a185-4fc7-86fa-c4e5b091e768.jpg?1",
             "name": "Infernal Phantom",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, Infernal Phantom gets +2/+0 until end of turn.\nWhen Infernal Phantom dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "78160156-ba38-5db3-b861-b8ab2eb8bfdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da254f5-53f2-41d2-a4f0-a90b3dd6209c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da254f5-53f2-41d2-a4f0-a90b3dd6209c.jpg?1",
             "name": "Irreverent Gremlin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever another creature you control with power 2 or less enters, you may discard a card. If you do, draw a card. Do this only once each turn.",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "90b12b3e-319b-5a42-a270-d1632eecb391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg?1",
             "name": "Leyline of Resonance",
             "text": "If Leyline of Resonance is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you cast an instant or sorcery spell that targets only a single creature you control, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "bea36a70-39c0-560c-942f-f5903ef33a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7b635-4c72-4129-bf95-1eef05cce3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7b635-4c72-4129-bf95-1eef05cce3d3.jpg?1",
             "name": "Most Valuable Slayer",
             "text": "Whenever you attack, target attacking creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "16444ace-4142-55f2-861d-89a12b83aea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0fdf4-3881-4327-924f-2c1b67ccda93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0fdf4-3881-4327-924f-2c1b67ccda93.jpg?1",
             "name": "Norin, Swift Survivalist",
             "text": "Norin, Swift Survivalist can't block.\nWhenever a creature you control becomes blocked, you may exile it. You may play that card from exile this turn.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "82395047-8396-5b73-9ba1-2d043963d9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58d3545-043a-457a-8324-facc3c2363ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58d3545-043a-457a-8324-facc3c2363ec.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "3e4d74d9-07ce-57f5-9f58-04a9200eb857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg?1",
             "name": "Painter's Studio // Defaced Gallery",
             "text": "When you unlock this door, exile the top two cards of your library. You may play them until the end of your next turn.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "aee7351e-476e-5b9c-ab18-2aa156f59557",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg?1",
             "name": "Painter's Studio // Defaced Gallery",
             "text": "Defaced Gallery\no1o\nR\nWhenever you attack, attacking creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5702,7 +5702,7 @@
         },
         {
             "id": "8423892d-34f6-5c0d-bab0-73949a2ff7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d35442-5ca0-4fd7-8ff1-b7347b3e6690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d35442-5ca0-4fd7-8ff1-b7347b3e6690.jpg?1",
             "name": "Piggy Bank",
             "text": "When Piggy Bank dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "aa3cdc04-b8f4-52a6-867c-81478d8accd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391b0af-2f26-4a45-9e2a-5bd8e9838107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4391b0af-2f26-4a45-9e2a-5bd8e9838107.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -5772,7 +5772,7 @@
         },
         {
             "id": "8fae41b1-a3f9-500f-98b1-22aa3fd9b4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000499a4-3f39-4d25-a2a2-b2f014e30754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000499a4-3f39-4d25-a2a2-b2f014e30754.jpg?1",
             "name": "Ragged Playmate",
             "text": "{1}, {T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "15a7680e-f64e-51f3-a4c3-07dca92c3a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c914b-95af-428f-a142-6f20e418bc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c914b-95af-428f-a142-6f20e418bc59.jpg?1",
             "name": "Rampaging Soulrager",
             "text": "Rampaging Soulrager gets +3/+0 as long as there are two or more unlocked doors among Rooms you control.",
             "colours": [
@@ -5841,7 +5841,7 @@
         },
         {
             "id": "65ae68a4-69bf-526b-a764-6ac74cd091f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fb0f11-d1d0-4941-a1a7-a2db88f30394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fb0f11-d1d0-4941-a1a7-a2db88f30394.jpg?1",
             "name": "Razorkin Hordecaller",
             "text": "Haste\nWhenever you attack, create a 1/1 red Gremlin creature token.",
             "colours": [
@@ -5877,7 +5877,7 @@
         },
         {
             "id": "08c414a4-3f2b-5e2d-8263-7e520cc66641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73b963-23c0-46d2-853a-34a8b463994e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73b963-23c0-46d2-853a-34a8b463994e.jpg?1",
             "name": "Razorkin Needlehead",
             "text": "Razorkin Needlehead has first strike during your turn.\nWhenever an opponent draws a card, Razorkin Needlehead deals 1 damage to them.",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "9ece59f6-d640-5925-9e98-fa5c9065055b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effad662-3309-434c-addc-4394db1f359c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effad662-3309-434c-addc-4394db1f359c.jpg?1",
             "name": "Ripchain Razorkin",
             "text": "Reach\n{2}{R}, Sacrifice a land: Draw a card.",
             "colours": [
@@ -5949,7 +5949,7 @@
         },
         {
             "id": "71d94431-9ee2-5e52-bc83-15a361dc005f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg?1",
             "name": "The Rollercrusher Ride",
             "text": "Delirium \u2014 If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "1d80ddc5-5f00-556f-8ab9-c67660e9ab6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f4f37-796a-4b18-a5ee-1d4f711f19b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f4f37-796a-4b18-a5ee-1d4f711f19b8.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "72056277-7cda-57af-ae3c-f313b0452b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg?1",
             "name": "Screaming Nemesis",
             "text": "Haste\nWhenever Screaming Nemesis is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "a159bb7d-dce3-53d3-9802-ce17dd9dd631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg?1",
             "name": "Ticket Booth // Tunnel of Hate",
             "text": "When you unlock this door, manifest dread.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -6088,7 +6088,7 @@
         },
         {
             "id": "2456a921-9f47-5733-ad99-dca9653e97c7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg?1",
             "name": "Ticket Booth // Tunnel of Hate",
             "text": "Tunnel of Hate\no4o\nRo\nR\nWhenever you attack, target attacking creature gains double strike until end of turn.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "028a9b4e-f39b-59b5-a077-fb13ab76ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa62f67a-d20f-4d99-b0a2-327634299c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa62f67a-d20f-4d99-b0a2-327634299c9f.jpg?1",
             "name": "Trial of Agony",
             "text": "Choose two target creatures controlled by the same opponent. That player chooses one of those creatures. Trial of Agony deals 5 damage to that creature, and the other can't block this turn.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "0e1256d1-a918-58fe-86f1-f62636a3cf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2a92c-06d3-4cb5-883d-cba428a7e98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2a92c-06d3-4cb5-883d-cba428a7e98e.jpg?1",
             "name": "Turn Inside Out",
             "text": "Target creature gets +3/+0 until end of turn. When it dies this turn, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "bb96d613-88b8-5566-a53f-d1bd90e00680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857bfb0e-17dc-4dda-bc37-3df927a9eae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857bfb0e-17dc-4dda-bc37-3df927a9eae6.jpg?1",
             "name": "Untimely Malfunction",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Change the target of target spell or ability with a single target.\n\u2022 One or two target creatures can't block this turn.",
             "colours": [
@@ -6218,7 +6218,7 @@
         },
         {
             "id": "d13a7980-9b48-52d6-bfeb-667bde9575d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6918d50-a4c3-40d8-9480-343f14773a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6918d50-a4c3-40d8-9480-343f14773a69.jpg?1",
             "name": "Vengeful Possession",
             "text": "Gain control of target creature until end of turn. Untap it. It gains haste until end of turn. You may discard a card. If you do, draw a card.",
             "colours": [
@@ -6250,7 +6250,7 @@
         },
         {
             "id": "a3e9b738-9852-52a5-ba37-21c8efaaafb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12649f73-9d29-4eed-bc89-cc0d1a8969e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12649f73-9d29-4eed-bc89-cc0d1a8969e3.jpg?1",
             "name": "Vicious Clown",
             "text": "Whenever another creature you control with power 2 or less enters, Vicious Clown gets +2/+0 until end of turn.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "469929f6-02ab-5618-97cb-96e8dedfa48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg?1",
             "name": "Violent Urge",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, that creature gains double strike until end of turn.",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "de6528b8-c898-56b3-95a5-91002d8036a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg?1",
             "name": "Waltz of Rage",
             "text": "Target creature you control deals damage equal to its power to each other creature. Until end of turn, whenever a creature you control dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -6351,7 +6351,7 @@
         },
         {
             "id": "840c6f16-70db-5e71-bfad-0a346f5f382f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807b0674-8eba-4204-b6b6-fa2b785a79e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807b0674-8eba-4204-b6b6-fa2b785a79e9.jpg?1",
             "name": "Altanak, the Thrice-Called",
             "text": "Trample\nWhenever Altanak, the Thrice-Called becomes the target of a spell or ability an opponent controls, draw a card.\n{1}{G}, Discard Altanak, the Thrice-Called: Return target land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6388,7 +6388,7 @@
         },
         {
             "id": "bbf7bafc-3981-57cc-b615-ed4c0134bf97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51216ab0-9806-4faa-afbd-143e95dc255b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51216ab0-9806-4faa-afbd-143e95dc255b.jpg?1",
             "name": "Anthropede",
             "text": "Reach\nWhen Anthropede enters, you may discard a card or pay {2}. When you do, destroy target Room.",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "a781e411-a28c-5a7f-9905-98ae782d7dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76610e6e-b60f-494f-bb11-68371eb494f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76610e6e-b60f-494f-bb11-68371eb494f2.jpg?1",
             "name": "Balustrade Wurm",
             "text": "This spell can't be countered.\nTrample, haste\nDelirium \u2014 {2}{G}{G}: Return Balustrade Wurm from your graveyard to the battlefield with a finality counter on it. Activate only if there are four or more card types among cards in your graveyard and only as a sorcery.",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "1e6e8a87-092e-53bc-a44f-0c643d234a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20fa7ee-a4c2-4eb0-9467-195f3b894fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20fa7ee-a4c2-4eb0-9467-195f3b894fa0.jpg?1",
             "name": "Bashful Beastie",
             "text": "When Bashful Beastie dies, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "fedd4a13-823c-55c9-a7ef-63516151d28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209e9bbc-a15d-47fc-b149-6b0c57dd09ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209e9bbc-a15d-47fc-b149-6b0c57dd09ea.jpg?1",
             "name": "Break Down the Door",
             "text": "Choose one \u2014\n\u2022 Exile target artifact.\n\u2022 Exile target enchantment.\n\u2022 Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6524,7 +6524,7 @@
         },
         {
             "id": "cc8a4772-78bf-5ba4-afdd-e80a053d64a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc250a-854d-4555-ba78-db9283fa7c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc250a-854d-4555-ba78-db9283fa7c22.jpg?1",
             "name": "Cathartic Parting",
             "text": "The owner of target artifact or enchantment an opponent controls shuffles it into their library. You may shuffle up to four target cards from your graveyard into your library.",
             "colours": [
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "cfa3aa18-9e1a-52cc-8316-11ca2c62169c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b4c1a-e058-4e06-bc46-e250fd9c9b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b4c1a-e058-4e06-bc46-e250fd9c9b54.jpg?1",
             "name": "Cautious Survivor",
             "text": "Survival \u2014 At the beginning of your second main phase, if Cautious Survivor is tapped, you gain 2 life.",
             "colours": [
@@ -6591,7 +6591,7 @@
         },
         {
             "id": "e79e46ee-3f69-55be-b14f-a38ea6d52345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498cd5d-5807-4297-bc8a-c0941f2f5ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d498cd5d-5807-4297-bc8a-c0941f2f5ce2.jpg?1",
             "name": "Coordinated Clobbering",
             "text": "Tap one or two target untapped creatures you control. They each deal damage equal to their power to target creature an opponent controls.",
             "colours": [
@@ -6623,7 +6623,7 @@
         },
         {
             "id": "31cd2be1-b74b-5d80-bd52-810273ef2a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820c2932-2e23-4f67-92d0-a630aec6f1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820c2932-2e23-4f67-92d0-a630aec6f1b4.jpg?1",
             "name": "Cryptid Inspector",
             "text": "Vigilance\nWhenever a face-down permanent you control enters and whenever Cryptid Inspector or another permanent you control is turned face up, put a +1/+1 counter on Cryptid Inspector.",
             "colours": [
@@ -6658,7 +6658,7 @@
         },
         {
             "id": "58ec8774-1f1a-574a-a7c0-5ac51c88acb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327772f3-5a87-47af-9308-c1119ad2711d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327772f3-5a87-47af-9308-c1119ad2711d.jpg?1",
             "name": "Defiant Survivor",
             "text": "Survival \u2014 At the beginning of your second main phase, if Defiant Survivor is tapped, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "b6ad6ec9-87db-5c99-9655-41043086ffef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "bf1b0b5b-46a5-5360-b424-ddabe7a6d0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93bb4abc-5af1-4cf5-919b-244b6a36f8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93bb4abc-5af1-4cf5-919b-244b6a36f8ec.jpg?1",
             "name": "Fear of Exposure",
             "text": "As an additional cost to cast this spell, tap two untapped creatures and/or lands you control.\nTrample",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "5f1ec504-0261-5342-aa10-e0f14abe7a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60499c90-a512-4abb-98eb-0735a7138421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60499c90-a512-4abb-98eb-0735a7138421.jpg?1",
             "name": "Flesh Burrower",
             "text": "Deathtouch\nWhenever Flesh Burrower attacks, another target creature you control gains deathtouch until end of turn.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "d2589919-0f1a-5b73-bfc0-5750eacc86d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9d35d-7fd0-4193-9f7e-b8a59fae4ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9d35d-7fd0-4193-9f7e-b8a59fae4ac5.jpg?1",
             "name": "Frantic Strength",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+2 and has trample.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "b4881ca4-298f-5f00-8735-97c86f1435f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fddcd48-3efe-4b56-9d69-9659b3dc6021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fddcd48-3efe-4b56-9d69-9659b3dc6021.jpg?1",
             "name": "Grasping Longneck",
             "text": "Reach\nWhen Grasping Longneck dies, you gain 2 life.",
             "colours": [
@@ -6871,7 +6871,7 @@
         },
         {
             "id": "bfa902a2-a366-572c-a819-c128686eb084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg?1",
             "name": "Greenhouse // Rickety Gazebo",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "6ac1fc4d-10df-5f00-9e0b-12efc8db59de",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22e8038-0706-47ec-bfda-f421a4912774.jpg?1",
             "name": "Greenhouse // Rickety Gazebo",
             "text": "Rickety Gazebo\no3o\nG\nWhen you unlock this door, mill four cards, then return up to two permanent cards from among them to your hand.",
             "colours": [
@@ -6939,7 +6939,7 @@
         },
         {
             "id": "b7b204b5-ac99-5ff8-9e58-f93c74ec9b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744ef0bc-9973-450e-a0c4-056d8244f357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744ef0bc-9973-450e-a0c4-056d8244f357.jpg?1",
             "name": "Hauntwoods Shrieker",
             "text": "Whenever Hauntwoods Shrieker attacks, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\n{1}{G}: Reveal target face-down permanent. If it's a creature card, you may turn it face up.",
             "colours": [
@@ -6976,7 +6976,7 @@
         },
         {
             "id": "a181e173-1403-5e66-b394-13bb2d261d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg?1",
             "name": "Hedge Shredder",
             "text": "Whenever Hedge Shredder attacks, you may mill two cards.\nWhenever one or more land cards are put into your graveyard from your library, put them onto the battlefield tapped.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "6dddf05e-ab72-5dac-9676-1f6758272558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c175c998-7b80-4187-bdbc-5b6e0d7eac91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c175c998-7b80-4187-bdbc-5b6e0d7eac91.jpg?1",
             "name": "Horrid Vigor",
             "text": "Target creature gains deathtouch and indestructible until end of turn.",
             "colours": [
@@ -7044,7 +7044,7 @@
         },
         {
             "id": "bab33d4b-5abb-507c-b5ed-4623246dca6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a534918-a009-4f7d-87c9-5ef600b6e7c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a534918-a009-4f7d-87c9-5ef600b6e7c2.jpg?1",
             "name": "House Cartographer",
             "text": "Survival \u2014 At the beginning of your second main phase, if House Cartographer is tapped, reveal cards from the top of your library until you reveal a land card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "e401eeb6-3f2b-52cd-9996-61630efe271f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60d2e62-06da-410a-81ed-6cebb2632fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60d2e62-06da-410a-81ed-6cebb2632fb6.jpg?1",
             "name": "Insidious Fungus",
             "text": "{2}, Sacrifice Insidious Fungus: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Draw a card. Then you may put a land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -7116,7 +7116,7 @@
         },
         {
             "id": "472c6623-aa7a-548f-8198-941b89904340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg?1",
             "name": "Kona, Rescue Beastie",
             "text": "Survival \u2014 At the beginning of your second main phase, if Kona, Rescue Beastie is tapped, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "f59cdb60-220a-52f8-b08e-b9031c056fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg?1",
             "name": "Leyline of Mutation",
             "text": "If Leyline of Mutation is in your opening hand, you may begin the game with it on the battlefield.\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "1573e95e-2673-52e7-bbe5-141f7dbbf5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a649265b-6c32-49e7-b6cb-6086c40d26e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a649265b-6c32-49e7-b6cb-6086c40d26e8.jpg?1",
             "name": "Manifest Dread",
             "text": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "fd52305c-8edf-536f-9384-bde983bf3e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg?1",
             "name": "Moldering Gym // Weight Room",
             "text": "When you unlock this door, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -7260,7 +7260,7 @@
         },
         {
             "id": "90eabdd2-7a2d-5fee-886c-a96ffa3b72eb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg?1",
             "name": "Moldering Gym // Weight Room",
             "text": "Weight Room\no5o\nG\nWhen you unlock this door, manifest dread, then put three +1/+1 counters on that creature.",
             "colours": [
@@ -7294,7 +7294,7 @@
         },
         {
             "id": "ed481b0e-f1b5-5213-bf7f-a53218b806da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999eb47-b842-47f1-be91-c79fc46e1896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b999eb47-b842-47f1-be91-c79fc46e1896.jpg?1",
             "name": "Monstrous Emergence",
             "text": "As an additional cost to cast this spell, choose a creature you control or reveal a creature card from your hand.\nMonstrous Emergence deals damage equal to the power of the creature you chose or the card you revealed to target creature.",
             "colours": [
@@ -7326,7 +7326,7 @@
         },
         {
             "id": "f52ecd4d-d13f-59a1-a9ca-608e0fc8792a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg?1",
             "name": "Omnivorous Flytrap",
             "text": "Delirium \u2014 Whenever Omnivorous Flytrap enters or attacks, if there are four or more card types among cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if there are six or more card types among cards in your graveyard, double the number of +1/+1 counters on those creatures.",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "665cca29-eb6c-5577-a582-7256d39d7a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d68d29-499a-4864-be18-bd98fda0d173.jpg?1",
             "name": "Overgrown Zealot",
             "text": "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this mana only to turn permanents face up.",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "efe21992-9359-5b88-a6ca-8a482a136ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d08ff1-edcc-4c76-96e0-683b3da36ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d08ff1-edcc-4c76-96e0-683b3da36ebb.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G} (If you cast this spell for its impending cost, it enters with four time counters and isn't a creature until the last is removed. At the beginning of your end step, remove a time counter from it.)\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -7437,7 +7437,7 @@
         },
         {
             "id": "eada20e1-7d44-5074-b6e1-15ebbc34cc22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895de583-36d2-43fd-927f-8876d4302c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895de583-36d2-43fd-927f-8876d4302c73.jpg?1",
             "name": "Patchwork Beastie",
             "text": "Delirium \u2014 Patchwork Beastie can't attack or block unless there are four or more card types among cards in your graveyard.\nAt the beginning of your upkeep, you may mill a card. (You may put the top card of your library into your graveyard.)",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "ddf4ca5a-5ff7-54c1-9a98-24d01c6bc02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d843c242-088f-4131-9e52-7ee2d0db5e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d843c242-088f-4131-9e52-7ee2d0db5e20.jpg?1",
             "name": "Rootwise Survivor",
             "text": "Haste\nSurvival \u2014 At the beginning of your second main phase, if Rootwise Survivor is tapped, put three +1/+1 counters on up to one target land you control. That land becomes a 0/0 Elemental creature in addition to its other types. It gains haste until your next turn.",
             "colours": [
@@ -7507,7 +7507,7 @@
         },
         {
             "id": "c2bfef0b-8c4e-5890-adee-da065f496927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c58683-b5f2-4863-9562-6f6be1ec21fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c58683-b5f2-4863-9562-6f6be1ec21fe.jpg?1",
             "name": "Say Its Name",
             "text": "Mill three cards. Then you may return a creature or land card from your graveyard to your hand.\nExile this card and two other cards named Say Its Name from your graveyard: Search your graveyard, hand, and/or library for a card named Altanak, the Thrice-Called and put it onto the battlefield. If you search your library this way, shuffle. Activate only as a sorcery.",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "075d6191-4a31-5a55-a4df-512611ef1af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ca4d-5895-4074-8315-656363d14862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ca4d-5895-4074-8315-656363d14862.jpg?1",
             "name": "Slavering Branchsnapper",
             "text": "Trample\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "0faa02e9-1c66-5238-9c85-b6dbd5a3b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d697c-8358-429b-8f79-7ad9d01a5edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d697c-8358-429b-8f79-7ad9d01a5edd.jpg?1",
             "name": "Spineseeker Centipede",
             "text": "When Spineseeker Centipede enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nDelirium \u2014 Spineseeker Centipede gets +1/+2 and has vigilance as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -7607,7 +7607,7 @@
         },
         {
             "id": "c94cdc97-f02e-5527-b0cc-b70986697e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7201ee12-9104-48d8-aeec-08a318c8ee10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7201ee12-9104-48d8-aeec-08a318c8ee10.jpg?1",
             "name": "Threats Around Every Corner",
             "text": "When Threats Around Every Corner enters, manifest dread.\nWhenever a face-down permanent you control enters, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "29f10329-ed52-5a84-b7fe-be3c522851ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg?1",
             "name": "Twitching Doll",
             "text": "{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.",
             "colours": [
@@ -7678,7 +7678,7 @@
         },
         {
             "id": "54a3710d-c0bb-539e-8ef0-95ed32a89b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7687b1-630a-4e95-89c7-eaf456d8cb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7687b1-630a-4e95-89c7-eaf456d8cb68.jpg?1",
             "name": "Tyvar, the Pummeler",
             "text": "Tap another untapped creature you control: Tyvar, the Pummeler gains indestructible until end of turn. Tap it.\n{3}{G}{G}: Creatures you control get +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "df6c1eb4-368e-5326-a8b0-0fc83959a386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1ad3-00ad-48ec-a71f-812649d55e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1ad3-00ad-48ec-a71f-812649d55e14.jpg?1",
             "name": "Under the Skin",
             "text": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nYou may return a permanent card from your graveyard to your hand.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "62d4034c-f7e5-5c0e-ac51-07338cfa2b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg?1",
             "name": "Valgavoth's Onslaught",
             "text": "Manifest dread X times, then put X +1/+1 counters on each of those creatures. (To manifest dread, look at the top two cards of your library, then put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "cc5f93b5-f109-5bc0-9b68-9189a7f6183f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "281345a9-41d8-5656-8758-4ebd616f9a70",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "",
             "colours": [
@@ -7858,7 +7858,7 @@
         },
         {
             "id": "a8da9466-b670-5618-9c25-90ff6f172452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ed97f2-b47e-49b7-9b1a-694c4bbeca3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ed97f2-b47e-49b7-9b1a-694c4bbeca3b.jpg?1",
             "name": "Wary Watchdog",
             "text": "When Wary Watchdog enters or dies, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7892,7 +7892,7 @@
         },
         {
             "id": "a6b9f2e9-1bba-5a12-8024-15f86f0ed65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a74892-20cd-47f7-b514-a4c7f14cca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a74892-20cd-47f7-b514-a4c7f14cca8b.jpg?1",
             "name": "Wickerfolk Thresher",
             "text": "Delirium \u2014 Whenever Wickerfolk Thresher attacks, if there are four or more card types among cards in your graveyard, look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "0a26e4d3-3762-5242-8478-4ffbcca37259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f683d5a1-b8bf-446f-9fe3-88a4398bf3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f683d5a1-b8bf-446f-9fe3-88a4398bf3cf.jpg?1",
             "name": "Arabella, Abandoned Doll",
             "text": "Whenever Arabella, Abandoned Doll attacks, it deals X damage to each opponent and you gain X life, where X is the number of creatures you control with power 2 or less.",
             "colours": [
@@ -7966,7 +7966,7 @@
         },
         {
             "id": "f590f8c0-5f2b-5fe3-9753-64112e31f7ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438accb1-6d2c-4710-adeb-df4301a7b8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438accb1-6d2c-4710-adeb-df4301a7b8f1.jpg?1",
             "name": "Baseball Bat",
             "text": "When Baseball Bat enters, attach it to target creature you control.\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, tap up to one target creature.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "861b3892-b706-5960-af73-7ff05396efd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f889c95-46af-4fd9-aff2-573d5384fd58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f889c95-46af-4fd9-aff2-573d5384fd58.jpg?1",
             "name": "Beastie Beatdown",
             "text": "Choose target creature you control and target creature an opponent controls.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, put two +1/+1 counters on the creature you control.\nThe creature you control deals damage equal to its power to the creature an opponent controls.",
             "colours": [
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "fc1d0b9a-c65f-562a-95fb-b37316e8bf45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdd2622-ab7a-4990-b026-3667cac42894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdd2622-ab7a-4990-b026-3667cac42894.jpg?1",
             "name": "Broodspinner",
             "text": "Reach\nWhen Broodspinner enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n{4}{B}{G}, {T}, Sacrifice Broodspinner: Create a number of 1/1 black and green Insect creature tokens with flying equal to the number of card types among cards in your graveyard.",
             "colours": [
@@ -8072,7 +8072,7 @@
         },
         {
             "id": "7a24ce69-bfc1-53e7-bed8-9c776c8e1019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b0c5d-6823-439c-a011-8b9bf424bdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b0c5d-6823-439c-a011-8b9bf424bdad.jpg?1",
             "name": "Disturbing Mirth",
             "text": "When Disturbing Mirth enters, you may sacrifice another enchantment or creature. If you do, draw two cards.\nWhen you sacrifice Disturbing Mirth, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "0f17aa5d-ff22-526b-8d52-b6aea79fc22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f46095-6479-46b0-9e59-194d83f86a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f46095-6479-46b0-9e59-194d83f86a46.jpg?1",
             "name": "Drag to the Roots",
             "text": "Delirium \u2014 This spell costs {2} less to cast as long as there are four or more card types among cards in your graveyard.\nDestroy target nonland permanent.",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "143eb035-4cc1-5d29-a878-a40c491b6fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81756844-c642-406f-842d-35c1e404fec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81756844-c642-406f-842d-35c1e404fec0.jpg?1",
             "name": "Fear of Infinity",
             "text": "Flying, lifelink\nFear of Infinity can't block.\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, you may return Fear of Infinity from your graveyard to your hand.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "93669828-8074-5886-8e8e-3872f18a3b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3593a222-21c5-4f91-bde1-763ea08071da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3593a222-21c5-4f91-bde1-763ea08071da.jpg?1",
             "name": "Gremlin Tamer",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 1/1 red Gremlin creature token.",
             "colours": [
@@ -8216,7 +8216,7 @@
         },
         {
             "id": "5c464cbc-7490-5df8-9501-a49fe8c9ed0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5479ac50-8335-4c6a-be99-750a44e24f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5479ac50-8335-4c6a-be99-750a44e24f25.jpg?1",
             "name": "Growing Dread",
             "text": "Flash\nWhen Growing Dread enters, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever you turn a permanent face up, put a +1/+1 counter on it.",
             "colours": [
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "480f7221-c81e-5d2f-8e9f-e964fc2e63c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f66e3e-9f1f-4601-aa30-30b66805a5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f66e3e-9f1f-4601-aa30-30b66805a5a8.jpg?1",
             "name": "Inquisitive Glimmer",
             "text": "Enchantment spells you cast cost {1} less to cast.\nUnlock costs you pay cost {1} less.",
             "colours": [
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "4d3e7bce-9b81-5f85-825c-541a61c37dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffc298-0219-4807-ab05-d94460e767bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffc298-0219-4807-ab05-d94460e767bc.jpg?1",
             "name": "Intruding Soulrager",
             "text": "Vigilance\n{T}, Sacrifice a Room: Intruding Soulrager deals 2 damage to each opponent. Draw a card.",
             "colours": [
@@ -8326,7 +8326,7 @@
         },
         {
             "id": "903dd6a6-e6e6-54f1-a41f-1cb716febba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e2e0-1c0e-475d-a0f4-1be4216c2bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e2e0-1c0e-475d-a0f4-1be4216c2bad.jpg?1",
             "name": "The Jolly Balloon Man",
             "text": "Haste\n{1}, {T}: Create a token that's a copy of another target creature you control, except it's a 1/1 red Balloon creature in addition to its other colors and types and it has flying and haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "e28d871a-716f-5e8a-af8c-0034d114837d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a14f30-4ff9-4472-90a6-c3139f1c18e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a14f30-4ff9-4472-90a6-c3139f1c18e5.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B} ({1}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "1f9cf760-85b7-50ae-b151-11c3e2f9570d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6428cddc-2fb6-41af-a643-e83c81dc04f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6428cddc-2fb6-41af-a643-e83c81dc04f5.jpg?1",
             "name": "Marina Vendrell",
             "text": "When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment cards from among them into your hand and the rest on the bottom of your library in a random order.\n{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
             "colours": [
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "f188e82b-2f29-5e73-8ead-206ea95f58d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc0b94f-08b3-4fb6-9b09-2f3a215203ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc0b94f-08b3-4fb6-9b09-2f3a215203ca.jpg?1",
             "name": "Midnight Mayhem",
             "text": "Create three 1/1 red Gremlin creature tokens. Gremlins you control gain menace, lifelink, and haste until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "a8e11bfc-1c4a-512b-87d8-94fad866a7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9e1e-43f2-499e-844d-22fc10dbad06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9e1e-43f2-499e-844d-22fc10dbad06.jpg?1",
             "name": "Nashi, Searcher in the Dark",
             "text": "Menace\nWhenever Nashi, Searcher in the Dark deals combat damage to a player, you mill that many cards. You may put any number of legendary and/or enchantment cards from among them into your hand. If you put no cards into your hand this way, put a +1/+1 counter on Nashi.",
             "colours": [
@@ -8532,7 +8532,7 @@
         },
         {
             "id": "da80eccb-b9fe-5ab4-aaf7-2575502453f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ad013f-de8d-4980-b4b6-c7f91ff495b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ad013f-de8d-4980-b4b6-c7f91ff495b1.jpg?1",
             "name": "Niko, Light of Hope",
             "text": "When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "2f227788-09fe-5dc3-ba0f-f62ad5d43188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b4c50b-fe76-430d-8f96-208f15ca4cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b4c50b-fe76-430d-8f96-208f15ca4cd7.jpg?1",
             "name": "Oblivious Bookworm",
             "text": "At the beginning of your end step, you may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn.",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "1efe9af6-58e0-588c-9bcf-d9695950a521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874eadb6-602e-47dc-8094-82e37ac89c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874eadb6-602e-47dc-8094-82e37ac89c94.jpg?1",
             "name": "Peer Past the Veil",
             "text": "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard.",
             "colours": [
@@ -8649,7 +8649,7 @@
         },
         {
             "id": "3306130d-0e63-5255-a217-bd1a7485ba3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "907454bd-5d40-5624-8711-07f0ce38590f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "",
             "colours": [
@@ -8723,7 +8723,7 @@
         },
         {
             "id": "78b68c36-8883-5af9-9119-89c188385704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12e3b3-a260-4913-b13a-7fbb753dd702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12e3b3-a260-4913-b13a-7fbb753dd702.jpg?1",
             "name": "Rip, Spawn Hunter",
             "text": "Survival \u2014 At the beginning of your second main phase, if Rip, Spawn Hunter is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8764,7 +8764,7 @@
         },
         {
             "id": "bf2acdc0-461a-5c0f-8b5e-554d4e8bdc0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e79123f-accd-4193-8c72-b750e0d6f3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e79123f-accd-4193-8c72-b750e0d6f3fa.jpg?1",
             "name": "Rite of the Moth",
             "text": "Return target creature card from your graveyard to the battlefield with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)\nFlashback {3}{W}{W}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8798,7 +8798,7 @@
         },
         {
             "id": "dbe5c0fc-9eaa-5030-8702-dde9ef1d9de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "",
             "colours": [
@@ -8835,7 +8835,7 @@
         },
         {
             "id": "f75d6d5f-8dff-5c31-9081-5ede6c598d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94352ffb-d716-484d-b018-4e1c033ef2f3.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "",
             "colours": [
@@ -8872,7 +8872,7 @@
         },
         {
             "id": "80decd66-646b-50d7-92eb-b3423b24d04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe51964-50d2-49b0-9c3c-81751dcbeade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe51964-50d2-49b0-9c3c-81751dcbeade.jpg?1",
             "name": "Sawblade Skinripper",
             "text": "Menace\n{2}, Sacrifice another creature or enchantment: Put a +1/+1 counter on Sawblade Skinripper.\nAt the beginning of your end step, if you sacrificed one or more permanents this turn, Sawblade Skinripper deals that much damage to any target.",
             "colours": [
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "2b1f5c62-d3da-5720-95d4-e39b7de656fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9636877-8fcc-4ad5-8eb2-a5d5ba49583d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9636877-8fcc-4ad5-8eb2-a5d5ba49583d.jpg?1",
             "name": "Shrewd Storyteller",
             "text": "Survival \u2014 At the beginning of your second main phase, if Shrewd Storyteller is tapped, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8946,7 +8946,7 @@
         },
         {
             "id": "cecffedd-9077-56dd-8b10-c481d97ae679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f746bf-0642-48db-835e-27a7fe369fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f746bf-0642-48db-835e-27a7fe369fef.jpg?1",
             "name": "Shroudstomper",
             "text": "Deathtouch\nWhenever Shroudstomper enters or attacks, each opponent loses 2 life. You gain 2 life and draw a card.",
             "colours": [
@@ -8982,7 +8982,7 @@
         },
         {
             "id": "22b67cb3-4c25-5514-94af-d77951ac3a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fdcdfd0-8c66-4767-a894-58cf0c6d7e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fdcdfd0-8c66-4767-a894-58cf0c6d7e07.jpg?1",
             "name": "Skullsnap Nuisance",
             "text": "Flying\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -9019,7 +9019,7 @@
         },
         {
             "id": "9568be43-ac9a-5c79-9940-453826cc59fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg?1",
             "name": "Smoky Lounge // Misty Salon",
             "text": "At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells and unlock doors.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -9054,7 +9054,7 @@
         },
         {
             "id": "1d1d6353-1898-5849-a4c5-a6de87a10454",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg?1",
             "name": "Smoky Lounge // Misty Salon",
             "text": "Misty Salon\no3o\nU\nWhen you unlock this door, create an X/X blue Spirit creature token with flying, where X is the number of unlocked doors among Rooms you control.",
             "colours": [
@@ -9089,7 +9089,7 @@
         },
         {
             "id": "8f124bbb-5bd0-5cf4-be5d-ac0b50889d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3b17b-f2f6-4702-864d-8c96100b0563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf3b17b-f2f6-4702-864d-8c96100b0563.jpg?1",
             "name": "The Swarmweaver",
             "text": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "e5e0e6d1-64e5-5ca5-8c6a-77b87c0dc0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b96951-4884-4df7-bdf0-94be2bc044f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b96951-4884-4df7-bdf0-94be2bc044f0.jpg?1",
             "name": "Undead Sprinter",
             "text": "Trample, haste\nYou may cast Undead Sprinter from your graveyard if a non-Zombie creature died this turn. If you do, Undead Sprinter enters with a +1/+1 counter on it.",
             "colours": [
@@ -9169,7 +9169,7 @@
         },
         {
             "id": "67f6cc5e-0158-5a98-890c-9305823f174a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51392ece-c9f5-46b0-9dce-0a1a0343a536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51392ece-c9f5-46b0-9dce-0a1a0343a536.jpg?1",
             "name": "Victor, Valgavoth's Seneschal",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "e423c38b-8221-5340-a66d-3335bd657288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7fbc6e-09c6-4f0e-92e2-766aae950b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7fbc6e-09c6-4f0e-92e2-766aae950b3d.jpg?1",
             "name": "Wildfire Wickerfolk",
             "text": "Haste\nDelirium \u2014 Wildfire Wickerfolk gets +1/+1 and has trample as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "fc1488ec-1f65-5813-a641-fc63e1feff4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b81421-44cb-440f-a6ac-3ddf620f1989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b81421-44cb-440f-a6ac-3ddf620f1989.jpg?1",
             "name": "Winter, Misanthropic Guide",
             "text": "Ward {2}\nAt the beginning of your upkeep, each player draws two cards.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, each opponent's maximum hand size is equal to seven minus the number of those card types.",
             "colours": [
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "3ed05381-6603-56e0-8355-7d555987d88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722f4f7-fe38-4107-a715-7b27b6a4e341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7722f4f7-fe38-4107-a715-7b27b6a4e341.jpg?1",
             "name": "Zimone, All-Questioning",
             "text": "At the beginning of your end step, if a land entered the battlefield under your control this turn and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters on it. (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, and 31 are prime numbers.)",
             "colours": [
@@ -9331,7 +9331,7 @@
         },
         {
             "id": "41eccfe3-4aaa-5c41-bb3a-4a5c967a7276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477dc3e-0fa1-4ce4-b3de-8cae0d1a0763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477dc3e-0fa1-4ce4-b3de-8cae0d1a0763.jpg?1",
             "name": "Attack-in-the-Box",
             "text": "Whenever Attack-in-the-Box attacks, you may have it get +4/+0 until end of turn. If you do, sacrifice it at the beginning of the next end step.",
             "colours": [],
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "fd2b2391-4a79-5724-9984-43f8380fb21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c27d6-dc3a-4420-bb35-d97dc216e002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27c27d6-dc3a-4420-bb35-d97dc216e002.jpg?1",
             "name": "Bear Trap",
             "text": "Flash\n{3}, {T}, Sacrifice Bear Trap: It deals 3 damage to target creature.",
             "colours": [],
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "eb26f5d6-e8de-5b3f-824f-2541480da797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf37c1a-096b-4306-97cf-bc4d4c47d4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf37c1a-096b-4306-97cf-bc4d4c47d4a1.jpg?1",
             "name": "Conductive Machete",
             "text": "When Conductive Machete enters, manifest dread, then attach Conductive Machete to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature gets +2/+1.\nEquip {4}",
             "colours": [],
@@ -9420,7 +9420,7 @@
         },
         {
             "id": "7bbc1f20-3388-5e00-9014-527b2d59d644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048bb2c6-91bd-4d6a-a070-c73d8277c264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048bb2c6-91bd-4d6a-a070-c73d8277c264.jpg?1",
             "name": "Dissection Tools",
             "text": "When Dissection Tools enters, manifest dread, then attach Dissection Tools to that creature.\nEquipped creature gets +2/+2 and has deathtouch and lifelink.\nEquip\u2014\nSacrifice a creature.",
             "colours": [],
@@ -9452,7 +9452,7 @@
         },
         {
             "id": "41c7c095-3248-5fd1-80f3-0abc0e9ca761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12eb087-762e-4e7d-a6e0-f48df603b7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12eb087-762e-4e7d-a6e0-f48df603b7c7.jpg?1",
             "name": "Found Footage",
             "text": "You may look at face-down creatures your opponents control any time.\n{2}, Sacrifice Found Footage: Surveil 2, then draw a card. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [],
@@ -9482,7 +9482,7 @@
         },
         {
             "id": "ee056c6d-15f1-5b5a-a94e-346c70756622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b142be-4586-487a-8dd8-a55eff776458.jpg?1",
             "name": "Friendly Teddy",
             "text": "When Friendly Teddy dies, each player draws a card.",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "c2ec2e17-401d-5f22-b37f-115bf70c41fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg?1",
             "name": "Ghost Vacuum",
             "text": "{T}: Exile target card from a graveyard.\n{6}, {T}, Sacrifice Ghost Vacuum: Put each creature card exiled with Ghost Vacuum onto the battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to its other types. Activate only as a sorcery.",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "deb12f49-09db-5dfd-a105-174b51c0db34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071691c-5c65-42d4-ac96-d302185ca678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071691c-5c65-42d4-ac96-d302185ca678.jpg?1",
             "name": "Glimmerlight",
             "text": "When Glimmerlight enters, create a 1/1 white Glimmer enchantment creature token.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "487d3471-44bb-59a9-91d5-0188bced4eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7d552f-a7ac-4a49-a582-9d378137005f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7d552f-a7ac-4a49-a582-9d378137005f.jpg?1",
             "name": "Haunted Screen",
             "text": "{T}: Add {W} or {B}.\n{T}, Pay 1 life: Add {G}, {U}, or {R}.\n{7}: Put seven +1/+1 counters on Haunted Screen. It becomes a 0/0 Spirit creature in addition to its other types. Activate only once.",
             "colours": [],
@@ -9608,7 +9608,7 @@
         },
         {
             "id": "2d19b129-8691-5527-9bed-4b8bb3f00bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c11a413-7f33-4b63-bdd9-e143e529f56d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c11a413-7f33-4b63-bdd9-e143e529f56d.jpg?1",
             "name": "Keys to the House",
             "text": "{1}, {T}, Sacrifice Keys to the House: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{3}, {T}, Sacrifice Keys to the House: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
             "colours": [],
@@ -9636,7 +9636,7 @@
         },
         {
             "id": "0193a02b-3977-5e0c-a77e-c33b71db25d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09d296-4493-47f7-ad76-ad76c747df78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09d296-4493-47f7-ad76-ad76c747df78.jpg?1",
             "name": "Malevolent Chandelier",
             "text": "Flying\n{2}: Put target card from a graveyard on the bottom of its owner's library. Activate only as a sorcery.",
             "colours": [],
@@ -9667,7 +9667,7 @@
         },
         {
             "id": "7842ec2a-7edc-5680-b6ab-c8707828afc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66898970-b99b-48f2-9240-68c301c95500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66898970-b99b-48f2-9240-68c301c95500.jpg?1",
             "name": "Marvin, Murderous Mimic",
             "text": "Marvin, Murderous Mimic has all activated abilities of creatures you control that don't have the same name as this creature.",
             "colours": [],
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "9f087ad0-b002-5d7f-a6b5-3fe7e1f71899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603c3ef4-4ef1-4db8-9ed2-e2b0926269d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603c3ef4-4ef1-4db8-9ed2-e2b0926269d5.jpg?1",
             "name": "Saw",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, you may sacrifice a permanent other than that creature or Saw. If you do, draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "b280bcf1-1373-5bfa-a6d5-c3e90bf7925f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0565f5-ebdb-43f9-bbb4-0485b1968937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0565f5-ebdb-43f9-bbb4-0485b1968937.jpg?1",
             "name": "Abandoned Campground",
             "text": "Abandoned Campground enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "3106d59e-a4f4-5cd4-8720-9c2fbe8ee7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151c8e2-d715-470d-868a-f45191db9fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d151c8e2-d715-470d-868a-f45191db9fa0.jpg?1",
             "name": "Blazemire Verge",
             "text": "{T}: Add {B}.\n{T}: Add {R}. Activate only if you control a Swamp or a Mountain.",
             "colours": [],
@@ -9796,7 +9796,7 @@
         },
         {
             "id": "b2cc16e6-79bd-56c0-b660-86ab1d10923c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb224874-aff5-461f-82ee-89b06663231a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb224874-aff5-461f-82ee-89b06663231a.jpg?1",
             "name": "Bleeding Woods",
             "text": "Bleeding Woods enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9827,7 +9827,7 @@
         },
         {
             "id": "96b237a3-84e0-5f3f-97cb-2130f66ff68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900b89-0e10-4602-bba2-da8d60ea5885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900b89-0e10-4602-bba2-da8d60ea5885.jpg?1",
             "name": "Etched Cornfield",
             "text": "Etched Cornfield enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9858,7 +9858,7 @@
         },
         {
             "id": "110c0fdc-c1b3-5027-a062-9022465fb47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ed0db-1199-44b3-8eda-8189dfcf53d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ed0db-1199-44b3-8eda-8189dfcf53d1.jpg?1",
             "name": "Floodfarm Verge",
             "text": "{T}: Add {W}.\n{T}: Add {U}. Activate only if you control a Plains or an Island.",
             "colours": [],
@@ -9891,7 +9891,7 @@
         },
         {
             "id": "2197641e-f184-5d7a-ac13-c467fc2e4b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f510b7-4cbd-4883-9c26-c8824bc668ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f510b7-4cbd-4883-9c26-c8824bc668ac.jpg?1",
             "name": "Gloomlake Verge",
             "text": "{T}: Add {U}.\n{T}: Add {B}. Activate only if you control an Island or a Swamp.",
             "colours": [],
@@ -9924,7 +9924,7 @@
         },
         {
             "id": "a6f3be16-22a5-5655-aace-bee1527ab595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec288d76-c1f5-471b-8a53-504f88469c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec288d76-c1f5-471b-8a53-504f88469c1b.jpg?1",
             "name": "Hushwood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {W}. Activate only if you control a Forest or a Plains.",
             "colours": [],
@@ -9957,7 +9957,7 @@
         },
         {
             "id": "ac39050a-f1b0-5dd8-9bb2-4075101a91ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9367acd-393a-4966-ba60-af2ecd4e7596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9367acd-393a-4966-ba60-af2ecd4e7596.jpg?1",
             "name": "Lakeside Shack",
             "text": "Lakeside Shack enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "42ec847f-fae8-53e4-8973-396c79dd08d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6098d8be-4e3f-455d-8799-91435bf45a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6098d8be-4e3f-455d-8799-91435bf45a1c.jpg?1",
             "name": "Murky Sewer",
             "text": "Murky Sewer enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "39350f1a-9160-51a1-9582-e74c7370c621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cf1531-8a3c-4e28-a114-d3a342b33bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cf1531-8a3c-4e28-a114-d3a342b33bb6.jpg?1",
             "name": "Neglected Manor",
             "text": "Neglected Manor enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10050,7 +10050,7 @@
         },
         {
             "id": "2d1e9d74-d182-5334-9a0e-2a06cbad4bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e40c0-e70e-4353-a920-9851cfac71dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e40c0-e70e-4353-a920-9851cfac71dd.jpg?1",
             "name": "Peculiar Lighthouse",
             "text": "Peculiar Lighthouse enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "22c9420e-993f-5784-ad36-5cae6c8dbccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3604a211-9bf7-474e-bd78-32a862f4259c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3604a211-9bf7-474e-bd78-32a862f4259c.jpg?1",
             "name": "Raucous Carnival",
             "text": "Raucous Carnival enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10112,7 +10112,7 @@
         },
         {
             "id": "3bdfeabf-e9c4-512a-a8ef-05cf89208535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d0d067-b52d-47ec-ba7b-8cfcd716c0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d0d067-b52d-47ec-ba7b-8cfcd716c0e5.jpg?1",
             "name": "Razortrap Gorge",
             "text": "Razortrap Gorge enters tapped unless a player has 13 or less life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "572333ff-8f00-5895-872a-2d50716c7b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ce9250-bdbe-4c77-9243-6db9ffffe69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ce9250-bdbe-4c77-9243-6db9ffffe69b.jpg?1",
             "name": "Strangled Cemetery",
             "text": "Strangled Cemetery enters tapped unless a player has 13 or less life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10174,7 +10174,7 @@
         },
         {
             "id": "80a92854-a04e-5203-87d3-5caab886a78c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b379c8f1-817c-4f18-8f58-45c40504433e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b379c8f1-817c-4f18-8f58-45c40504433e.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10202,7 +10202,7 @@
         },
         {
             "id": "9e39728c-ba50-5d30-814a-c25547182c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1cdc03-6faa-4138-9a52-caafbe34fb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1cdc03-6faa-4138-9a52-caafbe34fb59.jpg?1",
             "name": "Thornspire Verge",
             "text": "{T}: Add {R}.\n{T}: Add {G}. Activate only if you control a Mountain or a Forest.",
             "colours": [],
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "cbc36a0d-5ec5-51be-a24d-b89c7b5602f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff914e-3f3e-4b7a-b69d-73575b68fb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff914e-3f3e-4b7a-b69d-73575b68fb8e.jpg?1",
             "name": "Valgavoth's Lair",
             "text": "Hexproof\nValgavoth's Lair enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -10266,7 +10266,7 @@
         },
         {
             "id": "88dea124-b6f2-5890-8ec1-be2e74b8c588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67ce864-bf29-42f1-81ca-a98022892eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67ce864-bf29-42f1-81ca-a98022892eec.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10303,7 +10303,7 @@
         },
         {
             "id": "417e6ecf-e74f-5509-85d7-167d68762767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e3bf00-84cc-498c-b214-1052b4904d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e3bf00-84cc-498c-b214-1052b4904d92.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "7faf698f-7b41-5642-94a2-b55ba9ff5858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7442c1c7-1c10-4387-92e6-4bdea263064f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7442c1c7-1c10-4387-92e6-4bdea263064f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "b34bedff-8b29-5e46-bdad-a12a63da7b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8841b2-9b4e-4f65-8e30-1e9423cb8fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8841b2-9b4e-4f65-8e30-1e9423cb8fbc.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "d69ba27f-05d4-5f35-944e-147eba64ec36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a4cbb-f325-4178-80db-7090f5672414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2a4cbb-f325-4178-80db-7090f5672414.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10451,7 +10451,7 @@
         },
         {
             "id": "68b3cf6c-9a7e-56be-9518-942f93ef4aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b499b37-efaf-4484-95e8-a70a9778c804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b499b37-efaf-4484-95e8-a70a9778c804.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10488,7 +10488,7 @@
         },
         {
             "id": "50b89850-074b-5cfa-8cd1-addf6aaf944c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756abff9-9810-4e2d-b1d7-ec4e2d6d5187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756abff9-9810-4e2d-b1d7-ec4e2d6d5187.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10525,7 +10525,7 @@
         },
         {
             "id": "964a202d-195e-5753-8589-5a8a81990982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947702ca-d065-4368-9f26-f859d4642cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947702ca-d065-4368-9f26-f859d4642cb6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "fabcecd5-7c1e-5881-bf54-000581164c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d10d9c-8771-4870-aebf-e767d0fada32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d10d9c-8771-4870-aebf-e767d0fada32.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10599,7 +10599,7 @@
         },
         {
             "id": "d72a7d3f-15cc-55ae-9f80-cf1d72fa7983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c51de66-a3ed-4ca9-befb-9813e96c4ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c51de66-a3ed-4ca9-befb-9813e96c4ade.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10636,7 +10636,7 @@
         },
         {
             "id": "c6bc0f7a-916f-531c-8c81-d03843007720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd95de0-702a-4b88-a1cc-981cf1d9673e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd95de0-702a-4b88-a1cc-981cf1d9673e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "6b058c43-663c-5af1-9f0e-f429294ea437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accb56f0-3903-4894-86f0-3965162064d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accb56f0-3903-4894-86f0-3965162064d4.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "23e36a02-131b-5776-b42c-d19f35f0be9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44d8a4-21de-497d-9eed-702d7b592728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44d8a4-21de-497d-9eed-702d7b592728.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "f26c0259-765b-51bd-8081-6288f734bbce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c0880-728d-4ac2-b685-4f18f66c24db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c0880-728d-4ac2-b685-4f18f66c24db.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "ef3438e3-1028-5e37-9c74-98412ae9f536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da5fbc2-24ad-4520-a60a-436d3a485fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da5fbc2-24ad-4520-a60a-436d3a485fec.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10821,7 +10821,7 @@
         },
         {
             "id": "19442c19-47e0-5bef-905c-21500977133a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "When you unlock this door, create a 1/1 white Glimmer enchantment creature token.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -10857,7 +10857,7 @@
         },
         {
             "id": "cffe562a-3550-5992-9a83-36bd82ea6fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6ef39d0e-4caa-4808-949f-1d75e160dbc3.jpg?1",
             "name": "Grand Entryway // Elegant Rotunda",
             "text": "Elegant Rotunda\no2o\nW\nWhen you unlock this door, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -10893,7 +10893,7 @@
         },
         {
             "id": "22f31cf4-22c8-55a2-b778-90e2f06a6293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d6bd4-b03a-4d04-bc38-85b3ee39aa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d6bd4-b03a-4d04-bc38-85b3ee39aa8a.jpg?1",
             "name": "Optimistic Scavenger",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, put a +1/+1 counter on target creature.",
             "colours": [
@@ -10930,7 +10930,7 @@
         },
         {
             "id": "ac8f190a-296a-5fdd-9aa5-9d4982e77414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a6f3e-d517-4978-8958-db189fe3f1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693a6f3e-d517-4978-8958-db189fe3f1f9.jpg?1",
             "name": "Reluctant Role Model",
             "text": "Survival \u2014 At the beginning of your second main phase, if Reluctant Role Model is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever Reluctant Role Model or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
             "colours": [
@@ -10968,7 +10968,7 @@
         },
         {
             "id": "f9bfbb12-2c64-5e66-ab77-a7d7200bb510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0a079e-26f4-44ed-859a-f7df4b40a3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0a079e-26f4-44ed-859a-f7df4b40a3cd.jpg?1",
             "name": "Entity Tracker",
             "text": "Flash\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.",
             "colours": [
@@ -11006,7 +11006,7 @@
         },
         {
             "id": "cb7778ac-866c-580a-96c0-5e453300e8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd7bdd-2ba8-4658-9825-741aecad5f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd7bdd-2ba8-4658-9825-741aecad5f42.jpg?1",
             "name": "Stay Hidden, Stay Silent",
             "text": "Enchant creature\nWhen Stay Hidden, Stay Silent enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate only as a sorcery.",
             "colours": [
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "ad291d57-4d64-5ebf-a7d0-f6d6f518e6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abe8236-a9e3-435a-a459-833ec3af93c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abe8236-a9e3-435a-a459-833ec3af93c7.jpg?1",
             "name": "Come Back Wrong",
             "text": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -11077,7 +11077,7 @@
         },
         {
             "id": "90509dcf-d8d2-54c3-9d06-03df2beb443b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacb88b3-96a9-45e4-8053-2f8fcbe4028e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacb88b3-96a9-45e4-8053-2f8fcbe4028e.jpg?1",
             "name": "Meathook Massacre II",
             "text": "When Meathook Massacre II enters, each player sacrifices X creatures.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
             "colours": [
@@ -11114,7 +11114,7 @@
         },
         {
             "id": "edbe8957-ab3d-568a-8023-f7aeb5079b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d865cf-8c5f-4c27-a731-33564b01bc64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d865cf-8c5f-4c27-a731-33564b01bc64.jpg?1",
             "name": "Unstoppable Slasher",
             "text": "Deathtouch\nWhenever Unstoppable Slasher deals combat damage to a player, they lose half their life, rounded up.\nWhen Unstoppable Slasher dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
             "colours": [
@@ -11152,7 +11152,7 @@
         },
         {
             "id": "4b3dad97-5df6-5a2f-99ee-015bcd1eef66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44340c7-d3bb-4cf9-a105-ebbf6ce3ace1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44340c7-d3bb-4cf9-a105-ebbf6ce3ace1.jpg?1",
             "name": "Clockwork Percussionist",
             "text": "Haste\nWhen Clockwork Percussionist dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -11190,7 +11190,7 @@
         },
         {
             "id": "42473e28-ccc1-5006-a1e2-1ad851ee4592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d2c67b-b523-4da3-826e-5f56f19914ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d2c67b-b523-4da3-826e-5f56f19914ba.jpg?1",
             "name": "Cursed Recording",
             "text": "Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -11225,7 +11225,7 @@
         },
         {
             "id": "7e677483-6204-58e1-9b20-02fb9d93c187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f4026-b75a-4d74-871e-715ece0225d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f4026-b75a-4d74-871e-715ece0225d3.jpg?1",
             "name": "Norin, Swift Survivalist",
             "text": "Norin, Swift Survivalist can't block.\nWhenever a creature you control becomes blocked, you may exile it. You may play that card from exile this turn.",
             "colours": [
@@ -11264,7 +11264,7 @@
         },
         {
             "id": "993da63b-116d-50d4-a47f-fae97f31e453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb57a981-e70b-4298-b620-577914d67cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb57a981-e70b-4298-b620-577914d67cb7.jpg?1",
             "name": "The Rollercrusher Ride",
             "text": "Delirium \u2014 If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
             "colours": [
@@ -11301,7 +11301,7 @@
         },
         {
             "id": "e144b78e-aa1a-5a91-bad6-68501849e9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bfb93-c7f2-4a96-8c57-c356d8ce21c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3bfb93-c7f2-4a96-8c57-c356d8ce21c0.jpg?1",
             "name": "Kona, Rescue Beastie",
             "text": "Survival \u2014 At the beginning of your second main phase, if Kona, Rescue Beastie is tapped, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -11341,7 +11341,7 @@
         },
         {
             "id": "cb1140d2-067d-5c8d-9921-eacf76900018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f328937-6585-4325-a1f2-95facab2c58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f328937-6585-4325-a1f2-95facab2c58a.jpg?1",
             "name": "Oblivious Bookworm",
             "text": "At the beginning of your end step, you may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn.",
             "colours": [
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "b1cf80aa-ea29-58fd-a575-c25ef278215a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8fbdac-e3bb-4b6b-b210-febb23846c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8fbdac-e3bb-4b6b-b210-febb23846c23.jpg?1",
             "name": "The Swarmweaver",
             "text": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -11422,7 +11422,7 @@
         },
         {
             "id": "973ea2f6-d566-54ee-9f6f-52fa30003843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851b9caa-bb70-4d84-8139-b70867193922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851b9caa-bb70-4d84-8139-b70867193922.jpg?1",
             "name": "Ghostly Dancers",
             "text": "Flying\nWhen Ghostly Dancers enters, return an enchantment card from your graveyard to your hand or unlock a locked door of a Room you control.\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying.",
             "colours": [
@@ -11458,7 +11458,7 @@
         },
         {
             "id": "d18b7ca3-59f9-517e-81ae-66d2fb6845c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcea7eb-3174-4549-a1de-8dda577cd0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcea7eb-3174-4549-a1de-8dda577cd0b9.jpg?1",
             "name": "Reluctant Role Model",
             "text": "Survival \u2014 At the beginning of your second main phase, if Reluctant Role Model is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever Reluctant Role Model or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
             "colours": [
@@ -11496,7 +11496,7 @@
         },
         {
             "id": "7c6d2560-42d2-58a6-ab25-3493df542ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7428a157-67e8-48fb-9882-54bf3ae001e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7428a157-67e8-48fb-9882-54bf3ae001e3.jpg?1",
             "name": "Split Up",
             "text": "Choose one \u2014\n\u2022 Destroy all tapped creatures.\n\u2022 Destroy all untapped creatures.",
             "colours": [
@@ -11530,7 +11530,7 @@
         },
         {
             "id": "c06068c4-8840-5c92-906a-3e76012fd5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b1aa9-e94f-4654-88c7-9cea52f1bc0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426b1aa9-e94f-4654-88c7-9cea52f1bc0a.jpg?1",
             "name": "Unidentified Hovership",
             "text": "Flying\nWhen Unidentified Hovership enters, exile up to one target creature with toughness 5 or less.\nWhen Unidentified Hovership leaves the battlefield, the exiled card's owner manifests dread.\nCrew 1",
             "colours": [
@@ -11566,7 +11566,7 @@
         },
         {
             "id": "0e276c5f-6e3a-5d4e-9e55-ac18d2eb25be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be897dda-8603-4264-a022-87870f635b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be897dda-8603-4264-a022-87870f635b40.jpg?1",
             "name": "Unwanted Remake",
             "text": "Destroy target creature. Its controller manifests dread.",
             "colours": [
@@ -11600,7 +11600,7 @@
         },
         {
             "id": "ec5f5aef-28be-5b37-8785-b1a6c051d84f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885098d1-f9b4-429b-97b5-c5c448111e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885098d1-f9b4-429b-97b5-c5c448111e22.jpg?1",
             "name": "Entity Tracker",
             "text": "Flash\nEerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, draw a card.",
             "colours": [
@@ -11638,7 +11638,7 @@
         },
         {
             "id": "330df40e-c786-5f11-af85-036ea78948f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b976d642-3cf0-42c5-b3ba-12818e596f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b976d642-3cf0-42c5-b3ba-12818e596f9c.jpg?1",
             "name": "Marina Vendrell's Grimoire",
             "text": "When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.\nYou have no maximum hand size and don't lose the game for having 0 or less life.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.",
             "colours": [
@@ -11674,7 +11674,7 @@
         },
         {
             "id": "2ec8b11f-e0e7-5b58-aad1-ef1efbe1f5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8761b8-3583-422d-a23c-b3f0915ce15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8761b8-3583-422d-a23c-b3f0915ce15b.jpg?1",
             "name": "Come Back Wrong",
             "text": "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "4e2332bd-9af5-5b2e-ac67-2785d216c483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9defeb-d28e-451e-9333-914394231fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9defeb-d28e-451e-9333-914394231fbb.jpg?1",
             "name": "Demonic Counsel",
             "text": "Search your library for a Demon card, reveal it, put it into your hand, then shuffle.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead search your library for any card, put it into your hand, then shuffle.",
             "colours": [
@@ -11743,7 +11743,7 @@
         },
         {
             "id": "a6d354ec-b3de-5dd9-9896-8846fdceecbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3686075-cef4-48b7-ac50-3e27282a3f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3686075-cef4-48b7-ac50-3e27282a3f70.jpg?1",
             "name": "Meathook Massacre II",
             "text": "When Meathook Massacre II enters, each player sacrifices X creatures.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
             "colours": [
@@ -11780,7 +11780,7 @@
         },
         {
             "id": "64f888f1-6d59-5f43-80b5-67ab8d8cab21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30a301-8e87-46e7-89aa-cd55b1a14420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a30a301-8e87-46e7-89aa-cd55b1a14420.jpg?1",
             "name": "Unstoppable Slasher",
             "text": "Deathtouch\nWhenever Unstoppable Slasher deals combat damage to a player, they lose half their life, rounded up.\nWhen Unstoppable Slasher dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
             "colours": [
@@ -11818,7 +11818,7 @@
         },
         {
             "id": "cfacb253-c384-5fa8-afdd-9f16801dd20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e03d07-c491-4ea1-a2f7-49c022005059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e03d07-c491-4ea1-a2f7-49c022005059.jpg?1",
             "name": "Withering Torment",
             "text": "Destroy target creature or enchantment. You lose 2 life.",
             "colours": [
@@ -11852,7 +11852,7 @@
         },
         {
             "id": "347536dd-1930-5c48-9e2b-41772273e220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8d0f4e-6b1e-4444-8851-adf857273964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8d0f4e-6b1e-4444-8851-adf857273964.jpg?1",
             "name": "Chainsaw",
             "text": "When Chainsaw enters, it deals 3 damage to up to one target creature.\nWhenever one or more creatures die, put a rev counter on Chainsaw.\nEquipped creature gets +X/+0, where X is the number of rev counters on Chainsaw.\nEquip {3}",
             "colours": [
@@ -11888,7 +11888,7 @@
         },
         {
             "id": "3f5fe83a-3593-59b9-9b69-5b4fe2fbdfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aacedd1-de6b-4485-891e-0283ef33f3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aacedd1-de6b-4485-891e-0283ef33f3d4.jpg?1",
             "name": "Cursed Recording",
             "text": "Whenever you cast an instant or sorcery spell, put a time counter on Cursed Recording. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "be25b5f3-bc32-5e18-a18c-9c7296ed31de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b924a5-6533-4ca6-bd2e-32debdfb6c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b924a5-6533-4ca6-bd2e-32debdfb6c08.jpg?1",
             "name": "Fear of Missing Out",
             "text": "When Fear of Missing Out enters, discard a card, then draw a card.\nDelirium \u2014 Whenever Fear of Missing Out attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.",
             "colours": [
@@ -11960,7 +11960,7 @@
         },
         {
             "id": "46556200-fa70-50d9-abc7-9ed8787873fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d14e9ee-f82f-4062-b972-9486377dacdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d14e9ee-f82f-4062-b972-9486377dacdb.jpg?1",
             "name": "The Rollercrusher Ride",
             "text": "Delirium \u2014 If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
             "colours": [
@@ -11997,7 +11997,7 @@
         },
         {
             "id": "655b2363-c282-5ab4-aed3-ede090725418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcecce11-59e3-4c95-bff9-b02d004c917b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcecce11-59e3-4c95-bff9-b02d004c917b.jpg?1",
             "name": "Waltz of Rage",
             "text": "Target creature you control deals damage equal to its power to each other creature. Until end of turn, whenever a creature you control dies, exile the top card of your library. You may play it until the end of your next turn.",
             "colours": [
@@ -12031,7 +12031,7 @@
         },
         {
             "id": "56d4d205-3c35-5bc2-82d1-c710f0227ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7944c86-c578-48fa-b222-7fce3f5d301d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7944c86-c578-48fa-b222-7fce3f5d301d.jpg?1",
             "name": "Balustrade Wurm",
             "text": "This spell can't be countered.\nTrample, haste\nDelirium \u2014 {2}{G}{G}: Return Balustrade Wurm from your graveyard to the battlefield with a finality counter on it. Activate only if there are four or more card types among cards in your graveyard and only as a sorcery.",
             "colours": [
@@ -12067,7 +12067,7 @@
         },
         {
             "id": "558c09bd-54bd-5b50-921f-9623f36d6a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01595caa-7abd-4b47-8015-3754d8eb39cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01595caa-7abd-4b47-8015-3754d8eb39cf.jpg?1",
             "name": "Hedge Shredder",
             "text": "Whenever Hedge Shredder attacks, you may mill two cards.\nWhenever one or more land cards are put into your graveyard from your library, put them onto the battlefield tapped.\nCrew 1",
             "colours": [
@@ -12103,7 +12103,7 @@
         },
         {
             "id": "b5967616-0c58-5a8d-bf5b-679825298c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fadf08-c799-47da-8330-5d0df7b41ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fadf08-c799-47da-8330-5d0df7b41ca1.jpg?1",
             "name": "Insidious Fungus",
             "text": "{2}, Sacrifice Insidious Fungus: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Draw a card. Then you may put a land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -12139,7 +12139,7 @@
         },
         {
             "id": "c12af897-b531-598f-8e81-1967f859b032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f779cc02-2470-4fc0-ae08-503adeb8e0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f779cc02-2470-4fc0-ae08-503adeb8e0a9.jpg?1",
             "name": "Omnivorous Flytrap",
             "text": "Delirium \u2014 Whenever Omnivorous Flytrap enters or attacks, if there are four or more card types among cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if there are six or more card types among cards in your graveyard, double the number of +1/+1 counters on those creatures.",
             "colours": [
@@ -12175,7 +12175,7 @@
         },
         {
             "id": "c11d5507-883f-5ac9-acbe-ea35a6922a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb34e17-bc12-4a4e-a418-0dbd3e6665a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb34e17-bc12-4a4e-a418-0dbd3e6665a8.jpg?1",
             "name": "Under the Skin",
             "text": "Manifest dread.\nYou may return a permanent card from your graveyard to your hand.",
             "colours": [
@@ -12209,7 +12209,7 @@
         },
         {
             "id": "95cd918d-44c2-58c6-925d-30c39a1e8f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3518fbe6-5640-4aca-a2fd-e83c82d2e2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3518fbe6-5640-4aca-a2fd-e83c82d2e2fd.jpg?1",
             "name": "Valgavoth's Onslaught",
             "text": "Manifest dread X times, then put X +1/+1 counters on each of those creatures.",
             "colours": [
@@ -12243,7 +12243,7 @@
         },
         {
             "id": "7335ab48-f0bb-507a-915e-75c0d2f5e680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e7b3a-3fe2-4f3c-8292-b44e4a0fc5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70e7b3a-3fe2-4f3c-8292-b44e4a0fc5a4.jpg?1",
             "name": "Peer Past the Veil",
             "text": "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard.",
             "colours": [
@@ -12279,7 +12279,7 @@
         },
         {
             "id": "4767e37a-9413-5e69-a9ec-81edb7ea9a2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf254c0-7c3c-4b68-8b3e-4ae444baa886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf254c0-7c3c-4b68-8b3e-4ae444baa886.jpg?1",
             "name": "Ghost Vacuum",
             "text": "{T}: Exile target card from a graveyard.\n{6}, {T}, Sacrifice Ghost Vacuum: Put each creature card exiled with Ghost Vacuum onto the battlefield under your control with a flying counter on it. Each of them is a 1/1 Spirit in addition to its other types. Activate only as a sorcery.",
             "colours": [],
@@ -12309,7 +12309,7 @@
         },
         {
             "id": "e9b5b5ac-3d87-5efa-821a-50b686749bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5041f1-7cb8-4b60-94f6-436430bbece4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5041f1-7cb8-4b60-94f6-436430bbece4.jpg?1",
             "name": "Valgavoth's Lair",
             "text": "Hexproof\nValgavoth's Lair enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "a49df111-8e54-5a95-9b48-6e923eaa7854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d24cf8-107e-4b5b-a4f5-a7498647abef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d24cf8-107e-4b5b-a4f5-a7498647abef.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B}\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -12382,7 +12382,7 @@
         },
         {
             "id": "1c9d8c32-b605-5367-a741-66a916cfd120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a926c5-ba2b-4ac5-9717-6c9181f9a827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a926c5-ba2b-4ac5-9717-6c9181f9a827.jpg?1",
             "name": "Blazemire Verge",
             "text": "{T}: Add {B}.\n{T}: Add {R}. Activate only if you control a Swamp or a Mountain.",
             "colours": [],
@@ -12415,7 +12415,7 @@
         },
         {
             "id": "bd95beaf-970f-5cbd-9a8a-ee31a454e629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025152a1-4fdf-4e4e-a792-c540dd43fccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025152a1-4fdf-4e4e-a792-c540dd43fccd.jpg?1",
             "name": "Floodfarm Verge",
             "text": "{T}: Add {W}.\n{T}: Add {U}. Activate only if you control a Plains or an Island.",
             "colours": [],
@@ -12448,7 +12448,7 @@
         },
         {
             "id": "70bf27f5-14a8-5acd-9355-51581511b8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414e4bd-a443-4ab3-bee4-1ad1d039aa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414e4bd-a443-4ab3-bee4-1ad1d039aa1a.jpg?1",
             "name": "Gloomlake Verge",
             "text": "{T}: Add {U}.\n{T}: Add {B}. Activate only if you control an Island or a Swamp.",
             "colours": [],
@@ -12481,7 +12481,7 @@
         },
         {
             "id": "d50a02ae-7085-51a3-8eac-d75605d29a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b38f-11bf-4eb0-b333-4d605290e75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b38f-11bf-4eb0-b333-4d605290e75b.jpg?1",
             "name": "Hushwood Verge",
             "text": "{T}: Add {G}.\n{T}: Add {W}. Activate only if you control a Forest or a Plains.",
             "colours": [],
@@ -12514,7 +12514,7 @@
         },
         {
             "id": "2fff7faa-c02e-5713-aa10-715c5cb3ca75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a817f77d-19ea-4342-b90f-d92f62543303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a817f77d-19ea-4342-b90f-d92f62543303.jpg?1",
             "name": "Thornspire Verge",
             "text": "{T}: Add {R}.\n{T}: Add {G}. Activate only if you control a Mountain or a Forest.",
             "colours": [],
@@ -12547,7 +12547,7 @@
         },
         {
             "id": "b0331bd0-c891-5c5c-afb8-f833a4ad8001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "Creature spells you cast have convoke.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12583,7 +12583,7 @@
         },
         {
             "id": "479d07ed-b99a-5589-a657-c265b303388e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/988219dd-1b39-4c46-a3e3-844ca38e6e26.jpg?1",
             "name": "Dazzling Theater // Prop Room",
             "text": "Prop Room\no2o\nW\nUntap each creature you control during each other player's untap step.",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "43c9f704-7152-535e-ad83-994118eb0f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "Whenever one or more non-Toy creatures you control attack a player, create a 1/1 white Toy artifact creature token.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12655,7 +12655,7 @@
         },
         {
             "id": "84427b9c-7911-5254-bb94-a07a7bd36ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b9225ce-f29d-4235-8e9d-98a4fd159f73.jpg?1",
             "name": "Dollmaker's Shop // Porcelain Gallery",
             "text": "Porcelain Gallery\no4o\nWo\nW\nCreatures you control have base power and toughness each equal to the number of creatures you control.",
             "colours": [
@@ -12691,7 +12691,7 @@
         },
         {
             "id": "b6f94f62-1aa1-59a9-9a84-e0c987f49533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "When you unlock this door, search your library for a Room card that doesn't have the same name as a Room you control, reveal it, put it into your hand, then shuffle.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12727,7 +12727,7 @@
         },
         {
             "id": "8969cfa6-ff5e-5ba4-b45e-8d670f38d1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8634ba10-0312-4efe-9ddd-786c87d22131.jpg?1",
             "name": "Central Elevator // Promising Stairs",
             "text": "Promising Stairs\no2o\nU\nAt the beginning of your upkeep, surveil 1. You win the game if there are eight or more different names among unlocked doors of Rooms you control.",
             "colours": [
@@ -12763,7 +12763,7 @@
         },
         {
             "id": "61a43fa5-621a-5715-a73b-45f28dc12fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "When you unlock this door, create a token that's a copy of target creature you control, except it's a Reflection in addition to its other creature types.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12799,7 +12799,7 @@
         },
         {
             "id": "5717f16d-fdd4-5b3d-8b87-238ffb0d9e89",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/0/f0c32b23-0586-4ac2-9304-d90b4636e7ae.jpg?1",
             "name": "Mirror Room // Fractured Realm",
             "text": "Fractured Realm\no5o\nUo\nU\nIf a triggered ability of a permanent you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -12835,7 +12835,7 @@
         },
         {
             "id": "cbe4a5d4-be78-5772-88ab-16e17f031d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "c67f6f71-9a02-5428-9467-446d9c68d0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da30e940-acba-4f10-bd0e-3a0b165233f9.jpg?1",
             "name": "Funeral Room // Awakening Hall",
             "text": "Awakening Hall\no6o\nBo\nB\nWhen you unlock this door, return all creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -12907,7 +12907,7 @@
         },
         {
             "id": "e9fa1b75-f005-513a-8052-e9508196d5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "At the beginning of your end step, draw a card. If you control a Demon, each opponent loses 2 life and you gain 2 life. Otherwise, you lose 2 life.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -12943,7 +12943,7 @@
         },
         {
             "id": "240fed4e-493f-5d49-98ff-283f36f5298e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/681caa94-e95e-47f0-8305-eca0ed55cb5e.jpg?1",
             "name": "Unholy Annex // Ritual Chamber",
             "text": "Ritual Chamber\no3o\nBo\nB\nWhen you unlock this door, create a 6/6 black Demon creature token with flying.",
             "colours": [
@@ -12979,7 +12979,7 @@
         },
         {
             "id": "106efb13-af94-53db-aa8a-41b46d00d6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "At the beginning of your upkeep, exile the top card of your library. You may play it this turn.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13015,7 +13015,7 @@
         },
         {
             "id": "0208cfb4-ab12-50c5-b221-02e4b37b8ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c802966b-642c-4560-9c8e-e04adc9f41a4.jpg?1",
             "name": "Charred Foyer // Warped Space",
             "text": "Warped Space\no4o\nRo\nR\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.",
             "colours": [
@@ -13051,7 +13051,7 @@
         },
         {
             "id": "b21d6567-1307-52d4-9c6e-657491278d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "You may play lands from your graveyard.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13087,7 +13087,7 @@
         },
         {
             "id": "e4ebbef7-05dc-555c-9148-c23dead049c1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2e9868b-da2a-474d-8560-8bc4eb672cd3.jpg?1",
             "name": "Walk-In Closet // Forgotten Cellar",
             "text": "Forgotten Cellar\no3o\nGo\nG\nWhen you unlock this door, you may cast spells from your graveyard this turn, and if a card would be put into your graveyard from anywhere this turn, exile it instead.",
             "colours": [
@@ -13123,7 +13123,7 @@
         },
         {
             "id": "b90a5fdd-c423-5805-ac80-66ed20db2e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "When you unlock this door, destroy all creatures with power 3 or greater.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13160,7 +13160,7 @@
         },
         {
             "id": "9a7d5dcd-1978-5215-a870-095b8e95afd3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e35b3ab8-9230-469e-8c01-5f735fea5c9e.jpg?1",
             "name": "Restricted Office // Lecture Hall",
             "text": "Lecture Hall\no5o\nUo\nU\nOther permanents you control have hexproof.",
             "colours": [
@@ -13197,7 +13197,7 @@
         },
         {
             "id": "4e16a9c5-2aad-5cb9-babf-847d50ba41dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "When you unlock this door, this Room deals damage equal to the number of cards in your hand to target creature an opponent controls.\n\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13234,7 +13234,7 @@
         },
         {
             "id": "dc3ba564-5288-5dc6-8419-47a3e4f56fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe8e3d06-ae97-4f92-a379-b54e183e2aa0.jpg?1",
             "name": "Roaring Furnace // Steaming Sauna",
             "text": "At the beginning of your end step, draw a card.\n\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
             "colours": [
@@ -13271,7 +13271,7 @@
         },
         {
             "id": "d2074c78-c6f4-575b-8cd1-11fc33ca066b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f89402a-ef5c-47c1-8cef-f40920f98fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f89402a-ef5c-47c1-8cef-f40920f98fac.jpg?1",
             "name": "Abhorrent Oculus",
             "text": "As an additional cost to cast this spell, exile six cards from your graveyard.\nFlying\nAt the beginning of each opponent's upkeep, manifest dread.",
             "colours": [
@@ -13307,7 +13307,7 @@
         },
         {
             "id": "3a9d24d5-b2e9-5002-ae8a-325d52b4d782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ee370f-99d1-44bc-9952-29bcafbf7887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ee370f-99d1-44bc-9952-29bcafbf7887.jpg?1",
             "name": "Silent Hallcreeper",
             "text": "Silent Hallcreeper can't be blocked.\nWhenever Silent Hallcreeper deals combat damage to a player, choose one that hasn't been chosen \u2014\n\u2022 Put two +1/+1 counters on Silent Hallcreeper.\n\u2022 Draw a card.\n\u2022 Silent Hallcreeper becomes a copy of another target creature you control.",
             "colours": [
@@ -13344,7 +13344,7 @@
         },
         {
             "id": "a1c4e8a7-dda6-5b67-a794-9c4afa2a1732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f9cecb-0ff7-4837-a8c5-4af394834e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f9cecb-0ff7-4837-a8c5-4af394834e2c.jpg?1",
             "name": "Doomsday Excruciator",
             "text": "Flying\nWhen Doomsday Excruciator enters, if it was cast, each player exiles all but the bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card.",
             "colours": [
@@ -13380,7 +13380,7 @@
         },
         {
             "id": "f99449ac-909d-5223-83e0-6864e5783443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c34cb6-c8cb-4814-a647-9c63b10f02c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c34cb6-c8cb-4814-a647-9c63b10f02c4.jpg?1",
             "name": "Razorkin Needlehead",
             "text": "Razorkin Needlehead has first strike during your turn.\nWhenever an opponent draws a card, Razorkin Needlehead deals 1 damage to them.",
             "colours": [
@@ -13417,7 +13417,7 @@
         },
         {
             "id": "1868eb33-898c-592e-8938-2762df5392df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3f4c72-ff6e-4d7f-8eb8-45a0a9605fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3f4c72-ff6e-4d7f-8eb8-45a0a9605fc0.jpg?1",
             "name": "Screaming Nemesis",
             "text": "Haste\nWhenever Screaming Nemesis is dealt damage, it deals that much damage to any other target. If a player is dealt damage this way, they can't gain life for the rest of the game.",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "f908049c-dfb2-5805-a872-165982c821a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6148f7-01cb-4789-87a6-53d741f44ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6148f7-01cb-4789-87a6-53d741f44ec2.jpg?1",
             "name": "Hauntwoods Shrieker",
             "text": "Whenever Hauntwoods Shrieker attacks, manifest dread.\n{1}{G}: Reveal target face-down permanent. If it's a creature card, you may turn it face up.",
             "colours": [
@@ -13490,7 +13490,7 @@
         },
         {
             "id": "b9048d8c-b2ee-5a73-8c77-f839e4906266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef349a98-d4df-4eab-81e3-96a74aff5902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef349a98-d4df-4eab-81e3-96a74aff5902.jpg?1",
             "name": "Undead Sprinter",
             "text": "Trample, haste\nYou may cast Undead Sprinter from your graveyard if a non-Zombie creature died this turn. If you do, Undead Sprinter enters with a +1/+1 counter on it.",
             "colours": [
@@ -13528,7 +13528,7 @@
         },
         {
             "id": "5e9a11f3-2f98-57a4-8ca9-92364c87663d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e3837d-0481-42cd-a7da-56b7e5cb1b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e3837d-0481-42cd-a7da-56b7e5cb1b7e.jpg?1",
             "name": "The Wandering Rescuer",
             "text": "Flash, convoke\nDouble strike\nOther tapped creatures you control have hexproof.",
             "colours": [
@@ -13569,7 +13569,7 @@
         },
         {
             "id": "672bd9fa-0986-5f36-aeed-378ee1a42483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee79357-2488-41a1-8f8c-dfcb77206f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee79357-2488-41a1-8f8c-dfcb77206f8a.jpg?1",
             "name": "Valgavoth, Terror Eater",
             "text": "Flying, lifelink\nWard\u2014\nSacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
             "colours": [
@@ -13609,7 +13609,7 @@
         },
         {
             "id": "3a4f831f-241a-5d58-8fb0-a5dc146a1453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6f8dd7-6ec8-44b5-8827-192f255c4211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6f8dd7-6ec8-44b5-8827-192f255c4211.jpg?1",
             "name": "Tyvar, the Pummeler",
             "text": "Tap another untapped creature you control: Tyvar, the Pummeler gains indestructible until end of turn. Tap it.\n{3}{G}{G}: Creatures you control get +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -13649,7 +13649,7 @@
         },
         {
             "id": "5f44be78-a515-53c1-b985-ef1d1c1d05cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7927a69-62a9-4f69-923d-f651bb03a7b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7927a69-62a9-4f69-923d-f651bb03a7b4.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B}\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -13691,7 +13691,7 @@
         },
         {
             "id": "751a2866-6910-5e9b-8dcd-f688da724cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6f4e4e-8c3c-4860-bc9e-cbce44bcdc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6f4e4e-8c3c-4860-bc9e-cbce44bcdc23.jpg?1",
             "name": "Niko, Light of Hope",
             "text": "When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -13733,7 +13733,7 @@
         },
         {
             "id": "af2e51b4-3ad1-5091-8d98-847ab94d833e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafe5755-88b0-4fee-8596-4232844f60fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafe5755-88b0-4fee-8596-4232844f60fc.jpg?1",
             "name": "Toby, Beastie Befriender",
             "text": "When Toby, Beastie Befriender enters, create a 4/4 white Beast creature token with \"This creature can't attack or block alone.\"\nAs long as you control four or more creature tokens, creature tokens you control have flying.",
             "colours": [
@@ -13772,7 +13772,7 @@
         },
         {
             "id": "aa800869-c538-5340-998e-f4d582008bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3130a342-3c98-4c69-975b-a958ccddfe37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3130a342-3c98-4c69-975b-a958ccddfe37.jpg?1",
             "name": "The Mindskinner",
             "text": "The Mindskinner can't be blocked.\nIf a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.",
             "colours": [
@@ -13811,7 +13811,7 @@
         },
         {
             "id": "33e7c53b-73a6-5051-a913-b71d6ebf4f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf256f95-d184-4ea9-9039-fc64f461d9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf256f95-d184-4ea9-9039-fc64f461d9b3.jpg?1",
             "name": "Kona, Rescue Beastie",
             "text": "Survival \u2014 At the beginning of your second main phase, if Kona, Rescue Beastie is tapped, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -13851,7 +13851,7 @@
         },
         {
             "id": "f37e0aa7-0009-5d16-9b7b-82501b21d405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594df270-02d0-438b-a758-c32d71e8d4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594df270-02d0-438b-a758-c32d71e8d4ff.jpg?1",
             "name": "The Jolly Balloon Man",
             "text": "Haste\n{1}, {T}: Create a token that's a copy of another target creature you control, except it's a 1/1 red Balloon creature in addition to its other colors and types and it has flying and haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -13892,7 +13892,7 @@
         },
         {
             "id": "7e15c1f3-b4db-5e06-a890-2d66d9cbf33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6424845-7e9b-4514-93aa-1cf6c45f634c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6424845-7e9b-4514-93aa-1cf6c45f634c.jpg?1",
             "name": "Marina Vendrell",
             "text": "When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment cards from among them into your hand and the rest on the bottom of your library in a random order.\n{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
             "colours": [
@@ -13939,7 +13939,7 @@
         },
         {
             "id": "75d4fdf4-54d5-54e0-a99a-8daaab67db53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aa4f0c-7b2b-44cc-a59f-95f276b25898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aa4f0c-7b2b-44cc-a59f-95f276b25898.jpg?1",
             "name": "Nashi, Searcher in the Dark",
             "text": "Menace\nWhenever Nashi, Searcher in the Dark deals combat damage to a player, you mill that many cards. You may put any number of legendary and/or enchantment cards from among them into your hand. If you put no cards into your hand this way, put a +1/+1 counter on Nashi.",
             "colours": [
@@ -13981,7 +13981,7 @@
         },
         {
             "id": "32132e69-43a3-5f12-affe-b18b2e67a5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8da0e-7822-4e8b-b073-5d4edcb38c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8da0e-7822-4e8b-b073-5d4edcb38c59.jpg?1",
             "name": "Rip, Spawn Hunter",
             "text": "Survival \u2014 At the beginning of your second main phase, if Rip, Spawn Hunter is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14022,7 +14022,7 @@
         },
         {
             "id": "32467dbb-b1a5-552f-a24a-cf1d44ef310f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4542e4f-2fb7-4036-aefc-291f5c010ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4542e4f-2fb7-4036-aefc-291f5c010ca8.jpg?1",
             "name": "The Swarmweaver",
             "text": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -14064,7 +14064,7 @@
         },
         {
             "id": "694263f8-4b3d-5367-9f67-85b586e80693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db4440e-0107-434d-9d8e-77a11bc0245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db4440e-0107-434d-9d8e-77a11bc0245a.jpg?1",
             "name": "Victor, Valgavoth's Seneschal",
             "text": "Eerie \u2014 Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -14105,7 +14105,7 @@
         },
         {
             "id": "a416758a-699e-5415-b799-a00716921f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf9f742-a662-46b3-84e1-1609177d0c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf9f742-a662-46b3-84e1-1609177d0c8a.jpg?1",
             "name": "Winter, Misanthropic Guide",
             "text": "Ward {2}\nAt the beginning of your upkeep, each player draws two cards.\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, each opponent's maximum hand size is equal to seven minus the number of those card types.",
             "colours": [
@@ -14148,7 +14148,7 @@
         },
         {
             "id": "b71ae479-1a85-59da-8e6a-4b34d3754ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8af5a2b-b87e-4ee2-88bd-f80670559875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8af5a2b-b87e-4ee2-88bd-f80670559875.jpg?1",
             "name": "Zimone, All-Questioning",
             "text": "At the beginning of your end step, if a land entered the battlefield under your control this turn and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters on it. (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, and 31 are prime numbers.)",
             "colours": [
@@ -14189,7 +14189,7 @@
         },
         {
             "id": "ef5b3dce-b005-5205-9d6f-443813832d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f107a-ce90-464c-8be0-eb6c1db0f80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f107a-ce90-464c-8be0-eb6c1db0f80f.jpg?1",
             "name": "Marvin, Murderous Mimic",
             "text": "Marvin, Murderous Mimic has all activated abilities of creatures you control that don't have the same name as this creature.",
             "colours": [],
@@ -14224,7 +14224,7 @@
         },
         {
             "id": "f0906ea0-800f-54ad-b1c4-651bad927053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d908299-aac0-46a6-8fa5-780d5b3e0386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d908299-aac0-46a6-8fa5-780d5b3e0386.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14264,7 +14264,7 @@
         },
         {
             "id": "b9ab0570-0f37-5a45-8c8a-fafe7560de7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6209ca8-3a2a-4c0a-9f86-54283af9df75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6209ca8-3a2a-4c0a-9f86-54283af9df75.jpg?1",
             "name": "Leyline of Hope",
             "text": "If Leyline of Hope is in your opening hand, you may begin the game with it on the battlefield.\nIf you would gain life, you gain that much life plus 1 instead.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -14298,7 +14298,7 @@
         },
         {
             "id": "6e0eeee9-968f-5f52-a80f-ac9669ede1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509735a5-2b41-4e52-9ab1-0e4a6fa41d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509735a5-2b41-4e52-9ab1-0e4a6fa41d1b.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W}\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -14338,7 +14338,7 @@
         },
         {
             "id": "9cc887e8-2eda-5564-998f-12262dd12e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce740fb7-d2d1-451b-bfa0-27364b804161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce740fb7-d2d1-451b-bfa0-27364b804161.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14378,7 +14378,7 @@
         },
         {
             "id": "2893b439-f2be-5919-bacd-39ff6074a6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd545d86-9a3e-4e4f-b0fe-9363a85b9290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd545d86-9a3e-4e4f-b0fe-9363a85b9290.jpg?1",
             "name": "Leyline of Transformation",
             "text": "If Leyline of Transformation is in your opening hand, you may begin the game with it on the battlefield.\nAs Leyline of Transformation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -14412,7 +14412,7 @@
         },
         {
             "id": "247c977e-1c4e-585a-9b16-292964cbf9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d446b-75ac-49d8-911a-73d17419ff05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d446b-75ac-49d8-911a-73d17419ff05.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U}\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -14452,7 +14452,7 @@
         },
         {
             "id": "fdf30502-4f67-55b3-bbe6-a4df64c17fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2d0033-1a73-4927-93a9-76d00ae7c6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2d0033-1a73-4927-93a9-76d00ae7c6a8.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14492,7 +14492,7 @@
         },
         {
             "id": "2213e850-5456-5b3c-b1d2-e26760474bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3222c21-8d81-487d-a0c4-2413b30a26ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3222c21-8d81-487d-a0c4-2413b30a26ab.jpg?1",
             "name": "Grievous Wound",
             "text": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
             "colours": [
@@ -14529,7 +14529,7 @@
         },
         {
             "id": "8845dda6-859c-5c7c-88eb-5bf7d9bc6ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a559e-79f9-479e-8ef1-65fb91b9507d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30a559e-79f9-479e-8ef1-65fb91b9507d.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14563,7 +14563,7 @@
         },
         {
             "id": "07b5ac1e-5471-568a-a5dd-a719f07c53de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da8e15d-033e-41ab-9f95-656a5737bdac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da8e15d-033e-41ab-9f95-656a5737bdac.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B}\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -14603,7 +14603,7 @@
         },
         {
             "id": "9f0a3f02-5861-5543-a7a3-00dcb460da5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c10aa8-111a-4b02-a0a4-fee4c17f9c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c10aa8-111a-4b02-a0a4-fee4c17f9c24.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14643,7 +14643,7 @@
         },
         {
             "id": "d114ce3b-ca03-5e67-afc1-3248ffc58fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c006baf9-451e-461c-9355-7bf5a4f0d601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c006baf9-451e-461c-9355-7bf5a4f0d601.jpg?1",
             "name": "Leyline of Resonance",
             "text": "If Leyline of Resonance is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you cast an instant or sorcery spell that targets only a single creature you control, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -14677,7 +14677,7 @@
         },
         {
             "id": "979866cb-6f0b-5aa6-9641-3a7931c6f85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27266b27-3f16-4690-aaa0-07ea10b37bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27266b27-3f16-4690-aaa0-07ea10b37bb6.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R}\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -14717,7 +14717,7 @@
         },
         {
             "id": "16127a67-7da4-5783-bacc-14a05a035123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400eaca3-d7ee-4334-bade-1b05f3591417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400eaca3-d7ee-4334-bade-1b05f3591417.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14757,7 +14757,7 @@
         },
         {
             "id": "229dffa7-5f3d-5718-bd94-ab77cca01c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5ad232-9863-454f-9455-9725e69fa33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5ad232-9863-454f-9455-9725e69fa33f.jpg?1",
             "name": "Leyline of Mutation",
             "text": "If Leyline of Mutation is in your opening hand, you may begin the game with it on the battlefield.\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -14795,7 +14795,7 @@
         },
         {
             "id": "57a5414c-5d04-577f-b742-0ba8036d4357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3832d950-eb12-470f-9593-0f10d2a3a0f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3832d950-eb12-470f-9593-0f10d2a3a0f2.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G}\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -14835,7 +14835,7 @@
         },
         {
             "id": "87f1d396-965d-5f6c-99b6-70e7ca242c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47d003-bbdb-4c58-a648-3f0d7474f326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47d003-bbdb-4c58-a648-3f0d7474f326.jpg?1",
             "name": "Twitching Doll",
             "text": "{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.",
             "colours": [
@@ -14874,7 +14874,7 @@
         },
         {
             "id": "30ad74fb-3bee-51c7-93f0-9dd2027e65c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a376a56-7385-4d64-bbaa-952218531a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a376a56-7385-4d64-bbaa-952218531a76.jpg?1",
             "name": "Dissection Tools",
             "text": "When Dissection Tools enters, manifest dread, then attach Dissection Tools to that creature.\nEquipped creature gets +2/+2 and has deathtouch and lifelink.\nEquip\u2014\nSacrifice a creature.",
             "colours": [],
@@ -14906,7 +14906,7 @@
         },
         {
             "id": "51496970-cd7a-5092-8259-064abf12ff21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aca1ee8-c1ae-4052-b9d0-1a2903f61c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aca1ee8-c1ae-4052-b9d0-1a2903f61c88.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -14945,7 +14945,7 @@
         },
         {
             "id": "6ab6838d-e055-5d26-abef-b3b351095fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1951ed76-16a1-4639-b824-08dfc3d6d098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1951ed76-16a1-4639-b824-08dfc3d6d098.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W}\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -14984,7 +14984,7 @@
         },
         {
             "id": "e4b55305-dee6-5d99-b509-cd061887bae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3b6b0-ad74-43d1-bf2d-fc830214bdb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3b6b0-ad74-43d1-bf2d-fc830214bdb4.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15023,7 +15023,7 @@
         },
         {
             "id": "f56b3e8f-6675-5472-b554-908826b6eaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194a6f4-f994-494c-aa29-1de8af48a3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194a6f4-f994-494c-aa29-1de8af48a3f1.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U}\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -15062,7 +15062,7 @@
         },
         {
             "id": "c54b8502-5b07-5dc5-91f0-6ae7809bc3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74a0fbc-7150-4c44-983f-ac31e74644fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74a0fbc-7150-4c44-983f-ac31e74644fd.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "6310903c-32e2-5af5-a1d9-c0d2f305e678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49993a18-f733-4d1f-b629-12fc45cbb327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49993a18-f733-4d1f-b629-12fc45cbb327.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B}\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "faf000af-fcb3-528d-95a2-eb5a05b4e542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c7fa72-3c5f-49db-95f0-9a1c5d404651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c7fa72-3c5f-49db-95f0-9a1c5d404651.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15179,7 +15179,7 @@
         },
         {
             "id": "d2ab71a2-f0f4-5f38-82aa-caae7a6c94c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8607011b-0222-47c2-a537-b817dff93541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8607011b-0222-47c2-a537-b817dff93541.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R}\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -15218,7 +15218,7 @@
         },
         {
             "id": "8a318aa5-c25a-5374-9d4f-771b8f233511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999c030-66c1-41f3-b59a-8ba1ef5a756c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999c030-66c1-41f3-b59a-8ba1ef5a756c.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15257,7 +15257,7 @@
         },
         {
             "id": "60743256-48fa-5f6e-9d91-ba2759e56f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033440c-7d52-4f2c-bc62-ccd6d587d528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033440c-7d52-4f2c-bc62-ccd6d587d528.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G}\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -15296,7 +15296,7 @@
         },
         {
             "id": "ed600f8f-76d9-5f3a-bb05-bc67e6b503ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc36adbc-544c-46a1-9e99-92cc7b2b2af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc36adbc-544c-46a1-9e99-92cc7b2b2af1.jpg?1",
             "name": "Enduring Innocence",
             "text": "Lifelink\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.\nWhen Enduring Innocence dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15335,7 +15335,7 @@
         },
         {
             "id": "3925b792-cedf-5a10-84df-54801070f72f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2c4873-dfa7-4dd8-aded-a5d1b6048ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2c4873-dfa7-4dd8-aded-a5d1b6048ad7.jpg?1",
             "name": "Overlord of the Mistmoors",
             "text": "Impending 4\u2014{2}{W}{W}\nWhenever Overlord of the Mistmoors enters or attacks, create two 2/1 white Insect creature tokens with flying.",
             "colours": [
@@ -15374,7 +15374,7 @@
         },
         {
             "id": "adae6f77-9e5e-5d03-a9d5-50c164f30e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c10e8d-b393-41fd-ba31-5e39b2dc7cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c10e8d-b393-41fd-ba31-5e39b2dc7cce.jpg?1",
             "name": "Enduring Curiosity",
             "text": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15413,7 +15413,7 @@
         },
         {
             "id": "81e52a5c-918d-5696-b991-04b4b6f61081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42de20-43af-4c37-a5af-aa7c48699596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42de20-43af-4c37-a5af-aa7c48699596.jpg?1",
             "name": "Overlord of the Floodpits",
             "text": "Impending 4\u2014{1}{U}{U}\nFlying\nWhenever Overlord of the Floodpits enters or attacks, draw two cards, then discard a card.",
             "colours": [
@@ -15452,7 +15452,7 @@
         },
         {
             "id": "346910ee-bd22-5c18-8a36-03650bc45b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b698d6-4107-45d3-bc27-fb0746b7f91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b698d6-4107-45d3-bc27-fb0746b7f91a.jpg?1",
             "name": "Enduring Tenacity",
             "text": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15491,7 +15491,7 @@
         },
         {
             "id": "2f6190a3-9bb9-5589-9e66-4cb7c5f53432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49df3de4-ed62-4828-8256-a05220d9eada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49df3de4-ed62-4828-8256-a05220d9eada.jpg?1",
             "name": "Overlord of the Balemurk",
             "text": "Impending 5\u2014{1}{B}\nWhenever Overlord of the Balemurk enters or attacks, mill four cards, then you may return a non-Avatar creature card or a planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -15530,7 +15530,7 @@
         },
         {
             "id": "2b8d4174-966b-57b8-be31-3b96f8d3c294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07d4d21-2a88-4cfc-b0ce-9def76c20b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07d4d21-2a88-4cfc-b0ce-9def76c20b7d.jpg?1",
             "name": "Enduring Courage",
             "text": "Whenever another creature you control enters, it gets +2/+0 and gains haste until end of turn.\nWhen Enduring Courage dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15569,7 +15569,7 @@
         },
         {
             "id": "0da7a5cf-87e5-573e-a052-7c7803fba119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8c085e-db0e-45a8-96d0-80b480361771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8c085e-db0e-45a8-96d0-80b480361771.jpg?1",
             "name": "Overlord of the Boilerbilges",
             "text": "Impending 4\u2014{2}{R}{R}\nWhenever Overlord of the Boilerbilges enters or attacks, it deals 4 damage to any target.",
             "colours": [
@@ -15608,7 +15608,7 @@
         },
         {
             "id": "944c3bb6-4108-5ea7-8038-2e3decb99886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8c711f-f29f-4f6a-88c4-3dbf9ce471c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8c711f-f29f-4f6a-88c4-3dbf9ce471c3.jpg?1",
             "name": "Enduring Vitality",
             "text": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
             "colours": [
@@ -15647,7 +15647,7 @@
         },
         {
             "id": "2114a245-a82b-5b57-9990-5d7d9de30da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f3ecff-2d67-4676-8706-9191d67215fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f3ecff-2d67-4676-8706-9191d67215fc.jpg?1",
             "name": "Overlord of the Hauntwoods",
             "text": "Impending 4\u2014{1}{G}{G}\nWhenever Overlord of the Hauntwoods enters or attacks, create a tapped colorless land token named Everywhere that is every basic land type.",
             "colours": [
@@ -15686,7 +15686,7 @@
         },
         {
             "id": "ad242519-e249-5cb9-9b5c-49e5f7def9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a4f2ba-2d16-4dda-85e8-dafce0d5ee1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a4f2ba-2d16-4dda-85e8-dafce0d5ee1b.jpg?1",
             "name": "The Wandering Rescuer",
             "text": "Flash, convoke\nDouble strike\nOther tapped creatures you control have hexproof.",
             "colours": [
@@ -15726,7 +15726,7 @@
         },
         {
             "id": "3128d29a-1d2b-54f3-b372-ef82ee7beffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497ec48f-5e6a-4f57-86ca-3640b7235002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497ec48f-5e6a-4f57-86ca-3640b7235002.jpg?1",
             "name": "Valgavoth, Terror Eater",
             "text": "Flying, lifelink\nWard\u2014\nSacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
             "colours": [
@@ -15765,7 +15765,7 @@
         },
         {
             "id": "f8603604-9038-55aa-b7cd-595cd52d01c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd10920a-25b2-4191-b7f2-c43dbd1c5cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd10920a-25b2-4191-b7f2-c43dbd1c5cc5.jpg?1",
             "name": "Tyvar, the Pummeler",
             "text": "Tap another untapped creature you control: Tyvar, the Pummeler gains indestructible until end of turn. Tap it.\n{3}{G}{G}: Creatures you control get +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -15804,7 +15804,7 @@
         },
         {
             "id": "be1407df-ab32-5ed4-9834-5502738e6b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14901700-881a-4c79-b162-aeeb1579757e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14901700-881a-4c79-b162-aeeb1579757e.jpg?1",
             "name": "Kaito, Bane of Nightmares",
             "text": "Ninjutsu {1}{U}{B}\nDuring your turn, as long as Kaito has one or more loyalty counters on him, he's a 3/4 Ninja creature and has hexproof.\n+1: You get an emblem with \"Ninjas you control get +1/+1.\"\n0: Surveil 2. Then draw a card for each opponent who lost life this turn.\n\u22122: Tap target creature. Put two stun counters on it.",
             "colours": [
@@ -15845,7 +15845,7 @@
         },
         {
             "id": "d54622bc-0243-5640-a65b-62151ebd34a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54c9d18-76d7-4c24-ab19-7ad57d9a33a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54c9d18-76d7-4c24-ab19-7ad57d9a33a4.jpg?1",
             "name": "Niko, Light of Hope",
             "text": "When Niko, Light of Hope enters, create two Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n{2}, {T}: Exile target nonlegendary creature you control. Shards you control become copies of it until the beginning of the next end step. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -15886,7 +15886,7 @@
         },
         {
             "id": "f1b62f27-655d-554b-bf06-e80e2b943c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05652e01-1144-4214-b962-c34f677e0a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05652e01-1144-4214-b962-c34f677e0a07.jpg?1",
             "name": "Shardmage's Rescue",
             "text": "Flash\nEnchant creature you control\nAs long as Shardmage's Rescue entered this turn, enchanted creature has hexproof.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -15922,7 +15922,7 @@
         },
         {
             "id": "744a4ac3-612d-5c14-9228-da3a309dea82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ef0c5b-4bcf-435f-b9bb-c8175c7b4257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ef0c5b-4bcf-435f-b9bb-c8175c7b4257.jpg?1",
             "name": "Valgavoth's Faithful",
             "text": "{3}{B}, Sacrifice Valgavoth's Faithful: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -15959,7 +15959,7 @@
         },
         {
             "id": "7212101e-a2ac-58c7-9350-2dc5839b67e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4005974-fac5-465f-b742-bcb41eb8ba74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4005974-fac5-465f-b742-bcb41eb8ba74.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -15993,7 +15993,7 @@
         },
         {
             "id": "9c70b55c-aec1-58e9-95be-635c230b6e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f764d201-b62e-4968-a1fc-a69247859854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f764d201-b62e-4968-a1fc-a69247859854.jpg?1",
             "name": "Drag to the Roots",
             "text": "Delirium \u2014 This spell costs {2} less to cast as long as there are four or more card types among cards in your graveyard.\nDestroy target nonland permanent.",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "f1d1a127-5678-5abf-97c6-862dc129bbe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cc1465-ee00-40f4-aaa9-02f0465beb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cc1465-ee00-40f4-aaa9-02f0465beb88.jpg?1",
             "name": "Inquisitive Glimmer",
             "text": "Enchantment spells you cast cost {1} less to cast.\nUnlock costs you pay cost {1} less.",
             "colours": [
@@ -16069,7 +16069,7 @@
         },
         {
             "id": "42d28e51-7afd-59e9-9366-fd2f21fa3d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea4b0aa-7ed8-4e1c-867b-50754447f41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea4b0aa-7ed8-4e1c-867b-50754447f41b.jpg?1",
             "name": "Grievous Wound",
             "text": "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
             "colours": [
@@ -16105,7 +16105,7 @@
         },
         {
             "id": "911f4ff9-dd3b-58d9-bffe-7d516e669103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23684053-024e-4e15-8aec-de3d4bc7f126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23684053-024e-4e15-8aec-de3d4bc7f126.jpg?1",
             "name": "Twitching Doll",
             "text": "{T}: Add one mana of any color. Put a nest counter on Twitching Doll.\n{T}, Sacrifice Twitching Doll: Create a 2/2 green Spider creature token with reach for each counter on Twitching Doll. Activate only as a sorcery.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "3bbbe9b2-6a32-575f-90af-6b419debf932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19112b9-1583-445d-bc48-5ca3325fab48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19112b9-1583-445d-bc48-5ca3325fab48.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -16170,7 +16170,7 @@
         },
         {
             "id": "2310bee9-2b1f-58ea-b586-707024457259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a198942-049c-4537-b5b1-d35df32d45d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a198942-049c-4537-b5b1-d35df32d45d5.jpg?1",
             "name": "Shard",
             "text": "",
             "colours": [],
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "55726f99-c11b-58f8-91d9-1c84759541ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43e18d8-529d-4d63-b627-b9d9fa4f3f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43e18d8-529d-4d63-b627-b9d9fa4f3f38.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -16236,7 +16236,7 @@
         },
         {
             "id": "7918eafc-a710-5e80-9b59-bdfe07067a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg?1",
             "name": "Glimmer",
             "text": "",
             "colours": [
@@ -16271,7 +16271,7 @@
         },
         {
             "id": "d350c562-4e9f-5462-bbf5-afc8a0e7910d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802aea8-0ca3-4d2c-a8ef-a80e16729c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802aea8-0ca3-4d2c-a8ef-a80e16729c9b.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16306,7 +16306,7 @@
         },
         {
             "id": "2e65d6d5-6d8b-5dbd-a0a0-97c2bffc38fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16341,7 +16341,7 @@
         },
         {
             "id": "509d3688-c99e-5b90-b975-8716e3b97fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6d479d-c30d-4048-b250-5233358a174c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6d479d-c30d-4048-b250-5233358a174c.jpg?1",
             "name": "Toy",
             "text": "",
             "colours": [
@@ -16377,7 +16377,7 @@
         },
         {
             "id": "cf39570a-a491-5d21-a385-0119796ac0a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16412,7 +16412,7 @@
         },
         {
             "id": "1fb16f1b-36a5-5421-968c-19c83c42fdca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba307eb-814c-4c87-acdf-b54c87d04f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba307eb-814c-4c87-acdf-b54c87d04f82.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -16447,7 +16447,7 @@
         },
         {
             "id": "a5e74906-fe74-5db5-bb64-26b4472f3a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb6907-e7d7-4f99-966a-ab09ca130fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb6907-e7d7-4f99-966a-ab09ca130fb8.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [
@@ -16482,7 +16482,7 @@
         },
         {
             "id": "fc3e7e0f-3224-53c0-b66c-e404679fda18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d948b503-890a-49d5-a3cf-cb6e604851b8.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -16517,7 +16517,7 @@
         },
         {
             "id": "29562e6b-2aa3-563e-8e61-1ff513354a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8852eb-1318-40c2-aa2a-8c0e830cca71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8852eb-1318-40c2-aa2a-8c0e830cca71.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -16552,7 +16552,7 @@
         },
         {
             "id": "26fab7df-78f1-5a13-af43-ab906331ae31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377f1a20-b270-4b07-9892-7170cd0bee38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377f1a20-b270-4b07-9892-7170cd0bee38.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16589,7 +16589,7 @@
         },
         {
             "id": "4060afb6-0ca7-5111-9344-54ed2dd3f8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9de169-fb85-43cc-8527-9829d7cb5bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9de169-fb85-43cc-8527-9829d7cb5bc5.jpg?1",
             "name": "Primo, the Indivisible",
             "text": "",
             "colours": [
@@ -16628,7 +16628,7 @@
         },
         {
             "id": "bcc85e6e-80b5-537b-98fe-8b96243cd68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0b31c3-5775-41a6-9981-44fc4a6d4aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0b31c3-5775-41a6-9981-44fc4a6d4aa8.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -16659,7 +16659,7 @@
         },
         {
             "id": "705428c3-5dfd-5c2f-81cc-47db81a41e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b76b7a4-f398-4bb4-833e-97ec0d4e581a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b76b7a4-f398-4bb4-833e-97ec0d4e581a.jpg?1",
             "name": "Everywhere",
             "text": "",
             "colours": [],
@@ -16694,7 +16694,7 @@
         },
         {
             "id": "6b0efa14-b9fd-542d-ae6c-9d03e6a4fade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435e707c-2b1d-48a7-ba75-c3c67824b50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435e707c-2b1d-48a7-ba75-c3c67824b50d.jpg?1",
             "name": "Kaito, Bane of Nightmares Emblem",
             "text": "",
             "colours": [],
@@ -16722,7 +16722,7 @@
         },
         {
             "id": "34b761d0-6e4d-5706-9a21-5dbb4073d7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01104ab1-84e1-4c78-853d-637c6554bdf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01104ab1-84e1-4c78-853d-637c6554bdf9.jpg?1",
             "name": "Manifest",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DST.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DST.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ef1bb6bf-19f5-5987-9158-38571ab1c5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cce4d4-bff2-4dbb-bc12-1a726ad82dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cce4d4-bff2-4dbb-bc12-1a726ad82dd4.jpg?1",
             "name": "Auriok Glaivemaster",
             "text": "As long as Auriok Glaivemaster is equipped, it gets +1/+1 and has first strike.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "d5f1697b-551e-518c-be5e-43859c9d6075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060e278c-dc34-4a94-9b15-6e9ffb2a1aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060e278c-dc34-4a94-9b15-6e9ffb2a1aee.jpg?1",
             "name": "Echoing Calm",
             "text": "Destroy target enchantment and all other enchantments with the same name as that enchantment.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "739a12f3-d088-54b0-a5c8-43d11de907cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c47553-4209-4634-a49c-25714cd3967b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c47553-4209-4634-a49c-25714cd3967b.jpg?1",
             "name": "Emissary of Hope",
             "text": "Flying\nWhenever Emissary of Hope deals combat damage to a player, you gain 1 life for each artifact that player controls.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "648e15b8-d4b3-5e4a-92b7-0121e357588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fe80a0-cb3d-48bc-b67e-2e2253cfee14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fe80a0-cb3d-48bc-b67e-2e2253cfee14.jpg?1",
             "name": "Hallow",
             "text": "Prevent all damage target spell would deal this turn. You gain life equal to the damage prevented this way.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "c9f55419-1a24-5452-ac0f-ac72d2fdd552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c14e05-8c50-44de-8cd4-5b3a11ecdb30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c14e05-8c50-44de-8cd4-5b3a11ecdb30.jpg?1",
             "name": "Leonin Battlemage",
             "text": "{T}: Target creature gets +1/+1 until end of turn.\nWhenever you play a spell, you may untap Leonin Battlemage.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "99725375-64f6-552a-a258-725f8663dc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2a0f5-e340-4a85-aa5c-340e7f8231b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b2a0f5-e340-4a85-aa5c-340e7f8231b0.jpg?1",
             "name": "Leonin Shikari",
             "text": "You may play equip abilities any time you could play an instant.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "4e1701f7-78f0-5f69-9ead-e407e5f28ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976c352-ac49-4e0d-a4c0-ec9b6b78db9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976c352-ac49-4e0d-a4c0-ec9b6b78db9c.jpg?1",
             "name": "Loxodon Mystic",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "2fd1eafe-e422-5390-93fd-318844f5121d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa32494-24bc-44c7-81d4-7285bd1fe3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa32494-24bc-44c7-81d4-7285bd1fe3c8.jpg?1",
             "name": "Metal Fatigue",
             "text": "Tap all artifacts.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "c176698d-0f5b-5240-9375-0cde177735c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cabc4c-0c2b-4004-9676-aba151a9242f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cabc4c-0c2b-4004-9676-aba151a9242f.jpg?1",
             "name": "Pristine Angel",
             "text": "Flying\nAs long as Pristine Angel is untapped, it has protection from artifacts and from all colors.\nWhenever you play a spell, you may untap Pristine Angel.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "38fb6f62-24b4-5b7d-82f3-1fc601b2177e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aff26fc-e6d3-4135-96b9-0da7cb8b6dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aff26fc-e6d3-4135-96b9-0da7cb8b6dae.jpg?1",
             "name": "Pteron Ghost",
             "text": "Flying\nSacrifice Pteron Ghost: Regenerate target artifact.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "d32cdc71-4e93-59c9-9cbc-41ee3c1e7f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedff5d-4c5d-4120-9d9a-4bb5b0b2d2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedff5d-4c5d-4120-9d9a-4bb5b0b2d2f2.jpg?1",
             "name": "Pulse of the Fields",
             "text": "You gain 4 life. Then if an opponent has more life than you, return Pulse of the Fields to its owner's hand.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "77e017da-b7e2-5c41-9724-0436d2e70c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcbe727-81f0-469e-92f1-0dd9acdb54ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcbe727-81f0-469e-92f1-0dd9acdb54ea.jpg?1",
             "name": "Purge",
             "text": "Destroy target artifact creature or black creature. It can't be regenerated.",
             "colours": [
@@ -407,7 +407,7 @@
         },
         {
             "id": "8389e817-2078-582d-a5d0-68e3f435d806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73142844-de7c-4427-8183-c2281bde6449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73142844-de7c-4427-8183-c2281bde6449.jpg?1",
             "name": "Ritual of Restoration",
             "text": "Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "73091e10-9a09-5b95-b7bf-7247eb3b4c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b431711-ac9d-4f05-af66-44f1ca5fabf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b431711-ac9d-4f05-af66-44f1ca5fabf1.jpg?1",
             "name": "Soulscour",
             "text": "Destroy all nonartifact permanents.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "924d1f70-ce06-5f31-ae50-6c11d2be1507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4793de1-4d5d-4538-b48f-db5d31757bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4793de1-4d5d-4538-b48f-db5d31757bcc.jpg?1",
             "name": "Steelshaper Apprentice",
             "text": "{W}, {T}, Return Steelshaper Apprentice to its owner's hand: Search your library for an Equipment card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "8dd511f1-ec01-5a86-b418-89557d769ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7632585e-28e1-4f45-b5ba-172d44573708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7632585e-28e1-4f45-b5ba-172d44573708.jpg?1",
             "name": "Stir the Pride",
             "text": "Choose one Creatures you control get +2/+2 until end of turn; or until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "91622f41-152c-5c0c-862b-6a5f76f79473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e519c3ab-1963-4aa1-843f-3cc1b6aec7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e519c3ab-1963-4aa1-843f-3cc1b6aec7b2.jpg?1",
             "name": "Test of Faith",
             "text": "Prevent the next 3 damage that would be dealt to target creature this turn, and put a +1/+1 counter on that creature for each 1 damage prevented this way.",
             "colours": [
@@ -570,7 +570,7 @@
         },
         {
             "id": "a255a5d4-de5f-5222-b664-7adbc9388c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b38c5-4be1-4f33-92e8-6fe0476b5299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79b38c5-4be1-4f33-92e8-6fe0476b5299.jpg?1",
             "name": "Turn the Tables",
             "text": "All combat damage that would be dealt to you this turn is dealt to target attacking creature instead.",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "7d0477bb-e85e-5d23-b35d-536b45eb317f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17e86f-410e-42d0-8ef8-739ea26da0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17e86f-410e-42d0-8ef8-739ea26da0a7.jpg?1",
             "name": "Carry Away",
             "text": "When Carry Away comes into play, unattach enchanted Equipment.\nYou control enchanted Equipment.",
             "colours": [
@@ -636,7 +636,7 @@
         },
         {
             "id": "c261f03b-e8a9-54bb-947f-c2c6dd1da2ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22aa7ef-da34-49c1-9aac-67d129ffa6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22aa7ef-da34-49c1-9aac-67d129ffa6fe.jpg?1",
             "name": "Chromescale Drake",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying\nWhen Chromescale Drake comes into play, reveal the top three cards of your library. Put all artifact cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -670,7 +670,7 @@
         },
         {
             "id": "7dfd7f95-1e2a-57b4-8cf3-71e5549807ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefedd7-1bf5-4148-9084-d7d8f1138140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefedd7-1bf5-4148-9084-d7d8f1138140.jpg?1",
             "name": "Echoing Truth",
             "text": "Return target nonland permanent and all other permanents with the same name as that permanent to their owners' hands.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "014495d8-5069-5970-9914-00c9188e3d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ab80bf-d115-4155-82e1-9a3a70b1b67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ab80bf-d115-4155-82e1-9a3a70b1b67d.jpg?1",
             "name": "Hoverguard Observer",
             "text": "Flying\nHoverguard Observer can block only creatures with flying.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "65c73cf8-3513-597c-a1b3-ba0418be16d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d2ece-f656-4cac-8d77-b0f083f76c70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139d2ece-f656-4cac-8d77-b0f083f76c70.jpg?1",
             "name": "Last Word",
             "text": "Last Word can't be countered by spells or abilities.\nCounter target spell.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "a5735d2b-e4da-53ab-8bbb-9a64777d4042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e815b3-373c-4b2e-beb5-c894a52ffdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e815b3-373c-4b2e-beb5-c894a52ffdea.jpg?1",
             "name": "Machinate",
             "text": "Look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "7575b370-8b13-5146-8db5-ffb153c8c541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab7022-fa0f-42da-b0ca-998cbd0c791c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab7022-fa0f-42da-b0ca-998cbd0c791c.jpg?1",
             "name": "Magnetic Flux",
             "text": "Artifact creatures you control gain flying until end of turn.",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "d4e493a9-0686-53ff-84eb-ae75d85ff6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb179448-5e1f-4ef3-858c-ba7a9ea05a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb179448-5e1f-4ef3-858c-ba7a9ea05a78.jpg?1",
             "name": "Neurok Prodigy",
             "text": "Flying\nDiscard an artifact card from your hand: Return Neurok Prodigy to its owner's hand.",
             "colours": [
@@ -867,7 +867,7 @@
         },
         {
             "id": "48fdb57d-9f4f-5e12-a9a6-faa30a9dd7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604172f-e9b8-41bc-aee4-691f9fa4ce42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604172f-e9b8-41bc-aee4-691f9fa4ce42.jpg?1",
             "name": "Neurok Transmuter",
             "text": "{U}: Target creature becomes an artifact in addition to its other types until end of turn.\n{U}: Until end of turn, target artifact creature becomes blue and isn't an artifact.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "10fc6d3b-e272-5e4b-aca5-9d4d45fdb972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32d0779-ef2a-42be-ad67-cee9b06122de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32d0779-ef2a-42be-ad67-cee9b06122de.jpg?1",
             "name": "Psychic Overload",
             "text": "When Psychic Overload comes into play, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step.\nEnchanted permanent has \"Discard two artifact cards from your hand: Untap this permanent.\"",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "52c28fb2-33c8-5f35-a16b-f67fc3c50f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6805341-fa4f-4d89-8003-b27280fadfbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6805341-fa4f-4d89-8003-b27280fadfbd.jpg?1",
             "name": "Pulse of the Grid",
             "text": "Draw two cards, then discard a card from your hand. Then if an opponent has more cards in hand than you, return Pulse of the Grid to its owner's hand.",
             "colours": [
@@ -968,7 +968,7 @@
         },
         {
             "id": "9f44d218-9ee9-5e5d-9306-96f87645328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645bfe2d-845b-4cf3-88b6-b2b62b8531e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645bfe2d-845b-4cf3-88b6-b2b62b8531e4.jpg?1",
             "name": "Quicksilver Behemoth",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nWhen Quicksilver Behemoth attacks or blocks, return it to its owner's hand at end of combat. (Return it only if it's in play.)",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "9d689387-6572-5d01-b187-bc3952e4f80d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a8d65d-0c6f-433d-a818-002c242a17e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a8d65d-0c6f-433d-a818-002c242a17e8.jpg?1",
             "name": "Reshape",
             "text": "As an additional cost to play Reshape, sacrifice an artifact.\nSearch your library for an artifact card with converted mana cost X or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -1034,7 +1034,7 @@
         },
         {
             "id": "3d8471a3-3b59-57ae-bf48-e1a56c2e38bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e09a443-0a00-458a-b351-8cb188e9218c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e09a443-0a00-458a-b351-8cb188e9218c.jpg?1",
             "name": "Retract",
             "text": "Return all artifacts you control to their owner's hand.",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "799a0b2f-3fc9-505a-847c-e330d1101cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a07cdc-8335-45da-9ae2-3052193663ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a07cdc-8335-45da-9ae2-3052193663ef.jpg?1",
             "name": "Second Sight",
             "text": "Choose one Look at the top five cards of target opponent's library, then put them back in any order; or look at the top five cards of your library, then put them back in any order.\nEntwine {U} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "df8a1332-7b97-56fc-8289-14724fd1541d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc895eea-505d-4a12-936b-dcf9895d01a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc895eea-505d-4a12-936b-dcf9895d01a1.jpg?1",
             "name": "Synod Artificer",
             "text": "{X}, {T}: Tap X target noncreature artifacts.\n{X}, {T}: Untap X target noncreature artifacts.",
             "colours": [
@@ -1133,7 +1133,7 @@
         },
         {
             "id": "2c841a8f-586f-5657-929b-c6c55ebfa747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2d9a-9401-4711-97b6-825652090c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2d9a-9401-4711-97b6-825652090c4d.jpg?1",
             "name": "Vedalken Engineer",
             "text": "{T}: Add two mana of any one color to your mana pool. Spend this mana only to play artifact spells or activated abilities of artifacts.",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "70a12909-df2d-57e9-a767-308f136bec0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28a9f15-5469-4dc2-8a73-646f854fec7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28a9f15-5469-4dc2-8a73-646f854fec7e.jpg?1",
             "name": "Vex",
             "text": "Counter target spell. That spell's controller may draw a card.",
             "colours": [
@@ -1200,7 +1200,7 @@
         },
         {
             "id": "c5a6db43-2ca4-5869-943b-5ca0c50010dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9422b79-2bc5-4d0a-8f91-157d9fc09641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9422b79-2bc5-4d0a-8f91-157d9fc09641.jpg?1",
             "name": "Aether Snap",
             "text": "Remove all counters from all permanents and remove all tokens from the game.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "8bac6e76-2094-5e6f-9ca2-94f983917686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37abcf5-f009-4258-bf32-b93b47cb71dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d37abcf5-f009-4258-bf32-b93b47cb71dc.jpg?1",
             "name": "Burden of Greed",
             "text": "Target player loses 1 life for each tapped artifact he or she controls.",
             "colours": [
@@ -1264,7 +1264,7 @@
         },
         {
             "id": "6e755613-becc-598f-9b2c-149b6e0c74f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980135d5-dfaa-4beb-b4b3-1e256bb46e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980135d5-dfaa-4beb-b4b3-1e256bb46e61.jpg?1",
             "name": "Chittering Rats",
             "text": "When Chittering Rats comes into play, target opponent puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "96e855cd-aa9a-55c5-8588-61a981807d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0bfb9-859b-4fed-a1c4-1f0924715801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a0bfb9-859b-4fed-a1c4-1f0924715801.jpg?1",
             "name": "Death Cloud",
             "text": "Each player loses X life, then discards X cards from his or her hand, then sacrifices X creatures, then sacrifices X lands.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "da9c5948-f6c0-5760-9851-713012071a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e688e7-8350-4b78-bd49-a6ffdedad556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e688e7-8350-4b78-bd49-a6ffdedad556.jpg?1",
             "name": "Echoing Decay",
             "text": "Target creature and all other creatures with the same name as that creature get -2/-2 until end of turn.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "c02b797b-b500-5530-93ea-b3f3526cf068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa8ae06-882b-428e-b446-1e750ffcddd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa8ae06-882b-428e-b446-1e750ffcddd1.jpg?1",
             "name": "Emissary of Despair",
             "text": "Flying\nWhenever Emissary of Despair deals combat damage to a player, that player loses 1 life for each artifact he or she controls.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "1415fd15-bba0-5ac8-ade8-5505f6f6c205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9950052e-f674-4f09-802e-3f5f52f5e717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9950052e-f674-4f09-802e-3f5f52f5e717.jpg?1",
             "name": "Essence Drain",
             "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "4eb7b656-fae2-50e9-ad1d-35363d1cc01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b9c148-5f31-405e-9215-a12bafcac99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b9c148-5f31-405e-9215-a12bafcac99a.jpg?1",
             "name": "Greater Harvester",
             "text": "At the beginning of your upkeep, sacrifice a permanent.\nWhenever Greater Harvester deals combat damage to a player, that player sacrifices two permanents.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "f2d9c174-d936-5268-b5f4-cc50ca93f1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d6ed5-0bbc-465e-bc30-3174c910b435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d6ed5-0bbc-465e-bc30-3174c910b435.jpg?1",
             "name": "Grimclaw Bats",
             "text": "Flying\n{B}, Pay 1 life: Grimclaw Bats gets +1/+1 until end of turn.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "1f2a7e16-66f4-5989-979c-5f8b7e1b9883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba50e47-2417-447f-b334-50ef0faecfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba50e47-2417-447f-b334-50ef0faecfae.jpg?1",
             "name": "Hunger of the Nim",
             "text": "Target creature gets +1/+0 until end of turn for each artifact you control.",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "ff17cc87-ca9c-5a6e-94dc-cd5fa14f9f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5465de95-1249-4f14-a2e3-2b2861dfe058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5465de95-1249-4f14-a2e3-2b2861dfe058.jpg?1",
             "name": "Mephitic Ooze",
             "text": "Mephitic Ooze gets +1/+0 for each artifact you control.\nWhenever Mephitic Ooze deals combat damage to a creature, destroy that creature. The creature can't be regenerated.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "bb2c191a-e033-5d92-9378-95cbafed7007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ece344-c516-449e-ab7c-2e78d4778f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ece344-c516-449e-ab7c-2e78d4778f02.jpg?1",
             "name": "Murderous Spoils",
             "text": "Destroy target nonblack creature. It can't be regenerated. You gain control of all Equipment that was attached to it. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "d4c6168d-d48c-5eda-a8de-d7a36e24cf79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1072fef6-3a58-41bb-8d34-0aaedf827aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1072fef6-3a58-41bb-8d34-0aaedf827aa5.jpg?1",
             "name": "Nim Abomination",
             "text": "At the end of your turn, if Nim Abomination is untapped, you lose 3 life.",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "0cd58e48-fa0e-57dd-8136-63bbeac1f152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8b1d0a-2c78-4173-b7ed-d7f3a0502fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8b1d0a-2c78-4173-b7ed-d7f3a0502fe7.jpg?1",
             "name": "Pulse of the Dross",
             "text": "Target player reveals three cards from his or her hand and you choose one of them. That player discards that card. Then if that player has more cards in hand than you, return Pulse of the Dross to its owner's hand.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "067c996f-202e-5953-903a-c31a05669490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023603c1-3f1e-42d1-81e1-535547ef6ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023603c1-3f1e-42d1-81e1-535547ef6ee0.jpg?1",
             "name": "Scavenging Scarab",
             "text": "Scavenging Scarab can't block.",
             "colours": [
@@ -1694,7 +1694,7 @@
         },
         {
             "id": "7362d3fe-8a0b-57b5-937f-e270a1ec9540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c03b3c-5140-4577-a1aa-952986223a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c03b3c-5140-4577-a1aa-952986223a82.jpg?1",
             "name": "Screams from Within",
             "text": "Enchanted creature gets -1/-1.\nWhen enchanted creature is put into a graveyard, return Screams from Within from your graveyard to play.",
             "colours": [
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "7b721158-2c1a-5516-b185-f7fd9a46fadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30f99a-b295-45a2-bff7-479cbe7541a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a30f99a-b295-45a2-bff7-479cbe7541a5.jpg?1",
             "name": "Scrounge",
             "text": "Target opponent chooses an artifact card in his or her graveyard. Put that card into play under your control.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "7fca8ba8-bc6d-55a1-ab84-60a326a97c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c255d5-9246-4a93-8750-0da8871fb12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c255d5-9246-4a93-8750-0da8871fb12d.jpg?1",
             "name": "Shriveling Rot",
             "text": "Choose one Until end of turn, whenever a creature is dealt damage, destroy it; or until end of turn, whenever a creature is put into a graveyard from play, that creature's controller loses life equal to its toughness.\nEntwine {2}{B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "0eecae94-846b-59c3-8678-b7788ef28d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509482a-68d8-4e94-9d1e-5b069ebdc2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2509482a-68d8-4e94-9d1e-5b069ebdc2e4.jpg?1",
             "name": "Barbed Lightning",
             "text": "Choose one Barbed Lightning deals 3 damage to target creature; or Barbed Lightning deals 3 damage to target player.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "d28d7463-e215-5522-8460-cf69ef21acce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fdb57b-7547-4588-9780-15e3bea0bc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fdb57b-7547-4588-9780-15e3bea0bc4c.jpg?1",
             "name": "Crazed Goblin",
             "text": "Crazed Goblin attacks each turn if able.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "b8d7b3f4-945b-55de-9a64-89ecfae26d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9915ff-a9b9-429c-bdc1-6a52d9f0e6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9915ff-a9b9-429c-bdc1-6a52d9f0e6d4.jpg?1",
             "name": "Dismantle",
             "text": "Destroy target artifact. If that artifact had counters on it, put that many +1/+1 counters or charge counters on an artifact you control.",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "39f05caf-9329-54d0-824e-dfc1815f58f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2036745a-09ea-476f-ace6-1d06b8502f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2036745a-09ea-476f-ace6-1d06b8502f83.jpg?1",
             "name": "Drooling Ogre",
             "text": "Whenever a player plays an artifact spell, that player gains control of Drooling Ogre. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "a123a4da-da4c-54a2-989e-235e50717fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f842c8-cd6c-4f4d-9aa8-417a92b37867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f842c8-cd6c-4f4d-9aa8-417a92b37867.jpg?1",
             "name": "Echoing Ruin",
             "text": "Destroy target artifact and all other artifacts with the same name as that artifact.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "dc1b80b3-a3fd-5d0f-9f74-07a49ce727be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967465c4-619a-4407-bffc-ffadb89726cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967465c4-619a-4407-bffc-ffadb89726cd.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nAs an additional cost to play Fireball, pay {1} for each target beyond the first.",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "ae6f9535-2563-57ea-9f09-34fecfa29f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e1f06f-7c87-4da8-b339-e571e391cab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e1f06f-7c87-4da8-b339-e571e391cab1.jpg?1",
             "name": "Flamebreak",
             "text": "Flamebreak deals 3 damage to each creature without flying and each player. Creatures dealt damage this way can't be regenerated this turn.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "cc2b2881-8ef3-5055-91f7-42a9bc86118e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f5c675-b629-45ec-907c-36594f5fe54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f5c675-b629-45ec-907c-36594f5fe54a.jpg?1",
             "name": "Furnace Dragon",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying\nWhen Furnace Dragon comes into play, if you played it from your hand, remove all artifacts from the game.",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "e6b89a49-b0f9-5651-999e-9af4e284a19c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326a7d0-8e24-4ae4-9014-ca6eb6983644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326a7d0-8e24-4ae4-9014-ca6eb6983644.jpg?1",
             "name": "Goblin Archaeologist",
             "text": "{R}, {T}: Flip a coin. If you win the flip, destroy target artifact and untap Goblin Archaeologist. If you lose the flip, sacrifice Goblin Archaeologist.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "f526fc99-d02f-5500-9e1a-582635c56cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efad9a-2fcf-4045-8105-bf9f5e79d12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efad9a-2fcf-4045-8105-bf9f5e79d12c.jpg?1",
             "name": "Inflame",
             "text": "Inflame deals 2 damage to each creature dealt damage this turn.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "57729606-67c1-517a-9d27-49855cb52cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90da818-ffa1-435d-8734-fc7a1330d323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90da818-ffa1-435d-8734-fc7a1330d323.jpg?1",
             "name": "Krark-Clan Stoker",
             "text": "{T}, Sacrifice an artifact: Add {R}{R} to your mana pool.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "78f9f4b8-c4b9-54ab-a6c2-b420249cf0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ed9c8-b552-4a9a-b77a-8b148638b4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3ed9c8-b552-4a9a-b77a-8b148638b4f0.jpg?1",
             "name": "Pulse of the Forge",
             "text": "Pulse of the Forge deals 4 damage to target player. Then if that player has more life than you, return Pulse of the Forge to its owner's hand.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "c936f090-39bc-5880-b3df-b8246498f39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3739d37-7865-46bf-abbc-7a5678709508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3739d37-7865-46bf-abbc-7a5678709508.jpg?1",
             "name": "Savage Beating",
             "text": "Play Savage Beating only during your turn and only during combat.\nChoose one Creatures you control gain double strike until end of turn; or untap all creatures you control and after this phase, there is an additional combat phase.\nEntwine {1}{R}",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "12ceb544-270c-5091-9ffd-1bd0d95e683f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee290e-c22b-4fad-bf99-0630a2b89d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee290e-c22b-4fad-bf99-0630a2b89d68.jpg?1",
             "name": "Shunt",
             "text": "Change the target of target spell with a single target.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "701de95f-5d9d-5429-a21e-85f88e0435bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14aa0e-6d34-48ca-aee0-3563bbfb3b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14aa0e-6d34-48ca-aee0-3563bbfb3b15.jpg?1",
             "name": "Slobad, Goblin Tinkerer",
             "text": "Sacrifice an artifact: Target artifact becomes indestructible until end of turn. (\"Destroy\" effects and lethal damage don't destroy that artifact.)",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "40d2a942-c3e9-56fe-ae85-0d0216342847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070fa2d9-6238-49f6-9d63-75ae88ced8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070fa2d9-6238-49f6-9d63-75ae88ced8e5.jpg?1",
             "name": "Tears of Rage",
             "text": "Play Tears of Rage only during the declare attackers step.\nAttacking creatures you control get +X/+0 until end of turn, where X is the number of attacking creatures. Sacrifice those creatures at end of turn.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "adf0de87-23dd-50dc-80d3-6113eb736199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d369a3da-3424-4984-a50a-59fd9c3d689e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d369a3da-3424-4984-a50a-59fd9c3d689e.jpg?1",
             "name": "Unforge",
             "text": "Destroy target Equipment. If that Equipment was attached to a creature, Unforge deals 2 damage to that creature.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "95c67a5f-e08b-53da-9b3c-4b5ec5a94dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b232a-834c-4c9a-bf36-821d125dc318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b232a-834c-4c9a-bf36-821d125dc318.jpg?1",
             "name": "Vulshok War Boar",
             "text": "When Vulshok War Boar comes into play, sacrifice it unless you sacrifice an artifact.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "ba895b22-d67e-526c-8e2a-748c4d9d5868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d9b77b-d775-4546-91c8-df438a1d8dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d9b77b-d775-4546-91c8-df438a1d8dbe.jpg?1",
             "name": "Ageless Entity",
             "text": "Whenever you gain life, put that many +1/+1 counters on Ageless Entity.",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "ac92648a-5ef0-53fb-9964-5475d36b741d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37bf33-f340-44eb-a092-1cb9385c8981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37bf33-f340-44eb-a092-1cb9385c8981.jpg?1",
             "name": "Echoing Courage",
             "text": "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
             "colours": [
@@ -2455,7 +2455,7 @@
         },
         {
             "id": "d59ab0ac-3c4c-5bf3-9567-f9e1762971ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d5fc3c-7f6b-42a5-a482-d789a2a421c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d5fc3c-7f6b-42a5-a482-d789a2a421c7.jpg?1",
             "name": "Fangren Firstborn",
             "text": "Whenever Fangren Firstborn attacks, put a +1/+1 counter on each attacking creature.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "886e5649-aa8c-5b60-88ea-55076e614536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc7bf3-fa3f-450a-875e-05a022794181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc7bf3-fa3f-450a-875e-05a022794181.jpg?1",
             "name": "Infested Roothold",
             "text": "(Walls can't attack.)\nProtection from artifacts\nWhenever an opponent plays an artifact spell, you may put a 1/1 green Insect creature token into play.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "d2d4bed7-eb8a-5187-90f2-79e38bb3ef6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028c52f2-c45b-42da-89bd-cdd5cd7850f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028c52f2-c45b-42da-89bd-cdd5cd7850f3.jpg?1",
             "name": "Karstoderm",
             "text": "Karstoderm comes into play with five +1/+1 counters on it.\nWhenever an artifact comes into play, remove a +1/+1 counter from Karstoderm.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "20dd2477-c5bc-5fce-a33b-cca41778fb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0597dd97-fe6f-4e74-88e5-35528ada0140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0597dd97-fe6f-4e74-88e5-35528ada0140.jpg?1",
             "name": "Nourish",
             "text": "You gain 6 life.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "71241ec9-ac1f-5d12-9648-f57fae0feac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349969e-1cbe-4541-b3ed-154f5a39f1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1349969e-1cbe-4541-b3ed-154f5a39f1f0.jpg?1",
             "name": "Oxidize",
             "text": "Destroy target artifact. It can't be regenerated.",
             "colours": [
@@ -2621,7 +2621,7 @@
         },
         {
             "id": "ca2e3783-6492-5761-b354-df32cd3c8581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cf1c67-9edc-42dd-ba7f-96baab25813a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88cf1c67-9edc-42dd-ba7f-96baab25813a.jpg?1",
             "name": "Pulse of the Tangle",
             "text": "Put a 3/3 green Beast creature token into play. Then if an opponent controls more creatures than you, return Pulse of the Tangle to its owner's hand.",
             "colours": [
@@ -2653,7 +2653,7 @@
         },
         {
             "id": "7df6c8b0-8366-5d1d-a5f3-29b509da710b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6c4ae7-8509-47a2-bc28-d131b1e6676c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6c4ae7-8509-47a2-bc28-d131b1e6676c.jpg?1",
             "name": "Reap and Sow",
             "text": "Choose one Destroy target land; or search your library for a land card, put that card into play, then shuffle your library.\nEntwine {1}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "8197ca91-9cfa-55c4-b84f-bc76182b23d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5940ed12-5224-4aed-9edc-dd4190691ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5940ed12-5224-4aed-9edc-dd4190691ee9.jpg?1",
             "name": "Rebuking Ceremony",
             "text": "Put two target artifacts on top of their owners' libraries.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "94ea6e3c-8a75-5643-a4d0-847a5b99cef8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0338c6fe-54f6-4be0-a70d-b15e5403d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0338c6fe-54f6-4be0-a70d-b15e5403d842.jpg?1",
             "name": "Roaring Slagwurm",
             "text": "Whenever Roaring Slagwurm attacks, tap all artifacts.",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "c53f7b9d-647c-5970-b089-bea5917cdc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c590-fb9d-433a-8e5f-2b1aff4efd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c590-fb9d-433a-8e5f-2b1aff4efd29.jpg?1",
             "name": "Stand Together",
             "text": "Put two +1/+1 counters on target creature and two +1/+1 counters on another target creature.",
             "colours": [
@@ -2783,7 +2783,7 @@
         },
         {
             "id": "12975333-f8c9-57aa-9bb8-738490ccb8cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca75ce1-8f4e-4980-adb7-5816446d56a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca75ce1-8f4e-4980-adb7-5816446d56a9.jpg?1",
             "name": "Tangle Spider",
             "text": "You may play Tangle Spider any time you could play an instant.\nTangle Spider may block as though it had flying.",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "f4ede5e4-a6bd-5be7-9d00-cdc15725cb51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23266fca-7bda-47ca-a72e-140ed51e94c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23266fca-7bda-47ca-a72e-140ed51e94c0.jpg?1",
             "name": "Tanglewalker",
             "text": "Creatures you control are unblockable as long as defending player controls an artifact land.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "72cdf1c0-bf72-5a44-bf0b-97133301c802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d811d8f-437b-4c9f-8ea2-c85590a07935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d811d8f-437b-4c9f-8ea2-c85590a07935.jpg?1",
             "name": "Tel-Jilad Outrider",
             "text": "Protection from artifacts",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "5b6bacae-d444-5187-a09a-b8242426b82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac40a1c6-88df-4f01-aa59-4ef3c6b57e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac40a1c6-88df-4f01-aa59-4ef3c6b57e75.jpg?1",
             "name": "Tel-Jilad Wolf",
             "text": "Whenever Tel-Jilad Wolf becomes blocked by an artifact creature, Tel-Jilad Wolf gets +3/+3 until end of turn.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "36bd1018-ae5e-55e4-acf3-8ca81001a7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64448241-978c-43e0-b0ea-b4bb3e25b715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64448241-978c-43e0-b0ea-b4bb3e25b715.jpg?1",
             "name": "Viridian Acolyte",
             "text": "{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "b29b7094-6376-58fb-8b88-e6ecc1dffd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1ecdd4-9dbc-4635-a0ef-0aae6f8ffcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1ecdd4-9dbc-4635-a0ef-0aae6f8ffcdb.jpg?1",
             "name": "Viridian Zealot",
             "text": "{1}{G}, Sacrifice Viridian Zealot: Destroy target artifact or enchantment.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "d3261c53-4524-5e3a-8fba-ccce7588f206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741c479b-5e92-4837-9673-9bc72aa11d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741c479b-5e92-4837-9673-9bc72aa11d26.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on \u00c6ther Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on \u00c6ther Vial from your hand into play.",
             "colours": [],
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "a776a2e5-21bf-5116-bd36-d27869dc2bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a11d101-2e82-42d5-b4a1-8f0c520441ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a11d101-2e82-42d5-b4a1-8f0c520441ab.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player plays a white spell, you may gain 1 life.",
             "colours": [],
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "fb43aa91-02f3-5999-a26b-8074d851d220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d85c9-859a-4ff5-9a41-bf20622a3ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d85c9-859a-4ff5-9a41-bf20622a3ff5.jpg?1",
             "name": "Arcane Spyglass",
             "text": "{2}, {T}, Sacrifice a land: Draw a card and put a charge counter on Arcane Spyglass.\nRemove three charge counters from Arcane Spyglass: Draw a card.",
             "colours": [],
@@ -3074,7 +3074,7 @@
         },
         {
             "id": "10158614-de16-5b79-a009-b28d47e24adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4672ba6-cd82-4208-bc08-764986899999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4672ba6-cd82-4208-bc08-764986899999.jpg?1",
             "name": "Arcbound Bruiser",
             "text": "Modular 3 (This comes into play with three +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "48fe2843-c88d-5400-9f50-833f6a445d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748448bb-a1b2-4e84-b09a-5ecc4322f3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748448bb-a1b2-4e84-b09a-5ecc4322f3c6.jpg?1",
             "name": "Arcbound Crusher",
             "text": "Trample\nWhenever another artifact comes into play, put a +1/+1 counter on Arcbound Crusher.\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "698a0cb8-8d45-5da5-ab7c-da820a760584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408f42ae-fb83-4c8a-8638-38c719dec197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408f42ae-fb83-4c8a-8638-38c719dec197.jpg?1",
             "name": "Arcbound Fiend",
             "text": "Fear\nAt the beginning of your upkeep, you may move a +1/+1 counter from target creature onto Arcbound Fiend.\nModular 3 (This comes into play with three +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3167,7 +3167,7 @@
         },
         {
             "id": "cc13a05a-cd6c-5357-b10d-bee9a116c5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f33f9d-dffd-4742-92c6-be7fe6463dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f33f9d-dffd-4742-92c6-be7fe6463dca.jpg?1",
             "name": "Arcbound Hybrid",
             "text": "Haste\nModular 2 (This comes into play with two +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "e80a0d75-df79-52df-9f90-ce1a2fc03597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff3241b-49ba-4243-b8fc-fef600836c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff3241b-49ba-4243-b8fc-fef600836c8c.jpg?1",
             "name": "Arcbound Lancer",
             "text": "First strike\nModular 4 (This comes into play with four +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3229,7 +3229,7 @@
         },
         {
             "id": "c79f738e-c921-501c-bdd5-802b45eb646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b64717e-0e7b-4b4c-ba82-48498ee87aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b64717e-0e7b-4b4c-ba82-48498ee87aad.jpg?1",
             "name": "Arcbound Overseer",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each creature with modular you control.\nModular 6 (This comes into play with six +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "62ae25c1-2958-556e-8992-d82c96d35a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c1a731-7854-42b1-8719-ac3c2a269c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c1a731-7854-42b1-8719-ac3c2a269c1f.jpg?1",
             "name": "Arcbound Ravager",
             "text": "Sacrifice an artifact: Put a +1/+1 counter on Arcbound Ravager.\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "1cbcba85-610d-5f6e-9f9f-d6ad0fd4ca53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4c5228-1dff-4df0-9d14-f8103364c701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4c5228-1dff-4df0-9d14-f8103364c701.jpg?1",
             "name": "Arcbound Reclaimer",
             "text": "Remove a +1/+1 counter from Arcbound Reclaimer: Put target artifact card from your graveyard on top of your library.\nModular 2 (This comes into play with two +1/+1 counters on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "b420fcd6-80f2-57fa-a17b-232beae2df4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2f544a-4a42-43ee-9796-5bf6b396b245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2f544a-4a42-43ee-9796-5bf6b396b245.jpg?1",
             "name": "Arcbound Slith",
             "text": "Whenever Arcbound Slith deals combat damage to a player, put a +1/+1 counter on it.\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "8d976321-04c3-5b2e-a5de-c2d9dc73e71f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397ea22-93cd-498a-a493-9af841d09bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c397ea22-93cd-498a-a493-9af841d09bf5.jpg?1",
             "name": "Arcbound Stinger",
             "text": "Flying\nModular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "6cb5b235-575d-57c0-b1bc-7e6b5cef8bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75561093-8892-4b51-813a-c933a06d8cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75561093-8892-4b51-813a-c933a06d8cbd.jpg?1",
             "name": "Arcbound Worker",
             "text": "Modular 1 (This comes into play with a +1/+1 counter on it. When it's put into a graveyard, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "7a16982e-130d-55be-b975-f38ec0840105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3808b1-41df-467a-9779-70bbdfbefa6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3808b1-41df-467a-9779-70bbdfbefa6f.jpg?1",
             "name": "Auriok Siege Sled",
             "text": "{1}: Target artifact creature blocks Auriok Siege Sled this turn if able.\n{1}: Target artifact creature can't block Auriok Siege Sled this turn.",
             "colours": [],
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "3cb65b7a-c95a-55a2-a803-e06ae6d09d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516f267-e72b-453c-bceb-4766582568d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516f267-e72b-453c-bceb-4766582568d2.jpg?1",
             "name": "Chimeric Egg",
             "text": "Whenever an opponent plays a nonartifact spell, put a charge counter on Chimeric Egg.\nRemove three charge counters from Chimeric Egg: Chimeric Egg becomes a 6/6 artifact creature with trample until end of turn.",
             "colours": [],
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "3af8e80c-7b49-52c9-9a91-fa50b7406445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeaca72-aadd-4ef8-939a-36f320100e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeaca72-aadd-4ef8-939a-36f320100e6e.jpg?1",
             "name": "Coretapper",
             "text": "{T}: Put a charge counter on target artifact.\nSacrifice Coretapper: Put two charge counters on target artifact.",
             "colours": [],
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "3e827cfe-b245-55c0-ae2b-a1fffed6ede5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06125c05-a345-481d-bc7f-bf234b946b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06125c05-a345-481d-bc7f-bf234b946b5b.jpg?1",
             "name": "Darksteel Brute",
             "text": "Darksteel Brute is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{3}: Darksteel Brute becomes a 2/2 artifact creature until end of turn.",
             "colours": [],
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "89c0e775-0c96-51b8-b202-035f24e452a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc27b24-f085-48b0-8757-cd11fbf25b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc27b24-f085-48b0-8757-cd11fbf25b91.jpg?1",
             "name": "Darksteel Colossus",
             "text": "Trample\nDarksteel Colossus is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "4f3844bb-da9c-5a4d-bb3f-385f4aa4194c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99078ecc-f50a-43e0-93c1-63240cd97bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99078ecc-f50a-43e0-93c1-63240cd97bf7.jpg?1",
             "name": "Darksteel Forge",
             "text": "Artifacts you control are indestructible. (\"Destroy\" effects and lethal damage don't destroy them.)",
             "colours": [],
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "b0d2c01a-ea42-59ae-a805-9c9400e1d101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4fc3bf-a2c1-4a5f-a05e-b0a814c358bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4fc3bf-a2c1-4a5f-a05e-b0a814c358bd.jpg?1",
             "name": "Darksteel Gargoyle",
             "text": "Flying\nDarksteel Gargoyle is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)",
             "colours": [],
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "4d86aa69-68f7-55c6-9344-dfc757ffba7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02b9634-77e9-48ae-a6bf-859598d12c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02b9634-77e9-48ae-a6bf-859598d12c52.jpg?1",
             "name": "Darksteel Ingot",
             "text": "Darksteel Ingot is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "f2e749f7-45fa-54ee-af7a-a1da715cd873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1bac5f-c41a-49f0-94b0-79653b6fa67a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1bac5f-c41a-49f0-94b0-79653b6fa67a.jpg?1",
             "name": "Darksteel Pendant",
             "text": "Darksteel Pendant is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{1}, {T}: Look at the top card of your library. You may put that card on the bottom of your library.",
             "colours": [],
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "6acc678b-645d-5abd-afdd-5de89e3f9847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f1e30-7b30-4853-aeac-3b0933d4ac5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f1e30-7b30-4853-aeac-3b0933d4ac5e.jpg?1",
             "name": "Darksteel Reactor",
             "text": "Darksteel Reactor is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nAt the beginning of your upkeep, you may put a charge counter on Darksteel Reactor.\nWhen Darksteel Reactor has twenty or more charge counters on it, you win the game.",
             "colours": [],
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "b30dbba9-02ed-54e0-8f8e-262901d7d2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e8d67d-3b49-4158-b2bf-8dd0607de51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e8d67d-3b49-4158-b2bf-8dd0607de51f.jpg?1",
             "name": "Death-Mask Duplicant",
             "text": "Imprint {1}: Remove target creature card in your graveyard from the game. (The removed card is imprinted on this artifact.)\nAs long as an imprinted creature card has flying, Death-Mask Duplicant has flying. The same is true for fear, first strike, double strike, haste, landwalk, protection, and trample.",
             "colours": [],
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "6ea19d24-5091-55b5-a159-a13e3ed7e137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d40eb4-643a-4e22-a15f-eda45a48cfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d40eb4-643a-4e22-a15f-eda45a48cfd6.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player plays a black spell, you may gain 1 life.",
             "colours": [],
@@ -3766,7 +3766,7 @@
         },
         {
             "id": "c1a7adfe-0b42-5ffb-94f8-ac54c46d357d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a46bbcc-b287-47bb-b252-5dd3217f61a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a46bbcc-b287-47bb-b252-5dd3217f61a9.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player plays a red spell, you may gain 1 life.",
             "colours": [],
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "0415d3db-9a71-5635-9d38-88bf405aec3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b60dc6a-3b38-4dde-9dd4-aa49a53f29ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b60dc6a-3b38-4dde-9dd4-aa49a53f29ae.jpg?1",
             "name": "Drill-Skimmer",
             "text": "Flying\nDrill-Skimmer can't be the target of spells or abilities as long as you control another artifact creature.",
             "colours": [],
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "ec48b345-d86f-5c47-87b1-9ac23f54271e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df2f4fd-b96a-4537-93a4-38141b0fa577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df2f4fd-b96a-4537-93a4-38141b0fa577.jpg?1",
             "name": "Dross Golem",
             "text": "Affinity for Swamps (This spell costs {1} less to play for each Swamp you control.)\nFear",
             "colours": [],
@@ -3856,7 +3856,7 @@
         },
         {
             "id": "89bafda3-fbf7-502e-b82a-2dcfbf55cff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6870db-8aca-4aee-8e4d-c56a7d8dc242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6870db-8aca-4aee-8e4d-c56a7d8dc242.jpg?1",
             "name": "Eater of Days",
             "text": "Flying, trample\nWhen Eater of Days comes into play, you skip your next two turns.",
             "colours": [],
@@ -3887,7 +3887,7 @@
         },
         {
             "id": "e8d8cd0a-704e-57f6-83f9-1043dc1f76c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e03e05b-011b-4695-950b-98dd7643b8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e03e05b-011b-4695-950b-98dd7643b8a0.jpg?1",
             "name": "Gemini Engine",
             "text": "Whenever Gemini Engine attacks, put an attacking Twin artifact creature token into play. Its power is equal to Gemini Engine's power and its toughness is equal to Gemini Engine's toughness. Sacrifice the token at end of combat.",
             "colours": [],
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "e0a213ad-2eb0-5772-8b96-54677f44e348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a66ded-c697-4bab-8abf-464185f32a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a66ded-c697-4bab-8abf-464185f32a70.jpg?1",
             "name": "Genesis Chamber",
             "text": "Whenever a nontoken creature comes into play, if Genesis Chamber is untapped, that creature's controller puts a 1/1 Myr artifact creature token into play.",
             "colours": [],
@@ -3946,7 +3946,7 @@
         },
         {
             "id": "d7fb608e-8a0c-5021-9fe8-35954947bb27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a21d76d-d86c-4348-be45-f65167d2b5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a21d76d-d86c-4348-be45-f65167d2b5a9.jpg?1",
             "name": "Geth's Grimoire",
             "text": "Whenever an opponent discards a card from his or her hand, you may draw a card.",
             "colours": [],
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "6cf452fe-05d3-5f30-a240-bb7cfa5db655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f33c08-f3c3-4015-970d-ac0530f97c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f33c08-f3c3-4015-970d-ac0530f97c9c.jpg?1",
             "name": "Heartseeker",
             "text": "Equipped creature gets +2/+1 and has \"{T}, Unattach Heartseeker: Destroy target creature.\"\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "162e46dc-f438-58e7-9be4-2eedf60a35cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d159d90-2f3b-4034-bb45-41448b67fe2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d159d90-2f3b-4034-bb45-41448b67fe2e.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "5d880c7d-6deb-5d76-b740-6ffee474d6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc767637-627a-4ea2-873b-d8a80ccc925b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc767637-627a-4ea2-873b-d8a80ccc925b.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player plays a blue spell, you may gain 1 life.",
             "colours": [],
@@ -4063,7 +4063,7 @@
         },
         {
             "id": "fe2d957a-1d7f-5130-9890-d8337a0b7b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eab112-20a6-414f-84c9-678580485420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eab112-20a6-414f-84c9-678580485420.jpg?1",
             "name": "Leonin Bola",
             "text": "Equipped creature has \"{T}, Unattach Leonin Bola: Tap target creature.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "f13214a9-d8c3-5792-9a0f-b580796369d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca24a105-e32a-4b2c-99bf-cfd85bae6229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca24a105-e32a-4b2c-99bf-cfd85bae6229.jpg?1",
             "name": "Lich's Tomb",
             "text": "You don't lose the game for having 0 or less life.\nWhenever you lose life, sacrifice a permanent for each 1 life you lost. (Damage causes loss of life.)",
             "colours": [],
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "5a424865-95d6-53cc-9516-da9b7f94f040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae2417-b859-4254-a3a5-6bff159447ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ae2417-b859-4254-a3a5-6bff159447ca.jpg?1",
             "name": "Memnarch",
             "text": "{1}{U}{U}: Target permanent becomes an artifact in addition to its other types. (This effect doesn't end at end of turn.)\n{3}{U}: Gain control of target artifact. (This effect doesn't end at end of turn.)",
             "colours": [],
@@ -4156,7 +4156,7 @@
         },
         {
             "id": "e4b71e49-ea0d-5063-a7c7-d121bc1ff8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7f15a-074a-4137-88ca-e5d376d146fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e7f15a-074a-4137-88ca-e5d376d146fd.jpg?1",
             "name": "Mycosynth Lattice",
             "text": "All permanents are artifacts in addition to their other types.\nAll cards that aren't in play, spells, and permanents are colorless.\nPlayers may spend mana as though it were mana of any color.",
             "colours": [],
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "59b2345b-f410-521a-98fa-c7a52bcc0ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb654ac-9bb0-465e-8878-5456c154274f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb654ac-9bb0-465e-8878-5456c154274f.jpg?1",
             "name": "Myr Landshaper",
             "text": "{T}: Target land becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "13fcfb03-68ed-5ccd-ba51-0b4f42096f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1af62e-d566-4f39-a467-244602c9240b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1af62e-d566-4f39-a467-244602c9240b.jpg?1",
             "name": "Myr Matrix",
             "text": "Myr Matrix is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nAll Myr get +1/+1.\n{5}: Put a 1/1 Myr artifact creature token into play.",
             "colours": [],
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "0669e383-12f6-5560-96cb-3d0d2a1104c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0515cc-bf2d-4674-b339-4f4eefbc943d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0515cc-bf2d-4674-b339-4f4eefbc943d.jpg?1",
             "name": "Myr Moonvessel",
             "text": "When Myr Moonvessel is put into a graveyard from play, add {1} to your mana pool.",
             "colours": [],
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "37cd9de9-2551-5a0c-8cce-2c99bfab78ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fc3b76-bc51-49ce-8f3f-2314207be4a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fc3b76-bc51-49ce-8f3f-2314207be4a7.jpg?1",
             "name": "Nemesis Mask",
             "text": "All creatures able to block equipped creature do so.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "67908022-fa5b-5dbf-a1e5-bfd1098f2274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4624fff2-e78f-4c13-a444-7e50586cb0b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4624fff2-e78f-4c13-a444-7e50586cb0b3.jpg?1",
             "name": "Oxidda Golem",
             "text": "Affinity for Mountains (This spell costs {1} less to play for each Mountain you control.)\nHaste",
             "colours": [],
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "f1f15f6b-494d-5f74-83ba-939d0da8397f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e945b0-e919-41bb-9bc5-f71ad531e8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e945b0-e919-41bb-9bc5-f71ad531e8f1.jpg?1",
             "name": "Panoptic Mirror",
             "text": "Imprint {X}, {T}: You may remove an instant or sorcery card with converted mana cost X in your hand from the game. (That card is imprinted on this artifact.)\nAt the beginning of your upkeep, you may copy an imprinted instant or sorcery card and play the copy without paying its mana cost.",
             "colours": [],
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "658ab85f-81dc-553e-ac88-24febc08f390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a86ec3-378f-4fca-b5f7-6dc02d47f7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a86ec3-378f-4fca-b5f7-6dc02d47f7b9.jpg?1",
             "name": "Razor Golem",
             "text": "Affinity for Plains (This spell costs {1} less to play for each Plains you control.)\nAttacking doesn't cause Razor Golem to tap.",
             "colours": [],
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "c1bbf2db-926f-5247-895a-cc39f54d13c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8330afd6-f43a-4955-a704-8f2b963cd0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8330afd6-f43a-4955-a704-8f2b963cd0c6.jpg?1",
             "name": "Serum Powder",
             "text": "{T}: Add {1} to your mana pool.\nAny time you could mulligan and Serum Powder is in your hand, you may remove your hand from the game, then draw that many cards. (You can do this in addition to taking mulligans.)",
             "colours": [],
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "e60b3160-22da-5b21-a54b-5777783590d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e09c8a-6c55-491b-96e9-6cf05f673ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e09c8a-6c55-491b-96e9-6cf05f673ac3.jpg?1",
             "name": "Shield of Kaldra",
             "text": "Equipment named Sword of Kaldra, Shield of Kaldra, and Helm of Kaldra are indestructible.\nEquipped creature is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\nEquip {4}",
             "colours": [],
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "4df374aa-8bec-5152-b634-c18956d02ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55318397-de3c-47ea-a088-72a24df5c8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55318397-de3c-47ea-a088-72a24df5c8fa.jpg?1",
             "name": "Skullclamp",
             "text": "Equipped creature gets +1/-1.\nWhen equipped creature is put into a graveyard, draw two cards.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "4d81dc12-a7f5-5ffd-bbca-7649d0ff8e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a3345d-1190-45f4-8191-897b4dcec376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a3345d-1190-45f4-8191-897b4dcec376.jpg?1",
             "name": "Spawning Pit",
             "text": "Sacrifice a creature: Put a charge counter on Spawning Pit.\n{1}, Remove two charge counters from Spawning Pit: Put a 2/2 Spawn artifact creature token into play.",
             "colours": [],
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "d334c18e-f33f-5512-a2c7-49589e8f82a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6d2e20-3887-4996-adbe-304dff27dea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6d2e20-3887-4996-adbe-304dff27dea6.jpg?1",
             "name": "Specter's Shroud",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature deals combat damage to a player, that player discards a card from his or her hand.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4542,7 +4542,7 @@
         },
         {
             "id": "8b1d3657-e1a0-5adb-a832-ca16f315a970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d193d4f-1beb-4938-b3fb-b2e96d0c9ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d193d4f-1beb-4938-b3fb-b2e96d0c9ec4.jpg?1",
             "name": "Spellbinder",
             "text": "Imprint When Spellbinder comes into play, you may remove an instant card in your hand from the game.\nWhenever equipped creature deals combat damage to a player, you may copy the imprinted instant card and play the copy without paying its mana cost.\nEquip {4}",
             "colours": [],
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "39368544-2b46-5181-a4e9-52294e1e99ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269a34-cec6-4978-a109-592723cd80dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1269a34-cec6-4978-a109-592723cd80dc.jpg?1",
             "name": "Spincrusher",
             "text": "Whenever Spincrusher blocks, put a +1/+1 counter on it.\nRemove a +1/+1 counter from Spincrusher: Spincrusher is unblockable this turn.",
             "colours": [],
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "73db8f8d-d60a-5ca2-a73b-87dea4ec2474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19239c7b-add3-4537-bdfd-a0f7d38d4d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19239c7b-add3-4537-bdfd-a0f7d38d4d8e.jpg?1",
             "name": "Spire Golem",
             "text": "Affinity for Islands (This spell costs {1} less to play for each Island you control.)\nFlying",
             "colours": [],
@@ -4634,7 +4634,7 @@
         },
         {
             "id": "b489f67d-8939-53e4-97ae-dcce3fc2a4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4bd552-e629-41a4-868f-d656187317b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4bd552-e629-41a4-868f-d656187317b7.jpg?1",
             "name": "Sundering Titan",
             "text": "When Sundering Titan comes into play, choose a land of each basic land type, then destroy those lands.\nWhen Sundering Titan leaves play, choose a land of each basic land type, then destroy those lands.",
             "colours": [],
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "e2c5fb9b-4e3a-528c-9cab-fde857106321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcb621d-5831-4b7c-b3e1-c321a6e10392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcb621d-5831-4b7c-b3e1-c321a6e10392.jpg?1",
             "name": "Surestrike Trident",
             "text": "Equipped creature has first strike and \"{T}, Unattach Surestrike Trident: This creature deals damage equal to its power to target player.\"\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4695,7 +4695,7 @@
         },
         {
             "id": "ecb656f9-1886-54a9-9daf-cae0cbb424e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb613ee-8b8b-4a34-886c-6592b27672b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb613ee-8b8b-4a34-886c-6592b27672b3.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to target creature or player and you draw a card.\nEquip {2}",
             "colours": [],
@@ -4725,7 +4725,7 @@
         },
         {
             "id": "9be1c5f7-f516-5d11-b959-44bc8a994579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d08a91-665e-458c-9b8f-4ebd5f54a0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d08a91-665e-458c-9b8f-4ebd5f54a0d6.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "5eea39d9-fac9-5e7f-92f5-7d237e947c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4ab5e0-5f6b-422d-8ba7-9e0ce1450af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4ab5e0-5f6b-422d-8ba7-9e0ce1450af8.jpg?1",
             "name": "Talon of Pain",
             "text": "Whenever a source you control other than Talon of Pain deals damage to an opponent, put a charge counter on Talon of Pain.\n{X}, {T}, Remove X charge counters from Talon of Pain: Talon of Pain deals X damage to target creature or player.",
             "colours": [],
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "d7f3fecf-226e-582f-b8c1-9e2654e91366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9915977-bd6b-477a-a495-f7ddbbeb82eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9915977-bd6b-477a-a495-f7ddbbeb82eb.jpg?1",
             "name": "Tangle Golem",
             "text": "Affinity for Forests (This spell costs {1} less to play for each Forest you control.)",
             "colours": [],
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "f5e3162d-0e99-511f-b210-94a72c022f43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0e921-b81a-4803-8e1b-f7ae556c1e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0e921-b81a-4803-8e1b-f7ae556c1e6f.jpg?1",
             "name": "Thought Dissector",
             "text": "{X}, {T}: Target opponent reveals cards from the top of his or her library until an artifact card or X cards are revealed, whichever comes first. If an artifact card is revealed this way, put it into play under your control and sacrifice Thought Dissector. Put the rest of the revealed cards into that player's graveyard.",
             "colours": [],
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "5a4a6eb0-3561-5fdc-ab9a-68c7f8a67b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d23ce7-3880-40e7-985b-a8dce97ff77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d23ce7-3880-40e7-985b-a8dce97ff77c.jpg?1",
             "name": "Thunderstaff",
             "text": "If Thunderstaff is untapped and a creature would deal combat damage to you, prevent 1 of that damage.\n{2}, {T}: Attacking creatures get +1/+0 until end of turn.",
             "colours": [],
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "d2cba4f3-f556-59d5-b6b4-eff7d8371105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d465597a-362e-4bd0-b547-f11d8807e597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d465597a-362e-4bd0-b547-f11d8807e597.jpg?1",
             "name": "Trinisphere",
             "text": "As long as Trinisphere is untapped, each spell that would cost less than three mana to play costs three mana to play. (Additional mana in the cost may be paid with any color of mana or colorless mana. For example, a spell that would cost {1}{B} to play costs {2}{B} to play instead.)",
             "colours": [],
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "987cf3be-ebc3-5258-a59f-f4a17a5b015f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cd61eb-a526-46db-8675-334663e0d63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cd61eb-a526-46db-8675-334663e0d63a.jpg?1",
             "name": "Ur-Golem's Eye",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "5dbf217a-dff8-5bde-9f50-2992c4c42aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ca55ec-d262-40d8-b654-40e177bcfd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ca55ec-d262-40d8-b654-40e177bcfd6e.jpg?1",
             "name": "Voltaic Construct",
             "text": "{2}: Untap target artifact creature.",
             "colours": [],
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "3330b203-ac82-55ba-bcd0-5eeeb00096d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf00de0-af24-4ef9-8ac2-135e6b53a8fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf00de0-af24-4ef9-8ac2-135e6b53a8fd.jpg?1",
             "name": "Vulshok Morningstar",
             "text": "Equipped creature gets +2/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "e8470a8b-0063-56ca-bec4-c02247dcd845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1131c187-8fc3-4cee-9422-355ef6622de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1131c187-8fc3-4cee-9422-355ef6622de7.jpg?1",
             "name": "Wand of the Elements",
             "text": "{T}, Sacrifice an Island: Put a 2/2 blue Elemental creature token with flying into play.\n{T}, Sacrifice a Mountain: Put a 3/3 red Elemental creature token into play.",
             "colours": [],
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "38b1c8b5-6edc-5f45-aac0-407cec74ec9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf1b915-7790-43f4-b308-a80a1be6ec29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf1b915-7790-43f4-b308-a80a1be6ec29.jpg?1",
             "name": "Well of Lost Dreams",
             "text": "Whenever you gain life, you may pay {X}, where X is less than or equal to the amount of life you gained. If you do, draw X cards.",
             "colours": [],
@@ -5044,7 +5044,7 @@
         },
         {
             "id": "6beb596f-0b7e-5610-b162-e8e15a6665ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4fdefd-8774-400d-bea6-4064d87383f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4fdefd-8774-400d-bea6-4064d87383f1.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable and can't be the target of spells or abilities.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "4f452889-6501-50d0-94fc-c78f4f8949e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb7e06-748c-4fc0-adc5-f8f2ec62029a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb7e06-748c-4fc0-adc5-f8f2ec62029a.jpg?1",
             "name": "Wirefly Hive",
             "text": "{3}, {T}: Flip a coin. If you win the flip, put a 2/2 Wirefly artifact creature token with flying into play. If you lose the flip, destroy all Wireflies.",
             "colours": [],
@@ -5102,7 +5102,7 @@
         },
         {
             "id": "2d275458-31f7-5134-b17b-90c51251fbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482cdbe0-b865-4e09-bd30-61ab93739b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482cdbe0-b865-4e09-bd30-61ab93739b53.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player plays a green spell, you may gain 1 life.",
             "colours": [],
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "5eff4cda-a902-5231-8ac9-a7f47ae1eb02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf51c665-7823-4d6a-b1da-8c2d93dae10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf51c665-7823-4d6a-b1da-8c2d93dae10b.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth gets +1/+1 until end of turn.",
             "colours": [],
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "cd90f41e-8403-5b0a-88ef-95487157def7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d0e808-d67b-4ea3-9c04-d20269fe692c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d0e808-d67b-4ea3-9c04-d20269fe692c.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Darksteel Citadel is indestructible. (\"Destroy\" effects and lethal damage don't destroy it.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "d9f86b21-9463-567a-9103-94ae551c2518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0e60c9-1548-4981-ada1-6656804a772e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0e60c9-1548-4981-ada1-6656804a772e.jpg?1",
             "name": "Mirrodin's Core",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Put a charge counter on Mirrodin's Core.\n{T}, Remove a charge counter from Mirrodin's Core: Add one mana of any color to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/DTK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/DTK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "aee44480-bc11-53d9-a862-518058b354e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d62d6-8abf-4693-974c-bef6841b394f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d62d6-8abf-4693-974c-bef6841b394f.jpg?1",
             "name": "Scion of Ugin",
             "text": "Flying",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "86cb7e5f-7042-5134-9ed9-57cd3af38f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55611f05-10cf-42d0-b93e-7f0c0c852a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55611f05-10cf-42d0-b93e-7f0c0c852a06.jpg?1",
             "name": "Anafenza, Kin-Tree Spirit",
             "text": "Whenever another nontoken creature enters the battlefield under your control, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "3038dd92-6290-5003-b610-956d7f00b7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88ecc5-df1d-47e6-8cf3-1d708e2389e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88ecc5-df1d-47e6-8cf3-1d708e2389e4.jpg?1",
             "name": "Arashin Foremost",
             "text": "Double strike\nWhenever Arashin Foremost enters the battlefield or attacks, another target Warrior creature you control gains double strike until end of turn.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "383a836b-e636-57c8-81dd-2c0149dfacd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaf67e-ba97-4af9-8c47-dbca703cba35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcaf67e-ba97-4af9-8c47-dbca703cba35.jpg?1",
             "name": "Artful Maneuver",
             "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "1aefb80b-df80-52ba-afbf-60e79f5de00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a54b36b-5a8d-41a1-9371-1a59d81c2733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a54b36b-5a8d-41a1-9371-1a59d81c2733.jpg?1",
             "name": "Aven Sunstriker",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)\nMegamorph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "47a8f2a6-5b16-56c4-a347-c2922e950222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dfc3ec-ca06-40a6-b77c-c2432af9802f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dfc3ec-ca06-40a6-b77c-c2432af9802f.jpg?1",
             "name": "Aven Tactician",
             "text": "Flying\nWhen Aven Tactician enters the battlefield, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "0fa6ad36-6bc1-54d6-90e7-bba37deb03d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e3cab-3d01-4e8b-bb28-20d45acccdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e3cab-3d01-4e8b-bb28-20d45acccdbf.jpg?1",
             "name": "Battle Mastery",
             "text": "Enchant creature\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "2f7c5504-3689-5463-9c1e-e33c926b58db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfca3763-9823-4fa4-968d-c701434b3d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfca3763-9823-4fa4-968d-c701434b3d28.jpg?1",
             "name": "Center Soul",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "89eaeca5-cc68-5d61-8145-fc5e6a8921d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5635c8f2-164c-4a13-965a-9432d07092ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5635c8f2-164c-4a13-965a-9432d07092ed.jpg?1",
             "name": "Champion of Arashin",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "ff6585b9-075f-5968-bb3a-e076d5ef44b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a0362-b973-445a-a355-5a2f3dc67f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8a0362-b973-445a-a355-5a2f3dc67f16.jpg?1",
             "name": "Dragon Hunter",
             "text": "Protection from Dragons\nDragon Hunter can block Dragons as though it had reach.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "ef4dce37-ca34-5e68-bfdf-07ecf9f164f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750880cd-59bf-4b67-a2d5-9b66e4d05665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750880cd-59bf-4b67-a2d5-9b66e4d05665.jpg?1",
             "name": "Dragon's Eye Sentry",
             "text": "Defender, first strike",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "abd53c68-ee6a-594a-9e2a-0c5db6722c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d11837c-613f-4e36-b5dd-99baf8b38532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d11837c-613f-4e36-b5dd-99baf8b38532.jpg?1",
             "name": "Dromoka Captain",
             "text": "First strike\nWhenever Dromoka Captain attacks, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "41f8b102-5e10-5435-a4f8-b59f65db9042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e542-4bcc-43e1-9616-64ce40348a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e542-4bcc-43e1-9616-64ce40348a34.jpg?1",
             "name": "Dromoka Dunecaster",
             "text": "{1}{W}, {T}: Tap target creature without flying.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "59d77f1b-7e81-5156-a5a4-56d1343ebc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ae001b-556f-4576-8cf4-0b8902997bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ae001b-556f-4576-8cf4-0b8902997bb1.jpg?1",
             "name": "Dromoka Warrior",
             "text": "",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "096c8728-f265-5761-b551-0fbb2fa35b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531414e6-ea72-4934-b05e-e1782249fd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531414e6-ea72-4934-b05e-e1782249fd1f.jpg?1",
             "name": "Echoes of the Kin Tree",
             "text": "{2}{W}: Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "b7fefa73-d5bf-5fb1-88b3-e08e570f1381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fef763-7ee2-4341-9c67-546e4b6710b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fef763-7ee2-4341-9c67-546e4b6710b7.jpg?1",
             "name": "Enduring Victory",
             "text": "Destroy target attacking or blocking creature. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -549,7 +549,7 @@
         },
         {
             "id": "2390604b-8e50-582c-885c-875ac817b0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2161d9-ad52-45a6-9be9-e7ff09ec8f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2161d9-ad52-45a6-9be9-e7ff09ec8f5a.jpg?1",
             "name": "Fate Forgotten",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "1c102879-aeee-56d5-8215-fe04f2e5af02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f66474-05bb-4235-b8b4-c2e6452118fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f66474-05bb-4235-b8b4-c2e6452118fc.jpg?1",
             "name": "Glaring Aegis",
             "text": "Enchant creature\nWhen Glaring Aegis enters the battlefield, tap target creature an opponent controls.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "9c9bf39e-56ec-5a9a-981a-c1aa3c29dd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96847438-eb09-4e3f-8ebf-f064b88f70c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96847438-eb09-4e3f-8ebf-f064b88f70c9.jpg?1",
             "name": "Gleam of Authority",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each +1/+1 counter on other creatures you control.\nEnchanted creature has vigilance and \"{W}, {T}: Bolster 1.\" (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "fa23de08-5186-59e0-9f3f-28f734af4e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedcf6c-5796-4843-b6b8-df78e11e72c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedcf6c-5796-4843-b6b8-df78e11e72c2.jpg?1",
             "name": "Graceblade Artisan",
             "text": "Graceblade Artisan gets +2/+2 for each Aura attached to it.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "d04590e3-5768-51d6-ba98-74f749d1d415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce2761c-20ee-497a-8c05-947a1ac93e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce2761c-20ee-497a-8c05-947a1ac93e57.jpg?1",
             "name": "Great Teacher's Decree",
             "text": "Creatures you control get +2/+1 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "4937fb67-a3a5-5e62-9589-069c365450ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987b2af-66d6-4271-a139-37e544cdec62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987b2af-66d6-4271-a139-37e544cdec62.jpg?1",
             "name": "Herald of Dromoka",
             "text": "Vigilance\nOther Warrior creatures you control have vigilance.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "1abb9935-00ee-51a9-93d6-a1b3b3e591bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c760a8-e051-4584-ae1b-178164b84427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c760a8-e051-4584-ae1b-178164b84427.jpg?1",
             "name": "Hidden Dragonslayer",
             "text": "Lifelink\nMegamorph {2}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Hidden Dragonslayer is turned face up, destroy target creature with power 4 or greater an opponent controls.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "8f448b6f-77c4-5aba-b973-916af754ff9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bf1837-41b0-4ff1-9cb1-ee2d75d410c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bf1837-41b0-4ff1-9cb1-ee2d75d410c7.jpg?1",
             "name": "Lightwalker",
             "text": "Lightwalker has flying as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -821,7 +821,7 @@
         },
         {
             "id": "e319b50f-bf02-5c56-b892-f2fe8e3917b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef8595-96e8-4df3-aa5a-9fc8c5fa9a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccef8595-96e8-4df3-aa5a-9fc8c5fa9a3d.jpg?1",
             "name": "Misthoof Kirin",
             "text": "Flying, vigilance\nMegamorph {1}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "627c71d7-afbb-5bef-be33-3071f3d607a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd9f67-32a7-4022-bb53-5bfc671520c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bd9f67-32a7-4022-bb53-5bfc671520c7.jpg?1",
             "name": "Myth Realized",
             "text": "Whenever you cast a noncreature spell, put a lore counter on Myth Realized.\n{2}{W}: Put a lore counter on Myth Realized.\n{W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\"",
             "colours": [
@@ -887,7 +887,7 @@
         },
         {
             "id": "a35d827f-3889-5807-8148-57fb2ed1d8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1205482-2f9d-463e-893f-18998aaf09c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1205482-2f9d-463e-893f-18998aaf09c6.jpg?1",
             "name": "Ojutai Exemplars",
             "text": "Whenever you cast a noncreature spell, choose one \u2014\n\u2022 Tap target creature.\n\u2022 Ojutai Exemplars gains first strike and lifelink until of turn.\n\u2022 Exile Ojutai Exemplars, then return it to the battlefield tapped under its owner's control.",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "ef1b829a-e5de-55f8-a2dd-bb23a1561a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc68c7d8-60fa-4e55-92c1-43fcf5e9abf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc68c7d8-60fa-4e55-92c1-43fcf5e9abf1.jpg?1",
             "name": "Orator of Ojutai",
             "text": "As an additional cost to cast Orator of Ojutai, you may reveal a Dragon card from your hand.\nDefender, flying\nWhen Orator of Ojutai enters the battlefield, if you revealed a Dragon card or controlled a Dragon as you cast Orator of Ojutai, draw a card.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "d43ff56a-1ceb-5669-9a33-2092473a1da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7939502-d6aa-4bde-b42f-67ed433f95f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7939502-d6aa-4bde-b42f-67ed433f95f1.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "f39080d9-0ab0-56f7-9763-7c4c614db9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg?1",
             "name": "Profound Journey",
             "text": "Return target permanent card from your graveyard to the battlefield.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "afe3ac5b-2cb3-5475-9913-72e0cf437f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d94f4-c504-4cf1-9bc7-d318fbee54d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d94f4-c504-4cf1-9bc7-d318fbee54d7.jpg?1",
             "name": "Radiant Purge",
             "text": "Exile target multicolored creature or multicolored enchantment.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "1ad6f74a-0e42-5016-9fb5-95f9cf02c7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf47c52-4065-4b81-acdc-878e74767bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf47c52-4065-4b81-acdc-878e74767bba.jpg?1",
             "name": "Resupply",
             "text": "You gain 6 life.\nDraw a card.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "457764d1-2e1e-5357-9079-05d99104630f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8998b4a5-d94b-45b3-b619-bd850e240ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8998b4a5-d94b-45b3-b619-bd850e240ce0.jpg?1",
             "name": "Sandcrafter Mage",
             "text": "When Sandcrafter Mage enters the battlefield, bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "780e841d-94f6-57e6-8904-f0e8b5aa80a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757be26-4480-43b7-a38a-8e4bde4e2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9757be26-4480-43b7-a38a-8e4bde4e2d50.jpg?1",
             "name": "Sandstorm Charger",
             "text": "Megamorph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "01a72980-f328-577f-a23f-205fc6e10e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76515a0-31eb-4bba-bf07-1f9fde423e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76515a0-31eb-4bba-bf07-1f9fde423e24.jpg?1",
             "name": "Scale Blessing",
             "text": "Bolster 1, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. (To bolster 1, choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "ceb42101-7d73-5145-a307-c4dbabb6f129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d2f5f-b228-4190-ade9-52e2a8056847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d2f5f-b228-4190-ade9-52e2a8056847.jpg?1",
             "name": "Secure the Wastes",
             "text": "Put X 1/1 white Warrior creature tokens onto the battlefield.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "277edfc8-5e73-57e0-9d56-23b227491760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd0af4-44e1-424b-8e55-87f84a42d40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfd0af4-44e1-424b-8e55-87f84a42d40a.jpg?1",
             "name": "Shieldhide Dragon",
             "text": "Flying, lifelink\nMegamorph {5}{W}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Shieldhide Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "359049d9-b7d1-5c58-b98a-ee64e1f33751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ee9009-59a7-40e6-bf1a-1d26d4b399e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ee9009-59a7-40e6-bf1a-1d26d4b399e8.jpg?1",
             "name": "Silkwrap",
             "text": "When Silkwrap enters the battlefield, exile target creature with converted mana cost 3 or less an opponent controls until Silkwrap leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "ce9d8eb1-bce8-5bf1-8126-81f196713465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5f5ead-b9e0-44c0-893f-0e3ae01933d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5f5ead-b9e0-44c0-893f-0e3ae01933d3.jpg?1",
             "name": "Strongarm Monk",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "57f69c47-8d80-56f2-b29b-7e9a02325e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d06616c-a0df-4d2d-8bfc-9f59060d323b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d06616c-a0df-4d2d-8bfc-9f59060d323b.jpg?1",
             "name": "Student of Ojutai",
             "text": "Whenever you cast a noncreature spell, you gain 2 life.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "56fc81b8-9bca-588f-a19a-3d2bd6644964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e638-f478-40b8-8c89-120746b7cefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e638-f478-40b8-8c89-120746b7cefd.jpg?1",
             "name": "Sunscorch Regent",
             "text": "Flying\nWhenever an opponent casts a spell, put a +1/+1 counter on Sunscorch Regent and you gain 1 life.",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "972dd5dc-f2b9-5358-96a4-da8a8e34ac2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114366f3-237f-4f96-b644-5bd82d97b18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114366f3-237f-4f96-b644-5bd82d97b18b.jpg?1",
             "name": "Surge of Righteousness",
             "text": "Destroy target black or red creature that's attacking or blocking. You gain 2 life.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "5e6b8c2b-afc4-598e-94d9-2113a15ed046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c83aa5e-b607-4c4f-a5f6-db61c93a1152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c83aa5e-b607-4c4f-a5f6-db61c93a1152.jpg?1",
             "name": "Territorial Roc",
             "text": "Flying",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "b2fc0f64-a59a-51ce-acb6-602f490b0f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fef6e95-e7f1-4646-be5e-130c8b5a3ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fef6e95-e7f1-4646-be5e-130c8b5a3ca6.jpg?1",
             "name": "Ancient Carp",
             "text": "",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "75580c84-60ef-5db4-b891-d68ee7f254e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028d9e8-002f-43a1-bdce-0db0b6a642b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028d9e8-002f-43a1-bdce-0db0b6a642b0.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "2c8f26b4-0105-56e9-8697-f0ea747d93a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8fba0-fcb4-440c-9442-92278e21c5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8fba0-fcb4-440c-9442-92278e21c5e9.jpg?1",
             "name": "Belltoll Dragon",
             "text": "Flying, hexproof\nMegamorph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Belltoll Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "ae1783f0-e2cb-5a00-991b-48831496f740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401cd79d-638e-43b4-8d0c-d7af05c55a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401cd79d-638e-43b4-8d0c-d7af05c55a1a.jpg?1",
             "name": "Blessed Reincarnation",
             "text": "Exile target creature an opponent controls. That player reveals cards from the top of his or her library until a creature card is revealed. The player puts that card onto the battlefield, then shuffles the rest into his or her library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "fb65c743-cda4-554e-9480-37dd0ecf1e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c6a201-1d4d-4ae5-a84e-098e094eaf61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c6a201-1d4d-4ae5-a84e-098e094eaf61.jpg?1",
             "name": "Clone Legion",
             "text": "For each creature target player controls, put a token onto the battlefield that's a copy of that creature.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "0fa0ca0f-2171-520b-9332-1644e3a353f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b3d4ff-09d1-4d9f-8c83-cdfbd7bb1079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b3d4ff-09d1-4d9f-8c83-cdfbd7bb1079.jpg?1",
             "name": "Contradict",
             "text": "Counter target spell.\nDraw a card.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "44bc67fb-6dee-5565-a0b7-8b2af52c5cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c548d140-3d81-4b33-9985-87703d316a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c548d140-3d81-4b33-9985-87703d316a83.jpg?1",
             "name": "Dance of the Skywise",
             "text": "Until end of turn, target creature you control becomes a blue Dragon Illusion with base power and toughness 4/4, loses all abilities, and gains flying.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "03e07e06-3674-54f5-80c8-fb7108f5b3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c388de-c2c9-4975-9eac-86a8030a9884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c388de-c2c9-4975-9eac-86a8030a9884.jpg?1",
             "name": "Dirgur Nemesis",
             "text": "Defender\nMegamorph {6}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "b1f0d601-bb0f-52a6-bbd7-d626495cbee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f2d2b3-6e48-413e-ad8f-9ce40c7ff167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f2d2b3-6e48-413e-ad8f-9ce40c7ff167.jpg?1",
             "name": "Dragonlord's Prerogative",
             "text": "As an additional cost to cast Dragonlord's Prerogative, you may reveal a Dragon card from your hand.\nIf you revealed a Dragon card or controlled a Dragon as you cast Dragonlord's Prerogative, Dragonlord's Prerogative can't be countered.\nDraw four cards.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "8187f38d-fc71-5548-af1b-0da9140b9be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13b8c2-9d7d-44d8-8934-16458e7267dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13b8c2-9d7d-44d8-8934-16458e7267dc.jpg?1",
             "name": "Elusive Spellfist",
             "text": "Whenever you cast a noncreature spell, Elusive Spellfist gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "583c45dd-1d2c-537e-9b37-d0cbb534c1ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcad5bd9-3236-48d4-920f-c3ed12d5f329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcad5bd9-3236-48d4-920f-c3ed12d5f329.jpg?1",
             "name": "Encase in Ice",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant red or green creature\nWhen Encase in Ice enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "b4707d93-02bd-5f25-a9c0-c10b5903f75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fa105f-c76b-4fd0-9b83-34b46648e0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fa105f-c76b-4fd0-9b83-34b46648e0d6.jpg?1",
             "name": "Glint",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "acf20c1c-6421-5165-825d-957f9069e26e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84d5344-2d15-43da-b536-27e0d308606b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84d5344-2d15-43da-b536-27e0d308606b.jpg?1",
             "name": "Gudul Lurker",
             "text": "Gudul Lurker can't be blocked.\nMegamorph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "bf57a89f-a07c-5520-915d-709c20417f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5087a664-6ed7-43a1-8851-71bbee204eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5087a664-6ed7-43a1-8851-71bbee204eb1.jpg?1",
             "name": "Gurmag Drowner",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Gurmag Drowner exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "e553dbd0-5a4a-5f61-8492-8113083618ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbbd377-4617-4285-b367-98418a588dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbbd377-4617-4285-b367-98418a588dab.jpg?1",
             "name": "Icefall Regent",
             "text": "Flying\nWhen Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent.\nSpells your opponents cast that target Icefall Regent cost {2} more to cast.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "c56fd790-cb53-5c52-90e0-23a2a8e4b9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747dfb21-a00c-46ba-9da3-739f570e1246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747dfb21-a00c-46ba-9da3-739f570e1246.jpg?1",
             "name": "Illusory Gains",
             "text": "Enchant creature\nYou control enchanted creature.\nWhenever a creature enters the battlefield under an opponent's control, attach Illusory Gains to that creature.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "f4b40b83-6490-5fe9-b311-1242c6769fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c6e76-dba4-4448-a4f4-d9591d4539c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c6e76-dba4-4448-a4f4-d9591d4539c7.jpg?1",
             "name": "Learn from the Past",
             "text": "Target player shuffles his or her graveyard into his or her library.\nDraw a card.",
             "colours": [
@@ -2020,7 +2020,7 @@
         },
         {
             "id": "396b6a60-0838-542b-b53c-41ea392b170b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f658281-1c6c-4450-8d75-81714dbd0472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f658281-1c6c-4450-8d75-81714dbd0472.jpg?1",
             "name": "Living Lore",
             "text": "As Living Lore enters the battlefield, exile an instant or sorcery card from your graveyard.\nLiving Lore's power and toughness are each equal to the exiled card's converted mana cost.\nWhenever Living Lore deals combat damage, you may sacrifice it. If you do, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "2f7b8b4c-bf93-5cdd-af42-36ccd4f9ef8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837b050-70a6-46f0-963d-4badb37a42a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f837b050-70a6-46f0-963d-4badb37a42a1.jpg?1",
             "name": "Mirror Mockery",
             "text": "Enchant creature\nWhenever enchanted creature attacks, you may put a token onto the battlefield that's a copy of that creature. Exile that token at end of combat.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "c671e400-5783-5c77-8c50-b2610009b8ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b9d8de-5746-4af0-9353-a19fa977df41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b9d8de-5746-4af0-9353-a19fa977df41.jpg?1",
             "name": "Monastery Loremaster",
             "text": "Megamorph {5}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Monastery Loremaster is turned face up, return target noncreature, nonland card from your graveyard to your hand.",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "b4a53e0a-812c-557c-b567-b62b45b8493d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169f469-10d5-4ae8-88fe-12a8e20ab01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d169f469-10d5-4ae8-88fe-12a8e20ab01b.jpg?1",
             "name": "Mystic Meditation",
             "text": "Draw three cards. Then discard two cards unless you discard a creature card.",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "b9baf6b3-f404-5c19-abe9-0031dbf7613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60380ed0-fed1-4d68-9763-56a9ff8ac5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60380ed0-fed1-4d68-9763-56a9ff8ac5e6.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "89725140-e439-56aa-bea1-ecaa0f041ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a84666-ad2b-494c-b52b-ecee14788ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a84666-ad2b-494c-b52b-ecee14788ef2.jpg?1",
             "name": "Ojutai Interceptor",
             "text": "Flying\nMegamorph {3}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "4e207e89-95cb-5778-bd33-23855a76a6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af51e5a1-7d46-4dad-a25c-6767cbd03dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af51e5a1-7d46-4dad-a25c-6767cbd03dff.jpg?1",
             "name": "Ojutai's Breath",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "a29c3ae7-525b-5da5-9e56-63e1f53f3817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769341a-1331-456d-a2bb-cd7fffe7b51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6769341a-1331-456d-a2bb-cd7fffe7b51d.jpg?1",
             "name": "Ojutai's Summons",
             "text": "Put a 2/2 blue Djinn Monk creature token with flying onto the battlefield.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "085e9948-570d-5b12-977d-1bdbb6ca6a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0c17c9-54af-4dd4-8d4a-fd5a7b8c3c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0c17c9-54af-4dd4-8d4a-fd5a7b8c3c77.jpg?1",
             "name": "Palace Familiar",
             "text": "Flying\nWhen Palace Familiar dies, draw a card.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "551df7ec-f2ad-54e7-82f0-a1454e80c9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87630910-47cc-4347-b126-fd779e7dadc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87630910-47cc-4347-b126-fd779e7dadc0.jpg?1",
             "name": "Profaner of the Dead",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Profaner of the Dead exploits a creature, return to their owners' hands all creatures your opponents control with toughness less than the exploited creature's toughness.",
             "colours": [
@@ -2355,7 +2355,7 @@
         },
         {
             "id": "7a6f9cc5-336a-5abf-baff-918fffd7a6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d64264-895f-4d4d-8e5c-ab1d0d6e340b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d64264-895f-4d4d-8e5c-ab1d0d6e340b.jpg?1",
             "name": "Qarsi Deceiver",
             "text": "{T}: Add {1} to your mana pool. Spend this mana only to cast a face-down creature spell, pay a mana cost to turn a manifested creature face up, or pay a morph cost. (A megamorph cost is a morph cost.)",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "eb8bb124-6e5a-5319-9b98-8c0bfb9ac383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad1d13-c4f6-4440-9988-e1db40039f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad1d13-c4f6-4440-9988-e1db40039f02.jpg?1",
             "name": "Reduce in Stature",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/2.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "f292e1b2-420b-5dba-abb7-fbcb82578ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8890fc6-45e9-443d-ae86-f1acb1ebd0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8890fc6-45e9-443d-ae86-f1acb1ebd0aa.jpg?1",
             "name": "Shorecrasher Elemental",
             "text": "{U}: Exile Shorecrasher Elemental, then return it to the battlefield face down under its owner's control.\n{1}: Shorecrasher Elemental gets +1/-1 or -1/+1 until end of turn.\nMegamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "e0b0e245-513f-5b98-b005-34db5cfbacad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d02daad9-701f-40d4-ad0b-44a3cbd32c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d02daad9-701f-40d4-ad0b-44a3cbd32c3f.jpg?1",
             "name": "Sidisi's Faithful",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "d263f475-4097-5e81-9a84-1f4d981c04da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0df83-fe20-497f-b372-1d2e4d7c8df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0df83-fe20-497f-b372-1d2e4d7c8df9.jpg?1",
             "name": "Sight Beyond Sight",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "cce6b1ba-959b-590e-8ccf-834f73276a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a914304-e774-49fd-9ac7-09e36989b1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a914304-e774-49fd-9ac7-09e36989b1d5.jpg?1",
             "name": "Silumgar Sorcerer",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Silumgar Sorcerer exploits a creature, counter target creature spell.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "1ec07d11-5b1e-5c7e-aef8-b6baf4d18b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a99655-34b2-4756-bf12-b344eb71ad37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a99655-34b2-4756-bf12-b344eb71ad37.jpg?1",
             "name": "Silumgar Spell-Eater",
             "text": "Megamorph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Silumgar Spell-Eater is turned face up, counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "147a03d4-f5cb-5aa2-962f-d73b63cc4565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bee72-62f6-4d90-8557-ff9cac42ec9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077bee72-62f6-4d90-8557-ff9cac42ec9a.jpg?1",
             "name": "Silumgar's Scorn",
             "text": "As an additional cost to cast Silumgar's Scorn, you may reveal a Dragon card from your hand.\nCounter target spell unless its controller pays {1}. If you revealed a Dragon card or controlled a Dragon as you cast Silumgar's Scorn, counter that spell instead.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "59ba3abe-5f2a-54ec-82d7-cbdff833f98a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87875281-12d1-45b9-b1a9-fe0ae7448ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87875281-12d1-45b9-b1a9-fe0ae7448ab8.jpg?1",
             "name": "Skywise Teachings",
             "text": "Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, put a 2/2 blue Djinn Monk creature token with flying onto the battlefield.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "e446f088-52e9-5f89-9602-817b147e03e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bf4f37-2a2e-4c49-88dc-a26dd7367afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3bf4f37-2a2e-4c49-88dc-a26dd7367afb.jpg?1",
             "name": "Stratus Dancer",
             "text": "Flying\nMegamorph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Stratus Dancer is turned face up, counter target instant or sorcery spell.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "f68feeb8-69fd-5c0c-ba19-2b0465ebd9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef5e279-14c4-4f91-b24d-c7098140efcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef5e279-14c4-4f91-b24d-c7098140efcd.jpg?1",
             "name": "Taigam's Strike",
             "text": "Target creature gets +2/+0 until end of turn and can't be blocked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "957c93f1-b13f-5319-a5c6-0fda7db0ad50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621c700-569d-4d07-847e-68b97113415f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621c700-569d-4d07-847e-68b97113415f.jpg?1",
             "name": "Updraft Elemental",
             "text": "Flying",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "6c82ab9e-4d63-5fe3-98e8-6a6dd6bedcd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a7aee-6403-44ce-a119-66147aa311fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8a7aee-6403-44ce-a119-66147aa311fd.jpg?1",
             "name": "Void Squall",
             "text": "Return target nonland permanent to its owner's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "8c5c7160-5307-590b-85f2-8d79110dcc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ae8147-bf25-44f9-b75f-837b81ebe0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ae8147-bf25-44f9-b75f-837b81ebe0de.jpg?1",
             "name": "Youthful Scholar",
             "text": "When Youthful Scholar dies, draw two cards.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "3df60f70-7923-5e0a-a605-8c141afef475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ae0d2-0ca1-4095-8710-be5800e389cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ae0d2-0ca1-4095-8710-be5800e389cd.jpg?1",
             "name": "Zephyr Scribe",
             "text": "{U}, {T}: Draw a card, then discard a card.\nWhenever you cast a noncreature spell, untap Zephyr Scribe.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "72d82ff2-b291-5d85-959a-775b45a73d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f58f1-4843-4926-b3c4-98898201c216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f58f1-4843-4926-b3c4-98898201c216.jpg?1",
             "name": "Acid-Spewer Dragon",
             "text": "Flying, deathtouch\nMegamorph {5}{B}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Acid-Spewer Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "e5b5fe8c-3ea4-5cec-b912-f27d1c82783b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a91f8-5f9f-46a2-bd80-1ca014591de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9a91f8-5f9f-46a2-bd80-1ca014591de9.jpg?1",
             "name": "Ambuscade Shaman",
             "text": "Whenever Ambuscade Shaman or another creature enters the battlefield under your control, that creature gets +2/+2 until end of turn.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "d4f2bf65-292d-5d2e-bc23-17ce18cbc9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb00d55-de56-4bbb-9545-e8cfb25a4f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb00d55-de56-4bbb-9545-e8cfb25a4f23.jpg?1",
             "name": "Blood-Chin Fanatic",
             "text": "{1}{B}, Sacrifice another Warrior creature: Target player loses X life and you gain X life, where X is the sacrificed creature's power.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "784398fe-7e6e-5a8c-84b4-7a66ca720e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e93684-a587-4510-b48b-ecf27ff695f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e93684-a587-4510-b48b-ecf27ff695f4.jpg?1",
             "name": "Blood-Chin Rager",
             "text": "Whenever Blood-Chin Rager attacks, each Warrior creature you control can't be blocked this turn except by two or more creatures.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "ebdd3b42-869f-597d-8d52-b51bf9f72525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e7919e-6190-4f3c-99f7-faa666d34f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e7919e-6190-4f3c-99f7-faa666d34f79.jpg?1",
             "name": "Butcher's Glee",
             "text": "Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -3033,7 +3033,7 @@
         },
         {
             "id": "887a0f7b-6780-5c06-a378-b202c58904b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e012-7043-405c-b6cd-b3b38f8a8d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc8e012-7043-405c-b6cd-b3b38f8a8d54.jpg?1",
             "name": "Coat with Venom",
             "text": "Target creature gets +1/+2 and gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "f4ab3542-486f-5e01-885d-8054ce7379a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cf24e7-2e6e-46e0-aedd-89e17953811c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cf24e7-2e6e-46e0-aedd-89e17953811c.jpg?1",
             "name": "Corpseweft",
             "text": "{1}{B}, Exile one or more creature cards from your graveyard: Put an X/X black Zombie Horror creature token onto the battlefield tapped, where X is twice the number of cards exiled this way.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "8666ec97-ce16-5380-932c-2a991d012086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65bcf62-48c3-4e4d-b129-8e03b3635326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65bcf62-48c3-4e4d-b129-8e03b3635326.jpg?1",
             "name": "Damnable Pact",
             "text": "Target player draws X cards and loses X life.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "45300689-e5e8-5c2f-9042-347115a61997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bb5d9f-9b12-482a-91b4-6786e8310805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bb5d9f-9b12-482a-91b4-6786e8310805.jpg?1",
             "name": "Deadly Wanderings",
             "text": "As long as you control exactly one creature, that creature gets +2/+0 and has deathtouch and lifelink.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "b25b3ceb-1e37-58f4-9cb4-7a8d6d1135b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ed0a14-1a98-4190-b195-f84fa42d4364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ed0a14-1a98-4190-b195-f84fa42d4364.jpg?1",
             "name": "Death Wind",
             "text": "Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "7694a2d1-e9e4-596f-a101-836c5028b279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cad378-129f-41da-8db2-065fc45c76eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cad378-129f-41da-8db2-065fc45c76eb.jpg?1",
             "name": "Deathbringer Regent",
             "text": "Flying\nWhen Deathbringer Regent enters the battlefield, if you cast it from your hand and there are five or more other creatures on the battlefield, destroy all other creatures.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "45c339f6-9fff-522c-b3c4-79e9c2e9ceda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60473300-0bdc-4e89-87d9-28c8d7b4d83d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60473300-0bdc-4e89-87d9-28c8d7b4d83d.jpg?1",
             "name": "Defeat",
             "text": "Destroy target creature with power 2 or less.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "35fe28b9-d9d2-5457-a2c7-a553f6b08a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e79c2c-1b4d-4f20-a769-94890c91b539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e79c2c-1b4d-4f20-a769-94890c91b539.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "cf00ae72-a075-53cb-b38d-037099660889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee71b19-eb1d-4f5a-a1b7-1799f2f50da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee71b19-eb1d-4f5a-a1b7-1799f2f50da0.jpg?1",
             "name": "Dutiful Attendant",
             "text": "When Dutiful Attendant dies, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "9fcf6cdf-8ec4-5d33-aa4b-f17820431c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2acae67-5238-40bb-a173-6fc858264a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2acae67-5238-40bb-a173-6fc858264a6c.jpg?1",
             "name": "Flatten",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "be35f0a0-8398-52bf-998b-1670c7c71dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e319b7ca-d0a4-43ff-8e87-2af6ead089f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e319b7ca-d0a4-43ff-8e87-2af6ead089f5.jpg?1",
             "name": "Foul Renewal",
             "text": "Return target creature card from your graveyard to your hand. Target creature gets -X/-X until end of turn, where X is the toughness of the card returned this way.",
             "colours": [
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "25b5ba4d-7c10-5536-88f3-b669ef810294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d021a-7bb8-4173-9a2f-e4a1d21fda8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d021a-7bb8-4173-9a2f-e4a1d21fda8e.jpg?1",
             "name": "Foul-Tongue Invocation",
             "text": "As an additional cost to cast Foul-Tongue Invocation, you may reveal a Dragon card from your hand.\nTarget player sacrifices a creature. If you revealed a Dragon card or controlled a Dragon as you cast Foul-Tongue Invocation, you gain 4 life.",
             "colours": [
@@ -3422,7 +3422,7 @@
         },
         {
             "id": "e145effd-0976-5718-8b86-b7fe237742ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d98ee0-6b32-4735-89f1-b37da766761f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d98ee0-6b32-4735-89f1-b37da766761f.jpg?1",
             "name": "Foul-Tongue Shriek",
             "text": "Target opponent loses 1 life for each attacking creature you control. You gain that much life.",
             "colours": [
@@ -3454,7 +3454,7 @@
         },
         {
             "id": "a5eeae57-f2a7-50d0-b7ab-f2c2b43f8940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf549c-799f-456f-85d5-8a7302bc729d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf549c-799f-456f-85d5-8a7302bc729d.jpg?1",
             "name": "Gravepurge",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "2dad1239-64a9-57e3-ac89-f746a6657bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884cbc26-f164-47bd-878c-dd46652465d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884cbc26-f164-47bd-878c-dd46652465d0.jpg?1",
             "name": "Hand of Silumgar",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "a55fcbf7-633f-5897-b738-fb9615d20080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b73bbf-39a8-4358-9af6-8f4f0b57c028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b73bbf-39a8-4358-9af6-8f4f0b57c028.jpg?1",
             "name": "Hedonist's Trove",
             "text": "When Hedonist's Trove enters the battlefield, exile all cards from target opponent's graveyard.\nYou may play land cards exiled with Hedonist's Trove.\nYou may cast nonland cards exiled with Hedonist's Trove. You can't cast more than one spell this way each turn.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "291600cd-0030-530c-822d-ee16775267f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced0adca-d11c-41b6-aec4-4799946425d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced0adca-d11c-41b6-aec4-4799946425d3.jpg?1",
             "name": "Kolaghan Skirmisher",
             "text": "Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "da7c0ac9-0cad-5e26-b414-86af8f74f24d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9497f7e6-2121-44a9-9bd6-258685636b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9497f7e6-2121-44a9-9bd6-258685636b1c.jpg?1",
             "name": "Marang River Skeleton",
             "text": "{B}: Regenerate Marang River Skeleton.\nMegamorph {3}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "65992b70-b107-5d88-ba90-422eb29bd496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff347b25-7ce9-42c4-811d-86f3e9c55d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff347b25-7ce9-42c4-811d-86f3e9c55d75.jpg?1",
             "name": "Marsh Hulk",
             "text": "Megamorph {6}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "25042f74-ce0f-53de-8a9e-c79d54b5071c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272180bd-6afc-4be6-993c-b761acdedec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272180bd-6afc-4be6-993c-b761acdedec3.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "d2f96402-a6e9-5cc0-86ae-ddf9c9d49805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf4c637-82c3-41fa-b484-31e7dcf475a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf4c637-82c3-41fa-b484-31e7dcf475a9.jpg?1",
             "name": "Minister of Pain",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Minister of Pain exploits a creature, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "a32a062b-ceca-56d1-8e45-8a9bbb170a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg?1",
             "name": "Pitiless Horde",
             "text": "At the beginning of your upkeep, you lose 2 life.\nDash {2}{B}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "9313d685-4234-5af4-852f-e96af9ac9ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068c44b9-0ba8-4275-b73d-18ad366f4b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068c44b9-0ba8-4275-b73d-18ad366f4b45.jpg?1",
             "name": "Qarsi Sadist",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Qarsi Sadist exploits a creature, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "35e233d8-aa10-553f-8e8e-cfe73d1de30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf584fd-b13b-4f86-9c9a-fa6514255aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf584fd-b13b-4f86-9c9a-fa6514255aba.jpg?1",
             "name": "Rakshasa Gravecaller",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Rakshasa Gravecaller exploits a creature, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "9bf23f81-112e-5fbf-a040-eec0287e6183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a44e0a-5fff-4fc0-a76d-1b097f1d4d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a44e0a-5fff-4fc0-a76d-1b097f1d4d5d.jpg?1",
             "name": "Reckless Imp",
             "text": "Flying\nReckless Imp can't block.\nDash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "04c12079-03c8-537b-804c-fd21131bcd6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ff5e62-b73e-4b85-b65f-5226e75c7f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ff5e62-b73e-4b85-b65f-5226e75c7f97.jpg?1",
             "name": "Risen Executioner",
             "text": "Risen Executioner can't block.\nOther Zombie creatures you control get +1/+1.\nYou may cast Risen Executioner from your graveyard if you pay {1} more to cast it for each other creature card in your graveyard.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "ff92bcfa-c897-5059-a06c-8f0f74585826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b1a5d-fb17-43f0-bf29-4ade853e0e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b1a5d-fb17-43f0-bf29-4ade853e0e6e.jpg?1",
             "name": "Self-Inflicted Wound",
             "text": "Target opponent sacrifices a green or white creature. If that player does, he or she loses 2 life.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "ee146b59-eca3-5624-8e5f-e59206ca5aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9404c7d5-3450-4425-94e5-aa7d4e571d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9404c7d5-3450-4425-94e5-aa7d4e571d4e.jpg?1",
             "name": "Shambling Goblin",
             "text": "When Shambling Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "08c49f94-ded9-5ee1-a590-8cfab1d41698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3835752e-11a6-406c-8bff-b7d4f2f31d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3835752e-11a6-406c-8bff-b7d4f2f31d85.jpg?1",
             "name": "Sibsig Icebreakers",
             "text": "When Sibsig Icebreakers enters the battlefield, each player discards a card.",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "e93dd219-9064-5f86-8028-a965fc759074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5dbba-6114-4d97-9363-817ab9e896d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea5dbba-6114-4d97-9363-817ab9e896d3.jpg?1",
             "name": "Sidisi, Undead Vizier",
             "text": "Deathtouch\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Sidisi, Undead Vizier exploits a creature, you may search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4036,7 +4036,7 @@
         },
         {
             "id": "e7deaa10-8081-5fb7-a1ae-22b0fa11bb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc4693f-59fe-4671-b8c6-66fe53a76bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc4693f-59fe-4671-b8c6-66fe53a76bbe.jpg?1",
             "name": "Silumgar Assassin",
             "text": "Creatures with power greater than Silumgar Assassin's power can't block it.\nMegamorph {2}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Silumgar Assassin is turned face up, destroy target creature with power 3 or less an opponent controls.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "68dbd7d5-2b87-5d3a-8856-68136af7d9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cb67f7-b4e1-423b-8f55-d44ed383e778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cb67f7-b4e1-423b-8f55-d44ed383e778.jpg?1",
             "name": "Silumgar Butcher",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Silumgar Butcher exploits a creature, target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "2fb3c544-8099-5ada-b51f-7f885604fb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d2f6ee-af76-48f0-898d-3a19698d2790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d2f6ee-af76-48f0-898d-3a19698d2790.jpg?1",
             "name": "Ukud Cobra",
             "text": "Deathtouch",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "465fe5b5-cd45-57ed-94cc-0340ba11b607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41f7cf3-bd76-4184-b694-f565aa5cf3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41f7cf3-bd76-4184-b694-f565aa5cf3a4.jpg?1",
             "name": "Ultimate Price",
             "text": "Destroy target monocolored creature.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "44c604e1-aa40-5bbc-90ed-cf1306fe7906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f82b6-53d9-43ce-8a17-c680c443e586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f82b6-53d9-43ce-8a17-c680c443e586.jpg?1",
             "name": "Virulent Plague",
             "text": "Creature tokens get -2/-2.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "d057cdee-e74f-5d30-90ed-98a1e1243f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fb0cc9-aebd-4bbf-8735-add3b753c118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2fb0cc9-aebd-4bbf-8735-add3b753c118.jpg?1",
             "name": "Vulturous Aven",
             "text": "Flying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Vulturous Aven exploits a creature, you draw two cards and you lose 2 life.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "60fc623f-b7a0-5d0b-aefc-7eae1f917153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66e1d97-d676-471a-a140-deb39600a7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66e1d97-d676-471a-a140-deb39600a7a9.jpg?1",
             "name": "Wandering Tombshell",
             "text": "",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "675300d6-d129-54ca-87fa-896252ef6a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b192067c-7cdb-4d3c-95b7-819733e44678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b192067c-7cdb-4d3c-95b7-819733e44678.jpg?1",
             "name": "Atarka Efreet",
             "text": "Megamorph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Atarka Efreet is turned face up, it deals 1 damage to target creature or player.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "22073797-733a-55af-9687-719d6b66d807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f2528-f37f-46b9-b95f-4d142f656723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f2528-f37f-46b9-b95f-4d142f656723.jpg?1",
             "name": "Atarka Pummeler",
             "text": "Formidable \u2014 {3}{R}{R}: Each creature you control can't be blocked this turn except by two or more creatures. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "c06e8d97-01f2-51dd-b754-e5e9402c33cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee571a78-16b2-40ba-92b2-87c1bf4b39bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee571a78-16b2-40ba-92b2-87c1bf4b39bc.jpg?1",
             "name": "Berserkers' Onslaught",
             "text": "Attacking creatures you control have double strike.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "9617a02c-4214-5bbd-ba6f-485843cc5ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051141cb-562a-42a5-984b-a83ee8baca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051141cb-562a-42a5-984b-a83ee8baca51.jpg?1",
             "name": "Commune with Lava",
             "text": "Exile the top X cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "8c414afd-1f6c-54b4-9c23-16559ba0ce1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee8d1f-00e8-44e3-b125-ef98e1461263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee8d1f-00e8-44e3-b125-ef98e1461263.jpg?1",
             "name": "Crater Elemental",
             "text": "{R}, {T}, Sacrifice Crater Elemental: Crater Elemental deals 4 damage to target creature.\nFormidable \u2014 {2}{R}: Crater Elemental has base power 8 until end of turn. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "d398f15b-66df-5e2f-a8a0-c592c08ae4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab919f3-5797-406b-ae1f-7a7c27739b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab919f3-5797-406b-ae1f-7a7c27739b2d.jpg?1",
             "name": "Descent of the Dragons",
             "text": "Destroy any number of target creatures. For each creature destroyed this way, its controller puts a 4/4 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "7ffa4b7d-0b6e-52e2-a302-e3d38e36ccd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf5591c-46e3-4904-8b4e-4f1f84d3118f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf5591c-46e3-4904-8b4e-4f1f84d3118f.jpg?1",
             "name": "Draconic Roar",
             "text": "As an additional cost to cast Draconic Roar, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast Draconic Roar, Draconic Roar deals 3 damage to that creature's controller.",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "8bb7d15b-66c3-5fbb-ba48-da372bcbf55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220e572-7386-4f2f-905f-ba4a2d222f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5220e572-7386-4f2f-905f-ba4a2d222f83.jpg?1",
             "name": "Dragon Fodder",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "b9ee8ab5-d45e-5751-9f0b-85b60924a872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefac283-8491-4d11-9a40-0e90cbeac19f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefac283-8491-4d11-9a40-0e90cbeac19f.jpg?1",
             "name": "Dragon Tempest",
             "text": "Whenever a creature with flying enters the battlefield under your control, it gains haste until end of turn.\nWhenever a Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "c2c10853-c5e0-5e6f-93cc-2096cc89056b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c75b106-349f-44e1-a737-079955cc91b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c75b106-349f-44e1-a737-079955cc91b2.jpg?1",
             "name": "Dragon Whisperer",
             "text": "{R}: Dragon Whisperer gains flying until end of turn.\n{1}{R}: Dragon Whisperer gets +1/+0 until end of turn.\nFormidable \u2014 {4}{R}{R}: Put a 4/4 red Dragon creature token with flying onto the battlefield. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "3d45cd13-126d-5496-a343-2bff1525b298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffcdd54-b6be-4d42-82c0-ae927037e859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffcdd54-b6be-4d42-82c0-ae927037e859.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "8969fa11-9502-5ed2-9da0-0e5ec676ca6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10fb883-12b8-4050-967e-4281ea620906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10fb883-12b8-4050-967e-4281ea620906.jpg?1",
             "name": "Hardened Berserker",
             "text": "Whenever Hardened Berserker attacks, the next spell you cast this turn costs {1} less to cast.",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "a48f295e-926f-52ac-9c4b-79210825eb5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb4035-197b-4d28-9bf7-bb62c304067e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fb4035-197b-4d28-9bf7-bb62c304067e.jpg?1",
             "name": "Impact Tremors",
             "text": "Whenever a creature enters the battlefield under your control, Impact Tremors deals 1 damage to each opponent.",
             "colours": [
@@ -4707,7 +4707,7 @@
         },
         {
             "id": "50cbb70e-c47f-55ab-8d46-3d198e3d8ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f8ac7a-a68a-4adf-995f-1cd96ee3d295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f8ac7a-a68a-4adf-995f-1cd96ee3d295.jpg?1",
             "name": "Ire Shaman",
             "text": "Ire Shaman can't be blocked except by two or more creatures.\nMegamorph {R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ire Shaman is turned face up, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4742,7 +4742,7 @@
         },
         {
             "id": "c403767d-12d1-5121-bc31-059ab237ac16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82220a35-a6e0-4482-b514-f964664ec5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82220a35-a6e0-4482-b514-f964664ec5ec.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "801290e4-9d0e-5170-b374-1672f1317ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa17972e-c16b-4dec-a108-1c3fb0138a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa17972e-c16b-4dec-a108-1c3fb0138a4e.jpg?1",
             "name": "Kolaghan Aspirant",
             "text": "Whenever Kolaghan Aspirant becomes blocked by a creature, Kolaghan Aspirant deals 1 damage to that creature.",
             "colours": [
@@ -4809,7 +4809,7 @@
         },
         {
             "id": "4e51d7cc-06c3-5344-9d66-38d3550d999a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c56a8de-8ae8-4672-8119-9e6a1f4cf5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c56a8de-8ae8-4672-8119-9e6a1f4cf5cd.jpg?1",
             "name": "Kolaghan Forerunners",
             "text": "Trample\nKolaghan Forerunners's power is equal to the number of creatures you control.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "04a64196-ad9b-5b24-aa57-8ed7351e692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6723f5-a7a9-425d-b4b0-f380da578ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6723f5-a7a9-425d-b4b0-f380da578ef8.jpg?1",
             "name": "Kolaghan Stormsinger",
             "text": "Haste\nMegamorph {R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Kolaghan Stormsinger is turned face up, target creature gains haste until end of turn.",
             "colours": [
@@ -4879,7 +4879,7 @@
         },
         {
             "id": "202e7336-8271-5124-8691-e0811800de19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3285cb6f-a9c0-4195-b6b2-3f33a16eaa01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3285cb6f-a9c0-4195-b6b2-3f33a16eaa01.jpg?1",
             "name": "Lightning Berserker",
             "text": "{R}: Lightning Berserker gets +1/+0 until end of turn.\nDash {R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "b92ab86e-407c-5f5c-98af-861ede027586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732a4912-97d1-4640-976e-ae1ffeb70236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732a4912-97d1-4640-976e-ae1ffeb70236.jpg?1",
             "name": "Lose Calm",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn and can't be blocked this turn except by two or more creatures.",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "16faf6b2-986f-5c8b-b9ce-bb68690c4f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62a56c4-a3d9-43ab-83a8-6333578bcbc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62a56c4-a3d9-43ab-83a8-6333578bcbc8.jpg?1",
             "name": "Magmatic Chasm",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -4978,7 +4978,7 @@
         },
         {
             "id": "c276a7bc-e17f-5f85-829f-566d18dd8db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea70e96a-bebd-4ca4-aa24-e5fd0df38b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea70e96a-bebd-4ca4-aa24-e5fd0df38b8a.jpg?1",
             "name": "Qal Sisma Behemoth",
             "text": "Qal Sisma Behemoth can't attack or block unless you pay {2}.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "7a28a0d6-2615-571a-85bc-670d48b118a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8234090e-9df1-4915-90ef-8a4bc6212655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8234090e-9df1-4915-90ef-8a4bc6212655.jpg?1",
             "name": "Rending Volley",
             "text": "Rending Volley can't be countered by spells or abilities.\nRending Volley deals 4 damage to target white or blue creature.",
             "colours": [
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "4d2cb13b-45d0-5b3f-b23c-73e1daab5dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2e9a8-fcbb-4328-b475-36730182b765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2e9a8-fcbb-4328-b475-36730182b765.jpg?1",
             "name": "Roast",
             "text": "Roast deals 5 damage to target creature without flying.",
             "colours": [
@@ -5077,7 +5077,7 @@
         },
         {
             "id": "4a694867-c243-5b48-9fff-92cd82077f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ddda91-3ccb-4c87-82e6-d4e60f4afc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ddda91-3ccb-4c87-82e6-d4e60f4afc24.jpg?1",
             "name": "Sabertooth Outrider",
             "text": "Trample\nFormidable \u2014 Whenever Sabertooth Outrider attacks, if creatures you control have total power 8 or greater, Sabertooth Outrider gains first strike until end of turn.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "22d1228a-d991-57db-84a3-09b95b498e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4787924f-3186-4e18-b53c-dd67c5f42220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4787924f-3186-4e18-b53c-dd67c5f42220.jpg?1",
             "name": "Sarkhan's Rage",
             "text": "Sarkhan's Rage deals 5 damage to target creature or player. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "1b00a79d-bbf3-5cbb-af72-93ffdd952f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a0ff4d-060e-41dc-8b79-1fa42838adf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a0ff4d-060e-41dc-8b79-1fa42838adf2.jpg?1",
             "name": "Sarkhan's Triumph",
             "text": "Search your library for a Dragon creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "289c7605-f989-5228-8b05-dae35deb028b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfab1c5-e267-43a9-ae16-f6b8ae531eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfab1c5-e267-43a9-ae16-f6b8ae531eef.jpg?1",
             "name": "Screamreach Brawler",
             "text": "Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "de8c701e-0edc-5888-abc9-1cbe74dd4c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b952e4e-c1ed-4455-90d5-46b56478e6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b952e4e-c1ed-4455-90d5-46b56478e6b0.jpg?1",
             "name": "Seismic Rupture",
             "text": "Seismic Rupture deals 2 damage to each creature without flying.",
             "colours": [
@@ -5243,7 +5243,7 @@
         },
         {
             "id": "23a929a5-24c7-547b-ac73-7a8a431df97c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a215bde8-1680-4aea-9d0f-2d6d80a592e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a215bde8-1680-4aea-9d0f-2d6d80a592e3.jpg?1",
             "name": "Sprinting Warbrute",
             "text": "Sprinting Warbrute attacks each turn if able.\nDash {3}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "72a1cdcb-6e6b-5c9f-b9c6-2a6d728b9512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906f718-635b-4d51-8896-530c52b260f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a906f718-635b-4d51-8896-530c52b260f7.jpg?1",
             "name": "Stormcrag Elemental",
             "text": "Trample\nMegamorph {4}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "90c7b7d1-ddd8-56c1-9507-1a80a3cf3712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da2b004-97e5-41ab-98b0-3637cb32a35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da2b004-97e5-41ab-98b0-3637cb32a35a.jpg?1",
             "name": "Stormwing Dragon",
             "text": "Flying, first strike\nMegamorph {5}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Stormwing Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "4ec4444f-7974-5899-97f1-62b89e57af7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec9005d-eca8-45a6-b221-9d5a2cfb1e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec9005d-eca8-45a6-b221-9d5a2cfb1e91.jpg?1",
             "name": "Summit Prowler",
             "text": "",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "0d1901c8-be1d-5c19-89a6-ab5ca468899b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a59f12-8d1b-4378-abb8-e266d9b6cdba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a59f12-8d1b-4378-abb8-e266d9b6cdba.jpg?1",
             "name": "Tail Slash",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "776d2f42-9a5c-58a5-9acf-9d4ddcfccfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b9cf2b-efe3-4815-be18-c3b69ee762f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b9cf2b-efe3-4815-be18-c3b69ee762f2.jpg?1",
             "name": "Thunderbreak Regent",
             "text": "Flying\nWhenever a Dragon you control becomes the target of a spell or ability an opponent controls, Thunderbreak Regent deals 3 damage to that player.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "141d2766-952d-58d8-b7de-b4af4ad9fb8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfc312c-13c6-45e7-a780-229186be69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfc312c-13c6-45e7-a780-229186be69f4.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "df15dd46-9de6-5291-9951-efbde49a5d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd58ec4-34a9-4fc2-b057-438492e2e06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd58ec4-34a9-4fc2-b057-438492e2e06e.jpg?1",
             "name": "Twin Bolt",
             "text": "Twin Bolt deals 2 damage divided as you choose among one or two target creatures and/or players.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "2d8e2765-663c-5d5e-9230-8adba6ef56a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b04f7a-4fd6-47d2-b378-99c7fb0c1809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b04f7a-4fd6-47d2-b378-99c7fb0c1809.jpg?1",
             "name": "Vandalize",
             "text": "Choose one or both \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target land.",
             "colours": [
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "05090b72-d93d-5ed7-9ed1-6c4b32c56b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b808883-f630-4070-ab7e-d347e26a9564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b808883-f630-4070-ab7e-d347e26a9564.jpg?1",
             "name": "Volcanic Rush",
             "text": "Attacking creatures get +2/+0 and gain trample until end of turn.",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "dba0a8c1-5fb2-51d2-9088-3ca9b8e40a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979da13b-9be6-49cc-a62c-67eeea289612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979da13b-9be6-49cc-a62c-67eeea289612.jpg?1",
             "name": "Volcanic Vision",
             "text": "Return target instant or sorcery card from your graveyard to your hand. Volcanic Vision deals damage equal to that card's converted mana cost to each creature your opponents control. Exile Volcanic Vision.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "81958944-47d3-5bae-8dfe-2932480617e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4951ef-2519-4511-b952-c835cd81def7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4951ef-2519-4511-b952-c835cd81def7.jpg?1",
             "name": "Warbringer",
             "text": "Dash costs you pay cost {2} less (as long as this creature is on the battlefield).\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "d9dafe58-eb88-51b1-a8c2-9dbbbb8996d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbac6d75-59ab-4d7d-87ae-46875abf8cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbac6d75-59ab-4d7d-87ae-46875abf8cc7.jpg?1",
             "name": "Zurgo Bellstriker",
             "text": "Zurgo Bellstriker can't block creatures with power 2 or greater.\nDash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "311c8827-9716-5cd3-bcea-b22b19bf12e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6db26b5-d28c-4524-9347-eec412d584bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6db26b5-d28c-4524-9347-eec412d584bc.jpg?1",
             "name": "Aerie Bowmasters",
             "text": "Reach (This creature can block creatures with flying.)\nMegamorph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "69680809-ead1-58b0-a5d1-184fc3ff3ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4c8964-06e4-4a24-9a7e-9cac0fb8518e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4c8964-06e4-4a24-9a7e-9cac0fb8518e.jpg?1",
             "name": "Ainok Artillerist",
             "text": "Ainok Artillerist has reach as long as it has a +1/+1 counter on it. (It can block creatures with flying.)",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "b529f002-78e0-590f-b93e-3f617e0b2e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a7410-493c-4c99-99e2-b8e1116622e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a7410-493c-4c99-99e2-b8e1116622e8.jpg?1",
             "name": "Ainok Survivalist",
             "text": "Megamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Ainok Survivalist is turned face up, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "3dfafd08-a501-5b05-bce5-4a68ad9b7661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f672dd0-cd63-464c-9581-0ec6f0e391f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f672dd0-cd63-464c-9581-0ec6f0e391f7.jpg?1",
             "name": "Assault Formation",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -5815,7 +5815,7 @@
         },
         {
             "id": "d56c5296-487e-5f8f-b9e2-5fdb7e8e02c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ef9a03-3044-4e90-9409-c330972fcafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ef9a03-3044-4e90-9409-c330972fcafb.jpg?1",
             "name": "Atarka Beastbreaker",
             "text": "Formidable \u2014 {4}{G}: Atarka Beastbreaker gets +4/+4 until end of turn. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "7acb34f6-e5ab-5038-b2f4-c2b5fdf53a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf18a2f-f93e-4a18-92d5-c9d2cca276d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf18a2f-f93e-4a18-92d5-c9d2cca276d7.jpg?1",
             "name": "Avatar of the Resolute",
             "text": "Reach, trample\nAvatar of the Resolute enters the battlefield with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "7566cd94-7685-5731-9a83-1e01160c940f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99df522-cc97-41e3-8073-72e092afe8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99df522-cc97-41e3-8073-72e092afe8bb.jpg?1",
             "name": "Circle of Elders",
             "text": "Vigilance\nFormidable \u2014 {T}: Add {3} to your mana pool. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "11574c52-6597-5fe8-8133-bad84437c999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg?1",
             "name": "Collected Company",
             "text": "Look at the top six cards of your library. Put up to two creature cards with converted mana cost 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "c29c27af-8562-5ea9-8add-dd68bb712ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c60e63-0b86-4100-a932-bb9e9b197610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c60e63-0b86-4100-a932-bb9e9b197610.jpg?1",
             "name": "Colossodon Yearling",
             "text": "",
             "colours": [
@@ -5985,7 +5985,7 @@
         },
         {
             "id": "fdf5f7bc-5c8b-5afb-873b-f45e3a2d18a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f07879-7893-46d9-9239-8d2625355881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f07879-7893-46d9-9239-8d2625355881.jpg?1",
             "name": "Conifer Strider",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "e1c6ce51-a871-5e6b-aa8b-60bca8c05ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c40df1-3f63-49e7-a869-1ce14f94a753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c40df1-3f63-49e7-a869-1ce14f94a753.jpg?1",
             "name": "Deathmist Raptor",
             "text": "Deathtouch\nWhenever a permanent you control is turned face up, you may return Deathmist Raptor from your graveyard to the battlefield face up or face down.\nMegamorph {4}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "e0c322a9-4486-5282-9d62-4a1bf6d49453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd90d5ea-c586-4afd-be75-1c821e48df0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd90d5ea-c586-4afd-be75-1c821e48df0c.jpg?1",
             "name": "Den Protector",
             "text": "Creatures with power less than Den Protector's power can't block it.\nMegamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Den Protector is turned face up, return target card from your graveyard to your hand.",
             "colours": [
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "55a1cf60-3603-5905-bf05-219c768eba2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65572ff2-281f-431d-b776-e8231f24d2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65572ff2-281f-431d-b776-e8231f24d2c6.jpg?1",
             "name": "Display of Dominance",
             "text": "Choose one \u2014\n\u2022 Destroy target blue or black noncreature permanent.\n\u2022 Permanents you control can't be the targets of blue or black spells your opponents control this turn.",
             "colours": [
@@ -6121,7 +6121,7 @@
         },
         {
             "id": "f7acdd49-5c69-51bb-ab95-7c079e342a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689a6390-894a-4d31-87c2-f9cec3b187a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689a6390-894a-4d31-87c2-f9cec3b187a7.jpg?1",
             "name": "Dragon-Scarred Bear",
             "text": "Formidable \u2014 {1}{G}: Regenerate Dragon-Scarred Bear. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6155,7 +6155,7 @@
         },
         {
             "id": "ddd4ba0b-9563-52de-a51a-fc88b8eec35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a356afb6-19d7-459a-84ca-090924d45387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a356afb6-19d7-459a-84ca-090924d45387.jpg?1",
             "name": "Dromoka's Gift",
             "text": "Bolster 4. (Choose a creature with the least toughness among creatures you control and put four +1/+1 counters on it.)",
             "colours": [
@@ -6187,7 +6187,7 @@
         },
         {
             "id": "e2fcb8bc-e3ba-5b8d-8642-b24d4229b79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f587436e-51ff-4c9c-a6ce-e2768844a71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f587436e-51ff-4c9c-a6ce-e2768844a71a.jpg?1",
             "name": "Epic Confrontation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6219,7 +6219,7 @@
         },
         {
             "id": "c9b33f11-4ec0-55fa-94fe-0ebd67931595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9d3ec9-49d2-4322-aeb1-522aac380fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9d3ec9-49d2-4322-aeb1-522aac380fd3.jpg?1",
             "name": "Explosive Vegetation",
             "text": "Search your library for up to two basic land cards and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "123c5197-b92e-575c-9311-04502da331bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a266c3-de47-4e94-bdc4-210e34981de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a266c3-de47-4e94-bdc4-210e34981de3.jpg?1",
             "name": "Foe-Razer Regent",
             "text": "Flying\nWhen Foe-Razer Regent enters the battlefield, you may have it fight target creature you don't control.\nWhenever a creature you control fights, put two +1/+1 counters on it at the beginning of the next end step.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "bc3d268c-b8ec-54b5-80a5-b8cec49ad823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9c6d9-e715-4b70-a10e-8bc5a4e9e938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9c6d9-e715-4b70-a10e-8bc5a4e9e938.jpg?1",
             "name": "Glade Watcher",
             "text": "Defender\nFormidable \u2014 {G}: Glade Watcher can attack this turn as though it didn't have defender. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "8d5bc2d4-8af8-59b9-894a-fde80937ca56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbd7958-29a0-4f59-9648-eabe0fbfb4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbd7958-29a0-4f59-9648-eabe0fbfb4f9.jpg?1",
             "name": "Guardian Shield-Bearer",
             "text": "Megamorph {3}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Guardian Shield-Bearer is turned face up, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "20927d62-9876-59cd-b5de-775c7441cedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb84323-b6f7-43ea-baf1-3e29b33b680d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb84323-b6f7-43ea-baf1-3e29b33b680d.jpg?1",
             "name": "Herdchaser Dragon",
             "text": "Flying, trample\nMegamorph {5}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)\nWhen Herdchaser Dragon is turned face up, put a +1/+1 counter on each other Dragon creature you control.",
             "colours": [
@@ -6388,7 +6388,7 @@
         },
         {
             "id": "2b515b4c-16c3-5adf-9f82-8e2b4e4150e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565b991-7021-4b81-b9c0-f7231daae360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565b991-7021-4b81-b9c0-f7231daae360.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "a5f115c7-d4fa-584f-b5c3-2867393a7b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f59bc0b-88de-4580-bfc8-5af911d9ee99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f59bc0b-88de-4580-bfc8-5af911d9ee99.jpg?1",
             "name": "Lurking Arynx",
             "text": "Formidable \u2014 {2}{G}: Target creature blocks Lurking Arynx this turn if able. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "a73c8cf5-b47b-5da7-b676-a1fe61a8dac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a766442-bbfd-4869-9cf5-918d9117c359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a766442-bbfd-4869-9cf5-918d9117c359.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6487,7 +6487,7 @@
         },
         {
             "id": "c502e065-1e3a-5c94-9bcf-fc2dbeaae3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bff71e3-b309-4659-9d43-7a0d8ada1efc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bff71e3-b309-4659-9d43-7a0d8ada1efc.jpg?1",
             "name": "Obscuring Aether",
             "text": "Face-down creature spells you cast cost {1} less to cast.\n{1}{G}: Turn Obscuring \u00c6ther face down. (It becomes a 2/2 creature.)",
             "colours": [
@@ -6519,7 +6519,7 @@
         },
         {
             "id": "4a323985-63c1-5b1c-bfe4-31289eb3de39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d6df03-c3c3-42c3-85a4-6fccb0741592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d6df03-c3c3-42c3-85a4-6fccb0741592.jpg?1",
             "name": "Pinion Feast",
             "text": "Destroy target creature with flying. Bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -6551,7 +6551,7 @@
         },
         {
             "id": "98f0b41f-c2b6-5f9f-bcc3-a4f8a992aa0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09253b39-8b3e-4cb8-b054-0e1a49762387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09253b39-8b3e-4cb8-b054-0e1a49762387.jpg?1",
             "name": "Press the Advantage",
             "text": "Up to two target creatures each get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "11648354-262f-5300-8efd-c9613cfa0188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bdd624-e412-4ec8-9929-e1f6b4720e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bdd624-e412-4ec8-9929-e1f6b4720e82.jpg?1",
             "name": "Revealing Wind",
             "text": "Prevent all combat damage that would be dealt this turn. You may look at each face-down creature that's attacking or blocking.",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "bd09d604-47f9-50c5-8779-c9360b7ac7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1111a-9680-4d34-8cf7-af16ae508a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1111a-9680-4d34-8cf7-af16ae508a72.jpg?1",
             "name": "Salt Road Ambushers",
             "text": "Whenever another permanent you control is turned face up, if it's a creature, put two +1/+1 counters on it.\nMegamorph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "914a442e-1ff9-573b-88ae-e981fc21e29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4076bf6b-c8b1-49ef-8f23-afaf7a234e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4076bf6b-c8b1-49ef-8f23-afaf7a234e2d.jpg?1",
             "name": "Salt Road Quartermasters",
             "text": "Salt Road Quartermasters enters the battlefield with two +1/+1 counters on it.\n{2}{G}, Remove a +1/+1 counter from Salt Road Quartermasters: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -6685,7 +6685,7 @@
         },
         {
             "id": "8f15960f-74fa-5442-ad6a-a7638cce4a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f215b-4f3b-4aca-9664-3ef9a0ddea1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861f215b-4f3b-4aca-9664-3ef9a0ddea1a.jpg?1",
             "name": "Sandsteppe Scavenger",
             "text": "When Sandsteppe Scavenger enters the battlefield, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "44af609b-be23-506b-afce-756ce9f2467f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701da01c-0f27-4cb2-8bfa-407239778982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701da01c-0f27-4cb2-8bfa-407239778982.jpg?1",
             "name": "Scaleguard Sentinels",
             "text": "As an additional cost to cast Scaleguard Sentinels, you may reveal a Dragon card from your hand.\nScaleguard Sentinels enters the battlefield with a +1/+1 counter on it if you revealed a Dragon card or controlled a Dragon as you cast Scaleguard Sentinels.",
             "colours": [
@@ -6755,7 +6755,7 @@
         },
         {
             "id": "47729619-522d-5cc2-96e9-9d16c28d4e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbe824-f9c7-4f4d-af92-438b16057d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcdbe824-f9c7-4f4d-af92-438b16057d99.jpg?1",
             "name": "Segmented Krotiq",
             "text": "Megamorph {6}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
             "colours": [
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "49d4efff-351d-57ed-b8a2-38487f002f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca887c41-a8ee-4751-a902-87149c29a9df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca887c41-a8ee-4751-a902-87149c29a9df.jpg?1",
             "name": "Servant of the Scale",
             "text": "Servant of the Scale enters the battlefield with a +1/+1 counter on it.\nWhen Servant of the Scale dies, put X +1/+1 counters on target creature you control, where X is the number of +1/+1 counters on Servant of the Scale.",
             "colours": [
@@ -6824,7 +6824,7 @@
         },
         {
             "id": "368a0177-98c1-5a8c-947b-6203b3bd9aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e9c8f7-2232-4a2a-8a00-0a2908bc7543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e9c8f7-2232-4a2a-8a00-0a2908bc7543.jpg?1",
             "name": "Shaman of Forgotten Ways",
             "text": "{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast creature spells.\nFormidable \u2014 {9}{G}{G}, {T}: Each player's life total becomes the number of creatures he or she controls. Activate this ability only if creatures you control have total power 8 or greater.",
             "colours": [
@@ -6859,7 +6859,7 @@
         },
         {
             "id": "5ce0074c-f60f-5383-8a34-9d4ae9b4324a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0243dde4-29c9-4e47-9129-8e01296851cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0243dde4-29c9-4e47-9129-8e01296851cc.jpg?1",
             "name": "Shape the Sands",
             "text": "Target creature gets +0/+5 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -6891,7 +6891,7 @@
         },
         {
             "id": "275520f7-d43a-5d71-96c4-850e085d93e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afecf5a8-3c9e-48e0-8818-e2e3183e958c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afecf5a8-3c9e-48e0-8818-e2e3183e958c.jpg?1",
             "name": "Sheltered Aerie",
             "text": "Enchant land\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "b80ba665-148c-5362-a3bd-1001151c9625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5921758-4e21-4d34-8cf7-b0205d4b0912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5921758-4e21-4d34-8cf7-b0205d4b0912.jpg?1",
             "name": "Sight of the Scalelords",
             "text": "At the beginning of combat on your turn, creatures you control with toughness 4 or greater get +2/+2 and gain vigilance until end of turn.",
             "colours": [
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "8afec94e-8803-5fc9-9aec-6c8e21cb3946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55e213-6eab-4086-96cd-024de6150fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55e213-6eab-4086-96cd-024de6150fbe.jpg?1",
             "name": "Stampeding Elk Herd",
             "text": "Formidable \u2014 Whenever Stampeding Elk Herd attacks, if creatures you control have total power 8 or greater, creatures you control gain trample until end of turn.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "024c688c-0c0b-56b2-b0f0-6f6880de8970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4d33ea-0193-4ea5-92ea-5f50a533bf6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4d33ea-0193-4ea5-92ea-5f50a533bf6b.jpg?1",
             "name": "Sunbringer's Touch",
             "text": "Bolster X, where X is the number of cards in your hand. Each creature you control with a +1/+1 counter on it gains trample until end of turn. (To bolster X, choose a creature with the least toughness among creatures you control and put X +1/+1 counters on it.)",
             "colours": [
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "bf1aa40c-243a-50f3-8f2c-da18f94059f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b374446d-44bc-4ac5-9829-8c49f0cca173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b374446d-44bc-4ac5-9829-8c49f0cca173.jpg?1",
             "name": "Surrak, the Hunt Caller",
             "text": "Formidable \u2014 At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "3f357928-9abc-5025-a481-c6c51feb89a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f04d27-f38a-4be2-8eb6-7dd0d3a1ac6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f04d27-f38a-4be2-8eb6-7dd0d3a1ac6d.jpg?1",
             "name": "Tread Upon",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "4d7b91cc-43b0-5c95-8c42-6fb50bd5e5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7fbf78-8cb6-4fbf-b925-5543bcb64b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7fbf78-8cb6-4fbf-b925-5543bcb64b45.jpg?1",
             "name": "Arashin Sovereign",
             "text": "Flying\nWhen Arashin Sovereign dies, you may put it on the top or bottom of its owner's library.",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "e18396ae-0aa0-5b09-8368-dbbf4d36b40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d78c9-c5b3-45c3-a6d0-7e92b4196ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d78c9-c5b3-45c3-a6d0-7e92b4196ae3.jpg?1",
             "name": "Atarka's Command",
             "text": "Choose two \u2014\n\u2022 Your opponents can't gain life this turn.\n\u2022 Atarka's Command deals 3 damage to each opponent.\n\u2022 You may put a land card from your hand onto the battlefield.\n\u2022 Creatures you control get +1/+1 and gain reach until end of turn.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "bfb6c1dd-5f97-5aae-a50f-8e81c58a00fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab8841f-5c6f-47fc-91c9-acf3c84b7313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab8841f-5c6f-47fc-91c9-acf3c84b7313.jpg?1",
             "name": "Boltwing Marauder",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -7198,7 +7198,7 @@
         },
         {
             "id": "993fb839-ac31-5765-8f84-4cbd385f48f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbfe3b0-3b1d-4b0c-9d98-07f1cecce4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbfe3b0-3b1d-4b0c-9d98-07f1cecce4b7.jpg?1",
             "name": "Cunning Breezedancer",
             "text": "Flying\nWhenever you cast a noncreature spell, Cunning Breezedancer gets +2/+2 until end of turn.",
             "colours": [
@@ -7234,7 +7234,7 @@
         },
         {
             "id": "bb56cadb-a79f-54d7-92a0-d4f05ee68582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0c3b45-cf1d-4d85-9fe3-fb26b4b15dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0c3b45-cf1d-4d85-9fe3-fb26b4b15dfd.jpg?1",
             "name": "Dragonlord Atarka",
             "text": "Flying, trample\nWhen Dragonlord Atarka enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "c9da5048-60d4-5507-a462-5555c3b59466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908042f3-0d03-4edf-816a-ec846a1e315f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908042f3-0d03-4edf-816a-ec846a1e315f.jpg?1",
             "name": "Dragonlord Dromoka",
             "text": "Dragonlord Dromoka can't be countered.\nFlying, lifelink\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -7312,7 +7312,7 @@
         },
         {
             "id": "7c4369ad-9aa4-50c1-83b1-008ebc730658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbf8933-32a1-4892-9bdc-89464ed9ce1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbf8933-32a1-4892-9bdc-89464ed9ce1b.jpg?1",
             "name": "Dragonlord Kolaghan",
             "text": "Flying, haste\nOther creatures you control have haste.\nWhenever an opponent casts a creature or planeswalker spell with the same name as a card in his or her graveyard, that player loses 10 life.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "db22b048-ecbd-5498-b187-b0ea184f9cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42b2c9c-1650-468e-94d6-e09b3518447f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42b2c9c-1650-468e-94d6-e09b3518447f.jpg?1",
             "name": "Dragonlord Ojutai",
             "text": "Flying\nDragonlord Ojutai has hexproof as long as it's untapped.\nWhenever Dragonlord Ojutai deals combat damage to a player, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -7390,7 +7390,7 @@
         },
         {
             "id": "58a5ad07-c61e-59fd-b521-69f49bbbae31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eae504d-d4a9-440f-8ceb-df967cc50494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eae504d-d4a9-440f-8ceb-df967cc50494.jpg?1",
             "name": "Dragonlord Silumgar",
             "text": "Flying, deathtouch\nWhen Dragonlord Silumgar enters the battlefield, gain control of target creature or planeswalker for as long as you control Dragonlord Silumgar.",
             "colours": [
@@ -7429,7 +7429,7 @@
         },
         {
             "id": "1eba186b-ae39-569b-8725-9f65bc2226ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1e43a8-0adc-4e26-bc56-6b914bd35838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df1e43a8-0adc-4e26-bc56-6b914bd35838.jpg?1",
             "name": "Dromoka's Command",
             "text": "Choose two \u2014\n\u2022 Prevent all damage target instant or sorcery spell would deal this turn.\n\u2022 Target player sacrifices an enchantment.\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "0816d3fd-b480-5464-a7f5-83a56c22000e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfdfff3-0ef8-4e9a-b6bd-a0e11cbdf22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfdfff3-0ef8-4e9a-b6bd-a0e11cbdf22e.jpg?1",
             "name": "Enduring Scalelord",
             "text": "Flying\nWhenever one or more +1/+1 counters are placed on another creature you control, you may put a +1/+1 counter on Enduring Scalelord.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "f6d17a8a-3daa-53fa-803a-7a22378c4cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb21b8-8817-48c2-8ae8-25221600ce32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb21b8-8817-48c2-8ae8-25221600ce32.jpg?1",
             "name": "Harbinger of the Hunt",
             "text": "Flying\n{2}{R}: Harbinger of the Hunt deals 1 damage to each creature without flying.\n{2}{G}: Harbinger of the Hunt deals 1 damage to each other creature with flying.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "f20dc5a8-f699-529b-a2bf-b76dc2d6c150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c884e1e-fecb-4330-b3de-5fc2a60f7173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c884e1e-fecb-4330-b3de-5fc2a60f7173.jpg?1",
             "name": "Kolaghan's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target player discards a card.\n\u2022 Destroy target artifact.\n\u2022 Kolaghan's Command deals 2 damage to target creature or player.",
             "colours": [
@@ -7569,7 +7569,7 @@
         },
         {
             "id": "c32d309f-650c-5fae-8bd5-0b22b9aa5951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4816d092-e34b-4397-8599-43d8e85a8f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4816d092-e34b-4397-8599-43d8e85a8f39.jpg?1",
             "name": "Narset Transcendent",
             "text": "+1: Look at the top card of your library. If it's a noncreature, nonland card, you may reveal it and put it into your hand.\n\u22122: When you cast your next instant or sorcery spell from your hand this turn, it gains rebound.\n\u22129: You get an emblem with \"Your opponents can't cast noncreature spells.\"",
             "colours": [
@@ -7607,7 +7607,7 @@
         },
         {
             "id": "ee821486-d569-56f0-ae85-6c376fcc7d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2574aaf5-8397-4a88-b047-1b4dbb176930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2574aaf5-8397-4a88-b047-1b4dbb176930.jpg?1",
             "name": "Necromaster Dragon",
             "text": "Flying\nWhenever Necromaster Dragon deals combat damage to a player, you may pay {2}. If you do, put a 2/2 black Zombie creature token onto the battlefield and each opponent puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -7643,7 +7643,7 @@
         },
         {
             "id": "25a056dc-64cc-540a-b534-a238f042bf2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7f500-594d-4c7b-80e8-54ae1ada2444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a7f500-594d-4c7b-80e8-54ae1ada2444.jpg?1",
             "name": "Ojutai's Command",
             "text": "Choose two \u2014\n\u2022 Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u2022 You gain 4 life.\n\u2022 Counter target creature spell.\n\u2022 Draw a card.",
             "colours": [
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "23342fbb-7037-524a-9141-89a26b3bc93c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083eabac-f7c9-45d9-b3c7-10d719da1e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083eabac-f7c9-45d9-b3c7-10d719da1e0b.jpg?1",
             "name": "Pristine Skywise",
             "text": "Flying\nWhenever you cast a noncreature spell, untap Pristine Skywise. It gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "e81209bf-37fd-5d9c-a7fd-ad34d60cac97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d99f0d-f5d4-4480-ac5e-fe9ff808416e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d99f0d-f5d4-4480-ac5e-fe9ff808416e.jpg?1",
             "name": "Ruthless Deathfang",
             "text": "Flying\nWhenever you sacrifice a creature, target opponent sacrifices a creature.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "6da2f85a-8119-5e63-b89e-c330cb7e8ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192452f8-93c2-4a20-a52b-0093741a9e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192452f8-93c2-4a20-a52b-0093741a9e45.jpg?1",
             "name": "Sarkhan Unbroken",
             "text": "+1: Draw a card, then add one mana of any color to your mana pool.\n\u22122: Put a 4/4 red Dragon creature token with flying onto the battlefield.\n\u22128: Search your library for any number of Dragon creature cards and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "bc9c4385-2ae1-57d3-8e47-22bc8059184f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690008d1-d1fe-49ad-810c-84be57cecc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690008d1-d1fe-49ad-810c-84be57cecc6c.jpg?1",
             "name": "Savage Ventmaw",
             "text": "Flying\nWhenever Savage Ventmaw attacks, add {R}{R}{R}{G}{G}{G} to your mana pool. Until end of turn, this mana doesn't empty from your mana pool as steps and phases end.",
             "colours": [
@@ -7825,7 +7825,7 @@
         },
         {
             "id": "b482573a-1e19-5988-b764-e92dff6ad33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba26dbbc-d4a2-44a1-8e6b-affe61f43a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba26dbbc-d4a2-44a1-8e6b-affe61f43a34.jpg?1",
             "name": "Silumgar's Command",
             "text": "Choose two \u2014\n\u2022 Counter target noncreature spell.\n\u2022 Return target permanent to its owner's hand.\n\u2022 Target creature gets -3/-3 until end of turn.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "54cc72be-7e37-56b4-8146-b3ad637b29f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62db9d7-3cc7-49cb-bffc-d2f9c286aa36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62db9d7-3cc7-49cb-bffc-d2f9c286aa36.jpg?1",
             "name": "Swift Warkite",
             "text": "Flying\nWhen Swift Warkite enters the battlefield, you may put a creature card with converted mana cost 3 or less from your hand or graveyard onto the battlefield. That creature gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "3eafb831-32f7-5dc2-8f8e-4e794c29b511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7124a6f-b690-4326-93b5-036a8c520c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7124a6f-b690-4326-93b5-036a8c520c1f.jpg?1",
             "name": "Ancestral Statue",
             "text": "When Ancestral Statue enters the battlefield, return a nonland permanent you control to its owner's hand.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "0a1959a6-0db0-509e-b5dd-195e9aae4290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d52217-a340-4567-9b07-28092a7dc561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d52217-a340-4567-9b07-28092a7dc561.jpg?1",
             "name": "Atarka Monument",
             "text": "{T}: Add {R} or {G} to your mana pool.\n{4}{R}{G}: Atarka Monument becomes a 4/4 red and green Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "2fae3294-3f9d-5dec-b7ee-5105b36c897e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f061-9506-40fb-b10d-4bada38ca0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f061-9506-40fb-b10d-4bada38ca0f7.jpg?1",
             "name": "Custodian of the Trove",
             "text": "Defender\nCustodian of the Trove enters the battlefield tapped.",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "c174d8a1-191e-5bdb-8144-d903e645b397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7463c18-5bef-42a0-a37e-6112809ebc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7463c18-5bef-42a0-a37e-6112809ebc78.jpg?1",
             "name": "Dragonloft Idol",
             "text": "As long as you control a Dragon, Dragonloft Idol gets +1/+1 and has flying and trample.",
             "colours": [],
@@ -8019,7 +8019,7 @@
         },
         {
             "id": "9b4274c3-173e-51bd-9abe-ea8223d357f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df975f-b6ef-4e8e-8be8-529c0ffd8a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df975f-b6ef-4e8e-8be8-529c0ffd8a37.jpg?1",
             "name": "Dromoka Monument",
             "text": "{T}: Add {G} or {W} to your mana pool.\n{4}{G}{W}: Dromoka Monument becomes a 4/4 green and white Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "3d81011f-defe-519e-8bde-03dd1ad9f6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001e8222-8dea-4767-8c13-21fb7ba556d7.jpg?1",
             "name": "Gate Smasher",
             "text": "Gate Smasher can be attached only to a creature with toughness 4 or greater.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "1d377c83-74b6-58d0-8abd-a13f38adc9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6c502-ae3e-4e67-8f1d-3323b4468f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d6c502-ae3e-4e67-8f1d-3323b4468f72.jpg?1",
             "name": "Keeper of the Lens",
             "text": "You may look at face-down creatures you don't control. (You may do this at any time.)",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "9df978d1-61fc-59e5-b8ca-3b5b9926b41a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620cddb7-abf7-4367-8440-815b886db8e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620cddb7-abf7-4367-8440-815b886db8e0.jpg?1",
             "name": "Kolaghan Monument",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{4}{B}{R}: Kolaghan Monument becomes a 4/4 black and red Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "55792f05-92bf-5592-a9bc-9547870916b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29942-a7e3-4e47-9f95-527a5d7e4f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29942-a7e3-4e47-9f95-527a5d7e4f1d.jpg?1",
             "name": "Ojutai Monument",
             "text": "{T}: Add {W} or {U} to your mana pool.\n{4}{W}{U}: Ojutai Monument becomes a 4/4 white and blue Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "f69445e6-4110-5362-8517-e91d42031858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3243e300-1420-4e96-a3d3-610c3723a11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3243e300-1420-4e96-a3d3-610c3723a11f.jpg?1",
             "name": "Silumgar Monument",
             "text": "{T}: Add {U} or {B} to your mana pool.\n{4}{U}{B}: Silumgar Monument becomes a 4/4 blue and black Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -8204,7 +8204,7 @@
         },
         {
             "id": "3692b236-308a-5f4a-87be-ae96bb3c7a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561b47c-b863-463a-8a10-56fede2cb42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561b47c-b863-463a-8a10-56fede2cb42c.jpg?1",
             "name": "Spidersilk Net",
             "text": "Equipped creature gets +0/+2 and has reach. (It can block creatures with flying.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "066b9133-196d-5c15-b8c9-9bb61fc637b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b08344-780d-4bd7-882a-dcadeb40f159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b08344-780d-4bd7-882a-dcadeb40f159.jpg?1",
             "name": "Stormrider Rig",
             "text": "Equipped creature gets +1/+1.\nWhenever a creature enters the battlefield under your control, you may attach Stormrider Rig to it.\nEquip {2}",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "5a334c91-4a89-58d8-b04a-449d40d9373a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e5e24-d704-4f1c-9577-0f25aaabb7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e5e24-d704-4f1c-9577-0f25aaabb7ed.jpg?1",
             "name": "Tapestry of the Ages",
             "text": "{2}, {T}: Draw a card. Activate this ability only if you've cast a noncreature spell this turn.",
             "colours": [],
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "0d146a66-1402-531e-9bad-ad0fcdef32f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e88fe-307a-4944-9233-14df4e0bb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e88fe-307a-4944-9233-14df4e0bb775.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: Vial of Dragonfire deals 2 damage to target creature.",
             "colours": [],
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "c901a24a-4332-57a6-a95e-596e0e8a62db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb66398d-afb4-41d9-a8b8-ec115d2ad5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb66398d-afb4-41d9-a8b8-ec115d2ad5f2.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8348,7 +8348,7 @@
         },
         {
             "id": "55fabcc4-7129-5613-8a0e-693ba4eaf878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9910042e-091f-47da-ad29-8f76c9d3b8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9910042e-091f-47da-ad29-8f76c9d3b8c1.jpg?1",
             "name": "Haven of the Spirit Dragon",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a Dragon creature spell.\n{2}, {T}, Sacrifice Haven of the Spirit Dragon: Return target Dragon creature card or Ugin planeswalker card from your graveyard to your hand.",
             "colours": [],
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "2248938b-8183-5149-990e-55d2cac0d2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf91075-8d8d-43c3-8125-2469e2dcd132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf91075-8d8d-43c3-8125-2469e2dcd132.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8413,7 +8413,7 @@
         },
         {
             "id": "60144f0e-9761-5476-9d4f-1fc31ff89e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2484c9db-44bc-411c-af43-bfe0e30f0ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2484c9db-44bc-411c-af43-bfe0e30f0ffa.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "b8aafd34-77e3-5f65-bd1b-cc46c4640315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f2bcd-8d37-417c-a969-86e04f1daf23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f2bcd-8d37-417c-a969-86e04f1daf23.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "a1b40fb9-fec1-5bec-b994-a96b8e0c0ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2f901-7d7b-47ec-a3d4-96ddcbd9218c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2f901-7d7b-47ec-a3d4-96ddcbd9218c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "dbef8fa7-0a1f-590d-9507-45653279185c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78732e7f-421d-43e8-8f43-341bb01e993e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78732e7f-421d-43e8-8f43-341bb01e993e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "5723abb8-6486-5585-830e-695bd1c8c0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ac118-6d94-4f3b-9873-7a2440ab92d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966ac118-6d94-4f3b-9873-7a2440ab92d9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "e183fcd2-a6f5-592a-a407-78b04295c945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4498e-e753-418e-8db6-e11d2caac3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f4498e-e753-418e-8db6-e11d2caac3b1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "4fe3ed72-97c6-501b-ab16-208e3ee53185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4873cb-43ce-47b4-9d91-a8495a244c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4873cb-43ce-47b4-9d91-a8495a244c85.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "c5481830-959f-55e3-979b-41574a18ffbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846729-deec-436f-af5c-08faf53ec36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d846729-deec-436f-af5c-08faf53ec36f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8709,7 +8709,7 @@
         },
         {
             "id": "4dd86277-5f6c-581c-a032-3a8c45b4e049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54968fa2-36f1-4d21-89e7-a307d68cfccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54968fa2-36f1-4d21-89e7-a307d68cfccc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "155931ea-cdf3-5cdc-9923-cfd6f16b55db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f613b2-de5b-4592-8d14-5ad373537a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f613b2-de5b-4592-8d14-5ad373537a21.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "7ed8596b-ef0d-536c-8ff2-bd05207e40af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c356eb7-ebf4-400d-95a7-7452382bc32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c356eb7-ebf4-400d-95a7-7452382bc32f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "31be3f47-9c33-5ee1-844a-e6c36d07ac80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f341b39-ac40-436b-967c-568265354886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f341b39-ac40-436b-967c-568265354886.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "4c95ff48-606b-58f0-b736-f3cf6a8e2835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c9425a-2093-40c1-b3a9-a882d80cf198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c9425a-2093-40c1-b3a9-a882d80cf198.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8894,7 +8894,7 @@
         },
         {
             "id": "589002de-2c7b-5e6f-a64e-9c61268d61aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67becef5-cd70-4fe9-b8a3-1bff2ea04ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67becef5-cd70-4fe9-b8a3-1bff2ea04ab4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8931,7 +8931,7 @@
         },
         {
             "id": "333f27ec-e546-5d55-b739-ae314b12aefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677a1d9d-86fd-49db-9573-8cd2cbc1a096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677a1d9d-86fd-49db-9573-8cd2cbc1a096.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "309ecb76-1644-5382-887e-9d2a6a14381e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e8077e-4400-4923-afe6-6ff5a51b5e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e8077e-4400-4923-afe6-6ff5a51b5e91.jpg?1",
             "name": "Djinn Monk",
             "text": "",
             "colours": [
@@ -9000,7 +9000,7 @@
         },
         {
             "id": "f4bb30b0-4043-5507-adc3-cd7b229b2ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4de662d-374d-4dd7-908f-bcde7bdc5ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4de662d-374d-4dd7-908f-bcde7bdc5ae9.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9034,7 +9034,7 @@
         },
         {
             "id": "c648341a-d6a1-51c3-95c2-acaf0fdfe6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c41ab-d9ee-4817-a982-41d4da6fa9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533c41ab-d9ee-4817-a982-41d4da6fa9ad.jpg?1",
             "name": "Zombie Horror",
             "text": "",
             "colours": [
@@ -9069,7 +9069,7 @@
         },
         {
             "id": "c3375df1-7408-53da-bfd3-2d02d1394323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0725f-8562-49c2-83fa-11a702e5c78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0725f-8562-49c2-83fa-11a702e5c78d.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "4e38df2b-44f9-5199-bff8-87c0aa26a91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55d42ad-63b1-4468-8da0-c245db4d0ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55d42ad-63b1-4468-8da0-c245db4d0ae3.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9137,7 +9137,7 @@
         },
         {
             "id": "335a7198-afd5-582a-a988-51b077a203f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f29231c-dd21-4a45-a1f0-464d338128ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f29231c-dd21-4a45-a1f0-464d338128ed.jpg?1",
             "name": "Morph",
             "text": "",
             "colours": [],
@@ -9164,7 +9164,7 @@
         },
         {
             "id": "bf5f7333-ba0e-5c38-969e-c29de3b1d417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a70dfe0-874c-473a-a26e-1f88a842df41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a70dfe0-874c-473a-a26e-1f88a842df41.jpg?1",
             "name": "Narset Transcendent Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ELD.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ELD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7ebde572-911a-5ce4-a607-fe21718e01e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b12e7-bb93-4eb6-bad1-b256a6ccff4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b12e7-bb93-4eb6-bad1-b256a6ccff4e.jpg?1",
             "name": "Acclaimed Contender",
             "text": "When Acclaimed Contender enters the battlefield, if you control another Knight, look at the top five cards of your library. You may reveal a Knight, Aura, Equipment, or legendary artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "f045cc48-0343-50fe-8298-8b862cea93bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9713032-2956-4564-b5f5-2dd16245a4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9713032-2956-4564-b5f5-2dd16245a4e6.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "53ff6480-29a3-564c-8006-baea54baf120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ca60c-7ed4-49e1-b54a-91d129539375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684ca60c-7ed4-49e1-b54a-91d129539375.jpg?1",
             "name": "Archon of Absolution",
             "text": "Flying\nProtection from white (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything white.)\nCreatures can't attack you or a planeswalker you control unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "aaea1863-e4d3-5686-acfe-95f4dfac4bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32fa360-6c41-4146-931b-c19e9a766803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32fa360-6c41-4146-931b-c19e9a766803.jpg?1",
             "name": "Ardenvale Paladin",
             "text": "Adamant \u2014 If at least three white mana was spent to cast this spell, Ardenvale Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "387eb117-53ec-5272-b887-9ac2b3221bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "Flying",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "345c03f4-4667-55e3-bf82-c53a360a1675",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "Tap up to two target creatures. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "2e70ab93-91d9-5b1b-9da5-0b0fbc33a36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de43c67-7dfe-4282-b433-4e394366d2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de43c67-7dfe-4282-b433-4e394366d2e9.jpg?1",
             "name": "Bartered Cow",
             "text": "When Bartered Cow dies or when you discard it, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "deadf543-11a5-5b9f-8960-c4a3cbd5bac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6ee4eb-70b2-4f99-9d54-5caf2d3713be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6ee4eb-70b2-4f99-9d54-5caf2d3713be.jpg?1",
             "name": "Beloved Princess",
             "text": "Lifelink\nBeloved Princess can't be blocked by creatures with power 3 or greater.",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "51a8ed36-1e45-5c6b-9417-a237507b3b4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb94950-3f3e-4876-84f8-d5e4d9cfecee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb94950-3f3e-4876-84f8-d5e4d9cfecee.jpg?1",
             "name": "Charming Prince",
             "text": "When Charming Prince enters the battlefield, choose one \u2014\n\u2022 Scry 2.\n\u2022 You gain 3 life.\n\u2022 Exile another target creature you own. Return it to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "eacb708a-214c-5991-9e1e-07c00625acfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79093d00-362d-4d07-8a0a-cf5e1ccf9c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79093d00-362d-4d07-8a0a-cf5e1ccf9c0f.jpg?1",
             "name": "The Circle of Loyalty",
             "text": "This spell costs {1} less to cast for each Knight you control.\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "966e7d05-c334-546e-b610-749ea04e84f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6072d9b0-d3c7-46f4-bd24-095bb13c4dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6072d9b0-d3c7-46f4-bd24-095bb13c4dea.jpg?1",
             "name": "Deafening Silence",
             "text": "Each player can't cast more than one noncreature spell each turn.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "9e5550cb-10e1-59ca-b5c7-435c3dc263fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "Flying",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "87571e42-2272-5c7a-9d6b-1e1156b0f840",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8bbece8-9620-44d9-b991-350fe952538a.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "Target creature gets +2/+1 and gains flying until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "db73594f-d131-5b59-8f82-c5a1f4c94b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769cddf0-2078-456b-a622-057571464fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769cddf0-2078-456b-a622-057571464fe7.jpg?1",
             "name": "Flutterfox",
             "text": "As long as you control an artifact or enchantment, Flutterfox has flying.",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "54d3da09-0dfe-5e35-a33b-2aea643d8651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ce113c-53da-4fab-b7c9-fc3df248b65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ce113c-53da-4fab-b7c9-fc3df248b65e.jpg?1",
             "name": "Fortifying Provisions",
             "text": "Creatures you control get +0/+1.\nWhen Fortifying Provisions enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "91680403-7ed7-5c5a-8f38-b2005200e27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "{1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "6322919e-dd2c-5ca6-9408-fecd46c33671",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "Destroy target creature with power 4 or greater. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "1b262ddb-de89-5a53-983f-8d6e3d983dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1c51-d245-4771-bf61-415297e4f9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1c51-d245-4771-bf61-415297e4f9d5.jpg?1",
             "name": "Glass Casket",
             "text": "When Glass Casket enters the battlefield, exile target creature an opponent controls with converted mana cost 3 or less until Glass Casket leaves the battlefield.",
             "colours": [
@@ -636,7 +636,7 @@
         },
         {
             "id": "ddca76fa-b633-56fb-9503-e4117d19e58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d85d5-a6f0-4cc5-9fd6-6b329aae2e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d85d5-a6f0-4cc5-9fd6-6b329aae2e5b.jpg?1",
             "name": "Happily Ever After",
             "text": "When Happily Ever After enters the battlefield, each player gains 5 life and draws a card.\nAt the beginning of your upkeep, if there are five colors among permanents you control, there are six or more card types among permanents you control and/or cards in your graveyard, and your life total is greater than or equal to your starting life total, you win the game.",
             "colours": [
@@ -670,7 +670,7 @@
         },
         {
             "id": "1922fc6f-2bec-5803-aa7a-3f8132d01a43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7093834-9627-4da2-9322-c03bfd5b3a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7093834-9627-4da2-9322-c03bfd5b3a71.jpg?1",
             "name": "Harmonious Archon",
             "text": "Flying\nNon-Archon creatures have base power and toughness 3/3.\nWhen Harmonious Archon enters the battlefield, create two 1/1 white Human creature tokens.",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "3d05d919-983b-5efa-a65a-a429f6f2529f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663b3e6f-1099-4de8-a0a7-6f1919c38010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663b3e6f-1099-4de8-a0a7-6f1919c38010.jpg?1",
             "name": "Hushbringer",
             "text": "Flying, lifelink\nCreatures entering the battlefield or dying don't cause abilities to trigger.",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "83b512cf-106c-5461-a31a-f8c842583409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49653d-cd4e-40a7-99de-fc531b5d8594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d49653d-cd4e-40a7-99de-fc531b5d8594.jpg?1",
             "name": "Knight of the Keep",
             "text": "",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "83bba8bd-dc90-5739-ba31-df347823775e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ab467-be97-4b84-a73d-b03484d06b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ab467-be97-4b84-a73d-b03484d06b97.jpg?1",
             "name": "Linden, the Steadfast Queen",
             "text": "Vigilance\nWhenever a white creature you control attacks, you gain 1 life.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "5c7667ca-4006-532b-a8b5-eb9dcdd841f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "Vigilance",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "56effca8-14d7-5489-8bf6-e308c1314c64",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99083707-2152-42c0-b5c3-b4f97ec20190.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "451f195e-d557-50cc-ae0b-39dc7c099239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1028aa10-aded-4aeb-b70f-d7a9003ae846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1028aa10-aded-4aeb-b70f-d7a9003ae846.jpg?1",
             "name": "Mysterious Pathlighter",
             "text": "Flying\nEach creature you control that has an Adventure enters the battlefield with an additional +1/+1 counter on it. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "b2cd346d-f5c5-5246-99e2-270b865502c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663e0208-81c3-4a76-bcc2-bc59cf8ca649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663e0208-81c3-4a76-bcc2-bc59cf8ca649.jpg?1",
             "name": "Outflank",
             "text": "Outflank deals damage to target attacking or blocking creature equal to the number of creatures you control.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "4c953c2a-76b6-53ed-851c-aefe087e111c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877bd423-83ff-4a28-b0d2-447a7821bb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877bd423-83ff-4a28-b0d2-447a7821bb8c.jpg?1",
             "name": "Prized Griffin",
             "text": "Flying",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "805f103f-c18b-5dd0-a69e-afa38e2ea3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d7ff0-70b6-4221-b50b-3ee8547e1b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548d7ff0-70b6-4221-b50b-3ee8547e1b0a.jpg?1",
             "name": "Rally for the Throne",
             "text": "Create two 1/1 white Human creature tokens.\nAdamant \u2014 If at least three white mana was spent to cast this spell, you gain 1 life for each creature you control.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "3699ea8c-6b2d-5ef2-8aad-85f3b7a5ef8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "Vigilance",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "d7d28769-c1e9-53a0-8f31-cfc44919d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e5c8cf1-1d7c-49e5-bfad-7e13c418118f.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "Destroy all non-Giant creatures. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "13a45c3e-acf7-546e-a67a-c293e9e8184e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910df2-e288-4fa0-9859-c5ca35da2d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910df2-e288-4fa0-9859-c5ca35da2d55.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "1dddec28-ae0e-512e-a8a8-e93e1606fb8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "8580848d-5d70-5f53-966f-2c0979f71e02",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0b4f0ce-0d18-4546-803d-94a2f4f30951.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "Return target permanent you control to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "161c939a-5d1b-5331-959a-b2a3417f7547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7791f46e-f772-4d3f-824e-52b4fc721b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7791f46e-f772-4d3f-824e-52b4fc721b58.jpg?1",
             "name": "Shining Armor",
             "text": "Flash\nWhen Shining Armor enters the battlefield, attach it to target Knight you control.\nEquipped creature gets +0/+2 and has vigilance.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "073b5d29-9abc-56d4-b503-844d87776846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad7efd1-5f53-4466-9a02-c474c265298a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad7efd1-5f53-4466-9a02-c474c265298a.jpg?1",
             "name": "Silverflame Ritual",
             "text": "Put a +1/+1 counter on each creature you control.\nAdamant \u2014 If at least three white mana was spent to cast this spell, creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "bc7f6a84-51f1-5f5b-af14-ec1719cebb05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "f5bbbeae-e0b7-50e2-8666-197c3831aa8d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bd105f3-fa33-4490-aea9-b47ca121b664.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "Target creature gets +2/+2 until end of turn. Untap it. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "714b9b3c-2d29-559d-8060-e872a04282cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cddb2d2-d813-4b83-a592-380ba4edf54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cddb2d2-d813-4b83-a592-380ba4edf54f.jpg?1",
             "name": "Syr Alin, the Lion's Claw",
             "text": "First strike\nWhenever Syr Alin, the Lion's Claw attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1373,7 +1373,7 @@
         },
         {
             "id": "ed77de73-efcb-564f-931b-8fea1f03b36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974e84ce-5b51-4bd7-9a4d-b64d8f8f62d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974e84ce-5b51-4bd7-9a4d-b64d8f8f62d4.jpg?1",
             "name": "Trapped in the Tower",
             "text": "Enchant creature without flying\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1407,7 +1407,7 @@
         },
         {
             "id": "62c672b0-87f3-5e93-a9b8-d9de6013926a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4bac2-f6cb-4712-8510-a63657c43a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a4bac2-f6cb-4712-8510-a63657c43a5c.jpg?1",
             "name": "True Love's Kiss",
             "text": "Exile target artifact or enchantment.\nDraw a card.",
             "colours": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "a25e879a-579b-59fd-b069-4deff1f0aca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001f1ef-b957-4a55-b47f-14839cdbab6f.jpg?1",
             "name": "Venerable Knight",
             "text": "When Venerable Knight dies, put a +1/+1 counter on target Knight you control.",
             "colours": [
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "4b50fe89-fa8b-5e05-9fa9-586c5b67f9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2bde2d-e5df-407e-993c-85880dbb6045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2bde2d-e5df-407e-993c-85880dbb6045.jpg?1",
             "name": "Worthy Knight",
             "text": "Whenever you cast a Knight spell, create a 1/1 white Human creature token.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "dbc1152c-966d-5361-bfe8-112dfcf79595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1a3fec-39de-4223-9da2-22749a58cd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1a3fec-39de-4223-9da2-22749a58cd62.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "b4fa27bb-bf91-5c50-b22d-9d5656230820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "Flying",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "dfd33ae1-2d4e-570e-b5ed-85704ba766db",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32158458-42eb-41bc-a15a-11af28463eb0.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on it.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "51c8a322-0601-51ed-b5f9-bebb5d97b5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "Flash\nFlying\nBrazen Borrower can block only creatures with flying.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "6d05f540-87ee-53cb-b9ae-dcb9d1ff8844",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c2089ec9-0665-448f-bfe9-d181de127814.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "Return target nonland permanent an opponent controls to its owner's hand.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "f543c0a9-c3bf-5daa-9ab6-7d4fb5f47f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f97d9e-650b-4b69-8733-d80c8e0f723f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f97d9e-650b-4b69-8733-d80c8e0f723f.jpg?1",
             "name": "Charmed Sleep",
             "text": "Enchant creature\nWhen Charmed Sleep enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "da03442a-bfc6-538b-87e1-c98b8d5cfb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9347802a-0971-443c-867a-cb9400f18d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9347802a-0971-443c-867a-cb9400f18d5c.jpg?1",
             "name": "Corridor Monitor",
             "text": "When Corridor Monitor enters the battlefield, untap target artifact or creature you control.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "fbf9e0ad-f134-57b6-b4a4-929f78887993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77500b53-0852-4d6a-bfe3-b1e8ef5a12cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77500b53-0852-4d6a-bfe3-b1e8ef5a12cd.jpg?1",
             "name": "Didn't Say Please",
             "text": "Counter target spell. Its controller puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "be49dcfd-70d3-52a6-a597-912540e42e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4b9a8a-b42a-46fb-b0d0-9cf800f63c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4b9a8a-b42a-46fb-b0d0-9cf800f63c8a.jpg?1",
             "name": "Emry, Lurker of the Loch",
             "text": "This spell costs {1} less to cast for each artifact you control.\nWhen Emry, Lurker of the Loch enters the battlefield, put the top four cards of your library into your graveyard.\n{T}: Choose target artifact card in your graveyard. You may cast that card this turn. (You still pay its costs. Timing rules still apply.)",
             "colours": [
@@ -1831,7 +1831,7 @@
         },
         {
             "id": "c02816a4-59bf-5549-b5c7-59b86c760f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "Flying\n{1}{U}, Discard two cards: Return Fae of Wishes to its owner's hand.",
             "colours": [
@@ -1868,7 +1868,7 @@
         },
         {
             "id": "bb837ff4-f864-52e5-a244-eb416d598986",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "You may choose a noncreature card you own from outside the game, reveal it, and put it into your hand.",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "1f36d944-7a4b-5fdf-8c17-63e550a58c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789c5c2b-3e51-4f6c-ac76-d276facf716f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789c5c2b-3e51-4f6c-ac76-d276facf716f.jpg?1",
             "name": "Faerie Vandal",
             "text": "Flash\nFlying\nWhenever you draw your second card each turn, put a +1/+1 counter on Faerie Vandal.",
             "colours": [
@@ -1939,7 +1939,7 @@
         },
         {
             "id": "c5bdfd03-bf15-5ce3-9729-fd38098f5362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc67d1-1018-4a15-ab5f-377fd11dcd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afc67d1-1018-4a15-ab5f-377fd11dcd3d.jpg?1",
             "name": "Folio of Fancies",
             "text": "Players have no maximum hand size.\n{X}{X}, {T}: Each player draws X cards.\n{2}{U}, {T}: Each opponent puts a number of cards equal to the number of cards in their hand from the top of their library into their graveyard.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "5d15164e-fdd8-55f0-a4f9-1a88207b9c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cbb20-3c4e-480b-a330-9c6d6b39d12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cbb20-3c4e-480b-a330-9c6d6b39d12f.jpg?1",
             "name": "Frogify",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1. (It loses all other card types and creature types.)",
             "colours": [
@@ -2007,7 +2007,7 @@
         },
         {
             "id": "0f6208a8-2b72-5e81-b597-d7838749f951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ddce0d-f22a-4fcd-9a4a-d71938750ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ddce0d-f22a-4fcd-9a4a-d71938750ba1.jpg?1",
             "name": "Gadwick, the Wizened",
             "text": "When Gadwick, the Wizened enters the battlefield, draw X cards.\nWhenever you cast a blue spell, tap target nonland permanent an opponent controls.",
             "colours": [
@@ -2046,7 +2046,7 @@
         },
         {
             "id": "57214924-fcae-54b4-a6e6-0b9ffe18897d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "Flying",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "c5652c2c-a4ff-58e4-a8e1-eb4f7cfffe2e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7acbd812-b994-4e68-8f95-04222796e994.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "Counter target spell with converted mana cost 3 or less. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "d58d86a0-c935-5432-b26c-e8dca90e771e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c838f08e-7fb6-46e7-83bb-dce8877d6c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c838f08e-7fb6-46e7-83bb-dce8877d6c87.jpg?1",
             "name": "Into the Story",
             "text": "This spell costs {3} less to cast if an opponent has seven or more cards in their graveyard.\nDraw four cards.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "30c1cb26-cafa-565d-a597-5f226e8cf708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b89af1-7b22-4153-b42d-a2ea4e0f320c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b89af1-7b22-4153-b42d-a2ea4e0f320c.jpg?1",
             "name": "The Magic Mirror",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nYou have no maximum hand size.\nAt the beginning of your upkeep, put a knowledge counter on The Magic Mirror, then draw a card for each knowledge counter on The Magic Mirror.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "9cef53d2-7445-5fc0-8b4d-85f1a30bdbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058d01e-f705-4407-bd9e-a2d127afdf04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c058d01e-f705-4407-bd9e-a2d127afdf04.jpg?1",
             "name": "Mantle of Tides",
             "text": "Equipped creature gets +1/+2.\nWhenever you draw your second card each turn, attach Mantle of Tides to target creature you control.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "2af500fe-ae8a-58c9-8cbe-9f4491fce2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "31468d7c-d6d2-55d4-80b3-661261e1eb69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb7308d-608c-4ede-9496-d795fc5bb271.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "Target player puts the top four cards of their library into their graveyard. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "9eeb10fb-676b-52cd-9f26-4edf3f15f069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7f1148-7b1b-4969-a2f8-428de1e2e8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7f1148-7b1b-4969-a2f8-428de1e2e8ff.jpg?1",
             "name": "Midnight Clock",
             "text": "{T}: Add {U}.\n{2}{U}: Put an hour counter on Midnight Clock.\nAt the beginning of each upkeep, put an hour counter on Midnight Clock.\nWhen the twelfth hour counter is put on Midnight Clock, shuffle your hand and graveyard into your library, then draw seven cards. Exile Midnight Clock.",
             "colours": [
@@ -2327,7 +2327,7 @@
         },
         {
             "id": "54b1fa21-a848-51a5-aec8-63b087cced26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10c1407-d397-4caa-b7b7-e7d91ffd4ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10c1407-d397-4caa-b7b7-e7d91ffd4ee9.jpg?1",
             "name": "Mirrormade",
             "text": "You may have Mirrormade enter the battlefield as a copy of any artifact or enchantment on the battlefield.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "7ae19a7e-8232-5558-a377-6f57242ce9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c78c386-c64b-4fab-a718-f18b46360e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c78c386-c64b-4fab-a718-f18b46360e20.jpg?1",
             "name": "Mistford River Turtle",
             "text": "Whenever Mistford River Turtle attacks, another target attacking non-Human creature can't be blocked this turn.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "4425f1f0-f882-5eaf-a778-179a19cf963e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a658bbd-8d64-460b-87ae-ec8054204794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a658bbd-8d64-460b-87ae-ec8054204794.jpg?1",
             "name": "Moonlit Scavengers",
             "text": "When Moonlit Scavengers enters the battlefield, if you control an artifact or enchantment, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "5651bd95-cb41-5266-8654-93707f0c4f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe04cb8-a8b9-4241-baae-b398a2509a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe04cb8-a8b9-4241-baae-b398a2509a3a.jpg?1",
             "name": "Mystical Dispute",
             "text": "This spell costs {2} less to cast if it targets a blue spell.\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "3bb348f6-c64a-5540-a052-40b799c0301b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3669391-8f64-4904-b432-0f0582f30449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3669391-8f64-4904-b432-0f0582f30449.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "55aefaee-be7d-52f8-a75a-8518a348ffc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659092e-4fe8-42be-ab03-efc99ed37436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8659092e-4fe8-42be-ab03-efc99ed37436.jpg?1",
             "name": "Overwhelmed Apprentice",
             "text": "When Overwhelmed Apprentice enters the battlefield, each opponent puts the top two cards of their library into their graveyard. Then you scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "a86a55eb-9812-530b-9618-92eb860c2e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "Whenever Queen of Ice deals combat damage to a creature, tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "97f40d3e-37a6-5923-8387-52e5fe12e8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/de2f964a-e4e1-4321-92ad-34b781868e11.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "06db99b2-a318-5d62-ae7e-4440f7ab27b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeffc3c0-567c-442f-ba06-b7d9617c5789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeffc3c0-567c-442f-ba06-b7d9617c5789.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "aa7f274a-6812-5560-b5de-9263df65e0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3aa4-4b46-4daa-a7a8-400a20c59435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274e3aa4-4b46-4daa-a7a8-400a20c59435.jpg?1",
             "name": "Sage of the Falls",
             "text": "Whenever Sage of the Falls or another non-Human creature enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "dc1ec750-ccef-5538-a559-0dce7969741a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421650f2-1b34-4a36-9675-9424997c9d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421650f2-1b34-4a36-9675-9424997c9d0b.jpg?1",
             "name": "So Tiny",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-0. It gets -6/-0 instead as long as its controller has seven or more cards in their graveyard.",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "ab73b88e-b751-57d7-958c-6edb6d97f80a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d361328-8b0a-40a0-b5c0-215398fdfb47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d361328-8b0a-40a0-b5c0-215398fdfb47.jpg?1",
             "name": "Steelgaze Griffin",
             "text": "Flying\nWhenever you draw your second card each turn, Steelgaze Griffin gets +2/+0 until end of turn.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "ed815b0b-76c6-5a95-bae8-f4d29130c55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a7698-57fb-41f6-86d4-251c7d444c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a7698-57fb-41f6-86d4-251c7d444c6a.jpg?1",
             "name": "Stolen by the Fae",
             "text": "Return target creature with converted mana cost X to its owner's hand. You create X 1/1 blue Faerie creature tokens with flying.",
             "colours": [
@@ -2772,7 +2772,7 @@
         },
         {
             "id": "e0fb0b08-1121-5a60-9115-4edde0db4ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a0817-2e9c-4d98-974c-2d3e5c37e1a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a0817-2e9c-4d98-974c-2d3e5c37e1a2.jpg?1",
             "name": "Syr Elenora, the Discerning",
             "text": "Syr Elenora, the Discerning's power is equal to the number of cards in your hand.\nWhen Syr Elenora enters the battlefield, draw a card.\nSpells your opponents cast that target Syr Elenora cost {2} more to cast.",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "e739f8b6-e4e2-5208-bf52-8b8088c5ae3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ad850-5801-4654-a388-f86be20a43bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ad850-5801-4654-a388-f86be20a43bf.jpg?1",
             "name": "Tome Raider",
             "text": "Flying\nWhen Tome Raider enters the battlefield, draw a card.",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "ac08f109-cef3-5819-ba32-583086587870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a37dcb-4a18-4f03-b28c-27188a1a5ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a37dcb-4a18-4f03-b28c-27188a1a5ec1.jpg?1",
             "name": "Turn into a Pumpkin",
             "text": "Return target nonland permanent to its owner's hand. Draw a card.\nAdamant \u2014 If at least three blue mana was spent to cast this spell, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -2875,7 +2875,7 @@
         },
         {
             "id": "d0e4c4f4-1432-527e-ac41-34b2fcb4fe96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1de1d84-e548-409d-b9ec-d2665477b43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1de1d84-e548-409d-b9ec-d2665477b43d.jpg?1",
             "name": "Unexplained Vision",
             "text": "Draw three cards.\nAdamant \u2014 If at least three blue mana was spent to cast this spell, scry 3.",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "30e7a954-da07-5e47-92f3-53abf5b21296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff1c8d-0f25-4bec-bd50-208ae2ac0aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff1c8d-0f25-4bec-bd50-208ae2ac0aac.jpg?1",
             "name": "Vantress Gargoyle",
             "text": "Flying\nVantress Gargoyle can't attack unless defending player has seven or more cards in their graveyard.\nVantress Gargoyle can't block unless you have four or more cards in hand.\n{T}: Each player puts the top card of their library into their graveyard.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "7d2b6618-87c5-52bd-a787-1024d040eea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dd633f-9a07-47df-adb1-36013fc2f43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dd633f-9a07-47df-adb1-36013fc2f43a.jpg?1",
             "name": "Vantress Paladin",
             "text": "Flying\nAdamant \u2014 If at least three blue mana was spent to cast this spell, Vantress Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "626d95b7-56c7-5b24-99e3-baba831fc708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9358d5d-726e-43e0-a58e-4cfe7c755913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9358d5d-726e-43e0-a58e-4cfe7c755913.jpg?1",
             "name": "Wishful Merfolk",
             "text": "Defender\n{1}{U}: Wishful Merfolk loses defender and becomes a Human until end of turn.",
             "colours": [
@@ -3013,7 +3013,7 @@
         },
         {
             "id": "b55ab864-594e-5942-ae07-253cd2973b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3132f-f897-4a7a-9de4-c6388e83f5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3132f-f897-4a7a-9de4-c6388e83f5ad.jpg?1",
             "name": "Witching Well",
             "text": "When Witching Well enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{3}{U}, Sacrifice Witching Well: Draw two cards.",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "c699a4f4-1295-5cce-89d4-e7c0fda5a1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ace28-9a33-4f0d-b8c8-f5517f20ccf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ace28-9a33-4f0d-b8c8-f5517f20ccf1.jpg?1",
             "name": "Ayara, First of Locthwain",
             "text": "Whenever Ayara, First of Locthwain or another black creature enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.\n{T}, Sacrifice another black creature: Draw a card.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "ca7c4ece-bea2-52fb-b56e-e3ceecf18a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a4d090-1bb7-4334-ab22-e2527391e79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a4d090-1bb7-4334-ab22-e2527391e79b.jpg?1",
             "name": "Bake into a Pie",
             "text": "Destroy target creature. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "179d04be-61ce-5152-bb33-c4ada8c11771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45707c22-fce8-4dbd-9d19-73f08c68f449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45707c22-fce8-4dbd-9d19-73f08c68f449.jpg?1",
             "name": "Barrow Witches",
             "text": "When Barrow Witches enters the battlefield, return target Knight card from your graveyard to your hand.",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "804f8427-d707-5bfc-8fa4-b9b8459763ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3c992a-70b5-4d3c-9a96-93c3365691ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3c992a-70b5-4d3c-9a96-93c3365691ac.jpg?1",
             "name": "Belle of the Brawl",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Belle of the Brawl attacks, other Knights you control get +1/+0 until end of turn.",
             "colours": [
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "1854518a-e0c9-54c8-ae5d-4c3448793a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0a63bb-dd94-429f-aa9b-21f3d1c53ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0a63bb-dd94-429f-aa9b-21f3d1c53ae5.jpg?1",
             "name": "Blacklance Paragon",
             "text": "Flash\nWhen Blacklance Paragon enters the battlefield, target Knight gains deathtouch and lifelink until end of turn.",
             "colours": [
@@ -3223,7 +3223,7 @@
         },
         {
             "id": "bd247c88-9207-5d60-9033-330ab0a2594e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf282fe-83fd-4208-b46f-dae76e3a7f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf282fe-83fd-4208-b46f-dae76e3a7f62.jpg?1",
             "name": "Bog Naughty",
             "text": "Flying\n{2}{B}, Sacrifice a Food: Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "a18b87d1-223f-5c9f-983f-df9a2df5d40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a539a23-8383-4525-82dd-acfe1d219fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a539a23-8383-4525-82dd-acfe1d219fe9.jpg?1",
             "name": "Cauldron Familiar",
             "text": "When Cauldron Familiar enters the battlefield, each opponent loses 1 life and you gain 1 life.\nSacrifice a Food: Return Cauldron Familiar from your graveyard to the battlefield.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "d2fbe660-727d-54c3-8236-017da88bbded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55cdc15-e289-49a0-94d9-d0a118ad0a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55cdc15-e289-49a0-94d9-d0a118ad0a2a.jpg?1",
             "name": "A-Cauldron Familiar",
             "text": "",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "ab5b6ad3-3d04-552e-8310-c1b83d41ecb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb69473f-de99-43a7-b094-429465ae735c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb69473f-de99-43a7-b094-429465ae735c.jpg?1",
             "name": "The Cauldron of Eternity",
             "text": "This spell costs {2} less to cast for each creature card in your graveyard.\nWhenever a creature you control dies, put it on the bottom of its owner's library.\n{2}{B}, {T}, Pay 2 life: Return target creature card from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "92e12af9-81f7-53c4-ab48-bcaa708da3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db19a94-1170-45a0-9f06-893bf58b7233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db19a94-1170-45a0-9f06-893bf58b7233.jpg?1",
             "name": "Cauldron's Gift",
             "text": "Adamant \u2014 If at least three black mana was spent to cast this spell, put the top four cards of your library into your graveyard.\nYou may choose a creature card in your graveyard. If you do, return it to the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "ca832926-1143-5474-93f5-93aa7b75ea8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85929131-4df6-415c-b592-aefb2943c477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85929131-4df6-415c-b592-aefb2943c477.jpg?1",
             "name": "Clackbridge Troll",
             "text": "Trample, haste\nWhen Clackbridge Troll enters the battlefield, target opponent creates three 0/1 white Goat creature tokens.\nAt the beginning of combat on your turn, any opponent may sacrifice a creature. If a player does, tap Clackbridge Troll, you gain 3 life, and you draw a card.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "10939fcd-ecb1-51b0-9d0d-4a342a446cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63da83fe-fa59-40cb-a42e-e1b14b650bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63da83fe-fa59-40cb-a42e-e1b14b650bc8.jpg?1",
             "name": "Epic Downfall",
             "text": "Exile target creature with converted mana cost 3 or greater.",
             "colours": [
@@ -3460,7 +3460,7 @@
         },
         {
             "id": "406ca902-1edc-57f7-b93c-66871e97f144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9bb2f3-a7c7-4e8f-ba39-44e6acd9240b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9bb2f3-a7c7-4e8f-ba39-44e6acd9240b.jpg?1",
             "name": "Eye Collector",
             "text": "Flying\nWhenever Eye Collector deals combat damage to a player, each player puts the top card of their library into their graveyard.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "cb8a0180-b10a-5a37-8b7a-4290fd69af3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a90af0-eb40-40da-bf4b-f0af687c6430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a90af0-eb40-40da-bf4b-f0af687c6430.jpg?1",
             "name": "Festive Funeral",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "06e89b89-704a-5bed-a7d1-c2ac9ab2d14e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f79ec4-3722-4fda-824b-e80dc7608d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f79ec4-3722-4fda-824b-e80dc7608d01.jpg?1",
             "name": "Foreboding Fruit",
             "text": "Target player draws two cards and loses 2 life.\nAdamant \u2014 If at least three black mana was spent to cast this spell, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "5fcecdd6-f114-5515-9a86-62fc4074c0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7873c1f9-572c-4740-82f8-cf3cbc7318d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7873c1f9-572c-4740-82f8-cf3cbc7318d0.jpg?1",
             "name": "Forever Young",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "981642e0-5519-5928-95d6-c1a838185583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "Deathtouch",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "79fca063-ad37-5261-9a73-feab8e20f045",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5f6c745-e46a-42eb-8eca-b7b74ab1245e.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "65a9a6aa-8209-524c-9c9f-986e67c17db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050c03f9-ccbd-4dcc-9789-8013875ef470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050c03f9-ccbd-4dcc-9789-8013875ef470.jpg?1",
             "name": "Giant's Skewer",
             "text": "Equipped creature gets +2/+1.\nWhenever equipped creature deals combat damage to a creature, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "a99e9a94-d585-50c1-82c2-01b3af5ee46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea45e972-6e4a-4854-9be3-6ffb24e7d7a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea45e972-6e4a-4854-9be3-6ffb24e7d7a5.jpg?1",
             "name": "Lash of Thorns",
             "text": "Target creature gets +2/+1 and gains deathtouch until end of turn.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "0aff230e-db52-528b-b87f-4187ed9fb494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6f21a8-3dd0-42af-8a93-84f98968c781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6f21a8-3dd0-42af-8a93-84f98968c781.jpg?1",
             "name": "Locthwain Paladin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nAdamant \u2014 If at least three black mana was spent to cast this spell, Locthwain Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "a5837977-dd65-5900-beed-b2159f4a5b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6139d3-5397-4403-9c1e-312c11a7542b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6139d3-5397-4403-9c1e-312c11a7542b.jpg?1",
             "name": "Lost Legion",
             "text": "When Lost Legion enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "59ede61d-f18d-562c-b013-a12e2889af5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc7e996-151f-4d88-8e1e-91bb88f5db02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc7e996-151f-4d88-8e1e-91bb88f5db02.jpg?1",
             "name": "Malevolent Noble",
             "text": "{2}, Sacrifice an artifact or another creature: Put a +1/+1 counter on Malevolent Noble.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "d0636f61-06a4-517c-8778-678c421c6076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397fd49b-a520-4b0e-9ab9-71675ab5969d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397fd49b-a520-4b0e-9ab9-71675ab5969d.jpg?1",
             "name": "Memory Theft",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. You may put a card that has an Adventure that player owns from exile into that player's graveyard.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "1583e21a-84a4-5299-b3aa-ab4dec02d2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "Lifelink\nWhen Murderous Rider dies, put it on the bottom of its owner's library.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "7d27e18f-6ffa-5328-a13b-dfb41a2f0109",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e73d8a84-2c0d-423c-89c7-71de0af9e1ac.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "Destroy target creature or planeswalker. You lose 2 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "78db89fe-e6e4-502e-9571-11e131189fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9173ffda-1d3b-4dab-8dcb-de44717de464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9173ffda-1d3b-4dab-8dcb-de44717de464.jpg?1",
             "name": "Oathsworn Knight",
             "text": "Oathsworn Knight enters the battlefield with four +1/+1 counters on it.\nOathsworn Knight attacks each combat if able.\nIf damage would be dealt to Oathsworn Knight while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from it.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "a9879e18-ba17-5577-b5da-7e6b433804b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "Flying\nOrder of Midnight can't block.",
             "colours": [
@@ -4013,7 +4013,7 @@
         },
         {
             "id": "c45098e6-b676-5758-ac75-f83d41fe7afa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/330cc452-4382-401d-9432-ac27ae6e27ad.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4049,7 +4049,7 @@
         },
         {
             "id": "372145ed-c7a8-5494-b1e6-6f5aec74d7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7962fe-b715-4981-86c3-223bad9b1899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7962fe-b715-4981-86c3-223bad9b1899.jpg?1",
             "name": "Piper of the Swarm",
             "text": "Rats you control have menace.\n{1}{B}, {T}: Create a 1/1 black Rat creature token.\n{2}{B}{B}, {T}, Sacrifice three Rats: Gain control of target creature.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "27e99eca-011b-5569-b836-ee0b50b33e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2c11d-dfc3-4ba9-8c0f-a98114090396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2c11d-dfc3-4ba9-8c0f-a98114090396.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "Flying, haste\nWhenever Rankle, Master of Pranks deals combat damage to a player, choose any number \u2014\n\u2022 Each player discards a card.\n\u2022 Each player loses 1 life and draws a card.\n\u2022 Each player sacrifices a creature.",
             "colours": [
@@ -4126,7 +4126,7 @@
         },
         {
             "id": "223aa9a5-a95c-53fd-bdd2-aee24b7fa7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "Whenever Reaper of Night attacks, if defending player has two or fewer cards in hand, it gains flying until end of turn.",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "57d7d404-cb16-591a-97e6-43a71d32701c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dc774b4-3f70-4351-b1b8-8a0193cb3a50.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "Target opponent discards two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "0d475c4c-74c6-57d7-ad62-d5dde25e7612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ff657-aa44-4336-895a-87518159cef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7ff657-aa44-4336-895a-87518159cef6.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "f6e03176-0962-590d-885e-627b93867f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3474289a-193e-452d-b248-e53ee99e22c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3474289a-193e-452d-b248-e53ee99e22c0.jpg?1",
             "name": "Revenge of Ravens",
             "text": "Whenever a creature attacks you or a planeswalker you control, that creature's controller loses 1 life and you gain 1 life.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "8c533a75-2816-5c2e-8f1d-79610a7bc06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "Lifelink",
             "colours": [
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "c46d7d74-aa23-5f63-870d-bcda1f77c08a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f82541f2-b17c-45b4-87ff-f9b46d23578c.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "You gain X life and each opponent loses X life, where X is the number of Knights you control.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "adfe4990-cc5c-5bee-a0db-be6dc29b3a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edae2c29-1418-477c-9efe-e53fa6c7fe93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edae2c29-1418-477c-9efe-e53fa6c7fe93.jpg?1",
             "name": "Specter's Shriek",
             "text": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, that player exiles that card. If a nonblack card is exiled this way, exile a card from your hand.",
             "colours": [
@@ -4367,7 +4367,7 @@
         },
         {
             "id": "0cf485ea-1155-591d-967c-e74264331362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a808868f-aea8-4651-9357-85a4d7b4f290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a808868f-aea8-4651-9357-85a4d7b4f290.jpg?1",
             "name": "Syr Konrad, the Grim",
             "text": "Whenever another creature dies, or a creature card is put into a graveyard from anywhere other than the battlefield, or a creature card leaves your graveyard, Syr Konrad, the Grim deals 1 damage to each opponent.\n{1}{B}: Each player puts the top card of their library into their graveyard.",
             "colours": [
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "91232911-b35d-54ef-8c98-a215163c31fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b217e5a-3c18-48b4-8124-b8c4fd7b2df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b217e5a-3c18-48b4-8124-b8c4fd7b2df1.jpg?1",
             "name": "Tempting Witch",
             "text": "When Tempting Witch enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}, {T}, Sacrifice a Food: Target player loses 3 life.",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "5b65ac34-7762-58bd-baaf-972980afbefa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cd91b2-0f9b-4582-ad90-32fa3ee1fde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cd91b2-0f9b-4582-ad90-32fa3ee1fde7.jpg?1",
             "name": "Wicked Guardian",
             "text": "When Wicked Guardian enters the battlefield, you may have it deal 2 damage to another creature you control. If you do, draw a card.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "628f1173-87ee-5b2f-a20d-9df587f09e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c17b01-ee5d-491a-8403-b3f819b778c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c17b01-ee5d-491a-8403-b3f819b778c4.jpg?1",
             "name": "Wishclaw Talisman",
             "text": "Wishclaw Talisman enters the battlefield with three wish counters on it.\n{1}, {T}, Remove a wish counter from Wishclaw Talisman: Search your library for a card, put it into your hand, then shuffle your library. An opponent gains control of Wishclaw Talisman. Activate this ability only during your turn.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "570ffb14-1814-5dfc-8eca-3ca858552ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf16457-3444-4130-b220-834b69d9faa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf16457-3444-4130-b220-834b69d9faa3.jpg?1",
             "name": "Witch's Vengeance",
             "text": "Creatures of the creature type of your choice get -3/-3 until end of turn.",
             "colours": [
@@ -4542,7 +4542,7 @@
         },
         {
             "id": "e6724d82-da78-52a6-80cd-7a8b1f49c0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe337c-4b8c-42ce-8c43-4c95051d09ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe337c-4b8c-42ce-8c43-4c95051d09ac.jpg?1",
             "name": "Barge In",
             "text": "Target attacking creature gets +2/+2 until end of turn. Each attacking non-Human creature gains trample until end of turn.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "3655e999-b971-5f4c-8547-b9bfb1b58d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6c0bc1-cb07-4009-83b1-1122381cf9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6c0bc1-cb07-4009-83b1-1122381cf9c4.jpg?1",
             "name": "Bloodhaze Wolverine",
             "text": "Whenever you draw your second card each turn, Bloodhaze Wolverine gets +1/+1 and gains first strike until end of turn.",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "ec072252-348d-5972-8bed-9f93586d2a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04b85e7-a401-42d5-9629-8d4b8c8a46b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04b85e7-a401-42d5-9629-8d4b8c8a46b0.jpg?1",
             "name": "Blow Your House Down",
             "text": "Up to three target creatures can't block this turn. Destroy any of them that are Walls.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "d26fdb0c-80d4-5ea2-af6e-adbd290fc163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Whenever Bonecrusher Giant becomes the target of a spell, Bonecrusher Giant deals 2 damage to that spell's controller.",
             "colours": [
@@ -4676,7 +4676,7 @@
         },
         {
             "id": "9ec1a801-76eb-57ae-a3a2-b8d2d1b06e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09fd2d9c-1793-4beb-a3fb-7a869f660cd4.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "Damage can't be prevented this turn. Stomp deals 2 damage to any target.",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "74b27345-3ebb-53c3-9587-c86f2c74b154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c49e0e-4375-4e45-a57b-8df667e45ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c49e0e-4375-4e45-a57b-8df667e45ce6.jpg?1",
             "name": "Brimstone Trebuchet",
             "text": "Defender, reach\n{T}: Brimstone Trebuchet deals 1 damage to each opponent.\nWhenever a Knight enters the battlefield under your control, untap Brimstone Trebuchet.",
             "colours": [
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "fbd12dc3-997d-5df7-838e-cdc79e4b7fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17755d1b-3a56-4362-a534-85b35ceb1802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17755d1b-3a56-4362-a534-85b35ceb1802.jpg?1",
             "name": "Burning-Yard Trainer",
             "text": "Trample, haste\nWhen Burning-Yard Trainer enters the battlefield, another target Knight you control gets +2/+2 and gains trample and haste until end of turn.",
             "colours": [
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "4f39c093-f2d1-542d-93d8-d2f0ccbc490d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feaf1e6c-c7d9-4ac7-9aeb-c4b5d61548ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feaf1e6c-c7d9-4ac7-9aeb-c4b5d61548ec.jpg?1",
             "name": "Claim the Firstborn",
             "text": "Gain control of target creature with converted mana cost 3 or less until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "dc6df12a-75cb-52a0-8b19-f9d8644ec505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f738ca6-5254-4dbc-9f59-854e81c8dac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f738ca6-5254-4dbc-9f59-854e81c8dac2.jpg?1",
             "name": "Crystal Slipper",
             "text": "Equipped creature gets +1/+0 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "2786262b-6aac-5ed3-8ed1-ff3db07ab3a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaae15dd-11b6-4421-99e9-365c7fe4a5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaae15dd-11b6-4421-99e9-365c7fe4a5d6.jpg?1",
             "name": "Embercleave",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature you control.\nWhen Embercleave enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3}",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "01c6d9ad-8e56-55dc-87a4-53a637559403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcfe06b-3bb5-434e-acf4-4bfa8a94141d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bcfe06b-3bb5-434e-acf4-4bfa8a94141d.jpg?1",
             "name": "Embereth Paladin",
             "text": "Haste\nAdamant \u2014 If at least three red mana was spent to cast this spell, Embereth Paladin enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "c77178a9-4d38-5736-835c-318a46fa7edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "f668c83c-f302-5d4e-87ad-c0e12cf6e110",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6cc73d16-5ed7-4104-91f6-0997a2080e2e.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "Destroy target artifact. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "60fa1367-5c47-57b2-925d-cb0c5202db63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7005fd-5917-4f7d-9a7d-7ccc044d0f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7005fd-5917-4f7d-9a7d-7ccc044d0f87.jpg?1",
             "name": "Ferocity of the Wilds",
             "text": "Attacking non-Human creatures you control get +1/+0 and have trample.",
             "colours": [
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "55ba7cbf-7208-5e1f-9e14-25413e6d7fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d66db-5570-48a1-99cf-e0417517747b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d66db-5570-48a1-99cf-e0417517747b.jpg?1",
             "name": "Fervent Champion",
             "text": "First strike, haste\nWhenever Fervent Champion attacks, another target attacking Knight you control gets +1/+0 until end of turn.\nEquip abilities you activate that target Fervent Champion cost {3} less to activate.",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "3fb2a885-ed81-5522-bcbd-84e5c299fc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b16b0-f75f-42d8-9b24-947c1908e0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b16b0-f75f-42d8-9b24-947c1908e0f7.jpg?1",
             "name": "Fires of Invention",
             "text": "You can cast spells only during your turn and you can cast no more than two spells each turn.\nYou may cast spells with converted mana cost less than or equal to the number of lands you control without paying their mana costs.",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "1ee74ce9-713f-5e5c-977a-7d1dac645c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24729f25-e900-4a71-a304-7346eb17990a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24729f25-e900-4a71-a304-7346eb17990a.jpg?1",
             "name": "A-Fires of Invention",
             "text": "",
             "colours": [
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "e81cb093-7862-52d2-a148-7211d26acfce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28fe03-8269-41de-b766-42c3421aeaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28fe03-8269-41de-b766-42c3421aeaef.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to any target.",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "7ad805e7-bd7e-5568-89b3-8d6ff8af1722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bcf822-e129-45f6-9403-310ce9410f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bcf822-e129-45f6-9403-310ce9410f3b.jpg?1",
             "name": "Irencrag Feat",
             "text": "Add seven {R}. You can cast only one more spell this turn.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "af8e70cc-7a7f-5b03-9525-11af6e9cdc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7b0ead-5629-429d-bede-8154f3fae96d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7b0ead-5629-429d-bede-8154f3fae96d.jpg?1",
             "name": "Irencrag Pyromancer",
             "text": "Whenever you draw your second card each turn, Irencrag Pyromancer deals 3 damage to any target.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "c7767976-03e2-5440-8f2b-13c2b282d090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e725f04-5530-47f1-9f04-4cc13ed9348b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e725f04-5530-47f1-9f04-4cc13ed9348b.jpg?1",
             "name": "Joust",
             "text": "Choose target creature you control and target creature you don't control. The creature you control gets +2/+1 until end of turn if it's a Knight. Then those creatures fight each other. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5263,7 +5263,7 @@
         },
         {
             "id": "ef632a62-365a-5844-a27f-e7935f5a22ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4cabcc-fb29-4bf2-b5ba-32b8c96aefd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4cabcc-fb29-4bf2-b5ba-32b8c96aefd6.jpg?1",
             "name": "Mad Ratter",
             "text": "Whenever you draw your second card each turn, create two 1/1 black Rat creature tokens.",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "0908d356-67cc-5922-93be-e8884af020d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "{2}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "a2f5a90b-00bd-5821-9c58-8ace45bf7191",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b4399b6-e67f-40d8-8676-f5db7e04a6c9.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "You may discard a card. If you do, draw a card. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "0c941678-45c6-5aab-a863-136c1e0b7a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e96f3dc-dc58-4034-8d3d-3ae74fa64562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e96f3dc-dc58-4034-8d3d-3ae74fa64562.jpg?1",
             "name": "Ogre Errant",
             "text": "Whenever Ogre Errant attacks, another target attacking Knight gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "f8fb069c-0608-5e3b-ab49-63ecb732cf84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa16922-3583-4f5b-8805-509b95a8da49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa16922-3583-4f5b-8805-509b95a8da49.jpg?1",
             "name": "Opportunistic Dragon",
             "text": "Flying\nWhen Opportunistic Dragon enters the battlefield, choose target Human or artifact an opponent controls. For as long as Opportunistic Dragon remains on the battlefield, gain control of that permanent, it loses all abilities, and it can't attack or block.",
             "colours": [
@@ -5441,7 +5441,7 @@
         },
         {
             "id": "3ce33ca7-473c-54ff-b205-cae6f3bc6c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9325398-41c3-4177-a64d-ea38cb7a8737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9325398-41c3-4177-a64d-ea38cb7a8737.jpg?1",
             "name": "Raging Redcap",
             "text": "Double strike",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "ed974790-983c-50e3-aee9-7d20cfe97c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd1dd34-d480-4dfd-9f82-73c4e24a11fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd1dd34-d480-4dfd-9f82-73c4e24a11fc.jpg?1",
             "name": "Redcap Melee",
             "text": "Redcap Melee deals 4 damage to target creature or planeswalker. If a nonred permanent is dealt damage this way, you sacrifice a land.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "c90440b6-1901-5f01-9173-0f734dc68ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cf5c4-6ba3-4fa0-9732-0a350c637c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cf5c4-6ba3-4fa0-9732-0a350c637c7a.jpg?1",
             "name": "Redcap Raiders",
             "text": "Whenever Redcap Raiders attacks, you may tap an untapped non-Human creature you control. If you do, Redcap Raiders gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "21d183eb-268f-5f52-93d6-57b81e615767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "Rimrock Knight can't block.",
             "colours": [
@@ -5580,7 +5580,7 @@
         },
         {
             "id": "cc319b2b-9191-5b58-8749-6d008be25878",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3d13d84-01e4-4429-93db-e5afff811527.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "Target creature gets +2/+0 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "1a9b9120-c7ad-5024-b948-4ae2d0adb3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecbe097-ba51-42e5-957c-382eb66c08f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecbe097-ba51-42e5-957c-382eb66c08f0.jpg?1",
             "name": "Robber of the Rich",
             "text": "Reach, haste\nWhenever Robber of the Rich attacks, if defending player has more cards in hand than you, exile the top card of their library. During any turn you attacked with a Rogue, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "2427f954-eead-5ea7-8188-5749103baa53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b74a806-ed74-458e-8903-d3d084e9f507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b74a806-ed74-458e-8903-d3d084e9f507.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "3261737f-2698-5f05-b714-6d1dffcf20cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f11135-e9ce-4e4c-bea7-72a46d326e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f11135-e9ce-4e4c-bea7-72a46d326e40.jpg?1",
             "name": "Searing Barrage",
             "text": "Searing Barrage deals 5 damage to target creature.\nAdamant \u2014 If at least three red mana was spent to cast this spell, Searing Barrage deals 3 damage to that creature's controller.",
             "colours": [
@@ -5718,7 +5718,7 @@
         },
         {
             "id": "0a00eb60-c3a1-5e43-9d87-0ce618a7f599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464adbae-70ea-48e1-b8ae-b404766f7a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464adbae-70ea-48e1-b8ae-b404766f7a5a.jpg?1",
             "name": "Seven Dwarves",
             "text": "Seven Dwarves gets +1/+1 for each other creature named Seven Dwarves you control.\nA deck can have up to seven cards named Seven Dwarves.",
             "colours": [
@@ -5752,7 +5752,7 @@
         },
         {
             "id": "4b2e454d-1fb5-596b-986d-ab0a1060f20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa89e28-c0a9-4b76-b0d5-8dcaa75bfd59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa89e28-c0a9-4b76-b0d5-8dcaa75bfd59.jpg?1",
             "name": "Skullknocker Ogre",
             "text": "Whenever Skullknocker Ogre deals damage to an opponent, that player discards a card at random. If the player does, they draw a card.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "beb3990e-ee5c-51e0-9651-e1e5a5f336c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b5b110-c430-4ffe-9fc1-8e6987f52d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b5b110-c430-4ffe-9fc1-8e6987f52d1e.jpg?1",
             "name": "Slaying Fire",
             "text": "Slaying Fire deals 3 damage to any target.\nAdamant \u2014 If at least three red mana was spent to cast this spell, it deals 4 damage instead.",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "78347b06-1230-5109-b5cc-99374e1ff619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b7a774-ca49-4291-8a19-cb5e475b10d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b7a774-ca49-4291-8a19-cb5e475b10d5.jpg?1",
             "name": "Sundering Stroke",
             "text": "Sundering Stroke deals 7 damage divided as you choose among one, two, or three targets. If at least seven red mana was spent to cast this spell, instead Sundering Stroke deals 7 damage to each of those permanents and/or players.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "a629cfa4-41d5-5591-81ad-6e1ce4173a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a249a-df47-4769-bb63-0d8ab3f2467c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a249a-df47-4769-bb63-0d8ab3f2467c.jpg?1",
             "name": "Syr Carah, the Bold",
             "text": "Whenever Syr Carah, the Bold or an instant or sorcery spell you control deals damage to a player, exile the top card of your library. You may play that card this turn.\n{T}: Syr Carah deals 1 damage to any target.",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "df65bf2d-7ffc-5a0e-b5be-bee84a9b7f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5923,7 +5923,7 @@
         },
         {
             "id": "33cf4573-fd62-5f4d-a278-9d258b5285e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f591cd-d277-4ba5-b1bf-1c09cac9cb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f591cd-d277-4ba5-b1bf-1c09cac9cb8a.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "If a red source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "ce6e4f48-9eaa-5bb0-839e-594135a0646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a78207-fd76-4112-a257-54a25da6f818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a78207-fd76-4112-a257-54a25da6f818.jpg?1",
             "name": "Weaselback Redcap",
             "text": "{1}{R}: Weaselback Redcap gets +2/+0 until end of turn.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "59a637f5-ef4e-58c3-b1c0-dfddb587c815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Beanstalk Giant's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "b8de4b50-8889-5573-9ca7-eb3d7a7d62a8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a66f5ea7-ddbb-4b89-b812-77bd17972cf9.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "5093bb6a-f20e-5079-b4d7-e7422d7601cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "",
             "colours": [
@@ -6106,7 +6106,7 @@
         },
         {
             "id": "27045496-fb07-5260-8201-c98491e6ee31",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f78a570-d776-42f2-a609-6da0156c8de7.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "eb0467cf-9e18-590c-837e-bf039dcf9dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5d0560-f9e6-4c70-8cce-cae61e4e74bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5d0560-f9e6-4c70-8cce-cae61e4e74bc.jpg?1",
             "name": "Edgewall Innkeeper",
             "text": "Whenever you cast a creature spell that has an Adventure, draw a card. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "9fd6f332-5201-52da-8a53-1418d7f64b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6bb435-1205-416a-a5a0-ca6d37b4dcb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6bb435-1205-416a-a5a0-ca6d37b4dcb2.jpg?1",
             "name": "Feasting Troll King",
             "text": "Vigilance, trample\nWhen Feasting Troll King enters the battlefield, if you cast it from your hand, create three Food tokens.\nSacrifice three Foods: Return Feasting Troll King from your graveyard to the battlefield. Activate this ability only during your turn.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "b86be36e-0ce6-5382-ab23-8e1fa7d2ffd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d3cc84-7cb6-4de2-9018-4695a3b1e099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d3cc84-7cb6-4de2-9018-4695a3b1e099.jpg?1",
             "name": "Fell the Pheasant",
             "text": "Fell the Pheasant deals 5 damage to target creature with flying. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6246,7 +6246,7 @@
         },
         {
             "id": "4ec240b3-9595-5f13-abc0-953dd99e7955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63a6be2-ae9a-4758-9d5c-0297ef9af57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63a6be2-ae9a-4758-9d5c-0297ef9af57c.jpg?1",
             "name": "Fierce Witchstalker",
             "text": "Trample\nWhen Fierce Witchstalker enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "136a943f-a2c0-5f1f-b6d3-5a55b3ad76c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "Whenever Flaxen Intruder deals combat damage to a player, you may sacrifice it. When you do, destroy target artifact or enchantment.",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "8288d260-50a7-5c4d-a3fa-3855c5ec54fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06bd1ad2-fb5d-4aef-87d1-13a341c686fa.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "Create three 2/2 green Bear creature tokens. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "35a814b7-8c18-54d9-afac-86cc84fbaf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "",
             "colours": [
@@ -6390,7 +6390,7 @@
         },
         {
             "id": "15a36683-b9ef-5cce-b7b6-e8f560789e61",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/194b7a1c-291a-470e-9a40-61b72a46793b.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "Target creature gets +2/+2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6426,7 +6426,7 @@
         },
         {
             "id": "20f48c17-eb13-5d5c-a63c-56dd5288ed19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8445020a-6fab-47dd-9e57-886c28f68b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8445020a-6fab-47dd-9e57-886c28f68b3f.jpg?1",
             "name": "Garenbrig Paladin",
             "text": "Adamant \u2014 If at least three green mana was spent to cast this spell, Garenbrig Paladin enters the battlefield with a +1/+1 counter on it.\nGarenbrig Paladin can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6461,7 +6461,7 @@
         },
         {
             "id": "e39052a9-b084-583f-bcf9-db97dee8f00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74237cce-2ca2-4bfd-a846-c7309621a85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74237cce-2ca2-4bfd-a846-c7309621a85f.jpg?1",
             "name": "Garenbrig Squire",
             "text": "Whenever you cast a creature spell that has an Adventure, Garenbrig Squire gets +1/+1 until end of turn. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -6496,7 +6496,7 @@
         },
         {
             "id": "6726f091-63a5-5d78-a721-83800d1e0d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40383646-3fc4-4267-b9ad-bf90a85972fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40383646-3fc4-4267-b9ad-bf90a85972fc.jpg?1",
             "name": "Giant Opportunity",
             "text": "You may sacrifice two Foods. If you do, create a 7/7 green Giant creature token. Otherwise, create three Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "8e7dd1ef-db8a-5dd7-ac9e-c9fdb1682e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30377bf0-d9b1-4c14-8dde-f74b1e02d604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30377bf0-d9b1-4c14-8dde-f74b1e02d604.jpg?1",
             "name": "Gilded Goose",
             "text": "Flying\nWhen Gilded Goose enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{1}{G}, {T}: Create a Food token.\n{T}, Sacrifice a Food: Add one mana of any color.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "0a573387-0cbb-55f0-8b82-f300660b58eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af915ed2-1f34-43f6-85f5-2430325b720f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af915ed2-1f34-43f6-85f5-2430325b720f.jpg?1",
             "name": "The Great Henge",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\n{T}: Add {G}{G}. You gain 2 life.\nWhenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "ac5e2242-923a-50c1-91b8-55d821ac09fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2357f2db-00c2-41f6-bd04-93f905dea461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2357f2db-00c2-41f6-bd04-93f905dea461.jpg?1",
             "name": "Insatiable Appetite",
             "text": "You may sacrifice a Food. If you do, target creature gets +5/+5 until end of turn. Otherwise, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6632,7 +6632,7 @@
         },
         {
             "id": "9c024494-8a88-5dd8-989e-a4fee515f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6754d6cf-3506-48b5-a0ef-8a90b8dd2701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6754d6cf-3506-48b5-a0ef-8a90b8dd2701.jpg?1",
             "name": "Keeper of Fables",
             "text": "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "856041c2-3b3c-58e0-81cf-98947d913942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da7cd39-1f8a-4f68-adb7-df2beac02263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da7cd39-1f8a-4f68-adb7-df2beac02263.jpg?1",
             "name": "Kenrith's Transformation",
             "text": "Enchant creature\nWhen Kenrith's Transformation enters the battlefield, draw a card.\nEnchanted creature loses all abilities and is a green Elk creature with base power and toughness 3/3. (It loses all other card types and creature types.)",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "89fd5608-1ece-5c6f-8428-828d599b9cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Lovestruck Beast can't attack unless you control a 1/1 creature.",
             "colours": [
@@ -6739,7 +6739,7 @@
         },
         {
             "id": "3a4b9941-f695-5a5d-9b46-990a967f2eba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4ccdef9c-1e85-4358-8059-8972479f7556.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "Create a 1/1 white Human creature token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "cf9b9161-5519-55a2-8644-af583ec455bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b198d-493c-4d6c-bfb6-e842728522f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b198d-493c-4d6c-bfb6-e842728522f6.jpg?1",
             "name": "Maraleaf Rider",
             "text": "Sacrifice a Food: Target creature blocks Maraleaf Rider this turn if able.",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "9966ccd7-ad8e-5942-a717-8446b353fff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb4e77f-e189-4ad3-9fca-8da04289e396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb4e77f-e189-4ad3-9fca-8da04289e396.jpg?1",
             "name": "Oakhame Adversary",
             "text": "This spell costs {2} less to cast if an opponent controls a green permanent.\nDeathtouch\nWhenever Oakhame Adversary deals combat damage to a player, draw a card.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "73b4bff5-0a6e-5beb-9877-422c7ca2b8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5dd4e8-4d5f-45a0-9cae-4f842751894d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5dd4e8-4d5f-45a0-9cae-4f842751894d.jpg?1",
             "name": "Once and Future",
             "text": "Return target card from your graveyard to your hand. Put up to one other target card from your graveyard on top of your library. Exile Once and Future.\nAdamant \u2014 If at least three green mana was spent to cast this spell, instead return those cards to your hand and exile Once and Future.",
             "colours": [
@@ -6877,7 +6877,7 @@
         },
         {
             "id": "0add0930-720f-5bf5-bcf5-ee208eeb9040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4034e5ba-9974-43e3-bde7-8d9b4586c3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4034e5ba-9974-43e3-bde7-8d9b4586c3a4.jpg?1",
             "name": "Once Upon a Time",
             "text": "If this spell is the first spell you've cast this game, you may cast it without paying its mana cost.\nLook at the top five cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "14903635-d346-52c7-a401-230dfee1859f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d0ddcc-e6df-4fe1-9ac9-f895885ccc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d0ddcc-e6df-4fe1-9ac9-f895885ccc84.jpg?1",
             "name": "Outmuscle",
             "text": "Put a +1/+1 counter on target creature you control, then it fights target creature you don't control. (Each deals damage equal to its power to the other.)\nAdamant \u2014 If at least three green mana was spent to cast this spell, the creature you control gains indestructible until end of turn.",
             "colours": [
@@ -6943,7 +6943,7 @@
         },
         {
             "id": "11de1543-2792-58ea-9e93-2fc5e624d7a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cf82d-3213-47ce-a015-6e51a8b07e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cf82d-3213-47ce-a015-6e51a8b07e4f.jpg?1",
             "name": "Questing Beast",
             "text": "Vigilance, deathtouch, haste\nQuesting Beast can't be blocked by creatures with power 2 or less.\nCombat damage that would be dealt by creatures you control can't be prevented.\nWhenever Questing Beast deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "28a991a6-87fe-54c8-ace9-cd8759d3de3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a4943-bd1b-4d10-9cd3-b2ab91b25c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a4943-bd1b-4d10-9cd3-b2ab91b25c10.jpg?1",
             "name": "Return of the Wildspeaker",
             "text": "Choose one \u2014\n\u2022 Draw cards equal to the greatest power among non-Human creatures you control.\n\u2022 Non-Human creatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -7015,7 +7015,7 @@
         },
         {
             "id": "d0a4f8f6-7ee2-5825-bdf3-42e2e0234ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d5088e-21d0-4255-a14c-ad950133a90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d5088e-21d0-4255-a14c-ad950133a90e.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -7047,7 +7047,7 @@
         },
         {
             "id": "d514cf1d-cbbb-5c26-8d17-83439facfe19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "{T}: Add one mana of any color.",
             "colours": [
@@ -7084,7 +7084,7 @@
         },
         {
             "id": "1cb1e10a-f718-5a47-8396-19024a39f56f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a0d430f-da84-4752-940c-8457c525aac9.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "Add one mana of any color. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "852cc4ef-9b90-5b52-b897-4752217705f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a66e33-af5c-42b5-bef6-0ff0197ecc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a66e33-af5c-42b5-bef6-0ff0197ecc14.jpg?1",
             "name": "Rosethorn Halberd",
             "text": "When Rosethorn Halberd enters the battlefield, attach it to target non-Human creature you control.\nEquipped creature gets +2/+1.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "6f06ee37-7e68-5b43-a4a3-aa1789c21d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc33252-145f-45c0-bb70-23183c698f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc33252-145f-45c0-bb70-23183c698f66.jpg?1",
             "name": "Sporecap Spider",
             "text": "Reach",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "ca49d9d4-7941-5a6a-8e7f-0cc63db5e1bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b1fea-3c5d-43d2-b4d2-e8938f3f7b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b1fea-3c5d-43d2-b4d2-e8938f3f7b9c.jpg?1",
             "name": "Syr Faren, the Hengehammer",
             "text": "Whenever Syr Faren, the Hengehammer attacks, another target attacking creature gets +X/+X until end of turn, where X is Syr Faren's power.",
             "colours": [
@@ -7225,7 +7225,7 @@
         },
         {
             "id": "02004117-58fe-5d15-97fa-dab4bd86104b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098bfd71-a47f-4dfc-b516-b88a388fb7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098bfd71-a47f-4dfc-b516-b88a388fb7b5.jpg?1",
             "name": "Tall as a Beanstalk",
             "text": "Enchant creature\nEnchanted creature gets +3/+3, has reach, and is a Giant in addition to its other types.",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "2e5c5bd2-ed4a-556f-a920-10ee0ddcb6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ac16-4ed6-4e79-815a-be173deb4603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688ac16-4ed6-4e79-815a-be173deb4603.jpg?1",
             "name": "Trail of Crumbs",
             "text": "When Trail of Crumbs enters the battlefield, create a Food token.\nWhenever you sacrifice a Food, you may pay {1}. If you do, look at the top two cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "b881496f-e240-51b7-8218-5b4e179651e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "bcacffef-ba52-567e-9898-06472a44de1e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bc518fc-904e-4e39-aeda-ffb222bfcc82.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "Put two +1/+1 counters on target creature. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "53e0b2ab-a532-5181-a2a5-e8c48860bf31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09476eac-55d2-4955-8951-ae4ce117c98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09476eac-55d2-4955-8951-ae4ce117c98b.jpg?1",
             "name": "Wicked Wolf",
             "text": "When Wicked Wolf enters the battlefield, it fights up to one target creature you don't control.\nSacrifice a Food: Put a +1/+1 counter on Wicked Wolf. It gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "1ec2a1a5-9fb6-5718-837f-5efe58cb1f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f76830-369e-4224-9ded-7d1ce04c87e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f76830-369e-4224-9ded-7d1ce04c87e4.jpg?1",
             "name": "Wildborn Preserver",
             "text": "Flash\nReach\nWhenever another non-Human creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on Wildborn Preserver.",
             "colours": [
@@ -7437,7 +7437,7 @@
         },
         {
             "id": "5acfd1c1-7c07-5fca-883a-0887427889d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3538eba1-475a-4388-8a72-55ab7cd1027e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3538eba1-475a-4388-8a72-55ab7cd1027e.jpg?1",
             "name": "Wildwood Tracker",
             "text": "Whenever Wildwood Tracker attacks or blocks, if you control another non-Human creature, Wildwood Tracker gets +1/+1 until end of turn.",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "5ff9f483-6baf-5d10-928c-095a6752a896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21c15f-378e-4abf-992f-9743aa6ab6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21c15f-378e-4abf-992f-9743aa6ab6b8.jpg?1",
             "name": "Wolf's Quarry",
             "text": "Create three 1/1 green Boar creature tokens with \"When this creature dies, create a Food token.\" (A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "208ba1b3-5c90-5615-89a3-c333c31a6389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2998a1-1713-467e-a08e-0efd8720aa5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2998a1-1713-467e-a08e-0efd8720aa5b.jpg?1",
             "name": "Yorvo, Lord of Garenbrig",
             "text": "Yorvo, Lord of Garenbrig enters the battlefield with four +1/+1 counters on it.\nWhenever another green creature enters the battlefield under your control, put a +1/+1 counter on Yorvo. Then if that creature's power is greater than Yorvo's power, put another +1/+1 counter on Yorvo.",
             "colours": [
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "f8fa0571-f1cf-5b6d-92ce-bf66bbf689e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dca90ef-1c17-4dcc-9fef-dab9ee92f590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dca90ef-1c17-4dcc-9fef-dab9ee92f590.jpg?1",
             "name": "Dance of the Manse",
             "text": "Return up to X target artifact and/or non-Aura enchantment cards each with converted mana cost X or less from your graveyard to the battlefield. If X is 6 or more, those permanents are 4/4 creatures in addition to their other types.",
             "colours": [
@@ -7579,7 +7579,7 @@
         },
         {
             "id": "be69dba8-21fa-536d-b86a-a99d4f177d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c0c83-3e87-474d-bc72-1677eed32cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c0c83-3e87-474d-bc72-1677eed32cfa.jpg?1",
             "name": "Doom Foretold",
             "text": "At the beginning of each player's upkeep, that player sacrifices a nonland, nontoken permanent. If that player can't, they discard a card, they lose 2 life, you draw a card, you gain 2 life, you create a 2/2 white Knight creature token with vigilance, then you sacrifice Doom Foretold.",
             "colours": [
@@ -7615,7 +7615,7 @@
         },
         {
             "id": "18c59430-8741-5e14-88aa-efe0e73853e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf5df5b-164d-4ec2-a5e6-bbaea152e271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf5df5b-164d-4ec2-a5e6-bbaea152e271.jpg?1",
             "name": "Drown in the Loch",
             "text": "Choose one \u2014\n\u2022 Counter target spell with converted mana cost less than or equal to the number of cards in its controller's graveyard.\n\u2022 Destroy target creature with converted mana cost less than or equal to the number of cards in its controller's graveyard.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "477f0265-6a4f-54c5-b85a-f80981fa5930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e26c10b-179f-4a6e-bc8d-3ec1d6783fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e26c10b-179f-4a6e-bc8d-3ec1d6783fb9.jpg?1",
             "name": "Escape to the Wilds",
             "text": "Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn.\nYou may play an additional land this turn.",
             "colours": [
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "8859f1e4-f915-5ad5-a9ca-9e665516e5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca29912-88b1-413f-ad9d-63d7d1b1ca16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca29912-88b1-413f-ad9d-63d7d1b1ca16.jpg?1",
             "name": "Faeburrow Elder",
             "text": "Vigilance\nFaeburrow Elder gets +1/+1 for each color among permanents you control.\n{T}: For each color among permanents you control, add one mana of that color.",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "562674f3-9cb1-5fca-a574-6319fe190dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abef512f-8f1d-4257-b16f-c0eed58670ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abef512f-8f1d-4257-b16f-c0eed58670ec.jpg?1",
             "name": "Garruk, Cursed Huntsman",
             "text": "0: Create two 2/2 black and green Wolf creature tokens with \"When this creature dies, put a loyalty counter on each Garruk you control.\"\n\u22123: Destroy target creature. Draw a card.\n\u22126: You get an emblem with \"Creatures you control get +3/+3 and have trample.\"",
             "colours": [
@@ -7764,7 +7764,7 @@
         },
         {
             "id": "8d7df51b-d09e-5985-bd36-735e358258eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d50d26-3c44-4c8f-81bb-9093dacfb804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d50d26-3c44-4c8f-81bb-9093dacfb804.jpg?1",
             "name": "Grumgully, the Generous",
             "text": "Each other non-Human creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -7803,7 +7803,7 @@
         },
         {
             "id": "9ae4d2c9-8764-59bc-88ee-d6c4927118f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0461867b-ec35-4d37-a398-5247e06c4afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0461867b-ec35-4d37-a398-5247e06c4afe.jpg?1",
             "name": "Improbable Alliance",
             "text": "Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying.\n{4}{U}{R}: Draw a card, then discard a card.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "3a6f5d81-0f85-5718-ba57-077df1d3f93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3f372d-259d-4a31-9491-2d369b3f3f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3f372d-259d-4a31-9491-2d369b3f3f8b.jpg?1",
             "name": "Inspiring Veteran",
             "text": "Other Knights you control get +1/+1.",
             "colours": [
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "a6cfb134-1b19-53cf-8f54-2ef8dd87c3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287beea-747c-4cb6-aea5-051e85c5de8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287beea-747c-4cb6-aea5-051e85c5de8d.jpg?1",
             "name": "Lochmere Serpent",
             "text": "Flash\n{U}, Sacrifice an Island: Lochmere Serpent can't be blocked this turn.\n{B}, Sacrifice a Swamp: You gain 1 life and draw a card.\n{U}{B}: Exile five target cards from an opponent's graveyard. Return Lochmere Serpent from your graveyard to your hand. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "ecad5a65-7b5c-52a3-b4a2-46d4f1743937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d7f9c9-dd83-4684-a949-1c22f316138a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d7f9c9-dd83-4684-a949-1c22f316138a.jpg?1",
             "name": "Maraleaf Pixie",
             "text": "Flying\n{T}: Add {G} or {U}.",
             "colours": [
@@ -7952,7 +7952,7 @@
         },
         {
             "id": "46153afe-5e05-5082-852a-648c03924bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462a3d0-5552-49fa-9eb7-100960c55891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462a3d0-5552-49fa-9eb7-100960c55891.jpg?1",
             "name": "Oko, Thief of Crowns",
             "text": "+2: Create a Food token.\n+1: Target artifact or creature loses all abilities and becomes a green Elk creature with base power and toughness 3/3.\n\u22125: Exchange control of target artifact or creature you control and target creature an opponent controls with power 3 or less.",
             "colours": [
@@ -7992,7 +7992,7 @@
         },
         {
             "id": "5931de28-1cb3-5517-9f71-211f6cea385b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7585ab-a364-471c-8ef1-318e459b4020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7585ab-a364-471c-8ef1-318e459b4020.jpg?1",
             "name": "Outlaws' Merriment",
             "text": "At the beginning of your upkeep, choose one at random. Create a red and white creature token with those characteristics.\n\u2022 3/1 Human Warrior with trample and haste.\n\u2022 2/1 Human Cleric with lifelink and haste.\n\u2022 1/2 Human Rogue with haste and \"When this creature enters the battlefield, it deals 1 damage to any target.\"",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "0b84effe-4c47-53d1-b497-3a408b009c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7111f3-01a6-4311-bc08-036a1fba60f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7111f3-01a6-4311-bc08-036a1fba60f5.jpg?1",
             "name": "The Royal Scions",
             "text": "+1: Draw a card, then discard a card.\n+1: Target creature gets +2/+0 and gains first strike and trample until end of turn.\n\u22128: Draw four cards. When you do, The Royal Scions deals damage to any target equal to the number of cards in your hand.",
             "colours": [
@@ -8069,7 +8069,7 @@
         },
         {
             "id": "9a86407d-ccde-5c76-ac98-26dbd2b2927d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c98441-2b31-4e48-a399-f36dffcfa41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c98441-2b31-4e48-a399-f36dffcfa41d.jpg?1",
             "name": "Savvy Hunter",
             "text": "Whenever Savvy Hunter attacks or blocks, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nSacrifice two Foods: Draw a card.",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "db7930a7-37bb-5542-af54-b0bb58ae613c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5314b-4994-4cd0-a680-12e56be7c1e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d5314b-4994-4cd0-a680-12e56be7c1e2.jpg?1",
             "name": "Shinechaser",
             "text": "Flying, vigilance\nShinechaser gets +1/+1 as long as you control an artifact.\nShinechaser gets +1/+1 as long as you control an enchantment.",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "ca9035f4-c17f-5b5a-b561-3e73955e527e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafcf909-d726-4bc2-adf6-c12ca242f0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafcf909-d726-4bc2-adf6-c12ca242f0c1.jpg?1",
             "name": "Steelclaw Lance",
             "text": "Equipped creature gets +2/+2.\nEquip Knight {1}\nEquip {3}",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "ffe88f06-c830-5be4-b9fe-916d6c2b8d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27425f2e-e0b2-489d-877d-8257d2026bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27425f2e-e0b2-489d-877d-8257d2026bfd.jpg?1",
             "name": "Stormfist Crusader",
             "text": "Menace\nAt the beginning of your upkeep, each player draws a card and loses 1 life.",
             "colours": [
@@ -8217,7 +8217,7 @@
         },
         {
             "id": "fd7edeb0-80ad-5b6e-b47d-a6896b00cdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fb5b-5c55-4ce9-b9d0-98f924d6f338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72fb5b-5c55-4ce9-b9d0-98f924d6f338.jpg?1",
             "name": "Wandermare",
             "text": "Whenever you cast a creature spell that has an Adventure, put a +1/+1 counter on Wandermare. (It doesn't need to have gone on the adventure first.)",
             "colours": [
@@ -8253,7 +8253,7 @@
         },
         {
             "id": "031ee583-8863-5e0d-bb3f-140e346b6557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e8d715-025f-4578-b427-e401318a9c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e8d715-025f-4578-b427-e401318a9c58.jpg?1",
             "name": "Wintermoor Commander",
             "text": "Deathtouch\nWintermoor Commander's toughness is equal to the number of Knights you control.\nWhenever Wintermoor Commander attacks, another target Knight you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "d83a4786-30e6-522c-bb99-53bc4d5bfda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42e1359-c79d-4848-a0f1-3f274e0bf0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42e1359-c79d-4848-a0f1-3f274e0bf0d9.jpg?1",
             "name": "Arcanist's Owl",
             "text": "Flying\nWhen Arcanist's Owl enters the battlefield, look at the top four cards of your library. You may reveal an artifact or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "bcec5dee-375f-5367-97cc-7d8e169d4514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4871d-4d74-411b-88e0-9a9d386cafe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b4871d-4d74-411b-88e0-9a9d386cafe1.jpg?1",
             "name": "Covetous Urge",
             "text": "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -8361,7 +8361,7 @@
         },
         {
             "id": "1a1ca1b3-740f-547b-8917-596deae8feb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c6e952-97b5-435c-a7fd-6271ddc23200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c6e952-97b5-435c-a7fd-6271ddc23200.jpg?1",
             "name": "Deathless Knight",
             "text": "Haste\nWhen you gain life for the first time each turn, return Deathless Knight from your graveyard to your hand.",
             "colours": [
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "f890541a-a4a3-54c2-a36d-111cf82e662f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9d0279-4fe0-4228-a82f-bc3cd91500df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9d0279-4fe0-4228-a82f-bc3cd91500df.jpg?1",
             "name": "Elite Headhunter",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{BR}{BR}{BR}, Sacrifice another creature or an artifact: Elite Headhunter deals 2 damage to target creature or planeswalker.",
             "colours": [
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "36898bc6-f71c-58cc-98bc-513115c0aca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716f46c-806d-4b3e-8a1c-fd6dcedacf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6716f46c-806d-4b3e-8a1c-fd6dcedacf8e.jpg?1",
             "name": "Fireborn Knight",
             "text": "Double strike\n{GU}{GU}{GU}{GU}: Fireborn Knight gets +1/+1 until end of turn.",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "6f58230d-88a5-583f-a66c-dc0c071ddc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a99088e-7162-4e65-867f-bca1c7400ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a99088e-7162-4e65-867f-bca1c7400ce3.jpg?1",
             "name": "Loch Dragon",
             "text": "Flying\nWhenever Loch Dragon enters the battlefield or attacks, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "1945c138-c3fb-50cd-91f1-f9f92571365a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "{T}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "1503d4db-926c-5fec-8a74-e6780d863683",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a665794-513f-4f78-92c9-1844ec27c79c.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "Create two 1/1 white Human creature tokens. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8586,7 +8586,7 @@
         },
         {
             "id": "4e58283e-05a2-5f9d-b4d2-b613a0863efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb9a632-a56b-48fb-bc24-14572b6a8a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb9a632-a56b-48fb-bc24-14572b6a8a55.jpg?1",
             "name": "Rampart Smasher",
             "text": "Rampart Smasher can't be blocked by Knights or Walls.",
             "colours": [
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "afafb7b4-d994-552f-a510-91db87c36511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853dbf04-7165-4728-b96c-c9e4ff4d3491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853dbf04-7165-4728-b96c-c9e4ff4d3491.jpg?1",
             "name": "Resolute Rider",
             "text": "{WB}{WB}: Resolute Rider gains lifelink until end of turn.\n{WB}{WB}{WB}: Resolute Rider gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8659,7 +8659,7 @@
         },
         {
             "id": "74e8a0c7-6ae0-533f-8aa1-cb80ffd160ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576d4f1-47bb-45e0-803c-93fa2cdacbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576d4f1-47bb-45e0-803c-93fa2cdacbe5.jpg?1",
             "name": "Thunderous Snapper",
             "text": "Whenever you cast a spell with converted mana cost 5 or greater, draw a card.",
             "colours": [
@@ -8696,7 +8696,7 @@
         },
         {
             "id": "87ee6756-9cf6-587a-b2a6-4d53634cc66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3af5942-d171-401a-9444-3b59c579e4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3af5942-d171-401a-9444-3b59c579e4db.jpg?1",
             "name": "Clockwork Servant",
             "text": "Adamant \u2014 When Clockwork Servant enters the battlefield, if at least three mana of the same color was spent to cast it, draw a card.",
             "colours": [],
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "eb81c17e-a742-57b4-abdb-8180db177b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7108f-635c-423b-988a-bc8fc4c6edef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7108f-635c-423b-988a-bc8fc4c6edef.jpg?1",
             "name": "Crashing Drawbridge",
             "text": "Defender\n{T}: Creatures you control gain haste until end of turn.",
             "colours": [],
@@ -8758,7 +8758,7 @@
         },
         {
             "id": "af5f40f4-1dbd-537e-ac6d-1dad11a5b02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057c2ae-ea4f-404a-ab95-f3979efd1b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057c2ae-ea4f-404a-ab95-f3979efd1b3b.jpg?1",
             "name": "Enchanted Carriage",
             "text": "When Enchanted Carriage enters the battlefield, create two 1/1 white Mouse creature tokens.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "d15e8893-98ca-5a86-b8bb-cc7f24033b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55fe038-c903-4d92-b689-72dd6d041a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55fe038-c903-4d92-b689-72dd6d041a91.jpg?1",
             "name": "Gingerbrute",
             "text": "Haste\n{1}: Gingerbrute can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice Gingerbrute: You gain 3 life.",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "a93e03ba-e337-564c-9504-9310526133b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525142c3-f17c-4e02-a02d-fa385215aa12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525142c3-f17c-4e02-a02d-fa385215aa12.jpg?1",
             "name": "Golden Egg",
             "text": "When Golden Egg enters the battlefield, draw a card.\n{1}, {T}, Sacrifice Golden Egg: Add one mana of any color.\n{2}, {T}, Sacrifice Golden Egg: You gain 3 life.",
             "colours": [],
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "15683485-77f7-5c6f-b94d-93dab47a662b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9925f0bc-8685-4e38-8864-0ad3a9549ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9925f0bc-8685-4e38-8864-0ad3a9549ab5.jpg?1",
             "name": "Henge Walker",
             "text": "Adamant \u2014 If at least three mana of the same color was spent to cast this spell, Henge Walker enters the battlefield with a +1/+1 counter on it.",
             "colours": [],
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "c3fb2c28-dadb-5ca7-90d7-d05677605c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e349af5-3f25-46d3-908e-83b2f6028b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e349af5-3f25-46d3-908e-83b2f6028b95.jpg?1",
             "name": "Heraldic Banner",
             "text": "As Heraldic Banner enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+0.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "9312733a-9dd4-5601-8d7a-5439d6861c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807a570a-b5eb-420d-9fa5-6e5364025510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807a570a-b5eb-420d-9fa5-6e5364025510.jpg?1",
             "name": "Inquisitive Puppet",
             "text": "When Inquisitive Puppet enters the battlefield, scry 1.\nExile Inquisitive Puppet: Create a 1/1 white Human creature token.",
             "colours": [],
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "342a9886-3eec-51ee-bf23-fdc7069d98a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601056-af08-4239-97d5-5e11597fce18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601056-af08-4239-97d5-5e11597fce18.jpg?1",
             "name": "Jousting Dummy",
             "text": "{3}: Jousting Dummy gets +1/+0 until end of turn.",
             "colours": [],
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "7c1d7e97-f6d0-5b93-837a-e7cf417a809f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551bee-335c-4bf7-b38e-67dd71d1d567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551bee-335c-4bf7-b38e-67dd71d1d567.jpg?1",
             "name": "Locthwain Gargoyle",
             "text": "{4}: Locthwain Gargoyle gets +2/+0 and gains flying until end of turn.",
             "colours": [],
@@ -9003,7 +9003,7 @@
         },
         {
             "id": "cb4e9fb1-4b47-5cc4-9dc1-b2882c676e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5d23a6-3a23-4169-aea1-f10bf5153180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5d23a6-3a23-4169-aea1-f10bf5153180.jpg?1",
             "name": "Lucky Clover",
             "text": "Whenever you cast an Adventure instant or sorcery spell, copy it. You may choose new targets for the copy.",
             "colours": [],
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "03c54f64-639a-599b-b04e-b3d2b8a304ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58131bf2-2a9f-4b81-9eeb-810372f3896c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58131bf2-2a9f-4b81-9eeb-810372f3896c.jpg?1",
             "name": "Prophet of the Peak",
             "text": "When Prophet of the Peak enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [],
@@ -9062,7 +9062,7 @@
         },
         {
             "id": "4f7caf33-25ba-5280-b86e-a730d86010f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a0136e-a637-4a12-a38f-35f772b290a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a0136e-a637-4a12-a38f-35f772b290a9.jpg?1",
             "name": "Roving Keep",
             "text": "Defender\n{7}: Roving Keep gets +2/+0 and gains trample until end of turn. It can attack this turn as though it didn't have defender.",
             "colours": [],
@@ -9093,7 +9093,7 @@
         },
         {
             "id": "e9fb9412-47a1-53e9-b70d-c3cc3f429c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2782-2b23-441f-9890-6fa9c923b701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/710d2782-2b23-441f-9890-6fa9c923b701.jpg?1",
             "name": "Scalding Cauldron",
             "text": "{3}, {T}, Sacrifice Scalding Cauldron: It deals 3 damage to target creature.",
             "colours": [],
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "2ac9dead-1e25-5902-bbba-e39936cf1c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1100b898-31a8-4fdf-a54f-a1470ec032f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1100b898-31a8-4fdf-a54f-a1470ec032f3.jpg?1",
             "name": "Shambling Suit",
             "text": "Shambling Suit's power is equal to the number of artifacts and/or enchantments you control.",
             "colours": [],
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "ffdd0a0b-d797-539c-8e91-cc89106a7702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5f336-c100-4bec-89d5-548f60064d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5f336-c100-4bec-89d5-548f60064d7f.jpg?1",
             "name": "Signpost Scarecrow",
             "text": "Vigilance\n{2}: Add one mana of any color.",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "992aee64-505a-521f-a14c-eaa6e6bec4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071e8f20-18b3-4bf5-a23a-adb42bf5819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071e8f20-18b3-4bf5-a23a-adb42bf5819b.jpg?1",
             "name": "Sorcerer's Broom",
             "text": "Whenever you sacrifice another permanent, you may pay {3}. If you do, create a token that's a copy of Sorcerer's Broom.",
             "colours": [],
@@ -9214,7 +9214,7 @@
         },
         {
             "id": "141e393e-b431-5d42-90c8-b25e6f870437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47e85d1-8c4a-43a9-92b3-7cb2a5b89219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47e85d1-8c4a-43a9-92b3-7cb2a5b89219.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "ef6ef75d-0496-5ede-99f6-453aeb0e337a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070ff479-9d87-4ab6-aaaa-e96b9df0bac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070ff479-9d87-4ab6-aaaa-e96b9df0bac4.jpg?1",
             "name": "Spinning Wheel",
             "text": "{T}: Add one mana of any color.\n{5}, {T}: Tap target creature.",
             "colours": [],
@@ -9272,7 +9272,7 @@
         },
         {
             "id": "9df2da58-6741-5150-a7c0-a78eb5c17391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bf7fd-9fe3-43e2-8cfe-7ce7cff08afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bf7fd-9fe3-43e2-8cfe-7ce7cff08afe.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "Reach, trample, protection from multicolored\nStonecoil Serpent enters the battlefield with X +1/+1 counters on it.",
             "colours": [],
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "40bc1031-6cc8-5e10-9ff3-12f8a7b70c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ca22d2-3ba5-4173-9c8c-6587a901ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ca22d2-3ba5-4173-9c8c-6587a901ff4a.jpg?1",
             "name": "Weapon Rack",
             "text": "Weapon Rack enters the battlefield with three +1/+1 counters on it.\n{T}: Move a +1/+1 counter from Weapon Rack onto target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -9333,7 +9333,7 @@
         },
         {
             "id": "afc36fe4-7907-5968-add1-320302f9fc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ef8493-d986-45f8-a718-617b028f7ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ef8493-d986-45f8-a718-617b028f7ad4.jpg?1",
             "name": "Witch's Oven",
             "text": "{T}, Sacrifice a creature: Create a Food token. If the sacrificed creature's toughness was 4 or greater, create two Food tokens instead. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "278e5356-5ac2-5727-94e5-99e3c984b120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f910495-8bd7-4134-a281-c16fd666d5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f910495-8bd7-4134-a281-c16fd666d5cc.jpg?1",
             "name": "Castle Ardenvale",
             "text": "Castle Ardenvale enters the battlefield tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Create a 1/1 white Human creature token.",
             "colours": [],
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "93cfe50e-222e-5585-bd24-48482d449c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg?1",
             "name": "Castle Embereth",
             "text": "Castle Embereth enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "d609d89b-e2cd-5923-ab07-585316ebb90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c66c-f7f0-41d5-a805-a129aeaf1b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c66c-f7f0-41d5-a805-a129aeaf1b75.jpg?1",
             "name": "Castle Garenbrig",
             "text": "Castle Garenbrig enters the battlefield tapped unless you control a Forest.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Add six {G}. Spend this mana only to cast creature spells or activate abilities of creatures.",
             "colours": [],
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "5eca79a0-df79-59bb-bef4-9fa77b37fcbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195383c1-4723-40b0-ba53-298dfd8e30d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195383c1-4723-40b0-ba53-298dfd8e30d0.jpg?1",
             "name": "Castle Locthwain",
             "text": "Castle Locthwain enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{1}{B}{B}, {T}: Draw a card, then you lose life equal to the number of cards in your hand.",
             "colours": [],
@@ -9489,7 +9489,7 @@
         },
         {
             "id": "24d73291-c3b5-57ab-a63e-4744868343dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg?1",
             "name": "Castle Vantress",
             "text": "Castle Vantress enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{2}{U}{U}, {T}: Scry 2.",
             "colours": [],
@@ -9521,7 +9521,7 @@
         },
         {
             "id": "bd47e60c-8798-504d-8dc1-cea50931cec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c83074d-0c9b-4b58-94ca-d75240485579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c83074d-0c9b-4b58-94ca-d75240485579.jpg?1",
             "name": "Dwarven Mine",
             "text": "({T}: Add {R}.)\nDwarven Mine enters the battlefield tapped unless you control three or more other Mountains.\nWhen Dwarven Mine enters the battlefield untapped, create a 1/1 red Dwarf creature token.",
             "colours": [],
@@ -9553,7 +9553,7 @@
         },
         {
             "id": "aa351463-01d2-5c91-8e07-3f50865fa6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b841bfa8-7c17-4df2-8466-780ab9a4a53a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b841bfa8-7c17-4df2-8466-780ab9a4a53a.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -9583,7 +9583,7 @@
         },
         {
             "id": "716181f5-9562-59d6-9c39-c64756399a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f5296-5f7d-41ca-a67d-e976273d7386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f5296-5f7d-41ca-a67d-e976273d7386.jpg?1",
             "name": "Gingerbread Cabin",
             "text": "({T}: Add {G}.)\nGingerbread Cabin enters the battlefield tapped unless you control three or more other Forests.\nWhen Gingerbread Cabin enters the battlefield untapped, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -9615,7 +9615,7 @@
         },
         {
             "id": "732cab48-d4be-56ad-8d14-aa73f03ff677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2c611c-3a6f-44b0-9daa-837a465845e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2c611c-3a6f-44b0-9daa-837a465845e0.jpg?1",
             "name": "Idyllic Grange",
             "text": "({T}: Add {W}.)\nIdyllic Grange enters the battlefield tapped unless you control three or more other Plains.\nWhen Idyllic Grange enters the battlefield untapped, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -9647,7 +9647,7 @@
         },
         {
             "id": "649ffc40-4d61-599d-a2fa-17e99032d00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e792c-80d5-4775-ad95-37614574ab84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e792c-80d5-4775-ad95-37614574ab84.jpg?1",
             "name": "Mystic Sanctuary",
             "text": "({T}: Add {U}.)\nMystic Sanctuary enters the battlefield tapped unless you control three or more other Islands.\nWhen Mystic Sanctuary enters the battlefield untapped, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [],
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "7df77858-8f54-5934-8d38-db40ec93af97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd438d51-a778-4b38-8b4b-a6a9cd9b4b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd438d51-a778-4b38-8b4b-a6a9cd9b4b22.jpg?1",
             "name": "Tournament Grounds",
             "text": "{T}: Add {C}.\n{T}: Add {R}, {W}, or {B}. Spend this mana only to cast a Knight or Equipment spell.",
             "colours": [],
@@ -9711,7 +9711,7 @@
         },
         {
             "id": "45634668-e09f-5276-baf0-384dbdb34e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87891cd-b457-4dff-8d18-a7eaf6748fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87891cd-b457-4dff-8d18-a7eaf6748fc6.jpg?1",
             "name": "Witch's Cottage",
             "text": "({T}: Add {B}.)\nWitch's Cottage enters the battlefield tapped unless you control three or more other Swamps.\nWhen Witch's Cottage enters the battlefield untapped, you may put target creature card from your graveyard on top of your library.",
             "colours": [],
@@ -9743,7 +9743,7 @@
         },
         {
             "id": "5f4ea979-2cbd-540a-8903-a1c0a1153b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ded4b2a-ba56-43da-8ea7-392b77fc2926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ded4b2a-ba56-43da-8ea7-392b77fc2926.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9781,7 +9781,7 @@
         },
         {
             "id": "afb23454-e6ab-5dc0-b4b8-5f28bf5b4592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b7076-03b9-4a8b-a55c-6cba0b8162e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0b7076-03b9-4a8b-a55c-6cba0b8162e8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9819,7 +9819,7 @@
         },
         {
             "id": "bd2cb389-829c-514a-8150-da875b32cfd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5fbeae-9bd5-4741-80a2-9b646b374328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5fbeae-9bd5-4741-80a2-9b646b374328.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9857,7 +9857,7 @@
         },
         {
             "id": "3527fcd2-7319-547b-baac-f9178f070ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5f9eef-925c-479e-a9a5-ce61fc06f3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5f9eef-925c-479e-a9a5-ce61fc06f3be.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9895,7 +9895,7 @@
         },
         {
             "id": "566ca88c-f03f-540a-9198-527a899041ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4134cd82-6e48-4fc0-bcb4-1e3af369ef82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4134cd82-6e48-4fc0-bcb4-1e3af369ef82.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9933,7 +9933,7 @@
         },
         {
             "id": "208be91d-ac8c-54df-b0a5-f67df4192623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000f1f50-08e5-4d83-8159-98f06a0e2279.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9971,7 +9971,7 @@
         },
         {
             "id": "68d1c3e9-218c-5c1e-8a9d-e2e8822d5485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772b4f6b-dc2b-4247-8f55-f37608d75725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772b4f6b-dc2b-4247-8f55-f37608d75725.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10009,7 +10009,7 @@
         },
         {
             "id": "4b5c1cbd-b1bb-52ce-ad5c-4eac954c4bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb2a1e-9995-49c3-bfc7-7f392c95e16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb2a1e-9995-49c3-bfc7-7f392c95e16a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "12e211cb-ffb7-5324-bca9-d998f11f38bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f184c5-4f3c-4aea-afa1-f0903d3cc71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f184c5-4f3c-4aea-afa1-f0903d3cc71a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "799c8613-90a6-597a-bc3a-73d683aaf4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbeae38f-67e3-48fe-81ea-6af5db74cb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbeae38f-67e3-48fe-81ea-6af5db74cb28.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10123,7 +10123,7 @@
         },
         {
             "id": "e275cffc-6b6b-5f1b-8759-cac87732312d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41aa58c2-eaf2-4b17-b014-afbba7199d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41aa58c2-eaf2-4b17-b014-afbba7199d4a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10161,7 +10161,7 @@
         },
         {
             "id": "c6dfe188-fe59-5896-9a6e-1a1792545e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8705f4-c569-4d5f-bfd5-f076fbc78440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8705f4-c569-4d5f-bfd5-f076fbc78440.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10199,7 +10199,7 @@
         },
         {
             "id": "7cedd093-cbd9-5134-aa20-46bfd6de9712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32982ed2-96e4-4cc5-8562-744b06bca239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32982ed2-96e4-4cc5-8562-744b06bca239.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10237,7 +10237,7 @@
         },
         {
             "id": "43a2492e-2400-51e6-9e14-5cb96d95dc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c82442-e201-407d-9db7-613f24c1eb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c82442-e201-407d-9db7-613f24c1eb03.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10275,7 +10275,7 @@
         },
         {
             "id": "24f2c0d9-c443-5c5d-bbf6-860730e849fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84db98e-c51a-4380-8704-57fdd5eb360f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84db98e-c51a-4380-8704-57fdd5eb360f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10313,7 +10313,7 @@
         },
         {
             "id": "ba38264f-25ac-5370-ade8-b60d08684c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f43c81-10fc-4e08-9070-5453bc5826b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f43c81-10fc-4e08-9070-5453bc5826b4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "ae82cc1f-fef7-58ac-8bc7-e01197b5cbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f03bb2-313e-4688-945f-052eed678174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f03bb2-313e-4688-945f-052eed678174.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10389,7 +10389,7 @@
         },
         {
             "id": "403b406c-92b2-5f78-9a75-44a0abc290f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff5153-cdb8-4ed2-b17e-7ee2aa689da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff5153-cdb8-4ed2-b17e-7ee2aa689da0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "8d948f19-aea2-5d84-a86d-20aa539ff29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52fa771-eaff-48e0-8c23-d118dc4b3438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52fa771-eaff-48e0-8c23-d118dc4b3438.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10465,7 +10465,7 @@
         },
         {
             "id": "50929a4f-e5c8-5836-8133-8286f8beede2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd257a5-439d-4ef8-9cc9-9741e99a04e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd257a5-439d-4ef8-9cc9-9741e99a04e3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10503,7 +10503,7 @@
         },
         {
             "id": "6f6a1a8c-be54-5003-bcf2-5d7412678d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f8dd7-b774-40c5-9e67-3eb87bb72541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f8dd7-b774-40c5-9e67-3eb87bb72541.jpg?1",
             "name": "Garruk, Cursed Huntsman",
             "text": "",
             "colours": [
@@ -10543,7 +10543,7 @@
         },
         {
             "id": "f203bad8-9c07-507c-9699-fc8fec69e2d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da027e-34c1-4098-827d-1647693ad8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da027e-34c1-4098-827d-1647693ad8f4.jpg?1",
             "name": "Oko, Thief of Crowns",
             "text": "",
             "colours": [
@@ -10583,7 +10583,7 @@
         },
         {
             "id": "8e6befac-3f64-5666-ac47-99d5e82db820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e8af9-e3db-4cea-967f-11798dbcfa54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e8af9-e3db-4cea-967f-11798dbcfa54.jpg?1",
             "name": "The Royal Scions",
             "text": "",
             "colours": [
@@ -10624,7 +10624,7 @@
         },
         {
             "id": "24ddc5b0-3978-5cb0-9a05-b224b0642800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "985a785a-af16-59c3-bc70-237269bd19fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd6ccd0b-5279-431f-b65a-7fdbdffd1a90.jpg?1",
             "name": "Ardenvale Tactician // Dizzying Swoop",
             "text": "",
             "colours": [
@@ -10697,7 +10697,7 @@
         },
         {
             "id": "8e924666-0aa4-526d-affc-c777fbb9abef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "",
             "colours": [
@@ -10733,7 +10733,7 @@
         },
         {
             "id": "96dc3f02-5ece-5337-8609-7f6f5f490254",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed03df49-7ea7-40ca-96d6-3907d75cc8e3.jpg?1",
             "name": "Faerie Guidemother // Gift of the Fae",
             "text": "",
             "colours": [
@@ -10769,7 +10769,7 @@
         },
         {
             "id": "5ba3be28-c945-502d-8ef4-8297b5fa0fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "",
             "colours": [
@@ -10806,7 +10806,7 @@
         },
         {
             "id": "fb77bdb3-9f6d-5e6e-95ec-e10bc9465ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0960ccb-6952-4398-aa94-816e6fb04c2d.jpg?1",
             "name": "Giant Killer // Chop Down",
             "text": "",
             "colours": [
@@ -10842,7 +10842,7 @@
         },
         {
             "id": "fef06068-703b-5c3d-8d91-b7e73c7b2f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "643ce08b-0dd1-59cb-a498-8a59da0bd5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a1b6c9-8e66-475b-807b-4dd6e88b366a.jpg?1",
             "name": "Lonesome Unicorn // Rider in Need",
             "text": "",
             "colours": [
@@ -10914,7 +10914,7 @@
         },
         {
             "id": "2fe9fcfe-046b-5ccc-b477-269ab12262c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "",
             "colours": [
@@ -10950,7 +10950,7 @@
         },
         {
             "id": "3f9af606-6254-5896-9432-377a72309486",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d764af5-dd94-4874-a69b-c2a657a7d07b.jpg?1",
             "name": "Realm-Cloaked Giant // Cast Off",
             "text": "",
             "colours": [
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "34322e9d-0a9f-5a99-a0bc-80d579b395cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "",
             "colours": [
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "edf8f64f-384d-5ad1-a720-f3649ed57e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2a86ee7-f953-4fa2-8f28-a0c28afd733b.jpg?1",
             "name": "Shepherd of the Flock // Usher to Safety",
             "text": "",
             "colours": [
@@ -11059,7 +11059,7 @@
         },
         {
             "id": "2efb07cf-00e9-55da-8f4c-f40afb4724ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "",
             "colours": [
@@ -11096,7 +11096,7 @@
         },
         {
             "id": "ec577788-9d1c-5b69-b0a3-b52beaaaba69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cff94698-7065-40e9-8722-581b134a08fd.jpg?1",
             "name": "Silverflame Squire // On Alert",
             "text": "",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "e56fab2f-3093-555f-9c5d-c5fcca0dfbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "",
             "colours": [
@@ -11168,7 +11168,7 @@
         },
         {
             "id": "dce62e19-cecd-5484-89b0-ec878b20853c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8924faa-d5f5-4119-9fa1-be0789a5655d.jpg?1",
             "name": "Animating Faerie // Bring to Life",
             "text": "",
             "colours": [
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "66819bb9-e044-512b-921e-7a5a82be79f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -11241,7 +11241,7 @@
         },
         {
             "id": "f21cc3ef-1bd5-55b6-a5dd-11bdf3713a54",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d42a57b2-fbe9-4024-a593-f6dc711a2e9d.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -11277,7 +11277,7 @@
         },
         {
             "id": "8d2f7788-a8d8-5097-9cc2-ad61bbba9c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "",
             "colours": [
@@ -11314,7 +11314,7 @@
         },
         {
             "id": "d290ae99-5111-5cba-b04f-38a75c8ff266",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbe0da77-7b53-41cc-b6e6-eed5092d38c5.jpg?1",
             "name": "Fae of Wishes // Granted",
             "text": "",
             "colours": [
@@ -11350,7 +11350,7 @@
         },
         {
             "id": "4a41ac62-bf72-5175-a84d-25fdf2c925a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "",
             "colours": [
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "71a3d258-6da4-5761-b48b-3baaf1251db7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cdb80c03-53a5-4142-a630-bcf489d6383d.jpg?1",
             "name": "Hypnotic Sprite // Mesmeric Glare",
             "text": "",
             "colours": [
@@ -11422,7 +11422,7 @@
         },
         {
             "id": "1780ff22-2953-5b72-b4be-43b9f7454167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "",
             "colours": [
@@ -11459,7 +11459,7 @@
         },
         {
             "id": "1026a53f-0f85-5a52-b711-9d539967a52d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/8182c9e0-861e-4736-997b-e79e62a2fec5.jpg?1",
             "name": "Merfolk Secretkeeper // Venture Deeper",
             "text": "",
             "colours": [
@@ -11495,7 +11495,7 @@
         },
         {
             "id": "9bab7e52-edd0-595b-b3d7-81a850848843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "",
             "colours": [
@@ -11533,7 +11533,7 @@
         },
         {
             "id": "0f94b82d-fdf5-5d5f-b569-5b11ef34ec8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b16101-c0ac-4224-ade9-abba72773ec1.jpg?1",
             "name": "Queen of Ice // Rage of Winter",
             "text": "",
             "colours": [
@@ -11569,7 +11569,7 @@
         },
         {
             "id": "41747a81-62b5-51c2-984b-45cdd3f9adcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "",
             "colours": [
@@ -11606,7 +11606,7 @@
         },
         {
             "id": "c7c388bc-8daf-5b5f-b91d-302865b49d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6a16f907-93df-419e-8a65-ee96938e4143.jpg?1",
             "name": "Foulmire Knight // Profane Insight",
             "text": "",
             "colours": [
@@ -11642,7 +11642,7 @@
         },
         {
             "id": "4f200c09-f83f-586d-a364-1f94e5fa2652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "",
             "colours": [
@@ -11679,7 +11679,7 @@
         },
         {
             "id": "cde8ada5-6815-5946-ae7a-8607a9da00a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49c98e70-e8fe-4fea-b1d0-e7560780fda9.jpg?1",
             "name": "Murderous Rider // Swift End",
             "text": "",
             "colours": [
@@ -11715,7 +11715,7 @@
         },
         {
             "id": "fa18a3c2-fa27-5460-bd62-0222d1242cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "",
             "colours": [
@@ -11752,7 +11752,7 @@
         },
         {
             "id": "bacc03fa-774b-5b28-a24e-33d04be38333",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d747619-3057-4973-aec7-a0e4674e94f7.jpg?1",
             "name": "Order of Midnight // Alter Fate",
             "text": "",
             "colours": [
@@ -11788,7 +11788,7 @@
         },
         {
             "id": "3fe29c0e-4ca5-5f3b-93cd-8b2664bc61c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "",
             "colours": [
@@ -11824,7 +11824,7 @@
         },
         {
             "id": "084595aa-9673-52d0-89ec-d7f846bce8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39c0abef-f59c-473a-8a6e-eacd4a78ff72.jpg?1",
             "name": "Reaper of Night // Harvest Fear",
             "text": "",
             "colours": [
@@ -11860,7 +11860,7 @@
         },
         {
             "id": "56da8c67-31a8-567c-9ac0-18b42db36158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "",
             "colours": [
@@ -11897,7 +11897,7 @@
         },
         {
             "id": "4040c173-4cd4-5908-88e5-4d91b3913ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea2a7e55-be1c-4552-92f0-c68f085f3a27.jpg?1",
             "name": "Smitten Swordmaster // Curry Favor",
             "text": "",
             "colours": [
@@ -11933,7 +11933,7 @@
         },
         {
             "id": "7684f22a-6acb-53ed-a568-2029875ddfde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "",
             "colours": [
@@ -11969,7 +11969,7 @@
         },
         {
             "id": "7060ed02-2559-509e-af4b-0078286641b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff984a4c-1818-4f8f-a9d7-fce57e77937d.jpg?1",
             "name": "Bonecrusher Giant // Stomp",
             "text": "",
             "colours": [
@@ -12005,7 +12005,7 @@
         },
         {
             "id": "07f10747-d129-5025-9af0-b7919df3c82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -12042,7 +12042,7 @@
         },
         {
             "id": "5a4d4c37-4c8b-5232-bc2f-5eeb2fc28883",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13b553f1-8107-42a8-841a-91adf71cff72.jpg?1",
             "name": "Embereth Shieldbreaker // Battle Display",
             "text": "",
             "colours": [
@@ -12078,7 +12078,7 @@
         },
         {
             "id": "67884248-a6ce-5821-bd73-72ed8a292732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "",
             "colours": [
@@ -12115,7 +12115,7 @@
         },
         {
             "id": "4ff9473d-0b6b-59a0-9fef-5cf29cfd2457",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/039c20ab-13c4-426a-888c-9093340a85a0.jpg?1",
             "name": "Merchant of the Vale // Haggle",
             "text": "",
             "colours": [
@@ -12151,7 +12151,7 @@
         },
         {
             "id": "07d5f71c-4fca-53b8-abd7-626265880f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "",
             "colours": [
@@ -12188,7 +12188,7 @@
         },
         {
             "id": "a48274ad-20c8-5a9b-9480-da41d4ce348d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b218d970-d3a9-4845-8ee9-efad9aff0fdd.jpg?1",
             "name": "Rimrock Knight // Boulder Rush",
             "text": "",
             "colours": [
@@ -12224,7 +12224,7 @@
         },
         {
             "id": "935ddb73-3b3b-5466-8b25-706b1c5eeb5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "",
             "colours": [
@@ -12260,7 +12260,7 @@
         },
         {
             "id": "e78d0b7a-7b47-59b2-a148-c5a130224adb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49875f7a-31b9-4276-b971-8ead1e18fc81.jpg?1",
             "name": "Beanstalk Giant // Fertile Footsteps",
             "text": "",
             "colours": [
@@ -12296,7 +12296,7 @@
         },
         {
             "id": "56933d43-1a1f-58ce-8c7b-557def831b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "",
             "colours": [
@@ -12333,7 +12333,7 @@
         },
         {
             "id": "5e6369c8-d8c5-5877-8a26-6f7f5b021c09",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a20f78f-32c6-4ba4-8389-1fde32ea42e4.jpg?1",
             "name": "Curious Pair // Treats to Share",
             "text": "",
             "colours": [
@@ -12369,7 +12369,7 @@
         },
         {
             "id": "73562a88-c8d7-5bd3-abc2-2c7961a5c634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "",
             "colours": [
@@ -12406,7 +12406,7 @@
         },
         {
             "id": "7938d306-5ffd-59fe-afdf-4360f7ca1316",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/489ae8ac-8329-49f0-a301-875f7ba37c97.jpg?1",
             "name": "Flaxen Intruder // Welcome Home",
             "text": "",
             "colours": [
@@ -12442,7 +12442,7 @@
         },
         {
             "id": "eeec2aa9-1458-55c4-99f0-60ea6a0299ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "",
             "colours": [
@@ -12479,7 +12479,7 @@
         },
         {
             "id": "0f01a6ce-778a-538d-9926-e9f35d2efc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb6b2759-c315-42cb-8842-dc4f0f42c01d.jpg?1",
             "name": "Garenbrig Carver // Shield's Might",
             "text": "",
             "colours": [
@@ -12515,7 +12515,7 @@
         },
         {
             "id": "808aab9f-f353-598e-ae86-0099ad7b0da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "",
             "colours": [
@@ -12552,7 +12552,7 @@
         },
         {
             "id": "55214f09-66df-5578-901e-56ca36ee5102",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/341110e5-577d-45ee-bf62-53373a331c87.jpg?1",
             "name": "Lovestruck Beast // Heart's Desire",
             "text": "",
             "colours": [
@@ -12588,7 +12588,7 @@
         },
         {
             "id": "7d6334a7-3a55-5aa3-b67a-853af5d9ebec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "",
             "colours": [
@@ -12625,7 +12625,7 @@
         },
         {
             "id": "6753cc93-b956-54f1-8975-f62cfa591875",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/472bed9a-10f3-4811-b562-5a746a712cd8.jpg?1",
             "name": "Rosethorn Acolyte // Seasonal Ritual",
             "text": "",
             "colours": [
@@ -12661,7 +12661,7 @@
         },
         {
             "id": "9fc20058-38cb-5dd7-b7e4-1c40a33e921d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "",
             "colours": [
@@ -12698,7 +12698,7 @@
         },
         {
             "id": "02b707a3-0563-549e-9dba-36708ea3f25e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b7c91e7-b0c6-47e1-9c92-c5e9faace876.jpg?1",
             "name": "Tuinvale Treefolk // Oaken Boon",
             "text": "",
             "colours": [
@@ -12734,7 +12734,7 @@
         },
         {
             "id": "08f5c431-3da6-5cd9-b633-27c84fe7150d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "",
             "colours": [
@@ -12774,7 +12774,7 @@
         },
         {
             "id": "2531e40e-3271-500e-ab5e-ed12df3588e0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c389e04c-b009-4468-b760-5dd588cff9b9.jpg?1",
             "name": "Oakhame Ranger // Bring Back",
             "text": "",
             "colours": [
@@ -12812,7 +12812,7 @@
         },
         {
             "id": "b716ea42-01fa-5f8d-af42-efaecf77a748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1227e-bea7-47cb-bbec-389a3d585af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c1227e-bea7-47cb-bbec-389a3d585af5.jpg?1",
             "name": "Kenrith, the Returned King",
             "text": "{R}: All creatures gain trample and haste until end of turn.\n{1}{G}: Put a +1/+1 counter on target creature.\n{2}{W}: Target player gains 5 life.\n{3}{U}: Target player draws a card.\n{4}{B}: Put target creature card from a graveyard onto the battlefield under its owner's control.",
             "colours": [
@@ -12853,7 +12853,7 @@
         },
         {
             "id": "ade2779a-a5e9-5549-9a84-0875ae05ff1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030f4058-54e5-4333-bd6c-2789c334bf12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030f4058-54e5-4333-bd6c-2789c334bf12.jpg?1",
             "name": "Rowan, Fearless Sparkmage",
             "text": "+1: Up to one target creature gets +3/+0 and gains first strike until end of turn.\n\u22122: Rowan, Fearless Sparkmage deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.\n\u22129: Gain control of all creatures until end of turn. Untap them. They gain haste until end of turn.",
             "colours": [
@@ -12889,7 +12889,7 @@
         },
         {
             "id": "660dcfab-3332-55f8-8635-b39dcbb37423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a04717-5cd7-4982-bf36-00cea30b9ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a04717-5cd7-4982-bf36-00cea30b9ef1.jpg?1",
             "name": "Garrison Griffin",
             "text": "Flying\nWhenever Garrison Griffin attacks, target Knight you control gains flying until end of turn.",
             "colours": [
@@ -12922,7 +12922,7 @@
         },
         {
             "id": "3762582d-3812-57e2-8571-88e3c9b3564d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a3119-ce9b-4fe5-aea3-871a7eee216e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8a3119-ce9b-4fe5-aea3-871a7eee216e.jpg?1",
             "name": "Rowan's Battleguard",
             "text": "First strike\nAs long as you control a Rowan planeswalker, Rowan's Battleguard gets +3/+0.",
             "colours": [
@@ -12956,7 +12956,7 @@
         },
         {
             "id": "48e671ef-26fc-5b42-bc3f-363b3114c499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b537c4e3-88d1-430d-b4c8-16e0716d1927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b537c4e3-88d1-430d-b4c8-16e0716d1927.jpg?1",
             "name": "Rowan's Stalwarts",
             "text": "When Rowan's Stalwarts enters the battlefield, you may search your library and/or graveyard for a card named Rowan, Fearless Sparkmage, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "1b210c99-2bdd-5d82-99de-28d81a01472a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5875e-487f-4586-95f3-3627050a6744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5875e-487f-4586-95f3-3627050a6744.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -13020,7 +13020,7 @@
         },
         {
             "id": "4d2e6c97-b5f7-5b40-84a7-83c78cc427dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e61813-c4c8-4e80-8808-ac5107966ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e61813-c4c8-4e80-8808-ac5107966ee3.jpg?1",
             "name": "Oko, the Trickster",
             "text": "+1: Put two +1/+1 counters on up to one target creature you control.\n0: Until end of turn, Oko, the Trickster becomes a copy of target creature you control. Prevent all damage that would be dealt to him this turn.\n\u22127: Until end of turn, each creature you control has base power and toughness 10/10 and gains trample.",
             "colours": [
@@ -13058,7 +13058,7 @@
         },
         {
             "id": "f2bab806-a163-5ff2-ab64-ce1bb4f23bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c52b50-35aa-4858-8c8e-c81dcb29a7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c52b50-35aa-4858-8c8e-c81dcb29a7fc.jpg?1",
             "name": "Oko's Accomplices",
             "text": "Flying",
             "colours": [
@@ -13091,7 +13091,7 @@
         },
         {
             "id": "29e2cb93-93c1-51e6-9c6f-e39c637a0c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc83a142-9d0f-4a39-baeb-4e2f62009204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc83a142-9d0f-4a39-baeb-4e2f62009204.jpg?1",
             "name": "Bramblefort Fink",
             "text": "{8}: Bramblefort Fink has base power and toughness 10/10 until end of turn. Activate this ability only if you control an Oko planeswalker.",
             "colours": [
@@ -13124,7 +13124,7 @@
         },
         {
             "id": "b3dd0d4c-6f78-51e4-8354-d07300132f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fb103d-f07c-4113-9da7-843cc7dab340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fb103d-f07c-4113-9da7-843cc7dab340.jpg?1",
             "name": "Oko's Hospitality",
             "text": "Creatures you control have base power and toughness 3/3 until end of turn. You may search your library and/or graveyard for a card named Oko, the Trickster, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -13157,7 +13157,7 @@
         },
         {
             "id": "dda81482-5cfa-5c74-b46f-5e6e6b7821cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5159db6-a87f-40eb-8c5c-821dfb67ff6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5159db6-a87f-40eb-8c5c-821dfb67ff6d.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -13187,7 +13187,7 @@
         },
         {
             "id": "9d57d649-3a67-577e-81a1-df5a5cdaec35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c141ed6-02ee-49c4-98af-938ebcefb2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c141ed6-02ee-49c4-98af-938ebcefb2f5.jpg?1",
             "name": "Mace of the Valiant",
             "text": "Equipped creature gets +1/+1 for each charge counter on Mace of the Valiant and has vigilance.\nWhenever a creature enters the battlefield under your control, put a charge counter on Mace of the Valiant.\nEquip {3}",
             "colours": [
@@ -13220,7 +13220,7 @@
         },
         {
             "id": "a8ef0e50-2a6e-5d8c-8b07-98634840ffb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4348513e-4a03-4e06-98e0-ac6c0dfb013d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4348513e-4a03-4e06-98e0-ac6c0dfb013d.jpg?1",
             "name": "Silverwing Squadron",
             "text": "Flying, vigilance\nSilverwing Squadron's power and toughness are each equal to the number of creatures you control.\nWhenever Silverwing Squadron attacks, create a number of 2/2 white Knight creature tokens with vigilance equal to the number of opponents you have.",
             "colours": [
@@ -13254,7 +13254,7 @@
         },
         {
             "id": "aaa045ba-3b1f-5a10-b464-88eb8ff41403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg?1",
             "name": "Faerie Formation",
             "text": "Flying\n{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "afeae767-3cc1-5a17-be07-c0f4f575b422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5beffa4c-4188-48c1-8374-3ac3e8ea1900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5beffa4c-4188-48c1-8374-3ac3e8ea1900.jpg?1",
             "name": "Shimmer Dragon",
             "text": "Flying\nAs long as you control four or more artifacts, Shimmer Dragon has hexproof.\nTap two untapped artifacts you control: Draw a card.",
             "colours": [
@@ -13320,7 +13320,7 @@
         },
         {
             "id": "470588ce-cb15-5980-b9a5-59340bd695ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53913e26-d98b-4ca6-aeea-23633d762d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53913e26-d98b-4ca6-aeea-23633d762d46.jpg?1",
             "name": "Workshop Elders",
             "text": "Artifact creatures you control have flying.\nAt the beginning of combat on your turn, you may have target noncreature artifact you control become a 0/0 artifact creature. If you do, put four +1/+1 counters on it.",
             "colours": [
@@ -13354,7 +13354,7 @@
         },
         {
             "id": "e4872789-196f-5380-9c44-b3b988b95829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298940-4277-4145-9f2f-a284fd2e1a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c298940-4277-4145-9f2f-a284fd2e1a9d.jpg?1",
             "name": "Chittering Witch",
             "text": "When Chittering Witch enters the battlefield, create a number of 1/1 black Rat creature tokens equal to the number of opponents you have.\n{1}{B}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -13388,7 +13388,7 @@
         },
         {
             "id": "8377d66c-5953-5752-a2f7-08d6cf351fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851066e5-d5f2-4e53-8b88-487441a77548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851066e5-d5f2-4e53-8b88-487441a77548.jpg?1",
             "name": "Taste of Death",
             "text": "Each player sacrifices three creatures. You create three Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -13419,7 +13419,7 @@
         },
         {
             "id": "f7dc5362-c7ed-5d4a-ad03-ddaf9a35e58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166ee7fc-a0f7-49af-85bf-d5b36bb2bff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166ee7fc-a0f7-49af-85bf-d5b36bb2bff4.jpg?1",
             "name": "Embereth Skyblazer",
             "text": "As long as it's your turn, Embereth Skyblazer has flying.\nWhenever Embereth Skyblazer attacks, you may pay {2}{R}. If you do, creatures you control get +X/+0 until end of turn, where X is the number of opponents you have.",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "8d91375c-73b1-52bf-b475-d54ffce0f44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d0e54d-6e18-44a5-adc2-d875d5b6784f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d0e54d-6e18-44a5-adc2-d875d5b6784f.jpg?1",
             "name": "Steelbane Hydra",
             "text": "Steelbane Hydra enters the battlefield with X +1/+1 counters on it.\n{2}{G}, Remove a +1/+1 counter from Steelbane Hydra: Destroy target artifact or enchantment.",
             "colours": [
@@ -13487,7 +13487,7 @@
         },
         {
             "id": "fc932e4f-4e9b-529d-86b0-4c0429e9534c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80138656-b2e2-43bf-9fe6-7a852f53f9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80138656-b2e2-43bf-9fe6-7a852f53f9e9.jpg?1",
             "name": "Thorn Mammoth",
             "text": "Trample\nWhenever Thorn Mammoth or another creature enters the battlefield under your control, Thorn Mammoth fights up to one target creature you don't control.",
             "colours": [
@@ -13520,7 +13520,7 @@
         },
         {
             "id": "0aa7dd0c-321b-5164-ae52-cd0c047c2cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e7dc5-2089-4758-93e1-79212aedf75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e7dc5-2089-4758-93e1-79212aedf75f.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "Flying, deathtouch, lifelink\nOther creatures you control with flying get +1/+0.\nWhenever you cast an artifact or enchantment spell, create a 1/1 blue Faerie creature token with flying.",
             "colours": [
@@ -13561,7 +13561,7 @@
         },
         {
             "id": "5a301df2-47ee-5e02-906c-5a105f95da8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5e4c5d-7d1d-4426-8351-35c12e29d9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5e4c5d-7d1d-4426-8351-35c12e29d9c3.jpg?1",
             "name": "Banish into Fable",
             "text": "When you cast this spell from your hand, copy it if you control an artifact, then copy it if you control an enchantment. You may choose new targets for the copies.\nReturn target nonland permanent to its owner's hand. You create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -13594,7 +13594,7 @@
         },
         {
             "id": "56c28062-e7c3-542f-923c-4e11e3901983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f43730-1c1f-4150-8771-d901c54bedc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f43730-1c1f-4150-8771-d901c54bedc4.jpg?1",
             "name": "Chulane, Teller of Tales",
             "text": "Vigilance\nWhenever you cast a creature spell, draw a card, then you may put a land card from your hand onto the battlefield.\n{3}, {T}: Return target creature you control to its owner's hand.",
             "colours": [
@@ -13635,7 +13635,7 @@
         },
         {
             "id": "0ad01b9a-f691-5c55-9542-d58b070e604c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e245b-6153-479c-9e09-682afb017ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e245b-6153-479c-9e09-682afb017ff3.jpg?1",
             "name": "Gluttonous Troll",
             "text": "Trample\nWhen Gluttonous Troll enters the battlefield, create a number of Food tokens equal to the number of opponents you have. (Food tokens are artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{1}{G}, Sacrifice another nonland permanent: Gluttonous Troll gets +2/+2 until end of turn.",
             "colours": [
@@ -13670,7 +13670,7 @@
         },
         {
             "id": "cc92eca8-1a76-5b02-acab-26a45ef7f549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b86f7db-ae1d-49fe-a9c5-488bbf3afac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b86f7db-ae1d-49fe-a9c5-488bbf3afac7.jpg?1",
             "name": "Knights' Charge",
             "text": "Whenever a Knight you control attacks, each opponent loses 1 life and you gain 1 life.\n{6}{W}{B}, Sacrifice Knights' Charge: Return all Knight creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -13703,7 +13703,7 @@
         },
         {
             "id": "9aba2136-443c-515a-9154-318a1b046491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1575-eb64-43b5-b604-c6e23054f228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1575-eb64-43b5-b604-c6e23054f228.jpg?1",
             "name": "Korvold, Fae-Cursed King",
             "text": "Flying\nWhenever Korvold, Fae-Cursed King enters the battlefield or attacks, sacrifice another permanent.\nWhenever you sacrifice a permanent, put a +1/+1 counter on Korvold and draw a card.",
             "colours": [
@@ -13744,7 +13744,7 @@
         },
         {
             "id": "95648381-c7ec-5ce4-a86e-b1417feacf82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33add37-379d-4a90-9c04-529dff676986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33add37-379d-4a90-9c04-529dff676986.jpg?1",
             "name": "Syr Gwyn, Hero of Ashvale",
             "text": "Vigilance, menace\nWhenever an equipped creature you control attacks, you draw a card and you lose 1 life.\nEquipment you control have equip Knight {0}.",
             "colours": [
@@ -13785,7 +13785,7 @@
         },
         {
             "id": "92b1996a-d32e-5d11-b4be-dd5b73f92027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84128e98-87d6-4c2f-909b-9435a7833e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84128e98-87d6-4c2f-909b-9435a7833e63.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13812,7 +13812,7 @@
         },
         {
             "id": "d0113384-cc3f-5408-82e2-4e3ac27535b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040301e8-20c1-4f4c-8766-d05f11415efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040301e8-20c1-4f4c-8766-d05f11415efd.jpg?1",
             "name": "Tome of Legends",
             "text": "Tome of Legends enters the battlefield with a page counter on it.\nWhenever your commander enters the battlefield or attacks, put a page counter on Tome of Legends.\n{1}, {T}, Remove a page counter from Tome of Legends: Draw a card.",
             "colours": [],
@@ -13839,7 +13839,7 @@
         },
         {
             "id": "445b6d2a-be40-5ef0-8dfa-35f330c1f575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1f1041-f667-4b73-b1f2-e5bcae84095e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1f1041-f667-4b73-b1f2-e5bcae84095e.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13866,7 +13866,7 @@
         },
         {
             "id": "1653864b-0cb0-5917-a4f6-44df2fed3211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbf3260-b956-40da-abc7-764781c9f26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbf3260-b956-40da-abc7-764781c9f26f.jpg?1",
             "name": "Acclaimed Contender",
             "text": "",
             "colours": [
@@ -13903,7 +13903,7 @@
         },
         {
             "id": "11734b7b-4467-5f49-ae1e-c00a33ee0f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd45820e-39be-448e-b446-44f3ebab555e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd45820e-39be-448e-b446-44f3ebab555e.jpg?1",
             "name": "Charming Prince",
             "text": "",
             "colours": [
@@ -13940,7 +13940,7 @@
         },
         {
             "id": "818f500c-b45c-5edf-bf9e-6dddb4079a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35538cb0-813a-46a1-9c2b-0a1eda866ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35538cb0-813a-46a1-9c2b-0a1eda866ed0.jpg?1",
             "name": "The Circle of Loyalty",
             "text": "",
             "colours": [
@@ -13976,7 +13976,7 @@
         },
         {
             "id": "bf14e983-c011-535e-9032-14074f3520fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38c9120-ac20-4f81-b8d8-9d490cc2a913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38c9120-ac20-4f81-b8d8-9d490cc2a913.jpg?1",
             "name": "Happily Ever After",
             "text": "",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "5d7fea72-9a1e-5af2-a84d-f8107e5fcf41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee91fd2-794f-4c6a-8ce6-3bd2b12f95bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee91fd2-794f-4c6a-8ce6-3bd2b12f95bb.jpg?1",
             "name": "Harmonious Archon",
             "text": "",
             "colours": [
@@ -14046,7 +14046,7 @@
         },
         {
             "id": "bc763d1d-1509-533b-bba2-9159e44c6b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda18da1-1ba4-421c-8980-a94984a5e12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda18da1-1ba4-421c-8980-a94984a5e12a.jpg?1",
             "name": "Hushbringer",
             "text": "",
             "colours": [
@@ -14082,7 +14082,7 @@
         },
         {
             "id": "2620aa49-4bf1-534f-af69-a159de6491a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab231-6575-4682-9208-13ac6b9d7910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052ab231-6575-4682-9208-13ac6b9d7910.jpg?1",
             "name": "Linden, the Steadfast Queen",
             "text": "",
             "colours": [
@@ -14121,7 +14121,7 @@
         },
         {
             "id": "6f2774a6-607d-5632-a68e-f8d60bb64725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323ed08b-36a2-46ba-953b-59085e5db4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323ed08b-36a2-46ba-953b-59085e5db4e3.jpg?1",
             "name": "Worthy Knight",
             "text": "",
             "colours": [
@@ -14158,7 +14158,7 @@
         },
         {
             "id": "f0b0e75e-853c-5f43-ad42-be007d2d69c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157f343d-8583-4827-a77d-d916e6a5caa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157f343d-8583-4827-a77d-d916e6a5caa1.jpg?1",
             "name": "Emry, Lurker of the Loch",
             "text": "",
             "colours": [
@@ -14197,7 +14197,7 @@
         },
         {
             "id": "94b0c999-f0fa-5af0-936c-39d01f4f6994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb4518-406b-4673-afd9-61a9440e3335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fb4518-406b-4673-afd9-61a9440e3335.jpg?1",
             "name": "Folio of Fancies",
             "text": "",
             "colours": [
@@ -14231,7 +14231,7 @@
         },
         {
             "id": "c914c5a5-b573-5a69-b58b-cc121d0a75cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b89ce-fdb2-4730-b87c-e23aa131be24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73b89ce-fdb2-4730-b87c-e23aa131be24.jpg?1",
             "name": "Gadwick, the Wizened",
             "text": "",
             "colours": [
@@ -14270,7 +14270,7 @@
         },
         {
             "id": "54a23418-acbe-5fc5-83b3-cf7842aa54a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccea8f-b3f1-41a2-a145-8fc41b21d936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccea8f-b3f1-41a2-a145-8fc41b21d936.jpg?1",
             "name": "The Magic Mirror",
             "text": "",
             "colours": [
@@ -14306,7 +14306,7 @@
         },
         {
             "id": "0881200f-fa9e-59d3-96d1-0dbba3d71c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef0851-c2bb-4b11-b9c2-c659abadd0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eef0851-c2bb-4b11-b9c2-c659abadd0d9.jpg?1",
             "name": "Midnight Clock",
             "text": "",
             "colours": [
@@ -14340,7 +14340,7 @@
         },
         {
             "id": "f1a4f70c-5762-5776-8ea4-4263d6750d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b40cd-c359-41cc-b530-d7d6fbbe33bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b40cd-c359-41cc-b530-d7d6fbbe33bf.jpg?1",
             "name": "Mirrormade",
             "text": "",
             "colours": [
@@ -14374,7 +14374,7 @@
         },
         {
             "id": "704bca3e-445f-5329-b628-ce18aa485a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314ca59b-873b-4665-b46d-d73398f85a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314ca59b-873b-4665-b46d-d73398f85a67.jpg?1",
             "name": "Stolen by the Fae",
             "text": "",
             "colours": [
@@ -14408,7 +14408,7 @@
         },
         {
             "id": "23d92b62-cb7e-59e1-ba8a-f4a5adb2be8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42af2e9-a2cb-495e-a039-ee7b46035310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42af2e9-a2cb-495e-a039-ee7b46035310.jpg?1",
             "name": "Vantress Gargoyle",
             "text": "",
             "colours": [
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "6d97d91d-ed16-5684-8cdd-0c161f0c8e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c6e2cf-3799-4d5b-99c2-feeec15580ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c6e2cf-3799-4d5b-99c2-feeec15580ec.jpg?1",
             "name": "Ayara, First of Locthwain",
             "text": "",
             "colours": [
@@ -14484,7 +14484,7 @@
         },
         {
             "id": "1ee17f08-0e86-5fd8-b41d-e85bca6dce7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b03278-9ce8-4698-a8ca-135668384718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b03278-9ce8-4698-a8ca-135668384718.jpg?1",
             "name": "Blacklance Paragon",
             "text": "",
             "colours": [
@@ -14521,7 +14521,7 @@
         },
         {
             "id": "104ce562-e2f5-561b-bb0f-888b2ce23187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cc8dd-b32c-4306-a542-cc97dc2aafdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cc8dd-b32c-4306-a542-cc97dc2aafdf.jpg?1",
             "name": "The Cauldron of Eternity",
             "text": "",
             "colours": [
@@ -14557,7 +14557,7 @@
         },
         {
             "id": "a518300d-0ced-5a34-bd30-7bb378d1464c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfe592d-7733-4f26-a395-3042817cc831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfe592d-7733-4f26-a395-3042817cc831.jpg?1",
             "name": "Clackbridge Troll",
             "text": "",
             "colours": [
@@ -14593,7 +14593,7 @@
         },
         {
             "id": "5d4140fa-b08b-5591-86f7-d757191ae43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc82c1f-3584-49d0-b39f-87d97d9153fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc82c1f-3584-49d0-b39f-87d97d9153fc.jpg?1",
             "name": "Oathsworn Knight",
             "text": "",
             "colours": [
@@ -14630,7 +14630,7 @@
         },
         {
             "id": "cb8c4745-f3d2-51d6-87ab-71612430ae5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee235810-078e-4208-91e2-b559c277eb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee235810-078e-4208-91e2-b559c277eb86.jpg?1",
             "name": "Piper of the Swarm",
             "text": "",
             "colours": [
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "45647264-5fae-5944-899d-519e37416bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d196e-7ce4-4dc1-9d58-102a89aca2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d196e-7ce4-4dc1-9d58-102a89aca2a4.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "",
             "colours": [
@@ -14707,7 +14707,7 @@
         },
         {
             "id": "50b9af8d-eba0-5f8c-909e-49e16a726fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebcb070-953c-4b47-ad8a-ef207c65053f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebcb070-953c-4b47-ad8a-ef207c65053f.jpg?1",
             "name": "Wishclaw Talisman",
             "text": "",
             "colours": [
@@ -14741,7 +14741,7 @@
         },
         {
             "id": "12fef22c-6d30-5da3-a1f3-3e5d954aa951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28cfb-dedc-4dac-8b26-27f963f4d310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28cfb-dedc-4dac-8b26-27f963f4d310.jpg?1",
             "name": "Witch's Vengeance",
             "text": "",
             "colours": [
@@ -14775,7 +14775,7 @@
         },
         {
             "id": "ed70b04c-0be8-51e3-aca2-30e1baf1804a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b8bcc-b9ac-4d8c-9db4-2bf91a853f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b8bcc-b9ac-4d8c-9db4-2bf91a853f03.jpg?1",
             "name": "Embercleave",
             "text": "",
             "colours": [
@@ -14813,7 +14813,7 @@
         },
         {
             "id": "fd3f56b9-f103-5d57-bc4e-b18d26b92522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66e70e-354e-4c3c-9d5d-90f0bf1b857d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e66e70e-354e-4c3c-9d5d-90f0bf1b857d.jpg?1",
             "name": "Fervent Champion",
             "text": "",
             "colours": [
@@ -14850,7 +14850,7 @@
         },
         {
             "id": "59fffc28-3a2b-59eb-a547-d862530d3d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515aded7-16fc-498e-9736-f4853e6d5a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515aded7-16fc-498e-9736-f4853e6d5a72.jpg?1",
             "name": "Fires of Invention",
             "text": "",
             "colours": [
@@ -14884,7 +14884,7 @@
         },
         {
             "id": "866ac912-1e8e-50fd-a488-956e172dd278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257a84d3-bc4e-4bb3-a435-6d243929bd8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257a84d3-bc4e-4bb3-a435-6d243929bd8c.jpg?1",
             "name": "Irencrag Feat",
             "text": "",
             "colours": [
@@ -14918,7 +14918,7 @@
         },
         {
             "id": "2393eb7c-fb89-54c5-bc9c-3a9b7c950af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ef45e3-b12a-403e-823c-44f4c95543e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ef45e3-b12a-403e-823c-44f4c95543e8.jpg?1",
             "name": "Irencrag Pyromancer",
             "text": "",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "ed4f0f55-3741-57f0-9ea3-95b39d9eb10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104f257-b3aa-4e7e-987c-7358b6ca7b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104f257-b3aa-4e7e-987c-7358b6ca7b12.jpg?1",
             "name": "Opportunistic Dragon",
             "text": "",
             "colours": [
@@ -14991,7 +14991,7 @@
         },
         {
             "id": "ef8ced05-9770-5dfd-8612-193be7286975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b44930-f109-4865-8cd0-735ae5b4299c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b44930-f109-4865-8cd0-735ae5b4299c.jpg?1",
             "name": "Robber of the Rich",
             "text": "",
             "colours": [
@@ -15029,7 +15029,7 @@
         },
         {
             "id": "847b6ee2-8741-5455-8f79-e36831d556fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40ddc1e-aab6-497f-b0d0-ab1dc4d32b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40ddc1e-aab6-497f-b0d0-ab1dc4d32b44.jpg?1",
             "name": "Sundering Stroke",
             "text": "",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "1d075fe6-99a7-576a-97ae-a5a00caf9cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b63513-5e53-4357-8b28-cb91790e9a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b63513-5e53-4357-8b28-cb91790e9a72.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "",
             "colours": [
@@ -15102,7 +15102,7 @@
         },
         {
             "id": "f557770e-bb46-561b-b3c0-94ba106e25ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f907f50-c02e-4348-a2d0-6697705e4047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f907f50-c02e-4348-a2d0-6697705e4047.jpg?1",
             "name": "Feasting Troll King",
             "text": "",
             "colours": [
@@ -15139,7 +15139,7 @@
         },
         {
             "id": "0330234e-b38e-5973-9cf4-dce5f36254c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d274723a-27f3-49ec-ade0-d0b5e0e87d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d274723a-27f3-49ec-ade0-d0b5e0e87d84.jpg?1",
             "name": "Gilded Goose",
             "text": "",
             "colours": [
@@ -15175,7 +15175,7 @@
         },
         {
             "id": "3ef6edae-e899-521c-a731-3aeeff8b154e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7e30c8-b3fc-430f-ac63-d376d9e47a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7e30c8-b3fc-430f-ac63-d376d9e47a8d.jpg?1",
             "name": "The Great Henge",
             "text": "",
             "colours": [
@@ -15211,7 +15211,7 @@
         },
         {
             "id": "6c62c84e-ef63-5447-81d6-c6d1d0a9a117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ca07ab-32e9-477c-a263-721a03f778ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ca07ab-32e9-477c-a263-721a03f778ff.jpg?1",
             "name": "Once Upon a Time",
             "text": "",
             "colours": [
@@ -15245,7 +15245,7 @@
         },
         {
             "id": "fbfd3536-f255-5021-9922-833d1bbe2dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357e802-2d25-48d3-a188-101c142787b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5357e802-2d25-48d3-a188-101c142787b7.jpg?1",
             "name": "Questing Beast",
             "text": "",
             "colours": [
@@ -15283,7 +15283,7 @@
         },
         {
             "id": "4b0c9cbd-32b6-5986-849d-ef54fdd2331d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8183abc4-c4b3-409a-908f-cc549a545e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8183abc4-c4b3-409a-908f-cc549a545e69.jpg?1",
             "name": "Return of the Wildspeaker",
             "text": "",
             "colours": [
@@ -15317,7 +15317,7 @@
         },
         {
             "id": "a12d890a-1619-5545-b2f0-3897d6c61c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1377f-c907-4dd4-be1f-e447dd68a06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f1377f-c907-4dd4-be1f-e447dd68a06e.jpg?1",
             "name": "Wicked Wolf",
             "text": "",
             "colours": [
@@ -15353,7 +15353,7 @@
         },
         {
             "id": "3bf835a3-c2b2-5ccb-96d1-b5b63435673f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a907bc-2000-43b4-b95f-00acfa594fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a907bc-2000-43b4-b95f-00acfa594fe0.jpg?1",
             "name": "Wildborn Preserver",
             "text": "",
             "colours": [
@@ -15390,7 +15390,7 @@
         },
         {
             "id": "421f7635-1261-5d83-abbe-bf73a04bc234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85311717-07f7-4be5-902c-0df1307bf5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85311717-07f7-4be5-902c-0df1307bf5b5.jpg?1",
             "name": "Yorvo, Lord of Garenbrig",
             "text": "",
             "colours": [
@@ -15429,7 +15429,7 @@
         },
         {
             "id": "9836b5b8-0d2a-5c0b-94ac-906533ec81a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2804de2-5b13-493c-87ac-e59b3bb569a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2804de2-5b13-493c-87ac-e59b3bb569a4.jpg?1",
             "name": "Dance of the Manse",
             "text": "",
             "colours": [
@@ -15465,7 +15465,7 @@
         },
         {
             "id": "1af63d5d-68d4-547b-9500-c0dca2831471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6d15f8-7ebc-43b7-b8fd-00555e74bcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6d15f8-7ebc-43b7-b8fd-00555e74bcb0.jpg?1",
             "name": "Doom Foretold",
             "text": "",
             "colours": [
@@ -15501,7 +15501,7 @@
         },
         {
             "id": "14dcb06d-47c0-5882-9b9e-cc8b8e1bf7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bff641e-aad3-414f-ad5b-8d32c734efa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bff641e-aad3-414f-ad5b-8d32c734efa9.jpg?1",
             "name": "Escape to the Wilds",
             "text": "",
             "colours": [
@@ -15537,7 +15537,7 @@
         },
         {
             "id": "bff36b07-c09e-5992-b069-44e14b2f4d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d54dca-d09b-49a6-a446-8144a7db6711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d54dca-d09b-49a6-a446-8144a7db6711.jpg?1",
             "name": "Faeburrow Elder",
             "text": "",
             "colours": [
@@ -15576,7 +15576,7 @@
         },
         {
             "id": "ffe2f826-0559-576d-b0c7-065d3e2621b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072648c6-a3ee-4db7-877e-67a5fab46272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072648c6-a3ee-4db7-877e-67a5fab46272.jpg?1",
             "name": "Lochmere Serpent",
             "text": "",
             "colours": [
@@ -15614,7 +15614,7 @@
         },
         {
             "id": "b349e917-4cf2-520c-bd54-9fec516e53c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505532ef-3791-4253-8a2a-b6f02ef45ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505532ef-3791-4253-8a2a-b6f02ef45ab4.jpg?1",
             "name": "Outlaws' Merriment",
             "text": "",
             "colours": [
@@ -15650,7 +15650,7 @@
         },
         {
             "id": "fe594161-6f4c-517b-aca1-854e4888b166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516df79f-f2c1-43f1-af1a-c9a32820929b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516df79f-f2c1-43f1-af1a-c9a32820929b.jpg?1",
             "name": "Stormfist Crusader",
             "text": "",
             "colours": [
@@ -15689,7 +15689,7 @@
         },
         {
             "id": "7005b9ee-239e-5530-a095-81920d47eaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c177f0e0-a1d3-4790-9e2c-bd5d2250603d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c177f0e0-a1d3-4790-9e2c-bd5d2250603d.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "",
             "colours": [],
@@ -15719,7 +15719,7 @@
         },
         {
             "id": "e4aad3dd-c8d5-53df-92a6-2388b60b09d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47357be-9e4b-4581-94f5-0574754e2977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47357be-9e4b-4581-94f5-0574754e2977.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "",
             "colours": [],
@@ -15752,7 +15752,7 @@
         },
         {
             "id": "2c332633-6986-5048-af41-90153bcb3a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1383eb-aa7d-4d3b-bee4-8cffba9ae846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1383eb-aa7d-4d3b-bee4-8cffba9ae846.jpg?1",
             "name": "Castle Ardenvale",
             "text": "",
             "colours": [],
@@ -15784,7 +15784,7 @@
         },
         {
             "id": "67617d6c-87e2-5487-a21b-24ed36284a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954b9bb-21e7-40af-aaa7-b2001b8d1d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9954b9bb-21e7-40af-aaa7-b2001b8d1d45.jpg?1",
             "name": "Castle Embereth",
             "text": "",
             "colours": [],
@@ -15816,7 +15816,7 @@
         },
         {
             "id": "3b5b208f-f02c-5a05-a331-d4b20dedde4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca10c34-010a-4a9f-a747-2592c4d58c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca10c34-010a-4a9f-a747-2592c4d58c5d.jpg?1",
             "name": "Castle Garenbrig",
             "text": "",
             "colours": [],
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "fd9d6361-8ae1-503f-810a-e32895eb3c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b8c2e6-5256-4e7e-8d7d-4b386419780a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b8c2e6-5256-4e7e-8d7d-4b386419780a.jpg?1",
             "name": "Castle Locthwain",
             "text": "",
             "colours": [],
@@ -15880,7 +15880,7 @@
         },
         {
             "id": "57d8f9bd-7d36-52ae-a41f-f3ee2dea7f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4113eeed-9399-4b59-a6d9-7d40190853c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4113eeed-9399-4b59-a6d9-7d40190853c5.jpg?1",
             "name": "Castle Vantress",
             "text": "",
             "colours": [],
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "4545d8b2-5ba4-58ab-8ccc-1ec9962f494c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57645743-27fa-4a75-9511-acfc32dd349a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57645743-27fa-4a75-9511-acfc32dd349a.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -15942,7 +15942,7 @@
         },
         {
             "id": "37fdc0d7-976d-5e5e-af6c-ee6b50795454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3dee73-b220-4da9-82ef-e3f551dccb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3dee73-b220-4da9-82ef-e3f551dccb17.jpg?1",
             "name": "Piper of the Swarm",
             "text": "Rats you control have menace.\n{1}{B}, {T}: Create a 1/1 black Rat creature token.\n{2}{B}{B}, {T}, Sacrifice three Rats: Gain control of target creature.",
             "colours": [
@@ -15980,7 +15980,7 @@
         },
         {
             "id": "a0690948-e034-5e03-8d91-d3f5f2175d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2728180c-c24d-4deb-a901-ae90232ad45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2728180c-c24d-4deb-a901-ae90232ad45d.jpg?1",
             "name": "Glass Casket",
             "text": "",
             "colours": [
@@ -16014,7 +16014,7 @@
         },
         {
             "id": "7508bb9a-011e-5046-b882-b8e3f4e93dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfe8919-6244-41ca-a637-07ee971042ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfe8919-6244-41ca-a637-07ee971042ed.jpg?1",
             "name": "Slaying Fire",
             "text": "",
             "colours": [
@@ -16048,7 +16048,7 @@
         },
         {
             "id": "16f3580d-a7ea-53ad-bc81-9e0031cf2a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e5f61-6074-458d-9e8c-aff99fda75d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896e5f61-6074-458d-9e8c-aff99fda75d7.jpg?1",
             "name": "Kenrith's Transformation",
             "text": "",
             "colours": [
@@ -16084,7 +16084,7 @@
         },
         {
             "id": "7c8a80eb-0a12-56d0-bdd4-9caaea98d373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eceaa1d6-0d31-4f2d-8ffb-5a4e31712ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eceaa1d6-0d31-4f2d-8ffb-5a4e31712ffa.jpg?1",
             "name": "Improbable Alliance",
             "text": "",
             "colours": [
@@ -16120,7 +16120,7 @@
         },
         {
             "id": "5ee49684-4bbd-5888-803e-fa1f36612cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb96078d-8632-4e7e-93ae-c4c86c530d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb96078d-8632-4e7e-93ae-c4c86c530d19.jpg?1",
             "name": "Inspiring Veteran",
             "text": "",
             "colours": [
@@ -16159,7 +16159,7 @@
         },
         {
             "id": "c60ebff2-0afe-5a7e-b011-cb3156ff8207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213be25c-88db-440b-83c3-973586a4f320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213be25c-88db-440b-83c3-973586a4f320.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -16194,7 +16194,7 @@
         },
         {
             "id": "e9a6488c-20ca-5519-bf6e-7555fcf45db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94057dc6-e589-4a29-9bda-90f5bece96c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94057dc6-e589-4a29-9bda-90f5bece96c4.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -16229,7 +16229,7 @@
         },
         {
             "id": "d45c64b0-431e-58a6-8767-2e396adefc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703e7ecf-3d73-40c1-8cfe-0758778817cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703e7ecf-3d73-40c1-8cfe-0758778817cf.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16264,7 +16264,7 @@
         },
         {
             "id": "2b448a9b-08c0-5fd8-8eb4-faba27eb6cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10da68-dd05-4e8e-ab94-37262e835fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10da68-dd05-4e8e-ab94-37262e835fb3.jpg?1",
             "name": "Mouse",
             "text": "",
             "colours": [
@@ -16299,7 +16299,7 @@
         },
         {
             "id": "c08d6e6b-8a6b-5e8e-9e23-f48e8345ccdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd82cb0-ff4b-4f4d-b3d0-3ac53883b099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd82cb0-ff4b-4f4d-b3d0-3ac53883b099.jpg?1",
             "name": "Faerie",
             "text": "",
             "colours": [
@@ -16334,7 +16334,7 @@
         },
         {
             "id": "feb7929b-e7d1-5dae-aa9c-e3a6277f4892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a205e-43ea-4b3e-92ab-c2ee2172a50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a205e-43ea-4b3e-92ab-c2ee2172a50a.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -16369,7 +16369,7 @@
         },
         {
             "id": "2d55a6d7-c092-5fcf-abc0-8a0109e407d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5d0dd-8095-4410-8feb-8c13edfcb2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5d0dd-8095-4410-8feb-8c13edfcb2e5.jpg?1",
             "name": "Dwarf",
             "text": "",
             "colours": [
@@ -16404,7 +16404,7 @@
         },
         {
             "id": "a8e53688-0c28-52ac-855a-897c851fc151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f09f9e-e0f9-4ed8-bfc0-5f1a3046106e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f09f9e-e0f9-4ed8-bfc0-5f1a3046106e.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -16439,7 +16439,7 @@
         },
         {
             "id": "322b56a4-c774-50f2-9561-cd5ae4114b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365b2234-c29d-42db-a8e0-80685a4b6434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365b2234-c29d-42db-a8e0-80685a4b6434.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -16474,7 +16474,7 @@
         },
         {
             "id": "02dd9f56-d7d1-53e3-9819-b3029e8adbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1debc4-0b12-4848-b551-90680ab8c0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1debc4-0b12-4848-b551-90680ab8c0ab.jpg?1",
             "name": "Giant",
             "text": "",
             "colours": [
@@ -16509,7 +16509,7 @@
         },
         {
             "id": "2d5f69c8-8c6a-5ff3-95b2-93f039fa4a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db951f76-b785-453e-91b9-b3b8a5c1cfd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db951f76-b785-453e-91b9-b3b8a5c1cfd4.jpg?1",
             "name": "Human Cleric",
             "text": "",
             "colours": [
@@ -16547,7 +16547,7 @@
         },
         {
             "id": "a80b2904-822c-540c-b5f8-f1c910d05ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ca6d5-4b2c-46d4-95f3-f0f2fa47f447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ca6d5-4b2c-46d4-95f3-f0f2fa47f447.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -16585,7 +16585,7 @@
         },
         {
             "id": "54dc8e6d-10b4-56f7-a712-30c9f030c149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c994ea90-71f4-403f-9418-2b72cc2de14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c994ea90-71f4-403f-9418-2b72cc2de14d.jpg?1",
             "name": "Human Warrior",
             "text": "",
             "colours": [
@@ -16623,7 +16623,7 @@
         },
         {
             "id": "b3a7b457-9102-5fd2-8264-99624a253fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88452ed7-1065-41c3-94a6-dc41108c45c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88452ed7-1065-41c3-94a6-dc41108c45c1.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -16660,7 +16660,7 @@
         },
         {
             "id": "8671529f-3caf-52a0-ad0c-212d999deab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf36408d-ed85-497f-8e68-d3a922c388a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf36408d-ed85-497f-8e68-d3a922c388a0.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16690,7 +16690,7 @@
         },
         {
             "id": "dcf079a4-9833-5527-b318-9318ef6491d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e8f518-1c0d-4c01-a397-71481839d02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e8f518-1c0d-4c01-a397-71481839d02b.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16721,7 +16721,7 @@
         },
         {
             "id": "5f8204d1-ab7a-5182-b905-725704116a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46582e55-c6f4-46e4-a78e-2c586ca4cf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46582e55-c6f4-46e4-a78e-2c586ca4cf4d.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16751,7 +16751,7 @@
         },
         {
             "id": "90b377a5-5f77-5f59-a5e0-3da610eef6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261aed78-2d57-4ed4-b3d2-53b139b6bd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261aed78-2d57-4ed4-b3d2-53b139b6bd44.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16781,7 +16781,7 @@
         },
         {
             "id": "3f8126fa-4cc3-57c1-abbf-9aeddc9aa36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c65749-1774-4b36-891e-abf762c95cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c65749-1774-4b36-891e-abf762c95cec.jpg?1",
             "name": "Garruk, Cursed Huntsman Emblem",
             "text": "",
             "colours": [],
@@ -16809,7 +16809,7 @@
         },
         {
             "id": "f1ced965-e127-5b18-a7ce-f929eabeccd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d50cf9-03e6-467a-aadf-84a24106ffa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d50cf9-03e6-467a-aadf-84a24106ffa9.jpg?1",
             "name": "On an Adventure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/EMA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/EMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "46224561-ab6a-50c7-92e8-6f360efd75b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647208dd-77f3-4509-b9d6-7801a52418d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647208dd-77f3-4509-b9d6-7801a52418d9.jpg?1",
             "name": "Aven Riftwatcher",
             "text": "Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher enters the battlefield or leaves the battlefield, you gain 2 life.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "080c378c-79d0-5cee-a4e9-38b112d39d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce648aa3-098b-4af0-a433-fd290bc85904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce648aa3-098b-4af0-a433-fd290bc85904.jpg?1",
             "name": "Balance",
             "text": "Each player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "06fa564a-5fb3-5909-b215-f7b34f863626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d191b8f7-40e0-47f3-8395-659f26a12851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d191b8f7-40e0-47f3-8395-659f26a12851.jpg?1",
             "name": "Ballynock Cohort",
             "text": "First strike\nBallynock Cohort gets +1/+1 as long as you control another white creature.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "7a7b1d4f-4d01-517b-8e19-da1f882e9b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e5c4e-0f0b-4a3f-91e0-87387a11e81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e5c4e-0f0b-4a3f-91e0-87387a11e81e.jpg?1",
             "name": "Benevolent Bodyguard",
             "text": "Sacrifice Benevolent Bodyguard: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "b89495e9-9d61-50e2-bd63-d5dd6b90edd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1585bb24-41de-48a7-820e-d99ee76aec01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1585bb24-41de-48a7-820e-d99ee76aec01.jpg?1",
             "name": "Calciderm",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nVanishing 4 (This creature enters the battlefield with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "48163b4a-3b16-5da2-be7e-59cf5cf63ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7c2b5c-634a-4d83-81bc-c6128e3ac339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7c2b5c-634a-4d83-81bc-c6128e3ac339.jpg?1",
             "name": "Coalition Honor Guard",
             "text": "While choosing targets as part of casting a spell or activating an ability, your opponents must choose at least one Flagbearer on the battlefield if able.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "4a5a9dff-b78d-5ffa-871c-68d46dbb02eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10a72dc-10ca-4925-b1ea-5377f7867b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10a72dc-10ca-4925-b1ea-5377f7867b57.jpg?1",
             "name": "Eight-and-a-Half-Tails",
             "text": "{1}{W}: Target permanent you control gains protection from white until end of turn.\n{1}: Target spell or permanent becomes white until end of turn.",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "092e2182-55ad-59b1-8f5e-1c7383c3b420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a5c350-2ed1-4a25-9626-0f8da5d1aef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a5c350-2ed1-4a25-9626-0f8da5d1aef7.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -283,7 +283,7 @@
         },
         {
             "id": "0d6c4763-8c1e-596c-aecd-810241702e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ebec9-3474-4062-9607-2e2a72f78299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ebec9-3474-4062-9607-2e2a72f78299.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "27daaaa6-a74a-58bc-a05c-a9e86085a07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ef45fc-d431-4a24-9566-e52b5c4a06ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ef45fc-d431-4a24-9566-e52b5c4a06ca.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "ceab9d5a-5f03-530a-b496-999c8dbdec79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018e48ee-cbd8-4ff8-92f6-c649e8e8df57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018e48ee-cbd8-4ff8-92f6-c649e8e8df57.jpg?1",
             "name": "Field of Souls",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "935ac801-07ff-5925-85ef-6a3759ace102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63205c2a-e9d4-4354-b519-9e84be8f9eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63205c2a-e9d4-4354-b519-9e84be8f9eb7.jpg?1",
             "name": "Glimmerpoint Stag",
             "text": "Vigilance\nWhen Glimmerpoint Stag enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "6e23c0e0-8007-5ca7-a004-248847b7ccf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c3a75d-7cae-4199-8e87-915ebb439b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c3a75d-7cae-4199-8e87-915ebb439b62.jpg?1",
             "name": "Honden of Cleansing Fire",
             "text": "At the beginning of your upkeep, you gain 2 life for each Shrine you control.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "45472646-e6e6-53fd-8819-caa21b17982d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b876e92-ec9f-4b96-9ec2-2d44f4231b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b876e92-ec9f-4b96-9ec2-2d44f4231b14.jpg?1",
             "name": "Humble",
             "text": "Until end of turn, target creature loses all abilities and has base power and toughness 0/1.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "a7c82361-a014-5a20-80f8-14f9a950bfeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010bd0f4-994c-4793-99b3-f64f6f87fe67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010bd0f4-994c-4793-99b3-f64f6f87fe67.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "964e781b-295c-55a6-9f09-178972f25d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4351b9a4-0173-4373-9a0e-efdbf2d3bcc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4351b9a4-0173-4373-9a0e-efdbf2d3bcc8.jpg?1",
             "name": "Jareth, Leonine Titan",
             "text": "Whenever Jareth, Leonine Titan blocks, it gets +7/+7 until end of turn.\n{W}: Jareth gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "03dabf5d-4a8c-5fd5-a160-ff3438a8da8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab6c67-1fbb-44b7-a255-15ceaf8352cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dab6c67-1fbb-44b7-a255-15ceaf8352cf.jpg?1",
             "name": "Karmic Guide",
             "text": "Flying, protection from black\nEcho {3}{W}{W} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Karmic Guide enters the battlefield, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "ece47c74-9534-5146-8f36-54ff8dfb9c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447a17-7570-4174-b78b-f20c4cc9de14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447a17-7570-4174-b78b-f20c4cc9de14.jpg?1",
             "name": "Kor Hookmaster",
             "text": "When Kor Hookmaster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "a4b805a5-b9f2-5b50-874d-75092228b312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7550ac-c8cd-4e10-8099-c5a42ab093fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7550ac-c8cd-4e10-8099-c5a42ab093fc.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -657,7 +657,7 @@
         },
         {
             "id": "c91234d9-6666-585f-b37c-9506273c9b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5453dd-1000-4841-bace-36e67c35ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5453dd-1000-4841-bace-36e67c35ced4.jpg?1",
             "name": "Mistral Charger",
             "text": "Flying",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "f4c61e0a-9c5d-54b0-9857-ab674f9f743d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c729e2-4e55-4a14-a288-9c3473e58b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c729e2-4e55-4a14-a288-9c3473e58b88.jpg?1",
             "name": "Monk Idealist",
             "text": "When Monk Idealist enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -727,7 +727,7 @@
         },
         {
             "id": "cf6caedd-a850-574f-9d8c-045bf66dcfd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf2354e-1232-452e-b89b-78ac8be206f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf2354e-1232-452e-b89b-78ac8be206f7.jpg?1",
             "name": "Mother of Runes",
             "text": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "e06004a3-be92-5472-b428-0f8c084bc8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e0cc-68bd-49c6-97d2-be9b353d1579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e0cc-68bd-49c6-97d2-be9b353d1579.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "71d9f163-0c4c-55f0-b653-95b4c7964dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b883b92-1bd5-42c3-b893-073db5a60de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b883b92-1bd5-42c3-b893-073db5a60de2.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -828,7 +828,7 @@
         },
         {
             "id": "3e7e4348-20fe-57a9-90ee-31fd037f4ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3eab5-89fb-440a-b56a-b35e2dca44f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3eab5-89fb-440a-b56a-b35e2dca44f0.jpg?1",
             "name": "Rally the Peasants",
             "text": "Creatures you control get +2/+0 until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "35a45688-5d26-5c41-8869-a3f4fa6a3653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e69e8-a527-44b8-a8d8-79e09b92c7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e69e8-a527-44b8-a8d8-79e09b92c7b2.jpg?1",
             "name": "Seal of Cleansing",
             "text": "Sacrifice Seal of Cleansing: Destroy target artifact or enchantment.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "8ce0db8d-604f-5ebc-9b12-ee641564d00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8b53ca-272f-44ba-a3aa-13ec0844ada9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8b53ca-272f-44ba-a3aa-13ec0844ada9.jpg?1",
             "name": "Second Thoughts",
             "text": "Exile target attacking creature.\nDraw a card.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "03737714-097e-5999-a89c-1679e74b0611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d2060-8c4b-4115-ab31-e572ee61a0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d2060-8c4b-4115-ab31-e572ee61a0cc.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "6dc1b78a-970d-53d7-af28-cf81c724eaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431360c2-3c7c-4c96-b09b-9caafe211d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431360c2-3c7c-4c96-b09b-9caafe211d83.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "48cfb318-8e9d-55b2-b773-d50952f9f80a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3333fa0e-32d5-4c3f-a89a-637ab982d61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3333fa0e-32d5-4c3f-a89a-637ab982d61a.jpg?1",
             "name": "Soulcatcher",
             "text": "Flying\nWhenever a creature with flying dies, put a +1/+1 counter on Soulcatcher.",
             "colours": [
@@ -1026,7 +1026,7 @@
         },
         {
             "id": "301b0d04-b733-5379-ba28-fad3ca6ab555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affaf05a-020c-44c1-84fa-7976c3d2a5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affaf05a-020c-44c1-84fa-7976c3d2a5cc.jpg?1",
             "name": "Squadron Hawk",
             "text": "Flying\nWhen Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "7af4b517-5b1b-5d0b-a63b-cd2673ea4f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bafa7b-62a4-477c-b2f5-6b9d26c6cbf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bafa7b-62a4-477c-b2f5-6b9d26c6cbf4.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "8a63aab8-08de-5dfa-bb08-8fe77ea4ba18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6071cf-76bb-48f0-acbe-27b92558495a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6071cf-76bb-48f0-acbe-27b92558495a.jpg?1",
             "name": "Unexpectedly Absent",
             "text": "Put target nonland permanent into its owner's library just beneath the top X cards of that library.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "e0b84e03-9ced-5f2b-b5cc-f563226b7c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c2aad9-1dc4-4e33-a630-9b828de1ed20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c2aad9-1dc4-4e33-a630-9b828de1ed20.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "5d19d5c9-1631-5804-9769-221a60d3bb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b222a639-dd46-40f9-835d-3c68b74c295e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b222a639-dd46-40f9-835d-3c68b74c295e.jpg?1",
             "name": "War Priest of Thune",
             "text": "When War Priest of Thune enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "1a1c1fb1-82d8-5830-a115-164fe5d82b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5c82bd-9946-4121-94f6-70442dab9f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5c82bd-9946-4121-94f6-70442dab9f54.jpg?1",
             "name": "Welkin Guide",
             "text": "Flying\nWhen Welkin Guide enters the battlefield, target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "97f64add-f38e-5ecc-ae52-9033980ae9e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcef00b9-8f18-44fa-a690-569e33d6ce81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcef00b9-8f18-44fa-a690-569e33d6ce81.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "6438cd2b-e7b8-52fa-a083-39108592044d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b12cc-f616-4b52-91eb-a430e70f9251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9b12cc-f616-4b52-91eb-a430e70f9251.jpg?1",
             "name": "Wrath of God",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1294,7 +1294,7 @@
         },
         {
             "id": "23ca7245-0b51-521e-a0fe-f758bd1f9ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bf47e-ad40-4b3d-9e64-37b311df52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bf47e-ad40-4b3d-9e64-37b311df52e9.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "8c45184f-2b35-5e4b-abcc-4423bff915f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e6787-af32-44f2-ac56-6f348254aa6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4e6787-af32-44f2-ac56-6f348254aa6d.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "cb555a42-8aea-5fb4-bca3-923b63e016b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4186eb4-5c79-4616-9a20-c48a6c3f5a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4186eb4-5c79-4616-9a20-c48a6c3f5a82.jpg?1",
             "name": "Cephalid Sage",
             "text": "Threshold \u2014 As long as seven or more cards are in your graveyard, Cephalid Sage has \"When Cephalid Sage enters the battlefield, draw three cards, then discard two cards.\"",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "bdc8726d-8868-5c78-ada7-864f511757cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e90849-ca7a-4f66-871e-1cb4b59aefcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e90849-ca7a-4f66-871e-1cb4b59aefcf.jpg?1",
             "name": "Control Magic",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "43164596-7a42-5909-b9dc-e6de2ea5cec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9a7cb0-5bff-48ff-b620-2838816ac9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9a7cb0-5bff-48ff-b620-2838816ac9b5.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "43db7c72-9317-5dbe-b74c-ed678fc76558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05e9a3e-8a35-4687-85cb-e31b3927a5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05e9a3e-8a35-4687-85cb-e31b3927a5e2.jpg?1",
             "name": "Daze",
             "text": "You may return an Island you control to its owner's hand rather than pay Daze's mana cost.\nCounter target spell unless its controller pays {1}.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "c103c9c4-112d-5c5a-b6ec-b79c7556d407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cc8b6-eb2e-4441-8d88-c54cb44ab024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cc8b6-eb2e-4441-8d88-c54cb44ab024.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "825659f8-9a37-507a-82cf-2355cbcb9aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ed455f-95cd-48ca-8b0d-4db259347bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ed455f-95cd-48ca-8b0d-4db259347bb6.jpg?1",
             "name": "Diminishing Returns",
             "text": "Each player shuffles his or her hand and graveyard into his or her library. You exile the top ten cards of your library. Then each player draws up to seven cards.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "5ee13223-ebdb-5e3d-842c-ba773ba43f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fa20df-b8d5-4de7-a2fa-6ced4bfcf979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fa20df-b8d5-4de7-a2fa-6ced4bfcf979.jpg?1",
             "name": "Dream Twist",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "b6797bb4-dbcb-5dec-a5db-2906e891407b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e7c13-d73d-421a-b2cc-4ff7fde05af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e7c13-d73d-421a-b2cc-4ff7fde05af7.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "043c7d0d-fae3-5188-9a1d-51dfa3c5bd96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc01ab4-d89a-4d25-bf54-6aed33772f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc01ab4-d89a-4d25-bf54-6aed33772f4b.jpg?1",
             "name": "Force of Will",
             "text": "You may pay 1 life and exile a blue card from your hand rather than pay Force of Will's mana cost.\nCounter target spell.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "d8e4629f-2697-5cb9-ae3f-8d194a0e5d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf3b52f-edcd-429d-9a65-703bbd97cb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf3b52f-edcd-429d-9a65-703bbd97cb5e.jpg?1",
             "name": "Future Sight",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "a72eeae9-5d70-5e26-bed5-01685152e19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5464250-a6a9-4399-a67f-2488073794e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5464250-a6a9-4399-a67f-2488073794e9.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchant creature\nPrevent all combat damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "1b3db940-2450-549a-8e65-4b4703ba843c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5124c4bd-d9a4-4f17-80fc-c64d4a77a614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5124c4bd-d9a4-4f17-80fc-c64d4a77a614.jpg?1",
             "name": "Giant Tortoise",
             "text": "Giant Tortoise gets +0/+3 as long as it's untapped.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "1c47ee57-d277-5ba2-8a6a-0e6712da1e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059330e-1aef-4d22-b3c2-cd84cab5fe38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059330e-1aef-4d22-b3c2-cd84cab5fe38.jpg?1",
             "name": "Glacial Wall",
             "text": "Defender",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "1b1db4f3-2567-5db7-9782-effcd9fbc883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ffdaad-7b35-4256-9da1-0befc6bd86f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ffdaad-7b35-4256-9da1-0befc6bd86f4.jpg?1",
             "name": "Honden of Seeing Winds",
             "text": "At the beginning of your upkeep, draw a card for each Shrine you control.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "9a1dcc1c-a728-5cf4-a41c-bd13182646cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c9b16-5567-4473-95e6-622292f77336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c9b16-5567-4473-95e6-622292f77336.jpg?1",
             "name": "Hydroblast",
             "text": "Choose one \u2014\n\u2022 Counter target spell if it's red.\n\u2022 Destroy target permanent if it's red.",
             "colours": [
@@ -1856,7 +1856,7 @@
         },
         {
             "id": "e0158dcb-991b-55a2-930b-ff5ba1949a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1869098e-536f-4381-85d4-7691679a7cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1869098e-536f-4381-85d4-7691679a7cc9.jpg?1",
             "name": "Inkwell Leviathan",
             "text": "Islandwalk, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "49d8b49f-5c5f-5f1e-94a2-524c50569fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1a1910-9587-481c-9e5c-5eb0c3b098c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1a1910-9587-481c-9e5c-5eb0c3b098c6.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles his or her hand into his or her library.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "f6b60f02-2b4a-53ac-bfb6-876364046f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f01503-03d3-4d74-b9d0-b973f7d66094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f01503-03d3-4d74-b9d0-b973f7d66094.jpg?1",
             "name": "Jetting Glasskite",
             "text": "Flying\nWhenever Jetting Glasskite becomes the target of a spell or ability for the first time each turn, counter that spell or ability.",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "c076ca36-d2fb-5649-83c5-7eec7d2d9860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b484714-e1bc-4acb-a925-ac5e80dc8f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b484714-e1bc-4acb-a925-ac5e80dc8f04.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "c73a899c-4f3b-5699-b133-d93d5a90255e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30202613-d05f-4f47-af97-d0b75ccac293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30202613-d05f-4f47-af97-d0b75ccac293.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "fd392f01-53e5-59d9-a051-c3248fcdd2e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5db14e-6b48-4729-bdf7-2965cf3dbb9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5db14e-6b48-4729-bdf7-2965cf3dbb9d.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "99401923-bd82-517e-8b04-9f78b050493c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9264ecb7-bfc0-495d-aaaa-829045ea858f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9264ecb7-bfc0-495d-aaaa-829045ea858f.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "98849bc9-1ba9-545a-a0cb-e53dfe764bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441aa75a-e0f1-43d1-836a-9788e9fd1be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441aa75a-e0f1-43d1-836a-9788e9fd1be5.jpg?1",
             "name": "Oona's Grace",
             "text": "Target player draws a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "86dc310e-f959-5472-a1cf-84e5119c3c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e3b84-31ea-4ff2-8028-1e983fad22d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0e3b84-31ea-4ff2-8028-1e983fad22d4.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake enters the battlefield, untap up to five lands.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "408c2adc-e708-5cf1-b680-e7e886504f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e65e19-bc2b-4450-98ea-02a13effeb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e65e19-bc2b-4450-98ea-02a13effeb57.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "53b7c6c9-7d76-5ec6-b287-85671c6d1216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbf99b0-8287-4e30-bd47-989bd0a4d483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbf99b0-8287-4e30-bd47-989bd0a4d483.jpg?1",
             "name": "Phyrexian Ingester",
             "text": "Imprint \u2014 When Phyrexian Ingester enters the battlefield, you may exile target nontoken creature.\nPhyrexian Ingester gets +X/+Y, where X is the exiled creature card's power and Y is its toughness.",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "cb24fe92-d821-516b-91bc-5a363c0763d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef269-55f9-4d84-8bc5-29e794297f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aef269-55f9-4d84-8bc5-29e794297f11.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "{T}: Prodigal Sorcerer deals 1 damage to target creature or player.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "d0a621b3-5eb9-5680-9243-6b46734d8583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12fd06-26c5-42d8-936c-fe10b778a561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd12fd06-26c5-42d8-936c-fe10b778a561.jpg?1",
             "name": "Quiet Speculation",
             "text": "Search target player's library for up to three cards with flashback and put them into that player's graveyard. Then the player shuffles his or her library.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "fa4da507-0eca-5606-bbd4-3777d4386c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc87bc-2ae9-423d-8f95-6dbd18b57745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efc87bc-2ae9-423d-8f95-6dbd18b57745.jpg?1",
             "name": "Screeching Skaab",
             "text": "When Screeching Skaab enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "3a3b3860-c638-57f1-a08a-b3932800dfeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb9b623-db1c-47c4-a886-56266c27fab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb9b623-db1c-47c4-a886-56266c27fab5.jpg?1",
             "name": "Serendib Efreet",
             "text": "Flying\nAt the beginning of your upkeep, Serendib Efreet deals 1 damage to you.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "33a38068-b339-5f5f-9a28-8f0431654a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f5d61-cd96-4c02-8cc4-405d2efb37fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f5d61-cd96-4c02-8cc4-405d2efb37fd.jpg?1",
             "name": "Shoreline Ranger",
             "text": "Flying\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "97029835-54ec-5f35-a6de-4d651479268b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9882d7be-1d58-432b-ad36-4cd13609ad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9882d7be-1d58-432b-ad36-4cd13609ad90.jpg?1",
             "name": "Silent Departure",
             "text": "Return target creature to its owner's hand.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "8ab43445-f02b-523d-9d8d-b3f832053364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f1b2c9-7b37-451a-a8cc-252a47b2cded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f1b2c9-7b37-451a-a8cc-252a47b2cded.jpg?1",
             "name": "Sprite Noble",
             "text": "Flying\nOther creatures you control with flying get +0/+1.\n{T}: Other creatures you control with flying get +1/+0 until end of turn.",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "7a0598e3-f436-5d74-8b3c-0d6f77b7f6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6355ae63-3072-4c6f-bf46-ee6e9c4fedba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6355ae63-3072-4c6f-bf46-ee6e9c4fedba.jpg?1",
             "name": "Stupefying Touch",
             "text": "Enchant creature\nWhen Stupefying Touch enters the battlefield, draw a card.\nEnchanted creature's activated abilities can't be activated.",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "6cf24a2a-8c0f-537c-aac9-6fb1e86ca843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9dbed75-6153-4413-9fa4-d96a3c10c050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9dbed75-6153-4413-9fa4-d96a3c10c050.jpg?1",
             "name": "Tidal Wave",
             "text": "Put a 5/5 blue Wall creature token with defender onto the battlefield. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2533,7 +2533,7 @@
         },
         {
             "id": "b16b7f72-c8c8-5b66-88bc-a3a9d643751d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a65d542-7be3-4e11-8626-13392baadd57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a65d542-7be3-4e11-8626-13392baadd57.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "4c5d1c1c-74b3-5fb7-abe3-9dda1ede93fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597d16e3-aba1-4c23-a0a6-c8cb6f823888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597d16e3-aba1-4c23-a0a6-c8cb6f823888.jpg?1",
             "name": "Wonder",
             "text": "Flying\nAs long as Wonder is in your graveyard and you control an Island, creatures you control have flying.",
             "colours": [
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "1f146fb5-bc4e-58e4-9002-8a2cb1ebf2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83536a-efa4-41f3-9424-75b0efc0aea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b83536a-efa4-41f3-9424-75b0efc0aea5.jpg?1",
             "name": "Animate Dead",
             "text": "Enchant creature card in a graveyard\nWhen Animate Dead enters the battlefield, if it's on the battlefield, it loses \"enchant creature card in a graveyard\" and gains \"enchant creature put onto the battlefield with Animate Dead.\" Return enchanted creature card to the battlefield under your control and attach Animate Dead to it. When Animate Dead leaves the battlefield, that creature's controller sacrifices it.\nEnchanted creature gets -1/-0.",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "9432b784-59c8-5670-82ed-916ac2876383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b99f7-d388-4e1b-9fbc-8a945701b6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b99f7-d388-4e1b-9fbc-8a945701b6b1.jpg?1",
             "name": "Annihilate",
             "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "8e30c9b9-d3dc-5128-8965-f3ea8c36a431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fd17d4-96e1-4b53-8375-57f800dc661a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fd17d4-96e1-4b53-8375-57f800dc661a.jpg?1",
             "name": "Blightsoil Druid",
             "text": "{T}, Pay 1 life: Add {G} to your mana pool.",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "4e1f54cb-f68e-5919-869b-3fb768c54d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6d92a-45d3-4d67-8ae9-f25dd4a86739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6d92a-45d3-4d67-8ae9-f25dd4a86739.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "2e7bbd6e-6a1e-5f7e-9d54-f6574dc23a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532bca1-a115-4fe7-847e-296677bdd3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f532bca1-a115-4fe7-847e-296677bdd3ee.jpg?1",
             "name": "Braids, Cabal Minion",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact, creature, or land.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "e643d6aa-d79a-5337-9add-4c1d6d743e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b12f0-986f-43d0-a81b-64111e7f17e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b12f0-986f-43d0-a81b-64111e7f17e6.jpg?1",
             "name": "Cabal Therapy",
             "text": "Name a nonland card. Target player reveals his or her hand and discards all cards with that name.\nFlashback\u2014\nSacrifice a creature. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "5e009d4e-8bf3-58f1-a021-2773d144c1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e33835-a293-4a1f-85d5-8ac22360ef35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e33835-a293-4a1f-85d5-8ac22360ef35.jpg?1",
             "name": "Carrion Feeder",
             "text": "Carrion Feeder can't block.\nSacrifice a creature: Put a +1/+1 counter on Carrion Feeder.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "65b046e8-9c6f-5d3d-a68e-cc8b64e16bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110fa8e-3fbf-4a81-a743-e709f58e4414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110fa8e-3fbf-4a81-a743-e709f58e4414.jpg?1",
             "name": "Deadbridge Shaman",
             "text": "When Deadbridge Shaman dies, target opponent discards a card.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "d57129f4-a6ae-57a7-a9b0-78287691a71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3727cf-e4f8-4900-aeee-23ff36109c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3727cf-e4f8-4900-aeee-23ff36109c67.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "b3ae6888-0582-57fc-af2f-29258c10df7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba0068-c63f-4699-b630-a56b26ad8239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba0068-c63f-4699-b630-a56b26ad8239.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card and put that card into your graveyard. Then shuffle your library.",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "b0a773c1-bbd7-508c-97e3-1fe765c2f3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423fc5f-5a3b-46e3-8193-2542a0b35386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423fc5f-5a3b-46e3-8193-2542a0b35386.jpg?1",
             "name": "Eyeblight's Ending",
             "text": "Destroy target non-Elf creature.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "077695b2-43c4-5d7d-9b7e-df2563e9e338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8413748e-33f4-4bba-8fb6-864bd048bcb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8413748e-33f4-4bba-8fb6-864bd048bcb2.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "c31f7540-5aab-5f1b-b721-a19fcc0397bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad8ecef-bc09-4d30-bff1-4d21c239b2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad8ecef-bc09-4d30-bff1-4d21c239b2fb.jpg?1",
             "name": "Havoc Demon",
             "text": "Flying\nWhen Havoc Demon dies, all creatures get -5/-5 until end of turn.",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "aead6e23-b4c3-5b0a-80af-75f3ea2d6f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135b6adb-5c9c-4852-8c2a-c6f6d9bf96b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135b6adb-5c9c-4852-8c2a-c6f6d9bf96b1.jpg?1",
             "name": "Honden of Night's Reach",
             "text": "At the beginning of your upkeep, target opponent discards a card for each Shrine you control.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "06a73dbe-d929-579f-93c7-061de79c24fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faa8c5e-9e1b-4cee-b322-a033bf33dcbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faa8c5e-9e1b-4cee-b322-a033bf33dcbc.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "69f4bc7f-edcb-59e0-a66d-f4f45bcdcb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5bc1e4-eefb-4613-aa18-2bf2b9bdf415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5bc1e4-eefb-4613-aa18-2bf2b9bdf415.jpg?1",
             "name": "Ichorid",
             "text": "Haste\nAt the beginning of the end step, sacrifice Ichorid.\nAt the beginning of your upkeep, if Ichorid is in your graveyard, you may exile a black creature card other than Ichorid from your graveyard. If you do, return Ichorid to the battlefield.",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "4ef85ab0-4201-5ce6-916e-592b93bb08d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1621e396-b7ea-4507-95a3-7206a8fe7903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1621e396-b7ea-4507-95a3-7206a8fe7903.jpg?1",
             "name": "Innocent Blood",
             "text": "Each player sacrifices a creature.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "c99f6905-1c65-5ce8-a38a-7a1f95edbe93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d625a7-5753-4b11-ae68-0894af337d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d625a7-5753-4b11-ae68-0894af337d4b.jpg?1",
             "name": "Lys Alana Scarblade",
             "text": "{T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control.",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "0b58f372-eb9b-55a2-975a-6102f87286e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127f3f4d-93f4-4e52-b3c1-325c3981e0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127f3f4d-93f4-4e52-b3c1-325c3981e0e1.jpg?1",
             "name": "Malicious Affliction",
             "text": "Morbid \u2014 When you cast Malicious Affliction, if a creature died this turn, you may copy Malicious Affliction and may choose a new target for the copy.\nDestroy target nonblack creature.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "b26403df-ad96-59aa-91a8-e19cac505e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569173f-df5e-4518-9fb3-f972210595df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569173f-df5e-4518-9fb3-f972210595df.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "c763014c-45a6-5960-b004-0759043fbf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ffb8ad-d8b4-4764-bbb0-ca4106080a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ffb8ad-d8b4-4764-bbb0-ca4106080a90.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "22b82a1e-af05-5e9d-b5fa-95603074871e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a4f2a-57ea-4fa0-a76f-3e215a36d1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3a4f2a-57ea-4fa0-a76f-3e215a36d1f4.jpg?1",
             "name": "Nekrataal",
             "text": "First strike\nWhen Nekrataal enters the battlefield, destroy target nonartifact, nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "496af8d0-32b9-5690-8f4f-a8a6042c1603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4638720-a55d-4c3b-b57d-2d028db5894d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4638720-a55d-4c3b-b57d-2d028db5894d.jpg?1",
             "name": "Night's Whisper",
             "text": "You draw two cards and you lose 2 life.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "b0ceb949-1e89-527d-ab8e-2d26b7256a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f222e50-6fd3-4873-88f4-1c30d08dddfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f222e50-6fd3-4873-88f4-1c30d08dddfc.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "0bd4a1b3-e689-5236-a84f-4d5f947ef002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1cd5e02-9450-4097-b0a5-a62a8e2e552d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1cd5e02-9450-4097-b0a5-a62a8e2e552d.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "ebef09b3-311a-5af1-b9f5-3106e471114c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1e3438-dbee-473a-8556-d4e28b939266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1e3438-dbee-473a-8556-d4e28b939266.jpg?1",
             "name": "Plague Witch",
             "text": "{B}, {T}, Discard a card: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "825bb6ca-ed4b-57ab-9508-7dcaa0f387b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bf8191-3154-48d7-a49b-4d07b5e35a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bf8191-3154-48d7-a49b-4d07b5e35a15.jpg?1",
             "name": "Prowling Pangolin",
             "text": "When Prowling Pangolin enters the battlefield, any player may sacrifice two creatures. If a player does, sacrifice Prowling Pangolin.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "434dd6df-d11f-538a-ac34-93dc8bf50685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa8a17-ff86-465e-9092-0968081f4e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa8a17-ff86-465e-9092-0968081f4e28.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat enters the battlefield, put three 0/1 black Serf creature tokens onto the battlefield.\nWhen Sengir Autocrat leaves the battlefield, exile all Serf tokens.",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "6693dca0-30ab-5a9f-bd51-1e4fb980c007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a084d0fb-8db2-4873-a2f9-e6e5fecdd38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a084d0fb-8db2-4873-a2f9-e6e5fecdd38c.jpg?1",
             "name": "Sinkhole",
             "text": "Destroy target land.",
             "colours": [
@@ -3581,7 +3581,7 @@
         },
         {
             "id": "fc8722ab-0081-5e0c-ae39-c1832613a957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285f37a0-88ad-4cd6-8a8f-60c2d9805437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285f37a0-88ad-4cd6-8a8f-60c2d9805437.jpg?1",
             "name": "Skulking Ghost",
             "text": "Flying\nWhen Skulking Ghost becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "09feb324-5275-577b-8d63-31f3f670e319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796c01-0821-4a20-a256-d98b774faedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796c01-0821-4a20-a256-d98b774faedc.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast Toxic Deluge, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -3647,7 +3647,7 @@
         },
         {
             "id": "5196b3d3-1d46-5c67-bf24-c5dce3352ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3140bf5-9846-47ae-8142-b013aac14609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3140bf5-9846-47ae-8142-b013aac14609.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "ccd2d891-9be8-543d-b4c4-24ec356f5281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1335db4-dda0-4947-9ab6-1f140a1a8aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1335db4-dda0-4947-9ab6-1f140a1a8aa8.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "23fe1f1d-ff54-501d-9fdc-ce1e3499fbe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4f0fdb-fb1a-41e0-b7af-a2dc25cf116e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4f0fdb-fb1a-41e0-b7af-a2dc25cf116e.jpg?1",
             "name": "Urborg Uprising",
             "text": "Return up to two target creature cards from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -3746,7 +3746,7 @@
         },
         {
             "id": "145eaa60-d7aa-5a48-8dc3-833502dc1f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e778ce-3f1e-4626-8f55-bba03970d91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e778ce-3f1e-4626-8f55-bba03970d91a.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "6d30b3b3-8b83-5aa7-aec8-ecc6079519a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6660d6-b9e4-4020-a936-96d5eac26a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6660d6-b9e4-4020-a936-96d5eac26a58.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "f394205e-3005-568b-b6b9-34e183173369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f66946-ff52-4ce4-af25-b81196fa451b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f66946-ff52-4ce4-af25-b81196fa451b.jpg?1",
             "name": "Visara the Dreadful",
             "text": "Flying\n{T}: Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -3846,7 +3846,7 @@
         },
         {
             "id": "abbffe54-1c40-5b27-8537-e1c5dc8e5b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23716e-453e-4686-a8dd-ca1d67ad577d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23716e-453e-4686-a8dd-ca1d67ad577d.jpg?1",
             "name": "Wake of Vultures",
             "text": "Flying\n{1}{B}, Sacrifice a creature: Regenerate Wake of Vultures.",
             "colours": [
@@ -3880,7 +3880,7 @@
         },
         {
             "id": "74520ce1-ebfd-5eca-97f9-7269081b3b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a5833-042b-4b13-8151-f9e4bcf8e810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a5833-042b-4b13-8151-f9e4bcf8e810.jpg?1",
             "name": "Wakedancer",
             "text": "Morbid \u2014 When Wakedancer enters the battlefield, if a creature died this turn, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3915,7 +3915,7 @@
         },
         {
             "id": "b316bd3f-656f-5537-a152-51477730a7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421ee1c4-a105-41bf-83e9-edf3c49d057c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421ee1c4-a105-41bf-83e9-edf3c49d057c.jpg?1",
             "name": "Avarax",
             "text": "Haste\nWhen Avarax enters the battlefield, you may search your library for a card named Avarax, reveal it, and put it into your hand. If you do, shuffle your library.\n{1}{R}: Avarax gets +1/+0 until end of turn.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "cc16a205-ddbb-5d69-b2ed-deb7dd485a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d9dab-b8ab-420a-b1cf-edb6592e18c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d9dab-b8ab-420a-b1cf-edb6592e18c1.jpg?1",
             "name": "Battle Squadron",
             "text": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "5a0b9fd9-d8e2-57fb-9917-f3b4222c1bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779d4745-ff14-4c79-b2c8-8e273faf7375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779d4745-ff14-4c79-b2c8-8e273faf7375.jpg?1",
             "name": "Beetleback Chief",
             "text": "When Beetleback Chief enters the battlefield, put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4018,7 +4018,7 @@
         },
         {
             "id": "68c7a6d8-c9f1-505d-a38a-4d9c71f5511e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff958ec-ceae-424b-8f9c-3d8f581f1119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff958ec-ceae-424b-8f9c-3d8f581f1119.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "93127e39-c89c-58fe-8d6a-4daee7a1fb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b82ed97-b55d-45ed-a963-85c0741992be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b82ed97-b55d-45ed-a963-85c0741992be.jpg?1",
             "name": "Burning Vengeance",
             "text": "Whenever you cast a spell from your graveyard, Burning Vengeance deals 2 damage to target creature or player.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "ac34eabb-038a-5351-a675-2b4fead775ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b4767b-edd1-4e36-b363-52114a9afe5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b4767b-edd1-4e36-b363-52114a9afe5e.jpg?1",
             "name": "Carbonize",
             "text": "Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would die this turn, exile it instead.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "ca79025a-516f-5ffd-9c4b-2211e3e96915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89af0f45-c11c-4f13-9950-b1489440ee5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89af0f45-c11c-4f13-9950-b1489440ee5b.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -4149,7 +4149,7 @@
         },
         {
             "id": "ee687403-16a8-557a-9fab-ab81276732be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c02ae-e390-4da6-9904-ec138abbe047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c02ae-e390-4da6-9904-ec138abbe047.jpg?1",
             "name": "Crater Hellion",
             "text": "Echo {4}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Crater Hellion enters the battlefield, it deals 4 damage to each other creature.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "ddab1caa-3d35-504f-b972-ef22c862a031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88a833-273b-4fe6-b9aa-f014170f06fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a88a833-273b-4fe6-b9aa-f014170f06fd.jpg?1",
             "name": "Desperate Ravings",
             "text": "Draw two cards, then discard a card at random.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "1bcbd490-e374-5769-ab31-d675339c9244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdad3f3-7009-4b8b-9105-263b454217c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdad3f3-7009-4b8b-9105-263b454217c8.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, put a 2/2 red Dragon creature token with flying onto the battlefield. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "5c0bf156-3521-5391-b07c-28d5cfb731c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50607c1-c283-44b7-b69b-79d1ad332b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50607c1-c283-44b7-b69b-79d1ad332b5a.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "983d0caa-dd1c-5f8d-a375-077187da315c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734278b4-74ae-4df5-97d7-745e56189e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734278b4-74ae-4df5-97d7-745e56189e1b.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "e82de421-69f6-58af-945c-128e7dfafc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c00c27c-7826-4d6e-9d56-2844c59c8066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c00c27c-7826-4d6e-9d56-2844c59c8066.jpg?1",
             "name": "Fervent Cathar",
             "text": "Haste\nWhen Fervent Cathar enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4354,7 +4354,7 @@
         },
         {
             "id": "65af0baa-f0ac-5bf7-9f1c-8fa65cc3133e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90aae741-88af-4d21-a230-9a2592acdc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90aae741-88af-4d21-a230-9a2592acdc87.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to target creature or player.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4386,7 +4386,7 @@
         },
         {
             "id": "3ad556bc-c008-53bf-8f0b-4bdcbadef73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e227f18f-7260-4066-bae2-01db4fd1abdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e227f18f-7260-4066-bae2-01db4fd1abdd.jpg?1",
             "name": "Flame Jab",
             "text": "Flame Jab deals 1 damage to target creature or player.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "3cb3eeae-f2f6-53af-97e4-b99779490b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7602b70b-686f-432b-ac59-1141dd3d0dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7602b70b-686f-432b-ac59-1141dd3d0dea.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle your library.",
             "colours": [
@@ -4450,7 +4450,7 @@
         },
         {
             "id": "6740318b-46bb-5170-b314-d40da9152d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923de31f-0941-4df1-8939-3eed75b7eb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923de31f-0941-4df1-8939-3eed75b7eb39.jpg?1",
             "name": "Ghitu Slinger",
             "text": "Echo {2}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Ghitu Slinger enters the battlefield, it deals 2 damage to target creature or player.",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "19ec5d47-a2bf-564d-a86e-da0d65232a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174bcea4-4e9c-4de5-b001-6a9df2242e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174bcea4-4e9c-4de5-b001-6a9df2242e37.jpg?1",
             "name": "Honden of Infinite Rage",
             "text": "At the beginning of your upkeep, Honden of Infinite Rage deals damage to target creature or player equal to the number of Shrines you control.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "c67f1675-c67b-5f86-a3bd-f2880758643b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca0987e-7dff-410a-8328-45ba1c53e974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca0987e-7dff-410a-8328-45ba1c53e974.jpg?1",
             "name": "Keldon Champion",
             "text": "Haste\nEcho {2}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Keldon Champion enters the battlefield, it deals 3 damage to target player.",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "6eeddd60-d823-5134-b8ea-851f5b653daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42524c-97e5-40b2-8a6d-d2a1f0a9eb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf42524c-97e5-40b2-8a6d-d2a1f0a9eb65.jpg?1",
             "name": "Keldon Marauders",
             "text": "Vanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Keldon Marauders enters the battlefield or leaves the battlefield, it deals 1 damage to target player.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "ccec4ef4-3afb-57c6-aea6-7a39bbabb47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14a5c79-29a3-4415-9b70-b287a474a0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14a5c79-29a3-4415-9b70-b287a474a0e0.jpg?1",
             "name": "Kird Ape",
             "text": "Kird Ape gets +1/+2 as long as you control a Forest.",
             "colours": [
@@ -4625,7 +4625,7 @@
         },
         {
             "id": "b82feb72-8386-54ea-8212-2ad2daceb660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d479ca28-bdc2-4b87-abf7-5aeb229a3f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d479ca28-bdc2-4b87-abf7-5aeb229a3f1e.jpg?1",
             "name": "Mogg Fanatic",
             "text": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "964462f1-473b-5b3a-969f-2f8c39d312b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deed0a5a-6662-460c-bd78-e3d95e8bc83e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deed0a5a-6662-460c-bd78-e3d95e8bc83e.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, put a 1/1 red Goblin creature token onto the battlefield.",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "aa3509ab-f25e-5181-95f4-df2c94eea3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b568475-97db-47be-842c-03305b459fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b568475-97db-47be-842c-03305b459fb7.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "ea80cee9-e139-5170-b262-178b356f95ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1342144-7a15-438b-a848-3196238a79e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1342144-7a15-438b-a848-3196238a79e8.jpg?1",
             "name": "Price of Progress",
             "text": "Price of Progress deals damage to each player equal to twice the number of nonbasic lands that player controls.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "de4ba425-848d-537b-88a9-6b9f3a73a4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b029eb9a-dd7a-40c2-96c4-0063d9cc002c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b029eb9a-dd7a-40c2-96c4-0063d9cc002c.jpg?1",
             "name": "Pyroblast",
             "text": "Choose one \u2014\n\u2022 Counter target spell if it's blue.\n\u2022 Destroy target permanent if it's blue.",
             "colours": [
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "69783c37-2f0f-52d3-b317-2efe90dae7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f98f02-9ada-4561-93fd-9cfcb0f48b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f98f02-9ada-4561-93fd-9cfcb0f48b5d.jpg?1",
             "name": "Pyrokinesis",
             "text": "You may exile a red card from your hand rather than pay Pyrokinesis's mana cost.\nPyrokinesis deals 4 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "e60400c0-30e3-52f6-a424-69cd73085348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b357221-cae0-48ef-aedc-2dbdb694e373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b357221-cae0-48ef-aedc-2dbdb694e373.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "6c110743-92e1-5569-9597-e9ae8df0dac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2e7e50-e0b7-474b-a07d-35071011a70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2e7e50-e0b7-474b-a07d-35071011a70c.jpg?1",
             "name": "Rorix Bladewing",
             "text": "Flying, haste",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "c7eab655-e549-5627-9cbb-22015ce2c856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7bb50b1-e65c-4d56-8705-f20f6fa1ca12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7bb50b1-e65c-4d56-8705-f20f6fa1ca12.jpg?1",
             "name": "Seismic Stomp",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "51c2d24d-1a88-58ad-aee1-2a133764ec7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326dae6-7539-4422-8c81-a1cffbbe8f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326dae6-7539-4422-8c81-a1cffbbe8f74.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, put three 1/1 red Goblin creature tokens onto the battlefield.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "eee9b88e-e9e7-5abf-8748-56d71805c3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207d5f12-fbc6-4c75-9d84-fd2f0023fbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207d5f12-fbc6-4c75-9d84-fd2f0023fbd0.jpg?1",
             "name": "Sneak Attack",
             "text": "{R}: You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice the creature at the beginning of the next end step.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "b990a717-d830-5d1b-b6fa-30fd459b5970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617477d7-eb82-4324-b99b-d7c9ecbdcfda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617477d7-eb82-4324-b99b-d7c9ecbdcfda.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "93969bf6-4a4c-5ef7-8b1d-61c6808dae25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0463e989-ba32-4a46-a82f-e0d6daf3cd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0463e989-ba32-4a46-a82f-e0d6daf3cd51.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "3bc30864-6ba8-5592-9383-ce84227b23e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c77d9f-22bd-4676-b594-8499369c449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c77d9f-22bd-4676-b594-8499369c449c.jpg?1",
             "name": "Tooth and Claw",
             "text": "Sacrifice two creatures: Put a 3/1 red Beast creature token named Carnivore onto the battlefield.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "b8ff0476-9a11-5004-9bb8-7dc5c2c8847f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0876a17b-19d4-483d-bd01-dafd28c3635f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0876a17b-19d4-483d-bd01-dafd28c3635f.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "01a1c69d-1647-5184-848f-cca58dd6ff27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f255055-0499-400f-ae0a-c32624f0ce78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f255055-0499-400f-ae0a-c32624f0ce78.jpg?1",
             "name": "Wildfire Emissary",
             "text": "Protection from white\n{1}{R}: Wildfire Emissary gets +1/+0 until end of turn.",
             "colours": [
@@ -5155,7 +5155,7 @@
         },
         {
             "id": "1f96ccb0-c5ee-53c5-bcdb-8069165d109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae8fa6-c86e-492b-b28b-96d4ee83f6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae8fa6-c86e-492b-b28b-96d4ee83f6c6.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon enters the battlefield, exile all other permanents you control.\nWhen Worldgorger Dragon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "544cdac0-75f8-5b9f-bc13-7ae2cdc6dfa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd3e04-2cc6-4538-b0e4-11a3653f8331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd3e04-2cc6-4538-b0e4-11a3653f8331.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, put a 1/1 red Elemental creature token onto the battlefield.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "5b4e6175-8bf7-5bc3-a6cf-696ad7ab5190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc00bf8-236b-4c68-be85-1609be122259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc00bf8-236b-4c68-be85-1609be122259.jpg?1",
             "name": "Abundant Growth",
             "text": "Enchant land\nWhen Abundant Growth enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "bc42649d-282d-5fab-b247-6496ecf629ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a19fc5-20f3-48d2-8c12-e012d3b302e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a19fc5-20f3-48d2-8c12-e012d3b302e7.jpg?1",
             "name": "Ancestral Mask",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 for each other enchantment on the battlefield.",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "72754ff7-3237-58cb-a0c3-68beb508cf70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99ff81f-08d9-4b4a-a879-de5e5e402802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99ff81f-08d9-4b4a-a879-de5e5e402802.jpg?1",
             "name": "Argothian Enchantress",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nWhenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "cafe44be-7145-5160-a90a-6b7d99e85684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23745d1-e03f-429b-889f-9fb92400ee3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23745d1-e03f-429b-889f-9fb92400ee3b.jpg?1",
             "name": "Brawn",
             "text": "Trample\nAs long as Brawn is in your graveyard and you control a Forest, creatures you control have trample.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "80324925-96bf-5822-8987-dec555cad05f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb106dd9-32f4-4716-9578-8e7164cc704a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb106dd9-32f4-4716-9578-8e7164cc704a.jpg?1",
             "name": "Centaur Chieftain",
             "text": "Haste\nThreshold \u2014 As long as seven or more cards are in your graveyard, Centaur Chieftain has \"When Centaur Chieftain enters the battlefield, creatures you control get +1/+1 and gain trample until end of turn.\"",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "f5266746-23a5-56f6-8f8b-a317956203ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee03108-036b-4996-a256-7c772a801492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee03108-036b-4996-a256-7c772a801492.jpg?1",
             "name": "Civic Wayfinder",
             "text": "When Civic Wayfinder enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "97287c11-04d5-5576-a532-0e535c754bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d95f6f-3ff0-483d-b98f-ccb4fb5715f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d95f6f-3ff0-483d-b98f-ccb4fb5715f4.jpg?1",
             "name": "Commune with the Gods",
             "text": "Reveal the top five cards of your library. You may put a creature or enchantment card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "569691fd-ea78-59db-9e11-9f05b8418583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c997fe6c-cb57-4e0e-9267-42bd12cc3b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c997fe6c-cb57-4e0e-9267-42bd12cc3b03.jpg?1",
             "name": "Elephant Guide",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nWhen enchanted creature dies, put a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -5498,7 +5498,7 @@
         },
         {
             "id": "f79b8ebd-8e1e-5e99-a63b-658791e70d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dd5e5-8dc1-4de4-8bfb-3024e3ff8bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311dd5e5-8dc1-4de4-8bfb-3024e3ff8bf2.jpg?1",
             "name": "Elvish Vanguard",
             "text": "Whenever another Elf enters the battlefield, put a +1/+1 counter on Elvish Vanguard.",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "dc5cff82-7138-55ee-b1ee-071cce86a0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c30e2-e751-4481-9a46-413c52bbff90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c30e2-e751-4481-9a46-413c52bbff90.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -5567,7 +5567,7 @@
         },
         {
             "id": "1f6c0ff1-edf9-50ad-a464-02772d77fa51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873be98f-e263-4e84-afa0-1e329aa47550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873be98f-e263-4e84-afa0-1e329aa47550.jpg?1",
             "name": "Flinthoof Boar",
             "text": "Flinthoof Boar gets +1/+1 as long as you control a Mountain.\n{R}: Flinthoof Boar gains haste until end of turn.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "7b8a9840-e991-522e-9dc9-2450359dc654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3152e-7b3b-4ac6-8b33-abfebde216aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3152e-7b3b-4ac6-8b33-abfebde216aa.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "f6c15603-6a4a-5d56-8f3f-8f060632217a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a872293-d164-426d-aa3e-eeeaa02fd38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a872293-d164-426d-aa3e-eeeaa02fd38b.jpg?1",
             "name": "Gaea's Blessing",
             "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "4a9893ea-e327-5c46-810d-99903fd7a952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01794178-cf41-454c-ac37-1d8b18e42db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01794178-cf41-454c-ac37-1d8b18e42db2.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -5698,7 +5698,7 @@
         },
         {
             "id": "121c90e3-19c1-59a6-919a-09d1c334b064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e7f83-a54a-43bc-a518-b1aa2baf4758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e7f83-a54a-43bc-a518-b1aa2baf4758.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "29e52eb1-f699-58c8-a782-003450e32bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57948c65-4324-42bc-97ae-7cc700eb3817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57948c65-4324-42bc-97ae-7cc700eb3817.jpg?1",
             "name": "Heritage Druid",
             "text": "Tap three untapped Elves you control: Add {G}{G}{G} to your mana pool.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "0b4cdbc8-14d1-5f70-a8c6-5b02c59e2a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766562f1-63b2-41d3-b76d-a31bac70fa89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/766562f1-63b2-41d3-b76d-a31bac70fa89.jpg?1",
             "name": "Honden of Life's Web",
             "text": "At the beginning of your upkeep, put a 1/1 colorless Spirit creature token onto the battlefield for each Shrine you control.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "df112777-c228-5220-b6d5-a95b643910a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f527ba3-ac8f-4bcc-880a-94ec9623d624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f527ba3-ac8f-4bcc-880a-94ec9623d624.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elf creatures you control get +1/+1.\n{G}, {T}: Put a 1/1 green Elf Warrior creature token onto the battlefield.",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "657fba5a-fcc0-5cae-8345-00c8061d6814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcec43b3-80dd-40a3-a277-6bca00b69f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcec43b3-80dd-40a3-a277-6bca00b69f35.jpg?1",
             "name": "Invigorate",
             "text": "If you control a Forest, rather than pay Invigorate's mana cost, you may have an opponent gain 3 life.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5868,7 +5868,7 @@
         },
         {
             "id": "d5f35f56-55f6-52f0-8757-3f9ee33799dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8a1386-77ca-46ae-8987-aaed435556ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8a1386-77ca-46ae-8987-aaed435556ea.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "4cb1178f-61c1-5669-a24d-40ad9b02bbed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724d28a0-730c-489d-a729-55eb8149402d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724d28a0-730c-489d-a729-55eb8149402d.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "Whenever you cast an Elf spell, you may put a 1/1 green Elf Warrior creature token onto the battlefield.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "ab22c3ee-4b3b-5bcd-89b2-f969ed61bfe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe3329c-7faa-4925-b9d2-075a1ab27e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe3329c-7faa-4925-b9d2-075a1ab27e80.jpg?1",
             "name": "Natural Order",
             "text": "As an additional cost to cast Natural Order, sacrifice a green creature.\nSearch your library for a green creature card and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "fde6b1d1-d079-58b9-8fe0-5555f3d2dc17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666a8ac9-d21d-4f3e-84a4-117fbeabbe8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666a8ac9-d21d-4f3e-84a4-117fbeabbe8b.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "580124b3-0490-5576-9832-4169391e7686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bfc161-7bf5-4796-b539-1cdeaa95e3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bfc161-7bf5-4796-b539-1cdeaa95e3de.jpg?1",
             "name": "Nimble Mongoose",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nThreshold \u2014 Nimble Mongoose gets +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "4cd32922-4fc5-5832-96e3-bbc11e8510e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd96a99-c3a0-4923-80a1-51d26fc8bb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd96a99-c3a0-4923-80a1-51d26fc8bb91.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "54062b97-1db2-5a44-a27d-bca92736cd48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6eb422-6e99-42bc-890b-99d4f6cd20f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6eb422-6e99-42bc-890b-99d4f6cd20f2.jpg?1",
             "name": "Regal Force",
             "text": "When Regal Force enters the battlefield, draw a card for each green creature you control.",
             "colours": [
@@ -6104,7 +6104,7 @@
         },
         {
             "id": "fe37b4f5-b6e2-5fb1-8248-608b29dc0c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b55e5ab-f437-477d-8c21-eb96f03f089e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b55e5ab-f437-477d-8c21-eb96f03f089e.jpg?1",
             "name": "Roar of the Wurm",
             "text": "Put a 6/6 green Wurm creature token onto the battlefield.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "4d5b9975-589d-526e-b2b4-960f676f3cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e40f1-2212-402b-a1b6-31c75a2aa816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10e40f1-2212-402b-a1b6-31c75a2aa816.jpg?1",
             "name": "Roots",
             "text": "Enchant creature without flying\nWhen Roots enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -6170,7 +6170,7 @@
         },
         {
             "id": "ab556ec3-63d2-5666-9c32-d177ff4754d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559c3909-51e3-4a3e-8570-107ffe69e30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559c3909-51e3-4a3e-8570-107ffe69e30d.jpg?1",
             "name": "Seal of Strength",
             "text": "Sacrifice Seal of Strength: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "9e56efc1-8cc7-501b-ac7b-b8443dee8626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddd780-29e5-4dbd-a371-5e46f63157d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddd780-29e5-4dbd-a371-5e46f63157d4.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance, reach",
             "colours": [
@@ -6236,7 +6236,7 @@
         },
         {
             "id": "872cbe9c-0384-50c8-a2df-bbcf45198de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1175357-01fe-438c-93bc-09e29ed8c9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1175357-01fe-438c-93bc-09e29ed8c9cb.jpg?1",
             "name": "Silvos, Rogue Elemental",
             "text": "Trample\n{G}: Regenerate Silvos, Rogue Elemental.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "8935e459-ba0b-54d6-b123-1614b4e13058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d2a7-8185-4df0-a35a-f89c12857f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b5d2a7-8185-4df0-a35a-f89c12857f87.jpg?1",
             "name": "Sylvan Library",
             "text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
             "colours": [
@@ -6304,7 +6304,7 @@
         },
         {
             "id": "578d2e9b-792e-50ab-9087-791e1e69eaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f905cc8-dd34-4e56-a92e-1ea1814d1983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f905cc8-dd34-4e56-a92e-1ea1814d1983.jpg?1",
             "name": "Sylvan Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nFlashback {2}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6336,7 +6336,7 @@
         },
         {
             "id": "6bf38027-13df-5be3-b89a-67ca6cb1c635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608b0f34-83be-44a3-ba92-69df9b8af8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608b0f34-83be-44a3-ba92-69df9b8af8d1.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach, deathtouch",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "f4566c5e-316b-5771-84a3-713d129f37bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d902a83-5e39-4df3-a897-e9ac65a8209c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d902a83-5e39-4df3-a897-e9ac65a8209c.jpg?1",
             "name": "Timberwatch Elf",
             "text": "{T}: Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "7324cfb4-ce55-54d6-9053-f41ce8cb5715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224ea635-b95b-4803-8716-edd4cb655923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224ea635-b95b-4803-8716-edd4cb655923.jpg?1",
             "name": "Werebear",
             "text": "{T}: Add {G} to your mana pool.\nThreshold \u2014 Werebear gets +3/+3 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "7da184d2-aad9-5b27-bf1b-aedc8d0d232f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f1d22-1416-4012-979c-35152ff520bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f1d22-1416-4012-979c-35152ff520bd.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "Return an Elf you control to its owner's hand: Untap target creature. Activate this ability only once each turn.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "2cb51f34-c81a-53f0-b2a8-4862d2b89845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ab408-3292-40b6-b35e-ac1b7f06dffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ab408-3292-40b6-b35e-ac1b7f06dffa.jpg?1",
             "name": "Xantid Swarm",
             "text": "Flying\nWhenever Xantid Swarm attacks, defending player can't cast spells this turn.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "cda93da7-53ed-5b39-bd4b-34140cc29fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cc6976-7247-4cd9-a0f0-fcb2e860a70e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cc6976-7247-4cd9-a0f0-fcb2e860a70e.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment on the battlefield.",
             "colours": [
@@ -6544,7 +6544,7 @@
         },
         {
             "id": "8575f6ba-57c4-54eb-9919-de904435c575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa232c65-dbb4-4414-bd95-b3bbd321c653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa232c65-dbb4-4414-bd95-b3bbd321c653.jpg?1",
             "name": "Armadillo Cloak",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample.\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "f05af4a8-c77b-57b2-893b-9de4baff0a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7536fa-a501-4e31-941f-b391a61e358a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df7536fa-a501-4e31-941f-b391a61e358a.jpg?1",
             "name": "Baleful Strix",
             "text": "Flying, deathtouch\nWhen Baleful Strix enters the battlefield, draw a card.",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "78e075e1-4cc8-5f83-babe-aef751376a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b15ab8-c117-42b9-8177-df96153d6a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b15ab8-c117-42b9-8177-df96153d6a38.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -6654,7 +6654,7 @@
         },
         {
             "id": "fa07cb1f-8f33-5510-a786-3dc1e0b28d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba873c1-f1ff-49f2-9e0d-bc9d52f94d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba873c1-f1ff-49f2-9e0d-bc9d52f94d76.jpg?1",
             "name": "Brago, King Eternal",
             "text": "Flying\nWhenever Brago, King Eternal deals combat damage to a player, exile any number of target nonland permanents you control, then return those cards to the battlefield under their owner's control.",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "f517a677-d53c-541a-80c7-4137ccf7aca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10158a5e-5a03-41ab-85d2-0907ccf32c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10158a5e-5a03-41ab-85d2-0907ccf32c9b.jpg?1",
             "name": "Dack Fayden",
             "text": "+1: Target player draws two cards, then discards two cards.\n\u22122: Gain control of target artifact.\n\u22126: You get an emblem with \"Whenever you cast a spell that targets one or more permanents, gain control of those permanents.\"",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "a18545fa-c13e-5feb-ab3b-30de53b98442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17592ec3-cffb-4cf9-86bc-4ad3ac696d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17592ec3-cffb-4cf9-86bc-4ad3ac696d91.jpg?1",
             "name": "Extract from Darkness",
             "text": "Each player puts the top two cards of his or her library into his or her graveyard. Then put a creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -6765,7 +6765,7 @@
         },
         {
             "id": "39bd59e0-ed85-53a3-8d1b-172a32888c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7db99b-903f-43d8-bc60-cab2d914a0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7db99b-903f-43d8-bc60-cab2d914a0cb.jpg?1",
             "name": "Flame-Kin Zealot",
             "text": "When Flame-Kin Zealot enters the battlefield, creatures you control get +1/+1 and gain haste until end of turn.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "d52d8e38-17f1-514a-9af5-5986fe1344fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b6e40f-02d6-498f-bb3b-6a9e19ed46f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b6e40f-02d6-498f-bb3b-6a9e19ed46f6.jpg?1",
             "name": "Glare of Subdual",
             "text": "Tap an untapped creature you control: Tap target artifact or creature.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "941a5380-8613-5fe5-87e9-e94ef279bec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06625dee-d2e6-4efa-a385-5113d0fe78ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06625dee-d2e6-4efa-a385-5113d0fe78ac.jpg?1",
             "name": "Goblin Trenches",
             "text": "{2}, Sacrifice a land: Put two 1/1 red and white Goblin Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "8b388a3d-dc70-5931-b4b7-07da5f8ab6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a494b35-44d4-45e3-abfa-eb1874c6aa21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a494b35-44d4-45e3-abfa-eb1874c6aa21.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "Creatures you control have haste.\nCascade, cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order. Then do it again.)",
             "colours": [
@@ -6910,7 +6910,7 @@
         },
         {
             "id": "15324acd-6d61-5bee-ab7b-b96993317df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedf655-771d-4a08-a24a-3dc5d1725314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eedf655-771d-4a08-a24a-3dc5d1725314.jpg?1",
             "name": "Shaman of the Pack",
             "text": "When Shaman of the Pack enters the battlefield, target opponent loses life equal to the number of Elves you control.",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "f5104ae2-a0a9-54bf-af9c-0d3b606d43de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddb094-533a-4f9e-ab9a-e95a6432ce85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fddb094-533a-4f9e-ab9a-e95a6432ce85.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "1f191de2-6af5-5d6f-b941-4686b267c89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9b802-3381-4318-a352-d85451aba586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc9b802-3381-4318-a352-d85451aba586.jpg?1",
             "name": "Sphinx of the Steel Wind",
             "text": "Flying, first strike, vigilance, lifelink, protection from red and from green",
             "colours": [
@@ -7024,7 +7024,7 @@
         },
         {
             "id": "3bf15900-671a-54b6-abc9-8876269f7084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64551550-6279-4f6e-a5b9-e1332e927421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64551550-6279-4f6e-a5b9-e1332e927421.jpg?1",
             "name": "Thunderclap Wyvern",
             "text": "Flash\nFlying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "2a51a660-bc7c-57ad-bd6a-80b41f40472e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9f1b7c-96b4-4036-9c1b-0ea9891da89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9f1b7c-96b4-4036-9c1b-0ea9891da89e.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "525ef4ed-b7f8-5bf1-924e-233ee7d7d4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f7927-77a0-4f66-8b92-e42c5bf6251d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f7927-77a0-4f66-8b92-e42c5bf6251d.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -7130,7 +7130,7 @@
         },
         {
             "id": "a25022ce-8590-5eb7-ad2e-1c2493d17ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b3e320-a85c-4d92-944e-0a5e78a066a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b3e320-a85c-4d92-944e-0a5e78a066a5.jpg?1",
             "name": "Void",
             "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards all nonland cards with converted mana cost equal to the number.",
             "colours": [
@@ -7164,7 +7164,7 @@
         },
         {
             "id": "4f5fe89e-c721-55a8-9850-604f6179ce0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68a75f-abcb-49b0-a07b-a011b934969a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68a75f-abcb-49b0-a07b-a011b934969a.jpg?1",
             "name": "Wee Dragonauts",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Wee Dragonauts gets +2/+0 until end of turn.",
             "colours": [
@@ -7201,7 +7201,7 @@
         },
         {
             "id": "e88d42f9-a4d2-53d2-a326-40db60ad5979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e69fc-9a3e-4830-a0ea-36183274325a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e69fc-9a3e-4830-a0ea-36183274325a.jpg?1",
             "name": "Zealous Persecution",
             "text": "Until end of turn, creatures you control get +1/+1 and creatures your opponents control get -1/-1.",
             "colours": [
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "067c3a75-34a7-502d-bc28-92373931db25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9511172e-f5dc-4356-9a9d-9fd4527069e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9511172e-f5dc-4356-9a9d-9fd4527069e3.jpg?1",
             "name": "Call the Skybreaker",
             "text": "Put a 5/5 blue and red Elemental creature token with flying onto the battlefield.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -7269,7 +7269,7 @@
         },
         {
             "id": "e4762986-08df-5826-ba7d-463a77ba10a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14f9fc8-e48c-473f-ba6b-9cffce94bb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14f9fc8-e48c-473f-ba6b-9cffce94bb53.jpg?1",
             "name": "Deathrite Shaman",
             "text": "{T}: Exile target land card from a graveyard. Add one mana of any color to your mana pool.\n{B}, {T}: Exile target instant or sorcery card from a graveyard. Each opponent loses 2 life.\n{G}, {T}: Exile target creature card from a graveyard. You gain 2 life.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "9aeea31f-bd6f-5f7c-a1a9-b214b5be73e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6038-e2e9-4de2-a94e-0798c80a94c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6038-e2e9-4de2-a94e-0798c80a94c6.jpg?1",
             "name": "Giant Solifuge",
             "text": "Trample, haste\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -7342,7 +7342,7 @@
         },
         {
             "id": "dc7c896f-8d6b-5e0a-b771-2fbaa588dfc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0252d0d9-af34-4eaf-8cf2-ef1a3af494f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0252d0d9-af34-4eaf-8cf2-ef1a3af494f8.jpg?1",
             "name": "Torrent of Souls",
             "text": "Return up to one target creature card from your graveyard to the battlefield if {B} was spent to cast Torrent of Souls. Creatures target player controls get +2/+0 and gain haste until end of turn if {R} was spent to cast Torrent of Souls. (Do both if {B}{R} was spent.)",
             "colours": [
@@ -7376,7 +7376,7 @@
         },
         {
             "id": "72dce557-ea67-5b17-b5cd-adf407af04fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87da5ad8-b35f-4f9c-b17a-bb2563cbc186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87da5ad8-b35f-4f9c-b17a-bb2563cbc186.jpg?1",
             "name": "Ashnod's Altar",
             "text": "Sacrifice a creature: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "6ae990d1-0777-50a7-af3f-2753261602dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f7138-60e0-444e-aaa3-8769072da916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f7138-60e0-444e-aaa3-8769072da916.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint \u2014 When Chrome Mox enters the battlefield, you may exile a nonartifact, nonland card from your hand.\n{T}: Add one mana of any of the exiled card's colors to your mana pool.",
             "colours": [],
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "df5c550a-9a13-5723-8342-a7a5d6974fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e357856-99d6-407a-bfa2-3cddbf4affd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e357856-99d6-407a-bfa2-3cddbf4affd3.jpg?1",
             "name": "Duplicant",
             "text": "Imprint \u2014 When Duplicant enters the battlefield, you may exile target nontoken creature.\nAs long as a card exiled with Duplicant is a creature card, Duplicant has the power, toughness, and creature types of the last creature card exiled with Duplicant. It's still a Shapeshifter.",
             "colours": [],
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "5da345a2-3521-5abb-858f-3d1cda1fd99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb78dd-03d7-43a0-8ff5-1b97c6f515c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decb78dd-03d7-43a0-8ff5-1b97c6f515c9.jpg?1",
             "name": "Emmessi Tome",
             "text": "{5}, {T}: Draw two cards, then discard a card.",
             "colours": [],
@@ -7491,7 +7491,7 @@
         },
         {
             "id": "c88c0114-34f3-5cc8-9119-41d4dd106a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451f9489-6997-42c2-96c2-021cd8bdd5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451f9489-6997-42c2-96c2-021cd8bdd5d3.jpg?1",
             "name": "Goblin Charbelcher",
             "text": "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. Goblin Charbelcher deals damage equal to the number of nonland cards revealed this way to target creature or player. If the revealed land card was a Mountain, Goblin Charbelcher deals double that damage instead. Put the revealed cards on the bottom of your library in any order.",
             "colours": [],
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "5a3962da-e5aa-5ef4-8faf-d172b3aecd7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c0e902-f7ee-4dab-9a07-025a305c9958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c0e902-f7ee-4dab-9a07-025a305c9958.jpg?1",
             "name": "Isochron Scepter",
             "text": "Imprint \u2014 When Isochron Scepter enters the battlefield, you may exile an instant card with converted mana cost 2 or less from your hand.\n{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its mana cost.",
             "colours": [],
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "4cdfab61-9b1b-511f-b451-053a5541f71d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b0c1a-d4f5-4ef8-a7f1-020453314f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b0c1a-d4f5-4ef8-a7f1-020453314f97.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "a35420a0-a9ff-5fcb-ab06-14b35597c0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb33b46-4d1b-4f97-bfdc-d815aee111da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb33b46-4d1b-4f97-bfdc-d815aee111da.jpg?1",
             "name": "Mana Crypt",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you.\n{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7606,7 +7606,7 @@
         },
         {
             "id": "669b9206-4e2b-5618-8af8-d2f1d0444dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37757eae-e473-4d54-ab12-8ab453855e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37757eae-e473-4d54-ab12-8ab453855e91.jpg?1",
             "name": "Millikin",
             "text": "{T}, Put the top card of your library into your graveyard: Add {C} to your mana pool.",
             "colours": [],
@@ -7637,7 +7637,7 @@
         },
         {
             "id": "c235a8b6-0bb3-5b00-99f5-d1be80a84ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e81c3a-663d-414f-9a4f-95c0e55b1aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e81c3a-663d-414f-9a4f-95c0e55b1aa1.jpg?1",
             "name": "Mindless Automaton",
             "text": "Mindless Automaton enters the battlefield with two +1/+1 counters on it.\n{1}, Discard a card: Put a +1/+1 counter on Mindless Automaton.\nRemove two +1/+1 counters from Mindless Automaton: Draw a card.",
             "colours": [],
@@ -7668,7 +7668,7 @@
         },
         {
             "id": "12a83361-2303-5dab-883e-cdbd7bce12b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72584d-f65e-4c8f-be05-f44389c2381d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72584d-f65e-4c8f-be05-f44389c2381d.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "566b2882-d68a-5a19-9b0c-e623d7733ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da685792-5846-4201-ae64-19a822a4e575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da685792-5846-4201-ae64-19a822a4e575.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "b9f51098-909d-57d6-8543-3e8d6a16d010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19786221-ff63-48be-98cb-82360ca12634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19786221-ff63-48be-98cb-82360ca12634.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "b66754d3-60c2-53cf-9e47-ffc3defeba09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436cd66c-0622-43cd-8748-af4d21a2db3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436cd66c-0622-43cd-8748-af4d21a2db3f.jpg?1",
             "name": "Relic of Progenitus",
             "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "3b24df41-5116-503a-82ad-ee292c94237f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c01c91-ea01-46c7-b94c-97777b968459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c01c91-ea01-46c7-b94c-97777b968459.jpg?1",
             "name": "Sensei's Divining Top",
             "text": "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put Sensei's Divining Top on top of its owner's library.",
             "colours": [],
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "415c586d-8a69-5cf0-b8c0-286da95c33a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6358cf-fcb9-42af-9755-dd1f39bfc8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6358cf-fcb9-42af-9755-dd1f39bfc8ff.jpg?1",
             "name": "Ticking Gnomes",
             "text": "Echo {3} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nSacrifice Ticking Gnomes: Ticking Gnomes deals 1 damage to target creature or player.",
             "colours": [],
@@ -7842,7 +7842,7 @@
         },
         {
             "id": "d60c334b-6101-5464-9080-cdf86351d486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3cec7e-513e-400d-a1a8-2c71cdde02c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab3cec7e-513e-400d-a1a8-2c71cdde02c6.jpg?1",
             "name": "Winter Orb",
             "text": "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps.",
             "colours": [],
@@ -7870,7 +7870,7 @@
         },
         {
             "id": "eff7b726-f80a-53a9-9b33-c43881099e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb7c6c-14ac-41f3-a461-451d9ee8e1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb7c6c-14ac-41f3-a461-451d9ee8e1df.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone enters the battlefield tapped.\n{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "e0d8333d-5df6-53e0-adf3-28ce70adc060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d38a0-7714-40c7-ae8e-2afd121ed59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d38a0-7714-40c7-ae8e-2afd121ed59a.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "083c3942-34bc-553e-85ea-30c5c417f854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f3e01-c469-44f8-b34e-e594cd037e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5f3e01-c469-44f8-b34e-e594cd037e49.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7960,7 +7960,7 @@
         },
         {
             "id": "5f68b12d-3686-5458-bbe8-7bb45983b21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671633dd-017b-4da5-93e4-45a9b889cc68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671633dd-017b-4da5-93e4-45a9b889cc68.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7991,7 +7991,7 @@
         },
         {
             "id": "f0f39db8-2442-5de1-be6b-5fa433e2e798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d833fd8f-8d1f-4a4d-a42a-58af63c17186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d833fd8f-8d1f-4a4d-a42a-58af63c17186.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8022,7 +8022,7 @@
         },
         {
             "id": "12d5d8b0-0711-58f0-ba4a-ec1eb790875c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c2218-9d12-4ac3-a721-fca590b89847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c2218-9d12-4ac3-a721-fca590b89847.jpg?1",
             "name": "Karakas",
             "text": "{T}: Add {W} to your mana pool.\n{T}: Return target legendary creature to its owner's hand.",
             "colours": [],
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "c41f9f8e-fb71-5cf6-9669-18b3681e48a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8eee4f-99e3-499d-9d6d-0bff023f6512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8eee4f-99e3-499d-9d6d-0bff023f6512.jpg?1",
             "name": "Maze of Ith",
             "text": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "5915c825-a6be-50f7-ab4f-b10d1bd55ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f305f103-746b-4406-b569-1a7dc32beee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f305f103-746b-4406-b569-1a7dc32beee7.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C} to your mana pool.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "d7e66a47-9415-5679-9874-363b67e50a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642dd947-253b-4082-a774-d474b214a704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642dd947-253b-4082-a774-d474b214a704.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8141,7 +8141,7 @@
         },
         {
             "id": "acd31bcd-678d-54c6-bc93-41a45abf6c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54294215-3d63-4c44-8886-7e2f71c78379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54294215-3d63-4c44-8886-7e2f71c78379.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "ed7b96c9-9f2b-5537-875f-32a3ba2fdac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc7fdf-ff3e-4c09-9d5c-f08cf986689b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc7fdf-ff3e-4c09-9d5c-f08cf986689b.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "380226ae-232a-5846-9ff0-96e5948a6def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00323a16-8bfd-49af-b073-8f0b23a9d947.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "23014a87-6cc5-55c1-a71e-5b4eeb0ef997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f4e8-e4e8-4a77-992a-3af8ef2f8df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f4e8-e4e8-4a77-992a-3af8ef2f8df6.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "26c976b7-e593-5f9a-a1a6-4f5114af6f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaafb9bc-7cea-4624-a227-595544fa42b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaafb9bc-7cea-4624-a227-595544fa42b0.jpg?1",
             "name": "Wasteland",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Wasteland: Destroy target nonbasic land.",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "a7b00e53-2b83-5bb6-91f8-93a60f57393b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a34e90d-6b79-448a-8f90-05733139207e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a34e90d-6b79-448a-8f90-05733139207e.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8324,7 +8324,7 @@
         },
         {
             "id": "86ccef6e-a581-536a-8c5c-81040de8bb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082c3bad-3fea-4c3f-8263-4b16139bb32a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082c3bad-3fea-4c3f-8263-4b16139bb32a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -8354,7 +8354,7 @@
         },
         {
             "id": "243dd9d1-4750-5abb-9c7b-5878f3a4b702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c807dc-9c4f-4e87-9263-4dc9864e78ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c807dc-9c4f-4e87-9263-4dc9864e78ed.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "85cb438e-6852-54f6-98de-60384aac0fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b36a9a-7456-4c72-a7b2-478461d886a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b36a9a-7456-4c72-a7b2-478461d886a4.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8422,7 +8422,7 @@
         },
         {
             "id": "ac41772f-9365-5129-bbf3-99333ec63586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f31debf-0b93-44c7-99b6-be441ba4e167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f31debf-0b93-44c7-99b6-be441ba4e167.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "c1d00c5e-3e97-5815-b0f6-d3547afd1080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98dbedd-b1f1-4a9c-af37-8ce2ae07a247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98dbedd-b1f1-4a9c-af37-8ce2ae07a247.jpg?1",
             "name": "Serf",
             "text": "",
             "colours": [
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "f865d69f-5f58-50a7-9368-d4f2383f474b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207e9b8c-3e5e-4262-8d78-248780600462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207e9b8c-3e5e-4262-8d78-248780600462.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "2916cad8-e495-5469-a1d2-b80c26fb74e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8437b125-6057-4d17-9f2c-28ea56553f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8437b125-6057-4d17-9f2c-28ea56553f84.jpg?1",
             "name": "Carnivore",
             "text": "",
             "colours": [
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "494cf5e8-9c77-5cb5-9f4c-e1c318e8a6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d37f45-e5ad-48e2-b6d4-9f39b1643f3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d37f45-e5ad-48e2-b6d4-9f39b1643f3a.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8592,7 +8592,7 @@
         },
         {
             "id": "b729388a-eea6-5c99-a333-26a1cfed0ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f81e2-916f-4af4-9e63-f4469e953122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f81e2-916f-4af4-9e63-f4469e953122.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "261364f9-97f9-5ecd-a221-2d7b039ed47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ad6525-af56-4512-9a6e-3441e686c367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ad6525-af56-4512-9a6e-3441e686c367.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "c0dea9db-fb14-52e0-8304-5025d32f26f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de85f692-4c8b-45b5-af8b-05a4c2a6cebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de85f692-4c8b-45b5-af8b-05a4c2a6cebf.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8694,7 +8694,7 @@
         },
         {
             "id": "9c643f20-444d-5d60-a0fd-a946556a74fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355eaeb4-582f-4b74-b573-3dd68f376317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/355eaeb4-582f-4b74-b573-3dd68f376317.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -8729,7 +8729,7 @@
         },
         {
             "id": "7141cacc-91af-515d-9912-ecd112ba0f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32175ed-d4f8-43b0-8f31-df529167610b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32175ed-d4f8-43b0-8f31-df529167610b.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8763,7 +8763,7 @@
         },
         {
             "id": "22763a77-bc0b-584d-8c2d-6bfe415a0db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae82b600-c406-4c3b-a09b-a18e18fc57b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae82b600-c406-4c3b-a09b-a18e18fc57b1.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "40ea0deb-83d1-565f-9f72-592652ed3606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3022b41d-05c1-452e-a1cd-5ec5a7f4d79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3022b41d-05c1-452e-a1cd-5ec5a7f4d79d.jpg?1",
             "name": "Goblin Soldier",
             "text": "",
             "colours": [
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "6d990ec4-e98d-5b60-bf55-271f19741864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92a00d8-ddac-45df-8130-87ac32815984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92a00d8-ddac-45df-8130-87ac32815984.jpg?1",
             "name": "Dack Fayden Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/EMN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/EMN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e706ac5a-bcae-5b45-9a7a-592635b49c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e7ef7-7958-4d7c-b319-4d3db7955002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e7ef7-7958-4d7c-b319-4d3db7955002.jpg?1",
             "name": "Abundant Maw",
             "text": "Emerge {6}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Abundant Maw, target opponent loses 3 life and you gain 3 life.",
             "colours": [],
@@ -37,7 +37,7 @@
         },
         {
             "id": "75bb3101-c74c-5560-b905-6ed948f8bfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587cb384-db24-4e3d-a338-230e50305d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587cb384-db24-4e3d-a338-230e50305d31.jpg?1",
             "name": "Decimator of the Provinces",
             "text": "Emerge {6}{G}{G}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Decimator of the Provinces, creatures you control get +2/+2 and gain trample until end of turn.\nTrample, haste",
             "colours": [],
@@ -70,7 +70,7 @@
         },
         {
             "id": "f7fdce4d-1dc6-5da2-9326-2f8c4e9e06ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5d1e41-fb0b-4866-912a-2a7d49542428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5d1e41-fb0b-4866-912a-2a7d49542428.jpg?1",
             "name": "Distended Mindbender",
             "text": "Emerge {5}{B}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Distended Mindbender, target opponent reveals his or her hand. You choose from it a nonland card with converted mana cost 3 or less and a card with converted mana cost 4 or greater. That player discards those cards.",
             "colours": [],
@@ -103,7 +103,7 @@
         },
         {
             "id": "57f9c6c6-32b9-552e-93e1-cb929b9572aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082690e8-07b9-4a91-b779-e0123a69ee12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082690e8-07b9-4a91-b779-e0123a69ee12.jpg?1",
             "name": "Drownyard Behemoth",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEmerge {7}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nDrownyard Behemoth has hexproof as long as it entered the battlefield this turn.",
             "colours": [],
@@ -136,7 +136,7 @@
         },
         {
             "id": "658bf7ec-027a-5a3b-9677-1ba4c9135f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2789fb-a263-4207-8a56-4eeb015a024c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c2789fb-a263-4207-8a56-4eeb015a024c.jpg?1",
             "name": "Elder Deep-Fiend",
             "text": "Flash\nEmerge {5}{U}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Elder Deep-Fiend, tap up to four target permanents.",
             "colours": [],
@@ -169,7 +169,7 @@
         },
         {
             "id": "14e28c5d-8113-510c-b755-0b66b9281022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74a469-c71d-4773-99d3-5456b31df424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74a469-c71d-4773-99d3-5456b31df424.jpg?1",
             "name": "Emrakul, the Promised End",
             "text": "Emrakul, the Promised End costs {1} less to cast for each card type among cards in your graveyard.\nWhen you cast Emrakul, you gain control of target opponent during that player's next turn. After that turn, that player takes an extra turn.\nFlying, trample, protection from instants",
             "colours": [],
@@ -201,7 +201,7 @@
         },
         {
             "id": "ac3c3b6c-c7e1-58d1-8643-2d0c7f31ad22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce52f5-6d49-4d44-a3d7-925340de8406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce52f5-6d49-4d44-a3d7-925340de8406.jpg?1",
             "name": "Eternal Scourge",
             "text": "You may cast Eternal Scourge from exile.\nWhen Eternal Scourge becomes the target of a spell or ability an opponent controls, exile Eternal Scourge.",
             "colours": [],
@@ -232,7 +232,7 @@
         },
         {
             "id": "21ec97c2-bcf6-5e3e-99e8-22e555fd17d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9160cb-d3de-49ca-a97d-2cd259cd5447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9160cb-d3de-49ca-a97d-2cd259cd5447.jpg?1",
             "name": "It of the Horrid Swarm",
             "text": "Emerge {6}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast It of the Horrid Swarm, put two 1/1 green Insect creature tokens onto the battlefield.",
             "colours": [],
@@ -265,7 +265,7 @@
         },
         {
             "id": "99f63685-c8b6-5b1a-b447-9d95a114c483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13f9a76-3370-4809-88ff-c300bca31c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13f9a76-3370-4809-88ff-c300bca31c9e.jpg?1",
             "name": "Lashweed Lurker",
             "text": "Emerge {5}{G}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Lashweed Lurker, you may put target nonland permanent on top of its owner's library.",
             "colours": [],
@@ -299,7 +299,7 @@
         },
         {
             "id": "a8fd720a-678a-549c-932e-a8d6398bf5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3118737f-2fd9-4fe5-bd0f-43c9ef2166e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3118737f-2fd9-4fe5-bd0f-43c9ef2166e2.jpg?1",
             "name": "Mockery of Nature",
             "text": "Emerge {7}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Mockery of Nature, you may destroy target artifact or enchantment.",
             "colours": [],
@@ -332,7 +332,7 @@
         },
         {
             "id": "42573b73-ef26-5b35-b07e-35b291f95a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3dd0aa-f6e9-435c-af64-20e9de67efe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3dd0aa-f6e9-435c-af64-20e9de67efe9.jpg?1",
             "name": "Vexing Scuttler",
             "text": "Emerge {6}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Vexing Scuttler, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [],
@@ -365,7 +365,7 @@
         },
         {
             "id": "9fde7c4e-1ca6-5fff-a266-3e4c8871ca09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d65efec-018f-485c-906c-460379b4af87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d65efec-018f-485c-906c-460379b4af87.jpg?1",
             "name": "Wretched Gryff",
             "text": "Emerge {5}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's converted mana cost.)\nWhen you cast Wretched Gryff, draw a card.\nFlying",
             "colours": [],
@@ -398,7 +398,7 @@
         },
         {
             "id": "32962ab0-bb3f-5678-aaaf-e45cb3440d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5805eab-9a32-4c0c-9015-7bdb74ad7634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5805eab-9a32-4c0c-9015-7bdb74ad7634.jpg?1",
             "name": "Blessed Alliance",
             "text": "Escalate {2} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Target player gains 4 life.\n\u2022 Untap up to two target creatures.\n\u2022 Target opponent sacrifices an attacking creature.",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "b87bd158-cb94-5f95-b4f8-aef71e7e8eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0067567-3434-4c12-9d4d-04ffc98d012c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0067567-3434-4c12-9d4d-04ffc98d012c.jpg?1",
             "name": "Borrowed Grace",
             "text": "Escalate {1}{W} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "6081d8fd-26e1-5e6a-9c98-417d03214856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27907985-b5f6-4098-ab43-15a0c2bf94d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27907985-b5f6-4098-ab43-15a0c2bf94d5.jpg?1",
             "name": "Bruna, the Fading Light // Brisela, Voice of Nightmares",
             "text": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
             "colours": [
@@ -499,7 +499,7 @@
         },
         {
             "id": "1b18ca2b-4e5e-54c1-bf43-1f32afa75f78",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg?1",
             "name": "Brisela, Voice of Nightmares",
             "text": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
             "colours": [],
@@ -534,7 +534,7 @@
         },
         {
             "id": "74e72ea7-64c5-59f1-a63e-e5e8df4c1dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4549735d-df63-47db-ad53-0497499fe387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4549735d-df63-47db-ad53-0497499fe387.jpg?1",
             "name": "Choking Restraints",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{3}{W}{W}, Sacrifice Choking Restraints: Exile enchanted creature.",
             "colours": [
@@ -568,7 +568,7 @@
         },
         {
             "id": "d3208fe3-73ca-5def-88fb-d6dd796d4c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a6369-c07f-47d5-8448-72d8ec7e7898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a6369-c07f-47d5-8448-72d8ec7e7898.jpg?1",
             "name": "Collective Effort",
             "text": "Escalate\u2014\nTap an untapped creature you control. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Destroy target creature with power 4 or greater.\n\u2022 Destroy target enchantment.\n\u2022 Put a +1/+1 counter on each creature target player controls.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "19846933-bf72-506b-8f0c-2dc96bfaeb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4123da54-9947-462e-9862-3eecc459a75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4123da54-9947-462e-9862-3eecc459a75b.jpg?1",
             "name": "Courageous Outrider",
             "text": "When Courageous Outrider enters the battlefield, look at the top four cards of your library. You may reveal a Human card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -635,7 +635,7 @@
         },
         {
             "id": "556da1ee-5ecc-5598-8559-4ed6b11e21e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d30894-82b9-4af8-b0bb-48a78acbc4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d30894-82b9-4af8-b0bb-48a78acbc4bd.jpg?1",
             "name": "Dawn Gryff",
             "text": "Flying",
             "colours": [
@@ -669,7 +669,7 @@
         },
         {
             "id": "dd5f4eaf-b9d2-52e5-9cba-3313b17485cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aa54d9-9f01-46e4-b4bd-f8bc57b44ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aa54d9-9f01-46e4-b4bd-f8bc57b44ac1.jpg?1",
             "name": "Deploy the Gatewatch",
             "text": "Look at the top seven cards of your library. Put up to two planeswalker cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -701,7 +701,7 @@
         },
         {
             "id": "35957337-3c18-50cb-82c0-4997b7fa9ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4135c619-fcff-4339-b778-31dd83e68fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4135c619-fcff-4339-b778-31dd83e68fcb.jpg?1",
             "name": "Desperate Sentry",
             "text": "When Desperate Sentry dies, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.\nDelirium \u2014 Desperate Sentry gets +3/+0 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "755d1e2d-6d14-5dfd-a196-42d19f012daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156b4bca-4145-472b-bf80-13edb0bef561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156b4bca-4145-472b-bf80-13edb0bef561.jpg?1",
             "name": "Drogskol Shieldmate",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Drogskol Shieldmate enters the battlefield, other creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -771,7 +771,7 @@
         },
         {
             "id": "5bd2cbe8-89c4-5742-9abf-23a40cb84d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg?1",
             "name": "Extricator of Sin // Extricator of Flesh",
             "text": "When Extricator of Sin enters the battlefield, you may sacrifice another permanent. If you do, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.\nDelirium \u2014 At the beginning of your upkeep, if there are four or more card types among cards in your graveyard, transform Extricator of Sin.",
             "colours": [
@@ -806,7 +806,7 @@
         },
         {
             "id": "e141f315-d86b-54dc-a5a3-ce4ba65395d3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6867ddd-f953-41c6-ba36-86ae2c14c908.jpg?1",
             "name": "Extricator of Sin // Extricator of Flesh",
             "text": "Eldrazi you control have vigilance.\n{2}, {T}, Sacrifice a non-Eldrazi creature: Put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [],
@@ -839,7 +839,7 @@
         },
         {
             "id": "36b0132a-693a-5ef8-9feb-d079ae53002c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6e58-c278-4bfe-8443-33afc7618b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bf6e58-c278-4bfe-8443-33afc7618b38.jpg?1",
             "name": "Faith Unbroken",
             "text": "Enchant creature you control\nWhen Faith Unbroken enters the battlefield, exile target creature an opponent controls until Faith Unbroken leaves the battlefield.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -873,7 +873,7 @@
         },
         {
             "id": "8e2cae1a-fa5c-58a6-9ee8-2c42c1c9a5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af15a774-b97f-4bc0-913d-4d2a047fed8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af15a774-b97f-4bc0-913d-4d2a047fed8a.jpg?1",
             "name": "Faithbearer Paladin",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "51640cdb-ee01-520f-b8c8-0593a3c4b21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0870d21-603f-4d36-8054-943adba06301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0870d21-603f-4d36-8054-943adba06301.jpg?1",
             "name": "Fiend Binder",
             "text": "Whenever Fiend Binder attacks, tap target creature defending player controls.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "22710322-66ee-5ef6-b9dc-d25e1ab8a266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13118343-e026-4970-bf03-ba2d8fc58bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13118343-e026-4970-bf03-ba2d8fc58bac.jpg?1",
             "name": "Geist of the Lonely Vigil",
             "text": "Defender, flying\nDelirium \u2014 Geist of the Lonely Vigil can attack as though it didn't have defender as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "5bb79a0f-ad7d-5383-8c9d-04bc757bcb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c035a-7da9-4b36-982d-fca8220b1797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c035a-7da9-4b36-982d-fca8220b1797.jpg?1",
             "name": "Gisela, the Broken Blade // Brisela, Voice of Nightmares",
             "text": "Flying, first strike, lifelink\nAt the beginning of your end step, if you both own and control Gisela, the Broken Blade and a creature named Bruna, the Fading Light, exile them, then meld them into Brisela, Voice of Nightmares.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "0a26fb93-b908-5fa4-982d-586f4b574e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3347a-9b32-46a4-a621-4ae5244ba2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb3347a-9b32-46a4-a621-4ae5244ba2f5.jpg?1",
             "name": "Give No Ground",
             "text": "Target creature gets +2/+6 until end of turn and can block any number of creatures this turn.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "5bdc20b8-ddbf-5090-92dc-d619f6e701d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41b6ca9-1d6f-46ce-aba0-952871a10a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41b6ca9-1d6f-46ce-aba0-952871a10a4b.jpg?1",
             "name": "Guardian of Pilgrims",
             "text": "When Guardian of Pilgrims enters the battlefield, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "5da895ab-0681-542d-a3d4-c99cc0e95beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d413f69f-fe2d-4049-8640-178af7e927d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d413f69f-fe2d-4049-8640-178af7e927d9.jpg?1",
             "name": "Ironclad Slayer",
             "text": "When Ironclad Slayer enters the battlefield, you may return target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "e3b0edad-55db-5de9-ae4f-f154357d711a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916d8aa5-158f-46f4-babe-981a391fd88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916d8aa5-158f-46f4-babe-981a391fd88b.jpg?1",
             "name": "Ironwright's Cleansing",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "0a437bde-70d9-5efc-9a6a-c194179f58a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg?1",
             "name": "Lone Rider // It That Rides as One",
             "text": "First strike, lifelink\nAt the beginning of the end step, if you gained 3 or more life this turn, transform Lone Rider.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "d5b0032c-a988-5339-b2af-d23dc19b8426",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/a/9a55b60a-5d90-4f73-984e-53fdcc0366e4.jpg?1",
             "name": "Lone Rider // It That Rides as One",
             "text": "First strike, trample, lifelink",
             "colours": [],
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "e4f7e0b8-2f50-597e-b332-e7037bff95ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568323c-b631-48b6-b6da-4dc29d330a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568323c-b631-48b6-b6da-4dc29d330a12.jpg?1",
             "name": "Long Road Home",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "aa53d0e7-f7a0-5f07-b864-dd56f162b93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360f4759-c178-4ac2-b561-c81e13f67740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360f4759-c178-4ac2-b561-c81e13f67740.jpg?1",
             "name": "Lunarch Mantle",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}, Sacrifice a permanent: This creature gains flying until end of turn.\"",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "05482b05-a4e9-504b-ac5d-cb809194f468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e37aa2-d898-47f5-9679-5717bfa25688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e37aa2-d898-47f5-9679-5717bfa25688.jpg?1",
             "name": "Peace of Mind",
             "text": "{W}, Discard a card: You gain 3 life.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "3fd26259-6256-5b9d-8fd3-af7e36967f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5edd8d-8e10-4414-a326-95a672dfcff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5edd8d-8e10-4414-a326-95a672dfcff7.jpg?1",
             "name": "Providence",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, your life total becomes 26.\nYour life total becomes 26.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "00a51f75-8484-5d49-bc0c-ae5dff205332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf153f4d-0d37-41a9-80d8-7f2adaad79c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf153f4d-0d37-41a9-80d8-7f2adaad79c7.jpg?1",
             "name": "Repel the Abominable",
             "text": "Prevent all damage that would be dealt this turn by non-Human sources.",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "9c437fbc-ae92-5adc-8672-9bb339a9a3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d839c5a-dc35-4eaa-9cf0-b6e002815726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d839c5a-dc35-4eaa-9cf0-b6e002815726.jpg?1",
             "name": "Sanctifier of Souls",
             "text": "Whenever another creature enters the battlefield under your control, Sanctifier of Souls gets +1/+1 until end of turn.\n{2}{W}, Exile a creature card from your graveyard: Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -1414,7 +1414,7 @@
         },
         {
             "id": "274b02fc-18c3-5ce7-b3a7-a2c61636ebea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4624976-3773-4a1e-b725-5f6efce147a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4624976-3773-4a1e-b725-5f6efce147a5.jpg?1",
             "name": "Selfless Spirit",
             "text": "Flying\nSacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "0506e6a0-df3a-56f5-8e03-7656006cd5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc32f1d-dee7-4f71-a652-26a006e6020a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc32f1d-dee7-4f71-a652-26a006e6020a.jpg?1",
             "name": "Sigarda's Aid",
             "text": "You may cast Aura and Equipment spells as though they had flash.\nWhenever an Equipment enters the battlefield under your control, you may attach it to target creature you control.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "910708b9-cef0-538a-9fce-0cd329d47f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e798c7-0cbc-444e-8033-629baec7dca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e798c7-0cbc-444e-8033-629baec7dca8.jpg?1",
             "name": "Sigardian Priest",
             "text": "{1}, {T}: Tap target non-Human creature.",
             "colours": [
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "8279139e-363d-5bd0-bbd9-ca3c658164a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618aa2d-d5b3-41e6-978f-2c8292f7f896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618aa2d-d5b3-41e6-978f-2c8292f7f896.jpg?1",
             "name": "Spectral Reserves",
             "text": "Put two 1/1 white Spirit creature tokens with flying onto the battlefield. You gain 2 life.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "91252f81-6e45-54b5-9044-85542d0887dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b65a7-d385-428b-986c-a0d9283a5f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b65a7-d385-428b-986c-a0d9283a5f75.jpg?1",
             "name": "Steadfast Cathar",
             "text": "Whenever Steadfast Cathar attacks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -1583,7 +1583,7 @@
         },
         {
             "id": "35967a39-3539-5069-b272-20de8c72c3ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af01371c-cd09-4882-9caf-04426dd4c965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af01371c-cd09-4882-9caf-04426dd4c965.jpg?1",
             "name": "Subjugator Angel",
             "text": "Flying\nWhen Subjugator Angel enters the battlefield, tap all creatures your opponents control.",
             "colours": [
@@ -1617,7 +1617,7 @@
         },
         {
             "id": "15021980-357c-597c-9412-b378caf2c406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cee38-5e24-49d0-870c-22843ed4e101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0cee38-5e24-49d0-870c-22843ed4e101.jpg?1",
             "name": "Thalia, Heretic Cathar",
             "text": "First strike\nCreatures and nonbasic lands your opponents control enter the battlefield tapped.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "50c80ce4-7b6c-559c-adbd-ac89e921b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9930d08d-5965-4c16-a84d-43c8ccf2ad0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9930d08d-5965-4c16-a84d-43c8ccf2ad0b.jpg?1",
             "name": "Thalia's Lancers",
             "text": "First strike\nWhen Thalia's Lancers enters the battlefield, you may search your library for a legendary card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "59375340-7188-5bd8-8fa6-b86ca5a690cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b7cd60-e3b9-4dd8-ad3c-a687f642147f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b7cd60-e3b9-4dd8-ad3c-a687f642147f.jpg?1",
             "name": "Thraben Standard Bearer",
             "text": "{1}{W}, {T}, Discard a card: Put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "aee8c7a4-24fb-5f64-ad8f-0c0bcb8ef379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdb7f1c-6139-4e68-8706-01f373548a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdb7f1c-6139-4e68-8706-01f373548a4f.jpg?1",
             "name": "Advanced Stitchwing",
             "text": "Flying\n{2}{U}, Discard two cards: Return Advanced Stitchwing from your graveyard to the battlefield tapped.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "f0b412e0-7bdb-52a9-bacd-a40f4ec0cdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d85d58-eae3-4f9d-8f54-440fa6ded95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d85d58-eae3-4f9d-8f54-440fa6ded95b.jpg?1",
             "name": "Chilling Grasp",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.\nMadness {3}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "be51fb62-e5e3-5d1a-9c88-9a6add06e376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740ad768-2be0-4e5a-9d60-6c7ec4bdc107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740ad768-2be0-4e5a-9d60-6c7ec4bdc107.jpg?1",
             "name": "Coax from the Blind Eternities",
             "text": "You may choose an Eldrazi card you own from outside the game or in exile, reveal that card, and put it into your hand.",
             "colours": [
@@ -1823,7 +1823,7 @@
         },
         {
             "id": "b68d10da-b9e2-50d0-b559-defe6825a478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edb76bd-db4b-4279-8eaa-dfdf5952eafc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9edb76bd-db4b-4279-8eaa-dfdf5952eafc.jpg?1",
             "name": "Contingency Plan",
             "text": "Look at the top five cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "2241aab6-5f91-50da-bc56-af0f08f45425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17cf756-ec41-4934-8906-4276277c1470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17cf756-ec41-4934-8906-4276277c1470.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "16aef24b-0215-5551-8b15-24b14444c568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg?1",
             "name": "Curious Homunculus // Voracious Reader",
             "text": "{T}: Add {C} to your mana pool. Spend this mana only to cast an instant or sorcery spell.\nAt the beginning of your upkeep, if there are three or more instant and/or sorcery cards in your graveyard, transform Curious Homunculus.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "fdf2f2d9-484e-5fd3-b060-d67be380c513",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22e816af-df55-4a3f-a6e7-0ff3bb1b45b5.jpg?1",
             "name": "Curious Homunculus // Voracious Reader",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [],
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "1b59d5e1-a6e9-596b-a5c1-a9b4e66e57fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab850c5-6f5e-41b7-ab52-094579caca12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab850c5-6f5e-41b7-ab52-094579caca12.jpg?1",
             "name": "Displace",
             "text": "Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "321ceb85-30d5-5e14-8a42-15136755080e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1",
             "name": "Docent of Perfection // Final Iteration",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, put a 1/1 blue Human Wizard creature token onto the battlefield. Then if you control three or more Wizards, transform Docent of Perfection.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "f5fd28b8-2ca9-5b9c-809e-b683b36f6295",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1",
             "name": "Docent of Perfection // Final Iteration",
             "text": "Flying\nWizards you control get +2/+1 and have flying.\nWhenever you cast an instant or sorcery spell, put a 1/1 blue Human Wizard creature token onto the battlefield.",
             "colours": [],
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "a89b9107-02b2-506f-a380-3bbd688ec9e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dffa444-92ff-41d8-8b55-8896808bbfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dffa444-92ff-41d8-8b55-8896808bbfab.jpg?1",
             "name": "Drag Under",
             "text": "Return target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "d32ca20b-9397-533c-9238-dd0c96d19621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e692b8-f71d-485b-b37b-71259dc6c48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e692b8-f71d-485b-b37b-71259dc6c48e.jpg?1",
             "name": "Enlightened Maniac",
             "text": "When Enlightened Maniac enters the battlefield, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "6eb8577b-b1fd-549c-8d04-2c26fcef87bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c22e0a-81c5-485f-81f0-3e85397108e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c22e0a-81c5-485f-81f0-3e85397108e0.jpg?1",
             "name": "Exultant Cultist",
             "text": "When Exultant Cultist dies, draw a card.",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "118ea154-677d-52db-aa68-56d499345b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0894d76b-801a-4e3b-8378-bfa81fe24d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0894d76b-801a-4e3b-8378-bfa81fe24d59.jpg?1",
             "name": "Fogwalker",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Fogwalker enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "58de8d65-2a87-569c-8edb-fe80a1f86645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a67dd08-0064-4750-adf5-07bacb0296eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a67dd08-0064-4750-adf5-07bacb0296eb.jpg?1",
             "name": "Fortune's Favor",
             "text": "Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "1783e462-21fb-5dd7-9449-000f1d9b2c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4fcbc-15b2-4370-a267-bc2c63ba2aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4fcbc-15b2-4370-a267-bc2c63ba2aa5.jpg?1",
             "name": "Geist of the Archives",
             "text": "Defender\nAt the beginning of your upkeep, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "78df89c8-6aa3-57e8-bf41-c4943af674f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1",
             "name": "Grizzled Angler // Grisly Anglerfish",
             "text": "{T}: Put the top two cards of your library into your graveyard. Then if there is a colorless creature card in your graveyard, transform Grizzled Angler.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "1e3062d1-c2a5-545d-97d6-2137eade0190",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1",
             "name": "Grizzled Angler // Grisly Anglerfish",
             "text": "{6}: Creatures your opponents control attack this turn if able.",
             "colours": [],
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "1498e66b-3ddf-54e1-a4c4-a76a664a4bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9865100f-dddc-407e-a379-2c285475ec89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9865100f-dddc-407e-a379-2c285475ec89.jpg?1",
             "name": "Identity Thief",
             "text": "Whenever Identity Thief attacks, you may exile another target nontoken creature. If you do, Identity Thief becomes a copy of that creature until end of turn. Return the exiled card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "23612c12-a2cd-5945-97b4-db8d5ced1b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7990ebba-e9f2-4ba4-a352-e26ec81d4bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7990ebba-e9f2-4ba4-a352-e26ec81d4bed.jpg?1",
             "name": "Imprisoned in the Moon",
             "text": "Enchant creature, land, or planeswalker\nEnchanted permanent is a colorless land with \"{T}: Add {C} to your mana pool\" and loses all other card types and abilities.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "cba50d4b-c1ec-5baa-a7a3-7ac7f0b82f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6ed0b-40ba-407d-94de-05a705e79b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6ed0b-40ba-407d-94de-05a705e79b95.jpg?1",
             "name": "Ingenious Skaab",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{U}: Ingenious Skaab gets +1/-1 until end of turn.",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "bc071fad-cdcd-5a6a-80e8-2f63ec93c61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f228e-46ff-43e2-bc1d-c2d2df443c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325f228e-46ff-43e2-bc1d-c2d2df443c51.jpg?1",
             "name": "Laboratory Brute",
             "text": "When Laboratory Brute enters the battlefield, put the top four cards of your library into your graveyard.",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "3e18b449-9e68-5381-9394-4ded42d56b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614db3-480f-41f6-91ad-66301fc8e394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614db3-480f-41f6-91ad-66301fc8e394.jpg?1",
             "name": "Lunar Force",
             "text": "When an opponent casts a spell, sacrifice Lunar Force and counter that spell.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "5dff60f1-8ccc-59e9-859b-6708f99353ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42391fa7-6172-487c-b8aa-d41ab7c64973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42391fa7-6172-487c-b8aa-d41ab7c64973.jpg?1",
             "name": "Mausoleum Wanderer",
             "text": "Flying\nWhenever another Spirit enters the battlefield under your control, Mausoleum Wanderer gets +1/+1 until end of turn.\nSacrifice Mausoleum Wanderer: Counter target instant or sorcery spell unless its controller pays {X}, where X is Mausoleum Wanderer's power.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "6e2deb37-f4a5-54be-acdb-12bfd1615407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6522a-b9a0-4185-b5ba-c20fa1b772eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6522a-b9a0-4185-b5ba-c20fa1b772eb.jpg?1",
             "name": "Mind's Dilation",
             "text": "Whenever an opponent casts his or her first spell each turn, that player exiles the top card of his or her library. If it's a nonland card, you may cast it without paying its mana cost.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "f90110bf-659e-5ce4-8907-082636057a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40965d3b-9b8f-4706-9364-64f758a768e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40965d3b-9b8f-4706-9364-64f758a768e6.jpg?1",
             "name": "Nebelgast Herald",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever Nebelgast Herald or another Spirit enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "4e60474b-93e0-538b-b283-cdfc1500bd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2301c8-0ca8-4b26-a232-1df90effcb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2301c8-0ca8-4b26-a232-1df90effcb42.jpg?1",
             "name": "Niblis of Frost",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast an instant or sorcery spell, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "7cd27519-352c-5a76-81d2-75f704a84588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3247a4-f99a-4fff-a3a1-c3d51ed1a754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3247a4-f99a-4fff-a3a1-c3d51ed1a754.jpg?1",
             "name": "Scour the Laboratory",
             "text": "Delirium \u2014 Scour the Laboratory costs {2} less to cast if there are four or more card types among cards in your graveyard.\nDraw three cards.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "91be5b53-346d-5f93-88df-871ac4fdcc5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a022c983-0fb8-4e8c-9ba3-9356ad340f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a022c983-0fb8-4e8c-9ba3-9356ad340f66.jpg?1",
             "name": "Spontaneous Mutation",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "67afe4ef-7f85-551c-a778-8865ff426744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b75794d-3334-4b4d-9446-0a251dd3bd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b75794d-3334-4b4d-9446-0a251dd3bd15.jpg?1",
             "name": "Summary Dismissal",
             "text": "Exile all other spells and counter all abilities.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "3dba0b84-269e-5e0e-ba78-febcee1478b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3584150-4f09-4c15-b13e-707bd91b3004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3584150-4f09-4c15-b13e-707bd91b3004.jpg?1",
             "name": "Take Inventory",
             "text": "Draw a card, then draw cards equal to the number of cards named Take Inventory in your graveyard.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "72f20f7c-2170-557c-bd2d-de360e5eed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ac8da-7497-4b07-af86-29bac1361c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ac8da-7497-4b07-af86-29bac1361c8e.jpg?1",
             "name": "Tattered Haunter",
             "text": "Flying\nTattered Haunter can block only creatures with flying.",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "6c52c93d-8478-5c29-8810-f18478015e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7573c2-484c-4b4e-9c26-0f005bd1daee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7573c2-484c-4b4e-9c26-0f005bd1daee.jpg?1",
             "name": "Turn Aside",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "7e5fc133-fe8a-57d7-8d05-084b988bb194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5dac3d-4b49-44c4-a7b2-0a99485252c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5dac3d-4b49-44c4-a7b2-0a99485252c9.jpg?1",
             "name": "Unsubstantiate",
             "text": "Return target spell or creature to its owner's hand.",
             "colours": [
@@ -2854,7 +2854,7 @@
         },
         {
             "id": "d1403cc9-bc6d-5ab3-90c5-c824fbe09fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264baa9a-67fc-4903-9ed8-a4ce6912a184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264baa9a-67fc-4903-9ed8-a4ce6912a184.jpg?1",
             "name": "Wharf Infiltrator",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhenever Wharf Infiltrator deals combat damage to a player, you may draw a card. If you do, discard a card.\nWhenever you discard a creature card, you may pay {2}. If you do, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "cebbc3b7-7bda-5b14-8dd8-2c284798dba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bb97c6-d2ff-459f-986e-73e30534d865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bb97c6-d2ff-459f-986e-73e30534d865.jpg?1",
             "name": "Boon of Emrakul",
             "text": "Enchant creature\nEnchanted creature gets +3/-3.",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "d033495d-66ca-5d90-848c-4baf4615f423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f123e-aad9-4f3e-9f43-1d1be359affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71f123e-aad9-4f3e-9f43-1d1be359affb.jpg?1",
             "name": "Borrowed Malevolence",
             "text": "Escalate {2} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both \u2014\n\u2022 Target creature gets +1/+1 until end of turn.\n\u2022 Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "43e0a613-0250-5746-b043-450a137c8c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a23adea-9f4a-409c-a37d-323eee781273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a23adea-9f4a-409c-a37d-323eee781273.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "3a4e88d7-2228-5cef-aa24-ce68b17a981b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67784b3-eb55-452e-b965-f63220b88896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67784b3-eb55-452e-b965-f63220b88896.jpg?1",
             "name": "Certain Death",
             "text": "Destroy target creature. Its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "de291617-a2c1-5392-bcce-c846d62e3ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb94a02f-4660-45b6-8a39-941b710cf8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb94a02f-4660-45b6-8a39-941b710cf8f3.jpg?1",
             "name": "Collective Brutality",
             "text": "Escalate\u2014\nDiscard a card. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Target opponent reveals his or her hand. You choose an instant or sorcery card from it. That player discards that card.\n\u2022 Target creature gets -2/-2 until end of turn.\n\u2022 Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "2af70103-20e1-596c-8301-fcb991642b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629e37d1-c0f3-44f2-926e-41eb3687c1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/629e37d1-c0f3-44f2-926e-41eb3687c1d9.jpg?1",
             "name": "Cryptbreaker",
             "text": "{1}{B}, {T}, Discard a card: Put a 2/2 black Zombie creature token onto the battlefield.\nTap three untapped Zombies you control: You draw a card and you lose 1 life.",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "b33e2f83-6bb6-55c1-8651-ae591b4c8439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5978bd-a696-430e-8c35-729d96eec53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5978bd-a696-430e-8c35-729d96eec53e.jpg?1",
             "name": "Dark Salvation",
             "text": "Target player puts X 2/2 black Zombie creature tokens onto the battlefield, then up to one target creature gets -1/-1 until end of turn for each Zombie that player controls.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "9f80d052-a3f3-55c4-9a12-c117cad408a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34a6fdc-5be9-4cb4-97cc-de63e8a0dde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34a6fdc-5be9-4cb4-97cc-de63e8a0dde1.jpg?1",
             "name": "Dusk Feaster",
             "text": "Delirium \u2014 Dusk Feaster costs {2} less to cast if there are four or more card types among cards in your graveyard.\nFlying",
             "colours": [
@@ -3151,7 +3151,7 @@
         },
         {
             "id": "3e828497-a35d-545d-a8b3-6eec637edf96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f4c713-089b-497c-8c0f-826cab10aa87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f4c713-089b-497c-8c0f-826cab10aa87.jpg?1",
             "name": "Gavony Unhallowed",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Gavony Unhallowed.",
             "colours": [
@@ -3185,7 +3185,7 @@
         },
         {
             "id": "39733f58-1a2d-52a5-8a4a-876e5a585095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc17697-9db9-41d4-aacf-b2f2e6ff80cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc17697-9db9-41d4-aacf-b2f2e6ff80cf.jpg?1",
             "name": "Graf Harvest",
             "text": "Zombies you control have menace. (They can't be blocked except by two or more creatures.)\n{3}{B}, Exile a creature card from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "d8483bbd-7271-5fd3-9892-38473dc69f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dedaff6-bd69-4fe3-a301-f7ea7c2f2861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dedaff6-bd69-4fe3-a301-f7ea7c2f2861.jpg?1",
             "name": "Graf Rats // Chittering Host",
             "text": "At the beginning of combat on your turn, if you both own and control Graf Rats and a creature named Midnight Scavengers, exile them, then meld them into Chittering Host.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "656184c7-05fc-5194-bc28-6931a8ba451b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7c8b7-ca77-47a0-8965-949723ec902d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7c8b7-ca77-47a0-8965-949723ec902d.jpg?1",
             "name": "Haunted Dead",
             "text": "When Haunted Dead enters the battlefield, put a 1/1 white Spirit creature token with flying onto the battlefield.\n{1}{B}, Discard two cards: Return Haunted Dead from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "b695494a-8e71-5c42-a3ae-150d1c9ceccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6ac7d2-0127-49a8-b7d2-a38308d3c27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6ac7d2-0127-49a8-b7d2-a38308d3c27b.jpg?1",
             "name": "Liliana, the Last Hope",
             "text": "+1: Up to one target creature gets -2/-1 until your next turn.\n\u22122: Put the top two cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.\n\u22127: You get an emblem with \"At the beginning of your end step, put X 2/2 black Zombie creature tokens onto the battlefield, where X is two plus the number of Zombies you control.\"",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "e9a60a6f-eb8d-512c-b994-38f5b2cc8d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad542aa9-5c0e-4962-b167-9071e66f9c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad542aa9-5c0e-4962-b167-9071e66f9c03.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -3355,7 +3355,7 @@
         },
         {
             "id": "b48181d5-abd9-5080-9086-6fdeda1d057b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d8354b-df56-4294-9f8a-b7c92e31b88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d8354b-df56-4294-9f8a-b7c92e31b88e.jpg?1",
             "name": "Markov Crusader",
             "text": "Lifelink\nMarkov Crusader has haste as long as you control another Vampire.",
             "colours": [
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "639f197b-8f7f-5981-9d9d-c652c1a970b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a57187c-f0ec-40de-b725-786f787b00a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a57187c-f0ec-40de-b725-786f787b00a2.jpg?1",
             "name": "Midnight Scavengers // Chittering Host",
             "text": "When Midnight Scavengers enters the battlefield, you may return target creature card with converted mana cost 3 or less from your graveyard to your hand.\n(Melds with Graf Rats.)",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "3f8cdafb-10d5-510a-b908-49dd4c80fff3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70b94f21-4f01-46f8-ad50-e2bb0b68ea33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b94f21-4f01-46f8-ad50-e2bb0b68ea33.jpg?1",
             "name": "Chittering Host",
             "text": "When Midnight Scavengers enters the battlefield, you may return target creature card with converted mana cost 3 or less from your graveyard to your hand.\n(Melds with Graf Rats.)",
             "colours": [],
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "61a5fdce-439a-5c59-ad9f-48e55e9aa99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2eb849-b3ab-4d26-86c5-235c8161cf2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2eb849-b3ab-4d26-86c5-235c8161cf2a.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3490,7 +3490,7 @@
         },
         {
             "id": "d4b52df0-7bc0-5041-b3ac-510944cfe1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de44166d-3db6-4ece-985d-b8977c25e29f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de44166d-3db6-4ece-985d-b8977c25e29f.jpg?1",
             "name": "Noosegraf Mob",
             "text": "Noosegraf Mob enters the battlefield with five +1/+1 counters on it.\nWhenever a player casts a spell, remove a +1/+1 counter from Noosegraf Mob. If you do, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "0e41de37-a8b4-5741-be47-7f232262e635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2028f577-e0fb-48dd-89c6-f4a000b0a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2028f577-e0fb-48dd-89c6-f4a000b0a881.jpg?1",
             "name": "Oath of Liliana",
             "text": "When Oath of Liliana enters the battlefield, each opponent sacrifices a creature.\nAt the beginning of each end step, if a planeswalker entered the battlefield under your control this turn, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "5427de4e-98fa-50ac-b899-30b39859451c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868067ce-3415-4239-b7c3-d3ad4c03fb8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868067ce-3415-4239-b7c3-d3ad4c03fb8d.jpg?1",
             "name": "Olivia's Dragoon",
             "text": "Discard a card: Olivia's Dragoon gains flying until end of turn.",
             "colours": [
@@ -3593,7 +3593,7 @@
         },
         {
             "id": "f26941ad-592b-5475-95af-bbc643d3f37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9fcf7c-8785-4285-b583-7060edabc3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9fcf7c-8785-4285-b583-7060edabc3c6.jpg?1",
             "name": "Prying Questions",
             "text": "Target opponent loses 3 life and puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "5ac13717-8c8c-5070-910a-2d2507659bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e5b5d5-691c-44f0-8fab-fdecdd4c721d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e5b5d5-691c-44f0-8fab-fdecdd4c721d.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "e145b644-f955-58f9-9922-397d6c2c3ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe81c78f-e3e2-4513-9711-896e6a1e6aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe81c78f-e3e2-4513-9711-896e6a1e6aba.jpg?1",
             "name": "Ruthless Disposal",
             "text": "As an additional cost to cast Ruthless Disposal, discard a card and sacrifice a creature.\nTwo target creatures each get -13/-13 until end of turn.",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "76c99e60-9c6a-59ca-a909-96a0ae3d258e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f63897-15a1-4b34-9916-d9df62f66785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f63897-15a1-4b34-9916-d9df62f66785.jpg?1",
             "name": "Skirsdag Supplicant",
             "text": "{B}, {T}, Discard a card: Each player loses 2 life.",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "d060ca5b-ded0-5119-a31e-6cc1260863c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b9847-7ef7-4fcc-ba16-8f2859d53fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9b9847-7ef7-4fcc-ba16-8f2859d53fe6.jpg?1",
             "name": "Strange Augmentation",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nDelirium \u2014 Enchanted creature gets an additional +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -3758,7 +3758,7 @@
         },
         {
             "id": "439e5e45-6ec8-52a8-92c6-1d444fb2c7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a8403e-bf4c-4aae-9102-188f49c61ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a8403e-bf4c-4aae-9102-188f49c61ddf.jpg?1",
             "name": "Stromkirk Condemned",
             "text": "Discard a card: Vampires you control get +1/+1 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -3793,7 +3793,7 @@
         },
         {
             "id": "cd115834-83c7-59b9-b21e-57c88371d5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2974e18b-be17-4059-9f29-7afe1d1a51eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2974e18b-be17-4059-9f29-7afe1d1a51eb.jpg?1",
             "name": "Succumb to Temptation",
             "text": "You draw two cards and you lose 2 life.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "a52f763d-cdf5-5a72-8baf-35827270e36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0f72e0-1254-4bfb-b405-d64012dc171a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0f72e0-1254-4bfb-b405-d64012dc171a.jpg?1",
             "name": "Thraben Foulbloods",
             "text": "Delirium \u2014 Thraben Foulbloods gets +1/+1 and has menace as long as there are four or more card types among cards in your graveyard. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3860,7 +3860,7 @@
         },
         {
             "id": "e23c9d1a-66ba-5764-8dd8-dd0a4bea766c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305bd19a-ae5e-46ca-8ff7-27810c968315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/305bd19a-ae5e-46ca-8ff7-27810c968315.jpg?1",
             "name": "Tree of Perdition",
             "text": "Defender\n{T}: Exchange target opponent's life total with Tree of Perdition's toughness.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "0249922a-bd27-55e7-9bdf-73549c655870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954d53f3-ebbe-48e0-9e1a-7019d2b0740c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954d53f3-ebbe-48e0-9e1a-7019d2b0740c.jpg?1",
             "name": "Vampire Cutthroat",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3929,7 +3929,7 @@
         },
         {
             "id": "f4682753-4359-5150-9b2a-0df7094c18c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg?1",
             "name": "Voldaren Pariah // Abolisher of Bloodlines",
             "text": "Flying\nSacrifice three other creatures: Transform Voldaren Pariah.\nMadness {B}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3964,7 +3964,7 @@
         },
         {
             "id": "a9495c75-2e68-58ad-9a26-311d5f9cc35e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25baac6c-5bb4-4ecc-b1d5-fced52087bd9.jpg?1",
             "name": "Voldaren Pariah // Abolisher of Bloodlines",
             "text": "Flying\nWhen this creature transforms into Abolisher of Bloodlines, target opponent sacrifices three creatures.",
             "colours": [],
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "66295061-60b9-54db-ade5-155d6bbf1bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1bf0dd-825c-4c8a-a48d-84f35fbe5901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1bf0dd-825c-4c8a-a48d-84f35fbe5901.jpg?1",
             "name": "Wailing Ghoul",
             "text": "When Wailing Ghoul enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "c7504f2c-7c93-510e-8dda-60636d9ae7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5234ac-e308-417d-96b0-d860f3186e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5234ac-e308-417d-96b0-d860f3186e6b.jpg?1",
             "name": "Weirded Vampire",
             "text": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "152011ca-24fd-50db-bd56-4c3bf6c8e252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7ba428-5a35-4062-8e16-39eb927cb316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7ba428-5a35-4062-8e16-39eb927cb316.jpg?1",
             "name": "Whispers of Emrakul",
             "text": "Target opponent discards a card at random.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, that player discards two cards at random instead.",
             "colours": [
@@ -4098,7 +4098,7 @@
         },
         {
             "id": "f2c10c1a-e847-5ff9-bf09-5ea4e293514d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c0b3b3-bb62-42c5-9869-386af0540a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c0b3b3-bb62-42c5-9869-386af0540a9b.jpg?1",
             "name": "Abandon Reason",
             "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "256b47ac-76d4-5a46-871e-e42b0f8a97f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f33aaa1-cbaa-40a9-889e-3eca26b3a549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f33aaa1-cbaa-40a9-889e-3eca26b3a549.jpg?1",
             "name": "Alchemist's Greeting",
             "text": "Alchemist's Greeting deals 4 damage to target creature.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "c6947287-28c0-5416-b4e1-12fe952a54d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8603c493-afb0-47a1-b4e3-9848b3824840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8603c493-afb0-47a1-b4e3-9848b3824840.jpg?1",
             "name": "Assembled Alphas",
             "text": "Whenever Assembled Alphas blocks or becomes blocked by a creature, Assembled Alphas deals 3 damage to that creature and 3 damage to that creature's controller.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "b6bf6db4-c2e9-5811-bc25-20564cc52f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0232f188-44f2-4aee-963c-6f6edc4a21ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0232f188-44f2-4aee-963c-6f6edc4a21ac.jpg?1",
             "name": "Bedlam Reveler",
             "text": "Bedlam Reveler costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "d9425806-f510-56a8-bd2a-f4a0fa12b7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6982bde-1fa3-48fa-803d-a45d6acbc2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6982bde-1fa3-48fa-803d-a45d6acbc2fe.jpg?1",
             "name": "Blood Mist",
             "text": "At the beginning of combat on your turn, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "c3fa8e57-ccca-5795-a4e9-10b2d83229ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bb2e6d-2ead-4ce3-8e5e-fc6900435583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bb2e6d-2ead-4ce3-8e5e-fc6900435583.jpg?1",
             "name": "Bold Impaler",
             "text": "{2}{R}: Bold Impaler gets +2/+0 until end of turn.",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "aebde1ad-3f20-59a0-bbc6-7a7794701a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd91a194-6043-4c2d-afc8-427c38996ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd91a194-6043-4c2d-afc8-427c38996ef4.jpg?1",
             "name": "Borrowed Hostility",
             "text": "Escalate {3} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both \u2014\n\u2022 Target creature gets +3/+0 until end of turn.\n\u2022 Target creature gains first strike until end of turn.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "50ed97df-c060-5f6b-84f3-2dd1b4fc263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8e2ece-3c66-4f34-9042-fc02639c6a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8e2ece-3c66-4f34-9042-fc02639c6a79.jpg?1",
             "name": "Brazen Wolves",
             "text": "Whenever Brazen Wolves attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "c68f1b69-2b72-5d26-99b7-ece48f4fa716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960883f-3813-412b-9a5b-f8cf8d566fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8960883f-3813-412b-9a5b-f8cf8d566fac.jpg?1",
             "name": "Collective Defiance",
             "text": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Target player discards all the cards in his or her hand, then draws that many cards.\n\u2022 Collective Defiance deals 4 damage to target creature.\n\u2022 Collective Defiance deals 3 damage to target opponent.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "99cbc65e-59b7-5bcc-9dc2-e4ee565a5ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg?1",
             "name": "Conduit of Storms // Conduit of Emrakul",
             "text": "Whenever Conduit of Storms attacks, add {R} to your mana pool at the beginning of your next main phase this turn.\n{3}{R}{R}: Transform Conduit of Storms.",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "091d8bee-913c-5277-a9d6-13a03c772bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f95145a-41a1-478e-bf8a-ea8838d6f9b1.jpg?1",
             "name": "Conduit of Storms // Conduit of Emrakul",
             "text": "Whenever Conduit of Emrakul attacks, add {C}{C} to your mana pool at the beginning of your next main phase this turn.",
             "colours": [],
@@ -4464,7 +4464,7 @@
         },
         {
             "id": "0b5ebbfe-84bf-50ae-a2b2-972e8b706461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06f9eb-112e-458b-83c8-3761df6d60ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd06f9eb-112e-458b-83c8-3761df6d60ff.jpg?1",
             "name": "Deranged Whelp",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "9c766fd0-8a67-568d-8466-051f77e59a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad2acb-073b-4a98-be8c-2ea39ca85496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad2acb-073b-4a98-be8c-2ea39ca85496.jpg?1",
             "name": "Distemper of the Blood",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "57e77108-0148-5d43-8c42-3225507a7ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2023b3-5999-44b1-a67f-3f2a76cb2d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2023b3-5999-44b1-a67f-3f2a76cb2d14.jpg?1",
             "name": "Falkenrath Reaver",
             "text": "",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "e3367176-bd52-5b9d-964f-6ec287135fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a957d6-fc14-453a-a250-63fc130e330d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a957d6-fc14-453a-a250-63fc130e330d.jpg?1",
             "name": "Furyblade Vampire",
             "text": "Trample\nAt the beginning of combat on your turn, you may discard a card. If you do, Furyblade Vampire gets +3/+0 until end of turn.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "c1398e83-8956-59c0-acdf-c4f5a7ce1440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6a4367-bbee-43b8-b5dd-28498f8e2ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6a4367-bbee-43b8-b5dd-28498f8e2ede.jpg?1",
             "name": "Galvanic Bombardment",
             "text": "Galvanic Bombardment deals X damage to target creature, where X is 2 plus the number of cards named Galvanic Bombardment in your graveyard.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "68858e2c-9998-566e-a653-52cf1120957a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900e494-962d-48c6-8e78-66a489be4bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900e494-962d-48c6-8e78-66a489be4bb2.jpg?1",
             "name": "Hanweir Garrison // Hanweir, the Writhing Township",
             "text": "Whenever Hanweir Garrison attacks, put two 1/1 red Human creature tokens onto the battlefield tapped and attacking.\n(Melds with Hanweir Battlements.)",
             "colours": [
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "90a1aef4-314c-580d-8f64-fcddcafb474f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg?1",
             "name": "Hanweir, the Writhing Township",
             "text": "Whenever Hanweir Garrison attacks, put two 1/1 red Human creature tokens onto the battlefield tapped and attacking.\n(Melds with Hanweir Battlements.)",
             "colours": [],
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "432c740b-50c5-549d-a352-6eb854c53613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f3cc4f-7943-4025-b332-b40653b13014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f3cc4f-7943-4025-b332-b40653b13014.jpg?1",
             "name": "Harmless Offering",
             "text": "Target opponent gains control of target permanent you control.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "bc1e398f-fe7c-5dd9-aa2e-415dc5ef94e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba7acc0-6ef0-4c34-be23-118e1872271f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba7acc0-6ef0-4c34-be23-118e1872271f.jpg?1",
             "name": "Impetuous Devils",
             "text": "Trample, haste\nWhen Impetuous Devils attacks, up to one target creature defending player controls blocks it this combat if able.\nAt the beginning of the end step, sacrifice Impetuous Devils.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "5c5cba30-903c-5142-a654-c3e1f145c1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf464f61-8a7f-493b-a80f-2f2b0ebd8bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf464f61-8a7f-493b-a80f-2f2b0ebd8bf6.jpg?1",
             "name": "Incendiary Flow",
             "text": "Incendiary Flow deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "7f40fa2d-1065-5a16-b6f5-6cb8ab690ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb56491b-bad7-44da-8aa5-91ffd875e76a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb56491b-bad7-44da-8aa5-91ffd875e76a.jpg?1",
             "name": "Insatiable Gorgers",
             "text": "Insatiable Gorgers attacks each combat if able.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "ba490776-6b96-555e-9528-90c705a3d945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2049072-5901-4edd-8305-ce55f256bca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2049072-5901-4edd-8305-ce55f256bca5.jpg?1",
             "name": "Make Mischief",
             "text": "Make Mischief deals 1 damage to target creature or player. Put a 1/1 red Devil creature token onto the battlefield. It has \"When this creature dies, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "889044b3-cc97-5e91-85b2-48e9b1cabb2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7e33a8-765b-4909-a5c6-5fe8f8774a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7e33a8-765b-4909-a5c6-5fe8f8774a51.jpg?1",
             "name": "Mirrorwing Dragon",
             "text": "Flying\nWhenever a player casts an instant or sorcery spell that targets only Mirrorwing Dragon, that player copies that spell for each other creature he or she controls that the spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "5d9149e0-82b0-5c57-aa06-d00b2df95a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6cb8b0-e3a5-4a94-845d-3b286aa392ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6cb8b0-e3a5-4a94-845d-3b286aa392ac.jpg?1",
             "name": "Nahiri's Wrath",
             "text": "As an additional cost to cast Nahiri's Wrath, discard X cards.\nNahiri's Wrath deals damage equal to the total converted mana cost of the discarded cards to each of up to X target creatures and/or planeswalkers.",
             "colours": [
@@ -4932,7 +4932,7 @@
         },
         {
             "id": "57554642-bb44-5526-a351-d58f0b7f55f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34409e34-04e9-4279-8d21-6ef362b20b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34409e34-04e9-4279-8d21-6ef362b20b72.jpg?1",
             "name": "Otherworldly Outburst",
             "text": "Target creature gets +1/+0 until end of turn. When that creature dies this turn, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "f1556e6b-53e5-5850-947e-64a58cd3ca70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e58861-a548-4344-a37b-1c5764b144d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e58861-a548-4344-a37b-1c5764b144d9.jpg?1",
             "name": "Prophetic Ravings",
             "text": "Enchant creature\nEnchanted creature has haste and \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "42dea550-0519-54e9-a5fd-1782499b3f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5255da8-8511-48a7-98e5-ba43ca6e8681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5255da8-8511-48a7-98e5-ba43ca6e8681.jpg?1",
             "name": "Savage Alliance",
             "text": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Creatures target player controls gain trample until end of turn.\n\u2022 Savage Alliance deals 2 damage to target creature.\n\u2022 Savage Alliance deals 1 damage to each creature target opponent controls.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "72234756-e930-5912-8d31-01ef6578c056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782e5600-ac63-4f90-acbe-49c04d2840ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782e5600-ac63-4f90-acbe-49c04d2840ee.jpg?1",
             "name": "Shreds of Sanity",
             "text": "Return up to one target instant card and up to one target sorcery card from your graveyard to your hand, then discard a card. Exile Shreds of Sanity.",
             "colours": [
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "743fb3c8-3997-51c9-a514-4699be2e8d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1",
             "name": "Smoldering Werewolf // Erupting Dreadwolf",
             "text": "When Smoldering Werewolf enters the battlefield, it deals 1 damage to each of up to two target creatures.\n{4}{R}{R}: Transform Smoldering Werewolf.",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "81d2421f-34b6-5936-bde0-5aaa24784f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1",
             "name": "Smoldering Werewolf // Erupting Dreadwolf",
             "text": "Whenever Erupting Dreadwolf attacks, it deals 2 damage to target creature or player.",
             "colours": [],
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "5ce326fc-d4b8-56fd-8c55-d5c2bf55be72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c655b1dc-8df1-44c8-a963-bd0a671ec7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c655b1dc-8df1-44c8-a963-bd0a671ec7e5.jpg?1",
             "name": "Spreading Flames",
             "text": "Spreading Flames deals 6 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -5162,7 +5162,7 @@
         },
         {
             "id": "c3c0c30d-9431-519d-b57f-3378b2e29090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828db19a-ca0d-4b82-a4b6-451125865093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828db19a-ca0d-4b82-a4b6-451125865093.jpg?1",
             "name": "Stensia Banquet",
             "text": "Stensia Banquet deals damage to target opponent equal to the number of Vampires you control.\nDraw a card.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "4ce8abdf-9690-559a-8d7f-127b8cb54277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40c471-70c8-4171-a214-ce932c4c7e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee40c471-70c8-4171-a214-ce932c4c7e2e.jpg?1",
             "name": "Stensia Innkeeper",
             "text": "When Stensia Innkeeper enters the battlefield, tap target land an opponent controls. That land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "0b1489a2-f7f8-5d95-82d9-915d288ff101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa6a443-b23b-48ae-97bb-8fd4deec52c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa6a443-b23b-48ae-97bb-8fd4deec52c4.jpg?1",
             "name": "Stromkirk Occultist",
             "text": "Trample\nWhenever Stromkirk Occultist deals combat damage to a player, exile the top card of your library. Until end of turn, you may play that card.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5263,7 +5263,7 @@
         },
         {
             "id": "89079973-0e0c-51e0-998e-38af4980fc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c194ea-32a5-4683-a6da-4a93d9b4722e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c194ea-32a5-4683-a6da-4a93d9b4722e.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -5298,7 +5298,7 @@
         },
         {
             "id": "c55fd7a5-d0dc-5d80-b9b8-c83d69ab8331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg?1",
             "name": "Vildin-Pack Outcast // Dronepack Kindred",
             "text": "Trample\n{R}: Vildin-Pack Outcast gets +1/-1 until end of turn.\n{5}{R}{R}: Transform Vildin-Pack Outcast.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "8c6ab54f-9aeb-561d-9004-83a6ec0dd36b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/460f7733-c0a6-4439-a313-7b26ae6ee15b.jpg?1",
             "name": "Vildin-Pack Outcast // Dronepack Kindred",
             "text": "Trample\n{1}: Dronepack Kindred gets +1/+0 until end of turn.",
             "colours": [],
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "e0a4774f-130f-5b86-9ddd-4577714a57cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1e6885-dca0-4a4b-abb8-0f32680f618d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1e6885-dca0-4a4b-abb8-0f32680f618d.jpg?1",
             "name": "Weaver of Lightning",
             "text": "Reach\nWhenever you cast an instant or sorcery spell, Weaver of Lightning deals 1 damage to target creature an opponent controls.",
             "colours": [
@@ -5401,7 +5401,7 @@
         },
         {
             "id": "baf10ed1-ae11-557c-8dc2-b48beca958b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a65be-0ca1-437f-aafe-d96e8fe428ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a65be-0ca1-437f-aafe-d96e8fe428ad.jpg?1",
             "name": "Backwoods Survivalists",
             "text": "Delirium \u2014 Backwoods Survivalists gets +1/+1 and has trample as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "4bbf1a82-1084-5119-af0d-7b96e6d40011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1d82e-876f-48a6-8153-f02a44cf90a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1d82e-876f-48a6-8153-f02a44cf90a8.jpg?1",
             "name": "Bloodbriar",
             "text": "Whenever you sacrifice another permanent, put a +1/+1 counter on Bloodbriar.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "59a38566-ec90-5173-8eab-0c3aa0f442d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa1d34-7e32-45b7-9f6f-68f152f75d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fa1d34-7e32-45b7-9f6f-68f152f75d1a.jpg?1",
             "name": "Clear Shot",
             "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "025557fe-23a8-5749-a942-c00d352f6522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861e8c51-0cda-497a-b289-a9f678f0e328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861e8c51-0cda-497a-b289-a9f678f0e328.jpg?1",
             "name": "Crop Sigil",
             "text": "At the beginning of your upkeep, you may put the top card of your library into your graveyard.\nDelirium \u2014 {2}{G}, Sacrifice Crop Sigil: Return up to one target creature card and up to one target land card from your graveyard to your hand. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "16b61930-bb41-59a8-97ce-316d20acf94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a83854-dc45-4c26-aca0-67f372236383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a83854-dc45-4c26-aca0-67f372236383.jpg?1",
             "name": "Crossroads Consecrator",
             "text": "{G}, {T}: Target attacking Human gets +1/+1 until end of turn.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "a7688ec6-6872-553c-9242-3bb0927fa7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcb00e5-2caa-45c8-ad19-05d45c683d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcb00e5-2caa-45c8-ad19-05d45c683d16.jpg?1",
             "name": "Eldritch Evolution",
             "text": "As an additional cost to cast Eldritch Evolution, sacrifice a creature.\nSearch your library for a creature card with converted mana cost X or less, where X is 2 plus the sacrificed creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Exile Eldritch Evolution.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "e6c4c854-3a69-5a90-83e4-d6ec7084c839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c21822-972f-4c20-ac3b-80ba9af101c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c21822-972f-4c20-ac3b-80ba9af101c5.jpg?1",
             "name": "Emrakul's Evangel",
             "text": "{T}, Sacrifice Emrakul's Evangel and any number of other non-Eldrazi creatures: Put a 3/2 colorless Eldrazi Horror creature token onto the battlefield for each creature sacrificed this way.",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "1e949ace-e724-5659-88f9-e7414eb3bb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112476e7-72ab-4ebc-9e6e-e96fbf5109c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112476e7-72ab-4ebc-9e6e-e96fbf5109c0.jpg?1",
             "name": "Emrakul's Influence",
             "text": "Whenever you cast an Eldrazi creature spell with converted mana cost 7 or greater, draw two cards.",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "20dae635-b84f-521e-8826-df28a4d3958c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41446e3b-ecd1-442f-9209-713f0abfc538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41446e3b-ecd1-442f-9209-713f0abfc538.jpg?1",
             "name": "Foul Emissary",
             "text": "When Foul Emissary enters the battlefield, look at the top four cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nWhen you sacrifice Foul Emissary while casting a spell with emerge, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "3e7644ef-a11b-50bd-890d-5afb32f4ff3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa506387-e538-4b2c-94df-29866eb74a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa506387-e538-4b2c-94df-29866eb74a71.jpg?1",
             "name": "Gnarlwood Dryad",
             "text": "Deathtouch\nDelirium \u2014 Gnarlwood Dryad gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5739,7 +5739,7 @@
         },
         {
             "id": "95d1889c-f7aa-5a2d-9ec1-3c8bebc0af53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44a77a6-e8a1-4706-886f-8ab3af56b342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44a77a6-e8a1-4706-886f-8ab3af56b342.jpg?1",
             "name": "Grapple with the Past",
             "text": "Put the top three cards of your library into your graveyard, then you may return a creature or land card from your graveyard to your hand.",
             "colours": [
@@ -5771,7 +5771,7 @@
         },
         {
             "id": "610d888d-dea6-5621-b108-475aaf587b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43435939-20cf-49c9-8e37-63681740399b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43435939-20cf-49c9-8e37-63681740399b.jpg?1",
             "name": "Hamlet Captain",
             "text": "Whenever Hamlet Captain attacks or blocks, other Humans you control get +1/+1 until end of turn.",
             "colours": [
@@ -5806,7 +5806,7 @@
         },
         {
             "id": "9305bd16-2e28-5e4f-bddd-c3feb6e73eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6c5a98-2fe5-4671-a6a8-98a47c09c5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6c5a98-2fe5-4671-a6a8-98a47c09c5a7.jpg?1",
             "name": "Ishkanah, Grafwidow",
             "text": "Reach\nDelirium \u2014 When Ishkanah, Grafwidow enters the battlefield, if there are four or more card types among cards in your graveyard, put three 1/2 green Spider creature tokens with reach onto the battlefield.\n{6}{B}: Target opponent loses 1 life for each Spider you control.",
             "colours": [
@@ -5843,7 +5843,7 @@
         },
         {
             "id": "dd845d91-fc48-591e-b172-faeafe968345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg?1",
             "name": "Kessig Prowler // Sinuous Predator",
             "text": "{4}{G}: Transform Kessig Prowler.",
             "colours": [
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "7e6b0af1-c53d-5c00-b076-b288487d9e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f89f116a-1e8e-4ae7-be39-552e4954f229.jpg?1",
             "name": "Kessig Prowler // Sinuous Predator",
             "text": "Sinuous Predator can't be blocked by more than one creature.",
             "colours": [],
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "ee3157cd-3d0d-5f08-8f8b-796eb6b6ba83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307329cd-a69b-4acf-bcba-83d8306fe7ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307329cd-a69b-4acf-bcba-83d8306fe7ee.jpg?1",
             "name": "Noose Constrictor",
             "text": "Reach\nDiscard a card: Noose Constrictor gets +1/+1 until end of turn.",
             "colours": [
@@ -5945,7 +5945,7 @@
         },
         {
             "id": "2f323289-0329-5543-be5d-0609aa764b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71290eb-b529-4fc3-ab94-fee0ab9e2169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71290eb-b529-4fc3-ab94-fee0ab9e2169.jpg?1",
             "name": "Permeating Mass",
             "text": "Whenever Permeating Mass deals combat damage to a creature, that creature becomes a copy of Permeating Mass.",
             "colours": [
@@ -5979,7 +5979,7 @@
         },
         {
             "id": "1905d84c-611a-53a5-bc24-e681a877376f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f480aab-725d-410a-be06-242361d0be82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f480aab-725d-410a-be06-242361d0be82.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control.",
             "colours": [
@@ -6011,7 +6011,7 @@
         },
         {
             "id": "42901c99-6052-592d-9918-86377d64b83b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e928f694-c53b-46c5-8390-fa24b53f559c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e928f694-c53b-46c5-8390-fa24b53f559c.jpg?1",
             "name": "Primal Druid",
             "text": "When Primal Druid dies, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "1789cc6e-381d-5c70-9639-0a52b3123942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1",
             "name": "Shrill Howler // Howling Chorus",
             "text": "Creatures with power less than Shrill Howler's power can't block it.\n{5}{G}: Transform Shrill Howler.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "77010854-7200-586c-b4d5-e6e0e069520f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1",
             "name": "Shrill Howler // Howling Chorus",
             "text": "Creatures with power less than Howling Chorus's power can't block it.\nWhenever Howling Chorus deals combat damage to a player, put a 3/2 colorless Eldrazi Horror creature token onto the battlefield.",
             "colours": [],
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "aa4891ef-5327-5956-8d7e-835ebbabc4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651428a8-27af-4137-84f0-f71274a8b4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651428a8-27af-4137-84f0-f71274a8b4a6.jpg?1",
             "name": "Somberwald Stag",
             "text": "When Somberwald Stag enters the battlefield, you may have it fight target creature you don't control.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "5c155d0b-ef27-5a3c-9d6e-22557d86345d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f7b11-49ac-4078-aab7-efe3aff746b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5f7b11-49ac-4078-aab7-efe3aff746b2.jpg?1",
             "name": "Spirit of the Hunt",
             "text": "Flash\nWhen Spirit of the Hunt enters the battlefield, each other creature you control that's a Wolf or a Werewolf gets +0/+3 until end of turn.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "a09ad07d-3bf7-578c-bc97-475d95ed4d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17e172-3a46-4957-b711-edc53f70a284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17e172-3a46-4957-b711-edc53f70a284.jpg?1",
             "name": "Splendid Reclamation",
             "text": "Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "d5c39558-1e7b-5388-9b68-76ec630d6e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0b23a4-5868-4dd8-ae68-846934e1bd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0b23a4-5868-4dd8-ae68-846934e1bd52.jpg?1",
             "name": "Springsage Ritual",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "b65595aa-d11b-52fd-b159-4de71bd75514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264f78d8-d554-45f3-867e-19dba38e4644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264f78d8-d554-45f3-867e-19dba38e4644.jpg?1",
             "name": "Swift Spinner",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "ba4023ff-4e33-53ed-bde2-e5b84ccdb21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg?1",
             "name": "Tangleclaw Werewolf // Fibrous Entangler",
             "text": "Tangleclaw Werewolf can block an additional creature each combat.\n{6}{G}: Transform Tangleclaw Werewolf.",
             "colours": [
@@ -6316,7 +6316,7 @@
         },
         {
             "id": "9da52824-fd73-5375-97a5-6da4cec4ea82",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee648500-a213-4aa4-a97c-b7223c11bebd.jpg?1",
             "name": "Tangleclaw Werewolf // Fibrous Entangler",
             "text": "Vigilance\nFibrous Entangler must be blocked if able.\nFibrous Entangler can block an additional creature each combat.",
             "colours": [],
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "db8f0b43-e5f4-5b0f-abee-2f10df4244ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg?1",
             "name": "Ulvenwald Captive // Ulvenwald Abomination",
             "text": "Defender\n{T}: Add {G} to your mana pool.\n{5}{G}{G}: Transform Ulvenwald Captive.",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "9db8a0f2-7122-52ac-a257-ddd344f1e0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbaef61-fa39-4ea7-bc21-445401c373e7.jpg?1",
             "name": "Ulvenwald Captive // Ulvenwald Abomination",
             "text": "{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -6417,7 +6417,7 @@
         },
         {
             "id": "03165ee2-339b-5b9a-8799-ef5ddf062a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d23d5-2f94-48e6-824f-f1de8f742989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d23d5-2f94-48e6-824f-f1de8f742989.jpg?1",
             "name": "Ulvenwald Observer",
             "text": "Whenever a creature you control with toughness 4 or greater dies, draw a card.",
             "colours": [
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "56769a84-2658-5aa8-8d5e-f4f5f370a18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617f9f3a-61a1-4c73-8efe-3d74fe362901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617f9f3a-61a1-4c73-8efe-3d74fe362901.jpg?1",
             "name": "Waxing Moon",
             "text": "Transform up to one target Werewolf you control. Creatures you control gain trample until end of turn.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "86c6b348-08ed-56e1-a685-29f99696125c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748f263e-efef-4033-8950-c58fd024a87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748f263e-efef-4033-8950-c58fd024a87f.jpg?1",
             "name": "Wolfkin Bond",
             "text": "Enchant creature\nWhen Wolfkin Bond enters the battlefield, put a 2/2 green Wolf creature token onto the battlefield.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "9c843bf7-bb9f-5a6a-ae68-374bcf79c67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc329134-4b71-4c33-8cfb-c3867a733115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc329134-4b71-4c33-8cfb-c3867a733115.jpg?1",
             "name": "Woodcutter's Grit",
             "text": "Target creature you control gets +3/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "78fbf7dc-ebe5-5999-838a-64304e9573db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a134bd1-3c5a-467e-bad1-65548b33faa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a134bd1-3c5a-467e-bad1-65548b33faa5.jpg?1",
             "name": "Woodland Patrol",
             "text": "Vigilance",
             "colours": [
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "bc78b1b8-6424-5a9b-8c75-7e8f34dd7ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4824cca-0039-4486-be8f-650dac2c8e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4824cca-0039-4486-be8f-650dac2c8e9f.jpg?1",
             "name": "Bloodhall Priest",
             "text": "Whenever Bloodhall Priest enters the battlefield or attacks, if you have no cards in hand, Bloodhall Priest deals 2 damage to target creature or player.\nMadness {1}{B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6621,7 +6621,7 @@
         },
         {
             "id": "a9950534-e1f7-5a77-8929-85224529bd36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c284997a-cfc3-4ffc-bc25-00c130fb1eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c284997a-cfc3-4ffc-bc25-00c130fb1eb0.jpg?1",
             "name": "Campaign of Vengeance",
             "text": "Whenever a creature you control attacks, defending player loses 1 life and you gain 1 life.",
             "colours": [
@@ -6655,7 +6655,7 @@
         },
         {
             "id": "8bd69452-02c6-5e1c-9594-4d9dea373fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2c85d8-0bef-40d0-abaf-4555462c29c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2c85d8-0bef-40d0-abaf-4555462c29c5.jpg?1",
             "name": "Gisa and Geralf",
             "text": "When Gisa and Geralf enters the battlefield, put the top four cards of your library into your graveyard.\nDuring each of your turns, you may cast a Zombie creature card from your graveyard.",
             "colours": [
@@ -6694,7 +6694,7 @@
         },
         {
             "id": "0067f1bc-85aa-528e-ad50-4dcec5294077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025af99f-a029-4f99-9c76-676b68821520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025af99f-a029-4f99-9c76-676b68821520.jpg?1",
             "name": "Grim Flayer",
             "text": "Trample\nWhenever Grim Flayer deals combat damage to a player, look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDelirium \u2014 Grim Flayer gets +2/+2 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "c1b867eb-aff8-5d00-ab4e-1199e658a102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6448b2e2-01b2-4693-b41e-263909dc6a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6448b2e2-01b2-4693-b41e-263909dc6a95.jpg?1",
             "name": "Heron's Grace Champion",
             "text": "Flash\nLifelink\nWhen Heron's Grace Champion enters the battlefield, other Humans you control get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "ae121ee9-bab9-5797-a3ad-5e18c18f2480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab14779-7e79-449c-9a47-6ba219d0dbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab14779-7e79-449c-9a47-6ba219d0dbc5.jpg?1",
             "name": "Mercurial Geists",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Mercurial Geists gets +3/+0 until end of turn.",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "881d7adb-07ab-5fcd-a7ae-9b52238b16ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa37d8-6765-443f-9b70-200fecf8fa1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45aa37d8-6765-443f-9b70-200fecf8fa1e.jpg?1",
             "name": "Mournwillow",
             "text": "Haste\nDelirium \u2014 When Mournwillow enters the battlefield, if there are four or more card types among cards in your graveyard, creatures with power 2 or less can't block this turn.",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "c42ee763-b449-5746-822c-106fa03c5946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c021868f-9ab8-4a52-b12e-3cc35c9d67f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c021868f-9ab8-4a52-b12e-3cc35c9d67f0.jpg?1",
             "name": "Ride Down",
             "text": "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "b01b97e4-4e70-5bd0-8105-e1b03a4499b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b76bcd4-580a-4435-afe9-290940b1837f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b76bcd4-580a-4435-afe9-290940b1837f.jpg?1",
             "name": "Spell Queller",
             "text": "Flash\nFlying\nWhen Spell Queller enters the battlefield, exile target spell with converted mana cost 4 or less.\nWhen Spell Queller leaves the battlefield, the exiled card's owner may cast that card without paying its mana cost.",
             "colours": [
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "b8ff7df7-321c-5961-9b2c-5862f988a44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9aced7-9ae9-432f-b8c0-caac9cad098b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9aced7-9ae9-432f-b8c0-caac9cad098b.jpg?1",
             "name": "Tamiyo, Field Researcher",
             "text": "+1: Choose up to two target creatures. Until your next turn, whenever either of those creatures deals combat damage, you draw a card.\n\u22122: Tap up to two target nonland permanents. They don't untap during their controller's next untap step.\n\u22127: Draw three cards. You get an emblem with \"You may cast nonland cards from your hand without paying their mana costs.\"",
             "colours": [
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "a2dd98ba-a682-593d-91a3-fbdd707fc6f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg?1",
             "name": "Ulrich of the Krallenhorde // Ulrich, Uncontested Alpha",
             "text": "Whenever this creature enters the battlefield or transforms into Ulrich of the Krallenhorde, target creature gets +4/+4 until end of turn.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Ulrich of the Krallenhorde.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "64f8d938-d2d7-5c79-ab0e-926bb8aeaa04",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e2011f0-a640-4579-bd67-1dfbc09b8c09.jpg?1",
             "name": "Ulrich of the Krallenhorde // Ulrich, Uncontested Alpha",
             "text": "Whenever this creature transforms into Ulrich, Uncontested Alpha, you may have it fight target non-Werewolf creature you don't control.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ulrich, Uncontested Alpha.",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "55a8a643-a924-5c96-ad1f-8fc2f2ac1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c18ffa-ffff-4dc4-9db0-d5f183c35e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c18ffa-ffff-4dc4-9db0-d5f183c35e17.jpg?1",
             "name": "Cathar's Shield",
             "text": "Equipped creature gets +0/+3 and has vigilance.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "49aaf11e-fd85-50c4-9bac-2ced9b0cf779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1",
             "name": "Cryptolith Fragment // Aurora of Emrakul",
             "text": "Cryptolith Fragment enters the battlefield tapped.\n{T}: Add one mana of any color to your mana pool. Each player loses 1 life.\nAt the beginning of your upkeep, if each player has 10 or less life, transform Cryptolith Fragment.",
             "colours": [],
@@ -7086,7 +7086,7 @@
         },
         {
             "id": "913591af-1ed0-5c1e-8819-a99d145ab208",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1",
             "name": "Cryptolith Fragment // Aurora of Emrakul",
             "text": "Flying, deathtouch\nWhenever Aurora of Emrakul attacks, each opponent loses 3 life.",
             "colours": [],
@@ -7117,7 +7117,7 @@
         },
         {
             "id": "316faf30-fb10-57a3-87da-1c014c0101e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da8c523-44e8-43e7-8431-28dbed1015ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da8c523-44e8-43e7-8431-28dbed1015ac.jpg?1",
             "name": "Cultist's Staff",
             "text": "Equipped creature gets +2/+2.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7147,7 +7147,7 @@
         },
         {
             "id": "4222ffa7-2322-5cf0-9d6b-77c26005446e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92b162-f51d-4138-8d9b-e5eb929ad87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92b162-f51d-4138-8d9b-e5eb929ad87e.jpg?1",
             "name": "Field Creeper",
             "text": "",
             "colours": [],
@@ -7178,7 +7178,7 @@
         },
         {
             "id": "ada046ce-8d9c-5a3c-9f0e-dadc66151421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c9cafb-4543-409f-a98a-df0e7a0f2749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c9cafb-4543-409f-a98a-df0e7a0f2749.jpg?1",
             "name": "Geist-Fueled Scarecrow",
             "text": "Creature spells you cast cost {1} more to cast.",
             "colours": [],
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "6eea8158-b0fc-52f1-80d1-a9c532a4fa1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8272ca-8e3d-4980-99f2-352a1db76d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8272ca-8e3d-4980-99f2-352a1db76d74.jpg?1",
             "name": "Lupine Prototype",
             "text": "Lupine Prototype can't attack or block unless a player has no cards in hand.",
             "colours": [],
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "0adf9d9a-7130-5503-9109-167e84008df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de4a83a-3a0c-4174-ba65-a6e100383b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de4a83a-3a0c-4174-ba65-a6e100383b32.jpg?1",
             "name": "Slayer's Cleaver",
             "text": "Equipped creature gets +3/+1 and must be blocked by an Eldrazi if able.\nEquip {4}",
             "colours": [],
@@ -7271,7 +7271,7 @@
         },
         {
             "id": "0bf024e3-b0c9-5baf-a126-ddf18b903623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b1158-dfc4-4fe9-b970-338be8a99662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b1158-dfc4-4fe9-b970-338be8a99662.jpg?1",
             "name": "Soul Separator",
             "text": "{5}, {T}, Sacrifice Soul Separator: Exile target creature card from your graveyard. Put a token onto the battlefield that's a copy of that card except it's 1/1, it's a Spirit in addition to its other types, and it has flying. Put a black Zombie creature token onto the battlefield with power equal to that card's power and toughness equal to that card's toughness.",
             "colours": [],
@@ -7299,7 +7299,7 @@
         },
         {
             "id": "8c5f01b9-9160-529b-b401-c969161353b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6d700e-0514-41d7-9255-cedd859316fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6d700e-0514-41d7-9255-cedd859316fc.jpg?1",
             "name": "Stitcher's Graft",
             "text": "Equipped creature gets +3/+3.\nWhenever equipped creature attacks, it doesn't untap during its controller's next untap step.\nWhenever Stitcher's Graft becomes unattached from a permanent, sacrifice that permanent.\nEquip {2}",
             "colours": [],
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "5cc1c6c4-9078-557e-a202-3126b5148f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fae696-0db9-4a87-8a88-b4298da01a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fae696-0db9-4a87-8a88-b4298da01a19.jpg?1",
             "name": "Terrarion",
             "text": "Terrarion enters the battlefield tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana in any combination of colors to your mana pool.\nWhen Terrarion is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "8b036fa8-f0cf-5282-a4cb-42ad3deb7da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e5303-c07a-4be0-a314-bf5739a856e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e5303-c07a-4be0-a314-bf5739a856e5.jpg?1",
             "name": "Thirsting Axe",
             "text": "Equipped creature gets +4/+0.\nAt the beginning of your end step, if equipped creature didn't deal combat damage to a creature this turn, sacrifice it.\nEquip {2}",
             "colours": [],
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "9b1c5042-f89a-5e35-956d-78d488bf25f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96093739-fedc-4d8f-a29d-0e57f571e5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96093739-fedc-4d8f-a29d-0e57f571e5a9.jpg?1",
             "name": "Geier Reach Sanitarium",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Each player draws a card, then discards a card.",
             "colours": [],
@@ -7417,7 +7417,7 @@
         },
         {
             "id": "ded0b33b-e9ad-58ee-ba5a-2529756c398a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d743ad6-6ca2-409a-9773-581cc195dbf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d743ad6-6ca2-409a-9773-581cc195dbf2.jpg?1",
             "name": "Hanweir Battlements // Hanweir, the Writhing Township",
             "text": "{T}: Add {C} to your mana pool.\n{R}, {T}: Target creature gains haste until end of turn.\n{3}{R}{R}, {T}: If you both own and control Hanweir Battlements and a creature named Hanweir Garrison, exile them, then meld them into Hanweir, the Writhing Township.",
             "colours": [],
@@ -7447,7 +7447,7 @@
         },
         {
             "id": "5ff1e68f-51a1-5a04-8795-2048167fcc59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243eb5b-905e-446f-9ee0-7557e3b31db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243eb5b-905e-446f-9ee0-7557e3b31db3.jpg?1",
             "name": "Nephalia Academy",
             "text": "If a spell or ability an opponent controls causes you to discard a card, you may reveal that card and put it on top of your library instead of putting it anywhere else.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "97d1206f-a2e2-5a25-b24b-ff685b87d47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d25bde-a303-4b06-a3e1-4ad642deae58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d25bde-a303-4b06-a3e1-4ad642deae58.jpg?1",
             "name": "Eldrazi Horror",
             "text": "",
             "colours": [],
@@ -7506,7 +7506,7 @@
         },
         {
             "id": "5a885f7d-d9d3-58fc-adb5-4be0bc6cd1f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8586f9-97e2-438d-b74f-1e53c811f314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8586f9-97e2-438d-b74f-1e53c811f314.jpg?1",
             "name": "Eldritch Moon Checklist",
             "text": "",
             "colours": [],
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "7513b439-3b1b-51a6-a771-76d22da1c16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4439a8b-ef98-428d-a274-53c660b23afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4439a8b-ef98-428d-a274-53c660b23afe.jpg?1",
             "name": "Human Wizard",
             "text": "",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "c454ff79-6729-5d5d-bcfe-81ba641dc8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f1f43a-cbdb-4d1b-a254-dadcb2469784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f1f43a-cbdb-4d1b-a254-dadcb2469784.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "45532777-f91c-50a2-9b77-5bab52dc4d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e7f8df-826e-4ba7-9c6c-8c8eb7a61de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e7f8df-826e-4ba7-9c6c-8c8eb7a61de8.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "d73c5077-732d-5a56-b229-b23d3b4124aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8710a30-8314-49ef-b995-bd05454095be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8710a30-8314-49ef-b995-bd05454095be.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "94d9bf29-b5c7-57fe-b6da-bc068103aa50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44aa879-b63b-497c-9c1b-2333950161fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44aa879-b63b-497c-9c1b-2333950161fa.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7704,7 +7704,7 @@
         },
         {
             "id": "e1b159eb-6dd2-5aac-bf20-2ba7ac9de6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd994fc-f3f0-4c81-86bd-14ca63ec229b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd994fc-f3f0-4c81-86bd-14ca63ec229b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "c5d1d542-2d37-59c3-b620-05f69d6d9e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce90c48f-74fb-4e87-9e46-7f8c3d79cbb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce90c48f-74fb-4e87-9e46-7f8c3d79cbb0.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -7772,7 +7772,7 @@
         },
         {
             "id": "e7276485-7a85-577e-bd84-5f09f2333c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1512fe7b-5e01-424e-9747-8d4840a5d22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1512fe7b-5e01-424e-9747-8d4840a5d22a.jpg?1",
             "name": "Liliana, the Last Hope Emblem",
             "text": "",
             "colours": [],
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "b36eab7b-2acf-5694-b7c5-15e565e05cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c6e29e-261a-4953-bdbe-cce8790eb5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c6e29e-261a-4953-bdbe-cce8790eb5a8.jpg?1",
             "name": "Tamiyo, Field Researcher Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/EVE.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/EVE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "03a654ae-5f63-53dc-be7d-1e634101f44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab707e7f-8ab5-43f1-9428-6a17c1b672fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab707e7f-8ab5-43f1-9428-6a17c1b672fa.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice is put into a graveyard from play, remove target permanent from the game.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "e9326289-4e94-5a29-8422-4fb8e09535b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b10d37b-2cbc-4061-b25a-ad8ff3944ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b10d37b-2cbc-4061-b25a-ad8ff3944ad3.jpg?1",
             "name": "Ballynock Trapper",
             "text": "{T}: Tap target creature.\nWhenever you play a white spell, you may untap Ballynock Trapper.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "0f422807-8ad6-5dc0-9bf7-d08ae13fbe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c1375-9908-4fe8-960a-595b9b58cd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c1375-9908-4fe8-960a-595b9b58cd10.jpg?1",
             "name": "Cenn's Enlistment",
             "text": "Put two 1/1 white Kithkin Soldier creature tokens into play.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "a3a49712-f5da-5b9a-a8b3-1566ea539b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32385604-dcff-41e4-97a5-fcf230033a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32385604-dcff-41e4-97a5-fcf230033a87.jpg?1",
             "name": "Endless Horizons",
             "text": "When Endless Horizons comes into play, search your library for any number of Plains cards and remove them from the game. Then shuffle your library.\nAt the beginning of your upkeep, you may put a card you own removed from the game with Endless Horizons into your hand.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "f1897f1d-b02c-5871-b706-0634536ff191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7904ba-0764-4dd3-9c78-35f799e99049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7904ba-0764-4dd3-9c78-35f799e99049.jpg?1",
             "name": "Endure",
             "text": "Prevent all damage that would be dealt to you and permanents you control this turn.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "8a8b0f3b-3a37-5468-aa5a-208727d8c515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb3cb5c-8d66-4f5e-a9a9-917e6045f024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb3cb5c-8d66-4f5e-a9a9-917e6045f024.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp comes into play, remove another target permanent from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "41efc890-387c-54e1-99fc-a481adf701e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42fad4b-caeb-4aa2-9586-cb26bdec56cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c42fad4b-caeb-4aa2-9586-cb26bdec56cd.jpg?1",
             "name": "Hallowed Burial",
             "text": "Put all creatures on the bottom of their owners' libraries.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "fdfaa8c0-ce80-564c-9ed3-9b8c03c16f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71547cb8-b275-4ff2-a7fa-327cb493ce04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71547cb8-b275-4ff2-a7fa-327cb493ce04.jpg?1",
             "name": "Kithkin Spellduster",
             "text": "Flying\n{1}{W}, Sacrifice Kithkin Spellduster: Destroy target enchantment.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -270,7 +270,7 @@
         },
         {
             "id": "b71ad28f-5ba9-5ab9-9a37-edf23e2736de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f9a29c-9219-424f-a703-dccffbf23cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f9a29c-9219-424f-a703-dccffbf23cdc.jpg?1",
             "name": "Kithkin Zealot",
             "text": "When Kithkin Zealot comes into play, you gain 1 life for each black and/or red permanent target opponent controls.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "a2d49a09-d695-5dc5-85e9-1d1bfd2c1f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afda091-ed14-4bc5-8896-bdb7c95a499e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afda091-ed14-4bc5-8896-bdb7c95a499e.jpg?1",
             "name": "Light from Within",
             "text": "Chroma Each creature you control gets +1/+1 for each white mana symbol in its mana cost.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "e89ecf65-0146-5814-9e31-7c29f83cf52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f9f53-0a54-4097-9bb5-8a39732c7016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f9f53-0a54-4097-9bb5-8a39732c7016.jpg?1",
             "name": "Loyal Gyrfalcon",
             "text": "Defender, flying\nWhenever you play a white spell, Loyal Gyrfalcon loses defender until end of turn.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "f622649f-9bdc-505a-9c29-6f7abf1dec8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3fd4ccb-e632-4fa0-8e36-6103806f020c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3fd4ccb-e632-4fa0-8e36-6103806f020c.jpg?1",
             "name": "Patrol Signaler",
             "text": "{1}{W}, {Q}: Put a 1/1 white Kithkin Soldier creature token into play. ({Q} is the untap symbol.)",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "0d8b2f76-b5be-57e6-bb33-7bc2ef537176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c28634-337d-458a-bcf0-b7fbf65a41da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c28634-337d-458a-bcf0-b7fbf65a41da.jpg?1",
             "name": "Recumbent Bliss",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nAt the beginning of your upkeep, you may gain 1 life.",
             "colours": [
@@ -440,7 +440,7 @@
         },
         {
             "id": "8ac4c121-c50a-56a8-83d4-13472ef51947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667cf0b6-1dd9-420a-abf8-f6a698aafea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667cf0b6-1dd9-420a-abf8-f6a698aafea7.jpg?1",
             "name": "Spirit of the Hearth",
             "text": "Flying\nYou can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "caa31c0f-7512-50f1-a3a9-70019fb98aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25991e3-4b83-4521-ab2b-c11b1fa9d0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25991e3-4b83-4521-ab2b-c11b1fa9d0bd.jpg?1",
             "name": "Springjack Shepherd",
             "text": "Chroma When Springjack Shepherd comes into play, put a 0/1 white Goat creature token into play for each white mana symbol in the mana costs of permanents you control.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "913e6bba-0434-59ae-a02d-2c247872d0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08520f97-e7f5-45fc-9423-fa6a3a507671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08520f97-e7f5-45fc-9423-fa6a3a507671.jpg?1",
             "name": "Suture Spirit",
             "text": "Flying\n{WB}{WB}{WB}: Regenerate target creature.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "860ffaf2-de0c-5903-8251-70d02578de1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371a769a-ddae-47f6-b2c2-957de5c18417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371a769a-ddae-47f6-b2c2-957de5c18417.jpg?1",
             "name": "Banishing Knack",
             "text": "Until end of turn, target creature gains \"{T}: Return target nonland permanent to its owner's hand.\"",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "cfbfdd73-6d8e-5f28-882a-db43472bf87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe945308-f103-4d36-b279-98102e3de123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe945308-f103-4d36-b279-98102e3de123.jpg?1",
             "name": "Cache Raiders",
             "text": "At the beginning of your upkeep, return a permanent you control to its owner's hand.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "70eebf45-5b98-5e46-8278-ef1490f6f6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfd71ff-d899-4f5b-b7df-ec47e2840be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfd71ff-d899-4f5b-b7df-ec47e2840be9.jpg?1",
             "name": "Dream Fracture",
             "text": "Counter target spell. Its controller draws a card.\nDraw a card.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "ce6724c6-5725-565a-bfa6-4e4fade13607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811026ed-1bae-4464-bdfe-dcec76259152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811026ed-1bae-4464-bdfe-dcec76259152.jpg?1",
             "name": "Dream Thief",
             "text": "Flying\nWhen Dream Thief comes into play, draw a card if you played another blue spell this turn.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "ff7329b7-733a-533e-9c8e-78a0117ff8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829a0a1c-761f-4a7f-b59a-c889d995f446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829a0a1c-761f-4a7f-b59a-c889d995f446.jpg?1",
             "name": "Glamerdye",
             "text": "Change the text of target spell or permanent by replacing all instances of one color word with another.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "08954c3e-3497-528c-9efa-d70eb772d017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09516d3d-e6c2-4359-af2a-a4aa244ca033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09516d3d-e6c2-4359-af2a-a4aa244ca033.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "Flying\n{U}, Sacrifice Glen Elendra Archmage: Counter target noncreature spell.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "1584e48f-e820-5cc3-b976-75fdb4570f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797f80be-019d-4e44-a48d-43c6e52d2ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797f80be-019d-4e44-a48d-43c6e52d2ab5.jpg?1",
             "name": "Idle Thoughts",
             "text": "{2}: Draw a card if you have no cards in hand.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "6511fc06-1018-5539-b256-e414cc799373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e6e481-a050-4515-a557-d59ba6136ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e6e481-a050-4515-a557-d59ba6136ff6.jpg?1",
             "name": "Indigo Faerie",
             "text": "Flying\n{U}: Target permanent becomes blue in addition to its other colors until end of turn.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "6e0a832a-6741-5af2-9787-4b2a0395d03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5047c92-2885-4a7b-b51f-f3e093dca5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5047c92-2885-4a7b-b51f-f3e093dca5ad.jpg?1",
             "name": "Inundate",
             "text": "Return all nonblue creatures to their owners' hands.",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "503b9d37-6527-5a86-8145-59a577803812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b2f122-0406-44f4-82b0-9f46b52e7d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b2f122-0406-44f4-82b0-9f46b52e7d99.jpg?1",
             "name": "Merrow Levitator",
             "text": "{T}: Target creature gains flying until end of turn.\nWhenever you play a blue spell, you may untap Merrow Levitator.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "fb7edbb4-ad0a-5f27-86a9-3338e3f0b922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5404ae3f-ff19-4627-ae69-9bd2c36ab7d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5404ae3f-ff19-4627-ae69-9bd2c36ab7d3.jpg?1",
             "name": "Oona's Grace",
             "text": "Target player draws a card.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "7a46ff72-4644-5978-be44-9f5f039e87be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed978036-c473-46d8-8302-3707d222aff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed978036-c473-46d8-8302-3707d222aff5.jpg?1",
             "name": "Razorfin Abolisher",
             "text": "{1}{U}, {T}: Return target creature with a counter on it to its owner's hand.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "4286d5bd-1186-5878-a14c-5339ead8ad09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e377f-6bb7-4fa1-b58b-7e2af06ca4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e377f-6bb7-4fa1-b58b-7e2af06ca4b7.jpg?1",
             "name": "Sanity Grinding",
             "text": "Chroma Reveal the top ten cards of your library. For each blue mana symbol in the mana costs of the revealed cards, target opponent puts the top card of his or her library into his or her graveyard. Then put the cards you revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -979,7 +979,7 @@
         },
         {
             "id": "7e94e28f-be51-5a02-adf4-978d5af38f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f6256e-5d24-4fa0-a83b-5ff971f7e1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f6256e-5d24-4fa0-a83b-5ff971f7e1cc.jpg?1",
             "name": "Talonrend",
             "text": "Flying\n{UR}: Talonrend gets +1/-1 until end of turn.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "3ae72dce-629a-5059-b605-0ababaef231b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116209-636a-4b86-a8ed-d4a03e1d7212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116209-636a-4b86-a8ed-d4a03e1d7212.jpg?1",
             "name": "Wake Thrasher",
             "text": "Whenever a permanent you control becomes untapped, Wake Thrasher gets +1/+1 until end of turn.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "6849b431-06ad-56fc-8b7d-5ad9ced67322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947000d-bc0f-4f8b-a9a6-09bf29f846ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947000d-bc0f-4f8b-a9a6-09bf29f846ea.jpg?1",
             "name": "Wilderness Hypnotist",
             "text": "{T}: Target red or green creature gets -2/-0 until end of turn.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "a1281f43-e233-5a1e-a18f-bd710297ab38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/350580d8-45db-4428-a292-cc4802bf1e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/350580d8-45db-4428-a292-cc4802bf1e4d.jpg?1",
             "name": "Ashling, the Extinguisher",
             "text": "Whenever Ashling, the Extinguisher deals combat damage to a player, choose target creature that player controls. He or she sacrifices that creature.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "a569db27-40b9-5b10-8422-9db84723042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4e94d3-0df5-4d2b-a5d9-178fe1350ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4e94d3-0df5-4d2b-a5d9-178fe1350ceb.jpg?1",
             "name": "Creakwood Ghoul",
             "text": "{BG}{BG}: Remove target card in a graveyard from the game. You gain 1 life.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "cb53154a-c1b7-51de-922b-7f2634b3b9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73ac3c-bd5a-4993-be65-76396b7d38ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e73ac3c-bd5a-4993-be65-76396b7d38ad.jpg?1",
             "name": "Crumbling Ashes",
             "text": "At the beginning of your upkeep, destroy target creature with a -1/-1 counter on it.",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "85aef10c-c958-5b1e-85f8-82178c900020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5165880-9727-4f52-9633-fd5cecce7f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5165880-9727-4f52-9633-fd5cecce7f01.jpg?1",
             "name": "Lingering Tormentor",
             "text": "Fear\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "7abbdd3d-3a0c-55bf-ae81-2befd15dd489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e49aa4-ac23-49b1-b9b7-49d45b56b21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e49aa4-ac23-49b1-b9b7-49d45b56b21d.jpg?1",
             "name": "Merrow Bonegnawer",
             "text": "{T}: Target player removes a card in his or her graveyard from the game.\nWhenever you play a black spell, you may untap Merrow Bonegnawer.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "a5af59c0-f169-5372-a97f-2154d7db56c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02907b62-5456-4605-a8cd-321487928761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02907b62-5456-4605-a8cd-321487928761.jpg?1",
             "name": "Necroskitter",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls with a -1/-1 counter on it is put into a graveyard, you may return that card to play under your control.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "7f694101-4bb1-5e6a-94f5-ae2492810674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21af9e72-fbaf-460a-a2eb-a09b925ebd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21af9e72-fbaf-460a-a2eb-a09b925ebd9a.jpg?1",
             "name": "Needle Specter",
             "text": "Flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever Needle Specter deals combat damage to a player, that player discards that many cards.",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "5fb2898f-3f9f-53e8-968f-e3b6fa1a29b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cccd244-9fd4-4f58-85da-af6d235ef7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cccd244-9fd4-4f58-85da-af6d235ef7bb.jpg?1",
             "name": "Nightmare Incursion",
             "text": "Search target player's library for up to X cards, where X is the number of Swamps you control, and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1358,7 +1358,7 @@
         },
         {
             "id": "e8b8e0f2-ddf2-52ff-8499-851b79ad8498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ced5797-5de0-43ca-9dc9-e48912333a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ced5797-5de0-43ca-9dc9-e48912333a70.jpg?1",
             "name": "Raven's Crime",
             "text": "Target player discards a card.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "9e7071bb-d625-57fc-89bb-b77c41d9ac25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f764936-fceb-4a3d-ac32-15397d7ce664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f764936-fceb-4a3d-ac32-15397d7ce664.jpg?1",
             "name": "Smoldering Butcher",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "8802f614-decd-542e-a829-c6ef1c7ae6fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f50d1d-5694-4701-9755-a9d1e6dfae29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f50d1d-5694-4701-9755-a9d1e6dfae29.jpg?1",
             "name": "Soot Imp",
             "text": "Flying\nWhenever a player plays a nonblack spell, that player loses 1 life.",
             "colours": [
@@ -1459,7 +1459,7 @@
         },
         {
             "id": "3f0cce21-a806-5b4a-b95f-af6a835ea396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a129e2-bed5-4ee7-b223-851452f72682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a129e2-bed5-4ee7-b223-851452f72682.jpg?1",
             "name": "Soul Reap",
             "text": "Destroy target nongreen creature. Its controller loses 3 life if you played another black spell this turn.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "eed04d7f-11a8-5910-8aa7-53f27ef76ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06194432-d208-4e3e-8384-eceba58cfd63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06194432-d208-4e3e-8384-eceba58cfd63.jpg?1",
             "name": "Soul Snuffers",
             "text": "When Soul Snuffers comes into play, put a -1/-1 counter on each creature.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "93ffa620-3396-589f-9d6f-28ed4df597fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd8bf-fd0e-4cab-903b-10c6d0dd4741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225cd8bf-fd0e-4cab-903b-10c6d0dd4741.jpg?1",
             "name": "Syphon Life",
             "text": "Target player loses 2 life and you gain 2 life.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "78448a28-5437-5f35-9a97-6f3afe1abef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd68e4c4-0216-4f58-a3ce-3432ab5830c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd68e4c4-0216-4f58-a3ce-3432ab5830c6.jpg?1",
             "name": "Talara's Bane",
             "text": "Target opponent reveals his or her hand. Choose a green or white creature card from it. You gain life equal that creature card's toughness, then that player discards that card.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "9b59ccc9-23df-512b-8730-3048c0fe1b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efdd70a-5a84-48a5-82bf-ba29fda097c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efdd70a-5a84-48a5-82bf-ba29fda097c0.jpg?1",
             "name": "Umbra Stalker",
             "text": "Chroma Umbra Stalker's power and toughness are each equal to the number of black mana symbols in the mana costs of cards in your graveyard.",
             "colours": [
@@ -1624,7 +1624,7 @@
         },
         {
             "id": "1b9a1019-c07e-5cbe-bf0d-fa24c43fa04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f96c71-e585-4c99-b054-e53ab12b392c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f96c71-e585-4c99-b054-e53ab12b392c.jpg?1",
             "name": "Chaotic Backlash",
             "text": "Chaotic Backlash deals damage to target player equal to twice the number of white and/or blue permanents he or she controls.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "5773770f-63ab-578d-9fd7-ed2b0261886e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6125689-0098-4e52-bed8-24840d22cdc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6125689-0098-4e52-bed8-24840d22cdc1.jpg?1",
             "name": "Cinder Pyromancer",
             "text": "{T}: Cinder Pyromancer deals 1 damage to target player.\nWhenever you play a red spell, you may untap Cinder Pyromancer.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "dc37cb19-3a21-54c9-be10-996bcd3c5c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48fda3d-5e6f-4f32-8fca-030521f6df98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48fda3d-5e6f-4f32-8fca-030521f6df98.jpg?1",
             "name": "Duergar Cave-Guard",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{GU}: Duergar Cave-Guard gets +1/+0 until end of turn.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "d550bdcc-5ba7-5e24-a414-6630688dfb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c348d137-4774-41d7-8b4d-d383c816ae2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c348d137-4774-41d7-8b4d-d383c816ae2a.jpg?1",
             "name": "Fiery Bombardment",
             "text": "Chroma {2}, Sacrifice a creature: Fiery Bombardment deals damage to target creature or player equal to the number of red mana symbols in the sacrificed creature's mana cost.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "3fdb2c28-d478-54c2-9dda-1e8d1255ab2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c2b6b2-485e-41e6-b106-4f6f402e0ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c2b6b2-485e-41e6-b106-4f6f402e0ec3.jpg?1",
             "name": "Flame Jab",
             "text": "Flame Jab deals 1 damage to target creature or player.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "ebbe23c7-9f7e-54f3-b5cb-d39090c53073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d99d1c2-3c24-47b6-97eb-ae1d8726948e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d99d1c2-3c24-47b6-97eb-ae1d8726948e.jpg?1",
             "name": "Hatchet Bully",
             "text": "{2}{R}, {T}, Put a -1/-1 counter on a creature you control: Hatchet Bully deals 2 damage to target creature or player.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "570bf66f-237a-5487-bd0e-cc8c3c12f034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c26ba3-e325-433b-b653-4e80e737b54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c26ba3-e325-433b-b653-4e80e737b54d.jpg?1",
             "name": "Hateflayer",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{2}{R}, {Q}: Hateflayer deals damage equal to its power to target creature or player. ({Q} is the untap symbol.)",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "c8db8cff-7d91-5923-a9e6-eed05274b3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c38e02-5df3-4655-a18f-a7be2c352b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c38e02-5df3-4655-a18f-a7be2c352b7b.jpg?1",
             "name": "Heartlash Cinder",
             "text": "Haste\nChroma When Heartlash Cinder comes into play, it gets +X/+0 until end of turn, where X is the number of red mana symbols in the mana costs of permanents you control.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "8ffff4ce-2405-539d-93ad-56fcae334877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74481546-debc-44df-b5a9-7fde0ada0eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74481546-debc-44df-b5a9-7fde0ada0eca.jpg?1",
             "name": "Hotheaded Giant",
             "text": "Haste\nHotheaded Giant comes into play with two -1/-1 counters on it unless you played another red spell this turn.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "d0e77185-47bd-563f-bb36-1af9951288fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b768940-409a-4876-809f-ef311002b944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b768940-409a-4876-809f-ef311002b944.jpg?1",
             "name": "Impelled Giant",
             "text": "Trample\nTap an untapped red creature you control other than Impelled Giant: Impelled Giant gets +X/+0 until end of turn, where X is the power of the creature tapped this way.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "eca6a98e-fb78-5c2a-929a-eabab03bc4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf2b2fb-d521-42ea-a6de-f80054b8a4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf2b2fb-d521-42ea-a6de-f80054b8a4a6.jpg?1",
             "name": "Outrage Shaman",
             "text": "Chroma When Outrage Shaman comes into play, it deals damage to target creature equal to the number of red mana symbols in the mana costs of permanents you control.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "797378c6-2b54-558a-8be7-3964d2802f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf90b4d-98cf-4953-b6ae-c41d21ab559b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf90b4d-98cf-4953-b6ae-c41d21ab559b.jpg?1",
             "name": "Puncture Blast",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nPuncture Blast deals 3 damage to target creature or player.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "de550665-a4f2-57bb-96ea-9a3f596225e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131c6377-4ed4-4a76-a9cb-be7ad17d76fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131c6377-4ed4-4a76-a9cb-be7ad17d76fd.jpg?1",
             "name": "Rekindled Flame",
             "text": "Rekindled Flame deals 4 damage to target creature or player.\nAt the beginning of your upkeep, if an opponent has no cards in hand, you may return Rekindled Flame from your graveyard to your hand.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "07ffc7ed-3029-5a45-b76d-ed3b890b684a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5d1fd4-0543-46ce-bcea-1695fc04e85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5d1fd4-0543-46ce-bcea-1695fc04e85b.jpg?1",
             "name": "Stigma Lasher",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever Stigma Lasher deals damage to a player, that player can't gain life for the rest of the game.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "73ffcf75-7d76-5fde-bb36-378fed606c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5872624-7994-468c-9e16-4a771a0dbcfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5872624-7994-468c-9e16-4a771a0dbcfa.jpg?1",
             "name": "Thunderblust",
             "text": "Haste\nThunderblust has trample as long as it has a -1/-1 counter on it.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "a26b2da0-1b6c-5795-9414-841a30866834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cdd83c-50e2-4c04-a4fe-1fe2f545c7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cdd83c-50e2-4c04-a4fe-1fe2f545c7a2.jpg?1",
             "name": "Unwilling Recruit",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gets +X/+0 and gains haste until end of turn.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "7f9ffc76-4dc2-5468-a193-1d1d79f1c1d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4cb09-c99f-4a17-a6fd-55c9a169a808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4cb09-c99f-4a17-a6fd-55c9a169a808.jpg?1",
             "name": "Aerie Ouphes",
             "text": "Sacrifice Aerie Ouphes: Aerie Ouphes deals damage equal to its power to target creature with flying.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "3d13cead-3261-57f9-b3f8-bed61147e5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cc2828-dfe7-410b-9735-10bb7211f0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cc2828-dfe7-410b-9735-10bb7211f0f5.jpg?1",
             "name": "Bloom Tender",
             "text": "{T}: For each color among permanents you control, add one mana of that color to your mana pool.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "089ea162-a3b9-53a7-98e9-212ae916cec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d10736d-047b-423f-9017-f59732d446bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d10736d-047b-423f-9017-f59732d446bf.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "a93b25e4-9353-535c-9211-f4404c2fa8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1121df-b03e-4ad9-8c45-c3b4066e4a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1121df-b03e-4ad9-8c45-c3b4066e4a39.jpg?1",
             "name": "Helix Pinnacle",
             "text": "Shroud\n{X}: Put X tower counters on Helix Pinnacle.\nAt the beginning of your upkeep, if there are 100 or more tower counters on Helix Pinnacle, you win the game.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "26c4f971-9a40-5e93-a96a-dd5c3adcc6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1fbb7-aa02-4f56-8be7-88a3ba55f7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1fbb7-aa02-4f56-8be7-88a3ba55f7d2.jpg?1",
             "name": "Marshdrinker Giant",
             "text": "When Marshdrinker Giant comes into play, destroy target Island or Swamp an opponent controls.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "a5aa4436-34d1-5149-9075-9e8bff7d6f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585b52bc-aff5-4406-b55b-1b7decfd80f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585b52bc-aff5-4406-b55b-1b7decfd80f9.jpg?1",
             "name": "Monstrify",
             "text": "Target creature gets +4/+4 until end of turn.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "af7a10d6-69ed-5916-bcf8-4ee9181d7d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f21681-fd36-4106-8395-3153599a08a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f21681-fd36-4106-8395-3153599a08a6.jpg?1",
             "name": "Nettle Sentinel",
             "text": "Nettle Sentinel doesn't untap during its controller's untap step.\nWhenever you play a green spell, you may untap Nettle Sentinel.",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "b5c3a165-5e87-50ba-bbd5-e2c2db38f0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8316eb28-9e58-4194-a0c6-cad32bddc391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8316eb28-9e58-4194-a0c6-cad32bddc391.jpg?1",
             "name": "Phosphorescent Feast",
             "text": "Chroma Reveal any number of cards in your hand. You gain 2 life for each green mana symbol in those cards' mana costs.",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "7b43cb71-97f3-5c06-9f58-050285bb104b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f805f7b-bb7e-436b-abd3-20a35e7ef71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f805f7b-bb7e-436b-abd3-20a35e7ef71e.jpg?1",
             "name": "Primalcrux",
             "text": "Trample\nChroma Primalcrux's power and toughness are each equal to the number of green mana symbols in the mana costs of permanents you control.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "fcc54344-e5c5-53aa-a971-71119eeadcdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674a694a-22b8-4fb8-b901-91d64564c0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674a694a-22b8-4fb8-b901-91d64564c0db.jpg?1",
             "name": "Regal Force",
             "text": "When Regal Force comes into play, draw a card for each green creature you control.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "ff26a131-cae7-5742-ad86-cdfbf13140d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88ab58b-918b-478a-8c6b-a213e2bc87ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88ab58b-918b-478a-8c6b-a213e2bc87ab.jpg?1",
             "name": "Savage Conception",
             "text": "Put a 3/3 green Beast creature token into play.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "8a8ca92e-533a-56d7-a1e4-9960f23ccf45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d057c-c51c-46bb-b8fe-aabe7f3b07b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d057c-c51c-46bb-b8fe-aabe7f3b07b6.jpg?1",
             "name": "Swirling Spriggan",
             "text": "{GW}{GW}: Target creature you control becomes the color or colors of your choice until end of turn.",
             "colours": [
@@ -2570,7 +2570,7 @@
         },
         {
             "id": "03a2eef2-959c-5e10-9672-76317538e20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d00ea9-1111-47c3-9722-4c68ce3e4d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d00ea9-1111-47c3-9722-4c68ce3e4d56.jpg?1",
             "name": "Talara's Battalion",
             "text": "Trample\nPlay Talara's Battalion only if you played another green spell this turn.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "d37d518f-acdf-5e8a-af1f-8b43124d192b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a10d0-214d-4e7b-9683-c84034f8f6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a10d0-214d-4e7b-9683-c84034f8f6b7.jpg?1",
             "name": "Tilling Treefolk",
             "text": "When Tilling Treefolk comes into play, you may return up to two target land cards from your graveyard to your hand.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "a4da26e1-a546-5d54-84fb-d2407ace0542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0092d7a0-bd00-45e5-a052-c0a9d970bc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0092d7a0-bd00-45e5-a052-c0a9d970bc2e.jpg?1",
             "name": "Twinblade Slasher",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{1}{G}: Twinblade Slasher gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "9a7ee7b0-f244-5341-91a1-efe45e2cb2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc283b4-9106-4a32-88b4-000f2a3bed84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc283b4-9106-4a32-88b4-000f2a3bed84.jpg?1",
             "name": "Wickerbough Elder",
             "text": "Wickerbough Elder comes into play with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from Wickerbough Elder: Destroy target artifact or enchantment.",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "73ac6df6-0138-5f7c-ab0c-a177b5d24947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165960f2-b26a-4204-8234-9c00a98a8b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165960f2-b26a-4204-8234-9c00a98a8b34.jpg?1",
             "name": "Batwing Brume",
             "text": "Prevent all combat damage that would be dealt this turn if {W} was spent to play Batwing Brume. Each player loses 1 life for each attacking creature he or she controls if {B} was spent to play Batwing Brume. (Do both if {W}{B} was spent.)",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "7db601e3-b2c1-5f71-be25-31d671a67d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bae1a3b-881b-4b10-ac5f-822c809edc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bae1a3b-881b-4b10-ac5f-822c809edc36.jpg?1",
             "name": "Beckon Apparition",
             "text": "Remove target card in a graveyard from the game. Put a 1/1 white and black Spirit creature token with flying into play.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "3978f775-ccb9-50ee-838d-555303e7622d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68b6fc7-e565-4f7d-8efb-c4d29e41c689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68b6fc7-e565-4f7d-8efb-c4d29e41c689.jpg?1",
             "name": "Bloodied Ghost",
             "text": "Flying\nBloodied Ghost comes into play with a -1/-1 counter on it.",
             "colours": [
@@ -2814,7 +2814,7 @@
         },
         {
             "id": "53b0d15c-92cb-5678-8c94-0c5e12b98206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d0def7-42dd-46f4-8499-d79876783a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d0def7-42dd-46f4-8499-d79876783a39.jpg?1",
             "name": "Cauldron Haze",
             "text": "Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it's put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "e34ec215-3a1c-5efd-aee6-72c27eafbce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8157e1-72ae-47ea-84ce-fb0b154215aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8157e1-72ae-47ea-84ce-fb0b154215aa.jpg?1",
             "name": "Deathbringer Liege",
             "text": "Other white creatures you control get +1/+1.\nOther black creatures you control get +1/+1.\nWhenever you play a white spell, you may tap target creature.\nWhenever you play a black spell, you may destroy target creature if it's tapped.",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "02ea1702-5b8d-5914-9f58-ac73d7848f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb71651-7ede-4348-89a4-b441da72491b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb71651-7ede-4348-89a4-b441da72491b.jpg?1",
             "name": "Divinity of Pride",
             "text": "Flying, lifelink\nDivinity of Pride gets +4/+4 as long as you have 25 or more life.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "d927fab3-aa40-5b00-96be-fc6838d52ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd079d8-b191-4f54-bb04-427b3736f745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd079d8-b191-4f54-bb04-427b3736f745.jpg?1",
             "name": "Edge of the Divinity",
             "text": "Enchant creature\nAs long as enchanted creature is white, it gets +1/+2.\nAs long as enchanted creature is black, it gets +2/+1.",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "83f84198-c564-5329-9b7a-a4c6eb2a5980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499d1789-f7b0-47a1-962e-4c75b23befd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499d1789-f7b0-47a1-962e-4c75b23befd5.jpg?1",
             "name": "Evershrike",
             "text": "Flying\nEvershrike gets +2/+2 for each Aura attached to it.\n{X}{WB}{WB}: Return Evershrike from your graveyard to play. You may put an Aura card with converted mana cost X or less from your hand into play attached to it. If you don't, remove Evershrike from the game.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "236ba113-7381-5edd-a3f3-4013b3c01f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914e6fda-808f-43fb-8024-8b8a8781a7ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914e6fda-808f-43fb-8024-8b8a8781a7ac.jpg?1",
             "name": "Gwyllion Hedge-Mage",
             "text": "When Gwyllion Hedge-Mage comes into play, if you control two or more Plains, you may put a 1/1 white Kithkin Soldier creature token into play.\nWhen Gwyllion Hedge-Mage comes into play, if you control two or more Swamps, you may put a -1/-1 counter on target creature.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "049c80a9-db73-514f-9d76-79fcc535bf99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0491d1-343d-453e-aa52-a3d3daa1478e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0491d1-343d-453e-aa52-a3d3daa1478e.jpg?1",
             "name": "Harvest Gwyllion",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -3067,7 +3067,7 @@
         },
         {
             "id": "ea3ad998-6f53-5ccb-a0fb-772386d7b05c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dbda67-3bc4-4c8a-8357-250d84d0d1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dbda67-3bc4-4c8a-8357-250d84d0d1d8.jpg?1",
             "name": "Nightsky Mimic",
             "text": "Whenever you play a spell that's both white and black, Nightsky Mimic becomes 4/4 and gains flying until end of turn.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "e289d529-beda-5853-96bb-56ddcf570c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ad92d-8803-4569-98c8-4a7416799cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ad92d-8803-4569-98c8-4a7416799cfc.jpg?1",
             "name": "Nip Gwyllion",
             "text": "Lifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "33076fc0-c2f6-5ec1-a7cd-053a84ec94c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae92d23-2028-450c-9598-6932a71f8c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae92d23-2028-450c-9598-6932a71f8c32.jpg?1",
             "name": "Pyrrhic Revival",
             "text": "Each player returns each creature card in his or her graveyard to play with a -1/-1 counter on it.",
             "colours": [
@@ -3173,7 +3173,7 @@
         },
         {
             "id": "ae642db9-03ff-511c-a338-f301afb08994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6480d0-17c5-4ac2-afb2-4d44f089de22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6480d0-17c5-4ac2-afb2-4d44f089de22.jpg?1",
             "name": "Restless Apparition",
             "text": "{WB}{WB}{WB}: Restless Apparition gets +3/+3 until end of turn.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "919555eb-c02a-5424-a524-1d26795193fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400dc91e-96c0-49bf-b307-677d6f80f3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400dc91e-96c0-49bf-b307-677d6f80f3ed.jpg?1",
             "name": "Stillmoon Cavalier",
             "text": "Protection from white and from black\n{WB}: Stillmoon Cavalier gains flying until end of turn.\n{WB}: Stillmoon Cavalier gains first strike until end of turn.\n{WB}{WB}: Stillmoon Cavalier gets +1/+0 until end of turn.",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "53a72db0-0b43-5b0d-9418-a2fe48c4a1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338f7852-9f69-4406-b6ad-93a2574296f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338f7852-9f69-4406-b6ad-93a2574296f7.jpg?1",
             "name": "Unmake",
             "text": "Remove target creature from the game.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "455c6f9c-9b3d-590c-abb6-051ab7954f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66b1a84-ab15-48d8-909c-08116dc71c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66b1a84-ab15-48d8-909c-08116dc71c76.jpg?1",
             "name": "Voracious Hatchling",
             "text": "Lifelink\nVoracious Hatchling comes into play with four -1/-1 counters on it.\nWhenever you play a white spell, remove a -1/-1 counter from Voracious Hatchling.\nWhenever you play a black spell, remove a -1/-1 counter from Voracious Hatchling.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "8fe1a16a-ab5c-5737-a434-6632390e8d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751db106-e9bc-4f16-97c6-f624eb1aa809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751db106-e9bc-4f16-97c6-f624eb1aa809.jpg?1",
             "name": "Call the Skybreaker",
             "text": "Put a 5/5 blue and red Elemental creature token with flying into play.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "1a88fa8c-b551-535c-ab50-ba9204bd84dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ce6d6-014f-46c2-baf3-f250e9dc3085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ce6d6-014f-46c2-baf3-f250e9dc3085.jpg?1",
             "name": "Clout of the Dominus",
             "text": "Enchant creature\nAs long as enchanted creature is blue, it gets +1/+1 and has shroud. (It can't be the target of spells or abilities.)\nAs long as enchanted creature is red, it gets +1/+1 and has haste.",
             "colours": [
@@ -3386,7 +3386,7 @@
         },
         {
             "id": "dc162a3b-8625-5d0e-9cbf-a3df76e8677d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be19f23-5db4-4d50-a9d7-622e247ff0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be19f23-5db4-4d50-a9d7-622e247ff0ab.jpg?1",
             "name": "Crackleburr",
             "text": "{UR}{UR}, {T}, Tap two untapped red creatures you control: Crackleburr deals 3 damage to target creature or player.\n{UR}{UR}, {Q}, Untap two tapped blue creatures you control: Return target creature to its owner's hand. ({Q} is the untap symbol.)",
             "colours": [
@@ -3422,7 +3422,7 @@
         },
         {
             "id": "50ed9364-38ab-58ec-817d-1e16099cf911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c11707-1ded-4891-82b4-9827a7dfc489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c11707-1ded-4891-82b4-9827a7dfc489.jpg?1",
             "name": "Crag Puca",
             "text": "{UR}: Switch Crag Puca's power and toughness until end of turn.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "bf1256e3-9a98-54a1-a3a6-580576157387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff447e1-bbcc-4ada-87c0-04b6b144c2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff447e1-bbcc-4ada-87c0-04b6b144c2cd.jpg?1",
             "name": "Dominus of Fealty",
             "text": "Flying\nAt the beginning of your upkeep, you may gain control of target permanent until end of turn. If you do, untap it and it gains haste until end of turn.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "fa8333fc-ac7f-5bb0-9551-ad95434ddd81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51180ee-8677-4d5a-9685-3861c67a1d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51180ee-8677-4d5a-9685-3861c67a1d1f.jpg?1",
             "name": "Inside Out",
             "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "2d7965a6-b809-555b-b2c9-405356413584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b412a60-b49e-42ea-9547-03e4ef44ffea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b412a60-b49e-42ea-9547-03e4ef44ffea.jpg?1",
             "name": "Mindwrack Liege",
             "text": "Other blue creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\n{UR}{UR}{UR}{UR}: You may put a blue or red creature card from your hand into play.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "dbf1fc75-c757-5e18-81bb-64452c56415b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26b31ce-416f-4309-b591-798cf12175af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26b31ce-416f-4309-b591-798cf12175af.jpg?1",
             "name": "Mirror Sheen",
             "text": "{1}{UR}{UR}: Copy target instant or sorcery spell that targets you. You may choose new targets for the copy.",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "23ff7e34-5d90-5c61-8055-55271de0d6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552c9c66-8023-41ef-8d4f-3b0dc30743f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552c9c66-8023-41ef-8d4f-3b0dc30743f3.jpg?1",
             "name": "Noggle Bandit",
             "text": "Noggle Bandit can't be blocked except by creatures with defender.",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "0e3b9e3b-fd13-56e4-a72c-a49d7a732753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545a52ed-b4d4-4972-940d-9daf07a488b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545a52ed-b4d4-4972-940d-9daf07a488b1.jpg?1",
             "name": "Noggle Bridgebreaker",
             "text": "When Noggle Bridgebreaker comes into play, return a land you control to its owner's hand.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "a90c24e6-ed83-52a1-81db-2afeda06d24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497e1713-dd2d-4f25-8c8c-0c515eec7040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497e1713-dd2d-4f25-8c8c-0c515eec7040.jpg?1",
             "name": "Noggle Hedge-Mage",
             "text": "When Noggle Hedge-Mage comes into play, if you control two or more Islands, you may tap two target permanents.\nWhen Noggle Hedge-Mage comes into play, if you control two or more Mountains, you may have Noggle Hedge-Mage deal 2 damage to target player.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "7ed5b61f-02ed-5d6b-9f72-b3a12020ed9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dbe4e2-77f3-4764-b9fb-b555a1228bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dbe4e2-77f3-4764-b9fb-b555a1228bf3.jpg?1",
             "name": "Noggle Ransacker",
             "text": "When Noggle Ransacker comes into play, each player draws two cards, then discards a card at random.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "03cbb600-af0d-5b44-8f99-1582fcd2ae32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f54b0a-b0e1-44f1-bb91-523cc9e1c298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f54b0a-b0e1-44f1-bb91-523cc9e1c298.jpg?1",
             "name": "Nucklavee",
             "text": "When Nucklavee comes into play, you may return target red sorcery card from your graveyard to your hand.\nWhen Nucklavee comes into play, you may return target blue instant card from your graveyard to your hand.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "7427aa05-545a-549a-8970-c91685109622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ed3ce-d7f7-4275-baef-edc5127475d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5ed3ce-d7f7-4275-baef-edc5127475d7.jpg?1",
             "name": "Riverfall Mimic",
             "text": "Whenever you play a spell that's both blue and red, Riverfall Mimic becomes 3/3 and is unblockable until end of turn.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "731b23bd-14c4-5644-bcb5-46edd5243f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0148ef2-d825-4425-b767-c74b406880fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0148ef2-d825-4425-b767-c74b406880fd.jpg?1",
             "name": "Shrewd Hatchling",
             "text": "Shrewd Hatchling comes into play with four -1/-1 counters on it.\n{UR}: Target creature can't block Shrewd Hatchling this turn.\nWhenever you play a blue spell, remove a -1/-1 counter from Shrewd Hatchling.\nWhenever you play a red spell, remove a -1/-1 counter from Shrewd Hatchling.",
             "colours": [
@@ -3855,7 +3855,7 @@
         },
         {
             "id": "10dcf077-b25b-57b8-8322-6ae92d7e17ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55371d0e-29da-4517-ab16-075782a1326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55371d0e-29da-4517-ab16-075782a1326f.jpg?1",
             "name": "Stream Hopper",
             "text": "{UR}: Stream Hopper gains flying until end of turn.",
             "colours": [
@@ -3891,7 +3891,7 @@
         },
         {
             "id": "86e2b69f-5826-5eca-a541-daced00def07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eccfd-19d0-48cc-8b27-9027e4911fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eccfd-19d0-48cc-8b27-9027e4911fee.jpg?1",
             "name": "Unnerving Assault",
             "text": "Creatures your opponents control get -1/-0 until end of turn if {U} was spent to play Unnerving Assault, and creatures you control get +1/+0 until end of turn if {R} was spent to play it. (Do both if {U}{R} was spent.)",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "970d954f-3139-5711-89e1-257640183095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fac2e0-b65e-4b84-9d7e-2a9b2ddfe970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00fac2e0-b65e-4b84-9d7e-2a9b2ddfe970.jpg?1",
             "name": "Canker Abomination",
             "text": "As Canker Abomination comes into play, choose an opponent. Canker Abomination comes into play with a -1/-1 counter on it for each creature that player controls.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "d5a07ee2-8ffb-5487-85eb-23beb882515a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45840408-33e7-43fa-96ab-d3bd53e3fd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45840408-33e7-43fa-96ab-d3bd53e3fd6b.jpg?1",
             "name": "Cankerous Thirst",
             "text": "If {B} was spent to play Cankerous Thirst, you may have target creature get -3/-3 until end of turn. If {G} was spent to play Cankerous Thirst, you may have target creature get +3/+3 until end of turn. (Do both if {B}{G} was spent.)",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "d8f12878-6c9d-5d42-ad0a-38edb4c4b219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906ddeb6-4021-4e16-b0b9-dfe087673944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906ddeb6-4021-4e16-b0b9-dfe087673944.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may put a 1/1 black and green Worm creature token into play.",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "eae1e3b2-d14d-505c-9559-bf096f0cb9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efc2cc8-2445-4d64-b1c5-26483efbcc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efc2cc8-2445-4d64-b1c5-26483efbcc30.jpg?1",
             "name": "Deity of Scars",
             "text": "Trample\nDeity of Scars comes into play with two -1/-1 counters on it.\n{BG}, Remove a -1/-1 counter from Deity of Scars: Regenerate Deity of Scars.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "0c9dbe65-ff51-5726-847e-30f691af7f91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d2e092-c805-447c-b784-1896b69524e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d2e092-c805-447c-b784-1896b69524e0.jpg?1",
             "name": "Desecrator Hag",
             "text": "When Desecrator Hag comes into play, return to your hand the creature card in your graveyard with the highest power. If two or more cards are tied for highest power, you choose one of them.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "25a921ed-3db6-538e-894f-9d4fe41c6a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173fd1c6-ffd9-424f-ad65-90b193edbe00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173fd1c6-ffd9-424f-ad65-90b193edbe00.jpg?1",
             "name": "Doomgape",
             "text": "Trample\nAt the beginning of your upkeep, sacrifice a creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -4141,7 +4141,7 @@
         },
         {
             "id": "6cdaa356-055b-5cf8-ad52-fab72255015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebd1f5-55ee-48c9-a8df-85c8c4bf3473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebd1f5-55ee-48c9-a8df-85c8c4bf3473.jpg?1",
             "name": "Drain the Well",
             "text": "Destroy target land. You gain 2 life.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "1c2e3483-b7aa-58b3-897a-c99567dc74c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2dba5c-2f00-4a44-9093-3b845a8bf552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2dba5c-2f00-4a44-9093-3b845a8bf552.jpg?1",
             "name": "Gift of the Deity",
             "text": "Enchant creature\nAs long as enchanted creature is black, it gets +1/+1 and has deathtouch. (Whenever it deals damage to a creature, destroy that creature.)\nAs long as enchanted creature is green, it gets +1/+1 and all creatures able to block it do so.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "06cc030b-9ce9-5c21-a449-6b2b317b6c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d461d67-8554-4b55-8f01-909a54d23117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d461d67-8554-4b55-8f01-909a54d23117.jpg?1",
             "name": "Hag Hedge-Mage",
             "text": "When Hag Hedge-Mage comes into play, if you control two or more Swamps, you may have target player discard a card.\nWhen Hag Hedge-Mage comes into play, if you control two or more Forests, you may put target card in your graveyard on top of your library.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "3f1cf1dc-2f0a-5e7a-bede-f5e51c78decf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898fd93f-05f2-4523-a3f5-18b48a7365a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898fd93f-05f2-4523-a3f5-18b48a7365a2.jpg?1",
             "name": "Noxious Hatchling",
             "text": "Noxious Hatchling comes into play with four -1/-1 counters on it.\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever you play a black spell, remove a -1/-1 counter from Noxious Hatchling.\nWhenever you play a green spell, remove a -1/-1 counter from Noxious Hatchling.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "09525df4-cc1f-5a7d-95aa-c890f34f44e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2e0c36-645a-46c8-bd9e-4b8b591dfb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2e0c36-645a-46c8-bd9e-4b8b591dfb58.jpg?1",
             "name": "Odious Trow",
             "text": "{1}{BG}: Regenerate Odious Trow.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "873a1a6b-c824-5f5c-9f8e-a503eeded360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb4054-d5d6-4015-ae86-6f99280afe0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb4054-d5d6-4015-ae86-6f99280afe0a.jpg?1",
             "name": "Quillspike",
             "text": "{BG}, Remove a -1/-1 counter from a creature you control: Quillspike gets +3/+3 until end of turn.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "7f440a9b-1810-5401-85d3-3e304ae17c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc293a4b-abd6-47b6-99d1-578bc22580de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc293a4b-abd6-47b6-99d1-578bc22580de.jpg?1",
             "name": "Rendclaw Trow",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "81386b8c-77da-516b-b18a-093e0adb50fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c373d-9733-425b-8ff5-2862a96f5188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3c373d-9733-425b-8ff5-2862a96f5188.jpg?1",
             "name": "Sapling of Colfenor",
             "text": "Sapling of Colfenor is indestructible.\nWhenever Sapling of Colfenor attacks, reveal the top card of your library. If it's a creature card, you gain life equal to that card's toughness, lose life equal to its power, then put it into your hand.",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "20c0419d-6f7f-518b-93dd-ba6c4dccbdaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0eed33-553a-4865-9b22-30c33fbd1c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0eed33-553a-4865-9b22-30c33fbd1c51.jpg?1",
             "name": "Stalker Hag",
             "text": "Swampwalk, forestwalk",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "f969330a-62cf-5610-83fc-59f9012cf0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86dd5a9-4793-4ca2-b94d-4333781b1468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86dd5a9-4793-4ca2-b94d-4333781b1468.jpg?1",
             "name": "Woodlurker Mimic",
             "text": "Whenever you play a spell that's both black and green, Woodlurker Mimic becomes 4/5 and gains wither until end of turn. (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "44e371cf-3eb3-525a-a2d2-b68f31116aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f48156-a7db-4d96-981e-a288cfaa67e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f48156-a7db-4d96-981e-a288cfaa67e7.jpg?1",
             "name": "Worm Harvest",
             "text": "Put a 1/1 black and green Worm creature token into play for each land card in your graveyard.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "c713ccd6-8f61-515d-950e-c23db21ac5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d302fbd-d43c-47ff-920d-559c5a9028ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d302fbd-d43c-47ff-920d-559c5a9028ee.jpg?1",
             "name": "Balefire Liege",
             "text": "Other red creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nWhenever you play a red spell, Balefire Liege deals 3 damage to target player.\nWhenever you play a white spell, you gain 3 life.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "b4bdde27-7fd8-5305-b71a-553b48a2ed15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a0bc8-d736-45e6-ac20-63c5ca69a8d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2a0bc8-d736-45e6-ac20-63c5ca69a8d5.jpg?1",
             "name": "Battlegate Mimic",
             "text": "Whenever you play a spell that's both red and white, Battlegate Mimic becomes 4/2 and gains first strike until end of turn.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "290609e9-0057-5c2b-bb64-c113496f60a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cdf36c-d8a2-4629-8f2a-d4ac86ac9320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cdf36c-d8a2-4629-8f2a-d4ac86ac9320.jpg?1",
             "name": "Belligerent Hatchling",
             "text": "First strike\nBelligerent Hatchling comes into play with four -1/-1 counters on it.\nWhenever you play a red spell, remove a -1/-1 counter from Belligerent Hatchling.\nWhenever you play a white spell, remove a -1/-1 counter from Belligerent Hatchling.",
             "colours": [
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "300bb6f4-8100-51a8-8430-6d7a3d2a345e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ac70a-6484-4b1f-8948-4646a380ed20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ac70a-6484-4b1f-8948-4646a380ed20.jpg?1",
             "name": "Double Cleave",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "3cdf3142-ab49-5234-8873-e08b337d7b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6555cbb-97fc-4258-9b11-096c3eaec833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6555cbb-97fc-4258-9b11-096c3eaec833.jpg?1",
             "name": "Duergar Assailant",
             "text": "Sacrifice Duergar Assailant: Duergar Assailant deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "fc97e711-4dc9-51a7-9830-ed5dad2b0887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d45e026-58fc-4a0c-9099-6849e5a8fa67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d45e026-58fc-4a0c-9099-6849e5a8fa67.jpg?1",
             "name": "Duergar Hedge-Mage",
             "text": "When Duergar Hedge-Mage comes into play, if you control two or more Mountains, you may destroy target artifact.\nWhen Duergar Hedge-Mage comes into play, if you control two or more Plains, you may destroy target enchantment.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "d55259b7-19b1-5cde-ad49-9098a8d78779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97983b9-6c93-41ce-8deb-ac08811a0834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97983b9-6c93-41ce-8deb-ac08811a0834.jpg?1",
             "name": "Duergar Mine-Captain",
             "text": "{1}{GU}, {Q}: Attacking creatures get +1/+0 until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "6283ee8c-c13e-504d-9a55-ef5bce05fa83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da69523-cece-425a-b08a-fb27fac29374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da69523-cece-425a-b08a-fb27fac29374.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a 2/2 Kithkin Spirit.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a 4/4 Kithkin Spirit Warrior.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike.",
             "colours": [
@@ -4827,7 +4827,7 @@
         },
         {
             "id": "d05af934-4cd9-5383-9dd4-f817a5a288b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53617fbc-a6e9-4f06-8c4b-4699325cdcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53617fbc-a6e9-4f06-8c4b-4699325cdcac.jpg?1",
             "name": "Fire at Will",
             "text": "Fire at Will deals 3 damage divided as you choose among any number of target attacking or blocking creatures.",
             "colours": [
@@ -4861,7 +4861,7 @@
         },
         {
             "id": "5c0f3bbc-a417-51da-9674-82e753335a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc104-7189-480c-bfe1-c5da07df48f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc104-7189-480c-bfe1-c5da07df48f4.jpg?1",
             "name": "Hearthfire Hobgoblin",
             "text": "Double strike",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "efbc1025-9316-53ce-9e21-6e4b84174748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090223a1-2644-4b81-a9f5-d15ca6df5229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090223a1-2644-4b81-a9f5-d15ca6df5229.jpg?1",
             "name": "Hobgoblin Dragoon",
             "text": "Flying, first strike",
             "colours": [
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "e80731e8-f02c-5a09-8558-353f8423c9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72245a8-6f5e-4564-804f-30407c1c4e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c72245a8-6f5e-4564-804f-30407c1c4e57.jpg?1",
             "name": "Moonhold",
             "text": "Target player can't play land cards this turn if {R} was spent to play Moonhold and can't play creature cards this turn if {W} was spent to play it. (Do both if {R}{W} was spent.)",
             "colours": [
@@ -4969,7 +4969,7 @@
         },
         {
             "id": "6c24e909-3658-5791-85b0-bde025dd74ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d54ab6e-dd56-40fe-abab-a1e67b024744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d54ab6e-dd56-40fe-abab-a1e67b024744.jpg?1",
             "name": "Nobilis of War",
             "text": "Flying\nAttacking creatures you control get +2/+0.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "a7c05056-ff39-5cc8-ab92-2fe57cd1f2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d47d-0c5c-4932-aaf1-df21b8b8daeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d47d-0c5c-4932-aaf1-df21b8b8daeb.jpg?1",
             "name": "Rise of the Hobgoblins",
             "text": "When Rise of the Hobgoblins comes into play, you may pay {X}. If you do, put X 1/1 red and white Goblin Soldier creature tokens into play.\n{GU}: Red creatures and white creatures you control gain first strike until end of turn.",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "50858b80-3105-5ed0-b5f6-284d6e06114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adccc97-3774-4c57-aa78-dcb9fbbe9324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adccc97-3774-4c57-aa78-dcb9fbbe9324.jpg?1",
             "name": "Scourge of the Nobilis",
             "text": "Enchant creature\nAs long as enchanted creature is red, it gets +1/+1 and has \"{GU}: This creature gets +1/+0 until end of turn.\"\nAs long as enchanted creature is white, it gets +1/+1 and has lifelink. (Whenever it deals damage, its controller gains that much life.)",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "6ab82d81-c24a-59a8-9b3f-e2b77d1fa260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefeb0e2-ddd4-4881-bca4-6c7699c82d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefeb0e2-ddd4-4881-bca4-6c7699c82d79.jpg?1",
             "name": "Spitemare",
             "text": "Whenever Spitemare is dealt damage, it deals that much damage to target creature or player.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "fb6b216a-e05a-5558-953e-760fe475fbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d52ba7-ffb3-4c24-85d8-8635ef1880d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d52ba7-ffb3-4c24-85d8-8635ef1880d9.jpg?1",
             "name": "Waves of Aggression",
             "text": "Untap all creatures that attacked this turn. After this main phase, there is an additional combat phase followed by an additional main phase.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "c3d82ac5-9fd1-5f72-b064-486459ba8365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b266c6-20f9-46ae-990d-0017144971e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b266c6-20f9-46ae-990d-0017144971e7.jpg?1",
             "name": "Cold-Eyed Selkie",
             "text": "Islandwalk\nWhenever Cold-Eyed Selkie deals combat damage to a player, you may draw that many cards.",
             "colours": [
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "2bbc95a4-c748-541c-9db4-e0d223dbd427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be364b69-aa59-420c-a613-b1d0b303a4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be364b69-aa59-420c-a613-b1d0b303a4e5.jpg?1",
             "name": "Fable of Wolf and Owl",
             "text": "Whenever you play a green spell, you may put a 2/2 green Wolf creature token into play.\nWhenever you play a blue spell, you may put a 1/1 blue Bird creature token with flying into play.",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "ba39315e-3b9a-5362-a276-81b245893580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf061f8-3aec-429a-bde7-7c110f872416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf061f8-3aec-429a-bde7-7c110f872416.jpg?1",
             "name": "Favor of the Overbeing",
             "text": "Enchant creature\nAs long as enchanted creature is green, it gets +1/+1 and has vigilance.\nAs long as enchanted creature is blue, it gets +1/+1 and has flying.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "f4f0ebac-2a9e-50cf-a3b9-fa4553081d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca006ff-3a95-4821-bdb2-2d80e64b4abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca006ff-3a95-4821-bdb2-2d80e64b4abf.jpg?1",
             "name": "Gilder Bairn",
             "text": "{2}{GW}, {Q}: For each counter on target permanent, put another of those counters on that permanent. ({Q} is the untap symbol.)",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "fa3fd9b5-89f1-56f8-b903-d2781f23f818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ccef2d-9a1f-4011-89e1-911bcc109b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ccef2d-9a1f-4011-89e1-911bcc109b9d.jpg?1",
             "name": "Grazing Kelpie",
             "text": "{GW}, Sacrifice Grazing Kelpie: Put target card in a graveyard on the bottom of its owner's library.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5325,7 +5325,7 @@
         },
         {
             "id": "83bd0e35-ac0c-5e94-9d30-dfed8356de85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e7056e-42b9-436a-8302-fcbfa0abd84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e7056e-42b9-436a-8302-fcbfa0abd84f.jpg?1",
             "name": "Groundling Pouncer",
             "text": "{GW}: Groundling Pouncer gets +1/+3 and gains flying until end of turn. Play this ability only once each turn and only if an opponent controls a creature with flying.",
             "colours": [
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "211d982b-cec0-557b-93c6-89606d51ab24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d0a6f9-478f-43c7-8591-3b601c12ed01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d0a6f9-478f-43c7-8591-3b601c12ed01.jpg?1",
             "name": "Invert the Skies",
             "text": "Creatures your opponents control lose flying until end of turn if {G} was spent to play Invert the Skies, and creatures you control gain flying until end of turn if {U} was spent to play it. (Do both if {G}{U} was spent.)",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "a666b49c-a661-504f-9ef0-04925e9a6df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8250af-696f-4e28-86ba-29e316d01e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8250af-696f-4e28-86ba-29e316d01e56.jpg?1",
             "name": "Murkfiend Liege",
             "text": "Other green creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.\nUntap all green and/or blue creatures you control during each other player's untap step.",
             "colours": [
@@ -5431,7 +5431,7 @@
         },
         {
             "id": "145ec295-c0f9-5387-8687-6a2f9a371300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bbc404-a456-4a4b-af88-23921d80d671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bbc404-a456-4a4b-af88-23921d80d671.jpg?1",
             "name": "Overbeing of Myth",
             "text": "Overbeing of Myth's power and toughness are each equal to the number of cards in your hand.\nAt the beginning of your draw step, draw a card.",
             "colours": [
@@ -5468,7 +5468,7 @@
         },
         {
             "id": "ee4f4eac-55ea-5088-83ca-8fb8a0b2fb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f66b0b4-44fc-444d-9181-0b717c9642fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f66b0b4-44fc-444d-9181-0b717c9642fa.jpg?1",
             "name": "Selkie Hedge-Mage",
             "text": "When Selkie Hedge-Mage comes into play, if you control two or more Forests, you may gain 3 life.\nWhen Selkie Hedge-Mage comes into play, if you control two or more Islands, you may return target tapped creature to its owner's hand.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "e6432886-ffd5-5559-99c6-0669532319e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24babb9e-edc8-484b-9db4-18abbafdf096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24babb9e-edc8-484b-9db4-18abbafdf096.jpg?1",
             "name": "Shorecrasher Mimic",
             "text": "Whenever you play a spell that's both green and blue, Shorecrasher Mimic becomes 5/3 and gains trample until end of turn.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "dc3d0e52-dece-5711-baec-0482366e14a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19714d6c-2bfa-4ee0-aa2f-5ccc196bc5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19714d6c-2bfa-4ee0-aa2f-5ccc196bc5d8.jpg?1",
             "name": "Slippery Bogle",
             "text": "Slippery Bogle can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "6c48b000-825a-5b77-b4ba-8dff8fc0cef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d96d4f2-7f19-4687-927a-5b840254a4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d96d4f2-7f19-4687-927a-5b840254a4f9.jpg?1",
             "name": "Snakeform",
             "text": "Target creature loses all abilities and becomes a 1/1 green Snake until end of turn.\nDraw a card.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "67411f74-afd0-5cb7-a679-7eaf4f1283de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d60c0c-1bc8-4962-9205-4645db7fb26e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d60c0c-1bc8-4962-9205-4645db7fb26e.jpg?1",
             "name": "Spitting Image",
             "text": "Put a token into play that's a copy of target creature.\nRetrace (You may play this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -5645,7 +5645,7 @@
         },
         {
             "id": "2213f4fb-a302-52fe-9081-158451e60ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41330e2-c6e8-47af-831d-b2d2bd1d06a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41330e2-c6e8-47af-831d-b2d2bd1d06a3.jpg?1",
             "name": "Sturdy Hatchling",
             "text": "Sturdy Hatchling comes into play with four -1/-1 counters on it.\n{GW}: Sturdy Hatchling gains shroud until end of turn.\nWhenever you play a green spell, remove a -1/-1 counter from Sturdy Hatchling.\nWhenever you play a blue spell, remove a -1/-1 counter from Sturdy Hatchling.",
             "colours": [
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "fd46f8e0-3127-5f0c-a5ea-10809dfe8fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62615f86-0431-4709-b41c-af43f7793fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62615f86-0431-4709-b41c-af43f7793fdb.jpg?1",
             "name": "Trapjaw Kelpie",
             "text": "Flash\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "6ca1aa20-d0a4-57d6-94e3-c323b57f5139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3e6feb-3d78-4463-9315-5ba27ab33733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3e6feb-3d78-4463-9315-5ba27ab33733.jpg?1",
             "name": "Wistful Selkie",
             "text": "When Wistful Selkie comes into play, draw a card.",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "5f335e1a-6031-5203-8155-a92693ad8901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed81c72-743d-4d2a-97a6-22f5651e15d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed81c72-743d-4d2a-97a6-22f5651e15d5.jpg?1",
             "name": "Altar Golem",
             "text": "Trample\nAltar Golem's power and toughness are each equal to the number of creatures in play.\nAltar Golem doesn't untap during its controller's untap step.\nTap five untapped creatures you control: Untap Altar Golem.",
             "colours": [],
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "0acaee76-73b5-5439-b793-190cfac530ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca66c361-3cea-4f9c-836d-3513f05d6b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca66c361-3cea-4f9c-836d-3513f05d6b22.jpg?1",
             "name": "Antler Skulkin",
             "text": "{2}: Target white creature gains persist until end of turn. (When it's put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "866b0c2b-7344-584a-b3a1-74bc6a50a903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5ed574-4ff2-4f67-8989-d3e47ba1d750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5ed574-4ff2-4f67-8989-d3e47ba1d750.jpg?1",
             "name": "Fang Skulkin",
             "text": "{2}: Target black creature gains wither until end of turn. (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [],
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "839e9b19-8728-5a74-bf89-3547ef349318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea91be37-aca0-484a-ab94-0186073269d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea91be37-aca0-484a-ab94-0186073269d2.jpg?1",
             "name": "Hoof Skulkin",
             "text": "{3}: Target green creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "d0f77126-ff3c-59ba-9207-8415c40a2744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a88f807-96ce-432f-aaf5-d0097d234a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a88f807-96ce-432f-aaf5-d0097d234a4b.jpg?1",
             "name": "Jawbone Skulkin",
             "text": "{2}: Target red creature gains haste until end of turn.",
             "colours": [],
@@ -5909,7 +5909,7 @@
         },
         {
             "id": "00730563-84b6-562e-bf0a-51b2fdaf583c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bcabd-7bbe-463c-a35a-992c12c4e4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bcabd-7bbe-463c-a35a-992c12c4e4bf.jpg?1",
             "name": "Leering Emblem",
             "text": "Whenever you play a spell, equipped creature gets +2/+2 until end of turn.\nEquip {2}",
             "colours": [],
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "4696cb7b-484d-5035-afba-9829d160cba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1978400d-a8f1-4df7-8caf-b9ca81334bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1978400d-a8f1-4df7-8caf-b9ca81334bce.jpg?1",
             "name": "Scarecrone",
             "text": "{1}, Sacrifice a Scarecrow: Draw a card.\n{4}, {T}: Return target artifact creature card from your graveyard to play.",
             "colours": [],
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "401963b9-f54f-544c-bbe8-d32d2cca8758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0953373-66e1-4af1-a4ec-cc990e20a1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0953373-66e1-4af1-a4ec-cc990e20a1de.jpg?1",
             "name": "Shell Skulkin",
             "text": "{3}: Target blue creature gains shroud until end of turn.",
             "colours": [],
@@ -6001,7 +6001,7 @@
         },
         {
             "id": "975ccf00-3a2f-5ca6-b381-2e64b3e2759e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a271351e-5d5e-443b-99a4-ebdc8a3c4923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a271351e-5d5e-443b-99a4-ebdc8a3c4923.jpg?1",
             "name": "Ward of Bones",
             "text": "Each opponent who controls more creatures than you can't play creature cards. The same is true for artifacts, enchantments, and lands.",
             "colours": [],
@@ -6029,7 +6029,7 @@
         },
         {
             "id": "f4b7766a-8590-57bf-b625-159c8f9c4103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eede44-270a-481d-850b-b4862b9685ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eede44-270a-481d-850b-b4862b9685ea.jpg?1",
             "name": "Cascade Bluffs",
             "text": "{T}: Add {1} to your mana pool.\n{UR}, {T}: Add {U}{U}, {U}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "feecb7fd-b8c3-5136-9114-2b7257a2a766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb9790-3744-4dcb-881a-452573298822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb9790-3744-4dcb-881a-452573298822.jpg?1",
             "name": "Fetid Heath",
             "text": "{T}: Add {1} to your mana pool.\n{WB}, {T}: Add {W}{W}, {W}{B}, or {B}{B} to your mana pool.",
             "colours": [],
@@ -6091,7 +6091,7 @@
         },
         {
             "id": "b584f07b-e23b-5af1-bad0-944054694522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e45d16b-8320-4a9b-ad15-9687dfb52bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e45d16b-8320-4a9b-ad15-9687dfb52bed.jpg?1",
             "name": "Flooded Grove",
             "text": "{T}: Add {1} to your mana pool.\n{GW}, {T}: Add {G}{G}, {G}{U}, or {U}{U} to your mana pool.",
             "colours": [],
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "27e87e79-77ff-5179-b9f6-597433b8a038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31f8b2a-acf4-423c-bc99-8cf44f3c018a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31f8b2a-acf4-423c-bc99-8cf44f3c018a.jpg?1",
             "name": "Rugged Prairie",
             "text": "{T}: Add {1} to your mana pool.\n{GU}, {T}: Add {R}{R}, {R}{W}, or {W}{W} to your mana pool.",
             "colours": [],
@@ -6153,7 +6153,7 @@
         },
         {
             "id": "8db72e25-a8e8-529e-b017-e9136665691b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02df7f4-c664-48bd-9508-f0b4298b1ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02df7f4-c664-48bd-9508-f0b4298b1ef8.jpg?1",
             "name": "Springjack Pasture",
             "text": "{T}: Add {1} to your mana pool.\n{4}, {T}: Put a 0/1 white Goat creature token into play.\n{T}, Sacrifice X Goats: Add X mana of any one color to your mana pool. You gain X life.",
             "colours": [],
@@ -6181,7 +6181,7 @@
         },
         {
             "id": "7a39815b-7cac-550f-ad76-84167d8a9df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff619a09-4fe5-4341-9077-88a0a9f4fbf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff619a09-4fe5-4341-9077-88a0a9f4fbf9.jpg?1",
             "name": "Twilight Mire",
             "text": "{T}: Add {1} to your mana pool.\n{BG}, {T}: Add {B}{B}, {B}{G}, or {G}{G} to your mana pool.",
             "colours": [],
@@ -6212,7 +6212,7 @@
         },
         {
             "id": "da3796c8-1666-58fd-b962-3e960cd28bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f67615-8a09-4ab9-9927-899a15e72c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f67615-8a09-4ab9-9927-899a15e72c03.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -6246,7 +6246,7 @@
         },
         {
             "id": "4a3f32ed-8d70-5358-adde-7c206a525b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453ee89-6122-4d51-989c-e78b046a9de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453ee89-6122-4d51-989c-e78b046a9de3.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "0f7766ea-bb7c-5936-967b-49eac1f8fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc3a29a-280d-4f2c-9a01-8cfead75f583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc3a29a-280d-4f2c-9a01-8cfead75f583.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "c39b810f-d8ab-5fd6-a971-5e5017d7b511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d8e99-a530-4eec-a938-254c98073975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d8e99-a530-4eec-a938-254c98073975.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "e59691aa-e1f1-5b09-836c-3104c1f45bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c702fc63-4a79-4c54-b22e-7e479b8354d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c702fc63-4a79-4c54-b22e-7e479b8354d2.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "daae7519-b9df-5c2d-9bde-25d115b7ece3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0788f7a4-793a-42f4-a7c9-05e4b4587897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0788f7a4-793a-42f4-a7c9-05e4b4587897.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "69863b68-0cee-589c-a3d4-b02bbce9db2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e836db04-161c-4f4f-88d2-4271cec62008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e836db04-161c-4f4f-88d2-4271cec62008.jpg?1",
             "name": "Goblin Soldier",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/EXO.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/EXO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6eeb61a0-ea46-56f3-8118-89a32ffda0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20a1c6d-ec6a-4bd6-b3b2-b997f71d41fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20a1c6d-ec6a-4bd6-b3b2-b997f71d41fc.jpg?1",
             "name": "Allay",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target enchantment.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "0c1cf88e-67ca-516a-b59e-8a45585741f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3c8bae-953f-4bb4-a78d-02e4e354e53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3c8bae-953f-4bb4-a78d-02e4e354e53c.jpg?1",
             "name": "Angelic Blessing",
             "text": "Target creature gets +3/+3 and gains flying until end of turn.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "033d8210-7238-53cb-aacc-ac11cde3fc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024ae668-a1ae-4020-89c8-acbd8bd0a691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024ae668-a1ae-4020-89c8-acbd8bd0a691.jpg?1",
             "name": "Cataclysm",
             "text": "Each player chooses from the permanents he or she controls an artifact, a creature, an enchantment, and a land and sacrifices the rest.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "3a42c724-19e3-5ab5-989c-0d4d9cd8c17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f3f72-2923-4432-898a-02679a8b320f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f3f72-2923-4432-898a-02679a8b320f.jpg?1",
             "name": "Charging Paladin",
             "text": "If Charging Paladin attacks, it gets +0/+3 until end of turn.",
             "colours": [
@@ -131,7 +131,7 @@
         },
         {
             "id": "7cb04fb1-81b8-5d7f-b91b-47c3d64770bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd49a61-42ba-400a-8ca9-9f6058bf85ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd49a61-42ba-400a-8ca9-9f6058bf85ca.jpg?1",
             "name": "Convalescence",
             "text": "During your upkeep, if you have 10 or less life, gain 1 life.",
             "colours": [
@@ -162,7 +162,7 @@
         },
         {
             "id": "6f21746e-87ab-569a-bd4e-1ba4829c81b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7537bab3-4bac-4b83-9ad3-dfcb4ff19d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7537bab3-4bac-4b83-9ad3-dfcb4ff19d6d.jpg?1",
             "name": "Exalted Dragon",
             "text": "Flying\nEach turn, Exalted Dragon cannot attack unless you sacrifice a land.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "18bbb8c7-336b-5eb2-b92f-6a3e34fd0943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5239dc-f51b-48c0-91a2-ed6551aaff32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5239dc-f51b-48c0-91a2-ed6551aaff32.jpg?1",
             "name": "High Ground",
             "text": "Each creature you control may block one additional creature. (All defense must be legal.)",
             "colours": [
@@ -226,7 +226,7 @@
         },
         {
             "id": "1f029ee4-cb61-5510-99d6-99188b16885f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eda847-c599-4163-b48b-aa76b153ed86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eda847-c599-4163-b48b-aa76b153ed86.jpg?1",
             "name": "Keeper of the Light",
             "text": "o\nW, oc\nT: Gain 3 life. Play this ability only if you have less life than target opponent.",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "5dff28fd-f1d1-503a-811a-f051f9f98a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc61cc3-0312-44f4-9c23-4fc37c3fbbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc61cc3-0312-44f4-9c23-4fc37c3fbbd5.jpg?1",
             "name": "Kor Chant",
             "text": "Redirect to target creature all damage dealt to any one creature you control from any one source.",
             "colours": [
@@ -291,7 +291,7 @@
         },
         {
             "id": "43d9cb2c-c26c-53db-886e-ffabb72cf3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ae3609-a3cc-486c-94f6-b8f647adfb47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ae3609-a3cc-486c-94f6-b8f647adfb47.jpg?1",
             "name": "Limited Resources",
             "text": "When Limited Resources comes into play, each player chooses five lands he or she controls and sacrifices the rest.\nAs long as there are ten or more lands in play, players cannot play lands.",
             "colours": [
@@ -322,7 +322,7 @@
         },
         {
             "id": "1ae3cbd6-2c63-5936-b3f4-db3dc63c7a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470a2092-eeda-4557-8cee-ac401b61a225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470a2092-eeda-4557-8cee-ac401b61a225.jpg?1",
             "name": "Oath of Lieges",
             "text": "During each player's upkeep, if that player controls fewer lands than target opponent, the player may search his or her library for a basic land card and put that land into play. The player shuffles his or her library afterwards.",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "de082077-37e1-5ce8-a345-d22026487e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1ea89d-4b9d-455f-a7f4-a26026e0c272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1ea89d-4b9d-455f-a7f4-a26026e0c272.jpg?1",
             "name": "Paladin en-Vec",
             "text": "First strike, protection from black, protection from red",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "f1253730-e2ff-5886-adff-efb29db76322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c383f12f-da06-4ef0-bf8e-6a8a9cfcc74c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c383f12f-da06-4ef0-bf8e-6a8a9cfcc74c.jpg?1",
             "name": "Peace of Mind",
             "text": "o\nW, Choose and discard a card: Gain 3 life.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "e4c27329-ba8b-5fc7-ba9c-d75bfadf805e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b941576-8254-4d69-85ae-c748c7921ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b941576-8254-4d69-85ae-c748c7921ce5.jpg?1",
             "name": "Pegasus Stampede",
             "text": "Buyback\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Pegasus Stampede into your hand instead of your graveyard as part of the spell's effect.)\nPut a Pegasus token into play. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "9246de07-091e-50a5-9273-62e3225887b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3db848-8394-43bd-a236-264641033a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3db848-8394-43bd-a236-264641033a6d.jpg?1",
             "name": "Penance",
             "text": "Choose a card from your hand and put that card on top of your library: Prevent all damage from a black or red source. (Treat further damage from that source normally.)",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "a0d36f71-25b1-5881-8f9d-323fb9f322d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379b0495-8795-4b21-9d0a-dc4e10098de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379b0495-8795-4b21-9d0a-dc4e10098de2.jpg?1",
             "name": "Reaping the Rewards",
             "text": "Buyback\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Reaping the Rewards into your hand instead of your graveyard as part of the spell's effect.)\nGain 2 life.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "a52218c4-fc79-5fb4-b45b-a823db604f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16012d8-703c-4385-8769-13e3caba3fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16012d8-703c-4385-8769-13e3caba3fc6.jpg?1",
             "name": "Reconnaissance",
             "text": "o0: Remove target attacking creature you control from combat and untap it. (That creature neither deals nor receives combat damage this turn.)",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "35967038-f8fc-5986-a9a1-cfdc37b93a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5315668-b8ef-49ab-a8f5-144adc7bcd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5315668-b8ef-49ab-a8f5-144adc7bcd84.jpg?1",
             "name": "Shackles",
             "text": "Enchanted creature does not untap during its controller's untap phase.\noo\nW Return Shackles to owner's hand.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "a2029eeb-3dcb-5099-9ecb-72cbcb505308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49261bb-66b5-4226-9001-02d045fbcbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49261bb-66b5-4226-9001-02d045fbcbce.jpg?1",
             "name": "Shield Mate",
             "text": "Sacrifice Shield Mate: Target creature gets +0/+4 until end of turn.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "a8ec8b5b-b7d3-56d9-b770-55e960e9d9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3ae384-7b60-4264-9dc1-1613917168ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3ae384-7b60-4264-9dc1-1613917168ca.jpg?1",
             "name": "Soltari Visionary",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Visionary damages any player, destroy target enchantment that player controls.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "81a73b58-804f-5ae7-81c8-cbd680f3af6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ee24ee-4d28-4634-bd43-90eff15c16dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ee24ee-4d28-4634-bd43-90eff15c16dd.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever any other creature comes into play, gain 1 life.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "de06f13a-708b-5155-adc8-40f2e3435cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135e258a-71d8-45dd-9307-91111aa34bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135e258a-71d8-45dd-9307-91111aa34bde.jpg?1",
             "name": "Standing Troops",
             "text": "Attacking does not cause Standing Troops to tap.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "7f0d3965-257b-59b2-8703-60218456ba9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06452630-621b-498e-8f25-ecfe544d4213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06452630-621b-498e-8f25-ecfe544d4213.jpg?1",
             "name": "Treasure Hunter",
             "text": "When Treasure Hunter comes into play, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "0b1a698a-3c82-5cbf-91ba-0b7c7deb5a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1da8e79-365d-4a36-87c5-648085828f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1da8e79-365d-4a36-87c5-648085828f9f.jpg?1",
             "name": "Wall of Nets",
             "text": "(Walls cannot attack.)\nAt end of combat, remove from the game all creatures blocked by Wall of Nets.\nIf Wall of Nets leaves play, return to play under their owners' control all creatures removed from the game with Wall of Nets.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "7c320fb6-1943-503f-9982-96600f413d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8166253c-c6ac-4b5e-9746-09ce3774c66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8166253c-c6ac-4b5e-9746-09ce3774c66b.jpg?1",
             "name": "Welkin Hawk",
             "text": "Flying\nIf Welkin Hawk is put into any graveyard from play, you may search your library for a Welkin Hawk card, reveal that card to all players, and put it into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "b0ce8e40-719b-524e-ab32-4bdb2ae7ce49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9fb486-1d6a-478e-af6e-fd8539dc646d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9fb486-1d6a-478e-af6e-fd8539dc646d.jpg?1",
             "name": "Zealots en-Dal",
             "text": "During your upkeep, if all nonland permanents you control are white, gain 1 life.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "c52455af-fd3a-585a-a407-dd07d1625521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aab7526-5825-4f31-92ff-be25ab5af2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aab7526-5825-4f31-92ff-be25ab5af2f5.jpg?1",
             "name": "Aether Tide",
             "text": "Choose and discard X creature cards: Return X target creatures to their owner's hand.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "1cebea0d-f8cb-5ee4-8915-e99f8bfb22f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f36bb8-5a97-4596-8ca3-707665770c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f36bb8-5a97-4596-8ca3-707665770c76.jpg?1",
             "name": "Cunning",
             "text": "Enchanted creature gets +3/+3.\nIf enchanted creature attacks or blocks, sacrifice Cunning at end of turn.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "0b550b62-2a83-5006-af52-79742c04633e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee17ef5-7e1a-42ae-b680-df81204df7dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee17ef5-7e1a-42ae-b680-df81204df7dd.jpg?1",
             "name": "Curiosity",
             "text": "If enchanted creature damages an opponent, you may draw a card.",
             "colours": [
@@ -941,7 +941,7 @@
         },
         {
             "id": "72a5c776-0d93-5434-b0db-6315ce28265a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e03323-43e8-4ddc-a874-211a97fd7648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e03323-43e8-4ddc-a874-211a97fd7648.jpg?1",
             "name": "Dominating Licid",
             "text": "o1o\nUo\nU, oc\nT: Dominating Licid loses this ability and becomes a creature enchantment that reads \"Gain control of enchanted creature\" instead of any other type of permanent. Move Dominating Licid onto target creature. You may pay o\nU to end this effect.",
             "colours": [
@@ -974,7 +974,7 @@
         },
         {
             "id": "e9206e1d-7c2b-518e-ae7e-3227770b6e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cdcd3b-6df5-481a-a244-1fc2545d1356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2cdcd3b-6df5-481a-a244-1fc2545d1356.jpg?1",
             "name": "Ephemeron",
             "text": "Flying\nChoose and discard a card: Return Ephemeron to owner's hand.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "cf9f7ba1-13cd-592b-b50f-3e89ced55f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460b2ec6-0180-4214-acca-c9eed778ef50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460b2ec6-0180-4214-acca-c9eed778ef50.jpg?1",
             "name": "Equilibrium",
             "text": "Whenever you successfully cast a creature spell, you may pay o1 to return target creature to owner's hand.",
             "colours": [
@@ -1038,7 +1038,7 @@
         },
         {
             "id": "8806c719-4992-54dd-9263-320a344a0da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91971e19-61ce-45ac-b700-9ffca5091a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91971e19-61ce-45ac-b700-9ffca5091a27.jpg?1",
             "name": "Ertai, Wizard Adept",
             "text": "Ertai, Wizard Adept counts as a Wizard.\no2o\nUo\nU, oc\nT: Counter target spell. Play this ability as an interrupt.",
             "colours": [
@@ -1074,7 +1074,7 @@
         },
         {
             "id": "85b99b7d-7c0d-55dc-b660-26ac4768b42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f9103e-dcc2-4f7a-a8ca-eaa831f5f83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f9103e-dcc2-4f7a-a8ca-eaa831f5f83b.jpg?1",
             "name": "Fade Away",
             "text": "For each creature, that creature's controller pays o1 or sacrifices a permanent.",
             "colours": [
@@ -1105,7 +1105,7 @@
         },
         {
             "id": "e5bc597e-b51e-56eb-8560-11056578d552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29df5ef7-d679-4543-bdb7-3984155c87e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29df5ef7-d679-4543-bdb7-3984155c87e0.jpg?1",
             "name": "Forbid",
             "text": "Buyback\u2014\nChoose and discard two cards. (You may choose and discard two cards in addition to any other costs when you play this spell. If you do, put Forbid into your hand instead of your graveyard as part of the spell's effect.)\nCounter target spell.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "2059afee-3f3a-5587-babb-88dbccaee73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc232d4-ab4f-4d88-a9ec-72403d05ec04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc232d4-ab4f-4d88-a9ec-72403d05ec04.jpg?1",
             "name": "Keeper of the Mind",
             "text": "o\nU, oc\nT: Draw a card. Play this ability only if target opponent has at least two more cards in hand than you.",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "ce3ff3e3-6e11-5971-a8ef-ba3e9efb8329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d932f6d3-4918-4a41-836c-4eaa6cfac049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d932f6d3-4918-4a41-836c-4eaa6cfac049.jpg?1",
             "name": "Killer Whale",
             "text": "oo\nU Killer Whale gains flying until end of turn.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "f4a69d59-475a-54d6-a6ee-661550289927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a97f019-5ad9-4520-ba79-2c9b259748d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a97f019-5ad9-4520-ba79-2c9b259748d9.jpg?1",
             "name": "Mana Breach",
             "text": "Whenever any player plays a spell, that player returns a land he or she controls to owner's hand.",
             "colours": [
@@ -1234,7 +1234,7 @@
         },
         {
             "id": "ef4340b6-d60e-5107-8868-bc12c502c1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb1c41-388f-4ff2-af37-ad64a0f4618e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbb1c41-388f-4ff2-af37-ad64a0f4618e.jpg?1",
             "name": "Merfolk Looter",
             "text": "oc\nT: Draw a card, then choose and discard a card.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "47c1848a-9b00-568d-9a4d-5a3e24f0c914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e091dd6-149f-46ea-bae0-224e79e3aacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e091dd6-149f-46ea-bae0-224e79e3aacb.jpg?1",
             "name": "Mind Over Matter",
             "text": "Choose and discard a card: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "b10738f3-d416-5adc-8140-5c798aab779b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16417e94-e33f-4ed4-bb3e-52f29f7d441b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16417e94-e33f-4ed4-bb3e-52f29f7d441b.jpg?1",
             "name": "Mirozel",
             "text": "Flying\nIf Mirozel is the target of any spell or ability, return Mirozel to owner's hand.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "027750b1-809f-5833-b5bc-3b04b2084cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61376ad-21c8-4d34-b37d-ed60877f5d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61376ad-21c8-4d34-b37d-ed60877f5d4a.jpg?1",
             "name": "Oath of Scholars",
             "text": "During each player's upkeep, if that player has fewer cards in hand than target opponent, the player may discard his or her hand and draw three cards.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "82d8a704-9fc8-5b07-98af-b36e3e1ec051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371720a2-ec3f-43a5-9551-c018e164e79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371720a2-ec3f-43a5-9551-c018e164e79f.jpg?1",
             "name": "Robe of Mirrors",
             "text": "Enchanted creature cannot be the target of spells or abilities.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "26b4edef-e58f-5d8e-9c55-9e480473f4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94af81f2-383c-4129-b8dc-60633c3f4ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94af81f2-383c-4129-b8dc-60633c3f4ea1.jpg?1",
             "name": "Rootwater Mystic",
             "text": "o1oo\nU Look at the top card of target player's library.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "4807bd11-8a63-5129-bd56-85eb8d9933ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71217af5-3538-4e42-9343-3949b5306671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71217af5-3538-4e42-9343-3949b5306671.jpg?1",
             "name": "School of Piranha",
             "text": "During your upkeep, pay o1o\nU or sacrifice School of Piranha.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "b663c159-504d-5b95-9ae5-36a9034a3915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b236bba-160a-4637-a83e-8456834ce59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b236bba-160a-4637-a83e-8456834ce59f.jpg?1",
             "name": "Scrivener",
             "text": "When Scrivener comes into play, you may return target instant or interrupt card from your graveyard to your hand.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "30cf7f9c-81d9-52a8-85fd-8c6e4575cddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e13d2-6bd7-403c-8e2e-e00917b39597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e13d2-6bd7-403c-8e2e-e00917b39597.jpg?1",
             "name": "Thalakos Drifters",
             "text": "Choose and discard a card: Thalakos Drifters gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1530,7 +1530,7 @@
         },
         {
             "id": "58a812dc-9d44-5dba-b3a1-f7bf93ce619b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1703fe9d-ca70-4e8a-9d6a-6173a17d0f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1703fe9d-ca70-4e8a-9d6a-6173a17d0f04.jpg?1",
             "name": "Thalakos Scout",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nChoose and discard a card: Return Thalakos Scout to owner's hand.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "b913f6ed-3c82-5173-92b8-81b31b0f502b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099da8aa-16b1-4395-8467-1636feb14a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099da8aa-16b1-4395-8467-1636feb14a8a.jpg?1",
             "name": "Theft of Dreams",
             "text": "For each tapped creature target opponent controls, draw a card.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "ada1ef96-1161-5cd3-a732-e58b76608321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ce909-e744-47ca-943d-62d97e97b1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ce909-e744-47ca-943d-62d97e97b1ea.jpg?1",
             "name": "Treasure Trove",
             "text": "o2o\nUoo\nU Draw a card.",
             "colours": [
@@ -1627,7 +1627,7 @@
         },
         {
             "id": "120575e6-ed6a-5568-8e67-27e33ed308e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f96d5d-1d16-40bb-aaa7-8a7dd465d37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f96d5d-1d16-40bb-aaa7-8a7dd465d37b.jpg?1",
             "name": "Wayward Soul",
             "text": "Flying\noo\nU Put Wayward Soul on top of owner's library.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "b41ab697-6f63-5d7b-be26-e9f28150d72a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc17186-e786-46a3-9812-4a6e367e78b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc17186-e786-46a3-9812-4a6e367e78b9.jpg?1",
             "name": "Whiptongue Frog",
             "text": "oo\nU Whiptongue Frog gains flying until end of turn.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "37430fe8-172d-596f-b71e-066941598242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c057f-cb1b-4895-831a-fb35c75d3845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c057f-cb1b-4895-831a-fb35c75d3845.jpg?1",
             "name": "Carnophage",
             "text": "During your upkeep, pay 1 life or tap Carnophage.",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "286685ac-0c97-5df5-a51f-d6782b951e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947109f9-7035-4a2a-bbc2-a2958f8c5d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947109f9-7035-4a2a-bbc2-a2958f8c5d01.jpg?1",
             "name": "Cat Burglar",
             "text": "o2o\nB, oc\nT: Target player chooses and discards a card. Play this ability as a sorcery.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "28af757d-5e16-5725-9a81-d3b8b1bd97d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c33f18-0a5c-4e46-ab0d-6e450915594f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c33f18-0a5c-4e46-ab0d-6e450915594f.jpg?1",
             "name": "Culling the Weak",
             "text": "Sacrifice a creature: Add o\nBo\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "7fe15dd1-1b85-5c6e-9819-40627fe20211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7433b9bf-ee6e-41fe-b826-0d20584198b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7433b9bf-ee6e-41fe-b826-0d20584198b1.jpg?1",
             "name": "Cursed Flesh",
             "text": "Enchanted creature gets -1/-1 and cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "6ff71206-c05c-5ade-a42b-13cbb4f9ae4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127b8994-fff8-4500-8ab4-244eeb3ed110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/127b8994-fff8-4500-8ab4-244eeb3ed110.jpg?1",
             "name": "Dauthi Cutthroat",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no1o\nB, oc\nT: Destroy target creature with shadow.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "66abba6d-cbcd-50bb-8abb-72252187ab64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419871bc-f036-4244-8b6c-3857ebe993f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419871bc-f036-4244-8b6c-3857ebe993f3.jpg?1",
             "name": "Dauthi Jackal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no\nBo\nB, Sacrifice Dauthi Jackal: Destroy target blocking creature.",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "0e984450-ed46-5b17-ab0f-f589cdab2312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ca689-482a-457d-9744-0bd79981f361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3ca689-482a-457d-9744-0bd79981f361.jpg?1",
             "name": "Dauthi Warlord",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Warlord has power equal to the number of creatures with shadow in play.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "3bbed77b-5352-5dcd-88a1-00eec600e728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4756b6fd-2bb2-4be1-9b02-851a26ff4303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4756b6fd-2bb2-4be1-9b02-851a26ff4303.jpg?1",
             "name": "Death's Duet",
             "text": "Return two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -1958,7 +1958,7 @@
         },
         {
             "id": "b11f15be-6184-56f2-9611-829df104777d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb04d81-b0ab-4bc7-935d-c31005887240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb04d81-b0ab-4bc7-935d-c31005887240.jpg?1",
             "name": "Entropic Specter",
             "text": "Flying\nEntropic Specter has power and toughness each equal to the number of cards in target opponent's hand.\nIf Entropic Specter damages any player, that player chooses and discards a card.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "053f3c6c-5bfb-5f53-90bb-56f5b1ff94f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1629cd63-95aa-40b6-aa57-7fb88f569e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1629cd63-95aa-40b6-aa57-7fb88f569e59.jpg?1",
             "name": "Fugue",
             "text": "Target player chooses and discards three cards.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "393266ac-2012-55e4-a3dc-d3634465013f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f6301a-d581-4aaf-9993-3013323074aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f6301a-d581-4aaf-9993-3013323074aa.jpg?1",
             "name": "Grollub",
             "text": "For each 1 damage dealt to Grollub, each opponent gains 1 life.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "67ac1d38-e935-5955-a8a1-3860587eadd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2383a8d9-96fd-4f9a-bcf9-eb81fdb15ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2383a8d9-96fd-4f9a-bcf9-eb81fdb15ead.jpg?1",
             "name": "Hatred",
             "text": "Pay X life: Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "3990fc5f-b823-51f1-a8de-c5b75c39665b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b641171-35bc-4945-ada9-3ea28ea9fabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b641171-35bc-4945-ada9-3ea28ea9fabf.jpg?1",
             "name": "Keeper of the Dead",
             "text": "o\nB, oc\nT: Destroy target nonblack creature. Play this ability only if that creature's controller has at least two fewer creature cards in his or her graveyard than you have in yours.",
             "colours": [
@@ -2121,7 +2121,7 @@
         },
         {
             "id": "f18ec648-87bc-5597-91e5-797034de01ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c92a7f-a250-4497-aa7a-0394e94ef13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c92a7f-a250-4497-aa7a-0394e94ef13d.jpg?1",
             "name": "Mind Maggots",
             "text": "When Mind Maggots comes into play, choose and discard any number of creature cards. For each card discarded this way, put two +1/+1 counters on Mind Maggots.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "23aa6a30-f7de-5168-9e71-d87aa6cfa6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10531d8-fc99-4a2b-94b0-97a25521d725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10531d8-fc99-4a2b-94b0-97a25521d725.jpg?1",
             "name": "Nausea",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "676d1dff-2257-5a3b-9fe6-f7af3d15ceae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ee9d9-20be-46f0-8752-1df50942f59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ee9d9-20be-46f0-8752-1df50942f59c.jpg?1",
             "name": "Necrologia",
             "text": "Play Necrologia only during your discard phase.\nPay X life: Draw X cards.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "a35339cf-7b5c-569d-bcee-2d00d5929523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1102f35a-ae62-479d-b61c-31a82978aedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1102f35a-ae62-479d-b61c-31a82978aedd.jpg?1",
             "name": "Oath of Ghouls",
             "text": "During each player's upkeep, if there are more creature cards in that player's graveyard than in target opponent's graveyard, the player may return a creature card from his or her graveyard to his or her hand.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "c29b0822-ffec-5ab8-af54-61e9bea876bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669ad60b-4053-4f07-9072-52e6ff65b4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669ad60b-4053-4f07-9072-52e6ff65b4e3.jpg?1",
             "name": "Pit Spawn",
             "text": "First strike\nDuring your upkeep, pay o\nBo\nB or sacrifice Pit Spawn.\nIf Pit Spawn damages any creature, remove that creature from the game.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "5b7fdf35-7a82-5481-a97d-ff2c87e43afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8493df6-9954-4e33-867c-ca4bcf3953b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8493df6-9954-4e33-867c-ca4bcf3953b2.jpg?1",
             "name": "Plaguebearer",
             "text": "o\nXo\nXoo\nB Destroy target nonblack creature with total casting cost equal to X.",
             "colours": [
@@ -2313,7 +2313,7 @@
         },
         {
             "id": "063929a5-a4d9-5b57-8237-8db43be48342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173030-1c33-417c-b8e9-79231b6a85a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8173030-1c33-417c-b8e9-79231b6a85a7.jpg?1",
             "name": "Recurring Nightmare",
             "text": "Sacrifice a creature, Return Recurring Nightmare to owner's hand: Put target creature card from your graveyard into play. Play this ability as a sorcery.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "864b9ab2-aafc-5ba9-9de7-03b73473feea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9d4e11-ce2e-445a-9536-756a6687d6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9d4e11-ce2e-445a-9536-756a6687d6d7.jpg?1",
             "name": "Scare Tactics",
             "text": "All creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "1d2cc863-b67d-5f89-b4a5-d89ef7b81333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff06c7d-5e78-4bcf-864b-34487f6555b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff06c7d-5e78-4bcf-864b-34487f6555b2.jpg?1",
             "name": "Slaughter",
             "text": "Buyback\u2014\nPay 4 life. (You may pay 4 life in addition to any other costs when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target nonblack creature. That creature cannot be regenerated this turn.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "e534e4b0-75a4-5526-8dc4-4246d03f5bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64003772-c62f-4728-a00c-48c78991c6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64003772-c62f-4728-a00c-48c78991c6ae.jpg?1",
             "name": "Spike Cannibal",
             "text": "Spike Cannibal comes into play with one +1/+1 counter on it.\nWhen Spike Cannibal comes into play, move all +1/+1 counters from all creatures onto Spike Cannibal.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "2ee88115-88f6-56c6-a85b-8b00a602effd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e89bf1-42c9-4829-a565-78cac632810b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e89bf1-42c9-4829-a565-78cac632810b.jpg?1",
             "name": "Thrull Surgeon",
             "text": "o1o\nB, Sacrifice Thrull Surgeon: Look at target player's hand and choose one of those cards. That player discards that card. Play this ability as a sorcery.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "f6fdc3c5-4bdb-5213-b763-c374c3c16bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746bc301-9f08-4d9b-819e-690f6fce6bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746bc301-9f08-4d9b-819e-690f6fce6bc8.jpg?1",
             "name": "Vampire Hounds",
             "text": "Choose and discard a creature card: Vampire Hounds gets +2/+2 until end of turn.",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "4248f87e-7c73-502a-bc5a-ff6e60c3e07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab28e1-74e1-4c4e-920f-a658c6a44d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab28e1-74e1-4c4e-920f-a658c6a44d75.jpg?1",
             "name": "Volrath's Dungeon",
             "text": "Any player may pay 5 life during his or her turn to destroy Volrath's Dungeon.\nChoose and discard a card: Target player chooses a card in his or her hand and puts that card on top of his or her library. Play this ability as a sorcery.",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "2efaaaf9-beed-5d3f-95c0-bd48fb172d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a298df66-2075-40a7-bced-457656b6b788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a298df66-2075-40a7-bced-457656b6b788.jpg?1",
             "name": "Anarchist",
             "text": "When Anarchist comes into play, you may return target sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "3988282c-85d8-513b-9b7b-506b201dac0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9406050-d76b-4569-a463-e21acaf84166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9406050-d76b-4569-a463-e21acaf84166.jpg?1",
             "name": "Cinder Crawler",
             "text": "oo\nR Cinder Crawler gets +1/+0 until end of turn. Use this ability only if Cinder Crawler is blocked.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "614b94f8-4622-5d0f-9241-8e2840c653c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a482cf-a1cd-47b5-a76a-08e03965c679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a482cf-a1cd-47b5-a76a-08e03965c679.jpg?1",
             "name": "Dizzying Gaze",
             "text": "Play Dizzying Gaze only on a creature you control.\noo\nR Enchanted creature deals 1 damage to target creature with flying.",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "df323991-5e1a-5551-a28c-ad6a1e0a11fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75f6e9-5eee-4904-88c0-71ec730a0f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75f6e9-5eee-4904-88c0-71ec730a0f23.jpg?1",
             "name": "Fighting Chance",
             "text": "For each blocking creature, flip a coin. If you win the flip, that creature deals no combat damage this turn.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "7cd6dfc0-26da-5719-a25d-8aa8fcbb205f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcda003-6fac-4879-87e6-ec0c115630ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcda003-6fac-4879-87e6-ec0c115630ba.jpg?1",
             "name": "Flowstone Flood",
             "text": "Buyback\u2014\nPay 3 life, Discard a card at random. (You may pay 3 life and discard a card at random in addition to any other costs when you play this spell. If you do, put Flowstone Flood into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target land.",
             "colours": [
@@ -2699,7 +2699,7 @@
         },
         {
             "id": "7db4bad4-f785-5404-b48e-4b72c36b80e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79c6d9-96f1-434a-89b8-d773aa77ac5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79c6d9-96f1-434a-89b8-d773aa77ac5e.jpg?1",
             "name": "Furnace Brood",
             "text": "oo\nR Target creature cannot be regenerated this turn.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "bc580b31-a4ef-5b30-99d0-b3638cf17769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf246ca-9dfc-400f-8883-acc80ac016e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf246ca-9dfc-400f-8883-acc80ac016e1.jpg?1",
             "name": "Keeper of the Flame",
             "text": "o\nR, oc\nT: Keeper of the Flame deals 2 damage to target opponent. Use this ability only if that opponent has more life than you.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "e30ae589-4537-5533-8afc-5230dec41d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e3e38b-2191-4b92-ae5d-bb9397d24a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e3e38b-2191-4b92-ae5d-bb9397d24a27.jpg?1",
             "name": "Mage il-Vec",
             "text": "oc\nT, Discard a card at random: Mage il-Vec deals 1 damage to target creature or player.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "840f30ab-03e7-55ef-9731-3ac604a9135b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3aa840f-6a70-4674-acb7-ded0ea4397d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3aa840f-6a70-4674-acb7-ded0ea4397d8.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchanted creature gets +2/+2 and cannot block.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "0d4dc355-7dd4-512a-9046-809207bc6782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1124725d-e643-43a1-873e-255636c7f334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1124725d-e643-43a1-873e-255636c7f334.jpg?1",
             "name": "Mogg Assassin",
             "text": "oc\nT: Flip a coin. If you win the flip, destroy target creature an opponent controls. Otherwise, destroy target creature of that opponent's choice.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "c851f73d-d85a-5439-a4ef-bab1cedfcafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5066b1b-3910-4434-83d6-030851f20bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5066b1b-3910-4434-83d6-030851f20bcf.jpg?1",
             "name": "Monstrous Hound",
             "text": "Monstrous Hound cannot attack unless you control more lands than defending player.\nMonstrous Hound cannot block unless you control more lands than attacking player.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "cc2b64a2-d949-5a2f-9446-9892c3516e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8708d2-2c73-4da5-b6ff-41c083b59caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8708d2-2c73-4da5-b6ff-41c083b59caa.jpg?1",
             "name": "Oath of Mages",
             "text": "During each player's upkeep, if that player has less life than target opponent, he or she may have Oath of Mages deal 1 damage to that opponent.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "8b997794-4c6f-57ea-a2cf-f5f49fc28d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3224ac-9b60-48cf-9734-86768fd370ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3224ac-9b60-48cf-9734-86768fd370ac.jpg?1",
             "name": "Ogre Shaman",
             "text": "o2, Discard a card at random: Ogre Shaman deals 2 damage to target creature or player.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "3e917bef-a284-5c8b-b3cd-70922804d760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afaf142-dbca-45bf-aea2-01c53bda635a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afaf142-dbca-45bf-aea2-01c53bda635a.jpg?1",
             "name": "Onslaught",
             "text": "Whenever you successfully cast a creature spell, tap target creature.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "9e40c654-bb8c-5b20-8142-944bd1832d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f618231-28bb-4cdd-b887-a8aa186814d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f618231-28bb-4cdd-b887-a8aa186814d5.jpg?1",
             "name": "Pandemonium",
             "text": "Whenever any creature comes into play, that creature's controller may choose to have it deal damage equal to its power to target creature or player.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "3bb91b71-f9f5-510c-ab9a-bb7b839d558d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53320321-4f02-40ee-8171-2375b1d4ed66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53320321-4f02-40ee-8171-2375b1d4ed66.jpg?1",
             "name": "Paroxysm",
             "text": "During the upkeep of enchanted creature's controller, reveal the top card of that player's library to all players. If that card is a land card, destroy enchanted creature. Otherwise, enchanted creature gets +3/+3 until end of turn. (Return the card to the top of the player's library, face down.)",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "1dba2ff6-17b8-5af4-b036-126046cebc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5283db-3e22-4862-9d95-56d03d09c2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5283db-3e22-4862-9d95-56d03d09c2ae.jpg?1",
             "name": "Price of Progress",
             "text": "Price of Progress deals 2 damage to each player for each nonbasic land he or she controls.",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "fd41c261-d282-543b-ae32-cc38f5505060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0a166c-f7c0-45b4-aa90-053ce545cfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0a166c-f7c0-45b4-aa90-053ce545cfb2.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness.",
             "colours": [
@@ -3125,7 +3125,7 @@
         },
         {
             "id": "5ededc32-1479-50cb-86ef-646eee6802df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d00b68b-8b6a-48c9-8911-2a3270897091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d00b68b-8b6a-48c9-8911-2a3270897091.jpg?1",
             "name": "Ravenous Baboons",
             "text": "When Ravenous Baboons comes into play, destroy target nonbasic land.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "f7576f1b-1f69-52b3-bd5b-e8f79984f4e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d27b79-a22d-48d9-86b2-7ad02cab8697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d27b79-a22d-48d9-86b2-7ad02cab8697.jpg?1",
             "name": "Reckless Ogre",
             "text": "If Reckless Ogre attacks and no other creatures do, it gets +3/+0 until end of turn.",
             "colours": [
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "ee540c7f-0774-5693-85d9-69b1f5ea3771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c1d384-d341-4bab-bf71-5dbcf76d51e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c1d384-d341-4bab-bf71-5dbcf76d51e8.jpg?1",
             "name": "Sabertooth Wyvern",
             "text": "Flying, first strike",
             "colours": [
@@ -3224,7 +3224,7 @@
         },
         {
             "id": "3dcac15b-c8f3-5498-9cea-aea952007395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0e9433-88d7-4bfc-99a0-ff47807fd594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0e9433-88d7-4bfc-99a0-ff47807fd594.jpg?1",
             "name": "Scalding Salamander",
             "text": "o0: Scalding Salamander deals 1 damage to each creature without flying defending player controls. Play this ability only if Scalding Salamander is attacking and only once each turn.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "8ad24bd0-598b-5c4a-9451-e65c364a7e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc494af5-4da4-43f5-a193-426ef84d80a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc494af5-4da4-43f5-a193-426ef84d80a7.jpg?1",
             "name": "Seismic Assault",
             "text": "Choose and discard a land card: Seismic Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "00e99d4c-8aff-56b8-851e-ed83450095e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d3b846-6071-4d65-86ba-da08c4bd0aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d3b846-6071-4d65-86ba-da08c4bd0aa1.jpg?1",
             "name": "Shattering Pulse",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDestroy target artifact.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "97313f2c-0ed4-5475-b6ed-2c59133aae22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05530d5a-dcb6-403e-9e35-224c7b5cf615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05530d5a-dcb6-403e-9e35-224c7b5cf615.jpg?1",
             "name": "Sonic Burst",
             "text": "Discard a card at random: Sonic Burst deals 4 damage to target creature or player.",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "2be15898-9758-59b1-a378-d1b2445ee9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db2a78-e1c5-4732-a4ee-04b4c540edbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db2a78-e1c5-4732-a4ee-04b4c540edbe.jpg?1",
             "name": "Spellshock",
             "text": "Whenever any player successfully casts a spell, Spellshock deals 2 damage to him or her.",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "79bf01d1-a7b1-54f3-9849-2729ca5bcb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca9fd31-639a-4fbc-84bd-c3078df29c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca9fd31-639a-4fbc-84bd-c3078df29c0a.jpg?1",
             "name": "Avenging Druid",
             "text": "If Avenging Druid damages any opponent, you may reveal cards from your library until you reveal a land card. Put that land into play and put all other revealed cards into your graveyard.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "d775ffc0-0658-531c-8523-906edc5cdc80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aae577-9683-4d9b-bfd5-52702b38d3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aae577-9683-4d9b-bfd5-52702b38d3a7.jpg?1",
             "name": "Bequeathal",
             "text": "If enchanted creature is put into any graveyard, draw two cards.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "dcf01db0-5b17-5fbc-923a-eeec51af7b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c2cc9-37ce-435e-9df2-083d5e3c8c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c2cc9-37ce-435e-9df2-083d5e3c8c5c.jpg?1",
             "name": "Cartographer",
             "text": "When Cartographer comes into play, you may return target land card from your graveyard to your hand.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "4af2c742-954c-5766-93e9-fc503073dfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2965bd5-4f16-443a-9133-adb92cf0e12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2965bd5-4f16-443a-9133-adb92cf0e12b.jpg?1",
             "name": "Crashing Boars",
             "text": "If Crashing Boars attacks, defending player chooses an untapped creature he or she controls. That creature blocks Crashing Boars this turn if able.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "e58165d6-78c2-52fd-bc61-f1fc183d7ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b990ffe5-fd2a-4646-bac3-8e52cdc328aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b990ffe5-fd2a-4646-bac3-8e52cdc328aa.jpg?1",
             "name": "Elven Palisade",
             "text": "Sacrifice a forest: Target attacking creature gets -3/-0 until end of turn.",
             "colours": [
@@ -3545,7 +3545,7 @@
         },
         {
             "id": "77512035-74f5-5c6b-a98c-f061d02fe765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa69a8e-1b75-4d93-918d-d772cec69e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa69a8e-1b75-4d93-918d-d772cec69e99.jpg?1",
             "name": "Elvish Berserker",
             "text": "For each creature that blocks it, Elvish Berserker gets +1/+1 until end of turn.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "de622ed9-36c5-5a06-b888-e230ff4686a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80105c-d2c0-4f8c-9302-5e6152a60f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb80105c-d2c0-4f8c-9302-5e6152a60f54.jpg?1",
             "name": "Jackalope Herd",
             "text": "If you play any spell, return Jackalope Herd to owner's hand.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "b641bc13-2279-52cd-aebd-6b693096385e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccccf78-8b00-406b-a2b7-0e6ba76703d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccccf78-8b00-406b-a2b7-0e6ba76703d0.jpg?1",
             "name": "Keeper of the Beasts",
             "text": "o\nG, oc\nT: Put a Beast token into play. Treat this token as a 2/2 green creature. Play this ability only if target opponent controls more creatures than you.",
             "colours": [
@@ -3647,7 +3647,7 @@
         },
         {
             "id": "fab0a25c-a5fe-5c3f-90e4-3d64ae00046f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212ca7e7-5ba3-4da7-a2f0-16c721004bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212ca7e7-5ba3-4da7-a2f0-16c721004bac.jpg?1",
             "name": "Manabond",
             "text": "During your discard phase, you may choose to put all land cards from your hand into play. If you do, discard the rest of your hand.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "8166de85-98db-50be-88a8-81f2a9370f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1682dd-5a99-4bee-a2c2-c8735047e1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1682dd-5a99-4bee-a2c2-c8735047e1a9.jpg?1",
             "name": "Mirri, Cat Warrior",
             "text": "Mirri, Cat Warrior counts as a Cat Warrior.\nFirst strike; forestwalk (If defending player controls any forests, this creature is unblockable.)\nAttacking does not cause Mirri to tap.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "fc297e6e-f094-51b1-8e68-b6d93a677fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf14de50-d123-400c-862e-2c95fd2aa23f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf14de50-d123-400c-862e-2c95fd2aa23f.jpg?1",
             "name": "Oath of Druids",
             "text": "During each player's upkeep, if that player controls fewer creatures than target opponent, the player may reveal cards from his or her library until he or she reveals a creature card. The player puts that creature into play and all other revealed cards into his or her graveyard.",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "5431ece4-5a0b-5d6b-82a2-1b95dc158c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf4da70-c656-4e40-bb0f-68e9dda024c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf4da70-c656-4e40-bb0f-68e9dda024c9.jpg?1",
             "name": "Plated Rootwalla",
             "text": "o2oo\nG Plated Rootwalla gets +3/+3 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "68c5b687-b584-5f8a-915e-f9b106b009d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9d28-3a05-4dfa-a322-36b4cc2697d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6d9d28-3a05-4dfa-a322-36b4cc2697d4.jpg?1",
             "name": "Predatory Hunger",
             "text": "Whenever any opponent successfully casts a creature spell, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "0d3f06f3-743b-531a-95b3-357395bdbf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be9714d-125f-4700-879d-b920fe9f1b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be9714d-125f-4700-879d-b920fe9f1b68.jpg?1",
             "name": "Pygmy Troll",
             "text": "For each creature that blocks it, Pygmy Troll gets +1/+1 until end of turn.\noo\nG Regenerate Pygmy Troll.",
             "colours": [
@@ -3844,7 +3844,7 @@
         },
         {
             "id": "2a150efb-0b42-586c-9d47-8b41ca9bb0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99121a2b-c735-47be-b01e-cdf59809e7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99121a2b-c735-47be-b01e-cdf59809e7f3.jpg?1",
             "name": "Rabid Wolverines",
             "text": "For each creature that blocks it, Rabid Wolverines gets +1/+1 until end of turn.",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "1335c32c-cc3e-5d2e-a68c-7705259e4f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b47c082-57f6-4f69-87e8-a07cad9ef042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b47c082-57f6-4f69-87e8-a07cad9ef042.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -3908,7 +3908,7 @@
         },
         {
             "id": "ba8463f1-3703-5844-91ab-a0e9894f3017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5707560-fcc6-4aca-adce-d41de45f37e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5707560-fcc6-4aca-adce-d41de45f37e8.jpg?1",
             "name": "Resuscitate",
             "text": "Until end of turn, each creature you control gains \"o1: Regenerate this creature.\"",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "8ba6623d-8358-50ac-b38c-99fd5d50f726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a840bba-4725-45fd-885f-1b3d615dfa97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a840bba-4725-45fd-885f-1b3d615dfa97.jpg?1",
             "name": "Rootwater Alligator",
             "text": "Sacrifice a forest: Regenerate Rootwater Alligator.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "8c440f85-ef41-50c2-8916-376a45bd2632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a496a4-1b4c-4c5d-99e5-ec40601c759d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a496a4-1b4c-4c5d-99e5-ec40601c759d.jpg?1",
             "name": "Skyshroud Elite",
             "text": "Skyshroud Elite gets +1/+2 as long as any opponent controls any nonbasic lands.",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "10d6e38e-29be-59ba-933e-a709946b6100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d809c1-e674-40b8-816d-c45d77c66722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d809c1-e674-40b8-816d-c45d77c66722.jpg?1",
             "name": "Skyshroud War Beast",
             "text": "Trample\nSkyshroud War Beast has power and toughness each equal to the number of nonbasic lands target opponent controls.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "48abdb45-5704-56bb-bab0-ff97359770a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba85b2f-37da-4595-9880-8e9f1ddbac09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba85b2f-37da-4595-9880-8e9f1ddbac09.jpg?1",
             "name": "Song of Serenity",
             "text": "Creatures with any enchantments on them cannot attack or block.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "39ef301e-7b62-50ce-9d44-51e7f8cea9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f79fb79-37a0-483f-ba19-853cbfffc73d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f79fb79-37a0-483f-ba19-853cbfffc73d.jpg?1",
             "name": "Spike Hatcher",
             "text": "Spike Hatcher comes into play with six +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Hatcher: Put a +1/+1 counter on target creature.\no1, Remove a +1/+1 counter from Spike Hatcher: Regenerate Spike Hatcher.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "2644bf84-1b2b-5c9c-b3fd-066cd9d2f2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d9b671-344b-460d-8f65-d65129db91c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d9b671-344b-460d-8f65-d65129db91c3.jpg?1",
             "name": "Spike Rogue",
             "text": "Spike Rogue comes into play with two +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Rogue: Put a +1/+1 counter on target creature.\no2, Remove a +1/+1 counter from any creature you control: Put a +1/+1 counter on Spike Rogue.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "0f3895a1-c684-5546-b52f-940675291511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c561a2a-91c6-4d4b-9f96-bffd43a00478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c561a2a-91c6-4d4b-9f96-bffd43a00478.jpg?1",
             "name": "Spike Weaver",
             "text": "Spike Weaver comes into play with three +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Weaver: Put a +1/+1 counter on target creature.\no1, Remove a +1/+1 counter from Spike Weaver: Creatures deal no combat damage this turn.",
             "colours": [
@@ -4168,7 +4168,7 @@
         },
         {
             "id": "78e2c28e-4331-5f97-9ce8-96032de08bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060c178-3c0e-493f-b6f0-ead5b1d6f191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c060c178-3c0e-493f-b6f0-ead5b1d6f191.jpg?1",
             "name": "Survival of the Fittest",
             "text": "o\nG, Choose and discard a creature card: Search your library for a creature card, reveal that card to all players, and put it into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -4199,7 +4199,7 @@
         },
         {
             "id": "2707929d-98e6-54e4-b0ae-c5d915e340d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716bb55-0821-4809-9bc0-04e299b09549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716bb55-0821-4809-9bc0-04e299b09549.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play, search your library for a forest card and put that forest into play. Shuffle your library afterwards.",
             "colours": [
@@ -4233,7 +4233,7 @@
         },
         {
             "id": "6543faa0-fbdf-5247-bbb7-befd6e6d4cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e32c939-1d64-4082-bafe-59dfa9c054f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e32c939-1d64-4082-bafe-59dfa9c054f6.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature in play of the same creature type. (For example, if there are three Goblins in play, each of them gets +2/+2.)",
             "colours": [],
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "ae4cfad0-ea30-5046-8ffc-0cf995df16e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e652007-02f0-424f-b52c-c1540d1939bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e652007-02f0-424f-b52c-c1540d1939bd.jpg?1",
             "name": "Erratic Portal",
             "text": "o1, oc\nT: Return target creature to owner's hand unless its controller pays o1.",
             "colours": [],
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "c22daa90-fe5b-545a-be02-fc6d509597ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399c06d5-af2a-47a1-9239-ff14224a026b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399c06d5-af2a-47a1-9239-ff14224a026b.jpg?1",
             "name": "Medicine Bag",
             "text": "o1, oc\nT, Choose and discard a card: Regenerate target creature.",
             "colours": [],
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "dff23ea0-f7d1-519b-ba24-112cb6e6c5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c786ea5b-52ad-4d1b-855e-ce6d0b9af67e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c786ea5b-52ad-4d1b-855e-ce6d0b9af67e.jpg?1",
             "name": "Memory Crystal",
             "text": "All buyback costs are reduced by o2.",
             "colours": [],
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "6168b788-27e6-5cd7-b1c4-333195de93f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddfc5ab-b11b-4ad7-ab46-8ee60d938a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddfc5ab-b11b-4ad7-ab46-8ee60d938a5b.jpg?1",
             "name": "Mindless Automaton",
             "text": "Mindless Automaton comes into play with two +1/+1 counters on it.\no1, Choose and discard a card: Put a +1/+1 counter on Mindless Automaton.\nRemove two +1/+1 counters from Mindless Automaton: Draw a card.",
             "colours": [],
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "5842868e-0cfc-5309-8365-85bb2fd22a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d5a0c6-916c-428a-ae66-8adc8844e56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d5a0c6-916c-428a-ae66-8adc8844e56e.jpg?1",
             "name": "Null Brooch",
             "text": "o2, oc\nT, Discard your hand: Counter target noncreature spell. Play this ability as an interrupt.",
             "colours": [],
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "6a7b875c-0d24-52f0-b2a2-729596a47349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234ed934-6ea7-41f6-bd13-3df8662a3a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234ed934-6ea7-41f6-bd13-3df8662a3a1d.jpg?1",
             "name": "Skyshaper",
             "text": "Sacrifice Skyshaper: All creatures you control gain flying until end of turn.",
             "colours": [],
@@ -4425,7 +4425,7 @@
         },
         {
             "id": "b1f903e0-5d42-5e46-8cf5-e5c1ee28e7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb104c-f8ca-4da2-8f1f-8fe6f291407e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb104c-f8ca-4da2-8f1f-8fe6f291407e.jpg?1",
             "name": "Spellbook",
             "text": "Skip your discard phase.",
             "colours": [],
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "11c0de6b-9910-53b1-9669-4a941d53520b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f4d2a5-bb85-4662-b2dd-a363ec7eab9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f4d2a5-bb85-4662-b2dd-a363ec7eab9b.jpg?1",
             "name": "Sphere of Resistance",
             "text": "All spells cost an additional o1 to play.",
             "colours": [],
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "c5e356a6-8d4a-5b94-90d8-8866326090c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ac2d30-7c9a-40b3-812e-e77e49229f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ac2d30-7c9a-40b3-812e-e77e49229f48.jpg?1",
             "name": "Thopter Squadron",
             "text": "Flying\nThopter Squadron comes into play with three +1/+1 counters on it.\no1, Remove a +1/+1 counter from Thopter Squadron: Put a Thopter token into play. Treat this token as a 1/1 artifact creature with flying. Play this ability as a sorcery.\no1, Sacrifice a Thopter: Put a +1/+1 counter on Thopter Squadron. Play this ability as a sorcery.",
             "colours": [],
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "ce441c2b-34a2-58e4-871c-f43350600653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a115563-81da-42f6-95c4-22ae7bb51a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a115563-81da-42f6-95c4-22ae7bb51a0f.jpg?1",
             "name": "Transmogrifying Licid",
             "text": "Transmogrifying Licid counts as a Licid.\no1, oc\nT: Transmogrifying Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature gets +1/+1 and counts as an artifact\" instead of any other type of permanent. Move Transmogrifying Licid onto target creature. You may pay o1 to end this effect.",
             "colours": [],
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "80dec60e-3005-5d3a-a39c-db71c78d8864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2571ff7-0287-4ba2-8365-5ff08de641a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2571ff7-0287-4ba2-8365-5ff08de641a2.jpg?1",
             "name": "Workhorse",
             "text": "Workhorse comes into play with four +1/+1 counters on it.\nRemove a +1/+1 counter from Workhorse: Add one colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "d81e7409-5299-560b-a79c-e3dda4807c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a8b6b8-b95f-4014-b17a-a6d44d965995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a8b6b8-b95f-4014-b17a-a6d44d965995.jpg?1",
             "name": "City of Traitors",
             "text": "If you play a land, sacrifice City of Traitors.\noc\nT: Add two colorless mana to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/FDN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/FDN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "46149862-416f-563b-b854-1893b7c76d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8432a7-1c8a-4cfb-947c-ecf9791063eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8432a7-1c8a-4cfb-947c-ecf9791063eb.jpg?1",
             "name": "Sire of Seven Deaths",
             "text": "First strike, vigilance\nMenace, trample\nReach, lifelink\nWard\u2014\nPay 7 life.",
             "colours": [],
@@ -37,7 +37,7 @@
         },
         {
             "id": "355a81e1-e59a-5683-bc2c-17cf713b4372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524a5d93-26ed-436d-a437-dc9460acce98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524a5d93-26ed-436d-a437-dc9460acce98.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "a294c623-56e1-5a42-8b73-9966a7b7c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80fc380-0499-4499-8a60-c43844c02c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80fc380-0499-4499-8a60-c43844c02c9b.jpg?1",
             "name": "Armasaur Guide",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever you attack with three or more creatures, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "57cc0820-dfee-53e9-9d0b-8bd6667e44ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526fe356-bff1-4211-9e88-bf913ac76b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526fe356-bff1-4211-9e88-bf913ac76b1d.jpg?1",
             "name": "Cat Collector",
             "text": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nWhenever you gain life for the first time during each of your turns, create a 1/1 white Cat creature token.",
             "colours": [
@@ -147,7 +147,7 @@
         },
         {
             "id": "87fed9fb-fa34-5ea1-ba1d-3f1d50496c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809ee8ad-1573-49e5-9e84-b7cdd29efcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809ee8ad-1573-49e5-9e84-b7cdd29efcae.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W} ({3}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "e77d49ab-7da9-5761-a29c-f0924c337e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396049c-b976-4b7f-8ecd-564e24ebd631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4396049c-b976-4b7f-8ecd-564e24ebd631.jpg?1",
             "name": "Claws Out",
             "text": "This spell costs {1} less to cast for each Cat you control.\nCreatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "38156075-dfa1-58df-9c7a-c2a745d462f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender (This creature can't attack.)\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -256,7 +256,7 @@
         },
         {
             "id": "e99ecca8-89ab-5a08-8cf3-7a79b46bb2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a136f26-ac66-407f-b389-357222d2c4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a136f26-ac66-407f-b389-357222d2c4a2.jpg?1",
             "name": "Dauntless Veteran",
             "text": "Whenever this creature attacks, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -291,7 +291,7 @@
         },
         {
             "id": "dc07b427-46a4-548e-9d86-93f0cbd772a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027dc444-e544-4693-8653-3dcdda530162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/027dc444-e544-4693-8653-3dcdda530162.jpg?1",
             "name": "Dazzling Angel",
             "text": "Flying\nWhenever another creature you control enters, you gain 1 life.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "f6e5c20b-c629-5200-af95-20ed514e742d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a08245-a535-4d24-b8c0-78759bb9c4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a08245-a535-4d24-b8c0-78759bb9c4b0.jpg?1",
             "name": "Divine Resilience",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nTarget creature you control gains indestructible until end of turn. If this spell was kicked, instead any number of target creatures you control gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "4f570d33-17a1-551a-a965-a1e73b0117cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8fc5-fdd2-446a-a676-5c363f96928f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8fc5-fdd2-446a-a676-5c363f96928f.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -395,7 +395,7 @@
         },
         {
             "id": "b42f13e4-50b0-50bd-b267-5101d8444e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd092b14-d72f-4de0-8f19-1338661b9e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd092b14-d72f-4de0-8f19-1338661b9e3b.jpg?1",
             "name": "Felidar Savior",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "19b84094-8b71-5eb5-a48c-f7eabba27fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55139100-9342-41fd-b10a-8e9932e605d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55139100-9342-41fd-b10a-8e9932e605d4.jpg?1",
             "name": "Fleeting Flight",
             "text": "Put a +1/+1 counter on target creature. It gains flying until end of turn. Prevent all combat damage that would be dealt to it this turn.",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "f78300d6-df6c-5a18-a979-83ef6810f6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525ba5c7-3ce5-4e52-b8b5-96c9040a6738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525ba5c7-3ce5-4e52-b8b5-96c9040a6738.jpg?1",
             "name": "Guarded Heir",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, create two 3/3 white Knight creature tokens.",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "085bb8e1-07cf-55c2-853b-c9adf261237f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg?1",
             "name": "Hare Apparent",
             "text": "When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.\nA deck can have any number of cards named Hare Apparent.",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "81ded782-e8a5-59f1-94be-dbf78f1728fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9a0e91-80b5-428f-8f08-931d0631be14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9a0e91-80b5-428f-8f08-931d0631be14.jpg?1",
             "name": "Helpful Hunter",
             "text": "When this creature enters, draw a card.",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "2cf29847-ef40-588c-8c3e-ba9792edd04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdfebf-98e0-4718-bac3-6eee1cd0623d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdfebf-98e0-4718-bac3-6eee1cd0623d.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -606,7 +606,7 @@
         },
         {
             "id": "16d94186-533e-5f5a-acb1-77b494189626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0763be06-25b2-4d6b-ab33-a1af85aeb443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0763be06-25b2-4d6b-ab33-a1af85aeb443.jpg?1",
             "name": "Inspiring Paladin",
             "text": "During your turn, this creature has first strike. (It deals combat damage before creatures without first strike.)\nDuring your turn, creatures you control with +1/+1 counters on them have first strike.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "d8cc6e4b-1c35-5c9d-928b-b7de2d166a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846adb38-f9bb-4fed-b8ed-36ec7885f989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846adb38-f9bb-4fed-b8ed-36ec7885f989.jpg?1",
             "name": "Joust Through",
             "text": "Joust Through deals 3 damage to target attacking or blocking creature. You gain 1 life.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "207ea838-ef73-544a-9dc3-9a9cc004703e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621839e1-2756-4cdc-a25c-5f76ea98dd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621839e1-2756-4cdc-a25c-5f76ea98dd87.jpg?1",
             "name": "Luminous Rebuke",
             "text": "This spell costs {3} less to cast if it targets a tapped creature.\nDestroy target creature.",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "62d19be0-aed0-5dbd-afd6-52ca5a1e176d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742117a-8a72-43b9-b05d-274829d138a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742117a-8a72-43b9-b05d-274829d138a2.jpg?1",
             "name": "Prideful Parent",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "551fdc06-6070-52d1-bf01-fb069193f00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "9b7b196f-6c34-53a6-a258-8e4fbd6171fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfe4e62-c153-47b8-8e09-cedaf91f53d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfe4e62-c153-47b8-8e09-cedaf91f53d8.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "7477de59-d999-5f61-8d5f-ac841303d6e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e1ee86-6f08-4aa0-bf63-ae12028ef080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e1ee86-6f08-4aa0-bf63-ae12028ef080.jpg?1",
             "name": "Squad Rallier",
             "text": "{2}{W}: Look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "3e955570-70ed-5b87-a757-8949c2867a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323d029e-9a88-4188-b3a4-38ef32cffc9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323d029e-9a88-4188-b3a4-38ef32cffc9f.jpg?1",
             "name": "Sun-Blessed Healer",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, if it was kicked, return target nonland permanent card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "2b28a741-13f6-5ff8-8eae-adb815e329cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf01cbe-9fcb-4f35-bc6b-2280620b06ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf01cbe-9fcb-4f35-bc6b-2280620b06ff.jpg?1",
             "name": "Twinblade Blessing",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "412339eb-948c-5275-9a3c-fefad0ab86a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "c450689f-78df-5afb-a7f3-673a10da5b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329c861-fc16-4a96-9c03-25af6ac2adc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329c861-fc16-4a96-9c03-25af6ac2adc8.jpg?1",
             "name": "Vanguard Seraph",
             "text": "Flying\nWhenever you gain life for the first time each turn, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "b1d8b422-906f-50a8-a8a7-3ee1263d9b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06431793-5dfe-4cbf-990b-4bcc960d1f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06431793-5dfe-4cbf-990b-4bcc960d1f31.jpg?1",
             "name": "Arcane Epiphany",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nDraw three cards.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "a474f5de-fb4d-58f6-ad7a-1e7d2f7c4867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334b5018-2da9-49f1-9d09-83d312ecfb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334b5018-2da9-49f1-9d09-83d312ecfb02.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "e882ca08-bc72-53c3-963e-7e1b7b881532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1d5b76-b07e-45c6-800d-4cfce085164f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1d5b76-b07e-45c6-800d-4cfce085164f.jpg?1",
             "name": "Bigfin Bouncer",
             "text": "When this creature enters, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "a3ea191a-8510-5421-97be-1c9a8beb0b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e47680-18c7-4ffb-aac4-c5db6e7095ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e47680-18c7-4ffb-aac4-c5db6e7095ba.jpg?1",
             "name": "Cephalid Inkmage",
             "text": "When this creature enters, surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nThreshold \u2014 This creature can't be blocked as long as there are seven or more cards in your graveyard.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "bbe7a835-f541-5de0-ba7c-9aa2a9bd1c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36012810-0e83-4640-8ba7-7262229f1b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36012810-0e83-4640-8ba7-7262229f1b84.jpg?1",
             "name": "Clinquant Skymage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on this creature.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "1c08f5b8-02f2-56e2-abde-92da53c97519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "61d1ad67-45b8-562e-bfab-a01fea035a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaf4196-6bf3-47fa-b5c7-0e77f45cf820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaf4196-6bf3-47fa-b5c7-0e77f45cf820.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -1242,7 +1242,7 @@
         },
         {
             "id": "a864ad97-5274-59da-852e-5a49b13d685f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9768cc6-8f53-4922-ae32-376a2f32d719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9768cc6-8f53-4922-ae32-376a2f32d719.jpg?1",
             "name": "Elementalist Adept",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1277,7 +1277,7 @@
         },
         {
             "id": "679b8c5e-bbe5-57c5-9f36-fe7df05c84cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273c417-0fcd-4273-b24e-afff76336d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273c417-0fcd-4273-b24e-afff76336d0c.jpg?1",
             "name": "Erudite Wizard",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "58a42eb3-2135-5dd1-a4b7-297e8aca2c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3bee8f-f5be-4404-a696-c902637799c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3bee8f-f5be-4404-a696-c902637799c3.jpg?1",
             "name": "Faebloom Trick",
             "text": "Create two 1/1 blue Faerie creature tokens with flying. When you do, tap target creature an opponent controls.",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "d0fcbb0c-5811-5f31-b185-50286e37acce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f5cab3-3fc0-448d-8252-cd55abf5b596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f5cab3-3fc0-448d-8252-cd55abf5b596.jpg?1",
             "name": "Grappling Kraken",
             "text": "Landfall \u2014 Whenever a land you control enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1378,7 +1378,7 @@
         },
         {
             "id": "08078e34-6700-578c-aa7f-98a882cd82c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "26a41dbc-b05c-5168-9f59-2b29b513a25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "467a475b-0bbd-5236-9619-5f72e924e0ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0eba76-3829-408b-828f-0b223c884728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0eba76-3829-408b-828f-0b223c884728.jpg?1",
             "name": "Icewind Elemental",
             "text": "Flying\nWhen this creature enters, draw a card, then discard a card.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "7c68ec52-be40-54c1-b20e-946decd2173e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636fe95-664f-4fb1-aab9-28856edeccd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b636fe95-664f-4fb1-aab9-28856edeccd6.jpg?1",
             "name": "Inspiration from Beyond",
             "text": "Mill three cards, then return an instant or sorcery card from your graveyard to your hand.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "f014a6c5-c126-5011-a3e1-e7bfb621c71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "0ea5c8e8-97c6-5b1d-99d4-abe6d6a9211a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f20a32-9f5d-4a68-8995-549e57554da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f20a32-9f5d-4a68-8995-549e57554da2.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -1603,7 +1603,7 @@
         },
         {
             "id": "d78c556c-578b-5740-9e7d-0ee0f68ad3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a159f6-fecf-4bdd-b2f8-a9665a5cc32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a159f6-fecf-4bdd-b2f8-a9665a5cc32d.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "fd02035b-edc5-5748-a862-1cefa1b70410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d89cec-528b-4b2a-87db-e11ce0000622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d89cec-528b-4b2a-87db-e11ce0000622.jpg?1",
             "name": "Mischievous Mystic",
             "text": "Flying\nWhenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "d4ab1334-95e9-5b19-9a72-9e666a7170bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38806934-dd9c-4ad4-a59c-a16dce03a14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38806934-dd9c-4ad4-a59c-a16dce03a14a.jpg?1",
             "name": "Refute",
             "text": "Counter target spell. Draw a card, then discard a card.",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "6811ddcb-ad7a-5307-96a4-7495610fe970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0f147b-95ed-4f32-9b46-6a633ae31976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0f147b-95ed-4f32-9b46-6a633ae31976.jpg?1",
             "name": "Rune-Sealed Wall",
             "text": "Defender\n{T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "50f43a0c-2823-5faa-993a-3556d00df0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62958fc3-55dc-4b97-a070-490d6ed27820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62958fc3-55dc-4b97-a070-490d6ed27820.jpg?1",
             "name": "Skyship Buccaneer",
             "text": "Flying\nRaid \u2014 When this creature enters, if you attacked this turn, draw a card.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "9a238a7d-00d7-5198-9244-c57333b304d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "9e719055-5095-5c42-b1dc-4ee89358e501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd2422e-8e84-4c39-af29-3b4d38baee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd2422e-8e84-4c39-af29-3b4d38baee63.jpg?1",
             "name": "Strix Lookout",
             "text": "Flying, vigilance (Attacking doesn't cause this creature to tap.)\n{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "6344e200-94b5-5509-ab0a-c694e7f69d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0846820-e595-4743-8a28-29c57d728677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0846820-e595-4743-8a28-29c57d728677.jpg?1",
             "name": "Uncharted Voyage",
             "text": "Target creature's owner puts it on their choice of the top or bottom of their library.\nSurveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "53653716-0e7a-58f8-a65c-c9ab33494d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "7441c269-801c-5757-885e-47f929573f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2496c4a-df03-4583-bd76-f98ed5cb61ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2496c4a-df03-4583-bd76-f98ed5cb61ee.jpg?1",
             "name": "Arbiter of Woe",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying\nWhen this creature enters, each opponent discards a card and loses 2 life. You draw a card and gain 2 life.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "ecc7e249-e28a-56b0-a81d-f272cc52bf79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3587a9-0667-4d53-807b-c437bcb1d7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3587a9-0667-4d53-807b-c437bcb1d7b3.jpg?1",
             "name": "Billowing Shriekmass",
             "text": "Flying\nWhen this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nThreshold \u2014 This creature gets +2/+1 as long as there are seven or more cards in your graveyard.",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "162bf48c-f23e-5cbd-b899-168d386c94fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "07415aed-3458-58dd-a438-0a5e73e06de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life. (Damage causes loss of life.)",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "3e642319-331e-5fdf-813f-0cf352e216a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b072811-998a-4a71-b59c-6afecc0dc4b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b072811-998a-4a71-b59c-6afecc0dc4b6.jpg?1",
             "name": "Crypt Feaster",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nThreshold \u2014 Whenever this creature attacks, if there are seven or more cards in your graveyard, this creature gets +2/+0 until end of turn.",
             "colours": [
@@ -2100,7 +2100,7 @@
         },
         {
             "id": "43bef5ba-9abc-50ec-9aff-1a9b43b4d560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909d7778-c7f8-4fa4-89f2-8b32e86e96e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909d7778-c7f8-4fa4-89f2-8b32e86e96e4.jpg?1",
             "name": "Gutless Plunderer",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRaid \u2014 When this creature enters, if you attacked this turn, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "06eb1b5f-067c-534c-b273-48c086180093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da4a4b-ea12-4169-a7cf-eb4427f13e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51da4a4b-ea12-4169-a7cf-eb4427f13e84.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "0635f382-dc3e-56f8-9c28-c7b7b2fc6e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790f9433-7565-4f7f-88e8-8af762ea0296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790f9433-7565-4f7f-88e8-8af762ea0296.jpg?1",
             "name": "Hungry Ghoul",
             "text": "{1}, Sacrifice another creature: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "4de9f36d-8b8a-59ef-a7a5-1ac01189eca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b6330-2d0b-4f2f-a848-f10b06fb4ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877b6330-2d0b-4f2f-a848-f10b06fb4ef5.jpg?1",
             "name": "Infernal Vessel",
             "text": "When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's control with two +1/+1 counters on it. It's a Demon in addition to its other types.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "767849b3-c33e-5933-bebd-82ba519851bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c73de-7a5f-46f2-a70b-449bc8ecfe24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c73de-7a5f-46f2-a70b-449bc8ecfe24.jpg?1",
             "name": "Infestation Sage",
             "text": "When this creature dies, create a 1/1 black and green Insect creature token with flying.",
             "colours": [
@@ -2278,7 +2278,7 @@
         },
         {
             "id": "9566e2e2-fc51-5e4c-b3e6-aa57b967ec0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7543f-2a45-4db6-b560-d15507a58c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b7543f-2a45-4db6-b560-d15507a58c91.jpg?1",
             "name": "Midnight Snack",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{2}{B}, Sacrifice this enchantment: Target opponent loses X life, where X is the amount of life you gained this turn.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "9f578a4d-5d48-5cca-883a-2592f88d5bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -2348,7 +2348,7 @@
         },
         {
             "id": "6634ed50-f3ca-5500-a90a-88ea2d618c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f463c55-39a0-4f2f-aae3-0c5540bde5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f463c55-39a0-4f2f-aae3-0c5540bde5b7.jpg?1",
             "name": "Revenge of the Rats",
             "text": "Create a tapped 1/1 black Rat creature token for each creature card in your graveyard.\nFlashback {2}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2380,7 +2380,7 @@
         },
         {
             "id": "55fa65e4-32ef-515c-9ebf-37e7775585d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1daf5bb-c8e9-4e79-a532-ca92a9a885cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1daf5bb-c8e9-4e79-a532-ca92a9a885cd.jpg?1",
             "name": "Sanguine Syphoner",
             "text": "Whenever this creature attacks, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "69aef091-4420-5cd4-99c4-09b39fe65647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc359da6-8b7f-45ec-b530-ce159fc35953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc359da6-8b7f-45ec-b530-ce159fc35953.jpg?1",
             "name": "Seeker's Folly",
             "text": "Choose one \u2014\n\u2022 Target opponent discards two cards.\n\u2022 Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2447,7 +2447,7 @@
         },
         {
             "id": "09458ed6-d8b1-54f3-a256-61a6d706fd9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deea5690-6eb2-4353-b917-cbbf840e4e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deea5690-6eb2-4353-b917-cbbf840e4e71.jpg?1",
             "name": "Soul-Shackled Zombie",
             "text": "When this creature enters, exile up to two target cards from a single graveyard. If at least one creature card was exiled this way, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "272f41d3-3347-556b-b7ed-2481acae2b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6859a5ba-1c1c-4631-bba8-f9900b827178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6859a5ba-1c1c-4631-bba8-f9900b827178.jpg?1",
             "name": "Stab",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "4e2349e1-4f16-5bd7-94f2-78c995f660b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3d85bc-ef2d-4251-baf4-a14bd0cee61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3d85bc-ef2d-4251-baf4-a14bd0cee61e.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "2424970f-6872-55aa-86db-103debeec0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30df3e33-2f17-4067-99f1-5db6b0f41fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30df3e33-2f17-4067-99f1-5db6b0f41fd4.jpg?1",
             "name": "Tragic Banshee",
             "text": "Morbid \u2014 When this creature enters, target creature an opponent controls gets -1/-1 until end of turn. If a creature died this turn, that creature gets -13/-13 instead.",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "b1873070-cae4-5929-a2eb-3fb6b2f29660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917514c0-9cd5-4b97-85b9-c4f753560ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917514c0-9cd5-4b97-85b9-c4f753560ad4.jpg?1",
             "name": "Vampire Gourmand",
             "text": "Whenever this creature attacks, you may sacrifice another creature. If you do, draw a card and this creature can't be blocked this turn.",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "ad5f67d6-bef1-543b-aae5-82f682bed453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d076293-3b45-4878-8f67-978927cc1f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d076293-3b45-4878-8f67-978927cc1f68.jpg?1",
             "name": "Vampire Soulcaller",
             "text": "Flying\nThis creature can't block.\nWhen this creature enters, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "be29d89d-a25b-54ea-be5f-4bf34fa73be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0c12dd-f138-45c0-9614-d83a1d8e8399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0c12dd-f138-45c0-9614-d83a1d8e8399.jpg?1",
             "name": "Vengeful Bloodwitch",
             "text": "Whenever this creature or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "b8d8648e-e113-5111-ba55-522a8b2a771b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "9432017f-4236-5e67-83ee-b3162a46854e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8b199-5d62-485f-b1c3-b30aa550595b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8b199-5d62-485f-b1c3-b30aa550595b.jpg?1",
             "name": "Battlesong Berserker",
             "text": "Whenever you attack, target creature you control gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "73cc9164-0f64-5054-8d97-6da4e5a15e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1ec351-5e70-4eb2-b590-6bff94ef8178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1ec351-5e70-4eb2-b590-6bff94ef8178.jpg?1",
             "name": "Boltwave",
             "text": "Boltwave deals 3 damage to each opponent.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "1ea308d1-ff14-5a56-974d-47880bb27cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dcc50-da10-4281-b522-9240c1204f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977dcc50-da10-4281-b522-9240c1204f5d.jpg?1",
             "name": "Bulk Up",
             "text": "Double target creature's power until end of turn.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "7314f2bf-b150-5acd-ba1a-7f7dd4ee6ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg?1",
             "name": "Chandra, Flameshaper",
             "text": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n\u22124: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
             "colours": [
@@ -2873,7 +2873,7 @@
         },
         {
             "id": "846795bb-0155-5608-8772-87facc7ee2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db6819c-666a-409d-85a5-b9ac34d8dd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db6819c-666a-409d-85a5-b9ac34d8dd2f.jpg?1",
             "name": "Courageous Goblin",
             "text": "Whenever this creature attacks while you control a creature with power 4 or greater, this creature gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "095deb11-a6c2-5dbd-9765-1bbadeb2896a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5b899a-52f7-471b-ad50-4fa6566758fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5b899a-52f7-471b-ad50-4fa6566758fd.jpg?1",
             "name": "Crackling Cyclops",
             "text": "Whenever you cast a noncreature spell, this creature gets +3/+0 until end of turn.",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "23feb4ed-4363-5480-8613-13d4cda5068b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd75a1-cb54-4e38-9ce1-e8f32a73c6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bd75a1-cb54-4e38-9ce1-e8f32a73c6eb.jpg?1",
             "name": "Dragon Trainer",
             "text": "When this creature enters, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "18c0ffe6-fcef-55aa-835b-8fe455214384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3012,7 +3012,7 @@
         },
         {
             "id": "5c485a8e-11b9-5399-94f4-d758bbff453a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe00aa-d284-48f9-b5a2-1bd4c5fa8e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe00aa-d284-48f9-b5a2-1bd4c5fa8e58.jpg?1",
             "name": "Fiery Annihilation",
             "text": "Fiery Annihilation deals 5 damage to target creature. Exile up to one target Equipment attached to that creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "3982633c-d2f5-5ec4-ab2c-cbcf69ca9f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4409a063-bf2a-4a49-803e-3ce6bd474353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4409a063-bf2a-4a49-803e-3ce6bd474353.jpg?1",
             "name": "Goblin Boarders",
             "text": "Raid \u2014 This creature enters with a +1/+1 counter on it if you attacked this turn.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "a5ed1289-b561-58c8-a6c2-085bf8541988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2016585-e26c-4d13-b09f-af6383c192f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2016585-e26c-4d13-b09f-af6383c192f7.jpg?1",
             "name": "Goblin Negotiation",
             "text": "Goblin Negotiation deals X damage to target creature. Create a number of 1/1 red Goblin creature tokens equal to the amount of excess damage dealt to that creature this way.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "c532626d-d61a-535c-8a52-9148bc5cfc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ce6c40-3452-4aa0-a45b-dbfd70f8d220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ce6c40-3452-4aa0-a45b-dbfd70f8d220.jpg?1",
             "name": "Gorehorn Raider",
             "text": "Raid \u2014 When this creature enters, if you attacked this turn, this creature deals 2 damage to any target.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "aa4a12f3-a5b6-5a29-909d-8d6f88c38a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e20ab-c5ca-4295-884d-78efdaa83243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e20ab-c5ca-4295-884d-78efdaa83243.jpg?1",
             "name": "Incinerating Blast",
             "text": "Incinerating Blast deals 6 damage to target creature.\nYou may discard a card. If you do, draw a card.",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "f440d436-a6ab-5cae-aebf-fa7af5cecdfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "0dac603b-4c49-5e27-91f0-761f62108920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673e4561-8dfd-46db-b492-878009666ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673e4561-8dfd-46db-b492-878009666ac7.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -3256,7 +3256,7 @@
         },
         {
             "id": "b9df8b84-b747-517e-aeef-80beb45ecba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ad0b97-a318-4e76-ac79-b3e83417c333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ad0b97-a318-4e76-ac79-b3e83417c333.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "ed17e1dc-89a3-505a-9346-099ea35c6ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06faa8-201d-45db-b398-ad56f7b01848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d06faa8-201d-45db-b398-ad56f7b01848.jpg?1",
             "name": "Slumbering Cerberus",
             "text": "This creature doesn't untap during your untap step.\nMorbid \u2014 At the beginning of each end step, if a creature died this turn, untap this creature.",
             "colours": [
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "66f2c0bd-a18f-5e00-bccd-fa495e7a183f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff50606-491c-4946-8d03-719b01cfad77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff50606-491c-4946-8d03-719b01cfad77.jpg?1",
             "name": "Sower of Chaos",
             "text": "{2}{R}: Target creature can't block this turn.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "802042e5-e5da-5bc9-81ea-587a509ea93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2223eb8-59f9-489b-a3f3-b6496218cb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2223eb8-59f9-489b-a3f3-b6496218cb79.jpg?1",
             "name": "Strongbox Raider",
             "text": "Raid \u2014 When this creature enters, if you attacked this turn, exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -3398,7 +3398,7 @@
         },
         {
             "id": "3f120402-2fc1-5ef8-aec0-a556016bffbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "66885d74-6001-5a11-b8d4-01cbf10fef19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903832c-318e-42ab-bf58-c682ec2f7afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903832c-318e-42ab-bf58-c682ec2f7afd.jpg?1",
             "name": "Ambush Wolf",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, exile up to one target card from a graveyard.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "26481264-a3e0-541d-8620-47118d6e2c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7b0c-0e1b-46ce-9917-9fc6e05aa148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680b7b0c-0e1b-46ce-9917-9fc6e05aa148.jpg?1",
             "name": "Apothecary Stomper",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, choose one \u2014\n\u2022 Put two +1/+1 counters on target creature you control.\n\u2022 You gain 4 life.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "ae62b6eb-b7f9-5679-9450-1b226d77574c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0102e0be-5783-4825-9489-713b1b1df0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0102e0be-5783-4825-9489-713b1b1df0b2.jpg?1",
             "name": "Beast-Kin Ranger",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever another creature you control enters, this creature gets +1/+0 until end of turn.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "6b77124e-6ded-55ba-ae16-89751e538d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e971-c075-4203-8d83-c28f22d4f9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e971-c075-4203-8d83-c28f22d4f9b9.jpg?1",
             "name": "Cackling Prowler",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nMorbid \u2014 At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "06a79841-e87b-5e32-a469-bc3ed314df2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8433d-eb2a-43d1-b59b-7d70ff97c8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8433d-eb2a-43d1-b59b-7d70ff97c8e7.jpg?1",
             "name": "Eager Trufflesnout",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever this creature deals combat damage to a player, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "6fb94a99-c9a1-5cee-a86f-d90f16a2fd97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128a5be-ffa6-4998-8488-872d80b24cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128a5be-ffa6-4998-8488-872d80b24cb2.jpg?1",
             "name": "Elfsworn Giant",
             "text": "Reach (This creature can block creatures with flying.)\nLandfall \u2014 Whenever a land you control enters, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "880b41aa-ea48-5c53-a1ac-6778d40660b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2694e3cd-26ed-4a10-ae55-fb84d7800253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2694e3cd-26ed-4a10-ae55-fb84d7800253.jpg?1",
             "name": "Elvish Regrower",
             "text": "When this creature enters, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "22635d39-ec8b-534f-bd3c-6f71153e1991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96948ae3-b15d-4d6d-aa73-9f52084cd903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96948ae3-b15d-4d6d-aa73-9f52084cd903.jpg?1",
             "name": "Felling Blow",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "765fc4b1-421f-5a44-a298-fa101d2ca473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "fefd8be3-8253-598f-938d-4c44a090ebf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -3791,7 +3791,7 @@
         },
         {
             "id": "7eff95e7-d15b-575c-b65a-86d9b6df4db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c1679-e02b-44f2-b34e-12fd6b5142e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c1679-e02b-44f2-b34e-12fd6b5142e9.jpg?1",
             "name": "Needletooth Pack",
             "text": "Morbid \u2014 At the beginning of your end step, if a creature died this turn, put two +1/+1 counters on target creature you control.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "c2804779-4f95-51c5-b25f-f2e55f470c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb65189-60e4-42e0-9fb1-da6b716b91d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb65189-60e4-42e0-9fb1-da6b716b91d7.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "9cc580df-eede-5e20-9148-3d7d37c5a826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067f72c2-ead6-4879-bc9d-696c9f87c0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067f72c2-ead6-4879-bc9d-696c9f87c0b2.jpg?1",
             "name": "Quakestrider Ceratops",
             "text": "",
             "colours": [
@@ -3895,7 +3895,7 @@
         },
         {
             "id": "8d754d4e-e020-52e7-91d7-8d7457eae7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it. (It must survive to get the counters.)\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "e96c8eaf-27a4-5980-8765-67fa5155fa72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "9b3634b7-1517-501d-8a20-0ac82858eef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35b683c-d3b2-46a1-876a-81b34e8ba2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35b683c-d3b2-46a1-876a-81b34e8ba2fc.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "c157230e-551b-54ae-b1a5-a3f7c61a4907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e68fa3-159d-49a6-8ac6-afc9bd6f1718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e68fa3-159d-49a6-8ac6-afc9bd6f1718.jpg?1",
             "name": "Treetop Snarespinner",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{2}{G}: Put a +1/+1 counter on target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "9df9ba87-8740-52d9-b894-75437fecdaad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e3406-4e29-4bc0-ae52-cbd2ac1f99a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e3406-4e29-4bc0-ae52-cbd2ac1f99a4.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "4d91a969-98eb-5e3f-8f8b-2d1ff7bb7a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe3a40-9cbe-4235-86f9-32576aaebba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe3a40-9cbe-4235-86f9-32576aaebba8.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "def8ce02-ce59-588e-b793-70c739fc1a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece147f-d71a-4c95-9fe5-f5c862ef14ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dece147f-d71a-4c95-9fe5-f5c862ef14ac.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "1d75bb72-d5cf-5fe4-94e1-6cf6569b595d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d838b-ab48-410a-9a50-dbfea5da089b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d838b-ab48-410a-9a50-dbfea5da089b.jpg?1",
             "name": "Dreadwing Scavenger",
             "text": "Flying\nWhenever this creature enters or attacks, draw a card, then discard a card.\nThreshold \u2014 This creature gets +1/+1 and has deathtouch as long as there are seven or more cards in your graveyard.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "c54f7119-5c1c-5f5e-ba86-14da6ac96063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24955f5f-093c-4d33-b0c1-911cd36032ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24955f5f-093c-4d33-b0c1-911cd36032ce.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -4244,7 +4244,7 @@
         },
         {
             "id": "1bbbf5c2-4e97-519d-ada9-d58b4f5e6d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e434d74-cad0-45f5-bc8d-f34aa5e1d879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e434d74-cad0-45f5-bc8d-f34aa5e1d879.jpg?1",
             "name": "Fiendish Panda",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.\nWhen this creature dies, return another target non-Bear creature card with mana value less than or equal to this creature's power from your graveyard to the battlefield.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "089890db-60b4-5c24-a402-ce9633a1c699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b92caa-3401-4b11-9515-152f3e057c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b92caa-3401-4b11-9515-152f3e057c05.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "8318540e-9a05-5ae1-89a1-8ecd77ee2cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c980998-7124-4ec6-a0b6-e8d9a2364925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c980998-7124-4ec6-a0b6-e8d9a2364925.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -4366,7 +4366,7 @@
         },
         {
             "id": "82c132ce-0d38-57f8-9565-f63ad8dcbb2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69a618-d588-4745-8ede-0ff0a9f356f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69a618-d588-4745-8ede-0ff0a9f356f1.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "4d065588-13a8-5c05-9649-9a9cc9b6bd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72980409-53f0-43c1-965e-06f22e7bb608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72980409-53f0-43c1-965e-06f22e7bb608.jpg?1",
             "name": "Perforating Artist",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRaid \u2014 At the beginning of your end step, if you attacked this turn, each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card.",
             "colours": [
@@ -4445,7 +4445,7 @@
         },
         {
             "id": "4871ae10-f282-5a15-aea8-3ec1859f1af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea9b2c-5723-4eff-88ac-6669975939e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ea9b2c-5723-4eff-88ac-6669975939e3.jpg?1",
             "name": "Wardens of the Cycle",
             "text": "Morbid \u2014 At the beginning of your end step, if a creature died this turn, choose one \u2014\n\u2022 You gain 2 life.\n\u2022 You draw a card and you lose 1 life.",
             "colours": [
@@ -4482,7 +4482,7 @@
         },
         {
             "id": "27f1a808-3914-54a1-bc3f-062001f2267e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ccbfdd-ddae-440c-9bc0-38b15a56fdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ccbfdd-ddae-440c-9bc0-38b15a56fdd1.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "5b9d3a69-ca99-52b1-a72f-ae9720bf76bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c16c0-4053-46b0-8fa6-be8b4a7a1c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c16c0-4053-46b0-8fa6-be8b4a7a1c8a.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "781255ab-74d2-5801-bf63-e16d63746171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95ab836-3277-4223-9aaa-ef2c77256b65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95ab836-3277-4223-9aaa-ef2c77256b65.jpg?1",
             "name": "Fishing Pole",
             "text": "Equipped creature has \"{1}, {T}, Tap Fishing Pole: Put a bait counter on Fishing Pole.\"\nWhenever equipped creature becomes untapped, remove a bait counter from this Equipment. If you do, create a 1/1 blue Fish creature token.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "88dd0c2c-5045-5b7d-85a6-65637cc84d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c03336-a321-4c06-94d1-809f328fabd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c03336-a321-4c06-94d1-809f328fabd8.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "05d9a955-cf8f-5473-9277-f5e8fc8681e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beec98-c89c-4673-953c-8b3ef3d81560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beec98-c89c-4673-953c-8b3ef3d81560.jpg?1",
             "name": "Quick-Draw Katana",
             "text": "During your turn, equipped creature gets +2/+0 and has first strike. (It deals combat damage before creatures without first strike.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "14197f0a-3a76-5583-879b-a0a27793c1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cadee5-6f26-4440-ad31-a8e573a90436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cadee5-6f26-4440-ad31-a8e573a90436.jpg?1",
             "name": "Ravenous Amulet",
             "text": "{1}, {T}, Sacrifice a creature: Draw a card and put a soul counter on this artifact. Activate only as a sorcery.\n{4}, {T}, Sacrifice this artifact: Each opponent loses life equal to the number of soul counters on this artifact.",
             "colours": [],
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "dcce3613-a77f-5521-ad36-1c3fea6bcae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1176dcf-40ee-4342-aa74-791b8352e99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1176dcf-40ee-4342-aa74-791b8352e99a.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -4715,7 +4715,7 @@
         },
         {
             "id": "573f754d-a5ff-5baa-86e8-bbc83345c837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642553a7-6d0f-483d-a873-3a703786db42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642553a7-6d0f-483d-a873-3a703786db42.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -4747,7 +4747,7 @@
         },
         {
             "id": "8867b16d-e7a8-5b75-ba08-90ea76f2edd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59793f1c-8c7e-433e-9c09-40aa3ce931a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59793f1c-8c7e-433e-9c09-40aa3ce931a1.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n\u22123: Target creature gains flying and double strike until end of turn.\n\u22128: Create X 2/2 white Cat creature tokens, where X is your life total.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "07e7e965-ecc8-5533-b3b6-a2d5159263db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222c1a68-e34c-4103-b1be-17d4ceaef6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222c1a68-e34c-4103-b1be-17d4ceaef6ce.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.",
             "colours": [
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "3e2d47d0-e607-51e8-8cb3-bb36accc17f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaabd52-3aa9-4e2f-9369-d4db8b405ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaabd52-3aa9-4e2f-9369-d4db8b405ba8.jpg?1",
             "name": "Angel of Finality",
             "text": "Flying\nWhen this creature enters, exile target player's graveyard.",
             "colours": [
@@ -4857,7 +4857,7 @@
         },
         {
             "id": "2ca14c1f-2347-5ac8-82ac-e610e9bba806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ce2d7f-5924-47c0-b5ed-dacf9f9617a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ce2d7f-5924-47c0-b5ed-dacf9f9617a0.jpg?1",
             "name": "Authority of the Consuls",
             "text": "Creatures your opponents control enter tapped.\nWhenever a creature an opponent controls enters, you gain 1 life.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "4d998039-e580-50e3-b99a-b78d3f76bd9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38dc3b3-1629-491b-8afd-0e7a9a857713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38dc3b3-1629-491b-8afd-0e7a9a857713.jpg?1",
             "name": "Banishing Light",
             "text": "When this enchantment enters, exile target nonland permanent an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "3898d51d-0277-5621-86b7-d84ec537ecc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf024d-edb6-4a79-8676-73f8db0cdf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf024d-edb6-4a79-8676-73f8db0cdf1f.jpg?1",
             "name": "Cathar Commando",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\n{1}, Sacrifice this creature: Destroy target artifact or enchantment.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "4f00c3ce-f6b8-5a16-93b5-1477a8ec8e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e84bdc-8a9a-4c58-ba8b-9f052fd60069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e84bdc-8a9a-4c58-ba8b-9f052fd60069.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "c8ce1094-4857-5ea0-ac6e-e2767f097937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae6fc26-cfad-4da8-98d9-49c27c24d293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae6fc26-cfad-4da8-98d9-49c27c24d293.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "bb5fb4bc-c0b1-509a-9aee-925aed552554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8e4563-04bb-46b5-835e-64ba11c0e972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8e4563-04bb-46b5-835e-64ba11c0e972.jpg?1",
             "name": "Healer's Hawk",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -5064,7 +5064,7 @@
         },
         {
             "id": "9ed6bd6b-2f81-5036-8c62-fe6f5122e521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368f861-3288-4645-90a7-ca35d6da3721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368f861-3288-4645-90a7-ca35d6da3721.jpg?1",
             "name": "Make Your Move",
             "text": "Destroy target artifact, enchantment, or creature with power 4 or greater.",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "5ebf287a-abca-5158-a3a8-bb107c455437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7214d984-6400-44d7-bde6-57d96b606e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7214d984-6400-44d7-bde6-57d96b606e78.jpg?1",
             "name": "Mischievous Pup",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, return up to one other target permanent you control to its owner's hand.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "30c0b57a-bab2-5c50-b4ae-675dd10da7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f3989-77cc-49a9-92e0-095a75d80f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940f3989-77cc-49a9-92e0-095a75d80f0f.jpg?1",
             "name": "Resolute Reinforcements",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -5165,7 +5165,7 @@
         },
         {
             "id": "2e03b095-937a-5d41-9ce0-9e8236c6b1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9ac1bc-cdf3-4fa6-8319-a7ea164e9e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9ac1bc-cdf3-4fa6-8319-a7ea164e9e47.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -5199,7 +5199,7 @@
         },
         {
             "id": "ff7b8ff2-3450-5cef-aeaf-6405123a92ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cee9303-9d65-45a2-93d4-ef4aba59141b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cee9303-9d65-45a2-93d4-ef4aba59141b.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -5233,7 +5233,7 @@
         },
         {
             "id": "0e1ca27b-f3a6-5186-8d37-e111bd449d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab135925-d924-456d-851a-6ccdaaf27271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab135925-d924-456d-851a-6ccdaaf27271.jpg?1",
             "name": "Stroke of Midnight",
             "text": "Destroy target nonland permanent. Its controller creates a 1/1 white Human creature token.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "4e558a82-adc2-562f-8781-92a8ac0ae9d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d795f79-c3a5-4ea1-a5cf-1ce73d6837b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d795f79-c3a5-4ea1-a5cf-1ce73d6837b6.jpg?1",
             "name": "Youthful Valkyrie",
             "text": "Flying\nWhenever another Angel you control enters, put a +1/+1 counter on this creature.",
             "colours": [
@@ -5301,7 +5301,7 @@
         },
         {
             "id": "dcad9bd7-8edb-578c-96b3-f5061528191f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f2014a-fbc9-447c-a440-e06d01066bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f2014a-fbc9-447c-a440-e06d01066bb9.jpg?1",
             "name": "Aegis Turtle",
             "text": "",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "2125df2b-3434-5e48-ab5a-765df3708bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5530fc-0291-4a17-b048-c5d24e6f51d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5530fc-0291-4a17-b048-c5d24e6f51d8.jpg?1",
             "name": "Aetherize",
             "text": "Return all attacking creatures to their owner's hand.",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "fe59d085-e709-569e-87a7-8632a4194c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7aafb-931f-49e5-8691-eab8cb34b05e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7aafb-931f-49e5-8691-eab8cb34b05e.jpg?1",
             "name": "Brineborn Cutthroat",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "9c13b10c-3943-5977-b953-93653d891981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd05c850-f91e-4ffb-b4cc-8418d49dad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd05c850-f91e-4ffb-b4cc-8418d49dad90.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "d01b97ff-de7e-572b-8de4-e78612444282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a41dfae-bc7e-4105-8f7e-fd0109197ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a41dfae-bc7e-4105-8f7e-fd0109197ad8.jpg?1",
             "name": "Extravagant Replication",
             "text": "At the beginning of your upkeep, create a token that's a copy of another target nonland permanent you control.",
             "colours": [
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "db7131df-7834-5b20-9fde-fff474bc4a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b86a7b-4912-43a7-ab89-c3432385baa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b86a7b-4912-43a7-ab89-c3432385baa1.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -5498,7 +5498,7 @@
         },
         {
             "id": "999838e6-8761-5567-af66-5d9182fe09aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28e147-6622-4399-a314-c14a5c912dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28e147-6622-4399-a314-c14a5c912dd0.jpg?1",
             "name": "Imprisoned in the Moon",
             "text": "Enchant creature, land, or planeswalker\nEnchanted permanent is a colorless land with \"{T}: Add {C}\" and loses all other card types and abilities.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "92b19767-1f40-5bb3-b6c3-8a8dff0ba1de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb75315c-ea8f-4eb0-899e-c73ef75fc396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb75315c-ea8f-4eb0-899e-c73ef75fc396.jpg?1",
             "name": "Lightshell Duo",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -5567,7 +5567,7 @@
         },
         {
             "id": "cfccf86f-cc31-5231-82e6-88208119d8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6af54ea-b57a-4e50-8e46-1747cca14430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6af54ea-b57a-4e50-8e46-1747cca14430.jpg?1",
             "name": "Micromancer",
             "text": "When this creature enters, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "64fe199e-239e-517e-8b9b-bcbae7400cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6792f63-b651-497d-8aa5-cddf4cedeca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6792f63-b651-497d-8aa5-cddf4cedeca8.jpg?1",
             "name": "Mocking Sprite",
             "text": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "861ec992-f416-5138-a584-b6d11a87db94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a829747f-cf9b-4d81-ba66-9f0630ed4565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a829747f-cf9b-4d81-ba66-9f0630ed4565.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -5671,7 +5671,7 @@
         },
         {
             "id": "80e05035-5fab-5b73-acf2-df7f472e5d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d91d0-1506-45e4-9def-975bf901815e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d91d0-1506-45e4-9def-975bf901815e.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -5706,7 +5706,7 @@
         },
         {
             "id": "d8147e74-424f-5ef0-a155-2405c88481e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e598eb7b-10dc-49e6-ac60-2fefa987173e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e598eb7b-10dc-49e6-ac60-2fefa987173e.jpg?1",
             "name": "Run Away Together",
             "text": "Choose two target creatures controlled by different players. Return those creatures to their owners' hands.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "5440efd0-cb6f-5716-b54c-7cbfcda34616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e6abc9-25b2-4d51-b519-2525079eab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e6abc9-25b2-4d51-b519-2525079eab51.jpg?1",
             "name": "Self-Reflection",
             "text": "Create a token that's a copy of target creature you control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "782b2591-5045-5147-9d66-cd545666c8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a49535-c5f3-4a6f-b333-7ac7bffdc9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a49535-c5f3-4a6f-b333-7ac7bffdc9ae.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -5805,7 +5805,7 @@
         },
         {
             "id": "b9258cf8-55c5-50fd-a1e7-2d96da26978e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88faaa1-eb41-40f7-991c-5c06e1138f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88faaa1-eb41-40f7-991c-5c06e1138f3d.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5841,7 +5841,7 @@
         },
         {
             "id": "769baa76-524e-531a-9bbd-0c95270af172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d938603b-0f1e-44c4-b86e-38e15f4a0d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d938603b-0f1e-44c4-b86e-38e15f4a0d27.jpg?1",
             "name": "Time Stop",
             "text": "End the turn. (Exile all spells and abilities, including this spell. The player whose turn it is discards down to their maximum hand size. Damage heals and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "99197ef0-3841-5744-956d-e0c552720bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569d4f3-55ed-4f99-9592-34c7df0aab72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569d4f3-55ed-4f99-9592-34c7df0aab72.jpg?1",
             "name": "Tolarian Terror",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "cf9e44c8-ea46-5f0d-9119-52d15200f06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231e981-0069-43ce-ac1c-c85ced613e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f231e981-0069-43ce-ac1c-c85ced613e93.jpg?1",
             "name": "Witness Protection",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a green and white Citizen creature with base power and toughness 1/1 named Legitimate Businessperson. (It loses all other colors, card types, creature types, and names.)",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "b1f70c23-9846-53be-a574-f40a15e698e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab0e660-86a3-4b92-82fa-77dcb5db947d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab0e660-86a3-4b92-82fa-77dcb5db947d.jpg?1",
             "name": "Bake into a Pie",
             "text": "Destroy target creature. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
             "colours": [
@@ -5973,7 +5973,7 @@
         },
         {
             "id": "0026b9a2-e2f8-5c3d-bef2-d698955a74e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c8758-ce3d-49cf-8173-c0eb46f5e7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c8758-ce3d-49cf-8173-c0eb46f5e7bc.jpg?1",
             "name": "Burglar Rat",
             "text": "When this creature enters, each opponent discards a card.",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "b3609a7f-41c5-5e01-ad27-95d9d6babed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4682012c-d7e0-4257-b538-3de497507464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4682012c-d7e0-4257-b538-3de497507464.jpg?1",
             "name": "Diregraf Ghoul",
             "text": "This creature enters tapped.",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "86c0d20a-b5be-535f-a893-016281c6e502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f7b20-b2a8-498c-8c36-dc296863b0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f7b20-b2a8-498c-8c36-dc296863b0b9.jpg?1",
             "name": "Eaten Alive",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nExile target creature or planeswalker.",
             "colours": [
@@ -6073,7 +6073,7 @@
         },
         {
             "id": "ed7699a2-cd3d-55fa-9f96-ed5d37795652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11d7311-4066-4a5d-ba28-9857fa707a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11d7311-4066-4a5d-ba28-9857fa707a0b.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "0058c59f-1948-568d-80d6-a35ac7381c62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693635a6-df50-44c5-9598-0c79b45d4df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693635a6-df50-44c5-9598-0c79b45d4df4.jpg?1",
             "name": "Fake Your Own Death",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control and you create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "4ee883ed-faca-51ec-b4d8-4aa7a4ad4b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c01d9-8f54-46c0-9dc9-d4d4764ce1c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c01d9-8f54-46c0-9dc9-d4d4764ce1c9.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "f9e2074c-269f-5e4c-ad19-9fcf23efbab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28d217-795e-4320-a032-cd713f7ecc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb28d217-795e-4320-a032-cd713f7ecc8a.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures of their choice.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "44fb19b7-d696-50fc-8975-bfeccdc71a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1f3c84-89ba-4426-a80b-d524f172c912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1f3c84-89ba-4426-a80b-d524f172c912.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -6242,7 +6242,7 @@
         },
         {
             "id": "9a5acce6-55df-526e-aee8-2331b03cc338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f70dafc-c638-4ec0-ab5b-62998f752720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f70dafc-c638-4ec0-ab5b-62998f752720.jpg?1",
             "name": "Marauding Blight-Priest",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -6277,7 +6277,7 @@
         },
         {
             "id": "fad5d3e9-cb89-5ec2-8b0a-003398fdae02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05757669-e8a6-4a2f-8479-d4e2ade822ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05757669-e8a6-4a2f-8479-d4e2ade822ca.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless they discard a card.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "66ced0b1-e261-5a8d-a681-3b071921a940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0784b6f0-9ebf-43d2-ba0f-a6bc93ba0c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0784b6f0-9ebf-43d2-ba0f-a6bc93ba0c48.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "18761f76-86df-58e4-ad50-564fc9857c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7c88b5-6d09-453b-b9c1-7dcbba8f1080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7c88b5-6d09-453b-b9c1-7dcbba8f1080.jpg?1",
             "name": "Pilfer",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "00dec49b-3df4-5c26-a18d-3b48e577b5f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e84b1b-1c05-4e1b-93b8-9cc2ca73509d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e84b1b-1c05-4e1b-93b8-9cc2ca73509d.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return this card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6412,7 +6412,7 @@
         },
         {
             "id": "47d3d28c-b318-5d2a-8998-6b0286adf115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8645bf0c-631f-4003-bd24-3e069ae23513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8645bf0c-631f-4003-bd24-3e069ae23513.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "e47115ab-bbd3-59bd-98c5-03967f5b75fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae3165-554d-4759-8f18-794e2a7d8464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae3165-554d-4759-8f18-794e2a7d8464.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen this creature enters, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -6481,7 +6481,7 @@
         },
         {
             "id": "fe39828e-8601-5395-b7d7-6bb1d0d51ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485d6a5a-2054-47d5-91b8-71ce308ed4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485d6a5a-2054-47d5-91b8-71ce308ed4dc.jpg?1",
             "name": "Stromkirk Bloodthief",
             "text": "At the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on target Vampire you control.",
             "colours": [
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "672d1d6f-78f8-5e24-84bb-8d985aea5645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1934ab-3171-4fc6-8033-ad998899ba73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1934ab-3171-4fc6-8033-ad998899ba73.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -6551,7 +6551,7 @@
         },
         {
             "id": "dce4dfc8-5ffa-5d76-9642-86a30e25fc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc798e6f-13c4-457c-b052-b7b65bc83cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc798e6f-13c4-457c-b052-b7b65bc83cfe.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "9f288880-e42f-54ae-922b-d78df931e36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548947dc-a5ca-43b5-9531-bcef20fa4ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548947dc-a5ca-43b5-9531-bcef20fa4ae5.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "280fd6ca-591a-566a-8d93-e0e46b83c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3cc41a-adae-4c9b-b4d3-03f3ca862fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3cc41a-adae-4c9b-b4d3-03f3ca862fed.jpg?1",
             "name": "Axgard Cavalry",
             "text": "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "beed527f-6368-5295-8fd5-b604b2536861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fe7127-b0ec-400f-97f1-6e17ab8e319d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65fe7127-b0ec-400f-97f1-6e17ab8e319d.jpg?1",
             "name": "Brass's Bounty",
             "text": "For each land you control, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "fbee614d-e4f3-5dc8-9d6b-bc97f26b60b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84b86c-3276-4fc1-a09d-47de388cb729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb84b86c-3276-4fc1-a09d-47de388cb729.jpg?1",
             "name": "Brazen Scourge",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -6718,7 +6718,7 @@
         },
         {
             "id": "5714ba1e-1b5a-5d7e-9fb5-58150425ea44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec5d380-d354-4750-931a-6c91853e2edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec5d380-d354-4750-931a-6c91853e2edc.jpg?1",
             "name": "Burst Lightning",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to any target. If this spell was kicked, it deals 4 damage instead.",
             "colours": [
@@ -6750,7 +6750,7 @@
         },
         {
             "id": "d99c0e22-484a-56bf-ae58-f2434ea46989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b1edb-e1de-4f1c-81df-8d17f4920318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029b1edb-e1de-4f1c-81df-8d17f4920318.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -6786,7 +6786,7 @@
         },
         {
             "id": "6c7ec352-c9cd-5dc7-a74e-86175f9028a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6af9894-95b5-4c8e-902f-a9ba70f02e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6af9894-95b5-4c8e-902f-a9ba70f02e4a.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "a323bcc9-4858-55dd-b49e-4dc08816c7d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1296316-7781-4e98-95e6-7020648be6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1296316-7781-4e98-95e6-7020648be6a5.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}, Sacrifice this creature: It deals 1 damage to any target.",
             "colours": [
@@ -6861,7 +6861,7 @@
         },
         {
             "id": "3a0b1966-0bd7-574b-b6b5-bc99946707f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0312f1-4c98-4b7f-8a34-0059ea80edef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0312f1-4c98-4b7f-8a34-0059ea80edef.jpg?1",
             "name": "Firebrand Archer",
             "text": "Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "7935aa79-8e14-500c-b7f4-a48713598e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a4c7d-3126-4bde-9dca-cb6a1e2f37c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3a4c7d-3126-4bde-9dca-cb6a1e2f37c9.jpg?1",
             "name": "Firespitter Whelp",
             "text": "Flying\nWhenever you cast a noncreature or Dragon spell, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "379311e6-d2af-5723-b42d-c67e3892a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f008e-48a0-406b-83fa-99cd396831f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f008e-48a0-406b-83fa-99cd396831f8.jpg?1",
             "name": "Flamewake Phoenix",
             "text": "Flying, haste\nThis creature attacks each combat if able.\nAt the beginning of combat on your turn, if you control a creature with power 4 or greater, you may pay {R}. If you do, return this card from your graveyard to the battlefield.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "836b6067-c6f1-54bf-bc7d-9513bab8f267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592573-2889-40b1-b1d5-c2802482549a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592573-2889-40b1-b1d5-c2802482549a.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever this creature attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -6999,7 +6999,7 @@
         },
         {
             "id": "bb08b36d-fe2b-5ee2-98a4-640bd099d688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e.jpg?1",
             "name": "Goblin Surprise",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -7031,7 +7031,7 @@
         },
         {
             "id": "72524102-acf4-5c0c-8e78-7ab16f47aa1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca38f4d-01f5-4a02-9000-01261a440dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca38f4d-01f5-4a02-9000-01261a440dbf.jpg?1",
             "name": "Heartfire Immolator",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{R}, Sacrifice this creature: It deals damage equal to its power to target creature or planeswalker.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "c70d0bf4-de34-51aa-b5f1-1b7cbaab6cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609421da-8d89-4365-b18b-778832d91482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609421da-8d89-4365-b18b-778832d91482.jpg?1",
             "name": "Hidetsugu's Second Rite",
             "text": "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "72d323b6-606b-5535-8b94-43bc0a576bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad3d62-2f24-4562-b3fa-809213dbc4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad3d62-2f24-4562-b3fa-809213dbc4a4.jpg?1",
             "name": "Involuntary Employment",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -7130,7 +7130,7 @@
         },
         {
             "id": "3e788340-1f6f-5329-84e7-f8fe9c59c8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824b2d73-2151-4e5e-9f05-8f63e2bdcaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/824b2d73-2151-4e5e-9f05-8f63e2bdcaa9.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -7167,7 +7167,7 @@
         },
         {
             "id": "f8b60b98-baab-5164-9471-5c80bba19257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519a51a-26a0-4884-9ba8-9db135c9ee49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2519a51a-26a0-4884-9ba8-9db135c9ee49.jpg?1",
             "name": "Seismic Rupture",
             "text": "Seismic Rupture deals 2 damage to each creature without flying.",
             "colours": [
@@ -7199,7 +7199,7 @@
         },
         {
             "id": "fcb73a3f-8d66-5136-bf6b-e7bce48a85ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcff1e0-2745-448d-a27b-e31719e222e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcff1e0-2745-448d-a27b-e31719e222e9.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: This creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "f3e1b6ea-9876-5f82-af30-68faa0a90f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0.jpg?1",
             "name": "Slagstorm",
             "text": "Choose one \u2014\n\u2022 Slagstorm deals 3 damage to each creature.\n\u2022 Slagstorm deals 3 damage to each player.",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "d71e8b3a-bd6e-5b17-a087-728717e2e9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f600cd-b696-4f49-9cbc-5a33aa43d04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f600cd-b696-4f49-9cbc-5a33aa43d04c.jpg?1",
             "name": "Spitfire Lagac",
             "text": "Landfall \u2014 Whenever a land you control enters, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -7299,7 +7299,7 @@
         },
         {
             "id": "1c22a3a8-a478-53c0-8ae6-82ad92727e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de6a1e4-5c66-43e6-9f2a-2635bdab03f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de6a1e4-5c66-43e6-9f2a-2635bdab03f6.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "9779bd6a-8e06-5038-8419-b2bdb810714a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b348c-076b-41d8-b505-063480636669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b348c-076b-41d8-b505-063480636669.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "1f83bbd4-9ce6-5028-ba0d-bb2bee72c0b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8347d-06a4-46e0-a55e-cc2da4660263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da8347d-06a4-46e0-a55e-cc2da4660263.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When this creature enters, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "f29559f8-bbe0-5428-9c8d-0e4213838629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d70b3b-f6f9-4b3c-ad70-0ce369e812b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d70b3b-f6f9-4b3c-ad70-0ce369e812b5.jpg?1",
             "name": "Bite Down",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7429,7 +7429,7 @@
         },
         {
             "id": "b0979c34-a084-5e0d-b840-daf459a844b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd7ec1a-dafa-42ca-bc25-f6848fb03f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd7ec1a-dafa-42ca-bc25-f6848fb03f60.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -7463,7 +7463,7 @@
         },
         {
             "id": "b0b93d80-8fae-5be3-b302-5598bf2103b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f9cbeb-cc9c-4562-be65-8a77053faefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f9cbeb-cc9c-4562-be65-8a77053faefe.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -7495,7 +7495,7 @@
         },
         {
             "id": "7d0f68ef-cc8b-56f7-85d7-ce4d62bbbc13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ebdb36-55e0-49dd-a514-785fbeb4ae19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ebdb36-55e0-49dd-a514-785fbeb4ae19.jpg?1",
             "name": "Bushwhack",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n\u2022 Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7527,7 +7527,7 @@
         },
         {
             "id": "0c609e6f-a2e6-586c-8220-52c172de9da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c4f80e-84a0-463b-82c3-5c6503809351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c4f80e-84a0-463b-82c3-5c6503809351.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "e1438cba-8708-5da0-b38a-9ddbbcf6d0e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c00d7b-7fac-4f8c-a1ea-de2cf4d06627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c00d7b-7fac-4f8c-a1ea-de2cf4d06627.jpg?1",
             "name": "Dwynen, Gilt-Leaf Daen",
             "text": "Reach (This creature can block creatures with flying.)\nOther Elf creatures you control get +1/+1.\nWhenever Dwynen attacks, you gain 1 life for each attacking Elf you control.",
             "colours": [
@@ -7599,7 +7599,7 @@
         },
         {
             "id": "856703c6-99f7-53e9-827f-eee7254d4bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d94c28-ea2e-4a3d-935f-6b2d9f2efc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d94c28-ea2e-4a3d-935f-6b2d9f2efc7a.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When this creature enters, if you control another Elf, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "cc3c3154-566c-581b-85c1-21f091c9c382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341da856-7414-403b-b2e3-4bebd58a5aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341da856-7414-403b-b2e3-4bebd58a5aa4.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} for each Elf you control.",
             "colours": [
@@ -7669,7 +7669,7 @@
         },
         {
             "id": "92898aba-637b-5bf9-9d27-40633eb11dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805c303-e73b-443b-a09f-49d2c2c88bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4805c303-e73b-443b-a09f-49d2c2c88bb5.jpg?1",
             "name": "Garruk's Uprising",
             "text": "When this enchantment enters, if you control a creature with power 4 or greater, draw a card.\nCreatures you control have trample. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever a creature you control with power 4 or greater enters, draw a card.",
             "colours": [
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "49bfd3a9-f10f-5181-96bb-31e1b61f2124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f7ddb-f986-4f1f-b096-ae1a02d0bdc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f7ddb-f986-4f1f-b096-ae1a02d0bdc8.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -7736,7 +7736,7 @@
         },
         {
             "id": "1606bfd8-3f01-5c04-ab2b-806058523f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9c39e4-a8cf-42dd-8d0e-45634b335546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9c39e4-a8cf-42dd-8d0e-45634b335546.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "ec350655-b736-53b4-a7ed-85560b791cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf74e-14c1-4428-88d8-2181a080b5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf74e-14c1-4428-88d8-2181a080b5d0.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "24b330da-643f-5c73-af39-83bfd478153a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47565d10-96bf-4fb0-820f-f20a44a76b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47565d10-96bf-4fb0-820f-f20a44a76b6f.jpg?1",
             "name": "Gnarlid Colony",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nIf this creature was kicked, it enters with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7842,7 +7842,7 @@
         },
         {
             "id": "5b9584f4-7202-52fa-868e-c8aeb0f7579d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42525f8a-aee7-4811-8f05-471b559c2c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42525f8a-aee7-4811-8f05-471b559c2c4a.jpg?1",
             "name": "Grow from the Ashes",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nSearch your library for a basic land card, put it onto the battlefield, then shuffle. If this spell was kicked, instead search your library for two basic land cards, put them onto the battlefield, then shuffle.",
             "colours": [
@@ -7874,7 +7874,7 @@
         },
         {
             "id": "fd4049f5-a1f6-555b-b965-9c9bdebb0b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e241642-5172-4437-b694-f6aa159d5cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e241642-5172-4437-b694-f6aa159d5cd9.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -7906,7 +7906,7 @@
         },
         {
             "id": "1650c6e0-3ab7-5e71-a4bd-2483134076bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0b230b-d391-4998-a3f7-7b158a0ec2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0b230b-d391-4998-a3f7-7b158a0ec2cd.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "bbafe5df-71c8-5059-a7bd-408222eba716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5389663a-fe25-41b9-8c92-1f4d7721ffc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5389663a-fe25-41b9-8c92-1f4d7721ffc2.jpg?1",
             "name": "Mild-Mannered Librarian",
             "text": "{3}{G}: This creature becomes a Werewolf. Put two +1/+1 counters on it and you draw a card. Activate only once.",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "0d85ba9a-8f56-5ddd-a99c-0203fd81d694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d93de-85c6-4653-8ddd-d8bf21516d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d93de-85c6-4653-8ddd-d8bf21516d44.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on this creature.",
             "colours": [
@@ -8012,7 +8012,7 @@
         },
         {
             "id": "35bcb87c-69d7-5e8a-97d8-e810f866177d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8e9cbb-8bf4-4a48-a58e-79deb3abdf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8e9cbb-8bf4-4a48-a58e-79deb3abdf7f.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -8044,7 +8044,7 @@
         },
         {
             "id": "e952bab9-74d9-5184-8fb3-41af633076d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1918ea65-ab7f-4d40-97fd-a656c892a2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1918ea65-ab7f-4d40-97fd-a656c892a2a1.jpg?1",
             "name": "Reclamation Sage",
             "text": "When this creature enters, you may destroy target artifact or enchantment.",
             "colours": [
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "1e6f1167-9dbf-58b8-a7aa-86b1e1f655e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504c23-1e9a-411b-9cfe-4180d0c744f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504c23-1e9a-411b-9cfe-4180d0c744f6.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on this creature and you gain 1 life.",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "6ffda4af-33ff-5b4f-aaa8-b300f84df0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4c21d-9bdc-4490-9203-17f51db0ddd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4c21d-9bdc-4490-9203-17f51db0ddd1.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -8147,7 +8147,7 @@
         },
         {
             "id": "8c6baf50-15fa-55b9-9cc0-8e2fd6b4098e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38769247-42a1-4571-9071-6d59fe28650a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38769247-42a1-4571-9071-6d59fe28650a.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -8186,7 +8186,7 @@
         },
         {
             "id": "6291cf06-55c7-5d6b-baac-c9ee7ea38b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d62d04-0974-4cb5-9a35-5e996c6456e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d62d04-0974-4cb5-9a35-5e996c6456e2.jpg?1",
             "name": "Wary Thespian",
             "text": "When this creature enters or dies, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -8221,7 +8221,7 @@
         },
         {
             "id": "67a8461d-c1ef-50ac-947d-56e789c3d1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36359fb6-fb8c-4382-8555-e348422f116c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36359fb6-fb8c-4382-8555-e348422f116c.jpg?1",
             "name": "Wildwood Scourge",
             "text": "This creature enters with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on this creature.",
             "colours": [
@@ -8255,7 +8255,7 @@
         },
         {
             "id": "5043fbee-81bd-551d-9f2a-2e69d398c7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b45ab13-9bb6-48af-8b37-d97b25801ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b45ab13-9bb6-48af-8b37-d97b25801ac8.jpg?1",
             "name": "Balmor, Battlemage Captain",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, creatures you control get +1/+0 and gain trample until end of turn.",
             "colours": [
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "6bb47321-7f25-5e7a-9b13-0ade37f3cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2b28fd-66b0-457c-80ea-7caed2cc7926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2b28fd-66b0-457c-80ea-7caed2cc7926.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -8330,7 +8330,7 @@
         },
         {
             "id": "092f0078-d6d0-522a-aa9c-7ec4d1dc7058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577e99a7-4a55-4314-8f08-2ae0c33b85c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577e99a7-4a55-4314-8f08-2ae0c33b85c7.jpg?1",
             "name": "Empyrean Eagle",
             "text": "Flying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "769b68d9-5ef0-523c-9464-7de7db1e8d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabbe163-2b15-42e3-89ce-7363e6250d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabbe163-2b15-42e3-89ce-7363e6250d3a.jpg?1",
             "name": "Good-Fortune Unicorn",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on that creature.",
             "colours": [
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "549bd4d6-ec04-52b8-8254-79fac8572a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a05e8d5-c2ad-489a-888d-22622886b620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a05e8d5-c2ad-489a-888d-22622886b620.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste. (They can attack and {T} this turn.)",
             "colours": [
@@ -8437,7 +8437,7 @@
         },
         {
             "id": "def5bb0f-5706-5b75-b605-4ca34966cedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e5480-a287-4a25-b855-a26dae555b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e5480-a287-4a25-b855-a26dae555b1c.jpg?1",
             "name": "Lathril, Blade of the Elves",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Lathril deals combat damage to a player, create that many 1/1 green Elf Warrior creature tokens.\n{T}, Tap ten untapped Elves you control: Each opponent loses 10 life and you gain 10 life.",
             "colours": [
@@ -8479,7 +8479,7 @@
         },
         {
             "id": "1bb2562f-d7ef-56e6-baac-73bb4a798bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51710b19-68e3-4853-901f-e618bde61161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51710b19-68e3-4853-901f-e618bde61161.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard. (If a card has multiple permanent types, choose one as you play it.)",
             "colours": [
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "27d64304-575a-5941-a7b7-827ebe19d22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77fbc87-d78e-4602-baa0-da9b0d464dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77fbc87-d78e-4602-baa0-da9b0d464dfb.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "01a67c48-2ba1-55ba-aee9-8f0ad4ccf5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e7dd2-b66d-4218-9fde-f84bec26b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e7dd2-b66d-4218-9fde-f84bec26b7bf.jpg?1",
             "name": "Ruby, Daring Tracker",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever Ruby attacks while you control a creature with power 4 or greater, Ruby gets +2/+2 until end of turn.\n{T}: Add {R} or {G}.",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "0369b369-a4ac-54c5-8317-5ba92b671ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94618ec-000c-4371-b925-05ff82bfe221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94618ec-000c-4371-b925-05ff82bfe221.jpg?1",
             "name": "Swiftblade Vindicator",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nVigilance (Attacking doesn't cause this creature to tap.)\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "6270c594-3828-5c25-a691-bd4b1be4b5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc978a-0666-472d-bdc6-d4b29d29eca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc978a-0666-472d-bdc6-d4b29d29eca4.jpg?1",
             "name": "Tatyova, Benthic Druid",
             "text": "Landfall \u2014 Whenever a land you control enters, you gain 1 life and draw a card.",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "13075021-4a8d-5d12-9107-d8b024f5617c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c48a67-1410-40f1-9b93-0172d85e4688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c48a67-1410-40f1-9b93-0172d85e4688.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "cf260592-0390-520c-8aaf-97653a061c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361f9b99-5b5d-40da-b4b9-5ad90f6280ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361f9b99-5b5d-40da-b4b9-5ad90f6280ee.jpg?1",
             "name": "Adventuring Gear",
             "text": "Landfall \u2014 Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "90823c89-4af3-5108-89e9-26b631c07dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ebbff0-fbe6-4310-a33f-e00bb2534979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ebbff0-fbe6-4310-a33f-e00bb2534979.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice this creature: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "e027f4fc-37c6-54af-9f57-db18afbdd3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c59814-3167-4b05-bb85-6c736f3956a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c59814-3167-4b05-bb85-6c736f3956a4.jpg?1",
             "name": "Campus Guide",
             "text": "When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -8812,7 +8812,7 @@
         },
         {
             "id": "931c37e5-efd4-511d-8506-10a1852a7150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49b009-e6f2-494a-9235-f5c25c2d70a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49b009-e6f2-494a-9235-f5c25c2d70a9.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [],
@@ -8843,7 +8843,7 @@
         },
         {
             "id": "18314580-94e5-51e1-870c-8c697fb66003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a241317d-2277-467e-a8f9-aa71c944e244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a241317d-2277-467e-a8f9-aa71c944e244.jpg?1",
             "name": "Goldvein Pick",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "c81b9315-3cae-5081-a05a-dbe52ca07fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743ea709-dbb3-4db8-a2ce-544f47eb6339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743ea709-dbb3-4db8-a2ce-544f47eb6339.jpg?1",
             "name": "Heraldic Banner",
             "text": "As this artifact enters, choose a color.\nCreatures you control of the chosen color get +1/+0.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -8901,7 +8901,7 @@
         },
         {
             "id": "a9c74785-4978-507e-86a0-762af0598777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4468fff-cd6f-428c-b7a0-ff89f5bbea2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4468fff-cd6f-428c-b7a0-ff89f5bbea2e.jpg?1",
             "name": "Juggernaut",
             "text": "This creature attacks each combat if able.\nThis creature can't be blocked by Walls.",
             "colours": [],
@@ -8932,7 +8932,7 @@
         },
         {
             "id": "925cec9b-e266-560f-801c-e73adb72b19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291ea1e-36bc-46b3-b3ae-084fa0ba69eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291ea1e-36bc-46b3-b3ae-084fa0ba69eb.jpg?1",
             "name": "Meteor Golem",
             "text": "When this creature enters, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -8963,7 +8963,7 @@
         },
         {
             "id": "6fb69167-3ae7-55df-82b6-3d4dadf3a38d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383f45e-3da2-40fb-beee-801448bbb60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383f45e-3da2-40fb-beee-801448bbb60f.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When this creature enters, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen this creature dies, you may draw a card.",
             "colours": [],
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "28df17d7-72c6-5a97-961d-ae14cbaf0650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41040541-b129-4cf4-9411-09b1d9d32c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41040541-b129-4cf4-9411-09b1d9d32c19.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control. It can attack and {T} no matter when it came under your control.)\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9028,7 +9028,7 @@
         },
         {
             "id": "fb37ca76-d139-58bb-8801-2e8283640c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b90dc92-cb66-41d9-89f9-2b6e3cfc8082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b90dc92-cb66-41d9-89f9-2b6e3cfc8082.jpg?1",
             "name": "Bloodfell Caves",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9059,7 +9059,7 @@
         },
         {
             "id": "d2885538-8a01-5740-99c4-391cc559cc6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37676ed8-588c-4bca-8065-874b74d84807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37676ed8-588c-4bca-8065-874b74d84807.jpg?1",
             "name": "Blossoming Sands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9090,7 +9090,7 @@
         },
         {
             "id": "ae6c46f8-c255-5237-8c60-e358cf80722e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb0df36-8467-4a41-8e1c-6c3584d4fd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb0df36-8467-4a41-8e1c-6c3584d4fd10.jpg?1",
             "name": "Dismal Backwater",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "861df981-8c3c-5f2c-a7d2-64c113d69f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9356-5b91-4542-8802-f0f7275238e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b9356-5b91-4542-8802-f0f7275238e1.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9149,7 +9149,7 @@
         },
         {
             "id": "5eceeacc-92cc-5c58-85d9-437553042dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc758e14-d370-45e4-bbc5-938fb4d21127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc758e14-d370-45e4-bbc5-938fb4d21127.jpg?1",
             "name": "Jungle Hollow",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9180,7 +9180,7 @@
         },
         {
             "id": "b84ab312-34ca-5fd6-a7a3-81983f60268d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a424ea-ef32-4ac5-8f8c-3ea1839f01d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a424ea-ef32-4ac5-8f8c-3ea1839f01d4.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -9208,7 +9208,7 @@
         },
         {
             "id": "aed8fc71-6827-599c-a135-a121bf6b9de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6eaf8e-8881-4d7b-bafc-75e4ca5cbef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6eaf8e-8881-4d7b-bafc-75e4ca5cbef6.jpg?1",
             "name": "Rugged Highlands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "8d79cb33-5622-5627-b165-18437fafeacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2632a4b2-9ca6-4b67-9a99-14f52ad3dc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2632a4b2-9ca6-4b67-9a99-14f52ad3dc41.jpg?1",
             "name": "Scoured Barrens",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9270,7 +9270,7 @@
         },
         {
             "id": "66c5e01e-8337-5558-b7c1-aeb9c96e49ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13373d2-139b-48c7-a8c9-828cefc4f150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13373d2-139b-48c7-a8c9-828cefc4f150.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As this land enters, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature source of the chosen type.",
             "colours": [],
@@ -9298,7 +9298,7 @@
         },
         {
             "id": "bdcc2da8-673a-509b-8985-dec3db90bddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88667d-7088-4889-960f-317486ebe856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb88667d-7088-4889-960f-317486ebe856.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "49835ac8-1aa7-5025-ae57-88d259ce82f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42799f51-0f8c-444b-974e-dae281a5c697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42799f51-0f8c-444b-974e-dae281a5c697.jpg?1",
             "name": "Thornwood Falls",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9360,7 +9360,7 @@
         },
         {
             "id": "f1ce5c3b-ee79-509e-a3cb-1915458c303c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9cabca-5bcc-4b97-b2ac-a345ad3ee43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9cabca-5bcc-4b97-b2ac-a345ad3ee43c.jpg?1",
             "name": "Tranquil Cove",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9391,7 +9391,7 @@
         },
         {
             "id": "7e8f128c-0f48-58ef-8861-11956f964876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759e99df-11a8-4aee-b6bc-344e84e10d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/759e99df-11a8-4aee-b6bc-344e84e10d94.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9422,7 +9422,7 @@
         },
         {
             "id": "522c1064-48c5-5533-a5f5-94bfbd8b4270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef17ed4-a9b5-4b8e-b4cb-2ecb7e5898c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef17ed4-a9b5-4b8e-b4cb-2ecb7e5898c3.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9460,7 +9460,7 @@
         },
         {
             "id": "fd38849f-006a-503e-be35-f7f26c7c5792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37edc4b5-75f5-4b43-a57e-a8192565a2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37edc4b5-75f5-4b43-a57e-a8192565a2a0.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9498,7 +9498,7 @@
         },
         {
             "id": "11b33d79-95c0-511e-aa05-d367ee5cbff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e2b637-72b1-4457-aaba-66d51107be4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e2b637-72b1-4457-aaba-66d51107be4c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "90fded18-4d90-55c5-90b5-6a70f341f12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23635e40-d040-40b7-8b98-90ed362aa028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23635e40-d040-40b7-8b98-90ed362aa028.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "e315449b-6d8a-51c4-9dfe-f36ffe4b1e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319bc1f0-ee42-44e5-b08b-735613ded2ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319bc1f0-ee42-44e5-b08b-735613ded2ba.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9612,7 +9612,7 @@
         },
         {
             "id": "42ee61fd-b275-5813-877b-24715c590d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505c15-14e0-4200-82bd-fb9bce949e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505c15-14e0-4200-82bd-fb9bce949e68.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "083a5b53-5e60-5885-9f51-08d3ee19eab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279df7e2-2a3b-464a-a7df-e91da28e3a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279df7e2-2a3b-464a-a7df-e91da28e3a8c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "d95e58a5-2f67-59b0-be71-8da454a2a869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc5050-69bd-416d-b04c-7f82de2a1901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc5050-69bd-416d-b04c-7f82de2a1901.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9726,7 +9726,7 @@
         },
         {
             "id": "85b7201c-9329-575e-b3d2-a610493dd6fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d232fcc2-12f6-401a-b1aa-ddff11cb9378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d232fcc2-12f6-401a-b1aa-ddff11cb9378.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9764,7 +9764,7 @@
         },
         {
             "id": "1faa9e62-8ce1-5c5a-ac34-9639aca3f7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8affbb-d2a2-436b-bbc2-9e8b6cf0d2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8affbb-d2a2-436b-bbc2-9e8b6cf0d2c4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9802,7 +9802,7 @@
         },
         {
             "id": "b8bb403e-8178-5254-a13a-1ffb876307bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6f19b3-4c76-4078-8ed2-b2832a33d066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6f19b3-4c76-4078-8ed2-b2832a33d066.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "aaaa5c45-e9f4-5e5c-a22a-51e720a9e25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0f9892-89cd-46ff-bc87-114e175cb575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0f9892-89cd-46ff-bc87-114e175cb575.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9878,7 +9878,7 @@
         },
         {
             "id": "ccd7d78d-c8b2-5b93-833e-e148274c7446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886eae6e-ced2-4d94-96fa-9bb5385b06f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886eae6e-ced2-4d94-96fa-9bb5385b06f4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "d0cc9ee9-067a-5f02-abd0-7bd690650692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f534ddc-f610-45cd-84dc-bb6df6c5a84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f534ddc-f610-45cd-84dc-bb6df6c5a84f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "8e6343b2-c503-537c-89b2-09cbf90df0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f23a73a-522b-40cf-a14b-ffdf47a24c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f23a73a-522b-40cf-a14b-ffdf47a24c01.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9992,7 +9992,7 @@
         },
         {
             "id": "dc9161df-5d88-5705-b11a-de2ab77aa5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda1dbfa-a57b-4aa8-9993-c8f97aec28bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda1dbfa-a57b-4aa8-9993-c8f97aec28bb.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10030,7 +10030,7 @@
         },
         {
             "id": "da6bb75b-16ed-507f-9d66-6eb0e20be081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3afd00-da06-4a9f-8cd1-7133728e0fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3afd00-da06-4a9f-8cd1-7133728e0fdd.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "8277604e-aad1-53a3-8c17-b042de999dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b04b4-f7f4-4c1a-86ad-b50d788aa99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b04b4-f7f4-4c1a-86ad-b50d788aa99e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10106,7 +10106,7 @@
         },
         {
             "id": "d85b7806-1da6-5117-b86c-0b3e8b13d5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbeb57d-5fa0-4ff7-b5e8-caafc139669b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbeb57d-5fa0-4ff7-b5e8-caafc139669b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10144,7 +10144,7 @@
         },
         {
             "id": "4f4875b5-832b-580c-9781-04deca045354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ab60a-b888-4585-b0c6-769d387069f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117ab60a-b888-4585-b0c6-769d387069f7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10182,7 +10182,7 @@
         },
         {
             "id": "81ccfd9c-846f-56c8-9cc7-0068d1312a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b486b75-4680-4a94-af8c-c1c335c9782b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b486b75-4680-4a94-af8c-c1c335c9782b.jpg?1",
             "name": "Sire of Seven Deaths",
             "text": "First strike\nVigilance\nMenace\nTrample\nReach\nLifelink\nWard\u2014\nPay 7 life.",
             "colours": [],
@@ -10215,7 +10215,7 @@
         },
         {
             "id": "dded4ee2-67ba-5993-b241-b44e8abbd3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cfb9bc-4273-4e5f-a7ac-2006a8345a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cfb9bc-4273-4e5f-a7ac-2006a8345a4e.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.",
             "colours": [
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "1a6bf895-b9e1-57a8-9805-13c3470d41cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a39af-bafe-4a38-a270-39a0ce0f4aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a39af-bafe-4a38-a270-39a0ce0f4aa5.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -10293,7 +10293,7 @@
         },
         {
             "id": "ddff03c6-3ddf-591a-be5e-2cc2d9fb042a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0302a684-563c-49b2-9029-7f079ac58fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0302a684-563c-49b2-9029-7f079ac58fd2.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W}",
             "colours": [
@@ -10331,7 +10331,7 @@
         },
         {
             "id": "3b1e19c7-5465-522d-8b4c-0105a0088474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c62996-3dc9-4f1a-8979-790b9b6b134e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c62996-3dc9-4f1a-8979-790b9b6b134e.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender\nYou have hexproof.\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "ff222ac6-7563-5101-b79a-e6060c358a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b28fe-f10f-4e3e-8c19-ed012349faf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b28fe-f10f-4e3e-8c19-ed012349faf4.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "07159a60-1e11-5703-878d-6170ae538b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b235e9f-a8a6-45d7-b301-bc6db752dda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b235e9f-a8a6-45d7-b301-bc6db752dda8.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -10447,7 +10447,7 @@
         },
         {
             "id": "9c4780b8-f9ab-50e6-a9bb-bc976795c221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5e421e-c187-4bf5-be9d-20a1e32b570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5e421e-c187-4bf5-be9d-20a1e32b570b.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "9cfe6b55-aaea-52ae-b8ed-0474a15634df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff36db9-560b-4cda-8122-d9ff748acf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff36db9-560b-4cda-8122-d9ff748acf4d.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -10523,7 +10523,7 @@
         },
         {
             "id": "2e4a814a-2384-51b9-8e6f-8102f4d3c0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d0d34-4d66-4e0d-9d64-bb7786930b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d0d34-4d66-4e0d-9d64-bb7786930b7a.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "ccdab08b-6935-5ac3-bb9b-539c313067f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0f6b48-63e6-4eff-92db-9f2a4652c5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0f6b48-63e6-4eff-92db-9f2a4652c5c1.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "6e66dbf6-a7f9-528f-93ec-783d082d1948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d2690b-8d73-468c-be25-576bc615069a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d2690b-8d73-468c-be25-576bc615069a.jpg?1",
             "name": "Youthful Valkyrie",
             "text": "Flying\nWhenever another Angel you control enters, put a +1/+1 counter on this creature.",
             "colours": [
@@ -10634,7 +10634,7 @@
         },
         {
             "id": "9c7c07eb-9c46-5698-a4b4-1ba8ae65d04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f15cc5-c3dc-4830-aa55-13080c738739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f15cc5-c3dc-4830-aa55-13080c738739.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "5ef70719-424b-53c7-bbe7-8c7051c864b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abab9f07-ea0f-4f6f-81f4-a9177909c9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abab9f07-ea0f-4f6f-81f4-a9177909c9e7.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -10711,7 +10711,7 @@
         },
         {
             "id": "818f653b-e726-5a7a-a1fa-b643bc4ce13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60cf418-b927-49b6-9613-41eae6296902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60cf418-b927-49b6-9613-41eae6296902.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "9320a87a-7100-520a-b215-e8280a37293d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21180a4-208f-4c13-a704-58403ddaf12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21180a4-208f-4c13-a704-58403ddaf12f.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -10789,7 +10789,7 @@
         },
         {
             "id": "ffa7450b-8ea9-5289-9e34-59d55532448c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dbb6ff-1262-44cc-8d36-153b2d3eace0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dbb6ff-1262-44cc-8d36-153b2d3eace0.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -10827,7 +10827,7 @@
         },
         {
             "id": "1585e9ed-2652-5361-b869-5a328c5d821f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a123794-096f-4d01-bfd4-1d23f22608f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a123794-096f-4d01-bfd4-1d23f22608f7.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "1bc3fc63-9b43-5ce0-8ad7-31af13c5c785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80f2eb-e34a-4f39-a831-d6fb42f6b4cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80f2eb-e34a-4f39-a831-d6fb42f6b4cc.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "f6ff9880-d1d5-5fa0-8448-c9e1df91ebf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6aaee9-8c44-4e23-8167-ead64e599711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6aaee9-8c44-4e23-8167-ead64e599711.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens.",
             "colours": [
@@ -10938,7 +10938,7 @@
         },
         {
             "id": "2eb4d51c-afe8-52a6-b151-37b5910c917e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c72dced-adae-4c66-af2a-0a1216953ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c72dced-adae-4c66-af2a-0a1216953ab6.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -10973,7 +10973,7 @@
         },
         {
             "id": "215d5d25-70ea-5b30-abb8-2012f802642f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a65d5b-d07e-4ff0-900a-30d509ce0f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a65d5b-d07e-4ff0-900a-30d509ce0f35.jpg?1",
             "name": "Refute",
             "text": "Counter target spell. Draw a card, then discard a card.",
             "colours": [
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "3e908528-1e0f-52b4-a28a-927339c8e780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9571a123-37b4-42fa-96ba-42580afb6d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9571a123-37b4-42fa-96ba-42580afb6d9d.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -11045,7 +11045,7 @@
         },
         {
             "id": "b0178454-a1a6-536a-a2fb-5f753eb58e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a7e9bb-0772-4539-bbf9-7a95d5e47947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a7e9bb-0772-4539-bbf9-7a95d5e47947.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U}",
             "colours": [
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "21157ba1-f2c7-557e-92a4-11c892f95f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e44b856-1803-4e63-ad81-43a1c4ef5020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e44b856-1803-4e63-ad81-43a1c4ef5020.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -11120,7 +11120,7 @@
         },
         {
             "id": "a48f1a37-4568-57e3-ba42-96fe4147ff73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a669cb-24fc-4055-9e53-70b794805f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a669cb-24fc-4055-9e53-70b794805f3b.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -11156,7 +11156,7 @@
         },
         {
             "id": "d5c751e0-7dd8-5132-9e7b-cc4fd96ce83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c340ba8-9287-4072-937a-438251b5ff1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c340ba8-9287-4072-937a-438251b5ff1d.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "b12b2f8e-629d-5cea-80a1-9511349cbe27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cedc6d-075a-4f9b-a858-e2c29809ee33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cedc6d-075a-4f9b-a858-e2c29809ee33.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -11231,7 +11231,7 @@
         },
         {
             "id": "35cea5ff-c5bf-5727-979c-70c34107f6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30c5bb1-58c6-40a4-9e87-3f71b026c523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30c5bb1-58c6-40a4-9e87-3f71b026c523.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "c4be7dee-5ad1-52dc-87e6-b31edb72b535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc1623f-370d-42b5-88a2-039f31e9be0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc1623f-370d-42b5-88a2-039f31e9be0b.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "084d4581-8bae-51cf-a27f-2fe018bd4411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ea5129-7e83-4fb5-8096-2f5ebdc3efe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ea5129-7e83-4fb5-8096-2f5ebdc3efe1.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "f706000d-7a84-5754-ab30-9871e4eeac38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d466d44-3203-4e9d-befc-877414a7308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d466d44-3203-4e9d-befc-877414a7308d.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -11379,7 +11379,7 @@
         },
         {
             "id": "d575e330-48d1-5e10-8037-d6d851c73f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8d5d4-b52d-42c7-aa56-c104a539133c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8d5d4-b52d-42c7-aa56-c104a539133c.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -11420,7 +11420,7 @@
         },
         {
             "id": "55b95720-be50-5cf0-84e4-8478b9d28bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c944c5dc-9cb6-4dfd-aa90-5e180ffaa0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c944c5dc-9cb6-4dfd-aa90-5e180ffaa0fe.jpg?1",
             "name": "Vengeful Bloodwitch",
             "text": "Whenever this creature or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11457,7 +11457,7 @@
         },
         {
             "id": "ea167adf-3bec-52fe-9a69-4625807908ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1aad48-88f0-464d-9776-ecd023d87b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1aad48-88f0-464d-9776-ecd023d87b8f.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life.\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -11498,7 +11498,7 @@
         },
         {
             "id": "1cd5f92c-e2eb-5407-8cf7-833687237c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74ab7c-b9de-47ab-83ea-2b98738838c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa74ab7c-b9de-47ab-83ea-2b98738838c7.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "a5d176f0-39ff-5a43-b3a6-1f28d79371ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ab83-3b8e-4747-98ae-7b981bcc77b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ab83-3b8e-4747-98ae-7b981bcc77b1.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R}",
             "colours": [
@@ -11568,7 +11568,7 @@
         },
         {
             "id": "c858a5e7-e6fd-5ce6-ad46-8d06e0970fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f30943b-f739-49eb-bafb-fec6614a0c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f30943b-f739-49eb-bafb-fec6614a0c5e.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -11608,7 +11608,7 @@
         },
         {
             "id": "ccc1bbba-c414-5cee-93c7-0549cec4577f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e413f37-b59a-4302-86d3-2abce81edc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e413f37-b59a-4302-86d3-2abce81edc78.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -11650,7 +11650,7 @@
         },
         {
             "id": "688632df-a37f-5615-aa63-3d0a4bdf15aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa981d3-4a41-4bf1-ba64-2cd7224a6059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa981d3-4a41-4bf1-ba64-2cd7224a6059.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "218c9dba-60d2-5ec6-994f-c9e060b732e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58deba9d-5c95-4633-a86c-2637a8bb7ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58deba9d-5c95-4633-a86c-2637a8bb7ce2.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11725,7 +11725,7 @@
         },
         {
             "id": "d9337710-b760-56dc-8658-faea5ad0daeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab62a48-93b5-4eb3-aa6b-92dd4cc617f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab62a48-93b5-4eb3-aa6b-92dd4cc617f6.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -11765,7 +11765,7 @@
         },
         {
             "id": "48e22ecf-b631-5623-9d8d-50b0052eada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51445b-1590-4072-9712-5ca344b25e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b51445b-1590-4072-9712-5ca344b25e3e.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "c3009e9f-d785-5b1d-be15-3e0874f66131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4561678b-db52-4b89-9f34-50fe600a55d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4561678b-db52-4b89-9f34-50fe600a55d7.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -11840,7 +11840,7 @@
         },
         {
             "id": "1c35254e-1088-52de-aae9-30245b11bdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ce9555-a687-4a37-864c-eb59b1e80a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ce9555-a687-4a37-864c-eb59b1e80a8f.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -11881,7 +11881,7 @@
         },
         {
             "id": "8ce8012e-645c-5ac7-8a77-41f8f2dc3f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be84175-062c-439f-abad-c57cd9eb490f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be84175-062c-439f-abad-c57cd9eb490f.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -11920,7 +11920,7 @@
         },
         {
             "id": "69c1ce3b-023e-5c29-b9eb-67e8d85cc614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d611f8cd-fe7d-41d3-9572-9dda77d83d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d611f8cd-fe7d-41d3-9572-9dda77d83d25.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -11956,7 +11956,7 @@
         },
         {
             "id": "9aeb7be5-737e-5d0d-b466-c26999d69c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00e8e36-bd52-4eca-ae48-f3e03a655704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00e8e36-bd52-4eca-ae48-f3e03a655704.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it.\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -11994,7 +11994,7 @@
         },
         {
             "id": "3745f593-8030-574f-b058-e2301c819aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3f0764-9d80-4e15-a402-1f93e652bcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3f0764-9d80-4e15-a402-1f93e652bcbb.jpg?1",
             "name": "Reclamation Sage",
             "text": "When this creature enters, you may destroy target artifact or enchantment.",
             "colours": [
@@ -12031,7 +12031,7 @@
         },
         {
             "id": "19041e0b-6bbe-5420-8f65-10af96982cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984be4a8-8d34-4911-8210-0741f173bfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984be4a8-8d34-4911-8210-0741f173bfab.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12070,7 +12070,7 @@
         },
         {
             "id": "22c1bf9a-fa27-5574-b120-3c2c8f57f555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd7c1c1-e5e2-4481-b860-a4f7f7a1034b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd7c1c1-e5e2-4481-b860-a4f7f7a1034b.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -12106,7 +12106,7 @@
         },
         {
             "id": "ba7fcf49-852f-502b-8447-82fac3fe88a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48858f3-40a4-4117-b4c5-e1b973be4869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48858f3-40a4-4117-b4c5-e1b973be4869.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -12149,7 +12149,7 @@
         },
         {
             "id": "62ca4dff-e28f-5aa1-81e4-31a73b16a4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf3fcd4-bac8-4cf1-b042-743cfc62e517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf3fcd4-bac8-4cf1-b042-743cfc62e517.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -12187,7 +12187,7 @@
         },
         {
             "id": "09dc2cf5-133f-5fcc-a9cb-82dfd15d0ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b39d89-9902-4a45-a774-bea1c17ca5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b39d89-9902-4a45-a774-bea1c17ca5e4.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -12228,7 +12228,7 @@
         },
         {
             "id": "edd162ba-4b95-5020-ad16-8271243f3457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14994b68-5930-49a4-af1c-e8123c8c8025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14994b68-5930-49a4-af1c-e8123c8c8025.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -12271,7 +12271,7 @@
         },
         {
             "id": "3c231436-5f87-52c6-aa3f-df2a828ea473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8889e1ca-eec1-408b-b11e-98cc0a357a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8889e1ca-eec1-408b-b11e-98cc0a357a97.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -12313,7 +12313,7 @@
         },
         {
             "id": "6996c42c-3d1a-5281-96e9-d847af6fc25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1763648-802f-4178-a46a-a0c19142fd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1763648-802f-4178-a46a-a0c19142fd67.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -12356,7 +12356,7 @@
         },
         {
             "id": "9346ab3a-a62e-5de0-99b0-c642cf3f6b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f766b8-a92e-4353-b457-ac62fc470713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f766b8-a92e-4353-b457-ac62fc470713.jpg?1",
             "name": "Lathril, Blade of the Elves",
             "text": "Menace\nWhenever Lathril deals combat damage to a player, create that many 1/1 green Elf Warrior creature tokens.\n{T}, Tap ten untapped Elves you control: Each opponent loses 10 life and you gain 10 life.",
             "colours": [
@@ -12398,7 +12398,7 @@
         },
         {
             "id": "2982b6d7-8a09-5270-b548-44b462d187a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666749f4-3481-424b-9f18-37763ebf769a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666749f4-3481-424b-9f18-37763ebf769a.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "3f5f08f8-a281-50ff-b941-df29ccf21794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0490270-f94d-4f17-8a6c-527c9eab5d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0490270-f94d-4f17-8a6c-527c9eab5d73.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -12484,7 +12484,7 @@
         },
         {
             "id": "0cffee48-7438-5550-8120-47eefee780cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a9b8b0-c1ba-48c3-8f90-6af6948274ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a9b8b0-c1ba-48c3-8f90-6af6948274ee.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -12516,7 +12516,7 @@
         },
         {
             "id": "cfac1530-1611-5da5-a4d9-8c2d787a86ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9df1f5-1b60-47b8-ac87-5c58719d7de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9df1f5-1b60-47b8-ac87-5c58719d7de4.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3}",
             "colours": [],
@@ -12550,7 +12550,7 @@
         },
         {
             "id": "ccd0af47-8e4c-54d3-9792-366f7aeb8104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d8c9b5-6863-45d1-89f0-6a4f8189758b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d8c9b5-6863-45d1-89f0-6a4f8189758b.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "84c43af0-b6ca-5e75-bfcf-bbe954797b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9b53da-4744-429d-97c6-f7ee4d568731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9b53da-4744-429d-97c6-f7ee4d568731.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste.\nEquip {1}",
             "colours": [],
@@ -12618,7 +12618,7 @@
         },
         {
             "id": "db7f4806-7e59-54fb-beca-fcf9df1fd96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4cc78-c25f-494c-b57e-c185d37605e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4cc78-c25f-494c-b57e-c185d37605e8.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -12650,7 +12650,7 @@
         },
         {
             "id": "f10cc0c3-3d22-5e43-8f53-1c27d78ce214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f329a0b-13cc-48c5-9fb7-38d8a537aa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f329a0b-13cc-48c5-9fb7-38d8a537aa30.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n\u22123: Target creature gains flying and double strike until end of turn.\n\u22128: Create X 2/2 white Cat creature tokens, where X is your life total.",
             "colours": [
@@ -12689,7 +12689,7 @@
         },
         {
             "id": "b488c201-d718-592f-9d06-a4b3ed743d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be447408-0846-49be-b47e-c6f256032deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be447408-0846-49be-b47e-c6f256032deb.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -12730,7 +12730,7 @@
         },
         {
             "id": "e4848506-0172-5d87-92bd-8c66a835a1a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba461127-2220-4274-81cb-423a1700c9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba461127-2220-4274-81cb-423a1700c9eb.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures of their choice.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -12769,7 +12769,7 @@
         },
         {
             "id": "d181c236-8ee8-5ad0-81ae-2397e54ad76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02db5a2d-28d3-4f57-9045-f0ef16d8aad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02db5a2d-28d3-4f57-9045-f0ef16d8aad1.jpg?1",
             "name": "Chandra, Flameshaper",
             "text": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n\u22124: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
             "colours": [
@@ -12808,7 +12808,7 @@
         },
         {
             "id": "939129c7-d44f-5d63-a8d2-a902a57f2c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cc3e80-2ffa-4d48-bd67-a6315375b236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cc3e80-2ffa-4d48-bd67-a6315375b236.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -12847,7 +12847,7 @@
         },
         {
             "id": "39752ddb-d0e0-5712-8aad-2996b5acda2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5493f0f-6eec-4776-a5aa-661eef1389fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5493f0f-6eec-4776-a5aa-661eef1389fa.jpg?1",
             "name": "Sire of Seven Deaths",
             "text": "First strike\nVigilance\nMenace\nTrample\nReach\nLifelink\nWard\u2014\nPay 7 life.",
             "colours": [],
@@ -12879,7 +12879,7 @@
         },
         {
             "id": "500d2b98-d266-5ef8-acdf-433aa264bf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2507fddd-2dc0-45f0-ac47-1ddd8690be46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2507fddd-2dc0-45f0-ac47-1ddd8690be46.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -12919,7 +12919,7 @@
         },
         {
             "id": "22782a7a-1df2-5de1-a28b-c555e86be31f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0787c7-338d-4db5-bfe8-70d578a422b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0787c7-338d-4db5-bfe8-70d578a422b9.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W}",
             "colours": [
@@ -12956,7 +12956,7 @@
         },
         {
             "id": "545faba0-14a9-5360-82d5-f71268490f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f6acd2-3b91-4bd7-996f-42c75b88ee87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f6acd2-3b91-4bd7-996f-42c75b88ee87.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender\nYou have hexproof.\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -12994,7 +12994,7 @@
         },
         {
             "id": "9a47fe44-6cdb-5d73-883b-b4da92b84a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67b3e48-98e8-404b-93b0-c3cbbd764d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67b3e48-98e8-404b-93b0-c3cbbd764d1c.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -13031,7 +13031,7 @@
         },
         {
             "id": "cd2c5cd5-eec2-531c-a11c-49cfa09973fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ed447-aade-4fd8-8787-2330436c750f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ed447-aade-4fd8-8787-2330436c750f.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "a6bbd05e-a652-5ba3-9d33-25304809b6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cc6624-d288-4f99-9606-3ce914890530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cc6624-d288-4f99-9606-3ce914890530.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -13108,7 +13108,7 @@
         },
         {
             "id": "5dd61365-c12f-5d0b-a0b7-28b9cb987639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4542ac9d-74fe-4a38-ac54-e141f4923540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4542ac9d-74fe-4a38-ac54-e141f4923540.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -13143,7 +13143,7 @@
         },
         {
             "id": "15c55952-7b41-55e0-8c90-3a0fb39c8ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccc2ced-861f-40c3-90e9-49250e1874d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccc2ced-861f-40c3-90e9-49250e1874d9.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "a5f5edbe-778f-5c45-a700-4a30994a30b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb6810-6f51-4e28-a4e7-40edcffc2059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb6810-6f51-4e28-a4e7-40edcffc2059.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -13216,7 +13216,7 @@
         },
         {
             "id": "47081b9b-6444-5c6b-9c68-bd49bd444fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6117837-83d4-4f84-967a-f5551515f0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6117837-83d4-4f84-967a-f5551515f0b9.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -13254,7 +13254,7 @@
         },
         {
             "id": "aa7ac9ba-2808-5f1b-a570-3355588e2576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7b1e9-1a11-41bf-8257-a8d3218b34fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7b1e9-1a11-41bf-8257-a8d3218b34fc.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -13291,7 +13291,7 @@
         },
         {
             "id": "606a428d-96a9-5fb2-8c6a-62f9729dd484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ef01c5-c79e-4fc1-af17-0956dc156a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ef01c5-c79e-4fc1-af17-0956dc156a28.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -13329,7 +13329,7 @@
         },
         {
             "id": "f50514f7-548c-5317-b55d-95c046dc0641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257630d3-8f82-4cfc-b0fd-21399a2cde6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/257630d3-8f82-4cfc-b0fd-21399a2cde6c.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -13367,7 +13367,7 @@
         },
         {
             "id": "95f69a88-afa2-53aa-82f5-e7406e1f0528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae8f2d9-5759-49bf-b5d6-f2b9515ef919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae8f2d9-5759-49bf-b5d6-f2b9515ef919.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -13404,7 +13404,7 @@
         },
         {
             "id": "0e3cdf60-6e3b-5469-a57b-e61731ad0405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c7e2a5-9b56-48de-9cfd-be1ac6c692d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c7e2a5-9b56-48de-9cfd-be1ac6c692d9.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -13444,7 +13444,7 @@
         },
         {
             "id": "8cce51c0-708a-5d4b-9507-3db71b27ca99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c9474-f9d1-4123-aafa-dd41950ea112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605c9474-f9d1-4123-aafa-dd41950ea112.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -13479,7 +13479,7 @@
         },
         {
             "id": "3e2d528f-bb65-5451-b527-c428bf38f270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f173425-8bae-47b1-8a2c-e27a071acd24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f173425-8bae-47b1-8a2c-e27a071acd24.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -13513,7 +13513,7 @@
         },
         {
             "id": "e79ab8b6-d5ec-5d8e-a5b9-26b9ffc81825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0552a2c4-36d4-405f-a56f-dc55610ae191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0552a2c4-36d4-405f-a56f-dc55610ae191.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -13550,7 +13550,7 @@
         },
         {
             "id": "8ef6eb3d-d431-5a35-a446-0e04b14f1ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8aeaa6f-984a-4e8d-a934-547c95f0b482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8aeaa6f-984a-4e8d-a934-547c95f0b482.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -13588,7 +13588,7 @@
         },
         {
             "id": "a1374dd7-f452-51e4-9792-80504e60ebb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e35e15-9456-46eb-b6be-5faab05185b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e35e15-9456-46eb-b6be-5faab05185b2.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -13623,7 +13623,7 @@
         },
         {
             "id": "4878051e-a16e-5249-acc9-664c988c1639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b10ba4e-4e6a-4127-a8a3-d9728e8d5f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b10ba4e-4e6a-4127-a8a3-d9728e8d5f8b.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -13663,7 +13663,7 @@
         },
         {
             "id": "2fd3baac-059f-5293-a7fe-2ebea5535ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafa089f-e33b-4933-a43d-e110dba29069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafa089f-e33b-4933-a43d-e110dba29069.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -13701,7 +13701,7 @@
         },
         {
             "id": "f03437b3-53e2-550a-a960-810bc3415294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54357fb3-f76b-411e-a466-c97643a8c0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54357fb3-f76b-411e-a466-c97643a8c0c7.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -13738,7 +13738,7 @@
         },
         {
             "id": "d5aeeb7a-5a85-52cd-b622-91a8bf99900b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f9f00-b33a-434d-8293-3a4c9e614358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f9f00-b33a-434d-8293-3a4c9e614358.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -13773,7 +13773,7 @@
         },
         {
             "id": "068e73d6-22c0-5f7e-95c1-1279aae0ca60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afefa7d5-e83a-4bbe-a9eb-e20c1bc25cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afefa7d5-e83a-4bbe-a9eb-e20c1bc25cdd.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -13807,7 +13807,7 @@
         },
         {
             "id": "c18bf88a-29bf-5c5e-a927-8e8cafb92dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bdc11d-bef3-4823-b8bd-209cdac4ea31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bdc11d-bef3-4823-b8bd-209cdac4ea31.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -13847,7 +13847,7 @@
         },
         {
             "id": "f3448169-09bf-53a2-bd6a-d3b5942feefb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d94cc2-938d-4e98-a190-3a481b0a2966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d94cc2-938d-4e98-a190-3a481b0a2966.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life.\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -13887,7 +13887,7 @@
         },
         {
             "id": "a476dc9b-2c92-54fe-bfbe-47696b0b7687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47172bc-71c3-472a-b1bd-eff9b7c140e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47172bc-71c3-472a-b1bd-eff9b7c140e0.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R}",
             "colours": [
@@ -13922,7 +13922,7 @@
         },
         {
             "id": "31774cda-7f63-5280-970b-3cf73f73770a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d02e4b-4da8-4304-bce3-b4c273462106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d02e4b-4da8-4304-bce3-b4c273462106.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -13961,7 +13961,7 @@
         },
         {
             "id": "f3a4ccdd-ce1f-5924-98c4-db5ec5efffdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7913c8f-a374-4d12-8ec9-8aee7604e135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7913c8f-a374-4d12-8ec9-8aee7604e135.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -14002,7 +14002,7 @@
         },
         {
             "id": "b929679c-1d71-50ae-92fa-173bb52501b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73750c-ddd4-448e-94f3-f64bada20508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73750c-ddd4-448e-94f3-f64bada20508.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -14037,7 +14037,7 @@
         },
         {
             "id": "51bacf8e-3d41-5c0a-a8dc-86bab643fed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523f8d8-4324-4e1d-9a88-4fd871e93bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523f8d8-4324-4e1d-9a88-4fd871e93bb8.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -14075,7 +14075,7 @@
         },
         {
             "id": "da40d1a2-d8c5-5647-9a4e-0f6ae62b1a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd09badf-b28d-48b9-8cb4-2336e5b1e4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd09badf-b28d-48b9-8cb4-2336e5b1e4b9.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -14114,7 +14114,7 @@
         },
         {
             "id": "cdfe6b5e-a6f4-5c93-bc20-726fcfa40461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4742df-edef-4b72-b523-429b1c284102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4742df-edef-4b72-b523-429b1c284102.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -14148,7 +14148,7 @@
         },
         {
             "id": "ac550dfa-8f6a-56aa-999d-8eb75f069802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f89bc6f-fc43-49ad-881f-8897750e4b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f89bc6f-fc43-49ad-881f-8897750e4b5f.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -14187,7 +14187,7 @@
         },
         {
             "id": "981a0cdf-5ec8-5a9f-81b2-a1a86c03f893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25b231-f2cf-4915-b6e1-557142b4c7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a25b231-f2cf-4915-b6e1-557142b4c7bb.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -14227,7 +14227,7 @@
         },
         {
             "id": "3268120d-4be6-50c4-aefb-f6556a5036fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fca15a-16bb-439a-9dfe-b5168918a4ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fca15a-16bb-439a-9dfe-b5168918a4ed.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -14265,7 +14265,7 @@
         },
         {
             "id": "0c3492d9-db4f-5e12-b1a8-351fbd6df3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb6f1e-2545-4393-9985-383d11379977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb6f1e-2545-4393-9985-383d11379977.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -14300,7 +14300,7 @@
         },
         {
             "id": "36fedfb5-c15e-59bd-8984-b5d5829af063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6224fdea-d899-4bb2-af29-ef6faef5a0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6224fdea-d899-4bb2-af29-ef6faef5a0ed.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it.\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -14337,7 +14337,7 @@
         },
         {
             "id": "41936dab-82d5-5378-9f62-0e8d12781987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce5bc0f-ddb2-4135-a2a8-e8b21648a711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce5bc0f-ddb2-4135-a2a8-e8b21648a711.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14375,7 +14375,7 @@
         },
         {
             "id": "4cababf1-8726-5021-8360-0b427a2b7450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60b8a2-3302-43ea-a5c9-89c86b9104ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60b8a2-3302-43ea-a5c9-89c86b9104ac.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -14410,7 +14410,7 @@
         },
         {
             "id": "0b2c58c6-bb95-5f60-94be-3973c14bb0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea65396-4873-4bb0-9781-ea74f2ba923b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea65396-4873-4bb0-9781-ea74f2ba923b.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -14452,7 +14452,7 @@
         },
         {
             "id": "51a7fb98-33ab-55d5-b80c-d5ad2db52cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065802f-6194-49e9-94f5-880392519562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4065802f-6194-49e9-94f5-880392519562.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -14489,7 +14489,7 @@
         },
         {
             "id": "a50627df-6429-5e03-9bec-3ab37176c806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e3dcae-c1d5-46ba-8d0d-021968992d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e3dcae-c1d5-46ba-8d0d-021968992d76.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -14529,7 +14529,7 @@
         },
         {
             "id": "90a844dc-e7cd-5189-b68d-d17f29f52951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc24bc-1287-449e-8b8a-02b44f569610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc24bc-1287-449e-8b8a-02b44f569610.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -14571,7 +14571,7 @@
         },
         {
             "id": "205e1c27-d93c-5fbc-8130-c143adcf508c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338cc7f-1134-42b4-b384-a93a4f92edc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a338cc7f-1134-42b4-b384-a93a4f92edc9.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -14612,7 +14612,7 @@
         },
         {
             "id": "66950b8d-f2d1-52ac-a4e7-48eef99fc2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8ec6f1-4889-46e2-b681-59bf7b581195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8ec6f1-4889-46e2-b681-59bf7b581195.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -14654,7 +14654,7 @@
         },
         {
             "id": "54071920-0f1e-5f26-a0d7-9a1b0e879877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8463968-c2e9-48d7-ab9d-6a9b71470c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8463968-c2e9-48d7-ab9d-6a9b71470c3e.jpg?1",
             "name": "Lathril, Blade of the Elves",
             "text": "Menace\nWhenever Lathril deals combat damage to a player, create that many 1/1 green Elf Warrior creature tokens.\n{T}, Tap ten untapped Elves you control: Each opponent loses 10 life and you gain 10 life.",
             "colours": [
@@ -14695,7 +14695,7 @@
         },
         {
             "id": "9d606f8d-6d95-5a1e-bf2a-4a1e620dca1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c07579-1567-4e3f-a28a-ca7f106fd1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c07579-1567-4e3f-a28a-ca7f106fd1dc.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -14737,7 +14737,7 @@
         },
         {
             "id": "4a9e0a2e-4bce-5c67-ac93-c79775ad9d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ac2011-4021-46bc-b6cf-08de8db134aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ac2011-4021-46bc-b6cf-08de8db134aa.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -14779,7 +14779,7 @@
         },
         {
             "id": "91c61101-ace7-5779-970b-9b6b3aff7eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa434d9-c0c2-47f2-85ba-d2258ad91f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa434d9-c0c2-47f2-85ba-d2258ad91f58.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -14810,7 +14810,7 @@
         },
         {
             "id": "f01c4ef3-5cd7-5a62-9976-11f333645c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d3f263-cabd-4a81-a68a-cb93cb1c2107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d3f263-cabd-4a81-a68a-cb93cb1c2107.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3}",
             "colours": [],
@@ -14843,7 +14843,7 @@
         },
         {
             "id": "ed9ad2e3-3f37-5bfc-87b5-68b67b871c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c935438-2f3d-469d-a645-bfb3c95c3e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c935438-2f3d-469d-a645-bfb3c95c3e0a.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -14878,7 +14878,7 @@
         },
         {
             "id": "a710328e-23b8-513a-99eb-1318ed564b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab27d7a8-de69-4939-a35b-760b1b42e070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab27d7a8-de69-4939-a35b-760b1b42e070.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -14909,7 +14909,7 @@
         },
         {
             "id": "b4488e9b-8a6c-55d1-8417-13e3d397d592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345f7610-5b95-4d24-9ab0-e18d27ccabed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345f7610-5b95-4d24-9ab0-e18d27ccabed.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n\u22123: Target creature gains flying and double strike until end of turn.\n\u22128: Create X 2/2 white Cat creature tokens, where X is your life total.",
             "colours": [
@@ -14947,7 +14947,7 @@
         },
         {
             "id": "d421208c-2f93-54aa-b8e8-ad42fe26c505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6feaf235-ab3a-41f2-ae81-4f2d0b109ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6feaf235-ab3a-41f2-ae81-4f2d0b109ebc.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -14987,7 +14987,7 @@
         },
         {
             "id": "9f1b8a96-5982-5ead-aba6-6a3166160618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a097413-b77c-45e8-a4ac-5b2dc1d34e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a097413-b77c-45e8-a4ac-5b2dc1d34e16.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures of their choice.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -15025,7 +15025,7 @@
         },
         {
             "id": "56469e96-b56c-5531-90fb-73f437985743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd73be04-3ec2-4ea3-8d93-47fa39aaeed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd73be04-3ec2-4ea3-8d93-47fa39aaeed8.jpg?1",
             "name": "Chandra, Flameshaper",
             "text": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n\u22124: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "8d3d5b97-f1db-5dc5-884e-ae6940b44937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3a3b-257e-46c7-bb29-65627b00363d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3a3b-257e-46c7-bb29-65627b00363d.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "af868f46-ed09-53e1-a353-1e6ca413ddfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66be885f-a319-4c17-b909-0467fe66cf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66be885f-a319-4c17-b909-0467fe66cf3b.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -15135,7 +15135,7 @@
         },
         {
             "id": "44f9dd78-33f4-5f89-b9a0-8a42ec594e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b336e-7471-48d8-ac21-66b2a01578d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6b336e-7471-48d8-ac21-66b2a01578d5.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -15174,7 +15174,7 @@
         },
         {
             "id": "bd7e5238-9d3d-5000-9292-9288db88e24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a1cbdf-36aa-4619-932a-609c1699cc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a1cbdf-36aa-4619-932a-609c1699cc6a.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -15214,7 +15214,7 @@
         },
         {
             "id": "38f0ebf5-32cf-5d39-9b89-af41823f589f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6615cc95-0d7a-474d-bf35-3ea4dfc4cced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6615cc95-0d7a-474d-bf35-3ea4dfc4cced.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U}",
             "colours": [
@@ -15249,7 +15249,7 @@
         },
         {
             "id": "868cb584-8fb2-586e-a60f-79a94db32c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb45b34-a1e7-4861-b0fe-b701aa5e894a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb45b34-a1e7-4861-b0fe-b701aa5e894a.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -15289,7 +15289,7 @@
         },
         {
             "id": "a7b60325-9afc-5fd1-8d77-422fe8c03972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765e6a52-773d-420c-829c-fefe4993bfd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765e6a52-773d-420c-829c-fefe4993bfd9.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -15328,7 +15328,7 @@
         },
         {
             "id": "f91b4613-1633-5428-90ca-420174ceb533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8fabe-3af7-4f19-9508-5b5a6a608a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8fabe-3af7-4f19-9508-5b5a6a608a3c.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -15362,7 +15362,7 @@
         },
         {
             "id": "b3e2bea0-1c3b-5f00-afc1-29348081f591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd43a84a-cde2-48f8-b6ab-1ec023c9e0c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd43a84a-cde2-48f8-b6ab-1ec023c9e0c3.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -15399,7 +15399,7 @@
         },
         {
             "id": "19c9ce19-033c-5ed0-9b78-115be874df9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff672733-486b-4042-8209-fca70df86b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff672733-486b-4042-8209-fca70df86b7d.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard.",
             "colours": [
@@ -15442,7 +15442,7 @@
         },
         {
             "id": "45b17118-140d-59ed-8049-50632f9d9138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee7f2b-de71-4ab2-8104-5fb467b4100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fee7f2b-de71-4ab2-8104-5fb467b4100b.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -15489,7 +15489,7 @@
         },
         {
             "id": "a77faf94-1867-5b72-8139-2fc482dffde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b2d913-0b0e-4840-bf88-29dd6f9da631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b2d913-0b0e-4840-bf88-29dd6f9da631.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -15523,7 +15523,7 @@
         },
         {
             "id": "14e39fed-eef9-5d4e-9a5a-5913aa8319d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb46675-5286-4eaf-9c25-eef773a4daeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb46675-5286-4eaf-9c25-eef773a4daeb.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -15562,7 +15562,7 @@
         },
         {
             "id": "787698c2-808b-5cd2-aeca-f85d1ee28ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84779aa7-6147-4c83-aab2-ae4346524977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84779aa7-6147-4c83-aab2-ae4346524977.jpg?1",
             "name": "Kaito, Cunning Infiltrator",
             "text": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n\u22122: Create a 2/1 blue Ninja creature token.\n\u22129: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
             "colours": [
@@ -15602,7 +15602,7 @@
         },
         {
             "id": "4619eef9-1c44-5d53-a608-5dd904d7fdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228018d-3e25-41f0-ae16-beb96dd5e1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7228018d-3e25-41f0-ae16-beb96dd5e1cc.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U}",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "c7bcd838-cc76-5f87-b8c3-0a9740932afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926074a7-a01d-43bb-a257-0d95394773a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926074a7-a01d-43bb-a257-0d95394773a0.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -15677,7 +15677,7 @@
         },
         {
             "id": "8ca590aa-71c4-5bc1-9cf3-2af072b3363c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d02e4b-3854-4e10-acb7-0b6128401b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d02e4b-3854-4e10-acb7-0b6128401b2e.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -15716,7 +15716,7 @@
         },
         {
             "id": "a3b12060-c344-5a28-aee0-fd813cfddd53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bf249-3773-404f-9e46-d7745d3826e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bf249-3773-404f-9e46-d7745d3826e8.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
             "colours": [
@@ -15750,7 +15750,7 @@
         },
         {
             "id": "33698a32-1d56-5acf-9bcb-108c133a8c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bd6cef-f887-4b07-a957-4c53cb3c9c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bd6cef-f887-4b07-a957-4c53cb3c9c87.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -15787,7 +15787,7 @@
         },
         {
             "id": "6a4d429f-3145-5ffd-9bd6-511dd859eea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc15cd2-e6d1-406e-af58-2f5fbaa74a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc15cd2-e6d1-406e-af58-2f5fbaa74a30.jpg?1",
             "name": "Muldrotha, the Gravetide",
             "text": "During each of your turns, you may play a land and cast a permanent spell of each permanent type from your graveyard.",
             "colours": [
@@ -15830,7 +15830,7 @@
         },
         {
             "id": "002fe066-2f24-587e-bf2a-d9f7bb37bb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d284ddb-c1de-49a3-8a2a-8146f7c3fbeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d284ddb-c1de-49a3-8a2a-8146f7c3fbeb.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -15877,7 +15877,7 @@
         },
         {
             "id": "daad7cf1-f923-526b-9f4e-4121a260739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52605015-ba08-4427-8c06-b47ecd603b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52605015-ba08-4427-8c06-b47ecd603b27.jpg?1",
             "name": "Arahbo, the First Fang",
             "text": "Other Cats you control get +1/+1.\nWhenever Arahbo or another nontoken Cat you control enters, create a 1/1 white Cat creature token.",
             "colours": [
@@ -15918,7 +15918,7 @@
         },
         {
             "id": "7fc143cf-936a-5a82-b3d3-af237d371ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e9e1d6-5cb3-42c1-9211-9769b2c04db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e9e1d6-5cb3-42c1-9211-9769b2c04db6.jpg?1",
             "name": "Celestial Armor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this Equipment enters, attach it to target creature you control. That creature gains hexproof and indestructible until end of turn.\nEquipped creature gets +2/+0 and has flying.\nEquip {3}{W} ({3}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -15956,7 +15956,7 @@
         },
         {
             "id": "84d5323b-26a5-55bf-8545-f4e9f4763277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb02c30-8898-4692-a22b-7ea7855e8f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb02c30-8898-4692-a22b-7ea7855e8f81.jpg?1",
             "name": "Crystal Barricade",
             "text": "Defender (This creature can't attack.)\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)\nPrevent all noncombat damage that would be dealt to other creatures you control.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "9eaf450a-db55-56e0-b01b-66701f110e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d61887-a6f7-4ce0-a44d-9661e8bb2107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d61887-a6f7-4ce0-a44d-9661e8bb2107.jpg?1",
             "name": "Exemplar of Light",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on this creature.\nWhenever you put one or more +1/+1 counters on this creature, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -16033,7 +16033,7 @@
         },
         {
             "id": "b444b47c-beea-5cbe-9f59-3ae664a4b8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38dc08b-9a80-47ad-8c0e-ed19487f043f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38dc08b-9a80-47ad-8c0e-ed19487f043f.jpg?1",
             "name": "Herald of Eternal Dawn",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [
@@ -16073,7 +16073,7 @@
         },
         {
             "id": "e41c8b86-e8c1-5132-970b-b86330643f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f9421-da89-4221-8a59-a8d112a5598d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f9421-da89-4221-8a59-a8d112a5598d.jpg?1",
             "name": "Raise the Past",
             "text": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -16109,7 +16109,7 @@
         },
         {
             "id": "d81a14ee-6559-5fc1-aa30-135b124a3238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28007f11-6610-42e8-9fb6-1a6091ec9435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28007f11-6610-42e8-9fb6-1a6091ec9435.jpg?1",
             "name": "Skyknight Squire",
             "text": "Whenever another creature you control enters, put a +1/+1 counter on this creature.\nAs long as this creature has three or more +1/+1 counters on it, it has flying and is a Knight in addition to its other types.",
             "colours": [
@@ -16148,7 +16148,7 @@
         },
         {
             "id": "15e7f4f5-6631-5545-8cd6-e7b7d14c4e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650498aa-3fc1-47ac-b8d1-d13433640d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650498aa-3fc1-47ac-b8d1-d13433640d57.jpg?1",
             "name": "Valkyrie's Call",
             "text": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
             "colours": [
@@ -16184,7 +16184,7 @@
         },
         {
             "id": "97282d3d-b685-5f53-afef-ded75a5ec23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28658ae0-9b5b-497d-a3c9-0a0626b7b344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28658ae0-9b5b-497d-a3c9-0a0626b7b344.jpg?1",
             "name": "Archmage of Runes",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -16223,7 +16223,7 @@
         },
         {
             "id": "ff08a2ee-fb81-556b-b9cb-9d695770ad91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d11928-1d4b-413d-b43c-280525238d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d11928-1d4b-413d-b43c-280525238d58.jpg?1",
             "name": "Curator of Destinies",
             "text": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -16261,7 +16261,7 @@
         },
         {
             "id": "41bacfa2-1054-5ac0-92d0-b174376304f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c31f0d-b77f-4cf9-8350-2dde15d427a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c31f0d-b77f-4cf9-8350-2dde15d427a7.jpg?1",
             "name": "Drake Hatcher",
             "text": "Vigilance, prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, put that many incubation counters on it.\nRemove three incubation counters from this creature: Create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -16300,7 +16300,7 @@
         },
         {
             "id": "d15c8b80-3c92-501c-867e-660853781044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347e6783-3809-4b8f-ac68-e786c944e7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347e6783-3809-4b8f-ac68-e786c944e7f5.jpg?1",
             "name": "High Fae Trickster",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou may cast spells as though they had flash.",
             "colours": [
@@ -16339,7 +16339,7 @@
         },
         {
             "id": "8cd363d3-958c-5a1a-a8dd-9dc7b4138875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ec1d32-9467-4c79-a9d6-bf3aad2d7fed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ec1d32-9467-4c79-a9d6-bf3aad2d7fed.jpg?1",
             "name": "Homunculus Horde",
             "text": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
             "colours": [
@@ -16377,7 +16377,7 @@
         },
         {
             "id": "a3804baf-845b-5bb3-abc8-f126d2364f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b137e8d-3537-454d-8d6b-24d2a6d81993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b137e8d-3537-454d-8d6b-24d2a6d81993.jpg?1",
             "name": "Kiora, the Rising Tide",
             "text": "When Kiora enters, draw two cards, then discard two cards.\nThreshold \u2014 Whenever Kiora attacks, if there are seven or more cards in your graveyard, you may create Scion of the Deep, a legendary 8/8 blue Octopus creature token.",
             "colours": [
@@ -16418,7 +16418,7 @@
         },
         {
             "id": "4ee15643-5477-5aac-a4b3-2e00be0aa813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdec49a8-508d-4c4b-a60f-4cbeea56f4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdec49a8-508d-4c4b-a60f-4cbeea56f4cd.jpg?1",
             "name": "Lunar Insight",
             "text": "Draw a card for each different mana value among nonland permanents you control.",
             "colours": [
@@ -16454,7 +16454,7 @@
         },
         {
             "id": "926aea35-5674-5268-8f29-5b6bcc89f604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce455a01-87c1-42d1-a51e-1f9a7bd553d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce455a01-87c1-42d1-a51e-1f9a7bd553d6.jpg?1",
             "name": "Sphinx of Forgotten Lore",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -16492,7 +16492,7 @@
         },
         {
             "id": "5f4a5a2e-c379-5f08-9a69-cc8121226d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f257e3-1d03-4395-8a2d-c71f702db9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f257e3-1d03-4395-8a2d-c71f702db9ad.jpg?1",
             "name": "Abyssal Harvester",
             "text": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
             "colours": [
@@ -16531,7 +16531,7 @@
         },
         {
             "id": "ca7c3bdb-a853-5b5c-aeea-32ed3b904109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a6c01-70c4-4e84-b5ca-9a9d4e7c0d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252a6c01-70c4-4e84-b5ca-9a9d4e7c0d86.jpg?1",
             "name": "Blasphemous Edict",
             "text": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
             "colours": [
@@ -16567,7 +16567,7 @@
         },
         {
             "id": "c2eace62-5255-5625-a6ac-aeb88627f3d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd05eaa-7c0d-45f0-b085-87dc1d610c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd05eaa-7c0d-45f0-b085-87dc1d610c34.jpg?1",
             "name": "Bloodthirsty Conqueror",
             "text": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life. (Damage causes loss of life.)",
             "colours": [
@@ -16608,7 +16608,7 @@
         },
         {
             "id": "b29e23c5-d5e3-52e8-9bcc-6866707d70f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf85410-7abe-4bd8-97be-c6432142c947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf85410-7abe-4bd8-97be-c6432142c947.jpg?1",
             "name": "High-Society Hunter",
             "text": "Flying\nWhenever this creature attacks, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature.\nWhenever another nontoken creature dies, draw a card.",
             "colours": [
@@ -16647,7 +16647,7 @@
         },
         {
             "id": "786f45f8-ecb8-5a9c-8c80-c9da7aa2eca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c1b96-7ec0-4063-833f-fb32b720650e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c1b96-7ec0-4063-833f-fb32b720650e.jpg?1",
             "name": "Nine-Lives Familiar",
             "text": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
             "colours": [
@@ -16685,7 +16685,7 @@
         },
         {
             "id": "4ff1ac17-9544-554b-8305-4780a5481e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01d5f4b-a780-4a89-82b1-84d4f3b62a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01d5f4b-a780-4a89-82b1-84d4f3b62a7b.jpg?1",
             "name": "Tinybones, Bauble Burglar",
             "text": "Whenever an opponent discards a card, exile it from their graveyard with a stash counter on it.\nDuring your turn, you may play cards you don't own with stash counters on them from exile, and mana of any type can be spent to cast those spells.\n{3}{B}, {T}: Each opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -16726,7 +16726,7 @@
         },
         {
             "id": "43870e3e-cf42-5965-bda0-c6aab7a85492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb2c4-210c-4361-9232-dc1327f0a972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb2c4-210c-4361-9232-dc1327f0a972.jpg?1",
             "name": "Zul Ashur, Lich Lord",
             "text": "Ward\u2014\nPay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
             "colours": [
@@ -16767,7 +16767,7 @@
         },
         {
             "id": "0960b2a6-e118-5b86-a188-7cb316ef996f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6ab9e-99f7-4296-b8b2-6cdfa91c5fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6ab9e-99f7-4296-b8b2-6cdfa91c5fba.jpg?1",
             "name": "Electroduplicate",
             "text": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -16803,7 +16803,7 @@
         },
         {
             "id": "8823a572-c50a-5b7c-be97-8e9f108d3f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e35fbe-55b7-40c8-b24b-2d9d933bcdaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e35fbe-55b7-40c8-b24b-2d9d933bcdaa.jpg?1",
             "name": "Kellan, Planar Trailblazer",
             "text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
             "colours": [
@@ -16845,7 +16845,7 @@
         },
         {
             "id": "9816500e-2752-5f15-b7be-8cb1684a2c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a99d9bc-da4e-488b-bc4a-90594c072b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a99d9bc-da4e-488b-bc4a-90594c072b66.jpg?1",
             "name": "Rite of the Dragoncaller",
             "text": "Whenever you cast an instant or sorcery spell, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -16881,7 +16881,7 @@
         },
         {
             "id": "c085a252-8efb-559d-8577-23807d364a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3059e4-b198-4eba-98e8-f0f9f83d1928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3059e4-b198-4eba-98e8-f0f9f83d1928.jpg?1",
             "name": "Searslicer Goblin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked this turn, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -16920,7 +16920,7 @@
         },
         {
             "id": "aef84205-b056-51ac-bc57-aacd1240d3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a474e3-e7de-4b4d-ad89-a72571968687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a474e3-e7de-4b4d-ad89-a72571968687.jpg?1",
             "name": "Twinflame Tyrant",
             "text": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
             "colours": [
@@ -16960,7 +16960,7 @@
         },
         {
             "id": "28b74ac0-3a83-54eb-8c6c-5bc8bac5c26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6671b19-28d3-4d67-a8fa-83e4f6596c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6671b19-28d3-4d67-a8fa-83e4f6596c68.jpg?1",
             "name": "Loot, Exuberant Explorer",
             "text": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
             "colours": [
@@ -17001,7 +17001,7 @@
         },
         {
             "id": "0449c1a1-d75c-54f6-985a-fd512539f128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60e591e-5673-4504-9b1e-8448fae664ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60e591e-5673-4504-9b1e-8448fae664ea.jpg?1",
             "name": "Mossborn Hydra",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nThis creature enters with a +1/+1 counter on it.\nLandfall \u2014 Whenever a land you control enters, double the number of +1/+1 counters on this creature.",
             "colours": [
@@ -17040,7 +17040,7 @@
         },
         {
             "id": "bb4a5d76-2bd7-521a-9551-434937ad01de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838e2693-2dd4-4aec-bde9-369a069a3fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838e2693-2dd4-4aec-bde9-369a069a3fef.jpg?1",
             "name": "Preposterous Proportions",
             "text": "Creatures you control get +10/+10 and gain vigilance until end of turn.",
             "colours": [
@@ -17076,7 +17076,7 @@
         },
         {
             "id": "72300d6c-7fc3-5f32-8289-543ad243bd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354df84b-28a1-4b8f-a8ab-94060a35e05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354df84b-28a1-4b8f-a8ab-94060a35e05f.jpg?1",
             "name": "Quilled Greatwurm",
             "text": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it. (It must survive to get the counters.)\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
             "colours": [
@@ -17114,7 +17114,7 @@
         },
         {
             "id": "b00ed64a-4fd7-5e29-ad0e-01ac871c1309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3f233a-d4df-4836-84cc-9d3e86165926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3f233a-d4df-4836-84cc-9d3e86165926.jpg?1",
             "name": "Spinner of Souls",
             "text": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -17153,7 +17153,7 @@
         },
         {
             "id": "fef26c25-e7af-5cf5-bed9-ca779d8869a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4b8c6-ded3-4f97-b5a4-346792a25991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4b8c6-ded3-4f97-b5a4-346792a25991.jpg?1",
             "name": "Sylvan Scavenging",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature you control.\n\u2022 Create a 3/3 green Raccoon creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -17189,7 +17189,7 @@
         },
         {
             "id": "57c28198-5d31-5bf3-979d-4b3649c87470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003d05be-4cf2-43c6-a823-c2b9c6482d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003d05be-4cf2-43c6-a823-c2b9c6482d38.jpg?1",
             "name": "Alesha, Who Laughs at Fate",
             "text": "First strike\nWhenever Alesha attacks, put a +1/+1 counter on it.\nRaid \u2014 At the beginning of your end step, if you attacked this turn, return target creature card with mana value less than or equal to Alesha's power from your graveyard to the battlefield.",
             "colours": [
@@ -17232,7 +17232,7 @@
         },
         {
             "id": "a93d5cb6-8d51-554f-bc99-86f4eafaa031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6749d0b4-4c37-4b43-9ad3-3b36d831f9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6749d0b4-4c37-4b43-9ad3-3b36d831f9e7.jpg?1",
             "name": "Anthem of Champions",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -17270,7 +17270,7 @@
         },
         {
             "id": "d1b83b0a-0d9a-543e-ad1e-db56514292cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c436e43-e575-4a01-ba03-9d72810a2883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c436e43-e575-4a01-ba03-9d72810a2883.jpg?1",
             "name": "Ashroot Animist",
             "text": "Trample\nWhen this creature attacks, another target creature you control gains trample and gets +X/+X until end of turn, where X is this creature's power.",
             "colours": [
@@ -17311,7 +17311,7 @@
         },
         {
             "id": "34b3e296-fc8a-5644-be15-28347c15bdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c76cc76-317c-4680-b411-43842000aa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c76cc76-317c-4680-b411-43842000aa9f.jpg?1",
             "name": "Elenda, Saint of Dusk",
             "text": "Lifelink, hexproof from instants\nAs long as your life total is greater than your starting life total, Elenda gets +1/+1 and has menace. Elenda gets an additional +5/+5 as long as your life total is at least 10 greater than your starting life total.",
             "colours": [
@@ -17354,7 +17354,7 @@
         },
         {
             "id": "d703403e-ab48-5335-b18c-d9e7ec628187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ac4ece-8551-4662-baca-4e7d5beecb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ac4ece-8551-4662-baca-4e7d5beecb5e.jpg?1",
             "name": "Koma, World-Eater",
             "text": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
             "colours": [
@@ -17396,7 +17396,7 @@
         },
         {
             "id": "1c5db2d9-0e20-5cd0-a7cf-6c3a261fe728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa23ced5-0baa-4a8d-9263-ec2d94233a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa23ced5-0baa-4a8d-9263-ec2d94233a84.jpg?1",
             "name": "Kykar, Zephyr Awakener",
             "text": "Flying\nWhenever you cast a noncreature spell, choose one \u2014\n\u2022 Exile another target creature you control. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n\u2022 Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -17439,7 +17439,7 @@
         },
         {
             "id": "b8b39a7f-22b5-5f10-80c3-d82b2cafaae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76503c75-ff97-4c27-a55b-74c3e68578c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76503c75-ff97-4c27-a55b-74c3e68578c9.jpg?1",
             "name": "Niv-Mizzet, Visionary",
             "text": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
             "colours": [
@@ -17482,7 +17482,7 @@
         },
         {
             "id": "80c38cd6-5f7b-5fb0-84da-ca490bf81244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b82d3f-eaba-499a-9783-e90f5a2b623b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b82d3f-eaba-499a-9783-e90f5a2b623b.jpg?1",
             "name": "Zimone, Paradox Sculptor",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on each of up to two target creatures you control.\n{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
             "colours": [
@@ -17525,7 +17525,7 @@
         },
         {
             "id": "b3326774-41b0-5754-a9ed-a887f06f76fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4709aed-a74b-4319-87c1-40f14cca6dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4709aed-a74b-4319-87c1-40f14cca6dad.jpg?1",
             "name": "Banner of Kinship",
             "text": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
             "colours": [],
@@ -17557,7 +17557,7 @@
         },
         {
             "id": "516d3376-e811-5667-9fc8-7b52da3bb316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd7a17-24f5-43d5-bd5a-8b51b48e8a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dd7a17-24f5-43d5-bd5a-8b51b48e8a39.jpg?1",
             "name": "Leyline Axe",
             "text": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEquipped creature gets +1/+1 and has double strike and trample.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -17591,7 +17591,7 @@
         },
         {
             "id": "efad7897-c20e-56ed-8d5f-3791adc701e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1835cd8-16c1-467b-a613-a4df6f752894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1835cd8-16c1-467b-a613-a4df6f752894.jpg?1",
             "name": "Scrawling Crawler",
             "text": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
             "colours": [],
@@ -17627,7 +17627,7 @@
         },
         {
             "id": "8b93658b-6d54-5d41-84b8-71925d86bc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620f95e-fc95-4643-ba11-7f9116176253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620f95e-fc95-4643-ba11-7f9116176253.jpg?1",
             "name": "Soulstone Sanctuary",
             "text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
             "colours": [],
@@ -17659,7 +17659,7 @@
         },
         {
             "id": "fc0d8273-00d0-5895-870c-39438e52488e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2c9ab-b3dd-4f68-b91f-0f075a045757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2c9ab-b3dd-4f68-b91f-0f075a045757.jpg?1",
             "name": "Adamant Will",
             "text": "Target creature gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -17690,7 +17690,7 @@
         },
         {
             "id": "35b51a47-b92a-52e2-b84d-67bf74f3d117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df43d9d4-3fef-4a56-8b38-d52824117201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df43d9d4-3fef-4a56-8b38-d52824117201.jpg?1",
             "name": "Ancestor Dragon",
             "text": "Flying\nWhenever one or more creatures you control attack, you gain 1 life for each attacking creature.",
             "colours": [
@@ -17723,7 +17723,7 @@
         },
         {
             "id": "4480c07d-7a50-593d-9033-a5c676fe3f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bf349e-2974-4aea-a5c0-fdaea77325cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bf349e-2974-4aea-a5c0-fdaea77325cc.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -17754,7 +17754,7 @@
         },
         {
             "id": "af9bd0a0-9d53-5be4-82bc-e17569e53992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfd7b3-6d01-4e98-aec3-b27e8e2444e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dfd7b3-6d01-4e98-aec3-b27e8e2444e8.jpg?1",
             "name": "Bishop's Soldier",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -17788,7 +17788,7 @@
         },
         {
             "id": "9ca19d45-8552-517e-811f-98ca2aa2f1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5804a-075b-41d8-9639-785cad5c0974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5804a-075b-41d8-9639-785cad5c0974.jpg?1",
             "name": "Deadly Riposte",
             "text": "Deadly Riposte deals 3 damage to target tapped creature and you gain 2 life.",
             "colours": [
@@ -17819,7 +17819,7 @@
         },
         {
             "id": "d9aa5f74-cd0e-5168-a29e-ebe5205e4436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b405a442-cf6f-4c0b-9950-f208b30c052e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b405a442-cf6f-4c0b-9950-f208b30c052e.jpg?1",
             "name": "Elspeth's Smite",
             "text": "Elspeth's Smite deals 3 damage to target attacking or blocking creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -17850,7 +17850,7 @@
         },
         {
             "id": "b0178f62-907e-5ed6-a226-ccccbdff72b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5579f35b-b3d2-4342-a52b-ae36b579d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5579f35b-b3d2-4342-a52b-ae36b579d044.jpg?1",
             "name": "Herald of Faith",
             "text": "Flying\nWhenever this creature attacks, you gain 2 life.",
             "colours": [
@@ -17883,7 +17883,7 @@
         },
         {
             "id": "62541872-f74a-5bf8-993e-8fef7175ad25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea566679-4202-4076-9314-142241485f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea566679-4202-4076-9314-142241485f6e.jpg?1",
             "name": "Ingenious Leonin",
             "text": "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature is a Cat, it gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -17917,7 +17917,7 @@
         },
         {
             "id": "8cc449ac-1241-5459-beff-c0a17de186b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e9aa54-e5d5-4cbb-9d2a-263b9eba398f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e9aa54-e5d5-4cbb-9d2a-263b9eba398f.jpg?1",
             "name": "Inspiring Overseer",
             "text": "Flying\nWhen this creature enters, you gain 1 life and draw a card.",
             "colours": [
@@ -17951,7 +17951,7 @@
         },
         {
             "id": "a1cbccb7-fe7f-54bc-9277-27f635834306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa8f635-c638-4207-8631-f6b5185f8696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa8f635-c638-4207-8631-f6b5185f8696.jpg?1",
             "name": "Jazal Goldmane",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\n{3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -17987,7 +17987,7 @@
         },
         {
             "id": "0174c271-7d03-5201-8baa-000545050418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218e0009-5f11-4348-97b8-4bc7b41f80b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218e0009-5f11-4348-97b8-4bc7b41f80b8.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying",
             "colours": [
@@ -18021,7 +18021,7 @@
         },
         {
             "id": "ab5f0d7d-89eb-5692-b8ba-47a840973ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b25850-f1bd-4410-beec-603b2a77f264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b25850-f1bd-4410-beec-603b2a77f264.jpg?1",
             "name": "Leonin Vanguard",
             "text": "At the beginning of combat on your turn, if you control three or more creatures, this creature gets +1/+1 until end of turn and you gain 1 life.",
             "colours": [
@@ -18055,7 +18055,7 @@
         },
         {
             "id": "d54db298-7243-53d9-9ea1-b04c249e2fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911deea0-38d2-41d9-a2ae-fb8eb45b2c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911deea0-38d2-41d9-a2ae-fb8eb45b2c23.jpg?1",
             "name": "Moment of Triumph",
             "text": "Target creature gets +2/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -18086,7 +18086,7 @@
         },
         {
             "id": "28aacea2-107e-588f-b654-e0df405ab749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839160d2-44a3-4566-be9d-558d043beac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839160d2-44a3-4566-be9d-558d043beac8.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -18119,7 +18119,7 @@
         },
         {
             "id": "615eb743-0cb2-55ff-89a7-db6b21efcb69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b42c4-90d8-462d-aca5-891906992ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b42c4-90d8-462d-aca5-891906992ab8.jpg?1",
             "name": "Prayer of Binding",
             "text": "Flash\nWhen this enchantment enters, exile up to one target nonland permanent an opponent controls until this enchantment leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -18150,7 +18150,7 @@
         },
         {
             "id": "691a1848-eed9-54d3-b430-199307d1e5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9e73d-de8d-486f-bbbd-a2f5d3f8f686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd9e73d-de8d-486f-bbbd-a2f5d3f8f686.jpg?1",
             "name": "Twinblade Paladin",
             "text": "Whenever you gain life, put a +1/+1 counter on this creature.\nAs long as you have 25 or more life, this creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -18184,7 +18184,7 @@
         },
         {
             "id": "c2003792-8f98-5b69-bf9b-ae68678ce38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f11ea2-cd4c-417a-804c-3df80d9ddd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f11ea2-cd4c-417a-804c-3df80d9ddd5f.jpg?1",
             "name": "Burrog Befuddler",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature an opponent controls gets -1/-0 until end of turn.",
             "colours": [
@@ -18218,7 +18218,7 @@
         },
         {
             "id": "2d129c28-540c-53e0-8cf9-626dc67aaf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bff39-220a-4490-9c2e-d311e306a6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bff39-220a-4490-9c2e-d311e306a6db.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -18249,7 +18249,7 @@
         },
         {
             "id": "7b70ac65-c478-52ec-9640-89b06003106c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5017dbc-07fd-45ea-9629-7c584144e8be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5017dbc-07fd-45ea-9629-7c584144e8be.jpg?1",
             "name": "Corsair Captain",
             "text": "When this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nOther Pirates you control get +1/+1.",
             "colours": [
@@ -18283,7 +18283,7 @@
         },
         {
             "id": "47f6506d-4a22-52d1-b6db-a3016699bbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475e28bb-1333-45e1-b6fd-83121c2f1ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475e28bb-1333-45e1-b6fd-83121c2f1ab9.jpg?1",
             "name": "Eaten by Piranhas",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature loses all abilities and is a black Skeleton creature with base power and toughness 1/1. (It loses all other colors, card types, and creature types.)",
             "colours": [
@@ -18316,7 +18316,7 @@
         },
         {
             "id": "ad2beb36-a0f9-506b-857c-20c5bcbf2742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c8024e-490a-484a-bcee-da7728a64a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c8024e-490a-484a-bcee-da7728a64a1f.jpg?1",
             "name": "Exclusion Mage",
             "text": "When this creature enters, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -18350,7 +18350,7 @@
         },
         {
             "id": "a7514c4a-57af-5ada-897f-804525987c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25edefa9-9fff-4b71-83ae-696c196a795c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25edefa9-9fff-4b71-83ae-696c196a795c.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -18381,7 +18381,7 @@
         },
         {
             "id": "184f03c7-af9e-500b-8394-94b78ad6581f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82d7c6d-523c-46c9-a189-44c0bd8386d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82d7c6d-523c-46c9-a189-44c0bd8386d1.jpg?1",
             "name": "Kitesail Corsair",
             "text": "This creature has flying as long as it's attacking.",
             "colours": [
@@ -18415,7 +18415,7 @@
         },
         {
             "id": "1fc7bb2f-9b22-5a26-8663-d6661827a1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ff32-6759-48a2-8674-4f729c91dcd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c069ff32-6759-48a2-8674-4f729c91dcd0.jpg?1",
             "name": "Mystic Archaeologist",
             "text": "{3}{U}{U}: Draw two cards.",
             "colours": [
@@ -18449,7 +18449,7 @@
         },
         {
             "id": "3cdf748e-3c0d-5896-932e-8b5f9ae60a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d26b54-0093-4e90-a2b1-b57c64340f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d26b54-0093-4e90-a2b1-b57c64340f9c.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\nDraw a card.",
             "colours": [
@@ -18480,7 +18480,7 @@
         },
         {
             "id": "6625c7e1-58ef-5d09-ba65-92dcec1ecd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c86fd-5a38-41fd-be44-ab963448f2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c86fd-5a38-41fd-be44-ab963448f2a2.jpg?1",
             "name": "Quick Study",
             "text": "Draw two cards.",
             "colours": [
@@ -18511,7 +18511,7 @@
         },
         {
             "id": "8d67c9ca-fd13-5080-974d-d64239ae0ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fb19b2-4f6c-4cbd-8756-a7eb5c7c9ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fb19b2-4f6c-4cbd-8756-a7eb5c7c9ef6.jpg?1",
             "name": "Starlight Snare",
             "text": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -18544,7 +18544,7 @@
         },
         {
             "id": "180f033f-28ef-5d6b-a77a-ae56954d6bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c5206e-63db-44c0-86ab-f645cd358b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c5206e-63db-44c0-86ab-f645cd358b3b.jpg?1",
             "name": "Storm Fleet Spy",
             "text": "Raid \u2014 When this creature enters, if you attacked this turn, draw a card.",
             "colours": [
@@ -18578,7 +18578,7 @@
         },
         {
             "id": "cf792215-f3f0-53c5-b71a-eb89027215bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d951-dd85-4d22-9505-ce6e2eaf47cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d951-dd85-4d22-9505-ce6e2eaf47cf.jpg?1",
             "name": "Bloodtithe Collector",
             "text": "Flying\nWhen this creature enters, if an opponent lost life this turn, each opponent discards a card.",
             "colours": [
@@ -18612,7 +18612,7 @@
         },
         {
             "id": "c3ca3bd5-257c-59ea-a6e2-5234a022cb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a80873-86d7-44a9-894b-65e8f77dd2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a80873-86d7-44a9-894b-65e8f77dd2ea.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -18643,7 +18643,7 @@
         },
         {
             "id": "ac11efc3-7262-53bd-be2a-c3b3130ab6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5e19c-4cb8-4bd7-923c-4db747dc6ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5e19c-4cb8-4bd7-923c-4db747dc6ca3.jpg?1",
             "name": "Crossway Troublemakers",
             "text": "Attacking Vampires you control have deathtouch and lifelink. (Any amount of damage they deal to a creature is enough to destroy it. Damage dealt by those creatures also causes their controller to gain that much life.)\nWhenever a Vampire you control dies, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -18676,7 +18676,7 @@
         },
         {
             "id": "7a02c74b-3180-548e-9afe-053248a50e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd74e93-064a-42d7-8e6e-c413912a08cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd74e93-064a-42d7-8e6e-c413912a08cd.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen this creature enters or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -18710,7 +18710,7 @@
         },
         {
             "id": "10ed2023-c7c5-56f1-bc38-c13a86dc64f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32fddc3-a38f-4eea-ae01-4158e3cbca6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32fddc3-a38f-4eea-ae01-4158e3cbca6c.jpg?1",
             "name": "Deadly Plot",
             "text": "Choose one \u2014\n\u2022 Destroy target creature or planeswalker.\n\u2022 Return target Zombie creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -18741,7 +18741,7 @@
         },
         {
             "id": "c449934a-b1dd-5884-967e-03296a6fd3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a27142-cf45-4164-9e10-373e5c8bf7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a27142-cf45-4164-9e10-373e5c8bf7c6.jpg?1",
             "name": "Death Baron",
             "text": "Skeletons you control and other Zombies you control get +1/+1 and have deathtouch. (Any amount of damage they deal to a creature is enough to destroy it.)",
             "colours": [
@@ -18775,7 +18775,7 @@
         },
         {
             "id": "3e28ed1b-f64e-51a4-9a92-76aef12aaf46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c56a23-eb4f-4be1-ada9-1ad5b80195d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c56a23-eb4f-4be1-ada9-1ad5b80195d3.jpg?1",
             "name": "Highborn Vampire",
             "text": "",
             "colours": [
@@ -18809,7 +18809,7 @@
         },
         {
             "id": "937a713f-9599-5948-88fe-80bc7161cd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c166df8f-9508-427a-8ec7-bc8541b6ed88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c166df8f-9508-427a-8ec7-bc8541b6ed88.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When this creature dies, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -18842,7 +18842,7 @@
         },
         {
             "id": "791fd5a2-c405-5eaa-a71d-9563269f1fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3627f9fb-b828-49cd-887d-e2ab3ef43dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3627f9fb-b828-49cd-887d-e2ab3ef43dfb.jpg?1",
             "name": "Moment of Craving",
             "text": "Target creature gets -2/-2 until end of turn. You gain 2 life.",
             "colours": [
@@ -18873,7 +18873,7 @@
         },
         {
             "id": "1b6c5420-eca9-5979-94ba-c41bf99991fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5802ed-507d-4a52-90e3-d989cd61961b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5802ed-507d-4a52-90e3-d989cd61961b.jpg?1",
             "name": "Offer Immortality",
             "text": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -18904,7 +18904,7 @@
         },
         {
             "id": "9cc65db3-6560-59f0-9a94-cda6a146ecb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a959048-0d8a-41bb-8a33-52264e525085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a959048-0d8a-41bb-8a33-52264e525085.jpg?1",
             "name": "Skeleton Archer",
             "text": "When this creature enters, it deals 1 damage to any target.",
             "colours": [
@@ -18938,7 +18938,7 @@
         },
         {
             "id": "2c64f109-f55a-5d4a-92bd-7e3c01eec610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2c5345-eb55-4bca-9183-b4e1404405f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2c5345-eb55-4bca-9183-b4e1404405f8.jpg?1",
             "name": "Suspicious Shambler",
             "text": "{4}{B}{B}, Exile this card from your graveyard: Create two 2/2 black Zombie creature tokens. Activate only as a sorcery.",
             "colours": [
@@ -18971,7 +18971,7 @@
         },
         {
             "id": "ca8afbe3-0bba-54b6-93dd-ce83cffad897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b3cf11-e352-4ee1-8c03-13898f576ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b3cf11-e352-4ee1-8c03-13898f576ef9.jpg?1",
             "name": "Undying Malice",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
             "colours": [
@@ -19002,7 +19002,7 @@
         },
         {
             "id": "42216626-ef9d-5421-982e-e7eab521ab31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05937911-897b-4638-9536-2e463884f453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05937911-897b-4638-9536-2e463884f453.jpg?1",
             "name": "Untamed Hunger",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -19035,7 +19035,7 @@
         },
         {
             "id": "139d2b58-7895-5aeb-9d37-1464c87ac588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65455d94-487c-4104-a1a0-149515a90eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65455d94-487c-4104-a1a0-149515a90eaa.jpg?1",
             "name": "Vampire Interloper",
             "text": "Flying\nThis creature can't block.",
             "colours": [
@@ -19069,7 +19069,7 @@
         },
         {
             "id": "43d8854b-85c8-51f4-bc5e-9c90ffdd4e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d64a1d-cda4-4c76-8d58-ccab5a6859a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d64a1d-cda4-4c76-8d58-ccab5a6859a0.jpg?1",
             "name": "Vampire Neonate",
             "text": "{2}, {T}: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -19102,7 +19102,7 @@
         },
         {
             "id": "920641f4-7934-56dd-9cfe-77845fc87c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc8d2e-ad63-498d-83b6-5f72b5ae0e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fc8d2e-ad63-498d-83b6-5f72b5ae0e67.jpg?1",
             "name": "Vampire Spawn",
             "text": "When this creature enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -19135,7 +19135,7 @@
         },
         {
             "id": "cd400900-bc58-55ec-8c99-0976de2c04de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee05f7e-d4da-4a72-8140-d505eecbdd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee05f7e-d4da-4a72-8140-d505eecbdd32.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -19169,7 +19169,7 @@
         },
         {
             "id": "d953419f-4495-5e16-8fec-b49237983777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c07546-c5a1-4dfc-b5e1-d697578a8c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c07546-c5a1-4dfc-b5e1-d697578a8c11.jpg?1",
             "name": "Carnelian Orb of Dragonkind",
             "text": "{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.",
             "colours": [
@@ -19200,7 +19200,7 @@
         },
         {
             "id": "34b9cb7c-347a-5b0f-828f-7a04bcdcfbf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9abe517-f601-4784-8d62-2350bd755146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9abe517-f601-4784-8d62-2350bd755146.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -19231,7 +19231,7 @@
         },
         {
             "id": "19692683-4d62-5e09-8715-7288ebd36ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e35f88-a580-4b55-9c11-0b58e2f752d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e35f88-a580-4b55-9c11-0b58e2f752d1.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -19265,7 +19265,7 @@
         },
         {
             "id": "e4ceec86-7695-5108-a183-f6788d944fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg?1",
             "name": "Dropkick Bomber",
             "text": "Other Goblins you control get +1/+1.\n{R}: Until end of turn, another target Goblin you control gains flying and \"When this creature deals combat damage, sacrifice it.\"",
             "colours": [
@@ -19299,7 +19299,7 @@
         },
         {
             "id": "5d313e56-679b-5e13-a499-54014c996580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc506f58-048d-49cc-ad8c-2eb851b08bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc506f58-048d-49cc-ad8c-2eb851b08bb6.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -19332,7 +19332,7 @@
         },
         {
             "id": "a3b0198a-8108-5f78-987d-03af55525f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0259e4d8-849b-468e-a902-aa1d7f2d5b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0259e4d8-849b-468e-a902-aa1d7f2d5b6a.jpg?1",
             "name": "Goblin Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -19363,7 +19363,7 @@
         },
         {
             "id": "efbb133f-f316-50d0-8fb4-380b0aaad2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5837ccf1-9bac-4afb-bcc9-82c5f3c0e8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5837ccf1-9bac-4afb-bcc9-82c5f3c0e8e2.jpg?1",
             "name": "Goblin Smuggler",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Another target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -19397,7 +19397,7 @@
         },
         {
             "id": "cb95813c-93cb-54ad-b324-b070975069b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aef07-4291-4dfd-b9b2-bfc26745341c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aef07-4291-4dfd-b9b2-bfc26745341c.jpg?1",
             "name": "Kargan Dragonrider",
             "text": "As long as you control a Dragon, this creature has flying.",
             "colours": [
@@ -19431,7 +19431,7 @@
         },
         {
             "id": "1cc793c0-19bf-552b-8eb8-f428f6f77c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af158462-91e3-4ad7-b435-95d4eb32fe0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af158462-91e3-4ad7-b435-95d4eb32fe0a.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -19462,7 +19462,7 @@
         },
         {
             "id": "f87a9093-0d38-5504-a9c0-7c0766612c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627b0a7-bda9-44df-81c9-aa70cc976331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9627b0a7-bda9-44df-81c9-aa70cc976331.jpg?1",
             "name": "Raging Redcap",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -19496,7 +19496,7 @@
         },
         {
             "id": "3c6a2d11-6618-5d87-86fe-21388d0a6f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaddac1-d8ca-4949-8140-c9193e3df921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaddac1-d8ca-4949-8140-c9193e3df921.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen this creature enters, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -19529,7 +19529,7 @@
         },
         {
             "id": "bff7912b-93b9-567c-b67a-7261176d3f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ea09c1-d420-4e99-a968-ade614579287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ea09c1-d420-4e99-a968-ade614579287.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -19560,7 +19560,7 @@
         },
         {
             "id": "db9ede56-68d3-5d47-b3bd-e81e62cf0a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf7e75-5de2-45cc-9275-caccd73214fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf7e75-5de2-45cc-9275-caccd73214fa.jpg?1",
             "name": "Seize the Spoils",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -19591,7 +19591,7 @@
         },
         {
             "id": "6996adb5-72d0-58a9-a68b-8fa9a4dbd797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3fbafb-e915-43eb-8a68-245840ba73ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3fbafb-e915-43eb-8a68-245840ba73ff.jpg?1",
             "name": "Skyraker Giant",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -19624,7 +19624,7 @@
         },
         {
             "id": "976aa7aa-31ce-546e-a10c-585c3e918712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db11970-74c2-463d-88bb-9f88aa079eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db11970-74c2-463d-88bb-9f88aa079eaa.jpg?1",
             "name": "Swab Goblin",
             "text": "",
             "colours": [
@@ -19658,7 +19658,7 @@
         },
         {
             "id": "33420db6-b39b-5a86-964f-ebea8712beba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959a6c7-d615-4524-b94d-65f4164a2656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959a6c7-d615-4524-b94d-65f4164a2656.jpg?1",
             "name": "Terror of Mount Velus",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)\nWhen this creature enters, creatures you control gain double strike until end of turn.",
             "colours": [
@@ -19691,7 +19691,7 @@
         },
         {
             "id": "0dec2d4d-0035-5c6b-ab6f-d15d66390d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc914fe-e699-4a21-aa09-f3573d020b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc914fe-e699-4a21-aa09-f3573d020b87.jpg?1",
             "name": "Volley Veteran",
             "text": "When this creature enters, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -19725,7 +19725,7 @@
         },
         {
             "id": "9129a289-fd63-5173-b89c-d4311ac61755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7724b978-999b-4654-96f3-58e28aa7cb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7724b978-999b-4654-96f3-58e28aa7cb34.jpg?1",
             "name": "Aggressive Mammoth",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther creatures you control have trample.",
             "colours": [
@@ -19758,7 +19758,7 @@
         },
         {
             "id": "7c351923-0a42-5b25-817d-02686a9c532b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8662ebb-068b-41d2-b504-4b5854e4d4aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8662ebb-068b-41d2-b504-4b5854e4d4aa.jpg?1",
             "name": "Bear Cub",
             "text": "",
             "colours": [
@@ -19791,7 +19791,7 @@
         },
         {
             "id": "4a99527f-ab5a-5afa-8c0e-76270ff938ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef20af5e-1ffe-426a-805a-ca4a6a122260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef20af5e-1ffe-426a-805a-ca4a6a122260.jpg?1",
             "name": "Biogenic Upgrade",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.",
             "colours": [
@@ -19822,7 +19822,7 @@
         },
         {
             "id": "66a38f24-16fc-5b6c-afa2-3deb6a022be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2d0ee9-865c-4fc9-8cb6-540c597e1bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db2d0ee9-865c-4fc9-8cb6-540c597e1bf4.jpg?1",
             "name": "Druid of the Cowl",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -19856,7 +19856,7 @@
         },
         {
             "id": "5f277d3a-93b2-5c35-89df-c35af9fa8ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ceca57-65f4-4f99-bd14-9fe5f86c1f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ceca57-65f4-4f99-bd14-9fe5f86c1f62.jpg?1",
             "name": "Joraga Invocation",
             "text": "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -19887,7 +19887,7 @@
         },
         {
             "id": "0d93300f-5728-5a3d-897d-15b5af6fcb10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5624e610-c4c0-4103-a32b-0f1264030a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5624e610-c4c0-4103-a32b-0f1264030a7a.jpg?1",
             "name": "Magnigoth Sentry",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -19920,7 +19920,7 @@
         },
         {
             "id": "28c98466-e4fb-5da0-8e0c-f57efad292e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3923c-c35c-4eb2-9dd3-b15c13778ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b3923c-c35c-4eb2-9dd3-b15c13778ecf.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen this Aura enters, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -19953,7 +19953,7 @@
         },
         {
             "id": "069853c5-6346-5fbf-a581-3ab24fb636c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da20a0d3-2022-4dea-84c8-85adc5a974f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da20a0d3-2022-4dea-84c8-85adc5a974f8.jpg?1",
             "name": "Tajuru Pathwarden",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -19988,7 +19988,7 @@
         },
         {
             "id": "bcf2e9fe-a348-579f-a37a-ea2bd73e931e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f6199-f2fe-49a5-89ca-3c4cb39fbf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f6199-f2fe-49a5-89ca-3c4cb39fbf2b.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -20022,7 +20022,7 @@
         },
         {
             "id": "20a0096d-b0d5-5bc2-b287-6f1703f118c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592364bf-68b5-4ea0-97d6-c7cadce940fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592364bf-68b5-4ea0-97d6-c7cadce940fd.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice this creature: Destroy target artifact or enchantment.",
             "colours": [
@@ -20055,7 +20055,7 @@
         },
         {
             "id": "5b871ec9-e20f-5545-86c9-3783f78115dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f42969-bb5c-4183-8bd3-ba87f008391d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f42969-bb5c-4183-8bd3-ba87f008391d.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -20089,7 +20089,7 @@
         },
         {
             "id": "3fe523c5-3d5f-5c3e-bf3e-4996d9b87818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ab3f99-9541-4100-818c-5d9e916791e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ab3f99-9541-4100-818c-5d9e916791e4.jpg?1",
             "name": "Goblin Firebomb",
             "text": "Flash\n{7}, {T}, Sacrifice this artifact: Destroy target permanent.",
             "colours": [],
@@ -20116,7 +20116,7 @@
         },
         {
             "id": "adc8ae51-5efe-5339-99dd-6624b9b4d067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d20aef-d35b-4353-a241-e6cfa9730975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d20aef-d35b-4353-a241-e6cfa9730975.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When this Equipment enters, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -20145,7 +20145,7 @@
         },
         {
             "id": "0bf415d7-9a4a-50ff-b220-0e08916a856b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172cd5b7-98fc-4add-b858-a0b3dfb75c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172cd5b7-98fc-4add-b858-a0b3dfb75c19.jpg?1",
             "name": "Uncharted Haven",
             "text": "This land enters tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -20172,7 +20172,7 @@
         },
         {
             "id": "cfc7fd80-d1c7-585d-9845-53fb298aad71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066d73fa-369b-44a3-b1a9-d22176ac3566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066d73fa-369b-44a3-b1a9-d22176ac3566.jpg?1",
             "name": "Angelic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition to its other types.\nWhen enchanted creature dies, return Angelic Destiny to its owner's hand.",
             "colours": [
@@ -20205,7 +20205,7 @@
         },
         {
             "id": "44e268ff-2f50-54bb-83f0-b2fe08ed695e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ff489-bdd7-4aeb-8130-3c234d0dd3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ff489-bdd7-4aeb-8130-3c234d0dd3dd.jpg?1",
             "name": "Archway Angel",
             "text": "Flying\nWhen this creature enters, you gain 2 life for each Gate you control.",
             "colours": [
@@ -20238,7 +20238,7 @@
         },
         {
             "id": "0800b712-53f4-58e1-8d53-424fc1ad0c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a7daa-a112-4728-9123-594366694915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a7daa-a112-4728-9123-594366694915.jpg?1",
             "name": "Ballyrush Banneret",
             "text": "Kithkin spells and Soldier spells you cast cost {1} less to cast.",
             "colours": [
@@ -20272,7 +20272,7 @@
         },
         {
             "id": "12f71161-1bc7-5df6-bcd9-3162ead8df3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7b47e1-7e32-4f2f-aecf-bac7ca197081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7b47e1-7e32-4f2f-aecf-bac7ca197081.jpg?1",
             "name": "Charming Prince",
             "text": "When this creature enters, choose one \u2014\n\u2022 Scry 2.\n\u2022 You gain 3 life.\n\u2022 Exile another target creature you own. Return it to the battlefield under your control at the beginning of the next end step.",
             "colours": [
@@ -20306,7 +20306,7 @@
         },
         {
             "id": "4f353e97-e3a8-5d2a-a438-90c7c3233cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009029c2-26b9-498f-8765-e91c2e1f3aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009029c2-26b9-498f-8765-e91c2e1f3aee.jpg?1",
             "name": "Crusader of Odric",
             "text": "Crusader of Odric's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -20340,7 +20340,7 @@
         },
         {
             "id": "2d083f37-e9a0-5832-ad51-973c2ca32e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807db84f-addb-4ef0-b9ba-32b3e1bced3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807db84f-addb-4ef0-b9ba-32b3e1bced3d.jpg?1",
             "name": "Dawnwing Marshal",
             "text": "Flying\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -20374,7 +20374,7 @@
         },
         {
             "id": "4c21a8d5-a75b-5646-be01-b9ad91be11fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d174cb01-b1cf-444c-a893-cc61ddf88b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d174cb01-b1cf-444c-a893-cc61ddf88b8c.jpg?1",
             "name": "Devout Decree",
             "text": "Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -20405,7 +20405,7 @@
         },
         {
             "id": "ce340585-e603-5c45-a81c-10418d5b8448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac43e16-8b14-46f2-877a-600ea918766b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac43e16-8b14-46f2-877a-600ea918766b.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -20436,7 +20436,7 @@
         },
         {
             "id": "a61901c5-1bac-5643-bcad-4e89b9d080ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d61d50b-7ab6-45a9-b207-31d87aa2e555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d61d50b-7ab6-45a9-b207-31d87aa2e555.jpg?1",
             "name": "Felidar Cub",
             "text": "Sacrifice this creature: Destroy target enchantment.",
             "colours": [
@@ -20470,7 +20470,7 @@
         },
         {
             "id": "c7ce0ac9-8c1a-58b3-87fa-da8a21bb1dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e3cc09-5057-4c05-88fc-d6cda809fc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e3cc09-5057-4c05-88fc-d6cda809fc74.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land you control enters, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -20501,7 +20501,7 @@
         },
         {
             "id": "ff01fa7c-3794-5df9-842b-6077b53e74ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c1e655-1883-428f-abe8-69c011cfbd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c1e655-1883-428f-abe8-69c011cfbd4b.jpg?1",
             "name": "Fumigate",
             "text": "Destroy all creatures. You gain 1 life for each creature destroyed this way.",
             "colours": [
@@ -20532,7 +20532,7 @@
         },
         {
             "id": "cb432ba4-ffde-5f3a-af3c-eb63910b6947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efb8633-0a70-4ddc-80af-42508ec75cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efb8633-0a70-4ddc-80af-42508ec75cff.jpg?1",
             "name": "Knight of Grace",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nHexproof from black (This creature can't be the target of black spells or abilities your opponents control.)\nThis creature gets +1/+0 as long as any player controls a black permanent.",
             "colours": [
@@ -20566,7 +20566,7 @@
         },
         {
             "id": "28cd16d7-693b-5800-8915-2a3331a04095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcd0898-db3d-44ec-9d56-a1b558da90f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcd0898-db3d-44ec-9d56-a1b558da90f4.jpg?1",
             "name": "Linden, the Steadfast Queen",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever a white creature you control attacks, you gain 1 life.",
             "colours": [
@@ -20602,7 +20602,7 @@
         },
         {
             "id": "17bcec5b-61b5-5022-83db-da87b9dd8263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790977-efd4-470a-823a-6929f84016e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790977-efd4-470a-823a-6929f84016e7.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature you control with power 2 or less enters, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -20636,7 +20636,7 @@
         },
         {
             "id": "16d3a4d4-33bc-5de9-9452-4635ceb813bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6310a82-73db-40cb-ae64-6f07f869024c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6310a82-73db-40cb-ae64-6f07f869024c.jpg?1",
             "name": "Regal Caracal",
             "text": "Other Cats you control get +1/+1 and have lifelink. (Damage dealt by those creatures also causes you to gain that much life.)\nWhen this creature enters, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -20669,7 +20669,7 @@
         },
         {
             "id": "764717e1-2ffb-5a29-a6d6-75b4b3701b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f10906-4fd5-44e8-99c7-3f9dcc988c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f10906-4fd5-44e8-99c7-3f9dcc988c48.jpg?1",
             "name": "Release the Dogs",
             "text": "Create four 1/1 white Dog creature tokens.",
             "colours": [
@@ -20700,7 +20700,7 @@
         },
         {
             "id": "bee3b8ac-e34c-5207-9d1b-afd5423336e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce41e348-44c2-47f8-8e7d-da2e4d16d648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce41e348-44c2-47f8-8e7d-da2e4d16d648.jpg?1",
             "name": "Stasis Snare",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this enchantment enters, exile target creature an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -20731,7 +20731,7 @@
         },
         {
             "id": "998cdccb-6678-53ab-bf06-e636565db608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d42be5f-a6a7-4699-abf7-9632de6daede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d42be5f-a6a7-4699-abf7-9632de6daede.jpg?1",
             "name": "Syr Alin, the Lion's Claw",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Syr Alin attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -20767,7 +20767,7 @@
         },
         {
             "id": "002c8b92-c54f-5474-a5df-6ce7a0ea6143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4c47e3-04b6-4760-9a80-b6acef1e4524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4c47e3-04b6-4760-9a80-b6acef1e4524.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -20798,7 +20798,7 @@
         },
         {
             "id": "f2093e7e-1dd8-5cc0-9a05-8d82acd7d37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694df80e-77d1-4455-b6f1-58d212267d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694df80e-77d1-4455-b6f1-58d212267d76.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -20834,7 +20834,7 @@
         },
         {
             "id": "dc50d493-dfeb-5569-8c46-51373d6b2621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fee90a-7cb3-4fad-91a7-1b1edbde0133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fee90a-7cb3-4fad-91a7-1b1edbde0133.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "{T}: Draw three cards.\n{2}{U}{U}: Return Arcanis to its owner's hand.",
             "colours": [
@@ -20869,7 +20869,7 @@
         },
         {
             "id": "e3b81ced-d237-5704-9628-766ab6fe3529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599d459-fe71-48f4-8c65-0f519bb63a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599d459-fe71-48f4-8c65-0f519bb63a68.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked this turn.",
             "colours": [
@@ -20900,7 +20900,7 @@
         },
         {
             "id": "29397c75-2235-5bbf-9601-75a3a084773a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e4087b-e692-4eb2-bb59-ff2a001d6dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e4087b-e692-4eb2-bb59-ff2a001d6dd4.jpg?1",
             "name": "Dictate of Kruphix",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nAt the beginning of each player's draw step, that player draws an additional card.",
             "colours": [
@@ -20931,7 +20931,7 @@
         },
         {
             "id": "06369e19-248b-56eb-a3a0-29da9fdd9560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d5cff9-a3ec-432d-9ce5-68949e524279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d5cff9-a3ec-432d-9ce5-68949e524279.jpg?1",
             "name": "Dive Down",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -20962,7 +20962,7 @@
         },
         {
             "id": "19babb20-4d5e-5a23-b71c-93012e8e22cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a77e063-e8f6-4cb2-954e-74cf41ce73da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a77e063-e8f6-4cb2-954e-74cf41ce73da.jpg?1",
             "name": "Finale of Revelation",
             "text": "Draw X cards. If X is 10 or more, instead shuffle your graveyard into your library, draw X cards, untap up to five lands, and you have no maximum hand size for the rest of the game.\nExile Finale of Revelation.",
             "colours": [
@@ -20993,7 +20993,7 @@
         },
         {
             "id": "4350c5e6-acc1-56e7-a721-d9ea4eaefcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e37a7e-6093-4ef5-b6e4-4aa800ddfc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e37a7e-6093-4ef5-b6e4-4aa800ddfc1b.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -21024,7 +21024,7 @@
         },
         {
             "id": "38b7af9a-47ec-585b-bb61-ca4ceed8b08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18748b1d-4161-482c-a726-8762b4c1819c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18748b1d-4161-482c-a726-8762b4c1819c.jpg?1",
             "name": "Fog Bank",
             "text": "Defender (This creature can't attack.)\nFlying\nPrevent all combat damage that would be dealt to and dealt by this creature.",
             "colours": [
@@ -21057,7 +21057,7 @@
         },
         {
             "id": "41b3ca0f-6843-5055-a493-e3b1dd4a1017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3834176f-29c5-4511-87d6-75d0c348a770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3834176f-29c5-4511-87d6-75d0c348a770.jpg?1",
             "name": "Gateway Sneak",
             "text": "Whenever a Gate you control enters, this creature can't be blocked this turn.\nWhenever this creature deals combat damage to a player, draw a card.",
             "colours": [
@@ -21091,7 +21091,7 @@
         },
         {
             "id": "d0956e0e-6517-5b75-bc8c-f6daddc3bdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca4f70d-ec17-49a4-8968-598ecdbe8243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca4f70d-ec17-49a4-8968-598ecdbe8243.jpg?1",
             "name": "Harbinger of the Tides",
             "text": "You may cast this card as though it had flash if you pay {2} more to cast it. (You may cast it any time you could cast an instant.)\nWhen this creature enters, you may return target tapped creature an opponent controls to its owner's hand.",
             "colours": [
@@ -21125,7 +21125,7 @@
         },
         {
             "id": "6a27cbc3-3d65-5c19-add5-c4fae06ac2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f88eacf-5c7b-4a35-86f0-af3b0516d4c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f88eacf-5c7b-4a35-86f0-af3b0516d4c2.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, put it into your hand, then shuffle.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -21157,7 +21157,7 @@
         },
         {
             "id": "4b0ecaab-ce8d-50a3-9dec-cdd5bb1313b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg?1",
             "name": "River's Rebuke",
             "text": "Return all nonland permanents target player controls to their owner's hand.",
             "colours": [
@@ -21188,7 +21188,7 @@
         },
         {
             "id": "16020744-d652-5318-b6fa-7e7e2f975bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f20fe3d-792a-4030-a25c-e81b48b2bcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f20fe3d-792a-4030-a25c-e81b48b2bcb4.jpg?1",
             "name": "Shipwreck Dowser",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -21222,7 +21222,7 @@
         },
         {
             "id": "09e73939-6d95-5637-a63b-c7be5401ddc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cf2366-40d0-4f94-84a5-8aa42308e223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cf2366-40d0-4f94-84a5-8aa42308e223.jpg?1",
             "name": "Sphinx of the Final Word",
             "text": "This spell can't be countered.\nFlying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)\nInstant and sorcery spells you control can't be countered.",
             "colours": [
@@ -21255,7 +21255,7 @@
         },
         {
             "id": "9a810491-6100-5855-98c8-91e765ee6aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7766506c-bc18-4ac3-9034-e8f7e54c4039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7766506c-bc18-4ac3-9034-e8f7e54c4039.jpg?1",
             "name": "Tempest Djinn",
             "text": "Flying\nThis creature gets +1/+0 for each basic Island you control.",
             "colours": [
@@ -21288,7 +21288,7 @@
         },
         {
             "id": "1bab8a13-916b-5e7d-a59c-43cd6f6f84ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378d319-ab98-422a-8f72-121a9d26f5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b378d319-ab98-422a-8f72-121a9d26f5c6.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -21319,7 +21319,7 @@
         },
         {
             "id": "497fd560-8792-53dd-939c-95a9d669867a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27b40dd-9b2a-4a99-a984-ee9cfdb091a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27b40dd-9b2a-4a99-a984-ee9cfdb091a1.jpg?1",
             "name": "Voracious Greatshark",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, counter target artifact or creature spell.",
             "colours": [
@@ -21352,7 +21352,7 @@
         },
         {
             "id": "3bf3a815-5570-5dcb-b4ba-582e0f78d136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42592d75-593e-4719-b13b-bca374017e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42592d75-593e-4719-b13b-bca374017e79.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -21383,7 +21383,7 @@
         },
         {
             "id": "8c220808-74ba-523a-8bf8-4c8aa86ebc94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0b7242-df91-48cf-bf4e-b68306c9965f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0b7242-df91-48cf-bf4e-b68306c9965f.jpg?1",
             "name": "Demonic Pact",
             "text": "At the beginning of your upkeep, choose one that hasn't been chosen \u2014\n\u2022 This enchantment deals 4 damage to any target and you gain 4 life.\n\u2022 Target opponent discards two cards.\n\u2022 Draw two cards.\n\u2022 You lose the game.",
             "colours": [
@@ -21414,7 +21414,7 @@
         },
         {
             "id": "522ac52c-490d-5dd5-bb60-f0098381ee63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bf6460-0df6-4dd3-8af8-df728683bcaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bf6460-0df6-4dd3-8af8-df728683bcaa.jpg?1",
             "name": "Desecration Demon",
             "text": "Flying\nAt the beginning of each combat, any opponent may sacrifice a creature of their choice. If a player does, tap this creature and put a +1/+1 counter on it.",
             "colours": [
@@ -21447,7 +21447,7 @@
         },
         {
             "id": "13f0fd2f-5249-5098-8b62-c18e71d7e40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb5dd33-6e5b-4d78-92fa-678c9f01c606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb5dd33-6e5b-4d78-92fa-678c9f01c606.jpg?1",
             "name": "Dread Summons",
             "text": "Each player mills X cards. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -21478,7 +21478,7 @@
         },
         {
             "id": "5d984ec7-7295-5ca7-b608-82b1f959431e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443696a-0b9a-4081-91aa-800b5c4065d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443696a-0b9a-4081-91aa-800b5c4065d2.jpg?1",
             "name": "Driver of the Dead",
             "text": "When this creature dies, return target creature card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -21511,7 +21511,7 @@
         },
         {
             "id": "a251feb0-e73f-587c-a823-c0da42bffee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3a894-ee75-4db9-a69f-711bb3cc150a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3a894-ee75-4db9-a69f-711bb3cc150a.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -21542,7 +21542,7 @@
         },
         {
             "id": "bd3aaf58-5524-5450-beae-7c238e82bacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a52f6ef-7759-4be3-8b80-a57e9d6ae386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a52f6ef-7759-4be3-8b80-a57e9d6ae386.jpg?1",
             "name": "Kalastria Highborn",
             "text": "Whenever this creature or another Vampire you control dies, you may pay {B}. If you do, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -21576,7 +21576,7 @@
         },
         {
             "id": "89563a90-fcf4-50b2-8a82-a4f438f432d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb678e10-e5a4-4143-8e49-7b523118674e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb678e10-e5a4-4143-8e49-7b523118674e.jpg?1",
             "name": "Knight of Malice",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nHexproof from white (This creature can't be the target of white spells or abilities your opponents control.)\nThis creature gets +1/+0 as long as any player controls a white permanent.",
             "colours": [
@@ -21610,7 +21610,7 @@
         },
         {
             "id": "9095c95c-b8b5-5df2-9fd7-b5d3045b56d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f229b0e6-1ffd-410e-b04b-a0afc179c58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f229b0e6-1ffd-410e-b04b-a0afc179c58c.jpg?1",
             "name": "Midnight Reaper",
             "text": "Whenever a nontoken creature you control dies, this creature deals 1 damage to you and you draw a card.",
             "colours": [
@@ -21644,7 +21644,7 @@
         },
         {
             "id": "99fdc6fe-8f4a-5837-a200-a5406683c5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc5505-7fa0-4ebf-a691-b4ca5f52b019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc5505-7fa0-4ebf-a691-b4ca5f52b019.jpg?1",
             "name": "Myojin of Night's Reach",
             "text": "Myojin of Night's Reach enters with a divinity counter on it if you cast it from your hand.\nMyojin of Night's Reach has indestructible as long as it has a divinity counter on it.\nRemove a divinity counter from Myojin of Night's Reach: Each opponent discards their hand.",
             "colours": [
@@ -21679,7 +21679,7 @@
         },
         {
             "id": "9603dc1c-5273-5b26-9b55-06bda9e0f98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7613c-38fc-49c3-93ee-1df93136455a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c7613c-38fc-49c3-93ee-1df93136455a.jpg?1",
             "name": "Nullpriest of Oblivion",
             "text": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nLifelink\nMenace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, if it was kicked, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -21713,7 +21713,7 @@
         },
         {
             "id": "16520114-4140-5450-9347-b21f82e9cf2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbbe4d-5c93-4b14-8123-cd835452870f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbbe4d-5c93-4b14-8123-cd835452870f.jpg?1",
             "name": "Pulse Tracker",
             "text": "Whenever this creature attacks, each opponent loses 1 life.",
             "colours": [
@@ -21747,7 +21747,7 @@
         },
         {
             "id": "462a9cc6-3d4e-5ffd-ad82-4309164430ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a26ca7-b26f-4b86-a060-712f15f4bf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a26ca7-b26f-4b86-a060-712f15f4bf7f.jpg?1",
             "name": "Sanguine Indulgence",
             "text": "This spell costs {3} less to cast if you've gained 3 or more life this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -21778,7 +21778,7 @@
         },
         {
             "id": "2d1866ed-7412-5a9e-81aa-0604795a552a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1b897-bb7d-4217-97a7-c89f2453c8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f1b897-bb7d-4217-97a7-c89f2453c8fa.jpg?1",
             "name": "Tribute to Hunger",
             "text": "Target opponent sacrifices a creature of their choice. You gain life equal to that creature's toughness.",
             "colours": [
@@ -21809,7 +21809,7 @@
         },
         {
             "id": "3b853bf9-8485-536b-b2e2-1b306f8766de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0b1e0-a481-4a98-b67b-0cf8bac53fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae0b1e0-a481-4a98-b67b-0cf8bac53fdd.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -21840,7 +21840,7 @@
         },
         {
             "id": "3052f2c9-b1db-56cd-987b-ccbd941aed80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833b5a32-5d77-4e46-a524-25bada29ef59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833b5a32-5d77-4e46-a524-25bada29ef59.jpg?1",
             "name": "Vile Entomber",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen this creature enters, search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -21874,7 +21874,7 @@
         },
         {
             "id": "126156cd-d51f-5f9d-a154-607538a16b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5.jpg?1",
             "name": "Wishclaw Talisman",
             "text": "This artifact enters with three wish counters on it.\n{1}, {T}, Remove a wish counter from this artifact: Search your library for a card, put it into your hand, then shuffle. An opponent gains control of this artifact. Activate only during your turn.",
             "colours": [
@@ -21905,7 +21905,7 @@
         },
         {
             "id": "eebb2f94-beb6-538f-8ed7-f64a69bd885d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f27dbf0-6818-40ea-832d-10686b4c2900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f27dbf0-6818-40ea-832d-10686b4c2900.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nAt the beginning of the end step, sacrifice this creature.",
             "colours": [
@@ -21938,7 +21938,7 @@
         },
         {
             "id": "3cac278c-014b-55c3-9bf0-d09f5a087e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01af2c-68e5-4bb5-81de-f3a1b860fb2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf01af2c-68e5-4bb5-81de-f3a1b860fb2e.jpg?1",
             "name": "Bolt Bend",
             "text": "This spell costs {3} less to cast if you control a creature with power 4 or greater.\nChange the target of target spell or ability with a single target.",
             "colours": [
@@ -21969,7 +21969,7 @@
         },
         {
             "id": "9d6ad563-b624-557e-b697-90e45aba8a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb16918-6363-4849-8d74-e26822a0ddf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb16918-6363-4849-8d74-e26822a0ddf7.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn. (Each of those creature can deal excess combat damage to the player or planeswalker it's attacking.)\nDraw a card.",
             "colours": [
@@ -22000,7 +22000,7 @@
         },
         {
             "id": "8a5427ab-e3c1-594d-9d0a-735ecd317c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5525cfde-a92b-4fb5-8f15-a05efebecd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5525cfde-a92b-4fb5-8f15-a05efebecd3d.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever this creature deals combat damage to a player, each player discards their hand, then draws seven cards.",
             "colours": [
@@ -22034,7 +22034,7 @@
         },
         {
             "id": "e12a6665-c806-531c-8d4a-eb1a99f3116d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b720f3a8-f38f-4460-86a3-dad541e7add7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b720f3a8-f38f-4460-86a3-dad541e7add7.jpg?1",
             "name": "Dragonmaster Outcast",
             "text": "At the beginning of your upkeep, if you control six or more lands, create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -22068,7 +22068,7 @@
         },
         {
             "id": "cc5c3acd-6233-5e25-a05d-5ba2f7fe399b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940d76d-c09f-4d72-a037-439c70ee8d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8940d76d-c09f-4d72-a037-439c70ee8d9d.jpg?1",
             "name": "Ghitu Lavarunner",
             "text": "As long as there are two or more instant and/or sorcery cards in your graveyard, this creature gets +1/+0 and has haste. (It can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -22102,7 +22102,7 @@
         },
         {
             "id": "e17b6c63-d871-5e6e-bd6c-275759e23159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f5298-0e57-49cf-aaf5-2bb16f3e636c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f5298-0e57-49cf-aaf5-2bb16f3e636c.jpg?1",
             "name": "Giant Cindermaw",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nPlayers can't gain life.",
             "colours": [
@@ -22136,7 +22136,7 @@
         },
         {
             "id": "87143714-e631-55f1-ace4-22eb5575e274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg?1",
             "name": "Harmless Offering",
             "text": "Target opponent gains control of target permanent you control.",
             "colours": [
@@ -22167,7 +22167,7 @@
         },
         {
             "id": "154beef4-7ea7-5fb7-bf03-09c1676a61e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a35b3b-0c92-4b40-8210-86a5b5f275eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a35b3b-0c92-4b40-8210-86a5b5f275eb.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen this creature enters, you may search your library for an artifact card, exile it, then shuffle.\nWhen this creature dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -22200,7 +22200,7 @@
         },
         {
             "id": "08b966cc-4bcf-5535-8248-6806a84e2b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409acb8f-cf03-4a56-a8c0-e4c97a01ee10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409acb8f-cf03-4a56-a8c0-e4c97a01ee10.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon you control enters, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -22235,7 +22235,7 @@
         },
         {
             "id": "1bc5eb5b-f42b-54c3-aefe-2b3c61b80dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8b3e58-be07-451e-a5c7-61c70cc3a5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8b3e58-be07-451e-a5c7-61c70cc3a5a2.jpg?1",
             "name": "Mindsparker",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever an opponent casts a white or blue instant or sorcery spell, this creature deals 2 damage to that player.",
             "colours": [
@@ -22268,7 +22268,7 @@
         },
         {
             "id": "187d91dd-cdcf-5956-9762-0ebbc0f29a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e836b-1c7b-43ac-889b-5f94e1638c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e836b-1c7b-43ac-889b-5f94e1638c42.jpg?1",
             "name": "Obliterating Bolt",
             "text": "Obliterating Bolt deals 4 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -22299,7 +22299,7 @@
         },
         {
             "id": "94e7f574-c99e-5267-bc24-a2eef376eae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b70c4-9086-4db4-8e65-f9bb5f67cf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b70c4-9086-4db4-8e65-f9bb5f67cf1b.jpg?1",
             "name": "Ravenous Giant",
             "text": "At the beginning of your upkeep, this creature deals 1 damage to you.",
             "colours": [
@@ -22332,7 +22332,7 @@
         },
         {
             "id": "a9a3fbc0-da68-57a9-9877-7a6f6c55744e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c7f55a-bcc7-4ca3-853d-fc6e260d9429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c7f55a-bcc7-4ca3-853d-fc6e260d9429.jpg?1",
             "name": "Redcap Gutter-Dweller",
             "text": "Menace\nWhen this creature enters, create two 1/1 black Rat creature tokens with \"This token can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature and exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -22366,7 +22366,7 @@
         },
         {
             "id": "ccd3c206-4b94-5df8-87ba-3726848dafe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f306c7e-cacc-4c26-a3f1-fad4f3ff7cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f306c7e-cacc-4c26-a3f1-fad4f3ff7cf3.jpg?1",
             "name": "Stromkirk Noble",
             "text": "This creature can't be blocked by Humans.\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -22400,7 +22400,7 @@
         },
         {
             "id": "cb54466e-31f8-5b9b-ae86-48ae126c97c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca7caa5-d920-4f06-90bd-214aa4e85cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca7caa5-d920-4f06-90bd-214aa4e85cb3.jpg?1",
             "name": "Taurean Mauler",
             "text": "Changeling (This card is every creature type.)\nWhenever an opponent casts a spell, you may put a +1/+1 counter on this creature.",
             "colours": [
@@ -22433,7 +22433,7 @@
         },
         {
             "id": "985f184a-f5a4-551f-9134-a37a94942bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f52ada2-cabc-46a3-99df-271833a86909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f52ada2-cabc-46a3-99df-271833a86909.jpg?1",
             "name": "Viashino Pyromancer",
             "text": "When this creature enters, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -22467,7 +22467,7 @@
         },
         {
             "id": "af74d5af-5dbe-55a8-88ed-35f47dca3623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a806dec2-d4f9-4f8d-a1dd-170777941131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a806dec2-d4f9-4f8d-a1dd-170777941131.jpg?1",
             "name": "Circuitous Route",
             "text": "Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22498,7 +22498,7 @@
         },
         {
             "id": "8ea9035b-1e52-5ebd-a5d3-606a4efc10bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1dd7f-2e42-4062-a941-b489b98a49fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1dd7f-2e42-4062-a941-b489b98a49fc.jpg?1",
             "name": "Fierce Empath",
             "text": "When this creature enters, you may search your library for a creature card with mana value 6 or greater, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -22531,7 +22531,7 @@
         },
         {
             "id": "1d8f0d5e-1f91-5d67-a205-8e8108fbc679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699efb9e-2649-432b-8b2d-10775114c314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699efb9e-2649-432b-8b2d-10775114c314.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -22567,7 +22567,7 @@
         },
         {
             "id": "8aeb31df-6916-5f49-9bd0-c7a22cb3b618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b638f3d-7eb6-4675-9538-4a87a7f75c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b638f3d-7eb6-4675-9538-4a87a7f75c43.jpg?1",
             "name": "Gnarlback Rhino",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever you cast a spell that targets this creature, draw a card.",
             "colours": [
@@ -22600,7 +22600,7 @@
         },
         {
             "id": "49c7504a-649d-5898-bf8b-6c7d9c66ed86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f83195c-5150-4763-a2e1-5b109d185d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f83195c-5150-4763-a2e1-5b109d185d55.jpg?1",
             "name": "Heroes' Bane",
             "text": "This creature enters with four +1/+1 counters on it.\n{2}{G}{G}: Put X +1/+1 counters on this creature, where X is its power.",
             "colours": [
@@ -22633,7 +22633,7 @@
         },
         {
             "id": "7e532c83-1a3c-56e1-8f25-b929fc47d42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d665cd-a2c6-4b81-8032-379e476b5ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d665cd-a2c6-4b81-8032-379e476b5ea5.jpg?1",
             "name": "Mold Adder",
             "text": "Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on this creature.",
             "colours": [
@@ -22667,7 +22667,7 @@
         },
         {
             "id": "238dcbbf-dc26-5900-a97e-b950f0dde4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a70424d-86a7-44a3-acda-4463d7ac503b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a70424d-86a7-44a3-acda-4463d7ac503b.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice this Aura.\nWhen you sacrifice this Aura, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22700,7 +22700,7 @@
         },
         {
             "id": "8fae94e6-68bf-5b24-9e84-dd9590d229ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a.jpg?1",
             "name": "Predator Ooze",
             "text": "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature.)\nWhenever this creature attacks, put a +1/+1 counter on it.\nWhenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature.",
             "colours": [
@@ -22733,7 +22733,7 @@
         },
         {
             "id": "87e2456d-2b52-5aba-8cb1-4f3b9c4a3446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae57d6b-15e8-4f2a-97c2-76d801a1a42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae57d6b-15e8-4f2a-97c2-76d801a1a42a.jpg?1",
             "name": "Primal Might",
             "text": "Target creature you control gets +X/+X until end of turn. Then it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -22764,7 +22764,7 @@
         },
         {
             "id": "e307dc72-3423-512d-8e1b-8e6940283979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332c9742-dc3b-48e5-8736-7724fae1b4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332c9742-dc3b-48e5-8736-7724fae1b4c4.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nLandfall \u2014 Whenever a land you control enters, you gain 3 life.",
             "colours": [
@@ -22795,7 +22795,7 @@
         },
         {
             "id": "295e6c98-ea41-5578-8777-94b81a35f3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25ee47b-d099-4788-9c2b-73d151bf56fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25ee47b-d099-4788-9c2b-73d151bf56fb.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land you control enters, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -22828,7 +22828,7 @@
         },
         {
             "id": "ad04875d-d329-5217-aca6-8d725e5db702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa87cb5f-4dc9-49a4-9ae6-ebc7fedac018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa87cb5f-4dc9-49a4-9ae6-ebc7fedac018.jpg?1",
             "name": "Springbloom Druid",
             "text": "When this creature enters, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -22862,7 +22862,7 @@
         },
         {
             "id": "e67ae3d8-f610-5f84-85d9-139de3804a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8759d-0dc8-4218-93ac-b1a35088f776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8759d-0dc8-4218-93ac-b1a35088f776.jpg?1",
             "name": "Surrak, the Hunt Caller",
             "text": "At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn. (It can attack and {T} no matter when it came under your control.)",
             "colours": [
@@ -22898,7 +22898,7 @@
         },
         {
             "id": "5c914fe7-5636-5ed9-8e78-30dd90d7c246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f8d876-3697-4359-9f2b-6053682b556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f8d876-3697-4359-9f2b-6053682b556c.jpg?1",
             "name": "Venom Connoisseur",
             "text": "Whenever another creature you control enters, this creature gains deathtouch until end of turn. If this is the second time this ability has resolved this turn, all creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -22932,7 +22932,7 @@
         },
         {
             "id": "bbd8960a-ffdb-5060-b4c1-7648bec3535f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3010ec33-c3f6-42ce-ad5a-e149e5c9a805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3010ec33-c3f6-42ce-ad5a-e149e5c9a805.jpg?1",
             "name": "Vizier of the Menagerie",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\nYou can spend mana of any type to cast creature spells.",
             "colours": [
@@ -22966,7 +22966,7 @@
         },
         {
             "id": "fddef846-406d-5529-a805-66d1fa459f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a249d1c-a5fe-48e5-bd9b-e50d8eea391b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a249d1c-a5fe-48e5-bd9b-e50d8eea391b.jpg?1",
             "name": "Wildborn Preserver",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nReach (This creature can block creatures with flying.)\nWhenever another non-Human creature you control enters, you may pay {X}. When you do, put X +1/+1 counters on this creature.",
             "colours": [
@@ -23000,7 +23000,7 @@
         },
         {
             "id": "2d4e0d3f-2c1d-5a17-b5f2-86baba0ddaf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ffc1c-575b-4116-83c9-d13b29886c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ffc1c-575b-4116-83c9-d13b29886c35.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -23037,7 +23037,7 @@
         },
         {
             "id": "0fd4d2f0-bfba-5be1-af85-14d605378f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06969031-2c13-4b5a-bb4e-86eed025e614.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06969031-2c13-4b5a-bb4e-86eed025e614.jpg?1",
             "name": "Ayli, Eternal Pilgrim",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.\n{1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate only if you have at least 10 life more than your starting life total.",
             "colours": [
@@ -23075,7 +23075,7 @@
         },
         {
             "id": "3f93d5ae-c27b-51a5-a181-884610b3a320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c966ab-0d92-4fa7-8a91-1f77089d8fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c966ab-0d92-4fa7-8a91-1f77089d8fc7.jpg?1",
             "name": "Cloudblazer",
             "text": "Flying\nWhen this creature enters, you gain 2 life and draw two cards.",
             "colours": [
@@ -23111,7 +23111,7 @@
         },
         {
             "id": "3e4e2e91-c8da-5f0f-af4e-c8b45eaf229a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd4d5a4-4342-49fb-b1e4-7d08e6cf5376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd4d5a4-4342-49fb-b1e4-7d08e6cf5376.jpg?1",
             "name": "Deadly Brew",
             "text": "Each player sacrifices a creature or planeswalker of their choice. If you sacrificed a permanent this way, you may return another permanent card from your graveyard to your hand.",
             "colours": [
@@ -23144,7 +23144,7 @@
         },
         {
             "id": "04248f06-df86-5b21-a65c-58a0ec2f2705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a4450c-8dfd-4d05-adb9-e84ec6066c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a4450c-8dfd-4d05-adb9-e84ec6066c7d.jpg?1",
             "name": "Drogskol Reaver",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhenever you gain life, draw a card.",
             "colours": [
@@ -23179,7 +23179,7 @@
         },
         {
             "id": "72972ff9-e3e5-5683-9f6a-88ad7008c8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb36712-26e9-4ec7-8946-626bb7094c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb36712-26e9-4ec7-8946-626bb7094c15.jpg?1",
             "name": "Dryad Militant",
             "text": "({RW} can be paid with either {G} or {W}.)\nIf an instant or sorcery card would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -23215,7 +23215,7 @@
         },
         {
             "id": "5aecd614-a32b-5d65-8b57-dd60f3714f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce1338-5a46-4d96-a991-d5fa8d4330ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ce1338-5a46-4d96-a991-d5fa8d4330ae.jpg?1",
             "name": "Enigma Drake",
             "text": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -23250,7 +23250,7 @@
         },
         {
             "id": "8de1e29f-9c6c-503e-86e4-a6aa91a4074d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7fcd03-fffe-467a-88a5-e583e32afd7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7fcd03-fffe-467a-88a5-e583e32afd7a.jpg?1",
             "name": "Garna, Bloodfist of Keld",
             "text": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna deals 1 damage to each opponent.",
             "colours": [
@@ -23288,7 +23288,7 @@
         },
         {
             "id": "be7e1056-ad91-50f2-b46a-70bdeee2a962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b649f459-c9dc-495d-8703-b685996bb80c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b649f459-c9dc-495d-8703-b685996bb80c.jpg?1",
             "name": "Halana and Alena, Partners",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nReach (This creature can block creatures with flying.)\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is Halana and Alena's power. That creature gains haste until end of turn.",
             "colours": [
@@ -23326,7 +23326,7 @@
         },
         {
             "id": "79b53a94-8921-51c2-8df6-49747709f459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dfc234-e87a-4594-8dcf-0a2f95eedc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52dfc234-e87a-4594-8dcf-0a2f95eedc97.jpg?1",
             "name": "Immersturm Predator",
             "text": "Flying\nWhenever this creature becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on this creature.\nSacrifice another creature: This creature gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -23362,7 +23362,7 @@
         },
         {
             "id": "e2c1ac61-f4b1-513e-b279-d46cca1034bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e8d47-a086-4e9f-8130-8c3b2dc50179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e8d47-a086-4e9f-8130-8c3b2dc50179.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -23395,7 +23395,7 @@
         },
         {
             "id": "0a7de96a-8e98-5ed3-90fc-2af6cf78e0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e85619-3a7d-48c2-b9b0-20718c913696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e85619-3a7d-48c2-b9b0-20718c913696.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -23428,7 +23428,7 @@
         },
         {
             "id": "3b15b465-0c5d-54f1-bd6b-86838e6817f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54819d7a-eec6-49e6-a0bb-d9d07d42b4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54819d7a-eec6-49e6-a0bb-d9d07d42b4a6.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "Flying\nWard\u2014{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
             "colours": [
@@ -23466,7 +23466,7 @@
         },
         {
             "id": "2a0644d0-23e7-5481-9783-4c56e1a0f99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f007b0-b578-44f8-be65-cd9e2ac56e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f007b0-b578-44f8-be65-cd9e2ac56e09.jpg?1",
             "name": "Prime Speaker Zegana",
             "text": "Prime Speaker Zegana enters with X +1/+1 counters on it, where X is the greatest power among other creatures you control.\nWhen Prime Speaker Zegana enters, draw cards equal to its power.",
             "colours": [
@@ -23504,7 +23504,7 @@
         },
         {
             "id": "0d0475b5-46b5-5802-ab56-918c1233c7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50027d69-8bb0-444c-8e9b-4c9afd91cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50027d69-8bb0-444c-8e9b-4c9afd91cbda.jpg?1",
             "name": "Savage Ventmaw",
             "text": "Flying\nWhenever this creature attacks, add {R}{R}{R}{G}{G}{G}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -23539,7 +23539,7 @@
         },
         {
             "id": "a5f49c01-81b4-53a9-bd15-297554148263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516baae5-f7bf-4a90-a80d-192ff19dbae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516baae5-f7bf-4a90-a80d-192ff19dbae5.jpg?1",
             "name": "Teach by Example",
             "text": "({UR} can be paid with either {U} or {R}.)\nWhen you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -23572,7 +23572,7 @@
         },
         {
             "id": "957116b3-c28b-5c99-a239-cab4154698d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb88a22-8086-4bf7-89e8-cce929440dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb88a22-8086-4bf7-89e8-cce929440dd8.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever this creature deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -23607,7 +23607,7 @@
         },
         {
             "id": "10c100dc-dd35-5516-8f7f-5cfb03e7fc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d383bbf-6bb1-4c2c-899b-65d8df9d0889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d383bbf-6bb1-4c2c-899b-65d8df9d0889.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "({RW} can be paid with either {G} or {W}.)\nOther green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard this card, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -23643,7 +23643,7 @@
         },
         {
             "id": "1ecd6350-bc4d-52fc-a1bf-bf8ba079c76f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b36fba7-71f7-4b7f-bde5-b3a9752ad21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b36fba7-71f7-4b7f-bde5-b3a9752ad21c.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink. (Any amount of damage it deals to a creature is enough to destroy it. Damage dealt by this creature also causes you to gain that much life.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -23672,7 +23672,7 @@
         },
         {
             "id": "013893d0-9c04-547e-bff0-32d14eff6056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249aa94c-85ab-4606-aa2c-c902bd83ac21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249aa94c-85ab-4606-aa2c-c902bd83ac21.jpg?1",
             "name": "Cultivator's Caravan",
             "text": "{T}: Add one mana of any color.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -23701,7 +23701,7 @@
         },
         {
             "id": "fc7b35ff-806d-55a8-8b9f-86462f79abda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70197723-c61b-4600-b61d-41380c8f3067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70197723-c61b-4600-b61d-41380c8f3067.jpg?1",
             "name": "Darksteel Colossus",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nIndestructible (Damage and effects that say \"destroy\" don't destroy this creature.)\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -23731,7 +23731,7 @@
         },
         {
             "id": "3738b140-ba04-5b58-b739-e20732895617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721463ad-9531-487f-bd82-5e638c4fc35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721463ad-9531-487f-bd82-5e638c4fc35f.jpg?1",
             "name": "Diamond Mare",
             "text": "",
             "colours": [],
@@ -23761,7 +23761,7 @@
         },
         {
             "id": "4cb4a4b6-2a8d-5fd8-a71b-ef16aa91cb01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f55c3-8e65-4520-b26d-6208344f73b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f55c3-8e65-4520-b26d-6208344f73b2.jpg?1",
             "name": "Feldon's Cane",
             "text": "{T}, Exile this artifact: Shuffle your graveyard into your library.",
             "colours": [],
@@ -23788,7 +23788,7 @@
         },
         {
             "id": "280223fb-1780-5418-895a-f6af6fe285ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484fbce6-71bd-40eb-a71b-86958a094708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484fbce6-71bd-40eb-a71b-86958a094708.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -23817,7 +23817,7 @@
         },
         {
             "id": "8e20473c-9534-5760-bc2b-986d3c5ad789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc49d9cb-8c7a-4a8f-96ea-bbe6ade8ae00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc49d9cb-8c7a-4a8f-96ea-bbe6ade8ae00.jpg?1",
             "name": "Gate Colossus",
             "text": "This spell costs {1} less to cast for each Gate you control.\nThis creature can't be blocked by creatures with power 2 or less.\nWhenever a Gate you control enters, you may put this card from your graveyard on top of your library.",
             "colours": [],
@@ -23847,7 +23847,7 @@
         },
         {
             "id": "fbb8a1b2-cdba-56fb-9575-e09a54fd83ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45072cd-e3f2-4090-b984-50ec8d360bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45072cd-e3f2-4090-b984-50ec8d360bf2.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on this artifact: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{2}, {T}, Put a page counter on this artifact: Draw a card.\nWhen there are four or more page counters on this artifact, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -23874,7 +23874,7 @@
         },
         {
             "id": "82dfd914-6d49-5ca8-b4e3-3a6456180bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340d8a4-196a-4433-807c-b7124e96e44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f340d8a4-196a-4433-807c-b7124e96e44f.jpg?1",
             "name": "Pyromancer's Goggles",
             "text": "",
             "colours": [],
@@ -23905,7 +23905,7 @@
         },
         {
             "id": "9156339c-70f5-5972-ad6b-89a44a72a5ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f95f753-bbaa-4282-9cd9-f1737136fc9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f95f753-bbaa-4282-9cd9-f1737136fc9e.jpg?1",
             "name": "Ramos, Dragon Engine",
             "text": "Flying\nWhenever you cast a spell, put a +1/+1 counter on Ramos for each of that spell's colors.\nRemove five +1/+1 counters from Ramos: Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Activate only once each turn.",
             "colours": [],
@@ -23943,7 +23943,7 @@
         },
         {
             "id": "5513361c-0f1b-54f7-b72b-b9e5fecd0f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99356b-eed0-4d92-818b-80754bcb75f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f99356b-eed0-4d92-818b-80754bcb75f3.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As this artifact enters, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -23970,7 +23970,7 @@
         },
         {
             "id": "e017d45b-d0c8-51da-9c96-c8390fe4eefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3ff537-86f0-405e-b96b-1250720af031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3ff537-86f0-405e-b96b-1250720af031.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "When this artifact enters, exile target card from a graveyard.\n{T}, Sacrifice this artifact: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice this artifact: Draw a card.",
             "colours": [],
@@ -23997,7 +23997,7 @@
         },
         {
             "id": "95dcd8a5-2712-58ab-88be-035aa61bb181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931ad21b-a6bb-4a89-8d6f-80adfcf126c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931ad21b-a6bb-4a89-8d6f-80adfcf126c7.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: This creature gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with mana value X whose controller was dealt combat damage by this creature this turn. Activate only once each turn.",
             "colours": [],
@@ -24027,7 +24027,7 @@
         },
         {
             "id": "a42d2a93-d4be-511f-bcc5-d34e2d3df0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b8bf3a-1cb5-4ce2-ac25-9410f17130de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b8bf3a-1cb5-4ce2-ac25-9410f17130de.jpg?1",
             "name": "Three Tree Mascot",
             "text": "Changeling (This card is every creature type.)\n{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -24057,7 +24057,7 @@
         },
         {
             "id": "dda52b4e-b7c6-582f-8c0a-3c7510e3e929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a7264-0a83-42c8-a94d-05ad4c234242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98a7264-0a83-42c8-a94d-05ad4c234242.jpg?1",
             "name": "Azorius Guildgate",
             "text": "This land enters tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -24089,7 +24089,7 @@
         },
         {
             "id": "d016d703-0605-524d-91f7-b197242a72c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3c74ea-40e9-4ad9-a491-c208403b68ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3c74ea-40e9-4ad9-a491-c208403b68ad.jpg?1",
             "name": "Boros Guildgate",
             "text": "This land enters tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -24121,7 +24121,7 @@
         },
         {
             "id": "b2f651b5-d206-5a4d-8764-7e4ceb317358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2aff0e-1319-4d3b-903c-fa1ce3db7602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2aff0e-1319-4d3b-903c-fa1ce3db7602.jpg?1",
             "name": "Crawling Barrens",
             "text": "{T}: Add {C}.\n{4}: Put two +1/+1 counters on this land. Then you may have it become a 0/0 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -24148,7 +24148,7 @@
         },
         {
             "id": "e54241c8-6f31-50fa-8ed4-1fcbfa8c3400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7976098-b560-458a-ad3c-18f7873add21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7976098-b560-458a-ad3c-18f7873add21.jpg?1",
             "name": "Cryptic Caves",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands.",
             "colours": [],
@@ -24175,7 +24175,7 @@
         },
         {
             "id": "b0bc4aaf-ef5d-55d5-878b-b4f2f77d2a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7e51b6-4898-4632-b39c-3ce438caa882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7e51b6-4898-4632-b39c-3ce438caa882.jpg?1",
             "name": "Demolition Field",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. That land's controller may search their library for a basic land card, put it onto the battlefield, then shuffle. You may search your library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -24202,7 +24202,7 @@
         },
         {
             "id": "5aef3ea6-54e2-5cfb-9c55-c2afc2bb6169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8a159-5e58-4432-8ecd-62f39afa96da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b8a159-5e58-4432-8ecd-62f39afa96da.jpg?1",
             "name": "Dimir Guildgate",
             "text": "This land enters tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -24234,7 +24234,7 @@
         },
         {
             "id": "aabb9bce-ac0d-5093-ae0a-62a8447d69ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d4646c-a375-4835-aa58-8bb77d1a5abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d4646c-a375-4835-aa58-8bb77d1a5abf.jpg?1",
             "name": "Golgari Guildgate",
             "text": "This land enters tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -24266,7 +24266,7 @@
         },
         {
             "id": "07a862b1-ccc2-5898-8cb7-59c0bebf0b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab6c240-c97d-4a5c-bc39-860c2d9901c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab6c240-c97d-4a5c-bc39-860c2d9901c2.jpg?1",
             "name": "Gruul Guildgate",
             "text": "This land enters tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -24298,7 +24298,7 @@
         },
         {
             "id": "c28c2f78-bb82-5e72-8672-ab56ecf949a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9e6fc9-813d-4a71-8a68-8e0f83fa945d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9e6fc9-813d-4a71-8a68-8e0f83fa945d.jpg?1",
             "name": "Izzet Guildgate",
             "text": "",
             "colours": [],
@@ -24330,7 +24330,7 @@
         },
         {
             "id": "0fef10c3-7543-5d46-8732-38772aa1022f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a917be03-0c17-4454-b044-c4375e5c8085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a917be03-0c17-4454-b044-c4375e5c8085.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "This land enters tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -24362,7 +24362,7 @@
         },
         {
             "id": "6bdd5b9d-bf46-5444-bca8-57da44ba193e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f01964-c610-4d0f-a2b4-f52e46dc50d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f01964-c610-4d0f-a2b4-f52e46dc50d2.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "This land enters tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -24394,7 +24394,7 @@
         },
         {
             "id": "190d0cb3-f517-5e22-8c0a-60223f160946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6718d4e7-768e-473f-8064-a68422e977f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6718d4e7-768e-473f-8064-a68422e977f6.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "This land enters tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -24426,7 +24426,7 @@
         },
         {
             "id": "5fab4ae5-a4b8-576c-8920-041e348c62e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96590855-1ee5-4d69-9070-776e23f71976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96590855-1ee5-4d69-9070-776e23f71976.jpg?1",
             "name": "Simic Guildgate",
             "text": "This land enters tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -24458,7 +24458,7 @@
         },
         {
             "id": "2ed37817-9a74-5a98-a0a7-2176a6b592dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a990a92-8d0f-489f-ae97-68c90fc5ccf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a990a92-8d0f-489f-ae97-68c90fc5ccf1.jpg?1",
             "name": "Temple of Abandon",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -24488,7 +24488,7 @@
         },
         {
             "id": "15b9bfac-2443-5372-8cca-4c976a74fc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18748ce-e52e-4cd1-89d4-cd2578a0d574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18748ce-e52e-4cd1-89d4-cd2578a0d574.jpg?1",
             "name": "Temple of Deceit",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -24518,7 +24518,7 @@
         },
         {
             "id": "da49d26f-84c2-5f96-b7ac-cfaa40bf5234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f23c1a-a0fe-4520-88ed-045aa4044567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f23c1a-a0fe-4520-88ed-045aa4044567.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -24548,7 +24548,7 @@
         },
         {
             "id": "c6a3b8ce-bd36-5102-9cec-84d0a73c52fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224e8255-7bc6-44a2-86af-14f8446f4f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224e8255-7bc6-44a2-86af-14f8446f4f77.jpg?1",
             "name": "Temple of Epiphany",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -24578,7 +24578,7 @@
         },
         {
             "id": "0e1004b0-d1eb-5418-9e25-397ea0080b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e7d0d5-2329-42a6-b6ff-a5197ba5f1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e7d0d5-2329-42a6-b6ff-a5197ba5f1d0.jpg?1",
             "name": "Temple of Malady",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -24608,7 +24608,7 @@
         },
         {
             "id": "aacae80d-5043-5351-88a3-6d8d2d1014b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78eccc4-1500-43f1-94f5-b39c160b6381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78eccc4-1500-43f1-94f5-b39c160b6381.jpg?1",
             "name": "Temple of Malice",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -24638,7 +24638,7 @@
         },
         {
             "id": "fada3b60-6e13-5c68-ae38-5e4c76616c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd581f1d-d8ba-47f9-b10b-b7b6d46239ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd581f1d-d8ba-47f9-b10b-b7b6d46239ce.jpg?1",
             "name": "Temple of Mystery",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -24668,7 +24668,7 @@
         },
         {
             "id": "92bdc206-9682-5980-9cd9-fcd6e1c8f11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69762774-c8e1-42de-90b3-5a4d50f5d84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69762774-c8e1-42de-90b3-5a4d50f5d84d.jpg?1",
             "name": "Temple of Plenty",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -24698,7 +24698,7 @@
         },
         {
             "id": "35affd4b-e640-500e-9930-c143acdca0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408ad759-052a-4949-9adf-7541cb2ef77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408ad759-052a-4949-9adf-7541cb2ef77e.jpg?1",
             "name": "Temple of Silence",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -24728,7 +24728,7 @@
         },
         {
             "id": "97bf0d3f-8cbe-5b83-9bb3-d2a97549cfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f58450-838d-4404-a68f-159e82b0e58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f58450-838d-4404-a68f-159e82b0e58d.jpg?1",
             "name": "Temple of Triumph",
             "text": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -24758,7 +24758,7 @@
         },
         {
             "id": "029fd302-0a81-5b08-9280-ef4a25f4c4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c279947e-168f-4af5-902b-aba724f52b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c279947e-168f-4af5-902b-aba724f52b8a.jpg?1",
             "name": "Angel of Vitality",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nThis creature gets +2/+2 as long as you have 25 or more life.",
             "colours": [
@@ -24791,7 +24791,7 @@
         },
         {
             "id": "f0bc94df-5988-59cb-9db6-bcc600b76847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2abce4d-ef21-4028-8a86-b7d1387bc937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2abce4d-ef21-4028-8a86-b7d1387bc937.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -24826,7 +24826,7 @@
         },
         {
             "id": "fa4984dd-caa9-5feb-af2a-32e7b927b5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c26415d-9e98-480b-9e30-b3aed00d5f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c26415d-9e98-480b-9e30-b3aed00d5f3d.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -24857,7 +24857,7 @@
         },
         {
             "id": "4cc75136-a516-5410-b86c-c3a6e524ad00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a1553-e5f3-4c9c-833d-579e82e1708f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a1553-e5f3-4c9c-833d-579e82e1708f.jpg?1",
             "name": "Confiscate",
             "text": "Enchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -24890,7 +24890,7 @@
         },
         {
             "id": "bfc41f58-7eec-58d9-b843-37c417e37692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3b0dba-0207-4249-bdab-e807c76ce39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3b0dba-0207-4249-bdab-e807c76ce39e.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -24921,7 +24921,7 @@
         },
         {
             "id": "50cc768a-ebee-5491-b98b-ad14c1b506ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe98958d-30ee-4a47-aacc-064e02d109b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe98958d-30ee-4a47-aacc-064e02d109b3.jpg?1",
             "name": "Rite of Replication",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a token that's a copy of target creature. If this spell was kicked, create five of those tokens instead.",
             "colours": [
@@ -24952,7 +24952,7 @@
         },
         {
             "id": "46f98852-e2d0-582d-9481-ad3f1d59a562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d4541-160c-4137-98e7-0eaa692c7d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d4541-160c-4137-98e7-0eaa692c7d7a.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
             "colours": [
@@ -24983,7 +24983,7 @@
         },
         {
             "id": "83b8d3ab-37ca-521e-ab9c-7905b5b612d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd61c12-f5e2-4698-9080-097679754f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd61c12-f5e2-4698-9080-097679754f16.jpg?1",
             "name": "Gatekeeper of Malakir",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen this creature enters, if it was kicked, target player sacrifices a creature of their choice.",
             "colours": [
@@ -25017,7 +25017,7 @@
         },
         {
             "id": "f2b47362-28da-5f69-b5da-c45446920385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39be2675-986c-4812-9448-99737e797671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39be2675-986c-4812-9448-99737e797671.jpg?1",
             "name": "Massacre Wurm",
             "text": "When this creature enters, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -25051,7 +25051,7 @@
         },
         {
             "id": "0b3c496d-9650-5c2c-a6d2-6727d9cdae25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89024c5-eef5-468c-92b4-e53dd212909c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89024c5-eef5-468c-92b4-e53dd212909c.jpg?1",
             "name": "Gratuitous Violence",
             "text": "If a creature you control would deal damage to a permanent or player, it deals double that damage instead.",
             "colours": [
@@ -25082,7 +25082,7 @@
         },
         {
             "id": "22638c1e-1a01-567b-83af-6be4c84fb32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde674d6-f4e7-410b-acf0-34021290576d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde674d6-f4e7-410b-acf0-34021290576d.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, this creature deals 2 damage to each opponent.",
             "colours": [
@@ -25116,7 +25116,7 @@
         },
         {
             "id": "4ee957fd-079e-51cc-b737-39bf63af9b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b7cecf-b51b-4d30-b7e9-cd7976271e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b7cecf-b51b-4d30-b7e9-cd7976271e07.jpg?1",
             "name": "Impact Tremors",
             "text": "Whenever a creature you control enters, this enchantment deals 1 damage to each opponent.",
             "colours": [
@@ -25147,7 +25147,7 @@
         },
         {
             "id": "8dbbb3cf-5e03-5138-a2d9-857e81bd9923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1c518a-dcb4-407c-85be-ed5935a24198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1c518a-dcb4-407c-85be-ed5935a24198.jpg?1",
             "name": "Gigantosaurus",
             "text": "",
             "colours": [
@@ -25180,7 +25180,7 @@
         },
         {
             "id": "76d02e6d-e8db-5571-9a37-5acc3dd01b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b4a09f-ea53-42b4-a41a-4299192a6fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b4a09f-ea53-42b4-a41a-4299192a6fd3.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elves you control get +1/+1.\n{G}, {T}: Create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -25214,7 +25214,7 @@
         },
         {
             "id": "c1cec8e3-7dc0-5593-a5d3-34d0add3e8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa150070-80b6-453d-b00f-4462175cac79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa150070-80b6-453d-b00f-4462175cac79.jpg?1",
             "name": "Pelakka Wurm",
             "text": "",
             "colours": [
@@ -25247,7 +25247,7 @@
         },
         {
             "id": "6963f7ba-c820-5d37-8868-06e9b60e196a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d8c9f6-cbbd-4694-b100-01cfb81036cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d8c9f6-cbbd-4694-b100-01cfb81036cc.jpg?1",
             "name": "Boros Charm",
             "text": "",
             "colours": [
@@ -25280,7 +25280,7 @@
         },
         {
             "id": "eab953e3-68e2-5aed-9d6a-64bb027aad53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1201875-b3d8-4f95-801e-bf18ee77919b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1201875-b3d8-4f95-801e-bf18ee77919b.jpg?1",
             "name": "Unflinching Courage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample and lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -25315,7 +25315,7 @@
         },
         {
             "id": "4feb5911-355b-5ef7-9f30-3441e4430052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35e614c-51a9-4d5c-b7fa-1a0a87108785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35e614c-51a9-4d5c-b7fa-1a0a87108785.jpg?1",
             "name": "Adaptive Automaton",
             "text": "As this creature enters, choose a creature type.\nThis creature is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -25345,7 +25345,7 @@
         },
         {
             "id": "81a772ac-1ea7-5f9e-85f3-1c4e06b167ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e66835-c228-48fa-bcaa-eb96edbd4f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e66835-c228-48fa-bcaa-eb96edbd4f5a.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice this artifact: Search your library for a land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -25372,7 +25372,7 @@
         },
         {
             "id": "89aab41d-837c-5135-a91f-2fde25bf7765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5e88f1-0ddf-45d7-bbd0-baa88d121867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5e88f1-0ddf-45d7-bbd0-baa88d121867.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color.",
             "colours": [],
@@ -25399,7 +25399,7 @@
         },
         {
             "id": "0bc775e8-418c-506c-b00b-705ede9bc584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b9ac6-dba2-4162-86ed-df3e9fad0306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535b9ac6-dba2-4162-86ed-df3e9fad0306.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice this artifact: Draw two cards.",
             "colours": [],
@@ -25426,7 +25426,7 @@
         },
         {
             "id": "485ad0e8-dcc5-54d0-86a6-62df8b5461c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a4d1a-79dd-4b15-8e3b-f111f16d6bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a4d1a-79dd-4b15-8e3b-f111f16d6bfc.jpg?1",
             "name": "Maze's End",
             "text": "This land enters tapped.\n{T}: Add {C}.\n{3}, {T}, Return this land to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle. If you control ten or more Gates with different names, you win the game.",
             "colours": [],
@@ -25453,7 +25453,7 @@
         },
         {
             "id": "bb58388f-7e51-5d0e-b090-53261227457d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d28b7-1e56-428d-84a7-0eb6a2b5efda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d28b7-1e56-428d-84a7-0eb6a2b5efda.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -25488,7 +25488,7 @@
         },
         {
             "id": "ee0352c4-2c04-50df-b60d-d98ce400457d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aae48-a783-468d-aa14-552307ec2021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89aae48-a783-468d-aa14-552307ec2021.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When this creature enters, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen this creature dies, you may draw a card.",
             "colours": [],
@@ -25520,7 +25520,7 @@
         },
         {
             "id": "c7125740-84ed-5723-9349-8c44592b0a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632df69e-6377-43d0-bba5-65518a320aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632df69e-6377-43d0-bba5-65518a320aa5.jpg?1",
             "name": "Hinterland Sanctifier",
             "text": "Whenever another creature you control enters, you gain 1 life.",
             "colours": [
@@ -25555,7 +25555,7 @@
         },
         {
             "id": "a8f27148-ffb9-5e5d-aad4-9c8df30fff28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -25590,7 +25590,7 @@
         },
         {
             "id": "4983cf20-03e7-5f8d-a817-2d69acc1db5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16213b5-c0da-4a24-9f2e-b9432652859e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16213b5-c0da-4a24-9f2e-b9432652859e.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -25625,7 +25625,7 @@
         },
         {
             "id": "402d3eb7-f758-5f33-851b-3658e5e454e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06af3d5a-7b38-42f6-822f-da4e04a7f265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06af3d5a-7b38-42f6-822f-da4e04a7f265.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -25660,7 +25660,7 @@
         },
         {
             "id": "1093d137-4954-50d5-84c4-de2d86400ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d287806-07bb-4709-9260-b9ef34fe2a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d287806-07bb-4709-9260-b9ef34fe2a13.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -25695,7 +25695,7 @@
         },
         {
             "id": "9e6b66e9-f17f-5985-a9a9-30d0f919fe5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ae4f9c-ad6e-4d6a-89f1-653916bf5373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ae4f9c-ad6e-4d6a-89f1-653916bf5373.jpg?1",
             "name": "Rabbit",
             "text": "",
             "colours": [
@@ -25730,7 +25730,7 @@
         },
         {
             "id": "933197f0-b11c-50eb-9d03-d393b683e392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d093322e-a717-4e2d-8199-fa560792bcf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d093322e-a717-4e2d-8199-fa560792bcf6.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -25765,7 +25765,7 @@
         },
         {
             "id": "1e59b4ed-5f6e-57f1-9e1c-06282af80df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278adad2-49a6-4baa-8dbe-93474545eef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278adad2-49a6-4baa-8dbe-93474545eef7.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -25800,7 +25800,7 @@
         },
         {
             "id": "e86fefb7-38d9-58a6-94bc-102738bfd02b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a73034-e20f-4e7e-ac15-3460b1e9c69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a73034-e20f-4e7e-ac15-3460b1e9c69b.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -25835,7 +25835,7 @@
         },
         {
             "id": "b04a1625-27ea-55b7-9c1e-8988f4f71ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1",
             "name": "Faerie",
             "text": "",
             "colours": [
@@ -25870,7 +25870,7 @@
         },
         {
             "id": "de757afa-42be-5403-b98c-4ef9f3ef6ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44057462-40b7-4709-afac-2ce03d53d525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44057462-40b7-4709-afac-2ce03d53d525.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -25905,7 +25905,7 @@
         },
         {
             "id": "dc6cc014-7de9-55dd-8880-9bed7737775d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef25434-cd23-4dcf-b77e-36e648a8de23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef25434-cd23-4dcf-b77e-36e648a8de23.jpg?1",
             "name": "Koma's Coil",
             "text": "",
             "colours": [
@@ -25940,7 +25940,7 @@
         },
         {
             "id": "aceee0e0-4feb-53a8-a993-3385c20a2e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg?1",
             "name": "Ninja",
             "text": "",
             "colours": [
@@ -25975,7 +25975,7 @@
         },
         {
             "id": "d2eacb19-81f4-5484-864f-d20c70285496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c478f7-b426-4055-8d06-e5782226c826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c478f7-b426-4055-8d06-e5782226c826.jpg?1",
             "name": "Scion of the Deep",
             "text": "",
             "colours": [],
@@ -26008,7 +26008,7 @@
         },
         {
             "id": "8fc2ba1b-74e5-57f1-9ce7-1bee912bb474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad84b0-2bbf-479c-ae46-f725892d04d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad84b0-2bbf-479c-ae46-f725892d04d1.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -26043,7 +26043,7 @@
         },
         {
             "id": "e8918ec2-32fe-5ef5-a5aa-5c578794d5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29a360b-11fd-42ba-82ba-de8f7e136c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29a360b-11fd-42ba-82ba-de8f7e136c20.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -26078,7 +26078,7 @@
         },
         {
             "id": "637ba3b8-013c-5bd4-81a4-5ac52f4b05be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c6be20-b65a-4b1e-8133-4c2d88c1f6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c6be20-b65a-4b1e-8133-4c2d88c1f6f9.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -26113,7 +26113,7 @@
         },
         {
             "id": "1600e7fe-a629-50ea-9c4a-95c468f82f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d4dd3b-0a5f-4d2c-aa6b-3c47e71e8c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d4dd3b-0a5f-4d2c-aa6b-3c47e71e8c39.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -26148,7 +26148,7 @@
         },
         {
             "id": "c1c03878-08f8-5419-a688-6af5f5dce8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -26183,7 +26183,7 @@
         },
         {
             "id": "73b705e5-0868-50dc-aff2-73f0d36de975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c45f4-7bc9-45d5-bbf5-2533cf80af60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c45f4-7bc9-45d5-bbf5-2533cf80af60.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -26219,7 +26219,7 @@
         },
         {
             "id": "d971e0cc-d6c0-5778-8c33-1385ace5d6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d8730-d6bd-4525-96e9-0513ed02de37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d8730-d6bd-4525-96e9-0513ed02de37.jpg?1",
             "name": "Raccoon",
             "text": "",
             "colours": [
@@ -26254,7 +26254,7 @@
         },
         {
             "id": "8db2b86f-81e5-51c7-812a-532fef7b2acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c2cbd7-79bb-4d93-b2b6-5d3abe88a012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c2cbd7-79bb-4d93-b2b6-5d3abe88a012.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -26291,7 +26291,7 @@
         },
         {
             "id": "e097be71-8e76-516b-9764-7e93746e0d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1077f8-9e2a-4155-a7f0-4604bc0f94e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1077f8-9e2a-4155-a7f0-4604bc0f94e8.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -26322,7 +26322,7 @@
         },
         {
             "id": "9b7b8d88-0042-548c-a8dd-18089528b064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21210145-8edd-41f5-9a64-9f0b5be79864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21210145-8edd-41f5-9a64-9f0b5be79864.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -26353,7 +26353,7 @@
         },
         {
             "id": "a4f50f82-9b71-53fc-b719-3c50bb1ab393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4b1d5-f252-48fe-b4a1-7fbbc2523cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4b1d5-f252-48fe-b4a1-7fbbc2523cf1.jpg?1",
             "name": "Kaito, Cunning Infiltrator Emblem",
             "text": "",
             "colours": [],
@@ -26381,7 +26381,7 @@
         },
         {
             "id": "6ce46d45-a445-5567-9852-53a3040d5769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804d502-1092-4ff3-93d9-d1b0ac0f07d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804d502-1092-4ff3-93d9-d1b0ac0f07d5.jpg?1",
             "name": "Vivien Reid Emblem",
             "text": "",
             "colours": [],
@@ -26411,7 +26411,7 @@
         },
         {
             "id": "7f30de76-415e-5a5c-987d-a51686e4e4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc586e46-b7d0-4c84-8678-3542cd390de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc586e46-b7d0-4c84-8678-3542cd390de1.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -26439,7 +26439,7 @@
         },
         {
             "id": "1e6cce59-0cd2-56ea-94a3-452a0b4c7714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86701490-17ac-4253-810d-6cfd7a46594c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86701490-17ac-4253-810d-6cfd7a46594c.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -26474,7 +26474,7 @@
         },
         {
             "id": "2856c4fb-893c-5600-800f-2f1327f1ccc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322ef76e-e0f0-48d7-a6ad-5d4c1c9ccb2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322ef76e-e0f0-48d7-a6ad-5d4c1c9ccb2e.jpg?1",
             "name": "Cat Beast",
             "text": "",
             "colours": [
@@ -26510,7 +26510,7 @@
         },
         {
             "id": "fc2a3b16-ac9a-5eed-acb8-155f61615a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8da5b2-7e02-494b-8686-c5845286d0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8da5b2-7e02-494b-8686-c5845286d0b9.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -26545,7 +26545,7 @@
         },
         {
             "id": "1bff76b1-3db7-5b9c-af6a-0c9759ac4f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384238b-cffb-4946-96de-dc6b7a37b979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7384238b-cffb-4946-96de-dc6b7a37b979.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -26580,7 +26580,7 @@
         },
         {
             "id": "6e30de50-4851-5313-b1e3-eda8a0ef4027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e437a1-6d74-4006-8598-06284444c837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e437a1-6d74-4006-8598-06284444c837.jpg?1",
             "name": "Phyrexian Goblin",
             "text": "",
             "colours": [
@@ -26616,7 +26616,7 @@
         },
         {
             "id": "a044bb73-0342-5a84-985b-6526bf1e019f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca697323-bdc8-4fa0-a0ba-c2dd4deff68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca697323-bdc8-4fa0-a0ba-c2dd4deff68c.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -26651,7 +26651,7 @@
         },
         {
             "id": "97c5c865-86c4-5aac-8837-1caf9695383f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bd6fb3-f60c-49cc-8854-6a20a1e1d9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21bd6fb3-f60c-49cc-8854-6a20a1e1d9c7.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/FEM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/FEM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "262937ec-a425-589c-b17f-2d3e3eaf5c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfd96cb-03d6-4845-8595-50bf17b35726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfd96cb-03d6-4845-8595-50bf17b35726.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -43,7 +43,7 @@
         },
         {
             "id": "eb70eac4-88b1-5b5a-9fc1-fca34169202f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a324a98-31c2-470a-b792-96b6b098a58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a324a98-31c2-470a-b792-96b6b098a58c.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -82,7 +82,7 @@
         },
         {
             "id": "a7b0225d-8757-5605-82fd-14dfe6e1c7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9d1eac-3ac2-4881-a984-e40d87f60784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9d1eac-3ac2-4881-a984-e40d87f60784.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -121,7 +121,7 @@
         },
         {
             "id": "3a0aff41-d9ba-5ea9-9019-2935b3ab876b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26c079-61ea-436d-89ae-2f1c6f863e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26c079-61ea-436d-89ae-2f1c6f863e91.jpg?1",
             "name": "Combat Medic",
             "text": "o1oo\nW Prevent 1 damage to any player or creature.",
             "colours": [
@@ -160,7 +160,7 @@
         },
         {
             "id": "886243d9-b1c6-5f02-856a-e3902afcdbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af092da3-8713-4a59-86d3-827b942d6456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af092da3-8713-4a59-86d3-827b942d6456.jpg?1",
             "name": "Farrel's Mantle",
             "text": "If target creature attacks and is not blocked, it may deal X+2 damage to any other target creature, where X is the power of the creature Farrel's Mantle enchants. If it does so, it deals no damage to opponent this turn.",
             "colours": [
@@ -193,7 +193,7 @@
         },
         {
             "id": "640616ed-08b8-55d3-99b1-37187266e1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0401bd23-9f81-40b7-a6c2-e3f9847d175c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0401bd23-9f81-40b7-a6c2-e3f9847d175c.jpg?1",
             "name": "Farrel's Zealot",
             "text": "If Farrel's Zealot attacks and is not blocked, you may choose to have it deal 3 damage to a target creature. If you do so, it deals no damage to opponent this turn.",
             "colours": [
@@ -229,7 +229,7 @@
         },
         {
             "id": "1e587134-cb92-5383-b893-43e5f1da1ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3aeee7-975c-419a-bfb3-45bb48ba6918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3aeee7-975c-419a-bfb3-45bb48ba6918.jpg?1",
             "name": "Farrel's Zealot",
             "text": "If Farrel's Zealot attacks and is not blocked, you may choose to have it deal 3 damage to a target creature. If you do so, it deals no damage to opponent this turn.",
             "colours": [
@@ -265,7 +265,7 @@
         },
         {
             "id": "33a36fb1-9886-52ea-9c1a-d9ac0b2bc19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54252fd2-21a6-40d1-8515-697f18c78a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54252fd2-21a6-40d1-8515-697f18c78a06.jpg?1",
             "name": "Farrel's Zealot",
             "text": "If Farrel's Zealot attacks and is not blocked, you may choose to have it deal 3 damage to a target creature. If you do so, it deals no damage to opponent this turn.",
             "colours": [
@@ -301,7 +301,7 @@
         },
         {
             "id": "8e7f724c-ced6-55f7-a8f2-37df6fd9a2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11bf79b-a951-4d0c-acdf-d8ba5290a648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11bf79b-a951-4d0c-acdf-d8ba5290a648.jpg?1",
             "name": "Farrelite Priest",
             "text": "o1: Add o\nW to your mana pool. Play this ability as an interrupt. If more than 3 is spent in this way during one turn, bury Farrelite Priest at end of turn.",
             "colours": [
@@ -335,7 +335,7 @@
         },
         {
             "id": "e9a60f48-801c-56e6-bb9e-b0b495016915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a899b2d-825c-4929-a769-f4df70bf6a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a899b2d-825c-4929-a769-f4df70bf6a17.jpg?1",
             "name": "Hand of Justice",
             "text": "oc\nT: Tap three target white creatures you control to destroy any target creature.",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "4d2600b4-74dc-52f4-867f-fefed1bb051a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ee87a0-a7eb-4472-9045-85d11e8a1501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ee87a0-a7eb-4472-9045-85d11e8a1501.jpg?1",
             "name": "Heroism",
             "text": "o0: Sacrifice a white creature to have attacking red creatures deal no damage during combat this turn. The attacking player may pay o2o\nR for an attacking creature to have it deal damage as normal.",
             "colours": [
@@ -400,7 +400,7 @@
         },
         {
             "id": "7bb91f66-a7a7-5503-925c-ebb5b7080925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95d42d8-ba75-43bf-81b8-b02374f03e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95d42d8-ba75-43bf-81b8-b02374f03e83.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "75b1d080-7330-55c3-9b09-e8cc635249a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e4a9d2-ea43-46ac-8b8b-00496a478103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e4a9d2-ea43-46ac-8b8b-00496a478103.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "77ed49b3-5dba-586a-b952-27c4498c77ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efac583d-a492-45ee-8c52-60a6422b2168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efac583d-a492-45ee-8c52-60a6422b2168.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "f20c7ec2-30ae-572f-a892-47e607121e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a8d4-7c06-454c-9923-553294aada4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a8d4-7c06-454c-9923-553294aada4f.jpg?1",
             "name": "Icatian Infantry",
             "text": "o1: Bands until end of turn\no1: First strike until end of turn",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "d4324874-0c9d-5d2e-936c-d24b8f5de060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04b8356-2384-4743-80dd-f15ca7ec65f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04b8356-2384-4743-80dd-f15ca7ec65f7.jpg?1",
             "name": "Icatian Javelineers",
             "text": "When Icatian Javelineers is brought into play, put a javelin counter on it.\noc\nT: Remove the javelin counter to have Icatian Javelineers deal 1 damage to any target.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "aa2fefe5-c3ec-5bcc-be43-20ecf54c3ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70f8f50-866a-4889-b986-48636225638a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70f8f50-866a-4889-b986-48636225638a.jpg?1",
             "name": "Icatian Javelineers",
             "text": "When Icatian Javelineers is brought into play, put a javelin counter on it.\noc\nT: Remove the javelin counter to have Icatian Javelineers deal 1 damage to any target.",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "653fa5a7-0494-5ed3-9ac1-d10ac7e15c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be5ab7a-e7db-4c09-8df2-6fe55fa4a116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be5ab7a-e7db-4c09-8df2-6fe55fa4a116.jpg?1",
             "name": "Icatian Javelineers",
             "text": "When Icatian Javelineers is brought into play, put a javelin counter on it.\noc\nT: Remove the javelin counter to have Icatian Javelineers deal 1 damage to any target.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "2ae12fc4-706a-57b8-9d73-03c301e5db76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fec59a-4ade-4c6f-ae7d-911fbe6da26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fec59a-4ade-4c6f-ae7d-911fbe6da26d.jpg?1",
             "name": "Icatian Lieutenant",
             "text": "o1oo\nW Target Soldier gets +1/+0 until end of turn.",
             "colours": [
@@ -697,7 +697,7 @@
         },
         {
             "id": "45868b1b-41c0-58c3-8763-efbafa84ad40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d502d4-4a96-47b3-ae26-8b2c9f36623d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d502d4-4a96-47b3-ae26-8b2c9f36623d.jpg?1",
             "name": "Icatian Moneychanger",
             "text": "Moneychanger deals 3 damage to you when summoned; put three credit counters on Moneychanger at that time. During your upkeep, put one credit counter on Moneychanger.\no0: Sacrifice Moneychanger to gain 1 life for each credit counter on it. Use this ability only during your upkeep.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "7a927a19-7746-5842-8b8a-f1d922782090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf9194c-8e50-4f50-9a87-3b339a5bc279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf9194c-8e50-4f50-9a87-3b339a5bc279.jpg?1",
             "name": "Icatian Moneychanger",
             "text": "Moneychanger deals 3 damage to you when summoned; put three credit counters on Moneychanger at that time. During your upkeep, put one credit counter on Moneychanger.\no0: Sacrifice Moneychanger to gain 1 life for each credit counter on it. Use this ability only during your upkeep.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "219206df-2dd6-5471-9ce9-302a63080dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9521ae-6fac-4d86-9c60-adecaae5687d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9521ae-6fac-4d86-9c60-adecaae5687d.jpg?1",
             "name": "Icatian Moneychanger",
             "text": "Moneychanger deals 3 damage to you when summoned; put three credit counters on Moneychanger at that time. During your upkeep, put one credit counter on Moneychanger.\no0: Sacrifice Moneychanger to gain 1 life for each credit counter on it. Use this ability only during your upkeep.",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "67e973a5-333e-58ed-be99-7002192cf446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc02d30-3eef-4a48-8b11-b4f37219ab3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc02d30-3eef-4a48-8b11-b4f37219ab3a.jpg?1",
             "name": "Icatian Phalanx",
             "text": "Bands",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "7e07e17e-5711-5630-941f-723cd8c5e869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7690cdd-6610-4310-9e93-60dc4db2ae8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7690cdd-6610-4310-9e93-60dc4db2ae8d.jpg?1",
             "name": "Icatian Priest",
             "text": "o1o\nWo\nW: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -873,7 +873,7 @@
         },
         {
             "id": "d3050ced-2bac-5493-99a9-c59b6a518d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf4aaa-a9b1-4798-a96b-c3e35afb77f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bf4aaa-a9b1-4798-a96b-c3e35afb77f7.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "d38623e4-7729-5459-9c23-17d9a87992c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9db3442-01cb-4db2-ac33-8eca6880c315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9db3442-01cb-4db2-ac33-8eca6880c315.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "a893e1d3-98e1-515d-a094-28ae0e4effd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c461655-a05d-4eed-85b2-04d554f5ec50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c461655-a05d-4eed-85b2-04d554f5ec50.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "819145ba-68fe-5650-b3c0-9d9797154a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db63ad7f-6dc4-4249-b360-46ec5569a5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db63ad7f-6dc4-4249-b360-46ec5569a5a9.jpg?1",
             "name": "Icatian Scout",
             "text": "o1, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "c70c8733-75e9-51c2-bfe9-312e63f29180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f6d115-c02d-45a3-aa6d-402964df47dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f6d115-c02d-45a3-aa6d-402964df47dd.jpg?1",
             "name": "Icatian Skirmishers",
             "text": "Bands, first strike\nAll creatures that band with Skirmishers to attack gain first strike until end of turn.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "2ac349a9-ccfc-55f8-a7ae-a6dfa6eb299c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb7c28d-0366-4d01-84a2-f1bc9f38aa4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb7c28d-0366-4d01-84a2-f1bc9f38aa4a.jpg?1",
             "name": "Icatian Town",
             "text": "Put 4 Citizen tokens into play. Treat these tokens as 1/1 white creatures.",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "7718dd24-5332-555c-b691-43005671c656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd6e51e-f042-4673-a898-291607105829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd6e51e-f042-4673-a898-291607105829.jpg?1",
             "name": "Order of Leitbur",
             "text": "Protection from black\no\nWoo\nW +1/+0 until end of turn\noo\nW First strike until end of turn",
             "colours": [
@@ -1132,7 +1132,7 @@
         },
         {
             "id": "d03c0473-d059-53ea-be2f-c882d9cb7dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb537b5a-d725-420d-bc15-0d54ba23331c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb537b5a-d725-420d-bc15-0d54ba23331c.jpg?1",
             "name": "Order of Leitbur",
             "text": "Protection from black\no\nWoo\nW +1/+0 until end of turn\noo\nW First strike until end of turn",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "45612bba-095c-50aa-9582-2dd3099b7197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1373dea4-3565-4612-8505-ab8fba3ddb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1373dea4-3565-4612-8505-ab8fba3ddb67.jpg?1",
             "name": "Order of Leitbur",
             "text": "Protection from black\no\nWoo\nW +1/+0 until end of turn\noo\nW First strike until end of turn",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "56c8bc07-768b-554c-8928-b1f865086058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c9e4a5-735f-471c-ab1a-6e6d50ba5724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c9e4a5-735f-471c-ab1a-6e6d50ba5724.jpg?1",
             "name": "Deep Spawn",
             "text": "Trample\nDuring your upkeep, take two cards from the top of your library and put them in your graveyard, or destroy Deep Spawn.\noo\nU Deep Spawn may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Deep Spawn is untapped, tap it.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "0eb674a3-b4ec-5ba6-be30-ac533d728947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686bbb9-517f-4cce-aa7a-5db41e22c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686bbb9-517f-4cce-aa7a-5db41e22c02b.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, all islands produce an additional o\nU when tapped for mana.",
             "colours": [
@@ -1275,7 +1275,7 @@
         },
         {
             "id": "edcab1da-308a-52dc-87b5-ae9d00684121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2813677-91cc-4c8b-a8ea-403fa776c9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2813677-91cc-4c8b-a8ea-403fa776c9f0.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, all islands produce an additional o\nU when tapped for mana.",
             "colours": [
@@ -1309,7 +1309,7 @@
         },
         {
             "id": "09213226-093f-5643-a451-5316c8fe61ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af611e3-45d6-4aee-bf48-56598b14a242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af611e3-45d6-4aee-bf48-56598b14a242.jpg?1",
             "name": "High Tide",
             "text": "Until end of turn, all islands produce an additional o\nU when tapped for mana.",
             "colours": [
@@ -1343,7 +1343,7 @@
         },
         {
             "id": "33af6fd5-8db0-5680-8e52-80441a020d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ffeab4-83b1-4414-ae72-e59a2354ea15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ffeab4-83b1-4414-ae72-e59a2354ea15.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "4f0a2c3c-9d62-5f07-bca5-9a7a596e73ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6c13f-6019-4ad5-9de6-07844c361b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6c13f-6019-4ad5-9de6-07844c361b41.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "1eb9af4b-b2be-53ee-ad1e-b39e26c15910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33536b0a-1cff-481f-b695-eadaf6897bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33536b0a-1cff-481f-b695-eadaf6897bf0.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "3f288583-e627-5f24-ad59-7a635f97e76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f1cc24-a5fc-43cc-b558-ac7901c48b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f1cc24-a5fc-43cc-b558-ac7901c48b81.jpg?1",
             "name": "Homarid",
             "text": "Put a tide counter on Homarid when it is brought into play and during your upkeep. If there is one tide counter on Homarid, it gets -1/-1. If there are three tide counters on Homarid, it gets +1/+1. When there are four tide counters on Homarid, remove them all.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "84efb523-8ff5-5f09-a3b3-218a8a1a61ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17c6416-86d6-46ea-aea1-41b98a66b250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17c6416-86d6-46ea-aea1-41b98a66b250.jpg?1",
             "name": "Homarid Shaman",
             "text": "oo\nU Tap a target green creature.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "971bd5e2-098f-519b-84e2-a6678f1e0128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbb62fc-3cd9-41a6-804a-4ff9a766897f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbb62fc-3cd9-41a6-804a-4ff9a766897f.jpg?1",
             "name": "Homarid Spawning Bed",
             "text": "o1o\nUoo\nU Sacrifice a blue creature to put X Camarid tokens into play, where X is the casting cost of the sacrificed creature. Treat these tokens as 1/1 blue creatures.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "d63b2d32-9e00-558a-98eb-56ea6106db94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627ca588-917f-4768-a69d-3d93c1210390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627ca588-917f-4768-a69d-3d93c1210390.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Homarid Warrior is untapped, tap it.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "46015c37-2fbb-5d1c-b4f5-8378e777fb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a9bdcf-543b-4140-b836-9e222a4a9233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a9bdcf-543b-4140-b836-9e222a4a9233.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Homarid Warrior is untapped, tap it.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "8773d164-4681-545b-8858-4a03c78605ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1cccdc-9c4d-4ef3-807b-278e6fd23230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1cccdc-9c4d-4ef3-807b-278e6fd23230.jpg?1",
             "name": "Homarid Warrior",
             "text": "oo\nU Homarid Warrior may not be the target of spells or effects until end of turn and does not untap as normal during your next untap phase. If Homarid Warrior is untapped, tap it.",
             "colours": [
@@ -1667,7 +1667,7 @@
         },
         {
             "id": "cea65470-2c66-5175-8b33-f3f221fa4cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e96895-ef1d-44fa-b263-bce833fc3109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e96895-ef1d-44fa-b263-bce833fc3109.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "2f00edda-8d4a-53a3-9519-9b9242a22c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7fb804-65ba-477e-93e8-eea101c1521e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7fb804-65ba-477e-93e8-eea101c1521e.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "86cf768c-57f4-58ad-9a64-e7cb99ee6095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd197f8-ced0-461a-9672-2720a7b70803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd197f8-ced0-461a-9672-2720a7b70803.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "6978e422-5d61-5cf4-ac89-1f9cf7ad9c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a9e9a-d1f8-44c5-9f79-a1201acfb5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7a9e9a-d1f8-44c5-9f79-a1201acfb5fc.jpg?1",
             "name": "Merseine",
             "text": "Put three net counters on Merseine when it is brought into play. Target creature Merseine enchants does not untap as normal during its controller's untap phase as long as any net counters remain. As a fast effect, target creature's controller may pay creature's casting cost to remove a net counter.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "c090890d-b1da-5469-8a06-27ed37d26e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7fa54-4b89-4a9a-b088-4b89c525c1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7fa54-4b89-4a9a-b088-4b89c525c1ea.jpg?1",
             "name": "River Merfolk",
             "text": "oo\nU Mountainwalk until end of turn",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "46654342-8a75-5487-8f05-e0bb714517ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5266aa1-e2ea-46b9-91ab-b94a7bb7e9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5266aa1-e2ea-46b9-91ab-b94a7bb7e9f9.jpg?1",
             "name": "Seasinger",
             "text": "Bury Seasinger if you control no islands.\noc\nT: Gain control of a target creature if its controller controls at least one island. You lose control of target creature if Seasinger leaves play, if you lose control of Seasinger, or if Seasinger becomes untapped. You may choose not to untap Seasinger as normal during your untap phase.",
             "colours": [
@@ -1881,7 +1881,7 @@
         },
         {
             "id": "fcecb5a7-0da1-5b2d-8dad-0cf926187d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316d25ae-7ac6-4f5b-93ab-0e0e28ec104b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316d25ae-7ac6-4f5b-93ab-0e0e28ec104b.jpg?1",
             "name": "Svyelunite Priest",
             "text": "o\nUo\nU, oc\nT: Target creature may not be the target of spells or effects until end of turn. Use this ability only during your upkeep.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "02857b62-d88d-5b94-8f64-b51a457f2ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820f3f-434e-4d09-91b9-0ebd6966b393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e820f3f-434e-4d09-91b9-0ebd6966b393.jpg?1",
             "name": "Tidal Flats",
             "text": "o\nUoo\nU All your creatures that are blocking any non-flying creatures gain first strike until end of turn. The attacking player may pay o1 for each attacking creature to prevent Tidal Flats from giving that creature's blockers first strike.",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "92f448c4-34ae-5105-bba9-ea5f01f9a5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7d376-3e22-44aa-9c96-a3b8eb1568fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e7d376-3e22-44aa-9c96-a3b8eb1568fe.jpg?1",
             "name": "Tidal Flats",
             "text": "o\nUoo\nU All your creatures that are blocking any non-flying creatures gain first strike until end of turn. The attacking player may pay o1 for each attacking creature to prevent Tidal Flats from giving that creature's blockers first strike.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "56443850-917e-510f-b402-3d5c5c1f261d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445c4767-6261-449c-bb57-713e2a2bb0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445c4767-6261-449c-bb57-713e2a2bb0bf.jpg?1",
             "name": "Tidal Flats",
             "text": "o\nUoo\nU All your creatures that are blocking any non-flying creatures gain first strike until end of turn. The attacking player may pay o1 for each attacking creature to prevent Tidal Flats from giving that creature's blockers first strike.",
             "colours": [
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "41112049-753d-5fab-8cb8-991f0ae6b14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2192c7b-ef6f-4ff6-9017-b1a125340517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2192c7b-ef6f-4ff6-9017-b1a125340517.jpg?1",
             "name": "Tidal Influence",
             "text": "Put a tide counter on Tidal Influence when it is brought into play and during your upkeep. If there is one tide counter on Tidal Influence, all blue creatures get -2/-0. If there are three tide counters on Tidal Influence, all blue creatures get +2/+0. When there are four tide counters on Tidal Influence, remove them all.\nYou may not cast Tidal Influence if there is another Tidal Influence in play.",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "412b0e7a-d20b-5d2a-8ea8-f95c97767845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d97e1b-2526-4740-b354-f158734d1f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d97e1b-2526-4740-b354-f158734d1f72.jpg?1",
             "name": "Vodalian Knights",
             "text": "First strike\noo\nU Flying until end of turn\nVodalian Knights may not attack unless opponent controls at least one island. Bury Vodalian Knights if you control no islands.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "7d192fa9-cde1-51e0-a884-252dc2633244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c107e82b-134a-4f2b-98c2-6537fae6a50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c107e82b-134a-4f2b-98c2-6537fae6a50d.jpg?1",
             "name": "Vodalian Mage",
             "text": "o\nU, oc\nT: Counters a target spell if caster of target spell does not pay an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "5297d639-0248-56ff-9156-33933dab10a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47beac4-161d-4f8e-9778-78293ff9b383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47beac4-161d-4f8e-9778-78293ff9b383.jpg?1",
             "name": "Vodalian Mage",
             "text": "o\nU, oc\nT: Counters a target spell if caster of target spell does not pay an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "dacc6807-bf80-5000-9574-ab82a566f3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3cc91d-6f87-4f2e-b3c7-8181d19a1f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3cc91d-6f87-4f2e-b3c7-8181d19a1f0b.jpg?1",
             "name": "Vodalian Mage",
             "text": "o\nU, oc\nT: Counters a target spell if caster of target spell does not pay an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "2ba124cd-929c-5206-bab1-8d2fbbaabeed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb50256-9113-4b03-bcef-9aea24be8493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb50256-9113-4b03-bcef-9aea24be8493.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "40bdeefe-3e55-5490-b4be-56b65e0d68ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a68c-14d6-4447-a894-0e48d1662bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a68c-14d6-4447-a894-0e48d1662bc3.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "32ede19d-59b6-50e1-9602-1141ab6a257f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1ceac-bb75-4c46-9ab4-1ef623ed3027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d1ceac-bb75-4c46-9ab4-1ef623ed3027.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "593c7492-ced7-5a41-83d3-06f6c65f46e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d22f83-1171-4b5c-8a72-956db26d7c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d22f83-1171-4b5c-8a72-956db26d7c60.jpg?1",
             "name": "Vodalian Soldiers",
             "text": "",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "d7122aef-703d-5626-a32f-3cc2752028fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd962ff0-4aa6-453e-931e-bd36fc034273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd962ff0-4aa6-453e-931e-bd36fc034273.jpg?1",
             "name": "Vodalian War Machine",
             "text": "o0: Tap target Merfolk you control to allow Vodalian War Machine to attack this turn or to give Vodalian War Machine +2/+1 until end of turn. If Vodalian War Machine is put in the graveyard, all Merfolk tapped in this manner this turn are destroyed.",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "ca4da0be-14f0-5f79-adb8-f2116b99c768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98384d1-8e7d-4c41-9f23-47bc2ae2ad6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98384d1-8e7d-4c41-9f23-47bc2ae2ad6a.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "7d1d6ed5-e192-586d-b518-dcf5386ff852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6120e6-ceb8-4eab-86b0-18d38ed97d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6120e6-ceb8-4eab-86b0-18d38ed97d8f.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "a860ebd5-1f8a-54b8-bf83-473fd7594a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a91ed4-131e-455b-a3bd-0bd42aa754e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a91ed4-131e-455b-a3bd-0bd42aa754e5.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "c55e8de2-b991-55a4-9f88-052e55671ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d653ca4-c21f-4594-b900-2526a912001b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d653ca4-c21f-4594-b900-2526a912001b.jpg?1",
             "name": "Armor Thrull",
             "text": "oc\nT: Sacrifice Armor Thrull to put a +1/+2 counter on a target creature.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "40e70197-ddf5-59f4-86dd-c0d556ecd072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1d5d13-0160-48cb-8fac-dd86102569b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1d5d13-0160-48cb-8fac-dd86102569b4.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "1e5e8355-c4c0-552c-a000-ad80e603844e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf60db5-4f69-4db4-9dc2-1a6fbdec0429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf60db5-4f69-4db4-9dc2-1a6fbdec0429.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "2a5d5cf7-1bfe-58fd-9e7e-a0339b7feea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86d9647-3a87-4620-aa07-26f996fc6fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86d9647-3a87-4620-aa07-26f996fc6fa3.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "60fd2fa7-af05-54c7-b5f5-f631dc6d4f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6908e4c-f94d-4b0d-b9a5-64c04751f108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6908e4c-f94d-4b0d-b9a5-64c04751f108.jpg?1",
             "name": "Basal Thrull",
             "text": "oc\nT: Sacrifice Basal Thrull to add o\nBo\nB to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "97747bac-81c8-54b8-b745-6b7b5371f92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7e85f-eba5-4fc5-9fc0-109109d368aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7e85f-eba5-4fc5-9fc0-109109d368aa.jpg?1",
             "name": "Breeding Pit",
             "text": "During your upkeep, pay o\nBo\nB or bury Breeding Pit. At the end of your turn, put a Thrull token into play. Treat this token as a 0/1 black creature.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "f2a5af88-e0ad-591f-aebb-b368220518a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2b79f-f09a-49dc-8e0f-7d711ba78981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb2b79f-f09a-49dc-8e0f-7d711ba78981.jpg?1",
             "name": "Derelor",
             "text": "Your black spells cost an additional o\nB to cast.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "ab9458e9-aa10-5ef5-9e50-d40ab22cfdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40451f7a-692a-422d-99d3-d93a4d9315e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40451f7a-692a-422d-99d3-d93a4d9315e0.jpg?1",
             "name": "Ebon Praetor",
             "text": "Trample, first strike\nDuring your upkeep, put a -2/-2 counter on Ebon Praetor.\nYou may sacrifice a creature during your upkeep to remove a -2/-2 counter from Ebon Praetor. If the creature sacrificed was a Thrull, also put a +1/+0 counter on Ebon Praetor. Only one creature may be sacrificed in this manner each turn.",
             "colours": [
@@ -2772,7 +2772,7 @@
         },
         {
             "id": "d08f6e17-c983-5c32-815e-c66c8c90606e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9273ea-9a41-42e3-8c9c-0d50b127a818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9273ea-9a41-42e3-8c9c-0d50b127a818.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "51e85858-a0cd-5435-92fe-cb8230e5af63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8601f082-7e43-44ef-97d0-dead272b7eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8601f082-7e43-44ef-97d0-dead272b7eb4.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2842,7 +2842,7 @@
         },
         {
             "id": "edcdc086-3283-5a89-81dd-1cc27d196ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e125c6-81dc-4907-aad2-2ccd1cb166f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e125c6-81dc-4907-aad2-2ccd1cb166f0.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "70b81f27-2508-5ae5-a86c-eaa599e76113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc50e08-dd6f-4ea7-87f8-cce72bafb928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc50e08-dd6f-4ea7-87f8-cce72bafb928.jpg?1",
             "name": "Hymn to Tourach",
             "text": "Target player discards two cards at random from his or her hand. If target player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "111b576c-2b37-5786-91d5-7e8855e31f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be87527-3b8f-4529-afdb-a61ad4e787e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be87527-3b8f-4529-afdb-a61ad4e787e1.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. Play this ability as an interrupt. If more than o3 is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn.",
             "colours": [
@@ -2948,7 +2948,7 @@
         },
         {
             "id": "cd99cdda-0923-51f5-be4d-7ff7a6a7bb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7dc01-46d0-42be-a1a9-48f69c846d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7dc01-46d0-42be-a1a9-48f69c846d12.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. Play this ability as an interrupt. If more than o3 is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn.",
             "colours": [
@@ -2984,7 +2984,7 @@
         },
         {
             "id": "78140b2b-9da8-506d-af30-442d40cc4755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982970-e8b8-4659-bcf0-21aab662d89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982970-e8b8-4659-bcf0-21aab662d89d.jpg?1",
             "name": "Initiates of the Ebon Hand",
             "text": "o1: Add o\nB to your mana pool. Play this ability as an interrupt. If more than o3 is spent in this way during one turn, bury Initiates of the Ebon Hand at end of turn.",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "0d11234e-c969-5dab-a1e5-cb8e38b8dcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a791f-ac4f-4a96-b59b-37043686a79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a791f-ac4f-4a96-b59b-37043686a79a.jpg?1",
             "name": "Mindstab Thrull",
             "text": "If Mindstab Thrull attacks and is not blocked, you may sacrifice it to force the player it attacked to discard three cards. If you do so, it deals no damage during combat this turn. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "e220dc65-d0db-5d2c-96ad-004d57e6be19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781e4b62-3910-4ba1-9e72-e99de8523a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781e4b62-3910-4ba1-9e72-e99de8523a94.jpg?1",
             "name": "Mindstab Thrull",
             "text": "If Mindstab Thrull attacks and is not blocked, you may sacrifice it to force the player it attacked to discard three cards. If you do so, it deals no damage during combat this turn. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "ae6b247d-6e50-5c5f-9201-9988ce3d4d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923189c6-d407-4cc4-a062-2f09a4c7c1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923189c6-d407-4cc4-a062-2f09a4c7c1e3.jpg?1",
             "name": "Mindstab Thrull",
             "text": "If Mindstab Thrull attacks and is not blocked, you may sacrifice it to force the player it attacked to discard three cards. If you do so, it deals no damage during combat this turn. If that player does not have enough cards, his or her entire hand is discarded.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "ded6af34-c031-5a7c-979d-e4771e25c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d752a-ce8a-44cb-8aeb-1ed66705eb09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d752a-ce8a-44cb-8aeb-1ed66705eb09.jpg?1",
             "name": "Necrite",
             "text": "If Necrite attacks and is not blocked, you may sacrifice it to bury a target creature controlled by the player Necrite attacked this turn. If you do so, Necrite deals no damage during combat this turn.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "ec8ae7da-997f-5ee4-aeda-eb116f1473ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a4d41-e7b0-48b3-8e2e-9ac00f119ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a4d41-e7b0-48b3-8e2e-9ac00f119ce2.jpg?1",
             "name": "Necrite",
             "text": "If Necrite attacks and is not blocked, you may sacrifice it to bury a target creature controlled by the player Necrite attacked this turn. If you do so, Necrite deals no damage during combat this turn.",
             "colours": [
@@ -3200,7 +3200,7 @@
         },
         {
             "id": "a91d49fb-62bf-5b24-a5ad-754ec52852c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ae99f-4e61-45fd-9436-855a38289c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ae99f-4e61-45fd-9436-855a38289c8b.jpg?1",
             "name": "Necrite",
             "text": "If Necrite attacks and is not blocked, you may sacrifice it to bury a target creature controlled by the player Necrite attacked this turn. If you do so, Necrite deals no damage during combat this turn.",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "eb7b37a3-e980-57d6-8650-09189af34662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51f5d8-a7cc-4720-8af5-e002bcfd78a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51f5d8-a7cc-4720-8af5-e002bcfd78a0.jpg?1",
             "name": "Order of the Ebon Hand",
             "text": "Protection from white\no\nBoo\nB +1/+0 until end of turn\noo\nB First strike until end of turn",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "99f840de-f34c-5d12-b380-fa73207194dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ffbb40-13c1-4d01-9421-95b2410d0d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ffbb40-13c1-4d01-9421-95b2410d0d3b.jpg?1",
             "name": "Order of the Ebon Hand",
             "text": "Protection from white\no\nBoo\nB +1/+0 until end of turn\noo\nB First strike until end of turn",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "624f4270-ec57-5594-af14-faf585eadcbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c32774-5507-4a60-9ed2-2a570f6ff8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c32774-5507-4a60-9ed2-2a570f6ff8e3.jpg?1",
             "name": "Order of the Ebon Hand",
             "text": "Protection from white\no\nBoo\nB +1/+0 until end of turn\noo\nB First strike until end of turn",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "240b5139-0cfb-5902-a79d-341b7cd1ab78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f73597d-f453-4d37-b2ef-c54ef683a884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f73597d-f453-4d37-b2ef-c54ef683a884.jpg?1",
             "name": "Soul Exchange",
             "text": "Sacrifice a creature, but remove it from the game instead of putting it in your graveyard. Take a creature from your graveyard and put it directly into play as though it were just summoned. Put a +2/+2 counter on this creature if the creature sacrificed was a Thrull.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "65a703f4-bcca-51be-a26d-5f2fb6a77576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3cafdd-a03b-4b08-b9c1-c776f8450d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3cafdd-a03b-4b08-b9c1-c776f8450d3a.jpg?1",
             "name": "Thrull Champion",
             "text": "All Thrulls get +1/+1.\noc\nT: Take control of a target Thrull. You lose control of target Thrull if Thrull Champion leaves play or you lose control of Thrull Champion.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "79cbbdfe-eac3-55d3-993c-30fc6a917264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d800512b-1492-41d2-931d-57c625044454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d800512b-1492-41d2-931d-57c625044454.jpg?1",
             "name": "Thrull Retainer",
             "text": "Target creature gets +1/+1.\nSacrifice Thrull Retainer to regenerate the creature it enchants.",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "498b2236-4696-5154-959c-0d524e0786f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e732fb-cbef-4fd8-b704-e4d513a6cf2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e732fb-cbef-4fd8-b704-e4d513a6cf2d.jpg?1",
             "name": "Thrull Wizard",
             "text": "o1oo\nB Counters a target black spell if caster of target spell does not pay an additional o\nB or o3. Play this ability as an interrupt.",
             "colours": [
@@ -3478,7 +3478,7 @@
         },
         {
             "id": "cd5af987-2ff6-53eb-9796-91146643b921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06883fd2-eccd-47c6-8c34-10d95e923685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06883fd2-eccd-47c6-8c34-10d95e923685.jpg?1",
             "name": "Tourach's Chant",
             "text": "During your upkeep, pay o\nB or bury Tourach's Chant.\nWhenever a player puts a forest into play, Tourach's Chant deals 3 damage to him or her unless that player puts a -1/-1 counter on a target creature he or she controls.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "4eb3e0f3-6faa-5fb3-a312-0b90632631d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f6401-a9fb-449c-b511-6fb837055bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f6401-a9fb-449c-b511-6fb837055bb4.jpg?1",
             "name": "Tourach's Gate",
             "text": "Can only be played on a target land you control. Sacrifice a Thrull to put three time counters on Tourach's Gate. During your upkeep, remove a time counter from Tourach's Gate. If there are no time counters on Tourach's Gate, bury it.\no0: Tap land Tourach's Gate enchants. All attacking creatures you control get +2/-1 until end of turn.",
             "colours": [
@@ -3542,7 +3542,7 @@
         },
         {
             "id": "6d34d87d-95f5-568c-9e0e-a26b2961f02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0cb8f6-6ba7-402c-9829-251f7443e871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0cb8f6-6ba7-402c-9829-251f7443e871.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "45f14fda-e7ae-595e-a840-98c4008742c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9d0354-9ddd-4fe1-8174-9d3686ca564c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9d0354-9ddd-4fe1-8174-9d3686ca564c.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "a8babe8b-5cd5-53bf-ab72-695d887bbcf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1e461-f74e-436c-a9df-aff197cf48e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1e461-f74e-436c-a9df-aff197cf48e1.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3653,7 +3653,7 @@
         },
         {
             "id": "92a0ce5f-4d4e-530d-a1c6-9044bd8f303f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f0f4fe-2dd0-42c1-8f68-5d24a8a9d07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f0f4fe-2dd0-42c1-8f68-5d24a8a9d07d.jpg?1",
             "name": "Brassclaw Orcs",
             "text": "Cannot be assigned to block any creature of power greater than 1.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "97bdaecd-ba23-581b-8307-2b8be0879785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d50bf06-97ab-4874-a484-9289f41dc98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d50bf06-97ab-4874-a484-9289f41dc98e.jpg?1",
             "name": "Dwarven Armorer",
             "text": "o\nR, oc\nT: Discard a card from your hand to put either a +0/+1 or a +1/+0 counter on a target creature.",
             "colours": [
@@ -3723,7 +3723,7 @@
         },
         {
             "id": "9161ade4-b646-51cc-b0bb-3eb76125495b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c6932-638a-4df7-bf9b-8d921f7484d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c6932-638a-4df7-bf9b-8d921f7484d9.jpg?1",
             "name": "Dwarven Catapult",
             "text": "Dwarven Catapult does X damage, divided evenly among all of opponent's creatures (round down).",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "953c83e0-42ff-515c-9d60-c59d188dacb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a38b1-4676-425a-b40d-4fb478966024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9a38b1-4676-425a-b40d-4fb478966024.jpg?1",
             "name": "Dwarven Lieutenant",
             "text": "o1oo\nR Target Dwarf gets +1/+0 until end of turn.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "6c777825-7190-5178-a647-1a28157d173b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe77608-0b33-43f5-83fb-ae993ca1bf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe77608-0b33-43f5-83fb-ae993ca1bf7c.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "c593936b-fb18-572f-8179-ca5a2fbca40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c52-dfe1-4b15-a0d6-4f26c294426d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c52-dfe1-4b15-a0d6-4f26c294426d.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "731f2008-a273-5bd5-b553-180d055866f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872c5601-f356-4873-adf9-9a39536e7d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872c5601-f356-4873-adf9-9a39536e7d4a.jpg?1",
             "name": "Dwarven Soldier",
             "text": "If Dwarven Soldier blocks or is blocked by Orcs, it gets +0/+2 until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "8857aa11-9f31-5623-a398-736d63b5ab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b710c21-e9f5-4660-80f6-2104ec65f63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b710c21-e9f5-4660-80f6-2104ec65f63f.jpg?1",
             "name": "Goblin Chirurgeon",
             "text": "o0: Sacrifice a Goblin to regenerate a target creature.",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "03949ce0-be07-5bd8-972b-f17cc1222c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982115b2-e1e7-4b2f-8eb6-a1633477d4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982115b2-e1e7-4b2f-8eb6-a1633477d4a8.jpg?1",
             "name": "Goblin Chirurgeon",
             "text": "o0: Sacrifice a Goblin to regenerate a target creature.",
             "colours": [
@@ -3973,7 +3973,7 @@
         },
         {
             "id": "9f0ec541-47f9-5a3b-bbf9-90c842d7742d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9740842-7955-4cf9-8f76-a426858360b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9740842-7955-4cf9-8f76-a426858360b1.jpg?1",
             "name": "Goblin Chirurgeon",
             "text": "o0: Sacrifice a Goblin to regenerate a target creature.",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "a61790a8-0f29-5377-8514-eed8512b1c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87024efe-4a74-49fe-a43a-480bed0a650a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87024efe-4a74-49fe-a43a-480bed0a650a.jpg?1",
             "name": "Goblin Flotilla",
             "text": "Islandwalk\nAt the beginning of the attack, pay o\nR or any creatures blocking or blocked by Goblin Flotilla gain first strike until end of turn.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "3f8b0029-2c7f-5c25-9b43-3d866a8d2641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8837eaba-9602-4f63-9897-85583fcdcf51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8837eaba-9602-4f63-9897-85583fcdcf51.jpg?1",
             "name": "Goblin Grenade",
             "text": "Sacrifice a Goblin to have Goblin Grenade deal 5 damage to one target.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "466b471a-d541-54b7-8604-0dbdcb1fcd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee262da-3002-4c08-8043-4e40e1b46822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee262da-3002-4c08-8043-4e40e1b46822.jpg?1",
             "name": "Goblin Grenade",
             "text": "Sacrifice a Goblin to have Goblin Grenade deal 5 damage to one target.",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "ad4cf79d-16cf-5558-ae33-16012950dac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1befdfc7-a1e3-4a2a-ad68-7d0fee170f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1befdfc7-a1e3-4a2a-ad68-7d0fee170f3f.jpg?1",
             "name": "Goblin Grenade",
             "text": "Sacrifice a Goblin to have Goblin Grenade deal 5 damage to one target.",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "d525d883-72e0-5ef0-bc59-565c9c9068b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a27ac3-2273-469a-92ba-3f4a3d55de6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a27ac3-2273-469a-92ba-3f4a3d55de6f.jpg?1",
             "name": "Goblin Kites",
             "text": "oo\nR A target creature you control, which cannot have a toughness greater than 2, gains flying until end of turn. Other effects may later be used to increase the creature's toughness. At end of turn, flip a coin; opponent calls heads or tails while coin is in the air. If the flip ends up in opponent's favor, bury that creature.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "a03bd000-11d1-5252-ac55-ba73027fd2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c4e4b-e9a7-4180-927b-589514c21876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c4e4b-e9a7-4180-927b-589514c21876.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "6c0411bc-7a09-5be2-bfff-f67942f1a9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5988a3d2-748f-4642-9e33-293ddc568111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5988a3d2-748f-4642-9e33-293ddc568111.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "6cb580a1-0a98-5427-a435-b031ce19a8f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2232386e-986d-41b5-8b70-e086264f3277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2232386e-986d-41b5-8b70-e086264f3277.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "035a78f0-ce02-57c3-bbcf-3b541b4fc1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0185f3-fbc0-44d7-b933-30627cda1bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0185f3-fbc0-44d7-b933-30627cda1bf9.jpg?1",
             "name": "Goblin War Drums",
             "text": "Each attacking creature you control that opponent chooses to block may not be blocked with fewer than two creatures.",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "ed525145-3a80-598a-872b-d82a91d8fb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec4aa5-3319-43dc-8347-5633edbd7018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbec4aa5-3319-43dc-8347-5633edbd7018.jpg?1",
             "name": "Goblin Warrens",
             "text": "o2oo\nR Sacrifice two Goblins to put three Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -4347,7 +4347,7 @@
         },
         {
             "id": "9885640b-c264-58b6-8fa9-1cc5a8bef3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43cf61d-b4d6-4461-a228-47fd8b026d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43cf61d-b4d6-4461-a228-47fd8b026d33.jpg?1",
             "name": "Orcish Captain",
             "text": "o1: Choose a target Orc. Flip a coin; opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, that Orc gets +2/+0 until end of turn. Otherwise, that Orc gets -0/-2 until end of turn.",
             "colours": [
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "81c2db17-646a-54ca-a15c-6c054d061e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3890d1-563d-4519-ab8c-913031d71918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3890d1-563d-4519-ab8c-913031d71918.jpg?1",
             "name": "Orcish Spy",
             "text": "oc\nT: Look at the top three cards of target player's library and return them in the same order.",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "539f6f9f-1a21-5795-a592-a6d8e0db85ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b931cfd-b952-416c-ab2c-271ecaee8e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b931cfd-b952-416c-ab2c-271ecaee8e0c.jpg?1",
             "name": "Orcish Spy",
             "text": "oc\nT: Look at the top three cards of target player's library and return them in the same order.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "366db4ae-9b5f-5b22-a584-e73d57a40309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e08767-7e92-4ff4-b0d8-196565fbc23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e08767-7e92-4ff4-b0d8-196565fbc23c.jpg?1",
             "name": "Orcish Spy",
             "text": "oc\nT: Look at the top three cards of target player's library and return them in the same order.",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "f54b5068-3f09-50c5-a6dc-32ce16528115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbca765-8756-4e28-9faf-25714c9b8838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbca765-8756-4e28-9faf-25714c9b8838.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "4c099534-b6c2-5296-902f-5fedce0dcd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc37db83-9efc-4d58-90c9-78eef9073ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc37db83-9efc-4d58-90c9-78eef9073ec2.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "18c1f076-4741-5b81-8de5-e61775b86b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334004e6-bf8c-4a4e-a30c-1537a99819c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334004e6-bf8c-4a4e-a30c-1537a99819c9.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "27d543fc-6456-57e7-9d00-901228e5093a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4990dd4b-2b18-4e4c-81d4-1cd8d746a7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4990dd4b-2b18-4e4c-81d4-1cd8d746a7dc.jpg?1",
             "name": "Orcish Veteran",
             "text": "Cannot be assigned to block any white creature of power greater than 1.\noo\nR First strike until end of turn",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "e98e6dd3-c0e4-512d-9991-542f8d980b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af19ab0-4bd0-4d5f-8d2e-507e4fe87c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af19ab0-4bd0-4d5f-8d2e-507e4fe87c18.jpg?1",
             "name": "Orgg",
             "text": "Trample\nOrgg may not attack if opponent controls an untapped creature of power greater than 2. Orgg cannot be assigned to block any creature of power greater than 2.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "def75dab-f9a9-5ec6-8d84-467e46a76e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a3396-706b-4ca2-9973-bca758986032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907a3396-706b-4ca2-9973-bca758986032.jpg?1",
             "name": "Raiding Party",
             "text": "Raiding Party may not be the target of white spells or effects.\no0: Sacrifice an Orc to destroy all plains. A player may tap a white creature to prevent up to two plains from being destroyed. Any number of creatures may be tapped in this manner.",
             "colours": [
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "28398fda-0f34-5070-a939-db8c1c68e100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387105d-46d0-4db0-8980-dd0fded15eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9387105d-46d0-4db0-8980-dd0fded15eef.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "4187dc66-3ec5-5ffb-a9a0-e57e813dfd21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091b5ed4-91f5-47c1-b1a1-5443f7346078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091b5ed4-91f5-47c1-b1a1-5443f7346078.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "c0e12bcf-f43c-5bd8-9e41-3ed950989a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960b542f-cb24-4f74-92da-d31559d87c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960b542f-cb24-4f74-92da-d31559d87c2d.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4809,7 +4809,7 @@
         },
         {
             "id": "3d0663a1-e25f-594e-8c57-cc62132349c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52743f0-5c5b-46b9-bbbd-67950d4c89e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52743f0-5c5b-46b9-bbbd-67950d4c89e5.jpg?1",
             "name": "Elven Fortress",
             "text": "o1oo\nG Target blocking creature gets +0/+1 until end of turn.",
             "colours": [
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "a8f5020a-b193-5b39-951b-ae8e20eeb7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9710e-b2f8-4746-8640-d450f58a6e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a9710e-b2f8-4746-8640-d450f58a6e49.jpg?1",
             "name": "Elvish Farmer",
             "text": "During your upkeep, put a spore counter on Elvish Farmer.\no0: Remove three spore counters from Elvish Farmer to put a Saproling token into play. Treat this token as a 1/1 green creature.\no0: Sacrifice a Saproling to gain 2 life.",
             "colours": [
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "304cfa9f-b8f5-53fa-84b4-5501bc996007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00455ac-c7ce-4916-98ed-cca9354e3f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00455ac-c7ce-4916-98ed-cca9354e3f22.jpg?1",
             "name": "Elvish Hunter",
             "text": "o1o\nG, oc\nT: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "ff3c7e2c-45e1-52a9-a3a2-b07a92ab9984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff096c-487f-42f9-a394-a298503391da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff096c-487f-42f9-a394-a298503391da.jpg?1",
             "name": "Elvish Hunter",
             "text": "o1o\nG, oc\nT: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "c7b73d37-3fc4-56b1-8c7a-efb088bc6c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204c8aff-b103-4606-b86b-d794bc5dcde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204c8aff-b103-4606-b86b-d794bc5dcde1.jpg?1",
             "name": "Elvish Hunter",
             "text": "o1o\nG, oc\nT: Target creature does not untap as normal during its controller's next untap phase.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "84927d71-9a0c-520b-b67c-f6edb3e2c6d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cd2ed-be81-4769-a8ec-287946301396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689cd2ed-be81-4769-a8ec-287946301396.jpg?1",
             "name": "Elvish Scout",
             "text": "o\nG, oc\nT: Untap a target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "1b3c1275-1bcb-588f-a9d5-8880d8854148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faff88d-594e-473c-a2d1-cd60f51b2ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faff88d-594e-473c-a2d1-cd60f51b2ee7.jpg?1",
             "name": "Elvish Scout",
             "text": "o\nG, oc\nT: Untap a target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "934bba54-7fbc-5f13-8c17-bc08eb6181fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d414bf5a-2604-426c-8c68-5c1696557b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d414bf5a-2604-426c-8c68-5c1696557b57.jpg?1",
             "name": "Elvish Scout",
             "text": "o\nG, oc\nT: Untap a target attacking creature you control. That creature neither receives nor deals damage during combat this turn.",
             "colours": [
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "59df4db1-b36f-5442-a681-a571290399b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585241e-c647-456d-b3b1-3d48dd78c372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585241e-c647-456d-b3b1-3d48dd78c372.jpg?1",
             "name": "Feral Thallid",
             "text": "During your upkeep, put a spore counter on Feral Thallid.\no0: Remove three spore counters from Feral Thallid to regenerate it.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "c134ff45-b508-5394-b1d2-5383cd942aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1a2cb2-9a6b-41f7-96f7-ec457c69c16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1a2cb2-9a6b-41f7-96f7-ec457c69c16c.jpg?1",
             "name": "Fungal Bloom",
             "text": "o\nGoo\nG Put a spore counter on a target Fungus.",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "681d74ea-b1a4-571c-8571-32cc6b1b823d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda6d18-d4b1-4b8a-a72e-f90115adf4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda6d18-d4b1-4b8a-a72e-f90115adf4c3.jpg?1",
             "name": "Night Soil",
             "text": "o1: Remove two creatures in any graveyard from the game to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5197,7 +5197,7 @@
         },
         {
             "id": "0add4d13-9084-5b9c-8d85-ad94d7b8842c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f25a497-46dc-47aa-8586-d514578a6d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f25a497-46dc-47aa-8586-d514578a6d25.jpg?1",
             "name": "Night Soil",
             "text": "o1: Remove two creatures in any graveyard from the game to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5231,7 +5231,7 @@
         },
         {
             "id": "1c098126-42f1-5a45-aadf-5396609d4572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3eb61b-698c-42b1-8a33-0ce7c3829e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3eb61b-698c-42b1-8a33-0ce7c3829e07.jpg?1",
             "name": "Night Soil",
             "text": "o1: Remove two creatures in any graveyard from the game to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "e29fee44-6cc5-5be6-bae6-9e69f661ae8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1691a9f4-4ea7-440f-9bdc-4214ab3c90f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1691a9f4-4ea7-440f-9bdc-4214ab3c90f0.jpg?1",
             "name": "Spore Cloud",
             "text": "Tap all blocking creatures. No creatures deal damage in combat this turn. Neither attacking nor blocking creatures untap as normal during their controllers' next untap phase.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "43a93afc-c9d2-511c-9712-7f7204d6c735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3070f8-6dae-4f22-b186-e2a3a9647cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3070f8-6dae-4f22-b186-e2a3a9647cc5.jpg?1",
             "name": "Spore Cloud",
             "text": "Tap all blocking creatures. No creatures deal damage in combat this turn. Neither attacking nor blocking creatures untap as normal during their controllers' next untap phase.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "25fd3aa0-9a68-532f-9bb6-bf07bb6e967f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fe098c-c9b5-4bba-92b5-5720d6919073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fe098c-c9b5-4bba-92b5-5720d6919073.jpg?1",
             "name": "Spore Cloud",
             "text": "Tap all blocking creatures. No creatures deal damage in combat this turn. Neither attacking nor blocking creatures untap as normal during their controllers' next untap phase.",
             "colours": [
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "16a3be22-4630-5551-9132-340acebe5e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9681dc0-d0fc-4d5b-a23c-63ec1cc8343d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9681dc0-d0fc-4d5b-a23c-63ec1cc8343d.jpg?1",
             "name": "Spore Flower",
             "text": "During your upkeep, put a spore counter on Spore Flower.\no0: Remove three spore counters from Spore Flower. No creatures deal damage in combat this turn.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "98545ba8-e0df-5e18-ab4e-b69b7309800c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caaf31b-86a9-485b-8da7-d5b526ed1233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caaf31b-86a9-485b-8da7-d5b526ed1233.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "5d50a6ce-2c78-58a4-9589-b1492648e768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f8f778-ae31-45cd-b27f-f93a07853ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f8f778-ae31-45cd-b27f-f93a07853ede.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "65169180-9a19-578e-9c21-62e7f79839c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2f3da-9101-439d-8caa-910ff40bfbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2f3da-9101-439d-8caa-910ff40bfbb3.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "892cbc98-2909-52d9-82b4-a59bd98c5370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01827286-b104-41c5-bac9-7c38414bc40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01827286-b104-41c5-bac9-7c38414bc40e.jpg?1",
             "name": "Thallid",
             "text": "During your upkeep, put a spore counter on Thallid.\no0: Remove three spore counters from Thallid to put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -5548,7 +5548,7 @@
         },
         {
             "id": "8d6b22fe-8583-5908-b964-05e3174e3154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa533845-4c4b-4072-aa39-8e56ce7ec325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa533845-4c4b-4072-aa39-8e56ce7ec325.jpg?1",
             "name": "Thallid Devourer",
             "text": "During your upkeep, put a spore counter on Thallid Devourer.\no0: Remove three spore counters from Thallid Devourer to put a Saproling token into play. Treat this token as a 1/1 green creature.\no0: Sacrifice a Saproling to give Thallid Devourer +1/+2 until end of turn.",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "c2663eaa-e4aa-5ac6-97dc-8d98acb408f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d970195-0a09-4cb4-a2c0-c16fcab5c859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d970195-0a09-4cb4-a2c0-c16fcab5c859.jpg?1",
             "name": "Thelon's Chant",
             "text": "During your upkeep, pay o\nG or bury Thelon's Chant.\nWhenever a player puts a swamp into play, Thelon's Chant deals 3 damage to him or her unless that player puts a -1/-1 counter on a target creature he or she controls.",
             "colours": [
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "a0121bf2-80e8-5d26-a241-96a56a978970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b868846-cc3c-4756-a5dd-2335bb380567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b868846-cc3c-4756-a5dd-2335bb380567.jpg?1",
             "name": "Thelon's Curse",
             "text": "Blue creatures do not untap as normal during their controller's untap phase. During his or her upkeep, a blue creature's controller may pay an additional o\nU to untap it. Each creature may be untapped in this way only once per turn.",
             "colours": [
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "57183cf9-3f59-598c-9cb3-3aa52b9d5fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8772dd-513d-4dd0-a5db-5214dc8da4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8772dd-513d-4dd0-a5db-5214dc8da4e0.jpg?1",
             "name": "Thelonite Druid",
             "text": "o1o\nG, oc\nT: Sacrifice a creature to turn all your forests into 2/3 creatures until end of turn. The forests still count as lands but may not be tapped for mana if they were brought into play this turn.",
             "colours": [
@@ -5679,7 +5679,7 @@
         },
         {
             "id": "a34aaf79-2413-5cd7-88a0-b7c770548a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5400ff25-c70e-4095-a228-190601b86043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5400ff25-c70e-4095-a228-190601b86043.jpg?1",
             "name": "Thelonite Monk",
             "text": "oc\nT: Sacrifice a green creature to turn a target land into a basic forest. Mark changed land with a counter.",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "e1b79765-febc-532d-a615-9c38500433db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e61c00-3e94-4f6f-8515-65b430829e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e61c00-3e94-4f6f-8515-65b430829e91.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "f986ea00-5aef-575b-b776-92089eb75ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84283348-789b-4236-b406-7fc6338a867d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84283348-789b-4236-b406-7fc6338a867d.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5788,7 +5788,7 @@
         },
         {
             "id": "e4ee68ff-08d3-5796-85ab-0d8d869717f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1537a338-3b68-4a41-bac6-554e8e530e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1537a338-3b68-4a41-bac6-554e8e530e46.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "74032f60-c83c-5332-867d-7f5bb116bfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8f50be-1629-40eb-8916-019903d2e6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8f50be-1629-40eb-8916-019903d2e6a4.jpg?1",
             "name": "Thorn Thallid",
             "text": "During your upkeep, put a spore counter on Thorn Thallid.\no0: Remove three spore counters from Thorn Thallid to have it deal 1 damage to any target.",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "a510d791-ecf5-5d9f-b575-56702ddc649b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09030ee-415c-45af-bf08-7623197a314f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09030ee-415c-45af-bf08-7623197a314f.jpg?1",
             "name": "Aeolipile",
             "text": "o1, oc\nT: Sacrifice Aeolipile to have it deal 2 damage to any target.",
             "colours": [],
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "3a1167dc-13e9-5ebc-99f9-d0c20824a364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95de4a-7fae-42bc-9660-39ea7685ca02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f95de4a-7fae-42bc-9660-39ea7685ca02.jpg?1",
             "name": "Balm of Restoration",
             "text": "o1, oc\nT: Sacrifice Balm of Restoration to gain 2 life or prevent up to 2 damage to any player or creature.",
             "colours": [],
@@ -5916,7 +5916,7 @@
         },
         {
             "id": "8d60451e-b3de-5df2-81f2-d644313495af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860a9ba3-e4c4-4af9-bdfe-1ada39289fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860a9ba3-e4c4-4af9-bdfe-1ada39289fd5.jpg?1",
             "name": "Conch Horn",
             "text": "o1, oc\nT: Sacrifice Conch Horn. Draw two cards, then put any one card from your hand back on top of your library.",
             "colours": [],
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "e307c624-1d5d-529e-a750-f1474c99acce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262b8788-c5a0-4c8e-9d58-b769b1b0a2ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262b8788-c5a0-4c8e-9d58-b769b1b0a2ff.jpg?1",
             "name": "Delif's Cone",
             "text": "oc\nT: Sacrifice Delif's Cone. If target creature you control attacks and is not blocked, you may choose to gain its power in life. If you do so, it deals no damage to opponent this turn.",
             "colours": [],
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "9e8801cd-674d-59e6-ae06-6fce4a17d6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14749600-9eca-4122-b04f-30ddda091b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14749600-9eca-4122-b04f-30ddda091b74.jpg?1",
             "name": "Delif's Cube",
             "text": "o2, oc\nT: If target creature you control attacks and is not blocked, it deals no damage to opponent. Instead, put a cube counter on Delif's Cube.\no2: Remove a cube counter to regenerate a target creature.",
             "colours": [],
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "984e3138-f1b8-503b-adf9-c3defa134e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a419c9e3-5615-44f9-9256-94a3022bb69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a419c9e3-5615-44f9-9256-94a3022bb69f.jpg?1",
             "name": "Draconian Cylix",
             "text": "o2, oc\nT: Discard a card at random from your hand to regenerate a target creature.",
             "colours": [],
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "7f33817f-f1a2-5eca-84f8-6a0d35687f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a8cd72-04c0-46f7-a249-f1cecddfdc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a8cd72-04c0-46f7-a249-f1cecddfdc26.jpg?1",
             "name": "Elven Lyre",
             "text": "o1, oc\nT: Sacrifice Elven Lyre to give a target creature +2/+2 until end of turn.",
             "colours": [],
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "67e49cf2-34d8-5443-a60d-e2b98a6e276f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5deb95-79a6-4398-b82a-c1df169550d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5deb95-79a6-4398-b82a-c1df169550d9.jpg?1",
             "name": "Implements of Sacrifice",
             "text": "o1, oc\nT: Sacrifice Implements of Sacrifice to add 2 mana of any one color to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "619b0328-378c-5219-bd20-ff1aeb1a45ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a532d38a-809b-4132-8690-be15fe23afab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a532d38a-809b-4132-8690-be15fe23afab.jpg?1",
             "name": "Ring of Renewal",
             "text": "o5, oc\nT: Discard a card at random from your hand and draw two cards.",
             "colours": [],
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "7472d926-2a14-55c5-a645-0a0f6104d874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213d6e0d-5ec9-441e-a38d-50ce44583e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213d6e0d-5ec9-441e-a38d-50ce44583e4b.jpg?1",
             "name": "Spirit Shield",
             "text": "o2, oc\nT: Target creature gets +0/+2 as long as Spirit Shield remains tapped.\nYou may choose not to untap Spirit Shield as normal during your untap phase.",
             "colours": [],
@@ -6132,7 +6132,7 @@
         },
         {
             "id": "ae97c205-c455-5d81-8e1c-991f9c11bf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4137160b-5248-4fbd-8ae8-25e9afd8fb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4137160b-5248-4fbd-8ae8-25e9afd8fb5c.jpg?1",
             "name": "Zelyon Sword",
             "text": "o3, oc\nT: Target creature gets +2/+0 as long as Zelyon Sword remains tapped.\nYou may choose not to untap Zelyon Sword as normal during your untap phase.",
             "colours": [],
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "c30d5bf0-83bd-5160-9b8c-7739e728743b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639ae988-d1d1-4ead-b0f8-47fc39eb64a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639ae988-d1d1-4ead-b0f8-47fc39eb64a0.jpg?1",
             "name": "Bottomless Vault",
             "text": "Comes into play tapped. You may choose not to untap Bottomless Vault during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Bottomless Vault. For each storage counter removed, add o\nB to your mana pool.",
             "colours": [],
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "3a86ec0b-9c11-5eca-b370-cb9ade90ab2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3142ded-ff62-4817-aa54-75a7ea4498a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3142ded-ff62-4817-aa54-75a7ea4498a6.jpg?1",
             "name": "Dwarven Hold",
             "text": "Comes into play tapped. You may choose not to untap Dwarven Hold during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Dwarven Hold. For each storage counter removed, add o\nR to your mana pool.",
             "colours": [],
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "6bb18df7-b40f-5bba-accd-a791a434b122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfe1352-27be-4c99-a58f-b961f911f270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfe1352-27be-4c99-a58f-b961f911f270.jpg?1",
             "name": "Dwarven Ruins",
             "text": "Comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT: Sacrifice Dwarven Ruins to add o\nRo\nR to your mana pool.",
             "colours": [],
@@ -6246,7 +6246,7 @@
         },
         {
             "id": "7e74f2cc-c6d5-597a-bed1-e11700c79896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb2a11f-a8e4-4acf-871a-11171e3304ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb2a11f-a8e4-4acf-871a-11171e3304ef.jpg?1",
             "name": "Ebon Stronghold",
             "text": "Comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT: Sacrifice Ebon Stronghold to add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "368aca41-69c8-552c-9cc5-e30772a0bd3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9028f200-80dd-4c53-877f-ea380ff417cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9028f200-80dd-4c53-877f-ea380ff417cb.jpg?1",
             "name": "Havenwood Battleground",
             "text": "Comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT: Sacrifice Havenwood Battleground to add o\nGo\nG to your mana pool.",
             "colours": [],
@@ -6304,7 +6304,7 @@
         },
         {
             "id": "16fc106f-15a9-59b5-b16a-5f3ee3d4b6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90845410-e09a-4753-ad4c-bf2b2f3c95ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90845410-e09a-4753-ad4c-bf2b2f3c95ac.jpg?1",
             "name": "Hollow Trees",
             "text": "Comes into play tapped. You may choose not to untap Hollow Trees during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Hollow Trees. For each storage counter removed, add o\nG to your mana pool.",
             "colours": [],
@@ -6333,7 +6333,7 @@
         },
         {
             "id": "442d4d25-fcb3-5d63-b563-941cf7a11827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd8d8c-52c7-402f-92e1-5e5866f2555a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd8d8c-52c7-402f-92e1-5e5866f2555a.jpg?1",
             "name": "Icatian Store",
             "text": "Comes into play tapped. You may choose not to untap Icatian Store during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Icatian Store. For each storage counter removed, add o\nW to your mana pool.",
             "colours": [],
@@ -6362,7 +6362,7 @@
         },
         {
             "id": "1f244e6d-b287-5937-ad07-3529650e84ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b138e1-f8fc-435c-9aed-98004768479c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b138e1-f8fc-435c-9aed-98004768479c.jpg?1",
             "name": "Rainbow Vale",
             "text": "oc\nT: Add 1 mana of any color to your mana pool. Control of Rainbow Vale passes to opponent at end of turn.",
             "colours": [],
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "8305b0d0-7d4f-5351-806a-340186f705ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce2e734-8cff-4bfe-85f8-17b3e1903f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce2e734-8cff-4bfe-85f8-17b3e1903f18.jpg?1",
             "name": "Ruins of Trokair",
             "text": "Comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT: Sacrifice Ruins of Trokair to add o\nWo\nW to your mana pool.",
             "colours": [],
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "7d08d742-6b14-5f8e-a12a-5fa42f5d1fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f1fcb-d903-4a31-abab-40488569eef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f1fcb-d903-4a31-abab-40488569eef6.jpg?1",
             "name": "Sand Silos",
             "text": "Comes into play tapped. You may choose not to untap Sand Silos during your untap phase and instead put a storage counter on it.\noc\nT: Remove any number of storage counters from Sand Silos. For each storage counter removed, add o\nU to your mana pool.",
             "colours": [],
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "5bc5930c-6e0d-529f-8a4a-a376af5fb796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3fde62-ab21-459b-9c5d-01aa6fe1d08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3fde62-ab21-459b-9c5d-01aa6fe1d08e.jpg?1",
             "name": "Svyelunite Temple",
             "text": "Comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT: Sacrifice Svyelunite Temple to add o\nUo\nU to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/FRF.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/FRF.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6c42141e-0304-57b5-a1fc-d5b10ca09ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1e824-c8a9-4312-8e4c-a29a26d189a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1e824-c8a9-4312-8e4c-a29a26d189a4.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to target creature or player.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "80b708f8-4715-5270-83d6-904e09d5e0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffd46f5-afd1-4130-b019-d8822e61fdfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffd46f5-afd1-4130-b019-d8822e61fdfa.jpg?1",
             "name": "Abzan Advantage",
             "text": "Target player sacrifices an enchantment. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "be7dd08e-7787-5d28-a938-1eacc2bc31ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe356261-3126-41f1-ae71-b69ca5641f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe356261-3126-41f1-ae71-b69ca5641f84.jpg?1",
             "name": "Abzan Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has vigilance as long as you control a black or green permanent.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "1d90a1b9-872f-53da-be04-2111ac65fc12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4195373-e902-4fc3-aead-1f6e728dbbae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4195373-e902-4fc3-aead-1f6e728dbbae.jpg?1",
             "name": "Abzan Skycaptain",
             "text": "Flying\nWhen Abzan Skycaptain dies, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "ec827f0e-fd97-5372-903c-7ec28d74a1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10aeac19-6892-448e-9e5f-302051a089fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10aeac19-6892-448e-9e5f-302051a089fc.jpg?1",
             "name": "Arashin Cleric",
             "text": "When Arashin Cleric enters the battlefield, you gain 3 life.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "4c99bec8-64aa-5547-b791-4131ecf357e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f7a3b1-4d92-4d32-a823-2e774c6e7e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f7a3b1-4d92-4d32-a823-2e774c6e7e73.jpg?1",
             "name": "Aven Skirmisher",
             "text": "Flying",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "9ea10aa8-c3a5-5016-8626-05022669c614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8801465e-295f-4b6b-a321-120f1b1edd0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8801465e-295f-4b6b-a321-120f1b1edd0b.jpg?1",
             "name": "Channel Harm",
             "text": "Prevent all damage that would be dealt to you and permanents you control this turn by sources you don't control. If damage is prevented this way, you may have Channel Harm deal that much damage to target creature.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "0b9e6b05-8212-5334-b495-6b48c397be1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239c373a-465c-4cda-9895-624871d8606e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239c373a-465c-4cda-9895-624871d8606e.jpg?1",
             "name": "Citadel Siege",
             "text": "As Citadel Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of combat on your turn, put two +1/+1 counters on target creature you control.\n\u2022 Dragons \u2014 At the beginning of combat on each opponent's turn, tap target creature that player controls.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "55c52dba-3c5d-5f0e-98ad-e40552598df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce58a8bd-e979-41e0-a533-7408830e0154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce58a8bd-e979-41e0-a533-7408830e0154.jpg?1",
             "name": "Citadel Siege",
             "text": "",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "f57671bf-389f-583d-a336-6329243424c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7eed1e-7b28-4900-a6ac-67f167476c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7eed1e-7b28-4900-a6ac-67f167476c11.jpg?1",
             "name": "Daghatar the Adamant",
             "text": "Vigilance\nDaghatar the Adamant enters the battlefield with four +1/+1 counters on it.\n{1}{BG}{BG}: Move a +1/+1 counter from target creature onto a second target creature.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "9f22526e-b836-5b5d-865b-da55bd1fdc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed0c9c7-e50d-4bcf-a90e-89cb441de0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed0c9c7-e50d-4bcf-a90e-89cb441de0af.jpg?1",
             "name": "Dragon Bell Monk",
             "text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "686d25b2-c3f6-591c-a761-2d0feebfac4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df904cc6-3ee0-4326-a854-818695aa2890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df904cc6-3ee0-4326-a854-818695aa2890.jpg?1",
             "name": "Dragonscale General",
             "text": "At the beginning of your end step, bolster X, where X is the number of tapped creatures you control. (Choose a creature with the least toughness among creatures you control and put X +1/+1 counters on it.)",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "be30374c-04f9-5dda-9a3a-ad51e4ca3c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ac3224-54af-4688-a015-6a447971544e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ac3224-54af-4688-a015-6a447971544e.jpg?1",
             "name": "Elite Scaleguard",
             "text": "When Elite Scaleguard enters the battlefield, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)\nWhenever a creature you control with a +1/+1 counter on it attacks, tap target creature defending player controls.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "e056912b-45ea-54a4-ab64-6158f2fdefaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e08cb-407b-4b3d-8af0-077ff96bf160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122e08cb-407b-4b3d-8af0-077ff96bf160.jpg?1",
             "name": "Great-Horn Krushok",
             "text": "",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "2829d786-bfca-5f34-96c6-b5d4ea189f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084c8b16-7aae-4d1f-87c2-6a150f11bb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084c8b16-7aae-4d1f-87c2-6a150f11bb15.jpg?1",
             "name": "Honor's Reward",
             "text": "You gain 4 life. Bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "e076fd37-4421-538f-82e5-2a6cdefd7334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa2d511-6eec-42dd-9ebe-1260c8527856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa2d511-6eec-42dd-9ebe-1260c8527856.jpg?1",
             "name": "Jeskai Barricade",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nDefender\nWhen Jeskai Barricade enters the battlefield, you may return another target creature you control to its owner's hand.",
             "colours": [
@@ -549,7 +549,7 @@
         },
         {
             "id": "9e258de6-9c67-5989-a4ca-b63dc381be8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa25045-ae03-4ac0-a4ed-472f7ca4ab3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa25045-ae03-4ac0-a4ed-472f7ca4ab3b.jpg?1",
             "name": "Lightform",
             "text": "When Lightform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Lightform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has flying and lifelink.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "5fc080a0-b8d8-55d5-9e17-fa0da88eed18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf97a0-2b90-4006-8a54-7795dbc0dba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf97a0-2b90-4006-8a54-7795dbc0dba1.jpg?1",
             "name": "Lotus-Eye Mystics",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Lotus-Eye Mystics enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "91e08ed7-943c-5a34-934e-98c056df551f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf14a32-b97b-48c7-8395-d9c3626735c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf14a32-b97b-48c7-8395-d9c3626735c1.jpg?1",
             "name": "Mardu Woe-Reaper",
             "text": "Whenever Mardu Woe-Reaper or another Warrior enters the battlefield under your control, you may exile target creature card from a graveyard. If you do, you gain 1 life.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "7ca6e73f-0c6f-512c-aaa3-bba1d6dbc700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b844764-89d4-43a2-8041-3a9a8b4f2912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b844764-89d4-43a2-8041-3a9a8b4f2912.jpg?1",
             "name": "Mastery of the Unseen",
             "text": "Whenever a permanent you control is turned face up, you gain 1 life for each creature you control.\n{3}{W}: Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "0d7b47c3-5d61-5c37-922d-ff3b05d91780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd0e32-2e6b-419b-9e8a-af38f2b48a66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd0e32-2e6b-419b-9e8a-af38f2b48a66.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, put a 1/1 white Monk creature token with prowess onto the battlefield.",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "a1d90aa6-c544-57cc-95a5-95d004f660f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0027360-736c-4b3e-b2cd-0d821cca587a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0027360-736c-4b3e-b2cd-0d821cca587a.jpg?1",
             "name": "Pressure Point",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "5260630e-4da4-507d-a765-a443a5a4ad37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9efacb-9d7c-41f4-9b11-59df1be50e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9efacb-9d7c-41f4-9b11-59df1be50e11.jpg?1",
             "name": "Rally the Ancestors",
             "text": "Return each creature card with converted mana cost X or less from your graveyard to the battlefield. Exile those creatures at the beginning of your next upkeep. Exile Rally the Ancestors.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "b07d8aec-03a7-5e64-9f57-017c1502d9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f22dd6f-807a-48a7-bc69-29aaec7012de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f22dd6f-807a-48a7-bc69-29aaec7012de.jpg?1",
             "name": "Sage's Reverie",
             "text": "Enchant creature\nWhen Sage's Reverie enters the battlefield, draw a card for each Aura you control that's attached to a creature.\nEnchanted creature gets +1/+1 for each Aura you control that's attached to a creature.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "a74fd5cc-3ae3-5588-a4d5-57bff74c4842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7305cd4-a9f1-4801-bdfe-b07869ed5b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7305cd4-a9f1-4801-bdfe-b07869ed5b56.jpg?1",
             "name": "Sandblast",
             "text": "Sandblast deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "a24b339d-a28c-5de8-b0c4-5db3ed16466e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29943bb-aa89-443b-96b7-8f6f24672a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29943bb-aa89-443b-96b7-8f6f24672a9d.jpg?1",
             "name": "Sandsteppe Outcast",
             "text": "When Sandsteppe Outcast enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Sandsteppe Outcast.\n\u2022 Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "b89a8481-b9cb-5c43-aedc-7b262788209d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb884ac2-c990-4ab0-8610-e07d93da2f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb884ac2-c990-4ab0-8610-e07d93da2f13.jpg?1",
             "name": "Soul Summons",
             "text": "Manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "3d659aa1-cf0a-5e0a-be42-0d0a045672ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3a4e7d-6667-4c2f-b6b4-484f401b0455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3a4e7d-6667-4c2f-b6b4-484f401b0455.jpg?1",
             "name": "Soulfire Grand Master",
             "text": "Lifelink\nInstant and sorcery spells you control have lifelink.\n{2}{UR}{UR}: The next time you cast an instant or sorcery spell from your hand this turn, put that card into your hand instead of into your graveyard as it resolves.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "514c8116-7abc-5ded-9b6d-1eb7e5785d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65998e94-15a0-41f1-8288-730b957f81df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65998e94-15a0-41f1-8288-730b957f81df.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "69fc424a-78b9-5348-9969-9a28f09e8ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59086792-c048-455f-ac0d-1a4a994bd621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59086792-c048-455f-ac0d-1a4a994bd621.jpg?1",
             "name": "Wandering Champion",
             "text": "Whenever Wandering Champion deals combat damage to a player, if you control a blue or red permanent, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "5500fdcb-3be5-5b08-ad05-181f381169dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4290215-3aec-40b8-aac5-e5c39c035cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4290215-3aec-40b8-aac5-e5c39c035cfe.jpg?1",
             "name": "Wardscale Dragon",
             "text": "Flying\nAs long as Wardscale Dragon is attacking, defending player can't cast spells.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "067a49a2-c497-59a8-a6a7-222c6effbd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2185d-46c6-44c1-a67c-9b6af872e8eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2185d-46c6-44c1-a67c-9b6af872e8eb.jpg?1",
             "name": "Aven Surveyor",
             "text": "Flying\nWhen Aven Surveyor enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Aven Surveyor.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "6d56715b-0bb4-580f-a367-dcaaa8146132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bb0f87-a0b3-4389-9580-63db449a2241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bb0f87-a0b3-4389-9580-63db449a2241.jpg?1",
             "name": "Cloudform",
             "text": "When Cloudform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Cloudform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has flying and hexproof.",
             "colours": [
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "8696e165-d286-5e6a-8b18-0597b17b1ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21df7db7-c23b-4dca-b9c8-c785d7007285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21df7db7-c23b-4dca-b9c8-c785d7007285.jpg?1",
             "name": "Enhanced Awareness",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "4a9308a6-7af6-5da8-8b55-6d981bae3b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c96615-0dcb-4108-978a-b41b43e12f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c96615-0dcb-4108-978a-b41b43e12f38.jpg?1",
             "name": "Fascination",
             "text": "Choose one \u2014\n\u2022 Each player draws X cards.\n\u2022 Each player puts the top X cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "7f6b29d8-05dd-51ac-abba-51de3aeef1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb2c83d-48db-4d0b-8c3a-f4b0353eeb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb2c83d-48db-4d0b-8c3a-f4b0353eeb86.jpg?1",
             "name": "Frost Walker",
             "text": "When Frost Walker becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "85e6e583-9e48-5c0c-a593-2d023eafa82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea15d083-551b-4c13-92ad-3fc2d5414ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea15d083-551b-4c13-92ad-3fc2d5414ab3.jpg?1",
             "name": "Jeskai Infiltrator",
             "text": "Jeskai Infiltrator can't be blocked as long as you control no other creatures.\nWhen Jeskai Infiltrator deals combat damage to a player, exile it and the top card of your library in a face-down pile, shuffle that pile, then manifest those cards. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "5566f778-703e-5663-a31c-43e304e269ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ada6302-326b-4ab1-a9a3-ae4fa6a9001c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ada6302-326b-4ab1-a9a3-ae4fa6a9001c.jpg?1",
             "name": "Jeskai Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has flying as long as you control a red or white permanent.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "e6d75d27-bd5a-5af3-b542-69d5fdf90cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff4734-7b2a-4089-a78a-46199818f39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff4734-7b2a-4089-a78a-46199818f39d.jpg?1",
             "name": "Jeskai Sage",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Jeskai Sage dies, draw a card.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "16e101e1-1043-585a-a5d6-5d4e14fb7cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ec248-70d9-47f4-a53b-99b23f021116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197ec248-70d9-47f4-a53b-99b23f021116.jpg?1",
             "name": "Lotus Path Djinn",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "de002232-fb3a-5b89-bfdf-304ae5c3f542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8174c-da93-414e-b89c-c588a2c4ed0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8174c-da93-414e-b89c-c588a2c4ed0c.jpg?1",
             "name": "Marang River Prowler",
             "text": "Marang River Prowler can't block and can't be blocked.\nYou may cast Marang River Prowler from your graveyard as long as you control a black or green permanent.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "dc240c64-da4f-5b36-bd6c-9350e653d063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5708290-60ae-400c-b149-2a63153c2890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5708290-60ae-400c-b149-2a63153c2890.jpg?1",
             "name": "Mindscour Dragon",
             "text": "Flying\nWhenever Mindscour Dragon deals combat damage to an opponent, target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "33929abf-b781-5d4d-b872-fd8f4d7a33de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb2388-9ec4-496a-a63e-6b3f33a608a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb2388-9ec4-496a-a63e-6b3f33a608a7.jpg?1",
             "name": "Mistfire Adept",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, target creature gains flying until end of turn.",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "73d67c3d-1468-5da8-9073-0448a2ab3d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef398b5-38f7-4a11-8fcf-d4e0d27267cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef398b5-38f7-4a11-8fcf-d4e0d27267cf.jpg?1",
             "name": "Monastery Siege",
             "text": "As Monastery Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your draw step, draw an additional card, then discard a card.\n\u2022 Dragons \u2014 Spells your opponents cast that target you or a permanent you control cost {2} more to cast.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "44e6f00e-dcc3-58df-8c62-a2433ac13120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30154ecf-f7ae-435b-a339-0219650bebed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30154ecf-f7ae-435b-a339-0219650bebed.jpg?1",
             "name": "Monastery Siege",
             "text": "",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "2a29760a-6fb2-5286-8cf0-3131ca14dd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549a8fc-6001-43db-88b1-ce8ed42a3443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549a8fc-6001-43db-88b1-ce8ed42a3443.jpg?1",
             "name": "Neutralizing Blast",
             "text": "Counter target multicolored spell.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "0243ded6-df0f-5181-a923-4e12722ef835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9e8a25-2e71-431b-897f-8b62520a3ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9e8a25-2e71-431b-897f-8b62520a3ce9.jpg?1",
             "name": "Rakshasa's Disdain",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "ac5f7b6a-d6ce-59a1-9d05-7800f32b4388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01367cb-79f4-4ed9-b12c-66f3c30264a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01367cb-79f4-4ed9-b12c-66f3c30264a0.jpg?1",
             "name": "Reality Shift",
             "text": "Exile target creature. Its controller manifests the top card of his or her library. (That player puts the top card of his or her library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "4a354133-b78c-51f7-8e0e-b93dcd766c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c78973-f2ae-4c76-802f-793d1022fcbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c78973-f2ae-4c76-802f-793d1022fcbd.jpg?1",
             "name": "Refocus",
             "text": "Untap target creature.\nDraw a card.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "c612971c-a181-5e1f-949e-5de0c7f97142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500f72e0-2de2-4c02-bda0-8a61aa9b37fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500f72e0-2de2-4c02-bda0-8a61aa9b37fc.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {2} to your mana pool. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "c4ebfc30-ed41-5cf6-877a-21d7323defcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20afe614-a367-461a-a67b-02d5ed634cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20afe614-a367-461a-a67b-02d5ed634cc5.jpg?1",
             "name": "Rite of Undoing",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nReturn target nonland permanent you control and target nonland permanent you don't control to their owners' hands.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "70c2a1d4-c96b-56d0-af30-38b77931a969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8050bb72-4fd4-4acd-ab21-e83f8503dcc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8050bb72-4fd4-4acd-ab21-e83f8503dcc1.jpg?1",
             "name": "Sage-Eye Avengers",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Sage-Eye Avengers attacks, you may return target creature to its owner's hand if its power is less than Sage-Eye Avengers's power.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "9040f0fe-1f30-5609-8ce5-ef2a8aef46a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9ff175-2e4c-4658-813e-1bfb4b9a6ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed9ff175-2e4c-4658-813e-1bfb4b9a6ca0.jpg?1",
             "name": "Shifting Loyalties",
             "text": "Exchange control of two target permanents that share a card type. (Artifact, creature, enchantment, land, and planeswalker are card types.)",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "9351cdc9-d49a-5779-8a4d-4faf4bbfdd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79e83a-a34b-472c-9317-12af4ed2ca28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd79e83a-a34b-472c-9317-12af4ed2ca28.jpg?1",
             "name": "Shu Yun, the Silent Tempest",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, you may pay {GU}{GU}. If you do, target creature gains double strike until end of turn.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "171895f0-682c-55f0-bf70-fd893f742c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a93355-553c-456b-999b-e9f826a1f572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a93355-553c-456b-999b-e9f826a1f572.jpg?1",
             "name": "Sultai Skullkeeper",
             "text": "When Sultai Skullkeeper enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "ace37ff3-6ef4-558d-bb27-c7ad5c0d664c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df927c0-9aa9-450b-ab2a-ae12c5489d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df927c0-9aa9-450b-ab2a-ae12c5489d57.jpg?1",
             "name": "Supplant Form",
             "text": "Return target creature to its owner's hand. You put a token onto the battlefield that's a copy of that creature.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "aec2010f-08c8-5d60-b6e0-e3b413889fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b7a1e-b404-41ea-875f-b3468501cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b7a1e-b404-41ea-875f-b3468501cb4b.jpg?1",
             "name": "Temporal Trespass",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTake an extra turn after this one. Exile Temporal Trespass.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "1b8721c2-64ac-5b42-a9a0-fdd8cde03f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4850e4-acb9-458d-952f-b3952cab2a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4850e4-acb9-458d-952f-b3952cab2a5b.jpg?1",
             "name": "Torrent Elemental",
             "text": "Flying\nWhenever Torrent Elemental attacks, tap all creatures defending player controls.\n{3}{BG}{BG}: Put Torrent Elemental from exile onto the battlefield tapped. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "78304174-b3d0-5e91-ae4f-5f02a65cb3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5d96a9-11dd-44cc-baf1-bab298ae03f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5d96a9-11dd-44cc-baf1-bab298ae03f0.jpg?1",
             "name": "Whisk Away",
             "text": "Put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "071dfb78-6e25-5240-bf52-d1dd5cd16825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed1c4d-f11e-476a-bbb2-06ffc6e261f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed1c4d-f11e-476a-bbb2-06ffc6e261f3.jpg?1",
             "name": "Will of the Naga",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "1e9944c0-f47a-54ce-b2af-90c4d6d4b383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e6fbe-cda0-4fbf-853c-c03c567a7de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e6fbe-cda0-4fbf-853c-c03c567a7de9.jpg?1",
             "name": "Write into Being",
             "text": "Look at the top two cards of your library. Manifest one of those cards, then put the other on the top or bottom of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "09cbd9ec-5b45-5498-a0fd-80436ee21ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb135f-1c58-42ed-bbf2-4a2e842f99d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb135f-1c58-42ed-bbf2-4a2e842f99d7.jpg?1",
             "name": "Alesha's Vanguard",
             "text": "Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "0da8c72e-abbe-5937-8f87-d0849c981b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0094e-07ff-4b47-8c6e-500adabf12e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d0094e-07ff-4b47-8c6e-500adabf12e4.jpg?1",
             "name": "Ancestral Vengeance",
             "text": "Enchant creature\nWhen Ancestral Vengeance enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted creature gets -1/-1.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "fdf5cd5b-85ed-58c1-82d3-f2b273938bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e343b5-37d6-44f6-be24-66313f18c246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e343b5-37d6-44f6-be24-66313f18c246.jpg?1",
             "name": "Archfiend of Depravity",
             "text": "Flying\nAt the beginning of each opponent's end step, that player chooses up to two creatures he or she controls, then sacrifices the rest.",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "e76ff1dc-d103-5afd-b952-7e6e454d911b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9b5baf-6163-48a9-b58d-195edfeb437d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9b5baf-6163-48a9-b58d-195edfeb437d.jpg?1",
             "name": "Battle Brawler",
             "text": "As long as you control a red or white permanent, Battle Brawler gets +1/+0 and has first strike.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "683ce3b9-42f4-5578-a808-b722a463596f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8ec769-99cd-4542-9b4d-61ee41b622bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8ec769-99cd-4542-9b4d-61ee41b622bc.jpg?1",
             "name": "Brutal Hordechief",
             "text": "Whenever a creature you control attacks, defending player loses 1 life and you gain 1 life.\n{3}{GU}{GU}: Creatures your opponents control block this turn if able, and you choose how those creatures block.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "1b019d3c-63a9-5aa7-93d1-05db927e97db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d45374-a41b-4b3f-a7c8-3eb5ca767cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d45374-a41b-4b3f-a7c8-3eb5ca767cf6.jpg?1",
             "name": "Crux of Fate",
             "text": "Choose one \u2014\n\u2022 Destroy all Dragon creatures.\n\u2022 Destroy all non-Dragon creatures.",
             "colours": [
@@ -2267,7 +2267,7 @@
         },
         {
             "id": "fa59488e-a199-58cb-92bd-ff0e29c92278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c13a4-c077-4f9b-ba0f-9fc81b53e58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c13a4-c077-4f9b-ba0f-9fc81b53e58a.jpg?1",
             "name": "Crux of Fate",
             "text": "",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "04cffe1f-a7f4-5031-886b-a4f45bef34ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69dfaafe-2fbd-4f2f-913d-ea64e4ce44cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69dfaafe-2fbd-4f2f-913d-ea64e4ce44cd.jpg?1",
             "name": "Dark Deal",
             "text": "Each player discards all the cards in his or her hand, then draws that many cards minus one.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "132d2e97-9c4d-5f1a-b6ea-d24ac3e5e3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69faf63b-f39b-4005-a35d-1204faaa6d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69faf63b-f39b-4005-a35d-1204faaa6d57.jpg?1",
             "name": "Diplomacy of the Wastes",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from it. That player discards that card. If you control a Warrior, that player loses 2 life.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "9e4f2ed4-1882-5d50-833f-21dd78ae7849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b710fcd-0721-4720-a8fa-6d9ceb7b8104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b710fcd-0721-4720-a8fa-6d9ceb7b8104.jpg?1",
             "name": "Douse in Gloom",
             "text": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "2de3a528-ff43-5617-96f6-726e92299569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a672979-024a-4f69-91ae-a2cf4055e0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a672979-024a-4f69-91ae-a2cf4055e0a8.jpg?1",
             "name": "Fearsome Awakening",
             "text": "Return target creature card from your graveyard to the battlefield. If it's a Dragon, put two +1/+1 counters on it.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "0fbb9101-a4b5-588f-851b-0b842be73175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f7d4a-27b3-43e8-a301-c81d4d403a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f7d4a-27b3-43e8-a301-c81d4d403a8f.jpg?1",
             "name": "Ghastly Conscription",
             "text": "Exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "07221efb-b001-5e54-a595-85c418cb69df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bc4463-69f6-4039-987d-e5db2ef256d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bc4463-69f6-4039-987d-e5db2ef256d5.jpg?1",
             "name": "Grave Strength",
             "text": "Choose target creature. Put the top three cards of your library into your graveyard, then put a +1/+1 counter on that creature for each creature card in your graveyard.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "75acd622-5868-5a63-ab54-5385d21efe43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a8cf1-a8c7-4f45-bbd3-188fab2652f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a8cf1-a8c7-4f45-bbd3-188fab2652f9.jpg?1",
             "name": "Gurmag Angler",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "b105d337-eca5-5ed5-b63e-ebb9637b1253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d4da1d-5b8c-43be-aa30-22df69c0cc23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d4da1d-5b8c-43be-aa30-22df69c0cc23.jpg?1",
             "name": "Hooded Assassin",
             "text": "When Hooded Assassin enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Hooded Assassin.\n\u2022 Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "a354dbea-8cbe-5d36-9fd4-128b1928189b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f55b50-b3b1-4336-914c-1cc2669b8fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f55b50-b3b1-4336-914c-1cc2669b8fac.jpg?1",
             "name": "Mardu Shadowspear",
             "text": "Whenever Mardu Shadowspear attacks, each opponent loses 1 life.\nDash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "f6a9ebd9-bedb-55ed-85f2-b5d06cef55d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93fd5f0-fb62-42cc-8c7d-c0368e191c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93fd5f0-fb62-42cc-8c7d-c0368e191c4b.jpg?1",
             "name": "Mardu Strike Leader",
             "text": "Whenever Mardu Strike Leader attacks, put a 2/1 black Warrior creature token onto the battlefield.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "579ee755-5e39-5a90-948d-9f085d0c1965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c588d7a-e352-40a0-9fc7-55c7b4bfd013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c588d7a-e352-40a0-9fc7-55c7b4bfd013.jpg?1",
             "name": "Merciless Executioner",
             "text": "When Merciless Executioner enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "c653169e-aef2-58ce-a01e-6bd2c3cbb79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cece7235-604c-49b6-b80f-3229a20b154f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cece7235-604c-49b6-b80f-3229a20b154f.jpg?1",
             "name": "Noxious Dragon",
             "text": "Flying\nWhen Noxious Dragon dies, you may destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "c18ed337-6523-5726-b70e-8b31e5868149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/292326cd-4b90-40c6-88b1-f8560fde236c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/292326cd-4b90-40c6-88b1-f8560fde236c.jpg?1",
             "name": "Orc Sureshot",
             "text": "Whenever another creature enters the battlefield under your control, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "f1070ff9-1c8f-57f8-bf61-c9d69b44b3ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee5a83-7096-4cbd-ad16-eb839d293d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ee5a83-7096-4cbd-ad16-eb839d293d88.jpg?1",
             "name": "Palace Siege",
             "text": "As Palace Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your upkeep, return target creature card from your graveyard to your hand.\n\u2022 Dragons \u2014 At the beginning of your upkeep, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "eab5e691-9ab3-5d77-bcbf-0cd4e43ef63d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367945dd-871a-46c9-b047-c701e664d2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367945dd-871a-46c9-b047-c701e664d2bb.jpg?1",
             "name": "Palace Siege",
             "text": "",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "cc0ed524-5f8c-5ffb-b44b-bd4624825d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1bdbc-2bf4-4036-bf83-669c27458c6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c1bdbc-2bf4-4036-bf83-669c27458c6e.jpg?1",
             "name": "Qarsi High Priest",
             "text": "{1}{B}, {T}, Sacrifice another creature: Manifest the top card of your library. (Put that card onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "cbd38ede-f8b2-5c5c-906b-f87c7b485b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9a803-473a-4c38-b352-d47c4fd93d5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9a803-473a-4c38-b352-d47c4fd93d5e.jpg?1",
             "name": "Reach of Shadows",
             "text": "Destroy target creature that's one or more colors.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "3579c2f6-d4f7-5020-ab94-8310333efd60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2791f1a5-bf29-48ac-8a41-88b7f97ede41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2791f1a5-bf29-48ac-8a41-88b7f97ede41.jpg?1",
             "name": "Sibsig Host",
             "text": "When Sibsig Host enters the battlefield, each player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "9ee21aa6-8ee7-5f3d-a9bf-333552c5dd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88297c1-c612-47bf-80b7-374099b00e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88297c1-c612-47bf-80b7-374099b00e07.jpg?1",
             "name": "Sibsig Muckdraggers",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nWhen Sibsig Muckdraggers enters the battlefield, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "68a9f77e-60f7-5cb6-85d0-66929bc46f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5084c8ff-1296-4d8e-bd06-93b1a3401661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5084c8ff-1296-4d8e-bd06-93b1a3401661.jpg?1",
             "name": "Soulflayer",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nIf a creature card with flying was exiled with Soulflayer's delve ability, Soulflayer has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, reach, trample, and vigilance.",
             "colours": [
@@ -2971,7 +2971,7 @@
         },
         {
             "id": "dc86a473-46cd-54e4-b16a-2f3588442418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12421e1c-5144-4391-abf2-a2fb864920e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12421e1c-5144-4391-abf2-a2fb864920e9.jpg?1",
             "name": "Sultai Emissary",
             "text": "When Sultai Emissary dies, manifest the top card of your library. (Put that card onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "92ad5992-9ed9-5486-9992-b615beb1752a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d73ae0-de01-4a70-a51c-b990687561a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d73ae0-de01-4a70-a51c-b990687561a1.jpg?1",
             "name": "Sultai Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has deathtouch as long as you control a green or blue permanent. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3040,7 +3040,7 @@
         },
         {
             "id": "bbd2b1f9-891d-5178-830a-3de690491f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f93ac5-d149-4ccf-8b99-13ecf3190c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f93ac5-d149-4ccf-8b99-13ecf3190c29.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n{2}{GW}{GW}: Put the top two cards of your library into your graveyard, then return a nonland card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "429be107-fcba-5331-be63-69b5fa21301f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169748df-10ac-4db4-ba94-192345c6fad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169748df-10ac-4db4-ba94-192345c6fad3.jpg?1",
             "name": "Tasigur's Cruelty",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nEach opponent discards two cards.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "90a3ef51-f84e-5eed-8e25-e35a9554de03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb90b-50c3-46ef-83f8-812dfb7ff881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cb90b-50c3-46ef-83f8-812dfb7ff881.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "2cb4304e-dc77-5247-8862-93f3ffed528a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac9669-d0ee-4df8-af77-12dfccac774f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ac9669-d0ee-4df8-af77-12dfccac774f.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "fc19b800-7fc9-50c4-ad11-a888d8235344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc397d1-50a8-46cd-98b2-7104f2241420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc397d1-50a8-46cd-98b2-7104f2241420.jpg?1",
             "name": "Arcbond",
             "text": "Choose target creature. Whenever that creature is dealt damage this turn, it deals that much damage to each other creature and each player.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "a96d5e4d-8ab5-587b-b00e-ee7d9392a471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cc6931-2005-4d0a-a42a-ce8bc279372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cc6931-2005-4d0a-a42a-ce8bc279372e.jpg?1",
             "name": "Bathe in Dragonfire",
             "text": "Bathe in Dragonfire deals 4 damage to target creature.",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "61b883cb-182f-544a-a71c-dbf14cd6c67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f0a37-32d6-4c1f-858d-7eec096dd42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f0a37-32d6-4c1f-858d-7eec096dd42a.jpg?1",
             "name": "Bloodfire Enforcers",
             "text": "Bloodfire Enforcers has first strike and trample as long as an instant card and a sorcery card are in your graveyard.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "f1ec9108-caa5-5150-8643-ce5b38e94197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1cdbe-5ddb-4cc6-975b-42f3f1ee4749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1cdbe-5ddb-4cc6-975b-42f3f1ee4749.jpg?1",
             "name": "Break Through the Line",
             "text": "{R}: Target creature with power 2 or less gains haste until end of turn and can't be blocked this turn.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "b0260fea-e364-592c-a7d1-99aad533e513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb738362-b0b4-4811-9fbf-5f45c852c822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb738362-b0b4-4811-9fbf-5f45c852c822.jpg?1",
             "name": "Collateral Damage",
             "text": "As an additional cost to cast Collateral Damage, sacrifice a creature.\nCollateral Damage deals 3 damage to target creature or player.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "cca7bade-fdbf-535a-a2b8-11e3266b962b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfd3d5-1b44-4dc7-b35d-703f3a75da88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfd3d5-1b44-4dc7-b35d-703f3a75da88.jpg?1",
             "name": "Defiant Ogre",
             "text": "When Defiant Ogre enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Defiant Ogre.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "1f92d38a-5dc2-5ff0-8318-56ca814157ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b7bf2a-9d68-4aa8-a0b1-5df22a5a3c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b7bf2a-9d68-4aa8-a0b1-5df22a5a3c1b.jpg?1",
             "name": "Dragonrage",
             "text": "Add {R} to your mana pool for each attacking creature you control. Until end of turn, attacking creatures you control gain \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -3414,7 +3414,7 @@
         },
         {
             "id": "1492641f-7659-5796-9d2f-4c9049532cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0137de04-9fd7-41b0-b497-163e6e93432b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0137de04-9fd7-41b0-b497-163e6e93432b.jpg?1",
             "name": "Fierce Invocation",
             "text": "Manifest the top card of your library, then put two +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "e62a42f9-3358-5738-8d82-334d00bc50e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304107d6-d096-43a1-956f-5a3b6ed6dc60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304107d6-d096-43a1-956f-5a3b6ed6dc60.jpg?1",
             "name": "Flamerush Rider",
             "text": "Whenever Flamerush Rider attacks, put a token onto the battlefield tapped and attacking that's a copy of another target attacking creature. Exile the token at end of combat.\nDash {2}{R}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "76445c57-6be2-5669-ba2f-4fdb382152da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd5848-9fe1-4129-a5d7-e51606bf76ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd5848-9fe1-4129-a5d7-e51606bf76ef.jpg?1",
             "name": "Flamewake Phoenix",
             "text": "Flying, haste\nFlamewake Phoenix attacks each turn if able.\nFerocious \u2014 At the beginning of combat on your turn, if you control a creature with power 4 or greater, you may pay {R}. If you do, return Flamewake Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "719cc9e6-c25c-5be5-8628-46a68ed15ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4272ca-bb15-415c-a589-a472953a0dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4272ca-bb15-415c-a589-a472953a0dd9.jpg?1",
             "name": "Friendly Fire",
             "text": "Target creature's controller reveals a card at random from his or her hand. Friendly Fire deals damage to that creature and that player equal to the revealed card's converted mana cost.",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "ef428f6d-e079-5d19-9495-4dd5f5ab2cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3bfeb6-95d6-4f00-8981-c6d3c9c93f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3bfeb6-95d6-4f00-8981-c6d3c9c93f67.jpg?1",
             "name": "Goblin Heelcutter",
             "text": "Whenever Goblin Heelcutter attacks, target creature can't block this turn.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "95c72e36-170a-5628-9ff8-595d4e0ef13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c36d53-1173-4a55-8fb8-63a624fde7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c36d53-1173-4a55-8fb8-63a624fde7de.jpg?1",
             "name": "Gore Swine",
             "text": "",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "7ab1d9e9-05b0-5f09-a5a5-8e328ce5cf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb0c13f-6cea-48b4-a5c8-2c0cfcfea7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb0c13f-6cea-48b4-a5c8-2c0cfcfea7fd.jpg?1",
             "name": "Humble Defector",
             "text": "{T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.",
             "colours": [
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "ca81d5d6-6d80-5841-b1e6-724ffbd6bf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7c596-5633-41e8-adcd-d4dc6eae5c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7c596-5633-41e8-adcd-d4dc6eae5c88.jpg?1",
             "name": "Hungering Yeti",
             "text": "As long as you control a green or blue permanent, you may cast Hungering Yeti as though it had flash. (You may cast it any time you could cast an instant.)",
             "colours": [
@@ -3685,7 +3685,7 @@
         },
         {
             "id": "7aa2932b-afe6-53f8-b8d4-d12aaf3aba37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0071bf6e-a78b-4286-b3e7-acf44631a001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0071bf6e-a78b-4286-b3e7-acf44631a001.jpg?1",
             "name": "Lightning Shrieker",
             "text": "Flying, trample, haste\nAt the beginning of the end step, Lightning Shrieker's owner shuffles it into his or her library.",
             "colours": [
@@ -3719,7 +3719,7 @@
         },
         {
             "id": "bd70c5a6-ae97-54b0-a274-813c8aba47a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333df10b-7db4-4f8a-a754-e8a630b26cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333df10b-7db4-4f8a-a754-e8a630b26cac.jpg?1",
             "name": "Mardu Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has first strike as long as you control a white or black permanent.",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "106dd845-f8f9-5029-a737-c7cc84a91696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7891b8-ba69-4c5b-a29f-ee7bcf2374f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7891b8-ba69-4c5b-a29f-ee7bcf2374f0.jpg?1",
             "name": "Mardu Scout",
             "text": "Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "8fd346d9-55e1-5b96-8739-83a4868964e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d76845f-c827-4cb4-b2d0-3f2cf5ee0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d76845f-c827-4cb4-b2d0-3f2cf5ee0e81.jpg?1",
             "name": "Mob Rule",
             "text": "Choose one \u2014\n\u2022 Gain control of all creatures with power 4 or greater until end of turn. Untap those creatures. They gain haste until end of turn.\n\u2022 Gain control of all creatures with power 3 or less until end of turn. Untap those creatures. They gain haste until end of turn.",
             "colours": [
@@ -3820,7 +3820,7 @@
         },
         {
             "id": "30ee6a96-0e6f-5eff-8e37-79d9b2a117d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880f6602-f335-4ad8-9e2f-f32b6d715f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880f6602-f335-4ad8-9e2f-f32b6d715f72.jpg?1",
             "name": "Outpost Siege",
             "text": "As Outpost Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of your upkeep, exile the top card of your library. Until end of turn, you may play that card.\n\u2022 Dragons \u2014 Whenever a creature you control leaves the battlefield, Outpost Siege deals 1 damage to target creature or player.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "cf0666f8-634d-5300-9ea9-893998b816c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a2034-25bf-4b42-9f47-a2418d48286c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a2034-25bf-4b42-9f47-a2418d48286c.jpg?1",
             "name": "Outpost Siege",
             "text": "",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "aedc7dc0-4fa3-5ca6-bbd6-1cd98247b69d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51893dd5-e70f-44bb-85d4-e31480ba84d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51893dd5-e70f-44bb-85d4-e31480ba84d6.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "904e6eee-fd1e-52c3-897e-a81240a07287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038ed726-bde8-46b0-bdf5-f88e2f074434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038ed726-bde8-46b0-bdf5-f88e2f074434.jpg?1",
             "name": "Rageform",
             "text": "When Rageform enters the battlefield, it becomes an Aura with enchant creature. Manifest the top card of your library and attach Rageform to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -3950,7 +3950,7 @@
         },
         {
             "id": "2a26719e-458d-5868-bcce-3b6c90958bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbd8cd1-465c-4501-94ba-5a3402f30ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbd8cd1-465c-4501-94ba-5a3402f30ded.jpg?1",
             "name": "Shaman of the Great Hunt",
             "text": "Haste\nWhenever a creature you control deals combat damage to a player, put a +1/+1 counter on it.\nFerocious \u2014 {2}{GW}{GW}: Draw a card for each creature you control with power 4 or greater.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "e8e4021b-fa65-57b4-9bcd-56c201e81218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4810919-b379-40db-a68b-a769dd3ee32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4810919-b379-40db-a68b-a769dd3ee32d.jpg?1",
             "name": "Shockmaw Dragon",
             "text": "Flying\nWhenever Shockmaw Dragon deals combat damage to a player, it deals 1 damage to each creature that player controls.",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "6b703c19-84ed-5907-9b10-a257e368e4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af33b204-6b50-4404-b986-9f6b970a7f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af33b204-6b50-4404-b986-9f6b970a7f06.jpg?1",
             "name": "Smoldering Efreet",
             "text": "When Smoldering Efreet dies, it deals 2 damage to you.",
             "colours": [
@@ -4056,7 +4056,7 @@
         },
         {
             "id": "ca57337e-e9d3-5b69-ba5b-3a65e94f63ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1dd786-f4e3-4951-b87b-82442edec016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1dd786-f4e3-4951-b87b-82442edec016.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -4088,7 +4088,7 @@
         },
         {
             "id": "9a32aa43-2408-5d32-a1a9-8aadc89bc1dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12891fcf-7118-428a-bdfe-9495a77f8b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12891fcf-7118-428a-bdfe-9495a77f8b3d.jpg?1",
             "name": "Vaultbreaker",
             "text": "Whenever Vaultbreaker attacks, you may discard a card. If you do, draw a card.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "90c23009-e53c-53f9-8f1b-c587e7cca750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6975490f-7679-48b3-ba34-04dec97a29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6975490f-7679-48b3-ba34-04dec97a29c2.jpg?1",
             "name": "Wild Slash",
             "text": "Ferocious \u2014 If you control a creature with power 4 or greater, damage can't be prevented this turn.\nWild Slash deals 2 damage to target creature or player.",
             "colours": [
@@ -4155,7 +4155,7 @@
         },
         {
             "id": "a9b0162b-d9a2-5001-8036-f7e29d0688c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c4ab2-1f7c-469b-a72a-d435213f130c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c4ab2-1f7c-469b-a72a-d435213f130c.jpg?1",
             "name": "Abzan Beastmaster",
             "text": "At the beginning of your upkeep, draw a card if you control the creature with the greatest toughness or tied for the greatest toughness.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "c705cd87-8234-54d9-9031-f61ca5abff72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec0ef55-57fd-404f-b9f6-b5d41e77b58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec0ef55-57fd-404f-b9f6-b5d41e77b58c.jpg?1",
             "name": "Abzan Kin-Guard",
             "text": "Abzan Kin-Guard has lifelink as long as you control a white or black permanent.",
             "colours": [
@@ -4225,7 +4225,7 @@
         },
         {
             "id": "52d0092c-8c98-565a-a2ce-f9d4ca4e404f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c361ea9c-a989-4ded-8b2c-f565aa9d8a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c361ea9c-a989-4ded-8b2c-f565aa9d8a1d.jpg?1",
             "name": "Ainok Guide",
             "text": "When Ainok Guide enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Ainok Guide.\n\u2022 Search your library for a basic land card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "5c9ed491-b1e8-5c37-80e5-e987cafd3e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3068c6-d403-46d5-b3d7-1c3b00b9a9b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3068c6-d403-46d5-b3d7-1c3b00b9a9b1.jpg?1",
             "name": "Ambush Krotiq",
             "text": "Trample\nWhen Ambush Krotiq enters the battlefield, return another creature you control to its owner's hand.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "d45b58f6-9382-593f-9d59-0d0aa419ff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aed11a-0831-4619-931f-7dfded999c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aed11a-0831-4619-931f-7dfded999c66.jpg?1",
             "name": "Arashin War Beast",
             "text": "Whenever Arashin War Beast deals combat damage to one or more blocking creatures, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4328,7 +4328,7 @@
         },
         {
             "id": "288005ec-7474-5fe7-95d9-e902865f8176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcf0074-162a-4cc0-9726-8672a0261307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcf0074-162a-4cc0-9726-8672a0261307.jpg?1",
             "name": "Archers of Qarsi",
             "text": "Defender\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "5fd77950-33b7-54cf-a44c-25d12e90862b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b425cd-c5a5-48e9-b697-3860dfa6d5d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b425cd-c5a5-48e9-b697-3860dfa6d5d3.jpg?1",
             "name": "Battlefront Krushok",
             "text": "Battlefront Krushok can't be blocked by more than one creature.\nEach creature you control with a +1/+1 counter on it can't be blocked by more than one creature.",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "59a38e97-4db8-59d3-a010-b4ecb7f2b66e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad36cf-5f29-41c4-b2a3-6b8e8c0c493f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad36cf-5f29-41c4-b2a3-6b8e8c0c493f.jpg?1",
             "name": "Cached Defenses",
             "text": "Bolster 3. (Choose a creature with the least toughness among creatures you control and put three +1/+1 counters on it.)",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "10206d79-148d-5d99-b2f5-ffd2d4abbfde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cb2f2-00ed-46a3-a69d-5360e1558b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cb2f2-00ed-46a3-a69d-5360e1558b03.jpg?1",
             "name": "Destructor Dragon",
             "text": "Flying\nWhen Destructor Dragon dies, destroy target noncreature permanent.",
             "colours": [
@@ -4463,7 +4463,7 @@
         },
         {
             "id": "15ad54d1-0567-51dd-9809-b90f7acadf31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041996b-c265-4c4f-a52c-dfe29b2e282d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5041996b-c265-4c4f-a52c-dfe29b2e282d.jpg?1",
             "name": "Feral Krushok",
             "text": "",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "c5141733-10b6-5486-ad53-39ad25e18045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70646e4-936a-4c2a-8d4a-a2c659733093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70646e4-936a-4c2a-8d4a-a2c659733093.jpg?1",
             "name": "Formless Nurturing",
             "text": "Manifest the top card of your library, then put a +1/+1 counter on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "663d16c3-70fc-5d58-9d4e-216dc049f484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c09fe7-d55f-49b4-95c9-a3bb36baa3aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c09fe7-d55f-49b4-95c9-a3bb36baa3aa.jpg?1",
             "name": "Frontier Mastodon",
             "text": "Ferocious \u2014 Frontier Mastodon enters the battlefield with a +1/+1 counter on it if you control a creature with power 4 or greater.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "fbb94c50-7b98-502f-bfaf-a852edf628c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a474981a-581a-49c0-a036-87afaaeea7ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a474981a-581a-49c0-a036-87afaaeea7ef.jpg?1",
             "name": "Frontier Siege",
             "text": "As Frontier Siege enters the battlefield, choose Khans or Dragons.\n\u2022 Khans \u2014 At the beginning of each of your main phases, add {G}{G} to your mana pool.\n\u2022 Dragons \u2014 Whenever a creature with flying enters the battlefield under your control, you may have it fight target creature you don't control.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "63120617-fd87-5cef-8f91-dd4ba57f801b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d6b939-8331-49d2-a59a-3054c7b0f353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d6b939-8331-49d2-a59a-3054c7b0f353.jpg?1",
             "name": "Frontier Siege",
             "text": "",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "12d8fad9-94e8-5d8e-bbd3-d73bf82b100b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3e6a6a-4a19-41e1-b29e-a8f19838efe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3e6a6a-4a19-41e1-b29e-a8f19838efe3.jpg?1",
             "name": "Fruit of the First Tree",
             "text": "Enchant creature\nWhen enchanted creature dies, you gain X life and draw X cards, where X is its toughness.",
             "colours": [
@@ -4663,7 +4663,7 @@
         },
         {
             "id": "52a2b10e-3d40-587a-ad9e-af2183914bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdaf8bc-e7ce-4cfc-963a-c3fb924a8fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdaf8bc-e7ce-4cfc-963a-c3fb924a8fa7.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4695,7 +4695,7 @@
         },
         {
             "id": "cafe82f9-67a6-5d2b-be5a-847b532ab59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b61b1-79d5-44b6-8c0f-b8e8e508e5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b61b1-79d5-44b6-8c0f-b8e8e508e5a9.jpg?1",
             "name": "Map the Wastes",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Bolster 1. (Choose a creature with the least toughness among creatures you control and put a +1/+1 counter on it.)",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "4b5c66a4-7110-58a2-8cf7-6b39fa348d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a53144-2ef3-47d9-a176-73d620202df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a53144-2ef3-47d9-a176-73d620202df6.jpg?1",
             "name": "Return to the Earth",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -4759,7 +4759,7 @@
         },
         {
             "id": "4a20137b-474a-5d8f-86a3-8713a9eb6ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c8bfde-c4c5-40de-83de-ff236999d79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c8bfde-c4c5-40de-83de-ff236999d79b.jpg?1",
             "name": "Ruthless Instincts",
             "text": "Choose one \u2014\n\u2022 Target nonattacking creature gains reach and deathtouch until end of turn. Untap it.\n\u2022 Target attacking creature gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "a55f9d9c-1e70-5eaa-aa45-8540c0e2e177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae01fb-12fa-444d-9d49-bfe195c2a5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae01fb-12fa-444d-9d49-bfe195c2a5a6.jpg?1",
             "name": "Sandsteppe Mastodon",
             "text": "Reach\nWhen Sandsteppe Mastodon enters the battlefield, bolster 5. (Choose a creature with the least toughness among creatures you control and put five +1/+1 counters on it.)",
             "colours": [
@@ -4825,7 +4825,7 @@
         },
         {
             "id": "2b25315e-0ce8-567b-9d79-61a36c4b2957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f2c73-26d8-42a6-acde-2c5a2f4e21a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f2c73-26d8-42a6-acde-2c5a2f4e21a1.jpg?1",
             "name": "Shamanic Revelation",
             "text": "Draw a card for each creature you control.\nFerocious \u2014 You gain 4 life for each creature you control with power 4 or greater.",
             "colours": [
@@ -4857,7 +4857,7 @@
         },
         {
             "id": "3b17826d-2ac8-5876-a55a-b191119bd18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac7645d-ea10-4ca6-92a5-ac3418c6a510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac7645d-ea10-4ca6-92a5-ac3418c6a510.jpg?1",
             "name": "Sudden Reclamation",
             "text": "Put the top four cards of your library into your graveyard, then return a creature card and a land card from your graveyard to your hand.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "10aa246f-d9d0-55ad-9c68-0cbb5363da11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd76874-842e-4f4c-b18e-0e441dae59d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd76874-842e-4f4c-b18e-0e441dae59d7.jpg?1",
             "name": "Temur Runemark",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature has trample as long as you control a blue or red permanent.",
             "colours": [
@@ -4923,7 +4923,7 @@
         },
         {
             "id": "6b20767a-e3dd-5a36-8467-5e072529c71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d54da7c-8828-4d34-bfd0-a654692d3f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d54da7c-8828-4d34-bfd0-a654692d3f5a.jpg?1",
             "name": "Temur Sabertooth",
             "text": "{1}{G}: You may return another creature you control to its owner's hand. If you do, Temur Sabertooth gains indestructible until end of turn.",
             "colours": [
@@ -4957,7 +4957,7 @@
         },
         {
             "id": "7362464a-80ab-5a41-a59d-031e89df1f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873164f-d8eb-460e-a8cc-8b2a663dcf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a873164f-d8eb-460e-a8cc-8b2a663dcf3a.jpg?1",
             "name": "Temur War Shaman",
             "text": "When Temur War Shaman enters the battlefield, manifest the top card of your library. (Put that card onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever a permanent you control is turned face up, if it's a creature, you may have it fight target creature you don't control.",
             "colours": [
@@ -4992,7 +4992,7 @@
         },
         {
             "id": "328e770d-4a3e-58e3-b557-871681bf33c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0c6628-04f1-4800-baa8-bcaefe64f59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0c6628-04f1-4800-baa8-bcaefe64f59f.jpg?1",
             "name": "Warden of the First Tree",
             "text": "{1}{WB}: Warden of the First Tree becomes a Human Warrior with base power and toughness 3/3.\n{2}{WB}{WB}: If Warden of the First Tree is a Warrior, it becomes a Human Spirit Warrior with trample and lifelink.\n{3}{WB}{WB}{WB}: If Warden of the First Tree is a Spirit, put five +1/+1 counters on it.",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "f5bcd19a-740b-5b1c-bd7d-23636504d21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c66d388-b140-4d52-897a-6ac6cd68f980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c66d388-b140-4d52-897a-6ac6cd68f980.jpg?1",
             "name": "Whisperer of the Wilds",
             "text": "{T}: Add {G} to your mana pool.\nFerocious \u2014 {T}: Add {G}{G} to your mana pool. Activate this ability only if you control a creature with power 4 or greater.",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "8fdfeb71-2875-5625-a8ed-cf32f771499d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c61828-98b9-4264-b3dd-e83f881f4a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c61828-98b9-4264-b3dd-e83f881f4a67.jpg?1",
             "name": "Whisperwood Elemental",
             "text": "At the beginning of your end step, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nSacrifice Whisperwood Elemental: Until end of turn, face-up nontoken creatures you control gain \"When this creature dies, manifest the top card of your library.\"",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "7b8e2b08-a1a8-58a6-9caf-44be97d7639c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065fc4d8-c097-4d0e-81cf-22a0b694be9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065fc4d8-c097-4d0e-81cf-22a0b694be9a.jpg?1",
             "name": "Wildcall",
             "text": "Manifest the top card of your library, then put X +1/+1 counters on it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "625e838b-9c01-52fe-ae51-4e936ef5a4fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45d98d-b8bd-409d-bce9-d7d73be735a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45d98d-b8bd-409d-bce9-d7d73be735a9.jpg?1",
             "name": "Winds of Qal Sisma",
             "text": "Prevent all combat damage that would be dealt this turn.\nFerocious \u2014 If you control a creature with power 4 or greater, instead prevent all combat damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "a4e361b3-da80-52ea-9ab5-f7712eebafcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490994c6-9fef-482b-835d-a64350bfaa8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490994c6-9fef-482b-835d-a64350bfaa8d.jpg?1",
             "name": "Yasova Dragonclaw",
             "text": "Trample\nAt the beginning of combat on your turn, you may pay {1}{UR}{UR}. If you do, gain control of target creature an opponent controls with power less than Yasova Dragonclaw's power until end of turn, untap that creature, and it gains haste until end of turn.",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "56c1631d-7bdf-5c80-a368-dca6d2012282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c341df3-177c-49b4-91fe-38f73c64ef88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c341df3-177c-49b4-91fe-38f73c64ef88.jpg?1",
             "name": "Atarka, World Render",
             "text": "Flying, trample\nWhenever a Dragon you control attacks, it gains double strike until end of turn.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "937c4e71-3745-58d1-98fd-dbb1ec71bd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4991f81-3190-4d33-bf09-9d5387cbec11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4991f81-3190-4d33-bf09-9d5387cbec11.jpg?1",
             "name": "Cunning Strike",
             "text": "Cunning Strike deals 2 damage to target creature and 2 damage to target player.\nDraw a card.",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "8ff57104-30fd-5e02-a6c1-cdd62ae5cf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a10e86-d2cd-4193-85f5-5e4908c30e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a10e86-d2cd-4193-85f5-5e4908c30e7f.jpg?1",
             "name": "Dromoka, the Eternal",
             "text": "Flying\nWhenever a Dragon you control attacks, bolster 2. (Choose a creature with the least toughness among creatures you control and put two +1/+1 counters on it.)",
             "colours": [
@@ -5310,7 +5310,7 @@
         },
         {
             "id": "03a77f01-162d-5f39-b7d6-b0235bd3d434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d3f4d-eba3-4c45-8846-03b246e93f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d3f4d-eba3-4c45-8846-03b246e93f6c.jpg?1",
             "name": "Ethereal Ambush",
             "text": "Manifest the top two cards of your library. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -5344,7 +5344,7 @@
         },
         {
             "id": "e1f959fb-f897-5792-a953-790280d6eb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c44722-c65a-41ae-92a9-9c9d7d759a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c44722-c65a-41ae-92a9-9c9d7d759a8e.jpg?1",
             "name": "Grim Contest",
             "text": "Choose target creature you control and target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "36428486-2783-5d09-bc00-a513a53d108d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770d60a0-23fc-4224-873c-2e5549b3a816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770d60a0-23fc-4224-873c-2e5549b3a816.jpg?1",
             "name": "Harsh Sustenance",
             "text": "Harsh Sustenance deals X damage to target creature or player and you gain X life, where X is the number of creatures you control.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "e2eb5339-60e0-5a67-a91b-12bd110f6210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96376314-2085-4c57-861e-44d25e2d3bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96376314-2085-4c57-861e-44d25e2d3bc8.jpg?1",
             "name": "Kolaghan, the Storm's Fury",
             "text": "Flying\nWhenever a Dragon you control attacks, creatures you control get +1/+0 until end of turn.\nDash {3}{B}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "01a87dd9-e027-5750-beef-45f82da1c461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d470cd-9ff9-49d8-b66a-331cb6cf8257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d470cd-9ff9-49d8-b66a-331cb6cf8257.jpg?1",
             "name": "Ojutai, Soul of Winter",
             "text": "Flying, vigilance\nWhenever a Dragon you control attacks, tap target nonland permanent an opponent controls. That permanent doesn't untap during its controller's next untap step.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "ecc0f888-7056-5a64-8d0c-e4c73f965266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9108e7-6c39-4587-aa3a-0ec27f9761b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9108e7-6c39-4587-aa3a-0ec27f9761b2.jpg?1",
             "name": "Silumgar, the Drifting Death",
             "text": "Flying, hexproof\nWhenever a Dragon you control attacks, creatures defending player controls get -1/-1 until end of turn.",
             "colours": [
@@ -5526,7 +5526,7 @@
         },
         {
             "id": "8fbbe355-b0ed-52ac-b6a0-656b2df62d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243f33d8-ec20-4376-99c2-a12098773dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243f33d8-ec20-4376-99c2-a12098773dee.jpg?1",
             "name": "War Flare",
             "text": "Creatures you control get +2/+1 until end of turn. Untap those creatures.",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "654f272e-b755-5c88-ad58-125b9c57a79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14343e23-83fb-4d2e-a272-20d7787ef2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14343e23-83fb-4d2e-a272-20d7787ef2ca.jpg?1",
             "name": "Goblin Boom Keg",
             "text": "At the beginning of your upkeep, sacrifice Goblin Boom Keg.\nWhen Goblin Boom Keg is put into a graveyard from the battlefield, it deals 3 damage to target creature or player.",
             "colours": [],
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "cfa7f82b-e7de-5e9e-b60e-2213ff842847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69b72c1-232c-420e-b900-6dfe73cfff13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69b72c1-232c-420e-b900-6dfe73cfff13.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4}",
             "colours": [],
@@ -5618,7 +5618,7 @@
         },
         {
             "id": "3a05e49c-047c-5617-8350-9cede2ad1282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250bc19c-b882-42ae-b516-fe876d0d047d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250bc19c-b882-42ae-b516-fe876d0d047d.jpg?1",
             "name": "Hewed Stone Retainers",
             "text": "Cast Hewed Stone Retainers only if you've cast another spell this turn.",
             "colours": [],
@@ -5649,7 +5649,7 @@
         },
         {
             "id": "ea9b9595-9214-5508-a42f-b93c0957dab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a60623-d523-4b43-89b0-8e89568546c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a60623-d523-4b43-89b0-8e89568546c7.jpg?1",
             "name": "Pilgrim of the Fires",
             "text": "First strike, trample",
             "colours": [],
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "362c243a-56cb-5d1b-b340-092f790e4b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c7f24e-5ead-4b32-a804-4c89929508f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c7f24e-5ead-4b32-a804-4c89929508f6.jpg?1",
             "name": "Scroll of the Masters",
             "text": "Whenever you cast a noncreature spell, put a lore counter on Scroll of the Masters.\n{3}, {T}: Target creature you control gets +1/+1 until end of turn for each lore counter on Scroll of the Masters.",
             "colours": [],
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "52f97e1c-7515-54f3-8743-514eca0db0e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee009a4-72d0-4828-b826-3ed7c7d87b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee009a4-72d0-4828-b826-3ed7c7d87b53.jpg?1",
             "name": "Ugin's Construct",
             "text": "When Ugin's Construct enters the battlefield, sacrifice a permanent that's one or more colors.",
             "colours": [],
@@ -5739,7 +5739,7 @@
         },
         {
             "id": "fda1bc92-2a92-5435-ae87-a5ee2000b436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb65512-fb39-473e-b646-15ed81b55d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb65512-fb39-473e-b646-15ed81b55d17.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "8214e1e4-ba33-595f-ba88-52d1a7dff70c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247579f6-cf8c-4c61-aae6-e01c1d9237dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247579f6-cf8c-4c61-aae6-e01c1d9237dc.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "0b9ce27e-e344-5d0a-a6fb-5688920d093b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf563e0-1f42-4768-a667-3e120bdb6534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf563e0-1f42-4768-a667-3e120bdb6534.jpg?1",
             "name": "Crucible of the Spirit Dragon",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Crucible of the Spirit Dragon.\n{T}, Remove X storage counters from Crucible of the Spirit Dragon: Add X mana in any combination of colors to your mana pool. Spend this mana only to cast Dragon spells or activate abilities of Dragons.",
             "colours": [],
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "3931e802-c658-50d4-a11b-1c394c0bffdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69005861-f228-444d-ae64-d36ec74b23da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69005861-f228-444d-ae64-d36ec74b23da.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "317b5414-f93f-56b7-9a07-85b48c640a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b4535-468b-44b9-9ae3-d09a2228f1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b4535-468b-44b9-9ae3-d09a2228f1cc.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "ddcaf552-acc1-53da-bd8e-a708c915c3a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cfcbfc-f060-4610-a1ce-9437d6b32473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cfcbfc-f060-4610-a1ce-9437d6b32473.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5922,7 +5922,7 @@
         },
         {
             "id": "56efd197-9449-53ff-90e7-d7ab6b0d99e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f0d2ed-063a-4086-8563-de3bc71330cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f0d2ed-063a-4086-8563-de3bc71330cf.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "b7e6dec8-7541-5f0a-941a-348f0e678180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e3d45-5449-4479-893e-8c0f8d4b0154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8e3d45-5449-4479-893e-8c0f8d4b0154.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "fafa0a99-69e4-5366-add1-73f0518d379a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de1ade0-f4c7-4508-9fba-bbe00c634305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de1ade0-f4c7-4508-9fba-bbe00c634305.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -6015,7 +6015,7 @@
         },
         {
             "id": "085de752-ee66-5638-9269-f4e94f1b823c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ef7b5-ffad-4342-9a3a-f01a6d67d5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ef7b5-ffad-4342-9a3a-f01a6d67d5e2.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "ce175875-1450-5c86-92d2-49f144042678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43431a-d1cf-4f89-9c07-2efd6ac8f218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab43431a-d1cf-4f89-9c07-2efd6ac8f218.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -6077,7 +6077,7 @@
         },
         {
             "id": "341eb86c-5d5f-53af-9f23-2d69aeafde0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7eb6a-aed1-4fc9-9b10-06169fa50690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7eb6a-aed1-4fc9-9b10-06169fa50690.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6113,7 +6113,7 @@
         },
         {
             "id": "c2133aed-fc82-5b93-93d5-11665a74b50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133c49a9-6c43-4b52-8ee5-b1fb34cba060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133c49a9-6c43-4b52-8ee5-b1fb34cba060.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6149,7 +6149,7 @@
         },
         {
             "id": "c77a0a7a-0e98-58b7-b296-4913b1c82618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99702ff6-e496-422a-aa62-ec933110acf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99702ff6-e496-422a-aa62-ec933110acf7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6185,7 +6185,7 @@
         },
         {
             "id": "26c675c3-a585-59c2-88cb-222460c816fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899f42b3-2f7a-4d85-8883-ceae911473a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899f42b3-2f7a-4d85-8883-ceae911473a9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "b9673e78-16bc-50cd-be15-a624fd1e05f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21900fe6-ae43-42af-a601-d70c25457239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21900fe6-ae43-42af-a601-d70c25457239.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6257,7 +6257,7 @@
         },
         {
             "id": "1f6425b1-65c2-508e-bcea-ff269d75aa90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ace7e2d-17af-467d-a0fc-9af922189452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ace7e2d-17af-467d-a0fc-9af922189452.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "09b4b1bf-58c4-52af-ad84-51607f3c9320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55483163-c53a-424d-9cc4-74da9aa6dff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55483163-c53a-424d-9cc4-74da9aa6dff9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "a1048d2c-fe3f-5e03-90b3-6170fb16d57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d5cb40-7365-492b-a3bc-4a624f78cec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d5cb40-7365-492b-a3bc-4a624f78cec4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "2aafd7bf-285b-5444-a21c-c3bc21efcf42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b712739-df44-4c23-b076-0fb778aa6dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b712739-df44-4c23-b076-0fb778aa6dc4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "b88d9000-083f-5c76-994a-cc051fbf16a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d36c04-c238-412a-97de-63fc92840c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d36c04-c238-412a-97de-63fc92840c1e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6437,7 +6437,7 @@
         },
         {
             "id": "f675da35-e696-5a98-b8f9-3ae29c46c8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -6471,7 +6471,7 @@
         },
         {
             "id": "fc935967-06fc-55d4-b706-7d27c0a7a3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e32ad7-d59e-4cd8-ab88-3c7c0c083357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e32ad7-d59e-4cd8-ab88-3c7c0c083357.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -6505,7 +6505,7 @@
         },
         {
             "id": "6bd32f00-70a5-5a56-a22f-1b995028ad02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5eaba1-a7e1-4bbb-949c-e7f6a9592f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5eaba1-a7e1-4bbb-949c-e7f6a9592f50.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -6539,7 +6539,7 @@
         },
         {
             "id": "470d1083-a538-57bc-874f-bafc8157ade6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f896d4-34b4-407d-be7e-bf7a69aaf811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f896d4-34b4-407d-be7e-bf7a69aaf811.jpg?1",
             "name": "Manifest",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/FUT.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/FUT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b43d7a81-fdab-5540-8c21-8d00120c5a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf69645-d1f1-4836-bdc3-76874abcfd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf69645-d1f1-4836-bdc3-76874abcfd5f.jpg?1",
             "name": "Angel of Salvation",
             "text": "Flash; convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nFlying\nWhen Angel of Salvation comes into play, prevent the next 5 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "4797db27-910a-55d4-afa5-7ca4ff3233b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1fdf86-22aa-4c18-a971-8ff1fd8b3de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1fdf86-22aa-4c18-a971-8ff1fd8b3de1.jpg?1",
             "name": "Augur il-Vec",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSacrifice Augur il-Vec: You gain 4 life. Play this ability only during your upkeep.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "eeb28fe2-c190-5b59-8de6-5023d9c2d983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12220d53-3356-4541-aa43-a0de6ed3f7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12220d53-3356-4541-aa43-a0de6ed3f7d0.jpg?1",
             "name": "Barren Glory",
             "text": "At the beginning of your upkeep, if you control no permanents other than Barren Glory and have no cards in hand, you win the game.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "94cd3e76-00ad-5543-8715-e76a4aadc420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6989fd-05cf-4169-96c0-37c556454b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6989fd-05cf-4169-96c0-37c556454b92.jpg?1",
             "name": "Chronomantic Escape",
             "text": "Until your next turn, creatures can't attack you. Remove Chronomantic Escape from the game with three time counters on it.\nSuspend 3\u2014{2}{W} (Rather than play this card from your hand, you may pay {2}{W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "2831025f-a151-5cdc-866e-f5564992b3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c8f6f-8dcd-4b47-bc79-9657824cf1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c8f6f-8dcd-4b47-bc79-9657824cf1b7.jpg?1",
             "name": "Dust of Moments",
             "text": "Choose one Remove two time counters from each permanent and each suspended card; or put two time counters on each permanent with a time counter on it and each suspended card.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "1457ccee-92c4-53a1-a61c-6fc4ec24adb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704cd76-dca8-4526-b03f-7e3753d8fbb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704cd76-dca8-4526-b03f-7e3753d8fbb5.jpg?1",
             "name": "Even the Odds",
             "text": "Play Even the Odds only if you control fewer creatures than each opponent.\nPut three 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -201,7 +201,7 @@
         },
         {
             "id": "969794bb-95b2-57c3-95a0-a0dddad288f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b5231b-aed9-4b88-aba5-43e57a705dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b5231b-aed9-4b88-aba5-43e57a705dc5.jpg?1",
             "name": "Gift of Granite",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "ef358078-2c77-5345-81ea-9c8968f6d2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca127ef-349e-4380-875d-49c14fa03b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca127ef-349e-4380-875d-49c14fa03b18.jpg?1",
             "name": "Intervention Pact",
             "text": "Intervention Pact is white.\nThe next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.\nAt the beginning of your next upkeep, pay {1}{W}{W}. If you don't, you lose the game.",
             "colours": [
@@ -267,7 +267,7 @@
         },
         {
             "id": "376a7925-5683-53f6-831b-45784fa74c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0f9cb-f848-460e-94cc-d85b23133d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0f9cb-f848-460e-94cc-d85b23133d6e.jpg?1",
             "name": "Judge Unworthy",
             "text": "Choose target attacking or blocking creature. Scry 3, then reveal the top card of your library. Judge Unworthy deals damage equal to that card's converted mana cost to that creature. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -299,7 +299,7 @@
         },
         {
             "id": "1df10bb1-f0e3-5d02-bb6d-a5f4953d4999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b23129-25b2-4870-9462-ab12718ae7be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b23129-25b2-4870-9462-ab12718ae7be.jpg?1",
             "name": "Knight of Sursi",
             "text": "Flying, flanking\nSuspend 3\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "f3c162fa-25ad-5e4b-b9ba-c30ee8651cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834bfc49-9411-4a0f-b79b-d0d35f898952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834bfc49-9411-4a0f-b79b-d0d35f898952.jpg?1",
             "name": "Lost Auramancers",
             "text": "Vanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Lost Auramancers is put into a graveyard from play, if it had no time counters on it, you may search your library for an enchantment card and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "67450a81-338c-549d-9832-32caf17a3ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dcdda9-66a2-401f-9e1b-5603f771f56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dcdda9-66a2-401f-9e1b-5603f771f56f.jpg?1",
             "name": "Magus of the Moat",
             "text": "Creatures without flying can't attack.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "3df91cfb-d3e4-5294-82aa-88e2ff234a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d7f7e-8df3-4465-be07-83cb340cffc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920d7f7e-8df3-4465-be07-83cb340cffc1.jpg?1",
             "name": "Marshaling Cry",
             "text": "Creatures you control get +1/+1 and gain vigilance until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nFlashback {3}{W} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "57318d84-0440-5bf5-b5fb-78028c91d437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823bdf79-998f-4d7c-834d-7a474cfa895e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823bdf79-998f-4d7c-834d-7a474cfa895e.jpg?1",
             "name": "Saltskitter",
             "text": "Whenever another creature comes into play, remove Saltskitter from the game. Return Saltskitter to play under its owner's control at end of turn.",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "7b5c008e-67fe-5610-9ca2-db0157dab723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6aeea-0144-4148-b7a6-47b703f64af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6aeea-0144-4148-b7a6-47b703f64af9.jpg?1",
             "name": "Samite Censer-Bearer",
             "text": "{W}, Sacrifice Samite Censer-Bearer: Prevent the next 1 damage that would be dealt to each creature you control this turn.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "8bec845f-3d60-52f9-9337-5f85d47a70c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6639e3d-b0c4-4c08-83d5-f3fc58fac9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6639e3d-b0c4-4c08-83d5-f3fc58fac9b2.jpg?1",
             "name": "Scout's Warning",
             "text": "The next creature card you play this turn can be played as though it had flash.\nDraw a card.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "bf882285-f770-563f-8440-bb9d564a18dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0d6477-9c50-4196-a04f-da73b5a07e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0d6477-9c50-4196-a04f-da73b5a07e01.jpg?1",
             "name": "Spirit en-Dal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nForecast {1}{W}, Reveal Spirit en-Dal from your hand: Target creature gains shadow until end of turn. (Play this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "8d55ff4c-cfa1-5142-ab88-09636f9880c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ede8a-5317-4662-b964-a9bd202a4aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ede8a-5317-4662-b964-a9bd202a4aab.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "3c83aab8-25d2-5f31-9af3-2654add558b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ccfe28-ec08-4751-b65c-c40b2bafa955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ccfe28-ec08-4751-b65c-c40b2bafa955.jpg?1",
             "name": "Blade of the Sixth Pride",
             "text": "",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "8ba3daee-8e18-55ae-8566-23aa7bb5283c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a6e04-ce3b-4025-92ba-8980022b8038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8a6e04-ce3b-4025-92ba-8980022b8038.jpg?1",
             "name": "Bound in Silence",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "fac94213-9dd6-5084-b4f9-ec4765793139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f208f3d-ad21-477a-9e9b-de19afd536b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f208f3d-ad21-477a-9e9b-de19afd536b0.jpg?1",
             "name": "Daybreak Coronet",
             "text": "Enchant creature with another Aura attached to it\nEnchanted creature gets +3/+3 and has first strike, vigilance, and lifelink. (Whenever it deals damage, its controller gains that much life.)",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "028edd2d-eec3-59e6-a716-b120a4d89f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0eb4c-c8f1-40cf-ae0a-a413432b4c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0eb4c-c8f1-40cf-ae0a-a413432b4c5f.jpg?1",
             "name": "Goldmeadow Lookout",
             "text": "{W}, {T}, Discard a card: Put a 1/1 white Kithkin Soldier creature token named Goldmeadow Harrier into play with \"{W}, {T}: Tap target creature.\"",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "4f2d0431-aa3d-5fd9-b8da-e05a17943e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb02f692-80a9-4740-afde-cb4792d24774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb02f692-80a9-4740-afde-cb4792d24774.jpg?1",
             "name": "Imperial Mask",
             "text": "When Imperial Mask comes into play, if it's not a token, each of your teammates puts a token into play that's a copy of Imperial Mask.\nYou can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "4db420a9-bc0b-59a8-99fa-8037ad97a3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd700719-2f65-4fd5-b3aa-3e9402560c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd700719-2f65-4fd5-b3aa-3e9402560c79.jpg?1",
             "name": "Lucent Liminid",
             "text": "Flying",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "e76efd55-2ae9-52f2-9571-0806058598be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772bf1a3-ab2d-4fe6-830b-1c5ef8f5dc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772bf1a3-ab2d-4fe6-830b-1c5ef8f5dc07.jpg?1",
             "name": "Lumithread Field",
             "text": "Creatures you control get +0/+1.\nMorph {1}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "cbc1392f-11fc-52e9-be5d-722d9bba8dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cdb51f-c785-47d1-b23c-de74eeb22a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cdb51f-c785-47d1-b23c-de74eeb22a31.jpg?1",
             "name": "Lymph Sliver",
             "text": "All Sliver creatures have absorb 1. (If a source would deal damage to a Sliver, prevent 1 of that damage.)",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "2fc10375-ed28-55d9-838a-2bd0ca51a0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b45f8f-8f41-426d-b773-1e8cdfbff6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b45f8f-8f41-426d-b773-1e8cdfbff6f8.jpg?1",
             "name": "Mistmeadow Skulk",
             "text": "Protection from converted mana cost 3 or greater\nLifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "7a76b5a0-61c0-58a6-ae3d-c758c885fa1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9a3aeb-a316-4b1e-927b-36c3f999f2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9a3aeb-a316-4b1e-927b-36c3f999f2c3.jpg?1",
             "name": "Oriss, Samite Guardian",
             "text": "{T}: Prevent all damage that would be dealt to target creature this turn.\nGrandeur Discard another card named Oriss, Samite Guardian: Target player can't play spells this turn, and creatures that player controls can't attack this turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "2400c885-3546-55c1-93f8-53fd7a072751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfd70c-2923-4813-bf14-04194518163c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfd70c-2923-4813-bf14-04194518163c.jpg?1",
             "name": "Patrician's Scorn",
             "text": "If you played another white spell this turn, you may play Patrician's Scorn without paying its mana cost.\nDestroy all enchantments.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "37be15c4-bc82-5d95-affe-87a167b42fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250ee8d2-6f03-44a5-8f4c-ced4eaa4cdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250ee8d2-6f03-44a5-8f4c-ced4eaa4cdea.jpg?1",
             "name": "Ramosian Revivalist",
             "text": "{6}, {T}: Return target Rebel permanent card with converted mana cost 5 or less from your graveyard to play.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "5f5debdc-a2e4-5591-8fc7-c4e96b9fb284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092edca-cdc9-47e2-9c0c-e73c5a657777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092edca-cdc9-47e2-9c0c-e73c5a657777.jpg?1",
             "name": "Seht's Tiger",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Seht's Tiger comes into play, you gain protection from the color of your choice until end of turn. (You can't be targeted, dealt damage, or enchanted by anything of the chosen color.)",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "f98a04e8-f2f4-5b1d-a5a4-ef3e2294ea70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7599618-cbd9-4013-b0a5-4ba77fd52ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7599618-cbd9-4013-b0a5-4ba77fd52ab4.jpg?1",
             "name": "Aven Augur",
             "text": "Flying\nSacrifice Aven Augur: Return up to two target creatures to their owners' hands. Play this ability only during your upkeep.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "b2ceeb03-15c8-5694-8326-c0634f764892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727f9f4b-a8b6-47bd-9830-e69d118fe671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727f9f4b-a8b6-47bd-9830-e69d118fe671.jpg?1",
             "name": "Cloudseeder",
             "text": "Flying\n{U}, {T}, Discard a card: Put a 1/1 blue Faerie creature token named Cloud Sprite into play with flying and \"Cloud Sprite can block only creatures with flying.\"",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "9e90da30-0545-5224-8573-5c18f523804f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51026a-ae3c-4fa1-ac1e-96d44ae55b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a51026a-ae3c-4fa1-ac1e-96d44ae55b82.jpg?1",
             "name": "Cryptic Annelid",
             "text": "When Cryptic Annelid comes into play, scry 1, then scry 2, then scry 3. (To scry X, look at the top X cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "0e9113b4-b6a1-5564-919e-feb6a4b8198f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e821d337-4bc5-4401-ac9b-34adf4012b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e821d337-4bc5-4401-ac9b-34adf4012b73.jpg?1",
             "name": "Delay",
             "text": "Counter target spell. If the spell is countered this way, remove it from the game with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, remove a counter from that card. When the last is removed, the player plays it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "2049d8f3-991a-5e9f-a16a-ef940a6a0010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bd95b5-1e90-41c5-8a9f-f3009f3f504a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bd95b5-1e90-41c5-8a9f-f3009f3f504a.jpg?1",
             "name": "Foresee",
             "text": "Scry 4, then draw two cards. (To scry 4, look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "ad602a51-dd9d-5c13-9ade-68b90d2f12da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa2e4b5-aec8-43e0-9ef3-d9cbe1072f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa2e4b5-aec8-43e0-9ef3-d9cbe1072f18.jpg?1",
             "name": "Infiltrator il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSuspend 2\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "2928023e-5da0-5bbe-b5e0-9270eb442305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be497544-bbf0-472d-adf6-ff1fd1951370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be497544-bbf0-472d-adf6-ff1fd1951370.jpg?1",
             "name": "Leaden Fists",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets +3/+3 and doesn't untap during its controller's untap step.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "897f73d3-f77b-5b55-a49e-efd7252be6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c102f29-6f3f-4f97-8177-4307586bd1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c102f29-6f3f-4f97-8177-4307586bd1b2.jpg?1",
             "name": "Maelstrom Djinn",
             "text": "Flying\nMorph {2}{U}\nWhen Maelstrom Djinn is turned face up, put two time counters on it and it gains vanishing. (At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "9ec39787-7b67-58b8-bded-63feca7df62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7025e614-7d08-4915-a985-3b876f1bdd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7025e614-7d08-4915-a985-3b876f1bdd1c.jpg?1",
             "name": "Magus of the Future",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "800e94bf-6f50-510f-9637-22c8703c8292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adfcb4-6a0a-46f9-a171-bfa9fade2156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adfcb4-6a0a-46f9-a171-bfa9fade2156.jpg?1",
             "name": "Mystic Speculation",
             "text": "Buyback {2} (You may pay an additional {2} as you play this spell. If you do, put this card into your hand as it resolves.)\nScry 3 (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "a1b61724-cfd4-5301-9f8b-326cd572b4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca467a2-a2b3-4bdf-9d60-62979f675347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca467a2-a2b3-4bdf-9d60-62979f675347.jpg?1",
             "name": "Pact of Negation",
             "text": "Pact of Negation is blue.\nCounter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "d7fe7fd4-6814-53ca-ba73-90accaf1f280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d881a-f7b1-471f-bc0b-64a79bb491c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d881a-f7b1-471f-bc0b-64a79bb491c9.jpg?1",
             "name": "Reality Strobe",
             "text": "Return target permanent to its owner's hand. Remove Reality Strobe from the game with three time counters on it.\nSuspend 3\u2014{2}{U} (Rather than play this card from your hand, you may pay {2}{U} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "7b610dde-f3ce-55c7-9e26-3601bddf668d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78366049-4613-4cd1-aab0-308996926563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78366049-4613-4cd1-aab0-308996926563.jpg?1",
             "name": "Take Possession",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nEnchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "12059ea3-7324-51e4-99a7-e62ece70df88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06111178-685d-4bda-8325-1db142d5801c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06111178-685d-4bda-8325-1db142d5801c.jpg?1",
             "name": "Unblinking Bleb",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever Unblinking Bleb or another permanent is turned face up, you may scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "9a1bfd8a-59d7-5409-8635-1d6c1ed91f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84fc99-4045-4518-b588-512a675f2933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84fc99-4045-4518-b588-512a675f2933.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Venser, Shaper Savant comes into play, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "bc077c85-0a9e-5169-ba21-2a73f9091ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbedfc40-7c2f-4a6e-8157-219cafca3548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbedfc40-7c2f-4a6e-8157-219cafca3548.jpg?1",
             "name": "Venser's Diffusion",
             "text": "Return target nonland permanent or suspended card to its owner's hand.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "4a0c5a08-a077-5071-a83d-bf017ddb8d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e6e715-abd8-4ff9-a8aa-8f4b929b0283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e6e715-abd8-4ff9-a8aa-8f4b929b0283.jpg?1",
             "name": "Arcanum Wings",
             "text": "Enchant creature\nEnchanted creature has flying.\nAura swap {2}{U} ({2}{U}: Exchange this Aura with an Aura card in your hand.)",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "a5db391e-cf8b-54ac-bf6d-8e48b6617d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26ee7b-de1a-4a39-9580-89941c3d0f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b26ee7b-de1a-4a39-9580-89941c3d0f21.jpg?1",
             "name": "Blind Phantasm",
             "text": "",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "5af71cde-6547-5a8c-8b84-bcfbdc55a7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ced470-97c3-4683-b97f-9ebb8c3fbd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ced470-97c3-4683-b97f-9ebb8c3fbd11.jpg?1",
             "name": "Bonded Fetch",
             "text": "Defender, haste\n{T}: Draw a card, then discard a card.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "1bd417ba-230a-52de-bd29-f4962ff2f316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799538af-e497-457b-b096-ee6f342f51b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799538af-e497-457b-b096-ee6f342f51b5.jpg?1",
             "name": "Linessa, Zephyr Mage",
             "text": "{X}{U}{U}, {T}: Return target creature with converted mana cost X to its owner's hand.\nGrandeur Discard another card named Linessa, Zephyr Mage: Target player returns a creature he or she controls to its owner's hand, then repeats this process for an artifact, an enchantment, and a land.",
             "colours": [
@@ -1733,7 +1733,7 @@
         },
         {
             "id": "60c1d9f9-9903-5033-bf9d-f8b4b869dcf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e946be1-4ed6-4e2c-9782-3f630f8a8e1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e946be1-4ed6-4e2c-9782-3f630f8a8e1f.jpg?1",
             "name": "Logic Knot",
             "text": "Delve (You may remove any number of cards in your graveyard from the game as you play this spell. It costs {1} less to play for each card removed this way.)\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -1765,7 +1765,7 @@
         },
         {
             "id": "6f626eb9-cba0-55e7-8d0d-e3e4224b21ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bf083e-d0ec-4df9-a17a-8a28ad13d594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bf083e-d0ec-4df9-a17a-8a28ad13d594.jpg?1",
             "name": "Mesmeric Sliver",
             "text": "All Slivers have \"When this permanent comes into play, you may fateseal 1.\" (Its controller looks at the top card of an opponent's library, then he or she may put that card on the bottom of that library.)",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "89b91a60-c564-5561-b0b5-37ab602db1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76b3746-2e2c-4560-a2d2-e7b5b92833b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76b3746-2e2c-4560-a2d2-e7b5b92833b2.jpg?1",
             "name": "Narcomoeba",
             "text": "Flying\nWhen Narcomoeba is put into your graveyard from your library, you may put it into play.",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "d5464d6f-93a2-5f60-943a-3931289663d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dab4f64-2a91-409a-b83b-45b22afd22ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dab4f64-2a91-409a-b83b-45b22afd22ff.jpg?1",
             "name": "Nix",
             "text": "Counter target spell if no mana was spent to play it.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "10d17429-a28a-5eb2-9840-b6adbfd4a502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a425d3-a0b7-4d8d-8013-a27c59758b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a425d3-a0b7-4d8d-8013-a27c59758b28.jpg?1",
             "name": "Sarcomite Myr",
             "text": "{2}: Sarcomite Myr gains flying until end of turn.\n{2}, Sacrifice Sarcomite Myr: Draw a card.",
             "colours": [
@@ -1901,7 +1901,7 @@
         },
         {
             "id": "bcef3c65-860c-555c-be31-fea72a0dbb1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d2f8f-1166-4579-9609-d8ba5db79172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d2f8f-1166-4579-9609-d8ba5db79172.jpg?1",
             "name": "Second Wind",
             "text": "Enchant creature\n{T}: Tap enchanted creature.\n{T}: Untap enchanted creature.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "0070b2d5-60b8-556d-b36b-ad52c1421e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb3fa8-555f-4df6-994e-cf01896f7470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb3fa8-555f-4df6-994e-cf01896f7470.jpg?1",
             "name": "Shapeshifter's Marrow",
             "text": "At the beginning of each opponent's upkeep, that player reveals the top card of his or her library. If it's a creature card, the player puts the card into his or her graveyard and Shapeshifter's Marrow becomes a copy of that card. (If it does, it loses this ability.)",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "f718865e-bc7f-5bde-b3a5-b773d2075fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cc73ea-3f07-4d11-9961-dc31ac598b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cc73ea-3f07-4d11-9961-dc31ac598b73.jpg?1",
             "name": "Spellweaver Volute",
             "text": "Enchant instant card in a graveyard\nWhenever you play a sorcery spell, copy the enchanted instant card. You may play the copy without paying its mana cost. If you do, remove the enchanted card from the game and attach Spellweaver Volute to another instant card in a graveyard.",
             "colours": [
@@ -2001,7 +2001,7 @@
         },
         {
             "id": "03009531-9577-5d8a-9c97-e1a6fad472aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0808b800-9f5f-42ef-8cd0-c04e64945adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0808b800-9f5f-42ef-8cd0-c04e64945adf.jpg?1",
             "name": "Spin into Myth",
             "text": "Put target creature on top of its owner's library, then fateseal 2. (Look at the top two cards of an opponent's library, then put any number of them on the bottom of that player's library and the rest on top in any order.)",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "924bc581-766c-5c20-984a-699f33732de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496eb37d-5c8f-4dd7-a0a7-3ed1bd2210d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496eb37d-5c8f-4dd7-a0a7-3ed1bd2210d6.jpg?1",
             "name": "Vedalken Aethermage",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Vedalken \u00c6thermage comes into play, return target Sliver to its owner's hand.\nWizardcycling {3} ({3}, Discard this card: Search your library for a Wizard card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "34386302-0688-50b4-b516-6b5900882538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ddb99-08a4-4349-a246-d19de32527e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ddb99-08a4-4349-a246-d19de32527e2.jpg?1",
             "name": "Whip-Spine Drake",
             "text": "Flying\nMorph {2}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2103,7 +2103,7 @@
         },
         {
             "id": "097a7983-2be9-50c8-bae9-a1cacfe6aa50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945404d5-9e44-45e7-84fd-5f8c893e7d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945404d5-9e44-45e7-84fd-5f8c893e7d27.jpg?1",
             "name": "Augur of Skulls",
             "text": "{1}{B}: Regenerate Augur of Skulls.\nSacrifice Augur of Skulls: Target player discards two cards. Play this ability only during your upkeep.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "7a890435-0d34-5721-a155-8f4acfd03af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bc089-696d-41b4-a02f-d7dc166feedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bc089-696d-41b4-a02f-d7dc166feedd.jpg?1",
             "name": "Cutthroat il-Dal",
             "text": "Hellbent Cutthroat il-Dal has shadow as long as you have no cards in hand. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -2173,7 +2173,7 @@
         },
         {
             "id": "f209afcf-4062-5838-b314-3d6cad3a1db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c34e6aa-0414-45ba-b6eb-1ac4255d7de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c34e6aa-0414-45ba-b6eb-1ac4255d7de8.jpg?1",
             "name": "Festering March",
             "text": "Creatures your opponents control get -1/-1 until end of turn. Remove Festering March from the game with three time counters on it.\nSuspend 3\u2014{2}{B} (Rather than play this card from your hand, you may pay {2}{B} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "4c9ba1ce-f136-54e9-9e24-1281105ac8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4839a0b-47db-4464-9e9a-0e976d468106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4839a0b-47db-4464-9e9a-0e976d468106.jpg?1",
             "name": "Gibbering Descent",
             "text": "At the beginning of each player's upkeep, that player loses 1 life and discards a card.\nHellbent Skip your upkeep step if you have no cards in hand.\nMadness {2}{B}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "4c051da2-faeb-50f7-87ad-279be3b23cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d301f6-1ae2-4e26-a736-e59c7a8f2198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d301f6-1ae2-4e26-a736-e59c7a8f2198.jpg?1",
             "name": "Grave Peril",
             "text": "When a nonblack creature comes into play, sacrifice Grave Peril. If you do, destroy that creature.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "d4d87742-5958-5683-b298-45d7e1eab9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34603c3e-1078-48ca-9350-7d90c290b721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34603c3e-1078-48ca-9350-7d90c290b721.jpg?1",
             "name": "Ichor Slick",
             "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "20e4f99b-4227-557a-9765-09dbc4ed26a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfff4a8-43ae-41d4-acca-998234f9df35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfff4a8-43ae-41d4-acca-998234f9df35.jpg?1",
             "name": "Lost Hours",
             "text": "Target player reveals his or her hand. Choose a nonland card from it. That player puts that card into his or her library third from the top.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "7df71ba4-6d18-5a71-b038-dcdbbeeda323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a22c-491b-4969-befb-406c42fcec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a22c-491b-4969-befb-406c42fcec68.jpg?1",
             "name": "Magus of the Abyss",
             "text": "At the beginning of each player's upkeep, destroy target nonartifact creature that player controls of his or her choice. It can't be regenerated.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "039c3a5f-76e1-5779-afd0-c2157c13042c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6438a3b-6acb-4b49-8a46-9db80811d17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6438a3b-6acb-4b49-8a46-9db80811d17c.jpg?1",
             "name": "Minions' Murmurs",
             "text": "You draw X cards and you lose X life, where X is the number of creatures you control.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "c309fc53-571c-5e03-b81b-b0a9805ab77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a431fa-e98c-434a-9138-b4bcc86edde8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a431fa-e98c-434a-9138-b4bcc86edde8.jpg?1",
             "name": "Nihilith",
             "text": "Fear\nSuspend 7\u2014{1}{B}\nWhenever a card is put into an opponent's graveyard from anywhere, if Nihilith is suspended, you may remove a time counter from Nihilith.",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "ef874740-55c7-5a42-a028-833912859712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd5486b-c6f4-4cfc-9590-8ffc78b48b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd5486b-c6f4-4cfc-9590-8ffc78b48b0a.jpg?1",
             "name": "Oblivion Crown",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature has \"Discard a card: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "594bb6fd-7fdc-50f0-9557-924cf54299d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0911fb8b-d27a-4afc-9114-212f3e090393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0911fb8b-d27a-4afc-9114-212f3e090393.jpg?1",
             "name": "Pooling Venom",
             "text": "Enchant land\nWhenever enchanted land becomes tapped, its controller loses 2 life.\n{3}{B}: Destroy enchanted land.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "bde677d8-9681-58b4-bad8-44cad8afa480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e82edf-8acc-4024-bb88-f727f632b061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e82edf-8acc-4024-bb88-f727f632b061.jpg?1",
             "name": "Putrid Cyclops",
             "text": "When Putrid Cyclops comes into play, scry 1, then reveal the top card of your library. Putrid Cyclops gets -X/-X until end of turn, where X is that card's converted mana cost. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "22f33ee6-ba31-5852-ba5f-4cc2a5d70fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6faa406-aa7a-49ce-a42e-00e98f3fb74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6faa406-aa7a-49ce-a42e-00e98f3fb74e.jpg?1",
             "name": "Shimian Specter",
             "text": "Flying\nWhenever Shimian Specter deals combat damage to a player, that player reveals his or her hand. Choose a nonland card from it. Search that player's graveyard, hand, and library for all cards with the same name as that card and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "5a996160-85e5-5561-bb9c-cfa00f42d487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e783332-ea4e-4330-ba91-d23e5a58a7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e783332-ea4e-4330-ba91-d23e5a58a7eb.jpg?1",
             "name": "Skirk Ridge Exhumer",
             "text": "{B}, {T}, Discard a card: Put a 1/1 black Zombie Goblin creature token named Festering Goblin into play with \"When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.\"",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "2cf4902b-79ce-56d0-8413-f6b27406a5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42696fdb-de1f-44ae-bef3-b6af068958d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42696fdb-de1f-44ae-bef3-b6af068958d0.jpg?1",
             "name": "Slaughter Pact",
             "text": "Slaughter Pact is black.\nDestroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "521385bb-ec00-5592-a5e5-70e653ab73d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6006922b-20f8-4f38-9522-9851541a6de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6006922b-20f8-4f38-9522-9851541a6de5.jpg?1",
             "name": "Stronghold Rats",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Stronghold Rats deals combat damage to a player, each player discards a card.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "b9e4fd20-f99a-5964-b31f-e2624324d5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879e7a1-0256-4116-be22-7c9972e4ce0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879e7a1-0256-4116-be22-7c9972e4ce0b.jpg?1",
             "name": "Bitter Ordeal",
             "text": "Search target player's library for a card and remove that card from the game. Then that player shuffles his or her library.\nGravestorm (When you play this spell, copy it for each permanent put into a graveyard this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -2704,7 +2704,7 @@
         },
         {
             "id": "554e6701-31b5-517d-ad50-6491b7da2296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c44610-6d4b-4c14-839f-2c085badec90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c44610-6d4b-4c14-839f-2c085badec90.jpg?1",
             "name": "Bridge from Below",
             "text": "Whenever a nontoken creature is put into your graveyard from play, if Bridge from Below is in your graveyard, put a 2/2 black Zombie creature token into play.\nWhen a creature is put into an opponent's graveyard from play, if Bridge from Below is in your graveyard, remove Bridge from Below from the game.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "19ade576-ec17-571f-8b25-59957c013fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cddafc8-57d6-456e-af58-4b7f45e195d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cddafc8-57d6-456e-af58-4b7f45e195d5.jpg?1",
             "name": "Death Rattle",
             "text": "Delve (You may remove any number of cards in your graveyard from the game as you play this spell. It costs {1} less to play for each card removed this way.)\nDestroy target nongreen creature. It can't be regenerated.",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "8bfd8000-5c23-50e3-89de-9a92bce0ad7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66cc281-3fa9-4d7b-a32b-41c0a93059ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66cc281-3fa9-4d7b-a32b-41c0a93059ba.jpg?1",
             "name": "Deepcavern Imp",
             "text": "Flying, haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -2803,7 +2803,7 @@
         },
         {
             "id": "a3219b80-63ae-59ce-bede-2ea3b526d43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e1a646-6925-4a53-a99c-8951af016a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e1a646-6925-4a53-a99c-8951af016a7a.jpg?1",
             "name": "Fleshwrither",
             "text": "Transfigure {1}{B}{B} ({1}{B}{B}, Sacrifice this creature: Search your library for a creature card with the same converted mana cost as this creature and put that card into play. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "237fb0d8-93f8-5d3b-a0ed-2c96ab4fb9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d796119a-f1eb-4de9-a9ca-d322017e9c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d796119a-f1eb-4de9-a9ca-d322017e9c5e.jpg?1",
             "name": "Frenzy Sliver",
             "text": "All Sliver creatures have frenzy 1. (Whenever a Sliver attacks and isn't blocked, it gets +1/+0 until end of turn.)",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "abefe00c-c3fb-5dd2-9532-2dadfd9af55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0a08a8-bbb9-4816-b03c-af4d729fce45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0a08a8-bbb9-4816-b03c-af4d729fce45.jpg?1",
             "name": "Grave Scrabbler",
             "text": "Madness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)\nWhen Grave Scrabbler comes into play, if its madness cost was paid, you may return target creature card in a graveyard to its owner's hand.",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "a3a28617-28c6-5344-92ad-39cf7b9b0b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f1f022-da7f-49a4-881d-b3a2c54c38eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f1f022-da7f-49a4-881d-b3a2c54c38eb.jpg?1",
             "name": "Korlash, Heir to Blackblade",
             "text": "Korlash, Heir to Blackblade's power and toughness are each equal to the number of Swamps you control.\n{1}{B}: Regenerate Korlash.\nGrandeur Discard another card named Korlash, Heir to Blackblade: Search your library for up to two Swamp cards, put them into play tapped, then shuffle your library.",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "341ff434-b7b1-5649-85d3-f7a84b668dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c3f515-de7d-41eb-8ba0-532f4c13ac39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c3f515-de7d-41eb-8ba0-532f4c13ac39.jpg?1",
             "name": "Mass of Ghouls",
             "text": "",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "6142b42e-bf4b-57bc-9448-cd9875e0fc40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b47606-82d1-402c-b1c6-591457b10d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b47606-82d1-402c-b1c6-591457b10d86.jpg?1",
             "name": "Snake Cult Initiation",
             "text": "Enchant creature\nEnchanted creature has poisonous 3. (Whenever it deals combat damage to a player, that player gets three poison counters. A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "4fb8d892-2d39-5f60-acaa-f954e9f02943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2815-bbcc-4338-a8ba-9aa97142ea69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2815-bbcc-4338-a8ba-9aa97142ea69.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "59a14f02-aabf-5e00-bc24-649806f97879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd55a11-8658-4b92-9151-d6173a11991a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd55a11-8658-4b92-9151-d6173a11991a.jpg?1",
             "name": "Tombstalker",
             "text": "Flying\nDelve (You may remove any number of cards in your graveyard from the game as you play this spell. It costs {1} less to play for each card removed this way.)",
             "colours": [
@@ -3079,7 +3079,7 @@
         },
         {
             "id": "693142d6-5a33-59d0-a57b-3e0229615e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651c7735-088d-495b-a58f-69abf4cac197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651c7735-088d-495b-a58f-69abf4cac197.jpg?1",
             "name": "Witch's Mist",
             "text": "{2}{B}, {T}: Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "6f70a7b9-4baf-5c4c-9693-c00cf960dbc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6ba6a5-942d-44ff-87a9-3febf0b7e39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6ba6a5-942d-44ff-87a9-3febf0b7e39b.jpg?1",
             "name": "Yixlid Jailer",
             "text": "Cards in graveyards lose all abilities.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "39816564-ecef-5840-8be7-c72639804c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1c04fb-213f-4be1-9bba-94c737826bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1c04fb-213f-4be1-9bba-94c737826bf8.jpg?1",
             "name": "Arc Blade",
             "text": "Arc Blade deals 2 damage to target creature or player. Remove Arc Blade from the game with three time counters on it.\nSuspend 3\u2014{2}{R} (Rather than play this card from your hand, you may pay {2}{R} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "b81edfd5-8f34-5007-b26a-ff269f367cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814464-e5b6-46c6-ac2e-d7234add43f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814464-e5b6-46c6-ac2e-d7234add43f4.jpg?1",
             "name": "Bogardan Lancer",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nFlanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "7a2b0651-614e-55fc-bbf7-ed86a5a06d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae256118-3a7c-4b6e-b716-ba1ddfb4fb85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae256118-3a7c-4b6e-b716-ba1ddfb4fb85.jpg?1",
             "name": "Char-Rumbler",
             "text": "Double strike\n{R}: Char-Rumbler gets +1/+0 until end of turn.",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "efd085f8-ea88-50fe-a57b-a46faced763d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78dbef-315c-4f9b-8a1a-76a62a941182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc78dbef-315c-4f9b-8a1a-76a62a941182.jpg?1",
             "name": "Emberwilde Augur",
             "text": "Sacrifice Emberwilde Augur: Emberwilde Augur deals 3 damage to target player. Play this ability only during your upkeep.",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "86ae5062-0116-544a-806e-8f83f9a3c2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930ff9ec-6b97-445e-b274-7c8c5fe0c0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930ff9ec-6b97-445e-b274-7c8c5fe0c0fc.jpg?1",
             "name": "Fatal Attraction",
             "text": "Enchant creature\nWhen Fatal Attraction comes into play, it deals 2 damage to enchanted creature.\nAt the beginning of your upkeep, Fatal Attraction deals 4 damage to enchanted creature.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "2afcb3ef-f12b-5470-8e92-3c53155a7ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af5c695-d0f4-4ea7-bc12-f3a24d5b6a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af5c695-d0f4-4ea7-bc12-f3a24d5b6a11.jpg?1",
             "name": "Gathan Raiders",
             "text": "Hellbent Gathan Raiders gets +2/+2 if you have no cards in hand.\nMorph\u2014\nDiscard a card. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "b4c1f5a9-a905-5db8-bfd5-1458dcc8d802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846134c0-5a8d-4ccb-8451-db29b70be3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846134c0-5a8d-4ccb-8451-db29b70be3f5.jpg?1",
             "name": "Haze of Rage",
             "text": "Buyback {2} (You may pay an additional {2} as you play this spell. If you do, put this card into your hand as it resolves.)\nCreatures you control get +1/+0 until end of turn.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "0fc464fe-c198-5508-9bbc-3904df839d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06a4443-6851-4873-8fb8-2ef76c9d6d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06a4443-6851-4873-8fb8-2ef76c9d6d2c.jpg?1",
             "name": "Magus of the Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "4cb9bf40-ca7d-5c9f-83a4-4b58081ee8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e0713c-dbf4-4403-ae69-58fd483e2481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e0713c-dbf4-4403-ae69-58fd483e2481.jpg?1",
             "name": "Molten Disaster",
             "text": "Kicker {R} (You may pay an additional {R} as you play this spell.)\nIf the kicker cost was paid, Molten Disaster has split second. (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
             "colours": [
@@ -3450,7 +3450,7 @@
         },
         {
             "id": "66ca489c-f2ac-5aef-9959-b9e96f8805be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f332ef3-335a-494d-a90f-61a9e9834ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f332ef3-335a-494d-a90f-61a9e9834ccd.jpg?1",
             "name": "Pact of the Titan",
             "text": "Pact of the Titan is red.\nPut a 4/4 red Giant creature token into play.\nAt the beginning of your next upkeep, pay {4}{R}. If you don't, you lose the game.",
             "colours": [
@@ -3482,7 +3482,7 @@
         },
         {
             "id": "819844f1-0136-5077-b270-81ef3408c18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456c4d8b-1dec-42ca-af89-4c40545261bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456c4d8b-1dec-42ca-af89-4c40545261bb.jpg?1",
             "name": "Pyromancer's Swath",
             "text": "If an instant or sorcery source you control would deal damage to a creature or player, it deals that much damage plus 2 to that creature or player instead.\nAt end of turn, discard your hand.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "19fbf047-61d4-5a29-bc2b-77a467ae72dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338be9e2-c0b8-4b69-b7b6-6ba9927a3a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338be9e2-c0b8-4b69-b7b6-6ba9927a3a4d.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose target creature or player. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that creature or player. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "be5b911b-4c88-5e66-9e71-376f67696599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c1a05-0dd2-4535-aa7f-ed33bbe92681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c1a05-0dd2-4535-aa7f-ed33bbe92681.jpg?1",
             "name": "Rift Elemental",
             "text": "{1}{R}, Remove a time counter from a permanent you control or suspended card you own: Rift Elemental gets +2/+0 until end of turn.",
             "colours": [
@@ -3580,7 +3580,7 @@
         },
         {
             "id": "43374446-c7bc-5741-9601-29ecceec655b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede410a-8b5c-48c0-8f5d-d8bd17e0b86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bede410a-8b5c-48c0-8f5d-d8bd17e0b86b.jpg?1",
             "name": "Scourge of Kher Ridges",
             "text": "Flying\n{1}{R}: Scourge of Kher Ridges deals 2 damage to each creature without flying.\n{5}{R}: Scourge of Kher Ridges deals 6 damage to each other creature with flying.",
             "colours": [
@@ -3614,7 +3614,7 @@
         },
         {
             "id": "6dd7fbb7-2991-58bd-b720-1509f417a225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d3e0ff-7738-4f5e-b35a-b9494095ab9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d3e0ff-7738-4f5e-b35a-b9494095ab9f.jpg?1",
             "name": "Shivan Sand-Mage",
             "text": "When Shivan Sand-Mage comes into play, choose one Remove two time counters from target permanent or suspended card; or put two time counters on target permanent with a time counter on it or suspended card.\nSuspend 4\u2014{R}",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "0dba4d1e-232a-5201-9e95-b80bb8e878f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91431126-05b3-4c2e-aff7-41c2866265f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91431126-05b3-4c2e-aff7-41c2866265f6.jpg?1",
             "name": "Sparkspitter",
             "text": "{R}, {T}, Discard a card: Put a 3/1 red Elemental creature token named Spark Elemental into play with trample, haste, and \"At end of turn, sacrifice Spark Elemental.\"",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "f7a3bc00-73f5-560e-81a3-56337d19df03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930b146-d132-454f-b35d-4a247c14c054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930b146-d132-454f-b35d-4a247c14c054.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Play this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -3719,7 +3719,7 @@
         },
         {
             "id": "b96f5d56-8de8-5f83-ab95-753c248c934f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bec14-2e22-43eb-8854-b70a97dd023b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bec14-2e22-43eb-8854-b70a97dd023b.jpg?1",
             "name": "Boldwyr Intimidator",
             "text": "Cowards can't block Warriors.\n{R}: Target creature's type becomes Coward until end of turn.\n{2}{R}: Target creature's type becomes Warrior until end of turn.",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "e7137fdc-a325-5182-8201-8bc36686b16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab2a41-315b-439c-b02c-f12335fc903a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab2a41-315b-439c-b02c-f12335fc903a.jpg?1",
             "name": "Emblem of the Warmind",
             "text": "Enchant creature you control\nCreatures you control have haste.",
             "colours": [
@@ -3788,7 +3788,7 @@
         },
         {
             "id": "df7c3110-d5f1-591f-b8d0-f68ea57acd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3969cc7-92b9-45cd-9a4f-d94c2178a04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3969cc7-92b9-45cd-9a4f-d94c2178a04d.jpg?1",
             "name": "Flowstone Embrace",
             "text": "Enchant creature\n{T}: Enchanted creature gets +2/-2 until end of turn.",
             "colours": [
@@ -3822,7 +3822,7 @@
         },
         {
             "id": "f887a5ae-2166-5878-95b8-21f0143b633d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8216b3f3-b9b6-4d90-a624-c1b9b7bdf953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8216b3f3-b9b6-4d90-a624-c1b9b7bdf953.jpg?1",
             "name": "Fomori Nomad",
             "text": "",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "0125c541-acc6-5e3f-a3fc-f86a3aa9e24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60475e5-0d37-4af0-b717-da4c8dea45ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60475e5-0d37-4af0-b717-da4c8dea45ac.jpg?1",
             "name": "Ghostfire",
             "text": "Ghostfire is colorless.\nGhostfire deals 3 damage to target creature or player.",
             "colours": [],
@@ -3887,7 +3887,7 @@
         },
         {
             "id": "0fbc66ab-9292-596d-88fa-44a74ddb9956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31716a43-2522-46ff-a9a4-b6952cd41f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31716a43-2522-46ff-a9a4-b6952cd41f11.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {2}{R} to your mana pool. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "7dd039c7-047d-56f8-a351-009743452831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b41cef7-bb16-4d89-9900-dc6d1f5200f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b41cef7-bb16-4d89-9900-dc6d1f5200f0.jpg?1",
             "name": "Henchfiend of Ukor",
             "text": "Haste\nEcho {1}{B} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice this permanent unless you pay its echo cost.)\n{BR}: Henchfiend of Ukor gets +1/+0 until end of turn.",
             "colours": [
@@ -3956,7 +3956,7 @@
         },
         {
             "id": "f0ca8cf1-5617-525e-badf-c5508cd7106d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c876479-5040-4d36-b43a-54d7fc9160c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c876479-5040-4d36-b43a-54d7fc9160c1.jpg?1",
             "name": "Homing Sliver",
             "text": "Each Sliver card in each player's hand has slivercycling {3}.\nSlivercycling {3} ({3}, Discard this card: Search your library for a Sliver card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "6a7238a3-a107-5b00-a74c-8c3e706a1858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee5e9e3-e3ae-4e1b-a8fb-48c523631105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee5e9e3-e3ae-4e1b-a8fb-48c523631105.jpg?1",
             "name": "Shah of Naar Isle",
             "text": "Trample\nEcho {0} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Shah of Naar Isle's echo cost is paid, each opponent may draw up to three cards.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "e6d5751f-e385-559f-af0b-364e06ef0322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b232c36-bff1-4f5e-98a6-ce6a98591aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b232c36-bff1-4f5e-98a6-ce6a98591aa6.jpg?1",
             "name": "Skizzik Surger",
             "text": "Haste\nEcho\u2014\nSacrifice two lands. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "0881b75c-dc58-5076-a0f6-98d1d9740b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007ce039-def1-4039-a0a0-ba72e8872dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007ce039-def1-4039-a0a0-ba72e8872dc5.jpg?1",
             "name": "Steamflogger Boss",
             "text": "Other Rigger creatures you control get +1/+0 and have haste.\nIf a Rigger you control would assemble a Contraption, it assembles two Contraptions instead.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "28bd0d3b-3baf-50e8-ace6-6e74dd25e3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2db053-3da0-4c3a-9b36-0eff6477540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2db053-3da0-4c3a-9b36-0eff6477540d.jpg?1",
             "name": "Storm Entity",
             "text": "Haste\nStorm Entity comes into play with a +1/+1 counter on it for each other spell played this turn.",
             "colours": [
@@ -4127,7 +4127,7 @@
         },
         {
             "id": "9dfab376-fe2a-57ed-a043-617e01a86aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b06bd73-c45a-4560-bd8d-413608c5f89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b06bd73-c45a-4560-bd8d-413608c5f89e.jpg?1",
             "name": "Tarox Bladewing",
             "text": "Flying, haste\nGrandeur Discard another card named Tarox Bladewing: Tarox Bladewing gets +X/+X until end of turn, where X is its power.",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "3c793f92-cfab-59b2-a18b-9928b369a8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a85be1-9de5-4f96-9fd1-15f3f17c4bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a85be1-9de5-4f96-9fd1-15f3f17c4bea.jpg?1",
             "name": "Thunderblade Charge",
             "text": "Thunderblade Charge deals 3 damage to target creature or player.\nWhenever one or more creatures you control deal combat damage to a player, if Thunderblade Charge is in your graveyard, you may pay {2}{R}{R}{R}. If you do, play it without paying its mana cost.",
             "colours": [
@@ -4195,7 +4195,7 @@
         },
         {
             "id": "9f70d049-11ef-5358-93ae-5de038cc0975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2fa14-b08b-4cb9-bd77-c9da1dfa91d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2fa14-b08b-4cb9-bd77-c9da1dfa91d4.jpg?1",
             "name": "Cyclical Evolution",
             "text": "Target creature gets +3/+3 until end of turn. Remove Cyclical Evolution from the game with three time counters on it.\nSuspend 3\u2014{2}{G} (Rather than play this card from your hand, you may pay {2}{G} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "b72c7566-cedf-5410-8566-62a57f5748ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b344511d-631e-4f1d-9d7d-d7c89a473d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b344511d-631e-4f1d-9d7d-d7c89a473d1b.jpg?1",
             "name": "Force of Savagery",
             "text": "Trample",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "599cb0e2-d2a3-5463-b04e-ae6f6c54273c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2216497-ce38-41fe-bde9-e8066df36d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2216497-ce38-41fe-bde9-e8066df36d60.jpg?1",
             "name": "Heartwood Storyteller",
             "text": "Whenever a player plays a noncreature spell, each of that player's opponents may draw a card.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "586b8e51-e4c0-500a-aad9-82d05400bf5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19216a1-4fe2-496e-9ef4-6ac652e5b7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19216a1-4fe2-496e-9ef4-6ac652e5b7ca.jpg?1",
             "name": "Kavu Primarch",
             "text": "Convoke (Each creature you tap while playing this spell reduces its total cost by {1} or by one mana of that creature's color.)\nKicker {4} (You may pay an additional {4} as you play this spell.)\nIf the kicker cost was paid, Kavu Primarch comes into play with four +1/+1 counters on it.",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "e4f48bcc-5ac1-5039-a338-0fbfaa8841ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8c9473-97f4-4875-8f06-d3a70d4cbe6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8c9473-97f4-4875-8f06-d3a70d4cbe6d.jpg?1",
             "name": "Llanowar Augur",
             "text": "Sacrifice Llanowar Augur: Target creature gets +3/+3 and gains trample until end of turn. Play this ability only during your upkeep.",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "3f429b26-bdd0-576c-b7c8-401280f03764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf831ed3-d3ae-43ac-82ca-4984c05dde86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf831ed3-d3ae-43ac-82ca-4984c05dde86.jpg?1",
             "name": "Llanowar Empath",
             "text": "When Llanowar Empath comes into play, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "360867c1-f07d-59f2-b935-b05360ed2935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23f0074-40ad-4057-a672-42ed4f9564c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23f0074-40ad-4057-a672-42ed4f9564c0.jpg?1",
             "name": "Llanowar Mentor",
             "text": "{G}, {T}, Discard a card: Put a 1/1 green Elf Druid creature token named Llanowar Elves into play with \"{T}: Add {G} to your mana pool.\"",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "440f3189-41cc-595c-bbd7-83ecbfcaddcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a9453c-09b2-4dbb-969a-369f5e78a90f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a9453c-09b2-4dbb-969a-369f5e78a90f.jpg?1",
             "name": "Magus of the Vineyard",
             "text": "At the beginning of each player's precombat main phase, add {G}{G} to that player's mana pool.",
             "colours": [
@@ -4469,7 +4469,7 @@
         },
         {
             "id": "53dd061a-5c25-57d6-bad6-ae6121adef14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1195c459-5e06-4f4e-aa6e-58fefa712684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1195c459-5e06-4f4e-aa6e-58fefa712684.jpg?1",
             "name": "Petrified Plating",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nSuspend 2\u2014{G} (Rather than play this card from your hand, you may pay {G} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "387e6a8e-31f5-5cc4-b5b5-c0fdb83ab563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ce95e-5102-44fb-b74d-7469331ca9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ce95e-5102-44fb-b74d-7469331ca9cc.jpg?1",
             "name": "Quiet Disrepair",
             "text": "Enchant artifact or enchantment\nAt the beginning of your upkeep, choose one Destroy enchanted permanent; or you gain 2 life.",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "80d783b0-aafc-5766-83a8-f4ca4ad6d530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e09949e-c8cd-4bb4-9ed4-699abbc7ad3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e09949e-c8cd-4bb4-9ed4-699abbc7ad3c.jpg?1",
             "name": "Ravaging Riftwurm",
             "text": "Kicker {4} (You may pay an additional {4} as you play this spell.)\nVanishing 2 (This permanent comes into play with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nIf the kicker cost was paid, Ravaging Riftwurm comes into play with three additional time counters on it.",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "528a2572-25dc-504e-85e7-a2d7f0ee4e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847dbbbc-e069-4a90-bc47-c28418bb8540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847dbbbc-e069-4a90-bc47-c28418bb8540.jpg?1",
             "name": "Riftsweeper",
             "text": "When Riftsweeper comes into play, choose target face-up card that's removed from the game. Its owner shuffles it into his or her library.",
             "colours": [
@@ -4606,7 +4606,7 @@
         },
         {
             "id": "d6b0363a-4129-5cc5-a2af-433bf03bc973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811458c7-dcdc-43ef-8c3e-a90e21ce315e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811458c7-dcdc-43ef-8c3e-a90e21ce315e.jpg?1",
             "name": "Rites of Flourishing",
             "text": "At the beginning of each player's draw step, that player draws a card.\nEach player may play an additional land on each of his or her turns.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "68e727c2-ba07-59e8-9d98-4e9714edda47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b915355-4e98-44df-81bd-961a3d3c86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b915355-4e98-44df-81bd-961a3d3c86b8.jpg?1",
             "name": "Sprout Swarm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its total cost by {1} or by one mana of that creature's color.)\nBuyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nPut a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "bc78ff9e-3147-506b-b777-c6e3c5b33903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b026c-cfce-462b-afb6-7a383bd121de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b026c-cfce-462b-afb6-7a383bd121de.jpg?1",
             "name": "Summoner's Pact",
             "text": "Summoner's Pact is green.\nSearch your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -4702,7 +4702,7 @@
         },
         {
             "id": "fe326117-9808-5168-b9a6-7abed7310478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d3d285-8327-4dba-911b-ff03b186f6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d3d285-8327-4dba-911b-ff03b186f6b8.jpg?1",
             "name": "Utopia Mycon",
             "text": "At the beginning of your upkeep, put a spore counter on Utopia Mycon.\nRemove three spore counters from Utopia Mycon: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Add one mana of any color to your mana pool.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "b57fe913-f089-5951-a141-cebfe11c5c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d438a-ce68-480b-bdfc-1fc3e151e5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d438a-ce68-480b-bdfc-1fc3e151e5f8.jpg?1",
             "name": "Wrap in Vigor",
             "text": "Regenerate each creature you control.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "f8ed8eb7-7a54-5ff7-abd2-d1e780ad4b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a74fcde-7685-402c-9b2a-245aa75d75c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a74fcde-7685-402c-9b2a-245aa75d75c1.jpg?1",
             "name": "Baru, Fist of Krosa",
             "text": "Whenever a Forest comes into play, green creatures you control get +1/+1 and gain trample until end of turn.\nGrandeur Discard another card named Baru, Fist of Krosa: Put an X/X green Wurm creature token into play, where X is the number of lands you control.",
             "colours": [
@@ -4805,7 +4805,7 @@
         },
         {
             "id": "f0cade63-ec0f-5182-b089-24d93faef530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5807814f-7b18-431a-8031-898ff70ad69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5807814f-7b18-431a-8031-898ff70ad69f.jpg?1",
             "name": "Centaur Omenreader",
             "text": "As long as Centaur Omenreader is tapped, creature spells you play cost {2} less to play.",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "2fc908fc-8e52-5ee9-8e6c-f989d9e2b5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03998e86-ef67-4329-b106-61252f3f532a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03998e86-ef67-4329-b106-61252f3f532a.jpg?1",
             "name": "Edge of Autumn",
             "text": "If you control four or fewer lands, search your library for a basic land card, put it into play tapped, then shuffle your library.\nCycling\u2014\nSacrifice a land. (Sacrifice a land, Discard this card: Draw a card.)",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "6effbd5b-2357-5e44-8a1b-a43f3953b577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5136f8-1616-4463-8aa7-122cde6dcddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5136f8-1616-4463-8aa7-122cde6dcddb.jpg?1",
             "name": "Imperiosaur",
             "text": "Spend only mana produced by basic lands to play Imperiosaur.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "7d86e0d1-0184-513c-9b80-406f1d625966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4091524c-569c-4668-b18a-7f869b1169f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4091524c-569c-4668-b18a-7f869b1169f3.jpg?1",
             "name": "Muraganda Petroglyphs",
             "text": "Creatures with no abilities get +2/+2.",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "77590295-4c6c-5f4f-bde4-9eb6a49bcb3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef863d2-1e11-41cc-90d5-008bf6234565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef863d2-1e11-41cc-90d5-008bf6234565.jpg?1",
             "name": "Nacatl War-Pride",
             "text": "Nacatl War-Pride must be blocked by exactly one creature if able.\nWhenever Nacatl War-Pride attacks, put X tokens into play tapped and attacking that are copies of Nacatl War-Pride, where X is the number of creatures defending player controls. Remove the tokens from the game at end of turn.",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "ea92cd99-0f10-58bd-ae3a-08b518ffce2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b18b70-f656-4426-a3e5-69cf61fdaad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b18b70-f656-4426-a3e5-69cf61fdaad1.jpg?1",
             "name": "Nessian Courser",
             "text": "",
             "colours": [
@@ -5010,7 +5010,7 @@
         },
         {
             "id": "648ca487-a525-51e0-84fe-2b8f7185a38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca13d7a-0f60-4de6-9455-aea454cb2e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca13d7a-0f60-4de6-9455-aea454cb2e46.jpg?1",
             "name": "Phosphorescent Feast",
             "text": "Reveal any number of cards in your hand. You gain 2 life for each green mana symbol in those cards' mana costs.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "89b82a07-3fc4-525b-b438-2b3d077a653b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335c3aa3-af89-44ce-955a-69e12d83175f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/335c3aa3-af89-44ce-955a-69e12d83175f.jpg?1",
             "name": "Quagnoth",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nShroud (This permanent can't be the target of spells or abilities.)\nWhen a spell or ability an opponent controls causes you to discard Quagnoth, return it to your hand.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "012e1d6f-c232-5026-bdc3-2eb092180f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231eb017-2945-4915-8032-c09894e88d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231eb017-2945-4915-8032-c09894e88d49.jpg?1",
             "name": "Spellwild Ouphe",
             "text": "Spells that target Spellwild Ouphe cost {2} less to play.",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "6c13474e-af90-5eb7-b3e6-391a499ab115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8f3f3-4ff4-4943-8ae0-c1af78a5ae16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8f3f3-4ff4-4943-8ae0-c1af78a5ae16.jpg?1",
             "name": "Sporoloth Ancient",
             "text": "At the beginning of your upkeep, put a spore counter on Sporoloth Ancient.\nCreatures you control have \"Remove two spore counters from this creature: Put a 1/1 green Saproling creature token into play.\"",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "e4bc70c6-e2c9-5014-a570-af461df67335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6876d9e-0908-43ac-8542-09c7aa02b5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6876d9e-0908-43ac-8542-09c7aa02b5ba.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1. (The card types are artifact, creature, enchantment, instant, land, planeswalker, sorcery, and tribal.)",
             "colours": [
@@ -5178,7 +5178,7 @@
         },
         {
             "id": "d3b9df86-ae62-5de0-818b-c0f9efcc7869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783a50a0-9394-4d97-856f-21eb126a0018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783a50a0-9394-4d97-856f-21eb126a0018.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "539bf5c8-d8d4-5126-9e2a-2fab53558ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de9c95-e590-4b0d-a2d7-886d7a488a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66de9c95-e590-4b0d-a2d7-886d7a488a10.jpg?1",
             "name": "Virulent Sliver",
             "text": "All Sliver creatures have poisonous 1. (Whenever a Sliver deals combat damage to a player, that player gets a poison counter. A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "29b71dc4-30ec-5890-9f84-46da931d24d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec73e1ba-b543-4c64-aa89-164eef1d15d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec73e1ba-b543-4c64-aa89-164eef1d15d6.jpg?1",
             "name": "Glittering Wish",
             "text": "Choose a multicolored card you own from outside the game, reveal that card, and put it into your hand. Remove Glittering Wish from the game.",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "9efb77a5-faca-5da4-a6bf-8314e6f47b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f437128-3a87-4958-97d0-3940d8761cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f437128-3a87-4958-97d0-3940d8761cba.jpg?1",
             "name": "Jhoira of the Ghitu",
             "text": "{2}, Remove a nonland card in your hand from the game: Put four time counters on the removed card. If it doesn't have suspend, it gains suspend. (At the beginning of your upkeep, remove a time counter from that card. When the last is removed, play it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "1e9dac73-6c4e-5bec-a32c-6d3a76f584e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd37a04-87b1-42ad-b3e2-f17cd8998f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd37a04-87b1-42ad-b3e2-f17cd8998f9d.jpg?1",
             "name": "Sliver Legion",
             "text": "All Sliver creatures get +1/+1 for each other Sliver in play.",
             "colours": [
@@ -5364,7 +5364,7 @@
         },
         {
             "id": "20b00f09-f3d3-5a2c-bb57-48b6b985e016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cb3bdf-dff5-4285-ad67-ae7ca84c9fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cb3bdf-dff5-4285-ad67-ae7ca84c9fbc.jpg?1",
             "name": "Akroma's Memorial",
             "text": "Creatures you control have flying, first strike, vigilance, trample, haste, protection from black, and protection from red.",
             "colours": [],
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "aac8ddea-afd9-5f47-b065-7180efffcde0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b893ab56-44a6-4b3c-bb3e-6deec298cbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b893ab56-44a6-4b3c-bb3e-6deec298cbce.jpg?1",
             "name": "Cloud Key",
             "text": "As Cloud Key comes into play, choose artifact, creature, enchantment, instant, or sorcery.\nSpells you play of the chosen type cost {1} less to play.",
             "colours": [],
@@ -5422,7 +5422,7 @@
         },
         {
             "id": "c4f61a73-6471-574b-bd73-68915c550b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c98b0-d64d-4d0a-b284-1187a8e7095e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c98b0-d64d-4d0a-b284-1187a8e7095e.jpg?1",
             "name": "Coalition Relic",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color to your mana pool for each counter removed this way.",
             "colours": [],
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "f2a91235-cb6e-585f-9d56-2e46fc05ee14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7971f6a6-c26c-4f8f-8de7-afc40563967d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7971f6a6-c26c-4f8f-8de7-afc40563967d.jpg?1",
             "name": "Epochrasite",
             "text": "Epochrasite comes into play with three +1/+1 counters on it if you didn't play it from your hand.\nWhen Epochrasite is put into a graveyard from play, remove it from the game with three time counters on it and it gains suspend.",
             "colours": [],
@@ -5481,7 +5481,7 @@
         },
         {
             "id": "84590293-505b-5cd9-89a3-e598be5e4960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242b7dd-a632-4024-a69a-179a63fb93a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242b7dd-a632-4024-a69a-179a63fb93a8.jpg?1",
             "name": "Sliversmith",
             "text": "{1}, {T}, Discard a card: Put a 1/1 Sliver artifact creature token named Metallic Sliver into play.",
             "colours": [],
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "d9674423-3213-5467-b0d9-00b92438f806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efa61f0-c7bd-49e2-9d66-bf15ad0e9d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efa61f0-c7bd-49e2-9d66-bf15ad0e9d03.jpg?1",
             "name": "Soultether Golem",
             "text": "Vanishing 1 (This permanent comes into play with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever another creature comes into play under your control, put a time counter on Soultether Golem.",
             "colours": [],
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "cae0dd73-07bd-582d-9242-0f20f6be73e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f13705-6ede-4c29-a2b4-a082bf69e9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f13705-6ede-4c29-a2b4-a082bf69e9c5.jpg?1",
             "name": "Sword of the Meek",
             "text": "Equipped creature gets +1/+2.\nEquip {2}\nWhenever a 1/1 creature comes into play under your control, you may return Sword of the Meek from your graveyard to play, then attach it to that creature.",
             "colours": [],
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "5607990a-3534-5359-9877-a3bfdf49dd61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705d3e4-317e-460d-b16e-e57238a19070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705d3e4-317e-460d-b16e-e57238a19070.jpg?1",
             "name": "Veilstone Amulet",
             "text": "Whenever you play a spell, creatures you control can't be the targets of spells or abilities your opponents control this turn.",
             "colours": [],
@@ -5601,7 +5601,7 @@
         },
         {
             "id": "189be2a8-e419-5c70-8771-e322d71c235b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77eaaa0-40f9-40e4-b0ba-5a8addd764d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77eaaa0-40f9-40e4-b0ba-5a8addd764d3.jpg?1",
             "name": "Darksteel Garrison",
             "text": "Fortified land is indestructible.\nWhenever fortified land becomes tapped, target creature gets +1/+1 until end of turn.\nFortify {3} ({3}: Attach to target land you control. Fortify only as a sorcery. This card comes into play unattached and stays in play if the land leaves play.)",
             "colours": [],
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "a4b88ce5-f7f2-5d1f-ac81-3227305def78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6040b6-cf02-4f7e-a275-177c3a6415aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6040b6-cf02-4f7e-a275-177c3a6415aa.jpg?1",
             "name": "Whetwheel",
             "text": "{X}{X}, {T}: Target player puts the top X cards of his or her library into his or her graveyard.\nMorph {3} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "e73d4dbc-0b5e-5639-896c-091510bfecf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f06e8-d8ee-435c-965c-8e1302a8ec10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f06e8-d8ee-435c-965c-8e1302a8ec10.jpg?1",
             "name": "Dakmor Salvage",
             "text": "Dakmor Salvage comes into play tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [],
@@ -5689,7 +5689,7 @@
         },
         {
             "id": "9cc1d138-5ab1-5dd8-b765-4a1f303c61b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6d546d-df98-4cb4-a68b-2a0c8bac5a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6d546d-df98-4cb4-a68b-2a0c8bac5a72.jpg?1",
             "name": "Keldon Megaliths",
             "text": "Keldon Megaliths comes into play tapped.\n{T}: Add {R} to your mana pool.\nHellbent {1}{R}, {T}: Keldon Megaliths deals 1 damage to target creature or player. Play this ability only if you have no cards in hand.",
             "colours": [],
@@ -5719,7 +5719,7 @@
         },
         {
             "id": "f45f1ef3-9740-56a0-9cc0-1e9168969c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d07c6b-1afa-4321-b4f9-f22e81a0b818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d07c6b-1afa-4321-b4f9-f22e81a0b818.jpg?1",
             "name": "Llanowar Reborn",
             "text": "Llanowar Reborn comes into play tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land comes into play with a +1/+1 counter on it. Whenever a creature comes into play, you may move a +1/+1 counter from this land onto it.)",
             "colours": [],
@@ -5749,7 +5749,7 @@
         },
         {
             "id": "bd08706c-c4d7-50e8-b8c8-9b97ae7c4ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bde721-8fa0-4f69-9909-b4864929e676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bde721-8fa0-4f69-9909-b4864929e676.jpg?1",
             "name": "New Benalia",
             "text": "New Benalia comes into play tapped.\nWhen New Benalia comes into play, scry 1. (Look at the top card of your library, then you may put that card on the bottom of your library.)\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -5779,7 +5779,7 @@
         },
         {
             "id": "282d83ac-814f-5d1d-8fa7-66917eb57f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e80f06-ea05-4151-920f-7ddc88952169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e80f06-ea05-4151-920f-7ddc88952169.jpg?1",
             "name": "Tolaria West",
             "text": "Tolaria West comes into play tapped.\n{T}: Add {U} to your mana pool.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with converted mana cost 0, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [],
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "152ebf50-8a88-5bff-9da4-7f2364db8e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cee476d-42e1-4997-87af-73e18f542167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cee476d-42e1-4997-87af-73e18f542167.jpg?1",
             "name": "Dryad Arbor",
             "text": "(Dryad Arbor isn't a spell, it's affected by summoning sickness, and it has \"{T}: Add {G} to your mana pool.\")\nDryad Arbor is green.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "70535b46-aa0c-5d69-8654-ddb8735dcefd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7d329-ef6a-45f3-82b6-37a3606c00bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e7d329-ef6a-45f3-82b6-37a3606c00bc.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {1} to your mana pool.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "245cdf7a-8ff2-5e38-8b86-141627a122bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b4d4b1-6e25-4c4b-a21a-1b7b1c1d6452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b4d4b1-6e25-4c4b-a21a-1b7b1c1d6452.jpg?1",
             "name": "Grove of the Burnwillows",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Each opponent gains 1 life.",
             "colours": [],
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "98a6fbfc-2e16-5596-a309-0c9393acfa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfc25d-a17b-4ead-9484-e8a18b8fa176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfc25d-a17b-4ead-9484-e8a18b8fa176.jpg?1",
             "name": "Horizon Canopy",
             "text": "{T}, Pay 1 life: Add {G} or {W} to your mana pool.\n{1}, {T}, Sacrifice Horizon Canopy: Draw a card.",
             "colours": [],
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "159ccb76-6816-54b0-9000-fea0e6acdc39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d1f953-9403-4e0a-b8e1-3f7d928a2834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d1f953-9403-4e0a-b8e1-3f7d928a2834.jpg?1",
             "name": "Nimbus Maze",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} to your mana pool. Play this ability only if you control an Island.\n{T}: Add {U} to your mana pool. Play this ability only if you control a Plains.",
             "colours": [],
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "52be12f7-0d62-5d61-9e40-89e9741165d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5b2058-99fc-4d9b-9e3d-056fa3fd1244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5b2058-99fc-4d9b-9e3d-056fa3fd1244.jpg?1",
             "name": "River of Tears",
             "text": "{T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.",
             "colours": [],
@@ -6000,7 +6000,7 @@
         },
         {
             "id": "015ea4fb-f436-535f-9549-62fcdfa67de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db30e1-31df-44b9-930a-02428bd5ce47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db30e1-31df-44b9-930a-02428bd5ce47.jpg?1",
             "name": "Zoetic Cavern",
             "text": "{T}: Add {1} to your mana pool.\nMorph {2} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/GPT.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/GPT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9c1f142e-75e9-52e8-b0c5-37e5737f6e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711979c3-e70b-4973-a4f1-020db534fc73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711979c3-e70b-4973-a4f1-020db534fc73.jpg?1",
             "name": "Absolver Thrull",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Absolver Thrull comes into play or the creature it haunts is put into a graveyard, destroy target enchantment.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "07285b14-649d-57bd-9d45-c73b9db93759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556e4e71-b149-49c8-8a22-83660bef57bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556e4e71-b149-49c8-8a22-83660bef57bb.jpg?1",
             "name": "Belfry Spirit",
             "text": "Flying\nHaunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Belfry Spirit comes into play or the creature it haunts is put into a graveyard, put two 1/1 black Bat creature tokens with flying into play.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "1e304047-5c93-5c74-ae0d-c92ce79d2320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ea99d1-9e88-4b14-b0b3-39bcd8191eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ea99d1-9e88-4b14-b0b3-39bcd8191eab.jpg?1",
             "name": "Benediction of Moons",
             "text": "You gain 1 life for each player.\nHaunt (When this spell card is put into a graveyard after resolving, remove it from the game haunting target creature.)\nWhen the creature Benediction of Moons haunts is put into a graveyard, you gain 1 life for each player.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "fb02449c-c552-5537-bcab-147aca77db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756eb23a-c6de-439a-b83d-e694cfae7ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756eb23a-c6de-439a-b83d-e694cfae7ccb.jpg?1",
             "name": "Droning Bureaucrats",
             "text": "{X}, {T}: Each creature with converted mana cost X can't attack or block this turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "12effa8c-7175-5270-b762-3744624676af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4304abfe-3c81-4053-a398-574cfac613a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4304abfe-3c81-4053-a398-574cfac613a7.jpg?1",
             "name": "Ghost Warden",
             "text": "{T}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "1d4deb4b-b443-587d-98af-3a765b00ec09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b83d750-16d9-41e4-b823-3295c5f6b319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b83d750-16d9-41e4-b823-3295c5f6b319.jpg?1",
             "name": "Ghostway",
             "text": "Remove each creature you control from the game. Return those creatures to play under their owners' control at end of turn.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "2490835b-aa17-5720-8e94-3c0b609ecc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dc44f8-ff1d-4c5a-971d-c3ce9a65f35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6dc44f8-ff1d-4c5a-971d-c3ce9a65f35d.jpg?1",
             "name": "Graven Dominator",
             "text": "Flying\nHaunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Graven Dominator comes into play or the creature it haunts is put into a graveyard, each other creature becomes 1/1 until end of turn.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "c2372fba-62d9-5334-8c83-466125fbe2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a688e9-28ec-4604-8705-46549402a6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a688e9-28ec-4604-8705-46549402a6f8.jpg?1",
             "name": "Guardian's Magemark",
             "text": "You may play Guardian's Magemark any time you could play an instant.\nEnchant creature\nCreatures you control that are enchanted get +1/+1.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "dce6a0b1-b7f2-54b3-be26-c9038f97b1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2781696e-e70c-4c96-b3aa-75be51cdc68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2781696e-e70c-4c96-b3aa-75be51cdc68e.jpg?1",
             "name": "Harrier Griffin",
             "text": "Flying\nAt the beginning of your upkeep, tap target creature.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "2e72d8d6-497e-56da-81f0-24530a0ec6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc58757-abcc-41c9-b4d2-e70e9f387cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc58757-abcc-41c9-b4d2-e70e9f387cbb.jpg?1",
             "name": "Leyline of the Meek",
             "text": "If Leyline of the Meek is in your opening hand, you may begin the game with it in play.\nCreature tokens get +1/+1.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "5679474f-1fc6-5c00-bdc6-d184caaf7e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704ba6ce-5d28-417b-8574-d3c097e6e39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704ba6ce-5d28-417b-8574-d3c097e6e39f.jpg?1",
             "name": "Lionheart Maverick",
             "text": "Vigilance\n{4}{W}: Lionheart Maverick gets +1/+2 until end of turn.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "c1098fff-5cd3-5cb7-99c6-cd6e6486b03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d7ad75-1fa9-4683-b0d0-737368de3796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d7ad75-1fa9-4683-b0d0-737368de3796.jpg?1",
             "name": "Martyred Rusalka",
             "text": "{W}, Sacrifice a creature: Target creature can't attack this turn.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "6f215484-0773-57c4-b88c-37432c7f6dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41981edd-df29-4ded-85d6-0d1a2a3a7a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41981edd-df29-4ded-85d6-0d1a2a3a7a59.jpg?1",
             "name": "Order of the Stars",
             "text": "Defender (This creature can't attack.)\nAs Order of the Stars comes into play, choose a color.\nOrder of the Stars has protection from the chosen color.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "1cb71f20-8235-5ed9-b6a0-901d33ac70a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b5590f-d964-49cb-8e2e-94b067112c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b5590f-d964-49cb-8e2e-94b067112c8e.jpg?1",
             "name": "Shadow Lance",
             "text": "Enchant creature\nEnchanted creature has first strike.\n{1}{B}: Enchanted creature gets +2/+2 until end of turn.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "cbf32399-0a9b-5756-bf9b-532c30d6058b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924863b6-6d7b-441b-90cc-4e98e1c41aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924863b6-6d7b-441b-90cc-4e98e1c41aa9.jpg?1",
             "name": "Shadow Lance",
             "text": "",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "bcf6d79c-3b9b-56ba-b733-f2ddea7fc579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c221f01-b094-41c7-bb5f-eef97cbf584e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c221f01-b094-41c7-bb5f-eef97cbf584e.jpg?1",
             "name": "Shrieking Grotesque",
             "text": "Flying\nWhen Shrieking Grotesque comes into play, if {B} was spent to play Shrieking Grotesque, target player discards a card.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "34b3cba3-3068-5996-a603-b1605532a0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6889030-f4cd-41a3-8596-b552a9539873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6889030-f4cd-41a3-8596-b552a9539873.jpg?1",
             "name": "Sinstriker's Will",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to target attacking or blocking creature.\"",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "134f1b68-58ff-54b0-9f85-0acd45105c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d760a01-d6c4-462b-b66c-cfd0f594e13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d760a01-d6c4-462b-b66c-cfd0f594e13a.jpg?1",
             "name": "Skyrider Trainee",
             "text": "As long as Skyrider Trainee is enchanted, it has flying.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "2d105a88-a8c3-5ca9-91fc-f11cec30948f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd5682a-ca93-4b5f-af21-e1ff4439361b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd5682a-ca93-4b5f-af21-e1ff4439361b.jpg?1",
             "name": "Spelltithe Enforcer",
             "text": "Whenever an opponent plays a spell, that player sacrifices a permanent unless he or she pays {1}.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "65372408-f85a-5178-8a94-c3175f756de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c86398-2cbc-4ad7-a231-6802e3b4d1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c86398-2cbc-4ad7-a231-6802e3b4d1c0.jpg?1",
             "name": "Storm Herd",
             "text": "Put X 1/1 white Pegasus creature tokens with flying into play, where X is your life total.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "5a64edee-23a7-5c0d-8170-0cca6b8270ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f72d4b7-3b65-411b-a072-8218a0202974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f72d4b7-3b65-411b-a072-8218a0202974.jpg?1",
             "name": "To Arms!",
             "text": "Untap all creatures you control.\nDraw a card.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "75d0c810-d84b-5a28-9fb4-f82f4a8085b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb458f79-13dd-4446-be75-463f19548867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb458f79-13dd-4446-be75-463f19548867.jpg?1",
             "name": "Withstand",
             "text": "Prevent the next 3 damage that would be dealt to target creature or player this turn.\nDraw a card.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "0fc98b17-8787-5188-a733-40f385b8e56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bee334-c56e-4221-97ed-bea73a61b812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bee334-c56e-4221-97ed-bea73a61b812.jpg?1",
             "name": "Aetherplasm",
             "text": "Whenever \u00c6therplasm blocks a creature, you may return \u00c6therplasm to its owner's hand. If you do, you may put a creature card from your hand into play blocking that creature.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "b32cfc0f-eff4-5b30-9c6c-16056b314216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549ed5bd-da29-4cd4-893e-9e53e33a8557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549ed5bd-da29-4cd4-893e-9e53e33a8557.jpg?1",
             "name": "Crystal Seer",
             "text": "When Crystal Seer comes into play, look at the top four cards of your library, then put them back in any order.\n{4}{U}: Return Crystal Seer to its owner's hand.",
             "colours": [
@@ -821,7 +821,7 @@
         },
         {
             "id": "c46ca2ea-82ad-5365-afe8-936aba7759ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68864836-799e-467d-97cc-38c89f71afcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68864836-799e-467d-97cc-38c89f71afcf.jpg?1",
             "name": "Drowned Rusalka",
             "text": "{U}, Sacrifice a creature: Discard a card, then draw a card.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "1d33718e-17d5-54f2-8b1e-54e3622d547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7f705-4d64-4551-8d76-826d91324e9e.jpg?1",
             "name": "Frazzle",
             "text": "Counter target nonblue spell.",
             "colours": [
@@ -887,7 +887,7 @@
         },
         {
             "id": "0b1e0b30-b4a0-5782-a5bb-d2d3cc941686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9f85b3-eb8c-43de-aaac-8a887e9c58da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9f85b3-eb8c-43de-aaac-8a887e9c58da.jpg?1",
             "name": "Gigadrowse",
             "text": "Replicate {U} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTap target permanent.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "0694ed7b-921c-5461-b1c1-61c1a4abe9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef327629-9831-4a0c-bd61-7542b0713ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef327629-9831-4a0c-bd61-7542b0713ea8.jpg?1",
             "name": "Hatching Plans",
             "text": "When Hatching Plans is put into a graveyard from play, draw three cards.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "daedfc74-ddee-5044-b0b9-c7ff24fa6a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63a62b7-7c66-422d-8588-d48ec49de127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63a62b7-7c66-422d-8588-d48ec49de127.jpg?1",
             "name": "Infiltrator's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1 and can't be blocked except by creatures with defender.",
             "colours": [
@@ -985,7 +985,7 @@
         },
         {
             "id": "ca3438f0-4813-5158-939e-c8273ade1295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40d7e5c-3b6d-4e42-b495-b3cd7ae0d808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40d7e5c-3b6d-4e42-b495-b3cd7ae0d808.jpg?1",
             "name": "Leyline of Singularity",
             "text": "If Leyline of Singularity is in your opening hand, you may begin the game with it in play.\nAll nonland permanents are legendary.",
             "colours": [
@@ -1017,7 +1017,7 @@
         },
         {
             "id": "4dedf69b-dd50-56b8-abf9-7ee1d03c4ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ada33a-5b7c-426a-8416-4ce01bccaa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ada33a-5b7c-426a-8416-4ce01bccaa5c.jpg?1",
             "name": "Mimeofacture",
             "text": "Replicate {3}{U} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nChoose target permanent an opponent controls. Search that player's library for a card with the same name and put it into play under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "a6eafdd0-e651-5ce9-ba74-8ce6677dba61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a276b12-4647-4223-b89e-f55d72feb2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a276b12-4647-4223-b89e-f55d72feb2d0.jpg?1",
             "name": "Quicken",
             "text": "The next sorcery spell you play this turn can be played any time you could play an instant.\nDraw a card.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "502d49cf-e97b-5ee8-9354-5857583f68a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7dd929-4bba-46a6-86c9-b8ed853eb721.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "b49192ce-ad47-52d1-a30b-e39d8a091ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2fb23-f8b5-4f83-9b29-b18507acaa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b2fb23-f8b5-4f83-9b29-b18507acaa1a.jpg?1",
             "name": "Runeboggle",
             "text": "Counter target spell unless its controller pays {1}.\nDraw a card.",
             "colours": [
@@ -1145,7 +1145,7 @@
         },
         {
             "id": "cd9e2261-be3e-5a88-ab00-c98f9ef9ea7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05189964-5ad0-48b7-a3af-67c7f46fe89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05189964-5ad0-48b7-a3af-67c7f46fe89e.jpg?1",
             "name": "Sky Swallower",
             "text": "Flying\nWhen Sky Swallower comes into play, target opponent gains control of all other permanents you control.",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "dad8e5f0-d2a2-5220-a52d-644f61dca6bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3992f-f874-448f-8aa4-ade71d6b3168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3992f-f874-448f-8aa4-ade71d6b3168.jpg?1",
             "name": "Steamcore Weird",
             "text": "When Steamcore Weird comes into play, if {R} was spent to play Steamcore Weird, it deals 2 damage to target creature or player.",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "5ea50acf-b1b6-5e4e-b336-b3faae93456d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc49d-2a07-4088-a288-ba7be4da7bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc49d-2a07-4088-a288-ba7be4da7bc2.jpg?1",
             "name": "Stratozeppelid",
             "text": "Flying\nStratozeppelid can block only creatures with flying.",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "07d0a735-dec4-5b23-a5d5-6b9f0d7a9625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56de9727-021e-4b37-b80b-08dcd898aec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56de9727-021e-4b37-b80b-08dcd898aec0.jpg?1",
             "name": "Thunderheads",
             "text": "Replicate {2}{U} (When you play this spell, copy it for each time you paid its replicate cost.)\nPut a 3/3 blue Weird creature token with defender and flying into play. Remove it from the game at end of turn.",
             "colours": [
@@ -1280,7 +1280,7 @@
         },
         {
             "id": "596dfede-3094-5591-a391-3646cdce006f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beff896-df7a-42b3-aaca-0b9ca1b8cf0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0beff896-df7a-42b3-aaca-0b9ca1b8cf0c.jpg?1",
             "name": "Torch Drake",
             "text": "Flying\n{1}{R}: Torch Drake gets +1/+0 until end of turn.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "ae50ac73-4997-5754-8ad0-fa3d0f84c11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98f5890-a494-4609-acae-f9e9bacd991d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98f5890-a494-4609-acae-f9e9bacd991d.jpg?1",
             "name": "Train of Thought",
             "text": "Replicate {1}{U} (When you play this spell, copy it for each time you paid its replicate cost.)\nDraw a card.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "3c2cce49-3aae-5ca9-b492-d7399588319a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870cdf0b-f707-47b9-b977-f06dad8c345a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870cdf0b-f707-47b9-b977-f06dad8c345a.jpg?1",
             "name": "Vacuumelt",
             "text": "Replicate {2}{U} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nReturn target creature to its owner's hand.",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "a1bab7ba-6731-54f5-8a3c-b2029f97d5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a886154e-1b49-471c-9432-cf44a3b3c9f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a886154e-1b49-471c-9432-cf44a3b3c9f4.jpg?1",
             "name": "Vedalken Plotter",
             "text": "When Vedalken Plotter comes into play, exchange control of target land you control and target land an opponent controls.",
             "colours": [
@@ -1414,7 +1414,7 @@
         },
         {
             "id": "0415a68c-b771-55cf-a190-1ae3fcab38e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bdfb7d-029d-4a70-8ae3-ef9a27e729c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bdfb7d-029d-4a70-8ae3-ef9a27e729c3.jpg?1",
             "name": "Vertigo Spawn",
             "text": "Defender (This creature can't attack.)\nWhenever Vertigo Spawn blocks a creature, tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1448,7 +1448,7 @@
         },
         {
             "id": "bb5f1e38-2202-560c-bdb1-58355ec16e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe094903-45a6-4b11-b80e-aabe915c4b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe094903-45a6-4b11-b80e-aabe915c4b7c.jpg?1",
             "name": "Abyssal Nocturnus",
             "text": "Whenever an opponent discards a card, Abyssal Nocturnus gets +2/+2 and gains fear until end of turn.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "2b60038e-f193-5eca-a7ed-adb9e747e7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fde21d-ce4e-41b7-97d5-c982f90b84a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fde21d-ce4e-41b7-97d5-c982f90b84a0.jpg?1",
             "name": "Caustic Rain",
             "text": "Remove target land from the game.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "e2e07256-c340-5441-9fc1-17f228252d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a9ce8f-df8a-44bc-8d34-9f42135a3a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a9ce8f-df8a-44bc-8d34-9f42135a3a23.jpg?1",
             "name": "Cremate",
             "text": "Remove target card in a graveyard from the game.\nDraw a card.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "ca1de59b-92a0-5bd3-bd26-f42070dadeb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62016f24-3f40-406b-8e29-30a6545d0fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62016f24-3f40-406b-8e29-30a6545d0fc1.jpg?1",
             "name": "Cry of Contrition",
             "text": "Target player discards a card.\nHaunt (When this spell card is put into a graveyard after resolving, remove it from the game haunting target creature.)\nWhen the creature Cry of Contrition haunts is put into a graveyard, target player discards a card.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "1b7ffe80-d3d7-51c0-9bce-6732aefdec26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13337c99-7d9e-4464-905b-87e8deb072ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13337c99-7d9e-4464-905b-87e8deb072ac.jpg?1",
             "name": "Cryptwailing",
             "text": "{1}, Remove two creature cards in your graveyard from the game: Target player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "e50832b9-ecbc-5029-87c7-8f58347e04ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d285981-f342-4679-a199-cf5d003407e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d285981-f342-4679-a199-cf5d003407e8.jpg?1",
             "name": "Daggerclaw Imp",
             "text": "Flying\nDaggerclaw Imp can't block.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "aa23243e-9291-5e49-b563-08dd6cf06a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a4fe4d-460d-4143-9a8e-14e16b211722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a4fe4d-460d-4143-9a8e-14e16b211722.jpg?1",
             "name": "Douse in Gloom",
             "text": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "1fe12d9b-ae43-5e03-b19b-c12becd817db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c53fda-3768-4cc5-8ca3-a60805c340ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c53fda-3768-4cc5-8ca3-a60805c340ba.jpg?1",
             "name": "Exhumer Thrull",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Exhumer Thrull comes into play or the creature it haunts is put into a graveyard, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "685cec7e-ebe7-5d34-8f25-57472e68e835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f394fd39-842f-4c98-b857-bdad3fd09758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f394fd39-842f-4c98-b857-bdad3fd09758.jpg?1",
             "name": "Hissing Miasma",
             "text": "Whenever a creature attacks you, its controller loses 1 life.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "e12f3df4-ed41-5dd6-be00-f1bc55373f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dfe8b8-b39e-4e70-9e5b-be42c93b4f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37dfe8b8-b39e-4e70-9e5b-be42c93b4f70.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it in play.\nIf a card would be put into an opponent's graveyard, remove it from the game instead.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "e2f15d1c-6f14-567f-8899-93198274aad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b045121-7742-41ee-be27-591692f42331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b045121-7742-41ee-be27-591692f42331.jpg?1",
             "name": "Necromancer's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1.\nIf a creature you control that's enchanted would be put into a graveyard, return it to its owner's hand instead.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "5ed86732-f511-5046-abf9-cd0080759bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104adc35-69fb-4b63-9b03-a71097e15652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104adc35-69fb-4b63-9b03-a71097e15652.jpg?1",
             "name": "Orzhov Euthanist",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Orzhov Euthanist comes into play or the creature it haunts is put into a graveyard, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -1843,7 +1843,7 @@
         },
         {
             "id": "068275d5-00e8-5201-9a91-5d83f6d1b95b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26407330-d7a1-4915-b7c6-e08e166cf638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26407330-d7a1-4915-b7c6-e08e166cf638.jpg?1",
             "name": "Ostiary Thrull",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "a6f15e04-b517-5b04-b132-611e0ad9e11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd84bbb3-8b99-4e6d-b514-b094ec93eaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd84bbb3-8b99-4e6d-b514-b094ec93eaa0.jpg?1",
             "name": "Plagued Rusalka",
             "text": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -1912,7 +1912,7 @@
         },
         {
             "id": "9eaf5922-d5d7-5abe-a854-f60feac1c1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a168b953-eac4-472e-ac74-598febb05f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a168b953-eac4-472e-ac74-598febb05f83.jpg?1",
             "name": "Poisonbelly Ogre",
             "text": "Whenever another creature comes into play, its controller loses 1 life.",
             "colours": [
@@ -1947,7 +1947,7 @@
         },
         {
             "id": "b90c96d3-ea53-599f-8fae-8064eefa92d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d11a4f2-376e-42ae-9693-9dc754bd2282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d11a4f2-376e-42ae-9693-9dc754bd2282.jpg?1",
             "name": "Restless Bones",
             "text": "{3}{B}, {T}: Target creature gains swampwalk until end of turn.\n{1}{B}: Regenerate Restless Bones.",
             "colours": [
@@ -1981,7 +1981,7 @@
         },
         {
             "id": "c97a4b55-d3e2-54a4-9c45-7aaefab7b568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71b7b73-567a-4291-bf60-f17c1fe55de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71b7b73-567a-4291-bf60-f17c1fe55de6.jpg?1",
             "name": "Revenant Patriarch",
             "text": "When Revenant Patriarch comes into play, if {W} was spent to play Revenant Patriarch, target player skips his or her next combat phase.\nRevenant Patriarch can't block.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "f9bd30f2-53ce-5d30-9448-6595e506aff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8291b1a9-2d04-4dd7-b8c5-3b1018aa0d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8291b1a9-2d04-4dd7-b8c5-3b1018aa0d2f.jpg?1",
             "name": "Sanguine Praetor",
             "text": "{B}, Sacrifice a creature: Destroy each creature with the same converted mana cost as the sacrificed creature.",
             "colours": [
@@ -2051,7 +2051,7 @@
         },
         {
             "id": "e4a48c95-dde7-57e1-8d5b-2b002048b412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bf245f-e8e0-4d32-8cd7-06d832609910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bf245f-e8e0-4d32-8cd7-06d832609910.jpg?1",
             "name": "Seize the Soul",
             "text": "Destroy target nonwhite nonblack creature. Put a 1/1 white Spirit creature token with flying into play.\nHaunt\nWhen the creature Seize the Soul haunts is put into a graveyard, destroy target nonwhite nonblack creature. Put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -2083,7 +2083,7 @@
         },
         {
             "id": "84e03c6b-5559-5260-92e4-7481b4e6e039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69251d44-3038-4b64-ab78-fc87f0406ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69251d44-3038-4b64-ab78-fc87f0406ba2.jpg?1",
             "name": "Skeletal Vampire",
             "text": "Flying\nWhen Skeletal Vampire comes into play, put two 1/1 black Bat creature tokens with flying into play.\n{3}{B}{B}, Sacrifice a Bat: Put two 1/1 black Bat creature tokens with flying into play.\nSacrifice a Bat: Regenerate Skeletal Vampire.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "ce86cac0-64f2-596f-bd2d-ff24983cfe20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2b2bf-92bc-4362-b232-8a403b9a7ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2b2bf-92bc-4362-b232-8a403b9a7ade.jpg?1",
             "name": "Smogsteed Rider",
             "text": "Whenever Smogsteed Rider attacks, each other attacking creature gains fear until end of turn.",
             "colours": [
@@ -2153,7 +2153,7 @@
         },
         {
             "id": "60552cfd-3d39-5837-82e2-0a09262225c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8197cc43-c787-4372-81dc-759a9fe24708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8197cc43-c787-4372-81dc-759a9fe24708.jpg?1",
             "name": "Bloodscale Prowler",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "81e40627-4ea8-508b-a2d2-c0c651226cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a33fb-8b36-4dad-9eef-e0e601723f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a33fb-8b36-4dad-9eef-e0e601723f78.jpg?1",
             "name": "Fencer's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1 and have first strike.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "443472f7-9618-59a1-bfb5-6bfbc42a441f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cab68b-ee26-46eb-a18b-9b42bf2d10e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cab68b-ee26-46eb-a18b-9b42bf2d10e5.jpg?1",
             "name": "Ghor-Clan Bloodscale",
             "text": "First strike\n{3}{G}: Ghor-Clan Bloodscale gets +2/+2 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "2e42ef0e-a406-5f8b-a6ea-34ddf2f17ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaa3c6e-1f8a-4580-8e03-e670f50ab958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdaa3c6e-1f8a-4580-8e03-e670f50ab958.jpg?1",
             "name": "Hypervolt Grasp",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target creature or player.\"\n{1}{U}: Return Hypervolt Grasp to its owner's hand.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "c17c547a-7e96-59ad-b6ea-d17cbe2a62a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d09839-b41e-4aab-8913-40d63052dbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d09839-b41e-4aab-8913-40d63052dbf3.jpg?1",
             "name": "Leyline of Lightning",
             "text": "If Leyline of Lightning is in your opening hand, you may begin the game with it in play.\nWhenever you play a spell, you may pay {1}. If you do, Leyline of Lightning deals 1 damage to target player.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "8f974e95-3ad8-5035-ada0-63c84fa9d90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b8143-2742-4262-b18f-2825bf8cea6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4b8143-2742-4262-b18f-2825bf8cea6f.jpg?1",
             "name": "Living Inferno",
             "text": "{T}: Living Inferno deals damage equal to its power divided as you choose among any number of target creatures. Each of those creatures deals damage equal to its power to Living Inferno.",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "974941bb-c9fe-5e34-8441-16641c720f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7448ed3-8720-4098-a3dd-9151ba10bb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7448ed3-8720-4098-a3dd-9151ba10bb49.jpg?1",
             "name": "Ogre Savant",
             "text": "When Ogre Savant comes into play, if {U} was spent to play Ogre Savant, return target creature to its owner's hand.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "32bc1e9b-ff2d-5c4e-b466-1548f4cbbaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891f1d29-377a-4f71-917f-ff10e785caee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891f1d29-377a-4f71-917f-ff10e785caee.jpg?1",
             "name": "Parallectric Feedback",
             "text": "Parallectric Feedback deals damage to target spell's controller equal to that spell's converted mana cost.",
             "colours": [
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "76a8e95d-0c84-504a-93ff-4e32885c9689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c9dab-e8d5-48b3-8fd2-9f4138ee0c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c9dab-e8d5-48b3-8fd2-9f4138ee0c7c.jpg?1",
             "name": "Pyromatics",
             "text": "Replicate {1}{R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nPyromatics deals 1 damage to target creature or player.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "0fdfff6f-e68c-552c-bccb-eaa4e92e7748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6877862-f7c5-493d-baaf-41a91d4c7982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6877862-f7c5-493d-baaf-41a91d4c7982.jpg?1",
             "name": "Rabble-Rouser",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\n{R}, {T}: Attacking creatures get +X/+0 until end of turn, where X is Rabble-Rouser's power.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "c9ff9d01-0219-57e3-ac7b-198992f40cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f955164-ddb8-484c-a063-967621abce87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f955164-ddb8-484c-a063-967621abce87.jpg?1",
             "name": "Scorched Rusalka",
             "text": "{R}, Sacrifice a creature: Scorched Rusalka deals 1 damage to target player.",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "cdaeafb3-30c8-5610-8c2d-292d727cd1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dcff21-5900-43c4-a38b-cdc19c704ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dcff21-5900-43c4-a38b-cdc19c704ce4.jpg?1",
             "name": "Shattering Spree",
             "text": "Replicate {R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nDestroy target artifact.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "f285d140-c30a-5c72-9ac7-db059dabc996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db24da9-8901-4e2d-9565-39ce1b7639c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db24da9-8901-4e2d-9565-39ce1b7639c9.jpg?1",
             "name": "Siege of Towers",
             "text": "Replicate {1}{R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTarget Mountain becomes a 3/1 creature. It's still a land.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "7759e457-8103-5096-b3bf-5b67400dab6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c51e46-3236-41ee-913e-f253f218067c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c51e46-3236-41ee-913e-f253f218067c.jpg?1",
             "name": "Skarrgan Firebird",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature comes into play with three +1/+1 counters on it.)\nFlying\n{R}{R}{R}: Return Skarrgan Firebird from your graveyard to your hand. Play this ability only if an opponent was dealt damage this turn.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "40838d00-89c9-5c49-a1f8-d136d1be49f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad525bb3-15fd-4887-a3e7-0a036258dcc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad525bb3-15fd-4887-a3e7-0a036258dcc7.jpg?1",
             "name": "Tin Street Hooligan",
             "text": "When Tin Street Hooligan comes into play, if {G} was spent to play Tin Street Hooligan, destroy target artifact.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "cb6eecca-1b15-5b24-a397-2c56c2d47ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0fb683-2e9b-465c-9fb5-2eb334c2739a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0fb683-2e9b-465c-9fb5-2eb334c2739a.jpg?1",
             "name": "Battering Wurm",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nCreatures with power less than Battering Wurm's power can't block it.",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "159bfb6b-9da4-5820-ada5-337e7653e1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5eea61-373a-4bca-a793-d6be7f6214e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5eea61-373a-4bca-a793-d6be7f6214e2.jpg?1",
             "name": "Beastmaster's Magemark",
             "text": "Enchant creature\nCreatures you control that are enchanted get +1/+1.\nWhenever a creature you control that's enchanted becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -2730,7 +2730,7 @@
         },
         {
             "id": "8cf4932f-f361-53f8-ae40-5e4745a99740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7170a1db-3502-4caf-a54b-bd0df0d93f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7170a1db-3502-4caf-a54b-bd0df0d93f2d.jpg?1",
             "name": "Bioplasm",
             "text": "Whenever Bioplasm attacks, remove the top card of your library from the game. If it's a creature card, Bioplasm gets +X/+Y until end of turn, where X is the removed creature card's power and Y is its toughness. (A * on a card not in play is 0.)",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "5d17aaf5-e7b5-59e6-8dfe-17010302eee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8683546-85b7-4658-91be-91ef65fb3fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8683546-85b7-4658-91be-91ef65fb3fc3.jpg?1",
             "name": "Crash Landing",
             "text": "Target creature with flying loses flying until end of turn. Crash Landing deals damage to that creature equal to the number of Forests you control.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "416056ec-a5d4-5f3a-b476-92d6146c6df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bf5ce-f7f8-47cb-abb8-f14ce5f1af67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bf5ce-f7f8-47cb-abb8-f14ce5f1af67.jpg?1",
             "name": "Dryad Sophisticate",
             "text": "Nonbasic landwalk",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "72336841-4d42-5e0a-9b3b-78516ce38687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325503ee-ea62-459b-a58a-53fb3c1ef027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325503ee-ea62-459b-a58a-53fb3c1ef027.jpg?1",
             "name": "Earth Surge",
             "text": "Each land gets +2/+2 as long as it's a creature.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "5bbf705e-d900-5c3a-a724-db0934ff9e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d75367-88e7-44e6-9234-590dc143fd1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d75367-88e7-44e6-9234-590dc143fd1d.jpg?1",
             "name": "Gatherer of Graces",
             "text": "Gatherer of Graces gets +1/+1 for each Aura attached to it.\nSacrifice an Aura: Regenerate Gatherer of Graces.",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "fd821b70-252b-5616-a04b-5d3d8d4d3797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77ad353-7543-4d65-bf02-33f66abaf14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77ad353-7543-4d65-bf02-33f66abaf14b.jpg?1",
             "name": "Ghor-Clan Savage",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature comes into play with three +1/+1 counters on it.)",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "7cab5209-00d4-510b-806c-e11c81de715d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82f763a-c960-4b59-8c77-f3bea7bd8c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82f763a-c960-4b59-8c77-f3bea7bd8c8b.jpg?1",
             "name": "Gristleback",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nSacrifice Gristleback: You gain life equal to Gristleback's power.",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "54c31f5e-b954-5f10-a836-3f25b95d7189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9855ce83-ae26-4b1d-ab7f-637cde09d679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9855ce83-ae26-4b1d-ab7f-637cde09d679.jpg?1",
             "name": "Gruul Nodorog",
             "text": "{R}: Gruul Nodorog can't be blocked this turn except by two or more creatures.",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "7738a7d0-7640-54ef-9957-1f1a5dc21210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3fdc0-3fd1-47da-b3ed-e4a462179e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f3fdc0-3fd1-47da-b3ed-e4a462179e75.jpg?1",
             "name": "Gruul Scrapper",
             "text": "When Gruul Scrapper comes into play, if {R} was spent to play Gruul Scrapper, it gains haste until end of turn.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "f29a7a09-9114-5047-8560-5f1ddf215893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7caffa7-29bd-455c-9770-94a0ad7ef5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7caffa7-29bd-455c-9770-94a0ad7ef5e3.jpg?1",
             "name": "Leyline of Lifeforce",
             "text": "If Leyline of Lifeforce is in your opening hand, you may begin the game with it in play.\nCreature spells can't be countered.",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "47b754c9-8b07-5e22-9116-109c70f6135e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56fbf32-f08f-4882-b8d4-41ccb60cba63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56fbf32-f08f-4882-b8d4-41ccb60cba63.jpg?1",
             "name": "Petrified Wood-Kin",
             "text": "Petrified Wood-Kin can't be countered.\nBloodthirst X (This creature comes into play with X +1/+1 counters on it, where X is the damage dealt to your opponents this turn.)\nProtection from instants",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "02060fb0-0d17-5a54-92b2-17f457e3c3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fc1314-4bf2-44f2-a016-58765eb04607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fc1314-4bf2-44f2-a016-58765eb04607.jpg?1",
             "name": "Predatory Focus",
             "text": "You may have creatures you control deal their combat damage to defending player this turn as though they weren't blocked.",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "9b8e2b86-e932-5fbf-8157-391f28d0f1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293ce819-c228-4ff1-827c-3d0cbed703ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293ce819-c228-4ff1-827c-3d0cbed703ea.jpg?1",
             "name": "Primeval Light",
             "text": "Destroy all enchantments target player controls.",
             "colours": [
@@ -3169,7 +3169,7 @@
         },
         {
             "id": "4e78fc54-dd05-5750-b431-dba0a4837a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c921343a-4496-4e21-a0ff-e04a1fb407bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c921343a-4496-4e21-a0ff-e04a1fb407bf.jpg?1",
             "name": "Silhana Ledgewalker",
             "text": "Silhana Ledgewalker can't be blocked except by creatures with flying.\nSilhana Ledgewalker can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "58db6478-6a0e-5201-84ea-04bff70a16af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9c7e09-8384-4866-af92-ba56bd307d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9c7e09-8384-4866-af92-ba56bd307d9c.jpg?1",
             "name": "Silhana Starfletcher",
             "text": "As Silhana Starfletcher comes into play, choose a color.\n{T}: Add one mana of the chosen color to your mana pool.\nSilhana Starfletcher can block as though it had flying.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "7c1c2db3-5914-5581-a475-d355d18e537c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc65d7ea-e8f4-4be9-94e4-2fa2e4d83177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc65d7ea-e8f4-4be9-94e4-2fa2e4d83177.jpg?1",
             "name": "Skarrgan Pit-Skulk",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\nCreatures with power less than Skarrgan Pit-Skulk's power can't block it.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "f23adea7-9b35-53c7-b10f-36250b6e7343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b4aec5-0a7d-4b1c-8819-ea675d415eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b4aec5-0a7d-4b1c-8819-ea675d415eac.jpg?1",
             "name": "Starved Rusalka",
             "text": "{G}, Sacrifice a creature: You gain 1 life.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "ff8d0ab7-d985-5439-9bb3-e66895719a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef061ed-736c-41ba-b692-d1fbfaca242e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef061ed-736c-41ba-b692-d1fbfaca242e.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "49017e63-cd08-5658-ba92-51d66428a87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661580bc-b5e5-48ce-b855-c177f1c61742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661580bc-b5e5-48ce-b855-c177f1c61742.jpg?1",
             "name": "Wurmweaver Coil",
             "text": "Enchant green creature\nEnchanted creature gets +6/+6.\n{G}{G}{G}, Sacrifice Wurmweaver Coil: Put a 6/6 green Wurm creature token into play.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "09fc1989-e64c-57de-ac03-4cb9af7f3039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9b0ab4-5c6b-494d-926d-daa38a3ac640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9b0ab4-5c6b-494d-926d-daa38a3ac640.jpg?1",
             "name": "Agent of Masks",
             "text": "At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3412,7 +3412,7 @@
         },
         {
             "id": "115a644d-3b60-504d-8efe-35342b58fe9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae71424-df9c-481c-9305-a0c30adcfda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae71424-df9c-481c-9305-a0c30adcfda2.jpg?1",
             "name": "Angel of Despair",
             "text": "Flying\nWhen Angel of Despair comes into play, destroy target permanent.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "73a116cc-b5ca-5151-9f72-26afde63c0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c8995-be36-43f6-9bd7-7b8712894331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c8995-be36-43f6-9bd7-7b8712894331.jpg?1",
             "name": "Blind Hunter",
             "text": "Flying\nHaunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Blind Hunter comes into play or the creature it haunts is put into a graveyard, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "60aa0732-a2a4-55e2-98be-ea515159aa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4a08e9-06c7-43e9-a855-4f507a35ae8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4a08e9-06c7-43e9-a855-4f507a35ae8b.jpg?1",
             "name": "Borborygmos",
             "text": "Trample\nWhenever Borborygmos deals combat damage to a player, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "d48230ff-79b5-5036-ac75-5f537381d496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6492648-8115-41ff-a184-08efebae28b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6492648-8115-41ff-a184-08efebae28b1.jpg?1",
             "name": "Burning-Tree Bloodscale",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature comes into play with a +1/+1 counter on it.)\n{2}{R}: Target creature can't block Burning-Tree Bloodscale this turn.\n{2}{G}: Target creature blocks Burning-Tree Bloodscale this turn if able.",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "32af7bc3-fd5e-538e-a398-a5ca566cb126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133863fc-e820-4be6-a354-a02e7fe25eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133863fc-e820-4be6-a354-a02e7fe25eae.jpg?1",
             "name": "Burning-Tree Shaman",
             "text": "Whenever a player plays an activated ability that isn't a mana ability, Burning-Tree Shaman deals 1 damage to that player.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "dab0fb50-bd56-5daf-aed5-80d52d060c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112c47e4-5ff8-4ea0-ac14-956e4b94119a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112c47e4-5ff8-4ea0-ac14-956e4b94119a.jpg?1",
             "name": "Castigate",
             "text": "Target opponent reveals his or her hand. Choose a nonland card from it. Remove that card from the game.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "f2098da5-ea37-5729-bcf0-fef5427ab070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779cdad3-9d90-4de1-8071-f772fb85142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779cdad3-9d90-4de1-8071-f772fb85142b.jpg?1",
             "name": "Cerebral Vortex",
             "text": "Target player draws two cards, then Cerebral Vortex deals damage to that player equal to the number of cards he or she has drawn this turn.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "9fc10ab3-9607-5166-b0b9-11d4117d6b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39849576-b58f-45f0-ad33-a9bf2135d9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39849576-b58f-45f0-ad33-a9bf2135d9b7.jpg?1",
             "name": "Conjurer's Ban",
             "text": "Name a card. Until your next turn, the named card can't be played.\nDraw a card.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "c3f254ed-45ba-58b5-8079-ee425eae4e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec5a956-c846-46b6-91bd-37e4db542280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec5a956-c846-46b6-91bd-37e4db542280.jpg?1",
             "name": "Culling Sun",
             "text": "Destroy each creature with converted mana cost 3 or less.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "b999b6e3-d057-58b0-a619-52ca67546198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b4ee44-28c4-4a39-9c06-aca43787954f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b4ee44-28c4-4a39-9c06-aca43787954f.jpg?1",
             "name": "Dune-Brood Nephilim",
             "text": "Whenever Dune-Brood Nephilim deals combat damage to a player, put a 1/1 colorless Sand creature token into play for each land you control.",
             "colours": [
@@ -3772,7 +3772,7 @@
         },
         {
             "id": "2004a702-ab54-5f27-ab12-f6a110038618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef42b5b2-6504-486c-aaa0-9d5e4769ba1d.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among any number of target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "59035d42-c920-5a08-8b43-e3457d1decfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad65c721-b601-46f9-ba0b-ac4d96567cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad65c721-b601-46f9-ba0b-ac4d96567cee.jpg?1",
             "name": "Feral Animist",
             "text": "{3}: Feral Animist gets +X/+0 until end of turn, where X is its power.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "b2b15520-5c47-5b1a-93ef-9c799d2e3d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa9c4a-7027-4ddd-93e0-3c5dcaa8e48b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa9c4a-7027-4ddd-93e0-3c5dcaa8e48b.jpg?1",
             "name": "Gelectrode",
             "text": "{T}: Gelectrode deals 1 damage to target creature or player.\nWhenever you play an instant or sorcery spell, you may untap Gelectrode.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "6d6f471c-3a46-5ca1-aaa1-6b16258a6e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83a5785-a9a9-4a07-82c7-97dc5b9a2475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83a5785-a9a9-4a07-82c7-97dc5b9a2475.jpg?1",
             "name": "Ghost Council of Orzhova",
             "text": "When Ghost Council of Orzhova comes into play, target opponent loses 1 life and you gain 1 life.\n{1}, Sacrifice a creature: Remove Ghost Council of Orzhova from the game. Return it to play under its owner's control at end of turn.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "f76d698e-ea6e-5480-89e4-7610aa71bc17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc68fa-d6cf-4f6d-8f44-4d62c9cdd5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc68fa-d6cf-4f6d-8f44-4d62c9cdd5c3.jpg?1",
             "name": "Glint-Eye Nephilim",
             "text": "Whenever Glint-Eye Nephilim deals combat damage to a player, draw that many cards.\n{1}, Discard a card: Glint-Eye Nephilim gets +1/+1 until end of turn.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "677cc272-f243-5213-94c9-569875d827e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8170c05b-826c-4879-b202-29eec6f955ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8170c05b-826c-4879-b202-29eec6f955ea.jpg?1",
             "name": "Goblin Flectomancer",
             "text": "Sacrifice Goblin Flectomancer: You may change the targets of target instant or sorcery spell.",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "631432fa-43bb-5de3-a871-5a0a8807e736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29bb432-1ca6-4305-b6d3-d7afe06c6c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29bb432-1ca6-4305-b6d3-d7afe06c6c69.jpg?1",
             "name": "Ink-Treader Nephilim",
             "text": "Whenever a player plays an instant or sorcery spell, if Ink-Treader Nephilim is the only target of that spell, copy the spell for each other creature that spell could target. Each copy targets a different one of those creatures.",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "dfd6c1ed-e149-5975-80cf-7fd8be1fdd45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8e41a-5990-4ceb-9d41-76632faa7883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8e41a-5990-4ceb-9d41-76632faa7883.jpg?1",
             "name": "Invoke the Firemind",
             "text": "Choose one Draw X cards; or Invoke the Firemind deals X damage to target creature or player.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "edc9a91c-7bef-5722-8793-1b78cf0769ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c82dc47-38db-4ee1-9031-f8ea68d05389.jpg?1",
             "name": "Izzet Chronarch",
             "text": "When Izzet Chronarch comes into play, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "17c83766-c757-5655-b60e-780df43ea428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c808a8ec-895c-4777-9e11-e83ce34eddef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c808a8ec-895c-4777-9e11-e83ce34eddef.jpg?1",
             "name": "Killer Instinct",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card, put it into play. That creature gains haste until end of turn. Sacrifice it at end of turn.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "0943d268-b6ad-59d8-8c9f-0b8a725de477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c011b432-ec39-44c8-bf2a-1c3fec32a576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c011b432-ec39-44c8-bf2a-1c3fec32a576.jpg?1",
             "name": "Leap of Flame",
             "text": "Replicate {U}{R} (When you play this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nTarget creature gets +1/+0 and gains flying and first strike until end of turn.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "60856fe2-e02d-58a8-a8e7-67aa146f5dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2c5187-71c7-4801-8a76-339c67322d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2c5187-71c7-4801-8a76-339c67322d35.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "cebab560-850d-5078-91db-1ea78906d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994d98a-090b-4203-b44f-b6517b6a83ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994d98a-090b-4203-b44f-b6517b6a83ea.jpg?1",
             "name": "Niv-Mizzet, the Firemind",
             "text": "Flying\nWhenever you draw a card, Niv-Mizzet, the Firemind deals 1 damage to target creature or player.\n{T}: Draw a card.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "05bda4b6-4705-5283-bc40-59221482c032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b5813b-955b-469a-b287-65325c589b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b5813b-955b-469a-b287-65325c589b59.jpg?1",
             "name": "Orzhov Pontiff",
             "text": "Haunt (When this card is put into a graveyard from play, remove it from the game haunting target creature.)\nWhen Orzhov Pontiff comes into play or the creature it haunts is put into a graveyard, choose one creatures you control get +1/+1 until end of turn; or creatures you don't control get -1/-1 until end of turn.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "589d1006-c5bb-546b-a3da-52eb25fc7772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36964bbd-f068-4a69-8d6b-7e4e97938b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36964bbd-f068-4a69-8d6b-7e4e97938b98.jpg?1",
             "name": "Pillory of the Sleepless",
             "text": "",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "193ebeb2-5bc7-51b6-843b-8535ad32ea03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d891c5c2-55d4-43a9-a56b-a92166fd41b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d891c5c2-55d4-43a9-a56b-a92166fd41b8.jpg?1",
             "name": "Rumbling Slum",
             "text": "At the beginning of your upkeep, Rumbling Slum deals 1 damage to each player.",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "aeee755e-54a0-5f62-9bd8-b3fc6601983f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ee5a9-2995-4868-b7ea-8735b2aee77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ee5a9-2995-4868-b7ea-8735b2aee77e.jpg?1",
             "name": "Savage Twister",
             "text": "Savage Twister deals X damage to each creature.",
             "colours": [
@@ -4389,7 +4389,7 @@
         },
         {
             "id": "31bc27e8-ccc3-573f-84e7-6c9efa4aa33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e040a6-9e10-4528-8ee1-ef3a00e93cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e040a6-9e10-4528-8ee1-ef3a00e93cbc.jpg?1",
             "name": "Scab-Clan Mauler",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature comes into play with two +1/+1 counters on it.)\nTrample",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "cd726636-dba3-514b-8bc7-fe49b491de9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98510af3-a884-417a-8cd9-991890d42919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98510af3-a884-417a-8cd9-991890d42919.jpg?1",
             "name": "Schismotivate",
             "text": "Target creature gets +4/+0 until end of turn. Another target creature gets -4/-0 until end of turn.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "7b750d23-1fdb-5b95-bd0b-6ad7da290219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d24d84e-09ec-4300-914b-1a540e300692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d24d84e-09ec-4300-914b-1a540e300692.jpg?1",
             "name": "Skarrgan Skybreaker",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature comes into play with three +1/+1 counters on it.)\n{1}, Sacrifice Skarrgan Skybreaker: Skarrgan Skybreaker deals damage equal to its power to target creature or player.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "9d7325a6-7c6e-5d96-af7c-ad373770e411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f02a09-e959-438c-ab48-abd34b10d07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f02a09-e959-438c-ab48-abd34b10d07c.jpg?1",
             "name": "Souls of the Faultless",
             "text": "Defender (This creature can't attack.)\nWhenever Souls of the Faultless is dealt combat damage, you gain that much life and attacking player loses that much life.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "94523aba-1f04-5653-88fc-7b47f0139bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ee9c0d-c0ac-4c75-b254-77329dc42366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ee9c0d-c0ac-4c75-b254-77329dc42366.jpg?1",
             "name": "Stitch in Time",
             "text": "Flip a coin. If you win the flip, take an extra turn after this one.",
             "colours": [
@@ -4567,7 +4567,7 @@
         },
         {
             "id": "01837939-d874-57cd-bf7c-30f71ab6f933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5313054-91a5-401c-84d1-03a2cd265060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5313054-91a5-401c-84d1-03a2cd265060.jpg?1",
             "name": "Streetbreaker Wurm",
             "text": "",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "95b2c44e-8659-54c9-b255-82034154977f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb856e6-8f63-4048-9818-cc3e65748855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb856e6-8f63-4048-9818-cc3e65748855.jpg?1",
             "name": "Teysa, Orzhov Scion",
             "text": "Sacrifice three white creatures: Remove target creature from the game.\nWhenever another black creature you control is put into a graveyard from play, put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "a845ec00-f711-596c-b5d7-b44dd4837b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149ce3cc-5df6-4158-b732-5bd2c1b3007f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149ce3cc-5df6-4158-b732-5bd2c1b3007f.jpg?1",
             "name": "Tibor and Lumia",
             "text": "Whenever you play a blue spell, target creature gains flying until end of turn.\nWhenever you play a red spell, Tibor and Lumia deals 1 damage to each creature without flying.",
             "colours": [
@@ -4681,7 +4681,7 @@
         },
         {
             "id": "841f5b2d-3e8e-5e26-9138-6d1d6d62b997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ba043a-d508-49dd-9bf3-a7ae8d26ac9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ba043a-d508-49dd-9bf3-a7ae8d26ac9b.jpg?1",
             "name": "Ulasht, the Hate Seed",
             "text": "Ulasht, the Hate Seed comes into play with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.\n{1}, Remove a +1/+1 counter from Ulasht: Choose one Ulasht deals 1 damage to target creature; or put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "179815e0-d6c3-57a7-a603-12cee212d7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fd3734-8c28-4bd0-b202-eee1ab98c328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fd3734-8c28-4bd0-b202-eee1ab98c328.jpg?1",
             "name": "Wee Dragonauts",
             "text": "Flying\nWhenever you play an instant or sorcery spell, Wee Dragonauts gets +2/+0 until end of turn.",
             "colours": [
@@ -4757,7 +4757,7 @@
         },
         {
             "id": "25ef4d25-d1aa-5afd-8125-587d44dfb434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185d56ab-b7f2-4eb2-9540-db8f2dc9b436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/185d56ab-b7f2-4eb2-9540-db8f2dc9b436.jpg?1",
             "name": "Witch-Maw Nephilim",
             "text": "Whenever you play a spell, you may put two +1/+1 counters on Witch-Maw Nephilim.\nWhenever Witch-Maw Nephilim attacks, it gains trample until end of turn if its power is 10 or greater.",
             "colours": [
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "324a1ced-9b04-5582-99e8-183cda1ea09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b44e5-0ad8-4487-a6e2-d43b123086ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3b44e5-0ad8-4487-a6e2-d43b123086ab.jpg?1",
             "name": "Wreak Havoc",
             "text": "Wreak Havoc can't be countered by spells or abilities.\nDestroy target artifact or land.",
             "colours": [
@@ -4831,7 +4831,7 @@
         },
         {
             "id": "fb5e22ed-7232-5b85-8108-4c10b8269567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0247d76c-dee4-4d1b-9c25-faa56171541e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0247d76c-dee4-4d1b-9c25-faa56171541e.jpg?1",
             "name": "Yore-Tiller Nephilim",
             "text": "Whenever Yore-Tiller Nephilim attacks, return target creature card from your graveyard to play tapped and attacking.",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "68451ed9-c2df-505b-975f-f0696ea81e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a76c61-fd84-458d-9bc0-583768f4275a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a76c61-fd84-458d-9bc0-583768f4275a.jpg?1",
             "name": "Debtors' Knell",
             "text": "({WB} can be paid with either {W} or {B}.)\nAt the beginning of your upkeep, put target creature card in a graveyard into play under your control.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "7754b372-277d-5a0d-8d28-10b081e40812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc3bb4-657c-46fa-9ad5-c924fdaefc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc3bb4-657c-46fa-9ad5-c924fdaefc83.jpg?1",
             "name": "Djinn Illuminatus",
             "text": "({UR} can be paid with either {U} or {R}.)\nFlying\nEach instant and sorcery spell you play has replicate. The replicate cost is equal to its mana cost. (When you play it, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "c229ffc4-0155-57cd-acd4-9d4e4f6c1ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a83dbc9-802f-4ebf-93de-b2bf4844cc9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a83dbc9-802f-4ebf-93de-b2bf4844cc9e.jpg?1",
             "name": "Giant Solifuge",
             "text": "({RG} can be paid with either {R} or {G}.)\nTrample, haste\nGiant Solifuge can't be the target of spells or abilities.",
             "colours": [
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "92684e99-3d62-5e0e-8de8-ba1da3000514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a61f8-aab1-48d7-aebb-cf500ac5cb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a61f8-aab1-48d7-aebb-cf500ac5cb0e.jpg?1",
             "name": "Gruul Guildmage",
             "text": "({RG} can be paid with either {R} or {G}.)\n{3}{R}, Sacrifice a land: Gruul Guildmage deals 2 damage to target player.\n{3}{G}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "a34d5c92-b50e-5aa3-bb54-78d6e9dcf39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce6ade-8741-4567-8ed3-3e03becc6f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecce6ade-8741-4567-8ed3-3e03becc6f1b.jpg?1",
             "name": "Izzet Guildmage",
             "text": "({UR} can be paid with either {U} or {R}.)\n{2}{U}: Copy target instant spell you control with converted mana cost 2 or less. You may choose new targets for the copy.\n{2}{R}: Copy target sorcery spell you control with converted mana cost 2 or less. You may choose new targets for the copy.",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "aefab0a2-652d-5b52-b5ab-7def35c9bab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a217a-e47b-4874-9861-bb57c7b1f06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a217a-e47b-4874-9861-bb57c7b1f06a.jpg?1",
             "name": "Mourning Thrull",
             "text": "({WB} can be paid with either {W} or {B}.)\nFlying\nWhenever Mourning Thrull deals damage, you gain that much life.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "84c61fa0-61de-5b76-9baf-945f4e741893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ae5b4-2caf-4992-b2c2-64f00e9e567a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ae5b4-2caf-4992-b2c2-64f00e9e567a.jpg?1",
             "name": "Orzhov Guildmage",
             "text": "({WB} can be paid with either {W} or {B}.)\n{2}{W}: Target player gains 1 life.\n{2}{B}: Each player loses 1 life.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "f6b3d2de-af5b-5d0e-b223-4bee0db7c1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b876fa0-4018-43a2-8911-e1525f95f09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b876fa0-4018-43a2-8911-e1525f95f09f.jpg?1",
             "name": "Petrahydrox",
             "text": "({UR} can be paid with either {U} or {R}.)\nWhen Petrahydrox becomes the target of a spell or ability, return Petrahydrox to its owner's hand.",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "38d7a715-9bad-50e6-87fc-7dabadb7182f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242dc29e-d8f5-4207-abbf-cf5425f08551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242dc29e-d8f5-4207-abbf-cf5425f08551.jpg?1",
             "name": "Wild Cantor",
             "text": "({RG} can be paid with either {R} or {G}.)\nSacrifice Wild Cantor: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5197,7 +5197,7 @@
         },
         {
             "id": "0296fa82-0eeb-5dba-9c92-242f146e35d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb30340-96a4-49d8-838b-8788900401a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb30340-96a4-49d8-838b-8788900401a0.jpg?1",
             "name": "Gruul Signet",
             "text": "{1}, {T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "2e9f4115-343e-5098-bcc6-e8aab9f725ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92efc66e-4112-413b-ae7c-85f270abc4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92efc66e-4112-413b-ae7c-85f270abc4ff.jpg?1",
             "name": "Gruul War Plow",
             "text": "Creatures you control have trample.\n{1}{R}{G}: Gruul War Plow becomes a 4/4 Juggernaut artifact creature until end of turn.",
             "colours": [],
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "a7bb91bf-0cb2-5f41-979a-b61a36452cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f823be95-bef4-4e86-a924-239be62394bf.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -5290,7 +5290,7 @@
         },
         {
             "id": "1d03635b-50b1-597c-9ff9-7d8f4f8c0250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29c3bf9-d37c-4e0a-ac44-15d47770ed44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29c3bf9-d37c-4e0a-ac44-15d47770ed44.jpg?1",
             "name": "Mizzium Transreliquat",
             "text": "{3}: Mizzium Transreliquat becomes a copy of target artifact until end of turn.\n{1}{U}{R}: Mizzium Transreliquat becomes a copy of target artifact and gains this ability.",
             "colours": [],
@@ -5321,7 +5321,7 @@
         },
         {
             "id": "12cad604-0e2b-5f21-bd0c-5de640f1bba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5529edfc-22bd-43dc-878b-6ec9fba74795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5529edfc-22bd-43dc-878b-6ec9fba74795.jpg?1",
             "name": "Moratorium Stone",
             "text": "{2}, {T}: Remove target card in a graveyard from the game.\n{2}{W}{B}, {T}, Sacrifice Moratorium Stone: Remove from the game target nonland card in a graveyard, all other cards in graveyards with the same name as that card, and all permanents with that name.",
             "colours": [],
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "6d5ca155-b8d7-50a2-962b-52cbc4e9dd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9298a1d-5b41-46d8-929c-b6980d1e6eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9298a1d-5b41-46d8-929c-b6980d1e6eb7.jpg?1",
             "name": "Orzhov Signet",
             "text": "{1}, {T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "268c5e8d-3a09-538a-a648-db74d0b93a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2225d05-d85c-4304-8226-b056e7dedad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2225d05-d85c-4304-8226-b056e7dedad7.jpg?1",
             "name": "Sword of the Paruns",
             "text": "As long as equipped creature is tapped, tapped creatures you control get +2/+0.\nAs long as equipped creature is untapped, untapped creatures you control get +0/+2.\n{3}: Tap or untap equipped creature.\nEquip {3}",
             "colours": [],
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "ac4599aa-bdc3-5dca-9c8f-f8a9f81c9886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be010c2f-06db-47e3-80bd-df3f2a21ca34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be010c2f-06db-47e3-80bd-df3f2a21ca34.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B} to your mana pool.)\nAs Godless Shrine comes into play, you may pay 2 life. If you don't, Godless Shrine comes into play tapped instead.",
             "colours": [],
@@ -5447,7 +5447,7 @@
         },
         {
             "id": "1a198921-2aea-5b44-a92f-c406acca41ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550b70e0-ebd5-49de-b62c-5224b8bf8e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550b70e0-ebd5-49de-b62c-5224b8bf8e98.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf comes into play tapped.\nWhen Gruul Turf comes into play, return a land you control to its owner's hand.\n{T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "479f98b4-f3b2-5b85-80e5-9651947343e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666f455e-3a3d-475d-b67a-a1fdd74820eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666f455e-3a3d-475d-b67a-a1fdd74820eb.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks comes into play tapped.\nWhen Izzet Boilerworks comes into play, return a land you control to its owner's hand.\n{T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "2e8ea301-66de-58b0-aeec-7c4cf754c19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ddda-400b-4543-8c31-941e65aa5ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ddda-400b-4543-8c31-941e65aa5ad1.jpg?1",
             "name": "Nivix, Aerie of the Firemind",
             "text": "{T}: Add {1} to your mana pool.\n{2}{U}{R}, {T}: Remove the top card of your library from the game. Until your next turn, you may play that card if it's an instant or sorcery.",
             "colours": [],
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "63559645-0df5-5838-a1a8-194237dc2131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9154d2a-3fc5-4fd6-9885-a810cb6b542a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9154d2a-3fc5-4fd6-9885-a810cb6b542a.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica comes into play tapped.\nWhen Orzhov Basilica comes into play, return a land you control to its owner's hand.\n{T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "2e21b013-68c5-5755-b1b8-281166e5b7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9015cc09-56c9-4d8f-b241-a0cfaec7e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9015cc09-56c9-4d8f-b241-a0cfaec7e1f1.jpg?1",
             "name": "Orzhova, the Church of Deals",
             "text": "{T}: Add {1} to your mana pool.\n{3}{W}{B}, {T}: Target player loses 1 life and you gain 1 life.",
             "colours": [],
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "79e4302b-7c5f-59b1-8036-068a9f539a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342dcdde-e4cc-4a49-a818-9283002aba1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342dcdde-e4cc-4a49-a818-9283002aba1a.jpg?1",
             "name": "Skarrg, the Rage Pits",
             "text": "{T}: Add {1} to your mana pool.\n{R}{G}, {T}: Target creature gets +1/+1 and gains trample until end of turn.",
             "colours": [],
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "bc239abe-8839-5700-bf91-911165678248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f2276-2dd5-43da-bb26-c57c560861fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f2276-2dd5-43da-bb26-c57c560861fe.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R} to your mana pool.)\nAs Steam Vents comes into play, you may pay 2 life. If you don't, Steam Vents comes into play tapped instead.",
             "colours": [],
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "0b0728fd-8d36-539c-9ca2-b24e05d29e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2773d8f-f906-475d-aaff-b7ca3b01f188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2773d8f-f906-475d-aaff-b7ca3b01f188.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G} to your mana pool.)\nAs Stomping Ground comes into play, you may pay 2 life. If you don't, Stomping Ground comes into play tapped instead.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/GRN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/GRN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b443439d-d199-57eb-a6c9-61dc806153c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1c7f07-8d39-425b-8ae9-b3ab317cc0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1c7f07-8d39-425b-8ae9-b3ab317cc0fe.jpg?1",
             "name": "Blade Instructor",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "4a4c6630-b38e-5fb2-ab2c-cef0d0990b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e938121-5917-4b67-9014-74fca106a471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e938121-5917-4b67-9014-74fca106a471.jpg?1",
             "name": "Bounty Agent",
             "text": "Vigilance\n{T}, Sacrifice Bounty Agent: Destroy target legendary permanent that's an artifact, creature, or enchantment.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "27bfda10-73b4-5774-923b-12340e95fdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg?1",
             "name": "Candlelight Vigil",
             "text": "Enchant creature\nEnchanted creature gets +3/+2 and has vigilance.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "9837a5c1-2b49-5257-9771-d47c6b83187e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995200f-1e9d-4ff3-9e04-4a4309e0e09c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995200f-1e9d-4ff3-9e04-4a4309e0e09c.jpg?1",
             "name": "Citywide Bust",
             "text": "Destroy all creatures with toughness 4 or greater.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "fc6a3773-00d7-5a3c-8745-f8b7f1b06f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf305b7-d1f7-4770-9201-8f3fb6735cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf305b7-d1f7-4770-9201-8f3fb6735cd9.jpg?1",
             "name": "Collar the Culprit",
             "text": "Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "234c46d1-3372-5d8e-9958-fdc50a9c4710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9fda5d-df8f-45d6-b8f0-33f903c4bf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9fda5d-df8f-45d6-b8f0-33f903c4bf83.jpg?1",
             "name": "Conclave Tribunal",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Conclave Tribunal enters the battlefield, exile target nonland permanent an opponent controls until Conclave Tribunal leaves the battlefield.",
             "colours": [
@@ -204,7 +204,7 @@
         },
         {
             "id": "07370f86-e870-5092-98cf-6574736618c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg?1",
             "name": "Crush Contraband",
             "text": "Choose one or both \u2014\n\u2022 Exile target artifact.\n\u2022 Exile target enchantment.",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "122a2ad6-3931-54da-85b4-680b1603e8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg?1",
             "name": "Dawn of Hope",
             "text": "Whenever you gain life, you may pay {2}. If you do, draw a card.\n{3}{W}: Create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "b7cc4fc8-9e52-535d-8954-6e23714e1221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69202217-ef36-4d6c-bbd0-ebbb2ade51f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69202217-ef36-4d6c-bbd0-ebbb2ade51f7.jpg?1",
             "name": "Demotion",
             "text": "Enchant creature\nEnchanted creature can't block, and its activated abilities can't be activated.",
             "colours": [
@@ -302,7 +302,7 @@
         },
         {
             "id": "117ae35b-37c3-5b67-ac93-94439d7bafc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3789d4-3621-44a1-bb72-8e3bbac8bf72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3789d4-3621-44a1-bb72-8e3bbac8bf72.jpg?1",
             "name": "Divine Visitation",
             "text": "If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "2694d5ac-ba34-5c4b-9aae-1d8d8f9ca7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg?1",
             "name": "Flight of Equenauts",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "6cdb440c-190c-5333-9838-071a0e96065f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f731df-eb40-44c8-a72d-f377c824584d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f731df-eb40-44c8-a72d-f377c824584d.jpg?1",
             "name": "Gird for Battle",
             "text": "Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -401,7 +401,7 @@
         },
         {
             "id": "cd8d5415-5da4-59ca-9762-4135eee23ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c561d89-b02d-4f1a-b49a-cdf2def3404d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c561d89-b02d-4f1a-b49a-cdf2def3404d.jpg?1",
             "name": "Haazda Marshal",
             "text": "Whenever Haazda Marshal and at least two other creatures attack, create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "4b5e1a85-74f4-5505-a5c4-c5947ca6e3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3313bd5c-b657-47a3-822a-dd0d9165492a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3313bd5c-b657-47a3-822a-dd0d9165492a.jpg?1",
             "name": "Healer's Hawk",
             "text": "Flying, lifelink",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "90cbb8ff-d3a0-5457-a8f5-bcdd821855b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg?1",
             "name": "Hunted Witness",
             "text": "When Hunted Witness dies, create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "66f7bf77-082f-584d-bf7b-c0ddba4d94b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg?1",
             "name": "Inspiring Unicorn",
             "text": "Whenever Inspiring Unicorn attacks, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "daebfbad-5901-55b2-bcd9-ef400e2039b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49266f3c-4b43-4175-8bac-16789ba6f4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49266f3c-4b43-4175-8bac-16789ba6f4b9.jpg?1",
             "name": "Intrusive Packbeast",
             "text": "Vigilance\nWhen Intrusive Packbeast enters the battlefield, tap up to two target creatures your opponents control.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "c229fc96-6500-556a-9304-7076c95c980a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg?1",
             "name": "Ledev Guardian",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "f4d538e8-2c69-5672-a19f-e25e28132ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f1b831-ca55-4575-9dfa-c3163e3d789d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f1b831-ca55-4575-9dfa-c3163e3d789d.jpg?1",
             "name": "Light of the Legion",
             "text": "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhen Light of the Legion dies, put a +1/+1 counter on each white creature you control.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "a878bcd4-1af4-52f9-a948-cbc38fd26f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg?1",
             "name": "Loxodon Restorer",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Loxodon Restorer enters the battlefield, you gain 4 life.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "d09c6056-f6b9-5e0f-9fdd-329c11b92641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d471de4-a7b2-4e13-9492-3fa94f5867ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d471de4-a7b2-4e13-9492-3fa94f5867ac.jpg?1",
             "name": "Luminous Bonds",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "2056295e-f58e-5b53-92f7-dc3b183487a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef126f2-7e72-4338-8021-3ad95e4ab982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef126f2-7e72-4338-8021-3ad95e4ab982.jpg?1",
             "name": "Parhelion Patrol",
             "text": "Flying, vigilance\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "39016dcf-6b46-5937-aa28-b47a165c0714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4501520-acf4-438f-9e96-4a649875ffdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4501520-acf4-438f-9e96-4a649875ffdd.jpg?1",
             "name": "Righteous Blow",
             "text": "Righteous Blow deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "304d0914-a19a-5942-a651-17a96be4625c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg?1",
             "name": "Roc Charger",
             "text": "Flying\nWhenever Roc Charger attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "72d5f528-ac86-561f-b95d-ad0fb51f21b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg?1",
             "name": "Skyline Scout",
             "text": "Whenever Skyline Scout attacks, you may pay {1}{W}. If you do, it gains flying until end of turn.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "07a5db22-4846-5822-8081-de3ff4459953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a431f183-17eb-4a6c-a137-d106bdc8c997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a431f183-17eb-4a6c-a137-d106bdc8c997.jpg?1",
             "name": "Sunhome Stalwart",
             "text": "First strike\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "a632b22d-25f8-5f51-aeb0-b692d90eae09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg?1",
             "name": "Sworn Companions",
             "text": "Create two 1/1 white Soldier creature tokens with lifelink.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "15785dfb-9df8-5931-8560-2ce8243db9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg?1",
             "name": "Take Heart",
             "text": "Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "130923a8-445d-5b08-b245-3e389f6ea8eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg?1",
             "name": "Tenth District Guard",
             "text": "When Tenth District Guard enters the battlefield, target creature gets +0/+1 until end of turn.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "410c0320-3a53-562c-9fe4-21d4f34fcc6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93599fba-7c53-4621-85b5-6434be077bf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93599fba-7c53-4621-85b5-6434be077bf6.jpg?1",
             "name": "Venerated Loxodon",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Venerated Loxodon enters the battlefield, put a +1/+1 counter on each creature that convoked it.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "84737cc7-c6c1-5a62-911b-b8a8a66bfcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a799ac8-5798-4a26-81c1-763d6dcfcbe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a799ac8-5798-4a26-81c1-763d6dcfcbe8.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "1e56cb97-4cf4-55cc-9394-2f723523cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13a295-0d51-4b56-8c58-0896eb41c567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e13a295-0d51-4b56-8c58-0896eb41c567.jpg?1",
             "name": "Chemister's Insight",
             "text": "Draw two cards.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "78d7172e-ca26-5c8a-8f28-cbd83a992595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg?1",
             "name": "Citywatch Sphinx",
             "text": "Flying\nWhen Citywatch Sphinx dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1115,7 +1115,7 @@
         },
         {
             "id": "e97b27b0-a74a-5a80-bd51-67f9b4be0cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d4639a-b634-469e-a848-35e3a3dfd47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d4639a-b634-469e-a848-35e3a3dfd47e.jpg?1",
             "name": "Dazzling Lights",
             "text": "Target creature gets -3/-0 until end of turn.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "a1b25a13-6776-5e45-a64c-0830cbda27d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ac6b0a-b1a5-439d-b65e-5f04e1826c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ac6b0a-b1a5-439d-b65e-5f04e1826c80.jpg?1",
             "name": "Devious Cover-Up",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may shuffle up to four target cards from your graveyard into your library.",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "49506765-08ee-5c91-a7db-1d79a70934d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg?1",
             "name": "Dimir Informant",
             "text": "When Dimir Informant enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "10a83c44-a436-55a1-87d7-a6379596559d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0193dfa3-8409-44be-b4be-6c3cad42d4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0193dfa3-8409-44be-b4be-6c3cad42d4a4.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -1246,7 +1246,7 @@
         },
         {
             "id": "4337133b-b58c-5736-8c9d-59f9068786b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3a4677-7683-4f63-af31-b76491ec9f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3a4677-7683-4f63-af31-b76491ec9f9c.jpg?1",
             "name": "Dream Eater",
             "text": "Flash\nFlying\nWhen Dream Eater enters the battlefield, surveil 4. When you do, you may return target nonland permanent an opponent controls to its owner's hand. (To surveil 4, look at the top four cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "9241fc49-6ac3-533e-ad54-f700baf51975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc98428-7a0f-445f-9d48-eeb76c3e10d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc98428-7a0f-445f-9d48-eeb76c3e10d6.jpg?1",
             "name": "Drowned Secrets",
             "text": "Whenever you cast a blue spell, target player puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "e35ef37f-dfc1-5527-b8ce-c6aeb7e8336e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d254e-da25-494b-a16d-3d7d6bb75c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d254e-da25-494b-a16d-3d7d6bb75c73.jpg?1",
             "name": "Enhanced Surveillance",
             "text": "You may look at an additional two cards each time you surveil.\nExile Enhanced Surveillance: Shuffle your graveyard into your library.",
             "colours": [
@@ -1345,7 +1345,7 @@
         },
         {
             "id": "e8425587-a086-5fa0-94ae-c69e0596d9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d952259f-9e0a-49af-9dfb-3cad1a1bb3a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d952259f-9e0a-49af-9dfb-3cad1a1bb3a8.jpg?1",
             "name": "Guild Summit",
             "text": "When Guild Summit enters the battlefield, you may tap any number of untapped Gates you control. Draw a card for each Gate tapped this way.\nWhenever a Gate enters the battlefield under your control, draw a card.",
             "colours": [
@@ -1377,7 +1377,7 @@
         },
         {
             "id": "1d1aac09-7bf8-589e-90a7-60662a0ae19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e415a03-f7f8-4fca-954a-ef21b4a2c60f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e415a03-f7f8-4fca-954a-ef21b4a2c60f.jpg?1",
             "name": "Leapfrog",
             "text": "Leapfrog has flying as long as you've cast an instant or sorcery spell this turn.",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "2de2e7a9-a3fc-5f70-99dc-a9d5d683972a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5a08a0-b002-4bfe-9cac-d2bf96175f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5a08a0-b002-4bfe-9cac-d2bf96175f8e.jpg?1",
             "name": "Maximize Altitude",
             "text": "Target creature gets +1/+1 and gains flying until end of turn.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "24d08303-ac44-573b-a995-2bedf0c53c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bed34d-67d9-4ae9-b351-dc9a89daeabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bed34d-67d9-4ae9-b351-dc9a89daeabf.jpg?1",
             "name": "Mission Briefing",
             "text": "Surveil 2, then choose an instant or sorcery card in your graveyard. You may cast that card this turn. If that card would be put into your graveyard this turn, exile it instead. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "12584dbf-8696-59d0-b292-3f3ec1910c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc6adff-dcb3-456d-a8c2-0e77b784ff89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc6adff-dcb3-456d-a8c2-0e77b784ff89.jpg?1",
             "name": "Murmuring Mystic",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 blue Bird Illusion creature token with flying.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "2441b91d-a6b7-5d67-a7de-59b5e9b4e83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg?1",
             "name": "Muse Drake",
             "text": "Flying\nWhen Muse Drake enters the battlefield, draw a card.",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "47d73d75-84e8-5f66-9f07-5212e9df3135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e23275-2261-4d6d-88d8-124342334391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e23275-2261-4d6d-88d8-124342334391.jpg?1",
             "name": "Narcomoeba",
             "text": "Flying\nWhen Narcomoeba is put into your graveyard from your library, you may put it onto the battlefield.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "86e83dd9-d2f6-5cff-ad67-eb91c96956cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg?1",
             "name": "Nightveil Sprite",
             "text": "Flying\nWhenever Nightveil Sprite attacks, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "1bc9cf69-5f7a-5bd7-b3b2-7e2a75ae716b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17664df-e8ba-464d-b338-3e671d2d7f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17664df-e8ba-464d-b338-3e671d2d7f0e.jpg?1",
             "name": "Omnispell Adept",
             "text": "{2}{U}, {T}: You may cast an instant or sorcery card from your hand without paying its mana cost.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "375f5605-57bc-5af8-aa4d-df4761da2cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg?1",
             "name": "Passwall Adept",
             "text": "{2}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "946370fe-5ec2-54db-8fcd-9fc2f8d3d489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069646c-fae2-40bd-92bc-35459a84d847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069646c-fae2-40bd-92bc-35459a84d847.jpg?1",
             "name": "Quasiduplicate",
             "text": "Create a token that's a copy of target creature you control.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "d5261330-e2af-50ba-a943-db5b2f77065c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9570734-5e9b-46ff-b606-9759b5195756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9570734-5e9b-46ff-b606-9759b5195756.jpg?1",
             "name": "Radical Idea",
             "text": "Draw a card.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "311277a1-e1c8-5822-83d9-ee96931f3514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adfc0ac-08a9-487a-b01c-5de52fae0312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adfc0ac-08a9-487a-b01c-5de52fae0312.jpg?1",
             "name": "Selective Snare",
             "text": "Return X target creatures of the creature type of your choice to their owner's hand.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "4bef0dbd-8c27-5300-b23b-92c3d83dd397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbef36d-7170-424f-8fb1-8e7e112b7f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbef36d-7170-424f-8fb1-8e7e112b7f0b.jpg?1",
             "name": "Sinister Sabotage",
             "text": "Counter target spell.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -1811,7 +1811,7 @@
         },
         {
             "id": "0cee522e-c125-5d70-a7c4-d64b81e8d1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36478e73-162a-412c-bf5b-9ca0d92f51e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36478e73-162a-412c-bf5b-9ca0d92f51e2.jpg?1",
             "name": "Thoughtbound Phantasm",
             "text": "Defender\nWhenever you surveil, put a +1/+1 counter on Thoughtbound Phantasm.\nAs long as Thoughtbound Phantasm has three or more +1/+1 counters on it, it can attack as though it didn't have defender.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "8ae387f1-1b6a-57f6-a3e1-0179e09f6241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c99b239-50d2-4393-80ec-94dbfaa6ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c99b239-50d2-4393-80ec-94dbfaa6ae70.jpg?1",
             "name": "Unexplained Disappearance",
             "text": "Return target creature to its owner's hand.\nSurveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "5bbf628d-16b3-50c5-a36d-fd6f835488ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg?1",
             "name": "Vedalken Mesmerist",
             "text": "Whenever Vedalken Mesmerist attacks, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1912,7 +1912,7 @@
         },
         {
             "id": "37b5213a-3dea-545f-b0c8-6daf1174666e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a37646-8f7c-40fc-851d-e3fdd205b012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a37646-8f7c-40fc-851d-e3fdd205b012.jpg?1",
             "name": "Wall of Mist",
             "text": "Defender",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "6a3cc459-a9a2-5daa-a067-9d063b00274a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg?1",
             "name": "Watcher in the Mist",
             "text": "Flying\nWhen Watcher in the Mist enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -1980,7 +1980,7 @@
         },
         {
             "id": "6c1db7d1-69ce-5753-8128-625ae18e9818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg?1",
             "name": "Wishcoin Crab",
             "text": "",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "22b0b9f5-f617-5ace-a216-c79659560067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg?1",
             "name": "Barrier of Bones",
             "text": "Defender\nWhen Barrier of Bones enters the battlefield, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "54374096-819e-51f7-a323-784509a6b9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg?1",
             "name": "Bartizan Bats",
             "text": "Flying",
             "colours": [
@@ -2083,7 +2083,7 @@
         },
         {
             "id": "cac07159-ee01-5ef5-bbf1-fffdfab224b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1",
             "name": "Blood Operative",
             "text": "Lifelink\nWhen Blood Operative enters the battlefield, you may exile target card from a graveyard.\nWhenever you surveil, if Blood Operative is in your graveyard, you may pay 3 life. If you do, return Blood Operative to your hand.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "8c734b4a-22b2-55ba-926f-0b5937d21359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7f218-fd2a-4233-8753-065ddc314f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7f218-fd2a-4233-8753-065ddc314f2d.jpg?1",
             "name": "Burglar Rat",
             "text": "When Burglar Rat enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "70b5f6dc-543b-564a-bfd4-021c3a8fa9dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afebf1a5-eb9a-48c6-a26a-55b75408992b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afebf1a5-eb9a-48c6-a26a-55b75408992b.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "3040ba5c-13fd-5da5-9fcf-a4c363f9ae8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5456173-7a08-4b5c-8450-7123375f4a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5456173-7a08-4b5c-8450-7123375f4a86.jpg?1",
             "name": "Creeping Chill",
             "text": "Creeping Chill deals 3 damage to each opponent and you gain 3 life.\nWhen Creeping Chill is put into your graveyard from your library, you may exile it. If you do, Creeping Chill deals 3 damage to each opponent and you gain 3 life.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "43b41a9c-56c7-5aa9-80bf-dc90211351ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a81554-50d4-4fe0-bf0d-5304f215d19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a81554-50d4-4fe0-bf0d-5304f215d19e.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "b86144cd-5e45-5038-90d0-c4e97dcdab20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462fe190-5264-42d8-bd27-23c5aa0c641f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/462fe190-5264-42d8-bd27-23c5aa0c641f.jpg?1",
             "name": "Deadly Visit",
             "text": "Destroy target creature.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "68d37fc0-33e3-56ce-a96d-eacef2cc9139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg?1",
             "name": "Doom Whisperer",
             "text": "Flying, trample\nPay 2 life: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "f25e3d41-1524-5630-81a2-471af099c10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg?1",
             "name": "Douser of Lights",
             "text": "",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "58fe4998-d335-5261-931e-5071e3fa8531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0e4d9-bf0d-4e28-a647-9010701a915e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c0e4d9-bf0d-4e28-a647-9010701a915e.jpg?1",
             "name": "Gruesome Menagerie",
             "text": "Choose a creature card with converted mana cost 1 in your graveyard, then do the same for creature cards with converted mana costs 2 and 3. Return those cards to the battlefield.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "a6547ae0-9355-57e6-8b31-f591bf0a3f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg?1",
             "name": "Hired Poisoner",
             "text": "Deathtouch",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "26c2e7f4-b1d4-5f41-ac63-143b51508d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg?1",
             "name": "Kraul Swarm",
             "text": "Flying\n{2}{B}, Discard a creature card: Return Kraul Swarm from your graveyard to your hand.",
             "colours": [
@@ -2455,7 +2455,7 @@
         },
         {
             "id": "6f74cac8-fae8-53f5-b751-70a8c6c0e51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dc38b7-52f7-4394-b095-5442429ab291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dc38b7-52f7-4394-b095-5442429ab291.jpg?1",
             "name": "Lotleth Giant",
             "text": "Undergrowth \u2014 When Lotleth Giant enters the battlefield, it deals 1 damage to target opponent for each creature card in your graveyard.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "e10acf77-9e94-5b81-b413-0161d23438d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7cf38-78cc-4139-9f2a-4dd0be7d9da8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7cf38-78cc-4139-9f2a-4dd0be7d9da8.jpg?1",
             "name": "Mausoleum Secrets",
             "text": "Undergrowth \u2014 Search your library for a black card with converted mana cost less than or equal to the number of creature cards in your graveyard, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "b5f4dd37-3c87-51b4-af9e-09294aba0093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675640ba-37e7-4231-8524-87e8b87ea46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675640ba-37e7-4231-8524-87e8b87ea46f.jpg?1",
             "name": "Mephitic Vapors",
             "text": "All creatures get -1/-1 until end of turn.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "4b860dee-1cf9-5ed8-8a66-202b1574ead3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e122fe0-51c5-404d-a7b9-3d161a426c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e122fe0-51c5-404d-a7b9-3d161a426c35.jpg?1",
             "name": "Midnight Reaper",
             "text": "Whenever a nontoken creature you control dies, Midnight Reaper deals 1 damage to you and you draw a card.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "32e00b22-6a82-54c0-b1c5-30f69fc77c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82903e5f-c10f-4767-a2c0-6f8cc7280fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82903e5f-c10f-4767-a2c0-6f8cc7280fa0.jpg?1",
             "name": "Moodmark Painter",
             "text": "Undergrowth \u2014 When Moodmark Painter enters the battlefield, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "706d72ba-d6d7-5d8f-a01f-ebd6d130f1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab636af-5b30-4138-8e68-81f567f10417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab636af-5b30-4138-8e68-81f567f10417.jpg?1",
             "name": "Necrotic Wound",
             "text": "Undergrowth \u2014 Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "8fc41761-87dd-5a38-9f54-27b087797691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d3746-9e54-4983-9daa-f1a7afbdedad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289d3746-9e54-4983-9daa-f1a7afbdedad.jpg?1",
             "name": "Never Happened",
             "text": "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "5cfd67f3-2e14-53b9-b759-18aa881b4a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646dedff-150c-4ed2-8f2e-3b2e6ba5521a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646dedff-150c-4ed2-8f2e-3b2e6ba5521a.jpg?1",
             "name": "Pilfering Imp",
             "text": "Flying\n{1}{B}, {T}, Sacrifice Pilfering Imp: Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "3ee49282-9abf-55fa-a978-a7d1e1dfece3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8682fb87-df14-4277-aaa0-0d53d766c406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8682fb87-df14-4277-aaa0-0d53d766c406.jpg?1",
             "name": "Plaguecrafter",
             "text": "When Plaguecrafter enters the battlefield, each player sacrifices a creature or planeswalker. Each player who can't discards a card.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "eb9a092f-6db5-5da9-ab00-0a6ff077dd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b52152-0f7c-4466-9e49-033477028f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b52152-0f7c-4466-9e49-033477028f67.jpg?1",
             "name": "Price of Fame",
             "text": "This spell costs {2} less to cast if it targets a legendary creature.\nDestroy target creature.\nSurveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "5a717aec-3977-5bc7-b766-6c42dc386efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg?1",
             "name": "Ritual of Soot",
             "text": "Destroy all creatures with converted mana cost 3 or less.",
             "colours": [
@@ -2821,7 +2821,7 @@
         },
         {
             "id": "4d4e338d-493a-5b5a-86c6-3d0f077ad6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce654d6-fcf1-40a8-8bdb-5c37e561f7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce654d6-fcf1-40a8-8bdb-5c37e561f7dc.jpg?1",
             "name": "Severed Strands",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nYou gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "3c41bd01-7bd6-53d2-bd48-41ef47dc1cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg?1",
             "name": "Spinal Centipede",
             "text": "When Spinal Centipede dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "2249f36a-f49d-52da-940d-2448cfdb4bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2571d168-38d4-46d7-afae-ffbd12bd2313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2571d168-38d4-46d7-afae-ffbd12bd2313.jpg?1",
             "name": "Undercity Necrolisk",
             "text": "{1}, Sacrifice another creature: Put a +1/+1 counter on Undercity Necrolisk. It gains menace until end of turn. Activate this ability only any time you could cast a sorcery. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2922,7 +2922,7 @@
         },
         {
             "id": "4d66eafc-abed-53fa-8eb1-5d5967fbadc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg?1",
             "name": "Veiled Shade",
             "text": "{1}{B}: Veiled Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "9854701d-6337-54ab-a666-db111af92e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1939952-608e-4786-beeb-a6ff0fa36624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1939952-608e-4786-beeb-a6ff0fa36624.jpg?1",
             "name": "Vicious Rumors",
             "text": "Vicious Rumors deals 1 damage to each opponent. Each opponent discards a card, then puts the top card of their library into their graveyard. You gain 1 life.",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "d7651c82-2c00-5a74-ae5c-f28272e92032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ca97e-b402-4a73-9c70-79ec4565a39c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4ca97e-b402-4a73-9c70-79ec4565a39c.jpg?1",
             "name": "Whispering Snitch",
             "text": "Whenever you surveil for the first time each turn, Whispering Snitch deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -3023,7 +3023,7 @@
         },
         {
             "id": "864c94a7-a6d7-5055-bb8f-8709f90cfabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787de9ce-02c5-4a17-a88b-d38e83dbeb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787de9ce-02c5-4a17-a88b-d38e83dbeb0b.jpg?1",
             "name": "Arclight Phoenix",
             "text": "Flying, haste\nAt the beginning of combat on your turn, if you've cast three or more instant and sorcery spells this turn, return Arclight Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "d471e741-3508-5537-acd5-69905c03f8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a54ebc-008a-4180-a023-2e1d5318780c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a54ebc-008a-4180-a023-2e1d5318780c.jpg?1",
             "name": "Barging Sergeant",
             "text": "Haste\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "e742635f-49c7-5192-bfe7-12984ff1bad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dfe640-5bd2-4d0b-8977-887b2ed4c2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01dfe640-5bd2-4d0b-8977-887b2ed4c2dd.jpg?1",
             "name": "Book Devourer",
             "text": "Trample\nWhenever Book Devourer deals combat damage to a player, you may discard all the cards in your hand. If you do, draw that many cards.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "f9a6540d-1614-56ae-83f7-6518e3364b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg?1",
             "name": "Command the Storm",
             "text": "Command the Storm deals 5 damage to target creature.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "9f1bdcc2-02bf-55ee-9e7a-734d111dab93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c5bafa-8cd8-4158-98e0-46dc74c027c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c5bafa-8cd8-4158-98e0-46dc74c027c0.jpg?1",
             "name": "Cosmotronic Wave",
             "text": "Cosmotronic Wave deals 1 damage to each creature your opponents control. Creatures your opponents control can't block this turn.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "ec48568e-d830-5226-b2e5-115b94253659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166b0d75-824c-4c04-833b-7f7c69569a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166b0d75-824c-4c04-833b-7f7c69569a18.jpg?1",
             "name": "Direct Current",
             "text": "Direct Current deals 2 damage to any target.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "2735998c-9a71-5fd2-b8ea-b34b7cd70e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg?1",
             "name": "Electrostatic Field",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, Electrostatic Field deals 1 damage to each opponent.",
             "colours": [
@@ -3256,7 +3256,7 @@
         },
         {
             "id": "5a9ca116-5b28-503d-ab61-5656d8f50990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c310df89-d894-40ab-ae34-7d0bfd19a1af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c310df89-d894-40ab-ae34-7d0bfd19a1af.jpg?1",
             "name": "Erratic Cyclops",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, Erratic Cyclops gets +X/+0 until end of turn, where X is that spell's converted mana cost.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "98ae591f-44f7-58cc-a1cc-dd63da1ca671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8f32e2-5dc8-4f1b-8a69-d3ae06378ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8f32e2-5dc8-4f1b-8a69-d3ae06378ed8.jpg?1",
             "name": "Experimental Frenzy",
             "text": "You may look at the top card of your library any time.\nYou may play the top card of your library.\nYou can't play cards from your hand.\n{3}{R}: Destroy Experimental Frenzy.",
             "colours": [
@@ -3323,7 +3323,7 @@
         },
         {
             "id": "6cec0914-a17e-5835-8e3a-e7b57f6a2550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg?1",
             "name": "Fearless Halberdier",
             "text": "",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "d76567b1-5de1-56a5-9bf4-26e75adb14aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg?1",
             "name": "Fire Urchin",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, Fire Urchin gets +1/+0 until end of turn.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "4e8608b1-a0c4-5655-9283-f114eda815d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b3b56c-5236-4319-b17e-5f71143a7906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b3b56c-5236-4319-b17e-5f71143a7906.jpg?1",
             "name": "Goblin Banneret",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\n{1}{R}: Goblin Banneret gets +2/+0 until end of turn.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "9e31b423-8a4d-59b8-8196-aea1263da4a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaedc-08f1-4de7-aae8-056df57940e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecaedc-08f1-4de7-aae8-056df57940e0.jpg?1",
             "name": "Goblin Cratermaker",
             "text": "{1}, Sacrifice Goblin Cratermaker: Choose one \u2014\n\u2022 Goblin Cratermaker deals 2 damage to target creature.\n\u2022 Destroy target colorless nonland permanent.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "4db4ecec-4ae1-5323-b9b0-b6234987a02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2bed0a-990a-499a-af0a-52b77557d7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2bed0a-990a-499a-af0a-52b77557d7cb.jpg?1",
             "name": "Goblin Locksmith",
             "text": "Whenever Goblin Locksmith attacks, creatures with defender can't block this turn.",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "90819996-d612-5d27-b8e3-43ffee7a3e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05fe0428-6e7d-49d4-9a29-80a3589f565a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05fe0428-6e7d-49d4-9a29-80a3589f565a.jpg?1",
             "name": "Gravitic Punch",
             "text": "Target creature you control deals damage equal to its power to target player.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "573d9cfa-c531-56de-a0f1-bafcac074eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e902e8-bbd5-40fe-a655-45d3d3bc9fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e902e8-bbd5-40fe-a655-45d3d3bc9fde.jpg?1",
             "name": "Hellkite Whelp",
             "text": "Flying\nWhenever Hellkite Whelp attacks, it deals 1 damage to target creature defending player controls.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "cacf7fb2-e347-53cb-a646-0a8dfab3815e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg?1",
             "name": "Inescapable Blaze",
             "text": "This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "5a1e6511-67ab-5f6d-b133-0e14b470d092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6135cf4-50c2-4e44-b9b0-96e1187a2200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6135cf4-50c2-4e44-b9b0-96e1187a2200.jpg?1",
             "name": "Lava Coil",
             "text": "Lava Coil deals 4 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "f79181bb-060c-5b46-a651-c4950e641bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e84cb9c-9876-47a4-aea4-78574321bc36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e84cb9c-9876-47a4-aea4-78574321bc36.jpg?1",
             "name": "Legion Warboss",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token gains haste until end of turn and attacks this combat if able.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "0ef31c23-2190-551a-86c9-9f52e5c85c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882f8dcf-b361-4dc9-8329-e7d1f807acd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882f8dcf-b361-4dc9-8329-e7d1f807acd6.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "95917fd5-187c-5ea1-9f89-aed0c4490b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7a2aa-f002-4f05-b9ec-8adee4c65e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7a2aa-f002-4f05-b9ec-8adee4c65e46.jpg?1",
             "name": "Maximize Velocity",
             "text": "Target creature gets +1/+1 and gains haste until end of turn.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "ae683c2e-1a66-5b24-a631-07df1cd937b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c1353-b315-4a0e-80b5-0d9a2962e35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1c1353-b315-4a0e-80b5-0d9a2962e35f.jpg?1",
             "name": "Ornery Goblin",
             "text": "Whenever Ornery Goblin blocks or becomes blocked by a creature, Ornery Goblin deals 1 damage to that creature.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "e1bcac1d-a3cb-5876-a7b1-680c1ab789df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eda89d9-9bd1-4a55-ac02-f9a0625d8e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eda89d9-9bd1-4a55-ac02-f9a0625d8e5b.jpg?1",
             "name": "Risk Factor",
             "text": "Target opponent may have Risk Factor deal 4 damage to them. If that player doesn't, you draw three cards.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "017dcfc0-f2d7-546d-9527-8e91e8116e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg?1",
             "name": "Rubblebelt Boar",
             "text": "When Rubblebelt Boar enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "7793b045-4181-5fd4-a2de-be262150524f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c9c111-fbc7-44e1-94bd-1ca164370623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c9c111-fbc7-44e1-94bd-1ca164370623.jpg?1",
             "name": "Runaway Steam-Kin",
             "text": "Whenever you cast a red spell, if Runaway Steam-Kin has fewer than three +1/+1 counters on it, put a +1/+1 counter on Runaway Steam-Kin.\nRemove three +1/+1 counters from Runaway Steam-Kin: Add {R}{R}{R}.",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "f1ad73c0-6b88-57ce-acd8-d88f2357a6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg?1",
             "name": "Smelt-Ward Minotaur",
             "text": "Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "6b8719e6-62b6-5a68-949d-8ddb86df31f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b352d5-4a57-41bc-b4c4-8b81255a9db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b352d5-4a57-41bc-b4c4-8b81255a9db8.jpg?1",
             "name": "Street Riot",
             "text": "As long as it's your turn, creatures you control get +1/+0 and have trample.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "8e7b3bde-1aea-5135-aa81-c177c8694ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d01f1ce-9931-4712-a907-72c2c6d5ee76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d01f1ce-9931-4712-a907-72c2c6d5ee76.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "c89e6d0c-52b6-5838-817b-e58052c8e341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c9fc8c-e68f-4636-84b8-877f6ec04b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c9fc8c-e68f-4636-84b8-877f6ec04b09.jpg?1",
             "name": "Torch Courier",
             "text": "Haste\nSacrifice Torch Courier: Another target creature gains haste until end of turn.",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "449c654d-fa7c-5f6b-b701-b8f2d7addb76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebff5313-e325-47c3-814b-38fdb4c6c8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebff5313-e325-47c3-814b-38fdb4c6c8d2.jpg?1",
             "name": "Wojek Bodyguard",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWojek Bodyguard can't attack or block alone.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "e9e6f91a-126d-5ed3-83e2-1322950bf7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8ddc1-d95c-499f-b1d1-f608f8f07b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8ddc1-d95c-499f-b1d1-f608f8f07b02.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4065,7 +4065,7 @@
         },
         {
             "id": "f87bf8a4-74cb-5fd8-9aab-c3a05a870ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg?1",
             "name": "Arboretum Elemental",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "fe3f82f5-33b4-527a-9f68-cbe829e0e6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg?1",
             "name": "Beast Whisperer",
             "text": "Whenever you cast a creature spell, draw a card.",
             "colours": [
@@ -4134,7 +4134,7 @@
         },
         {
             "id": "e60b5355-1652-50ee-934e-2da578d92d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a950d8-e6e2-42d6-83d7-a60c15d2035d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a950d8-e6e2-42d6-83d7-a60c15d2035d.jpg?1",
             "name": "Bounty of Might",
             "text": "Target creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "b1affcc5-4e71-5143-aea6-d65e4f9881bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a970429-6369-4422-a343-00b30267f09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a970429-6369-4422-a343-00b30267f09d.jpg?1",
             "name": "Circuitous Route",
             "text": "Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "7ee20e10-de9e-5360-87a4-52ebf5520047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c4f213-0ea4-44c0-8429-172a317b77f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c4f213-0ea4-44c0-8429-172a317b77f5.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "91466c81-42e4-5362-88da-4e61e217b55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg?1",
             "name": "Devkarin Dissident",
             "text": "{4}{G}: Devkarin Dissident gets +2/+2 until end of turn.",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "49da04ef-411e-551d-aa49-859946b398f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150deec-3287-40ef-9b9c-c22bf5d70b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150deec-3287-40ef-9b9c-c22bf5d70b02.jpg?1",
             "name": "District Guide",
             "text": "When District Guide enters the battlefield, you may search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4300,7 +4300,7 @@
         },
         {
             "id": "00afc5b6-4169-5049-8486-bb7e65d5154c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg?1",
             "name": "Generous Stray",
             "text": "When Generous Stray enters the battlefield, draw a card.",
             "colours": [
@@ -4334,7 +4334,7 @@
         },
         {
             "id": "39f82ac4-e3c2-5713-8b6c-061259d7f650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37284ba8-441c-4cf6-95c6-6a0f52e6d36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37284ba8-441c-4cf6-95c6-6a0f52e6d36d.jpg?1",
             "name": "Golgari Raiders",
             "text": "Haste\nUndergrowth \u2014 Golgari Raiders enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "d9abff7a-6dab-5649-9182-ea4baf79e78c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg?1",
             "name": "Grappling Sundew",
             "text": "Defender, reach\n{4}{G}: Grappling Sundew gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy this creature.)",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "97f4712f-3d04-580c-9899-eeb6aacf89fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b841904-202c-4b42-869a-e345112ab1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b841904-202c-4b42-869a-e345112ab1c8.jpg?1",
             "name": "Hatchery Spider",
             "text": "Reach\nUndergrowth \u2014 When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with converted mana cost X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "a063bbc9-da81-53b9-a9a6-c337fa3f9bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe349432-8726-49cf-ad07-6f8add8f78c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe349432-8726-49cf-ad07-6f8add8f78c8.jpg?1",
             "name": "Hitchclaw Recluse",
             "text": "Reach",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "7f54e17b-41af-5f71-bc56-4322abeae495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f8b6b0-f858-41d5-9839-fd1247b9477f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f8b6b0-f858-41d5-9839-fd1247b9477f.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "5af631e1-7c82-524d-acce-41ea641b69f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ed4b08-8583-4ad4-b0ba-0463d367efc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ed4b08-8583-4ad4-b0ba-0463d367efc8.jpg?1",
             "name": "Kraul Foragers",
             "text": "Undergrowth \u2014 When Kraul Foragers enters the battlefield, you gain 1 life for each creature card in your graveyard.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "b14e38b7-5cd9-521c-8f3e-8c1b0a685b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d3c086-9ce4-41c3-8402-2818f1b27192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d3c086-9ce4-41c3-8402-2818f1b27192.jpg?1",
             "name": "Kraul Harpooner",
             "text": "Reach\nUndergrowth \u2014 When Kraul Harpooner enters the battlefield, choose up to one target creature with flying you don't control. Kraul Harpooner gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have Kraul Harpooner fight that creature.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "efaabd70-37be-5705-87b4-fd2f40ae9661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d9ef7-0b16-4095-9c70-f6776e4cd3cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6d9ef7-0b16-4095-9c70-f6776e4cd3cb.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "ac0d34ed-7e9e-53b4-a995-69dd1e0ebd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c30bb0-06ba-432b-a20c-6fa79b0dc68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c30bb0-06ba-432b-a20c-6fa79b0dc68a.jpg?1",
             "name": "Nullhide Ferox",
             "text": "Hexproof\nYou can't cast noncreature spells.\n{2}: Nullhide Ferox loses all abilities until end of turn. Any player may activate this ability.\nIf a spell or ability an opponent controls causes you to discard Nullhide Ferox, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "518dd289-0af5-5ff5-b8d7-1dd00217f275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg?1",
             "name": "Pack's Favor",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "2feaaa54-4d66-5439-8ae7-7e87dfd244bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg?1",
             "name": "Pause for Reflection",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPrevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "ae9aea70-f636-58b5-8dac-5cc88dc2f55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee125cb-12b9-4f78-8e1d-6018d9c52275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee125cb-12b9-4f78-8e1d-6018d9c52275.jpg?1",
             "name": "Pelt Collector",
             "text": "Whenever another creature you control enters the battlefield or dies, if that creature's power is greater than Pelt Collector's, put a +1/+1 counter on Pelt Collector.\nAs long as Pelt Collector has three or more +1/+1 counters on it, it has trample.",
             "colours": [
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "acb4a681-f10b-5ea4-b6d0-c6c39e5a4379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg?1",
             "name": "Portcullis Vine",
             "text": "Defender\n{2}, {T}, Sacrifice a creature with defender: Draw a card.",
             "colours": [
@@ -4775,7 +4775,7 @@
         },
         {
             "id": "73741041-b0df-5e2f-abc0-e2e3b9c93325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16979827-4011-454a-9886-18326cfa3e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16979827-4011-454a-9886-18326cfa3e77.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "1d7e3d5c-8ed5-525a-8344-498ea373a6ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1dfd96-8e17-4ba8-b786-a5cc0ae2ff2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1dfd96-8e17-4ba8-b786-a5cc0ae2ff2d.jpg?1",
             "name": "Siege Wurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "d5b6d782-5eb5-590f-b583-997da474ae53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668232ab-5e58-49f3-804a-c938252ff177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668232ab-5e58-49f3-804a-c938252ff177.jpg?1",
             "name": "Sprouting Renewal",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one \u2014\n\u2022 Create a 2/2 green and white Elf Knight creature token with vigilance.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "cb2ae5f2-52ba-5da6-b311-3ad5cee26b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d7ab0e-db37-4051-86dd-3ab09c047a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d7ab0e-db37-4051-86dd-3ab09c047a2b.jpg?1",
             "name": "Urban Utopia",
             "text": "Enchant land\nWhen Urban Utopia enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "315acfe0-7346-53ed-8421-99a1140d1597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62625de-3a2f-43d6-8cf7-ea38f038f3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62625de-3a2f-43d6-8cf7-ea38f038f3b6.jpg?1",
             "name": "Vigorspore Wurm",
             "text": "Undergrowth \u2014 When Vigorspore Wurm enters the battlefield, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.\nVigorspore Wurm can't be blocked by more than one creature.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "f136c090-cd0c-5527-99cb-d378e598203b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e67fcfd-0e9e-4b88-8c65-2125fac10a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e67fcfd-0e9e-4b88-8c65-2125fac10a3d.jpg?1",
             "name": "Vivid Revival",
             "text": "Return up to three target multicolored cards from your graveyard to your hand. Exile Vivid Revival.",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "fdd073ee-44d1-5ba6-943f-8e87a437a0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg?1",
             "name": "Wary Okapi",
             "text": "Vigilance",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "ebbe9eb9-26f0-52b9-a02d-2ea455d5c402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg?1",
             "name": "Wild Ceratok",
             "text": "",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "11b108a1-e4d3-56b3-beb1-fb9a1b3a964e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg?1",
             "name": "Artful Takedown",
             "text": "Choose one or both \u2014\n\u2022 Tap target creature.\n\u2022 Target creature gets -2/-4 until end of turn.",
             "colours": [
@@ -5075,7 +5075,7 @@
         },
         {
             "id": "159d16f2-4a84-57e3-9e87-12f036e84e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle their library.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "62cbbd6e-0b9f-5d86-bd36-541e9a60bc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9f4d2-bba5-4061-8ae7-a68b912f2c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9f4d2-bba5-4061-8ae7-a68b912f2c11.jpg?1",
             "name": "Aurelia, Exemplar of Justice",
             "text": "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nAt the beginning of combat on your turn, choose up to one target creature you control. Until end of turn, that creature gets +2/+0, gains trample if it's red, and gains vigilance if it's white.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "83db81aa-2e76-5609-bad2-a0adf5427274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c9e4b5-364b-4c0b-bb47-266563a6abf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c9e4b5-364b-4c0b-bb47-266563a6abf2.jpg?1",
             "name": "Beacon Bolt",
             "text": "Beacon Bolt deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "c84ce67b-ddc7-59e1-83e8-a9124060b584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1801f2-ea6e-4196-858e-2afc456cf6a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1801f2-ea6e-4196-858e-2afc456cf6a0.jpg?1",
             "name": "Beamsplitter Mage",
             "text": "Whenever you cast an instant or sorcery spell that targets only Beamsplitter Mage, if you control one or more other creatures that spell could target, choose one of those creatures. Copy that spell. The copy targets the chosen creature.",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "89b88e85-91dc-56d9-8694-68f27c9c331e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545f3a30-7984-4046-8a14-51bc9cbc3fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545f3a30-7984-4046-8a14-51bc9cbc3fe0.jpg?1",
             "name": "Boros Challenger",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\n{2}{R}{W}: Boros Challenger gets +1/+1 until end of turn.",
             "colours": [
@@ -5255,7 +5255,7 @@
         },
         {
             "id": "101c3036-0587-5078-95c8-5c6a9ea1a758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890a2fa9-1141-4a4c-85af-05723aba5e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890a2fa9-1141-4a4c-85af-05723aba5e39.jpg?1",
             "name": "Camaraderie",
             "text": "You gain X life and draw X cards, where X is the number of creatures you control. Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "86d5b24e-49fc-5a4d-9dd6-9e0c1465e900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e630e9b-7817-4255-9de1-795b2a788d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e630e9b-7817-4255-9de1-795b2a788d80.jpg?1",
             "name": "Centaur Peacemaker",
             "text": "When Centaur Peacemaker enters the battlefield, each player gains 4 life.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "3c700851-c1b3-5fbc-ba9a-171dd8b1a34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edf6f9-b863-41e2-bb51-857ea2798090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85edf6f9-b863-41e2-bb51-857ea2798090.jpg?1",
             "name": "Chance for Glory",
             "text": "Creatures you control gain indestructible. Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
             "colours": [
@@ -5360,7 +5360,7 @@
         },
         {
             "id": "afdc0573-5bc9-59aa-a036-6243fb8627bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fec229-e22c-4655-8640-02d0ec472be0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fec229-e22c-4655-8640-02d0ec472be0.jpg?1",
             "name": "Charnel Troll",
             "text": "Trample\nAt the beginning of your upkeep, exile a creature card from your graveyard. If you do, put a +1/+1 counter on Charnel Troll. Otherwise, sacrifice it.\n{B}{G}, Discard a creature card: Put a +1/+1 counter on Charnel Troll.",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "4a5aae8c-8528-5fbb-b337-053654804214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b658a309-d14c-4e20-8c76-e7b3c5156bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b658a309-d14c-4e20-8c76-e7b3c5156bf2.jpg?1",
             "name": "Conclave Cavalier",
             "text": "Vigilance\nWhen Conclave Cavalier dies, create two 2/2 green and white Elf Knight creature tokens with vigilance.",
             "colours": [
@@ -5433,7 +5433,7 @@
         },
         {
             "id": "deea540c-a88d-5b4d-8f18-d97e7b7fb019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279e551d-3ac3-48d5-9822-1d05159c8905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279e551d-3ac3-48d5-9822-1d05159c8905.jpg?1",
             "name": "Conclave Guildmage",
             "text": "{G}, {T}: Creatures you control gain trample until end of turn.\n{5}{W}, {T}: Create a 2/2 green and white Elf Knight creature token with vigilance.",
             "colours": [
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "085c5343-6060-5d4e-a967-3b40e64246f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00fa3a7-e3e2-4b23-a126-a076e75b5dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00fa3a7-e3e2-4b23-a126-a076e75b5dbd.jpg?1",
             "name": "Crackling Drake",
             "text": "Flying\nCrackling Drake's power is equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\nWhen Crackling Drake enters the battlefield, draw a card.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "55c72075-a0af-5396-a11f-fd314c11e360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b610c5-61e5-43df-a87b-3eaaa915402b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b610c5-61e5-43df-a87b-3eaaa915402b.jpg?1",
             "name": "Darkblade Agent",
             "text": "As long as you've surveilled this turn, Darkblade Agent has deathtouch and \"Whenever this creature deals combat damage to a player, you draw a card.\"",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "1f51d832-5077-5d7c-b65b-5a598e789df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg?1",
             "name": "Deafening Clarion",
             "text": "Choose one or both \u2014\n\u2022 Deafening Clarion deals 3 damage to each creature.\n\u2022 Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "07323ff9-0d38-5e8f-9a48-57370dcd091b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c18c450-0bfb-4ba6-9212-b5833fce63a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c18c450-0bfb-4ba6-9212-b5833fce63a2.jpg?1",
             "name": "Dimir Spybug",
             "text": "Flying\nMenace (This creature can't be blocked except by two or more creatures.)\nWhenever you surveil, put a +1/+1 counter on Dimir Spybug.",
             "colours": [
@@ -5613,7 +5613,7 @@
         },
         {
             "id": "a3951b3f-cc88-5b3d-bdb1-36d75d9cd1b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a79ff3-58ed-4cc2-9ebc-0edbb86cd6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a79ff3-58ed-4cc2-9ebc-0edbb86cd6fb.jpg?1",
             "name": "Disinformation Campaign",
             "text": "When Disinformation Campaign enters the battlefield, you draw a card and each opponent discards a card.\nWhenever you surveil, return Disinformation Campaign to its owner's hand.",
             "colours": [
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "41e731d9-eaf6-5c30-84df-2c30ebb15312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b930ee-e16b-4612-87de-c03ecc6ff6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b930ee-e16b-4612-87de-c03ecc6ff6db.jpg?1",
             "name": "Emmara, Soul of the Accord",
             "text": "Whenever Emmara, Soul of the Accord becomes tapped, create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "cc9c728b-331c-5d0d-b283-e4ec7e267766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg?1",
             "name": "Erstwhile Trooper",
             "text": "Discard a creature card: Erstwhile Trooper gets +2/+2 and gains trample until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "d42b3e98-9383-53be-b968-57cd0b4a0e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa36b142-e67e-49da-9080-c5994e275266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa36b142-e67e-49da-9080-c5994e275266.jpg?1",
             "name": "Etrata, the Silencer",
             "text": "Etrata, the Silencer can't be blocked.\nWhenever Etrata deals combat damage to a player, exile target creature that player controls and put a hit counter on that card. That player loses the game if they own three or more exiled cards with hit counters on them. Etrata's owner shuffles Etrata into their library.",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "36f9e604-5239-5094-8e5f-df2f0e688313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc926b2-1e54-4c62-8b6c-fce4ef013abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc926b2-1e54-4c62-8b6c-fce4ef013abc.jpg?1",
             "name": "Firemind's Research",
             "text": "Whenever you cast an instant or sorcery spell, put a charge counter on Firemind's Research.\n{1}{U}, Remove two charge counters from Firemind's Research: Draw a card.\n{1}{R}, Remove five charge counters from Firemind's Research: It deals 5 damage to any target.",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "134ffdc6-a6e8-5553-b710-4fe3b7281fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd957a1-a354-48e9-80ad-66e49aa845fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd957a1-a354-48e9-80ad-66e49aa845fc.jpg?1",
             "name": "Garrison Sergeant",
             "text": "Garrison Sergeant has double strike as long as you control a Gate.",
             "colours": [
@@ -5833,7 +5833,7 @@
         },
         {
             "id": "9a818048-a017-5b0d-bd47-76b3a61d51ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fe260a-d204-4e75-b3e5-0cd9b4ca7084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fe260a-d204-4e75-b3e5-0cd9b4ca7084.jpg?1",
             "name": "Glowspore Shaman",
             "text": "When Glowspore Shaman enters the battlefield, put the top three cards of your library into your graveyard. You may put a land card from your graveyard on top of your library.",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "7130e8b8-b5d5-5a91-9c36-afd3c68bf048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae987da-e4b5-4b82-843c-6aaa87262fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae987da-e4b5-4b82-843c-6aaa87262fc8.jpg?1",
             "name": "Goblin Electromancer",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "ce380ce9-e8da-5310-a8aa-5203d55d43b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg?1",
             "name": "Golgari Findbroker",
             "text": "When Golgari Findbroker enters the battlefield, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "6509858f-5a80-5498-9143-06c33630914a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efac789-587b-45c1-b16e-616e9486b59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efac789-587b-45c1-b16e-616e9486b59b.jpg?1",
             "name": "Hammer Dropper",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)",
             "colours": [
@@ -5981,7 +5981,7 @@
         },
         {
             "id": "1b8b0b2c-6f59-5658-97e7-ade12c57cff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ee7bc8-d5cf-47b1-93c2-7e1d5f536c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ee7bc8-d5cf-47b1-93c2-7e1d5f536c85.jpg?1",
             "name": "House Guildmage",
             "text": "{1}{U}, {T}: Target creature doesn't untap during its controller's next untap step.\n{2}{B}, {T}: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "4d35f9d3-a4a5-579b-8524-6cccefbfd520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5690329-feb8-49c0-8f59-ee13782e8d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5690329-feb8-49c0-8f59-ee13782e8d3b.jpg?1",
             "name": "Hypothesizzle",
             "text": "Draw two cards. Then you may discard a nonland card. When you do, Hypothesizzle deals 4 damage to target creature.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "760d8369-2e5d-5c20-a1a0-3a18d42612a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f161f7d2-eaa1-4931-93f9-befa8b5df821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f161f7d2-eaa1-4931-93f9-befa8b5df821.jpg?1",
             "name": "Ionize",
             "text": "Counter target spell. Ionize deals 2 damage to that spell's controller.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "cbc55a76-9235-5e23-98c7-7b916a649903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75955b0e-12d6-40ba-aab5-b7b7e2bde121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75955b0e-12d6-40ba-aab5-b7b7e2bde121.jpg?1",
             "name": "Izoni, Thousand-Eyed",
             "text": "Undergrowth \u2014 When Izoni, Thousand-Eyed enters the battlefield, create a 1/1 black and green Insect creature token for each creature card in your graveyard.\n{B}{G}, Sacrifice another creature: You gain 1 life and draw a card.",
             "colours": [
@@ -6125,7 +6125,7 @@
         },
         {
             "id": "de8109be-ef99-5a40-817c-6225575f5b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91898d8a-589d-43db-8dc4-0ec6a3bd6d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91898d8a-589d-43db-8dc4-0ec6a3bd6d49.jpg?1",
             "name": "Join Shields",
             "text": "Untap all creatures you control. They gain hexproof and indestructible until end of turn. (They can't be the targets of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "fa0d0bb3-e9b7-5752-911e-0719ff9a1a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27619ce9-59df-4f0e-a5db-2d32a530e547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27619ce9-59df-4f0e-a5db-2d32a530e547.jpg?1",
             "name": "Justice Strike",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -6193,7 +6193,7 @@
         },
         {
             "id": "4d44e0cd-5c67-50fa-b05e-57a6437ebe08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg?1",
             "name": "Knight of Autumn",
             "text": "When Knight of Autumn enters the battlefield, choose one \u2014\n\u2022 Put two +1/+1 counters on Knight of Autumn.\n\u2022 Destroy target artifact or enchantment.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6230,7 +6230,7 @@
         },
         {
             "id": "99d3110e-bdd3-576e-b261-16c47efcdc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1e710-f61c-4dd6-b620-6d2e1ecab689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1e710-f61c-4dd6-b620-6d2e1ecab689.jpg?1",
             "name": "Lazav, the Multifarious",
             "text": "When Lazav, the Multifarious enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{X}: Lazav, the Multifarious becomes a copy of target creature card in your graveyard with converted mana cost X, except its name is Lazav, the Multifarious, it's legendary in addition to its other types, and it has this ability.",
             "colours": [
@@ -6268,7 +6268,7 @@
         },
         {
             "id": "56cb0f63-0be1-5d5b-84fb-72827b85ab6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439118d-4869-486e-8930-6e00db2634b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7439118d-4869-486e-8930-6e00db2634b2.jpg?1",
             "name": "League Guildmage",
             "text": "{3}{U}, {T}: Draw a card.\n{X}{R}, {T}: Copy target instant or sorcery spell you control with converted mana cost X. You may choose new targets for the copy.",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "3c24662a-8032-53bf-b2c4-1c45a86b35b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f508b-a48d-4462-9d89-ee2ead3a0847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f508b-a48d-4462-9d89-ee2ead3a0847.jpg?1",
             "name": "Ledev Champion",
             "text": "Whenever Ledev Champion attacks, you may tap any number of untapped creatures you control. Ledev Champion gets +1/+1 until end of turn for each creature tapped this way.\n{3}{G}{W}: Create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -6342,7 +6342,7 @@
         },
         {
             "id": "c5a56599-33d0-550c-b7fa-ed55275611d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03423b2-faca-4b2e-8328-8b9b7fdb7ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03423b2-faca-4b2e-8328-8b9b7fdb7ce3.jpg?1",
             "name": "Legion Guildmage",
             "text": "{5}{R}, {T}: Legion Guildmage deals 3 damage to each opponent.\n{2}{W}, {T}: Tap another target creature.",
             "colours": [
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "fb06f4e1-d214-53fc-9a14-9f8ca309e3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg?1",
             "name": "March of the Multitudes",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate X 1/1 white Soldier creature tokens with lifelink.",
             "colours": [
@@ -6413,7 +6413,7 @@
         },
         {
             "id": "1799b591-fd2a-5241-8fc0-7dc2d0364a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cf45aa-ed34-4add-a2ec-fc11f8c15ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cf45aa-ed34-4add-a2ec-fc11f8c15ffa.jpg?1",
             "name": "Mnemonic Betrayal",
             "text": "Exile all cards from all opponents' graveyards. You may cast those cards this turn, and you may spend mana as though it were mana of any type to cast those spells. At the beginning of the next end step, if any of those cards remain exiled, return them to their owners' graveyards.\nExile Mnemonic Betrayal.",
             "colours": [
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "ababf69f-3fc4-51a6-869a-d52ae3f4e8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg?1",
             "name": "Molderhulk",
             "text": "Undergrowth \u2014 This spell costs {1} less to cast for each creature card in your graveyard.\nWhen Molderhulk enters the battlefield, return target land card from your graveyard to the battlefield.",
             "colours": [
@@ -6484,7 +6484,7 @@
         },
         {
             "id": "27f9cec2-429f-5463-bd40-f237853969fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg?1",
             "name": "Nightveil Predator",
             "text": "Flying, deathtouch\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6520,7 +6520,7 @@
         },
         {
             "id": "f72d5581-dd94-5ecb-8ad1-a86b1bdf6df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d2dc5-7b9d-4af6-9f3b-4de90fbf63c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3d2dc5-7b9d-4af6-9f3b-4de90fbf63c9.jpg?1",
             "name": "Niv-Mizzet, Parun",
             "text": "This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.",
             "colours": [
@@ -6559,7 +6559,7 @@
         },
         {
             "id": "c23f19a5-9257-59bf-acf1-bf034d826cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db287e-34c1-459b-882d-3db58f13eade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4db287e-34c1-459b-882d-3db58f13eade.jpg?1",
             "name": "Notion Rain",
             "text": "Surveil 2, then draw two cards. Notion Rain deals 2 damage to you. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "01584bee-dcc6-514e-91cd-a67eede89b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ef933-64f8-4075-9bd3-97149ac84b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541ef933-64f8-4075-9bd3-97149ac84b2b.jpg?1",
             "name": "Ochran Assassin",
             "text": "Deathtouch\nAll creatures able to block Ochran Assassin do so.",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "fd7eebd4-8033-5ba3-9405-cf24d017e4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52066b3-84dc-4198-8090-3336e7df8b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52066b3-84dc-4198-8090-3336e7df8b5d.jpg?1",
             "name": "Ral, Izzet Viceroy",
             "text": "+1: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\n\u22123: Ral, Izzet Viceroy deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\n\u22128: You get an emblem with \"Whenever you cast an instant or sorcery spell, this emblem deals 4 damage to any target and you draw two cards.\"",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "f8d4e5b2-66da-5ad2-aa06-bedadddf5bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg?1",
             "name": "Rhizome Lurcher",
             "text": "Undergrowth \u2014 Rhizome Lurcher enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "9dcd6265-67b3-59d7-a38a-07fc88e728d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg?1",
             "name": "Rosemane Centaur",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nVigilance",
             "colours": [
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "a4a26c58-0694-5d52-9305-38188651411b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c27f2ce-702a-4ec2-a470-982171a9ec73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c27f2ce-702a-4ec2-a470-982171a9ec73.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -6779,7 +6779,7 @@
         },
         {
             "id": "ec8ea354-791f-536d-bbcb-313bc598dd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61a398-cf16-415b-b3cf-897217dc7cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61a398-cf16-415b-b3cf-897217dc7cc9.jpg?1",
             "name": "Sonic Assault",
             "text": "Tap target creature. Sonic Assault deals 2 damage to that creature's controller.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "fb4d9ac2-a253-56a2-bc5f-391a6f7863a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg?1",
             "name": "Sumala Woodshaper",
             "text": "When Sumala Woodshaper enters the battlefield, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "89829313-05f6-5c86-ad9a-e7b8c3e01110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg?1",
             "name": "Swarm Guildmage",
             "text": "{4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn. (They can't be blocked except by two or more creatures.)\n{1}{G}, {T}: You gain 2 life.",
             "colours": [
@@ -6887,7 +6887,7 @@
         },
         {
             "id": "5a2696f3-ecfe-5cb0-b650-384d5a050882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700b38c5-3fd2-4566-8d27-9a09d5ab02b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700b38c5-3fd2-4566-8d27-9a09d5ab02b2.jpg?1",
             "name": "Swathcutter Giant",
             "text": "Vigilance\nWhenever Swathcutter Giant attacks, it deals 1 damage to each creature defending player controls.",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "68dae348-4104-5a94-8492-12a98d446d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285c4d9e-0f22-49a8-b68c-150fd0d4b617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285c4d9e-0f22-49a8-b68c-150fd0d4b617.jpg?1",
             "name": "Swiftblade Vindicator",
             "text": "Double strike, vigilance, trample",
             "colours": [
@@ -6961,7 +6961,7 @@
         },
         {
             "id": "05529d8e-db22-5193-8ead-04e5c6dd835b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e669a01-84d3-4fcc-8396-9e987bd89b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e669a01-84d3-4fcc-8396-9e987bd89b4f.jpg?1",
             "name": "Tajic, Legion's Edge",
             "text": "Haste\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nPrevent all noncombat damage that would be dealt to other creatures you control.\n{R}{W}: Tajic, Legion's Edge gains first strike until end of turn.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "7b882e45-4540-5f06-a157-a24e015c58e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307543ca-8e17-433f-9758-4c77da6c0870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307543ca-8e17-433f-9758-4c77da6c0870.jpg?1",
             "name": "Thief of Sanity",
             "text": "Flying\nWhenever Thief of Sanity deals combat damage to a player, look at the top three cards of that player's library, exile one of them face down, then put the rest into their graveyard. For as long as that card remains exiled, you may look at it, you may cast it, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "f2b51d93-e3c4-570e-b075-4cc1f5c9bd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce226ad-cb1d-47f5-90fc-27704e181884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce226ad-cb1d-47f5-90fc-27704e181884.jpg?1",
             "name": "Thought Erasure",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nSurveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7070,7 +7070,7 @@
         },
         {
             "id": "32a42452-a10b-5c6f-92a0-d13a7c1d95f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a0863-7d07-43f0-925d-a8ce0383a1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a0863-7d07-43f0-925d-a8ce0383a1cb.jpg?1",
             "name": "Thousand-Year Storm",
             "text": "Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "48b1becc-f701-5ae5-b9f4-f94666339df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1190a4-3d7e-4500-991f-e36ec3d1d9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1190a4-3d7e-4500-991f-e36ec3d1d9dc.jpg?1",
             "name": "Trostani Discordant",
             "text": "Other creatures you control get +1/+1.\nWhen Trostani Discordant enters the battlefield, create two 1/1 white Soldier creature tokens with lifelink.\nAt the beginning of your end step, each player gains control of all creatures they own.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "7c6e54ef-0763-56be-9411-c4acd8948b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6099a230-9298-4649-b257-243af40d0625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6099a230-9298-4649-b257-243af40d0625.jpg?1",
             "name": "Truefire Captain",
             "text": "Mentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhenever Truefire Captain is dealt damage, it deals that much damage to target player.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "e2e6cbb2-a9cb-51d4-ad56-d31290ddeedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e08bf-a5d6-48bb-9f7f-4711f9ec88d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e08bf-a5d6-48bb-9f7f-4711f9ec88d7.jpg?1",
             "name": "Undercity Uprising",
             "text": "Creatures you control gain deathtouch until end of turn. Then target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7213,7 +7213,7 @@
         },
         {
             "id": "b0712617-ce64-57c4-ba79-9f35a9105b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782e090-209c-428f-966a-17f3ceab2903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0782e090-209c-428f-966a-17f3ceab2903.jpg?1",
             "name": "Underrealm Lich",
             "text": "If you would draw a card, instead look at the top three cards of your library, then put one into your hand and the rest into your graveyard.\nPay 4 life: Underrealm Lich gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -7251,7 +7251,7 @@
         },
         {
             "id": "0bb3a53b-2004-5426-95ea-31ce7f71c17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95aecc12-3363-41f7-9b58-277c81859670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95aecc12-3363-41f7-9b58-277c81859670.jpg?1",
             "name": "Unmoored Ego",
             "text": "Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles their library, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "c92d3b22-ae93-5660-a487-44fd09845dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36d3ea7-0f18-4865-b47b-755673db065e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36d3ea7-0f18-4865-b47b-755673db065e.jpg?1",
             "name": "Vraska, Golgari Queen",
             "text": "+2: You may sacrifice another permanent. If you do, you gain 1 life and draw a card.\n\u22123: Destroy target nonland permanent with converted mana cost 3 or less.\n\u22129: You get an emblem with \"Whenever a creature you control deals combat damage to a player, that player loses the game.\"",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "b62a63e8-5208-5d18-b8dc-8190d37b885a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee17a1-76ce-4ae8-9109-ba32457cbeec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee17a1-76ce-4ae8-9109-ba32457cbeec.jpg?1",
             "name": "Wee Dragonauts",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Wee Dragonauts gets +2/+0 until end of turn.",
             "colours": [
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "8708d385-a3ee-50f4-8377-83be641cad4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg?1",
             "name": "Worldsoul Colossus",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWorldsoul Colossus enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -7396,7 +7396,7 @@
         },
         {
             "id": "aa07b355-dcd5-585f-bdd9-1fa028eaf24d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b19518-7752-4673-a7d8-ae2e0070129c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b19518-7752-4673-a7d8-ae2e0070129c.jpg?1",
             "name": "Fresh-Faced Recruit",
             "text": "As long as it's your turn, Fresh-Faced Recruit has first strike.",
             "colours": [
@@ -7433,7 +7433,7 @@
         },
         {
             "id": "4b319d61-dfce-52bc-b81d-72ddc165ccf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec7523a-a9c4-4b76-8f9e-b591a88e2e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec7523a-a9c4-4b76-8f9e-b591a88e2e37.jpg?1",
             "name": "Piston-Fist Cyclops",
             "text": "Defender\nAs long as you've cast an instant or sorcery spell this turn, Piston-Fist Cyclops can attack as though it didn't have defender.",
             "colours": [
@@ -7469,7 +7469,7 @@
         },
         {
             "id": "1d09942f-b07d-564d-8396-719ee994d7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg?1",
             "name": "Pitiless Gorgon",
             "text": "Deathtouch",
             "colours": [
@@ -7505,7 +7505,7 @@
         },
         {
             "id": "093bfdec-03ae-5159-b5a5-7518b84fb50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg?1",
             "name": "Vernadi Shieldmate",
             "text": "Vigilance",
             "colours": [
@@ -7542,7 +7542,7 @@
         },
         {
             "id": "c107f11f-13e1-5b9c-896f-52c753c5fa81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg?1",
             "name": "Whisper Agent",
             "text": "Flash\nWhen Whisper Agent enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -7579,7 +7579,7 @@
         },
         {
             "id": "30151a21-89a0-5e95-9c50-18569875cdab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg?1",
             "name": "Assure // Assemble",
             "text": "Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.",
             "colours": [
@@ -7613,7 +7613,7 @@
         },
         {
             "id": "67adb8d5-8077-5222-a0b5-e1e37ec7507a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg?1",
             "name": "Assure // Assemble",
             "text": "Create three 2/2 green and white Elf Knight creature tokens with vigilance.",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "e3406eb1-506e-553d-81b1-f3ef839ff58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg?1",
             "name": "Connive // Concoct",
             "text": "Gain control of target creature with power 2 or less.",
             "colours": [
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "9044bc5b-81bb-5d32-8ee8-48cc8671efae",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg?1",
             "name": "Connive // Concoct",
             "text": "Surveil 3, then return a creature card from your graveyard to the battlefield.",
             "colours": [
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "84af590f-f59c-5961-b312-70dcc1d2dfea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg?1",
             "name": "Discovery // Dispersal",
             "text": "Surveil 2, then draw a card. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "08aec574-a6c5-58cd-aaa8-5de809f3cefb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg?1",
             "name": "Discovery // Dispersal",
             "text": "Each opponent returns a nonland permanent they control with the highest converted mana cost among permanents they control to its owner's hand, then discards a card.",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "f2f6904a-e7f7-524c-9077-feab5f2e4577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg?1",
             "name": "Expansion // Explosion",
             "text": "Copy target instant or sorcery spell with converted mana cost 4 or less. You may choose new targets for the copy.",
             "colours": [
@@ -7817,7 +7817,7 @@
         },
         {
             "id": "a0aaef0f-9c24-5708-90f9-50fd524cd312",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg?1",
             "name": "Expansion // Explosion",
             "text": "Explosion deals X damage to any target. Target player draws X cards.",
             "colours": [
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "dc6a3121-9752-5078-b88f-abd64a96118e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg?1",
             "name": "Find // Finality",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -7885,7 +7885,7 @@
         },
         {
             "id": "7b7fedbb-7703-55e2-b678-c8698bdf8ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1e4e9e35-6cbc-4997-beff-d1a22d87545e.jpg?1",
             "name": "Find // Finality",
             "text": "You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.",
             "colours": [
@@ -7919,7 +7919,7 @@
         },
         {
             "id": "fbc07191-5f41-5ce8-b5a0-2330840715a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg?1",
             "name": "Flower // Flourish",
             "text": "Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -7953,7 +7953,7 @@
         },
         {
             "id": "565c56f9-b9b7-50b2-9852-f7ea0a137978",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg?1",
             "name": "Flower // Flourish",
             "text": "Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -7987,7 +7987,7 @@
         },
         {
             "id": "6374adea-5750-5bf6-8f82-e70bdfd71bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg?1",
             "name": "Integrity // Intervention",
             "text": "Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "0766b4b2-e233-5827-ad3c-b048f2ac3d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg?1",
             "name": "Integrity // Intervention",
             "text": "Intervention deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "4387960d-3972-5b9c-a186-8dcf70034359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg?1",
             "name": "Invert // Invent",
             "text": "Switch the power and toughness of each of up to two target creatures.",
             "colours": [
@@ -8089,7 +8089,7 @@
         },
         {
             "id": "c5d3fc32-fe45-5c84-86f3-174edf24b334",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg?1",
             "name": "Invert // Invent",
             "text": "Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -8123,7 +8123,7 @@
         },
         {
             "id": "5d6e8114-f958-5521-966c-1a3a044423fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg?1",
             "name": "Response // Resurgence",
             "text": "Response deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "e1746db1-c96d-5887-bb16-c2d14f4714e2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92162888-35ea-4f4f-ab99-64dd3104e230.jpg?1",
             "name": "Response // Resurgence",
             "text": "Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.",
             "colours": [
@@ -8191,7 +8191,7 @@
         },
         {
             "id": "11d1affe-50ea-54d7-86e7-649416f30204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg?1",
             "name": "Status // Statue",
             "text": "Target creature gets +1/+1 and gains deathtouch until end of turn.",
             "colours": [
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "3a952e1f-b101-5652-a90b-eb0fa00b1e48",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg?1",
             "name": "Status // Statue",
             "text": "Destroy target artifact, creature, or enchantment.",
             "colours": [
@@ -8259,7 +8259,7 @@
         },
         {
             "id": "f5e3b7fa-83e1-5e77-b656-ffc34b2c5437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg?1",
             "name": "Boros Locket",
             "text": "{T}: Add {R} or {W}.\n{GU}{GU}{GU}{GU}, {T}, Sacrifice Boros Locket: Draw two cards.",
             "colours": [],
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "b36fb73e-f357-5f54-bd3f-43b82108180b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dfd5f2-5298-4cf4-80fe-43db9be24f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dfd5f2-5298-4cf4-80fe-43db9be24f57.jpg?1",
             "name": "Chamber Sentry",
             "text": "Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.\n{X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.\n{W}{U}{B}{R}{G}: Return Chamber Sentry from your graveyard to your hand.",
             "colours": [],
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "0aeb1e56-d320-53f2-9f29-4c699dcf2b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea123356-3055-4e42-b816-ac3c4e9087d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea123356-3055-4e42-b816-ac3c4e9087d1.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "431afa9a-168b-579a-b004-10b0f8cffd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg?1",
             "name": "Dimir Locket",
             "text": "{T}: Add {U} or {B}.\n{UB}{UB}{UB}{UB}, {T}, Sacrifice Dimir Locket: Draw two cards.",
             "colours": [],
@@ -8386,7 +8386,7 @@
         },
         {
             "id": "601991f2-36ef-5583-8f79-7fd5e3c1e346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bbdd54e-5d7e-4e4b-8d59-4e3f46877d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bbdd54e-5d7e-4e4b-8d59-4e3f46877d39.jpg?1",
             "name": "Gatekeeper Gargoyle",
             "text": "Flying\nGatekeeper Gargoyle enters the battlefield with a +1/+1 counter on it for each Gate you control.",
             "colours": [],
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "83c992e4-1493-5858-886c-213fd0fcb040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19723ad-7bd2-49ee-a57a-ece99018f4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19723ad-7bd2-49ee-a57a-ece99018f4e8.jpg?1",
             "name": "Glaive of the Guildpact",
             "text": "Equipped creature gets +1/+0 for each Gate you control and has vigilance and menace. (A creature with menace can't be blocked except by two or more creatures.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "5418a8ad-be11-567c-99f6-8a2c6db605e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg?1",
             "name": "Golgari Locket",
             "text": "{T}: Add {B} or {G}.\n{BG}{BG}{BG}{BG}, {T}, Sacrifice Golgari Locket: Draw two cards.",
             "colours": [],
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "ee1277fe-8246-5d33-85d4-905fc897b702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg?1",
             "name": "Izzet Locket",
             "text": "{T}: Add {U} or {R}.\n{UR}{UR}{UR}{UR}, {T}, Sacrifice Izzet Locket: Draw two cards.",
             "colours": [],
@@ -8509,7 +8509,7 @@
         },
         {
             "id": "dc7b364d-2755-513a-b414-6c88b73343db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg?1",
             "name": "Rampaging Monument",
             "text": "Trample\nRampaging Monument enters the battlefield with three +1/+1 counters on it.\nWhenever you cast a multicolored spell, put a +1/+1 counter on Rampaging Monument.",
             "colours": [],
@@ -8540,7 +8540,7 @@
         },
         {
             "id": "3b5437ec-9f28-55f8-9fd3-6814fe7d1578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg?1",
             "name": "Selesnya Locket",
             "text": "{T}: Add {G} or {W}.\n{RW}{RW}{RW}{RW}, {T}, Sacrifice Selesnya Locket: Draw two cards.",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "5ecb845a-1e71-5fd1-ba08-14dafe510a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg?1",
             "name": "Silent Dart",
             "text": "{4}, {T}, Sacrifice Silent Dart: It deals 3 damage to target creature.",
             "colours": [],
@@ -8599,7 +8599,7 @@
         },
         {
             "id": "d3888501-29a1-5636-86d6-84c706a7ee0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f208bc-e4dc-4d3a-8906-dccde3cc251b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f208bc-e4dc-4d3a-8906-dccde3cc251b.jpg?1",
             "name": "Wand of Vertebrae",
             "text": "{T}: Put the top card of your library into your graveyard.\n{2}, {T}, Exile Wand of Vertebrae: Shuffle up to five target cards from your graveyard into your library.",
             "colours": [],
@@ -8627,7 +8627,7 @@
         },
         {
             "id": "bfd93037-c939-5174-9c4a-b735bbd2822f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52ceefc-90d0-49d1-ae54-9a4eab819849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52ceefc-90d0-49d1-ae54-9a4eab819849.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "d3cf9123-77d4-5f74-ad3c-b1d6f86f142b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f52d32-c04b-4711-9edc-8fd1d3547a44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f52d32-c04b-4711-9edc-8fd1d3547a44.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "86e860bb-6974-5b6b-9158-0bd2adcdb911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7129bdf-de02-4ed2-b5de-f774b8a7d302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7129bdf-de02-4ed2-b5de-f774b8a7d302.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8732,7 +8732,7 @@
         },
         {
             "id": "44f8087c-cc55-5ae7-a618-8751e7bcb13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3694ac90-e71e-4736-8945-7dbf5b5fd6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3694ac90-e71e-4736-8945-7dbf5b5fd6a9.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "b65b4e3d-d08a-5559-a8c2-714de82e3889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg?1",
             "name": "Gateway Plaza",
             "text": "Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8797,7 +8797,7 @@
         },
         {
             "id": "218b1942-147e-5714-bc42-313a5f63b2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86706d8e-de08-4778-94ba-ae75ed522472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86706d8e-de08-4778-94ba-ae75ed522472.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8832,7 +8832,7 @@
         },
         {
             "id": "adc48ddd-9973-57f9-8fd4-541d24c9a02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a021e9-b11a-4028-86c9-01b62eae1877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a021e9-b11a-4028-86c9-01b62eae1877.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "e02d2a6d-cea1-55dc-817e-8e7389fcb118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba12bda-d460-4206-8469-4357c967b9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba12bda-d460-4206-8469-4357c967b9b8.jpg?1",
             "name": "Guildmages' Forum",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color. If that mana is spent on a multicolored creature spell, that creature enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [],
@@ -8895,7 +8895,7 @@
         },
         {
             "id": "e5c3454f-6ad9-5b79-848a-0577f126a365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2055a83a-99c8-4808-90b9-1c2fdcda79b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2055a83a-99c8-4808-90b9-1c2fdcda79b4.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "3c010556-ee1a-50fd-b488-ec4ae0832d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc36bb2a-115d-4e24-a1e9-02b21773e945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc36bb2a-115d-4e24-a1e9-02b21773e945.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "6746108f-8643-5585-9e7a-a3444ec29122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff1f52c-5c43-4260-aaa0-6920846a191c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff1f52c-5c43-4260-aaa0-6920846a191c.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G}.)\nAs Overgrown Tomb enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "0f18776f-71b4-59aa-af5a-df8ff1bc0ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b598d0-535d-477d-a33d-d6a10ff5439a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b598d0-535d-477d-a33d-d6a10ff5439a.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W}.)\nAs Sacred Foundry enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9033,7 +9033,7 @@
         },
         {
             "id": "17416856-3b20-5357-a0cd-977a73d75b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee7a5-937a-4c2b-af8c-6e5734677c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee7a5-937a-4c2b-af8c-6e5734677c53.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9068,7 +9068,7 @@
         },
         {
             "id": "60b24e18-89ed-5657-8bff-bfc191b872b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1db693-5dd9-48de-8520-014d9ad5b596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1db693-5dd9-48de-8520-014d9ad5b596.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "6d0c10f2-c95b-5b71-b5df-ad2f14e642c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ebe3cf-7143-453a-b0ef-2f5bdaac3185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ebe3cf-7143-453a-b0ef-2f5bdaac3185.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R}.)\nAs Steam Vents enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9137,7 +9137,7 @@
         },
         {
             "id": "f5d5918f-da74-5790-9130-37f0ad7f839e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9b0195-beda-403e-bc27-7ae3be9f318c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9b0195-beda-403e-bc27-7ae3be9f318c.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W}.)\nAs Temple Garden enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9171,7 +9171,7 @@
         },
         {
             "id": "1e98e3ac-019c-5a88-9473-993be2484c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4595f2-9297-40dc-b2dd-7144bbb401f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4595f2-9297-40dc-b2dd-7144bbb401f7.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B}.)\nAs Watery Grave enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9205,7 +9205,7 @@
         },
         {
             "id": "61e6c590-9134-5dfc-8d5e-1f5edad07549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983acda-68b6-468b-b0c1-aad8b53db49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b983acda-68b6-468b-b0c1-aad8b53db49c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "a865513e-d082-5b04-8009-1f8bb7e636c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bfbf3e-3a6c-40d4-8e1b-255f429de6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bfbf3e-3a6c-40d4-8e1b-255f429de6cc.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9273,7 +9273,7 @@
         },
         {
             "id": "1f848d3c-98b8-5941-86b6-352995f489b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd5a7f0-5ad3-44e8-a103-07739fd53630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd5a7f0-5ad3-44e8-a103-07739fd53630.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "f7e3deba-7d3e-5705-be88-957a77523c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f918a49-a046-4115-80b8-13490ed5cd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f918a49-a046-4115-80b8-13490ed5cd0a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "adb305c1-9371-57b5-8212-6a890b82330c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85892ae-dacd-4a55-a557-9db3c16017c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85892ae-dacd-4a55-a557-9db3c16017c7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "72c69fec-2809-5a5f-ad5e-02e9963bca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44f0c60-5732-4c25-9ba9-4829f1891762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44f0c60-5732-4c25-9ba9-4829f1891762.jpg?1",
             "name": "Ral, Caller of Storms",
             "text": "+1: Draw a card.\n\u22122: Ral, Caller of Storms deals 3 damage divided as you choose among one, two, or three targets.\n\u22127: Draw seven cards. Ral, Caller of Storms deals 7 damage to each creature your opponents control.",
             "colours": [
@@ -9412,7 +9412,7 @@
         },
         {
             "id": "ff593171-c63d-5ed9-88b4-4353525a073a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2660fae-6459-446d-85dc-3c9126c81cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2660fae-6459-446d-85dc-3c9126c81cb3.jpg?1",
             "name": "Ral's Dispersal",
             "text": "Return target creature to its owner's hand. You may search your library and/or graveyard for a card named Ral, Caller of Storms, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9443,7 +9443,7 @@
         },
         {
             "id": "4132334d-c29c-5ee7-a307-7d3c0b2f32e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg?1",
             "name": "Precision Bolt",
             "text": "Precision Bolt deals 3 damage to any target.",
             "colours": [
@@ -9474,7 +9474,7 @@
         },
         {
             "id": "06451a69-e67d-5ea8-bfcf-8b28ad10d0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa16dc-03b3-4533-884c-a23b992b8d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa16dc-03b3-4533-884c-a23b992b8d86.jpg?1",
             "name": "Ral's Staticaster",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever Ral's Staticaster attacks, if you control a Ral planeswalker, Ral's Staticaster gets +1/+0 for each card in your hand until end of turn.",
             "colours": [
@@ -9510,7 +9510,7 @@
         },
         {
             "id": "b11075fb-b582-5438-aa8a-5fbd46e33a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4299dbe6-c94d-4ecc-8bfd-741d2649cba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4299dbe6-c94d-4ecc-8bfd-741d2649cba1.jpg?1",
             "name": "Vraska, Regal Gorgon",
             "text": "+2: Put a +1/+1 counter on up to one target creature. That creature gains menace until end of turn.\n\u22123: Destroy target creature.\n\u221210: For each creature card in your graveyard, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -9547,7 +9547,7 @@
         },
         {
             "id": "76a96141-7f23-537f-bc92-f288b8d08b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg?1",
             "name": "Kraul Raider",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -9581,7 +9581,7 @@
         },
         {
             "id": "475c1dd9-816b-5fec-a1a8-a48a9b3dfec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4840f1-3db3-4ba6-b75b-bbd87251a3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4840f1-3db3-4ba6-b75b-bbd87251a3af.jpg?1",
             "name": "Attendant of Vraska",
             "text": "When Attendant of Vraska dies, if you control a Vraska planeswalker, you gain life equal to Attendant of Vraska's power.",
             "colours": [
@@ -9617,7 +9617,7 @@
         },
         {
             "id": "116d77fe-d09d-516b-87e7-736686ee122e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fc4db6-a5f5-4254-ae64-c8eaf2c98030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fc4db6-a5f5-4254-ae64-c8eaf2c98030.jpg?1",
             "name": "Vraska's Stoneglare",
             "text": "Destroy target creature. You gain life equal to its toughness. You may search your library and/or graveyard for a card named Vraska, Regal Gorgon, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "ad5c0740-144d-58fd-8fde-e2f3aee52fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg?1",
             "name": "Impervious Greatwurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
             "colours": [
@@ -9683,7 +9683,7 @@
         },
         {
             "id": "4c454188-bb99-56c9-8ef8-54c6b0a13053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb271a8-68bb-45e6-9f99-568479e92ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb271a8-68bb-45e6-9f99-568479e92ea0.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9717,7 +9717,7 @@
         },
         {
             "id": "4f83983f-76b0-57e8-8231-0e19f4bd4362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45907b16-af17-4237-ab38-9d7537fd30e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45907b16-af17-4237-ab38-9d7537fd30e8.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9751,7 +9751,7 @@
         },
         {
             "id": "c5499171-7f2a-51e7-8679-f4732f2b4d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c3dc23-d6f2-4209-82e1-a0b936c94231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c3dc23-d6f2-4209-82e1-a0b936c94231.jpg?1",
             "name": "Bird Illusion",
             "text": "",
             "colours": [
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "02c36c5b-83d2-5f52-8936-ef55ae895933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27dc0bd-ba46-4a5c-9559-7c11eb4ec37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27dc0bd-ba46-4a5c-9559-7c11eb4ec37b.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "99859c93-5f3d-5dc3-ace1-f8c1802706f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0436e71b-c1f9-4ca8-a29c-775da858a0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0436e71b-c1f9-4ca8-a29c-775da858a0cd.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -9856,7 +9856,7 @@
         },
         {
             "id": "e34f0600-7c7d-53c2-9a84-79b7cba4b62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74506297-41ad-40e5-bb05-175650ff4907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74506297-41ad-40e5-bb05-175650ff4907.jpg?1",
             "name": "Elf Knight",
             "text": "",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "5ef31151-c5e4-5a26-8239-e17a1cbe245b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03580d3a-4c02-4f2e-b667-f82028ccde0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03580d3a-4c02-4f2e-b667-f82028ccde0b.jpg?1",
             "name": "Ral, Izzet Viceroy Emblem",
             "text": "",
             "colours": [],
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "6d9a50c3-1fbb-5ac3-9b2a-3f809e5ca705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81478ee-1ddf-44f5-98a0-df6d4eecad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81478ee-1ddf-44f5-98a0-df6d4eecad7e.jpg?1",
             "name": "Vraska, Golgari Queen Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/GTC.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/GTC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "bee409c6-6fb9-5ac1-8c12-891ad27b72b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63e9c49-3fa4-41ad-9eed-19801df103c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63e9c49-3fa4-41ad-9eed-19801df103c6.jpg?1",
             "name": "Aerial Maneuver",
             "text": "Target creature gets +1/+1 and gains flying and first strike until end of turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "7be5a9a3-d8ba-5b98-aeab-34609f042bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b62d3-c200-4330-a255-92d77f01ba44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b62d3-c200-4330-a255-92d77f01ba44.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "8a74424e-bb7c-5c8c-b2d1-3e6e2c230ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb04702-5cb2-4590-b675-9409ba52a395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb04702-5cb2-4590-b675-9409ba52a395.jpg?1",
             "name": "Angelic Skirmisher",
             "text": "Flying\nAt the beginning of each combat, choose first strike, vigilance, or lifelink. Creatures you control gain that ability until end of turn.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "a54dc634-b6f5-5ffe-afb2-21bdf1331e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704286a5-e3a8-4517-85e5-6447c5c2530f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704286a5-e3a8-4517-85e5-6447c5c2530f.jpg?1",
             "name": "Assault Griffin",
             "text": "Flying",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "4b210ccc-11d0-5bbe-9511-4aff34d2994a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39fed-4b39-4027-9c80-f2186f7dd941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be39fed-4b39-4027-9c80-f2186f7dd941.jpg?1",
             "name": "Basilica Guards",
             "text": "Defender\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "7419d1dc-a480-52ac-9b8c-f96825f58a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c3e78d-d917-4552-842f-feff99c059e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c3e78d-d917-4552-842f-feff99c059e0.jpg?1",
             "name": "Blind Obedience",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nArtifacts and creatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "52214847-9686-541a-b344-b3d825860763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03974e6-aced-4664-8c5c-3190bb1eb233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03974e6-aced-4664-8c5c-3190bb1eb233.jpg?1",
             "name": "Boros Elite",
             "text": "Battalion \u2014 Whenever Boros Elite and at least two other creatures attack, Boros Elite gets +2/+2 until end of turn.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "a68d4ba3-a72c-5778-9e07-f17df73dd287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6a5cb3-b6e5-4879-83b5-4ad590a5467a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6a5cb3-b6e5-4879-83b5-4ad590a5467a.jpg?1",
             "name": "Court Street Denizen",
             "text": "Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "1ee7384f-513a-514c-b41d-940a1ae9ad87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c28412d-9add-4911-8487-c84559006fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c28412d-9add-4911-8487-c84559006fb0.jpg?1",
             "name": "Daring Skyjek",
             "text": "Battalion \u2014 Whenever Daring Skyjek and at least two other creatures attack, Daring Skyjek gains flying until end of turn.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "531edb3b-9590-592c-a035-3c15a886b0a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafb0372-6860-4b0b-b92e-873735489006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafb0372-6860-4b0b-b92e-873735489006.jpg?1",
             "name": "Debtor's Pulpit",
             "text": "Enchant land\nEnchanted land has \"{T}: Tap target creature.\"",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "d19ad127-ffcb-51a2-852a-6ce53ddb5a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d586143-fac0-463f-96ec-c6b9fd582194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d586143-fac0-463f-96ec-c6b9fd582194.jpg?1",
             "name": "Dutiful Thrull",
             "text": "{B}: Regenerate Dutiful Thrull.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "a7759ce2-cbd0-5410-b1fb-1e2a7cb051b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711a5eca-531d-4b07-b7df-9b06bad491be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711a5eca-531d-4b07-b7df-9b06bad491be.jpg?1",
             "name": "Frontline Medic",
             "text": "Battalion \u2014 Whenever Frontline Medic and at least two other creatures attack, creatures you control are indestructible this turn.\nSacrifice Frontline Medic: Counter target spell with {X} in its mana cost unless its controller pays {3}.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "1744765e-0d19-5111-99aa-206fd97af367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d0509a-a863-4d9c-b39f-625a8cc1a547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d0509a-a863-4d9c-b39f-625a8cc1a547.jpg?1",
             "name": "Gideon, Champion of Justice",
             "text": "+1: Put a loyalty counter on Gideon, Champion of Justice for each creature target opponent controls.\n0: Until end of turn, Gideon, Champion of Justice becomes an indestructible Human Soldier creature with power and toughness each equal to the number of loyalty counters on him. He's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n-15: Exile all other permanents.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "4cfc18c6-76b8-54e2-aecb-9683515c0daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86940635-7001-4ecf-b4ee-25aa1e2d81fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86940635-7001-4ecf-b4ee-25aa1e2d81fc.jpg?1",
             "name": "Guardian of the Gateless",
             "text": "Flying\nGuardian of the Gateless can block any number of creatures.\nWhenever Guardian of the Gateless blocks, it gets +1/+1 until end of turn for each creature it's blocking.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "c63b0b5d-9a3e-5bcf-9f7b-89e9e5f2dabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c5c496-0a3e-40e1-84ac-8ad3a9d8352b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c5c496-0a3e-40e1-84ac-8ad3a9d8352b.jpg?1",
             "name": "Guildscorn Ward",
             "text": "Enchant creature\nEnchanted creature has protection from multicolored.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "9b8c573d-ad6a-5f4f-a56c-43c4a82bb9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fd52d0-0e41-48d5-b96f-4c6409788c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fd52d0-0e41-48d5-b96f-4c6409788c18.jpg?1",
             "name": "Hold the Gates",
             "text": "Creatures you control get +0/+1 for each Gate you control and have vigilance.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "3aa60db0-9a99-5201-bd07-977e1e7c760f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95567596-c5b1-426f-bc2c-43306f7221b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95567596-c5b1-426f-bc2c-43306f7221b0.jpg?1",
             "name": "Holy Mantle",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has protection from creatures.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "4b19bd55-06b7-53b1-91b1-2f571ff747aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2a1100-a2e6-4ef5-a8e3-2aca552d6b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2a1100-a2e6-4ef5-a8e3-2aca552d6b66.jpg?1",
             "name": "Knight of Obligation",
             "text": "Vigilance\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "9853c637-334c-5d0f-be60-bb4cdd2a3668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd492072-9a8c-4d55-ac71-3c8efaa3fc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd492072-9a8c-4d55-ac71-3c8efaa3fc87.jpg?1",
             "name": "Knight Watch",
             "text": "Put two 2/2 white Knight creature tokens with vigilance onto the battlefield.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "dbd830c7-eddf-5040-a486-fe2c50a73272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0747b12-c75a-4fdf-a881-f2383a23ccdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0747b12-c75a-4fdf-a881-f2383a23ccdd.jpg?1",
             "name": "Luminate Primordial",
             "text": "Vigilance\nWhen Luminate Primordial enters the battlefield, for each opponent, exile up to one target creature that player controls and that player gains life equal to its power.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "c4c15faa-3bd0-533c-88f4-527569aeeea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3bb284-d10e-4265-92a4-8dcaf118f3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3bb284-d10e-4265-92a4-8dcaf118f3c8.jpg?1",
             "name": "Murder Investigation",
             "text": "Enchant creature you control\nWhen enchanted creature dies, put X 1/1 white Soldier creature tokens onto the battlefield, where X is its power.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "6b2fe06e-eb5a-58ee-8703-fe525bcb8a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d7f8-375f-40f5-98cd-08be08580bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d7f8-375f-40f5-98cd-08be08580bef.jpg?1",
             "name": "Nav Squad Commandos",
             "text": "Battalion \u2014 Whenever Nav Squad Commandos and at least two other creatures attack, Nav Squad Commandos gets +1/+1 until end of turn. Untap it.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "5ccfb36c-c190-558d-ad6b-54734e83b0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52cb325-4f16-4cf3-9999-feafe0fde8c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52cb325-4f16-4cf3-9999-feafe0fde8c2.jpg?1",
             "name": "Righteous Charge",
             "text": "Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "236594f4-c099-54c0-8107-08388ccb8d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6546b6c4-73b2-41b3-9ff9-316e9ce916e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6546b6c4-73b2-41b3-9ff9-316e9ce916e5.jpg?1",
             "name": "Shielded Passage",
             "text": "Prevent all damage that would be dealt to target creature this turn.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "8b186c0d-3a80-576f-aa18-7983522cc8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff799e40-fd40-4f6a-8fa8-c22d77476168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff799e40-fd40-4f6a-8fa8-c22d77476168.jpg?1",
             "name": "Smite",
             "text": "Destroy target blocked creature.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "8d610cba-8282-5f0d-b665-6c3d152510fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bafaa3b-eeaa-427f-9a73-6a1c98d257ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bafaa3b-eeaa-427f-9a73-6a1c98d257ca.jpg?1",
             "name": "Syndic of Tithes",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "f176ac72-ab9a-5262-b08a-fef5c1e084c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf932ac-5ea5-491b-b555-5e9ea971d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf932ac-5ea5-491b-b555-5e9ea971d93d.jpg?1",
             "name": "Urbis Protector",
             "text": "When Urbis Protector enters the battlefield, put a 4/4 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "f8091b87-998c-53bd-a6bc-fa091cc79f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf5efe4-d9a0-4704-b5ba-3213c946df37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf5efe4-d9a0-4704-b5ba-3213c946df37.jpg?1",
             "name": "Zarichi Tiger",
             "text": "{1}{W}, {T}: You gain 2 life.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "3377e7d7-fcea-5636-82d8-ca0ffabc16e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33303859-c6e0-4ebd-bb5f-44be7f5d7459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33303859-c6e0-4ebd-bb5f-44be7f5d7459.jpg?1",
             "name": "Aetherize",
             "text": "Return all attacking creatures to their owner's hand.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "8e6e0c9d-b5f1-5de8-986b-36042c11326d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a3efab-ee0a-4770-a323-e4bac38e4287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a3efab-ee0a-4770-a323-e4bac38e4287.jpg?1",
             "name": "Agoraphobia",
             "text": "Enchant creature\nEnchanted creature gets -5/-0.\n{2}{U}: Return Agoraphobia to its owner's hand.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "f708accb-edc6-5684-8711-5b69bfc80895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e183069-096d-4977-8154-e7b60f17a787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e183069-096d-4977-8154-e7b60f17a787.jpg?1",
             "name": "Clinging Anemones",
             "text": "Defender\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "2d25f0a0-c0d8-56e7-b006-a982ee6abddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2931f27-43f9-4e52-aab3-967c26739e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2931f27-43f9-4e52-aab3-967c26739e43.jpg?1",
             "name": "Cloudfin Raptor",
             "text": "Flying\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "f711d896-7ec5-5dbd-ad8a-1c0dc310b8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c34af-91de-44c6-a3e2-f48dbb0ce9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c34af-91de-44c6-a3e2-f48dbb0ce9fd.jpg?1",
             "name": "Diluvian Primordial",
             "text": "Flying\nWhen Diluvian Primordial enters the battlefield, for each opponent, you may cast up to one target instant or sorcery card from that player's graveyard without paying its mana cost. If a card cast this way would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "501b70c9-4d86-519b-9a08-af31deb555cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612beb8f-2ab1-4a8b-84c5-c47d19d400ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612beb8f-2ab1-4a8b-84c5-c47d19d400ab.jpg?1",
             "name": "Enter the Infinite",
             "text": "Draw cards equal to the number of cards in your library, then put a card from your hand on top of your library. You have no maximum hand size until your next turn.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "f99185c5-c847-5092-9679-607207a45f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f3a08f-403e-4d6c-87c7-add8170bde8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f3a08f-403e-4d6c-87c7-add8170bde8b.jpg?1",
             "name": "Frilled Oculus",
             "text": "{1}{G}: Frilled Oculus gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "bfc0f48f-c36d-5e24-8e3f-352d57fb1c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f5c126-3df9-4771-9e74-4ca33161ac08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f5c126-3df9-4771-9e74-4ca33161ac08.jpg?1",
             "name": "Gridlock",
             "text": "Tap X target nonland permanents.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "27041222-6210-5044-a7eb-68edfc5dda1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeef50a-f5c9-47ab-ad04-645f49bbae6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeef50a-f5c9-47ab-ad04-645f49bbae6b.jpg?1",
             "name": "Hands of Binding",
             "text": "Tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "f036c5b4-d4d8-53ec-b90a-b39b8aeea1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290e56e0-e699-413a-9d6a-e740bf460b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290e56e0-e699-413a-9d6a-e740bf460b35.jpg?1",
             "name": "Incursion Specialist",
             "text": "Whenever you cast your second spell each turn, Incursion Specialist gets +2/+0 until end of turn and is unblockable this turn.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "328d557b-438d-52da-b8fc-20c6fcf99c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ee9a3-a862-46a7-9aa5-7b6fc4ffa1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970ee9a3-a862-46a7-9aa5-7b6fc4ffa1ab.jpg?1",
             "name": "Keymaster Rogue",
             "text": "Keymaster Rogue is unblockable.\nWhen Keymaster Rogue enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "ac15542b-15b6-5600-8633-4bb8d51cac9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6033d07-124c-4001-81e1-c6eb99e07fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6033d07-124c-4001-81e1-c6eb99e07fdd.jpg?1",
             "name": "Last Thoughts",
             "text": "Draw a card.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1354,7 +1354,7 @@
         },
         {
             "id": "a7d2544b-6834-5bc0-95f2-fa871f777951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0867865-d9eb-45d2-a359-064f0f61197b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0867865-d9eb-45d2-a359-064f0f61197b.jpg?1",
             "name": "Leyline Phantom",
             "text": "When Leyline Phantom deals combat damage, return it to its owner's hand. (Return it only if it survived combat.)",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "e60a0605-0e50-5e0e-a9ad-3071fa19c6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f349013-0846-4bec-bdf9-47a3706d9989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f349013-0846-4bec-bdf9-47a3706d9989.jpg?1",
             "name": "Metropolis Sprite",
             "text": "Flying\n{U}: Metropolis Sprite gets +1/-1 until end of turn.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "dd6fea2b-3220-5553-8f24-c13c5c5d7b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947f44b0-91be-4115-b499-57893f0f69a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947f44b0-91be-4115-b499-57893f0f69a9.jpg?1",
             "name": "Mindeye Drake",
             "text": "Flying\nWhen Mindeye Drake dies, target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "14bcd970-5e90-50d2-acf7-a91d7a4fff3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83557f55-f1ab-4995-9cc1-37be895a59db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83557f55-f1ab-4995-9cc1-37be895a59db.jpg?1",
             "name": "Rapid Hybridization",
             "text": "Destroy target creature. It can't be regenerated. That creature's controller puts a 3/3 green Frog Lizard creature token onto the battlefield.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "ddac5c27-49dc-571d-a142-9950ab16e17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989c76b2-d130-443d-8534-6525fef404c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989c76b2-d130-443d-8534-6525fef404c2.jpg?1",
             "name": "Realmwright",
             "text": "As Realmwright enters the battlefield, choose a basic land type.\nLands you control are the chosen type in addition to their other types.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "b9e56838-e585-5f46-a58f-c2dbf4208627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063e6df9-2287-485a-ab46-fa4a38783884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063e6df9-2287-485a-ab46-fa4a38783884.jpg?1",
             "name": "Sage's Row Denizen",
             "text": "Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "44a82c1d-9fd1-594c-b4a1-b1fb2a8eb2c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fe14cf-5d34-47d1-9071-4a532819719b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fe14cf-5d34-47d1-9071-4a532819719b.jpg?1",
             "name": "Sapphire Drake",
             "text": "Flying\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "c3fca587-b376-5e1a-a847-da240bf892f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ed969f-2c8e-4421-9448-dc5a2afdc81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ed969f-2c8e-4421-9448-dc5a2afdc81d.jpg?1",
             "name": "Scatter Arc",
             "text": "Counter target noncreature spell.\nDraw a card.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "06024474-14b6-53d7-b744-fb7ae8cdf09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633b59-6051-4f47-9e27-538fda03b5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50633b59-6051-4f47-9e27-538fda03b5dd.jpg?1",
             "name": "Simic Fluxmage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\n{1}{U}, {T}: Move a +1/+1 counter from Simic Fluxmage onto target creature.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "6f890f45-e5cc-5d03-89ff-7457e3387c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dff9e6-5e0c-4e5b-8184-f0ae9cf347b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dff9e6-5e0c-4e5b-8184-f0ae9cf347b3.jpg?1",
             "name": "Simic Manipulator",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\n{T}, Remove one or more +1/+1 counters from Simic Manipulator: Gain control of target creature with power less than or equal to the number of +1/+1 counters removed this way.",
             "colours": [
@@ -1695,7 +1695,7 @@
         },
         {
             "id": "840a11c5-862e-5b58-a5a6-3101ebac30fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5bf75-762f-46ef-8304-aacdb248bc5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5bf75-762f-46ef-8304-aacdb248bc5b.jpg?1",
             "name": "Skygames",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature gains flying until end of turn. Activate this ability only any time you could cast a sorcery.\"",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "babc3fdc-8296-5b65-96ff-8c7e16661230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7267fcec-0879-4743-a45f-35057ccb2596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7267fcec-0879-4743-a45f-35057ccb2596.jpg?1",
             "name": "Spell Rupture",
             "text": "Counter target spell unless its controller pays {X}, where X is the greatest power among creatures you control.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "7caa711f-6581-5858-815a-f5b55c9d3129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e058447-7cee-4670-b86b-c95bd6b68144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e058447-7cee-4670-b86b-c95bd6b68144.jpg?1",
             "name": "Stolen Identity",
             "text": "Put a token onto the battlefield that's a copy of target artifact or creature.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "746dec76-537b-5614-8e7f-c3146c4686ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8e4142-7c46-4d2f-aaa6-6410f323d9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8e4142-7c46-4d2f-aaa6-6410f323d9f0.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "d696c22d-5fdd-579a-ba6a-c11f0e126be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611d0e10-e767-4e66-b1f1-02f1624fab2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611d0e10-e767-4e66-b1f1-02f1624fab2b.jpg?1",
             "name": "Voidwalk",
             "text": "Exile target creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "b3596e45-6339-5780-90c9-5019cb33b3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249ca81-bd8d-4d3d-81d6-15e8d669c416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b249ca81-bd8d-4d3d-81d6-15e8d669c416.jpg?1",
             "name": "Way of the Thief",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nEnchanted creature is unblockable as long as you control a Gate.",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "a295ce0b-0c89-5196-b9ba-3584335d42f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a3f05-864d-401d-a2f1-5f58358fe089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8a3f05-864d-401d-a2f1-5f58358fe089.jpg?1",
             "name": "Balustrade Spy",
             "text": "Flying\nWhen Balustrade Spy enters the battlefield, target player reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "83d849a7-2e83-57d3-bf6d-d4a1ed199f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d233c6bc-c4dd-482d-b0f4-87359acab7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d233c6bc-c4dd-482d-b0f4-87359acab7cb.jpg?1",
             "name": "Basilica Screecher",
             "text": "Flying\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "f92a3c70-8fee-5bf3-b35b-d7226c7d6fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2384356-0a62-499a-8b28-085974331368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2384356-0a62-499a-8b28-085974331368.jpg?1",
             "name": "Contaminated Ground",
             "text": "Enchant land\nEnchanted land is a Swamp.\nWhenever enchanted land becomes tapped, its controller loses 2 life.",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "811d3657-606e-5b5e-83bd-336de23b00f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84234e51-e5d6-43d9-89d0-f0398fc6b7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84234e51-e5d6-43d9-89d0-f0398fc6b7fd.jpg?1",
             "name": "Corpse Blockade",
             "text": "Defender\nSacrifice another creature: Corpse Blockade gains deathtouch until end of turn.",
             "colours": [
@@ -2028,7 +2028,7 @@
         },
         {
             "id": "a029ea82-d13c-5e89-8df4-b9a68c7c95c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3795a4e7-646f-4bb7-b154-2610eb740e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3795a4e7-646f-4bb7-b154-2610eb740e8d.jpg?1",
             "name": "Crypt Ghast",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever you tap a Swamp for mana, add {B} to your mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "7d636893-17aa-553b-9b1f-6db7b20d2008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f69c6f-522d-42c8-be7c-ea6d7ffb6a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f69c6f-522d-42c8-be7c-ea6d7ffb6a90.jpg?1",
             "name": "Death's Approach",
             "text": "Enchant creature\nEnchanted creature gets -X/-X, where X is the number of creature cards in its controller's graveyard.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "ae3c76af-8641-5f57-b41f-6002c67e6b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c42ebd-114a-430d-b3a4-ff2fb3093bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c42ebd-114a-430d-b3a4-ff2fb3093bf5.jpg?1",
             "name": "Devour Flesh",
             "text": "Target player sacrifices a creature, then gains life equal to that creature's toughness.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "7bbdb017-92b2-5bb7-8895-568e749ce16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46e83d3-c66d-42fb-8435-b6c448db01ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46e83d3-c66d-42fb-8435-b6c448db01ae.jpg?1",
             "name": "Dying Wish",
             "text": "Enchant creature you control\nWhen enchanted creature dies, target player loses X life and you gain X life, where X is its power.",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "c246c024-f040-5d9f-b4e9-12580748d21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33fc15-3a4f-48bc-be7c-fdec1cb49c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33fc15-3a4f-48bc-be7c-fdec1cb49c10.jpg?1",
             "name": "Gateway Shade",
             "text": "{B}: Gateway Shade gets +1/+1 until end of turn.\nTap an untapped Gate you control: Gateway Shade gets +2/+2 until end of turn.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "8070ed06-c052-5b7f-a8c9-1c0f030a1d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d0f6e-e7bd-4206-a0da-1c9c203a73f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26d0f6e-e7bd-4206-a0da-1c9c203a73f2.jpg?1",
             "name": "Grisly Spectacle",
             "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "faf78a13-4585-53bc-8c96-3756ffd7a281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830c7c77-20c4-429f-88c7-b85ab7a0e38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830c7c77-20c4-429f-88c7-b85ab7a0e38b.jpg?1",
             "name": "Gutter Skulk",
             "text": "",
             "colours": [
@@ -2263,7 +2263,7 @@
         },
         {
             "id": "82a0b21a-2bf3-59d6-a3e0-e4d0114de55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d36c9d-967e-42dc-890c-0485b12f704f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d36c9d-967e-42dc-890c-0485b12f704f.jpg?1",
             "name": "Horror of the Dim",
             "text": "{U}: Horror of the Dim gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "e114c72c-06fe-5c6b-bf2b-fcf7c7e69f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989a68c1-3b76-4c2d-9db3-23c45be3f9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989a68c1-3b76-4c2d-9db3-23c45be3f9ff.jpg?1",
             "name": "Illness in the Ranks",
             "text": "Creature tokens get -1/-1.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "37b9b0ce-7abb-56a3-ac78-8d94e32c5aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a4d87d-b844-4f20-8b14-4fd32c53dea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a4d87d-b844-4f20-8b14-4fd32c53dea5.jpg?1",
             "name": "Killing Glare",
             "text": "Destroy target creature with power X or less.",
             "colours": [
@@ -2362,7 +2362,7 @@
         },
         {
             "id": "200865c3-37bb-5e7b-a419-60239bda0ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b83fe5-fd00-4532-bc67-07836abfc99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b83fe5-fd00-4532-bc67-07836abfc99c.jpg?1",
             "name": "Lord of the Void",
             "text": "Flying\nWhenever Lord of the Void deals combat damage to a player, exile the top seven cards of that player's library, then put a creature card from among them onto the battlefield under your control.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "d3241085-4130-5aa2-b9d4-f164fec00a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076e7c58-a6fe-4882-8f8d-698be9a7f22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076e7c58-a6fe-4882-8f8d-698be9a7f22d.jpg?1",
             "name": "Mental Vapors",
             "text": "Target player discards a card.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "caa808f4-5de9-5f2d-8e50-576787f582ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df40471-1118-4429-83bf-8225ea50b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df40471-1118-4429-83bf-8225ea50b69f.jpg?1",
             "name": "Midnight Recovery",
             "text": "Return target creature card from your graveyard to your hand.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "52ba9b7e-9761-5e35-8048-2136880d97c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727bd1-9415-408a-99de-dd992e26e767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727bd1-9415-408a-99de-dd992e26e767.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may put a 1/1 black Rat creature token onto the battlefield.\nRats you control have deathtouch.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "10671ab6-0121-52ee-813f-2e36322aa87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0865cd-d9b4-43ea-87d2-ad5c65fc0459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0865cd-d9b4-43ea-87d2-ad5c65fc0459.jpg?1",
             "name": "Sepulchral Primordial",
             "text": "Intimidate\nWhen Sepulchral Primordial enters the battlefield, for each opponent, you may put up to one target creature card from that player's graveyard onto the battlefield under your control.",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "011ccfdb-3149-52a6-b57e-9720ab1b3d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985997ae-59bc-49d7-87ca-e63ed9706fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985997ae-59bc-49d7-87ca-e63ed9706fdf.jpg?1",
             "name": "Shadow Alley Denizen",
             "text": "Whenever another black creature enters the battlefield under your control, target creature gains intimidate until end of turn. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2564,7 +2564,7 @@
         },
         {
             "id": "04f6262b-a81e-5a45-b970-983208ae7f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497fbf4-cf09-4028-af16-349ed12ca360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497fbf4-cf09-4028-af16-349ed12ca360.jpg?1",
             "name": "Shadow Slice",
             "text": "Target opponent loses 3 life.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "852268ea-ce0b-562c-97e4-def7e2e512a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51528a3e-beba-47f8-a524-ad99b1fec308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51528a3e-beba-47f8-a524-ad99b1fec308.jpg?1",
             "name": "Slate Street Ruffian",
             "text": "Whenever Slate Street Ruffian becomes blocked, defending player discards a card.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "b98227f8-711e-5666-a1d9-19e0ebe56123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667871d3-0d1b-496b-afbd-7504989798e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667871d3-0d1b-496b-afbd-7504989798e4.jpg?1",
             "name": "Smog Elemental",
             "text": "Flying\nCreatures with flying your opponents control get -1/-1.",
             "colours": [
@@ -2665,7 +2665,7 @@
         },
         {
             "id": "77aebac0-58c8-5379-a89f-602d0856e044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde6ee2e-a114-4935-8345-d3e264f9fc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde6ee2e-a114-4935-8345-d3e264f9fc26.jpg?1",
             "name": "Syndicate Enforcer",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "50e02e85-171c-5676-a1cb-627b887e1725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38dfb08-ab41-4759-9967-b5a25f18518a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38dfb08-ab41-4759-9967-b5a25f18518a.jpg?1",
             "name": "Thrull Parasite",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\n{T}, Pay 2 life: Remove a counter from target nonland permanent.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "09b06bba-0c62-5b5f-acce-5ab08ae72b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0f73-cfb0-41d9-b4eb-09c605112a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0f73-cfb0-41d9-b4eb-09c605112a13.jpg?1",
             "name": "Undercity Informer",
             "text": "{1}, Sacrifice a creature: Target player reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "982abb54-d16b-5386-8a07-76687a18a9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b25d3bc-33e9-4d1a-855d-38580e67b6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b25d3bc-33e9-4d1a-855d-38580e67b6cc.jpg?1",
             "name": "Undercity Plague",
             "text": "Target player loses 1 life, discards a card, then sacrifices a permanent.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "736996b4-3053-5055-aace-11bdbe3953a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04644ba-5962-4e64-bc53-92941c5b6715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04644ba-5962-4e64-bc53-92941c5b6715.jpg?1",
             "name": "Wight of Precinct Six",
             "text": "Wight of Precinct Six gets +1/+1 for each creature card in your opponents' graveyards.",
             "colours": [
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "6e2b6aad-f9a0-5c6b-a667-a73f4917fdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04c8c6f-14e9-427c-918e-208ccd39ec4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04c8c6f-14e9-427c-918e-208ccd39ec4a.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "a8fe51ff-e2ee-5f70-afc5-f153e7b8a440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1675f2-e950-4f3c-9dd3-29ead615ff23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1675f2-e950-4f3c-9dd3-29ead615ff23.jpg?1",
             "name": "Bomber Corps",
             "text": "Battalion \u2014 Whenever Bomber Corps and at least two other creatures attack, Bomber Corps deals 1 damage to target creature or player.",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "b210a41a-6df9-51b9-a3a9-b38331019c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf10ce-69e0-4984-91a3-f65df919830d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf10ce-69e0-4984-91a3-f65df919830d.jpg?1",
             "name": "Cinder Elemental",
             "text": "{X}{R}, {T}, Sacrifice Cinder Elemental: Cinder Elemental deals X damage to target creature or player.",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "039b8af0-7436-590f-a9e5-a2dfee7ffd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323c86c-73bd-4e23-9f80-54bf5c1dd0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323c86c-73bd-4e23-9f80-54bf5c1dd0bc.jpg?1",
             "name": "Crackling Perimeter",
             "text": "Tap an untapped Gate you control: Crackling Perimeter deals 1 damage to each opponent.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "8409a946-77a4-55c0-9719-644dba661d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d9cab-b07b-456b-9562-7ea7f6bec7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d9cab-b07b-456b-9562-7ea7f6bec7f3.jpg?1",
             "name": "Ember Beast",
             "text": "Ember Beast can't attack or block alone.",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "89e0b5c5-b4fb-5860-bf9b-c50a16c883ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc2f22-4500-4c74-a1a2-51d8238c1d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc2f22-4500-4c74-a1a2-51d8238c1d16.jpg?1",
             "name": "Firefist Striker",
             "text": "Battalion \u2014 Whenever Firefist Striker and at least two other creatures attack, target creature can't block this turn.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "eaf56bb3-2a64-5632-a62e-7d1bc1bf33ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb550d0c-2261-4f41-a2b1-d185f0bce86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb550d0c-2261-4f41-a2b1-d185f0bce86a.jpg?1",
             "name": "Five-Alarm Fire",
             "text": "Whenever a creature you control deals combat damage, put a blaze counter on Five-Alarm Fire.\nRemove five blaze counters from Five-Alarm Fire: Five-Alarm Fire deals 5 damage to target creature or player.",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "b6fa94fd-d44d-54b7-aec2-5898c37a7196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0befed63-07ba-4728-9078-57bbccbeeeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0befed63-07ba-4728-9078-57bbccbeeeb1.jpg?1",
             "name": "Foundry Street Denizen",
             "text": "Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "2ec932a2-0eb1-50d1-bde3-73ddadc836af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeea013-1cf8-4c77-a097-aa69e141e3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeea013-1cf8-4c77-a097-aa69e141e3f4.jpg?1",
             "name": "Furious Resistance",
             "text": "Target blocking creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "7d88b6d9-c6f0-5326-ad91-dc643c4485d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3401f-935b-45ce-b1e6-300a5d9dfd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3401f-935b-45ce-b1e6-300a5d9dfd4f.jpg?1",
             "name": "Hellkite Tyrant",
             "text": "Flying, trample\nWhenever Hellkite Tyrant deals combat damage to a player, gain control of all artifacts that player controls.\nAt the beginning of your upkeep, if you control twenty or more artifacts, you win the game.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "7e995515-e099-5f4a-8256-a8321e9aaf5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156941e7-9169-47aa-b04d-37ca78c54f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156941e7-9169-47aa-b04d-37ca78c54f7c.jpg?1",
             "name": "Hellraiser Goblin",
             "text": "Creatures you control have haste and attack each combat if able.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "39c8355f-26e9-533d-9561-c6bc440688b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6535816-8fa4-4c8b-8677-ac80f769f528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6535816-8fa4-4c8b-8677-ac80f769f528.jpg?1",
             "name": "Homing Lightning",
             "text": "Homing Lightning deals 4 damage to target creature and each other creature with the same name as that creature.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "2e6de5bd-c4ed-540d-bcc8-95d01d23feff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47f639e-4635-4c26-bb2a-4925f0582c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47f639e-4635-4c26-bb2a-4925f0582c21.jpg?1",
             "name": "Legion Loyalist",
             "text": "Haste\nBattalion \u2014 Whenever Legion Loyalist and at least two other creatures attack, creatures you control gain first strike and trample until end of turn and can't be blocked by creature tokens this turn.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "ea117600-17da-5065-8656-b23c380d5c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2667-40f6-4c1c-af81-3e45d2437d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef2667-40f6-4c1c-af81-3e45d2437d5f.jpg?1",
             "name": "Madcap Skills",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and can't be blocked except by two or more creatures.",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "8d1d2b60-3179-578f-b171-017638c169a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45498dbd-a512-4299-800b-06c15a4fd94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45498dbd-a512-4299-800b-06c15a4fd94e.jpg?1",
             "name": "Mark for Death",
             "text": "Target creature an opponent controls blocks this turn if able. Untap that creature. Other creatures that player controls can't block this turn.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "2fe94e9e-4c1f-5e52-aa53-dcf95a02ca2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b16fbd8-fb62-4f75-92b3-a6295d95b327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b16fbd8-fb62-4f75-92b3-a6295d95b327.jpg?1",
             "name": "Massive Raid",
             "text": "Massive Raid deals damage to target creature or player equal to the number of creatures you control.",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "53271b3f-498f-5fe9-aceb-f60f2f27a4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5c7e2-f4da-4cee-a7d0-80b29bb73acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5c7e2-f4da-4cee-a7d0-80b29bb73acd.jpg?1",
             "name": "Molten Primordial",
             "text": "Haste\nWhen Molten Primordial enters the battlefield, for each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "3148644d-45e6-585b-a98d-26882e6e2dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ca502f-73a3-42f3-b7ad-f69aa239900a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ca502f-73a3-42f3-b7ad-f69aa239900a.jpg?1",
             "name": "Mugging",
             "text": "Mugging deals 2 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -3436,7 +3436,7 @@
         },
         {
             "id": "49cb7a50-09e8-5eb0-97ca-36b0df3aa3aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d5daf-404d-46e9-b622-e89a1f55e908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d5daf-404d-46e9-b622-e89a1f55e908.jpg?1",
             "name": "Ripscale Predator",
             "text": "Ripscale Predator can't be blocked except by two or more creatures.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "4a0d6748-4df1-5c12-a136-e392bb3e5108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ac6bde-1fef-45f4-b505-80a66b03140a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ac6bde-1fef-45f4-b505-80a66b03140a.jpg?1",
             "name": "Scorchwalker",
             "text": "Bloodrush \u2014 {1}{R}{R}, Discard Scorchwalker: Target attacking creature gets +5/+1 until end of turn.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "476425dd-8896-557d-806e-7ca653fb0f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4f9b6c-3ba9-4f4f-8135-f5236195e507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4f9b6c-3ba9-4f4f-8135-f5236195e507.jpg?1",
             "name": "Skinbrand Goblin",
             "text": "Bloodrush \u2014 {R}, Discard Skinbrand Goblin: Target attacking creature gets +2/+1 until end of turn.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "61b3ae38-ad0a-54b6-8a26-aad0567cf6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068a146-f6fe-46f3-a42e-822fbc3502e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068a146-f6fe-46f3-a42e-822fbc3502e6.jpg?1",
             "name": "Skullcrack",
             "text": "Players can't gain life this turn. Damage can't be prevented this turn. Skullcrack deals 3 damage to target player.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "928ad2e9-9272-5f1e-8ea9-a630a2ccd6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10da484-db67-4afc-90ef-6caf7d2e3a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10da484-db67-4afc-90ef-6caf7d2e3a75.jpg?1",
             "name": "Structural Collapse",
             "text": "Target player sacrifices an artifact and a land. Structural Collapse deals 2 damage to that player.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "d2ac5556-c442-5da1-a774-e3dbf6b372ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1f543b-2222-4ef5-b4f7-2c3d2ea27fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1f543b-2222-4ef5-b4f7-2c3d2ea27fdc.jpg?1",
             "name": "Tin Street Market",
             "text": "Enchant land\nEnchanted land has \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "80313df5-ca0f-5d07-9217-a20d18227236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68e9280-cb1a-48e1-a91e-217e101f19c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68e9280-cb1a-48e1-a91e-217e101f19c5.jpg?1",
             "name": "Towering Thunderfist",
             "text": "{W}: Towering Thunderfist gains vigilance until end of turn.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "a03e9272-4b67-5bdc-8f84-cb79b58d31c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dd72d5-548a-4b0e-95bb-e6b8d2de0fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dd72d5-548a-4b0e-95bb-e6b8d2de0fbe.jpg?1",
             "name": "Viashino Shanktail",
             "text": "First strike\nBloodrush \u2014 {2}{R}, Discard Viashino Shanktail: Target attacking creature gets +3/+1 and gains first strike until end of turn.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "044345d6-7cb8-5c5a-9a00-2049f0c6b521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a5f801-9e55-4e14-85b0-5719521cd9d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a5f801-9e55-4e14-85b0-5719521cd9d6.jpg?1",
             "name": "Warmind Infantry",
             "text": "Battalion \u2014 Whenever Warmind Infantry and at least two other creatures attack, Warmind Infantry gets +2/+0 until end of turn.",
             "colours": [
@@ -3743,7 +3743,7 @@
         },
         {
             "id": "2a0b7325-b5cb-5ee0-871d-8d547704fc99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f1a27c-c576-4c34-873f-6faf020c2773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f1a27c-c576-4c34-873f-6faf020c2773.jpg?1",
             "name": "Wrecking Ogre",
             "text": "Double strike\nBloodrush \u2014 {3}{R}{R}, Discard Wrecking Ogre: Target attacking creature gets +3/+3 and gains double strike until end of turn.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "189efa7c-ff59-5c95-99f5-c1e88531a919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3c0c43-2d6d-49b8-a112-07611a23ae69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3c0c43-2d6d-49b8-a112-07611a23ae69.jpg?1",
             "name": "Adaptive Snapjaw",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3813,7 +3813,7 @@
         },
         {
             "id": "22a36c33-8c3e-50f4-afdf-c31de32342f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc42ca6-db90-41d0-8a4b-3217fb2c114c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc42ca6-db90-41d0-8a4b-3217fb2c114c.jpg?1",
             "name": "Alpha Authority",
             "text": "Enchant creature\nEnchanted creature has hexproof and can't be blocked by more than one creature.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "b1397a7c-1175-5fef-b1d8-701336901330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbd617-9f2e-4882-b8f0-dfc2fced2281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cbd617-9f2e-4882-b8f0-dfc2fced2281.jpg?1",
             "name": "Burst of Strength",
             "text": "Put a +1/+1 counter on target creature and untap it.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "f5fbabd1-6e66-5a5e-8187-8e7f3b8b99ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b459a988-97b0-4370-b89a-2565f8721b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b459a988-97b0-4370-b89a-2565f8721b60.jpg?1",
             "name": "Crocanura",
             "text": "Reach (This creature can block creatures with flying.)\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3914,7 +3914,7 @@
         },
         {
             "id": "f85e2c35-bb4a-590e-aa1b-484db366664b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eacc64-f418-4df0-bd8a-6b0036d0d2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7eacc64-f418-4df0-bd8a-6b0036d0d2a1.jpg?1",
             "name": "Crowned Ceratok",
             "text": "Trample\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "73b7d35d-b2a6-5d45-a07e-d9bbc2624d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c62b3ee-db2b-45c3-87d5-5d917ea4baeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c62b3ee-db2b-45c3-87d5-5d917ea4baeb.jpg?1",
             "name": "Disciple of the Old Ways",
             "text": "{R}: Disciple of the Old Ways gains first strike until end of turn.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "981e4517-b3e6-5aeb-b50b-42937a3408a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc1d8d0-bb43-4962-ad29-bb6478aa986b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc1d8d0-bb43-4962-ad29-bb6478aa986b.jpg?1",
             "name": "Experiment One",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nRemove two +1/+1 counters from Experiment One: Regenerate Experiment One.",
             "colours": [
@@ -4019,7 +4019,7 @@
         },
         {
             "id": "f5fab74a-f8f0-5ad1-be76-5a41874034a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6527d61-e9d3-44d0-833e-19c072309270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6527d61-e9d3-44d0-833e-19c072309270.jpg?1",
             "name": "Forced Adaptation",
             "text": "Enchant creature\nAt the beginning of your upkeep, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "366fde79-33fe-5ae5-9748-31b959d633b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae725f-e582-4377-a855-51af035cdac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae725f-e582-4377-a855-51af035cdac3.jpg?1",
             "name": "Giant Adephage",
             "text": "Trample\nWhenever Giant Adephage deals combat damage to a player, put a token onto the battlefield that's a copy of Giant Adephage.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "a9f6b2e5-56ad-518a-b869-408718c05a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e825cb2d-98d7-423d-9ba1-b4d04027027e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e825cb2d-98d7-423d-9ba1-b4d04027027e.jpg?1",
             "name": "Greenside Watcher",
             "text": "{T}: Untap target Gate.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "6ca3f7fa-713b-5769-9090-eb8491406d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6345376a-3d2d-4fff-9430-5e90a96e2f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6345376a-3d2d-4fff-9430-5e90a96e2f0f.jpg?1",
             "name": "Gyre Sage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\n{T}: Add {G} to your mana pool for each +1/+1 counter on Gyre Sage.",
             "colours": [
@@ -4157,7 +4157,7 @@
         },
         {
             "id": "bc853ac1-054b-548c-b67d-a13a42c03ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b85a09-6d43-4798-8164-131d35b65836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b85a09-6d43-4798-8164-131d35b65836.jpg?1",
             "name": "Hindervines",
             "text": "Prevent all combat damage that would be dealt this turn by creatures with no +1/+1 counters on them.",
             "colours": [
@@ -4189,7 +4189,7 @@
         },
         {
             "id": "83cf41cb-58ea-5daa-a9f4-77bec644a75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95be874-93c0-4e05-9e5a-fe8f38bcb445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95be874-93c0-4e05-9e5a-fe8f38bcb445.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "cc8ef28b-fa86-5fcd-9617-62c48e598714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d0584-89d2-499b-b6c2-2425c4ffcd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d0584-89d2-499b-b6c2-2425c4ffcd13.jpg?1",
             "name": "Miming Slime",
             "text": "Put an X/X green Ooze creature token onto the battlefield, where X is the greatest power among creatures you control.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "3ee506e1-8a6f-5c5c-8d02-8126146ea746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf36ca-56ca-4987-ac93-248d43c9c401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf36ca-56ca-4987-ac93-248d43c9c401.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "de8eea8f-b20f-51c4-a51e-3505f7ae4cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9554369-7961-4cea-9da0-a1235805a26a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9554369-7961-4cea-9da0-a1235805a26a.jpg?1",
             "name": "Ooze Flux",
             "text": "{1}{G}, Remove one or more +1/+1 counters from among creatures you control: Put an X/X green Ooze creature token onto the battlefield, where X is the number of +1/+1 counters removed this way.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "17787951-6808-50dc-b4ab-79696afa114f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47324ab7-df78-4859-be0b-2eef5d4f8082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47324ab7-df78-4859-be0b-2eef5d4f8082.jpg?1",
             "name": "Predator's Rapport",
             "text": "Choose target creature you control. You gain life equal to that creature's power plus its toughness.",
             "colours": [
@@ -4352,7 +4352,7 @@
         },
         {
             "id": "64a86440-5b54-51a5-9bb6-986ea92fb40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57335b5-30e2-431f-ab50-d5f1981783c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57335b5-30e2-431f-ab50-d5f1981783c3.jpg?1",
             "name": "Rust Scarab",
             "text": "Whenever Rust Scarab becomes blocked, you may destroy target artifact or enchantment defending player controls.",
             "colours": [
@@ -4386,7 +4386,7 @@
         },
         {
             "id": "6234ea25-15ac-57b8-8d8f-736500c8ca63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964c88d3-3141-44ab-8856-44a3f08331ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964c88d3-3141-44ab-8856-44a3f08331ea.jpg?1",
             "name": "Scab-Clan Charger",
             "text": "Bloodrush \u2014 {1}{G}, Discard Scab-Clan Charger: Target attacking creature gets +2/+4 until end of turn.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "a7e9682e-c5ce-50d4-acba-902af50acd8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3da4b8-9dd6-455d-b24a-3d0207ae5ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3da4b8-9dd6-455d-b24a-3d0207ae5ee8.jpg?1",
             "name": "Serene Remembrance",
             "text": "Shuffle Serene Remembrance and up to three target cards from a single graveyard into their owners' libraries.",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "ac290a91-0e75-5fb3-81f6-a674841e93e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2dcafd-eb72-4f3a-9c1c-ba17fe30bf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2dcafd-eb72-4f3a-9c1c-ba17fe30bf0f.jpg?1",
             "name": "Skarrg Goliath",
             "text": "Trample\nBloodrush \u2014 {5}{G}{G}, Discard Skarrg Goliath: Target attacking creature gets +9/+9 and gains trample until end of turn.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "b5501360-ef2f-563e-8277-bfc1def32e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3fcc7a-ff5b-4695-aa86-9166f6cba565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3fcc7a-ff5b-4695-aa86-9166f6cba565.jpg?1",
             "name": "Slaughterhorn",
             "text": "Bloodrush \u2014 {G}, Discard Slaughterhorn: Target attacking creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "31f51b71-ff55-5c4a-8934-cf3802694b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428b0d43-94c9-4f7f-b042-ea63f88ac697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428b0d43-94c9-4f7f-b042-ea63f88ac697.jpg?1",
             "name": "Spire Tracer",
             "text": "Spire Tracer can't be blocked except by creatures with flying or reach.",
             "colours": [
@@ -4556,7 +4556,7 @@
         },
         {
             "id": "60bbf3f1-2ceb-56b1-a1e7-8a02ceef1a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0483c869-38dc-4b0b-82f3-dd08a1ab985f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0483c869-38dc-4b0b-82f3-dd08a1ab985f.jpg?1",
             "name": "Sylvan Primordial",
             "text": "Reach\nWhen Sylvan Primordial enters the battlefield, for each opponent, destroy target noncreature permanent that player controls. For each permanent destroyed this way, search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "9ed78783-af34-5a81-ad69-45d6d093888c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857e1eb2-f3f2-4c7f-9965-da9d7e385223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857e1eb2-f3f2-4c7f-9965-da9d7e385223.jpg?1",
             "name": "Tower Defense",
             "text": "Creatures you control get +0/+5 and gain reach until end of turn.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "86b45483-51ae-5bdf-ab90-1d4cbafc6c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59109a0-fdab-49cb-bbf6-d405de4d1645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59109a0-fdab-49cb-bbf6-d405de4d1645.jpg?1",
             "name": "Verdant Haven",
             "text": "Enchant land\nWhen Verdant Haven enters the battlefield, you gain 2 life.\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "ceed2fb9-ec96-59ae-8ce0-dc7e0ba856e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a5b2b8-3890-485f-8731-8f178a2da3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a5b2b8-3890-485f-8731-8f178a2da3d7.jpg?1",
             "name": "Wasteland Viper",
             "text": "Deathtouch\nBloodrush \u2014 {G}, Discard Wasteland Viper: Target attacking creature gets +1/+2 and gains deathtouch until end of turn.",
             "colours": [
@@ -4690,7 +4690,7 @@
         },
         {
             "id": "b07568f8-5b1f-5aca-89b5-79a2434d87b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a93a1-4442-4d5b-ad7a-136b87b5f7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713a93a1-4442-4d5b-ad7a-136b87b5f7ab.jpg?1",
             "name": "Wildwood Rebirth",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "fda5b1c5-8c98-55b7-a77d-6cf167ce6dbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce441759-cd4c-4bcc-925e-08e8b60853c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce441759-cd4c-4bcc-925e-08e8b60853c0.jpg?1",
             "name": "Alms Beast",
             "text": "Creatures blocking or blocked by Alms Beast have lifelink.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "37a44282-ab4f-5509-af5a-0aebe83c868f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43675ed7-ece1-4414-965e-9ebadcbf3dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43675ed7-ece1-4414-965e-9ebadcbf3dfb.jpg?1",
             "name": "Assemble the Legion",
             "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then put a 1/1 red and white Soldier creature token with haste onto the battlefield for each muster counter on Assemble the Legion.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "33cae8f7-d7ee-5bfe-a5f4-fb522799dbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18e35-05e4-4bfc-b32b-c3e71c95a71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18e35-05e4-4bfc-b32b-c3e71c95a71d.jpg?1",
             "name": "Aurelia, the Warleader",
             "text": "Flying, vigilance, haste\nWhenever Aurelia, the Warleader attacks for the first time each turn, untap all creatures you control. After this phase, there is an additional combat phase.",
             "colours": [
@@ -4830,7 +4830,7 @@
         },
         {
             "id": "a195ee3b-6b98-5c42-8a9d-ff093ec7935c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3465b6-ee7f-4553-bbf1-85fae9734b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3465b6-ee7f-4553-bbf1-85fae9734b67.jpg?1",
             "name": "Aurelia's Fury",
             "text": "Aurelia's Fury deals X damage divided as you choose among any number of target creatures and/or players. Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.",
             "colours": [
@@ -4864,7 +4864,7 @@
         },
         {
             "id": "621aff12-468b-593c-828a-dca8b58fd1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996df7f-70f5-412c-9573-9512e4e131ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996df7f-70f5-412c-9573-9512e4e131ac.jpg?1",
             "name": "Bane Alley Broker",
             "text": "{T}: Draw a card, then exile a card from your hand face down.\nYou may look at cards exiled with Bane Alley Broker.\n{U}{B}, {T}: Return a card exiled with Bane Alley Broker to its owner's hand.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "cb451162-23bf-5969-8473-92da77538c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000b4e8-7887-454e-9d52-211516613dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2000b4e8-7887-454e-9d52-211516613dd0.jpg?1",
             "name": "Biovisionary",
             "text": "At the beginning of the end step, if you control four or more creatures named Biovisionary, you win the game.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "f5a22037-cf5a-54e8-bf1b-1e3e5907244c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644c60f-7d06-4026-bcf3-df054701ca0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644c60f-7d06-4026-bcf3-df054701ca0a.jpg?1",
             "name": "Borborygmos Enraged",
             "text": "Trample\nWhenever Borborygmos Enraged deals combat damage to a player, reveal the top three cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.\nDiscard a land card: Borborygmos Enraged deals 3 damage to target creature or player.",
             "colours": [
@@ -4976,7 +4976,7 @@
         },
         {
             "id": "7db0102a-5a85-55d8-9f87-d5c0adf08ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ddf9cc-40a7-4b4f-bb51-b08171453c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ddf9cc-40a7-4b4f-bb51-b08171453c9a.jpg?1",
             "name": "Boros Charm",
             "text": "Choose one \u2014 Boros Charm deals 4 damage to target player; or permanents you control are indestructible this turn; or target creature gains double strike until end of turn.",
             "colours": [
@@ -5010,7 +5010,7 @@
         },
         {
             "id": "961594a7-ba1a-55cb-af05-31d8bf916c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef30a570-b988-42e8-8910-41fe39ffa260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef30a570-b988-42e8-8910-41fe39ffa260.jpg?1",
             "name": "Call of the Nightwing",
             "text": "Put a 1/1 blue and black Horror creature token with flying onto the battlefield.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -5044,7 +5044,7 @@
         },
         {
             "id": "c95d3247-d1a1-5733-9057-c663169f52ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcfbc0-1401-4e5e-8145-c8936c4ff725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bcfbc0-1401-4e5e-8145-c8936c4ff725.jpg?1",
             "name": "Cartel Aristocrat",
             "text": "Sacrifice another creature: Cartel Aristocrat gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "49ffa3c8-6d2e-5daf-8f1b-9ac2b5b37fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa05298-9c94-4179-b75a-49ee2ca92920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa05298-9c94-4179-b75a-49ee2ca92920.jpg?1",
             "name": "Clan Defiance",
             "text": "Choose one or more \u2014 Clan Defiance deals X damage to target creature with flying; Clan Defiance deals X damage to target creature without flying; and/or Clan Defiance deals X damage to target player.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "fb67069b-7732-5c85-8b0c-5c3fb2e61a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6354de66-f7f8-4e33-98d0-52624d3d7828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6354de66-f7f8-4e33-98d0-52624d3d7828.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "2c2b8b80-6b37-5b47-9d7b-840279708c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cfc3c5-6d69-443e-a506-76b94178979b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81cfc3c5-6d69-443e-a506-76b94178979b.jpg?1",
             "name": "Deathpact Angel",
             "text": "Flying\nWhen Deathpact Angel dies, put a 1/1 white and black Cleric creature token onto the battlefield. It has \"{3}{W}{B}{B}, {T}, Sacrifice this creature: Return a card named Deathpact Angel from your graveyard to the battlefield.\"",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "f5fb364c-0acc-52fd-9c43-2a3a3f133260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f4cfa7-8ee4-4a85-9e6a-65a7541f62c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f4cfa7-8ee4-4a85-9e6a-65a7541f62c1.jpg?1",
             "name": "Dimir Charm",
             "text": "Choose one \u2014 Counter target sorcery spell; or destroy target creature with power 2 or less; or look at the top three cards of target player's library, then put one back and the rest into that player's graveyard.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "8f43a230-5467-5534-a678-0167a4001867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398df5e6-6bda-467a-81e2-91be7e21d715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398df5e6-6bda-467a-81e2-91be7e21d715.jpg?1",
             "name": "Dinrova Horror",
             "text": "When Dinrova Horror enters the battlefield, return target permanent to its owner's hand, then that player discards a card.",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "8cef3768-7062-5b98-87ea-243eaf4facba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b48170-99dd-440f-9954-fc229d6094d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b48170-99dd-440f-9954-fc229d6094d3.jpg?1",
             "name": "Domri Rade",
             "text": "+1: Look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand.\n-2: Target creature you control fights another target creature.\n-7: You get an emblem with \"Creatures you control have double strike, trample, hexproof, and haste.\"",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "abfa904b-ca58-57bb-b143-acdfd373927f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016d1d17-ba5c-4168-9a3d-232bdcc98c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/016d1d17-ba5c-4168-9a3d-232bdcc98c80.jpg?1",
             "name": "Drakewing Krasis",
             "text": "Flying, trample",
             "colours": [
@@ -5332,7 +5332,7 @@
         },
         {
             "id": "ead8b7f3-6de1-5b68-94dc-95286e61a5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1509ff-387e-4ccd-bda0-86e8738a98fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1509ff-387e-4ccd-bda0-86e8738a98fb.jpg?1",
             "name": "Duskmantle Guildmage",
             "text": "{1}{U}{B}: Whenever a card is put into an opponent's graveyard from anywhere this turn, that player loses 1 life.\n{2}{U}{B}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "eea2ffee-b527-5cc7-b045-b58aa4f234a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63711861-87e0-4a63-8b7b-f834aa5f3f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63711861-87e0-4a63-8b7b-f834aa5f3f18.jpg?1",
             "name": "Duskmantle Seer",
             "text": "Flying\nAt the beginning of your upkeep, each player reveals the top card of his or her library, loses life equal to that card's converted mana cost, then puts it into his or her hand.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "57e09939-73cc-5e9c-a681-7a5049580dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd62e422-e5e2-4736-9ed3-d2dc693f6f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd62e422-e5e2-4736-9ed3-d2dc693f6f8f.jpg?1",
             "name": "Elusive Krasis",
             "text": "Elusive Krasis is unblockable.\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -5443,7 +5443,7 @@
         },
         {
             "id": "aa565831-8bc8-5bba-ae9d-ea5d9ad9b08d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2122586d-9b23-47c2-8b00-e673aa0310f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2122586d-9b23-47c2-8b00-e673aa0310f0.jpg?1",
             "name": "Executioner's Swing",
             "text": "Target creature that dealt damage this turn gets -5/-5 until end of turn.",
             "colours": [
@@ -5477,7 +5477,7 @@
         },
         {
             "id": "0c0b31c3-4d54-576d-826f-7662b703d4d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa311f1-f11e-492d-9f18-e7489f950be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa311f1-f11e-492d-9f18-e7489f950be7.jpg?1",
             "name": "Fathom Mage",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever a +1/+1 counter is placed on Fathom Mage, you may draw a card.",
             "colours": [
@@ -5514,7 +5514,7 @@
         },
         {
             "id": "6315c69c-f0ad-52ca-a24f-2570568f3242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c198-efdc-492a-9c52-76aac006de9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c198-efdc-492a-9c52-76aac006de9d.jpg?1",
             "name": "Firemane Avenger",
             "text": "Flying\nBattalion \u2014 Whenever Firemane Avenger and at least two other creatures attack, Firemane Avenger deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -5550,7 +5550,7 @@
         },
         {
             "id": "8c305c77-51d9-56a2-8d20-6d602f9f78a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f835f0-abba-402c-bdae-be03ad3fb658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f835f0-abba-402c-bdae-be03ad3fb658.jpg?1",
             "name": "Fortress Cyclops",
             "text": "Whenever Fortress Cyclops attacks, it gets +3/+0 until end of turn.\nWhenever Fortress Cyclops blocks, it gets +0/+3 until end of turn.",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "1096ed0b-ef32-58e8-b26f-4f4b64a47154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e39703-db78-4d3d-aacd-5396848253ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e39703-db78-4d3d-aacd-5396848253ed.jpg?1",
             "name": "Foundry Champion",
             "text": "When Foundry Champion enters the battlefield, it deals damage to target creature or player equal to the number of creatures you control.\n{R}: Foundry Champion gets +1/+0 until end of turn.\n{W}: Foundry Champion gets +0/+1 until end of turn.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "18abd15b-df71-50d6-87fa-c871f1fe6ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bce9a7-6215-43ff-b4d0-55f96f683aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bce9a7-6215-43ff-b4d0-55f96f683aba.jpg?1",
             "name": "Frenzied Tilling",
             "text": "Destroy target land. Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "5fda76c9-9320-5f4f-b961-ee372cd07967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382048ec-0bf5-49a5-90d5-f80fbda08962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382048ec-0bf5-49a5-90d5-f80fbda08962.jpg?1",
             "name": "Ghor-Clan Rampager",
             "text": "Trample\nBloodrush \u2014 {R}{G}, Discard Ghor-Clan Rampager: Target attacking creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5694,7 +5694,7 @@
         },
         {
             "id": "83cab24e-b201-5fc9-adcc-f0a1c6c4a10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4220348-f030-4639-b1a9-6f61ac6bb6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4220348-f030-4639-b1a9-6f61ac6bb6a8.jpg?1",
             "name": "Ground Assault",
             "text": "Ground Assault deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "7ede2cb4-37d2-5d4b-81a1-931c67740da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235afe5-0a6b-43c2-921c-18524cf032f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235afe5-0a6b-43c2-921c-18524cf032f1.jpg?1",
             "name": "Gruul Charm",
             "text": "Choose one \u2014 Creatures without flying can't block this turn; or gain control of all permanents you own; or Gruul Charm deals 3 damage to each creature with flying.",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "80706d20-fe62-5b12-9fbc-3ce209d1e48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ef367-7904-4e5c-a8b4-1fb62f951f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ef367-7904-4e5c-a8b4-1fb62f951f3e.jpg?1",
             "name": "Gruul Ragebeast",
             "text": "Whenever Gruul Ragebeast or another creature enters the battlefield under your control, that creature fights target creature an opponent controls.",
             "colours": [
@@ -5798,7 +5798,7 @@
         },
         {
             "id": "7f01d00c-9f5f-589a-94f9-995ca7aa19e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ff8d-6d7e-49f0-8d30-7f8c23db568b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ff8d-6d7e-49f0-8d30-7f8c23db568b.jpg?1",
             "name": "High Priest of Penance",
             "text": "Whenever High Priest of Penance is dealt damage, you may destroy target nonland permanent.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "fe2fa9ee-b8d3-5e2f-8f4b-fb6e248d0dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4e1f41-4aed-451b-bbaa-6cc6780cd6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4e1f41-4aed-451b-bbaa-6cc6780cd6c9.jpg?1",
             "name": "Hydroform",
             "text": "Target land becomes a 3/3 Elemental creature with flying until end of turn. It's still a land.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "950efa9c-5bf2-513f-8b20-c34f0a165b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3465cf63-4f10-4b53-9703-69746364dbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3465cf63-4f10-4b53-9703-69746364dbc7.jpg?1",
             "name": "Kingpin's Pet",
             "text": "Flying\nExtort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)",
             "colours": [
@@ -5905,7 +5905,7 @@
         },
         {
             "id": "48a839e0-d8d9-5a16-b7b5-46a0ad994d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8fcdb-4798-4961-995a-e128a3ff431a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8fcdb-4798-4961-995a-e128a3ff431a.jpg?1",
             "name": "Lazav, Dimir Mastermind",
             "text": "Hexproof\nWhenever a creature card is put into an opponent's graveyard from anywhere, you may have Lazav, Dimir Mastermind become a copy of that card except its name is still Lazav, Dimir Mastermind, it's legendary in addition to its other types, and it gains hexproof and this ability.",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "345795cc-a87c-5259-baf2-95354eb3b264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690c96c-70a3-45e5-84d7-5c82809a8f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690c96c-70a3-45e5-84d7-5c82809a8f45.jpg?1",
             "name": "Martial Glory",
             "text": "Target creature gets +3/+0 until end of turn.\nTarget creature gets +0/+3 until end of turn.",
             "colours": [
@@ -5977,7 +5977,7 @@
         },
         {
             "id": "676871af-8fe8-5d8d-a3c3-cf49126c19b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a47da7c-80f3-4b98-aaac-778c34a35cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a47da7c-80f3-4b98-aaac-778c34a35cb6.jpg?1",
             "name": "Master Biomancer",
             "text": "Each other creature you control enters the battlefield with a number of additional +1/+1 counters on it equal to Master Biomancer's power and as a Mutant in addition to its other types.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "1d67b296-1b75-5fe1-8b9e-4e58987054bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9876a4c-714b-47e5-9589-148a623af96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9876a4c-714b-47e5-9589-148a623af96a.jpg?1",
             "name": "Merciless Eviction",
             "text": "Choose one \u2014 Exile all artifacts; or exile all creatures; or exile all enchantments; or exile all planeswalkers.",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "00640f49-f878-5a62-842e-ae7bcd658b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671eb9e8-1a69-4570-8972-2e7de371cef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671eb9e8-1a69-4570-8972-2e7de371cef4.jpg?1",
             "name": "Mind Grind",
             "text": "Each opponent reveals cards from the top of his or her library until he or she reveals X land cards, then puts all cards revealed this way into his or her graveyard. X can't be 0.",
             "colours": [
@@ -6082,7 +6082,7 @@
         },
         {
             "id": "d4cff110-dd79-5bfd-a7a7-2b1ebb3d0089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644eb6e-cc49-4834-bc2c-53f6a4ceb451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d644eb6e-cc49-4834-bc2c-53f6a4ceb451.jpg?1",
             "name": "Mortus Strider",
             "text": "When Mortus Strider dies, return it to its owner's hand.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "98cdfa4c-e4ff-5d86-9091-afdf08c049b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1dd1ac-1a1e-485d-a11f-d1323a69f95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1dd1ac-1a1e-485d-a11f-d1323a69f95e.jpg?1",
             "name": "Mystic Genesis",
             "text": "Counter target spell. Put an X/X green Ooze creature token onto the battlefield, where X is that spell's converted mana cost.",
             "colours": [
@@ -6152,7 +6152,7 @@
         },
         {
             "id": "04333f76-ed5f-5085-9be3-9215e1b63b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d691cd3b-afe5-4f28-95a9-125475515126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d691cd3b-afe5-4f28-95a9-125475515126.jpg?1",
             "name": "Nimbus Swimmer",
             "text": "Flying\nNimbus Swimmer enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "d2438561-33fb-5a8b-8f59-cca51bb75f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc198d8-1f27-482d-8f5d-21e02c59797a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc198d8-1f27-482d-8f5d-21e02c59797a.jpg?1",
             "name": "Obzedat, Ghost Council",
             "text": "When Obzedat, Ghost Council enters the battlefield, target opponent loses 2 life and you gain 2 life.\nAt the beginning of your end step, you may exile Obzedat. If you do, return it to the battlefield under its owner's control at the beginning of your next upkeep. It gains haste.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "2738798b-ae64-5365-9ad4-741282884aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef2d548-477b-4be1-b946-6df6aac2ee6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef2d548-477b-4be1-b946-6df6aac2ee6e.jpg?1",
             "name": "One Thousand Lashes",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "2ba16d21-8fcf-51bc-81a5-e47dd9edccd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fea3f6-e64a-4964-86bc-c0b8fef0ab25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fea3f6-e64a-4964-86bc-c0b8fef0ab25.jpg?1",
             "name": "Ordruun Veteran",
             "text": "Battalion \u2014 Whenever Ordruun Veteran and at least two other creatures attack, Ordruun Veteran gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -6300,7 +6300,7 @@
         },
         {
             "id": "6ef4f182-2b33-5564-a10f-fb47f5378853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca44265-5e1b-4fbf-9002-52b2ce9b7448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca44265-5e1b-4fbf-9002-52b2ce9b7448.jpg?1",
             "name": "Orzhov Charm",
             "text": "Choose one \u2014 Return target creature you control and all Auras you control attached to it to their owner's hand; or destroy target creature and you lose life equal to its toughness; or return target creature card with converted mana cost 1 or less from your graveyard to the battlefield.",
             "colours": [
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "337b0cb1-5b79-5c2b-b9c3-6d61200eed64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af406038-91ce-41fe-8b6d-55408a96d0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af406038-91ce-41fe-8b6d-55408a96d0a2.jpg?1",
             "name": "Paranoid Delusions",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -6368,7 +6368,7 @@
         },
         {
             "id": "686b8cd7-f23c-5db0-8af9-3005c6d3a069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd518e8-047a-4df0-a0b8-ba116d048fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd518e8-047a-4df0-a0b8-ba116d048fa8.jpg?1",
             "name": "Primal Visitation",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has haste.",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "98a4219f-09d2-5aa6-b686-cc89c734c101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30dfb8e-f540-45ab-a4e8-63425099646a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30dfb8e-f540-45ab-a4e8-63425099646a.jpg?1",
             "name": "Prime Speaker Zegana",
             "text": "Prime Speaker Zegana enters the battlefield with X +1/+1 counters on it, where X is the greatest power among other creatures you control.\nWhen Prime Speaker Zegana enters the battlefield, draw cards equal to its power.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "f0beff58-f38b-53a5-ad5f-4ce988694955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d87927c-80a6-4146-92a5-58c510ce7958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d87927c-80a6-4146-92a5-58c510ce7958.jpg?1",
             "name": "Psychic Strike",
             "text": "Counter target spell. Its controller puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -6477,7 +6477,7 @@
         },
         {
             "id": "b7b109ee-6f08-544b-8daa-c0c0e1ff30f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937ee156-0105-4291-8c67-d03a59c24679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937ee156-0105-4291-8c67-d03a59c24679.jpg?1",
             "name": "Purge the Profane",
             "text": "Target opponent discards two cards and you gain 2 life.",
             "colours": [
@@ -6511,7 +6511,7 @@
         },
         {
             "id": "af722f5f-55e5-5949-a467-b9677793c134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c502590-f780-4512-8067-7c66f16f8c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c502590-f780-4512-8067-7c66f16f8c9d.jpg?1",
             "name": "Rubblehulk",
             "text": "Rubblehulk's power and toughness are each equal to the number of lands you control.\nBloodrush \u2014 {1}{R}{G}, Discard Rubblehulk: Target attacking creature gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "83f6680f-8d1d-5e15-b651-468ff42fa358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce04d1ee-2605-472d-b3ee-24800342e9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce04d1ee-2605-472d-b3ee-24800342e9af.jpg?1",
             "name": "Ruination Wurm",
             "text": "",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "19966dd9-e91a-5df1-b027-74555322c8f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07855a17-4e68-4257-af7f-275c9fb0a9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07855a17-4e68-4257-af7f-275c9fb0a9b8.jpg?1",
             "name": "Shambleshark",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "6a4559cc-a1c0-51a3-80ae-5513e472d72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34261992-db62-49e3-95bc-1b2960868de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34261992-db62-49e3-95bc-1b2960868de4.jpg?1",
             "name": "Signal the Clans",
             "text": "Search your library for three creature cards and reveal them. If you reveal three cards with different names, choose one of them at random and put that card into your hand. Shuffle the rest into your library.",
             "colours": [
@@ -6654,7 +6654,7 @@
         },
         {
             "id": "2d4403f5-8912-511b-b256-bd3b6f26a906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c27bdd-77f5-4e93-8f54-93a204fc980a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c27bdd-77f5-4e93-8f54-93a204fc980a.jpg?1",
             "name": "Simic Charm",
             "text": "Choose one \u2014 Target creature gets +3/+3 until end of turn; or permanents you control gain hexproof until end of turn; or return target creature to its owner's hand.",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "0da5a13d-0a8b-53e1-ae68-4dbedebb412c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f206c0-a8a7-4ca0-b88f-4736c3dac588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f206c0-a8a7-4ca0-b88f-4736c3dac588.jpg?1",
             "name": "Skarrg Guildmage",
             "text": "{R}{G}: Creatures you control gain trample until end of turn.\n{1}{R}{G}: Target land you control becomes a 4/4 Elemental creature until end of turn. It's still a land.",
             "colours": [
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "b649315e-9bfb-5f12-9bda-6805dfb41871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8c9948-b52e-4d07-a72a-99ab6be05cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8c9948-b52e-4d07-a72a-99ab6be05cc6.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "be7ed97d-bfda-5e4d-b842-4ccb15f57b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd705732-cce9-4d11-85ca-be49381dbaa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd705732-cce9-4d11-85ca-be49381dbaa8.jpg?1",
             "name": "Soul Ransom",
             "text": "Enchant creature\nYou control enchanted creature.\nDiscard two cards: Soul Ransom's controller sacrifices it, then draws two cards. Only any opponent may activate this ability.",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "151a289b-1c0b-50cd-8d04-edd3f43fdee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eb69b5-b8e2-48c6-8c27-cb0108df8dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09eb69b5-b8e2-48c6-8c27-cb0108df8dad.jpg?1",
             "name": "Spark Trooper",
             "text": "Trample, lifelink, haste\nAt the beginning of the end step, sacrifice Spark Trooper.",
             "colours": [
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "e9cf8ab3-a6b9-566a-bdbb-d799a944316e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d1122a-099b-49bf-9b53-52429658816a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d1122a-099b-49bf-9b53-52429658816a.jpg?1",
             "name": "Sunhome Guildmage",
             "text": "{1}{R}{W}: Creatures you control get +1/+0 until end of turn.\n{2}{R}{W}: Put a 1/1 red and white Soldier creature token with haste onto the battlefield.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "6b2c1983-e5a6-5b16-8f25-12f26e58c654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f013e6f0-85d0-4c8e-a10b-7beea572c32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f013e6f0-85d0-4c8e-a10b-7beea572c32d.jpg?1",
             "name": "Treasury Thrull",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nWhenever Treasury Thrull attacks, you may return target artifact, creature, or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "cffb01e3-a868-56b8-bdb0-c2689e077b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39610192-6d3c-4d03-9c3e-cda966c924b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39610192-6d3c-4d03-9c3e-cda966c924b1.jpg?1",
             "name": "Truefire Paladin",
             "text": "Vigilance\n{R}{W}: Truefire Paladin gets +2/+0 until end of turn.\n{R}{W}: Truefire Paladin gains first strike until end of turn.",
             "colours": [
@@ -6945,7 +6945,7 @@
         },
         {
             "id": "88ba71cf-5061-598e-b121-6ef176554ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10a22-6070-48d7-99ab-45f770f16fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e10a22-6070-48d7-99ab-45f770f16fd1.jpg?1",
             "name": "Unexpected Results",
             "text": "Shuffle your library, then reveal the top card. If it's a nonland card, you may cast it without paying its mana cost. If it's a land card, you may put it onto the battlefield and return Unexpected Results to its owner's hand.",
             "colours": [
@@ -6979,7 +6979,7 @@
         },
         {
             "id": "c138b935-e096-5da7-8c76-5c4ee25795d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcd6fac-2cde-4a89-b484-b910be2dcecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcd6fac-2cde-4a89-b484-b910be2dcecf.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -7013,7 +7013,7 @@
         },
         {
             "id": "e8401ce4-67a0-59f2-9514-d70d8912c70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac639b9-6c20-45ac-a61f-082bdcebdb83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac639b9-6c20-45ac-a61f-082bdcebdb83.jpg?1",
             "name": "Vizkopa Confessor",
             "text": "Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.)\nWhen Vizkopa Confessor enters the battlefield, pay any amount of life. Target opponent reveals that many cards from his or her hand. You choose one of them and exile it.",
             "colours": [
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "2121deba-edd4-5782-8e00-207d10e2da6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f505a3-2c54-43a9-b4a9-43a1451b36f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f505a3-2c54-43a9-b4a9-43a1451b36f6.jpg?1",
             "name": "Vizkopa Guildmage",
             "text": "{1}{W}{B}: Target creature gains lifelink until end of turn.\n{1}{W}{B}: Whenever you gain life this turn, each opponent loses that much life.",
             "colours": [
@@ -7087,7 +7087,7 @@
         },
         {
             "id": "ae621fea-aa1d-57cb-ba21-74c6ef03f881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4b0cc-e611-4a4b-8392-b37bfc3a77e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4b0cc-e611-4a4b-8392-b37bfc3a77e1.jpg?1",
             "name": "Whispering Madness",
             "text": "Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way.\nCipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "d29b521b-164c-5ef8-a576-030b9a70c87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f0870-dc1c-4cd8-b92c-6d5f92abbaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f0870-dc1c-4cd8-b92c-6d5f92abbaec.jpg?1",
             "name": "Wojek Halberdiers",
             "text": "Battalion \u2014 Whenever Wojek Halberdiers and at least two other creatures attack, Wojek Halberdiers gains first strike until end of turn.",
             "colours": [
@@ -7158,7 +7158,7 @@
         },
         {
             "id": "1abfe4a2-0132-5569-9160-cee05164547a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeaf99b-7720-42e3-8cb1-23218b646458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeaf99b-7720-42e3-8cb1-23218b646458.jpg?1",
             "name": "Zameck Guildmage",
             "text": "{G}{U}: This turn, each creature you control enters the battlefield with an additional +1/+1 counter on it.\n{G}{U}, Remove a +1/+1 counter from a creature you control: Draw a card.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "8d03d417-e907-5aef-b829-8acb32809a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef93050-2f24-4c85-a00b-796e53868ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef93050-2f24-4c85-a00b-796e53868ac1.jpg?1",
             "name": "Zhur-Taa Swine",
             "text": "Bloodrush \u2014 {1}{R}{G}, Discard Zhur-Taa Swine: Target attacking creature gets +5/+4 until end of turn.",
             "colours": [
@@ -7231,7 +7231,7 @@
         },
         {
             "id": "82883729-c917-531a-8dd2-e692fdecc4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64a15f4-6e2f-4479-95da-8805ce2091fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64a15f4-6e2f-4479-95da-8805ce2091fa.jpg?1",
             "name": "Arrows of Justice",
             "text": "Arrows of Justice deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "f95ca074-e12a-50b9-9604-c865fa5a2260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2ef9c5-ca6f-4243-bd38-2b325257831c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2ef9c5-ca6f-4243-bd38-2b325257831c.jpg?1",
             "name": "Beckon Apparition",
             "text": "Exile target card from a graveyard. Put a 1/1 white and black Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -7299,7 +7299,7 @@
         },
         {
             "id": "c5db77c4-8dcc-581f-9e60-ac7a6457183b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0a11d-0390-437e-8ece-3229863c76db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe0a11d-0390-437e-8ece-3229863c76db.jpg?1",
             "name": "Biomass Mutation",
             "text": "Creatures you control become X/X until end of turn.",
             "colours": [
@@ -7333,7 +7333,7 @@
         },
         {
             "id": "2f8e9281-44c8-5180-b0a4-157b05f2a5e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18f7a9-2af6-467a-8f62-5f7da83a3c92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e18f7a9-2af6-467a-8f62-5f7da83a3c92.jpg?1",
             "name": "Bioshift",
             "text": "Move any number of +1/+1 counters from target creature onto another target creature with the same controller.",
             "colours": [
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "43c8c8bc-e235-5b30-b2b3-1be6d9407f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a18b07-38b8-4854-9735-3cfe83b11bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a18b07-38b8-4854-9735-3cfe83b11bf1.jpg?1",
             "name": "Boros Reckoner",
             "text": "Whenever Boros Reckoner is dealt damage, it deals that much damage to target creature or player.\n{GU}: Boros Reckoner gains first strike until end of turn.",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "5995e269-6e40-5850-b88d-c766de2ae29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d5f35-3613-4c69-9176-13baf442fb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d5f35-3613-4c69-9176-13baf442fb50.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G} to your mana pool.",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "cb16d4a7-6eaf-5d05-9dea-4e46270eb2b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76102f1-b05f-472b-81cf-eae424c55638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76102f1-b05f-472b-81cf-eae424c55638.jpg?1",
             "name": "Coerced Confession",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard. You draw a card for each creature card put into that graveyard this way.",
             "colours": [
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "2f3954ba-b17d-5837-be29-4604286898b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c186d2-e631-4811-83ea-fdb54e730a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c186d2-e631-4811-83ea-fdb54e730a5d.jpg?1",
             "name": "Deathcult Rogue",
             "text": "Deathcult Rogue can't be blocked except by Rogues.",
             "colours": [
@@ -7512,7 +7512,7 @@
         },
         {
             "id": "cf8e58d8-0a2c-5dc4-a62a-b1a0db7adfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d759ef8-cb04-4769-9944-85793af3f6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d759ef8-cb04-4769-9944-85793af3f6e8.jpg?1",
             "name": "Gift of Orzhova",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying and lifelink.",
             "colours": [
@@ -7548,7 +7548,7 @@
         },
         {
             "id": "1e63e3e6-ba67-519f-8f03-ecff3d4aa4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88366762-4be0-422a-a0ff-ed046d30afe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88366762-4be0-422a-a0ff-ed046d30afe1.jpg?1",
             "name": "Immortal Servitude",
             "text": "Return each creature card with converted mana cost X from your graveyard to the battlefield.",
             "colours": [
@@ -7582,7 +7582,7 @@
         },
         {
             "id": "4b2d7089-47db-5b16-80cc-efb2456bff9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddb2e15-a53e-4647-a627-6c7032429fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddb2e15-a53e-4647-a627-6c7032429fca.jpg?1",
             "name": "Merfolk of the Depths",
             "text": "Flash (You may cast this spell any time you could cast an instant.)",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "68658172-c4ae-5b96-95bf-47186b87f945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3754b8c-16d2-41e3-b41b-4b2e70833e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3754b8c-16d2-41e3-b41b-4b2e70833e82.jpg?1",
             "name": "Nightveil Specter",
             "text": "Flying\nWhenever Nightveil Specter deals combat damage to a player, that player exiles the top card of his or her library.\nYou may play cards exiled with Nightveil Specter.",
             "colours": [
@@ -7655,7 +7655,7 @@
         },
         {
             "id": "e906aad3-043f-563e-a4e0-5233a61bbbfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3624332e-60fc-4819-a0f1-d7ec41c6518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3624332e-60fc-4819-a0f1-d7ec41c6518b.jpg?1",
             "name": "Pit Fight",
             "text": "Target creature you control fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7689,7 +7689,7 @@
         },
         {
             "id": "d0cc1f38-200f-5c6b-bf0f-dafb87b21bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec7d6a-2362-4c62-bd81-35bba6086f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec7d6a-2362-4c62-bd81-35bba6086f7d.jpg?1",
             "name": "Rubblebelt Raiders",
             "text": "Whenever Rubblebelt Raiders attacks, put a +1/+1 counter on it for each attacking creature you control.",
             "colours": [
@@ -7726,7 +7726,7 @@
         },
         {
             "id": "57e2deb3-6050-581c-bc5d-00d0c98d1ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77058d9-d2b5-424a-bfe2-070b754051cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77058d9-d2b5-424a-bfe2-070b754051cb.jpg?1",
             "name": "Shattering Blow",
             "text": "Exile target artifact.",
             "colours": [
@@ -7760,7 +7760,7 @@
         },
         {
             "id": "4b1a24aa-2216-527e-8a41-72558c3034dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cf8f6c-217e-4d51-aa63-859c2d38d438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8cf8f6c-217e-4d51-aa63-859c2d38d438.jpg?1",
             "name": "Armored Transport",
             "text": "Prevent all combat damage that would be dealt to Armored Transport by creatures blocking it.",
             "colours": [],
@@ -7791,7 +7791,7 @@
         },
         {
             "id": "c539a52f-f7bc-521a-8129-bf80757604b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b65847-fee2-4e00-b598-7363059ec3ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b65847-fee2-4e00-b598-7363059ec3ff.jpg?1",
             "name": "Boros Keyrune",
             "text": "{T}: Add {R} or {W} to your mana pool.\n{R}{W}: Boros Keyrune becomes a 1/1 red and white Soldier artifact creature with double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [],
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "24dbbacb-5dc0-53f7-b540-4fe2dfedf412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d91bb34-5d8d-48c9-ad19-d28884e083bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d91bb34-5d8d-48c9-ad19-d28884e083bc.jpg?1",
             "name": "Dimir Keyrune",
             "text": "{T}: Add {U} or {B} to your mana pool.\n{U}{B}: Dimir Keyrune becomes a 2/2 blue and black Horror artifact creature until end of turn and is unblockable this turn.",
             "colours": [],
@@ -7853,7 +7853,7 @@
         },
         {
             "id": "647ca3ba-3c6c-5aaa-9d87-456907ffaed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6070239-54a7-49d4-bd3c-d5c4cda971db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6070239-54a7-49d4-bd3c-d5c4cda971db.jpg?1",
             "name": "Glaring Spotlight",
             "text": "Creatures your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.\n{3}, Sacrifice Glaring Spotlight: Creatures you control gain hexproof until end of turn and are unblockable this turn.",
             "colours": [],
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "f9aa2ccb-4420-5bf0-a985-7ae5111263f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf96f1c-066e-4fde-acb8-4674842fb6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf96f1c-066e-4fde-acb8-4674842fb6c2.jpg?1",
             "name": "Gruul Keyrune",
             "text": "{T}: Add {R} or {G} to your mana pool.\n{R}{G}: Gruul Keyrune becomes a 3/2 red and green Beast artifact creature with trample until end of turn.",
             "colours": [],
@@ -7912,7 +7912,7 @@
         },
         {
             "id": "dcf312dd-3399-5965-a1d4-f2ee60961870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc06cf32-5d66-4772-845d-ff7649396092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc06cf32-5d66-4772-845d-ff7649396092.jpg?1",
             "name": "Illusionist's Bracers",
             "text": "Whenever an ability of equipped creature is activated, if it isn't a mana ability, copy that ability. You may choose new targets for the copy.\nEquip {3}",
             "colours": [],
@@ -7942,7 +7942,7 @@
         },
         {
             "id": "f9fd5b5f-840d-5633-a8d1-9eb35168510e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d1bc6e-84aa-4973-924a-6688b742bafa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d1bc6e-84aa-4973-924a-6688b742bafa.jpg?1",
             "name": "Millennial Gargoyle",
             "text": "Flying",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "312f3444-aeb9-5167-b200-1e165cac648b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5c0f38-916a-4f6c-b678-7447cb0709e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5c0f38-916a-4f6c-b678-7447cb0709e0.jpg?1",
             "name": "Orzhov Keyrune",
             "text": "{T}: Add {W} or {B} to your mana pool.\n{W}{B}: Orzhov Keyrune becomes a 1/4 white and black Thrull artifact creature with lifelink until end of turn.",
             "colours": [],
@@ -8004,7 +8004,7 @@
         },
         {
             "id": "44c41b6b-0150-5397-8967-1ad2781c3514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b29a2-9e6f-45b7-8af5-f09779aae58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b15b29a2-9e6f-45b7-8af5-f09779aae58e.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8032,7 +8032,7 @@
         },
         {
             "id": "dd6b2ba9-f4f8-5124-9c24-3f2318d0a16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24619d3f-1051-4d8e-9c8d-70a12621b282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24619d3f-1051-4d8e-9c8d-70a12621b282.jpg?1",
             "name": "Razortip Whip",
             "text": "{1}, {T}: Razortip Whip deals 1 damage to target opponent.",
             "colours": [],
@@ -8060,7 +8060,7 @@
         },
         {
             "id": "d0594ad5-ec6c-5fd0-86f6-e5a30632550a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be1289-76f9-40b3-9387-b76a8b8d8797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be1289-76f9-40b3-9387-b76a8b8d8797.jpg?1",
             "name": "Riot Gear",
             "text": "Equipped creature gets +1/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8090,7 +8090,7 @@
         },
         {
             "id": "39b37e23-dde7-562d-bd0a-b8cfd5e1ed66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039aae6-38f5-42b5-a530-e0dd03abc7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d039aae6-38f5-42b5-a530-e0dd03abc7d5.jpg?1",
             "name": "Simic Keyrune",
             "text": "{T}: Add {G} or {U} to your mana pool.\n{G}{U}: Simic Keyrune becomes a 2/3 green and blue Crab artifact creature with hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [],
@@ -8121,7 +8121,7 @@
         },
         {
             "id": "8ef0f29f-dcfc-573f-b7b0-4eb09cdd2abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1602ee8-019d-4dde-8d31-042207017615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1602ee8-019d-4dde-8d31-042207017615.jpg?1",
             "name": "Skyblinder Staff",
             "text": "Equipped creature gets +1/+0 and can't be blocked by creatures with flying.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8151,7 +8151,7 @@
         },
         {
             "id": "eb247595-7283-5c3b-aa01-3421bc2fce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b447a8-524b-4bda-b975-7e194fd741fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b447a8-524b-4bda-b975-7e194fd741fb.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8184,7 +8184,7 @@
         },
         {
             "id": "78441f3e-0047-548a-8f0d-e157fede836b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece3bcdd-cb33-4923-b919-ba57a327d3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece3bcdd-cb33-4923-b919-ba57a327d3cd.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U} to your mana pool.)\nAs Breeding Pool enters the battlefield, you may pay 2 life. If you don't, Breeding Pool enters the battlefield tapped.",
             "colours": [],
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "f800f864-c42c-58a2-8f3b-3771a66bc8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951bf75-1a88-4c85-b4e9-063d84f1dabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951bf75-1a88-4c85-b4e9-063d84f1dabf.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "4230de84-de12-50c8-91b9-de0412f2de83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd672bb-18cf-44e3-8dda-5310b1e0fffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd672bb-18cf-44e3-8dda-5310b1e0fffe.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B} to your mana pool.)\nAs Godless Shrine enters the battlefield, you may pay 2 life. If you don't, Godless Shrine enters the battlefield tapped.",
             "colours": [],
@@ -8285,7 +8285,7 @@
         },
         {
             "id": "21c7493a-2c25-5737-aee0-41aeae09223d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c54269-8798-4023-836f-640103e08ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c54269-8798-4023-836f-640103e08ce0.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8318,7 +8318,7 @@
         },
         {
             "id": "9e18976f-5c7f-561d-9c8d-8dfc06140d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d609c-deb7-4bd7-9c1d-e20fb3ed4f5f.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8351,7 +8351,7 @@
         },
         {
             "id": "b67b96c4-42c5-5c5c-a1e2-4a7fa17d6cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a26d900-c652-4f9c-8681-a35c5f8b1937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a26d900-c652-4f9c-8681-a35c5f8b1937.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W} to your mana pool.)\nAs Sacred Foundry enters the battlefield, you may pay 2 life. If you don't, Sacred Foundry enters the battlefield tapped.",
             "colours": [],
@@ -8385,7 +8385,7 @@
         },
         {
             "id": "9a83ba1c-2fb4-5cc0-b34e-ddcc6ecb507a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce3f6f2-c52c-4fb8-afa0-b1ea723bb4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce3f6f2-c52c-4fb8-afa0-b1ea723bb4c6.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "ef4ff4ab-6732-5fc4-b2f4-6dd9aac2f65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29f3415-971c-4a5d-aae9-3893f4bdab1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29f3415-971c-4a5d-aae9-3893f4bdab1e.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G} to your mana pool.)\nAs Stomping Ground enters the battlefield, you may pay 2 life. If you don't, Stomping Ground enters the battlefield tapped.",
             "colours": [],
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "358351a4-e9f0-5340-a45d-35f670f24b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f27909-e5cd-44c0-91c4-21624f692fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f27909-e5cd-44c0-91c4-21624f692fd9.jpg?1",
             "name": "Thespian's Stage",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Thespian's Stage becomes a copy of target land and gains this ability.",
             "colours": [],
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "84425e4b-a93e-5a64-8ec9-eca0e5caffd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fde349-010e-4a2e-838e-e924dbeec355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fde349-010e-4a2e-838e-e924dbeec355.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B} to your mana pool.)\nAs Watery Grave enters the battlefield, you may pay 2 life. If you don't, Watery Grave enters the battlefield tapped.",
             "colours": [],
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "072cf722-dcbf-5a4e-aff0-b20b9d6a2483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71766a5a-ce00-4e48-b4f6-0d1a7f5b2691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71766a5a-ce00-4e48-b4f6-0d1a7f5b2691.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "454575b1-cacd-57fc-b25c-4a2025f5285e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fb8ca6-7351-457a-b2a4-48f57ec3c64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fb8ca6-7351-457a-b2a4-48f57ec3c64a.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "90c3872a-9afa-5003-bc53-cbec13e1bb0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b938d2e0-7e90-4f57-b363-5c68a6207d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b938d2e0-7e90-4f57-b363-5c68a6207d6c.jpg?1",
             "name": "Frog Lizard",
             "text": "",
             "colours": [
@@ -8617,7 +8617,7 @@
         },
         {
             "id": "a0f235bb-c637-520c-9262-d810aefc8192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af74e26-69d7-4683-9a71-9b420c03d75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af74e26-69d7-4683-9a71-9b420c03d75f.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -8653,7 +8653,7 @@
         },
         {
             "id": "222e0f63-f7c4-52e0-8f47-6d600b2586a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a71b52-58f9-4945-9557-0fbcbbf5a241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a71b52-58f9-4945-9557-0fbcbbf5a241.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [
@@ -8689,7 +8689,7 @@
         },
         {
             "id": "413b8191-e883-5446-8618-8929e16a2a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5a5a5-a8ae-41ed-9af5-b99d80ce0b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5a5a5-a8ae-41ed-9af5-b99d80ce0b35.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8725,7 +8725,7 @@
         },
         {
             "id": "6465289c-c523-5089-a6c0-66f85c308232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f3a4b0-0992-4245-b245-033ad1083a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f3a4b0-0992-4245-b245-033ad1083a93.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "7705471e-c210-59ec-9248-ee989cee67ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1612f546-1bdb-4861-966c-4eeb7d1e65e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1612f546-1bdb-4861-966c-4eeb7d1e65e8.jpg?1",
             "name": "Domri Rade Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/HML.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/HML.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "505092c2-5501-54c4-bf8a-4e296cb08c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5d8de-25f1-4070-a7a6-dc3f2339ce30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5d8de-25f1-4070-a7a6-dc3f2339ce30.jpg?1",
             "name": "Abbey Gargoyles",
             "text": "Flying, protection from red",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "64a0d121-4a0b-5015-bcf2-985a996f196f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158caa84-da2e-4c4c-b24d-0c035c900e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158caa84-da2e-4c4c-b24d-0c035c900e20.jpg?1",
             "name": "Abbey Matron",
             "text": "o\nW, oc\nT: +0/+3 until end of turn",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "a4c57432-3ccd-5b85-897e-bfa922e002e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd950ddc-28f4-47a5-8fc1-d6f70002fceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd950ddc-28f4-47a5-8fc1-d6f70002fceb.jpg?1",
             "name": "Abbey Matron",
             "text": "o\nW, oc\nT: +0/+3 until end of turn",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "b356ac91-c608-5730-b532-a2a59604895f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91170faf-3143-4fa8-88d6-eef72e1f5459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91170faf-3143-4fa8-88d6-eef72e1f5459.jpg?1",
             "name": "Aysen Bureaucrats",
             "text": "oc\nT: Tap target creature with power no greater than 2.",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "4c4b0b7c-61b0-58b9-ba25-6038be2e1316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca3fa70-50b3-4157-afda-fe58bf72ee16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca3fa70-50b3-4157-afda-fe58bf72ee16.jpg?1",
             "name": "Aysen Bureaucrats",
             "text": "oc\nT: Tap target creature with power no greater than 2.",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "665af871-8404-520a-8103-b12420b413ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7908cfdc-5ed6-48a8-a5b9-351864f8b4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7908cfdc-5ed6-48a8-a5b9-351864f8b4fd.jpg?1",
             "name": "Aysen Crusader",
             "text": "Aysen Crusader has power and toughness each equal to 2 plus the number of Heroes you control.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "1cb80f4b-f3a6-5786-8341-91669498223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa87eb-9a11-459c-bff8-87bb09b61b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfa87eb-9a11-459c-bff8-87bb09b61b87.jpg?1",
             "name": "Aysen Highway",
             "text": "All white creatures gain plainswalk.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "af5b3c88-a9b2-5b7b-8503-2e05adba8d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b42f6c-5c7e-4ba8-b0fb-ac8564aaf825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b42f6c-5c7e-4ba8-b0fb-ac8564aaf825.jpg?1",
             "name": "Beast Walkers",
             "text": "oo\nG Banding until end of turn",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "bbd07804-fc81-5a51-bc58-83e741fc7953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17c19a4-0186-45a0-89b9-d7b0fb0ddd8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17c19a4-0186-45a0-89b9-d7b0fb0ddd8a.jpg?1",
             "name": "Death Speakers",
             "text": "Protection from black",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "0d35f19d-0f3d-5f09-91aa-f21e262fa364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfd416a-dddf-40e4-acf0-84057edb7a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfd416a-dddf-40e4-acf0-84057edb7a58.jpg?1",
             "name": "Hazduhr the Abbot",
             "text": "o\nX, oc\nT: Redirect to Hazduhr the Abbot X damage dealt to any white creature you control.",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "1653e699-3073-5c83-88ae-c8106dea3cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db206e-b254-476c-b2f3-1cd56bb5297d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90db206e-b254-476c-b2f3-1cd56bb5297d.jpg?1",
             "name": "Leeches",
             "text": "Target player loses all poison counters. Leeches deals 1 damage to that player for each poison counter removed in this way.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "b6b84f7e-6898-5b57-bb8e-96df2718494d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2c7004-691b-4385-ad9b-60b93d474ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2c7004-691b-4385-ad9b-60b93d474ebd.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "9351e0dc-afed-56c0-acb3-ee72aec6f246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2f5e2-fb95-48b0-b7bf-689d45fa8970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d2f5e2-fb95-48b0-b7bf-689d45fa8970.jpg?1",
             "name": "Mesa Falcon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "c7f6cb42-96c6-5660-844e-7228d3dae0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f514eb63-3a4e-4410-ba3d-487cf81f7063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f514eb63-3a4e-4410-ba3d-487cf81f7063.jpg?1",
             "name": "Prophecy",
             "text": "Reveal the top card of target opponent's library to all players. If it is a land, gain 1 life. That opponent then shuffles his or her library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "9d730c77-4340-5654-94f0-11c1a5b090bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf30363-9db2-44c5-8c13-dbf1aaa8c86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf30363-9db2-44c5-8c13-dbf1aaa8c86b.jpg?1",
             "name": "Rashka the Slayer",
             "text": "Can block creatures with flying.\nIf assigned to block any black creatures, Rashka the Slayer gets +1/+2 until end of turn.",
             "colours": [
@@ -520,7 +520,7 @@
         },
         {
             "id": "14166bc5-0ab1-51ca-a1bb-3c0d7be36660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68224871-d4c2-4b43-9ab8-c0685588b035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68224871-d4c2-4b43-9ab8-c0685588b035.jpg?1",
             "name": "Samite Alchemist",
             "text": "o\nWo\nW, oc\nT: Prevent up to 4 damage to a creature you control. Tap that creature. The creature does not untap during your next untap phase.",
             "colours": [
@@ -556,7 +556,7 @@
         },
         {
             "id": "335833e6-92d4-5795-aecb-df3475a5f566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0545fc43-9c67-4ad4-b1d9-6b57b53321af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0545fc43-9c67-4ad4-b1d9-6b57b53321af.jpg?1",
             "name": "Samite Alchemist",
             "text": "o\nWo\nW, oc\nT: Prevent up to 4 damage to a creature you control. Tap that creature. The creature does not untap during your next untap phase.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "9aef9f49-079f-59ee-92c4-a65760e6bd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688a8de2-0167-4b35-a38d-3574034a892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688a8de2-0167-4b35-a38d-3574034a892c.jpg?1",
             "name": "Serra Aviary",
             "text": "All creatures with flying get +1/+1.",
             "colours": [
@@ -625,7 +625,7 @@
         },
         {
             "id": "35fca37b-26bb-5918-a5f3-930cf86850de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1c8b8-9b3e-444a-a12c-bd09ec899641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab1c8b8-9b3e-444a-a12c-bd09ec899641.jpg?1",
             "name": "Serra Bestiary",
             "text": "During your upkeep, pay o\nWo\nW or bury Serra Bestiary.\nTarget creature cannot attack, block, or use any ability that includes oc\nT in the activation cost.",
             "colours": [
@@ -658,7 +658,7 @@
         },
         {
             "id": "119546dc-6b64-5b3d-8dd6-c49d969b2b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fbe3c8-92fb-41b9-b778-726d22c63054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fbe3c8-92fb-41b9-b778-726d22c63054.jpg?1",
             "name": "Serra Inquisitors",
             "text": "If assigned to block any black creatures or any black creatures are assigned to block it, Serra Inquisitors gets +2/+0 until end of turn.",
             "colours": [
@@ -692,7 +692,7 @@
         },
         {
             "id": "a29dc632-0c32-5108-a65f-025ad03b77ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd25adf-4d97-4229-abdb-1c060036cfbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd25adf-4d97-4229-abdb-1c060036cfbd.jpg?1",
             "name": "Serra Paladin",
             "text": "oc\nT: Prevent 1 damage to any creature or player.\no1o\nWo\nW, oc\nT: Attacking does not cause target creature to tap this turn.",
             "colours": [
@@ -726,7 +726,7 @@
         },
         {
             "id": "092ea29a-bae4-56e3-af4e-33dcb2b1a48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb3ce2-a660-4829-9af4-330cfd612f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb3ce2-a660-4829-9af4-330cfd612f06.jpg?1",
             "name": "Soraya the Falconer",
             "text": "All Falcons get +1/+1.\no1oo\nW Target Falcon gains banding until end of turn.",
             "colours": [
@@ -761,7 +761,7 @@
         },
         {
             "id": "6967f9b4-b2da-5c72-8d78-7ce6391c3c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcc821b-8125-4585-ba44-4bf8c1873fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcc821b-8125-4585-ba44-4bf8c1873fbf.jpg?1",
             "name": "Trade Caravan",
             "text": "During your upkeep, put a currency counter on Trade Caravan.\no0: Remove two currency counters from Trade Caravan to untap target basic land. Use this ability only during any opponent's upkeep.",
             "colours": [
@@ -797,7 +797,7 @@
         },
         {
             "id": "d50bc621-bf66-5be9-98d9-84485729a274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ddb1e-e607-4080-849c-3e1a79052729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60ddb1e-e607-4080-849c-3e1a79052729.jpg?1",
             "name": "Trade Caravan",
             "text": "During your upkeep, put a currency counter on Trade Caravan.\no0: Remove two currency counters from Trade Caravan to untap target basic land. Use this ability only during any opponent's upkeep.",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "b54484c9-e44b-5b52-8ac2-20467dde7aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c5fd74-bd46-4833-ae25-1a11a8c15ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c5fd74-bd46-4833-ae25-1a11a8c15ed2.jpg?1",
             "name": "Truce",
             "text": "Each player may draw up to two cards. For each card less than two any player draws, that player gains 2 life.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "3fde0a9a-8705-5d15-894d-1695b166b38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce479e91-7b21-4312-a3c0-950d9f6dc029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce479e91-7b21-4312-a3c0-950d9f6dc029.jpg?1",
             "name": "Aether Storm",
             "text": "No summon spells may be cast. Any player may pay 4 life to bury \u00c6ther Storm. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "098159fb-552b-5854-bd8b-f4ca6a119e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3261b4c-7963-4ca0-875d-77b7c8571b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3261b4c-7963-4ca0-875d-77b7c8571b3f.jpg?1",
             "name": "Baki's Curse",
             "text": "Baki's Curse deals 2 damage to each creature for each creature enchantment on that creature.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "2808a088-455c-5249-bd0b-38d6e73e6c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f0c52-67c2-4302-82bd-fbb4e3c6d4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f0c52-67c2-4302-82bd-fbb4e3c6d4f4.jpg?1",
             "name": "Chain Stasis",
             "text": "Tap or untap target creature. Whenever any player uses Chain Stasis to tap or untap a creature, that creature's controller may pay o2o\nU to use Chain Stasis to tap or untap any target creature.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "ce158f87-7b75-5bff-bd9f-5a75b9f2ed22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe2280-a996-4072-b5bf-f4fd56607a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe2280-a996-4072-b5bf-f4fd56607a51.jpg?1",
             "name": "Coral Reef",
             "text": "When Coral Reef comes into play, put four polyp counters on it.\no0: Sacrifice an island to put two polyp counters on Coral Reef.\noo\nU Tap target blue creature you control and remove a polyp counter from Coral Reef to put a +0/+1 counter on any target creature.",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "93d6a697-0f9a-5a02-8231-d931f7371222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a8ed9-db1e-4ce8-bfb3-92604a577df7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a8ed9-db1e-4ce8-bfb3-92604a577df7.jpg?1",
             "name": "Dark Maze",
             "text": "o0: Dark Maze can attack this turn. At end of turn, remove Dark Maze from the game. Dark Maze cannot attack the turn it comes under your control.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "3b17c358-4930-53eb-812c-f87e76c5588b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d68a76-c843-4c67-90a7-2f79295798d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d68a76-c843-4c67-90a7-2f79295798d0.jpg?1",
             "name": "Dark Maze",
             "text": "o0: Dark Maze can attack this turn. At end of turn, remove Dark Maze from the game. Dark Maze cannot attack the turn it comes under your control.",
             "colours": [
@@ -1058,7 +1058,7 @@
         },
         {
             "id": "5abe3c8e-e5dd-535b-a51d-44f813aebd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3115a9-ad65-4213-9320-6f39c11676f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3115a9-ad65-4213-9320-6f39c11676f3.jpg?1",
             "name": "Forget",
             "text": "Target player chooses and discards 2 cards from his or her hand. If that player does not have enough cards in hand, his or her entire hand is discarded. The player then draws as many cards as he or she discarded in this way.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "cea58a4e-9166-58f3-aefb-b76b92837b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce05870-74d3-43f1-92d0-dc1744c0138d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce05870-74d3-43f1-92d0-dc1744c0138d.jpg?1",
             "name": "Giant Albatross",
             "text": "Flying\no1oo\nU Bury all creatures that damaged Giant Albatross this turn. The controller of any of those creatures may pay 2 life to prevent that creature from being buried. Effects that prevent or redirect damage cannot be used to counter this loss of life. Use this ability only when Giant Albatross is put into the graveyard from play.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "e161364b-e4ad-5ce8-81c7-0548e3e4ce47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26334fc-d8ee-4b8c-ac50-5a304fae6c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26334fc-d8ee-4b8c-ac50-5a304fae6c60.jpg?1",
             "name": "Giant Albatross",
             "text": "Flying\no1oo\nU Bury all creatures that damaged Giant Albatross this turn. The controller of any of those creatures may pay 2 life to prevent that creature from being buried. Effects that prevent or redirect damage cannot be used to counter this loss of life. Use this ability only when Giant Albatross is put into the graveyard from play.",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "2517de1c-4037-597c-9c1d-99d4bc7b6421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8045d23-e6e6-474c-a3e7-ddfc6121657a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8045d23-e6e6-474c-a3e7-ddfc6121657a.jpg?1",
             "name": "Giant Oyster",
             "text": "You may choose not to untap Giant Oyster during your untap phase.\noc\nT: Target tapped creature does not untap during its controller's untap phase as long as Giant Oyster remains tapped. During your upkeep, put a -1/-1 counter on that creature. If Giant Oyster becomes untapped or leaves play, remove all these counters from the creature.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "04778b81-5bf3-5b8c-8c47-e739eb253959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81fca41-2315-4d12-b05c-d921a4c3c19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81fca41-2315-4d12-b05c-d921a4c3c19e.jpg?1",
             "name": "Jinx",
             "text": "Target land becomes a basic land type of your choice until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "26c206f5-339a-569f-a0fe-7d23d3ce7f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8c1786-a2c1-43f9-9cef-8c4542833093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8c1786-a2c1-43f9-9cef-8c4542833093.jpg?1",
             "name": "Labyrinth Minotaur",
             "text": "Creatures Labyrinth Minotaur is assigned to block do not untap during their controller's next untap phase.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "687d5f47-0b3d-59f7-a572-2327df234616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0663c756-9db9-4298-8a6e-a1af935286a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0663c756-9db9-4298-8a6e-a1af935286a0.jpg?1",
             "name": "Labyrinth Minotaur",
             "text": "Creatures Labyrinth Minotaur is assigned to block do not untap during their controller's next untap phase.",
             "colours": [
@@ -1293,7 +1293,7 @@
         },
         {
             "id": "f0052d9e-34f5-5aca-a8fd-ba5f6cc2fb8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6aa3299-3b7a-4ea5-bc1f-beead26d8116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6aa3299-3b7a-4ea5-bc1f-beead26d8116.jpg?1",
             "name": "Marjhan",
             "text": "Does not untap during your untap phase.\nMarjhan cannot attack if defending player controls no islands. If at any time you control no islands, bury Marjhan.\no\nUoo\nU Sacrifice a creature to untap Marjhan. Use this ability only during your upkeep.\no\nUoo\nU -1/-0 until end of turn. Marjhan deals 1 damage to target attacking creature without flying.",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "927391aa-2a02-5318-bb37-c176732eb2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2cc591-3a81-468a-91a4-3c3aac83a21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2cc591-3a81-468a-91a4-3c3aac83a21a.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of its owner's library.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "2f01f5b8-6fe8-510e-8c35-3b209dbd41ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8b5df3-6153-470e-be9c-f38d3cf66081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8b5df3-6153-470e-be9c-f38d3cf66081.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of its owner's library.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "81963e5d-d248-5465-bd26-f4274a77b0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4133ceb-6176-411a-9eb8-51721c1bb435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4133ceb-6176-411a-9eb8-51721c1bb435.jpg?1",
             "name": "Merchant Scroll",
             "text": "Search your library for a blue instant or interrupt. Reveal that card to all players and put it into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "c7f55f12-d1fe-57ed-8255-681ac76234f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b069e6a-2c0e-4fc9-8e19-08bf1245a6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b069e6a-2c0e-4fc9-8e19-08bf1245a6c0.jpg?1",
             "name": "Mystic Decree",
             "text": "All creatures lose flying and islandwalk.",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "75305680-c561-5f44-be80-f7bfc8f14be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202d3ed5-f493-43b6-bf36-81ad289e6fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202d3ed5-f493-43b6-bf36-81ad289e6fb0.jpg?1",
             "name": "Narwhal",
             "text": "First strike, protection from red",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "8831bbc0-fffa-57fc-ad21-f65e392c5f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b742d75-860d-4b90-89cb-4292f18aed39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b742d75-860d-4b90-89cb-4292f18aed39.jpg?1",
             "name": "Reef Pirates",
             "text": "Whenever Reef Pirates damages any opponent, take the top card of his or her library and put it into his or her graveyard.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "275f800c-1280-53f6-ba37-18a5d018e212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5e641-0276-4321-b486-ef8602a5f185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5e641-0276-4321-b486-ef8602a5f185.jpg?1",
             "name": "Reef Pirates",
             "text": "Whenever Reef Pirates damages any opponent, take the top card of his or her library and put it into his or her graveyard.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "7c752380-dc52-57b4-8f92-3137528a8c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a952236e-3085-4e6e-8639-355976b7c8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a952236e-3085-4e6e-8639-355976b7c8f5.jpg?1",
             "name": "Reveka, Wizard Savant",
             "text": "oc\nT: Reveka deals 2 damage to target creature or player and does not untap during your next untap phase.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "f46ddd4a-3151-5ef7-a7f0-61318532d8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb001b-3afb-44f5-ab78-af2bf9a4e63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb001b-3afb-44f5-ab78-af2bf9a4e63a.jpg?1",
             "name": "Sea Sprite",
             "text": "Flying, protection from red",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "97903ffc-6caa-5e1a-b06c-8b95f6b0f8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da23d4-f9fb-40a5-8395-51b47a064600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da23d4-f9fb-40a5-8395-51b47a064600.jpg?1",
             "name": "Sea Troll",
             "text": "o\nU: Regenerate. Use this ability only during a turn in which Sea Troll blocked a blue creature or a blue creature blocked Sea Troll.",
             "colours": [
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "8905aa96-5654-5e13-ae0e-c7ec8ac3d36a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff5051-e24b-4453-aaae-ed4f2bf213ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff5051-e24b-4453-aaae-ed4f2bf213ab.jpg?1",
             "name": "Wall of Kelp",
             "text": "o\nUo\nU, oc\nT: Put a Kelp token into play. Treat this token as a 0/1 blue wall.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "c86a9100-58a5-53ef-b3c1-ad2e9531a0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bdddac-02fc-493a-a0ea-689273252d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bdddac-02fc-493a-a0ea-689273252d7e.jpg?1",
             "name": "Baron Sengir",
             "text": "Flying\nWhenever a creature is put into the graveyard the same turn Baron Sengir damaged it, put a +2/+2 counter on Baron Sengir.\noc\nT: Regenerate target Vampire.",
             "colours": [
@@ -1733,7 +1733,7 @@
         },
         {
             "id": "80fdf65b-0b12-5aea-8ad6-a0401fe2361b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87068116-6000-44ee-b47f-f5cb8c233bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87068116-6000-44ee-b47f-f5cb8c233bb2.jpg?1",
             "name": "Black Carriage",
             "text": "Trample\nDoes not untap during your untap phase.\no0: Sacrifice a creature to untap Black Carriage. Use this ability only during your upkeep.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "b0780f79-4368-526b-b6ec-042a58fe2172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be199e7-feaa-4f23-b93c-3eab54a02e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be199e7-feaa-4f23-b93c-3eab54a02e74.jpg?1",
             "name": "Broken Visage",
             "text": "Bury target non-artifact attacking creature and put a Shadow token into play.\nTreat this token as a black creature with power and toughness equal to the power and toughness of that attacking creature. Bury Shadow token at end of turn.",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "bb8a0acc-7d46-579c-b2ac-edb4fe0ecbc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f0614-06dc-4bd2-b8b9-d951ae27db21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f0614-06dc-4bd2-b8b9-d951ae27db21.jpg?1",
             "name": "Cemetery Gate",
             "text": "Protection from black",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "f018f607-a9e3-5e6f-a22d-50f3a92b34c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b2cc1-cb0b-4cb8-963f-453a1d5b0e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b2cc1-cb0b-4cb8-963f-453a1d5b0e3c.jpg?1",
             "name": "Cemetery Gate",
             "text": "Protection from black",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "66f4f554-786f-5c18-b066-5e8e34d30860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b352de-e989-4ad5-963c-818092fc9f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b352de-e989-4ad5-963c-818092fc9f1a.jpg?1",
             "name": "Drudge Spell",
             "text": "oo\nB Remove from the game two target creatures in your graveyard to put a Skeleton token into play. Treat this token as a 1/1 black creature with \"oo\nB Regenerate\". If Drudge Spell leaves play, bury all Skeleton tokens.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "88c67ae7-99f0-574f-ba7a-27d69b8f9b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c10ea-8ace-4496-8b99-61863c0cec1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547c10ea-8ace-4496-8b99-61863c0cec1b.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and player.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "12277540-a5d1-58df-9538-78c997935db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997ea663-40a1-49b7-80f1-2e1febc1b6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997ea663-40a1-49b7-80f1-2e1febc1b6fa.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and player.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "08b7d7d0-a64a-59b1-a0be-139a2b1c4952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e41d6-79c3-463f-ae63-872c3d8729a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e41d6-79c3-463f-ae63-872c3d8729a7.jpg?1",
             "name": "Feast of the Unicorn",
             "text": "Target creature gets +4/+0.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "7b6ef475-b6c3-5152-bd91-b5ac9dea2128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05a2735-0f0d-46b5-9c2e-6c0ed8d8944d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05a2735-0f0d-46b5-9c2e-6c0ed8d8944d.jpg?1",
             "name": "Feast of the Unicorn",
             "text": "Target creature gets +4/+0.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "0615af89-af8c-5690-8138-388f62fb9fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054c5678-63d1-45d9-bd51-43100fd10afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054c5678-63d1-45d9-bd51-43100fd10afd.jpg?1",
             "name": "Funeral March",
             "text": "When target creature leaves play, that creature's controller sacrifices a creature he or she controls. Ignore this effect if that player controls no creatures.",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "a078e132-b9e2-5dbf-87f5-cf05605e1535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1298b43-0b10-4b7c-9d33-786d4d7bd80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1298b43-0b10-4b7c-9d33-786d4d7bd80e.jpg?1",
             "name": "Ghost Hounds",
             "text": "Attacking does not cause Ghost Hounds to tap.\nIf assigned to block any white creatures or any white creatures are assigned to block it, Ghost Hounds gains first strike until end of turn.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "664e2a2b-f7af-5b91-9ceb-0f7d5b4bfe10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0ac91-5e8e-47b1-aa34-902eef60349f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb0ac91-5e8e-47b1-aa34-902eef60349f.jpg?1",
             "name": "Grandmother Sengir",
             "text": "o1o\nB, oc\nT: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "bbb8a453-58ef-598e-83d8-4a0b89a267f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c29c45f-db1a-43e3-ae42-1a72dabe7880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c29c45f-db1a-43e3-ae42-1a72dabe7880.jpg?1",
             "name": "Greater Werewolf",
             "text": "At end of combat, put a -0/-2 counter on all creatures blocking or blocked by Greater Werewolf.",
             "colours": [
@@ -2170,7 +2170,7 @@
         },
         {
             "id": "153a14cc-7df7-592f-8001-c5d1fea3d076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdae7fa-1076-4ff3-b771-fc3f5d9ba89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdae7fa-1076-4ff3-b771-fc3f5d9ba89f.jpg?1",
             "name": "Headstone",
             "text": "Remove from the game target card in any graveyard.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "f3dc3c30-e5bb-5a73-bfd0-7e5c096913d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82351724-2814-4d9e-b065-bb72c761b2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82351724-2814-4d9e-b065-bb72c761b2e7.jpg?1",
             "name": "Ihsan's Shade",
             "text": "Protection from white",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "1837863b-a6a4-5cf8-b666-da341dc00f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518e3b77-d482-4b90-94c0-0b8cdd949b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518e3b77-d482-4b90-94c0-0b8cdd949b9f.jpg?1",
             "name": "Irini Sengir",
             "text": "White enchantments and green enchantments each cost an additional o2 to cast.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "aa943b1b-cf1a-541c-a075-b9b196c34a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04292a4e-8910-4911-a76d-4f2c3e15da33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04292a4e-8910-4911-a76d-4f2c3e15da33.jpg?1",
             "name": "Koskun Falls",
             "text": "During your upkeep, tap target untapped creature you control or bury Koskun Falls.\nNo creature can attack you unless its controller pays an additional o2 whenever that creature attacks.",
             "colours": [
@@ -2306,7 +2306,7 @@
         },
         {
             "id": "ce7ac428-ec21-5ff7-a322-b2b37c94a031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e024-7865-43d0-8cd8-8933ef741d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e024-7865-43d0-8cd8-8933ef741d05.jpg?1",
             "name": "Sengir Autocrat",
             "text": "When Sengir Autocrat comes into play, put three Serf tokens into play. Treat these tokens as 0/1 black creatures. If Sengir Autocrat leaves play, bury all Serf tokens.",
             "colours": [
@@ -2339,7 +2339,7 @@
         },
         {
             "id": "44d7ed30-b9ad-57c9-83c4-7f363d8aa6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c745c2c-4311-412d-a137-02bf6d106e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c745c2c-4311-412d-a137-02bf6d106e46.jpg?1",
             "name": "Sengir Bats",
             "text": "Flying\nWhenever a creature is put into the graveyard the same turn Sengir Bats damaged it, put a +1/+1 counter on Sengir Bats.",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "0ea0d106-4b6f-50bd-931b-e0faa73ed707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb981a-d9e3-4efe-a383-5c98ee3b0b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb981a-d9e3-4efe-a383-5c98ee3b0b84.jpg?1",
             "name": "Sengir Bats",
             "text": "Flying\nWhenever a creature is put into the graveyard the same turn Sengir Bats damaged it, put a +1/+1 counter on Sengir Bats.",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "981507e9-74e5-5a9c-a597-4ed49e6f22ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90643766-c92f-4a25-bd02-227f3c91f391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90643766-c92f-4a25-bd02-227f3c91f391.jpg?1",
             "name": "Timmerian Fiends",
             "text": "Remove Timmerian Fiends from your deck before playing if not playing for ante.\no\nBo\nBoo\nB Sacrifice Timmerian Fiends to bury target artifact that any opponent owns in your graveyard. Put Timmerian Fiends into that opponent's graveyard. This change in ownership is permanent. The opponent may ante an additional card to counter this effect.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "3e135447-ac30-57e9-8110-4b93c6ca8ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8cc6c-7e24-4629-a9ce-5f717f236c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8cc6c-7e24-4629-a9ce-5f717f236c37.jpg?1",
             "name": "Torture",
             "text": "Choose target creature.\no1oo\nB Put a -1/-1 counter on creature Torture enchants.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "283d1079-24fc-5c86-ac28-a37203e12826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7e94a3-192f-483b-9a62-b94904ba3464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7e94a3-192f-483b-9a62-b94904ba3464.jpg?1",
             "name": "Torture",
             "text": "Choose target creature.\no1oo\nB Put a -1/-1 counter on creature Torture enchants.",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "2e9978c5-609d-5d81-914d-f97a697b6ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ce7d7-d370-4ef8-b1fa-aa70b2fd5ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ce7d7-d370-4ef8-b1fa-aa70b2fd5ab1.jpg?1",
             "name": "Veldrane of Sengir",
             "text": "o1o\nBoo\nB Forestwalk and -3/-0 until end of turn",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "0dccf89d-c38c-5394-8a8c-57f8d5ccb4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f711ea8-a73a-42da-8bf7-101ba588f203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f711ea8-a73a-42da-8bf7-101ba588f203.jpg?1",
             "name": "Aliban's Tower",
             "text": "Target blocking creature gets +3/+1 until end of turn.",
             "colours": [
@@ -2581,7 +2581,7 @@
         },
         {
             "id": "29188648-93d3-5f7e-b1e2-de930242ee07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e94b9-23f6-45a8-97bd-602e3aaa6711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66e94b9-23f6-45a8-97bd-602e3aaa6711.jpg?1",
             "name": "Aliban's Tower",
             "text": "Target blocking creature gets +3/+1 until end of turn.",
             "colours": [
@@ -2614,7 +2614,7 @@
         },
         {
             "id": "612e57e8-442c-5056-8a6c-75e01b05c050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7dd8623-b64a-4b47-a69d-ed62d44596fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7dd8623-b64a-4b47-a69d-ed62d44596fb.jpg?1",
             "name": "Ambush",
             "text": "All blocking creatures gain first strike until end of turn.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "5c5d1977-c9b5-573f-bce4-f64076800545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e24788-cc7c-4f5d-84d8-dcb35e10626f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e24788-cc7c-4f5d-84d8-dcb35e10626f.jpg?1",
             "name": "Ambush Party",
             "text": "First strike\nAmbush Party can attack the turn it comes into play on your side.",
             "colours": [
@@ -2681,7 +2681,7 @@
         },
         {
             "id": "f6e61f41-35db-5c39-a24c-0b64ae6b0c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea200e93-e5bd-4777-b47e-e53849a89fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea200e93-e5bd-4777-b47e-e53849a89fe7.jpg?1",
             "name": "Ambush Party",
             "text": "First strike\nAmbush Party can attack the turn it comes into play on your side.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "27b9d2e1-b6f5-547c-b52f-2bef3eab5591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f905d57-2f52-4179-8041-2667b1fb1baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f905d57-2f52-4179-8041-2667b1fb1baa.jpg?1",
             "name": "An-Zerrin Ruins",
             "text": "Choose a creature type. Creatures of that type do not untap during their controller's untap phase.",
             "colours": [
@@ -2748,7 +2748,7 @@
         },
         {
             "id": "93a9141f-f4df-5442-9d85-c4708001f545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d33cc0-525d-4e25-927b-b6b18087c27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d33cc0-525d-4e25-927b-b6b18087c27b.jpg?1",
             "name": "Anaba Ancestor",
             "text": "oc\nT: Target Minotaur gets +1/+1 until end of turn.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "3a1ce028-11d5-5e59-999e-7bb86c858eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e3c69-dca7-4c0a-8f8c-984250e6a867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882e3c69-dca7-4c0a-8f8c-984250e6a867.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "43f2cf62-df65-57ea-8973-cfe72843c59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a54048-4640-499b-a1c3-192917c25169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a54048-4640-499b-a1c3-192917c25169.jpg?1",
             "name": "Anaba Bodyguard",
             "text": "First strike",
             "colours": [
@@ -2852,7 +2852,7 @@
         },
         {
             "id": "4588b1bd-2b86-5859-9f89-94934f50eb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55d086a-d848-43bc-8c1e-de96d10877e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55d086a-d848-43bc-8c1e-de96d10877e1.jpg?1",
             "name": "Anaba Shaman",
             "text": "o\nR, oc\nT: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -2888,7 +2888,7 @@
         },
         {
             "id": "63de4b50-24ab-5de3-b5f2-0945d98bc042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b456355-9f73-45c2-9554-6e6b20d949a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b456355-9f73-45c2-9554-6e6b20d949a1.jpg?1",
             "name": "Anaba Shaman",
             "text": "o\nR, oc\nT: Anaba Shaman deals 1 damage to target creature or player.",
             "colours": [
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "b59ca690-f655-5625-be35-6977f91fd420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aaabc2-1dab-4f9c-8ed3-60bc1aa995ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aaabc2-1dab-4f9c-8ed3-60bc1aa995ba.jpg?1",
             "name": "Anaba Spirit Crafter",
             "text": "All Minotaurs get +1/+0.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "5617f78b-162d-5154-977d-befa7c8400f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd3a8e3-9a90-44f4-996c-57242d3c47a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd3a8e3-9a90-44f4-996c-57242d3c47a5.jpg?1",
             "name": "Chandler",
             "text": "o\nRo\nRo\nR, oc\nT: Destroy target artifact creature.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "2bebfdc9-c070-5a51-bb30-4a0e7566f473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a3019f-0b27-4ba3-be4c-73ed50eb9514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a3019f-0b27-4ba3-be4c-73ed50eb9514.jpg?1",
             "name": "Dwarven Pony",
             "text": "o1o\nR, oc\nT: Target Dwarf gains mountainwalk until end of turn.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "48098f7f-fa5a-5a67-a75b-99a3795ecd1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb722d9-1998-4912-a6f2-4ffa8d21311a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb722d9-1998-4912-a6f2-4ffa8d21311a.jpg?1",
             "name": "Dwarven Sea Clan",
             "text": "oc\nT: At end of combat, Dwarven Sea Clan deals 2 damage to target attacking or blocking creature. Use this ability only if that creature's controller controls any islands.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "0e9963aa-3754-53ab-b28a-2cab6a3fcceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db9aa47-f42b-41e9-948c-8b012c3809fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db9aa47-f42b-41e9-948c-8b012c3809fb.jpg?1",
             "name": "Dwarven Trader",
             "text": "",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "b7717b9b-4ea0-5327-906f-e0cf4408ab16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d9318-30d6-473f-b576-cc249454440f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e6d9318-30d6-473f-b576-cc249454440f.jpg?1",
             "name": "Dwarven Trader",
             "text": "",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "63e1cf96-2985-5012-a8a1-c6c2aa2ade0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6329bd9-1e03-43e6-b50b-8abe1356ffcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6329bd9-1e03-43e6-b50b-8abe1356ffcc.jpg?1",
             "name": "Eron the Relentless",
             "text": "Eron the Relentless can attack the turn it comes into play on your side.\no\nRo\nRoo\nR Regenerate",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "5109a80b-3326-5f34-880b-3d7b5396ac33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c99939-4854-4e28-a142-4cb7f89fe898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c99939-4854-4e28-a142-4cb7f89fe898.jpg?1",
             "name": "Evaporate",
             "text": "Evaporate deals 1 damage to each blue creature and white creature.",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "63ba138c-da9c-5827-b50f-3278ae542f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0427dcd-26da-462b-b936-a382d3d8afce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0427dcd-26da-462b-b936-a382d3d8afce.jpg?1",
             "name": "Heart Wolf",
             "text": "First strike\noc\nT: Target Dwarf gains first strike and gets +2/+0 until end of turn. If that Dwarf leaves play this turn, bury Heart Wolf. Use this ability only when attack or defense is announced.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "452a2552-9c83-5c5c-afcb-579741d24fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796f0ff-4e7b-4849-b463-0aac860c72ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e796f0ff-4e7b-4849-b463-0aac860c72ea.jpg?1",
             "name": "Ironclaw Curse",
             "text": "Target creature gets -0/-1. That creature cannot be assigned to block any creature with power greater than or equal to the toughness of the creature Ironclaw Curse enchants.",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "39154614-22f8-595c-9893-77da50ac2339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dabe3af-cd5b-461e-95a4-aad046646419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dabe3af-cd5b-461e-95a4-aad046646419.jpg?1",
             "name": "Joven",
             "text": "o\nRo\nRo\nR, oc\nT: Destroy target non-creature artifact.",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "5421a66c-f4ba-5445-88a7-b04890f5a041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a630875-b43d-4591-992c-117e1212fa34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a630875-b43d-4591-992c-117e1212fa34.jpg?1",
             "name": "Orcish Mine",
             "text": "When Orcish Mine comes into play, put three ore counters on it. During your upkeep and whenever target land becomes tapped, remove an ore counter from Orcish Mine. When the last ore counter is removed from Orcish Mine, destroy the land Orcish Mine enchants; Orcish Mine deals 2 damage to that land's controller.",
             "colours": [
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "da4b9c03-3bae-54e2-9927-1d1c6017ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3adf9a6-7137-4995-9a83-2d410cb3cd20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3adf9a6-7137-4995-9a83-2d410cb3cd20.jpg?1",
             "name": "Retribution",
             "text": "Choose two target creatures controlled by an opponent. Bury one of those creatures, and put a -1/-1 counter on the other. That opponent chooses which creature is buried.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "3e6f01c5-e95b-5a92-94e8-00628d0d424c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1035f3-3027-4a41-834c-55222b13c2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1035f3-3027-4a41-834c-55222b13c2bc.jpg?1",
             "name": "Winter Sky",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, Winter Sky deals 1 damage to each creature and player. Otherwise, each player draws a card.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "04e7fce9-9088-5dc0-9974-03a4f163049c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c5a793-a777-44f9-a977-d16d26d3f852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c5a793-a777-44f9-a977-d16d26d3f852.jpg?1",
             "name": "An-Havva Constable",
             "text": "An-Havva Constable has toughness equal to 1 plus the total number of green creatures in play.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "b4b11381-9512-53fe-88fb-47b4804534ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff4531f-d19d-44af-861a-33087197d21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff4531f-d19d-44af-861a-33087197d21c.jpg?1",
             "name": "An-Havva Inn",
             "text": "Gain 1+* life, where * is equal to the total number of green creatures in play.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "06170056-7792-52d8-8553-790c1058c1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea60340-bbdb-48e2-94a6-5ac1197e978a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea60340-bbdb-48e2-94a6-5ac1197e978a.jpg?1",
             "name": "Autumn Willow",
             "text": "Cannot be the target of spells or effects.\noo\nG Target player may target Autumn Willow with spells or effects until end of turn.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "6f3048dd-9939-5a40-96fc-67bd7c03e6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07159586-270e-4a3e-9b21-0d74cf3e49d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07159586-270e-4a3e-9b21-0d74cf3e49d7.jpg?1",
             "name": "Carapace",
             "text": "Target creature gets +0/+2.\no0: Sacrifice Carapace to regenerate creature Carapace enchants.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "17355e9c-9fa6-5cd0-b56a-1618454c9a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d51d61e-c010-4b4e-a337-20ba5eb845e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d51d61e-c010-4b4e-a337-20ba5eb845e3.jpg?1",
             "name": "Carapace",
             "text": "Target creature gets +0/+2.\no0: Sacrifice Carapace to regenerate creature Carapace enchants.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "36c365c0-f233-5906-ae55-7f92b42f3e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9c59-f340-414c-b55b-39d46dd97e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972e9c59-f340-414c-b55b-39d46dd97e8e.jpg?1",
             "name": "Daughter of Autumn",
             "text": "oo\nW Redirect to Daughter of Autumn 1 damage dealt to a white creature.",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "68a6589e-b358-5bff-a003-0f92ca7b3374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8931e-6402-483c-a9e8-63ee344c36a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8931e-6402-483c-a9e8-63ee344c36a7.jpg?1",
             "name": "Faerie Noble",
             "text": "Flying\nAll Faeries you control get +0/+1.\noc\nT: All Faeries you control get +1/+0 until end of turn.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "5a8aacf9-dfb4-5d3a-a36e-87b2ef6cca43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4a595e-51f6-4e84-aa3a-5d9c18dc8b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4a595e-51f6-4e84-aa3a-5d9c18dc8b3f.jpg?1",
             "name": "Folk of An-Havva",
             "text": "If assigned as a blocker, Folk of An-Havva gets +2/+0 until end of turn.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "c4e32e64-d5df-5721-b7c3-0cf2c5d9f212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4118c563-08a7-4654-973e-ab9c454f00f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4118c563-08a7-4654-973e-ab9c454f00f9.jpg?1",
             "name": "Folk of An-Havva",
             "text": "If assigned as a blocker, Folk of An-Havva gets +2/+0 until end of turn.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "91556c5f-b11e-573d-a3bb-627dfa6c2926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085973eb-56cd-4bb5-aefd-bdf36f2d2a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085973eb-56cd-4bb5-aefd-bdf36f2d2a3e.jpg?1",
             "name": "Hungry Mist",
             "text": "During your upkeep, pay o\nGo\nG or bury Hungry Mist.",
             "colours": [
@@ -3738,7 +3738,7 @@
         },
         {
             "id": "74484d41-3d02-5bd7-a5fc-a0dfc481bb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a486eab3-3a09-4bd5-ad97-8ec620434f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a486eab3-3a09-4bd5-ad97-8ec620434f7e.jpg?1",
             "name": "Hungry Mist",
             "text": "During your upkeep, pay o\nGo\nG or bury Hungry Mist.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "c0fc3770-4e7b-5ea5-98f1-db232e794588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f95eda2-f791-46e9-bb82-31422b8c5ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f95eda2-f791-46e9-bb82-31422b8c5ce4.jpg?1",
             "name": "Joven's Ferrets",
             "text": "If declared as an attacker, Joven's Ferrets gets +0/+2 until end of turn. At end of combat, tap any creatures that blocked Joven's Ferrets. Those creatures do not untap during their controller's next untap phase.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "558610bc-f4ea-5715-9e8d-b82c1a3babe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e4744-4d73-4e6e-950b-bb4c83229499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e4744-4d73-4e6e-950b-bb4c83229499.jpg?1",
             "name": "Leaping Lizard",
             "text": "o1oo\nG Flying and -0/-1 until end of turn",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "b00c496b-e598-5d1b-8369-ab696a71598a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be67121-068c-4770-bc42-c081577a442c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be67121-068c-4770-bc42-c081577a442c.jpg?1",
             "name": "Mammoth Harness",
             "text": "Target creature loses flying. If any creature is assigned to block the creature Mammoth Harness enchants or has the creature Mammoth Harness enchants assigned to block it, that creature gains first strike until end of turn.",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "16507ca6-d14d-5f55-bef9-a600f731582f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3b8f7-c794-40ef-9ebd-dec5357260d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3b8f7-c794-40ef-9ebd-dec5357260d4.jpg?1",
             "name": "Primal Order",
             "text": "During each player's upkeep, Primal Order deals 1 damage to that player for each non-basic land he or she controls.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "764be8fe-81c3-54ba-a86b-4864fb96eb65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab998cd1-2f49-42e7-b889-c6717b0ce884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab998cd1-2f49-42e7-b889-c6717b0ce884.jpg?1",
             "name": "Renewal",
             "text": "Sacrifice a land to search your library for a basic land and put it directly into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "c22f8d59-7870-565f-84be-751b889eb836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d67b0-d496-401b-8844-8e3ea2fd2046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d67b0-d496-401b-8844-8e3ea2fd2046.jpg?1",
             "name": "Root Spider",
             "text": "If assigned as a blocker, Root Spider gains first strike and gets +1/+0 until end of turn.",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "2d439fcb-eb25-5dd0-9e69-202af1ec308c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb4c256-e790-41ec-a9ab-e6358e810798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb4c256-e790-41ec-a9ab-e6358e810798.jpg?1",
             "name": "Roots",
             "text": "Tap target creature without flying. That creature does not untap during its controller's untap phase.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "990ab0f0-b4a8-5ec2-92b6-a2243da8c171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab87a387-678b-4913-a0c7-85f0238cee26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab87a387-678b-4913-a0c7-85f0238cee26.jpg?1",
             "name": "Rysorian Badger",
             "text": "If Rysorian Badger attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, remove from the game up to two target creatures from that player's graveyard. Gain 1 life for each creature removed in this way.",
             "colours": [
@@ -4033,7 +4033,7 @@
         },
         {
             "id": "52f5f1de-ae4e-5f84-8c32-fd2ef3f4a324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30785867-32f7-46c9-94c2-775078e792ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30785867-32f7-46c9-94c2-775078e792ae.jpg?1",
             "name": "Shrink",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "e8cd1fd2-96d1-5499-9932-48c28f7195e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f4eaa1-3c2b-4f5d-8d4e-98d153899873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f4eaa1-3c2b-4f5d-8d4e-98d153899873.jpg?1",
             "name": "Shrink",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "647035d6-42e5-58d6-9214-c1f03787b22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e13875f-f745-4afd-a830-33df9576dce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e13875f-f745-4afd-a830-33df9576dce8.jpg?1",
             "name": "Spectral Bears",
             "text": "If Spectral Bears is declared as an attacker and defending player controls no black cards, it does not untap during your next untap phase.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "1d95ef75-7a9b-5ad0-abee-826ecf707f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce80dc-86d9-4613-af98-c385ca5d1cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce80dc-86d9-4613-af98-c385ca5d1cf4.jpg?1",
             "name": "Willow Faerie",
             "text": "Flying",
             "colours": [
@@ -4168,7 +4168,7 @@
         },
         {
             "id": "4240c9a9-72a2-535e-8684-e8dedd0c5ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e777dfe-44ed-4e73-bf77-ef4c667092d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e777dfe-44ed-4e73-bf77-ef4c667092d4.jpg?1",
             "name": "Willow Faerie",
             "text": "Flying",
             "colours": [
@@ -4203,7 +4203,7 @@
         },
         {
             "id": "1eacde4d-93b3-52c9-a7c3-7b7c6ea77dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c636a608-26d7-4154-8052-a093b11362b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c636a608-26d7-4154-8052-a093b11362b1.jpg?1",
             "name": "Willow Priestess",
             "text": "oc\nT: Take a Faerie from your hand and put it directly into play as though it were just summoned.\no2oo\nG Target green creature gains protection from black until end of turn.",
             "colours": [
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "5a0d5476-80c3-5a47-aa82-28981d06f261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef20d8f-6e80-4fca-b6a7-541981f6a112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef20d8f-6e80-4fca-b6a7-541981f6a112.jpg?1",
             "name": "Apocalypse Chime",
             "text": "o2, oc\nT: Sacrifice Apocalypse Chime to bury all cards from the Homelands expansion.",
             "colours": [],
@@ -4264,7 +4264,7 @@
         },
         {
             "id": "bfd3ddf3-ee0d-5023-95d3-154eb6c23a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0ca2ea-e059-4742-8ce4-22876762048c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0ca2ea-e059-4742-8ce4-22876762048c.jpg?1",
             "name": "Clockwork Gnomes",
             "text": "o3, oc\nT: Regenerate target artifact creature.",
             "colours": [],
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "03ad43a4-1f04-543a-b131-e8bcdf28feec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b080587-d062-42ff-abc5-8e04a20faece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b080587-d062-42ff-abc5-8e04a20faece.jpg?1",
             "name": "Clockwork Steed",
             "text": "Cannot be blocked by artifact creatures.\nWhen Clockwork Steed comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Steed attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Steed. You may have no more than four of these counters on Clockwork Steed. Use this ability only during your upkeep.",
             "colours": [],
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "a02bc541-512c-5d22-bc3d-46b5b03dbefb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd89e5c-79dc-4a57-b5ea-16491443fea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd89e5c-79dc-4a57-b5ea-16491443fea1.jpg?1",
             "name": "Clockwork Swarm",
             "text": "Cannot be blocked by walls.\nWhen Clockwork Swarm comes into play, put four +1/+0 counters on it. At the end of any combat in which Clockwork Swarm attacked or blocked, remove one of these counters.\no\nX, oc\nT: Put X +1/+0 counters on Clockwork Swarm. You may have no more than four of these counters on Clockwork Swarm. Use this ability only during your upkeep.",
             "colours": [],
@@ -4354,7 +4354,7 @@
         },
         {
             "id": "f3dc2766-6503-5984-a30b-470d8a1da1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828f8f68-abe2-4e39-b3e4-991dceacd5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828f8f68-abe2-4e39-b3e4-991dceacd5d9.jpg?1",
             "name": "Didgeridoo",
             "text": "o3: Take a Minotaur from your hand and put it directly into play as though it were just summoned.",
             "colours": [],
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "647bddea-8ab7-5762-ac56-0101ce77005c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db749e-a1df-4615-9449-94731fa23a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81db749e-a1df-4615-9449-94731fa23a9f.jpg?1",
             "name": "Ebony Rhino",
             "text": "Trample",
             "colours": [],
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "e67ff526-b337-5c58-b4f9-ca189dd20c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff4430-c8f7-408a-aad2-a098d747ea62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ff4430-c8f7-408a-aad2-a098d747ea62.jpg?1",
             "name": "Feroz's Ban",
             "text": "Summon spells each cost an additional o2 to cast.",
             "colours": [],
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "1984f95d-48a8-51b9-9570-736f3a1252bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2520b38-76c1-45a2-9cda-a305f70762bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2520b38-76c1-45a2-9cda-a305f70762bd.jpg?1",
             "name": "Joven's Tools",
             "text": "o4, oc\nT: Target creature cannot be blocked except by walls until end of turn.",
             "colours": [],
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "85848a71-d5df-589c-9320-fc18328f27bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22148a1a-2172-4718-8ee4-08770eafed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22148a1a-2172-4718-8ee4-08770eafed9f.jpg?1",
             "name": "Roterothopter",
             "text": "Flying\no2: +1/+0 until end of turn. You cannot spend more than o4 in this way each turn.",
             "colours": [],
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "67fad983-0ed6-5705-9f19-50dd36542853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a7d2b-3fdb-4e7f-b0b6-f6559dcb32e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a7d2b-3fdb-4e7f-b0b6-f6559dcb32e2.jpg?1",
             "name": "Serrated Arrows",
             "text": "When Serrated Arrows comes into play, put three arrowhead counters on it.\nDuring your upkeep, bury Serrated Arrows if there are no arrowhead counters on it.\noc\nT: Remove an arrowhead counter from Serrated Arrows to put a -1/-1 counter on target creature.",
             "colours": [],
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "567d9c4b-c847-51bd-89a9-9b8855363456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afac347-4316-43e2-848b-e474ed563af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afac347-4316-43e2-848b-e474ed563af6.jpg?1",
             "name": "An-Havva Township",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nG to your mana pool.\no2, oc\nT: Add o\nW to your mana pool.\no2, oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "82b2543f-8aaa-5fdc-85e3-686bcd03b903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2e669b-61b2-4729-b636-094796fb1d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2e669b-61b2-4729-b636-094796fb1d93.jpg?1",
             "name": "Aysen Abbey",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nW to your mana pool.\no2, oc\nT: Add o\nU to your mana pool.\no2, oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "efa14e7d-f7bc-5e13-84ed-6945b6e98916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bfba30-4075-4bd6-9e4b-3a37641d43ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bfba30-4075-4bd6-9e4b-3a37641d43ce.jpg?1",
             "name": "Castle Sengir",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nB to your mana pool.\no2, oc\nT: Add o\nU to your mana pool.\no2, oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "32b84f4e-c4b7-5b41-b230-9af50f247efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395fe900-ed19-438e-a658-ed7cf85818e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395fe900-ed19-438e-a658-ed7cf85818e5.jpg?1",
             "name": "Koskun Keep",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nR to your mana pool.\no2, oc\nT: Add o\nB to your mana pool.\no2, oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "c848f0c5-5857-5189-9c59-4485134ffbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd736532-8e98-4f4a-b48f-a66c57efcbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd736532-8e98-4f4a-b48f-a66c57efcbfd.jpg?1",
             "name": "Wizards' School",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Add o\nU to your mana pool.\no2, oc\nT: Add o\nW to your mana pool.\no2, oc\nT: Add o\nB to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/HOU.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/HOU.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d4508551-ed8f-524e-abc5-c1e28ad49677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebc06f6-305d-4a5a-9be7-fbc6d8cd9c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebc06f6-305d-4a5a-9be7-fbc6d8cd9c72.jpg?1",
             "name": "Act of Heroism",
             "text": "Untap target creature. It gets +2/+2 until end of turn and can block an additional creature this turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "5c4b27d3-1d37-572f-bba7-aba489855a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e267d-450c-4eeb-b61d-bd0ec5d8534a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865e267d-450c-4eeb-b61d-bd0ec5d8534a.jpg?1",
             "name": "Adorned Pouncer",
             "text": "Double strike\nEternalize {3}{W}{W} ({3}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Cat with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "910022e0-4598-52f3-85a7-032c2f92bb9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dad070-e41d-419b-ae27-ace82b9ab2c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dad070-e41d-419b-ae27-ace82b9ab2c5.jpg?1",
             "name": "Angel of Condemnation",
             "text": "Flying, vigilance\n{2}{W}, {T}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.\n{2}{W}, {T}, Exert Angel of Condemnation: Exile another target creature until Angel of Condemnation leaves the battlefield. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "a1c442b7-e8be-5246-9fdc-203ab55c993b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad202785-a91f-4dc8-bcc0-eb1bd49f162e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad202785-a91f-4dc8-bcc0-eb1bd49f162e.jpg?1",
             "name": "Angel of the God-Pharaoh",
             "text": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "42a98d49-5115-5ee8-9b7b-65c301d47249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c1310c-1b54-42dd-bf24-889770fa2ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c1310c-1b54-42dd-bf24-889770fa2ded.jpg?1",
             "name": "Aven of Enduring Hope",
             "text": "Flying\nWhen Aven of Enduring Hope enters the battlefield, you gain 3 life.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "609cd717-5e92-5b4d-b04c-2e26b9965d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732fa4c9-11da-4bdb-96af-aa37c74be25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732fa4c9-11da-4bdb-96af-aa37c74be25f.jpg?1",
             "name": "Crested Sunmare",
             "text": "Other Horses you control have indestructible.\nAt the beginning of each end step, if you gained life this turn, create a 5/5 white Horse creature token.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "8836bac7-34af-58a2-b56f-6c697b9e9577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e6320c-6f8b-4582-ad11-9b868bff08a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e6320c-6f8b-4582-ad11-9b868bff08a1.jpg?1",
             "name": "Dauntless Aven",
             "text": "Flying\nWhenever Dauntless Aven attacks, untap target creature you control.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "5ddaa9ea-5561-5392-9ec7-2cc3c97caa82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082298e-05c4-48b3-9367-713f59aafdc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8082298e-05c4-48b3-9367-713f59aafdc6.jpg?1",
             "name": "Desert's Hold",
             "text": "Enchant creature\nWhen Desert's Hold enters the battlefield, if you control a Desert or there is a Desert card in your graveyard, you gain 3 life.\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "93a50a7d-30e1-53ea-be26-e94158fe00c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad806d67-4c98-438b-859f-b1358281e09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad806d67-4c98-438b-859f-b1358281e09d.jpg?1",
             "name": "Disposal Mummy",
             "text": "When Disposal Mummy enters the battlefield, exile target card from an opponent's graveyard.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "66db8210-bfd5-5949-a78e-68466f6bad0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2234df89-0835-4a17-b5d8-2334ee8f692d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2234df89-0835-4a17-b5d8-2334ee8f692d.jpg?1",
             "name": "Djeru, With Eyes Open",
             "text": "Vigilance\nWhen Djeru, With Eyes Open enters the battlefield, you may search your library for a planeswalker card, reveal it, put it into your hand, then shuffle your library.\nIf a source would deal damage to a planeswalker you control, prevent 1 of that damage.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "ba32c3b9-d59a-5391-8f1e-75dc71e0111a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f005de-7971-4f22-ad1f-5d0667f68113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f005de-7971-4f22-ad1f-5d0667f68113.jpg?1",
             "name": "Djeru's Renunciation",
             "text": "Tap up to two target creatures.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "24d128d3-b617-5c94-8012-71eb8ddd5ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7684db4c-6eff-4da1-a410-48d707fb5bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7684db4c-6eff-4da1-a410-48d707fb5bf1.jpg?1",
             "name": "Dutiful Servants",
             "text": "",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "6aa04650-ca1e-5cff-8044-c152b19aecc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4722eb81-1aa1-4863-8dfb-d9d6035bd6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4722eb81-1aa1-4863-8dfb-d9d6035bd6c6.jpg?1",
             "name": "Gideon's Defeat",
             "text": "Exile target white creature that's attacking or blocking. If it was a Gideon planeswalker, you gain 5 life.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "596eea2e-de8f-549f-8be1-6a4bf1e734cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8a25b-2ad0-4ffe-b41a-6b3f8b48c1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8a25b-2ad0-4ffe-b41a-6b3f8b48c1e9.jpg?1",
             "name": "God-Pharaoh's Faithful",
             "text": "Whenever you cast a blue, black, or red spell, you gain 1 life.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "6d7c254e-eea2-5f7d-9861-d7f26fa02fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a89652-95ef-45b4-80c3-02241483f3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a89652-95ef-45b4-80c3-02241483f3c0.jpg?1",
             "name": "Hour of Revelation",
             "text": "Hour of Revelation costs {3} less to cast if there are ten or more nonland permanents on the battlefield.\nDestroy all nonland permanents.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "a962307a-9855-5b2f-85d4-938124f782cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b1a3e5-cf77-439d-8e0d-cf6571f6891c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b1a3e5-cf77-439d-8e0d-cf6571f6891c.jpg?1",
             "name": "Mummy Paramount",
             "text": "Whenever another Zombie enters the battlefield under your control, Mummy Paramount gets +1/+1 until end of turn.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "f8bed615-54f8-5d80-a0d4-9bc22b6de1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a644b4-a2f7-4219-935b-237936b07948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a644b4-a2f7-4219-935b-237936b07948.jpg?1",
             "name": "Oketra's Avenger",
             "text": "You may exert Oketra's Avenger as it attacks. When you do, prevent all combat damage that would be dealt to it this turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "41a9cf25-26c4-5337-80ec-a79d505b304a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d3bf26-6003-4699-a26e-b3b5bcd3e8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d3bf26-6003-4699-a26e-b3b5bcd3e8dc.jpg?1",
             "name": "Oketra's Last Mercy",
             "text": "Your life total becomes equal to your starting life total. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "b9a5189b-1f0d-5233-a36d-cc87d8104fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867b32d2-e396-411d-ac02-1af4106dd3d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867b32d2-e396-411d-ac02-1af4106dd3d2.jpg?1",
             "name": "Overwhelming Splendor",
             "text": "Enchant player\nCreatures enchanted player controls lose all abilities and have base power and toughness 1/1.\nEnchanted player can't activate abilities that aren't mana abilities or loyalty abilities.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "0c59a8ff-e1d2-5fce-afae-3ffc7ada3d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c501c-4e23-4e56-ad99-1803c8a877ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c501c-4e23-4e56-ad99-1803c8a877ca.jpg?1",
             "name": "Sandblast",
             "text": "Sandblast deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "87ab393d-1f15-500d-a0fe-875dc82a51bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac7b2d8-7702-4b8c-84ed-1d785dea5cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac7b2d8-7702-4b8c-84ed-1d785dea5cc5.jpg?1",
             "name": "Saving Grace",
             "text": "Flash\nEnchant creature you control\nWhen Saving Grace enters the battlefield, all damage that would be dealt this turn to you and permanents you control is dealt to enchanted creature instead.\nEnchanted creature gets +0/+3.",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "e3d2d863-12e9-5165-83d6-2fcae0f0b15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a71fb62-acbd-49f5-842f-0fc9fa48afea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a71fb62-acbd-49f5-842f-0fc9fa48afea.jpg?1",
             "name": "Solemnity",
             "text": "Players can't get counters.\nCounters can't be put on artifacts, creatures, enchantments, or lands.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "a7952b62-ecfb-53fa-82b1-92e05b15b98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adb8dbf-c83c-4169-b822-8e32aa36cffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adb8dbf-c83c-4169-b822-8e32aa36cffa.jpg?1",
             "name": "Solitary Camel",
             "text": "Solitary Camel has lifelink as long as you control a Desert or there is a Desert card in your graveyard. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "4750017d-0360-5f0c-bb3c-63dcd43a6752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707a30d2-0fca-4b39-91fb-9b03152705ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707a30d2-0fca-4b39-91fb-9b03152705ba.jpg?1",
             "name": "Steadfast Sentinel",
             "text": "Vigilance\nEternalize {4}{W}{W} ({4}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Cleric with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "268aab3f-b2b5-5f21-b5a6-e98c82bf49e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda3cd3b-d4c5-4537-8c81-5ccf269f810e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda3cd3b-d4c5-4537-8c81-5ccf269f810e.jpg?1",
             "name": "Steward of Solidarity",
             "text": "{T}, Exert Steward of Solidarity: Create a 1/1 white Warrior creature token with vigilance. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "df30f715-29b6-537b-bd1b-b2fe08621100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb41cc-6edb-4a31-92cb-b17850b49432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb41cc-6edb-4a31-92cb-b17850b49432.jpg?1",
             "name": "Sunscourge Champion",
             "text": "When Sunscourge Champion enters the battlefield, you gain life equal to its power.\nEternalize\u2014{2}{W}{W}, Discard a card. ({2}{W}{W}, Discard a card, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "0d4dc816-9e9f-5ee3-9d51-39ed4626cde2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db5673-ecd3-4e58-8dc9-b42c76f80186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52db5673-ecd3-4e58-8dc9-b42c76f80186.jpg?1",
             "name": "Unconventional Tactics",
             "text": "Target creature gets +3/+3 and gains flying until end of turn.\nWhenever a Zombie enters the battlefield under your control, you may pay {W}. If you do, return Unconventional Tactics from your graveyard to your hand.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "8eed6a70-eea5-5a36-9319-4fcdd47e93d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1800882-e886-48d5-ac85-0a8e5841dc9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1800882-e886-48d5-ac85-0a8e5841dc9a.jpg?1",
             "name": "Vizier of the True",
             "text": "You may exert Vizier of the True as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, tap target creature an opponent controls.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "f77b1642-4235-53f7-a1e6-482fcc88c9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b744c138-9b9e-47f6-9d56-feb6a78ce377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b744c138-9b9e-47f6-9d56-feb6a78ce377.jpg?1",
             "name": "Aerial Guide",
             "text": "Flying\nWhenever Aerial Guide attacks, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "722fd135-242e-5ed2-80cf-8e4e64d266bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c2d70a-d646-44eb-9f65-ddf6e329ab43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c2d70a-d646-44eb-9f65-ddf6e329ab43.jpg?1",
             "name": "Aven Reedstalker",
             "text": "Flash\nFlying",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "eed9b3ea-33ae-564f-a419-f971d6ef907b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765221d-9718-47eb-aa49-9c0719337139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765221d-9718-47eb-aa49-9c0719337139.jpg?1",
             "name": "Champion of Wits",
             "text": "When Champion of Wits enters the battlefield, you may draw cards equal to its power. If you do, discard two cards.\nEternalize {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Naga Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1057,7 +1057,7 @@
         },
         {
             "id": "1da388b9-a308-5703-aa66-a52b8e75d6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0ef3-b32c-403a-93cb-29cf05795711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0ef3-b32c-403a-93cb-29cf05795711.jpg?1",
             "name": "Countervailing Winds",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "07c39d9f-c042-52a7-b360-c5ea1530e7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9093e7-c129-4efa-9f25-a2366f92e15a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9093e7-c129-4efa-9f25-a2366f92e15a.jpg?1",
             "name": "Cunning Survivor",
             "text": "Whenever you cycle or discard a card, Cunning Survivor gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "071c2878-b456-5c27-b9a8-f775c7e741cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0389daf7-0818-488f-8e6a-94818a6c94a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0389daf7-0818-488f-8e6a-94818a6c94a6.jpg?1",
             "name": "Eternal of Harsh Truths",
             "text": "Afflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)\nWhenever Eternal of Harsh Truths attacks and isn't blocked, draw a card.",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "b6bd3097-c28c-563a-883a-421acbe4d903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e5c1ab-eebd-41ca-a1ca-29b00370f6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e5c1ab-eebd-41ca-a1ca-29b00370f6e8.jpg?1",
             "name": "Fraying Sanity",
             "text": "Enchant player\nAt the beginning of each end step, enchanted player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards put into that graveyard from anywhere this turn.",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "1b309e3c-55a4-555b-b3c9-337978a300f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01040ed3-4f64-4e47-8f80-3d3a339004f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01040ed3-4f64-4e47-8f80-3d3a339004f7.jpg?1",
             "name": "Hour of Eternity",
             "text": "Exile X target creature cards from your graveyard. For each card exiled this way, create a token that's a copy of that card, except it's a 4/4 black Zombie.",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "707eee32-9200-5d99-a6b8-9318d6662b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c3a6a5-9a50-4a38-9f5f-b8caa320909d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c3a6a5-9a50-4a38-9f5f-b8caa320909d.jpg?1",
             "name": "Imaginary Threats",
             "text": "Creatures target opponent controls attack this turn if able. During that player's next untap step, creatures he or she controls don't untap.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "4269a447-33f1-5645-83bb-66976183a10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b103c1-9b25-4bfe-9081-570977e9fdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b103c1-9b25-4bfe-9081-570977e9fdad.jpg?1",
             "name": "Jace's Defeat",
             "text": "Counter target blue spell. If it was a Jace planeswalker spell, scry 2.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "83054a5e-497a-526c-85c0-620563b60b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7e5103-ee7d-40d7-bcd4-c5d1a48e9821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7e5103-ee7d-40d7-bcd4-c5d1a48e9821.jpg?1",
             "name": "Kefnet's Last Word",
             "text": "Gain control of target artifact, creature, or enchantment. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "e093e616-3d30-57c6-b9c3-d8d562e593a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26012b65-7e0a-427e-945e-de24738517fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26012b65-7e0a-427e-945e-de24738517fb.jpg?1",
             "name": "Nimble Obstructionist",
             "text": "Flash\nFlying\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\nWhen you cycle Nimble Obstructionist, counter target activated or triggered ability you don't control.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "357cb20e-2d75-5fd8-b0e4-d3b51af1852d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2361bd3b-9ae0-4198-9296-6d278feff042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2361bd3b-9ae0-4198-9296-6d278feff042.jpg?1",
             "name": "Ominous Sphinx",
             "text": "Flying\nWhenever you cycle or discard a card, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "fda6c3ac-f459-58c0-b0b0-50130454e4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83fd08a-c87b-4e29-bd1d-31dea3732156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83fd08a-c87b-4e29-bd1d-31dea3732156.jpg?1",
             "name": "Proven Combatant",
             "text": "Eternalize {4}{U}{U} ({4}{U}{U}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Warrior with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "4ba1fcc7-94b0-5a8a-847f-09b34aa02d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e54dc4a-3fd6-4895-8497-3a19e4e9a3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e54dc4a-3fd6-4895-8497-3a19e4e9a3d8.jpg?1",
             "name": "Riddleform",
             "text": "Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1.",
             "colours": [
@@ -1458,7 +1458,7 @@
         },
         {
             "id": "cc5cbb72-6e95-52c7-aa0d-6c3655f5f4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e897f14-8775-4bc3-a3b2-b149f79ec702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e897f14-8775-4bc3-a3b2-b149f79ec702.jpg?1",
             "name": "Seer of the Last Tomorrow",
             "text": "{U}, {T}, Discard a card: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "30641e76-d07d-5cfd-8a3d-b9bb93b158f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2b97d1-3e69-4305-b1df-947ff64c5043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2b97d1-3e69-4305-b1df-947ff64c5043.jpg?1",
             "name": "Sinuous Striker",
             "text": "{U}: Sinuous Striker gets +1/-1 until end of turn.\nEternalize\u2014{3}{U}{U}, Discard a card. ({3}{U}{U}, Discard a card, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Naga Warrior with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "f3d79f36-87af-5976-a67b-1d405129bf3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb7d1a-d606-46a8-a592-648c5d2e7382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb7d1a-d606-46a8-a592-648c5d2e7382.jpg?1",
             "name": "Spellweaver Eternal",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nAfflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)",
             "colours": [
@@ -1564,7 +1564,7 @@
         },
         {
             "id": "eebf317d-ba0a-5e39-a0c6-fe4048813ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95756b98-59c2-494d-9894-7406185ad144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95756b98-59c2-494d-9894-7406185ad144.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "b7dbc8d3-132a-5902-979c-ccb49fb45c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeef9ef-487c-400b-bcee-1c0e8ec94b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeef9ef-487c-400b-bcee-1c0e8ec94b6a.jpg?1",
             "name": "Striped Riverwinder",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "1f29a0e0-e50d-54c1-a34b-7ba572934465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b677e7cb-7b5d-4993-8f13-881493c498ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b677e7cb-7b5d-4993-8f13-881493c498ce.jpg?1",
             "name": "Supreme Will",
             "text": "Choose one \u2014\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "b8956b67-4835-5768-b174-b05fbd3668ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bec26d-20ba-4f31-a153-2c93a4f474e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bec26d-20ba-4f31-a153-2c93a4f474e5.jpg?1",
             "name": "Swarm Intelligence",
             "text": "Whenever you cast an instant or sorcery spell, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -1694,7 +1694,7 @@
         },
         {
             "id": "5e28ab4c-30c5-5a87-b35d-7cae075aab4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0353c-f1e0-49db-9edc-eea9090de872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0353c-f1e0-49db-9edc-eea9090de872.jpg?1",
             "name": "Tragic Lesson",
             "text": "Draw two cards. Then discard a card unless you return a land you control to its owner's hand.",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "91f1328d-e988-594e-a984-bb4d66fabd5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd1a8b2-f4ba-45af-9586-98a98834b8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd1a8b2-f4ba-45af-9586-98a98834b8bc.jpg?1",
             "name": "Unesh, Criosphinx Sovereign",
             "text": "Flying\nSphinx spells you cast cost {2} less to cast.\nWhenever Unesh, Criosphinx Sovereign or another Sphinx enters the battlefield under your control, reveal the top four cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "4f1dda38-ba12-5cbe-b725-d8dee358fb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a418b2aa-dbc2-409b-9f19-e16a0ad8cbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a418b2aa-dbc2-409b-9f19-e16a0ad8cbac.jpg?1",
             "name": "Unquenchable Thirst",
             "text": "Enchant creature\nWhen Unquenchable Thirst enters the battlefield, if you control a Desert or there is a Desert card in your graveyard, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "39cf7018-6173-5c6a-91c9-a410555a14bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a5bd6-d7e0-4e35-bb7d-b9a41fcf67bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a5bd6-d7e0-4e35-bb7d-b9a41fcf67bc.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "bc5ac72b-ff19-5a0d-9c83-a74794fbd155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef426c-b396-4767-b360-435f67207022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef426c-b396-4767-b360-435f67207022.jpg?1",
             "name": "Vizier of the Anointed",
             "text": "When Vizier of the Anointed enters the battlefield, you may search your library for a creature card with eternalize or embalm, put that card into your graveyard, then shuffle your library.\nWhenever you activate an eternalize or embalm ability, draw a card.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "e57173a9-dd2b-5787-8eb9-2d1a1fe423ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691b79ef-87da-4b52-8311-2f6f46c6368d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691b79ef-87da-4b52-8311-2f6f46c6368d.jpg?1",
             "name": "Accursed Horde",
             "text": "{1}{B}: Target attacking Zombie gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "93755b0e-972c-5ed4-8625-cd64f795b53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b04934f-87d1-4768-b7b5-5f7249a09771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b04934f-87d1-4768-b7b5-5f7249a09771.jpg?1",
             "name": "Ammit Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nWhenever an opponent casts a spell, put a -1/-1 counter on Ammit Eternal.\nWhenever Ammit Eternal deals combat damage to a player, remove all -1/-1 counters from it.",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "5c5c835c-6f5d-5c27-8ff5-615e2722252a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dfbf99-55e8-468b-bcd9-9179cad7cab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dfbf99-55e8-468b-bcd9-9179cad7cab6.jpg?1",
             "name": "Apocalypse Demon",
             "text": "Flying\nApocalypse Demon's power and toughness are each equal to the number of cards in your graveyard.\nAt the beginning of your upkeep, tap Apocalypse Demon unless you sacrifice another creature.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "255b77ca-75e6-5ec3-876e-dd0ca432e2ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005a19e2-c334-4b87-bc8b-55f62fc9abd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005a19e2-c334-4b87-bc8b-55f62fc9abd9.jpg?1",
             "name": "Banewhip Punisher",
             "text": "When Banewhip Punisher enters the battlefield, you may put a -1/-1 counter on target creature.\n{B}, Sacrifice Banewhip Punisher: Destroy target creature that has a -1/-1 counter on it.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "c63fd178-043a-5b08-a567-e34bffa89f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0102-c0d6-4d50-941a-dd1c3575a3a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4d0102-c0d6-4d50-941a-dd1c3575a3a8.jpg?1",
             "name": "Bontu's Last Reckoning",
             "text": "Destroy all creatures. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "0a1b7773-30ff-5273-811f-895ad5637263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b9e3a3-8d01-4273-9658-9ffcbc2d2297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b9e3a3-8d01-4273-9658-9ffcbc2d2297.jpg?1",
             "name": "Carrion Screecher",
             "text": "Flying",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "160442d0-264d-58c7-8d42-8ae9034552ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db6ef5-1aa9-4b8c-b0b7-d6668a2347a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db6ef5-1aa9-4b8c-b0b7-d6668a2347a1.jpg?1",
             "name": "Doomfall",
             "text": "Choose one \u2014\n\u2022 Target opponent exiles a creature he or she controls.\n\u2022 Target opponent reveals his or her hand. You choose a nonland card from it. Exile that card.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "ec7ae413-8afc-54cf-a233-9cd86c753975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4fcde3-03c9-43e6-a34b-29f6ce44e7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4fcde3-03c9-43e6-a34b-29f6ce44e7c4.jpg?1",
             "name": "Dreamstealer",
             "text": "Menace\nWhenever Dreamstealer deals combat damage to a player, that player discards that many cards.\nEternalize {4}{B}{B} ({4}{B}{B}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "b7b873de-0154-59a3-ad0e-03ade8ef523d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035ee44d-63ef-45b7-b36b-38ac341a2ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035ee44d-63ef-45b7-b36b-38ac341a2ca7.jpg?1",
             "name": "Grisly Survivor",
             "text": "Whenever you cycle or discard a card, Grisly Survivor gets +2/+0 until end of turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "0ee5a5f1-5527-5932-a9bc-6f69fa0656d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35e66cb-af50-411a-b6f2-16fb7072eff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35e66cb-af50-411a-b6f2-16fb7072eff5.jpg?1",
             "name": "Hour of Glory",
             "text": "Exile target creature. If that creature was a God, its controller reveals his or her hand and exiles all cards from it with the same name as that creature.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "7122934b-8d56-5c3f-ba41-ec1df596341b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbdc277-4a76-44a9-aeda-edabab1f579e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbdc277-4a76-44a9-aeda-edabab1f579e.jpg?1",
             "name": "Khenra Eternal",
             "text": "Afflict 1 (Whenever this creature becomes blocked, defending player loses 1 life.)",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "09b2acaa-7c4e-55db-ad5b-da9cda721ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaded6bf-2db7-4b1d-93cc-4b7b571cd2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaded6bf-2db7-4b1d-93cc-4b7b571cd2de.jpg?1",
             "name": "Lethal Sting",
             "text": "As an additional cost to cast Lethal Sting, put a -1/-1 counter on a creature you control.\nDestroy target creature.",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "697f2b9b-4ca8-52bb-bd13-d1578684a9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f72b028-b9df-40c7-822f-4acc6bdcc719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f72b028-b9df-40c7-822f-4acc6bdcc719.jpg?1",
             "name": "Liliana's Defeat",
             "text": "Destroy target black creature or black planeswalker. If that permanent was a Liliana planeswalker, her controller loses 3 life.",
             "colours": [
@@ -2303,7 +2303,7 @@
         },
         {
             "id": "61e661fc-669f-5a84-9194-8f02fab8e6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06be97-71c8-46c8-a1c2-5da3af25e6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06be97-71c8-46c8-a1c2-5da3af25e6de.jpg?1",
             "name": "Lurching Rotbeast",
             "text": "Cycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "0856bd9a-c9b1-5e49-9a0a-106f47b13760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfb7f50-14b1-4c7d-b4c8-f50bc14f4fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfb7f50-14b1-4c7d-b4c8-f50bc14f4fb7.jpg?1",
             "name": "Marauding Boneslasher",
             "text": "Marauding Boneslasher can't block unless you control another Zombie.",
             "colours": [
@@ -2373,7 +2373,7 @@
         },
         {
             "id": "3f3e95b9-be2c-5571-a259-ed61795655d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a6becd-15be-4f2d-8fda-35b1b289b28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a6becd-15be-4f2d-8fda-35b1b289b28f.jpg?1",
             "name": "Merciless Eternal",
             "text": "Afflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)\n{2}{B}, Discard a card: Merciless Eternal gets +2/+2 until end of turn.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "ebfff495-2257-5e09-980d-51d5fb128611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef494f81-638a-4e5d-b987-0dde7f2a135c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef494f81-638a-4e5d-b987-0dde7f2a135c.jpg?1",
             "name": "Moaning Wall",
             "text": "Defender\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "5eff6de5-153b-51ea-a75f-fa7f48d1efe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14adff9-33cc-467e-b782-068854c5e7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14adff9-33cc-467e-b782-068854c5e7b7.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "Flying, trample\nPay 2 life, Sacrifice another creature: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -2479,7 +2479,7 @@
         },
         {
             "id": "ccd1ae3b-a99e-5fea-bc22-dd58a3a953c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd36987a-48c3-477b-b859-0268e84b7e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd36987a-48c3-477b-b859-0268e84b7e7b.jpg?1",
             "name": "Razaketh's Rite",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "a19fdf32-17e7-524d-961e-7744371b142e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91652fe0-2064-4996-b484-a1f88e0023f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91652fe0-2064-4996-b484-a1f88e0023f7.jpg?1",
             "name": "Ruin Rat",
             "text": "Deathtouch\nWhen Ruin Rat dies, exile target card from an opponent's graveyard.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "f7ffb3be-b705-5e52-ba54-ce97d1eb4c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66f3c4-5a11-4e28-a4ae-673b3b36d3ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66f3c4-5a11-4e28-a4ae-673b3b36d3ec.jpg?1",
             "name": "Scrounger of Souls",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "292c20c5-2a81-5a1c-b664-ded1d46c4256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69d77d1-5980-436c-bf48-790939b069aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69d77d1-5980-436c-bf48-790939b069aa.jpg?1",
             "name": "Torment of Hailfire",
             "text": "Repeat the following process X times. Each opponent loses 3 life unless that player sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -2611,7 +2611,7 @@
         },
         {
             "id": "39c66ea4-b8e9-5676-a62a-67ab726c8405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01651f67-cc25-4240-9698-58b7d906a160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01651f67-cc25-4240-9698-58b7d906a160.jpg?1",
             "name": "Torment of Scarabs",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player loses 3 life unless he or she sacrifices a nonland permanent or discards a card.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "8de2277a-8770-56b3-b010-a8c124d1395b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66410b-67a3-4f6a-b3ae-dcad9858a5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66410b-67a3-4f6a-b3ae-dcad9858a5da.jpg?1",
             "name": "Torment of Venom",
             "text": "Put three -1/-1 counters on target creature. Its controller loses 3 life unless he or she sacrifices another nonland permanent or discards a card.",
             "colours": [
@@ -2678,7 +2678,7 @@
         },
         {
             "id": "c06d3db7-dc8b-5427-8623-d5cca8824cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160bc31-bdfa-4654-9d69-95ee2a5fe870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160bc31-bdfa-4654-9d69-95ee2a5fe870.jpg?1",
             "name": "Vile Manifestation",
             "text": "Vile Manifestation gets +1/+0 for each card with cycling in your graveyard.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "3f28f2a6-9eb9-5bb3-a456-c7923a51226f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6695fa8-881c-407c-91d9-3ac770372d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6695fa8-881c-407c-91d9-3ac770372d35.jpg?1",
             "name": "Without Weakness",
             "text": "Target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "d2f0cf1f-a8d6-5efe-a47f-fc786d0db97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd729df-8a02-4d5e-8432-bc0d006b0d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd729df-8a02-4d5e-8432-bc0d006b0d3d.jpg?1",
             "name": "Wretched Camel",
             "text": "When Wretched Camel dies, if you control a Desert or there is a Desert card in your graveyard, target player discards a card.",
             "colours": [
@@ -2779,7 +2779,7 @@
         },
         {
             "id": "8bfef07c-ae3d-51ce-8020-46aef3724660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84319dfb-eaf7-4b98-8c4f-30f5e779591b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84319dfb-eaf7-4b98-8c4f-30f5e779591b.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "49cb8945-d967-5bdf-b2d0-3621b91749a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5b9b-d24b-4e9a-bc90-7ed198cd1132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5b9b-d24b-4e9a-bc90-7ed198cd1132.jpg?1",
             "name": "Blur of Blades",
             "text": "Put a -1/-1 counter on target creature. Blur of Blades deals 2 damage to that creature's controller.",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "c1703dfe-c749-5ff7-9660-ccbc0e3d4b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f191fb-eaf6-432f-a668-37ad48ffabaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f191fb-eaf6-432f-a668-37ad48ffabaf.jpg?1",
             "name": "Burning-Fist Minotaur",
             "text": "First strike\n{1}{R}, Discard a card: Burning-Fist Minotaur gets +2/+0 until end of turn.",
             "colours": [
@@ -2878,7 +2878,7 @@
         },
         {
             "id": "916e3734-27ce-5b8b-998a-5cccc3a820df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38c6613-b1f7-4b38-b956-7860d041e593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38c6613-b1f7-4b38-b956-7860d041e593.jpg?1",
             "name": "Chandra's Defeat",
             "text": "Chandra's Defeat deals 5 damage to target red creature or red planeswalker. If that permanent is a Chandra planeswalker, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -2910,7 +2910,7 @@
         },
         {
             "id": "f7b4dae5-fe4e-5907-b768-5343fdbbd79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8094908b-1d3a-42df-bc27-8456fbb98e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8094908b-1d3a-42df-bc27-8456fbb98e65.jpg?1",
             "name": "Chaos Maw",
             "text": "When Chaos Maw enters the battlefield, it deals 3 damage to each other creature.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "63224dc2-7aee-5dba-aa48-ac5e584c4d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdaba76-b98d-4699-9a5f-e59285b09552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdaba76-b98d-4699-9a5f-e59285b09552.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn.\nDraw a card.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "06bbb3b2-a0cc-55f5-bcda-043147b3b7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e3983d-b1ed-46a9-9ab0-96c4d0d77050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e3983d-b1ed-46a9-9ab0-96c4d0d77050.jpg?1",
             "name": "Defiant Khenra",
             "text": "",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "7e971bfe-9d90-59e6-b355-3cd28b8c437d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60eabe-b281-4eba-9c26-287364ed2067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60eabe-b281-4eba-9c26-287364ed2067.jpg?1",
             "name": "Earthshaker Khenra",
             "text": "Haste\nWhen Earthshaker Khenra enters the battlefield, target creature with power less than or equal to Earthshaker Khenra's power can't block this turn.\nEternalize {4}{R}{R} ({4}{R}{R}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Jackal Warrior with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "38d14f01-a54a-54a6-8b46-1023e1187b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c78708-254c-446f-b6eb-8839faf08790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c78708-254c-446f-b6eb-8839faf08790.jpg?1",
             "name": "Fervent Paincaster",
             "text": "{T}: Fervent Paincaster deals 1 damage to target player.\n{T}, Exert Fervent Paincaster: It deals 1 damage to target creature. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "f275366f-bc06-5607-afa2-a7292195dd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc6b73-298b-4afa-990a-63706e77dd9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc6b73-298b-4afa-990a-63706e77dd9f.jpg?1",
             "name": "Firebrand Archer",
             "text": "Whenever you cast a noncreature spell, Firebrand Archer deals 1 damage to each opponent.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "75196f4b-0a58-5923-b4f2-9169f4a45c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c869cc4-eed9-4b24-b60f-2d7f85b885dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c869cc4-eed9-4b24-b60f-2d7f85b885dc.jpg?1",
             "name": "Frontline Devastator",
             "text": "Afflict 2 (Whenever this creature becomes blocked, defending player loses 2 life.)\n{1}{R}: Frontline Devastator gets +1/+0 until end of turn.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "32c2dc52-d1ff-50ce-b162-8167b1ed9122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8fbd-9223-447d-a85c-fa6222c75277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68c8fbd-9223-447d-a85c-fa6222c75277.jpg?1",
             "name": "Gilded Cerodon",
             "text": "Whenever Gilded Cerodon attacks, if you control a Desert or there is a Desert card in your graveyard, target creature can't block this turn.",
             "colours": [
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "60d9a908-f1dd-570b-b48b-772e79b54f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607bdb54-a956-4a9c-89cf-af6f1163b856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607bdb54-a956-4a9c-89cf-af6f1163b856.jpg?1",
             "name": "Granitic Titan",
             "text": "Menace\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "eb7ede84-6408-504d-bda9-abbc35021553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f578576-19ca-4e67-94da-2c0767d9a2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f578576-19ca-4e67-94da-2c0767d9a2bb.jpg?1",
             "name": "Hazoret's Undying Fury",
             "text": "Shuffle your library, then exile the top four cards. You may cast any number of nonland cards with converted mana cost 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "bd31cb83-233a-5aa2-a960-c1e8bb856b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420cc12-cfd7-4007-a0c2-b16c8f63a754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420cc12-cfd7-4007-a0c2-b16c8f63a754.jpg?1",
             "name": "Hour of Devastation",
             "text": "All creatures lose indestructible until end of turn. Hour of Devastation deals 5 damage to each creature and each non-Bolas planeswalker.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "d8ee858b-3e39-5a03-a92a-f8e3ff938352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f8207-485e-4a4e-aa62-8e0e69645a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51f8207-485e-4a4e-aa62-8e0e69645a0e.jpg?1",
             "name": "Imminent Doom",
             "text": "Imminent Doom enters the battlefield with a doom counter on it.\nWhenever you cast a spell with converted mana cost equal to the number of doom counters on Imminent Doom, Imminent Doom deals that much damage to target creature or player. Then put a doom counter on Imminent Doom.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "113b0483-3c74-5393-9256-be66b39779ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6a43fe-369d-4943-a825-570eb3cceba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6a43fe-369d-4943-a825-570eb3cceba4.jpg?1",
             "name": "Inferno Jet",
             "text": "Inferno Jet deals 6 damage to target opponent.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3348,7 +3348,7 @@
         },
         {
             "id": "f8c486d6-6c92-5758-a182-932c35dfc703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4caac-95e8-47bb-90c4-3bf877afdc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4caac-95e8-47bb-90c4-3bf877afdc57.jpg?1",
             "name": "Khenra Scrapper",
             "text": "Menace\nYou may exert Khenra Scrapper as it attacks. When you do, it gets +2/+0 until end of turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "072c38b4-65ed-5644-b081-d61d733a6e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffb2c38-76b0-4d5f-a4d1-e2494f4be192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cffb2c38-76b0-4d5f-a4d1-e2494f4be192.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "9722e68d-3d12-5e88-b6fb-6e38f54785ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f87128-2d12-467b-895d-943f318b7c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f87128-2d12-467b-895d-943f318b7c38.jpg?1",
             "name": "Magmaroth",
             "text": "At the beginning of your upkeep, put a -1/-1 counter on Magmaroth.\nWhenever you cast a noncreature spell, remove a -1/-1 counter from Magmaroth.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "35690152-40d1-548a-b765-b229e46a6a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03a9686-d30b-4048-8b0a-23fd2f0aed4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03a9686-d30b-4048-8b0a-23fd2f0aed4b.jpg?1",
             "name": "Manticore Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nManticore Eternal attacks each combat if able.",
             "colours": [
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "232b5560-25c5-5e78-9db1-4f0ad6fc8a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54231832-d492-4812-b658-4ab9a30fefe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54231832-d492-4812-b658-4ab9a30fefe2.jpg?1",
             "name": "Neheb, the Eternal",
             "text": "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\nAt the beginning of your postcombat main phase, add {R} to your mana pool for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "c37b43f6-0b65-56d0-b1e2-fd3ececc351b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f9fb5-ffb5-4325-9f81-ce8782e5f9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f9fb5-ffb5-4325-9f81-ce8782e5f9e9.jpg?1",
             "name": "Open Fire",
             "text": "Open Fire deals 3 damage to target creature or player.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "2f1027b1-ae1e-5962-a52e-146bca00a76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d88da5-d9a3-49b3-a091-458b058c9114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d88da5-d9a3-49b3-a091-458b058c9114.jpg?1",
             "name": "Puncturing Blow",
             "text": "Puncturing Blow deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "d77a320d-863c-50af-8787-b86315a548b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7153be-ad6c-47ff-8f45-bc8df17973cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7153be-ad6c-47ff-8f45-bc8df17973cb.jpg?1",
             "name": "Sand Strangler",
             "text": "When Sand Strangler enters the battlefield, if you control a Desert or there is a Desert card in your graveyard, you may have Sand Strangler deal 3 damage to target creature.",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "8f703ff2-775e-5120-8eb6-18a3c25003ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ab2615-5a02-4b59-b8bd-577b91a1a0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ab2615-5a02-4b59-b8bd-577b91a1a0e3.jpg?1",
             "name": "Thorned Moloch",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nThorned Moloch has first strike as long as it's attacking.",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "3df51c5a-8374-56b8-a913-8c0d9e37273c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd845479-619a-4262-b445-d93975c183b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd845479-619a-4262-b445-d93975c183b4.jpg?1",
             "name": "Wildfire Eternal",
             "text": "Afflict 4 (Whenever this creature becomes blocked, defending player loses 4 life.)\nWhenever Wildfire Eternal attacks and isn't blocked, you may cast an instant or sorcery card from your hand without paying its mana cost.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "9885f042-add6-51af-aa3c-2b2d92571c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc06303-cb35-4feb-b23d-7ac0a2fa7ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc06303-cb35-4feb-b23d-7ac0a2fa7ce3.jpg?1",
             "name": "Ambuscade",
             "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -3722,7 +3722,7 @@
         },
         {
             "id": "3c483fd1-ac6e-527b-bab9-e804c9ec8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c0cf0-df4a-4e50-8396-53713f925b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c0cf0-df4a-4e50-8396-53713f925b53.jpg?1",
             "name": "Beneath the Sands",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3754,7 +3754,7 @@
         },
         {
             "id": "004d92ae-0ce9-5f63-9e63-1451c4270c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfcf99-be2b-4e5f-adef-1977ee5c6a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfcf99-be2b-4e5f-adef-1977ee5c6a0f.jpg?1",
             "name": "Bitterbow Sharpshooters",
             "text": "Vigilance, reach",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "fbba740f-2ce1-5166-8de7-e1e9dcdca3d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977698ab-3b64-41f2-a214-ac95e04c9956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977698ab-3b64-41f2-a214-ac95e04c9956.jpg?1",
             "name": "Devotee of Strength",
             "text": "{4}{G}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3824,7 +3824,7 @@
         },
         {
             "id": "69872bb7-4607-53b2-bc65-d92a60614d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01818188-e18e-4dc0-b7ef-34cedef64f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01818188-e18e-4dc0-b7ef-34cedef64f7e.jpg?1",
             "name": "Dune Diviner",
             "text": "{1}, Tap an untapped Desert you control: You gain 1 life.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "b88c6b2f-7452-5282-a539-08f8022a07f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0431ad-185a-4917-b994-e58dd9850f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0431ad-185a-4917-b994-e58dd9850f5e.jpg?1",
             "name": "Feral Prowler",
             "text": "When Feral Prowler dies, draw a card.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "481f98a6-54d2-5303-9a5d-1ab301c8f388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b1be52-5e54-4840-bb53-0b2512785e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b1be52-5e54-4840-bb53-0b2512785e0b.jpg?1",
             "name": "Frilled Sandwalla",
             "text": "{1}{G}: Frilled Sandwalla gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "b1cf1064-7166-513c-9125-32450b5ac937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b779620-6bac-445e-a6fe-6d770c0a9c70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b779620-6bac-445e-a6fe-6d770c0a9c70.jpg?1",
             "name": "Gift of Strength",
             "text": "Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -3959,7 +3959,7 @@
         },
         {
             "id": "0a8978e2-2516-5588-89ca-3e8abd3c0e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg?1",
             "name": "Harrier Naga",
             "text": "",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "2823ef1f-f1e1-528f-8233-c94da63a07ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffb676d-54b7-4d30-9c84-ff9b48030705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffb676d-54b7-4d30-9c84-ff9b48030705.jpg?1",
             "name": "Hope Tender",
             "text": "{1}, {T}: Untap target land.\n{1}, {T}, Exert Hope Tender: Untap two target lands. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "2299967c-747e-577d-aacc-b819687cdc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee374f-31dc-4b2c-beba-431d5b1126d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ee374f-31dc-4b2c-beba-431d5b1126d0.jpg?1",
             "name": "Hour of Promise",
             "text": "Search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library. Then if you control three or more Deserts, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "03a4592e-6a1f-52f5-92b9-8b5769740dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f39c264-a9a5-46f3-bd67-01d93d69e457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f39c264-a9a5-46f3-bd67-01d93d69e457.jpg?1",
             "name": "Life Goes On",
             "text": "You gain 4 life. If a creature died this turn, you gain 8 life instead.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "c2757919-baf3-51df-89d3-28b6f229a700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d47cc7-2849-432e-9bcd-6b97023f1969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d47cc7-2849-432e-9bcd-6b97023f1969.jpg?1",
             "name": "Majestic Myriarch",
             "text": "Majestic Myriarch's power and toughness are each equal to twice the number of creatures you control.\nAt the beginning of each combat, if you control a creature with flying, Majestic Myriarch gains flying until end of turn. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -4127,7 +4127,7 @@
         },
         {
             "id": "ffa74dcd-dd8d-53c2-af9a-25b9b9bfceeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86326456-d188-4083-9141-a639b821b291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86326456-d188-4083-9141-a639b821b291.jpg?1",
             "name": "Nissa's Defeat",
             "text": "Destroy target Forest, green enchantment, or green planeswalker. If that permanent was a Nissa planeswalker, draw a card.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "0c202d3b-b4f5-5953-9325-c843c65e2f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb49b-956e-44bc-8a32-46d4c9c13245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb49b-956e-44bc-8a32-46d4c9c13245.jpg?1",
             "name": "Oasis Ritualist",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}, Exert Oasis Ritualist: Add two mana of any one color to your mana pool. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4194,7 +4194,7 @@
         },
         {
             "id": "c2deeb98-bd8b-5a15-91c6-a528224fe1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dc2427-685a-4739-8b92-e60f134d4adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dc2427-685a-4739-8b92-e60f134d4adb.jpg?1",
             "name": "Overcome",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "b76be63d-7324-5cfb-af3b-d758248c6aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3d32b7-672f-4ceb-a1c9-17daefd2cb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3d32b7-672f-4ceb-a1c9-17daefd2cb0c.jpg?1",
             "name": "Pride Sovereign",
             "text": "Pride Sovereign gets +1/+1 for each other Cat you control.\n{W}, {T}, Exert Pride Sovereign: Create two 1/1 white Cat creature tokens with lifelink. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "4de575c7-69cf-5968-bde2-c27d61be7519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e11478-bfc7-4bcc-b65c-dc2d4449e99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e11478-bfc7-4bcc-b65c-dc2d4449e99f.jpg?1",
             "name": "Quarry Beetle",
             "text": "When Quarry Beetle enters the battlefield, you may return target land card from your graveyard to the battlefield.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "517044f9-5a08-5d86-9391-75d3b2262bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c97229f-2fc8-439a-a18b-efa09b366b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c97229f-2fc8-439a-a18b-efa09b366b70.jpg?1",
             "name": "Rampaging Hippo",
             "text": "Trample\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "25bd760e-7f64-56bb-9021-f8289bfd3229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a54d18-8403-441d-a115-ee462fabdabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a54d18-8403-441d-a115-ee462fabdabb.jpg?1",
             "name": "Ramunap Excavator",
             "text": "You may play land cards from your graveyard.",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "a9f39ac3-0322-5b25-99bd-9bef640a381e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f3722-2126-4eb3-a3d8-cff4b0703a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f3722-2126-4eb3-a3d8-cff4b0703a9c.jpg?1",
             "name": "Ramunap Hydra",
             "text": "Vigilance, reach, trample\nRamunap Hydra gets +1/+1 as long as you control a Desert.\nRamunap Hydra gets +1/+1 as long as there is a Desert card in your graveyard.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "18fcc4b1-e865-50b8-948e-4e3f948e713b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033a69fb-2af9-426c-b1d6-3e5b18c78c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033a69fb-2af9-426c-b1d6-3e5b18c78c9a.jpg?1",
             "name": "Resilient Khenra",
             "text": "When Resilient Khenra enters the battlefield, you may have target creature get +X/+X until end of turn, where X is Resilient Khenra's power.\nEternalize {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Jackal Wizard with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "771f848b-35a2-585f-bc4d-77f1ddd1ad66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e991d1eb-70ab-4e2c-862d-fb8bfcefc542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e991d1eb-70ab-4e2c-862d-fb8bfcefc542.jpg?1",
             "name": "Rhonas's Last Stand",
             "text": "Create a 5/4 green Snake creature token. Lands you control don't untap during your next untap step.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "68ce379d-058d-5caf-9b0a-1bdcb7f9a85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d4f791-9084-4644-a1f5-85adbf6dc790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d4f791-9084-4644-a1f5-85adbf6dc790.jpg?1",
             "name": "Rhonas's Stalwart",
             "text": "You may exert Rhonas's Stalwart as it attacks. When you do, it gets +1/+1 until end of turn and can't be blocked by creatures with power 2 or less this turn. (An exerted creature won't untap during your next untap step.)",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "55fd9ecf-324c-5ff8-ab9d-a912dc3d4e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3786d75-1a8a-4917-aa98-6836df1b9145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3786d75-1a8a-4917-aa98-6836df1b9145.jpg?1",
             "name": "Sidewinder Naga",
             "text": "As long as you control a Desert or there is a Desert card in your graveyard, Sidewinder Naga gets +1/+0 and has trample.",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "18091443-fd1f-519a-9b63-69a62f2dfd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbaf7e3-e2fc-4399-aa83-c13df43008a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dbaf7e3-e2fc-4399-aa83-c13df43008a0.jpg?1",
             "name": "Sifter Wurm",
             "text": "Trample\nWhen Sifter Wurm enters the battlefield, scry 3, then reveal the top card of your library. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "2ce39e23-9823-52b0-945e-6ba4e7431bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eec0010-52ab-4bf2-b589-e7fd97c290fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eec0010-52ab-4bf2-b589-e7fd97c290fe.jpg?1",
             "name": "Tenacious Hunter",
             "text": "As long as a creature has a -1/-1 counter on it, Tenacious Hunter has vigilance and deathtouch.",
             "colours": [
@@ -4604,7 +4604,7 @@
         },
         {
             "id": "d369b012-0f80-50a7-b68b-912581df194c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4aa918-53b9-4177-a859-f5a8eff09fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4aa918-53b9-4177-a859-f5a8eff09fe5.jpg?1",
             "name": "Uncage the Menagerie",
             "text": "Search your library for up to X creature cards with different names that each have converted mana cost X, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "3e65a929-0c1e-59c3-8a80-327307babada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d0a04-b640-4d1d-b538-2d946c1ff913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474d0a04-b640-4d1d-b538-2d946c1ff913.jpg?1",
             "name": "Bloodwater Entity",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Bloodwater Entity enters the battlefield, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "b9e4d55e-7ce2-544d-8e5a-b77639b5714f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0c1d0a-2651-4961-8b70-ff78093732ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0c1d0a-2651-4961-8b70-ff78093732ce.jpg?1",
             "name": "The Locust God",
             "text": "Flying\nWhenever you draw a card, create a 1/1 blue and red Insect creature token with flying and haste.\n{2}{U}{R}: Draw a card, then discard a card.\nWhen The Locust God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "97cf4661-6eed-5251-afa7-29f495a9b941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e92f4-3904-41df-91f7-42eedbe3ccd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e92f4-3904-41df-91f7-42eedbe3ccd2.jpg?1",
             "name": "Nicol Bolas, God-Pharaoh",
             "text": "+2: Target opponent exiles cards from the top of his or her library until he or she exiles a nonland card. Until end of turn, you may cast that card without paying its mana cost.\n+1: Each opponent exiles two cards from his or her hand.\n\u22124: Nicol Bolas, God-Pharaoh deals 7 damage to target opponent or creature an opponent controls.\n\u221212: Exile each nonland permanent your opponents control.",
             "colours": [
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "873f9f77-c4f3-5afe-9dcc-296841f35523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae054604-0d77-45d0-b17b-55a83fb18e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae054604-0d77-45d0-b17b-55a83fb18e39.jpg?1",
             "name": "Obelisk Spider",
             "text": "Reach\nWhenever Obelisk Spider deals combat damage to a creature, put a -1/-1 counter on that creature.\nWhenever you put one or more -1/-1 counters on a creature, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "f9cffddd-c246-5ae6-b567-d08295ec36c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713f469e-58c3-4db4-aa7a-77126bda13f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/713f469e-58c3-4db4-aa7a-77126bda13f2.jpg?1",
             "name": "Resolute Survivors",
             "text": "You may exert Resolute Survivors as it attacks. (It won't untap during your next untap step.)\nWhenever you exert a creature, Resolute Survivors deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "c5251a7e-62a9-5db4-9bb9-05eadfc1bb50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ec4c2-aae2-403e-af32-3324122c472a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ec4c2-aae2-403e-af32-3324122c472a.jpg?1",
             "name": "River Hoopoe",
             "text": "Flying\n{3}{G}{U}: You gain 2 life and draw a card.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "a53c626a-d931-5489-ab2f-9348f77591e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f06f55-7918-46c4-80ff-0bf39e091a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f06f55-7918-46c4-80ff-0bf39e091a4a.jpg?1",
             "name": "Samut, the Tested",
             "text": "+1: Up to one target creature gains double strike until end of turn.\n\u22122: Samut, the Tested deals 2 damage divided as you choose among one or two target creatures and/or players.\n\u22127: Search your library for up to two creature and/or planeswalker cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "c750f8b5-1259-528c-b113-8829a14e80d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621cfd79-be4e-41e3-95ce-62b0eeff5baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621cfd79-be4e-41e3-95ce-62b0eeff5baf.jpg?1",
             "name": "The Scarab God",
             "text": "At the beginning of your upkeep, each opponent loses X life and you scry X, where X is the number of Zombies you control.\n{2}{U}{B}: Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.\nWhen The Scarab God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "ab2f6dcd-8ed0-561c-8aea-4a9260a2e57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0d0ac-6422-486e-b42b-e1813dd0a23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def0d0ac-6422-486e-b42b-e1813dd0a23e.jpg?1",
             "name": "The Scorpion God",
             "text": "Whenever a creature with a -1/-1 counter on it dies, draw a card.\n{1}{B}{R}: Put a -1/-1 counter on another target creature.\nWhen The Scorpion God dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "8a9ad5d7-a7ae-57c6-94fc-d10a1990d725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3802f3-feb3-4dcd-a5ba-f493baf3d447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3802f3-feb3-4dcd-a5ba-f493baf3d447.jpg?1",
             "name": "Unraveling Mummy",
             "text": "{1}{W}: Target attacking Zombie gains lifelink until end of turn.\n{1}{B}: Target attacking Zombie gains deathtouch until end of turn.",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "c96e7305-f5c0-51cd-94c9-bbc47377a847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg?1",
             "name": "Farm // Market",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "c0e0ca48-6241-5e4a-8b35-a5c322546317",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d998db65-8785-4ee9-940e-fa9ab62e180f.jpg?1",
             "name": "Farm // Market",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDraw two cards, then discard two cards.",
             "colours": [
@@ -5075,7 +5075,7 @@
         },
         {
             "id": "7dccf77f-fb2c-527d-9611-51d042c35c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg?1",
             "name": "Consign // Oblivion",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "d5645482-98df-52f2-99e3-63c5f9acec18",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c1ead90-10d8-4217-80e4-6f40320c5569.jpg?1",
             "name": "Consign // Oblivion",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget opponent discards two cards.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "f7d57482-4b76-5c59-9e0d-19fc4616b605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg?1",
             "name": "Claim // Fame",
             "text": "Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -5174,7 +5174,7 @@
         },
         {
             "id": "7250b98f-aba3-52e7-a7eb-5db86eaf427f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/15b0f214-8668-4921-88ba-7ccf38c9f770.jpg?1",
             "name": "Claim // Fame",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTarget creature gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "49fb02c7-49c0-5eed-b547-431c64546b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg?1",
             "name": "Struggle // Survive",
             "text": "Struggle deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "13d3b70a-003e-568e-9cab-d8bfa6a24b22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76f21f0b-aaa5-4677-8398-cef98c6fac2a.jpg?1",
             "name": "Struggle // Survive",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nEach player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "c74b3d87-9240-5181-811d-84c22c2ec873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg?1",
             "name": "Appeal // Authority",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.",
             "colours": [
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "0a894f7b-0dc8-566d-95d4-b780d19d2aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c25b8ef-6331-49df-9457-b8b4e44da2c9.jpg?1",
             "name": "Appeal // Authority",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nTap up to two target creatures your opponents control. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "5226f792-da6b-59db-8ca8-a80e488284b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg?1",
             "name": "Leave // Chance",
             "text": "Return any number of target permanents you own to your hand.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "0d89fce1-8041-54bd-ac7f-963b88e51a05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f928e8e8-aa20-402c-85bd-59106e9b9cc7.jpg?1",
             "name": "Leave // Chance",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nDiscard any number of cards, then draw that many cards.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "e9724b0e-dc11-5eed-a095-0de10f996bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg?1",
             "name": "Reason // Believe",
             "text": "Scry 3.",
             "colours": [
@@ -5438,7 +5438,7 @@
         },
         {
             "id": "ee68cb5a-ce11-5cb3-9601-bf854e6ed323",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca644e3-4fb3-4d38-b714-e3d7459bd8b9.jpg?1",
             "name": "Reason // Believe",
             "text": "Aftermath\nLook at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "fa414a0a-ce09-5c11-b6b8-c263d45aa4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg?1",
             "name": "Grind // Dust",
             "text": "Put a -1/-1 counter on each of up to two target creatures.",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "852ce01a-0c3e-51f1-b2cb-7e2a189d76fd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0383401f-d453-4e8f-82d2-5c016acc2591.jpg?1",
             "name": "Grind // Dust",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nExile any number of target creatures that have -1/-1 counters on them.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "7e1f20b1-f2bd-52ad-ac39-1e490018d067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg?1",
             "name": "Refuse // Cooperate",
             "text": "Refuse deals damage to target spell's controller equal to that spell's converted mana cost.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "5081088f-8d64-5649-857a-7496bbb26294",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054b07d8-99ae-430b-8e54-f9601fa572e7.jpg?1",
             "name": "Refuse // Cooperate",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "b1e82c03-4ed1-5339-a46d-4920792ed449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg?1",
             "name": "Driven // Despair",
             "text": "Until end of turn, creatures you control gain trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "f2177eb9-4646-5ee7-8e36-84d353e1bec0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/7713ba59-dd4c-4b49-93a7-292728df86b8.jpg?1",
             "name": "Driven // Despair",
             "text": "Aftermath\nUntil end of turn, creatures you control gain menace and \"Whenever this creature deals combat damage to a player, that player discards a card.\"",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "ff3e3eb6-1132-596f-9148-953a2e3da20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191fb87-f111-4ac2-a52a-3af103a9314e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191fb87-f111-4ac2-a52a-3af103a9314e.jpg?1",
             "name": "Abandoned Sarcophagus",
             "text": "You may cast nonland cards with cycling from your graveyard.\nIf a card with cycling would be put into your graveyard from anywhere and it wasn't cycled, exile it instead.",
             "colours": [],
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "ac6f1d10-ec92-5045-b531-3c1d85044fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f6d7c2-ee4f-4cd0-a9a2-d8469ff89291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f6d7c2-ee4f-4cd0-a9a2-d8469ff89291.jpg?1",
             "name": "Crook of Condemnation",
             "text": "{1}, {T}: Exile target card from a graveyard.\n{1}, Exile Crook of Condemnation: Exile all cards from all graveyards.",
             "colours": [],
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "ee2ef81f-666b-587a-a363-552a8efced54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9d9d7-bc4e-4367-b27c-e8d6e430467e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9d9d7-bc4e-4367-b27c-e8d6e430467e.jpg?1",
             "name": "Dagger of the Worthy",
             "text": "Equipped creature gets +2/+0 and has afflict 1. (Whenever it becomes blocked, defending player loses 1 life.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5755,7 +5755,7 @@
         },
         {
             "id": "1a7c10f4-ad51-56c6-bc35-b70933f984b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e85a9e-4c37-4721-b7ea-de3413ec39df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e85a9e-4c37-4721-b7ea-de3413ec39df.jpg?1",
             "name": "God-Pharaoh's Gift",
             "text": "At the beginning of combat on your turn, you may exile a creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a 4/4 black Zombie. It gains haste until end of turn.",
             "colours": [],
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "8198d1f0-d143-5a13-9a57-e01d939ad44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89880f30-aa38-4231-8d16-25c644bde6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89880f30-aa38-4231-8d16-25c644bde6bf.jpg?1",
             "name": "Graven Abomination",
             "text": "Whenever Graven Abomination attacks, exile target card from defending player's graveyard.",
             "colours": [],
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "c4ed4661-40de-518d-b8af-12079e65d84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fe9c6d-4fa2-4f9a-9025-1bf12fe7ed9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fe9c6d-4fa2-4f9a-9025-1bf12fe7ed9f.jpg?1",
             "name": "Hollow One",
             "text": "Hollow One costs {2} less to cast for each card you've cycled or discarded this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "0fcfd5c4-723e-5aab-93bb-f7323817449d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b420ed-75b8-4779-aaa2-e245e84202d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b420ed-75b8-4779-aaa2-e245e84202d1.jpg?1",
             "name": "Manalith",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "b6f204be-a9a2-5c3b-9c39-21d808f3c078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29148d7e-b398-4e19-a29e-d9a660ad5016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29148d7e-b398-4e19-a29e-d9a660ad5016.jpg?1",
             "name": "Mirage Mirror",
             "text": "{2}: Mirage Mirror becomes a copy of target artifact, creature, enchantment, or land until end of turn.",
             "colours": [],
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "09a51b4b-a63a-52d8-a141-8dc26feeb4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377a4e80-0f28-42a2-9972-47ab66baee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377a4e80-0f28-42a2-9972-47ab66baee63.jpg?1",
             "name": "Sunset Pyramid",
             "text": "Sunset Pyramid enters the battlefield with three brick counters on it.\n{2}, {T}, Remove a brick counter from Sunset Pyramid: Draw a card.\n{2}, {T}: Scry 1.",
             "colours": [],
@@ -5929,7 +5929,7 @@
         },
         {
             "id": "0395ca43-dbfd-5455-80ed-c1804fc4c038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195464f1-f01c-4211-950d-963c5bad786f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195464f1-f01c-4211-950d-963c5bad786f.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -5957,7 +5957,7 @@
         },
         {
             "id": "5f7fee49-a922-57da-86cd-8f6b5708693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f8f211-79f9-4d34-8e23-c0835703cd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f8f211-79f9-4d34-8e23-c0835703cd91.jpg?1",
             "name": "Wall of Forgotten Pharaohs",
             "text": "Defender\n{T}: Wall of Forgotten Pharaohs deals 1 damage to target player. Activate this ability only if you control a Desert or there is a Desert card in your graveyard.",
             "colours": [],
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "2dc9cde3-6af8-5521-b969-d7998a6dad49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5b199-e79d-4ca9-970c-cfd9df8fd1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab5b199-e79d-4ca9-970c-cfd9df8fd1e4.jpg?1",
             "name": "Crypt of the Eternals",
             "text": "When Crypt of the Eternals enters the battlefield, you gain 1 life.\n{T}: Add {C} to your mana pool.\n{1}, {T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -6020,7 +6020,7 @@
         },
         {
             "id": "c81eee3f-b130-5752-ba94-61aea6700ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f547d664-25ce-4a24-b3ae-7bf3cbdf4703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f547d664-25ce-4a24-b3ae-7bf3cbdf4703.jpg?1",
             "name": "Desert of the Fervent",
             "text": "Desert of the Fervent enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "1ab2c8c5-98a5-5092-97ab-f1195483ea27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a19aea-209d-4354-8c59-d08244185eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a19aea-209d-4354-8c59-d08244185eb8.jpg?1",
             "name": "Desert of the Glorified",
             "text": "Desert of the Glorified enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nCycling {1}{B} ({1}{B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "86c9cfc9-8cc7-5642-bdc9-d1fb884c1d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42aa0c-0408-4b0d-bec5-9861dbcf9ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42aa0c-0408-4b0d-bec5-9861dbcf9ee1.jpg?1",
             "name": "Desert of the Indomitable",
             "text": "Desert of the Indomitable enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6116,7 +6116,7 @@
         },
         {
             "id": "ad2f92b0-6f31-5fda-b885-dc32e0bb2b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b92d87-776c-490f-9ff1-234e47145df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b92d87-776c-490f-9ff1-234e47145df8.jpg?1",
             "name": "Desert of the Mindful",
             "text": "Desert of the Mindful enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "c5cf207b-4a6d-557c-80a1-6c2da3e139b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d9308c-8af4-4587-b740-aea874d5ccae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d9308c-8af4-4587-b740-aea874d5ccae.jpg?1",
             "name": "Desert of the True",
             "text": "Desert of the True enters the battlefield tapped.\n{T}: Add {W} to your mana pool.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "92c45684-4357-5f7d-a9e1-3883336ce00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326c7483-2c45-4804-85c4-d40ecdba4fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326c7483-2c45-4804-85c4-d40ecdba4fc7.jpg?1",
             "name": "Dunes of the Dead",
             "text": "{T}: Add {C} to your mana pool.\nWhen Dunes of the Dead is put into a graveyard from the battlefield, create a 2/2 black Zombie creature token.",
             "colours": [],
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "4f0a27e8-cc5b-53ed-acf5-632f1a5d1778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebd3e0a-30cc-4bc1-b9fa-6d65db9a6f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebd3e0a-30cc-4bc1-b9fa-6d65db9a6f5b.jpg?1",
             "name": "Endless Sands",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}: Exile target creature you control.\n{4}, {T}, Sacrifice Endless Sands: Return each creature card exiled with Endless Sands to the battlefield under its owner's control.",
             "colours": [],
@@ -6240,7 +6240,7 @@
         },
         {
             "id": "3623249e-2a12-59b4-b036-dc71cf940fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bba75d2-3f1b-4828-be11-2da695f7bde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bba75d2-3f1b-4828-be11-2da695f7bde7.jpg?1",
             "name": "Hashep Oasis",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {G} to your mana pool.\n{1}{G}{G}, {T}, Sacrifice a Desert: Target creature gets +3/+3 until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "c30f214b-513e-59bd-9f81-7d7003e79a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c35cb-77e7-4600-a915-ccf327fe3385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250c35cb-77e7-4600-a915-ccf327fe3385.jpg?1",
             "name": "Hostile Desert",
             "text": "{T}: Add {C} to your mana pool.\n{2}, Exile a land card from your graveyard: Hostile Desert becomes a 3/4 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -6302,7 +6302,7 @@
         },
         {
             "id": "162303a8-38ed-55ca-b9e1-15ec20b8dae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b88728b-9b18-40c6-b634-f87f8da83665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b88728b-9b18-40c6-b634-f87f8da83665.jpg?1",
             "name": "Ifnir Deadlands",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {B} to your mana pool.\n{2}{B}{B}, {T}, Sacrifice a Desert: Put two -1/-1 counters on target creature an opponent controls. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "bd4079df-b93d-5137-a79b-06a3ed1797f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203011ef-3737-4fd1-bd23-0e531b5a7c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203011ef-3737-4fd1-bd23-0e531b5a7c32.jpg?1",
             "name": "Ipnu Rivulet",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {U} to your mana pool.\n{1}{U}, {T}, Sacrifice a Desert: Target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "6a7d2671-4374-5e08-8415-faf4b6c82a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11d41a-0d29-45e9-9d27-a41282b9e292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11d41a-0d29-45e9-9d27-a41282b9e292.jpg?1",
             "name": "Ramunap Ruins",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {R} to your mana pool.\n{2}{R}{R}, {T}, Sacrifice a Desert: Ramunap Ruins deals 2 damage to each opponent.",
             "colours": [],
@@ -6398,7 +6398,7 @@
         },
         {
             "id": "d807f64f-b71e-5467-abe9-f2f1464bc662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd91eeb-7abf-4538-91dc-47c736dfc237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd91eeb-7abf-4538-91dc-47c736dfc237.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice a Desert: Exile all cards from all graveyards.",
             "colours": [],
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "7ba86193-e572-5023-843f-d7ca0c543502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6077f4e9-5717-4048-b798-4f8d535a4170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6077f4e9-5717-4048-b798-4f8d535a4170.jpg?1",
             "name": "Shefet Dunes",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Pay 1 life: Add {W} to your mana pool.\n{2}{W}{W}, {T}, Sacrifice a Desert: Creatures you control get +1/+1 until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "57f13be1-910e-52a3-9c44-4dfba17e772f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b0404e-0f42-456b-91ce-f960195c4951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b0404e-0f42-456b-91ce-f960195c4951.jpg?1",
             "name": "Survivors' Encampment",
             "text": "{T}: Add {C} to your mana pool.\n{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6490,7 +6490,7 @@
         },
         {
             "id": "7a263ce3-bf16-5a5a-ad77-a0ca5b397126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20ec10e-78fc-49dc-a112-7863a34056b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20ec10e-78fc-49dc-a112-7863a34056b1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6527,7 +6527,7 @@
         },
         {
             "id": "a10ed875-dbe2-5f6f-a534-9980abbbeb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a735e9b5-1231-4aa9-9eb3-c83037b849f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a735e9b5-1231-4aa9-9eb3-c83037b849f2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "13612292-1094-5c52-855b-1b9d76a81743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5cb444-7b48-40c8-a4d9-3fee37429513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5cb444-7b48-40c8-a4d9-3fee37429513.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "a449e8f7-9b24-53c8-93af-4afbf5171535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad4e9cd-76e2-4ee0-8185-8b3aec3578ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad4e9cd-76e2-4ee0-8185-8b3aec3578ce.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "43647e8e-7297-5656-b2a6-26048516d6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c318bae5-5d3f-4e91-adfe-13c182511ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c318bae5-5d3f-4e91-adfe-13c182511ef7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "70adcf98-90cb-5239-b597-2e1fe3363d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce617aad-2c72-4b47-a9ae-51792459cffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce617aad-2c72-4b47-a9ae-51792459cffd.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "7ab20360-c04d-5c0b-9786-4ef470d5493f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fd89a6-56ef-4488-842b-27bf31d8c04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fd89a6-56ef-4488-842b-27bf31d8c04f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6749,7 +6749,7 @@
         },
         {
             "id": "bbfc7dbd-4cbb-5e91-94eb-13ddb3724188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4717cd-f9a7-4386-9091-d25218e23d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4717cd-f9a7-4386-9091-d25218e23d79.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6786,7 +6786,7 @@
         },
         {
             "id": "ecb091a7-e6d7-5577-bbbc-1083820cb49a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0830bbcf-ee78-4f8a-bc6c-547be3a9fc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0830bbcf-ee78-4f8a-bc6c-547be3a9fc4c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6823,7 +6823,7 @@
         },
         {
             "id": "b4662504-783e-539f-a91c-4b8e3cc36126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447f8dbc-2f09-4995-81e2-2dc1654031fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447f8dbc-2f09-4995-81e2-2dc1654031fd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "a066d360-e617-530e-a4b9-47212927372d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e864369-2837-4487-8eee-0d643889d642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e864369-2837-4487-8eee-0d643889d642.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "bb3de13b-7169-5ff6-af2e-8b8cc971989f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e439e2-2c7c-42fd-a47b-f615641f7392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e439e2-2c7c-42fd-a47b-f615641f7392.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "da94e20d-5e51-5ac5-b0b3-8a7b5d3843dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e7306-df23-4339-b3af-faf9effe0140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e7306-df23-4339-b3af-faf9effe0140.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6971,7 +6971,7 @@
         },
         {
             "id": "a5272f48-77a9-5398-9b04-1db1bc7b0953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cbd941-53ab-4b02-b96c-a9af7767e606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cbd941-53ab-4b02-b96c-a9af7767e606.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "5ae80a0f-08c7-5792-aa56-1c477128ce65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99aacd5-c692-4de8-b565-d5092598295d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99aacd5-c692-4de8-b565-d5092598295d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "66afc412-0014-5c0b-8104-970ac6bba526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2923c85a-4022-4cda-bcbb-bb000137f64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2923c85a-4022-4cda-bcbb-bb000137f64f.jpg?1",
             "name": "Nissa, Genesis Mage",
             "text": "+2: Untap up to two target creatures and up to two target lands.\n\u22123: Target creature gets +5/+5 until end of turn.\n\u221210: Look at the top ten cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7080,7 +7080,7 @@
         },
         {
             "id": "f5da01e9-925b-535d-822e-c3695c231aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468e488-94ce-4ae3-abe4-7782673a7e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0468e488-94ce-4ae3-abe4-7782673a7e62.jpg?1",
             "name": "Avid Reclaimer",
             "text": "{T}: Add {G} or {U} to your mana pool. If you control a Nissa planeswalker, you gain 2 life.",
             "colours": [
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "a1e0de95-16b6-560c-a6ba-3813d7a90db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c759e94-e437-4dda-af0f-6578c0a50619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c759e94-e437-4dda-af0f-6578c0a50619.jpg?1",
             "name": "Brambleweft Behemoth",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -7148,7 +7148,7 @@
         },
         {
             "id": "a4165e7c-a155-592a-83f9-455c159aaab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a489d5c7-ef57-4973-86ac-06234c308c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a489d5c7-ef57-4973-86ac-06234c308c3c.jpg?1",
             "name": "Nissa's Encouragement",
             "text": "Search your library and graveyard for a card named Forest, a card named Brambleweft Behemoth, and a card named Nissa, Genesis Mage. Reveal those cards, put them into your hand, then shuffle your library.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "bb1a2bd9-91fc-5e87-aa2f-e88555ec29f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d757641-a6e8-4584-b35e-be043c228134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d757641-a6e8-4584-b35e-be043c228134.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "0212b149-6b3d-59e5-8709-9f2cba006dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74239d78-1608-4b27-b2fd-8c7453f6b86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74239d78-1608-4b27-b2fd-8c7453f6b86b.jpg?1",
             "name": "Nicol Bolas, the Deceiver",
             "text": "+3: Each opponent loses 3 life unless that player sacrifices a nonland permanent or discards a card.\n\u22123: Destroy target creature. Draw a card.\n\u221211: Nicol Bolas, the Deceiver deals 7 damage to each opponent. You draw seven cards.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "19e1688e-e826-5f51-86da-0d9b11ec41ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d348eb-7db0-4209-8960-c6adc473417d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d348eb-7db0-4209-8960-c6adc473417d.jpg?1",
             "name": "Wasp of the Bitter End",
             "text": "Flying\nWhenever you cast a Bolas planeswalker spell, you may sacrifice Wasp of the Bitter End. If you do, destroy target creature.",
             "colours": [
@@ -7282,7 +7282,7 @@
         },
         {
             "id": "ff93f08c-02e6-586b-a448-1ed32babb862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d1cd4-7d0d-4279-bc2a-59bb21b06904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d1cd4-7d0d-4279-bc2a-59bb21b06904.jpg?1",
             "name": "Zealot of the God-Pharaoh",
             "text": "{4}{R}: Zealot of the God-Pharaoh deals 2 damage to target opponent.",
             "colours": [
@@ -7316,7 +7316,7 @@
         },
         {
             "id": "69ba0772-4500-5a74-8fe4-abe4a0d9f627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29bbfe2-d59f-4361-8ea4-6a8d1b909769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29bbfe2-d59f-4361-8ea4-6a8d1b909769.jpg?1",
             "name": "Visage of Bolas",
             "text": "When Visage of Bolas enters the battlefield, you may search your library and/or graveyard for a card named Nicol Bolas, the Deceiver, reveal it, and put it into your hand. If you search your library this way, shuffle it.\n{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7347,7 +7347,7 @@
         },
         {
             "id": "d12d46ae-6be6-54f2-be5c-9328f9a83118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caedf353-35f8-4b58-8ed9-183d29302be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caedf353-35f8-4b58-8ed9-183d29302be9.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7377,7 +7377,7 @@
         },
         {
             "id": "d4974282-1fae-53a6-84c1-db1374537f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc8556-a658-40e1-8a93-6a62af208a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc8556-a658-40e1-8a93-6a62af208a28.jpg?1",
             "name": "Adorned Pouncer",
             "text": "",
             "colours": [
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "46bbc6b1-67bd-5471-959a-8aeca495d287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eebe6c-5bc9-463c-b74c-eae79fc3c1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eebe6c-5bc9-463c-b74c-eae79fc3c1b6.jpg?1",
             "name": "Champion of Wits",
             "text": "",
             "colours": [
@@ -7448,7 +7448,7 @@
         },
         {
             "id": "1cfb9daa-8bf2-52e4-a048-b442f30a3a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c362d05-f2f7-4415-8937-f9f368986e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c362d05-f2f7-4415-8937-f9f368986e61.jpg?1",
             "name": "Dreamstealer",
             "text": "",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "54246804-4196-54aa-b8c2-5db7cc754529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb3bd7-5aef-495e-81ba-f5d287981dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb3bd7-5aef-495e-81ba-f5d287981dbd.jpg?1",
             "name": "Earthshaker Khenra",
             "text": "",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "33dc50f9-6044-5afb-b9d9-b23b91f7330d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d8aac-c032-4e0d-a8ef-99a7c53c7a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d8aac-c032-4e0d-a8ef-99a7c53c7a19.jpg?1",
             "name": "Proven Combatant",
             "text": "",
             "colours": [
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "77f2af28-01a6-5fb6-bf0b-b263c23cea8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1326c5d-b5a5-4942-b15d-37830ac62c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1326c5d-b5a5-4942-b15d-37830ac62c7d.jpg?1",
             "name": "Resilient Khenra",
             "text": "",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "4c97ece3-648a-5cdb-80c9-8ef423834674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513f2ce9-0127-4479-b37a-a835fbada8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513f2ce9-0127-4479-b37a-a835fbada8f8.jpg?1",
             "name": "Sinuous Striker",
             "text": "",
             "colours": [
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "5d63c444-2bf4-58e0-9987-c98dcfb45bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872694ba-0666-43c1-8884-47a2e92a127c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872694ba-0666-43c1-8884-47a2e92a127c.jpg?1",
             "name": "Steadfast Sentinel",
             "text": "",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "5186a529-39ed-5561-8577-2a86a9d17ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a9593-151e-47d0-b0de-5eb9f061515a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289a9593-151e-47d0-b0de-5eb9f061515a.jpg?1",
             "name": "Sunscourge Champion",
             "text": "",
             "colours": [
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "6637c9fd-5c78-5fd5-9854-e4a4d7b011ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b.jpg?1",
             "name": "Horse",
             "text": "",
             "colours": [
@@ -7735,7 +7735,7 @@
         },
         {
             "id": "a01fef88-79a9-5885-b1a9-354a1be3b6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57708b3d-ddfb-4924-b5c9-123aa9e967ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57708b3d-ddfb-4924-b5c9-123aa9e967ad.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "2a09eeab-3490-5d02-a556-ba650d80126e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae56d9e8-de05-456b-af32-b5992992ee15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae56d9e8-de05-456b-af32-b5992992ee15.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "01176210-5c0b-5a3b-87f8-5e521d2e116f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37022fc1-6a13-4873-9eaf-b827da73328e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37022fc1-6a13-4873-9eaf-b827da73328e.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],
@@ -7832,7 +7832,7 @@
         },
         {
             "id": "81416e88-9cbb-5add-ac03-ce34d7838db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d3368-6295-4db1-ac89-06c77175c6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d3368-6295-4db1-ac89-06c77175c6de.jpg?1",
             "name": "Punchcard",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ICE.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ICE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e56f418c-a350-5803-847d-ea0c82d49438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7526f-dba8-4483-b925-946164fc0ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7526f-dba8-4483-b925-946164fc0ae9.jpg?1",
             "name": "Adarkar Unicorn",
             "text": "oc\nT: Add either o\nU or o\nU and one colorless mana to your mana pool. This mana is usable only for cumulative upkeep. Play this ability as an interrupt.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "08caa01c-b2d4-5742-bdf8-64903c9b9dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f99c3e-dddc-492f-aab6-1d899346a385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f99c3e-dddc-492f-aab6-1d899346a385.jpg?1",
             "name": "Arctic Foxes",
             "text": "If defending player controls any snow-covered lands, no creature with power greater than 1 may be assigned to block Arctic Foxes.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "a1335d78-5a6e-5436-b1f3-7d96b76091e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94f3e87-1b39-49a8-ad0d-f18c854e298a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94f3e87-1b39-49a8-ad0d-f18c854e298a.jpg?1",
             "name": "Arenson's Aura",
             "text": "oo\nW Sacrifice an enchantment to destroy target enchantment.\no3o\nUoo\nU Counter target enchantment.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "c9c47303-74e3-5fe2-812f-d94a150df474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccbbc47-99c6-4ba9-95c2-992d5d2a67b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccbbc47-99c6-4ba9-95c2-992d5d2a67b2.jpg?1",
             "name": "Armor of Faith",
             "text": "Target creature gets +1/+1.\noo\nW Creature Armor of Faith enchants gets +0/+1 until end of turn.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "e0a5849a-ab9b-55cd-a263-36d4da9c06fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c558a8c4-035c-464e-9ff8-c188c1bb619e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c558a8c4-035c-464e-9ff8-c188c1bb619e.jpg?1",
             "name": "Battle Cry",
             "text": "Untap all white creatures you control. Any creature that blocks this turn gets +0/+1 until end of turn.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "4fcfa122-587d-5251-91f1-d03694a76852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfd4ee1-05f9-45ae-a31d-1225b271dbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfd4ee1-05f9-45ae-a31d-1225b271dbe6.jpg?1",
             "name": "Black Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any black cards. That creature cannot be blocked by black creatures.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "b50e467d-88e3-5e49-95e9-b98832d2fa36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a92f9-9bbc-4887-9fbc-0f7212fd5e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9a92f9-9bbc-4887-9fbc-0f7212fd5e66.jpg?1",
             "name": "Blessed Wine",
             "text": "Gain 1 life. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "ea10d39b-1006-5f56-8a28-7e5e471ff54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0683-9cfa-4439-a533-8773e7747ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fc0683-9cfa-4439-a533-8773e7747ec4.jpg?1",
             "name": "Blinking Spirit",
             "text": "o0: Return Blinking Spirit to owner's hand.",
             "colours": [
@@ -264,7 +264,7 @@
         },
         {
             "id": "aafcd972-9197-5422-82c1-77407680ddcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b423bb5a-eaac-4c1d-981a-1c635001fc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b423bb5a-eaac-4c1d-981a-1c635001fc5a.jpg?1",
             "name": "Blue Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any blue cards. That creature cannot be blocked by blue creatures.",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "290851be-48c6-5a06-a257-a0228ade6170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92f0d4a-23d8-47d4-b910-d142e0eefd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92f0d4a-23d8-47d4-b910-d142e0eefd3d.jpg?1",
             "name": "Call to Arms",
             "text": "Choose a color. As long as target opponent controls more cards of that color than any other color, all white creatures get +1/+1. If at any time that opponent does not control more cards of that color than any other color, bury Call to Arms.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "1c1a02cc-ea2c-5327-8340-f0eef2b1b085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5f8041-67fc-4e00-b119-d216e5cc5a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5f8041-67fc-4e00-b119-d216e5cc5a3a.jpg?1",
             "name": "Caribou Range",
             "text": "When Caribou Range comes into play, choose target land you control.\no\nWo\nW: Tap land Caribou Range enchants to put a Caribou token into play. Treat this token as a 0/1 white creature.\no0: Sacrifice a Caribou token to gain 1 life.",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "4594c8e8-617c-5a99-944d-0a775edd203e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528045d-3b80-48fd-b606-c132da052685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528045d-3b80-48fd-b606-c132da052685.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage against you from one black source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "fc6a079e-3cac-5cc7-952c-e40789ed131b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d377ec-c43c-43b9-934a-91b4d11650ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d377ec-c43c-43b9-934a-91b4d11650ab.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage against you from one blue source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "3c554814-4215-5d3a-b4ab-077543e6f103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487dfb1f-b3ab-4daa-bbd9-c43dc91a5fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487dfb1f-b3ab-4daa-bbd9-c43dc91a5fba.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage against you from one green source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -454,7 +454,7 @@
         },
         {
             "id": "0095dc15-9033-59d3-9931-00cf4bdc03e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790ce22-a94f-402e-bcc7-b98f71af9fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790ce22-a94f-402e-bcc7-b98f71af9fe5.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage against you from one red source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "e1399f87-13e9-5ff4-ad6f-c3b6e59c0890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bc4bb0-350c-424e-976e-b800915f7fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bc4bb0-350c-424e-976e-b800915f7fb4.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage against you from one white source. If a source deals damage to you more than once in a turn, you may pay o1 each time to prevent the damage.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "d2294aa6-f06a-5015-92eb-fa8cfa213a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b87a58-b20c-4f38-afa3-59d398195740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b87a58-b20c-4f38-afa3-59d398195740.jpg?1",
             "name": "Cold Snap",
             "text": "Cumulative Upkeep: o2\nDuring each player's upkeep, Cold Snap deals 1 damage to that player for each snow-covered land he or she controls.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "b79507c5-e039-54cf-81ec-999889b0337b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a815ed-c8b4-4414-8b27-ea612e2977e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a815ed-c8b4-4414-8b27-ea612e2977e2.jpg?1",
             "name": "Cooperation",
             "text": "Target creature gains banding.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "cfc80d68-92e9-5bc1-be60-5a684f161eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b21d29-050d-4704-a4c8-93e3b55086ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b21d29-050d-4704-a4c8-93e3b55086ac.jpg?1",
             "name": "Death Ward",
             "text": "Regenerate target creature.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "2efd1be9-e0ad-5ba6-834f-c3127dee074e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6085d0c-ab2b-445d-bf9d-0fa0a19183a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6085d0c-ab2b-445d-bf9d-0fa0a19183a2.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "fe6c6282-200d-5239-92e5-bb19716adb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97736696-3de3-416d-94cf-4fac792f23f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97736696-3de3-416d-94cf-4fac792f23f0.jpg?1",
             "name": "Drought",
             "text": "During your upkeep, pay o\nWo\nW or destroy Drought. Before a spell that requires o\nB as part of its casting cost may be cast or an ability that requires o\nB as part of its activation cost may be played, the controller of that spell or ability sacrifices a swamp for each o\nB in the spell's casting cost or the ability's activation cost.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "92ceaebc-dc95-5a68-996e-6d721b584612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bd8485-d63a-4077-a3d1-4d0f2f4d8035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bd8485-d63a-4077-a3d1-4d0f2f4d8035.jpg?1",
             "name": "Elvish Healer",
             "text": "oc\nT: Prevent 1 damage to any non-green creature or any player or up to 2 damage to any green creature.",
             "colours": [
@@ -707,7 +707,7 @@
         },
         {
             "id": "3914ef61-feb9-5a05-a59c-70f917689c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be77edac-9a8b-4b7f-a859-27df76b10aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be77edac-9a8b-4b7f-a859-27df76b10aa6.jpg?1",
             "name": "Enduring Renewal",
             "text": "Play with the cards in your hand face up on the table. If you draw a creature card from your library, discard it. Whenever a creature goes to your graveyard from play, put that creature into your hand.",
             "colours": [
@@ -738,7 +738,7 @@
         },
         {
             "id": "917a8faa-2f99-5a28-9a3f-3b1d11fb80ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3955e358-4285-44e2-9e24-9804346a6e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3955e358-4285-44e2-9e24-9804346a6e58.jpg?1",
             "name": "Energy Storm",
             "text": "Cumulative Upkeep: o1\nDamage dealt by instants, interrupts, and sorceries is reduced to 0.\nCreatures with flying do not untap during their controller's untap phase.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "c2f34a21-2828-5912-8652-c125a50268d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78446ead-61b0-485f-a5a9-b3e72d8075a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78446ead-61b0-485f-a5a9-b3e72d8075a7.jpg?1",
             "name": "Formation",
             "text": "Target creature gains banding until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "4c976a10-48f9-5557-9601-75e8b0ef89e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6358a1-37f0-4b40-93d4-4f1652c38404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6358a1-37f0-4b40-93d4-4f1652c38404.jpg?1",
             "name": "Fylgja",
             "text": "When Fylgja comes into play, put four healing counters on it.\no0: Remove a healing counter from Fylgja to prevent 1 damage to creature Fylgja enchants.\no2oo\nW Put a healing counter on Fylgja.",
             "colours": [
@@ -833,7 +833,7 @@
         },
         {
             "id": "8acad1d6-f8e9-5bbb-b135-fd57dc4f30a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4f5a28-0bd2-4cc4-b67f-324e89193caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4f5a28-0bd2-4cc4-b67f-324e89193caa.jpg?1",
             "name": "General Jarkeld",
             "text": "oc\nT: Switch the blocking creatures of two target attacking creatures; all defense must remain legal. Use this ability only during combat after defense is chosen and before damage is dealt.",
             "colours": [
@@ -869,7 +869,7 @@
         },
         {
             "id": "8e44adfb-7dae-561e-a792-2cc415963f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9266-c97e-4666-b0fa-1802a69a62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbf9266-c97e-4666-b0fa-1802a69a62cc.jpg?1",
             "name": "Green Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any green cards. That creature cannot be blocked by green creatures.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "47322217-3b88-55ae-8c82-31f1da0972f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b35c0f4-5633-4ea9-9bda-daaf787aebdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b35c0f4-5633-4ea9-9bda-daaf787aebdd.jpg?1",
             "name": "Hallowed Ground",
             "text": "o\nWoo\nW Return target non-snow-covered land you control to owner's hand.",
             "colours": [
@@ -933,7 +933,7 @@
         },
         {
             "id": "c19009e7-339f-5196-809b-87722141bce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6b2704-685e-4c74-875a-25846175e5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6b2704-685e-4c74-875a-25846175e5e4.jpg?1",
             "name": "Heal",
             "text": "Prevent 1 damage to any creature or player. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "c2cf9a59-f2f0-5a27-96eb-94a8fc84edba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5969875a-f647-4daf-b76c-d1514d45c312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5969875a-f647-4daf-b76c-d1514d45c312.jpg?1",
             "name": "Hipparion",
             "text": "Cannot be assigned to block a creature with power 3 or greater unless you pay an additional o1.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "2e7e1758-4fe7-5cdc-8426-6308f3faf40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6e0c8d-0fc1-4f52-8357-e550b0ac579a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6e0c8d-0fc1-4f52-8357-e550b0ac579a.jpg?1",
             "name": "Justice",
             "text": "During your upkeep, pay o\nWo\nW or destroy Justice. Whenever a red creature or spell deals damage, Justice deals an equal amount of damage to the controller of that creature or spell. If another spell or effect reduces the amount of damage a red creature or spell deals, it does not reduce the amount of damage dealt by Justice.",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "2e031458-479d-57e1-92d8-633e09796520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8402543e-5406-404f-95c4-800a1dce35f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8402543e-5406-404f-95c4-800a1dce35f1.jpg?1",
             "name": "Kelsinko Ranger",
             "text": "o1oo\nW Target green creature gains first strike until end of turn.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "2ef05878-1d21-5f6e-ba20-fa28096e77cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73bc4b6-f7d0-494c-9e60-48279c11b7b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73bc4b6-f7d0-494c-9e60-48279c11b7b6.jpg?1",
             "name": "Kjeldoran Elite Guard",
             "text": "oc\nT: Target creature gets +2/+2 until end of turn. If that creature leaves play this turn, bury Kjeldoran Elite Guard. Use this ability only when attack or defense is announced.",
             "colours": [
@@ -1096,7 +1096,7 @@
         },
         {
             "id": "3202ccd3-9ca3-52d8-b417-1e5e64878a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf41f17-8f82-4a8c-adec-0f3804faff3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf41f17-8f82-4a8c-adec-0f3804faff3b.jpg?1",
             "name": "Kjeldoran Guard",
             "text": "oc\nT: Target creature gets +1/+1 until end of turn. If that creature leaves play this turn, bury Kjeldoran Guard. Use this ability only when attack or defense is announced and only if defending player controls no snow-covered lands.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "0f407d33-d0bd-52ed-b458-fd2cb294ad36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg?1",
             "name": "Kjeldoran Knight",
             "text": "Banding\no1oo\nW +1/+0 until end of turn\no\nWoo\nW +0/+2 until end of turn",
             "colours": [
@@ -1164,7 +1164,7 @@
         },
         {
             "id": "8cd4fe98-e14f-5297-9fb1-44cdbca6aebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg?1",
             "name": "Kjeldoran Phalanx",
             "text": "Banding, first strike",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "be127cf9-c410-5b23-bc75-5201f2f7ae90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66343008-c38a-48a9-b767-fd2243103690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66343008-c38a-48a9-b767-fd2243103690.jpg?1",
             "name": "Kjeldoran Royal Guard",
             "text": "oc\nT: Redirect to Kjeldoran Royal Guard all damage dealt to you from unblocked creatures this turn.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "a7032ea7-d2bb-5930-875c-fed81407f377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0115e0-6192-48a9-9e58-f3ef77ef77c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0115e0-6192-48a9-9e58-f3ef77ef77c2.jpg?1",
             "name": "Kjeldoran Skycaptain",
             "text": "Banding, flying, first strike",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "52d79e0a-44e5-5744-aeff-2080b923d6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f794665a-8353-482a-b065-2a0777a8acda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f794665a-8353-482a-b065-2a0777a8acda.jpg?1",
             "name": "Kjeldoran Skyknight",
             "text": "Banding, flying, first strike",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "c34e5926-adff-5bf1-bbe1-ff02d819f493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce76f38f-566e-49ff-b197-510cfa1cb51c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce76f38f-566e-49ff-b197-510cfa1cb51c.jpg?1",
             "name": "Kjeldoran Warrior",
             "text": "Banding",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "11d1b80c-5af1-5c40-99c6-2dbcf26682b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4ed99-f38c-4e0f-9ff2-2e1e9126e6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4ed99-f38c-4e0f-9ff2-2e1e9126e6ef.jpg?1",
             "name": "Lightning Blow",
             "text": "Target creature gains first strike until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "86974850-7c07-52ff-ac2e-be1285523078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe1e5-69d2-401f-97cb-3cc01064bad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe1e5-69d2-401f-97cb-3cc01064bad3.jpg?1",
             "name": "Lost Order of Jarkeld",
             "text": "Lost Order of Jarkeld has power and toughness each equal to 1 plus the number of creatures target opponent controls.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "9598c560-1d64-5c63-b885-c59a036c59fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b28762d-1ab7-460e-b433-27f5fa858959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b28762d-1ab7-460e-b433-27f5fa858959.jpg?1",
             "name": "Mercenaries",
             "text": "Whenever Mercenaries damages a player, that player may pay o3 to prevent that damage.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "0ae5943a-3bc1-5d1a-a5cc-fe5ed747b161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5cb36-c43d-4c71-8019-9b683e160a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc5cb36-c43d-4c71-8019-9b683e160a0a.jpg?1",
             "name": "Order of the Sacred Torch",
             "text": "oc\nT: Pay 1 life to destroy target black spell. Effects that prevent or redirect damage cannot be used to counter this loss of life. Play this ability as an interrupt.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "ca59939b-a659-5073-af99-ab7bc85b7f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e55b10-375f-4b4f-b676-3b9b8085fdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e55b10-375f-4b4f-b676-3b9b8085fdd2.jpg?1",
             "name": "Order of the White Shield",
             "text": "Protection from black\noo\nW First strike until end of turn\no\nWoo\nW +1/+0 until end of turn",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "6028800a-0a4c-54bd-93e9-e7558bf98322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8b50fd-3d1d-4ea8-a3c7-98ca7a8a455e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8b50fd-3d1d-4ea8-a3c7-98ca7a8a455e.jpg?1",
             "name": "Prismatic Ward",
             "text": "When Prismatic Ward comes into play, choose a color; all damage dealt to target creature by sources of that color is reduced to 0.",
             "colours": [
@@ -1534,7 +1534,7 @@
         },
         {
             "id": "58a52255-1173-508e-8698-b9837596a251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e9f80e-5d75-45b7-9c66-c0f30996f4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e9f80e-5d75-45b7-9c66-c0f30996f4dc.jpg?1",
             "name": "Rally",
             "text": "All blocking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "c1c98e7a-8c5b-5800-bd6e-ee781c99cc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a734154-5944-42f4-a02e-c426a45847f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a734154-5944-42f4-a02e-c426a45847f3.jpg?1",
             "name": "Red Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any red cards. That creature cannot be blocked by red creatures.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "f6d1f3ed-c56b-53dc-826c-adaca31cfaba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d721569d-9cf2-4c3c-b11c-4c46c258a0d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d721569d-9cf2-4c3c-b11c-4c46c258a0d2.jpg?1",
             "name": "Sacred Boon",
             "text": "Prevent up to 3 damage to target creature. At end of turn, put a +0/+1 counter on that creature for each 1 damage prevented by Sacred Boon.",
             "colours": [
@@ -1629,7 +1629,7 @@
         },
         {
             "id": "fe46c86a-069d-58bb-9f7c-6bd439e382a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab675291-3189-43f3-b11b-0724eca8b941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab675291-3189-43f3-b11b-0724eca8b941.jpg?1",
             "name": "Seraph",
             "text": "Flying\nAt the end of a turn in which any creature is damaged by Seraph and put into the graveyard, put that creature directly into play under your control as though it were just summoned. If you lose control of Seraph or if Seraph leaves play, bury the creature.",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "0a6b613a-60cc-5303-b39c-887b73163340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ff2da-d309-469c-8e2f-fa3c7517a15a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ff2da-d309-469c-8e2f-fa3c7517a15a.jpg?1",
             "name": "Shield Bearer",
             "text": "Banding",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "d9bf2cf5-f6b5-5c0f-aaea-a8f0b90c460a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084437ba-26d4-4af6-ab00-dcb145dd2cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084437ba-26d4-4af6-ab00-dcb145dd2cd0.jpg?1",
             "name": "Snow Hound",
             "text": "o1,oc\nT: Return Snow Hound to owner's hand and target blue or green creature you control to owner's hand.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "545d6490-df91-5d62-af72-3f40bd0e4cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fd2cb-443b-4be4-ad60-6d1a8e74f510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375fd2cb-443b-4be4-ad60-6d1a8e74f510.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Remove target creature from the game. That creature's controller gains life equal to its power.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "a14074a2-790d-5149-945e-a0b13a380f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca5b4a7-df11-4635-a147-df12cd13a67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca5b4a7-df11-4635-a147-df12cd13a67c.jpg?1",
             "name": "Warning",
             "text": "Target attacking creature deals no damage in combat this turn.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "b77a7121-b13f-5b1a-8735-d7c9ff6756d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57726b5-dfdd-4e47-bc52-ebf6eedbf3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57726b5-dfdd-4e47-bc52-ebf6eedbf3bd.jpg?1",
             "name": "White Scarab",
             "text": "Target creature gets +2/+2 as long as any opponent controls any white cards. That creature cannot be blocked by white creatures.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "76f7c342-0da9-53c2-adfe-5ada4c99d732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2307fb16-8b77-45b5-8a02-51a13214791d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2307fb16-8b77-45b5-8a02-51a13214791d.jpg?1",
             "name": "Arnjlot's Ascent",
             "text": "Cumulative Upkeep: o\nU\no1: Target creature gains flying until end of turn.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "42fada9e-e376-5304-b72c-656b3748ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b616963-fac0-451c-8df4-2cacc9466b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b616963-fac0-451c-8df4-2cacc9466b17.jpg?1",
             "name": "Balduvian Conjurer",
             "text": "oc\nT: Target snow-covered land becomes a 2/2 creature until end of turn. The target still counts as land but cannot be tapped for mana if it came into play on a side this turn.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "0bc7a822-3667-5dca-9783-8b8e879304b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74859723-8ddf-4ee6-a0a7-87192c84e8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74859723-8ddf-4ee6-a0a7-87192c84e8ad.jpg?1",
             "name": "Balduvian Shaman",
             "text": "oc\nT: Permanently change the text of target white enchantment you control that does not have cumulative upkeep by replacing all instances of one color word with another. For example, you may change \"Counters black spells\" to \"Counters blue spells.\" Balduvian Shaman cannot change mana symbols. That enchantment now has Cumulative Upkeep: o1.",
             "colours": [
@@ -1924,7 +1924,7 @@
         },
         {
             "id": "1f4bff84-b5ff-557e-b86d-6cd341583954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b086186-5fbf-4ba7-af0d-ee3ad61d27bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b086186-5fbf-4ba7-af0d-ee3ad61d27bb.jpg?1",
             "name": "Binding Grasp",
             "text": "During your upkeep, pay o1o\nU or bury Binding Grasp.\nGain control of target creature; that creature gets +0/+1.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "c1683c57-1795-53bd-98a9-8e0a05c5a406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d42d7aa-7f53-4cfc-842a-086aab2448d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d42d7aa-7f53-4cfc-842a-086aab2448d1.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards; then, take two cards from your hand and put them on top of your library in any order.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "e121c45d-7f2b-57fb-86d6-3b41587a5d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40c9657-fab4-489d-8eb0-960ba2605add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e40c9657-fab4-489d-8eb0-960ba2605add.jpg?1",
             "name": "Breath of Dreams",
             "text": "Cumulative Upkeep: o\nU\nGreen creatures each require an additional Cumulative Upkeep: o1.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "4bd5f141-8622-578c-a1e1-85970666299e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46740353-e2ba-4d80-a97d-1368bc67bf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46740353-e2ba-4d80-a97d-1368bc67bf30.jpg?1",
             "name": "Clairvoyance",
             "text": "Look at target player's hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "4e5f706e-e67b-5cc9-bf93-dc853d738d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedbcbaa-40f0-485f-8427-778edc2d2ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedbcbaa-40f0-485f-8427-778edc2d2ec0.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "81695af1-c685-5185-b2bd-51d1a988af04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a00a-6a0e-44cb-abea-37e2e53125e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1005a00a-6a0e-44cb-abea-37e2e53125e2.jpg?1",
             "name": "Deflection",
             "text": "Target spell, which must have a single target, targets a new legal target of your choice.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "0db901db-db12-5822-8b69-fb2917a0df88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93372854-57e7-4db7-a1a6-376c9f49a514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93372854-57e7-4db7-a1a6-376c9f49a514.jpg?1",
             "name": "Dreams of the Dead",
             "text": "o1oo\nU Take target white or black creature from your graveyard and put it directly into play as though it were just summoned. That creature now requires an additional Cumulative Upkeep: o2. If the creature leaves play, remove it from the game.",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "6748f29b-1044-53d5-8709-783205cfe350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fdfc5b-c2ab-4c4d-b120-301e17f3d9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fdfc5b-c2ab-4c4d-b120-301e17f3d9c6.jpg?1",
             "name": "Enervate",
             "text": "Tap target artifact, creature, or land. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "55a7f0d0-f714-586f-b81f-eb726439e83b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61648ddb-6efb-43d0-b2b1-418cc957854c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61648ddb-6efb-43d0-b2b1-418cc957854c.jpg?1",
             "name": "Errant Minion",
             "text": "During target creature's controller's upkeep, Errant Minion deals 2 damage to him or her. He or she may pay o1 for each 1 damage he or she wishes to prevent from Errant Minion.",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "8962a3f3-972b-585d-b743-e82da1acce58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ebb5dd-d7f1-4b06-8585-7004045be542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ebb5dd-d7f1-4b06-8585-7004045be542.jpg?1",
             "name": "Essence Flare",
             "text": "Target creature gets +2/+0. During each of its controller's upkeeps, put a -0/-1 counter on the creature. These counters remain even if Essence Flare is removed.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "3abaa8cd-0c40-5069-9103-1771454c0793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226555ba-22af-45f1-a3f4-d265f8685dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226555ba-22af-45f1-a3f4-d265f8685dd5.jpg?1",
             "name": "Force Void",
             "text": "Counter target spell unless that spell's caster pays an additional o1. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2271,7 +2271,7 @@
         },
         {
             "id": "49564e5d-6cec-5bcf-8186-d81ed903ebbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b71bc1-d9a2-4e99-a8fa-cd696925328d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b71bc1-d9a2-4e99-a8fa-cd696925328d.jpg?1",
             "name": "Glacial Wall",
             "text": "",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "fa48c996-f891-5e01-b6bf-001b386ecc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62716f0-fde2-49ef-b8a4-c1b03f451194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62716f0-fde2-49ef-b8a4-c1b03f451194.jpg?1",
             "name": "Hydroblast",
             "text": "Counter target spell if it is red or destroy target permanent if it is red.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "b0becf20-d1c5-5a62-9506-1d6c2532d9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f70e49-17fa-4033-bd45-63374f7f5ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f70e49-17fa-4033-bd45-63374f7f5ec5.jpg?1",
             "name": "Iceberg",
             "text": "When Iceberg comes into play, put X ice counters on it.\no3: Put an ice counter on Iceberg.\no0: Remove an ice counter from Iceberg to add one colorless mana to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -2366,7 +2366,7 @@
         },
         {
             "id": "431d6245-86b1-5c68-a8d3-671660cdae84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7e496-8d2e-49db-b298-475d9017537a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7e496-8d2e-49db-b298-475d9017537a.jpg?1",
             "name": "Icy Prison",
             "text": "When Icy Prison comes into play, remove target creature from the game. When Icy Prison leaves play, return that creature to play under its owner's control as though it were just summoned. During your upkeep, destroy Icy Prison. Any player may pay o3 to prevent this.",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "2c6a8071-2b56-573d-8f99-5d7c9d37af21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab02268e-01cf-4729-95ca-5773afd40b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab02268e-01cf-4729-95ca-5773afd40b56.jpg?1",
             "name": "Illusionary Forces",
             "text": "Flying\nCumulative Upkeep: o\nU",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "e695ac6c-45cf-58ac-b8b8-017d7741ec29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa31efed-4a11-4f59-a623-bac45d20091d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa31efed-4a11-4f59-a623-bac45d20091d.jpg?1",
             "name": "Illusionary Presence",
             "text": "Cumulative Upkeep: o\nU\nDuring your upkeep, Illusionary Presence gains a landwalk ability of your choice until end of turn.",
             "colours": [
@@ -2463,7 +2463,7 @@
         },
         {
             "id": "36ef2500-08a5-5f96-aafc-c3515c81587b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691f4a1b-4706-41aa-82da-ae920739f036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691f4a1b-4706-41aa-82da-ae920739f036.jpg?1",
             "name": "Illusionary Terrain",
             "text": "Cumulative Upkeep: o2\nAll basic lands of one type become basic lands of a different type of your choice.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "a5460c85-3154-5439-8868-4366381c5e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430e8e2-fee3-4744-820e-d6e16cb992bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6430e8e2-fee3-4744-820e-d6e16cb992bd.jpg?1",
             "name": "Illusionary Wall",
             "text": "Flying, first strike\nCumulative Upkeep: o\nU",
             "colours": [
@@ -2528,7 +2528,7 @@
         },
         {
             "id": "a16252b5-83ec-5709-b42a-00fed3941629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eeeef2-2ced-42b8-a5e0-1095c9e13b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eeeef2-2ced-42b8-a5e0-1095c9e13b02.jpg?1",
             "name": "Illusions of Grandeur",
             "text": "Cumulative Upkeep: o2\nWhen Illusions of Grandeur comes into play, gain 20 life. When Illusions of Grandeur leaves play, lose 20 life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "fdb5493b-3165-535f-9164-e592f6eb5ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223287b6-224c-4e00-946c-e7ac5539bd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223287b6-224c-4e00-946c-e7ac5539bd45.jpg?1",
             "name": "Infuse",
             "text": "Untap target artifact, creature, or land. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "afb52a89-909e-53f7-a850-c50ecae2857e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc053-7b0b-4e76-bf87-ccdb1e8752ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c5fc053-7b0b-4e76-bf87-ccdb1e8752ed.jpg?1",
             "name": "Krovikan Sorcerer",
             "text": "oc\nT: Choose and discard a card from your hand to draw a card. If the card discarded was black, draw two cards instead of one; keep one and discard the other.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "8e7b054e-1a32-5ac4-9f71-4ea0a3181fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86da04e9-b94d-42af-add3-02baf772bd33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86da04e9-b94d-42af-add3-02baf772bd33.jpg?1",
             "name": "Magus of the Unseen",
             "text": "o1o\nU,oc\nT: Untap target artifact opponent controls and gain control of it until end of turn. If that artifact is an artifact creature, it can attack, and you may use any of its abilities that require oc\nT as part of the activation cost. When you lose control of the artifact, tap it.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "f1de1621-c0fb-5f31-82fd-e840110fa10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3df593-e9d5-479d-9a9a-1c7262dd9c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3df593-e9d5-479d-9a9a-1c7262dd9c6c.jpg?1",
             "name": "Mesmeric Trance",
             "text": "Cumulative Upkeep: o1\noo\nU Discard a card from your hand to draw a card.",
             "colours": [
@@ -2689,7 +2689,7 @@
         },
         {
             "id": "412c085c-d9bc-5724-8699-6e7a78ad4338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3f4d4e-ca4a-4fba-b9fd-cd1d9457cfa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3f4d4e-ca4a-4fba-b9fd-cd1d9457cfa1.jpg?1",
             "name": "Mistfolk",
             "text": "oo\nU Counter target spell that targets Mistfolk.",
             "colours": [
@@ -2722,7 +2722,7 @@
         },
         {
             "id": "23e343b1-e95c-5770-9c7c-f85f71b06bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8d2247-a10e-413a-b497-2add3918f991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8d2247-a10e-413a-b497-2add3918f991.jpg?1",
             "name": "Musician",
             "text": "Cumulative Upkeep: o1\noc\nT: Put a music counter on target creature. During that creature's controller's upkeep, he or she pays o1 for each music counter on the creature, or destroy the creature.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "71cacf5e-ac7f-503d-bf34-e7df5f7f874e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d7f08-0687-41bd-8c53-31a49adabb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d7f08-0687-41bd-8c53-31a49adabb11.jpg?1",
             "name": "Mystic Might",
             "text": "Cumulative Upkeep: o1o\nU\nWhen Mystic Might comes into play, choose target land you control.\no0: Tap land Mystic Might enchants to give target creature +2/+2 until end of turn.",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "be4b3a20-f148-54bb-b25c-a619a9c1714a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e93dff-b774-4765-b7bd-d3957e42ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e93dff-b774-4765-b7bd-d3957e42ff4a.jpg?1",
             "name": "Mystic Remora",
             "text": "Cumulative Upkeep: o1\nWhenever target opponent successfully casts a non-creature spell, you may draw a card. That player may pay o4 to counter this effect.",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "391d2a9a-192a-529f-b830-1ac09f489b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75afdbe6-a3f9-49cf-b4ef-f370e518e960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75afdbe6-a3f9-49cf-b4ef-f370e518e960.jpg?1",
             "name": "Phantasmal Mount",
             "text": "Flying\noc\nT: Target creature you control, which has toughness less than 3, gains flying and gets +1/+1 until end of turn. Other effects may later be used to increase that creature's toughness beyond 3. If Phantasmal Mount leaves play before end of turn, bury the creature. If the creature leaves play before end of turn, bury Phantasmal Mount.",
             "colours": [
@@ -2854,7 +2854,7 @@
         },
         {
             "id": "5581a0c9-a0b6-5657-a970-dcbb6d1132c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee01e9c-0445-4228-a73a-3e5744844ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee01e9c-0445-4228-a73a-3e5744844ed3.jpg?1",
             "name": "Polar Kraken",
             "text": "Trample\nCumulative Upkeep: Sacrifice a land.\nComes into play tapped.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "4a3afe72-ac2a-56f9-90ab-49ab0773e1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040be83-3fb5-4da5-ba7a-4923b8854b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040be83-3fb5-4da5-ba7a-4923b8854b74.jpg?1",
             "name": "Portent",
             "text": "Look at the top three cards of target player's library; then, either shuffle that library or put those three cards on top of the library in any order. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2918,7 +2918,7 @@
         },
         {
             "id": "11f7a079-9451-5c4b-9cac-ca7c849f1f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbec45-81b4-40cc-b356-d6713a6a9b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbec45-81b4-40cc-b356-d6713a6a9b2b.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless that spell's caster pays an additional o\nX. That player must draw and pay all available mana from lands and mana pool until o\nX is paid; he or she may also pay mana from other sources if desired.",
             "colours": [
@@ -2949,7 +2949,7 @@
         },
         {
             "id": "de467bc1-2b2f-546a-a4a6-c75991b04d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/638abe5f-2a8a-42ca-bcdf-a52a3df66946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/638abe5f-2a8a-42ca-bcdf-a52a3df66946.jpg?1",
             "name": "Ray of Command",
             "text": "Untap target creature opponent controls and gain control of it until end of turn. That creature can attack or use abilities that require oc\nT as part of the activation cost. When you lose control of the creature, tap it.",
             "colours": [
@@ -2980,7 +2980,7 @@
         },
         {
             "id": "ee323db5-29a5-52b8-a80a-6a2ca987399d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a09fc0b-7b9c-4283-8336-f2607f5ffaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a09fc0b-7b9c-4283-8336-f2607f5ffaf5.jpg?1",
             "name": "Ray of Erasure",
             "text": "Target player takes the top card of his or her library and puts it in his or her graveyard. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "959da211-25a3-5f3f-b6a0-ba8d919139c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7e955c-3de2-430c-93b9-0b39ccea5420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7e955c-3de2-430c-93b9-0b39ccea5420.jpg?1",
             "name": "Reality Twist",
             "text": "Cumulative Upkeep: o1o\nUo\nU\nInstead of their normal mana, plains produce o\nR, swamps produce o\nG, mountains produce o\nW, and forests produce o\nB.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "4734ed73-7ca7-57d4-9aa6-fc3e439df990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d93d05-98bc-4504-9045-dedb925895ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d93d05-98bc-4504-9045-dedb925895ae.jpg?1",
             "name": "Sea Spirit",
             "text": "o\nU: +1/+0 until end of turn",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "662d53a0-8a76-538e-9033-3179df8c99ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a60c33-b641-42c4-870d-95d07bc975dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a60c33-b641-42c4-870d-95d07bc975dc.jpg?1",
             "name": "Shyft",
             "text": "During your upkeep, you may change the color of Shyft to any color or combination of colors.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "a0e507d7-762e-5695-ad6e-b21424d6efca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47364ad2-5ce9-4b19-a9d2-f6a33188b882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47364ad2-5ce9-4b19-a9d2-f6a33188b882.jpg?1",
             "name": "Sibilant Spirit",
             "text": "Flying\nWhenever Sibilant Spirit is declared as an attacker, defending player may draw a card.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "2ac01bf8-8601-5577-bcdf-63e47d42f58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685076cc-098c-4f98-918c-0ad825eda10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685076cc-098c-4f98-918c-0ad825eda10f.jpg?1",
             "name": "Silver Erne",
             "text": "Flying, trample",
             "colours": [
@@ -3179,7 +3179,7 @@
         },
         {
             "id": "0cfdfb12-f1bf-5738-9dab-61bca7102adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dc9f02-11ad-4c4a-8199-9d20c23d31a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93dc9f02-11ad-4c4a-8199-9d20c23d31a7.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of target spell or permanent by replacing all instances of one color word with another. For example, you may change \"Counters black spells\" to \"Counters blue spells.\" Sleight of Mind cannot change mana symbols.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "b2da5329-48e7-5c83-a55a-a3cb0b75777c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be3a9a5-2ac5-4ea4-915d-8cff35c0e72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be3a9a5-2ac5-4ea4-915d-8cff35c0e72f.jpg?1",
             "name": "Snow Devil",
             "text": "Target creature gains flying. As long as you control any snow-covered lands, that creature also gains first strike when blocking.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "b9e7a694-2ce8-5ff5-b4e1-a9054206162f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788ed793-3993-4a63-b9f9-9ac3947c3108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788ed793-3993-4a63-b9f9-9ac3947c3108.jpg?1",
             "name": "Snowfall",
             "text": "Cumulative Upkeep: o\nU\nIslands may produce an additional o\nU when tapped for mana. This mana is usable only for cumulative upkeep.\nSnow-covered islands may produce either an additional o\nUo\nU or an additional o\nU when tapped for mana. This mana is usable only for cumulative upkeep.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "0d68baeb-b2a3-52d0-9682-215413b62ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0999df-2f94-499e-b9af-fe377d515400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0999df-2f94-499e-b9af-fe377d515400.jpg?1",
             "name": "Soldevi Machinist",
             "text": "oc\nT: Add two colorless mana to your mana pool. This mana may only be used to pay the activation cost of an artifact. Play this ability as an interrupt.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "d3a73b6a-88de-5640-b7c5-c483e2cdc954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad7fac7-db4d-45b2-aba6-16f4fd1a586f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad7fac7-db4d-45b2-aba6-16f4fd1a586f.jpg?1",
             "name": "Soul Barrier",
             "text": "Whenever target opponent casts a summon spell, Soul Barrier deals 2 damage to him or her. That player may pay o2 to prevent this damage.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "6f36f973-da16-5bc3-b829-e8e91eaa6362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc5d510-c4f7-4a09-bf86-83c3fa3f8928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc5d510-c4f7-4a09-bf86-83c3fa3f8928.jpg?1",
             "name": "Thunder Wall",
             "text": "Flying\noo\nU +1/+1 until end of turn",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "eacea80e-6f00-5ba8-951b-cc6305fc6a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bd4e16-27fe-4c7b-ae25-78ed77d8e8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bd4e16-27fe-4c7b-ae25-78ed77d8e8e7.jpg?1",
             "name": "Updraft",
             "text": "Target creature gains flying until end of turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "90d18407-e9bd-57f1-8981-d0e27b960c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d882447-9594-4aab-b1a7-8bb275f250cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d882447-9594-4aab-b1a7-8bb275f250cf.jpg?1",
             "name": "Wind Spirit",
             "text": "Flying\nCannot be blocked by only one creature.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "c9d28c5a-afd6-5a11-9830-26cc26aae107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a779aca7-ff2c-48d8-9484-6ad04b2c6bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a779aca7-ff2c-48d8-9484-6ad04b2c6bcb.jpg?1",
             "name": "Winter's Chill",
             "text": "Cast only during combat before defense is chosen. At end of combat, destroy X target attacking creatures; X cannot be greater than the number of snow-covered lands you control. For each attacking creature, its controller may pay o1 or o2 to prevent it from being destroyed in this way. If that player pays o1, the creature neither deals nor receives damage in combat. If that player pays o2, the creature deals and receives damage in combat as normal.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "1af5ebdf-c7ba-5ba1-a2bb-d6310ebdad53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b04476-5a5d-4843-a948-82db209c4218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b04476-5a5d-4843-a948-82db209c4218.jpg?1",
             "name": "Word of Undoing",
             "text": "Return target creature to owner's hand. Return any white enchantments you own on that creature to your hand.",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "7857b1ba-dd49-5537-bd4e-9a8b9910347a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d512f5c-0327-4d49-8a26-672574a49102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d512f5c-0327-4d49-8a26-672574a49102.jpg?1",
             "name": "Wrath of Marit Lage",
             "text": "When Wrath of Marit Lage comes into play, tap all red creatures. Red creatures do not untap during their controller's untap phase.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "c42a00e8-8293-509a-a2fa-a217c61fba20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f8531f-19ca-48a2-baf2-c5dc6f18d79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f8531f-19ca-48a2-baf2-c5dc6f18d79c.jpg?1",
             "name": "Zur's Weirding",
             "text": "All players play with the cards in their hands face up on the table. Whenever any player draws a card, any other player may pay 2 life to force the drawing player to discard that card. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "64d14fb3-68b8-5988-a715-154fb3ef9bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721edcef-f40a-4d43-9d80-26161dc425cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721edcef-f40a-4d43-9d80-26161dc425cb.jpg?1",
             "name": "Zuran Enchanter",
             "text": "o2o\nB,oc\nT: Target player chooses and discards one card from his or her hand. Ignore this ability if that player has no cards in his or her hand. Use this ability only during your turn.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "85eb7278-b8d8-5702-a3eb-43a62fc0b7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152a72b1-a7b7-4e5c-8558-fab97465f549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152a72b1-a7b7-4e5c-8558-fab97465f549.jpg?1",
             "name": "Zuran Spellcaster",
             "text": "oc\nT: Zuran Spellcaster deals 1 damage to target creature or player.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "2cf7a942-363c-5b65-bad8-9bcfe73dce28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26f19c-bcf7-4bd8-af42-4757dbe47fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc26f19c-bcf7-4bd8-af42-4757dbe47fb1.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter damages any player, that player chooses and discards a card from his or her hand. Ignore this ability if the player has no cards in hand.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "3d2c108c-be12-5331-85b6-8764580a9ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb83301-5662-4628-b536-6a3ee0296f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb83301-5662-4628-b536-6a3ee0296f2e.jpg?1",
             "name": "Ashen Ghoul",
             "text": "Ashen Ghoul can attack the turn it comes into play.\noo\nB Return Ashen Ghoul to play under your control. Use this ability only at the end of your upkeep and only if Ashen Ghoul is in your graveyard with at least three creature cards above it.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "75113f4e-ea1e-5a57-9f72-1a9fb91f30b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f445962c-44a1-4f3f-88d4-17048f8ca9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f445962c-44a1-4f3f-88d4-17048f8ca9dc.jpg?1",
             "name": "Brine Shaman",
             "text": "oc\nT: Sacrifice a creature to give target creature +2/+2 until end of turn.\no1o\nUo\nU: Sacrifice a creature to counter target summon spell.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "71e56940-b579-5ce5-819e-8592d6d6830c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dae52a2-3af7-4b97-9d2e-2448b7c413fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dae52a2-3af7-4b97-9d2e-2448b7c413fb.jpg?1",
             "name": "Burnt Offering",
             "text": "Sacrifice a creature to add that creature's casting cost in any combination of red and/or black mana to your mana pool.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "7e64809d-bd1f-51b9-b9ea-d8325a95d7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45d103-0fca-4431-a5c0-869f0f9be93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45d103-0fca-4431-a5c0-869f0f9be93e.jpg?1",
             "name": "Cloak of Confusion",
             "text": "If target creature you control attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, that player discards a card at random from his or her hand. Ignore this ability if that player has no cards in hand.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "06baa505-be67-5ef7-b963-6d24caf844e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c53ba4-9956-4cd6-85ca-2d6b61a5127c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c53ba4-9956-4cd6-85ca-2d6b61a5127c.jpg?1",
             "name": "Dance of the Dead",
             "text": "Take target creature from any graveyard and put it directly into play under your control, tapped, with +1/+1. Treat that creature as though it were just summoned. The creature does not untap during its controller's untap phase. At the end of his or her upkeep, its controller may pay an additional o1o\nB to untap it. If Dance of the Dead is removed, bury the creature in its owner's graveyard.",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "9b6a9e9f-e8e6-5492-a73b-1a3ae2d16046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc2716-ed62-4797-ad2b-227eca5408d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc2716-ed62-4797-ad2b-227eca5408d0.jpg?1",
             "name": "Dark Banishing",
             "text": "Bury target non-black creature.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "da8cb874-99d3-5ce7-bf1b-8253245975f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebcd681-1871-4914-bcd7-6bd95829f6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebcd681-1871-4914-bcd7-6bd95829f6e0.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "78c65636-9830-51b2-aaa9-f3bd30487c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d727b9b-6114-414d-9172-16b6e1db41cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d727b9b-6114-414d-9172-16b6e1db41cc.jpg?1",
             "name": "Demonic Consultation",
             "text": "Name a card. Remove the top six cards of your library from the game and reveal the next card to all players. If it is the card named, put it into your hand. If not, remove that card from the game and continue revealing the top card of your library and removing it from the game until the named card appears.",
             "colours": [
@@ -3924,7 +3924,7 @@
         },
         {
             "id": "a90cbb75-da04-5f5a-817d-a1687c6455cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d332e2-4b2d-4131-84f7-862cb138c477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d332e2-4b2d-4131-84f7-862cb138c477.jpg?1",
             "name": "Dread Wight",
             "text": "At end of combat, put a paralyzation counter on any creature blocking or blocked by Dread Wight and tap that creature. As long as the creature has a paralyzation counter on it, it does not untap during its controller's untap phase. As a non-interrupt fast effect, the creature's controller may pay o4 to remove a paralyzation counter.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "119552b0-cf3f-5d6b-8043-14520b4d5151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b65656-9f8c-4179-81aa-4b15d8280baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b65656-9f8c-4179-81aa-4b15d8280baa.jpg?1",
             "name": "Drift of the Dead",
             "text": "Drift of the Dead has power and toughness each equal to the number of snow-covered lands you control.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "9ad7da13-cbd4-52cd-9204-90889b1bbb70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5709398f-0744-4780-a1d2-eead96c8f348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5709398f-0744-4780-a1d2-eead96c8f348.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked except by artifact creatures or black creatures.",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "fa1c0d08-15dd-566e-bba7-d492ba3fcae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6880a4d3-5cbc-4a01-9190-3565617efcc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6880a4d3-5cbc-4a01-9190-3565617efcc9.jpg?1",
             "name": "Flow of Maggots",
             "text": "Cumulative Upkeep: o1\nCannot be blocked by non-wall creatures.",
             "colours": [
@@ -4056,7 +4056,7 @@
         },
         {
             "id": "551ece0c-cc65-5c5d-a29c-b674f5686a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad3541-8e40-4a2f-ac9d-f7b61f3d75a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bad3541-8e40-4a2f-ac9d-f7b61f3d75a1.jpg?1",
             "name": "Foul Familiar",
             "text": "Cannot be declared as a blocking creature.\noo\nB Pay 1 life to return Foul Familiar to owner's hand. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "da8b3da6-7402-58cf-9833-ec809c663574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be4d83-99be-4360-90f1-104dee1c3c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be4d83-99be-4360-90f1-104dee1c3c2f.jpg?1",
             "name": "Gangrenous Zombies",
             "text": "oc\nT: Sacrifice Gangrenous Zombies to have it deal 1 damage to each creature and player. If you control any snow-covered swamps, Gangrenous Zombies instead deals 2 damage to each creature and player.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "8d18962c-8573-5e83-b0e7-fccea1abd2fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48401643-ec4b-444a-8f9a-1a5ea471ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48401643-ec4b-444a-8f9a-1a5ea471ff4a.jpg?1",
             "name": "Gaze of Pain",
             "text": "For each creature you control that attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do so, it instead deals damage equal to its power to any target creature.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "7db89ce2-c636-57ae-bfb6-7005894379e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4782fd4f-2474-4d0d-8301-e0b52af93746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4782fd4f-2474-4d0d-8301-e0b52af93746.jpg?1",
             "name": "Gravebind",
             "text": "Target creature cannot regenerate this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "2e680461-4712-5c9c-97d3-cea9137c6d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f59620f-ff9e-44d8-9c4e-be9de1a919e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f59620f-ff9e-44d8-9c4e-be9de1a919e8.jpg?1",
             "name": "Hecatomb",
             "text": "When Hecatomb comes into play, sacrifice four creatures.\no0: Tap target swamp you control to have Hecatomb deal 1 damage to target creature or player.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "a4f54ec7-a14c-5918-839f-3a1fe6352c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72242dff-15ca-4da0-b3ae-9984d037b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72242dff-15ca-4da0-b3ae-9984d037b31f.jpg?1",
             "name": "Hoar Shade",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "d729c97a-3581-54c8-9595-930e8df27acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d0d6b-056e-4b94-8de5-a325768f67b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9d0d6b-056e-4b94-8de5-a325768f67b6.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "255d872c-7080-5f94-9a21-c0bc52a93d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e037-f4d5-46fd-b439-56bee6fb2ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e037-f4d5-46fd-b439-56bee6fb2ad3.jpg?1",
             "name": "Hyalopterous Lemure",
             "text": "o0: Flying and -1/-0 until end of turn",
             "colours": [
@@ -4312,7 +4312,7 @@
         },
         {
             "id": "5b37c31c-8b11-5821-8a93-c6280f0f8d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b4dd4d-c617-4603-8a87-761ec6fc6883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b4dd4d-c617-4603-8a87-761ec6fc6883.jpg?1",
             "name": "Icequake",
             "text": "Destroy target land. If that land is a snow-covered land, Icequake deals 1 damage to the land's controller.",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "12c336ea-bdc6-5810-a963-56e329926d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3475eb3-909d-450b-9597-b241b259b425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3475eb3-909d-450b-9597-b241b259b425.jpg?1",
             "name": "Infernal Darkness",
             "text": "Cumulative Upkeep: o\nB and 1 life\nAll mana-producing lands produce o\nB instead of their normal mana.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "168e6384-1ed3-5968-a4d9-5a4cda65a9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ac9a6-aaa5-4659-97d1-c5f6b0d5ccfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ac9a6-aaa5-4659-97d1-c5f6b0d5ccfe.jpg?1",
             "name": "Infernal Denizen",
             "text": "During your upkeep, sacrifice two swamps. If you cannot, tap Infernal Denizen, and target opponent may gain control of target creature of his or her choice you control. The opponent loses control of that creature if Infernal Denizen leaves play.\noc\nT: Gain control of target creature. Lose control of that creature if Infernal Denizen leaves play.",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "33f96886-32fa-58b6-bf9f-a7e7090e2aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f7b614-6075-4b7c-acc7-ab63185b570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f7b614-6075-4b7c-acc7-ab63185b570b.jpg?1",
             "name": "Kjeldoran Dead",
             "text": "When Kjeldoran Dead comes into play, sacrifice a creature.\noo\nB Regenerate",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "da806ea3-7c84-5c8a-9fde-6b8c97b37439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b87069b-ebaf-4705-b5da-446932af9b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b87069b-ebaf-4705-b5da-446932af9b73.jpg?1",
             "name": "Knight of Stromgald",
             "text": "Protection from white\no\nBo\nB: +1/+0 until end of turn\no\nB: First strike until end of turn",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "cf0cb215-b429-5976-8900-ea8864476d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedca18-a074-4441-b0a9-7b14fdb07412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbedca18-a074-4441-b0a9-7b14fdb07412.jpg?1",
             "name": "Krovikan Elementalist",
             "text": "o2oo\nR Target creature gets +1/+0 until end of turn.\no\nUoo\nU Target creature you control gains flying until end of turn. At end of turn, bury that creature.",
             "colours": [
@@ -4510,7 +4510,7 @@
         },
         {
             "id": "5e771f10-04fe-504f-9984-11c19be0b1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e73e6-b201-4b2e-b46a-b719484fba0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e73e6-b201-4b2e-b46a-b719484fba0e.jpg?1",
             "name": "Krovikan Fetish",
             "text": "Draw a card at the beginning of the upkeep of the turn after Krovikan Fetish comes into play.\nTarget creature gets +1/+1.",
             "colours": [
@@ -4543,7 +4543,7 @@
         },
         {
             "id": "9d984957-07c8-54a0-86f4-116fb8ba24e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5dda-8e38-4c76-b241-685198402284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717c5dda-8e38-4c76-b241-685198402284.jpg?1",
             "name": "Krovikan Vampire",
             "text": "At the end of a turn in which any creature is damaged by Krovikan Vampire and put into any graveyard, put that creature directly into play under your control. Treat the creature as though it were just summoned. If you lose control of Krovikan Vampire or Krovikan Vampire leaves play, bury the creature.",
             "colours": [
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "a73354e2-1be3-51d6-bb17-dea0c1423ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b67eb2-b60e-46b4-9d48-11c284957bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b67eb2-b60e-46b4-9d48-11c284957bec.jpg?1",
             "name": "Legions of Lim-D\u00fbl",
             "text": "Snow-covered swampwalk",
             "colours": [
@@ -4609,7 +4609,7 @@
         },
         {
             "id": "b7b5a6b9-125e-51bb-9611-a14f7801d4df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0a6b4e-95b4-40f6-bb19-568dbd908a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0a6b4e-95b4-40f6-bb19-568dbd908a2b.jpg?1",
             "name": "Leshrac's Rite",
             "text": "Target creature gains swampwalk.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "225d9950-d771-5849-82aa-e8c61274003b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ba7ee-d6df-4b62-a8a1-c81e6fca392a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ba7ee-d6df-4b62-a8a1-c81e6fca392a.jpg?1",
             "name": "Leshrac's Sigil",
             "text": "o\nBoo\nB When any opponent successfully casts a green spell, look at that player's hand and choose a card; he or she then discards that card. Use this ability only once each time a green spell is cast.\no\nBoo\nB Return Leshrac's Sigil to owner's hand.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "85c3ee77-6ee4-5a92-bfb0-7a39490275c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0006f6-2f96-453d-9145-eaefa588efbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0006f6-2f96-453d-9145-eaefa588efbc.jpg?1",
             "name": "Lim-D\u00fbl's Cohort",
             "text": "Creatures blocking or blocked by Lim-D\u00fbl's Cohort cannot regenerate this turn.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "b4916725-be57-566a-b08d-765dd4b08ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af976f42-3d56-4e32-8294-970a276a4bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af976f42-3d56-4e32-8294-970a276a4bf3.jpg?1",
             "name": "Lim-D\u00fbl's Hex",
             "text": "During your upkeep, Lim-D\u00fbl's Hex deals 1 damage to each player. Each player may pay o\nB or o3 to prevent the damage to himself or herself.",
             "colours": [
@@ -4737,7 +4737,7 @@
         },
         {
             "id": "b3450b1d-f04f-543e-b682-a6371ed57938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf3ac5-985d-4b48-b230-d5ae4ab1ace8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cf3ac5-985d-4b48-b230-d5ae4ab1ace8.jpg?1",
             "name": "Mind Ravel",
             "text": "Target player chooses and discards a card from his or her hand.\nIgnore this ability if that player has no cards in hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "74ad44ab-12ea-58ec-923f-a4c6795fa36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de150cd6-0bbc-47f7-a781-cd1aa10eabc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de150cd6-0bbc-47f7-a781-cd1aa10eabc6.jpg?1",
             "name": "Mind Warp",
             "text": "Look at target player's hand and choose X cards; that player then discards those cards. If the player does not have enough cards in hand, his or her entire hand is discarded.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "50a1bef7-5c76-5ece-a13a-d815118f726e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3ff5fb-4126-4a18-b540-2beaae382e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3ff5fb-4126-4a18-b540-2beaae382e59.jpg?1",
             "name": "Mind Whip",
             "text": "During target creature's controller's upkeep, he or she pays o3 or Mind Whip deals 2 damage to him or her. If Mind Whip deals damage in this way, tap that creature.",
             "colours": [
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "d6e9ca83-4769-5d8b-9e80-e258434c5e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61278908-a1b4-4b4c-84f5-498ca41fc6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61278908-a1b4-4b4c-84f5-498ca41fc6b6.jpg?1",
             "name": "Minion of Leshrac",
             "text": "Protection from black\nDuring your upkeep, sacrifice a creature or Minion of Leshrac deals 5 damage to you. If Minion of Leshrac deals damage to you in this way, tap it. You cannot sacrifice Minion of Leshrac to itself.\noc\nT: Destroy target creature or land.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "289d6fbd-b1fa-53d1-b60a-0c13c0ce3927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f3ab5-6a31-47db-b8bf-4c56a7ff19d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9f3ab5-6a31-47db-b8bf-4c56a7ff19d1.jpg?1",
             "name": "Minion of Tevesh Szat",
             "text": "During your upkeep, pay o\nBo\nB or Minion of Tevesh Szat deals 2 damage to you.\noc\nT: Target creature gets +3/-2 until end of turn.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "1d7b1c45-edd3-5460-a105-2206f024db59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4914f6fc-e3e7-426b-8688-12157c7df9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4914f6fc-e3e7-426b-8688-12157c7df9e7.jpg?1",
             "name": "Mole Worms",
             "text": "You may choose not to untap Mole Worms during your untap phase.\noc\nT: Tap target land. As long as Mole Worms remains tapped, that land does not untap during its controller's untap phase.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "a3c2296b-45b6-5679-8b59-0163765eb937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57089dd4-e30d-498d-9341-43c104c6f3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57089dd4-e30d-498d-9341-43c104c6f3f9.jpg?1",
             "name": "Moor Fiend",
             "text": "Swampwalk",
             "colours": [
@@ -4966,7 +4966,7 @@
         },
         {
             "id": "403ed7f3-4bfc-5187-97c8-dde8c7299d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d7a0c1-efb4-4a8d-ad92-a96d43835052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d7a0c1-efb4-4a8d-ad92-a96d43835052.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw phase. If you discard a card from your hand, remove that card from the game.\no0: Pay 1 life to set aside the top card of your library. At the beginning of your next discard phase, put that card into your hand. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "5e204e66-0d0b-5ee9-8fc6-6e68692716a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35abefe6-c39b-4fe5-b2e3-d213f0c4f447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35abefe6-c39b-4fe5-b2e3-d213f0c4f447.jpg?1",
             "name": "Norritt",
             "text": "oc\nT: Untap target blue creature.\noc\nT: Force target non-wall creature to attack. If creature cannot attack, destroy it at end of turn. Use this ability only during target creature's controller's turn, before the attack. Cannot target creatures brought under their controller's control this turn.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "db82f03f-6db9-52eb-90e3-0f89de183ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df768-06de-43a0-b548-44fb0887490b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df768-06de-43a0-b548-44fb0887490b.jpg?1",
             "name": "Oath of Lim-D\u00fbl",
             "text": "For each 1 damage dealt to you or 1 life you lose, sacrifice a permanent you control or choose and discard a card from your hand. You cannot sacrifice Oath of Lim-D\u00fbl in this way. Ignore this effect if you control no permanents other than Oath of Lim-D\u00fbl and have no cards in hand.\no\nBo\nB: Draw a card.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "9eb8128f-6c76-54c6-8437-f9a9c84dfcdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff7f6a6-0e90-4eb4-b76e-d98454975fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff7f6a6-0e90-4eb4-b76e-d98454975fb6.jpg?1",
             "name": "Pestilence Rats",
             "text": "Pestilence Rats has power equal to the total number of other Rats in play, no matter who controls them. For example, as long as there are two other Rats in play, Pestilence Rats has power and toughness 2/3.",
             "colours": [
@@ -5094,7 +5094,7 @@
         },
         {
             "id": "f168c218-5d8e-587b-9496-f2ca57c30ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a914138c-a593-414c-bbcb-83d3c1bc4f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a914138c-a593-414c-bbcb-83d3c1bc4f6f.jpg?1",
             "name": "Pox",
             "text": "Each player loses 1/3 of his or her life; then chooses and discards 1/3 of the cards in his or her hand; then sacrifices 1/3 of the creatures he or she controls; and finally sacrifices 1/3 of the lands he or she controls. Round each loss up. Effects that prevent or redirect damage cannot be used to counter the this loss of life.",
             "colours": [
@@ -5125,7 +5125,7 @@
         },
         {
             "id": "2300531d-4497-57da-b0db-f161a0d010e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da369c86-7e17-43d8-b626-b6842e3d2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da369c86-7e17-43d8-b626-b6842e3d2d50.jpg?1",
             "name": "Seizures",
             "text": "Whenever target creature becomes tapped, that creature's controller pays o3 or Seizures deals 3 damage to him or her.",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "611c30f7-85a6-5423-a4c7-9e3706c82d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff3547-8c72-439a-91fe-ebe729dab748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff3547-8c72-439a-91fe-ebe729dab748.jpg?1",
             "name": "Songs of the Damned",
             "text": "Add o\nB to your mana pool for each creature in your graveyard.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "a0cb9a39-7a8f-51f3-9e8d-720b2e585adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8e00d2-2381-4d45-bed8-c9bf738a9419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8e00d2-2381-4d45-bed8-c9bf738a9419.jpg?1",
             "name": "Soul Burn",
             "text": "Soul Burn deals 1 damage to a single target creature or player for each o\nB or o\nR you pay in addition to the casting cost. Gain 1 life for each o\nB you spend in this way. You cannot gain more life than the toughness of the creature or the total life of the targeted player.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "34cc3b28-9e8f-593c-a965-d9c0217e9bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fbf6a5-86fe-41a3-891e-f72f11ad0aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fbf6a5-86fe-41a3-891e-f72f11ad0aee.jpg?1",
             "name": "Soul Kiss",
             "text": "When Soul Kiss comes into play, choose target creature.\no\nB: Pay 1 life to give creature Soul Kiss enchants +2/+2 until end of turn. You cannot spend more than o\nBo\nBo\nB in this way each turn. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "c3027065-4403-5577-993c-921961b76e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd368eb6-72f0-42d4-afa5-3daa7de949ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd368eb6-72f0-42d4-afa5-3daa7de949ff.jpg?1",
             "name": "Spoils of Evil",
             "text": "For each artifact or creature in target opponent's graveyard, add one colorless mana to your mana pool and gain 1 life.",
             "colours": [
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "de617743-3583-5309-bb10-da89829294ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38af8bd-d927-46d0-a1b1-fb437ea9ea66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38af8bd-d927-46d0-a1b1-fb437ea9ea66.jpg?1",
             "name": "Spoils of War",
             "text": "Put X +1/+1 counters on any number of target creatures, distributed any way you choose, where X is equal to the number of creatures and artifacts in target opponent's graveyard.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "55fd585f-98ab-5a2b-8cf6-06255a5221b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7065a2-f819-4cbe-b453-a55e904f0461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7065a2-f819-4cbe-b453-a55e904f0461.jpg?1",
             "name": "Stench of Evil",
             "text": "Destroy all plains. Stench of Evil deals 1 damage to each player for each plains he or she controls that is destroyed in this way. Each player may pay o2 for each 1 damage he or she wishes to prevent from Stench of Evil.",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "d7861879-4a2a-5941-be32-c8a57827d113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac6fa0c-753e-4fbc-8a70-0f956503cf4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac6fa0c-753e-4fbc-8a70-0f956503cf4e.jpg?1",
             "name": "Stromgald Cabal",
             "text": "oc\nT: Pay 1 life to counter target white spell. Effects that prevent or redirect damage cannot be used to counter this loss of life. Play this ability as an interrupt.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "a4e26f72-10e0-557e-9c4b-abd55a7ffd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c658f-e657-490b-af1f-e67e48d0046e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49c658f-e657-490b-af1f-e67e48d0046e.jpg?1",
             "name": "Touch of Death",
             "text": "Touch of Death deals 1 damage to target player, and you gain 1 life. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "6d4f65e6-4bcc-522e-8e5e-d3ba705cb50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1e6ae5-c972-42c0-ae78-f203873aeeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1e6ae5-c972-42c0-ae78-f203873aeeb1.jpg?1",
             "name": "Withering Wisps",
             "text": "At the end of any turn, if there are no creatures in play, bury Withering Wisps.\noo\nB Withering Wisps deals 1 damage to each creature and each player. You cannot spend more o\nB in this way each turn than the number of snow-covered swamps you control.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "5ba9eca8-0e78-52e0-968a-7e4bf9869cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f26060-0c24-496c-b8e2-4dac7ea6166b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f26060-0c24-496c-b8e2-4dac7ea6166b.jpg?1",
             "name": "Aggression",
             "text": "Target non-wall creature gains first strike and trample. At the end of its controller's turn, destroy that creature if it did not attack that turn.",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "c2d83dfc-a70f-5b54-b757-272765bd7db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d941da-b5cb-4b7e-84f2-ece883f89af3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d941da-b5cb-4b7e-84f2-ece883f89af3.jpg?1",
             "name": "Anarchy",
             "text": "Destroy all white permanents.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "c507dd9d-e3d1-55a7-8200-ff4a2f85e40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a925e5-0d0a-42ec-b1c6-9793b8e11625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a925e5-0d0a-42ec-b1c6-9793b8e11625.jpg?1",
             "name": "Avalanche",
             "text": "Destroy X target snow-covered lands.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "c11548bb-8bc3-5634-beb0-32d80fc38b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeabe8e-8107-4d19-8a43-362aa79cdd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeabe8e-8107-4d19-8a43-362aa79cdd92.jpg?1",
             "name": "Balduvian Barbarians",
             "text": "",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "7baec890-cb6e-50c8-8ae8-0ad462a5a13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a3b37f-daa6-4502-bb12-c72afe3df035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a3b37f-daa6-4502-bb12-c72afe3df035.jpg?1",
             "name": "Balduvian Hydra",
             "text": "When Balduvian Hydra comes into play, put X +1/+0 counters on it.\no0: Remove a +1/+0 counter from Balduvian Hydra to prevent 1 damage to Balduvian Hydra.\no\nRo\nRo\nR: Put a +1/+0 counter on Balduvian Hydra. Use this ability only during your upkeep.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "e0af987b-6715-5be3-9dfe-f263fa026abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65a045-dacb-4392-bcb6-843394ef98c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe65a045-dacb-4392-bcb6-843394ef98c9.jpg?1",
             "name": "Barbarian Guides",
             "text": "o2o\nR,oc\nT: Target creature you control gains a snow-covered landwalk ability of your choice until end of turn. At end of turn, return that creature to its owner's hand.",
             "colours": [
@@ -5638,7 +5638,7 @@
         },
         {
             "id": "bac57e15-6629-5ad6-b31a-858000347988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85ae675-56ca-4a00-83d2-ee035f33d6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85ae675-56ca-4a00-83d2-ee035f33d6d1.jpg?1",
             "name": "Battle Frenzy",
             "text": "All green creatures you control get +1/+1 until end of turn. All non-green creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "e80acd3a-10b7-578c-93a5-f03706fc9419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e3d54-4dc4-482b-8ecc-bb819ba03d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e3d54-4dc4-482b-8ecc-bb819ba03d2c.jpg?1",
             "name": "Bone Shaman",
             "text": "oo\nB Any creature damaged by Bone Shaman this turn cannot regenerate until end of turn.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "c4024b1e-1077-55c7-87be-5ea88971ae61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceeb7bbc-2d41-4709-95be-1ceb952ed1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceeb7bbc-2d41-4709-95be-1ceb952ed1fb.jpg?1",
             "name": "Brand of Ill Omen",
             "text": "Cumulative Upkeep: o\nR\nTarget creature's controller cannot cast summon spells.",
             "colours": [
@@ -5737,7 +5737,7 @@
         },
         {
             "id": "a51f3f5a-6caa-54ca-9975-cb4a1c244271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee245922-b380-4b2e-a43f-ab1ba8078943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee245922-b380-4b2e-a43f-ab1ba8078943.jpg?1",
             "name": "Chaos Lord",
             "text": "First strike\nChaos Lord can attack the first turn it comes into play on a side, except the turn it first comes into play. During your upkeep, count the number of permanents. If that number is even, target opponent gains control of Chaos Lord.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "15d5e88f-005e-53c3-812a-370cd19354a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae0543f-7f8b-4327-b735-ac21244e9936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae0543f-7f8b-4327-b735-ac21244e9936.jpg?1",
             "name": "Chaos Moon",
             "text": "During each player's upkeep, count the number of permanents. If that number is odd, all red creatures get +1/+1 and mountains produce an additional o\nR when tapped for mana until end of turn. If the number is even, all red creatures get -1/-1 and mountains produce colorless mana instead of their normal mana until end of turn.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "0cb58851-b9b4-5003-8023-68b6d4ea033f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae610e66-7bcb-40ec-bed5-86dcfd098654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae610e66-7bcb-40ec-bed5-86dcfd098654.jpg?1",
             "name": "Conquer",
             "text": "Gain control of target land.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "981a54a8-d154-5dd3-bcef-6284aef39f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b381c1-aa71-4d40-a320-70f58a440d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b381c1-aa71-4d40-a320-70f58a440d51.jpg?1",
             "name": "Curse of Marit Lage",
             "text": "When Curse of Marit Lage comes into play, tap all islands. Islands do not untap during their controller's untap phase.",
             "colours": [
@@ -5865,7 +5865,7 @@
         },
         {
             "id": "4200b26a-57ab-5d05-ad06-a5d844e15bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d14a430-6e08-40cf-970a-cae84bba6ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d14a430-6e08-40cf-970a-cae84bba6ef7.jpg?1",
             "name": "Dwarven Armory",
             "text": "o2: Sacrifice a land to put a +2/+2 counter on target creature. Use this ability only during upkeep.",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "a9d37160-06f3-50d7-9009-c38d7d438881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8346e741-61f8-4283-be51-f5f80e9595a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8346e741-61f8-4283-be51-f5f80e9595a5.jpg?1",
             "name": "Errantry",
             "text": "Target creature gets +3/+0. If that creature attacks, no other creatures can attack this turn.",
             "colours": [
@@ -5929,7 +5929,7 @@
         },
         {
             "id": "45bff88e-be44-5094-81f6-87ab28d624b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add2b82a-9aa5-4d5c-a1c2-e313541f12c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add2b82a-9aa5-4d5c-a1c2-e313541f12c8.jpg?1",
             "name": "Flame Spirit",
             "text": "oo\nR +1/+0 until end of turn",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "ef066205-82d0-5792-b9f0-3683ca0acd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5350236-7bd2-462d-9768-50087626c764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5350236-7bd2-462d-9768-50087626c764.jpg?1",
             "name": "Flare",
             "text": "Flare deals 1 damage to target creature or player. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "52bb1349-ef1e-5cf8-8962-eb33d1434628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08265332-2c0e-4c42-8c51-83ac20462eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08265332-2c0e-4c42-8c51-83ac20462eed.jpg?1",
             "name": "Game of Chaos",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, you gain 1 life and that opponent loses 1 life. Otherwise, you lose 1 life and the opponent gains 1 life. Effects that prevent or redirect damage cannot be used to counter this loss of life. The winner of each round decides whether to continue. Double the stakes in life each round.",
             "colours": [
@@ -6025,7 +6025,7 @@
         },
         {
             "id": "e4a23cc9-02f8-57e4-b9ae-3dec6e93d185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2726b192-f239-470b-8ad6-69887405e7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2726b192-f239-470b-8ad6-69887405e7f9.jpg?1",
             "name": "Glacial Crevasses",
             "text": "o0: Sacrifice a snow-covered mountain. No creatures deal damage in combat this turn.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "ea1753a9-bcb3-5291-bf51-9ddced017fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db54f95-6652-45a3-b960-c2fc118beca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db54f95-6652-45a3-b960-c2fc118beca1.jpg?1",
             "name": "Goblin Mutant",
             "text": "Trample\nCannot attack if defending player controls an untapped creature with power greater than 2. Cannot be assigned to block any creature with power greater than 2.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "b786ac3e-1f06-5010-92ff-83ed68b6e85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de839540-a7b9-4f91-91df-3fd4f5c0bc4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de839540-a7b9-4f91-91df-3fd4f5c0bc4e.jpg?1",
             "name": "Goblin Sappers",
             "text": "o\nRo\nR,oc\nT: Target creature you control cannot be blocked this turn. At end of combat, destroy that creature and Goblin Sappers.\no\nRo\nRo\nRo\nR,oc\nT: Target creature you control cannot be blocked this turn. At end of combat, destroy that creature.",
             "colours": [
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "88eba857-dab3-555b-80dc-3edb4f46aee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1c8b5-1e01-4920-8d02-bf80d5b238c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde1c8b5-1e01-4920-8d02-bf80d5b238c5.jpg?1",
             "name": "Goblin Ski Patrol",
             "text": "o1oo\nR Flying and +2/+0. At end of turn, bury Goblin Ski Patrol. Use this ability only once and only if you control any snow-covered mountains.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "8dc1c5cc-f864-523c-9d52-214c3ed0ead8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb260a-6763-4d1c-a009-4e34cd572519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb260a-6763-4d1c-a009-4e34cd572519.jpg?1",
             "name": "Goblin Snowman",
             "text": "When blocking, Goblin Snowman neither deals nor receives damage in combat.\noc\nT: Goblin Snowman deals 1 damage to target creature it blocks.",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "6ccf4b79-7a50-5e37-b7f3-f9a15ff64ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bb17b9-55c4-4cc1-83f6-75490b9a97d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bb17b9-55c4-4cc1-83f6-75490b9a97d0.jpg?1",
             "name": "Grizzled Wolverine",
             "text": "oo\nR +2/+0 until end of turn. Use this ability only when a creature is assigned to block Grizzled Wolverine and only once each turn.",
             "colours": [
@@ -6222,7 +6222,7 @@
         },
         {
             "id": "74e608f5-bac6-5592-9441-15e48b58d145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca42b74-9b42-482b-b12a-79cafdcd087e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca42b74-9b42-482b-b12a-79cafdcd087e.jpg?1",
             "name": "Imposing Visage",
             "text": "Target creature cannot be blocked by only one creature.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "1b0f4d49-e6c3-59c3-8db3-464f3cc2f565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f00af-010d-4485-b8b7-47400d99c496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f00af-010d-4485-b8b7-47400d99c496.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. No creature damaged by Incinerate can regenerate this turn.",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "cd34ab68-3523-5b09-b81c-8d3bbca57d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf0d325-5928-4593-8faa-64ffa414cb48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf0d325-5928-4593-8faa-64ffa414cb48.jpg?1",
             "name": "Jokulhaups",
             "text": "Bury all artifacts, creatures, and lands.",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "0d92a072-c221-5e73-b5b2-737a0bd5a8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c524ac2a-294c-4b19-b00b-999e370a3b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c524ac2a-294c-4b19-b00b-999e370a3b95.jpg?1",
             "name": "Karplusan Giant",
             "text": "o0: Tap target snow-covered land you control to give Karplusan Giant +1/+1 until end of turn.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "a65ce270-da6b-514c-8643-e77869693c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9b214-d9fe-4c2e-b45b-7145ad98c408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd9b214-d9fe-4c2e-b45b-7145ad98c408.jpg?1",
             "name": "Karplusan Yeti",
             "text": "oc\nT: Karplusan Yeti deals an amount of damage equal to its power to target creature. That creature deals an amount of damage equal to its power to Karplusan Yeti.",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "aa0886d5-c183-51d8-84f5-3e1887e015c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc0e20-5790-4927-8432-cf0e9b7381d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc0e20-5790-4927-8432-cf0e9b7381d4.jpg?1",
             "name": "Lava Burst",
             "text": "Lava Burst deals X damage to target creature or player. Effects that prevent or redirect damage cannot be used to protect that creature.",
             "colours": [
@@ -6414,7 +6414,7 @@
         },
         {
             "id": "17e143c6-0bf6-508d-a49d-468565f7fa67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880e815-53e7-43e0-befd-e368f00a75d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880e815-53e7-43e0-befd-e368f00a75d8.jpg?1",
             "name": "M\u00e1rton Stromgald",
             "text": "If M\u00e1rton Stromgald attacks, all other attacking creatures get +*/+* until end of turn, where * is equal to the number of other attacking creatures. If M\u00e1rton blocks, all other blocking creatures get +*/+* until end of turn, where * is equal to the number of other blocking creatures.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "0b3ef975-9577-5338-ab19-04d33bfd4a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13a064d-bff4-4a48-a158-1b61951b0ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13a064d-bff4-4a48-a158-1b61951b0ac3.jpg?1",
             "name": "Melee",
             "text": "Cast only on your turn during combat before defense is chosen. Choose how attacking creatures you control are blocked; all defense must be legal. After declaring blocking, untap any unblocked attacking creature. Treat those creatures as though they had not attacked.",
             "colours": [
@@ -6481,7 +6481,7 @@
         },
         {
             "id": "668b773d-93e4-542f-bb6c-5ba373a9cb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90065e-2c7e-44e5-9f59-015d468214bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90065e-2c7e-44e5-9f59-015d468214bf.jpg?1",
             "name": "Melting",
             "text": "All snow-covered lands become non-snow-covered lands of the same type.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "6d0828a8-e6ce-552d-81da-8897b5a9fbdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4851e-677b-468e-9baa-e47a3b4b8339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4851e-677b-468e-9baa-e47a3b4b8339.jpg?1",
             "name": "Meteor Shower",
             "text": "Meteor Shower deals X+1 damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "29388aa8-52fd-5c9c-a4cb-b1d7037dcdc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf70276-a40c-4d25-b584-4c8a07a00602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf70276-a40c-4d25-b584-4c8a07a00602.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk",
             "colours": [
@@ -6576,7 +6576,7 @@
         },
         {
             "id": "6fe2704f-7e37-52ed-a175-a078edd568cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65acce56-8674-471e-9d5e-91b7e3f672c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65acce56-8674-471e-9d5e-91b7e3f672c1.jpg?1",
             "name": "Mudslide",
             "text": "Creatures without flying do not untap during their controller's untap phase. At the end of his or her upkeep, each player may pay an additional o2 per creature to untap a creature without flying he or she controls.",
             "colours": [
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "2caf7b1c-a0d9-5653-b8d1-1e0d44db7380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4309a2f-27f5-4652-b0b4-6a6119436f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4309a2f-27f5-4652-b0b4-6a6119436f75.jpg?1",
             "name": "Orcish Cannoneers",
             "text": "oc\nT: Orcish Cannoneers deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -6641,7 +6641,7 @@
         },
         {
             "id": "39f92a5f-712d-5504-a376-973c56aedb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71394f8-3038-4cad-adea-a704f004777f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71394f8-3038-4cad-adea-a704f004777f.jpg?1",
             "name": "Orcish Conscripts",
             "text": "Cannot be declared as attacking unless at least two other creatures are also declared as attacking. Cannot be assigned to block unless at least two other creatures are also assigned to block.",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "4d9bfded-19f6-5499-8576-9ce12b9ff95f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa5beef-d609-4809-a813-621b0b4cff7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa5beef-d609-4809-a813-621b0b4cff7f.jpg?1",
             "name": "Orcish Farmer",
             "text": "oc\nT: Target land becomes a swamp until its controller's next untap phase.",
             "colours": [
@@ -6707,7 +6707,7 @@
         },
         {
             "id": "672f25f2-bcc7-50f1-bd43-a31459075bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff511f3-416e-4919-acd6-fd8183bf5c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff511f3-416e-4919-acd6-fd8183bf5c60.jpg?1",
             "name": "Orcish Healer",
             "text": "o\nRo\nR,oc\nT: Target creature cannot regenerate this turn.\no\nRo\nBo\nB,oc\nT: Regenerate target black or green creature.\no\nRo\nGo\nG,oc\nT: Regenerate target black or green creature.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "eed9cb1a-8aea-58f4-9a62-77df82800471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed908d6-6d06-4ccb-9577-37ef2d01c1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed908d6-6d06-4ccb-9577-37ef2d01c1a5.jpg?1",
             "name": "Orcish Librarian",
             "text": "o\nR,oc\nT: Take the top eight cards of your library; remove four of them at random from the game. Put the remaining four on top of your library in any order.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "c75c9fce-b455-5e80-8676-5764e18005ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ef13e3-658c-43a3-a290-4c5dde8e8b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ef13e3-658c-43a3-a290-4c5dde8e8b55.jpg?1",
             "name": "Orcish Lumberjack",
             "text": "oc\nT: Sacrifice a forest to add three mana in any combination of red and/or green to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "9ed2768c-b7b4-5a50-940f-b5b860237c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ee7bd5-612b-4916-a914-1294805b8f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ee7bd5-612b-4916-a914-1294805b8f64.jpg?1",
             "name": "Orcish Squatters",
             "text": "If Orcish Squatters attacks and is not blocked, you may gain control of target land controlled by defending player. If you do so, Orcish Squatters deals no damage in combat this turn. Lose control of that land if Orcish Squatters leaves play or if you lose control of Orcish Squatters.",
             "colours": [
@@ -6843,7 +6843,7 @@
         },
         {
             "id": "f52d4e53-e256-5993-938d-1e3493be8c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ab85ac-311c-4e36-943a-817e43a3c8a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ab85ac-311c-4e36-943a-817e43a3c8a8.jpg?1",
             "name": "Panic",
             "text": "Target creature cannot block this turn. Cast only during combat before defense is chosen. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "4640459b-f0f5-5118-93df-70f841fbdf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342cac5-08ae-4428-9c2c-f6c5904e54d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342cac5-08ae-4428-9c2c-f6c5904e54d2.jpg?1",
             "name": "Pyroblast",
             "text": "Counter target spell if it is blue or destroy target permanent if it is blue.",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "9236cd11-1292-524f-94a3-563507f2af9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040748-ad76-4b9a-bd4e-87e5980e9816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040748-ad76-4b9a-bd4e-87e5980e9816.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -6936,7 +6936,7 @@
         },
         {
             "id": "7c92629d-3649-520a-a5c1-d3e649e7cb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914c5a8-2114-41c5-a471-ca97524d622f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914c5a8-2114-41c5-a471-ca97524d622f.jpg?1",
             "name": "Sabretooth Tiger",
             "text": "First strike",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "0b54482a-650f-5022-92bd-ee72a5de3ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb18d53-20de-43d7-86f7-97a6d14d54b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb18d53-20de-43d7-86f7-97a6d14d54b8.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "43463ae6-abd2-5dcb-af70-e52af0508be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a002e6d-ea59-4694-b3e5-075d6020b0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a002e6d-ea59-4694-b3e5-075d6020b0d9.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -7031,7 +7031,7 @@
         },
         {
             "id": "d69c7237-8d1e-560e-bff9-8a3015497e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789dfae7-fe23-4e2e-9f5f-304535d22a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789dfae7-fe23-4e2e-9f5f-304535d22a78.jpg?1",
             "name": "Stone Spirit",
             "text": "Cannot be blocked by creatures with flying.",
             "colours": [
@@ -7065,7 +7065,7 @@
         },
         {
             "id": "75e44e13-2e9c-5169-914c-ad1b7e3dd43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23fa1af-78e5-4d23-bbf6-cd62bc54b4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23fa1af-78e5-4d23-bbf6-cd62bc54b4e9.jpg?1",
             "name": "Stonehands",
             "text": "Target creature gets +0/+2.\no\nR: Creature Stonehands enchants gets +1/+0 until end of turn.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "82b30b8a-62a3-59dc-8c95-09e4852a2e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef8f279-1a10-4685-99d6-bc971a7f922b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef8f279-1a10-4685-99d6-bc971a7f922b.jpg?1",
             "name": "Tor Giant",
             "text": "",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "1ad34cbe-82ac-5d3c-9fa5-9d3054246d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6107388b-ec1e-401e-a407-a821c908ed8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6107388b-ec1e-401e-a407-a821c908ed8d.jpg?1",
             "name": "Total War",
             "text": "Whenever any player declares an attack, destroy all untapped non-wall creatures that player controls that don't attack. Do not destroy creatures the player did not control at the beginning of the turn.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "805eb62e-e48b-57a4-9a97-aeee11f226f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067e7af-7bbd-48c1-9f1d-df2a91a0ec54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067e7af-7bbd-48c1-9f1d-df2a91a0ec54.jpg?1",
             "name": "Vertigo",
             "text": "Vertigo deals 2 damage to target creature with flying; that creature loses flying until end of turn.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "f14837a2-aa63-557a-b201-2894760d8626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99d6d11-b3f7-4d73-967c-3049af82a9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99d6d11-b3f7-4d73-967c-3049af82a9d8.jpg?1",
             "name": "Wall of Lava",
             "text": "oo\nR +1/+1 until end of turn",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "2a091400-b7af-5ef3-9f43-98673abb76e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b383c8-d604-4131-a869-9e9d13e30b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b383c8-d604-4131-a869-9e9d13e30b94.jpg?1",
             "name": "Word of Blasting",
             "text": "Bury target wall. Word of Blasting deals an amount of damage equal to that wall's casting cost to the wall's controller.",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "d185fcb8-51ed-55f0-9926-3fded47c2960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e973a84-7f7d-4524-9f2f-ec9a014d52ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e973a84-7f7d-4524-9f2f-ec9a014d52ee.jpg?1",
             "name": "Aurochs",
             "text": "Trample\nWhen attacking, Aurochs gets +1/+0 for each other Aurochs that attacks.",
             "colours": [
@@ -7290,7 +7290,7 @@
         },
         {
             "id": "3e523230-9699-5657-82f2-a10d238f599e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5297cb-e763-4871-9cd3-0e2dbcc52095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5297cb-e763-4871-9cd3-0e2dbcc52095.jpg?1",
             "name": "Balduvian Bears",
             "text": "",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "5ff129c4-2bc1-52dd-8896-fb5cb88a8cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c369e4f9-0f2b-446c-9e2d-d3eefab0586d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c369e4f9-0f2b-446c-9e2d-d3eefab0586d.jpg?1",
             "name": "Blizzard",
             "text": "Cumulative Upkeep: o2\nYou cannot cast Blizzard if you control no snow-covered lands. Creatures with flying do not untap during their controller's untap phase.",
             "colours": [
@@ -7354,7 +7354,7 @@
         },
         {
             "id": "56918c03-a823-5835-89db-60fded342089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ce35b-ba65-451d-a5ed-e1db6f1d0c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ce35b-ba65-451d-a5ed-e1db6f1d0c6f.jpg?1",
             "name": "Brown Ouphe",
             "text": "o1o\nG,oc\nT: Counter target artifact ability requiring an activation cost. Play this ability as an interrupt.",
             "colours": [
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "97e48cb1-8d79-5e95-bd6f-6fa5329f292d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ebcc1d-0c5c-4bc2-ade7-41944f69162e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ebcc1d-0c5c-4bc2-ade7-41944f69162e.jpg?1",
             "name": "Chub Toad",
             "text": "Chub Toad gets +2/+2 until end of turn when blocking or blocked.",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "5f7fb126-7b22-5687-b627-77c32079ad6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602c93d-e00f-4b4f-a7ff-95316b7e7641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602c93d-e00f-4b4f-a7ff-95316b7e7641.jpg?1",
             "name": "Dire Wolves",
             "text": "Gains banding if you control any plains.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "4a1cc629-d7e4-50fd-a22e-3f5481ca7e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319d252e-7c43-47d6-8873-f69b0e063256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319d252e-7c43-47d6-8873-f69b0e063256.jpg?1",
             "name": "Earthlore",
             "text": "When Earthlore comes into play, choose target land you control.\no0: Tap land Earthlore enchants to give target blocking creature +1/+2 until end of turn.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "790b090e-ceef-58e3-9328-2c4acf459a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210f6fab-62f0-42ab-bd01-00d647bd25e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210f6fab-62f0-42ab-bd01-00d647bd25e7.jpg?1",
             "name": "Elder Druid",
             "text": "o3o\nG,oc\nT: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "9e9704cd-9311-56d0-84ee-6c88615c206d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b610103-dafd-4248-9d79-ce57f84b9e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b610103-dafd-4248-9d79-ce57f84b9e03.jpg?1",
             "name": "Essence Filter",
             "text": "Destroy all enchantments or destroy all non-white enchantments.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "ad0dffca-2613-5afa-af49-25fa03b9e1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abba7f1-5d07-4137-88a2-5967396a3e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abba7f1-5d07-4137-88a2-5967396a3e42.jpg?1",
             "name": "Fanatical Fever",
             "text": "Target creature gains trample and gets +3/+0 until end of turn.",
             "colours": [
@@ -7583,7 +7583,7 @@
         },
         {
             "id": "cd8dea58-8b3e-57c1-b388-fd4ace182366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13311d-db83-483f-ba2b-4f54ceb8b026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13311d-db83-483f-ba2b-4f54ceb8b026.jpg?1",
             "name": "Folk of the Pines",
             "text": "o1oo\nG +1/+0 until end of turn",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "91f5d46e-3382-5724-bd74-6cb8787f0b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc225cf-4fe2-4a5b-828e-ffcb99e404e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc225cf-4fe2-4a5b-828e-ffcb99e404e8.jpg?1",
             "name": "Forbidden Lore",
             "text": "When Forbidden Lore comes into play, choose target land.\no0: Tap land Forbidden Lore enchants to give target creature +2/+1 until end of turn.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "3d0d1d9a-bade-5d31-bf49-c797a58ed2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01dd39-a957-4c1a-86cf-f31a699a154a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01dd39-a957-4c1a-86cf-f31a699a154a.jpg?1",
             "name": "Forgotten Lore",
             "text": "Target opponent chooses target card from your graveyard. You may pay o\nG to have that opponent choose a new target that he or she has not already chosen. Put the last target card in your hand.",
             "colours": [
@@ -7680,7 +7680,7 @@
         },
         {
             "id": "dabe77dd-e762-505b-a952-8e2d0b352650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db9685-6a2f-4548-b6c4-669918d653b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db9685-6a2f-4548-b6c4-669918d653b4.jpg?1",
             "name": "Foxfire",
             "text": "Untap target attacking creature. That creature neither receives nor deals damage in combat this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "69abb5b4-ab80-5a3b-9672-4efd4adeb380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1e718a-882a-4bdc-9d62-4dda88da0ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1e718a-882a-4bdc-9d62-4dda88da0ba0.jpg?1",
             "name": "Freyalise Supplicant",
             "text": "oc\nT: Sacrifice a red or white creature to have Freyalise Supplicant deal an amount of damage equal to half the creature's power, rounded down, to target creature or player.",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "69c448ad-599e-5103-8281-c63b8b115b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e147ac1-d221-49c7-966e-5e665ddeab6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e147ac1-d221-49c7-966e-5e665ddeab6b.jpg?1",
             "name": "Freyalise's Charm",
             "text": "o\nGoo\nG When any opponent successfully casts a black spell, draw a card. Use this ability only once each time a black spell is cast.\no\nGoo\nG Return Freyalise's Charm to owner's hand.",
             "colours": [
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "20acbfce-2c8b-58d4-a2fe-cb1d36e8dd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11cd2e0-9419-4267-807e-5b73915c748a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11cd2e0-9419-4267-807e-5b73915c748a.jpg?1",
             "name": "Freyalise's Winds",
             "text": "Whenever a permanent becomes tapped, put a wind counter on it. Permanents with any wind counters on them do not untap during their controller's untap phase; instead, remove all wind counters from those permanents.",
             "colours": [
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "1b0a58fd-f196-5e29-ab55-7121bc2f98ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06204e82-9dfd-4334-a23a-f8240fc37772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06204e82-9dfd-4334-a23a-f8240fc37772.jpg?1",
             "name": "Fyndhorn Brownie",
             "text": "o2o\nG,oc\nT: Untap target creature.",
             "colours": [
@@ -7840,7 +7840,7 @@
         },
         {
             "id": "44119bef-1f16-5692-b4eb-301458525c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8aa11-f7cb-4f88-a041-30098579f1d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8aa11-f7cb-4f88-a041-30098579f1d2.jpg?1",
             "name": "Fyndhorn Elder",
             "text": "oc\nT: Add o\nGo\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7874,7 +7874,7 @@
         },
         {
             "id": "eae94fdd-0349-5d88-aa4c-2a8e882e8610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba95ffa-990a-4013-98b7-5d8c0b34e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba95ffa-990a-4013-98b7-5d8c0b34e9c4.jpg?1",
             "name": "Fyndhorn Elves",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as an interrupt.",
             "colours": [
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "44a9d80c-b272-5e50-b928-626e14474d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efbe59d-bebc-40b1-85ac-2e4c1ff3731e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efbe59d-bebc-40b1-85ac-2e4c1ff3731e.jpg?1",
             "name": "Fyndhorn Pollen",
             "text": "Cumulative Upkeep: o1\nAll creatures get -1/-0.\no1o\nG: All creatures get -1/-0 until end of turn.",
             "colours": [
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "4d8015a0-c296-5e32-927b-9e07a7a957fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431c9749-fd7b-4960-a910-8d41d3704e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431c9749-fd7b-4960-a910-8d41d3704e6c.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7970,7 +7970,7 @@
         },
         {
             "id": "91da4fba-6574-53ee-b422-e094192c45c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046f6b76-5f17-4728-aa34-72b7eff1d4c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046f6b76-5f17-4728-aa34-72b7eff1d4c9.jpg?1",
             "name": "Gorilla Pack",
             "text": "Gorilla Pack cannot attack if defending player controls no forests. Bury Gorilla Pack if you control no forests.",
             "colours": [
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "320bf49e-17a6-5b77-8c93-7bb4376009d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4fe072-81a7-424e-8d21-aaca010d5b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4fe072-81a7-424e-8d21-aaca010d5b1d.jpg?1",
             "name": "Hot Springs",
             "text": "When Hot Springs comes into play, choose target land you control.\no0: Tap land Hot Springs enchants to prevent 1 damage to any creature or player.",
             "colours": [
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "fe7bedb9-6459-5107-b45e-61bc06fd4d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cc6db7-1f40-40e3-a7ea-92f1d05e2e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cc6db7-1f40-40e3-a7ea-92f1d05e2e3d.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each creature with flying and each player.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "a60bac10-d818-501b-b366-106b7868c005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a22e88-f7b1-48c8-a199-e57edcd50654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a22e88-f7b1-48c8-a199-e57edcd50654.jpg?1",
             "name": "Johtull Wurm",
             "text": "For each blocking creature assigned to Johtull Worm beyond the first, Johtull Worm gets -2/-1 until end of turn.",
             "colours": [
@@ -8100,7 +8100,7 @@
         },
         {
             "id": "f15efc3c-0727-5037-87b8-16f6f5647ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb211704-ff8e-498b-b7bb-f8384f198ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb211704-ff8e-498b-b7bb-f8384f198ffd.jpg?1",
             "name": "Juniper Order Druid",
             "text": "oc\nT: Untap target land. Play this ability as an interrupt.",
             "colours": [
@@ -8135,7 +8135,7 @@
         },
         {
             "id": "8c4715a2-b4bd-5043-9af2-168535e9e498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee6d385-d44b-4f1a-beb1-13aeebde063e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee6d385-d44b-4f1a-beb1-13aeebde063e.jpg?1",
             "name": "Lhurgoyf",
             "text": "Lhurgoyf has power equal to the total number of creatures in all graveyards and toughness equal to 1 plus the total number of creatures in all graveyards.",
             "colours": [
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "d5868753-b721-5ba0-9226-f06f4901ab4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87af69ee-c2bb-46ea-8d36-d484d04a3c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87af69ee-c2bb-46ea-8d36-d484d04a3c8a.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. Lure does not prevent a creature from blocking more than one creature if blocker has that ability. If blocker is forced to block more creatures than it is allowed to, defender chooses which of these creatures to block, but must block as many creatures as allowed.",
             "colours": [
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "fa4db3bd-ed29-57b3-be92-5151f3b385c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277656c-70f5-4660-bd58-7d9261d53fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277656c-70f5-4660-bd58-7d9261d53fb5.jpg?1",
             "name": "Maddening Wind",
             "text": "Cumulative Upkeep: o\nG\nDuring target creature's controller's upkeep, Maddening Wind deals 2 damage to that player.",
             "colours": [
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "09ff3dd6-0cf6-5a26-aada-bea1567a2603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668d2969-b6b7-4507-bdd4-20bbaa68035a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668d2969-b6b7-4507-bdd4-20bbaa68035a.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for any forest and put it directly into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards.",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "445260c1-85c5-5417-9554-1d8a31cc48b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg?1",
             "name": "Pale Bears",
             "text": "Islandwalk",
             "colours": [
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "c95df579-4d1b-5de1-80b7-4a589808bf4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg?1",
             "name": "Pygmy Allosaurus",
             "text": "Swampwalk",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "6758456f-642c-5e7a-a4d0-b67a07b51844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffc64e4-ae3c-49f9-8ed6-518dd497bfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffc64e4-ae3c-49f9-8ed6-518dd497bfe6.jpg?1",
             "name": "Pyknite",
             "text": "Draw a card at the beginning of the upkeep of the turn after Pyknite comes into play.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "5d54b40e-25f8-5ef9-84d1-58a7797c4b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dacfaec-6b61-450d-a134-2087c38a298a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dacfaec-6b61-450d-a134-2087c38a298a.jpg?1",
             "name": "Regeneration",
             "text": "When Regeneration comes into play, choose target creature.\noo\nG Regenerate creature Regeneration enchants.",
             "colours": [
@@ -8397,7 +8397,7 @@
         },
         {
             "id": "e72c2777-c999-5b05-ad55-c42a839a663f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93e6ce-1295-41f8-b454-2dfe321481a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93e6ce-1295-41f8-b454-2dfe321481a6.jpg?1",
             "name": "Rime Dryad",
             "text": "Snow-covered forestwalk",
             "colours": [
@@ -8430,7 +8430,7 @@
         },
         {
             "id": "dc35b53c-0cdb-5d89-ae3e-26a8bd4df6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5c01e7-8116-45fc-afc3-d52a31a635cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5c01e7-8116-45fc-afc3-d52a31a635cb.jpg?1",
             "name": "Ritual of Subdual",
             "text": "Cumulative Upkeep: o2\nAll mana-producing lands produce colorless mana instead of their normal mana.",
             "colours": [
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "57802a82-d97e-5ad6-8ed3-7e4d4fdf0250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cd7fa-c86c-4a5f-b36d-8160e8a6af1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cd7fa-c86c-4a5f-b36d-8160e8a6af1f.jpg?1",
             "name": "Scaled Wurm",
             "text": "",
             "colours": [
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "f26d2597-8c83-5711-b8dd-7d402d3a8ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8886ba2d-b25a-4b74-9299-911c509ae864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8886ba2d-b25a-4b74-9299-911c509ae864.jpg?1",
             "name": "Shambling Strider",
             "text": "o\nRoo\nG +1/-1 until end of turn",
             "colours": [
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "57ae69f9-f643-5ab0-a0cd-87478b50c0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f62c376-487a-42bc-bd85-ab8b0480f7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f62c376-487a-42bc-bd85-ab8b0480f7dc.jpg?1",
             "name": "Snowblind",
             "text": "Target creature gets -*/-*. When that creature attacks, * is equal to the number of snow-covered lands defending player controls. At other times, * is equal to the number of snow-covered lands its controller controls. If this reduces the creature's toughness to less than 1, the creature's toughness is 1.",
             "colours": [
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "3637f9ef-9692-5c9c-b012-8d9846078923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8265a1-4621-4d25-8f7f-f0179951a694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8265a1-4621-4d25-8f7f-f0179951a694.jpg?1",
             "name": "Stampede",
             "text": "All attacking creatures gain trample and get +1/+0 until end of turn.",
             "colours": [
@@ -8592,7 +8592,7 @@
         },
         {
             "id": "2b21c9c4-4115-5be0-9166-3fcfd2d68ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9b7393-eb35-4c99-bbf5-bcf924aa8ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9b7393-eb35-4c99-bbf5-bcf924aa8ff3.jpg?1",
             "name": "Stunted Growth",
             "text": "Target player chooses three cards from his or her hand and puts them on top of his or her library in any order. If that player does not have enough cards in hand, his or her entire hand is put on top of his or her library in any order.",
             "colours": [
@@ -8623,7 +8623,7 @@
         },
         {
             "id": "1c211aac-f76a-5b3b-b1e7-7c5d5d1f1e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1420ec5-367c-4514-86c5-3993bf339e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1420ec5-367c-4514-86c5-3993bf339e37.jpg?1",
             "name": "Tarpan",
             "text": "If Tarpan is put into the graveyard from play, gain 1 life.",
             "colours": [
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "fdbab131-b8f8-5a92-ab66-e55f708b19ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ae906b-2c4d-48e9-9f2d-217777e22292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ae906b-2c4d-48e9-9f2d-217777e22292.jpg?1",
             "name": "Thermokarst",
             "text": "Destroy target land. If that land is a snow-covered land, gain 1 life.",
             "colours": [
@@ -8687,7 +8687,7 @@
         },
         {
             "id": "fb4759c4-18c5-5a14-bb54-fff7d3350a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe7f9d-644f-48d0-93fa-d9a536f1f755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fe7f9d-644f-48d0-93fa-d9a536f1f755.jpg?1",
             "name": "Thoughtleech",
             "text": "Whenever an island controlled by target opponent becomes tapped, gain 1 life.",
             "colours": [
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "0f2bebf5-e2a8-560e-8820-f7b37405cece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7c6489-21e9-4b86-a54a-b1e2f1fce318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7c6489-21e9-4b86-a54a-b1e2f1fce318.jpg?1",
             "name": "Tinder Wall",
             "text": "o0: Sacrifice Tinder Wall to add o\nRo\nR to your mana pool. Play this ability as an interrupt.\noo\nR Sacrifice Tinder Wall to have it deal 2 damage to target creature it blocks.",
             "colours": [
@@ -8753,7 +8753,7 @@
         },
         {
             "id": "f2986bfe-9c4e-5974-8364-7ee38e4d98ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d2cd18-a24d-40e0-a654-777d9e623ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d2cd18-a24d-40e0-a654-777d9e623ae2.jpg?1",
             "name": "Touch of Vitae",
             "text": "Target creature may untap one additional time this turn. That creature may attack or use abilities that require oc\nT as part of the activation cost this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "19bc52d1-8c69-5626-97b7-9582b498bfbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg?1",
             "name": "Trailblazer",
             "text": "Target creature cannot be blocked this turn.",
             "colours": [
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "00378fdb-e65f-5279-8b34-c0d03bce6c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eeb9e02-1d26-4959-a878-2ef8db2358bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eeb9e02-1d26-4959-a878-2ef8db2358bc.jpg?1",
             "name": "Venomous Breath",
             "text": "At end of combat, destroy all creatures blocking or blocked by target creature this turn.",
             "colours": [
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "a60de631-485b-56d1-9ae8-c375df9ff2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d879923-55fc-46ab-9306-5e1f10441c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d879923-55fc-46ab-9306-5e1f10441c89.jpg?1",
             "name": "Wall of Pine Needles",
             "text": "oo\nG Regenerate",
             "colours": [
@@ -8880,7 +8880,7 @@
         },
         {
             "id": "1af1d448-1b0d-53cb-9ccd-570f193fae16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8645e4f-eaa8-4420-a6a3-eb53c311fab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8645e4f-eaa8-4420-a6a3-eb53c311fab1.jpg?1",
             "name": "Whiteout",
             "text": "All creatures with flying lose flying until end of turn.\nIf Whiteout is in your graveyard, you may sacrifice a snow-covered land to return Whiteout to your hand.",
             "colours": [
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "5aa56110-912b-5b71-8d5a-c7c3c49307cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee86bf2-6c54-4c6e-8394-eb39f98d5a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee86bf2-6c54-4c6e-8394-eb39f98d5a85.jpg?1",
             "name": "Wiitigo",
             "text": "When Wiitigo comes into play, put six +1/+1 counters on it.\nDuring your upkeep, put a +1/+1 counter on Wiitigo if it has blocked or been blocked since your last upkeep. Otherwise, remove a +1/+1 counter from Wiitigo. Ignore this effect if there are no counters left on Wiitigo.",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "45e2c20e-c9b2-54ab-9979-e0c43236ff5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8047ab9-a0fc-4933-bcbc-e761aa0f622b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8047ab9-a0fc-4933-bcbc-e761aa0f622b.jpg?1",
             "name": "Wild Growth",
             "text": "Wild Growth adds o\nG to your mana pool whenever target land is tapped for mana.",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "cca2682d-06b8-5df7-99d9-44872ba7e0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca1216-99c8-4ad5-a51a-3c4ff3b82097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca1216-99c8-4ad5-a51a-3c4ff3b82097.jpg?1",
             "name": "Woolly Mammoths",
             "text": "Gains trample as long as you control any snow-covered lands.",
             "colours": [
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "79dd7339-911b-540e-a72a-a15546e3eac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10520b2-b5a7-4328-84c8-20443b6f588a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e10520b2-b5a7-4328-84c8-20443b6f588a.jpg?1",
             "name": "Woolly Spider",
             "text": "Can block creatures with flying.\nIf Woolly Spider is assigned to block a creature with flying, Woolly Spider gets +0/+2 until end of turn.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "931e96ac-74b4-50c7-b9c5-f6dd6b6fc770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8b7020-ca8f-4867-bc51-13d824daf154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8b7020-ca8f-4867-bc51-13d824daf154.jpg?1",
             "name": "Yavimaya Gnats",
             "text": "Flying\noo\nG Regenerate",
             "colours": [
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "2bc9f88e-bcae-5d1a-ab86-4fbfa3cee2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5b014-8675-4d91-a539-ac5c31d44b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5b014-8675-4d91-a539-ac5c31d44b35.jpg?1",
             "name": "Altar of Bone",
             "text": "Sacrifice a creature to look through your library for a creature card; put that card into your hand after showing it to all other players. Reshuffle your library afterwards.",
             "colours": [
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "7c96948b-b232-5e32-850f-ee21b074f10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e275c295-72da-4a86-82c6-cfd75b38b19c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e275c295-72da-4a86-82c6-cfd75b38b19c.jpg?1",
             "name": "Centaur Archer",
             "text": "oc\nT: Centaur Archer deals 1 damage to target creature with flying.",
             "colours": [
@@ -9145,7 +9145,7 @@
         },
         {
             "id": "f0df0044-1348-5649-92fe-c8cbd216d49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2657e85b-8f77-41fa-9df2-233443efef43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2657e85b-8f77-41fa-9df2-233443efef43.jpg?1",
             "name": "Chromatic Armor",
             "text": "When Chromatic Armor comes into play, put a sleight counter on it and choose a color. Any damage dealt to target creature by a source of that color is reduced to 0.\noo\nX Put a sleight counter on Chromatic Armor and change the color that it protects against. X is equal to the number of sleight counters on Chromatic Armor.",
             "colours": [
@@ -9180,7 +9180,7 @@
         },
         {
             "id": "5a371d02-c58d-538c-a01b-45ae934909cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea01324-1cfb-498c-8299-f690373864bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea01324-1cfb-498c-8299-f690373864bd.jpg?1",
             "name": "Diabolic Vision",
             "text": "Look at the top five cards of your library and put one of them into your hand. Put the remaining four on top of your library in any order.",
             "colours": [
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "87ec80cf-db55-55a0-b9d9-549345b061b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83cb1c4-7c5b-4a5e-b15e-138d644f5cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83cb1c4-7c5b-4a5e-b15e-138d644f5cdb.jpg?1",
             "name": "Earthlink",
             "text": "During your upkeep, pay o2 or bury Earthlink.\nWhenever a creature is put into the graveyard from play, that creature's controller sacrifices a land. Ignore this effect if that player controls no lands.",
             "colours": [
@@ -9248,7 +9248,7 @@
         },
         {
             "id": "3a6b07fe-188a-576b-8d50-24a7b8902d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbff2a-5109-400a-961b-eacffb9aed67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbff2a-5109-400a-961b-eacffb9aed67.jpg?1",
             "name": "Elemental Augury",
             "text": "o3: Look at the top three cards of target player's library. Put them on the top of that player's library in any order.",
             "colours": [
@@ -9283,7 +9283,7 @@
         },
         {
             "id": "28782c7c-b868-5d54-a9dc-fe44a528ecb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe07e496-5070-4116-a91a-a3bbe19c12af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe07e496-5070-4116-a91a-a3bbe19c12af.jpg?1",
             "name": "Essence Vortex",
             "text": "Bury target creature. That creature's controller may counter this spell by paying the creature's toughness in life. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -9316,7 +9316,7 @@
         },
         {
             "id": "78dd7139-236e-5770-a45e-aa0723ded776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965ce61-0522-4f77-a82d-89441d1ba867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965ce61-0522-4f77-a82d-89441d1ba867.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided any way you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
             "colours": [
@@ -9351,7 +9351,7 @@
         },
         {
             "id": "8dc3762d-d641-5cd8-8d25-413f2d5a557c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0139c2-ad86-4c71-ab6d-4840c37d5d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0139c2-ad86-4c71-ab6d-4840c37d5d20.jpg?1",
             "name": "Fire Covenant",
             "text": "Fire Covenant deals X damage, divided any way you choose among any number of target creatures, where X is equal to the amount of life you pay. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -9384,7 +9384,7 @@
         },
         {
             "id": "eab6520c-0923-5850-aa83-473f9a15464d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de89e9e1-485b-42e5-9728-5d6f948999e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de89e9e1-485b-42e5-9728-5d6f948999e1.jpg?1",
             "name": "Flooded Woodlands",
             "text": "No green creature can attack unless its controller sacrifices a land whenever that creature attacks.",
             "colours": [
@@ -9417,7 +9417,7 @@
         },
         {
             "id": "6435102d-1b91-56ff-8007-50d200fd99b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa53e9a-0d7c-4d17-b2be-56930edfa2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa53e9a-0d7c-4d17-b2be-56930edfa2c2.jpg?1",
             "name": "Fumarole",
             "text": "Pay 3 life to destroy target creature and target land. Effects that prevent or redirect damage cannot be used to counter this loss of life.",
             "colours": [
@@ -9450,7 +9450,7 @@
         },
         {
             "id": "dd19f61b-0c2a-56bf-afb4-fa7888f19d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6314344b-6493-4142-9c76-da9b90b8d3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6314344b-6493-4142-9c76-da9b90b8d3e1.jpg?1",
             "name": "Ghostly Flame",
             "text": "Both black and red permanents and spells are considered colorless sources of damage.",
             "colours": [
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "da208fa7-3acb-5bc1-adf2-b06087476a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965dfa8-dc90-4cf2-a93b-72bf88b58936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8965dfa8-dc90-4cf2-a93b-72bf88b58936.jpg?1",
             "name": "Giant Trap Door Spider",
             "text": "o1o\nRo\nG,oc\nT: Remove from the game target creature, which doesn't have flying and is attacking you, and Giant Trap Door Spider.",
             "colours": [
@@ -9518,7 +9518,7 @@
         },
         {
             "id": "c4bf7eb8-e087-5889-95b6-1f544d05436e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86e159b-ecf1-4b4a-9041-4e97fdf935e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86e159b-ecf1-4b4a-9041-4e97fdf935e5.jpg?1",
             "name": "Glaciers",
             "text": "During your upkeep, pay o\nWo\nU or destroy Glaciers. All mountains become plains.",
             "colours": [
@@ -9551,7 +9551,7 @@
         },
         {
             "id": "39f364b0-c0a9-5b77-bb88-f7f26cb12fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d0f2f2-f6e2-4b8a-8418-10b17c5e0ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d0f2f2-f6e2-4b8a-8418-10b17c5e0ea9.jpg?1",
             "name": "Hymn of Rebirth",
             "text": "Take target creature from any graveyard and put it directly into play under your control as though it were just summoned.",
             "colours": [
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "87ed46bc-25c4-5a38-94b2-523b59b78b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fccb1d0-b324-4780-bb9e-4533240da06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fccb1d0-b324-4780-bb9e-4533240da06d.jpg?1",
             "name": "Kjeldoran Frostbeast",
             "text": "At end of combat, destroy all creatures blocking or blocked by Kjeldoran Frostbeast.",
             "colours": [
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "d6b51e69-9891-578e-bb2d-0c02bcbc54cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf47c0a-5c17-47d0-b663-becff62fbdf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf47c0a-5c17-47d0-b663-becff62fbdf8.jpg?1",
             "name": "Merieke Ri Berit",
             "text": "Does not untap during your untap phase.\noc\nT: Gain control of target creature. Lose control of that creature if you lose control of Merieke Ri Berit. If Merieke Ri Berit leaves play or becomes untapped, bury the creature.",
             "colours": [
@@ -9659,7 +9659,7 @@
         },
         {
             "id": "b517df89-a133-5999-8a0b-ea8fe0a3baee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fcc50-79a5-40cd-b028-e78dde3f8480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fcc50-79a5-40cd-b028-e78dde3f8480.jpg?1",
             "name": "Monsoon",
             "text": "Whenever any island is untapped at the end of its controller's turn, tap it; Monsoon deals 1 damage to that player.",
             "colours": [
@@ -9692,7 +9692,7 @@
         },
         {
             "id": "82a9e176-d9f4-51df-8712-02e07d17c2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1d589-02a2-4896-a283-9d0385534667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1d589-02a2-4896-a283-9d0385534667.jpg?1",
             "name": "Mountain Titan",
             "text": "o1o\nRoo\nR For the rest of the turn, put a +1/+1 counter on Mountain Titan whenever you successfully cast a black spell.",
             "colours": [
@@ -9727,7 +9727,7 @@
         },
         {
             "id": "befdd0c7-f240-5cb4-af67-204833c90698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca335f4f-d345-4eb9-9bc6-74595c501078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca335f4f-d345-4eb9-9bc6-74595c501078.jpg?1",
             "name": "Reclamation",
             "text": "No black creature can attack unless its controller sacrifices a land whenever that creature attacks.",
             "colours": [
@@ -9760,7 +9760,7 @@
         },
         {
             "id": "1ce305d1-f51b-5754-bd6a-2e5ad2102565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271c8a7c-0f71-4f9d-ab0e-ca7c8c4aca50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271c8a7c-0f71-4f9d-ab0e-ca7c8c4aca50.jpg?1",
             "name": "Skeleton Ship",
             "text": "If at any time you control no islands, bury Skeleton Ship.\noc\nT: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -9797,7 +9797,7 @@
         },
         {
             "id": "0caafc44-08a9-586f-acca-b8e639b74c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe0a783-d086-4dc8-ae4a-59f3c2daaca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe0a783-d086-4dc8-ae4a-59f3c2daaca0.jpg?1",
             "name": "Spectral Shield",
             "text": "Target creature gets +0/+2. That creature cannot be the target of further spells.",
             "colours": [
@@ -9832,7 +9832,7 @@
         },
         {
             "id": "156ac927-52cd-51cb-a34b-da1c26d22c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a383a5f-4814-4b92-aa80-2a6440a719bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a383a5f-4814-4b92-aa80-2a6440a719bc.jpg?1",
             "name": "Storm Spirit",
             "text": "Flying\noc\nT: Storm Spirit deals 2 damage to target creature.",
             "colours": [
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "54cb2bcb-bd46-51e3-8464-c5b45c506eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5d91b-aeb4-4d7e-b748-77f9960da55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5d91b-aeb4-4d7e-b748-77f9960da55f.jpg?1",
             "name": "Stormbind",
             "text": "o2: Discard a card at random from your hand to have Stormbind deal 2 damage to target creature or player.",
             "colours": [
@@ -9903,7 +9903,7 @@
         },
         {
             "id": "3a32e591-282a-5a68-9d0c-b329d68863ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb0282d-ccec-4556-8b70-b6f665077afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb0282d-ccec-4556-8b70-b6f665077afe.jpg?1",
             "name": "Wings of Aesthir",
             "text": "Target creature gains flying and first strike and gets +1/+0.",
             "colours": [
@@ -9938,7 +9938,7 @@
         },
         {
             "id": "016d3929-b1f9-5716-9712-162cf635ea58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff62754b-f4f0-4731-8dd7-327a820f60a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff62754b-f4f0-4731-8dd7-327a820f60a8.jpg?1",
             "name": "Adarkar Sentinel",
             "text": "o1: +0/+1 until end of turn",
             "colours": [],
@@ -9968,7 +9968,7 @@
         },
         {
             "id": "ce9127eb-27e2-5f18-b2c0-c02fdc93c46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d272051-f442-4f6e-8c64-df28b398d2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d272051-f442-4f6e-8c64-df28b398d2e8.jpg?1",
             "name": "Aegis of the Meek",
             "text": "o1,oc\nT: Target 1/1 creature gets +1/+2 until end of turn.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "32ad8104-985a-5247-a789-eb46dbe8d177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764ec6a8-a878-446c-b7e4-6026c2a3e9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764ec6a8-a878-446c-b7e4-6026c2a3e9a4.jpg?1",
             "name": "Amulet of Quoz",
             "text": "Remove Amulet of Quoz from your deck before playing if you are not playing for ante.\no0,oc\nT: Sacrifice Amulet of Quoz. Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, that opponent loses the game. Otherwise, you lose the game.\nEffects that prevent or redirect damage cannot be used to prevent this loss of life. Use this ability only during your upkeep. The opponent may ante an additional card to counter this effect.",
             "colours": [],
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "8a0ef859-3471-5aa6-b3da-78597b8ba0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9780ce2-756c-48e5-9936-45f6a224f61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9780ce2-756c-48e5-9936-45f6a224f61d.jpg?1",
             "name": "Arcum's Sleigh",
             "text": "o2,oc\nT: Attacking this turn does not cause target creature to tap. You cannot use this ability if defending player controls no snow-covered lands.",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "be34f080-b656-5a02-b01a-947a6623cc7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e142435-6930-4596-bc3b-60abde1229df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e142435-6930-4596-bc3b-60abde1229df.jpg?1",
             "name": "Arcum's Weathervane",
             "text": "o2,oc\nT: Target snow-covered land becomes a non-snow-covered land of the same type. Mark the changed land with a counter.\no2,oc\nT: Target non-snow-covered basic land becomes a snow-covered land of the same type. Mark the changed land with a counter.",
             "colours": [],
@@ -10076,7 +10076,7 @@
         },
         {
             "id": "ba982969-c132-5828-ae20-b146d3b99657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c07c87-0e44-4a5a-92b7-728350cd02de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c07c87-0e44-4a5a-92b7-728350cd02de.jpg?1",
             "name": "Arcum's Whistle",
             "text": "o3,oc\nT: Target non-wall creature must attack. At end of turn, destroy that creature if it could not attack. Use this ability only during the creature's controller's turn before the attack. The creature's controller may counter this effect by paying X, where X is equal to the creature's casting cost. Arcum's Whistle does not affect creatures brought under their controller's control this turn.",
             "colours": [],
@@ -10103,7 +10103,7 @@
         },
         {
             "id": "5f89d18d-829f-58b3-b999-36bb3f0461e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb82654-de12-4dce-8c6b-f28d68f0fbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb82654-de12-4dce-8c6b-f28d68f0fbe1.jpg?1",
             "name": "Barbed Sextant",
             "text": "o1,oc\nT: Sacrifice Barbed Sextant to add one mana of any color to your mana pool. Play this ability as an interrupt. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -10130,7 +10130,7 @@
         },
         {
             "id": "1ca7fad9-6a44-5d49-958f-84d890ab436d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc29872-b1a2-4851-9eca-f3e67ae6e14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc29872-b1a2-4851-9eca-f3e67ae6e14c.jpg?1",
             "name": "Baton of Morale",
             "text": "o2: Target creature gains banding until end of turn.",
             "colours": [],
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "8e4f7daa-f3d0-5fcc-9f06-f3c53b622ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc0e8d3-633b-4281-863f-c51c69eed0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc0e8d3-633b-4281-863f-c51c69eed0b6.jpg?1",
             "name": "Celestial Sword",
             "text": "o3,oc\nT: Target creature you control gets +3/+3 until end of turn. At end of turn, bury that creature.",
             "colours": [],
@@ -10184,7 +10184,7 @@
         },
         {
             "id": "b117b005-7430-5188-be8d-e0b09ce75954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce2991f-48e1-4cfe-af0a-18b6d9400493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce2991f-48e1-4cfe-af0a-18b6d9400493.jpg?1",
             "name": "Crown of the Ages",
             "text": "o4,oc\nT: Switch target enchantment from one creature to another; the enchantment's new target must be legal. The controller of the enchantment does not change. Treat the enchantment as though it were just cast on the new target.",
             "colours": [],
@@ -10211,7 +10211,7 @@
         },
         {
             "id": "54598ef4-511b-5448-a616-492943730780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e381a4-810e-4b75-aed3-c16cf0eb06fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e381a4-810e-4b75-aed3-c16cf0eb06fa.jpg?1",
             "name": "Despotic Scepter",
             "text": "oc\nT: Bury target permanent you own.",
             "colours": [],
@@ -10238,7 +10238,7 @@
         },
         {
             "id": "5d47742d-d305-51a8-9a17-7b3277da382c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49301c19-55a0-4146-9474-0b86cd320e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49301c19-55a0-4146-9474-0b86cd320e31.jpg?1",
             "name": "Elkin Bottle",
             "text": "o3,oc\nT: Take the top card from your library and place it face up in front of you. You may play that card as though it were in your hand; if you do not play it by your next upkeep, remove it from the game.",
             "colours": [],
@@ -10265,7 +10265,7 @@
         },
         {
             "id": "bccdfc31-1eb0-5b82-8b45-d1eed4529c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd0a41-cc51-4728-b597-fdb2510accd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd0a41-cc51-4728-b597-fdb2510accd8.jpg?1",
             "name": "Fyndhorn Bow",
             "text": "o3,oc\nT: Target creature gains first strike until end of turn.",
             "colours": [],
@@ -10292,7 +10292,7 @@
         },
         {
             "id": "6ee07778-0366-5daf-bdb5-568509250b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951114fb-5ae5-4eb0-8e03-6e39b0b634b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951114fb-5ae5-4eb0-8e03-6e39b0b634b5.jpg?1",
             "name": "Goblin Lyre",
             "text": "o0: Sacrifice Goblin Lyre. Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, Goblin Lyre deals * damage to that opponent, where * is equal to the number of creatures you control. Otherwise, Goblin Lyre deals * damage to you, where * is equal to the number of creatures the opponent controls.",
             "colours": [],
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "49613970-d3fe-5607-8416-9b2e2a2c109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83585337-56a9-44d2-9ed1-8a959bcfb010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83585337-56a9-44d2-9ed1-8a959bcfb010.jpg?1",
             "name": "Hematite Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a red spell is successfully cast and only once for each red spell cast.",
             "colours": [],
@@ -10346,7 +10346,7 @@
         },
         {
             "id": "8ccae383-15b4-5c93-9f75-af5506e61e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3e095a-7056-4df3-bf7d-9c217d591446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3e095a-7056-4df3-bf7d-9c217d591446.jpg?1",
             "name": "Ice Cauldron",
             "text": "X,oc\nT: Put a charge counter on Ice Cauldron, and put a spell card face up on Ice Cauldron. Note the type and amount of mana used to pay this activation cost. Use this ability only if there are no charge counters on Ice Cauldron. You may play that spell card as though it were in your hand.\noc\nT: Remove the charge counter from Ice Cauldron to add mana of the type and amount last used to put a charge counter on Ice Cauldron to your mana pool. This mana is usable only to cast the spell on top of Ice Cauldron.",
             "colours": [],
@@ -10373,7 +10373,7 @@
         },
         {
             "id": "ef5664d7-4d0f-5764-9c67-36aa368a1ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eda936f-7691-4440-9b83-eb0c6035b109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eda936f-7691-4440-9b83-eb0c6035b109.jpg?1",
             "name": "Icy Manipulator",
             "text": "o1,oc\nT: Tap target artifact, creature, or land.",
             "colours": [],
@@ -10400,7 +10400,7 @@
         },
         {
             "id": "0329458a-a2cf-5daf-8468-6a92baae32b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a42152-32c0-47ff-aaac-8deaf01873ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a42152-32c0-47ff-aaac-8deaf01873ca.jpg?1",
             "name": "Infinite Hourglass",
             "text": "During your upkeep, put a time counter on Infinite Hourglass. During any upkeep, any player may pay o3 to remove a time counter from Infinite Hourglass. All creatures get +1/+0 for each time counter on Infinite Hourglass.",
             "colours": [],
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "d8498c13-56b6-5e60-a74d-4a8b4ec839b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ac44d0-8090-4e7b-ac47-c567294f185e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ac44d0-8090-4e7b-ac47-c567294f185e.jpg?1",
             "name": "Jester's Cap",
             "text": "o2,oc\nT: Sacrifice Jester's Cap to look through target player's library and remove any three of those cards from the game. Reshuffle that library afterwards.",
             "colours": [],
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "509f7e05-1222-5932-9457-448808d12384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1ba0c-cb89-4bb2-8a35-6a4a4eecccf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1ba0c-cb89-4bb2-8a35-6a4a4eecccf7.jpg?1",
             "name": "Jester's Mask",
             "text": "Comes into play tapped.\no1,oc\nT: Sacrifice Jester's Mask to look through target opponent's hand and library. Give that player a new hand of as many cards as he or she had before. Reshuffle the remaining cards afterwards.",
             "colours": [],
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "4bbd7dce-304d-541e-93ff-cd36336428d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f7bad2-d28f-42d2-9246-fe3545ef49a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f7bad2-d28f-42d2-9246-fe3545ef49a7.jpg?1",
             "name": "Jeweled Amulet",
             "text": "o1,oc\nT: Put a charge counter on Jeweled Amulet. Note what type of mana was used to pay this activation cost. Use this ability only if there are no charge counters on Jeweled Amulet.\noc\nT: Remove the charge counter from Jeweled Amulet to add one mana of the type last used to put a charge counter on Jeweled Amulet to your mana pool. Play this ability as an interrupt.",
             "colours": [],
@@ -10508,7 +10508,7 @@
         },
         {
             "id": "56d086c1-aa66-5732-8a6c-a7370ae4d5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce00bb19-983e-427d-be54-ae6daf0ccdde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce00bb19-983e-427d-be54-ae6daf0ccdde.jpg?1",
             "name": "Lapis Lazuli Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a blue spell is successfully cast and only once for each blue spell cast.",
             "colours": [],
@@ -10535,7 +10535,7 @@
         },
         {
             "id": "96d99e6f-45be-5898-842a-21e658330898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb8a24-ce53-4a69-be2a-55c6dbba5ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb8a24-ce53-4a69-be2a-55c6dbba5ee7.jpg?1",
             "name": "Malachite Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a green spell is successfully cast and only once for each green spell cast.",
             "colours": [],
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "2d275d3e-5028-5ad3-b34a-2e16602bacec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06912236-8225-4eb0-8086-c6a163c69892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06912236-8225-4eb0-8086-c6a163c69892.jpg?1",
             "name": "Nacre Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a white spell is successfully cast and only once for each white spell cast.",
             "colours": [],
@@ -10589,7 +10589,7 @@
         },
         {
             "id": "760145a0-712f-5be9-8cbd-a25d34f66924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabadfb2-93cd-4c7a-b901-59c3dd1a7c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabadfb2-93cd-4c7a-b901-59c3dd1a7c3c.jpg?1",
             "name": "Naked Singularity",
             "text": "Cumulative Upkeep: o3\nInstead of their normal mana, plains produce o\nR, islands produce o\nG, swamps produce o\nW, mountains produce o\nU, and forests produce o\nB.",
             "colours": [],
@@ -10622,7 +10622,7 @@
         },
         {
             "id": "49b9a971-324d-553c-98a9-427cbcea9f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b2368-1180-4821-bcb8-8161c18e5538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b2368-1180-4821-bcb8-8161c18e5538.jpg?1",
             "name": "Onyx Talisman",
             "text": "o3: Untap target permanent.\nUse this ability only when a black spell is successfully cast and only once for each black spell cast.",
             "colours": [],
@@ -10649,7 +10649,7 @@
         },
         {
             "id": "70d98211-2f97-5370-8d13-c6e313e3309a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d889a5-f6c7-410d-97f9-acf08b9091c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d889a5-f6c7-410d-97f9-acf08b9091c8.jpg?1",
             "name": "Pentagram of the Ages",
             "text": "o4,oc\nT: Prevent all damage dealt to you from one source. Pentagram of the Ages does not prevent the same source damaging you again later this turn.",
             "colours": [],
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "bbb34d44-5c4d-573b-8a6b-a263d2b5fdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c588fe7f-945d-4459-904c-67442f88b4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c588fe7f-945d-4459-904c-67442f88b4e1.jpg?1",
             "name": "Pit Trap",
             "text": "o2,oc\nT: Sacrifice Pit Trap to bury target creature without flying that is attacking you.",
             "colours": [],
@@ -10703,7 +10703,7 @@
         },
         {
             "id": "fbb7ad7e-5457-5b20-9437-99fa47e44f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca02861b-9639-480d-8e54-e024f0c70158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca02861b-9639-480d-8e54-e024f0c70158.jpg?1",
             "name": "Runed Arch",
             "text": "Comes into play tapped.\no\nX,oc\nT: Sacrifice Runed Arch. X target creatures with power no greater than 2 cannot be blocked this turn. Other effects may later be used to increase a creature's power beyond 2.",
             "colours": [],
@@ -10730,7 +10730,7 @@
         },
         {
             "id": "74345aae-0bdd-5f29-b9d7-33de661368a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7411ab40-47f6-44d1-8e33-9ff5301dcd9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7411ab40-47f6-44d1-8e33-9ff5301dcd9b.jpg?1",
             "name": "Shield of the Ages",
             "text": "o2: Prevent 1 damage to you.",
             "colours": [],
@@ -10757,7 +10757,7 @@
         },
         {
             "id": "9f901b87-edcf-519a-aa37-dd2f4ea3d289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb92a3e6-dc30-4a08-baba-e125290cadc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb92a3e6-dc30-4a08-baba-e125290cadc5.jpg?1",
             "name": "Skull Catapult",
             "text": "o1,oc\nT: Sacrifice a creature to have Skull Catapult deal 2 damage to target creature or player.",
             "colours": [],
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "ef55e806-1ff4-50e0-9441-5bce1f5d914a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c480e07-fb26-4760-865f-47985f7447bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c480e07-fb26-4760-865f-47985f7447bb.jpg?1",
             "name": "Snow Fortress",
             "text": "Counts as a wall\no1: +1/+0 until end of turn\no1: +0/+1 until end of turn\no3: Snow Fortress deals 1 damage to target creature without flying that is attacking you.",
             "colours": [],
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "c27e8144-7edb-58e6-a219-d3472f15b116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d35e88-81d3-4a54-aa79-190615abc616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d35e88-81d3-4a54-aa79-190615abc616.jpg?1",
             "name": "Soldevi Golem",
             "text": "Does not untap during your untap phase.\no0: Untap target creature opponent controls to untap Soldevi Golem at the end of your upkeep. Use this ability only during your upkeep.",
             "colours": [],
@@ -10844,7 +10844,7 @@
         },
         {
             "id": "4727a338-9aa7-5a63-a37a-7e8fa1b2ff6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fabc7b6-e766-4e3c-816e-04cfeceaff09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fabc7b6-e766-4e3c-816e-04cfeceaff09.jpg?1",
             "name": "Soldevi Simulacrum",
             "text": "Cumulative Upkeep: o1\no1: +1/+0 until end of turn",
             "colours": [],
@@ -10874,7 +10874,7 @@
         },
         {
             "id": "15e1df4a-1858-5d0c-a71a-57f096aa2def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c709836-55b6-4de9-b190-b5f66dc53c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c709836-55b6-4de9-b190-b5f66dc53c87.jpg?1",
             "name": "Staff of the Ages",
             "text": "Creatures with any landwalk ability may be blocked as though they did not have those abilities.",
             "colours": [],
@@ -10901,7 +10901,7 @@
         },
         {
             "id": "59a98f7b-6fc2-57c5-a31a-4d96c370ae73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1c67fa-ff88-4a61-b8a5-8a872b3dc44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1c67fa-ff88-4a61-b8a5-8a872b3dc44f.jpg?1",
             "name": "Sunstone",
             "text": "o2: Sacrifice a snow-covered land to have all creatures deal no damage in combat this turn.",
             "colours": [],
@@ -10928,7 +10928,7 @@
         },
         {
             "id": "0c802afe-1f40-5416-9f3f-ff3534df8f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092ec691-4729-46d3-a4e2-0cfc5df42a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092ec691-4729-46d3-a4e2-0cfc5df42a31.jpg?1",
             "name": "Time Bomb",
             "text": "During your upkeep, put a time counter on Time Bomb.\no1,oc\nT: Sacrifice Time Bomb to have it deal * damage to each creature and player, where * is equal to the number of time counters on Time Bomb.",
             "colours": [],
@@ -10955,7 +10955,7 @@
         },
         {
             "id": "07599f31-afe4-543a-ac68-30715778febc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c9e9a7-e170-4361-b7d5-22fc0771c489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c9e9a7-e170-4361-b7d5-22fc0771c489.jpg?1",
             "name": "Urza's Bauble",
             "text": "oc\nT: Sacrifice Urza's Bauble to choose a card at random from target player's hand; look at that card. Ignore this ability if that player has no cards left in hand. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "66dae17d-a742-51b4-ba09-0b37d7c64265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ea118-6a19-4e1b-aa5a-9b2729efc096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9ea118-6a19-4e1b-aa5a-9b2729efc096.jpg?1",
             "name": "Vexing Arcanix",
             "text": "o3,oc\nT: Target player names a card and then turns over the top card of his or her library. If that is the card named, put it into the player's hand. Otherwise, put it into the player's graveyard, and Vexing Arcanix deals 2 damage to that player.",
             "colours": [],
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "aa2b9332-fbaa-569d-b7e4-c8a658956ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f93ded-ecf6-4a70-8ca3-a9c0c3201c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f93ded-ecf6-4a70-8ca3-a9c0c3201c21.jpg?1",
             "name": "Vibrating Sphere",
             "text": "During your turn, all creatures you control get +2/+0. During all other turns, all creatures you control get -0/-2.",
             "colours": [],
@@ -11036,7 +11036,7 @@
         },
         {
             "id": "df2959a6-183d-54b3-831f-787c64abb4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba1238c-1969-452d-8112-124cbbd49417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba1238c-1969-452d-8112-124cbbd49417.jpg?1",
             "name": "Walking Wall",
             "text": "Counts as a wall\no3: Walking Wall gets +3/-1 until end of turn and can attack this turn. Walking Wall cannot attack the turn it comes under your control. Use this ability only once a turn.",
             "colours": [],
@@ -11066,7 +11066,7 @@
         },
         {
             "id": "9ddffd7f-7024-5d35-81f8-35cce55a00f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376c7c4-aaca-4625-83d4-a49f01aec535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6376c7c4-aaca-4625-83d4-a49f01aec535.jpg?1",
             "name": "Wall of Shields",
             "text": "Banding, counts as a wall",
             "colours": [],
@@ -11096,7 +11096,7 @@
         },
         {
             "id": "d33c67f3-55a0-5270-916e-692aebf3885f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ea0c6c-aa76-4b16-bc99-2ff46dc56d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ea0c6c-aa76-4b16-bc99-2ff46dc56d4e.jpg?1",
             "name": "War Chariot",
             "text": "o3,oc\nT: Target creature gains trample until end of turn.",
             "colours": [],
@@ -11123,7 +11123,7 @@
         },
         {
             "id": "df236003-fe5f-5aa1-91a6-e146c918b832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b75adf0-9501-4776-a213-456c2b821070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b75adf0-9501-4776-a213-456c2b821070.jpg?1",
             "name": "Whalebone Glider",
             "text": "o2,oc\nT: Target creature with power no greater than 3 gains flying until end of turn. Other effects may later be used to increase that creature's power beyond 3.",
             "colours": [],
@@ -11150,7 +11150,7 @@
         },
         {
             "id": "3f7e3f20-4dd5-58a9-a251-d38e9589062c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg?1",
             "name": "Zuran Orb",
             "text": "o0: Sacrifice a land to gain 2 life.",
             "colours": [],
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "95b07c7f-fb51-555f-835b-e04e3a53fcc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd9023-f7ee-4e99-8821-7059deb83730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09dd9023-f7ee-4e99-8821-7059deb83730.jpg?1",
             "name": "Adarkar Wastes",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nW to your mana pool. Adarkar Wastes deals 1 damage to you.\noc\nT: Add o\nU to your mana pool. Adarkar Wastes deals 1 damage to you.",
             "colours": [],
@@ -11207,7 +11207,7 @@
         },
         {
             "id": "78e56ab8-b0e8-5c84-9c4b-8177228fff7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e5ccd-54bf-4c6d-86b4-0359ca8f36e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170e5ccd-54bf-4c6d-86b4-0359ca8f36e8.jpg?1",
             "name": "Brushland",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nW to your mana pool. Brushland deals 1 damage to you.\noc\nT: Add o\nG to your mana pool. Brushland deals 1 damage to you.",
             "colours": [],
@@ -11237,7 +11237,7 @@
         },
         {
             "id": "cf0b9ecf-2f58-54e1-92d4-d212ef73a08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d23f800-7a6f-40e3-b242-9f5955e47a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d23f800-7a6f-40e3-b242-9f5955e47a75.jpg?1",
             "name": "Glacial Chasm",
             "text": "Cumulative Upkeep: 2 life\nWhen Glacial Chasm comes into play, sacrifice a land. You cannot attack. All damage dealt to you is reduced to 0.",
             "colours": [],
@@ -11264,7 +11264,7 @@
         },
         {
             "id": "b3ba2b45-4416-5f3a-9d32-384224890ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b926a189-90b6-47bb-b5d6-b033e57007b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b926a189-90b6-47bb-b5d6-b033e57007b4.jpg?1",
             "name": "Halls of Mist",
             "text": "Cumulative Upkeep: o1\nNo creature can attack if it attacked during its controller's last turn.",
             "colours": [],
@@ -11291,7 +11291,7 @@
         },
         {
             "id": "9058c0de-6a91-5d38-b085-afd5cb1c2735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce04fb-e687-41e0-ae9a-16a51df5d943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ce04fb-e687-41e0-ae9a-16a51df5d943.jpg?1",
             "name": "Ice Floe",
             "text": "You may choose not to untap Ice Floe during your untap phase.\noc\nT: Tap target creature without flying that is attacking you. As long as Ice Floe remains tapped, that creature does not untap during its controller's untap phase.",
             "colours": [],
@@ -11318,7 +11318,7 @@
         },
         {
             "id": "b7dfa867-04fd-5693-a534-1259fe97da09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f1263-d598-49fb-b5f8-09f11822ebd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f1263-d598-49fb-b5f8-09f11822ebd0.jpg?1",
             "name": "Karplusan Forest",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nR to your mana pool. Karplusan Forest deals 1 damage to you.\noc\nT: Add o\nG to your mana pool. Karplusan Forest deals 1 damage to you.",
             "colours": [],
@@ -11348,7 +11348,7 @@
         },
         {
             "id": "e31e6ec6-f9ee-52e2-8ea7-bd50cef363fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4806c02-7a4d-42e3-affd-0338084bd3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4806c02-7a4d-42e3-affd-0338084bd3ab.jpg?1",
             "name": "Land Cap",
             "text": "If there are any depletion counters on Land Cap, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Land Cap.\noc\nT: Add o\nW to your mana pool. Put a depletion counter on Land Cap.\noc\nT: Add o\nU to your mana pool. Put a depletion counter on Land Cap.",
             "colours": [],
@@ -11378,7 +11378,7 @@
         },
         {
             "id": "3125c9e2-9d66-507a-bb8c-2921def54074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7c2cf6-f36f-451b-bba5-19a82c659c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7c2cf6-f36f-451b-bba5-19a82c659c4c.jpg?1",
             "name": "Lava Tubes",
             "text": "If there are any depletion counters on Lava Tubes, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Lava Tubes.\noc\nT: Add o\nB to your mana pool. Put a depletion counter on Lava Tubes.\noc\nT: Add o\nR to your mana pool. Put a depletion counter on Lava Tubes.",
             "colours": [],
@@ -11408,7 +11408,7 @@
         },
         {
             "id": "8e173647-85f6-5c73-a33a-3ad835f881f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea335fc0-0591-4acd-9ae8-7858222770da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea335fc0-0591-4acd-9ae8-7858222770da.jpg?1",
             "name": "River Delta",
             "text": "If there are any depletion counters on River Delta, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from River Delta.\noc\nT: Add o\nU to your mana pool. Put a depletion counter on River Delta.\noc\nT: Add o\nB to your mana pool. Put a depletion counter on River Delta.",
             "colours": [],
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "fc50a57b-07d0-57c8-a4ed-b2bf2180feb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdeab50-b45f-412b-85a3-c6cf009ce567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdeab50-b45f-412b-85a3-c6cf009ce567.jpg?1",
             "name": "Sulfurous Springs",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nB to your mana pool. Sulfurous Springs deals 1 damage to you.\noc\nT: Add o\nR to your mana pool. Sulfurous Springs deals 1 damage to you.",
             "colours": [],
@@ -11468,7 +11468,7 @@
         },
         {
             "id": "68961a04-fa12-53a7-ae79-d8547e0455b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2fc9-0a24-4ac1-afcc-9317b90c7178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2fc9-0a24-4ac1-afcc-9317b90c7178.jpg?1",
             "name": "Timberline Ridge",
             "text": "If there are any depletion counters on Timberline Ridge, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Timberline Ridge.\noc\nT: Add o\nR to your mana pool. Put a depletion counter on Timberline Ridge.\noc\nT: Add o\nG to your mana pool. Put a depletion counter on Timberline Ridge.",
             "colours": [],
@@ -11498,7 +11498,7 @@
         },
         {
             "id": "b2afa72f-d1f4-5743-bb3e-99f3ffda5ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92369d7e-5e5a-46f9-bb31-c57d62410283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92369d7e-5e5a-46f9-bb31-c57d62410283.jpg?1",
             "name": "Underground River",
             "text": "oc\nT: Add o1 to your mana pool.\noc\nT: Add o\nU to your mana pool. Underground River deals 1 damage to you.\noc\nT: Add o\nB to your mana pool. Underground River deals 1 damage to you.",
             "colours": [],
@@ -11528,7 +11528,7 @@
         },
         {
             "id": "3909534e-20b9-5337-ac8f-6881691bbdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987534fb-74a9-46a3-805f-fe2fe2df4a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987534fb-74a9-46a3-805f-fe2fe2df4a90.jpg?1",
             "name": "Veldt",
             "text": "If there are any depletion counters on Veldt, it does not untap during your untap phase. At the beginning of your upkeep, remove a depletion counter from Veldt.\noc\nT: Add o\nW to your mana pool. Put a depletion counter on Veldt.\noc\nT: Add o\nG to your mana pool. Put a depletion counter on Veldt.",
             "colours": [],
@@ -11558,7 +11558,7 @@
         },
         {
             "id": "314b47fb-c976-55e8-a1ab-3560f91cb230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b68bdb0-41cc-48f6-905e-7da1ff4ba5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b68bdb0-41cc-48f6-905e-7da1ff4ba5e0.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11594,7 +11594,7 @@
         },
         {
             "id": "28ee6407-45c4-5572-9d0e-27c921b3a5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3e94f7-9f97-4652-a1f1-381feb15f688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3e94f7-9f97-4652-a1f1-381feb15f688.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11630,7 +11630,7 @@
         },
         {
             "id": "9a9f3101-eb5f-526d-89a6-bed45e684830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ac1fc7-0698-4a94-8353-cc4c13bd6ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ac1fc7-0698-4a94-8353-cc4c13bd6ffa.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11666,7 +11666,7 @@
         },
         {
             "id": "9263e828-8c92-5fb1-b515-cadac67a58f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3ac778-fb45-4fd3-a9af-8a0791f833e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3ac778-fb45-4fd3-a9af-8a0791f833e8.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -11700,7 +11700,7 @@
         },
         {
             "id": "9bf5a479-a60a-5534-885c-3080d282683f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2d6fc9-ddad-4dd2-b218-afa1a5449b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2d6fc9-ddad-4dd2-b218-afa1a5449b7e.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11736,7 +11736,7 @@
         },
         {
             "id": "6a1301db-b2f4-500e-ad97-bdb57349599b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a467ab-4460-4e5e-94c1-8150bfe0c954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a467ab-4460-4e5e-94c1-8150bfe0c954.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11772,7 +11772,7 @@
         },
         {
             "id": "690d9344-68b1-5629-957e-499f8c7b4a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f11c42-9d67-4833-9519-e165e6a7e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f11c42-9d67-4833-9519-e165e6a7e9c4.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11808,7 +11808,7 @@
         },
         {
             "id": "cab1b8bb-d941-5eb4-86b3-eabfc6f6a9e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1",
             "name": "Snow-Covered Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -11842,7 +11842,7 @@
         },
         {
             "id": "0748a698-c3ab-5db0-bf2c-077a16ac0457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a3c27f-6b15-49b6-ac89-36cfb79b3b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a3c27f-6b15-49b6-ac89-36cfb79b3b54.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "98e0ddf7-54e9-51c9-b80d-f7ed8a0c13a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4695653a-5c4c-4ff3-b80c-f4b6c685f370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4695653a-5c4c-4ff3-b80c-f4b6c685f370.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11912,7 +11912,7 @@
         },
         {
             "id": "0717c6ba-ae0f-5d7f-831c-b65a01f9aba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90b49f-53b3-4ce0-92c1-bcd76d6981ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90b49f-53b3-4ce0-92c1-bcd76d6981ea.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "0d5747b2-250f-53d3-b107-cbdd8bf42640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddca7e2e-bb0a-47ed-ade3-31900da992dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddca7e2e-bb0a-47ed-ade3-31900da992dc.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11984,7 +11984,7 @@
         },
         {
             "id": "54cbdc4d-0171-55ab-8efc-cfbe26b720f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf39c3-3b5f-4263-a7b5-9881bded3494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecf39c3-3b5f-4263-a7b5-9881bded3494.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12020,7 +12020,7 @@
         },
         {
             "id": "1596fbf7-9101-5fef-b063-1b4c0f18c0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb15b42-be2a-4663-b064-aad6c7cb2714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb15b42-be2a-4663-b064-aad6c7cb2714.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12056,7 +12056,7 @@
         },
         {
             "id": "40105434-e292-5e94-987c-026a576daeee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ac61e4-b543-4c37-9bfa-43f0c928152d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ac61e4-b543-4c37-9bfa-43f0c928152d.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12092,7 +12092,7 @@
         },
         {
             "id": "9f5e5e8f-07f4-5121-b405-0736d90d1c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3afb3-5574-4f2d-adbe-969a428f1c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3afb3-5574-4f2d-adbe-969a428f1c63.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -12126,7 +12126,7 @@
         },
         {
             "id": "e01ef1d8-d531-5749-900e-e536f5c369b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdcbd97-90a9-45ea-94f6-2a1c6faaf965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdcbd97-90a9-45ea-94f6-2a1c6faaf965.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -12162,7 +12162,7 @@
         },
         {
             "id": "e2d5b6af-3744-598e-819c-a0a792f04e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b346b784-7bde-49d0-bfa9-56236cbe19d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b346b784-7bde-49d0-bfa9-56236cbe19d9.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -12198,7 +12198,7 @@
         },
         {
             "id": "be7aaccd-487b-50c5-aa95-36581728726d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c4d8f-5700-4f0a-9ff2-58422aeb1dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c4d8f-5700-4f0a-9ff2-58422aeb1dac.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -12234,7 +12234,7 @@
         },
         {
             "id": "fd5c9890-c319-52ca-bb80-8f1ba3ec83ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0ad95c-d62c-4138-ada0-fa39a63a449e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0ad95c-d62c-4138-ada0-fa39a63a449e.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/IKO.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/IKO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d1bedeac-8dfb-5014-930a-7c2d5796f890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a2e243-e446-46c6-8a37-e26620951c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a2e243-e446-46c6-8a37-e26620951c41.jpg?1",
             "name": "Adaptive Shimmerer",
             "text": "Flash\nAdaptive Shimmerer enters the battlefield with three +1/+1 counters on it.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "053bc238-3d0a-53d0-ada0-c6284fb70351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f63f40-46f1-4b9e-b447-ff9274f2b926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f63f40-46f1-4b9e-b447-ff9274f2b926.jpg?1",
             "name": "Farfinder",
             "text": "Vigilance\nWhen Farfinder enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "d71d5711-8598-5e61-96a9-72e0c53a9b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfac3c3-7f38-49d6-bd88-dc0f5001116f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfac3c3-7f38-49d6-bd88-dc0f5001116f.jpg?1",
             "name": "Mysterious Egg",
             "text": "Whenever this creature mutates, put a +1/+1 counter on it.",
             "colours": [],
@@ -96,7 +96,7 @@
         },
         {
             "id": "89c3ce43-d694-5402-96cd-338e174a926b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a30091-7f68-4a67-b47e-f44318fc93b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a30091-7f68-4a67-b47e-f44318fc93b2.jpg?1",
             "name": "Blade Banish",
             "text": "Exile target creature with power 4 or greater.",
             "colours": [
@@ -128,7 +128,7 @@
         },
         {
             "id": "e9b7b5ee-97c7-5355-85c7-f844e931053b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e12f5-7b15-4a8c-b045-35bcbf1fbb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e12f5-7b15-4a8c-b045-35bcbf1fbb90.jpg?1",
             "name": "Checkpoint Officer",
             "text": "{1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -163,7 +163,7 @@
         },
         {
             "id": "a50cb538-9233-5289-a807-315a59315aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129c404b-2c1e-4f0b-bb4e-7e8e627a69a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129c404b-2c1e-4f0b-bb4e-7e8e627a69a8.jpg?1",
             "name": "Coordinated Charge",
             "text": "Creatures you control get +2/+1 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "b178049d-5bb8-581e-8b69-dedc93bdcffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc322744-5d8f-448d-b868-381bb86b68f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc322744-5d8f-448d-b868-381bb86b68f9.jpg?1",
             "name": "Cubwarden",
             "text": "Mutate {2}{W}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nLifelink\nWhenever this creature mutates, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "a4355de7-039a-50e4-b203-5293ef7a206d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d566bd-f272-49d1-bffb-588f2a42046a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d566bd-f272-49d1-bffb-588f2a42046a.jpg?1",
             "name": "Daysquad Marshal",
             "text": "When Daysquad Marshal enters the battlefield, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -266,7 +266,7 @@
         },
         {
             "id": "d1af5b4e-78d3-576d-af87-ab17648ea361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b29acc2-5749-4e8a-924d-3c82406e6393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b29acc2-5749-4e8a-924d-3c82406e6393.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -298,7 +298,7 @@
         },
         {
             "id": "7c5b82ab-81c5-5fd7-996d-dc97774f22c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a821c-eaec-4f69-97c7-8299cdebc2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5a821c-eaec-4f69-97c7-8299cdebc2f4.jpg?1",
             "name": "Drannith Healer",
             "text": "Whenever you cycle another card, you gain 1 life.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -333,7 +333,7 @@
         },
         {
             "id": "051a8365-78af-5f9d-b82b-65678cf22476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b0a4a8-9319-451b-9b79-b0bca7a41e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b0a4a8-9319-451b-9b79-b0bca7a41e91.jpg?1",
             "name": "Drannith Magistrate",
             "text": "Your opponents can't cast spells from anywhere other than their hands.",
             "colours": [
@@ -370,7 +370,7 @@
         },
         {
             "id": "75311d84-76ee-5b04-b382-156ff443bcdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62ea13-9bd5-46ce-a861-68cf9a2c6f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62ea13-9bd5-46ce-a861-68cf9a2c6f8c.jpg?1",
             "name": "Fight as One",
             "text": "Choose one or both \u2014\n\u2022 Target Human creature you control gets +1/+1 and gains indestructible until end of turn.\n\u2022 Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn.",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "8e2f9c84-fd93-503e-87f4-f842bad9569c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b81339-746d-4f71-9943-01c0f6a5683a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b81339-746d-4f71-9943-01c0f6a5683a.jpg?1",
             "name": "Flourishing Fox",
             "text": "Whenever you cycle another card, put a +1/+1 counter on Flourishing Fox.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "d20069ec-c5ac-53ba-8160-1053e2acb6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ff8345-227c-43b4-bed5-af3a34c0a990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ff8345-227c-43b4-bed5-af3a34c0a990.jpg?1",
             "name": "Garrison Cat",
             "text": "When Garrison Cat dies, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -472,7 +472,7 @@
         },
         {
             "id": "c1f207e0-471f-51e2-a6c3-30751349f997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc88fe0-2424-49a7-9abf-4773a547d010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc88fe0-2424-49a7-9abf-4773a547d010.jpg?1",
             "name": "Helica Glider",
             "text": "Helica Glider enters the battlefield with your choice of a flying counter or a first strike counter on it.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "585f1a62-cd0b-5d30-8fd5-3e74f95ea1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058d6a7d-12b0-4d82-a5bd-91fa44bbc5e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/058d6a7d-12b0-4d82-a5bd-91fa44bbc5e1.jpg?1",
             "name": "Huntmaster Liger",
             "text": "Mutate {2}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, other creatures you control get +X/+X until end of turn, where X is the number of times this creature has mutated.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "1a50c117-99fb-5b3e-b97f-d83bb950321f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fa5feb-f5e9-4079-acc9-84e458044769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fa5feb-f5e9-4079-acc9-84e458044769.jpg?1",
             "name": "Imposing Vantasaur",
             "text": "Vigilance\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "b4e13fda-df34-538d-93ff-cd5593d00bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0583065-9a6c-4ea4-b6dd-2edfbaed1181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0583065-9a6c-4ea4-b6dd-2edfbaed1181.jpg?1",
             "name": "Keensight Mentor",
             "text": "When Keensight Mentor enters the battlefield, put a vigilance counter on target non-Human creature you control.\n{1}{W}, {T}: Put a +1/+1 counter on each creature you control with vigilance.",
             "colours": [
@@ -613,7 +613,7 @@
         },
         {
             "id": "565ef74e-8efa-5ed6-a3ff-259b407467dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0d9d6-c9c7-4169-8106-400445643a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0d9d6-c9c7-4169-8106-400445643a1a.jpg?1",
             "name": "Lavabrink Venturer",
             "text": "As Lavabrink Venturer enters the battlefield, choose odd or even. (Zero is even.)\nLavabrink Venturer has protection from each converted mana cost of the chosen value.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "edeca4ca-2378-5505-9727-26d683c36a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb00599-e082-49b0-88f3-ef91b75595e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb00599-e082-49b0-88f3-ef91b75595e4.jpg?1",
             "name": "Light of Hope",
             "text": "Choose one \u2014\n\u2022 You gain 4 life.\n\u2022 Destroy target enchantment.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "39ebc226-262a-58fa-a44a-8db82796b6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb65df55-d6a6-4a57-a903-e5eb17637982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb65df55-d6a6-4a57-a903-e5eb17637982.jpg?1",
             "name": "Luminous Broodmoth",
             "text": "Flying\nWhenever a creature you control without flying dies, return it to the battlefield under its owner's control with a flying counter on it.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "5b2871e7-63f0-53fa-afeb-db3dea3b28bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df320c9-449a-457e-8688-f611aceb3352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df320c9-449a-457e-8688-f611aceb3352.jpg?1",
             "name": "Majestic Auricorn",
             "text": "Mutate {3}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nVigilance\nWhenever this creature mutates, you gain 4 life.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "9963ab3e-e478-5404-8449-001999905568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac51e35-e2c5-4457-981c-e59894584288.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac51e35-e2c5-4457-981c-e59894584288.jpg?1",
             "name": "Maned Serval",
             "text": "Vigilance",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "a2e2a441-848e-5718-b827-6e81a717e409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2712a1a3-dd28-44c8-a661-5bcf68d3acaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2712a1a3-dd28-44c8-a661-5bcf68d3acaa.jpg?1",
             "name": "Mythos of Snapdax",
             "text": "Each player chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest. If {B}{R} was spent to cast this spell, you choose the permanents for each player instead.",
             "colours": [
@@ -825,7 +825,7 @@
         },
         {
             "id": "da8641e7-9004-59b3-b525-51ee2e35613a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47adc9fc-d620-4cb7-a03c-8d9578992249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47adc9fc-d620-4cb7-a03c-8d9578992249.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "3902ae75-aae1-5c86-a0e8-98c12586d3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be398100-89e2-432b-8017-74fb7e4dbc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be398100-89e2-432b-8017-74fb7e4dbc26.jpg?1",
             "name": "Patagia Tiger",
             "text": "Flying\nWhen Patagia Tiger enters the battlefield, target Human you control gets +2/+2 until end of turn.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "03a3705f-c9e3-50bc-92a5-e2fda593f87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a174587-d964-48b3-8f69-fa576c1b8bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a174587-d964-48b3-8f69-fa576c1b8bba.jpg?1",
             "name": "Perimeter Sergeant",
             "text": "Whenever Perimeter Sergeant attacks, other Humans you control get +1/+0 until end of turn.",
             "colours": [
@@ -928,7 +928,7 @@
         },
         {
             "id": "059af630-c21d-5684-afc3-8ee50b501862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1387b7be-f69e-4919-9070-a89654c656f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1387b7be-f69e-4919-9070-a89654c656f3.jpg?1",
             "name": "Sanctuary Lockdown",
             "text": "Humans you control get +1/+1.\n{2}, Tap two untapped Humans you control: Tap target creature an opponent controls.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "729f2470-8092-571b-8a75-7f5aa0400c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46702b0-7e10-462a-9aac-7564efe91804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46702b0-7e10-462a-9aac-7564efe91804.jpg?1",
             "name": "Savai Sabertooth",
             "text": "",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "cc9c2e9c-a554-5b5f-965c-9457e0044877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f640e0c-298d-4a5f-94d0-d839cf06ca86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f640e0c-298d-4a5f-94d0-d839cf06ca86.jpg?1",
             "name": "Snare Tactician",
             "text": "Whenever you cycle a card, tap target creature an opponent controls.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "2268d512-fedc-5d06-a15c-3acb312fbe5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900a8d1-a1b1-48c9-8af1-726a623c7d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0900a8d1-a1b1-48c9-8af1-726a623c7d74.jpg?1",
             "name": "Solid Footing",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nAs long as enchanted creature has vigilance, it assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "ceebc01d-402c-58e3-8cf3-f5f438d41d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535ccc75-b24e-4071-b6a0-fc5267a454e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535ccc75-b24e-4071-b6a0-fc5267a454e3.jpg?1",
             "name": "Splendor Mare",
             "text": "Lifelink\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Splendor Mare, put a lifelink counter on target creature you control.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "4236010e-f9e6-5c48-b5b8-13db4b0b56de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc24dd4-d259-4687-8247-f56aa7abb5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc24dd4-d259-4687-8247-f56aa7abb5b9.jpg?1",
             "name": "Spontaneous Flight",
             "text": "Target creature gets +2/+2 until end of turn. Put a flying counter on it.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "4353d0d5-d5a8-541e-a3d3-5d36d5404397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afded81-2fc1-4285-bf48-d25f72e72138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afded81-2fc1-4285-bf48-d25f72e72138.jpg?1",
             "name": "Stormwild Capridor",
             "text": "Flying\nIf noncombat damage would be dealt to Stormwild Capridor, prevent that damage. Put a +1/+1 counter on Stormwild Capridor for each 1 damage prevented this way.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "d2cd94e6-6b94-5ab9-b4d2-e1fb9d6fb9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b9140b-848f-4886-8c28-eccd3829a607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b9140b-848f-4886-8c28-eccd3829a607.jpg?1",
             "name": "Swallow Whole",
             "text": "As an additional cost to cast this spell, tap an untapped creature you control.\nExile target tapped creature. Put a +1/+1 counter on the creature tapped to pay this spell's additional cost.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "843093dc-01ce-5cf5-8ceb-a349f5a064c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b13ff6-67e9-4760-aef4-a8548ea44344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b13ff6-67e9-4760-aef4-a8548ea44344.jpg?1",
             "name": "Valiant Rescuer",
             "text": "Whenever you cycle another card for the first time each turn, create a 1/1 white Human Soldier creature token.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "09188393-b9c6-5eee-937d-c163dec589a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bce816-3d18-4ca1-b88f-7307ec7c345d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bce816-3d18-4ca1-b88f-7307ec7c345d.jpg?1",
             "name": "Vulpikeet",
             "text": "Mutate {2}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying\nWhenever this creature mutates, put a +1/+1 counter on it.",
             "colours": [
@@ -1269,7 +1269,7 @@
         },
         {
             "id": "1b1bcc70-a0c0-5b64-8ff1-3fd8cb49be27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7acbfa-ce3b-424d-886d-6865bc5fc085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7acbfa-ce3b-424d-886d-6865bc5fc085.jpg?1",
             "name": "Will of the All-Hunter",
             "text": "Target creature gets +2/+2 until end of turn. If it's blocking, instead put two +1/+1 counters on it.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1301,7 +1301,7 @@
         },
         {
             "id": "0c77895d-7bc7-56cd-a53b-a64be05966b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e433e7f0-7417-4dfe-a7a4-3f222b0a835f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e433e7f0-7417-4dfe-a7a4-3f222b0a835f.jpg?1",
             "name": "Aegis Turtle",
             "text": "",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "511819bc-6693-5487-95ab-0215ab09524a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b6dfb2-ffe4-44fb-bfd9-df11bc3193df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b6dfb2-ffe4-44fb-bfd9-df11bc3193df.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "65d4b44a-86e8-54be-8880-73b29c653834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b1030-64d5-4c94-a04c-1d9520bfddab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b1030-64d5-4c94-a04c-1d9520bfddab.jpg?1",
             "name": "Archipelagore",
             "text": "Mutate {5}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, tap up to X target creatures, where X is the number of times this creature has mutated. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "7aeac403-5fb4-5ca2-ae87-117d8ae18ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f325873b-97de-4701-910f-ec5cdb66de33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f325873b-97de-4701-910f-ec5cdb66de33.jpg?1",
             "name": "Avian Oddity",
             "text": "Flying\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\nWhen you cycle Avian Oddity, put a flying counter on target creature you control.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "7443819c-67d8-56b6-94a5-122a88e53752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e790851-f0f7-4f1a-80e6-94be649499b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e790851-f0f7-4f1a-80e6-94be649499b6.jpg?1",
             "name": "Boon of the Wish-Giver",
             "text": "Draw four cards.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "45d9f2a4-1ce0-5595-ac37-c4bdebbdffbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1d2d9d-6eee-4334-bbbe-87e026fa6fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1d2d9d-6eee-4334-bbbe-87e026fa6fc0.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "fdbb8ef6-bc84-5772-9c61-420a8f1d8b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd8e607-8179-4ae8-ba7f-f5f22649dc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd8e607-8179-4ae8-ba7f-f5f22649dc18.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "db3c347b-506c-5074-bb93-27ffa3f9f550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32afec8a-dbae-446e-919a-3efb556f5cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32afec8a-dbae-446e-919a-3efb556f5cb1.jpg?1",
             "name": "Crystacean",
             "text": "Flash",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "a607f3cf-3a34-556d-8530-469c1429f39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca777d40-736a-4cd6-85c4-5afd52f2fadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca777d40-736a-4cd6-85c4-5afd52f2fadd.jpg?1",
             "name": "Dreamtail Heron",
             "text": "Mutate {3}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying\nWhenever this creature mutates, draw a card.",
             "colours": [
@@ -1606,7 +1606,7 @@
         },
         {
             "id": "8540ff2d-cb92-5dd7-8c70-db705397019c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3eeddd-c86d-4f35-ba57-3caa9565fcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3eeddd-c86d-4f35-ba57-3caa9565fcb0.jpg?1",
             "name": "Escape Protocol",
             "text": "Whenever you cycle a card, you may pay {1}. When you do, exile target artifact or creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1638,7 +1638,7 @@
         },
         {
             "id": "be6c70b1-01c6-5b10-8c63-3da184a3e53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f79c8a0-291e-4e13-b765-4cf8c726cf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f79c8a0-291e-4e13-b765-4cf8c726cf30.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1670,7 +1670,7 @@
         },
         {
             "id": "39d53ee7-48bd-5bc7-bcd3-42b083f47e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1199596-ae77-4192-ae70-3e2ebd009b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1199596-ae77-4192-ae70-3e2ebd009b64.jpg?1",
             "name": "Facet Reader",
             "text": "{1}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "51ecace6-3298-5015-899e-59d77243b64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcaeccc-fc8c-4a9e-80d5-b48da71d7ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcaeccc-fc8c-4a9e-80d5-b48da71d7ff1.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1740,7 +1740,7 @@
         },
         {
             "id": "0adc8631-644f-58b7-acaf-8648e1a1305d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deef1197-e40a-4c9d-919a-213f1bdf3e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deef1197-e40a-4c9d-919a-213f1bdf3e3e.jpg?1",
             "name": "Frostveil Ambush",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -1772,7 +1772,7 @@
         },
         {
             "id": "9886384a-d2a0-5f5f-b7f1-418e3854a1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f71f8a-546a-465e-a254-09a3ae873ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f71f8a-546a-465e-a254-09a3ae873ef4.jpg?1",
             "name": "Glimmerbell",
             "text": "Flying\n{1}{U}: Untap Glimmerbell.",
             "colours": [
@@ -1807,7 +1807,7 @@
         },
         {
             "id": "3d5b01a2-d862-5430-bc1d-a54a1aa72716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabea92-d8cf-4591-b528-3e597d56b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabea92-d8cf-4591-b528-3e597d56b31f.jpg?1",
             "name": "Gust of Wind",
             "text": "This spell costs {2} less to cast if you control a creature with flying.\nReturn target nonland permanent you don't control to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "27b242b7-a855-5e93-a6ba-3e76ec699027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7b331a-bd21-429b-a49f-88da9a31c98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7b331a-bd21-429b-a49f-88da9a31c98e.jpg?1",
             "name": "Hampering Snare",
             "text": "Creatures your opponents control get -2/-0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "c843e078-3cc1-564d-b99b-5cc2fb02502a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfa682-76ae-4979-a40c-c1eae1121f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febfa682-76ae-4979-a40c-c1eae1121f3c.jpg?1",
             "name": "Keep Safe",
             "text": "Counter target spell that targets a permanent you control.\nDraw a card.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "f4e7def7-6be0-5cad-8794-86744b48acbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c2111-b7d7-40bc-aa30-57d72338b32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c2111-b7d7-40bc-aa30-57d72338b32d.jpg?1",
             "name": "Mystic Subdual",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-0 and loses all abilities. (Mutating onto the creature won't give it new abilities. It can gain abilities in other ways.)",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "42983ebf-1f1e-5b1d-928e-b2ad932b6683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b07082-c5a5-4283-a2f5-5b1e0120d752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b07082-c5a5-4283-a2f5-5b1e0120d752.jpg?1",
             "name": "Mythos of Illuna",
             "text": "Create a token that's a copy of target permanent. If {R}{G} was spent to cast this spell, instead create a token that's a copy of that permanent, except the token has \"When this permanent enters the battlefield, if it's a creature, it fights up to one target creature you don't control.\"",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "4cc87779-ba91-5824-a5c6-6d7b1fbce572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430da3c-9460-4b62-ae28-2e7e6f4d06a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430da3c-9460-4b62-ae28-2e7e6f4d06a4.jpg?1",
             "name": "Neutralize",
             "text": "Counter target spell.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "409ad1e6-dc39-5429-b486-8d61f836c036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95fb136-f21d-4f3a-82b7-bcf490b7e90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95fb136-f21d-4f3a-82b7-bcf490b7e90c.jpg?1",
             "name": "Of One Mind",
             "text": "This spell costs {2} less to cast if you control a Human creature and a non-Human creature.\nDraw two cards.",
             "colours": [
@@ -2037,7 +2037,7 @@
         },
         {
             "id": "7d31e624-2cd0-5b37-a432-b4cc4cbc06f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8965f2-756a-4461-a643-db024a11c2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8965f2-756a-4461-a643-db024a11c2de.jpg?1",
             "name": "Ominous Seas",
             "text": "Whenever you draw a card, put a foreshadow counter on Ominous Seas.\nRemove eight foreshadow counters from Ominous Seas: Create an 8/8 blue Kraken creature token.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "0a74790b-dca1-5608-8204-6ade2516551b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4042-e9c1-4b0f-b1f6-4180b0d79663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88fb4042-e9c1-4b0f-b1f6-4180b0d79663.jpg?1",
             "name": "Phase Dolphin",
             "text": "Whenever Phase Dolphin attacks, another target attacking creature can't be blocked this turn.",
             "colours": [
@@ -2104,7 +2104,7 @@
         },
         {
             "id": "233db185-ba73-50fa-a8b6-b36976a0a770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77adf375-e7d7-4ebd-8c86-ad7e822a5483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77adf375-e7d7-4ebd-8c86-ad7e822a5483.jpg?1",
             "name": "Pollywog Symbiote",
             "text": "Each creature spell you cast costs {1} less to cast if it has mutate.\nWhenever you cast a creature spell, if it has mutate, draw a card, then discard a card.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "3ba6b275-197e-5c04-99d1-1e04f984f360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859b339-b55b-41fe-948c-27502e3b3ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c859b339-b55b-41fe-948c-27502e3b3ea8.jpg?1",
             "name": "Pouncing Shoreshark",
             "text": "Mutate {3}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlash\nWhenever this creature mutates, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "3181822e-5828-5fb5-af83-ebf01f99eec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f7efa-d125-4f83-825e-172ea099a62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f7efa-d125-4f83-825e-172ea099a62a.jpg?1",
             "name": "Reconnaissance Mission",
             "text": "Whenever a creature you control deals combat damage to a player, you may draw a card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "ffed3087-c310-5a19-a05c-f87c9e8a0d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f59d9e-6c1b-437a-934c-7c776c8dd1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f59d9e-6c1b-437a-934c-7c776c8dd1d5.jpg?1",
             "name": "Sea-Dasher Octopus",
             "text": "Mutate {1}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlash\nWhenever this creature deals combat damage to a player, draw a card.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "9bae2632-4472-5fa3-bad8-08cc4d34e878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da4d4f3-b3cb-4b61-81b8-06ae441c41bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da4d4f3-b3cb-4b61-81b8-06ae441c41bf.jpg?1",
             "name": "Shark Typhoon",
             "text": "Whenever you cast a noncreature spell, create an X/X blue Shark creature token with flying, where X is that spell's converted mana cost.\nCycling {X}{1}{U} ({X}{1}{U}, Discard this card: Draw a card.)\nWhen you cycle Shark Typhoon, create an X/X blue Shark creature token with flying.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "3941e293-975c-563c-bb45-0db114ae306e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12680db-957f-48c1-9062-2edd9115ba26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12680db-957f-48c1-9062-2edd9115ba26.jpg?1",
             "name": "Startling Development",
             "text": "Until end of turn, target creature becomes a blue Serpent with base power and toughness 4/4.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "34046de0-b79a-5f3a-a29a-c809405c551b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f84b0a-37d9-4b0f-8d75-1fab45a12d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f84b0a-37d9-4b0f-8d75-1fab45a12d44.jpg?1",
             "name": "Thieving Otter",
             "text": "Whenever Thieving Otter deals damage to an opponent, draw a card.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "62dbc03d-30e1-5159-9a95-e34a93ffbb52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg?1",
             "name": "Voracious Greatshark",
             "text": "Flash\nWhen Voracious Greatshark enters the battlefield, counter target artifact or creature spell.",
             "colours": [
@@ -2381,7 +2381,7 @@
         },
         {
             "id": "a0205859-d1ae-5e1e-bfe2-4259704a67f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e21a5f-fae7-4488-9463-f0af6e4c5233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e21a5f-fae7-4488-9463-f0af6e4c5233.jpg?1",
             "name": "Wingfold Pteron",
             "text": "Wingfold Pteron enters the battlefield with your choice of a flying counter or a hexproof counter on it. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "9dc77e83-8edc-5efe-8d61-e796c2675de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89348a02-29f6-40b9-b39f-cb5f8c230a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89348a02-29f6-40b9-b39f-cb5f8c230a02.jpg?1",
             "name": "Wingspan Mentor",
             "text": "When Wingspan Mentor enters the battlefield, put a flying counter on target non-Human creature you control.\n{2}{U}, {T}: Put a +1/+1 counter on each creature you control with flying.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "603cba6d-572b-52db-822f-2f096b08f039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd354dd-939e-4b1a-8ed6-fe89a7fd64bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd354dd-939e-4b1a-8ed6-fe89a7fd64bf.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "When Bastion of Remembrance enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "2ca635de-cfb1-58a3-96e8-1dfb91cb5226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9b5bde-a851-480b-b45e-d384fd1c11bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9b5bde-a851-480b-b45e-d384fd1c11bb.jpg?1",
             "name": "Blitz Leech",
             "text": "Flash\nWhen Blitz Leech enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn. Remove all counters from that creature.",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "2476cf61-4054-5b39-8e42-977853fcb38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4184c851-1419-476c-ba9c-9f0cb1137114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4184c851-1419-476c-ba9c-9f0cb1137114.jpg?1",
             "name": "Blood Curdle",
             "text": "Destroy target creature. Put a menace counter on a creature you control. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "b63ba2bd-dbfd-59f6-82b4-bb7c83428bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5a5b8-f823-4429-acd8-c4f34a676cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5a5b8-f823-4429-acd8-c4f34a676cb4.jpg?1",
             "name": "Boot Nipper",
             "text": "Boot Nipper enters the battlefield with your choice of a deathtouch counter or a lifelink counter on it.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "6cc8eed0-b8dd-50cf-be55-8e9a87780003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc01faf4-fabb-40c9-a1d6-359280535f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc01faf4-fabb-40c9-a1d6-359280535f91.jpg?1",
             "name": "Bushmeat Poacher",
             "text": "{1}, {T}, Sacrifice another creature: You gain life equal to that creature's toughness. Draw a card.",
             "colours": [
@@ -2617,7 +2617,7 @@
         },
         {
             "id": "06d17c40-e524-5b03-a6ee-0edceca5730a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e34017-0aeb-4a93-9edf-596bf3597a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e34017-0aeb-4a93-9edf-596bf3597a0e.jpg?1",
             "name": "Call of the Death-Dweller",
             "text": "Return up to two target creature cards with total converted mana cost 3 or less from your graveyard to the battlefield. Put a deathtouch counter on either of them. Then put a menace counter on either of them.",
             "colours": [
@@ -2649,7 +2649,7 @@
         },
         {
             "id": "8e61fd42-99eb-5a94-8542-28bbcad882b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae7651-4a5c-41f3-b528-41b9b0f2e5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae7651-4a5c-41f3-b528-41b9b0f2e5d8.jpg?1",
             "name": "Cavern Whisperer",
             "text": "Mutate {3}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nMenace (This creature can't be blocked except by two or more creatures.)\nWhenever this creature mutates, each opponent discards a card.",
             "colours": [
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "5437928c-138e-539c-a46b-63efffb6db7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51a0700-d4d3-4b7e-bdb5-6cd913c948d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51a0700-d4d3-4b7e-bdb5-6cd913c948d9.jpg?1",
             "name": "Chittering Harvester",
             "text": "Mutate {4}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, each opponent sacrifices a creature.",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "af3367f8-3fe3-5e5d-b4e3-ae2b463b9509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0c764-791d-4181-8f7a-147554d97d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c0c764-791d-4181-8f7a-147554d97d97.jpg?1",
             "name": "Corpse Churn",
             "text": "Put the top three cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "711bc45f-00bb-59f9-b882-1a520c4d27a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6f861-90ef-4e1d-9f17-1dd306e7d0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef6f861-90ef-4e1d-9f17-1dd306e7d0af.jpg?1",
             "name": "Dark Bargain",
             "text": "Look at the top three cards of your library. Put two of them into your hand and the other into your graveyard. Dark Bargain deals 2 damage to you.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "404cf848-a6ac-519e-ab6f-b2873f7ebdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf18476-f67b-46e6-905c-e6808981c58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf18476-f67b-46e6-905c-e6808981c58a.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "793cba6b-4f65-5834-b055-b83822576a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59677c76-8148-4b6f-95b0-0e3ccf137a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59677c76-8148-4b6f-95b0-0e3ccf137a3f.jpg?1",
             "name": "Dirge Bat",
             "text": "Mutate {4}{B}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlash\nFlying\nWhenever this creature mutates, destroy target creature or planeswalker an opponent controls.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "43644d4c-dca3-567e-866a-2768ad55e1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cbdfb6-c029-440f-bc07-c95e03c20110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cbdfb6-c029-440f-bc07-c95e03c20110.jpg?1",
             "name": "Durable Coilbug",
             "text": "{4}{B}: Return Durable Coilbug from your graveyard to your hand.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "2939b0c6-fcf0-53f7-8123-db3ef7e02d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc38fe5d-6c35-4fff-8f1b-726a0685c6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc38fe5d-6c35-4fff-8f1b-726a0685c6f8.jpg?1",
             "name": "Duskfang Mentor",
             "text": "When Duskfang Mentor enters the battlefield, put a lifelink counter on target non-Human creature you control.\n{1}{B}, {T}: Put a +1/+1 counter on each creature you control with lifelink.",
             "colours": [
@@ -2925,7 +2925,7 @@
         },
         {
             "id": "65801db8-4a90-5e61-830d-6af547269832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312fb6e4-1eb1-4fbb-b7a4-125829a6e96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312fb6e4-1eb1-4fbb-b7a4-125829a6e96a.jpg?1",
             "name": "Easy Prey",
             "text": "Destroy target creature with converted mana cost 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "32ea8570-3565-5ce1-8705-697ce1e7bff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725a869-462b-4381-880a-b4bcc63a655b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725a869-462b-4381-880a-b4bcc63a655b.jpg?1",
             "name": "Extinction Event",
             "text": "Choose odd or even. Exile each creature with converted mana cost of the chosen value. (Zero is even.)",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "bde3d656-05f1-51b5-b219-a25902e5c5cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f135dd7-2a4f-4c83-9a90-76bcab3cc33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f135dd7-2a4f-4c83-9a90-76bcab3cc33d.jpg?1",
             "name": "Gloom Pangolin",
             "text": "",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "3263bab7-7d1c-594a-a204-aa4ef58510bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819257c8-9806-48bd-ba49-e117ca31de54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819257c8-9806-48bd-ba49-e117ca31de54.jpg?1",
             "name": "Grimdancer",
             "text": "Grimdancer enters the battlefield with your choice of two different counters on it from among menace, deathtouch, and lifelink.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "9765302f-7eb2-5f70-8d1a-95c53b492b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6794a-feeb-4fc8-a2ee-38c75c18aaae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6794a-feeb-4fc8-a2ee-38c75c18aaae.jpg?1",
             "name": "Heartless Act",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with no counters on it.\n\u2022 Remove up to three counters from target creature.",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "3cf92ac2-0ca8-5608-acc6-ae1422595a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2dddce-583e-4af3-b144-a60dd268e84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2dddce-583e-4af3-b144-a60dd268e84f.jpg?1",
             "name": "Hunted Nightmare",
             "text": "Menace\nWhen Hunted Nightmare enters the battlefield, target opponent puts a deathtouch counter on a creature they control.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "dda806e1-a2e9-5436-8436-fa0e1a0f6907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70419590-2e0d-4232-b596-a5359b284647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70419590-2e0d-4232-b596-a5359b284647.jpg?1",
             "name": "Insatiable Hemophage",
             "text": "Mutate {2}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nDeathtouch\nWhenever this creature mutates, each opponent loses X life and you gain X life, where X is the number of times this creature has mutated.",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "55568114-ee69-5bff-ba9e-7fc2d8d5cb2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43925a8d-dd02-4907-929e-c015d678bb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43925a8d-dd02-4907-929e-c015d678bb49.jpg?1",
             "name": "Lurking Deadeye",
             "text": "Flash\nWhen Lurking Deadeye enters the battlefield, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -3201,7 +3201,7 @@
         },
         {
             "id": "b74c3b04-c822-593b-b557-2011712d9f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b45a493-a1c2-430e-a45c-abc1ba554877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b45a493-a1c2-430e-a45c-abc1ba554877.jpg?1",
             "name": "Memory Leak",
             "text": "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -3233,7 +3233,7 @@
         },
         {
             "id": "f872a733-2f8e-5dee-8219-e3ea98cf5563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ac0b25-80bf-4871-a6f6-5cf4d5b9496e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ac0b25-80bf-4871-a6f6-5cf4d5b9496e.jpg?1",
             "name": "Mutual Destruction",
             "text": "This spell has flash as long as you control a permanent with flash.\nAs an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -3265,7 +3265,7 @@
         },
         {
             "id": "2bfa0603-2a5c-5c32-b6b3-d0828f643b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abc24e1-e721-471a-9efd-547f320675b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6abc24e1-e721-471a-9efd-547f320675b0.jpg?1",
             "name": "Mythos of Nethroi",
             "text": "Destroy target nonland permanent if it's a creature or if {G}{W} was spent to cast this spell.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "c015085e-1634-5025-9af7-42850464547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80306d10-0da7-4ee7-b975-ef6c9b535a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80306d10-0da7-4ee7-b975-ef6c9b535a2a.jpg?1",
             "name": "Nightsquad Commando",
             "text": "When Nightsquad Commando enters the battlefield, if you attacked this turn, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -3336,7 +3336,7 @@
         },
         {
             "id": "d284ed49-e301-5683-9385-bbe8a69bee80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8f0242-35e1-4409-9321-56e742e8fef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8f0242-35e1-4409-9321-56e742e8fef4.jpg?1",
             "name": "Serrated Scorpion",
             "text": "When Serrated Scorpion dies, it deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "b89918e0-c401-597f-801e-af5a91c29580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b562e4-35df-4aee-848d-ceb4204bbe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b562e4-35df-4aee-848d-ceb4204bbe58.jpg?1",
             "name": "Suffocating Fumes",
             "text": "Creatures your opponents control get -1/-1 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "28280ba9-cb20-52c8-a132-2fa210e5ac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9da02a1-7b39-4a0e-8466-6512a02f3e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9da02a1-7b39-4a0e-8466-6512a02f3e3b.jpg?1",
             "name": "Unbreakable Bond",
             "text": "Return target creature card from your graveyard to the battlefield with a lifelink counter on it.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "86a4e4b5-37fb-53af-8913-41c90ecbef1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6494ad-a35e-4b09-8623-7740f3c20b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6494ad-a35e-4b09-8623-7740f3c20b0b.jpg?1",
             "name": "Unexpected Fangs",
             "text": "Put a +1/+1 counter and a lifelink counter on target creature.",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "f58458a9-e3ff-53cf-9758-649e1cfce1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac3409e-7c24-43b0-9956-5f0cdeae6468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac3409e-7c24-43b0-9956-5f0cdeae6468.jpg?1",
             "name": "Unlikely Aid",
             "text": "Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "e2fb0a41-862d-5872-b87b-26ce48a48964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1523cda-c47d-4419-a5d3-fd6ed9867c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1523cda-c47d-4419-a5d3-fd6ed9867c56.jpg?1",
             "name": "Void Beckoner",
             "text": "Deathtouch\nCycling {2}{B} ({2}{B}, Discard this card: Draw a card.)\nWhen you cycle Void Beckoner, put a deathtouch counter on target creature you control.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "f49ba7c8-499f-547e-8b91-8a7286c6c885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097eeb32-cfd5-4adb-ac30-d7762e6ea48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097eeb32-cfd5-4adb-ac30-d7762e6ea48f.jpg?1",
             "name": "Whisper Squad",
             "text": "{1}{B}: Search your library for a card named Whisper Squad, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "fe65b63c-5e63-5bd9-87d2-0d21ced18d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce945f7e-ded9-4819-9313-d50d3aad40fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce945f7e-ded9-4819-9313-d50d3aad40fa.jpg?1",
             "name": "Zagoth Mamba",
             "text": "Whenever this creature mutates, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "787cdfa5-413b-54fe-8dd8-4bd071f24380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adc0288-acdf-4a99-9bfb-919cae1aeb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3adc0288-acdf-4a99-9bfb-919cae1aeb69.jpg?1",
             "name": "Blazing Volley",
             "text": "Blazing Volley deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -3638,7 +3638,7 @@
         },
         {
             "id": "4695331e-f056-50ff-924e-1cf1e1cb0bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec65b97-d5c0-4609-8a60-3c4daa3e59c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec65b97-d5c0-4609-8a60-3c4daa3e59c1.jpg?1",
             "name": "Blisterspit Gremlin",
             "text": "{1}, {T}: Blisterspit Gremlin deals 1 damage to each opponent.\nWhenever you cast a noncreature spell, untap Blisterspit Gremlin.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "3ac10a7d-419a-578e-a047-3c5fd983fac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0174556-9f9b-4756-84ca-d14a5a60720c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0174556-9f9b-4756-84ca-d14a5a60720c.jpg?1",
             "name": "Blitz of the Thunder-Raptor",
             "text": "Blitz of the Thunder-Raptor deals damage to target creature or planeswalker equal to the number of instant and sorcery cards in your graveyard. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "9f55fa9b-8ec5-5626-8b57-9168118ad13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d93cfd-06d1-4c6a-87f6-9b6eaa2a995f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d93cfd-06d1-4c6a-87f6-9b6eaa2a995f.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast this spell, discard two cards.\nDraw three cards.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "17b71251-5a61-5671-b6bf-59888a332634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10e2b8-a317-4c98-a866-43bf274e82cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10e2b8-a317-4c98-a866-43bf274e82cb.jpg?1",
             "name": "Clash of Titans",
             "text": "Target creature fights another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "4ec947f3-913e-5f24-965f-0ba554fc715d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec5f005-d8fb-48b8-8ac5-74445cc83273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec5f005-d8fb-48b8-8ac5-74445cc83273.jpg?1",
             "name": "Cloudpiercer",
             "text": "Mutate {3}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nReach\nWhenever this creature mutates, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3804,7 +3804,7 @@
         },
         {
             "id": "951230fb-eee0-568a-8868-e5e5c12d8a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ee4be-e7a2-423c-a37c-7c6ca97f630e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612ee4be-e7a2-423c-a37c-7c6ca97f630e.jpg?1",
             "name": "Drannith Stinger",
             "text": "Whenever you cycle another card, Drannith Stinger deals 1 damage to each opponent.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "df2fd1f3-1b61-53ec-87a2-cc959b65af71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3953157f-2deb-4ab7-b4b3-592ebb7c7a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3953157f-2deb-4ab7-b4b3-592ebb7c7a9c.jpg?1",
             "name": "Everquill Phoenix",
             "text": "Mutate {3}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying\nWhenever this creature mutates, create a red artifact token named Feather with \"{1}, Sacrifice Feather: Return target Phoenix card from your graveyard to the battlefield tapped.\"",
             "colours": [
@@ -3876,7 +3876,7 @@
         },
         {
             "id": "24887078-1ab7-5d40-831e-00d6e2ed4dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976e8d8-5122-4423-b3eb-61170390ad7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5976e8d8-5122-4423-b3eb-61170390ad7a.jpg?1",
             "name": "Ferocious Tigorilla",
             "text": "Ferocious Tigorilla enters the battlefield with your choice of a trample counter or a menace counter on it. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "29eefa63-921a-5ffc-b894-184608814eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2029e5-cf7d-461f-b7b9-bf96399d8f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2029e5-cf7d-461f-b7b9-bf96399d8f49.jpg?1",
             "name": "Fire Prophecy",
             "text": "Fire Prophecy deals 3 damage to target creature. You may put a card from your hand on the bottom of your library. If you do, draw a card.",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "136e00ed-9b7f-57a6-9c3c-5039228e17c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3090004-d7dd-47bc-92e5-977be4fd9ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3090004-d7dd-47bc-92e5-977be4fd9ae5.jpg?1",
             "name": "Flame Spill",
             "text": "Flame Spill deals 4 damage to target creature. Excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "3759805e-0d98-5a71-9eb2-134695354852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b75aac-54e3-4181-bac5-5a142757ec05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b75aac-54e3-4181-bac5-5a142757ec05.jpg?1",
             "name": "Footfall Crater",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature gains trample and haste until end of turn.\"\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "80499d53-40ce-5438-a578-467e2b4980ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e634baa3-2cdd-412a-9407-c347fe46f9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e634baa3-2cdd-412a-9407-c347fe46f9b8.jpg?1",
             "name": "Forbidden Friendship",
             "text": "Create a 1/1 red Dinosaur creature token with haste and a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "50b63c8c-ebb4-5ba8-8210-af7406bf4823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb22ac0-3863-4165-8c93-f2ec1775474f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb22ac0-3863-4165-8c93-f2ec1775474f.jpg?1",
             "name": "Frenzied Raptor",
             "text": "",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "cb80a309-4210-57a0-982b-ac280fd094b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7d034-6403-41e2-9e44-4d58ef54cf10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7d034-6403-41e2-9e44-4d58ef54cf10.jpg?1",
             "name": "Frillscare Mentor",
             "text": "When Frillscare Mentor enters the battlefield, put a menace counter on target non-Human creature you control. (It can't be blocked except by two or more creatures.)\n{2}{R}, {T}: Put a +1/+1 counter on each creature you control with menace.",
             "colours": [
@@ -4112,7 +4112,7 @@
         },
         {
             "id": "d2f35809-877d-565a-8c57-97d78cbdd79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67315df9-99a1-45ba-8ade-ddc476368a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67315df9-99a1-45ba-8ade-ddc476368a86.jpg?1",
             "name": "Go for Blood",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "625d6d0a-50cf-51e6-add0-b12ed8c7c01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7cc8e7-3002-4ee0-869f-931438d8362d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7cc8e7-3002-4ee0-869f-931438d8362d.jpg?1",
             "name": "Heightened Reflexes",
             "text": "Target creature gets +1/+0 until end of turn. Put a first strike counter on it.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "00e252b2-7dd3-5ebf-84ca-2f6349cbd13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ebd57f-7f7c-41b0-aa56-511c1816bc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ebd57f-7f7c-41b0-aa56-511c1816bc14.jpg?1",
             "name": "Lava Serpent",
             "text": "Haste\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "cc7b9bd8-7943-5ae5-9a2b-ed50e2227966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5798fdf0-d178-43d9-b821-8f3f654654b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5798fdf0-d178-43d9-b821-8f3f654654b4.jpg?1",
             "name": "Lukka, Coppercoat Outcast",
             "text": "+1: Exile the top three cards of your library. Creature cards exiled this way gain \"You may cast this card from exile as long as you control a Lukka planeswalker.\"\n\u22122: Exile target creature you control, then reveal cards from the top of your library until you reveal a creature card with higher converted mana cost. Put that card onto the battlefield and the rest on the bottom of your library in a random order.\n\u22127: Each creature you control deals damage equal to its power to each opponent.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "ca31b7fc-03bf-526a-9c10-8f2f60d01cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3587f450-c1ba-4074-84bb-47978a2b6116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3587f450-c1ba-4074-84bb-47978a2b6116.jpg?1",
             "name": "Momentum Rumbler",
             "text": "Whenever Momentum Rumbler attacks, if it doesn't have first strike, put a first strike counter on it.\nWhenever Momentum Rumbler attacks, if it has first strike, it gains double strike until end of turn.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "ff03a839-b8f5-5a82-b995-d5889491efe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe99a7-3b58-4f23-bf86-e1e35b0bec2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe99a7-3b58-4f23-bf86-e1e35b0bec2e.jpg?1",
             "name": "Mythos of Vadrok",
             "text": "Mythos of Vadrok deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers. If {W}{U} was spent to cast this spell, until your next turn, those permanents can't attack or block and their activated abilities can't be activated.",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "a971530c-47a6-593c-a13b-118c1b25d19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856892c8-ba47-46d0-aec2-0416b55b9e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856892c8-ba47-46d0-aec2-0416b55b9e88.jpg?1",
             "name": "Porcuparrot",
             "text": "Mutate {2}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\n{T}: This creature deals X damage to any target, where X is the number of times this creature has mutated.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "723961d9-0bbc-5e02-b89b-d02e0179e6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad8512f-31b9-48ba-bb10-1497303dcfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad8512f-31b9-48ba-bb10-1497303dcfba.jpg?1",
             "name": "Prickly Marmoset",
             "text": "First strike\nWhenever you cycle a card, Prickly Marmoset gets +2/+0 until end of turn.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "b777dd8b-155e-5830-9560-c1374c6d6b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6599645-dbb5-4174-bd26-8556af6d89c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6599645-dbb5-4174-bd26-8556af6d89c3.jpg?1",
             "name": "Pyroceratops",
             "text": "Trample\nWhenever you cast a noncreature spell, put a +1/+1 counter on Pyroceratops.",
             "colours": [
@@ -4425,7 +4425,7 @@
         },
         {
             "id": "32142ce6-5228-5c8b-8c69-d5854f46cf3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb0d9a2-f9bb-4d8e-a1ca-896c42f8ad56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb0d9a2-f9bb-4d8e-a1ca-896c42f8ad56.jpg?1",
             "name": "Raking Claws",
             "text": "Target creature gains double strike until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4457,7 +4457,7 @@
         },
         {
             "id": "d7f614a9-12af-5ebf-a62a-4775787639e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7871b4dd-9085-4a3f-a1ae-9a292f73689b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7871b4dd-9085-4a3f-a1ae-9a292f73689b.jpg?1",
             "name": "Reptilian Reflection",
             "text": "Whenever you cycle a card, you may have Reptilian Reflection become a 5/4 Dinosaur creature with trample and haste in addition to its other types until end of turn.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "842a9e81-ac38-50d6-b575-0d080590f332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2fd581-5cf8-4154-90dd-922afddcd556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2fd581-5cf8-4154-90dd-922afddcd556.jpg?1",
             "name": "Rooting Moloch",
             "text": "When Rooting Moloch enters the battlefield, exile target card with a cycling ability from your graveyard. Until the end of your next turn, you may play that card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "8838190f-cb0c-5376-824f-893d18f07aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9aaa7-11c7-4cd0-9803-9471c14ab846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9aaa7-11c7-4cd0-9803-9471c14ab846.jpg?1",
             "name": "Rumbling Rockslide",
             "text": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "bc794588-6e67-55ee-8c6d-a43047cdbb65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc634c10-42c5-4bdc-bc22-f862ae285492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc634c10-42c5-4bdc-bc22-f862ae285492.jpg?1",
             "name": "Sanctuary Smasher",
             "text": "First strike\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle Sanctuary Smasher, put a first strike counter on target creature you control.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "c6f914d2-676d-5a14-950d-5735854670ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b10219a-aa72-4431-9a6a-984109a605c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b10219a-aa72-4431-9a6a-984109a605c8.jpg?1",
             "name": "Shredded Sails",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Shredded Sails deals 4 damage to target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "6a6e7756-f264-5a85-b9f8-1cc2d422b1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f03ffd-dcdb-441c-8dfc-4fe06a289b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f03ffd-dcdb-441c-8dfc-4fe06a289b22.jpg?1",
             "name": "Spelleater Wolverine",
             "text": "Spelleater Wolverine has double strike as long as there are three or more instant and/or sorcery cards in your graveyard.",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "b4d76539-5a7b-567b-aa45-513e603d5dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c40fd33-bb95-48f3-a10f-a33eb27c48f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c40fd33-bb95-48f3-a10f-a33eb27c48f1.jpg?1",
             "name": "Tentative Connection",
             "text": "This spell costs {3} less to cast if you control a creature with menace.\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4688,7 +4688,7 @@
         },
         {
             "id": "672fd934-b146-5bf7-8455-1a19e0500766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0462f6-a027-43c0-8e01-c0591d9a45d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0462f6-a027-43c0-8e01-c0591d9a45d9.jpg?1",
             "name": "Unpredictable Cyclone",
             "text": "If a cycling ability of another nonland card would cause you to draw a card, instead exile cards from the top of your library until you exile a card that shares a card type with the cycled card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of your library in a random order.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "377f94bd-0dd7-5c2c-a2e9-026e34168125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bba622-a0ab-4c0e-88b1-9120690ea5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bba622-a0ab-4c0e-88b1-9120690ea5a0.jpg?1",
             "name": "Weaponize the Monsters",
             "text": "{2}, Sacrifice a creature: Weaponize the Monsters deals 2 damage to any target.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "1ed1090b-a684-5560-ae82-946f39d710b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b540c7c6-5b9e-4606-ac84-e583a62a3647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b540c7c6-5b9e-4606-ac84-e583a62a3647.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "Trample, haste\nCycling {1}{R}\nWhen you cycle Yidaro, Wandering Monster, shuffle it into your library from your graveyard. If you've cycled a card named Yidaro, Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead. (Do this before you draw.)",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "d45823a8-9df1-5b4a-83d9-5f837b3af415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30811fb2-5767-4106-9a8d-6091f61969c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30811fb2-5767-4106-9a8d-6091f61969c6.jpg?1",
             "name": "Adventurous Impulse",
             "text": "Look at the top three cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "b0dfbceb-48c2-5b56-8090-de2be047eed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2b7ac-8742-468d-b6a3-87881cb522ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2b7ac-8742-468d-b6a3-87881cb522ff.jpg?1",
             "name": "Almighty Brushwagg",
             "text": "Trample\n{3}{G}: Almighty Brushwagg gets +3/+3 until end of turn.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "aedf0bf6-d36e-564a-9d2d-8a6fe01069e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ae1e4-d4dd-4691-af5a-5fa25ace4ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39ae1e4-d4dd-4691-af5a-5fa25ace4ebe.jpg?1",
             "name": "Auspicious Starrix",
             "text": "Mutate {5}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, exile cards from the top of your library until you exile X permanent cards, where X is the number of times this creature has mutated. Put those permanent cards onto the battlefield.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "56c4aaeb-7d62-516d-9160-a70706651987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822f8403-77a7-4e75-88af-60d604632f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822f8403-77a7-4e75-88af-60d604632f5d.jpg?1",
             "name": "Barrier Breach",
             "text": "Exile up to three target enchantments.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "ae7fa4b6-d018-5ad7-a7e9-5ee48929f26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c3243c-e9af-4b7d-8296-f7714436e571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c3243c-e9af-4b7d-8296-f7714436e571.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -4963,7 +4963,7 @@
         },
         {
             "id": "13b25102-77c8-54ae-a360-63f66b47ee30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf147a6-2282-4120-9cbd-d0309fc9b02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf147a6-2282-4120-9cbd-d0309fc9b02b.jpg?1",
             "name": "Charge of the Forever-Beast",
             "text": "As an additional cost to cast this spell, reveal a creature card from your hand.\nCharge of the Forever-Beast deals damage to target creature or planeswalker equal to the revealed card's power.",
             "colours": [
@@ -4995,7 +4995,7 @@
         },
         {
             "id": "2475f50a-a574-5a8a-a6d8-9726a235b82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6e6f2a-5015-44c6-aa8d-85188494d1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6e6f2a-5015-44c6-aa8d-85188494d1a6.jpg?1",
             "name": "Colossification",
             "text": "Enchant creature\nWhen Colossification enters the battlefield, tap enchanted creature.\nEnchanted creature gets +20/+20.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "b9c1c37f-00ae-5207-a646-0b0c876f0a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09ddf0-91f0-4e76-809f-c39ca7418ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09ddf0-91f0-4e76-809f-c39ca7418ed5.jpg?1",
             "name": "Essence Symbiote",
             "text": "Whenever a creature you control mutates, put a +1/+1 counter on that creature and you gain 2 life.",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "e7b1a653-0eea-52bf-b9db-4fe334a65fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1712dc-8f4c-407f-83ea-3a1c59c437d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1712dc-8f4c-407f-83ea-3a1c59c437d1.jpg?1",
             "name": "Excavation Mole",
             "text": "Trample\nWhen Excavation Mole enters the battlefield, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "e737042c-0e62-5fef-8057-96336b57b870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8ff0da-fbe3-4c95-bc39-c975c55b6aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8ff0da-fbe3-4c95-bc39-c975c55b6aea.jpg?1",
             "name": "Exuberant Wolfbear",
             "text": "Whenever Exuberant Wolfbear attacks, you may change the base power and toughness of target Human you control to Exuberant Wolfbear's power and toughness until end of turn.",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "21d51948-8631-569a-9feb-e43cef9bee67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6b39b9-0615-4899-8de2-b579d5b12f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6b39b9-0615-4899-8de2-b579d5b12f1c.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles their library.",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "6e894fba-f57e-5cf0-a101-7567c1d26ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1988e220-d746-46e4-a534-164203e63c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1988e220-d746-46e4-a534-164203e63c14.jpg?1",
             "name": "Flycatcher Giraffid",
             "text": "Flycatcher Giraffid enters the battlefield with your choice of a vigilance counter or a reach counter on it.",
             "colours": [
@@ -5204,7 +5204,7 @@
         },
         {
             "id": "a206b2d5-e1f1-5ee0-b324-ce5ec3600a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b683d3f-025c-4b8d-89d7-3513488649d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b683d3f-025c-4b8d-89d7-3513488649d5.jpg?1",
             "name": "Fully Grown",
             "text": "Target creature gets +3/+3 until end of turn. Put a trample counter on it.",
             "colours": [
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "ad472671-1604-5585-8ae8-603a73b41915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0095245c-a30e-4e2a-88c9-632c678e9f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0095245c-a30e-4e2a-88c9-632c678e9f03.jpg?1",
             "name": "Gemrazer",
             "text": "Mutate {1}{G}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nReach, trample\nWhenever this creature mutates, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "4a1ce1e7-1762-5ba4-bbca-02edf4511be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a9698d-400c-4c31-82cd-28d0897fe28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a9698d-400c-4c31-82cd-28d0897fe28c.jpg?1",
             "name": "Glowstone Recluse",
             "text": "Mutate {3}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nReach\nWhenever this creature mutates, put two +1/+1 counters on it.",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "9f9b4392-3d30-5a5c-99d2-0d4aa0b5023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90c5650-7eb2-480a-856e-a04406096830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90c5650-7eb2-480a-856e-a04406096830.jpg?1",
             "name": "Greater Sandwurm",
             "text": "Greater Sandwurm can't be blocked by creatures with power 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "c947d54e-4642-51a5-a118-f3e6c55db70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b9bee2-b973-4de7-b72d-7f36f8e8153c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b9bee2-b973-4de7-b72d-7f36f8e8153c.jpg?1",
             "name": "Honey Mammoth",
             "text": "When Honey Mammoth enters the battlefield, you gain 4 life.",
             "colours": [
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "60588665-84ac-567f-9c48-38e3d0a1a070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47d2596-a321-44c0-a9f6-87bf80abc1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47d2596-a321-44c0-a9f6-87bf80abc1c4.jpg?1",
             "name": "Hornbash Mentor",
             "text": "When Hornbash Mentor enters the battlefield, put a trample counter on target non-Human creature you control.\n{2}{G}, {T}: Put a +1/+1 counter on each creature you control with trample.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "4e3ea897-8f79-5148-ade4-936f9995c17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f56705d-eb64-4cef-b716-edbeac60bf79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f56705d-eb64-4cef-b716-edbeac60bf79.jpg?1",
             "name": "Humble Naturalist",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.",
             "colours": [
@@ -5447,7 +5447,7 @@
         },
         {
             "id": "397d416b-c473-50ee-9322-c793e089201a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8aea71-02aa-4799-86fb-efd2a36efc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8aea71-02aa-4799-86fb-efd2a36efc22.jpg?1",
             "name": "Ivy Elemental",
             "text": "Ivy Elemental enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5481,7 +5481,7 @@
         },
         {
             "id": "23fa3b37-12b6-53fb-a77d-345b29e0db3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c35ca79-eb72-427a-a8ed-404b2214389a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c35ca79-eb72-427a-a8ed-404b2214389a.jpg?1",
             "name": "Kogla, the Titan Ape",
             "text": "When Kogla, the Titan Ape enters the battlefield, it fights up to one target creature you don't control.\nWhenever Kogla attacks, destroy target artifact or enchantment defending player controls.\n{1}{G}: Return target Human you control to its owner's hand. Kogla gains indestructible until end of turn.",
             "colours": [
@@ -5519,7 +5519,7 @@
         },
         {
             "id": "e2d5f174-b324-51a4-b334-debd13570880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76b676-c7a3-4de6-a78d-3059a0df83f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e76b676-c7a3-4de6-a78d-3059a0df83f2.jpg?1",
             "name": "Lead the Stampede",
             "text": "Look at the top five cards of your library. You may reveal any number of creature cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "d79467e9-930e-53dd-9bc8-0128a346631e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345ca63-16a3-4988-93f5-d0e00e8d6ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345ca63-16a3-4988-93f5-d0e00e8d6ab0.jpg?1",
             "name": "Migration Path",
             "text": "Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5585,7 +5585,7 @@
         },
         {
             "id": "02c2a74f-2618-5b3b-aa9f-0c95bf63aa0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2a287b-b83f-444f-84f7-e388beb616c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2a287b-b83f-444f-84f7-e388beb616c2.jpg?1",
             "name": "Migratory Greathorn",
             "text": "Mutate {2}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5621,7 +5621,7 @@
         },
         {
             "id": "8c2f1a9f-6bd7-5840-ad24-5aed4ee8e561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893f300b-a823-4156-90f2-0636e9f499b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/893f300b-a823-4156-90f2-0636e9f499b0.jpg?1",
             "name": "Monstrous Step",
             "text": "Target creature gets +7/+7 until end of turn. Up to one other target creature blocks it this turn if able.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "f3735ccb-b2f8-5b83-a987-ca7c275f5a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23139d4-0db5-4683-8d49-f4600fbe29e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23139d4-0db5-4683-8d49-f4600fbe29e2.jpg?1",
             "name": "Mosscoat Goriak",
             "text": "Vigilance",
             "colours": [
@@ -5687,7 +5687,7 @@
         },
         {
             "id": "57716ae0-695a-5165-836b-7e80a720f655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4fc5b1-6666-4c60-898f-f927212c7923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4fc5b1-6666-4c60-898f-f927212c7923.jpg?1",
             "name": "Mythos of Brokkos",
             "text": "If {U}{B} was spent to cast this spell, search your library for a card, put that card into your graveyard, then shuffle your library.\nReturn up to two permanent cards from your graveyard to your hand.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "860e1116-2025-53b8-af0f-66b4b9506b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d884b2f2-946e-4d5d-b8cf-ef035726a188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d884b2f2-946e-4d5d-b8cf-ef035726a188.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -5755,7 +5755,7 @@
         },
         {
             "id": "52f3bb82-119b-5b69-b311-55e2b26beb80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0b24e7-14e7-45ee-b5d8-bdb8674b669c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0b24e7-14e7-45ee-b5d8-bdb8674b669c.jpg?1",
             "name": "Ram Through",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -5787,7 +5787,7 @@
         },
         {
             "id": "4d4201cf-6acb-5f8a-a0bb-2ebb61c6a9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3730996a-96d2-4311-a4dc-0045a2f8ccc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3730996a-96d2-4311-a4dc-0045a2f8ccc9.jpg?1",
             "name": "Sudden Spinnerets",
             "text": "Target creature gets +1/+3 until end of turn. Put a reach counter on it. Untap it.",
             "colours": [
@@ -5819,7 +5819,7 @@
         },
         {
             "id": "996fc1b6-e384-51b6-bb2b-d8f37397428f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ff2a1-6447-4653-a661-d9a39156d6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ff2a1-6447-4653-a661-d9a39156d6fa.jpg?1",
             "name": "Survivors' Bond",
             "text": "Choose one or both \u2014\n\u2022 Return target Human creature card from your graveyard to your hand.\n\u2022 Return target non-Human creature card from your graveyard to your hand.",
             "colours": [
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "ce25b8c1-2886-5f35-b48a-74fad6eecd9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7101f35-d8c9-4320-bffc-8bb25000d103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7101f35-d8c9-4320-bffc-8bb25000d103.jpg?1",
             "name": "Thwart the Enemy",
             "text": "Prevent all damage that would be dealt this turn by creatures your opponents control.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "8c9f38a6-4e08-5d56-a07c-aa39f211d0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d02e1e8-b85b-4e26-8ab8-ca2f49d05b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d02e1e8-b85b-4e26-8ab8-ca2f49d05b88.jpg?1",
             "name": "Titanoth Rex",
             "text": "Trample\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)\nWhen you cycle Titanoth Rex, put a trample counter on target creature you control.",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "193ae10e-2032-5153-994d-567deff6d5da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504ebb84-7e7b-4119-a128-a9c183c5d9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504ebb84-7e7b-4119-a128-a9c183c5d9de.jpg?1",
             "name": "Vivien, Monsters' Advocate",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n+1: Create a 3/3 green Beast creature token. Put your choice of a vigilance counter, a reach counter, or a trample counter on it.\n\u22122: When you cast your next creature spell this turn, search your library for a creature card with lesser converted mana cost, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5958,7 +5958,7 @@
         },
         {
             "id": "1bc81524-6b20-5ca9-8494-09b368315759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55987bab-c24f-4261-b97e-f0ad4474b0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55987bab-c24f-4261-b97e-f0ad4474b0a0.jpg?1",
             "name": "Wilt",
             "text": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "7c87d0da-939b-505a-984e-526f254ca0e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc7210c-da23-4cec-9195-4de75587f40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc7210c-da23-4cec-9195-4de75587f40f.jpg?1",
             "name": "Back for More",
             "text": "Return target creature card from your graveyard to the battlefield. When you do, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "2f2b609d-b867-5091-9498-e29c1c301471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e4df5b-ec53-4f8a-8c26-272b3177c0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e4df5b-ec53-4f8a-8c26-272b3177c0a6.jpg?1",
             "name": "Boneyard Lurker",
             "text": "Mutate {2}{BG}{BG} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "575bd36a-9beb-505b-8df8-4447687bfa8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f07625-fbd8-4581-8568-eb3cfb2a4c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f07625-fbd8-4581-8568-eb3cfb2a4c1e.jpg?1",
             "name": "Brokkos, Apex of Forever",
             "text": "Mutate {2}{UB}{G}{G} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nTrample\nYou may cast Brokkos, Apex of Forever from your graveyard using its mutate ability.",
             "colours": [
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "e70df510-8c9c-5968-ae01-927db32851a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8918d24e-8ae8-4028-9f06-ba6fafcc717e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8918d24e-8ae8-4028-9f06-ba6fafcc717e.jpg?1",
             "name": "Channeled Force",
             "text": "As an additional cost to cast this spell, discard X cards.\nTarget player draws X cards. Channeled Force deals X damage to up to one target creature or planeswalker.",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "01fe85be-8ff0-5b6c-b900-e688e0a69f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecbf0a3-ebe1-43b6-a720-462ba19002eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecbf0a3-ebe1-43b6-a720-462ba19002eb.jpg?1",
             "name": "Chevill, Bane of Monsters",
             "text": "Deathtouch\nAt the beginning of your upkeep, if your opponents control no permanents with bounty counters on them, put a bounty counter on target creature or planeswalker an opponent controls.\nWhenever a permanent an opponent controls with a bounty counter on it dies, you gain 3 life and draw a card.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "5a6e08c6-80af-5b09-852f-d93daae34df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112e2cca-bae7-4296-9514-e6058f4b38a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112e2cca-bae7-4296-9514-e6058f4b38a5.jpg?1",
             "name": "Death's Oasis",
             "text": "Whenever a nontoken creature you control dies, put the top two cards of your library into your graveyard. Then return a creature card with lesser converted mana cost than the creature that died from your graveyard to your hand.\n{1}, Sacrifice Death's Oasis: You gain life equal to the greatest converted mana cost among creatures you control.",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "f02b95df-5856-5db7-8659-a1029d0b150f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3974e-3753-4f25-8930-6d96b40332ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3974e-3753-4f25-8930-6d96b40332ce.jpg?1",
             "name": "Dire Tactics",
             "text": "Exile target creature. If you don't control a Human, you lose life equal to that creature's toughness.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "d52eafb7-8a90-5ab0-a917-57f457333b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb2db-228f-4d48-acdf-6330baf356c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb2db-228f-4d48-acdf-6330baf356c7.jpg?1",
             "name": "Eerie Ultimatum",
             "text": "Return any number of permanent cards with different names from your graveyard to the battlefield.",
             "colours": [
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "8c7efa00-c2a1-5e45-8ca9-8a930dbdd245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6a52ab-6d38-4429-9969-90064e615152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6a52ab-6d38-4429-9969-90064e615152.jpg?1",
             "name": "Emergent Ultimatum",
             "text": "Search your library for up to three monocolored cards with different names and exile them. An opponent chooses one of those cards. Shuffle that card into your library. You may cast the other cards without paying their mana costs. Exile Emergent Ultimatum.",
             "colours": [
@@ -6331,7 +6331,7 @@
         },
         {
             "id": "98445397-a664-59a9-a422-e94879cc2ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab220695-e1a9-45ec-a1b1-5a82c9c90a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab220695-e1a9-45ec-a1b1-5a82c9c90a03.jpg?1",
             "name": "Frondland Felidar",
             "text": "Vigilance\nCreatures you control with vigilance have \"{1}, {T}: Tap target creature.\"",
             "colours": [
@@ -6370,7 +6370,7 @@
         },
         {
             "id": "6b186c14-725d-5eb4-9412-631b186ae694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3227ae-0c72-478a-a6dd-661aaf718038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3227ae-0c72-478a-a6dd-661aaf718038.jpg?1",
             "name": "General Kudro of Drannith",
             "text": "Other Humans you control get +1/+1.\nWhenever General Kudro of Drannith or another Human enters the battlefield under your control, exile target card from an opponent's graveyard.\n{2}, Sacrifice two Humans: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "498b22ef-7cf7-562a-af5d-38e718ab5bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a45d0e-582a-4ec1-b83b-71b6a0ff6249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a45d0e-582a-4ec1-b83b-71b6a0ff6249.jpg?1",
             "name": "General's Enforcer",
             "text": "Legendary Humans you control have indestructible.\n{2}{W}{B}: Exile target card from a graveyard. If it was a creature card, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "194b1848-3516-5bf5-8c2f-4c92e090d813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556dfe7a-43e8-4801-ad79-89ab2148eca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556dfe7a-43e8-4801-ad79-89ab2148eca6.jpg?1",
             "name": "Genesis Ultimatum",
             "text": "Look at the top five cards of your library. Put any number of permanent cards from among them onto the battlefield and the rest into your hand. Exile Genesis Ultimatum.",
             "colours": [
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "f3f01bdc-5679-5f7d-94cc-caa5c889f620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc99c81-d112-4811-9bba-77a14d904692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc99c81-d112-4811-9bba-77a14d904692.jpg?1",
             "name": "Illuna, Apex of Wishes",
             "text": "Mutate {3}{RG}{U}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying, trample\nWhenever this creature mutates, exile cards from the top of your library until you exile a nonland permanent card. Put that card onto the battlefield or into your hand.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "c9959ad6-f277-5374-b1bf-2977d0e679fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64f064-8f05-41ef-b95b-1b723137f846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd64f064-8f05-41ef-b95b-1b723137f846.jpg?1",
             "name": "Inspired Ultimatum",
             "text": "Target player gains 5 life, Inspired Ultimatum deals 5 damage to any target, then you draw five cards.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "f0b4b160-806a-5d29-bfc8-c9ae5e33f30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cda4a0-0dff-4edb-ae67-a2b7e2971350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cda4a0-0dff-4edb-ae67-a2b7e2971350.jpg?1",
             "name": "Kinnan, Bonder Prodigy",
             "text": "Whenever you tap a nonland permanent for mana, add one mana of any type that permanent produced.\n{5}{G}{U}: Look at the top five cards of your library. You may put a non-Human creature card from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6610,7 +6610,7 @@
         },
         {
             "id": "d9d2e9c0-b1dc-52df-9ae4-b4cbde877399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c608543d-cb60-44c3-a437-e4a18c311420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c608543d-cb60-44c3-a437-e4a18c311420.jpg?1",
             "name": "Labyrinth Raptor",
             "text": "Menace\nWhenever a creature you control with menace becomes blocked, defending player sacrifices a creature blocking it.\n{B}{R}: Creatures you control with menace get +1/+0 until end of turn.",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "9e3c6d03-12e9-5a50-bb09-6adfea01bebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e035ca-eccd-4b63-817c-f2c676b9c98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e035ca-eccd-4b63-817c-f2c676b9c98d.jpg?1",
             "name": "Lore Drakkis",
             "text": "Mutate {UR}{UR} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "34e92a87-95e4-5849-97c4-f2473912b2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7b28d8-b835-44a0-978d-cadfd392fff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7b28d8-b835-44a0-978d-cadfd392fff5.jpg?1",
             "name": "Narset of the Ancient Way",
             "text": "+1: You gain 2 life. Add {U}, {R}, or {W}. Spend this mana only to cast a noncreature spell.\n\u22122: Draw a card, then you may discard a card. When you discard a nonland card this way, Narset of the Ancient Way deals damage equal to that card's converted mana cost to target creature or planeswalker.\n\u22126: You get an emblem with \"Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.\"",
             "colours": [
@@ -6730,7 +6730,7 @@
         },
         {
             "id": "01b418a4-f982-57f8-bd75-8874e3c7fd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1ed055-8988-4625-9d57-8ce8a4e04aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1ed055-8988-4625-9d57-8ce8a4e04aea.jpg?1",
             "name": "Necropanther",
             "text": "Mutate {2}{WB}{WB} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "6468e77d-1c96-59a8-8ef9-94b8732f1c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca6eb5a-8bc9-4091-bcfb-b207f0afd188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca6eb5a-8bc9-4091-bcfb-b207f0afd188.jpg?1",
             "name": "Nethroi, Apex of Death",
             "text": "Mutate {4}{RW}{B}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nDeathtouch, lifelink\nWhenever this creature mutates, return any number of target creature cards with total power 10 or less from your graveyard to the battlefield.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "8be785cd-792e-531e-bce9-d1557ba86884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78619ffb-f514-4f9f-9d77-3ab49e045f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78619ffb-f514-4f9f-9d77-3ab49e045f7c.jpg?1",
             "name": "Offspring's Revenge",
             "text": "At the beginning of combat on your turn, exile target red, white, or black creature card from your graveyard. Create a token that's a copy of that card, except it's 1/1. It gains haste until your next turn.",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "be0e5b03-253c-52ef-b71c-403a45dc85a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610bb98c-d66a-44cc-92e2-a80d700b59e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610bb98c-d66a-44cc-92e2-a80d700b59e4.jpg?1",
             "name": "Parcelbeast",
             "text": "Mutate {G}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\n{1}, {T}: Look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -6891,7 +6891,7 @@
         },
         {
             "id": "490673db-70ac-5cc7-95c3-385f020d8f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0afb-7787-4cb8-8bb4-cf6997dbf7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0afb-7787-4cb8-8bb4-cf6997dbf7e4.jpg?1",
             "name": "Primal Empathy",
             "text": "At the beginning of your upkeep, draw a card if you control a creature with the greatest power among creatures on the battlefield. Otherwise, put a +1/+1 counter on a creature you control.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "aae34a9e-d9d5-5ad3-b0e0-682a68337583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e4c609-19c9-433b-a852-7999e375ee4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e4c609-19c9-433b-a852-7999e375ee4f.jpg?1",
             "name": "Quartzwood Crasher",
             "text": "Trample\nWhenever one or more creatures you control with trample deal combat damage to a player, create an X/X green Dinosaur Beast creature token with trample, where X is the amount of damage those creatures dealt to that player.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "59e38a29-d0b7-5450-b867-dfdac5c17072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fdf313-740b-4976-911f-9fb5eb54afce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fdf313-740b-4976-911f-9fb5eb54afce.jpg?1",
             "name": "Regal Leosaur",
             "text": "Mutate {1}{GU}{GU} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, other creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "884118a6-cd59-50e2-b880-463ce370d951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f03c944-1929-4cb2-a373-d57eefa29ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f03c944-1929-4cb2-a373-d57eefa29ed1.jpg?1",
             "name": "Rielle, the Everwise",
             "text": "Rielle, the Everwise gets +1/+0 for each instant and sorcery card in your graveyard.\nWhenever you discard one or more cards for the first time each turn, draw that many cards.",
             "colours": [
@@ -7044,7 +7044,7 @@
         },
         {
             "id": "51357e44-65f8-5a51-8bf6-8334147c27c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1d6ca-7789-46b5-bc89-85cc3915cb85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1d6ca-7789-46b5-bc89-85cc3915cb85.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "Destroy all nonland permanents your opponents control.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "239980f4-b020-585f-96aa-edda4a32dcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d3925c-cf7d-4546-bc70-33f04d4b7566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d3925c-cf7d-4546-bc70-33f04d4b7566.jpg?1",
             "name": "Savai Thundermane",
             "text": "Whenever you cycle a card, you may pay {2}. When you do, Savai Thundermane deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -7119,7 +7119,7 @@
         },
         {
             "id": "fce9f3c3-bbcb-5e63-8f17-1b02fd090a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5ec787-79f6-4922-a0f7-debde8f7a4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5ec787-79f6-4922-a0f7-debde8f7a4be.jpg?1",
             "name": "Skull Prophet",
             "text": "{T}: Add {B} or {G}.\n{T}: Put the top two cards of your library into your graveyard.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "08ed7fb5-f8df-555b-84e7-f50b5ce00f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209dbfd-b765-44c5-b3ad-94f6e0705926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209dbfd-b765-44c5-b3ad-94f6e0705926.jpg?1",
             "name": "Skycat Sovereign",
             "text": "Flying\nSkycat Sovereign gets +1/+1 for each other creature you control with flying.\n{2}{W}{U}: Create a 1/1 white Cat Bird creature token with flying.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "aa40e2e5-c032-580a-b296-f9359ee12fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8067f195-8b6e-4329-a34e-43e52f67c571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8067f195-8b6e-4329-a34e-43e52f67c571.jpg?1",
             "name": "Slitherwisp",
             "text": "Flash\nWhenever you cast another spell that has flash, you draw a card and each opponent loses 1 life.",
             "colours": [
@@ -7234,7 +7234,7 @@
         },
         {
             "id": "a7c56c17-1fe6-5520-bf32-10c4573ad68d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdeeb7-9868-4fc2-9c53-806244cd5488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdeeb7-9868-4fc2-9c53-806244cd5488.jpg?1",
             "name": "Snapdax, Apex of the Hunt",
             "text": "Mutate {2}{BR}{W}{W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nDouble strike\nWhenever this creature mutates, it deals 4 damage to target creature or planeswalker an opponent controls and you gain 4 life.",
             "colours": [
@@ -7279,7 +7279,7 @@
         },
         {
             "id": "9e11b64e-86e5-5936-b34c-2e93410110bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7320233-1c83-4f61-8c08-cc8361867256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7320233-1c83-4f61-8c08-cc8361867256.jpg?1",
             "name": "Song of Creation",
             "text": "You may play an additional land on each of your turns.\nWhenever you cast a spell, draw two cards.\nAt the beginning of your end step, discard your hand.",
             "colours": [
@@ -7317,7 +7317,7 @@
         },
         {
             "id": "f3a94132-ce71-5556-bfd3-1461601a810d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f6118-adb8-4a7d-9c77-5570f3399e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f6118-adb8-4a7d-9c77-5570f3399e6e.jpg?1",
             "name": "Sprite Dragon",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on Sprite Dragon.",
             "colours": [
@@ -7357,7 +7357,7 @@
         },
         {
             "id": "89cebc6e-20fd-5107-a9dc-675281f145f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d4e6f3-73cb-4799-bcb9-c1f5bc234a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d4e6f3-73cb-4799-bcb9-c1f5bc234a02.jpg?1",
             "name": "Titans' Nest",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.\nExile a card from your graveyard: Add {C}. Spend this mana only to cast a colored spell without {X} in its mana cost.",
             "colours": [
@@ -7395,7 +7395,7 @@
         },
         {
             "id": "e9e82e36-bf89-5b5d-bf33-2e7aa3a92580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063a95ee-3fda-436f-9ff8-de80cc874dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063a95ee-3fda-436f-9ff8-de80cc874dde.jpg?1",
             "name": "Trumpeting Gnarr",
             "text": "Mutate {3}{GW}{GW} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, create a 3/3 green Beast creature token.",
             "colours": [
@@ -7433,7 +7433,7 @@
         },
         {
             "id": "f07d63b4-4708-56d6-930d-abae98a2d071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7b0256-d342-4523-9516-6a007bf51825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7b0256-d342-4523-9516-6a007bf51825.jpg?1",
             "name": "Vadrok, Apex of Thunder",
             "text": "Mutate {1}{WU}{R}{R} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nFlying, first strike\nWhenever this creature mutates, you may cast target noncreature card with converted mana cost 3 or less from your graveyard without paying its mana cost.",
             "colours": [
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "2f045425-0d27-540c-ad03-0c339adc6207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0699cbc-b499-44a6-82e1-631491aaaec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0699cbc-b499-44a6-82e1-631491aaaec6.jpg?1",
             "name": "Whirlwind of Thought",
             "text": "Whenever you cast a noncreature spell, draw a card.",
             "colours": [
@@ -7516,7 +7516,7 @@
         },
         {
             "id": "d943182b-88a8-5103-a306-667f862b1935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd13a6c-23d3-44ce-a628-cb1c19d777c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd13a6c-23d3-44ce-a628-cb1c19d777c4.jpg?1",
             "name": "Winota, Joiner of Forces",
             "text": "Whenever a non-Human creature you control attacks, look at the top six cards of your library. You may put a Human creature card from among them onto the battlefield tapped and attacking. It gains indestructible until end of turn. Put the rest of the cards on the bottom of your library in a random order.",
             "colours": [
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "d318b77d-ea8f-5260-b3f7-a8830c4633e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf6e906-9305-4003-b040-1dfecca590c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf6e906-9305-4003-b040-1dfecca590c1.jpg?1",
             "name": "A-Winota, Joiner of Forces",
             "text": "",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "5a87360a-16dc-532d-b272-b765026b202f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efac1ed-3f01-487c-86be-8239568b4425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efac1ed-3f01-487c-86be-8239568b4425.jpg?1",
             "name": "Zenith Flare",
             "text": "Zenith Flare deals X damage to any target and you gain X life, where X is the number of cards with a cycling ability in your graveyard.",
             "colours": [
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "86cf4d49-4698-576b-ae97-e16fceeee184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2ccae-c322-4e99-a094-a68fc5d52ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2ccae-c322-4e99-a094-a68fc5d52ea3.jpg?1",
             "name": "Alert Heedbonder",
             "text": "Vigilance\nAt the beginning of your end step, you gain 1 life for each creature you control with vigilance.",
             "colours": [
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "f23ed192-57c8-5e0f-a4d9-783aa05ac489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb202e7-f9a4-4785-840d-18aa6aa663b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb202e7-f9a4-4785-840d-18aa6aa663b4.jpg?1",
             "name": "Cunning Nightbonder",
             "text": "Flash\nSpells with flash you cast cost {1} less to cast and can't be countered.",
             "colours": [
@@ -7703,7 +7703,7 @@
         },
         {
             "id": "aed0fad6-b599-5d55-ab16-35391b7716e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd9d800-6d31-42e2-87d2-772db0ff95ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd9d800-6d31-42e2-87d2-772db0ff95ed.jpg?1",
             "name": "Fiend Artisan",
             "text": "Fiend Artisan gets +1/+1 for each creature card in your graveyard.\n{X}{BG}, {T}, Sacrifice another creature: Search your library for a creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "6f3fc058-f695-5b01-8262-a88b95dd1d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eb1804-6fd8-4917-af36-87fdfce39d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eb1804-6fd8-4917-af36-87fdfce39d3a.jpg?1",
             "name": "Gyruda, Doom of Depths",
             "text": "Companion \u2014 Your starting deck contains only cards with even converted mana costs. (If this card is your chosen companion, you may cast it once from outside the game.)\nWhen Gyruda enters the battlefield, each player puts the top four cards of their library into their graveyard. Put a creature card with an even converted mana cost from among those cards onto the battlefield under your control.",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "02a724f6-4a37-5321-81a3-a2fb658b4566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d52e527-3835-4350-8c01-0f2d5d623b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d52e527-3835-4350-8c01-0f2d5d623b9c.jpg?1",
             "name": "Jegantha, the Wellspring",
             "text": "Companion \u2014 No card in your starting deck has more than one of the same mana symbol in its mana cost. (If this card is your chosen companion, you may cast it once from outside the game.)\n{T}: Add {W}{U}{B}{R}{G}. This mana can't be spent to pay generic mana costs.",
             "colours": [
@@ -7827,7 +7827,7 @@
         },
         {
             "id": "049ec717-52bf-56ce-99d3-005092acdcef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8f2d69-fba9-40e5-8ef7-75e14ef4070a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8f2d69-fba9-40e5-8ef7-75e14ef4070a.jpg?1",
             "name": "Jubilant Skybonder",
             "text": "Flying\nCreatures you control with flying have \"Spells your opponents cast that target this creature cost {2} more to cast.\"",
             "colours": [
@@ -7864,7 +7864,7 @@
         },
         {
             "id": "1a9f0cd9-e4fc-5c3d-951e-b7f37fefad78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebed0b-8060-4a7b-a060-5cfcd2172b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebed0b-8060-4a7b-a060-5cfcd2172b16.jpg?1",
             "name": "Kaheera, the Orphanguard",
             "text": "Companion \u2014 Each creature card in your starting deck is a Cat, Elemental, Nightmare, Dinosaur, or Beast card. (If this card is your chosen companion, you may cast it once from outside the game.)\nVigilance\nEach other creature you control that's a Cat, Elemental, Nightmare, Dinosaur, or Beast gets +1/+1 and has vigilance.",
             "colours": [
@@ -7905,7 +7905,7 @@
         },
         {
             "id": "90b4baf3-db2a-5171-8df3-2b463509a456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ee952-de7a-420f-993c-a38db89bc8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90ee952-de7a-420f-993c-a38db89bc8ac.jpg?1",
             "name": "Keruga, the Macrosage",
             "text": "Companion \u2014 Your starting deck contains only cards with converted mana cost 3 or greater and land cards. (If this card is your chosen companion, you may cast it once from outside the game.)\nWhen Keruga, the Macrosage enters the battlefield, draw a card for each other permanent you control with converted mana cost 3 or greater.",
             "colours": [
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "d15f90a4-afd5-57d0-b303-07e32be36648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad36fb2-c44e-4085-ba0d-54277841ad3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad36fb2-c44e-4085-ba0d-54277841ad3a.jpg?1",
             "name": "Lurrus of the Dream-Den",
             "text": "Companion \u2014 Each permanent card in your starting deck has converted mana cost 2 or less. (If this card is your chosen companion, you may cast it once from outside the game.)\nLifelink\nDuring each of your turns, you may cast one permanent spell with converted mana cost 2 or less from your graveyard.",
             "colours": [
@@ -7987,7 +7987,7 @@
         },
         {
             "id": "e70f447c-6386-50bf-b376-a4cbb807d125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1189c9-7842-466e-8238-1e02677d8494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1189c9-7842-466e-8238-1e02677d8494.jpg?1",
             "name": "Lutri, the Spellchaser",
             "text": "Companion \u2014 Each nonland card in your starting deck has a different name. (If this card is your chosen companion, you may cast it once from outside the game.)\nFlash\nWhen Lutri, the Spellchaser enters the battlefield, if you cast it, copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "310e4b40-8931-5d39-8e63-399d913e7285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451507de-9c42-43ee-b9ba-1f69e9aa29d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451507de-9c42-43ee-b9ba-1f69e9aa29d2.jpg?1",
             "name": "Obosh, the Preypiercer",
             "text": "Companion \u2014 Your starting deck contains only cards with odd converted mana costs and land cards. (If this card is your chosen companion, you may cast it once from outside the game.)\nIf a source you control with an odd converted mana cost would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -8069,7 +8069,7 @@
         },
         {
             "id": "89e28082-be28-5525-805b-4938046638f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4876e17-a206-4351-9c0b-0845db4569a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4876e17-a206-4351-9c0b-0845db4569a3.jpg?1",
             "name": "Proud Wildbonder",
             "text": "Trample\nCreatures you control with trample have \"You may have this creature assign its combat damage as though it weren't blocked.\"",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "9c072db1-b96f-5f77-8b89-2c0e2b6494f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f0b25-6e6e-43c4-a4a0-903920067df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595f0b25-6e6e-43c4-a4a0-903920067df1.jpg?1",
             "name": "Sonorous Howlbonder",
             "text": "Menace\nEach creature you control with menace can't be blocked except by three or more creatures.",
             "colours": [
@@ -8143,7 +8143,7 @@
         },
         {
             "id": "69f1601a-c4b3-5596-a73a-bc8d1955e531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac31e0-ac70-4ee6-b2b1-cc445ffa1da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac31e0-ac70-4ee6-b2b1-cc445ffa1da9.jpg?1",
             "name": "Umori, the Collector",
             "text": "Companion \u2014 Each nonland card in your starting deck shares a card type. (If this card is your chosen companion, you may cast it once from outside the game.)\nAs Umori, the Collector enters the battlefield, choose a card type.\nSpells you cast of the chosen type cost {1} less to cast.",
             "colours": [
@@ -8183,7 +8183,7 @@
         },
         {
             "id": "1b6b455a-34dd-5426-99c5-13f60e9bfcb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275426c4-c14e-47d0-a9d4-24da7f6f6911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275426c4-c14e-47d0-a9d4-24da7f6f6911.jpg?1",
             "name": "Yorion, Sky Nomad",
             "text": "Companion \u2014 Your starting deck contains at least twenty cards more than the minimum deck size. (If this card is your chosen companion, you may cast it once from outside the game.)\nFlying\nWhen Yorion enters the battlefield, exile any number of other nonland permanents you own and control. Return those cards to the battlefield at the beginning of the next end step.",
             "colours": [
@@ -8224,7 +8224,7 @@
         },
         {
             "id": "35f3951f-5ed3-5ede-858d-4c26986cdbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e61c-2ee8-4243-a848-7008810db8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd8e61c-2ee8-4243-a848-7008810db8a0.jpg?1",
             "name": "Zirda, the Dawnwaker",
             "text": "Companion \u2014 Each permanent card in your starting deck has an activated ability. (If this card is your chosen companion, you may cast it once from outside the game.)\nAbilities you activate that aren't mana abilities cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.\n{1}, {T}: Target creature can't block this turn.",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "f81c079e-64da-596c-9777-fdd7c06c3010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1146c418-2176-466e-8a06-f2ef6bf2b1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1146c418-2176-466e-8a06-f2ef6bf2b1a9.jpg?1",
             "name": "Crystalline Giant",
             "text": "At the beginning of combat on your turn, choose a kind of counter at random that Crystalline Giant doesn't have on it from among flying, first strike, deathtouch, hexproof, lifelink, menace, reach, trample, vigilance, and +1/+1. Put a counter of that kind on Crystalline Giant.",
             "colours": [],
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "58315e6e-4f1c-5ac1-8782-f95466fa1ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdace59f-f025-4717-8eb4-3d1e13b31d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdace59f-f025-4717-8eb4-3d1e13b31d2b.jpg?1",
             "name": "Indatha Crystal",
             "text": "{T}: Add {W}, {B}, or {G}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "6520246f-261e-5d5a-bf61-1c4e9c885074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df435cb-3aeb-490a-8fca-91f3b6936965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df435cb-3aeb-490a-8fca-91f3b6936965.jpg?1",
             "name": "Ketria Crystal",
             "text": "{T}: Add {G}, {U}, or {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8363,7 +8363,7 @@
         },
         {
             "id": "a5308950-4946-5cf2-808d-26e644d9f30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9341ed06-53db-4604-b60a-3ea9129afbc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9341ed06-53db-4604-b60a-3ea9129afbc2.jpg?1",
             "name": "The Ozolith",
             "text": "Whenever a creature you control leaves the battlefield, if it had counters on it, put those counters on The Ozolith.\nAt the beginning of combat on your turn, if The Ozolith has counters on it, you may move all counters from The Ozolith onto target creature.",
             "colours": [],
@@ -8395,7 +8395,7 @@
         },
         {
             "id": "5bea6a67-2a4a-5f41-94aa-7c7eb0e99387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bce0fb-53d6-47ee-8c5a-a99e50f67fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bce0fb-53d6-47ee-8c5a-a99e50f67fc9.jpg?1",
             "name": "Raugrin Crystal",
             "text": "{T}: Add {U}, {R}, or {W}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "499d23a0-db63-5085-9f03-b2267e37ec58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954a5c1-89b1-4edd-814e-8f88fd49cda3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954a5c1-89b1-4edd-814e-8f88fd49cda3.jpg?1",
             "name": "Savai Crystal",
             "text": "{T}: Add {R}, {W}, or {B}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "0cc5661e-5119-5b55-9b6f-318f950bc253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311f827a-1585-483e-b0fd-3dc05969b485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311f827a-1585-483e-b0fd-3dc05969b485.jpg?1",
             "name": "Sleeper Dart",
             "text": "When Sleeper Dart enters the battlefield, draw a card.\n{T}, Sacrifice Sleeper Dart: Target creature doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "bf55db75-7524-534d-85c0-e58fc6e210ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741de51-ea92-493a-8058-e0f2000e7701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3741de51-ea92-493a-8058-e0f2000e7701.jpg?1",
             "name": "Springjaw Trap",
             "text": "Flash\n{4}, {T}, Sacrifice Springjaw Trap: It deals 3 damage to any target.",
             "colours": [],
@@ -8515,7 +8515,7 @@
         },
         {
             "id": "71fd817e-cd28-582b-96fd-675b8ab46316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9138a442-8e8b-465f-bb76-b6af7e6dab6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9138a442-8e8b-465f-bb76-b6af7e6dab6f.jpg?1",
             "name": "Zagoth Crystal",
             "text": "{T}: Add {B}, {G}, or {U}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8547,7 +8547,7 @@
         },
         {
             "id": "acc56d9e-c2ca-5459-bb54-4a99390d9460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8269e6-b30c-4fdc-82a7-d503c133afa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8269e6-b30c-4fdc-82a7-d503c133afa6.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8578,7 +8578,7 @@
         },
         {
             "id": "05234d95-db8f-51c6-8693-70af0008e0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828044d6-0f53-4caf-a581-d71919df4175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828044d6-0f53-4caf-a581-d71919df4175.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8609,7 +8609,7 @@
         },
         {
             "id": "45824e6d-9aad-524c-a537-cd4a245614a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe9388d-b1ee-4f35-9fbd-5f504528b398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe9388d-b1ee-4f35-9fbd-5f504528b398.jpg?1",
             "name": "Bonders' Enclave",
             "text": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate this ability only if you control a creature with power 4 or greater.",
             "colours": [],
@@ -8639,7 +8639,7 @@
         },
         {
             "id": "5e8c5056-91cd-5b48-8d3f-4e71f9347c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0981e-54fc-4919-96a4-a9608a5452fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0981e-54fc-4919-96a4-a9608a5452fc.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "c818af25-ca69-596a-8902-1483205fd27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3d6745-8904-4905-a98f-d43f18b51d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3d6745-8904-4905-a98f-d43f18b51d6d.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "4a559698-608b-5d25-8ac1-1ae604e30383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b74bb81-fb9a-40e5-a941-e517430b52f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b74bb81-fb9a-40e5-a941-e517430b52f5.jpg?1",
             "name": "Indatha Triome",
             "text": "({T}: Add {W}, {B}, or {G}.)\nIndatha Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "9c8b8080-228f-5cec-8ed4-1a3dc93e5fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01926862-bf2d-4a2b-af94-1ea5e4dd7444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01926862-bf2d-4a2b-af94-1ea5e4dd7444.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "d110dabf-b35c-5392-b1c8-bb2331a01148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249b1f4-2b22-4b67-a207-e0c4ae95d2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a249b1f4-2b22-4b67-a207-e0c4ae95d2e1.jpg?1",
             "name": "Ketria Triome",
             "text": "({T}: Add {G}, {U}, or {R}.)\nKetria Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "1d9c469f-5526-5262-ade1-9bcc627d7247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02138fbb-3962-4348-8d31-faaefba0b8b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02138fbb-3962-4348-8d31-faaefba0b8b2.jpg?1",
             "name": "Raugrin Triome",
             "text": "({T}: Add {U}, {R}, or {W}.)\nRaugrin Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8843,7 +8843,7 @@
         },
         {
             "id": "cbcb76fe-0e86-57ce-a41a-74bdc73bf0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a69fa8f-1c2b-453d-8d54-2748890ce925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a69fa8f-1c2b-453d-8d54-2748890ce925.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "d570b77b-cd78-55d3-965d-09cd27030416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748e6a61-9c1f-4225-9f04-e54002f63ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/748e6a61-9c1f-4225-9f04-e54002f63ac3.jpg?1",
             "name": "Savai Triome",
             "text": "({T}: Add {R}, {W}, or {B}.)\nSavai Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8912,7 +8912,7 @@
         },
         {
             "id": "2f71fa70-5939-50ac-aae1-de3ad5615e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2282018a-46c8-41ca-ab93-f7dbf32cd295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2282018a-46c8-41ca-ab93-f7dbf32cd295.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "8f6aeeea-333b-5ea5-9e09-81bdc01a8f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7108c071-5f1c-4cf5-90c6-530cee3f7685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7108c071-5f1c-4cf5-90c6-530cee3f7685.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8974,7 +8974,7 @@
         },
         {
             "id": "6ab08d15-01fd-5401-9348-54c0a679d4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d011b0f-1681-4a51-9f5d-47ad135d03fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d011b0f-1681-4a51-9f5d-47ad135d03fe.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9005,7 +9005,7 @@
         },
         {
             "id": "fae4a3bb-b350-56dd-ae3a-d5b5fc93a404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ac097-39cb-4401-87c7-1dd73bf34329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ac097-39cb-4401-87c7-1dd73bf34329.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9036,7 +9036,7 @@
         },
         {
             "id": "8ef17795-afce-5f19-8a2c-0e3ac9469174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86367edc-9587-4f3b-aa95-c3a2bfc8c6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86367edc-9587-4f3b-aa95-c3a2bfc8c6f4.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9067,7 +9067,7 @@
         },
         {
             "id": "7bfbe058-d513-58e2-8892-a4c5cf67e0ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc520518-2063-4b57-a0d4-10cf62a7175e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc520518-2063-4b57-a0d4-10cf62a7175e.jpg?1",
             "name": "Zagoth Triome",
             "text": "({T}: Add {B}, {G}, or {U}.)\nZagoth Triome enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9105,7 +9105,7 @@
         },
         {
             "id": "d64c14d1-f545-5e71-bae0-0ed02d9196aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebbce9-fd10-4c14-b52d-cf82c0c1a58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebbce9-fd10-4c14-b52d-cf82c0c1a58c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "d7ffb076-7251-5eb2-bc70-ec035ed40af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84f2b9b-1412-476f-8739-17d35ea48a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84f2b9b-1412-476f-8739-17d35ea48a51.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "4ae4552c-ba52-5bd9-8c9b-631717f225ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65b379-47a9-48f2-be6e-abb4e7868ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65b379-47a9-48f2-be6e-abb4e7868ad0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "738ccbb2-ed6c-54d4-b512-1cab22bd5ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2ad5b3-7257-4521-8916-6b1cbfb89e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2ad5b3-7257-4521-8916-6b1cbfb89e27.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "52a1331b-d6ba-5411-8385-fe1e21bc9d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9bbc32-a89a-4bed-ab52-ac6569ec74ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9bbc32-a89a-4bed-ab52-ac6569ec74ce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "01a62c88-be14-508e-8eb6-15673668ad45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be169f8c-6472-40ec-9b4a-0edcb63e9e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be169f8c-6472-40ec-9b4a-0edcb63e9e2f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "f9b97388-17d6-54f3-9f3d-923863e14786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c3f0e-7af4-410b-a675-9ea84f51e812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c3f0e-7af4-410b-a675-9ea84f51e812.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "a147c37c-143f-53c8-9708-b841f8e5ebb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d99025-46bc-4848-bcbc-bee858ed906c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d99025-46bc-4848-bcbc-bee858ed906c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9401,7 +9401,7 @@
         },
         {
             "id": "89b5d419-161e-5be9-8a41-4396f37e21c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45991831-1018-4f98-a4ad-0998a9577d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45991831-1018-4f98-a4ad-0998a9577d97.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "7a72e9a9-0fda-5ab9-914e-3125c03fcf3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3d2fcd-11e0-4071-8c53-cb3315b7360a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3d2fcd-11e0-4071-8c53-cb3315b7360a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9475,7 +9475,7 @@
         },
         {
             "id": "a5b50a68-1485-5f52-acaa-07ceee3bcba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ba09d-ecdd-48c0-af0b-3dc5ef908f9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1ba09d-ecdd-48c0-af0b-3dc5ef908f9e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9512,7 +9512,7 @@
         },
         {
             "id": "4b1d8e05-2031-5883-a1e8-b8c758dcf632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609028b-43b8-4aea-9f9a-25aa127482db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e609028b-43b8-4aea-9f9a-25aa127482db.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9549,7 +9549,7 @@
         },
         {
             "id": "9f6b7e5a-4770-5c59-80c5-86b4320ffa3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c348494-f60c-4bd1-9077-bff24f2e634b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c348494-f60c-4bd1-9077-bff24f2e634b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9586,7 +9586,7 @@
         },
         {
             "id": "8c1f6c17-f5f4-5605-a321-ca21ee6b1f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb61e54a-646b-4c0a-88fe-f55d514202aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb61e54a-646b-4c0a-88fe-f55d514202aa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "902f5e18-a61b-5678-ade8-4b135bf07881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cf3bbf-acc0-4fe7-a631-aca698190ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cf3bbf-acc0-4fe7-a631-aca698190ce2.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9660,7 +9660,7 @@
         },
         {
             "id": "bf553e3b-7b79-5cf1-a40e-a0115baa6b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0639a0-c898-4a07-975c-a02bdd53175b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0639a0-c898-4a07-975c-a02bdd53175b.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "Trample\nLethal damage dealt to creatures you control is determined by their power rather than their toughness.",
             "colours": [
@@ -9700,7 +9700,7 @@
         },
         {
             "id": "30c3ae76-75b2-5fee-be86-2a847ce7c954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c48ddf5-c2da-4fbc-95f2-8a3f2f5737ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c48ddf5-c2da-4fbc-95f2-8a3f2f5737ba.jpg?1",
             "name": "Zilortha, Strength Incarnate",
             "text": "",
             "colours": [
@@ -9739,7 +9739,7 @@
         },
         {
             "id": "62ec689f-4d8b-5ea0-9b13-9cff3d9c990e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f74c3-c552-4331-a47c-e8155841bb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8f74c3-c552-4331-a47c-e8155841bb27.jpg?1",
             "name": "Lukka, Coppercoat Outcast",
             "text": "",
             "colours": [
@@ -9777,7 +9777,7 @@
         },
         {
             "id": "5e52bd2a-f453-58d1-ab8a-9d42295f445e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7ce2ee-2ebc-4336-a9f3-02380ea9784b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7ce2ee-2ebc-4336-a9f3-02380ea9784b.jpg?1",
             "name": "Vivien, Monsters' Advocate",
             "text": "",
             "colours": [
@@ -9815,7 +9815,7 @@
         },
         {
             "id": "f0aedec3-750f-5e6c-89d4-8bb95bf57d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ac6589-75ee-4fbf-8056-1860c1482592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ac6589-75ee-4fbf-8056-1860c1482592.jpg?1",
             "name": "Narset of the Ancient Way",
             "text": "",
             "colours": [
@@ -9857,7 +9857,7 @@
         },
         {
             "id": "6661f745-7e01-5d62-b31f-edd24558d501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17398d7f-baf3-4605-aced-21582a81c73a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17398d7f-baf3-4605-aced-21582a81c73a.jpg?1",
             "name": "Cubwarden",
             "text": "",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "be11fd9c-0c32-5df5-a169-fee93da35ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208084f5-35d4-4042-bdc6-dc2bf14c9990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208084f5-35d4-4042-bdc6-dc2bf14c9990.jpg?1",
             "name": "Huntmaster Liger",
             "text": "",
             "colours": [
@@ -9930,7 +9930,7 @@
         },
         {
             "id": "08457d1c-cb77-506c-b0d5-56e5ca653cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d63b878-4d0d-444c-9db2-05cf5dd3fa8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d63b878-4d0d-444c-9db2-05cf5dd3fa8c.jpg?1",
             "name": "Majestic Auricorn",
             "text": "",
             "colours": [
@@ -9966,7 +9966,7 @@
         },
         {
             "id": "2cebf1ad-2a90-5fda-970c-bb9b8fb10bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dae1f-a767-49f8-b4e2-85161f2685d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dae1f-a767-49f8-b4e2-85161f2685d5.jpg?1",
             "name": "Vulpikeet",
             "text": "",
             "colours": [
@@ -10003,7 +10003,7 @@
         },
         {
             "id": "c3f98d3c-210b-5e32-bed5-cd17f643912e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cda84f-7bd8-4166-b496-a04a4baa9b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cda84f-7bd8-4166-b496-a04a4baa9b62.jpg?1",
             "name": "Archipelagore",
             "text": "",
             "colours": [
@@ -10039,7 +10039,7 @@
         },
         {
             "id": "02d174b8-5d9e-55bf-abff-b53218b1cdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1828b1-a6eb-4346-b405-7642e34b3e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1828b1-a6eb-4346-b405-7642e34b3e71.jpg?1",
             "name": "Dreamtail Heron",
             "text": "",
             "colours": [
@@ -10076,7 +10076,7 @@
         },
         {
             "id": "98363b5d-e614-5cdd-8c60-6a9373cd567c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428228-83a0-440f-afe9-573c9d8640cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428228-83a0-440f-afe9-573c9d8640cc.jpg?1",
             "name": "Pouncing Shoreshark",
             "text": "",
             "colours": [
@@ -10113,7 +10113,7 @@
         },
         {
             "id": "f2bd9f3f-bc04-5aa8-b022-899c84d83062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6986a8-e258-46f0-88a9-8f84732f359e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6986a8-e258-46f0-88a9-8f84732f359e.jpg?1",
             "name": "Sea-Dasher Octopus",
             "text": "",
             "colours": [
@@ -10149,7 +10149,7 @@
         },
         {
             "id": "82765c2e-f409-5d50-afb7-5a57dc5bfb0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecae13c-fbbf-4199-a1dc-0e14263ed887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecae13c-fbbf-4199-a1dc-0e14263ed887.jpg?1",
             "name": "Cavern Whisperer",
             "text": "",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "128a058f-36f4-5c48-bb54-4bd107913482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd157ee-d17e-402c-a97d-206445dcf864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd157ee-d17e-402c-a97d-206445dcf864.jpg?1",
             "name": "Chittering Harvester",
             "text": "",
             "colours": [
@@ -10221,7 +10221,7 @@
         },
         {
             "id": "cc2778a4-a8dc-55c8-8b0d-e5e09c4a868d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef6998d-bda7-4847-b3d6-30e1596bf730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef6998d-bda7-4847-b3d6-30e1596bf730.jpg?1",
             "name": "Dirge Bat",
             "text": "",
             "colours": [
@@ -10258,7 +10258,7 @@
         },
         {
             "id": "71e3079a-c62e-51c9-ac7e-5c8d3ed94712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada6588b-3efc-4464-ae83-11586eb54775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada6588b-3efc-4464-ae83-11586eb54775.jpg?1",
             "name": "Insatiable Hemophage",
             "text": "",
             "colours": [
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "df9e0cea-e7ce-5fbe-ae04-72edadded0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db7d906-1794-40eb-9d73-1f2a4db3a13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db7d906-1794-40eb-9d73-1f2a4db3a13f.jpg?1",
             "name": "Cloudpiercer",
             "text": "",
             "colours": [
@@ -10330,7 +10330,7 @@
         },
         {
             "id": "be20d529-183f-5f99-82d6-a3d35cc4c7e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe3c735-d091-4a32-8d10-38a7f23e5c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe3c735-d091-4a32-8d10-38a7f23e5c65.jpg?1",
             "name": "Everquill Phoenix",
             "text": "",
             "colours": [
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "65778d61-cfd7-51b4-a9da-a378c19c0a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6373fe1-c834-419e-8a0b-590fb5dc555e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6373fe1-c834-419e-8a0b-590fb5dc555e.jpg?1",
             "name": "Porcuparrot",
             "text": "",
             "colours": [
@@ -10404,7 +10404,7 @@
         },
         {
             "id": "79c14bf3-53b3-5eec-9972-83a5e39c231d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b41cfa-b22e-4d34-bfe9-68c9d8740704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b41cfa-b22e-4d34-bfe9-68c9d8740704.jpg?1",
             "name": "Auspicious Starrix",
             "text": "",
             "colours": [
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "14c9bb0e-89a9-5b12-8f95-cae9eda7cf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75546a5-81fd-41c1-a081-d8980f6bd60a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75546a5-81fd-41c1-a081-d8980f6bd60a.jpg?1",
             "name": "Gemrazer",
             "text": "",
             "colours": [
@@ -10478,7 +10478,7 @@
         },
         {
             "id": "b1b23fc8-bab7-5719-b483-1eb8adf2c131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980dcb8f-fc04-49d2-9859-830ca3d12af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980dcb8f-fc04-49d2-9859-830ca3d12af6.jpg?1",
             "name": "Glowstone Recluse",
             "text": "",
             "colours": [
@@ -10514,7 +10514,7 @@
         },
         {
             "id": "5178eae1-be17-50cc-a52e-7b41a465885c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e31f56d-bf75-4e14-94de-5c77193abf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e31f56d-bf75-4e14-94de-5c77193abf3a.jpg?1",
             "name": "Migratory Greathorn",
             "text": "",
             "colours": [
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "d1372a9c-a5b0-5c5f-8b97-c6aa7cececd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0232c0-0867-4217-8e5d-b3454c0c8dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0232c0-0867-4217-8e5d-b3454c0c8dab.jpg?1",
             "name": "Boneyard Lurker",
             "text": "",
             "colours": [
@@ -10589,7 +10589,7 @@
         },
         {
             "id": "7b0aad4c-3f93-5250-a60a-3a121d8eac02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4dfeb-d2a8-4b34-8605-75a79c706fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec4dfeb-d2a8-4b34-8605-75a79c706fe0.jpg?1",
             "name": "Brokkos, Apex of Forever",
             "text": "",
             "colours": [
@@ -10634,7 +10634,7 @@
         },
         {
             "id": "0898a67d-e593-5028-b0e2-66f9fe5c11b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c974c68-1a9f-457a-8bcb-265d29fee8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c974c68-1a9f-457a-8bcb-265d29fee8e4.jpg?1",
             "name": "Illuna, Apex of Wishes",
             "text": "",
             "colours": [
@@ -10679,7 +10679,7 @@
         },
         {
             "id": "efd0dbcd-0256-5e31-85dd-efadd95ce2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e938fac3-544a-4f27-9726-a67153392031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e938fac3-544a-4f27-9726-a67153392031.jpg?1",
             "name": "Lore Drakkis",
             "text": "",
             "colours": [
@@ -10718,7 +10718,7 @@
         },
         {
             "id": "53b63b9f-d5a4-5511-9d55-9bb45826805b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776f88b-65f5-4cac-8207-c7e6b976d206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776f88b-65f5-4cac-8207-c7e6b976d206.jpg?1",
             "name": "Necropanther",
             "text": "",
             "colours": [
@@ -10757,7 +10757,7 @@
         },
         {
             "id": "5be41c2f-a7dc-5933-84b1-44c341c78e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba04c102-e4c1-43a8-9c2f-d1f3c9bf5edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba04c102-e4c1-43a8-9c2f-d1f3c9bf5edf.jpg?1",
             "name": "Nethroi, Apex of Death",
             "text": "",
             "colours": [
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "fe77f67e-02e8-5a3b-944d-2b8bbf0c00b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac98e5-a22c-41b5-94a9-b37b5aeb124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac98e5-a22c-41b5-94a9-b37b5aeb124f.jpg?1",
             "name": "Parcelbeast",
             "text": "",
             "colours": [
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "c6efa4d1-2a6b-515e-a46d-87a77ed14717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8801b-6cfd-4ada-b6cc-bac09117f4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb8801b-6cfd-4ada-b6cc-bac09117f4d5.jpg?1",
             "name": "Regal Leosaur",
             "text": "",
             "colours": [
@@ -10880,7 +10880,7 @@
         },
         {
             "id": "c0f52b87-d699-5af0-9baf-54bdc823a027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceffd13b-8039-44ed-bd7f-68d46476dbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceffd13b-8039-44ed-bd7f-68d46476dbe7.jpg?1",
             "name": "Snapdax, Apex of the Hunt",
             "text": "",
             "colours": [
@@ -10925,7 +10925,7 @@
         },
         {
             "id": "678ab9f6-d88f-5f28-9319-97a13f63f258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe88a45-a420-4998-b242-b475c6b5b0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe88a45-a420-4998-b242-b475c6b5b0bc.jpg?1",
             "name": "Trumpeting Gnarr",
             "text": "",
             "colours": [
@@ -10963,7 +10963,7 @@
         },
         {
             "id": "517e63e2-22dd-5747-9d10-608850ce3c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b75a1-c12c-4904-8a65-4eb75d1d32f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658b75a1-c12c-4904-8a65-4eb75d1d32f7.jpg?1",
             "name": "Vadrok, Apex of Thunder",
             "text": "",
             "colours": [
@@ -11008,7 +11008,7 @@
         },
         {
             "id": "3bda577e-629e-5ddf-9f2a-ded7a7718307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf2b208-79c6-4c4c-bf66-871352ed600f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf2b208-79c6-4c4c-bf66-871352ed600f.jpg?1",
             "name": "Indatha Triome",
             "text": "",
             "colours": [],
@@ -11046,7 +11046,7 @@
         },
         {
             "id": "b1d108dc-bbe1-58fa-bf01-ffb40f5f2c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b5b9bb-ee9f-4a52-bd74-fd2759c8e3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b5b9bb-ee9f-4a52-bd74-fd2759c8e3d3.jpg?1",
             "name": "Ketria Triome",
             "text": "",
             "colours": [],
@@ -11084,7 +11084,7 @@
         },
         {
             "id": "1c93509b-3a8c-5ce2-a710-2cb545d9f73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303a627-cce3-4045-81f8-fe7427e0a941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303a627-cce3-4045-81f8-fe7427e0a941.jpg?1",
             "name": "Raugrin Triome",
             "text": "",
             "colours": [],
@@ -11122,7 +11122,7 @@
         },
         {
             "id": "f8371146-020e-5455-952e-4a4c041eb2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21ef9e6-e2dd-4e0a-a36c-e07034ac4ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21ef9e6-e2dd-4e0a-a36c-e07034ac4ba3.jpg?1",
             "name": "Savai Triome",
             "text": "",
             "colours": [],
@@ -11160,7 +11160,7 @@
         },
         {
             "id": "f082ca30-a227-5c88-b95a-37ca03cefcd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f809f970-25a7-4c34-b98f-1cb08012080d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f809f970-25a7-4c34-b98f-1cb08012080d.jpg?1",
             "name": "Zagoth Triome",
             "text": "",
             "colours": [],
@@ -11198,7 +11198,7 @@
         },
         {
             "id": "b64d9b40-d67d-5467-82cc-5a068ba139cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adaf8f6a-9559-4b47-8e67-2c4c3d6d8c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adaf8f6a-9559-4b47-8e67-2c4c3d6d8c60.jpg?1",
             "name": "Drannith Magistrate",
             "text": "",
             "colours": [
@@ -11235,7 +11235,7 @@
         },
         {
             "id": "19529a83-ff94-5029-9ce9-c4850280ac95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ab4e55-7c55-4480-83df-c9d9fd4df65a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ab4e55-7c55-4480-83df-c9d9fd4df65a.jpg?1",
             "name": "Lavabrink Venturer",
             "text": "",
             "colours": [
@@ -11272,7 +11272,7 @@
         },
         {
             "id": "91cff9f4-41ec-5359-8723-dd2e6ba6efc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535c823-f6e9-4a2f-8adf-f69b6f0fea1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535c823-f6e9-4a2f-8adf-f69b6f0fea1f.jpg?1",
             "name": "Luminous Broodmoth",
             "text": "",
             "colours": [
@@ -11309,7 +11309,7 @@
         },
         {
             "id": "9d8cb1a2-9dac-57d7-919e-f437dea2a16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a12b361-ed36-4a89-a973-1e4c7fb56fa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a12b361-ed36-4a89-a973-1e4c7fb56fa9.jpg?1",
             "name": "Mythos of Snapdax",
             "text": "",
             "colours": [
@@ -11345,7 +11345,7 @@
         },
         {
             "id": "8dc764a0-42bf-586d-934c-167b1b632d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf1cdf3-2543-4b91-b6a8-ac0d04a9c045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf1cdf3-2543-4b91-b6a8-ac0d04a9c045.jpg?1",
             "name": "Mythos of Illuna",
             "text": "",
             "colours": [
@@ -11381,7 +11381,7 @@
         },
         {
             "id": "72b12a9c-73b0-5b62-bbd3-b13df3cb69de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd8d35-3f73-4181-80a3-d4d69badcc47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd8d35-3f73-4181-80a3-d4d69badcc47.jpg?1",
             "name": "Shark Typhoon",
             "text": "",
             "colours": [
@@ -11415,7 +11415,7 @@
         },
         {
             "id": "738277a8-7f70-5d73-b487-45933ded0456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5ee3a2-c683-4657-98c8-daebaa7819f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5ee3a2-c683-4657-98c8-daebaa7819f1.jpg?1",
             "name": "Voracious Greatshark",
             "text": "",
             "colours": [
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "96cc5938-2198-5017-9ac0-2a2733ba030e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb788cd-a6ab-44a9-adcf-13bdfc3be2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb788cd-a6ab-44a9-adcf-13bdfc3be2e8.jpg?1",
             "name": "Extinction Event",
             "text": "",
             "colours": [
@@ -11485,7 +11485,7 @@
         },
         {
             "id": "ca3071e9-1051-54d7-a678-ff565425acef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ee8cfc-5d76-4e30-8b53-6ac6c9637d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ee8cfc-5d76-4e30-8b53-6ac6c9637d5d.jpg?1",
             "name": "Hunted Nightmare",
             "text": "",
             "colours": [
@@ -11521,7 +11521,7 @@
         },
         {
             "id": "3aae731c-22fd-5802-9cbc-26bd5faf5ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfb70ec-c9c8-4359-b2d4-e116bf5ad669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfb70ec-c9c8-4359-b2d4-e116bf5ad669.jpg?1",
             "name": "Mythos of Nethroi",
             "text": "",
             "colours": [
@@ -11557,7 +11557,7 @@
         },
         {
             "id": "3814ee98-8b22-5e01-bcad-84fc73a1d735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce59b5b6-97d8-4678-9381-2800667fdb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce59b5b6-97d8-4678-9381-2800667fdb41.jpg?1",
             "name": "Mythos of Vadrok",
             "text": "",
             "colours": [
@@ -11593,7 +11593,7 @@
         },
         {
             "id": "4868aadd-57a7-5514-b011-6bae0287d64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b94e1d-f328-4e4c-b112-45d6c6f98376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b94e1d-f328-4e4c-b112-45d6c6f98376.jpg?1",
             "name": "Unpredictable Cyclone",
             "text": "",
             "colours": [
@@ -11627,7 +11627,7 @@
         },
         {
             "id": "11a2496e-22c2-5ac8-b094-20dc58815110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9679442a-ecd4-4220-aae4-01b95dc18486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9679442a-ecd4-4220-aae4-01b95dc18486.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "",
             "colours": [
@@ -11667,7 +11667,7 @@
         },
         {
             "id": "5a54f9ba-dde1-5f3d-a21c-a5926df007a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9111b3dc-63da-45c7-bbe6-42a443ac2015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9111b3dc-63da-45c7-bbe6-42a443ac2015.jpg?1",
             "name": "Colossification",
             "text": "",
             "colours": [
@@ -11704,7 +11704,7 @@
         },
         {
             "id": "510fa7e1-2e2d-5f4e-95cd-968dda27d03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a5905f-4d53-4f7e-8af8-3d802978ec03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a5905f-4d53-4f7e-8af8-3d802978ec03.jpg?1",
             "name": "Kogla, the Titan Ape",
             "text": "",
             "colours": [
@@ -11742,7 +11742,7 @@
         },
         {
             "id": "cd1c7c32-61c9-5f56-a5d3-caef4245321c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e3e1ed-eeb6-4d7e-ab50-0b0f104606b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e3e1ed-eeb6-4d7e-ab50-0b0f104606b9.jpg?1",
             "name": "Mythos of Brokkos",
             "text": "",
             "colours": [
@@ -11778,7 +11778,7 @@
         },
         {
             "id": "99d90e5e-58a4-5f2d-9a33-01a66107952d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f90d92a-2297-4a52-80cb-10b56943b828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f90d92a-2297-4a52-80cb-10b56943b828.jpg?1",
             "name": "Chevill, Bane of Monsters",
             "text": "",
             "colours": [
@@ -11819,7 +11819,7 @@
         },
         {
             "id": "a910922c-1f79-5512-b71d-8d182858fdd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c4e70-81fb-42b9-9725-4d5206520037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c4e70-81fb-42b9-9725-4d5206520037.jpg?1",
             "name": "Death's Oasis",
             "text": "",
             "colours": [
@@ -11857,7 +11857,7 @@
         },
         {
             "id": "186bd0a4-49cd-505c-9c25-b469edd74dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe5a6f-82a2-4c6b-a69d-3a07917e15c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe5a6f-82a2-4c6b-a69d-3a07917e15c9.jpg?1",
             "name": "Eerie Ultimatum",
             "text": "",
             "colours": [
@@ -11895,7 +11895,7 @@
         },
         {
             "id": "3e1c22c8-08c8-5c9c-b136-1ff0731c3f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400d79b0-102a-406c-8369-8d024b18c4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400d79b0-102a-406c-8369-8d024b18c4e9.jpg?1",
             "name": "Emergent Ultimatum",
             "text": "",
             "colours": [
@@ -11933,7 +11933,7 @@
         },
         {
             "id": "a92bc3bd-5e5e-5ba8-99ad-df458d684196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9438c0-080b-4541-bfb7-6214be694584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9438c0-080b-4541-bfb7-6214be694584.jpg?1",
             "name": "Frondland Felidar",
             "text": "",
             "colours": [
@@ -11972,7 +11972,7 @@
         },
         {
             "id": "8d1f2aab-ce6d-5648-bcc9-e58ad973a45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6eb6b97-8b87-4565-940a-01a7fd79a989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6eb6b97-8b87-4565-940a-01a7fd79a989.jpg?1",
             "name": "General Kudro of Drannith",
             "text": "",
             "colours": [
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "46b52728-b5f5-5016-8ac1-b1be8c36584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51e3a2-c188-4212-8cc0-ef2d4722cb84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51e3a2-c188-4212-8cc0-ef2d4722cb84.jpg?1",
             "name": "Genesis Ultimatum",
             "text": "",
             "colours": [
@@ -12051,7 +12051,7 @@
         },
         {
             "id": "11af04cd-381e-5d18-8623-737141fdc849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e96967-d694-4c26-8e10-d904e1e64c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e96967-d694-4c26-8e10-d904e1e64c09.jpg?1",
             "name": "Inspired Ultimatum",
             "text": "",
             "colours": [
@@ -12089,7 +12089,7 @@
         },
         {
             "id": "aa39adc4-e9d7-5cb9-a78b-5e81a2a370e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532746e2-f822-4920-ab31-94e0c8baaa84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532746e2-f822-4920-ab31-94e0c8baaa84.jpg?1",
             "name": "Kinnan, Bonder Prodigy",
             "text": "",
             "colours": [
@@ -12130,7 +12130,7 @@
         },
         {
             "id": "8bb7f287-f17d-5eaa-a17a-4095006e4553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4a7b3-9eb3-4f96-b151-8b1c4c85118b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b4a7b3-9eb3-4f96-b151-8b1c4c85118b.jpg?1",
             "name": "Labyrinth Raptor",
             "text": "",
             "colours": [
@@ -12169,7 +12169,7 @@
         },
         {
             "id": "a04cb183-8792-5c92-aa38-80cbffd6640f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd7462d-0dfb-4f3f-96c4-43c281f0beb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd7462d-0dfb-4f3f-96c4-43c281f0beb5.jpg?1",
             "name": "Offspring's Revenge",
             "text": "",
             "colours": [
@@ -12207,7 +12207,7 @@
         },
         {
             "id": "15fe057d-e982-58ae-9bce-7d66b7a8159c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e1effa-92a6-4e8c-9cd6-fc57ae7b3cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e1effa-92a6-4e8c-9cd6-fc57ae7b3cbf.jpg?1",
             "name": "Quartzwood Crasher",
             "text": "",
             "colours": [
@@ -12246,7 +12246,7 @@
         },
         {
             "id": "f3415317-1bc3-5924-8039-262847510a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbe5ae7-5c50-476f-9022-cfb61ced107b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cbe5ae7-5c50-476f-9022-cfb61ced107b.jpg?1",
             "name": "Rielle, the Everwise",
             "text": "",
             "colours": [
@@ -12287,7 +12287,7 @@
         },
         {
             "id": "b2d7e7f1-9bf9-5e77-ab24-9b70f64b96b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa531e0-a3e5-4b40-a824-354ed7a13fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa531e0-a3e5-4b40-a824-354ed7a13fd5.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "",
             "colours": [
@@ -12325,7 +12325,7 @@
         },
         {
             "id": "b57cc6aa-5901-5f71-8857-febc9dcd17e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b08d66-4168-433d-9655-08f64b72e2cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b08d66-4168-433d-9655-08f64b72e2cc.jpg?1",
             "name": "Skycat Sovereign",
             "text": "",
             "colours": [
@@ -12364,7 +12364,7 @@
         },
         {
             "id": "0f1d6363-a216-5c94-98f8-13bb56a657a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a641ad-4268-46c4-a5fb-c1515e52d648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a641ad-4268-46c4-a5fb-c1515e52d648.jpg?1",
             "name": "Slitherwisp",
             "text": "",
             "colours": [
@@ -12403,7 +12403,7 @@
         },
         {
             "id": "69eb66c2-2339-5024-936a-369df521209b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e98d2e6-8247-4915-928b-25d6e2efc908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e98d2e6-8247-4915-928b-25d6e2efc908.jpg?1",
             "name": "Song of Creation",
             "text": "",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "52963a7b-e488-5bbb-9256-2d64a69a3429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894502fb-1ec7-4520-90e5-5f97de1c9151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894502fb-1ec7-4520-90e5-5f97de1c9151.jpg?1",
             "name": "Titans' Nest",
             "text": "",
             "colours": [
@@ -12479,7 +12479,7 @@
         },
         {
             "id": "b1f420dc-cf58-571d-878b-984dee5f155d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c48195-074a-4236-a82d-603b5dd1aa66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c48195-074a-4236-a82d-603b5dd1aa66.jpg?1",
             "name": "Whirlwind of Thought",
             "text": "",
             "colours": [
@@ -12517,7 +12517,7 @@
         },
         {
             "id": "98ad6967-41e5-5b24-8e6e-b3c43cd5b11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c7d63-b07d-456d-95ca-d3c3f346715e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c7d63-b07d-456d-95ca-d3c3f346715e.jpg?1",
             "name": "Winota, Joiner of Forces",
             "text": "",
             "colours": [
@@ -12558,7 +12558,7 @@
         },
         {
             "id": "6c4f8edd-fd45-5471-a1dc-0b547b94c6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e706a-5506-4efd-a86b-2a25bb66a2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653e706a-5506-4efd-a86b-2a25bb66a2ae.jpg?1",
             "name": "Fiend Artisan",
             "text": "",
             "colours": [
@@ -12596,7 +12596,7 @@
         },
         {
             "id": "c852305e-6481-59c0-b540-5372cdaee0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d59bf12-f898-40ad-a8a9-2f31f733cf15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d59bf12-f898-40ad-a8a9-2f31f733cf15.jpg?1",
             "name": "Gyruda, Doom of Depths",
             "text": "",
             "colours": [
@@ -12638,7 +12638,7 @@
         },
         {
             "id": "ffc8293d-e340-5dd4-9005-67d9292d3f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592378-f9e7-4c50-8425-2105744aa85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5592378-f9e7-4c50-8425-2105744aa85c.jpg?1",
             "name": "Jegantha, the Wellspring",
             "text": "",
             "colours": [
@@ -12682,7 +12682,7 @@
         },
         {
             "id": "8b9dacbb-5ca7-5827-9472-d4c3c5125d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe646123-c399-4ead-96a9-f7b46215f9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe646123-c399-4ead-96a9-f7b46215f9d9.jpg?1",
             "name": "Kaheera, the Orphanguard",
             "text": "",
             "colours": [
@@ -12723,7 +12723,7 @@
         },
         {
             "id": "ba5e4137-7bbb-59de-a870-c25e15113687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1206f4fc-6ebf-4205-90d3-1cb3a9caaa82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1206f4fc-6ebf-4205-90d3-1cb3a9caaa82.jpg?1",
             "name": "Keruga, the Macrosage",
             "text": "",
             "colours": [
@@ -12764,7 +12764,7 @@
         },
         {
             "id": "e7bac34f-6ff3-5884-bb57-a6c5fda48119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c89beb2-3467-4be0-a066-919f54331942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c89beb2-3467-4be0-a066-919f54331942.jpg?1",
             "name": "Lurrus of the Dream-Den",
             "text": "",
             "colours": [
@@ -12805,7 +12805,7 @@
         },
         {
             "id": "7fa9d199-8e60-519a-b3b6-459c43f83229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c01a00-2128-4b6c-874f-a206eca3a756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c01a00-2128-4b6c-874f-a206eca3a756.jpg?1",
             "name": "Lutri, the Spellchaser",
             "text": "",
             "colours": [
@@ -12846,7 +12846,7 @@
         },
         {
             "id": "08b95ec1-e566-5108-8c79-775f9557b6ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8cf901-1452-4664-be10-0bacc5bef83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8cf901-1452-4664-be10-0bacc5bef83a.jpg?1",
             "name": "Obosh, the Preypiercer",
             "text": "",
             "colours": [
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "1c5f808b-2224-5beb-a8ef-e9720c0c99c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10576f29-1ab8-4157-b5a0-8ad94a1ff634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10576f29-1ab8-4157-b5a0-8ad94a1ff634.jpg?1",
             "name": "Umori, the Collector",
             "text": "",
             "colours": [
@@ -12927,7 +12927,7 @@
         },
         {
             "id": "4902cb6d-64cd-5c4c-8745-647a23a94d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b05368-1661-42de-9319-bbe987d27327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b05368-1661-42de-9319-bbe987d27327.jpg?1",
             "name": "Yorion, Sky Nomad",
             "text": "",
             "colours": [
@@ -12968,7 +12968,7 @@
         },
         {
             "id": "d28ba5df-a066-53bb-b9c4-53bddccc4748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7301bd-05db-436b-8a49-5840c4cb9995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7301bd-05db-436b-8a49-5840c4cb9995.jpg?1",
             "name": "Zirda, the Dawnwaker",
             "text": "",
             "colours": [
@@ -13009,7 +13009,7 @@
         },
         {
             "id": "3ba9d8e5-055d-5fc5-b1ec-6d2a5637819e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b4c21-342f-4b46-86bb-8e8f38659f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b4c21-342f-4b46-86bb-8e8f38659f82.jpg?1",
             "name": "Crystalline Giant",
             "text": "",
             "colours": [],
@@ -13043,7 +13043,7 @@
         },
         {
             "id": "6f54548f-4f36-5f32-b0cf-a43257050527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3b5f52-ce33-4e67-aca0-6d417fe7f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3b5f52-ce33-4e67-aca0-6d417fe7f5fa.jpg?1",
             "name": "The Ozolith",
             "text": "",
             "colours": [],
@@ -13075,7 +13075,7 @@
         },
         {
             "id": "0429fd9d-969f-59b6-bd87-0dfedbf8efdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a26d0b-cf19-4c3e-bc81-6ffdc21757fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a26d0b-cf19-4c3e-bc81-6ffdc21757fa.jpg?1",
             "name": "Bonders' Enclave",
             "text": "",
             "colours": [],
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "e498d8c9-6429-5948-9b7f-407bd3b89668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa8a7b-d886-4005-950d-bad589b6e03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faa8a7b-d886-4005-950d-bad589b6e03a.jpg?1",
             "name": "Colossification",
             "text": "",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "6ac4db46-e6de-59ea-9cc2-835f4c85ff99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b6981-0fd4-4f58-bba4-a7efd4c633d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0b6981-0fd4-4f58-bba4-a7efd4c633d0.jpg?1",
             "name": "Flourishing Fox",
             "text": "",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "45fd1ad0-0fc6-5f17-8212-74bb15f2a645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928b0234-fc62-4ab8-b257-3fddcc52376b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928b0234-fc62-4ab8-b257-3fddcc52376b.jpg?1",
             "name": "Heartless Act",
             "text": "",
             "colours": [
@@ -13212,7 +13212,7 @@
         },
         {
             "id": "0a3f4dca-d27c-5658-b875-fdc057b2930d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae39803e-e67a-4d1b-a3fe-2e255d502656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae39803e-e67a-4d1b-a3fe-2e255d502656.jpg?1",
             "name": "Forbidden Friendship",
             "text": "",
             "colours": [
@@ -13246,7 +13246,7 @@
         },
         {
             "id": "86a9a5bb-391f-5c14-8cdd-69b2835ad118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363428be-0f89-4de5-a804-93172da4d99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363428be-0f89-4de5-a804-93172da4d99f.jpg?1",
             "name": "Migration Path",
             "text": "",
             "colours": [
@@ -13280,7 +13280,7 @@
         },
         {
             "id": "70647cee-589b-5e81-9fc6-142f30ce95de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172db88-2208-47c4-8226-bc094fd04a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172db88-2208-47c4-8226-bc094fd04a9b.jpg?1",
             "name": "Sprite Dragon",
             "text": "",
             "colours": [
@@ -13320,7 +13320,7 @@
         },
         {
             "id": "9648c4a5-4e32-53d3-8332-95e8cdf2d69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f741e3-82d8-4842-8054-25e20a10dddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f741e3-82d8-4842-8054-25e20a10dddd.jpg?1",
             "name": "Huntmaster Liger",
             "text": "Mutate {2}{W}\nWhenever this creature mutates, other creatures you control get +X/+X until end of turn, where X is the number of times this creature has mutated.",
             "colours": [
@@ -13357,7 +13357,7 @@
         },
         {
             "id": "60a33c1a-8430-5be7-802f-e2ab5dd563f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d393cc4-0e6b-44fe-a74a-822c52678ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d393cc4-0e6b-44fe-a74a-822c52678ec9.jpg?1",
             "name": "Luminous Broodmoth",
             "text": "Flying\nWhenever a creature you control without flying dies, return it to the battlefield under its owner's control with a flying counter on it.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "3aa21396-8dcd-5f9a-9243-677182293d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60a4f8-cb75-42e9-8a33-347e0f4bb458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd60a4f8-cb75-42e9-8a33-347e0f4bb458.jpg?1",
             "name": "Pollywog Symbiote",
             "text": "Each creature spell you cast costs {1} less to cast if it has mutate.\nWhenever you cast a creature spell, if it has mutate, draw a card, then discard a card.",
             "colours": [
@@ -13430,7 +13430,7 @@
         },
         {
             "id": "5b62d7ac-440b-58f9-8086-a002d074cfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca7065e-88c1-44bb-ac68-e6e1df9e0726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca7065e-88c1-44bb-ac68-e6e1df9e0726.jpg?1",
             "name": "Void Beckoner",
             "text": "",
             "colours": [
@@ -13468,7 +13468,7 @@
         },
         {
             "id": "15c513ba-f3be-56b0-b991-bbde1ecf5b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ae88c2-1f9b-4515-9f2e-78e1dc5468b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ae88c2-1f9b-4515-9f2e-78e1dc5468b1.jpg?1",
             "name": "Void Beckoner",
             "text": "",
             "colours": [
@@ -13506,7 +13506,7 @@
         },
         {
             "id": "1a8426ed-5ac5-5715-9d28-9f0c41c12b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e93bf3-94e8-408c-94ba-e83796077548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e93bf3-94e8-408c-94ba-e83796077548.jpg?1",
             "name": "Everquill Phoenix",
             "text": "Mutate {3}{R}\nFlying\nWhenever this creature mutates, create a red artifact token named Feather with \"{1}, Sacrifice Feather: Return target Phoenix card from your graveyard to the battlefield tapped.\"",
             "colours": [
@@ -13543,7 +13543,7 @@
         },
         {
             "id": "ada1956b-bb99-5e73-b440-e6c320ba133a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6b4c7-4f18-4bea-b927-916c7bb987ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6b4c7-4f18-4bea-b927-916c7bb987ee.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "Trample, haste\nCycling {1}{R}\nWhen you cycle Yidaro, Wandering Monster, shuffle it into your library from your graveyard. If you've cycled a card named Yidaro, Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead.",
             "colours": [
@@ -13583,7 +13583,7 @@
         },
         {
             "id": "72af5eef-c83e-5498-b3ea-4245b9e4c376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c811c0d4-e2fc-45eb-8a76-b89c38a95536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c811c0d4-e2fc-45eb-8a76-b89c38a95536.jpg?1",
             "name": "Gemrazer",
             "text": "Mutate {1}{G}{G}\nReach, trample\nWhenever this creature mutates, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -13620,7 +13620,7 @@
         },
         {
             "id": "65a430c8-6201-5667-8606-0bd8512e0d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4817b86-d55a-4334-82ee-603f8c4b3e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4817b86-d55a-4334-82ee-603f8c4b3e93.jpg?1",
             "name": "Titanoth Rex",
             "text": "Trample\nCycling {1}{G}\nWhen you cycle Titanoth Rex, put a trample counter on target creature you control.",
             "colours": [
@@ -13657,7 +13657,7 @@
         },
         {
             "id": "a95d4adb-9fc8-5331-816e-a26c844e4195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf6ca85-0ef5-4104-b0e6-1137c4975579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf6ca85-0ef5-4104-b0e6-1137c4975579.jpg?1",
             "name": "Brokkos, Apex of Forever",
             "text": "Mutate {2}{UB}{G}{G}\nTrample\nYou may cast Brokkos, Apex of Forever from your graveyard using its mutate ability.",
             "colours": [
@@ -13702,7 +13702,7 @@
         },
         {
             "id": "824d322b-6117-5f32-a56a-5c67cb6a6baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb1fba6-8eb3-4338-9249-cec888c892dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb1fba6-8eb3-4338-9249-cec888c892dc.jpg?1",
             "name": "Illuna, Apex of Wishes",
             "text": "Mutate {3}{RG}{U}{U}\nFlying, trample\nWhenever this creature mutates, exile cards from the top of your library until you exile a nonland permanent card. Put that card onto the battlefield or into your hand.",
             "colours": [
@@ -13747,7 +13747,7 @@
         },
         {
             "id": "6f8ddb82-805d-573a-beca-5d8f369c8108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ebe73b-29d7-4a07-b7dc-a885dad61a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ebe73b-29d7-4a07-b7dc-a885dad61a88.jpg?1",
             "name": "Nethroi, Apex of Death",
             "text": "Mutate {4}{RW}{B}{B}\nDeathtouch, lifelink\nWhenever this creature mutates, return any number of target creature cards with total power 10 or less from your graveyard to the battlefield.",
             "colours": [
@@ -13792,7 +13792,7 @@
         },
         {
             "id": "277249ba-20b2-5f24-8439-828c86f81386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673d14b1-e93a-4594-b2c9-792696adb991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673d14b1-e93a-4594-b2c9-792696adb991.jpg?1",
             "name": "Snapdax, Apex of the Hunt",
             "text": "Mutate {2}{BR}{W}{W}\nDouble strike\nWhenever this creature mutates, it deals 4 damage to target creature or planeswalker an opponent controls and you gain 4 life.",
             "colours": [
@@ -13837,7 +13837,7 @@
         },
         {
             "id": "7a8fdc89-bdd8-5f81-8fe1-af8c5663907f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d3b231-d15d-4186-826c-452009cd5c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d3b231-d15d-4186-826c-452009cd5c5e.jpg?1",
             "name": "Sprite Dragon",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on Sprite Dragon.",
             "colours": [
@@ -13877,7 +13877,7 @@
         },
         {
             "id": "fe1607a2-4ffe-566c-a75f-dcbb6fa17b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3346674-43cf-4006-b829-bf824560f413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3346674-43cf-4006-b829-bf824560f413.jpg?1",
             "name": "Vadrok, Apex of Thunder",
             "text": "Mutate {1}{WU}{R}{R}\nFlying, first strike\nWhenever this creature mutates, you may cast target noncreature card with converted mana cost 3 or less from your graveyard without paying its mana cost.",
             "colours": [
@@ -13922,7 +13922,7 @@
         },
         {
             "id": "f4d96a33-af22-5177-92a8-c79537b530d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206739b3-9b6a-4855-a2c3-721879bdbfb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206739b3-9b6a-4855-a2c3-721879bdbfb7.jpg?1",
             "name": "Gyruda, Doom of Depths",
             "text": "Companion \u2014 Your starting deck contains only cards with even converted mana costs.\nWhen Gyruda enters the battlefield, each player puts the top four cards of their library into their graveyard. Put a creature card with an even converted mana cost from among those cards onto the battlefield under your control.",
             "colours": [
@@ -13964,7 +13964,7 @@
         },
         {
             "id": "5df3565b-ab85-5cc7-83c4-9cd3bb5674da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333b41d-e42c-4b12-be08-742eefb4e401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f333b41d-e42c-4b12-be08-742eefb4e401.jpg?1",
             "name": "Mysterious Egg",
             "text": "",
             "colours": [],
@@ -13996,7 +13996,7 @@
         },
         {
             "id": "fd9ff43c-fee9-5bdb-ab0a-d4c55f2178fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb53dbd-b35f-414a-9f99-d340ef9398dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb53dbd-b35f-414a-9f99-d340ef9398dc.jpg?1",
             "name": "Dirge Bat",
             "text": "",
             "colours": [
@@ -14033,7 +14033,7 @@
         },
         {
             "id": "f192bfef-50ef-535f-818e-b8a57f93a498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c2de2f-bb56-4713-861a-34523b331e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c2de2f-bb56-4713-861a-34523b331e26.jpg?1",
             "name": "Crystalline Giant",
             "text": "",
             "colours": [],
@@ -14067,7 +14067,7 @@
         },
         {
             "id": "720b698d-92f0-5cd9-b953-d8108b15e2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d754e09c-efc0-4536-9f2a-6bd7e2f860ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d754e09c-efc0-4536-9f2a-6bd7e2f860ab.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -14102,7 +14102,7 @@
         },
         {
             "id": "5507c5a3-2bd1-5db3-9db5-31a60cd2c7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816da759-e224-4960-b2b6-453cadc2faf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816da759-e224-4960-b2b6-453cadc2faf1.jpg?1",
             "name": "Cat Bird",
             "text": "",
             "colours": [
@@ -14138,7 +14138,7 @@
         },
         {
             "id": "26de75d4-7184-5138-b179-db16f1884a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de6d1e-e654-4f4a-8014-061ce69e540f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de6d1e-e654-4f4a-8014-061ce69e540f.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -14174,7 +14174,7 @@
         },
         {
             "id": "619dbf5b-bede-500d-b138-137233fa1b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9669b1-04bd-4620-9856-04ea0473ec57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9669b1-04bd-4620-9856-04ea0473ec57.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -14210,7 +14210,7 @@
         },
         {
             "id": "9fbf46e4-9f16-5f2f-a41c-55abad4ed523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e406949f-c629-48fa-9fb0-ba6191054d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e406949f-c629-48fa-9fb0-ba6191054d35.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -14246,7 +14246,7 @@
         },
         {
             "id": "d298041b-f7af-592d-b0ce-eeb017859086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17c7b2-180a-4bd1-9ab2-152f8f656dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17c7b2-180a-4bd1-9ab2-152f8f656dba.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -14281,7 +14281,7 @@
         },
         {
             "id": "0c16da93-98d7-5037-a250-30d1e5482f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d12226-6417-4b98-beb5-89a36c774141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d12226-6417-4b98-beb5-89a36c774141.jpg?1",
             "name": "Shark",
             "text": "",
             "colours": [
@@ -14316,7 +14316,7 @@
         },
         {
             "id": "94878ed5-7735-56d2-9946-ec24d08d7338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f918b740-1984-4090-8886-9e290a698b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f918b740-1984-4090-8886-9e290a698b95.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -14351,7 +14351,7 @@
         },
         {
             "id": "0ba68999-e73c-5667-84e4-7093a5671128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc7c63-5d13-4fd6-af9d-4a26c2bab8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc7c63-5d13-4fd6-af9d-4a26c2bab8e6.jpg?1",
             "name": "Feather",
             "text": "",
             "colours": [
@@ -14384,7 +14384,7 @@
         },
         {
             "id": "e532a629-e171-5745-a730-c6e5152d15f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c9241-9cba-4c99-85cc-7e74286d1dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c9241-9cba-4c99-85cc-7e74286d1dc1.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -14419,7 +14419,7 @@
         },
         {
             "id": "f1bed91d-6add-5945-ac41-be69ba306baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d447365-3aca-4996-9098-efcbe6f28f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d447365-3aca-4996-9098-efcbe6f28f57.jpg?1",
             "name": "Dinosaur Beast",
             "text": "",
             "colours": [
@@ -14455,7 +14455,7 @@
         },
         {
             "id": "8ce14edc-833b-5117-b87b-fbb30f5b094f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e573150-9f7e-4398-8997-aecb6057a020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e573150-9f7e-4398-8997-aecb6057a020.jpg?1",
             "name": "Narset of the Ancient Way Emblem",
             "text": "",
             "colours": [],
@@ -14483,7 +14483,7 @@
         },
         {
             "id": "502291fe-ef30-5ac4-8f22-f5037bc492a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b95e8bd-2686-4790-afeb-9b17d482f156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b95e8bd-2686-4790-afeb-9b17d482f156.jpg?1",
             "name": "Companion",
             "text": "",
             "colours": [],
@@ -14510,7 +14510,7 @@
         },
         {
             "id": "54864471-3b86-5b6f-ad6b-28239f7e5ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe8eefe-c9f8-43f7-a348-8afee8b0ec68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe8eefe-c9f8-43f7-a348-8afee8b0ec68.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],
@@ -14537,7 +14537,7 @@
         },
         {
             "id": "bad84a92-ad05-569f-8d74-9c8dd65b3a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff073ee-117f-4e86-aeb5-f970caff95fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff073ee-117f-4e86-aeb5-f970caff95fa.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/IMA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/IMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ee7d1427-ff03-5e2d-8afd-3b25b13c7b7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2904aaaa-cd25-4c05-9d57-4c5a951ac6d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2904aaaa-cd25-4c05-9d57-4c5a951ac6d9.jpg?1",
             "name": "Scion of Ugin",
             "text": "Flying",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "fc447e94-37b1-503f-a535-adb83277d966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2877ac-195b-4397-89bd-0bee3220b2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2877ac-195b-4397-89bd-0bee3220b2a4.jpg?1",
             "name": "Abzan Battle Priest",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has lifelink.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "363cd6b7-0413-582a-961c-b75bffe9d8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c06621d-a0c9-4c84-8b1a-cb0abd8390c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c06621d-a0c9-4c84-8b1a-cb0abd8390c4.jpg?1",
             "name": "Abzan Falconer",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "5e34e263-cfe7-5a5e-88ab-a11d7b1a610a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32c514-36b9-4e1f-86e8-1d36e5282062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32c514-36b9-4e1f-86e8-1d36e5282062.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "4da7afe2-d883-507e-9b92-78d0c5e4f1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d0c32-1b7d-4c91-8675-2543c97a3753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d0c32-1b7d-4c91-8675-2543c97a3753.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f46a4fbd-ad07-5483-9766-c6a85245584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19caada3-7548-44d4-bf3f-680f7d3fa7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19caada3-7548-44d4-bf3f-680f7d3fa7b8.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy enters the battlefield, you gain 3 life.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "2feb2bb4-a064-5976-91d3-dfdd84503704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e8190-15fd-44ed-a821-9a5f3615d2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349e8190-15fd-44ed-a821-9a5f3615d2d9.jpg?1",
             "name": "Angelic Accord",
             "text": "At the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "770409d7-ea90-5896-9bd4-0c68e26f4fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff10db6-f9bf-4fc8-b3ef-c4c11f192f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff10db6-f9bf-4fc8-b3ef-c4c11f192f53.jpg?1",
             "name": "Archangel of Thune",
             "text": "Flying, lifelink\nWhenever you gain life, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "610c24d1-772a-5c49-8460-7ca3bccc326e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b769c1-48a0-448b-98d9-0d86526ef51e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b769c1-48a0-448b-98d9-0d86526ef51e.jpg?1",
             "name": "Auriok Champion",
             "text": "Protection from black and from red\nWhenever another creature enters the battlefield, you may gain 1 life.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "d1004636-96b0-5bff-b60d-600efaa03101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef16a71-5ed2-4f30-a844-c02a0754f679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef16a71-5ed2-4f30-a844-c02a0754f679.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with converted mana cost 3 or less.\n\u2022 Destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "43afb785-fd4b-56bc-8716-063c95441b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb92ef6-0ef8-4b1d-8a45-3064fea23926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb92ef6-0ef8-4b1d-8a45-3064fea23926.jpg?1",
             "name": "Avacyn, Angel of Hope",
             "text": "Flying, vigilance, indestructible\nOther permanents you control have indestructible.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "cbba1a83-c4bb-570f-9693-01181d29483a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf59723-fa84-40e3-b63e-b735addfdb43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf59723-fa84-40e3-b63e-b735addfdb43.jpg?1",
             "name": "Benevolent Ancestor",
             "text": "Defender\n{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "00b2f49b-2f4c-5772-905f-145a52cce877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173675c1-685c-4f4c-a6dc-b42a3ae69137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173675c1-685c-4f4c-a6dc-b42a3ae69137.jpg?1",
             "name": "Blinding Mage",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "f0069b21-9445-5691-8358-73a8b14ef440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd31ae-f252-449b-9d79-749a9a255763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd31ae-f252-449b-9d79-749a9a255763.jpg?1",
             "name": "Burrenton Forge-Tender",
             "text": "Protection from red\nSacrifice Burrenton Forge-Tender: Prevent all damage a red source of your choice would deal this turn.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "0122dacc-4b11-5911-bce0-b9b22f476db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfcbc11-bf1a-438b-9c66-0928cea6d297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfcbc11-bf1a-438b-9c66-0928cea6d297.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "76839172-bb45-5d0e-800a-87dca37db93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbfd61b-fba3-4826-817a-e0eed7b8eda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbfd61b-fba3-4826-817a-e0eed7b8eda0.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -549,7 +549,7 @@
         },
         {
             "id": "efd1dac9-246f-50d9-8efb-15d7ab207de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1244c95-a066-412d-bd04-c906ea4b4dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1244c95-a066-412d-bd04-c906ea4b4dd0.jpg?1",
             "name": "Dragon Bell Monk",
             "text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "394b774b-49f2-5f20-8ac8-bcb4f2ed2eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c2bfef-06a5-4c7f-8283-ea3fb673b7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c2bfef-06a5-4c7f-8283-ea3fb673b7a1.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "Vigilance\nOther creatures you control get +2/+2.\nCreatures your opponents control get -2/-2.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "0d568b51-dccc-5167-8b06-05450327b488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d016f166-183e-4d9e-9292-9bfb1ca0d72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d016f166-183e-4d9e-9292-9bfb1ca0d72b.jpg?1",
             "name": "Emerge Unscathed",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "dc539eeb-dbd6-58f9-9afc-aa9593e69382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ba1fa-3ace-488b-97e6-d9f3b389c602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47ba1fa-3ace-488b-97e6-d9f3b389c602.jpg?1",
             "name": "Emeria Angel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "10815618-3c1e-5303-b4a6-45a4c31f3553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc449dc-60c7-4b78-9a73-afa1de64a41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc449dc-60c7-4b78-9a73-afa1de64a41e.jpg?1",
             "name": "Great Teacher's Decree",
             "text": "Creatures you control get +2/+1 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "fbf5789b-dca0-5ec9-8978-81b826215b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584687fd-59e1-46cb-aca2-3104349407d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584687fd-59e1-46cb-aca2-3104349407d9.jpg?1",
             "name": "Guard Duty",
             "text": "Enchant creature\nEnchanted creature has defender.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "ea007a5d-11a8-599a-99ec-e3a5b2c7f12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9696feed-e8e3-434d-b155-1f5734966b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9696feed-e8e3-434d-b155-1f5734966b49.jpg?1",
             "name": "Guided Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "a29674fe-c919-55fe-873a-8cfe6ba7379a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4b0fd0-045d-4a96-9a57-c7ba1548b4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4b0fd0-045d-4a96-9a57-c7ba1548b4cd.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "2d1c020d-14f8-5741-9ede-ac6401831929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad15a-82c8-4cdd-84e7-02ef66fd0d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad15a-82c8-4cdd-84e7-02ef66fd0d19.jpg?1",
             "name": "Iona's Judgment",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "afec5425-e5d6-5765-a45b-8139e4e5c946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760f7e0a-51bc-417b-9f69-38a9f2d2c78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760f7e0a-51bc-417b-9f69-38a9f2d2c78f.jpg?1",
             "name": "Path of Bravery",
             "text": "As long as your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "49ba997e-8d63-5849-aec0-09c22537dc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455d6d8-f116-46b5-9e6d-615b752b8455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455d6d8-f116-46b5-9e6d-615b752b8455.jpg?1",
             "name": "Pentarch Ward",
             "text": "Enchant creature\nAs Pentarch Ward enters the battlefield, choose a color.\nWhen Pentarch Ward enters the battlefield, draw a card.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Pentarch Ward.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "3ce6cbc0-c25d-525b-b3ab-a654a0679efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5233ff-03bc-4053-9b49-c4185c2de38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5233ff-03bc-4053-9b49-c4185c2de38d.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "50fd60ef-afd9-5df8-8636-326472fc45ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d7aafb-969f-4a39-9af3-125f7f5c99f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d7aafb-969f-4a39-9af3-125f7f5c99f3.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "cc3580e4-0a41-5afa-a74f-28f6c7432b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd88ba4-4b2a-479c-9ff8-e02092afe9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd88ba4-4b2a-479c-9ff8-e02092afe9de.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "3beb5c78-8b36-558c-9a7c-3b64be174941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a22ee47-fc56-436d-8570-88fbff421027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a22ee47-fc56-436d-8570-88fbff421027.jpg?1",
             "name": "Serra Ascendant",
             "text": "Lifelink\nAs long as you have 30 or more life, Serra Ascendant gets +5/+5 and has flying.",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "8dcbc896-f46a-55fd-bf36-b05b7b8fafc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4248b993-87c6-42a8-b800-75d958805440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4248b993-87c6-42a8-b800-75d958805440.jpg?1",
             "name": "Stalwart Aven",
             "text": "Flying\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "923b4237-fb71-58e0-b460-a71b3869c2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df49884b-9e12-488c-8381-ec543349b97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df49884b-9e12-488c-8381-ec543349b97b.jpg?1",
             "name": "Student of Ojutai",
             "text": "Whenever you cast a noncreature spell, you gain 2 life.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "eb5a8c87-0608-5bc3-9cb2-d9969d6bfa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b8d1e-a144-432e-b3ac-63c37be55191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b8d1e-a144-432e-b3ac-63c37be55191.jpg?1",
             "name": "Survival Cache",
             "text": "You gain 2 life. Then if you have more life than an opponent, draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "f11b8a78-47fc-59f4-9c19-b89694f7b039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7e21e-d4d8-4d6c-9530-b17d5204e9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f7e21e-d4d8-4d6c-9530-b17d5204e9e7.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "Flying\nWhenever Sustainer of the Realm blocks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "4de36700-b684-5e69-a81c-b7f545d5f579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0ae49-8aca-44fe-abea-2cff92a6adbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0ae49-8aca-44fe-abea-2cff92a6adbc.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "33490b70-2f28-5db1-abb4-f8c70b2544f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e953224-6ea0-4580-b2a2-c1ff133fb991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e953224-6ea0-4580-b2a2-c1ff133fb991.jpg?1",
             "name": "Topan Freeblade",
             "text": "Vigilance\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "755c3598-7293-52e1-99b7-57488c81073a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ebbf-e3a5-406a-941d-ca7ade992d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed7ebbf-e3a5-406a-941d-ca7ade992d64.jpg?1",
             "name": "Wing Shards",
             "text": "Target player sacrifices an attacking creature.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "74ad56c6-d604-5ac0-9710-85f0a8f63a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47af956c-e2ba-47c5-bc5d-ec0ab345ce57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47af956c-e2ba-47c5-bc5d-ec0ab345ce57.jpg?1",
             "name": "Yosei, the Morning Star",
             "text": "Flying\nWhen Yosei, the Morning Star dies, target player skips his or her next untap step. Tap up to five target permanents that player controls.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "fe17e926-146e-5fe5-b6c5-658918497812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8dc68c-da77-4ba4-a0a0-d00b93904932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8dc68c-da77-4ba4-a0a0-d00b93904932.jpg?1",
             "name": "Aetherize",
             "text": "Return all attacking creatures to their owner's hand.",
             "colours": [
@@ -1360,7 +1360,7 @@
         },
         {
             "id": "c2cad87f-b77e-54be-9cd2-9ffbd87e1416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36521a7-8997-45da-aaa6-dd70d5c4e7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36521a7-8997-45da-aaa6-dd70d5c4e7f4.jpg?1",
             "name": "Amass the Components",
             "text": "Draw three cards, then put a card from your hand on the bottom of your library.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "29b56bcc-337a-58e5-aea1-db29989194a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dc736d-7e61-4909-973f-61f7adb82b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dc736d-7e61-4909-973f-61f7adb82b64.jpg?1",
             "name": "Ancestral Vision",
             "text": "Suspend 4\u2014{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "a4ba5759-8f8a-53dc-917c-7ffb82fab0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ad45e5-8a80-4a6c-b9da-36d5f778ca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ad45e5-8a80-4a6c-b9da-36d5f778ca51.jpg?1",
             "name": "Bewilder",
             "text": "Target creature gets -3/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1456,7 +1456,7 @@
         },
         {
             "id": "b499e19f-85bc-54dd-a02f-c4931c01b25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b435ee-82cc-41df-a09f-cf3602e31c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b435ee-82cc-41df-a09f-cf3602e31c23.jpg?1",
             "name": "Cephalid Broker",
             "text": "{T}: Target player draws two cards, then discards two cards.",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "328ee5af-d4a3-5b93-b2ac-edd34ab9217c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4bc422-2378-4be8-8d81-ac4c30fcce9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4bc422-2378-4be8-8d81-ac4c30fcce9a.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "ebd8bf85-e1ab-5ae4-8e00-3899194359f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba16c0f-dd42-4a2a-8f08-bc8c8478952b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba16c0f-dd42-4a2a-8f08-bc8c8478952b.jpg?1",
             "name": "Condescend",
             "text": "Counter target spell unless its controller pays {X}. Scry 2.",
             "colours": [
@@ -1556,7 +1556,7 @@
         },
         {
             "id": "c5833736-7615-53ee-b642-58ce113be50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030e46a1-64a7-47e3-9b9f-82a22fe3734b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030e46a1-64a7-47e3-9b9f-82a22fe3734b.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "a51aea16-7c5f-58de-998c-ca4ceca1a398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6fca9-003b-4f6b-9d6e-1e88adda4155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6fca9-003b-4f6b-9d6e-1e88adda4155.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Counter target spell.\n\u2022 Return target permanent to its owner's hand.\n\u2022 Tap all creatures your opponents control.\n\u2022 Draw a card.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "68b44134-0027-54f3-8e91-0a98f734b26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d702a9-efdc-4e88-afe1-451f3a5b3ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d702a9-efdc-4e88-afe1-451f3a5b3ebb.jpg?1",
             "name": "Day of the Dragons",
             "text": "When Day of the Dragons enters the battlefield, exile all creatures you control. Then create that many 5/5 red Dragon creature tokens with flying.\nWhen Day of the Dragons leaves the battlefield, sacrifice all Dragons you control. Then return the exiled cards to the battlefield under your control.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "57608f24-7b0e-5613-bd72-1b68be51c3b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d468111-f7af-4ea2-a250-cd8c15ba60cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d468111-f7af-4ea2-a250-cd8c15ba60cc.jpg?1",
             "name": "Diminish",
             "text": "Target creature has base power and toughness 1/1 until end of turn.",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "e93e81d3-440e-5f4f-aaed-979dfdc81dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb87ab-8595-459a-a5f2-087296d9b120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fb87ab-8595-459a-a5f2-087296d9b120.jpg?1",
             "name": "Dissolve",
             "text": "Counter target spell. Scry 1.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "ba53b2cd-082d-5d8a-a4bf-553ba4d90478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57556595-8ede-4a35-b3a4-0e6f8bfc4d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57556595-8ede-4a35-b3a4-0e6f8bfc4d9d.jpg?1",
             "name": "Distortion Strike",
             "text": "Target creature gets +1/+0 until end of turn and can't be blocked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "6a410259-3a20-54d3-8c18-7115316ccb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca527a9e-3a01-4e0b-add4-a6882f1c89d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca527a9e-3a01-4e0b-add4-a6882f1c89d1.jpg?1",
             "name": "Doorkeeper",
             "text": "Defender\n{2}{U}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of creatures with defender you control.",
             "colours": [
@@ -1784,7 +1784,7 @@
         },
         {
             "id": "c9b7c3e9-9889-5d10-a22b-05a5c123cd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac94901-f4ec-4888-82ef-87fd2b20cf11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac94901-f4ec-4888-82ef-87fd2b20cf11.jpg?1",
             "name": "Elusive Spellfist",
             "text": "Whenever you cast a noncreature spell, Elusive Spellfist gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "7363e17a-f74b-58a4-b17f-8b480bc71936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f900eeb7-7c45-44bc-ad3a-0bbe594ecf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f900eeb7-7c45-44bc-ad3a-0bbe594ecf50.jpg?1",
             "name": "Flusterstorm",
             "text": "Counter target instant or sorcery spell unless its controller pays {1}.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "20776bf6-9812-5ec7-bae8-9b7adbe7dce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f234849-42c7-4862-aee1-863a77eeacb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f234849-42c7-4862-aee1-863a77eeacb7.jpg?1",
             "name": "Fog Bank",
             "text": "Defender, flying\nPrevent all combat damage that would be dealt to and dealt by Fog Bank.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "7058bf1b-93fa-5e60-8547-7a5aabb6466d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce19a8d-ab1b-415a-ab55-c402c78da5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce19a8d-ab1b-415a-ab55-c402c78da5f0.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "fa6b9fb5-b580-54fd-95e4-2c171774745f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d5a82-3089-403a-8a27-5e4d53d793f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d5a82-3089-403a-8a27-5e4d53d793f0.jpg?1",
             "name": "Illusory Ambusher",
             "text": "Flash\nWhenever Illusory Ambusher is dealt damage, draw that many cards.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "1361f4d0-afac-5b7a-9c2f-bed3e9504be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a88a855-827c-4b08-bc1c-2c8f7cf92660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a88a855-827c-4b08-bc1c-2c8f7cf92660.jpg?1",
             "name": "Illusory Angel",
             "text": "Flying\nCast Illusory Angel only if you've cast another spell this turn.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "7e5d5a58-0cea-59f3-9173-d2e36f222c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a1803-552e-4eb4-b48c-04b359acb14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a1803-552e-4eb4-b48c-04b359acb14a.jpg?1",
             "name": "Jace's Phantasm",
             "text": "Flying\nJace's Phantasm gets +4/+4 as long as an opponent has ten or more cards in his or her graveyard.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "150204e7-8b5e-5224-aa63-3749889ced7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1227fb31-2780-48e2-9790-4a7e9a413f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1227fb31-2780-48e2-9790-4a7e9a413f75.jpg?1",
             "name": "Jhessian Thief",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jhessian Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "b0a94e61-889f-5265-8a18-ca1271694239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a360b6-c7b4-4b25-8288-b3bb8d527bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a360b6-c7b4-4b25-8288-b3bb8d527bda.jpg?1",
             "name": "Jin-Gitaxias, Core Augur",
             "text": "Flash\nAt the beginning of your end step, draw seven cards.\nEach opponent's maximum hand size is reduced by seven.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "8a215c21-cf5e-5d85-baf0-6461a5ee2360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040f57ef-cea4-4935-9207-b3108e175ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040f57ef-cea4-4935-9207-b3108e175ed5.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star dies, gain control of target creature.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "e7ae7655-e573-54c7-97de-d21202c58c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707b0ace-6826-4a07-a9fb-ac06cb96398c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707b0ace-6826-4a07-a9fb-ac06cb96398c.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "916d15ce-1bbf-57cd-b4d8-fc05458160e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416d2d51-8f29-4e95-b037-e8c32b081e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416d2d51-8f29-4e95-b037-e8c32b081e6c.jpg?1",
             "name": "Mana Drain",
             "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} to your mana pool equal to that spell's converted mana cost.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "3c05be88-9a60-5955-90b9-af78b8cf3467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247939d9-87e9-4f01-b223-fb4cfa7dbbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247939d9-87e9-4f01-b223-fb4cfa7dbbe1.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "8bc13470-a121-5523-bb51-3c398c51a774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e6784b-78e8-4f0b-8d27-d49c7cea9252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e6784b-78e8-4f0b-8d27-d49c7cea9252.jpg?1",
             "name": "Mnemonic Wall",
             "text": "Defender\nWhen Mnemonic Wall enters the battlefield, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2265,7 +2265,7 @@
         },
         {
             "id": "97c8de76-97e9-5a98-ad12-cc1fe7d87984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428c4985-95de-4703-9cda-7762d7fee04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428c4985-95de-4703-9cda-7762d7fee04f.jpg?1",
             "name": "Ojutai's Breath",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2297,7 +2297,7 @@
         },
         {
             "id": "6261ba76-8c2b-5c1f-bca3-a71b13ba547c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cddd47-8c2b-47de-bf82-e810d4cf4df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cddd47-8c2b-47de-bf82-e810d4cf4df4.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "ea4abe77-cabb-51bb-948b-b44ebb44f228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8ccab7-cc10-4fe8-a302-25d7518f4823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8ccab7-cc10-4fe8-a302-25d7518f4823.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2363,7 +2363,7 @@
         },
         {
             "id": "ee1c1fe2-fde7-5d69-8b8e-f82daf45ae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1d59d6-7f53-4139-b2f2-3189f24bdc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1d59d6-7f53-4139-b2f2-3189f24bdc84.jpg?1",
             "name": "Riverwheel Aerialists",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "1cdbb7f8-27a3-5977-8d5a-2e5ea5168979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b08b1-d9a3-4f18-a5ef-0f46698ac7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b08b1-d9a3-4f18-a5ef-0f46698ac7ed.jpg?1",
             "name": "Shriekgeist",
             "text": "Flying\nWhenever Shriekgeist deals combat damage to a player, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2432,7 +2432,7 @@
         },
         {
             "id": "d0e4e6da-6884-530a-9613-1a30efa34725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ba092-abc0-49ba-b756-6cb714165fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ba092-abc0-49ba-b756-6cb714165fec.jpg?1",
             "name": "Skywise Teachings",
             "text": "Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, create a 2/2 blue Djinn Monk creature token with flying.",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "c549ab52-45f1-57a5-9f78-95cd2a8292eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616676e6-8751-4dfd-a722-be644979dd48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616676e6-8751-4dfd-a722-be644979dd48.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "1db955b3-a78f-5ab7-b350-c2c4d77b78ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19573a69-5022-4d63-9252-c8789602d051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19573a69-5022-4d63-9252-c8789602d051.jpg?1",
             "name": "Teferi, Mage of Zhalfir",
             "text": "Flash\nCreature cards you own that aren't on the battlefield have flash.\nEach opponent can cast spells only any time he or she could cast a sorcery.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "cd22f5a4-a9d9-5654-adbb-ccd1665e315e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d32e59-54e7-4be0-99b7-261cd433bd03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d32e59-54e7-4be0-99b7-261cd433bd03.jpg?1",
             "name": "Thought Scour",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard.\nDraw a card.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "ec0b41de-f985-50b6-b41f-0636ef6b25c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cf802-2d66-49a4-bf43-ab3bc30ab825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cf802-2d66-49a4-bf43-ab3bc30ab825.jpg?1",
             "name": "Windfall",
             "text": "Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way.",
             "colours": [
@@ -2599,7 +2599,7 @@
         },
         {
             "id": "91fe5adc-b3f5-50a0-9e28-dc021a4203f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b9f27-459c-4585-9051-b83ffe053a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2b9f27-459c-4585-9051-b83ffe053a74.jpg?1",
             "name": "Abyssal Persecutor",
             "text": "Flying, trample\nYou can't win the game and your opponents can't lose the game.",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "ea6f36c2-a795-51bd-b871-e178aecc378c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6234dca-088f-4888-98d3-0d5a50eb5e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6234dca-088f-4888-98d3-0d5a50eb5e61.jpg?1",
             "name": "Bala Ged Scorpion",
             "text": "When Bala Ged Scorpion enters the battlefield, you may destroy target creature with power 1 or less.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "219f367a-cb98-567a-8d4b-cd3f7421556f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d295ef8c-fe8f-49f2-8588-7f5782315fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d295ef8c-fe8f-49f2-8588-7f5782315fc7.jpg?1",
             "name": "Balustrade Spy",
             "text": "Flying\nWhen Balustrade Spy enters the battlefield, target player reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2702,7 +2702,7 @@
         },
         {
             "id": "354f5f66-ca93-5222-a062-e020372031a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63d3d8-5699-4577-a908-4415bc96b404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d63d3d8-5699-4577-a908-4415bc96b404.jpg?1",
             "name": "Bladewing's Thrall",
             "text": "Bladewing's Thrall has flying as long as you control a Dragon.\nWhen a Dragon enters the battlefield, you may return Bladewing's Thrall from your graveyard to the battlefield.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "fb5049b0-b52b-54ef-85a6-bee6e815386b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730c521f-ba12-48fb-b18f-6bb55423a551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730c521f-ba12-48fb-b18f-6bb55423a551.jpg?1",
             "name": "Bloodghast",
             "text": "Bloodghast can't block.\nBloodghast has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may return Bloodghast from your graveyard to the battlefield.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "5ea0f728-c00c-5315-ba8c-6e983a4ef7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d57d94-0507-49b0-84fc-a84b885d355d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d57d94-0507-49b0-84fc-a84b885d355d.jpg?1",
             "name": "Bogbrew Witch",
             "text": "{2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "4af16209-f626-5fe2-b588-956958c523e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a00c8d-9dac-4edc-b66c-ab3245d80969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a00c8d-9dac-4edc-b66c-ab3245d80969.jpg?1",
             "name": "Butcher's Glee",
             "text": "Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "006a38e6-eba7-5a0a-b24b-be7bf351f9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6124cc-1106-4cf6-8499-26fff83a9611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6124cc-1106-4cf6-8499-26fff83a9611.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "d630dd0f-1267-5f1e-823c-924cc8685b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e52f38-2991-429a-a312-a02696c86b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e52f38-2991-429a-a312-a02696c86b05.jpg?1",
             "name": "Dead Reveler",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "eea83330-4fc0-53bd-9af4-20c14a5f5612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90699423-2556-40f7-b8f5-c9d82f22d52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90699423-2556-40f7-b8f5-c9d82f22d52e.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "7008e4b3-c543-530a-a382-9aa3cd36ae7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02eba7-f9ef-418d-9c8e-6e7d2bd3869d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02eba7-f9ef-418d-9c8e-6e7d2bd3869d.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "64ebaa90-b83d-58c2-a94c-411acafa8f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ab1802-1756-44cf-8cf5-ca69f24875f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ab1802-1756-44cf-8cf5-ca69f24875f2.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "5fb53a0a-8b27-5e64-9078-ac5a57e29564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05764968-0abe-4a6f-9f8a-066a4d484571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05764968-0abe-4a6f-9f8a-066a4d484571.jpg?1",
             "name": "Festering Newt",
             "text": "When Festering Newt dies, target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "f9576a0f-7f00-58f4-b255-46af0d3c98cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b77ed75-05d4-4eb3-8c19-dada6b8bb116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b77ed75-05d4-4eb3-8c19-dada6b8bb116.jpg?1",
             "name": "Foul-Tongue Invocation",
             "text": "As an additional cost to cast Foul-Tongue Invocation, you may reveal a Dragon card from your hand.\nTarget player sacrifices a creature. If you revealed a Dragon card or controlled a Dragon as you cast Foul-Tongue Invocation, you gain 4 life.",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "a5a88363-de22-5a13-9e91-92028d084da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce3816e-0f81-40b6-a592-ba2c65243c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce3816e-0f81-40b6-a592-ba2c65243c6d.jpg?1",
             "name": "Grisly Spectacle",
             "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "6b6be42d-e842-5f78-a564-d3cbb77c20a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be041f3-482d-40f3-a525-39e3d6890c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be041f3-482d-40f3-a525-39e3d6890c56.jpg?1",
             "name": "Haunting Hymn",
             "text": "Target player discards two cards. If you cast this spell during your main phase, that player discards four cards instead.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "2d51993e-22e0-5bbc-865b-5ee909ed3b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af042ca9-c57d-4477-965e-182fc557ca6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af042ca9-c57d-4477-965e-182fc557ca6b.jpg?1",
             "name": "Indulgent Tormentor",
             "text": "Flying\nAt the beginning of your upkeep, draw a card unless target opponent sacrifices a creature or pays 3 life.",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "b997771b-6c7c-5d79-a13d-5a4b0d6972b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab56cedb-1bcd-48a5-8503-a8e324e236ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab56cedb-1bcd-48a5-8503-a8e324e236ad.jpg?1",
             "name": "Kokusho, the Evening Star",
             "text": "Flying\nWhen Kokusho, the Evening Star dies, each opponent loses 5 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "df47cae6-8594-57d7-973f-8f65c54a3369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b626ab2-4cf6-42e8-a7e2-9c9f310d2f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b626ab2-4cf6-42e8-a7e2-9c9f310d2f00.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature other than Lord of the Pit. If you can't, Lord of the Pit deals 7 damage to you.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "8cbaaef7-c12b-592e-a4f3-3abab04476af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f32c-d188-4a36-98a4-584b6ef95902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f32c-d188-4a36-98a4-584b6ef95902.jpg?1",
             "name": "Mer-Ek Nightblade",
             "text": "Outlast {B} ({B}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has deathtouch.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "3eba331c-856f-5c6a-89a6-416ee37f4616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1",
             "name": "Necropotence",
             "text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "adf1907e-c3b0-5c60-8020-af85662ee5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42c5234-7395-4c9f-a885-8b63cf02c5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42c5234-7395-4c9f-a885-8b63cf02c5e8.jpg?1",
             "name": "Night of Souls' Betrayal",
             "text": "All creatures get -1/-1.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "a7dbfdc1-239c-5779-916b-af4c227eff3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a6facd-0b7f-436d-9529-bf9c931cd492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a6facd-0b7f-436d-9529-bf9c931cd492.jpg?1",
             "name": "Noxious Dragon",
             "text": "Flying\nWhen Noxious Dragon dies, you may destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "cbd981ba-7d0d-5c1a-9e18-74780cab8b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5769888-78e0-4d06-b6b6-b4602f7cd462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5769888-78e0-4d06-b6b6-b4602f7cd462.jpg?1",
             "name": "Ob Nixilis, the Fallen",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have target player lose 3 life. If you do, put three +1/+1 counters on Ob Nixilis, the Fallen.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "95036636-509b-5382-ae2d-f8a5832edd70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8253166-0bf4-4d50-bea3-516a9f60b039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8253166-0bf4-4d50-bea3-516a9f60b039.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "965b0512-51cb-56a7-a1c2-d231b16718b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f619f3-37aa-4f37-9df6-f455c0800f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f619f3-37aa-4f37-9df6-f455c0800f87.jpg?1",
             "name": "Rakdos Drake",
             "text": "Flying\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "3429a010-889b-5db0-8744-712e94dba1ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018ae45-64b8-4e65-8949-586d62b97132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018ae45-64b8-4e65-8949-586d62b97132.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -3511,7 +3511,7 @@
         },
         {
             "id": "f4004310-741b-5ffc-b96e-cdb3f6f189f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857631-8cd5-424f-b93e-d3e98a929988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf857631-8cd5-424f-b93e-d3e98a929988.jpg?1",
             "name": "Rotfeaster Maggot",
             "text": "When Rotfeaster Maggot enters the battlefield, exile target creature card from a graveyard. You gain life equal to that card's toughness.",
             "colours": [
@@ -3545,7 +3545,7 @@
         },
         {
             "id": "09263bc9-fd4b-5170-92ef-dc6a5733c300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ed184c-bb2a-47cc-a8e3-ba46b2fc4f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ed184c-bb2a-47cc-a8e3-ba46b2fc4f64.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "4d1afc71-6bd5-5c36-88a3-d445b7fa8132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc236d85-dfe5-4bc8-b116-8306b0922abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc236d85-dfe5-4bc8-b116-8306b0922abf.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "8c2f6201-1543-52f9-a26a-3b8164b01887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd672c9-46ae-4d2b-93d9-16271d2f71ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd672c9-46ae-4d2b-93d9-16271d2f71ff.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "Swampwalk\nAt the beginning of your upkeep, return target creature card from your graveyard to the battlefield.\nAt the beginning of each opponent's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "a09a07fc-adaf-538f-a109-6234e7e8027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86557e1-6960-42a2-8d18-baafc22fbb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86557e1-6960-42a2-8d18-baafc22fbb90.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "bfb6439a-52c9-5eb9-a543-afb9af8a9b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1c46-8331-4a09-9fcb-d942f8102364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1c46-8331-4a09-9fcb-d942f8102364.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "5e87e8ed-1a41-5063-9bab-32e79ca17631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23915972-2009-4363-a791-24be90a4fbe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23915972-2009-4363-a791-24be90a4fbe0.jpg?1",
             "name": "Thrill-Kill Assassin",
             "text": "Deathtouch\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "31a8856b-717c-514a-b4ae-f89ba3f5e948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78ab496-a19f-4c70-a56c-09a512d40c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78ab496-a19f-4c70-a56c-09a512d40c87.jpg?1",
             "name": "Ulcerate",
             "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
             "colours": [
@@ -3782,7 +3782,7 @@
         },
         {
             "id": "99466d84-9471-5724-a592-4d1c109591f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d6ca74-70f5-44c6-82f7-dae8980bdd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d6ca74-70f5-44c6-82f7-dae8980bdd44.jpg?1",
             "name": "Virulent Swipe",
             "text": "Target creature gets +2/+0 and gains deathtouch until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -3814,7 +3814,7 @@
         },
         {
             "id": "6446c0ab-cc72-59b3-a380-c22b6e2317d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8698868-2aff-4973-8fc6-e2ac7202384d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8698868-2aff-4973-8fc6-e2ac7202384d.jpg?1",
             "name": "Wight of Precinct Six",
             "text": "Wight of Precinct Six gets +1/+1 for each creature card in your opponents' graveyards.",
             "colours": [
@@ -3848,7 +3848,7 @@
         },
         {
             "id": "3413f32a-9953-580f-9bf5-5c6d25c3570d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360a6ada-b257-44b8-b830-aaa122474bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360a6ada-b257-44b8-b830-aaa122474bce.jpg?1",
             "name": "Wrench Mind",
             "text": "Target player discards two cards unless he or she discards an artifact card.",
             "colours": [
@@ -3880,7 +3880,7 @@
         },
         {
             "id": "8fc6df75-ddd9-57b8-8df4-c2c6916684a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ecae08-bcc6-4074-822c-3dfe1d46ae39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ecae08-bcc6-4074-822c-3dfe1d46ae39.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "5c049347-1731-56d7-a0d1-aee3c6cb6855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccbfd3f-da15-46aa-9ffc-b6bfdf9d1d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccbfd3f-da15-46aa-9ffc-b6bfdf9d1d91.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "2d76d5fa-4975-5950-b25e-37cfe3faaac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99ee7b4-7a9b-4ccf-830b-adf203e2fe7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99ee7b4-7a9b-4ccf-830b-adf203e2fe7f.jpg?1",
             "name": "Bogardan Hellkite",
             "text": "Flash\nFlying\nWhen Bogardan Hellkite enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "ecf568ce-69fd-57dc-b32c-aa03fd6c11c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93bd9ae-a514-44f0-91b9-8889c1039555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93bd9ae-a514-44f0-91b9-8889c1039555.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "ad0b53de-e58e-557e-9598-02ca7a605444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2f3a3-7f5f-4ddf-aadb-9ddfe0a9197c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e2f3a3-7f5f-4ddf-aadb-9ddfe0a9197c.jpg?1",
             "name": "Charmbreaker Devils",
             "text": "At the beginning of your upkeep, return an instant or sorcery card at random from your graveyard to your hand.\nWhenever you cast an instant or sorcery spell, Charmbreaker Devils gets +4/+0 until end of turn.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "ec3dec6e-744b-5b86-8cce-f89e51b09df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08654c6-9073-4c37-b23d-02136248cf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08654c6-9073-4c37-b23d-02136248cf37.jpg?1",
             "name": "Coordinated Assault",
             "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "045a4000-75e9-5956-9c9c-19b594e9721e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a6f4dd-29c9-4084-a622-098b197a6eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a6f4dd-29c9-4084-a622-098b197a6eb7.jpg?1",
             "name": "Crucible of Fire",
             "text": "Dragon creatures you control get +3/+3.",
             "colours": [
@@ -4114,7 +4114,7 @@
         },
         {
             "id": "b38f158d-05c4-53cb-88d9-1eae6560af4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c57c26-500b-4ca2-9c47-f2a0e31975b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c57c26-500b-4ca2-9c47-f2a0e31975b3.jpg?1",
             "name": "Draconic Roar",
             "text": "As an additional cost to cast Draconic Roar, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast Draconic Roar, Draconic Roar deals 3 damage to that creature's controller.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "b8d6c839-2cfc-541f-a48c-72b7384d85ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9fb609-3df9-42e9-b15e-39d18661526a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9fb609-3df9-42e9-b15e-39d18661526a.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4181,7 +4181,7 @@
         },
         {
             "id": "2469fcfb-c4c6-5157-974b-52ecfeadb806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1933d08-07fe-45ea-9b60-d9afb98d5753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1933d08-07fe-45ea-9b60-d9afb98d5753.jpg?1",
             "name": "Dragon Tempest",
             "text": "Whenever a creature with flying enters the battlefield under your control, it gains haste until end of turn.\nWhenever a Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.",
             "colours": [
@@ -4213,7 +4213,7 @@
         },
         {
             "id": "998dc952-b4f9-5ef4-b85b-95b93da983e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e387494-a184-49f8-bbf6-37dce964e702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e387494-a184-49f8-bbf6-37dce964e702.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "06e40daa-7ce9-586c-adf7-f58fe93b792f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67562b9-7f07-4bfd-b049-6216cbcb1cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67562b9-7f07-4bfd-b049-6216cbcb1cd2.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "c00057a6-1cc1-5753-b694-1e2a09685270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7220aaa0-c457-4067-b1ff-360b161c34e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7220aaa0-c457-4067-b1ff-360b161c34e5.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "3055acc3-ceab-5187-8398-0cc0770e681c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267597a-bbfe-4fb7-91b7-7fee371f0dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1267597a-bbfe-4fb7-91b7-7fee371f0dfd.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "bb86d9b1-794b-5c26-94ce-7bbfddbeae53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d585cf04-b823-49c1-a33a-9cd8f3116eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d585cf04-b823-49c1-a33a-9cd8f3116eda.jpg?1",
             "name": "Fury Charm",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target creature gets +1/+1 and gains trample until end of turn.\n\u2022 Remove two time counters from target permanent or suspended card.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "4c4926c4-4ec6-56f2-8c74-24cd8de67732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9923ad-67a3-4d2a-be67-3b8063e2f3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9923ad-67a3-4d2a-be67-3b8063e2f3b3.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "3eb68c53-4cb2-5aaf-9d33-88f9a7821fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f980def6-9a87-4948-9d02-956d568a95fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f980def6-9a87-4948-9d02-956d568a95fe.jpg?1",
             "name": "Hammerhand",
             "text": "Enchant creature\nWhen Hammerhand enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "9c83694d-a891-569e-b58f-c4687d1cc935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59a9859-c50a-4dc5-aae2-56fcafb1792d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59a9859-c50a-4dc5-aae2-56fcafb1792d.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "43fc2b80-9f04-5de9-b765-d4a43ad6ce1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cd59a-f184-4e8e-885e-36fbceddfc06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cd59a-f184-4e8e-885e-36fbceddfc06.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle your library.\nWhen Hoarding Dragon dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -4515,7 +4515,7 @@
         },
         {
             "id": "2a47e451-f719-5e62-83d2-3ef5e57e4385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed95d07-5a9b-4fd9-85ff-9860f6a492d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ed95d07-5a9b-4fd9-85ff-9860f6a492d0.jpg?1",
             "name": "Keldon Halberdier",
             "text": "First strike\nSuspend 4\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "5615514f-e5d0-5ff9-acbc-0b95da651c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ff0ee3-9600-4c7d-acec-6ec90595384e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ff0ee3-9600-4c7d-acec-6ec90595384e.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Create a token that's a copy of target nonlegendary creature you control. That token has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "bec536b9-3fe5-50ae-a4a9-5f29540491ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89e7c4-7864-4031-a9e5-38b5d47290ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89e7c4-7864-4031-a9e5-38b5d47290ff.jpg?1",
             "name": "Kiln Fiend",
             "text": "Whenever you cast an instant or sorcery spell, Kiln Fiend gets +3/+0 until end of turn.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "7221a224-b29f-58e5-ac5a-990ab5fa2184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f685078-c9b3-42aa-be5a-be16be89ecc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f685078-c9b3-42aa-be5a-be16be89ecc6.jpg?1",
             "name": "Magus of the Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "2ed72dc6-8943-5c5d-9b99-d827c6a015d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8882153-ad51-4bef-91bd-275a46688320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8882153-ad51-4bef-91bd-275a46688320.jpg?1",
             "name": "Mark of Mutiny",
             "text": "Gain control of target creature until end of turn. Put a +1/+1 counter on it and untap it. That creature gains haste until end of turn.",
             "colours": [
@@ -4689,7 +4689,7 @@
         },
         {
             "id": "2be739f0-348c-5a0b-9649-432b0b573941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58db2f81-6ff5-402c-8aef-0b667e82cdc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58db2f81-6ff5-402c-8aef-0b667e82cdc4.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4724,7 +4724,7 @@
         },
         {
             "id": "89831bc4-79e6-5618-b916-94c07f66b52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16b001f-dffd-4e7c-a7ab-daa00221bfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16b001f-dffd-4e7c-a7ab-daa00221bfbf.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "fd3a8347-4cf1-5a69-817c-98ac4d7ddeae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf1c10f-b1f7-480e-8e8b-f98c26fe9b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf1c10f-b1f7-480e-8e8b-f98c26fe9b4b.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "df108e80-69ea-56b1-aef5-1bed6e2d08b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98895a-bfc3-4b0b-a8a6-2c202f6edf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98895a-bfc3-4b0b-a8a6-2c202f6edf0d.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to target creature or player.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "db37a632-442c-51a7-a825-99f10ee64e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e62328-fe29-4097-b45c-66cd62f93f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e62328-fe29-4097-b45c-66cd62f93f86.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "35731d41-bf4a-51a7-b0fb-a36a5409a18e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f59f13a-653d-4883-a18b-bc030c51e61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f59f13a-653d-4883-a18b-bc030c51e61e.jpg?1",
             "name": "Scourge of Valkas",
             "text": "Flying\nWhenever Scourge of Valkas or another Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.\n{R}: Scourge of Valkas gets +1/+0 until end of turn.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "b9c83afe-679c-5bcd-ba38-91b66558c34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80656711-0e36-4bf6-9ba2-ef4fbdfa433a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80656711-0e36-4bf6-9ba2-ef4fbdfa433a.jpg?1",
             "name": "Splatter Thug",
             "text": "First strike\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "9b5735d5-5c7d-5330-ba81-ff1aca5a4818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312ada22-0085-4103-b20d-a5bbfacb6ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312ada22-0085-4103-b20d-a5bbfacb6ec1.jpg?1",
             "name": "Staggershock",
             "text": "Staggershock deals 2 damage to target creature or player.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "0f9bc623-9fcc-5b4a-85e0-a9052314025f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681912e7-9dee-436f-a115-1701287f8a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681912e7-9dee-436f-a115-1701287f8a49.jpg?1",
             "name": "Surreal Memoir",
             "text": "Return an instant card at random from your graveyard to your hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "9f74c981-f478-5a64-af04-13fc8ba668e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75f6bb4-ab06-42ca-a0df-326d9a098a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75f6bb4-ab06-42ca-a0df-326d9a098a26.jpg?1",
             "name": "Thundermaw Hellkite",
             "text": "Flying, haste\nWhen Thundermaw Hellkite enters the battlefield, it deals 1 damage to each creature with flying your opponents control. Tap those creatures.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "05e75111-7491-53d3-ab91-2a122d959d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d373ce86-c92d-4d91-b3bb-739aba7d09a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d373ce86-c92d-4d91-b3bb-739aba7d09a1.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "110556d2-6f5d-5839-8801-b6da1a123f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a3e069-856a-4fe7-9357-56697fb665fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a3e069-856a-4fe7-9357-56697fb665fc.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5091,7 +5091,7 @@
         },
         {
             "id": "7b68c5d8-6b32-53bf-bf7d-7f2aa88a977b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba50b62-710e-4c92-9e02-736c1a987bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba50b62-710e-4c92-9e02-736c1a987bb9.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "Creatures you control have haste.\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "5350060b-b240-5360-8431-d46638cebbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6f563e-4f94-4caf-83b9-bfc64e18bc9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6f563e-4f94-4caf-83b9-bfc64e18bc9c.jpg?1",
             "name": "Vent Sentinel",
             "text": "Defender\n{1}{R}, {T}: Vent Sentinel deals damage to target player equal to the number of creatures with defender you control.",
             "colours": [
@@ -5162,7 +5162,7 @@
         },
         {
             "id": "661e985f-4b24-5908-9dbc-3a3b9450f506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b405858-83eb-4939-b86d-4ba190fca048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b405858-83eb-4939-b86d-4ba190fca048.jpg?1",
             "name": "Aerial Predation",
             "text": "Destroy target creature with flying. You gain 2 life.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "6e7e86be-c23e-5082-a172-e17bb9d6e890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72a45f-16e9-4040-acf1-927133ba198e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb72a45f-16e9-4040-acf1-927133ba198e.jpg?1",
             "name": "Assault Formation",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -5226,7 +5226,7 @@
         },
         {
             "id": "30267ddf-c87b-5c7c-b435-0e223e4c2922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbc15e-003b-4d8b-9840-d0d2f74f44c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbc15e-003b-4d8b-9840-d0d2f74f44c0.jpg?1",
             "name": "Carven Caryatid",
             "text": "Defender\nWhen Carven Caryatid enters the battlefield, draw a card.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "1a7f0997-6994-5513-8999-418adaba306d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce54c7c1-3401-4414-8da0-5846cb0ae1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce54c7c1-3401-4414-8da0-5846cb0ae1b4.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "e40aeaf0-f5f7-5d53-8757-0a73b15181d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc5264-e27e-4286-9feb-0dda0b074097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cfc5264-e27e-4286-9feb-0dda0b074097.jpg?1",
             "name": "Crowned Ceratok",
             "text": "Trample\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "3e419f27-f1f9-5b65-93ac-b0617de30fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf631ad-762f-4bec-9588-aca88507cad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf631ad-762f-4bec-9588-aca88507cad5.jpg?1",
             "name": "Curse of Predation",
             "text": "Enchant player\nWhenever a creature attacks enchanted player, put a +1/+1 counter on it.",
             "colours": [
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "16c94c7e-5d9c-567a-b9fe-e7fff0b1e008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df027117-9cb2-428f-b5ab-eb4491493fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df027117-9cb2-428f-b5ab-eb4491493fa3.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "a9f79770-5a98-5a63-bdb9-2520e7e2730c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6879321-9a61-4c4f-9513-81ad5684c99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6879321-9a61-4c4f-9513-81ad5684c99e.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample",
             "colours": [
@@ -5429,7 +5429,7 @@
         },
         {
             "id": "5634df34-59ef-5cd3-9e78-3624fbd8dd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f2e230-4c40-4e2a-a39e-81560122cd88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f2e230-4c40-4e2a-a39e-81560122cd88.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "1f6c3e16-0000-5a4d-b84f-441ac68ffc08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0118e-4449-4394-b4c1-5b4f83d7bc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f0118e-4449-4394-b4c1-5b4f83d7bc4a.jpg?1",
             "name": "Genesis Hydra",
             "text": "When you cast Genesis Hydra, reveal the top X cards of your library. You may put a nonland permanent card with converted mana cost X or less from among them onto the battlefield. Then shuffle the rest into your library.\nGenesis Hydra enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "bbe4bec3-68ef-5f20-a7c5-f4d597a132ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5007919b-27d3-46e7-a588-ce796709d565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5007919b-27d3-46e7-a588-ce796709d565.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "e8509fef-27d9-5bb7-90ab-822192b0956b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886e40d7-5677-493d-9ea4-205f50d2aefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886e40d7-5677-493d-9ea4-205f50d2aefe.jpg?1",
             "name": "Greater Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "2449e94e-2e01-5aae-9dc7-6f139336b9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f060ff2-d2cb-4203-85b8-ad531029575a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f060ff2-d2cb-4203-85b8-ad531029575a.jpg?1",
             "name": "Heroes' Bane",
             "text": "Heroes' Bane enters the battlefield with four +1/+1 counters on it.\n{2}{G}{G}: Put X +1/+1 counters on Heroes' Bane, where X is its power.",
             "colours": [
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "1c4a5a75-4dcf-58f8-bba8-8714540240ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f763a4-8a79-4056-8066-74899a0fb304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f763a4-8a79-4056-8066-74899a0fb304.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5628,7 +5628,7 @@
         },
         {
             "id": "f3d7129f-8363-5561-a3d5-8e59b2034fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06224230-d4cb-437d-87d5-956251c6f03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06224230-d4cb-437d-87d5-956251c6f03d.jpg?1",
             "name": "Hunting Pack",
             "text": "Create a 4/4 green Beast creature token.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "d8ee97ef-71a1-54e9-ac77-13bc33caa996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ed4a28-50b6-4349-82d2-165e6f08956e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ed4a28-50b6-4349-82d2-165e6f08956e.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn.",
             "colours": [
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "5165834a-c648-5819-b3f1-0dc43afc9ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704a2367-823f-4e40-8b3c-91115bb9b755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704a2367-823f-4e40-8b3c-91115bb9b755.jpg?1",
             "name": "Ivy Elemental",
             "text": "Ivy Elemental enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5726,7 +5726,7 @@
         },
         {
             "id": "ead5a52f-84fe-5624-b327-62a4546f3ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e69772-50b7-496e-a7b1-702f57a66d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e69772-50b7-496e-a7b1-702f57a66d64.jpg?1",
             "name": "Jaddi Offshoot",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "7944f8e1-71ea-5ea5-9782-c3ccd23e4f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d897caab-3720-4f1a-bf38-4ba266352567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d897caab-3720-4f1a-bf38-4ba266352567.jpg?1",
             "name": "Jugan, the Rising Star",
             "text": "Flying\nWhen Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "d2dedaa9-9713-5c98-ac1f-5611c350f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc160fd-e34f-46a1-9a38-5c51a49fe64e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc160fd-e34f-46a1-9a38-5c51a49fe64e.jpg?1",
             "name": "Lead the Stampede",
             "text": "Look at the top five cards of your library. You may reveal any number of creature cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "f8847b9d-b990-5b1f-ab15-b979fad936e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6365c6-bd12-4d02-a403-60d0c5290c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6365c6-bd12-4d02-a403-60d0c5290c06.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may add one mana of any color to your mana pool.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "1d2b38a3-55a1-5db2-83d6-adc6cdcde05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c8336d-54cf-45af-a9ef-a1428facf91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c8336d-54cf-45af-a9ef-a1428facf91b.jpg?1",
             "name": "Lure",
             "text": "Enchant creature\nAll creatures able to block enchanted creature do so.",
             "colours": [
@@ -5897,7 +5897,7 @@
         },
         {
             "id": "c59f1c2b-76c9-5fd9-8cc4-3525a51e1851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdfbff4-32fb-4228-a5ec-4bdeb8bb8e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdfbff4-32fb-4228-a5ec-4bdeb8bb8e70.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman enters the battlefield, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than cast this card from your hand, you may pay {2}{G}{G} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "5f6f49d1-1d16-5698-b9d5-0cbaacb391f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b6640-ef2f-4c92-beb3-afdf78f9c2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b6640-ef2f-4c92-beb3-afdf78f9c2d5.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -5964,7 +5964,7 @@
         },
         {
             "id": "7be8f82e-f02c-5503-8a9c-65c90d9a2105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bc55d3-dd1c-40da-9197-76cb1b5d29c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bc55d3-dd1c-40da-9197-76cb1b5d29c2.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "165f861a-01b6-5952-834a-3e08441f8346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d12669-ca08-4a3c-b30f-15168b75abe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d12669-ca08-4a3c-b30f-15168b75abe4.jpg?1",
             "name": "Obstinate Baloth",
             "text": "When Obstinate Baloth enters the battlefield, you gain 4 life.\nIf a spell or ability an opponent controls causes you to discard Obstinate Baloth, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "e0d3f715-4530-5a3f-9914-afa4a6f255d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43ea5d8-d7b7-4518-b37c-32668e4fd5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c43ea5d8-d7b7-4518-b37c-32668e4fd5d4.jpg?1",
             "name": "Overgrown Battlement",
             "text": "Defender\n{T}: Add {G} to your mana pool for each creature with defender you control.",
             "colours": [
@@ -6066,7 +6066,7 @@
         },
         {
             "id": "44b4ed57-1d2c-5e36-a313-f2d73774405d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f8a506-04e4-4f6f-9f81-f31db562f7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f8a506-04e4-4f6f-9f81-f31db562f7c6.jpg?1",
             "name": "Phantom Tiger",
             "text": "Phantom Tiger enters the battlefield with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Tiger, prevent that damage. Remove a +1/+1 counter from Phantom Tiger.",
             "colours": [
@@ -6101,7 +6101,7 @@
         },
         {
             "id": "e7773706-622d-5236-9786-7ecacaa16f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7992e-494b-4b1b-bd5d-8f9bb19b275e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7992e-494b-4b1b-bd5d-8f9bb19b275e.jpg?1",
             "name": "Prey's Vengeance",
             "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "10753ea0-ab77-56bd-83f4-1d309402cec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5537da-112e-4679-a113-b5d7ce32a66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5537da-112e-4679-a113-b5d7ce32a66b.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "4ff8f18e-d3a0-5099-b560-bcaa94213fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5667d8e-c72e-478a-9e90-633d608b8c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5667d8e-c72e-478a-9e90-633d608b8c31.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "882b5b60-321b-529c-8699-0d2da20e9823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a950b3-5083-474a-8f56-fec7637cc402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a950b3-5083-474a-8f56-fec7637cc402.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -6233,7 +6233,7 @@
         },
         {
             "id": "21488745-e445-5f11-a458-c46adffbc2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50d74eb-07df-48b5-8788-8b5f5fc0b22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50d74eb-07df-48b5-8788-8b5f5fc0b22b.jpg?1",
             "name": "Sultai Flayer",
             "text": "Whenever a creature you control with toughness 4 or greater dies, you gain 4 life.",
             "colours": [
@@ -6268,7 +6268,7 @@
         },
         {
             "id": "33316a29-d7fa-535c-872c-301f2905dbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50965f7e-a4e2-41b7-8b81-4a2ffa9db123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50965f7e-a4e2-41b7-8b81-4a2ffa9db123.jpg?1",
             "name": "Timberland Guide",
             "text": "When Timberland Guide enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -6303,7 +6303,7 @@
         },
         {
             "id": "2aebe2d5-7bff-5273-8ec8-c135a9339a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe1ebf9-8378-444b-870a-5be12aa1f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe1ebf9-8378-444b-870a-5be12aa1f5fa.jpg?1",
             "name": "Undercity Troll",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{2}{G}: Regenerate Undercity Troll.",
             "colours": [
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "55520b71-3a90-5333-9634-a93c7b91d095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe3af8c-109d-486c-aa34-3f023abda5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe3af8c-109d-486c-aa34-3f023abda5b7.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "Trample\nWhenever you tap a land for mana, add one mana to your mana pool of any type that land produced.\nWhenever an opponent taps a land for mana, that land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "ff944f8f-fdcb-5a2e-985b-cc3583223610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65cb901-bfb0-454a-97ef-138021e524ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65cb901-bfb0-454a-97ef-138021e524ff.jpg?1",
             "name": "Wall of Roots",
             "text": "Defender\nPut a -0/-1 counter on Wall of Roots: Add {G} to your mana pool. Activate this ability only once each turn.",
             "colours": [
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "e3fd21bc-2982-56c6-9775-d4d747ff0095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b80bc77-eee4-4384-904a-b746be5987ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b80bc77-eee4-4384-904a-b746be5987ac.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "4d268678-6b7a-530e-b3a6-6eb132728e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9740ceaf-4ef9-48dd-ab7d-cd5eb3be8cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9740ceaf-4ef9-48dd-ab7d-cd5eb3be8cec.jpg?1",
             "name": "Azorius Charm",
             "text": "Choose one \u2014\n\u2022 Creatures you control gain lifelink until end of turn.\n\u2022 Draw a card.\n\u2022 Put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "fe335f04-3b8f-516f-8c38-2a7906f756d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce43cb-44f4-4d94-8700-d9f3cc043989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce43cb-44f4-4d94-8700-d9f3cc043989.jpg?1",
             "name": "Bladewing the Risen",
             "text": "Flying\nWhen Bladewing the Risen enters the battlefield, you may return target Dragon permanent card from your graveyard to the battlefield.\n{B}{R}: Dragon creatures get +1/+1 until end of turn.",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "36248f46-9639-5085-878b-36322b86729c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0167df83-3bf4-4442-897d-c4ed06fa05a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0167df83-3bf4-4442-897d-c4ed06fa05a6.jpg?1",
             "name": "Blizzard Specter",
             "text": "Flying\nWhenever Blizzard Specter deals combat damage to a player, choose one \u2014\n\u2022 That player returns a permanent he or she controls to its owner's hand.\n\u2022 That player discards a card.",
             "colours": [
@@ -6552,7 +6552,7 @@
         },
         {
             "id": "0256edf3-a8de-52b6-a571-62396989e056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56955e63-db6f-4f1d-b3c4-dd268c902653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56955e63-db6f-4f1d-b3c4-dd268c902653.jpg?1",
             "name": "Blood Baron of Vizkopa",
             "text": "Lifelink, protection from white and from black\nAs long as you have 30 or more life and an opponent has 10 or less life, Blood Baron of Vizkopa gets +6/+6 and has flying.",
             "colours": [
@@ -6588,7 +6588,7 @@
         },
         {
             "id": "0922d44c-1f86-5328-a6b2-4c33c6f82d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4d6cc-bbd1-471e-888b-33e20a96ce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d4d6cc-bbd1-471e-888b-33e20a96ce60.jpg?1",
             "name": "Chronicler of Heroes",
             "text": "When Chronicler of Heroes enters the battlefield, draw a card if you control a creature with a +1/+1 counter on it.",
             "colours": [
@@ -6625,7 +6625,7 @@
         },
         {
             "id": "9e324151-fbd8-59e0-8c4b-d8f874ce8239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74fbb14-d7ad-47ff-9171-37ed0fc2acff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74fbb14-d7ad-47ff-9171-37ed0fc2acff.jpg?1",
             "name": "Corpsejack Menace",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on it instead.",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "c9b1530b-7d91-5f74-a8ae-382480e6c9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112af09-1305-4e00-8273-403eac40786f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112af09-1305-4e00-8273-403eac40786f.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "19a589fd-fca1-5c4b-b2e5-5fca23bdc2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16384575-d0bc-4826-966e-a4bf6ae6ab97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16384575-d0bc-4826-966e-a4bf6ae6ab97.jpg?1",
             "name": "Firemane Angel",
             "text": "Flying, first strike\nAt the beginning of your upkeep, if Firemane Angel is in your graveyard or on the battlefield, you may gain 1 life.\n{6}{R}{R}{W}{W}: Return Firemane Angel from your graveyard to the battlefield. Activate this ability only during your upkeep.",
             "colours": [
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "6cf6586d-f193-5686-9e69-388d187e7e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afde7ce-b0d7-4ac0-947b-ae298a61c37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afde7ce-b0d7-4ac0-947b-ae298a61c37b.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player puts the top ten cards of his or her library into his or her graveyard.",
             "colours": [
@@ -6765,7 +6765,7 @@
         },
         {
             "id": "1f6488a5-3c3c-58ff-afb2-8b3363aa743e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99dc07bf-7c55-442b-9260-5ea74a42af41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99dc07bf-7c55-442b-9260-5ea74a42af41.jpg?1",
             "name": "Hypersonic Dragon",
             "text": "Flying, haste\nYou may cast sorcery spells as though they had flash.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "7623d88d-602c-5feb-9167-eea9cdd7d5c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8097e6e-c04e-4266-a8f4-07e5fb0638d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8097e6e-c04e-4266-a8f4-07e5fb0638d4.jpg?1",
             "name": "Jungle Barrier",
             "text": "Defender\nWhen Jungle Barrier enters the battlefield, draw a card.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "9b872a91-9bad-51c1-b0c2-82d4c1a92c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205df311-a72d-40f1-b2ea-9b30274bc9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205df311-a72d-40f1-b2ea-9b30274bc9bd.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "7668caf0-7ee0-54a1-996c-df75e8c3ca15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7053b773-a369-45b8-912f-ee66de3a63c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7053b773-a369-45b8-912f-ee66de3a63c6.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "38c0af39-8839-5dc4-a1b0-25e22bbe9de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010a4b07-c2d5-433e-9898-6e148104e9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010a4b07-c2d5-433e-9898-6e148104e9e0.jpg?1",
             "name": "Malfegor",
             "text": "Flying\nWhen Malfegor enters the battlefield, discard your hand. Each opponent sacrifices a creature for each card discarded this way.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "0c1a2bac-c9cd-5e30-8959-09ca1d50f752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472efa7f-203f-4c48-b9ad-505e18f2976f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472efa7f-203f-4c48-b9ad-505e18f2976f.jpg?1",
             "name": "Rosheen Meanderer",
             "text": "{T}: Add {C}{C}{C}{C} to your mana pool. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -6987,7 +6987,7 @@
         },
         {
             "id": "5eef1e9e-d910-5acf-b4e5-f8d647dea13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a2043-d8e1-42e4-bbd4-0e6163ecd91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a2043-d8e1-42e4-bbd4-0e6163ecd91f.jpg?1",
             "name": "Savageborn Hydra",
             "text": "Double strike\nSavageborn Hydra enters the battlefield with X +1/+1 counters on it.\n{1}{RG}: Put a +1/+1 counter on Savageborn Hydra. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "de92be69-7e40-513f-bddd-c58bdaca2176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18816df-9b73-4a3f-a1d5-ceabf76d3fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18816df-9b73-4a3f-a1d5-ceabf76d3fb0.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -7059,7 +7059,7 @@
         },
         {
             "id": "f3eda7dd-5468-5dbe-bb72-9e32a02885f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c2ce16-840b-4971-b4cc-89c8cdc5b093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c2ce16-840b-4971-b4cc-89c8cdc5b093.jpg?1",
             "name": "Spiritmonger",
             "text": "Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.\n{B}: Regenerate Spiritmonger.\n{G}: Spiritmonger becomes the color of your choice until end of turn.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "6c4528f2-6b15-5a8e-b827-a5e33460a3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a679cc74-6119-468f-8c64-5dcf216438d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a679cc74-6119-468f-8c64-5dcf216438d1.jpg?1",
             "name": "Supreme Verdict",
             "text": "Supreme Verdict can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "c19afd60-9a58-582a-931d-08154bbea6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdce9d1-a163-40e1-a70a-1f09cf400a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdce9d1-a163-40e1-a70a-1f09cf400a6c.jpg?1",
             "name": "Vizkopa Guildmage",
             "text": "{1}{W}{B}: Target creature gains lifelink until end of turn.\n{1}{W}{B}: Whenever you gain life this turn, each opponent loses that much life.",
             "colours": [
@@ -7166,7 +7166,7 @@
         },
         {
             "id": "effa7a1c-5b96-50e5-8308-bc8a1b5d5893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14cdc38-dd46-495e-93bd-d2694b64d5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14cdc38-dd46-495e-93bd-d2694b64d5ad.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on Aether Vial from your hand onto the battlefield.",
             "colours": [],
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "9ce99de8-bbd0-5043-9670-7f69ec41c1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9262dc-2b12-49c8-b339-4394694c81d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9262dc-2b12-49c8-b339-4394694c81d7.jpg?1",
             "name": "Bubbling Cauldron",
             "text": "{1}, {T}, Sacrifice a creature: You gain 4 life.\n{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.",
             "colours": [],
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "fa51b456-075b-5bdb-8148-59f07a6f4b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091da355-a253-443b-ad97-1908bd1a40ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091da355-a253-443b-ad97-1908bd1a40ab.jpg?1",
             "name": "Darksteel Axe",
             "text": "Indestructible\nEquipped creature gets +2/+0.\nEquip {2}",
             "colours": [],
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "6b1f6f5b-e98e-5376-a987-06f1ff7ef638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdff68c-ad98-48b0-9e00-8c5032a3cdb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdff68c-ad98-48b0-9e00-8c5032a3cdb1.jpg?1",
             "name": "Dragonloft Idol",
             "text": "As long as you control a Dragon, Dragonloft Idol gets +1/+1 and has flying and trample.",
             "colours": [],
@@ -7283,7 +7283,7 @@
         },
         {
             "id": "df473eeb-3575-5be1-bfda-4970bab3d046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75ea55-294f-40d5-b155-448fe363466a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db75ea55-294f-40d5-b155-448fe363466a.jpg?1",
             "name": "Guardian Idol",
             "text": "Guardian Idol enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}: Guardian Idol becomes a 2/2 Golem artifact creature until end of turn.",
             "colours": [],
@@ -7311,7 +7311,7 @@
         },
         {
             "id": "1c53959c-79ed-5b38-82fa-e92608fea71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efb210e-00a9-470e-ac30-4036a7befd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efb210e-00a9-470e-ac30-4036a7befd4c.jpg?1",
             "name": "Kolaghan Monument",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{4}{B}{R}: Kolaghan Monument becomes a 4/4 black and red Dragon artifact creature with flying until end of turn.",
             "colours": [],
@@ -7342,7 +7342,7 @@
         },
         {
             "id": "31f30861-89e1-5a4b-b193-2894fe0f511f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f91e78e-9297-4ae3-b55f-d73e79d0d21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f91e78e-9297-4ae3-b55f-d73e79d0d21a.jpg?1",
             "name": "Manakin",
             "text": "{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -7373,7 +7373,7 @@
         },
         {
             "id": "2ea8ec31-3f12-50db-bd7f-a53a809a1cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54814f1-3598-4859-b956-b39d8335e6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54814f1-3598-4859-b956-b39d8335e6d3.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "b5e9ebe8-3086-5bf7-93a7-8123046b795b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679a847-7196-4a45-8610-229aa2e124d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2679a847-7196-4a45-8610-229aa2e124d6.jpg?1",
             "name": "Mindcrank",
             "text": "Whenever an opponent loses life, that player puts that many cards from the top of his or her library into his or her graveyard. (Damage causes loss of life.)",
             "colours": [],
@@ -7429,7 +7429,7 @@
         },
         {
             "id": "c9e0717e-efe4-5615-b1da-6dec83f0a9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbe32c7-180f-4b9e-b260-0ff1d9017e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbe32c7-180f-4b9e-b260-0ff1d9017e28.jpg?1",
             "name": "Mishra's Bauble",
             "text": "{T}, Sacrifice Mishra's Bauble: Look at the top card of target player's library. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [],
@@ -7457,7 +7457,7 @@
         },
         {
             "id": "8c2b2d7c-0285-51bd-a9eb-433090686e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d016c5f-265b-4426-8dd8-87872f075f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d016c5f-265b-4426-8dd8-87872f075f33.jpg?1",
             "name": "Moonglove Extract",
             "text": "Sacrifice Moonglove Extract: It deals 2 damage to target creature or player.",
             "colours": [],
@@ -7485,7 +7485,7 @@
         },
         {
             "id": "d6c9378c-7bd7-580f-9f23-346780810ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5876108-ffaa-4690-9dba-20f43aea29fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5876108-ffaa-4690-9dba-20f43aea29fe.jpg?1",
             "name": "Oblivion Stone",
             "text": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice Oblivion Stone: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
             "colours": [],
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "94bce371-c6ad-5c82-bb45-adc8e028da9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086c355-596d-40f0-95e0-a52d710c5f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086c355-596d-40f0-95e0-a52d710c5f80.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {C}{C} to your mana pool.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "a79f7da0-8b00-5498-9c8c-f58c415359bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f59820b-462e-4023-8b00-d8b5fafe15a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f59820b-462e-4023-8b00-d8b5fafe15a3.jpg?1",
             "name": "Pristine Talisman",
             "text": "{T}: Add {C} to your mana pool. You gain 1 life.",
             "colours": [],
@@ -7572,7 +7572,7 @@
         },
         {
             "id": "c22a2453-5b8a-5d7d-b443-0c1250032859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876340a5-2dbd-44e2-bfd6-720f53b7115d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876340a5-2dbd-44e2-bfd6-720f53b7115d.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "2ee6b092-d6f7-598c-af67-a864c15d9d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e917fe-648c-4b26-ae9a-c3b1a8c55c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e917fe-648c-4b26-ae9a-c3b1a8c55c86.jpg?1",
             "name": "Sandstone Oracle",
             "text": "Flying\nWhen Sandstone Oracle enters the battlefield, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.",
             "colours": [],
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "f14e41a1-51d1-5fbc-b9f0-c5dbbbf73da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8753b80-aa9e-4f82-9a02-6b3997169dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8753b80-aa9e-4f82-9a02-6b3997169dbb.jpg?1",
             "name": "Serum Powder",
             "text": "{T}: Add {C} to your mana pool.\nAny time you could mulligan and Serum Powder is in your hand, you may exile all the cards from your hand, then draw that many cards. (You can do this in addition to taking mulligans.)",
             "colours": [],
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "e6c75b16-a101-52ce-ba6b-b742e03d442c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010712-7f42-4c55-9a63-aca2452aac05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010712-7f42-4c55-9a63-aca2452aac05.jpg?1",
             "name": "Star Compass",
             "text": "Star Compass enters the battlefield tapped.\n{T}: Add to your mana pool one mana of any color that a basic land you control could produce.",
             "colours": [],
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "073f6484-d2f3-558e-8a44-824196d4963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508a8735-642c-4f22-bbd9-4a189d93e7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508a8735-642c-4f22-bbd9-4a189d93e7b7.jpg?1",
             "name": "Thran Dynamo",
             "text": "{T}: Add {C}{C}{C} to your mana pool.",
             "colours": [],
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "d9caf228-a9c7-5bb6-bd87-53f6bec9f853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1bab36-3fb7-48f3-b3ed-90863d244641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b1bab36-3fb7-48f3-b3ed-90863d244641.jpg?1",
             "name": "Trepanation Blade",
             "text": "Whenever equipped creature attacks, defending player reveals cards from the top of his or her library until he or she reveals a land card. The creature gets +1/+0 until end of turn for each card revealed this way. That player puts the revealed cards into his or her graveyard.\nEquip {2}",
             "colours": [],
@@ -7748,7 +7748,7 @@
         },
         {
             "id": "55bf1e79-5055-5a35-9603-738e8dc164a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118fd026-3777-4ce4-bea9-6fdfa05e7110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118fd026-3777-4ce4-bea9-6fdfa05e7110.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -7779,7 +7779,7 @@
         },
         {
             "id": "2381da18-66df-5995-99db-bc0196db2d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a4cfa-e306-4024-8ece-8bf2c1d0cce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7a4cfa-e306-4024-8ece-8bf2c1d0cce8.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -7810,7 +7810,7 @@
         },
         {
             "id": "3d72b1e7-ad39-5de7-b31a-4dbef5f6f1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01a793a-e6ad-4778-b87d-cc0bbdd5846f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01a793a-e6ad-4778-b87d-cc0bbdd5846f.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "da99f8e5-72f0-5d60-a127-b7ab9512ddb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a2804d-d925-4950-8542-608f6e92387a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a2804d-d925-4950-8542-608f6e92387a.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -7869,7 +7869,7 @@
         },
         {
             "id": "44c4c3e3-6c66-5077-8e90-261b3b9e09f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501425e3-31ae-4d19-997c-33ad89733969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501425e3-31ae-4d19-997c-33ad89733969.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "53aa25ac-7206-57a6-9a15-163527ed42b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9140b-3886-4f4d-82f1-76144c5501c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf9140b-3886-4f4d-82f1-76144c5501c2.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {C} to your mana pool.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "63c7fabf-d6b9-57ab-be43-f6a9f85e962e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b75ad-7539-4184-a940-6014a0327b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b75ad-7539-4184-a940-6014a0327b3a.jpg?1",
             "name": "Grove of the Burnwillows",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Each opponent gains 1 life.",
             "colours": [],
@@ -7962,7 +7962,7 @@
         },
         {
             "id": "e6ab32e6-57f4-5407-8f0e-8f0e5928ecc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fcea4c-1fc4-4476-8b95-90134d7841e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fcea4c-1fc4-4476-8b95-90134d7841e7.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -7993,7 +7993,7 @@
         },
         {
             "id": "21375a3d-db0f-58d7-8371-885d53373ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f7c880-9bae-4d29-b7b6-b6be6b2ffa89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f7c880-9bae-4d29-b7b6-b6be6b2ffa89.jpg?1",
             "name": "Horizon Canopy",
             "text": "{T}, Pay 1 life: Add {G} or {W} to your mana pool.\n{1}, {T}, Sacrifice Horizon Canopy: Draw a card.",
             "colours": [],
@@ -8024,7 +8024,7 @@
         },
         {
             "id": "2fda16ef-2d24-52f5-bae4-ce8ceb3fe3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a1f12-0c2e-4c72-839d-ae13bffa1ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a1f12-0c2e-4c72-839d-ae13bffa1ef0.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "327291af-ef7b-5987-a0fa-0e61ae59ba50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152c6a1-7c78-483e-b13f-cb43a6bd4001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152c6a1-7c78-483e-b13f-cb43a6bd4001.jpg?1",
             "name": "Nimbus Maze",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add {W} to your mana pool. Activate this ability only if you control an Island.\n{T}: Add {U} to your mana pool. Activate this ability only if you control a Plains.",
             "colours": [],
@@ -8086,7 +8086,7 @@
         },
         {
             "id": "2e44168c-03c3-5c01-85e3-091a1331aa26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd942b9a-1802-41bb-a33a-344bfa353c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd942b9a-1802-41bb-a33a-344bfa353c47.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "5994fd26-0c8f-5f52-970d-128b4376d0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff618efc-ebea-476e-9c88-0383a5272aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff618efc-ebea-476e-9c88-0383a5272aae.jpg?1",
             "name": "Radiant Fountain",
             "text": "When Radiant Fountain enters the battlefield, you gain 2 life.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "02a9dc8c-7634-585c-9fae-19e16823ea52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25665f-6af2-46c8-b5f9-88e1caa8395c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25665f-6af2-46c8-b5f9-88e1caa8395c.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -8176,7 +8176,7 @@
         },
         {
             "id": "5032e4e4-018e-5aa2-bbed-9b1f867957ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8de9ac4-e03f-4d08-b836-83f461159bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8de9ac4-e03f-4d08-b836-83f461159bd3.jpg?1",
             "name": "River of Tears",
             "text": "{T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.",
             "colours": [],
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "a7283339-3881-537e-8fcd-cae62c096afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636539f-67f1-4fcd-ab0b-70c4a20bbdc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636539f-67f1-4fcd-ab0b-70c4a20bbdc4.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "7cb00676-9128-5dc1-a8ac-bdb0b56d9c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f2594-c6e8-4758-86b4-885d1dba3a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03f2594-c6e8-4758-86b4-885d1dba3a91.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8266,7 +8266,7 @@
         },
         {
             "id": "2156432f-72d3-5fc6-990d-032fab36af4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5101e712-2b4f-422b-ae80-6fd1a18c82ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5101e712-2b4f-422b-ae80-6fd1a18c82ec.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "f34494e6-8d2a-5361-a2c7-5c5a1ef80dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc88baf-217f-4b25-9945-75c33ae37dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc88baf-217f-4b25-9945-75c33ae37dc2.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "fd437463-78d9-5de9-812f-ec1bfd3ccebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1b1f2-f067-4c8a-b134-4567e4d5a7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1b1f2-f067-4c8a-b134-4567e4d5a7c6.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "aef0ca69-5e0e-5874-b13b-1b4c657a8c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcd7257-ca21-4847-802b-94e2957993c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcd7257-ca21-4847-802b-94e2957993c3.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "1d22fdd3-3211-52da-98ae-49971402c894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5e32a-b86b-4f8b-ae93-19f0b95c4514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b5e32a-b86b-4f8b-ae93-19f0b95c4514.jpg?1",
             "name": "Djinn Monk",
             "text": "",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "cb3aa9a9-4404-53ec-b965-b4c26b82b625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83e8599-49e0-4a70-b8a8-883af4b1b7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83e8599-49e0-4a70-b8a8-883af4b1b7bc.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "75f1aaaf-4e2a-5338-91b8-21c4ac47076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a341b61-c945-4ea1-89a3-217a97f98ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a341b61-c945-4ea1-89a3-217a97f98ae3.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "19e07859-3b54-5489-adb5-0f318c486276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e02247-42ad-4bbc-9c89-0265c3ad85db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e02247-42ad-4bbc-9c89-0265c3ad85db.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/INV.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/INV.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c4f9d9ad-7322-5398-82ed-dc66558cda8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b45d9-aba6-4c09-8605-037754ba7fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b45d9-aba6-4c09-8605-037754ba7fd4.jpg?1",
             "name": "Alabaster Leech",
             "text": "White spells you play cost o\nW more to play.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "c78b4058-dc49-57f4-9fbf-06812602f55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6de688-685f-4389-be35-a472ada988e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6de688-685f-4389-be35-a472ada988e1.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy comes into play, you gain 3 life.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "652edad7-0c26-5677-b2af-5b3c24eb9160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dce974-846f-4365-b0a5-851e38668e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dce974-846f-4365-b0a5-851e38668e7d.jpg?1",
             "name": "Ardent Soldier",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nAttacking doesn't cause Ardent Soldier to tap.\nIf you paid the kicker cost, Ardent Soldier comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "f9034461-a72c-5a84-8be1-c55c4e142631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90500e7a-f76d-453a-bda0-d56d3f7c7534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90500e7a-f76d-453a-bda0-d56d3f7c7534.jpg?1",
             "name": "Atalya, Samite Master",
             "text": "o\nX, oc\nT: Choose one Prevent the next X damage that would be dealt to target creature this turn; or you gain X life. Spend only white mana this way.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "d98108f4-a14a-516e-a240-9986c180204a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b82d56e-80d7-4be9-ac22-de3257efc458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b82d56e-80d7-4be9-ac22-de3257efc458.jpg?1",
             "name": "Benalish Emissary",
             "text": "Kicker o1o\nG (You may pay an additional o1o\nG as you play this spell.)\nWhen Benalish Emissary comes into play, if you paid the kicker cost, destroy target land.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "ddbd6700-07c1-5680-ae77-4837785adb3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6e51d-54eb-4e5b-9ec9-54521b16b8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6e51d-54eb-4e5b-9ec9-54521b16b8d1.jpg?1",
             "name": "Benalish Heralds",
             "text": "o3o\nU, oc\nT: Draw a card.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "3a1bcbc6-4c4f-59cd-8a88-036e891d766b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a38d40a-e745-4fee-b179-f8c27e9b2fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a38d40a-e745-4fee-b179-f8c27e9b2fbd.jpg?1",
             "name": "Benalish Lancer",
             "text": "Kicker o2o\nW (You may pay an additional o2o\nW as you play this spell.)\nIf you paid the kicker cost, Benalish Lancer comes into play with two +1/+1 counters on it and has first strike.",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "e714a71d-cbdf-55c8-941a-f9386e51d255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312653d-c3e1-4c79-90d2-0963419b618c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312653d-c3e1-4c79-90d2-0963419b618c.jpg?1",
             "name": "Benalish Trapper",
             "text": "o\nW, oc\nT: Tap target creature.",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "5bcc7ef8-791b-5d01-b42b-c9d8b16be1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882c1e15-b508-4885-9626-4c8d2598a006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882c1e15-b508-4885-9626-4c8d2598a006.jpg?1",
             "name": "Blinding Light",
             "text": "Tap all nonwhite creatures.",
             "colours": [
@@ -318,7 +318,7 @@
         },
         {
             "id": "9b0dfd1a-e602-5dc8-816a-42b98255337d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3e5741-88d7-4837-9b43-ba8304d9ee74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3e5741-88d7-4837-9b43-ba8304d9ee74.jpg?1",
             "name": "Capashen Unicorn",
             "text": "o1o\nW, oc\nT, Sacrifice Capashen Unicorn: Destroy target artifact or enchantment.",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "101301c0-f31b-5561-af3d-d0d4dd7d8478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1718028-3009-4bdd-9f6f-59c17edd1344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1718028-3009-4bdd-9f6f-59c17edd1344.jpg?1",
             "name": "Crimson Acolyte",
             "text": "Protection from red\noo\nW Target creature gains protection from red until end of turn.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "9010338f-40eb-5790-8660-cea74342b31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab4640-1871-41dd-bd21-64741e21ba37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ab4640-1871-41dd-bd21-64741e21ba37.jpg?1",
             "name": "Crusading Knight",
             "text": "Protection from black\nCrusading Knight gets +1/+1 for each swamp your opponents control.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "98dec30c-156b-5b0d-bb98-1f200a835825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f967c9-b38d-489d-96cc-44a6b1804e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f967c9-b38d-489d-96cc-44a6b1804e10.jpg?1",
             "name": "Death or Glory",
             "text": "Separate all creature cards in your graveyard into two face-up piles. Remove the pile of an opponent's choice from the game and return the other to play.",
             "colours": [
@@ -454,7 +454,7 @@
         },
         {
             "id": "c92a66e5-d0f2-5bc6-a90e-feda6e23a29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39514d54-cb6c-4b3b-a3be-46db991be4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39514d54-cb6c-4b3b-a3be-46db991be4d4.jpg?1",
             "name": "Dismantling Blow",
             "text": "Kicker o2o\nU (You may pay an additional o2o\nU as you play this spell.)\nDestroy target artifact or enchantment.\nIf you paid the kicker cost, draw two cards.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "05455c12-377b-5678-bcef-4f6f52be22f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb898d-d6ce-410a-83bf-37962cca2735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28cb898d-d6ce-410a-83bf-37962cca2735.jpg?1",
             "name": "Divine Presence",
             "text": "If a source would deal 4 damage or more to a creature or player, that source deals 3 damage to that creature or player instead.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "b6c6b278-f759-5134-8edb-d0cd077781f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bde162-3737-4b93-a27a-63b909a4183d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bde162-3737-4b93-a27a-63b909a4183d.jpg?1",
             "name": "Fight or Flight",
             "text": "At the beginning of each opponent's combat phase, separate all creatures that player controls into two face-up piles. Only creatures in the pile of his or her choice may attack this turn.",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "57bf9439-dc0f-51de-9fef-f833c254aa62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f55e4-eded-4a86-87f4-b8fa6f30bc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f55e4-eded-4a86-87f4-b8fa6f30bc0f.jpg?1",
             "name": "Glimmering Angel",
             "text": "Flying\noo\nU Glimmering Angel can't be the target of spells or abilities this turn.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "90c0c53f-366a-590e-8dcd-166a1fdfd7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336474b4-2cf5-44c0-b72c-f75f1a7ed928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336474b4-2cf5-44c0-b72c-f75f1a7ed928.jpg?1",
             "name": "Global Ruin",
             "text": "Each player chooses from the lands he or she controls a land of each basic land type, then sacrifices the rest.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "a16975c9-b37b-5cbf-b1a2-b1797d86ca61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c78dee-ab45-4638-b89a-10686145b19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c78dee-ab45-4638-b89a-10686145b19a.jpg?1",
             "name": "Harsh Judgment",
             "text": "As Harsh Judgment comes into play, choose a color.\nIf an instant or sorcery of the chosen color would deal damage to you, it deals that damage to its controller instead.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "52ec468c-9f49-56d7-8dd5-a9af40c2e3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa91fd4e-4e1f-4cfa-b10f-456bd875238f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa91fd4e-4e1f-4cfa-b10f-456bd875238f.jpg?1",
             "name": "Holy Day",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "ab985f9a-81a8-54ba-a3f8-4a718ef88382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96794470-31ea-478f-b11c-dc8342a508e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96794470-31ea-478f-b11c-dc8342a508e2.jpg?1",
             "name": "Liberate",
             "text": "Remove target creature you control from the game. At end of turn, return that card to play under its owner's control.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "13f4b3d4-6c41-5f51-8ca0-1715d52a0209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868efcee-bb13-4b6f-b81b-99408685e4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868efcee-bb13-4b6f-b81b-99408685e4c4.jpg?1",
             "name": "Obsidian Acolyte",
             "text": "Protection from black\noo\nW Target creature gains protection from black until end of turn.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "2f95572e-c41e-5680-a10c-f52b5c6e6007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559f551e-7891-4c6d-8798-a25c0255fa3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559f551e-7891-4c6d-8798-a25c0255fa3b.jpg?1",
             "name": "Orim's Touch",
             "text": "Kicker o1 (You may pay an additional o1 as you play this spell.)\nPrevent the next 2 damage that would be dealt to target creature or player this turn. If you paid the kicker cost, prevent the next 4 damage that would be dealt to that creature or player this turn instead.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "78ec0235-7898-5eb5-a345-5cc5a4d3be81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f98c26-5b30-400c-8af1-8c6c43065f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f98c26-5b30-400c-8af1-8c6c43065f63.jpg?1",
             "name": "Pledge of Loyalty",
             "text": "Enchanted creature has protection from the colors of permanents you control. This effect doesn't remove Pledge of Loyalty.",
             "colours": [
@@ -815,7 +815,7 @@
         },
         {
             "id": "92aeb134-8a09-51d4-a13f-50bb91300cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c4800-8718-4593-a61e-03ad7f348c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449c4800-8718-4593-a61e-03ad7f348c6d.jpg?1",
             "name": "Prison Barricade",
             "text": "(Walls can't attack.)\nKicker o1o\nW (You may pay an additional o1o\nW as you play this spell.)\nIf you paid the kicker cost, Prison Barricade comes into play with a +1/+1 counter on it and may attack as though it weren't a Wall.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "88e63265-7e94-5dc6-89d8-20ec010ab9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5ef13e-1cf0-42a9-95d0-30ade254d6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5ef13e-1cf0-42a9-95d0-30ade254d6a8.jpg?1",
             "name": "Protective Sphere",
             "text": "o1, Pay 1 life: Prevent all damage that would be dealt to you this turn by a source of your choice that shares a color with the mana spent on this activation cost. (Colorless mana prevents no damage.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "c6400cf0-5d96-50e4-9bba-c8aab1a6f994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbff85a6-a51b-424e-a86b-da52c9b3a9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbff85a6-a51b-424e-a86b-da52c9b3a9da.jpg?1",
             "name": "Pure Reflection",
             "text": "Whenever a player plays a creature spell, destroy all Reflections. Then that player puts a white Reflection creature token into play with power and toughness each equal to the converted mana cost of that spell.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "fce16d7e-67f0-56e7-a048-26c04393eb98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752642d2-3dad-4f58-b154-beb5982141dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752642d2-3dad-4f58-b154-beb5982141dc.jpg?1",
             "name": "Rampant Elephant",
             "text": "oo\nG Target creature blocks Rampant Elephant this turn if able.",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "28260ce8-5b15-5083-acb4-715b2020466a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819e2046-9b78-4fd0-92f8-798bfac51195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819e2046-9b78-4fd0-92f8-798bfac51195.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "d02c249d-6963-564b-a0f9-286711fa934d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b5c765-619c-4db9-b509-91892fb65e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b5c765-619c-4db9-b509-91892fb65e8f.jpg?1",
             "name": "Restrain",
             "text": "Prevent all combat damage that would be dealt by target attacking creature this turn.\nDraw a card.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "69b5afab-ca82-514c-9dc2-2e7659d33f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d44dd88-ad20-4d89-8831-d2dfa6873428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d44dd88-ad20-4d89-8831-d2dfa6873428.jpg?1",
             "name": "Reviving Dose",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1046,7 +1046,7 @@
         },
         {
             "id": "e8900247-ace1-5709-aade-848ef64c15ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04116b38-8fb1-47c6-b68d-060d0fc4a60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04116b38-8fb1-47c6-b68d-060d0fc4a60d.jpg?1",
             "name": "Rewards of Diversity",
             "text": "Whenever an opponent plays a multicolored spell, you gain 4 life.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "d8c4ada2-c353-53b4-84e8-bb62085edbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e0e72b-e65e-4578-b610-9f529daa32d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e0e72b-e65e-4578-b610-9f529daa32d7.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "Flying\nAt the beginning of your upkeep, you may return target creature card from your graveyard to play.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "7439f91b-7327-5c33-86bd-02026015c4e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bc55ed-b89b-4e22-b3f1-4ce0f8d180d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bc55ed-b89b-4e22-b3f1-4ce0f8d180d7.jpg?1",
             "name": "Rout",
             "text": "You may play Rout any time you could play an instant if you pay o2 more to play it.\nDestroy all creatures. They can't be regenerated.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "0f7e3e41-f801-555b-90ec-ea073dc89d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46c7718-1ecc-418c-b213-13be9de5cb7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46c7718-1ecc-418c-b213-13be9de5cb7f.jpg?1",
             "name": "Ruham Djinn",
             "text": "First strike\nRuham Djinn gets -2/-2 as long as white is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "267b8f06-47ed-571d-959b-cc58ffb3c0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1de62ed-79e6-4daf-a2ab-dc0726e1f7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1de62ed-79e6-4daf-a2ab-dc0726e1f7df.jpg?1",
             "name": "Samite Ministration",
             "text": "Prevent all damage that would be dealt by a source of your choice to you this turn. Whenever damage from a black or red source is prevented this way, you gain life equal to that damage.",
             "colours": [
@@ -1212,7 +1212,7 @@
         },
         {
             "id": "3631085b-00fd-5040-8f38-837904400dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3da05-9a3e-4827-96b8-5de244128db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3da05-9a3e-4827-96b8-5de244128db3.jpg?1",
             "name": "Shackles",
             "text": "Enchanted creature doesn't untap during its controller's untap step.\noo\nW Return Shackles to its owner's hand.",
             "colours": [
@@ -1246,7 +1246,7 @@
         },
         {
             "id": "e3054de8-11b8-5ae2-9485-afac9305143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb66439-df73-4a01-a8d4-6f2334297fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb66439-df73-4a01-a8d4-6f2334297fdf.jpg?1",
             "name": "Spirit of Resistance",
             "text": "If you control a permanent of each color, prevent all damage that would be dealt to you.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "68d2c03d-beb7-538b-9a26-afb55d189283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0ef47-cb22-4146-a17e-e49a6031a7e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b0ef47-cb22-4146-a17e-e49a6031a7e6.jpg?1",
             "name": "Spirit Weaver",
             "text": "o2: Target green or blue creature gets +0/+1 until end of turn.",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "09fec7ae-64e3-5a0f-a08b-db8ad0f742cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d4ff8-af35-413f-9aa2-f4c6e34fade2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9d4ff8-af35-413f-9aa2-f4c6e34fade2.jpg?1",
             "name": "Strength of Unity",
             "text": "Enchanted creature gets +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "8638b750-d5e1-5b24-81d6-e66ab2922a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d6bd19-77c9-4a1a-a2d5-6f9737693fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d6bd19-77c9-4a1a-a2d5-6f9737693fea.jpg?1",
             "name": "Sunscape Apprentice",
             "text": "o\nG, oc\nT: Target creature gets +1/+1 until end of turn.\no\nU, oc\nT: Put target creature you control on top of its owner's library.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "c9d8ba2b-c213-50cf-9635-05ba6b64c951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7203d-529d-45d2-8e03-cd342c153f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb7203d-529d-45d2-8e03-cd342c153f38.jpg?1",
             "name": "Sunscape Master",
             "text": "o\nGo\nG, oc\nT: Creatures you control get +2/+2 until end of turn.\no\nUo\nU, oc\nT: Return target creature to its owner's hand.",
             "colours": [
@@ -1421,7 +1421,7 @@
         },
         {
             "id": "ae218dc9-951f-558c-9bc6-b1c0ce7d8b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b1cc1-4468-4bc5-85c0-c22dce131225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031b1cc1-4468-4bc5-85c0-c22dce131225.jpg?1",
             "name": "Teferi's Care",
             "text": "o\nW, Sacrifice an enchantment: Destroy target enchantment.\no3o\nUoo\nU Counter target enchantment spell.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "b2f89ca8-96ed-5a09-b09d-0aafaec4a5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e45de5-0e8b-41d3-979b-ec5a29cac682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e45de5-0e8b-41d3-979b-ec5a29cac682.jpg?1",
             "name": "Wayfaring Giant",
             "text": "Wayfaring Giant gets +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "c577e4e2-3445-5cf0-9eaa-5bf966f3c015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61748dd-4010-47da-8717-ca0147877057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61748dd-4010-47da-8717-ca0147877057.jpg?1",
             "name": "Winnow",
             "text": "Destroy target nonland permanent if another permanent with the same name is in play.\nDraw a card.",
             "colours": [
@@ -1520,7 +1520,7 @@
         },
         {
             "id": "c1848238-5699-5783-8633-6c02a16071e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4cecb0-12b5-4678-b5e7-8cec8fc86cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4cecb0-12b5-4678-b5e7-8cec8fc86cef.jpg?1",
             "name": "Barrin's Unmaking",
             "text": "Return target permanent to its owner's hand if that permanent shares a color with the most common color among all permanents or the color tied for most common.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "f9959e9b-4401-5b8a-9862-01a8ab312422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c54ec26-c7f1-4258-9cc9-1709987f293c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c54ec26-c7f1-4258-9cc9-1709987f293c.jpg?1",
             "name": "Blind Seer",
             "text": "o1oo\nU Target spell or permanent becomes the color of your choice until end of turn.",
             "colours": [
@@ -1589,7 +1589,7 @@
         },
         {
             "id": "4b3db33c-9706-5235-91d3-9a36eceb9c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b39cd77-97aa-4099-8405-366f82079758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b39cd77-97aa-4099-8405-366f82079758.jpg?1",
             "name": "Breaking Wave",
             "text": "You may play Breaking Wave any time you could play an instant if you pay o2 more to play it.\nSimultaneously untap all tapped creatures and tap all untapped creatures.",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "0fca98b9-1743-5051-8d07-48807edf09ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71daa57-ac02-4dd9-8c90-d38bdd45fb51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71daa57-ac02-4dd9-8c90-d38bdd45fb51.jpg?1",
             "name": "Collective Restraint",
             "text": "Creatures can't attack you unless their controller pays o\nX for each creature attacking you, where X is the number of basic land types among lands you control. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -1653,7 +1653,7 @@
         },
         {
             "id": "a37dd042-4c96-5ba6-a37f-ea1c122adc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798a4f1-34bb-449d-a8cc-faf8bda8e0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8798a4f1-34bb-449d-a8cc-faf8bda8e0ab.jpg?1",
             "name": "Crystal Spray",
             "text": "Change the text of target spell or permanent by replacing all instances of one color word or basic land type with another until end of turn.\nDraw a card.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "20e2d573-cd8f-5e54-86d5-61606bb53116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000a02f-6b7e-4925-a938-59e645e980d7.jpg?1",
             "name": "Disrupt",
             "text": "Counter target instant or sorcery spell unless its controller pays o1.\nDraw a card.",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "d3fc5bb8-6380-526e-a6f6-db1e043090e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf48eec9-96be-4f53-9d9a-c6f02d44c995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf48eec9-96be-4f53-9d9a-c6f02d44c995.jpg?1",
             "name": "Distorting Wake",
             "text": "Return X target nonland permanents to their owners' hands.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "11ab299d-6003-5b61-8dcf-6933af2e6448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258217df-ae88-4d93-895a-3fd242baacd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258217df-ae88-4d93-895a-3fd242baacd1.jpg?1",
             "name": "Dream Thrush",
             "text": "Flying\noc\nT: Target land becomes a land of the basic land type of your choice until end of turn.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "7eec70cb-3af0-5305-a751-d2fbd897b819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6851dbc7-f072-41e7-a899-897445d99425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6851dbc7-f072-41e7-a899-897445d99425.jpg?1",
             "name": "Empress Galina",
             "text": "o\nUo\nU, oc\nT: Gain control of target Legend or legendary permanent. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "23cbd9fe-fea5-50c2-b043-0335f10b06a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099b2e6-9ed8-4a9c-97ca-77cc47678228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099b2e6-9ed8-4a9c-97ca-77cc47678228.jpg?1",
             "name": "Essence Leak",
             "text": "If enchanted permanent is red or green, it has \"At the beginning of your upkeep, sacrifice this permanent unless you pay its mana cost.\"",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "46438b6d-1586-5c5c-be5e-2e5ae8abbac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb359c8-209c-455f-84b2-970e5678a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb359c8-209c-455f-84b2-970e5678a9fa.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "d2387533-6426-533f-879a-74cbd3d9d174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4d018-dcf3-4439-8445-02d66e44f7d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4d018-dcf3-4439-8445-02d66e44f7d3.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two face-up piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "9452fc71-7a11-5f01-8add-ede60a0ad95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c707c81-dbbd-43be-a79a-7bc92a584839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c707c81-dbbd-43be-a79a-7bc92a584839.jpg?1",
             "name": "Faerie Squadron",
             "text": "Kicker o3o\nU (You may pay an additional o3o\nU as you play this spell.)\nIf you paid the kicker cost, Faerie Squadron comes into play with two +1/+1 counters on it and has flying.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "3323b377-4f9c-55b1-b969-7e3a271344a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62cc17-8fa3-495c-a098-ffbbec89fa53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62cc17-8fa3-495c-a098-ffbbec89fa53.jpg?1",
             "name": "Mana Maze",
             "text": "Players can't play spells that share a color with the spell last played this turn.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "e27fb2a2-56d7-5f54-8a9d-22b6f13e6a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb52acb-dedb-4ed6-a6da-8c036f2b2958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb52acb-dedb-4ed6-a6da-8c036f2b2958.jpg?1",
             "name": "Manipulate Fate",
             "text": "Search your library for three cards, remove them from the game, then shuffle your library.\nDraw a card.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "d9378d7c-f5d1-53da-b5be-f080d46d319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f34850-fb6f-4ac5-8309-4d53d770e28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f34850-fb6f-4ac5-8309-4d53d770e28c.jpg?1",
             "name": "Metathran Aerostat",
             "text": "Flying\no\nXoo\nU You may put a creature card with converted mana cost X from your hand into play. If you do, return Metathran Aerostat to its owner's hand.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "34afe4f2-b5f2-5df2-84cb-78b6057ba6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa9048d-1599-44a5-b4b2-45382c5b238d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa9048d-1599-44a5-b4b2-45382c5b238d.jpg?1",
             "name": "Metathran Transport",
             "text": "Flying\nMetathran Transport can't be blocked by blue creatures.\noo\nU Target creature becomes blue until end of turn.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "2d2f4492-45b8-58bc-a1cf-1a977523ba67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6676a0f7-8213-4547-b2ac-b904cd418073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6676a0f7-8213-4547-b2ac-b904cd418073.jpg?1",
             "name": "Metathran Zombie",
             "text": "oo\nB Regenerate Metathran Zombie.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "c784eb6c-0b15-58cc-a9ae-ff19bc1167ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958262ec-8e52-40cf-a9fd-a60e42643e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958262ec-8e52-40cf-a9fd-a60e42643e15.jpg?1",
             "name": "Opt",
             "text": "Look at the top card of your library. You may put that card on the bottom of your library.\nDraw a card.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "0bcd790f-b0f1-5c5d-b331-a1986a6b62c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56a1bb-f52c-4c6b-a089-1f78600f3db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56a1bb-f52c-4c6b-a089-1f78600f3db0.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "As Phantasmal Terrain comes into play, choose a basic land type.\nEnchanted land is a land of the chosen type.",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "f27cea1a-a22e-57c6-9f54-e59727fad31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a58d18-3d52-4178-86b2-7590d4164e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a58d18-3d52-4178-86b2-7590d4164e76.jpg?1",
             "name": "Probe",
             "text": "Kicker o1o\nB (You may pay an additional o1o\nB as you play this spell.)\nDraw three cards, then discard two cards from your hand.\nIf you paid the kicker cost, target player discards two cards from his or her hand.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "b412a4b2-be0e-5cb1-a4e6-98da53f51de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daa5458-2a97-40d0-b18d-2381a7a68ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daa5458-2a97-40d0-b18d-2381a7a68ee1.jpg?1",
             "name": "Prohibit",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nCounter target spell if its converted mana cost is 2 or less. If you paid the kicker cost, counter that spell if its converted mana cost is 4 or less instead.",
             "colours": [
@@ -2251,7 +2251,7 @@
         },
         {
             "id": "48291028-a206-5589-bd45-28220f3d2b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8758ca24-e613-43bf-be58-4cf557f82d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8758ca24-e613-43bf-be58-4cf557f82d0c.jpg?1",
             "name": "Psychic Battle",
             "text": "Whenever a player chooses one or more targets, each player reveals the top card of his or her library. The player who reveals the card with the highest converted mana cost may change the target or targets. If two or more cards are tied for highest cost, the target or targets remain unchanged.",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "91242a90-c914-5809-ba16-47cff6d34bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e622ad2-473f-489e-b4cf-bbdcc44d0cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e622ad2-473f-489e-b4cf-bbdcc44d0cde.jpg?1",
             "name": "Rainbow Crow",
             "text": "Flying\no1: Rainbow Crow becomes the color of your choice until end of turn.",
             "colours": [
@@ -2317,7 +2317,7 @@
         },
         {
             "id": "2e2bf688-9778-5c5f-b31d-87ceeb2533ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a04e9be-48be-440e-9825-cfffd4c2b1a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a04e9be-48be-440e-9825-cfffd4c2b1a4.jpg?1",
             "name": "Repulse",
             "text": "Return target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "baf3477b-0d60-59d1-9c99-21590de5fed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6763ffd-9d89-4f26-871a-be24fbdef38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6763ffd-9d89-4f26-871a-be24fbdef38d.jpg?1",
             "name": "Sapphire Leech",
             "text": "Flying\nBlue spells you play cost o\nU more to play.",
             "colours": [
@@ -2383,7 +2383,7 @@
         },
         {
             "id": "0dce6096-9bee-59df-aecc-977d0c34e344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9615a6c2-1732-4a04-9be1-cc0a8d39de3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9615a6c2-1732-4a04-9be1-cc0a8d39de3f.jpg?1",
             "name": "Shimmering Wings",
             "text": "Enchanted creature has flying.\noo\nU Return Shimmering Wings to its owner's hand.",
             "colours": [
@@ -2417,7 +2417,7 @@
         },
         {
             "id": "b02850ee-5f10-530b-837b-5151ddc9d737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895b3b8-2acc-4c9f-8341-f651c1255b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d895b3b8-2acc-4c9f-8341-f651c1255b7c.jpg?1",
             "name": "Shoreline Raider",
             "text": "Protection from Kavu",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "c7850b1d-e6ba-5971-9d7c-5765526faba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04974146-42a8-4f10-b443-67bfeaa54d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04974146-42a8-4f10-b443-67bfeaa54d5d.jpg?1",
             "name": "Sky Weaver",
             "text": "o2: Target white or black creature gains flying until end of turn.",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "fe029ebb-be6e-580e-a0d7-d1dd715b98e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb42f39-9187-44e4-aa34-14ab31977199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb42f39-9187-44e4-aa34-14ab31977199.jpg?1",
             "name": "Stormscape Apprentice",
             "text": "o\nW, oc\nT: Tap target creature.\no\nB, oc\nT: Target player loses 1 life.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "81993508-51fb-519c-96a8-836311b1f026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b704165-4587-48f1-8830-c5a07ec666cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b704165-4587-48f1-8830-c5a07ec666cc.jpg?1",
             "name": "Stormscape Master",
             "text": "o\nWo\nW, oc\nT: Target creature gains protection from the color of your choice until end of turn.\no\nBo\nB, oc\nT: Target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "b0ecb4f9-7dd3-558b-a432-d595545636b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff65e386-9aec-4deb-a4ec-d9a97bd87645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff65e386-9aec-4deb-a4ec-d9a97bd87645.jpg?1",
             "name": "Sway of Illusion",
             "text": "Any number of target creatures become the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "4e47953d-ff4d-5f40-b575-3bdb0443e094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bb2df8-c559-4a34-83b0-d48fbc694cc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bb2df8-c559-4a34-83b0-d48fbc694cc8.jpg?1",
             "name": "Teferi's Response",
             "text": "Counter target spell or ability an opponent controls that targets a land you control. If a permanent's ability is countered this way, destroy that permanent.\nDraw two cards.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "65020fc1-e766-5ab4-8e9d-e32cc1b2a68d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd0d14-8d26-403f-9405-d0dcdecd1a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bd0d14-8d26-403f-9405-d0dcdecd1a49.jpg?1",
             "name": "Temporal Distortion",
             "text": "Whenever a creature or land becomes tapped, put an hourglass counter on it.\nPermanents with an hourglass counter on them don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, remove all hourglass counters from permanents that player controls.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "5f245587-25fa-5791-8d33-1094c62d5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72a3051-7f46-4b6b-b4fb-0f170d9687ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72a3051-7f46-4b6b-b4fb-0f170d9687ab.jpg?1",
             "name": "Tidal Visionary",
             "text": "oc\nT: Target creature becomes the color of your choice until end of turn.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "9f56b7d0-ea6a-536e-adee-5ea848f5a804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbc55e5-b84c-4449-a288-ec26cdd3997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cbc55e5-b84c-4449-a288-ec26cdd3997c.jpg?1",
             "name": "Tolarian Emissary",
             "text": "Kicker o1o\nW (You may pay an additional o1o\nW as you play this spell.)\nFlying\nWhen Tolarian Emissary comes into play, if you paid the kicker cost, destroy target enchantment.",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "6a484c98-c5e6-5b21-b1ed-d2080af6c757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef97b38-f7a5-4db7-9550-24aa1a1ebbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef97b38-f7a5-4db7-9550-24aa1a1ebbda.jpg?1",
             "name": "Tower Drake",
             "text": "Flying\noo\nW Tower Drake gets +0/+1 until end of turn.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "c3939f24-038b-5d90-94a2-81bab4c3ed75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f0f82-0542-40c9-9a48-73077941dbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f0f82-0542-40c9-9a48-73077941dbd1.jpg?1",
             "name": "Traveler's Cloak",
             "text": "As Traveler's Cloak comes into play, choose a land type.\nEnchanted creature has landwalk of the chosen type. (It's unblockable as long as defending player controls a land of that type.)\nWhen Traveler's Cloak comes into play, draw a card.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "9207ae01-6d06-521a-921d-d7abf21489f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721fd877-0a28-4002-8b47-058bac4ac44d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721fd877-0a28-4002-8b47-058bac4ac44d.jpg?1",
             "name": "Vodalian Hypnotist",
             "text": "o2o\nB, oc\nT: Target player discards a card from his or her hand. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "5ff22f54-5ad4-5855-900f-025f553d285e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0effa-a4b8-4166-a66a-90cf01c6ea0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c0effa-a4b8-4166-a66a-90cf01c6ea0d.jpg?1",
             "name": "Vodalian Merchant",
             "text": "When Vodalian Merchant comes into play, draw a card, then discard a card from your hand.",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "b07d8231-4ff5-52be-ac3e-d6de6634845b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adcf6c-ab14-414c-a5cb-56feae048c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adcf6c-ab14-414c-a5cb-56feae048c84.jpg?1",
             "name": "Vodalian Serpent",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nVodalian Serpent can't attack unless defending player controls an island.\nIf you paid the kicker cost, Vodalian Serpent comes into play with four +1/+1 counters on it.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "60ffe39c-6325-5ac7-b4e5-fd0b2326b8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7719d043-5827-4479-825b-23d9e979ead7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7719d043-5827-4479-825b-23d9e979ead7.jpg?1",
             "name": "Wash Out",
             "text": "Return all permanents of the color of your choice to their owners' hands.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "5f2b3879-c962-5274-89a8-2f1da2b56a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c55eb8f-925a-42c1-9e48-d7f99cab3b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c55eb8f-925a-42c1-9e48-d7f99cab3b01.jpg?1",
             "name": "Well-Laid Plans",
             "text": "Prevent all damage that would be dealt to a creature by another creature if they share a color.",
             "colours": [
@@ -2964,7 +2964,7 @@
         },
         {
             "id": "db31e8c4-6791-5472-b9e5-ba7abfa21aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc66fbf-f411-4607-aece-7c35d9a07c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc66fbf-f411-4607-aece-7c35d9a07c80.jpg?1",
             "name": "Worldly Counsel",
             "text": "Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "5a04c60c-8cca-5f51-8738-fbe47761c8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a3c1d5-0ca8-443b-ae7a-66e0363e377b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a3c1d5-0ca8-443b-ae7a-66e0363e377b.jpg?1",
             "name": "Zanam Djinn",
             "text": "Flying\nZanam Djinn gets -2/-2 as long as blue is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -3030,7 +3030,7 @@
         },
         {
             "id": "3a4be75a-5d5d-5931-9b29-16c76ed5e892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afb9d0-affa-4599-bf29-729cfe64703b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8afb9d0-affa-4599-bf29-729cfe64703b.jpg?1",
             "name": "Addle",
             "text": "Choose a color. Look at target player's hand and choose a card of that color from it. That player discards that card.",
             "colours": [
@@ -3062,7 +3062,7 @@
         },
         {
             "id": "febd181c-6159-555c-bd07-d3e20ea1b4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539ac5e1-4bad-4f70-abac-e70c406bebec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539ac5e1-4bad-4f70-abac-e70c406bebec.jpg?1",
             "name": "Agonizing Demise",
             "text": "Kicker o1o\nR (You may pay an additional o1o\nR as you play this spell.)\nDestroy target nonblack creature. It can't be regenerated. If you paid the kicker cost, Agonizing Demise deals damage equal to that creature's power to the creature's controller.",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "00e0694f-aced-5fe0-a555-caab009a87df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da0d4f3-9216-406c-8f3e-b9bb0a11dc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da0d4f3-9216-406c-8f3e-b9bb0a11dc75.jpg?1",
             "name": "Andradite Leech",
             "text": "Black spells you play cost o\nB more to play.\noo\nB Andradite Leech gets +1/+1 until end of turn.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "12fc2cac-1a35-5847-8f86-1249cf72894c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3bf039-ecf6-477e-997c-e32c55323c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3bf039-ecf6-477e-997c-e32c55323c01.jpg?1",
             "name": "Annihilate",
             "text": "Destroy target nonblack creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "4debc721-34df-5532-9229-30518b62d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8962dc3b-24ca-4c3c-ba1d-933c29cf7b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8962dc3b-24ca-4c3c-ba1d-933c29cf7b73.jpg?1",
             "name": "Bog Initiate",
             "text": "o1: Add o\nB to your mana pool.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "c5d3abb5-6a9f-5f8b-86e2-631784477b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1095cdfe-8060-4a73-bacf-9f983152b486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1095cdfe-8060-4a73-bacf-9f983152b486.jpg?1",
             "name": "Cremate",
             "text": "Remove target card in a graveyard from the game.\nDraw a card.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "5772e08b-9e83-5a9d-94dd-1dc70fe05a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522ddc6f-ec13-4a70-8f4c-b3c846b102fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522ddc6f-ec13-4a70-8f4c-b3c846b102fd.jpg?1",
             "name": "Crypt Angel",
             "text": "Flying, protection from white\nWhen Crypt Angel comes into play, return target blue or red creature card from your graveyard to your hand.",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "6375b288-08f7-55be-afed-a0668942af0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb151ae8-9281-434d-ba8d-9ce34f0875eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb151ae8-9281-434d-ba8d-9ce34f0875eb.jpg?1",
             "name": "Cursed Flesh",
             "text": "Enchanted creature gets -1/-1 and can't be blocked except by artifact creatures and/or black creatures.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "6aa40c6f-5195-592e-aa90-2d21a65866e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7cba29-9472-4874-bd54-37edf70645b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7cba29-9472-4874-bd54-37edf70645b2.jpg?1",
             "name": "Defiling Tears",
             "text": "Until end of turn, target creature becomes black, gets +1/-1, and gains \"oo\nB Regenerate this creature.\"",
             "colours": [
@@ -3328,7 +3328,7 @@
         },
         {
             "id": "d029ca15-9518-52dc-9f6c-a097d84306fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42ac7e-4a27-488c-a2e7-338b18103b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a42ac7e-4a27-488c-a2e7-338b18103b02.jpg?1",
             "name": "Desperate Research",
             "text": "Name a card other than a basic land. Then reveal the top seven cards of your library and put all of them with that name into your hand. Remove the rest from the game.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "c3b55f8a-cc3a-5532-8a7c-2dd08414d7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064f013f-e74f-419d-8d17-7748bd91885e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064f013f-e74f-419d-8d17-7748bd91885e.jpg?1",
             "name": "Devouring Strossus",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature.\nSacrifice a creature: Regenerate Devouring Strossus.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "24074ca4-9a25-56a8-b8b2-aa0c3a94575d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f63cd9-e82b-4cf8-b8ce-f0aa0157692b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f63cd9-e82b-4cf8-b8ce-f0aa0157692b.jpg?1",
             "name": "Do or Die",
             "text": "Separate all creatures target player controls into two face-up piles. Destroy all creatures in the pile of that player's choice. They can't be regenerated.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "63a6d7f8-7465-59a2-8177-744515409916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bfa3d5-0f0b-4684-9567-f1478da01df7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68bfa3d5-0f0b-4684-9567-f1478da01df7.jpg?1",
             "name": "Dredge",
             "text": "Sacrifice a creature or land.\nDraw a card.",
             "colours": [
@@ -3459,7 +3459,7 @@
         },
         {
             "id": "a40b88a5-b9ef-5d71-8f69-09ed2ea69563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4a026-f44e-40e1-9942-a3d8448aca70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a4a026-f44e-40e1-9942-a3d8448aca70.jpg?1",
             "name": "Duskwalker",
             "text": "Kicker o3o\nB (You may pay an additional o3o\nB as you play this spell.)\nIf you paid the kicker cost, Duskwalker comes into play with two +1/+1 counters on it and has \"Duskwalker can't be blocked except by artifact creatures and/or black creatures.\"",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "086e9217-ffc6-5b0e-87e7-750f8b81569a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee35d99-9a8a-421b-bf43-74446909d87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee35d99-9a8a-421b-bf43-74446909d87d.jpg?1",
             "name": "Exotic Curse",
             "text": "Enchanted creature gets -1/-1 for each basic land type among lands you control.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "59bd5992-531e-5e3d-822c-c36d215df867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155a2213-bf6e-4a54-924b-e450b7d06f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155a2213-bf6e-4a54-924b-e450b7d06f26.jpg?1",
             "name": "Firescreamer",
             "text": "oo\nR Firescreamer gets +1/+0 until end of turn.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "1aa34a3e-e415-5354-9182-986cdcfc26ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67796c7-4d93-4c50-8839-bb69e075bc42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67796c7-4d93-4c50-8839-bb69e075bc42.jpg?1",
             "name": "Goham Djinn",
             "text": "o1oo\nB Regenerate Goham Djinn.\nGoham Djinn gets -2/-2 as long as black is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "b90e7b0f-92a7-53ab-9604-859383a284ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8328e131-b44d-4dd0-9ce4-454c6afe6fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8328e131-b44d-4dd0-9ce4-454c6afe6fa6.jpg?1",
             "name": "Hate Weaver",
             "text": "o2: Target blue or red creature gets +1/+0 until end of turn.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "413e11a5-35a1-51c7-928b-219b4453a094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7502ea2-7555-449e-baee-6ecef5573a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7502ea2-7555-449e-baee-6ecef5573a3b.jpg?1",
             "name": "Hypnotic Cloud",
             "text": "Kicker o4 (You may pay an additional o4 as you play this spell.)\nTarget player discards a card from his or her hand. If you paid the kicker cost, that player discards three cards from his or her hand instead.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "c0a47623-83c5-5d0e-8923-7346780ec650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2a7de-c67e-4541-be8c-e5ef7b64d94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea2a7de-c67e-4541-be8c-e5ef7b64d94a.jpg?1",
             "name": "Marauding Knight",
             "text": "Protection from white\nMarauding Knight gets +1/+1 for each plains your opponents control.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "34eddaca-b90b-5604-b36e-678f4433833e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4649d881-709f-4ed0-91de-744d232a82f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4649d881-709f-4ed0-91de-744d232a82f5.jpg?1",
             "name": "Mourning",
             "text": "Enchanted creature gets -2/-0.\noo\nB Return Mourning to its owner's hand.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "bcbda174-b210-5a8b-97ee-673832a98758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7498ca4c-614a-4776-8886-0a6ed58520f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7498ca4c-614a-4776-8886-0a6ed58520f6.jpg?1",
             "name": "Nightscape Apprentice",
             "text": "o\nU, oc\nT: Put target creature you control on top of its owner's library.\no\nR, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "70ef2dac-1e75-5411-8a05-9ea40197a1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86174b8-dd9e-4ece-bc23-4f9ac50bccd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86174b8-dd9e-4ece-bc23-4f9ac50bccd3.jpg?1",
             "name": "Nightscape Master",
             "text": "o\nUo\nU, oc\nT: Return target creature to its owner's hand.\no\nRo\nR, oc\nT: Nightscape Master deals 2 damage to target creature.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "33befc85-e9ca-562d-a982-393369fa53d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da27c489-c541-4b0d-a844-71aa65e55ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da27c489-c541-4b0d-a844-71aa65e55ceb.jpg?1",
             "name": "Phyrexian Battleflies",
             "text": "Flying\noo\nB Phyrexian Battleflies gets +1/+0 until end of turn. This ability may be played no more than twice each turn.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "daefd3ce-d1c6-5e15-8466-54738e480927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d87a5-7b67-4ec5-b5e2-518d67123118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d87a5-7b67-4ec5-b5e2-518d67123118.jpg?1",
             "name": "Phyrexian Delver",
             "text": "When Phyrexian Delver comes into play, return target creature card from your graveyard to play. You lose life equal to that card's converted mana cost.",
             "colours": [
@@ -3878,7 +3878,7 @@
         },
         {
             "id": "50ae50a1-054d-5636-a92b-ad4d0a7d6282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224b8254-553d-4d88-8163-1f15e1244bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224b8254-553d-4d88-8163-1f15e1244bd2.jpg?1",
             "name": "Phyrexian Infiltrator",
             "text": "o2o\nUoo\nU Exchange control of Phyrexian Infiltrator and target creature.",
             "colours": [
@@ -3914,7 +3914,7 @@
         },
         {
             "id": "47a6a551-927f-5487-9129-9f10568c8691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd498b-1081-43fe-8193-518337a5a3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd498b-1081-43fe-8193-518337a5a3ea.jpg?1",
             "name": "Phyrexian Reaper",
             "text": "Whenever Phyrexian Reaper becomes blocked by a green creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "fa178034-087c-5cc7-aff5-adbd6cf47dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa8c604-343f-4c94-ac25-439ab1845c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa8c604-343f-4c94-ac25-439ab1845c19.jpg?1",
             "name": "Phyrexian Slayer",
             "text": "Flying\nWhenever Phyrexian Slayer becomes blocked by a white creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "371b6df9-312e-5118-99a9-4f3e2ce4ab9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8845e6bd-40ee-45ca-a099-53f19ff20a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8845e6bd-40ee-45ca-a099-53f19ff20a8a.jpg?1",
             "name": "Plague Spitter",
             "text": "At the beginning of your upkeep, Plague Spitter deals 1 damage to each creature and each player.\nWhen Plague Spitter is put into a graveyard from play, Plague Spitter deals 1 damage to each creature and each player.",
             "colours": [
@@ -4019,7 +4019,7 @@
         },
         {
             "id": "6c53c7fc-9f2a-5d4a-baf2-856e3adfa497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e29069-add5-4099-b800-9f1e4402cc1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e29069-add5-4099-b800-9f1e4402cc1a.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent discards a card from his or her hand.",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "4d154391-beba-50ab-be1d-37c2f5cdf496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2412497b-cae5-444d-9beb-7761d15cd5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2412497b-cae5-444d-9beb-7761d15cd5c5.jpg?1",
             "name": "Reckless Spite",
             "text": "Destroy two target nonblack creatures. You lose 5 life.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "50d9ba15-b5de-5e05-9ca4-3e9e113aa5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e695b-24e1-4c65-81e0-1624bda646e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e695b-24e1-4c65-81e0-1624bda646e7.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "0d2e327e-a1ea-5ace-95b4-360906b1f7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8072a9-2699-4c6c-9556-67d91bd67a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8072a9-2699-4c6c-9556-67d91bd67a4b.jpg?1",
             "name": "Scavenged Weaponry",
             "text": "When Scavenged Weaponry comes into play, draw a card.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "495da4d1-1fae-5329-9221-5f16b03768c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70515cd2-97d5-4491-a758-bc7188fdc6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70515cd2-97d5-4491-a758-bc7188fdc6dc.jpg?1",
             "name": "Soul Burn",
             "text": "Spend only black and/or red mana on X.\nSoul Burn deals X damage to target creature or player. You gain life equal to the damage dealt, but not more than the amount of o\nB spent on X, the player's life total before Soul Burn dealt damage, or the creature's toughness.",
             "colours": [
@@ -4185,7 +4185,7 @@
         },
         {
             "id": "f01277b4-7a9c-59d3-bcbd-40578c7cbee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb3278a-1a23-4e0a-b541-0c37b2bc3f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb3278a-1a23-4e0a-b541-0c37b2bc3f3c.jpg?1",
             "name": "Soul Burn",
             "text": "",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "0cf600b3-347b-5482-8737-2c5f8dc6f3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86055d-ce08-4b05-a92c-45e007ca0ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac86055d-ce08-4b05-a92c-45e007ca0ba4.jpg?1",
             "name": "Spreading Plague",
             "text": "Whenever a creature comes into play, destroy all other creatures that share a color with it. They can't be regenerated.",
             "colours": [
@@ -4251,7 +4251,7 @@
         },
         {
             "id": "3368c5dd-74ac-521e-81a9-489a725b0aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec00a1-7e12-42d2-8f46-de8ab7323c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec00a1-7e12-42d2-8f46-de8ab7323c2c.jpg?1",
             "name": "Tainted Well",
             "text": "When Tainted Well comes into play, draw a card.\nEnchanted land is a swamp.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "7c6ec3ea-63df-58d1-b1d5-ba21825adbc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b076f85-d1bf-491a-af9d-f35b8e1bd163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b076f85-d1bf-491a-af9d-f35b8e1bd163.jpg?1",
             "name": "Trench Wurm",
             "text": "o2o\nR, oc\nT: Destroy target nonbasic land.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "e7b418f9-50c6-554e-8f5e-5d1f074c283d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0047302d-4e3d-4327-9bb2-ecd5b00b00e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0047302d-4e3d-4327-9bb2-ecd5b00b00e3.jpg?1",
             "name": "Tsabo's Assassin",
             "text": "oc\nT: Destroy target creature if it shares a color with the most common color among all permanents or the color tied for most common. A creature destroyed this way can't be regenerated.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "441b0f88-3545-596e-b0a2-ba853174e42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1a0ebd-1add-49e6-b5e6-5b26abb1de88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1a0ebd-1add-49e6-b5e6-5b26abb1de88.jpg?1",
             "name": "Tsabo's Decree",
             "text": "Choose a creature type. Target player reveals his or her hand and discards all creature cards of that type from it. Then destroy all creatures of that type that player controls. They can't be regenerated.",
             "colours": [
@@ -4388,7 +4388,7 @@
         },
         {
             "id": "1bedc034-0609-51db-b7f6-7e99f83648a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c97c8a5-33b3-4f7f-a224-bb4df7b4bcc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c97c8a5-33b3-4f7f-a224-bb4df7b4bcc0.jpg?1",
             "name": "Twilight's Call",
             "text": "You may play Twilight's Call any time you could play an instant if you pay o2 more to play it.\nEach player returns all creature cards from his or her graveyard to play.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "5c6d92e9-5a7d-52e7-b4b0-981ad1d5b6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6912c71-1836-4e87-9a65-d577d903d03c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6912c71-1836-4e87-9a65-d577d903d03c.jpg?1",
             "name": "Urborg Emissary",
             "text": "Kicker o1o\nU (You may pay an additional o1o\nU as you play this spell.)\nWhen Urborg Emissary comes into play, if you paid the kicker cost, return target permanent to its owner's hand.",
             "colours": [
@@ -4456,7 +4456,7 @@
         },
         {
             "id": "fcd81b2d-6156-5272-a894-ea63dffb17e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397355b9-5b67-4973-972e-3505c500d116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397355b9-5b67-4973-972e-3505c500d116.jpg?1",
             "name": "Urborg Phantom",
             "text": "Urborg Phantom can't block.\noo\nU Prevent all combat damage that would be dealt to and dealt by Urborg Phantom this turn.",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "df120759-82cf-59ba-aa5d-05f8f1af1a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaedd5c8-03c6-4bbb-bf83-632551830bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaedd5c8-03c6-4bbb-bf83-632551830bd4.jpg?1",
             "name": "Urborg Shambler",
             "text": "All other black creatures get -1/-1.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "b5bd9208-d7ff-54ad-8a3b-073e367566da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e522a62-fbca-4362-9006-d4356c525704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e522a62-fbca-4362-9006-d4356c525704.jpg?1",
             "name": "Urborg Skeleton",
             "text": "Kicker o3 (You may pay an additional o3 as you play this spell.)\noo\nB Regenerate Urborg Skeleton.\nIf you paid the kicker cost, Urborg Skeleton comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -4562,7 +4562,7 @@
         },
         {
             "id": "95764259-fc5d-550d-9d1b-d59c89ccbb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819c2f5-29a2-46d2-af36-c22b64338807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819c2f5-29a2-46d2-af36-c22b64338807.jpg?1",
             "name": "Urborg Skeleton",
             "text": "",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "07058277-1671-5b3d-a742-70ff6d8ad094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7ea7f-4f17-4f78-b68e-693e265ca829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f7ea7f-4f17-4f78-b68e-693e265ca829.jpg?1",
             "name": "Yawgmoth's Agenda",
             "text": "Play no more than one spell each turn.\nYou may play cards in your graveyard as though they were in your hand.\nIf a card would be put into your graveyard from anywhere, remove it from the game instead.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "2af472c9-a63d-56f0-87c9-234be3c1a1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ccb5d0-735b-443f-addd-8b70f5f2c60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ccb5d0-735b-443f-addd-8b70f5f2c60d.jpg?1",
             "name": "Ancient Kavu",
             "text": "o2: Ancient Kavu becomes colorless until end of turn.",
             "colours": [
@@ -4664,7 +4664,7 @@
         },
         {
             "id": "05f2aa8e-dab5-5fd3-9182-3326d81e2410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76b6660-d4b2-44de-a1a7-8d00811f90f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76b6660-d4b2-44de-a1a7-8d00811f90f6.jpg?1",
             "name": "Bend or Break",
             "text": "Each player separates all land cards he or she controls into two face-up piles. For each player, an opponent chooses a pile. Destroy all lands in that pile. Tap all lands in the other pile.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "3548f788-f5ea-5ee5-abc5-6044c22c7aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bb7e3-df03-454d-ada0-592ef8a4a6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bb7e3-df03-454d-ada0-592ef8a4a6f0.jpg?1",
             "name": "Breath of Darigaaz",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nBreath of Darigaaz deals 1 damage to each creature without flying and each player. If you paid the kicker cost, Breath of Darigaaz deals 4 damage to each creature without flying and each player instead.",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "5bf770dc-1c03-57b4-b5e8-364a4532d617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330028c4-8e91-4fe3-a87d-1660dfd2507e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/330028c4-8e91-4fe3-a87d-1660dfd2507e.jpg?1",
             "name": "Callous Giant",
             "text": "If a source would deal 3 damage or less to Callous Giant, prevent that damage.",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "30d298c6-17fb-56a9-b203-58969406e57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df8e4-6947-4bbb-9fe7-52ca4fd95d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df8e4-6947-4bbb-9fe7-52ca4fd95d65.jpg?1",
             "name": "Chaotic Strike",
             "text": "Play Chaotic Strike only during combat after blockers are declared.\nChoose target creature and flip a coin. If you win the flip, that creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "b5541427-f489-5e6b-b472-1ad6c7ea3b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc019633-788e-4095-9610-6c0a432f7656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc019633-788e-4095-9610-6c0a432f7656.jpg?1",
             "name": "Collapsing Borders",
             "text": "At the beginning of each player's upkeep, that player gains 1 life for each basic land type among lands he or she controls. Then Collapsing Borders deals 3 damage to him or her.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "10f10731-d750-564b-94d4-4b09e3f30b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46239c-3de7-48ca-8f5c-b51f307fd0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46239c-3de7-48ca-8f5c-b51f307fd0e5.jpg?1",
             "name": "Crown of Flames",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.\noo\nR Return Crown of Flames to its owner's hand.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "052552e9-576d-50c5-ba7c-08469a393ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee05211e-cf08-4dea-9740-ed06f8682153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee05211e-cf08-4dea-9740-ed06f8682153.jpg?1",
             "name": "Firebrand Ranger",
             "text": "o\nG, oc\nT: Put a basic land card from your hand into play.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "72747668-04db-5143-b04d-7dfa74c833e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78827acd-a526-411b-bd22-ab9b538c75dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78827acd-a526-411b-bd22-ab9b538c75dd.jpg?1",
             "name": "Ghitu Fire",
             "text": "You may play Ghitu Fire any time you could play an instant if you pay o2 more to play it.\nGhitu Fire deals X damage to target creature or player.",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "d57cb13d-5b4f-517b-a1b3-7bb70ce09bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a89a099-8805-4b26-babd-5d9f48ee406a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a89a099-8805-4b26-babd-5d9f48ee406a.jpg?1",
             "name": "Goblin Spy",
             "text": "Play with the top card of your library revealed.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "12d4842b-e7d2-5e3e-b996-9f3590605aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369ade1f-e909-47ae-bb01-19588269ad8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369ade1f-e909-47ae-bb01-19588269ad8f.jpg?1",
             "name": "Halam Djinn",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nHalam Djinn gets -2/-2 as long as red is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "066f6e7d-3078-5343-a6bd-7f94dc90be28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5464b80a-22fe-42c7-a839-31667712fb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5464b80a-22fe-42c7-a839-31667712fb2d.jpg?1",
             "name": "Hooded Kavu",
             "text": "oo\nB Hooded Kavu can't be blocked this turn except by artifact creatures and/or black creatures.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "6a195f11-4888-57ba-bf9a-d33597ba2a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2832ad3-ce7f-44d2-beb2-c95d982905a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2832ad3-ce7f-44d2-beb2-c95d982905a6.jpg?1",
             "name": "Kavu Aggressor",
             "text": "Kicker o4 (You may pay an additional o4 as you play this spell.)\nKavu Aggressor can't block.\nIf you paid the kicker cost, Kavu Aggressor comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "04b5c40e-0fef-5237-847c-89d5ba750c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea63dfd5-d8d7-45b8-8219-1cc2b3de5666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea63dfd5-d8d7-45b8-8219-1cc2b3de5666.jpg?1",
             "name": "Kavu Monarch",
             "text": "All Kavu have trample.\nWhenever another Kavu comes into play, put a +1/+1 counter on Kavu Monarch.",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "9471d778-a436-5441-abde-f54fd72c92c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b462-4e3c-47cc-87c5-f6e29dd70c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1b462-4e3c-47cc-87c5-f6e29dd70c01.jpg?1",
             "name": "Kavu Runner",
             "text": "Kavu Runner has haste as long as no opponent controls a white or blue creature. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "7b71ff13-8242-53b0-a703-0c0c45010065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc2670d-a3f4-47c2-b424-01fd379ff186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc2670d-a3f4-47c2-b424-01fd379ff186.jpg?1",
             "name": "Kavu Scout",
             "text": "Kavu Scout gets +1/+0 for each basic land type among lands you control.",
             "colours": [
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "cd16094c-e503-5b06-ac2a-26ed7e2ea9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d05157-d154-4203-bf3e-add110cb1cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d05157-d154-4203-bf3e-add110cb1cee.jpg?1",
             "name": "Lightning Dart",
             "text": "Lightning Dart deals 1 damage to target creature. If that creature is white or blue, Lightning Dart deals 4 damage to it instead.",
             "colours": [
@@ -5202,7 +5202,7 @@
         },
         {
             "id": "117fc415-2a6f-5ca9-9ee2-adf325dce4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5f738-04d0-44c9-88ec-28469b668040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5f738-04d0-44c9-88ec-28469b668040.jpg?1",
             "name": "Loafing Giant",
             "text": "Whenever Loafing Giant attacks or blocks, put the top card of your library into your graveyard. If that card is a land card, prevent all combat damage that Loafing Giant would deal this turn.",
             "colours": [
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "ac7b6979-01ca-543d-b448-9d430ff02e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516861c-68d9-4d02-a343-689dba0526c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516861c-68d9-4d02-a343-689dba0526c6.jpg?1",
             "name": "Mages' Contest",
             "text": "You and target spell's controller bid life. You start the bidding with a high bid of 1. In turn order, each player may top the high bid. The bidding ends when the high bid stands. The highest bidder loses life equal to the high bid. If you win the bidding, counter that spell.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "9cc446d6-4469-545a-bd5d-75314cd835fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d17886c-fffd-4f0d-b4da-4b5fba18b811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d17886c-fffd-4f0d-b4da-4b5fba18b811.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -5302,7 +5302,7 @@
         },
         {
             "id": "6ffb5a5d-2ade-5d29-865d-83ef12aa8baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabde40-2143-4677-b7b4-ea8fbf9b1f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdabde40-2143-4677-b7b4-ea8fbf9b1f25.jpg?1",
             "name": "Obliterate",
             "text": "Obliterate can't be countered.\nDestroy all artifacts, creatures, and lands. They can't be regenerated.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "288f0d14-483b-5029-94b0-35b6afe34d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91fca91-7296-422e-b251-d571b710ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91fca91-7296-422e-b251-d571b710ff71.jpg?1",
             "name": "Overload",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nDestroy target artifact if its converted mana cost is 2 or less. If you paid the kicker cost, destroy that artifact if its converted mana cost is 5 or less instead.",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "201720cd-1495-5769-bbf0-f3ce7a3616c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e2e49-7bde-43c1-8caf-43d237dfc052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6e2e49-7bde-43c1-8caf-43d237dfc052.jpg?1",
             "name": "Pouncing Kavu",
             "text": "Kicker o2o\nR (You may pay an additional o2o\nR as you play this spell.)\nFirst strike\nIf you paid the kicker cost, Pouncing Kavu comes into play with two +1/+1 counters on it and has haste. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "c5079439-b847-5a42-954c-dcee2b4dab9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a654295d-b63c-4025-bf36-899023a8ba1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a654295d-b63c-4025-bf36-899023a8ba1d.jpg?1",
             "name": "Rage Weaver",
             "text": "o2: Target black or green creature gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "1cf11188-4623-588b-812d-2a180feb7c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e1a445-129d-4bb9-a8b0-3f55e3e0bc58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e1a445-129d-4bb9-a8b0-3f55e3e0bc58.jpg?1",
             "name": "Rogue Kavu",
             "text": "Whenever Rogue Kavu attacks alone, it gets +2/+0 until end of turn.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "32df9034-78e2-51b2-a79a-71b8088b43f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be621b12-4f4e-43a6-b65e-da4223e742b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be621b12-4f4e-43a6-b65e-da4223e742b5.jpg?1",
             "name": "Ruby Leech",
             "text": "First strike\nRed spells you play cost o\nR more to play.",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "066a6c8e-8fb1-5f20-a9da-0c3011cf0a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356744f3-e444-4f4e-bf00-80bb6b2ef76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356744f3-e444-4f4e-bf00-80bb6b2ef76f.jpg?1",
             "name": "Savage Offensive",
             "text": "Kicker o\nG (You may pay an additional o\nG as you play this spell.)\nCreatures you control gain first strike until end of turn. If you paid the kicker cost, they get +1/+1 until end of turn.",
             "colours": [
@@ -5536,7 +5536,7 @@
         },
         {
             "id": "74640888-5937-5b0e-ae9a-b3702afcd1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067ff95e-c4dc-41bb-9677-67f51a09b05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067ff95e-c4dc-41bb-9677-67f51a09b05a.jpg?1",
             "name": "Scarred Puma",
             "text": "Scarred Puma can't attack unless a black or green creature also attacks.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "3f245e3d-b773-52e3-9910-4247079ae02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a85437f-052e-494c-a9ee-265c4624a409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a85437f-052e-494c-a9ee-265c4624a409.jpg?1",
             "name": "Scorching Lava",
             "text": "Kicker o\nR (You may pay an additional o\nR as you play this spell.)\nScorching Lava deals 2 damage to target creature or player. If you paid the kicker cost, that creature can't be regenerated this turn and if it would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "0608aeee-6efb-52de-b018-a38551928568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f66ff2d-f2d2-4a6b-bf26-b510de60c0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f66ff2d-f2d2-4a6b-bf26-b510de60c0b6.jpg?1",
             "name": "Searing Rays",
             "text": "Choose a color. Searing Rays deals damage to each player equal to the number of creatures of that color that player controls.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "89a20b6d-961d-5b0b-a8c2-7f0513a50dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c596e-492e-4cf5-857c-4ddbbdd78485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945c596e-492e-4cf5-857c-4ddbbdd78485.jpg?1",
             "name": "Shivan Emissary",
             "text": "Kicker o1o\nB (You may pay an additional o1o\nB as you play this spell.)\nWhen Shivan Emissary comes into play, if you paid the kicker cost, destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "75267792-5843-5ec4-a0e8-6160aae00b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dbd765-d7ea-4181-bd22-5c749ad081af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dbd765-d7ea-4181-bd22-5c749ad081af.jpg?1",
             "name": "Shivan Harvest",
             "text": "o1o\nR, Sacrifice a creature: Destroy target nonbasic land.",
             "colours": [
@@ -5702,7 +5702,7 @@
         },
         {
             "id": "f1d08a87-9980-573a-814a-e46bb5fbffb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be806378-50a7-4416-9d99-1ea2c1f2b7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be806378-50a7-4416-9d99-1ea2c1f2b7cb.jpg?1",
             "name": "Skittish Kavu",
             "text": "Skittish Kavu gets +1/+1 as long as no opponent controls a white or blue creature.",
             "colours": [
@@ -5736,7 +5736,7 @@
         },
         {
             "id": "8f32584c-1bd4-5cfb-8893-864d7e9e42c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7732bc-e168-44d9-923a-db7e985bd6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc7732bc-e168-44d9-923a-db7e985bd6db.jpg?1",
             "name": "Skizzik",
             "text": "Kicker o\nR (You may pay an additional o\nR as you play this spell.)\nTrample; haste (This creature may attack and oc\nT the turn it comes under your control.)\nAt end of turn, sacrifice Skizzik unless the kicker cost was paid.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "7c2e88d5-72d9-50af-8553-c9cef160bb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e82044d-88cd-4ee4-8ec9-e71a0a85ed46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e82044d-88cd-4ee4-8ec9-e71a0a85ed46.jpg?1",
             "name": "Slimy Kavu",
             "text": "oc\nT: Target land becomes a swamp until end of turn.",
             "colours": [
@@ -5804,7 +5804,7 @@
         },
         {
             "id": "1a00b769-32a5-5ed9-b39e-0948a00a69e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c34970-a106-490c-ac37-6156eb7f34ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c34970-a106-490c-ac37-6156eb7f34ce.jpg?1",
             "name": "Stand or Fall",
             "text": "At the beginning of your combat phase, separate all creatures defending player controls into two face-up piles. Only creatures in the pile of that player's choice may block this turn.",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "a07ddef0-5661-5d4c-b41c-0aadda87006b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22f3ae8-a40b-4dab-abf4-3ab7b05191f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22f3ae8-a40b-4dab-abf4-3ab7b05191f7.jpg?1",
             "name": "Stun",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -5868,7 +5868,7 @@
         },
         {
             "id": "40d0b1e1-b623-596c-8242-2e2500729d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0476cc6b-ecc6-44d6-9f44-a90d4ee85daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0476cc6b-ecc6-44d6-9f44-a90d4ee85daa.jpg?1",
             "name": "Tectonic Instability",
             "text": "Whenever a land comes into play, tap all lands its controller controls.",
             "colours": [
@@ -5900,7 +5900,7 @@
         },
         {
             "id": "b3f43efb-56eb-5cb7-bd8e-ae2f68041b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a0b075-5414-48d3-a2b1-47dc20213e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a0b075-5414-48d3-a2b1-47dc20213e96.jpg?1",
             "name": "Thunderscape Apprentice",
             "text": "o\nB, oc\nT: Target player loses 1 life.\no\nG, oc\nT: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -5937,7 +5937,7 @@
         },
         {
             "id": "1be1d3bf-0b18-525d-bf3e-bf3e68b8be38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22abdc2f-bdc8-46c4-8ce2-f06befedbc32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22abdc2f-bdc8-46c4-8ce2-f06befedbc32.jpg?1",
             "name": "Thunderscape Master",
             "text": "o\nBo\nB, oc\nT: Target player loses 2 life and you gain 2 life.\no\nGo\nG, oc\nT: Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "44172f98-4dc7-5202-b576-164297e0d495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32531e-c759-4603-abd0-1724e8df70db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b32531e-c759-4603-abd0-1724e8df70db.jpg?1",
             "name": "Tribal Flames",
             "text": "Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -6006,7 +6006,7 @@
         },
         {
             "id": "cbe9edd6-bde9-5d9e-8a9b-971fd00b7835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91392e9f-f96a-4ac5-b1f1-c73540cf249e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91392e9f-f96a-4ac5-b1f1-c73540cf249e.jpg?1",
             "name": "Turf Wound",
             "text": "Target player can't play land cards this turn.\nDraw a card.",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "9815060f-b2f5-55c7-8852-532c73fc9632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25a35-3ae4-471e-adcd-d8baf2f77b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25a35-3ae4-471e-adcd-d8baf2f77b68.jpg?1",
             "name": "Urza's Rage",
             "text": "Kicker o8o\nR (You may pay an additional o8o\nR as you play this spell.)\nUrza's Rage can't be countered by spells or abilities.\nUrza's Rage deals 3 damage to target creature or player. If you paid the kicker cost, instead Urza's Rage deals 10 damage to that creature or player and the damage can't be prevented.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "04a50982-107e-5b6b-9cc2-a77c3b103ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a94aeb4-349c-4394-848d-c1c9133856e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a94aeb4-349c-4394-848d-c1c9133856e2.jpg?1",
             "name": "Viashino Grappler",
             "text": "oo\nG Viashino Grappler gains trample until end of turn.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "d46f9ede-4479-5fda-b775-ebc32ebf7f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7502ce01-b762-40fe-a064-c7b20b08a722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7502ce01-b762-40fe-a064-c7b20b08a722.jpg?1",
             "name": "Zap",
             "text": "Zap deals 1 damage to target creature or player.\nDraw a card.",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "0153d3a5-b120-509b-8d6b-3cbe0d6c880f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e3154d-9b1c-4f93-9bc3-a39e68d59d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e3154d-9b1c-4f93-9bc3-a39e68d59d23.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "7590c9e7-2a83-5ee5-a77c-8bc5a1bcaf38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa51783-9ef8-4e51-ba0d-ce8439d83bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa51783-9ef8-4e51-ba0d-ce8439d83bdf.jpg?1",
             "name": "Bind",
             "text": "Counter target activated ability. (Mana abilities can't be countered.)\nDraw a card.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "80ad9a81-3a81-5935-a96a-062a2424c4ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073e3f-6a6f-495a-ab16-39d906b660f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073e3f-6a6f-495a-ab16-39d906b660f1.jpg?1",
             "name": "Blurred Mongoose",
             "text": "Blurred Mongoose can't be countered.\nBlurred Mongoose can't be the target of spells or abilities.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "841f1940-9744-5498-9c45-b5911bfdea34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19d68e-7554-4627-a316-beb1f75fa494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19d68e-7554-4627-a316-beb1f75fa494.jpg?1",
             "name": "Canopy Surge",
             "text": "Kicker o2 (You may pay an additional o2 as you play this spell.)\nCanopy Surge deals 1 damage to each creature with flying and each player. If you paid the kicker cost, Canopy Surge deals 4 damage to each creature with flying and each player instead.",
             "colours": [
@@ -6267,7 +6267,7 @@
         },
         {
             "id": "ba756da2-f8a5-58a0-abe2-adc16a058cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab9a90c-5fd8-4f8c-b692-f98a2974810c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab9a90c-5fd8-4f8c-b692-f98a2974810c.jpg?1",
             "name": "Elfhame Sanctuary",
             "text": "At the beginning of your upkeep, you may search your library for a basic land card, reveal that card, and put it into your hand. If you do, skip your draw step this turn and shuffle your library.",
             "colours": [
@@ -6299,7 +6299,7 @@
         },
         {
             "id": "4fb137a3-5fb7-5691-9294-19cacf292cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19bb473-03b0-4e6d-a7da-0ec1e7707a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19bb473-03b0-4e6d-a7da-0ec1e7707a68.jpg?1",
             "name": "Elvish Champion",
             "text": "All Elves get +1/+1 and have forestwalk. (They're unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -6333,7 +6333,7 @@
         },
         {
             "id": "abd2b195-2ec6-57e9-86d1-e08ad22c8b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc1e77-404c-436b-bde1-be1b21d00584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabc1e77-404c-436b-bde1-be1b21d00584.jpg?1",
             "name": "Explosive Growth",
             "text": "Kicker o5 (You may pay an additional o5 as you play this spell.)\nTarget creature gets +2/+2 until end of turn. If you paid the kicker cost, that creature gets +5/+5 until end of turn instead.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "0ca3e334-293f-56fc-8e2d-b7c845c6d33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789e3582-b541-4916-ac7e-015214d7a27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789e3582-b541-4916-ac7e-015214d7a27a.jpg?1",
             "name": "Fertile Ground",
             "text": "Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool.",
             "colours": [
@@ -6399,7 +6399,7 @@
         },
         {
             "id": "6fa83f5d-b589-5c30-8db2-f2ffb3c0e521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0f633e-7238-4d02-ad8b-06dd20453030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0f633e-7238-4d02-ad8b-06dd20453030.jpg?1",
             "name": "Harrow",
             "text": "As an additional cost to play Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them into play. Then shuffle your library.",
             "colours": [
@@ -6431,7 +6431,7 @@
         },
         {
             "id": "219c31c4-6f89-57de-8bbb-b49d3485b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3392171d-ed25-46a1-91cc-a4f24537617d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3392171d-ed25-46a1-91cc-a4f24537617d.jpg?1",
             "name": "Jade Leech",
             "text": "Green spells you play cost o\nG more to play.",
             "colours": [
@@ -6465,7 +6465,7 @@
         },
         {
             "id": "9e536848-aabd-569a-ac23-cc0860147bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726437b-a41a-4ee9-b0ee-e09327508615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726437b-a41a-4ee9-b0ee-e09327508615.jpg?1",
             "name": "Kavu Chameleon",
             "text": "Kavu Chameleon can't be countered.\noo\nG Kavu Chameleon becomes the color of your choice until end of turn.",
             "colours": [
@@ -6499,7 +6499,7 @@
         },
         {
             "id": "d4adcce9-399b-5378-a245-b077b127d1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2063f31e-d972-411e-a265-1d409153b49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2063f31e-d972-411e-a265-1d409153b49c.jpg?1",
             "name": "Kavu Climber",
             "text": "When Kavu Climber comes into play, draw a card.",
             "colours": [
@@ -6533,7 +6533,7 @@
         },
         {
             "id": "42ee6189-af57-50d0-bf0d-a3c6f14582e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4581b53-23a0-4ca6-a77c-97d79e7a6570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4581b53-23a0-4ca6-a77c-97d79e7a6570.jpg?1",
             "name": "Kavu Lair",
             "text": "Whenever a creature with power 4 or greater comes into play, its controller draws a card.",
             "colours": [
@@ -6565,7 +6565,7 @@
         },
         {
             "id": "245123d4-ed59-5436-a692-9905ba00726c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fb86d-1d9a-4da2-bb5b-4266faa20197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fb86d-1d9a-4da2-bb5b-4266faa20197.jpg?1",
             "name": "Kavu Titan",
             "text": "Kicker o2o\nG (You may pay an additional o2o\nG as you play this spell.)\nIf you paid the kicker cost, Kavu Titan comes into play with three +1/+1 counters on it and has trample.",
             "colours": [
@@ -6599,7 +6599,7 @@
         },
         {
             "id": "e95861b3-4774-5f3a-be25-35d7379f7ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d92191-a743-4916-bbe4-5e207e964d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d92191-a743-4916-bbe4-5e207e964d9b.jpg?1",
             "name": "Llanowar Cavalry",
             "text": "oo\nW Attacking doesn't cause Llanowar Cavalry to tap this turn.",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "dc4bc380-0f1c-5c65-a2e5-defb30ca2792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e207863-de68-47e1-8c63-413b5fa48943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e207863-de68-47e1-8c63-413b5fa48943.jpg?1",
             "name": "Llanowar Elite",
             "text": "Kicker o8 (You may pay an additional o8 as you play this spell.)\nTrample\nIf you paid the kicker cost, Llanowar Elite comes into play with five +1/+1 counters on it.",
             "colours": [
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "84e65f14-c7e3-54b1-8b2e-e2796b8ec82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e6ed79-bdfd-49f9-bfa4-be4196880487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e6ed79-bdfd-49f9-bfa4-be4196880487.jpg?1",
             "name": "Llanowar Vanguard",
             "text": "oc\nT: Llanowar Vanguard gets +0/+4 until end of turn.",
             "colours": [
@@ -6703,7 +6703,7 @@
         },
         {
             "id": "918c16ed-f450-5ea9-a7e6-3209f41df3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032a4ec7-82ce-4ea0-b0dd-ebc40823a014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032a4ec7-82ce-4ea0-b0dd-ebc40823a014.jpg?1",
             "name": "Might Weaver",
             "text": "o2: Target red or white creature gains trample until end of turn.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "d154e3e4-7e7b-5084-9082-479db0b849ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d3475-ae72-42c1-ae4d-638f8e7c6d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750d3475-ae72-42c1-ae4d-638f8e7c6d1a.jpg?1",
             "name": "Molimo, Maro-Sorcerer",
             "text": "Trample\nMolimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -6774,7 +6774,7 @@
         },
         {
             "id": "293b0202-3595-56db-89e7-48f5f582753e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69e57a-5b19-450c-9cf5-c189e8505781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b69e57a-5b19-450c-9cf5-c189e8505781.jpg?1",
             "name": "Nomadic Elf",
             "text": "o1oo\nG Add one mana of any color to your mana pool.",
             "colours": [
@@ -6809,7 +6809,7 @@
         },
         {
             "id": "c4df0559-a430-5463-a7f0-8a3edfc1e911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23271658-19ae-420d-beeb-4bed4fdbb891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23271658-19ae-420d-beeb-4bed4fdbb891.jpg?1",
             "name": "Pincer Spider",
             "text": "Kicker o3 (You may pay an additional o3 as you play this spell.)\nPincer Spider may block as though it had flying.\nIf you paid the kicker cost, Pincer Spider comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -6843,7 +6843,7 @@
         },
         {
             "id": "b02523e9-281a-5f38-84ff-bd195a070b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db09afe5-5f01-4f77-a239-12d7a6e59024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db09afe5-5f01-4f77-a239-12d7a6e59024.jpg?1",
             "name": "Pulse of Llanowar",
             "text": "If a basic land you control is tapped for mana, it produces mana of any one color instead of its normal type.",
             "colours": [
@@ -6875,7 +6875,7 @@
         },
         {
             "id": "daf26542-c17b-5118-9301-23f28078300f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c660a748-82a9-4d6a-8023-56aeafe1bdce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c660a748-82a9-4d6a-8023-56aeafe1bdce.jpg?1",
             "name": "Quirion Elves",
             "text": "As Quirion Elves comes into play, choose a color.\noc\nT: Add o\nG to your mana pool.\noc\nT: Add one mana of the chosen color to your mana pool.",
             "colours": [
@@ -6910,7 +6910,7 @@
         },
         {
             "id": "16ceb35a-725a-50eb-aa45-89c39636114d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc639ea-a925-4f1e-879f-b8fcb12bf257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc639ea-a925-4f1e-879f-b8fcb12bf257.jpg?1",
             "name": "Quirion Sentinel",
             "text": "When Quirion Sentinel comes into play, add one mana of any color to your mana pool.",
             "colours": [
@@ -6945,7 +6945,7 @@
         },
         {
             "id": "694df494-c86d-575b-aafc-45fc5d6caf81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b258c1-5fb4-4072-bb32-ad364df1874a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b258c1-5fb4-4072-bb32-ad364df1874a.jpg?1",
             "name": "Quirion Trailblazer",
             "text": "When Quirion Trailblazer comes into play, you may search your library for a basic land card and put that card into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -6980,7 +6980,7 @@
         },
         {
             "id": "26ea6f4c-017e-52fe-97b8-b232f6eafbfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a013ff-7c99-445a-b9e0-0fc45036f068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a013ff-7c99-445a-b9e0-0fc45036f068.jpg?1",
             "name": "Restock",
             "text": "Return two target cards from your graveyard to your hand. Remove Restock from the game.",
             "colours": [
@@ -7012,7 +7012,7 @@
         },
         {
             "id": "53ed4fee-3377-5d7f-a912-61fab6d150f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c25a4c-d93a-402b-999f-0b9919123cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c25a4c-d93a-402b-999f-0b9919123cc5.jpg?1",
             "name": "Rooting Kavu",
             "text": "When Rooting Kavu is put into a graveyard from play, you may remove Rooting Kavu from the game. If you do, shuffle all creature cards from your graveyard into your library.",
             "colours": [
@@ -7046,7 +7046,7 @@
         },
         {
             "id": "072eb147-bca8-5e01-8011-eece50d384a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8642e530-914c-4149-944a-c4966ee27299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8642e530-914c-4149-944a-c4966ee27299.jpg?1",
             "name": "Saproling Infestation",
             "text": "Whenever a player pays a kicker cost, you put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "1e76216a-6bc9-5682-b987-a5a60f30eb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb63748-5c84-43a0-8f17-a2a17f658337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb63748-5c84-43a0-8f17-a2a17f658337.jpg?1",
             "name": "Saproling Symbiosis",
             "text": "You may play Saproling Symbiosis any time you could play an instant if you pay o2 more to play it.\nPut a 1/1 green Saproling creature token into play for each creature you control.",
             "colours": [
@@ -7110,7 +7110,7 @@
         },
         {
             "id": "db27ccce-79fa-5a60-9db3-f495cc600f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b882e68-5c03-4ec6-9982-8c3b09847969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b882e68-5c03-4ec6-9982-8c3b09847969.jpg?1",
             "name": "Scouting Trek",
             "text": "Search your library for any number of basic land cards, reveal them, and set them aside. Shuffle your library, then put those cards on top of it in any order.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "acd79a2e-7ec5-55ab-b830-f0907637dd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699f1fe8-02c6-4d95-9231-3f8aefe603da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699f1fe8-02c6-4d95-9231-3f8aefe603da.jpg?1",
             "name": "Serpentine Kavu",
             "text": "oo\nR Serpentine Kavu gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "273addd9-bfed-5758-a579-9776d112e229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aeab16f-e104-47e7-81c7-b6e0123120d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aeab16f-e104-47e7-81c7-b6e0123120d7.jpg?1",
             "name": "Sulam Djinn",
             "text": "Trample\nSulam Djinn gets -2/-2 as long as green is the most common color among all permanents or is tied for most common.",
             "colours": [
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "2bed758b-472a-5996-b3a4-22746106425f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b37e39c-8aa4-4938-a492-7dac5de98dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b37e39c-8aa4-4938-a492-7dac5de98dfb.jpg?1",
             "name": "Tangle",
             "text": "Prevent all combat damage that would be dealt this turn.\nAttacking creatures don't untap during their controllers' next untap steps.",
             "colours": [
@@ -7243,7 +7243,7 @@
         },
         {
             "id": "9d00ac75-fb42-56d0-a458-d62f675c1115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80a56ed-3ebb-4e20-bf6a-e27127f762e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80a56ed-3ebb-4e20-bf6a-e27127f762e8.jpg?1",
             "name": "Thicket Elemental",
             "text": "Kicker o1o\nG (You may pay an additional o1o\nG as you play this spell.)\nWhen Thicket Elemental comes into play, if you paid the kicker cost, you may reveal cards from the top of your library until you reveal a creature card. If you do, put that card into play and shuffle all other cards revealed this way into your library.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "54ba1fb1-9146-50e1-9455-e08f70017499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505da522-73a8-4232-ae1a-d3365f3e598f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505da522-73a8-4232-ae1a-d3365f3e598f.jpg?1",
             "name": "Thornscape Apprentice",
             "text": "o\nW, oc\nT: Tap target creature.\no\nR, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "132611c4-6938-584d-98b8-7118db10fca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8f164d-3782-4eaa-a4db-ab7082d45ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8f164d-3782-4eaa-a4db-ab7082d45ee7.jpg?1",
             "name": "Thornscape Master",
             "text": "o\nRo\nR, oc\nT: Thornscape Master deals 2 damage to target creature.\no\nWo\nW, oc\nT: Target creature gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "268cc350-17ee-566c-a743-3c99bf81b126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97019ba5-ce2a-460c-8a4e-2b22053ced65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97019ba5-ce2a-460c-8a4e-2b22053ced65.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -7383,7 +7383,7 @@
         },
         {
             "id": "99e00888-9322-5725-8bd9-b2a73d5998a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6f5c0-686d-4b3a-add7-487f9fff5faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6f5c0-686d-4b3a-add7-487f9fff5faa.jpg?1",
             "name": "Treefolk Healer",
             "text": "o2o\nW, oc\nT: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "952deb18-a6f5-5f83-90b8-1042d92e9849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720452e9-3245-4b0e-94b6-843cbcb641a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720452e9-3245-4b0e-94b6-843cbcb641a5.jpg?1",
             "name": "Utopia Tree",
             "text": "oc\nT: Add one mana of any color to your mana pool.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "5fcbd11c-114b-558a-8878-4346a9c6f75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5fab1-fa20-4006-b19d-179d36238c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d5fab1-fa20-4006-b19d-179d36238c9b.jpg?1",
             "name": "Verdeloth the Ancient",
             "text": "Kicker o\nX (You may pay an additional o\nX as you play this spell.)\nAll other Treefolk and all Saprolings get +1/+1.\nWhen Verdeloth the Ancient comes into play, if you paid the kicker cost, put X 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "ed883ebe-bd25-530b-9b40-3cfcd7089f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f3361b-e2e7-4297-85c2-94323f90cc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f3361b-e2e7-4297-85c2-94323f90cc90.jpg?1",
             "name": "Verduran Emissary",
             "text": "Kicker o1o\nR (You may pay an additional o1o\nR as you play this spell.)\nWhen Verduran Emissary comes into play, if you paid the kicker cost, destroy target artifact. It can't be regenerated.",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "38857791-44b9-5c9a-abc0-6268c0d34885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6f57ad-d370-4c81-8da0-c15d87725ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6f57ad-d370-4c81-8da0-c15d87725ab1.jpg?1",
             "name": "Vigorous Charge",
             "text": "Kicker o\nW (You may pay an additional o\nW as you play this spell.)\nTarget creature gains trample until end of turn. Whenever that creature deals combat damage this turn, if you paid the kicker cost, you gain life equal to that damage.",
             "colours": [
@@ -7558,7 +7558,7 @@
         },
         {
             "id": "4a1ddbb5-132e-562d-bc68-6d13ef1c0cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ce5126-e7b1-41ab-9e56-1e12927c4d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ce5126-e7b1-41ab-9e56-1e12927c4d27.jpg?1",
             "name": "Wallop",
             "text": "Destroy target blue or black creature with flying.",
             "colours": [
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "645b4b5b-1727-50b2-a826-3daa9021f16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da5cb6c-253b-44f0-98f9-d75f42c6e14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da5cb6c-253b-44f0-98f9-d75f42c6e14b.jpg?1",
             "name": "Wandering Stream",
             "text": "You gain 2 life for each basic land type among lands you control.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "f4354647-67c8-5ac6-92e5-c9b44c865286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10566804-fd15-4ef0-ad7d-cc979f4cc8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10566804-fd15-4ef0-ad7d-cc979f4cc8c5.jpg?1",
             "name": "Whip Silk",
             "text": "Enchanted creature may block as though it had flying.\noo\nG Return Whip Silk to its owner's hand.",
             "colours": [
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "d6fa9c57-71c2-5e2b-a28e-c2416c13b467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6a0f3e-457f-41f5-be26-5fb249874f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6a0f3e-457f-41f5-be26-5fb249874f1a.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "0c71533f-09b0-51db-927b-c615ac909e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692c186a-997c-4f7e-a339-bf84884e1019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692c186a-997c-4f7e-a339-bf84884e1019.jpg?1",
             "name": "Aether Rift",
             "text": "At the beginning of your upkeep, discard a card at random from your hand. If you discard a creature card this way, put that card into play unless any player pays 5 life.",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "8cbffc6d-c248-5f00-8e41-ffdcef757646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaa3e4e-4e08-4df2-9e0c-66e15a10fec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaa3e4e-4e08-4df2-9e0c-66e15a10fec4.jpg?1",
             "name": "Angelic Shield",
             "text": "Creatures you control get +0/+1.\nSacrifice Angelic Shield: Return target creature to its owner's hand.",
             "colours": [
@@ -7758,7 +7758,7 @@
         },
         {
             "id": "a47b330a-ac90-5b76-b4ea-2c0d67fa22a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d816f98-6cb6-432c-b0a4-a0eed21658ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d816f98-6cb6-432c-b0a4-a0eed21658ac.jpg?1",
             "name": "Armadillo Cloak",
             "text": "Enchanted creature gets +2/+2 and has trample.\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -7794,7 +7794,7 @@
         },
         {
             "id": "24aa424d-dbd8-53a3-9333-a9a892dde939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de5e1bd-1d31-4f9f-b18d-d6f49bc7ef10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de5e1bd-1d31-4f9f-b18d-d6f49bc7ef10.jpg?1",
             "name": "Armored Guardian",
             "text": "o1o\nWo\nW Target creature you control gains protection from the color of your choice until end of turn.\no1o\nUo\nU Armored Guardian can't be the target of spells or abilities this turn.",
             "colours": [
@@ -7831,7 +7831,7 @@
         },
         {
             "id": "ebace84a-ad06-54eb-ba91-c864b5e88823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eef49c-a80f-4622-ba77-999f9151c841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eef49c-a80f-4622-ba77-999f9151c841.jpg?1",
             "name": "Artifact Mutation",
             "text": "Destroy target artifact. It can't be regenerated. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "850d9673-72b6-5a09-bce9-c494659eec46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38421179-615e-4aba-91a4-503bfee05403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38421179-615e-4aba-91a4-503bfee05403.jpg?1",
             "name": "Aura Mutation",
             "text": "Destroy target enchantment. Put X 1/1 green Saproling creature tokens into play, where X is its converted mana cost.",
             "colours": [
@@ -7899,7 +7899,7 @@
         },
         {
             "id": "c27d1814-e867-5f08-bc75-d4ad0d57b5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4039ef-af72-4267-ade9-fdb7c921279e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4039ef-af72-4267-ade9-fdb7c921279e.jpg?1",
             "name": "Aura Shards",
             "text": "Whenever a creature comes into play under your control, you may destroy target artifact or enchantment.",
             "colours": [
@@ -7933,7 +7933,7 @@
         },
         {
             "id": "5315a8ae-0945-5c8e-ad7b-f5e5a94dec9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadf030d-5451-43fc-bf0c-c1629fdf88ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dadf030d-5451-43fc-bf0c-c1629fdf88ec.jpg?1",
             "name": "Backlash",
             "text": "Tap target untapped creature. That creature deals damage equal to its power to its controller.",
             "colours": [
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "991bafe8-ad32-5981-a173-f41d4a9a4818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8ec4dc-c74a-4d49-856e-95703675fe9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8ec4dc-c74a-4d49-856e-95703675fe9b.jpg?1",
             "name": "Barrin's Spite",
             "text": "Choose two target creatures controlled by one player. That player chooses and sacrifices one of them. Return the other to its owner's hand.",
             "colours": [
@@ -8001,7 +8001,7 @@
         },
         {
             "id": "0714ccbf-5744-5ebf-af59-b77055767760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd397be-0e61-4f41-b0cf-f0c9d2440da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd397be-0e61-4f41-b0cf-f0c9d2440da7.jpg?1",
             "name": "Blazing Specter",
             "text": "Flying; haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhenever Blazing Specter deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -8037,7 +8037,7 @@
         },
         {
             "id": "c772e5f6-1801-5f7b-bbc4-06f1dd8282dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d441c-f37f-44fe-8a93-f5c89df807e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d441c-f37f-44fe-8a93-f5c89df807e4.jpg?1",
             "name": "Captain Sisay",
             "text": "oc\nT: Search your library for a Legend or legendary card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "7fb5c732-3aa0-5669-87a9-6b34d45a4cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dadcae0-f2b2-487c-bb93-0a2c073044c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dadcae0-f2b2-487c-bb93-0a2c073044c0.jpg?1",
             "name": "Cauldron Dance",
             "text": "Play Cauldron Dance only during combat.\nReturn target creature card from your graveyard to play. That creature gains haste. Return it to your hand at end of turn.\nPut a creature card from your hand into play. That creature gains haste. Put it into your graveyard at end of turn.",
             "colours": [
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "9f2cf254-e41d-58a0-903b-10aeea4184bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58956099-6b97-4c7b-ab23-9f9b4d50ef95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58956099-6b97-4c7b-ab23-9f9b4d50ef95.jpg?1",
             "name": "Charging Troll",
             "text": "Attacking doesn't cause Charging Troll to tap.\noo\nG Regenerate Charging Troll.",
             "colours": [
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "9fff4c32-dc8f-56ab-81e7-011ff29b33de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd933a-19ed-4d30-a94a-bfb2f66f8f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dd933a-19ed-4d30-a94a-bfb2f66f8f13.jpg?1",
             "name": "Cinder Shade",
             "text": "oo\nB Cinder Shade gets +1/+1 until end of turn.\no\nR, Sacrifice Cinder Shade: Cinder Shade deals damage equal to its power to target creature.",
             "colours": [
@@ -8182,7 +8182,7 @@
         },
         {
             "id": "4325d429-05f6-5549-b104-9c80c6ce21f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ad3aa-3225-45ae-8343-5991f5b52269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ad3aa-3225-45ae-8343-5991f5b52269.jpg?1",
             "name": "Coalition Victory",
             "text": "You win the game if you control a land of each basic land type and a creature of each color.",
             "colours": [
@@ -8222,7 +8222,7 @@
         },
         {
             "id": "07eb5558-bd9d-5a21-a410-677031c63cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f336d8-12a4-482d-8ffd-c205858c72ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f336d8-12a4-482d-8ffd-c205858c72ba.jpg?1",
             "name": "Crosis, the Purger",
             "text": "Flying\nWhenever Crosis, the Purger deals combat damage to a player, you may pay o2o\nB. If you do, choose a color. That player reveals his or her hand and discards all cards of that color from it.",
             "colours": [
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "109b1c56-f677-5a3b-a3e1-a7da68b82463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dcf5e3-4303-41a3-b54c-24a9d462ce07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dcf5e3-4303-41a3-b54c-24a9d462ce07.jpg?1",
             "name": "Darigaaz, the Igniter",
             "text": "Flying\nWhenever Darigaaz, the Igniter deals combat damage to a player, you may pay o2o\nR. If you do, choose a color. That player reveals his or her hand and Darigaaz deals X damage to him or her, where X is the number of cards revealed of that color.",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "a3b1b0b0-f51c-5fcd-a198-325f08a96b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc3c72-fff5-454c-814c-eb952fd23ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc3c72-fff5-454c-814c-eb952fd23ba9.jpg?1",
             "name": "Dromar, the Banisher",
             "text": "Flying\nWhenever Dromar, the Banisher deals combat damage to a player, you may pay o2o\nU. If you do, choose a color. Return all creatures of that color to their owners' hands.",
             "colours": [
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "e4ea6495-37c7-5702-94e9-bf8adeb856c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52760183-bee0-4ce0-96c0-074b88f78980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52760183-bee0-4ce0-96c0-074b88f78980.jpg?1",
             "name": "Dueling Grounds",
             "text": "No more than one creature may attack each turn.\nNo more than one creature may block each turn.",
             "colours": [
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "6a853699-3d59-52f7-a8ac-24b8a6fe0e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967f1658-8777-46fc-a648-07fb19e46745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967f1658-8777-46fc-a648-07fb19e46745.jpg?1",
             "name": "Fires of Yavimaya",
             "text": "Creatures you control have haste. (They may attack and oc\nT the turn they come under your control.)\nSacrifice Fires of Yavimaya: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "8850b430-c617-5152-929e-b0ebded0aef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15875876-3341-40fb-866f-5587c3638538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15875876-3341-40fb-866f-5587c3638538.jpg?1",
             "name": "Frenzied Tilling",
             "text": "Destroy target land. Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "310edd9a-0fe4-5fd7-a78c-015553cb8a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b492d6-5e28-4f4b-942c-080d03cb0e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b492d6-5e28-4f4b-942c-080d03cb0e92.jpg?1",
             "name": "Galina's Knight",
             "text": "Protection from red",
             "colours": [
@@ -8481,7 +8481,7 @@
         },
         {
             "id": "eadc61a4-a3b4-5b8c-8611-5cfe24dbab37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a4e48d-6452-4245-bdad-63fe3263550e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a4e48d-6452-4245-bdad-63fe3263550e.jpg?1",
             "name": "Hanna, Ship's Navigator",
             "text": "o1o\nWo\nU, oc\nT: Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -8520,7 +8520,7 @@
         },
         {
             "id": "53728906-e771-5f7e-9c3a-fbf5621f4ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d6043-5ec1-4ad4-8296-41fe23f11cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d6043-5ec1-4ad4-8296-41fe23f11cb9.jpg?1",
             "name": "Heroes' Reunion",
             "text": "Target player gains 7 life.",
             "colours": [
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "5d51907a-3db1-5501-a905-c0e452a5d63d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ad983-ce91-40b6-a1ce-fe36ec7fbce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ad983-ce91-40b6-a1ce-fe36ec7fbce8.jpg?1",
             "name": "Horned Cheetah",
             "text": "Whenever Horned Cheetah deals damage, you gain that much life.",
             "colours": [
@@ -8590,7 +8590,7 @@
         },
         {
             "id": "b2b8dc5e-ee46-54f6-b9d5-ec5d8642077c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8943304a-89c9-48b0-97b4-3e1aa690ca4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8943304a-89c9-48b0-97b4-3e1aa690ca4d.jpg?1",
             "name": "Hunting Kavu",
             "text": "o1o\nRo\nG, oc\nT: Remove from the game Hunting Kavu and target creature without flying that's attacking you.",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "ac22c757-ce78-5cd1-896d-b0b0d84b1d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afd7e8e-4fcc-4003-9791-7baf10ef1880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afd7e8e-4fcc-4003-9791-7baf10ef1880.jpg?1",
             "name": "Kangee, Aerie Keeper",
             "text": "Kicker o2o\nX (You may pay an additional o2o\nX as you play this spell.)\nFlying\nWhen Kangee, Aerie Keeper comes into play, if you paid the kicker cost, put X feather counters on it.\nAll Birds get +1/+1 for each feather counter on Kangee, Aerie Keeper.",
             "colours": [
@@ -8665,7 +8665,7 @@
         },
         {
             "id": "8c607d03-8945-5a57-9504-8faaf8aef642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c75d89-e432-49aa-a407-555b223b7eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c75d89-e432-49aa-a407-555b223b7eff.jpg?1",
             "name": "Llanowar Knight",
             "text": "Protection from black",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "d709042f-ba40-5e8f-b08c-5f044b263bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff307dbb-4ab6-457b-be56-47106864bf61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff307dbb-4ab6-457b-be56-47106864bf61.jpg?1",
             "name": "Lobotomy",
             "text": "Look at target player's hand and choose a card other than a basic land card from it. Search that player's graveyard, hand, and library for all cards with the same name as the chosen card and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "e22268a3-6e28-53db-a5d5-f221b4a0ffde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36489b24-f8a8-46b6-b879-0a5ce400a6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36489b24-f8a8-46b6-b879-0a5ce400a6dc.jpg?1",
             "name": "Meteor Storm",
             "text": "o2o\nRo\nG, Discard two cards at random from your hand: Meteor Storm deals 4 damage to target creature or player.",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "85447ea1-ad6b-5f00-bab7-f306c9477f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f327818-8222-4295-8cef-118757b34d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f327818-8222-4295-8cef-118757b34d17.jpg?1",
             "name": "Noble Panther",
             "text": "o1: Noble Panther gains first strike until end of turn.",
             "colours": [
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "ad9a256b-78b4-5ee1-9d41-bf77362b2fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d83a07-6054-45f1-bdf9-07f2006238d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d83a07-6054-45f1-bdf9-07f2006238d2.jpg?1",
             "name": "Ordered Migration",
             "text": "Put a 1/1 blue Bird creature token with flying into play for each basic land type among lands you control.",
             "colours": [
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "9ca122f6-78d5-5a94-abe0-e4c6798fb1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4183e73d-609a-4292-b173-e39eb51949f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4183e73d-609a-4292-b173-e39eb51949f3.jpg?1",
             "name": "Overabundance",
             "text": "Whenever a player taps a land for mana, that player adds one additional mana to his or her mana pool of the same type, and Overabundance deals 1 damage to him or her.",
             "colours": [
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "00551690-1726-5f86-a5f1-a7d2e7f64c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d106d56-a688-49cc-8d5d-0279a5a7c0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d106d56-a688-49cc-8d5d-0279a5a7c0a7.jpg?1",
             "name": "Plague Spores",
             "text": "Destroy target nonblack creature and target land. They can't be regenerated.",
             "colours": [
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "e3e337a0-1acd-5490-b09d-77b1b41478ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c030108-2995-4fb0-9b80-efdfdd0f11e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c030108-2995-4fb0-9b80-efdfdd0f11e0.jpg?1",
             "name": "Pyre Zombie",
             "text": "At the beginning of your upkeep, if Pyre Zombie is in your graveyard, you may pay o1o\nBo\nB. If you do, return Pyre Zombie from your graveyard to your hand.\no1o\nRo\nR, Sacrifice Pyre Zombie: Pyre Zombie deals 2 damage to target creature or player.",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "1cae53a0-e015-52a1-9527-293bf58349d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573679-e9e5-4bfc-b5d5-85d4648b01b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573679-e9e5-4bfc-b5d5-85d4648b01b6.jpg?1",
             "name": "Raging Kavu",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nYou may play Raging Kavu any time you could play an instant.",
             "colours": [
@@ -8980,7 +8980,7 @@
         },
         {
             "id": "937458fe-54dd-5d84-a42d-2d56b2643f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0f568e-4d3a-40a5-b72a-63040ec5402d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0f568e-4d3a-40a5-b72a-63040ec5402d.jpg?1",
             "name": "Reckless Assault",
             "text": "o1, Pay 2 life: Reckless Assault deals 1 damage to target creature or player.",
             "colours": [
@@ -9014,7 +9014,7 @@
         },
         {
             "id": "d35caa38-6f96-5dd7-acae-788238dcc861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a77be3-e3b0-40f5-a470-414bac49da60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a77be3-e3b0-40f5-a470-414bac49da60.jpg?1",
             "name": "Recoil",
             "text": "Return target permanent to its owner's hand. Then that player discards a card from his or her hand.",
             "colours": [
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "57810cc8-f3bf-54d6-87da-c24d59afb833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a23c32-e122-400b-b252-e636ea2e684b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a23c32-e122-400b-b252-e636ea2e684b.jpg?1",
             "name": "Reviving Vapors",
             "text": "Reveal the top three cards of your library and put one of them into your hand. You gain life equal to that card's converted mana cost. Put the other cards revealed this way into your graveyard.",
             "colours": [
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "0e7f60e9-03bd-5dcd-8306-414c2d1c31f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e42ae1d-62b4-4b19-aafc-f12bdd6fb8cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e42ae1d-62b4-4b19-aafc-f12bdd6fb8cc.jpg?1",
             "name": "Riptide Crab",
             "text": "Attacking doesn't cause Riptide Crab to tap.\nWhen Riptide Crab is put into a graveyard from play, draw a card.",
             "colours": [
@@ -9118,7 +9118,7 @@
         },
         {
             "id": "407c7653-cdb7-5fc8-becd-a33a1e5817cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30be387-280d-49bd-a3d1-c1636ee931ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30be387-280d-49bd-a3d1-c1636ee931ce.jpg?1",
             "name": "Rith, the Awakener",
             "text": "Flying\nWhenever Rith, the Awakener deals combat damage to a player, you may pay o2o\nG. If you do, choose a color. Put a 1/1 green Saproling creature token into play for each permanent of that color.",
             "colours": [
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "55d31234-d3b2-5ec7-9309-b7609f4d7f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8338c296-cf3f-41d7-b380-3fb4237cb41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8338c296-cf3f-41d7-b380-3fb4237cb41c.jpg?1",
             "name": "Sabertooth Nishoba",
             "text": "Trample, protection from blue, protection from red",
             "colours": [
@@ -9196,7 +9196,7 @@
         },
         {
             "id": "3070d12c-3e50-5e11-a9d8-9f251cece574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a262d7-6d0c-43d0-89b6-9f46a1a9eb69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a262d7-6d0c-43d0-89b6-9f46a1a9eb69.jpg?1",
             "name": "Samite Archer",
             "text": "oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\noc\nT: Samite Archer deals 1 damage to target creature or player.",
             "colours": [
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "10964488-7fa3-558c-84ec-335fa2d9011e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c94618a-808c-4b3c-8f34-45e64d0414d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c94618a-808c-4b3c-8f34-45e64d0414d3.jpg?1",
             "name": "Seer's Vision",
             "text": "All opponents play with their hands revealed.\nSacrifice Seer's Vision: Look at target player's hand and choose a card from it. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -9268,7 +9268,7 @@
         },
         {
             "id": "203bf647-b1f7-547b-a5ea-86dbcbc9f759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c99269-f730-4d33-bbce-9e855e9ad0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c99269-f730-4d33-bbce-9e855e9ad0fc.jpg?1",
             "name": "Shivan Zombie",
             "text": "Protection from white",
             "colours": [
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "093a9087-e840-52a3-bc44-d69f8b81f886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b1930d-2e4b-472f-98a9-008fd632f3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b1930d-2e4b-472f-98a9-008fd632f3be.jpg?1",
             "name": "Simoon",
             "text": "Simoon deals 1 damage to each creature target opponent controls.",
             "colours": [
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "19b06952-090b-559d-8311-63be9b224846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411f0fd-8b85-4d0d-a202-701a24ffac9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411f0fd-8b85-4d0d-a202-701a24ffac9f.jpg?1",
             "name": "Sleeper's Robe",
             "text": "Enchanted creature can't be blocked except by artifact creatures and/or black creatures.\nWhenever enchanted creature deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -9376,7 +9376,7 @@
         },
         {
             "id": "5d987cb6-127f-53e7-9e84-11d386012ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a7004-5a28-4ccb-8640-ad6b07b51ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a7004-5a28-4ccb-8640-ad6b07b51ece.jpg?1",
             "name": "Slinking Serpent",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -9412,7 +9412,7 @@
         },
         {
             "id": "24eb4558-a7a2-5659-a8e6-3170165f002f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdc55c0-c8ac-49d5-969b-9bf0ee8e696c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdc55c0-c8ac-49d5-969b-9bf0ee8e696c.jpg?1",
             "name": "Smoldering Tar",
             "text": "At the beginning of your upkeep, target player loses 1 life.\nSacrifice Smoldering Tar: Smoldering Tar deals 4 damage to target creature. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -9446,7 +9446,7 @@
         },
         {
             "id": "683d145b-14ba-5acc-8949-1fa8bf01b66c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ad1eb-62a3-4560-bf8e-35f7db73c7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692ad1eb-62a3-4560-bf8e-35f7db73c7a3.jpg?1",
             "name": "Spinal Embrace",
             "text": "Play Spinal Embrace only during combat.\nUntap target creature you don't control and gain control of it. It gains haste until end of turn. At end of turn, sacrifice it. If you do, you gain life equal to its toughness. (The creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -9480,7 +9480,7 @@
         },
         {
             "id": "be22a23d-18dc-527a-a2c2-161c2b9e74e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8cc71f-3070-497f-908f-35aa13a8a857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8cc71f-3070-497f-908f-35aa13a8a857.jpg?1",
             "name": "Stalking Assassin",
             "text": "o3o\nU, oc\nT: Tap target creature.\no3o\nB, oc\nT: Destroy target tapped creature.",
             "colours": [
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "7173fd5f-9402-5f9a-afea-2874eacd6aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b26aa3-8169-4978-9554-bd2fc8e18e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b26aa3-8169-4978-9554-bd2fc8e18e3b.jpg?1",
             "name": "Sterling Grove",
             "text": "All other enchantments you control can't be the targets of spells or abilities.\no1, Sacrifice Sterling Grove: Search your library for an enchantment card and reveal that card. Shuffle your library, then put the card on top of it.",
             "colours": [
@@ -9551,7 +9551,7 @@
         },
         {
             "id": "48757829-4add-5c06-b25b-8c190937b1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5845c-ef6d-4a7b-b725-b09d3e9bbc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5845c-ef6d-4a7b-b725-b09d3e9bbc17.jpg?1",
             "name": "Teferi's Moat",
             "text": "As Teferi's Moat comes into play, choose a color.\nCreatures of the chosen color without flying can't attack you.",
             "colours": [
@@ -9585,7 +9585,7 @@
         },
         {
             "id": "f458838a-42ee-5ea4-ba79-0d84f3639f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee67039-6cee-4a2d-b973-570f5060f550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee67039-6cee-4a2d-b973-570f5060f550.jpg?1",
             "name": "Treva, the Renewer",
             "text": "Flying\nWhenever Treva, the Renewer deals combat damage to a player, you may pay o2o\nW. If you do, choose a color. You gain 1 life for each permanent of that color.",
             "colours": [
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "969e8310-2492-5803-90eb-4dbfb49b1be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbe2539-7a7c-468b-a270-7ca1bdcccb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbe2539-7a7c-468b-a270-7ca1bdcccb1e.jpg?1",
             "name": "Tsabo Tavoc",
             "text": "First strike, protection from Legends\no\nBo\nB, oc\nT: Destroy target Legend. It can't be regenerated.",
             "colours": [
@@ -9664,7 +9664,7 @@
         },
         {
             "id": "5f17ee2f-3b46-532a-ad55-ef35d163877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2334bc71-5f85-47ff-b393-601a1e746a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2334bc71-5f85-47ff-b393-601a1e746a4e.jpg?1",
             "name": "Undermine",
             "text": "Counter target spell. Its controller loses 3 life.",
             "colours": [
@@ -9698,7 +9698,7 @@
         },
         {
             "id": "4d7300a1-8a5e-5acc-950a-8abc4a11c5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d1327e-bf87-423f-8a04-8124e45b9ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d1327e-bf87-423f-8a04-8124e45b9ae0.jpg?1",
             "name": "Urborg Drake",
             "text": "Flying\nUrborg Drake attacks each turn if able.",
             "colours": [
@@ -9734,7 +9734,7 @@
         },
         {
             "id": "24510a16-8953-555d-8142-9d01b0e9b440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e9e629-7c25-4d45-aa35-9ba5f95b43cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e9e629-7c25-4d45-aa35-9ba5f95b43cb.jpg?1",
             "name": "Vicious Kavu",
             "text": "Whenever Vicious Kavu attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -9770,7 +9770,7 @@
         },
         {
             "id": "688e6e69-91d9-5cde-a7d1-924b5c172605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e5716-77f3-45d2-a40a-f5bf500f6ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7e5716-77f3-45d2-a40a-f5bf500f6ad7.jpg?1",
             "name": "Vile Consumption",
             "text": "All creatures have \"At the beginning of your upkeep, sacrifice this creature unless you pay 1 life.\"",
             "colours": [
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "84417e9d-98e0-592e-aca5-b4dff3107db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30a5a06-32ce-4d71-b71f-e3e1d8d4511a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30a5a06-32ce-4d71-b71f-e3e1d8d4511a.jpg?1",
             "name": "Vodalian Zombie",
             "text": "Protection from green",
             "colours": [
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "b140423a-9454-5665-a886-fdacf8ae482d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dc1df7-b9db-4f5f-a340-08287cd3d9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dc1df7-b9db-4f5f-a340-08287cd3d9e5.jpg?1",
             "name": "Void",
             "text": "Choose a number. Destroy all artifacts and creatures with converted mana cost equal to that number. Then target player reveals his or her hand and discards from it all nonland cards with converted mana cost equal to the number.",
             "colours": [
@@ -9875,7 +9875,7 @@
         },
         {
             "id": "523f5d45-c048-5eb6-a2cd-af4ee0b345ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8c5669-11a9-4d95-8431-7065037f1fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8c5669-11a9-4d95-8431-7065037f1fb6.jpg?1",
             "name": "Voracious Cobra",
             "text": "First strike\nWhenever Voracious Cobra deals combat damage to a creature, destroy that creature.",
             "colours": [
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "1b28e5aa-9f17-5eaa-95f2-1d7aa096bf51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0d2402-f1ef-4a71-ac01-c7099c4ce54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0d2402-f1ef-4a71-ac01-c7099c4ce54c.jpg?1",
             "name": "Wings of Hope",
             "text": "Enchanted creature gets +1/+3 and has flying.",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "3d6edfdd-0298-5aee-b394-defb04a70052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17377d-4dad-4144-b0ce-c849636096a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17377d-4dad-4144-b0ce-c849636096a2.jpg?1",
             "name": "Yavimaya Barbarian",
             "text": "Protection from blue",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "137cb1a7-427e-522e-aa59-f62dcd193409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1872f104-7cf1-41e3-b1b4-ca75c678e08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1872f104-7cf1-41e3-b1b4-ca75c678e08b.jpg?1",
             "name": "Yavimaya Kavu",
             "text": "Yavimaya Kavu's power is equal to the number of red creatures in play.\nYavimaya Kavu's toughness is equal to the number of green creatures in play.",
             "colours": [
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "e083d28d-dbae-5c2b-a7a1-308052cd9483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg?1",
             "name": "Stand // Deliver",
             "text": "Prevent the next 2 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -10053,7 +10053,7 @@
         },
         {
             "id": "729b77ee-d817-5981-bda1-d13b592a2af2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be8b338f-6f05-43c6-beeb-c5052cc0d6a9.jpg?1",
             "name": "Stand // Deliver",
             "text": "Prevent the next 2 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "fef58ab8-d9d8-53ba-b6bd-d9de6dd60137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg?1",
             "name": "Spite // Malice",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -10119,7 +10119,7 @@
         },
         {
             "id": "b3344b6d-5b60-506a-ab2b-833eaedde3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/054f1845-196f-41c1-9682-042171cccd49.jpg?1",
             "name": "Spite // Malice",
             "text": "Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -10152,7 +10152,7 @@
         },
         {
             "id": "7fe20b60-6f9f-5956-aa75-baff3f07a1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg?1",
             "name": "Pain // Suffering",
             "text": "Target player discards a card from his or her hand.",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "7cd8bb84-271e-55a0-9b5a-4e96437b49e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81be27d6-e16f-4158-b2b6-66a0f3315327.jpg?1",
             "name": "Pain // Suffering",
             "text": "Target player discards a card from his or her hand.",
             "colours": [
@@ -10218,7 +10218,7 @@
         },
         {
             "id": "1407fbbd-8bc8-52e3-9b35-ee9df8017530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg?1",
             "name": "Assault // Battery",
             "text": "Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "85344e88-7453-5e12-b621-b0fb8362560a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec6a889-c941-4898-a2f6-4d3863faf535.jpg?1",
             "name": "Assault // Battery",
             "text": "Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -10284,7 +10284,7 @@
         },
         {
             "id": "fc84f5cd-fd2f-5402-ac0f-ad92bf25e493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg?1",
             "name": "Wax // Wane",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "a5cca3be-220e-5bbb-a6f0-98252ed72871",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19859061-f5ec-4b7f-86a1-196f98648e0a.jpg?1",
             "name": "Wax // Wane",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -10350,7 +10350,7 @@
         },
         {
             "id": "216c366c-c7f9-5a99-be05-3cdc801cbc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb6d6a1-9d71-405b-9c93-1a7f06c67abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb6d6a1-9d71-405b-9c93-1a7f06c67abd.jpg?1",
             "name": "Alloy Golem",
             "text": "As Alloy Golem comes into play, choose a color.\nAlloy Golem is the chosen color. (It's still an artifact.)",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "3f8395f6-a708-5bf5-810f-1186b9a5a5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db32fa-64b2-4ef6-88f2-28e758d420bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db32fa-64b2-4ef6-88f2-28e758d420bb.jpg?1",
             "name": "Bloodstone Cameo",
             "text": "oc\nT: Add o\nB or o\nR to your mana pool.",
             "colours": [],
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "f14f94ca-8041-5a7f-9411-2308e8230d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920cd17f-9274-443e-906f-c9904f0658d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920cd17f-9274-443e-906f-c9904f0658d5.jpg?1",
             "name": "Chromatic Sphere",
             "text": "o1, oc\nT, Sacrifice Chromatic Sphere: Add one mana of any color to your mana pool. Draw a card.",
             "colours": [],
@@ -10440,7 +10440,7 @@
         },
         {
             "id": "67913c1b-e26d-5a8e-8a6e-3e41f45ef70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45edc18c-2046-4d0e-92fe-a6cf4aaf1c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45edc18c-2046-4d0e-92fe-a6cf4aaf1c6f.jpg?1",
             "name": "Crosis's Attendant",
             "text": "o1, Sacrifice Crosis's Attendant: Add o\nUo\nBo\nR to your mana pool.",
             "colours": [],
@@ -10475,7 +10475,7 @@
         },
         {
             "id": "4631013f-ce7b-553f-8d72-eec26a17e917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22b575-443a-4c06-8e75-d4140cbd3660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22b575-443a-4c06-8e75-d4140cbd3660.jpg?1",
             "name": "Darigaaz's Attendant",
             "text": "o1, Sacrifice Darigaaz's Attendant: Add o\nBo\nRo\nG to your mana pool.",
             "colours": [],
@@ -10510,7 +10510,7 @@
         },
         {
             "id": "8699d1db-7277-50c5-a544-aff0876b9989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ce135-9c2f-45bd-b2db-c0e00c50c964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3ce135-9c2f-45bd-b2db-c0e00c50c964.jpg?1",
             "name": "Drake-Skull Cameo",
             "text": "oc\nT: Add o\nU or o\nB to your mana pool.",
             "colours": [],
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "6321fbfb-367e-546c-a88d-9b08e67c99e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24936fa9-41a3-4da5-91cf-c28fa45f47c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24936fa9-41a3-4da5-91cf-c28fa45f47c9.jpg?1",
             "name": "Dromar's Attendant",
             "text": "o1, Sacrifice Dromar's Attendant: Add o\nWo\nUo\nB to your mana pool.",
             "colours": [],
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "fd3a0f4b-57ab-504b-a37f-43a982b8dfb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab7cf53-f62d-47e1-af70-ab12be0d22e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab7cf53-f62d-47e1-af70-ab12be0d22e2.jpg?1",
             "name": "Juntu Stakes",
             "text": "Creatures with power 1 or less don't untap during their controllers' untap steps.",
             "colours": [],
@@ -10604,7 +10604,7 @@
         },
         {
             "id": "fe6296c7-1e0f-51dc-90c3-a73ada8ea690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfc6396-5377-4ab3-9c10-8abcdeae2aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfc6396-5377-4ab3-9c10-8abcdeae2aa1.jpg?1",
             "name": "Lotus Guardian",
             "text": "Flying\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10635,7 +10635,7 @@
         },
         {
             "id": "f152bcf8-73a3-5bd0-9368-5ccdaeeac21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25158cd5-749b-408c-9ab1-0f83e38730f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25158cd5-749b-408c-9ab1-0f83e38730f7.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "970e17f1-fb18-5869-b9f7-0f4b403769c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec9a91d-7af0-44a8-839f-fb9960be0ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec9a91d-7af0-44a8-839f-fb9960be0ddd.jpg?1",
             "name": "Phyrexian Lens",
             "text": "oc\nT, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "a4086680-d0d9-50f4-bb2f-9254eda1ef63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24315eaa-ef55-4fd6-9145-e75b3de6f492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24315eaa-ef55-4fd6-9145-e75b3de6f492.jpg?1",
             "name": "Planar Portal",
             "text": "o6, oc\nT: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -10719,7 +10719,7 @@
         },
         {
             "id": "2c2f3218-c1a7-5603-aa98-8475a5417fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1981dd-c0f3-4e9d-a1f1-8bea823326ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1981dd-c0f3-4e9d-a1f1-8bea823326ef.jpg?1",
             "name": "Power Armor",
             "text": "o3, oc\nT: Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "85ba5c25-d19e-5a57-87a9-89037bdc8122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e8130-7fe9-4ef4-98af-928814f5b130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26e8130-7fe9-4ef4-98af-928814f5b130.jpg?1",
             "name": "Rith's Attendant",
             "text": "o1, Sacrifice Rith's Attendant: Add o\nRo\nGo\nW to your mana pool.",
             "colours": [],
@@ -10782,7 +10782,7 @@
         },
         {
             "id": "c65fbd79-9741-5c5a-b84a-92df1e1ba59c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efdbcad-e2e4-4f54-ade5-920b1853109e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efdbcad-e2e4-4f54-ade5-920b1853109e.jpg?1",
             "name": "Seashell Cameo",
             "text": "oc\nT: Add o\nW or o\nU to your mana pool.",
             "colours": [],
@@ -10813,7 +10813,7 @@
         },
         {
             "id": "91b3ee98-48a8-5e61-a85d-54352b071e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d829d9de-83fa-4feb-8efc-0075315163c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d829d9de-83fa-4feb-8efc-0075315163c6.jpg?1",
             "name": "Sparring Golem",
             "text": "Whenever Sparring Golem becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [],
@@ -10844,7 +10844,7 @@
         },
         {
             "id": "c4a55c52-53ae-5232-affe-5ddd29ec5e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f38104-a699-4bb9-930a-699f7bbc338a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f38104-a699-4bb9-930a-699f7bbc338a.jpg?1",
             "name": "Tek",
             "text": "Tek gets +0/+2 as long as you control a plains, has flying as long as you control an island, gets +2/+0 as long as you control a swamp, has first strike as long as you control a mountain, and has trample as long as you control a forest.",
             "colours": [],
@@ -10875,7 +10875,7 @@
         },
         {
             "id": "084c5f0b-05a1-5b5f-8268-9b54681e5f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976da8-338d-4f46-b8ea-78a0aa3daa35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976da8-338d-4f46-b8ea-78a0aa3daa35.jpg?1",
             "name": "Tigereye Cameo",
             "text": "oc\nT: Add o\nG or o\nW to your mana pool.",
             "colours": [],
@@ -10906,7 +10906,7 @@
         },
         {
             "id": "34474b38-e8b2-591e-ad21-62fb6a432e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9857af81-fb95-4dc4-b048-9ce4e96d1eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9857af81-fb95-4dc4-b048-9ce4e96d1eca.jpg?1",
             "name": "Treva's Attendant",
             "text": "o1, Sacrifice Treva's Attendant: Add o\nGo\nWo\nU to your mana pool.",
             "colours": [],
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "0a0cff55-60f0-534c-914a-fa6112fabbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b1ca6c-6ca0-4b02-885a-58cee3fa2aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b1ca6c-6ca0-4b02-885a-58cee3fa2aa8.jpg?1",
             "name": "Troll-Horn Cameo",
             "text": "oc\nT: Add o\nR or o\nG to your mana pool.",
             "colours": [],
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "ce1fdecd-639d-5191-9158-1561d66de3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee69f8-cceb-41b9-a0ee-6b2ac9f4bad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dee69f8-cceb-41b9-a0ee-6b2ac9f4bad9.jpg?1",
             "name": "Tsabo's Web",
             "text": "When Tsabo's Web comes into play, draw a card.\nLands with an activated ability that doesn't produce mana don't untap during their controllers' untap steps.",
             "colours": [],
@@ -11000,7 +11000,7 @@
         },
         {
             "id": "0d7dedbc-ef99-5e2e-b756-2e469f1331f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680c75b1-e766-40be-84d7-2332047bb3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680c75b1-e766-40be-84d7-2332047bb3de.jpg?1",
             "name": "Urza's Filter",
             "text": "Multicolored spells cost up to o2 less to play.",
             "colours": [],
@@ -11028,7 +11028,7 @@
         },
         {
             "id": "f0731bdc-7aa9-573f-b0f9-dcbb56f2a9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004eefa4-947b-45fc-b45c-5263bfd763bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004eefa4-947b-45fc-b45c-5263bfd763bc.jpg?1",
             "name": "Ancient Spring",
             "text": "Ancient Spring comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Ancient Spring: Add o\nWo\nB to your mana pool.",
             "colours": [],
@@ -11060,7 +11060,7 @@
         },
         {
             "id": "6621f943-df23-554e-addb-19248fb135c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f55af0-5a46-4900-b3d0-ca796b710e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f55af0-5a46-4900-b3d0-ca796b710e07.jpg?1",
             "name": "Archaeological Dig",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Archaeological Dig: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -11088,7 +11088,7 @@
         },
         {
             "id": "690a4cdc-74ca-5e46-bba4-db98275948ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d115dbff-e35b-495f-a1e3-19651895927e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d115dbff-e35b-495f-a1e3-19651895927e.jpg?1",
             "name": "Coastal Tower",
             "text": "Coastal Tower comes into play tapped.\noc\nT: Add o\nW or o\nU to your mana pool.",
             "colours": [],
@@ -11119,7 +11119,7 @@
         },
         {
             "id": "26f0932f-c2fe-558e-a169-3d9476d150fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65986555-a5d7-497e-876f-b8d967d6aa5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65986555-a5d7-497e-876f-b8d967d6aa5b.jpg?1",
             "name": "Elfhame Palace",
             "text": "Elfhame Palace comes into play tapped.\noc\nT: Add o\nG or o\nW to your mana pool.",
             "colours": [],
@@ -11150,7 +11150,7 @@
         },
         {
             "id": "c5647e00-0000-5c53-8326-ddf62d6d856b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744b593-13fe-4967-b492-ac02f5815e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744b593-13fe-4967-b492-ac02f5815e57.jpg?1",
             "name": "Geothermal Crevice",
             "text": "Geothermal Crevice comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Geothermal Crevice: Add o\nBo\nG to your mana pool.",
             "colours": [],
@@ -11182,7 +11182,7 @@
         },
         {
             "id": "f7118c50-5239-5cf9-9c3a-4665b1193310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f1b44-166c-4faf-8a7b-d431707e90ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977f1b44-166c-4faf-8a7b-d431707e90ce.jpg?1",
             "name": "Irrigation Ditch",
             "text": "Irrigation Ditch comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Irrigation Ditch: Add o\nGo\nU to your mana pool.",
             "colours": [],
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "1aa1d14d-6dd5-53f0-9afc-8f73b0b11cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0cccf6-b79b-4fff-89aa-801341598532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0cccf6-b79b-4fff-89aa-801341598532.jpg?1",
             "name": "Keldon Necropolis",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no4o\nR, oc\nT, Sacrifice a creature: Keldon Necropolis deals 2 damage to target creature or player.",
             "colours": [],
@@ -11246,7 +11246,7 @@
         },
         {
             "id": "b625f84b-4311-5bf1-b322-923ad0a6b3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed64934b-0e64-4b2f-97aa-c3fb7e6ce0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed64934b-0e64-4b2f-97aa-c3fb7e6ce0b0.jpg?1",
             "name": "Salt Marsh",
             "text": "Salt Marsh comes into play tapped.\noc\nT: Add o\nU or o\nB to your mana pool.",
             "colours": [],
@@ -11277,7 +11277,7 @@
         },
         {
             "id": "7a50bb98-2817-5c7c-ba99-b6aa52a59b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9841f7e8-162c-44a3-96f3-af944fce15d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9841f7e8-162c-44a3-96f3-af944fce15d1.jpg?1",
             "name": "Shivan Oasis",
             "text": "Shivan Oasis comes into play tapped.\noc\nT: Add o\nR or o\nG to your mana pool.",
             "colours": [],
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "2c5574f1-0a2f-5166-9838-0252f4c4ddaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c66ed6-55fb-4c65-aac4-26d9cc3053b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c66ed6-55fb-4c65-aac4-26d9cc3053b8.jpg?1",
             "name": "Sulfur Vent",
             "text": "Sulfur Vent comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Sulfur Vent: Add o\nUo\nR to your mana pool.",
             "colours": [],
@@ -11340,7 +11340,7 @@
         },
         {
             "id": "49d78aa3-d60e-580d-b17d-91e9a2b1e584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b5901-aeb0-4a48-8c53-3b0ec0e0deba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b5901-aeb0-4a48-8c53-3b0ec0e0deba.jpg?1",
             "name": "Tinder Farm",
             "text": "Tinder Farm comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Tinder Farm: Add o\nRo\nW to your mana pool.",
             "colours": [],
@@ -11372,7 +11372,7 @@
         },
         {
             "id": "345dfcdd-8f08-5bc4-9cee-fb2206c90967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76f346c-ae34-4f5f-8e3b-6c77b0c4d530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76f346c-ae34-4f5f-8e3b-6c77b0c4d530.jpg?1",
             "name": "Urborg Volcano",
             "text": "Urborg Volcano comes into play tapped.\noc\nT: Add o\nB or o\nR to your mana pool.",
             "colours": [],
@@ -11403,7 +11403,7 @@
         },
         {
             "id": "fa297738-0842-56f0-aeec-14198e170cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba9ef2e-d3ec-41f7-802e-e1414f14dd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba9ef2e-d3ec-41f7-802e-e1414f14dd10.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11441,7 +11441,7 @@
         },
         {
             "id": "288a2e5f-7f6e-57bd-9019-efcb8669fa0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73d7ff-bbef-4df9-ae7f-aa2ac8ac7025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73d7ff-bbef-4df9-ae7f-aa2ac8ac7025.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11479,7 +11479,7 @@
         },
         {
             "id": "32392b7b-a27f-5099-88ce-1aebe05dc1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a66868-2efa-4985-b4fc-405d7fa8d410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a66868-2efa-4985-b4fc-405d7fa8d410.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11517,7 +11517,7 @@
         },
         {
             "id": "08a06a68-cf93-5948-8867-cdfc9bdd7ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4963b-c706-439f-9800-ff5d70003dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4963b-c706-439f-9800-ff5d70003dcf.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11555,7 +11555,7 @@
         },
         {
             "id": "aa3c2c3b-9211-51e6-9e1c-067d95abba2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3fc29c-f5cb-49b9-aabf-a5fef97e7a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3fc29c-f5cb-49b9-aabf-a5fef97e7a7e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11593,7 +11593,7 @@
         },
         {
             "id": "6c4c7c1a-5b2d-586e-8725-adc242cd63ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc04e1e-6a14-41cc-9fff-6dcd92cc6a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc04e1e-6a14-41cc-9fff-6dcd92cc6a3b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11631,7 +11631,7 @@
         },
         {
             "id": "77dd338f-de06-52e9-9cca-d02dee0f1113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f849f726-c6a2-400d-9b90-fe050f8ef5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f849f726-c6a2-400d-9b90-fe050f8ef5eb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11669,7 +11669,7 @@
         },
         {
             "id": "fd39852e-488e-5a26-8a1f-ec77689f4e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07d1982-56ff-47ef-87aa-62978f1fcf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07d1982-56ff-47ef-87aa-62978f1fcf30.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11707,7 +11707,7 @@
         },
         {
             "id": "8bf0ad54-3d61-5121-ba09-208f68f986fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7ce037-e04d-404a-afde-9122518e6a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7ce037-e04d-404a-afde-9122518e6a31.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11745,7 +11745,7 @@
         },
         {
             "id": "db4cf100-f94f-5d21-9c52-8ec1834a3dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8b9d-2573-4162-9255-50a281dfb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8b9d-2573-4162-9255-50a281dfb775.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11783,7 +11783,7 @@
         },
         {
             "id": "7d0ce87e-b3d4-5f0c-8c13-6bd459b592f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2bba7-8889-460c-a18f-fcd1e350ef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2bba7-8889-460c-a18f-fcd1e350ef4e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11821,7 +11821,7 @@
         },
         {
             "id": "596f16b5-8dda-524c-9603-acf99b5b038e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a756b0-f430-4286-afe1-97c641e4f3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a756b0-f430-4286-afe1-97c641e4f3b4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "8ecd02fd-331e-55e0-b6b6-3fe195d4ab3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6694bb-f3b7-48ff-9d93-cbed84fac210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6694bb-f3b7-48ff-9d93-cbed84fac210.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11897,7 +11897,7 @@
         },
         {
             "id": "9a6f52e7-0fff-5a2b-a47b-b824bb1cf2b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977527da-2953-493f-8e8c-ffc64ddeaf10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977527da-2953-493f-8e8c-ffc64ddeaf10.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "72c802c9-7e14-5507-b557-ebc2a4f70719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68df89dc-3909-4051-adc1-a86589d0e99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68df89dc-3909-4051-adc1-a86589d0e99d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11973,7 +11973,7 @@
         },
         {
             "id": "3916c2ee-9698-5fe4-9d53-bb0a83eb8d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8ae541-98e2-4a84-90a6-b17502f4442d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8ae541-98e2-4a84-90a6-b17502f4442d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -12011,7 +12011,7 @@
         },
         {
             "id": "b1c6d4ef-8f7d-5735-9e5c-24afa0341a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82d0a1c-5812-4254-a000-e4ff9aece3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82d0a1c-5812-4254-a000-e4ff9aece3d9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "90bbb35f-73ad-5f91-8d7b-12835b49a28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24788990-42ff-4b2b-8d01-fa2d0ec66a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24788990-42ff-4b2b-8d01-fa2d0ec66a03.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -12087,7 +12087,7 @@
         },
         {
             "id": "6bffc76b-ecfb-50e0-a5ae-fc6581d9b750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b741c86-a563-4180-a857-7850de6ee366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b741c86-a563-4180-a857-7850de6ee366.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -12125,7 +12125,7 @@
         },
         {
             "id": "a0df9fb2-4e23-550a-b6e5-768ad873a6f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacc498-f089-4ae4-8ce8-697cc671f445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacc498-f089-4ae4-8ce8-697cc671f445.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ISD.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ISD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1a077ae3-343a-57ab-acfa-0b13e431dc9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87803b-e7c6-4122-add4-72e596167b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87803b-e7c6-4122-add4-72e596167b7e.jpg?1",
             "name": "Abbey Griffin",
             "text": "Flying, vigilance",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "ba8648ea-4e93-5fbb-a864-f00023e188ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfe629f-485c-4619-9713-32d2ae406e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfe629f-485c-4619-9713-32d2ae406e63.jpg?1",
             "name": "Angel of Flight Alabaster",
             "text": "Flying\nAt the beginning of your upkeep, return target Spirit card from your graveyard to your hand.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "35690667-41c7-5456-910d-08f20d3ce643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221d999c-dde1-4a0f-87cf-9e9f44969f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221d999c-dde1-4a0f-87cf-9e9f44969f94.jpg?1",
             "name": "Angelic Overseer",
             "text": "Flying\nAs long as you control a Human, Angelic Overseer has hexproof and is indestructible.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "63004079-b2bd-5797-a3e6-b7379f8f8138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a47828-a79a-4189-9eef-2a5fc5125b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a47828-a79a-4189-9eef-2a5fc5125b61.jpg?1",
             "name": "Avacynian Priest",
             "text": "{1}, {T}: Tap target non-Human creature.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "15214e71-3d36-52cf-bd42-a268420ef5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8d1ce0-78c5-4e97-9cca-33e7b6ff3440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8d1ce0-78c5-4e97-9cca-33e7b6ff3440.jpg?1",
             "name": "Bonds of Faith",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Human. Otherwise, it can't attack or block.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f7d2da7f-6c15-5a21-90b9-935f5e0eb2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7314414-c2d2-48ed-af2c-764cf0207c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7314414-c2d2-48ed-af2c-764cf0207c62.jpg?1",
             "name": "Champion of the Parish",
             "text": "Whenever another Human enters the battlefield under your control, put a +1/+1 counter on Champion of the Parish.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "0a49beff-7d7c-5809-b405-7e144d96164c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790cdf67-80d6-4ade-aecf-f77120b509b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790cdf67-80d6-4ade-aecf-f77120b509b0.jpg?1",
             "name": "Chapel Geist",
             "text": "Flying",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "eb91f1bf-734e-56a4-bb04-544b94889fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg?1",
             "name": "Cloistered Youth // Unholy Fiend",
             "text": "At the beginning of your upkeep, you may transform Cloistered Youth.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "ccab0ddd-6403-5ec4-a03c-e8a63bed55d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8b8f0b4-71e1-4822-99a1-b1b3c2f10cb2.jpg?1",
             "name": "Cloistered Youth // Unholy Fiend",
             "text": "At the beginning of your end step, you lose 1 life.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "aa9eded6-a821-5e01-941b-95d0e138b336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008061f-cda4-4bcf-b6b3-d1b4a251cc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008061f-cda4-4bcf-b6b3-d1b4a251cc66.jpg?1",
             "name": "Dearly Departed",
             "text": "Flying\nAs long as Dearly Departed is in your graveyard, each Human creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "f68ee59c-d335-5d7a-84fe-b4fb5d7c67aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ea3a4-206a-4097-87c1-c04bb7812972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ea3a4-206a-4097-87c1-c04bb7812972.jpg?1",
             "name": "Divine Reckoning",
             "text": "Each player chooses a creature he or she controls. Destroy the rest.\nFlashback {5}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "ed0c9224-8216-5130-b505-0078009546b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652c3bbb-cac8-47ad-81de-41e954e17a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652c3bbb-cac8-47ad-81de-41e954e17a29.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "37f6953d-2b2b-59de-8897-d410f4981948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b9e51-fecd-4f9a-9354-a6dc1613feb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b9e51-fecd-4f9a-9354-a6dc1613feb3.jpg?1",
             "name": "Elder Cathar",
             "text": "When Elder Cathar dies, put a +1/+1 counter on target creature you control. If that creature is a Human, put two +1/+1 counters on it instead.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "fab06692-10f2-5db2-81ee-e4063ba71cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9411c44-92a8-4f5d-b3de-d80046649c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9411c44-92a8-4f5d-b3de-d80046649c8c.jpg?1",
             "name": "Elite Inquisitor",
             "text": "First strike, vigilance\nProtection from Vampires, from Werewolves, and from Zombies",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "ca800b48-8f28-5a9d-ab34-5b9c58952d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846a2f9e-ad4f-4666-b152-fdeab7559d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846a2f9e-ad4f-4666-b152-fdeab7559d86.jpg?1",
             "name": "Feeling of Dread",
             "text": "Tap up to two target creatures.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "f42979d6-cee0-5b71-8d57-6aba880bdd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4c7d8-11a5-40fe-962b-7e938bf08616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4c7d8-11a5-40fe-962b-7e938bf08616.jpg?1",
             "name": "Fiend Hunter",
             "text": "When Fiend Hunter enters the battlefield, you may exile another target creature.\nWhen Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "3204b2c9-576a-57d5-9d47-978d38522fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15947b20-8c8e-42ed-9599-8b180a382d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15947b20-8c8e-42ed-9599-8b180a382d21.jpg?1",
             "name": "Gallows Warden",
             "text": "Flying\nOther Spirit creatures you control get +0/+1.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "00f83362-5805-54fd-8e72-677a9c23d305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51355e-55fa-43bb-a5de-fc55ac7b6446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51355e-55fa-43bb-a5de-fc55ac7b6446.jpg?1",
             "name": "Geist-Honored Monk",
             "text": "Vigilance\nGeist-Honored Monk's power and toughness are each equal to the number of creatures you control.\nWhen Geist-Honored Monk enters the battlefield, put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "3c133cbd-4331-59e9-8eec-bbaaaf740e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f048d9-ca13-485d-ad92-de4695b7dc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f048d9-ca13-485d-ad92-de4695b7dc18.jpg?1",
             "name": "Ghostly Possession",
             "text": "Enchant creature\nEnchanted creature has flying.\nPrevent all combat damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "1953c8c6-ce8e-5634-bd66-22fff2a1a752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd21f5e-d284-4072-87b9-7f0e6140fe60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd21f5e-d284-4072-87b9-7f0e6140fe60.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "7d3b740e-6199-522a-90ac-836f331ed6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b19de-96a6-4590-bfc3-31b0c7b2e25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7b19de-96a6-4590-bfc3-31b0c7b2e25e.jpg?1",
             "name": "Mausoleum Guard",
             "text": "When Mausoleum Guard dies, put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -723,7 +723,7 @@
         },
         {
             "id": "7ba22fb3-08c1-5220-a79d-d78a10d17ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8f179a-f6ab-4d4c-8195-ed077a7770d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8f179a-f6ab-4d4c-8195-ed077a7770d3.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -758,7 +758,7 @@
         },
         {
             "id": "18f51323-7a84-59a1-b4bc-e5a1a2adc3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1eb098-7128-4ec8-8218-51fdde3e8326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1eb098-7128-4ec8-8218-51fdde3e8326.jpg?1",
             "name": "Midnight Haunting",
             "text": "Put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -790,7 +790,7 @@
         },
         {
             "id": "7bcfe418-879d-5b24-8211-8ef4fa2a0f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22dc283-ea54-4344-b1ca-fd6cc05080d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22dc283-ea54-4344-b1ca-fd6cc05080d9.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -827,7 +827,7 @@
         },
         {
             "id": "bcf39801-5fbc-5faf-89be-b9538389ca36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8d15bc-889d-4fd0-9688-00e22db30036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba8d15bc-889d-4fd0-9688-00e22db30036.jpg?1",
             "name": "Moment of Heroism",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "635e92f3-4179-5244-8627-e222e48b7170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b610fe-36ee-4d58-8ed4-04e7a12587b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b610fe-36ee-4d58-8ed4-04e7a12587b2.jpg?1",
             "name": "Nevermore",
             "text": "As Nevermore enters the battlefield, name a nonland card.\nThe named card can't be cast.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "e940c646-696c-5600-9b60-8fa97193ed1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406380ab-2695-4084-99a5-f5560304f8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406380ab-2695-4084-99a5-f5560304f8cb.jpg?1",
             "name": "Paraselene",
             "text": "Destroy all enchantments. You gain 1 life for each enchantment destroyed this way.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "89d2a8a7-7c07-5f75-803f-13ee92df148d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf39365-e468-46ac-bb5b-7f43faa19458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf39365-e468-46ac-bb5b-7f43faa19458.jpg?1",
             "name": "Purify the Grave",
             "text": "Exile target card from a graveyard.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "771a0638-8c17-5867-97a6-4a969f75b366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514fe7de-16b2-42c0-adb1-f0af1c89cfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514fe7de-16b2-42c0-adb1-f0af1c89cfd6.jpg?1",
             "name": "Rally the Peasants",
             "text": "Creatures you control get +2/+0 until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "05083315-739f-5370-ab69-7383fc655998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267185ac-a176-423e-a7f8-ee966d1d9a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267185ac-a176-423e-a7f8-ee966d1d9a1e.jpg?1",
             "name": "Rebuke",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "ea2eed7c-f377-5423-88da-4a662335a1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1dc067-1972-4d46-ad5d-56e6a563f638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1dc067-1972-4d46-ad5d-56e6a563f638.jpg?1",
             "name": "Selfless Cathar",
             "text": "{1}{W}, Sacrifice Selfless Cathar: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "c6e08592-0eee-571f-8f89-0f01326c61e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a81bfab-3397-4562-8b82-5f24cef167e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a81bfab-3397-4562-8b82-5f24cef167e3.jpg?1",
             "name": "Silverchase Fox",
             "text": "{1}{W}, Sacrifice Silverchase Fox: Exile target enchantment.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "a8f8640c-186e-5d19-a49e-4aabfb4cc965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2cd68e-ff4c-49c7-ba0d-f2299d9c21f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2cd68e-ff4c-49c7-ba0d-f2299d9c21f4.jpg?1",
             "name": "Slayer of the Wicked",
             "text": "When Slayer of the Wicked enters the battlefield, you may destroy target Vampire, Werewolf, or Zombie.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "07e96493-9c17-55c9-ba27-8575580f2c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0103f3b1-88c2-4cbf-a67c-49420f92970f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0103f3b1-88c2-4cbf-a67c-49420f92970f.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "9313aa66-9ad0-52fe-9b0f-fb8f839c7ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01b5d97-b5ae-42a7-944a-feb12febd63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01b5d97-b5ae-42a7-944a-feb12febd63c.jpg?1",
             "name": "Spare from Evil",
             "text": "Creatures you control gain protection from non-Human creatures until end of turn.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "cad6031e-8a79-5691-936e-914fac7abfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e4e56-8bde-480d-b59c-17a017665b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e4e56-8bde-480d-b59c-17a017665b19.jpg?1",
             "name": "Spectral Rider",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "5758f73d-3642-572a-8818-7fa2b8016014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56a5a73-5f10-4f97-989f-7cea0a8d95e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56a5a73-5f10-4f97-989f-7cea0a8d95e3.jpg?1",
             "name": "Stony Silence",
             "text": "Activated abilities of artifacts can't be activated.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "b4a6efd2-6a14-5ceb-9188-bb04c4ab17ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db28f4-3d96-42f5-a264-592fdc2d4196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16db28f4-3d96-42f5-a264-592fdc2d4196.jpg?1",
             "name": "Thraben Purebloods",
             "text": "",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "f33004f5-507c-5e10-b22a-64e2a6d2da90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg?1",
             "name": "Thraben Sentry // Thraben Militia",
             "text": "Vigilance\nWhenever another creature you control dies, you may transform Thraben Sentry.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "2f2c2e6a-01e3-5f19-8f63-16f71d4cd9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58ae9cbc-d88d-42df-ab76-63ab5d05c023.jpg?1",
             "name": "Thraben Sentry // Thraben Militia",
             "text": "Trample",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "baf120ca-66cf-50b8-b18d-dc9f6bf97950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491c6e40-151a-4efd-980c-e6b6a1057c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/491c6e40-151a-4efd-980c-e6b6a1057c58.jpg?1",
             "name": "Unruly Mob",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Unruly Mob.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "d204849c-a646-545a-be15-f5c110f6a855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a437c-a2ee-43c6-876c-1a63a455c97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516a437c-a2ee-43c6-876c-1a63a455c97c.jpg?1",
             "name": "Urgent Exorcism",
             "text": "Destroy target Spirit or enchantment.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "fe1a6c65-49ea-5397-8ca9-8f95f93c1cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6912b3-bab9-4937-afdd-3711e6d792a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6912b3-bab9-4937-afdd-3711e6d792a0.jpg?1",
             "name": "Village Bell-Ringer",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Village Bell-Ringer enters the battlefield, untap all creatures you control.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "ae78c49c-290b-5104-ba95-6029471224c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d9bd7-5721-4436-a86f-35e376727f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24d9bd7-5721-4436-a86f-35e376727f46.jpg?1",
             "name": "Voiceless Spirit",
             "text": "Flying, first strike",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "d5c55822-3121-5d64-8ab4-765eea73ff17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4d00f2-30e6-41d5-b997-c66350fe783c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4d00f2-30e6-41d5-b997-c66350fe783c.jpg?1",
             "name": "Armored Skaab",
             "text": "When Armored Skaab enters the battlefield, put the top four cards of your library into your graveyard.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "27690860-adeb-56e9-a45b-ca1faca6b002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bba140-5c06-4542-9ae0-b2517104ab7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bba140-5c06-4542-9ae0-b2517104ab7c.jpg?1",
             "name": "Back from the Brink",
             "text": "Exile a creature card from your graveyard and pay its mana cost: Put a token onto the battlefield that's a copy of that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "4483f334-324e-5fdb-a707-92ae879d1346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129905ef-5b3b-4860-923c-109a7d7cad80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129905ef-5b3b-4860-923c-109a7d7cad80.jpg?1",
             "name": "Battleground Geist",
             "text": "Flying\nOther Spirit creatures you control get +1/+0.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "943f0833-6bfa-5b59-a7e4-89df1883f370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a2b93-94dc-4285-a6fd-455a796426bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2a2b93-94dc-4285-a6fd-455a796426bc.jpg?1",
             "name": "Cackling Counterpart",
             "text": "Put a token onto the battlefield that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1627,7 +1627,7 @@
         },
         {
             "id": "8bdfb070-3dc7-5199-93eb-ba458a84eb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg?1",
             "name": "Civilized Scholar // Homicidal Brute",
             "text": "{T}: Draw a card, then discard a card. If a creature card is discarded this way, untap Civilized Scholar, then transform it.",
             "colours": [
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "a6c93bba-9e3e-5232-8f0c-a165ca3ff3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7bf864db-4754-433d-9d77-6695f78f6c09.jpg?1",
             "name": "Civilized Scholar // Homicidal Brute",
             "text": "At the beginning of your end step, if Homicidal Brute didn't attack this turn, tap Homicidal Brute, then transform it.",
             "colours": [
@@ -1699,7 +1699,7 @@
         },
         {
             "id": "9059c584-4185-5f94-8880-14aa735cb7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e5f600-4d19-42a4-b57e-650c76041798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e5f600-4d19-42a4-b57e-650c76041798.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1733,7 +1733,7 @@
         },
         {
             "id": "ec51a706-8912-502e-8841-053b9aaa010e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b212c36a-6d1f-4217-b384-1c2b0e07b68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b212c36a-6d1f-4217-b384-1c2b0e07b68a.jpg?1",
             "name": "Curiosity",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "b64b5e28-51f0-597b-ab43-700956cd5bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7865e11-263b-4d61-af54-907c1acbb54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7865e11-263b-4d61-af54-907c1acbb54f.jpg?1",
             "name": "Curse of the Bloody Tome",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1802,7 +1802,7 @@
         },
         {
             "id": "88d06769-564f-5474-a0a4-50b95b409224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform Delver of Secrets.",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "ba2cd594-ce42-589e-b166-5509ab0cd60f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "Flying",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "e719e615-91fc-5811-9ca5-543cd47daa22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c03171-5ff0-4f79-bb03-16decf7d34ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c03171-5ff0-4f79-bb03-16decf7d34ce.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Put the top card of your library into your graveyard: Add {1} to your mana pool.",
             "colours": [
@@ -1907,7 +1907,7 @@
         },
         {
             "id": "98ffe750-2e11-5d75-a601-1426d3eca3f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778082-bcdb-423a-b16f-57ac0d4dace7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d778082-bcdb-423a-b16f-57ac0d4dace7.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1939,7 +1939,7 @@
         },
         {
             "id": "ee42fe61-c118-5681-b212-0c89aa328cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dd8790-bfdf-427d-8e8d-a5c3a64a3063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dd8790-bfdf-427d-8e8d-a5c3a64a3063.jpg?1",
             "name": "Dream Twist",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "41ff5992-98c0-5e76-97b4-c9c27f96e718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb22ae62-6207-4693-87cf-7adf0fc1fe29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb22ae62-6207-4693-87cf-7adf0fc1fe29.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "4623dded-8574-57be-bc66-5cbf7738fbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca16d4-089f-42a7-a648-55301a77faea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ca16d4-089f-42a7-a648-55301a77faea.jpg?1",
             "name": "Fortress Crab",
             "text": "",
             "colours": [
@@ -2038,7 +2038,7 @@
         },
         {
             "id": "dc916d31-1be0-5662-a28a-b427dc225277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c9ba98-90b4-4c28-9eef-a4fe0913b921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c9ba98-90b4-4c28-9eef-a4fe0913b921.jpg?1",
             "name": "Frightful Delusion",
             "text": "Counter target spell unless its controller pays {1}. That player discards a card.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "ba4cf547-490c-5764-b927-f4e81b1ad3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02655d3d-82d0-4be6-bb64-25e1478edfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02655d3d-82d0-4be6-bb64-25e1478edfc3.jpg?1",
             "name": "Grasp of Phantoms",
             "text": "Put target creature on top of its owner's library.\nFlashback {7}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "ec88d4a6-225b-558d-b0d6-80e8f362c499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeaa757-e3b0-4606-a689-e8a20a686c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeaa757-e3b0-4606-a689-e8a20a686c3a.jpg?1",
             "name": "Hysterical Blindness",
             "text": "Creatures your opponents control get -4/-0 until end of turn.",
             "colours": [
@@ -2134,7 +2134,7 @@
         },
         {
             "id": "f8dded67-7714-5d36-a8ea-26ee0677c97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013620d-8e17-4246-86bf-71eafd51b806.jpg?1",
             "name": "Invisible Stalker",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nInvisible Stalker is unblockable.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "b006bae5-a67f-571b-80c4-d63a9fcf2724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg?1",
             "name": "Laboratory Maniac",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "151da55d-1574-5643-a9f2-58f29a9ea4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50a5772-f411-458a-97f9-9f3967bb79c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50a5772-f411-458a-97f9-9f3967bb79c5.jpg?1",
             "name": "Lantern Spirit",
             "text": "Flying\n{U}: Return Lantern Spirit to its owner's hand.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "2406cbe2-1efc-5ea5-8c30-da2864ae87a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5fc39d-590a-436b-ab90-a1741d2ae3da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5fc39d-590a-436b-ab90-a1741d2ae3da.jpg?1",
             "name": "Lost in the Mist",
             "text": "Counter target spell. Return target permanent to its owner's hand.",
             "colours": [
@@ -2270,7 +2270,7 @@
         },
         {
             "id": "43140b4f-aa7f-5ef5-b27a-488dcb0c76a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg?1",
             "name": "Ludevic's Test Subject // Ludevic's Abomination",
             "text": "Defender\n{1}{U}: Put a hatchling counter on Ludevic's Test Subject. Then if there are five or more hatchling counters on it, remove all of them and transform it.",
             "colours": [
@@ -2305,7 +2305,7 @@
         },
         {
             "id": "f56b147e-e593-59a9-9585-385d51419dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebf5e16f-a8bd-419f-b5ca-8c7fce09c4f1.jpg?1",
             "name": "Ludevic's Test Subject // Ludevic's Abomination",
             "text": "Trample",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "dc198743-15bb-5fcc-954e-c6d6409cc0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d869de57-9454-47ff-af14-eaefd387047a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d869de57-9454-47ff-af14-eaefd387047a.jpg?1",
             "name": "Makeshift Mauler",
             "text": "As an additional cost to cast Makeshift Mauler, exile a creature card from your graveyard.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "cdd140b4-b5e7-5c0a-a93d-36e39a995fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aaa73-1a1e-4282-a860-f7c422f21db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265aaa73-1a1e-4282-a860-f7c422f21db3.jpg?1",
             "name": "Memory's Journey",
             "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "d348c1b2-3c49-5a52-a006-a1ce66ab8314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1e52af-6746-4ec6-afbf-008594c874f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1e52af-6746-4ec6-afbf-008594c874f8.jpg?1",
             "name": "Mindshrieker",
             "text": "Flying\n{2}: Target player puts the top card of his or her library into his or her graveyard. Mindshrieker gets +X/+X until end of turn, where X is that card's converted mana cost.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "b878cb7f-df20-5c10-ab89-0eabb7521f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eea41-9daf-4ac1-8bad-bb4aa211bb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eea41-9daf-4ac1-8bad-bb4aa211bb53.jpg?1",
             "name": "Mirror-Mad Phantasm",
             "text": "Flying\n{1}{U}: Mirror-Mad Phantasm's owner shuffles it into his or her library. If that player does, he or she reveals cards from the top of that library until a card named Mirror-Mad Phantasm is revealed. The player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "b53ac8ce-56e5-55ff-8cb1-c96dddf1c67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24de601-1d7b-41c4-aba1-fdb6fd8d5251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24de601-1d7b-41c4-aba1-fdb6fd8d5251.jpg?1",
             "name": "Moon Heron",
             "text": "Flying",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "0b2a9217-c3be-5426-afc0-eeac3b90c371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f914f7e4-06fc-4943-8597-b7f834938c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f914f7e4-06fc-4943-8597-b7f834938c00.jpg?1",
             "name": "Murder of Crows",
             "text": "Flying\nWhenever another creature dies, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2546,7 +2546,7 @@
         },
         {
             "id": "f0158766-07e4-5c03-afcd-10f6d13ea979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab01d871-ba50-400a-95e7-09af9e34405f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab01d871-ba50-400a-95e7-09af9e34405f.jpg?1",
             "name": "Rooftop Storm",
             "text": "You may pay {0} rather than pay the mana cost for Zombie creature spells you cast.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "443229b8-62eb-552f-ada3-be75e0aebca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e47ba6-3a55-41b4-b8fe-580041669408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e47ba6-3a55-41b4-b8fe-580041669408.jpg?1",
             "name": "Runic Repetition",
             "text": "Return target exiled card with flashback you own to your hand.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "a272f431-fb39-551b-a5aa-fd32b9778631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeac4885-bd04-42bd-8e10-06c3efbce108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeac4885-bd04-42bd-8e10-06c3efbce108.jpg?1",
             "name": "Selhoff Occultist",
             "text": "Whenever Selhoff Occultist or another creature dies, target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "3f8a7b6e-4981-5adf-941c-e002b6ad26f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454739db-a3d6-45e8-849a-287438c36627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454739db-a3d6-45e8-849a-287438c36627.jpg?1",
             "name": "Sensory Deprivation",
             "text": "Enchant creature\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "06a2c1b0-53d8-52a0-880e-3dcefc7f6bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18dea16-d535-4310-94ff-836645253d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18dea16-d535-4310-94ff-836645253d73.jpg?1",
             "name": "Silent Departure",
             "text": "Return target creature to its owner's hand.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "271a12c9-9433-54a4-9681-ecdf7bb7ec59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg?1",
             "name": "Skaab Goliath",
             "text": "As an additional cost to cast Skaab Goliath, exile two creature cards from your graveyard.\nTrample",
             "colours": [
@@ -2746,7 +2746,7 @@
         },
         {
             "id": "6dd09f44-0099-5243-b74c-907b4e40adb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c40cdc-a11a-47df-b902-d8fbe9014d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c40cdc-a11a-47df-b902-d8fbe9014d03.jpg?1",
             "name": "Skaab Ruinator",
             "text": "As an additional cost to cast Skaab Ruinator, exile three creature cards from your graveyard.\nFlying\nYou may cast Skaab Ruinator from your graveyard.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "00ae2026-8987-569e-afa8-726e1a65fad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b279e-4670-4a1e-87d0-3cab7e4f9e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5b279e-4670-4a1e-87d0-3cab7e4f9e58.jpg?1",
             "name": "Snapcaster Mage",
             "text": "Flash\nWhen Snapcaster Mage enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "6bcd6f69-aa1d-52c3-a9cf-037c4b05eed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7149f2a-6917-4ad7-8035-c7a1babd4d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7149f2a-6917-4ad7-8035-c7a1babd4d4b.jpg?1",
             "name": "Spectral Flight",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2850,7 +2850,7 @@
         },
         {
             "id": "214ad2d5-64c2-5012-bb00-201e48510186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad81266a-488f-449a-9daf-637727564865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad81266a-488f-449a-9daf-637727564865.jpg?1",
             "name": "Stitched Drake",
             "text": "As an additional cost to cast Stitched Drake, exile a creature card from your graveyard.\nFlying",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "28236fed-0318-5d2f-a20b-0a1910c7d907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fcc53-cd0b-4b4c-b6de-5d301232106a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fcc53-cd0b-4b4c-b6de-5d301232106a.jpg?1",
             "name": "Stitcher's Apprentice",
             "text": "{1}{U}, {T}: Put a 2/2 blue Homunculus creature token onto the battlefield, then sacrifice a creature.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "a090eef1-8ee7-511d-b6d9-401ee2cc0f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c409d1d0-fc45-40bf-adac-83b680209a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c409d1d0-fc45-40bf-adac-83b680209a38.jpg?1",
             "name": "Sturmgeist",
             "text": "Flying\nSturmgeist's power and toughness are each equal to the number of cards in your hand.\nWhenever Sturmgeist deals combat damage to a player, draw a card.",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "096299f9-864f-5c66-ae91-3da67ac1228f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e44060-a9a2-4095-9f5b-f60297525315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e44060-a9a2-4095-9f5b-f60297525315.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "01aa9a14-1daf-5555-872c-1f71e93fb2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f4592-6c81-43ac-8975-f6d5d6710310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f4592-6c81-43ac-8975-f6d5d6710310.jpg?1",
             "name": "Undead Alchemist",
             "text": "If a Zombie you control would deal combat damage to a player, instead that player puts that many cards from the top of his or her library into his or her graveyard.\nWhenever a creature card is put into an opponent's graveyard from his or her library, exile that card and put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "c10fb040-85d0-53ae-b78e-4dcca2a41921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0906-04fa-4b30-a7a6-3d117931154f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0906-04fa-4b30-a7a6-3d117931154f.jpg?1",
             "name": "Abattoir Ghoul",
             "text": "First strike\nWhenever a creature dealt damage by Abattoir Ghoul this turn dies, you gain life equal to that creature's toughness.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "fd6423d6-8d9a-54e4-bec3-5b5b2516a0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2eec4-7e68-45d5-8736-6b32a47c671b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc2eec4-7e68-45d5-8736-6b32a47c671b.jpg?1",
             "name": "Altar's Reap",
             "text": "As an additional cost to cast Altar's Reap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "ed93ff62-7df9-5dd9-b990-2616998638c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260a4544-a1eb-4d07-943f-0401ae288e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260a4544-a1eb-4d07-943f-0401ae288e13.jpg?1",
             "name": "Army of the Damned",
             "text": "Put thirteen 2/2 black Zombie creature tokens onto the battlefield tapped.\nFlashback {7}{B}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "d7ff9c20-5971-5832-b3c9-715992841783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ff2b4-8f40-42c0-af3c-b55bfa8839be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ff2b4-8f40-42c0-af3c-b55bfa8839be.jpg?1",
             "name": "Bitterheart Witch",
             "text": "Deathtouch\nWhen Bitterheart Witch dies, you may search your library for a Curse card, put it onto the battlefield attached to target player, then shuffle your library.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "f72da99c-ac8e-5f00-ba2b-40932124da47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271addb-e267-4397-b181-f1eaeabbfe71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f271addb-e267-4397-b181-f1eaeabbfe71.jpg?1",
             "name": "Bloodgift Demon",
             "text": "Flying\nAt the beginning of your upkeep, target player draws a card and loses 1 life.",
             "colours": [
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "1c12ea60-ce46-594e-a588-cfe5b2ef44b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "Flying\n{T}: Put a 2/2 black Vampire creature token with flying onto the battlefield.\n{B}: Transform Bloodline Keeper. Activate this ability only if you control five or more Vampires.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "27453e61-7297-57fb-b0fe-e43557e96607",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13896468-e3d0-4bcb-b09e-b5c187aecb03.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "Flying\nOther Vampire creatures you control get +2/+2.\n{T}: Put a 2/2 black Vampire creature token with flying onto the battlefield.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "46e738d0-b7f7-58c1-b5f0-070de44c5fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1bd88-939a-4adc-8693-210a7ba9a5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e1bd88-939a-4adc-8693-210a7ba9a5a1.jpg?1",
             "name": "Brain Weevil",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nSacrifice Brain Weevil: Target player discards two cards. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "5e1d407d-06ba-5c75-8bc8-36890f41b9f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3ec389-a267-484f-994d-4a29ef494eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3ec389-a267-484f-994d-4a29ef494eb1.jpg?1",
             "name": "Bump in the Night",
             "text": "Target opponent loses 3 life.\nFlashback {5}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "16cbff86-dd33-5cea-9df2-af3acb681ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a74b987-527a-4560-a018-19d6bdf7e8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a74b987-527a-4560-a018-19d6bdf7e8b7.jpg?1",
             "name": "Corpse Lunge",
             "text": "As an additional cost to cast Corpse Lunge, exile a creature card from your graveyard.\nCorpse Lunge deals damage equal to the exiled card's power to target creature.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "e7fd5543-5774-5a62-809d-7e0fc5d429ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774d0a8-1cd3-4582-ace0-1caff92af0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774d0a8-1cd3-4582-ace0-1caff92af0e7.jpg?1",
             "name": "Curse of Death's Hold",
             "text": "Enchant player\nCreatures enchanted player controls get -1/-1.",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "e90d0843-520b-5815-ba5a-d9fb22a689f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15cbd2f-8bbf-423a-81fe-521fd99bc8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15cbd2f-8bbf-423a-81fe-521fd99bc8bf.jpg?1",
             "name": "Curse of Oblivion",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, that player exiles two cards from his or her graveyard.",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "dcb5376b-9211-5788-9f87-2eb88e97dce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7933987e-7b8c-4d5a-804a-708d6bb6d231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7933987e-7b8c-4d5a-804a-708d6bb6d231.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "ffc1accf-0302-50bd-b3fe-fb30c1c98cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed5790a-3354-49c2-89b6-3fc0de8dcc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed5790a-3354-49c2-89b6-3fc0de8dcc7c.jpg?1",
             "name": "Diregraf Ghoul",
             "text": "Diregraf Ghoul enters the battlefield tapped.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "ffac58b6-08b8-5f4e-b184-d11bc69e5797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4acaa1-7d99-41ce-81ce-f6aef3e4dc1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4acaa1-7d99-41ce-81ce-f6aef3e4dc1d.jpg?1",
             "name": "Disciple of Griselbrand",
             "text": "{1}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "8d382fa4-f010-5c7f-8f83-6d39a1f67a52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db15c5f-80b7-4f7f-985a-9bbec3199ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db15c5f-80b7-4f7f-985a-9bbec3199ad9.jpg?1",
             "name": "Endless Ranks of the Dead",
             "text": "At the beginning of your upkeep, put X 2/2 black Zombie creature tokens onto the battlefield, where X is half the number of Zombies you control, rounded down.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "f96bfb2d-cf71-5487-b798-f29ed821e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2286f94-4cf9-4462-b5d7-cee7f6910018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2286f94-4cf9-4462-b5d7-cee7f6910018.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3593,7 +3593,7 @@
         },
         {
             "id": "2f34e74a-8773-56b0-871e-184339503df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8c1b10-2155-404a-8f20-eb8f643849d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8c1b10-2155-404a-8f20-eb8f643849d6.jpg?1",
             "name": "Ghoulcaller's Chant",
             "text": "Choose one \u2014 Return target creature card from your graveyard to your hand; or return two target Zombie cards from your graveyard to your hand.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "32be090b-2acc-5061-9523-7d42ccbb1e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c537d1-2d57-4a87-9dac-594d40d95633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c537d1-2d57-4a87-9dac-594d40d95633.jpg?1",
             "name": "Ghoulraiser",
             "text": "When Ghoulraiser enters the battlefield, return a Zombie card at random from your graveyard to your hand.",
             "colours": [
@@ -3659,7 +3659,7 @@
         },
         {
             "id": "3182195e-83a0-526c-bab1-20ed987bb477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5696db03-206f-4e7e-9b65-ccef31bfd7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5696db03-206f-4e7e-9b65-ccef31bfd7d2.jpg?1",
             "name": "Gruesome Deformity",
             "text": "Enchant creature\nEnchanted creature has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "af0a2bbf-520e-53bd-b998-79647dc29e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8f638-b7fc-4e38-8623-ce7d2ebc82e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8f638-b7fc-4e38-8623-ce7d2ebc82e6.jpg?1",
             "name": "Heartless Summoning",
             "text": "Creature spells you cast cost {2} less to cast.\nCreatures you control get -1/-1.",
             "colours": [
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "fb346729-7d16-5e5b-993d-49b713b8ed06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac506c17-adc8-49c6-9d8d-43db7cb1ec9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac506c17-adc8-49c6-9d8d-43db7cb1ec9d.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n-2: Target player sacrifices a creature.\n-6: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of his or her choice.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "fa89e15a-4496-5144-beb7-f665ecc48376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b45197-d5c2-48c8-b72e-00236552e338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b45197-d5c2-48c8-b72e-00236552e338.jpg?1",
             "name": "Manor Skeleton",
             "text": "Haste\n{1}{B}: Regenerate Manor Skeleton.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "ebf0992e-90c5-524d-ab1a-0ef6d194a5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3d3f7-5e28-4fec-8422-87856fcd1e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3d3f7-5e28-4fec-8422-87856fcd1e8e.jpg?1",
             "name": "Markov Patrician",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "e4434970-f5ca-56f8-a19d-27ef4982a730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b34a03-3270-412c-90ca-03c1b3e61222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b34a03-3270-412c-90ca-03c1b3e61222.jpg?1",
             "name": "Maw of the Mire",
             "text": "Destroy target land. You gain 4 life.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "71884a86-1b60-549a-8b0d-52cf4030080d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5a8f-c03a-40ab-8390-ff6b5b654717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c5a8f-c03a-40ab-8390-ff6b5b654717.jpg?1",
             "name": "Moan of the Unhallowed",
             "text": "Put two 2/2 black Zombie creature tokens onto the battlefield.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "f1ad4e26-b1e3-5e9a-ad10-2abf2ee0ac1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff9989f-77a3-4f73-ade6-c04306c98501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff9989f-77a3-4f73-ade6-c04306c98501.jpg?1",
             "name": "Morkrut Banshee",
             "text": "Morbid \u2014 When Morkrut Banshee enters the battlefield, if a creature died this turn, target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "7980c3c3-80f8-5f6b-bcb3-e87600175432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5091658c-0314-42ee-87d8-95d3f457c4ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5091658c-0314-42ee-87d8-95d3f457c4ab.jpg?1",
             "name": "Night Terrors",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. Exile that card.",
             "colours": [
@@ -3959,7 +3959,7 @@
         },
         {
             "id": "bf5545f5-f132-5b8e-b768-a5a688bdce80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d74c3e-8370-419b-808d-96b8d9306024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d74c3e-8370-419b-808d-96b8d9306024.jpg?1",
             "name": "Reaper from the Abyss",
             "text": "Flying\nMorbid \u2014 At the beginning of each end step, if a creature died this turn, destroy target non-Demon creature.",
             "colours": [
@@ -3993,7 +3993,7 @@
         },
         {
             "id": "bb4d590e-bfdd-599b-95e9-e5319d4574ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21cbb10-9157-4887-a752-29b9e94fc77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21cbb10-9157-4887-a752-29b9e94fc77a.jpg?1",
             "name": "Rotting Fensnake",
             "text": "",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "a9f8a44e-3551-5410-a569-effd4c440ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg?1",
             "name": "Screeching Bat // Stalking Vampire",
             "text": "Flying\nAt the beginning of your upkeep, you may pay {2}{B}{B}. If you do, transform Screeching Bat.",
             "colours": [
@@ -4062,7 +4062,7 @@
         },
         {
             "id": "a41f8938-eef7-5a30-a0a9-cb13174029f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/88db324f-11f1-43d3-a897-f4e3caf8d642.jpg?1",
             "name": "Screeching Bat // Stalking Vampire",
             "text": "At the beginning of your upkeep, you may pay {2}{B}{B}. If you do, transform Stalking Vampire.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "f3052302-8cae-5b11-9208-ebe93536a793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6da820-dfb9-4b61-aff8-56dfc9f4894e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6da820-dfb9-4b61-aff8-56dfc9f4894e.jpg?1",
             "name": "Sever the Bloodline",
             "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "52fa72be-fac4-5c42-bd69-af59232c2709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b28f37-d6b8-4d35-95e9-9533aea0a071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b28f37-d6b8-4d35-95e9-9533aea0a071.jpg?1",
             "name": "Skeletal Grimace",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "7dd4e02c-6c50-563a-85e8-ebb68febeb70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa6b66-f69b-4f89-b802-e30c247f90e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa6b66-f69b-4f89-b802-e30c247f90e3.jpg?1",
             "name": "Skirsdag High Priest",
             "text": "Morbid \u2014 {T}, Tap two untapped creatures you control: Put a 5/5 black Demon creature token with flying onto the battlefield. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -4197,7 +4197,7 @@
         },
         {
             "id": "d06be91d-e6e7-5fec-bbfa-a3a0bca90dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86634a1-7016-4500-8857-924d51857bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86634a1-7016-4500-8857-924d51857bad.jpg?1",
             "name": "Stromkirk Patrol",
             "text": "Whenever Stromkirk Patrol deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4232,7 +4232,7 @@
         },
         {
             "id": "ba1322e2-797a-5e86-91d6-c19b8ee116ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e0f88-2285-4b59-9165-9948c75d77a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e0f88-2285-4b59-9165-9948c75d77a3.jpg?1",
             "name": "Tribute to Hunger",
             "text": "Target opponent sacrifices a creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -4264,7 +4264,7 @@
         },
         {
             "id": "668cad9d-70d2-57dc-8b5d-d890b932788a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4490ce65-c73a-4809-abd1-ccc3175bd2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4490ce65-c73a-4809-abd1-ccc3175bd2a4.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "01ec1605-7bdc-5e49-a157-8f51e41fb6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91ea47-0c06-4333-a309-ac360c5cc9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a91ea47-0c06-4333-a309-ac360c5cc9bd.jpg?1",
             "name": "Unbreathing Horde",
             "text": "Unbreathing Horde enters the battlefield with a +1/+1 counter on it for each other Zombie you control and each Zombie card in your graveyard.\nIf Unbreathing Horde would be dealt damage, prevent that damage and remove a +1/+1 counter from it.",
             "colours": [
@@ -4332,7 +4332,7 @@
         },
         {
             "id": "9b549ebe-fc73-53aa-b167-a4eb51e1ec87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794c82b-e5ce-4369-894e-bf56c6402ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794c82b-e5ce-4369-894e-bf56c6402ae1.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "d13f2b59-b0e0-584a-9168-c6f9128f8695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48105c2e-ee36-4117-b56b-3440298da995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48105c2e-ee36-4117-b56b-3440298da995.jpg?1",
             "name": "Vampire Interloper",
             "text": "Flying\nVampire Interloper can't block.",
             "colours": [
@@ -4400,7 +4400,7 @@
         },
         {
             "id": "dea2f57b-9c5a-528a-a7e5-48da498c08bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4c6135-eee9-43ec-bbe8-76912352dcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4c6135-eee9-43ec-bbe8-76912352dcac.jpg?1",
             "name": "Victim of Night",
             "text": "Destroy target non-Vampire, non-Werewolf, non-Zombie creature.",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "3356cd31-2500-5483-bb5e-e85505d8fdb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5400460-da9d-437b-bb81-cf382beb371e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5400460-da9d-437b-bb81-cf382beb371e.jpg?1",
             "name": "Village Cannibals",
             "text": "Whenever another Human creature dies, put a +1/+1 counter on Village Cannibals.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "2ec59d3a-daa3-587e-a102-cb25ad5a8b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e033384-3334-4082-9541-f2443d3bc424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e033384-3334-4082-9541-f2443d3bc424.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -4500,7 +4500,7 @@
         },
         {
             "id": "3e84c735-5599-58a6-8691-d67bc79a4467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e7b966-7c5b-44e6-a6df-4bd7af4edaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e7b966-7c5b-44e6-a6df-4bd7af4edaa9.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "c5ad8418-0ca8-5373-b73c-f00ba2031128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900ff07e-e5d2-4fe6-ad1a-d0d7e1a272ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900ff07e-e5d2-4fe6-ad1a-d0d7e1a272ea.jpg?1",
             "name": "Ashmouth Hound",
             "text": "Whenever Ashmouth Hound blocks or becomes blocked by a creature, Ashmouth Hound deals 1 damage to that creature.",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "4bd792c7-fa65-5a48-94c1-5d348e881f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dce4ac-f472-4f3b-b01a-eff0902a578f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dce4ac-f472-4f3b-b01a-eff0902a578f.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "c4ee8111-7247-502e-9c8a-e82593e0ebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509ce648-fb76-486d-8b39-183e368b7cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509ce648-fb76-486d-8b39-183e368b7cb7.jpg?1",
             "name": "Blasphemous Act",
             "text": "Blasphemous Act costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -4634,7 +4634,7 @@
         },
         {
             "id": "685abfe5-b100-5653-9ab1-fdc7ea6e6d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2452e-309d-44ae-9360-9d6e22a15e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2452e-309d-44ae-9360-9d6e22a15e2b.jpg?1",
             "name": "Bloodcrazed Neonate",
             "text": "Bloodcrazed Neonate attacks each turn if able.\nWhenever Bloodcrazed Neonate deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "0bc593fa-d23d-5399-9281-36bf68b74cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6960f2da-6b84-4680-8ab2-f0567a5d1b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6960f2da-6b84-4680-8ab2-f0567a5d1b0a.jpg?1",
             "name": "Brimstone Volley",
             "text": "Brimstone Volley deals 3 damage to target creature or player.\nMorbid \u2014 Brimstone Volley deals 5 damage to that creature or player instead if a creature died this turn.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "00f89f38-6490-5806-b3f0-cf36d2cd8bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd403810-840b-46ac-ae6e-5df23ce16fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd403810-840b-46ac-ae6e-5df23ce16fec.jpg?1",
             "name": "Burning Vengeance",
             "text": "Whenever you cast a spell from your graveyard, Burning Vengeance deals 2 damage to target creature or player.",
             "colours": [
@@ -4732,7 +4732,7 @@
         },
         {
             "id": "c7092035-27af-5a10-b0f0-9c6464bf6647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9197a67-6609-496c-9aae-825ede4f755b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9197a67-6609-496c-9aae-825ede4f755b.jpg?1",
             "name": "Charmbreaker Devils",
             "text": "At the beginning of your upkeep, return an instant or sorcery card at random from your graveyard to your hand.\nWhenever you cast an instant or sorcery spell, Charmbreaker Devils gets +4/+0 until end of turn.",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "00f80e99-75f6-5cce-9330-071a7c019c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7a137f-e19e-43a6-aab8-02b175c9d626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7a137f-e19e-43a6-aab8-02b175c9d626.jpg?1",
             "name": "Crossway Vampire",
             "text": "When Crossway Vampire enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "9b0bd2d0-126d-5f73-ab27-843336440c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a18883-8990-40a0-bcb2-e01d0e82bfad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a18883-8990-40a0-bcb2-e01d0e82bfad.jpg?1",
             "name": "Curse of Stalked Prey",
             "text": "Enchant player\nWhenever a creature deals combat damage to enchanted player, put a +1/+1 counter on that creature.",
             "colours": [
@@ -4835,7 +4835,7 @@
         },
         {
             "id": "b52f7a23-4a3f-5ee0-b2ba-338469f3a5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cbfcf2-462e-4bbf-a529-a70816eb1436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cbfcf2-462e-4bbf-a529-a70816eb1436.jpg?1",
             "name": "Curse of the Nightly Hunt",
             "text": "Enchant player\nCreatures enchanted player controls attack each turn if able.",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "342d55d2-9796-57ec-afec-562d2a0403bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71010182-c004-4d18-adab-80319cd1e625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71010182-c004-4d18-adab-80319cd1e625.jpg?1",
             "name": "Curse of the Pierced Heart",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, Curse of the Pierced Heart deals 1 damage to that player.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "7f2463aa-595b-5199-83dd-df792d07207c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba3ab3e-d16c-492f-a860-6d8efcadf679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba3ab3e-d16c-492f-a860-6d8efcadf679.jpg?1",
             "name": "Desperate Ravings",
             "text": "Draw two cards, then discard a card at random.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "982876df-48d7-598e-ba4e-f5e29dc6882a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80596a4-b464-4b9e-8186-94a1c44838eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80596a4-b464-4b9e-8186-94a1c44838eb.jpg?1",
             "name": "Devil's Play",
             "text": "Devil's Play deals X damage to target creature or player.\nFlashback {X}{R}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "6f4bd7f1-db65-5f2f-8478-b062edac2e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09887-6d2b-48b4-a483-16b8a45babd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09887-6d2b-48b4-a483-16b8a45babd0.jpg?1",
             "name": "Falkenrath Marauders",
             "text": "Flying, haste\nWhenever Falkenrath Marauders deals combat damage to a player, put two +1/+1 counters on it.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "92e35209-36e2-5c7a-8037-8cb7f85216b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c66cc0-cb0f-4daf-8141-0923ad46a834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c66cc0-cb0f-4daf-8141-0923ad46a834.jpg?1",
             "name": "Feral Ridgewolf",
             "text": "Trample\n{1}{R}: Feral Ridgewolf gets +2/+0 until end of turn.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "5b023322-846c-5f65-bfef-c419aacceb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a4c19-6427-4a03-a543-992c910e668f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a4c19-6427-4a03-a543-992c910e668f.jpg?1",
             "name": "Furor of the Bitten",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "c8108506-da66-5c94-9f1a-5067d6387dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b856f31-ac80-4338-95a5-3f8acda74cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b856f31-ac80-4338-95a5-3f8acda74cfe.jpg?1",
             "name": "Geistflame",
             "text": "Geistflame deals 1 damage to target creature or player.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "7c6ae2f4-0799-5164-8c9d-a5f51e35a3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1",
             "name": "Hanweir Watchkeep // Bane of Hanweir",
             "text": "Defender\nAt the beginning of each upkeep, if no spells were cast last turn, transform Hanweir Watchkeep.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "986c3997-7a5b-5651-9536-278adaa3ba4f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1",
             "name": "Hanweir Watchkeep // Bane of Hanweir",
             "text": "Bane of Hanweir attacks each turn if able.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Bane of Hanweir.",
             "colours": [
@@ -5175,7 +5175,7 @@
         },
         {
             "id": "dd62be7e-378a-599d-be04-688d53d4f815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6220b4-a5b8-45c8-9422-fab9eb32322c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6220b4-a5b8-45c8-9422-fab9eb32322c.jpg?1",
             "name": "Harvest Pyre",
             "text": "As an additional cost to cast Harvest Pyre, exile X cards from your graveyard.\nHarvest Pyre deals X damage to target creature.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "a56cfa22-dbd4-570a-92bb-6a2516d08c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e963-bb0c-4490-8238-9476b924abf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9e963-bb0c-4490-8238-9476b924abf7.jpg?1",
             "name": "Heretic's Punishment",
             "text": "{3}{R}: Choose target creature or player, then put the top three cards of your library into your graveyard.  Heretic's Punishment deals damage to that creature or player equal to the highest converted mana cost among those cards.",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "139c7008-0558-51c1-b62e-59ec50d498ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f50e17-c29c-4d2c-b3e7-45d1216b81ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f50e17-c29c-4d2c-b3e7-45d1216b81ea.jpg?1",
             "name": "Infernal Plunge",
             "text": "As an additional cost to cast Infernal Plunge, sacrifice a creature.\nAdd {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5271,7 +5271,7 @@
         },
         {
             "id": "2fb42e68-8ae1-538e-8635-bc23172e088d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg?1",
             "name": "Instigator Gang // Wildblood Pack",
             "text": "Attacking creatures you control get +1/+0.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Instigator Gang.",
             "colours": [
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "30d3650b-56cf-531f-a20f-0dec057b0ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb90a6f1-c7f2-4c2e-ab1e-59c5c7937841.jpg?1",
             "name": "Instigator Gang // Wildblood Pack",
             "text": "Trample\nAttacking creatures you control get +3/+0.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Wildblood Pack.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "cd38b4f5-8e5c-589c-9ba1-3743b407b14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d188d9b-7a12-4eaf-855b-af4f0204dc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d188d9b-7a12-4eaf-855b-af4f0204dc5a.jpg?1",
             "name": "Into the Maw of Hell",
             "text": "Destroy target land. Into the Maw of Hell deals 13 damage to target creature.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "12b09b42-7012-5446-a1d3-fe9c99a89450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3255480b-c1cf-43d9-a40e-43e38112bb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3255480b-c1cf-43d9-a40e-43e38112bb18.jpg?1",
             "name": "Kessig Wolf",
             "text": "{1}{R}: Kessig Wolf gains first strike until end of turn.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "61017f5c-3ae5-5bfa-bbf5-7c702a61c335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1",
             "name": "Kruin Outlaw // Terror of Kruin Pass",
             "text": "First strike\nAt the beginning of each upkeep, if no spells were cast last turn, transform Kruin Outlaw.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "37a06508-33c9-53fc-ba87-067967c5458d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1",
             "name": "Kruin Outlaw // Terror of Kruin Pass",
             "text": "Double strike\nEach Werewolf you control can't be blocked except by two or more creatures.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Terror of Kruin Pass.",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "9db05e04-cc5c-5711-b7f4-d5e1ceaacc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f82c5c-77fa-45f3-a91e-4c2489444855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f82c5c-77fa-45f3-a91e-4c2489444855.jpg?1",
             "name": "Night Revelers",
             "text": "Night Revelers has haste as long as an opponent controls a Human.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "821e4cae-44ae-56a3-b22c-837369f962c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c7410d-b69b-41a3-b469-e12c6ffc7578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c7410d-b69b-41a3-b469-e12c6ffc7578.jpg?1",
             "name": "Nightbird's Clutches",
             "text": "Up to two target creatures can't block this turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "48e0a904-63f2-5db2-80e4-f0af03dbbdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23af6033-4930-48e4-821d-14cbbe1754b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23af6033-4930-48e4-821d-14cbbe1754b4.jpg?1",
             "name": "Past in Flames",
             "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5574,7 +5574,7 @@
         },
         {
             "id": "310d4242-0c3f-5c71-bab6-21e749c05f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d3de5-4028-457f-8eba-82e829061a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d3de5-4028-457f-8eba-82e829061a40.jpg?1",
             "name": "Pitchburn Devils",
             "text": "When Pitchburn Devils dies, it deals 3 damage to target creature or player.",
             "colours": [
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "ceb1cc1c-8ed4-5ec1-9d19-6d75d8249f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16db004-3e0c-491b-b8b6-0ae046d11761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16db004-3e0c-491b-b8b6-0ae046d11761.jpg?1",
             "name": "Rage Thrower",
             "text": "Whenever another creature dies, Rage Thrower deals 2 damage to target player.",
             "colours": [
@@ -5643,7 +5643,7 @@
         },
         {
             "id": "2c6a220e-609c-55be-a4b7-600e0f199470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afab3a6-95e3-4786-94f2-d9aa7365a4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afab3a6-95e3-4786-94f2-d9aa7365a4de.jpg?1",
             "name": "Rakish Heir",
             "text": "Whenever a Vampire you control deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "3e6bbc8a-f285-5a36-9d97-10325c411b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg?1",
             "name": "Reckless Waif // Merciless Predator",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Reckless Waif.",
             "colours": [
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "09018ca4-a360-57ba-a381-5cb6203d2da0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/028aeebc-4073-4595-94da-02f9f96ea148.jpg?1",
             "name": "Reckless Waif // Merciless Predator",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Merciless Predator.",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "2820d884-ada0-53eb-bb5c-7f58d51df869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd35107b-6aaf-4fd8-bf1c-12b724d1482e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd35107b-6aaf-4fd8-bf1c-12b724d1482e.jpg?1",
             "name": "Riot Devils",
             "text": "",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "fd053e1e-ca2e-50fc-9583-86a5a82335e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060ce982-94dd-4b9e-b240-15da297e29f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060ce982-94dd-4b9e-b240-15da297e29f9.jpg?1",
             "name": "Rolling Temblor",
             "text": "Rolling Temblor deals 2 damage to each creature without flying.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5813,7 +5813,7 @@
         },
         {
             "id": "98f55859-6f07-502c-9ad6-5406a9c40274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c25932-96e7-4ae5-b544-8780f92d0be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c25932-96e7-4ae5-b544-8780f92d0be7.jpg?1",
             "name": "Scourge of Geier Reach",
             "text": "Scourge of Geier Reach gets +1/+1 for each creature your opponents control.",
             "colours": [
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "5cb09172-ea91-5334-8c5c-e57378dc3723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63fa0de-2ec3-41ff-8e5d-0b54f400f27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63fa0de-2ec3-41ff-8e5d-0b54f400f27f.jpg?1",
             "name": "Skirsdag Cultist",
             "text": "{R}, {T}, Sacrifice a creature: Skirsdag Cultist deals 2 damage to target creature or player.",
             "colours": [
@@ -5882,7 +5882,7 @@
         },
         {
             "id": "87329a40-2cb1-5c58-bd81-6ab8b7763450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c16cf74-f9e0-4d80-9a29-b91dec0b6b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c16cf74-f9e0-4d80-9a29-b91dec0b6b38.jpg?1",
             "name": "Stromkirk Noble",
             "text": "Stromkirk Noble can't be blocked by Humans.\nWhenever Stromkirk Noble deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "d3fb28e3-3d23-5aeb-958b-ef4af1bd283f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg?1",
             "name": "Tormented Pariah // Rampaging Werewolf",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Tormented Pariah.",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "cbc388a8-db73-5439-a889-02e674e2f605",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6151cae7-92a4-4891-a952-21def412d3e4.jpg?1",
             "name": "Tormented Pariah // Rampaging Werewolf",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Rampaging Werewolf.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "ffdaaf00-7c99-58cd-9bdb-14a0485f21a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8220f18a-f23f-4fe6-bb58-58b6c5f36c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8220f18a-f23f-4fe6-bb58-58b6c5f36c79.jpg?1",
             "name": "Traitorous Blood",
             "text": "Gain control of target creature until end of turn. Untap it. It gains trample and haste until end of turn.",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "590e1d1b-d6d0-5619-9768-0214b0c17318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4fd254-0ae9-498d-b9da-4fb3d6a1a55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4fd254-0ae9-498d-b9da-4fb3d6a1a55c.jpg?1",
             "name": "Vampiric Fury",
             "text": "Vampire creatures you control get +2/+0 and gain first strike until end of turn.",
             "colours": [
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "205ffd26-5560-547d-be97-0fbb2e4d4a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg?1",
             "name": "Village Ironsmith // Ironfang",
             "text": "First strike\nAt the beginning of each upkeep, if no spells were cast last turn, transform Village Ironsmith.",
             "colours": [
@@ -6086,7 +6086,7 @@
         },
         {
             "id": "1663bf35-5b02-5f55-aacf-48ed9f134037",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd5435d0-789f-4c42-8efc-165c072404a2.jpg?1",
             "name": "Village Ironsmith // Ironfang",
             "text": "First strike\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ironfang.",
             "colours": [
@@ -6120,7 +6120,7 @@
         },
         {
             "id": "92172320-16e6-5162-9654-530a910ce461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c082aa8-bf7f-47f2-baf8-43ad253fd7d7.jpg?1",
             "name": "Ambush Viper",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "0a149d34-ff47-578d-aae0-7aae555b5f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb39e97-53c2-4df0-9fb3-a3d6a24ec41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb39e97-53c2-4df0-9fb3-a3d6a24ec41f.jpg?1",
             "name": "Avacyn's Pilgrim",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "3ffa5ed0-afc8-55e1-8e91-7a656fc6cbad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f3d9eb-462c-41b5-ad1a-baab7dc5eac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f3d9eb-462c-41b5-ad1a-baab7dc5eac3.jpg?1",
             "name": "Boneyard Wurm",
             "text": "Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "813eeaf1-d45b-5f7e-84a0-f9adb14113fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60fa219e-5dba-4d49-9cae-40d254f140e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60fa219e-5dba-4d49-9cae-40d254f140e4.jpg?1",
             "name": "Bramblecrush",
             "text": "Destroy target noncreature permanent.",
             "colours": [
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "0003caab-9ff5-5d1a-bc06-976dd0457f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8dfb98-a975-41bf-8aac-c0001c9ddaa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8dfb98-a975-41bf-8aac-c0001c9ddaa7.jpg?1",
             "name": "Caravan Vigil",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nMorbid \u2014 You may put that card onto the battlefield instead of putting it into your hand if a creature died this turn.",
             "colours": [
@@ -6288,7 +6288,7 @@
         },
         {
             "id": "4f1b5687-98d7-5af0-96a4-7546dc027786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b965069d-8513-41ab-98f6-3fbd46c19e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b965069d-8513-41ab-98f6-3fbd46c19e2d.jpg?1",
             "name": "Creeping Renaissance",
             "text": "Choose a permanent type. Return all cards of the chosen type from your graveyard to your hand.\nFlashback {5}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "b6ec2af8-9a2f-581b-903a-5b4838b7557e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec37c5a-8223-441c-a8a6-8da1a2dfc3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec37c5a-8223-441c-a8a6-8da1a2dfc3fb.jpg?1",
             "name": "Darkthicket Wolf",
             "text": "{2}{G}: Darkthicket Wolf gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "bf0aa055-3635-5efd-930d-4f0a7caaa411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg?1",
             "name": "Daybreak Ranger // Nightfall Predator",
             "text": "{T}: Daybreak Ranger deals 2 damage to target creature with flying.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Daybreak Ranger.",
             "colours": [
@@ -6392,7 +6392,7 @@
         },
         {
             "id": "4f8f89b1-0dc0-5012-a980-c2197ebb0a96",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25b54a1d-e201-453b-9173-b04e06ee6fb7.jpg?1",
             "name": "Daybreak Ranger // Nightfall Predator",
             "text": "{R}, {T}: Nightfall Predator fights target creature. (Each deals damage equal to its power to the other.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Nightfall Predator.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "2ec3427e-6972-5aac-bb03-3eb0c3490d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b82ef0-c974-4357-b21a-4c2a28ec7279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b82ef0-c974-4357-b21a-4c2a28ec7279.jpg?1",
             "name": "Elder of Laurels",
             "text": "{3}{G}: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "5fb1dcd8-0daf-5280-96e5-af6101d9a719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec48cba-1b5d-44e7-9e25-16922dedb67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec48cba-1b5d-44e7-9e25-16922dedb67d.jpg?1",
             "name": "Essence of the Wild",
             "text": "Creatures you control enter the battlefield as a copy of Essence of the Wild.",
             "colours": [
@@ -6496,7 +6496,7 @@
         },
         {
             "id": "9cb62c63-8fba-51a5-a8c6-aa788c13d6a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31740fe9-27d2-416e-93de-509ac1a7b7cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31740fe9-27d2-416e-93de-509ac1a7b7cd.jpg?1",
             "name": "Festerhide Boar",
             "text": "Trample\nMorbid \u2014 Festerhide Boar enters the battlefield with two +1/+1 counters on it if a creature died this turn.",
             "colours": [
@@ -6530,7 +6530,7 @@
         },
         {
             "id": "e4f312ea-46b1-5e1a-bf76-c55c701bf046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a35eac-b962-466e-a4da-a4010c68ef16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a35eac-b962-466e-a4da-a4010c68ef16.jpg?1",
             "name": "Full Moon's Rise",
             "text": "Werewolf creatures you control get +1/+0 and have trample.\nSacrifice Full Moon's Rise: Regenerate all Werewolf creatures you control.",
             "colours": [
@@ -6562,7 +6562,7 @@
         },
         {
             "id": "d4254138-884d-5c33-a2fd-a5c86ccfdf34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg?1",
             "name": "Garruk Relentless // Garruk, the Veil-Cursed",
             "text": "When Garruk Relentless has two or fewer loyalty counters on him, transform him.\n0: Garruk Relentless deals 3 damage to target creature. That creature deals damage equal to its power to him.\n0: Put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -6599,7 +6599,7 @@
         },
         {
             "id": "d9116cba-0917-551f-bc20-c1a15659a173",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4160322-ff40-41a4-887a-73cd6b85ae45.jpg?1",
             "name": "Garruk Relentless // Garruk, the Veil-Cursed",
             "text": "+1: Put a 1/1 black Wolf creature token with deathtouch onto the battlefield.\n-1: Sacrifice a creature. If you do, search your library for a creature card, reveal it, put it into your hand, then shuffle your library.\n-3: Creatures you control gain trample and get +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "597ba0c2-2ab3-5ca2-a320-b29c3ec61e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg?1",
             "name": "Gatstaf Shepherd // Gatstaf Howler",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Gatstaf Shepherd.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "308ee849-5c1a-5824-bb17-2fb033dfd623",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57f0907f-74f4-4d86-93df-f2e50c9d0b2f.jpg?1",
             "name": "Gatstaf Shepherd // Gatstaf Howler",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Gatstaf Howler.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "04e5f1b2-6ef9-59b6-b31a-a98ec2b111f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416148c8-13d3-46d3-ac93-6eb7cbab2881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416148c8-13d3-46d3-ac93-6eb7cbab2881.jpg?1",
             "name": "Gnaw to the Bone",
             "text": "You gain 2 life for each creature card in your graveyard.\nFlashback {2}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "571b8305-a169-5f73-8aed-941be0dcd6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be1d4d2-5215-44b2-9b67-627d088efdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be1d4d2-5215-44b2-9b67-627d088efdb5.jpg?1",
             "name": "Grave Bramble",
             "text": "Defender, protection from Zombies",
             "colours": [
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "704bc6b2-505b-5d21-a0cc-6014a5d4b8e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg?1",
             "name": "Grizzled Outcasts // Krallenhorde Wantons",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Grizzled Outcasts.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "8f9e65d3-a135-51cc-98b6-bb138810cbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/b/4b43b0cb-a5a3-47b4-9b6b-9d2638222bb6.jpg?1",
             "name": "Grizzled Outcasts // Krallenhorde Wantons",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Krallenhorde Wantons.",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "a28f0442-2775-5723-b275-af0314259bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d007a2-163d-4e09-a70b-280a6fa3203b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d007a2-163d-4e09-a70b-280a6fa3203b.jpg?1",
             "name": "Gutter Grime",
             "text": "Whenever a nontoken creature you control dies, put a slime counter on Gutter Grime, then put a green Ooze creature token onto the battlefield with \"This creature's power and toughness are each equal to the number of slime counters on Gutter Grime.\"",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "c242c074-067d-578d-a338-e25f0e2545de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203ae4f-4d69-490f-8a7c-dadbefa6d697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203ae4f-4d69-490f-8a7c-dadbefa6d697.jpg?1",
             "name": "Hamlet Captain",
             "text": "Whenever Hamlet Captain attacks or blocks, other Human creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "8447046d-c7a9-5ba9-9f25-d8b322aee599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9ff632-0e27-4521-9e9d-5725e618f5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9ff632-0e27-4521-9e9d-5725e618f5dd.jpg?1",
             "name": "Hollowhenge Scavenger",
             "text": "Morbid \u2014 When Hollowhenge Scavenger enters the battlefield, if a creature died this turn, you gain 5 life.",
             "colours": [
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "c6ffd50d-795f-5a5a-97d4-7e2e48e95cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae22886-da03-49f2-873c-98a7ea2ee17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae22886-da03-49f2-873c-98a7ea2ee17d.jpg?1",
             "name": "Kessig Cagebreakers",
             "text": "Whenever Kessig Cagebreakers attacks, put a 2/2 green Wolf creature token onto the battlefield tapped and attacking for each creature card in your graveyard.",
             "colours": [
@@ -6977,7 +6977,7 @@
         },
         {
             "id": "6270375b-b162-5b21-b478-f6f8c2482acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4954e8a3-e72b-4f28-8762-2b1c658c31b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4954e8a3-e72b-4f28-8762-2b1c658c31b6.jpg?1",
             "name": "Kindercatch",
             "text": "",
             "colours": [
@@ -7011,7 +7011,7 @@
         },
         {
             "id": "e01bba9b-674c-54a5-a55e-4bec90a9c77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c86c84e-9bab-4a2c-b594-7f7b4b6bba88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c86c84e-9bab-4a2c-b594-7f7b4b6bba88.jpg?1",
             "name": "Lumberknot",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever a creature dies, put a +1/+1 counter on Lumberknot.",
             "colours": [
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "06cdec9f-7843-5cf9-986a-a3ab0ab0a989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a8508d-25a7-4fb2-8aa3-349275f80c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a8508d-25a7-4fb2-8aa3-349275f80c42.jpg?1",
             "name": "Make a Wish",
             "text": "Return two cards at random from your graveyard to your hand.",
             "colours": [
@@ -7077,7 +7077,7 @@
         },
         {
             "id": "3d534857-3daf-558b-a0ba-f0e231db7a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1",
             "name": "Mayor of Avabruck // Howlpack Alpha",
             "text": "Other Human creatures you control get +1/+1.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Mayor of Avabruck.",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "cd567de0-8d69-58f6-823a-7dcfe5cbc65b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1",
             "name": "Mayor of Avabruck // Howlpack Alpha",
             "text": "Other Werewolf and Wolf creatures you control get +1/+1.\nAt the beginning of your end step, put a 2/2 green Wolf creature token onto the battlefield.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Howlpack Alpha.",
             "colours": [
@@ -7147,7 +7147,7 @@
         },
         {
             "id": "ea51f57d-1986-5dcf-b49c-ff8b329e6b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f387c86a-702f-4f86-bcb9-d2bfa46fd211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f387c86a-702f-4f86-bcb9-d2bfa46fd211.jpg?1",
             "name": "Moldgraf Monstrosity",
             "text": "Trample\nWhen Moldgraf Monstrosity dies, exile it, then return two creature cards at random from your graveyard to the battlefield.",
             "colours": [
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "7b25c01a-2300-5615-ba70-cdf6e4c6d662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57153c3f-9e55-418c-b67b-36901f29f9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57153c3f-9e55-418c-b67b-36901f29f9c1.jpg?1",
             "name": "Moonmist",
             "text": "Transform all Humans. Prevent all combat damage that would be dealt this turn by creatures other than Werewolves and Wolves. (Only double-faced cards can be transformed.)",
             "colours": [
@@ -7213,7 +7213,7 @@
         },
         {
             "id": "2eae6225-3a93-5e4a-92cb-736170dd8ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1dabd-82df-4814-9d64-bf7bf9c1018d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1dabd-82df-4814-9d64-bf7bf9c1018d.jpg?1",
             "name": "Mulch",
             "text": "Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -7245,7 +7245,7 @@
         },
         {
             "id": "13daf309-cdf6-5716-9a54-570ad74e6fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236f1a8c-13ab-4ab3-b11f-082054d297e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236f1a8c-13ab-4ab3-b11f-082054d297e5.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "486005f2-2484-5a65-86da-0a590c770b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac43ced-35b0-4e70-a049-1a65db9b2b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac43ced-35b0-4e70-a049-1a65db9b2b1e.jpg?1",
             "name": "Orchard Spirit",
             "text": "Orchard Spirit can't be blocked except by creatures with flying or reach.",
             "colours": [
@@ -7311,7 +7311,7 @@
         },
         {
             "id": "b88545f8-42bd-5193-8199-5d630d36b502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01033dae-fec1-41f2-b7f2-cc6a43331790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01033dae-fec1-41f2-b7f2-cc6a43331790.jpg?1",
             "name": "Parallel Lives",
             "text": "If an effect would put one or more tokens onto the battlefield under your control, it puts twice that many of those tokens onto the battlefield instead.",
             "colours": [
@@ -7343,7 +7343,7 @@
         },
         {
             "id": "b44558d5-c9ea-5d76-be3b-37ae49911978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b3eaf0-4207-4bac-923d-29f348c95a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b3eaf0-4207-4bac-923d-29f348c95a35.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "d07fd1a4-abb0-5eda-9d6e-a28c599f99d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90742ae-c48b-4d32-a6b7-aa51a94018bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90742ae-c48b-4d32-a6b7-aa51a94018bd.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "a2c1228b-bf31-54b4-8817-1939380f875f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43003ad7-2f42-4c85-8b00-77cbf3f50a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43003ad7-2f42-4c85-8b00-77cbf3f50a7b.jpg?1",
             "name": "Somberwald Spider",
             "text": "Reach (This creature can block creatures with flying.)\nMorbid \u2014 Somberwald Spider enters the battlefield with two +1/+1 counters on it if a creature died this turn.",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "b8e1bf7a-5029-5e79-b364-895d22ce52f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97007af-6642-4105-8d8c-4223681e1cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97007af-6642-4105-8d8c-4223681e1cf9.jpg?1",
             "name": "Spider Spawning",
             "text": "Put a 1/2 green Spider creature token with reach onto the battlefield for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "0ecd9ed3-96a7-584b-8516-619a3e6a7f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdfd82-d025-4070-a1f5-4ee759978bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdfd82-d025-4070-a1f5-4ee759978bcb.jpg?1",
             "name": "Spidery Grasp",
             "text": "Untap target creature. It gets +2/+4 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -7506,7 +7506,7 @@
         },
         {
             "id": "c1e3cce9-2e29-5edf-aae2-9b876caff1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37068a41-bc5c-44b9-a307-5d3919794233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37068a41-bc5c-44b9-a307-5d3919794233.jpg?1",
             "name": "Splinterfright",
             "text": "Trample\nSplinterfright's power and toughness are each equal to the number of creature cards in your graveyard.\nAt the beginning of your upkeep, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -7540,7 +7540,7 @@
         },
         {
             "id": "2d0da2d1-f477-5456-97ac-cea9d040b55d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654ae7-af2c-4956-be3a-68befa33f523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9654ae7-af2c-4956-be3a-68befa33f523.jpg?1",
             "name": "Travel Preparations",
             "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "26ee394e-eef4-5206-828a-0785d159aad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6110bba-5c2d-4183-9dd0-d85a4cc42753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6110bba-5c2d-4183-9dd0-d85a4cc42753.jpg?1",
             "name": "Tree of Redemption",
             "text": "Defender\n{T}: Exchange your life total with Tree of Redemption's toughness.",
             "colours": [
@@ -7607,7 +7607,7 @@
         },
         {
             "id": "0e9264fb-abc0-5ba1-a635-716a62dbc26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg?1",
             "name": "Ulvenwald Mystics // Ulvenwald Primordials",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Ulvenwald Mystics.",
             "colours": [
@@ -7643,7 +7643,7 @@
         },
         {
             "id": "297b1abb-ee3e-5511-bff0-92e8140d874d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/8325c570-4d74-4e65-891c-3e153abf4bf9.jpg?1",
             "name": "Ulvenwald Mystics // Ulvenwald Primordials",
             "text": "{G}: Regenerate Ulvenwald Primordials.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Ulvenwald Primordials.",
             "colours": [
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "95948ae1-917d-5a8d-a319-1d576958f525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1",
             "name": "Villagers of Estwald // Howlpack of Estwald",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Villagers of Estwald.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "6e4196be-ec3d-5343-a232-de8f1c05e28a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1",
             "name": "Villagers of Estwald // Howlpack of Estwald",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Howlpack of Estwald.",
             "colours": [
@@ -7746,7 +7746,7 @@
         },
         {
             "id": "da2e432b-3d50-5891-a7d3-88df48946c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088a924-58c6-4ab7-baf0-842d6688fcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3088a924-58c6-4ab7-baf0-842d6688fcec.jpg?1",
             "name": "Woodland Sleuth",
             "text": "Morbid \u2014 When Woodland Sleuth enters the battlefield, if a creature died this turn, return a creature card at random from your graveyard to your hand.",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "f0072bed-ca26-5116-aa36-9bdc166f4a90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604e22e-1f29-4a8f-b887-b18f43e3745e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604e22e-1f29-4a8f-b887-b18f43e3745e.jpg?1",
             "name": "Wreath of Geists",
             "text": "Enchant creature\nEnchanted creature gets +X/+X, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -7815,7 +7815,7 @@
         },
         {
             "id": "5c6227bf-f0a9-568c-96cf-b6e4a6726e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53487a-c00b-42da-904c-f022a0c5b1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53487a-c00b-42da-904c-f022a0c5b1ed.jpg?1",
             "name": "Evil Twin",
             "text": "You may have Evil Twin enter the battlefield as a copy of any creature on the battlefield except it gains \"{U}{B}, {T}: Destroy target creature with the same name as this creature.\"",
             "colours": [
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "0f691827-756c-5373-a87a-7bdfd95cdbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b57113-b39a-460b-b4aa-02606b40bbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b57113-b39a-460b-b4aa-02606b40bbd0.jpg?1",
             "name": "Geist of Saint Traft",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Geist of Saint Traft attacks, put a 4/4 white Angel creature token with flying onto the battlefield tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "83039e0c-241b-5e45-aedb-ecc6e8d363b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8648734-ed6c-471f-91a1-6b710bbaf370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8648734-ed6c-471f-91a1-6b710bbaf370.jpg?1",
             "name": "Grimgrin, Corpse-Born",
             "text": "Grimgrin, Corpse-Born enters the battlefield tapped and doesn't untap during your untap step.\nSacrifice another creature: Untap Grimgrin and put a +1/+1 counter on it.\nWhenever Grimgrin attacks, destroy target creature defending player controls, then put a +1/+1 counter on Grimgrin.",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "b3f04750-9511-54bc-892f-7ac78dc3aae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed750692-ba6a-4a89-ad6d-92fda7edc2cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed750692-ba6a-4a89-ad6d-92fda7edc2cb.jpg?1",
             "name": "Olivia Voldaren",
             "text": "Flying\n{1}{R}: Olivia Voldaren deals 1 damage to another target creature. That creature becomes a Vampire in addition to its other types. Put a +1/+1 counter on Olivia Voldaren.\n{3}{B}{B}: Gain control of target Vampire for as long as you control Olivia Voldaren.",
             "colours": [
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "cbb12edb-d200-593f-94f7-03f45741efb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e14fc60-f300-40f0-b712-4e339dc27929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e14fc60-f300-40f0-b712-4e339dc27929.jpg?1",
             "name": "Blazing Torch",
             "text": "Equipped creature can't be blocked by Vampires or Zombies.\nEquipped creature has \"{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to target creature or player.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "b66b5d73-6147-5ab5-8328-01b8a9c387c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e141fe62-515e-4fe4-b032-81f169ec58d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e141fe62-515e-4fe4-b032-81f169ec58d6.jpg?1",
             "name": "Butcher's Cleaver",
             "text": "Equipped creature gets +3/+0.\nAs long as equipped creature is a Human, it has lifelink.\nEquip {3}",
             "colours": [],
@@ -8027,7 +8027,7 @@
         },
         {
             "id": "a5eecbf5-ffc3-511e-91f9-5179ee0f9619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97bdfb00-7773-4af6-895c-c90088a96b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97bdfb00-7773-4af6-895c-c90088a96b07.jpg?1",
             "name": "Cellar Door",
             "text": "{3}, {T}: Target player puts the bottom card of his or her library into his or her graveyard. If it's a creature card, you put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [],
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "8859c78a-95de-5487-9841-2aa1c3e6b2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24abd762-e533-491a-97b6-aed40c214e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24abd762-e533-491a-97b6-aed40c214e9d.jpg?1",
             "name": "Cobbled Wings",
             "text": "Equipped creature has flying.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8085,7 +8085,7 @@
         },
         {
             "id": "ccd2c10d-e621-5f88-bb97-71e4fb046035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762a598b-8753-47ec-9dd6-2c3d8882fda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762a598b-8753-47ec-9dd6-2c3d8882fda6.jpg?1",
             "name": "Creepy Doll",
             "text": "Creepy Doll is indestructible.\nWhenever Creepy Doll deals combat damage to a creature, flip a coin. If you win the flip, destroy that creature.",
             "colours": [],
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "66fa7495-c2a1-5ebb-8ecd-afc01d84c9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33caa8-2a07-4f6c-a6c2-d21cf2d61193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa33caa8-2a07-4f6c-a6c2-d21cf2d61193.jpg?1",
             "name": "Demonmail Hauberk",
             "text": "Equipped creature gets +4/+2.\nEquip\u2014\nSacrifice a creature.",
             "colours": [],
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "e4893d07-6e28-516f-9bbd-f7e43d331838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14bc109-d5d5-4777-90e4-bef26d106571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14bc109-d5d5-4777-90e4-bef26d106571.jpg?1",
             "name": "Galvanic Juggernaut",
             "text": "Galvanic Juggernaut attacks each turn if able.\nGalvanic Juggernaut doesn't untap during your untap step.\nWhenever another creature dies, untap Galvanic Juggernaut.",
             "colours": [],
@@ -8177,7 +8177,7 @@
         },
         {
             "id": "f12ebdd2-8557-566d-a8c9-27797d8fa606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb8ecf0-8c12-4a14-9a75-4cc5bf9e47f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb8ecf0-8c12-4a14-9a75-4cc5bf9e47f1.jpg?1",
             "name": "Geistcatcher's Rig",
             "text": "When Geistcatcher's Rig enters the battlefield, you may have it deal 4 damage to target creature with flying.",
             "colours": [],
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "c6a59256-70a8-5952-a1e5-7a80c9684591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e7c2a-698c-4dce-a10b-ca58e4affa57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863e7c2a-698c-4dce-a10b-ca58e4affa57.jpg?1",
             "name": "Ghoulcaller's Bell",
             "text": "{T}: Each player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "fd58d17f-2970-58d5-90f8-d38225697a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b8888-a10c-48b1-ba19-c041e5667b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b8888-a10c-48b1-ba19-c041e5667b29.jpg?1",
             "name": "Graveyard Shovel",
             "text": "{2}, {T}: Target player exiles a card from his or her graveyard. If it's a creature card, you gain 2 life.",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "cae9598b-a1ec-5550-86b5-c6e715a067c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d268d078-b854-47c1-bc7f-7698723405a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d268d078-b854-47c1-bc7f-7698723405a2.jpg?1",
             "name": "Grimoire of the Dead",
             "text": "{1}, {T}, Discard a card: Put a study counter on Grimoire of the Dead.\n{T}, Remove three study counters from Grimoire of the Dead and sacrifice it: Put all creature cards from all graveyards onto the battlefield under your control. They're black Zombies in addition to their other colors and types.",
             "colours": [],
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "8d4e85a2-a10b-5078-9173-49b824281162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014f59d-9012-473a-8bb1-8085c6e91632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014f59d-9012-473a-8bb1-8085c6e91632.jpg?1",
             "name": "Inquisitor's Flail",
             "text": "If equipped creature would deal combat damage, it deals double that damage instead.\nIf another creature would deal combat damage to equipped creature, it deals double that damage to equipped creature instead.\nEquip {2}",
             "colours": [],
@@ -8324,7 +8324,7 @@
         },
         {
             "id": "4b1a8cdb-fe3f-5211-b9ae-7fe000176b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb40965-9096-4a19-b71d-4da2a5b36baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb40965-9096-4a19-b71d-4da2a5b36baa.jpg?1",
             "name": "Manor Gargoyle",
             "text": "Defender\nManor Gargoyle is indestructible as long as it has defender.\n{1}: Until end of turn, Manor Gargoyle loses defender and gains flying.",
             "colours": [],
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "3bb08bfb-e286-5b11-a612-5d38ba8c5664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff1acce-bed4-452c-8416-06726004f2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff1acce-bed4-452c-8416-06726004f2e8.jpg?1",
             "name": "Mask of Avacyn",
             "text": "Equipped creature gets +1/+2 and has hexproof. (It can't be the target of spells or abilities your opponents control.)\nEquip {3}",
             "colours": [],
@@ -8385,7 +8385,7 @@
         },
         {
             "id": "d33d5bc3-88d4-578a-a86a-d68c38ce6905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d495d85-6458-44d5-b3b4-5e09569057e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d495d85-6458-44d5-b3b4-5e09569057e3.jpg?1",
             "name": "One-Eyed Scarecrow",
             "text": "Defender\nCreatures with flying your opponents control get -1/-0.",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "3892a8b9-981e-5592-a5a7-7d39a3d3a69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f54e38b-b4a0-4406-a635-7a5ab3722f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f54e38b-b4a0-4406-a635-7a5ab3722f25.jpg?1",
             "name": "Runechanter's Pike",
             "text": "Equipped creature has first strike and gets +X/+0, where X is the number of instant and sorcery cards in your graveyard.\nEquip {2}",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "78047ea9-ac61-5cde-ac78-1c9d55e127f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce20f19-a159-40e6-bb67-6108872ac1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce20f19-a159-40e6-bb67-6108872ac1e0.jpg?1",
             "name": "Sharpened Pitchfork",
             "text": "Equipped creature has first strike.\nAs long as equipped creature is a Human, it gets +1/+1.\nEquip {1}",
             "colours": [],
@@ -8476,7 +8476,7 @@
         },
         {
             "id": "b3d5dc51-1b1c-53ca-adb1-af85acbe9df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8162a-68f0-45df-bb25-8fd4487257a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b8162a-68f0-45df-bb25-8fd4487257a4.jpg?1",
             "name": "Silver-Inlaid Dagger",
             "text": "Equipped creature gets +2/+0.\nAs long as equipped creature is a Human, it gets an additional +1/+0.\nEquip {2}",
             "colours": [],
@@ -8506,7 +8506,7 @@
         },
         {
             "id": "035aa89b-2000-5b7f-af94-4dca4df1aed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0afa7-e9f9-4751-af36-d85343fabc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0afa7-e9f9-4751-af36-d85343fabc26.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -8534,7 +8534,7 @@
         },
         {
             "id": "ba5ed461-d12f-5b20-9d83-842a3cfef745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182be77-9186-4d16-a070-9577d4392999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2182be77-9186-4d16-a070-9577d4392999.jpg?1",
             "name": "Trepanation Blade",
             "text": "Whenever equipped creature attacks, defending player reveals cards from the top of his or her library until he or she reveals a land card. The creature gets +1/+0 until end of turn for each card revealed this way. That player puts the revealed cards into his or her graveyard.\nEquip {2}",
             "colours": [],
@@ -8564,7 +8564,7 @@
         },
         {
             "id": "2e9f7a06-56d1-55a8-aa41-adefbdee3128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e0bf16-62f5-4b62-96e8-bc7e049bcf89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e0bf16-62f5-4b62-96e8-bc7e049bcf89.jpg?1",
             "name": "Witchbane Orb",
             "text": "When Witchbane Orb enters the battlefield, destroy all Curses attached to you.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control, including Aura spells.)",
             "colours": [],
@@ -8592,7 +8592,7 @@
         },
         {
             "id": "697fdd69-a0b2-5c25-998f-8e5dfc65b6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2825f5-8112-4108-910a-4303b2d57356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2825f5-8112-4108-910a-4303b2d57356.jpg?1",
             "name": "Wooden Stake",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature blocks or becomes blocked by a Vampire, destroy that creature. It can't be regenerated.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8622,7 +8622,7 @@
         },
         {
             "id": "64fcf5f2-dfee-58d3-b51d-73d33acad0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7e1bf9-bd6a-48e3-9331-178e5142c06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7e1bf9-bd6a-48e3-9331-178e5142c06a.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8653,7 +8653,7 @@
         },
         {
             "id": "2b8085eb-adaa-5437-a57f-e427f57d9b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f73443-2fe8-424f-8e71-fc7ce1f3a3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f73443-2fe8-424f-8e71-fc7ce1f3a3eb.jpg?1",
             "name": "Gavony Township",
             "text": "{T}: Add {1} to your mana pool.\n{2}{G}{W}, {T}: Put a +1/+1 counter on each creature you control.",
             "colours": [],
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "2a765b32-392e-5b70-a62f-228726c3ffc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6456ed-0ffb-4d22-b252-5775076030ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6456ed-0ffb-4d22-b252-5775076030ce.jpg?1",
             "name": "Ghost Quarter",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Ghost Quarter: Destroy target land. Its controller may search his or her library for a basic land card, put it onto the battlefield, then shuffle his or her library.",
             "colours": [],
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "9ea20892-1722-5c60-979b-60f59fec347e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f15306-56fe-4643-bb4c-4c7c12378d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f15306-56fe-4643-bb4c-4c7c12378d01.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "c25228bb-836f-568a-b545-0b61bb3e1f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c1a371-5ded-4a3a-bf96-503c4f1a665d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c1a371-5ded-4a3a-bf96-503c4f1a665d.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8774,7 +8774,7 @@
         },
         {
             "id": "ea377195-f7f7-5197-890f-a2d03a06bc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8447fe-7368-470a-911a-1083ec6cc831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8447fe-7368-470a-911a-1083ec6cc831.jpg?1",
             "name": "Kessig Wolf Run",
             "text": "{T}: Add {1} to your mana pool.\n{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",
             "colours": [],
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "e44f2e95-4e18-5f22-b85c-c3a9c2fe8f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5569e3-278c-4cf3-860e-712010333fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5569e3-278c-4cf3-860e-712010333fe6.jpg?1",
             "name": "Moorland Haunt",
             "text": "{T}: Add {1} to your mana pool.\n{W}{U}, {T}, Exile a creature card from your graveyard: Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [],
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "4666d86f-3ce5-596c-a653-4d7c9b2b11fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef058312-6926-49f8-ae72-a8d60fedbf6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef058312-6926-49f8-ae72-a8d60fedbf6c.jpg?1",
             "name": "Nephalia Drownyard",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}{B}, {T}: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "d6aedd57-456b-5165-b06a-aba0ccfa40c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e7a7a-574f-4850-9697-8cb276a5812c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e7a7a-574f-4850-9697-8cb276a5812c.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8895,7 +8895,7 @@
         },
         {
             "id": "143ce35a-0735-59fa-9838-2ab17aabd337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2741d8-2c02-4acd-8ca2-55b4bf6aef1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2741d8-2c02-4acd-8ca2-55b4bf6aef1c.jpg?1",
             "name": "Stensia Bloodhall",
             "text": "{T}: Add {1} to your mana pool.\n{3}{B}{R}, {T}: Stensia Bloodhall deals 2 damage to target player.",
             "colours": [],
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "7e794845-14f6-59f9-8f7a-1a3d2f0f4899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4968b65d-50e5-4d7e-b78b-cdada1cbf7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4968b65d-50e5-4d7e-b78b-cdada1cbf7a7.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "1d1ddd51-4eb8-5ff9-8ae1-ab6cb7135c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67139101-ec5e-434b-be3a-21338cc33840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67139101-ec5e-434b-be3a-21338cc33840.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "b672236a-463d-5445-8fcd-492da1f4d640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d595ba72-3334-48f4-9ea9-a43f5e824aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d595ba72-3334-48f4-9ea9-a43f5e824aa8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9025,7 +9025,7 @@
         },
         {
             "id": "b291a163-6c22-5c4b-ae1d-e4ea5465a501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceab58a-304a-40e4-8830-837a7b51d31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceab58a-304a-40e4-8830-837a7b51d31b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9062,7 +9062,7 @@
         },
         {
             "id": "965b9128-1c32-56ee-9997-2a18a979f120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ca372-c110-4321-b497-8841547f3c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ca372-c110-4321-b497-8841547f3c2b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "83d1c051-092f-5eee-9263-5276255c876c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf258641-b73c-4813-8a23-da47cf79eca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf258641-b73c-4813-8a23-da47cf79eca5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "331b43de-b1a9-5120-b5a5-2d73a3855e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b51501-d3b3-480f-9bcb-e66420c4db06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b51501-d3b3-480f-9bcb-e66420c4db06.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "54b07438-0c7a-5242-a803-c8a8e87524ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19f6dd-9eed-4656-b8c7-e64b61446d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e19f6dd-9eed-4656-b8c7-e64b61446d7f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "51412986-6d35-50ac-91b9-a1c78f583940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a14894-2936-4fc4-b6a5-f9c73c32b177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a14894-2936-4fc4-b6a5-f9c73c32b177.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "4d5a56d8-438e-5c3a-8d85-50f128df18f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d37e23b-7898-4b5d-b088-d4e54947f579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d37e23b-7898-4b5d-b088-d4e54947f579.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9284,7 +9284,7 @@
         },
         {
             "id": "71acb144-fd1b-5ec9-a600-12751b7f0d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2ecdd-37ee-4351-833a-f4eac3c55eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2ecdd-37ee-4351-833a-f4eac3c55eca.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9321,7 +9321,7 @@
         },
         {
             "id": "0513d4ed-2c32-59a8-a849-e315fa8fd18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17de9f2c-e051-404c-8ec0-c35f500efd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17de9f2c-e051-404c-8ec0-c35f500efd67.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9358,7 +9358,7 @@
         },
         {
             "id": "bffefb78-504d-589e-aac6-67fdf021b88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a200286-67f3-4bff-8a53-3e76733414fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a200286-67f3-4bff-8a53-3e76733414fa.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9395,7 +9395,7 @@
         },
         {
             "id": "09906734-1fd1-5907-8c2e-5356059310a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2075dfe-b48c-46e3-bde1-f9f8e3b9d928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2075dfe-b48c-46e3-bde1-f9f8e3b9d928.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9432,7 +9432,7 @@
         },
         {
             "id": "24cf042e-99d1-5ff3-9419-930fedce261a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b606f644-1728-4cb3-90ed-121838875de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b606f644-1728-4cb3-90ed-121838875de1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "b8bdbcb5-e9ff-5f79-bda9-ef7cbec2bc96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f52885-1f01-4f06-90a8-1a0ecf291ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16f52885-1f01-4f06-90a8-1a0ecf291ab5.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "b1e5e7a3-13ca-5dca-85ab-e5b80e60cb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea3762-c6ae-4304-aee4-6c3f56685319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea3762-c6ae-4304-aee4-6c3f56685319.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9543,7 +9543,7 @@
         },
         {
             "id": "dd1f7bad-5e81-5704-b567-b4b38de6cd0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7d857-2a54-4d0e-a97c-11400053194c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d7d857-2a54-4d0e-a97c-11400053194c.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9577,7 +9577,7 @@
         },
         {
             "id": "d5e3dcb8-b8a8-5cf5-ad80-db6cba8eb0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbede5b-8e61-4ed8-bccb-8b54f69cccee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbede5b-8e61-4ed8-bccb-8b54f69cccee.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9611,7 +9611,7 @@
         },
         {
             "id": "eca3f5bc-09cb-59c4-a0e4-048bf9d1b6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2020f53-d012-4d26-be13-87ed0f196c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2020f53-d012-4d26-be13-87ed0f196c53.jpg?1",
             "name": "Homunculus",
             "text": "",
             "colours": [
@@ -9645,7 +9645,7 @@
         },
         {
             "id": "6ae55f03-ae8e-55dd-9147-40771507c8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "dbd2113f-ed9f-54b3-b54a-f23fb12971fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68c2ab-5131-4620-920f-7ba99522ccf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68c2ab-5131-4620-920f-7ba99522ccf0.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -9713,7 +9713,7 @@
         },
         {
             "id": "9138077f-b563-55d5-a333-de099c084a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a49607c-427a-474c-ad77-60cd05844b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a49607c-427a-474c-ad77-60cd05844b3c.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "7e030759-9fde-5bea-bc2a-2c4d71647eab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85357-3cad-4a1e-805b-ea4146d8b05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85357-3cad-4a1e-805b-ea4146d8b05f.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9781,7 +9781,7 @@
         },
         {
             "id": "4a67628e-a40c-55eb-abba-72f5bd6f7adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afec06c5-28e3-462c-9e15-4b0c405cc810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afec06c5-28e3-462c-9e15-4b0c405cc810.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9815,7 +9815,7 @@
         },
         {
             "id": "85ffe86f-9a69-5300-8743-96097fe44c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a98d0bf-4106-4ff1-89d4-3f6040b2cd5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a98d0bf-4106-4ff1-89d4-3f6040b2cd5e.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9849,7 +9849,7 @@
         },
         {
             "id": "f0a5b981-cd82-54db-8950-0c824031c19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f22cfdb-15af-46b9-b5c9-d0c76d5b15d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f22cfdb-15af-46b9-b5c9-d0c76d5b15d6.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9883,7 +9883,7 @@
         },
         {
             "id": "af261c63-c918-5bdb-b816-93cba9f0afcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71031ff1-17dc-46b7-a72b-3297137a83bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71031ff1-17dc-46b7-a72b-3297137a83bb.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -9917,7 +9917,7 @@
         },
         {
             "id": "b573ea1a-b988-52ca-b27c-d0b1f2a3cf61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -9951,7 +9951,7 @@
         },
         {
             "id": "7ee63a2d-9bea-5cf6-b74d-dd9e0b4c2411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ce1bee-8f95-4284-8e06-9de9bfcb53b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ce1bee-8f95-4284-8e06-9de9bfcb53b5.jpg?1",
             "name": "Innistrad Checklist",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/J22.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/J22.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "85eabd47-bc5f-5e56-9baa-73da77eb7abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea531418-6c7c-4e23-b681-6bfdd4a3eb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea531418-6c7c-4e23-b681-6bfdd4a3eb79.jpg?1",
             "name": "Agrus Kos, Eternal Soldier",
             "text": "Vigilance\nWhenever Agrus Kos, Eternal Soldier becomes the target of an ability that targets only it, you may pay {1}{GU}. If you do, copy that ability for each other creature you control that ability could target. Each copy targets a different one of those creatures. ({GU} can be paid with either {R} or {W}.)",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "9edb262c-fd1d-5242-aeb9-c7434567c475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45e1832-1070-4d12-aba9-dcad47a02eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45e1832-1070-4d12-aba9-dcad47a02eda.jpg?1",
             "name": "Angelic Cub",
             "text": "Whenever Angelic Cub becomes the target of a spell or ability for the first time each turn, put a +1/+1 counter on it.\nAs long as Angelic Cub has three or more +1/+1 counters on it, it has flying.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "7dc970af-bbc9-510b-9e80-19926c6e80dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a1a840-bcdc-4d6f-a28d-9805578473f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a1a840-bcdc-4d6f-a28d-9805578473f6.jpg?1",
             "name": "Chains of Custody",
             "text": "Enchant creature you control\nWhen Chains of Custody enters the battlefield, exile target nonland permanent an opponent controls until Chains of Custody leaves the battlefield.\nEnchanted creature has ward {2}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "fe9b2d17-f79a-556e-ab6d-17b46aae8cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0eaeec2-d1d4-4494-9c5d-cebfd7f088de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0eaeec2-d1d4-4494-9c5d-cebfd7f088de.jpg?1",
             "name": "Distinguished Conjurer",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.\n{4}{W}, {T}: Exile another target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "7c997788-8162-565d-82d3-b32ce6587509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6fd0bf-3f02-46f3-9c9a-931eab190584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6fd0bf-3f02-46f3-9c9a-931eab190584.jpg?1",
             "name": "Ingenious Leonin",
             "text": "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature is a Cat, it gains first strike until end of turn.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "7faa79a8-306e-599b-a501-235ee75a36ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a5a044-d474-43f4-95a9-e67808908e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a5a044-d474-43f4-95a9-e67808908e6c.jpg?1",
             "name": "Lita, Mechanical Engineer",
             "text": "Vigilance\nAt the beginning of your end step, untap each other artifact creature you control.\n{3}{W}, {T}: Create a 5/5 colorless Vehicle artifact token named Zeppelin with flying and crew 3. (It has \"Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.\")",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "48adc7b3-5692-5fcc-87e3-49592f9c6726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6649e6c-bbd8-43db-9f3f-a24b32aed4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6649e6c-bbd8-43db-9f3f-a24b32aed4e4.jpg?1",
             "name": "Magnanimous Magistrate",
             "text": "Magnanimous Magistrate enters the battlefield with five reprieve counters on it.\nWhenever another nontoken creature you control dies, if its mana value was 1 or greater, you may remove that many reprieve counters from Magnanimous Magistrate. If you do, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "e823032c-89bd-54c8-8aad-4c3d3666f4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb0b3-a6b7-4279-8833-3d8890b2d005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb0b3-a6b7-4279-8833-3d8890b2d005.jpg?1",
             "name": "Preston, the Vanisher",
             "text": "Whenever another nontoken creature enters the battlefield under your control, if it wasn't cast, create a token that's a copy of that creature, except it's a 0/1 white Illusion.\n{1}{W}, Sacrifice five Illusions: Exile target nonland permanent.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "82ad647b-f5e6-57ac-9794-748db01fb0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61561585-f4fb-4e47-a65a-0c43a855ebcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61561585-f4fb-4e47-a65a-0c43a855ebcf.jpg?1",
             "name": "Alandra, Sky Dreamer",
             "text": "Whenever you draw your second card each turn, create a 2/2 blue Drake creature token with flying.\nWhenever you draw your fifth card each turn, Alandra, Sky Dreamer and Drakes you control each get +X/+X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -318,7 +318,7 @@
         },
         {
             "id": "ec0f6f84-7049-52a3-9a8f-9b05783367a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f69f0bf-6626-4418-9335-b79d75c99df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f69f0bf-6626-4418-9335-b79d75c99df1.jpg?1",
             "name": "Biblioplex Kraken",
             "text": "When Biblioplex Kraken enters the battlefield, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\nWhenever Biblioplex Kraken attacks, you may return another creature you control to its owner's hand. If you do, Biblioplex Kraken can't be blocked this turn.",
             "colours": [
@@ -351,7 +351,7 @@
         },
         {
             "id": "7fd51d5c-5912-5c2d-844e-4417c6ff4d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74004b11-53dc-475c-8d29-cf52403456cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74004b11-53dc-475c-8d29-cf52403456cf.jpg?1",
             "name": "Hold for Questioning",
             "text": "Enchant creature or planeswalker\nWhen Hold for Questioning enters the battlefield, tap enchanted permanent and investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
             "colours": [
@@ -384,7 +384,7 @@
         },
         {
             "id": "13eec19e-18c2-590e-8074-8b4f5e70acc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1d50c3-3219-49cb-8f63-c1faff93215c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1d50c3-3219-49cb-8f63-c1faff93215c.jpg?1",
             "name": "Isu the Abominable",
             "text": "You may look at the top card of your library any time.\nYou may play snow lands and cast snow spells from the top of your library.\nWhenever another snow permanent enters the battlefield under your control, you may pay {G}, {W}, or {U}. If you do, put a +1/+1 counter on Isu the Abominable.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "da92201f-0c11-5973-96da-abfea41a547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba97da8-0106-4e8b-b58b-8f2d63e3d618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba97da8-0106-4e8b-b58b-8f2d63e3d618.jpg?1",
             "name": "Kenessos, Priest of Thassa",
             "text": "If you would scry a number of cards, scry that many cards plus one instead.\n{3}{GW}: Look at the top card of your library. If it's a Kraken, Leviathan, Octopus, or Serpent creature card, you may put it onto the battlefield. If you don't put the card onto the battlefield, you may put it on the bottom of your library.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "4921b064-d9ff-51ef-95da-5361787e3a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc561d3-9e52-41fd-8311-60cc9dfffdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc561d3-9e52-41fd-8311-60cc9dfffdd1.jpg?1",
             "name": "Launch Mishap",
             "text": "Counter target creature or planeswalker spell. Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "1e10d522-a7d1-55d0-baf2-8a9984d83777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aacf99-39d1-4299-8557-6cc10ce9e35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aacf99-39d1-4299-8557-6cc10ce9e35f.jpg?1",
             "name": "Merfolk Pupil",
             "text": "When Merfolk Pupil enters the battlefield, draw a card, then discard a card.\n{1}{U}, Exile Merfolk Pupil from your graveyard: Draw a card, then discard a card.",
             "colours": [
@@ -524,7 +524,7 @@
         },
         {
             "id": "9f6b99af-486e-581d-b865-557843e325e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0567fb-2b4f-4fa9-8dfe-df4e665a4c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0567fb-2b4f-4fa9-8dfe-df4e665a4c5c.jpg?1",
             "name": "Pirated Copy",
             "text": "You may have Pirated Copy enter the battlefield as a copy of any creature on the battlefield, except it's a Pirate in addition to its other types and it has \"Whenever this creature or another creature with the same name deals combat damage to a player, you draw a card.\"",
             "colours": [
@@ -558,7 +558,7 @@
         },
         {
             "id": "77defcfd-f43b-528d-8be0-f4a60c0da4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cebbfa1-e709-45bb-9b86-c6b09e7866b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cebbfa1-e709-45bb-9b86-c6b09e7866b2.jpg?1",
             "name": "Soul Read",
             "text": "Choose one \u2014\n\u2022 Counter target spell unless its controller pays {4}.\n\u2022 Draw two cards.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "7402a36f-50fb-5a5b-8460-ffe4bbe136b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f10249-8cd0-4366-bd9a-755f8e1c3592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f10249-8cd0-4366-bd9a-755f8e1c3592.jpg?1",
             "name": "Synchronized Eviction",
             "text": "This spell costs {2} less to cast if you control at least two creatures that share a creature type.\nPut target nonland permanent into its owner's library second from the top.",
             "colours": [
@@ -620,7 +620,7 @@
         },
         {
             "id": "e8828925-5655-5bdc-8edb-ec59d185d383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fce5989-a2a0-4825-b90a-a1f78659b6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fce5989-a2a0-4825-b90a-a1f78659b6e0.jpg?1",
             "name": "Ashcoat of the Shadow Swarm",
             "text": "Whenever Ashcoat of the Shadow Swarm attacks or blocks, other Rats you control get +X/+X until end of turn, where X is the number of Rats you control.\nAt the beginning of your end step, you may mill four cards. If you do, return up to two Rat creature cards from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -656,7 +656,7 @@
         },
         {
             "id": "e7564f59-90fa-519f-b38e-a2492f083f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4f19b-3c4e-4aa0-90f5-6cf397a5ad6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4f19b-3c4e-4aa0-90f5-6cf397a5ad6d.jpg?1",
             "name": "Conductor of Cacophony",
             "text": "Conductor of Cacophony enters the battlefield with two +1/+1 counters on it.\n{B}, Remove a +1/+1 counter from Conductor of Cacophony: It deals 1 damage to each other creature and each player.",
             "colours": [
@@ -689,7 +689,7 @@
         },
         {
             "id": "3153c071-7d57-5dae-9b20-756702c6b2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e3a9e1-fafe-4859-a550-7ae09804aced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e3a9e1-fafe-4859-a550-7ae09804aced.jpg?1",
             "name": "Creeping Bloodsucker",
             "text": "At the beginning of your upkeep, Creeping Bloodsucker deals 1 damage to each opponent. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "bc61d70f-1113-5156-9361-130f34c19ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78da23-e7ec-4a3d-9f79-09fb86993b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78da23-e7ec-4a3d-9f79-09fb86993b26.jpg?1",
             "name": "Deadly Plot",
             "text": "Choose one \u2014\n\u2022 Destroy target creature or planeswalker.\n\u2022 Return target Zombie creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "4f6c344f-356b-598c-90a9-a732bc91d4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9abb9b-5d52-401f-aa6b-189aad72bfc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9abb9b-5d52-401f-aa6b-189aad72bfc2.jpg?1",
             "name": "Disciple of Perdition",
             "text": "When Disciple of Perdition dies, choose one. If you have exactly 13 life, you may choose both.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Exile target opponent's graveyard. That player loses 1 life.",
             "colours": [
@@ -787,7 +787,7 @@
         },
         {
             "id": "50d11f75-2872-5524-baa1-13ea3252e845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dc52c-6f62-45cc-a5e2-95f794e04b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93dc52c-6f62-45cc-a5e2-95f794e04b94.jpg?1",
             "name": "Ossuary Rats",
             "text": "When Ossuary Rats enters the battlefield, it deals X damage to target creature or planeswalker an opponent controls, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "aaf65fee-3a84-5564-bbc9-b921e2009208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9afd47b-ff94-4fdd-bb04-bdf9b8b61a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9afd47b-ff94-4fdd-bb04-bdf9b8b61a6d.jpg?1",
             "name": "Rodolf Duskbringer",
             "text": "Flying, deathtouch, lifelink\nWhenever you gain life, Rodolf Duskbringer gains indestructible until end of turn.\nAt the beginning of your end step, you may pay {1}{WB}. When you do, return target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of life you gained this turn.",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "ba3d790a-c047-5046-acf6-10483fa3c8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd4db9-8cab-4df2-ae65-0d7546c2d06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdd4db9-8cab-4df2-ae65-0d7546c2d06b.jpg?1",
             "name": "Skullslither Worm",
             "text": "When Skullslither Worm enters the battlefield, each opponent discards a card. For each opponent who can't, put two +1/+1 counters on Skullslither Worm.",
             "colours": [
@@ -890,7 +890,7 @@
         },
         {
             "id": "d57037ae-4a1e-5db2-850f-5abac0caa7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff36347c-1fc1-4493-8e45-ef3372ecce45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff36347c-1fc1-4493-8e45-ef3372ecce45.jpg?1",
             "name": "Suspicious Shambler",
             "text": "{4}{B}{B}, Exile Suspicious Shambler from your graveyard: Create two 2/2 black Zombie creature tokens. Activate only as a sorcery.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "fa13e3ac-8fc8-577f-900e-79dff03639b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db59164-f0b1-4b5a-b821-ad0b2e1612d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db59164-f0b1-4b5a-b821-ad0b2e1612d1.jpg?1",
             "name": "Termination Facilitator",
             "text": "{T}: Put a bounty counter on target creature or planeswalker. Activate only as a sorcery.\nWhenever a creature or planeswalker an opponent controls with a bounty counter on it is dealt damage, destroy it.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "30f58c9c-9270-5820-96a5-9312b563ecac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a012f05-0009-42cf-8a69-07140b2a2aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a012f05-0009-42cf-8a69-07140b2a2aef.jpg?1",
             "name": "Ardoz, Cobbler of War",
             "text": "Haste\nWhenever Ardoz, Cobbler of War or another creature enters the battlefield under your control, that creature gets +2/+0 until end of turn.\n{3}{R}: Create a 1/1 red Goblin creature token with haste. Activate only as a sorcery.",
             "colours": [
@@ -993,7 +993,7 @@
         },
         {
             "id": "48cacc08-44a5-524a-a96a-32d8473c9e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c18d01-62cd-45c2-94b8-a63a4239311d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c18d01-62cd-45c2-94b8-a63a4239311d.jpg?1",
             "name": "Auntie Blyte, Bad Influence",
             "text": "Flying\nWhenever a source you control deals damage to you, put that many +1/+1 counters on Auntie Blyte, Bad Influence.\n{1}{R}, {T}, Remove X +1/+1 counters from Auntie Blyte: It deals X damage to any target.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "d8711ce6-7256-5dfd-9199-495464132f67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcbad10-475e-41cf-b3fb-68c1ca6c2caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcbad10-475e-41cf-b3fb-68c1ca6c2caa.jpg?1",
             "name": "Brazen Cannonade",
             "text": "Whenever an attacking creature you control dies, Brazen Cannonade deals 2 damage to each opponent.\nRaid \u2014 At the beginning of your postcombat main phase, if you attacked with a creature this turn, exile the top card of your library. Until end of combat on your next turn, you may play that card.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "7b9d2c02-3aad-5deb-9edf-0ae6121fc2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d581e4f-77a7-4ad1-a263-882babffded8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d581e4f-77a7-4ad1-a263-882babffded8.jpg?1",
             "name": "Coalborn Entity",
             "text": "{2}{R}: Coalborn Entity deals 1 damage to target creature token, player, or planeswalker.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "871d9699-898c-5f9b-a726-75a535bf9156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6ce176-a4f3-44dd-b66a-a23b6cf512e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6ce176-a4f3-44dd-b66a-a23b6cf512e4.jpg?1",
             "name": "Daring Piracy",
             "text": "At the beginning of combat on your turn, create a 1/1 red Pirate creature token with menace and haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "b0136741-ee78-54ca-8355-c2035db55f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529e62a1-a32f-477a-ae5c-955f3df2a628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529e62a1-a32f-477a-ae5c-955f3df2a628.jpg?1",
             "name": "Goblin Researcher",
             "text": "When Goblin Researcher enters the battlefield, exile the top card of your library. During any turn you attacked with Goblin Researcher, you may play that card.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "7bcc7917-d2d3-5d2f-81fe-78041a2e8087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf1d83-3b6b-4e07-a024-3dfd37c29814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf1d83-3b6b-4e07-a024-3dfd37c29814.jpg?1",
             "name": "Mizzix, Replica Rider",
             "text": "Flying\nWhenever you cast a spell from anywhere other than your hand, you may pay {1}{UR}. If you do, copy that spell and you may choose new targets for the copy. If the copy is a permanent spell, it gains haste and \"At the beginning of your end step, sacrifice this permanent.\" (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "b0abaf92-f014-528e-98b9-e921a0a159ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f1ab2-4c66-4d91-8f6a-1bad230632df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298f1ab2-4c66-4d91-8f6a-1bad230632df.jpg?1",
             "name": "Ogre Battlecaster",
             "text": "First strike\nWhenever Ogre Battlecaster attacks, you may cast target instant or sorcery card from your graveyard by paying {R}{R} in addition to its other costs. If that spell would be put into a graveyard, exile it instead. When you cast that spell, Ogre Battlecaster gets +X/+0 until end of turn, where X is that spell's mana value.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "0a17b823-106b-5d15-82a4-a7014ace465d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b3f46-0e62-4f44-8064-857cd3040659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b3f46-0e62-4f44-8064-857cd3040659.jpg?1",
             "name": "Plundering Predator",
             "text": "Flying\nWhen Plundering Predator enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "ab80e21e-d66b-5962-bdb4-1f15728cf82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575ed35-6357-4b48-9d20-e4249577142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c575ed35-6357-4b48-9d20-e4249577142b.jpg?1",
             "name": "Benevolent Hydra",
             "text": "Benevolent Hydra enters the battlefield with X +1/+1 counters on it.\nIf one or more +1/+1 counters would be put on another creature you control, that many plus one +1/+1 counters are put on it instead.\n{T}, Remove a +1/+1 counter from Benevolent Hydra: Put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "c24753a8-1e19-5f75-b4df-13f3e587d4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg?1",
             "name": "Giant Ladybug",
             "text": "Reach\nWhen Giant Ladybug enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "43cc81e1-bd9e-5e64-9bb1-178b1b8984db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71345a-c3e8-4b35-beb7-6347e41d7626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71345a-c3e8-4b35-beb7-6347e41d7626.jpg?1",
             "name": "Kibo, Uktabi Prince",
             "text": "{T}: Each player creates a colorless artifact token named Banana with \"{T}, Sacrifice this artifact: Add {R} or {G}. You gain 2 life.\"\nWhenever an artifact an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on each creature you control that's an Ape or a Monkey.\nWhenever Kibo attacks, defending player sacrifices an artifact.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "531f53cf-59d9-524d-8584-f5b8b17d116d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg?1",
             "name": "Mild-Mannered Librarian",
             "text": "{3}{G}: Mild-Mannered Librarian becomes a Werewolf. Put two +1/+1 counters on it and you draw a card. Activate only once.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "c07fae46-278a-5525-bca6-53c8a7c45a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0a91b-246b-4c1f-9b98-2ad6ff1ba124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb0a91b-246b-4c1f-9b98-2ad6ff1ba124.jpg?1",
             "name": "Primeval Herald",
             "text": "Trample\nWhenever Primeval Herald enters the battlefield or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1434,7 +1434,7 @@
         },
         {
             "id": "09fc5efd-3c5a-5eef-8a91-abbb4988a11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218779-7e18-4fa2-a0bb-c07052951a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57218779-7e18-4fa2-a0bb-c07052951a78.jpg?1",
             "name": "Rampaging Growth",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle. Until end of turn, that land becomes a 4/3 Insect creature with reach and haste. It's still a land.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "c6db5f0b-3eab-57de-85ee-28e11bb7718a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f5500f-e82c-44f3-8be8-cee4c86824b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f5500f-e82c-44f3-8be8-cee4c86824b1.jpg?1",
             "name": "Runadi, Behemoth Caller",
             "text": "Whenever you cast a creature spell with mana value 5 or greater, that creature enters the battlefield with X additional +1/+1 counters on it, where X is its mana value minus 4.\nCreatures you control with three or more +1/+1 counters on them have haste.\n{T}: Add {G}.",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "cbf446f2-5681-5375-b921-8be3fc2813a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg?1",
             "name": "Spectral Hunt-Caller",
             "text": "{5}{G}: Creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "e8db91ce-0042-533c-8aec-6250020c2097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a22aa-0f79-4497-a7ff-08d92d14bc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a22aa-0f79-4497-a7ff-08d92d14bc0f.jpg?1",
             "name": "Towering Gibbon",
             "text": "Reach\nTowering Gibbon's power is equal to the greatest mana value among creatures you control.",
             "colours": [
@@ -1568,7 +1568,7 @@
         },
         {
             "id": "a3a6fac1-797f-5012-960f-1a3cb5de6486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eafc507-973a-4aec-91b9-c29d70b0e25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eafc507-973a-4aec-91b9-c29d70b0e25d.jpg?1",
             "name": "Zask, Skittering Swarmlord",
             "text": "You may play lands and cast Insect spells from your graveyard.\nWhenever another Insect you control dies, put it on the bottom of its owner's library, then mill two cards. (Put the top two cards of your library into your graveyard.)\n{1}{BG}: Target Insect gets +1/+0 and gains deathtouch until end of turn. ({BG} can be paid with either {B} or {G}.)",
             "colours": [
@@ -1604,7 +1604,7 @@
         },
         {
             "id": "288f5d55-8f1b-5a94-bf7e-c6fe70867341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de6fc60-89ad-4c6f-a734-5344e5b954fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de6fc60-89ad-4c6f-a734-5344e5b954fa.jpg?1",
             "name": "Dutiful Replicator",
             "text": "When Dutiful Replicator enters the battlefield, you may pay {1}. When you do, create a token that's a copy of target token you control not named Dutiful Replicator.",
             "colours": [],
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "2b1dcc69-8919-5dd2-9dc7-dcfb77bef15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d986229-c8d5-462c-bf74-ae94326a5aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d986229-c8d5-462c-bf74-ae94326a5aa0.jpg?1",
             "name": "Infernal Idol",
             "text": "{T}: Add {B}.\n{1}{B}{B}, {T}, Sacrifice Infernal Idol: You draw two cards and you lose 2 life.",
             "colours": [],
@@ -1663,7 +1663,7 @@
         },
         {
             "id": "e3a78c5c-9e24-5ee4-a9db-1ab20c00ffea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9526bea2-8d47-4a82-a617-6c57c7abc69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9526bea2-8d47-4a82-a617-6c57c7abc69a.jpg?1",
             "name": "Instruments of War",
             "text": "Flash\nAs Instruments of War enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "289437fb-5421-55ee-b59e-fc215f1cebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909b15e4-c6c8-44bf-a993-13a97de40e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909b15e4-c6c8-44bf-a993-13a97de40e36.jpg?1",
             "name": "Planar Atlas",
             "text": "Planar Atlas enters the battlefield tapped.\nWhen Planar Atlas enters the battlefield, you may look at the top four cards of your library. If you do, reveal up to one land card from among them, then put that card on top of your library and the rest on the bottom in a random order.\n{T}: Add {C}.",
             "colours": [],
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "20f06f2f-7c32-55cc-95a9-3dbb76f88b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b9897-a473-4c47-994a-a6d7e9e81ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b9897-a473-4c47-994a-a6d7e9e81ef2.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "7d605089-ac8e-5774-9f7d-68df32080ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f6da2e-3759-4550-999f-2c0fa6c76c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f6da2e-3759-4550-999f-2c0fa6c76c73.jpg?1",
             "name": "Balan, Wandering Knight",
             "text": "First strike\nBalan, Wandering Knight has double strike as long as two or more Equipment are attached to it.\n{1}{W}: Attach all Equipment you control to Balan.",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "7e05b848-0153-588b-9e96-6a318a45cb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ad5c0-a343-4d1a-9a85-1f4d5fa64079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ad5c0-a343-4d1a-9a85-1f4d5fa64079.jpg?1",
             "name": "Eidolon of Rhetoric",
             "text": "Each player can't cast more than one spell each turn.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "6a461222-0483-5713-82b6-aefb33672a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5927be-dd6b-4ebb-a7f9-affd66d78b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5927be-dd6b-4ebb-a7f9-affd66d78b3a.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "091046f6-5173-5a6c-8a95-1df1b016b0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6417e616-0490-4d89-a8ab-9b92fcc62a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6417e616-0490-4d89-a8ab-9b92fcc62a29.jpg?1",
             "name": "Flicker of Fate",
             "text": "Exile target creature or enchantment, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "91b0d2ec-fd9a-57f1-902e-83490239d7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b8343f-0554-42b1-9e32-431dcc4b0346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b8343f-0554-42b1-9e32-431dcc4b0346.jpg?1",
             "name": "King of the Pride",
             "text": "Other Cats you control get +2/+1.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "9dba7db2-8719-5a06-9dd3-fedd67dfda9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef561541-c64a-419a-87b3-b2c71d8161c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef561541-c64a-419a-87b3-b2c71d8161c5.jpg?1",
             "name": "Sage's Reverie",
             "text": "Enchant creature\nWhen Sage's Reverie enters the battlefield, draw a card for each Aura you control that's attached to a creature.\nEnchanted creature gets +1/+1 for each Aura you control that's attached to a creature.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "b2ce5f75-a792-5ac7-95f3-01757a2660af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7297c43-41bf-41f0-8df0-c1b1c2e5e951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7297c43-41bf-41f0-8df0-c1b1c2e5e951.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "daecbcfc-6f21-5596-9b4b-78b315be6484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2b53e2-aa6a-4cb2-899c-8e022e822ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2b53e2-aa6a-4cb2-899c-8e022e822ffc.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "Spells your opponents cast that target a creature or planeswalker you control cost {2} more to cast.\n\u22122: Create a 2/2 blue Wizard creature token. Draw a card, then discard a card.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "086cd5da-d9aa-56f3-84f7-342a37bf659a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6487eeae-95c9-4aa6-b1a9-1af8e405f0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6487eeae-95c9-4aa6-b1a9-1af8e405f0df.jpg?1",
             "name": "Merrow Reejerey",
             "text": "Other Merfolk creatures you control get +1/+1.\nWhenever you cast a Merfolk spell, you may tap or untap target permanent.",
             "colours": [
@@ -2052,7 +2052,7 @@
         },
         {
             "id": "c101c8d3-5164-5609-884a-f86a4423cbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b7f07-cffb-4797-94a6-3279714b1c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9b7f07-cffb-4797-94a6-3279714b1c88.jpg?1",
             "name": "Mirror Image",
             "text": "You may have Mirror Image enter the battlefield as a copy of a creature you control.",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "fdaf13d4-35e4-5fed-b8f1-7a58484d2bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95460ec-153d-4fe0-a261-f9840a174308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95460ec-153d-4fe0-a261-f9840a174308.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2116,7 +2116,7 @@
         },
         {
             "id": "9b2264ed-b29d-549a-b676-48d1d960b036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7743b587-e498-4761-9173-e803c9eed86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7743b587-e498-4761-9173-e803c9eed86b.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "3566a8c3-a2d3-5c76-aa66-5d034ecd5461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e262a3-0e69-4d61-8143-b9d137c31496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e262a3-0e69-4d61-8143-b9d137c31496.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "Flash\nFlying\nWhen Spellstutter Sprite enters the battlefield, counter target spell with mana value X or less, where X is the number of Faeries you control.",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "e07d1c4e-22db-5e1e-8dee-5ed329e88407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62a27a8-271c-4ac8-97a5-2efb192e3a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62a27a8-271c-4ac8-97a5-2efb192e3a15.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "99fd1ed6-6f82-56d4-be6f-f57cf5b11475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abd138-b840-4222-88ad-7b0ed64a927b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abd138-b840-4222-88ad-7b0ed64a927b.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "dc5745c8-0e21-500f-bcbe-4582f5842620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0f98c-264e-4d82-893a-5f84fc890705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0f98c-264e-4d82-893a-5f84fc890705.jpg?1",
             "name": "Feast on the Fallen",
             "text": "At the beginning of each upkeep, if an opponent lost life last turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "a09b0f04-0276-5859-8716-f3314a75bbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67c2c4c-f593-4e46-910c-616d3135a8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67c2c4c-f593-4e46-910c-616d3135a8b1.jpg?1",
             "name": "Lord of the Accursed",
             "text": "Other Zombies you control get +1/+1.\n{1}{B}, {T}: All Zombies gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2314,7 +2314,7 @@
         },
         {
             "id": "ca13cd47-74cf-5cee-af3d-6748ffb19a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04099735-bc73-40ae-bc28-0ad5c96feb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04099735-bc73-40ae-bc28-0ad5c96feb12.jpg?1",
             "name": "Oathsworn Vampire",
             "text": "Oathsworn Vampire enters the battlefield tapped.\nYou may cast Oathsworn Vampire from your graveyard if you gained life this turn.",
             "colours": [
@@ -2348,7 +2348,7 @@
         },
         {
             "id": "1f08a6dd-cada-56e8-898c-5e54d044f5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f176f9-d353-479e-a808-54dc5e8ff746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f176f9-d353-479e-a808-54dc5e8ff746.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "9438892d-99dc-59f6-9c35-78ee4f9e014f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad4b00-b56b-4b55-9e6f-3de3e3748fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad4b00-b56b-4b55-9e6f-3de3e3748fe9.jpg?1",
             "name": "Plaguecrafter",
             "text": "When Plaguecrafter enters the battlefield, each player sacrifices a creature or planeswalker. Each player who can't discards a card.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "ca47e990-94a0-5b13-a870-13658b1ecf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e65e74-14fc-4286-84d3-36c70d6dcf46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e65e74-14fc-4286-84d3-36c70d6dcf46.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "When Stitcher's Supplier enters the battlefield or dies, mill three cards. (Put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "aefd11fd-6f77-584c-8546-ea69986d0c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecbe209-7f91-4add-98e0-e6ffa1739631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecbe209-7f91-4add-98e0-e6ffa1739631.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -2484,7 +2484,7 @@
         },
         {
             "id": "00101d47-ae6f-54fd-9fd6-b265478229a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4aef6f-10f8-4376-8518-a3165d0df062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4aef6f-10f8-4376-8518-a3165d0df062.jpg?1",
             "name": "Tree of Perdition",
             "text": "Defender\n{T}: Exchange target opponent's life total with Tree of Perdition's toughness.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "5289db83-25b9-5341-a13f-be28b581e908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686d43eb-ea91-4ae1-bdc4-dcd885688acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686d43eb-ea91-4ae1-bdc4-dcd885688acd.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -2550,7 +2550,7 @@
         },
         {
             "id": "950e280a-0dcc-5ca4-8581-dd7874eab1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f4ae10-a3da-4d4f-8706-87ccb076c1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f4ae10-a3da-4d4f-8706-87ccb076c1f2.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever Dragon Mage deals combat damage to a player, each player discards their hand, then draws seven cards.",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "e9b37e98-82f0-5e9b-9af3-c37d0264925d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b5d44-a314-4d72-b4fe-25d6921d51cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9b5d44-a314-4d72-b4fe-25d6921d51cb.jpg?1",
             "name": "Drannith Stinger",
             "text": "Whenever you cycle another card, Drannith Stinger deals 1 damage to each opponent.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "2c06c445-882b-5641-8085-f5f66b21a402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6fc996-17ba-4090-bf82-0c2eba93a81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6fc996-17ba-4090-bf82-0c2eba93a81e.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Create a token that's a copy of target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "04e49223-23e4-5793-9ddd-c35d16c48a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5d5f0b-7574-43d9-b9ab-b4d0fa419212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5d5f0b-7574-43d9-b9ab-b4d0fa419212.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "5676abff-b841-50ea-a937-a9415f70e3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2bc701-2a18-4e49-acef-5e18ebfba64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2bc701-2a18-4e49-acef-5e18ebfba64f.jpg?1",
             "name": "Rigging Runner",
             "text": "First strike\nRaid \u2014 Rigging Runner enters the battlefield with a +1/+1 counter on it if you attacked this turn.",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "d7642caa-82fa-5183-ace7-98b0eb9d693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77d7286-fb41-4078-ada0-38622b84ddd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77d7286-fb41-4078-ada0-38622b84ddd0.jpg?1",
             "name": "Spear Spewer",
             "text": "Defender\n{T}: Spear Spewer deals 1 damage to each player.",
             "colours": [
@@ -2755,7 +2755,7 @@
         },
         {
             "id": "cc40557d-d036-567e-ba41-a2db2836fe37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd33b2c2-9f1c-4304-bbc3-e9bee5d4052f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd33b2c2-9f1c-4304-bbc3-e9bee5d4052f.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "c8c0fe27-9312-58e7-a023-8d4a09d1b2f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3b2cb7-06a3-4c2e-9684-480b0e4c005f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3b2cb7-06a3-4c2e-9684-480b0e4c005f.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "a8382f74-e7fb-5224-a1fa-4e392b189b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bee15d-6868-4dfc-9dd9-b437c5f3d6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bee15d-6868-4dfc-9dd9-b437c5f3d6db.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "Each creature you control that's a Wolf or a Werewolf enters the battlefield with an additional +1/+1 counter on it.\n\u22122: Create a 2/2 green Wolf creature token.",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "5714c157-5505-5cd7-b075-ee939f2a8713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0e3e1-a578-4c3d-95d1-f1c6c243779d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c0e3e1-a578-4c3d-95d1-f1c6c243779d.jpg?1",
             "name": "Caustic Caterpillar",
             "text": "{1}{G}, Sacrifice Caustic Caterpillar: Destroy target artifact or enchantment.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "62518ada-ad4a-527b-bbf9-8de7ddbc61bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1764f-9b62-4977-9fee-1266f0ea01aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1764f-9b62-4977-9fee-1266f0ea01aa.jpg?1",
             "name": "Colossal Majesty",
             "text": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "4f3b29ca-8882-5629-9254-b359e3cf2760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d657f45-ee7f-4114-a570-314688138b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d657f45-ee7f-4114-a570-314688138b4f.jpg?1",
             "name": "Elvish Rejuvenator",
             "text": "When Elvish Rejuvenator enters the battlefield, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "417a8939-38e1-5833-bc04-4beca8a8a06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095a1dcb-fb19-4449-9148-851b7e06c16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095a1dcb-fb19-4449-9148-851b7e06c16f.jpg?1",
             "name": "Hydra's Growth",
             "text": "Enchant creature\nWhen Hydra's Growth enters the battlefield, put a +1/+1 counter on enchanted creature.\nAt the beginning of your upkeep, double the number of +1/+1 counters on enchanted creature.",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "376a7178-fdb0-55f0-8021-f5a3573b7f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9079b4-71c9-4afb-ba81-3d3bece084e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9079b4-71c9-4afb-ba81-3d3bece084e7.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "a01bcc41-3b8b-5e0b-8398-43c817b3c4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d41ca70-8a47-44a7-9494-265e2f401028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d41ca70-8a47-44a7-9494-265e2f401028.jpg?1",
             "name": "Ram Through",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "069f2dc0-229f-5a0f-81b7-43b819e706fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a65e7c-3f2e-44d1-8f85-4acf5f147c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a65e7c-3f2e-44d1-8f85-4acf5f147c17.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "b98fb339-afaf-520d-933b-9d7252184ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2979d4b-2a95-4178-a204-b2df09042135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2979d4b-2a95-4178-a204-b2df09042135.jpg?1",
             "name": "World Breaker",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, exile target artifact, enchantment, or land.\nReach\n{2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand. ({C} represents colorless mana.)",
             "colours": [],
@@ -3114,7 +3114,7 @@
         },
         {
             "id": "facb7d51-4e64-5cfc-8b09-16cbeda5d0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2599b027-1ff8-48b8-8a90-8ac1fac7ed63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2599b027-1ff8-48b8-8a90-8ac1fac7ed63.jpg?1",
             "name": "Coldsteel Heart",
             "text": "Coldsteel Heart enters the battlefield tapped.\nAs Coldsteel Heart enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "7d41aef0-fdc0-5404-a0b2-8d83e9b0b9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db997a7-d54c-4821-9e9f-56292f9e7e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db997a7-d54c-4821-9e9f-56292f9e7e5a.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "cf6c02be-67cf-5f9c-8ba3-a649e85821ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae799ee8-f1cf-4259-9e78-def9fc13b63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae799ee8-f1cf-4259-9e78-def9fc13b63a.jpg?1",
             "name": "Peacewalker Colossus",
             "text": "{1}{W}: Another target Vehicle you control becomes an artifact creature until end of turn.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -3201,7 +3201,7 @@
         },
         {
             "id": "784adfff-ed29-557e-9289-fdab2885fa97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740dbebf-9e0b-4918-850b-8c1aa0b06c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740dbebf-9e0b-4918-850b-8c1aa0b06c18.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -3232,7 +3232,7 @@
         },
         {
             "id": "8d85452d-cbb7-56ab-af92-737a8dade8d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a479838-b6b1-4d83-9104-0a79f3b934c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a479838-b6b1-4d83-9104-0a79f3b934c7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3268,7 +3268,7 @@
         },
         {
             "id": "3a5e8b25-5db5-5de4-ade0-9131700eb16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464fa166-82be-4f28-8fd8-0c9cc4393012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464fa166-82be-4f28-8fd8-0c9cc4393012.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "1feb83ee-4542-576a-9f09-5a08d3c7d0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4b8bde-412b-4d12-b296-7364c95e0510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4b8bde-412b-4d12-b296-7364c95e0510.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "be47edd4-58d7-5216-9ab3-541c33934457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0559d67-e151-4c6b-b8eb-5e9b5603f487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0559d67-e151-4c6b-b8eb-5e9b5603f487.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "078dbb69-e17b-5d0a-967e-887d605796da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49050cb4-1d8b-4f2f-ba48-206a107eb09c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49050cb4-1d8b-4f2f-ba48-206a107eb09c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3412,7 +3412,7 @@
         },
         {
             "id": "6b885758-9973-5e10-8113-89e02702cfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4237eaa8-1169-47b2-9009-ac529831a36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4237eaa8-1169-47b2-9009-ac529831a36e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "093129a3-934b-56cd-a114-4f90aeb254af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fec83d-8260-478e-a20f-94d265036e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fec83d-8260-478e-a20f-94d265036e31.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "15996ac2-4d38-58bf-9d76-b1267c4bb75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a442a-16a0-459a-8c24-cd0c72edee03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7a442a-16a0-459a-8c24-cd0c72edee03.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "0d43138e-22ce-505d-af04-d6e80c162104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802ec1c-4d12-45d0-930b-6b4ca77487e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c802ec1c-4d12-45d0-930b-6b4ca77487e8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "dd775312-0618-5a75-bf7e-6a8c8dab755a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577aff75-67f7-42c8-b31f-50026c5ba5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577aff75-67f7-42c8-b31f-50026c5ba5c6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "096fa466-11da-51cd-86a2-c246cafe95c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c79d57-a8eb-427d-86ac-b203c0bb7cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c79d57-a8eb-427d-86ac-b203c0bb7cda.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3628,7 +3628,7 @@
         },
         {
             "id": "4c4b9005-a05a-5c95-ab52-d7db96b20954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cfd796-50a5-404f-acc1-21dbf543ccc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cfd796-50a5-404f-acc1-21dbf543ccc1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "08bb8f11-5a93-5121-9f05-f55d07e2dc6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee97ab6-8e81-4396-a788-db0ed0da62d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee97ab6-8e81-4396-a788-db0ed0da62d2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "bda821c9-421f-5543-b713-e1d664914488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee56689a-da7b-4cd7-8767-e3f514b6db9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee56689a-da7b-4cd7-8767-e3f514b6db9e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "4a472a30-00d1-56f4-b8d2-cc23f616fcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900eedf8-71b0-4b82-9709-019018bc29fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900eedf8-71b0-4b82-9709-019018bc29fe.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -3772,7 +3772,7 @@
         },
         {
             "id": "6b58ba9e-91ae-5537-81a1-64ca79215d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1db6ef2-92a7-4dc1-bb7f-f9ad1dd76593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1db6ef2-92a7-4dc1-bb7f-f9ad1dd76593.jpg?1",
             "name": "Task Force",
             "text": "Whenever Task Force becomes the target of a spell or ability, it gets +0/+3 until end of turn.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "0f989a90-c73e-5f4e-ac54-7a347c674907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f37c5b6-a59c-45cd-9a99-e9357fe9ea1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f37c5b6-a59c-45cd-9a99-e9357fe9ea1b.jpg?1",
             "name": "Rhystic Study",
             "text": "Whenever an opponent casts a spell, you may draw a card unless that player pays {1}.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "bece7cc1-1965-5ccb-9f5e-4dec700800f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31430e8-538b-4361-ba80-b91b2ca0fe36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31430e8-538b-4361-ba80-b91b2ca0fe36.jpg?1",
             "name": "Tragic Lesson",
             "text": "Draw two cards. Then discard a card unless you return a land you control to its owner's hand.",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "6cf4e3a3-56dc-57d2-a55f-43617912b8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24faaf5-f63f-4c46-9bed-ae4693ff8e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24faaf5-f63f-4c46-9bed-ae4693ff8e9a.jpg?1",
             "name": "Wizard Mentor",
             "text": "{T}: Return Wizard Mentor and target creature you control to their owner's hand.",
             "colours": [
@@ -3902,7 +3902,7 @@
         },
         {
             "id": "0b2c58ab-1164-54df-a994-22811199e0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1641d-c4ea-4657-a0ae-db09bba83a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1641d-c4ea-4657-a0ae-db09bba83a0f.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "c5b8d910-3f73-5c43-85a9-695eb647ce47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f576f3b6-59c5-4710-b238-7fb2bbcf563e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f576f3b6-59c5-4710-b238-7fb2bbcf563e.jpg?1",
             "name": "Feast of Blood",
             "text": "Cast this spell only if you control two or more Vampires.\nDestroy target creature. You gain 4 life.",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "42346c9e-7dc9-573e-8fb6-6deb499d3cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc58d8cd-f1f8-4a3e-9052-12e319802cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc58d8cd-f1f8-4a3e-9052-12e319802cb5.jpg?1",
             "name": "Festering Evil",
             "text": "At the beginning of your upkeep, Festering Evil deals 1 damage to each creature and each player.\n{B}{B}, Sacrifice Festering Evil: It deals 3 damage to each creature and each player.",
             "colours": [
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "21022eb6-a898-5d6e-8cb7-877718d43de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be82e102-b62d-4590-85d4-dd9b5811510d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be82e102-b62d-4590-85d4-dd9b5811510d.jpg?1",
             "name": "Ghoul's Feast",
             "text": "Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "42d37abd-e345-5044-a2d0-99e0789d9836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28e4a2-5ed6-43f5-a38d-b8bb30d935d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28e4a2-5ed6-43f5-a38d-b8bb30d935d9.jpg?1",
             "name": "Morkrut Banshee",
             "text": "Morbid \u2014 When Morkrut Banshee enters the battlefield, if a creature died this turn, target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "7ba330df-12e7-51bb-ba6c-390bab78a6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987aa13-8d61-4db7-9680-63421e729325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987aa13-8d61-4db7-9680-63421e729325.jpg?1",
             "name": "Nezumi Bone-Reader",
             "text": "{B}, Sacrifice a creature: Target player discards a card. Activate only as a sorcery.",
             "colours": [
@@ -4095,7 +4095,7 @@
         },
         {
             "id": "b9600289-ccf7-5152-88bd-de6fe46f7da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e537802-164f-4ba2-8f3a-9ebc845e05fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e537802-164f-4ba2-8f3a-9ebc845e05fd.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "{T}, Sacrifice Phyrexian Plaguelord: Target creature gets -4/-4 until end of turn.\nSacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -4129,7 +4129,7 @@
         },
         {
             "id": "89ede49e-e620-5ec6-98cf-e820d4626639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a82ea-6d35-4121-84bb-93adff381f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a82ea-6d35-4121-84bb-93adff381f99.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4160,7 +4160,7 @@
         },
         {
             "id": "ef55f5c6-5620-5a54-92ab-56888c4a0436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835da43-0a3e-40fb-a7e8-4fa118c7d975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835da43-0a3e-40fb-a7e8-4fa118c7d975.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -4194,7 +4194,7 @@
         },
         {
             "id": "573573a8-6427-548d-8620-fdc274e79ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee747f-4a9e-4752-815a-dc7ebabccd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee747f-4a9e-4752-815a-dc7ebabccd6b.jpg?1",
             "name": "Renegade Demon",
             "text": "",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "e1a710e8-3af7-5c6d-8348-4c1a491875cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675b8a4-3cbc-458f-bdc3-1ec85f95dde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b675b8a4-3cbc-458f-bdc3-1ec85f95dde9.jpg?1",
             "name": "Swarm of Bloodflies",
             "text": "Flying\nSwarm of Bloodflies enters the battlefield with two +1/+1 counters on it.\nWhenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "7cc0160f-9b0c-5d0e-a665-3309442781cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd24ce-6b37-4801-b10f-5e2dbada7a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd24ce-6b37-4801-b10f-5e2dbada7a41.jpg?1",
             "name": "Wakedancer",
             "text": "Morbid \u2014 When Wakedancer enters the battlefield, if a creature died this turn, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "354359de-d4ac-533c-a724-6393f6dea88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc85084-f948-4d66-ae3c-67fd82fb3acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc85084-f948-4d66-ae3c-67fd82fb3acf.jpg?1",
             "name": "Aftershock",
             "text": "Destroy target artifact, creature, or land. Aftershock deals 3 damage to you.",
             "colours": [
@@ -4325,7 +4325,7 @@
         },
         {
             "id": "bbfbdfda-a70d-5993-bb74-dcc10fd5aaf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb92c7-29d0-40fc-80ae-3c7f0cdd2218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb92c7-29d0-40fc-80ae-3c7f0cdd2218.jpg?1",
             "name": "Fireslinger",
             "text": "{T}: Fireslinger deals 1 damage to any target and 1 damage to you.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "5a689668-9ee1-5a1d-b5da-61a364e96850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02d939-cca4-4f80-b4e8-0bc92032c23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed02d939-cca4-4f80-b4e8-0bc92032c23e.jpg?1",
             "name": "Flameblade Adept",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever you cycle or discard a card, Flameblade Adept gets +1/+0 until end of turn.",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "fcbad822-4c25-5860-9091-3ca4c8204186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291d064-b191-4ff6-940a-c9cfc4289ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d291d064-b191-4ff6-940a-c9cfc4289ff8.jpg?1",
             "name": "Ruin in Their Wake",
             "text": "Devoid (This card has no color.)\nSearch your library for a basic land card and reveal it. You may put that card onto the battlefield tapped if you control a land named Wastes. Otherwise, put that card into your hand. Then shuffle.",
             "colours": [],
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "cd3848b8-d5b1-5056-bdf7-2d0997916e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cff91-9f18-4ebc-8deb-3d4bf617fdb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cff91-9f18-4ebc-8deb-3d4bf617fdb9.jpg?1",
             "name": "Uktabi Orangutan",
             "text": "When Uktabi Orangutan enters the battlefield, destroy target artifact.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "9342833e-4694-5fbd-97e4-1ea68fb2b02b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecca4c21-a076-4ddf-b61c-c1164eba5513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecca4c21-a076-4ddf-b61c-c1164eba5513.jpg?1",
             "name": "Wicked Wolf",
             "text": "When Wicked Wolf enters the battlefield, it fights up to one target creature you don't control.\nSacrifice a Food: Put a +1/+1 counter on Wicked Wolf. It gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "18cec106-80c4-5fb3-8b7a-ab3a9c24b410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a14f1-7230-4b4e-998b-543a2971324e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a14f1-7230-4b4e-998b-543a2971324e.jpg?1",
             "name": "Clockwork Hydra",
             "text": "Clockwork Hydra enters the battlefield with four +1/+1 counters on it.\nWhenever Clockwork Hydra attacks or blocks, remove a +1/+1 counter from it. If you do, Clockwork Hydra deals 1 damage to any target.\n{T}: Put a +1/+1 counter on Clockwork Hydra.",
             "colours": [],
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "5ed7986f-1c80-5f11-9519-2efb7a872cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f1ece0-83be-4f46-8c17-3fb0af900b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f1ece0-83be-4f46-8c17-3fb0af900b7a.jpg?1",
             "name": "Spawning Pit",
             "text": "Sacrifice a creature: Put a charge counter on Spawning Pit.\n{1}, Remove two charge counters from Spawning Pit: Create a 2/2 colorless Spawn artifact creature token.",
             "colours": [],
@@ -4545,7 +4545,7 @@
         },
         {
             "id": "d8aa6791-b267-5bf8-affb-0aca12a2d7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e96d842-721d-4662-b94d-e6c6cc1f32ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e96d842-721d-4662-b94d-e6c6cc1f32ed.jpg?1",
             "name": "Leechridden Swamp",
             "text": "({T}: Add {B}.)\nLeechridden Swamp enters the battlefield tapped.\n{B}, {T}: Each opponent loses 1 life. Activate only if you control two or more black permanents.",
             "colours": [],
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "a9cd935b-1238-5771-808f-179a530a6c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fd2df9-496b-440a-8667-17af4fb62731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fd2df9-496b-440a-8667-17af4fb62731.jpg?1",
             "name": "Acrobatic Maneuver",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "a10844fb-2fa3-5395-bc44-5d2f3bb9ac26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a54d1-64d0-4dc6-99a2-148052af1e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58a54d1-64d0-4dc6-99a2-148052af1e61.jpg?1",
             "name": "Aerial Modification",
             "text": "Enchant creature or Vehicle\nAs long as enchanted permanent is a Vehicle, it's a creature in addition to its other types.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "aead2360-3fbc-5df2-a1c1-79698ce23620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd33b41-e8f4-46e2-9a44-9cba5758a6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd33b41-e8f4-46e2-9a44-9cba5758a6fb.jpg?1",
             "name": "Aethershield Artificer",
             "text": "At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "3f2d717e-3c46-5d37-a7e9-53321d192708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58deb8a-1c4b-4e3d-9c00-63f615f358c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58deb8a-1c4b-4e3d-9c00-63f615f358c0.jpg?1",
             "name": "Ajani, Strength of the Pride",
             "text": "+1: You gain life equal to the number of creatures you control plus the number of planeswalkers you control.\n\u22122: Create a 2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.\"\n0: If you have at least 15 life more than your starting life total, exile Ajani, Strength of the Pride and each artifact and creature your opponents control.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "5a148e45-8603-5f94-84d4-2d5a726fd614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc35481-1f63-4c04-aee9-b3fe8eb89916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc35481-1f63-4c04-aee9-b3fe8eb89916.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "1dea6f81-f036-547b-9e01-653c70537465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dbfdac-059c-411c-aeac-6d849ee54212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dbfdac-059c-411c-aeac-6d849ee54212.jpg?1",
             "name": "Alseid of Life's Bounty",
             "text": "Lifelink\n{1}, Sacrifice Alseid of Life's Bounty: Target creature or enchantment you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "6c2c59d0-ffd0-50f3-b6ff-74a3779c4219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39a1e1-9784-4cb0-b8ed-98e659b32edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39a1e1-9784-4cb0-b8ed-98e659b32edd.jpg?1",
             "name": "Angel of Flight Alabaster",
             "text": "Flying\nAt the beginning of your upkeep, return target Spirit card from your graveyard to your hand.",
             "colours": [
@@ -4810,7 +4810,7 @@
         },
         {
             "id": "0bb208c2-df50-5958-ab09-178726dc4ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef1f8f-42bc-4e0a-96d3-4904fbdcc923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baef1f8f-42bc-4e0a-96d3-4904fbdcc923.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "380f1ef9-1177-5ae4-8fe1-98a5a1261335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623d9e1d-4154-4d77-bd0e-e6204117dc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623d9e1d-4154-4d77-bd0e-e6204117dc83.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "a9193791-fa6a-589f-83b9-13524e16b200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4586e3c-9463-4663-8746-021a7496f3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4586e3c-9463-4663-8746-021a7496f3c5.jpg?1",
             "name": "Angelic Protector",
             "text": "Flying\nWhenever Angelic Protector becomes the target of a spell or ability, Angelic Protector gets +0/+3 until end of turn.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "6bb0e2df-93a3-5091-8422-8bf54545c2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570bb02-394c-424c-98ad-30824a097d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570bb02-394c-424c-98ad-30824a097d1b.jpg?1",
             "name": "Anointer of Valor",
             "text": "Flying\nWhenever a creature attacks, you may pay {3}. When you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "92590b11-6354-51ab-988b-1257288b1bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dfc4f5-5103-4e60-9c54-2aff113dc4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dfc4f5-5103-4e60-9c54-2aff113dc4b7.jpg?1",
             "name": "Apothecary Geist",
             "text": "Flying\nWhen Apothecary Geist enters the battlefield, if you control another Spirit, you gain 3 life.",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "c8969453-92d2-5840-8afb-e6de0b19fe05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c4f01-78c4-4635-86e0-46596e6e6ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17c4f01-78c4-4635-86e0-46596e6e6ec6.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice dies, exile target permanent.",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "319f71cf-3442-5929-80c8-fe343246a22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895da74d-26ce-4e0c-baef-6eabc40bf0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895da74d-26ce-4e0c-baef-6eabc40bf0de.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, create a 2/2 white Pegasus creature token with flying.",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "39026542-5e15-5fe8-b57a-6e2ac67d1d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae2fa8-032a-49d5-8e5f-de742cded9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eae2fa8-032a-49d5-8e5f-de742cded9c2.jpg?1",
             "name": "Attended Healer",
             "text": "Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.\n{2}{W}: Another target Cleric gains lifelink until end of turn.",
             "colours": [
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "16e11dfb-4e09-5a6e-8ccf-fa175f38deb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3b21e-a05c-4603-b4d1-68353273d4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3b21e-a05c-4603-b4d1-68353273d4a9.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "7527ebe6-1063-5c41-b822-e846dcb75f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c9c3ac-4ffe-4f83-a3d2-fa2e834f8e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c9c3ac-4ffe-4f83-a3d2-fa2e834f8e29.jpg?1",
             "name": "Basri's Acolyte",
             "text": "Lifelink\nWhen Basri's Acolyte enters the battlefield, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -5142,7 +5142,7 @@
         },
         {
             "id": "1126db4f-d3c6-5985-aee5-71df19eab6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc79ad-6616-4166-9cf2-4e663d81de2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc79ad-6616-4166-9cf2-4e663d81de2d.jpg?1",
             "name": "Benalish Honor Guard",
             "text": "Benalish Honor Guard gets +1/+0 for each legendary creature you control.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "8cc051d1-7644-5144-93d8-c4e81b76f6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333e35c-ca90-4aaa-950a-48b5623c31a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333e35c-ca90-4aaa-950a-48b5623c31a6.jpg?1",
             "name": "Blessed Defiance",
             "text": "Target creature you control gets +2/+0 and gains lifelink until end of turn. When that creature dies this turn, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "fdf58db8-2f29-5d4e-ba9d-73c6c6669f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737cfc4d-2a11-4f5e-a871-8c081d08a961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737cfc4d-2a11-4f5e-a871-8c081d08a961.jpg?1",
             "name": "Blessed Sanctuary",
             "text": "Prevent all noncombat damage that would be dealt to you and creatures you control.\nWhenever a nontoken creature enters the battlefield under your control, create a 2/2 white Unicorn creature token.",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "e6b0a528-3bd2-5201-8e2d-4d004a803c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41adcf82-1cb2-4b38-8607-c6229e9948cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41adcf82-1cb2-4b38-8607-c6229e9948cb.jpg?1",
             "name": "Blessed Spirits",
             "text": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on Blessed Spirits.",
             "colours": [
@@ -5271,7 +5271,7 @@
         },
         {
             "id": "20ba15d4-d019-528f-b9da-ba8617a4cd4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb4aab6-144d-437d-8936-7220a27aae13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb4aab6-144d-437d-8936-7220a27aae13.jpg?1",
             "name": "Brightmare",
             "text": "When Brightmare enters the battlefield, tap up to one target creature. You gain life equal to that creature's power.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "f427744a-2c30-53a1-a42c-ab8f294ca7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444d7e10-0d5b-47f4-b29c-730d1d08a59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444d7e10-0d5b-47f4-b29c-730d1d08a59a.jpg?1",
             "name": "Bring to Trial",
             "text": "Exile target creature with power 4 or greater.",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "619a4460-2476-56e4-a9bc-434b689ed65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f3d01-a61a-4702-8331-28f911e8358f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f3d01-a61a-4702-8331-28f911e8358f.jpg?1",
             "name": "Built to Last",
             "text": "Target creature gets +2/+2 until end of turn. If it's an artifact creature, it gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "c1507d96-cc97-5de2-bbfc-7ea90e7f798b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7635b128-5d14-43fb-9f6a-5da8aeb21172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7635b128-5d14-43fb-9f6a-5da8aeb21172.jpg?1",
             "name": "Cage of Hands",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{1}{W}: Return Cage of Hands to its owner's hand.",
             "colours": [
@@ -5399,7 +5399,7 @@
         },
         {
             "id": "141a647f-eb2b-59da-9005-27d7ec25d084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5364ee-cfa3-48b0-93e9-c14c55ecc8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5364ee-cfa3-48b0-93e9-c14c55ecc8ba.jpg?1",
             "name": "Captivating Unicorn",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "3a4f9e38-8913-52ba-8c87-396c87d9313b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d4b46-b12f-4819-8d75-1540e2b402e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d4b46-b12f-4819-8d75-1540e2b402e5.jpg?1",
             "name": "Caught in the Brights",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen a Vehicle you control attacks, exile enchanted creature.",
             "colours": [
@@ -5465,7 +5465,7 @@
         },
         {
             "id": "ec56e9f8-f90d-5f3c-a481-2cf32cce60ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db546a-f117-41ad-a917-69e6086a43dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db546a-f117-41ad-a917-69e6086a43dd.jpg?1",
             "name": "Cavalry Drillmaster",
             "text": "When Cavalry Drillmaster enters the battlefield, target creature gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5499,7 +5499,7 @@
         },
         {
             "id": "bd27feba-b220-5b60-9eeb-4ad97e9f399b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a37ed7-223e-4e19-b318-83cac54f6b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a37ed7-223e-4e19-b318-83cac54f6b16.jpg?1",
             "name": "The Circle of Loyalty",
             "text": "This spell costs {1} less to cast for each Knight you control.\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "5b99321f-fa2f-53c4-adb3-bec0008448a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8e9d2-8c5b-4f75-ac03-df23435f3404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d8e9d2-8c5b-4f75-ac03-df23435f3404.jpg?1",
             "name": "Combat Professor",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn.",
             "colours": [
@@ -5566,7 +5566,7 @@
         },
         {
             "id": "a95520b0-d702-5833-827b-40c4e83a3948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5569b514-9049-4b44-b69e-78552a7bbf97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5569b514-9049-4b44-b69e-78552a7bbf97.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "First strike, vigilance, lifelink\nAura and Equipment spells you cast cost {1} less to cast.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "51143163-3085-5c38-ab8c-ed0217b8ff42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66cf2f-191d-4cbf-a340-a516973a7751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66cf2f-191d-4cbf-a340-a516973a7751.jpg?1",
             "name": "Dawn of Hope",
             "text": "Whenever you gain life, you may pay {2}. If you do, draw a card.\n{3}{W}: Create a 1/1 white Soldier creature token with lifelink.",
             "colours": [
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "ae4e4091-cb8f-50ff-a4f6-a6b63533452e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326e1569-3394-468d-addd-c0a5346f7031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326e1569-3394-468d-addd-c0a5346f7031.jpg?1",
             "name": "Dawning Angel",
             "text": "Flying\nWhen Dawning Angel enters the battlefield, you gain 4 life.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "b3cc74a2-d830-54f2-a3b6-33195d9db626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0877c7da-e606-4c24-822a-2af987527361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0877c7da-e606-4c24-822a-2af987527361.jpg?1",
             "name": "Daybreak Chaplain",
             "text": "Lifelink",
             "colours": [
@@ -5700,7 +5700,7 @@
         },
         {
             "id": "7f22b87f-8bed-5170-9bdd-4ac42d4e88be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ea7a5-c096-4216-b6bd-a848f2540c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ea7a5-c096-4216-b6bd-a848f2540c31.jpg?1",
             "name": "Daybreak Charger",
             "text": "When Daybreak Charger enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "ae56853d-80ae-5f5f-8e91-d995061b53f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cecbd0-87a7-45e5-bf10-e97b298803fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cecbd0-87a7-45e5-bf10-e97b298803fd.jpg?1",
             "name": "Decree of Justice",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
             "colours": [
@@ -5764,7 +5764,7 @@
         },
         {
             "id": "8b1f6a4c-23bd-5a88-bba5-3614706a8ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500edf50-7d23-453d-baf9-e755939cabdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500edf50-7d23-453d-baf9-e755939cabdc.jpg?1",
             "name": "Defy Death",
             "text": "Return target creature card from your graveyard to the battlefield. If it's an Angel, put two +1/+1 counters on it.",
             "colours": [
@@ -5795,7 +5795,7 @@
         },
         {
             "id": "545ff4b5-9365-563f-9fc8-013e73e099fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ef2107-1d92-482c-a7ea-6847e6c50aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ef2107-1d92-482c-a7ea-6847e6c50aed.jpg?1",
             "name": "Devouring Light",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "cd10cef5-64f3-52c9-a0e6-ae0f65cde8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b54945-444f-45db-bffa-0d844291f579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b54945-444f-45db-bffa-0d844291f579.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -5857,7 +5857,7 @@
         },
         {
             "id": "a1e0933c-e62a-5ac2-b0ea-85890670cb1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb9d872-3ea5-4f8a-891e-00707c4ff5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb9d872-3ea5-4f8a-891e-00707c4ff5c0.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -5888,7 +5888,7 @@
         },
         {
             "id": "5f05ced8-4bc7-5850-84ed-d6eb03f3f977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98c3007-c45f-4502-ae4b-693bd64f23ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98c3007-c45f-4502-ae4b-693bd64f23ba.jpg?1",
             "name": "Doomed Traveler",
             "text": "When Doomed Traveler dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -5922,7 +5922,7 @@
         },
         {
             "id": "65b20dfb-e04d-5e51-8412-622e2a184553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2778f8ac-6abc-4e28-838d-fd68ce34120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2778f8ac-6abc-4e28-838d-fd68ce34120e.jpg?1",
             "name": "Dreadful Apathy",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "b7b257b7-98fc-5ba7-8578-c6417b322cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2aec96-a679-475c-9c71-4fe06a890880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2aec96-a679-475c-9c71-4fe06a890880.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead. ({RW} can be paid with either {G} or {W}.)",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "06440101-cf9a-5438-8acf-df4598ee23b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc226022-c422-4e9d-a359-5c2104e0a5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc226022-c422-4e9d-a359-5c2104e0a5f2.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "72276473-22be-58aa-a089-26d2a90fe8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888a511d-218e-49a9-a57a-ee0e9e4ddc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888a511d-218e-49a9-a57a-ee0e9e4ddc5d.jpg?1",
             "name": "Favored of Iroas",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Favored of Iroas gains double strike until end of turn.",
             "colours": [
@@ -6058,7 +6058,7 @@
         },
         {
             "id": "bfd061b1-19ea-5397-9b31-0a00240660ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b096d925-a76d-494e-8f72-ebb14263748b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b096d925-a76d-494e-8f72-ebb14263748b.jpg?1",
             "name": "Felidar Cub",
             "text": "Sacrifice Felidar Cub: Destroy target enchantment.",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "f3392524-3259-5f0f-91ca-ac1bf2d3d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b3b925-743d-4f88-97d6-d0847c0d7d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b3b925-743d-4f88-97d6-d0847c0d7d6a.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "b0feedd0-9cc8-5965-95df-00b00c8a2491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db741799-0b2f-429c-a978-aa2ab9681d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db741799-0b2f-429c-a978-aa2ab9681d1c.jpg?1",
             "name": "Forced Worship",
             "text": "Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "903e2f88-8084-58a8-8ed5-038b7360f9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f370a9-1401-4018-bbd3-0a8737f9fbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f370a9-1401-4018-bbd3-0a8737f9fbea.jpg?1",
             "name": "Gallant Cavalry",
             "text": "Vigilance\nWhen Gallant Cavalry enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "07995e2a-2583-5de0-ba9e-f73223c420fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa9a592-9495-41ea-918e-09f81bd10309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa9a592-9495-41ea-918e-09f81bd10309.jpg?1",
             "name": "Gallows Warden",
             "text": "Flying\nOther Spirit creatures you control get +0/+1.",
             "colours": [
@@ -6223,7 +6223,7 @@
         },
         {
             "id": "f7789136-feb3-5f88-9e10-6dff7f92441a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f4dbc9-baa5-407b-a96c-43f356a0875b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f4dbc9-baa5-407b-a96c-43f356a0875b.jpg?1",
             "name": "Giant Ox",
             "text": "Giant Ox crews Vehicles using its toughness rather than its power.",
             "colours": [
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "34cef839-95bb-5454-8fbf-3d826e18fdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9eadb92-2a87-4b3b-90b5-f10cb1cfda0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9eadb92-2a87-4b3b-90b5-f10cb1cfda0f.jpg?1",
             "name": "Gideon, Champion of Justice",
             "text": "+1: Put a loyalty counter on Gideon, Champion of Justice for each creature target opponent controls.\n0: Until end of turn, Gideon, Champion of Justice becomes a Human Soldier creature with power and toughness each equal to the number of loyalty counters on him and gains indestructible. He's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n\u221215: Exile all other permanents.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "4e7ee0e2-82ac-5c2f-80db-d6c3a397fd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e4e1a-9c21-4296-9bfc-ba1c007c1cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e4e1a-9c21-4296-9bfc-ba1c007c1cdd.jpg?1",
             "name": "Gideon's Lawkeeper",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -6325,7 +6325,7 @@
         },
         {
             "id": "f76be773-30db-5588-aed9-345938d6fb3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0f1eb3-379d-4dc0-a3c8-618cfd3414b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0f1eb3-379d-4dc0-a3c8-618cfd3414b2.jpg?1",
             "name": "Glory Bearers",
             "text": "Whenever another creature you control attacks, it gets +0/+1 until end of turn.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "7d74229d-ac3f-5c85-bfe4-c638cd6d2eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889f5a07-3b5c-494b-834a-3a5e444e38cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889f5a07-3b5c-494b-834a-3a5e444e38cc.jpg?1",
             "name": "Goldnight Commander",
             "text": "Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "7b97d70f-7b2a-55ca-8adb-2cea4204a798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8e6238-0716-4ed0-b405-05330b7abc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8e6238-0716-4ed0-b405-05330b7abc54.jpg?1",
             "name": "Hotshot Mechanic",
             "text": "Hotshot Mechanic crews Vehicles as though its power were 2 greater.",
             "colours": [
@@ -6430,7 +6430,7 @@
         },
         {
             "id": "c7680fee-1903-5a42-ba1e-c0c4a1ec8882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c50249-4039-4442-bc6c-a9318f8ffe9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c50249-4039-4442-bc6c-a9318f8ffe9d.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
             "colours": [
@@ -6461,7 +6461,7 @@
         },
         {
             "id": "597bd00e-fd85-51ee-a525-477781814794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4202dc3-3299-4bf3-a37e-78588e07bb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4202dc3-3299-4bf3-a37e-78588e07bb1e.jpg?1",
             "name": "Impeccable Timing",
             "text": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "c9771780-3066-5db4-aa24-a8f6b5e0b963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27048b6-5412-428f-aa3c-c50c6ed70500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27048b6-5412-428f-aa3c-c50c6ed70500.jpg?1",
             "name": "Imperial Aerosaur",
             "text": "Flying\nWhen Imperial Aerosaur enters the battlefield, another target creature you control gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -6525,7 +6525,7 @@
         },
         {
             "id": "2eb3497d-266d-5f2f-8c53-9a8c0873ae3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8004e33-ec53-4f37-b035-6765004fa1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8004e33-ec53-4f37-b035-6765004fa1f3.jpg?1",
             "name": "Imperial Recovery Unit",
             "text": "Whenever Imperial Recovery Unit attacks, return target creature or Vehicle card with mana value 2 or less from your graveyard to your hand.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "dbf522f8-ca1f-52dc-baac-e98920e9df16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d42086a-74b3-4700-b070-95e1357ae527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d42086a-74b3-4700-b070-95e1357ae527.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -6592,7 +6592,7 @@
         },
         {
             "id": "733a8a9b-2f10-5508-98e0-845f5bd75057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc56f47-ae0a-498b-8730-2096937887e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc56f47-ae0a-498b-8730-2096937887e5.jpg?1",
             "name": "Inspiring Cleric",
             "text": "When Inspiring Cleric enters the battlefield, you gain 4 life.",
             "colours": [
@@ -6626,7 +6626,7 @@
         },
         {
             "id": "49de0ed3-6f80-56bd-9b01-143db9bcd79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa372561-4c23-4aea-8186-9fcf8b230ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa372561-4c23-4aea-8186-9fcf8b230ce2.jpg?1",
             "name": "Inspiring Overseer",
             "text": "Flying\nWhen Inspiring Overseer enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "b9eae505-2bb5-58b3-86ed-5af4491e564d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e66b0f2-262e-4feb-8ae5-ad1f60b6611c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e66b0f2-262e-4feb-8ae5-ad1f60b6611c.jpg?1",
             "name": "Isamaru, Hound of Konda",
             "text": "",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "55a6a701-6bab-5e2f-8d37-b542904eccf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8383ce-b8db-4c32-8564-79a3b6196e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8383ce-b8db-4c32-8564-79a3b6196e4c.jpg?1",
             "name": "Justiciar's Portal",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. It gains first strike until end of turn.",
             "colours": [
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "5520b4d9-cad2-5859-bb9d-10d63eefeed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d39bae5-780c-489c-87b6-4a60336afe31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d39bae5-780c-489c-87b6-4a60336afe31.jpg?1",
             "name": "Kami of Ancient Law",
             "text": "Sacrifice Kami of Ancient Law: Destroy target enchantment.",
             "colours": [
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "a64ab5b2-b73d-5505-98c5-17b210de919a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abff1b-1f9e-48a6-825f-1e7336fab70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abff1b-1f9e-48a6-825f-1e7336fab70c.jpg?1",
             "name": "Kitsune Ace",
             "text": "Whenever a Vehicle you control attacks, choose one \u2014\n\u2022 That Vehicle gains first strike until end of turn.\n\u2022 Untap Kitsune Ace.",
             "colours": [
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "1fe187a0-8520-5114-ae59-45e6bda6e81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff87191-2325-4230-8af1-ebbfdff56a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff87191-2325-4230-8af1-ebbfdff56a0f.jpg?1",
             "name": "Kwende, Pride of Femeref",
             "text": "Double strike\nCreatures you control with first strike have double strike.",
             "colours": [
@@ -6829,7 +6829,7 @@
         },
         {
             "id": "4c1fe0bb-d259-5ef1-809a-d7914024fabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8430557a-9e31-4ab1-8fef-0dc7d07e018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8430557a-9e31-4ab1-8fef-0dc7d07e018f.jpg?1",
             "name": "Law-Rune Enforcer",
             "text": "{1}, {T}: Tap target creature with mana value 2 or greater.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "115cac8d-061d-5717-9547-46eebe0eee04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708124d5-8447-4c22-a3c9-268ccece7854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708124d5-8447-4c22-a3c9-268ccece7854.jpg?1",
             "name": "Leonin Snarecaster",
             "text": "When Leonin Snarecaster enters the battlefield, you may tap target creature.",
             "colours": [
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "d1267721-f1e1-52c5-8973-8cb8399c4cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24820fa-7cef-4396-920c-810dd06e3887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24820fa-7cef-4396-920c-810dd06e3887.jpg?1",
             "name": "Leonin Warleader",
             "text": "Whenever Leonin Warleader attacks, create two 1/1 white Cat creature tokens with lifelink that are tapped and attacking.",
             "colours": [
@@ -6931,7 +6931,7 @@
         },
         {
             "id": "ca2f4a58-fa54-53da-97e4-e3c2b5ba38f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fcdd23-7535-4995-b5db-c004bfc40566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fcdd23-7535-4995-b5db-c004bfc40566.jpg?1",
             "name": "Light of Hope",
             "text": "Choose one \u2014\n\u2022 You gain 4 life.\n\u2022 Destroy target enchantment.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -6962,7 +6962,7 @@
         },
         {
             "id": "ed26c884-6ac9-5359-8f77-f6f99ddc9c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a395674-3b3e-43bf-8384-2ffc63fe84dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a395674-3b3e-43bf-8384-2ffc63fe84dd.jpg?1",
             "name": "Lyra Dawnbringer",
             "text": "Flying, first strike, lifelink\nOther Angels you control get +1/+1 and have lifelink.",
             "colours": [
@@ -6997,7 +6997,7 @@
         },
         {
             "id": "4cbf7953-c2be-59f5-a2fb-af23bb380042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d0d4a3-7ce9-4881-a94b-bac5cbbf4dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d0d4a3-7ce9-4881-a94b-bac5cbbf4dc0.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "3b87afa8-c1c4-5d1c-b406-c1d3787ab853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820036e8-3f3c-4166-a5a7-6ca9d0f15323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820036e8-3f3c-4166-a5a7-6ca9d0f15323.jpg?1",
             "name": "Martyr's Soul",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Martyr's Soul enters the battlefield, if you control no tapped lands, put two +1/+1 counters on it.",
             "colours": [
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "79190bfe-fd01-5eb8-8c8f-74f9e875a535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43227caf-f902-46b4-936f-125d879eb54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43227caf-f902-46b4-936f-125d879eb54a.jpg?1",
             "name": "Mausoleum Guard",
             "text": "When Mausoleum Guard dies, create two 1/1 white Spirit creature tokens with flying.",
             "colours": [
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "79ac432b-f61f-57fa-bd37-77a7afb30c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfcac-4912-4b34-b00e-16a18ee49823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfcac-4912-4b34-b00e-16a18ee49823.jpg?1",
             "name": "Mesa Lynx",
             "text": "As long as it's not your turn, Mesa Lynx gets +0/+2.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "db7f977e-1b1c-52e0-921d-b6ffb29bc137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4124fc-c9c5-4752-9618-dfe722c38d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4124fc-c9c5-4752-9618-dfe722c38d0b.jpg?1",
             "name": "Michiko Konda, Truth Seeker",
             "text": "Whenever a source an opponent controls deals damage to you, that player sacrifices a permanent.",
             "colours": [
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "b6bb1081-a835-55c6-941a-c5fe3c5e232f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d2cc-5380-4be1-ab67-a755b2e02016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185d2cc-5380-4be1-ab67-a755b2e02016.jpg?1",
             "name": "Midnight Guard",
             "text": "Whenever another creature enters the battlefield, untap Midnight Guard.",
             "colours": [
@@ -7199,7 +7199,7 @@
         },
         {
             "id": "10d4c867-bc90-514f-9a39-486214058cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a193b7b6-0ec6-4225-9f23-67294a957f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a193b7b6-0ec6-4225-9f23-67294a957f06.jpg?1",
             "name": "Miraculous Recovery",
             "text": "Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.",
             "colours": [
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "c69b5580-9894-52cf-9d83-8fa50aa3f773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffffb3e-253e-4e93-9ed1-9c2455220dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffffb3e-253e-4e93-9ed1-9c2455220dac.jpg?1",
             "name": "Moment of Triumph",
             "text": "Target creature gets +2/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "cf6b4fc7-f67c-58b8-b7f3-0b34ccbededc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612da129-c8dd-4f89-a505-548ad5c2f7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612da129-c8dd-4f89-a505-548ad5c2f7e1.jpg?1",
             "name": "Murder Investigation",
             "text": "Enchant creature you control\nWhen enchanted creature dies, create X 1/1 white Soldier creature tokens, where X is its power.",
             "colours": [
@@ -7294,7 +7294,7 @@
         },
         {
             "id": "8acad8ba-6fe4-56d7-a4b6-9a1b25ecf45a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb360f53-0013-4c0e-b7db-d2fc8029473a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb360f53-0013-4c0e-b7db-d2fc8029473a.jpg?1",
             "name": "Nightguard Patrol",
             "text": "First strike, vigilance",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "f57331c7-993d-5ad0-8e03-c8784db50599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260ca48-e932-4396-a726-eefc30935c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260ca48-e932-4396-a726-eefc30935c35.jpg?1",
             "name": "Ninth Bridge Patrol",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Ninth Bridge Patrol.",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "ce5212ff-d4ea-5834-9ea2-a05975d192dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05860b72-fb1b-44d8-9275-12863724a9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05860b72-fb1b-44d8-9275-12863724a9ef.jpg?1",
             "name": "Not Forgotten",
             "text": "Put target card from a graveyard on the top or bottom of its owner's library. Create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -7393,7 +7393,7 @@
         },
         {
             "id": "36a3b3c0-a52a-569f-acd4-c2aa4427f2e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcf25b6-b4a6-4077-b827-3d44a6f5d744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcf25b6-b4a6-4077-b827-3d44a6f5d744.jpg?1",
             "name": "Order of the Golden Cricket",
             "text": "Whenever Order of the Golden Cricket attacks, you may pay {W}. If you do, it gains flying until end of turn.",
             "colours": [
@@ -7427,7 +7427,7 @@
         },
         {
             "id": "c7a222ef-0585-507d-b9de-189a5b0436fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944c5ac7-09ab-4b6f-b809-5422c22ea6a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944c5ac7-09ab-4b6f-b809-5422c22ea6a1.jpg?1",
             "name": "Phalanx Tactics",
             "text": "Target creature you control gets +2/+1 until end of turn. Each other creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -7458,7 +7458,7 @@
         },
         {
             "id": "a025f87d-ec23-51d2-8a4e-9493ecb260df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca680ef-07e1-4e95-bf11-d2f7672857d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca680ef-07e1-4e95-bf11-d2f7672857d8.jpg?1",
             "name": "Pilgrim of the Ages",
             "text": "When Pilgrim of the Ages enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n{6}: Return Pilgrim of the Ages from your graveyard to your hand.",
             "colours": [
@@ -7491,7 +7491,7 @@
         },
         {
             "id": "ad5b016a-a873-5f3b-b46c-86835ea626f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e4175b-d498-4f89-9dd0-559b22690312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e4175b-d498-4f89-9dd0-559b22690312.jpg?1",
             "name": "Pillardrop Rescuer",
             "text": "Flying\nWhen Pillardrop Rescuer enters the battlefield, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "bdc88741-fbda-50bf-848d-d5363d474eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52429695-4146-4b68-98b7-72b31c854070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52429695-4146-4b68-98b7-72b31c854070.jpg?1",
             "name": "Pious Wayfarer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "7848ec13-c66b-5dcc-a558-aa1d166d8fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e00f43-bd0e-4664-8ef3-fb0aeb0d281e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e00f43-bd0e-4664-8ef3-fb0aeb0d281e.jpg?1",
             "name": "Pouncing Lynx",
             "text": "As long as it's your turn, Pouncing Lynx has first strike.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "a39436ef-e6c5-5d1b-a267-f57796230fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bb131e-b659-4caa-98c5-505b72ac26ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bb131e-b659-4caa-98c5-505b72ac26ac.jpg?1",
             "name": "Prowling Felidar",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Prowling Felidar.",
             "colours": [
@@ -7626,7 +7626,7 @@
         },
         {
             "id": "e4176bc9-e130-5939-8df9-6b006469bfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f8f288-69da-438d-967b-167060fdcbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f8f288-69da-438d-967b-167060fdcbb9.jpg?1",
             "name": "Radiant's Judgment",
             "text": "Destroy target creature with power 4 or greater.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -7657,7 +7657,7 @@
         },
         {
             "id": "6d1e3f9c-7fcf-50f6-b059-e290268e96a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc371de-3e82-4d66-8636-f9c03579ba10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc371de-3e82-4d66-8636-f9c03579ba10.jpg?1",
             "name": "Rambunctious Mutt",
             "text": "When Rambunctious Mutt enters the battlefield, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "024d5938-d8c7-56d3-a527-71d914ac1db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8511fb74-dd0c-492d-87f6-7d27d39d101a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8511fb74-dd0c-492d-87f6-7d27d39d101a.jpg?1",
             "name": "Regal Caracal",
             "text": "Other Cats you control get +1/+1 and have lifelink.\nWhen Regal Caracal enters the battlefield, create two 1/1 white Cat creature tokens with lifelink.",
             "colours": [
@@ -7723,7 +7723,7 @@
         },
         {
             "id": "d4920bb5-7b54-5d7f-b596-d68a257d4da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee6fbf-4562-4c73-afa7-2c573d6acd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee6fbf-4562-4c73-afa7-2c573d6acd77.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -7756,7 +7756,7 @@
         },
         {
             "id": "16507506-2fb0-5dec-9bca-e2e26d94a960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e8e2a9-8dcb-40dd-8079-6c8484c3b157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e8e2a9-8dcb-40dd-8079-6c8484c3b157.jpg?1",
             "name": "Righteous Valkyrie",
             "text": "Flying\nWhenever another Angel or Cleric enters the battlefield under your control, you gain life equal to that creature's toughness.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "97eb9e93-04dd-5230-baf0-cbae27f5d5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7ee36d-fdaa-4520-a86a-0feb93a7f9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7ee36d-fdaa-4520-a86a-0feb93a7f9b4.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "e4194759-91d9-5788-96a8-1b0c6999d00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e6ab8-d778-4cf6-ab21-1352618d093b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e6ab8-d778-4cf6-ab21-1352618d093b.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle enters the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -7855,7 +7855,7 @@
         },
         {
             "id": "9f4a2a5c-9306-5e8a-bbea-ce71cffa31f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b77ad5-1585-49dc-b635-780143e1e1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b77ad5-1585-49dc-b635-780143e1e1c8.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -7888,7 +7888,7 @@
         },
         {
             "id": "e8eca721-2f5e-5e90-bf32-6e52ea191336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9edf976-bf2e-4528-9001-0c70bdc94762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9edf976-bf2e-4528-9001-0c70bdc94762.jpg?1",
             "name": "Savannah Sage",
             "text": "When Savannah Sage enters the battlefield, you gain 2 life.",
             "colours": [
@@ -7922,7 +7922,7 @@
         },
         {
             "id": "94ed2ec2-f05c-5460-b2e0-c895e7127987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc30cb5-e845-472c-8bdb-659ce7ece6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc30cb5-e845-472c-8bdb-659ce7ece6de.jpg?1",
             "name": "Selfless Spirit",
             "text": "Flying\nSacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -7956,7 +7956,7 @@
         },
         {
             "id": "91e5cda2-c8a7-5eb3-90da-2354af7f1be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b2176-958a-42e0-b88e-5b3416b40150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b2176-958a-42e0-b88e-5b3416b40150.jpg?1",
             "name": "Seller of Songbirds",
             "text": "When Seller of Songbirds enters the battlefield, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "01b6e333-6797-509d-b5f8-126febf66adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746381e7-1695-40c0-a830-ab58bb240180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746381e7-1695-40c0-a830-ab58bb240180.jpg?1",
             "name": "Serene Steward",
             "text": "Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8024,7 +8024,7 @@
         },
         {
             "id": "501f2c55-38e0-5af9-90a0-a6ddf928a9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8eb805-70ac-4680-bcee-83ed40b43881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8eb805-70ac-4680-bcee-83ed40b43881.jpg?1",
             "name": "Settle Beyond Reality",
             "text": "Choose one or both \u2014\n\u2022 Exile target creature you don't control.\n\u2022 Exile target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -8055,7 +8055,7 @@
         },
         {
             "id": "e3c4ec11-9f3c-5ccb-8311-95295dfb5771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0dcfeb-27b9-4455-bb79-06059006b006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0dcfeb-27b9-4455-bb79-06059006b006.jpg?1",
             "name": "Shining Armor",
             "text": "Flash\nWhen Shining Armor enters the battlefield, attach it to target Knight you control.\nEquipped creature gets +0/+2 and has vigilance.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "d3ca9344-7602-5703-a16d-140bcfb73e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733e1156-39a3-49a2-af5d-75c978107b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733e1156-39a3-49a2-af5d-75c978107b2a.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -8119,7 +8119,7 @@
         },
         {
             "id": "8cdadd74-aa28-5d38-994f-6646eee76197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028bd68c-24bf-4808-80d7-051012ff90e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028bd68c-24bf-4808-80d7-051012ff90e1.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "Flying, first strike",
             "colours": [
@@ -8153,7 +8153,7 @@
         },
         {
             "id": "00290eac-3475-5574-a73f-444a1d3779d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2014229c-11cd-4289-bf06-1b55d1f2939a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2014229c-11cd-4289-bf06-1b55d1f2939a.jpg?1",
             "name": "Skyhunter Prowler",
             "text": "Flying, vigilance",
             "colours": [
@@ -8187,7 +8187,7 @@
         },
         {
             "id": "dd608c88-5b1a-59e9-a2fc-815fe0a6da68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa7a9a0-43ca-4bce-9ed8-dfe0b258dca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa7a9a0-43ca-4bce-9ed8-dfe0b258dca7.jpg?1",
             "name": "Spectral Steel",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\n{1}{W}, Exile Spectral Steel from your graveyard: Return another target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "f6a131c3-fcf8-53e2-9714-a901b49ecbf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28a16-e119-456d-ad8b-c37cec069ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28a16-e119-456d-ad8b-c37cec069ab0.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -8254,7 +8254,7 @@
         },
         {
             "id": "16a11c80-7b36-5b17-9012-fee063ff2eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc7746a-ff2a-4bc1-bc30-45eb53a94ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc7746a-ff2a-4bc1-bc30-45eb53a94ddc.jpg?1",
             "name": "Stalwart Valkyrie",
             "text": "You may pay {1}{W} and exile a creature card from your graveyard rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -8288,7 +8288,7 @@
         },
         {
             "id": "f5e59da3-e93c-58b4-854e-1a2348f1e0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170914cc-3c3d-4929-a45d-836a5b8a4090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170914cc-3c3d-4929-a45d-836a5b8a4090.jpg?1",
             "name": "Starnheim Aspirant",
             "text": "Angel spells you cast cost {2} less to cast.",
             "colours": [
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "711a6ada-c3f8-521e-92a1-70785b50a0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff6978-a794-4f4c-9039-594b15e7dbfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dff6978-a794-4f4c-9039-594b15e7dbfe.jpg?1",
             "name": "Steppe Lynx",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Steppe Lynx gets +2/+2 until end of turn.",
             "colours": [
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "a2adaa75-18db-5b1d-a691-5d9a11d79433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2d3b-a1aa-435d-b46d-0cecd1ef1c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2d3b-a1aa-435d-b46d-0cecd1ef1c40.jpg?1",
             "name": "Syr Alin, the Lion's Claw",
             "text": "First strike\nWhenever Syr Alin, the Lion's Claw attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "b88090e3-f8d5-50bd-9a3d-910c521eede8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623be150-7440-428f-9f57-73cf46189205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623be150-7440-428f-9f57-73cf46189205.jpg?1",
             "name": "Taranika, Akroan Veteran",
             "text": "Vigilance\nWhenever Taranika, Akroan Veteran attacks, untap another target creature you control. Until end of turn, that creature has base power and toughness 4/4 and gains indestructible.",
             "colours": [
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "e60158d9-6fad-5eab-b789-a59d087e073c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7af30c-3486-4a29-8bb2-736c6cd8c7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7af30c-3486-4a29-8bb2-736c6cd8c7c7.jpg?1",
             "name": "Tempered Veteran",
             "text": "{W}, {T}: Put a +1/+1 counter on target creature with a +1/+1 counter on it.\n{4}{W}{W}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "ba8cdd57-3821-5225-9759-2759a4018f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b65852b-b748-4263-a5aa-7a44e891c582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b65852b-b748-4263-a5aa-7a44e891c582.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "d6e1b5fe-3096-5286-9f3f-9affb3033bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c299243b-5ccf-44e8-82f7-fce496f237d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c299243b-5ccf-44e8-82f7-fce496f237d1.jpg?1",
             "name": "Trained Caracal",
             "text": "Lifelink",
             "colours": [
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "81057fc2-690d-50a1-a68c-65a7a42c6a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39830f8b-3c92-4bce-9ddc-e71d402f599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39830f8b-3c92-4bce-9ddc-e71d402f599a.jpg?1",
             "name": "Transcendent Envoy",
             "text": "Flying\nAura spells you cast cost {1} less to cast.",
             "colours": [
@@ -8562,7 +8562,7 @@
         },
         {
             "id": "61fde2ea-28aa-5d9c-9128-261ca9e48a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f.jpg?1",
             "name": "Triplicate Spirits",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 white Spirit creature tokens with flying.",
             "colours": [
@@ -8593,7 +8593,7 @@
         },
         {
             "id": "2fe3d363-0020-5615-920b-e173e67fa66c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e05f939-f5bb-4813-b2fe-ed79df1818ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e05f939-f5bb-4813-b2fe-ed79df1818ec.jpg?1",
             "name": "Trove Warden",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, exile target permanent card with mana value 3 or less from your graveyard.\nWhen Trove Warden dies, put each permanent card exiled with it onto the battlefield under the control of that card's owner.",
             "colours": [
@@ -8627,7 +8627,7 @@
         },
         {
             "id": "c9756d49-d0ac-599c-a232-c3104dc44b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd305056-c22f-4f2b-9082-26a377d6bb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd305056-c22f-4f2b-9082-26a377d6bb53.jpg?1",
             "name": "Unquestioned Authority",
             "text": "Enchant creature\nWhen Unquestioned Authority enters the battlefield, draw a card.\nEnchanted creature has protection from creatures.",
             "colours": [
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "aa52a606-f166-5068-8171-9cacc9a45c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9828a61-bc29-4a6d-8a41-e439dcb822db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9828a61-bc29-4a6d-8a41-e439dcb822db.jpg?1",
             "name": "Valkyrie Harbinger",
             "text": "Flying, lifelink\nAt the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.",
             "colours": [
@@ -8694,7 +8694,7 @@
         },
         {
             "id": "590cddc4-2552-5a6b-aa34-5bee104a51a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e20c0de-c9fa-463c-965a-2e868f7965b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e20c0de-c9fa-463c-965a-2e868f7965b1.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8725,7 +8725,7 @@
         },
         {
             "id": "aefd4c2b-6512-5154-884a-5fc9499dde95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab54275-240c-4f32-9e80-c6a74f90a55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab54275-240c-4f32-9e80-c6a74f90a55e.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -8758,7 +8758,7 @@
         },
         {
             "id": "002554a0-2669-58ee-8f01-d59b45970248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c80b7-6cbb-4f3f-b279-55048b90ad1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c80b7-6cbb-4f3f-b279-55048b90ad1c.jpg?1",
             "name": "Valorous Steed",
             "text": "Vigilance\nWhen Valorous Steed enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -8791,7 +8791,7 @@
         },
         {
             "id": "7f74afc0-0d32-55a1-9067-b3d2950a0ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51406b6f-7402-4641-9e0b-7b4a59ffaa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51406b6f-7402-4641-9e0b-7b4a59ffaa52.jpg?1",
             "name": "Weight of Conscience",
             "text": "Enchant creature\nEnchanted creature can't attack.\nTap two untapped creatures you control that share a creature type: Exile enchanted creature.",
             "colours": [
@@ -8824,7 +8824,7 @@
         },
         {
             "id": "36d033b3-c077-5148-b4c6-df86af483aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47a35-1992-4827-af08-b53efab2a46d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47a35-1992-4827-af08-b53efab2a46d.jpg?1",
             "name": "Wispweaver Angel",
             "text": "Flying\nWhen Wispweaver Angel enters the battlefield, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "4c6bdf2c-258a-586e-907a-4ecc5456f9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a88507f-8089-42a6-a722-d07d04a59295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a88507f-8089-42a6-a722-d07d04a59295.jpg?1",
             "name": "Academy Journeymage",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nWhen Academy Journeymage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "e2dbb8ba-2136-5329-873f-b770f3c3a8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86920134-b45d-4690-af61-c9c1488d70e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86920134-b45d-4690-af61-c9c1488d70e0.jpg?1",
             "name": "Aeronaut Tinkerer",
             "text": "Aeronaut Tinkerer has flying as long as you control an artifact.",
             "colours": [
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "3391bf53-bfa2-59c0-ac28-cc1d526f3c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559a14ce-de7a-4ce4-8c46-99818372187f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559a14ce-de7a-4ce4-8c46-99818372187f.jpg?1",
             "name": "Amoeboid Changeling",
             "text": "Changeling (This card is every creature type.)\n{T}: Target creature gains all creature types until end of turn.\n{T}: Target creature loses all creature types until end of turn.",
             "colours": [
@@ -8958,7 +8958,7 @@
         },
         {
             "id": "00fd5954-b876-52f0-ae88-a58d808cc198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57976884-2a67-41c6-bf06-c10b6c3afb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57976884-2a67-41c6-bf06-c10b6c3afb4b.jpg?1",
             "name": "Anchor to the Aether",
             "text": "Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -8989,7 +8989,7 @@
         },
         {
             "id": "532639ab-5faa-5926-a2d1-f2e17ac6c477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e7566ac-e9b3-4220-9b25-84d5b33f5842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e7566ac-e9b3-4220-9b25-84d5b33f5842.jpg?1",
             "name": "Aquatic Incursion",
             "text": "When Aquatic Incursion enters the battlefield, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)\n{3}{U}: Target Merfolk can't be blocked this turn.",
             "colours": [
@@ -9020,7 +9020,7 @@
         },
         {
             "id": "3c453e23-9883-5db9-9f9d-d2023f9b138f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90d050-65e3-4ed3-9ea1-347a05022b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d90d050-65e3-4ed3-9ea1-347a05022b3e.jpg?1",
             "name": "Artificer's Epiphany",
             "text": "Draw two cards. If you control no artifacts, discard a card.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "22ecb5ea-cf3c-50f8-8ced-e8fb48b2f909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25dd284-ccc5-423c-830d-d3d331212293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25dd284-ccc5-423c-830d-d3d331212293.jpg?1",
             "name": "Augury Owl",
             "text": "Flying\nWhen Augury Owl enters the battlefield, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "8dbfc2b0-bd0d-527f-93ec-91d91ec2a998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e20032-685c-47e0-98cd-f48ddc2de90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e20032-685c-47e0-98cd-f48ddc2de90e.jpg?1",
             "name": "Avalanche Caller",
             "text": "{2}: Target snow land you control becomes a 4/4 Elemental creature with hexproof and haste until end of turn. It's still a land. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "e3ee4b90-615e-563b-b4c8-50c7bbce2851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4165233d-8651-4498-91b6-d3e5e6d613a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4165233d-8651-4498-91b6-d3e5e6d613a5.jpg?1",
             "name": "Aviation Pioneer",
             "text": "When Aviation Pioneer enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "ced8e38a-67d2-5539-966d-6ccc6512d0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba45332-1231-41be-ae79-454674b70ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba45332-1231-41be-ae79-454674b70ff4.jpg?1",
             "name": "Barrin, Tolarian Archmage",
             "text": "When Barrin, Tolarian Archmage enters the battlefield, return up to one other target creature or planeswalker to its owner's hand.\nAt the beginning of your end step, if a permanent was put into your hand from the battlefield this turn, draw a card.",
             "colours": [
@@ -9190,7 +9190,7 @@
         },
         {
             "id": "c17592e4-a50e-5edf-8da3-cb3a5ed25078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27b52dd-bbdf-4f00-b070-1b12a1f4d650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27b52dd-bbdf-4f00-b070-1b12a1f4d650.jpg?1",
             "name": "Berg Strider",
             "text": "When Berg Strider enters the battlefield, tap target artifact or creature an opponent controls. If {S} was spent to cast this spell, that permanent doesn't untap during its controller's next untap step. ({S} is mana from a snow source.)",
             "colours": [
@@ -9226,7 +9226,7 @@
         },
         {
             "id": "52c6701a-02c5-5ea1-86ca-25204b875f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9021592a-1170-4e8e-a9bd-3086bbc0d435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9021592a-1170-4e8e-a9bd-3086bbc0d435.jpg?1",
             "name": "Brineborn Cutthroat",
             "text": "Flash\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on Brineborn Cutthroat.",
             "colours": [
@@ -9260,7 +9260,7 @@
         },
         {
             "id": "c2e1ff5b-50af-5b9f-bb5d-35e6f7935ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e18c93-7707-471a-a5f0-4079a9c6003b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e18c93-7707-471a-a5f0-4079a9c6003b.jpg?1",
             "name": "Bury in Books",
             "text": "This spell costs {2} less to cast if it targets an attacking creature.\nPut target creature into its owner's library second from the top.",
             "colours": [
@@ -9291,7 +9291,7 @@
         },
         {
             "id": "b6b4ef19-1bfa-5752-8c34-0119d9172b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae18cc3-af8d-458c-8441-a3f661d38505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae18cc3-af8d-458c-8441-a3f661d38505.jpg?1",
             "name": "Chillerpillar",
             "text": "{4}{S}{S}: Monstrosity 2. (If this creature isn't monstrous, put two +1/+1 counters on it and it becomes monstrous. {S} can be paid with one mana from a snow source.)\nAs long as Chillerpillar is monstrous, it has flying.",
             "colours": [
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "477b1588-e7ad-516f-bd04-cf52e78e551b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f33bb-4796-4890-a209-d9d4b3afa601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f33bb-4796-4890-a209-d9d4b3afa601.jpg?1",
             "name": "Chilling Trap",
             "text": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
             "colours": [
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "a76e1e28-7584-5c21-8d97-b0f2026a5c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e29ea-d7b4-4255-83da-f29b312f1813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48e29ea-d7b4-4255-83da-f29b312f1813.jpg?1",
             "name": "Condescend",
             "text": "Counter target spell unless its controller pays {X}. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -9388,7 +9388,7 @@
         },
         {
             "id": "0b699d53-146e-5dd5-a603-3d6055dff20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba21250-baae-4f40-8efc-6a58a287bcdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba21250-baae-4f40-8efc-6a58a287bcdc.jpg?1",
             "name": "Crashing Tide",
             "text": "This spell has flash as long as you control a Merfolk.\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "47e1d546-f155-5611-80dd-012d68460a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28885f-9a4a-4364-b95c-7544b2efa7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d28885f-9a4a-4364-b95c-7544b2efa7da.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -9450,7 +9450,7 @@
         },
         {
             "id": "37868b2c-28b5-5814-a1f4-beb16e4b55af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc3e4cd-022d-48e4-abc9-b8ddfb0c8c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc3e4cd-022d-48e4-abc9-b8ddfb0c8c5c.jpg?1",
             "name": "Cryptic Serpent",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "8acaa85d-cead-5878-beff-a7daa18dfb3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ada66-9da3-4a88-81f7-111dfa737874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ada66-9da3-4a88-81f7-111dfa737874.jpg?1",
             "name": "Dismiss",
             "text": "Counter target spell.\nDraw a card.",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "89671daf-0bf6-5c1d-bd2b-04680f93cf4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8477e664-3a2f-4ba2-a3cb-ded3c376b3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8477e664-3a2f-4ba2-a3cb-ded3c376b3a5.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -9547,7 +9547,7 @@
         },
         {
             "id": "aadb9dd8-50b2-5c7d-bef1-501106f63c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa465d-0e36-4294-b363-fabca95223d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafa465d-0e36-4294-b363-fabca95223d9.jpg?1",
             "name": "Drag Under",
             "text": "Return target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -9578,7 +9578,7 @@
         },
         {
             "id": "6c044e55-3c67-59da-a8e6-5513d0bdfa80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7a4792-0d24-47d7-a1df-818d97d40904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7a4792-0d24-47d7-a1df-818d97d40904.jpg?1",
             "name": "Drownyard Explorers",
             "text": "When Drownyard Explorers enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -9612,7 +9612,7 @@
         },
         {
             "id": "5856be2c-6d05-563f-9a0b-067029938f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64fa3b1-fbaa-4b35-bd09-007b95fb54a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64fa3b1-fbaa-4b35-bd09-007b95fb54a4.jpg?1",
             "name": "Elite Instructor",
             "text": "When Elite Instructor enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "35026be0-d72f-5a69-a286-a4a1d6aed86e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbfd62-0318-4f77-ab91-37e56233e493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbfd62-0318-4f77-ab91-37e56233e493.jpg?1",
             "name": "Erdwal Illuminator",
             "text": "Flying\nWhenever you investigate for the first time each turn, investigate an additional time.",
             "colours": [
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "aba70716-c51b-5d10-b0d0-87be619e82ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095ccd82-4898-4506-84dc-87da136470c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095ccd82-4898-4506-84dc-87da136470c6.jpg?1",
             "name": "Eternity Snare",
             "text": "Enchant creature\nWhen Eternity Snare enters the battlefield, draw a card.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "32c8ef14-6cef-5dd9-98b3-05610d35ff1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc1849-f601-4519-a92e-c4d4216b209a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc1849-f601-4519-a92e-c4d4216b209a.jpg?1",
             "name": "Eyekite",
             "text": "Flying\nEyekite gets +2/+0 as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -9745,7 +9745,7 @@
         },
         {
             "id": "74715da6-ab7f-5368-b3d6-c6f0201b7c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86682959-6720-44e0-8fe3-982f0b3e94ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86682959-6720-44e0-8fe3-982f0b3e94ce.jpg?1",
             "name": "Faerie Formation",
             "text": "Flying\n{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card.",
             "colours": [
@@ -9778,7 +9778,7 @@
         },
         {
             "id": "c1130ce3-706b-5041-9c69-e32c7647aaf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05949b2-abb4-4431-b047-f4381a2a920e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05949b2-abb4-4431-b047-f4381a2a920e.jpg?1",
             "name": "Faerie Seer",
             "text": "Flying\nWhen Faerie Seer enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -9812,7 +9812,7 @@
         },
         {
             "id": "b736f382-b4ce-5aff-b469-4e3c426da0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc487c86-caae-4bc0-b41b-5227404e761f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc487c86-caae-4bc0-b41b-5227404e761f.jpg?1",
             "name": "Faerie Vandal",
             "text": "Flash\nFlying\nWhenever you draw your second card each turn, put a +1/+1 counter on Faerie Vandal.",
             "colours": [
@@ -9846,7 +9846,7 @@
         },
         {
             "id": "61a5a996-7e36-5d62-bc3b-55a0060a7be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc890f39-e506-497c-ab0b-3e548fd2676d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc890f39-e506-497c-ab0b-3e548fd2676d.jpg?1",
             "name": "Fallowsage",
             "text": "Whenever Fallowsage becomes tapped, you may draw a card.",
             "colours": [
@@ -9880,7 +9880,7 @@
         },
         {
             "id": "ebd0c479-2096-5af5-a905-7ff84a17d0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70d6006-9f57-4db1-8e65-f2392689b5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70d6006-9f57-4db1-8e65-f2392689b5dd.jpg?1",
             "name": "Filigree Attendant",
             "text": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
             "colours": [
@@ -9914,7 +9914,7 @@
         },
         {
             "id": "c06c4eac-97ef-5dd6-acb5-8c22d4be83af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a7507f-2f18-4a94-9b56-814f26b4490b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a7507f-2f18-4a94-9b56-814f26b4490b.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -9945,7 +9945,7 @@
         },
         {
             "id": "517b7167-628e-5cef-aed2-28f6d424d199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ca694c-f0ee-4994-92a2-be2a840c7e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ca694c-f0ee-4994-92a2-be2a840c7e07.jpg?1",
             "name": "Floodhound",
             "text": "{3}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -9979,7 +9979,7 @@
         },
         {
             "id": "832a532b-a504-5fde-911c-ce06b8eeb872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328aade2-6196-48df-a19b-e61845c5d3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328aade2-6196-48df-a19b-e61845c5d3a9.jpg?1",
             "name": "Frostpeak Yeti",
             "text": "{1}{S}: Frostpeak Yeti can't be blocked this turn. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -10014,7 +10014,7 @@
         },
         {
             "id": "dd84a17c-5070-5c10-a048-fd0c94da16b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ff91c-3d6c-45ed-bc58-28b17e8a213d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ff91c-3d6c-45ed-bc58-28b17e8a213d.jpg?1",
             "name": "Gearseeker Serpent",
             "text": "This spell costs {1} less to cast for each artifact you control.\n{5}{U}: Gearseeker Serpent can't be blocked this turn.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "229a71af-2a40-51af-b570-815b6762f904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c0b9b-3c92-44b3-90b4-a725c7b68a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554c0b9b-3c92-44b3-90b4-a725c7b68a73.jpg?1",
             "name": "Gearsmith Prodigy",
             "text": "Gearsmith Prodigy gets +1/+0 as long as you control an artifact.",
             "colours": [
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "2853268c-94b5-57a8-8fe7-72d05c3710c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4264fa-11cb-4d3c-9a8e-c2e18829ddb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4264fa-11cb-4d3c-9a8e-c2e18829ddb0.jpg?1",
             "name": "Gigantoplasm",
             "text": "You may have Gigantoplasm enter the battlefield as a copy of any creature on the battlefield, except it has \"{X}: This creature has base power and toughness X/X.\"",
             "colours": [
@@ -10114,7 +10114,7 @@
         },
         {
             "id": "85eceee4-a65b-58af-908b-eba4fdccb079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6696207-cc2e-4b7a-8992-5101ded5c51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6696207-cc2e-4b7a-8992-5101ded5c51f.jpg?1",
             "name": "Glen Elendra Pranksters",
             "text": "Flying\nWhenever you cast a spell during an opponent's turn, you may return target creature you control to its owner's hand.",
             "colours": [
@@ -10148,7 +10148,7 @@
         },
         {
             "id": "8b9e769c-2620-5ce4-975b-182250bc11a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ef0d68-d9bb-4a46-a063-332d4bd4cf73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ef0d68-d9bb-4a46-a063-332d4bd4cf73.jpg?1",
             "name": "Harbinger of the Tides",
             "text": "You may cast Harbinger of the Tides as though it had flash if you pay {2} more to cast it.\nWhen Harbinger of the Tides enters the battlefield, you may return target tapped creature an opponent controls to its owner's hand.",
             "colours": [
@@ -10182,7 +10182,7 @@
         },
         {
             "id": "a656bf3b-4450-5fc0-92b9-39001de4ab91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbaf939-e475-4fb6-b5cd-440632bba505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbaf939-e475-4fb6-b5cd-440632bba505.jpg?1",
             "name": "Hieroglyphic Illumination",
             "text": "Draw two cards.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [
@@ -10213,7 +10213,7 @@
         },
         {
             "id": "8be7ff92-e2ca-5f33-97b7-0e141ee87c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a4bbc-660f-442b-9300-69c4141348f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a4bbc-660f-442b-9300-69c4141348f6.jpg?1",
             "name": "Icebind Pillar",
             "text": "{S}, {T}: Tap target artifact or creature. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -10246,7 +10246,7 @@
         },
         {
             "id": "2fd2c443-6ecd-51ee-a279-2688e7d3554c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc72645-d2c3-40cd-81d7-77142e495c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc72645-d2c3-40cd-81d7-77142e495c8d.jpg?1",
             "name": "Interpret the Signs",
             "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's mana value. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -10277,7 +10277,7 @@
         },
         {
             "id": "0578dd86-8a51-5655-b544-7032a183f515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b870094-08bf-41fc-b9d6-e435e02dc4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b870094-08bf-41fc-b9d6-e435e02dc4e0.jpg?1",
             "name": "Jace, Arcane Strategist",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on target creature you control.\n+1: Draw a card.\n\u22127: Creatures you control can't be blocked this turn.",
             "colours": [
@@ -10312,7 +10312,7 @@
         },
         {
             "id": "aecd6a26-7a82-5658-b8d3-a41d22e7cdaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e8e533-350b-4558-98d3-b7fcab3770f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e8e533-350b-4558-98d3-b7fcab3770f5.jpg?1",
             "name": "Jace's Scrutiny",
             "text": "Target creature gets -4/-0 until end of turn.\nInvestigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -10343,7 +10343,7 @@
         },
         {
             "id": "82accfdb-83ef-5231-b73a-1ddfa4a13a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d2ab42-8178-4a6d-9605-976a430491ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d2ab42-8178-4a6d-9605-976a430491ef.jpg?1",
             "name": "Lay Claim",
             "text": "Enchant permanent\nYou control enchanted permanent.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -10376,7 +10376,7 @@
         },
         {
             "id": "3bf0f655-4e32-5523-b715-77e2647db61c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e30459a-4114-4074-a70f-615d84e75a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e30459a-4114-4074-a70f-615d84e75a61.jpg?1",
             "name": "Leave in the Dust",
             "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
             "colours": [
@@ -10407,7 +10407,7 @@
         },
         {
             "id": "0cad779f-bec8-5740-9dbf-43111e7c01ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3287f1-aaef-4db2-bed6-63fc7dfa39c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3287f1-aaef-4db2-bed6-63fc7dfa39c7.jpg?1",
             "name": "Library Larcenist",
             "text": "Whenever Library Larcenist attacks, draw a card.",
             "colours": [
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "9795b56e-d87f-5bca-a990-fafd3aa04383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209a1c1e-7fe8-42b4-81d7-3ad0d14f0549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209a1c1e-7fe8-42b4-81d7-3ad0d14f0549.jpg?1",
             "name": "Littjara Kinseekers",
             "text": "Changeling (This card is every creature type.)\nWhen Littjara Kinseekers enters the battlefield, if you control three or more creatures that share a creature type, put a +1/+1 counter on Littjara Kinseekers, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -10474,7 +10474,7 @@
         },
         {
             "id": "95447692-0930-5a76-a3d9-030d08b668f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7f1f29-dabb-4887-8930-30c9dc797a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e7f1f29-dabb-4887-8930-30c9dc797a31.jpg?1",
             "name": "Lookout's Dispersal",
             "text": "This spell costs {1} less to cast if you control a Pirate.\nCounter target spell unless its controller pays {4}.",
             "colours": [
@@ -10505,7 +10505,7 @@
         },
         {
             "id": "8a299fcf-5d6a-581d-943b-6f0666751eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8763fe5-ae09-48c9-ada6-0b05f3c0adc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8763fe5-ae09-48c9-ada6-0b05f3c0adc3.jpg?1",
             "name": "Lumengrid Sentinel",
             "text": "Flying\nWhenever an artifact enters the battlefield under your control, you may tap target permanent.",
             "colours": [
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "b86199d2-e69f-5da4-9d5c-269c0170e13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de64b61-4fb7-4e01-8c30-626b8650325c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de64b61-4fb7-4e01-8c30-626b8650325c.jpg?1",
             "name": "Mantle of Tides",
             "text": "Equipped creature gets +1/+2.\nWhenever you draw your second card each turn, attach Mantle of Tides to target creature you control.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -10572,7 +10572,7 @@
         },
         {
             "id": "82a99308-78ac-597c-b431-75a72f4bc481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8538685-e36b-43ee-b756-7a89bc24f330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8538685-e36b-43ee-b756-7a89bc24f330.jpg?1",
             "name": "Marit Lage's Slumber",
             "text": "Whenever Marit Lage's Slumber or another snow permanent enters the battlefield under your control, scry 1.\nAt the beginning of your upkeep, if you control ten or more snow permanents, sacrifice Marit Lage's Slumber. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [
@@ -10606,7 +10606,7 @@
         },
         {
             "id": "d0ac929c-b7ba-5acb-bd98-bdeef2fc701e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a954372-7bd9-4af8-bef4-91035ba2bd6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a954372-7bd9-4af8-bef4-91035ba2bd6b.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "25909400-ac56-5b36-9e3d-e6d655a5cbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6436ac-e129-461c-a40d-9388ec7a0d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6436ac-e129-461c-a40d-9388ec7a0d27.jpg?1",
             "name": "Merfolk Sovereign",
             "text": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature can't be blocked this turn.",
             "colours": [
@@ -10673,7 +10673,7 @@
         },
         {
             "id": "e472ba35-d0ad-5dca-9fce-09b007979edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7d0a1e-4d80-4ae5-be07-38ab6d48df36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7d0a1e-4d80-4ae5-be07-38ab6d48df36.jpg?1",
             "name": "Military Intelligence",
             "text": "Whenever you attack with two or more creatures, draw a card.",
             "colours": [
@@ -10704,7 +10704,7 @@
         },
         {
             "id": "8313c0ff-6b87-5b92-baa3-aa60b3cd8c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397551c-5609-4353-aa43-504af1b27f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397551c-5609-4353-aa43-504af1b27f5a.jpg?1",
             "name": "Mistwalker",
             "text": "Changeling (This card is every creature type.)\nFlying\n{1}{U}: Mistwalker gets +1/-1 until end of turn.",
             "colours": [
@@ -10737,7 +10737,7 @@
         },
         {
             "id": "f57e944e-9f42-5610-8dcc-294717970d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a67010c-9136-48cf-b12a-0032e4e5ec2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a67010c-9136-48cf-b12a-0032e4e5ec2c.jpg?1",
             "name": "Moonfolk Puzzlemaker",
             "text": "Flying\nWhenever Moonfolk Puzzlemaker becomes tapped, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "1f4fa8f4-8f6c-5d76-96a4-ae823be667ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b23e7-4f4c-46bc-a512-4e2e6ff303cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b23e7-4f4c-46bc-a512-4e2e6ff303cd.jpg?1",
             "name": "Multiple Choice",
             "text": "If X is 1, scry 1, then draw a card.\nIf X is 2, you may choose a player. They return a creature they control to its owner's hand.\nIf X is 3, create a 4/4 blue and red Elemental creature token.\nIf X is 4 or more, do all of the above.",
             "colours": [
@@ -10803,7 +10803,7 @@
         },
         {
             "id": "fdcb9f4d-80c6-5067-8eaa-9cd993d4e843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c18de8-4448-4c32-8161-dc23ab237880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c18de8-4448-4c32-8161-dc23ab237880.jpg?1",
             "name": "Mystic Skyfish",
             "text": "Whenever you draw your second card each turn, Mystic Skyfish gains flying until end of turn.",
             "colours": [
@@ -10836,7 +10836,7 @@
         },
         {
             "id": "15385700-2e7b-5d07-a200-ca01a2b074d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a897be4-95e2-4fab-bd08-565afe19533b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a897be4-95e2-4fab-bd08-565afe19533b.jpg?1",
             "name": "Neutralize",
             "text": "Counter target spell.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -10867,7 +10867,7 @@
         },
         {
             "id": "6165f216-7b9a-5eca-8c66-a5424514cdb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc8b95e-250d-432c-968c-1bc81a15716e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc8b95e-250d-432c-968c-1bc81a15716e.jpg?1",
             "name": "No Escape",
             "text": "Counter target creature or planeswalker spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "1e6bdcc8-fa69-5977-81e9-cc05f15bff45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84622757-064b-4323-b4ea-0a87084f57cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84622757-064b-4323-b4ea-0a87084f57cd.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -10931,7 +10931,7 @@
         },
         {
             "id": "c399342e-85f4-54a3-a7ee-1dc176a2d7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a897196-85d0-4e49-a617-b30fb33b145a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a897196-85d0-4e49-a617-b30fb33b145a.jpg?1",
             "name": "One With the Wind",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -10964,7 +10964,7 @@
         },
         {
             "id": "c634c8bf-0eb3-5006-b4ae-7d4a846fc6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67084738-bfda-4996-906e-5a0b0bae5de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67084738-bfda-4996-906e-5a0b0bae5de3.jpg?1",
             "name": "Oneirophage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on Oneirophage.",
             "colours": [
@@ -10998,7 +10998,7 @@
         },
         {
             "id": "cbab3661-e669-5158-a5a3-ce6e776c9127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f63d984-5638-4167-a7ba-1ac2454df8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f63d984-5638-4167-a7ba-1ac2454df8a5.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -11029,7 +11029,7 @@
         },
         {
             "id": "3e88f1d0-684a-5b7b-aea3-f830e7e96f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788cc7f3-f688-472e-a784-aabf7bc8c1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788cc7f3-f688-472e-a784-aabf7bc8c1ea.jpg?1",
             "name": "Overwhelmed Apprentice",
             "text": "When Overwhelmed Apprentice enters the battlefield, each opponent mills two cards. Then you scry 2. (To mill a card, a player puts the top card of their library into their graveyard. To scry 2, look at the top two cards card of your library, then then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11063,7 +11063,7 @@
         },
         {
             "id": "7eeb64bf-cbde-5355-ab3f-364821e0e082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a07251-005c-4f09-8310-a934e3b9d5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a07251-005c-4f09-8310-a934e3b9d5c1.jpg?1",
             "name": "Perilous Voyage",
             "text": "Return target nonland permanent you don't control to its owner's hand. If its mana value was 2 or less, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11094,7 +11094,7 @@
         },
         {
             "id": "8d1bcc7c-e0f9-526c-8850-07ec1cbea13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c961027c-b311-48f2-9fbc-3882ad6f0fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c961027c-b311-48f2-9fbc-3882ad6f0fe6.jpg?1",
             "name": "Pestermite",
             "text": "Flash\nFlying\nWhen Pestermite enters the battlefield, you may tap or untap target permanent.",
             "colours": [
@@ -11128,7 +11128,7 @@
         },
         {
             "id": "8732ddf0-80ed-5239-88a2-342fdf0267a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d98bb7-911b-410b-a4d3-54d411900717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d98bb7-911b-410b-a4d3-54d411900717.jpg?1",
             "name": "Pilfering Hawk",
             "text": "Flying\n{S}, {T}: Draw a card, then discard a card. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -11163,7 +11163,7 @@
         },
         {
             "id": "01fd6cfb-b3f3-509b-84dd-1099e7153daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7854c3f-8c89-4ac6-8cfe-3b5b3b651918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7854c3f-8c89-4ac6-8cfe-3b5b3b651918.jpg?1",
             "name": "Press for Answers",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "cdcabf2c-17de-5504-8fba-86d1124f1d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc02d1-6203-47ee-b834-29f9fd9edb83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecc02d1-6203-47ee-b834-29f9fd9edb83.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -11228,7 +11228,7 @@
         },
         {
             "id": "7b9b49d0-8cf2-5354-89e6-50a132f9cbe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac32ebc-c7c6-49fd-a2e3-1ace1bc979ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac32ebc-c7c6-49fd-a2e3-1ace1bc979ae.jpg?1",
             "name": "River Sneak",
             "text": "River Sneak can't be blocked.\nWhenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.",
             "colours": [
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "bf7fba4f-8746-5946-88db-3ab10f397875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0d5c00-0936-445b-8a97-235aec4159b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0d5c00-0936-445b-8a97-235aec4159b3.jpg?1",
             "name": "Sage of the Falls",
             "text": "Whenever Sage of the Falls or another non-Human creature enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "69879e9e-a05b-5be6-ba43-9a1dea89d203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5c9852-bd90-42fd-bf8f-87e131c96461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5c9852-bd90-42fd-bf8f-87e131c96461.jpg?1",
             "name": "Sage's Row Savant",
             "text": "When Sage's Row Savant enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11330,7 +11330,7 @@
         },
         {
             "id": "18f3ebd0-d154-5485-8127-343c06e52bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f660ef24-5cdc-4757-b972-0ea94bb6e074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f660ef24-5cdc-4757-b972-0ea94bb6e074.jpg?1",
             "name": "Saltwater Stalwart",
             "text": "Whenever Saltwater Stalwart deals damage to an opponent, target player draws a card.",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "33721431-3da2-5f01-b66e-4174c6dacdc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479aff39-d9b0-411d-bcc5-a4d1d495f11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479aff39-d9b0-411d-bcc5-a4d1d495f11c.jpg?1",
             "name": "Seafloor Oracle",
             "text": "Whenever a Merfolk you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -11398,7 +11398,7 @@
         },
         {
             "id": "1d41c42c-5a13-5993-b556-bcc23f8cd232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccd614d-f57b-413f-9177-830964a65150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccd614d-f57b-413f-9177-830964a65150.jpg?1",
             "name": "Sentinels of Glen Elendra",
             "text": "Flash\nFlying",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "a1bb9963-2adc-5b69-8772-84118d33f506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44d8329-fe4c-4102-a5ee-3c058b84e315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44d8329-fe4c-4102-a5ee-3c058b84e315.jpg?1",
             "name": "Serum Visions",
             "text": "Draw a card. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -11463,7 +11463,7 @@
         },
         {
             "id": "d8493987-e7cb-5140-bf12-24c676a5a61c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95febc2d-e12c-41fa-9e21-be775d5ca164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95febc2d-e12c-41fa-9e21-be775d5ca164.jpg?1",
             "name": "Shaper Apprentice",
             "text": "Shaper Apprentice has flying as long as you control another Merfolk.",
             "colours": [
@@ -11497,7 +11497,7 @@
         },
         {
             "id": "9462d0e7-b0fd-5210-8baf-a3ea4ca279c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4de1a9-18c2-4dcd-9377-e8dc6ac6190c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4de1a9-18c2-4dcd-9377-e8dc6ac6190c.jpg?1",
             "name": "Shimmer Dragon",
             "text": "Flying\nAs long as you control four or more artifacts, Shimmer Dragon has hexproof.\nTap two untapped artifacts you control: Draw a card.",
             "colours": [
@@ -11530,7 +11530,7 @@
         },
         {
             "id": "c2428f7f-348e-52a8-aba6-d83c12a31cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86625fda-c9aa-44ec-874b-351d66012b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86625fda-c9aa-44ec-874b-351d66012b66.jpg?1",
             "name": "Skilled Animator",
             "text": "When Skilled Animator enters the battlefield, target artifact you control becomes an artifact creature with base power and toughness 5/5 for as long as Skilled Animator remains on the battlefield.",
             "colours": [
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "60fe4891-7802-5b83-b785-273789601287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f13eb3-4f41-4b42-b5c9-e3b5a25b722f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f13eb3-4f41-4b42-b5c9-e3b5a25b722f.jpg?1",
             "name": "So Tiny",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-0. It gets -6/-0 instead as long as its controller has seven or more cards in their graveyard.",
             "colours": [
@@ -11597,7 +11597,7 @@
         },
         {
             "id": "b6027553-fa5c-5f34-b841-64ec483fac45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4858a8d-a31a-471f-a740-6c6774ec7dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4858a8d-a31a-471f-a740-6c6774ec7dac.jpg?1",
             "name": "Startling Development",
             "text": "Until end of turn, target creature becomes a blue Serpent with base power and toughness 4/4.\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -11628,7 +11628,7 @@
         },
         {
             "id": "00b588b6-ce9e-5c09-9ec4-eaefe0f92918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bce8db-803b-4eda-af98-e131d39525ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bce8db-803b-4eda-af98-e131d39525ec.jpg?1",
             "name": "Steelgaze Griffin",
             "text": "Flying\nWhenever you draw your second card each turn, Steelgaze Griffin gets +2/+0 until end of turn.",
             "colours": [
@@ -11661,7 +11661,7 @@
         },
         {
             "id": "fed53c1f-7daa-5a34-b8cd-6ab35a6539e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fc6a86-d778-4407-8db2-1c15ce827e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fc6a86-d778-4407-8db2-1c15ce827e01.jpg?1",
             "name": "Stinging Lionfish",
             "text": "Whenever you cast your first spell during each opponent's turn, you may tap or untap target nonland permanent.",
             "colours": [
@@ -11695,7 +11695,7 @@
         },
         {
             "id": "3e332f0a-75c0-547d-94f6-f15c87d491d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d00b7-af88-483c-a209-6dde97d6e3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d00b7-af88-483c-a209-6dde97d6e3c8.jpg?1",
             "name": "Stolen by the Fae",
             "text": "Return target creature with mana value X to its owner's hand. You create X 1/1 blue Faerie creature tokens with flying.",
             "colours": [
@@ -11726,7 +11726,7 @@
         },
         {
             "id": "c5b64e78-6bab-59c0-9e08-38aed8ebf3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef312a-43c4-43cc-a7bb-942c580e9aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef312a-43c4-43cc-a7bb-942c580e9aef.jpg?1",
             "name": "Stonybrook Angler",
             "text": "{1}{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -11760,7 +11760,7 @@
         },
         {
             "id": "0c049e4f-b46b-5459-9875-76eaea53c39b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18b6d8d-5226-414b-a000-3e9e02d76980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18b6d8d-5226-414b-a000-3e9e02d76980.jpg?1",
             "name": "Storm Sculptor",
             "text": "Storm Sculptor can't be blocked.\nWhen Storm Sculptor enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -11794,7 +11794,7 @@
         },
         {
             "id": "c8d92935-a9fa-5604-a0d2-be60eff31116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7369d6-54bb-4070-b5fb-fd6fe5886820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7369d6-54bb-4070-b5fb-fd6fe5886820.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}. (Whenever another Merfolk you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "0e3d2337-87ee-5191-b44d-c6c65bd5e329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2b141-b7bb-4033-aed8-a521fcd76d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2b141-b7bb-4033-aed8-a521fcd76d4f.jpg?1",
             "name": "Syr Elenora, the Discerning",
             "text": "Syr Elenora, the Discerning's power is equal to the number of cards in your hand.\nWhen Syr Elenora enters the battlefield, draw a card.\nSpells your opponents cast that target Syr Elenora cost {2} more to cast.",
             "colours": [
@@ -11866,7 +11866,7 @@
         },
         {
             "id": "65fadea0-861f-56ce-86cf-77c9ca552e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f635017-d773-46ce-aecd-39f6e00430d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f635017-d773-46ce-aecd-39f6e00430d0.jpg?1",
             "name": "Tamiyo, the Moon Sage",
             "text": "+1: Tap target permanent. It doesn't untap during its controller's next untap step.\n\u22122: Draw a card for each tapped creature target player controls.\n\u22128: You get an emblem with \"You have no maximum hand size\" and \"Whenever a card is put into your graveyard from anywhere, you may return it to your hand.\"",
             "colours": [
@@ -11901,7 +11901,7 @@
         },
         {
             "id": "30fdf9cb-bab3-5c81-aa76-448fa45711f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662ccce8-c49a-4890-a725-fe01733d07f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662ccce8-c49a-4890-a725-fe01733d07f3.jpg?1",
             "name": "Teferi's Protege",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "a2591dfc-b6eb-5b5a-b81d-113dd872ad47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03fbb-10e9-4bf8-8fd3-e99e8c1cd84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03fbb-10e9-4bf8-8fd3-e99e8c1cd84f.jpg?1",
             "name": "Tezzeret, Artifice Master",
             "text": "+1: Create a 1/1 colorless Thopter artifact creature token with flying.\n0: Draw a card. If you control three or more artifacts, draw two cards instead.\n\u22129: You get an emblem with \"At the beginning of your end step, search your library for a permanent card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -11970,7 +11970,7 @@
         },
         {
             "id": "a1bc75d7-a8b8-5fe2-bab7-bbada1b41f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc605d26-417f-4ef6-a3c4-8482ea05ee12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc605d26-417f-4ef6-a3c4-8482ea05ee12.jpg?1",
             "name": "Thopter Spy Network",
             "text": "At the beginning of your upkeep, if you control an artifact, create a 1/1 colorless Thopter artifact creature token with flying.\nWhenever one or more artifact creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -12001,7 +12001,7 @@
         },
         {
             "id": "9d98a293-7e65-509b-8cc9-8b933a314f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc11641f-a3bd-4282-8c86-fafa63d2d6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc11641f-a3bd-4282-8c86-fafa63d2d6ab.jpg?1",
             "name": "Tolarian Kraken",
             "text": "Whenever you draw a card, you may pay {1}. When you do, you may tap or untap target creature.",
             "colours": [
@@ -12034,7 +12034,7 @@
         },
         {
             "id": "71a6c4cb-f822-5112-8b4c-02669db4f055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92867aa1-698d-47cf-bed7-b758a2cc0e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92867aa1-698d-47cf-bed7-b758a2cc0e5d.jpg?1",
             "name": "Tolarian Sentinel",
             "text": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -12068,7 +12068,7 @@
         },
         {
             "id": "09751ab8-a6a5-59f5-a73c-676a9dca4a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bab5274-99e0-458b-afd5-fe8fb2a753d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bab5274-99e0-458b-afd5-fe8fb2a753d6.jpg?1",
             "name": "Tome Anima",
             "text": "Tome Anima can't be blocked as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -12101,7 +12101,7 @@
         },
         {
             "id": "dc37e8eb-dc0e-5362-b036-4881d2a55fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5213d8-2848-4cb3-b05e-226e08676b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5213d8-2848-4cb3-b05e-226e08676b18.jpg?1",
             "name": "Triton Shorestalker",
             "text": "Triton Shorestalker can't be blocked.",
             "colours": [
@@ -12135,7 +12135,7 @@
         },
         {
             "id": "63c4e1f7-9b64-56e4-a764-ca9342131d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68eb319b-e455-4803-8884-3b28d207ead0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68eb319b-e455-4803-8884-3b28d207ead0.jpg?1",
             "name": "Undersea Invader",
             "text": "Flash\nUndersea Invader enters the battlefield tapped.",
             "colours": [
@@ -12169,7 +12169,7 @@
         },
         {
             "id": "c78c5f8d-55bc-5d63-ba1b-e2308ac5127d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46f0f64-4c1d-4a65-af67-a675c34119f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46f0f64-4c1d-4a65-af67-a675c34119f1.jpg?1",
             "name": "Vedalken Engineer",
             "text": "{T}: Add two mana of any one color. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -12203,7 +12203,7 @@
         },
         {
             "id": "6c38a506-d719-5d7e-856f-b7cc25a7b5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0208c551-a4de-43c7-bd4c-12d24ae179c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0208c551-a4de-43c7-bd4c-12d24ae179c1.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of their library, then draws a card.",
             "colours": [
@@ -12239,7 +12239,7 @@
         },
         {
             "id": "2abe056e-ffe1-5c46-81c7-e4f6772141db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606ffebe-1b17-4770-ab0c-f57ae549fc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606ffebe-1b17-4770-ab0c-f57ae549fc3f.jpg?1",
             "name": "Wake Thrasher",
             "text": "Whenever a permanent you control becomes untapped, Wake Thrasher gets +1/+1 until end of turn.",
             "colours": [
@@ -12273,7 +12273,7 @@
         },
         {
             "id": "6c43149a-ed5d-5a84-9532-de6a3bba4efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42adbafd-1f0d-46b0-a1a5-07c2e2ef41e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42adbafd-1f0d-46b0-a1a5-07c2e2ef41e6.jpg?1",
             "name": "Watertrap Weaver",
             "text": "When Watertrap Weaver enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -12307,7 +12307,7 @@
         },
         {
             "id": "284ecf46-d0a3-5797-852e-e3db427327c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0b6f3-d2c7-441a-9b8f-3269d196a106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d0b6f3-d2c7-441a-9b8f-3269d196a106.jpg?1",
             "name": "Wavebreak Hippocamp",
             "text": "Whenever you cast your first spell during each opponent's turn, draw a card.",
             "colours": [
@@ -12342,7 +12342,7 @@
         },
         {
             "id": "2897425c-bae4-54db-9e9f-5c7ff88203ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2494e2a-847a-4605-80dd-a5a6ce80abf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2494e2a-847a-4605-80dd-a5a6ce80abf5.jpg?1",
             "name": "Weldfast Wingsmith",
             "text": "Whenever an artifact enters the battlefield under your control, Weldfast Wingsmith gains flying until end of turn.",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "d74e9278-8044-55c2-911c-caa64c2dc261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9978703f-30bc-4126-a8e5-e7fcb654956c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9978703f-30bc-4126-a8e5-e7fcb654956c.jpg?1",
             "name": "Windrider Patrol",
             "text": "Flying\nWhenever Windrider Patrol deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "b78d5c85-54ad-5d57-bfa1-c12289440bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4a71ea-ac26-4f61-96fc-bb7152cb5341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4a71ea-ac26-4f61-96fc-bb7152cb5341.jpg?1",
             "name": "Winter's Rest",
             "text": "Enchant creature\nWhen Winter's Rest enters the battlefield, tap enchanted creature.\nAs long as you control another snow permanent, enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -12445,7 +12445,7 @@
         },
         {
             "id": "a5a9c075-985c-5cf1-9661-a170696ec67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b168d5-b111-4a1c-a4b8-d3cd376bfa3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b168d5-b111-4a1c-a4b8-d3cd376bfa3b.jpg?1",
             "name": "Alley Strangler",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -12479,7 +12479,7 @@
         },
         {
             "id": "ec7289bc-b92f-5163-8e51-51c83af71963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a46159-2a91-4c89-87d7-13b52bfb0fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a46159-2a91-4c89-87d7-13b52bfb0fdf.jpg?1",
             "name": "Ancient Craving",
             "text": "You draw three cards and you lose 3 life.",
             "colours": [
@@ -12510,7 +12510,7 @@
         },
         {
             "id": "03f77afc-d055-559a-89b2-de199cb8f083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ede129-83fc-42b7-8941-fa649d3329e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ede129-83fc-42b7-8941-fa649d3329e5.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "f8740c1c-247b-5815-b4b2-384b96bf4c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8458f030-f333-486e-8b52-b7422c1ff059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8458f030-f333-486e-8b52-b7422c1ff059.jpg?1",
             "name": "Blight Keeper",
             "text": "Flying\n{7}{B}, {T}, Sacrifice Blight Keeper: Target opponent loses 4 life and you gain 4 life.",
             "colours": [
@@ -12578,7 +12578,7 @@
         },
         {
             "id": "b4045dd8-7e5b-5c71-9cd3-1cdf0d791be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53782723-0a1e-483f-86e0-9a13650d29b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53782723-0a1e-483f-86e0-9a13650d29b7.jpg?1",
             "name": "Blood Price",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order. You lose 2 life.",
             "colours": [
@@ -12609,7 +12609,7 @@
         },
         {
             "id": "61358ea0-9266-5fa4-a355-4a06b8195ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2937cc19-d0bb-4695-b4c1-5e72000e08b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2937cc19-d0bb-4695-b4c1-5e72000e08b4.jpg?1",
             "name": "Bloodbond Vampire",
             "text": "Whenever you gain life, put a +1/+1 counter on Bloodbond Vampire.",
             "colours": [
@@ -12644,7 +12644,7 @@
         },
         {
             "id": "e64552e5-e34d-517f-8621-10996e02168b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5196ae-2fec-43c3-b6d4-b446646438e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b5196ae-2fec-43c3-b6d4-b446646438e6.jpg?1",
             "name": "Bloodthirsty Aerialist",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on Bloodthirsty Aerialist.",
             "colours": [
@@ -12678,7 +12678,7 @@
         },
         {
             "id": "d466574f-2a9a-5e8b-bb31-2fda82afafcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73041c8a-2282-40f6-b2bf-592e8091f1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73041c8a-2282-40f6-b2bf-592e8091f1de.jpg?1",
             "name": "Bloodtracker",
             "text": "Flying\n{B}, Pay 2 life: Put a +1/+1 counter on Bloodtracker.\nWhen Bloodtracker leaves the battlefield, draw a card for each +1/+1 counter on it.",
             "colours": [
@@ -12712,7 +12712,7 @@
         },
         {
             "id": "ea7e63e3-d46d-5cf8-9f4f-ffbbfae0c0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ce1b-a28f-45d5-8643-cc4d955a2350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ce1b-a28f-45d5-8643-cc4d955a2350.jpg?1",
             "name": "Bone Picker",
             "text": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -12745,7 +12745,7 @@
         },
         {
             "id": "96bfc507-8635-51f5-8526-8a901107c15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8bb46d-acc2-4631-89c7-b92f927a5940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8bb46d-acc2-4631-89c7-b92f927a5940.jpg?1",
             "name": "Burglar Rat",
             "text": "When Burglar Rat enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -12778,7 +12778,7 @@
         },
         {
             "id": "a6d52c3b-5d5a-57d1-94a8-726c5c3761d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3897e9f-363d-42f9-85b1-28143b223b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3897e9f-363d-42f9-85b1-28143b223b08.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "1c5145d5-d038-5bf7-bc99-0e76a67a8334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe14b9b-4341-4a1b-96f1-5cb1bb253eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe14b9b-4341-4a1b-96f1-5cb1bb253eba.jpg?1",
             "name": "Certain Death",
             "text": "Destroy target creature. Its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -12840,7 +12840,7 @@
         },
         {
             "id": "b567624b-2f35-5d16-83dd-a0e5bb69ccc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9993c2-eaf7-4163-bd19-8161025cad56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9993c2-eaf7-4163-bd19-8161025cad56.jpg?1",
             "name": "Chittering Rats",
             "text": "When Chittering Rats enters the battlefield, target opponent puts a card from their hand on top of their library.",
             "colours": [
@@ -12873,7 +12873,7 @@
         },
         {
             "id": "9a28a0ed-6b92-5626-b24f-af540e0ea9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d00252-f2db-4065-8242-d4bf2b30e201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d00252-f2db-4065-8242-d4bf2b30e201.jpg?1",
             "name": "Consign to the Pit",
             "text": "Destroy target creature. Consign to the Pit deals 2 damage to that creature's controller.",
             "colours": [
@@ -12904,7 +12904,7 @@
         },
         {
             "id": "0c50e594-fd6f-5b29-8be9-ee9d32c88458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135d748-0da5-4ec4-a7cc-b0b731cb272c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135d748-0da5-4ec4-a7cc-b0b731cb272c.jpg?1",
             "name": "Corpse Churn",
             "text": "Mill three cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -12935,7 +12935,7 @@
         },
         {
             "id": "cf6a56a6-06ec-507b-8221-3ee6d297719c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e541e7a0-7162-482b-8c46-ad9481d24b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e541e7a0-7162-482b-8c46-ad9481d24b48.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -12969,7 +12969,7 @@
         },
         {
             "id": "c4154992-460a-5750-a97f-9a1cf7624904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b948b2a2-0864-4dd8-89f7-27a8c6748911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b948b2a2-0864-4dd8-89f7-27a8c6748911.jpg?1",
             "name": "Cruel Sadist",
             "text": "{B}, {T}, Pay 1 life: Put a +1/+1 counter on Cruel Sadist.\n{2}{B}, {T}, Remove X +1/+1 counters from Cruel Sadist: It deals X damage to target creature.",
             "colours": [
@@ -13003,7 +13003,7 @@
         },
         {
             "id": "0afa24bd-af2b-5cf4-bd77-fd53c7e28e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccdaba-7504-4df6-a079-d7fe450934ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccdaba-7504-4df6-a079-d7fe450934ab.jpg?1",
             "name": "Crypt Rats",
             "text": "{X}: Crypt Rats deals X damage to each creature and each player. Spend only black mana on X.",
             "colours": [
@@ -13036,7 +13036,7 @@
         },
         {
             "id": "ade9ef73-eeea-5160-81c1-8ec4c1bbb318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7776aa09-158a-4286-a6db-8c94cea22855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7776aa09-158a-4286-a6db-8c94cea22855.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -13069,7 +13069,7 @@
         },
         {
             "id": "e3b9711e-afa3-5d39-9c5b-69a343d5196e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829de1a5-93b9-4c5a-a47f-691a81a7b76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829de1a5-93b9-4c5a-a47f-691a81a7b76f.jpg?1",
             "name": "Death Wind",
             "text": "Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "2d5c3865-b553-5d34-a0fa-dbb7a764af5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e.jpg?1",
             "name": "Deathbloom Thallid",
             "text": "When Deathbloom Thallid dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13133,7 +13133,7 @@
         },
         {
             "id": "f44998bd-5591-5ba5-8dbd-4994e6780438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78229484-b07a-4b6c-ae27-74c7dac3d620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78229484-b07a-4b6c-ae27-74c7dac3d620.jpg?1",
             "name": "Deathbringer Regent",
             "text": "Flying\nWhen Deathbringer Regent enters the battlefield, if you cast it from your hand and there are five or more other creatures on the battlefield, destroy all other creatures.",
             "colours": [
@@ -13166,7 +13166,7 @@
         },
         {
             "id": "1427b029-5506-5ba8-a41d-699aa9887405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861100dd-376a-4a8b-862a-76ad4edda725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861100dd-376a-4a8b-862a-76ad4edda725.jpg?1",
             "name": "Demon of Catastrophes",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample",
             "colours": [
@@ -13199,7 +13199,7 @@
         },
         {
             "id": "0ea7cd86-cadd-5272-824e-fa02ac625b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6721bbf0-b268-4030-aa90-713f0e9360c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6721bbf0-b268-4030-aa90-713f0e9360c5.jpg?1",
             "name": "Demonic Gifts",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -13230,7 +13230,7 @@
         },
         {
             "id": "e0f3aa87-c7ea-5da5-8e59-1a3355ddf936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c09c4b8-dcb3-4dfe-a892-718e0d1c5a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c09c4b8-dcb3-4dfe-a892-718e0d1c5a8a.jpg?1",
             "name": "Demon's Disciple",
             "text": "When Demon's Disciple enters the battlefield, each player sacrifices a creature or planeswalker.",
             "colours": [
@@ -13264,7 +13264,7 @@
         },
         {
             "id": "4bbf6048-8156-5333-aa01-0551ab103065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305f55c-6bcf-464b-aa80-e227bf30c9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c305f55c-6bcf-464b-aa80-e227bf30c9ea.jpg?1",
             "name": "Demon's Grasp",
             "text": "Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -13295,7 +13295,7 @@
         },
         {
             "id": "fbc19476-8ab0-56ea-95f7-3d8ba94b5fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1065b467-f24b-4add-bced-1d4709df1adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1065b467-f24b-4add-bced-1d4709df1adb.jpg?1",
             "name": "Devouring Swarm",
             "text": "Flying\nSacrifice a creature: Devouring Swarm gets +1/+1 until end of turn.",
             "colours": [
@@ -13328,7 +13328,7 @@
         },
         {
             "id": "4bb91315-43d2-5f94-922e-cc8c671467b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d3ce5-3e71-44f1-ab0e-98d399287722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53d3ce5-3e71-44f1-ab0e-98d399287722.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -13361,7 +13361,7 @@
         },
         {
             "id": "d0ea4273-31ae-524a-929d-cefc44331bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98f8d65-e326-42a1-97e3-630416595eeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98f8d65-e326-42a1-97e3-630416595eeb.jpg?1",
             "name": "Dread Presence",
             "text": "Whenever a Swamp enters the battlefield under your control, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Dread Presence deals 2 damage to any target and you gain 2 life.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "03476ae9-fb22-5a36-a30c-638f408b1dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3cdb0f-3e08-47cc-841f-80f34d6cce49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3cdb0f-3e08-47cc-841f-80f34d6cce49.jpg?1",
             "name": "Dread Rider",
             "text": "{1}{B}, {T}, Exile a creature card from your graveyard: Target opponent loses 3 life.",
             "colours": [
@@ -13428,7 +13428,7 @@
         },
         {
             "id": "e9bc4f84-3eb2-5d5e-8154-4f023c1f59d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b84820d-187c-4d3b-b7a7-7999d4efe443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b84820d-187c-4d3b-b7a7-7999d4efe443.jpg?1",
             "name": "Dread Slaver",
             "text": "Whenever a creature dealt damage by Dread Slaver this turn dies, return it to the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -13462,7 +13462,7 @@
         },
         {
             "id": "ead8986f-5384-54c9-b796-414201c38968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12f259-2c62-4196-8786-dfb75b40f5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12f259-2c62-4196-8786-dfb75b40f5c0.jpg?1",
             "name": "Dreadhound",
             "text": "When Dreadhound enters the battlefield, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhenever a creature dies or a creature card is put into a graveyard from a library, each opponent loses 1 life.",
             "colours": [
@@ -13496,7 +13496,7 @@
         },
         {
             "id": "c298df8b-75a0-5656-a4c7-8d3ddfcfe87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd4f7da-5200-4c1b-8c42-95d601952995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd4f7da-5200-4c1b-8c42-95d601952995.jpg?1",
             "name": "Dune Beetle",
             "text": "",
             "colours": [
@@ -13529,7 +13529,7 @@
         },
         {
             "id": "04f34648-9e22-582f-89fa-245ef8446821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58725475-ff77-4511-9797-c44b0fa9909d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58725475-ff77-4511-9797-c44b0fa9909d.jpg?1",
             "name": "Durable Coilbug",
             "text": "{4}{B}: Return Durable Coilbug from your graveyard to your hand.",
             "colours": [
@@ -13562,7 +13562,7 @@
         },
         {
             "id": "a630b9df-8644-5563-93d5-c2663c75bafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73686b22-0ef3-41b6-a7d4-a226bde458c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73686b22-0ef3-41b6-a7d4-a226bde458c0.jpg?1",
             "name": "Eaten Alive",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nExile target creature or planeswalker.",
             "colours": [
@@ -13593,7 +13593,7 @@
         },
         {
             "id": "a32bf872-7776-57ed-a017-5396f701c972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920b00c-d4ed-4d21-abfa-da270a1ae94f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920b00c-d4ed-4d21-abfa-da270a1ae94f.jpg?1",
             "name": "Endless Ranks of the Dead",
             "text": "At the beginning of your upkeep, create X 2/2 black Zombie creature tokens, where X is half the number of Zombies you control, rounded down.",
             "colours": [
@@ -13624,7 +13624,7 @@
         },
         {
             "id": "1902ba46-f5b2-5812-b82f-19280698a93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f71ff90-13ff-4ac6-8bdd-2cf53cc24ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f71ff90-13ff-4ac6-8bdd-2cf53cc24ec1.jpg?1",
             "name": "Epicure of Blood",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -13657,7 +13657,7 @@
         },
         {
             "id": "8ef62094-5b9c-5128-ab88-1bb62be5fb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e215786-5c2a-4f08-afab-78342ad8fa17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e215786-5c2a-4f08-afab-78342ad8fa17.jpg?1",
             "name": "Eviscerate",
             "text": "Destroy target creature.",
             "colours": [
@@ -13688,7 +13688,7 @@
         },
         {
             "id": "7c4936d3-468c-57a7-9cba-9e9d34a1335a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ffebc3-8ad4-42da-b4f2-837ae22dee72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ffebc3-8ad4-42da-b4f2-837ae22dee72.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -13719,7 +13719,7 @@
         },
         {
             "id": "7a52c6b4-f8af-5d4d-b6ae-ce659615b43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b55746e-28b3-4446-a695-2711836ab1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b55746e-28b3-4446-a695-2711836ab1b6.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -13753,7 +13753,7 @@
         },
         {
             "id": "e0d44a5b-7af0-5501-abc4-b369a37f971d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3353a2-b443-4084-b43f-0ff3a22b26c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3353a2-b443-4084-b43f-0ff3a22b26c1.jpg?1",
             "name": "Fetid Imp",
             "text": "Flying\n{B}: Fetid Imp gains deathtouch until end of turn.",
             "colours": [
@@ -13786,7 +13786,7 @@
         },
         {
             "id": "78567cff-7fba-5dc5-8e14-6c17295791bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727a589a-2248-478f-825f-932bfb456675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/727a589a-2248-478f-825f-932bfb456675.jpg?1",
             "name": "Fungal Infection",
             "text": "Target creature gets -1/-1 until end of turn. Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13817,7 +13817,7 @@
         },
         {
             "id": "9cf79cfb-876e-51d3-a5eb-ae0c2324c558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d8209-cd48-465b-8f39-f337e0e0a820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d8209-cd48-465b-8f39-f337e0e0a820.jpg?1",
             "name": "Gavony Unhallowed",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Gavony Unhallowed.",
             "colours": [
@@ -13850,7 +13850,7 @@
         },
         {
             "id": "0f059647-2236-5fe5-a236-20a7a00fce4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc0588-6feb-475c-817d-c71385419cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fc0588-6feb-475c-817d-c71385419cac.jpg?1",
             "name": "Ghoulraiser",
             "text": "When Ghoulraiser enters the battlefield, return a Zombie card at random from your graveyard to your hand.",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "e48b753a-12c1-5c26-994d-a22c7b28d793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d82703-20a5-4e81-a396-c5e22655b8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d82703-20a5-4e81-a396-c5e22655b8ba.jpg?1",
             "name": "Gnawing Zombie",
             "text": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -13916,7 +13916,7 @@
         },
         {
             "id": "654e6d8e-0964-5e37-a8b0-626bd5df8a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06488720-9875-483a-b163-f620692ef627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06488720-9875-483a-b163-f620692ef627.jpg?1",
             "name": "Gorging Vulture",
             "text": "Flying\nWhen Gorging Vulture enters the battlefield, mill four cards. You gain 1 life for each creature card milled this way. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -13949,7 +13949,7 @@
         },
         {
             "id": "93d84038-7d56-50dd-8f16-64431ffc16ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f2413f-987f-4eab-96c1-f662821546a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f2413f-987f-4eab-96c1-f662821546a5.jpg?1",
             "name": "Graf Harvest",
             "text": "Zombies you control have menace. (They can't be blocked except by two or more creatures.)\n{3}{B}, Exile a creature card from your graveyard: Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "cce2729d-f845-5fe5-8343-9174c44b3e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5c03c6-123b-4d4d-878e-0158659bf27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5c03c6-123b-4d4d-878e-0158659bf27b.jpg?1",
             "name": "Graveblade Marauder",
             "text": "Deathtouch\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -14014,7 +14014,7 @@
         },
         {
             "id": "66f62828-b89c-562c-b484-3449d5eae0da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128351fb-2ce0-4439-982a-9cc741936992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128351fb-2ce0-4439-982a-9cc741936992.jpg?1",
             "name": "Gravecrawler",
             "text": "Gravecrawler can't block.\nYou may cast Gravecrawler from your graveyard as long as you control a Zombie.",
             "colours": [
@@ -14047,7 +14047,7 @@
         },
         {
             "id": "f6c37f61-2593-590a-aa59-404065242cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80467e94-81b3-4b2f-865d-69e3d531e845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80467e94-81b3-4b2f-865d-69e3d531e845.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -14080,7 +14080,7 @@
         },
         {
             "id": "49562caa-a866-5fcd-aed7-031d9e6437d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db61b56-6bfb-448f-ae6d-932d96760917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db61b56-6bfb-448f-ae6d-932d96760917.jpg?1",
             "name": "Grotesque Mutation",
             "text": "Target creature gets +3/+1 and gains lifelink until end of turn.",
             "colours": [
@@ -14111,7 +14111,7 @@
         },
         {
             "id": "2f6581c7-81a0-5f49-8b27-06925d89b5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a8a789-cda2-4ef6-b82a-7e46d609c835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a8a789-cda2-4ef6-b82a-7e46d609c835.jpg?1",
             "name": "Hooded Assassin",
             "text": "When Hooded Assassin enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Hooded Assassin.\n\u2022 Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -14145,7 +14145,7 @@
         },
         {
             "id": "d6e62bcc-f651-55d7-9e84-56c6ad7b8a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc24cd32-e275-4fc1-9fde-834db4564663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc24cd32-e275-4fc1-9fde-834db4564663.jpg?1",
             "name": "Ill-Gotten Inheritance",
             "text": "At the beginning of your upkeep, Ill-Gotten Inheritance deals 1 damage to each opponent and you gain 1 life.\n{5}{B}, Sacrifice Ill-Gotten Inheritance: It deals 4 damage to target opponent and you gain 4 life.",
             "colours": [
@@ -14176,7 +14176,7 @@
         },
         {
             "id": "c9e3acd4-f4c8-5776-8451-05037ed0df51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa312f39-8076-4ef7-8890-02c1f2771766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa312f39-8076-4ef7-8890-02c1f2771766.jpg?1",
             "name": "Inner Demon",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has flying, and is a Demon in addition to its other types.\nWhen Inner Demon enters the battlefield, all non-Demon creatures get -2/-2 until end of turn.",
             "colours": [
@@ -14209,7 +14209,7 @@
         },
         {
             "id": "331193d7-ff17-559e-af22-a97d5da846b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdadf8-d4f2-4273-b7b6-02866ba54610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdadf8-d4f2-4273-b7b6-02866ba54610.jpg?1",
             "name": "Kalastria Nightwatch",
             "text": "Whenever you gain life, Kalastria Nightwatch gains flying until end of turn.",
             "colours": [
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "848ce683-26fc-5952-898f-2e19c87c062c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2e14c7-1bee-4bc6-ad26-03dc55e149d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2e14c7-1bee-4bc6-ad26-03dc55e149d5.jpg?1",
             "name": "Karfell Kennel-Master",
             "text": "When Karfell Kennel-Master enters the battlefield, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -14278,7 +14278,7 @@
         },
         {
             "id": "3137e55f-d7cd-5feb-92a7-96ad9a4f70a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3414d-3c79-4771-a6ba-812608855922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f3414d-3c79-4771-a6ba-812608855922.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "Flying\nWhenever a permanent owned by another player is put into a graveyard from the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -14313,7 +14313,7 @@
         },
         {
             "id": "8234bdec-bc47-5a28-81df-56be04855583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5758460-d1bc-49ba-80de-c0849958f705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5758460-d1bc-49ba-80de-c0849958f705.jpg?1",
             "name": "Kraul Swarm",
             "text": "Flying\n{2}{B}, Discard a creature card: Return Kraul Swarm from your graveyard to your hand.",
             "colours": [
@@ -14347,7 +14347,7 @@
         },
         {
             "id": "c7a97583-bdc6-5e2c-aa6e-fe1e35431930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42b0052-0758-489f-b7e2-208686ad82af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42b0052-0758-489f-b7e2-208686ad82af.jpg?1",
             "name": "Liliana, Death's Majesty",
             "text": "+1: Create a 2/2 black Zombie creature token. Mill two cards.\n\u22123: Return target creature card from your graveyard to the battlefield. That creature is a black Zombie in addition to its other colors and types.\n\u22127: Destroy all non-Zombie creatures.",
             "colours": [
@@ -14382,7 +14382,7 @@
         },
         {
             "id": "3424a20a-f396-5b34-870a-0e80b388e86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f826404-3df5-4b0c-9739-837938ac8401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f826404-3df5-4b0c-9739-837938ac8401.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "6ef0926c-9ef9-5742-bfa7-f3c890d66d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28b5fce-ac73-44ec-be2c-c95d8d3579fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28b5fce-ac73-44ec-be2c-c95d8d3579fe.jpg?1",
             "name": "Liliana's Mastery",
             "text": "Zombies you control get +1/+1.\nWhen Liliana's Mastery enters the battlefield, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -14446,7 +14446,7 @@
         },
         {
             "id": "7d6753b4-9ac6-56e0-98db-7cdeec80e3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9f9747-5320-43b7-b8ca-92330be64272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9f9747-5320-43b7-b8ca-92330be64272.jpg?1",
             "name": "Liliana's Steward",
             "text": "{T}, Sacrifice Liliana's Steward: Target opponent discards a card. Activate only as a sorcery.",
             "colours": [
@@ -14479,7 +14479,7 @@
         },
         {
             "id": "1e1a46f6-08b0-52d4-bf2f-23d8713fc444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ba7512-54cc-40cc-b13a-5d8990fa33bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ba7512-54cc-40cc-b13a-5d8990fa33bc.jpg?1",
             "name": "Lurking Deadeye",
             "text": "Flash\nWhen Lurking Deadeye enters the battlefield, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -14513,7 +14513,7 @@
         },
         {
             "id": "018e7bee-4fa0-5817-8b77-4299a56649c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cce8a-43b4-42aa-abbd-0835583e74bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cce8a-43b4-42aa-abbd-0835583e74bd.jpg?1",
             "name": "Maalfeld Twins",
             "text": "When Maalfeld Twins dies, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -14546,7 +14546,7 @@
         },
         {
             "id": "783bbd0d-a8be-5cf9-bf83-80cd8de6ae06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9de75b-5295-4c7f-b149-b9cd508db1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9de75b-5295-4c7f-b149-b9cd508db1f2.jpg?1",
             "name": "Marauding Blight-Priest",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -14580,7 +14580,7 @@
         },
         {
             "id": "64eee1ee-1ec6-5400-a6fb-3533b72f33c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df47291-c285-49db-a4eb-b9a150979127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df47291-c285-49db-a4eb-b9a150979127.jpg?1",
             "name": "Marauding Boneslasher",
             "text": "Marauding Boneslasher can't block unless you control another Zombie.",
             "colours": [
@@ -14614,7 +14614,7 @@
         },
         {
             "id": "4296d634-e782-5e17-8388-a69812f18917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38fda1-8008-4b2d-a2b6-eb02a8b125e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee38fda1-8008-4b2d-a2b6-eb02a8b125e8.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -14648,7 +14648,7 @@
         },
         {
             "id": "caa106d8-27ae-5406-b07a-056e79443c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1702ed-3a74-41f4-af6d-3fda3876c221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1702ed-3a74-41f4-af6d-3fda3876c221.jpg?1",
             "name": "Mire Blight",
             "text": "Enchant creature\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -14681,7 +14681,7 @@
         },
         {
             "id": "78cc2eb2-b687-547c-9d83-25e093d7fc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56246461-67f3-46cb-a2df-ef90ea89ceb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56246461-67f3-46cb-a2df-ef90ea89ceb3.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "69d4e2e0-f5f5-5752-b693-fb73782fed02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a506f54f-b25b-4b15-99b9-cdf0af9df79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a506f54f-b25b-4b15-99b9-cdf0af9df79a.jpg?1",
             "name": "Moment of Craving",
             "text": "Target creature gets -2/-2 until end of turn. You gain 2 life.",
             "colours": [
@@ -14746,7 +14746,7 @@
         },
         {
             "id": "d352ead0-69be-5f1a-b967-7771aeee3fb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50101d86-5cda-4dbd-aa6b-c6da791ef73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50101d86-5cda-4dbd-aa6b-c6da791ef73b.jpg?1",
             "name": "Moodmark Painter",
             "text": "Undergrowth \u2014 When Moodmark Painter enters the battlefield, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -14780,7 +14780,7 @@
         },
         {
             "id": "15bef1e7-a44f-5320-afb8-73701f51ce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdec536-d233-40f1-9448-82c3c845ead6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdec536-d233-40f1-9448-82c3c845ead6.jpg?1",
             "name": "Necromancer's Stockpile",
             "text": "{1}{B}, Discard a creature card: Draw a card. If the discarded card was a Zombie card, create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -14811,7 +14811,7 @@
         },
         {
             "id": "c8d776a3-4cde-5107-8978-e7c9e8513fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4819311f-fc0a-4662-8f5b-48e2a409f1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4819311f-fc0a-4662-8f5b-48e2a409f1d5.jpg?1",
             "name": "Necrotic Wound",
             "text": "Undergrowth \u2014 Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -14842,7 +14842,7 @@
         },
         {
             "id": "3c09aa35-c8a0-5fd7-9b5f-78f7efbaead1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a296bf5f-3358-4bd1-83b0-3220aaba049f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a296bf5f-3358-4bd1-83b0-3220aaba049f.jpg?1",
             "name": "Nested Ghoul",
             "text": "Whenever a source deals damage to Nested Ghoul, create a 2/2 black Phyrexian Zombie creature token.",
             "colours": [
@@ -14877,7 +14877,7 @@
         },
         {
             "id": "2034fd28-163e-5ab1-9d86-59ece6907e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959fb12c-3ea2-4caa-80d9-2a844e83ba0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959fb12c-3ea2-4caa-80d9-2a844e83ba0f.jpg?1",
             "name": "Nirkana Assassin",
             "text": "Whenever you gain life, Nirkana Assassin gains deathtouch until end of turn.",
             "colours": [
@@ -14912,7 +14912,7 @@
         },
         {
             "id": "9025ff85-83f0-5739-a22a-5cbc4942064c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7400da3-22f2-4238-8e8a-969794790209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7400da3-22f2-4238-8e8a-969794790209.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "Whenever an opponent draws a card, Ob Nixilis, the Hate-Twisted deals 1 damage to that player.\n\u22122: Destroy target creature. Its controller draws two cards.",
             "colours": [
@@ -14947,7 +14947,7 @@
         },
         {
             "id": "afe0cd82-6cd6-56f7-b6f5-15452729975e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4832271-ba68-4bed-a0ee-9da4bc3bedaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4832271-ba68-4bed-a0ee-9da4bc3bedaa.jpg?1",
             "name": "Ob Nixilis's Cruelty",
             "text": "Target creature gets -5/-5 until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -14978,7 +14978,7 @@
         },
         {
             "id": "89d4f477-169c-506d-ad3c-9192c7c89537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44fca9-3a41-41c3-aa74-f0f5a81e8b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44fca9-3a41-41c3-aa74-f0f5a81e8b7d.jpg?1",
             "name": "Ophiomancer",
             "text": "At the beginning of each upkeep, if you control no Snakes, create a 1/1 black Snake creature token with deathtouch.",
             "colours": [
@@ -15012,7 +15012,7 @@
         },
         {
             "id": "69422ff4-d823-55d9-a896-7553767c09f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649ec97-fb5e-49ee-a15a-1acbb54344a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f649ec97-fb5e-49ee-a15a-1acbb54344a6.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15043,7 +15043,7 @@
         },
         {
             "id": "b7885367-0e55-5ba7-b040-9c34e975dd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f3efc2-2b36-4e69-8bcc-54385b78519a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f3efc2-2b36-4e69-8bcc-54385b78519a.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\n{T}, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -15077,7 +15077,7 @@
         },
         {
             "id": "250bf232-a8cd-5499-a0cd-f0b43312fe3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef90fdf-a88b-4060-85cf-e0180f685bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef90fdf-a88b-4060-85cf-e0180f685bd1.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper enters the battlefield, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15111,7 +15111,7 @@
         },
         {
             "id": "16ee9771-43a2-564a-add6-f4f51107ef8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c8cfe-79b1-463e-a0bd-5bc003ce26cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c8cfe-79b1-463e-a0bd-5bc003ce26cd.jpg?1",
             "name": "Plague Spitter",
             "text": "At the beginning of your upkeep, Plague Spitter deals 1 damage to each creature and each player.\nWhen Plague Spitter dies, it deals 1 damage to each creature and each player.",
             "colours": [
@@ -15145,7 +15145,7 @@
         },
         {
             "id": "cc17f22a-3c39-54aa-b53c-2e0d2199a803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f77674-dd03-4f19-bd87-aec2359b620e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f77674-dd03-4f19-bd87-aec2359b620e.jpg?1",
             "name": "Priest of the Blood Rite",
             "text": "When Priest of the Blood Rite enters the battlefield, create a 5/5 black Demon creature token with flying.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -15179,7 +15179,7 @@
         },
         {
             "id": "3827ebc2-eccf-5014-a86e-50ccfd5e9c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29595671-fcec-41a0-a361-91c6be3af6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29595671-fcec-41a0-a361-91c6be3af6b7.jpg?1",
             "name": "Reaper from the Abyss",
             "text": "Flying\nMorbid \u2014 At the beginning of each end step, if a creature died this turn, destroy target non-Demon creature.",
             "colours": [
@@ -15212,7 +15212,7 @@
         },
         {
             "id": "e7c8e908-3318-54cf-8423-3e44a7a3bf36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f7a6-d7ef-462c-9e6c-980c35bb81ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f1f7a6-d7ef-462c-9e6c-980c35bb81ed.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -15243,7 +15243,7 @@
         },
         {
             "id": "beafeef8-e254-5fe1-b028-316de268e7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4beadd29-e445-42f5-bf0f-75050b701b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4beadd29-e445-42f5-bf0f-75050b701b2c.jpg?1",
             "name": "Returned Reveler",
             "text": "When Returned Reveler dies, each player mills three cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -15277,7 +15277,7 @@
         },
         {
             "id": "11577ee4-3d2d-5b8d-a2b4-3cb627a209a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e36bf-021f-4a17-99a3-3e87fd7e39bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e36bf-021f-4a17-99a3-3e87fd7e39bd.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -15310,7 +15310,7 @@
         },
         {
             "id": "49d7bc1d-9a32-5cd9-8ea8-557b45c0add4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9e959-7a17-4641-aa91-f10beae99cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9e959-7a17-4641-aa91-f10beae99cdc.jpg?1",
             "name": "Ruthless Disposal",
             "text": "As an additional cost to cast this spell, discard a card and sacrifice a creature.\nTwo target creatures each get -13/-13 until end of turn.",
             "colours": [
@@ -15341,7 +15341,7 @@
         },
         {
             "id": "22e80360-0fc4-566f-842d-8ae1ae207545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690c472e-98a9-464a-84de-78dda6d111c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690c472e-98a9-464a-84de-78dda6d111c8.jpg?1",
             "name": "Seizan, Perverter of Truth",
             "text": "At the beginning of each player's upkeep, that player loses 2 life and draws two cards.",
             "colours": [
@@ -15377,7 +15377,7 @@
         },
         {
             "id": "026975c1-e081-565e-ba9c-45ce10e222fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0410803-7337-4537-bcae-e677014640d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0410803-7337-4537-bcae-e677014640d4.jpg?1",
             "name": "Shadowborn Demon",
             "text": "Flying\nWhen Shadowborn Demon enters the battlefield, destroy target non-Demon creature.\nAt the beginning of your upkeep, if there are fewer than six creature cards in your graveyard, sacrifice a creature.",
             "colours": [
@@ -15410,7 +15410,7 @@
         },
         {
             "id": "f5cfa921-5922-50d3-a152-ff78f2df5ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1258c7d4-cc4f-47c2-b346-27274bfee151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1258c7d4-cc4f-47c2-b346-27274bfee151.jpg?1",
             "name": "Shambling Ghoul",
             "text": "Shambling Ghoul enters the battlefield tapped.",
             "colours": [
@@ -15443,7 +15443,7 @@
         },
         {
             "id": "37a213a3-0714-590d-9a34-8e54394f272a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c61e2-4af4-4e19-bee6-4b8c90a33f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c61e2-4af4-4e19-bee6-4b8c90a33f03.jpg?1",
             "name": "Sinuous Vermin",
             "text": "{3}{B}{B}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nAs long as Sinuous Vermin is monstrous, it has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -15477,7 +15477,7 @@
         },
         {
             "id": "51577307-7b95-5137-9966-4336cc9005a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265ed45-2954-4fca-b13f-5c1afd1ef134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265ed45-2954-4fca-b13f-5c1afd1ef134.jpg?1",
             "name": "Skirsdag High Priest",
             "text": "Morbid \u2014 {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token with flying. Activate only if a creature died this turn.",
             "colours": [
@@ -15511,7 +15511,7 @@
         },
         {
             "id": "f37bb4fa-b646-579c-a649-a05277528e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb107063-d6fc-4572-914d-3f0382134ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb107063-d6fc-4572-914d-3f0382134ac5.jpg?1",
             "name": "Skirsdag Supplicant",
             "text": "{B}, {T}, Discard a card: Each player loses 2 life.",
             "colours": [
@@ -15545,7 +15545,7 @@
         },
         {
             "id": "b2d21963-206a-52eb-bd37-a96a01ccb21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8d27af-e4cf-4e18-825e-8f6c972e64ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8d27af-e4cf-4e18-825e-8f6c972e64ba.jpg?1",
             "name": "Sling-Gang Lieutenant",
             "text": "When Sling-Gang Lieutenant enters the battlefield, create two 1/1 red Goblin creature tokens.\nSacrifice a Goblin: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -15578,7 +15578,7 @@
         },
         {
             "id": "f3cfa639-58b0-5414-b33e-cd47d4600a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f1d112-4c62-41c0-8be6-da78c1036b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f1d112-4c62-41c0-8be6-da78c1036b4d.jpg?1",
             "name": "Soulcage Fiend",
             "text": "When Soulcage Fiend dies, each player loses 3 life.",
             "colours": [
@@ -15611,7 +15611,7 @@
         },
         {
             "id": "896d142f-7a9f-5efb-bf47-40ce5139b3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6f8cfe-20b1-430a-8aa8-dcaebc94ca2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6f8cfe-20b1-430a-8aa8-dcaebc94ca2a.jpg?1",
             "name": "Spark Reaper",
             "text": "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card.",
             "colours": [
@@ -15644,7 +15644,7 @@
         },
         {
             "id": "dd66f55a-2c0c-51ca-837f-fa5d050f597d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44e634-7a1f-4e7d-afdd-e7fd9a0bab06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c44e634-7a1f-4e7d-afdd-e7fd9a0bab06.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "When Stitcher's Supplier enters the battlefield or dies, mill three cards. (Put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -15679,7 +15679,7 @@
         },
         {
             "id": "c6493d2c-d0c7-5786-8b56-a1cd527e2257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c87f47-419f-4551-9e74-29f1df81dfbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c87f47-419f-4551-9e74-29f1df81dfbe.jpg?1",
             "name": "Strangling Spores",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -15710,7 +15710,7 @@
         },
         {
             "id": "5adae475-4597-543b-89bd-4c929fe42fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754baf3f-4bad-4739-9f55-65040c96825c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754baf3f-4bad-4739-9f55-65040c96825c.jpg?1",
             "name": "Syr Konrad, the Grim",
             "text": "Whenever another creature dies, or a creature card is put into a graveyard from anywhere other than the battlefield, or a creature card leaves your graveyard, Syr Konrad, the Grim deals 1 damage to each opponent.\n{1}{B}: Each player mills a card.",
             "colours": [
@@ -15746,7 +15746,7 @@
         },
         {
             "id": "57753dc7-48d6-57a2-a126-ae0961f5a830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6e6918-7941-46f0-b6d7-83e0c95c6938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6e6918-7941-46f0-b6d7-83e0c95c6938.jpg?1",
             "name": "Takenuma Bleeder",
             "text": "Whenever Takenuma Bleeder attacks or blocks, you lose 1 life if you don't control a Demon.",
             "colours": [
@@ -15780,7 +15780,7 @@
         },
         {
             "id": "107245d2-4cbf-59a3-88a6-342cb17b712c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f930f102-ad69-4b70-ae0f-641f5c05f40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f930f102-ad69-4b70-ae0f-641f5c05f40c.jpg?1",
             "name": "Tivash, Gloom Summoner",
             "text": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay X life, where X is the amount of life you gained this turn. If you do, create an X/X black Demon creature token with flying.",
             "colours": [
@@ -15816,7 +15816,7 @@
         },
         {
             "id": "1eba62e7-677c-5ac4-936d-51e14138fc16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97012a9c-34cb-4d66-bb2c-3127be4c0f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97012a9c-34cb-4d66-bb2c-3127be4c0f28.jpg?1",
             "name": "Tormented Soul",
             "text": "Tormented Soul can't block and can't be blocked.",
             "colours": [
@@ -15849,7 +15849,7 @@
         },
         {
             "id": "bf6076dc-877c-5998-92a1-69d160f7348f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08cadcd-7e2d-48a6-8900-ca92499fdaff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08cadcd-7e2d-48a6-8900-ca92499fdaff.jpg?1",
             "name": "Tragic Slip",
             "text": "Target creature gets -1/-1 until end of turn.\nMorbid \u2014 That creature gets -13/-13 until end of turn instead if a creature died this turn.",
             "colours": [
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "13b7df9b-c94b-5336-beb1-95fef6a3e3cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99a9bc1-8ee2-48b2-bb36-c8b3b8ace470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99a9bc1-8ee2-48b2-bb36-c8b3b8ace470.jpg?1",
             "name": "Triskaidekaphobia",
             "text": "At the beginning of your upkeep, choose one \u2014\n\u2022 Each player with exactly 13 life loses the game, then each player gains 1 life.\n\u2022 Each player with exactly 13 life loses the game, then each player loses 1 life.",
             "colours": [
@@ -15913,7 +15913,7 @@
         },
         {
             "id": "2a1bd527-2d38-5efe-82cd-5fba1a811c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec112cf-aa50-4246-9730-e034a3656c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec112cf-aa50-4246-9730-e034a3656c3d.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch",
             "colours": [
@@ -15946,7 +15946,7 @@
         },
         {
             "id": "d21e6edd-35ec-5760-a21b-e1b42c3443f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b01b24-67a7-44a5-80ab-b058d8b0f593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b01b24-67a7-44a5-80ab-b058d8b0f593.jpg?1",
             "name": "Ulcerate",
             "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
             "colours": [
@@ -15977,7 +15977,7 @@
         },
         {
             "id": "7578a411-febe-537d-aff7-2e8aa1f1f4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a4dce7-f13a-4109-8da0-81da89397eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a4dce7-f13a-4109-8da0-81da89397eb0.jpg?1",
             "name": "Undead Augur",
             "text": "Whenever Undead Augur or another Zombie you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -16011,7 +16011,7 @@
         },
         {
             "id": "ef4802a6-c61a-5f5e-93a1-bf6edbcccca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf33f08-eb13-4bed-b286-aef9e2e84abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf33f08-eb13-4bed-b286-aef9e2e84abb.jpg?1",
             "name": "Vampire Envoy",
             "text": "Flying\nWhenever Vampire Envoy becomes tapped, you gain 1 life.",
             "colours": [
@@ -16046,7 +16046,7 @@
         },
         {
             "id": "795c057e-7996-51cb-a29e-13b9cad2ca84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afbfbc-55d3-4cea-be37-9c6c015d121d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afbfbc-55d3-4cea-be37-9c6c015d121d.jpg?1",
             "name": "Vampiric Rites",
             "text": "{1}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -16077,7 +16077,7 @@
         },
         {
             "id": "10b0f3e4-f50a-5d4f-ba10-b57ab4581b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3af160-3993-4b49-b4ec-065e458951fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3af160-3993-4b49-b4ec-065e458951fd.jpg?1",
             "name": "Vermin Gorger",
             "text": "{T}, Sacrifice another creature: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -16110,7 +16110,7 @@
         },
         {
             "id": "8bd2c774-fc7e-5661-b6c5-2013de86bcd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a27914-5e4f-48d4-ba2a-9d3187a39606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a27914-5e4f-48d4-ba2a-9d3187a39606.jpg?1",
             "name": "Village Rites",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -16141,7 +16141,7 @@
         },
         {
             "id": "fd61018d-b6ca-5ba9-8eb3-bd9bc3c5b14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c61e0ef-4dc7-4acc-a4a1-e63c35a854ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c61e0ef-4dc7-4acc-a4a1-e63c35a854ba.jpg?1",
             "name": "Vito, Thorn of the Dusk Rose",
             "text": "Whenever you gain life, target opponent loses that much life.\n{3}{B}{B}: Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -16177,7 +16177,7 @@
         },
         {
             "id": "bb9ec9b7-56d6-500e-99e8-e7e80d9e5010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155d1aa-929d-46eb-ab9d-02a40d6e9782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155d1aa-929d-46eb-ab9d-02a40d6e9782.jpg?1",
             "name": "Wailing Ghoul",
             "text": "When Wailing Ghoul enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -16210,7 +16210,7 @@
         },
         {
             "id": "20948163-b5a7-5042-b1a5-19f69faf5803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c6b02-64c6-486d-b38b-be0f7327e9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84c6b02-64c6-486d-b38b-be0f7327e9c6.jpg?1",
             "name": "Wicked Guardian",
             "text": "When Wicked Guardian enters the battlefield, you may have it deal 2 damage to another creature you control. If you do, draw a card.",
             "colours": [
@@ -16244,7 +16244,7 @@
         },
         {
             "id": "e6e5f988-bc80-5e8b-9891-2338f0a71849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d11924-23c5-485e-9c56-9efcaf6cd9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d11924-23c5-485e-9c56-9efcaf6cd9d2.jpg?1",
             "name": "Witch's Cauldron",
             "text": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -16275,7 +16275,7 @@
         },
         {
             "id": "2c960118-8bd9-56bd-bbff-ccb33efac11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a4a591-92e0-4318-a71c-376fbfe2b14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a4a591-92e0-4318-a71c-376fbfe2b14f.jpg?1",
             "name": "Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -16311,7 +16311,7 @@
         },
         {
             "id": "776eac93-ac4d-5be9-a622-a39f8c38ba25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4fd9dc-5cf9-4f10-836a-8b7aaf8aca29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4fd9dc-5cf9-4f10-836a-8b7aaf8aca29.jpg?1",
             "name": "Act on Impulse",
             "text": "Exile the top three cards of your library. Until end of turn, you may play those cards. (If you cast a spell this way, you still pay its costs. You can play a land this way only if you have an available land play remaining.)",
             "colours": [
@@ -16342,7 +16342,7 @@
         },
         {
             "id": "06c6b0ea-067b-59de-8b27-d38515672948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa460a11-afd1-4997-89ac-6a64af63db55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa460a11-afd1-4997-89ac-6a64af63db55.jpg?1",
             "name": "Arms Dealer",
             "text": "{1}{R}, Sacrifice a Goblin: Arms Dealer deals 4 damage to target creature.",
             "colours": [
@@ -16376,7 +16376,7 @@
         },
         {
             "id": "6d6fa705-cc97-596c-8b91-dc1809f8d4fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e16bc35-5237-4a13-9179-aaa0347ceffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e16bc35-5237-4a13-9179-aaa0347ceffe.jpg?1",
             "name": "Axgard Cavalry",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -16410,7 +16410,7 @@
         },
         {
             "id": "60f477ce-ed09-5667-ba9f-6ea2f2439b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7688ad33-62b2-46ab-b15b-2e20c28710de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7688ad33-62b2-46ab-b15b-2e20c28710de.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to any target.\nIf X is 5 or more, this spell can't be countered and the damage can't be prevented.",
             "colours": [
@@ -16441,7 +16441,7 @@
         },
         {
             "id": "7e347fe3-c7bc-528e-882c-a6c94795d939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a335cb-e437-4957-9675-6eaa0316abd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a335cb-e437-4957-9675-6eaa0316abd2.jpg?1",
             "name": "Barrage Ogre",
             "text": "{T}, Sacrifice an artifact: Barrage Ogre deals 2 damage to any target.",
             "colours": [
@@ -16475,7 +16475,7 @@
         },
         {
             "id": "89d089cb-e489-5ae0-8244-8211e5533b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca05c60-edef-4107-bd86-31b7d4a38398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca05c60-edef-4107-bd86-31b7d4a38398.jpg?1",
             "name": "Battle Squadron",
             "text": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -16508,7 +16508,7 @@
         },
         {
             "id": "a1ebd60c-d23a-5c93-991e-253bcf40a484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb7413-af44-4038-a56c-8cc3ca645a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb7413-af44-4038-a56c-8cc3ca645a58.jpg?1",
             "name": "Big Score",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -16539,7 +16539,7 @@
         },
         {
             "id": "5d1c8a51-41b5-554f-9f8e-d9ef3b5293d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e27dd9-5b6a-4dab-9ee6-ad083b5c0911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e27dd9-5b6a-4dab-9ee6-ad083b5c0911.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any target.",
             "colours": [
@@ -16570,7 +16570,7 @@
         },
         {
             "id": "9500abac-ccd8-596a-be8c-2875b54ffeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fed3bc-6ce1-409c-9eac-ce6fd12d9ea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fed3bc-6ce1-409c-9eac-ce6fd12d9ea8.jpg?1",
             "name": "Blisterspit Gremlin",
             "text": "{1}, {T}: Blisterspit Gremlin deals 1 damage to each opponent.\nWhenever you cast a noncreature spell, untap Blisterspit Gremlin.",
             "colours": [
@@ -16603,7 +16603,7 @@
         },
         {
             "id": "8894c2a0-403f-5aaa-82cf-b808e7770338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fa2529-e00e-457b-928f-b1c378f31cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fa2529-e00e-457b-928f-b1c378f31cb5.jpg?1",
             "name": "Blood Aspirant",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Blood Aspirant.\n{1}{R}, {T}, Sacrifice a creature or enchantment: Blood Aspirant deals 1 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -16637,7 +16637,7 @@
         },
         {
             "id": "61b0da9b-362a-517c-a4b1-d18d074bbd6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dfd4f1-abe4-4300-aa16-54a515f0c1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dfd4f1-abe4-4300-aa16-54a515f0c1e3.jpg?1",
             "name": "Bloodhaze Wolverine",
             "text": "Whenever you draw your second card each turn, Bloodhaze Wolverine gets +1/+1 and gains first strike until end of turn.",
             "colours": [
@@ -16670,7 +16670,7 @@
         },
         {
             "id": "36af5937-a550-597e-8ba0-88861d78edfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c174e1f1-d7ed-4784-bf22-791102855022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c174e1f1-d7ed-4784-bf22-791102855022.jpg?1",
             "name": "Bogardan Dragonheart",
             "text": "Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.",
             "colours": [
@@ -16704,7 +16704,7 @@
         },
         {
             "id": "72f41c70-b481-5cf9-949e-9b78d0c3e6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df5b536-6098-4352-8172-ec11d656d4a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df5b536-6098-4352-8172-ec11d656d4a9.jpg?1",
             "name": "Bolt Hound",
             "text": "Haste\nWhenever Bolt Hound attacks, other creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -16738,7 +16738,7 @@
         },
         {
             "id": "b706f793-c086-5b8a-88a8-eff100da3012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eef6f1-318b-4f0b-b269-94b09a039c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eef6f1-318b-4f0b-b269-94b09a039c97.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -16772,7 +16772,7 @@
         },
         {
             "id": "34d32f09-4fbc-5f7b-b1d9-3c8460c173e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a1e6e9-5e5f-4431-9732-fd313df843df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a1e6e9-5e5f-4431-9732-fd313df843df.jpg?1",
             "name": "Brazen Freebooter",
             "text": "When Brazen Freebooter enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -16806,7 +16806,7 @@
         },
         {
             "id": "a8c2c6d0-ae06-5ab9-8c9d-fbc59df51894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f94348-6c9a-4d0e-975c-618b4a540ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f94348-6c9a-4d0e-975c-618b4a540ad4.jpg?1",
             "name": "Brazen Wolves",
             "text": "Whenever Brazen Wolves attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -16839,7 +16839,7 @@
         },
         {
             "id": "25883dc2-a9a2-5b4d-b41c-c342665ceebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8836ea09-9136-4f97-9b38-1aeb9c155d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8836ea09-9136-4f97-9b38-1aeb9c155d03.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -16870,7 +16870,7 @@
         },
         {
             "id": "047f1861-67eb-590f-b630-504a3c878333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d910f-f378-4b55-9587-2101faefe0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33d910f-f378-4b55-9587-2101faefe0fa.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "Haste\nWhenever Captain Lannery Storm attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever you sacrifice a Treasure, Captain Lannery Storm gets +1/+0 until end of turn.",
             "colours": [
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "64013b40-e3cc-57eb-87ea-fda08171ae0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9b5c4-0911-4d0a-92bf-2d0107329671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9b5c4-0911-4d0a-92bf-2d0107329671.jpg?1",
             "name": "Catalyst Elemental",
             "text": "Sacrifice Catalyst Elemental: Add {R}{R}.",
             "colours": [
@@ -16939,7 +16939,7 @@
         },
         {
             "id": "f5b5ed43-791d-58eb-ad31-d9a369d39f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6872aa6f-2a81-4ea6-acd7-f7457e245533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6872aa6f-2a81-4ea6-acd7-f7457e245533.jpg?1",
             "name": "Chandra, Flame's Fury",
             "text": "+1: Chandra, Flame's Fury deals 2 damage to any target.\n\u22122: Chandra, Flame's Fury deals 4 damage to target creature and 2 damage to that creature's controller.\n\u22128: Chandra, Flame's Fury deals 10 damage to target player and each creature that player controls.",
             "colours": [
@@ -16974,7 +16974,7 @@
         },
         {
             "id": "debaf74d-0018-5b51-bdbc-5e0852a31e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6eb9-dd25-4a1d-ae0a-ad5d235073c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6eb9-dd25-4a1d-ae0a-ad5d235073c3.jpg?1",
             "name": "Chandra's Magmutt",
             "text": "{T}: Chandra's Magmutt deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -17008,7 +17008,7 @@
         },
         {
             "id": "1af80db7-b113-5917-ac4c-17ff9a8bc950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64106412-36ad-46f1-a7df-7dbff296473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64106412-36ad-46f1-a7df-7dbff296473e.jpg?1",
             "name": "Chandra's Pyreling",
             "text": "Whenever a source you control deals noncombat damage to an opponent, Chandra's Pyreling gets +1/+0 and gains double strike until end of turn.",
             "colours": [
@@ -17042,7 +17042,7 @@
         },
         {
             "id": "204b7a7c-d158-5dfb-ba32-21e2370533d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc6a24c-2927-4aed-94c1-9cab2c95682e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc6a24c-2927-4aed-94c1-9cab2c95682e.jpg?1",
             "name": "Chandra's Pyrohelix",
             "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -17073,7 +17073,7 @@
         },
         {
             "id": "b0c59241-d9bb-5d9e-a612-dac73f307db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e823359-865d-4ef4-8e55-e170527b1b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e823359-865d-4ef4-8e55-e170527b1b42.jpg?1",
             "name": "Chandra's Spitfire",
             "text": "Flying\nWhenever an opponent is dealt noncombat damage, Chandra's Spitfire gets +3/+0 until end of turn.",
             "colours": [
@@ -17106,7 +17106,7 @@
         },
         {
             "id": "65f47537-406a-5166-a1de-d4c60d26496c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b5e55b-e888-4bd5-a6a9-d253f6e406a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b5e55b-e888-4bd5-a6a9-d253f6e406a6.jpg?1",
             "name": "Coalhauler Swine",
             "text": "Whenever Coalhauler Swine is dealt damage, it deals that much damage to each player.",
             "colours": [
@@ -17140,7 +17140,7 @@
         },
         {
             "id": "98cb8edd-ddff-5d45-b63d-dda88d8820e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89872245-6be7-4d28-8b0a-d8df42e2f150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89872245-6be7-4d28-8b0a-d8df42e2f150.jpg?1",
             "name": "Cone of Flame",
             "text": "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target.",
             "colours": [
@@ -17171,7 +17171,7 @@
         },
         {
             "id": "12a35473-0c6f-5355-becb-e8b70fa54c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427e31b2-2c53-46c8-af51-16a1ad6c66fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427e31b2-2c53-46c8-af51-16a1ad6c66fd.jpg?1",
             "name": "Cyclops Electromancer",
             "text": "When Cyclops Electromancer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -17205,7 +17205,7 @@
         },
         {
             "id": "567fc9d3-d5c9-5040-b345-dec70db0b240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f0b72-fc78-415c-9999-4ce362ed037d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f0b72-fc78-415c-9999-4ce362ed037d.jpg?1",
             "name": "Dance with Devils",
             "text": "Create two 1/1 red Devil creature tokens. They have \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -17236,7 +17236,7 @@
         },
         {
             "id": "64619845-bcdc-5e7a-9130-ea215e6493b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955e94dd-f3f1-4f5a-8940-54190d5f2f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955e94dd-f3f1-4f5a-8940-54190d5f2f77.jpg?1",
             "name": "Deem Worthy",
             "text": "Deem Worthy deals 7 damage to target creature.\nCycling {3}{R} ({3}{R}, Discard this card: Draw a card.)\nWhen you cycle Deem Worthy, you may have it deal 2 damage to target creature.",
             "colours": [
@@ -17267,7 +17267,7 @@
         },
         {
             "id": "7503627e-26a0-53c9-b559-b8ef6610c1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1c3c1-3afc-48be-83e4-05df11d3e7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1c3c1-3afc-48be-83e4-05df11d3e7da.jpg?1",
             "name": "Destructive Tampering",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Creatures without flying can't block this turn.",
             "colours": [
@@ -17298,7 +17298,7 @@
         },
         {
             "id": "b0d9fda1-0c56-5587-ad00-97bcd43ada62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d31ba0-6cec-4d8b-950f-f0b70bb8b0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d31ba0-6cec-4d8b-950f-f0b70bb8b0dd.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -17332,7 +17332,7 @@
         },
         {
             "id": "a218dab8-4f7e-5ab1-9384-e57842a429a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27238e0e-c676-44f5-841c-6e4a3a3f6374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27238e0e-c676-44f5-841c-6e4a3a3f6374.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -17365,7 +17365,7 @@
         },
         {
             "id": "22650984-4f37-5a05-8be0-a15b1121d753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac2c18-a26b-4683-b326-97f0e75b4f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac2c18-a26b-4683-b326-97f0e75b4f2a.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -17399,7 +17399,7 @@
         },
         {
             "id": "aaa6f387-d6b8-541a-997b-e2e0819e5487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7098bac-9e43-41e7-a891-780fe4232940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7098bac-9e43-41e7-a891-780fe4232940.jpg?1",
             "name": "Dragonspeaker Shaman",
             "text": "Dragon spells you cast cost {2} less to cast.",
             "colours": [
@@ -17434,7 +17434,7 @@
         },
         {
             "id": "fec0da09-e832-5d1d-8070-f40e85308ec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e628-3a8f-44ea-aec2-60c8fbd1baae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e628-3a8f-44ea-aec2-60c8fbd1baae.jpg?1",
             "name": "Electric Revelation",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -17465,7 +17465,7 @@
         },
         {
             "id": "947a215f-8cb2-5555-a7f5-cdcb4f14631d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0538bd14-fc75-4e1b-8183-8e852b78fa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0538bd14-fc75-4e1b-8183-8e852b78fa9d.jpg?1",
             "name": "Electrify",
             "text": "Electrify deals 4 damage to target creature.",
             "colours": [
@@ -17496,7 +17496,7 @@
         },
         {
             "id": "8a7e472d-0d9a-5de3-8444-e81c0ede5b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d927-c8ed-4bb3-abfe-ae4f12571377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff16d927-c8ed-4bb3-abfe-ae4f12571377.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to any target.",
             "colours": [
@@ -17530,7 +17530,7 @@
         },
         {
             "id": "b90e49dc-0256-5c02-ac5e-f4271290a407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9555482-f0b8-4b1d-8557-4138e9d20126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9555482-f0b8-4b1d-8557-4138e9d20126.jpg?1",
             "name": "Fervent Strike",
             "text": "Target creature gets +1/+0 and gains first strike and haste until end of turn.",
             "colours": [
@@ -17561,7 +17561,7 @@
         },
         {
             "id": "8b012952-355d-56dc-b6ae-93bafd4c44d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aef50c-2d73-49a9-8458-0d7c2dc3e658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aef50c-2d73-49a9-8458-0d7c2dc3e658.jpg?1",
             "name": "Fiery Conclusion",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFiery Conclusion deals 5 damage to target creature.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "9e5473ad-bd6f-5040-8f7b-f9f8cd8fffdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85cfa83-27bd-4bd5-92e3-65aab37e2ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85cfa83-27bd-4bd5-92e3-65aab37e2ae6.jpg?1",
             "name": "Fiery Intervention",
             "text": "Choose one \u2014\n\u2022 Fiery Intervention deals 5 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -17623,7 +17623,7 @@
         },
         {
             "id": "2ebed4d2-fa2e-5d8b-b838-b5612631539d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bbf30c-795c-4580-a0e6-5e2665e6b6fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bbf30c-795c-4580-a0e6-5e2665e6b6fc.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to any target.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -17654,7 +17654,7 @@
         },
         {
             "id": "eca7388e-156a-5827-8df7-e0c17f5950ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd242c8-c146-4d5a-86f8-6009ed29fe5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd242c8-c146-4d5a-86f8-6009ed29fe5a.jpg?1",
             "name": "Firecannon Blast",
             "text": "Firecannon Blast deals 3 damage to target creature.\nRaid \u2014 Firecannon Blast deals 6 damage instead if you attacked this turn.",
             "colours": [
@@ -17685,7 +17685,7 @@
         },
         {
             "id": "1d919981-67fc-5ce9-98e7-c20c4338afb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a0053-f9a3-43f4-a317-07eb801dbb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1a0053-f9a3-43f4-a317-07eb801dbb9b.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to any target.",
             "colours": [
@@ -17716,7 +17716,7 @@
         },
         {
             "id": "767d1e38-3f50-5960-a059-449b2ac49fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19866e42-5248-42c5-a2a1-13fe0d646068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19866e42-5248-42c5-a2a1-13fe0d646068.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -17747,7 +17747,7 @@
         },
         {
             "id": "ed511d77-1303-5ae4-993c-de6a78b2bfba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e68ddf0-5cf6-4024-ab71-827f28a0b0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e68ddf0-5cf6-4024-ab71-827f28a0b0ee.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -17781,7 +17781,7 @@
         },
         {
             "id": "d5f7aa84-e1c5-5f8c-953a-fb4f4b78ffb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ba3f5-3ad5-47e7-86c9-31954f015b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ba3f5-3ad5-47e7-86c9-31954f015b91.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -17814,7 +17814,7 @@
         },
         {
             "id": "4bc14e68-b23d-55ef-ae1b-0abda3d675c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb13721-e6f7-439c-8993-a896de5d6892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb13721-e6f7-439c-8993-a896de5d6892.jpg?1",
             "name": "Gadrak, the Crown-Scourge",
             "text": "Flying\nGadrak, the Crown-Scourge can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -17849,7 +17849,7 @@
         },
         {
             "id": "2a5e4ba3-ccec-521a-8bfa-9cc678aa832c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884ffe1-4f4c-40a4-88c2-d34a19d80dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884ffe1-4f4c-40a4-88c2-d34a19d80dd9.jpg?1",
             "name": "Glint-Horn Buccaneer",
             "text": "Haste\nWhenever you discard a card, Glint-Horn Buccaneer deals 1 damage to each opponent.\n{1}{R}, Discard a card: Draw a card. Activate only if Glint-Horn Buccaneer is attacking.",
             "colours": [
@@ -17883,7 +17883,7 @@
         },
         {
             "id": "f873c2a5-8fb9-5559-b84b-02d3147d5a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40185b55-7693-429f-8d0a-2853d6beda90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40185b55-7693-429f-8d0a-2853d6beda90.jpg?1",
             "name": "Go for Blood",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\nCycling {1} ({1}, Discard this card: Draw a card.)",
             "colours": [
@@ -17914,7 +17914,7 @@
         },
         {
             "id": "dba570f7-2356-5629-bd52-7bd3914dfd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee809c0-eb2c-4576-a077-e030d4402045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee809c0-eb2c-4576-a077-e030d4402045.jpg?1",
             "name": "Goblin Artillery",
             "text": "{T}: Goblin Artillery deals 2 damage to any target and 3 damage to you.",
             "colours": [
@@ -17948,7 +17948,7 @@
         },
         {
             "id": "455f3d8a-8299-51c8-9f1e-bc4d327a5927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dacb5a-68d7-4eb0-b3ba-b1b96a100d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5dacb5a-68d7-4eb0-b3ba-b1b96a100d3c.jpg?1",
             "name": "Goblin Grenade",
             "text": "As an additional cost to cast this spell, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to any target.",
             "colours": [
@@ -17979,7 +17979,7 @@
         },
         {
             "id": "3ee524c3-7535-5d5a-8015-ecbd4a468388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e00348c-bfa7-4254-9a13-8f7e3d38f6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e00348c-bfa7-4254-9a13-8f7e3d38f6f0.jpg?1",
             "name": "Goblin Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -18010,7 +18010,7 @@
         },
         {
             "id": "16a48e2c-1b1f-524d-8e06-deb99c366da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879b406-c382-47e6-af33-439a164438ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879b406-c382-47e6-af33-439a164438ae.jpg?1",
             "name": "Goblin Psychopath",
             "text": "Whenever Goblin Psychopath attacks or blocks, flip a coin. If you lose the flip, the next time it would deal combat damage this turn, it deals that damage to you instead.",
             "colours": [
@@ -18044,7 +18044,7 @@
         },
         {
             "id": "1423814d-ed3c-580b-b94e-152bd4cbd3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecbe76-5118-4844-9a20-b227c924189d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecbe76-5118-4844-9a20-b227c924189d.jpg?1",
             "name": "Goblin Rabblemaster",
             "text": "Other Goblin creatures you control attack each combat if able.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token with haste.\nWhenever Goblin Rabblemaster attacks, it gets +1/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -18078,7 +18078,7 @@
         },
         {
             "id": "95de004a-4276-5a69-8abf-74bcab992044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b0a697-e901-42d9-9833-fedfcb6db9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b0a697-e901-42d9-9833-fedfcb6db9b3.jpg?1",
             "name": "Goblin Rally",
             "text": "Create four 1/1 red Goblin creature tokens.",
             "colours": [
@@ -18109,7 +18109,7 @@
         },
         {
             "id": "5d4210c1-e7e3-5f9f-83fd-95ea5ea431a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b16412-3e91-415a-9444-3ca4d30bd8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b16412-3e91-415a-9444-3ca4d30bd8d6.jpg?1",
             "name": "Goblin Trailblazer",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -18143,7 +18143,7 @@
         },
         {
             "id": "64c76398-f0e8-51b2-b859-0d89e6df354c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8567a329-9e3a-4c3d-b74d-2a2d2d4c8c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8567a329-9e3a-4c3d-b74d-2a2d2d4c8c41.jpg?1",
             "name": "Goblin Warchief",
             "text": "Goblin spells you cast cost {1} less to cast.\nGoblins you control have haste.",
             "colours": [
@@ -18177,7 +18177,7 @@
         },
         {
             "id": "a0e8bf44-72d9-579b-bf56-c9bc16c096c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed08f2-b251-43ea-818a-7ad833151284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ed08f2-b251-43ea-818a-7ad833151284.jpg?1",
             "name": "Goldhound",
             "text": "First strike\nMenace (This creature can't be blocked except by two or more creatures.)\n{T}, Sacrifice Goldhound: Add one mana of any color.",
             "colours": [
@@ -18212,7 +18212,7 @@
         },
         {
             "id": "de018edd-f0be-524b-8021-9d93211a172a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c67a683-4e1d-4a64-952d-a1c27a34ed1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c67a683-4e1d-4a64-952d-a1c27a34ed1d.jpg?1",
             "name": "Goldspan Dragon",
             "text": "Flying, haste\nWhenever Goldspan Dragon attacks or becomes the target of a spell, create a Treasure token.\nTreasures you control have \"{T}, Sacrifice this artifact: Add two mana of any one color.\"",
             "colours": [
@@ -18245,7 +18245,7 @@
         },
         {
             "id": "f81c7037-f430-5a57-96ce-08a66dba5be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c690b-5d10-4fbc-9ca1-12627bf070f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c690b-5d10-4fbc-9ca1-12627bf070f3.jpg?1",
             "name": "Grotag Night-Runner",
             "text": "Whenever Grotag Night-Runner deals combat damage to a player, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -18279,7 +18279,7 @@
         },
         {
             "id": "d27f9e9c-3ca5-5e54-b2e0-4df291cf4ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b98d04-937e-47ee-8f97-775c77e33de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b98d04-937e-47ee-8f97-775c77e33de9.jpg?1",
             "name": "Hordeling Outburst",
             "text": "Create three 1/1 red Goblin creature tokens.",
             "colours": [
@@ -18310,7 +18310,7 @@
         },
         {
             "id": "40b88d72-a254-5271-9fc4-1108ccb55269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e7ec98-fd08-479b-ace6-10c7c700ab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e7ec98-fd08-479b-ace6-10c7c700ab51.jpg?1",
             "name": "Hungry Flames",
             "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player or planeswalker.",
             "colours": [
@@ -18341,7 +18341,7 @@
         },
         {
             "id": "740a611d-b585-516b-bae1-fcbe481c6c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09f9597-c2a9-4c1a-8375-ab06b1a21ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09f9597-c2a9-4c1a-8375-ab06b1a21ee3.jpg?1",
             "name": "Ib Halfheart, Goblin Tactician",
             "text": "Whenever another Goblin you control becomes blocked, sacrifice it. If you do, it deals 4 damage to each creature blocking it.\nSacrifice two Mountains: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -18377,7 +18377,7 @@
         },
         {
             "id": "b2bac41a-babc-5a22-b8de-133ee724cdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272a9a89-6318-487a-b6f6-cc4ccd744f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272a9a89-6318-487a-b6f6-cc4ccd744f54.jpg?1",
             "name": "Ignite the Future",
             "text": "Exile the top three cards of your library. Until the end of your next turn, you may play those cards. If this spell was cast from a graveyard, you may play cards this way without paying their mana costs.\nFlashback {7}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -18408,7 +18408,7 @@
         },
         {
             "id": "5bc156b1-24ef-5fcf-a0e7-be6e293ed5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11fd96f-9adb-4227-b1cb-4300c0621789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11fd96f-9adb-4227-b1cb-4300c0621789.jpg?1",
             "name": "Immersturm Raider",
             "text": "When Immersturm Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -18442,7 +18442,7 @@
         },
         {
             "id": "a204fad0-bca0-543a-b64b-b8904bcb123b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b813e554-12ea-4675-bc90-f161f80de50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b813e554-12ea-4675-bc90-f161f80de50e.jpg?1",
             "name": "Impending Doom",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and attacks each combat if able.\nWhen enchanted creature dies, Impending Doom deals 3 damage to that creature's controller.",
             "colours": [
@@ -18475,7 +18475,7 @@
         },
         {
             "id": "b1d915e8-0bab-53a4-9309-e325ea0659ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828a5005-0b19-49a2-bc9a-5b32c719c74c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828a5005-0b19-49a2-bc9a-5b32c719c74c.jpg?1",
             "name": "Improvised Weaponry",
             "text": "Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -18506,7 +18506,7 @@
         },
         {
             "id": "11d1e47e-70fb-52d8-a6be-be5223c3a594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a950b05-fcdf-4d3e-b038-76dc31a9dff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a950b05-fcdf-4d3e-b038-76dc31a9dff2.jpg?1",
             "name": "Irencrag Pyromancer",
             "text": "Whenever you draw your second card each turn, Irencrag Pyromancer deals 3 damage to any target.",
             "colours": [
@@ -18540,7 +18540,7 @@
         },
         {
             "id": "5581f555-c2e7-59ae-92b5-9226f2bcf566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5690c-7c11-4b04-9a50-9d3dc6aa8d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5690c-7c11-4b04-9a50-9d3dc6aa8d49.jpg?1",
             "name": "Irreverent Revelers",
             "text": "When Irreverent Revelers enters the battlefield, choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Irreverent Revelers gains haste until end of turn.",
             "colours": [
@@ -18573,7 +18573,7 @@
         },
         {
             "id": "aa77f530-25a4-5a1a-a9f8-7cb1f36d10d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069b3c69-ee4c-4fc9-981e-62db77f9821d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069b3c69-ee4c-4fc9-981e-62db77f9821d.jpg?1",
             "name": "Kargan Dragonrider",
             "text": "As long as you control a Dragon, Kargan Dragonrider has flying.",
             "colours": [
@@ -18607,7 +18607,7 @@
         },
         {
             "id": "41bbe598-6940-58e3-8564-0fd0ade69166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9638a43f-6b61-4455-8e0f-4142652c4b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9638a43f-6b61-4455-8e0f-4142652c4b54.jpg?1",
             "name": "Kari Zev, Skyship Raider",
             "text": "First strike, menace\nWhenever Kari Zev, Skyship Raider attacks, create Ragavan, a legendary 2/1 red Monkey creature token. Ragavan enters the battlefield tapped and attacking. Exile that token at end of combat.",
             "colours": [
@@ -18643,7 +18643,7 @@
         },
         {
             "id": "4116b342-579d-5a95-a0e4-367e2b72b6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524677a-d27c-41e1-9122-f471980a1fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524677a-d27c-41e1-9122-f471980a1fff.jpg?1",
             "name": "Keldon Raider",
             "text": "When Keldon Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -18677,7 +18677,7 @@
         },
         {
             "id": "f8de2b57-afd2-5434-bab7-bc96fb291d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9c68ff-1fe4-42ef-8d1f-43120de5c1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9c68ff-1fe4-42ef-8d1f-43120de5c1ff.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -18713,7 +18713,7 @@
         },
         {
             "id": "97bf04b6-9026-56ee-bb43-ac664580dabe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d7412-d779-4154-a1f7-747ed1356c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57d7412-d779-4154-a1f7-747ed1356c1a.jpg?1",
             "name": "Kuldotha Flamefiend",
             "text": "When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.",
             "colours": [
@@ -18746,7 +18746,7 @@
         },
         {
             "id": "7bd23f0c-66f5-5009-90ca-f51a4c85a880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8435c03c-b9a2-40fa-a979-879bd120a011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8435c03c-b9a2-40fa-a979-879bd120a011.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon enters the battlefield under your control, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -18781,7 +18781,7 @@
         },
         {
             "id": "48d29c47-674b-5028-9045-75e1df781669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772df6a2-315b-4516-93e1-623a90b802c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772df6a2-315b-4516-93e1-623a90b802c7.jpg?1",
             "name": "Lava Serpent",
             "text": "Haste\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -18815,7 +18815,7 @@
         },
         {
             "id": "8ad5a5e3-35c0-5a38-856c-c45fea662943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a6b01-1a0e-46bb-8576-80eaf2490f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a6b01-1a0e-46bb-8576-80eaf2490f21.jpg?1",
             "name": "Lavastep Raider",
             "text": "{2}{R}: Lavastep Raider gets +2/+0 until end of turn.",
             "colours": [
@@ -18849,7 +18849,7 @@
         },
         {
             "id": "045edd04-1e7c-5dd7-8e13-efede82dbe42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e43b0f-118c-4abe-a1f2-f3bacbba57c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e43b0f-118c-4abe-a1f2-f3bacbba57c8.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -18880,7 +18880,7 @@
         },
         {
             "id": "adaac217-f437-5d8c-a696-a6541d9de869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b15eb3-ad86-48cd-b414-b8a06f61635d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b15eb3-ad86-48cd-b414-b8a06f61635d.jpg?1",
             "name": "Mad Ratter",
             "text": "Whenever you draw your second card each turn, create two 1/1 black Rat creature tokens.",
             "colours": [
@@ -18913,7 +18913,7 @@
         },
         {
             "id": "6004db22-840c-5193-b71f-ee40f13a21f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd4da60-5ae2-458e-a4dd-fbba0cfe497b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd4da60-5ae2-458e-a4dd-fbba0cfe497b.jpg?1",
             "name": "Magmatic Channeler",
             "text": "As long as there are four or more instant and/or sorcery cards in your graveyard, Magmatic Channeler gets +3/+1.\n{T}, Discard a card: Exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -18947,7 +18947,7 @@
         },
         {
             "id": "6ee20ce2-bf38-55f7-a71d-1e87072ffa30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee5683-0131-47ca-b9e4-5ef94e367b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ee5683-0131-47ca-b9e4-5ef94e367b26.jpg?1",
             "name": "Mardu Heart-Piercer",
             "text": "Raid \u2014 When Mardu Heart-Piercer enters the battlefield, if you attacked this turn, Mardu Heart-Piercer deals 2 damage to any target.",
             "colours": [
@@ -18981,7 +18981,7 @@
         },
         {
             "id": "9d7f91a4-fb78-585f-b3e2-b9af8a3d7237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3659dccd-7b20-4807-9cd9-fa869c75f260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3659dccd-7b20-4807-9cd9-fa869c75f260.jpg?1",
             "name": "Markov Warlord",
             "text": "Haste\nWhen Markov Warlord enters the battlefield, up to two target creatures can't block this turn.",
             "colours": [
@@ -19015,7 +19015,7 @@
         },
         {
             "id": "81a39997-ad84-57c7-b0a4-3302c973941e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696b42b-02c7-4389-bc37-15fa1fa4f01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696b42b-02c7-4389-bc37-15fa1fa4f01b.jpg?1",
             "name": "Mudbutton Torchrunner",
             "text": "When Mudbutton Torchrunner dies, it deals 3 damage to any target.",
             "colours": [
@@ -19049,7 +19049,7 @@
         },
         {
             "id": "c35b1245-fbef-544a-baff-43cc46d48ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de974053-a1b2-4ee6-96be-3b5e9f9b290a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de974053-a1b2-4ee6-96be-3b5e9f9b290a.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "When Muxus, Goblin Grandee enters the battlefield, reveal the top six cards of your library. Put all Goblin creature cards with mana value 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.\nWhenever Muxus attacks, it gets +1/+1 until end of turn for each other Goblin you control.",
             "colours": [
@@ -19085,7 +19085,7 @@
         },
         {
             "id": "e895a570-738e-529f-8e2c-eace9aeb307d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3135dfde-ad52-4b93-9356-107d0efad93c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3135dfde-ad52-4b93-9356-107d0efad93c.jpg?1",
             "name": "Nest Robber",
             "text": "Haste",
             "colours": [
@@ -19118,7 +19118,7 @@
         },
         {
             "id": "78ff763f-8cd7-5365-9241-d23cd46fec4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0265b7d1-5646-4974-ae6a-34b1fa2281b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0265b7d1-5646-4974-ae6a-34b1fa2281b4.jpg?1",
             "name": "Ordeal of Purphoros",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Purphoros.\nWhen you sacrifice Ordeal of Purphoros, it deals 3 damage to any target.",
             "colours": [
@@ -19151,7 +19151,7 @@
         },
         {
             "id": "b24ca34f-2f4e-5b38-971e-ae87f1e25a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf73acce-3159-458b-a0d3-28a02959b7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf73acce-3159-458b-a0d3-28a02959b7f5.jpg?1",
             "name": "Outnumber",
             "text": "Outnumber deals damage to target creature equal to the number of creatures you control.",
             "colours": [
@@ -19182,7 +19182,7 @@
         },
         {
             "id": "298ac924-d32e-5a17-a4d7-20f17d738fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cdfbb2-8c85-4302-9114-de25f59af10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1cdfbb2-8c85-4302-9114-de25f59af10e.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -19213,7 +19213,7 @@
         },
         {
             "id": "8e890979-8088-5f0d-a6b1-0962ef097f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb0f9f2-4434-40aa-a683-481ec1f3aadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb0f9f2-4434-40aa-a683-481ec1f3aadd.jpg?1",
             "name": "Prickly Marmoset",
             "text": "First strike\nWhenever you cycle a card, Prickly Marmoset gets +2/+0 until end of turn.",
             "colours": [
@@ -19246,7 +19246,7 @@
         },
         {
             "id": "b4e27e35-13c1-514a-959b-6bca01537995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2561e6-c5b6-4c88-896e-67b33b8cf6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2561e6-c5b6-4c88-896e-67b33b8cf6bc.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "Menace\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nSacrifice a Treasure: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -19280,7 +19280,7 @@
         },
         {
             "id": "e947ad58-abc9-5976-abae-8e151822e5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7413f4db-d560-4c26-902d-27282b202339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7413f4db-d560-4c26-902d-27282b202339.jpg?1",
             "name": "Pyre-Sledge Arsonist",
             "text": "{1}, {T}: Pyre-Sledge Arsonist deals X damage to any target, where X is the number of permanents you've sacrificed this turn.",
             "colours": [
@@ -19314,7 +19314,7 @@
         },
         {
             "id": "fb4786bc-ff61-5166-b871-b6e3ba6da3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23538c0-ef71-4bbe-b500-7d61aa8b269b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23538c0-ef71-4bbe-b500-7d61aa8b269b.jpg?1",
             "name": "Quakefoot Cyclops",
             "text": "When Quakefoot Cyclops enters the battlefield, up to two target creatures can't block this turn.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Quakefoot Cyclops, target creature can't block this turn.",
             "colours": [
@@ -19347,7 +19347,7 @@
         },
         {
             "id": "47774546-20ab-5640-ae16-ca95dca7a419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018be5c-0357-47cc-ac8c-2929f90c4097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018be5c-0357-47cc-ac8c-2929f90c4097.jpg?1",
             "name": "Raking Claws",
             "text": "Target creature gains double strike until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -19378,7 +19378,7 @@
         },
         {
             "id": "e4b6f56b-8ba5-563f-b31c-9f9e710c8e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f781d608-6bc6-4ab8-beb1-b8e73643d01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f781d608-6bc6-4ab8-beb1-b8e73643d01b.jpg?1",
             "name": "Ravenous Giant",
             "text": "At the beginning of your upkeep, Ravenous Giant deals 1 damage to you.",
             "colours": [
@@ -19411,7 +19411,7 @@
         },
         {
             "id": "84123be4-4f53-5fe6-b923-df3db8617316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4277a7f-13c3-4e7b-a489-3116ae9d21bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4277a7f-13c3-4e7b-a489-3116ae9d21bc.jpg?1",
             "name": "Raze the Effigy",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target attacking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -19442,7 +19442,7 @@
         },
         {
             "id": "7e3616a4-5c33-5d57-8101-88d243137efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7dbe7ba-d4a0-42b7-ba8c-ade413333622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7dbe7ba-d4a0-42b7-ba8c-ade413333622.jpg?1",
             "name": "Reckless Fireweaver",
             "text": "Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent.",
             "colours": [
@@ -19476,7 +19476,7 @@
         },
         {
             "id": "e00bb97f-0059-5956-9070-2656e5100b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33386da8-48cf-47df-9b17-3ffc4c3f7af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33386da8-48cf-47df-9b17-3ffc4c3f7af9.jpg?1",
             "name": "Reptilian Reflection",
             "text": "Whenever you cycle a card, you may have Reptilian Reflection become a 5/4 Dinosaur creature with trample and haste in addition to its other types until end of turn.",
             "colours": [
@@ -19507,7 +19507,7 @@
         },
         {
             "id": "a476f172-0b6d-52a6-8772-f9c13e7e20c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bf7caa-cf00-4b94-8cc8-40b31c7cb3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bf7caa-cf00-4b94-8cc8-40b31c7cb3a5.jpg?1",
             "name": "Ripscale Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -19540,7 +19540,7 @@
         },
         {
             "id": "77bdf4b6-216c-5b46-99b3-73753e66fff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ec71-33c0-4a86-8110-30977e574341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ec71-33c0-4a86-8110-30977e574341.jpg?1",
             "name": "Rooting Moloch",
             "text": "When Rooting Moloch enters the battlefield, exile target card with a cycling ability from your graveyard. Until the end of your next turn, you may play that card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -19573,7 +19573,7 @@
         },
         {
             "id": "50e99e04-1e49-5c1d-92d7-c702ddffa4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d300a9e8-4611-4728-b54d-bb73005091d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d300a9e8-4611-4728-b54d-bb73005091d1.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -19607,7 +19607,7 @@
         },
         {
             "id": "290ea9a8-9c2e-5d24-9d70-9a0cc3a57f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b5383-f4cf-45e7-aefc-7f3a42748a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8b5383-f4cf-45e7-aefc-7f3a42748a8e.jpg?1",
             "name": "Rush of Adrenaline",
             "text": "Target creature gets +2/+1 and gains trample until end of turn.",
             "colours": [
@@ -19638,7 +19638,7 @@
         },
         {
             "id": "7908e855-e8f3-56b3-a576-3e55fc3fe7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadef4eb-d1fc-4b27-9d37-938f8893b9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadef4eb-d1fc-4b27-9d37-938f8893b9e7.jpg?1",
             "name": "Sarkhan, the Dragonspeaker",
             "text": "+1: Until end of turn, Sarkhan, the Dragonspeaker becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste. (He doesn't lose loyalty while he's not a planeswalker.)\n\u22123: Sarkhan, the Dragonspeaker deals 4 damage to target creature.\n\u22126: You get an emblem with \"At the beginning of your draw step, draw two additional cards\" and \"At the beginning of your end step, discard your hand.\"",
             "colours": [
@@ -19673,7 +19673,7 @@
         },
         {
             "id": "a3ea4fcc-0168-5d93-a987-a91cf6b74e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a34a4-2f2c-4c9c-a8d4-73953b62e189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a34a4-2f2c-4c9c-a8d4-73953b62e189.jpg?1",
             "name": "Sarkhan's Rage",
             "text": "Sarkhan's Rage deals 5 damage to any target. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
             "colours": [
@@ -19704,7 +19704,7 @@
         },
         {
             "id": "30693e30-578b-51f8-91ac-1117a3c3c7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeb27bc-bbdf-4ef1-89f5-ec91916c0d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caeb27bc-bbdf-4ef1-89f5-ec91916c0d4e.jpg?1",
             "name": "Sarkhan's Whelp",
             "text": "Flying\nWhenever you activate an ability of a Sarkhan planeswalker, Sarkhan's Whelp deals 1 damage to any target.",
             "colours": [
@@ -19737,7 +19737,7 @@
         },
         {
             "id": "f19ec4c8-d107-53ca-9dd2-6cbd92dd189e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f3c49-dbfa-4eab-a561-656e74266834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f3c49-dbfa-4eab-a561-656e74266834.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -19768,7 +19768,7 @@
         },
         {
             "id": "48ddcb8d-1754-5833-995f-d78d03c6e34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9154f49f-229f-4362-a8e1-616666a81bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9154f49f-229f-4362-a8e1-616666a81bee.jpg?1",
             "name": "Searing Spear",
             "text": "Searing Spear deals 3 damage to any target.",
             "colours": [
@@ -19799,7 +19799,7 @@
         },
         {
             "id": "b7bafcff-0e3a-5263-aad3-7a68c5947c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3.jpg?1",
             "name": "Seize the Storm",
             "text": "Create a red Elemental creature token with trample and \"This creature's power and toughness are each equal to the number of instant and sorcery cards in your graveyard plus the number of cards with flashback you own in exile.\"\nFlashback {6}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -19830,7 +19830,7 @@
         },
         {
             "id": "a4aa57ab-b554-568f-807d-b6a69dbdda98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e9434-5db8-4497-9dc9-a42f3675a1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e9434-5db8-4497-9dc9-a42f3675a1cc.jpg?1",
             "name": "Shredded Sails",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Shredded Sails deals 4 damage to target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -19861,7 +19861,7 @@
         },
         {
             "id": "fefdd1f6-3b1d-5044-b03a-bca632863b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ff279f-0ad2-4bbd-8eb2-2ddd422c65cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ff279f-0ad2-4bbd-8eb2-2ddd422c65cf.jpg?1",
             "name": "Smoldering Efreet",
             "text": "When Smoldering Efreet dies, it deals 2 damage to you.",
             "colours": [
@@ -19895,7 +19895,7 @@
         },
         {
             "id": "45e784e8-c104-52e8-8829-61b20b53889d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ec8275-80c0-4c1e-9432-a940a83756a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ec8275-80c0-4c1e-9432-a940a83756a0.jpg?1",
             "name": "Sokenzan Smelter",
             "text": "At the beginning of combat on your turn, you may pay {1} and sacrifice an artifact. If you do, create a 3/1 red Construct artifact creature token with haste.",
             "colours": [
@@ -19929,7 +19929,7 @@
         },
         {
             "id": "ad148878-780e-5c89-9d77-76960638b36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cfd7b9-bf10-4fad-b66b-896fcce451d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cfd7b9-bf10-4fad-b66b-896fcce451d6.jpg?1",
             "name": "Spark of Creativity",
             "text": "Choose target creature. Exile the top card of your library. You may have Spark of Creativity deal damage to that creature equal to the exiled card's mana value. If you don't, you may play that card until end of turn.",
             "colours": [
@@ -19960,7 +19960,7 @@
         },
         {
             "id": "a30ade37-6dd1-5af5-8f48-8dc1d05f321b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b652-f429-4b2a-ab43-ce551eb0a59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b652-f429-4b2a-ab43-ce551eb0a59d.jpg?1",
             "name": "Sparkmage Apprentice",
             "text": "When Sparkmage Apprentice enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -19994,7 +19994,7 @@
         },
         {
             "id": "49553bd9-9785-5d2b-8660-a2b1ab4e3ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af09cfd-1dd1-45a8-869b-b21bcb03f7ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af09cfd-1dd1-45a8-869b-b21bcb03f7ce.jpg?1",
             "name": "Sparktongue Dragon",
             "text": "Flying\nWhen Sparktongue Dragon enters the battlefield, you may pay {2}{R}. When you do, it deals 3 damage to any target.",
             "colours": [
@@ -20027,7 +20027,7 @@
         },
         {
             "id": "a93fb07e-b75f-5773-8753-2b3e5b0c2622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312069a7-bbe2-44a2-b00c-5f3b827f21ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312069a7-bbe2-44a2-b00c-5f3b827f21ae.jpg?1",
             "name": "Spellgorger Weird",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.",
             "colours": [
@@ -20060,7 +20060,7 @@
         },
         {
             "id": "44c2512a-ee85-5fe6-be2f-5528677f50d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972040b8-1033-4c5a-8c3b-369b942fc594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972040b8-1033-4c5a-8c3b-369b942fc594.jpg?1",
             "name": "Spiteful Prankster",
             "text": "As long as it's your turn, Spiteful Prankster has first strike.\nWhenever another creature dies, Spiteful Prankster deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -20093,7 +20093,7 @@
         },
         {
             "id": "a4b67343-2ea4-501e-ac4e-040a9b124dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2b0910-33e3-484c-97fc-2938d15e0d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2b0910-33e3-484c-97fc-2938d15e0d92.jpg?1",
             "name": "Starstorm",
             "text": "Starstorm deals X damage to each creature.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [
@@ -20124,7 +20124,7 @@
         },
         {
             "id": "7db1cac0-b9db-5391-9bac-94783c41ac34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f40a0c-89f1-4d6d-9297-99c90615d8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f40a0c-89f1-4d6d-9297-99c90615d8ed.jpg?1",
             "name": "Storm Fleet Pyromancer",
             "text": "Raid \u2014 When Storm Fleet Pyromancer enters the battlefield, if you attacked this turn, Storm Fleet Pyromancer deals 2 damage to any target.",
             "colours": [
@@ -20159,7 +20159,7 @@
         },
         {
             "id": "84415bb1-e330-5fa0-abb1-dabb18eaab69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502f2f7-e12b-4a3b-85ae-c0e69f210e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c502f2f7-e12b-4a3b-85ae-c0e69f210e8b.jpg?1",
             "name": "Subterranean Scout",
             "text": "When Subterranean Scout enters the battlefield, target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -20193,7 +20193,7 @@
         },
         {
             "id": "fea7a0ae-bbd9-535f-bc1a-0b59c56d18c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78dd917-7748-41dd-b294-943302bdab34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78dd917-7748-41dd-b294-943302bdab34.jpg?1",
             "name": "Sudden Breakthrough",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -20224,7 +20224,7 @@
         },
         {
             "id": "54d39676-f453-5aa2-b008-c450a843532e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09baa4e-4ae0-4509-ab48-51d31d367649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09baa4e-4ae0-4509-ab48-51d31d367649.jpg?1",
             "name": "Swaggering Corsair",
             "text": "Raid \u2014 Swaggering Corsair enters the battlefield with a +1/+1 counter on it if you attacked this turn.",
             "colours": [
@@ -20258,7 +20258,7 @@
         },
         {
             "id": "0fefbff6-c4a3-5a3d-b4c0-acac489a09fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1a9476-83bf-42a5-8194-b3681e3c95e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1a9476-83bf-42a5-8194-b3681e3c95e8.jpg?1",
             "name": "Swift Kick",
             "text": "Target creature you control gets +1/+0 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -20289,7 +20289,7 @@
         },
         {
             "id": "d59ead28-1d95-591f-8546-8e6618f7623c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46f4a46-50ee-4a1f-8ebf-36689e8184a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46f4a46-50ee-4a1f-8ebf-36689e8184a6.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -20325,7 +20325,7 @@
         },
         {
             "id": "ad3d079f-0fbd-57ef-9698-fb84b7c3358e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74130f80-5e62-41a5-80c5-8b08ee9f8a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74130f80-5e62-41a5-80c5-8b08ee9f8a10.jpg?1",
             "name": "Torch Courier",
             "text": "Haste\nSacrifice Torch Courier: Another target creature gains haste until end of turn.",
             "colours": [
@@ -20358,7 +20358,7 @@
         },
         {
             "id": "cfb3081e-7133-50c4-b300-9c034476abf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c337af5-35bf-4a80-8cc0-bb9af20305b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c337af5-35bf-4a80-8cc0-bb9af20305b3.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -20389,7 +20389,7 @@
         },
         {
             "id": "576ea51e-79fa-5758-803c-5ec09a52f662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf67f7a-00da-422b-b517-fb55990a1999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf67f7a-00da-422b-b517-fb55990a1999.jpg?1",
             "name": "Trove of Temptation",
             "text": "Each opponent must attack you or a planeswalker you control with at least one creature each combat if able.\nAt the beginning of your end step, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -20420,7 +20420,7 @@
         },
         {
             "id": "d9d061e2-4f63-5630-851f-fb7f139c86f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f67518-b5ea-4b9b-96b5-e01de054b348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f67518-b5ea-4b9b-96b5-e01de054b348.jpg?1",
             "name": "Vault Robber",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -20454,7 +20454,7 @@
         },
         {
             "id": "109da23e-05c7-520c-ab01-0b186f147244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379a456f-ebc7-4e15-8750-b710dd1edcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379a456f-ebc7-4e15-8750-b710dd1edcec.jpg?1",
             "name": "Viashino Pyromancer",
             "text": "When Viashino Pyromancer enters the battlefield, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -20488,7 +20488,7 @@
         },
         {
             "id": "e1dc4fa9-6d63-5307-94f7-6d42ce4fb257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e618a-eec3-4077-841e-4503b6a06963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e618a-eec3-4077-841e-4503b6a06963.jpg?1",
             "name": "Volley Veteran",
             "text": "When Volley Veteran enters the battlefield, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -20522,7 +20522,7 @@
         },
         {
             "id": "40779e33-4030-52ac-a7c0-0d95f9ab5d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c688b-7eb4-4741-9f6f-6f8d21b22cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c688b-7eb4-4741-9f6f-6f8d21b22cc5.jpg?1",
             "name": "War-Name Aspirant",
             "text": "Raid \u2014 War-Name Aspirant enters the battlefield with a +1/+1 counter on it if you attacked this turn.\nWar-Name Aspirant can't be blocked by creatures with power 1 or less.",
             "colours": [
@@ -20556,7 +20556,7 @@
         },
         {
             "id": "47230f93-9854-59d2-92bc-0f3ae9c06b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3824c432-38c2-40cc-a371-ba797dd963e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3824c432-38c2-40cc-a371-ba797dd963e4.jpg?1",
             "name": "Warcry Phoenix",
             "text": "Flying, haste\nWhenever you attack with three or more creatures, you may pay {2}{R}. If you do, return Warcry Phoenix from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -20589,7 +20589,7 @@
         },
         {
             "id": "8479920c-fb45-58ed-a21e-8e9adaca02d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6e6945-ce52-4e50-a558-9c974b08e781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6e6945-ce52-4e50-a558-9c974b08e781.jpg?1",
             "name": "Weaselback Redcap",
             "text": "{1}{R}: Weaselback Redcap gets +2/+0 until end of turn.",
             "colours": [
@@ -20623,7 +20623,7 @@
         },
         {
             "id": "a9a3c4b7-532d-5931-a9bf-45ffa089dc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed0ceb6-f0cf-410d-977d-68889f4b9a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed0ceb6-f0cf-410d-977d-68889f4b9a4f.jpg?1",
             "name": "Welding Sparks",
             "text": "Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.",
             "colours": [
@@ -20654,7 +20654,7 @@
         },
         {
             "id": "9f2e4d58-e706-5c0a-a0dc-0518509a42c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7b16f9-11f2-4612-9ef3-152826d0ae45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7b16f9-11f2-4612-9ef3-152826d0ae45.jpg?1",
             "name": "Wildfire Elemental",
             "text": "Whenever an opponent is dealt noncombat damage, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -20687,7 +20687,7 @@
         },
         {
             "id": "7998ada8-77d4-5434-8285-084fc351151a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d00a73-4699-4a94-b121-159a0d17c817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d00a73-4699-4a94-b121-159a0d17c817.jpg?1",
             "name": "Yidaro, Wandering Monster",
             "text": "Trample, haste\nCycling {1}{R}\nWhen you cycle Yidaro, Wandering Monster, shuffle it into your library from your graveyard. If you've cycled a card named Yidaro, Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead. (Do this before you draw.)",
             "colours": [
@@ -20723,7 +20723,7 @@
         },
         {
             "id": "5eff27c4-93d5-5c34-a02b-c49c82e1e9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -20757,7 +20757,7 @@
         },
         {
             "id": "7590d812-7a64-5139-a6ce-b2263f9a16c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a20507-7db5-4f6d-92cd-8065191fd002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a20507-7db5-4f6d-92cd-8065191fd002.jpg?1",
             "name": "Adventurous Impulse",
             "text": "Look at the top three cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -20788,7 +20788,7 @@
         },
         {
             "id": "934f2489-da80-5609-b0ec-0d10741da272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0ef635-3642-484a-beb9-d977e6cca9aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0ef635-3642-484a-beb9-d977e6cca9aa.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -20819,7 +20819,7 @@
         },
         {
             "id": "4ebba11d-3a48-5327-babd-958482708da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5f7be6-c30a-43f0-a371-e93a24cc5636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5f7be6-c30a-43f0-a371-e93a24cc5636.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -20852,7 +20852,7 @@
         },
         {
             "id": "c82debd2-d502-5ab7-9556-ba2ffb9f2bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ce531-48cb-4a52-a0ea-9cba5dcb4060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65ce531-48cb-4a52-a0ea-9cba5dcb4060.jpg?1",
             "name": "Baloth Woodcrasher",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Baloth Woodcrasher gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -20885,7 +20885,7 @@
         },
         {
             "id": "d5804f64-bbb5-5e0c-8f77-071611dec7f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e35b793-1b2c-4194-8186-c907197ff89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e35b793-1b2c-4194-8186-c907197ff89c.jpg?1",
             "name": "Band Together",
             "text": "Up to two target creatures you control each deal damage equal to their power to another target creature.",
             "colours": [
@@ -20916,7 +20916,7 @@
         },
         {
             "id": "33b67a02-614c-56e4-b77e-a8cc76419707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db1cc35-8901-4528-9100-38f12d89540c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db1cc35-8901-4528-9100-38f12d89540c.jpg?1",
             "name": "Blisterpod",
             "text": "Devoid (This card has no color.)\nWhen Blisterpod dies, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -20948,7 +20948,7 @@
         },
         {
             "id": "2fa1d1fc-5bbd-5321-bf35-c023382fdb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515d4a0a-61db-4be0-b9a3-cfd4c163f31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/515d4a0a-61db-4be0-b9a3-cfd4c163f31b.jpg?1",
             "name": "Bounding Wolf",
             "text": "Flash\nReach",
             "colours": [
@@ -20981,7 +20981,7 @@
         },
         {
             "id": "8cfa7780-de75-5eb5-845c-07967a4885e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c145-3ddf-45d8-a5f0-f757dbd94ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c2c145-3ddf-45d8-a5f0-f757dbd94ad1.jpg?1",
             "name": "Briarpack Alpha",
             "text": "Flash\nWhen Briarpack Alpha enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -21014,7 +21014,7 @@
         },
         {
             "id": "11296d69-0f27-52f7-8288-d958ee75f10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27591452-2750-4eed-bded-832bdee79e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27591452-2750-4eed-bded-832bdee79e00.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -21047,7 +21047,7 @@
         },
         {
             "id": "d94be596-c487-5f6c-8504-41e75dd970f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e084d745-ce11-4819-81c3-957b913fbe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e084d745-ce11-4819-81c3-957b913fbe4d.jpg?1",
             "name": "Broken Bond",
             "text": "Destroy target artifact or enchantment. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -21078,7 +21078,7 @@
         },
         {
             "id": "6ec0e878-d763-580e-a699-27e910d13a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5a6be1-f706-4681-9f95-512381be123e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5a6be1-f706-4681-9f95-512381be123e.jpg?1",
             "name": "Brood Monitor",
             "text": "Devoid (This card has no color.)\nWhen Brood Monitor enters the battlefield, create three 1/1 colorless Eldrazi Scion creature tokens. They have \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -21110,7 +21110,7 @@
         },
         {
             "id": "dd0526f6-f0fe-5ec7-8c5a-95c9b298b411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20920ff-ccfe-46a2-9b2e-0dc342f2e057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20920ff-ccfe-46a2-9b2e-0dc342f2e057.jpg?1",
             "name": "Canopy Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Canopy Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -21143,7 +21143,7 @@
         },
         {
             "id": "599c145a-ccbb-5c9b-9036-5eeed6aef072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef77d59-ad3d-4888-894b-7439f9a57999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef77d59-ad3d-4888-894b-7439f9a57999.jpg?1",
             "name": "Challenger Troll",
             "text": "Each creature you control with power 4 or greater can't be blocked by more than one creature.",
             "colours": [
@@ -21176,7 +21176,7 @@
         },
         {
             "id": "362c9c94-533b-527e-93f3-ff304b7357fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35fd2a8-cccd-4b35-b791-d70e74e203bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35fd2a8-cccd-4b35-b791-d70e74e203bc.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -21209,7 +21209,7 @@
         },
         {
             "id": "9602f337-7397-5b14-b2e4-ae1fa55039df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccc9e96-b3dd-4443-935e-621ec37f595b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccc9e96-b3dd-4443-935e-621ec37f595b.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play lands from the top of your library.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -21243,7 +21243,7 @@
         },
         {
             "id": "d4e97bba-a39a-5478-9c1a-88ebbd037258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedb008c-c89b-4093-8622-ee18e217de15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedb008c-c89b-4093-8622-ee18e217de15.jpg?1",
             "name": "Crawling Sensation",
             "text": "At the beginning of your upkeep, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nWhenever one or more land cards are put into your graveyard from anywhere for the first time each turn, create a 1/1 green Insect creature token.",
             "colours": [
@@ -21274,7 +21274,7 @@
         },
         {
             "id": "a89fcd55-0699-507c-b9f4-2b7dead9e14d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd21b3ae-37f0-4415-8f12-20aba6afbae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd21b3ae-37f0-4415-8f12-20aba6afbae4.jpg?1",
             "name": "Creeperhulk",
             "text": "Trample\n{1}{G}: Until end of turn, target creature you control has base power and toughness 5/5 and gains trample.",
             "colours": [
@@ -21308,7 +21308,7 @@
         },
         {
             "id": "d3a30b09-04c6-5130-988c-5b05310446ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075cac04-9397-4edb-b49a-485dd58dcae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075cac04-9397-4edb-b49a-485dd58dcae1.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -21339,7 +21339,7 @@
         },
         {
             "id": "bfdbc97e-fd7c-5c15-9f31-0f501fbca190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fce3a3a-56d8-4895-8110-27e5480e15fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fce3a3a-56d8-4895-8110-27e5480e15fd.jpg?1",
             "name": "Deadbridge Goliath",
             "text": "Scavenge {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -21372,7 +21372,7 @@
         },
         {
             "id": "ef52be6e-5262-56b1-8e2c-fe1ea205c36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f56fa52-9d92-4bf7-9dbc-a3da91e98087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f56fa52-9d92-4bf7-9dbc-a3da91e98087.jpg?1",
             "name": "Declare Dominance",
             "text": "Target creature gets +3/+3 until end of turn. All creatures able to block it this turn do so.",
             "colours": [
@@ -21403,7 +21403,7 @@
         },
         {
             "id": "2e38a170-e6c0-5276-aabb-b42aab7ce42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f1435-5900-47db-b7ec-57f71896f94b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846f1435-5900-47db-b7ec-57f71896f94b.jpg?1",
             "name": "Domesticated Hydra",
             "text": "{X}{G}{G}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nAs long as Domesticated Hydra is monstrous, it has trample.",
             "colours": [
@@ -21436,7 +21436,7 @@
         },
         {
             "id": "0f32827e-5e02-5451-bd12-843fcaebaad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59954cf9-2ea3-45c4-88e4-6c5005011f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59954cf9-2ea3-45c4-88e4-6c5005011f44.jpg?1",
             "name": "Drowsing Tyrannodon",
             "text": "Defender\nAs long as you control a creature with power 4 or greater, Drowsing Tyrannodon can attack as though it didn't have defender.",
             "colours": [
@@ -21469,7 +21469,7 @@
         },
         {
             "id": "a788eb80-8361-56f1-90e3-9b3bb4c2629e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931d53de-a1c7-4ed7-a8b9-e8e76ad4bfd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931d53de-a1c7-4ed7-a8b9-e8e76ad4bfd0.jpg?1",
             "name": "Drudge Beetle",
             "text": "Scavenge {5}{G} ({5}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -21502,7 +21502,7 @@
         },
         {
             "id": "e6f05fdf-8435-55b6-9a68-da5cb9d53290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c0088-124d-45ea-9214-f0a440681403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c0088-124d-45ea-9214-f0a440681403.jpg?1",
             "name": "Duskshell Crawler",
             "text": "When Duskshell Crawler enters the battlefield, put a +1/+1 counter on target creature.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -21535,7 +21535,7 @@
         },
         {
             "id": "00af7adf-9109-5029-8ce0-1e8b9aa9a49a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31eee7a7-af13-4de5-9f4b-5f803335cfc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31eee7a7-af13-4de5-9f4b-5f803335cfc5.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When Dwynen's Elite enters the battlefield, if you control another Elf, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -21569,7 +21569,7 @@
         },
         {
             "id": "0ffdd220-49b9-5f5e-a67e-e966b95b1247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175c5cf-b33d-481d-b093-57072f6f671e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175c5cf-b33d-481d-b093-57072f6f671e.jpg?1",
             "name": "Elderleaf Mentor",
             "text": "When Elderleaf Mentor enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -21603,7 +21603,7 @@
         },
         {
             "id": "23f99fa9-8e1c-57a9-b614-26f62edb1c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d986c6e3-dabc-4422-94b9-f7154935a355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d986c6e3-dabc-4422-94b9-f7154935a355.jpg?1",
             "name": "Elven Bow",
             "text": "When Elven Bow enters the battlefield, you may pay {2}. If you do, create a 1/1 green Elf Warrior creature token, then attach Elven Bow to it.\nEquipped creature gets +1/+2 and has reach.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -21636,7 +21636,7 @@
         },
         {
             "id": "8b64a3ed-f18f-5332-b20f-513c65a43ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc94b52-1cb1-4c1e-8b17-5632abc2490d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc94b52-1cb1-4c1e-8b17-5632abc2490d.jpg?1",
             "name": "Elvish Warmaster",
             "text": "Whenever one or more other Elves enter the battlefield under your control, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
             "colours": [
@@ -21670,7 +21670,7 @@
         },
         {
             "id": "15ab7bed-0e41-5206-a9b0-97e3a6eaf41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9180de1c-27ad-48f1-b9c1-2008623911d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9180de1c-27ad-48f1-b9c1-2008623911d0.jpg?1",
             "name": "Engulfing Slagwurm",
             "text": "Whenever Engulfing Slagwurm blocks or becomes blocked by a creature, destroy that creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -21703,7 +21703,7 @@
         },
         {
             "id": "7e2792af-ac73-5066-b9fa-1546e25f5f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33bd73-e15f-4bc2-8053-b34f849c1a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33bd73-e15f-4bc2-8053-b34f849c1a85.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -21734,7 +21734,7 @@
         },
         {
             "id": "3c537876-6d10-5c28-b5a5-def01765b781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81df4f6c-fa65-43cd-bad1-4f255d75d1aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81df4f6c-fa65-43cd-bad1-4f255d75d1aa.jpg?1",
             "name": "Feed the Pack",
             "text": "At the beginning of your end step, you may sacrifice a nontoken creature. If you do, create X 2/2 green Wolf creature tokens, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -21765,7 +21765,7 @@
         },
         {
             "id": "069fa98c-0471-5084-b942-f956f35a7f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d621a3-c613-44f2-a986-25d72dfa4ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d621a3-c613-44f2-a986-25d72dfa4ff6.jpg?1",
             "name": "Feral Hydra",
             "text": "Feral Hydra enters the battlefield with X +1/+1 counters on it.\n{3}: Put a +1/+1 counter on Feral Hydra. Any player may activate this ability.",
             "colours": [
@@ -21799,7 +21799,7 @@
         },
         {
             "id": "a4f8e843-21bf-5cc0-9124-ed7e04ca38e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee53763-7344-4627-93c3-b4a5b26b1f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee53763-7344-4627-93c3-b4a5b26b1f16.jpg?1",
             "name": "Ferocious Pup",
             "text": "When Ferocious Pup enters the battlefield, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -21832,7 +21832,7 @@
         },
         {
             "id": "74f8ae4a-295d-50b0-a13b-17deca4561e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f511123-4a07-4e80-aa85-e52ee4c7ea4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f511123-4a07-4e80-aa85-e52ee4c7ea4d.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles.",
             "colours": [
@@ -21865,7 +21865,7 @@
         },
         {
             "id": "c8df57aa-7e7a-5359-86cf-03c14ac7ac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797744c0-cfcc-43cb-baeb-bc2be3f7523d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797744c0-cfcc-43cb-baeb-bc2be3f7523d.jpg?1",
             "name": "Fierce Witchstalker",
             "text": "Trample\nWhen Fierce Witchstalker enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -21898,7 +21898,7 @@
         },
         {
             "id": "2e9cb1f0-40ba-530d-b062-420396d9cfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c03c782-cd45-45a6-8089-a603509ef0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c03c782-cd45-45a6-8089-a603509ef0ec.jpg?1",
             "name": "Flourishing Hunter",
             "text": "When Flourishing Hunter enters the battlefield, you gain life equal to the greatest toughness among other creatures you control.",
             "colours": [
@@ -21932,7 +21932,7 @@
         },
         {
             "id": "d17782e5-12dd-5910-8d8a-91191ba00d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86d6a38-78c9-4045-b72b-e6a3fa87861f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86d6a38-78c9-4045-b72b-e6a3fa87861f.jpg?1",
             "name": "Frontier Mastodon",
             "text": "Ferocious \u2014 Frontier Mastodon enters the battlefield with a +1/+1 counter on it if you control a creature with power 4 or greater.",
             "colours": [
@@ -21965,7 +21965,7 @@
         },
         {
             "id": "524e2890-cf28-5ae0-ab15-f68dbe05a273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b335f-16f3-474e-8bdc-7453b2fc62bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b335f-16f3-474e-8bdc-7453b2fc62bc.jpg?1",
             "name": "Gaea's Protector",
             "text": "Gaea's Protector must be blocked if able.",
             "colours": [
@@ -21999,7 +21999,7 @@
         },
         {
             "id": "c4f59c4e-5eed-5d1f-93d6-db1d8225c40b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b093537-962b-4707-8e17-a6a2b089a863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b093537-962b-4707-8e17-a6a2b089a863.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -22033,7 +22033,7 @@
         },
         {
             "id": "3433c88d-58c3-541f-b8a2-6a037ec66c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf3c63-2f8c-4f43-b08b-35a974214ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf3c63-2f8c-4f43-b08b-35a974214ad3.jpg?1",
             "name": "Giant Caterpillar",
             "text": "{G}, Sacrifice Giant Caterpillar: Create a 1/1 green Insect creature token with flying named Butterfly at the beginning of the next end step.",
             "colours": [
@@ -22066,7 +22066,7 @@
         },
         {
             "id": "2ff40ef1-904c-5283-a52c-dbd74a6eea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018fba0-a475-4df1-bb81-447c48f2e320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c018fba0-a475-4df1-bb81-447c48f2e320.jpg?1",
             "name": "Gift of the Gargantuan",
             "text": "Look at the top four cards of your library. You may reveal a creature card and/or a land card from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -22097,7 +22097,7 @@
         },
         {
             "id": "c9976617-0722-5822-909a-a2450fbe1acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6367056d-c066-40a3-b744-21a921bccc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6367056d-c066-40a3-b744-21a921bccc2c.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "Creature spells you cast with power 4 or greater cost {2} less to cast.\nWhenever Goreclaw, Terror of Qal Sisma attacks, each creature you control with power 4 or greater gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -22132,7 +22132,7 @@
         },
         {
             "id": "896a0fd7-93e5-5a02-a967-50818bd91aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fac3f2-68f5-4f6f-940d-285508fccdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fac3f2-68f5-4f6f-940d-285508fccdea.jpg?1",
             "name": "Groundswell",
             "text": "Target creature gets +2/+2 until end of turn.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -22163,7 +22163,7 @@
         },
         {
             "id": "d16cb2ba-e01a-537e-b177-3cc927eafc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3577918-58a0-4bcb-a037-f3932c1cdc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3577918-58a0-4bcb-a037-f3932c1cdc8a.jpg?1",
             "name": "Havenwood Wurm",
             "text": "Flash\nTrample",
             "colours": [
@@ -22196,7 +22196,7 @@
         },
         {
             "id": "75f83b98-4723-5301-a297-d8ff1769dcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829f217-4d59-442a-8a03-21bd93d84103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7829f217-4d59-442a-8a03-21bd93d84103.jpg?1",
             "name": "Hooting Mandrills",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTrample",
             "colours": [
@@ -22229,7 +22229,7 @@
         },
         {
             "id": "f692e3fc-849a-5b08-9cf1-120d7760a8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ca3780-5eff-439f-bdf6-23c449efce3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ca3780-5eff-439f-bdf6-23c449efce3c.jpg?1",
             "name": "Howl of the Hunt",
             "text": "Flash\nEnchant creature\nWhen Howl of the Hunt enters the battlefield, if enchanted creature is a Wolf or Werewolf, untap that creature.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -22262,7 +22262,7 @@
         },
         {
             "id": "2a7d2aa0-8dd3-514c-8243-c92f59e9565b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00502ed1-4364-41cd-b717-1f9e38d1afe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00502ed1-4364-41cd-b717-1f9e38d1afe6.jpg?1",
             "name": "Howlgeist",
             "text": "Creatures with power less than Howlgeist's power can't block it.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -22296,7 +22296,7 @@
         },
         {
             "id": "3243e8b3-5254-55f4-82a6-0ce7f227c197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a0d9c-315a-416e-a8af-ad12bc9b62fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a0d9c-315a-416e-a8af-ad12bc9b62fa.jpg?1",
             "name": "Hunger of the Howlpack",
             "text": "Put a +1/+1 counter on target creature.\nMorbid \u2014 Put three +1/+1 counters on that creature instead if a creature died this turn.",
             "colours": [
@@ -22327,7 +22327,7 @@
         },
         {
             "id": "39d5df03-bd5a-546e-9492-3702d496663f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ba254e-84bb-4d5c-8372-66f73e556b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ba254e-84bb-4d5c-8372-66f73e556b39.jpg?1",
             "name": "Hunter's Edge",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -22358,7 +22358,7 @@
         },
         {
             "id": "3b4223be-41a3-5adb-b9ee-5e871101eb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e931e8ec-78c1-473c-b772-d359842d8350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e931e8ec-78c1-473c-b772-d359842d8350.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -22391,7 +22391,7 @@
         },
         {
             "id": "ae8fd6d2-f9b7-5a8c-96cc-5b2921f7652e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525cf980-275e-423e-9470-e782ce4796dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525cf980-275e-423e-9470-e782ce4796dd.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elves you control get +1/+1.\n{G}, {T}: Create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -22425,7 +22425,7 @@
         },
         {
             "id": "26183c0e-6290-52ae-83e3-266237084025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424f3f1e-f61d-4130-8f1c-52698074cc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424f3f1e-f61d-4130-8f1c-52698074cc90.jpg?1",
             "name": "Iridescent Hornbeetle",
             "text": "At the beginning of your end step, create a 1/1 green Insect creature token for each +1/+1 counter you've put on creatures under your control this turn.",
             "colours": [
@@ -22458,7 +22458,7 @@
         },
         {
             "id": "f719eca7-10e9-5825-880d-8408483471d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ffe5ca-9b60-4882-ad17-5657bff0ae20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ffe5ca-9b60-4882-ad17-5657bff0ae20.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -22491,7 +22491,7 @@
         },
         {
             "id": "fbecb5e5-5ae7-5548-9c81-69c90a5594dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90202611-961d-48b5-87b6-58486b572216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90202611-961d-48b5-87b6-58486b572216.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.",
             "colours": [
@@ -22525,7 +22525,7 @@
         },
         {
             "id": "8c484010-ea76-5be3-b4f2-1a6d11e701b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d305e7c-81b2-460e-8f56-63cfbb018f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d305e7c-81b2-460e-8f56-63cfbb018f15.jpg?1",
             "name": "Kessig Cagebreakers",
             "text": "Whenever Kessig Cagebreakers attacks, create a 2/2 green Wolf creature token that's tapped and attacking for each creature card in your graveyard.",
             "colours": [
@@ -22559,7 +22559,7 @@
         },
         {
             "id": "55c0e09e-214d-545f-b06a-3bfa21fee46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae954a-faf5-47db-bdee-312652086df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae954a-faf5-47db-bdee-312652086df5.jpg?1",
             "name": "Kraul Foragers",
             "text": "Undergrowth \u2014 When Kraul Foragers enters the battlefield, you gain 1 life for each creature card in your graveyard.",
             "colours": [
@@ -22593,7 +22593,7 @@
         },
         {
             "id": "a42d4592-e1c6-5af6-be88-77f612683e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce45a70-7fbc-42f8-8608-980eb4aee2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce45a70-7fbc-42f8-8608-980eb4aee2b8.jpg?1",
             "name": "Kraul Harpooner",
             "text": "Reach\nUndergrowth \u2014 When Kraul Harpooner enters the battlefield, choose up to one target creature with flying you don't control. Kraul Harpooner gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have Kraul Harpooner fight that creature.",
             "colours": [
@@ -22627,7 +22627,7 @@
         },
         {
             "id": "0f790f0b-0e16-5aec-9ca4-e1a0e8b1b10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7b87d-cd5c-45de-a7bd-e834337f3400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fd7b87d-cd5c-45de-a7bd-e834337f3400.jpg?1",
             "name": "Kraul Warrior",
             "text": "{5}{G}: Kraul Warrior gets +3/+3 until end of turn.",
             "colours": [
@@ -22661,7 +22661,7 @@
         },
         {
             "id": "cc0baea2-76d0-555a-8ba8-d2f367acd93c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d81bf-a573-441f-9593-41af41d927d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8d81bf-a573-441f-9593-41af41d927d2.jpg?1",
             "name": "Kujar Seedsculptor",
             "text": "When Kujar Seedsculptor enters the battlefield, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -22695,7 +22695,7 @@
         },
         {
             "id": "4321844b-2a3a-5f0a-a508-a410cd99a487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df23b1-7d28-403f-bf12-d4ec81500c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df23b1-7d28-403f-bf12-d4ec81500c36.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "Whenever you cast an Elf spell, you may create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -22729,7 +22729,7 @@
         },
         {
             "id": "952958a2-dd72-5f04-8931-b49379067208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac46277-1980-40aa-8356-dd283bda297b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac46277-1980-40aa-8356-dd283bda297b.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach",
             "colours": [
@@ -22762,7 +22762,7 @@
         },
         {
             "id": "bc25cb65-b9d8-522d-a18e-94202529001e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cace1a3-34df-45d0-b653-b120b3617d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cace1a3-34df-45d0-b653-b120b3617d40.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "At the beginning of your upkeep, create a 2/2 green Wolf creature token.\n{T}: Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves.",
             "colours": [
@@ -22796,7 +22796,7 @@
         },
         {
             "id": "84273559-faf7-58eb-8173-4674a3627b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0fef06-aaf8-4476-a321-199a466f8400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0fef06-aaf8-4476-a321-199a466f8400.jpg?1",
             "name": "Master's Rebuke",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -22827,7 +22827,7 @@
         },
         {
             "id": "a771240c-9c0f-55ac-8cc3-34706b67bd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a87b43-84bb-4878-85c3-490d283a2a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a87b43-84bb-4878-85c3-490d283a2a77.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -22858,7 +22858,7 @@
         },
         {
             "id": "e7f9369b-3cd1-5968-92cc-0e176bc7e978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fc5e1-013d-485d-a4a1-bf616a53098d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fc5e1-013d-485d-a4a1-bf616a53098d.jpg?1",
             "name": "Moldgraf Millipede",
             "text": "When Moldgraf Millipede enters the battlefield, mill three cards, then put a +1/+1 counter on Moldgraf Millipede for each creature card in your graveyard. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -22892,7 +22892,7 @@
         },
         {
             "id": "d4216332-2653-5a0a-833d-444558a8666f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7afc6-dcc2-45ce-99e8-696cd5a11466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7afc6-dcc2-45ce-99e8-696cd5a11466.jpg?1",
             "name": "Moonlight Hunt",
             "text": "Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf deals damage equal to its power to that creature.",
             "colours": [
@@ -22923,7 +22923,7 @@
         },
         {
             "id": "f4847337-7591-5b8f-a17b-daa853dab1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a6d4d-693e-4170-bda8-2e21540e69c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a6d4d-693e-4170-bda8-2e21540e69c9.jpg?1",
             "name": "Naga Vitalist",
             "text": "{T}: Add one mana of any type that a land you control could produce.",
             "colours": [
@@ -22957,7 +22957,7 @@
         },
         {
             "id": "c322bc99-c1d3-54a3-ab8a-8132b681ab1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069a7b3-adad-4d46-a0ed-09fb62790699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f069a7b3-adad-4d46-a0ed-09fb62790699.jpg?1",
             "name": "Nantuko Cultivator",
             "text": "When Nantuko Cultivator enters the battlefield, you may discard any number of land cards. Put that many +1/+1 counters on Nantuko Cultivator and draw that many cards.",
             "colours": [
@@ -22991,7 +22991,7 @@
         },
         {
             "id": "c47ace5b-86b0-50da-a5bd-480d5a4d8a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7f2302-9bd2-45fe-b27c-1e3eed74a465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7f2302-9bd2-45fe-b27c-1e3eed74a465.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on Nessian Hornbeetle.",
             "colours": [
@@ -23024,7 +23024,7 @@
         },
         {
             "id": "01e3f008-f1fc-5c71-95ec-555b3ddb21eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd67241-6ff1-41bc-9bda-4a87fd4f6bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd67241-6ff1-41bc-9bda-4a87fd4f6bdd.jpg?1",
             "name": "Nightpack Ambusher",
             "text": "Flash\nOther Wolves and Werewolves you control get +1/+1.\nAt the beginning of your end step, if you didn't cast a spell this turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -23057,7 +23057,7 @@
         },
         {
             "id": "9de9f6da-cbc3-5a3a-93b2-6c5ef2ac9c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a8c23-4d30-4b0b-8561-b8c22bbc194a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a8c23-4d30-4b0b-8561-b8c22bbc194a.jpg?1",
             "name": "Oashra Cultivator",
             "text": "{2}{G}, {T}, Sacrifice Oashra Cultivator: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -23091,7 +23091,7 @@
         },
         {
             "id": "408eea16-861b-586d-b8d1-47621363e590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af65ef1-d4e4-4fdb-819f-a0dbe7b62376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af65ef1-d4e4-4fdb-819f-a0dbe7b62376.jpg?1",
             "name": "Ondu Giant",
             "text": "When Ondu Giant enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -23125,7 +23125,7 @@
         },
         {
             "id": "1e79f430-7c60-5c61-9a79-97ed58779545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f551c983-8bbd-4698-b6af-f22c8eba1ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f551c983-8bbd-4698-b6af-f22c8eba1ea5.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea.\nWhen you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -23158,7 +23158,7 @@
         },
         {
             "id": "52dd3981-8293-5ec6-8c6d-39375522c5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac24ccd-8db0-4c93-9542-0eac3b369d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac24ccd-8db0-4c93-9542-0eac3b369d61.jpg?1",
             "name": "Ornery Dilophosaur",
             "text": "Deathtouch\nWhenever Ornery Dilophosaur attacks, if you control a creature with power 4 or greater, Ornery Dilophosaur gets +2/+2 until end of turn.",
             "colours": [
@@ -23191,7 +23191,7 @@
         },
         {
             "id": "6e7d7427-ef7c-56ae-a4b9-ef8a714befa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f1dab-24c5-4bcd-bcc0-d282f28c8689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f1dab-24c5-4bcd-bcc0-d282f28c8689.jpg?1",
             "name": "Overcome",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -23222,7 +23222,7 @@
         },
         {
             "id": "daa2d181-5f01-56e9-9886-d59d40da9362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce941f72-27b6-4fb5-a303-630686fb97a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce941f72-27b6-4fb5-a303-630686fb97a9.jpg?1",
             "name": "Overgrowth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}{G}.",
             "colours": [
@@ -23255,7 +23255,7 @@
         },
         {
             "id": "2733e9d8-789b-5964-ab27-c343d3389994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565640bf-cc41-4365-b1f7-54f66ebcfa01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565640bf-cc41-4365-b1f7-54f66ebcfa01.jpg?1",
             "name": "Packsong Pup",
             "text": "At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1 counter on Packsong Pup.\nWhen Packsong Pup dies, you gain life equal to its power.",
             "colours": [
@@ -23288,7 +23288,7 @@
         },
         {
             "id": "df415314-e60a-5d2c-8c30-c494bfbe8441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863cac64-ceb6-4c3c-8f66-72c579ff2954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863cac64-ceb6-4c3c-8f66-72c579ff2954.jpg?1",
             "name": "Paradise Druid",
             "text": "Paradise Druid has hexproof as long as it's untapped.(It can't be the target of spells or abilities your opponents control.)\n{T}: Add one mana of any color.",
             "colours": [
@@ -23322,7 +23322,7 @@
         },
         {
             "id": "84caf057-2a8e-5a54-951d-481f47882ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed46aa9c-bcf1-4853-abbe-8bae3499aa2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed46aa9c-bcf1-4853-abbe-8bae3499aa2d.jpg?1",
             "name": "Pestilent Wolf",
             "text": "{2}{G}: Pestilent Wolf gains deathtouch until end of turn.",
             "colours": [
@@ -23355,7 +23355,7 @@
         },
         {
             "id": "479a1dbb-24d4-5ad6-90f4-68cad113c27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0b9478-0fe5-4c4c-b634-bde8bc225195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0b9478-0fe5-4c4c-b634-bde8bc225195.jpg?1",
             "name": "Phantom Nantuko",
             "text": "Trample\nPhantom Nantuko enters the battlefield with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Nantuko, prevent that damage. Remove a +1/+1 counter from Phantom Nantuko.\n{T}: Put a +1/+1 counter on Phantom Nantuko.",
             "colours": [
@@ -23389,7 +23389,7 @@
         },
         {
             "id": "4a388f38-8170-5bcc-99b1-bef673e7b90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052864bb-6f76-482a-961e-b427af135da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052864bb-6f76-482a-961e-b427af135da0.jpg?1",
             "name": "Pounce",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -23420,7 +23420,7 @@
         },
         {
             "id": "d7c83e60-9087-51ba-81cf-634dd7a6df45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0976212-1e3f-4a31-ac56-15827fdbe28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0976212-1e3f-4a31-ac56-15827fdbe28d.jpg?1",
             "name": "Predator's Howl",
             "text": "Create a 2/2 green Wolf creature token.\nMorbid \u2014 Create three 2/2 green Wolf creature tokens instead if a creature died this turn.",
             "colours": [
@@ -23451,7 +23451,7 @@
         },
         {
             "id": "8b966590-69b4-5d25-82f3-30bb980ac71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fcba6c-c078-4a0d-be68-984536d91831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fcba6c-c078-4a0d-be68-984536d91831.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Create a 1/1 green Elf Warrior creature token.\"",
             "colours": [
@@ -23484,7 +23484,7 @@
         },
         {
             "id": "3b281663-bef9-5f14-b249-14a5480139a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8c721f-93b8-4c43-9054-2168f66726db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8c721f-93b8-4c43-9054-2168f66726db.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -23515,7 +23515,7 @@
         },
         {
             "id": "854167f9-906d-5b2c-91e3-a9cd9ef6d172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd004c-50a8-43df-9dec-a7822b720966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd004c-50a8-43df-9dec-a7822b720966.jpg?1",
             "name": "Pridemalkin",
             "text": "When Pridemalkin enters the battlefield, put a +1/+1 counter on target creature you control.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -23548,7 +23548,7 @@
         },
         {
             "id": "8a5e4a2d-fde9-583e-b790-4070d94de4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a83f0aa-55bc-4528-b521-7b4223ed4a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a83f0aa-55bc-4528-b521-7b4223ed4a6e.jpg?1",
             "name": "Primordial Hydra",
             "text": "Primordial Hydra enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Primordial Hydra.\nPrimordial Hydra has trample as long as it has ten or more +1/+1 counters on it.",
             "colours": [
@@ -23581,7 +23581,7 @@
         },
         {
             "id": "4802de1e-9d6a-5cdb-999c-82cccbc56c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d1c576-0203-4ede-8728-1efa87c33d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d1c576-0203-4ede-8728-1efa87c33d20.jpg?1",
             "name": "Prowling Serpopard",
             "text": "This spell can't be countered.\nCreature spells you control can't be countered.",
             "colours": [
@@ -23615,7 +23615,7 @@
         },
         {
             "id": "39690413-5256-505a-ad2f-23b63028bf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0614fe56-aafb-4e7b-96b9-a940735da560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0614fe56-aafb-4e7b-96b9-a940735da560.jpg?1",
             "name": "Quarry Beetle",
             "text": "When Quarry Beetle enters the battlefield, you may return target land card from your graveyard to the battlefield.",
             "colours": [
@@ -23648,7 +23648,7 @@
         },
         {
             "id": "f55eb810-667d-5695-a37e-4ce1dea278f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4de4-c6f5-43f5-b9f0-f1e9414b7748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4de4-c6f5-43f5-b9f0-f1e9414b7748.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -23681,7 +23681,7 @@
         },
         {
             "id": "f5f20528-35bc-56c6-a50f-745bd4861a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71235882-5d2e-4250-8b2a-24a5d502e88d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71235882-5d2e-4250-8b2a-24a5d502e88d.jpg?1",
             "name": "Reckless Amplimancer",
             "text": "{4}{G}: Double Reckless Amplimancer's power and toughness until end of turn.",
             "colours": [
@@ -23715,7 +23715,7 @@
         },
         {
             "id": "f9107300-cac6-5536-a637-b21e7cd88897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67127e1-accb-49a5-99c6-4508d5dd81da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67127e1-accb-49a5-99c6-4508d5dd81da.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -23749,7 +23749,7 @@
         },
         {
             "id": "137cfc2f-af2d-50bb-bb81-e109e2122016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f6140e-4e96-478b-8a77-dc5100a9f95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f6140e-4e96-478b-8a77-dc5100a9f95e.jpg?1",
             "name": "Relentless Pursuit",
             "text": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -23780,7 +23780,7 @@
         },
         {
             "id": "df8f5e10-be1e-5f64-8281-9217478d3826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bd038-727f-4e7e-8b87-fccc7b2ca0a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bd038-727f-4e7e-8b87-fccc7b2ca0a6.jpg?1",
             "name": "Rhonas the Indomitable",
             "text": "Deathtouch, indestructible\nRhonas the Indomitable can't attack or block unless you control another creature with power 4 or greater.\n{2}{G}: Another target creature gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -23815,7 +23815,7 @@
         },
         {
             "id": "cb9aba3a-16ab-53a9-8d7c-d11925df721c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f303e0-4832-4d8d-b1b1-9ff16283f4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f303e0-4832-4d8d-b1b1-9ff16283f4b5.jpg?1",
             "name": "Roar of Challenge",
             "text": "All creatures able to block target creature this turn do so.\nFerocious \u2014 That creature gains indestructible until end of turn if you control a creature with power 4 or greater. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -23846,7 +23846,7 @@
         },
         {
             "id": "251de176-9a6a-5e83-a862-b24a3ca8a4bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacd6f7b-3bb7-4957-afb6-f59881b55bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacd6f7b-3bb7-4957-afb6-f59881b55bb1.jpg?1",
             "name": "Roots of Wisdom",
             "text": "Mill three cards, then return a land card or Elf card from your graveyard to your hand. If you can't, draw a card. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -23877,7 +23877,7 @@
         },
         {
             "id": "e805b7e0-1c10-5d52-9a99-8f6c37b8a5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9c52ec-5ca1-43d9-85bf-6f2c515a6151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9c52ec-5ca1-43d9-85bf-6f2c515a6151.jpg?1",
             "name": "Rosethorn Halberd",
             "text": "When Rosethorn Halberd enters the battlefield, attach it to target non-Human creature you control.\nEquipped creature gets +2/+1.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -23910,7 +23910,7 @@
         },
         {
             "id": "6aa480c9-a679-5f05-b9ae-a667a084eaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39db8020-86a6-4ff2-8715-654121c2f3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39db8020-86a6-4ff2-8715-654121c2f3a2.jpg?1",
             "name": "Savage Punch",
             "text": "Target creature you control fights target creature you don't control.\nFerocious \u2014 The creature you control gets +2/+2 until end of turn before it fights if you control a creature with power 4 or greater. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -23941,7 +23941,7 @@
         },
         {
             "id": "6b93ecca-5810-53be-b1ef-cf8820a9a9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f2f01-ff8f-48db-8bad-cb0eba2346d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f2f01-ff8f-48db-8bad-cb0eba2346d1.jpg?1",
             "name": "Scale the Heights",
             "text": "Put a +1/+1 counter on up to one target creature. You gain 2 life. You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -23972,7 +23972,7 @@
         },
         {
             "id": "288ada96-3b03-5c0d-ab6f-1b56114bc974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709bf1f-9bbb-4da7-a1ea-7deb94858b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e709bf1f-9bbb-4da7-a1ea-7deb94858b8c.jpg?1",
             "name": "Scion Summoner",
             "text": "Devoid (This card has no color.)\nWhen Scion Summoner enters the battlefield, create a 1/1 colorless Eldrazi Scion creature token. It has \"Sacrifice this creature: Add {C}.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -24004,7 +24004,7 @@
         },
         {
             "id": "231b75d4-27d7-56a7-8984-ad9d604599a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f050b4-ae64-47ae-8e55-047e7a588d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f050b4-ae64-47ae-8e55-047e7a588d9c.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -24038,7 +24038,7 @@
         },
         {
             "id": "48c4652a-f5fa-578f-8374-866364ac98c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1091-01bd-4540-8681-344085b5ff84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ea1091-01bd-4540-8681-344085b5ff84.jpg?1",
             "name": "Servant of the Scale",
             "text": "Servant of the Scale enters the battlefield with a +1/+1 counter on it.\nWhen Servant of the Scale dies, put X +1/+1 counters on target creature you control, where X is the number of +1/+1 counters on Servant of the Scale.",
             "colours": [
@@ -24072,7 +24072,7 @@
         },
         {
             "id": "dad769f3-0c82-55bb-8f74-ad699af341a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49463346-99b6-422f-9577-34873dd13d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49463346-99b6-422f-9577-34873dd13d36.jpg?1",
             "name": "Silverback Shaman",
             "text": "Trample\nWhen Silverback Shaman dies, draw a card.",
             "colours": [
@@ -24106,7 +24106,7 @@
         },
         {
             "id": "5343629e-f495-52c5-aeaf-a80fd845645a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20f5455-70ac-416c-8cf4-021b41e51a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20f5455-70ac-416c-8cf4-021b41e51a7e.jpg?1",
             "name": "Simian Brawler",
             "text": "Discard a land card: Simian Brawler gets +1/+1 until end of turn.",
             "colours": [
@@ -24140,7 +24140,7 @@
         },
         {
             "id": "2c1c129a-56b6-524a-872a-26c08d48fc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062c430-c8a4-4f35-83b5-21519b6c0edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062c430-c8a4-4f35-83b5-21519b6c0edc.jpg?1",
             "name": "Snapping Gnarlid",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Snapping Gnarlid gets +1/+1 until end of turn.",
             "colours": [
@@ -24173,7 +24173,7 @@
         },
         {
             "id": "9632036d-d83a-5e15-b629-3816b562007c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a912a5-8318-4cb3-aa62-6f826eaeb22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a912a5-8318-4cb3-aa62-6f826eaeb22b.jpg?1",
             "name": "Soul's Might",
             "text": "Put X +1/+1 counters on target creature, where X is that creature's power.",
             "colours": [
@@ -24204,7 +24204,7 @@
         },
         {
             "id": "03a7737c-6081-5321-9d2b-63c64186929a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37992e3-93b9-4c9d-b9a3-99c38df7464b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37992e3-93b9-4c9d-b9a3-99c38df7464b.jpg?1",
             "name": "Sporeback Wolf",
             "text": "As long as it's your turn, Sporeback Wolf gets +0/+2.",
             "colours": [
@@ -24237,7 +24237,7 @@
         },
         {
             "id": "364e71b7-3508-5fa6-8c42-d24675877bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301cb90-5b50-4ea6-968c-3641baccb140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301cb90-5b50-4ea6-968c-3641baccb140.jpg?1",
             "name": "Stalking Drone",
             "text": "Devoid (This card has no color.)\n{C}: Stalking Drone gets +1/+2 until end of turn. Activate only once each turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -24269,7 +24269,7 @@
         },
         {
             "id": "34e7fdf8-19ca-5570-8d2b-254576a683b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ccad14-ec2b-4235-a917-c0355c16599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ccad14-ec2b-4235-a917-c0355c16599a.jpg?1",
             "name": "Swarm Shambler",
             "text": "Swarm Shambler enters the battlefield with a +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.\n{1}, {T}: Put a +1/+1 counter on Swarm Shambler.",
             "colours": [
@@ -24303,7 +24303,7 @@
         },
         {
             "id": "28cb4dce-216b-5f7a-9d8f-c43c144baaed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d6534c-c77d-4d58-ab9a-a4897ca17e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d6534c-c77d-4d58-ab9a-a4897ca17e6a.jpg?1",
             "name": "Titanic Brawl",
             "text": "This spell costs {1} less to cast if it targets a creature you control with a +1/+1 counter on it.\nTarget creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -24334,7 +24334,7 @@
         },
         {
             "id": "32e83893-5f84-5e89-b737-a8184b6b1113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee515542-a636-45bf-a63a-04ffcf2b23c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee515542-a636-45bf-a63a-04ffcf2b23c6.jpg?1",
             "name": "Turntimber Basilisk",
             "text": "Deathtouch\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target creature block Turntimber Basilisk this turn if able.",
             "colours": [
@@ -24367,7 +24367,7 @@
         },
         {
             "id": "2d298f5a-723f-521a-ab68-dc298f7d75bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3785a6d2-4120-4190-b398-d63ab1eb36fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3785a6d2-4120-4190-b398-d63ab1eb36fe.jpg?1",
             "name": "Unnatural Aggression",
             "text": "Devoid (This card has no color.)\nTarget creature you control fights target creature an opponent controls. If the creature an opponent controls would die this turn, exile it instead. (Creatures that fight each deal damage equal to their power to the other.)",
             "colours": [],
@@ -24396,7 +24396,7 @@
         },
         {
             "id": "fefc2c50-610e-5670-921a-419dd6731b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ab77b-cd98-4889-afcc-884940999d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75ab77b-cd98-4889-afcc-884940999d48.jpg?1",
             "name": "Wildborn Preserver",
             "text": "Flash\nReach\nWhenever another non-Human creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on Wildborn Preserver.",
             "colours": [
@@ -24430,7 +24430,7 @@
         },
         {
             "id": "af6cd4c4-de5c-5211-a40e-d2f50c699bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4fe963-5bf3-473a-afbd-0b93f5791279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4fe963-5bf3-473a-afbd-0b93f5791279.jpg?1",
             "name": "Wily Bandar",
             "text": "{2}{G}: Wily Bandar gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -24464,7 +24464,7 @@
         },
         {
             "id": "59747f7e-30ba-53ed-b7e8-2c2dc11ccdab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2f778-2ad0-4b80-9296-f37c6090f8ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2f778-2ad0-4b80-9296-f37c6090f8ff.jpg?1",
             "name": "Wolf's Quarry",
             "text": "Create three 1/1 green Boar creature tokens with \"When this creature dies, create a Food token.\" (A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -24495,7 +24495,7 @@
         },
         {
             "id": "f6baebec-efe5-5367-bf32-607cbaf4e660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40101dc6-4354-4f0a-aa90-946ed78d731e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40101dc6-4354-4f0a-aa90-946ed78d731e.jpg?1",
             "name": "Wolfkin Bond",
             "text": "Enchant creature\nWhen Wolfkin Bond enters the battlefield, create a 2/2 green Wolf creature token.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -24528,7 +24528,7 @@
         },
         {
             "id": "7feba69a-ee66-5425-b006-f530465bdd01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d135a17-2d93-41d9-be1d-80aa55f1050a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d135a17-2d93-41d9-be1d-80aa55f1050a.jpg?1",
             "name": "Wolfwillow Haven",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.\n{4}{G}, Sacrifice Wolfwillow Haven: Create a 2/2 green Wolf creature token. Activate only during your turn.",
             "colours": [
@@ -24561,7 +24561,7 @@
         },
         {
             "id": "5118fa0b-3d27-54c8-9274-b33979415022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575d407c-c37e-4664-b2e3-217dfd5a78a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/575d407c-c37e-4664-b2e3-217dfd5a78a2.jpg?1",
             "name": "Wolverine Riders",
             "text": "At the beginning of each upkeep, create a 1/1 green Elf Warrior creature token.\nWhenever another Elf enters the battlefield under your control, you gain life equal to its toughness.",
             "colours": [
@@ -24595,7 +24595,7 @@
         },
         {
             "id": "bf4d9218-56ef-5a11-acb1-f07013d43c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f887474-760c-4f33-8051-35b9d2e65307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f887474-760c-4f33-8051-35b9d2e65307.jpg?1",
             "name": "Woodborn Behemoth",
             "text": "As long as you control eight or more lands, Woodborn Behemoth gets +4/+4 and has trample.",
             "colours": [
@@ -24628,7 +24628,7 @@
         },
         {
             "id": "8a6df0af-b79c-5395-9168-3009f4d9b899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c0f16f-55c5-4334-bcec-08bf46d71d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c0f16f-55c5-4334-bcec-08bf46d71d88.jpg?1",
             "name": "Woodland Champion",
             "text": "Whenever one or more tokens enter the battlefield under your control, put that many +1/+1 counters on Woodland Champion.",
             "colours": [
@@ -24662,7 +24662,7 @@
         },
         {
             "id": "76dd4de4-ae74-5d30-b8e5-8a20672bd895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dccb5f-dca4-44d1-bbbf-a84dd016fbb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dccb5f-dca4-44d1-bbbf-a84dd016fbb1.jpg?1",
             "name": "Young Wolf",
             "text": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -24695,7 +24695,7 @@
         },
         {
             "id": "a77bf30b-bc2e-5b01-aa69-3e775bc6b3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0768ee-aa58-48ca-91e8-64332af5dcfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0768ee-aa58-48ca-91e8-64332af5dcfe.jpg?1",
             "name": "Zendikar's Roil",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 2/2 green Elemental creature token.",
             "colours": [
@@ -24726,7 +24726,7 @@
         },
         {
             "id": "8e2c465d-3654-59ad-872b-f11ca3ac01e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ee3947-e147-4d04-bb01-161a72ffdf0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ee3947-e147-4d04-bb01-161a72ffdf0e.jpg?1",
             "name": "Endbringer",
             "text": "Untap Endbringer during each other player's untap step.\n{T}: Endbringer deals 1 damage to any target.\n{C}, {T}: Target creature can't attack or block this turn.\n{C}{C}, {T}: Draw a card.",
             "colours": [],
@@ -24755,7 +24755,7 @@
         },
         {
             "id": "388cbef6-9d0f-52c4-98d0-a7b716c92988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca258b-981f-4762-a398-ae8de81f6713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ca258b-981f-4762-a398-ae8de81f6713.jpg?1",
             "name": "Titan's Presence",
             "text": "As an additional cost to cast this spell, reveal a colorless creature card from your hand.\nExile target creature if its power is less than or equal to the revealed card's power.",
             "colours": [],
@@ -24782,7 +24782,7 @@
         },
         {
             "id": "cc9c0fd0-d6c5-5cfa-8381-07f40e69d7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c06a62-ae48-4732-94d8-659917201726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c06a62-ae48-4732-94d8-659917201726.jpg?1",
             "name": "Warden of Geometries",
             "text": "Vigilance\n{T}: Add {C}. ({C} represents colorless mana.)",
             "colours": [],
@@ -24812,7 +24812,7 @@
         },
         {
             "id": "869124e7-1ecd-5712-9e3d-496a2a44e14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7493ccb-98a1-4032-9e01-5535d29e106b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7493ccb-98a1-4032-9e01-5535d29e106b.jpg?1",
             "name": "Adventuring Gear",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -24841,7 +24841,7 @@
         },
         {
             "id": "6fb877a3-c4bd-50fa-9ac2-252099306414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee539bda-62b4-40fb-95d3-c7d1fc0a7e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee539bda-62b4-40fb-95d3-c7d1fc0a7e09.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice Aether Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice Aether Spellbomb: Draw a card.",
             "colours": [],
@@ -24870,7 +24870,7 @@
         },
         {
             "id": "2cb892be-cb66-512f-8f6f-8da5469573cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d22523a-bb2d-489d-994e-65455def4fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d22523a-bb2d-489d-994e-65455def4fc5.jpg?1",
             "name": "Alchemist's Vial",
             "text": "When Alchemist's Vial enters the battlefield, draw a card.\n{1}, {T}, Sacrifice Alchemist's Vial: Target creature can't attack or block this turn.",
             "colours": [],
@@ -24897,7 +24897,7 @@
         },
         {
             "id": "a866000b-b1f1-5159-8074-58bc67ea3d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28fa0c-5c88-40cd-8295-8d56c76a7938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28fa0c-5c88-40cd-8295-8d56c76a7938.jpg?1",
             "name": "Aradara Express",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -24926,7 +24926,7 @@
         },
         {
             "id": "318b1c56-af64-5f40-a60a-063b1ef63c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af30619-272f-4574-a9cf-f2e83167ac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af30619-272f-4574-a9cf-f2e83167ac35.jpg?1",
             "name": "Assembly-Worker",
             "text": "{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -24956,7 +24956,7 @@
         },
         {
             "id": "ea80de57-0905-5bd2-83a1-2095869e8d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e799bd-87c7-4f62-87a9-6f8f8d459db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e799bd-87c7-4f62-87a9-6f8f8d459db8.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -24983,7 +24983,7 @@
         },
         {
             "id": "7606f3f7-a808-5f4d-81c2-3cae5ec4c1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69696834-d306-4431-9279-37143c9ac00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69696834-d306-4431-9279-37143c9ac00a.jpg?1",
             "name": "Bloodline Pretender",
             "text": "Changeling (This card is every creature type.)\nAs Bloodline Pretender enters the battlefield, choose a creature type.\nWhenever another creature of the chosen type enters the battlefield under your control, put a +1/+1 counter on Bloodline Pretender.",
             "colours": [],
@@ -25013,7 +25013,7 @@
         },
         {
             "id": "5f0478c7-1ae6-59fe-b46f-876518e49ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7655790-d091-47d6-8387-08bfa4333f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7655790-d091-47d6-8387-08bfa4333f19.jpg?1",
             "name": "Campus Guide",
             "text": "When Campus Guide enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -25043,7 +25043,7 @@
         },
         {
             "id": "ef9dab8d-58a2-5c4b-b64c-f4f69f6379d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b217c-c3d4-4cdb-9ee7-2cf7c8d0eb7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b217c-c3d4-4cdb-9ee7-2cf7c8d0eb7b.jpg?1",
             "name": "Cellar Door",
             "text": "{3}, {T}: Target player puts the bottom card of their library into their graveyard. If it's a creature card, you create a 2/2 black Zombie creature token.",
             "colours": [],
@@ -25070,7 +25070,7 @@
         },
         {
             "id": "d1a14288-8f6d-5907-8f3b-10d596b29eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6fc201-9365-40be-bc59-f3715fd3d15d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6fc201-9365-40be-bc59-f3715fd3d15d.jpg?1",
             "name": "Circuit Mender",
             "text": "When Circuit Mender enters the battlefield, you gain 2 life.\nWhen Circuit Mender leaves the battlefield, draw a card.",
             "colours": [],
@@ -25100,7 +25100,7 @@
         },
         {
             "id": "e0590b02-514c-5868-8b68-7b0f518bc008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7c162-4c29-481c-8157-a2bd04760225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb7c162-4c29-481c-8157-a2bd04760225.jpg?1",
             "name": "Cogwork Assembler",
             "text": "{7}: Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -25130,7 +25130,7 @@
         },
         {
             "id": "3c71ff50-ac81-5f35-b90b-7591d2652d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aed32a2-01db-4416-bd27-666f3abe04a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aed32a2-01db-4416-bd27-666f3abe04a1.jpg?1",
             "name": "Dragon Blood",
             "text": "{3}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -25157,7 +25157,7 @@
         },
         {
             "id": "f1096b64-3cc3-5c4b-b881-4b46b6a9655f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48e23fe-f0ed-4c5a-b90b-30cf096a9d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48e23fe-f0ed-4c5a-b90b-30cf096a9d02.jpg?1",
             "name": "Dragon's Hoard",
             "text": "Whenever a Dragon enters the battlefield under your control, put a gold counter on Dragon's Hoard.\n{T}, Remove a gold counter from Dragon's Hoard: Draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -25184,7 +25184,7 @@
         },
         {
             "id": "0bedc91d-0f1d-5d95-8794-ba172d7726b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7807f8ba-f597-4567-98c4-7086df7ab92c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7807f8ba-f597-4567-98c4-7086df7ab92c.jpg?1",
             "name": "Edifice of Authority",
             "text": "{1}, {T}: Target creature can't attack this turn. Put a brick counter on Edifice of Authority.\n{1}, {T}: Until your next turn, target creature can't attack or block and its activated abilities can't be activated. Activate only if there are three or more brick counters on Edifice of Authority.",
             "colours": [],
@@ -25211,7 +25211,7 @@
         },
         {
             "id": "9a3f852c-0b54-56c4-91b5-c5ee4eaf7e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02f3e9-7bee-486c-9f19-9fac52c93418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02f3e9-7bee-486c-9f19-9fac52c93418.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -25238,7 +25238,7 @@
         },
         {
             "id": "41ed8611-f5e3-5072-9e10-9ca0425fb5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f614775-1c15-4eeb-8405-a829d5eccafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f614775-1c15-4eeb-8405-a829d5eccafe.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25267,7 +25267,7 @@
         },
         {
             "id": "e1104cb6-49dd-5f37-9762-6c7aedb11cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a89661-47a3-4827-8c60-532c3934aa45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a89661-47a3-4827-8c60-532c3934aa45.jpg?1",
             "name": "Gearsmith Guardian",
             "text": "Gearsmith Guardian gets +2/+0 as long as you control a blue creature.",
             "colours": [],
@@ -25297,7 +25297,7 @@
         },
         {
             "id": "f2fa5815-bad0-547f-a842-bb31816bc0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen Gleaming Barrier dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -25327,7 +25327,7 @@
         },
         {
             "id": "90fb9d99-14ef-58e0-9f31-d4dc7eb3c2a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd33b5fc-9901-493b-8d7f-5e98223fdcad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd33b5fc-9901-493b-8d7f-5e98223fdcad.jpg?1",
             "name": "Goldvein Pick",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25356,7 +25356,7 @@
         },
         {
             "id": "e9a8f5f5-230b-58d4-a8ce-8a779b829f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a673d71-58a5-4cd4-b9bc-d7819269d693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a673d71-58a5-4cd4-b9bc-d7819269d693.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -25386,7 +25386,7 @@
         },
         {
             "id": "7d839020-e5f1-5845-90e4-33287e6d01b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09e0f4-87d9-46ef-a45e-2036a2779b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb09e0f4-87d9-46ef-a45e-2036a2779b48.jpg?1",
             "name": "Hammer of Ruin",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, you may destroy target Equipment that player controls.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25415,7 +25415,7 @@
         },
         {
             "id": "db4286f9-7b49-5018-a967-b1dfa213785d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b2624-0396-4576-aedc-2b7980f76241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b2624-0396-4576-aedc-2b7980f76241.jpg?1",
             "name": "Hangarback Walker",
             "text": "Hangarback Walker enters the battlefield with X +1/+1 counters on it.\nWhen Hangarback Walker dies, create a 1/1 colorless Thopter artifact creature token with flying for each +1/+1 counter on Hangarback Walker.\n{1}, {T}: Put a +1/+1 counter on Hangarback Walker.",
             "colours": [],
@@ -25445,7 +25445,7 @@
         },
         {
             "id": "6cedb91f-4a7e-585a-a7d5-b3bff93d6296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e9077e-084c-4146-8330-567f815bd3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e9077e-084c-4146-8330-567f815bd3d9.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25474,7 +25474,7 @@
         },
         {
             "id": "6f53d355-8c51-57cc-ba74-fff59902ad97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d324d-3576-4f1a-9025-db84703ef10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857d324d-3576-4f1a-9025-db84703ef10f.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -25501,7 +25501,7 @@
         },
         {
             "id": "de9edba5-6eda-50cb-865b-47920f6e3e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a1fdeb-3569-4c2e-81ab-f746e08527eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a1fdeb-3569-4c2e-81ab-f746e08527eb.jpg?1",
             "name": "Heirloom Blade",
             "text": "Equipped creature gets +3/+1.\nWhenever equipped creature dies, you may reveal cards from the top of your library until you reveal a creature card that shares a creature type with it. Put that card into your hand and the rest on the bottom of your library in a random order.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25530,7 +25530,7 @@
         },
         {
             "id": "8d97c56e-273f-5c25-a1e8-17fdac4fb416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b342fb32-d1a0-4fb3-9765-af7674bc6628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b342fb32-d1a0-4fb3-9765-af7674bc6628.jpg?1",
             "name": "Hero's Blade",
             "text": "Equipped creature gets +3/+2.\nWhenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25559,7 +25559,7 @@
         },
         {
             "id": "3caae4ab-c4de-57b7-9d43-1c16ad47f930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e59c9b-5959-4e44-b09b-d378b3b39021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e59c9b-5959-4e44-b09b-d378b3b39021.jpg?1",
             "name": "Infiltration Lens",
             "text": "Whenever equipped creature becomes blocked by a creature, you may draw two cards.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25588,7 +25588,7 @@
         },
         {
             "id": "acb7e0c8-f166-5290-8873-1e7e091a7c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fd4e1d-359c-46b3-ae99-50a4b90b3032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fd4e1d-359c-46b3-ae99-50a4b90b3032.jpg?1",
             "name": "Iron Bully",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Iron Bully enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -25618,7 +25618,7 @@
         },
         {
             "id": "2e87fdbb-9b9f-5179-b186-de1e8e18380f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060518c9-a76c-410e-8a90-fc1d24747f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060518c9-a76c-410e-8a90-fc1d24747f74.jpg?1",
             "name": "Jousting Lance",
             "text": "Equipped creature gets +2/+0.\nAs long as it's your turn, equipped creature has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25647,7 +25647,7 @@
         },
         {
             "id": "3a5a49fd-1476-5be4-8fee-3aafdac4256f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9510b0-925d-49f4-8237-d634f66230bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9510b0-925d-49f4-8237-d634f66230bd.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -25677,7 +25677,7 @@
         },
         {
             "id": "5d72d4b0-d627-5a2e-b9e5-d647b253d3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557dc342-b265-4370-969e-ecb9de5bc01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557dc342-b265-4370-969e-ecb9de5bc01d.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25706,7 +25706,7 @@
         },
         {
             "id": "2274ea99-ffba-5fa0-a679-40ecddee64e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f30adfa-2581-47ca-946f-d1a193523be3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f30adfa-2581-47ca-946f-d1a193523be3.jpg?1",
             "name": "Leonin Scimitar",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -25735,7 +25735,7 @@
         },
         {
             "id": "a91b1fee-a704-5814-9c7f-7737917d809f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372b3c3a-ed78-43a1-b117-9e2793d77bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372b3c3a-ed78-43a1-b117-9e2793d77bbc.jpg?1",
             "name": "Locthwain Gargoyle",
             "text": "{4}: Locthwain Gargoyle gets +2/+0 and gains flying until end of turn.",
             "colours": [],
@@ -25765,7 +25765,7 @@
         },
         {
             "id": "f6eff2e9-4ca7-5369-b4c3-5460bbe7e733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca896a-6f1e-4235-a725-aa5d57c06181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca896a-6f1e-4235-a725-aa5d57c06181.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0 and has trample and lifelink.\nEquip {3}",
             "colours": [],
@@ -25794,7 +25794,7 @@
         },
         {
             "id": "f90dd507-2daa-5719-bb8a-af5e623f1b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990b3d4-50cd-4c54-9068-5403796ab394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990b3d4-50cd-4c54-9068-5403796ab394.jpg?1",
             "name": "Manakin",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -25824,7 +25824,7 @@
         },
         {
             "id": "948cf873-ee6f-5aaa-b85f-c347e9aa7043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cda05e-a1c8-451f-9d1f-b47b4e2b1e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cda05e-a1c8-451f-9d1f-b47b4e2b1e95.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -25854,7 +25854,7 @@
         },
         {
             "id": "f7a92935-0b07-5ea7-a7ef-826d988afe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97a43ed-f69a-435c-8ede-62e664f60ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97a43ed-f69a-435c-8ede-62e664f60ee0.jpg?1",
             "name": "Monkey Cage",
             "text": "When a creature enters the battlefield, sacrifice Monkey Cage and create X 2/2 green Monkey creature tokens, where X is that creature's mana value.",
             "colours": [],
@@ -25881,7 +25881,7 @@
         },
         {
             "id": "3824cce9-3fbd-55d0-850c-1727a075c17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d1335e-f83e-41f6-b125-a906cee67af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d1335e-f83e-41f6-b125-a906cee67af8.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -25908,7 +25908,7 @@
         },
         {
             "id": "4db1dbf4-67ea-51b1-8860-28bd50694a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b504fd00-f71d-4675-8f11-b19ea7b27739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b504fd00-f71d-4675-8f11-b19ea7b27739.jpg?1",
             "name": "Phyrexian Ironfoot",
             "text": "Phyrexian Ironfoot doesn't untap during your untap step.\n{1}{S}: Untap Phyrexian Ironfoot. ({S} can be paid with one mana from a snow source.)",
             "colours": [],
@@ -25941,7 +25941,7 @@
         },
         {
             "id": "2c7e41b4-1180-575a-a867-f1792cf60eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d2ea2-54b1-4274-992b-c8f0b0206ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d2ea2-54b1-4274-992b-c8f0b0206ca1.jpg?1",
             "name": "Pierce Strider",
             "text": "When Pierce Strider enters the battlefield, target opponent loses 3 life.",
             "colours": [],
@@ -25972,7 +25972,7 @@
         },
         {
             "id": "a413fd7a-5e44-5f9c-8825-b02cd5e54fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ec1dd3-cc5c-4bd1-b9a8-b3035e67a290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ec1dd3-cc5c-4bd1-b9a8-b3035e67a290.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -26002,7 +26002,7 @@
         },
         {
             "id": "3783a8d1-96df-5550-b2a1-2411307bbaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94609a6-ae39-4770-9ff1-9e483102a8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94609a6-ae39-4770-9ff1-9e483102a8df.jpg?1",
             "name": "Psychosis Crawler",
             "text": "Psychosis Crawler's power and toughness are each equal to the number of cards in your hand.\nWhenever you draw a card, each opponent loses 1 life.",
             "colours": [],
@@ -26033,7 +26033,7 @@
         },
         {
             "id": "67ba1a01-0083-5bbf-93f3-6a8921d8977e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd47aa1a-d398-460e-b95c-b903297468d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd47aa1a-d398-460e-b95c-b903297468d6.jpg?1",
             "name": "Raiders' Karve",
             "text": "Whenever Raiders' Karve attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -26062,7 +26062,7 @@
         },
         {
             "id": "16e272ab-a08f-5381-9a43-268fb85fc7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb77b0ac-7e6a-4411-8b3c-c43b55439361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb77b0ac-7e6a-4411-8b3c-c43b55439361.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -26092,7 +26092,7 @@
         },
         {
             "id": "f112dee9-83c5-52d5-a2e3-c99d31cd5caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e77f29-8ce1-4a18-871c-d69853bfd9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e77f29-8ce1-4a18-871c-d69853bfd9db.jpg?1",
             "name": "Self-Assembler",
             "text": "When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -26122,7 +26122,7 @@
         },
         {
             "id": "a4a0f134-2346-55a2-a538-a908f45508f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d73e18d-ad7a-4b6a-829e-43f58b70afbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d73e18d-ad7a-4b6a-829e-43f58b70afbc.jpg?1",
             "name": "Shambling Suit",
             "text": "Shambling Suit's power is equal to the number of artifacts and/or enchantments you control.",
             "colours": [],
@@ -26152,7 +26152,7 @@
         },
         {
             "id": "53ecb78e-cfd4-5a9a-9c7c-b2302632d880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f8e1cd-8f4d-4bc7-a400-bbee02260ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f8e1cd-8f4d-4bc7-a400-bbee02260ab0.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -26182,7 +26182,7 @@
         },
         {
             "id": "6a84241c-541a-59e5-bf05-2eb2d9a477c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e51fec0-0412-48d8-ad33-538075248abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e51fec0-0412-48d8-ad33-538075248abb.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -26212,7 +26212,7 @@
         },
         {
             "id": "87225bc6-9434-5432-b5d4-4df3bb647048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1ff17a-7a30-42b1-a299-1219d4309407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1ff17a-7a30-42b1-a299-1219d4309407.jpg?1",
             "name": "Talon of Pain",
             "text": "Whenever a source you control other than Talon of Pain deals damage to an opponent, put a charge counter on Talon of Pain.\n{X}, {T}, Remove X charge counters from Talon of Pain: It deals X damage to any target.",
             "colours": [],
@@ -26239,7 +26239,7 @@
         },
         {
             "id": "78284847-a173-59c2-b172-c58ebd089b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b623e860-febb-4e30-9423-e8b1fadd5ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b623e860-febb-4e30-9423-e8b1fadd5ee2.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "At the beginning of your upkeep, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{T}, Sacrifice three Clues: Search your library for a card, put that card into your hand, then shuffle.",
             "colours": [],
@@ -26268,7 +26268,7 @@
         },
         {
             "id": "b460f622-17fc-51ad-a618-16336b91877a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c98eb-3b75-43c3-843c-25fb93c1b8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7c98eb-3b75-43c3-843c-25fb93c1b8af.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "At the beginning of each player's draw step, that player puts the cards in their hand on the bottom of their library in any order, then draws that many cards. (That player draws their card for the turn first.)",
             "colours": [],
@@ -26295,7 +26295,7 @@
         },
         {
             "id": "3fd32f9a-af8a-5d6b-8507-aeff72b63b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1858f5-16b8-4a58-8f31-b60f926fdbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1858f5-16b8-4a58-8f31-b60f926fdbf8.jpg?1",
             "name": "Thaumaturge's Familiar",
             "text": "Flying\nWhen Thaumaturge's Familiar enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -26325,7 +26325,7 @@
         },
         {
             "id": "4319a40e-7aba-5688-ac18-bd692c113be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16ddbcb-b28d-4a67-857b-5c30ccf055f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16ddbcb-b28d-4a67-857b-5c30ccf055f0.jpg?1",
             "name": "Universal Automaton",
             "text": "Changeling (This card is every creature type.)",
             "colours": [],
@@ -26355,7 +26355,7 @@
         },
         {
             "id": "2300cefd-75f7-5345-901c-45d436db6c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db05aef5-07b4-46d3-bad7-6568c00b2aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db05aef5-07b4-46d3-bad7-6568c00b2aef.jpg?1",
             "name": "Universal Solvent",
             "text": "{7}, {T}, Sacrifice Universal Solvent: Destroy target permanent.",
             "colours": [],
@@ -26382,7 +26382,7 @@
         },
         {
             "id": "825b54e9-f293-52f8-b906-0b3308692769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eca56b1-0e1f-4473-a427-fba3f8200b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eca56b1-0e1f-4473-a427-fba3f8200b2e.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.",
             "colours": [],
@@ -26409,7 +26409,7 @@
         },
         {
             "id": "67b10c80-d3a8-5289-977d-ef88fd681283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c353a09f-8a5a-41ce-97dc-60e7350460c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c353a09f-8a5a-41ce-97dc-60e7350460c0.jpg?1",
             "name": "Walking Ballista",
             "text": "Walking Ballista enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Walking Ballista.\nRemove a +1/+1 counter from Walking Ballista: It deals 1 damage to any target.",
             "colours": [],
@@ -26439,7 +26439,7 @@
         },
         {
             "id": "3a27890b-ee1c-5b84-a9f1-de1e3a2d030a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6baaf6-832c-4352-8b7b-872ca559fe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6baaf6-832c-4352-8b7b-872ca559fe3b.jpg?1",
             "name": "Weapon Rack",
             "text": "Weapon Rack enters the battlefield with three +1/+1 counters on it.\n{T}: Move a +1/+1 counter from Weapon Rack onto target creature. Activate only as a sorcery.",
             "colours": [],
@@ -26466,7 +26466,7 @@
         },
         {
             "id": "44510db6-a20f-56cc-a0fc-0c093b1d1c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e02966-ff20-4e5e-b27d-adc6156c802d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e02966-ff20-4e5e-b27d-adc6156c802d.jpg?1",
             "name": "Whirlermaker",
             "text": "{4}, {T}: Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [],
@@ -26493,7 +26493,7 @@
         },
         {
             "id": "a28f4c79-d3ed-5461-89a7-23b8b012f944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b20e63c-f9fa-46c0-a3f8-30ea70e07fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b20e63c-f9fa-46c0-a3f8-30ea70e07fc6.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -26520,7 +26520,7 @@
         },
         {
             "id": "f7b24301-81fc-5f8a-a085-47353122966f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09994b67-4b83-4b23-834b-73bae87e8272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09994b67-4b83-4b23-834b-73bae87e8272.jpg?1",
             "name": "Blighted Fen",
             "text": "{T}: Add {C}.\n{4}{B}, {T}, Sacrifice Blighted Fen: Target opponent sacrifices a creature.",
             "colours": [],
@@ -26549,7 +26549,7 @@
         },
         {
             "id": "c6d76caa-c21f-57ba-a148-aa4de53d29ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f06a2-9d89-4cf7-aa4c-fe7ca4163511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f06a2-9d89-4cf7-aa4c-fe7ca4163511.jpg?1",
             "name": "Bonders' Enclave",
             "text": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater.",
             "colours": [],
@@ -26576,7 +26576,7 @@
         },
         {
             "id": "4dad9a47-2f12-591d-8fb8-e8d329ff9a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf14f8a-373b-4244-9427-a5a3224bf21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf14f8a-373b-4244-9427-a5a3224bf21f.jpg?1",
             "name": "Desert of the Mindful",
             "text": "Desert of the Mindful enters the battlefield tapped.\n{T}: Add {U}.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -26607,7 +26607,7 @@
         },
         {
             "id": "9eb2d879-e8ce-55af-a6db-aab46a41fa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a27ba-bd56-4f07-bd29-260180bd5eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35a27ba-bd56-4f07-bd29-260180bd5eb0.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -26634,7 +26634,7 @@
         },
         {
             "id": "19b1f5e0-c8d6-5d55-8767-ff33650ae980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501d59-b253-4449-966f-8922803d84a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501d59-b253-4449-966f-8922803d84a0.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave enters the battlefield tapped.\n{T}: Add {R}.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -26663,7 +26663,7 @@
         },
         {
             "id": "f0faf9b0-d74b-538a-aa63-155ea80d4771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238a5103-6688-4fe5-ab93-b949afd0c2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238a5103-6688-4fe5-ab93-b949afd0c2ca.jpg?1",
             "name": "Memorial to Genius",
             "text": "Memorial to Genius enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Memorial to Genius: Draw two cards.",
             "colours": [],
@@ -26692,7 +26692,7 @@
         },
         {
             "id": "d751e5c9-51cf-5003-9ef3-f0b51278a448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f292de-238a-4b19-a6da-f164158b79dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f292de-238a-4b19-a6da-f164158b79dc.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -26719,7 +26719,7 @@
         },
         {
             "id": "025330d7-0a19-54e3-b000-b61fc24d0ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c237554-e345-474a-88db-faf628ba6667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c237554-e345-474a-88db-faf628ba6667.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.\n{T}: Add {B}.",
             "colours": [],
@@ -26748,7 +26748,7 @@
         },
         {
             "id": "831127e0-acd9-585e-a685-57497c57954c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9332ac39-1a34-42e2-9c84-645cbf1721cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9332ac39-1a34-42e2-9c84-645cbf1721cf.jpg?1",
             "name": "Piranha Marsh",
             "text": "Piranha Marsh enters the battlefield tapped.\nWhen Piranha Marsh enters the battlefield, target player loses 1 life.\n{T}: Add {B}.",
             "colours": [],
@@ -26777,7 +26777,7 @@
         },
         {
             "id": "aff9670e-ae7b-54e1-be57-d2041e7b3cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb3d37e-5118-405a-906d-529ec1d90dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb3d37e-5118-405a-906d-529ec1d90dce.jpg?1",
             "name": "Sandstone Bridge",
             "text": "Sandstone Bridge enters the battlefield tapped.\nWhen Sandstone Bridge enters the battlefield, target creature gets +1/+1 and gains vigilance until end of turn.\n{T}: Add {W}.",
             "colours": [],
@@ -26806,7 +26806,7 @@
         },
         {
             "id": "73c74309-e0f4-5f84-8ff9-37ecf3508b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0633d38e-de0b-4f14-abbb-ac9260887c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0633d38e-de0b-4f14-abbb-ac9260887c4d.jpg?1",
             "name": "Seat of the Synod",
             "text": "{T}: Add {U}.",
             "colours": [],
@@ -26836,7 +26836,7 @@
         },
         {
             "id": "cdf44c36-19c3-52b0-b301-6e0eeb8a991a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a5b62-f0db-41de-b3f4-aa6d7a51d376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a5b62-f0db-41de-b3f4-aa6d7a51d376.jpg?1",
             "name": "Shimmerdrift Vale",
             "text": "Shimmerdrift Vale enters the battlefield tapped.\nAs Shimmerdrift Vale enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -26865,7 +26865,7 @@
         },
         {
             "id": "370b63bb-41ee-5e90-94c1-ec3dabf5afe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3593aa-e33c-4482-a0bb-c843ac70a824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3593aa-e33c-4482-a0bb-c843ac70a824.jpg?1",
             "name": "Thriving Bluff",
             "text": "Thriving Bluff enters the battlefield tapped.\nAs Thriving Bluff enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -26894,7 +26894,7 @@
         },
         {
             "id": "da0d956f-c612-5cc9-a850-a87e8c2a20a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23829580-9ae9-41c1-9b58-aea07389110d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23829580-9ae9-41c1-9b58-aea07389110d.jpg?1",
             "name": "Thriving Grove",
             "text": "Thriving Grove enters the battlefield tapped.\nAs Thriving Grove enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -26923,7 +26923,7 @@
         },
         {
             "id": "a04e9563-a925-5006-9eff-d8d21379a5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa01378-4d7f-4700-9303-f0535468dc62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa01378-4d7f-4700-9303-f0535468dc62.jpg?1",
             "name": "Thriving Heath",
             "text": "Thriving Heath enters the battlefield tapped.\nAs Thriving Heath enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -26952,7 +26952,7 @@
         },
         {
             "id": "52c3e9b6-7653-5c90-9796-c3838f55dd98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464168e8-e11f-4826-a709-bf1e725ef62b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464168e8-e11f-4826-a709-bf1e725ef62b.jpg?1",
             "name": "Thriving Isle",
             "text": "Thriving Isle enters the battlefield tapped.\nAs Thriving Isle enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -26981,7 +26981,7 @@
         },
         {
             "id": "22a8fe67-ad5e-56fc-940e-cc5ea4e71f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26096a40-fc6a-42ce-acbf-ce0ebc4ad3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26096a40-fc6a-42ce-acbf-ce0ebc4ad3b4.jpg?1",
             "name": "Thriving Moor",
             "text": "Thriving Moor enters the battlefield tapped.\nAs Thriving Moor enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -27010,7 +27010,7 @@
         },
         {
             "id": "00db824d-2f12-59ea-8e5d-343b7debc0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d39df-aaab-4733-b7c4-f33c9b4fb10c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d39df-aaab-4733-b7c4-f33c9b4fb10c.jpg?1",
             "name": "Treetop Village",
             "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G}.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land.",
             "colours": [],
@@ -27039,7 +27039,7 @@
         },
         {
             "id": "1065e810-0498-5800-ad36-74f31d2a83e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d9f428-8ce0-4a73-ac38-2dcbdcf12584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d9f428-8ce0-4a73-ac38-2dcbdcf12584.jpg?1",
             "name": "Urza's Factory",
             "text": "{T}: Add {C}.\n{7}, {T}: Create a 2/2 colorless Assembly-Worker artifact creature token.",
             "colours": [],
@@ -27068,7 +27068,7 @@
         },
         {
             "id": "5dcaeb56-8991-5696-88ad-3c2199426741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1c8759-ec90-420b-b9c3-33515e91b705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1c8759-ec90-420b-b9c3-33515e91b705.jpg?1",
             "name": "Urza's Mine",
             "text": "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -27098,7 +27098,7 @@
         },
         {
             "id": "012d62c1-77f8-57c0-b522-c15e462c1800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ced23-1991-4335-9ead-83ae4a6d09cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446ced23-1991-4335-9ead-83ae4a6d09cf.jpg?1",
             "name": "Urza's Power Plant",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
             "colours": [],
@@ -27128,7 +27128,7 @@
         },
         {
             "id": "7ad877e6-1ebc-5251-ad11-a1cf681a5ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba9d0e3-9ff3-4aeb-9de6-c7695d88a31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba9d0e3-9ff3-4aeb-9de6-c7695d88a31d.jpg?1",
             "name": "Urza's Tower",
             "text": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
             "colours": [],
@@ -27158,7 +27158,7 @@
         },
         {
             "id": "8482240c-664d-5f6b-8af3-425cb53c8941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f4e5e-e83e-4ec8-8db0-259b85219b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3f4e5e-e83e-4ec8-8db0-259b85219b89.jpg?1",
             "name": "Warped Landscape",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Warped Landscape: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -27185,7 +27185,7 @@
         },
         {
             "id": "dff3aea1-e7ea-5795-9d4d-317917c1ef4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6b4706-5452-4c50-872d-2d04f96407a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6b4706-5452-4c50-872d-2d04f96407a8.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -27219,7 +27219,7 @@
         },
         {
             "id": "d555be17-8953-5e74-811c-019a5c102229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef693d-7c48-46cb-8f52-abc660a2736e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ef693d-7c48-46cb-8f52-abc660a2736e.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -27248,7 +27248,7 @@
         },
         {
             "id": "53a89e07-979b-5bb6-9a09-9b643b48ac2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da105c2f-017e-4df0-b45e-a9482c02a29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da105c2f-017e-4df0-b45e-a9482c02a29d.jpg?1",
             "name": "Kibo, Uktabi Prince",
             "text": "{T}: Each player creates a colorless artifact token named Banana with \"{T}, Sacrifice this artifact: Add {R} or {G}. You gain 2 life.\"\nWhenever an artifact an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on each creature you control that's an Ape or a Monkey.\nWhenever Kibo attacks, defending player sacrifices an artifact.",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/JMP.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/JMP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3c466bee-9fe3-516b-aef0-2eef8e13c85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff80029e-650e-469d-8393-0edf7d9cd695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff80029e-650e-469d-8393-0edf7d9cd695.jpg?1",
             "name": "Blessed Sanctuary",
             "text": "Prevent all noncombat damage that would be dealt to you and creatures you control.\nWhenever a nontoken creature enters the battlefield under your control, create a 2/2 white Unicorn creature token.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "989ba589-6801-50d1-b111-12d126220d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc18921-59f5-413f-a221-dc47d31b2ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc18921-59f5-413f-a221-dc47d31b2ec8.jpg?1",
             "name": "Brightmare",
             "text": "When Brightmare enters the battlefield, tap up to one target creature. You gain life equal to that creature's power.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "1a0a7cd9-87cb-504a-a793-7883a233a9f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74dfd07-d17c-4890-82c3-4b12a6029940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74dfd07-d17c-4890-82c3-4b12a6029940.jpg?1",
             "name": "Emiel the Blessed",
             "text": "{3}: Exile another target creature you control, then return it to the battlefield under its owner's control.\nWhenever another creature enters the battlefield under your control, you may pay {RW}. If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead. ({RW} can be paid with either {G} or {W}.)",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "dfb02544-b29a-5982-8d20-f295ff76b001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9.jpg?1",
             "name": "Release the Dogs",
             "text": "Create four 1/1 white Dog creature tokens.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "e19db0d1-0058-589d-9a98-6669a4406e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbcb165-0a60-493a-8cbb-ba8b36c527da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddbcb165-0a60-493a-8cbb-ba8b36c527da.jpg?1",
             "name": "Steel-Plume Marshal",
             "text": "Flying\nWhenever Steel-Plume Marshal attacks, other attacking creatures you control with flying get +2/+2 until end of turn.",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "31f4b3c7-4979-5354-b7cd-2faaedd94bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd3287d-e4d8-4670-a2dd-b683055ae4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd3287d-e4d8-4670-a2dd-b683055ae4b9.jpg?1",
             "name": "Stone Haven Pilgrim",
             "text": "Whenever Stone Haven Pilgrim attacks, if you control an artifact or enchantment, Stone Haven Pilgrim gets +1/+1 and gains lifelink until end of turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "102443fd-8673-57cc-9664-91338718041c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c10c77-1446-4581-9587-dc2860fe78fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c10c77-1446-4581-9587-dc2860fe78fe.jpg?1",
             "name": "Supply Runners",
             "text": "When Supply Runners enters the battlefield, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "3c9345f4-6f88-5c82-8931-5d482bdde9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4eb490-acd0-4162-8e8a-7e7ff003d0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4eb490-acd0-4162-8e8a-7e7ff003d0f3.jpg?1",
             "name": "Trusty Retriever",
             "text": "When Trusty Retriever enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Trusty Retriever.\n\u2022 Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "edce7d82-8373-533f-9733-7f0a8695196b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb8779-ac19-43d6-b818-86eb8ee2f87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb8779-ac19-43d6-b818-86eb8ee2f87d.jpg?1",
             "name": "Archaeomender",
             "text": "When Archaeomender enters the battlefield, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -303,7 +303,7 @@
         },
         {
             "id": "b122f4b4-34b1-5e58-9495-afca777eb070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b43bdc7-e49e-4848-9101-6cad2ecab4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b43bdc7-e49e-4848-9101-6cad2ecab4dc.jpg?1",
             "name": "Bruvac the Grandiloquent",
             "text": "If an opponent would mill one or more cards, they mill twice that many cards instead. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "23247265-3fec-56d0-8598-b54be228be59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b016d4-ddf6-47d6-b934-a0b979b60680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b016d4-ddf6-47d6-b934-a0b979b60680.jpg?1",
             "name": "Corsair Captain",
             "text": "When Corsair Captain enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nOther Pirates you control get +1/+1.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "f4031181-f475-5a38-83a8-38ae5c28decf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b238485f-ef67-4295-892b-a10235368f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b238485f-ef67-4295-892b-a10235368f74.jpg?1",
             "name": "Inniaz, the Gale Force",
             "text": "Flying\n{2}{WU}: Attacking creatures with flying get +1/+1 until end of turn. ({WU} can be paid with either {W} or {U}.)\nWhenever three or more creatures you control with flying attack, each player gains control of a nonland permanent of your choice controlled by the player to their right.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "9e8d42f7-cf3b-5345-bcbc-11794c0d28a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711412f1-9ab3-48b6-91a4-77232b416a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711412f1-9ab3-48b6-91a4-77232b416a32.jpg?1",
             "name": "Ormos, Archive Keeper",
             "text": "Flying\nIf you would draw a card while your library has no cards in it, instead put five +1/+1 counters on Ormos, Archive Keeper.\n{1}{U}{U}, Discard three cards with different names: Draw five cards.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "21af8cb5-f5ce-505f-a3c3-97b9a5b1e2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa254a86-3c30-408d-9c14-befd472f9740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa254a86-3c30-408d-9c14-befd472f9740.jpg?1",
             "name": "Scholar of the Lost Trove",
             "text": "Flying\nWhen Scholar of the Lost Trove enters the battlefield, you may cast target instant, sorcery, or artifact card from your graveyard without paying its mana cost. If an instant or sorcery spell cast this way would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "9b235a8a-cf52-5a0c-bf61-2ba2ad7aee33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70d445b-d3d6-4f7c-b9ea-bed6a26d4a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70d445b-d3d6-4f7c-b9ea-bed6a26d4a2a.jpg?1",
             "name": "Kels, Fight Fixer",
             "text": "Menace\nWhenever you sacrifice a creature, you may pay {UB}. If you do, draw a card. ({UB} can be paid with either {U} or {B}.)\n{1}, Sacrifice a creature: Kels, Fight Fixer gains indestructible until end of turn.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "d26fc1a8-9368-5596-882b-d881290bf642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487aced8-e018-4c93-8e13-bb68b43096a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487aced8-e018-4c93-8e13-bb68b43096a4.jpg?1",
             "name": "Nocturnal Feeder",
             "text": "Flying\nWhen Nocturnal Feeder dies, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "1f3b873f-1419-5b33-a965-b191d23491ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4063be5b-bfd9-43c5-bc39-09a40bc793bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4063be5b-bfd9-43c5-bc39-09a40bc793bf.jpg?1",
             "name": "Tinybones, Trinket Thief",
             "text": "At the beginning of each end step, if an opponent discarded a card this turn, you draw a card and you lose 1 life.\n{4}{B}{B}: Each opponent with no cards in hand loses 10 life.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "4f06427c-71af-5c58-9367-1276228adcf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484f19a-0121-4173-a70b-6698cc5f6303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484f19a-0121-4173-a70b-6698cc5f6303.jpg?1",
             "name": "Witch of the Moors",
             "text": "Deathtouch\nAt the beginning of your end step, if you gained life this turn, each opponent sacrifices a creature and you return up to one target creature card from your graveyard to your hand.",
             "colours": [
@@ -620,7 +620,7 @@
         },
         {
             "id": "2da1bc53-e3da-5789-9306-040ff1436372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4e5c23-3a7f-4a6b-99c4-6a1487a9b097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4e5c23-3a7f-4a6b-99c4-6a1487a9b097.jpg?1",
             "name": "Chained Brute",
             "text": "Chained Brute doesn't untap during your untap step.\n{1}, Sacrifice another creature: Untap Chained Brute. Activate this ability only during your turn.",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "0d349696-9abb-5937-b3c3-7deb2184dbd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0b8aee-fbfb-470f-9ac2-64fce0b4b2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0b8aee-fbfb-470f-9ac2-64fce0b4b2fb.jpg?1",
             "name": "Immolating Gyre",
             "text": "Immolating Gyre deals X damage to each creature and planeswalker you don't control, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "9bab6d93-3255-5991-88ac-b3e20b1a1815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52a3f11-6d55-4492-9a2c-c128c09b3d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52a3f11-6d55-4492-9a2c-c128c09b3d77.jpg?1",
             "name": "Lightning Phoenix",
             "text": "Flying, haste\nLightning Phoenix can't block.\nAt the beginning of your end step, if an opponent was dealt 3 or more damage this turn, you may pay {R}. If you do, return Lightning Phoenix from your graveyard to the battlefield.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "c1a8f157-536c-5b22-a532-c9c29d91cf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af648aaf-a8e0-4291-acf9-5f8533728f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af648aaf-a8e0-4291-acf9-5f8533728f92.jpg?1",
             "name": "Lightning Visionary",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "3eefb7ec-dc61-506c-9dfb-e9089a9c1379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84379a-369e-4a9f-8c8b-bf47ab524c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84379a-369e-4a9f-8c8b-bf47ab524c4e.jpg?1",
             "name": "Living Lightning",
             "text": "When Living Lightning dies, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "d99ec328-d83c-571c-af45-e0fb474b023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c716d10-2130-43b7-a939-349d437e1091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c716d10-2130-43b7-a939-349d437e1091.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "When Muxus, Goblin Grandee enters the battlefield, reveal the top six cards of your library. Put all Goblin creature cards with converted mana cost 5 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.\nWhenever Muxus attacks, it gets +1/+1 until end of turn for each other Goblin you control.",
             "colours": [
@@ -821,7 +821,7 @@
         },
         {
             "id": "9a54ef89-8a73-5481-a56a-b06477f984d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg?1",
             "name": "Sethron, Hurloon General",
             "text": "Whenever Sethron, Hurloon General or another nontoken Minotaur enters the battlefield under your control, create a 2/3 red Minotaur creature token.\n{2}{BR}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn. ({BR} can be paid with either {B} or {R}.)",
             "colours": [
@@ -858,7 +858,7 @@
         },
         {
             "id": "7b1e21a9-f002-545e-85d1-9acba400a854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ee7a6-3dfa-44c7-8f00-0183137c4d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59ee7a6-3dfa-44c7-8f00-0183137c4d31.jpg?1",
             "name": "Spiteful Prankster",
             "text": "As long as it's your turn, Spiteful Prankster has first strike.\nWhenever another creature dies, Spiteful Prankster deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "5e0d039d-f1c2-5bdf-aa4a-c647d214c6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d94b4c3-7944-41b6-8c92-78fd6e50658d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d94b4c3-7944-41b6-8c92-78fd6e50658d.jpg?1",
             "name": "Zurzoth, Chaos Rider",
             "text": "Whenever an opponent draws their first card each turn, if it's not their turn, you create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\nWhenever one or more Devils you control attack one or more players, you and those players each draw a card, then discard a card at random.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "4cb25159-6cd8-59e2-92e5-d3fd295a76bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee4a931-5d61-49ba-affc-f022263938ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee4a931-5d61-49ba-affc-f022263938ca.jpg?1",
             "name": "Allosaurus Shepherd",
             "text": "Allosaurus Shepherd can't be countered.\nGreen spells you control can't be countered.\n{4}{G}{G}: Until end of turn, each Elf creature you control has base power and toughness 5/5 and becomes a Dinosaur in addition to its other creature types.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "71f56814-0776-5b9f-a9c2-c8853ffe8fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6971ad-cbb4-4f66-9bc4-b407c5805e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6971ad-cbb4-4f66-9bc4-b407c5805e85.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "c808e414-d95b-58bd-8ef7-201a0f304d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1eed0f-9692-44c0-b1ad-afa691165d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1eed0f-9692-44c0-b1ad-afa691165d52.jpg?1",
             "name": "Neyith of the Dire Hunt",
             "text": "Whenever one or more creatures you control fight or become blocked, draw a card.\nAt the beginning of combat on your turn, you may pay {2}{RG}. If you do, double target creature's power until end of turn. That creature must be blocked this combat if able. ({RG} can be paid with either {R} or {G}.)",
             "colours": [
@@ -1028,7 +1028,7 @@
         },
         {
             "id": "7244b00e-be44-50ff-a6b0-cf5c40681712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c3eac5-3354-44ce-97c2-bafce78433ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c3eac5-3354-44ce-97c2-bafce78433ca.jpg?1",
             "name": "Towering Titan",
             "text": "Towering Titan enters the battlefield with X +1/+1 counters on it, where X is the total toughness of other creatures you control.\nSacrifice a creature with defender: All creatures gain trample until end of turn.",
             "colours": [
@@ -1061,7 +1061,7 @@
         },
         {
             "id": "5d3ff4ef-14ae-5cbb-9a9f-96fe3d1ec9c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b959af-bb23-42e7-8848-7405ed597c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b959af-bb23-42e7-8848-7405ed597c8d.jpg?1",
             "name": "Lightning-Core Excavator",
             "text": "{5}, {T}, Sacrifice Lightning-Core Excavator: It deals 3 damage to any target.",
             "colours": [],
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "115710ca-4067-5c4d-8800-9955aa264285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15481459-3703-4185-ad27-105d95691e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15481459-3703-4185-ad27-105d95691e9d.jpg?1",
             "name": "Thriving Bluff",
             "text": "Thriving Bluff enters the battlefield tapped.\nAs Thriving Bluff enters the battlefield, choose a color other than red.\n{T}: Add {R} or one mana of the chosen color.",
             "colours": [],
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "556a45ee-13ad-5940-b9e6-e358dc7b925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cabbe0-1c44-4888-8ebc-25a4c3e2c5d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cabbe0-1c44-4888-8ebc-25a4c3e2c5d7.jpg?1",
             "name": "Thriving Grove",
             "text": "Thriving Grove enters the battlefield tapped.\nAs Thriving Grove enters the battlefield, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
             "colours": [],
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "9c8d7f2c-a1cc-58b7-8432-c005eca33629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe424eb3-7df8-4317-8776-6d960afbb90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe424eb3-7df8-4317-8776-6d960afbb90a.jpg?1",
             "name": "Thriving Heath",
             "text": "Thriving Heath enters the battlefield tapped.\nAs Thriving Heath enters the battlefield, choose a color other than white.\n{T}: Add {W} or one mana of the chosen color.",
             "colours": [],
@@ -1178,7 +1178,7 @@
         },
         {
             "id": "08993e0c-4387-561b-84fa-c087e1ffd799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb8fd94-2b59-4b05-b4d0-c93497301d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb8fd94-2b59-4b05-b4d0-c93497301d19.jpg?1",
             "name": "Thriving Isle",
             "text": "Thriving Isle enters the battlefield tapped.\nAs Thriving Isle enters the battlefield, choose a color other than blue.\n{T}: Add {U} or one mana of the chosen color.",
             "colours": [],
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "cac4131a-2bd5-5280-a579-5d5354359428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18756fe5-70f0-48d9-a4f1-ea78f77d2084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18756fe5-70f0-48d9-a4f1-ea78f77d2084.jpg?1",
             "name": "Thriving Moor",
             "text": "Thriving Moor enters the battlefield tapped.\nAs Thriving Moor enters the battlefield, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
             "colours": [],
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "bc5af6ce-b68a-562d-a6ee-d991096581c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d283ba-9d88-45d2-80d3-7e4fffea6d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d283ba-9d88-45d2-80d3-7e4fffea6d22.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1277,7 +1277,7 @@
         },
         {
             "id": "43a09983-5ffe-584d-9a7e-b2456766ded6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bcd008d-446e-41ba-a92e-871b9296fead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bcd008d-446e-41ba-a92e-871b9296fead.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "7743d92d-5965-517c-9fc2-814701a245c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c3424f-0500-48ce-9779-b77e7763e253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c3424f-0500-48ce-9779-b77e7763e253.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "7f8f84ac-0c12-5d17-8aa3-81cd0cbd496e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0690e60-e11e-4903-b1e0-e36854213b65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0690e60-e11e-4903-b1e0-e36854213b65.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "b1a5f044-35b2-56b2-8d3b-5c5066224c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999d82f8-6c64-4b6a-a8ac-fbc48dd1750c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999d82f8-6c64-4b6a-a8ac-fbc48dd1750c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1441,7 +1441,7 @@
         },
         {
             "id": "96a94835-2cf2-5518-887f-a9d610127f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a334360b-2943-4442-8557-e0a5efd272b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a334360b-2943-4442-8557-e0a5efd272b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "dac3cc6e-ddde-5d7a-a32b-0c2f6f426d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d96d9e-c6c2-4c51-ac57-b63dee0cf27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d96d9e-c6c2-4c51-ac57-b63dee0cf27a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "f7397177-fb1c-578a-b133-d189c54190e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe75b38-c145-420e-9446-f2ac443ab3a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe75b38-c145-420e-9446-f2ac443ab3a5.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -1564,7 +1564,7 @@
         },
         {
             "id": "347a70ad-739b-5be0-ba7a-7f61c87f463a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a837f2-dbb0-435f-adf9-7632b97f94ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a837f2-dbb0-435f-adf9-7632b97f94ab.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "13e7b016-30c3-542a-9efe-08e4e32fe9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4a655-0051-47c6-a683-c4c3f56e45fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b4a655-0051-47c6-a683-c4c3f56e45fc.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "a60243d7-54c6-533a-a09f-6473afcba061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3c7c06-76e4-487d-a63f-4aed3bbb4638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3c7c06-76e4-487d-a63f-4aed3bbb4638.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "1995b285-2adb-51e9-b9e5-8da0b33a9dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f7338-8edc-4579-b92f-86b02527682c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7f7338-8edc-4579-b92f-86b02527682c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "fcca533d-a708-5ed1-8e59-20075ed79470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed351e4f-7ee7-4e84-a69d-02b59cebd180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed351e4f-7ee7-4e84-a69d-02b59cebd180.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "17ab34ed-0c8d-5ce2-a658-bd463cea96df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cd2ccc-3148-4507-856d-55140c54d09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cd2ccc-3148-4507-856d-55140c54d09d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "c4ab5c0a-bfec-5a22-82ca-829e16bbf326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c61b0c-408a-4ba5-9a1c-5208b5f7f8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c61b0c-408a-4ba5-9a1c-5208b5f7f8d0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "97ee4c33-4bc6-5cda-ba06-4ea21be43c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a4dfac-2a47-48be-8611-d7f69e261c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a4dfac-2a47-48be-8611-d7f69e261c60.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "333fe9a6-c1f0-5bb1-a016-14f6946ed17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e0edda-1943-47a3-9ad3-673b38f42c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e0edda-1943-47a3-9ad3-673b38f42c86.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "2d81ccd9-e85f-5849-b429-8003e64ee100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a189653-dc0b-4b04-9544-5314cebf23fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a189653-dc0b-4b04-9544-5314cebf23fd.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "6d7b4877-ad57-5508-92cc-4a060c83e09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3810ec60-3f93-46c0-af39-7628b77bacec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3810ec60-3f93-46c0-af39-7628b77bacec.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "542926fc-a893-5212-bf00-6a0e8eaef071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ea7816-e501-4384-9176-61819a1784f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ea7816-e501-4384-9176-61819a1784f6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "fe954474-dc50-5624-9539-3a316f2321dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577198f-8b2d-4cee-b400-ebab8fb0df8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7577198f-8b2d-4cee-b400-ebab8fb0df8c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "cc96d27b-558e-5fd4-83df-3ae246958b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "874535cd-2277-52c2-9d92-ba5dd2defa06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e597d5-37e7-4add-b454-c3399b4e3704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e597d5-37e7-4add-b454-c3399b4e3704.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "0b3a8dd2-71f2-5213-8267-27f9c1a4c95b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f7b339-cce2-421e-83b8-1764c53dee47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f7b339-cce2-421e-83b8-1764c53dee47.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "2a7ca032-f5a6-5f6a-85d9-d56f38a10962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d1535-68e7-4ca0-aa71-fc7fc63090fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8d1535-68e7-4ca0-aa71-fc7fc63090fc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2261,7 +2261,7 @@
         },
         {
             "id": "e6d85336-b24d-5180-b9aa-5ceb86db19d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92c5c74-d5b5-40bf-be86-39ac5e4c4f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92c5c74-d5b5-40bf-be86-39ac5e4c4f1a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "16c51de0-a63d-5030-8f0a-9bf62e7b0004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb524a84-34a4-43bf-9872-b4a053a141b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb524a84-34a4-43bf-9872-b4a053a141b5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2343,7 +2343,7 @@
         },
         {
             "id": "bc5d5a2c-0237-5157-8577-ae4e17e49bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0d802-2bd2-444f-81e0-4cc2f8ece38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0d802-2bd2-444f-81e0-4cc2f8ece38f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "4b7d8a15-3c56-5f5e-ac05-d2f3cff4ea7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55498ad-f474-4805-b9e9-592ec1c8a8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55498ad-f474-4805-b9e9-592ec1c8a8e5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "cf82442b-636d-5efc-a977-cb986936a2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bce91-f1e6-40d4-9ecc-cafa8d2586b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bce91-f1e6-40d4-9ecc-cafa8d2586b6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "8d156bd9-7abb-54c8-b532-0fe5d7570ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6382b-ceff-4092-9ec3-328cefab440e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6382b-ceff-4092-9ec3-328cefab440e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "3e9318de-15bf-53df-b89f-a73ff9930714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c3decf-4a32-45ff-b7f6-ea2d52387c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c3decf-4a32-45ff-b7f6-ea2d52387c89.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2548,7 +2548,7 @@
         },
         {
             "id": "4b21f80d-f675-5ab8-b781-fe7e4862b156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6712361-976a-4ef9-bae9-48505344904e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6712361-976a-4ef9-bae9-48505344904e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "7cdae8aa-c236-5389-ac58-91c6a77d8b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88adbda4-7818-4888-a908-de6073bd0152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88adbda4-7818-4888-a908-de6073bd0152.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2630,7 +2630,7 @@
         },
         {
             "id": "3706ebe6-05ec-5342-8c47-7aab97104caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01838859-51ef-474a-9653-23dd37eed1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01838859-51ef-474a-9653-23dd37eed1d6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "91a5dad4-e78b-5962-bb1f-92fd5b486308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b534b1-2d78-4de3-afc8-8bdd6ee6da82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b534b1-2d78-4de3-afc8-8bdd6ee6da82.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "2058d91b-51bb-5aa7-8ac4-bb0f44b6a420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea556a69-c487-45ca-8f60-7e89407ec7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea556a69-c487-45ca-8f60-7e89407ec7b7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "2c57ac89-ceb9-506f-8f23-d7c72e2a2a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a4d3de-e004-4a15-9f45-4d50813de533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a4d3de-e004-4a15-9f45-4d50813de533.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "802acea3-c322-5786-850d-86ad11615696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4e14a-ab24-4740-b727-165ee9d22e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b4e14a-ab24-4740-b727-165ee9d22e99.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "4f636989-6e64-57a0-bc0f-6dcc150daf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c301150-16a8-4ce3-818c-16d6fb0df1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c301150-16a8-4ce3-818c-16d6fb0df1b7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "34823ef8-826d-54b5-82e7-f7fdcd08ad0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ab0de-6691-4a45-95ac-9b75721c6c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ab0de-6691-4a45-95ac-9b75721c6c5a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "ec985c99-db22-5127-ab0e-90aeb325ee4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f356d-4714-4500-8fb0-1ac68ec5c1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94f356d-4714-4500-8fb0-1ac68ec5c1cf.jpg?1",
             "name": "Aegis of the Heavens",
             "text": "Target creature gets +1/+7 until end of turn.",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "3728056e-fb4a-5cde-992f-dcbc2cf8fc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e84a4a-034f-4f55-a827-e62f2b61f091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e84a4a-034f-4f55-a827-e62f2b61f091.jpg?1",
             "name": "Aerial Assault",
             "text": "Destroy target tapped creature. You gain 1 life for each creature you control with flying.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "26d7aaca-f5bb-5f3c-a2b7-65761926835f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f762546c-f5eb-420d-a8f7-c3566cd8f506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f762546c-f5eb-420d-a8f7-c3566cd8f506.jpg?1",
             "name": "Affa Guard Hound",
             "text": "Flash\nWhen Affa Guard Hound enters the battlefield, target creature gets +0/+3 until end of turn.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "b3538201-e921-521b-9235-a414cb21343e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea009c1-505e-4307-b8f3-2d37e36507a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea009c1-505e-4307-b8f3-2d37e36507a6.jpg?1",
             "name": "Ajani's Chosen",
             "text": "Whenever an enchantment enters the battlefield under your control, create a 2/2 white Cat creature token. If that enchantment is an Aura, you may attach it to the token.",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "22f9577a-744b-5ba2-acb8-c543038d44d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7026ffb-98de-4da7-84a8-1198639873f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7026ffb-98de-4da7-84a8-1198639873f4.jpg?1",
             "name": "Alabaster Mage",
             "text": "{1}{W}: Target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -3066,7 +3066,7 @@
         },
         {
             "id": "416d29af-9188-5bb3-b985-76f17b3a1438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d22fdde-5590-4a4c-af2e-09711f4b5ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d22fdde-5590-4a4c-af2e-09711f4b5ffd.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy enters the battlefield, you gain 3 life.",
             "colours": [
@@ -3099,7 +3099,7 @@
         },
         {
             "id": "fa45e6a2-43cd-5e35-8a8d-c8ed573bc6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ab81d4-aaf7-4c72-9651-5e1482126928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ab81d4-aaf7-4c72-9651-5e1482126928.jpg?1",
             "name": "Angel of the Dire Hour",
             "text": "Flash\nFlying\nWhen Angel of the Dire Hour enters the battlefield, if you cast it from your hand, exile all attacking creatures.",
             "colours": [
@@ -3132,7 +3132,7 @@
         },
         {
             "id": "ec5c29a9-72f5-56e1-9785-b18131569613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8637d263-5d7e-45bc-aad3-d97f57e6898e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8637d263-5d7e-45bc-aad3-d97f57e6898e.jpg?1",
             "name": "Angelic Arbiter",
             "text": "Flying\nEach opponent who cast a spell this turn can't attack with creatures.\nEach opponent who attacked with a creature this turn can't cast spells.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "1b974154-e35e-57a3-8e6a-ea03fced5890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14ed7f7-83c4-425b-a2b7-5bd76558ce76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14ed7f7-83c4-425b-a2b7-5bd76558ce76.jpg?1",
             "name": "Angelic Edict",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "66e1863a-caf0-5646-9629-14f28547f156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf5db14-f2aa-4088-9894-7bd3a56dfe1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf5db14-f2aa-4088-9894-7bd3a56dfe1e.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\n{T}: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "a161d4af-138b-57b2-98c3-5e2708945306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b0148-5821-4105-9cda-a0e405eb8bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b0148-5821-4105-9cda-a0e405eb8bee.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice dies, exile target permanent.",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "d078d4ca-c601-51f1-bb3d-1bc3c3ad661d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e8eb41-3800-4553-843b-ec27a44e8d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e8eb41-3800-4553-843b-ec27a44e8d55.jpg?1",
             "name": "Archon of Redemption",
             "text": "Flying\nWhenever Archon of Redemption or another creature with flying enters the battlefield under your control, you may gain life equal to that creature's power.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "fd5e0e71-2e8c-56ad-a14e-3f247235b62e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bac081-a946-4278-90f0-c0f262b7abf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bac081-a946-4278-90f0-c0f262b7abf2.jpg?1",
             "name": "Battlefield Promotion",
             "text": "Put a +1/+1 counter on target creature. That creature gains first strike until end of turn. You gain 2 life.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "4c6c3a19-8fc9-5174-9f21-059cdd69f2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f060a74-dd75-4625-8842-27cb13a279e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f060a74-dd75-4625-8842-27cb13a279e6.jpg?1",
             "name": "Blessed Spirits",
             "text": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on Blessed Spirits.",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "cdbd962c-d0d0-5155-b8f5-dc86ded4efdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5104d4fe-4c20-4106-b405-a2b35140c942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5104d4fe-4c20-4106-b405-a2b35140c942.jpg?1",
             "name": "Bulwark Giant",
             "text": "When Bulwark Giant enters the battlefield, you gain 5 life.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "1628b256-762a-5b5b-b6e4-b9d9fbdb3972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291a964-1117-4fbd-9193-9719b273c348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291a964-1117-4fbd-9193-9719b273c348.jpg?1",
             "name": "Cathar's Companion",
             "text": "Whenever you cast a noncreature spell, Cathar's Companion gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "82c3c0b6-de7e-5b30-b94e-b4d3d3720acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb70e7b-2a68-436e-96a4-32a88fb87da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb70e7b-2a68-436e-96a4-32a88fb87da0.jpg?1",
             "name": "Cathars' Crusade",
             "text": "Whenever a creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "28ae5d92-6559-5b72-9826-6ccddd535cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136dfcf5-130a-4d75-9785-a090215a29b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136dfcf5-130a-4d75-9785-a090215a29b1.jpg?1",
             "name": "Celestial Mantle",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nWhenever enchanted creature deals combat damage to a player, double its controller's life total.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "556be442-68d0-57fc-9944-c0c7d6ff13ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc7fdf0-3e1e-487c-833d-7c74aa02c0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc7fdf0-3e1e-487c-833d-7c74aa02c0c1.jpg?1",
             "name": "Cloudshift",
             "text": "Exile target creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "1bdf5331-a59d-5898-a3cc-29b9eee3056b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caae1f4-dfb0-466f-9fa6-eb014767e3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4caae1f4-dfb0-466f-9fa6-eb014767e3c8.jpg?1",
             "name": "Cradle of Vitality",
             "text": "Whenever you gain life, you may pay {1}{W}. If you do, put a +1/+1 counter on target creature for each 1 life you gained.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "8a73b5a5-a5d9-5a95-9d70-97cbcf54136f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae001aa-10a0-482a-86fe-bf6ca7fc0866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae001aa-10a0-482a-86fe-bf6ca7fc0866.jpg?1",
             "name": "Dauntless Onslaught",
             "text": "Up to two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "b0fa2882-d2b6-5264-a6b2-8a98ab79d6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c4997-2b96-45da-a4e1-70a86453c6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352c4997-2b96-45da-a4e1-70a86453c6fa.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "796b821f-e1cd-5c1b-a106-1868c5a45173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefef556-dd3c-49b9-a6f5-8b86af64416e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefef556-dd3c-49b9-a6f5-8b86af64416e.jpg?1",
             "name": "Duelist's Heritage",
             "text": "Whenever one or more creatures attack, you may have target attacking creature gain double strike until end of turn.",
             "colours": [
@@ -3646,7 +3646,7 @@
         },
         {
             "id": "8ebe4905-a7e1-583c-8225-2b3cf511f0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2a972a-a953-485d-920d-8f4f978ef758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2a972a-a953-485d-920d-8f4f978ef758.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "afa7c72a-5480-575a-856f-ade0c75e4ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207b7c60-ecf0-4661-8022-1e1714237e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207b7c60-ecf0-4661-8022-1e1714237e9f.jpg?1",
             "name": "Face of Divinity",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nAs long as another Aura is attached to enchanted creature, it has first strike and lifelink.",
             "colours": [
@@ -3712,7 +3712,7 @@
         },
         {
             "id": "3c58b463-d5b7-568e-a089-96b663bf5d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4004b7-89b6-43f5-8d6e-13db1b08f3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa4004b7-89b6-43f5-8d6e-13db1b08f3b8.jpg?1",
             "name": "Forced Worship",
             "text": "Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "75184ed2-f823-526a-8d7d-feea7b24e794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4b138-5edc-4c12-b526-5c258bc1555c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4b138-5edc-4c12-b526-5c258bc1555c.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "499d476a-cff8-5235-969d-7f36f4612530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77238879-6dc7-46ff-8354-89e60c2a04e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77238879-6dc7-46ff-8354-89e60c2a04e9.jpg?1",
             "name": "Gird for Battle",
             "text": "Put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -3807,7 +3807,7 @@
         },
         {
             "id": "912101c7-cb9f-59df-8761-7eccdbb05c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39dd28-1dc2-46a5-a3cf-9b5d267e16d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd39dd28-1dc2-46a5-a3cf-9b5d267e16d6.jpg?1",
             "name": "Healer's Hawk",
             "text": "Flying, lifelink",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "751801e9-c5b4-5cb4-bcd3-44461cae9c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2002d263-3fe0-481a-b389-84e281b009d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2002d263-3fe0-481a-b389-84e281b009d7.jpg?1",
             "name": "High Sentinels of Arashin",
             "text": "Flying\nHigh Sentinels of Arashin gets +1/+1 for each other creature you control with a +1/+1 counter on it.\n{3}{W}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "89eb4a1a-a424-55ab-aef3-3b20fe2421c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ba5d4b-5dbb-43d6-8f44-a2f80944df98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ba5d4b-5dbb-43d6-8f44-a2f80944df98.jpg?1",
             "name": "Indomitable Will",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "019eb95e-4c16-5a56-b859-4212ba174ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9822b57-8e42-4158-981d-f0b0b0646fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9822b57-8e42-4158-981d-f0b0b0646fc9.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "92c7efe5-1b37-555b-b33f-c17df336b8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac9c0ee-97a1-4c31-8a42-30408ef3a49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac9c0ee-97a1-4c31-8a42-30408ef3a49c.jpg?1",
             "name": "Inspiring Captain",
             "text": "When Inspiring Captain enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "356b1fcd-717f-5559-8d37-b36b777bd2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3320865c-ef02-4f18-82b0-47a6d845de0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3320865c-ef02-4f18-82b0-47a6d845de0f.jpg?1",
             "name": "Inspiring Unicorn",
             "text": "Whenever Inspiring Unicorn attacks, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "8f988512-19df-526e-9f80-169168570933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afead32-3542-44c4-82d6-b6a81beb9f90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afead32-3542-44c4-82d6-b6a81beb9f90.jpg?1",
             "name": "Isamaru, Hound of Konda",
             "text": "",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "fcc627aa-2b6a-5a28-a041-f23fdf59983d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f81d2a0-5301-4cae-ac83-ad51647146e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f81d2a0-5301-4cae-ac83-ad51647146e3.jpg?1",
             "name": "Knight of the Tusk",
             "text": "Vigilance",
             "colours": [
@@ -4074,7 +4074,7 @@
         },
         {
             "id": "a9c184c6-e9ce-59f5-bdff-416b91b7dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f463b5-188f-4ecc-8cbf-0f200515bb09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f463b5-188f-4ecc-8cbf-0f200515bb09.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, create a 2/2 white Knight creature token with vigilance.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "1e9f8f5c-4adf-5808-a1c2-44ebf4834ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59813c47-e779-404d-8a1c-70ea29bc7023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59813c47-e779-404d-8a1c-70ea29bc7023.jpg?1",
             "name": "Kor Spiritdancer",
             "text": "Kor Spiritdancer gets +2/+2 for each Aura attached to it.\nWhenever you cast an Aura spell, you may draw a card.",
             "colours": [
@@ -4141,7 +4141,7 @@
         },
         {
             "id": "4fe5c999-93d5-5c4e-8a7e-88e3d8d6dcaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1fb1a6-7f64-45a6-9fc0-a325b7600afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1fb1a6-7f64-45a6-9fc0-a325b7600afa.jpg?1",
             "name": "Lena, Selfless Champion",
             "text": "When Lena, Selfless Champion enters the battlefield, create a 1/1 white Soldier creature token for each nontoken creature you control.\nSacrifice Lena: Creatures you control with power less than Lena's power gain indestructible until end of turn.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "929df165-cac5-5580-9a54-5819bd930b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cfd373-148d-4073-8867-3d9ccae20fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cfd373-148d-4073-8867-3d9ccae20fd1.jpg?1",
             "name": "Lightwalker",
             "text": "Lightwalker has flying as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "5fe46713-f615-59af-a1e5-28cb941190e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dded98c3-17cb-4a43-a209-289ceb11df39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dded98c3-17cb-4a43-a209-289ceb11df39.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "Flying\nActivated abilities of creatures your opponents control can't be activated.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "f5b54576-8dc4-50aa-9553-4fb87fbbba47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504698a9-1512-4288-b5ef-392d41ebcd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504698a9-1512-4288-b5ef-392d41ebcd05.jpg?1",
             "name": "Long Road Home",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "020fcfb8-2d43-59d3-a175-9bc88931a18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46150e35-bcaf-4b53-871d-d1d9091a36ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46150e35-bcaf-4b53-871d-d1d9091a36ab.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "c4a84543-6375-559e-a96e-01bd85ad2dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e321bbb0-1660-4452-a9b7-d41674f7f743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e321bbb0-1660-4452-a9b7-d41674f7f743.jpg?1",
             "name": "Mesa Unicorn",
             "text": "Lifelink",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "0fb104f2-5985-5774-865b-c1e6c0e4057e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b24d60d-bd80-4363-829c-a9d7f8c61fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b24d60d-bd80-4363-829c-a9d7f8c61fdf.jpg?1",
             "name": "Mikaeus, the Lunarch",
             "text": "Mikaeus, the Lunarch enters the battlefield with X +1/+1 counters on it.\n{T}: Put a +1/+1 counter on Mikaeus.\n{T}, Remove a +1/+1 counter from Mikaeus: Put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "79850572-a228-55f8-bddc-a39c2e94c784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17da4d0-f9fd-43af-85fc-ede9fa3962bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17da4d0-f9fd-43af-85fc-ede9fa3962bf.jpg?1",
             "name": "Moment of Heroism",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn.",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "c1788f37-5a9a-525a-aa33-80d35ebdd56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da7c6dc-9325-4866-8c09-78c7021f8f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da7c6dc-9325-4866-8c09-78c7021f8f17.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -4444,7 +4444,7 @@
         },
         {
             "id": "602a5fab-a84a-5144-a728-9b32b2a1c61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389a05-2e1a-471d-a865-1c3b68a03e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389a05-2e1a-471d-a865-1c3b68a03e01.jpg?1",
             "name": "Path of Bravery",
             "text": "As long as your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
             "colours": [
@@ -4475,7 +4475,7 @@
         },
         {
             "id": "b7ac0ff5-d80f-5e94-86a3-aec781167970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40386-6ea6-4b77-8c61-2a9a16a88a01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40386-6ea6-4b77-8c61-2a9a16a88a01.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle their library.",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "4bdaf4f3-8f64-506a-8032-6d9bcefa5f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f43272-6681-41dd-8bfd-d18cc68171c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f43272-6681-41dd-8bfd-d18cc68171c1.jpg?1",
             "name": "Patron of the Valiant",
             "text": "Flying\nWhen Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "c15e881a-ee01-5704-9a82-30ff9e9e60d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f552f9b6-0a60-44d8-985e-249617e04866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f552f9b6-0a60-44d8-985e-249617e04866.jpg?1",
             "name": "Raise the Alarm",
             "text": "Create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "1bc581eb-d021-5a03-975d-ba2d0325f31f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62498e3c-2e9b-4444-a61c-fae3f8906010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62498e3c-2e9b-4444-a61c-fae3f8906010.jpg?1",
             "name": "Rhox Faithmender",
             "text": "Lifelink\nIf you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -4604,7 +4604,7 @@
         },
         {
             "id": "35233dab-225b-5f72-b3dc-0b11782faf45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb993412-69bc-4000-ac8f-b2f62161fc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb993412-69bc-4000-ac8f-b2f62161fc55.jpg?1",
             "name": "Ronom Unicorn",
             "text": "Sacrifice Ronom Unicorn: Destroy target enchantment.",
             "colours": [
@@ -4637,7 +4637,7 @@
         },
         {
             "id": "7224e18f-ce5f-58ca-9e32-61624dde9ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f035-3437-4c5c-bae9-d3c9001a3411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f035-3437-4c5c-bae9-d3c9001a3411.jpg?1",
             "name": "Serra Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "f56199c9-bbc1-578d-8cda-24b8de3f4f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b4430-95c0-424b-a365-4ae467bb303d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b4430-95c0-424b-a365-4ae467bb303d.jpg?1",
             "name": "Sky Tether",
             "text": "Enchant creature\nEnchanted creature has defender and loses flying.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "b4ae1aa2-ad8f-5434-81e2-7ba15da4f910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457eb507-bbbf-4064-bdb0-cfeefe2195df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457eb507-bbbf-4064-bdb0-cfeefe2195df.jpg?1",
             "name": "Take Heart",
             "text": "Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "4b66b455-796e-59a3-8ea1-eecbf5f09df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acd58e4-7dc7-4ca0-8750-2558ff97b5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7acd58e4-7dc7-4ca0-8750-2558ff97b5da.jpg?1",
             "name": "Tandem Tactics",
             "text": "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "1328f914-a639-5581-993b-d79497e70453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20516400-b37a-46d2-89c8-d6be88f5ab3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20516400-b37a-46d2-89c8-d6be88f5ab3d.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -4796,7 +4796,7 @@
         },
         {
             "id": "516871bf-0498-518d-a52d-4347cb65e251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a78066-c52e-48fd-bcf9-d0b60f00fddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a78066-c52e-48fd-bcf9-d0b60f00fddc.jpg?1",
             "name": "Voice of the Provinces",
             "text": "Flying\nWhen Voice of the Provinces enters the battlefield, create a 1/1 white Human creature token.",
             "colours": [
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "ec8a23a0-6dd8-5d3d-af5b-fea3d44edaf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7003ebae-5d82-4360-ae63-0e51c37977ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7003ebae-5d82-4360-ae63-0e51c37977ed.jpg?1",
             "name": "Aegis Turtle",
             "text": "",
             "colours": [
@@ -4862,7 +4862,7 @@
         },
         {
             "id": "c7012778-e33d-515f-a634-a1adecdd4afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b2d108-16f2-4d9b-abc8-83ee3d2e8baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b2d108-16f2-4d9b-abc8-83ee3d2e8baf.jpg?1",
             "name": "Battleground Geist",
             "text": "Flying\nOther Spirit creatures you control get +1/+0.",
             "colours": [
@@ -4895,7 +4895,7 @@
         },
         {
             "id": "d20bbda6-0791-518c-a5f6-926ade37424a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c1f80e-65b7-4534-bfd4-1ae88274945b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c1f80e-65b7-4534-bfd4-1ae88274945b.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "52fde117-f750-5959-ad0d-91d9a09a9f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef04340d-284c-4e7b-afd7-444d21a6b382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef04340d-284c-4e7b-afd7-444d21a6b382.jpg?1",
             "name": "Belltower Sphinx",
             "text": "Flying\nWhenever a source deals damage to Belltower Sphinx, that source's controller mills that many cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "c78c983b-7b74-51e1-8185-83b7653ae773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6f256b-943e-4cfb-9fc9-d1ded68b5f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6f256b-943e-4cfb-9fc9-d1ded68b5f97.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked with a creature this turn.",
             "colours": [
@@ -4990,7 +4990,7 @@
         },
         {
             "id": "4de3b876-fe1c-50d4-a132-c14adf4ab2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149d4f00-106b-4aa7-a667-6360d2e149e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149d4f00-106b-4aa7-a667-6360d2e149e7.jpg?1",
             "name": "Cloudreader Sphinx",
             "text": "Flying\nWhen Cloudreader Sphinx enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "7420c28c-4f35-5c7d-aa6a-5e19cb1c7b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c4e43-71b2-4483-ba54-4be1dcffcd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c4e43-71b2-4483-ba54-4be1dcffcd5f.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "0fc2254b-27af-52b3-8edb-4c10f026f2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4e2977-b518-4fa3-83e4-5af326ded290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4e2977-b518-4fa3-83e4-5af326ded290.jpg?1",
             "name": "Crookclaw Transmuter",
             "text": "Flash\nFlying\nWhen Crookclaw Transmuter enters the battlefield, switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -5088,7 +5088,7 @@
         },
         {
             "id": "5b4f5d47-071b-5552-ad08-54951904f279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a636f74-3bac-4b88-a24f-32a66a94e340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a636f74-3bac-4b88-a24f-32a66a94e340.jpg?1",
             "name": "Cryptic Serpent",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "3bf05e06-5609-5e30-be6c-6af8107835f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a0be10-c20f-4ac0-89a5-1770ecf48aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a0be10-c20f-4ac0-89a5-1770ecf48aad.jpg?1",
             "name": "Curiosity",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "04f147d0-f3c0-537a-a52f-ebacdb318184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cf3030-dc92-45ab-9c26-f2e6aef67e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04cf3030-dc92-45ab-9c26-f2e6aef67e56.jpg?1",
             "name": "Curious Obsession",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, you may draw a card.\"\nAt the beginning of your end step, if you didn't attack with a creature this turn, sacrifice Curious Obsession.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "1e053d94-1d40-5cab-b019-bfeafc8bb626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b3c3e3-151f-4f16-bb40-167978180bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b3c3e3-151f-4f16-bb40-167978180bbc.jpg?1",
             "name": "Departed Deckhand",
             "text": "When Departed Deckhand becomes the target of a spell, sacrifice it.\nDeparted Deckhand can't be blocked except by Spirits.\n{3}{U}: Another target creature you control can't be blocked this turn except by Spirits.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "7ad06b4c-1465-5f46-809c-c142579533ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dfe354-d527-4f56-8457-b95884700a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dfe354-d527-4f56-8457-b95884700a40.jpg?1",
             "name": "Erratic Visionary",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -5255,7 +5255,7 @@
         },
         {
             "id": "b890057e-f663-53d8-b594-20a8fe9f0aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2600a51b-0dae-431e-a0a7-2b1421706a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2600a51b-0dae-431e-a0a7-2b1421706a6a.jpg?1",
             "name": "Essence Flux",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. If it's a Spirit, put a +1/+1 counter on it.",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "68348971-73b8-5703-97dc-4b8f6461e671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1455f59e-f487-4195-ab25-8fc7695903e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1455f59e-f487-4195-ab25-8fc7695903e4.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -5317,7 +5317,7 @@
         },
         {
             "id": "3edf8a32-9ac2-5d84-a1b1-8f593fe5df58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6344ecd-ca57-4104-a77a-d7d14264776d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6344ecd-ca57-4104-a77a-d7d14264776d.jpg?1",
             "name": "Exclusion Mage",
             "text": "When Exclusion Mage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -5351,7 +5351,7 @@
         },
         {
             "id": "5c73bba7-3d61-5fd2-bbcc-8cf22ac86d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437ded6e-4e53-49fa-a5ca-fd76b9165a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437ded6e-4e53-49fa-a5ca-fd76b9165a47.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability for the first time each turn, counter that spell or ability.\"",
             "colours": [
@@ -5386,7 +5386,7 @@
         },
         {
             "id": "0bc3b035-99df-5363-b8a6-476402e22039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36056deb-a7f8-4bb3-9c51-890e96f41482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36056deb-a7f8-4bb3-9c51-890e96f41482.jpg?1",
             "name": "Kitesail Corsair",
             "text": "Kitesail Corsair has flying as long as it's attacking.",
             "colours": [
@@ -5420,7 +5420,7 @@
         },
         {
             "id": "19d8a18f-69a5-5be4-bf07-254bc1e20650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049955c6-63f5-4f80-8c60-34c890f3c71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049955c6-63f5-4f80-8c60-34c890f3c71a.jpg?1",
             "name": "Leave in the Dust",
             "text": "Return target nonland permanent to its owner's hand.\nDraw a card.",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "8bf759d4-0cc8-55b1-ba39-8b0fa69ad495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c1aaff-ab26-437e-a88a-494683aec831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c1aaff-ab26-437e-a88a-494683aec831.jpg?1",
             "name": "Murmuring Phantasm",
             "text": "Defender",
             "colours": [
@@ -5484,7 +5484,7 @@
         },
         {
             "id": "48087c07-e7ce-57fe-bf51-2d5a2c9d0f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de19d2db-604b-4d5f-8184-9bb0a31c7405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de19d2db-604b-4d5f-8184-9bb0a31c7405.jpg?1",
             "name": "Mystic Archaeologist",
             "text": "{3}{U}{U}: Draw two cards.",
             "colours": [
@@ -5518,7 +5518,7 @@
         },
         {
             "id": "35c102de-7840-51bd-9e1b-f2ec95088087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95681c43-ba2e-41a5-8a51-e66db8ec6cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95681c43-ba2e-41a5-8a51-e66db8ec6cb9.jpg?1",
             "name": "Narcolepsy",
             "text": "Enchant creature\nAt the beginning of each upkeep, if enchanted creature is untapped, tap it.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "506e03ac-b060-5b77-aa1b-481a8e0501cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c0715-416c-4316-98ef-ff90bb3112ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768c0715-416c-4316-98ef-ff90bb3112ae.jpg?1",
             "name": "Nebelgast Herald",
             "text": "Flash\nFlying\nWhenever Nebelgast Herald or another Spirit enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "fb3cbb52-2077-5e88-b828-f2cbeb8a1f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbb3f9d-8629-4815-8b7d-f8ec9368b9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbb3f9d-8629-4815-8b7d-f8ec9368b9b0.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "cbdf3c42-7abc-5f6d-840b-36be1d1ea850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61921b05-ee83-4768-a405-4d3355c0ad6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61921b05-ee83-4768-a405-4d3355c0ad6e.jpg?1",
             "name": "Oneirophage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on Oneirophage.",
             "colours": [
@@ -5651,7 +5651,7 @@
         },
         {
             "id": "6e04a465-8a37-5d49-9392-12aeaea09f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d0f29b-fcc4-4135-af36-6539912ab3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d0f29b-fcc4-4135-af36-6539912ab3bb.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "87a37b24-0f70-515f-9a6c-6f671e19fe04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bb655d-8d62-4a79-9a9d-7384d1cb2cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bb655d-8d62-4a79-9a9d-7384d1cb2cc0.jpg?1",
             "name": "Prescient Chimera",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5715,7 +5715,7 @@
         },
         {
             "id": "a17b04aa-9df5-5b48-b6d7-4e7cc69fef2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db054e-8303-44c7-8c96-d031a8c85b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db054e-8303-44c7-8c96-d031a8c85b34.jpg?1",
             "name": "Prosperous Pirates",
             "text": "When Prosperous Pirates enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5749,7 +5749,7 @@
         },
         {
             "id": "3661764e-6764-5057-9067-0b01b9e456ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505e7f2c-c040-427a-a3a1-e7b36066e4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505e7f2c-c040-427a-a3a1-e7b36066e4fe.jpg?1",
             "name": "Rattlechains",
             "text": "Flash\nFlying\nWhen Rattlechains enters the battlefield, target Spirit gains hexproof until end of turn.\nYou may cast Spirit spells as though they had flash.",
             "colours": [
@@ -5782,7 +5782,7 @@
         },
         {
             "id": "ac655828-e102-540e-9590-3b03466b6065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65088f-bbbd-4e8d-b482-58181069bef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c65088f-bbbd-4e8d-b482-58181069bef2.jpg?1",
             "name": "Read the Runes",
             "text": "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.",
             "colours": [
@@ -5813,7 +5813,7 @@
         },
         {
             "id": "252a6a8d-6c67-54c6-9a5e-3fddc553e63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad3313a-61ef-42c8-a092-390adb51e17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad3313a-61ef-42c8-a092-390adb51e17e.jpg?1",
             "name": "Reckless Scholar",
             "text": "{T}: Target player draws a card, then discards a card.",
             "colours": [
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "41b36bfa-1fb6-5f4e-87ba-94143495b70c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914dba-0d27-4055-ac34-b3ebf5802221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914dba-0d27-4055-ac34-b3ebf5802221.jpg?1",
             "name": "Rhystic Study",
             "text": "Whenever an opponent casts a spell, you may draw a card unless that player pays {1}.",
             "colours": [
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "0fdba264-519c-57d1-8d3d-0f572e57fc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ea87f1-fbe2-4905-8a97-ceef9d3d0faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ea87f1-fbe2-4905-8a97-ceef9d3d0faf.jpg?1",
             "name": "Rishadan Airship",
             "text": "Flying\nRishadan Airship can block only creatures with flying.",
             "colours": [
@@ -5912,7 +5912,7 @@
         },
         {
             "id": "c6575626-15f6-5e99-b6ba-13146c089c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c17066-c551-4aed-9258-1e5ed947385b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c17066-c551-4aed-9258-1e5ed947385b.jpg?1",
             "name": "Sage's Row Savant",
             "text": "When Sage's Row Savant enters the battlefield, scry 2.",
             "colours": [
@@ -5946,7 +5946,7 @@
         },
         {
             "id": "99005fa0-d3c1-52da-b62e-e805787e536c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c1e6ad-1227-4049-89bf-69ace48c3076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c1e6ad-1227-4049-89bf-69ace48c3076.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5980,7 +5980,7 @@
         },
         {
             "id": "6934ade8-bb25-5eb7-999f-03be7a2c7cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b3006-16cb-4752-908e-3c9f37ac249c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0b3006-16cb-4752-908e-3c9f37ac249c.jpg?1",
             "name": "Sea Gate Oracle",
             "text": "When Sea Gate Oracle enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "156dd28e-3c5f-5cae-b113-a89c4b07a4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94975b02-f678-4442-9d1a-cf586aee8789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94975b02-f678-4442-9d1a-cf586aee8789.jpg?1",
             "name": "Selhoff Occultist",
             "text": "Whenever Selhoff Occultist or another creature dies, target player mills a card. (They put the top card of their library into their graveyard.)",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "d21ae4ed-adc4-5459-95c7-71670e8dd412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30032a0b-dece-42a4-9309-fa9e9e277603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30032a0b-dece-42a4-9309-fa9e9e277603.jpg?1",
             "name": "Serendib Efreet",
             "text": "Flying\nAt the beginning of your upkeep, Serendib Efreet deals 1 damage to you.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "bfbab9a0-1fb0-5ec9-b80c-60e4a20fc21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df1ce35-1f1c-40ab-8e4d-cb087b4656d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df1ce35-1f1c-40ab-8e4d-cb087b4656d8.jpg?1",
             "name": "Sharding Sphinx",
             "text": "Flying\nWhenever an artifact creature you control deals combat damage to a player, you may create a 1/1 blue Thopter artifact creature token with flying.",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "91f6855e-e113-5a2c-8cf6-84a036da3fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1a93c3-8561-4c65-bea8-a9c3a898a48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1a93c3-8561-4c65-bea8-a9c3a898a48c.jpg?1",
             "name": "Sigiled Starfish",
             "text": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "d263be8d-d432-5627-9b3c-5e71c78b8740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b591fef-21ca-4a3b-990b-d7897a405511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b591fef-21ca-4a3b-990b-d7897a405511.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "e6cc1636-dd92-5e4b-920d-584441a035b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9ac55-4bb4-4447-b214-6a108ddb3f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb9ac55-4bb4-4447-b214-6a108ddb3f07.jpg?1",
             "name": "Storm Sculptor",
             "text": "Storm Sculptor can't be blocked.\nWhen Storm Sculptor enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -6216,7 +6216,7 @@
         },
         {
             "id": "943b118f-b104-5bd7-92b7-08aaa9e17102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad50269-6e80-47ea-a027-fa274f904e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad50269-6e80-47ea-a027-fa274f904e86.jpg?1",
             "name": "Sweep Away",
             "text": "Return target creature to its owner's hand. If that creature is attacking, you may put it on top of its owner's library instead.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "d7666baf-973f-5532-a0e3-58850da10630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c1a1-1896-4360-b123-52d82a6871d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c1a1-1896-4360-b123-52d82a6871d4.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "a010065c-d4b1-5bfd-83fb-69fd85952729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b153c2f-fc87-49bc-9d1e-d5e7e25b2142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b153c2f-fc87-49bc-9d1e-d5e7e25b2142.jpg?1",
             "name": "Talrand's Invocation",
             "text": "Create two 2/2 blue Drake creature tokens with flying.",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "9e120b5e-f42d-5579-8a93-a9618a590a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e40cb2-d306-4c8d-859b-ac288e9dc78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e40cb2-d306-4c8d-859b-ac288e9dc78d.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "cd895cab-a26f-544b-9eb5-761b3f9981a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a932a37-a1db-4df9-9b65-27ee7b46957d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a932a37-a1db-4df9-9b65-27ee7b46957d.jpg?1",
             "name": "Thought Collapse",
             "text": "Counter target spell. Its controller mills three cards. (They put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -6376,7 +6376,7 @@
         },
         {
             "id": "f819df36-2daa-5092-b9fc-c8becb5b3ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142944d5-1b11-4ec4-b6b4-b5c03e682cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142944d5-1b11-4ec4-b6b4-b5c03e682cd3.jpg?1",
             "name": "Thought Scour",
             "text": "Target player mills two cards. (They put the top two cards of their library into their graveyard.)\nDraw a card.",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "937912d9-d0d2-58e3-8f2f-53c9aa350e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8203f709-0fac-41c1-a056-3fa1a2c1d127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8203f709-0fac-41c1-a056-3fa1a2c1d127.jpg?1",
             "name": "Towering-Wave Mystic",
             "text": "Whenever Towering-Wave Mystic deals damage, target player mills that many cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "1c14f9bd-9563-56ff-83dd-9f64a743bb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b3cb7-b434-4524-8ef0-7db7f7f22edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b3cb7-b434-4524-8ef0-7db7f7f22edd.jpg?1",
             "name": "Vedalken Archmage",
             "text": "Whenever you cast an artifact spell, draw a card.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "ee8dc4d8-1478-5875-9493-c8bacc3945d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bdfd6-8baf-430d-a4c4-5acf81e58b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bdfd6-8baf-430d-a4c4-5acf81e58b62.jpg?1",
             "name": "Vedalken Entrancer",
             "text": "{U}, {T}: Target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "704c1976-a74f-5d30-b8ae-4ceee05f3a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55c60dc-40ed-4a36-9daa-702f79ffe818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55c60dc-40ed-4a36-9daa-702f79ffe818.jpg?1",
             "name": "Voyage's End",
             "text": "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6540,7 +6540,7 @@
         },
         {
             "id": "cede2da9-cbd5-5a24-a73d-135698ddf566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e3084c-c690-4cc7-9d79-42b1cde073ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e3084c-c690-4cc7-9d79-42b1cde073ad.jpg?1",
             "name": "Wall of Lost Thoughts",
             "text": "Defender\nWhen Wall of Lost Thoughts enters the battlefield, target player mills four cards. (They put the top four cards of their library into their graveyard.)",
             "colours": [
@@ -6573,7 +6573,7 @@
         },
         {
             "id": "24f55bbe-0e03-5ca5-9d04-b45fa1c90703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58807d-1663-486a-ac94-627a8677f2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58807d-1663-486a-ac94-627a8677f2b3.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "a27c4eb5-7c98-5be9-9ae5-19a584f42540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada68b91-3379-483e-93a0-b6c7c675c1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada68b91-3379-483e-93a0-b6c7c675c1dc.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "cef870f4-6fa3-53f8-9f45-473cbd02605e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84fb92-bb66-4f1a-b360-f87fdbcd45b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc84fb92-bb66-4f1a-b360-f87fdbcd45b7.jpg?1",
             "name": "Whelming Wave",
             "text": "Return all creatures to their owners' hands except for Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "c94b4137-a58a-514e-b841-be298da3b528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0346326-6bdf-4385-ab41-7b06e9f66ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0346326-6bdf-4385-ab41-7b06e9f66ffd.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "fb945500-8c4b-56d1-b792-1c17957364f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff4bd1-2b61-46be-b547-38916ea08298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ff4bd1-2b61-46be-b547-38916ea08298.jpg?1",
             "name": "Windstorm Drake",
             "text": "Flying\nOther creatures you control with flying get +1/+0.",
             "colours": [
@@ -6737,7 +6737,7 @@
         },
         {
             "id": "ca80a818-4061-5f97-9bed-5f4acaffe6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48ebd79-95d7-4860-9785-45e34a94755d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48ebd79-95d7-4860-9785-45e34a94755d.jpg?1",
             "name": "Winged Words",
             "text": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "6011787a-fe2b-5fce-8f5f-83eb11cff445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a7809-4bef-48e9-afbc-e473eb7072e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a7809-4bef-48e9-afbc-e473eb7072e8.jpg?1",
             "name": "Wishful Merfolk",
             "text": "Defender\n{1}{U}: Wishful Merfolk loses defender and becomes a Human until end of turn.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "3da2d1e2-c435-5c4d-8bca-a2404523d7a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979cd394-80ce-4559-9f3a-57cd84299182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979cd394-80ce-4559-9f3a-57cd84299182.jpg?1",
             "name": "Wizard's Retort",
             "text": "This spell costs {1} less to cast if you control a Wizard.\nCounter target spell.",
             "colours": [
@@ -6832,7 +6832,7 @@
         },
         {
             "id": "1a0e33f4-34ae-51fd-9040-87139d7d2b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532a279-b8e1-4124-bcd7-d7f4c71673eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532a279-b8e1-4124-bcd7-d7f4c71673eb.jpg?1",
             "name": "Agonizing Syphon",
             "text": "Agonizing Syphon deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "3b11977a-2822-5a2f-a061-3d2e1661be42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aacb3ae-c889-4912-bc2d-2aa0adfd20bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aacb3ae-c889-4912-bc2d-2aa0adfd20bd.jpg?1",
             "name": "Assassin's Strike",
             "text": "Destroy target creature. Its controller discards a card.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "dcdf79ab-fd4e-5430-add7-96a9b65f4176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6e5b25-b721-45ee-894a-697de1310b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6e5b25-b721-45ee-894a-697de1310b8c.jpg?1",
             "name": "Bake into a Pie",
             "text": "Destroy target creature. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "96a0dcf9-3e94-5ff0-9d5a-d100e45bf70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23986add-b33d-4bad-86f3-e2d0f99cf949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23986add-b33d-4bad-86f3-e2d0f99cf949.jpg?1",
             "name": "Barter in Blood",
             "text": "Each player sacrifices two creatures.",
             "colours": [
@@ -6956,7 +6956,7 @@
         },
         {
             "id": "c30dd503-6e0f-5b25-9aee-d9834b8ae97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90a12af-b453-4d83-9a14-5411b562d480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90a12af-b453-4d83-9a14-5411b562d480.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "8c30f906-3bc9-5059-bc5f-b3790375603a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f51ced8-9384-4b8d-aa60-efb281ac9439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f51ced8-9384-4b8d-aa60-efb281ac9439.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "5947d4f3-869c-5035-ba76-0e428496d9f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0cc3d9-85f1-49ed-bf8a-81fc6c60bd2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0cc3d9-85f1-49ed-bf8a-81fc6c60bd2a.jpg?1",
             "name": "Blighted Bat",
             "text": "Flying\n{1}: Blighted Bat gains haste until end of turn.",
             "colours": [
@@ -7055,7 +7055,7 @@
         },
         {
             "id": "96834c94-3b08-5745-98f4-9deaf255b926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8c18-c76b-488a-a4ec-ec0d2267a307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8c18-c76b-488a-a4ec-ec0d2267a307.jpg?1",
             "name": "Blood Artist",
             "text": "Whenever Blood Artist or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -7088,7 +7088,7 @@
         },
         {
             "id": "dd37d438-c478-53c5-ab67-ab0608ffb929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab76e956-5d6c-49b8-991c-c39d5b18b876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab76e956-5d6c-49b8-991c-c39d5b18b876.jpg?1",
             "name": "A-Blood Artist",
             "text": "",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "64ef2474-11af-525f-a10a-e2990883b250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51278b56-5056-4a37-a1e8-daca45d8e360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51278b56-5056-4a37-a1e8-daca45d8e360.jpg?1",
             "name": "Blood Divination",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "ee7d209e-5469-5f6b-8373-3904f260f434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d0839b-a021-4227-aa0f-1fa2ff806892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d0839b-a021-4227-aa0f-1fa2ff806892.jpg?1",
             "name": "Blood Host",
             "text": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Blood Host and you gain 2 life.",
             "colours": [
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "a0db9b74-4c60-54e0-b5ff-3218d5c25fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c6df1d-7709-41e4-a79f-0dc722600191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c6df1d-7709-41e4-a79f-0dc722600191.jpg?1",
             "name": "Bloodbond Vampire",
             "text": "Whenever you gain life, put a +1/+1 counter on Bloodbond Vampire.",
             "colours": [
@@ -7220,7 +7220,7 @@
         },
         {
             "id": "fd5d6dc7-1046-5407-92f8-7df9a2118ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a14228-3716-4448-a8c3-93928b9b85d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a14228-3716-4448-a8c3-93928b9b85d6.jpg?1",
             "name": "Bloodhunter Bat",
             "text": "Flying\nWhen Bloodhunter Bat enters the battlefield, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -7253,7 +7253,7 @@
         },
         {
             "id": "bb0afd85-2b16-50bc-bb91-11e58c58a141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce1aa49-fe00-4390-8c4b-d1203cc337cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce1aa49-fe00-4390-8c4b-d1203cc337cd.jpg?1",
             "name": "Bogbrew Witch",
             "text": "{2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "f4f67a4a-6f82-5392-9bb9-fe8b2930fa20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c57801-cc6f-4f1f-b401-7f621fdcfaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c57801-cc6f-4f1f-b401-7f621fdcfaaa.jpg?1",
             "name": "Bone Picker",
             "text": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
             "colours": [
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "92633608-1527-5938-b7d9-00abce133c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc676672-1aeb-420a-b909-5a3215cc2ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc676672-1aeb-420a-b909-5a3215cc2ca6.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "dd98a74e-8c6c-5f39-a0c1-9dff9303ab66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb457c05-2a60-437a-8138-cfd581b22996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb457c05-2a60-437a-8138-cfd581b22996.jpg?1",
             "name": "Burglar Rat",
             "text": "When Burglar Rat enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "62a73824-4d69-5233-976f-d0079356159f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fefd7f9-57ff-41bb-aef6-b1d568a7588b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fefd7f9-57ff-41bb-aef6-b1d568a7588b.jpg?1",
             "name": "Cadaver Imp",
             "text": "Flying\nWhen Cadaver Imp enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7417,7 +7417,7 @@
         },
         {
             "id": "1bc98625-6339-5841-9f38-ef73bcd61a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf273e-b8f7-434b-9d5d-883dfd6f7423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cf273e-b8f7-434b-9d5d-883dfd6f7423.jpg?1",
             "name": "Cauldron Familiar",
             "text": "When Cauldron Familiar enters the battlefield, each opponent loses 1 life and you gain 1 life.\nSacrifice a Food: Return Cauldron Familiar from your graveyard to the battlefield.",
             "colours": [
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "01f26f87-b1da-53e2-bbc1-d2d5bf9d47c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88531c36-2330-474b-9426-1e4dd0fe4e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88531c36-2330-474b-9426-1e4dd0fe4e3e.jpg?1",
             "name": "Cemetery Recruitment",
             "text": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
             "colours": [
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "93bc2731-3ff6-517a-86c9-086d0e72864c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3887af00-a87d-4396-b82b-38b88c084e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3887af00-a87d-4396-b82b-38b88c084e8e.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "704b900a-5115-56c9-992c-d06823f1e10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7bdf8-505e-4ed2-8a3b-aba263afd196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7bdf8-505e-4ed2-8a3b-aba263afd196.jpg?1",
             "name": "Corpse Hauler",
             "text": "{2}{B}, Sacrifice Corpse Hauler: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -7548,7 +7548,7 @@
         },
         {
             "id": "419538bb-fe35-56e9-b6a4-a776fd1a44de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd6d782-ce5a-4994-8310-34faf9c41de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd6d782-ce5a-4994-8310-34faf9c41de2.jpg?1",
             "name": "Corpse Traders",
             "text": "{2}{B}, Sacrifice a creature: Target opponent reveals their hand. You choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7582,7 +7582,7 @@
         },
         {
             "id": "8f54f230-cf2e-5342-b15d-aca62bcf1bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beed7579-f4f1-4545-9653-4c1179e88dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beed7579-f4f1-4545-9653-4c1179e88dc8.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -7616,7 +7616,7 @@
         },
         {
             "id": "5cd7143a-db8f-561a-999b-bcf4b306b2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954e983-397c-4fdc-a6a1-142d03bfec7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954e983-397c-4fdc-a6a1-142d03bfec7e.jpg?1",
             "name": "Death's Approach",
             "text": "Enchant creature\nEnchanted creature gets -X/-X, where X is the number of creature cards in its controller's graveyard.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "45294c1b-960a-5e3d-93b9-567b43552b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fa15b-4559-4a8f-aa29-5c43eb4eeef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fa15b-4559-4a8f-aa29-5c43eb4eeef9.jpg?1",
             "name": "Douse in Gloom",
             "text": "Douse in Gloom deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -7680,7 +7680,7 @@
         },
         {
             "id": "940ddc2c-40c4-500d-a2da-2b7f31f5a4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f2f66-a43b-422e-94b7-3c068314b7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f2f66-a43b-422e-94b7-3c068314b7ec.jpg?1",
             "name": "Drainpipe Vermin",
             "text": "When Drainpipe Vermin dies, you may pay {B}. If you do, target player discards a card.",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "6002a5b6-04e3-582b-83e3-5c12347356d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d0c37f-ebce-4362-9400-6b9a6e439247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d0c37f-ebce-4362-9400-6b9a6e439247.jpg?1",
             "name": "Drana, Liberator of Malakir",
             "text": "Flying, first strike\nWhenever Drana, Liberator of Malakir deals combat damage to a player, put a +1/+1 counter on each attacking creature you control.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "4bab0d43-2519-522d-bb40-8dbba82655be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35fd9cd-795f-4a8b-b2e9-648f6273927e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35fd9cd-795f-4a8b-b2e9-648f6273927e.jpg?1",
             "name": "Dutiful Attendant",
             "text": "When Dutiful Attendant dies, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "b297842d-35dc-5c14-b7d7-e3f261ddbca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39498cd-9b44-4563-b0fd-9258a52a85b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39498cd-9b44-4563-b0fd-9258a52a85b2.jpg?1",
             "name": "Entomber Exarch",
             "text": "When Entomber Exarch enters the battlefield, choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target opponent reveals their hand. You choose a noncreature card from it. That player discards that card.",
             "colours": [
@@ -7817,7 +7817,7 @@
         },
         {
             "id": "4e8f6993-3a8e-558c-9c65-584df8bba4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a6644a-52e6-454e-a479-44b086240974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a6644a-52e6-454e-a479-44b086240974.jpg?1",
             "name": "Eternal Taskmaster",
             "text": "Eternal Taskmaster enters the battlefield tapped.\nWhenever Eternal Taskmaster attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -7850,7 +7850,7 @@
         },
         {
             "id": "03784467-adb4-5213-85a0-fd20ebd09f20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbc405d-0cfb-45c6-baa1-75845d82e713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbc405d-0cfb-45c6-baa1-75845d82e713.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -7883,7 +7883,7 @@
         },
         {
             "id": "921746cb-3e67-57ed-9b9d-813692f7c830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1cdcba-a04a-4a2f-8bc1-0dd7fa03754d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1cdcba-a04a-4a2f-8bc1-0dd7fa03754d.jpg?1",
             "name": "Exhume",
             "text": "Each player puts a creature card from their graveyard onto the battlefield.",
             "colours": [
@@ -7914,7 +7914,7 @@
         },
         {
             "id": "aca1da85-f6e1-5a14-affd-a5d39dd23812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1653811-1c2c-4e6c-bf1c-287d1b496d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1653811-1c2c-4e6c-bf1c-287d1b496d51.jpg?1",
             "name": "Exquisite Blood",
             "text": "Whenever an opponent loses life, you gain that much life.",
             "colours": [
@@ -7945,7 +7945,7 @@
         },
         {
             "id": "bac6195f-7e31-5fe7-b2bb-ead2feb8e24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60b3c77-62e4-4718-9ddb-cb2e3f1f861f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60b3c77-62e4-4718-9ddb-cb2e3f1f861f.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -7979,7 +7979,7 @@
         },
         {
             "id": "db99bdc7-17f1-5592-9a69-43573caa3728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b3bb-90b1-4241-a9ca-fdd7a0e0f0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b3bb-90b1-4241-a9ca-fdd7a0e0f0ac.jpg?1",
             "name": "Fell Specter",
             "text": "Flying\nWhen Fell Specter enters the battlefield, target opponent discards a card.\nWhenever an opponent discards a card, that player loses 2 life.",
             "colours": [
@@ -8012,7 +8012,7 @@
         },
         {
             "id": "a367c69f-add9-5fb0-a787-8b4f36872697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d7d31e-eaa7-4edf-8e98-5a191ec3b91d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d7d31e-eaa7-4edf-8e98-5a191ec3b91d.jpg?1",
             "name": "Festering Newt",
             "text": "When Festering Newt dies, target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch.",
             "colours": [
@@ -8045,7 +8045,7 @@
         },
         {
             "id": "8c9bc777-d4ec-50b1-9ad9-4514ecf94c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb5fb06-d7b3-4871-a530-9004110596ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb5fb06-d7b3-4871-a530-9004110596ad.jpg?1",
             "name": "Funeral Rites",
             "text": "You draw two cards, lose 2 life, then mill two cards. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "99f1abe1-ce4f-5ff0-90f8-b221f93d62f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcba8d3-725b-49f9-8281-eafac15208c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcba8d3-725b-49f9-8281-eafac15208c5.jpg?1",
             "name": "Ghoulcaller Gisa",
             "text": "{B}, {T}, Sacrifice another creature: Create X 2/2 black Zombie creature tokens, where X is the sacrificed creature's power.",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "ca52b885-c462-5ab4-8500-b6136b0b9c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b62aaf-cc36-4235-b802-828b2c4d6341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b62aaf-cc36-4235-b802-828b2c4d6341.jpg?1",
             "name": "Ghoulcaller's Accomplice",
             "text": "{3}{B}, Exile Ghoulcaller's Accomplice from your graveyard: Create a 2/2 black Zombie creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "c8ea4da3-fb96-54f0-b86b-165a024cec96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850ccdcb-2cd7-4f27-aa9b-917a62a5e94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850ccdcb-2cd7-4f27-aa9b-917a62a5e94d.jpg?1",
             "name": "Ghoulraiser",
             "text": "When Ghoulraiser enters the battlefield, return a Zombie card at random from your graveyard to your hand.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "0b955ae7-2979-5b7f-9c96-1bb45a7d35f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644d4d1-8499-40a8-a01f-68172c82bf58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8644d4d1-8499-40a8-a01f-68172c82bf58.jpg?1",
             "name": "Gifted Aetherborn",
             "text": "Deathtouch, lifelink",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "d99be31c-b176-530a-bb17-88056d2e06b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb69961-0053-476f-b58e-20b6df0e2649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb69961-0053-476f-b58e-20b6df0e2649.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -8249,7 +8249,7 @@
         },
         {
             "id": "d77d7b84-30e6-560c-a2d6-33bf7833881b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c5eb7a-abb2-46bd-8fbd-19af63e70c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c5eb7a-abb2-46bd-8fbd-19af63e70c9c.jpg?1",
             "name": "Gravewaker",
             "text": "Flying\n{5}{B}{B}: Return target creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "28f84ef1-a6e9-514b-96b5-249ff409ac5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d6e32e-6479-48b3-93ae-da5378c09bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d6e32e-6479-48b3-93ae-da5378c09bb1.jpg?1",
             "name": "Gristle Grinner",
             "text": "Whenever a creature dies, Gristle Grinner gets +2/+2 until end of turn.",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "5cbad187-bf77-51f4-a81c-8e45f1081cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ebc0b-b748-4a21-b939-a48811451bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870ebc0b-b748-4a21-b939-a48811451bba.jpg?1",
             "name": "Harvester of Souls",
             "text": "Deathtouch\nWhenever another nontoken creature dies, you may draw a card.",
             "colours": [
@@ -8349,7 +8349,7 @@
         },
         {
             "id": "830d71c5-dfe4-5f17-9d1a-52c84c98d810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29184c64-03f3-4a50-ac18-e34b6c89635e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29184c64-03f3-4a50-ac18-e34b6c89635e.jpg?1",
             "name": "Innocent Blood",
             "text": "Each player sacrifices a creature.",
             "colours": [
@@ -8380,7 +8380,7 @@
         },
         {
             "id": "2e52b35b-76ef-5d7c-924f-911eb81182c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527faa-9d06-4f46-b2f7-c78aedacc3a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98527faa-9d06-4f46-b2f7-c78aedacc3a4.jpg?1",
             "name": "Kalastria Nightwatch",
             "text": "Whenever you gain life, Kalastria Nightwatch gains flying until end of turn.",
             "colours": [
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "4aca0ce6-b840-5fce-97c9-e44090e4cdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53ce1b-9353-42ad-89a0-36e907ba576a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b53ce1b-9353-42ad-89a0-36e907ba576a.jpg?1",
             "name": "Languish",
             "text": "All creatures get -4/-4 until end of turn.",
             "colours": [
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "42bf1b73-fa25-5864-83f5-791a0b7fad9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d3b392-cbd0-437a-a21f-a36d5093a719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d3b392-cbd0-437a-a21f-a36d5093a719.jpg?1",
             "name": "Last Gasp",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -8477,7 +8477,7 @@
         },
         {
             "id": "7b303957-cf7e-58eb-a8f3-ebfe16d68366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49b95d9-2b64-4f33-97b1-db350026aa95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49b95d9-2b64-4f33-97b1-db350026aa95.jpg?1",
             "name": "Launch Party",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature. Its controller loses 2 life.",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "a4384e1f-a116-57a4-9a34-3ffbd2cec9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381b4e3b-85d7-4f61-b395-f278f212bda7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381b4e3b-85d7-4f61-b395-f278f212bda7.jpg?1",
             "name": "Lawless Broker",
             "text": "When Lawless Broker dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8542,7 +8542,7 @@
         },
         {
             "id": "039cc762-9b5f-5478-950e-c28d8e92e0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd4dbd9-982c-43cf-b14c-c3179427d5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd4dbd9-982c-43cf-b14c-c3179427d5a1.jpg?1",
             "name": "Liliana's Elite",
             "text": "Liliana's Elite gets +1/+1 for each creature card in your graveyard.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "75c9432e-282c-5008-8689-898c0e34ca41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9396f3-a93c-47ee-91da-78af864c86c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9396f3-a93c-47ee-91da-78af864c86c3.jpg?1",
             "name": "Liliana's Reaver",
             "text": "Deathtouch\nWhenever Liliana's Reaver deals combat damage to a player, that player discards a card and you create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -8608,7 +8608,7 @@
         },
         {
             "id": "69874c03-2da0-5077-83c1-1ccd603620c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5776bc9-7295-4143-a453-64e3c681f8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5776bc9-7295-4143-a453-64e3c681f8e7.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -8639,7 +8639,7 @@
         },
         {
             "id": "85010d5f-824f-5a80-9053-4cdddfcb6888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fe5c92-7da2-47b5-ad13-f95590e93ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fe5c92-7da2-47b5-ad13-f95590e93ac2.jpg?1",
             "name": "Malakir Familiar",
             "text": "Flying, deathtouch\nWhenever you gain life, Malakir Familiar gets +1/+1 until end of turn.",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "9c947bfb-391d-538b-a6a6-cc4178081d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908bf00-86ba-4911-b15b-1af2a79dff85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d908bf00-86ba-4911-b15b-1af2a79dff85.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
             "colours": [
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "fde8bcd2-a0a2-5867-a4f7-22f7d20a94ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b6e993-1988-4b6d-970e-be71d95cf21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b6e993-1988-4b6d-970e-be71d95cf21a.jpg?1",
             "name": "Mausoleum Turnkey",
             "text": "When Mausoleum Turnkey enters the battlefield, return target creature card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "657acdcf-e116-51be-9c80-8c8428b7ddef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405c096c-a94b-4817-8c7f-f0551f6513e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405c096c-a94b-4817-8c7f-f0551f6513e3.jpg?1",
             "name": "Miasmic Mummy",
             "text": "When Miasmic Mummy enters the battlefield, each player discards a card.",
             "colours": [
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "259f6c3c-0e90-5793-85f4-8e96533d34ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9dc87b3-60b2-4cf8-b620-334700db1aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9dc87b3-60b2-4cf8-b620-334700db1aa9.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -8807,7 +8807,7 @@
         },
         {
             "id": "0dc56561-5480-5cbb-922a-17d38fd72b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c894372f-7d28-4035-b45a-384c5bf8fd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c894372f-7d28-4035-b45a-384c5bf8fd1f.jpg?1",
             "name": "Nightshade Stinger",
             "text": "Flying\nNightshade Stinger can't block.",
             "colours": [
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "bec37ce6-0bc3-5419-8d36-f5875276e86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9843f26-83ed-4517-8ad6-0e288833d140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9843f26-83ed-4517-8ad6-0e288833d140.jpg?1",
             "name": "Nyxathid",
             "text": "As Nyxathid enters the battlefield, choose an opponent.\nNyxathid gets -1/-1 for each card in the chosen player's hand.",
             "colours": [
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "0ccac2f3-a3ad-5850-a7b6-b21b06d8a505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342052f-6b6b-40b9-bbc9-7ba3e8365fe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342052f-6b6b-40b9-bbc9-7ba3e8365fe1.jpg?1",
             "name": "Ogre Slumlord",
             "text": "Whenever another nontoken creature dies, you may create a 1/1 black Rat creature token.\nRats you control have deathtouch.",
             "colours": [
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "e10ca2f9-f2da-58ad-9bac-cb5d1abfe524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b4b7f9-dfc6-4995-bd41-ff04c98d4c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b4b7f9-dfc6-4995-bd41-ff04c98d4c37.jpg?1",
             "name": "Oona's Blackguard",
             "text": "Flying\nEach other Rogue creature you control enters the battlefield with an additional +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it deals combat damage to a player, that player discards a card.",
             "colours": [
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "6b0b81d4-489e-5c21-afff-a652731777e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43296ce8-f055-4778-a187-363a642001e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43296ce8-f055-4778-a187-363a642001e4.jpg?1",
             "name": "Parasitic Implant",
             "text": "Enchant creature\nAt the beginning of your upkeep, enchanted creature's controller sacrifices it and you create a 1/1 colorless Myr artifact creature token.",
             "colours": [
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "24d93c0d-3afb-5419-aa1a-917ffef0a10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf4c9e1-eff6-4abc-ad4e-ffd7f1895d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf4c9e1-eff6-4abc-ad4e-ffd7f1895d8d.jpg?1",
             "name": "Phyrexian Broodlings",
             "text": "{1}, Sacrifice a creature: Put a +1/+1 counter on Phyrexian Broodlings.",
             "colours": [
@@ -9009,7 +9009,7 @@
         },
         {
             "id": "e90fe02c-5202-516b-aa2c-e72c64da3b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e19435-59e5-44d4-b26f-f140f8bcaeb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e19435-59e5-44d4-b26f-f140f8bcaeb0.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\n{T}, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "d6c721ae-03aa-5625-bc21-8acdaa84c013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4497c0-6e0a-4645-b04e-454d8fe97f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4497c0-6e0a-4645-b04e-454d8fe97f05.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -9077,7 +9077,7 @@
         },
         {
             "id": "2879f6de-5c53-50df-80a5-e688222d52c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb76e0-11ed-4f89-a2f4-04bc67f3c94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb76e0-11ed-4f89-a2f4-04bc67f3c94d.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -9111,7 +9111,7 @@
         },
         {
             "id": "668ff59a-ab30-56b7-badf-b68c1c803b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0271e4-8ad1-4ad9-9b3e-7abf911f3059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0271e4-8ad1-4ad9-9b3e-7abf911f3059.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "{1}{B}, Pay 2 life: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "f6ec0e94-4a60-53aa-bb50-33de1062da9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bcfb24-1649-4c8f-ba76-346914d11572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bcfb24-1649-4c8f-ba76-346914d11572.jpg?1",
             "name": "Plagued Rusalka",
             "text": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "d0c8027a-46bf-5d58-96bc-97602a2b79bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d3e58e-f989-4169-9e2c-a66a23170dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d3e58e-f989-4169-9e2c-a66a23170dcf.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -9209,7 +9209,7 @@
         },
         {
             "id": "b4dff1a5-0f59-5173-b6e8-57539a4f6e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652271a0-80e8-4b9b-8823-26c1528378fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652271a0-80e8-4b9b-8823-26c1528378fc.jpg?1",
             "name": "Reanimate",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
             "colours": [
@@ -9240,7 +9240,7 @@
         },
         {
             "id": "d1723bd4-1c48-5aca-9ef6-7e023564ddae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0e1064-47c3-4f03-a1f2-3bcb356db82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0e1064-47c3-4f03-a1f2-3bcb356db82b.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -9271,7 +9271,7 @@
         },
         {
             "id": "03750fe9-206c-54eb-9ede-dfffd3675dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdebdfd-a29b-4482-ab83-012d5faba2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdebdfd-a29b-4482-ab83-012d5faba2e4.jpg?1",
             "name": "Sangromancer",
             "text": "Flying\nWhenever a creature an opponent controls dies, you may gain 3 life.\nWhenever an opponent discards a card, you may gain 3 life.",
             "colours": [
@@ -9305,7 +9305,7 @@
         },
         {
             "id": "088a4082-784e-5507-90df-5db92f574ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e78a44-fff3-4cbf-929b-8dfed4e45d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e78a44-fff3-4cbf-929b-8dfed4e45d62.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -9338,7 +9338,7 @@
         },
         {
             "id": "e431615a-bf25-5ced-98b7-5f5106764ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39ee60-c467-4145-8ca7-123eef01791e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39ee60-c467-4145-8ca7-123eef01791e.jpg?1",
             "name": "Scourge of Nel Toth",
             "text": "Flying\nYou may cast Scourge of Nel Toth from your graveyard by paying {B}{B} and sacrificing two creatures rather than paying its mana cost.",
             "colours": [
@@ -9372,7 +9372,7 @@
         },
         {
             "id": "64df5f27-df16-5a4f-bafb-be729c7404a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de652420-eacf-4f9d-9f13-c6bc02b0fa72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de652420-eacf-4f9d-9f13-c6bc02b0fa72.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "09428411-3a3f-56f1-af8e-470e725490d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee181d58-fed1-4f6d-96a3-4bf057ddd36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee181d58-fed1-4f6d-96a3-4bf057ddd36e.jpg?1",
             "name": "Settle the Score",
             "text": "Exile target creature. Put two loyalty counters on a planeswalker you control.",
             "colours": [
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "c250b590-84e0-5a20-a3ae-f4f1288cfb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab1d6c-09a6-4f6a-9549-94b439a46680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab1d6c-09a6-4f6a-9549-94b439a46680.jpg?1",
             "name": "Shambling Goblin",
             "text": "When Shambling Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -9470,7 +9470,7 @@
         },
         {
             "id": "7103821b-b53f-5e49-8608-5c89c1bd2d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b207a4a-47d1-4905-81d3-455c59bfd7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b207a4a-47d1-4905-81d3-455c59bfd7da.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nAt the beginning of your upkeep, return target creature card from your graveyard to the battlefield.\nAt the beginning of each opponent's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "7581a137-edc9-5e23-95c6-3462f0a12258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d683abb8-46b4-424e-8a10-325519477419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d683abb8-46b4-424e-8a10-325519477419.jpg?1",
             "name": "Slate Street Ruffian",
             "text": "Whenever Slate Street Ruffian becomes blocked, defending player discards a card.",
             "colours": [
@@ -9540,7 +9540,7 @@
         },
         {
             "id": "ac51bcbd-ede0-5cc5-8e42-0f07ec1d381d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db574719-746a-433e-a5be-06d232a01021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db574719-746a-433e-a5be-06d232a01021.jpg?1",
             "name": "Soul Salvage",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -9571,7 +9571,7 @@
         },
         {
             "id": "4af76f37-49b3-5a2d-8923-098a95f6f3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8dd5c5-823a-47f2-8b12-8005d89fe948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8dd5c5-823a-47f2-8b12-8005d89fe948.jpg?1",
             "name": "Stab Wound",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 2 life.",
             "colours": [
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "526939fa-9bfa-53d2-89d9-356c6865c5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fb56fc-47a4-44ba-8b55-4d0ceb8ce62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fb56fc-47a4-44ba-8b55-4d0ceb8ce62f.jpg?1",
             "name": "Swarm of Bloodflies",
             "text": "Flying\nSwarm of Bloodflies enters the battlefield with two +1/+1 counters on it.\nWhenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies.",
             "colours": [
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "923b34d2-a6cc-513e-af57-23f6e2bfe578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adbd4a5-3171-495a-a540-0ecf280b77fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adbd4a5-3171-495a-a540-0ecf280b77fc.jpg?1",
             "name": "Tempting Witch",
             "text": "When Tempting Witch enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}, {T}, Sacrifice a Food: Target player loses 3 life.",
             "colours": [
@@ -9671,7 +9671,7 @@
         },
         {
             "id": "59cab43a-edaf-5939-96c5-6bff0d034ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bddc9-0b0b-4d6d-a708-019356f9649e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49bddc9-0b0b-4d6d-a708-019356f9649e.jpg?1",
             "name": "Tithebearer Giant",
             "text": "When Tithebearer Giant enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -9705,7 +9705,7 @@
         },
         {
             "id": "4c3e85e8-0fd9-5d90-a428-2d25f408024f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7649d57-3537-45a2-b57e-98e7d32025c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7649d57-3537-45a2-b57e-98e7d32025c9.jpg?1",
             "name": "Vampire Neonate",
             "text": "{2}, {T}: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "759dd82a-b7a5-5543-92cf-2f9c2653ce52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e35a461-9a8e-4d08-b963-14c8b5237eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e35a461-9a8e-4d08-b963-14c8b5237eec.jpg?1",
             "name": "Wailing Ghoul",
             "text": "When Wailing Ghoul enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -9771,7 +9771,7 @@
         },
         {
             "id": "92553688-b71b-5eb0-a933-019fc2d5a10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aec0ec-0feb-4276-ab9c-5bb18b5005a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aec0ec-0feb-4276-ab9c-5bb18b5005a0.jpg?1",
             "name": "Wight of Precinct Six",
             "text": "Wight of Precinct Six gets +1/+1 for each creature card in your opponents' graveyards.",
             "colours": [
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "d6a7a111-fc80-54fe-bc88-e559066f6420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce5007-56ab-4361-8130-df48add1492b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce5007-56ab-4361-8130-df48add1492b.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards: Create a 2/2 black Zombie creature token.",
             "colours": [
@@ -9835,7 +9835,7 @@
         },
         {
             "id": "a81a38f6-3d14-583d-9eb0-13d0a31ca304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fec7e6-5ed9-46dc-93b4-7a054d763403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fec7e6-5ed9-46dc-93b4-7a054d763403.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -9866,7 +9866,7 @@
         },
         {
             "id": "8abca07f-f1a0-5828-8801-991eb81c92d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b4cbb7-c9ad-4320-9322-a6a3afbc4a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b4cbb7-c9ad-4320-9322-a6a3afbc4a50.jpg?1",
             "name": "Ashmouth Hound",
             "text": "Whenever Ashmouth Hound blocks or becomes blocked by a creature, Ashmouth Hound deals 1 damage to that creature.",
             "colours": [
@@ -9900,7 +9900,7 @@
         },
         {
             "id": "37d618df-0012-55a1-b8c5-90d0619b2ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b53218-804b-4992-9c93-a797dd6b2a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b53218-804b-4992-9c93-a797dd6b2a04.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample, haste\nAt the beginning of the end step, sacrifice Ball Lightning.",
             "colours": [
@@ -9933,7 +9933,7 @@
         },
         {
             "id": "77676bda-1341-5418-87b0-09a292f2db38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94ff00-0821-4743-b693-2ba310466306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94ff00-0821-4743-b693-2ba310466306.jpg?1",
             "name": "Barrage of Expendables",
             "text": "{R}, Sacrifice a creature: Barrage of Expendables deals 1 damage to any target.",
             "colours": [
@@ -9964,7 +9964,7 @@
         },
         {
             "id": "65fe1242-e26f-557d-b997-30208a7eec92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102740d0-ca74-460d-af30-c71bddad87c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102740d0-ca74-460d-af30-c71bddad87c4.jpg?1",
             "name": "Bathe in Dragonfire",
             "text": "Bathe in Dragonfire deals 4 damage to target creature.",
             "colours": [
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "14c409aa-a9b5-5484-b54b-687e90702196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a514b9-8a67-47aa-8218-8d6fe8040128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a514b9-8a67-47aa-8218-8d6fe8040128.jpg?1",
             "name": "Beetleback Chief",
             "text": "When Beetleback Chief enters the battlefield, create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -10029,7 +10029,7 @@
         },
         {
             "id": "3405c527-5627-55e9-b76c-4069f01ddb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9feaa623-3422-4997-af7b-f75074af5fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9feaa623-3422-4997-af7b-f75074af5fa1.jpg?1",
             "name": "Blindblast",
             "text": "Blindblast deals 1 damage to target creature. That creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -10060,7 +10060,7 @@
         },
         {
             "id": "3567c50e-129d-549b-bf3b-8d65f044a16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b633bf-a77e-4b78-b729-a83896abf17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b633bf-a77e-4b78-b729-a83896abf17c.jpg?1",
             "name": "Bloodrage Brawler",
             "text": "When Bloodrage Brawler enters the battlefield, discard a card.",
             "colours": [
@@ -10094,7 +10094,7 @@
         },
         {
             "id": "43dfdc39-ab26-503c-9e43-0e251df1a0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128f37ff-eb63-4417-87c2-96a3a026fcf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128f37ff-eb63-4417-87c2-96a3a026fcf4.jpg?1",
             "name": "Bloodrock Cyclops",
             "text": "Bloodrock Cyclops attacks each combat if able.",
             "colours": [
@@ -10127,7 +10127,7 @@
         },
         {
             "id": "9cbd8fd0-9684-5cf8-882f-73aa95f191e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1a398b-4551-4522-a90a-620c90bd92c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1a398b-4551-4522-a90a-620c90bd92c7.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -10161,7 +10161,7 @@
         },
         {
             "id": "e4ababf7-5d6c-58f7-a89f-f0240f7d6880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6de3a7-30a7-49d7-8e39-494355c6edae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6de3a7-30a7-49d7-8e39-494355c6edae.jpg?1",
             "name": "Boggart Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -10195,7 +10195,7 @@
         },
         {
             "id": "b1aa5f51-1544-5bae-87bc-991e0fb5628b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3132919-58a7-429f-8a0f-9210d3c2c734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3132919-58a7-429f-8a0f-9210d3c2c734.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -10229,7 +10229,7 @@
         },
         {
             "id": "f06e1f63-dac1-5018-a784-1610122f9b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c80ea-7b29-4335-ba7b-3e51a5a104a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c80ea-7b29-4335-ba7b-3e51a5a104a9.jpg?1",
             "name": "Borderland Minotaur",
             "text": "",
             "colours": [
@@ -10263,7 +10263,7 @@
         },
         {
             "id": "5c519912-8ee5-5a08-a6ce-d7e88e5ca6c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cef88c-0ad6-47c4-b6c8-f989586aa635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cef88c-0ad6-47c4-b6c8-f989586aa635.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "1e78f5e3-dcf4-5333-af38-dac3e328ce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47361f61-b717-4468-8050-5f28a8fe6754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47361f61-b717-4468-8050-5f28a8fe6754.jpg?1",
             "name": "Charmbreaker Devils",
             "text": "At the beginning of your upkeep, return an instant or sorcery card at random from your graveyard to your hand.\nWhenever you cast an instant or sorcery spell, Charmbreaker Devils gets +4/+0 until end of turn.",
             "colours": [
@@ -10327,7 +10327,7 @@
         },
         {
             "id": "31059d36-aab4-5ebd-9e33-0d127c238c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c3c616-1f95-41b1-a624-79d6362d4f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c3c616-1f95-41b1-a624-79d6362d4f16.jpg?1",
             "name": "Cinder Elemental",
             "text": "{X}{R}, {T}, Sacrifice Cinder Elemental: It deals X damage to any target.",
             "colours": [
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "d98e7d6e-ba62-5bb8-8cda-58b222e0f386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81232b04-a4a0-48d8-b8af-a6e3d50173e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81232b04-a4a0-48d8-b8af-a6e3d50173e5.jpg?1",
             "name": "Collateral Damage",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nCollateral Damage deals 3 damage to any target.",
             "colours": [
@@ -10391,7 +10391,7 @@
         },
         {
             "id": "69044e15-b193-5de9-a563-20202750dda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9189fafa-f30f-49a1-b07d-e432640d2bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9189fafa-f30f-49a1-b07d-e432640d2bc5.jpg?1",
             "name": "Dance with Devils",
             "text": "Create two 1/1 red Devil creature tokens. They have \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -10422,7 +10422,7 @@
         },
         {
             "id": "a136fb3e-ec7d-5835-951b-fd858f90a1cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a3153e-4259-4e03-bf79-8979d3c0db36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a3153e-4259-4e03-bf79-8979d3c0db36.jpg?1",
             "name": "Doublecast",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -10453,7 +10453,7 @@
         },
         {
             "id": "e9ced5a5-5b81-5258-b386-0dcb5c11eddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a0ec06-7c48-4334-ac50-c249e7e91dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a0ec06-7c48-4334-ac50-c249e7e91dbe.jpg?1",
             "name": "Draconic Roar",
             "text": "As an additional cost to cast this spell, you may reveal a Dragon card from your hand.\nDraconic Roar deals 3 damage to target creature. If you revealed a Dragon card or controlled a Dragon as you cast this spell, Draconic Roar deals 3 damage to that creature's controller.",
             "colours": [
@@ -10484,7 +10484,7 @@
         },
         {
             "id": "572e343e-cc53-593c-86b5-6271506fb6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb5eab0-5397-4c00-8cef-7d3baf38a171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb5eab0-5397-4c00-8cef-7d3baf38a171.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "e3aa537b-f9f0-5923-8eec-acc348ad5ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d3a18c-d030-494d-b7b1-4d1d1e27fbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d3a18c-d030-494d-b7b1-4d1d1e27fbbf.jpg?1",
             "name": "Dragon Hatchling",
             "text": "Flying\n{R}: Dragon Hatchling gets +1/+0 until end of turn.",
             "colours": [
@@ -10548,7 +10548,7 @@
         },
         {
             "id": "610626f7-a9f4-5434-8e36-fead585c33a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e5f3d8-c468-412c-a32b-92c5d8fc1e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e5f3d8-c468-412c-a32b-92c5d8fc1e14.jpg?1",
             "name": "Dragonlord's Servant",
             "text": "Dragon spells you cast cost {1} less to cast.",
             "colours": [
@@ -10582,7 +10582,7 @@
         },
         {
             "id": "cc0ae380-99cc-5644-82df-2bbf81b5de15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca8335b-21b1-40bc-970a-480e74874d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca8335b-21b1-40bc-970a-480e74874d03.jpg?1",
             "name": "Dragonspeaker Shaman",
             "text": "Dragon spells you cast cost {2} less to cast.",
             "colours": [
@@ -10617,7 +10617,7 @@
         },
         {
             "id": "03e3a827-5867-5214-abe5-b63eed54d511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d294e8-ed96-4584-b4f2-1b03ae6d1314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d294e8-ed96-4584-b4f2-1b03ae6d1314.jpg?1",
             "name": "Dualcaster Mage",
             "text": "Flash\nWhen Dualcaster Mage enters the battlefield, copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "ce0787cb-e94f-5821-b681-f2cf34343b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c40669-87fa-4b1e-885f-2d0a626c3a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c40669-87fa-4b1e-885f-2d0a626c3a25.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "f5ace32a-b38e-511f-813a-5e8c49641a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05469d01-0d2b-47b9-8a69-16cf0c3d43f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05469d01-0d2b-47b9-8a69-16cf0c3d43f8.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to any target.",
             "colours": [
@@ -10721,7 +10721,7 @@
         },
         {
             "id": "6532ea14-2353-59e9-9ea4-344a036d5369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8383e698-0dd7-4f35-aecb-53f0ee746999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8383e698-0dd7-4f35-aecb-53f0ee746999.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to any target.",
             "colours": [
@@ -10752,7 +10752,7 @@
         },
         {
             "id": "b772ef86-a55e-5f9a-9ab1-6f089fbad1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584cdb52-08f8-425b-8407-8192b1dc6843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584cdb52-08f8-425b-8407-8192b1dc6843.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "85e4bcfb-d6b7-5ed1-b9be-4ade336f62da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b32bb8a-ff23-436d-8e63-bbaf05e830ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b32bb8a-ff23-436d-8e63-bbaf05e830ca.jpg?1",
             "name": "Flames of the Raze-Boar",
             "text": "Flames of the Raze-Boar deals 4 damage to target creature an opponent controls. Then Flames of the Raze-Boar deals 2 damage to each other creature that player controls if you control a creature with power 4 or greater.",
             "colours": [
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "55dd4324-5f50-5774-8962-1e104e34cc38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3f8d6-80ff-4292-871e-e19907841448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a3f8d6-80ff-4292-871e-e19907841448.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu enters the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -10847,7 +10847,7 @@
         },
         {
             "id": "e115dca8-8480-5a88-b474-310c1dd48782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42d773-c742-4465-b6d5-31feaba49146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42d773-c742-4465-b6d5-31feaba49146.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to any target.",
             "colours": [
@@ -10878,7 +10878,7 @@
         },
         {
             "id": "6674a4a5-cc16-52aa-a35e-52d4f1070339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be522ae8-9cf4-4c63-9a1c-0010d482c00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be522ae8-9cf4-4c63-9a1c-0010d482c00a.jpg?1",
             "name": "Flurry of Horns",
             "text": "Create two 2/3 red Minotaur creature tokens with haste.",
             "colours": [
@@ -10909,7 +10909,7 @@
         },
         {
             "id": "4b938616-a61d-56a4-b224-c45c9e3e570a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7308e6-4303-4f01-928b-f154b376e1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7308e6-4303-4f01-928b-f154b376e1a5.jpg?1",
             "name": "Forge Devil",
             "text": "When Forge Devil enters the battlefield, it deals 1 damage to target creature and 1 damage to you.",
             "colours": [
@@ -10942,7 +10942,7 @@
         },
         {
             "id": "429a224c-c3c5-5037-97b2-a2350619cd01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce76e86-39f3-4ebf-b550-88ea7f23a91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce76e86-39f3-4ebf-b550-88ea7f23a91f.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -10975,7 +10975,7 @@
         },
         {
             "id": "cc5ceae0-871f-5f89-8dfd-d5b39fd35c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fcc35b-76fa-4408-8620-a1e11b2caf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fcc35b-76fa-4408-8620-a1e11b2caf1f.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -11008,7 +11008,7 @@
         },
         {
             "id": "9a6f0222-3590-5590-929e-ee380a6ba1a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c742d940-1a8d-487a-a787-2ad96a96ef1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c742d940-1a8d-487a-a787-2ad96a96ef1f.jpg?1",
             "name": "Goblin Commando",
             "text": "When Goblin Commando enters the battlefield, it deals 2 damage to target creature.",
             "colours": [
@@ -11041,7 +11041,7 @@
         },
         {
             "id": "01457c99-b554-516b-b188-6ac79bb8260e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7.jpg?1",
             "name": "Goblin Goon",
             "text": "Goblin Goon can't attack unless you control more creatures than defending player.\nGoblin Goon can't block unless you control more creatures than attacking player.",
             "colours": [
@@ -11075,7 +11075,7 @@
         },
         {
             "id": "a7d4f50e-491d-58e1-a39c-fd48ee637c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32d7ce5-078b-40ff-8ecb-34309a0e3719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32d7ce5-078b-40ff-8ecb-34309a0e3719.jpg?1",
             "name": "Goblin Instigator",
             "text": "When Goblin Instigator enters the battlefield, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "6eef3253-0da2-5e26-ad66-2e632581b786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660e7067-9f1d-4e2c-bd12-0ad752a3cec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660e7067-9f1d-4e2c-bd12-0ad752a3cec8.jpg?1",
             "name": "Goblin Lore",
             "text": "Draw four cards, then discard three cards at random.",
             "colours": [
@@ -11140,7 +11140,7 @@
         },
         {
             "id": "eb853940-d92f-5090-b0c9-8291841dd691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6a2d0-d855-4b87-9f4c-58dda0b81c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6a2d0-d855-4b87-9f4c-58dda0b81c82.jpg?1",
             "name": "Goblin Rally",
             "text": "Create four 1/1 red Goblin creature tokens.",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "6097e46e-52ea-55c9-a3c8-bffa2dfeee01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a98be-e7d9-4cb7-a7ed-de2bf593170d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a98be-e7d9-4cb7-a7ed-de2bf593170d.jpg?1",
             "name": "Goblin Shortcutter",
             "text": "When Goblin Shortcutter enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -11205,7 +11205,7 @@
         },
         {
             "id": "72cb65e2-9014-51e8-a4e6-d2d833c4640c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a359f4a8-3c06-441a-81bd-e3773b122e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a359f4a8-3c06-441a-81bd-e3773b122e45.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to any target.",
             "colours": [
@@ -11239,7 +11239,7 @@
         },
         {
             "id": "dfe5fccf-d934-5734-8c20-d389d364d2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee4e3-c9eb-4898-99cd-bbe148936f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee4e3-c9eb-4898-99cd-bbe148936f99.jpg?1",
             "name": "Hamletback Goliath",
             "text": "Whenever another creature enters the battlefield, you may put X +1/+1 counters on Hamletback Goliath, where X is that creature's power.",
             "colours": [
@@ -11273,7 +11273,7 @@
         },
         {
             "id": "714d2ff8-8798-52fa-b06a-49151dc268b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af482a14-a144-4e60-bd04-a548a3c89f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af482a14-a144-4e60-bd04-a548a3c89f5a.jpg?1",
             "name": "Heartfire",
             "text": "As an additional cost to cast this spell, sacrifice a creature or planeswalker.\nHeartfire deals 4 damage to any target.",
             "colours": [
@@ -11304,7 +11304,7 @@
         },
         {
             "id": "70928977-e5d9-5945-b0e6-f7e4081c9dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbfd905-8c71-4389-9174-6e84bcbcf05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbfd905-8c71-4389-9174-6e84bcbcf05c.jpg?1",
             "name": "Hellrider",
             "text": "Haste\nWhenever a creature you control attacks, Hellrider deals 1 damage to the player or planeswalker it's attacking.",
             "colours": [
@@ -11337,7 +11337,7 @@
         },
         {
             "id": "8e77e38a-0e28-56d6-8327-1902df2b0173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212e27a-d2e1-430d-86ff-1f7abaad46d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d212e27a-d2e1-430d-86ff-1f7abaad46d4.jpg?1",
             "name": "Homing Lightning",
             "text": "Homing Lightning deals 4 damage to target creature and each other creature with the same name as that creature.",
             "colours": [
@@ -11368,7 +11368,7 @@
         },
         {
             "id": "0552eb00-02d9-5ecd-b0b3-588154966b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392a36-e63a-4648-b8df-1172403922eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07392a36-e63a-4648-b8df-1172403922eb.jpg?1",
             "name": "Hungry Flames",
             "text": "Hungry Flames deals 3 damage to target creature and 2 damage to target player or planeswalker.",
             "colours": [
@@ -11399,7 +11399,7 @@
         },
         {
             "id": "7199116d-4551-57bd-b8e9-ad58cc5640f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c59a4db-5806-40da-8752-cec05af6bf51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c59a4db-5806-40da-8752-cec05af6bf51.jpg?1",
             "name": "Inferno Hellion",
             "text": "Trample\nAt the beginning of each end step, if Inferno Hellion attacked or blocked this turn, its owner shuffles it into their library.",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "21a9c1b2-6ccb-55df-8097-eeaec624ae1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c957c94-3d2d-4b98-8990-cd8909462081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c957c94-3d2d-4b98-8990-cd8909462081.jpg?1",
             "name": "Kiln Fiend",
             "text": "Whenever you cast an instant or sorcery spell, Kiln Fiend gets +3/+0 until end of turn.",
             "colours": [
@@ -11466,7 +11466,7 @@
         },
         {
             "id": "d63e5f07-a342-5957-851c-2dec9b6bc0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9fec9d-23c8-4d35-97c1-9499527198fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9fec9d-23c8-4d35-97c1-9499527198fb.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "137bcbfd-9dd4-52f4-82ea-f21dc4771dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9460e3c6-e745-41d3-8e17-0b92fb126a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9460e3c6-e745-41d3-8e17-0b92fb126a16.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon enters the battlefield under your control, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -11537,7 +11537,7 @@
         },
         {
             "id": "cb3d28cb-9cbc-5de1-8b25-185dbb899e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65ea432-9ece-40bf-9cdc-95e01a85b78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65ea432-9ece-40bf-9cdc-95e01a85b78f.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -11568,7 +11568,7 @@
         },
         {
             "id": "f5e9103b-8b91-54fc-88bc-57ca415bdb44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce711943-c1a1-43a0-8b89-8d169cfb8e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce711943-c1a1-43a0-8b89-8d169cfb8e06.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to any target.",
             "colours": [
@@ -11599,7 +11599,7 @@
         },
         {
             "id": "3c699c2c-4ba4-5e6d-be85-691d03ce1743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9223ac16-e6fc-4ba6-91d9-7ff27cc17271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9223ac16-e6fc-4ba6-91d9-7ff27cc17271.jpg?1",
             "name": "Lightning Diadem",
             "text": "Enchant creature\nWhen Lightning Diadem enters the battlefield, it deals 2 damage to any target.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -11632,7 +11632,7 @@
         },
         {
             "id": "5927428d-9c25-5d68-9748-541678867207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a959e-7c17-4226-afcb-bc0bb5a4492b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a959e-7c17-4226-afcb-bc0bb5a4492b.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste",
             "colours": [
@@ -11665,7 +11665,7 @@
         },
         {
             "id": "83b3cd54-8152-5bdd-9336-76f5e518227a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017f94bc-f7f0-4eed-9ca0-392872405f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017f94bc-f7f0-4eed-9ca0-392872405f32.jpg?1",
             "name": "Lightning Shrieker",
             "text": "Flying, trample, haste\nAt the beginning of the end step, Lightning Shrieker's owner shuffles it into their library.",
             "colours": [
@@ -11698,7 +11698,7 @@
         },
         {
             "id": "0b1a422b-b757-5a4e-ad97-23e40acc3dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975ce11-589a-4da8-a016-854bbaeb869c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975ce11-589a-4da8-a016-854bbaeb869c.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to any target. Scry 2.",
             "colours": [
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "71c0d11d-9b14-5f90-b032-be9739542675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feebd1ba-758f-4029-9f5c-19b07146b80d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feebd1ba-758f-4029-9f5c-19b07146b80d.jpg?1",
             "name": "Magmaquake",
             "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
             "colours": [
@@ -11760,7 +11760,7 @@
         },
         {
             "id": "5053af10-bad4-50bc-927e-008db77c3277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8669513f-4fc2-47ee-a919-f4b538be2385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8669513f-4fc2-47ee-a919-f4b538be2385.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "0d6d100f-67b9-548b-81f4-99ede2f74521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fef9f8-ff3e-4a3f-a3ff-4534ff0c3946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fef9f8-ff3e-4a3f-a3ff-4534ff0c3946.jpg?1",
             "name": "Minotaur Skullcleaver",
             "text": "Haste\nWhen Minotaur Skullcleaver enters the battlefield, it gets +2/+0 until end of turn.",
             "colours": [
@@ -11825,7 +11825,7 @@
         },
         {
             "id": "e7365281-c30f-5c12-908f-866349a71ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd65150-a698-4f23-836c-5cd0fb153eb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd65150-a698-4f23-836c-5cd0fb153eb3.jpg?1",
             "name": "Minotaur Sureshot",
             "text": "Reach\n{1}{R}: Minotaur Sureshot gets +1/+0 until end of turn.",
             "colours": [
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "8ea83f8b-ca1a-5846-bb39-09b169b7e6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5664b7d-b553-4e0a-93ec-3d70e8e4f63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5664b7d-b553-4e0a-93ec-3d70e8e4f63b.jpg?1",
             "name": "Molten Ravager",
             "text": "{R}: Molten Ravager gets +1/+0 until end of turn.",
             "colours": [
@@ -11892,7 +11892,7 @@
         },
         {
             "id": "fff24045-ad81-5683-bf9d-871a85c3bbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d36724e-0669-43f9-9d10-f67562b8c6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d36724e-0669-43f9-9d10-f67562b8c6bc.jpg?1",
             "name": "Mugging",
             "text": "Mugging deals 2 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "1df212c5-830b-52f5-b2f6-10a14e1cc5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164e358-cbb4-4c3a-aea2-48f1891757df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2164e358-cbb4-4c3a-aea2-48f1891757df.jpg?1",
             "name": "Ornery Goblin",
             "text": "Whenever Ornery Goblin blocks or becomes blocked by a creature, Ornery Goblin deals 1 damage to that creature.",
             "colours": [
@@ -11957,7 +11957,7 @@
         },
         {
             "id": "8bf734d1-d968-5299-8b76-1b1499270ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1214fc4-26ac-4a57-b894-6fd634d4d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1214fc4-26ac-4a57-b894-6fd634d4d4fd.jpg?1",
             "name": "Outnumber",
             "text": "Outnumber deals damage to target creature equal to the number of creatures you control.",
             "colours": [
@@ -11988,7 +11988,7 @@
         },
         {
             "id": "9b8f0a3f-adcd-5c01-bdad-73302ac3b307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdb47a8-130b-4ca9-ad29-9484b5c0c582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdb47a8-130b-4ca9-ad29-9484b5c0c582.jpg?1",
             "name": "Pillar of Flame",
             "text": "Pillar of Flame deals 2 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -12019,7 +12019,7 @@
         },
         {
             "id": "a2c506a6-ca96-5e3e-860d-529d83d798e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15148b4e-19e2-4e39-8e6f-1dc94ea03463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15148b4e-19e2-4e39-8e6f-1dc94ea03463.jpg?1",
             "name": "Pyroclastic Elemental",
             "text": "{1}{R}{R}: Pyroclastic Elemental deals 1 damage to target player.",
             "colours": [
@@ -12052,7 +12052,7 @@
         },
         {
             "id": "fabc3c66-884d-53be-9e30-87be142c91e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568a31c0-799b-48b6-a91c-95d176b22670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568a31c0-799b-48b6-a91c-95d176b22670.jpg?1",
             "name": "Rageblood Shaman",
             "text": "Trample\nOther Minotaur creatures you control get +1/+1 and have trample.",
             "colours": [
@@ -12086,7 +12086,7 @@
         },
         {
             "id": "f8a973cc-cbb3-5d88-8249-eae31fbb5d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495c0dbf-1671-40f9-809c-98ef6d588512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495c0dbf-1671-40f9-809c-98ef6d588512.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -12119,7 +12119,7 @@
         },
         {
             "id": "77f6f67b-4216-506c-bbbf-3f61974929bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14f36e-54b8-4019-bc85-0d9218c52ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14f36e-54b8-4019-bc85-0d9218c52ad2.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose any target. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that permanent or player. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -12150,7 +12150,7 @@
         },
         {
             "id": "a1eefe68-fd12-5c1f-a74d-ab3bfde9eb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47daba07-1f1e-48e1-a500-ef94d0a3b327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47daba07-1f1e-48e1-a500-ef94d0a3b327.jpg?1",
             "name": "Sarkhan's Rage",
             "text": "Sarkhan's Rage deals 5 damage to any target. If you control no Dragons, Sarkhan's Rage deals 2 damage to you.",
             "colours": [
@@ -12181,7 +12181,7 @@
         },
         {
             "id": "dbbc2146-8a91-5d64-b4cb-b06be26ed6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9c6068-cfd8-4371-b549-e474d573e52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9c6068-cfd8-4371-b549-e474d573e52e.jpg?1",
             "name": "Sarkhan's Unsealing",
             "text": "Whenever you cast a creature spell with power 4, 5, or 6, Sarkhan's Unsealing deals 4 damage to any target.\nWhenever you cast a creature spell with power 7 or greater, Sarkhan's Unsealing deals 4 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -12212,7 +12212,7 @@
         },
         {
             "id": "b8b46109-8d29-5a54-9abc-10c39d767aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dcec0d7-897e-4593-bd09-460207e28c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dcec0d7-897e-4593-bd09-460207e28c90.jpg?1",
             "name": "Seismic Elemental",
             "text": "When Seismic Elemental enters the battlefield, creatures without flying can't block this turn.",
             "colours": [
@@ -12245,7 +12245,7 @@
         },
         {
             "id": "3d9ab48d-a868-5b88-80c6-1d37a211be88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89172e-0542-4858-9e65-38b1bac8cdeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89172e-0542-4858-9e65-38b1bac8cdeb.jpg?1",
             "name": "Sin Prodder",
             "text": "Menace\nAt the beginning of your upkeep, reveal the top card of your library. Any opponent may have you put that card into your graveyard. If a player does, Sin Prodder deals damage to that player equal to that card's converted mana cost. Otherwise, put that card into your hand.",
             "colours": [
@@ -12278,7 +12278,7 @@
         },
         {
             "id": "912b6a5a-8ff3-5335-9ed7-1f48e4acf599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1aa8f9-8200-4ddd-9ab5-1a8181cc1792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1aa8f9-8200-4ddd-9ab5-1a8181cc1792.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals damage to target creature equal to the number of Mountains you control.",
             "colours": [
@@ -12309,7 +12309,7 @@
         },
         {
             "id": "e54bda3a-a33a-5895-8e33-0646f017178f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c1b56-621a-4908-89b2-21622d195223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37c1b56-621a-4908-89b2-21622d195223.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -12343,7 +12343,7 @@
         },
         {
             "id": "cf592ada-e494-5531-a0a8-3cbfba7aa2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2947ad7e-d365-45ff-b107-35819b308f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2947ad7e-d365-45ff-b107-35819b308f8c.jpg?1",
             "name": "Tibalt's Rager",
             "text": "When Tibalt's Rager dies, it deals 1 damage to any target.\n{1}{R}: Tibalt's Rager gets +2/+0 until end of turn.",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "a545392b-84e3-5074-856a-58de0a30a927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c3aa66-2436-40a3-a541-185f457bd55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c3aa66-2436-40a3-a541-185f457bd55a.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -12409,7 +12409,7 @@
         },
         {
             "id": "9291d782-dfb6-5ad7-9c39-3d518d9d4ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba926b-915c-4dd2-84f3-019775e1cc14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba926b-915c-4dd2-84f3-019775e1cc14.jpg?1",
             "name": "Volcanic Fallout",
             "text": "This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
             "colours": [
@@ -12440,7 +12440,7 @@
         },
         {
             "id": "e8d8a466-152c-5131-abf6-a2487f761813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8e3b3-c8bb-415d-a19f-45ec679108ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c8e3b3-c8bb-415d-a19f-45ec679108ee.jpg?1",
             "name": "Volley Veteran",
             "text": "When Volley Veteran enters the battlefield, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -12474,7 +12474,7 @@
         },
         {
             "id": "a15ee6fd-aec0-57c9-b5a0-1423cc2a0a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9ea25-7a5e-4b6d-b071-e929f6b652c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c9ea25-7a5e-4b6d-b071-e929f6b652c4.jpg?1",
             "name": "Warfire Javelineer",
             "text": "When Warfire Javelineer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -12508,7 +12508,7 @@
         },
         {
             "id": "0946fda8-a1c7-59cc-9c67-5712986e0673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ec5d2-ea36-415c-9aa6-808c88a17932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302ec5d2-ea36-415c-9aa6-808c88a17932.jpg?1",
             "name": "Weaver of Lightning",
             "text": "Reach\nWhenever you cast an instant or sorcery spell, Weaver of Lightning deals 1 damage to target creature an opponent controls.",
             "colours": [
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "aa7ffa26-75b6-5918-8c37-5967f7f28dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218af707-cc60-407e-af20-e21879a0e902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/218af707-cc60-407e-af20-e21879a0e902.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -12576,7 +12576,7 @@
         },
         {
             "id": "b72038e6-f8b2-55df-8994-14a31550e8f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f13bda-9157-437d-b58b-20d34d03fc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f13bda-9157-437d-b58b-20d34d03fc49.jpg?1",
             "name": "Affectionate Indrik",
             "text": "When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -12609,7 +12609,7 @@
         },
         {
             "id": "0665d2a7-0643-5678-b31d-16e205ae5b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff69e6a8-f34f-4aea-9a54-c4b64ed3116c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff69e6a8-f34f-4aea-9a54-c4b64ed3116c.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -12640,7 +12640,7 @@
         },
         {
             "id": "6fa14f89-73eb-5e60-bf16-372173d708c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8664d29-dacc-49cb-949f-e00ceeb75ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8664d29-dacc-49cb-949f-e00ceeb75ff6.jpg?1",
             "name": "Ambassador Oak",
             "text": "When Ambassador Oak enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -12674,7 +12674,7 @@
         },
         {
             "id": "4a1fb4cb-c1aa-5e93-bba0-24ff8d74a612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c10923-a5b3-4b50-ae51-59982e05963a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c10923-a5b3-4b50-ae51-59982e05963a.jpg?1",
             "name": "Arbor Armament",
             "text": "Put a +1/+1 counter on target creature. That creature gains reach until end of turn.",
             "colours": [
@@ -12705,7 +12705,7 @@
         },
         {
             "id": "93d597a4-a224-5ebe-bfd9-f4b93dd4eb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bd60d3-d2d3-4b69-bd08-04833ff2394e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bd60d3-d2d3-4b69-bd08-04833ff2394e.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -12739,7 +12739,7 @@
         },
         {
             "id": "5c6c8f4e-46d1-54fc-a21d-9c4434347eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf261c8-98e4-491e-9e51-a9058ff2c03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf261c8-98e4-491e-9e51-a9058ff2c03a.jpg?1",
             "name": "Assault Formation",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n{G}: Target creature with defender can attack this turn as though it didn't have defender.\n{2}{G}: Creatures you control get +0/+1 until end of turn.",
             "colours": [
@@ -12770,7 +12770,7 @@
         },
         {
             "id": "e401d3e3-4a92-5253-9958-82365f0a9a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de98df4-9552-4ba6-a324-1669dc077d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de98df4-9552-4ba6-a324-1669dc077d4c.jpg?1",
             "name": "Awakener Druid",
             "text": "When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature for as long as Awakener Druid remains on the battlefield. It's still a land.",
             "colours": [
@@ -12804,7 +12804,7 @@
         },
         {
             "id": "04ca4a31-cb1c-5fa7-900f-5e12356672d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a41e3-1c5a-467e-9ffb-e6a5f817f8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318a41e3-1c5a-467e-9ffb-e6a5f817f8fe.jpg?1",
             "name": "Brindle Shoat",
             "text": "When Brindle Shoat dies, create a 3/3 green Boar creature token.",
             "colours": [
@@ -12837,7 +12837,7 @@
         },
         {
             "id": "8ec6e5d4-e491-5239-a40c-3577839bfda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6649d5e9-22fb-4134-a4d9-ee05e6668f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6649d5e9-22fb-4134-a4d9-ee05e6668f94.jpg?1",
             "name": "Brushstrider",
             "text": "Vigilance",
             "colours": [
@@ -12870,7 +12870,7 @@
         },
         {
             "id": "edae399a-534f-5a88-8218-29c8d4a98755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53847a21-aded-4aaa-9bf1-8592e67763ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53847a21-aded-4aaa-9bf1-8592e67763ef.jpg?1",
             "name": "Carven Caryatid",
             "text": "Defender\nWhen Carven Caryatid enters the battlefield, draw a card.",
             "colours": [
@@ -12903,7 +12903,7 @@
         },
         {
             "id": "dee52dd6-6cf2-5393-80e0-aa90fc2af2b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d851d8-d7d0-4b8a-b520-f3863b78bc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d851d8-d7d0-4b8a-b520-f3863b78bc66.jpg?1",
             "name": "Champion of Lambholt",
             "text": "Creatures with power less than Champion of Lambholt's power can't block creatures you control.\nWhenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.",
             "colours": [
@@ -12937,7 +12937,7 @@
         },
         {
             "id": "dd7304ff-0283-5f91-9539-c1f15024e4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66d2ddc-b4d4-4387-bde0-16d81ef2b1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66d2ddc-b4d4-4387-bde0-16d81ef2b1a7.jpg?1",
             "name": "Commune with Dinosaurs",
             "text": "Look at the top five cards of your library. You may reveal a Dinosaur or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -12968,7 +12968,7 @@
         },
         {
             "id": "1b7a8f63-73e1-52bb-965d-109747f5e2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44afd414-cc69-4888-ba12-7ea87e60b1f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44afd414-cc69-4888-ba12-7ea87e60b1f7.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "2f96a3a8-d104-543d-a004-6c8381505dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01398f5f-f38e-45a7-b755-e65c8fa779f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01398f5f-f38e-45a7-b755-e65c8fa779f8.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -13032,7 +13032,7 @@
         },
         {
             "id": "2c91be93-dae1-55f9-97ac-4c428b75bad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fab2b-ff28-4e02-9f25-e038c754b2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fab2b-ff28-4e02-9f25-e038c754b2cf.jpg?1",
             "name": "Dawntreader Elk",
             "text": "{G}, Sacrifice Dawntreader Elk: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -13065,7 +13065,7 @@
         },
         {
             "id": "e2bc98cb-a9c0-51f7-a1ec-589d2d0d92c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f1d2e6-ffa4-4c4e-8179-671deb9f5a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f1d2e6-ffa4-4c4e-8179-671deb9f5a7f.jpg?1",
             "name": "Drover of the Mighty",
             "text": "Drover of the Mighty gets +2/+2 as long as you control a Dinosaur.\n{T}: Add one mana of any color.",
             "colours": [
@@ -13099,7 +13099,7 @@
         },
         {
             "id": "ea37311b-1dfb-5f50-828f-83ebcaf025cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95d4f15-613c-42f1-a49b-f4f604e69feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95d4f15-613c-42f1-a49b-f4f604e69feb.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When Dwynen's Elite enters the battlefield, if you control another Elf, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -13133,7 +13133,7 @@
         },
         {
             "id": "ee84ac29-c684-5e50-97b9-7be6dc33f337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819f4-cabf-4a31-86f4-3213deb6b719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819f4-cabf-4a31-86f4-3213deb6b719.jpg?1",
             "name": "Elemental Uprising",
             "text": "Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. It must be blocked this turn if able.",
             "colours": [
@@ -13164,7 +13164,7 @@
         },
         {
             "id": "9fb57475-aa6b-508f-a59f-78d2f343d977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc63793-9bf9-4c69-8f6d-74484bb40fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc63793-9bf9-4c69-8f6d-74484bb40fda.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} for each Elf you control.",
             "colours": [
@@ -13198,7 +13198,7 @@
         },
         {
             "id": "7c31a37a-70a9-530e-8e41-9c6ce8e641ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9f4647-4214-4f11-8995-72e149592e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9f4647-4214-4f11-8995-72e149592e2f.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -13229,7 +13229,7 @@
         },
         {
             "id": "a013de81-5792-53c9-add8-c13c4b41c4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea6c234-ede2-4543-ab8e-38d7a503a5e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea6c234-ede2-4543-ab8e-38d7a503a5e1.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -13260,7 +13260,7 @@
         },
         {
             "id": "47bb07a5-2824-5330-a127-3cb4c8982bb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70180e04-1453-43dc-9bbb-ab0d6291a8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70180e04-1453-43dc-9bbb-ab0d6291a8b5.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -13294,7 +13294,7 @@
         },
         {
             "id": "541dfbc3-207a-53f3-90f3-e4412f8f75bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bc8745-9aaf-4b3c-922f-5a577324bb1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bc8745-9aaf-4b3c-922f-5a577324bb1f.jpg?1",
             "name": "Feral Hydra",
             "text": "Feral Hydra enters the battlefield with X +1/+1 counters on it.\n{3}: Put a +1/+1 counter on Feral Hydra. Any player may activate this ability.",
             "colours": [
@@ -13328,7 +13328,7 @@
         },
         {
             "id": "eb213985-6a31-5290-91d0-3ccedb88c726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ad379-1a0f-4598-b5b1-453955846597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ad379-1a0f-4598-b5b1-453955846597.jpg?1",
             "name": "Feral Invocation",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -13361,7 +13361,7 @@
         },
         {
             "id": "28ddd8ce-2afb-5f6b-931a-8ce0dbbe0124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59d92b0-5ad1-42a7-9c06-1cb31a63bd64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59d92b0-5ad1-42a7-9c06-1cb31a63bd64.jpg?1",
             "name": "Feral Prowler",
             "text": "When Feral Prowler dies, draw a card.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "a634bc58-f109-53dd-8cc8-e7181a6083b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ca48-b34c-4b9f-bd58-e85e75d94508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ca48-b34c-4b9f-bd58-e85e75d94508.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid enters the battlefield with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles their library.",
             "colours": [
@@ -13427,7 +13427,7 @@
         },
         {
             "id": "965d0f5f-5a52-5464-a891-3e054728960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c342309-aef7-4733-ac1c-ff0b704539a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c342309-aef7-4733-ac1c-ff0b704539a7.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -13463,7 +13463,7 @@
         },
         {
             "id": "07858405-7725-5d5b-b000-085a0e61d028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23680a1a-7c8d-4ea0-a62c-a302f07b6ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23680a1a-7c8d-4ea0-a62c-a302f07b6ed5.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -13497,7 +13497,7 @@
         },
         {
             "id": "683af11a-714e-5bda-87ba-18856f9d8e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084446ca-fec5-446f-b6f8-edf32ecb57e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084446ca-fec5-446f-b6f8-edf32ecb57e3.jpg?1",
             "name": "Grave Bramble",
             "text": "Defender\nProtection from Zombies (This creature can't be blocked, targeted, or dealt damage by Zombies.)",
             "colours": [
@@ -13530,7 +13530,7 @@
         },
         {
             "id": "44c9f13f-a65b-56d4-9da7-f35046578a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12cf74d-aad9-41d8-959e-66557c39204d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12cf74d-aad9-41d8-959e-66557c39204d.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -13561,7 +13561,7 @@
         },
         {
             "id": "7563a3b7-24f8-56ea-8767-6bf6663e2c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e83c1-e5e3-49b2-bbf3-fad8cc7d020a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e83c1-e5e3-49b2-bbf3-fad8cc7d020a.jpg?1",
             "name": "Initiate's Companion",
             "text": "Whenever Initiate's Companion deals combat damage to a player, untap target creature or land.",
             "colours": [
@@ -13594,7 +13594,7 @@
         },
         {
             "id": "4b34c85f-e508-5c8a-83c3-e962a83d3827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a443d-ab85-4c3e-9fd4-f84afcea2665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7a443d-ab85-4c3e-9fd4-f84afcea2665.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "6111893c-4e84-5b27-b1eb-4e0803dac91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5573f8-5fdd-4050-af2a-fbdec51e4f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5573f8-5fdd-4050-af2a-fbdec51e4f37.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -13658,7 +13658,7 @@
         },
         {
             "id": "cac5bfdf-7b08-5a7c-a41b-c41552f82899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb613e46-af18-4195-883b-cdd35b2eaf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb613e46-af18-4195-883b-cdd35b2eaf50.jpg?1",
             "name": "Irresistible Prey",
             "text": "Target creature must be blocked this turn if able.\nDraw a card.",
             "colours": [
@@ -13689,7 +13689,7 @@
         },
         {
             "id": "e372c550-2f00-5d73-88cc-06fb9e0e05cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c21c795-e455-4ecf-a7a2-8f204c114c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c21c795-e455-4ecf-a7a2-8f204c114c81.jpg?1",
             "name": "Keeper of Fables",
             "text": "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -13722,7 +13722,7 @@
         },
         {
             "id": "8543f61a-2620-5ed3-875f-613ae8d6099d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b3bd44-3b01-4507-b9be-ab94601ea736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b3bd44-3b01-4507-b9be-ab94601ea736.jpg?1",
             "name": "Leaf Gilder",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -13756,7 +13756,7 @@
         },
         {
             "id": "9ef954f7-912c-5e26-99b5-6956aa447c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c622c-03ed-492d-baf9-6412cf5e50f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c622c-03ed-492d-baf9-6412cf5e50f4.jpg?1",
             "name": "Lifecrafter's Gift",
             "text": "Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -13787,7 +13787,7 @@
         },
         {
             "id": "64b0ec38-b064-5676-8fa6-2e46aabdb3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9952da7c-3cfc-413f-8849-0f10e9c8dceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9952da7c-3cfc-413f-8849-0f10e9c8dceb.jpg?1",
             "name": "Lurking Predators",
             "text": "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.",
             "colours": [
@@ -13818,7 +13818,7 @@
         },
         {
             "id": "d0aa6513-a61e-5354-9f7d-691d77e6b161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a6f558-a754-4437-8328-00a6ca47f9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a6f558-a754-4437-8328-00a6ca47f9b5.jpg?1",
             "name": "Momentous Fall",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nYou draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness.",
             "colours": [
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "8b5d05b2-9356-501a-9489-1a0f0a8940e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cf9d11-936f-4e02-8595-0cbcabaafb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77cf9d11-936f-4e02-8595-0cbcabaafb1e.jpg?1",
             "name": "Nature's Way",
             "text": "Target creature you control gains vigilance and trample until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -13880,7 +13880,7 @@
         },
         {
             "id": "70f03e8e-ec4a-5dea-b9d3-c1b790dfa471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1900efd-262a-4eef-a8e8-238801466a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1900efd-262a-4eef-a8e8-238801466a88.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on Nessian Hornbeetle.",
             "colours": [
@@ -13913,7 +13913,7 @@
         },
         {
             "id": "7695e2ba-5879-5e06-8604-c2d08b952d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7df29a3-c40f-4cd8-a6fe-c1b95085cfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7df29a3-c40f-4cd8-a6fe-c1b95085cfed.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen New Horizons enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -13946,7 +13946,7 @@
         },
         {
             "id": "d2a0499e-ded9-57c3-85b5-c72443730390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de097e5-e960-4404-a370-defe93ce892f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de097e5-e960-4404-a370-defe93ce892f.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play lands from the top of your library.",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "db627403-b4c6-55bd-af6d-941101497380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20471a3b-90f9-4463-9b43-fc7b9b28f5d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20471a3b-90f9-4463-9b43-fc7b9b28f5d1.jpg?1",
             "name": "Orazca Frillback",
             "text": "",
             "colours": [
@@ -14013,7 +14013,7 @@
         },
         {
             "id": "1e430d89-a75d-54c8-b482-2856eb0e6d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50974264-b509-4df9-802b-623805a4cbee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50974264-b509-4df9-802b-623805a4cbee.jpg?1",
             "name": "Overgrown Battlement",
             "text": "Defender\n{T}: Add {G} for each creature with defender you control.",
             "colours": [
@@ -14046,7 +14046,7 @@
         },
         {
             "id": "043e3a13-a2db-5c12-8df1-0c2a3d99e37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cce86-ff61-4d24-8d37-8c27acaff21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cce86-ff61-4d24-8d37-8c27acaff21c.jpg?1",
             "name": "Penumbra Bobcat",
             "text": "When Penumbra Bobcat dies, create a 2/1 black Cat creature token.",
             "colours": [
@@ -14079,7 +14079,7 @@
         },
         {
             "id": "7dda9c07-4513-5919-9496-5cb162d8d571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f5156b-b200-41f7-8b93-557c4cdc2bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f5156b-b200-41f7-8b93-557c4cdc2bf7.jpg?1",
             "name": "Pouncing Cheetah",
             "text": "Flash",
             "colours": [
@@ -14112,7 +14112,7 @@
         },
         {
             "id": "cc99ec88-fe9c-5582-8849-f5a04c7347fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba661af-c4a8-4230-830e-a9ee22b25d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba661af-c4a8-4230-830e-a9ee22b25d6b.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Create a 1/1 green Elf Warrior creature token.\"",
             "colours": [
@@ -14145,7 +14145,7 @@
         },
         {
             "id": "51e6f431-5f75-5cb9-a15e-69f30d3d651b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8123d01-da65-4d03-9f23-3842fba5fc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8123d01-da65-4d03-9f23-3842fba5fc28.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, create a 3/3 green Beast creature token.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nWhenever a land enters the battlefield under your control, you gain 3 life.",
             "colours": [
@@ -14176,7 +14176,7 @@
         },
         {
             "id": "e80b5e3d-ef57-5f3a-943f-3797dd66b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0d8dec-e139-4565-9259-3c24c54c1d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0d8dec-e139-4565-9259-3c24c54c1d45.jpg?1",
             "name": "Primordial Sage",
             "text": "Whenever you cast a creature spell, you may draw a card.",
             "colours": [
@@ -14209,7 +14209,7 @@
         },
         {
             "id": "bd859129-fe7b-52f4-81dc-ad9983ded5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9a1e7-fe87-40e0-bff9-a1fa84b3b949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d9a1e7-fe87-40e0-bff9-a1fa84b3b949.jpg?1",
             "name": "Rampaging Brontodon",
             "text": "Trample\nWhenever Rampaging Brontodon attacks, it gets +1/+1 until end of turn for each land you control.",
             "colours": [
@@ -14242,7 +14242,7 @@
         },
         {
             "id": "10694fbf-a753-56ec-ad7d-4313e6d7a77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48df6c-8d5d-4d8a-b98a-793f6a56184d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48df6c-8d5d-4d8a-b98a-793f6a56184d.jpg?1",
             "name": "Ravenous Baloth",
             "text": "Sacrifice a Beast: You gain 4 life.",
             "colours": [
@@ -14275,7 +14275,7 @@
         },
         {
             "id": "67d38ff2-926d-5a06-8032-24f92ae10c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a35e69-145f-4cb0-b7f1-0eac8638afbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a35e69-145f-4cb0-b7f1-0eac8638afbe.jpg?1",
             "name": "Rishkar, Peema Renegade",
             "text": "When Rishkar, Peema Renegade enters the battlefield, put a +1/+1 counter on each of up to two target creatures.\nEach creature you control with a counter on it has \"{T}: Add {G}.\"",
             "colours": [
@@ -14311,7 +14311,7 @@
         },
         {
             "id": "c8c9bce7-3471-5f69-92f2-adbc454c7c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a56610-482b-4ddf-88e1-e4a2edf4fa0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a56610-482b-4ddf-88e1-e4a2edf4fa0f.jpg?1",
             "name": "Rumbling Baloth",
             "text": "",
             "colours": [
@@ -14344,7 +14344,7 @@
         },
         {
             "id": "f5c1bb68-c447-5cee-8a93-b6ac874a3f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf15ef-91e9-433f-a4c8-e670adef904c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdf15ef-91e9-433f-a4c8-e670adef904c.jpg?1",
             "name": "Savage Stomp",
             "text": "This spell costs {2} less to cast if it targets a Dinosaur you control.\nPut a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -14375,7 +14375,7 @@
         },
         {
             "id": "9a44f479-d867-5411-a410-bf34b3f673d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f2163-5e08-4465-9669-a5a176a2b810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6f2163-5e08-4465-9669-a5a176a2b810.jpg?1",
             "name": "Scrounging Bandar",
             "text": "Scrounging Bandar enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.",
             "colours": [
@@ -14409,7 +14409,7 @@
         },
         {
             "id": "cec8cd30-796e-5802-93ad-2f742b5940bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87782d-e9c7-440b-bd96-aa043d18e185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb87782d-e9c7-440b-bd96-aa043d18e185.jpg?1",
             "name": "Selvala, Heart of the Wilds",
             "text": "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.\n{G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.",
             "colours": [
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "005b2fd7-9d34-56fa-a3d1-72f457355830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cc1d52-04bd-4546-a20f-d2993654c830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cc1d52-04bd-4546-a20f-d2993654c830.jpg?1",
             "name": "Silhana Wayfinder",
             "text": "When Silhana Wayfinder enters the battlefield, look at the top four cards of your library. You may reveal a creature or land card from among them and put it on top of your library. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14479,7 +14479,7 @@
         },
         {
             "id": "7cbb18cb-ee86-589c-ae30-d06ca93d1d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbe1270-7300-4408-a4c8-92157a8a076f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbe1270-7300-4408-a4c8-92157a8a076f.jpg?1",
             "name": "Somberwald Stag",
             "text": "When Somberwald Stag enters the battlefield, you may have it fight target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "dfabb7ac-81ff-54f8-84f6-15e3b67c2ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce9104-0ad3-4d3d-bb2c-c456c25030f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce9104-0ad3-4d3d-bb2c-c456c25030f6.jpg?1",
             "name": "Soul of the Harvest",
             "text": "Trample\nWhenever another nontoken creature enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -14545,7 +14545,7 @@
         },
         {
             "id": "b551c6ec-0557-5383-ac95-7dabe1d0c0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2799310-c77a-47b2-b1a5-50c029600020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2799310-c77a-47b2-b1a5-50c029600020.jpg?1",
             "name": "Sporemound",
             "text": "Whenever a land enters the battlefield under your control, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -14578,7 +14578,7 @@
         },
         {
             "id": "55325d46-debe-5bb0-a4c3-965460d36f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16482e12-7a8d-4999-8438-da227e6d1305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16482e12-7a8d-4999-8438-da227e6d1305.jpg?1",
             "name": "Sylvan Brushstrider",
             "text": "When Sylvan Brushstrider enters the battlefield, you gain 2 life.",
             "colours": [
@@ -14611,7 +14611,7 @@
         },
         {
             "id": "2d767e35-75fc-59d6-a91a-d1e8c26aacc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a5be0-a730-4cb7-9d1e-6ae84b5bc872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36a5be0-a730-4cb7-9d1e-6ae84b5bc872.jpg?1",
             "name": "Sylvan Ranger",
             "text": "When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -14646,7 +14646,7 @@
         },
         {
             "id": "72b3cedb-5e09-58a5-bbbc-e7b42f697b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0594c41-0361-4a3b-a9cd-60f4e3b0cffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0594c41-0361-4a3b-a9cd-60f4e3b0cffe.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -14679,7 +14679,7 @@
         },
         {
             "id": "41deef35-5b23-5105-977e-5b593961a115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e40ded-6daf-423e-8d74-2c6d448e0853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e40ded-6daf-423e-8d74-2c6d448e0853.jpg?1",
             "name": "Thundering Spineback",
             "text": "Other Dinosaurs you control get +1/+1.\n{5}{G}: Create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -14712,7 +14712,7 @@
         },
         {
             "id": "e643aca7-7caa-54ec-a910-995ec63a321b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e89e51-fd37-4f41-ad13-d1b8a93e5277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e89e51-fd37-4f41-ad13-d1b8a93e5277.jpg?1",
             "name": "Time to Feed",
             "text": "Choose target creature an opponent controls. When that creature dies this turn, you gain 3 life. Target creature you control fights that creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "657d1ea5-f1ed-53c3-9e7b-12b371c0f2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0700d1c1-faab-4a1a-b55d-a2fa4582a2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0700d1c1-faab-4a1a-b55d-a2fa4582a2b4.jpg?1",
             "name": "Ulvenwald Hydra",
             "text": "Reach\nUlvenwald Hydra's power and toughness are each equal to the number of lands you control.\nWhen Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -14776,7 +14776,7 @@
         },
         {
             "id": "b52b487c-f407-5ec6-bbc7-81e9d0bbe1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00cb59d-de35-45b2-a7f8-f8c1e821f6ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00cb59d-de35-45b2-a7f8-f8c1e821f6ee.jpg?1",
             "name": "Vastwood Zendikon",
             "text": "Enchant land\nEnchanted land is a 6/4 green Elemental creature. It's still a land.\nWhen enchanted land dies, return that card to its owner's hand.",
             "colours": [
@@ -14809,7 +14809,7 @@
         },
         {
             "id": "c0cd4a49-c31c-5182-aa50-de434153d882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c915a4-a75f-40e7-b78a-9c304dcdd83e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c915a4-a75f-40e7-b78a-9c304dcdd83e.jpg?1",
             "name": "Verdant Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has \"At the beginning of each upkeep, create a 1/1 green Saproling creature token.\"",
             "colours": [
@@ -14842,7 +14842,7 @@
         },
         {
             "id": "72ab390b-86b8-5905-aee8-9b4ea42ececa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836b155-8829-460b-91f8-4cd00b988196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836b155-8829-460b-91f8-4cd00b988196.jpg?1",
             "name": "Wall of Blossoms",
             "text": "Defender\nWhen Wall of Blossoms enters the battlefield, draw a card.",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "523436a7-6490-53cf-bc3d-e9c28a77de0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b7563-752b-4391-95d1-f5e3960d35c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b7563-752b-4391-95d1-f5e3960d35c1.jpg?1",
             "name": "Wall of Vines",
             "text": "Defender, reach",
             "colours": [
@@ -14910,7 +14910,7 @@
         },
         {
             "id": "b49632ec-ef0f-53c3-892a-f7b4a10aa005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b146ba7-591c-4553-b250-0a6eed24f0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b146ba7-591c-4553-b250-0a6eed24f0b5.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -14944,7 +14944,7 @@
         },
         {
             "id": "4e28037c-25ec-5292-b209-15205b8c9506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44ec73-169a-4354-8ee1-238b8abd8d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44ec73-169a-4354-8ee1-238b8abd8d81.jpg?1",
             "name": "Wildsize",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -14975,7 +14975,7 @@
         },
         {
             "id": "4cd1c704-2dec-5a05-8363-bc4c03a9bd51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e49925-a4ab-4960-ad83-20583dcd2c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e49925-a4ab-4960-ad83-20583dcd2c2c.jpg?1",
             "name": "Woodborn Behemoth",
             "text": "As long as you control eight or more lands, Woodborn Behemoth gets +4/+4 and has trample.",
             "colours": [
@@ -15008,7 +15008,7 @@
         },
         {
             "id": "b9abb6bf-6f38-5dd4-ba23-7f853f5afc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61eae36-9c4a-4d72-9431-6cac34dbb527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61eae36-9c4a-4d72-9431-6cac34dbb527.jpg?1",
             "name": "Wren's Run Vanquisher",
             "text": "As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}.\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -15042,7 +15042,7 @@
         },
         {
             "id": "f0265693-ac53-5192-9776-ceadc7ea766e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180aa3d6-8475-4c98-a140-af736a9c135e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180aa3d6-8475-4c98-a140-af736a9c135e.jpg?1",
             "name": "Zendikar's Roil",
             "text": "Whenever a land enters the battlefield under your control, create a 2/2 green Elemental creature token.",
             "colours": [
@@ -15073,7 +15073,7 @@
         },
         {
             "id": "e028b633-2e69-5a0b-ab73-3fcf5087e56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0092a-b642-41be-a907-4c8931962ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0092a-b642-41be-a907-4c8931962ef9.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -15106,7 +15106,7 @@
         },
         {
             "id": "d6b74aae-cf37-5dfd-b0f3-e4039e8ddfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da93bf0-2075-4e36-b69b-3db3d4288e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da93bf0-2075-4e36-b69b-3db3d4288e7a.jpg?1",
             "name": "Dinrova Horror",
             "text": "When Dinrova Horror enters the battlefield, return target permanent to its owner's hand, then that player discards a card.",
             "colours": [
@@ -15141,7 +15141,7 @@
         },
         {
             "id": "c003349a-aeda-57ab-aae2-e60041d8e7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538bc51-e320-437e-867d-0d01621e31fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5538bc51-e320-437e-867d-0d01621e31fb.jpg?1",
             "name": "Fusion Elemental",
             "text": "",
             "colours": [
@@ -15182,7 +15182,7 @@
         },
         {
             "id": "24c3b9c0-1d99-5422-b8b3-4f06757ef303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78765aa-f952-47f5-b6fc-8aca93fc4104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78765aa-f952-47f5-b6fc-8aca93fc4104.jpg?1",
             "name": "Ironroot Warlord",
             "text": "Ironroot Warlord's power is equal to the number of creatures you control.\n{3}{G}{W}: Create a 1/1 white Soldier creature token.",
             "colours": [
@@ -15218,7 +15218,7 @@
         },
         {
             "id": "00b74be4-bd80-5924-800f-653fd3587f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64771e8-94bb-452b-b028-619ed3b4327c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64771e8-94bb-452b-b028-619ed3b4327c.jpg?1",
             "name": "Lawmage's Binding",
             "text": "Flash\nEnchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -15253,7 +15253,7 @@
         },
         {
             "id": "ce1b965b-1595-5d6b-8525-f458c09d5cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed111116-c2cc-4c97-a84c-f9576ea2ada7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed111116-c2cc-4c97-a84c-f9576ea2ada7.jpg?1",
             "name": "Maelstrom Archangel",
             "text": "Flying\nWhenever Maelstrom Archangel deals combat damage to a player, you may cast a spell from your hand without paying its mana cost.",
             "colours": [
@@ -15294,7 +15294,7 @@
         },
         {
             "id": "e21c85ab-3eae-53cf-973c-2e33056ae9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1632bd-30bc-40a2-963f-44be3b42efb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1632bd-30bc-40a2-963f-44be3b42efb3.jpg?1",
             "name": "Raging Regisaur",
             "text": "Whenever Raging Regisaur attacks, it deals 1 damage to any target.",
             "colours": [
@@ -15329,7 +15329,7 @@
         },
         {
             "id": "cf1cf1ac-4c9b-520e-865a-e2a45ad4af42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e8ce9-edd7-4ae7-9521-6fb6727cf63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54e8ce9-edd7-4ae7-9521-6fb6727cf63b.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice Aether Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice Aether Spellbomb: Draw a card.",
             "colours": [],
@@ -15358,7 +15358,7 @@
         },
         {
             "id": "e23eb20e-7f05-5a67-be7a-98988c2a1d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d2180b-f54c-47a9-9458-28e7a19e35ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d2180b-f54c-47a9-9458-28e7a19e35ee.jpg?1",
             "name": "Alloy Myr",
             "text": "{T}: Add one mana of any color.",
             "colours": [],
@@ -15388,7 +15388,7 @@
         },
         {
             "id": "9d8527f7-0023-5e24-a9b0-65c695cde5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4113be-6dd9-4c15-9f57-a146bc520df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4113be-6dd9-4c15-9f57-a146bc520df8.jpg?1",
             "name": "Ancestral Statue",
             "text": "When Ancestral Statue enters the battlefield, return a nonland permanent you control to its owner's hand.",
             "colours": [],
@@ -15418,7 +15418,7 @@
         },
         {
             "id": "bccd2f2e-5021-5db3-9fc8-cf05eacfdc10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416a2796-08c7-4370-8bc5-2152877e9034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416a2796-08c7-4370-8bc5-2152877e9034.jpg?1",
             "name": "Arcane Encyclopedia",
             "text": "{3}, {T}: Draw a card.",
             "colours": [],
@@ -15445,7 +15445,7 @@
         },
         {
             "id": "d34f647d-6d14-5b6a-a946-df8a6ae8e09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955aa79b-448e-4752-8e36-0fe80c18280c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955aa79b-448e-4752-8e36-0fe80c18280c.jpg?1",
             "name": "Bubbling Cauldron",
             "text": "{1}, {T}, Sacrifice a creature: You gain 4 life.\n{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.",
             "colours": [],
@@ -15472,7 +15472,7 @@
         },
         {
             "id": "ee07a3d9-b20c-5769-83df-5a1f979cf3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3260793-bf43-4862-9e1f-122edfc35ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3260793-bf43-4862-9e1f-122edfc35ee4.jpg?1",
             "name": "Chamber Sentry",
             "text": "Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.\n{X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.\n{W}{U}{B}{R}{G}: Return Chamber Sentry from your graveyard to your hand.",
             "colours": [],
@@ -15508,7 +15508,7 @@
         },
         {
             "id": "73748a64-e411-57d1-9e5b-783c30e28ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc8b2-4413-48e4-8d6f-521b19d839a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edabc8b2-4413-48e4-8d6f-521b19d839a6.jpg?1",
             "name": "Chromatic Sphere",
             "text": "{1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color. Draw a card.",
             "colours": [],
@@ -15535,7 +15535,7 @@
         },
         {
             "id": "94c4ced9-3209-5f2b-8c83-374b45ba88b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa21a-a92e-4bcd-84fe-a7aa159fd0eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa21a-a92e-4bcd-84fe-a7aa159fd0eb.jpg?1",
             "name": "Dragonloft Idol",
             "text": "As long as you control a Dragon, Dragonloft Idol gets +1/+1 and has flying and trample.",
             "colours": [],
@@ -15565,7 +15565,7 @@
         },
         {
             "id": "010490e9-ac24-5762-b23d-c3376c44d3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58382d72-9b2b-44cf-8a02-b745deafc286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58382d72-9b2b-44cf-8a02-b745deafc286.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {C}{C}{C}.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -15592,7 +15592,7 @@
         },
         {
             "id": "2e50e011-c5df-58a7-af81-73df57ce4cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5abd21-9736-4e9e-b195-813461cfcd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5abd21-9736-4e9e-b195-813461cfcd0a.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -15622,7 +15622,7 @@
         },
         {
             "id": "cce45bf7-46a0-54a1-8455-22e0c5f2c0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1195ec5-979b-4c4a-9c04-62bb53c2b011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1195ec5-979b-4c4a-9c04-62bb53c2b011.jpg?1",
             "name": "Gingerbrute",
             "text": "Haste\n{1}: Gingerbrute can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice Gingerbrute: You gain 3 life.",
             "colours": [],
@@ -15653,7 +15653,7 @@
         },
         {
             "id": "8021cdef-65ba-5764-b55a-e0ec89573b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393ef742-6968-4266-ae07-a4564b7f6ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393ef742-6968-4266-ae07-a4564b7f6ede.jpg?1",
             "name": "Guardian Idol",
             "text": "Guardian Idol enters the battlefield tapped.\n{T}: Add {C}.\n{2}: Guardian Idol becomes a 2/2 Golem artifact creature until end of turn.",
             "colours": [],
@@ -15680,7 +15680,7 @@
         },
         {
             "id": "8460c269-ce91-5d1d-b0e3-b6a5fd7a53d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5112871-dd07-4257-9a11-a86523c4a8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5112871-dd07-4257-9a11-a86523c4a8b6.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -15707,7 +15707,7 @@
         },
         {
             "id": "246b9b2b-2ee2-5693-b93e-6b6e786ddb8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d51b3-20a2-4cc3-bd70-7f165940c157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d51b3-20a2-4cc3-bd70-7f165940c157.jpg?1",
             "name": "Herald's Horn",
             "text": "As Herald's Horn enters the battlefield, choose a creature type.\nCreature spells you cast of the chosen type cost {1} less to cast.\nAt the beginning of your upkeep, look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand.",
             "colours": [],
@@ -15734,7 +15734,7 @@
         },
         {
             "id": "451ba3ff-0e23-5540-a83d-e37d32c30e3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0c95b0-7b63-40e8-92ad-5ae5ffd3c4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0c95b0-7b63-40e8-92ad-5ae5ffd3c4c1.jpg?1",
             "name": "Jousting Dummy",
             "text": "{3}: Jousting Dummy gets +1/+0 until end of turn.",
             "colours": [],
@@ -15765,7 +15765,7 @@
         },
         {
             "id": "930e76a5-9efe-50b6-9c68-fc6e142745b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc90cf8-9dd6-4dac-8cbb-21677d81e4d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc90cf8-9dd6-4dac-8cbb-21677d81e4d3.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each combat if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -15795,7 +15795,7 @@
         },
         {
             "id": "5947ec44-ef0e-5d78-a793-62e7d08c1be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54d41-683e-42fd-8aa4-371dddf3bcb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54d41-683e-42fd-8aa4-371dddf3bcb3.jpg?1",
             "name": "Mana Geode",
             "text": "When Mana Geode enters the battlefield, scry 1.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -15822,7 +15822,7 @@
         },
         {
             "id": "58262196-0805-53b2-9965-ae21df793890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d8aa8a-3e87-42ac-9c79-2baec771c1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d8aa8a-3e87-42ac-9c79-2baec771c1ef.jpg?1",
             "name": "Marauder's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15851,7 +15851,7 @@
         },
         {
             "id": "d48244b1-87a2-51e2-99cd-cab907192a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a086bf-19d2-4827-af2c-a6f57d640782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a086bf-19d2-4827-af2c-a6f57d640782.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -15881,7 +15881,7 @@
         },
         {
             "id": "3e210eb5-283e-5166-b610-2216a2e60ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f2e2e5-5ed2-4040-92ba-ad1ac13f03f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f2e2e5-5ed2-4040-92ba-ad1ac13f03f6.jpg?1",
             "name": "Myr Sire",
             "text": "When Myr Sire dies, create a 1/1 colorless Myr artifact creature token.",
             "colours": [],
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "39c83432-a4fc-5a73-8381-b81d159c981f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0aa3726-038f-4522-a7bd-1877a4fef350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0aa3726-038f-4522-a7bd-1877a4fef350.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr dies, it deals 2 damage to any target.",
             "colours": [],
@@ -15943,7 +15943,7 @@
         },
         {
             "id": "343d884d-4181-5f12-8499-d77ff33cf899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff526b-3822-4073-baab-8ea5f95daf91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff526b-3822-4073-baab-8ea5f95daf91.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When Pirate's Cutlass enters the battlefield, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -15972,7 +15972,7 @@
         },
         {
             "id": "1b58506a-3f40-5a2e-a58f-51ae4dffa4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f25660-97ec-4308-bc5b-1ee405b23399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f25660-97ec-4308-bc5b-1ee405b23399.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -15999,7 +15999,7 @@
         },
         {
             "id": "f4c7032e-786e-547f-b467-7824769255b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794fe9d4-2af4-40b0-bbb2-8015b6206972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794fe9d4-2af4-40b0-bbb2-8015b6206972.jpg?1",
             "name": "Rogue's Gloves",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16028,7 +16028,7 @@
         },
         {
             "id": "0ca2ca78-7b6e-5f29-a62d-3052c71aab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e64bc76-c6df-4b3c-b37f-f9386d30cab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e64bc76-c6df-4b3c-b37f-f9386d30cab9.jpg?1",
             "name": "Roving Keep",
             "text": "Defender\n{7}: Roving Keep gets +2/+0 and gains trample until end of turn. It can attack this turn as though it didn't have defender.",
             "colours": [],
@@ -16058,7 +16058,7 @@
         },
         {
             "id": "c044e9d3-d25b-5ae8-b730-95a382cca81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedf97b-8901-4558-8bd0-3f488097f686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedf97b-8901-4558-8bd0-3f488097f686.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -16088,7 +16088,7 @@
         },
         {
             "id": "10549c66-5677-5b3c-8f8e-0b8b3272b00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c9d86a-54a3-457c-b9b4-61f914de6e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c9d86a-54a3-457c-b9b4-61f914de6e14.jpg?1",
             "name": "Scarecrone",
             "text": "{1}, Sacrifice a Scarecrow: Draw a card.\n{4}, {T}: Return target artifact creature card from your graveyard to the battlefield.",
             "colours": [],
@@ -16118,7 +16118,7 @@
         },
         {
             "id": "efc23a3d-d27a-5fe3-8416-28fb919a4785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2d0981-0af6-42d6-b926-16f8f2327320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2d0981-0af6-42d6-b926-16f8f2327320.jpg?1",
             "name": "Scroll of Avacyn",
             "text": "{1}, Sacrifice Scroll of Avacyn: Draw a card. If you control an Angel, you gain 5 life.",
             "colours": [],
@@ -16145,7 +16145,7 @@
         },
         {
             "id": "91414b8f-624c-50d3-ac6b-5c612705ce58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd8e7c-13cb-4aea-a3cb-c7ed29d43163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd8e7c-13cb-4aea-a3cb-c7ed29d43163.jpg?1",
             "name": "Scuttlemutt",
             "text": "{T}: Add one mana of any color.\n{T}: Target creature becomes the color or colors of your choice until end of turn.",
             "colours": [],
@@ -16175,7 +16175,7 @@
         },
         {
             "id": "fd366051-085f-5d09-8981-a2f90a1bd8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77f544c-1d27-4632-8ca5-7dfb38f42b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77f544c-1d27-4632-8ca5-7dfb38f42b1c.jpg?1",
             "name": "Signpost Scarecrow",
             "text": "Vigilance\n{2}: Add one mana of any color.",
             "colours": [],
@@ -16205,7 +16205,7 @@
         },
         {
             "id": "301d0cd7-084f-57ee-b547-09735b4cd41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e9f488-db24-4bcd-bdf9-38c1e50f5504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e9f488-db24-4bcd-bdf9-38c1e50f5504.jpg?1",
             "name": "Skittering Surveyor",
             "text": "When Skittering Surveyor enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -16235,7 +16235,7 @@
         },
         {
             "id": "3e301354-c7f2-5743-b2e0-05ca5d492c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b14ff70-6817-4539-b19b-142f8f6b6b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b14ff70-6817-4539-b19b-142f8f6b6b1f.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -16265,7 +16265,7 @@
         },
         {
             "id": "2cc6e8dc-1fcd-57d1-87b3-9212a0e82163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eda056-e00f-4e28-ad26-9150a4704d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eda056-e00f-4e28-ad26-9150a4704d21.jpg?1",
             "name": "Terrarion",
             "text": "Terrarion enters the battlefield tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana in any combination of colors.\nWhen Terrarion is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -16292,7 +16292,7 @@
         },
         {
             "id": "35db08cf-f047-5ad6-a51e-e1dae36a3f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d3681a-78d8-469f-9109-5f8faf04b707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d3681a-78d8-469f-9109-5f8faf04b707.jpg?1",
             "name": "Unstable Obelisk",
             "text": "{T}: Add {C}.\n{7}, {T}, Sacrifice Unstable Obelisk: Destroy target permanent.",
             "colours": [],
@@ -16319,7 +16319,7 @@
         },
         {
             "id": "defb3ebe-be6c-5f21-ab66-705473db4b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7321473-5747-4430-86b2-b5029d9f6486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7321473-5747-4430-86b2-b5029d9f6486.jpg?1",
             "name": "Warmonger's Chariot",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature has defender, it can attack as though it didn't have defender.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -16348,7 +16348,7 @@
         },
         {
             "id": "970aa41f-c757-5777-b6ba-cd47a33683a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bc5b7-c4d5-4c4c-af0d-aa0853d63f3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bc5b7-c4d5-4c4c-af0d-aa0853d63f3a.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -16375,7 +16375,7 @@
         },
         {
             "id": "14330b46-8937-5173-baff-564b0cc8354d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9fbb3-9fe4-4ec6-82f0-3bb101524e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9fbb3-9fe4-4ec6-82f0-3bb101524e1e.jpg?1",
             "name": "Mirrodin's Core",
             "text": "{T}: Add {C}.\n{T}: Put a charge counter on Mirrodin's Core.\n{T}, Remove a charge counter from Mirrodin's Core: Add one mana of any color.",
             "colours": [],
@@ -16402,7 +16402,7 @@
         },
         {
             "id": "8e186e43-08f8-5e67-a5ac-552acb092b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b2cc68-1d20-421f-9800-af0996071554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b2cc68-1d20-421f-9800-af0996071554.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -16433,7 +16433,7 @@
         },
         {
             "id": "afe4b64c-1c8b-5bef-9600-2b1f81aaf134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6eadd8-71d8-4a87-8395-efe8cc9f0676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6eadd8-71d8-4a87-8395-efe8cc9f0676.jpg?1",
             "name": "Riptide Laboratory",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Return target Wizard you control to its owner's hand.",
             "colours": [],
@@ -16462,7 +16462,7 @@
         },
         {
             "id": "2e521012-305f-5697-b831-1d65282dd203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2c2fea-d657-49f1-af03-d5d3fef3ead0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2c2fea-d657-49f1-af03-d5d3fef3ead0.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -16489,7 +16489,7 @@
         },
         {
             "id": "412013dc-8a6a-54f8-beb7-77b56baa5057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390a53e5-2392-403d-9105-338e0c8320a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390a53e5-2392-403d-9105-338e0c8320a2.jpg?1",
             "name": "Scholar of the Lost Trove",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/JOU.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/JOU.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "0abbf519-365e-57df-81e9-192d6e6b8f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2f381-86a2-42ac-b694-dcde437d574f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b2f381-86a2-42ac-b694-dcde437d574f.jpg?1",
             "name": "Aegis of the Gods",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "eadb867f-d5f6-50ed-be4a-00903ef39b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77e2fd5-5c46-4f6b-ac43-ec23fab57a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77e2fd5-5c46-4f6b-ac43-ec23fab57a1a.jpg?1",
             "name": "Ajani's Presence",
             "text": "Strive \u2014 Ajani's Presence costs {2}{W} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+1 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "6d4b4554-b880-532f-b9b0-21c873a2d9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e21938b-46b1-4b2f-8269-0cd0e998cddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e21938b-46b1-4b2f-8269-0cd0e998cddc.jpg?1",
             "name": "Akroan Mastiff",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "b5df9263-354a-5ee0-9abc-2713b224632f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4203df15-dd44-496b-889a-d7a8fe320330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4203df15-dd44-496b-889a-d7a8fe320330.jpg?1",
             "name": "Armament of Nyx",
             "text": "Enchant creature\nEnchanted creature has double strike as long as it's an enchantment. Otherwise, prevent all damage that would be dealt by enchanted creature. (A creature with double strike deals both first-strike and regular combat damage.)",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "e8e230e9-b40e-5b94-b341-b3a1091c48f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaa4800-30cc-4a80-a6cc-9a24ada9eb40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaa4800-30cc-4a80-a6cc-9a24ada9eb40.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield. (That permanent returns under its owner's control.)",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "937bb8fa-dec5-5d1d-995e-545e32e79ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca7b7d9-8b69-411a-8a1d-9b7d0492e7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca7b7d9-8b69-411a-8a1d-9b7d0492e7d0.jpg?1",
             "name": "Dawnbringer Charioteers",
             "text": "Flying, lifelink\nHeroic \u2014 Whenever you cast a spell that targets Dawnbringer Charioteers, put a +1/+1 counter on Dawnbringer Charioteers.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "e571eb4c-33be-5264-9447-a5d12b5ed5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6012964c-eb76-4581-82ae-aec2d36f0d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6012964c-eb76-4581-82ae-aec2d36f0d56.jpg?1",
             "name": "Deicide",
             "text": "Exile target enchantment. If the exiled card is a God card, search its controller's graveyard, hand, and library for any number of cards with the same name as that card and exile them, then that player shuffles his or her library.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "49159197-1934-5c68-a665-8de2bd72a12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95602d52-988c-472b-ba8e-cf25aa92f1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95602d52-988c-472b-ba8e-cf25aa92f1fc.jpg?1",
             "name": "Dictate of Heliod",
             "text": "Flash\nCreatures you control get +2/+2.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "aba2a762-dd00-5bdb-8edc-5e0d8fd1259f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg?1",
             "name": "Eagle of the Watch",
             "text": "Flying, vigilance",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "54b6bd3d-341c-5c88-87a0-31e0545abd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bc8b9e-4d22-41ba-b593-d383fd301ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bc8b9e-4d22-41ba-b593-d383fd301ef9.jpg?1",
             "name": "Eidolon of Rhetoric",
             "text": "Each player can't cast more than one spell each turn.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "a95c27bb-674e-56a3-937a-32910ced5606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef3a8e-ef8b-417a-a3a9-cb0ce88cb0c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef3a8e-ef8b-417a-a3a9-cb0ce88cb0c9.jpg?1",
             "name": "Font of Vigor",
             "text": "{2}{W}, Sacrifice Font of Vigor: You gain 7 life.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "3f62a2dd-79e2-5a05-aef3-b8aa2a55c386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcf3975-7f81-4bdd-810d-476f46444b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcf3975-7f81-4bdd-810d-476f46444b7a.jpg?1",
             "name": "Godsend",
             "text": "Equipped creature gets +3/+3.\nWhenever equipped creature blocks or becomes blocked by one or more creatures, you may exile one of those creatures.\nOpponents can't cast cards with the same name as cards exiled with Godsend.\nEquip {3}",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "cbf343f7-28f6-5b18-bf01-798eaf631e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9256e2-b59c-4997-91c1-4c565746d53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9256e2-b59c-4997-91c1-4c565746d53d.jpg?1",
             "name": "Harvestguard Alseids",
             "text": "Constellation \u2014 Whenever Harvestguard Alseids or another enchantment enters the battlefield under your control, prevent all damage that would be dealt to target creature this turn.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "78d4d192-b09e-5345-84ef-2633bad01443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a6f533-6acb-4c24-ae9d-fe4977230156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a6f533-6acb-4c24-ae9d-fe4977230156.jpg?1",
             "name": "Lagonna-Band Trailblazer",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Lagonna-Band Trailblazer, put a +1/+1 counter on Lagonna-Band Trailblazer.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "407b9968-a592-5990-8aa1-4114b56c40c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e52c0-2f79-4537-8f1c-70b68836bac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3e52c0-2f79-4537-8f1c-70b68836bac0.jpg?1",
             "name": "Launch the Fleet",
             "text": "Strive \u2014 Launch the Fleet costs {1} more to cast for each target beyond the first.\nUntil end of turn, any number of target creatures each gain \"Whenever this creature attacks, put a 1/1 white Soldier creature token onto the battlefield tapped and attacking.\"",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "e0ae1ea6-55ff-5db1-806e-385fc6338fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfaa12e-f1d9-4a39-804f-14cdaf382257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfaa12e-f1d9-4a39-804f-14cdaf382257.jpg?1",
             "name": "Leonin Iconoclast",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Leonin Iconoclast, destroy target enchantment creature an opponent controls.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "0f81d745-41fe-5c30-b329-8a75e02c763a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67652df1-f2cc-44cd-ac66-9722d4cd86e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67652df1-f2cc-44cd-ac66-9722d4cd86e9.jpg?1",
             "name": "Mortal Obstinacy",
             "text": "Enchant creature you control\nEnchanted creature gets +1/+1.\nWhenever enchanted creature deals combat damage to a player, you may sacrifice Mortal Obstinacy. If you do, destroy target enchantment.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "7b96a227-773e-5234-a9df-687cf7baaa6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d13a98-e715-49a8-a59e-a2adfcdec70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d13a98-e715-49a8-a59e-a2adfcdec70b.jpg?1",
             "name": "Nyx-Fleece Ram",
             "text": "At the beginning of your upkeep, you gain 1 life.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "1ebe9ef7-1969-54ac-bf65-e4e832385145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac995f-514d-4c65-8135-417f2b1a6fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac995f-514d-4c65-8135-417f2b1a6fba.jpg?1",
             "name": "Oppressive Rays",
             "text": "Enchant creature\nEnchanted creature can't attack or block unless its controller pays {3}.\nActivated abilities of enchanted creature cost {3} more to activate.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "4a837bdb-7088-5933-be6a-e49111fe2e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c67b91-7f05-44b1-9e99-3e2094434f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c67b91-7f05-44b1-9e99-3e2094434f6a.jpg?1",
             "name": "Oreskos Swiftclaw",
             "text": "",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "ed457f38-f18d-5bc0-9886-c6c545ec8176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9aaba1-e480-4667-b3c9-d5665a3b4806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9aaba1-e480-4667-b3c9-d5665a3b4806.jpg?1",
             "name": "Phalanx Formation",
             "text": "Strive \u2014 Phalanx Formation costs {1}{W} more to cast for each target beyond the first.\nAny number of target creatures each gain double strike until end of turn. (They deal both first-strike and regular combat damage.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "13d2f915-7a37-5e1b-894a-67ca628a24c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921128a-ebfd-4e3c-8728-481a8c3c03f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d921128a-ebfd-4e3c-8728-481a8c3c03f3.jpg?1",
             "name": "Quarry Colossus",
             "text": "When Quarry Colossus enters the battlefield, put target creature into its owner's library just beneath the top X cards of that library, where X is the number of Plains you control.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "50d40046-ddcc-5c0b-97bd-b0d2d135511d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343baad1-dd58-4d64-9b0a-258618094ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343baad1-dd58-4d64-9b0a-258618094ceb.jpg?1",
             "name": "Reprisal",
             "text": "Destroy target creature with power 4 or greater. It can't be regenerated.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "950586fd-94b2-5618-a861-71bd2594af0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2fcd27-c068-468f-9825-2825c0cf217d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e2fcd27-c068-468f-9825-2825c0cf217d.jpg?1",
             "name": "Sightless Brawler",
             "text": "Bestow {4}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nSightless Brawler can't attack alone.\nEnchanted creature gets +3/+2 and can't attack alone.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "37485e19-54db-52da-9900-07876c605c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e3117a-0955-47fc-81c0-7a662c8c487f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e3117a-0955-47fc-81c0-7a662c8c487f.jpg?1",
             "name": "Skybind",
             "text": "Constellation \u2014 Whenever Skybind or another enchantment enters the battlefield under your control, exile target nonenchantment permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "46c0a1dc-e2db-5fa2-a35c-e787cae25044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86ab26f-0959-476f-9f83-939e9138ca8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86ab26f-0959-476f-9f83-939e9138ca8d.jpg?1",
             "name": "Skyspear Cavalry",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "32141275-a415-5d16-9af8-8da38add24f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1cd291-92a0-4f0f-b73a-64fc498da1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1cd291-92a0-4f0f-b73a-64fc498da1ef.jpg?1",
             "name": "Stonewise Fortifier",
             "text": "{4}{W}: Prevent all damage that would be dealt to Stonewise Fortifier by target creature this turn.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "3ff400a7-063c-5650-9a49-6680f510cf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764bd86e-4156-4c58-9ce0-ca3dffbc7298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764bd86e-4156-4c58-9ce0-ca3dffbc7298.jpg?1",
             "name": "Supply-Line Cranes",
             "text": "Flying\nWhen Supply-Line Cranes enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "93723983-17a5-524b-b724-f0fb3bd30c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d901b9d7-6af9-40ce-afb7-d3c9f9143c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d901b9d7-6af9-40ce-afb7-d3c9f9143c18.jpg?1",
             "name": "Tethmos High Priest",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Tethmos High Priest, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "885b1ed5-0bce-536c-a5bd-f6fcef09522e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce86785-bc03-451e-8422-8bb53082cc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce86785-bc03-451e-8422-8bb53082cc12.jpg?1",
             "name": "Aerial Formation",
             "text": "Strive \u2014 Aerial Formation costs {2}{U} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+1 and gain flying until end of turn.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "6c4c32d4-7226-5bec-a8cd-931c7c6f566a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffc93-b107-457c-af04-a1b682a4b886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffc93-b107-457c-af04-a1b682a4b886.jpg?1",
             "name": "Battlefield Thaumaturge",
             "text": "Each instant and sorcery spell you cast costs {1} less to cast for each creature it targets.\nHeroic \u2014 Whenever you cast a spell that targets Battlefield Thaumaturge, Battlefield Thaumaturge gains hexproof until end of turn.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "be6525ff-544b-536d-b5c1-23b5ec2d423f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a639aa-91f4-49df-8671-122710073084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a639aa-91f4-49df-8671-122710073084.jpg?1",
             "name": "Cloaked Siren",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "e39ae191-0bf5-51d3-bf6b-be09aca12c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07815e32-0b64-4c2b-84e6-a72336c45cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07815e32-0b64-4c2b-84e6-a72336c45cf5.jpg?1",
             "name": "Countermand",
             "text": "Counter target spell. Its controller puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "db7cd569-ee9b-59bb-9de4-19c27581af68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a60d25-b97f-40e7-a5ac-c456cee02aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a60d25-b97f-40e7-a5ac-c456cee02aeb.jpg?1",
             "name": "Crystalline Nautilus",
             "text": "Bestow {3}{U}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhen Crystalline Nautilus becomes the target of a spell or ability, sacrifice it.\nEnchanted creature gets +4/+4 and has \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "b707ed88-dacb-5aae-b889-b4f817c18702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5f71ca-e7d9-4f9a-adf1-40353693deea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5f71ca-e7d9-4f9a-adf1-40353693deea.jpg?1",
             "name": "Dakra Mystic",
             "text": "{U}, {T}: Each player reveals the top card of his or her library. You may put the revealed cards into their owners' graveyards. If you don't, each player draws a card.",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "da6a7da7-620d-509e-8726-fe111295e831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d9378d-e553-48b5-8a23-59a35329eda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d9378d-e553-48b5-8a23-59a35329eda2.jpg?1",
             "name": "Daring Thief",
             "text": "Inspired \u2014 Whenever Daring Thief becomes untapped, you may exchange control of target nonland permanent you control and target permanent an opponent controls that shares a card type with it.",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "5302975e-13be-5e99-a8f4-8c846e37e009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7916c-f39a-48a0-a47d-7e83ebf028fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7916c-f39a-48a0-a47d-7e83ebf028fa.jpg?1",
             "name": "Dictate of Kruphix",
             "text": "Flash\nAt the beginning of each player's draw step, that player draws an additional card.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "23cd2416-bf35-52c2-b7a6-ba1ee1bcc458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de3481-9b0d-4747-a97b-171b6aa41073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de3481-9b0d-4747-a97b-171b6aa41073.jpg?1",
             "name": "Font of Fortunes",
             "text": "{1}{U}, Sacrifice Font of Fortunes: Draw two cards.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "a7fa8bd2-0b0c-568d-806d-96cb5d4cca13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da106c23-fd1c-461b-9301-159f93ef489b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da106c23-fd1c-461b-9301-159f93ef489b.jpg?1",
             "name": "Godhunter Octopus",
             "text": "Godhunter Octopus can't attack unless defending player controls an enchantment or an enchanted permanent.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "aadc6659-6cae-5997-bfd8-3f3098f32d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737b859d-d81e-4da3-a8bf-9a8f23c75a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737b859d-d81e-4da3-a8bf-9a8f23c75a50.jpg?1",
             "name": "Hour of Need",
             "text": "Strive \u2014 Hour of Need costs {1}{U} more to cast for each target beyond the first.\nExile any number of target creatures. For each creature exiled this way, its controller puts a 4/4 blue Sphinx creature token with flying onto the battlefield.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "bc7698e0-c578-5fbc-ae51-5255d9289180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f5b473-edad-43a9-b4e7-b6d3fc877cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f5b473-edad-43a9-b4e7-b6d3fc877cf2.jpg?1",
             "name": "Hubris",
             "text": "Return target creature and all Auras attached to it to their owners' hands.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "f0c07171-29bc-5bd2-86b1-aae6f04ff923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f562f-00d1-41da-a6ac-bc019cce7fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f562f-00d1-41da-a6ac-bc019cce7fe7.jpg?1",
             "name": "Hypnotic Siren",
             "text": "Bestow {5}{U}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying\nYou control enchanted creature.\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "292ce9d2-e05c-5b79-87dc-8585f0c58fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696f2da6-3943-4555-9610-e6b925b3d6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696f2da6-3943-4555-9610-e6b925b3d6bc.jpg?1",
             "name": "Interpret the Signs",
             "text": "Scry 3, then reveal the top card of your library. Draw cards equal to that card's converted mana cost. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "136f23bf-06b6-500e-9d3b-28bed18e0359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b040e5-651b-42ca-b487-66cf1d8180f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b040e5-651b-42ca-b487-66cf1d8180f9.jpg?1",
             "name": "Kiora's Dismissal",
             "text": "",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "8dd349a9-8d2c-5ef7-9aa8-cffd25d21c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04e6915-39b0-4fbc-9114-2ecf371b6f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04e6915-39b0-4fbc-9114-2ecf371b6f72.jpg?1",
             "name": "Pin to the Earth",
             "text": "Enchant creature\nEnchanted creature gets -6/-0.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "716c68a3-6e9f-5f82-9c5a-f2e8da1758c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5f703-339f-430c-b342-77bcc2c63222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5f703-339f-430c-b342-77bcc2c63222.jpg?1",
             "name": "Polymorphous Rush",
             "text": "Strive \u2014 Polymorphous Rush costs {1}{U} more to cast for each target beyond the first.\nChoose a creature on the battlefield. Any number of target creatures you control each become a copy of that creature until end of turn.",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "2d7131a8-122c-5a0d-9695-2762d1466637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051b622-fa1d-4694-aef7-0fcdd7bff8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a051b622-fa1d-4694-aef7-0fcdd7bff8d2.jpg?1",
             "name": "Pull from the Deep",
             "text": "Return up to one target instant card and up to one target sorcery card from your graveyard to your hand. Exile Pull from the Deep.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "f398bb28-f7fc-59af-b669-aa9fddef49ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f88da5-b013-478a-8a0b-da9d1e8eb2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f88da5-b013-478a-8a0b-da9d1e8eb2c9.jpg?1",
             "name": "Riptide Chimera",
             "text": "Flying\nAt the beginning of your upkeep, return an enchantment you control to its owner's hand.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "adba7118-81e2-5f3f-a54e-88fdf5139f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b5b278-b883-4703-9bfa-bab5a6da4660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b5b278-b883-4703-9bfa-bab5a6da4660.jpg?1",
             "name": "Rise of Eagles",
             "text": "Put two 2/2 blue Bird enchantment creature tokens with flying onto the battlefield. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "5272a65c-b493-5b75-bb14-683cf1339a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb55caf-fc95-40dc-80af-5144f94333ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb55caf-fc95-40dc-80af-5144f94333ee.jpg?1",
             "name": "Sage of Hours",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Sage of Hours, put a +1/+1 counter on it.\nRemove all +1/+1 counters from Sage of Hours: For each five counters removed this way, take an extra turn after this one.",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "a05b942e-3934-5c0e-b53a-028140b67c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1de7-1476-4f8d-b8b3-67675891df23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaf1de7-1476-4f8d-b8b3-67675891df23.jpg?1",
             "name": "Scourge of Fleets",
             "text": "When Scourge of Fleets enters the battlefield, return each creature your opponents control with toughness X or less to its owner's hand, where X is the number of Islands you control.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "41de6a6c-a651-5eb8-a8be-086f6886880d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a61f99-44f8-4a2b-b7f2-7899a694552d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a61f99-44f8-4a2b-b7f2-7899a694552d.jpg?1",
             "name": "Sigiled Starfish",
             "text": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "68e88c94-ae29-5ead-8651-8542ac4bac29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebd8c0-bb03-434d-b669-d9b35d07b2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ebd8c0-bb03-434d-b669-d9b35d07b2c6.jpg?1",
             "name": "Thassa's Devourer",
             "text": "Constellation \u2014 Whenever Thassa's Devourer or another enchantment enters the battlefield under your control, target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "32bfae5c-a2f8-5e7a-adfc-f51d6af69966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc6245f-c60f-4674-8c6d-24fe3b78e00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc6245f-c60f-4674-8c6d-24fe3b78e00e.jpg?1",
             "name": "Thassa's Ire",
             "text": "{3}{U}: You may tap or untap target creature.",
             "colours": [
@@ -1822,7 +1822,7 @@
         },
         {
             "id": "6a4b9573-518e-5b3c-b52b-00667e5bc4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b6c6b-35f8-4c8a-aa29-ae71d5166121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b6c6b-35f8-4c8a-aa29-ae71d5166121.jpg?1",
             "name": "Triton Cavalry",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Triton Cavalry, you may return target enchantment to its owner's hand.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "967f9454-301d-515a-b360-7bcdfdcb6df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881c554e-2324-41e2-89f1-db9f4017bc31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881c554e-2324-41e2-89f1-db9f4017bc31.jpg?1",
             "name": "Triton Shorestalker",
             "text": "Triton Shorestalker can't be blocked.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "dad824cf-9938-5d85-9a67-9c678224b3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d88c942-3a69-4975-a08d-80405a549beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d88c942-3a69-4975-a08d-80405a549beb.jpg?1",
             "name": "War-Wing Siren",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets War-Wing Siren, put a +1/+1 counter on War-Wing Siren.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "25b3bd7a-aa42-56c8-9a53-3cc093e9c818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f61c85c-03cf-411a-aa66-cbe178aeaa02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f61c85c-03cf-411a-aa66-cbe178aeaa02.jpg?1",
             "name": "Whitewater Naiads",
             "text": "Constellation \u2014 Whenever Whitewater Naiads or another enchantment enters the battlefield under your control, target creature can't be blocked this turn.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "846d8310-4e55-5d42-b813-242549bc1501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07a595-5579-4d5a-b07c-84239d690459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e07a595-5579-4d5a-b07c-84239d690459.jpg?1",
             "name": "Agent of Erebos",
             "text": "Constellation \u2014 Whenever Agent of Erebos or another enchantment enters the battlefield under your control, exile all cards from target player's graveyard.",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "ba8fd57e-11b3-5780-bff2-dbb7b1c63ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8956d0-5502-415d-bead-d8bbddf9871d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8956d0-5502-415d-bead-d8bbddf9871d.jpg?1",
             "name": "Aspect of Gorgon",
             "text": "Enchant creature\nEnchanted creature gets +1/+3 and has deathtouch. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "a879c447-f82e-533e-bce2-b168859ed3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a6556b-a4f1-4ff5-8e6e-a47618c8c66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a6556b-a4f1-4ff5-8e6e-a47618c8c66e.jpg?1",
             "name": "Bloodcrazed Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Bloodcrazed Hoplite, put a +1/+1 counter on it.\nWhenever a +1/+1 counter is placed on Bloodcrazed Hoplite, remove a +1/+1 counter from target creature an opponent controls.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "3d17b973-b0e6-5af0-9b33-59ff5d21cdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdc31d5-6726-453e-94e0-69d2fe9447af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdc31d5-6726-453e-94e0-69d2fe9447af.jpg?1",
             "name": "Brain Maggot",
             "text": "When Brain Maggot enters the battlefield, target opponent reveals his or her hand and you choose a nonland card from it. Exile that card until Brain Maggot leaves the battlefield.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "439b67da-fa04-5499-a5fd-17e09c9b247b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1880d4-90c7-46a2-bbc9-d2b52971d11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1880d4-90c7-46a2-bbc9-d2b52971d11c.jpg?1",
             "name": "Cast into Darkness",
             "text": "Enchant creature\nEnchanted creature gets -2/-0 and can't block.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "b580f6a4-570e-5c61-ae92-08b35b8b45e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53624ee-2925-4a56-8706-e278db5d963d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53624ee-2925-4a56-8706-e278db5d963d.jpg?1",
             "name": "Cruel Feeding",
             "text": "Strive \u2014 Cruel Feeding costs {2}{B} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+0 and gain lifelink until end of turn. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -2167,7 +2167,7 @@
         },
         {
             "id": "9ee74cdc-17f8-5e59-91e9-f50edd57fd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06db70-95f9-41eb-8e5f-8bc56fd34c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f06db70-95f9-41eb-8e5f-8bc56fd34c09.jpg?1",
             "name": "Dictate of Erebos",
             "text": "Flash\nWhenever a creature you control dies, each opponent sacrifices a creature.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "fbe397b3-77ab-5dcd-aa8c-a4988b893cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eabfb-f086-45dd-97e2-b2ed5286bc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20eabfb-f086-45dd-97e2-b2ed5286bc3c.jpg?1",
             "name": "Doomwake Giant",
             "text": "Constellation \u2014 Whenever Doomwake Giant or another enchantment enters the battlefield under your control, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "a6383684-f5c5-5ea0-8532-54dec753f469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2b4819-8aeb-49c0-b40a-3ff280604970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2b4819-8aeb-49c0-b40a-3ff280604970.jpg?1",
             "name": "Dreadbringer Lampads",
             "text": "Constellation \u2014 Whenever Dreadbringer Lampads or another enchantment enters the battlefield under your control, target creature gains intimidate until end of turn. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "62a6e01b-b638-57ec-825b-b700c07ae68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6895024f-a04b-46cf-b020-df4487d0c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6895024f-a04b-46cf-b020-df4487d0c758.jpg?1",
             "name": "Extinguish All Hope",
             "text": "Destroy all nonenchantment creatures.",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "43979580-4b2c-58ff-a8d1-cc9f95243ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de07e21e-c12a-47a6-ad2c-ef6fed343407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de07e21e-c12a-47a6-ad2c-ef6fed343407.jpg?1",
             "name": "Feast of Dreams",
             "text": "Destroy target enchanted creature or enchantment creature.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "c5b528b3-db93-5dfc-bcd0-8b72638bf29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cce01-a0cb-4059-a0ad-fbf7d9b998b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cce01-a0cb-4059-a0ad-fbf7d9b998b8.jpg?1",
             "name": "Felhide Petrifier",
             "text": "Deathtouch\nOther Minotaur creatures you control have deathtouch.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "2d278097-8bef-53fd-a01b-26ebc324640c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13eacff-0fd1-4e2e-8213-5bf5fff973c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13eacff-0fd1-4e2e-8213-5bf5fff973c8.jpg?1",
             "name": "Font of Return",
             "text": "{3}{B}, Sacrifice Font of Return: Return up to three target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "a7fb1c3c-ff89-5df5-80cb-12b8d0517717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040af9b9-1e94-4dd1-b347-b54b6b9e0275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040af9b9-1e94-4dd1-b347-b54b6b9e0275.jpg?1",
             "name": "Gnarled Scarhide",
             "text": "Bestow {3}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nGnarled Scarhide can't block.\nEnchanted creature gets +2/+1 and can't block.",
             "colours": [
@@ -2435,7 +2435,7 @@
         },
         {
             "id": "a71da27e-cc68-599f-8712-03e47dfad99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732b5444-0410-430b-87ca-cf2d9f165bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732b5444-0410-430b-87ca-cf2d9f165bd7.jpg?1",
             "name": "Grim Guardian",
             "text": "Constellation \u2014 Whenever Grim Guardian or another enchantment enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "b2f58460-d5d8-57b8-93d6-3c7190354222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5987ab-570a-426c-ae4a-a270fac6b346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5987ab-570a-426c-ae4a-a270fac6b346.jpg?1",
             "name": "King Macar, the Gold-Cursed",
             "text": "Inspired \u2014 Whenever King Macar, the Gold-Cursed becomes untapped, you may exile target creature. If you do, put a colorless artifact token named Gold onto the battlefield. It has \"Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "355904cb-b923-5f9c-8218-ca6d150c09f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528f7a3-0a7b-42e3-8e4f-f1eeab02e23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d528f7a3-0a7b-42e3-8e4f-f1eeab02e23a.jpg?1",
             "name": "Master of the Feast",
             "text": "Flying\nAt the beginning of your upkeep, each opponent draws a card.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "6ebff1db-aef6-5f6f-ae18-5d37cdcf40e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bab0e0a-7eb9-4422-a1d4-82cc05b4374d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bab0e0a-7eb9-4422-a1d4-82cc05b4374d.jpg?1",
             "name": "Nightmarish End",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "70d2fbb3-13b2-5161-97f4-f74eb445b46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1910d072-1660-4918-a338-d9f87926541d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1910d072-1660-4918-a338-d9f87926541d.jpg?1",
             "name": "Nyx Infusion",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's an enchantment. Otherwise, it gets -2/-2.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "9172053c-54c7-5c60-a389-020c2a145231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119ce0c-d709-463c-9abc-f7025673ea72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119ce0c-d709-463c-9abc-f7025673ea72.jpg?1",
             "name": "Pharika's Chosen",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "237a15e5-1786-59d8-aa78-00f84eb39023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea61098-2c6a-48d2-b99f-f3065c67d8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea61098-2c6a-48d2-b99f-f3065c67d8e3.jpg?1",
             "name": "Returned Reveler",
             "text": "When Returned Reveler dies, each player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "88ec8031-77aa-57b7-b13e-3af0330f7a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bdf00a-e7f1-42f4-997f-388f3b28bf8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20bdf00a-e7f1-42f4-997f-388f3b28bf8f.jpg?1",
             "name": "Ritual of the Returned",
             "text": "Exile target creature card from your graveyard. Put a black Zombie creature token onto the battlefield. Its power is equal to that card's power and its toughness is equal to that card's toughness.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "05c9779f-d955-5f2d-a20e-449b9b2d5e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1066644a-ac62-4809-805c-607c645613c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1066644a-ac62-4809-805c-607c645613c5.jpg?1",
             "name": "Rotted Hulk",
             "text": "",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "408f3550-d44f-5a15-ab18-0633390816aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dc2bd1-a980-4eab-8bb3-1ce28c3f9ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6dc2bd1-a980-4eab-8bb3-1ce28c3f9ef4.jpg?1",
             "name": "Silence the Believers",
             "text": "Strive \u2014 Silence the Believers costs {2}{B} more to cast for each target beyond the first.\nExile any number of target creatures and all Auras attached to them.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "cbf58d23-5195-5267-a1f7-2cccd768306e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafaa798-e534-4cd0-b369-9e767a02fe3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafaa798-e534-4cd0-b369-9e767a02fe3d.jpg?1",
             "name": "Spiteful Blow",
             "text": "Destroy target creature and target land.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "d663dd37-efe3-59b0-92bb-c1b3827280c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3fff48-ebc9-4fca-a098-77d973e7d238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3fff48-ebc9-4fca-a098-77d973e7d238.jpg?1",
             "name": "Squelching Leeches",
             "text": "Squelching Leeches's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "3a79c074-0808-5a4d-99bd-cbac31ef58a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69799971-6e24-4b90-ba72-44c6393fc3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69799971-6e24-4b90-ba72-44c6393fc3c4.jpg?1",
             "name": "Thoughtrender Lamia",
             "text": "Constellation \u2014 Whenever Thoughtrender Lamia or another enchantment enters the battlefield under your control, each opponent discards a card.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "aeeb647d-d2a0-54b2-b583-d3a55c0e5123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130655e0-af82-4d91-acc2-270eaa33e3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130655e0-af82-4d91-acc2-270eaa33e3d1.jpg?1",
             "name": "Tormented Thoughts",
             "text": "As an additional cost to cast Tormented Thoughts, sacrifice a creature.\nTarget player discards a number of cards equal to the sacrificed creature's power.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "e28539b2-26da-5ddc-b4c2-b9337495a1af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e21ac-4f3e-4a3e-83c0-0a59a1b84020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e21ac-4f3e-4a3e-83c0-0a59a1b84020.jpg?1",
             "name": "Worst Fears",
             "text": "You control target player during that player's next turn. Exile Worst Fears. (You see all cards that player could see and make all decisions for the player.)",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "50109836-f262-5205-ad02-f832ecbb0382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5114db5-b545-43dc-85a3-c0e68ab22a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5114db5-b545-43dc-85a3-c0e68ab22a95.jpg?1",
             "name": "Akroan Line Breaker",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Line Breaker, Akroan Line Breaker gets +2/+0 and gains intimidate until end of turn.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "2131387e-6da4-540a-a1cd-201ccb158208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d9fa5-a8e0-4263-9804-22d648554eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061d9fa5-a8e0-4263-9804-22d648554eba.jpg?1",
             "name": "Bearer of the Heavens",
             "text": "When Bearer of the Heavens dies, destroy all permanents at the beginning of the next end step.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "9d1a2910-6003-5934-bcfe-f5091fb258b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f157fb0-81ac-4108-aafc-7ee81df965a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f157fb0-81ac-4108-aafc-7ee81df965a9.jpg?1",
             "name": "Bladetusk Boar",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "3a4a3f27-f083-536d-95e1-b4695af58566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07f43b6-e07f-4d0c-90d2-e5b0d23ba0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07f43b6-e07f-4d0c-90d2-e5b0d23ba0f9.jpg?1",
             "name": "Blinding Flare",
             "text": "Strive \u2014 Blinding Flare costs {R} more to cast for each target beyond the first.\nAny number of target creatures can't block this turn.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "24176295-f89f-58eb-a2d2-6bd14b2ecc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a92b7a-7119-45b3-b9ed-5dbf5abca818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a92b7a-7119-45b3-b9ed-5dbf5abca818.jpg?1",
             "name": "Cyclops of Eternal Fury",
             "text": "Creatures you control have haste.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "9cf3e08b-568f-516f-b00f-d693812bf157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cc93f2-8198-45b1-9193-7cfd1cf7ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cc93f2-8198-45b1-9193-7cfd1cf7ced4.jpg?1",
             "name": "Dictate of the Twin Gods",
             "text": "Flash\nIf a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "a28f645f-3672-5c3d-8dcc-000a66686123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6c10816-e825-452a-90b0-80eb9f20bd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6c10816-e825-452a-90b0-80eb9f20bd6d.jpg?1",
             "name": "Eidolon of the Great Revel",
             "text": "Whenever a player casts a spell with converted mana cost 3 or less, Eidolon of the Great Revel deals 2 damage to that player.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "9e4a689e-3656-555d-9b84-f45fba53d46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b5e3bb-f9e8-4a74-9798-41d8f8515e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b5e3bb-f9e8-4a74-9798-41d8f8515e12.jpg?1",
             "name": "Flamespeaker's Will",
             "text": "Enchant creature you control\nEnchanted creature gets +1/+1.\nWhenever enchanted creature deals combat damage to a player, you may sacrifice Flamespeaker's Will. If you do, destroy target artifact.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "82929508-3ea4-5108-a473-81daf8da2a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333ff270-4bc7-48ee-9738-f8c70b8a7e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333ff270-4bc7-48ee-9738-f8c70b8a7e40.jpg?1",
             "name": "Flurry of Horns",
             "text": "Put two 2/3 red Minotaur creature tokens with haste onto the battlefield.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "e7613acb-a554-5a49-aa38-88fff17503fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41509414-9faf-472d-8d38-391d9594cd56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41509414-9faf-472d-8d38-391d9594cd56.jpg?1",
             "name": "Font of Ire",
             "text": "{3}{R}, Sacrifice Font of Ire: Font of Ire deals 5 damage to target player.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "a4575acc-0c7c-521c-acd0-b88b6e21c961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80038ed-4206-4e44-943e-f332e4ce2f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80038ed-4206-4e44-943e-f332e4ce2f14.jpg?1",
             "name": "Forgeborn Oreads",
             "text": "Constellation \u2014 Whenever Forgeborn Oreads or another enchantment enters the battlefield under your control, Forgeborn Oreads deals 1 damage to target creature or player.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "5424c657-a096-5d0d-9b78-8483cfdb8490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e583f6be-3d78-4085-9059-c3c989a4977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e583f6be-3d78-4085-9059-c3c989a4977f.jpg?1",
             "name": "Gluttonous Cyclops",
             "text": "{5}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -3344,7 +3344,7 @@
         },
         {
             "id": "93b2ef33-99ad-58a7-959a-207661e5dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde89c1-aafa-43d9-adbf-671fa2b52d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde89c1-aafa-43d9-adbf-671fa2b52d4f.jpg?1",
             "name": "Harness by Force",
             "text": "Strive \u2014 Harness by Force costs {2}{R} more to cast for each target beyond the first.\nGain control of any number of target creatures until end of turn. Untap those creatures. They gain haste until end of turn.",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "a104cd0d-bd78-5acd-b310-ac87076d8acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd48a18-df3d-4381-a7e7-a3e9ae18d4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd48a18-df3d-4381-a7e7-a3e9ae18d4d7.jpg?1",
             "name": "Knowledge and Power",
             "text": "Whenever you scry, you may pay {2}. If you do, Knowledge and Power deals 2 damage to target creature or player.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "4ae93464-ee13-5e87-8dc4-6b1935f0c0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce3f1c6-2e6f-4087-8619-a01fdcc6d4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce3f1c6-2e6f-4087-8619-a01fdcc6d4a3.jpg?1",
             "name": "Lightning Diadem",
             "text": "Enchant creature\nWhen Lightning Diadem enters the battlefield, it deals 2 damage to target creature or player.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "a3805b84-4e34-5096-abf6-41fb4ec6b1e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9710889c-0fc6-43a9-83df-484ab0659030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9710889c-0fc6-43a9-83df-484ab0659030.jpg?1",
             "name": "Magma Spray",
             "text": "Magma Spray deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "48dc1127-ca3c-5204-b7ef-801af019a6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e73e06-d708-41dc-b20c-1f71651230e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e73e06-d708-41dc-b20c-1f71651230e1.jpg?1",
             "name": "Mogis's Warhound",
             "text": "Bestow {2}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nMogis's Warhound attacks each turn if able.\nEnchanted creature gets +2/+2 and attacks each turn if able.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "119932d7-ef43-5c1f-8b2f-61a807b416ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902b462a-a552-42d4-91f0-bd33cd9cb719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902b462a-a552-42d4-91f0-bd33cd9cb719.jpg?1",
             "name": "Pensive Minotaur",
             "text": "",
             "colours": [
@@ -3544,7 +3544,7 @@
         },
         {
             "id": "f725830e-e94a-5474-890f-ffa8d190e8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73326c79-f884-42d5-8546-3db46ce4fe52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73326c79-f884-42d5-8546-3db46ce4fe52.jpg?1",
             "name": "Prophetic Flamespeaker",
             "text": "Double strike, trample\nWhenever Prophetic Flamespeaker deals combat damage to a player, exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "b2f17c81-7e65-5802-9b15-973e000fda18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4250b-4493-4054-b0b2-465f76f0c2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f4250b-4493-4054-b0b2-465f76f0c2f0.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose target creature or player. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that creature or player. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "dd1b7725-1799-5a8a-b136-48d67dd13fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a80c4-8119-437d-bf5b-549c5679c90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a80c4-8119-437d-bf5b-549c5679c90a.jpg?1",
             "name": "Rollick of Abandon",
             "text": "All creatures get +2/-2 until end of turn.",
             "colours": [
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "e97eb768-c625-5419-b7d4-f6dad355ccaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a07e7d-e203-4ecd-98bf-f8ef08c38d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a07e7d-e203-4ecd-98bf-f8ef08c38d78.jpg?1",
             "name": "Rouse the Mob",
             "text": "Strive \u2014 Rouse the Mob costs {2}{R} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+0 and gain trample until end of turn.",
             "colours": [
@@ -3675,7 +3675,7 @@
         },
         {
             "id": "23054dde-a803-5968-a4e0-0b5b2c2a389f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8754d66-facb-432e-a6c2-91430a6dec94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8754d66-facb-432e-a6c2-91430a6dec94.jpg?1",
             "name": "Satyr Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Satyr Hoplite, put a +1/+1 counter on Satyr Hoplite.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "d97f3acb-e168-5dfb-9caa-edba4c8848a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f84b4d-82db-4e3a-a099-2e438c0a6418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f84b4d-82db-4e3a-a099-2e438c0a6418.jpg?1",
             "name": "Sigiled Skink",
             "text": "Whenever Sigiled Skink attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "6f815155-38e8-562f-afec-d3cb05dda422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13aa40e-c626-486d-8abc-10aa68542c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e13aa40e-c626-486d-8abc-10aa68542c5b.jpg?1",
             "name": "Spawn of Thraxes",
             "text": "Flying\nWhen Spawn of Thraxes enters the battlefield, it deals damage to target creature or player equal to the number of Mountains you control.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "14f06994-b870-50e8-97d0-8fb53c94d9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5676d255-707e-4621-a0df-3305f999f124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5676d255-707e-4621-a0df-3305f999f124.jpg?1",
             "name": "Spite of Mogis",
             "text": "Spite of Mogis deals damage to target creature equal to the number of instant and sorcery cards in your graveyard. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "72d5d224-023a-5848-8076-803a762eed3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13921f0d-f163-4275-b025-045c1ccd99e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13921f0d-f163-4275-b025-045c1ccd99e5.jpg?1",
             "name": "Starfall",
             "text": "Starfall deals 3 damage to target creature. If that creature is an enchantment, Starfall deals 3 damage to that creature's controller.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "c28f4206-0029-533d-823f-26e882fbb2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207128b3-2de3-495a-bf29-eec50c3bd752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207128b3-2de3-495a-bf29-eec50c3bd752.jpg?1",
             "name": "Twinflame",
             "text": "Strive \u2014 Twinflame costs {2}{R} more to cast for each target beyond the first.\nChoose any number of target creatures you control. For each of them, put a token that's a copy of that creature onto the battlefield. Those tokens have haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "2d7319ad-1f07-5c91-81c7-c832ae520e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a26c23-abb9-41c3-aea1-bb241093119d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a26c23-abb9-41c3-aea1-bb241093119d.jpg?1",
             "name": "Wildfire Cerberus",
             "text": "{5}{R}{R}: Monstrosity 1. (If this creature isn't monstrous, put a +1/+1 counter on it and it becomes monstrous.)\nWhen Wildfire Cerberus becomes monstrous, it deals 2 damage to each opponent and each creature your opponents control.",
             "colours": [
@@ -3908,7 +3908,7 @@
         },
         {
             "id": "6327aad3-1d36-512b-bcf5-8feff15aebf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a1e5c2-7f5b-4ae4-83d9-06e334ba57ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a1e5c2-7f5b-4ae4-83d9-06e334ba57ea.jpg?1",
             "name": "Bassara Tower Archer",
             "text": "Hexproof, reach",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "f6c4c158-eb08-525a-b3a5-50b4dde902e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6139443-e31c-4eea-a99e-df9498fe18a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6139443-e31c-4eea-a99e-df9498fe18a8.jpg?1",
             "name": "Colossal Heroics",
             "text": "Strive \u2014 Colossal Heroics costs {1}{G} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+2 until end of turn. Untap those creatures.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "8d0dd104-5b15-5256-abee-31cb2c00b72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28c0ba-7305-4b64-8cb8-3ecd9c284c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee28c0ba-7305-4b64-8cb8-3ecd9c284c4a.jpg?1",
             "name": "Consign to Dust",
             "text": "Strive \u2014 Consign to Dust costs {2}{G} more to cast for each target beyond the first.\nDestroy any number of target artifacts and/or enchantments.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "4cc2c070-9ae6-52bf-9eda-363324c8af79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbc5e5-5d46-47f7-a700-b65781a13c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dbc5e5-5d46-47f7-a700-b65781a13c7a.jpg?1",
             "name": "Desecration Plague",
             "text": "Destroy target enchantment or land.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "95d8a02a-51d8-5613-90b8-7fa1ac3e4ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5114607-df8f-4e44-8ef5-b6af89964bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5114607-df8f-4e44-8ef5-b6af89964bbc.jpg?1",
             "name": "Dictate of Karametra",
             "text": "Flash\nWhenever a player taps a land for mana, that player adds one mana to his or her mana pool of any type that land produced.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "e764c891-f985-587a-a738-c52a1aa02ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb2112-85b9-49cf-9ed5-9273829c34f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb2112-85b9-49cf-9ed5-9273829c34f1.jpg?1",
             "name": "Eidolon of Blossoms",
             "text": "Constellation \u2014 Whenever Eidolon of Blossoms or another enchantment enters the battlefield under your control, draw a card.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "5456439b-e09a-5139-9266-6fdd42060548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d1ecb-de7c-4641-81da-13117820195c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d1ecb-de7c-4641-81da-13117820195c.jpg?1",
             "name": "Font of Fertility",
             "text": "{1}{G}, Sacrifice Font of Fertility: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "a2a9eb75-3189-5ae3-af6b-24ad07d4debd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae883ea-191e-4571-be3d-1e3149e6965e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae883ea-191e-4571-be3d-1e3149e6965e.jpg?1",
             "name": "Golden Hind",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "7c52333f-ac56-5bed-8526-238abcf2e092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d107c72f-483a-4af9-b86f-681669d99c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d107c72f-483a-4af9-b86f-681669d99c46.jpg?1",
             "name": "Goldenhide Ox",
             "text": "Constellation \u2014 Whenever Goldenhide Ox or another enchantment enters the battlefield under your control, target creature must be blocked this turn if able.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "029aa49a-7182-513e-beec-519424a43f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e82f6-30ee-49c5-b5a2-85c5cf3e9bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380e82f6-30ee-49c5-b5a2-85c5cf3e9bb1.jpg?1",
             "name": "Heroes' Bane",
             "text": "Heroes' Bane enters the battlefield with four +1/+1 counters on it.\n{2}{G}{G}: Put X +1/+1 counters on Heroes' Bane, where X is its power.",
             "colours": [
@@ -4241,7 +4241,7 @@
         },
         {
             "id": "da0b015d-f105-5c69-ae83-4f66512ffc79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12149b9-b450-4ad6-ab5d-9a0eeb36997e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12149b9-b450-4ad6-ab5d-9a0eeb36997e.jpg?1",
             "name": "Humbler of Mortals",
             "text": "Constellation \u2014 Whenever Humbler of Mortals or another enchantment enters the battlefield under your control, creatures you control gain trample until end of turn.",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "55bdab22-a2f5-522a-b778-a95ddeea027c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b465289-676d-4c34-84d3-ce8daf0fd40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b465289-676d-4c34-84d3-ce8daf0fd40e.jpg?1",
             "name": "Hydra Broodmaster",
             "text": "{X}{X}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen Hydra Broodmaster becomes monstrous, put X X/X green Hydra creature tokens onto the battlefield.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "67abbd3c-2507-5d4f-8668-632585edbc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e14f09-9629-443a-bc55-03152eabb2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e14f09-9629-443a-bc55-03152eabb2e7.jpg?1",
             "name": "Kruphix's Insight",
             "text": "Reveal the top six cards of your library. Put up to three enchantment cards from among them into your hand and the rest of the revealed cards into your graveyard.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "5ab5863c-57fb-59f3-87cf-6f489ff24311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a70329-ecae-4647-b912-75d936a6c8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a70329-ecae-4647-b912-75d936a6c8c5.jpg?1",
             "name": "Market Festival",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds two mana in any combination of colors to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "4476d1b1-5ec0-54f3-bddc-a3630ed871d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32177b9c-eef3-4eea-b623-74bfea1afad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32177b9c-eef3-4eea-b623-74bfea1afad6.jpg?1",
             "name": "Nature's Panoply",
             "text": "Strive \u2014 Nature's Panoply costs {2}{G} more to cast for each target beyond the first.\nChoose any number of target creatures. Put a +1/+1 counter on each of them.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "1c8392d9-0c7d-5b93-8f8c-10a628843817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5099d18d-c8b5-4706-bc93-40d1bb12988d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5099d18d-c8b5-4706-bc93-40d1bb12988d.jpg?1",
             "name": "Nessian Game Warden",
             "text": "When Nessian Game Warden enters the battlefield, look at the top X cards of your library, where X is the number of Forests you control. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "fcf59a9e-26f6-58cd-9710-b1b2d30ce23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ef63b9-c021-40fe-910e-93c06d660c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ef63b9-c021-40fe-910e-93c06d660c20.jpg?1",
             "name": "Oakheart Dryads",
             "text": "Constellation \u2014 Whenever Oakheart Dryads or another enchantment enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "61ce3558-b8e2-505d-a17e-73c27550668f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19a2e8e-9d8f-4537-838c-ac60e09d78bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19a2e8e-9d8f-4537-838c-ac60e09d78bf.jpg?1",
             "name": "Pheres-Band Thunderhoof",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Pheres-Band Thunderhoof, put two +1/+1 counters on Pheres-Band Thunderhoof.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "39d7dac7-a0b1-5ff0-b642-a0be45c981d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8456730a-607c-44c0-b18e-0df8f35b0634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8456730a-607c-44c0-b18e-0df8f35b0634.jpg?1",
             "name": "Pheres-Band Warchief",
             "text": "Vigilance, trample\nOther Centaur creatures you control get +1/+1 and have vigilance and trample.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "d9ac7620-3b3b-54c6-aeb4-5d56e8e656b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e91524b-4885-45fc-b22d-f9e5ee55845d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e91524b-4885-45fc-b22d-f9e5ee55845d.jpg?1",
             "name": "Ravenous Leucrocota",
             "text": "Vigilance\n{6}{G}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -4582,7 +4582,7 @@
         },
         {
             "id": "42f873e4-921a-51e5-b297-0817c53a9d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240830be-53f8-4f46-a0fb-6ecc439d1349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240830be-53f8-4f46-a0fb-6ecc439d1349.jpg?1",
             "name": "Renowned Weaver",
             "text": "{1}{G}, Sacrifice Renowned Weaver: Put a 1/3 green Spider enchantment creature token with reach onto the battlefield. (It can block creatures with flying.)",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "d1507b98-c122-58de-8294-8218d7428834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b152cc-d39f-470e-8b62-e4a833db7b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b152cc-d39f-470e-8b62-e4a833db7b88.jpg?1",
             "name": "Reviving Melody",
             "text": "Choose one or both \u2014 Return target creature card from your graveyard to your hand; and/or return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "b91244b4-c044-5001-bb26-63fad68a70de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46febca-f3c0-4467-aef4-4dfcdf3009fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46febca-f3c0-4467-aef4-4dfcdf3009fe.jpg?1",
             "name": "Satyr Grovedancer",
             "text": "When Satyr Grovedancer enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "db8d1336-fd9d-55d1-8a8b-268a6afad088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385a1939-15e5-4f13-b01b-7cdc6835da2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385a1939-15e5-4f13-b01b-7cdc6835da2a.jpg?1",
             "name": "Setessan Tactics",
             "text": "Strive \u2014 Setessan Tactics costs {G} more to cast for each target beyond the first.\nUntil end of turn, any number of target creatures each get +1/+1 and gain \"{T}: This creature fights another target creature.\"",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "29052076-172e-588a-89f2-41e03b623908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba88e10-d306-44df-bdbf-f5ba85887fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba88e10-d306-44df-bdbf-f5ba85887fe8.jpg?1",
             "name": "Solidarity of Heroes",
             "text": "Strive \u2014 Solidarity of Heroes costs {1}{G} more to cast for each target beyond the first.\nChoose any number of target creatures. Double the number of +1/+1 counters on each of them.",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "66d2b8e6-27b1-5693-90eb-228cf2e71e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71491f-3027-4257-a18f-ba4de6041feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71491f-3027-4257-a18f-ba4de6041feb.jpg?1",
             "name": "Spirespine",
             "text": "Bestow {4}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nSpirespine blocks each turn if able.\nEnchanted creature gets +4/+1 and blocks each turn if able.",
             "colours": [
@@ -4783,7 +4783,7 @@
         },
         {
             "id": "c3d118c3-4bcc-5178-bf37-27bc5bb0b8fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b3a8e-3cbb-47c4-9535-dfdeece7ee02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b3a8e-3cbb-47c4-9535-dfdeece7ee02.jpg?1",
             "name": "Strength from the Fallen",
             "text": "Constellation \u2014 Whenever Strength from the Fallen or another enchantment enters the battlefield under your control, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "e7c39f0c-0e23-5876-af90-fe9bdfdda951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ddf9-b682-4691-bb1d-abd1d3486f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a3ddf9-b682-4691-bb1d-abd1d3486f59.jpg?1",
             "name": "Swarmborn Giant",
             "text": "When you're dealt combat damage, sacrifice Swarmborn Giant.\n{4}{G}{G}: Monstrosity 2. (If this creature isn't monstrous, put two +1/+1 counters on it and it becomes monstrous.)\nAs long as Swarmborn Giant is monstrous, it has reach.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "fde92a39-11b7-585e-ba93-fd7f6f3df608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a30bcfa-6f95-450f-aea7-885983d7c6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a30bcfa-6f95-450f-aea7-885983d7c6a5.jpg?1",
             "name": "Ajani, Mentor of Heroes",
             "text": "+1: Distribute three +1/+1 counters among one, two, or three target creatures you control.\n+1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\n-8: You gain 100 life.",
             "colours": [
@@ -4887,7 +4887,7 @@
         },
         {
             "id": "fd3b3599-01f3-59ca-84d0-96b0b61294f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705c53-883e-4b6a-9c08-3fa35f6f17d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52705c53-883e-4b6a-9c08-3fa35f6f17d5.jpg?1",
             "name": "Athreos, God of Passage",
             "text": "Indestructible\nAs long as your devotion to white and black is less than seven, Athreos isn't a creature.\nWhenever another creature you own dies, return it to your hand unless target opponent pays 3 life.",
             "colours": [
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "309215af-9e17-5680-8eb5-0a6288bc7179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a4fb8d-8ddd-4d1d-92c7-2bf6b0e6c488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a4fb8d-8ddd-4d1d-92c7-2bf6b0e6c488.jpg?1",
             "name": "Desperate Stand",
             "text": "Strive \u2014 Desperate Stand costs {R}{W} more to cast for each target beyond the first.\nAny number of target creatures each get +2/+0 and gain first strike and vigilance until end of turn.",
             "colours": [
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "a7586d95-a9da-52f4-8d9f-9d513aa0eb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfe88fd-9bb9-42af-8134-96fd264b8405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfe88fd-9bb9-42af-8134-96fd264b8405.jpg?1",
             "name": "Disciple of Deceit",
             "text": "Inspired \u2014 Whenever Disciple of Deceit becomes untapped, you may discard a nonland card. If you do, search your library for a card with the same converted mana cost as that card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "355d9fe2-77e6-5a52-aeb3-1124a53badd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1139236e-5d71-4fc1-937d-ba1efadee031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1139236e-5d71-4fc1-937d-ba1efadee031.jpg?1",
             "name": "Fleetfeather Cockatrice",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying, deathtouch\n{5}{G}{U}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "1a2cded1-cd1b-503a-b189-5b4e81eacfa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacf28cb-feea-4afb-b22e-1b8d50ee66c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacf28cb-feea-4afb-b22e-1b8d50ee66c1.jpg?1",
             "name": "Iroas, God of Victory",
             "text": "Indestructible\nAs long as your devotion to red and white is less than seven, Iroas isn't a creature.\nCreatures you control can't be blocked except by two or more creatures.\nPrevent all damage that would be dealt to attacking creatures you control.",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "a9077792-12d9-52b0-b596-7d59578d444a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab70c262-37a9-4dcd-80bb-d4422368eade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab70c262-37a9-4dcd-80bb-d4422368eade.jpg?1",
             "name": "Keranos, God of Storms",
             "text": "Indestructible\nAs long as your devotion to blue and red is less than seven, Keranos isn't a creature.\nReveal the first card you draw on each of your turns. Whenever you reveal a land card this way, draw a card. Whenever you reveal a nonland card this way, Keranos deals 3 damage to target creature or player.",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "5902ed50-a569-5aed-aeeb-a962a60192af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27427233-da58-45af-ade8-e0727929efaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27427233-da58-45af-ade8-e0727929efaa.jpg?1",
             "name": "Kruphix, God of Horizons",
             "text": "Indestructible\nAs long as your devotion to green and blue is less than seven, Kruphix isn't a creature.\nYou have no maximum hand size.\nIf unused mana would empty from your mana pool, that mana becomes colorless instead.",
             "colours": [
@@ -5150,7 +5150,7 @@
         },
         {
             "id": "d21e0d48-504c-5a56-a96b-6e6940112017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8553cc-8f61-4022-97c9-e31183b65059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8553cc-8f61-4022-97c9-e31183b65059.jpg?1",
             "name": "Nyx Weaver",
             "text": "Reach\nAt the beginning of your upkeep, put the top two cards of your library into your graveyard.\n{1}{B}{G}, Exile Nyx Weaver: Return target card from your graveyard to your hand.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "f3b851d6-266d-5830-b229-43ed904396f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec8548-5790-4eac-8780-cdd126438192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec8548-5790-4eac-8780-cdd126438192.jpg?1",
             "name": "Pharika, God of Affliction",
             "text": "Indestructible\nAs long as your devotion to black and green is less than seven, Pharika isn't a creature.\n{B}{G}: Exile target creature card from a graveyard. Its owner puts a 1/1 black and green Snake enchantment creature token with deathtouch onto the battlefield.",
             "colours": [
@@ -5226,7 +5226,7 @@
         },
         {
             "id": "d52365e8-4064-5cc9-bf38-b5c6b86cfa0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2c774-aab9-4747-af91-da792ed7cfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2c774-aab9-4747-af91-da792ed7cfe1.jpg?1",
             "name": "Revel of the Fallen God",
             "text": "Put four 2/2 red and green Satyr creature tokens with haste onto the battlefield.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "fdad4a7c-736f-5ea6-9a2e-a3ebcfc88040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6621dd-7220-4b53-a30f-7dd05b2e0134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6621dd-7220-4b53-a30f-7dd05b2e0134.jpg?1",
             "name": "Stormchaser Chimera",
             "text": "Flying\n{2}{U}{R}: Scry 1, then reveal the top card of your library. Stormchaser Chimera gets +X/+0 until end of turn, where X is that card's converted mana cost. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "12eba0de-18d9-52b4-b3f5-f59a59d1c30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5346e3-3fe4-47ea-a184-e237091cc4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5346e3-3fe4-47ea-a184-e237091cc4a1.jpg?1",
             "name": "Underworld Coinsmith",
             "text": "Constellation \u2014 Whenever Underworld Coinsmith or another enchantment enters the battlefield under your control, you gain 1 life.\n{W}{B}, Pay 1 life: Each opponent loses 1 life.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "51e6af22-a51f-5e5e-a03d-2fba83456018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac44e4b-25ba-4b32-ad56-c87c202c310a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac44e4b-25ba-4b32-ad56-c87c202c310a.jpg?1",
             "name": "Armory of Iroas",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on it.\nEquip {2}",
             "colours": [],
@@ -5364,7 +5364,7 @@
         },
         {
             "id": "59ce28fa-099b-567f-be43-84927a2f2a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dd03d2-05ef-4929-b973-3dbe49fc7592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dd03d2-05ef-4929-b973-3dbe49fc7592.jpg?1",
             "name": "Chariot of Victory",
             "text": "Equipped creature has first strike, trample, and haste.\nEquip {1}",
             "colours": [],
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "593c4059-368b-526f-902e-945fb2aca67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7d3b2d-e06e-4d30-9ed8-2a52aa7e31c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7d3b2d-e06e-4d30-9ed8-2a52aa7e31c6.jpg?1",
             "name": "Deserter's Quarters",
             "text": "You may choose not to untap Deserter's Quarters during your untap step.\n{6}, {T}: Tap target creature. It doesn't untap during its controller's untap step for as long as Deserter's Quarters remains tapped.",
             "colours": [],
@@ -5422,7 +5422,7 @@
         },
         {
             "id": "24251725-9101-5407-bbb9-26441c51178a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg?1",
             "name": "Gold-Forged Sentinel",
             "text": "Flying",
             "colours": [],
@@ -5453,7 +5453,7 @@
         },
         {
             "id": "0b527f6e-914b-5f23-9b3e-bf428c4796e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634fd988-5d5c-4637-b7fd-05a41798ead8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634fd988-5d5c-4637-b7fd-05a41798ead8.jpg?1",
             "name": "Hall of Triumph",
             "text": "As Hall of Triumph enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+1.",
             "colours": [],
@@ -5483,7 +5483,7 @@
         },
         {
             "id": "1e9e0cc1-7d8a-5adb-ba7d-1857078c4bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504a69eb-3c2d-4bb1-b117-252b15acf0c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504a69eb-3c2d-4bb1-b117-252b15acf0c2.jpg?1",
             "name": "Mana Confluence",
             "text": "{T}, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "782827da-a997-530c-ba18-51210b03b03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b882c6bf-b795-49fe-8242-a928aadb6f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b882c6bf-b795-49fe-8242-a928aadb6f13.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "3c58b880-5407-5d50-8f6c-77e848bf475e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30220f1-1992-4b5c-9e13-1762fb673155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30220f1-1992-4b5c-9e13-1762fb673155.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "f6fa1566-66f9-535e-90dd-5446b9519420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f1983-e9ac-47f0-836d-843a53c054cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74f1983-e9ac-47f0-836d-843a53c054cc.jpg?1",
             "name": "Sphinx",
             "text": "",
             "colours": [
@@ -5607,7 +5607,7 @@
         },
         {
             "id": "675dfee7-ab2e-5b06-9d0d-07e567aa9b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c59642-575f-4356-ae1a-20b90895545b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c59642-575f-4356-ae1a-20b90895545b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -5641,7 +5641,7 @@
         },
         {
             "id": "88185341-ad20-5d1b-acc3-edaf04f6dac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a3833-ab5b-4f84-b39c-d0eeb7b474d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2a3833-ab5b-4f84-b39c-d0eeb7b474d3.jpg?1",
             "name": "Minotaur",
             "text": "",
             "colours": [
@@ -5675,7 +5675,7 @@
         },
         {
             "id": "2429f52e-1661-533b-bc09-9bad24c35085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1af553-ec9f-46fd-9c6d-49436e93e682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1af553-ec9f-46fd-9c6d-49436e93e682.jpg?1",
             "name": "Hydra",
             "text": "",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "07cb6e21-be71-51ff-8686-2bc7387fda26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0275af-708d-4c43-b226-c88cb9a8054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0275af-708d-4c43-b226-c88cb9a8054c.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "316d0b61-ce39-5800-91b0-f047750e64f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5910a7f2-71a7-4e85-8feb-4a0da228eb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5910a7f2-71a7-4e85-8feb-4a0da228eb15.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/JUD.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/JUD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7a7e2e9b-93ad-5616-8e3f-ed53a06acfd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cf71e1-3c57-47f9-a4ef-e0d0ad1ee329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cf71e1-3c57-47f9-a4ef-e0d0ad1ee329.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "First strike\nWhen Ancestor's Chosen comes into play, you gain 1 life for each card in your graveyard.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "01c000d7-f083-528c-b410-cb0047909751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd5d21a-b151-4fea-ac0d-6659af131bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd5d21a-b151-4fea-ac0d-6659af131bf9.jpg?1",
             "name": "Aven Warcraft",
             "text": "Creatures you control get +0/+2 until end of turn.\nThreshold Creatures you control also gain protection from the color of your choice until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "ed6bc7a0-d1e6-5a0b-a8fb-12c993b2dd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c38264-0d79-47d4-bca2-a20a991bbac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c38264-0d79-47d4-bca2-a20a991bbac9.jpg?1",
             "name": "Battle Screech",
             "text": "Put two 1/1 white Bird creature tokens with flying into play.\nFlashback\u2014\nTap three untapped white creatures you control. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d5d0080a-9936-52c8-99bb-60e7a9acb853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca363409-cba9-43ed-bf88-3519521e1983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca363409-cba9-43ed-bf88-3519521e1983.jpg?1",
             "name": "Battlewise Aven",
             "text": "Flying\nThreshold Battlewise Aven gets +1/+1 and has first strike. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "6e47abf7-7a40-5f42-8e20-54bc36a6dd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22492fb3-5ceb-4d5e-ba82-ae1a6a69c105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22492fb3-5ceb-4d5e-ba82-ae1a6a69c105.jpg?1",
             "name": "Benevolent Bodyguard",
             "text": "Sacrifice Benevolent Bodyguard: Target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "c00ed446-053c-5fc2-aff0-766d9f762a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a85c8-3516-4dda-b16b-bf1bf890becb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a85c8-3516-4dda-b16b-bf1bf890becb.jpg?1",
             "name": "Border Patrol",
             "text": "Attacking doesn't cause Border Patrol to tap.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "5a20b5c3-0f24-5a4d-9af0-6c0f120f1522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ab91ab-2bcf-4617-bec3-2bf040d4997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ab91ab-2bcf-4617-bec3-2bf040d4997c.jpg?1",
             "name": "Cagemail",
             "text": "Enchanted creature gets +2/+2 and can't attack.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "03141537-5877-56c8-8bf3-e2e83dbd99d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1169dab7-8f4c-474d-9289-42765a275376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1169dab7-8f4c-474d-9289-42765a275376.jpg?1",
             "name": "Chastise",
             "text": "Destroy target attacking creature. You gain life equal to its power.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "896d66a4-57e2-5850-98cc-6f45ea9d0a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607f6a9-b8d2-4119-9f70-95dcedc0662d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607f6a9-b8d2-4119-9f70-95dcedc0662d.jpg?1",
             "name": "Commander Eesha",
             "text": "Flying, protection from creatures",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "ed26b57c-d705-5023-903f-645e00e54227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8542f6-ee34-42c6-acd5-07b0c7cc2f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8542f6-ee34-42c6-acd5-07b0c7cc2f63.jpg?1",
             "name": "Funeral Pyre",
             "text": "Remove target card in a graveyard from the game. Its owner puts a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "a7438ac8-0aba-5c4f-8e2b-71866b86887c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a414f0e-b157-4570-8213-1c58a96bf7a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a414f0e-b157-4570-8213-1c58a96bf7a5.jpg?1",
             "name": "Glory",
             "text": "Flying\no2o\nW: Creatures you control gain protection from the color of your choice until end of turn. Play this ability only if Glory is in your graveyard.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "90b8e495-1d89-5abb-be0c-8429906ab699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc409ded-41f3-4f14-8199-72a9fe98bac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc409ded-41f3-4f14-8199-72a9fe98bac0.jpg?1",
             "name": "Golden Wish",
             "text": "Choose an artifact or enchantment card you own from outside the game, reveal that card, and put it into your hand. Remove Golden Wish from the game.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "737bd22c-dfae-5a96-b016-4d1a5ab53b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13138c1-e98f-4803-8c68-ffc80139c168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13138c1-e98f-4803-8c68-ffc80139c168.jpg?1",
             "name": "Guided Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "0faaddc4-02e1-535c-a551-9d1c65f48b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a8fd2f-11fa-4879-be89-ea7833cf60d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a8fd2f-11fa-4879-be89-ea7833cf60d4.jpg?1",
             "name": "Lead Astray",
             "text": "Tap up to two target creatures.",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "a362d31b-1250-5864-bfa6-85cbb48c4efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5694fe-57d2-4359-857a-63213d986747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5694fe-57d2-4359-857a-63213d986747.jpg?1",
             "name": "Nomad Mythmaker",
             "text": "o\nW, oc\nT: Put target enchant creature card from a graveyard into play enchanting a creature you control. (You control that enchantment.)",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "67c87a40-e0f6-5139-964a-b3468a9eeb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617d4246-c827-4742-ab6a-c5170c12cb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617d4246-c827-4742-ab6a-c5170c12cb87.jpg?1",
             "name": "Phantom Flock",
             "text": "Flying\nPhantom Flock comes into play with three +1/+1 counters on it.\nIf damage would be dealt to Phantom Flock, prevent that damage. Remove a +1/+1 counter from Phantom Flock.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "b9fd7e91-c85b-5e6d-bd1f-79e611b6f1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5309f5-8b32-4a57-99f2-dcf7a8341898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5309f5-8b32-4a57-99f2-dcf7a8341898.jpg?1",
             "name": "Phantom Nomad",
             "text": "Phantom Nomad comes into play with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Nomad, prevent that damage. Remove a +1/+1 counter from Phantom Nomad.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "ef7a8ba7-fff4-5c5d-b64b-ced6e0f45a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3454ef42-2e0b-4ce4-945f-e4ec3e83c39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3454ef42-2e0b-4ce4-945f-e4ec3e83c39d.jpg?1",
             "name": "Prismatic Strands",
             "text": "Prevent all damage that sources of the color of your choice would deal this turn.\nFlashback\u2014\nTap an untapped white creature you control. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "5099e18d-5634-51b2-b92b-5f393fabc711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce0e8f-9ad6-42b6-af61-c883613efc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce0e8f-9ad6-42b6-af61-c883613efc97.jpg?1",
             "name": "Pulsemage Advocate",
             "text": "oc\nT: Return three target cards in an opponent's graveyard to his or her hand.  Return target creature card from your graveyard to play.",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "291037b6-e159-5013-952b-633fbf2ad9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d762c8c-6172-4dc0-8fcc-d0f6dd8ca013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d762c8c-6172-4dc0-8fcc-d0f6dd8ca013.jpg?1",
             "name": "Ray of Revelation",
             "text": "Destroy target enchantment.\nFlashback o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "61421ae5-b0ee-5e98-b6f7-73dfeba393ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1c300-aec3-4512-9902-309615e86c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b1c300-aec3-4512-9902-309615e86c73.jpg?1",
             "name": "Selfless Exorcist",
             "text": "oc\nT: Remove target creature card in a graveyard from the game. That card deals damage equal to its power to Selfless Exorcist. (A * on a card not in play is 0.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "71b0b715-3c69-5950-9494-3f00dd6d48c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea66a41-cb2e-49d6-81fe-3f69b0dfd40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea66a41-cb2e-49d6-81fe-3f69b0dfd40e.jpg?1",
             "name": "Shieldmage Advocate",
             "text": "oc\nT: Return target card in an opponent's graveyard to his or her hand. Prevent all damage that would be dealt to target creature or player this turn by a source of your choice.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "49185d7f-ff5a-5dbb-8ab0-4ed95dcc76db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1465ca9e-a997-4b8c-9677-6c7961f67eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1465ca9e-a997-4b8c-9677-6c7961f67eba.jpg?1",
             "name": "Silver Seraph",
             "text": "Flying\nThreshold Other creatures you control get +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "643ed0d6-0fc3-595a-8fd0-dd763dc03a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a8eb7a-eb3f-405e-8f44-d8ea64d76386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a8eb7a-eb3f-405e-8f44-d8ea64d76386.jpg?1",
             "name": "Solitary Confinement",
             "text": "At the beginning of your upkeep, sacrifice Solitary Confinement unless you discard a card from your hand.\nSkip your draw step.\nYou can't be the target of spells or abilities.\nPrevent all damage that would be dealt to you.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "2151bde1-c7e3-52a4-8ea0-8efc401004fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30df994-bb09-4d16-8443-223c6ce342dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30df994-bb09-4d16-8443-223c6ce342dc.jpg?1",
             "name": "Soulcatchers' Aerie",
             "text": "Whenever a Bird is put into your graveyard from play, put a feather counter on Soulcatchers' Aerie.\nAll Birds get +1/+1 for each feather counter on Soulcatchers' Aerie.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "0897ea48-4bb6-5e1f-b26d-1f67a3bf2adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8baf60f-c20b-4b2f-9fe1-df008a9273c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8baf60f-c20b-4b2f-9fe1-df008a9273c6.jpg?1",
             "name": "Spirit Cairn",
             "text": "Whenever a player discards a card from his or her hand, you may pay o\nW. If you do, put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "e5942620-dcbe-5cf4-a801-c89aa960c9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008c8d72-097e-472d-88c8-78bf29e42e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008c8d72-097e-472d-88c8-78bf29e42e32.jpg?1",
             "name": "Spurnmage Advocate",
             "text": "oc\nT: Return two target cards in an opponent's graveyard to his or her hand. Destroy target attacking creature.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "46c195e8-e30c-54b1-8bb5-6765eabf8bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbdae0b-b4aa-40ff-9017-b4349bd6b627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbdae0b-b4aa-40ff-9017-b4349bd6b627.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "6c4deccc-cc1a-5f4d-9a3a-0f9751bccb95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16bd6b-e99c-4da3-bd03-11f63b7ee85d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16bd6b-e99c-4da3-bd03-11f63b7ee85d.jpg?1",
             "name": "Test of Endurance",
             "text": "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "9c93bc58-8be0-57ef-b16d-21e7eef23d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ec745-226c-4211-974f-e04a4f9e1902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ec745-226c-4211-974f-e04a4f9e1902.jpg?1",
             "name": "Trained Pronghorn",
             "text": "Discard a card from your hand: Prevent all damage that would be dealt to Trained Pronghorn this turn.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "99215223-80c5-580c-8080-489c77376a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015205e-5895-4038-9c2f-ed4766c498ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015205e-5895-4038-9c2f-ed4766c498ff.jpg?1",
             "name": "Unquestioned Authority",
             "text": "When Unquestioned Authority comes into play, draw a card.\nEnchanted creature has protection from creatures.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "f1f72c0c-eade-5fe9-a9b8-b54ec4c6bdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58095f6b-d937-4871-b3af-5c6a1d9c04b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58095f6b-d937-4871-b3af-5c6a1d9c04b3.jpg?1",
             "name": "Valor",
             "text": "First strike\nAs long as Valor is in your graveyard and you control a plains, creatures you control have first strike.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "82644810-d000-53d9-b3c6-a054fe8010c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3790282-ea04-4600-8912-dac541ffd081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3790282-ea04-4600-8912-dac541ffd081.jpg?1",
             "name": "Vigilant Sentry",
             "text": "Threshold Vigilant Sentry gets +1/+1 and has \"oc\nT: Target attacking or blocking creature gets +3/+3 until end of turn.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1118,7 +1118,7 @@
         },
         {
             "id": "440b861f-e5c3-5d57-bcea-1598f5065f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee9e09-c4b1-4133-90a3-350677f0b72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ee9e09-c4b1-4133-90a3-350677f0b72a.jpg?1",
             "name": "Aven Fogbringer",
             "text": "Flying\nWhen Aven Fogbringer comes into play, return target land to its owner's hand.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "01addd4f-0150-5053-93a2-9ff979ffa8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d98f05b-ddfe-4b93-b247-dbd1a89e0731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d98f05b-ddfe-4b93-b247-dbd1a89e0731.jpg?1",
             "name": "Cephalid Constable",
             "text": "Whenever Cephalid Constable deals combat damage to a player, return up to X target permanents that player controls to their owners' hands, where X is the damage it dealt to that player.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "3f3904ec-bb64-5939-8cff-5949a8328342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3e8c80-690b-4d79-9dee-99d1a3876160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3e8c80-690b-4d79-9dee-99d1a3876160.jpg?1",
             "name": "Cephalid Inkshrouder",
             "text": "Discard a card from your hand: Cephalid Inkshrouder can't be the target of spells or abilities and is unblockable this turn.",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "68626111-485b-57d5-9ff4-e7ee0fa10005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca097675-5e82-493d-beab-9fc11efd7492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca097675-5e82-493d-beab-9fc11efd7492.jpg?1",
             "name": "Cunning Wish",
             "text": "Choose an instant card you own from outside the game, reveal that card, and put it into your hand. Remove Cunning Wish from the game.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "fe1bb942-926d-5ec1-a9b5-f3120307331d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461413fe-0392-41c1-b50f-05e87ea1c338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461413fe-0392-41c1-b50f-05e87ea1c338.jpg?1",
             "name": "Defy Gravity",
             "text": "Target creature gains flying until end of turn.\nFlashback o\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "719a5b65-a9e3-5ccf-8932-c0b6adb9dd51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ed250e-12d0-4ebc-9410-5711e71c6d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ed250e-12d0-4ebc-9410-5711e71c6d1f.jpg?1",
             "name": "Envelop",
             "text": "Counter target sorcery spell.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "7796a097-7b69-5ba8-bfce-10fd15291fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaab905-0b97-42c2-a1a3-1e72275caa82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaab905-0b97-42c2-a1a3-1e72275caa82.jpg?1",
             "name": "Flash of Insight",
             "text": "Look at the top X cards of your library. Put one of them into your hand and the rest on the bottom of your library.\nFlashback\u2014o1o\nU, Remove X blue cards in your graveyard from the game. (You can't remove Flash of Insight to pay for its own flashback cost.)",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "3c89e06a-8a7e-5e00-8e8f-3f0771f04fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc7e2a-5b9b-4f0f-8b2e-a7c7f847e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc7e2a-5b9b-4f0f-8b2e-a7c7f847e1f1.jpg?1",
             "name": "Grip of Amnesia",
             "text": "Counter target spell unless its controller removes his or her graveyard from the game.\nDraw a card.",
             "colours": [
@@ -1382,7 +1382,7 @@
         },
         {
             "id": "61ec1a1f-ea3d-5800-9102-d67a5d1f4020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ed0ee7-6749-4f38-8e53-c11b46b17e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ed0ee7-6749-4f38-8e53-c11b46b17e5d.jpg?1",
             "name": "Hapless Researcher",
             "text": "Sacrifice Hapless Researcher: Draw a card, then discard a card from your hand.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "1a346e5b-1d30-5b81-8021-daddc0f6a57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e702ee4-62b5-4d3b-a202-8cac4b84591c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e702ee4-62b5-4d3b-a202-8cac4b84591c.jpg?1",
             "name": "Keep Watch",
             "text": "Draw a card for each attacking creature.",
             "colours": [
@@ -1449,7 +1449,7 @@
         },
         {
             "id": "00a39a4c-05f5-5ee3-af89-68cfe4e10fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ea5448-2d72-42eb-814c-197153d8e06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ea5448-2d72-42eb-814c-197153d8e06a.jpg?1",
             "name": "Laquatus's Disdain",
             "text": "Counter target spell played from a graveyard.\nDraw a card.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "1bc2fa3d-e3a5-54a2-b78e-96a781e06eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fb391a-2687-461d-b5ef-a494287ddb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5fb391a-2687-461d-b5ef-a494287ddb5d.jpg?1",
             "name": "Lost in Thought",
             "text": "Enchanted creature can't attack or block and its activated abilities can't be played. Its controller may remove three cards in his or her graveyard from the game to ignore this ability until end of turn.",
             "colours": [
@@ -1515,7 +1515,7 @@
         },
         {
             "id": "f5173f9d-bab5-567d-a0d2-e1607b5e911e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f343724-6ecd-494f-8bfc-93676af4e173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f343724-6ecd-494f-8bfc-93676af4e173.jpg?1",
             "name": "Mental Note",
             "text": "Put the top two cards of your library into your graveyard.\nDraw a card.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "711cf147-b2b1-584b-bf01-f7ae82ae8aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e52b73-ebdf-4339-8780-84327a59ca57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e52b73-ebdf-4339-8780-84327a59ca57.jpg?1",
             "name": "Mirror Wall",
             "text": "(Walls can't attack.)\no\nW: Mirror Wall may attack this turn as though it weren't a Wall.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "fb81f19b-c854-5d5e-a544-bbcaaec6dbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d03121-9515-4101-9d60-e01225533f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d03121-9515-4101-9d60-e01225533f44.jpg?1",
             "name": "Mist of Stagnation",
             "text": "Permanents don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player untaps a permanent for each card in his or her graveyard.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "cdfdd998-cc0d-5f1f-987a-eac5642622d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a314fa-293b-486f-95d8-267d340e4d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a314fa-293b-486f-95d8-267d340e4d8e.jpg?1",
             "name": "Quiet Speculation",
             "text": "Search target player's library for up to three cards with flashback and put them into that player's graveyard. Then the player shuffles his or her library.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "44eb6589-2d32-5b91-8dc8-16bbbef6570e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3b7fa-78e7-4a0c-bcdc-4b829638e3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c3b7fa-78e7-4a0c-bcdc-4b829638e3f6.jpg?1",
             "name": "Scalpelexis",
             "text": "Flying\nWhenever Scalpelexis deals combat damage to a player, that player removes the top four cards of his or her library from the game. If two or more of those cards have the same name, repeat this process.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "9a4409eb-2cad-5a0a-875e-8052622a2ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eda8c7b-ce35-482a-bece-52a30cc78a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eda8c7b-ce35-482a-bece-52a30cc78a9a.jpg?1",
             "name": "Spelljack",
             "text": "Counter target spell. If it's countered this way, remove it from the game instead of putting it into its owner's graveyard. As long as it remains removed from the game, you may play it as though it were in your hand without paying its mana cost. If it has X in its mana cost, X is 0.",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "23c6e83b-728a-5b5b-b4d0-74e35cec93c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fad1d-a517-433a-b939-d0635e8f5535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fad1d-a517-433a-b939-d0635e8f5535.jpg?1",
             "name": "Telekinetic Bonds",
             "text": "Whenever a player discards a card from his or her hand, you may pay o1o\nU. If you do, tap or untap target permanent.",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "6a70f792-4bf7-5ab6-b2bf-8d7a1692b0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6d2721-1dfc-4f4f-a914-9352ca6981c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6d2721-1dfc-4f4f-a914-9352ca6981c0.jpg?1",
             "name": "Web of Inertia",
             "text": "At the beginning of each opponent's combat phase, that player may remove a card in his or her graveyard from the game. If the player doesn't, creatures he or she controls can't attack you this turn.",
             "colours": [
@@ -1776,7 +1776,7 @@
         },
         {
             "id": "622bd240-9967-590a-89b1-4ba908cb94d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44670666-9028-4b4a-a5af-a3bf35fc6a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44670666-9028-4b4a-a5af-a3bf35fc6a21.jpg?1",
             "name": "Wonder",
             "text": "Flying\nAs long as Wonder is in your graveyard and you control an island, creatures you control have flying.",
             "colours": [
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "072b032c-e6cd-5253-89bf-31ca6b67f713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7f29aa-c069-4adb-b313-6a56849905d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7f29aa-c069-4adb-b313-6a56849905d4.jpg?1",
             "name": "Wormfang Behemoth",
             "text": "When Wormfang Behemoth comes into play, remove all cards in your hand from the game.\nWhen Wormfang Behemoth leaves play, return the removed cards to their owner's hand.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "194fe638-d45e-52d1-94e2-d3442bcbb428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf56dcf-ec1a-4298-8644-1fe248443b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf56dcf-ec1a-4298-8644-1fe248443b7e.jpg?1",
             "name": "Wormfang Crab",
             "text": "Wormfang Crab is unblockable.\nWhen Wormfang Crab comes into play, an opponent chooses a permanent you control and removes it from the game.\nWhen Wormfang Crab leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1881,7 +1881,7 @@
         },
         {
             "id": "b2396bb8-c1d4-5a28-b821-44b8ded36ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6afd312-6448-4bd1-8539-0910cefead0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6afd312-6448-4bd1-8539-0910cefead0d.jpg?1",
             "name": "Wormfang Drake",
             "text": "Flying\nWhen Wormfang Drake comes into play, sacrifice it unless you remove a creature you control other than Wormfang Drake from the game.\nWhen Wormfang Drake leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1916,7 +1916,7 @@
         },
         {
             "id": "b445ad8c-e598-5349-86c6-e8573257ec0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bf91d-6f7c-4fb5-bbc6-c012212e62e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bf91d-6f7c-4fb5-bbc6-c012212e62e9.jpg?1",
             "name": "Wormfang Manta",
             "text": "Flying\nWhen Wormfang Manta comes into play, you skip your next turn.\nWhen Wormfang Manta leaves play, you take an extra turn after this one.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "2af801f0-9fc3-5001-ba08-391469ecd106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8012c1-76ec-4c36-8b38-5bc41ce5e156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8012c1-76ec-4c36-8b38-5bc41ce5e156.jpg?1",
             "name": "Wormfang Newt",
             "text": "When Wormfang Newt comes into play, remove a land you control from the game.\nWhen Wormfang Newt leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "d23caf34-9ea4-5a2d-a8db-e16b1ea430e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48404362-7579-4896-a71a-8eb40e5ac416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48404362-7579-4896-a71a-8eb40e5ac416.jpg?1",
             "name": "Wormfang Turtle",
             "text": "When Wormfang Turtle comes into play, remove a land you control from the game.\nWhen Wormfang Turtle leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "053098a5-f78e-578e-a299-f0f30e97c1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4cc273-adc3-4f46-9743-134b552d1d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4cc273-adc3-4f46-9743-134b552d1d56.jpg?1",
             "name": "Balthor the Defiled",
             "text": "All Minions get +1/+1.\no\nBo\nBo\nB, Remove Balthor the Defiled from the game: Each player returns all black and all red creature cards from his or her graveyard to play.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "f9ccee15-8fd3-5c09-a17c-60e4f46df39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5df970-c6ba-4824-b8ba-67244aec2b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5df970-c6ba-4824-b8ba-67244aec2b82.jpg?1",
             "name": "Cabal Therapy",
             "text": "Name a nonland card. Target player reveals his or her hand and discards from it all cards with that name.\nFlashback\u2014\nSacrifice a creature. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "24da3a0b-7d07-5a57-9bc4-df56eecdfd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345d702-b205-4391-985a-6201e707f0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d345d702-b205-4391-985a-6201e707f0ba.jpg?1",
             "name": "Cabal Trainee",
             "text": "Sacrifice Cabal Trainee: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "aca2c582-8b97-58cc-91ca-f7fb1309967b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf134c9-a50d-4eff-a5a8-7cfe6a010080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf134c9-a50d-4eff-a5a8-7cfe6a010080.jpg?1",
             "name": "Death Wish",
             "text": "Choose a card you own from outside the game and put it into your hand. You lose half your life, rounded up. Remove Death Wish from the game.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "e1845684-358b-52c4-814b-aabcd8a5a99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dad63b5-ced3-4150-ad84-1ca05a892840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dad63b5-ced3-4150-ad84-1ca05a892840.jpg?1",
             "name": "Earsplitting Rats",
             "text": "When Earsplitting Rats comes into play, each player discards a card from his or her hand.\nDiscard a card from your hand: Regenerate Earsplitting Rats.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "23f05bb8-3ef5-5753-b3dd-8238764ed899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37de06dc-c0c1-4edb-9732-2d16dbabfb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37de06dc-c0c1-4edb-9732-2d16dbabfb31.jpg?1",
             "name": "Filth",
             "text": "Swampwalk\nAs long as Filth is in your graveyard and you control a swamp, creatures you control have swampwalk.",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "625e6a02-ba01-5f38-946e-f84899eb63ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad5f9f2-282a-4ee0-a259-cc24404ddf6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad5f9f2-282a-4ee0-a259-cc24404ddf6f.jpg?1",
             "name": "Grave Consequences",
             "text": "Each player may remove any number of cards in his or her graveyard from the game. Then each player loses 1 life for each card in his or her graveyard.\nDraw a card.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "5af2c2a5-1d6b-515f-a8b4-ca70a5ce4fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e9af4e-bd02-4d91-898f-68d192446904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e9af4e-bd02-4d91-898f-68d192446904.jpg?1",
             "name": "Guiltfeeder",
             "text": "Guiltfeeder can't be blocked except by artifact creatures and/or black creatures.\nWhenever Guiltfeeder attacks and isn't blocked, defending player loses 1 life for each card in his or her graveyard.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "65412394-3815-5c46-bd76-8c4e82f2640a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62728b-b834-4fa8-aed5-6348033ee69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d62728b-b834-4fa8-aed5-6348033ee69c.jpg?1",
             "name": "Masked Gorgon",
             "text": "Green creatures and white creatures have protection from Gorgons.\nThreshold Masked Gorgon has protection from green and from white. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2328,7 +2328,7 @@
         },
         {
             "id": "1445cbde-08a6-518b-8631-20352639de86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c83e4d-ccc1-4ebf-9e74-2cc1ff9a7b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c83e4d-ccc1-4ebf-9e74-2cc1ff9a7b07.jpg?1",
             "name": "Morality Shift",
             "text": "Exchange your graveyard and library. Then shuffle your library.",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "0f355726-a3cd-5ddd-b251-92475937f315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b243ce02-4fff-444c-acc4-e1a199621a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b243ce02-4fff-444c-acc4-e1a199621a53.jpg?1",
             "name": "Rats' Feast",
             "text": "Remove X target cards in a single graveyard from the game.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "df30a48e-a6af-5a30-865c-f4ec6939b90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6172-2400-4038-8b8b-c62f2fbfce39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43c6172-2400-4038-8b8b-c62f2fbfce39.jpg?1",
             "name": "Stitch Together",
             "text": "Return target creature card from your graveyard to your hand.\nThreshold Instead return that card from your graveyard to play. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "db696a05-394b-5767-b9e7-12e3accefc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f769536f-def1-40b8-863f-ba12c7cb0d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f769536f-def1-40b8-863f-ba12c7cb0d87.jpg?1",
             "name": "Sutured Ghoul",
             "text": "Trample\nAs Sutured Ghoul comes into play, remove any number of creature cards in your graveyard from the game.\nSutured Ghoul's power is equal to the total power of the removed cards and its toughness is equal to their total toughness. (A * on a card not in play is 0.)",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "6cde041f-b8b2-562a-90d7-340e6fb41ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d1f59-0dba-4b83-8386-ae564fb4b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4d1f59-0dba-4b83-8386-ae564fb4b771.jpg?1",
             "name": "Toxic Stench",
             "text": "Target nonblack creature gets -1/-1 until end of turn.\nThreshold Instead destroy that creature. It can't be regenerated. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "df811622-5d3f-559f-9406-7b898ef4d56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00562ae-b8b4-4f8f-8ea8-15d20568997d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00562ae-b8b4-4f8f-8ea8-15d20568997d.jpg?1",
             "name": "Treacherous Vampire",
             "text": "Flying\nWhenever Treacherous Vampire attacks or blocks, sacrifice it unless you remove a card in your graveyard from the game.\nThreshold Treacherous Vampire gets +2/+2 and has \"When Treacherous Vampire is put into a graveyard from play, you lose 6 life.\"",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "20a87733-3d64-5492-bd63-263f1de9e962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9647726-302b-4fc4-91d7-2aa0bba0b653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9647726-302b-4fc4-91d7-2aa0bba0b653.jpg?1",
             "name": "Treacherous Werewolf",
             "text": "Threshold Treacherous Werewolf gets +2/+2 and has \"When Treacherous Werewolf is put into a graveyard from play, you lose 4 life.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "91d7e0ce-339b-5c90-8583-7b966baa89c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2920af-e6a1-4939-ab59-67af4430e5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2920af-e6a1-4939-ab59-67af4430e5b8.jpg?1",
             "name": "Anger",
             "text": "Haste\nAs long as Anger is in your graveyard and you control a mountain, creatures you control have haste.",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "9e467003-0ded-5220-85ad-c5a2d31fdfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c56677-c8e2-4500-9ee0-0b102496f454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c56677-c8e2-4500-9ee0-0b102496f454.jpg?1",
             "name": "Arcane Teachings",
             "text": "Enchanted creature gets +2/+2 and has \"oc\nT: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "9cbf931d-9df0-50d0-885f-0d0b36286a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38f0f9f-ad7b-48da-89f3-b3e5346a3b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38f0f9f-ad7b-48da-89f3-b3e5346a3b71.jpg?1",
             "name": "Barbarian Bully",
             "text": "Discard a card at random from your hand: Barbarian Bully gets +2/+2 until end of turn unless a player has Barbarian Bully deal 4 damage to him or her. Play this ability only once each turn.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "8abb1ade-7f72-53d9-8212-ff84bc144f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead678c-7b6a-4668-9919-623312e08a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead678c-7b6a-4668-9919-623312e08a65.jpg?1",
             "name": "Book Burning",
             "text": "Unless a player has Book Burning deal 6 damage to him or her, put the top six cards of target player's library into his or her graveyard.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "7a37aa81-7c88-5932-a6d7-f6d07c88d2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765ec2c9-8ffe-488a-bebe-e5dd63825a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765ec2c9-8ffe-488a-bebe-e5dd63825a8c.jpg?1",
             "name": "Breaking Point",
             "text": "Destroy all creatures unless a player has Breaking Point deal 6 damage to him or her. Creatures destroyed this way can't be regenerated.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "a6d9549a-a329-5b13-b815-3acbb3288127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f20068-f225-4055-be7a-5c4a18e33b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f20068-f225-4055-be7a-5c4a18e33b0b.jpg?1",
             "name": "Browbeat",
             "text": "Unless a player has Browbeat deal 5 damage to him or her, target player draws three cards.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "e6cf6ff3-1d24-5e3b-9651-395b111fdbdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9b692a-e832-4612-a6ec-93b52f6a0410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9b692a-e832-4612-a6ec-93b52f6a0410.jpg?1",
             "name": "Burning Wish",
             "text": "Choose a sorcery card you own from outside the game, reveal that card, and put it into your hand. Remove Burning Wish from the game.",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "c1bddc1f-9587-5c76-8ac5-a7e4c2bc85ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac576b2-cda4-4aea-aa5c-933ec0457dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac576b2-cda4-4aea-aa5c-933ec0457dda.jpg?1",
             "name": "Dwarven Bloodboiler",
             "text": "Tap an untapped Dwarf you control: Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "02bd7cd3-668e-56c7-bec0-230c4abf8215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d815d3-7e33-4de9-aa36-ff5ffb893d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d815d3-7e33-4de9-aa36-ff5ffb893d73.jpg?1",
             "name": "Dwarven Driller",
             "text": "oc\nT: Destroy target land unless its controller has Dwarven Driller deal 2 damage to him or her.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "4f06d306-462c-5bb3-a410-66692964f94c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099873b1-7181-4b9d-8ce1-8ec63c814afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099873b1-7181-4b9d-8ce1-8ec63c814afe.jpg?1",
             "name": "Dwarven Scorcher",
             "text": "Sacrifice Dwarven Scorcher: Dwarven Scorcher deals 1 damage to target creature unless that creature's controller has Dwarven Scorcher deal 2 damage to him or her.",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "8bf8c0f7-bdee-5748-827b-92f492f4f846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9eb72b-9ae2-4b64-bbb9-187446b5fd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9eb72b-9ae2-4b64-bbb9-187446b5fd2f.jpg?1",
             "name": "Ember Shot",
             "text": "Ember Shot deals 3 damage to target creature or player.\nDraw a card.",
             "colours": [
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "cb093ab4-635b-5ee4-b28c-e886af80ada5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e1d485-02d5-4a07-bcc6-d2a8d95763e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e1d485-02d5-4a07-bcc6-d2a8d95763e8.jpg?1",
             "name": "Firecat Blitz",
             "text": "Put X 1/1 red Cat creature tokens with haste into play. Remove them from the game at end of turn.\nFlashback\u2014o\nRo\nR, Sacrifice X mountains. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "cd0fb2f4-32b9-5739-8fd1-45373a8bf5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb5c96a-1d16-459d-9968-ced9a8f1c520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb5c96a-1d16-459d-9968-ced9a8f1c520.jpg?1",
             "name": "Flaring Pain",
             "text": "Damage can't be prevented this turn.\nFlashback o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "37c0e137-e376-5b42-9fae-1e342498801c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e5b4e-ae58-412a-be27-c4ef4899fbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e5b4e-ae58-412a-be27-c4ef4899fbbd.jpg?1",
             "name": "Fledgling Dragon",
             "text": "Flying\nThreshold Fledgling Dragon gets +3/+3 and has \"o\nR: Fledgling Dragon gets +1/+0 until end of turn.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "06a1c206-b968-5e39-b2d0-68ec7451e28f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919d2dd-d6a1-4d45-b6aa-227ed05d7051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919d2dd-d6a1-4d45-b6aa-227ed05d7051.jpg?1",
             "name": "Goretusk Firebeast",
             "text": "When Goretusk Firebeast comes into play, it deals 4 damage to target player.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "c968f289-ad5f-533e-a8c8-c8d1e1ebd9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8569cdf7-e0e9-4733-98b5-56fac216fad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8569cdf7-e0e9-4733-98b5-56fac216fad3.jpg?1",
             "name": "Infectious Rage",
             "text": "Enchanted creature gets +2/-1.\nWhen enchanted creature is put into a graveyard, choose a creature at random Infectious Rage can enchant. Return Infectious Rage to play enchanting that creature.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "cf1a3802-786c-5418-992c-e1131263d85d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf96a59-8b7d-4a5b-adfd-17eeedd95db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf96a59-8b7d-4a5b-adfd-17eeedd95db5.jpg?1",
             "name": "Jeska, Warrior Adept",
             "text": "First strike, haste\noc\nT: Jeska, Warrior Adept deals 1 damage to target creature or player.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "a04d8985-a9f5-526a-8203-e04ef0c6b730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865bb1d3-5b7d-40e9-87cc-96be9524a105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865bb1d3-5b7d-40e9-87cc-96be9524a105.jpg?1",
             "name": "Lava Dart",
             "text": "Lava Dart deals 1 damage to target creature or player.\nFlashback\u2014\nSacrifice a mountain. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "cccad65c-b324-58bd-a396-1de036fb64a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c07842-9b70-40b1-9b97-9a9279b7ebc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c07842-9b70-40b1-9b97-9a9279b7ebc4.jpg?1",
             "name": "Liberated Dwarf",
             "text": "o\nR, Sacrifice Liberated Dwarf: Target green creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "3a542300-84b9-5c88-b326-b0fa78a3ef93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452d78d-eafc-4ccb-a478-d1f46bcefffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0452d78d-eafc-4ccb-a478-d1f46bcefffe.jpg?1",
             "name": "Lightning Surge",
             "text": "Lightning Surge deals 4 damage to target creature or player.\nThreshold Instead Lightning Surge deals 6 damage to that creature or player and the damage can't be prevented.\nFlashback o5o\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "4513df8b-c3b9-5f34-b5e1-4eb377fb12f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae5e16-d2fc-488c-9c53-d35c377d6a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae5e16-d2fc-488c-9c53-d35c377d6a00.jpg?1",
             "name": "Planar Chaos",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, sacrifice Planar Chaos.\nWhenever a player plays a spell, that player flips a coin. If he or she loses the flip, counter that spell.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "07c30dd5-3d86-5c7c-bcae-6621d1191954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc33a4f-9ec2-4324-82a1-a4b9700572f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc33a4f-9ec2-4324-82a1-a4b9700572f2.jpg?1",
             "name": "Shaman's Trance",
             "text": "Until end of turn, other players can't play cards from their graveyards, and you may play cards from other players' graveyards as though they were in your graveyard.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "c0875fca-2af2-5906-82a4-e2127b52cc67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aef55b8-5813-4aff-a35d-4b3cbd4a9ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aef55b8-5813-4aff-a35d-4b3cbd4a9ffb.jpg?1",
             "name": "Soulgorger Orgg",
             "text": "Trample\nWhen Soulgorger Orgg comes into play, you lose all but 1 life.\nWhen Soulgorger Orgg leaves play, you gain life equal to the life you lost when it came into play.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "db76df95-a913-5746-a820-10246482fa1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043fcf80-dd20-4cc2-a0d5-4bb22b8b0789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043fcf80-dd20-4cc2-a0d5-4bb22b8b0789.jpg?1",
             "name": "Spellgorger Barbarian",
             "text": "When Spellgorger Barbarian comes into play, discard a card at random from your hand.\nWhen Spellgorger Barbarian leaves play, draw a card.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "c0d6d35d-a381-534c-9bbe-d6e8459558c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f667c26-40f5-4ac5-87a4-cb03f70590a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f667c26-40f5-4ac5-87a4-cb03f70590a2.jpg?1",
             "name": "Swelter",
             "text": "Swelter deals 2 damage to each of two target creatures.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "e6f46738-e24b-5de4-8af1-0127e43caa37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d757ec3-c15f-4d6e-8e18-36ebae985448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d757ec3-c15f-4d6e-8e18-36ebae985448.jpg?1",
             "name": "Swirling Sandstorm",
             "text": "Threshold Swirling Sandstorm deals 5 damage to each creature without flying. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "7c9ef54a-a0e6-598a-a372-b57929407cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99783a2b-a95a-457b-82d6-001933aee5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99783a2b-a95a-457b-82d6-001933aee5ec.jpg?1",
             "name": "Worldgorger Dragon",
             "text": "Flying, trample\nWhen Worldgorger Dragon comes into play, remove all other permanents you control from the game.\nWhen Worldgorger Dragon leaves play, return the removed cards to play under their owners' control.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "c814b7ac-6b6a-50a4-be59-6d2fe8eb9b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33255dfd-f8a9-4a15-aac5-c53dc0257859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33255dfd-f8a9-4a15-aac5-c53dc0257859.jpg?1",
             "name": "Anurid Barkripper",
             "text": "Threshold Anurid Barkripper gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "7d58689a-f636-5b39-a189-31c9f818acca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3636a9f8-d1d7-4452-8a53-788b514fdb97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3636a9f8-d1d7-4452-8a53-788b514fdb97.jpg?1",
             "name": "Anurid Swarmsnapper",
             "text": "Anurid Swarmsnapper may block as though it had flying.\no1o\nG: Anurid Swarmsnapper may block an additional creature this turn.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "65f17551-f79e-541c-b7aa-2da05ec3d038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac74bc-1198-4a9a-bcde-668cca08b274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ac74bc-1198-4a9a-bcde-668cca08b274.jpg?1",
             "name": "Battlefield Scrounger",
             "text": "Threshold Put three cards from your graveyard on the bottom of your library: Battlefield Scrounger gets +3/+3 until end of turn. Play this ability only once each turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "c72ec57d-e51f-568f-8e61-20f3b69925b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f4b7fc-8793-43af-ade3-b23846a80457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f4b7fc-8793-43af-ade3-b23846a80457.jpg?1",
             "name": "Brawn",
             "text": "Trample\nAs long as Brawn is in your graveyard and you control a forest, creatures you control have trample.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "d5d3c5a2-eec6-5a69-8018-3807881714df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4530da2-fd04-40d9-ad69-5c2847921509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4530da2-fd04-40d9-ad69-5c2847921509.jpg?1",
             "name": "Canopy Claws",
             "text": "Target creature loses flying until end of turn.\nFlashback o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "d62b675d-c7c9-57fd-a758-39440ed2519c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f10dfd9-9889-4d9e-872a-07623dee6b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f10dfd9-9889-4d9e-872a-07623dee6b6b.jpg?1",
             "name": "Centaur Rootcaster",
             "text": "Whenever Centaur Rootcaster deals combat damage to a player, you may search your library for a basic land card and put that card into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "826d0b2e-0fbf-5b08-afe2-e6f23c9af25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a924b3-3bd6-43ad-acbd-1303dd670db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a924b3-3bd6-43ad-acbd-1303dd670db4.jpg?1",
             "name": "Crush of Wurms",
             "text": "Put three 6/6 green Wurm creature tokens into play.\nFlashback o9o\nGo\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "58a5553c-77a7-5438-b1a0-8873c8172172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3a7226-f574-430e-9b8f-4e531a21540f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3a7226-f574-430e-9b8f-4e531a21540f.jpg?1",
             "name": "Elephant Guide",
             "text": "Enchanted creature gets +3/+3.\nWhen enchanted creature is put into a graveyard, put a 3/3 green Elephant creature token into play.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "2609efb1-c26a-59dc-aa13-196faca5ce84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc71f6f-f831-409e-aafd-3fa82a318e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc71f6f-f831-409e-aafd-3fa82a318e72.jpg?1",
             "name": "Epic Struggle",
             "text": "At the beginning of your upkeep, if you control twenty or more creatures, you win the game.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "0ad0ebf6-53a3-596d-a786-c773b4bb4da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcf61ba-37fd-4029-b299-add7cf9d70bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcf61ba-37fd-4029-b299-add7cf9d70bc.jpg?1",
             "name": "Erhnam Djinn",
             "text": "At the beginning of your upkeep, target non-Wall creature an opponent controls gains forestwalk until your next upkeep.",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "e0fd73c1-303d-5b8d-a3e4-e18c97b00a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e111fcab-17f7-4a02-b4eb-606ba18812b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e111fcab-17f7-4a02-b4eb-606ba18812b3.jpg?1",
             "name": "Exoskeletal Armor",
             "text": "Enchanted creature gets +X/+X, where X is the number of creature cards in all graveyards.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "bee95889-b188-5a01-a635-1b6046589137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751bd716-5352-41d7-89fb-d5f100f6646b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751bd716-5352-41d7-89fb-d5f100f6646b.jpg?1",
             "name": "Folk Medicine",
             "text": "You gain 1 life for each creature you control.\nFlashback o1o\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "1a04576f-aee3-5287-b0d4-0323c73e364f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad217fe-9309-4c67-8a6a-cfb8b1ce91f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad217fe-9309-4c67-8a6a-cfb8b1ce91f1.jpg?1",
             "name": "Forcemage Advocate",
             "text": "oc\nT: Return target card in an opponent's graveyard to his or her hand. Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "5cee42fb-7749-55f5-88b2-4c7ba4cd9da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43aee5e-b12e-43ea-9fae-16310acdc640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43aee5e-b12e-43ea-9fae-16310acdc640.jpg?1",
             "name": "Genesis",
             "text": "At the beginning of your upkeep, if Genesis is in your graveyard, you may pay o2o\nG. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "3e9d4b09-ced5-58be-b29a-f0a27266d7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c402ef0e-51e7-4da6-a434-b99c5d435698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c402ef0e-51e7-4da6-a434-b99c5d435698.jpg?1",
             "name": "Giant Warthog",
             "text": "Trample",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "c7c64803-ae75-58b2-800e-b8cee8b41308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d23432-6181-44c3-8d36-d7632a8a329f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d23432-6181-44c3-8d36-d7632a8a329f.jpg?1",
             "name": "Grizzly Fate",
             "text": "Put two 2/2 green Bear creature tokens into play.\nThreshold Instead put four 2/2 green Bear creature tokens into play.\nFlashback o5o\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "f516c108-df9c-58ae-a656-3e6ff48f692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97337e6e-1b3f-43a2-91f2-ca8f6c5dea88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97337e6e-1b3f-43a2-91f2-ca8f6c5dea88.jpg?1",
             "name": "Harvester Druid",
             "text": "oc\nT: Add to your mana pool one mana of any color that a land you control could produce.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "b4b7f1c1-f9bb-5428-a39b-7ea4b92d04d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9299cc-6f21-4185-ac63-2fd92e843faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9299cc-6f21-4185-ac63-2fd92e843faa.jpg?1",
             "name": "Ironshell Beetle",
             "text": "When Ironshell Beetle comes into play, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "83578199-11b6-583f-b246-64d74205c2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c5144-7e15-46c6-b819-d729ecb30bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c5144-7e15-46c6-b819-d729ecb30bb1.jpg?1",
             "name": "Krosan Reclamation",
             "text": "Target player shuffles up to two target cards from his or her graveyard into his or her library.\nFlashback o1o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "404eb72f-c3da-57a4-a362-ffac2b6d64db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356e684-c2fc-465e-a16c-7300824d2a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5356e684-c2fc-465e-a16c-7300824d2a8d.jpg?1",
             "name": "Krosan Wayfarer",
             "text": "Sacrifice Krosan Wayfarer: Put a land card from your hand into play.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "77feda65-5bc2-59a1-972c-6b474644c4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2478a8d2-ca44-4c42-8d75-dd9cb1b59f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2478a8d2-ca44-4c42-8d75-dd9cb1b59f61.jpg?1",
             "name": "Living Wish",
             "text": "Choose a creature or land card you own from outside the game, reveal that card, and put it into your hand. Remove Living Wish from the game.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "eaa286d4-1c0e-5902-b163-df67e4fc2a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b93c93-5944-4289-bc5a-30b6e73b0dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b93c93-5944-4289-bc5a-30b6e73b0dfd.jpg?1",
             "name": "Nantuko Tracer",
             "text": "When Nantuko Tracer comes into play, you may put target card from a graveyard on the bottom of its owner's library.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "e2e49da7-53e0-5196-92ff-73d8ea9513d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c29991d-82f2-479d-95ca-5c88e9f3f219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c29991d-82f2-479d-95ca-5c88e9f3f219.jpg?1",
             "name": "Nullmage Advocate",
             "text": "oc\nT: Return two target cards in an opponent's graveyard to his or her hand. Destroy target artifact or enchantment.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "922b25d8-875c-5058-b6fd-8b398d23ca4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c421c2f1-2137-41bd-9a89-74d8a76fb5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c421c2f1-2137-41bd-9a89-74d8a76fb5c5.jpg?1",
             "name": "Phantom Centaur",
             "text": "Protection from black\nPhantom Centaur comes into play with three +1/+1 counters on it.\nIf damage would be dealt to Phantom Centaur, prevent that damage. Remove a +1/+1 counter from Phantom Centaur.",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "b92bd98a-19e3-59ef-a0e0-54363c2c8755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ca45-b60f-4bb9-9f7e-1b5e13478f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ca45-b60f-4bb9-9f7e-1b5e13478f22.jpg?1",
             "name": "Phantom Nantuko",
             "text": "Trample\nPhantom Nantuko comes into play with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Nantuko, prevent that damage. Remove a +1/+1 counter from Phantom Nantuko.\noc\nT: Put a +1/+1 counter on Phantom Nantuko.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "25c9f3f2-3dab-51e2-9f54-16594b391755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32839296-e583-4f71-aa44-dbe16408665e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32839296-e583-4f71-aa44-dbe16408665e.jpg?1",
             "name": "Phantom Tiger",
             "text": "Phantom Tiger comes into play with two +1/+1 counters on it.\nIf damage would be dealt to Phantom Tiger, prevent that damage. Remove a +1/+1 counter from Phantom Tiger.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "eb9bc7dc-5705-56a0-aee2-f186386e716d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5c52-f260-400c-b088-8792282509a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5c52-f260-400c-b088-8792282509a5.jpg?1",
             "name": "Seedtime",
             "text": "Play Seedtime only during your turn.\nTake an extra turn after this one if an opponent played a blue spell this turn.",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "453a3438-07c6-5d82-8d23-e814485a7a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6ded26-b748-406d-8740-9b8590be2bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6ded26-b748-406d-8740-9b8590be2bb1.jpg?1",
             "name": "Serene Sunset",
             "text": "Prevent all combat damage X target creatures would deal this turn.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "a5e7b429-848e-5ad0-872a-4213f6b8d81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca1108-ccf2-48ea-8ca7-986aa45d5fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca1108-ccf2-48ea-8ca7-986aa45d5fe8.jpg?1",
             "name": "Sudden Strength",
             "text": "Target creature gets +3/+3 until end of turn.\nDraw a card.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "1f488419-db27-5dc2-8923-b24b06ab3b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8413f-c9fc-4cea-b416-a1fcf651b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b8413f-c9fc-4cea-b416-a1fcf651b009.jpg?1",
             "name": "Sylvan Safekeeper",
             "text": "Sacrifice a land: Target creature you control can't be the target of spells or abilities this turn.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "eddbde35-0722-580f-b68a-78933fc5224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9e647d-903f-4a77-a56c-cd5c0c2f12cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9e647d-903f-4a77-a56c-cd5c0c2f12cf.jpg?1",
             "name": "Thriss, Nantuko Primus",
             "text": "o\nG, oc\nT: Target creature gets +5/+5 until end of turn.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "26eb099e-12cd-5552-8194-3b0eeb658f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e246c8-3b3f-47c4-8a1b-b5f2d36f0ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e246c8-3b3f-47c4-8a1b-b5f2d36f0ca4.jpg?1",
             "name": "Tunneler Wurm",
             "text": "Discard a card from your hand: Regenerate Tunneler Wurm.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "c0bd0272-9f61-5db2-983d-1e974d67c480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10359c-1ea8-4453-bc01-f638ad20a5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db10359c-1ea8-4453-bc01-f638ad20a5ec.jpg?1",
             "name": "Venomous Vines",
             "text": "Destroy target enchanted permanent.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "8d5ada0f-11f4-5bdd-a8e8-2fa9cb3b25f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09204c7-3e3d-484a-a4f7-da1b818e3884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09204c7-3e3d-484a-a4f7-da1b818e3884.jpg?1",
             "name": "Anurid Brushhopper",
             "text": "Discard two cards from your hand: Remove Anurid Brushhopper from the game. Return it to play under its owner's control at end of turn.",
             "colours": [
@@ -4616,7 +4616,7 @@
         },
         {
             "id": "00ce940b-8ade-5680-aa7a-0ff5e654cb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14a736-5223-457b-9d4e-f4a2d6ed9a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b14a736-5223-457b-9d4e-f4a2d6ed9a8d.jpg?1",
             "name": "Hunting Grounds",
             "text": "Threshold Whenever an opponent plays a spell, you may put a creature card from your hand into play. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "f1a96030-8882-536d-8857-03bad5af0988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ddad46-5e2e-43c9-8c91-7aca6ca23562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ddad46-5e2e-43c9-8c91-7aca6ca23562.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana to your mana pool of any type that land produced.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "28d6205e-c666-5a14-8871-3cd175277bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ebc372-aabd-4174-a943-c7bf59e5028d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ebc372-aabd-4174-a943-c7bf59e5028d.jpg?1",
             "name": "Phantom Nishoba",
             "text": "Trample\nPhantom Nishoba comes into play with seven +1/+1 counters on it.\nWhenever Phantom Nishoba deals damage, you gain that much life.\nIf damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "1ba799db-9db6-5432-bd0a-a92143efb8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae25abc-22c2-436d-9e08-f123543a0911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae25abc-22c2-436d-9e08-f123543a0911.jpg?1",
             "name": "Krosan Verge",
             "text": "Krosan Verge comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\no2, oc\nT, Sacrifice Krosan Verge: Search your library for a forest card and a plains card and put them into play tapped. Then shuffle your library.",
             "colours": [],
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "981c3ce4-1a4d-5763-b5f1-3fc9b18ba717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb870406-9d59-4493-9f81-0f4b84642001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb870406-9d59-4493-9f81-0f4b84642001.jpg?1",
             "name": "Nantuko Monastery",
             "text": "oc\nT: Add one colorless mana to your mana pool.\nThreshold o\nGo\nW: Nantuko Monastery becomes a 4/4 green and white creature with first strike until end of turn. It's still a land. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "ebfe17e0-abc8-591a-9784-55c93743b98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ece630-e484-4221-911f-e32048894f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ece630-e484-4221-911f-e32048894f23.jpg?1",
             "name": "Riftstone Portal",
             "text": "oc\nT: Add one colorless mana to your mana pool.\nAs long as Riftstone Portal is in your graveyard, lands you control have \"oc\nT: Add o\nG or o\nW to your mana pool.\"",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/KHM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/KHM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "027d4611-2917-5151-87a9-9ff81dc88ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5ff64-6fe7-4fc5-be27-cdbaa14545ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de5ff64-6fe7-4fc5-be27-cdbaa14545ab.jpg?1",
             "name": "Axgard Braggart",
             "text": "Boast \u2014 {1}{W}: Untap Axgard Braggart. Put a +1/+1 counter on it. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "e4106261-b91b-5d2f-90d1-798026a0b096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb79dc85-f85a-4846-9ac3-c75c64ea9c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb79dc85-f85a-4846-9ac3-c75c64ea9c0a.jpg?1",
             "name": "Battershield Warrior",
             "text": "Boast \u2014 {1}{W}: Creatures you control get +1/+1 until end of turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "820067e6-1a5b-565d-85a4-aadd6a664d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f0045-218d-41cd-bdca-8a9a0ab1b31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/389f0045-218d-41cd-bdca-8a9a0ab1b31b.jpg?1",
             "name": "Battlefield Raptor",
             "text": "Flying, first strike",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "80d5aab5-5ac8-51a2-a205-3befbe472d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc1df84-9c47-444b-9d58-d9c7bed51c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc1df84-9c47-444b-9d58-d9c7bed51c66.jpg?1",
             "name": "Beskir Shieldmate",
             "text": "When Beskir Shieldmate dies, create a 1/1 white Human Warrior creature token.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "da812f7a-5e1f-57d6-8884-22002508a926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074d526a-1eef-4045-bd38-f6d68c4bc4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074d526a-1eef-4045-bd38-f6d68c4bc4b9.jpg?1",
             "name": "Bound in Gold",
             "text": "Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "670eed3c-ea36-5a99-a417-199a86c5105e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a4c348-1012-4339-960a-c7bc7fd84fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a4c348-1012-4339-960a-c7bc7fd84fbb.jpg?1",
             "name": "Clarion Spirit",
             "text": "Whenever you cast your second spell each turn, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "ce0eab62-b27a-5457-9210-fb12f5a28739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1316a74e-da55-4668-87f2-98389a90a2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1316a74e-da55-4668-87f2-98389a90a2a4.jpg?1",
             "name": "Codespell Cleric",
             "text": "Vigilance\nWhen Codespell Cleric enters the battlefield, if it was the second spell you cast this turn, put a +1/+1 counter on target creature.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "28836cd7-2aae-592c-8613-211b3df1cc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a8c12-4a1f-4b96-a921-538fa1a2de43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696a8c12-4a1f-4b96-a921-538fa1a2de43.jpg?1",
             "name": "Divine Gambit",
             "text": "Exile target artifact, creature, or enchantment an opponent controls. That player may put a permanent card from their hand onto the battlefield.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "61698655-73a4-5419-9650-2d09121e39ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg?1",
             "name": "Doomskar",
             "text": "Destroy all creatures.\nForetell {1}{W}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "a66eba61-8efb-5734-ab72-35bfbac9b827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dae01c8-15bb-44ad-a2c6-9bcf7a9e8c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dae01c8-15bb-44ad-a2c6-9bcf7a9e8c17.jpg?1",
             "name": "Doomskar Oracle",
             "text": "Whenever you cast your second spell each turn, you gain 2 life.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -347,7 +347,7 @@
         },
         {
             "id": "938396d7-6f6d-5e0f-beac-7018b57060a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71d8ca-c613-4534-bc9d-bc1e13202a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71d8ca-c613-4534-bc9d-bc1e13202a2c.jpg?1",
             "name": "Giant Ox",
             "text": "Giant Ox crews Vehicles using its toughness rather than its power.",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "0bc75517-1165-56c2-a37b-b979cd258829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f08552-7f1a-4fdb-9a70-d99cdbf75910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f08552-7f1a-4fdb-9a70-d99cdbf75910.jpg?1",
             "name": "Glorious Protector",
             "text": "Flash\nFlying\nWhen Glorious Protector enters the battlefield, you may exile any number of non-Angel creatures you control until Glorious Protector leaves the battlefield.\nForetell {2}{W}",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "ea839ef5-2602-5fcc-bb8e-b886b256561a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e645c8-90ac-4865-b441-e64251d6c9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e645c8-90ac-4865-b441-e64251d6c9a8.jpg?1",
             "name": "Gods' Hall Guardian",
             "text": "Vigilance\nForetell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "4d5d790f-dc9f-5fec-993b-4501717e2f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4cd64-8560-48f5-b0bc-f75286c1c91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d4cd64-8560-48f5-b0bc-f75286c1c91c.jpg?1",
             "name": "Goldmaw Champion",
             "text": "Boast \u2014 {1}{W}: Tap target creature. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "4d175cbb-33c1-5e06-a9a5-bfd90cac55ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "c87e91b0-9117-538e-800f-f8c915aaea8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/7/97502411-5c93-434c-b77b-ceb2c32feae7.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "4f28efd1-494a-57ff-8c74-1462d2966a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7213d9e1-e9c6-45d8-bb7f-336c41e7b6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7213d9e1-e9c6-45d8-bb7f-336c41e7b6f7.jpg?1",
             "name": "Invoke the Divine",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -595,7 +595,7 @@
         },
         {
             "id": "224fc334-346e-5777-b2c9-03a96813616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb38f5b-a2c2-4b06-8c9c-9615475a43e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb38f5b-a2c2-4b06-8c9c-9615475a43e7.jpg?1",
             "name": "Iron Verdict",
             "text": "Iron Verdict deals 5 damage to target tapped creature.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -627,7 +627,7 @@
         },
         {
             "id": "32ccf42b-4943-50db-b076-f317ef4f747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28e151f-b61b-486f-b7f8-7abde207c442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f28e151f-b61b-486f-b7f8-7abde207c442.jpg?1",
             "name": "Kaya's Onslaught",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -659,7 +659,7 @@
         },
         {
             "id": "fe1fe8c7-a986-5d62-8553-aafe64f8d2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b269e27-8e17-4bf2-b28a-a83ecc7d22c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b269e27-8e17-4bf2-b28a-a83ecc7d22c0.jpg?1",
             "name": "Master Skald",
             "text": "When Master Skald enters the battlefield, you may exile a creature card from your graveyard. If you do, return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "9bdc2764-ce8a-5f56-862f-c73f481660bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03595195-3be2-4d18-b5c0-43b2dcc1c0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03595195-3be2-4d18-b5c0-43b2dcc1c0f5.jpg?1",
             "name": "Rally the Ranks",
             "text": "As Rally the Ranks enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "f0c356e8-740c-5363-9fde-56f4902492ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "fb2bf34b-1c20-5fc2-97f1-5d5170a94364",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/3606519e-5677-4c21-a34e-be195b6669fa.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "e15b22fa-863c-524d-921a-6c2b01a3460a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e849bec-2ee6-4c83-83e6-bf9f5543e414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e849bec-2ee6-4c83-83e6-bf9f5543e414.jpg?1",
             "name": "Resplendent Marshal",
             "text": "Flying\nWhen Resplendent Marshal enters the battlefield or dies, you may exile another creature card from your graveyard. When you do, put a +1/+1 counter on each creature you control other than Resplendent Marshal that shares a creature type with the exiled card.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "2561f771-1cbd-5f10-bf7c-e7622c4c4988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb75e-c8e5-417b-83d4-5105af9c66c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9fb75e-c8e5-417b-83d4-5105af9c66c1.jpg?1",
             "name": "Revitalize",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "6c26c3fb-aa25-5880-9e3e-e6560db70228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb5f9f-8750-4eb5-a03a-6dacc60e0b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fb5f9f-8750-4eb5-a03a-6dacc60e0b90.jpg?1",
             "name": "Righteous Valkyrie",
             "text": "Flying\nWhenever another Angel or Cleric enters the battlefield under your control, you gain life equal to that creature's toughness.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "2639591a-f2bd-5087-aac0-12b1c55c3d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e31b716-f325-445a-9098-9ca75d7b35a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e31b716-f325-445a-9098-9ca75d7b35a4.jpg?1",
             "name": "Rune of Sustenance",
             "text": "Enchant permanent\nWhen Rune of Sustenance enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it has lifelink.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature has lifelink.\"",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "486134a9-1763-591a-abd3-3dea7ac17f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4368b087-05a0-4a88-ab43-0cd16446239b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4368b087-05a0-4a88-ab43-0cd16446239b.jpg?1",
             "name": "Runeforge Champion",
             "text": "When Runeforge Champion enters the battlefield, you may search your library and/or graveyard for a Rune card, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nYou may pay {1} rather than pay the mana cost for Rune spells you cast.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "94a38469-de92-573a-84e5-578b30c236c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65c215d-562d-4c7c-bc9f-b1d741050158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65c215d-562d-4c7c-bc9f-b1d741050158.jpg?1",
             "name": "Search for Glory",
             "text": "Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle your library. You gain 1 life for each {S} spent to cast this spell. ({S} is mana from a snow source.)",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "c9afcddd-da73-5f8f-9cf4-985a91481149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33c84e-008c-48d8-a8e8-77cd19cc4f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce33c84e-008c-48d8-a8e8-77cd19cc4f1f.jpg?1",
             "name": "Shepherd of the Cosmos",
             "text": "Flying\nWhen Shepherd of the Cosmos enters the battlefield, return target permanent card with converted mana cost 2 or less from your graveyard to the battlefield.\nForetell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "dee928bb-c1f3-5599-8ff7-372b648f94ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec3c1e-e612-4700-888e-300912932552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeec3c1e-e612-4700-888e-300912932552.jpg?1",
             "name": "Sigrid, God-Favored",
             "text": "Flash\nFirst strike, protection from God creatures\nWhen Sigrid, God-Favored enters the battlefield, exile up to one target attacking or blocking creature until Sigrid leaves the battlefield.",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "181edc9e-78b3-5d7a-ae23-e89f6007dfbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf036489-ef9e-40ee-a1bb-24ee37c554f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf036489-ef9e-40ee-a1bb-24ee37c554f1.jpg?1",
             "name": "Spectral Steel",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\n{1}{W}, Exile Spectral Steel from your graveyard: Return another target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "13f1d349-5c08-5c4a-86d8-484b3f92960d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ecb530-e429-4b50-a24c-8437614cf224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ecb530-e429-4b50-a24c-8437614cf224.jpg?1",
             "name": "Stalwart Valkyrie",
             "text": "You may pay {1}{W} and exile a creature card from your graveyard rather than pay this spell's mana cost.\nFlying",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "70dcac83-8e4c-5031-b3f5-bec4b0f6e07a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5373dd-4aec-4e93-97fb-a639aa096764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5373dd-4aec-4e93-97fb-a639aa096764.jpg?1",
             "name": "Starnheim Courser",
             "text": "Flying\nArtifact and enchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "ec0b00a6-1568-561d-a960-958263e5950b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea660d42-a441-48d8-98c1-00933cde94a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea660d42-a441-48d8-98c1-00933cde94a4.jpg?1",
             "name": "Starnheim Unleashed",
             "text": "Create a 4/4 white Angel Warrior creature token with flying and vigilance. If this spell was foretold, create X of those tokens instead.\nForetell {X}{X}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "7617afa5-06e9-56dc-81a4-6ec48d69c85c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dae817-3db1-4edf-86ba-c2c2b238fcf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dae817-3db1-4edf-86ba-c2c2b238fcf5.jpg?1",
             "name": "Story Seeker",
             "text": "Lifelink",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "a2f896c9-857f-5ad8-aa4e-06fe8af109ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e58478-c6a8-4f86-854a-a489c99bd777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e58478-c6a8-4f86-854a-a489c99bd777.jpg?1",
             "name": "Usher of the Fallen",
             "text": "Boast \u2014 {1}{W}: Create a 1/1 white Human Warrior creature token. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "cf3cd246-f5f2-5622-9ede-002c3152980b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97873c66-6bff-4d79-850c-1e2663098ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97873c66-6bff-4d79-850c-1e2663098ef4.jpg?1",
             "name": "Valkyrie's Sword",
             "text": "When Valkyrie's Sword enters the battlefield, you may pay {4}{W}. If you do, create a 4/4 white Angel Warrior creature token with flying and vigilance, then attach Valkyrie's Sword to it.\nEquipped creature gets +2/+1.\nEquip {3}",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "ef594038-38fb-5c7c-bd4c-58234de87400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83632e73-be3f-43fc-932f-45cb1af4f8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83632e73-be3f-43fc-932f-45cb1af4f8fb.jpg?1",
             "name": "Valor of the Worthy",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nWhen enchanted creature leaves the battlefield, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "ee6cba4d-91a8-5449-973e-e222bd277959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc98aff-edc0-4f78-ae4f-e08735c9e512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fc98aff-edc0-4f78-ae4f-e08735c9e512.jpg?1",
             "name": "Warhorn Blast",
             "text": "Creatures you control get +2/+1 until end of turn.\nForetell {2}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "225ff3ef-7b44-5df0-a69e-27e2f0166a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b26c95-f90d-43fb-8c99-2a3aa13ac2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b26c95-f90d-43fb-8c99-2a3aa13ac2c6.jpg?1",
             "name": "Wings of the Cosmos",
             "text": "Target creature gets +1/+3 and gains flying until end of turn. Untap it.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "45a682a9-a941-5d1b-b101-314eda89ac87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "ae4e6e88-7801-54f1-8372-8e78386ae6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "ec1f62d3-ec77-5fa9-925b-e036225bb625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg?1",
             "name": "A-Alrund, God of the Cosmos // A-Hakka, Whispering Raven",
             "text": "",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "27a2189a-fe39-5e71-8b33-2d2ca13b02a2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b443504e-1b25-4565-bad7-2575826c7bb9.jpg?1",
             "name": "A-Alrund, God of the Cosmos // A-Hakka, Whispering Raven",
             "text": "",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "1541782c-db65-5e33-af0f-cda3c626b648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94fcb53-a7bd-4a80-a536-9fb0eb24261a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94fcb53-a7bd-4a80-a536-9fb0eb24261a.jpg?1",
             "name": "Alrund's Epiphany",
             "text": "Create two 1/1 blue Bird creature tokens with flying. Take an extra turn after this one. Exile Alrund's Epiphany.\nForetell {4}{U}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "992dcf7e-b4d3-54ad-88f8-b28f57125206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f81dc-2346-4bd9-aa3b-aaa2d3873415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2f81dc-2346-4bd9-aa3b-aaa2d3873415.jpg?1",
             "name": "A-Alrund's Epiphany",
             "text": "",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "3f2e7535-d519-55b1-bd9b-2ad30b737cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d4a59-11a0-4a55-8ac0-07377a9e6dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d4a59-11a0-4a55-8ac0-07377a9e6dc8.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "01d0a0f3-3139-50e0-9f8e-7b18deefb7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56de43-c0fd-4627-846d-41a962b95f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea56de43-c0fd-4627-846d-41a962b95f17.jpg?1",
             "name": "Ascendant Spirit",
             "text": "{S}{S}: Ascendant Spirit becomes a Spirit Warrior with base power and toughness 2/3.|{S}{S}{S}: If Ascendant Spirit is a Warrior, put a flying counter on it and it becomes a Spirit Warrior Angel with base power and toughness 4/4.|{S}{S}{S}{S}: If Ascendant Spirit is an Angel, put two +1/+1 counters on it and it gains \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "c362004f-bbb4-5f7c-a0fa-300abfb1c0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9947cfd-91d6-479e-a7f6-2a2050f020f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9947cfd-91d6-479e-a7f6-2a2050f020f3.jpg?1",
             "name": "Augury Raven",
             "text": "Flying\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "44fe7d0d-ddda-52ef-9e58-1f7e61374694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cef049-6a47-4264-b2bc-b9d291a09c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cef049-6a47-4264-b2bc-b9d291a09c4c.jpg?1",
             "name": "Avalanche Caller",
             "text": "{2}: Target snow land you control becomes a 4/4 Elemental creature with hexproof and haste until end of turn. It's still a land. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "21a797d8-808a-5a9f-b9d8-3fb7eb97d56c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27855a38-a682-4f97-ad22-ac625e86faec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27855a38-a682-4f97-ad22-ac625e86faec.jpg?1",
             "name": "Behold the Multiverse",
             "text": "Scry 2, then draw two cards.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "d29e6261-9ec8-50bd-b0c5-f035845cdd65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3567bdc-450e-4481-9349-a80fe52fe431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3567bdc-450e-4481-9349-a80fe52fe431.jpg?1",
             "name": "Berg Strider",
             "text": "When Berg Strider enters the battlefield, tap target artifact or creature an opponent controls. If {S} was spent to cast this spell, that permanent doesn't untap during its controller's next untap step. ({S} is mana from a snow source.)",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "572bcdd9-157f-55ae-b35e-0f3f51742857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080be8d1-e453-4250-b917-f0eb26644895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080be8d1-e453-4250-b917-f0eb26644895.jpg?1",
             "name": "Bind the Monster",
             "text": "Enchant creature\nWhen Bind the Monster enters the battlefield, tap enchanted creature. It deals damage to you equal to its power.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "87e805b9-599d-5572-96f7-746b0cdee3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89960a74-9e17-4e30-874a-4286dd4c917d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89960a74-9e17-4e30-874a-4286dd4c917d.jpg?1",
             "name": "Brinebarrow Intruder",
             "text": "Flash\nWhen Brinebarrow Intruder enters the battlefield, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "1e55fcba-f46e-596f-b567-73fc2f83c71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "81538024-f662-55ea-9818-c2778f6203b2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab2fca4-a99f-4ffe-9c02-edb6e0be2358.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "6190b354-a423-572f-87a3-a5ba81401a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec318c6-b718-436f-b9e8-e0c6154e5010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec318c6-b718-436f-b9e8-e0c6154e5010.jpg?1",
             "name": "Cosmos Charger",
             "text": "Flash\nFlying|\nForetelling cards from your hand costs {1} less and can be done on any player's turn.\nForetell {2}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "0e67b98d-22a8-5b34-a067-85dfdd36152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfd73e2-1fad-46f6-90c5-ea35a380dbef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfd73e2-1fad-46f6-90c5-ea35a380dbef.jpg?1",
             "name": "A-Cosmos Charger",
             "text": "",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "0fba284f-2fd5-5bc6-9d97-59ee1083e393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d40071-cadf-48de-a8ed-d55adbfab632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d40071-cadf-48de-a8ed-d55adbfab632.jpg?1",
             "name": "Cyclone Summoner",
             "text": "When Cyclone Summoner enters the battlefield, if you cast it from your hand, return all permanents to their owners' hands except for Giants, Wizards, and lands.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "bd37123e-a700-5ff8-9b63-4203c428d372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce0403d-76ed-4eb0-abdd-74ed28f96137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce0403d-76ed-4eb0-abdd-74ed28f96137.jpg?1",
             "name": "Depart the Realm",
             "text": "Return target nonland permanent to its owner's hand.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "215312ae-6b48-52d9-880c-84c2ef1e8564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7691ac89-f8ba-493e-aa11-5674a783dffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7691ac89-f8ba-493e-aa11-5674a783dffb.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "abdac51e-36bb-5ea7-87c7-16fb2f1c8cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31da60a2-d4d3-4954-be59-c7ff61fa2905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31da60a2-d4d3-4954-be59-c7ff61fa2905.jpg?1",
             "name": "Draugr Thought-Thief",
             "text": "When Draugr Thought-Thief enters the battlefield, look at the top card of target player's library. You may put that card into their graveyard.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "2bdfe8cc-a1fc-5266-bbf3-3c10ce5c6ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae592f-caf6-445a-970b-f8101998e657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ae592f-caf6-445a-970b-f8101998e657.jpg?1",
             "name": "Frost Augur",
             "text": "{S}, {T}: Look at the top card of your library. If it's a snow card, you may reveal it and put it into your hand. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "b32c4fb8-3d37-5a07-b727-2ad987d3bd0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f406ce3-dce1-42d3-b76c-8e8c4b2770cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f406ce3-dce1-42d3-b76c-8e8c4b2770cb.jpg?1",
             "name": "Frostpeak Yeti",
             "text": "{1}{S}: Frostpeak Yeti can't be blocked this turn. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "f7715482-1676-59c4-af22-1f04ce353c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f8abd-4d39-4b50-876f-9c6713bc4ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f8abd-4d39-4b50-876f-9c6713bc4ab5.jpg?1",
             "name": "Frostpyre Arcanist",
             "text": "This spell costs {1} less to cast if you control a Giant or a Wizard.\nWhen Frostpyre Arcanist enters the battlefield, search your library for an instant or sorcery card with the same name as a card in your graveyard, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "c0c08a05-726c-5ad2-be6c-b61dfdfc1aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8b1ec2-9303-4722-8644-b3bc1a5c387f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8b1ec2-9303-4722-8644-b3bc1a5c387f.jpg?1",
             "name": "Giant's Amulet",
             "text": "When Giant's Amulet enters the battlefield, you may pay {3}{U}. If you do, create a 4/4 blue Giant Wizard creature token, then attach Giant's Amulet to it.\nEquipped creature gets +0/+1 and has \"This creature has hexproof as long as it's untapped.\"(It can't be the target of spells or abilities your opponents control.)\nEquip {2}",
             "colours": [
@@ -2346,7 +2346,7 @@
         },
         {
             "id": "9e651cdd-76b9-5239-a93f-d35ff01d50a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc96ebe8-f4b3-4788-a6f5-2a50b6c0d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc96ebe8-f4b3-4788-a6f5-2a50b6c0d935.jpg?1",
             "name": "Glimpse the Cosmos",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\nAs long as you control a Giant, you may cast Glimpse the Cosmos from your graveyard by paying {U} rather than paying its mana cost. If you cast Glimpse the Cosmos this way and it would be put into your graveyard, exile it instead.",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "508d6e65-942d-529b-a9d2-ae976e1b7075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4386e5c-32b1-4096-a93f-fedd1a4801fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4386e5c-32b1-4096-a93f-fedd1a4801fc.jpg?1",
             "name": "Graven Lore",
             "text": "Scry X, where X is the amount of {S} spent to cast this spell, then draw three cards. ({S} is mana from a snow source.)",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "2b89173e-c5ac-5df3-adfc-c4743e8df05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3152f1f-5d3f-4bc4-9b6f-f2983ab3f691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3152f1f-5d3f-4bc4-9b6f-f2983ab3f691.jpg?1",
             "name": "Icebind Pillar",
             "text": "{S}, {T}: Tap target artifact or creature. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2448,7 +2448,7 @@
         },
         {
             "id": "3be6b457-a5e5-5139-bf4d-1346f716b5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fdb9bb-09a2-4ff7-bcd4-35ea33c1b752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1fdb9bb-09a2-4ff7-bcd4-35ea33c1b752.jpg?1",
             "name": "Icebreaker Kraken",
             "text": "This spell costs {1} less to cast for each snow land you control.\nWhen Icebreaker Kraken enters the battlefield, artifacts and creatures target opponent controls don't untap during that player's next untap step.\nReturn three snow lands you control to their owner's hand: Return Icebreaker Kraken to its owner's hand.",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "8c04332b-4e7b-541c-a47f-c361633e145f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6f095-5beb-42a8-af8f-d40eef27150e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6f095-5beb-42a8-af8f-d40eef27150e.jpg?1",
             "name": "Inga Rune-Eyes",
             "text": "When Inga Rune-Eyes enters the battlefield, scry 3.\nWhen Inga Rune-Eyes dies, draw three cards if three or more creatures died this turn.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "40b80c8b-8fcb-56a3-ad06-dc58068c67c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4911016c-b92a-47cc-9553-b424d7be196a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4911016c-b92a-47cc-9553-b424d7be196a.jpg?1",
             "name": "Karfell Harbinger",
             "text": "{T}: Add {U}. Spend this mana only to foretell a card from your hand or cast an instant or sorcery spell.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "e7ac699e-d07d-5eb1-8104-6271fd16ea67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c119f836-0707-49e2-b6d4-25f849d054a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c119f836-0707-49e2-b6d4-25f849d054a4.jpg?1",
             "name": "Littjara Kinseekers",
             "text": "Changeling (This card is every creature type.)\nWhen Littjara Kinseekers enters the battlefield, if you control three or more creatures that share a creature type, put a +1/+1 counter on Littjara Kinseekers, then scry 1.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "20474ed9-5d72-5d30-ace0-90dfe4d34a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfd4944-790f-4835-a8a1-c23ef7047648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cfd4944-790f-4835-a8a1-c23ef7047648.jpg?1",
             "name": "Mists of Littjara",
             "text": "Flash\nEnchant creature or Vehicle\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "119d316d-24b8-5822-9d8d-0f3600317151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f64b49-327c-473b-a492-f020a322aed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f64b49-327c-473b-a492-f020a322aed7.jpg?1",
             "name": "Mistwalker",
             "text": "Changeling (This card is every creature type.)\nFlying\n{1}{U}: Mistwalker gets +1/-1 until end of turn.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "ebe4fc82-fd5d-510f-bc01-b6eaa005253c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b877e2-60eb-46cd-acd7-8555b9e7e993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b877e2-60eb-46cd-acd7-8555b9e7e993.jpg?1",
             "name": "Mystic Reflection",
             "text": "Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "2cd061b1-487b-5778-89aa-4489f48f0ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f36775e-9e48-49cc-a771-d58481712edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f36775e-9e48-49cc-a771-d58481712edc.jpg?1",
             "name": "Orvar, the All-Form",
             "text": "Changeling\nWhenever you cast an instant or sorcery spell, if it targets one or more other permanents you control, create a token that's a copy of one of those permanents.\nWhen a spell or ability an opponent controls causes you to discard this card, create a token that's a copy of target permanent.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "a5e400f1-e666-56a2-af7c-1efd6345151b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ee3829-8dec-4c0f-a6c2-ad47a1c94cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ee3829-8dec-4c0f-a6c2-ad47a1c94cfc.jpg?1",
             "name": "Pilfering Hawk",
             "text": "Flying\n{S}, {T}: Draw a card, then discard a card. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "b22c18db-2eb8-5639-8864-8120f121f2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2cfcd7-b43a-4dad-a033-e661f55ceecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2cfcd7-b43a-4dad-a033-e661f55ceecd.jpg?1",
             "name": "Ravenform",
             "text": "Exile target artifact or creature. Its controller creates a 1/1 blue Bird creature token with flying.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "689dcbcb-fead-5baa-a6d4-cbc8c07b03be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadee447-ce9a-4dea-a074-bfd04197548e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadee447-ce9a-4dea-a074-bfd04197548e.jpg?1",
             "name": "Reflections of Littjara",
             "text": "As Reflections of Littjara enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, copy that spell. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "81f26664-186d-5f9c-b009-4abee5319bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eed5a2d-d7a4-4f64-a96b-04c5d4206c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eed5a2d-d7a4-4f64-a96b-04c5d4206c5a.jpg?1",
             "name": "Run Ashore",
             "text": "Choose one or both \u2014\n\u2022 The owner of target nonland permanent puts it on the top or bottom of their library.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "d3313ae2-bad5-5567-ab89-ab573eacf3f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c1a271-2107-462a-9d4a-9c7fbcfa8d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c1a271-2107-462a-9d4a-9c7fbcfa8d77.jpg?1",
             "name": "Rune of Flight",
             "text": "Enchant permanent\nWhen Rune of Flight enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it has flying.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature has flying.\"",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "b1baf88d-9c85-5a60-918b-8b87bd875b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877a1bb9-5eae-453a-bec0-a9de20ea6815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/877a1bb9-5eae-453a-bec0-a9de20ea6815.jpg?1",
             "name": "Saw It Coming",
             "text": "Counter target spell.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -2936,7 +2936,7 @@
         },
         {
             "id": "b8712f01-997b-5fe4-9157-9656b80cc897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29306305-cb71-4fef-bf86-f5deb4e7e561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29306305-cb71-4fef-bf86-f5deb4e7e561.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "70a8163d-984f-50f7-8b8f-ce52c846dba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550c745b-64e8-4d20-9cf0-024248ddbd57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550c745b-64e8-4d20-9cf0-024248ddbd57.jpg?1",
             "name": "Undersea Invader",
             "text": "Flash\nUndersea Invader enters the battlefield tapped.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "95642a75-7397-5156-870b-7f7f04aa5aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8606f40-0af4-443b-a413-a88dc3e8f32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8606f40-0af4-443b-a413-a88dc3e8f32e.jpg?1",
             "name": "Blood on the Snow",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all planeswalkers.|\nThen return a creature or planeswalker card with converted mana cost X or less from your graveyard to the battlefield, where X is the amount of {S} spent to cast this spell. ({S} is mana from a snow source.)",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "660fa2e6-3608-516b-909f-47d464d6f3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6308a53-de07-4ed9-80a1-3579843466c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6308a53-de07-4ed9-80a1-3579843466c2.jpg?1",
             "name": "Bloodsky Berserker",
             "text": "Whenever you cast your second spell each turn, put two +1/+1 counters on Bloodsky Berserker. It gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "1ece5168-111a-5844-94fd-d6317ff0f029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f358a52b-8044-404e-8d04-2ec5903386cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f358a52b-8044-404e-8d04-2ec5903386cc.jpg?1",
             "name": "Burning-Rune Demon",
             "text": "Flying\nWhen Burning-Rune Demon enters the battlefield, you may search your library for exactly two cards not named Burning-Rune Demon that have different names. If you do, reveal those cards. An opponent chooses one of them. Put the chosen card into your hand and the other into your graveyard, then shuffle your library.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "dfd3f415-e9a1-5fed-ad2c-fdd87b075fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9bd181-b99f-477e-bcfb-9b78cbf51224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9bd181-b99f-477e-bcfb-9b78cbf51224.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "6254f38b-e7c9-5ab3-8ee3-9e5fc4fc1c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f2029f-ffda-4374-9a78-79866ac23fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f2029f-ffda-4374-9a78-79866ac23fca.jpg?1",
             "name": "Deathknell Berserker",
             "text": "When Deathknell Berserker dies, if its power was 3 or greater, create a 2/2 black Zombie Berserker creature token.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "1853e26f-51f9-5af2-96c8-a7d35efc45e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f23c487-ac4a-475b-ad5e-ec6f8678e668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f23c487-ac4a-475b-ad5e-ec6f8678e668.jpg?1",
             "name": "Demonic Gifts",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "913234cf-0a8a-5aa2-9e69-cd73f6196d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f6a159-b969-4767-802e-409f8bf286fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f6a159-b969-4767-802e-409f8bf286fe.jpg?1",
             "name": "Dogged Pursuit",
             "text": "At the beginning of your end step, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "a791e5b5-3145-59ff-ba54-7cadfc74e5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d8e0ff-e720-41ca-af69-35585a2d7ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d8e0ff-e720-41ca-af69-35585a2d7ae2.jpg?1",
             "name": "Draugr Necromancer",
             "text": "If a nontoken creature an opponent controls would die, exile that card with an ice counter on it instead.\nYou may cast spells from among cards in exile your opponents own with ice counters on them, and you may spend mana from snow sources as though it were mana of any color to cast those spells.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "96904f2e-58aa-5d8e-a03d-48e690bb60e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0fe66b-0067-4e5c-9b3a-b014b2f0daf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b0fe66b-0067-4e5c-9b3a-b014b2f0daf2.jpg?1",
             "name": "Draugr Recruiter",
             "text": "Boast \u2014 {3}{B}: Return target creature card from your graveyard to your hand. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "ee684323-f641-5cd3-9a9f-23f2e888ae97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4aade3-b1e3-43d1-b4a8-6b55ecdb4327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4aade3-b1e3-43d1-b4a8-6b55ecdb4327.jpg?1",
             "name": "Draugr's Helm",
             "text": "When Draugr's Helm enters the battlefield, you may pay {2}{B}. If you do, create a 2/2 black Zombie Berserker creature token, then attach Draugr's Helm to it.\nEquipped creature gets +2/+2 and has menace. (It can't be blocked except by two or more creatures.)\nEquip {4}",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "5b50bd95-9b83-55c8-b2d9-87ba068f23fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205eb029-68a0-4895-b142-2eb09987b5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205eb029-68a0-4895-b142-2eb09987b5cb.jpg?1",
             "name": "Dread Rider",
             "text": "{1}{B}, {T}, Exile a creature card from your graveyard: Target opponent loses 3 life.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "fe095c0a-560b-5b73-a038-01e8d0e85d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1d88a6-a74d-44b5-b7a8-866e866807f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1d88a6-a74d-44b5-b7a8-866e866807f1.jpg?1",
             "name": "Dream Devourer",
             "text": "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}. (During your turn, you may pay {2} and exile it from your hand face down. Cast it on a later turn for its foretell cost.)\nWhenever you foretell a card, Dream Devourer gets +2/+0 until end of turn.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "b18a5fb2-dd2a-560c-9267-d1a7aaba48f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5490b8-5652-40f5-8678-e1263ef69b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5490b8-5652-40f5-8678-e1263ef69b5a.jpg?1",
             "name": "Duskwielder",
             "text": "Boast \u2014 {1}: Target opponent loses 1 life and you gain 1 life. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "a6cd429a-386e-51c9-8014-33af45d5c689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "e7619d66-eed8-5e0d-9b45-26e299de2ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9dfdb73d-b001-4a59-b79e-8c8c1baea116.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "84376211-7d68-5498-a0e1-51941efe5cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3a6148-d005-49c1-a7fc-867c4e8251cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3a6148-d005-49c1-a7fc-867c4e8251cd.jpg?1",
             "name": "Elderfang Disciple",
             "text": "When Elderfang Disciple enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -3570,7 +3570,7 @@
         },
         {
             "id": "cd5b549d-434c-53e1-8095-3654011e2366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00edda3-ddbc-44ee-a14b-47a701445bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00edda3-ddbc-44ee-a14b-47a701445bb0.jpg?1",
             "name": "Eradicator Valkyrie",
             "text": "Flying, lifelink, hexproof from planeswalkers\nBoast \u2014 {1}{B}, Sacrifice a creature: Each opponent sacrifices a creature or planeswalker. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "d2db699c-fb42-5d8c-81e6-949ad41377a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a1a75b-20cf-4db9-a244-cc54411446c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a1a75b-20cf-4db9-a244-cc54411446c4.jpg?1",
             "name": "Feed the Serpent",
             "text": "Exile target creature or planeswalker.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "8870b7aa-0a0c-52e0-9df0-e0f0e7667be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54340c59-03a9-4d9d-bd27-9aed337ce75a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54340c59-03a9-4d9d-bd27-9aed337ce75a.jpg?1",
             "name": "Grim Draugr",
             "text": "{1}{S}: Grim Draugr gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures. {S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "2964bf60-eb4b-5f70-b891-4cf88241d3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a272b3-aaab-4c98-86a8-85c67a5f3d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a272b3-aaab-4c98-86a8-85c67a5f3d4d.jpg?1",
             "name": "Hailstorm Valkyrie",
             "text": "Flying, trample\n{S}{S}: Hailstorm Valkyrie gets +2/+2 until end of turn. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -3713,7 +3713,7 @@
         },
         {
             "id": "4ec399b4-03a0-56f5-be98-99db7854bb83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac5bca0-35fe-47be-a78c-d5eac68a3bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac5bca0-35fe-47be-a78c-d5eac68a3bfa.jpg?1",
             "name": "Haunting Voyage",
             "text": "Choose a creature type. Return up to two creature cards of that type from your graveyard to the battlefield. If this spell was foretold, return all creature cards of that type from your graveyard to the battlefield instead.\nForetell {5}{B}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "696ed9e8-c0ee-5ace-832d-68b01466842d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80340582-655b-4bf1-88fb-14bcbe17aa04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80340582-655b-4bf1-88fb-14bcbe17aa04.jpg?1",
             "name": "Infernal Pet",
             "text": "Whenever you cast your second spell each turn, put a +1/+1 counter on Infernal Pet and it gains flying until end of turn.",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "fae554e0-15ee-5a46-9dab-3afbbf28f763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b12c6c-c3d6-4b8a-bed4-d61f67f565b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b12c6c-c3d6-4b8a-bed4-d61f67f565b9.jpg?1",
             "name": "Jarl of the Forsaken",
             "text": "Flash\nWhen Jarl of the Forsaken enters the battlefield, destroy target creature or planeswalker an opponent controls that was dealt damage this turn.\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "e4e41312-71a8-504b-a589-594be121b4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670c380-6faa-42ec-ab41-6be8137169b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670c380-6faa-42ec-ab41-6be8137169b2.jpg?1",
             "name": "Karfell Kennel-Master",
             "text": "When Karfell Kennel-Master enters the battlefield, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "27d5bbe9-af5a-5b4a-9fca-b8168d1f02df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f1a90-af64-4122-9c1a-954edf8fa240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f1a90-af64-4122-9c1a-954edf8fa240.jpg?1",
             "name": "Koma's Faithful",
             "text": "Lifelink\nWhen Koma's Faithful dies, each player mills three cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "4a8a71e4-e1b6-5643-b4d3-10ea03fc351f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb94456-5266-47db-b514-a0e17e34b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb94456-5266-47db-b514-a0e17e34b771.jpg?1",
             "name": "Poison the Cup",
             "text": "Destroy target creature. If this spell was foretold, scry 2.\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "faab7c5d-3a2c-58bd-bb0f-80afb8966ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde0f4d-5acc-4a25-a3d6-c6b9b734360c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cde0f4d-5acc-4a25-a3d6-c6b9b734360c.jpg?1",
             "name": "Priest of the Haunted Edge",
             "text": "{T}, Sacrifice Priest of the Haunted Edge: Target creature gets -X/-X until end of turn, where X is the number of snow lands you control. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "537c2606-8a99-5415-ad7b-2f7ed7f03b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67c196-632c-4c7b-a132-de07d894e634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67c196-632c-4c7b-a132-de07d894e634.jpg?1",
             "name": "Raise the Draugr",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return two target creature cards that share a creature type from your graveyard to your hand.",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "fdab4ad2-153d-54bd-a999-5384666906b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470601b0-9598-487f-bb14-4bfec7ca6d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470601b0-9598-487f-bb14-4bfec7ca6d61.jpg?1",
             "name": "Return Upon the Tide",
             "text": "Return target creature card from your graveyard to the battlefield. If it's an Elf, create two 1/1 green Elf Warrior creature tokens.\nForetell {3}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "98482a2e-0257-534b-8fba-5493893c4ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238560c-4633-4507-828e-4e96ecf62e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238560c-4633-4507-828e-4e96ecf62e11.jpg?1",
             "name": "A-Return Upon the Tide",
             "text": "",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "8c57873b-d158-5296-9f91-adbf61471829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a1ec1-f362-494d-a23b-6a963ce44fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a1ec1-f362-494d-a23b-6a963ce44fdd.jpg?1",
             "name": "Rise of the Dread Marn",
             "text": "Create X 2/2 black Zombie Berserker creature tokens, where X is the number of nontoken creatures that died this turn.\nForetell {B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "34c7416b-4b40-5fe7-8ee9-b07ebe3c280b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75a5e5-70df-49c3-abe1-8cc6975f5171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75a5e5-70df-49c3-abe1-8cc6975f5171.jpg?1",
             "name": "Rune of Mortality",
             "text": "Enchant permanent\nWhen Rune of Mortality enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it has deathtouch.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature has deathtouch.\"",
             "colours": [
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "a70e1ab6-ff9e-5cde-bfe6-58d8139e5f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad2c6d4-03dd-4dab-861c-77c55bda0db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad2c6d4-03dd-4dab-861c-77c55bda0db7.jpg?1",
             "name": "Skemfar Avenger",
             "text": "Whenever another nontoken Elf or Berserker you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "eee4cd76-b77f-5707-a2f8-1d656f2f7316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886b815b-ffcb-4239-b161-68983e091124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886b815b-ffcb-4239-b161-68983e091124.jpg?1",
             "name": "A-Skemfar Avenger",
             "text": "",
             "colours": [
@@ -4192,7 +4192,7 @@
         },
         {
             "id": "623ffec9-2b27-58f5-8789-6a359194ffd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204130f-0483-49ed-8512-03a74894702e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204130f-0483-49ed-8512-03a74894702e.jpg?1",
             "name": "Skemfar Shadowsage",
             "text": "When Skemfar Shadowsage enters the battlefield, choose one \u2014\n\u2022 Each opponent loses X life, where X is the greatest number of creatures you control that have a creature type in common.\n\u2022 You gain X life, where X is the greatest number of creatures you control that have a creature type in common.",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "1ce4b8ac-8b77-5f81-80c8-4c03fe84dbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4589c520-4db3-47bf-bfb2-5d7e02ede4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4589c520-4db3-47bf-bfb2-5d7e02ede4bf.jpg?1",
             "name": "Skull Raid",
             "text": "Target opponent discards two cards. If fewer than two cards were discarded this way, you draw cards equal to the difference.\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4259,7 +4259,7 @@
         },
         {
             "id": "8430581c-d266-5713-b712-f9c507ab5fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -4297,7 +4297,7 @@
         },
         {
             "id": "90c4d598-dd83-566a-9138-2eb1e255ec8e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14dc88ee-bba9-4625-af0d-89f3762a0ead.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "7d59a82c-b5c1-5b89-aeae-6317ec5a246b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/417f71d2-d7da-4279-8847-d27c67e9ea9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/417f71d2-d7da-4279-8847-d27c67e9ea9d.jpg?1",
             "name": "Tergrid's Shadow",
             "text": "Each player sacrifices two creatures.\nForetell {2}{B}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "6161b207-65da-513c-b322-c6c1c75ad21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "cd94f98e-85bb-5eea-b1c1-5d5b39e2e9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "13fecfa5-7f0a-56c0-ae90-848d4fb262e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa8dbf0-4e5a-452b-826f-5813e8cd9d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa8dbf0-4e5a-452b-826f-5813e8cd9d85.jpg?1",
             "name": "Varragoth, Bloodsky Sire",
             "text": "Deathtouch\nBoast \u2014 {1}{B}: Target player searches their library for a card, then shuffles their library and puts that card on top of it. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "5bd29a84-04bb-5c91-8800-f8a4e07770f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c99fd-71ba-40b7-98cf-b783f01a77b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854c99fd-71ba-40b7-98cf-b783f01a77b4.jpg?1",
             "name": "Vengeful Reaper",
             "text": "Flying, deathtouch, haste|\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "66d20282-5804-54f0-a579-ffc6351a6fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fab9ee8-776a-48e5-b309-bcd381e67bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fab9ee8-776a-48e5-b309-bcd381e67bf7.jpg?1",
             "name": "Village Rites",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -4552,7 +4552,7 @@
         },
         {
             "id": "43c61b32-95c0-5e67-80da-a36c28219d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffa795d-2211-49b0-a6df-812599758f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffa795d-2211-49b0-a6df-812599758f7b.jpg?1",
             "name": "Weigh Down",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nTarget creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "926dc4cd-682d-5909-b5c1-2e535769090f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597fe119-64a7-4499-8b69-738af5a71a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597fe119-64a7-4499-8b69-738af5a71a20.jpg?1",
             "name": "Withercrown",
             "text": "Enchant creature\nEnchanted creature has base power 0 and has \"At the beginning of your upkeep, you lose 1 life unless you sacrifice this creature.\"",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "16837722-fc11-58c7-aa4a-d1b08ee584e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff334bba-0805-4d5d-86c4-99185fe9a77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff334bba-0805-4d5d-86c4-99185fe9a77a.jpg?1",
             "name": "Arni Brokenbrow",
             "text": "Haste\nBoast \u2014 {1}: You may change Arni Brokenbrow's base power to 1 plus the greatest power among other creatures you control until end of turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "066332db-776e-5646-8f3d-aba9d1817e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2411c341-a470-4484-9248-7c1d3ca12978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2411c341-a470-4484-9248-7c1d3ca12978.jpg?1",
             "name": "Axgard Cavalry",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "1b414b20-21c1-53e9-86c4-98944dd9d36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32aea04-04f7-48a8-a8ab-8b38fa53da3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32aea04-04f7-48a8-a8ab-8b38fa53da3b.jpg?1",
             "name": "Basalt Ravager",
             "text": "When Basalt Ravager enters the battlefield, it deals X damage to any target, where X is the greatest number of creatures you control that have a creature type in common.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "750b2eca-e9c3-52bf-919f-b45eaf865193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "3511fd42-d534-5dd8-9e31-ef81bfc49949",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44657ab1-0a6a-4a5f-9688-86f239083821.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -4801,7 +4801,7 @@
         },
         {
             "id": "a516071c-7025-5fd1-b664-6849648752a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6eb23c9-6061-4ad1-a8f3-2c791c49f352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6eb23c9-6061-4ad1-a8f3-2c791c49f352.jpg?1",
             "name": "Breakneck Berserker",
             "text": "Haste",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "2e2b8656-c379-5efa-b798-3d71eb82e924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15edad1-ff68-4f20-95f6-99fe549bea98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15edad1-ff68-4f20-95f6-99fe549bea98.jpg?1",
             "name": "Calamity Bearer",
             "text": "If a Giant source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "9768d7da-4b97-50c4-b317-9f70af933db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4802e6c-6921-4dac-bf44-7e09d6942b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4802e6c-6921-4dac-bf44-7e09d6942b71.jpg?1",
             "name": "Cinderheart Giant",
             "text": "Trample\nWhen Cinderheart Giant dies, it deals 7 damage to a creature an opponent controls chosen at random.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "7967c0f7-bacc-58dc-b549-0c81c1507cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be804ab-1024-4eee-b339-48ed8b84d363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be804ab-1024-4eee-b339-48ed8b84d363.jpg?1",
             "name": "Craven Hulk",
             "text": "Craven Hulk can't block alone.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "869ffe36-ec84-500f-85c2-287eb4d0e07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a20c2-1d17-46ea-b4d2-3e70bc05aae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a20c2-1d17-46ea-b4d2-3e70bc05aae3.jpg?1",
             "name": "Crush the Weak",
             "text": "Crush the Weak deals 2 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "9e1d970b-0b62-5df9-b27f-45ee15ee0df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f856b0e-b413-49b0-9aa7-d935ad40ae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f856b0e-b413-49b0-9aa7-d935ad40ae53.jpg?1",
             "name": "Demon Bolt",
             "text": "Demon Bolt deals 4 damage to target creature or planeswalker.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "f1df6271-d786-572c-b6ee-318e5a8b04a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e125e4-103f-4a68-b85f-1382646da71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e125e4-103f-4a68-b85f-1382646da71e.jpg?1",
             "name": "Doomskar Titan",
             "text": "When Doomskar Titan enters the battlefield, creatures you control get +1/+0 and gain haste until end of turn.\nForetell {4}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "446fc63a-ba05-54fe-996e-4b01de172f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f22fe4-2390-4c3d-8b5e-0cf398d97f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f22fe4-2390-4c3d-8b5e-0cf398d97f6a.jpg?1",
             "name": "Dragonkin Berserker",
             "text": "First strike\nBoast abilities you activate cost {1} less to activate for each Dragon you control.\nBoast \u2014 {4}{R}: Create a 5/5 red Dragon creature token with flying. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "3d0256fd-0186-57dc-8827-8175eeb21af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef580f8-efec-4d31-8dc3-2018dd48b6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef580f8-efec-4d31-8dc3-2018dd48b6f4.jpg?1",
             "name": "Dual Strike",
             "text": "When you cast your next instant or sorcery spell with converted mana cost 4 or less this turn, copy that spell. You may choose new targets for the copy.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "b45fa37b-16a6-5e6b-91bb-25e227327d69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cc132f-d4c1-4bc4-9c9e-f63ab5e7d094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cc132f-d4c1-4bc4-9c9e-f63ab5e7d094.jpg?1",
             "name": "Dwarven Hammer",
             "text": "When Dwarven Hammer enters the battlefield, you may pay {2}. If you do, create a 2/1 red Dwarf Berserker creature token, then attach Dwarven Hammer to it.\nEquipped creature gets +3/+0 and has trample.\nEquip {3}",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "7df02a24-2cf9-5feb-a4ba-524c1537a217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bcc7cb-65dd-4bc6-8606-a162fa6c65f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bcc7cb-65dd-4bc6-8606-a162fa6c65f7.jpg?1",
             "name": "Dwarven Reinforcements",
             "text": "Create two 2/1 red Dwarf Berserker creature tokens.\nForetell {1}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "64a2f326-fa76-5101-af28-a8e592c7d6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212462b7-e23e-4c87-93aa-9cadefbf1ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212462b7-e23e-4c87-93aa-9cadefbf1ac8.jpg?1",
             "name": "Fearless Liberator",
             "text": "Boast \u2014 {2}{R}: Create a 2/1 red Dwarf Berserker creature token. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "cb67b8d3-adf3-5d7c-9743-f3916d541472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eba2250-0e9b-46fd-a4b5-23f30329e063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eba2250-0e9b-46fd-a4b5-23f30329e063.jpg?1",
             "name": "Fearless Pup",
             "text": "First strike\nBoast \u2014 {2}{R}: Fearless Pup gets +2/+0 until end of turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5246,7 +5246,7 @@
         },
         {
             "id": "00393b64-7072-55fe-8342-26e6be96086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c59e0b-5b78-4cf5-9c2a-92ccf833778f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22c59e0b-5b78-4cf5-9c2a-92ccf833778f.jpg?1",
             "name": "Frenzied Raider",
             "text": "Whenever you activate a boast ability, put a +1/+1 counter on Frenzied Raider.",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "e3bd9213-4bf8-575b-b201-6b41879d3aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423318a-c5a8-48d2-92f5-280d15a050a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9423318a-c5a8-48d2-92f5-280d15a050a6.jpg?1",
             "name": "Frost Bite",
             "text": "Frost Bite deals 2 damage to target creature or planeswalker. If you control three or more snow permanents, it deals 3 damage instead.",
             "colours": [
@@ -5317,7 +5317,7 @@
         },
         {
             "id": "1784be5d-fcfe-5b33-9fa5-53e396a602eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d914868-9000-4df2-a818-0ef8a7f636ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d914868-9000-4df2-a818-0ef8a7f636ae.jpg?1",
             "name": "Goldspan Dragon",
             "text": "Flying, haste\nWhenever Goldspan Dragon attacks or becomes the target of a spell, create a Treasure token.\nTreasures you control have \"{T}, Sacrifice this artifact: Add two mana of any one color.\"",
             "colours": [
@@ -5353,7 +5353,7 @@
         },
         {
             "id": "2369993b-6535-5bc9-a24c-9a43cb4718bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b18cdb-bc17-42ae-bfb7-4eafce01cd39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b18cdb-bc17-42ae-bfb7-4eafce01cd39.jpg?1",
             "name": "Hagi Mob",
             "text": "Boast \u2014 {1}{R}: Hagi Mob deals 1 damage to any target. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -5388,7 +5388,7 @@
         },
         {
             "id": "40774957-fa82-5429-965b-af22a04d23eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77da4de2-4d34-40e5-8fc0-850aef05356b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77da4de2-4d34-40e5-8fc0-850aef05356b.jpg?1",
             "name": "Immersturm Raider",
             "text": "When Immersturm Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5423,7 +5423,7 @@
         },
         {
             "id": "dbad2e98-aeee-5810-9602-8661463f52ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e6263-e54c-4899-a336-5315909b9322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079e6263-e54c-4899-a336-5315909b9322.jpg?1",
             "name": "Magda, Brazen Outlaw",
             "text": "Other Dwarves you control get +1/+0.\nWhenever a Dwarf you control becomes tapped, create a Treasure token.\nSacrifice five Treasures: Search your library for an artifact or Dragon card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "9fe6f71e-1a3d-5787-80a6-ed474572da75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4023c8-8e7f-42b9-99e5-87e80fc3d6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4023c8-8e7f-42b9-99e5-87e80fc3d6c8.jpg?1",
             "name": "Open the Omenpaths",
             "text": "Choose one \u2014\n\u2022 Add two mana of any one color and two mana of any other color. Spend this mana only to cast creature or enchantment spells.\n\u2022 Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -5494,7 +5494,7 @@
         },
         {
             "id": "bfa674e2-af8d-53c4-99b0-12e41c3d200e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2727b05a-0c86-4c59-b7b4-425bdd8e775d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2727b05a-0c86-4c59-b7b4-425bdd8e775d.jpg?1",
             "name": "Provoke the Trolls",
             "text": "Provoke the Trolls deals 3 damage to any target. If a creature is dealt damage this way, it gets +5/+0 until end of turn.",
             "colours": [
@@ -5526,7 +5526,7 @@
         },
         {
             "id": "0e67ecba-a8f6-57d3-89a7-f4444026a238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bbffb9-1f1c-40e5-97f4-29bf1fc68625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bbffb9-1f1c-40e5-97f4-29bf1fc68625.jpg?1",
             "name": "Quakebringer",
             "text": "Your opponents can't gain life.\nAt the beginning of your upkeep, Quakebringer deals 2 damage to each opponent. This ability triggers only if Quakebringer is on the battlefield or if Quakebringer is in your graveyard and you control a Giant.\nForetell {2}{R}{R}",
             "colours": [
@@ -5563,7 +5563,7 @@
         },
         {
             "id": "6444b6a9-12e2-55e3-afbf-c43f8941ff34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd68d9d-b0b9-4915-8a12-658eb0e3dd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd68d9d-b0b9-4915-8a12-658eb0e3dd4a.jpg?1",
             "name": "Reckless Crew",
             "text": "Create X 2/1 red Dwarf Berserker creature tokens, where X is the number of Vehicles you control plus the number of Equipment you control. For each of those tokens, you may attach an Equipment you control to it.",
             "colours": [
@@ -5597,7 +5597,7 @@
         },
         {
             "id": "a35e52f9-1e8f-5bd2-9605-5dea92a5d76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c8136f-2826-476c-a103-7094670506a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c8136f-2826-476c-a103-7094670506a6.jpg?1",
             "name": "Run Amok",
             "text": "Target attacking creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "3d4ce9e8-7a81-57d5-94a4-9e36307bde18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47faee66-b274-466a-890e-bb396dda943d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47faee66-b274-466a-890e-bb396dda943d.jpg?1",
             "name": "Rune of Speed",
             "text": "Enchant permanent\nWhen Rune of Speed enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it gets +1/+0 and has haste.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature gets +1/+0 and has haste.\"",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "e079879b-0a43-52fe-b93d-1af4bb8808f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b7a69c-75d2-49a6-ab56-ef608d0b0208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b7a69c-75d2-49a6-ab56-ef608d0b0208.jpg?1",
             "name": "Seize the Spoils",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "0e766ded-2ce3-5dab-b3e2-2a34af815683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db743c6e-1385-468e-921a-7a525b88a1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db743c6e-1385-468e-921a-7a525b88a1b6.jpg?1",
             "name": "Shackles of Treachery",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and \"Whenever this creature deals damage, destroy target Equipment attached to it.\"",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "6ff16380-e799-5ddd-9871-6c1f781b2a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c7383-ba4d-4b3c-91d6-2d6528e19825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22c7383-ba4d-4b3c-91d6-2d6528e19825.jpg?1",
             "name": "Smashing Success",
             "text": "Destroy target artifact or land. If an artifact is destroyed this way, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "a57fd155-198c-5e9c-8fc0-3ffec03809c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b99299-bf84-4654-a331-e4406768b33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b99299-bf84-4654-a331-e4406768b33c.jpg?1",
             "name": "Squash",
             "text": "This spell costs {3} less to cast if you control a Giant.\nSquash deals 6 damage to target creature or planeswalker.",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "d6ce0e70-92a3-5248-abdf-d9859aa80b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd921e27-3e08-438c-bec2-723226d35175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd921e27-3e08-438c-bec2-723226d35175.jpg?1",
             "name": "Tibalt's Trickery",
             "text": "Counter target spell. Choose 1, 2, or 3 at random. Its controller mills that many cards, then exiles cards from the top of their library until they exile a nonland card with a different name than that spell. They may cast that card without paying its mana cost. Then they put the exiled cards on the bottom of their library in a random order.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "0c820b30-6cf7-5cce-a853-496c13c78916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "ea3f8349-f3e6-519a-9d65-04d8434360d0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/22a6a5f1-1405-4efb-af3e-e1f58d664e99.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "16527db5-21c4-57bd-aeef-d9316a31bfa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2318d4f8-309e-4645-b6d1-46572edd6996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2318d4f8-309e-4645-b6d1-46572edd6996.jpg?1",
             "name": "Tormentor's Helm",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature becomes blocked, it deals 1 damage to defending player.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "9ecdc572-126e-5dfc-8646-20a229c9df6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b251aa7c-d011-4b52-ab92-415d536c0182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b251aa7c-d011-4b52-ab92-415d536c0182.jpg?1",
             "name": "Tundra Fumarole",
             "text": "Tundra Fumarole deals 4 damage to target creature or planeswalker. Add {C} for each {S} spent to cast this spell. Until end of turn, you don't lose this mana as steps and phases end. ({S} is mana from a snow source.)",
             "colours": [
@@ -5972,7 +5972,7 @@
         },
         {
             "id": "551687da-151e-52a8-b7a3-97a295065375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54d0170-a375-4e65-b98d-3e94a3aeef90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54d0170-a375-4e65-b98d-3e94a3aeef90.jpg?1",
             "name": "Tuskeri Firewalker",
             "text": "Boast \u2014 {1}: Exile the top card of your library. You may play that card this turn. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "5d007d60-9d54-5778-b9b6-c8a590d09316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f68014-489d-4f51-a959-0f335541cb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f68014-489d-4f51-a959-0f335541cb4e.jpg?1",
             "name": "Vault Robber",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6042,7 +6042,7 @@
         },
         {
             "id": "16d7623e-49bc-54f5-8d13-7448c11649dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe560b-f7b5-4614-91f1-b669a39abc16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe560b-f7b5-4614-91f1-b669a39abc16.jpg?1",
             "name": "Arachnoform",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has reach, and is every creature type.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "6d187592-205b-527e-ba98-60f50f15f3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3377d9-eec3-49b9-a3a7-e540d2038f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3377d9-eec3-49b9-a3a7-e540d2038f51.jpg?1",
             "name": "Battle Mammoth",
             "text": "Trample\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\nForetell {2}{G}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -6112,7 +6112,7 @@
         },
         {
             "id": "bc380b5a-d4f5-5d41-ae34-c5ebb42f4314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01f4d-491e-4f25-a017-a0d9c437ac8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f01f4d-491e-4f25-a017-a0d9c437ac8c.jpg?1",
             "name": "Blessing of Frost",
             "text": "Distribute X +1/+1 counters among any number of creatures you control, where X is the amount of {S} spent to cast this spell. Then draw a card for each creature you control with power 4 or greater.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "fea48b09-0f75-525a-8506-034130c0f6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6318918f-34e4-4bbf-9816-8e88f21ae324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6318918f-34e4-4bbf-9816-8e88f21ae324.jpg?1",
             "name": "Blizzard Brawl",
             "text": "Choose target creature you control and target creature you don't control. If you control three or more snow permanents, the creature you control gets +1/+0 and gains indestructible until end of turn. Then those creatures fight each other. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "6f0fc214-213d-5610-ad39-a3fa750e9bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455ae615-20d7-4251-828d-72a3345d06f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455ae615-20d7-4251-828d-72a3345d06f1.jpg?1",
             "name": "Boreal Outrider",
             "text": "Whenever you cast a creature spell, if {S} of any of that spell's colors was spent to cast it, that creature enters the battlefield with an additional +1/+1 counter on it. ({S} is mana from a snow source.)",
             "colours": [
@@ -6219,7 +6219,7 @@
         },
         {
             "id": "b43a1f9f-c13b-52ae-869d-e3a3f7178d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6201f78e-ff45-4c59-ac85-c8447c14a496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6201f78e-ff45-4c59-ac85-c8447c14a496.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "fa644feb-bf18-5bcc-8f1a-496c8dc3836b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8bded3-46c3-474f-9d09-978df8705ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8bded3-46c3-474f-9d09-978df8705ad1.jpg?1",
             "name": "Elderleaf Mentor",
             "text": "When Elderleaf Mentor enters the battlefield, create a 1/1 green Elf Warrior creature token.",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "5e40dfb9-7f0d-5439-b8a2-6ce62d91c6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1d225c-8a49-43f9-a9d2-aef7e406ab52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1d225c-8a49-43f9-a9d2-aef7e406ab52.jpg?1",
             "name": "A-Elderleaf Mentor",
             "text": "",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "33d7a5fb-9375-5328-98ae-59a639ddd7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c599c7-bcc1-4005-b830-1fa4811af66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c599c7-bcc1-4005-b830-1fa4811af66e.jpg?1",
             "name": "Elven Bow",
             "text": "When Elven Bow enters the battlefield, you may pay {2}. If you do, create a 1/1 green Elf Warrior creature token, then attach Elven Bow to it.\nEquipped creature gets +1/+2 and has reach.\nEquip {3}",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "b762f92a-af34-5a2f-a3fd-c1c005963a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6310bf62-6016-4987-83ed-671283a7ff61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6310bf62-6016-4987-83ed-671283a7ff61.jpg?1",
             "name": "A-Elven Bow",
             "text": "",
             "colours": [
@@ -6387,7 +6387,7 @@
         },
         {
             "id": "c8e48eb0-f316-51f7-b1f7-c828a86731dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg?1",
             "name": "Elvish Warmaster",
             "text": "Whenever one or more other Elves enters the battlefield under your control, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
             "colours": [
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "51cea10e-7235-567e-9339-292571210ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "1d918ac9-583f-5063-bfe9-c3a3597f21f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6cd7465-9dd0-473c-ac5e-dd9e2f22f5f6.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -6510,7 +6510,7 @@
         },
         {
             "id": "70b489a6-0907-5607-a494-fa4fcc95e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87606cc-fbf0-4e2c-9798-f1c935d0573d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87606cc-fbf0-4e2c-9798-f1c935d0573d.jpg?1",
             "name": "Esika's Chariot",
             "text": "When Esika's Chariot enters the battlefield, create two 2/2 green Cat creature tokens.\nWhenever Esika's Chariot attacks, create a token that's a copy of target token you control.\nCrew 4",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "e96eb9bf-9e06-52ea-84ca-a970a5ebba2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7a8a90-13c1-4b0c-ab2e-fc8d91ccefd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7a8a90-13c1-4b0c-ab2e-fc8d91ccefd9.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "Deathtouch|\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -6587,7 +6587,7 @@
         },
         {
             "id": "c492a467-330b-5150-b578-618582d3fe41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60fbc33-6198-4661-967e-cc94f2788e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60fbc33-6198-4661-967e-cc94f2788e4a.jpg?1",
             "name": "Glittering Frost",
             "text": "Enchant land\nEnchanted land is snow.\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -6623,7 +6623,7 @@
         },
         {
             "id": "2e6cca3c-78ca-55c3-a76e-9025d20a04bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46c8c8-5dfa-4ebb-b0b9-cd25d01dd432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af46c8c8-5dfa-4ebb-b0b9-cd25d01dd432.jpg?1",
             "name": "Gnottvold Recluse",
             "text": "Reach",
             "colours": [
@@ -6657,7 +6657,7 @@
         },
         {
             "id": "2c2bc6eb-da19-554c-a303-d4a0b90557ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1d4473-5317-4bdd-9cb9-93670acf52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1d4473-5317-4bdd-9cb9-93670acf52e9.jpg?1",
             "name": "Grizzled Outrider",
             "text": "",
             "colours": [
@@ -6692,7 +6692,7 @@
         },
         {
             "id": "219aed18-2b7e-515c-b216-233bc8ad02b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587eed42-5111-4161-9af5-bf76556c542a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587eed42-5111-4161-9af5-bf76556c542a.jpg?1",
             "name": "Guardian Gladewalker",
             "text": "Changeling (This card is every creature type.)\nWhen Guardian Gladewalker enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "d61ea09b-d6ea-587a-91b6-be39545db745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17f4b21-6478-407d-b567-2888349f3b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17f4b21-6478-407d-b567-2888349f3b66.jpg?1",
             "name": "Horizon Seeker",
             "text": "Boast \u2014 {1}{G}: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library. (Activate this ability only if this creature attacked this turn and only once each turn.)",
             "colours": [
@@ -6761,7 +6761,7 @@
         },
         {
             "id": "0c42baf0-07ca-5275-837b-19a8b872495f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f3aaed-a01f-4c6a-b9bb-cd70b0f6ceb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f3aaed-a01f-4c6a-b9bb-cd70b0f6ceb1.jpg?1",
             "name": "Icehide Troll",
             "text": "{S}{S}: Icehide Troll gets +2/+0 and gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it. {S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -6798,7 +6798,7 @@
         },
         {
             "id": "2be7749d-f12d-5536-b6d1-4745e43c062e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0e50fa-5114-4f96-89f4-000906da7c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0e50fa-5114-4f96-89f4-000906da7c76.jpg?1",
             "name": "In Search of Greatness",
             "text": "At the beginning of your upkeep, you may cast a permanent spell from your hand with converted mana cost equal to 1 plus the highest converted mana cost among other permanents you control without paying its mana cost. If you don't, scry 1.",
             "colours": [
@@ -6832,7 +6832,7 @@
         },
         {
             "id": "54d42105-776e-535a-ae4d-5f84f7107482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68615d-9808-479d-aa80-50651246954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a68615d-9808-479d-aa80-50651246954e.jpg?1",
             "name": "Jaspera Sentinel",
             "text": "Reach\n{T}, Tap an untapped creature you control: Add one mana of any color.",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "c7de6c34-97b3-52c7-91bf-843da36f13f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "952b18a4-86b1-504c-8ba4-29d11c6e7589",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c697548f-925b-405e-970a-4e78067d5c8e.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "92886584-8cca-55d7-9eae-3ad213545a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a659b6-c4a8-4c0a-8b2a-07b6c9e27dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a659b6-c4a8-4c0a-8b2a-07b6c9e27dfc.jpg?1",
             "name": "King Harald's Revenge",
             "text": "Until end of turn, target creature gets +1/+1 for each creature you control and gains trample. It must be blocked this turn if able.",
             "colours": [
@@ -6980,7 +6980,7 @@
         },
         {
             "id": "f3e6f720-2c59-5be0-90d8-98a0bd311ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "257919a8-f3fc-5b1c-878b-0ac385b9d12a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b76bed98-30b1-4572-b36c-684ada06826c.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "f02f2920-b3ec-5de0-8836-ccde95d62343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92dde51-310e-4f28-bd3b-d43b639785ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92dde51-310e-4f28-bd3b-d43b639785ec.jpg?1",
             "name": "Littjara Glade-Warden",
             "text": "Changeling (This card is every creature type.)\n{2}{G}, {T}, Exile a creature card from your graveyard: Put two +1/+1 counters on target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7088,7 +7088,7 @@
         },
         {
             "id": "6902c497-9f91-5883-9e6e-e1b07f39ee8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e55041f-69a5-4bcf-899f-a4b44c208b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e55041f-69a5-4bcf-899f-a4b44c208b4d.jpg?1",
             "name": "Mammoth Growth",
             "text": "Target creature gets +4/+4 until end of turn.\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "b2937b8c-cde1-5b9b-a93f-c73a26d2befc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a9c72a-e450-41e3-80e5-06f2f1171245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a9c72a-e450-41e3-80e5-06f2f1171245.jpg?1",
             "name": "Masked Vandal",
             "text": "Changeling (This card is every creature type.)\nWhen Masked Vandal enters the battlefield, you may exile a creature card from your graveyard. If you do, exile target artifact or enchantment an opponent controls.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "6c1c10d9-566d-5814-8d29-3fc6934401f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759b0f6-342c-4bba-89f1-8451835d8c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b759b0f6-342c-4bba-89f1-8451835d8c45.jpg?1",
             "name": "Old-Growth Troll",
             "text": "Trample\nWhen Old-Growth Troll dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add {G}{G}' and \u2018{1}, {T}, Sacrifice this land: Create a tapped 4/4 green Troll Warrior creature token with trample.'\"",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "5cbf1933-af61-5974-9c64-69e592a1842c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606da75d-382a-47a8-9739-644438594700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606da75d-382a-47a8-9739-644438594700.jpg?1",
             "name": "Path to the World Tree",
             "text": "When Path to the World Tree enters the battlefield, search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\n{2}{W}{U}{B}{R}{G}, Sacrifice Path to the World Tree: You gain 2 life and draw two cards. Target opponent loses 2 life. Path to the World Tree deals 2 damage to up to one target creature. You create a 2/2 green Bear creature token.",
             "colours": [
@@ -7229,7 +7229,7 @@
         },
         {
             "id": "a1509526-ac48-5371-ab77-d78561dfdf5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961e3fc-167e-4043-8510-cc5cf08d473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961e3fc-167e-4043-8510-cc5cf08d473e.jpg?1",
             "name": "Ravenous Lindwurm",
             "text": "When Ravenous Lindwurm enters the battlefield, you gain 4 life.",
             "colours": [
@@ -7263,7 +7263,7 @@
         },
         {
             "id": "6bc0737d-fb9a-5483-bff2-3ba4a875c0cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8212667-7e18-42a5-9f36-4f8a6ad12f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8212667-7e18-42a5-9f36-4f8a6ad12f83.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling (This card is every creature type.)\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -7300,7 +7300,7 @@
         },
         {
             "id": "690f64b2-a443-5ca7-9fb4-829f726e3d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992aba3f-e1cb-4f5a-8b6f-328a069102a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992aba3f-e1cb-4f5a-8b6f-328a069102a4.jpg?1",
             "name": "Rootless Yew",
             "text": "When Rootless Yew dies, search your library for a creature card with power or toughness 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -7334,7 +7334,7 @@
         },
         {
             "id": "c3dd351f-ea57-5b1c-9b3f-692d0310ea9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734afb5b-3163-47fa-856f-8a85b9da22d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734afb5b-3163-47fa-856f-8a85b9da22d3.jpg?1",
             "name": "Roots of Wisdom",
             "text": "Mill three cards, then return a land card or Elf card from your graveyard to your hand. If you can't, draw a card. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -7366,7 +7366,7 @@
         },
         {
             "id": "9f916177-0dec-566e-9017-e6cf77fd7964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0d507b-fc08-46cb-b092-484fa4adeef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0d507b-fc08-46cb-b092-484fa4adeef6.jpg?1",
             "name": "Rune of Might",
             "text": "Enchant permanent\nWhen Rune of Might enters the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it gets +1/+1 and has trample.\nAs long as enchanted permanent is an Equipment, it has \"Equipped creature gets +1/+1 and has trample.\"",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "6478c624-a012-5c22-acc1-a252d892e8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6061113e-7dd8-4739-b4dd-55bb7f9e39a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6061113e-7dd8-4739-b4dd-55bb7f9e39a2.jpg?1",
             "name": "Sarulf's Packmate",
             "text": "When Sarulf's Packmate enters the battlefield, draw a card.\nForetell {1}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "7d35d671-86ad-5f1e-8b9f-3e899ff50c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab2ca2-0039-4eac-a7dc-68756362737d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab2ca2-0039-4eac-a7dc-68756362737d.jpg?1",
             "name": "Sculptor of Winter",
             "text": "{T}: Untap target snow land.",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "e853058d-143c-5383-912f-1d168473f5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e692c208-c171-4964-9207-43c2cbc62845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e692c208-c171-4964-9207-43c2cbc62845.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "fab1f3db-e724-5bf7-a5b3-c931f3bd2ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220df551-3820-4910-a206-14501ba02e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220df551-3820-4910-a206-14501ba02e69.jpg?1",
             "name": "Spirit of the Aldergard",
             "text": "When Spirit of the Aldergard enters the battlefield, search your library for a snow land card, reveal it, put it into your hand, then shuffle your library.\nSpirit of the Aldergard gets +1/+0 for each other snow permanent you control.",
             "colours": [
@@ -7541,7 +7541,7 @@
         },
         {
             "id": "41439043-57d3-5073-9916-f68ef0d6c039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67747a9-3299-4b4a-a4e0-e8a269c4f927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67747a9-3299-4b4a-a4e0-e8a269c4f927.jpg?1",
             "name": "Struggle for Skemfar",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "4b17f191-b422-5fb0-9ff5-f18237690bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e79b59-94c8-4697-bf88-f0a0433170f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e79b59-94c8-4697-bf88-f0a0433170f5.jpg?1",
             "name": "Toski, Bearer of Secrets",
             "text": "This spell can't be countered.\nIndestructible\nToski, Bearer of Secrets attacks each combat if able.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -7611,7 +7611,7 @@
         },
         {
             "id": "6a808233-2aa7-596d-9532-6be1bd4f3bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d18008f-10d2-4cdf-b4b5-7675782a8b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d18008f-10d2-4cdf-b4b5-7675782a8b0d.jpg?1",
             "name": "Tyvar Kell",
             "text": "Elves you control have \"{T}: Add {B}.\"\n+1: Put a +1/+1 counter on up to one target Elf. Untap it. It gains deathtouch until end of turn.\n0: Create a 1/1 green Elf Warrior creature token.\n\u22126: You get an emblem with \"Whenever you cast an Elf spell, it gains haste until end of turn and you draw two cards.\"",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "926de766-bd14-5c8f-9e2c-5095caa1b675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16492772-1a2a-4935-95ff-c2416633d064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16492772-1a2a-4935-95ff-c2416633d064.jpg?1",
             "name": "A-Tyvar Kell",
             "text": "",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "9d9018f2-42b3-5930-9663-f8a9a026d0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92613468-205e-488b-930d-11908477e9f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92613468-205e-488b-930d-11908477e9f8.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "Trample, haste\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.",
             "colours": [
@@ -7728,7 +7728,7 @@
         },
         {
             "id": "f8c45cab-5635-56ae-bfde-3c5a5cb0d702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68011f60-6202-48f4-8255-fb94764e2951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68011f60-6202-48f4-8255-fb94764e2951.jpg?1",
             "name": "Aegar, the Freezing Flame",
             "text": "Whenever a creature or planeswalker an opponent controls is dealt excess damage, if a Giant, Wizard, or spell you controlled dealt damage to it this turn, draw a card.",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "b0301776-03fc-5236-a655-2db74c554b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18396f9-ae20-4471-84ab-a2148319bc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18396f9-ae20-4471-84ab-a2148319bc39.jpg?1",
             "name": "Arni Slays the Troll",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Target creature you control fights up to one target creature you don't control.\nII \u2014 Add {R}. Put two +1/+1 counters on up to one target creature you control.\nIII \u2014 You gain life equal to the greatest power among creatures you control.",
             "colours": [
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "3e83e4ab-9aff-5967-8fee-e7ab005c74db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf01666-0fbf-4b15-a33d-964165bbfafb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf01666-0fbf-4b15-a33d-964165bbfafb.jpg?1",
             "name": "Ascent of the Worthy",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Choose a creature you control. Until your next turn, all damage that would be dealt to creatures you control is dealt to that creature instead.\nIII \u2014 Return target creature card from your graveyard to the battlefield with a flying counter on it. That creature is an Angel Warrior in addition to its other types.",
             "colours": [
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "163dac49-fd7c-5d40-ad76-662be57810b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31ec15-2fe0-40ab-b320-bc4333db4787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31ec15-2fe0-40ab-b320-bc4333db4787.jpg?1",
             "name": "Battle for Bretagard",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human Warrior creature token.\nII \u2014 Create a 1/1 green Elf Warrior creature token.\nIII \u2014 Choose any number of artifact tokens and/or creature tokens you control with different names. For each of them, create a token that's a copy of it.",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "36dfdbcc-da55-51f9-bc38-aa48d6f598a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620ed5b7-8874-40d0-9245-98876bdec153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620ed5b7-8874-40d0-9245-98876bdec153.jpg?1",
             "name": "Battle of Frost and Fire",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Battle of Frost and Fire deals 4 damage to each non-Giant creature and each planeswalker.\nII \u2014 Scry 3.\nIII \u2014 Whenever you cast a spell with converted mana cost 5 or greater this turn, draw two cards, then discard a card.",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "70f3d028-7bee-510c-ba98-7c3f2117d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be43a643-6cb7-4bb6-a28d-8ad30b7fbb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be43a643-6cb7-4bb6-a28d-8ad30b7fbb6d.jpg?1",
             "name": "The Bears of Littjara",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 2/2 blue Shapeshifter creature token with changeling.\nII \u2014 Any number of target Shapeshifter creatures you control have base power and toughness 4/4.\nIII \u2014 Choose up to one target creature or planeswalker. Each creature with power 4 or greater you control deals damage equal to its power to that permanent.",
             "colours": [
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "20698034-14fa-58cc-8e6c-fbd3af624448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93ee644-d7d7-48d8-a04b-fb479b74edb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93ee644-d7d7-48d8-a04b-fb479b74edb0.jpg?1",
             "name": "Binding the Old Gods",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target nonland permanent an opponent controls.\nII \u2014 Search your library for a Forest card, put it onto the battlefield tapped, then shuffle your library.\nIII \u2014 Creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "744ccac0-1a2f-50b1-9a7a-97fcf619179a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669975ed-0501-4b48-988d-29c1215179a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669975ed-0501-4b48-988d-29c1215179a4.jpg?1",
             "name": "The Bloodsky Massacre",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 2/3 red Demon Berserker creature token with menace.\nII \u2014 Whenever a Berserker attacks this turn, you draw a card and you lose 1 life.\nIII \u2014 Add {R} for each Berserker you control. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "d757bcb3-e373-533f-8baa-054d7d35fb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7de696a-49c2-421d-a86c-bcffd68870c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7de696a-49c2-421d-a86c-bcffd68870c6.jpg?1",
             "name": "Fall of the Impostor",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put a +1/+1 counter on up to one target creature.\nIII \u2014 Exile a creature with the greatest power among creatures target opponent controls.",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "53c29ebf-2d32-5d5c-b724-6d8aed0fdcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe02fae-3e0a-402e-9f2e-f0e9c553cc1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe02fae-3e0a-402e-9f2e-f0e9c553cc1a.jpg?1",
             "name": "A-Fall of the Impostor",
             "text": "",
             "colours": [
@@ -8092,7 +8092,7 @@
         },
         {
             "id": "bcc9befa-0ae6-54a1-ba1b-abea4f724e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df87077c-85d8-499e-bce0-27697caada5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df87077c-85d8-499e-bce0-27697caada5a.jpg?1",
             "name": "Firja, Judge of Valor",
             "text": "Flying, lifelink\nWhenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "1f806470-d830-5799-8b97-3f059daebca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dff23e-d7e3-4d75-a9dc-fdf4a42f31e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03dff23e-d7e3-4d75-a9dc-fdf4a42f31e0.jpg?1",
             "name": "Firja's Retribution",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 4/4 white Angel Warrior creature token with flying and vigilance.\nII \u2014 Until end of turn, Angels you control gain \"{T}: Destroy target creature with power less than this creature's power.\"\nIII \u2014 Angels you control gain double strike until end of turn.",
             "colours": [
@@ -8169,7 +8169,7 @@
         },
         {
             "id": "58156fd3-f584-5c9c-972c-c8985f897068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce46100-461d-424e-afa4-7a0bb7d0a822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce46100-461d-424e-afa4-7a0bb7d0a822.jpg?1",
             "name": "Forging the Tyrite Sword",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a Treasure token.\nIII \u2014 Search your library for a card named Halvar, God of Battle or an Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -8205,7 +8205,7 @@
         },
         {
             "id": "e97518a4-53fa-58ad-8bb4-10423e99bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac78a2-599f-4dba-aec7-982c5ae3f75a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac78a2-599f-4dba-aec7-982c5ae3f75a.jpg?1",
             "name": "Harald, King of Skemfar",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Harald, King of Skemfar enters the battlefield, look at the top five cards of your library. You may reveal an Elf, Warrior, or Tyvar card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "d173be02-e112-56c0-8ea6-bcd613c1cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3987c7-4114-44ea-bd40-1a6054e06f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3987c7-4114-44ea-bd40-1a6054e06f09.jpg?1",
             "name": "A-Harald, King of Skemfar",
             "text": "",
             "colours": [
@@ -8284,7 +8284,7 @@
         },
         {
             "id": "f626416d-72ba-536c-aa94-36e1e3d39320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c5f681-0145-45e9-b943-ca9784cfdea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c5f681-0145-45e9-b943-ca9784cfdea0.jpg?1",
             "name": "Harald Unites the Elves",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Mill three cards. You may put an Elf or Tyvar card from your graveyard onto the battlefield.\nII \u2014 Put a +1/+1 counter on each Elf you control.\nIII \u2014 Whenever an Elf you control attacks this turn, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "30306284-3c15-5313-beef-84f0fd3e360c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db8705b7-e851-483e-a2af-bd309e62f079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db8705b7-e851-483e-a2af-bd309e62f079.jpg?1",
             "name": "A-Harald Unites the Elves",
             "text": "",
             "colours": [
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "6aedbadc-331a-5320-b8bb-111db0234182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d83d2d9-b9d0-47f5-989b-f2c726401ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d83d2d9-b9d0-47f5-989b-f2c726401ade.jpg?1",
             "name": "Immersturm Predator",
             "text": "Flying\nWhenever Immersturm Predator becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on Immersturm Predator.\nSacrifice another creature: Immersturm Predator gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -8394,7 +8394,7 @@
         },
         {
             "id": "4f22dbaf-f2bf-5264-a1d6-0b16194135b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5075a0-c72a-474c-937c-95dc9205d14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5075a0-c72a-474c-937c-95dc9205d14f.jpg?1",
             "name": "Invasion of the Giants",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Scry 2.\nII \u2014 Draw a card. Then you may reveal a Giant card from your hand. When you do, Invasion of the Giants deals 2 damage to target opponent or planeswalker.\nIII \u2014 The next Giant spell you cast this turn costs {2} less to cast.",
             "colours": [
@@ -8430,7 +8430,7 @@
         },
         {
             "id": "20e0d713-4555-526d-b1aa-16aba4b2c41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9685e2a0-5573-41bc-a914-f40c3011459b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9685e2a0-5573-41bc-a914-f40c3011459b.jpg?1",
             "name": "Kardur, Doomscourge",
             "text": "When Kardur, Doomscourge enters the battlefield, until your next turn, creatures your opponents control attack each combat if able and attack a player other than you if able.\nWhenever an attacking creature dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "7b9d0f54-9e17-59c3-86f4-f9660e6468fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233e4774-e701-42d9-aa25-e7e06c14e43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233e4774-e701-42d9-aa25-e7e06c14e43d.jpg?1",
             "name": "Kardur's Vicious Return",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You may sacrifice a creature. When you do, Kardur's Vicious Return deals 3 damage to any target.\nII \u2014 Each player discards a card.\nIII \u2014 Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it. It gains haste until your next turn.",
             "colours": [
@@ -8507,7 +8507,7 @@
         },
         {
             "id": "a337df42-7f64-5a2f-ad35-50020e3d953d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166c0bd1-b59d-4644-832f-888a4ca3a0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166c0bd1-b59d-4644-832f-888a4ca3a0aa.jpg?1",
             "name": "Kaya the Inexorable",
             "text": "+1: Put a ghostform counter on up to one target nontoken creature. It gains \"When this creature dies or is put into exile, return it to its owner's hand and create a 1/1 white Spirit creature token with flying.\"\n\u22123: Exile target nonland permanent.\n\u22127: You get an emblem with \"At the beginning of your upkeep, you may cast a legendary spell from your hand, from your graveyard, or from among cards you own in exile without paying its mana cost.\"",
             "colours": [
@@ -8547,7 +8547,7 @@
         },
         {
             "id": "95a7da1e-f1d5-5b8e-a32f-38c18700f4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30ff1fa-6639-492a-b257-934e5818c98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30ff1fa-6639-492a-b257-934e5818c98f.jpg?1",
             "name": "King Narfi's Betrayal",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player mills four cards. Then you may exile a creature or planeswalker card from each graveyard.\nII, III \u2014 Until end of turn, you may cast spells from among cards exiled with King Narfi's Betrayal, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -8583,7 +8583,7 @@
         },
         {
             "id": "7a802cbb-a47c-593f-8839-ad3a4b3c7378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f68b53-0cf7-434d-9da5-1d18c0828a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f68b53-0cf7-434d-9da5-1d18c0828a46.jpg?1",
             "name": "Koll, the Forgemaster",
             "text": "Whenever another nontoken creature you control dies, if it was enchanted or equipped, return it to its owner's hand.\nCreature tokens you control that are enchanted or equipped get +1/+1.",
             "colours": [
@@ -8624,7 +8624,7 @@
         },
         {
             "id": "30d3f784-0175-52c6-90f6-3856a4a742be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de25ea4-284a-4c16-b823-048ff00c6a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de25ea4-284a-4c16-b823-048ff00c6a03.jpg?1",
             "name": "Koma, Cosmos Serpent",
             "text": "This spell can't be countered.|\nAt the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.\nSacrifice another Serpent: Choose one \u2014\n\u2022 Tap target permanent. Its activated abilities can't be activated this turn.\n\u2022 Koma, Cosmos Serpent gains indestructible until end of turn.",
             "colours": [
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "f047c96c-816a-504a-bb9b-c2c027c5c256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3707f1-ed9d-412e-a7be-b6d8b554bd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3707f1-ed9d-412e-a7be-b6d8b554bd6c.jpg?1",
             "name": "Maja, Bretagard Protector",
             "text": "Other creatures you control get +1/+1.\nWhenever a land enters the battlefield under your control, create a 1/1 white Human Warrior creature token.",
             "colours": [
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "72fa27c5-56cc-55a8-9144-72f695cd7b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fdbe71-abca-4e48-99b2-1cb6b35d930b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fdbe71-abca-4e48-99b2-1cb6b35d930b.jpg?1",
             "name": "Moritte of the Frost",
             "text": "Changeling (This card is every creature type.)\nYou may have Moritte of the Frost enter the battlefield as a copy of a permanent you control, except it's legendary and snow in addition to its other types and, if it's a creature, it enters with two additional +1/+1 counters on it and has changeling.",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "01568f6b-7838-54f3-bd56-ea98115218a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421376e4-a4ad-427c-bc9c-d315308dcf68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421376e4-a4ad-427c-bc9c-d315308dcf68.jpg?1",
             "name": "Narfi, Betrayer King",
             "text": "Other snow and Zombie creatures you control get +1/+1.\n{S}{S}{S}: Return Narfi, Betrayer King from your graveyard to the battlefield tapped. ({S} can be paid with one mana from a snow source.)",
             "colours": [
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "13e6361e-d2a0-51de-9ebc-52fa7fd94fb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d689fc6-c7b5-46f8-9ec2-2bc4b4af87c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d689fc6-c7b5-46f8-9ec2-2bc4b4af87c0.jpg?1",
             "name": "A-Narfi, Betrayer King",
             "text": "",
             "colours": [
@@ -8827,7 +8827,7 @@
         },
         {
             "id": "a0d0f918-cfe2-5a3a-9221-dba672053ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4e9cfe-e72e-46a1-a8d8-9fda5f2bae73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4e9cfe-e72e-46a1-a8d8-9fda5f2bae73.jpg?1",
             "name": "Niko Aris",
             "text": "When Niko Aris enters the battlefield, create X Shard tokens. (They're enchantments with \"{2}, Sacrifice this enchantment: Scry 1, then draw a card.\")\n+1: Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.|\u22121: Niko Aris deals 2 damage to target tapped creature for each card you've drawn this turn.|\u22121: Create a Shard token.",
             "colours": [
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "8d4dd5f5-dff7-5361-afb6-8be79f5d448d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19312f53-5b9d-4e76-91e8-65f444bb68c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19312f53-5b9d-4e76-91e8-65f444bb68c9.jpg?1",
             "name": "Niko Defies Destiny",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You gain 2 life for each foretold card you own in exile.\nII \u2014 Add {W}{U}. Spend this mana only to foretell cards or cast spells that have foretell.\nIII \u2014 Return target card with foretell from your graveyard to your hand.",
             "colours": [
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "3df34d29-1d60-52df-84c6-e922a78bf6f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bd457-e1cc-45e1-8b2e-58f886bd6df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00bd457-e1cc-45e1-8b2e-58f886bd6df8.jpg?1",
             "name": "The Raven's Warning",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 blue Bird creature token with flying. You gain 2 life.\nII \u2014 Whenever one or more creatures you control with flying deal combat damage to a player this turn, look at that player's hand and draw a card.\nIII \u2014 You may put a card you own from outside the game on top of your library.",
             "colours": [
@@ -8939,7 +8939,7 @@
         },
         {
             "id": "cb02366a-23e2-5811-bdeb-ad57260ef512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcecf9ba-36da-490a-9460-99ff87d99fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcecf9ba-36da-490a-9460-99ff87d99fbd.jpg?1",
             "name": "Sarulf, Realm Eater",
             "text": "Whenever a permanent an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on Sarulf, Realm Eater.|\nAt the beginning of your upkeep, if Sarulf has one or more +1/+1 counters on it, you may remove all of them. If you do, exile each other nonland permanent with converted mana cost less than or equal to the number of counters removed this way.",
             "colours": [
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "5ae6c426-9021-5c9f-9883-b5dca4d7f888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9d840e-1f13-44e3-a4de-903cfa58a346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9d840e-1f13-44e3-a4de-903cfa58a346.jpg?1",
             "name": "Showdown of the Skalds",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile the top four cards of your library. Until the end of your next turn, you may play those cards.\nII, III \u2014 Whenever you cast a spell this turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -9015,7 +9015,7 @@
         },
         {
             "id": "014d710c-d4fa-5be2-bee8-1fa58c646f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7054d48-5ed3-43a1-85e5-9f306b081b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7054d48-5ed3-43a1-85e5-9f306b081b4f.jpg?1",
             "name": "Svella, Ice Shaper",
             "text": "{3}, {T}: Create a colorless snow artifact token named Icy Manalith with \"{T}: Add one mana of any color.\"\n{6}{R}{G}, {T}: Look at the top four cards of your library. You may cast a spell from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9057,7 +9057,7 @@
         },
         {
             "id": "9b4bfcad-0328-535b-a92b-291939ab2812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ce03b3-ec7c-46df-b89a-55405f3b5245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ce03b3-ec7c-46df-b89a-55405f3b5245.jpg?1",
             "name": "The Three Seasons",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Mill three cards.\nII \u2014 Return up to two target snow permanent cards from your graveyard to your hand.\nIII \u2014 Choose three cards in each graveyard. Their owners shuffle those cards into their libraries.",
             "colours": [
@@ -9093,7 +9093,7 @@
         },
         {
             "id": "833a7b24-19c0-5709-916a-58c89ff3d052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa19a68-0d71-4123-a64d-8cb76f93cd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa19a68-0d71-4123-a64d-8cb76f93cd74.jpg?1",
             "name": "The Trickster-God's Heist",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You may exchange control of two target creatures.\nII \u2014 You may exchange control of two target nonbasic, noncreature permanents that share a card type.|\nIII \u2014 Target player loses 3 life and you gain 3 life.",
             "colours": [
@@ -9129,7 +9129,7 @@
         },
         {
             "id": "203290b7-1c21-5e40-b74c-d94b06c308f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fced7f-3078-4a54-8f76-0ef14c732e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28fced7f-3078-4a54-8f76-0ef14c732e97.jpg?1",
             "name": "Vega, the Watcher",
             "text": "Flying\nWhenever you cast a spell from anywhere other than your hand, draw a card.",
             "colours": [
@@ -9170,7 +9170,7 @@
         },
         {
             "id": "5c349f97-c4ad-588f-aedb-ecd639993d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f471133-db82-4610-81fb-736fbd3b1c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f471133-db82-4610-81fb-736fbd3b1c6c.jpg?1",
             "name": "A-Vega, the Watcher",
             "text": "",
             "colours": [
@@ -9208,7 +9208,7 @@
         },
         {
             "id": "eaae0c5a-05ec-547c-aa69-4f2376bc7186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36016324-384c-4c68-8f73-8f39a244c879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36016324-384c-4c68-8f73-8f39a244c879.jpg?1",
             "name": "Waking the Trolls",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target land.\nII \u2014 Put target land card from a graveyard onto the battlefield under your control.\nIII \u2014 Choose target opponent. If they control fewer lands than you, create a number of 4/4 green Troll Warrior creature tokens with trample equal to the difference.",
             "colours": [
@@ -9244,7 +9244,7 @@
         },
         {
             "id": "0c907b47-fa7c-5b2a-b406-66d711763f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8a16f6-55c1-40eb-998f-592bf31916b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8a16f6-55c1-40eb-998f-592bf31916b1.jpg?1",
             "name": "Bloodline Pretender",
             "text": "Changeling (This card is every creature type.)\nAs Bloodline Pretender enters the battlefield, choose a creature type.\nWhenever another creature of the chosen type enters the battlefield under your control, put a +1/+1 counter on Bloodline Pretender.",
             "colours": [],
@@ -9275,7 +9275,7 @@
         },
         {
             "id": "1d2c1a0f-49a7-5627-8205-379018d5d506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3fe29-067f-4c7e-8b3b-779f3b37712a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba3fe29-067f-4c7e-8b3b-779f3b37712a.jpg?1",
             "name": "Colossal Plow",
             "text": "Whenever Colossal Plow attacks, add {W}{W}{W} and you gain 3 life. Until end of turn, you don't lose this mana as steps and phases end.\nCrew 6 (Tap any number of creatures you control with total power 6 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "2c18f906-ba7b-517c-82ec-5e8bab52cc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf084fe-7762-49c5-974a-cdecc10666b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf084fe-7762-49c5-974a-cdecc10666b3.jpg?1",
             "name": "Cosmos Elixir",
             "text": "At the beginning of your end step, draw a card if your life total is greater than your starting life total. Otherwise, you gain 2 life.",
             "colours": [],
@@ -9337,7 +9337,7 @@
         },
         {
             "id": "c7da89b2-0300-5ab9-b79d-96d192839ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f1ce0b-6668-4d16-8fe0-07c65ce4bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f1ce0b-6668-4d16-8fe0-07c65ce4bc82.jpg?1",
             "name": "A-Cosmos Elixir",
             "text": "",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "b45d821f-e930-5ee2-b2d0-dd2b632ae1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c48042-178f-432e-9eee-10bfa1e0795f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c48042-178f-432e-9eee-10bfa1e0795f.jpg?1",
             "name": "Funeral Longboat",
             "text": "Vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9394,7 +9394,7 @@
         },
         {
             "id": "0b22426f-ecc6-5764-a565-773defb71153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf5e4ad-a6e9-4b7c-a1ec-8246d3a3b6ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf5e4ad-a6e9-4b7c-a1ec-8246d3a3b6ca.jpg?1",
             "name": "Goldvein Pick",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature deals combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9424,7 +9424,7 @@
         },
         {
             "id": "bf98c5a0-5e1f-571a-b850-5ece0783cdd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471d2aef-cfd4-4131-bbc7-62eeed9f3343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471d2aef-cfd4-4131-bbc7-62eeed9f3343.jpg?1",
             "name": "Maskwood Nexus",
             "text": "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling. (It is every creature type.)",
             "colours": [],
@@ -9454,7 +9454,7 @@
         },
         {
             "id": "1df7dbb3-9309-5b56-a3c6-d0114c1f25f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9a8e44-f5de-497d-be48-adf1bcbaec97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9a8e44-f5de-497d-be48-adf1bcbaec97.jpg?1",
             "name": "Pyre of Heroes",
             "text": "{2}, {T}, Sacrifice a creature: Search your library for a creature card that shares a creature type with the sacrificed creature and has converted mana cost equal to 1 plus that creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -9484,7 +9484,7 @@
         },
         {
             "id": "745ab8ec-53b1-5724-899e-bff47f9c162a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f572cbb1-49ee-4c95-90a3-82704cf92454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f572cbb1-49ee-4c95-90a3-82704cf92454.jpg?1",
             "name": "Raiders' Karve",
             "text": "Whenever Raiders' Karve attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "10bad46d-c75f-5116-983b-5d355ff250de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60916ebe-6d84-4873-bd91-351bbe219c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60916ebe-6d84-4873-bd91-351bbe219c57.jpg?1",
             "name": "Raven Wings",
             "text": "Equipped creature gets +1/+0, has flying, and is a Bird in addition to its other types.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "e4a3fcb0-8fc9-55ff-86a6-415cea36ff2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b079e285-8431-46aa-bb04-70cac586ed0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b079e285-8431-46aa-bb04-70cac586ed0b.jpg?1",
             "name": "Replicating Ring",
             "text": "{T}: Add one mana of any color.\nAt the beginning of your upkeep, put a night counter on Replicating Ring. Then if it has eight or more night counters on it, remove all of them and create eight colorless snow artifact tokens named Replicated Ring with \"{T}: Add one mana of any color.\"",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "0def5d43-5a96-5654-8956-b901fea294fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef89770-2dbb-4a57-99f7-191591bb8e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef89770-2dbb-4a57-99f7-191591bb8e38.jpg?1",
             "name": "Runed Crown",
             "text": "When Runed Crown enters the battlefield, you may search your library, hand, and/or graveyard for a Rune card and put it onto the battlefield attached to Runed Crown. If you search your library this way, shuffle it.\nEquipped creature gets +1/+1.\nEquip {2}",
             "colours": [],
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "72001f9b-f2aa-5063-91c3-7a4e6f83e44e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa13084-3e68-49f4-8cc9-6d02286fd150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa13084-3e68-49f4-8cc9-6d02286fd150.jpg?1",
             "name": "Scorn Effigy",
             "text": "Foretell {0} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
             "colours": [],
@@ -9635,7 +9635,7 @@
         },
         {
             "id": "bf0b86d0-8f3f-57ac-9696-f7a93661a4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc2478f-e624-46fb-85af-1254564cd4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc2478f-e624-46fb-85af-1254564cd4d2.jpg?1",
             "name": "Weathered Runestone",
             "text": "Nonland permanent cards in graveyards and libraries can't enter the battlefield.\nPlayers can't cast spells from graveyards or libraries.",
             "colours": [],
@@ -9663,7 +9663,7 @@
         },
         {
             "id": "6d49419f-fc98-58a7-93b0-0f5fbaf57c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702d6b9-bb01-4841-a76d-4a576066c772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702d6b9-bb01-4841-a76d-4a576066c772.jpg?1",
             "name": "Alpine Meadow",
             "text": "({T}: Add {R} or {W}.)\nAlpine Meadow enters the battlefield tapped.",
             "colours": [],
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "66df352f-9038-570b-9a8f-d0a8442e01a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20e3117-f1e4-4449-ae9d-0b66abfc717d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20e3117-f1e4-4449-ae9d-0b66abfc717d.jpg?1",
             "name": "Arctic Treeline",
             "text": "({T}: Add {G} or {W}.)\nArctic Treeline enters the battlefield tapped.",
             "colours": [],
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "0cb9e2c6-80cc-543c-bcb2-2a7112497a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c77d35-8418-48fb-b7d7-7cfa763545c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c77d35-8418-48fb-b7d7-7cfa763545c5.jpg?1",
             "name": "Axgard Armory",
             "text": "Axgard Armory enters the battlefield tapped.\n{T}: Add {W}.\n{1}{R}{R}{W}, {T}, Sacrifice Axgard Armory: Search your library for an Aura card and/or an Equipment card, reveal them, put them into your hand, then shuffle your library.",
             "colours": [],
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "6d56c60a-3436-5c1d-8d1d-a5d64c4fe544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "c277aee9-4263-5fbe-ad24-57f5533f14da",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -9832,7 +9832,7 @@
         },
         {
             "id": "02af4608-bbde-591b-ab12-42ce070b3b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -9865,7 +9865,7 @@
         },
         {
             "id": "71ed444a-156b-5689-8923-39c30c908a69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -9898,7 +9898,7 @@
         },
         {
             "id": "0f109fda-eb89-5646-9c28-83afc2246518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0f2e2-cfd7-4374-a172-4357d5de47bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a0f2e2-cfd7-4374-a172-4357d5de47bb.jpg?1",
             "name": "Bretagard Stronghold",
             "text": "Bretagard Stronghold enters the battlefield tapped.\n{T}: Add {G}.\n{G}{W}{W}, {T}, Sacrifice Bretagard Stronghold: Put a +1/+1 counter on each of up to two target creatures you control. They gain vigilance and lifelink until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -9929,7 +9929,7 @@
         },
         {
             "id": "1a89e81d-5138-5d66-a9af-34d775d7e37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88010fdf-41e5-4303-82e2-19cfe9082270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88010fdf-41e5-4303-82e2-19cfe9082270.jpg?1",
             "name": "A-Bretagard Stronghold",
             "text": "",
             "colours": [],
@@ -9959,7 +9959,7 @@
         },
         {
             "id": "06fa03a6-0e18-5b6b-bd56-0c024cdf6026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -9992,7 +9992,7 @@
         },
         {
             "id": "72f2e3ba-ff92-51e4-b38f-5c8f3ad5652d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "5b0de032-d690-5556-b888-7c4a514e73bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cd82e5-6072-4334-a493-01ca4ad6b4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cd82e5-6072-4334-a493-01ca4ad6b4eb.jpg?1",
             "name": "Faceless Haven",
             "text": "{T}: Add {C}.\n{S}{S}{S}: Faceless Haven becomes a 4/3 creature with vigilance and all creature types until end of turn. It's still a land. ({S} can be paid with one mana from a snow source.)",
             "colours": [],
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "d547ed81-1310-5c5b-a5f4-122662e39879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2627acb7-57d9-4429-9bc5-e7dd444d8d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2627acb7-57d9-4429-9bc5-e7dd444d8d48.jpg?1",
             "name": "Gates of Istfell",
             "text": "Gates of Istfell enters the battlefield tapped.\n{T}: Add {W}.\n{2}{W}{U}{U}, {T}, Sacrifice Gates of Istfell: You gain 2 life and draw two cards.",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "d0b666aa-d8d8-5c7a-8b3c-e56f4d593822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5fadd-4559-479f-b45d-abe792f0f6e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de5fadd-4559-479f-b45d-abe792f0f6e5.jpg?1",
             "name": "Glacial Floodplain",
             "text": "({T}: Add {W} or {U}.)\nGlacial Floodplain enters the battlefield tapped.",
             "colours": [],
@@ -10124,7 +10124,7 @@
         },
         {
             "id": "943714fc-e75d-56a9-9f56-22c102a4d188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735470df-65d8-43e9-837e-4869c8e4f052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735470df-65d8-43e9-837e-4869c8e4f052.jpg?1",
             "name": "Gnottvold Slumbermound",
             "text": "Gnottvold Slumbermound enters the battlefield tapped.\n{T}: Add {R}.\n{3}{R}{G}{G}, {T}, Sacrifice Gnottvold Slumbermound: Destroy target land. Create a 4/4 green Troll Warrior creature token with trample.",
             "colours": [],
@@ -10155,7 +10155,7 @@
         },
         {
             "id": "f4cbd428-ce23-57db-88b6-a9467099d787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23c757e-5944-47ce-b06f-27b4c403044c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23c757e-5944-47ce-b06f-27b4c403044c.jpg?1",
             "name": "Great Hall of Starnheim",
             "text": "Great Hall of Starnheim enters the battlefield tapped.\n{T}: Add {B}.\n{W}{W}{B}, {T}, Sacrifice Great Hall of Starnheim and a creature you control: Create a 4/4 white Angel Warrior creature token with flying and vigilance. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10186,7 +10186,7 @@
         },
         {
             "id": "9606bf17-5049-5e6d-bcdc-994c68397b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -10219,7 +10219,7 @@
         },
         {
             "id": "5ac020f0-ccbe-52a9-99fa-fcc244cb9874",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "38302237-8c95-5b98-b71f-57dbdbac1043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682eee5f-7986-45d3-910f-407303fdbcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682eee5f-7986-45d3-910f-407303fdbcc4.jpg?1",
             "name": "Highland Forest",
             "text": "({T}: Add {R} or {G}.)\nHighland Forest enters the battlefield tapped.",
             "colours": [],
@@ -10288,7 +10288,7 @@
         },
         {
             "id": "3fa97c34-f069-59ca-8bc1-f439569cf53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cff3ef0-4dfb-472e-aa1e-77613dd0f6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cff3ef0-4dfb-472e-aa1e-77613dd0f6d8.jpg?1",
             "name": "Ice Tunnel",
             "text": "({T}: Add {U} or {B}.)\nIce Tunnel enters the battlefield tapped.",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "2bbf3b7a-6bc3-5cc3-9b92-3d96b5ac2f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ed97de-736d-43d8-977b-308ac54f88f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12ed97de-736d-43d8-977b-308ac54f88f4.jpg?1",
             "name": "Immersturm Skullcairn",
             "text": "Immersturm Skullcairn enters the battlefield tapped.\n{T}: Add {B}.\n{1}{B}{R}{R}, {T}, Sacrifice Immersturm Skullcairn: It deals 3 damage to target player. That player discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10355,7 +10355,7 @@
         },
         {
             "id": "b64e273d-95a3-5aab-936c-2cda71f352f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf2bb3e-828f-4d53-9d0a-26bbc5e7f3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf2bb3e-828f-4d53-9d0a-26bbc5e7f3cc.jpg?1",
             "name": "Littjara Mirrorlake",
             "text": "Littjara Mirrorlake enters the battlefield tapped.\n{T}: Add {U}.\n{2}{G}{G}{U}, {T}, Sacrifice Littjara Mirrorlake: Create a token that's a copy of target creature you control, except it enters the battlefield with an additional +1/+1 counter on it. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10386,7 +10386,7 @@
         },
         {
             "id": "ab6f2438-1dad-5c71-8ca6-314adc02aa2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9465a6-d009-4ecd-9fd1-d046547de902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9465a6-d009-4ecd-9fd1-d046547de902.jpg?1",
             "name": "Port of Karfell",
             "text": "Port of Karfell enters the battlefield tapped.\n{T}: Add {U}.\n{3}{U}{B}{B}, {T}, Sacrifice Port of Karfell: Mill four cards, then return a creature card from your graveyard to the battlefield tapped. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -10417,7 +10417,7 @@
         },
         {
             "id": "20d52f69-a760-5bed-a044-121dec642bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1db084-f235-4e26-8867-5f0835a0d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1db084-f235-4e26-8867-5f0835a0d283.jpg?1",
             "name": "Rimewood Falls",
             "text": "({T}: Add {G} or {U}.)\nRimewood Falls enters the battlefield tapped.",
             "colours": [],
@@ -10453,7 +10453,7 @@
         },
         {
             "id": "1310bf39-aa1a-5d51-be17-2b428cb5c0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d98db-0176-41a7-b99b-ead29876cdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09d98db-0176-41a7-b99b-ead29876cdab.jpg?1",
             "name": "Shimmerdrift Vale",
             "text": "Shimmerdrift Vale enters the battlefield tapped.\nAs Shimmerdrift Vale enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "92f2748b-86d9-5e5f-9817-30b26d851deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2a0f7-0f53-4627-8be8-227fde331a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2a0f7-0f53-4627-8be8-227fde331a69.jpg?1",
             "name": "Skemfar Elderhall",
             "text": "Skemfar Elderhall enters the battlefield tapped.\n{T}: Add {G}.\n{2}{B}{B}{G}, {T}, Sacrifice Skemfar Elderhall: Up to one target creature you don't control gets -2/-2 until end of turn. Create two 1/1 green Elf Warrior creature tokens. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10514,7 +10514,7 @@
         },
         {
             "id": "9db8841f-6850-5f1f-8128-3ff431b3668f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d305dd37-2764-46cb-8cb9-d3d2c049b36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d305dd37-2764-46cb-8cb9-d3d2c049b36c.jpg?1",
             "name": "A-Skemfar Elderhall",
             "text": "",
             "colours": [],
@@ -10544,7 +10544,7 @@
         },
         {
             "id": "31c34df2-fdef-5be4-943c-eedc7b505681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6611dc5e-6acc-48df-b8c4-4b327314578b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6611dc5e-6acc-48df-b8c4-4b327314578b.jpg?1",
             "name": "Snowfield Sinkhole",
             "text": "({T}: Add {W} or {B}.)\nSnowfield Sinkhole enters the battlefield tapped.",
             "colours": [],
@@ -10580,7 +10580,7 @@
         },
         {
             "id": "0d72a768-d9e2-5ce7-9669-5fb60a8df59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ebe245-ebb5-493c-b9c1-56fbfda9bd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ebe245-ebb5-493c-b9c1-56fbfda9bd66.jpg?1",
             "name": "Sulfurous Mire",
             "text": "({T}: Add {B} or {R}.)\nSulfurous Mire enters the battlefield tapped.",
             "colours": [],
@@ -10616,7 +10616,7 @@
         },
         {
             "id": "0980cb87-d0a4-561f-8cad-a3d8cfb3313e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b02149a-4a8f-4be9-9944-3d216248b549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b02149a-4a8f-4be9-9944-3d216248b549.jpg?1",
             "name": "Surtland Frostpyre",
             "text": "Surtland Frostpyre enters the battlefield tapped.\n{T}: Add {R}.\n{2}{U}{U}{R}, {T}, Sacrifice Surtland Frostpyre: Scry 2. Surtland Frostpyre deals 2 damage to each creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -10647,7 +10647,7 @@
         },
         {
             "id": "cbc7c862-6993-5a2a-b823-37a6cdc5cc24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ff3bf-acd3-4bea-b518-6e25f6cfce61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309ff3bf-acd3-4bea-b518-6e25f6cfce61.jpg?1",
             "name": "Tyrite Sanctum",
             "text": "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice Tyrite Sanctum: Put an indestructible counter on target God.",
             "colours": [],
@@ -10677,7 +10677,7 @@
         },
         {
             "id": "35800369-cffd-577a-af13-db87d5251ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2392fbb-d9c4-4688-b99c-4e7614c60c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2392fbb-d9c4-4688-b99c-4e7614c60c12.jpg?1",
             "name": "Volatile Fjord",
             "text": "({T}: Add {U} or {R}.)\nVolatile Fjord enters the battlefield tapped.",
             "colours": [],
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "eafca210-0895-5530-bf33-f42d940c3366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd0b71-5a60-418c-82fc-f13d1b5075d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd0b71-5a60-418c-82fc-f13d1b5075d0.jpg?1",
             "name": "Woodland Chasm",
             "text": "({T}: Add {B} or {G}.)\nWoodland Chasm enters the battlefield tapped.",
             "colours": [],
@@ -10749,7 +10749,7 @@
         },
         {
             "id": "e381a6b6-dd5b-5932-bb49-9a628871a0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70cb6d9-3955-4064-917b-11dec26440c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70cb6d9-3955-4064-917b-11dec26440c5.jpg?1",
             "name": "The World Tree",
             "text": "The World Tree enters the battlefield tapped.\n{T}: Add {G}.\nAs long as you control six or more lands, lands you control have \"{T}: Add one mana of any color.\"\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice The World Tree: Search your library for any number of God cards, put them onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -10785,7 +10785,7 @@
         },
         {
             "id": "e465e355-ab30-52dc-be34-457f7efbf059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2730f-878e-47ee-ad2a-73f8fa4e0794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2730f-878e-47ee-ad2a-73f8fa4e0794.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -10822,7 +10822,7 @@
         },
         {
             "id": "735b562f-3493-51d3-b05d-ac1345b5e52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb78693-354a-49d0-a493-430a89c6e6f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb78693-354a-49d0-a493-430a89c6e6f6.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -10859,7 +10859,7 @@
         },
         {
             "id": "74deed74-3933-5e68-988a-f08094168137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfa5ebc-5623-4eec-89ea-dc187489ee4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfa5ebc-5623-4eec-89ea-dc187489ee4a.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -10896,7 +10896,7 @@
         },
         {
             "id": "19bff48a-5ca1-5d8a-80bc-a24646ad3e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcf8c0a-cf91-42a0-a54e-da5e7c697ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcf8c0a-cf91-42a0-a54e-da5e7c697ee3.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -10933,7 +10933,7 @@
         },
         {
             "id": "55df79fb-15ed-52e0-ae57-640b8d75017b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa85af8-15f5-4620-8aea-0b45c28372ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa85af8-15f5-4620-8aea-0b45c28372ed.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -10970,7 +10970,7 @@
         },
         {
             "id": "835738a8-792c-5adb-bfb5-44e7a6b9a705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160baf7-5796-4815-8e9d-e804af70cb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160baf7-5796-4815-8e9d-e804af70cb74.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "e6be6f72-a8f7-5482-9d9b-8c590834d628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474e67c-628f-41b0-aa31-3d85a267265a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474e67c-628f-41b0-aa31-3d85a267265a.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -11044,7 +11044,7 @@
         },
         {
             "id": "d72df22a-c715-5e98-ac07-2073ddd29bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54aa46b-4b7c-4846-bf19-a289ed36c172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54aa46b-4b7c-4846-bf19-a289ed36c172.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "58d852c8-bfda-5a91-a64e-0be4e9cdae33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17acea-f079-4e53-8176-a2f5c5c408a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca17acea-f079-4e53-8176-a2f5c5c408a1.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -11118,7 +11118,7 @@
         },
         {
             "id": "9726c83a-67d0-5b08-b262-2f642844344f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe241460-f7c1-4ba8-a156-6720b494ac97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe241460-f7c1-4ba8-a156-6720b494ac97.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -11155,7 +11155,7 @@
         },
         {
             "id": "987b5b69-552c-5f3a-b7af-70a700817cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -11195,7 +11195,7 @@
         },
         {
             "id": "88be86ce-90b6-5d9d-b132-044c41baf7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86528590-6ff1-4dfa-adf2-6de05ff7b89c.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "When Valki enters the battlefield, each opponent reveals their hand. For each opponent, exile a creature card they revealed this way until Valki leaves the battlefield.\n{X}: Choose a creature card exiled with Valki with converted mana cost X. Valki becomes a copy of that card.\n\n\nTibalt\n{5}{B}{R}",
             "colours": [
@@ -11236,7 +11236,7 @@
         },
         {
             "id": "ea11f54d-b663-5a65-94b5-56feb74a68ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b35ee-03ba-43f0-8c57-29718c899719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b35ee-03ba-43f0-8c57-29718c899719.jpg?1",
             "name": "Tyvar Kell",
             "text": "Elves you control have \"{T}: Add {B}.\"\n+1: Put a +1/+1 counter on up to one target Elf. Untap it. It gains deathtouch until end of turn.\n0: Create a 1/1 green Elf Warrior creature token.\n\u22126: You get an emblem with \"Whenever you cast an Elf spell, it gains haste until end of turn and you draw two cards.\"",
             "colours": [
@@ -11275,7 +11275,7 @@
         },
         {
             "id": "19b2a48b-35b5-5831-a151-622d341b48dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e3a516-2989-4cac-892f-deb3d754ba7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e3a516-2989-4cac-892f-deb3d754ba7d.jpg?1",
             "name": "Kaya the Inexorable",
             "text": "+1: Put a ghostform counter on up to one target nontoken creature. It gains \"When this creature dies or is put into exile, return it to its owner's hand and create a 1/1 white Spirit creature token with flying.\"\n\u22123: Exile target nonland permanent.\n\u22127: You get an emblem with \"At the beginning of your upkeep, you may cast a legendary spell from your hand, from your graveyard, or from among cards you own in exile without paying its mana cost.\"",
             "colours": [
@@ -11315,7 +11315,7 @@
         },
         {
             "id": "1bb3764c-9153-568d-82e0-7b4635f81f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974a54b8-4f76-45db-a2f3-b2ed28a16cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974a54b8-4f76-45db-a2f3-b2ed28a16cac.jpg?1",
             "name": "Niko Aris",
             "text": "When Niko Aris enters the battlefield, create X Shard tokens.\n+1: Up to one target creature you control can't be blocked this turn. Whenever that creature deals damage this turn, return it to its owner's hand.\n\u22121: Niko Aris deals 2 damage to target tapped creature for each card you've drawn this turn.\n\u22121: Create a Shard token.",
             "colours": [
@@ -11355,7 +11355,7 @@
         },
         {
             "id": "82253240-82f9-5aa3-88b0-20d1b611f696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -11388,7 +11388,7 @@
         },
         {
             "id": "1bd0076a-80ad-59f7-bb8d-9dc5e3cc92ef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87c33c94-4b56-4a96-9c4c-a376f8d54943.jpg?1",
             "name": "Barkchannel Pathway // Tidechannel Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -11421,7 +11421,7 @@
         },
         {
             "id": "f77952ce-3925-5753-b2b1-45b332ab893d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11454,7 +11454,7 @@
         },
         {
             "id": "1da37e87-57bf-5a70-aaf2-aad976848548",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3933326a-2014-4ac0-bfd3-8ff26e178920.jpg?1",
             "name": "Blightstep Pathway // Searstep Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11487,7 +11487,7 @@
         },
         {
             "id": "7fc805f8-b23b-5935-8148-0ebc156f2a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11520,7 +11520,7 @@
         },
         {
             "id": "8dbc37a4-d21a-5539-8e45-ef2955a0456d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/501ceec3-c196-4db4-980d-31edf6232acf.jpg?1",
             "name": "Darkbore Pathway // Slitherbore Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "d34646f9-c799-5b3c-9ef8-eab6776a6d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11586,7 +11586,7 @@
         },
         {
             "id": "033eb1e7-7536-52c0-a371-44267b8fb9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/8/b851c41b-ed73-4ee4-9063-544f97f35f67.jpg?1",
             "name": "Hengegate Pathway // Mistgate Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11619,7 +11619,7 @@
         },
         {
             "id": "32ee01b6-0341-5578-b2dd-322a805318d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86999e06-62a3-4878-8db0-dc36b52d9794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86999e06-62a3-4878-8db0-dc36b52d9794.jpg?1",
             "name": "Starnheim Unleashed",
             "text": "Create a 4/4 white Angel Warrior creature token with flying and vigilance. If this spell was foretold, create X of those tokens instead.\nForetell {X}{X}{W}",
             "colours": [
@@ -11653,7 +11653,7 @@
         },
         {
             "id": "bac6e8a9-f20c-5240-91ef-2d1cf0c233e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd24105-4202-4690-bb62-16d0b9c291c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd24105-4202-4690-bb62-16d0b9c291c9.jpg?1",
             "name": "Alrund's Epiphany",
             "text": "Create two 1/1 blue Bird creature tokens with flying. Take an extra turn after this one. Exile Alrund's Epiphany.\nForetell {4}{U}{U}",
             "colours": [
@@ -11687,7 +11687,7 @@
         },
         {
             "id": "5431111e-d54e-534f-b42a-39719fa54568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fb42a-9faf-4873-bf46-c80af7d34934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fb42a-9faf-4873-bf46-c80af7d34934.jpg?1",
             "name": "Haunting Voyage",
             "text": "Choose a creature type. Return up to two creature cards of that type from your graveyard to the battlefield. If this spell was foretold, return all creature cards of that type from your graveyard to the battlefield instead.\nForetell {5}{B}{B}",
             "colours": [
@@ -11721,7 +11721,7 @@
         },
         {
             "id": "d104d1ed-d847-5ffc-a62b-47ece43a746b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f7850-8fe6-4487-9b1e-52e27e9f7244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f7850-8fe6-4487-9b1e-52e27e9f7244.jpg?1",
             "name": "Quakebringer",
             "text": "Your opponents can't gain life.\nAt the beginning of your upkeep, Quakebringer deals 2 damage to each opponent. This ability triggers only if Quakebringer is on the battlefield or if Quakebringer is in your graveyard and you control a Giant.\nForetell {2}{R}{R}",
             "colours": [
@@ -11758,7 +11758,7 @@
         },
         {
             "id": "0c720d6c-2c0f-53cb-8e5c-34c6215b48c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87cd73-9149-4e48-acff-dcfce4bd1b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87cd73-9149-4e48-acff-dcfce4bd1b11.jpg?1",
             "name": "Battle Mammoth",
             "text": "Trample\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\nForetell {2}{G}{G}",
             "colours": [
@@ -11794,7 +11794,7 @@
         },
         {
             "id": "435e9aeb-7f95-51aa-8e18-bf324fe3187d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -11832,7 +11832,7 @@
         },
         {
             "id": "52b1b2b0-0e53-5c80-b62b-de28b4582171",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/feddb683-a8f8-4def-bd3e-6d630c42cd34.jpg?1",
             "name": "Halvar, God of Battle // Sword of the Realms",
             "text": "Creatures you control that are enchanted or equipped have double strike.\nAt the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.\n\n\nEquipment\n{1}{W}",
             "colours": [
@@ -11870,7 +11870,7 @@
         },
         {
             "id": "40fe6ac7-6154-5d84-8431-394c4d6ca155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -11908,7 +11908,7 @@
         },
         {
             "id": "1ab602f9-7872-538e-8e22-a7de15590101",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c717b484-4b88-4073-a185-71b6085e7324.jpg?1",
             "name": "Reidane, God of the Worthy // Valkmira, Protector's Shield",
             "text": "Flying, vigilance\nSnow lands your opponents control enter the battlefield tapped.\nNoncreature spells your opponents cast with converted mana cost 4 or greater cost {2} more to cast.\n\n\nArtifact\n{3}{W}",
             "colours": [
@@ -11944,7 +11944,7 @@
         },
         {
             "id": "e938a863-bbaa-5a20-9b62-56cc3b62f14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4654f703-db16-4221-8ec2-bc6832b4ef83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4654f703-db16-4221-8ec2-bc6832b4ef83.jpg?1",
             "name": "Sigrid, God-Favored",
             "text": "Flash\nFirst strike, protection from God creatures\nWhen Sigrid, God-Favored enters the battlefield, exile up to one target attacking or blocking creature until Sigrid leaves the battlefield.",
             "colours": [
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "fdeede86-c85a-56cb-8106-5734d7505b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -12021,7 +12021,7 @@
         },
         {
             "id": "94d856f7-f456-574b-b962-a2dcebc08e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg?1",
             "name": "Alrund, God of the Cosmos // Hakka, Whispering Raven",
             "text": "Alrund gets +1/+1 for each card in your hand and each foretold card you own in exile.\nAt the beginning of your end step, choose a card type, then reveal the top two cards of your library. Put all cards of the chosen type into your hand and the rest on the bottom of your library in any order.\n\n\nBird\n{1}{U}",
             "colours": [
@@ -12059,7 +12059,7 @@
         },
         {
             "id": "4aa56cf4-4ed0-512e-bf2c-06b27c4aea33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -12097,7 +12097,7 @@
         },
         {
             "id": "ac4ffd71-aa91-5694-8a0d-b0e303ca5385",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b660733-6ed4-49a6-ae4c-e9e4f9c851cf.jpg?1",
             "name": "Cosima, God of the Voyage // The Omenkeel",
             "text": "At the beginning of your upkeep, you may exile Cosima. If you do, it gains \"Whenever a land enters the battlefield under your control, if Cosima is exiled, you may put a voyage counter on it. If you don't, return Cosima to the battlefield with X +1/+1 counters on it and draw X cards, where X is the number of voyage counters on it.\"\n\n\nVehicle\n{1}{U}",
             "colours": [
@@ -12135,7 +12135,7 @@
         },
         {
             "id": "058089cf-8130-5735-b7c5-d0a974bb36bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d1b1a2-3861-4fbb-955b-4f3f8fcca9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d1b1a2-3861-4fbb-955b-4f3f8fcca9a7.jpg?1",
             "name": "Inga Rune-Eyes",
             "text": "When Inga Rune-Eyes enters the battlefield, scry 3.\nWhen Inga Rune-Eyes dies, draw three cards if three or more creatures died this turn.",
             "colours": [
@@ -12174,7 +12174,7 @@
         },
         {
             "id": "c61cdb9b-6888-59c2-8aec-9dd6777a2c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d700064-1fda-4de0-9576-17a3faa5f04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d700064-1fda-4de0-9576-17a3faa5f04c.jpg?1",
             "name": "Orvar, the All-Form",
             "text": "Changeling\nWhenever you cast an instant or sorcery spell, if it targets one or more other permanents you control, create a token that's a copy of one of those permanents.\nWhen a spell or ability an opponent controls causes you to discard this card, create a token that's a copy of target permanent.",
             "colours": [
@@ -12212,7 +12212,7 @@
         },
         {
             "id": "da81c5e0-e073-54ee-b4c9-8467e5fd3c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -12250,7 +12250,7 @@
         },
         {
             "id": "d6d2604f-d6b2-5b02-b10a-f74d2ffb2142",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/ddfef9b6-4c78-49ac-b97c-5ddbbd8be7ef.jpg?1",
             "name": "Egon, God of Death // Throne of Death",
             "text": "Deathtouch\nAt the beginning of your upkeep, exile two cards from your graveyard. If you can't, sacrifice Egon and draw a card.\n\n\nArtifact\n{B}",
             "colours": [
@@ -12286,7 +12286,7 @@
         },
         {
             "id": "ebba06ad-eae1-5a32-9fe6-ebc7d3eeeec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -12324,7 +12324,7 @@
         },
         {
             "id": "c67bd337-137d-5f48-aaa9-9eab721bc018",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9ff4efdf-c0bb-443a-a100-2f3850571e91.jpg?1",
             "name": "Tergrid, God of Fright // Tergrid's Lantern",
             "text": "Menace\nWhenever an opponent sacrifices a nontoken permanent or discards a permanent card, you may put that card from a graveyard onto the battlefield under your control.\n\n\nArtifact\n{3}{B}",
             "colours": [
@@ -12360,7 +12360,7 @@
         },
         {
             "id": "7d929665-72d1-578b-b2e2-c0695f343242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "As Tibalt enters the battlefield, you get an emblem with \"You may play cards exiled with Tibalt, Cosmic Impostor, and you may spend mana as though it were mana of any color to cast those spells.\"\n+2: Exile the top card of each player's library.\n\u22123: Exile target artifact or creature.\n\u22128: Exile all cards from all graveyards. Add {R}{R}{R}.\n\n\nGod\n{1}{B}",
             "colours": [
@@ -12400,7 +12400,7 @@
         },
         {
             "id": "98eb886b-7695-52c2-9cc7-b7017e62d44a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e3e5c965-a689-4726-b8c2-63b836895939.jpg?1",
             "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
             "text": "As Tibalt enters the battlefield, you get an emblem with \"You may play cards exiled with Tibalt, Cosmic Impostor, and you may spend mana as though it were mana of any color to cast those spells.\"\n+2: Exile the top card of each player's library.\n\u22123: Exile target artifact or creature.\n\u22128: Exile all cards from all graveyards. Add {R}{R}{R}.\n\n\nGod\n{1}{B}",
             "colours": [
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "5c3a0a89-86c1-548c-974e-c3104e65475b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656a371-639f-4e4b-889f-4ee0bc085030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656a371-639f-4e4b-889f-4ee0bc085030.jpg?1",
             "name": "Varragoth, Bloodsky Sire",
             "text": "Deathtouch\nBoast \u2014 {1}{B}: Target player searches their library for a card, then shuffles their library and puts that card on top of it.",
             "colours": [
@@ -12480,7 +12480,7 @@
         },
         {
             "id": "4bde37de-39a2-50d3-ae4b-4dc60b9ca526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29945a0a-5d40-4305-b996-579177c8e8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29945a0a-5d40-4305-b996-579177c8e8bf.jpg?1",
             "name": "Arni Brokenbrow",
             "text": "Haste\nBoast \u2014 {1}: You may change Arni Brokenbrow's base power to 1 plus the greatest power among other creatures you control until end of turn.",
             "colours": [
@@ -12519,7 +12519,7 @@
         },
         {
             "id": "a79d2038-b76f-5112-8cf8-78c91050d0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -12557,7 +12557,7 @@
         },
         {
             "id": "af16a633-1a07-5752-8bb4-503c859c8e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54dccbc0-528c-4e99-a6db-f2373978fe5f.jpg?1",
             "name": "Birgi, God of Storytelling // Harnfel, Horn of Bounty",
             "text": "Whenever you cast a spell, add {R}. Until end of turn, you don't lose this mana as steps and phases end.\nCreatures you control can boast twice during each of your turns rather than once.\n\n\nArtifact\n{4}{R}",
             "colours": [
@@ -12593,7 +12593,7 @@
         },
         {
             "id": "6f4c1e6b-ff04-5fd4-95aa-0ac2c3c1a30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab551f0e-7a9c-4c99-b199-042ab018dd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab551f0e-7a9c-4c99-b199-042ab018dd9a.jpg?1",
             "name": "Magda, Brazen Outlaw",
             "text": "Other Dwarves you control get +1/+0.\nWhenever a Dwarf you control becomes tapped, create a Treasure token.\nSacrifice five Treasures: Search your library for an artifact or Dragon card, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -12632,7 +12632,7 @@
         },
         {
             "id": "0c779216-7abd-56f1-aa40-f4953b6f9324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -12670,7 +12670,7 @@
         },
         {
             "id": "6a91169d-f7bc-554e-b366-2aca4666101a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5af80f3b-229d-43f8-976e-50bee70b32e7.jpg?1",
             "name": "Toralf, God of Fury // Toralf's Hammer",
             "text": "Trample\nWhenever a creature or planeswalker an opponent controls is dealt excess noncombat damage, Toralf deals damage equal to the excess to any target other than that permanent.\n\n\nEquipment\n{1}{R}",
             "colours": [
@@ -12708,7 +12708,7 @@
         },
         {
             "id": "04d0bed8-7fde-5991-9d53-27fc0732646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -12750,7 +12750,7 @@
         },
         {
             "id": "b8e15f58-1152-5c18-ae93-70ae50f71024",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ced8571a-24e1-45be-8698-3314b663940a.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "Vigilance\n{T}: Add one mana of any color.\nOther legendary creatures you control have vigilance and \"{T}: Add one mana of any color.\"\n\n\nEnchantment\n{W}{U}{B}{R}{G}",
             "colours": [
@@ -12794,7 +12794,7 @@
         },
         {
             "id": "bb5621e2-a916-5081-bc15-7f31b32b5b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a7d7e5-428d-4f42-8f13-9908fc65dcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a7d7e5-428d-4f42-8f13-9908fc65dcb4.jpg?1",
             "name": "Esika's Chariot",
             "text": "When Esika's Chariot enters the battlefield, create two 2/2 green Cat creature tokens.\nWhenever Esika's Chariot attacks, create a token that's a copy of target token you control.\nCrew 4",
             "colours": [
@@ -12832,7 +12832,7 @@
         },
         {
             "id": "2e7d93a4-1be2-591c-8404-b6ab0a1b5aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb2319b-e23b-46df-87e6-c256f0cb111e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb2319b-e23b-46df-87e6-c256f0cb111e.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters.",
             "colours": [
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "c46d13c0-1daa-551c-86e0-9c6b0d00aa8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -12912,7 +12912,7 @@
         },
         {
             "id": "e6be0e0d-28b6-5d0f-8cbd-0a4ccaab2774",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/950ecba7-90b1-42bc-a5f4-ab8d9e9607ee.jpg?1",
             "name": "Jorn, God of Winter // Kaldring, the Rimestaff",
             "text": "Whenever Jorn attacks, untap each snow permanent you control.\n\n\nArtifact\n{1}{U}{B}",
             "colours": [
@@ -12952,7 +12952,7 @@
         },
         {
             "id": "27010f7d-06fe-5438-a4fb-9b6696868694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "66d1354d-0c08-5695-b698-2fd6defbb16c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aabe2c58-620a-4caa-880f-326676422fe7.jpg?1",
             "name": "Kolvori, God of Kinship // The Ringhart Crest",
             "text": "As long as you control three or more legendary creatures, Kolvori gets +4/+2 and has vigilance.\n{1}{G}, {T}: Look at the top six cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nArtifact\n{1}{G}",
             "colours": [
@@ -13026,7 +13026,7 @@
         },
         {
             "id": "f3ccaee9-e1ab-5311-b434-89c8c1103403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eb31f3-7686-4d6b-a0e4-5d6ece6fba82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eb31f3-7686-4d6b-a0e4-5d6ece6fba82.jpg?1",
             "name": "Toski, Bearer of Secrets",
             "text": "This spell can't be countered.\nIndestructible\nToski, Bearer of Secrets attacks each combat if able.\nWhenever a creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -13064,7 +13064,7 @@
         },
         {
             "id": "f85a6483-b319-54a8-ac93-3dfe883fd166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db03ef-db89-43c4-89b4-d48e0620e101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6db03ef-db89-43c4-89b4-d48e0620e101.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "Trample, haste\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.",
             "colours": [
@@ -13106,7 +13106,7 @@
         },
         {
             "id": "49afd9b6-c8dc-5e1d-aa41-08a75e709b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edac3fd7-8124-4614-ae50-651608d45adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edac3fd7-8124-4614-ae50-651608d45adb.jpg?1",
             "name": "Aegar, the Freezing Flame",
             "text": "Whenever a creature or planeswalker an opponent controls is dealt excess damage, if a Giant, Wizard, or spell you controlled dealt damage to it this turn, draw a card.",
             "colours": [
@@ -13147,7 +13147,7 @@
         },
         {
             "id": "77565329-79b3-5a18-aa5a-26a0883f256f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8cdd5-e55b-40e0-a61e-f28890f5628d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec8cdd5-e55b-40e0-a61e-f28890f5628d.jpg?1",
             "name": "Firja, Judge of Valor",
             "text": "Flying, lifelink\nWhenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -13188,7 +13188,7 @@
         },
         {
             "id": "11e878e6-9c60-55d5-9784-76e68e41aaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc37772-7052-46a9-a34e-f982331595a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc37772-7052-46a9-a34e-f982331595a3.jpg?1",
             "name": "Harald, King of Skemfar",
             "text": "Menace\nWhen Harald, King of Skemfar enters the battlefield, look at the top five cards of your library. You may reveal an Elf, Warrior, or Tyvar card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13229,7 +13229,7 @@
         },
         {
             "id": "5cd6ce63-9906-58e9-9ab3-793f71be3e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc779ac-a418-4cd0-aa73-8d0d91d51f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc779ac-a418-4cd0-aa73-8d0d91d51f1c.jpg?1",
             "name": "Kardur, Doomscourge",
             "text": "When Kardur, Doomscourge enters the battlefield, until your next turn, creatures your opponents control attack each combat if able and attack a player other than you if able.\nWhenever an attacking creature dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -13270,7 +13270,7 @@
         },
         {
             "id": "13a9e01b-606c-5429-b6ee-5854ef24b251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37533179-8e58-40bc-af16-0d2c58b773ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37533179-8e58-40bc-af16-0d2c58b773ba.jpg?1",
             "name": "Koll, the Forgemaster",
             "text": "Whenever another nontoken creature you control dies, if it was enchanted or equipped, return it to its owner's hand.\nCreature tokens you control that are enchanted or equipped get +1/+1.",
             "colours": [
@@ -13311,7 +13311,7 @@
         },
         {
             "id": "1e259488-4036-5d9c-b3f6-78dce29a9e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876ad1df-e926-4d89-aad7-499a37b27f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876ad1df-e926-4d89-aad7-499a37b27f4c.jpg?1",
             "name": "Koma, Cosmos Serpent",
             "text": "This spell can't be countered.\nAt the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.\nSacrifice another Serpent: Choose one \u2014\n\u2022 Tap target permanent. Its activated abilities can't be activated this turn.\n\u2022 Koma, Cosmos Serpent gains indestructible until end of turn.",
             "colours": [
@@ -13351,7 +13351,7 @@
         },
         {
             "id": "09dca96c-7cf2-5107-9fe8-180743b9ad55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8832509-497d-4253-bbb1-92adfb69368f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8832509-497d-4253-bbb1-92adfb69368f.jpg?1",
             "name": "Maja, Bretagard Protector",
             "text": "Other creatures you control get +1/+1.\nWhenever a land enters the battlefield under your control, create a 1/1 white Human Warrior creature token.",
             "colours": [
@@ -13392,7 +13392,7 @@
         },
         {
             "id": "a5abb453-3513-5a78-98bc-3d27950fcdde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47d29bb-8710-4a3d-8789-38956fa7a2be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47d29bb-8710-4a3d-8789-38956fa7a2be.jpg?1",
             "name": "Moritte of the Frost",
             "text": "Changeling\nYou may have Moritte of the Frost enter the battlefield as a copy of a permanent you control, except it's legendary and snow in addition to its other types and, if it's a creature, it enters with two additional +1/+1 counters on it and has changeling.",
             "colours": [
@@ -13433,7 +13433,7 @@
         },
         {
             "id": "43368cb3-36ff-5773-b8b7-2edb19ef829b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ecbec4-0f29-4795-a16c-15e7ca55af4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ecbec4-0f29-4795-a16c-15e7ca55af4f.jpg?1",
             "name": "Narfi, Betrayer King",
             "text": "Other snow and Zombie creatures you control get +1/+1.\n{S}{S}{S}: Return Narfi, Betrayer King from your graveyard to the battlefield tapped.",
             "colours": [
@@ -13475,7 +13475,7 @@
         },
         {
             "id": "a29c8fbd-de53-5e70-86d7-09560c186ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b31046-d84d-4afa-a207-bb6cccac4339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b31046-d84d-4afa-a207-bb6cccac4339.jpg?1",
             "name": "Sarulf, Realm Eater",
             "text": "Whenever a permanent an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on Sarulf, Realm Eater.\nAt the beginning of your upkeep, if Sarulf has one or more +1/+1 counters on it, you may remove all of them. If you do, exile each other nonland permanent with converted mana cost less than or equal to the number of counters removed this way.",
             "colours": [
@@ -13515,7 +13515,7 @@
         },
         {
             "id": "5497f0a8-6f0c-55ba-aa13-4a3726276bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec553af-5254-4812-bb68-cd6d853f693a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec553af-5254-4812-bb68-cd6d853f693a.jpg?1",
             "name": "Svella, Ice Shaper",
             "text": "{3}, {T}: Create a colorless snow artifact token named Icy Manalith with \"{T}: Add one mana of any color.\"\n{6}{R}{G}, {T}: Look at the top four cards of your library. You may cast a spell from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "d79921bd-c201-5eb5-9900-8c98ad47bc04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd1fc45-531e-4e0c-9e1b-c665447e88ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd1fc45-531e-4e0c-9e1b-c665447e88ef.jpg?1",
             "name": "Vega, the Watcher",
             "text": "Flying\nWhenever you cast a spell from anywhere other than your hand, draw a card.",
             "colours": [
@@ -13598,7 +13598,7 @@
         },
         {
             "id": "1128b16a-0e6a-50aa-b4e7-f188fea3f0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4b4019-b73d-4be3-991e-2deb811ee675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4b4019-b73d-4be3-991e-2deb811ee675.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "Trample, haste\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\nIf an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.",
             "colours": [
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "cc57e6e7-a690-5c21-88e7-6e1c384bbc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdeb7c77-0507-4534-a314-696a6871bdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdeb7c77-0507-4534-a314-696a6871bdbf.jpg?1",
             "name": "Doomskar",
             "text": "Destroy all creatures.\nForetell {1}{W}{W}",
             "colours": [
@@ -13674,7 +13674,7 @@
         },
         {
             "id": "7826b2ca-8cfb-525a-97c5-512e682cbcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5008bc-edbc-4ad1-9a06-7eea5723db26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5008bc-edbc-4ad1-9a06-7eea5723db26.jpg?1",
             "name": "Glorious Protector",
             "text": "Flash\nFlying\nWhen Glorious Protector enters the battlefield, you may exile any number of non-Angel creatures you control until Glorious Protector leaves the battlefield.\nForetell {2}{W}",
             "colours": [
@@ -13711,7 +13711,7 @@
         },
         {
             "id": "10ef2283-d844-5dfb-b15b-045c9cc2377a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661481d-62cc-4c00-a53f-1cee380d9d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b661481d-62cc-4c00-a53f-1cee380d9d75.jpg?1",
             "name": "Rally the Ranks",
             "text": "As Rally the Ranks enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.",
             "colours": [
@@ -13745,7 +13745,7 @@
         },
         {
             "id": "5c4bc0fd-fe23-5f9a-9e35-3f146f28f477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39906ca0-0f52-42fa-8266-add1860c7a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39906ca0-0f52-42fa-8266-add1860c7a4d.jpg?1",
             "name": "Resplendent Marshal",
             "text": "Flying\nWhen Resplendent Marshal enters the battlefield or dies, you may exile another creature card from your graveyard. When you do, put a +1/+1 counter on each creature you control other than Resplendent Marshal that shares a creature type with the exiled card.",
             "colours": [
@@ -13782,7 +13782,7 @@
         },
         {
             "id": "59783387-ba17-5e95-8a00-d89153b8102f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ff8c9f-a865-4570-8bd3-8229a18e5c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ff8c9f-a865-4570-8bd3-8229a18e5c99.jpg?1",
             "name": "Righteous Valkyrie",
             "text": "Flying\nWhenever another Angel or Cleric enters the battlefield under your control, you gain life equal to that creature's toughness.\nAs long as you have at least 7 life more than your starting life total, creatures you control get +2/+2.",
             "colours": [
@@ -13819,7 +13819,7 @@
         },
         {
             "id": "ac9c1ada-8cb7-5fa1-ac1b-6b4cc3b04b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5a934-3a6c-43b6-b369-2b422f0bc8a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5a934-3a6c-43b6-b369-2b422f0bc8a2.jpg?1",
             "name": "Runeforge Champion",
             "text": "When Runeforge Champion enters the battlefield, you may search your library and/or graveyard for a Rune card, reveal it, and put it into your hand. If you search your library this way, shuffle it.\nYou may pay {1} rather than pay the mana cost for Rune spells you cast.",
             "colours": [
@@ -13856,7 +13856,7 @@
         },
         {
             "id": "106ead4a-be16-5c0d-80ca-a14830b8ee90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd06b52f-f14d-48f1-9eb8-b17b2af4689e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd06b52f-f14d-48f1-9eb8-b17b2af4689e.jpg?1",
             "name": "Search for Glory",
             "text": "Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle your library. You gain 1 life for each {S} spent to cast this spell.",
             "colours": [
@@ -13892,7 +13892,7 @@
         },
         {
             "id": "0abcb984-49c1-5a7c-946d-f42327922986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336490d-5a97-49e9-b772-3435eeede65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336490d-5a97-49e9-b772-3435eeede65d.jpg?1",
             "name": "Ascendant Spirit",
             "text": "{S}{S}: Ascendant Spirit becomes a Spirit Warrior with base power and toughness 2/3.\n{S}{S}{S}: If Ascendant Spirit is a Warrior, put a flying counter on it and it becomes a Spirit Warrior Angel with base power and toughness 4/4.\n{S}{S}{S}{S}: If Ascendant Spirit is an Angel, put two +1/+1 counters on it and it gains \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -13930,7 +13930,7 @@
         },
         {
             "id": "6426097b-5bf6-5b0b-a15f-25a582007b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058feb-4331-49cc-aab2-33908cfafe1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058feb-4331-49cc-aab2-33908cfafe1b.jpg?1",
             "name": "Cosmos Charger",
             "text": "Flash\nFlying\nForetelling cards from your hand costs {1} less and can be done on any player's turn.\nForetell {2}{U}",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "de072243-47ac-5d5e-8dc1-440a34d867e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3420845c-bcb3-4969-9c21-bf4732babfe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3420845c-bcb3-4969-9c21-bf4732babfe2.jpg?1",
             "name": "Cyclone Summoner",
             "text": "When Cyclone Summoner enters the battlefield, if you cast it from your hand, return all permanents to their owners' hands except for Giants, Wizards, and lands.",
             "colours": [
@@ -14004,7 +14004,7 @@
         },
         {
             "id": "813110fd-4705-5e46-8dbe-307661d287d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2d932-0051-4efd-8dd0-3711c5645744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2d932-0051-4efd-8dd0-3711c5645744.jpg?1",
             "name": "Graven Lore",
             "text": "Scry X, where X is the amount of {S} spent to cast this spell, then draw three cards.",
             "colours": [
@@ -14040,7 +14040,7 @@
         },
         {
             "id": "b354d699-e2ce-5325-960f-ced4ac9343ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91f3b0-70fa-48f6-901b-756790a26100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91f3b0-70fa-48f6-901b-756790a26100.jpg?1",
             "name": "Icebreaker Kraken",
             "text": "This spell costs {1} less to cast for each snow land you control.\nWhen Icebreaker Kraken enters the battlefield, artifacts and creatures target opponent controls don't untap during that player's next untap step.\nReturn three snow lands you control to their owner's hand: Return Icebreaker Kraken to its owner's hand.",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "ab0add61-5a41-5597-bbbd-6abbbec66657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557b3c7-98c6-4362-9a89-b71f0feaaaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557b3c7-98c6-4362-9a89-b71f0feaaaec.jpg?1",
             "name": "Mystic Reflection",
             "text": "Choose target nonlegendary creature. The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of the chosen creature.\nForetell {U}",
             "colours": [
@@ -14112,7 +14112,7 @@
         },
         {
             "id": "51c5d32d-cc3f-5478-bcf1-176c0eeb5cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694973a3-cf8b-4e5f-a0cd-40b7396c2550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694973a3-cf8b-4e5f-a0cd-40b7396c2550.jpg?1",
             "name": "Reflections of Littjara",
             "text": "As Reflections of Littjara enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, copy that spell.",
             "colours": [
@@ -14147,7 +14147,7 @@
         },
         {
             "id": "28e2958c-e66c-590b-b35b-b86a9ca9aecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd7d506-2f02-47a2-8786-fdccbb60f28c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd7d506-2f02-47a2-8786-fdccbb60f28c.jpg?1",
             "name": "Blood on the Snow",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all planeswalkers.\nThen return a creature or planeswalker card with converted mana cost X or less from your graveyard to the battlefield, where X is the amount of {S} spent to cast this spell.",
             "colours": [
@@ -14183,7 +14183,7 @@
         },
         {
             "id": "7983b00b-d4ab-5a5c-b46d-3b42fc2d61aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3b0c3b-896e-4d1e-b7fb-670718ba97d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3b0c3b-896e-4d1e-b7fb-670718ba97d4.jpg?1",
             "name": "Burning-Rune Demon",
             "text": "Flying\nWhen Burning-Rune Demon enters the battlefield, you may search your library for exactly two cards not named Burning-Rune Demon that have different names. If you do, reveal those cards. An opponent chooses one of them. Put the chosen card into your hand and the other into your graveyard, then shuffle your library.",
             "colours": [
@@ -14220,7 +14220,7 @@
         },
         {
             "id": "7fc965d6-1ff2-5deb-86e1-8f6e063d48ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7aaf8-f0e0-481f-bca4-25c612f2d63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7aaf8-f0e0-481f-bca4-25c612f2d63b.jpg?1",
             "name": "Crippling Fear",
             "text": "Choose a creature type. Creatures that aren't of the chosen type get -3/-3 until end of turn.",
             "colours": [
@@ -14254,7 +14254,7 @@
         },
         {
             "id": "eb77ab35-313e-5968-bfb7-22805372d87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a6725d-7a76-40e6-ace3-e19d0ac8e817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a6725d-7a76-40e6-ace3-e19d0ac8e817.jpg?1",
             "name": "Draugr Necromancer",
             "text": "If a nontoken creature an opponent controls would die, exile that card with an ice counter on it instead.\nYou may cast spells from among cards in exile your opponents own with ice counters on them, and you may spend mana from snow sources as though it were mana of any color to cast those spells.",
             "colours": [
@@ -14293,7 +14293,7 @@
         },
         {
             "id": "980f24ab-b5b8-5f49-aa37-82df58f5f995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c01887-d4b3-46d2-af6b-2877659d057f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c01887-d4b3-46d2-af6b-2877659d057f.jpg?1",
             "name": "Dream Devourer",
             "text": "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}.\nWhenever you foretell a card, Dream Devourer gets +2/+0 until end of turn.",
             "colours": [
@@ -14330,7 +14330,7 @@
         },
         {
             "id": "e794e047-18d4-539c-97d9-3b88cf45a688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41fdfb7-4d0d-4030-a085-9c692f1783ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41fdfb7-4d0d-4030-a085-9c692f1783ed.jpg?1",
             "name": "Eradicator Valkyrie",
             "text": "Flying, lifelink, hexproof from planeswalkers\nBoast \u2014 {1}{B}, Sacrifice a creature: Each opponent sacrifices a creature or planeswalker.",
             "colours": [
@@ -14367,7 +14367,7 @@
         },
         {
             "id": "44d02f77-f2db-56d3-b6eb-d70cffa50796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68e39-e3a9-4f9e-ba43-bd4b126a9137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68e39-e3a9-4f9e-ba43-bd4b126a9137.jpg?1",
             "name": "Rise of the Dread Marn",
             "text": "Create X 2/2 black Zombie Berserker creature tokens, where X is the number of nontoken creatures that died this turn.\nForetell {B}",
             "colours": [
@@ -14401,7 +14401,7 @@
         },
         {
             "id": "0b62b8b9-b190-55ec-ae81-677f7ace049a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b5346e-b9d1-4214-a15e-c082fb0e0949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b5346e-b9d1-4214-a15e-c082fb0e0949.jpg?1",
             "name": "Skemfar Avenger",
             "text": "Whenever another nontoken Elf or Berserker you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -14438,7 +14438,7 @@
         },
         {
             "id": "4f631924-efe9-5363-ae54-e3e2a388bf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b7a0b-4657-4f89-a2da-933199fa58fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b7a0b-4657-4f89-a2da-933199fa58fa.jpg?1",
             "name": "Calamity Bearer",
             "text": "If a Giant source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -14475,7 +14475,7 @@
         },
         {
             "id": "66858e4d-d847-53eb-bdbe-47ac067c6209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fadbe4-ecb4-4e89-8db4-1cf910b510cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fadbe4-ecb4-4e89-8db4-1cf910b510cf.jpg?1",
             "name": "Dragonkin Berserker",
             "text": "First strike\nBoast abilities you activate cost {1} less to activate for each Dragon you control.\nBoast \u2014 {4}{R}: Create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "847a7d02-dc3b-5e26-9a7f-2ecfdda2f9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cec498-e2ac-4ca0-9aa2-ef98ba634c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cec498-e2ac-4ca0-9aa2-ef98ba634c32.jpg?1",
             "name": "Goldspan Dragon",
             "text": "Flying, haste\nWhenever Goldspan Dragon attacks or becomes the target of a spell, create a Treasure token.\nTreasures you control have \"{T}, Sacrifice this artifact: Add two mana of any one color.\"",
             "colours": [
@@ -14548,7 +14548,7 @@
         },
         {
             "id": "1806d520-92ba-52e8-a7ed-b5dc495f6d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328adc1b-2e28-4615-a65b-4874dd2a1af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328adc1b-2e28-4615-a65b-4874dd2a1af5.jpg?1",
             "name": "Reckless Crew",
             "text": "Create X 2/1 red Dwarf Berserker creature tokens, where X is the number of Vehicles you control plus the number of Equipment you control. For each of those tokens, you may attach an Equipment you control to it.",
             "colours": [
@@ -14582,7 +14582,7 @@
         },
         {
             "id": "45429708-a0c4-5133-8293-df48914bb825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f5b3-1685-42b6-b838-3e19f1f6b36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9067f5b3-1685-42b6-b838-3e19f1f6b36e.jpg?1",
             "name": "Tibalt's Trickery",
             "text": "Counter target spell. Choose 1, 2, or 3 at random. Its controller mills that many cards, then exiles cards from the top of their library until they exile a nonland card with a different name than that spell. They may cast that card without paying its mana cost. Then they put the exiled cards on the bottom of their library in a random order.",
             "colours": [
@@ -14616,7 +14616,7 @@
         },
         {
             "id": "48ffebf4-c0ae-5ca7-bef6-341b874a5edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50112dbc-275c-47ab-adb1-e9c4de002f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50112dbc-275c-47ab-adb1-e9c4de002f40.jpg?1",
             "name": "Tundra Fumarole",
             "text": "Tundra Fumarole deals 4 damage to target creature or planeswalker. Add {C} for each {S} spent to cast this spell. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -14652,7 +14652,7 @@
         },
         {
             "id": "d6f30239-7c91-5673-aa12-d715ca07dfd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8018046-568d-4550-863a-dbab6f5d2210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8018046-568d-4550-863a-dbab6f5d2210.jpg?1",
             "name": "Blessing of Frost",
             "text": "Distribute X +1/+1 counters among any number of creatures you control, where X is the amount of {S} spent to cast this spell. Then draw a card for each creature you control with power 4 or greater.",
             "colours": [
@@ -14688,7 +14688,7 @@
         },
         {
             "id": "669c1fe3-a30f-5c31-9e19-487c27bc1bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e59380e-2c82-46a9-9749-4dcb978d5419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e59380e-2c82-46a9-9749-4dcb978d5419.jpg?1",
             "name": "Elvish Warmaster",
             "text": "Whenever one or more other Elves enters the battlefield under your control, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
             "colours": [
@@ -14725,7 +14725,7 @@
         },
         {
             "id": "0ccf7083-1532-5b35-8c16-40b6a46fec73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f75c3ad-839a-4658-9706-5d9df7ce6dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f75c3ad-839a-4658-9706-5d9df7ce6dff.jpg?1",
             "name": "In Search of Greatness",
             "text": "At the beginning of your upkeep, you may cast a permanent spell from your hand with converted mana cost equal to 1 plus the highest converted mana cost among other permanents you control without paying its mana cost. If you don't, scry 1.",
             "colours": [
@@ -14759,7 +14759,7 @@
         },
         {
             "id": "902d4447-e251-574b-99b6-0e27b09c8372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125915dd-0499-4690-8897-4c8906e9817c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125915dd-0499-4690-8897-4c8906e9817c.jpg?1",
             "name": "Old-Growth Troll",
             "text": "Trample\nWhen Old-Growth Troll dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add {G}{G}' and \u2018{1}, {T}, Sacrifice this land: Create a tapped 4/4 green Troll Warrior creature token with trample.'\"",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "6de10eb7-1660-56c2-a9c0-1f7a477d27c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367b007-5985-448d-9203-67c22195d708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367b007-5985-448d-9203-67c22195d708.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "e8996db8-1529-5b93-b75c-b7359f629b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222d66-137b-4707-b28a-a23549b1ee35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d222d66-137b-4707-b28a-a23549b1ee35.jpg?1",
             "name": "Immersturm Predator",
             "text": "Flying\nWhenever Immersturm Predator becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on Immersturm Predator.\nSacrifice another creature: Immersturm Predator gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -14872,7 +14872,7 @@
         },
         {
             "id": "deb656e8-0c16-5d01-aa57-6c38be5c5bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea524e81-4898-4a41-8b34-06defd26e4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea524e81-4898-4a41-8b34-06defd26e4c7.jpg?1",
             "name": "Cosmos Elixir",
             "text": "At the beginning of your end step, draw a card if your life total is greater than your starting life total. Otherwise, you gain 2 life.",
             "colours": [],
@@ -14902,7 +14902,7 @@
         },
         {
             "id": "571409c8-c232-53d4-9879-824c4859ba81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45887949-7cc6-4f83-a659-fb3284685c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45887949-7cc6-4f83-a659-fb3284685c7d.jpg?1",
             "name": "Maskwood Nexus",
             "text": "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling.",
             "colours": [],
@@ -14932,7 +14932,7 @@
         },
         {
             "id": "b7312844-152b-5f08-be4e-6e43e1abda93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba697b79-e3e4-4574-87bd-b7f8c4ce6c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba697b79-e3e4-4574-87bd-b7f8c4ce6c52.jpg?1",
             "name": "Pyre of Heroes",
             "text": "{2}, {T}, Sacrifice a creature: Search your library for a creature card that shares a creature type with the sacrificed creature and has converted mana cost equal to 1 plus that creature's converted mana cost. Put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -14962,7 +14962,7 @@
         },
         {
             "id": "7a0792e7-91c3-5c07-98a3-fab3b2322804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21481b68-2396-4c94-956d-55d7427eeeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21481b68-2396-4c94-956d-55d7427eeeb6.jpg?1",
             "name": "Faceless Haven",
             "text": "{T}: Add {C}.\n{S}{S}{S}: Faceless Haven becomes a 4/3 creature with vigilance and all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -14994,7 +14994,7 @@
         },
         {
             "id": "a137a199-75bb-5edd-8a5c-0f0cf3bbb4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cc143-3ef2-4e08-a5e3-41753f0f704c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923cc143-3ef2-4e08-a5e3-41753f0f704c.jpg?1",
             "name": "Tyrite Sanctum",
             "text": "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice Tyrite Sanctum: Put an indestructible counter on target God.",
             "colours": [],
@@ -15024,7 +15024,7 @@
         },
         {
             "id": "21ed76d8-d964-5ee1-9d7c-d0d3bf45e0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999fa01b-4e54-4e3e-973d-7af137a53684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999fa01b-4e54-4e3e-973d-7af137a53684.jpg?1",
             "name": "The World Tree",
             "text": "The World Tree enters the battlefield tapped.\n{T}: Add {G}.\nAs long as you control six or more lands, lands you control have \"{T}: Add one mana of any color.\"\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice The World Tree: Search your library for any number of God cards, put them onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -15060,7 +15060,7 @@
         },
         {
             "id": "ce2706eb-94b9-5647-9b5f-55c3ce7cbbd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab83a9-35b5-4312-b8ee-1c042c02aa31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edab83a9-35b5-4312-b8ee-1c042c02aa31.jpg?1",
             "name": "Valkyrie Harbinger",
             "text": "Flying, lifelink\nAt the beginning of each end step, if you gained 4 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.",
             "colours": [
@@ -15095,7 +15095,7 @@
         },
         {
             "id": "5d34cfb8-272f-50e1-93b9-e56f3facf192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9e7fdc-676f-4901-83ff-bfea3a96d937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9e7fdc-676f-4901-83ff-bfea3a96d937.jpg?1",
             "name": "Surtland Elementalist",
             "text": "As an additional cost to cast this spell, reveal a Giant card from your hand or pay {2}.\nWhenever Surtland Elementalist attacks, you may cast an instant or sorcery spell from your hand without paying its mana cost.",
             "colours": [
@@ -15130,7 +15130,7 @@
         },
         {
             "id": "f49e77ac-9441-51e2-8418-efd1fc1f64bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59dadef-74e5-47c7-a3e0-51075ddb82b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59dadef-74e5-47c7-a3e0-51075ddb82b1.jpg?1",
             "name": "Cleaving Reaper",
             "text": "Flying, trample\nPay 3 life: Return Cleaving Reaper from your graveyard to your hand. Activate this ability only if you had an Angel or Berserker enter the battlefield under your control this turn.",
             "colours": [
@@ -15165,7 +15165,7 @@
         },
         {
             "id": "ff9fa178-10c5-5888-8bea-f750cc90c51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a628052-8175-495f-bfab-eeb3a0388e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a628052-8175-495f-bfab-eeb3a0388e4e.jpg?1",
             "name": "Surtland Flinger",
             "text": "Whenever Surtland Flinger attacks, you may sacrifice another creature. When you do, Surtland Flinger deals damage equal to the sacrificed creature's power to any target. If the sacrificed creature was a Giant, Surtland Flinger deals twice that much damage instead.",
             "colours": [
@@ -15200,7 +15200,7 @@
         },
         {
             "id": "46b99860-424f-5dd8-8b32-fd627985e3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg?1",
             "name": "Canopy Tactician",
             "text": "Other Elves you control get +1/+1.\n{T}: Add {G}{G}{G}.",
             "colours": [
@@ -15235,7 +15235,7 @@
         },
         {
             "id": "2f2df7f1-fc88-5aab-a5b5-b8778a0f167c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693eb7cb-a78c-4d79-b4de-f59da76cce31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/693eb7cb-a78c-4d79-b4de-f59da76cce31.jpg?1",
             "name": "A-Canopy Tactician",
             "text": "",
             "colours": [
@@ -15269,7 +15269,7 @@
         },
         {
             "id": "28986538-dd9b-5b18-a7d4-d6114163e049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c1253-7eba-454b-9269-3695ba746a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4c1253-7eba-454b-9269-3695ba746a7a.jpg?1",
             "name": "Armed and Armored",
             "text": "Vehicles you control become artifact creatures until end of turn. Choose a Dwarf you control. Attach any number of Equipment you control to it.",
             "colours": [
@@ -15301,7 +15301,7 @@
         },
         {
             "id": "4752c551-540f-5a4a-9325-213cdb119608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea007a18-b31a-4881-92c4-86120dc5729b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea007a18-b31a-4881-92c4-86120dc5729b.jpg?1",
             "name": "Starnheim Aspirant",
             "text": "Angel spells you cast cost {2} less to cast.",
             "colours": [
@@ -15336,7 +15336,7 @@
         },
         {
             "id": "8c06a9af-089d-55ea-91b4-c878b4727047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79c5e95-f6c6-4e2f-9c6c-d99addb757ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79c5e95-f6c6-4e2f-9c6c-d99addb757ac.jpg?1",
             "name": "Warchanter Skald",
             "text": "Whenever Warchanter Skald becomes tapped, if it's enchanted or equipped, create a 2/1 red Dwarf Berserker creature token.",
             "colours": [
@@ -15371,7 +15371,7 @@
         },
         {
             "id": "3b29814d-2076-5ce8-9bee-532ae666436c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe93b27-f8ae-4abf-8ade-90f503f132c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe93b27-f8ae-4abf-8ade-90f503f132c2.jpg?1",
             "name": "Youthful Valkyrie",
             "text": "Flying\nWhenever another Angel enters the battlefield under your control, put a +1/+1 counter on Youthful Valkyrie.",
             "colours": [
@@ -15405,7 +15405,7 @@
         },
         {
             "id": "fa3e1540-8f7c-5fcc-9aaf-19b6b4af1c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c6bcc-2d43-4ea9-a93f-019793616869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c6bcc-2d43-4ea9-a93f-019793616869.jpg?1",
             "name": "Absorb Identity",
             "text": "Return target creature to its owner's hand. You may have Shapeshifters you control become copies of that creature until end of turn.",
             "colours": [
@@ -15437,7 +15437,7 @@
         },
         {
             "id": "c75e8a57-0bf6-5ffa-96e2-b38b3e229e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c92d48-504a-4320-b9f4-c1d2d06fa223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c92d48-504a-4320-b9f4-c1d2d06fa223.jpg?1",
             "name": "Giant's Grasp",
             "text": "Enchant Giant you control\nWhen Giant's Grasp enters the battlefield, gain control of target nonland permanent for as long as Giant's Grasp remains on the battlefield.",
             "colours": [
@@ -15471,7 +15471,7 @@
         },
         {
             "id": "785ced98-24fe-5498-9ad8-264c1229b471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57348f93-8764-4b1a-b02e-4e7881337fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57348f93-8764-4b1a-b02e-4e7881337fa2.jpg?1",
             "name": "Elderfang Ritualist",
             "text": "When Elderfang Ritualist dies, return another target Elf card from your graveyard to your hand.",
             "colours": [
@@ -15506,7 +15506,7 @@
         },
         {
             "id": "5c799e07-7291-5d9e-b5ca-a4d252b97cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62872f7d-26ab-40b7-96db-955e576ec110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62872f7d-26ab-40b7-96db-955e576ec110.jpg?1",
             "name": "A-Elderfang Ritualist",
             "text": "",
             "colours": [
@@ -15540,7 +15540,7 @@
         },
         {
             "id": "8e5de290-77a4-5746-b232-20b9d24a9d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5675655-dc9f-45ad-9cd0-ce28fba1f972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5675655-dc9f-45ad-9cd0-ce28fba1f972.jpg?1",
             "name": "Renegade Reaper",
             "text": "Flying\nWhen Renegade Reaper enters the battlefield, mill four cards. If at least one Angel card is milled this way, you gain 4 life.(To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -15575,7 +15575,7 @@
         },
         {
             "id": "a530a668-ef38-5b6f-bed2-f3e190787554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b6477-cefa-40e2-a96a-72794c7eb815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544b6477-cefa-40e2-a96a-72794c7eb815.jpg?1",
             "name": "Thornmantle Striker",
             "text": "When Thornmantle Striker enters the battlefield, choose one \u2014\n\u2022 Remove X counters from target permanent, where X is the number of Elves you control.\n\u2022 Target creature an opponent controls gets -X/-X until end of turn, where X is the number of Elves you control.",
             "colours": [
@@ -15610,7 +15610,7 @@
         },
         {
             "id": "4112d86a-7e8d-5d58-89ee-48b957a9ac78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7a57af-b44d-476d-8f11-43c54eff52b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7a57af-b44d-476d-8f11-43c54eff52b2.jpg?1",
             "name": "A-Thornmantle Striker",
             "text": "",
             "colours": [
@@ -15644,7 +15644,7 @@
         },
         {
             "id": "366277a8-08f5-5867-bb66-7918fd8e4157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2381dbab-e968-4bbc-b3a7-a1e55b066039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2381dbab-e968-4bbc-b3a7-a1e55b066039.jpg?1",
             "name": "Bearded Axe",
             "text": "Equipped creature gets +1/+1 for each Dwarf, Equipment, and/or Vehicle you control.\nEquip {2}",
             "colours": [
@@ -15678,7 +15678,7 @@
         },
         {
             "id": "2322de92-1215-5212-89bc-6200ff7d2708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f05d49-dfc1-4dad-89e0-07174330d98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f05d49-dfc1-4dad-89e0-07174330d98e.jpg?1",
             "name": "Fire Giant's Fury",
             "text": "Target Giant you control gets +2/+2 and gains trample until end of turn. Whenever it deals combat damage to a player this turn, exile that many cards from the top of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -15710,7 +15710,7 @@
         },
         {
             "id": "e011c8a1-ed28-53e1-85a1-8c5d44f4c9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5274c2fa-eb0e-438b-8a48-d0b58829083a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5274c2fa-eb0e-438b-8a48-d0b58829083a.jpg?1",
             "name": "Gilded Assault Cart",
             "text": "Trample\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)\nSacrifice two Treasures: Return Gilded Assault Cart from your graveyard to your hand.",
             "colours": [
@@ -15744,7 +15744,7 @@
         },
         {
             "id": "346d97d0-2040-56f9-ab3d-cfb8a0971adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70479c44-da7c-48c7-8c6a-47210dc03277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70479c44-da7c-48c7-8c6a-47210dc03277.jpg?1",
             "name": "Elven Ambush",
             "text": "Create a 1/1 green Elf Warrior creature token for each Elf you control.",
             "colours": [
@@ -15776,7 +15776,7 @@
         },
         {
             "id": "c9b1157c-70df-5cea-97ce-3beb853b8ca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8053b888-a680-4318-88c3-0924e596e780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8053b888-a680-4318-88c3-0924e596e780.jpg?1",
             "name": "Gladewalker Ritualist",
             "text": "Changeling (This card is every creature type.)\nWhenever another creature named Gladewalker Ritualist enters the battlefield under your control, draw a card.",
             "colours": [
@@ -15810,7 +15810,7 @@
         },
         {
             "id": "feaebc0f-001b-5f90-b56d-2b1e63400986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e928b7c-ca30-4e2d-adf7-965f111c8bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e928b7c-ca30-4e2d-adf7-965f111c8bf1.jpg?1",
             "name": "Rampage of the Valkyries",
             "text": "When Rampage of the Valkyries enters the battlefield, create a 4/4 white Angel creature token with flying and vigilance.\nWhenever an Angel you control dies, each other player sacrifices a creature.",
             "colours": [
@@ -15844,7 +15844,7 @@
         },
         {
             "id": "805b69dc-31dd-50fb-bd2b-4051f90916ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbfbafa-f58f-40b2-a374-68ac35b77d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbfbafa-f58f-40b2-a374-68ac35b77d89.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15878,7 +15878,7 @@
         },
         {
             "id": "8c527336-7b37-5dba-bfbf-297cfaf76765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a25a714-c7f3-4697-8b69-8f966b4d370a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a25a714-c7f3-4697-8b69-8f966b4d370a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "dd6ddc65-4585-5a60-9bdf-798201c5270d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e61c0-b185-4704-913f-9284ed0ce250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e61c0-b185-4704-913f-9284ed0ce250.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15946,7 +15946,7 @@
         },
         {
             "id": "e59d6211-1b9d-567a-8dd0-84f2c90524b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69419307-53d5-40d7-82da-cab2e7bfbda4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69419307-53d5-40d7-82da-cab2e7bfbda4.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15980,7 +15980,7 @@
         },
         {
             "id": "4ac153f5-8a7c-5128-8135-64b1c0c851e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e307c-b2e3-47ac-aac2-59f0c3542fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771e307c-b2e3-47ac-aac2-59f0c3542fa6.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16014,7 +16014,7 @@
         },
         {
             "id": "63ef8762-36b8-5891-97ae-744d0e5d3f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a0877c-5217-422d-89b8-92f951068693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a0877c-5217-422d-89b8-92f951068693.jpg?1",
             "name": "Realmwalker",
             "text": "Changeling (This card is every creature type.)\nAs Realmwalker enters the battlefield, choose a creature type.\nYou may look at the top card of your library any time.\nYou may cast creature spells of the chosen type from the top of your library.",
             "colours": [
@@ -16050,7 +16050,7 @@
         },
         {
             "id": "2153dd69-cac3-5c07-8647-ed32b4008c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebaa07d-68f6-4cdb-a5cd-cd715e50abf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebaa07d-68f6-4cdb-a5cd-cd715e50abf5.jpg?1",
             "name": "Reflections of Littjara",
             "text": "",
             "colours": [
@@ -16084,7 +16084,7 @@
         },
         {
             "id": "b9a54462-1cff-5826-9fdf-dd95d9f3278c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7811579-0d01-4fae-b621-98eb6c0355f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7811579-0d01-4fae-b621-98eb6c0355f6.jpg?1",
             "name": "Usher of the Fallen",
             "text": "",
             "colours": [
@@ -16121,7 +16121,7 @@
         },
         {
             "id": "8c6c9d42-9ede-5959-9807-0f3761eb91ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994fff9f-ded1-4741-b48a-e95fd88f9b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994fff9f-ded1-4741-b48a-e95fd88f9b3b.jpg?1",
             "name": "Strategic Planning",
             "text": "",
             "colours": [
@@ -16155,7 +16155,7 @@
         },
         {
             "id": "8e6646e0-0ab6-5fc8-968e-2ec1deeaaf92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397f533-204b-4187-b4fe-4e7f067ea3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a397f533-204b-4187-b4fe-4e7f067ea3f4.jpg?1",
             "name": "Poison the Cup",
             "text": "",
             "colours": [
@@ -16189,7 +16189,7 @@
         },
         {
             "id": "010e3000-b734-55f2-b6c2-f12d112b224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24345ae-c2c9-435e-a578-1835bb1a9a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24345ae-c2c9-435e-a578-1835bb1a9a00.jpg?1",
             "name": "Frost Bite",
             "text": "",
             "colours": [
@@ -16225,7 +16225,7 @@
         },
         {
             "id": "c9e37fc8-0563-5573-9d67-9405afa5d92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ace8e69-7550-4c40-bf63-59cb95603391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ace8e69-7550-4c40-bf63-59cb95603391.jpg?1",
             "name": "Masked Vandal",
             "text": "",
             "colours": [
@@ -16261,7 +16261,7 @@
         },
         {
             "id": "e4febcb9-880e-5548-a4f2-961c29296f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff018fe2-9feb-431d-b4c5-61b2ed0d919d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff018fe2-9feb-431d-b4c5-61b2ed0d919d.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "",
             "colours": [
@@ -16303,7 +16303,7 @@
         },
         {
             "id": "0eaaec31-25c2-517e-9ec4-977c85c63ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7412d90-b864-4a9c-9f8b-a28e86b9a03d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7412d90-b864-4a9c-9f8b-a28e86b9a03d.jpg?1",
             "name": "Vorinclex, Monstrous Raider",
             "text": "",
             "colours": [
@@ -16344,7 +16344,7 @@
         },
         {
             "id": "872a2f10-d48f-541d-a27b-a8f3ae7bb23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df826c7d-5508-4e21-848c-91bc3e3f447a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df826c7d-5508-4e21-848c-91bc3e3f447a.jpg?1",
             "name": "Shard",
             "text": "",
             "colours": [],
@@ -16375,7 +16375,7 @@
         },
         {
             "id": "cb069841-fefe-546d-a730-38c9abe208e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd871a3-3802-4bdc-8033-3ecfd01c0449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd871a3-3802-4bdc-8033-3ecfd01c0449.jpg?1",
             "name": "Angel Warrior",
             "text": "",
             "colours": [
@@ -16411,7 +16411,7 @@
         },
         {
             "id": "6804f50f-17f5-5b4e-bac5-c5bc7fbdc337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06fbcd85-c54e-492e-9e42-5e101cac4255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06fbcd85-c54e-492e-9e42-5e101cac4255.jpg?1",
             "name": "Human Warrior",
             "text": "",
             "colours": [
@@ -16447,7 +16447,7 @@
         },
         {
             "id": "8afdab41-b0bd-517e-9bc1-728e671c0f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95694c03-2b3b-455c-8361-0799c078bf04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95694c03-2b3b-455c-8361-0799c078bf04.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16482,7 +16482,7 @@
         },
         {
             "id": "b5963847-fa34-5396-84fd-23bd855482af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0cb299-057d-4c39-9d73-3a3512526e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0cb299-057d-4c39-9d73-3a3512526e4a.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16517,7 +16517,7 @@
         },
         {
             "id": "87d70064-55f4-5d8b-a130-f794038946b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40a0cb8-0caf-4dd1-b7d0-abbc626985d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40a0cb8-0caf-4dd1-b7d0-abbc626985d2.jpg?1",
             "name": "Giant Wizard",
             "text": "",
             "colours": [
@@ -16553,7 +16553,7 @@
         },
         {
             "id": "7fe69ac3-3746-5976-a53c-e4d06492050c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1c6a9-3531-4432-9157-e4400dbc89fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1c6a9-3531-4432-9157-e4400dbc89fd.jpg?1",
             "name": "Koma's Coil",
             "text": "",
             "colours": [
@@ -16588,7 +16588,7 @@
         },
         {
             "id": "4619d1ad-f2df-56e6-b96e-c8e204239231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef775ad0-b1a9-4254-ab6f-304558bb77a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef775ad0-b1a9-4254-ab6f-304558bb77a1.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [
@@ -16623,7 +16623,7 @@
         },
         {
             "id": "5ee687f2-f19b-59a0-b6c9-e881606998a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bbd379-6728-4c6b-b375-295926fe6b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bbd379-6728-4c6b-b375-295926fe6b00.jpg?1",
             "name": "Zombie Berserker",
             "text": "",
             "colours": [
@@ -16659,7 +16659,7 @@
         },
         {
             "id": "1e44480c-8578-5b74-b4d4-a5e3a4729f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58def55-f2ca-4c41-b891-c32e5220fc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58def55-f2ca-4c41-b891-c32e5220fc66.jpg?1",
             "name": "Demon Berserker",
             "text": "",
             "colours": [
@@ -16695,7 +16695,7 @@
         },
         {
             "id": "ff07ac7d-b9fe-5fa5-8402-45ce70e5a9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029c9790-d5f3-4fe2-a2f5-6da5d27de835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029c9790-d5f3-4fe2-a2f5-6da5d27de835.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "11581c55-ec27-5d91-83fe-0b7cd7d7257a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142bbbe1-4446-4d80-b82d-0df8ef17eac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142bbbe1-4446-4d80-b82d-0df8ef17eac1.jpg?1",
             "name": "Dwarf Berserker",
             "text": "",
             "colours": [
@@ -16766,7 +16766,7 @@
         },
         {
             "id": "6e8cb570-6b9b-5a4e-b1a5-dcae91a6b8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53abaa-b316-496d-9351-318a9dd9de4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53abaa-b316-496d-9351-318a9dd9de4d.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -16801,7 +16801,7 @@
         },
         {
             "id": "f7683af3-3bef-5b9d-8b81-9e78afc97371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e07758f-0d1c-47d9-ba5a-43bc2a7423cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e07758f-0d1c-47d9-ba5a-43bc2a7423cd.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16836,7 +16836,7 @@
         },
         {
             "id": "ba573e3a-81c4-55a0-97c6-2aa6f0c7269e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118d0655-5719-4512-8bc1-fe759669811b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118d0655-5719-4512-8bc1-fe759669811b.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -16872,7 +16872,7 @@
         },
         {
             "id": "dbeac9d3-edd3-574a-9bdb-c8d419f6a373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8869a8cc-d196-417f-bba5-5ed31bae6a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8869a8cc-d196-417f-bba5-5ed31bae6a18.jpg?1",
             "name": "Troll Warrior",
             "text": "",
             "colours": [
@@ -16908,7 +16908,7 @@
         },
         {
             "id": "bc456a8c-3810-5b38-aa34-abc21261ee4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db39e3b-fad4-4c9b-911f-69883ac7e0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db39e3b-fad4-4c9b-911f-69883ac7e0e1.jpg?1",
             "name": "Icy Manalith",
             "text": "",
             "colours": [],
@@ -16939,7 +16939,7 @@
         },
         {
             "id": "51e0d2f4-5611-5adb-9795-be83c6b7d516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ce1236-ec2f-4cd1-9701-ba6ead74c220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ce1236-ec2f-4cd1-9701-ba6ead74c220.jpg?1",
             "name": "Replicated Ring",
             "text": "",
             "colours": [],
@@ -16970,7 +16970,7 @@
         },
         {
             "id": "fc9da973-a626-5457-808e-f83f5ae6c6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae9f454-4f8c-4123-9886-674bc439dfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae9f454-4f8c-4123-9886-674bc439dfe7.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17001,7 +17001,7 @@
         },
         {
             "id": "4e0e50a2-acf1-5745-b605-8a1800110fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b149bbf-5d2a-4f7e-aa87-23edd5848cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b149bbf-5d2a-4f7e-aa87-23edd5848cde.jpg?1",
             "name": "Kaya the Inexorable Emblem",
             "text": "",
             "colours": [],
@@ -17029,7 +17029,7 @@
         },
         {
             "id": "e887464c-161a-5e13-9b5b-1335a033042b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62490ac-4838-4b68-baff-18d9823a2a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62490ac-4838-4b68-baff-18d9823a2a7f.jpg?1",
             "name": "Tibalt, Cosmic Impostor Emblem",
             "text": "",
             "colours": [],
@@ -17057,7 +17057,7 @@
         },
         {
             "id": "6ffda757-579d-563a-862f-3c64eab1edb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53162f62-5327-4f2d-8f34-e90de2a1c818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53162f62-5327-4f2d-8f34-e90de2a1c818.jpg?1",
             "name": "Tyvar Kell Emblem",
             "text": "",
             "colours": [],
@@ -17085,7 +17085,7 @@
         },
         {
             "id": "8e042dc9-2a57-525d-b26f-eae5ef1fdadf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb02637f-1385-4d3d-8dc0-de513db7633a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb02637f-1385-4d3d-8dc0-de513db7633a.jpg?1",
             "name": "Foretell",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/KLD.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/KLD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c31d87c4-6781-55fe-ba94-0ca2e7bc1594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f92174-f38f-4623-a5f7-f5be7f7dcc9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f92174-f38f-4623-a5f7-f5be7f7dcc9d.jpg?1",
             "name": "Acrobatic Maneuver",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "0ca3c205-8e19-50f7-8495-4cbc8f9041ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956adc86-c0d9-4408-837e-b5def19af1ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956adc86-c0d9-4408-837e-b5def19af1ec.jpg?1",
             "name": "Aerial Responder",
             "text": "Flying, vigilance, lifelink",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "efefd57d-cce8-56b2-9f1e-939472dc779f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb7541-7a27-40a5-aabd-fce26df03485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb7541-7a27-40a5-aabd-fce26df03485.jpg?1",
             "name": "Aetherstorm Roc",
             "text": "Flying\nWhenever Aetherstorm Roc or another creature enters the battlefield under your control, you get {E} (an energy counter).\nWhenever Aetherstorm Roc attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it and tap up to one target creature defending player controls.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "b06601ed-b1ae-5e9a-9da8-f043fed7b3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3920f7d-8559-40f8-95be-860c16bf7700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3920f7d-8559-40f8-95be-860c16bf7700.jpg?1",
             "name": "Angel of Invention",
             "text": "Flying, vigilance, lifelink\nFabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)\nOther creatures you control get +1/+1.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "d8dcf5ee-fd60-53a0-b89e-2849dcde901f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b2f55-1e09-490e-8f7e-bfde85a91ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b2f55-1e09-490e-8f7e-bfde85a91ac4.jpg?1",
             "name": "Authority of the Consuls",
             "text": "Creatures your opponents control enter the battlefield tapped.\nWhenever a creature enters the battlefield under an opponent's control, you gain 1 life.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "5d3e543d-bfd1-5bcc-a335-0886bee0cf3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97b0767-4308-4e5d-bc12-6cf8d8724797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97b0767-4308-4e5d-bc12-6cf8d8724797.jpg?1",
             "name": "Aviary Mechanic",
             "text": "When Aviary Mechanic enters the battlefield, you may return another permanent you control to its owner's hand.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "bd45ddb7-aa4f-5b94-88b7-57c8d4060cf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e09a4-93d0-4ed7-bbee-82108672d5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e09a4-93d0-4ed7-bbee-82108672d5f8.jpg?1",
             "name": "Built to Last",
             "text": "Target creature gets +2/+2 until end of turn. If it's an artifact creature, it gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "8be2a739-990a-5c4d-a723-ca3875735b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c20018-4446-4c2b-bdc5-53fcf1fbc3bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c20018-4446-4c2b-bdc5-53fcf1fbc3bf.jpg?1",
             "name": "Captured by the Consulate",
             "text": "Enchant creature you don't control\nEnchanted creature can't attack.\nWhenever an opponent casts a spell, if it has a single target, change the target to enchanted creature if able.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "1dddca31-23ef-59bc-8e31-f8467082079a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b10947b-c276-41c4-b72c-efcddd94d13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b10947b-c276-41c4-b72c-efcddd94d13b.jpg?1",
             "name": "Cataclysmic Gearhulk",
             "text": "Vigilance\nWhen Cataclysmic Gearhulk enters the battlefield, each player chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents he or she controls, then sacrifices the rest.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "a8225a76-2a58-5325-9616-2868821b8840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c92238-7765-48ee-a799-9e8b68ec118d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c92238-7765-48ee-a799-9e8b68ec118d.jpg?1",
             "name": "Consulate Surveillance",
             "text": "When Consulate Surveillance enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}{E}: Prevent all damage that would be dealt to you this turn by a source of your choice.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "bfaa801a-00c1-585e-8437-e81396b6a7ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b66d65-1981-4abf-b27f-e9a1b2800110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b66d65-1981-4abf-b27f-e9a1b2800110.jpg?1",
             "name": "Consul's Shieldguard",
             "text": "When Consul's Shieldguard enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Consul's Shieldguard attacks, you may pay {E}. If you do, another target attacking creature gains indestructible until end of turn.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "7c9d36be-d510-551a-b755-f812968f5d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dcaec6-4cb9-46d8-aed1-46f33c67dff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dcaec6-4cb9-46d8-aed1-46f33c67dff2.jpg?1",
             "name": "Eddytrail Hawk",
             "text": "Flying\nWhen Eddytrail Hawk enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Eddytrail Hawk attacks, you may pay {E}. If you do, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "fc0dc38f-4342-5bd0-851e-28d3df2ed9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b6c8f3-76b7-4954-8608-023304cdec3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b6c8f3-76b7-4954-8608-023304cdec3e.jpg?1",
             "name": "Fairgrounds Warden",
             "text": "When Fairgrounds Warden enters the battlefield, exile target creature an opponent controls until Fairgrounds Warden leaves the battlefield.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "26b455c8-f3dd-5b58-a02d-e87dfda4c5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf09deb-2607-4eb0-94a7-9584e771fdfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf09deb-2607-4eb0-94a7-9584e771fdfb.jpg?1",
             "name": "Fragmentize",
             "text": "Destroy target artifact or enchantment with converted mana cost 4 or less.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "33354b1a-4224-5379-8a97-ff4f232b0875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00f27a7-9e92-4fbf-baa8-f47a5eee48a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00f27a7-9e92-4fbf-baa8-f47a5eee48a6.jpg?1",
             "name": "Fumigate",
             "text": "Destroy all creatures. You gain 1 life for each creature destroyed this way.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "ff1947a9-823d-50f7-8a63-ff3d65d2a292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c6a9d-6169-40f8-8b3e-53ebf75be663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c6a9d-6169-40f8-8b3e-53ebf75be663.jpg?1",
             "name": "Gearshift Ace",
             "text": "First strike\nWhenever Gearshift Ace crews a Vehicle, that Vehicle gains first strike until end of turn.",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "4cd3c928-9dec-50c4-af10-8568f154e54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e39e79b-2755-4fb4-86b5-b6e350ce9514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e39e79b-2755-4fb4-86b5-b6e350ce9514.jpg?1",
             "name": "Glint-Sleeve Artisan",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "77add2f5-00c6-59fc-9349-4f364ec7a682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9ed217-8378-4a58-a00d-fa4e4cb27c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9ed217-8378-4a58-a00d-fa4e4cb27c9d.jpg?1",
             "name": "Herald of the Fair",
             "text": "When Herald of the Fair enters the battlefield, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "ae790286-c000-5b15-ae41-0a9ad9cca1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2921c95e-bf2f-409b-a41d-86d873690562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2921c95e-bf2f-409b-a41d-86d873690562.jpg?1",
             "name": "Impeccable Timing",
             "text": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "7cc84310-01a8-5a70-9a8e-9b5d48243262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca67eb3-44e7-4315-9808-870057915a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca67eb3-44e7-4315-9808-870057915a84.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "32cecb79-3b0f-5287-9317-94944002e9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb6beb3-1669-4e7b-9c76-65424673eb36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb6beb3-1669-4e7b-9c76-65424673eb36.jpg?1",
             "name": "Master Trinketeer",
             "text": "Servos and Thopters you control get +1/+1.\n{3}{W}: Create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "f489a8fa-dcac-523f-a2f3-4c58f5fe441b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a22cf8-4441-48ab-8adc-ae071cbc5999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a22cf8-4441-48ab-8adc-ae071cbc5999.jpg?1",
             "name": "Ninth Bridge Patrol",
             "text": "Whenever another creature you control leaves the battlefield, put a +1/+1 counter on Ninth Bridge Patrol.",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "0a34b9bd-48e9-5565-9335-d330fb32b7a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d28b806-88a3-4852-982e-0d6be0a2edac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d28b806-88a3-4852-982e-0d6be0a2edac.jpg?1",
             "name": "Pressure Point",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "8b3e8239-b5fc-5e9a-9bf7-5bea2efddb10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee60224-960a-4f92-996a-7b0b878109e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee60224-960a-4f92-996a-7b0b878109e4.jpg?1",
             "name": "Propeller Pioneer",
             "text": "Flying\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "bb851d66-b3e4-5bf0-a418-88fb8caf4a99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60e2ac4-f21f-4232-abc8-db078472408b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60e2ac4-f21f-4232-abc8-db078472408b.jpg?1",
             "name": "Refurbish",
             "text": "Return target artifact card from your graveyard to the battlefield.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "e793472e-a1d9-5e8f-a301-990c5422619f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e44502-f4e4-440a-92b1-97bfb6314820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e44502-f4e4-440a-92b1-97bfb6314820.jpg?1",
             "name": "Revoke Privileges",
             "text": "Enchant creature\nEnchanted creature can't attack, block, or crew Vehicles.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "afa6c398-1eb8-5a69-953a-9f13aee76d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0c60-78e2-4e1c-a6ad-6f1c001ad7ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aba0c60-78e2-4e1c-a6ad-6f1c001ad7ee.jpg?1",
             "name": "Servo Exhibition",
             "text": "Create two 1/1 colorless Servo artifact creature tokens.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "e6b6ad27-7baf-5fb2-a4e2-f821146be223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b951bc89-be0b-4330-8a13-e196e084d53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b951bc89-be0b-4330-8a13-e196e084d53c.jpg?1",
             "name": "Skyswirl Harrier",
             "text": "Flying",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "e3bae8e0-8c3a-5323-8898-163615c849f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dd4948-dc79-4fe5-b4a0-fb257058f9dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54dd4948-dc79-4fe5-b4a0-fb257058f9dd.jpg?1",
             "name": "Skywhaler's Shot",
             "text": "Destroy target creature with power 3 or greater. Scry 1.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "eafa69f2-c89d-5d7f-817c-7df423033359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cef3bf2-55cf-4f42-9ec0-fa921ef22311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cef3bf2-55cf-4f42-9ec0-fa921ef22311.jpg?1",
             "name": "Tasseled Dromedary",
             "text": "",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "dcac3976-5bd3-534b-8da8-343d1616f851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edc7c57-9298-4fad-a0c2-4b75b944e2ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edc7c57-9298-4fad-a0c2-4b75b944e2ce.jpg?1",
             "name": "Thriving Ibex",
             "text": "When Thriving Ibex enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Ibex attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "0a522504-ac7f-5600-a284-b973b9133f22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daae3dae-3297-4750-9bca-c8aadaf815ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daae3dae-3297-4750-9bca-c8aadaf815ea.jpg?1",
             "name": "Toolcraft Exemplar",
             "text": "At the beginning of combat on your turn, if you control an artifact, Toolcraft Exemplar gets +2/+1 until end of turn. If you control three or more artifacts, it also gains first strike until end of turn.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "d66ab00c-7c09-5c3d-a78c-869060ca2338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79eefb-50a4-41c4-93cf-378fa546f539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a79eefb-50a4-41c4-93cf-378fa546f539.jpg?1",
             "name": "Trusty Companion",
             "text": "Vigilance\nTrusty Companion can't attack alone.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "91ea152b-c0fb-5ee9-bc1f-777ff2f5df6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918691b1-f927-4027-a444-adc418f3ab16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918691b1-f927-4027-a444-adc418f3ab16.jpg?1",
             "name": "Visionary Augmenter",
             "text": "Fabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "10d13bc5-171d-5c3e-8650-017cab213d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57300d02-faad-43b2-afa9-023d1c3a0901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57300d02-faad-43b2-afa9-023d1c3a0901.jpg?1",
             "name": "Wispweaver Angel",
             "text": "Flying\nWhen Wispweaver Angel enters the battlefield, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "a8b26f48-48b6-5f60-aba4-5b23634f8cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f99614-45e2-4688-8403-f3a6b9162b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f99614-45e2-4688-8403-f3a6b9162b08.jpg?1",
             "name": "Aether Meltdown",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature or Vehicle\nWhen Aether Meltdown enters the battlefield, you get {E}{E} (two energy counters).\nEnchanted permanent gets -4/-0.",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "e1a652fb-9348-53a5-aae5-738e2660f53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b5580-ee23-4d65-a2b3-82475d6faf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b5580-ee23-4d65-a2b3-82475d6faf8e.jpg?1",
             "name": "Aether Theorist",
             "text": "When Aether Theorist enters the battlefield, you get {E}{E}{E} (three energy counters).\n{T}, Pay {E}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "3f20f026-afad-5796-bfe8-d8ba042d6f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fe4768-fe18-4698-885d-86f5ad150125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fe4768-fe18-4698-885d-86f5ad150125.jpg?1",
             "name": "Aether Tradewinds",
             "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "65446995-0178-5d75-9f64-f7b58e94feae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55127a25-dc64-4f26-ae50-ed7247c22ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55127a25-dc64-4f26-ae50-ed7247c22ae6.jpg?1",
             "name": "Aethersquall Ancient",
             "text": "Flying\nAt the beginning of your upkeep, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}{E}{E}{E}{E}{E}: Return all other creatures to their owners' hands. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1317,7 +1317,7 @@
         },
         {
             "id": "1d04b55f-5403-54fc-8813-e6b1757fc41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5ed8e-4804-4042-8a1d-ad24c6846816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c5ed8e-4804-4042-8a1d-ad24c6846816.jpg?1",
             "name": "Ceremonious Rejection",
             "text": "Counter target colorless spell.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "58339c18-3c9c-575d-9677-937bad434837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf453f-54be-4346-831d-a0434aa086fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf453f-54be-4346-831d-a0434aa086fe.jpg?1",
             "name": "Confiscation Coup",
             "text": "Choose target artifact or creature. You get {E}{E}{E}{E} (four energy counters), then you may pay an amount of {E} equal to that permanent's converted mana cost. If you do, gain control of it.",
             "colours": [
@@ -1381,7 +1381,7 @@
         },
         {
             "id": "ee5e91e2-ae65-56d4-a4d3-7c9890c5cd19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598054a-26fa-40e7-8497-3da8eaf12aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598054a-26fa-40e7-8497-3da8eaf12aac.jpg?1",
             "name": "Curio Vendor",
             "text": "",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "a23c9e44-c15c-5dd3-9f7b-dd188e83f9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4a6d56-9bed-444c-aae8-383c315779a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4a6d56-9bed-444c-aae8-383c315779a0.jpg?1",
             "name": "Disappearing Act",
             "text": "As an additional cost to cast Disappearing Act, return a permanent you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "c0d9f0a6-e438-5fbf-8e0f-e8320ddbc751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb59045-2743-48ae-8063-727e551b1c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb59045-2743-48ae-8063-727e551b1c41.jpg?1",
             "name": "Dramatic Reversal",
             "text": "Untap all nonland permanents you control.",
             "colours": [
@@ -1479,7 +1479,7 @@
         },
         {
             "id": "6daf1bd3-b497-5036-9a52-d3370b4a3c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae3b1f-6a31-4a8a-9e44-063f8f670134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae3b1f-6a31-4a8a-9e44-063f8f670134.jpg?1",
             "name": "Era of Innovation",
             "text": "Whenever an artifact or Artificer enters the battlefield under your control, you may pay {1}. If you do, you get {E}{E} (two energy counters).\nPay {E}{E}{E}{E}{E}{E}, Sacrifice Era of Innovation: Draw three cards.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "ef6eb655-d2da-5105-9bb9-f7c36304b736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962dc573-612d-434b-82fb-af9c3e3c9aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962dc573-612d-434b-82fb-af9c3e3c9aca.jpg?1",
             "name": "Experimental Aviator",
             "text": "Flying\nWhen Experimental Aviator enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "2236b149-e6bf-553f-8f5d-0812f54f0d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900f91-cb17-4f99-a5ce-15819369beb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8900f91-cb17-4f99-a5ce-15819369beb8.jpg?1",
             "name": "Failed Inspection",
             "text": "Counter target spell. Draw a card, then discard a card.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "2bf1d408-f956-5b23-80c5-2486eab84a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d8327-6ec2-4d43-b254-b04407612715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d32d8327-6ec2-4d43-b254-b04407612715.jpg?1",
             "name": "Gearseeker Serpent",
             "text": "Gearseeker Serpent costs {1} less to cast for each artifact you control.\n{5}{U}: Gearseeker Serpent can't be blocked this turn.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "817cf5fb-6268-54b7-afc9-d78cbd5c16cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1673d-c92c-43be-8648-af7fbc790421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f1673d-c92c-43be-8648-af7fbc790421.jpg?1",
             "name": "Glimmer of Genius",
             "text": "Scry 2, then draw two cards. You get {E}{E} (two energy counters).",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "a3a2c344-9ca7-55ce-ab88-c2568d031841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa5b030-23a6-4fca-b318-c580e3ea2bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa5b030-23a6-4fca-b318-c580e3ea2bad.jpg?1",
             "name": "Glint-Nest Crane",
             "text": "Flying\nWhen Glint-Nest Crane enters the battlefield, look at the top four cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1678,7 +1678,7 @@
         },
         {
             "id": "3791cc91-b81a-5783-9408-62e5db89e87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c871fa-d333-4c73-9d5c-f5cfec5954da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c871fa-d333-4c73-9d5c-f5cfec5954da.jpg?1",
             "name": "Hightide Hermit",
             "text": "Defender\nWhen Hightide Hermit enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nPay {E}{E}: Hightide Hermit can attack this turn as though it didn't have defender.",
             "colours": [
@@ -1712,7 +1712,7 @@
         },
         {
             "id": "9ae8f83f-8bfc-59b1-a569-515d895d5d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eafb2bb-58bf-4c6b-ae8f-91bcea12c7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eafb2bb-58bf-4c6b-ae8f-91bcea12c7d2.jpg?1",
             "name": "Insidious Will",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 You may choose new targets for target spell.\n\u2022 Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "08f0d733-8b47-5cf6-b642-4712e50045ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826b9080-2b6d-4f4e-93a6-cf977d40654f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826b9080-2b6d-4f4e-93a6-cf977d40654f.jpg?1",
             "name": "Janjeet Sentry",
             "text": "When Janjeet Sentry enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}{E}: You may tap or untap target artifact or creature.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "647980d2-fba9-5dd1-b6aa-da3eb80c8295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e9472-c710-474e-b8e9-54662330a592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772e9472-c710-474e-b8e9-54662330a592.jpg?1",
             "name": "Long-Finned Skywhale",
             "text": "Flying\nLong-Finned Skywhale can block only creatures with flying.",
             "colours": [
@@ -1813,7 +1813,7 @@
         },
         {
             "id": "c05a374a-dbdc-58fd-b331-2e0d7dcb6288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41f907f-4512-4c5d-827b-fef04613d641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41f907f-4512-4c5d-827b-fef04613d641.jpg?1",
             "name": "Malfunction",
             "text": "Enchant artifact or creature\nWhen Malfunction enters the battlefield, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step.",
             "colours": [
@@ -1847,7 +1847,7 @@
         },
         {
             "id": "6565451f-499a-545d-b40e-2e7dd99d6d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ac06f9-5c9f-4d4f-be57-7c58bd8da568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ac06f9-5c9f-4d4f-be57-7c58bd8da568.jpg?1",
             "name": "Metallurgic Summonings",
             "text": "Whenever you cast an instant or sorcery spell, create an X/X colorless Construct artifact creature token, where X is that spell's converted mana cost.\n{3}{U}{U}, Exile Metallurgic Summonings: Return all instant and sorcery cards from your graveyard to your hand. Activate this ability only if you control six or more artifacts.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "f827983d-6990-53fb-9364-16ea109f5ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6c31d1-6e2a-41b3-aa4f-d30a7cd997d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6c31d1-6e2a-41b3-aa4f-d30a7cd997d2.jpg?1",
             "name": "Minister of Inquiries",
             "text": "When Minister of Inquiries enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "b464ba9c-abdb-5294-8c9a-6c0cde5ae7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dbf333-23b5-47d9-9e55-1e8fbd5a72cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dbf333-23b5-47d9-9e55-1e8fbd5a72cb.jpg?1",
             "name": "Nimble Innovator",
             "text": "When Nimble Innovator enters the battlefield, draw a card.",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "19dfefa0-5679-58d2-adce-11051f57763a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b30a7-13e8-408e-a758-60e6e9290808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31b30a7-13e8-408e-a758-60e6e9290808.jpg?1",
             "name": "Padeem, Consul of Innovation",
             "text": "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the highest converted mana cost or tied for the highest converted mana cost, draw a card.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "0bafe6f5-e6bf-5791-978d-11d8ffb6c7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e50157-bf49-4c5f-9b8a-bf73484e63a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e50157-bf49-4c5f-9b8a-bf73484e63a5.jpg?1",
             "name": "Paradoxical Outcome",
             "text": "Return any number of target nonland, nontoken permanents you control to their owners' hands. Draw a card for each card returned to your hand this way.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "a0353866-85e4-545b-88ae-185095debe42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea63dad-6afe-464e-ab19-fabd9709c6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea63dad-6afe-464e-ab19-fabd9709c6f9.jpg?1",
             "name": "Revolutionary Rebuff",
             "text": "Counter target nonartifact spell unless its controller pays {2}.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "b38939e8-00a3-5502-9df5-e497ef15efb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42237c1d-5579-4c15-b97b-bcaaaf0b1ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42237c1d-5579-4c15-b97b-bcaaaf0b1ab2.jpg?1",
             "name": "Saheeli's Artistry",
             "text": "Choose one or both \u2014\n\u2022 Create a token that's a copy of target artifact.\n\u2022 Create a token that's a copy of target creature, except it's an artifact in addition to its other types.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "ac7aafa0-d22b-5c13-aa7c-1a7496e9e7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f0fb0-4831-4759-b58c-05c4be90a4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120f0fb0-4831-4759-b58c-05c4be90a4af.jpg?1",
             "name": "Select for Inspection",
             "text": "Return target tapped creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2114,7 +2114,7 @@
         },
         {
             "id": "38add4d6-14c8-5b19-9ac0-061268c449d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37900980-c2e2-4b70-8511-405f0a8389cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37900980-c2e2-4b70-8511-405f0a8389cd.jpg?1",
             "name": "Shrewd Negotiation",
             "text": "Exchange control of target artifact you control and target artifact or creature you don't control.",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "b737a8de-5cb7-59de-84a3-9df2e537474c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3700b0-d6b5-4967-add8-3adc2bc8ca86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3700b0-d6b5-4967-add8-3adc2bc8ca86.jpg?1",
             "name": "Tezzeret's Ambition",
             "text": "Draw three cards. If you control no artifacts, discard a card.",
             "colours": [
@@ -2178,7 +2178,7 @@
         },
         {
             "id": "f723451c-d2da-5985-a93e-36eb2669adcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a112a3-ae4e-4aba-86ac-74a8960a6326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a112a3-ae4e-4aba-86ac-74a8960a6326.jpg?1",
             "name": "Thriving Turtle",
             "text": "When Thriving Turtle enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Turtle attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "2fbc9f1c-129a-51ee-9651-366e556d8b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52868cb-087e-4f91-91bc-455f2e2e7cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52868cb-087e-4f91-91bc-455f2e2e7cd7.jpg?1",
             "name": "Torrential Gearhulk",
             "text": "Flash\nWhen Torrential Gearhulk enters the battlefield, you may cast target instant card from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "9f6ac51b-f9bf-5788-aad4-23983c6c7409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572c15ab-2229-4536-b586-638ec77d9cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572c15ab-2229-4536-b586-638ec77d9cb7.jpg?1",
             "name": "Vedalken Blademaster",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2282,7 +2282,7 @@
         },
         {
             "id": "5ae5e1fd-a5de-5485-bcb4-be5f530fa974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b115a65-e273-4264-9db7-317e1855f492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b115a65-e273-4264-9db7-317e1855f492.jpg?1",
             "name": "Weldfast Wingsmith",
             "text": "Whenever an artifact enters the battlefield under your control, Weldfast Wingsmith gains flying until end of turn.",
             "colours": [
@@ -2317,7 +2317,7 @@
         },
         {
             "id": "e1b8fc9f-e974-51cd-972f-624b3e9d0c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e227a63-abea-494e-9d66-6ff0a3da14ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e227a63-abea-494e-9d66-6ff0a3da14ca.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "992c07f2-f9b9-5c7a-a66c-efd497c3c9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5a14b-8fd2-4a62-90dc-4adb1cee4505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5a14b-8fd2-4a62-90dc-4adb1cee4505.jpg?1",
             "name": "Wind Drake",
             "text": "",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "2711fdbc-e7b9-53a1-a438-c16f38118ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce02ef8-1731-43a9-9bd0-9ec592e3883f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce02ef8-1731-43a9-9bd0-9ec592e3883f.jpg?1",
             "name": "Aetherborn Marauder",
             "text": "Flying, lifelink\nWhen Aetherborn Marauder enters the battlefield, move any number of +1/+1 counters from other permanents you control onto Aetherborn Marauder.",
             "colours": [
@@ -2423,7 +2423,7 @@
         },
         {
             "id": "b51dbe10-b24d-5783-aaa7-13f487f5812f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cb628e-fa83-4d7e-92cb-8779ea02193f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cb628e-fa83-4d7e-92cb-8779ea02193f.jpg?1",
             "name": "Ambitious Aetherborn",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "0f863059-5f1b-5376-987b-edcf1cc222fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c99736-5c9c-4d2f-946d-05606fcdd039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c99736-5c9c-4d2f-946d-05606fcdd039.jpg?1",
             "name": "Demon of Dark Schemes",
             "text": "Flying\nWhen Demon of Dark Schemes enters the battlefield, all other creatures get -2/-2 until end of turn.\nWhenever another creature dies, you get {E} (an energy counter).\n{2}{B}, Pay {E}{E}{E}{E}: Put target creature card from a graveyard onto the battlefield under your control tapped.",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "06ad011a-2e2a-57e9-b9dc-f42375f940ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f91094-5214-4268-8f91-5ba0b891256d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f91094-5214-4268-8f91-5ba0b891256d.jpg?1",
             "name": "Dhund Operative",
             "text": "As long as you control an artifact, Dhund Operative gets +1/+0 and has deathtouch. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "0e1ae14b-5c2e-5354-8cb9-6c54b9eca962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06750380-a9a9-4ab4-a03b-d4d35a31132a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06750380-a9a9-4ab4-a03b-d4d35a31132a.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -2559,7 +2559,7 @@
         },
         {
             "id": "b0675cda-a353-5972-85e6-3ff94770989b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf7bb52-013f-4d8d-b4ea-53d1fa4bb694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf7bb52-013f-4d8d-b4ea-53d1fa4bb694.jpg?1",
             "name": "Die Young",
             "text": "Choose target creature. You get {E}{E} (two energy counters), then you may pay any amount of {E}. The creature gets -1/-1 until end of turn for each {E} paid this way.",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "fed26485-0d0f-5a0a-ad3a-68120185ca43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81591264-1342-418d-b5c6-9d700b729c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81591264-1342-418d-b5c6-9d700b729c51.jpg?1",
             "name": "Dukhara Scavenger",
             "text": "When Dukhara Scavenger enters the battlefield, you may put target artifact or creature card from your graveyard on top of your library.",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "0789c94b-9c62-5d17-b0b0-f2766b26986f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf09460-2e54-4434-ab03-95eef77265dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf09460-2e54-4434-ab03-95eef77265dc.jpg?1",
             "name": "Eliminate the Competition",
             "text": "As an additional cost to cast Eliminate the Competition, sacrifice X creatures.\nDestroy X target creatures.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "dd57be96-6ac2-5330-9c19-853440f68dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f90f877-4033-4892-a6e7-22d2b393c65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f90f877-4033-4892-a6e7-22d2b393c65d.jpg?1",
             "name": "Embraal Bruiser",
             "text": "Embraal Bruiser enters the battlefield tapped.\nEmbraal Bruiser has menace as long as you control an artifact.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "b6d18a41-f810-52b1-82c3-25c6630999f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7693c10-5ebb-4896-bb60-63d03577dd60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7693c10-5ebb-4896-bb60-63d03577dd60.jpg?1",
             "name": "Essence Extraction",
             "text": "Essence Extraction deals 3 damage to target creature and you gain 3 life.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "ff08b208-bbbf-5ffd-a0ae-9bd7bd132b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7706bbb1-c94a-4169-9f12-a54cfcc3a7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7706bbb1-c94a-4169-9f12-a54cfcc3a7ad.jpg?1",
             "name": "Fortuitous Find",
             "text": "Choose one or both \u2014\n\u2022 Return target artifact card from your graveyard to your hand.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "662d0b2e-9cf0-56e6-bb80-a00a024124f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4313802f-b969-47d0-b4aa-b049df0755c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4313802f-b969-47d0-b4aa-b049df0755c0.jpg?1",
             "name": "Foundry Screecher",
             "text": "Flying\nFoundry Screecher gets +1/+0 as long as you control an artifact.",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "a1e03ebe-0ea4-5fdd-bdbe-0d401002ceaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bf6ae3-352b-416c-a404-de51cd624198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bf6ae3-352b-416c-a404-de51cd624198.jpg?1",
             "name": "Fretwork Colony",
             "text": "Fretwork Colony can't block.\nAt the beginning of your upkeep, put a +1/+1 counter on Fretwork Colony and you lose 1 life.",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "7475ced3-0585-55c6-a3ee-0efb3fe77c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7735ecda-9bb0-4ef9-86b2-16e5b6592e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7735ecda-9bb0-4ef9-86b2-16e5b6592e61.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "Deathtouch\nWhen Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. For as long as that card remains exiled, you may look at it, you may cast it, and you may spend mana as though it were mana of any type to cast it.",
             "colours": [
@@ -2861,7 +2861,7 @@
         },
         {
             "id": "9f6622b0-8f40-57c5-9ab5-509faa771f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe68b484-cc8d-4a0b-94c2-1fec9090dfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe68b484-cc8d-4a0b-94c2-1fec9090dfcd.jpg?1",
             "name": "Harsh Scrutiny",
             "text": "Target opponent reveals his or her hand. You choose a creature card from it. That player discards that card. Scry 1.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "cd103a17-51a8-5d27-957f-5720a3372171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5bfff7-aa23-42ef-af1b-bc3304bd3a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5bfff7-aa23-42ef-af1b-bc3304bd3a17.jpg?1",
             "name": "Lawless Broker",
             "text": "When Lawless Broker dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "f7d85f15-6da9-52b7-889c-47b7fbea6da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0bb8da-ad05-43d9-aba3-d917744168fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0bb8da-ad05-43d9-aba3-d917744168fe.jpg?1",
             "name": "Live Fast",
             "text": "You draw two cards, lose 2 life, and get {E}{E} (two energy counters).",
             "colours": [
@@ -2960,7 +2960,7 @@
         },
         {
             "id": "06023b8e-fb5a-5189-912e-cef93a8731c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d0e447-d98e-43d5-9b53-166221c34be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d0e447-d98e-43d5-9b53-166221c34be2.jpg?1",
             "name": "Lost Legacy",
             "text": "Name a nonartifact, nonland card. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles his or her library, then draws a card for each card exiled from hand this way.",
             "colours": [
@@ -2992,7 +2992,7 @@
         },
         {
             "id": "75dc9c88-dc56-5176-920a-6b1f29d46496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a96feb-accc-4c30-8ecd-7d9272ebd45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a96feb-accc-4c30-8ecd-7d9272ebd45b.jpg?1",
             "name": "Make Obsolete",
             "text": "Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "fb6344e8-3412-57c9-8bca-e9a02708ac15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358a87a3-c76e-4c7d-ac84-464894ed9a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358a87a3-c76e-4c7d-ac84-464894ed9a31.jpg?1",
             "name": "Marionette Master",
             "text": "Fabricate 3 (When this creature enters the battlefield, put three +1/+1 counters on it or create three 1/1 colorless Servo artifact creature tokens.)\nWhenever an artifact you control is put into a graveyard from the battlefield, target opponent loses life equal to Marionette Master's power.",
             "colours": [
@@ -3059,7 +3059,7 @@
         },
         {
             "id": "7db7cd2f-bc33-5268-b46a-5ea753d8cd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4cd13a-66b6-4c65-a5a0-82f93145d16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4cd13a-66b6-4c65-a5a0-82f93145d16a.jpg?1",
             "name": "Maulfist Squad",
             "text": "Menace\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "01b149da-86ae-544d-bb1e-7ba4ada438a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14875840-044d-482f-845e-79240cad66f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14875840-044d-482f-845e-79240cad66f3.jpg?1",
             "name": "Midnight Oil",
             "text": "Midnight Oil enters the battlefield with seven hour counters on it.\nAt the beginning of your draw step, draw an additional card and remove two hour counters from Midnight Oil.\nYour maximum hand size is equal to the number of hour counters on Midnight Oil.\nWhenever you discard a card, you lose 1 life.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "af14876e-5471-58ff-ab13-9b7bc93e019f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317ff1a-9104-44e6-acb9-5ee09648138f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3317ff1a-9104-44e6-acb9-5ee09648138f.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "55b34d5e-5696-550f-8574-038a1dc56c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f26722e-e7fc-4a90-9a5b-cefda096e5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f26722e-e7fc-4a90-9a5b-cefda096e5fe.jpg?1",
             "name": "Morbid Curiosity",
             "text": "As an additional cost to cast Morbid Curiosity, sacrifice an artifact or creature.\nDraw cards equal to the converted mana cost of the sacrificed permanent.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "5749731e-46d9-554f-98cd-3b368b8e44c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb03b7-e5a2-4ba1-b0ec-bfbfeaa94efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edb03b7-e5a2-4ba1-b0ec-bfbfeaa94efd.jpg?1",
             "name": "Night Market Lookout",
             "text": "Whenever Night Market Lookout becomes tapped, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "cfbdefd7-7a88-5f5f-af0d-e0f6551f23cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f86e5fe-8723-4494-b4cc-b7ac3a047bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f86e5fe-8723-4494-b4cc-b7ac3a047bd1.jpg?1",
             "name": "Noxious Gearhulk",
             "text": "Menace\nWhen Noxious Gearhulk enters the battlefield, you may destroy another target creature. If a creature is destroyed this way, you gain life equal to its toughness.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "e5547975-b09b-50a3-9cec-318e4e161a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a323a495-e154-4541-ba4e-25b66b84d692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a323a495-e154-4541-ba4e-25b66b84d692.jpg?1",
             "name": "Ovalchase Daredevil",
             "text": "Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "98e59455-09f9-5bf8-9e2b-793303579de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b73ce-cb25-4104-bccd-6b6a131790a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b73ce-cb25-4104-bccd-6b6a131790a9.jpg?1",
             "name": "Prakhata Club Security",
             "text": "",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "86a47955-77ec-5226-8cc0-15d77f790c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e53cd8b-18f8-4950-84d4-7aafa26c7ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e53cd8b-18f8-4950-84d4-7aafa26c7ae4.jpg?1",
             "name": "Rush of Vitality",
             "text": "Target creature gets +1/+0 and gains lifelink and indestructible until end of turn. (Damage dealt by that creature also causes its controller to gain that much life, and it can't be destroyed by damage or effects that say \"destroy.\")",
             "colours": [
@@ -3362,7 +3362,7 @@
         },
         {
             "id": "e78171d2-ca60-579b-b4bf-c8d85f3feacc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a8cb98-7ee7-4f90-bfba-0a406a5e6d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a8cb98-7ee7-4f90-bfba-0a406a5e6d6b.jpg?1",
             "name": "Subtle Strike",
             "text": "Choose one or both \u2014\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "3f1b90c9-b8df-5930-b65c-68e88c12d120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89427f0-08d5-49a1-9684-ebe8769430f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89427f0-08d5-49a1-9684-ebe8769430f6.jpg?1",
             "name": "Syndicate Trafficker",
             "text": "{1}, Sacrifice an artifact: Put a +1/+1 counter on Syndicate Trafficker. It gains indestructible until end of turn.",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "b440aed5-2892-5f77-90c9-ad29efe9e6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba911b-6a52-4430-8f61-63bdae25c16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba911b-6a52-4430-8f61-63bdae25c16a.jpg?1",
             "name": "Thriving Rats",
             "text": "When Thriving Rats enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Rats attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "3186d105-afba-5641-bc56-eb93583edad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf6849-4fac-41b9-8e70-dc77c4562a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf6849-4fac-41b9-8e70-dc77c4562a42.jpg?1",
             "name": "Tidy Conclusion",
             "text": "Destroy target creature. You gain 1 life for each artifact you control.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "6ed73eba-d5fa-5b1f-8d6e-f08fb9169a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4392fe0a-a15e-46c6-9a3d-8e30e4dab17f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4392fe0a-a15e-46c6-9a3d-8e30e4dab17f.jpg?1",
             "name": "Underhanded Designs",
             "text": "Whenever an artifact enters the battlefield under your control, you may pay {1}. If you do, each opponent loses 1 life and you gain 1 life.\n{1}{B}, Sacrifice Underhanded Designs: Destroy target creature. Activate this ability only if you control two or more artifacts.",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "9faf516a-e0b1-5b92-91b8-fdbb23dc23ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe99535a-cc81-4e79-9d30-d514c86b849c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe99535a-cc81-4e79-9d30-d514c86b849c.jpg?1",
             "name": "Weaponcraft Enthusiast",
             "text": "Fabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "3b1a773a-66e4-589a-8054-28e1015f8ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c443e1-fd13-4627-85a9-8e9a340a2786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c443e1-fd13-4627-85a9-8e9a340a2786.jpg?1",
             "name": "Aethertorch Renegade",
             "text": "When Aethertorch Renegade enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\n{T}, Pay {E}{E}: Aethertorch Renegade deals 1 damage to target creature.\n{T}, Pay {E}{E}{E}{E}{E}{E}{E}{E}: Aethertorch Renegade deals 6 damage to target player.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "ed666e7c-ca2d-5210-a46b-b544030720c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c6fbdb-7b5c-4ad0-88f5-4779deae16ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c6fbdb-7b5c-4ad0-88f5-4779deae16ce.jpg?1",
             "name": "Brazen Scourge",
             "text": "Haste",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "4606ce47-6a66-52dd-ac5b-d3339cc30c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d002f9-ae69-4e07-943f-95036f083dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d002f9-ae69-4e07-943f-95036f083dea.jpg?1",
             "name": "Brazen Scourge",
             "text": "",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "14282035-7cc2-5f63-ad88-11088e18f776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f054978-446c-4565-b51e-8f1f0e0f01e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f054978-446c-4565-b51e-8f1f0e0f01e2.jpg?1",
             "name": "Built to Smash",
             "text": "Target attacking creature gets +3/+3 until end of turn. If it's an artifact creature, it gains trample until end of turn.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "2f47e1cd-7d29-52c7-a4fb-d6f6b5f7437b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68a6226-6dd7-4e1a-9e8a-124eef2caa13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68a6226-6dd7-4e1a-9e8a-124eef2caa13.jpg?1",
             "name": "Cathartic Reunion",
             "text": "As an additional cost to cast Cathartic Reunion, discard two cards.\nDraw three cards.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "4b95a228-8ad7-53a7-b861-a23820c94989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8086cd-b868-4f4e-823e-2635ad7ebc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8086cd-b868-4f4e-823e-2635ad7ebc07.jpg?1",
             "name": "Chandra, Torch of Defiance",
             "text": "+1: Exile the top card of your library. You may cast that card. If you don't, Chandra, Torch of Defiance deals 2 damage to each opponent.\n+1: Add {R}{R} to your mana pool.\n\u22123: Chandra, Torch of Defiance deals 4 damage to target creature.\n\u22127: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to target creature or player.\"",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "549f269f-5bad-59d4-99e2-f0af81bdb731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05659715-3002-4bd0-919e-664814c1ca57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05659715-3002-4bd0-919e-664814c1ca57.jpg?1",
             "name": "Chandra's Pyrohelix",
             "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two target creatures and/or players.",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "d4be3ea7-77ad-588c-96fa-f994831adeb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f43147-4552-48fd-be0a-0629b9a0ad69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f43147-4552-48fd-be0a-0629b9a0ad69.jpg?1",
             "name": "Combustible Gearhulk",
             "text": "First strike\nWhen Combustible Gearhulk enters the battlefield, target opponent may have you draw three cards. If the player doesn't, put the top three cards of your library into your graveyard, then Combustible Gearhulk deals damage to that player equal to the total converted mana cost of those cards.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "a8cf8115-8400-5826-bf6e-7a0e286c0a69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d231d40-c113-4a8d-897c-ed3120a1363e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d231d40-c113-4a8d-897c-ed3120a1363e.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "f76bf155-2d02-59b6-a085-df55fb77f284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19d5bdd-7f45-4ff1-bd1a-ac4e87572bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19d5bdd-7f45-4ff1-bd1a-ac4e87572bcb.jpg?1",
             "name": "Fateful Showdown",
             "text": "Fateful Showdown deals damage to target creature or player equal to the number of cards in your hand. Discard all the cards in your hand, then draw that many cards.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "14f37ef5-f210-5209-8c7e-acc9cdbf8050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeeecd-1d62-49f3-82b0-60f1f5e57d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeeecd-1d62-49f3-82b0-60f1f5e57d97.jpg?1",
             "name": "Furious Reprisal",
             "text": "Furious Reprisal deals 2 damage to each of two target creatures and/or players.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "0fdd14ec-288f-5ff2-8626-43b854f99544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c425337-6f1f-494e-a7ae-7d533d7a0b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c425337-6f1f-494e-a7ae-7d533d7a0b4e.jpg?1",
             "name": "Giant Spectacle",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "c3274e9d-de1a-5c89-ad59-45ceef0bd8d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9be9b5c-eed4-4a5d-962f-3482da5a6f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9be9b5c-eed4-4a5d-962f-3482da5a6f1d.jpg?1",
             "name": "Harnessed Lightning",
             "text": "Choose target creature. You get {E}{E}{E} (three energy counters), then you may pay any amount of {E}. Harnessed Lightning deals that much damage to that creature.",
             "colours": [
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "c7d7d871-f681-51ec-8132-aba1788b4be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e925954-faa3-4d16-8442-e34af1f85fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e925954-faa3-4d16-8442-e34af1f85fb6.jpg?1",
             "name": "Hijack",
             "text": "Gain control of target artifact or creature until end of turn. Untap it. It gains haste until end of turn.",
             "colours": [
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "165e4950-0120-56c1-8470-23682a21c53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee44ca0-1989-42fa-8024-b6b3e5c3883c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee44ca0-1989-42fa-8024-b6b3e5c3883c.jpg?1",
             "name": "Incendiary Sabotage",
             "text": "As an additional cost to cast Incendiary Sabotage, sacrifice an artifact.\nIncendiary Sabotage deals 3 damage to each creature.",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "92b95ff9-85c1-56c3-8205-44ad9ba1015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737109b-15fb-4b92-9007-99a33ae68628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737109b-15fb-4b92-9007-99a33ae68628.jpg?1",
             "name": "Inventor's Apprentice",
             "text": "Inventor's Apprentice gets +1/+1 as long as you control an artifact.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "a7958417-0e9b-5dc6-97aa-5bd6a6e33ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14050179-84af-46f6-89be-338f8e7131cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14050179-84af-46f6-89be-338f8e7131cc.jpg?1",
             "name": "Lathnu Hellion",
             "text": "Haste\nWhen Lathnu Hellion enters the battlefield, you get {E}{E} (two energy counters).\nAt the beginning of your end step, sacrifice Lathnu Hellion unless you pay {E}{E}.",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "442b94d7-8ca0-530f-a9ea-f6730575bc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05768b87-d2df-42fc-bf63-e471d31b32e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05768b87-d2df-42fc-bf63-e471d31b32e3.jpg?1",
             "name": "Madcap Experiment",
             "text": "Reveal cards from the top of your library until you reveal an artifact card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. Madcap Experiment deals damage to you equal to the number of cards revealed this way.",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "c6e2faff-4de9-5902-a549-33afb9f2eb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53681384-b72d-42a6-b134-aa420115ea12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53681384-b72d-42a6-b134-aa420115ea12.jpg?1",
             "name": "Maulfist Doorbuster",
             "text": "When Maulfist Doorbuster enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Maulfist Doorbuster attacks, you may pay {E}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4197,7 +4197,7 @@
         },
         {
             "id": "4c8af9ce-2523-5644-847e-39f0e3e2cae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2954-0734-4219-b6df-c6cc3dcd8d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b2954-0734-4219-b6df-c6cc3dcd8d5a.jpg?1",
             "name": "Pia Nalaar",
             "text": "When Pia Nalaar enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{R}: Target artifact creature gets +1/+0 until end of turn.\n{1}, Sacrifice an artifact: Target creature can't block this turn.",
             "colours": [
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "c45e3b8e-25ad-515f-b1c8-0efcc1e2ce51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f1dc85-3cda-45d6-8d65-3cb93854bb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f1dc85-3cda-45d6-8d65-3cb93854bb16.jpg?1",
             "name": "Quicksmith Genius",
             "text": "Whenever an artifact enters the battlefield under your control, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4269,7 +4269,7 @@
         },
         {
             "id": "5b1f84cd-9047-5a7d-a33c-0ff679303857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ffac51-62c4-4170-85b3-a43d7cfae7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ffac51-62c4-4170-85b3-a43d7cfae7d7.jpg?1",
             "name": "Reckless Fireweaver",
             "text": "Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent.",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "0f7356e9-507e-5175-8047-74fe2de753a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c06a39c-68bb-4e65-9a6d-9d9bc745201f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c06a39c-68bb-4e65-9a6d-9d9bc745201f.jpg?1",
             "name": "Renegade Tactics",
             "text": "Target creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -4336,7 +4336,7 @@
         },
         {
             "id": "b7f64991-5dd3-5397-81e4-e708e6490801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88067bc3-6ec9-4a96-8077-817c57e032d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88067bc3-6ec9-4a96-8077-817c57e032d0.jpg?1",
             "name": "Ruinous Gremlin",
             "text": "{2}{R}, Sacrifice Ruinous Gremlin: Destroy target artifact.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "140519bb-6896-55ba-988c-963a463bfb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e0187a-438f-407c-a0ef-f62517c44994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e0187a-438f-407c-a0ef-f62517c44994.jpg?1",
             "name": "Salivating Gremlins",
             "text": "Whenever an artifact enters the battlefield under your control, Salivating Gremlins gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "0666b86c-976b-53bc-b7af-581f797df993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a35be7b-d693-4433-9b13-8e019adc594e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a35be7b-d693-4433-9b13-8e019adc594e.jpg?1",
             "name": "Skyship Stalker",
             "text": "Flying\n{R}: Skyship Stalker gets +1/+0 until end of turn.\n{R}: Skyship Stalker gains first strike until end of turn.\n{R}: Skyship Stalker gains haste until end of turn.",
             "colours": [
@@ -4438,7 +4438,7 @@
         },
         {
             "id": "bbe5d9df-576a-527a-b9c2-fa9c01f3768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718bf224-5e1b-439c-a998-ceec5c0a8903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718bf224-5e1b-439c-a998-ceec5c0a8903.jpg?1",
             "name": "Spark of Creativity",
             "text": "Choose target creature. Exile the top card of your library. You may have Spark of Creativity deal damage to that creature equal to the exiled card's converted mana cost. If you don't, you may play that card until end of turn.",
             "colours": [
@@ -4470,7 +4470,7 @@
         },
         {
             "id": "6d362f42-942e-5e69-bdcd-e19824c1f80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436ce901-6ac6-4f8c-8ff0-18103f2642b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436ce901-6ac6-4f8c-8ff0-18103f2642b8.jpg?1",
             "name": "Speedway Fanatic",
             "text": "Haste\nWhenever Speedway Fanatic crews a Vehicle, that Vehicle gains haste until end of turn.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "2f754bf8-ca18-578f-a491-53be9afe928a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9551190-9764-47a6-b414-8411beec89d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9551190-9764-47a6-b414-8411beec89d2.jpg?1",
             "name": "Spireside Infiltrator",
             "text": "Whenever Spireside Infiltrator becomes tapped, it deals 1 damage to each opponent.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "36dd0a5d-37e0-5022-a4fd-53651f1ca145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bbeb22-5e50-4b90-b756-9d420f9cfe7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8bbeb22-5e50-4b90-b756-9d420f9cfe7f.jpg?1",
             "name": "Spontaneous Artist",
             "text": "When Spontaneous Artist enters the battlefield, you get {E} (an energy counter).\nPay {E}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "db29d150-bb59-585f-8fa4-3ed4f8921f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae1eb8-697d-43e1-b03e-f4246a9f225e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbae1eb8-697d-43e1-b03e-f4246a9f225e.jpg?1",
             "name": "Start Your Engines",
             "text": "Vehicles you control become artifact creatures until end of turn. Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "ce45c6ef-7c7f-59f6-bba4-7b62fe9463ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3525ad1-3c17-4959-ab61-ae0e784c526a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3525ad1-3c17-4959-ab61-ae0e784c526a.jpg?1",
             "name": "Territorial Gorger",
             "text": "Trample\nWhenever you get one or more {E} (energy counters), Territorial Gorger gets +2/+2 until end of turn.",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "27ec79d6-ad98-5d09-bbc0-071a4cb86950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04623df9-8fa9-44cc-b528-c2c484626d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04623df9-8fa9-44cc-b528-c2c484626d1f.jpg?1",
             "name": "Terror of the Fairgrounds",
             "text": "",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "b1081f78-2a11-577b-9189-6040dd188039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3184a-eeda-4f22-92de-257c20cff6e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc3184a-eeda-4f22-92de-257c20cff6e2.jpg?1",
             "name": "Thriving Grubs",
             "text": "When Thriving Grubs enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Grubs attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "2eeaa359-f43b-5072-9d5d-6e4407c9f358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db01e574-7a96-472c-8e5a-bbd503280c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db01e574-7a96-472c-8e5a-bbd503280c71.jpg?1",
             "name": "Wayward Giant",
             "text": "Menace",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "ac13691b-b128-53a2-ada7-3929041ea469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d98db-64c4-40b4-b6c8-61da8cc09f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2d98db-64c4-40b4-b6c8-61da8cc09f42.jpg?1",
             "name": "Welding Sparks",
             "text": "Welding Sparks deals X damage to target creature, where X is 3 plus the number of artifacts you control.",
             "colours": [
@@ -4775,7 +4775,7 @@
         },
         {
             "id": "0a366615-031b-5973-ab70-4e9d62309163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa8840-31f8-4263-b992-40584e31595a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa8840-31f8-4263-b992-40584e31595a.jpg?1",
             "name": "Appetite for the Unnatural",
             "text": "Destroy target artifact or enchantment. You gain 2 life.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "4cae7cfc-6fd7-5972-ac73-895709213982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788b9d55-6679-4fcc-a3af-11d31e477421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788b9d55-6679-4fcc-a3af-11d31e477421.jpg?1",
             "name": "Arborback Stomper",
             "text": "Trample\nWhen Arborback Stomper enters the battlefield, you gain 5 life.",
             "colours": [
@@ -4843,7 +4843,7 @@
         },
         {
             "id": "fd84a5fe-8891-591c-b4e2-8a321e57d0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d228ad88-669a-435f-a2fd-6188261988ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d228ad88-669a-435f-a2fd-6188261988ea.jpg?1",
             "name": "Arborback Stomper",
             "text": "",
             "colours": [
@@ -4878,7 +4878,7 @@
         },
         {
             "id": "ad8d56bf-892a-5df9-9172-a042224ac137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc540f5-96a1-44d8-910d-914b9e61b2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc540f5-96a1-44d8-910d-914b9e61b2a5.jpg?1",
             "name": "Architect of the Untamed",
             "text": "Whenever a land enters the battlefield under your control, you get {E} (an energy counter).\nPay {E}{E}{E}{E}{E}{E}{E}{E}: Create a 6/6 colorless Beast artifact creature token.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "550f46ca-5f04-5606-98e4-1b2fef94242e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b54854-c21f-47d3-99b2-72829fc66071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b54854-c21f-47d3-99b2-72829fc66071.jpg?1",
             "name": "Armorcraft Judge",
             "text": "When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "90e65980-a445-5071-ad9c-f4baaf004b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b0707d-241e-4ced-9251-b16af4fef2cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b0707d-241e-4ced-9251-b16af4fef2cb.jpg?1",
             "name": "Attune with Aether",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library. You get {E}{E} (two energy counters).",
             "colours": [
@@ -4981,7 +4981,7 @@
         },
         {
             "id": "f4065088-c736-5050-a7ba-a8b65727da29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c026c39-b09c-408a-844f-fb5eb785862a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c026c39-b09c-408a-844f-fb5eb785862a.jpg?1",
             "name": "Blossoming Defense",
             "text": "Target creature you control gets +2/+2 and gains hexproof until end of turn.",
             "colours": [
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "4598840b-dd90-5705-8b7c-13c64a114ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf38096-05bc-4734-b33c-eb1e8f2986de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf38096-05bc-4734-b33c-eb1e8f2986de.jpg?1",
             "name": "Bristling Hydra",
             "text": "When Bristling Hydra enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}: Put a +1/+1 counter on Bristling Hydra. It gains hexproof until end of turn.",
             "colours": [
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "e36f0677-7f0c-5190-8d55-6dc5c64c741c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724602-2ae1-40a4-aeb0-51a483a6948c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724602-2ae1-40a4-aeb0-51a483a6948c.jpg?1",
             "name": "Commencement of Festivities",
             "text": "Prevent all combat damage that would be dealt to players this turn.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "ee338a61-055c-58eb-b7cd-2b913420b005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1b25f4-f50c-4210-a03f-080a5e4e5708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a1b25f4-f50c-4210-a03f-080a5e4e5708.jpg?1",
             "name": "Cowl Prowler",
             "text": "",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "20b420df-4eb4-5982-8035-e996a4835736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277b549c-8691-42b2-9867-802b158a506c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277b549c-8691-42b2-9867-802b158a506c.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "2c842f91-4cae-5ca1-bce6-d0653f9b367c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21d35b-1b4e-43aa-8fb7-0dd7a2fa91a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d21d35b-1b4e-43aa-8fb7-0dd7a2fa91a1.jpg?1",
             "name": "Cultivator of Blades",
             "text": "Fabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)\nWhenever Cultivator of Blades attacks, you may have other attacking creatures get +X/+X until end of turn, where X is Cultivator of Blades's power.",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "5c419f0d-2d2e-548a-9c37-90851caa649e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92965a78-277d-4a27-8174-fc2564bd1ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92965a78-277d-4a27-8174-fc2564bd1ee3.jpg?1",
             "name": "Dubious Challenge",
             "text": "Look at the top ten cards of your library, exile up to two creature cards from among them, then shuffle your library. Target opponent may choose one of the exiled cards and put it onto the battlefield under his or her control. Put the rest onto the battlefield under your control.",
             "colours": [
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "dd12878f-136c-5962-b973-a7b29613e12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d5e2ff-dc8a-4ed5-989a-4b4b79591b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d5e2ff-dc8a-4ed5-989a-4b4b79591b3f.jpg?1",
             "name": "Durable Handicraft",
             "text": "Whenever a creature enters the battlefield under your control, you may pay {1}. If you do, put a +1/+1 counter on that creature.\n{5}{G}, Sacrifice Durable Handicraft: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -5244,7 +5244,7 @@
         },
         {
             "id": "613eba59-2ec9-5082-b3af-613222eedc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352941f3-951e-428d-bec4-7790c3ea7cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352941f3-951e-428d-bec4-7790c3ea7cb2.jpg?1",
             "name": "Elegant Edgecrafters",
             "text": "Elegant Edgecrafters can't be blocked by creatures with power 2 or less.\nFabricate 2 (When this creature enters the battlefield, put two +1/+1 counters on it or create two 1/1 colorless Servo artifact creature tokens.)",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "7dbdee9a-788a-59ec-bdc5-f56d55f0242b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65983338-8806-4386-94a6-4670eb853848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65983338-8806-4386-94a6-4670eb853848.jpg?1",
             "name": "Fairgrounds Trumpeter",
             "text": "At the beginning of each end step, if a +1/+1 counter was placed on a permanent under your control this turn, put a +1/+1 counter on Fairgrounds Trumpeter.",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "ab5d6ee9-5b81-569c-9bd8-66fd3bd8cb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b6ad4a-3701-4ee8-8e1e-46cdab8e730f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b6ad4a-3701-4ee8-8e1e-46cdab8e730f.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -5348,7 +5348,7 @@
         },
         {
             "id": "2286d559-3d0b-5780-84c0-3cf7a6b4994d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a26cb0-655f-4bf8-899a-952d5bfe2b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a26cb0-655f-4bf8-899a-952d5bfe2b42.jpg?1",
             "name": "Highspire Artisan",
             "text": "Reach (This creature can block creatures with flying.)\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "9c4f01ea-520c-561f-92c2-993a687efebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acbe3e-cc60-4e17-97da-ac4c803e8a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6acbe3e-cc60-4e17-97da-ac4c803e8a5a.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "0fefe3fd-6595-55a9-8db3-ef0a324c303b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8664c65-77ca-4881-959a-e1923e1a6b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8664c65-77ca-4881-959a-e1923e1a6b98.jpg?1",
             "name": "Kujar Seedsculptor",
             "text": "When Kujar Seedsculptor enters the battlefield, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "a90b01fd-d1bd-589b-82fa-abc52e7e22dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0da994-d3e7-41b9-ae8f-6f1a3b779f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0da994-d3e7-41b9-ae8f-6f1a3b779f23.jpg?1",
             "name": "Larger Than Life",
             "text": "Target creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5482,7 +5482,7 @@
         },
         {
             "id": "5328c170-6589-55d5-9b8e-0bd8a20d6adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4de778a-4419-49a5-9dcf-5d0095c873fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4de778a-4419-49a5-9dcf-5d0095c873fa.jpg?1",
             "name": "Longtusk Cub",
             "text": "Whenever Longtusk Cub deals combat damage to a player, you get {E}{E} (two energy counters).\nPay {E}{E}: Put a +1/+1 counter on Longtusk Cub.",
             "colours": [
@@ -5516,7 +5516,7 @@
         },
         {
             "id": "7608a288-c5ca-586b-8487-a4a48070561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122287-fe33-4ac3-803c-f5173cae50a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec122287-fe33-4ac3-803c-f5173cae50a7.jpg?1",
             "name": "Nature's Way",
             "text": "Target creature you control gains vigilance and trample until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5548,7 +5548,7 @@
         },
         {
             "id": "bccf1730-d3ee-5e29-9ad1-4e78a51fad2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaaa98a-ec40-4ff1-8762-a719cf1c475d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaaa98a-ec40-4ff1-8762-a719cf1c475d.jpg?1",
             "name": "Nissa, Vital Force",
             "text": "+1: Untap target land you control. Until your next turn, it becomes a 5/5 Elemental creature with haste. It's still a land.\n\u22123: Return target permanent card from your graveyard to your hand.\n\u22126: You get an emblem with \"Whenever a land enters the battlefield under your control, you may draw a card.\"",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "5df32589-14b8-52d1-9e7f-b7e02a488080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0c49ab-da04-4461-8440-d6c9086443c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0c49ab-da04-4461-8440-d6c9086443c6.jpg?1",
             "name": "Ornamental Courage",
             "text": "Untap target creature. It gets +1/+3 until end of turn.",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "fe63c06d-d540-5aff-8eee-57f23c7507bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eb9d40-958b-41b8-b04b-7f45adc0a862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eb9d40-958b-41b8-b04b-7f45adc0a862.jpg?1",
             "name": "Oviya Pashiri, Sage Lifecrafter",
             "text": "{2}{G}, {T}: Create a 1/1 colorless Servo artifact creature token.\n{4}{G}, {T}: Create an X/X colorless Construct artifact creature token, where X is the number of creatures you control.",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "0edaf98f-3d13-500b-a35a-13b4cfc49db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab38bd5-64bb-41aa-851b-c6bc6b44bcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab38bd5-64bb-41aa-851b-c6bc6b44bcf0.jpg?1",
             "name": "Peema Outrider",
             "text": "Trample\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [
@@ -5688,7 +5688,7 @@
         },
         {
             "id": "874bca0d-5151-5969-af7b-e4bcb27095d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf7e050-9631-431c-bcae-f74d91d537b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf7e050-9631-431c-bcae-f74d91d537b0.jpg?1",
             "name": "Riparian Tiger",
             "text": "Trample\nWhen Riparian Tiger enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Riparian Tiger attacks, you may pay {E}{E}. If you do, it gets +2/+2 until end of turn.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "060273cd-726e-5dbc-971d-a25d13bae406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d29a-2043-4341-89d5-5e34bb6507e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d29a-2043-4341-89d5-5e34bb6507e2.jpg?1",
             "name": "Sage of Shaila's Claim",
             "text": "When Sage of Shaila's Claim enters the battlefield, you get {E}{E}{E} (three energy counters).",
             "colours": [
@@ -5757,7 +5757,7 @@
         },
         {
             "id": "2c07fdf8-1400-519a-b960-8d56d0d05784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9cf30-4baa-4f28-84e8-b9b1168a40e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce9cf30-4baa-4f28-84e8-b9b1168a40e0.jpg?1",
             "name": "Servant of the Conduit",
             "text": "When Servant of the Conduit enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "6c2bf99c-52bb-53c5-876a-647f8ee5d819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e702db-8c73-4947-9c13-5dcb50f4efab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e702db-8c73-4947-9c13-5dcb50f4efab.jpg?1",
             "name": "Take Down",
             "text": "Choose one \u2014\n\u2022 Take Down deals 4 damage to target creature with flying.\n\u2022 Take Down deals 1 damage to each creature with flying.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "b7baf46d-ee02-55cd-9d33-cd929e3328d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acf10ec-f2dd-4569-909b-ac52a9ed6adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acf10ec-f2dd-4569-909b-ac52a9ed6adf.jpg?1",
             "name": "Thriving Rhino",
             "text": "When Thriving Rhino enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Thriving Rhino attacks, you may pay {E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "026df6af-8896-560f-b0a5-156ea2a9a28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0130b99e-5b2f-4482-b141-752e59b72c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0130b99e-5b2f-4482-b141-752e59b72c31.jpg?1",
             "name": "Verdurous Gearhulk",
             "text": "Trample\nWhen Verdurous Gearhulk enters the battlefield, distribute four +1/+1 counters among any number of target creatures you control.",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "8cf79162-87e0-52a6-8c94-0b3ea4a49195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d20e020-30e1-4deb-8dfc-4c5fe056193d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d20e020-30e1-4deb-8dfc-4c5fe056193d.jpg?1",
             "name": "Wild Wanderer",
             "text": "When Wild Wanderer enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5928,7 +5928,7 @@
         },
         {
             "id": "a21e62f3-be94-5c65-b0e2-d74f0937b697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fedd63c-22e4-4c36-8a7a-a167a070678f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fedd63c-22e4-4c36-8a7a-a167a070678f.jpg?1",
             "name": "Wildest Dreams",
             "text": "Return X target cards from your graveyard to your hand. Exile Wildest Dreams.",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "f784394b-124d-5779-bfd0-9b267923c12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6ece3-9889-47fa-9140-420b4f31dd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac6ece3-9889-47fa-9140-420b4f31dd1b.jpg?1",
             "name": "Wily Bandar",
             "text": "{2}{G}: Wily Bandar gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -5995,7 +5995,7 @@
         },
         {
             "id": "4e854018-4059-5acd-9b3e-e78dcea9c632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb12355-abd8-4bf3-aac1-f710ac162585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb12355-abd8-4bf3-aac1-f710ac162585.jpg?1",
             "name": "Cloudblazer",
             "text": "Flying\nWhen Cloudblazer enters the battlefield, you gain 2 life and draw two cards.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "305f050f-c180-55ed-bcd0-c585e0014277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beafcd-6c90-40c2-afff-0bd82377febf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69beafcd-6c90-40c2-afff-0bd82377febf.jpg?1",
             "name": "Contraband Kingpin",
             "text": "Lifelink\nWhenever an artifact enters the battlefield under your control, scry 1.",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "264276da-019d-589e-880f-9bc99c37d7ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592f3a92-787e-4180-9d0b-06c973ce8975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592f3a92-787e-4180-9d0b-06c973ce8975.jpg?1",
             "name": "Depala, Pilot Exemplar",
             "text": "Other Dwarves you control get +1/+1.\nEach Vehicle you control gets +1/+1 as long as it's a creature.\nWhenever Depala, Pilot Exemplar becomes tapped, you may pay {X}. If you do, reveal the top X cards of your library, put all Dwarf and Vehicle cards from among them into your hand, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "67ae4127-0adf-5088-b3bd-fa66c6b7548f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2344e710-4570-41b6-af84-a3e7d784003a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2344e710-4570-41b6-af84-a3e7d784003a.jpg?1",
             "name": "Dovin Baan",
             "text": "+1: Until your next turn, up to one target creature gets -3/-0 and its activated abilities can't be activated.\n\u22121: You gain 2 life and draw a card.\n\u22127: You get an emblem with \"Your opponents can't untap more than two permanents during their untap steps.\"",
             "colours": [
@@ -6146,7 +6146,7 @@
         },
         {
             "id": "8965fba9-530a-5e2b-821c-fa3b5990eb1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4554b10e-9c3e-4eb4-b0fe-044e483e872f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4554b10e-9c3e-4eb4-b0fe-044e483e872f.jpg?1",
             "name": "Empyreal Voyager",
             "text": "Flying, trample\nWhenever Empyreal Voyager deals combat damage to a player, you get that many {E} (energy counters).",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "59ed559a-b6b8-5729-98e1-8abd41c5f8ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b5fc7-51b2-4425-b053-a5d19c1595e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b5fc7-51b2-4425-b053-a5d19c1595e0.jpg?1",
             "name": "Engineered Might",
             "text": "Choose one \u2014\n\u2022 Target creature gets +5/+5 and gains trample until end of turn.\n\u2022 Creatures you control get +2/+2 and gain vigilance until end of turn.",
             "colours": [
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "4e3a61fe-a281-5851-8772-d06927893d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa9b08b-c56f-480e-874e-069e72d979c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa9b08b-c56f-480e-874e-069e72d979c8.jpg?1",
             "name": "Hazardous Conditions",
             "text": "Creatures with no counters on them get -2/-2 until end of turn.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "70e592bb-18c1-5946-adb6-faeb6fe93110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d61ddb-2662-427c-a97d-21e41b86130d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d61ddb-2662-427c-a97d-21e41b86130d.jpg?1",
             "name": "Kambal, Consul of Allocation",
             "text": "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -6290,7 +6290,7 @@
         },
         {
             "id": "df694982-825d-5904-b7e2-19a0315db30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce37555-49a2-4112-95b4-f3376b55b45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce37555-49a2-4112-95b4-f3376b55b45b.jpg?1",
             "name": "Rashmi, Eternities Crafter",
             "text": "Whenever you cast your first spell each turn, reveal the top card of your library. If it's a nonland card with converted mana cost less than that spell's, you may cast it without paying its mana cost. If you don't cast the revealed card, put it into your hand.",
             "colours": [
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "a79ab97d-d3cf-5623-b37c-48e06f0f78c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228ea9c6-5732-4a2a-ac25-a768ea7d433b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228ea9c6-5732-4a2a-ac25-a768ea7d433b.jpg?1",
             "name": "Restoration Gearsmith",
             "text": "When Restoration Gearsmith enters the battlefield, return target artifact or creature card from your graveyard to your hand.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "c907a265-5aa6-503d-8351-049d3bfb10c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b38464-39cd-4ee6-b9bf-a0bc1e128d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b38464-39cd-4ee6-b9bf-a0bc1e128d9a.jpg?1",
             "name": "Saheeli Rai",
             "text": "+1: Scry 1. Saheeli Rai deals 1 damage to each opponent.\n\u22122: Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. That token gains haste. Exile it at the beginning of the next end step.\n\u22127: Search your library for up to three artifact cards with different names, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "ceecfdc9-bd9a-5f28-a1f3-71fbe130580d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ad8f86-7860-4896-a161-07bf347bbd5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ad8f86-7860-4896-a161-07bf347bbd5b.jpg?1",
             "name": "Unlicensed Disintegration",
             "text": "Destroy target creature. If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller.",
             "colours": [
@@ -6438,7 +6438,7 @@
         },
         {
             "id": "3c94a913-5819-5828-aed3-4513ac8973e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5be9c1-cb28-42bd-b159-5548124ba8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5be9c1-cb28-42bd-b159-5548124ba8d1.jpg?1",
             "name": "Veteran Motorist",
             "text": "When Veteran Motorist enters the battlefield, scry 2.\nWhenever Veteran Motorist crews a Vehicle, that Vehicle gets +1/+1 until end of turn.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "cd6e48ec-e6fb-5538-a846-bd49da99dd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb038fd3-51b7-4de7-9b38-cbad7c8717c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb038fd3-51b7-4de7-9b38-cbad7c8717c2.jpg?1",
             "name": "Voltaic Brawler",
             "text": "When Voltaic Brawler enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Voltaic Brawler attacks, you may pay {E}. If you do, it gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "a3497e66-3050-5355-8374-b247289a2c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae429806-28b5-4bee-b0e1-1bd876f282c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae429806-28b5-4bee-b0e1-1bd876f282c2.jpg?1",
             "name": "Whirler Virtuoso",
             "text": "When Whirler Virtuoso enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}: Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "5b04effe-37f7-52fd-bd96-dbf3b9bdd98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2362-f901-4ec6-9bc4-1988f30380fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2362-f901-4ec6-9bc4-1988f30380fd.jpg?1",
             "name": "Accomplished Automaton",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "41e9b210-f525-526b-abe6-723471722d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b6b2e1-c3e6-464c-8a13-b15deb34e862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b6b2e1-c3e6-464c-8a13-b15deb34e862.jpg?1",
             "name": "Aetherflux Reservoir",
             "text": "Whenever you cast a spell, you gain 1 life for each spell you've cast this turn.\nPay 50 life: Aetherflux Reservoir deals 50 damage to target creature or player.",
             "colours": [],
@@ -6608,7 +6608,7 @@
         },
         {
             "id": "ed07b8c1-c93f-523e-b722-cfcb7190b52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884f6948-3e03-48c6-8be2-6f2539386c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884f6948-3e03-48c6-8be2-6f2539386c9d.jpg?1",
             "name": "Aetherworks Marvel",
             "text": "Whenever a permanent you control is put into a graveyard, you get {E} (an energy counter).\n{T}, Pay {E}{E}{E}{E}{E}{E}: Look at the top six cards of your library. You may cast a card from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "6855c4c7-e56b-5ab9-8955-bb3a412d4682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bdc973-db45-46a6-ac48-ce88fb59920a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bdc973-db45-46a6-ac48-ce88fb59920a.jpg?1",
             "name": "Animation Module",
             "text": "Whenever one or more +1/+1 counters are placed on a permanent you control, you may pay {1}. If you do, create a 1/1 colorless Servo artifact creature token.\n{3}, {T}: Choose a counter on target permanent or player. Give that permanent or player another counter of that kind.",
             "colours": [],
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "ff2ea7fa-2f4f-5df0-b132-46ca000a9938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0d1f7-c81c-4329-92b7-c4df227cc56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc0d1f7-c81c-4329-92b7-c4df227cc56c.jpg?1",
             "name": "Aradara Express",
             "text": "Menace\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6696,7 +6696,7 @@
         },
         {
             "id": "f116bb6a-36cd-5d61-8cea-dcfbb40e3ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd3f376-1075-42c9-91df-80dc2d5faacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd3f376-1075-42c9-91df-80dc2d5faacf.jpg?1",
             "name": "Ballista Charger",
             "text": "Whenever Ballista Charger attacks, it deals 1 damage to target creature or player.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "3ea7966c-16e4-5e81-bb4e-3539fd1f2ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ea690f-fd4e-4d05-b815-22d97736e894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ea690f-fd4e-4d05-b815-22d97736e894.jpg?1",
             "name": "Bastion Mastodon",
             "text": "{W}: Bastion Mastodon gains vigilance until end of turn.",
             "colours": [],
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "36b1e0c7-7431-5f6d-810f-c05cb63257fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32be75-979d-43a9-9132-2cf013ddaf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f32be75-979d-43a9-9132-2cf013ddaf3b.jpg?1",
             "name": "Bomat Bazaar Barge",
             "text": "When Bomat Bazaar Barge enters the battlefield, draw a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "cebb4bb9-27ab-564e-a4c4-1eaa6f07fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bff89-ad15-4d22-bce9-a4a07dbafd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bff89-ad15-4d22-bce9-a4a07dbafd87.jpg?1",
             "name": "Bomat Courier",
             "text": "Haste\nWhenever Bomat Courier attacks, exile the top card of your library face down. (You can't look at it.)\n{R}, Discard your hand, Sacrifice Bomat Courier: Put all cards exiled with Bomat Courier into their owners' hands.",
             "colours": [],
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "b87074ef-2796-5472-9164-3db65d481b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a6f80-3ff9-4d9e-8b1e-cb07c3dc326a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a6f80-3ff9-4d9e-8b1e-cb07c3dc326a.jpg?1",
             "name": "Chief of the Foundry",
             "text": "Other artifact creatures you control get +1/+1.",
             "colours": [],
@@ -6853,7 +6853,7 @@
         },
         {
             "id": "edc76636-08ef-5781-a9eb-df37036a3dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d594df-c51b-4936-9af1-536dab1792ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d594df-c51b-4936-9af1-536dab1792ae.jpg?1",
             "name": "Cogworker's Puzzleknot",
             "text": "When Cogworker's Puzzleknot enters the battlefield, create a 1/1 colorless Servo artifact creature token.\n{1}{W}, Sacrifice Cogworker's Puzzleknot: Create a 1/1 colorless Servo artifact creature token.",
             "colours": [],
@@ -6883,7 +6883,7 @@
         },
         {
             "id": "973bfec9-cdbc-5cab-bb5c-0be3d11fb121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7922c3-1baa-41ed-bd06-b5a97cddb90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7922c3-1baa-41ed-bd06-b5a97cddb90e.jpg?1",
             "name": "Consulate Skygate",
             "text": "Defender\nReach (This creature can block creatures with flying.)",
             "colours": [],
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "e4ceee6b-13c9-5006-935d-47d3a129d4ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b3726-4bc8-4e3a-bc6d-402c81663712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b3726-4bc8-4e3a-bc6d-402c81663712.jpg?1",
             "name": "Cultivator's Caravan",
             "text": "{T}: Add one mana of any color to your mana pool.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "195efc9d-0cf1-5dcd-ae32-b80f6162049f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f956dedc-2cf4-4039-8302-feab94b78426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f956dedc-2cf4-4039-8302-feab94b78426.jpg?1",
             "name": "Deadlock Trap",
             "text": "Deadlock Trap enters the battlefield tapped.\nWhen Deadlock Trap enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Tap target creature or planeswalker. Its activated abilities can't be activated this turn.",
             "colours": [],
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "149888c1-b432-56b6-92bb-779069f76c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08ae769-0070-47a6-aae0-1a3bcfd40d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08ae769-0070-47a6-aae0-1a3bcfd40d07.jpg?1",
             "name": "Decoction Module",
             "text": "Whenever a creature enters the battlefield under your control, you get {E} (an energy counter).\n{4}, {T}: Return target creature you control to its owner's hand.",
             "colours": [],
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "36108ccc-7a00-568f-8444-a7c3b542e04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9af13a0-a9c1-454c-992d-ce79ff161187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9af13a0-a9c1-454c-992d-ce79ff161187.jpg?1",
             "name": "Demolition Stomper",
             "text": "Demolition Stomper can't be blocked by creatures with power 2 or less.\nCrew 5 (Tap any number of creatures you control with total power 5 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "bcb8ebd6-ff17-5a3a-8ddb-39ae2e178a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c54795-d555-4972-b72d-b2d2374bed9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c54795-d555-4972-b72d-b2d2374bed9b.jpg?1",
             "name": "Dukhara Peafowl",
             "text": "{U}: Dukhara Peafowl gains flying until end of turn.",
             "colours": [],
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "4be340f4-8345-5904-8096-44b4fda777da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45fd2ae-0f91-47ca-99bd-22ddf946df9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45fd2ae-0f91-47ca-99bd-22ddf946df9f.jpg?1",
             "name": "Dynavolt Tower",
             "text": "Whenever you cast an instant or sorcery spell, you get {E}{E} (two energy counters).\n{T}, Pay {E}{E}{E}{E}{E}: Dynavolt Tower deals 3 damage to target creature or player.",
             "colours": [],
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "3af562b0-5fdf-5f94-98bc-8bcd3c9b4605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ae7b-02a5-45ce-8a63-aa880b1e582a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f8ae7b-02a5-45ce-8a63-aa880b1e582a.jpg?1",
             "name": "Eager Construct",
             "text": "When Eager Construct enters the battlefield, each player may scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [],
@@ -7122,7 +7122,7 @@
         },
         {
             "id": "36faeb35-bce9-558c-80d7-053d391e3def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565d11b-a57e-4de4-9d18-2be48a2ef742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c565d11b-a57e-4de4-9d18-2be48a2ef742.jpg?1",
             "name": "Electrostatic Pummeler",
             "text": "When Electrostatic Pummeler enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}{E}: Electrostatic Pummeler gets +X/+X until end of turn, where X is its power.",
             "colours": [],
@@ -7153,7 +7153,7 @@
         },
         {
             "id": "6147870f-bd46-5ffd-8bb2-26609bfe082d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93a9693-f899-47ac-8ee0-3549d9333fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93a9693-f899-47ac-8ee0-3549d9333fff.jpg?1",
             "name": "Fabrication Module",
             "text": "Whenever you get one or more {E} (energy counters), put a +1/+1 counter on target creature you control.\n{4}, {T}: You get {E}.",
             "colours": [],
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "b971b0e4-be13-588e-b487-ef6acd35d024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc9ecfd-6cf0-4488-a14a-afec1bc0d253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc9ecfd-6cf0-4488-a14a-afec1bc0d253.jpg?1",
             "name": "Filigree Familiar",
             "text": "When Filigree Familiar enters the battlefield, you gain 2 life.\nWhen Filigree Familiar dies, draw a card.",
             "colours": [],
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "3e44be5b-7c66-51e8-a17d-575fc1a25cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c11ca-c81b-451e-a767-68865827e06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1c11ca-c81b-451e-a767-68865827e06d.jpg?1",
             "name": "Fireforger's Puzzleknot",
             "text": "When Fireforger's Puzzleknot enters the battlefield, it deals 1 damage to target creature or player.\n{2}{R}, Sacrifice Fireforger's Puzzleknot: It deals 1 damage to target creature or player.",
             "colours": [],
@@ -7242,7 +7242,7 @@
         },
         {
             "id": "866614dc-c787-5205-bc85-15572825a2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdaca1e-5741-456e-ae98-e2c45fd1731b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdaca1e-5741-456e-ae98-e2c45fd1731b.jpg?1",
             "name": "Fleetwheel Cruiser",
             "text": "Trample, haste\nWhen Fleetwheel Cruiser enters the battlefield, it becomes an artifact creature until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "a398c156-3766-5d2a-96e0-9e447b64cfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f827e8-1cc4-4a15-a4be-2e74323963b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f827e8-1cc4-4a15-a4be-2e74323963b9.jpg?1",
             "name": "Foundry Inspector",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [],
@@ -7303,7 +7303,7 @@
         },
         {
             "id": "576eaf10-ed9d-567d-a2cb-d3326d047580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bff744-873b-4fa1-8088-5f28bbcdc7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bff744-873b-4fa1-8088-5f28bbcdc7b8.jpg?1",
             "name": "Ghirapur Orrery",
             "text": "Each player may play an additional land on each of his or her turns.\nAt the beginning of each player's upkeep, if that player has no cards in hand, that player draws three cards.",
             "colours": [],
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "fa76b3fa-64a9-55db-8129-6ac64cc2d26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d123031-6702-4d49-a788-42eb6dbc569e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d123031-6702-4d49-a788-42eb6dbc569e.jpg?1",
             "name": "Glassblower's Puzzleknot",
             "text": "When Glassblower's Puzzleknot enters the battlefield, scry 2, then you get {E}{E}. (You get two energy counters. To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)\n{2}{U}, Sacrifice Glassblower's Puzzleknot: Scry 2, then you get {E}{E}.",
             "colours": [],
@@ -7361,7 +7361,7 @@
         },
         {
             "id": "99214e46-9fac-5bd2-8284-519450d41c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a26fdf-fdce-4939-8c6a-c9dff623072f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a26fdf-fdce-4939-8c6a-c9dff623072f.jpg?1",
             "name": "Inventor's Goggles",
             "text": "Equipped creature gets +1/+2.\nWhenever an Artificer enters the battlefield under your control, you may attach Inventor's Goggles to it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "416f481f-fd07-5003-ad0e-c32f1736f3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47993b2-694d-4697-8b06-64aa5663598b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47993b2-694d-4697-8b06-64aa5663598b.jpg?1",
             "name": "Iron League Steed",
             "text": "Haste\nFabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)",
             "colours": [],
@@ -7422,7 +7422,7 @@
         },
         {
             "id": "a2e94f9a-73a1-5a61-b813-480000b7d4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66154969-5c69-40ce-8bc9-c9bc5e280d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66154969-5c69-40ce-8bc9-c9bc5e280d4c.jpg?1",
             "name": "Key to the City",
             "text": "{T}, Discard a card: Up to one target creature can't be blocked this turn.\nWhenever Key to the City becomes untapped, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "774e793b-e9b8-5d5c-b5fd-87b85268f32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1639c3-f22d-4246-9252-219a4b2b2999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1639c3-f22d-4246-9252-219a4b2b2999.jpg?1",
             "name": "Metalspinner's Puzzleknot",
             "text": "When Metalspinner's Puzzleknot enters the battlefield, you draw a card and you lose 1 life.\n{2}{B}, Sacrifice Metalspinner's Puzzleknot: You draw a card and you lose 1 life.",
             "colours": [],
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "8f079cbd-8419-5f5f-9f30-ea601918ebb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474480b5-c60b-4c7f-9d3e-751bca43d074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474480b5-c60b-4c7f-9d3e-751bca43d074.jpg?1",
             "name": "Metalwork Colossus",
             "text": "Metalwork Colossus costs {X} less to cast, where X is the total converted mana cost of noncreature artifacts you control.\nSacrifice two artifacts: Return Metalwork Colossus from your graveyard to your hand.",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "f2ef411d-bea9-5527-b154-9d144a4622d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6956c1-36e2-4c9c-9f69-00b459f094d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6956c1-36e2-4c9c-9f69-00b459f094d8.jpg?1",
             "name": "Multiform Wonder",
             "text": "When Multiform Wonder enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}: Multiform Wonder gains your choice of flying, vigilance, or lifelink until end of turn.\nPay {E}: Multiform Wonder gets +2/-2 or -2/+2 until end of turn.",
             "colours": [],
@@ -7542,7 +7542,7 @@
         },
         {
             "id": "87b8b93b-7118-5a62-aca5-2c849c4061eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1a67-61f7-4f03-b677-a874b64c989e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf1a67-61f7-4f03-b677-a874b64c989e.jpg?1",
             "name": "Narnam Cobra",
             "text": "{G}: Narnam Cobra gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [],
@@ -7575,7 +7575,7 @@
         },
         {
             "id": "1b0e6722-7fb3-5256-89ad-f77175b70fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20411aa0-f87b-49dd-b943-ca82d59db185.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20411aa0-f87b-49dd-b943-ca82d59db185.jpg?1",
             "name": "Ovalchase Dragster",
             "text": "Trample, haste\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "32ea8ed5-f64a-5359-8327-4230078fcf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15856326-d943-476a-9d31-898b9f990bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15856326-d943-476a-9d31-898b9f990bb6.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "4372cce1-c534-558c-9f33-beece9127f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc87a27-93d9-4ce0-a022-0309242c1e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc87a27-93d9-4ce0-a022-0309242c1e89.jpg?1",
             "name": "Perpetual Timepiece",
             "text": "{T}: Put the top two cards of your library into your graveyard.\n{2}, Exile Perpetual Timepiece: Shuffle any number of target cards from your graveyard into your library.",
             "colours": [],
@@ -7661,7 +7661,7 @@
         },
         {
             "id": "006e08e7-5c3d-53a4-b8b3-d726573887fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c91b356-b5d8-4239-bb45-dec7f673868d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c91b356-b5d8-4239-bb45-dec7f673868d.jpg?1",
             "name": "Prakhata Pillar-Bug",
             "text": "{B}: Prakhata Pillar-Bug gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [],
@@ -7694,7 +7694,7 @@
         },
         {
             "id": "c5312b5e-f7aa-5526-8110-7f121fc375c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06450be5-0634-4aef-bda7-4d4fbb9ec00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06450be5-0634-4aef-bda7-4d4fbb9ec00a.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "7b0f8369-d8e1-5466-a818-782f4cbca145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10e2c3-0132-4eb2-94f0-5915caca2a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a10e2c3-0132-4eb2-94f0-5915caca2a17.jpg?1",
             "name": "Renegade Freighter",
             "text": "Whenever Renegade Freighter attacks, it gets +1/+1 and gains trample until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "58aac6d5-3929-5005-a5cb-f65a7c65f536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a8e4e-ea7b-41c7-a982-b5751025ff25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a8e4e-ea7b-41c7-a982-b5751025ff25.jpg?1",
             "name": "Scrapheap Scrounger",
             "text": "Scrapheap Scrounger can't block.\n{1}{B}, Exile another creature card from your graveyard: Return Scrapheap Scrounger from your graveyard to the battlefield.",
             "colours": [],
@@ -7785,7 +7785,7 @@
         },
         {
             "id": "d6cb6e6b-c5fd-5058-a595-19730fb53931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d05c6c2-4bb3-468a-b23c-b0425a9982f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d05c6c2-4bb3-468a-b23c-b0425a9982f1.jpg?1",
             "name": "Self-Assembler",
             "text": "When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "56e4847a-887e-597a-8f54-d6b03ceaacfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4939-130b-40d7-8a0f-e31eb931d2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4939-130b-40d7-8a0f-e31eb931d2d5.jpg?1",
             "name": "Sky Skiff",
             "text": "Flying\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7846,7 +7846,7 @@
         },
         {
             "id": "2e4cda99-296f-5113-9724-1b8a79d9cff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df70ef3-8919-43ac-9317-23548437a181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df70ef3-8919-43ac-9317-23548437a181.jpg?1",
             "name": "Skysovereign, Consul Flagship",
             "text": "Flying\nWhenever Skysovereign, Consul Flagship enters the battlefield or attacks, it deals 3 damage to target creature or planeswalker an opponent controls.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "33da5ee5-1ff3-54ae-851f-2d686fcb764d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832abb5-5107-4603-904e-491b221bd3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832abb5-5107-4603-904e-491b221bd3e3.jpg?1",
             "name": "Smuggler's Copter",
             "text": "Flying\nWhenever Smuggler's Copter attacks or blocks, you may draw a card. If you do, discard a card.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "90494316-350c-5176-83a5-1e87adc982c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687febd3-1825-4fd2-b9ab-bd32a9baffc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687febd3-1825-4fd2-b9ab-bd32a9baffc7.jpg?1",
             "name": "Snare Thopter",
             "text": "Flying, haste",
             "colours": [],
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "64e0867d-7e0c-5d5a-bc0f-317194d2047e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf9a88-c5f8-4c26-a2ee-d2827e9a31d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfcf9a88-c5f8-4c26-a2ee-d2827e9a31d8.jpg?1",
             "name": "Torch Gauntlet",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7969,7 +7969,7 @@
         },
         {
             "id": "e7c8a81a-aec9-57fa-92b8-f39c702efad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75720c1b-8b04-4e45-ab47-018c04576e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75720c1b-8b04-4e45-ab47-018c04576e83.jpg?1",
             "name": "Weldfast Monitor",
             "text": "{R}: Weldfast Monitor gains menace until end of turn.",
             "colours": [],
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "8a4ca27c-1a81-53f1-a676-489ee099ea48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1a1246-d5a0-43dc-825a-062a3bb4def9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1a1246-d5a0-43dc-825a-062a3bb4def9.jpg?1",
             "name": "Whirlermaker",
             "text": "{4}, {T}: Create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "1fc70f38-7785-571d-ac9d-e4d1349341d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d7420-f16d-4910-adf7-6deff47ecf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899d7420-f16d-4910-adf7-6deff47ecf1e.jpg?1",
             "name": "Woodweaver's Puzzleknot",
             "text": "When Woodweaver's Puzzleknot enters the battlefield, you gain 3 life and get {E}{E}{E} (three energy counters).\n{2}{G}, Sacrifice Woodweaver's Puzzleknot: You gain 3 life and get {E}{E}{E}.",
             "colours": [],
@@ -8060,7 +8060,7 @@
         },
         {
             "id": "7784a6eb-2ff2-5ee3-9649-e48834093f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509a1a3a-d9a6-4903-95f6-dae6b330f4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509a1a3a-d9a6-4903-95f6-dae6b330f4ea.jpg?1",
             "name": "Workshop Assistant",
             "text": "When Workshop Assistant dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -8091,7 +8091,7 @@
         },
         {
             "id": "57b404f8-1969-5262-9bfa-b9b2e3729752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea04d8-5d85-49d3-8d8d-7fe123d0ed6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea04d8-5d85-49d3-8d8d-7fe123d0ed6c.jpg?1",
             "name": "Aether Hub",
             "text": "When Aether Hub enters the battlefield, you get {E} (an energy counter).\n{T}: Add {C} to your mana pool.\n{T}, Pay {E}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8119,7 +8119,7 @@
         },
         {
             "id": "64d39ad9-7e16-544e-b531-483cbf6c5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da33d4-fe9c-42fe-b326-2fe337dc3ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da33d4-fe9c-42fe-b326-2fe337dc3ecd.jpg?1",
             "name": "Blooming Marsh",
             "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8150,7 +8150,7 @@
         },
         {
             "id": "d769cf36-47e1-5a43-bb74-5a1777bc0f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8744471b-a528-47d9-84d0-4526273f55e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8744471b-a528-47d9-84d0-4526273f55e9.jpg?1",
             "name": "Botanical Sanctum",
             "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8181,7 +8181,7 @@
         },
         {
             "id": "86995bdf-9a82-5501-8efa-7434a241bf54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8769e97-aee8-4466-a9d7-0f4245ae4a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8769e97-aee8-4466-a9d7-0f4245ae4a97.jpg?1",
             "name": "Concealed Courtyard",
             "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8212,7 +8212,7 @@
         },
         {
             "id": "c43fae16-a919-5d77-b952-7b9fbea71868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160ac412-005f-48ca-a204-10207307c6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160ac412-005f-48ca-a204-10207307c6c2.jpg?1",
             "name": "Inspiring Vantage",
             "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8243,7 +8243,7 @@
         },
         {
             "id": "65378049-749a-535a-9021-b028a54d57be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275471e3-ded1-40ac-91ef-369dce5764d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275471e3-ded1-40ac-91ef-369dce5764d9.jpg?1",
             "name": "Inventors' Fair",
             "text": "At the beginning of your upkeep, if you control three or more artifacts, you gain 1 life.\n{T}: Add {C} to your mana pool.\n{4}, {T}, Sacrifice Inventors' Fair: Search your library for an artifact card, reveal it, put it into your hand, then shuffle your library. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -8273,7 +8273,7 @@
         },
         {
             "id": "c300440d-c031-58d9-8cab-1150dda8ac18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a17084-bb96-4e81-bff0-005bd44a1fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a17084-bb96-4e81-bff0-005bd44a1fbd.jpg?1",
             "name": "Sequestered Stash",
             "text": "{T}: Add {C} to your mana pool.\n{4}, {T}, Sacrifice Sequestered Stash: Put the top five cards of your library into your graveyard. Then you may put an artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -8301,7 +8301,7 @@
         },
         {
             "id": "5f092bac-80d7-5e97-bd98-8ffb5a2c2346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e587ea7-0632-4789-ba75-3c410da2bb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e587ea7-0632-4789-ba75-3c410da2bb96.jpg?1",
             "name": "Spirebluff Canal",
             "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8332,7 +8332,7 @@
         },
         {
             "id": "1ab8edeb-254e-514d-9b07-ce07fd415806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32912b82-bbe5-4d70-817d-cd18bfdecacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32912b82-bbe5-4d70-817d-cd18bfdecacb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8369,7 +8369,7 @@
         },
         {
             "id": "a8d9d2fd-1eab-571c-8ef5-bd25d5a33321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41416-bc0f-4e49-9137-df8572e91ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e41416-bc0f-4e49-9137-df8572e91ae5.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "0e4dd86c-f308-597e-8087-8858e9b83da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879162e8-3a10-40da-8d86-9a7dff67c961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879162e8-3a10-40da-8d86-9a7dff67c961.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8443,7 +8443,7 @@
         },
         {
             "id": "aa56ca7c-430a-53ca-8800-3bca8f56fa3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca139d8-08a1-45d4-be9d-2ee5c9b3de43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca139d8-08a1-45d4-be9d-2ee5c9b3de43.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "c75cfb4e-9620-5124-b30c-653c8bb19863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086d6aed-1f7e-4a80-8d66-01d995f344ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086d6aed-1f7e-4a80-8d66-01d995f344ed.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8517,7 +8517,7 @@
         },
         {
             "id": "d9e2677d-9074-5383-9dd1-ef53f8c40cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197080a9-ebb5-4a8b-81f8-0368c5bba35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197080a9-ebb5-4a8b-81f8-0368c5bba35a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "64242f9e-d81a-5f75-82fa-3f3be1aad9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4760cdcc-e973-439c-a74a-5cb73b4fa22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4760cdcc-e973-439c-a74a-5cb73b4fa22f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "ed1e67b6-87df-51a2-806c-e439b2648322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f8ee-1416-4be8-9da1-f4546164c522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a9f8ee-1416-4be8-9da1-f4546164c522.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8628,7 +8628,7 @@
         },
         {
             "id": "7d10c362-6fee-540c-8ee0-a800f68b63ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364ee0ec-4970-4a30-bf5b-b045a6122860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364ee0ec-4970-4a30-bf5b-b045a6122860.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8665,7 +8665,7 @@
         },
         {
             "id": "8428ca03-8964-5acb-ae86-c82fc07316df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b4a0e0-3d27-414b-80cb-352f16389a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b4a0e0-3d27-414b-80cb-352f16389a83.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "cd5c0124-6ae4-591c-8401-81a4a1b319ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72d883e-d194-4154-a96c-35e601c5f797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72d883e-d194-4154-a96c-35e601c5f797.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "61f00e71-8554-5dfd-b0ae-f0986ceb6bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b65f77-85c1-49cd-bb2e-70e5225ace9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b65f77-85c1-49cd-bb2e-70e5225ace9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "57869970-bb45-5cdf-8944-2f541d141a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e67efe-cc8a-4132-9019-26ddfc72a735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e67efe-cc8a-4132-9019-26ddfc72a735.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8813,7 +8813,7 @@
         },
         {
             "id": "1542ff69-86bd-53aa-913d-07d747e0b0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2864a75-2945-4467-be00-3b4b71831f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2864a75-2945-4467-be00-3b4b71831f4f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "53dee5ae-d118-5654-8bee-c24c9abec4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8bd63e-303e-402c-9ad2-4f6e55ed0e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8bd63e-303e-402c-9ad2-4f6e55ed0e14.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8887,7 +8887,7 @@
         },
         {
             "id": "d3d00dce-d9b9-5670-94c8-17e0035620ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab8435b-5fe8-4074-8809-46aa6e5504c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab8435b-5fe8-4074-8809-46aa6e5504c8.jpg?1",
             "name": "Chandra, Pyrogenius",
             "text": "+2: Chandra, Pyrogenius deals 2 damage to each opponent.\n\u22123: Chandra, Pyrogenius deals 4 damage to target creature.\n\u221210: Chandra, Pyrogenius deals 6 damage to target player and each creature he or she controls.",
             "colours": [
@@ -8922,7 +8922,7 @@
         },
         {
             "id": "66ed454d-05ae-5d41-9946-759cec012075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44e3cb-cc69-4222-87bc-ffa54b7ab34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44e3cb-cc69-4222-87bc-ffa54b7ab34a.jpg?1",
             "name": "Flame Lash",
             "text": "Flame Lash deals 4 damage to target creature or player.",
             "colours": [
@@ -8953,7 +8953,7 @@
         },
         {
             "id": "5053131a-c727-5221-b521-4c630c26f8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d2156e-2d54-440e-b0fd-7bef702afbfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d2156e-2d54-440e-b0fd-7bef702afbfc.jpg?1",
             "name": "Liberating Combustion",
             "text": "Liberating Combustion deals 6 damage to target creature. You may search your library and/or graveyard for a card named Chandra, Pyrogenius, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "c04950de-e529-5740-99ae-76473e8e5762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633884-867c-4b51-bd5b-5f246d0ecd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633884-867c-4b51-bd5b-5f246d0ecd4e.jpg?1",
             "name": "Renegade Firebrand",
             "text": "As long as you control a Chandra planeswalker, Renegade Firebrand gets +1/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "83ceb0e5-8ffc-5717-adf0-a3b8b1ba212b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214a439-b388-4f41-a897-725e56d23fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214a439-b388-4f41-a897-725e56d23fe8.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "6ad705b1-8a3d-5215-a97f-abd4e589b050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777533c3-0a87-4625-8987-d850fc236ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777533c3-0a87-4625-8987-d850fc236ddb.jpg?1",
             "name": "Nissa, Nature's Artisan",
             "text": "+3: You gain 3 life.\n\u22124: Reveal the top two cards of your library. Put all land cards from among them onto the battlefield and the rest into your hand.\n\u221212: Creatures you control get +5/+5 and gain trample until end of turn.",
             "colours": [
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "19c7b9e5-e941-5111-9be9-31364fa0191d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72638ac5-84fd-4688-9b81-0eea3c05e53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72638ac5-84fd-4688-9b81-0eea3c05e53e.jpg?1",
             "name": "Guardian of the Great Conduit",
             "text": "Reach (This creature can block creatures with flying.)\nAs long as you control a Nissa planeswalker, Guardian of the Great Conduit gets +2/+0 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "31b35586-4796-552a-88e7-4f8dc6284c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b89e5c-ffb4-406f-99d1-ec2797aca061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b89e5c-ffb4-406f-99d1-ec2797aca061.jpg?1",
             "name": "Terrain Elemental",
             "text": "",
             "colours": [
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "d32f5f06-897f-57d8-a1db-9df47647717e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07997554-9fd7-4d6f-abaf-6c3fda9644d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07997554-9fd7-4d6f-abaf-6c3fda9644d2.jpg?1",
             "name": "Terrain Elemental",
             "text": "",
             "colours": [
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "79c058d4-18f7-516b-aed3-e38cba54a21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea890019-f48f-4164-b057-773499ef273f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea890019-f48f-4164-b057-773499ef273f.jpg?1",
             "name": "Verdant Crescendo",
             "text": "Search your library for a basic land card and put it onto the battlefield tapped. Search your library and graveyard for a card named Nissa, Nature's Artisan, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -9217,7 +9217,7 @@
         },
         {
             "id": "355a3df3-6b53-5b55-b89c-3f09d11b8da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a333bbdc-5af7-4679-b263-3aaa056452a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a333bbdc-5af7-4679-b263-3aaa056452a0.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "43d997bc-e6fb-5d74-8c96-9f7bb8c8e8f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de1d095-459f-42fd-9d9f-8f71d002a5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de1d095-459f-42fd-9d9f-8f71d002a5b2.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [],
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "1322fef2-b30e-5895-aa28-f0fa0879a89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a08d1-f5ff-48b7-bdb6-54b8d7a4b931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a08d1-f5ff-48b7-bdb6-54b8d7a4b931.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -9309,7 +9309,7 @@
         },
         {
             "id": "36d79a78-afc0-5abc-8157-037512af9d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f071a-f250-4a2b-9060-da27f2fc0f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55f071a-f250-4a2b-9060-da27f2fc0f48.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "c2951084-f8a8-5e6c-bb0b-4cd5f3a8b26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60842b1a-6ae7-4b3b-a23f-0d94a3d89884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60842b1a-6ae7-4b3b-a23f-0d94a3d89884.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "0c159f1d-c5e0-5ff5-9634-772cd3526dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79e2bf1-d26d-4be3-a5ad-a43346ed445a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79e2bf1-d26d-4be3-a5ad-a43346ed445a.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "150509ae-ac3b-5e5a-9670-0cc97ab89d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1980809-4c81-4080-92cd-31776962a4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1980809-4c81-4080-92cd-31776962a4e1.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "fc01d548-995f-5697-80d7-301382c1c049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd03a2b9-bfd7-4e1d-b660-e9f945699b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd03a2b9-bfd7-4e1d-b660-e9f945699b78.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "9d0d0374-386c-58e1-aa0f-6a517a1af119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d39524b-a4af-44ed-8f04-50680628c28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d39524b-a4af-44ed-8f04-50680628c28f.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -9495,7 +9495,7 @@
         },
         {
             "id": "6d455809-dce4-52fe-964c-02a3bbdf7eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9a3d08-040a-4fec-b86d-c41a074f925c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9a3d08-040a-4fec-b86d-c41a074f925c.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -9526,7 +9526,7 @@
         },
         {
             "id": "8a6cb21e-58b7-5eb0-9990-2602c22ce8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ce1db3-417c-4c22-84e5-c463addde476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ce1db3-417c-4c22-84e5-c463addde476.jpg?1",
             "name": "Chandra, Torch of Defiance Emblem",
             "text": "",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "95e9e55d-9581-5f65-a0d8-a2f73241a09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54986eaa-1bbb-4d34-ae09-fa7de2627ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54986eaa-1bbb-4d34-ae09-fa7de2627ba0.jpg?1",
             "name": "Nissa, Vital Force Emblem",
             "text": "",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "990e91b7-c20e-54eb-aa7f-f8246d36c48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ccde7-c78d-4f4a-9fe4-ad6986e2cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ccde7-c78d-4f4a-9fe4-ad6986e2cb8e.jpg?1",
             "name": "Dovin Baan Emblem",
             "text": "",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "9327a71d-09d2-5918-ad9f-b1949f3cf34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a446b9f8-cb22-408a-93ff-bee44a0dccc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a446b9f8-cb22-408a-93ff-bee44a0dccc0.jpg?1",
             "name": "Energy Reserve",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/KTK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/KTK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f7e45242-33fa-5e09-8632-868d89b2fb9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5427b1-f1c2-4bb3-8736-701667ac2256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f5427b1-f1c2-4bb3-8736-701667ac2256.jpg?1",
             "name": "Abzan Battle Priest",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has lifelink.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "ec479532-374c-551a-864d-a9b939527cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ee4f3c-dc94-4156-b0ed-60fe6310451a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ee4f3c-dc94-4156-b0ed-60fe6310451a.jpg?1",
             "name": "Abzan Falconer",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "155497e8-9b23-51e7-aead-c3eae36e29d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2a844-17fc-4628-9591-684555e98f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d2a844-17fc-4628-9591-684555e98f7b.jpg?1",
             "name": "Ainok Bond-Kin",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has first strike.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "678ac4fd-f92e-5c9f-836e-3ff03b051b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1ce529-06ed-4e85-9988-8c8b58401ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1ce529-06ed-4e85-9988-8c8b58401ed5.jpg?1",
             "name": "Alabaster Kirin",
             "text": "Flying, vigilance",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "ed5e70e0-034f-5fef-ae07-50131c1f92ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9c2b8a-148c-4393-b691-e333ad11c44e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9c2b8a-148c-4393-b691-e333ad11c44e.jpg?1",
             "name": "Brave the Sands",
             "text": "Creatures you control have vigilance.\nEach creature you control can block an additional creature.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "b3ee3be5-37b9-50a6-8fe0-80d5750f908f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce43a2df-4305-4ab1-ae45-96cca597650e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce43a2df-4305-4ab1-ae45-96cca597650e.jpg?1",
             "name": "Dazzling Ramparts",
             "text": "Defender\n{1}{W}, {T}: Tap target creature.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "804021f9-9979-5423-ac2b-948f2f74c5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ec83fa-5cb4-4633-8827-36d874a2d2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ec83fa-5cb4-4633-8827-36d874a2d2e7.jpg?1",
             "name": "Defiant Strike",
             "text": "Target creature gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "b97cf8a9-26d2-5a20-9b3d-1164ad4ff4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a53ed7-a7b7-40d8-9239-cf6f205dbc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a53ed7-a7b7-40d8-9239-cf6f205dbc59.jpg?1",
             "name": "End Hostilities",
             "text": "Destroy all creatures and all permanents attached to creatures.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "c2e995b6-07f1-59a5-9539-1c769a230430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd0e10-2ad7-467f-8d4b-c70b95bf2e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd0e10-2ad7-467f-8d4b-c70b95bf2e9c.jpg?1",
             "name": "Erase",
             "text": "Exile target enchantment.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "085b7d80-1a2c-5002-bc68-3427ae850695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6173466-30db-4b95-a556-dd69e03b731e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6173466-30db-4b95-a556-dd69e03b731e.jpg?1",
             "name": "Feat of Resistance",
             "text": "Put a +1/+1 counter on target creature you control. It gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "0e7b0b5b-4cdb-5cfd-a071-8a5f7bccacb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2b284-f79c-41eb-a25f-4710d4a5228f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2b284-f79c-41eb-a25f-4710d4a5228f.jpg?1",
             "name": "Firehoof Cavalry",
             "text": "{3}{R}: Firehoof Cavalry gets +2/+0 and gains trample until end of turn.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "c41509e1-fb42-5d53-875a-bd54138d7eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf6ed4-48f3-419f-bafd-d1ee4d798482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf6ed4-48f3-419f-bafd-d1ee4d798482.jpg?1",
             "name": "Herald of Anafenza",
             "text": "Outlast {2}{W} ({2}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nWhenever you activate Herald of Anafenza's outlast ability, put a 1/1 white Warrior creature token onto the battlefield.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "c8caeaeb-c01a-50c6-88ca-5444189a3097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5f4bab-f918-4b42-b82c-cfcf5ff0c58a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5f4bab-f918-4b42-b82c-cfcf5ff0c58a.jpg?1",
             "name": "High Sentinels of Arashin",
             "text": "Flying\nHigh Sentinels of Arashin gets +1/+1 for each other creature you control with a +1/+1 counter on it.\n{3}{W}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "f2574b13-1166-5ddb-962d-0935bd65c4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9007c528-0107-40fd-a97e-e5576f297eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9007c528-0107-40fd-a97e-e5576f297eb2.jpg?1",
             "name": "Jeskai Student",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "74627ab2-3f44-55b4-9c67-6eafce3077c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30d4136-78a3-4760-83af-d365cc97d118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30d4136-78a3-4760-83af-d365cc97d118.jpg?1",
             "name": "Kill Shot",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "89cd914c-63e1-5c45-87b3-c28359a9014e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d1cdfa-834c-4028-8036-c4bfb7da071b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d1cdfa-834c-4028-8036-c4bfb7da071b.jpg?1",
             "name": "Mardu Hateblade",
             "text": "{B}: Mardu Hateblade gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "4b098f64-f37a-5b65-8ed7-e3dcf83a66eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23426221-30a8-4be2-9c70-f0eb022edad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23426221-30a8-4be2-9c70-f0eb022edad7.jpg?1",
             "name": "Mardu Hordechief",
             "text": "Raid \u2014 When Mardu Hordechief enters the battlefield, if you attacked with a creature this turn, put a 1/1 white Warrior creature token onto the battlefield.",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "8c87011a-b42e-5653-8aa4-f9509039ace8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8455229-6fec-4843-b888-e701c09620af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8455229-6fec-4843-b888-e701c09620af.jpg?1",
             "name": "Master of Pearls",
             "text": "Morph {3}{W}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Master of Pearls is turned face up, creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "a8cc72f0-0862-5dd0-81e6-f5ccac89f49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47d8aa-59c8-4e2c-bb48-328ae924dbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d47d8aa-59c8-4e2c-bb48-328ae924dbb3.jpg?1",
             "name": "Rush of Battle",
             "text": "Creatures you control get +2/+1 until end of turn. Warrior creatures you control gain lifelink until end of turn. (Damage dealt by those Warriors also causes their controller to gain that much life.)",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "3566d8a7-9f24-5308-ad65-faf520f88879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc7b4c3-647e-48da-86f8-f55e3e990ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc7b4c3-647e-48da-86f8-f55e3e990ac1.jpg?1",
             "name": "Sage-Eye Harrier",
             "text": "Flying\nMorph {3}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "87d49a97-0939-5be4-8ec8-84c6f226867d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ee84d-e5b9-4103-8ba7-ccd79a272c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ee84d-e5b9-4103-8ba7-ccd79a272c0f.jpg?1",
             "name": "Salt Road Patrol",
             "text": "Outlast {1}{W} ({1}{W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "f1b82e29-f4b4-5df3-aee7-790b3d157456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c17e350-44f7-4413-ad24-7c5d6616effd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c17e350-44f7-4413-ad24-7c5d6616effd.jpg?1",
             "name": "Seeker of the Way",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, Seeker of the Way gains lifelink until end of turn.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "38e62d02-c08d-5a5e-8444-2557961711d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd17ef9-9f1b-4937-a60a-d7175f04eef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd17ef9-9f1b-4937-a60a-d7175f04eef2.jpg?1",
             "name": "Siegecraft",
             "text": "Enchant creature\nEnchanted creature gets +2/+4.",
             "colours": [
@@ -787,7 +787,7 @@
         },
         {
             "id": "0438b370-c689-5534-9968-fca3c760aa30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1405bb2e-2204-43ab-82a3-5d0c8537325a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1405bb2e-2204-43ab-82a3-5d0c8537325a.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "fcb9bedb-5317-5a95-880d-88b1a73cdeb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5c9628-1801-43d9-8bb4-4cca168510b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5c9628-1801-43d9-8bb4-4cca168510b2.jpg?1",
             "name": "Suspension Field",
             "text": "When Suspension Field enters the battlefield, you may exile target creature with toughness 3 or greater until Suspension Field leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "42066ed7-12c8-50b7-98c6-d8a1bfa27bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc783f49-f58a-4783-87b4-4dbc7e896f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc783f49-f58a-4783-87b4-4dbc7e896f2e.jpg?1",
             "name": "Take Up Arms",
             "text": "Put three 1/1 white Warrior creature tokens onto the battlefield.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "1f90370b-66f2-526c-8b47-bb2a19f6ce0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb3c08e-b591-421a-898a-533021cbabd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb3c08e-b591-421a-898a-533021cbabd2.jpg?1",
             "name": "Timely Hordemate",
             "text": "Raid \u2014 When Timely Hordemate enters the battlefield, if you attacked with a creature this turn, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "b0bc7985-4f23-5b8b-9bda-738994b208db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229919ef-e39f-4bdc-bcc5-46224a3eb7b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229919ef-e39f-4bdc-bcc5-46224a3eb7b4.jpg?1",
             "name": "Venerable Lammasu",
             "text": "Flying",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "c6f4c9f2-4693-5610-be11-b61a7dbfb312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652109b9-d607-42b6-945d-0c0dd5bba89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652109b9-d607-42b6-945d-0c0dd5bba89c.jpg?1",
             "name": "War Behemoth",
             "text": "Morph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "e4ba6ef9-7d05-5598-8a49-a75b8e4dd0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8684039-e4d9-4e48-9a41-7ccf4a795507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8684039-e4d9-4e48-9a41-7ccf4a795507.jpg?1",
             "name": "Watcher of the Roost",
             "text": "Flying\nMorph\u2014\nReveal a white card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Watcher of the Roost is turned face up, you gain 2 life.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "4a7a9d0c-b5a5-5dac-b653-b1d7e4a03207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f0f6a2-b392-45e6-97c4-4f00016144d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f0f6a2-b392-45e6-97c4-4f00016144d3.jpg?1",
             "name": "Wingmate Roc",
             "text": "Flying\nRaid \u2014 When Wingmate Roc enters the battlefield, if you attacked with a creature this turn, put a 3/4 white Bird creature token with flying onto the battlefield.\nWhenever Wingmate Roc attacks, you gain 1 life for each attacking creature.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "2b914584-70b8-5b16-82a3-06d9ad1c8f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b588355-c349-458d-aeb7-0e2780caa3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b588355-c349-458d-aeb7-0e2780caa3f9.jpg?1",
             "name": "Blinding Spray",
             "text": "Creatures your opponents control get -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "c95e0357-f3fa-52f8-9a3d-b3b27149a976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f540dcb-8d0b-4d33-8c0d-893fa5db54eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f540dcb-8d0b-4d33-8c0d-893fa5db54eb.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "e502db19-a246-5e79-ab37-640acc996e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8fffd3-81ad-47e3-a27b-d8059f2b506f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8fffd3-81ad-47e3-a27b-d8059f2b506f.jpg?1",
             "name": "Clever Impersonator",
             "text": "You may have Clever Impersonator enter the battlefield as a copy of any nonland permanent on the battlefield.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "9db0fc97-db9b-5ce8-8725-40de514e9745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf53a79-7573-43c2-bd3a-93abea58ba80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf53a79-7573-43c2-bd3a-93abea58ba80.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "9544ddce-b079-522d-8282-541baee0ca0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18c2d8-995c-4736-bdef-464abcd1d31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18c2d8-995c-4736-bdef-464abcd1d31a.jpg?1",
             "name": "Dig Through Time",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nLook at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "939b6ffe-85f5-5cb8-ae23-c93587d478ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180425c9-1898-48d4-9932-ddfb1a28e6b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180425c9-1898-48d4-9932-ddfb1a28e6b0.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "d80095ab-f5c1-5556-b865-e1ed13ac35da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff29b2c-2156-45fd-a2dd-655b8d208197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff29b2c-2156-45fd-a2dd-655b8d208197.jpg?1",
             "name": "Dragon's Eye Savants",
             "text": "Morph\u2014\nReveal a blue card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Dragon's Eye Savants is turned face up, look at target opponent's hand.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "810d8b57-81d6-5270-bee7-6cee7a06d553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e07226-f180-4972-b7f8-90c743d45fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e07226-f180-4972-b7f8-90c743d45fb8.jpg?1",
             "name": "Embodiment of Spring",
             "text": "{1}{G}, {T}, Sacrifice Embodiment of Spring: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "56965aa8-caf8-57a8-a4c7-f4423daa7ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda70b3e-4b70-404e-a579-41dd126be084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda70b3e-4b70-404e-a579-41dd126be084.jpg?1",
             "name": "Force Away",
             "text": "Return target creature to its owner's hand.\nFerocious \u2014 If you control a creature with power 4 or greater, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "0957f09e-86fd-5dbd-ba60-20915c704421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8821c7b9-702b-416f-b006-941ad57f9e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8821c7b9-702b-416f-b006-941ad57f9e11.jpg?1",
             "name": "Glacial Stalker",
             "text": "Morph {4}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1385,7 +1385,7 @@
         },
         {
             "id": "164f13ab-4fd7-55af-91bd-34a6eb153904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b098f029-6b5d-49e4-9a81-f497ebbdb5ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b098f029-6b5d-49e4-9a81-f497ebbdb5ce.jpg?1",
             "name": "Icy Blast",
             "text": "Tap X target creatures.\nFerocious \u2014 If you control a creature with power 4 or greater, those creatures don't untap during their controllers' next untap steps.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "daa2d15e-d56e-5450-926c-553c3e19fe7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff9907c-4090-4dcc-aaf5-bc2a8dacce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff9907c-4090-4dcc-aaf5-bc2a8dacce8b.jpg?1",
             "name": "Jeskai Elder",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jeskai Elder deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "c41480f6-a666-50c4-a897-b4bd44837c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66356e38-38e1-4b09-80c2-be26007ff99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66356e38-38e1-4b09-80c2-be26007ff99c.jpg?1",
             "name": "Jeskai Windscout",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "d519d779-eae0-5e00-a55b-2a7b6851f247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e15117f-f05e-4c5d-9ef5-98f21f4d7529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e15117f-f05e-4c5d-9ef5-98f21f4d7529.jpg?1",
             "name": "Kheru Spellsnatcher",
             "text": "Morph {4}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Kheru Spellsnatcher is turned face up, counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may cast that card without paying its mana cost for as long as it remains exiled.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "5c24ba9e-0178-5ecd-947b-16d50e5e5248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8003a31f-7662-4e9e-8165-1ceea04fdf20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8003a31f-7662-4e9e-8165-1ceea04fdf20.jpg?1",
             "name": "Mistfire Weaver",
             "text": "Flying\nMorph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Mistfire Weaver is turned face up, target creature you control gains hexproof until end of turn.",
             "colours": [
@@ -1557,7 +1557,7 @@
         },
         {
             "id": "9db7837b-8c85-5b83-8c92-50fd2ad6644f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53c0e50-4b0b-43d8-80c0-2c216722c87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53c0e50-4b0b-43d8-80c0-2c216722c87a.jpg?1",
             "name": "Monastery Flock",
             "text": "Defender, flying\nMorph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "394de2e1-fe82-57ef-860d-83eea6cacd97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5de843-e05d-43b5-a5d0-a737484fbd71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5de843-e05d-43b5-a5d0-a737484fbd71.jpg?1",
             "name": "Mystic of the Hidden Way",
             "text": "Mystic of the Hidden Way can't be blocked.\nMorph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "05f453ea-19e7-5ca7-8cd3-04da14190ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbee4d2f-6b41-4717-a1c6-831034452bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbee4d2f-6b41-4717-a1c6-831034452bec.jpg?1",
             "name": "Pearl Lake Ancient",
             "text": "Flash\nPearl Lake Ancient can't be countered.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nReturn three lands you control to their owner's hand: Return Pearl Lake Ancient to its owner's hand.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "836d8b9d-53b6-59af-906c-4cf3f88f3eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc7c9d5-904e-4ab6-9773-5c4f1c6d34c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc7c9d5-904e-4ab6-9773-5c4f1c6d34c4.jpg?1",
             "name": "Quiet Contemplation",
             "text": "Whenever you cast a noncreature spell, you may pay {1}. If you do, tap target creature an opponent controls and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "ade59e7d-abe1-5b68-b469-7eb080b3ba38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c210b102-8a94-4b5e-858a-777fa8ad18b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c210b102-8a94-4b5e-858a-777fa8ad18b9.jpg?1",
             "name": "Riverwheel Aerialists",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "36d9a760-2dd1-53a7-8798-84214a25a017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8110eb0a-63dc-43df-b55a-9241f45b1cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8110eb0a-63dc-43df-b55a-9241f45b1cc6.jpg?1",
             "name": "Scaldkin",
             "text": "Flying\n{2}{R}, Sacrifice Scaldkin: Scaldkin deals 2 damage to target creature or player.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "46397bb9-edbf-5ee9-8d61-4a81f3ed9116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e370939-831b-4c42-8291-8ffb0b6c1af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e370939-831b-4c42-8291-8ffb0b6c1af7.jpg?1",
             "name": "Scion of Glaciers",
             "text": "{U}: Scion of Glaciers gets +1/-1 until end of turn.",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "618d3fcf-e257-5326-8ea0-1540ab5fb36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad122d-a872-449f-9a7c-0f054b711d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad122d-a872-449f-9a7c-0f054b711d11.jpg?1",
             "name": "Set Adrift",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nPut target nonland permanent on top of its owner's library.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "ae6f842b-feab-5564-9b6a-07bfd71c3562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670f24e1-dec9-42e6-b762-c447366ed16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670f24e1-dec9-42e6-b762-c447366ed16c.jpg?1",
             "name": "Singing Bell Strike",
             "text": "Enchant creature\nWhen Singing Bell Strike enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"{6}: Untap this creature.\"",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "c7142e4e-7699-5f3b-b11b-677c6a546112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8626c4-306f-4e9d-8840-2bb73fe87e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8626c4-306f-4e9d-8840-2bb73fe87e87.jpg?1",
             "name": "Stubborn Denial",
             "text": "Counter target noncreature spell unless its controller pays {1}.\nFerocious \u2014 If you control a creature with power 4 or greater, counter that spell instead.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "a97153ce-63eb-5a79-9813-389cabe77913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f4b533-7113-4b36-9c7a-e4cf798c88a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f4b533-7113-4b36-9c7a-e4cf798c88a9.jpg?1",
             "name": "Taigam's Scheming",
             "text": "Look at the top five cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "75836a21-9c64-563e-9e24-e8cb3aa60e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249b453c-0d5b-4af9-aaec-ebd2f19c5d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249b453c-0d5b-4af9-aaec-ebd2f19c5d23.jpg?1",
             "name": "Thousand Winds",
             "text": "Flying\nMorph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Thousand Winds is turned face up, return all other tapped creatures to their owners' hands.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "61fda89e-aaa0-5dbe-ba17-714876581301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a59d4b1-6cf4-44ec-8a96-1bb7094fea21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a59d4b1-6cf4-44ec-8a96-1bb7094fea21.jpg?1",
             "name": "Treasure Cruise",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "df4fd2b8-676c-54d9-97a2-bce3a72938ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd58503-d269-4756-a71c-a6a2bfb1658d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd58503-d269-4756-a71c-a6a2bfb1658d.jpg?1",
             "name": "Waterwhirl",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "9d175471-3de8-59e5-95de-72bf8237488d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a1f9c1-25a3-465f-b3d8-98f0867c9bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a1f9c1-25a3-465f-b3d8-98f0867c9bb6.jpg?1",
             "name": "Weave Fate",
             "text": "Draw two cards.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "bbc16600-0878-5bd5-9667-84c4e4b5f25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71a86e0-d15a-4fba-94f6-bfbaade8d837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71a86e0-d15a-4fba-94f6-bfbaade8d837.jpg?1",
             "name": "Wetland Sambar",
             "text": "",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "e4d030e8-02fb-5a04-9cd4-4e6a37329542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c9bd9c-900a-48a1-9cfe-2f8d031af6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c9bd9c-900a-48a1-9cfe-2f8d031af6b8.jpg?1",
             "name": "Whirlwind Adept",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2125,7 +2125,7 @@
         },
         {
             "id": "b072e17d-1490-5012-ab41-696edfe1abfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939b5d-e24f-4e4b-b4c5-8bdb232d8926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939b5d-e24f-4e4b-b4c5-8bdb232d8926.jpg?1",
             "name": "Bellowing Saddlebrute",
             "text": "Raid \u2014 When Bellowing Saddlebrute enters the battlefield, you lose 4 life unless you attacked with a creature this turn.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "0a499de7-798f-5cc5-bb42-434e0ec6f340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42f5aa9-2a47-47c3-ab87-dc25735b0e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42f5aa9-2a47-47c3-ab87-dc25735b0e54.jpg?1",
             "name": "Bitter Revelation",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.",
             "colours": [
@@ -2192,7 +2192,7 @@
         },
         {
             "id": "8112b0cf-129b-55a5-b363-721b7b546e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bc9bb0-5ec1-400f-89e7-b450980a3391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bc9bb0-5ec1-400f-89e7-b450980a3391.jpg?1",
             "name": "Bloodsoaked Champion",
             "text": "Bloodsoaked Champion can't block.\nRaid \u2014 {1}{B}: Return Bloodsoaked Champion from your graveyard to the battlefield. Activate this ability only if you attacked with a creature this turn.",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "cd62e815-dad4-548f-9427-99a50dd9b39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff25a19a-8f98-47ef-847c-ba526c82b290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff25a19a-8f98-47ef-847c-ba526c82b290.jpg?1",
             "name": "Dead Drop",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget player sacrifices two creatures.",
             "colours": [
@@ -2259,7 +2259,7 @@
         },
         {
             "id": "426d02df-8015-5e71-b263-349007089762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b2b263-34db-4961-bf41-1eaaba3701da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b2b263-34db-4961-bf41-1eaaba3701da.jpg?1",
             "name": "Debilitating Injury",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "7a90835a-b9ab-5fb1-bc81-1016b5e614e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64216ce3-945e-42d8-9127-cf11c687da67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64216ce3-945e-42d8-9127-cf11c687da67.jpg?1",
             "name": "Despise",
             "text": "Target opponent reveals his or her hand. You choose a creature or planeswalker card from it. That player discards that card.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "8255a511-c747-5359-986f-8a38967e817d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd496-632d-4d6d-a529-f35cf3222de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd496-632d-4d6d-a529-f35cf3222de7.jpg?1",
             "name": "Disowned Ancestor",
             "text": "Outlast {1}{B} ({1}{B}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "0e21cda2-d4a3-50c3-b4c1-e4e893dc3396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f83b3a-ce34-4179-8745-059181dd79b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f83b3a-ce34-4179-8745-059181dd79b8.jpg?1",
             "name": "Dutiful Return",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "2d633e3a-7718-5002-ba9e-7ad687ed7419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b1ac7-dd7b-46a1-a74e-aa0563bab3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94b1ac7-dd7b-46a1-a74e-aa0563bab3cd.jpg?1",
             "name": "Empty the Pits",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nPut X 2/2 black Zombie creature tokens onto the battlefield tapped.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "438539a6-87d5-5167-897e-48c9ffa30556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1fe2bf-1640-4781-87b4-09a1f7d35831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1fe2bf-1640-4781-87b4-09a1f7d35831.jpg?1",
             "name": "Grim Haruspex",
             "text": "Morph {B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever another nontoken creature you control dies, draw a card.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "123ef5b4-c5df-57b6-bc7a-e2302e8ca49f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7492918-b3c6-468f-9484-d73f0a27b37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7492918-b3c6-468f-9484-d73f0a27b37b.jpg?1",
             "name": "Gurmag Swiftwing",
             "text": "Flying, first strike, haste",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "f16e8452-b761-5917-a1cd-955e399ca200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf15cd4-13be-48e7-b3f5-a5106eb02c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf15cd4-13be-48e7-b3f5-a5106eb02c45.jpg?1",
             "name": "Kheru Bloodsucker",
             "text": "Whenever a creature you control with toughness 4 or greater dies, each opponent loses 2 life and you gain 2 life.\n{2}{B}, Sacrifice another creature: Put a +1/+1 counter on Kheru Bloodsucker.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "67838960-9277-5cd6-8a87-00b9f0831038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b10468-18b8-4321-a791-0cbd18ea9c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b10468-18b8-4321-a791-0cbd18ea9c4d.jpg?1",
             "name": "Kheru Dreadmaw",
             "text": "Defender\n{1}{G}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "a7898d26-cecb-5f98-9bae-ef1e968eb918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f38391-ffb7-4420-9a38-f791627b12b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f38391-ffb7-4420-9a38-f791627b12b3.jpg?1",
             "name": "Krumar Bond-Kin",
             "text": "Morph {4}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "669c7bd3-7817-5efb-a1bb-aab786430887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3ca5e7-96f3-4326-9315-34bb396a054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3ca5e7-96f3-4326-9315-34bb396a054c.jpg?1",
             "name": "Mardu Skullhunter",
             "text": "Mardu Skullhunter enters the battlefield tapped.\nRaid \u2014 When Mardu Skullhunter enters the battlefield, if you attacked with a creature this turn, target opponent discards a card.",
             "colours": [
@@ -2633,7 +2633,7 @@
         },
         {
             "id": "863e4aa1-7f5b-5bf2-87b8-ac86360ca2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8589b2-9527-46ba-bf9e-0dec7d84d5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8589b2-9527-46ba-bf9e-0dec7d84d5d2.jpg?1",
             "name": "Mer-Ek Nightblade",
             "text": "Outlast {B} ({B}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has deathtouch.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "fe05f26f-26be-56bb-ba41-8c1dc036d7ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b781cbcf-dbba-41c1-be02-2396b824a217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b781cbcf-dbba-41c1-be02-2396b824a217.jpg?1",
             "name": "Molting Snakeskin",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"{2}{B}: Regenerate this creature.\"",
             "colours": [
@@ -2702,7 +2702,7 @@
         },
         {
             "id": "cf935c91-b1d8-534b-a68b-cc025bb16875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dadff2-883f-4134-a881-be145cdcbd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dadff2-883f-4134-a881-be145cdcbd84.jpg?1",
             "name": "Murderous Cut",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDestroy target creature.",
             "colours": [
@@ -2734,7 +2734,7 @@
         },
         {
             "id": "cb1262a1-93f2-5e44-bf2b-0060edc0e413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093426d2-29e0-49e4-b02a-a70cce3b25d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093426d2-29e0-49e4-b02a-a70cce3b25d5.jpg?1",
             "name": "Necropolis Fiend",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying\n{X}, {T}, Exile X cards from your graveyard: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "9ab096bf-3531-599d-aa1a-6e2b75ac3ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3e423e-cb62-43e1-9d0c-e702f823c8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3e423e-cb62-43e1-9d0c-e702f823c8e1.jpg?1",
             "name": "Raiders' Spoils",
             "text": "Creatures you control get +1/+0.\nWhenever a Warrior you control deals combat damage to a player, you may pay 1 life. If you do, draw a card.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "f6e38d97-a63e-568a-92fb-589c4ca2d84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae62a43e-36ce-471e-93f1-21fe674858b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae62a43e-36ce-471e-93f1-21fe674858b5.jpg?1",
             "name": "Rakshasa's Secret",
             "text": "Target opponent discards two cards. Put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "e99347b2-054a-584f-a0d7-828e15865fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3ee29d-b374-471d-80c3-bcad7a4226e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3ee29d-b374-471d-80c3-bcad7a4226e6.jpg?1",
             "name": "Retribution of the Ancients",
             "text": "{B}, Remove X +1/+1 counters from among creatures you control: Target creature gets -X/-X until end of turn.",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "2ad79f27-3760-54d1-b88f-641f928e843f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005b9fec-66de-4079-88e0-c7de7e22d18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/005b9fec-66de-4079-88e0-c7de7e22d18e.jpg?1",
             "name": "Rite of the Serpent",
             "text": "Destroy target creature. If that creature had a +1/+1 counter on it, put a 1/1 green Snake creature token onto the battlefield.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "72c9300e-cf9d-5208-828d-315b0897c864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1564a20a-0e57-4ced-9eda-7acff74274e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1564a20a-0e57-4ced-9eda-7acff74274e7.jpg?1",
             "name": "Rotting Mastodon",
             "text": "",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "7307d81e-33a2-528f-915f-fad3a9189880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c67b11-a82e-4a25-88a4-5771ab5c4f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c67b11-a82e-4a25-88a4-5771ab5c4f00.jpg?1",
             "name": "Ruthless Ripper",
             "text": "Deathtouch\nMorph\u2014\nReveal a black card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Ruthless Ripper is turned face up, target player loses 2 life.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "004157f3-5c88-5c8c-a264-b297ed080622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459ca25c-775f-4110-8d70-59720692ab27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459ca25c-775f-4110-8d70-59720692ab27.jpg?1",
             "name": "Shambling Attendants",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "08e321c9-82b1-57eb-b207-ea85b683aa84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e02a99-da37-4cea-9182-39ccb1e35ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e02a99-da37-4cea-9182-39ccb1e35ee9.jpg?1",
             "name": "Sidisi's Pet",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nMorph {1}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "46d181f1-3596-5762-802c-4043e2d57987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8e423-f7e7-4ac3-acc2-2a3722e409e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb8e423-f7e7-4ac3-acc2-2a3722e409e7.jpg?1",
             "name": "Sultai Scavenger",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "7b481c7d-2ba5-54be-8165-a5559993377d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd36319-e05d-4a9e-a6d4-48fba9111648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd36319-e05d-4a9e-a6d4-48fba9111648.jpg?1",
             "name": "Swarm of Bloodflies",
             "text": "Flying\nSwarm of Bloodflies enters the battlefield with two +1/+1 counters on it.\nWhenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "77f738f3-62d1-578d-8e67-8cb6a56abe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c00-3f38-47dc-90bc-6464d346c098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b71c00-3f38-47dc-90bc-6464d346c098.jpg?1",
             "name": "Throttle",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "17247d46-698c-5bfc-8e29-9617686c78c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a232d196-490d-4712-b2a2-466751b28d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a232d196-490d-4712-b2a2-466751b28d11.jpg?1",
             "name": "Unyielding Krumar",
             "text": "{1}{W}: Unyielding Krumar gains first strike until end of turn.",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "94a859ae-a4f7-5dfe-9662-2e1afc07e589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20d6dfd-5f7b-4c71-89e6-8f996d85801d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20d6dfd-5f7b-4c71-89e6-8f996d85801d.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "5dba7143-a462-5211-b2f8-694e87b9210d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff9400d-4842-471f-bf7e-3b21df352e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff9400d-4842-471f-bf7e-3b21df352e0a.jpg?1",
             "name": "Ainok Tracker",
             "text": "First strike\nMorph {4}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "9da4572d-c440-5e52-80a1-aa0325bf9e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7c392-6782-40c8-bb24-6aad24f14660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7c392-6782-40c8-bb24-6aad24f14660.jpg?1",
             "name": "Arc Lightning",
             "text": "Arc Lightning deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -3271,7 +3271,7 @@
         },
         {
             "id": "e2ed71b1-572a-5e9d-a087-84506848064e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57534fb-2591-4003-aeec-6452faa4a759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57534fb-2591-4003-aeec-6452faa4a759.jpg?1",
             "name": "Arrow Storm",
             "text": "Arrow Storm deals 4 damage to target creature or player.\nRaid \u2014 If you attacked with a creature this turn, instead Arrow Storm deals 5 damage to that creature or player and the damage can't be prevented.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "309ed39c-7886-52bd-a537-dedf4f9f74a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a53752c-5689-4939-9a8b-bf59d88d7c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a53752c-5689-4939-9a8b-bf59d88d7c6b.jpg?1",
             "name": "Ashcloud Phoenix",
             "text": "Flying\nWhen Ashcloud Phoenix dies, return it to the battlefield face down.\nMorph {4}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Ashcloud Phoenix is turned face up, it deals 2 damage to each player.",
             "colours": [
@@ -3337,7 +3337,7 @@
         },
         {
             "id": "3a214a87-3e85-579e-bfb2-d6c434d5291d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb1a9f7-32ba-48fd-a7f7-788b0ec052c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb1a9f7-32ba-48fd-a7f7-788b0ec052c6.jpg?1",
             "name": "Barrage of Boulders",
             "text": "Barrage of Boulders deals 1 damage to each creature you don't control.\nFerocious \u2014 If you control a creature with power 4 or greater, creatures can't block this turn.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "45a8fce8-3dc2-5faa-965c-f4286fee4332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0742564e-f7a7-4107-b9ed-63703ca4702c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0742564e-f7a7-4107-b9ed-63703ca4702c.jpg?1",
             "name": "Bloodfire Expert",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "6c530f37-0983-51ed-a398-3ae9672d0eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4836fb70-a8f3-44ed-bae4-890ef7d07f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4836fb70-a8f3-44ed-bae4-890ef7d07f88.jpg?1",
             "name": "Bloodfire Mentor",
             "text": "{2}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "8edb7a3c-2471-5566-9386-530851d372cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba5e7bf-2ad8-4061-937a-ef1e9b63da3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba5e7bf-2ad8-4061-937a-ef1e9b63da3d.jpg?1",
             "name": "Bring Low",
             "text": "Bring Low deals 3 damage to target creature. If that creature has a +1/+1 counter on it, Bring Low deals 5 damage to it instead.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "2f21fd55-d43e-550e-adb2-44acd5287258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b24e40-c0f0-4472-973e-d3b0e88fc93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b24e40-c0f0-4472-973e-d3b0e88fc93e.jpg?1",
             "name": "Burn Away",
             "text": "Burn Away deals 6 damage to target creature. When that creature dies this turn, exile all cards from its controller's graveyard.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "719cc261-11f0-5f03-963e-37bafecff314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6c56d1-6eca-43be-9834-0478bea67b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6c56d1-6eca-43be-9834-0478bea67b48.jpg?1",
             "name": "Canyon Lurkers",
             "text": "Morph {3}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "93275283-9982-5a2c-bd33-e982766a4632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dde66b-b4a1-4a1e-8c9e-0bec4790b1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dde66b-b4a1-4a1e-8c9e-0bec4790b1e5.jpg?1",
             "name": "Crater's Claws",
             "text": "Crater's Claws deals X damage to target creature or player.\nFerocious \u2014 Crater's Claws deals X plus 2 damage to that creature or player instead if you control a creature with power 4 or greater.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "03186774-1137-5a8b-9451-8476de7644e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0269d5bd-d8aa-465b-bfe9-6703937f933c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0269d5bd-d8aa-465b-bfe9-6703937f933c.jpg?1",
             "name": "Dragon Grip",
             "text": "Ferocious \u2014 If you control a creature with power 4 or greater, you may cast Dragon Grip as though it had flash. (You may cast it any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+0 and has first strike.",
             "colours": [
@@ -3605,7 +3605,7 @@
         },
         {
             "id": "e6af7c1c-2c1c-5dda-b885-b0543db75c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646edf58-4bc5-4d87-af68-b8b006ccb806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646edf58-4bc5-4d87-af68-b8b006ccb806.jpg?1",
             "name": "Dragon-Style Twins",
             "text": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "7f29a7e7-8a95-59ea-acec-13193e6c559f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d80e96-3956-4408-84fb-5f94a364eb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d80e96-3956-4408-84fb-5f94a364eb41.jpg?1",
             "name": "Goblinslide",
             "text": "Whenever you cast a noncreature spell, you may pay {1}. If you do, put a 1/1 red Goblin creature token with haste onto the battlefield.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "d1ef0b7e-6c1a-5108-8b70-27412f487e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53926b92-adf0-4bb2-873f-103d9a1bdda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53926b92-adf0-4bb2-873f-103d9a1bdda8.jpg?1",
             "name": "Horde Ambusher",
             "text": "Whenever Horde Ambusher blocks, it deals 1 damage to you.\nMorph\u2014\nReveal a red card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Horde Ambusher is turned face up, target creature can't block this turn.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "ffeef7c1-8ef2-5322-bbe0-4817db9143ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c1bf52-2737-423a-b340-07448afcaea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c1bf52-2737-423a-b340-07448afcaea6.jpg?1",
             "name": "Hordeling Outburst",
             "text": "Put three 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "fa149d64-0700-525c-85a9-9c4d55567f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4baf3-f0dc-4b27-8323-a76764332590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db4baf3-f0dc-4b27-8323-a76764332590.jpg?1",
             "name": "Howl of the Horde",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nRaid \u2014 If you attacked with a creature this turn, when you cast your next instant or sorcery spell this turn, copy that spell an additional time. You may choose new targets for the copy.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "904455bd-cf23-555d-b15f-3c4b411362b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72777ccf-1cd8-45e8-8dfb-0a42550b5607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72777ccf-1cd8-45e8-8dfb-0a42550b5607.jpg?1",
             "name": "Jeering Instigator",
             "text": "Morph {2}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Jeering Instigator is turned face up, if it's your turn, gain control of another target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "838fc418-3e02-5bc1-82a3-48e54011780a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f786a1d-4703-4bac-abba-632506d2726c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f786a1d-4703-4bac-abba-632506d2726c.jpg?1",
             "name": "Leaping Master",
             "text": "{2}{W}: Leaping Master gains flying until end of turn.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "2986f351-15fc-5561-8e83-7b91548dcf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf7a797-f32a-4ed2-b835-a356120f5817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf7a797-f32a-4ed2-b835-a356120f5817.jpg?1",
             "name": "Mardu Blazebringer",
             "text": "When Mardu Blazebringer attacks or blocks, sacrifice it at end of combat.",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "dfb5aee3-76b4-5a5a-943b-6f136edd1403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17b6eee-da22-48aa-ba8a-cbd1a3389bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17b6eee-da22-48aa-ba8a-cbd1a3389bcb.jpg?1",
             "name": "Mardu Heart-Piercer",
             "text": "Raid \u2014 When Mardu Heart-Piercer enters the battlefield, if you attacked with a creature this turn, Mardu Heart-Piercer deals 2 damage to target creature or player.",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "eb0c06a5-5887-5b6c-855c-79fda9301419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381ae25-0d44-4d06-beae-48e4bbb4bb45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1381ae25-0d44-4d06-beae-48e4bbb4bb45.jpg?1",
             "name": "Mardu Warshrieker",
             "text": "Raid \u2014 When Mardu Warshrieker enters the battlefield, if you attacked with a creature this turn, add {R}{W}{B} to your mana pool.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "c2dfe6ed-8fcf-54f6-822c-c637f725a65a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81c6c8b-a9cf-4866-89ba-7f8ad077b836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81c6c8b-a9cf-4866-89ba-7f8ad077b836.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "1eb3ada8-f422-5524-bf92-8463cddd8051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58064fd-4d8b-4f54-812f-0bb1d7e2ddc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58064fd-4d8b-4f54-812f-0bb1d7e2ddc2.jpg?1",
             "name": "Sarkhan, the Dragonspeaker",
             "text": "+1: Until end of turn, Sarkhan, the Dragonspeaker becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste. (He doesn't lose loyalty while he's not a planeswalker.)\n\u22123: Sarkhan, the Dragonspeaker deals 4 damage to target creature.\n\u22126: You get an emblem with \"At the beginning of your draw step, draw two additional cards\" and \"At the beginning of your end step, discard your hand.\"",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "0e17b309-4d64-5f56-9de4-d28326a6b032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4ecaa0-a85f-4771-a829-1ab440b29165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4ecaa0-a85f-4771-a829-1ab440b29165.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "b16d21b2-a033-5eec-9e7f-bfb11703a7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f998fb-4518-4a0c-8b1e-55393b6ff9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f998fb-4518-4a0c-8b1e-55393b6ff9c4.jpg?1",
             "name": "Summit Prowler",
             "text": "",
             "colours": [
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "9de10a1a-00b6-5f9c-b5c8-13c844a09e16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc3120c-7e04-4c4a-af16-da264593a1d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc3120c-7e04-4c4a-af16-da264593a1d1.jpg?1",
             "name": "Swift Kick",
             "text": "Target creature you control gets +1/+0 until end of turn. It fights target creature you don't control.",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "faa1832a-f2d0-5fe4-98a9-06c082f40a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25af9ac1-a03b-4be7-b726-fb66427b1caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25af9ac1-a03b-4be7-b726-fb66427b1caa.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "9d2dae80-0601-55c3-adfa-8a8645db319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6deef5-876f-4c81-8af5-6e91e0c4656a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6deef5-876f-4c81-8af5-6e91e0c4656a.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "b9790ed3-7c2e-5b0c-a363-5ca88aaed8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8543adbd-0dd1-47d3-ac41-2ec72d6a5d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8543adbd-0dd1-47d3-ac41-2ec72d6a5d35.jpg?1",
             "name": "Valley Dasher",
             "text": "Haste\nValley Dasher attacks each turn if able.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "c511fa2c-5bfc-5516-af13-672215b763ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d1714b-ff65-4c5c-ad21-b469f2c72286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8d1714b-ff65-4c5c-ad21-b469f2c72286.jpg?1",
             "name": "War-Name Aspirant",
             "text": "Raid \u2014 War-Name Aspirant enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.\nWar-Name Aspirant can't be blocked by creatures with power 1 or less.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "0bd12511-6170-5fc0-9dc2-83f0b7baf31f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bbf983-df71-4403-86f3-2e86aa8765b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bbf983-df71-4403-86f3-2e86aa8765b8.jpg?1",
             "name": "Alpine Grizzly",
             "text": "",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "47f48b76-e451-524a-bc3d-82f7f05579c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ac0667-8ecc-4034-89bb-dce0af531014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ac0667-8ecc-4034-89bb-dce0af531014.jpg?1",
             "name": "Archers' Parapet",
             "text": "Defender\n{1}{B}, {T}: Each opponent loses 1 life.",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "87c115d2-a3f7-5e35-9509-a69e84cae0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803a6ac7-9327-4c2f-b023-93f5f65f83b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803a6ac7-9327-4c2f-b023-93f5f65f83b8.jpg?1",
             "name": "Awaken the Bear",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "195dfacd-7c27-5ec5-acf0-d29418bf8a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17b65e-56c3-4e12-a774-780514dfd8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e17b65e-56c3-4e12-a774-780514dfd8ba.jpg?1",
             "name": "Become Immense",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget creature gets +6/+6 until end of turn.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "bb06fc41-4ffc-5277-90e3-64dfd202197a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aadb382-f912-4ccb-98bc-1abdef733126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aadb382-f912-4ccb-98bc-1abdef733126.jpg?1",
             "name": "Dragonscale Boon",
             "text": "Put two +1/+1 counters on target creature and untap it.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "067aac58-286e-5e72-a99d-91499bf53d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f7c53d-0b53-400f-aa67-967547f3e394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f7c53d-0b53-400f-aa67-967547f3e394.jpg?1",
             "name": "Feed the Clan",
             "text": "You gain 5 life.\nFerocious \u2014 You gain 10 life instead if you control a creature with power 4 or greater.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "6aeb4c60-b77e-5054-bd4c-45212f128091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdf1db-bfaf-4160-8003-1fa2e56b00dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdf1db-bfaf-4160-8003-1fa2e56b00dc.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be placed on a creature you control, that many plus one +1/+1 counters are placed on it instead.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "3cfe2e23-dbaf-5520-8172-38ac5ed1af3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0995e041-fe90-4459-8c70-fd9851ecf830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0995e041-fe90-4459-8c70-fd9851ecf830.jpg?1",
             "name": "Heir of the Wilds",
             "text": "Deathtouch\nFerocious \u2014 Whenever Heir of the Wilds attacks, if you control a creature with power 4 or greater, Heir of the Wilds gets +1/+1 until end of turn.",
             "colours": [
@@ -4516,7 +4516,7 @@
         },
         {
             "id": "3d0804e7-ca3e-5010-9d1c-edf5c2595625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb10a9-486a-4b9a-b3f5-c17f661af2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbb10a9-486a-4b9a-b3f5-c17f661af2b2.jpg?1",
             "name": "Highland Game",
             "text": "When Highland Game dies, you gain 2 life.",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "69f40292-e955-5a4f-9687-621000767a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7e651f-4187-44c5-99bf-34042d6dd9a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7e651f-4187-44c5-99bf-34042d6dd9a2.jpg?1",
             "name": "Hooded Hydra",
             "text": "Hooded Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Hooded Hydra dies, put a 1/1 green Snake creature token onto the battlefield for each +1/+1 counter on it.\nMorph {3}{G}{G}\nAs Hooded Hydra is turned face up, put five +1/+1 counters on it.",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "163a4224-b8f3-5e88-8c6f-6506c228879d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090d678c-f0e4-4757-8900-93dfe67aefe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090d678c-f0e4-4757-8900-93dfe67aefe9.jpg?1",
             "name": "Hooting Mandrills",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTrample",
             "colours": [
@@ -4619,7 +4619,7 @@
         },
         {
             "id": "e233ab6e-b5a9-5a96-ba7a-001c6e9ae39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7d833-f71b-4ec4-aad1-07b7583bad64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7d833-f71b-4ec4-aad1-07b7583bad64.jpg?1",
             "name": "Incremental Growth",
             "text": "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
             "colours": [
@@ -4651,7 +4651,7 @@
         },
         {
             "id": "6dbb9aab-c2d9-59dd-8ea3-d954c6a29acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddafbc-590b-4610-894a-b91335a60528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddafbc-590b-4610-894a-b91335a60528.jpg?1",
             "name": "Kin-Tree Warden",
             "text": "{2}: Regenerate Kin-Tree Warden.\nMorph {G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4686,7 +4686,7 @@
         },
         {
             "id": "46fc8fab-0155-5b26-aed3-cb7dfcd5ba36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9edd62-dc18-4887-a020-4464e31b79c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9edd62-dc18-4887-a020-4464e31b79c2.jpg?1",
             "name": "Longshot Squad",
             "text": "Outlast {1}{G} ({1}{G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has reach. (A creature with reach can block creatures with flying.)",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "90a1d9f3-479d-5eac-b339-7232aedd0652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a945b43d-39bc-4ce4-be03-0109e1a681b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a945b43d-39bc-4ce4-be03-0109e1a681b1.jpg?1",
             "name": "Meandering Towershell",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Meandering Towershell attacks, exile it. Return it to the battlefield under your control tapped and attacking at the beginning of the declare attackers step on your next turn.",
             "colours": [
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "20d2b003-6c96-535c-9199-279fde626b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b129b44e-a1ce-41f2-a0cf-b6c879c7cbbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b129b44e-a1ce-41f2-a0cf-b6c879c7cbbd.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "7293bbd2-1aa0-5d40-9bd5-cc4415d7607b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a49d9c-8fe7-494b-9a26-cf4bde71e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a49d9c-8fe7-494b-9a26-cf4bde71e420.jpg?1",
             "name": "Pine Walker",
             "text": "Morph {4}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhenever Pine Walker or another creature you control is turned face up, untap that creature.",
             "colours": [
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "7f45dd41-6a5b-5d40-b2e8-1fad3726fd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb6c2e0-eeaa-4d60-aab7-2b8c739a9278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb6c2e0-eeaa-4d60-aab7-2b8c739a9278.jpg?1",
             "name": "Rattleclaw Mystic",
             "text": "{T}: Add {G}, {U}, or {R} to your mana pool.\nMorph {2} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Rattleclaw Mystic is turned face up, add {G}{U}{R} to your mana pool.",
             "colours": [
@@ -4858,7 +4858,7 @@
         },
         {
             "id": "feeb98b4-633b-5490-996a-84469333ab85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83456f8f-8a1a-403c-816b-25e454ba1edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83456f8f-8a1a-403c-816b-25e454ba1edf.jpg?1",
             "name": "Roar of Challenge",
             "text": "All creatures able to block target creature this turn do so.\nFerocious \u2014 That creature gains indestructible until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "b044519a-9cc9-5fcd-9fdd-c34ea72366d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a26baca-467e-4d94-873e-f266bebd5fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a26baca-467e-4d94-873e-f266bebd5fd8.jpg?1",
             "name": "Sagu Archer",
             "text": "Reach (This creature can block creatures with flying.)\nMorph {4}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "50fe4e88-abab-5a44-afe5-ef1a6e6c4927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6b50dc-244a-4df5-a9a9-5a2b8f30d40c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6b50dc-244a-4df5-a9a9-5a2b8f30d40c.jpg?1",
             "name": "Savage Punch",
             "text": "Target creature you control fights target creature you don't control.\nFerocious \u2014 The creature you control gets +2/+2 until end of turn before it fights if you control a creature with power 4 or greater.",
             "colours": [
@@ -4957,7 +4957,7 @@
         },
         {
             "id": "90971b83-48fd-5b7b-8fec-a9cb391c356e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb15c6c7-8fe6-496c-9977-3e7942b920c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb15c6c7-8fe6-496c-9977-3e7942b920c4.jpg?1",
             "name": "Scout the Borders",
             "text": "Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "75fe9de3-71f2-5ad2-90bd-cdef0e1a2347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689a7f1-9713-412e-a030-9cba463c170e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689a7f1-9713-412e-a030-9cba463c170e.jpg?1",
             "name": "See the Unwritten",
             "text": "Reveal the top eight cards of your library. You may put a creature card from among them onto the battlefield. Put the rest into your graveyard.\nFerocious \u2014 If you control a creature with power 4 or greater, you may put two creature cards onto the battlefield instead of one.",
             "colours": [
@@ -5021,7 +5021,7 @@
         },
         {
             "id": "4542aa9f-2f2c-5c3b-803f-f1b80ee5f938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5269292-11be-4647-9074-7ce8115bf36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5269292-11be-4647-9074-7ce8115bf36f.jpg?1",
             "name": "Seek the Horizon",
             "text": "Search your library for up to three basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -5053,7 +5053,7 @@
         },
         {
             "id": "f811931c-810f-58cd-86e4-50be261ec920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1916a2d9-4747-4118-b1b2-7a5ce492e3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1916a2d9-4747-4118-b1b2-7a5ce492e3fc.jpg?1",
             "name": "Smoke Teller",
             "text": "{1}{U}: Look at target face-down creature.",
             "colours": [
@@ -5089,7 +5089,7 @@
         },
         {
             "id": "18d9f0ca-add0-580e-bcf8-3ad995978533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3b2ef3-551d-4782-8dce-a923c0e2965e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3b2ef3-551d-4782-8dce-a923c0e2965e.jpg?1",
             "name": "Sultai Flayer",
             "text": "Whenever a creature you control with toughness 4 or greater dies, you gain 4 life.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "2a448bb0-e87f-5978-a6bc-4dd4bead18fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77258fc-8683-4656-84a3-4df4ea2a8435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77258fc-8683-4656-84a3-4df4ea2a8435.jpg?1",
             "name": "Temur Charger",
             "text": "Morph\u2014\nReveal a green card in your hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Temur Charger is turned face up, target creature gains trample until end of turn.",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "1f26c293-6045-54c3-aa23-d250ad3cbfde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6149685f-cb05-4c1f-95a4-3810505d1a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6149685f-cb05-4c1f-95a4-3810505d1a95.jpg?1",
             "name": "Trail of Mystery",
             "text": "Whenever a face-down creature enters the battlefield under your control, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nWhenever a permanent you control is turned face up, if it's a creature, it gets +2/+2 until end of turn.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "ed9bc771-3f64-5cf5-baee-a50927400d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d511407-0c1e-4342-a578-ca557c6886fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d511407-0c1e-4342-a578-ca557c6886fd.jpg?1",
             "name": "Tusked Colossodon",
             "text": "",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "04beb49a-2af1-5107-ae08-d4ad1172114f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b341cc65-d316-41bb-95b8-294afa019a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b341cc65-d316-41bb-95b8-294afa019a71.jpg?1",
             "name": "Tuskguard Captain",
             "text": "Outlast {G} ({G}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "ba313f3c-4230-5b9d-a267-a06eaa6ad9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154dc31c-ac9d-4b78-b92b-e7bacc532915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154dc31c-ac9d-4b78-b92b-e7bacc532915.jpg?1",
             "name": "Windstorm",
             "text": "Windstorm deals X damage to each creature with flying.",
             "colours": [
@@ -5291,7 +5291,7 @@
         },
         {
             "id": "58ad74dd-6e19-5f96-9694-f2cee61a442e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890c55a-8746-4233-b75a-19cc760c1e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890c55a-8746-4233-b75a-19cc760c1e8e.jpg?1",
             "name": "Woolly Loxodon",
             "text": "Morph {5}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "8e8670b3-323a-563b-b83c-2ada06e4023f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df9759e-1072-4a6a-be57-f73b15bf3847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df9759e-1072-4a6a-be57-f73b15bf3847.jpg?1",
             "name": "Abomination of Gudul",
             "text": "Flying\nWhenever Abomination of Gudul deals combat damage to a player, you may draw a card. If you do, discard a card.\nMorph {2}{B}{G}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5364,7 +5364,7 @@
         },
         {
             "id": "f2572440-4d6c-53ac-9729-1a13e54b5034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af53a53-d30a-4289-a043-953cd81ee241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af53a53-d30a-4289-a043-953cd81ee241.jpg?1",
             "name": "Abzan Ascendancy",
             "text": "When Abzan Ascendancy enters the battlefield, put a +1/+1 counter on each creature you control.\nWhenever a nontoken creature you control dies, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "c7722ac3-3e52-5854-a9cb-abaaf28737e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b7598-35b0-4bb5-8347-8c868500f846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b7598-35b0-4bb5-8347-8c868500f846.jpg?1",
             "name": "Abzan Charm",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power 3 or greater.\n\u2022 You draw two cards and you lose 2 life.\n\u2022 Distribute two +1/+1 counters among one or two target creatures.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "49b03c62-9c50-525f-aa26-63e666065b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7f7158-4a31-4a1c-bf3b-574c0b09276a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7f7158-4a31-4a1c-bf3b-574c0b09276a.jpg?1",
             "name": "Abzan Guide",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nMorph {2}{W}{B}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "4e2a75aa-1a3a-51c0-9f44-d393baf50d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b432a7-53da-4480-b571-e6feb1364a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b432a7-53da-4480-b571-e6feb1364a3a.jpg?1",
             "name": "Anafenza, the Foremost",
             "text": "Whenever Anafenza, the Foremost attacks, put a +1/+1 counter on another target tapped creature you control.\nIf a creature card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -5516,7 +5516,7 @@
         },
         {
             "id": "f9202e4e-465e-51b0-a0c0-92631f65294d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5bb5d2-181a-44ea-9b56-87f8d96bf634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5bb5d2-181a-44ea-9b56-87f8d96bf634.jpg?1",
             "name": "Ankle Shanker",
             "text": "Haste\nWhenever Ankle Shanker attacks, creatures you control gain first strike and deathtouch until end of turn.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "d16c4f56-d1b1-58f0-8f08-77bf51f5921e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c69876-809d-4af3-9fd6-3bac41541dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c69876-809d-4af3-9fd6-3bac41541dad.jpg?1",
             "name": "Armament Corps",
             "text": "When Armament Corps enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "a075afeb-1f0f-55f5-bd8b-5bc1f096a709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e3f12-53d5-45f4-8ccc-6c00f8a9c6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e3f12-53d5-45f4-8ccc-6c00f8a9c6fe.jpg?1",
             "name": "Avalanche Tusker",
             "text": "Whenever Avalanche Tusker attacks, target creature defending player controls blocks it this combat if able.",
             "colours": [
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "157b7cc9-d634-5a18-b749-5c0815355815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6912c5b-6aff-4506-96ca-acb5ce660322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6912c5b-6aff-4506-96ca-acb5ce660322.jpg?1",
             "name": "Bear's Companion",
             "text": "When Bear's Companion enters the battlefield, put a 4/4 green Bear creature token onto the battlefield.",
             "colours": [
@@ -5672,7 +5672,7 @@
         },
         {
             "id": "733231e4-96f4-5fe3-badc-19c8190423ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c76027b-9c8d-4181-9311-270fed0212e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c76027b-9c8d-4181-9311-270fed0212e3.jpg?1",
             "name": "Butcher of the Horde",
             "text": "Flying\nSacrifice another creature: Butcher of the Horde gains your choice of vigilance, lifelink, or haste until end of turn.",
             "colours": [
@@ -5710,7 +5710,7 @@
         },
         {
             "id": "5d88416e-4f22-53cc-9c10-2d3659aa6999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28822a9a-97fa-4784-ad97-072fcfc7b9ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28822a9a-97fa-4784-ad97-072fcfc7b9ed.jpg?1",
             "name": "Chief of the Edge",
             "text": "Other Warrior creatures you control get +1/+0.",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "f94b22e7-f5c5-57a8-9f2b-073a81622884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a227b8cc-cbe5-4955-ad1b-a354704a82e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a227b8cc-cbe5-4955-ad1b-a354704a82e8.jpg?1",
             "name": "Chief of the Scale",
             "text": "Other Warrior creatures you control get +0/+1.",
             "colours": [
@@ -5784,7 +5784,7 @@
         },
         {
             "id": "20011f49-5e60-54ed-ae75-9a46bf3182c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c7d53-2599-42a9-ae96-a2699c5164cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c7d53-2599-42a9-ae96-a2699c5164cb.jpg?1",
             "name": "Crackling Doom",
             "text": "Crackling Doom deals 2 damage to each opponent. Each opponent sacrifices a creature with the greatest power among creatures he or she controls.",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "734cfa5f-a4dc-5f80-b9a4-e917abbbac10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92096311-a3fa-41fc-b7a9-71ac2310f7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92096311-a3fa-41fc-b7a9-71ac2310f7fe.jpg?1",
             "name": "Death Frenzy",
             "text": "All creatures get -2/-2 until end of turn. Whenever a creature dies this turn, you gain 1 life.",
             "colours": [
@@ -5854,7 +5854,7 @@
         },
         {
             "id": "91890210-3060-58ba-8780-e5b78c43da4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32374918-1bcb-4516-96af-f27da752517e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32374918-1bcb-4516-96af-f27da752517e.jpg?1",
             "name": "Deflecting Palm",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. If damage is prevented this way, Deflecting Palm deals that much damage to that source's controller.",
             "colours": [
@@ -5888,7 +5888,7 @@
         },
         {
             "id": "e50d72a0-2f86-53d3-93eb-3d0129096c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d076ea5f-630a-4670-9b15-29fd2cececd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d076ea5f-630a-4670-9b15-29fd2cececd2.jpg?1",
             "name": "Duneblast",
             "text": "Choose up to one creature. Destroy the rest.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "26489b74-cbae-5621-93a4-cfcfbcde9588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8986cb2e-76e0-41f3-8810-3d11c39a527a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8986cb2e-76e0-41f3-8810-3d11c39a527a.jpg?1",
             "name": "Efreet Weaponmaster",
             "text": "First strike\nWhen Efreet Weaponmaster enters the battlefield or is turned face up, another target creature you control gets +3/+0 until end of turn.\nMorph {2}{U}{R}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "0535aecf-976a-5f7e-84ae-8ce9c27a68fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba7efe-ae5a-4d11-b535-1c2e5e6f5982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ba7efe-ae5a-4d11-b535-1c2e5e6f5982.jpg?1",
             "name": "Flying Crane Technique",
             "text": "Untap all creatures you control. They gain flying and double strike until end of turn.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "aefa7f7b-b935-5582-800d-9c6742a98109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d3708b-dd40-4515-bf8f-36cbc5de6b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d3708b-dd40-4515-bf8f-36cbc5de6b67.jpg?1",
             "name": "Highspire Mantis",
             "text": "Flying, trample",
             "colours": [
@@ -6035,7 +6035,7 @@
         },
         {
             "id": "79ec3cee-14ca-5bd9-88f2-a131eb78ef81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdee089-8e89-4c99-9390-e8f4c189cffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdee089-8e89-4c99-9390-e8f4c189cffb.jpg?1",
             "name": "Icefeather Aven",
             "text": "Flying\nMorph {1}{G}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Icefeather Aven is turned face up, you may return another target creature to its owner's hand.",
             "colours": [
@@ -6072,7 +6072,7 @@
         },
         {
             "id": "4ed470b4-ec07-59b7-ab19-863b2ac121d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a8df73-0141-4c07-87d8-b1f34a4b374b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a8df73-0141-4c07-87d8-b1f34a4b374b.jpg?1",
             "name": "Ivorytusk Fortress",
             "text": "Untap each creature you control with a +1/+1 counter on it during each other player's untap step.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "95f4615c-23d6-5c97-bd0c-461af4855cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9c2522-5606-4bbd-863d-f0ab0a612b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9c2522-5606-4bbd-863d-f0ab0a612b4e.jpg?1",
             "name": "Jeskai Ascendancy",
             "text": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn. Untap those creatures.\nWhenever you cast a noncreature spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -6146,7 +6146,7 @@
         },
         {
             "id": "0d835ec5-be0d-5009-8dac-6f933394d7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca268705-ef04-4bf1-8a5d-866bb3e5bb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca268705-ef04-4bf1-8a5d-866bb3e5bb61.jpg?1",
             "name": "Jeskai Charm",
             "text": "Choose one \u2014\n\u2022 Put target creature on top of its owner's library.\n\u2022 Jeskai Charm deals 4 damage to target opponent.\n\u2022 Creatures you control get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "cd110822-4eb9-52a3-a959-9e7ff0c9a8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbca8d-34a3-4df1-986a-36fca142a758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbca8d-34a3-4df1-986a-36fca142a758.jpg?1",
             "name": "Kheru Lich Lord",
             "text": "At the beginning of your upkeep, you may pay {2}{B}. If you do, return a creature card at random from your graveyard to the battlefield. It gains flying, trample, and haste. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "14a8c494-07b0-59ca-9410-6b47074054c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926b49a1-f220-41ab-8c67-8354a91a15e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926b49a1-f220-41ab-8c67-8354a91a15e8.jpg?1",
             "name": "Kin-Tree Invocation",
             "text": "Put an X/X black and green Spirit Warrior creature token onto the battlefield, where X is the greatest toughness among creatures you control.",
             "colours": [
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "b2e0b768-e6c8-5576-9552-c7828a86e9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d5ce46-7118-4ede-ba1d-c387e7ce16e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d5ce46-7118-4ede-ba1d-c387e7ce16e7.jpg?1",
             "name": "Mantis Rider",
             "text": "Flying, vigilance, haste",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "6217fc46-b910-59b2-9272-bd0c51687190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bc2415-b1d1-467a-9578-3948dda166cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bc2415-b1d1-467a-9578-3948dda166cf.jpg?1",
             "name": "Mardu Ascendancy",
             "text": "Whenever a nontoken creature you control attacks, put a 1/1 red Goblin creature token onto the battlefield tapped and attacking.\nSacrifice Mardu Ascendancy: Creatures you control get +0/+3 until end of turn.",
             "colours": [
@@ -6330,7 +6330,7 @@
         },
         {
             "id": "37032212-1ca0-5c1c-ac96-5f282ea03f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35fb7a3-7c7f-4470-b1ad-5b8709a608e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35fb7a3-7c7f-4470-b1ad-5b8709a608e6.jpg?1",
             "name": "Mardu Charm",
             "text": "Choose one \u2014\n\u2022 Mardu Charm deals 4 damage to target creature.\n\u2022 Put two 1/1 white Warrior creature tokens onto the battlefield. They gain first strike until end of turn.\n\u2022 Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "81645c5f-c3c9-52b9-993d-ac7629fe612d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6341345-55a6-43f3-915a-c03afea92ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6341345-55a6-43f3-915a-c03afea92ec3.jpg?1",
             "name": "Mardu Roughrider",
             "text": "Whenever Mardu Roughrider attacks, target creature can't block this turn.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "c15f231e-2a1a-549a-ac39-cdaa4f99b93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704743a8-27d6-4db9-8fe1-f65f5f3a955f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704743a8-27d6-4db9-8fe1-f65f5f3a955f.jpg?1",
             "name": "Master the Way",
             "text": "Draw a card. Master the Way deals damage to target creature or player equal to the number of cards in your hand.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "9d69f2f9-1a9d-5de3-b455-e4c7501c9b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557e8303-a021-4257-b41a-7d25f04618c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557e8303-a021-4257-b41a-7d25f04618c8.jpg?1",
             "name": "Mindswipe",
             "text": "Counter target spell unless its controller pays {X}. Mindswipe deals X damage to that spell's controller.",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "15e45fe0-92ea-52dc-8665-7105ac30db70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f210adb7-b389-4672-a3eb-0ced9bfe190c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f210adb7-b389-4672-a3eb-0ced9bfe190c.jpg?1",
             "name": "Narset, Enlightened Master",
             "text": "First strike, hexproof\nWhenever Narset, Enlightened Master attacks, exile the top four cards of your library. Until end of turn, you may cast noncreature cards exiled with Narset this turn without paying their mana costs.",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "8a895088-0510-51fd-88ae-0791142517e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192d77ef-e8b5-44e2-842b-2c1f342c1e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192d77ef-e8b5-44e2-842b-2c1f342c1e69.jpg?1",
             "name": "Ponyback Brigade",
             "text": "When Ponyback Brigade enters the battlefield or is turned face up, put three 1/1 red Goblin creature tokens onto the battlefield.\nMorph {2}{R}{W}{B} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6553,7 +6553,7 @@
         },
         {
             "id": "8f5602ef-0d92-50eb-9a29-4b7c79ddfe0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4e0b33-dad1-4443-a7c7-a7bab067d04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4e0b33-dad1-4443-a7c7-a7bab067d04a.jpg?1",
             "name": "Rakshasa Deathdealer",
             "text": "{B}{G}: Rakshasa Deathdealer gets +2/+2 until end of turn.\n{B}{G}: Regenerate Rakshasa Deathdealer.",
             "colours": [
@@ -6590,7 +6590,7 @@
         },
         {
             "id": "34f28b82-8280-54d5-9620-0b1e89d29ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb39e674-919d-4db6-9ac1-cfa1cca02207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb39e674-919d-4db6-9ac1-cfa1cca02207.jpg?1",
             "name": "Rakshasa Vizier",
             "text": "Whenever one or more cards are put into exile from your graveyard, put that many +1/+1 counters on Rakshasa Vizier.",
             "colours": [
@@ -6629,7 +6629,7 @@
         },
         {
             "id": "c339c58e-15b4-58ce-9d48-5a533dd580e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc9a434-9617-4a20-88f0-355b20f2c538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc9a434-9617-4a20-88f0-355b20f2c538.jpg?1",
             "name": "Ride Down",
             "text": "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn.",
             "colours": [
@@ -6663,7 +6663,7 @@
         },
         {
             "id": "be8f07e8-044f-5890-b960-34db19988c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c336b-3f70-4518-b1f1-7b773774895d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297c336b-3f70-4518-b1f1-7b773774895d.jpg?1",
             "name": "Sage of the Inward Eye",
             "text": "Flying\nWhenever you cast a noncreature spell, creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "71a285ac-c477-54e8-ad38-1323491b66e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c64af58-963d-497b-ab95-104839d96b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c64af58-963d-497b-ab95-104839d96b94.jpg?1",
             "name": "Sagu Mauler",
             "text": "Trample, hexproof\nMorph {3}{G}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "dc7d4d17-7d6f-5b4b-a250-797a5e5de1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9dddd3-7c8d-4669-8298-58149b142b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9dddd3-7c8d-4669-8298-58149b142b8a.jpg?1",
             "name": "Savage Knuckleblade",
             "text": "{2}{G}: Savage Knuckleblade gets +2/+2 until end of turn. Activate this ability only once each turn.\n{2}{U}: Return Savage Knuckleblade to its owner's hand.\n{R}: Savage Knuckleblade gains haste until end of turn.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "231b76c5-779e-5d67-9ecf-85a6a42978ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01589046-a969-400f-b4ac-90cbbb814504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01589046-a969-400f-b4ac-90cbbb814504.jpg?1",
             "name": "Secret Plans",
             "text": "Face-down creatures you control get +0/+1.\nWhenever a permanent you control is turned face up, draw a card.",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "fd4ff2e8-9b8a-5c18-85db-09b42750b049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa2b070-952e-4242-83bb-3e73135ceeeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa2b070-952e-4242-83bb-3e73135ceeeb.jpg?1",
             "name": "Sidisi, Brood Tyrant",
             "text": "Whenever Sidisi, Brood Tyrant enters the battlefield or attacks, put the top three cards of your library into your graveyard.\nWhenever one or more creature cards are put into your graveyard from your library, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "a1913893-a1a9-556b-be7d-0f166dc57b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9011126a-20bd-4c86-a63b-1691f79ac247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9011126a-20bd-4c86-a63b-1691f79ac247.jpg?1",
             "name": "Siege Rhino",
             "text": "Trample\nWhen Siege Rhino enters the battlefield, each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -6890,7 +6890,7 @@
         },
         {
             "id": "3846b095-6dca-577f-8aaf-b1d5cb301445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d9aa9b-1ed4-46db-89d1-6c9593c29f55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d9aa9b-1ed4-46db-89d1-6c9593c29f55.jpg?1",
             "name": "Snowhorn Rider",
             "text": "Trample\nMorph {2}{G}{U}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6929,7 +6929,7 @@
         },
         {
             "id": "ceaf8582-0037-5541-8a7e-55ed61d6b64c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1a9643-34d6-4b4b-b896-2d4626eca40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1a9643-34d6-4b4b-b896-2d4626eca40a.jpg?1",
             "name": "Sorin, Solemn Visitor",
             "text": "+1: Until your next turn, creatures you control get +1/+0 and gain lifelink.\n\u22122: Put a 2/2 black Vampire creature token with flying onto the battlefield.\n\u22126: You get an emblem with \"At the beginning of each opponent's upkeep, that player sacrifices a creature.\"",
             "colours": [
@@ -6967,7 +6967,7 @@
         },
         {
             "id": "5aa6a4d0-6ba1-53aa-82d4-80fbb61a4aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3314d77a-039f-43e4-a457-6ceba20c0ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3314d77a-039f-43e4-a457-6ceba20c0ffe.jpg?1",
             "name": "Sultai Ascendancy",
             "text": "At the beginning of your upkeep, look at the top two cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "47c2a2bf-a9c8-56fd-a6f0-b15a299b37db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c9028-9b1b-4903-81b2-3cf4f37b7229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993c9028-9b1b-4903-81b2-3cf4f37b7229.jpg?1",
             "name": "Sultai Charm",
             "text": "Choose one \u2014\n\u2022 Destroy target monocolored creature.\n\u2022 Destroy target artifact or enchantment.\n\u2022 Draw two cards, then discard a card.",
             "colours": [
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "bd290ebd-615c-57ac-bbf4-b8b026e220ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0de2c9-957e-41ee-8899-b93e6f1091dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0de2c9-957e-41ee-8899-b93e6f1091dc.jpg?1",
             "name": "Sultai Soothsayer",
             "text": "When Sultai Soothsayer enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "aa8f9334-998d-5452-81eb-73e3f490e0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03032d89-caca-43ff-b2ea-028e376c829c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03032d89-caca-43ff-b2ea-028e376c829c.jpg?1",
             "name": "Surrak Dragonclaw",
             "text": "Flash\nSurrak Dragonclaw can't be countered.\nCreature spells you control can't be countered.\nOther creatures you control have trample.",
             "colours": [
@@ -7119,7 +7119,7 @@
         },
         {
             "id": "3337f951-d608-50b4-aa19-954d1c3a2fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11746bf1-d813-4ade-8ce4-9935cebef856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11746bf1-d813-4ade-8ce4-9935cebef856.jpg?1",
             "name": "Temur Ascendancy",
             "text": "Creatures you control have haste.\nWhenever a creature with power 4 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -7155,7 +7155,7 @@
         },
         {
             "id": "7caa1fbd-ca51-59a3-b11f-78d0f5e1bcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee3e36-a849-42b0-b84b-027a08427c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee3e36-a849-42b0-b84b-027a08427c35.jpg?1",
             "name": "Temur Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+1 until end of turn. It fights target creature you don't control.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Creatures with power 3 or less can't block this turn.",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "760f946c-0849-5eb6-9289-4bb7871f36f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb37bd9-10a0-48d5-87f0-23a03b5c1072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb37bd9-10a0-48d5-87f0-23a03b5c1072.jpg?1",
             "name": "Trap Essence",
             "text": "Counter target creature spell. Put two +1/+1 counters on up to one target creature.",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "505d315a-2c03-54f5-82d4-8608d3fda3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39643107-8873-42f6-9b4d-b546a0a976ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39643107-8873-42f6-9b4d-b546a0a976ba.jpg?1",
             "name": "Utter End",
             "text": "Exile target nonland permanent.",
             "colours": [
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "0294f8a5-33ba-5c4b-9e10-a640f9d7d87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610e69b-8b7c-40e4-bb10-28ee4411f861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610e69b-8b7c-40e4-bb10-28ee4411f861.jpg?1",
             "name": "Villainous Wealth",
             "text": "Target opponent exiles the top X cards of his or her library. You may cast any number of nonland cards with converted mana cost X or less from among them without paying their mana costs.",
             "colours": [
@@ -7297,7 +7297,7 @@
         },
         {
             "id": "48218cd4-8bf2-5deb-9611-d0626280ab6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04135bf7-2bcf-4a92-80f0-6d5eefca551b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04135bf7-2bcf-4a92-80f0-6d5eefca551b.jpg?1",
             "name": "Warden of the Eye",
             "text": "When Warden of the Eye enters the battlefield, return target noncreature, nonland card from your graveyard to your hand.",
             "colours": [
@@ -7336,7 +7336,7 @@
         },
         {
             "id": "17dfef20-c08a-5f61-a784-8699bb3f0739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8924ab9-fa55-4348-b67d-b2b9e48a357a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8924ab9-fa55-4348-b67d-b2b9e48a357a.jpg?1",
             "name": "Winterflame",
             "text": "Choose one or both \u2014\n\u2022 Tap target creature.\n\u2022 Winterflame deals 2 damage to target creature.",
             "colours": [
@@ -7370,7 +7370,7 @@
         },
         {
             "id": "cde24b01-b97c-5f77-9961-6d9ac24ab172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f4bafe-0d21-47ba-8f16-0274107d618c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f4bafe-0d21-47ba-8f16-0274107d618c.jpg?1",
             "name": "Zurgo Helmsmasher",
             "text": "Haste\nZurgo Helmsmasher attacks each combat if able.\nZurgo Helmsmasher has indestructible as long as it's your turn.\nWhenever a creature dealt damage by Zurgo Helmsmasher this turn dies, put a +1/+1 counter on Zurgo Helmsmasher.",
             "colours": [
@@ -7411,7 +7411,7 @@
         },
         {
             "id": "b182ef0f-ff19-5503-abdd-1ad3791953d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7855528a-ede9-49a9-8749-795a004fd927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7855528a-ede9-49a9-8749-795a004fd927.jpg?1",
             "name": "Abzan Banner",
             "text": "{T}: Add {W}, {B}, or {G} to your mana pool.\n{W}{B}{G}, {T}, Sacrifice Abzan Banner: Draw a card.",
             "colours": [],
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "c733921a-daa0-5737-8a1a-a7d853cea260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d59d264-87ee-4305-bffb-110549331a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d59d264-87ee-4305-bffb-110549331a82.jpg?1",
             "name": "Altar of the Brood",
             "text": "Whenever another permanent enters the battlefield under your control, each opponent puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "0b985fa4-6e59-587b-a05a-0d882121f162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9951f1-ca51-44a2-8480-602df466f0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9951f1-ca51-44a2-8480-602df466f0ab.jpg?1",
             "name": "Briber's Purse",
             "text": "Briber's Purse enters the battlefield with X gem counters on it.\n{1}, {T}, Remove a gem counter from Briber's Purse: Target creature can't attack or block this turn.",
             "colours": [],
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "146f1d09-ddf7-596d-b5b2-c1e881cc7550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1284b15f-2a70-48d6-89d3-e787af3f07eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1284b15f-2a70-48d6-89d3-e787af3f07eb.jpg?1",
             "name": "Cranial Archive",
             "text": "{2}, Exile Cranial Archive: Target player shuffles his or her graveyard into his or her library. Draw a card.",
             "colours": [],
@@ -7527,7 +7527,7 @@
         },
         {
             "id": "7d9d9762-2d52-5b91-9345-07919a778c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d508e6a6-034c-424d-993e-7354ce212f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d508e6a6-034c-424d-993e-7354ce212f13.jpg?1",
             "name": "Dragon Throne of Tarkir",
             "text": "Equipped creature has defender and \"{2}, {T}: Other creatures you control gain trample and get +X/+X until end of turn, where X is this creature's power.\"\nEquip {3}",
             "colours": [],
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "8bd92644-918c-5569-8059-e355539b3aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711145d8-5178-4fdc-8494-4ab680f55b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711145d8-5178-4fdc-8494-4ab680f55b1a.jpg?1",
             "name": "Ghostfire Blade",
             "text": "Equipped creature gets +2/+2.\nEquip {3}\nGhostfire Blade's equip ability costs {2} less to activate if it targets a colorless creature.",
             "colours": [],
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "33988b65-7cef-5bbf-b3c5-58682832723e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48168005-65cc-43dc-9d45-17ea5dd4848f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48168005-65cc-43dc-9d45-17ea5dd4848f.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1}",
             "colours": [],
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "4f5e39be-4271-5bc0-bff1-d8820ae9fe1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684dc050-a66b-4364-9880-56f383db6c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684dc050-a66b-4364-9880-56f383db6c0a.jpg?1",
             "name": "Jeskai Banner",
             "text": "{T}: Add {U}, {R}, or {W} to your mana pool.\n{U}{R}{W}, {T}, Sacrifice Jeskai Banner: Draw a card.",
             "colours": [],
@@ -7651,7 +7651,7 @@
         },
         {
             "id": "40c624d5-8c84-596d-a91a-a8ac1bfd1471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c82e2b8-f0f6-44da-83ee-8a671344ac62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c82e2b8-f0f6-44da-83ee-8a671344ac62.jpg?1",
             "name": "Lens of Clarity",
             "text": "You may look at the top card of your library and at face-down creatures you don't control. (You may do this at any time.)",
             "colours": [],
@@ -7679,7 +7679,7 @@
         },
         {
             "id": "fcb9218c-1c1a-545f-8c05-acb9d030e8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10c56d-a8e1-495d-a03a-0b920b44182f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10c56d-a8e1-495d-a03a-0b920b44182f.jpg?1",
             "name": "Mardu Banner",
             "text": "{T}: Add {R}, {W}, or {B} to your mana pool.\n{R}{W}{B}, {T}, Sacrifice Mardu Banner: Draw a card.",
             "colours": [],
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "72f86169-a42f-59a9-b63c-5820a9ae64c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695cf35-8f7c-4674-bfd3-43520b13d084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1695cf35-8f7c-4674-bfd3-43520b13d084.jpg?1",
             "name": "Sultai Banner",
             "text": "{T}: Add {B}, {G}, or {U} to your mana pool.\n{B}{G}{U}, {T}, Sacrifice Sultai Banner: Draw a card.",
             "colours": [],
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "03efd706-c54a-5a3d-88e8-04b07f6e090a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990bdff-c27a-447f-b530-d8b7614fe9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9990bdff-c27a-447f-b530-d8b7614fe9a0.jpg?1",
             "name": "Temur Banner",
             "text": "{T}: Add {G}, {U}, or {R} to your mana pool.\n{G}{U}{R}, {T}, Sacrifice Temur Banner: Draw a card.",
             "colours": [],
@@ -7775,7 +7775,7 @@
         },
         {
             "id": "e908dc61-420a-5c93-b850-db8505186549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94002868-a48a-4ea8-bfce-17257078f5db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94002868-a48a-4ea8-bfce-17257078f5db.jpg?1",
             "name": "Ugin's Nexus",
             "text": "If a player would begin an extra turn, that player skips that turn instead.\nIf Ugin's Nexus would be put into a graveyard from the battlefield, instead exile it and take an extra turn after this one.",
             "colours": [],
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "bc4e670d-cade-5571-a1c0-ef1b58b02aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763ac4c4-af2d-4b71-9fb3-244c96f93860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763ac4c4-af2d-4b71-9fb3-244c96f93860.jpg?1",
             "name": "Witness of the Ages",
             "text": "Morph {5} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [],
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "abff8f9f-b24b-5aa2-8818-488ba2739361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a7b30a-c59f-4a87-9e8a-b29daea27422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a7b30a-c59f-4a87-9e8a-b29daea27422.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7867,7 +7867,7 @@
         },
         {
             "id": "efe7b30c-c659-5316-91cd-6ece7955c546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f430794-0d86-4f6a-97e0-4bbb6716d613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f430794-0d86-4f6a-97e0-4bbb6716d613.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "3c6e2867-643e-59a9-9367-58268ab3b70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a1c0b-f6ea-475a-aa01-3618ea7d8647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a1c0b-f6ea-475a-aa01-3618ea7d8647.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "5b0dd831-547e-5b95-a8c6-452633ea7ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63742780-47ee-4a66-993a-69e06c14967d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63742780-47ee-4a66-993a-69e06c14967d.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "de3ca801-1eb9-5fa1-b4fd-87f76b1cc576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2996d9-3287-4480-8c04-7a378e37e3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2996d9-3287-4480-8c04-7a378e37e3cf.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "7444d7ca-9be4-5121-b562-1ea60e1f7b61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4335951-e73e-45cb-b2a5-6e9d14ba87ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4335951-e73e-45cb-b2a5-6e9d14ba87ee.jpg?1",
             "name": "Frontier Bivouac",
             "text": "Frontier Bivouac enters the battlefield tapped.\n{T}: Add {G}, {U}, or {R} to your mana pool.",
             "colours": [],
@@ -8017,7 +8017,7 @@
         },
         {
             "id": "60963fb2-9880-5d92-8346-46d49cec36b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea27aa7-7fcf-4198-b03a-5034a03ba81f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea27aa7-7fcf-4198-b03a-5034a03ba81f.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "1ebd09c5-d32a-58e4-9d57-49fffed50805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae51d77-e06b-4e5a-9543-a17dd0b2a333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae51d77-e06b-4e5a-9543-a17dd0b2a333.jpg?1",
             "name": "Mystic Monastery",
             "text": "Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W} to your mana pool.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "5d833dca-ecb2-5b6e-9592-68e2dfa85b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6ae4a5-227d-465b-9e99-bae158b7d410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6ae4a5-227d-465b-9e99-bae158b7d410.jpg?1",
             "name": "Nomad Outpost",
             "text": "Nomad Outpost enters the battlefield tapped.\n{T}: Add {R}, {W}, or {B} to your mana pool.",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "9ecc9b74-d125-59cb-9eb8-27cccba77b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21326575-80b9-4a4e-a93c-6880ec6575d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21326575-80b9-4a4e-a93c-6880ec6575d5.jpg?1",
             "name": "Opulent Palace",
             "text": "Opulent Palace enters the battlefield tapped.\n{T}: Add {B}, {G}, or {U} to your mana pool.",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "dbc76978-5109-550a-b0e5-5768cdd1f6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2f5f58-9a95-4ca6-93a0-813738f0072f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2f5f58-9a95-4ca6-93a0-813738f0072f.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8172,7 +8172,7 @@
         },
         {
             "id": "edb6225d-bbfa-53ed-accd-4d99fb33c81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ce6cb-0324-4cca-bc79-903cefe1ac1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501ce6cb-0324-4cca-bc79-903cefe1ac1f.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "bc9ad76c-3095-5f3b-8bc3-d9deac347cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd40d90-c939-458a-9a98-27d10da6ff2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd40d90-c939-458a-9a98-27d10da6ff2f.jpg?1",
             "name": "Sandsteppe Citadel",
             "text": "Sandsteppe Citadel enters the battlefield tapped.\n{T}: Add {W}, {B}, or {G} to your mana pool.",
             "colours": [],
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "1d37ee26-50db-5dc6-8179-a91616cc8c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0824a960-dd89-45c5-90f0-3ec9eb47d9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0824a960-dd89-45c5-90f0-3ec9eb47d9ce.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8266,7 +8266,7 @@
         },
         {
             "id": "0064afc8-3d2b-5225-8e72-3b3fb9e9655c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782d005-a563-4738-978a-73a3465de78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782d005-a563-4738-978a-73a3465de78f.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "54774062-bf44-5b1c-9014-8ea7c15dd979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e57abd9-e864-4047-a3c8-618952071858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e57abd9-e864-4047-a3c8-618952071858.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "3cde416a-c757-53d2-aa89-7bfcb01dd98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6be7ab-8fad-4606-b623-f2188219d60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6be7ab-8fad-4606-b623-f2188219d60b.jpg?1",
             "name": "Tomb of the Spirit Dragon",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: You gain 1 life for each colorless creature you control.",
             "colours": [],
@@ -8356,7 +8356,7 @@
         },
         {
             "id": "7e80184a-fe9e-56d9-84a3-bae686a8f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f840bd2-c4f5-4ac4-918c-91b4feeb8783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f840bd2-c4f5-4ac4-918c-91b4feeb8783.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "39d7f920-a910-511d-8504-c99ae44a85d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b296781-78ac-411f-88fc-2d924ad22986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b296781-78ac-411f-88fc-2d924ad22986.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "982bc8f7-d9ee-5a79-9c05-718b31a375df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b28650-cddc-4878-b1d1-b5a764f4df49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b28650-cddc-4878-b1d1-b5a764f4df49.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "71dc1055-b9e8-5574-9232-8eba92030e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8503cca-7e7d-44c4-8587-81376b396398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8503cca-7e7d-44c4-8587-81376b396398.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8474,7 +8474,7 @@
         },
         {
             "id": "3501b3cf-a81d-545c-b46d-c541875eb061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576dc74-1847-44b8-aef9-9d74f333b9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576dc74-1847-44b8-aef9-9d74f333b9cc.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8512,7 +8512,7 @@
         },
         {
             "id": "a9a6d82c-3f49-57ad-84db-531a339ed836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40337e60-065e-425d-ae35-c639d2bb5b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40337e60-065e-425d-ae35-c639d2bb5b42.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "6fce0f8e-d1fd-54c4-a9c4-ba66d75188c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bfb654-ab99-4272-a184-b95e1022af5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bfb654-ab99-4272-a184-b95e1022af5c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "00f1765b-bb43-5ef8-96aa-5006f2725270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b97fb-da4a-4867-abde-825383c74b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324b97fb-da4a-4867-abde-825383c74b63.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "b839452f-ea03-5b5a-81a5-0e7e0bec01b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010ca5-b609-4ae9-8c23-adf5723a9daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c010ca5-b609-4ae9-8c23-adf5723a9daa.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "b8f7d4ad-2834-59b8-af83-7c1bdd9ade65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65c53-7b35-4ba0-9344-b311eee087cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65c53-7b35-4ba0-9344-b311eee087cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "6a84a69e-e14f-5edf-8c4e-c17b17cc3a2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45827e8-d4b9-4a42-8516-22560568e678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45827e8-d4b9-4a42-8516-22560568e678.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8740,7 +8740,7 @@
         },
         {
             "id": "f89d6a77-cf24-55ac-a6cc-b3e7ec453f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61c4c14-e45d-45a8-87c7-fec98d46ee79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61c4c14-e45d-45a8-87c7-fec98d46ee79.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "987de836-90f8-5a41-9f7c-f228d2f21c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d7e861-8dda-4073-bfd6-4ade3bca5cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d7e861-8dda-4073-bfd6-4ade3bca5cff.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "8db4472f-9bea-5bc8-884a-bac960170536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a8d790-61e5-4b46-94b8-54ea68ed18ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a8d790-61e5-4b46-94b8-54ea68ed18ea.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8854,7 +8854,7 @@
         },
         {
             "id": "bb1f754e-6519-56bb-805a-c1c3e5f1ecd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11fd2a-d872-4abc-ac2b-c0678c1be773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11fd2a-d872-4abc-ac2b-c0678c1be773.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "c0b457f1-8542-5a5e-b5ad-c7a4484b9cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cac8b-6609-42ac-a594-002068e02de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cac8b-6609-42ac-a594-002068e02de4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "cf1e944d-a871-5433-86a4-0d70d37f7bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802b1bb0-6c73-481a-ac3e-7d4e1682b4c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802b1bb0-6c73-481a-ac3e-7d4e1682b4c2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8968,7 +8968,7 @@
         },
         {
             "id": "f34e090e-ee1b-5375-a0d0-49b4c82ebd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5037330a-6e9b-4ce5-ba81-ae1ccef63334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5037330a-6e9b-4ce5-ba81-ae1ccef63334.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "94cff076-2400-592a-a3f2-7ea72131591b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45c7ed-cf98-455b-b665-81103fdc9331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45c7ed-cf98-455b-b665-81103fdc9331.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "c2f44642-9883-5c3b-b815-8d82dd274218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ad8df0-20f3-4372-8b2b-7c4ccfc2e9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ad8df0-20f3-4372-8b2b-7c4ccfc2e9c0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "f0250715-4061-54be-8dc3-ef9dc1971575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5342f9-3f91-48e4-bfd1-49fbf9ca89cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5342f9-3f91-48e4-bfd1-49fbf9ca89cf.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "be22b604-ef97-586a-8870-857be59e59d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722111d4-99f4-463b-b232-96821c18f189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722111d4-99f4-463b-b232-96821c18f189.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "8cd482f1-be96-5baf-a8a3-769ade3fd503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe7f25-71c5-4fd2-8696-0a4ce8c4b0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe7f25-71c5-4fd2-8696-0a4ce8c4b0b6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9196,7 +9196,7 @@
         },
         {
             "id": "4b9b8783-ccc0-5962-913b-44ff1769bc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742ffa7-915f-45ce-b3f2-8391723bb34c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742ffa7-915f-45ce-b3f2-8391723bb34c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "e5ffaf0b-de4f-539d-a767-45f9c5d3f2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa788dea-2968-45e8-9e08-c89e3e227d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa788dea-2968-45e8-9e08-c89e3e227d88.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -9268,7 +9268,7 @@
         },
         {
             "id": "4a9e435a-f448-5ee1-bfd3-4ff47dbc59e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7071930c-689a-44b9-b52d-45027fd14446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7071930c-689a-44b9-b52d-45027fd14446.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9302,7 +9302,7 @@
         },
         {
             "id": "9e097860-c9e4-545a-be49-9b86757b0646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46bcc76-181c-4e06-aa04-590a3e651dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46bcc76-181c-4e06-aa04-590a3e651dc7.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -9336,7 +9336,7 @@
         },
         {
             "id": "9f33f0a5-ce38-5c8c-8bed-4fe07868f39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4c9101-85bf-4a4f-a496-ff6db7b531b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4c9101-85bf-4a4f-a496-ff6db7b531b7.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -9370,7 +9370,7 @@
         },
         {
             "id": "658c8c34-5aeb-5ffc-adee-d69d421b4d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71496671-f7ba-4014-a895-d70a27979db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71496671-f7ba-4014-a895-d70a27979db7.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -9404,7 +9404,7 @@
         },
         {
             "id": "3a0c9727-c93a-54d6-abba-0d6a723e839c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7da3d0-2471-48ab-8e7c-af8046d9e0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7da3d0-2471-48ab-8e7c-af8046d9e0be.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "10ecaa3d-ccc8-5277-9969-6af572f03b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9472,7 +9472,7 @@
         },
         {
             "id": "3d6a2993-34db-51c3-a046-bd879aa312d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3dae7d-3880-4c0a-acfb-8fd227cf9fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3dae7d-3880-4c0a-acfb-8fd227cf9fab.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "801f9c59-c1c6-5332-b3d7-6537990e7c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e9f9d-b1e5-4724-9b80-e51500d12d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e9f9d-b1e5-4724-9b80-e51500d12d5b.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -9540,7 +9540,7 @@
         },
         {
             "id": "58572f10-72f2-5f42-9216-1fb08db52d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc7ce0-387f-413c-a387-2952b990ff3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc7ce0-387f-413c-a387-2952b990ff3f.jpg?1",
             "name": "Spirit Warrior",
             "text": "",
             "colours": [
@@ -9577,7 +9577,7 @@
         },
         {
             "id": "10de7c9d-7fed-5f6d-8f60-ded881c3eb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc513990-b4e8-498b-84d5-8317bc79a667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc513990-b4e8-498b-84d5-8317bc79a667.jpg?1",
             "name": "Morph",
             "text": "",
             "colours": [],
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "fcbf401e-2b30-502c-af40-14a0b8d701b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0430bc-5b7e-431e-a8d0-168f679fe79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0430bc-5b7e-431e-a8d0-168f679fe79c.jpg?1",
             "name": "Sarkhan, the Dragonspeaker Emblem",
             "text": "",
             "colours": [],
@@ -9633,7 +9633,7 @@
         },
         {
             "id": "4876ec20-452c-5752-b24f-1ca65a840966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6e8950-5b1e-48b6-8d32-2a463455499d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6e8950-5b1e-48b6-8d32-2a463455499d.jpg?1",
             "name": "Sorin, Solemn Visitor Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/LCI.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LCI.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7a692863-f331-512c-8b66-9371923a1833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b725e-2b9c-4830-ac54-b2562afe09bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93b725e-2b9c-4830-ac54-b2562afe09bb.jpg?1",
             "name": "Abuelo's Awakening",
             "text": "Return target artifact or non-Aura enchantment card from your graveyard to the battlefield with X additional +1/+1 counters on it. It's a 1/1 Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "2d693bd9-e99e-5a40-a90c-b2bcc7bff2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f82d84-03ad-42dd-80ce-f0ac5e353e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f82d84-03ad-42dd-80ce-f0ac5e353e46.jpg?1",
             "name": "Acrobatic Leap",
             "text": "Target creature gets +1/+3 and gains flying until end of turn. Untap it.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "6cebbfac-215c-5586-96b1-c2ed6164f4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c91e24-b7e8-4040-80cb-d1b375002c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c91e24-b7e8-4040-80cb-d1b375002c10.jpg?1",
             "name": "Adaptive Gemguard",
             "text": "Tap two untapped artifacts and/or creatures you control: Put a +1/+1 counter on Adaptive Gemguard. Activate only as a sorcery.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "072b67a9-271f-5708-ac99-93f749aa49c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1a0159-7f00-429c-9318-b028b1e03ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1a0159-7f00-429c-9318-b028b1e03ba8.jpg?1",
             "name": "Attentive Sunscribe",
             "text": "Whenever Attentive Sunscribe becomes tapped, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "4dc2e7b3-8049-54c1-bb93-3ad9a4e6350e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c02134c-ec9f-4090-820e-8ba7ae4a8c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c02134c-ec9f-4090-820e-8ba7ae4a8c2b.jpg?1",
             "name": "Bat Colony",
             "text": "When Bat Colony enters the battlefield, create a 1/1 black Bat creature token with flying for each mana from a Cave spent to cast it.\nWhenever a Cave enters the battlefield under your control, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "32480bfd-5be9-5eb9-989d-6650eb53c16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1",
             "name": "Clay-Fired Bricks // Cosmium Kiln",
             "text": "",
             "colours": [
@@ -204,7 +204,7 @@
         },
         {
             "id": "16466dc8-409b-5570-ab4d-29e847d1321c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1",
             "name": "Clay-Fired Bricks // Cosmium Kiln",
             "text": "",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "8e33fd00-f101-5568-9096-f369858cbe16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d1eac-ede7-4f75-9c74-05133b215f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d1eac-ede7-4f75-9c74-05133b215f93.jpg?1",
             "name": "Cosmium Blast",
             "text": "Cosmium Blast deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -268,7 +268,7 @@
         },
         {
             "id": "36858ec4-1791-54ef-86c1-9d5c17aa8b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg?1",
             "name": "Dauntless Dismantler",
             "text": "Artifacts your opponents control enter the battlefield tapped.\n{X}{X}{W}, Sacrifice Dauntless Dismantler: Destroy each artifact with mana value X.",
             "colours": [
@@ -303,7 +303,7 @@
         },
         {
             "id": "ea9697c6-0a8b-5467-a1c7-a8cd6a5ac370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ba382-18c4-4833-b3d2-bd469ae2ad77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7ba382-18c4-4833-b3d2-bd469ae2ad77.jpg?1",
             "name": "Deconstruction Hammer",
             "text": "Equipped creature gets +1/+1 and has \"{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "c5da07c5-0146-5aea-9976-eb7c21a01237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f231ef-4167-4b0a-b54c-a098b2eb2f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f231ef-4167-4b0a-b54c-a098b2eb2f6f.jpg?1",
             "name": "Dusk Rose Reliquary",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nWard {2}\nWhen Dusk Rose Reliquary enters the battlefield, exile target artifact or creature an opponent controls until Dusk Rose Reliquary leaves the battlefield.",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "73281fe7-14de-5cec-a901-a19a618c0f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96de0741-9270-4118-bb8e-f3480c75a582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96de0741-9270-4118-bb8e-f3480c75a582.jpg?1",
             "name": "Envoy of Okinec Ahau",
             "text": "{4}{W}: Create a 1/1 colorless Gnome artifact creature token.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "1d237770-d605-5369-ad94-28cf9168114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323a05ee-8296-41c0-94ab-00913d9d84f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323a05ee-8296-41c0-94ab-00913d9d84f1.jpg?1",
             "name": "Fabrication Foundry",
             "text": "{T}: Add {W}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.\n{2}{W}, {T}, Exile one or more other artifacts you control with total mana value X: Return target artifact card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "117078e4-1d82-5d7b-a1ca-e8d464f190ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2cfbdc-8d40-4abb-afca-6c6d8e36185b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2cfbdc-8d40-4abb-afca-6c6d8e36185b.jpg?1",
             "name": "Family Reunion",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +1/+1 until end of turn.\n\u2022 Creatures you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "db1015f4-e493-5b91-8dbc-92ca13870e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522aa72b-2b8c-484c-872b-f082101cee35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522aa72b-2b8c-484c-872b-f082101cee35.jpg?1",
             "name": "Get Lost",
             "text": "Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "adf80616-0390-5266-a40d-a0bcd8f364a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7580ad36-7362-4dee-9511-d119173b70e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7580ad36-7362-4dee-9511-d119173b70e8.jpg?1",
             "name": "Glorifier of Suffering",
             "text": "When Glorifier of Suffering enters the battlefield, you may sacrifice another creature or artifact. When you do, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "8fab2c14-6455-5197-ad12-28cb21226e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86f3cb2-7822-4c19-bd84-cea177e5b6e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86f3cb2-7822-4c19-bd84-cea177e5b6e9.jpg?1",
             "name": "Guardian of the Great Door",
             "text": "As an additional cost to cast this spell, tap four untapped artifacts, creatures, and/or lands you control.\nFlying",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "06c75fc4-258a-5af7-ab9e-eaca18a07e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa7126-5df3-42dd-b4a3-0d0ea59eeebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aa7126-5df3-42dd-b4a3-0d0ea59eeebd.jpg?1",
             "name": "Helping Hand",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped.",
             "colours": [
@@ -605,7 +605,7 @@
         },
         {
             "id": "2228c4c3-ad1c-5b86-ab33-a65912691b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70689a0-ac69-4052-84fc-9055e9e1c54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70689a0-ac69-4052-84fc-9055e9e1c54b.jpg?1",
             "name": "Ironpaw Aspirant",
             "text": "When Ironpaw Aspirant enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -640,7 +640,7 @@
         },
         {
             "id": "f76ad1f5-6c5e-5f80-957a-6c22ef599082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4c527c-6963-47f4-bcad-841d06bb2211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4c527c-6963-47f4-bcad-841d06bb2211.jpg?1",
             "name": "Kinjalli's Dawnrunner",
             "text": "Double strike\nWhen Kinjalli's Dawnrunner enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "aa1e494f-d58b-5f10-94aa-15fce78fa083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1201811-54ab-4c4e-b6e1-19b0d07e5ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1201811-54ab-4c4e-b6e1-19b0d07e5ede.jpg?1",
             "name": "Kutzil's Flanker",
             "text": "Flash\nWhen Kutzil's Flanker enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Kutzil's Flanker for each creature that left the battlefield under your control this turn.\n\u2022 You gain 2 life and scry 2.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "9e976fc8-ad61-54ac-8f94-29fca305a0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a6ba0-cea0-4084-92f1-2bd60ea25fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a6ba0-cea0-4084-92f1-2bd60ea25fb0.jpg?1",
             "name": "Malamet War Scribe",
             "text": "When Malamet War Scribe enters the battlefield, creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "29ae111d-2d91-540b-9dc3-5c1bf1ae6ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dafcd6-ce4e-4a27-bd8c-fa1a3bffc99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36dafcd6-ce4e-4a27-bd8c-fa1a3bffc99e.jpg?1",
             "name": "Market Gnome",
             "text": "When Market Gnome dies, you gain 1 life and draw a card.\nWhen Market Gnome is exiled from the battlefield while you're activating a craft ability, you gain 1 life and draw a card.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "0bec44e8-e176-52c8-8340-b2516ef6af37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f82c95-8bc1-4df9-9120-86ffc059c7dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f82c95-8bc1-4df9-9120-86ffc059c7dd.jpg?1",
             "name": "Might of the Ancestors",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 and gains vigilance until end of turn.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "dfac90ed-6531-5f92-bec8-54137933df8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9048cd9d-df3f-4705-a5f4-e5b09760c631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9048cd9d-df3f-4705-a5f4-e5b09760c631.jpg?1",
             "name": "Miner's Guidewing",
             "text": "Flying, vigilance\nWhen Miner's Guidewing dies, target creature you control explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "d4c3219b-f534-5b24-8331-6ee05ffb1147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c219861-f808-456f-b551-37512764062d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c219861-f808-456f-b551-37512764062d.jpg?1",
             "name": "Mischievous Pup",
             "text": "Flash\nWhen Mischievous Pup enters the battlefield, return up to one other target permanent you control to its owner's hand.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "c531ac32-d1b4-5d22-bbf7-1d1f4aeb40ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "f8514939-0b54-5ae5-9454-b06c2497b12e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [],
@@ -952,7 +952,7 @@
         },
         {
             "id": "1351680e-dce6-55bf-bd77-2554747b0ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c21561-2213-4524-89a6-30a305843e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c21561-2213-4524-89a6-30a305843e5a.jpg?1",
             "name": "Oltec Archaeologists",
             "text": "When Oltec Archaeologists enters the battlefield, choose one \u2014\n\u2022 Return target artifact card from your graveyard to your hand.\n\u2022 Scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "aa281663-d72d-5be3-98bb-0ce8db132f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d68a38-2e0b-401b-b67d-a55e2af5b18d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d68a38-2e0b-401b-b67d-a55e2af5b18d.jpg?1",
             "name": "Oltec Cloud Guard",
             "text": "Flying\nWhen Oltec Cloud Guard enters the battlefield, create a 1/1 colorless Gnome artifact creature token.",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "635d1144-b4a3-5bb2-be79-b03bf77c39a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1",
             "name": "Oteclan Landmark // Oteclan Levitator",
             "text": "",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "55997d2c-bc8f-55a0-bb4b-6e4adc9a0c81",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1",
             "name": "Oteclan Landmark // Oteclan Levitator",
             "text": "",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "5dc96eb4-ac6c-5bbf-ac5d-81714824f3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc5f28f-6361-455f-ac82-260a70e59316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc5f28f-6361-455f-ac82-260a70e59316.jpg?1",
             "name": "Petrify",
             "text": "Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "c15cff24-93f0-55ad-9ff3-9a4cae67ec68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74ddccb-ebbd-4fad-a9b6-6b9e9bafae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74ddccb-ebbd-4fad-a9b6-6b9e9bafae31.jpg?1",
             "name": "Quicksand Whirlpool",
             "text": "This spell costs {3} less to cast if it targets a tapped creature.\nExile target creature.",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "d26ab600-e360-55ae-a1c7-bf82b0249af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59adbd35-9959-4a0f-babf-46ea3c15f018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59adbd35-9959-4a0f-babf-46ea3c15f018.jpg?1",
             "name": "Resplendent Angel",
             "text": "Flying\nAt the beginning of each end step, if you gained 5 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.\n{3}{W}{W}{W}: Until end of turn, Resplendent Angel gets +2/+2 and gains lifelink.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "ac833432-0ad7-51ef-bf2c-e42045ac7603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bedf13-c2bc-4e5d-aba3-3c0d5495a9bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bedf13-c2bc-4e5d-aba3-3c0d5495a9bb.jpg?1",
             "name": "Ruin-Lurker Bat",
             "text": "Flying, lifelink\nAt the beginning of your end step, if you descended this turn, scry 1. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "0347638d-968d-5ddb-8327-84667caab72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269ddd84-fdc4-4c94-b183-32ecec56967c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269ddd84-fdc4-4c94-b183-32ecec56967c.jpg?1",
             "name": "Sanguine Evangelist",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhen Sanguine Evangelist enters the battlefield or dies, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -1263,7 +1263,7 @@
         },
         {
             "id": "aaa28fa4-e75b-5029-8fd3-50d0cbda3a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7833724-aec6-41a4-a7ea-2aa722467732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7833724-aec6-41a4-a7ea-2aa722467732.jpg?1",
             "name": "Soaring Sandwing",
             "text": "Flying\nWhen Soaring Sandwing enters the battlefield, you gain 3 life.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "b1955388-df25-58b2-8db5-d6eb6b2cc537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24417388-f2bb-4783-bdce-264774531838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1",
             "name": "Spring-Loaded Sawblades // Bladewheel Chariot",
             "text": "",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "14531b23-2ee9-540d-80e6-2a2f44ede4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24417388-f2bb-4783-bdce-264774531838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1",
             "name": "Spring-Loaded Sawblades // Bladewheel Chariot",
             "text": "",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "7cab183a-0bc8-5eb4-b184-0fb7cd731d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a7439-965d-49f2-b43e-053f29196e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a7439-965d-49f2-b43e-053f29196e6b.jpg?1",
             "name": "Thousand Moons Crackshot",
             "text": "Whenever Thousand Moons Crackshot attacks, you may pay {2}{W}. When you do, tap target creature.",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "536d940c-12ac-580b-81c4-84e4d5d72ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg?1",
             "name": "Thousand Moons Infantry",
             "text": "Untap Thousand Moons Infantry during each other player's untap step.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "d8c50305-4946-5619-b77a-bd5b08b80897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "9c6b2e2a-0bda-5b77-87aa-56ed24b18fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a6bec46-1acd-4726-b8d9-3045ac6a2ea2.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [],
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "44ca2991-ee4a-5122-bd66-b8f3e9f9b824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321857e-7977-46dd-8357-d732312e5261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321857e-7977-46dd-8357-d732312e5261.jpg?1",
             "name": "Tinker's Tote",
             "text": "When Tinker's Tote enters the battlefield, create two 1/1 colorless Gnome artifact creature tokens.\n{W}, Sacrifice Tinker's Tote: You gain 3 life.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "163f7f19-c6b4-5ff9-9fd9-a53cc31432f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "9c1aa948-6d98-599c-a152-1f37e0d772ea",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d70f48e7-582c-4dd2-a64e-6fd03fa6b77e.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "ef0f87cc-2352-58bb-83dc-c0b4af0050d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200c504-9137-4bc2-9cd4-eaf0643a2855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200c504-9137-4bc2-9cd4-eaf0643a2855.jpg?1",
             "name": "Vanguard of the Rose",
             "text": "{1}, Sacrifice another creature or artifact: Vanguard of the Rose gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "1e422d91-fe93-5e4e-9cfe-a4f78c8882ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549fd992-ed37-431d-97cb-9ca017db1d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549fd992-ed37-431d-97cb-9ca017db1d47.jpg?1",
             "name": "Warden of the Inner Sky",
             "text": "As long as Warden of the Inner Sky has three or more counters on it, it has flying and vigilance.\nTap three untapped artifacts and/or creatures you control: Put a +1/+1 counter on Warden of the Inner Sky. Scry 1. Activate only as a sorcery.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "8e1d7eca-f254-5b53-bf02-56d81c1b19f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg?1",
             "name": "Akal Pakal, First Among Equals",
             "text": "At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "077a0f3a-b18d-52f3-b390-4ea2a9004b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625690d3-7131-45de-adea-9c927241e661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625690d3-7131-45de-adea-9c927241e661.jpg?1",
             "name": "Ancestral Reminiscence",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "6c3ed12f-d8da-59f2-b25c-50abfdc49a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea3d0f4-76f5-416f-93ba-8b003b967816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea3d0f4-76f5-416f-93ba-8b003b967816.jpg?1",
             "name": "Brackish Blunder",
             "text": "Return target creature to its owner's hand. If it was tapped, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "12121978-97f4-588f-99c0-2b0ed31cde6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -1816,7 +1816,7 @@
         },
         {
             "id": "43017d21-c6f5-53e5-b0db-a4589bcf8baa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68a6ede0-6d57-4e29-9e3b-3569ab7f0bcd.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "70b425f8-4758-5044-bade-0d4eb5354f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233beaac-37a4-4824-8f31-438b6bfe794b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233beaac-37a4-4824-8f31-438b6bfe794b.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked this turn.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "2b482c81-5966-5c56-973b-c0543abafa72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d329ad-6b19-4aa7-a53f-38c7b76c4c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d329ad-6b19-4aa7-a53f-38c7b76c4c96.jpg?1",
             "name": "Cogwork Wrestler",
             "text": "Flash\nWhen Cogwork Wrestler enters the battlefield, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "cfe1987b-7f2e-5421-8519-debcdf8bfdd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ae23db-c391-402c-9568-65447cada66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ae23db-c391-402c-9568-65447cada66e.jpg?1",
             "name": "Confounding Riddle",
             "text": "Choose one \u2014\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\n\u2022 Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "634edc8f-4780-5342-a64b-e6fcabac6815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg?1",
             "name": "Council of Echoes",
             "text": "Flying\nDescend 4 \u2014 When Council of Echoes enters the battlefield, if there are four or more permanent cards in your graveyard, return up to one target nonland permanent other than Council of Echoes to its owner's hand.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "4caf2f73-688e-501d-ad3f-ef3db8952e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2449311-a705-4a31-a345-a36d436ae561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2449311-a705-4a31-a345-a36d436ae561.jpg?1",
             "name": "Deeproot Pilgrimage",
             "text": "Whenever one or more nontoken Merfolk you control become tapped, create a 1/1 blue Merfolk creature token with hexproof.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "88f6f49d-4c48-55e5-87fc-6777a8f5978b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c068b2e-17cc-4fb8-bd79-b775a4713d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c068b2e-17cc-4fb8-bd79-b775a4713d74.jpg?1",
             "name": "Didact Echo",
             "text": "When Didact Echo enters the battlefield, draw a card.\nDescend 4 \u2014 Didact Echo has flying as long as there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -2053,7 +2053,7 @@
         },
         {
             "id": "40dff87f-3950-5fe4-aeac-1e97fe0ef8fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c504ef-2382-4174-9b1d-5f38e12a28fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c504ef-2382-4174-9b1d-5f38e12a28fc.jpg?1",
             "name": "Eaten by Piranhas",
             "text": "Flash\nEnchant creature\nEnchanted creature loses all abilities and is a black Skeleton creature with base power and toughness 1/1. (It loses all other card types and creature types.)",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "7425b8e1-e6d4-53c4-9a72-0db911baa48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "a353f5d9-8fbd-5125-81c6-3e88351619b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2e98970d-06a8-4c91-ba47-4a02c5b949f2.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "eb44b7cf-6a50-51ee-ac08-8047874c5e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [
@@ -2195,7 +2195,7 @@
         },
         {
             "id": "241f7226-4d6b-5542-a24d-e72c006d450b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf573fb7-fa6c-4df7-8e5e-1e071585361e.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [],
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "9fc37be7-9981-5732-b501-81d651d10d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65e1bc-fade-4fdf-a1fd-de068bff9e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65e1bc-fade-4fdf-a1fd-de068bff9e4c.jpg?1",
             "name": "Frilled Cave-Wurm",
             "text": "Descend 4 \u2014 Frilled Cave-Wurm gets +2/+0 as long as there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -2265,7 +2265,7 @@
         },
         {
             "id": "ada46e23-22c3-52af-a341-8dcc894615ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545503f8-a8c6-4518-9ad6-76e4996397fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545503f8-a8c6-4518-9ad6-76e4996397fc.jpg?1",
             "name": "Hermitic Nautilus",
             "text": "Vigilance\n{1}{U}: Hermitic Nautilus gets +3/-3 until end of turn.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "1e8f44a5-fd9c-5ba1-bdec-186df38d2ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5946463a-2240-4376-b6f5-fd6e3a9cc51c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5946463a-2240-4376-b6f5-fd6e3a9cc51c.jpg?1",
             "name": "Hurl into History",
             "text": "Counter target artifact or creature spell. Discover X, where X is that spell's mana value. (Exile cards from the top of your library until you exile a nonland card with that mana value or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "feb9c975-368a-50fd-9ece-c3a6c734e841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1",
             "name": "Inverted Iceberg // Iceberg Titan",
             "text": "",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "cf9082d6-607b-54c6-addb-32d2540822dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1",
             "name": "Inverted Iceberg // Iceberg Titan",
             "text": "",
             "colours": [
@@ -2399,7 +2399,7 @@
         },
         {
             "id": "ac7a2020-caaf-571a-a2ac-58266aaea366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03207457-70d8-4462-8c8b-ed39791d56a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03207457-70d8-4462-8c8b-ed39791d56a1.jpg?1",
             "name": "Kitesail Larcenist",
             "text": "Flying, ward {1}\nWhen Kitesail Larcenist enters the battlefield, for each player, choose up to one other target artifact or creature that player controls. For as long as Kitesail Larcenist remains on the battlefield, the chosen permanents become Treasure artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color\" and lose all other abilities.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "7e5745ac-a79d-53f2-90f8-bc20797cd8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1",
             "name": "Lodestone Needle // Guidestone Compass",
             "text": "",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "3ed12a09-70ff-5e04-8f96-123cb4378c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1",
             "name": "Lodestone Needle // Guidestone Compass",
             "text": "",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "e4dba3c8-4cee-5610-8b6c-e933a81b455c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6834d-afa3-4747-a62d-0654f4d9729f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d6834d-afa3-4747-a62d-0654f4d9729f.jpg?1",
             "name": "Malcolm, Alluring Scoundrel",
             "text": "Flash\nFlying\nWhenever Malcolm, Alluring Scoundrel deals combat damage to a player, put a chorus counter on it. Draw a card, then discard a card. If there are four or more chorus counters on Malcolm, you may cast the discarded card without paying its mana cost.",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "5e7dfaef-5bfa-5029-b359-8ca0b1455ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78328899-7996-4cfd-bf00-d2a0d0ff3ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78328899-7996-4cfd-bf00-d2a0d0ff3ef8.jpg?1",
             "name": "Marauding Brinefang",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "066767b1-f7a7-50f0-91e8-1382d50a79b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0fe81c-b8ef-49ff-8743-f03d0220cb9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0fe81c-b8ef-49ff-8743-f03d0220cb9e.jpg?1",
             "name": "Merfolk Cave-Diver",
             "text": "Whenever a creature you control explores, Merfolk Cave-Diver gets +1/+0 until end of turn and can't be blocked this turn.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "d108f286-3454-54cc-8094-b6c0aa4cc554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg?1",
             "name": "Oaken Siren",
             "text": "Flying, vigilance\n{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "ae8f37ef-6177-5f65-9df8-3c19da12d793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "5e9aeb7f-7f3e-5c3a-8e45-e938230b14bc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [],
@@ -2714,7 +2714,7 @@
         },
         {
             "id": "55e3737b-e0c3-5795-a092-951a4c3598b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27acf726-52f5-493d-8678-c12485f67747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27acf726-52f5-493d-8678-c12485f67747.jpg?1",
             "name": "Orazca Puzzle-Door",
             "text": "{1}, {T}, Sacrifice Orazca Puzzle-Door: Look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
             "colours": [
@@ -2746,7 +2746,7 @@
         },
         {
             "id": "cf8d1748-d194-55e4-8b63-49d5ed81e84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg?1",
             "name": "Out of Air",
             "text": "This spell costs {2} less to cast if it targets a creature spell.\nCounter target spell.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "25b0b6dd-e86f-5456-8c0e-b3003a5462ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d11e3d4-769d-47aa-8d3a-ce1ac60b68b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d11e3d4-769d-47aa-8d3a-ce1ac60b68b8.jpg?1",
             "name": "Pirate Hat",
             "text": "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, draw a card, then discard a card.\"\nEquip Pirate {1}\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "9708c4f1-921d-5880-ad70-5d3c8d8c2482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35096eb3-ad7b-4b6e-b799-cb4cc447883e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35096eb3-ad7b-4b6e-b799-cb4cc447883e.jpg?1",
             "name": "Relic's Roar",
             "text": "Until end of turn, target artifact or creature becomes a Dinosaur artifact creature with base power and toughness 4/3 in addition to its other types.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "63e1d6de-83b0-564b-8118-787228e33d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae8ab66-5840-4b2e-bd4e-94ead0c79b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae8ab66-5840-4b2e-bd4e-94ead0c79b61.jpg?1",
             "name": "River Herald Scout",
             "text": "When River Herald Scout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "013b2841-8007-5c68-a6b9-a053c0c49224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e53495-c76c-4cd4-b93e-b2c491d2c13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e53495-c76c-4cd4-b93e-b2c491d2c13a.jpg?1",
             "name": "Sage of Days",
             "text": "When Sage of Days enters the battlefield, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
             "colours": [
@@ -2914,7 +2914,7 @@
         },
         {
             "id": "ad7803e2-7dc5-5741-981b-5e4a10fb96dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1242203d-c9b5-4ab6-802e-e222f92291e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1242203d-c9b5-4ab6-802e-e222f92291e9.jpg?1",
             "name": "Self-Reflection",
             "text": "Create a token that's a copy of target creature you control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "51288f6c-be62-5ed2-a535-8cdf6ab510b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814803bc-72cd-46db-b957-4322f2a7b28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814803bc-72cd-46db-b957-4322f2a7b28a.jpg?1",
             "name": "Shipwreck Sentry",
             "text": "Defender\nAs long as an artifact entered the battlefield under your control this turn, Shipwreck Sentry can attack as though it didn't have defender.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "f6e6b59f-1f80-51b8-9e44-20b74ebddce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58639c-001f-4cb1-89fd-0a0967b86977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58639c-001f-4cb1-89fd-0a0967b86977.jpg?1",
             "name": "Sinuous Benthisaur",
             "text": "When Sinuous Benthisaur enters the battlefield, look at the top X cards of your library, where X is the number of Caves you control plus the number of Cave cards in your graveyard. Put two of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "795c4128-5608-5cfa-8ef0-4e4bc6245081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8f7a75-df5e-43b3-8c33-328ad0dc3c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8f7a75-df5e-43b3-8c33-328ad0dc3c40.jpg?1",
             "name": "Song of Stupefaction",
             "text": "Enchant creature or Vehicle\nWhen Song of Stupefaction enters the battlefield, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nFathomless descent \u2014 Enchanted permanent gets -X/-0, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "9560dd53-5303-54e2-b5fc-bfae92db36a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e54343-95e5-4dc4-9f18-e4a415fe5e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e54343-95e5-4dc4-9f18-e4a415fe5e0a.jpg?1",
             "name": "Spyglass Siren",
             "text": "Flying\nWhen Spyglass Siren enters the battlefield, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -3086,7 +3086,7 @@
         },
         {
             "id": "d84e0e4c-0ed2-5aed-bb30-1f73c5a1b88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9845-8a11-4fc4-b116-29a929985146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9845-8a11-4fc4-b116-29a929985146.jpg?1",
             "name": "Staunch Crewmate",
             "text": "When Staunch Crewmate enters the battlefield, look at the top four cards of your library. You may reveal an artifact or Pirate card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "1dc0553b-6e6f-5982-a43d-697a18aae0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b6881a-b00e-4e90-92e6-602ed8e0e090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b6881a-b00e-4e90-92e6-602ed8e0e090.jpg?1",
             "name": "Subterranean Schooner",
             "text": "Whenever Subterranean Schooner attacks, target creature that crewed it this turn explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)\nCrew 1",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "d9c396f8-c423-54d6-87d8-cff54b358593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b3d1d-8c85-4707-80b5-c4d832df9846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907b3d1d-8c85-4707-80b5-c4d832df9846.jpg?1",
             "name": "Tishana's Tidebinder",
             "text": "Flash\nWhen Tishana's Tidebinder enters the battlefield, counter up to one target activated or triggered ability. If an ability of an artifact, creature, or planeswalker is countered this way, that permanent loses all abilities for as long as Tishana's Tidebinder remains on the battlefield. (Mana abilities can't be targeted.)",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "335eb602-64d9-5657-ac0c-9e5fc77c1ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebb2df-8891-434e-9cd0-f25b848cb754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebb2df-8891-434e-9cd0-f25b848cb754.jpg?1",
             "name": "Unlucky Drop",
             "text": "Target artifact or creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -3226,7 +3226,7 @@
         },
         {
             "id": "2f43b4c8-b207-5fcb-b9f4-f33bcc9c4f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1",
             "name": "Waterlogged Hulk // Watertight Gondola",
             "text": "",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "2d2facd0-de51-52cc-b3a9-4d851512fd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1",
             "name": "Waterlogged Hulk // Watertight Gondola",
             "text": "",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "c38fba30-7f25-57df-a674-aecb47d1031f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7738fb-0a1b-4010-b8c0-e1129739c765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7738fb-0a1b-4010-b8c0-e1129739c765.jpg?1",
             "name": "Waterwind Scout",
             "text": "Flying\nWhen Waterwind Scout enters the battlefield, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "51bc29a8-78c8-548e-9cfb-db0c412ddde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2bb06-7163-47fe-bede-9c192c9b8952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2bb06-7163-47fe-bede-9c192c9b8952.jpg?1",
             "name": "Waylaying Pirates",
             "text": "When Waylaying Pirates enters the battlefield, if you control an artifact, tap target artifact or creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -3362,7 +3362,7 @@
         },
         {
             "id": "65e895e7-a6ea-5f56-9778-51be4bc4bf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f498ac-179e-4055-9b83-97bcc5ab1bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f498ac-179e-4055-9b83-97bcc5ab1bb9.jpg?1",
             "name": "Zoetic Glyph",
             "text": "Enchant artifact\nEnchanted artifact is a Golem creature with base power and toughness 5/4 in addition to its other types.\nWhen Zoetic Glyph is put into a graveyard from the battlefield, discover 3.",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "9dab74b6-103d-5dad-a7eb-91b66fd0f2ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559f77f-1f10-475b-9361-7f297d50f254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559f77f-1f10-475b-9361-7f297d50f254.jpg?1",
             "name": "Abyssal Gorestalker",
             "text": "When Abyssal Gorestalker enters the battlefield, each player sacrifices two creatures.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "d5b57b40-e57e-5c6a-8fc8-52a57dec51fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "028b6a88-806f-5c4d-b0e7-de3fe6f50ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [],
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "2140ad02-1240-5bc1-aa78-1b5b608f14c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99009400-ffa4-40af-8305-78295ae605ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99009400-ffa4-40af-8305-78295ae605ac.jpg?1",
             "name": "Acolyte of Aclazotz",
             "text": "{T}, Sacrifice another creature or artifact: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "10444841-d550-553e-8190-d2fb3294ef32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d9eb9f-2fcc-49f0-99c1-bad748239466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d9eb9f-2fcc-49f0-99c1-bad748239466.jpg?1",
             "name": "Another Chance",
             "text": "You may mill two cards. Then return up to two creature cards from your graveyard to your hand. (To mill two cards, put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "35789897-27ae-532f-a8de-90c01b62c57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bdd22c-3e11-4c29-bdfa-d3dfc0e90a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bdd22c-3e11-4c29-bdfa-d3dfc0e90a9f.jpg?1",
             "name": "Bitter Triumph",
             "text": "As an additional cost to cast this spell, discard a card or pay 3 life.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "dce4a5ae-3282-5a05-907d-9284a6880f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6027a-003a-4f9d-929a-0b6da1fa42c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6027a-003a-4f9d-929a-0b6da1fa42c9.jpg?1",
             "name": "Bloodletter of Aclazotz",
             "text": "Flying\nIf an opponent would lose life during your turn, they lose twice that much life instead. (Damage causes loss of life.)",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "0a2e07fa-bc01-5b6e-ba2d-fffee4f7f019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db38babd-57e8-4e59-9701-11a0682baa77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db38babd-57e8-4e59-9701-11a0682baa77.jpg?1",
             "name": "Bloodthorn Flail",
             "text": "Equipped creature gets +2/+1.\nEquip\u2014\nPay {3} or discard a card.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "b55489ac-5af3-58a2-ac12-df7006b2aaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19775c18-4cc0-49d3-86e4-0841768cbf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19775c18-4cc0-49d3-86e4-0841768cbf4d.jpg?1",
             "name": "Bringer of the Last Gift",
             "text": "Flying\nWhen Bringer of the Last Gift enters the battlefield, if you cast it, each player sacrifices all other creatures they control. Then each player returns all creature cards from their graveyard that weren't put there this way to the battlefield.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "2eac678e-b95a-5014-82ce-e2c3fff11a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08318a16-a9ed-42c8-9433-876b7a72e368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08318a16-a9ed-42c8-9433-876b7a72e368.jpg?1",
             "name": "Broodrage Mycoid",
             "text": "At the beginning of your end step, if you descended this turn, create a 1/1 black Fungus creature token with \"This creature can't block.\" (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "b3795668-9527-5409-8f49-46148dffc32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b6892-5dfc-4607-b511-cf83544a9357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b6892-5dfc-4607-b511-cf83544a9357.jpg?1",
             "name": "Canonized in Blood",
             "text": "At the beginning of your end step, if you descended this turn, put a +1/+1 counter on target creature you control. (You descended if a permanent card was put into your graveyard from anywhere.)\n{5}{B}{B}, Sacrifice Canonized in Blood: Create a 4/3 white and black Vampire Demon creature token with flying.",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "8c30794f-3057-5775-ab5e-03c351ebe356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd8eed6-91da-4454-a5e3-7bbfac614f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd8eed6-91da-4454-a5e3-7bbfac614f47.jpg?1",
             "name": "Chupacabra Echo",
             "text": "Fathomless descent \u2014 When Chupacabra Echo enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -3810,7 +3810,7 @@
         },
         {
             "id": "31c7fe65-e9db-5c1b-bce8-da06b60668d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1",
             "name": "Corpses of the Lost",
             "text": "Skeletons you control get +1/+0 and have haste.\nWhen Corpses of the Lost enters the battlefield, create a 2/2 black Skeleton Pirate creature token.\nAt the beginning of your end step, if you descended this turn, you may pay 1 life. If you do, return Corpses of the Lost to its owner's hand. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -3844,7 +3844,7 @@
         },
         {
             "id": "e30a2047-0552-5b4f-9fa3-9bb571e0f91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e6b971-3f5b-47e7-8209-98d72ee781fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e6b971-3f5b-47e7-8209-98d72ee781fc.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -3878,7 +3878,7 @@
         },
         {
             "id": "5c29a9cd-52d7-5b6f-8f46-67c23d4f7e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc9d22c-dfce-4136-aed8-a5fe9bb852f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc9d22c-dfce-4136-aed8-a5fe9bb852f2.jpg?1",
             "name": "Deathcap Marionette",
             "text": "Deathtouch\nWhen Deathcap Marionette enters the battlefield, you may mill two cards. (You may put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -3912,7 +3912,7 @@
         },
         {
             "id": "931027c6-7291-5ca5-bc17-128a5483c6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b24bb7c-6b34-48b6-af94-f312ebdbb759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b24bb7c-6b34-48b6-af94-f312ebdbb759.jpg?1",
             "name": "Deep Goblin Skulltaker",
             "text": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Deep Goblin Skulltaker. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "45db1587-d9aa-55d5-a64a-7437928a2564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c68c95-b788-43b1-9f22-1b22c5a00b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c68c95-b788-43b1-9f22-1b22c5a00b25.jpg?1",
             "name": "Deep-Cavern Bat",
             "text": "Flying, lifelink\nWhen Deep-Cavern Bat enters the battlefield, look at target opponent's hand. You may exile a nonland card from it until Deep-Cavern Bat leaves the battlefield.",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "a50ff94a-727c-564f-9c64-13ece44f823f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9abaec-af72-4399-b162-5e62e7487242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9abaec-af72-4399-b162-5e62e7487242.jpg?1",
             "name": "Defossilize",
             "text": "Return target creature card from your graveyard to the battlefield. That creature explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "d85f3081-9d6e-5ec0-b2bf-ec2957e1f4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319a457c-89b7-47f6-a13c-20bb50d41138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/319a457c-89b7-47f6-a13c-20bb50d41138.jpg?1",
             "name": "Echo of Dusk",
             "text": "Descend 4 \u2014 As long as there are four or more permanent cards in your graveyard, Echo of Dusk gets +1/+1 and has lifelink.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "76b0e955-6216-5a7e-900a-55c9ebbe8925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d896dd52-b134-4b55-ab91-ccb05ecc50f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d896dd52-b134-4b55-ab91-ccb05ecc50f4.jpg?1",
             "name": "Fanatical Offering",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "4ef7a422-64f0-5588-8185-1b8a66c8bb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2bd0ca-521c-45d9-85ed-2f36f583408e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d2bd0ca-521c-45d9-85ed-2f36f583408e.jpg?1",
             "name": "Fungal Fortitude",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+0.\nWhen enchanted creature dies, return it to the battlefield tapped under its owner's control.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "d04430dc-b671-5ae6-af29-78bdc6eb92cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94724efb-4785-4751-9fe1-07f243dd6008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94724efb-4785-4751-9fe1-07f243dd6008.jpg?1",
             "name": "Gargantuan Leech",
             "text": "This spell costs {1} less to cast for each Cave you control and each Cave card in your graveyard.\nLifelink",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "5f9f8a16-6934-5635-b915-83ef9ec9fe98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg?1",
             "name": "Grasping Shadows // Shadows' Lair",
             "text": "",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "5c7acdf9-cf71-5973-9690-d7fd32ecb5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/81b8b9c9-725d-476d-a3cf-55e3dc3e433d.jpg?1",
             "name": "Grasping Shadows // Shadows' Lair",
             "text": "",
             "colours": [],
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "e7530ea8-4bfd-531c-82c1-8fec496afb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692fe4e8-13b4-4bec-938e-a8073a7fbd71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692fe4e8-13b4-4bec-938e-a8073a7fbd71.jpg?1",
             "name": "Greedy Freebooter",
             "text": "When Greedy Freebooter dies, scry 1 and create a Treasure token. (To scry 1, look at the top card of your library. You may put that card on the bottom. A Treasure token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "402fc9fe-c387-5771-9e03-e4f863d7a0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg?1",
             "name": "Join the Dead",
             "text": "Target creature gets -5/-5 until end of turn.\nDescend 4 \u2014 That creature gets -10/-10 until end of turn instead if there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "2b7892c8-fb92-53a6-9d62-93884c6b6e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2796fffa-8cbf-4ec9-91a8-7b6f39fd50ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2796fffa-8cbf-4ec9-91a8-7b6f39fd50ec.jpg?1",
             "name": "Malicious Eclipse",
             "text": "All creatures get -2/-2 until end of turn. If a creature an opponent controls would die this turn, exile it instead.",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "5204fa9e-de36-578b-b7d4-23483c68970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcae196-dbcc-44d5-b700-c57b0b646483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcae196-dbcc-44d5-b700-c57b0b646483.jpg?1",
             "name": "Mephitic Draught",
             "text": "When Mephitic Draught enters the battlefield or is put into a graveyard from the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "e756d193-31e8-530c-a0ae-0040ec733ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89345f55-2b32-4356-945a-d56dded39909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89345f55-2b32-4356-945a-d56dded39909.jpg?1",
             "name": "Preacher of the Schism",
             "text": "Deathtouch\nWhenever Preacher of the Schism attacks the player with the most life or tied for most life, create a 1/1 white Vampire creature token with lifelink.\nWhenever Preacher of the Schism attacks while you have the most life or are tied for most life, you draw a card and you lose 1 life.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "fb20199b-547b-593f-a0bc-3140d3907e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f5ad0-e9c1-4e45-b245-2946e29baecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f5ad0-e9c1-4e45-b245-2946e29baecb.jpg?1",
             "name": "Primordial Gnawer",
             "text": "When Primordial Gnawer dies, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "40d30848-c5a7-566f-a252-9db8fbeb84ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg?1",
             "name": "Queen's Bay Paladin",
             "text": "Whenever Queen's Bay Paladin enters the battlefield or attacks, return up to one target Vampire card from your graveyard to the battlefield with a finality counter on it. You lose life equal to its mana value. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "f8787d76-bdc6-5b8b-bbbd-e3bb01d9910e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad0adcb-80e5-4c6d-bcdd-9e5d18c017b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad0adcb-80e5-4c6d-bcdd-9e5d18c017b3.jpg?1",
             "name": "Rampaging Spiketail",
             "text": "When Rampaging Spiketail enters the battlefield, target creature you control gets +2/+0 and gains indestructible until end of turn.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "b2ab463f-6623-5954-b940-095697450ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d440d90e-ac7e-4715-971a-700c977c7fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d440d90e-ac7e-4715-971a-700c977c7fde.jpg?1",
             "name": "Ray of Ruin",
             "text": "Exile target creature, Vehicle, or nonbasic land. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "fbc70c15-74b8-5c39-a308-9dde4fc1495c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2f3efb-1526-48c0-842a-374af63ea467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2f3efb-1526-48c0-842a-374af63ea467.jpg?1",
             "name": "Screaming Phantom",
             "text": "Flying\nWhenever Screaming Phantom attacks, mill a card. (Put the top card of your library into your graveyard.)",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "9e8802df-a81e-5a17-a27c-3c870581f4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d96d019-5d80-468a-b891-e3e99346372a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d96d019-5d80-468a-b891-e3e99346372a.jpg?1",
             "name": "Skullcap Snail",
             "text": "When Skullcap Snail enters the battlefield, target opponent exiles a card from their hand.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "bb94f29d-dea5-5f3a-b2a5-3656385bdc00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1125fdf2-2dbb-49a6-b76f-8cd6c3d6fab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1125fdf2-2dbb-49a6-b76f-8cd6c3d6fab4.jpg?1",
             "name": "Soulcoil Viper",
             "text": "{B}, {T}, Sacrifice Soulcoil Viper: Return target creature card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "c175fbcf-103a-5e70-b87b-a0e7808dfa85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg?1",
             "name": "Souls of the Lost",
             "text": "As an additional cost to cast this spell, discard a card or sacrifice a permanent.\nFathomless descent \u2014 Souls of the Lost's power is equal to the number of permanent cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "e56cdb90-3c68-5d53-a6fa-529c65c075ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5319c0b1-de54-492a-bdea-85a5a75d693e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5319c0b1-de54-492a-bdea-85a5a75d693e.jpg?1",
             "name": "Stalactite Stalker",
             "text": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Stalactite Stalker. (You descended if a permanent card was put into your graveyard from anywhere.)\n{2}{B}, Sacrifice Stalactite Stalker: Target creature gets -X/-X until end of turn, where X is Stalactite Stalker's power.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "d2bcd953-b25c-5f72-9487-9b69ec6891ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg?1",
             "name": "Starving Revenant",
             "text": "When Starving Revenant enters the battlefield, surveil 2. Then for each card you put on top of your library, you draw a card and you lose 3 life.\nDescend 8 \u2014 Whenever you draw a card, if there are eight or more permanent cards in your graveyard, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "3e84981b-fafc-524e-8d81-5b63bb5b897e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a230208-84ae-4f48-afbd-a0d50596ad27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a230208-84ae-4f48-afbd-a0d50596ad27.jpg?1",
             "name": "Stinging Cave Crawler",
             "text": "Deathtouch\nDescend 4 \u2014 Whenever Stinging Cave Crawler attacks, if there are four or more permanent cards in your graveyard, you draw a card and you lose 1 life.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "8c19468c-3738-560e-8419-ba1e52e73ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg?1",
             "name": "Synapse Necromage",
             "text": "When Synapse Necromage dies, create two 1/1 black Fungus creature tokens with \"This creature can't block.\"",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "149669b4-972d-5e3d-8f16-5cc4a12f632e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "376b2c19-7693-522d-abca-39d852e3a5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99255a66-b868-45fc-a2a9-0c89bd851b69.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [],
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "338a9018-33f9-52ba-9464-44328acd9e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a281d2c-20b9-4887-a924-9be6c07b7629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a281d2c-20b9-4887-a924-9be6c07b7629.jpg?1",
             "name": "Terror Tide",
             "text": "Fathomless descent \u2014 All creatures get -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "e395ab8e-ec66-5f5c-a7d2-5ce3f1591998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1",
             "name": "Tithing Blade // Consuming Sepulcher",
             "text": "",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "b574deaa-3d3c-5ee9-8d1e-467200e376d6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1",
             "name": "Tithing Blade // Consuming Sepulcher",
             "text": "",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "022d74a3-def7-59a2-ae7b-3c66fa53b87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg?1",
             "name": "Visage of Dread // Dread Osseosaur",
             "text": "",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "90f77a9f-ab73-5a50-af96-ea120f211dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d4b61c6-3e88-49f5-9e16-aa8a59653327.jpg?1",
             "name": "Visage of Dread // Dread Osseosaur",
             "text": "",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "8973b27b-24b7-5888-91e8-123d52f82051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9030048a-b866-4a89-8d4a-aa55411463e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9030048a-b866-4a89-8d4a-aa55411463e4.jpg?1",
             "name": "Vito's Inquisitor",
             "text": "{B}, Sacrifice another creature or artifact: Put a +1/+1 counter on Vito's Inquisitor. It gains menace until end of turn.",
             "colours": [
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "44eabec6-851c-5942-8b3f-50ba39452c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f39b5e-2e85-4f31-bbab-0b0bf58f701d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f39b5e-2e85-4f31-bbab-0b0bf58f701d.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5108,7 +5108,7 @@
         },
         {
             "id": "1d42fece-0e15-57d8-b675-3f547045be94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d5b7d-e27d-42d6-ba7a-d4a6b0dd8549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d5b7d-e27d-42d6-ba7a-d4a6b0dd8549.jpg?1",
             "name": "Ancestors' Aid",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "ae40803c-d58f-5ada-8c28-debf22a9a52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2debca-8535-4cf6-a461-c268faaacaae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2debca-8535-4cf6-a461-c268faaacaae.jpg?1",
             "name": "Belligerent Yearling",
             "text": "Trample\nWhenever another Dinosaur enters the battlefield under your control, you may have Belligerent Yearling's base power become equal to that creature's power until end of turn.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "b09fa20f-c822-51bd-b0f9-0d669b182b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220ed60-3f8f-4dd2-8319-6a06896a5350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220ed60-3f8f-4dd2-8319-6a06896a5350.jpg?1",
             "name": "Bonehoard Dracosaur",
             "text": "Flying, first strike\nAt the beginning of your upkeep, exile the top two cards of your library. You may play them this turn. If you exiled a land card this way, create a 3/1 red Dinosaur creature token. If you exiled a nonland card this way, create a Treasure token.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "295fd7d7-e6c0-55c2-b75a-ac769832b5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "3890c69d-65fa-55c2-95e1-fd5f03159372",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d61d8895-7f2e-4c77-951f-4f1a49e96f57.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [],
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "f2befba0-297a-5cec-907b-f88caa066bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9e0c66-f64a-428c-be13-a52691833df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9e0c66-f64a-428c-be13-a52691833df1.jpg?1",
             "name": "Brazen Blademaster",
             "text": "Whenever Brazen Blademaster attacks while you control two or more artifacts, it gets +2/+1 until end of turn.",
             "colours": [
@@ -5320,7 +5320,7 @@
         },
         {
             "id": "7fb9b8a4-421d-5542-9d93-e0551944dd0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf5028-8dfe-40d3-89b4-22bd7ed0aae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf5028-8dfe-40d3-89b4-22bd7ed0aae6.jpg?1",
             "name": "Breeches, Eager Pillager",
             "text": "First strike\nWhenever a Pirate you control attacks, choose one that hasn't been chosen this turn \u2014\n\u2022 Create a Treasure token.\n\u2022 Target creature can't block this turn.\n\u2022 Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -5359,7 +5359,7 @@
         },
         {
             "id": "044adcac-fcff-5081-8df9-cd517cd6aab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c491ac0-4752-47a7-967e-456b6e4245de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c491ac0-4752-47a7-967e-456b6e4245de.jpg?1",
             "name": "Burning Sun Cavalry",
             "text": "Whenever Burning Sun Cavalry attacks or blocks while you control a Dinosaur, Burning Sun Cavalry gets +1/+1 until end of turn.",
             "colours": [
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "d1837b03-64d6-5952-b831-9aba1ed54243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8341ddd9-aac1-4773-b8ce-51e35f696263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8341ddd9-aac1-4773-b8ce-51e35f696263.jpg?1",
             "name": "Calamitous Cave-In",
             "text": "Calamitous Cave-In deals X damage to each creature and each planeswalker, where X is the number of Caves you control plus the number of Cave cards in your graveyard.",
             "colours": [
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "6b3121dc-fa61-570e-9075-804c20e4a989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e964f026-9cbf-4fa2-acdc-60d19b88f183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e964f026-9cbf-4fa2-acdc-60d19b88f183.jpg?1",
             "name": "Child of the Volcano",
             "text": "Trample\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Child of the Volcano. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -5460,7 +5460,7 @@
         },
         {
             "id": "8c180975-85da-50b2-ad3f-57bb3b8e4879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a144d0b3-678d-4f4c-a9b0-22af19f5cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a144d0b3-678d-4f4c-a9b0-22af19f5cf9f.jpg?1",
             "name": "Curator of Sun's Creation",
             "text": "Whenever you discover, discover again for the same value. This ability triggers only once each turn.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "af6f662a-bed6-5be9-8cc0-e7d0a789e07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95018a4-be10-4c46-b14d-4b1eba838bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95018a4-be10-4c46-b14d-4b1eba838bc0.jpg?1",
             "name": "Daring Discovery",
             "text": "Up to three target creatures can't block this turn.\nDiscover 4. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -5527,7 +5527,7 @@
         },
         {
             "id": "47daaac6-622d-5e66-a709-820a9ba2a0da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae30fa7-3d1d-417f-80d7-a668236cb2c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae30fa7-3d1d-417f-80d7-a668236cb2c1.jpg?1",
             "name": "Diamond Pick-Axe",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.)\nEquipped creature gets +1/+1 and has \"Whenever this creature attacks, create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquip {2}",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "a5089709-142c-5ddd-ace5-01cae951323f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1a93e-ec71-45fa-b0b8-2c21123e390c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1a93e-ec71-45fa-b0b8-2c21123e390c.jpg?1",
             "name": "Dinotomaton",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Dinotomaton enters the battlefield, target creature you control gains menace until end of turn.",
             "colours": [
@@ -5597,7 +5597,7 @@
         },
         {
             "id": "a6794b02-f81e-5574-bf66-80bbc0114d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -5633,7 +5633,7 @@
         },
         {
             "id": "ca41e9ce-b7c4-5fc1-8ddc-2b21b31a7f10",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d2d98ae-fe02-4a86-9e80-7b95e08de21c.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -5669,7 +5669,7 @@
         },
         {
             "id": "df02e122-9e54-57f9-a0e8-b27c3b6776f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg?1",
             "name": "Dowsing Device // Geode Grotto",
             "text": "",
             "colours": [
@@ -5701,7 +5701,7 @@
         },
         {
             "id": "fe27fbe8-9d40-5c99-93e7-a4aabdd91fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d715e9f-223d-462e-8ce3-eebbaf1cd021.jpg?1",
             "name": "Dowsing Device // Geode Grotto",
             "text": "",
             "colours": [],
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "30134751-b231-529d-8b69-6bac974f8a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062e00a1-f1dc-4089-b640-800ab781c590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062e00a1-f1dc-4089-b640-800ab781c590.jpg?1",
             "name": "Dreadmaw's Ire",
             "text": "Until end of turn, target attacking creature gets +2/+2 and gains trample and \"Whenever this creature deals combat damage to a player, destroy target artifact that player controls.\"",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "d59284e8-5616-59da-8975-5ed6723b2c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44420f52-2ed8-4f81-93e4-5decc77bed01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44420f52-2ed8-4f81-93e4-5decc77bed01.jpg?1",
             "name": "Enterprising Scallywag",
             "text": "At the beginning of your end step, if you descended this turn, create a Treasure token. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "e28c0841-80f2-56cd-9a85-4edf22ca4ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4075a8-c15d-4078-bf4b-0f85c03fecec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4075a8-c15d-4078-bf4b-0f85c03fecec.jpg?1",
             "name": "Etali's Favor",
             "text": "Enchant creature you control\nWhen Etali's Favor enters the battlefield, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)\nEnchanted creature gets +1/+1 and has trample.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "8d055292-a68b-5883-b9f8-92d4f15565d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c1a82-695b-4df2-8e51-2d71a62e7baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c1a82-695b-4df2-8e51-2d71a62e7baf.jpg?1",
             "name": "Geological Appraiser",
             "text": "When Geological Appraiser enters the battlefield, if you cast it, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -5871,7 +5871,7 @@
         },
         {
             "id": "a3aa44df-8e58-5f56-b9e5-6de02348a9fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dec77b-e790-48b8-8c13-91305d9f97ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dec77b-e790-48b8-8c13-91305d9f97ce.jpg?1",
             "name": "A-Geological Appraiser",
             "text": "",
             "colours": [
@@ -5905,7 +5905,7 @@
         },
         {
             "id": "01490ea5-eac1-5be1-b95f-e1af9f2c0f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018160fe-f602-43f5-8495-241a08eaa69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018160fe-f602-43f5-8495-241a08eaa69c.jpg?1",
             "name": "Goblin Tomb Raider",
             "text": "As long as you control an artifact, Goblin Tomb Raider gets +1/+0 and has haste.",
             "colours": [
@@ -5940,7 +5940,7 @@
         },
         {
             "id": "5cbea8fc-d00d-505d-8ab3-256cf510e2b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415904fe-b77f-4c1a-850f-688484d629e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415904fe-b77f-4c1a-850f-688484d629e6.jpg?1",
             "name": "Goldfury Strider",
             "text": "Trample\nTap two untapped artifacts and/or creatures you control: Target creature gets +2/+0 until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "9734b99b-7c13-576b-a05e-14a405aee7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg?1",
             "name": "Hit the Mother Lode",
             "text": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference. (To discover 10, exile cards from the top of your library until you exile a nonland card with mana value 10 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -6010,7 +6010,7 @@
         },
         {
             "id": "72777e08-b27c-5bf2-942c-d8f3da90677b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87468b6b-6f78-42e4-ab0d-6730aeecdc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87468b6b-6f78-42e4-ab0d-6730aeecdc3f.jpg?1",
             "name": "Hotfoot Gnome",
             "text": "Haste\n{T}: Another target creature gains haste until end of turn.",
             "colours": [
@@ -6045,7 +6045,7 @@
         },
         {
             "id": "8f6ce616-2351-5977-a5cb-36d8b81081f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1",
             "name": "Idol of the Deep King // Sovereign's Macuahuitl",
             "text": "",
             "colours": [
@@ -6077,7 +6077,7 @@
         },
         {
             "id": "ab79e26b-c7be-5443-b42e-37a1242c18fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1",
             "name": "Idol of the Deep King // Sovereign's Macuahuitl",
             "text": "",
             "colours": [
@@ -6111,7 +6111,7 @@
         },
         {
             "id": "2bdacef4-4c48-53b9-8644-1d890fb4a2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7a55aa-ae61-4933-b7a4-dcc55dac6fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7a55aa-ae61-4933-b7a4-dcc55dac6fcd.jpg?1",
             "name": "Inti, Seneschal of the Sun",
             "text": "Whenever you attack, you may discard a card. When you do, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.\nWhenever you discard one or more cards, exile the top card of your library. You may play that card until your next end step.",
             "colours": [
@@ -6150,7 +6150,7 @@
         },
         {
             "id": "ed27cd7c-8283-565d-af99-6eab078080e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471a833-11b9-4146-a9c0-84a6896c94d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471a833-11b9-4146-a9c0-84a6896c94d8.jpg?1",
             "name": "Magmatic Galleon",
             "text": "When Magmatic Galleon enters the battlefield, it deals 5 damage to target creature an opponent controls.\nWhenever one or more creatures your opponents control are dealt excess noncombat damage, create a Treasure token.\nCrew 2",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "b1ff7c42-75e8-5c0c-8c29-a2f0bb987517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "cec0ffae-7a03-51be-a750-0f958492ff20",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [],
@@ -6256,7 +6256,7 @@
         },
         {
             "id": "12259bd4-a689-5887-a8cd-686652faba7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad371c97-a266-4a88-9d28-2e889a37ba00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad371c97-a266-4a88-9d28-2e889a37ba00.jpg?1",
             "name": "Panicked Altisaur",
             "text": "Reach\n{T}: Panicked Altisaur deals 2 damage to each opponent.",
             "colours": [
@@ -6290,7 +6290,7 @@
         },
         {
             "id": "5e684366-7a6c-5619-8fd4-77dc41b17175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb2552f-8370-4931-83e1-93706d51413a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb2552f-8370-4931-83e1-93706d51413a.jpg?1",
             "name": "Plundering Pirate",
             "text": "When Plundering Pirate enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6325,7 +6325,7 @@
         },
         {
             "id": "9ad52490-8541-5257-aa4c-b465cc93a808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg?1",
             "name": "Poetic Ingenuity",
             "text": "Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.\nWhenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. This ability triggers only once each turn.",
             "colours": [
@@ -6359,7 +6359,7 @@
         },
         {
             "id": "01811d3f-d839-5da0-9099-8e0d7a299720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bab3f8f-cb06-466d-a35d-0b5e1a2b524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bab3f8f-cb06-466d-a35d-0b5e1a2b524c.jpg?1",
             "name": "Rampaging Ceratops",
             "text": "Rampaging Ceratops can't be blocked except by three or more creatures.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "b72fa5f6-9ae5-5af1-a099-a5599629584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg?1",
             "name": "Rumbling Rockslide",
             "text": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "abb5d688-c918-5421-9ef6-08e48504f014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg?1",
             "name": "Saheeli's Lattice // Mastercraft Raptor",
             "text": "",
             "colours": [
@@ -6459,7 +6459,7 @@
         },
         {
             "id": "e9034943-a625-5536-bb00-32adf8527499",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0bdc79c6-1193-46bd-931d-2c2a0381e420.jpg?1",
             "name": "Saheeli's Lattice // Mastercraft Raptor",
             "text": "",
             "colours": [
@@ -6494,7 +6494,7 @@
         },
         {
             "id": "4e6b69d4-5106-531c-b604-9a288ec9cbc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9436cf62-56d6-4662-9982-72e9be80d25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9436cf62-56d6-4662-9982-72e9be80d25c.jpg?1",
             "name": "Scytheclaw Raptor",
             "text": "Whenever a player casts a spell, if it's not their turn, Scytheclaw Raptor deals 4 damage to them.",
             "colours": [
@@ -6530,7 +6530,7 @@
         },
         {
             "id": "1adb623f-d228-5068-a2d9-cc376794ba34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeb9dc-18f9-4120-ac3d-226c62a1dc1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeb9dc-18f9-4120-ac3d-226c62a1dc1d.jpg?1",
             "name": "Seismic Monstrosaur",
             "text": "Trample\n{2}{R}, Sacrifice a land: Draw a card.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "797dff5f-db54-51f1-8389-df7b5322ef49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb040fc7-f728-4482-92af-9a320c03bb54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb040fc7-f728-4482-92af-9a320c03bb54.jpg?1",
             "name": "Sunfire Torch",
             "text": "Equipped creature gets +1/+0 and has \"Whenever this creature attacks, you may sacrifice Sunfire Torch. When you do, this creature deals 2 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6598,7 +6598,7 @@
         },
         {
             "id": "e5c00766-0c58-5e7b-9bc7-d8eb624a81ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg?1",
             "name": "Sunshot Militia",
             "text": "Tap two untapped artifacts and/or creatures you control: Sunshot Militia deals 1 damage to each opponent. Activate only as a sorcery.",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "5e2633d6-7d30-5b59-a3a2-a3f41a78f99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg?1",
             "name": "Tectonic Hazard",
             "text": "Tectonic Hazard deals 1 damage to each opponent and each creature they control.",
             "colours": [
@@ -6665,7 +6665,7 @@
         },
         {
             "id": "429832e0-540f-5205-9633-33045c3f00db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b28139-efa7-4818-a012-cf8150692b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b28139-efa7-4818-a012-cf8150692b43.jpg?1",
             "name": "Triumphant Chomp",
             "text": "Triumphant Chomp deals damage to target creature equal to 2 or the greatest power among Dinosaurs you control, whichever is greater.",
             "colours": [
@@ -6697,7 +6697,7 @@
         },
         {
             "id": "99a8aaf4-b7b6-51f3-910f-59eaaeb187d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg?1",
             "name": "Trumpeting Carnosaur",
             "text": "Trample\nWhen Trumpeting Carnosaur enters the battlefield, discover 5.\n{2}{R}, Discard Trumpeting Carnosaur: It deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "a144c634-6789-5801-ab91-24f5d4c447c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101921a-d26f-4a00-a0db-1b418f2e6b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101921a-d26f-4a00-a0db-1b418f2e6b01.jpg?1",
             "name": "Volatile Wanderglyph",
             "text": "Whenever Volatile Wanderglyph becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "bb47f068-9a4f-5f7a-8547-5878594708f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04839717-d2f9-481d-9d13-e4038dbcbb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04839717-d2f9-481d-9d13-e4038dbcbb0e.jpg?1",
             "name": "Zoyowa's Justice",
             "text": "The owner of target artifact or creature with mana value 1 or greater shuffles it into their library. Then that player discovers X, where X is its mana value. (They exile cards from the top of their library until they exile a nonland card with that mana value or less. They cast it without paying its mana cost or put it into their hand. They put the rest on the bottom in a random order.)",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "26bf283a-8554-5bce-8301-c6126e3ff357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76a46a1-a63e-460a-98c5-699dd1c827aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76a46a1-a63e-460a-98c5-699dd1c827aa.jpg?1",
             "name": "Armored Kincaller",
             "text": "When Armored Kincaller enters the battlefield, you may reveal a Dinosaur card from your hand. If you do or if you control another Dinosaur, you gain 3 life.",
             "colours": [
@@ -6834,7 +6834,7 @@
         },
         {
             "id": "5821e64b-cd62-53e2-960e-0cb705877f22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a2ba4-dfa8-49d6-95e9-04b7a14d0c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a2ba4-dfa8-49d6-95e9-04b7a14d0c6c.jpg?1",
             "name": "Basking Capybara",
             "text": "Descend 4 \u2014 Basking Capybara gets +3/+0 as long as there are four or more permanent cards in your graveyard.",
             "colours": [
@@ -6868,7 +6868,7 @@
         },
         {
             "id": "2c71599f-3508-5a69-8685-9db73d9faa43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bd623-3100-44dc-adec-53fa3a95ab19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bd623-3100-44dc-adec-53fa3a95ab19.jpg?1",
             "name": "Bedrock Tortoise",
             "text": "As long as it's your turn, creatures you control have hexproof.\nEach creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -6904,7 +6904,7 @@
         },
         {
             "id": "13d37ab9-5775-5acf-8c72-1588bc4c9588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decdfd6b-55ab-47fd-9f98-1845261f1caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decdfd6b-55ab-47fd-9f98-1845261f1caf.jpg?1",
             "name": "Cavern Stomper",
             "text": "When Cavern Stomper enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{3}{G}: Cavern Stomper can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "77bf1d38-ed87-5674-9ad9-c97cbf25d293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce4b7bc-636b-4723-a7c1-2c859f333492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce4b7bc-636b-4723-a7c1-2c859f333492.jpg?1",
             "name": "Cenote Scout",
             "text": "When Cenote Scout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6975,7 +6975,7 @@
         },
         {
             "id": "ee2cc6e3-921e-5d59-aeb0-ba5fd4cb05d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c70d86-1764-487d-a415-15ae79ba570c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c70d86-1764-487d-a415-15ae79ba570c.jpg?1",
             "name": "Coati Scavenger",
             "text": "Descend 4 \u2014 When Coati Scavenger enters the battlefield, if there are four or more permanent cards in your graveyard, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -7009,7 +7009,7 @@
         },
         {
             "id": "c1fe450c-9007-534e-a1b5-46c4763a04f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702e776-be2c-48a9-9bc5-bb8ea514333b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8702e776-be2c-48a9-9bc5-bb8ea514333b.jpg?1",
             "name": "Colossadactyl",
             "text": "Reach, trample",
             "colours": [
@@ -7043,7 +7043,7 @@
         },
         {
             "id": "292d0b2f-2844-59f8-bc76-339fc2c84d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1",
             "name": "Cosmium Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n\u2022 Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -7077,7 +7077,7 @@
         },
         {
             "id": "13725885-cc9e-5bef-a23f-3ae5ff9b41da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404b8d6-3673-4d82-b9ed-d28e9b54e1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404b8d6-3673-4d82-b9ed-d28e9b54e1f6.jpg?1",
             "name": "Disturbed Slumber",
             "text": "Until end of turn, target land you control becomes a 4/4 Dinosaur creature with reach and haste. It's still a land. It must be blocked this turn if able.",
             "colours": [
@@ -7109,7 +7109,7 @@
         },
         {
             "id": "dc8df2e0-327e-5e09-a416-814a61a8ae0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcbba6f-aa54-44be-a3b0-f712fa8bd5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdcbba6f-aa54-44be-a3b0-f712fa8bd5ad.jpg?1",
             "name": "Earthshaker Dreadmaw",
             "text": "Trample\nWhen Earthshaker Dreadmaw enters the battlefield, draw a card for each other Dinosaur you control.",
             "colours": [
@@ -7145,7 +7145,7 @@
         },
         {
             "id": "dde14eea-5f8c-5079-9b34-b5777b9ef0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b36214-9c7e-4a24-93d4-17b2d00cbc51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b36214-9c7e-4a24-93d4-17b2d00cbc51.jpg?1",
             "name": "Explorer's Cache",
             "text": "Explorer's Cache enters the battlefield with two +1/+1 counters on it.\nWhenever a creature you control with a +1/+1 counter on it dies, put a +1/+1 counter on Explorer's Cache.\n{T}: Move a +1/+1 counter from Explorer's Cache onto target creature. Activate only as a sorcery.",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "44f9a407-0765-5b35-a73d-7267770b065c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e805e9-69be-45c1-aa04-f460641a0c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e805e9-69be-45c1-aa04-f460641a0c1e.jpg?1",
             "name": "Ghalta, Stampede Tyrant",
             "text": "Trample\nWhen Ghalta, Stampede Tyrant enters the battlefield, put any number of creature cards from your hand onto the battlefield.",
             "colours": [
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "f2e69c4c-9d6a-5c5a-a81e-3b277ba65715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7d6aed-3dc8-417d-a190-1660cfc8ee4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7d6aed-3dc8-417d-a190-1660cfc8ee4a.jpg?1",
             "name": "Glimpse the Core",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic Forest card, put that card onto the battlefield tapped, then shuffle.\n\u2022 Return target Cave card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "84e0cdb7-592f-5967-bbf2-80a9116ad1b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafde87c-743d-4307-93e0-fbd30f5d92f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafde87c-743d-4307-93e0-fbd30f5d92f6.jpg?1",
             "name": "Glowcap Lantern",
             "text": "Equipped creature has \"You may look at the top card of your library any time\" and \"Whenever this creature attacks, it explores.\" (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)\nEquip {2}",
             "colours": [
@@ -7282,7 +7282,7 @@
         },
         {
             "id": "9487b866-aa46-5666-b5b8-981dcedf8901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [
@@ -7318,7 +7318,7 @@
         },
         {
             "id": "040aedf7-51db-585e-89a1-90a136e2447b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/004524bf-b249-4dac-9c10-44d57143feb9.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [],
@@ -7352,7 +7352,7 @@
         },
         {
             "id": "d022ea1f-57b6-573a-ac29-8207e848f770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -7395,7 +7395,7 @@
         },
         {
             "id": "a05b81eb-b74a-5432-9fc6-a23cc2fba41c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57df2563-18d4-4526-a8bc-0c114e6fd4d9.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "2cbe916e-3064-52c5-83d8-d664bb115094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1247a5fa-b50a-4ab1-96ca-dbeb45bd0b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1247a5fa-b50a-4ab1-96ca-dbeb45bd0b56.jpg?1",
             "name": "Huatli's Final Strike",
             "text": "Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "eee137b8-79fe-5fde-b9b5-28d0df5d713e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg?1",
             "name": "Hulking Raptor",
             "text": "Ward {2}\nAt the beginning of your precombat main phase, add {G}{G}.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "ff6a85ce-0bc6-5340-988b-ee527216d030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b1be22-3177-49af-bb06-42497d717c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b1be22-3177-49af-bb06-42497d717c21.jpg?1",
             "name": "In the Presence of Ages",
             "text": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -7536,7 +7536,7 @@
         },
         {
             "id": "74e5efac-cfdc-597a-adaa-f534e5a54501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg?1",
             "name": "Intrepid Paleontologist",
             "text": "{T}: Add one mana of any color.\n{2}: Exile target card from a graveyard.\nYou may cast Dinosaur creature spells from among cards you own exiled with Intrepid Paleontologist. If you cast a spell this way, that creature enters the battlefield with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "df9b840b-c755-54d2-b82a-cce4d9fdf14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc94ded-458d-4458-9c0b-136d825b885d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc94ded-458d-4458-9c0b-136d825b885d.jpg?1",
             "name": "Ixalli's Lorekeeper",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or activate an ability of a Dinosaur source.",
             "colours": [
@@ -7608,7 +7608,7 @@
         },
         {
             "id": "f06b16be-fe66-5ff7-a91e-ffa4bebf8533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg?1",
             "name": "Jade Seedstones // Jadeheart Attendant",
             "text": "",
             "colours": [
@@ -7640,7 +7640,7 @@
         },
         {
             "id": "b5c58f34-9eac-5611-a8f9-4d5e0b647fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bb95ffc2-ef35-49bf-8211-c5354d176051.jpg?1",
             "name": "Jade Seedstones // Jadeheart Attendant",
             "text": "",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "14709ded-825a-5985-8d1b-653adea072a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1",
             "name": "Jadelight Spelunker",
             "text": "When Jadelight Spelunker enters the battlefield, it explores X times. (To have it explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "9323ab60-32fd-5e98-a20d-5f4cb4fe6e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1",
             "name": "Kaslem's Stonetree // Kaslem's Strider",
             "text": "",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "74473b7d-1a47-5403-9dd5-8a1a22c29a75",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1",
             "name": "Kaslem's Stonetree // Kaslem's Strider",
             "text": "",
             "colours": [
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "8fbfd0c1-1d36-525f-9a83-4ad0de864859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259f959-ca97-4df9-8d50-0532090fb967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259f959-ca97-4df9-8d50-0532090fb967.jpg?1",
             "name": "Malamet Battle Glyph",
             "text": "Choose target creature you control and target creature you don't control. If the creature you control entered the battlefield this turn, put a +1/+1 counter on it. Then those creatures fight each other.",
             "colours": [
@@ -7812,7 +7812,7 @@
         },
         {
             "id": "f62e5c57-9ac7-5ecc-aff6-2e507dbb26d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d2fb65-cc3d-4664-bee0-8cf1cba5d8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d2fb65-cc3d-4664-bee0-8cf1cba5d8fa.jpg?1",
             "name": "Malamet Brawler",
             "text": "Whenever Malamet Brawler attacks, target attacking creature gains trample until end of turn.",
             "colours": [
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "d33e51cc-1ebe-511e-b534-2bf8630d1ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6776a4-cc01-46a3-90df-04e1e3ba513c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6776a4-cc01-46a3-90df-04e1e3ba513c.jpg?1",
             "name": "Malamet Scythe",
             "text": "Flash\nWhen Malamet Scythe enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+2.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "adb9b1c9-7757-5448-9bb4-b25861b6a78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg?1",
             "name": "Malamet Veteran",
             "text": "Trample\nDescend 4 \u2014 Whenever Malamet Veteran attacks, if there are four or more permanent cards in your graveyard, put a +1/+1 counter on target creature.",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "e23969ed-502d-52f8-be34-47e0ec65be94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a3639-a917-4700-a093-14a4cda78d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a3639-a917-4700-a093-14a4cda78d9f.jpg?1",
             "name": "Mineshaft Spider",
             "text": "Reach\nWhen Mineshaft Spider enters the battlefield, you may mill two cards. (You may put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -7950,7 +7950,7 @@
         },
         {
             "id": "5e40961e-1ad2-522c-86dd-7a9d8cdc5b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081d5c9e-71da-4454-ae4e-c76cb7790d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081d5c9e-71da-4454-ae4e-c76cb7790d20.jpg?1",
             "name": "Nurturing Bristleback",
             "text": "When Nurturing Bristleback enters the battlefield, create a 3/3 green Dinosaur creature token.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -7984,7 +7984,7 @@
         },
         {
             "id": "8724735e-4349-56f1-8d98-1531271db650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [
@@ -8022,7 +8022,7 @@
         },
         {
             "id": "5f85ce74-4276-5f18-ad1e-4f4366ac9f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [],
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "88f6dbaa-7ee2-5636-a857-08fd8d8c1ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg?1",
             "name": "Over the Edge",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Target creature you control explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
             "colours": [
@@ -8086,7 +8086,7 @@
         },
         {
             "id": "aa5cbbbf-fd46-52bc-9422-804d9c94852d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f619075-ca5d-4e09-bd84-31e6b61eaa7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f619075-ca5d-4e09-bd84-31e6b61eaa7e.jpg?1",
             "name": "Pathfinding Axejaw",
             "text": "When Pathfinding Axejaw enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8120,7 +8120,7 @@
         },
         {
             "id": "e673cf81-a7b6-5a88-9268-2b08adc61325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c1f09a-9d17-415c-8afa-cd0b62abe48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c1f09a-9d17-415c-8afa-cd0b62abe48d.jpg?1",
             "name": "Poison Dart Frog",
             "text": "Reach\n{T}: Add one mana of any color.\n{2}: Poison Dart Frog gains deathtouch until end of turn.",
             "colours": [
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "08438fca-8883-50fe-9ae0-2da1a52dbd6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg?1",
             "name": "Pugnacious Hammerskull",
             "text": "Whenever Pugnacious Hammerskull attacks while you don't control another Dinosaur, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -8190,7 +8190,7 @@
         },
         {
             "id": "823f92a2-4742-5831-b27d-37e7753c91bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7e323-f329-4928-b25a-c0b44c5ac058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7e323-f329-4928-b25a-c0b44c5ac058.jpg?1",
             "name": "River Herald Guide",
             "text": "Vigilance\nWhen River Herald Guide enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "9c6c81de-b720-5e86-b261-4a86a8086443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdb10f-4bad-4f89-8e7c-daa5c0c69230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdb10f-4bad-4f89-8e7c-daa5c0c69230.jpg?1",
             "name": "Seeker of Sunlight",
             "text": "{2}{G}: Seeker of Sunlight explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8260,7 +8260,7 @@
         },
         {
             "id": "382be9f4-71e3-5683-bf92-3cc855a97cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeffc0b-dc92-458e-ad58-86ff6077a508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeffc0b-dc92-458e-ad58-86ff6077a508.jpg?1",
             "name": "Sentinel of the Nameless City",
             "text": "Vigilance\nWhenever Sentinel of the Nameless City enters the battlefield or attacks, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "a2daecfc-94f5-5d67-90e3-76111fb05fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56a7631-5f94-468d-aab7-7e9e129c5f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56a7631-5f94-468d-aab7-7e9e129c5f49.jpg?1",
             "name": "The Skullspore Nexus",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nWhenever one or more nontoken creatures you control die, create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.\n{2}, {T}: Double target creature's power until end of turn.",
             "colours": [
@@ -8334,7 +8334,7 @@
         },
         {
             "id": "8461af88-7209-5107-9d80-dd290a94881a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be4257-2316-4a2e-b347-f71c0368a947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3be4257-2316-4a2e-b347-f71c0368a947.jpg?1",
             "name": "Spelunking",
             "text": "When Spelunking enters the battlefield, draw a card, then you may put a land card from your hand onto the battlefield. If you put a Cave onto the battlefield this way, you gain 4 life.\nLands you control enter the battlefield untapped.",
             "colours": [
@@ -8366,7 +8366,7 @@
         },
         {
             "id": "7a8587d9-2b24-591b-810a-59b68f32eb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34c4946-6c21-4ae1-9595-35933d38da52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34c4946-6c21-4ae1-9595-35933d38da52.jpg?1",
             "name": "Staggering Size",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "fff91eab-59ee-5d56-abde-243fcec668d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg?1",
             "name": "Tendril of the Mycotyrant",
             "text": "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes a 0/0 Fungus creature with haste. It's still a land.",
             "colours": [
@@ -8433,7 +8433,7 @@
         },
         {
             "id": "c8e76f08-1576-5c61-86ea-3828cf292ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52ef7c1-dacb-4204-b64e-5fa3ae3b1ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52ef7c1-dacb-4204-b64e-5fa3ae3b1ace.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -8469,7 +8469,7 @@
         },
         {
             "id": "c230d168-692a-5fd7-b9d7-d2b6f43535b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg?1",
             "name": "Twists and Turns // Mycoid Maze",
             "text": "",
             "colours": [
@@ -8501,7 +8501,7 @@
         },
         {
             "id": "93b16110-9cb5-5021-b4fc-915c79287e68",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdf691e-96a5-45c7-9b94-6f04af81c8e4.jpg?1",
             "name": "Twists and Turns // Mycoid Maze",
             "text": "",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "dba4ae92-1b13-512e-81f8-afa39692867e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f85b-5ef8-4526-9c86-7cb71508b4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f85b-5ef8-4526-9c86-7cb71508b4c0.jpg?1",
             "name": "Walk with the Ancestors",
             "text": "Return up to one target permanent card from your graveyard to your hand. Discover 4. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "bd5e9bd7-ee6d-56dc-b5f1-b2bb05a83ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eee689-2514-421a-8056-eb7668be66ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eee689-2514-421a-8056-eb7668be66ff.jpg?1",
             "name": "Abuelo, Ancestral Echo",
             "text": "Flying, ward {2}\n{1}{W}{U}: Exile another target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -8605,7 +8605,7 @@
         },
         {
             "id": "5574d56c-59bd-57cc-9def-d191f400278e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee62dd1-97d0-4e5d-8937-26c9e51e9414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee62dd1-97d0-4e5d-8937-26c9e51e9414.jpg?1",
             "name": "Akawalli, the Seething Tower",
             "text": "Descend 4 \u2014 As long as there are four or more permanent cards in your graveyard, Akawalli, the Seething Tower gets +2/+2 and has trample.\nDescend 8 \u2014 As long as there are eight or more permanent cards in your graveyard, Akawalli gets an additional +2/+2 and can't be blocked by more than one creature.",
             "colours": [
@@ -8645,7 +8645,7 @@
         },
         {
             "id": "92e26b32-eea8-5d45-989e-47b7b0c2e33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acf80a5-f2ca-45b4-aca8-fbc690e35401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acf80a5-f2ca-45b4-aca8-fbc690e35401.jpg?1",
             "name": "Amalia Benavides Aguirre",
             "text": "Ward\u2014\nPay 3 life.\nWhenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other creatures if its power is exactly 20. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "92fed694-d3df-538e-9533-68d183aa21a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66dd43d7-76a7-46ea-b431-097fcea417af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66dd43d7-76a7-46ea-b431-097fcea417af.jpg?1",
             "name": "The Ancient One",
             "text": "Descend 8 \u2014 The Ancient One can't attack or block unless there are eight or more permanent cards in your graveyard.\n{2}{U}{B}: Draw a card, then discard a card. When you discard a card this way, target player mills cards equal to its mana value.",
             "colours": [
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "7ae780f2-759e-50cc-9476-b612f0b7fba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868856b7-8875-43c1-8249-0f8fb2c8319b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868856b7-8875-43c1-8249-0f8fb2c8319b.jpg?1",
             "name": "Anim Pakal, Thousandth Moon",
             "text": "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal, then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where X is the number of +1/+1 counters on Anim Pakal.",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "a3e92b17-ceac-5d35-8165-d98bbc66d62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690ccdc7-6c43-4902-9d11-2f07b7a36b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690ccdc7-6c43-4902-9d11-2f07b7a36b11.jpg?1",
             "name": "Bartolom\u00e9 del Presidio",
             "text": "Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolom\u00e9 del Presidio.",
             "colours": [
@@ -8810,7 +8810,7 @@
         },
         {
             "id": "a0a90611-f9a8-53e0-a99f-99a7003b7fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454af8c-bce9-47d3-890f-283e2fea2cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454af8c-bce9-47d3-890f-283e2fea2cf2.jpg?1",
             "name": "The Belligerent",
             "text": "Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the top card of your library any time, and you may play lands and cast spells from the top of your library.\nCrew 3",
             "colours": [
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "5499e2d7-3392-57e4-b0bc-ebd3ec3a2296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea82964-fd9c-48e3-962f-94954476b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea82964-fd9c-48e3-962f-94954476b31f.jpg?1",
             "name": "Caparocti Sunborn",
             "text": "Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you control. If you do, discover 3. (Exile cards from the top of your library until you exile a nonland card with mana value 3 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "bd28cd6c-9e22-5e5c-b62c-257991ae2793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c65f5a-10bd-4f9b-b816-46c2240b11ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c65f5a-10bd-4f9b-b816-46c2240b11ff.jpg?1",
             "name": "Captain Storm, Cosmium Raider",
             "text": "Whenever an artifact enters the battlefield under your control, put a +1/+1 counter on target Pirate you control.",
             "colours": [
@@ -8932,7 +8932,7 @@
         },
         {
             "id": "ab4790bb-6930-51ec-b876-306f30091ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg?1",
             "name": "Deepfathom Echo",
             "text": "At the beginning of combat on your turn, Deepfathom Echo explores. Then you may have it become a copy of another creature you control until end of turn. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -8971,7 +8971,7 @@
         },
         {
             "id": "495959e0-860d-5fb6-994b-dc6a85fd002f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4a65de-23b5-48f0-b8b7-94608eaced3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4a65de-23b5-48f0-b8b7-94608eaced3e.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "Vigilance, trample, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9014,7 +9014,7 @@
         },
         {
             "id": "7c9bedaa-5795-5d34-a3f9-4f56b41a1e9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg?1",
             "name": "Itzquinth, Firstborn of Gishath",
             "text": "Haste\nWhen Itzquinth, Firstborn of Gishath enters the battlefield, you may pay {2}. When you do, target Dinosaur you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -9054,7 +9054,7 @@
         },
         {
             "id": "8bbe4ff8-20b8-5ea9-adaf-9497f57aaae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -9095,7 +9095,7 @@
         },
         {
             "id": "8f783ba6-daad-58a4-a5bd-c32649960fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -9132,7 +9132,7 @@
         },
         {
             "id": "5e6b6b27-9e33-5449-bec6-e9d77b0b079d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f88a40-a6ed-4c1f-a309-011aca1acddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f88a40-a6ed-4c1f-a309-011aca1acddd.jpg?1",
             "name": "Kutzil, Malamet Exemplar",
             "text": "Your opponents can't cast spells during your turn.\nWhenever one or more creatures you control each with power greater than its base power deals combat damage to a player, draw a card.",
             "colours": [
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "8f4e4696-c78d-58e0-939b-3285dca7b366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1",
             "name": "Master's Guide-Mural // Master's Manufactory",
             "text": "",
             "colours": [
@@ -9207,7 +9207,7 @@
         },
         {
             "id": "66480aff-06b9-57e3-a6d5-d713fb285e22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1",
             "name": "Master's Guide-Mural // Master's Manufactory",
             "text": "",
             "colours": [
@@ -9241,7 +9241,7 @@
         },
         {
             "id": "8350e263-3d7a-5e58-90db-2571939e044e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg?1",
             "name": "Molten Collapse",
             "text": "Choose one. If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)\n\u2022 Destroy target creature or planeswalker.\n\u2022 Destroy target noncreature, nonland permanent with mana value 1 or less.",
             "colours": [
@@ -9277,7 +9277,7 @@
         },
         {
             "id": "18570bf6-2ef0-55d4-908e-503ce8545322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caef93cc-70d0-4cce-9aaa-13c0931b2ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caef93cc-70d0-4cce-9aaa-13c0931b2ef7.jpg?1",
             "name": "The Mycotyrant",
             "text": "Trample\nThe Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings.\nAt the beginning of your end step, create X 1/1 black Fungus creature tokens with \"This creature can't block,\" where X is the number of times you descended this turn. (You descend each time a permanent card is put into your graveyard from anywhere.)",
             "colours": [
@@ -9318,7 +9318,7 @@
         },
         {
             "id": "df7ec6a1-45d7-5d71-b4c2-0de9a20a7347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f4aba-3500-4fb7-ab78-02f63c03778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6f4aba-3500-4fb7-ab78-02f63c03778a.jpg?1",
             "name": "Nicanzil, Current Conductor",
             "text": "Whenever a creature you control explores a land card, you may put a land card from your hand onto the battlefield tapped.\nWhenever a creature you control explores a nonland card, put a +1/+1 counter on Nicanzil, Current Conductor.",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "c9f0b51a-4240-56df-828e-7f4c3eb60ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff73c7-428c-469c-b564-6aa9f4eeca14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ff73c7-428c-469c-b564-6aa9f4eeca14.jpg?1",
             "name": "Palani's Hatcher",
             "text": "Other Dinosaurs you control have haste.\nWhen Palani's Hatcher enters the battlefield, create two 0/1 green Dinosaur Egg creature tokens.\nAt the beginning of combat on your turn, if you control one or more Eggs, sacrifice an Egg, then create a 3/3 green Dinosaur creature token.",
             "colours": [
@@ -9397,7 +9397,7 @@
         },
         {
             "id": "c5604d70-ed5e-55fe-b987-d86371b0fb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4382fa49-9e34-45b3-8495-4916dcd995ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4382fa49-9e34-45b3-8495-4916dcd995ec.jpg?1",
             "name": "Quintorius Kand",
             "text": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n\u22123: Discover 4.\n\u22126: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
             "colours": [
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "5cf3c5ed-7a69-52a8-8426-62c3f235a12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba99b60-c7d0-4041-a065-f2c510745223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba99b60-c7d0-4041-a065-f2c510745223.jpg?1",
             "name": "Saheeli, the Sun's Brilliance",
             "text": "{U}{R}, {T}: Create a token that's a copy of another target creature or artifact you control, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "6e64e137-2cb5-5ede-a28d-0741f6ffb5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c75aa7-e2f9-4a69-8086-c982019ca714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c75aa7-e2f9-4a69-8086-c982019ca714.jpg?1",
             "name": "Sovereign Okinec Ahau",
             "text": "Ward {2}\nWhenever Sovereign Okinec Ahau attacks, for each creature you control with power greater than that creature's base power, put a number of +1/+1 counters on that creature equal to the difference.",
             "colours": [
@@ -9520,7 +9520,7 @@
         },
         {
             "id": "d1eaf6a9-4d49-51cf-abca-6f456179b8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee16629-f9be-4cdb-bf52-1d640781ee00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee16629-f9be-4cdb-bf52-1d640781ee00.jpg?1",
             "name": "Squirming Emergence",
             "text": "Fathomless descent \u2014 Return to the battlefield target nonland permanent card in your graveyard with mana value less than or equal to the number of permanent cards in your graveyard.",
             "colours": [
@@ -9556,7 +9556,7 @@
         },
         {
             "id": "0dd5f52b-fe94-507a-8de7-282e601739a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062202c-f9fb-4dd6-989a-c3083644f1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062202c-f9fb-4dd6-989a-c3083644f1c0.jpg?1",
             "name": "Uchbenbak, the Great Mistake",
             "text": "Vigilance, menace\nDescend 8 \u2014 {4}{U}{B}: Return Uchbenbak, the Great Mistake from your graveyard to the battlefield with a finality counter on it. Activate only if there are eight or more permanent cards in your graveyard and only as a sorcery. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "0532b7be-82cd-57ec-9bcb-3cc332a60db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd9047-df91-4d82-be00-c623acae0f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd9047-df91-4d82-be00-c623acae0f01.jpg?1",
             "name": "Vito, Fanatic of Aclazotz",
             "text": "Flying\nWhenever you sacrifice another permanent, you gain 2 life if this is the first time this ability has resolved this turn. If it's the second time, each opponent loses 2 life. If it's the third time, create a 4/3 white and black Vampire Demon creature token with flying.",
             "colours": [
@@ -9638,7 +9638,7 @@
         },
         {
             "id": "87c21b24-662f-5ca6-9165-f09111646527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67108256-b7da-44bd-9639-4264931d348f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67108256-b7da-44bd-9639-4264931d348f.jpg?1",
             "name": "Wail of the Forgotten",
             "text": "Descend 8 \u2014 Choose one. If there are eight or more permanent cards in your graveyard as you cast this spell, choose one or more instead.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Target opponent discards a card.\n\u2022 Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "b0a4f156-f40c-55a0-a1d2-60bafbdf6e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06f0ff2-d42f-4854-bbe5-4b022fb26d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06f0ff2-d42f-4854-bbe5-4b022fb26d7d.jpg?1",
             "name": "Zoyowa Lava-Tongue",
             "text": "Deathtouch\nAt the beginning of your end step, if you descended this turn, each opponent may discard a card or sacrifice a permanent. Zoyowa Lava-Tongue deals 3 damage to each opponent who didn't. (You descended if a permanent card was put into your graveyard from anywhere.)",
             "colours": [
@@ -9715,7 +9715,7 @@
         },
         {
             "id": "19de3ddb-5d5c-5d9c-b6f4-0b92c69cfe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c45b6-dedd-4481-a06a-c83ace2f18fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c9c45b6-dedd-4481-a06a-c83ace2f18fa.jpg?1",
             "name": "Buried Treasure",
             "text": "{T}, Sacrifice Buried Treasure: Add one mana of any color.\n{5}, Exile Buried Treasure from your graveyard: Discover 5. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -9745,7 +9745,7 @@
         },
         {
             "id": "4b7f649e-8d74-5961-8103-74726d24ef44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a96d8ae-200a-40be-95a8-72b53638a090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a96d8ae-200a-40be-95a8-72b53638a090.jpg?1",
             "name": "Careening Mine Cart",
             "text": "Whenever Careening Mine Cart attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9775,7 +9775,7 @@
         },
         {
             "id": "9de98774-b4ce-549a-bf00-688df842d2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd8115e-4cb3-49b6-b74f-8fcfa28c6404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd8115e-4cb3-49b6-b74f-8fcfa28c6404.jpg?1",
             "name": "Cartographer's Companion",
             "text": "When Cartographer's Companion enters the battlefield, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery.\")",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "98b92e5d-406a-53b1-9605-65371cbc89da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a1bfb5-ddfc-49cf-baa3-5d1958d2067a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a1bfb5-ddfc-49cf-baa3-5d1958d2067a.jpg?1",
             "name": "Chimil, the Inner Sun",
             "text": "Spells you control can't be countered.\nAt the beginning of your end step, discover 5. (Exile cards from the top of your library until you exile a nonland card with mana value 5 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "e43aee9d-524e-52c8-81a0-d8d8ebf4e0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e1030e-2b95-4807-9111-e495a2fc8813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e1030e-2b95-4807-9111-e495a2fc8813.jpg?1",
             "name": "Compass Gnome",
             "text": "When Compass Gnome enters the battlefield, you may search your library for a basic land card or Cave card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -9867,7 +9867,7 @@
         },
         {
             "id": "9c5d7951-8eea-59df-8f51-62e181af9b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cb7776-a6af-4efb-b536-6b9b4f3d3874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cb7776-a6af-4efb-b536-6b9b4f3d3874.jpg?1",
             "name": "Contested Game Ball",
             "text": "Whenever you're dealt combat damage, the attacking player gains control of Contested Game Ball and untaps it.\n{2}, {T}: Draw a card and put a point counter on Contested Game Ball. Then if it has five or more point counters on it, sacrifice it and create a Treasure token.",
             "colours": [],
@@ -9895,7 +9895,7 @@
         },
         {
             "id": "3adad123-bea7-526c-bd5c-8f86055ff808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa3cd5e-b727-479d-9a77-9f320b92f3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa3cd5e-b727-479d-9a77-9f320b92f3f2.jpg?1",
             "name": "Digsite Conservator",
             "text": "Sacrifice Digsite Conservator: Exile up to four target cards from a single graveyard. Activate only as a sorcery.\nWhen Digsite Conservator dies, you may pay {4}. If you do, discover 4. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -9926,7 +9926,7 @@
         },
         {
             "id": "af3baa78-a0c6-5459-becc-78040bbde782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802ca61-6fcc-4965-9f8f-dd58fe82c6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802ca61-6fcc-4965-9f8f-dd58fe82c6bf.jpg?1",
             "name": "Disruptor Wanderglyph",
             "text": "Whenever Disruptor Wanderglyph attacks, exile target card from an opponent's graveyard.",
             "colours": [],
@@ -9957,7 +9957,7 @@
         },
         {
             "id": "7dca6111-56f2-5ee3-a2d5-5c36ae6c677a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7e12ee-3db6-4df7-9859-7a8dee9171c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7e12ee-3db6-4df7-9859-7a8dee9171c7.jpg?1",
             "name": "Hoverstone Pilgrim",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\n{2}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "ee6f96c2-3000-5aa2-9d37-14804c0d3c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3348abe7-6aa3-47f7-8203-a15f75007e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3348abe7-6aa3-47f7-8203-a15f75007e33.jpg?1",
             "name": "Hunter's Blowgun",
             "text": "Equipped creature gets +1/+1.\nEquipped creature has deathtouch as long as it's your turn. Otherwise, it has reach.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "a18a4a85-32e6-5a15-8ed3-bf21149a5ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -10050,7 +10050,7 @@
         },
         {
             "id": "33d8bf64-2cb9-526b-bc1c-0e967234f8df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "2219dbc8-e90e-5652-bc2b-c1bf67b850eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabba7f-05ef-41cf-ae3a-d950d051cf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabba7f-05ef-41cf-ae3a-d950d051cf1e.jpg?1",
             "name": "The Millennium Calendar",
             "text": "Whenever you untap one or more permanents during your untap step, put that many time counters on The Millennium Calendar.\n{2}, {T}: Double the number of time counters on The Millennium Calendar.\nWhen there are 1,000 or more time counters on The Millennium Calendar, sacrifice it and each opponent loses 1,000 life.",
             "colours": [],
@@ -10114,7 +10114,7 @@
         },
         {
             "id": "080b0062-4aa4-5fd6-a1b3-081655cabf99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32fd8b7c-baf3-4d3d-be6f-044a917b11a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32fd8b7c-baf3-4d3d-be6f-044a917b11a0.jpg?1",
             "name": "Roaming Throne",
             "text": "Ward {2}\nAs Roaming Throne enters the battlefield, choose a creature type.\nRoaming Throne is the chosen type in addition to its other types.\nIf a triggered ability of another creature you control of the chosen type triggers, it triggers an additional time.",
             "colours": [],
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "cab9b259-d917-56d0-ae6e-691c2a762e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d47a3b-dc66-48d8-981b-dde0ccc34ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d47a3b-dc66-48d8-981b-dde0ccc34ad5.jpg?1",
             "name": "Runaway Boulder",
             "text": "Flash\nWhen Runaway Boulder enters the battlefield, it deals 6 damage to target creature an opponent controls.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10175,7 +10175,7 @@
         },
         {
             "id": "0e1c53e2-fdf7-5089-aecd-3b7f2cc01ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb2a90-d4c0-4c83-8ee7-2ac3a23b4402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb2a90-d4c0-4c83-8ee7-2ac3a23b4402.jpg?1",
             "name": "Scampering Surveyor",
             "text": "When Scampering Surveyor enters the battlefield, search your library for a basic land card or Cave card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10206,7 +10206,7 @@
         },
         {
             "id": "2ef6aff8-e149-5393-b2d3-82e3f9839f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7899-6b44-4ecc-8ddc-ec24304eb14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194b7899-6b44-4ecc-8ddc-ec24304eb14c.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -10234,7 +10234,7 @@
         },
         {
             "id": "4ccb3303-fe0b-5de4-9c42-86d9931e67f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg?1",
             "name": "Sunbird Standard // Sunbird Effigy",
             "text": "",
             "colours": [],
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "d8cf7462-ba69-5aa2-bbdf-5529f94d67c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg?1",
             "name": "Sunbird Standard // Sunbird Effigy",
             "text": "",
             "colours": [],
@@ -10294,7 +10294,7 @@
         },
         {
             "id": "db1ca080-50a2-5a7d-a5d2-d475c27d9865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg?1",
             "name": "Swashbuckler's Whip",
             "text": "Equipped creature has reach, \"{2}, {T}: Tap target artifact or creature,\" and \"{8}, {T}: Discover 10.\" (Exile cards from the top of your library until you exile a nonland card with mana value 10 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)\nEquip {1}",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "9cfda85c-978d-5858-aae8-b59806955b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg?1",
             "name": "Tarrian's Soulcleaver",
             "text": "Equipped creature has vigilance.\nWhenever another artifact or creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature.\nEquip {2}",
             "colours": [],
@@ -10358,7 +10358,7 @@
         },
         {
             "id": "ca175461-c8c6-55e4-9a63-c8db8c01d077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917c62f-d463-43eb-87ad-89ffbc88b6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917c62f-d463-43eb-87ad-89ffbc88b6fe.jpg?1",
             "name": "Threefold Thunderhulk",
             "text": "Threefold Thunderhulk enters the battlefield with three +1/+1 counters on it.\nWhenever Threefold Thunderhulk enters the battlefield or attacks, create a number of 1/1 colorless Gnome artifact creature tokens equal to its power.\n{2}, Sacrifice another artifact: Put a +1/+1 counter on Threefold Thunderhulk.",
             "colours": [],
@@ -10391,7 +10391,7 @@
         },
         {
             "id": "fc545235-e269-5f46-b9ee-c39523679fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [],
@@ -10425,7 +10425,7 @@
         },
         {
             "id": "5b8baf43-2d81-5b24-aa90-aae148e48902",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c13e8e3d-2a6b-4782-a3c9-71af7336a881.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [
@@ -10465,7 +10465,7 @@
         },
         {
             "id": "7df9a00a-a5cb-5cc8-875f-d73a69d5132f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -10495,7 +10495,7 @@
         },
         {
             "id": "94eaa7a6-dbe7-5c6a-85d4-4883a2d38144",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a924fe1e-a85e-4e14-88d2-ac55130638ab.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -10525,7 +10525,7 @@
         },
         {
             "id": "18b81dbe-d9fe-57b7-9219-e9501812c65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1a645e-85c7-4044-b817-6e24744d245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1a645e-85c7-4044-b817-6e24744d245e.jpg?1",
             "name": "Captivating Cave",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Sacrifice Captivating Cave: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
             "colours": [],
@@ -10555,7 +10555,7 @@
         },
         {
             "id": "00a2f73d-1eda-5265-8a4f-834ff8786a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aad15a2-8a1b-4460-9b06-e85863081878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aad15a2-8a1b-4460-9b06-e85863081878.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "caab6ae5-f9c4-5100-a807-cfafa37860df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a51ebf6-a465-42e2-82b7-d2cb928ca632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a51ebf6-a465-42e2-82b7-d2cb928ca632.jpg?1",
             "name": "Cavernous Maw",
             "text": "{T}: Add {C}.\n{2}: Cavernous Maw becomes a 3/3 Elemental creature until end of turn. It's still a Cave land. Activate only if the number of other Caves you control plus the number of Cave cards in your graveyard is three or greater.",
             "colours": [],
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "ea4f5993-ef28-596f-8a68-c6e2e23278c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244c06b3-532d-426e-8bee-ee9461d092a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244c06b3-532d-426e-8bee-ee9461d092a6.jpg?1",
             "name": "Echoing Deeps",
             "text": "You may have Echoing Deeps enter the battlefield tapped as a copy of any land card in a graveyard, except it's a Cave in addition to its other types.\n{T}: Add {C}.",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "d519f054-83a1-52aa-b76c-49e3330118cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8c1c02-e533-46b2-a3eb-91dff561854b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8c1c02-e533-46b2-a3eb-91dff561854b.jpg?1",
             "name": "Forgotten Monument",
             "text": "{T}: Add {C}.\nOther Caves you control have \"{T}, Pay 1 life: Add one mana of any color.\"",
             "colours": [],
@@ -10683,7 +10683,7 @@
         },
         {
             "id": "eb32f123-eba7-5103-81db-f9403beb1266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f317fc-f603-45b5-9208-545be4dcbf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f317fc-f603-45b5-9208-545be4dcbf36.jpg?1",
             "name": "Hidden Cataract",
             "text": "Hidden Cataract enters the battlefield tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice Hidden Cataract: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10715,7 +10715,7 @@
         },
         {
             "id": "2de8cdb6-5126-55ce-9f6b-18d8cd2c1b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8685d46-99fc-44b3-be95-707a4b7b8327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8685d46-99fc-44b3-be95-707a4b7b8327.jpg?1",
             "name": "Hidden Courtyard",
             "text": "Hidden Courtyard enters the battlefield tapped.\n{T}: Add {W}.\n{4}{W}, {T}, Sacrifice Hidden Courtyard: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "16b9ae6a-ab36-5fd1-8a0c-51f56c1972cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67fd04f-05da-4418-97de-abeb7346cc69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67fd04f-05da-4418-97de-abeb7346cc69.jpg?1",
             "name": "Hidden Necropolis",
             "text": "Hidden Necropolis enters the battlefield tapped.\n{T}: Add {B}.\n{4}{B}, {T}, Sacrifice Hidden Necropolis: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10779,7 +10779,7 @@
         },
         {
             "id": "8b77aeb5-fc61-5795-9e37-d3a003c363a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a942939a-c06e-4b90-a404-ae5acfffcff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a942939a-c06e-4b90-a404-ae5acfffcff9.jpg?1",
             "name": "Hidden Nursery",
             "text": "Hidden Nursery enters the battlefield tapped.\n{T}: Add {G}.\n{4}{G}, {T}, Sacrifice Hidden Nursery: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10811,7 +10811,7 @@
         },
         {
             "id": "da7b6277-6281-5be8-b55f-036b380b9cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa06aed-52c1-48f1-9906-362db12a3cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa06aed-52c1-48f1-9906-362db12a3cf7.jpg?1",
             "name": "Hidden Volcano",
             "text": "Hidden Volcano enters the battlefield tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice Hidden Volcano: Discover 4. Activate only as a sorcery. (Exile cards from the top of your library until you exile a nonland card with mana value 4 or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [],
@@ -10843,7 +10843,7 @@
         },
         {
             "id": "818b20ff-f1cb-5d02-a0d2-ed3037f0faba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7d3957-b483-4a1f-a244-293c90032f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7d3957-b483-4a1f-a244-293c90032f5e.jpg?1",
             "name": "Pit of Offerings",
             "text": "Pit of Offerings enters the battlefield tapped.\nWhen Pit of Offerings enters the battlefield, exile up to three target cards from graveyards.\n{T}: Add {C}.\n{T}: Add one mana of any of the exiled cards' colors.",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "8071f5e3-665e-57d4-83ad-080be4e6e7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9681a54-6413-4ff4-b6b1-ee4decb25bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9681a54-6413-4ff4-b6b1-ee4decb25bfa.jpg?1",
             "name": "Promising Vein",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Promising Vein: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10903,7 +10903,7 @@
         },
         {
             "id": "12906a7f-5ef1-50d2-86ff-a9dfd12086fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cab352-734e-454b-8b58-733165f4b3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cab352-734e-454b-8b58-733165f4b3b3.jpg?1",
             "name": "Restless Anchorage",
             "text": "Restless Anchorage enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{1}{W}{U}: Until end of turn, Restless Anchorage becomes a 2/3 white and blue Bird creature with flying. It's still a land.\nWhenever Restless Anchorage attacks, create a Map token.",
             "colours": [],
@@ -10936,7 +10936,7 @@
         },
         {
             "id": "d0e3fbe3-dd33-5d36-9e64-52d8a061810b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ef116-6aff-4f53-a7f9-be5e21c7afa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94ef116-6aff-4f53-a7f9-be5e21c7afa4.jpg?1",
             "name": "Restless Prairie",
             "text": "Restless Prairie enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}: Restless Prairie becomes a 3/3 green and white Llama creature until end of turn. It's still a land.\nWhenever Restless Prairie attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [],
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "1fc03e51-0e51-5474-bd35-d01416b8016e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8121c9-2480-419c-aa9c-5b8b55f65014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8121c9-2480-419c-aa9c-5b8b55f65014.jpg?1",
             "name": "Restless Reef",
             "text": "Restless Reef enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}: Until end of turn, Restless Reef becomes a 4/4 blue and black Shark creature with deathtouch. It's still a land.\nWhenever Restless Reef attacks, target player mills four cards.",
             "colours": [],
@@ -11002,7 +11002,7 @@
         },
         {
             "id": "d6342dd6-39e7-5649-bda4-8eaa17ebe2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde5bed-dc4e-4b2b-820c-18d4d0cf8042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde5bed-dc4e-4b2b-820c-18d4d0cf8042.jpg?1",
             "name": "Restless Ridgeline",
             "text": "Restless Ridgeline enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Restless Ridgeline becomes a 3/4 red and green Dinosaur creature until end of turn. It's still a land.\nWhenever Restless Ridgeline attacks, another target attacking creature gets +2/+0 until end of turn. Untap that creature.",
             "colours": [],
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "1911a5f1-e523-5ea8-a593-5bc1e0f02a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e628e89b-bee9-408d-bb05-1784fda6b8a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e628e89b-bee9-408d-bb05-1784fda6b8a1.jpg?1",
             "name": "Restless Vents",
             "text": "Restless Vents enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{1}{B}{R}: Until end of turn, Restless Vents becomes a 2/3 black and red Insect creature with menace. It's still a land.\nWhenever Restless Vents attacks, you may discard a card. If you do, draw a card.",
             "colours": [],
@@ -11068,7 +11068,7 @@
         },
         {
             "id": "7fbc77f2-7967-5135-ae91-de9f57432b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1c9b1a-e306-47bb-9f68-2083660319c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1c9b1a-e306-47bb-9f68-2083660319c0.jpg?1",
             "name": "Sunken Citadel",
             "text": "Sunken Citadel enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{T}: Add two mana of the chosen color. Spend this mana only to activate abilities of land sources.",
             "colours": [],
@@ -11100,7 +11100,7 @@
         },
         {
             "id": "18702c50-a428-5c07-833d-af12e86474ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9385abf3-b067-4586-bf3d-175526cf8f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9385abf3-b067-4586-bf3d-175526cf8f0a.jpg?1",
             "name": "Volatile Fault",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Volatile Fault: Destroy target nonbasic land an opponent controls. That player may search their library for a basic land card, put it onto the battlefield, then shuffle. You create a Treasure token.",
             "colours": [],
@@ -11130,7 +11130,7 @@
         },
         {
             "id": "fc786cb5-6c36-5dc1-bec0-5b634818a5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5453630-bfff-4403-a9a9-49f1534e1d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5453630-bfff-4403-a9a9-49f1534e1d42.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11167,7 +11167,7 @@
         },
         {
             "id": "2f69ab92-2dc8-58a2-8059-47f9135e5237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338e5b63-1fee-4a7c-af9b-483d383f79b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/338e5b63-1fee-4a7c-af9b-483d383f79b7.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "4a4f04ac-4837-5397-a39d-519fb6891401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a825ac86-d642-42fd-b6aa-94aa804907d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a825ac86-d642-42fd-b6aa-94aa804907d9.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11241,7 +11241,7 @@
         },
         {
             "id": "bccb6971-59b5-5d0c-b3ca-018a88f58d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb82fdb-5090-45c0-ae67-4846667c8625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb82fdb-5090-45c0-ae67-4846667c8625.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11278,7 +11278,7 @@
         },
         {
             "id": "96ff3340-29d4-5278-ac7a-c8456d3d7d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c13cafb-3078-4856-a5b0-c38aace8a34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c13cafb-3078-4856-a5b0-c38aace8a34a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11315,7 +11315,7 @@
         },
         {
             "id": "b2a4dce9-2de0-505a-904c-c5d7f3634932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acaf4dbe-5b63-4948-bc85-b5d288378d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acaf4dbe-5b63-4948-bc85-b5d288378d4e.jpg?1",
             "name": "Akal Pakal, First Among Equals",
             "text": "At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -11354,7 +11354,7 @@
         },
         {
             "id": "b4f0a58e-840c-5de2-b003-be4eab23d69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed6341-59f4-44f3-99c9-80f636fa484d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed6341-59f4-44f3-99c9-80f636fa484d.jpg?1",
             "name": "Malcolm, Alluring Scoundrel",
             "text": "Flash\nFlying\nWhenever Malcolm, Alluring Scoundrel deals combat damage to a player, put a chorus counter on it. Draw a card, then discard a card. If there are four or more chorus counters on Malcolm, you may cast the discarded card without paying its mana cost.",
             "colours": [
@@ -11393,7 +11393,7 @@
         },
         {
             "id": "fd8102df-14d1-5275-a81d-1d78cf2f64bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb60b23-2397-4897-9462-56b09f45f321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb60b23-2397-4897-9462-56b09f45f321.jpg?1",
             "name": "Breeches, Eager Pillager",
             "text": "First strike\nWhenever a Pirate you control attacks, choose one that hasn't been chosen this turn \u2014\n\u2022 Create a Treasure token.\n\u2022 Target creature can't block this turn.\n\u2022 Exile the top card of your library. You may play it this turn.",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "39033b89-71b2-53c1-a2ed-92d7df0f2dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0548ddb6-5301-4911-93fd-bb988275f44a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0548ddb6-5301-4911-93fd-bb988275f44a.jpg?1",
             "name": "Inti, Seneschal of the Sun",
             "text": "Whenever you attack, you may discard a card. When you do, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.\nWhenever you discard one or more cards, exile the top card of your library. You may play that card until your next end step.",
             "colours": [
@@ -11471,7 +11471,7 @@
         },
         {
             "id": "486e5452-4d52-5412-9666-c18ad3598aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -11514,7 +11514,7 @@
         },
         {
             "id": "f8ef2981-611f-530a-b34b-250f62b24e94",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b94c8a9e-5b9f-4a80-bced-ee99e5ed060a.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -11555,7 +11555,7 @@
         },
         {
             "id": "a55758bb-352a-5080-ae78-47d83ecd6195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bcc6f3-bae4-485c-82da-56c15c97c7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bcc6f3-bae4-485c-82da-56c15c97c7f8.jpg?1",
             "name": "Abuelo, Ancestral Echo",
             "text": "Flying, ward {2}\n{1}{W}{U}: Exile another target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -11595,7 +11595,7 @@
         },
         {
             "id": "7956880f-d308-5cd9-b9fd-0c9a375c0986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e9dbe6-5685-480d-b0d7-828a7058fb22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e9dbe6-5685-480d-b0d7-828a7058fb22.jpg?1",
             "name": "Akawalli, the Seething Tower",
             "text": "Descend 4 \u2014 As long as there are four or more permanent cards in your graveyard, Akawalli, the Seething Tower gets +2/+2 and has trample.\nDescend 8 \u2014 As long as there are eight or more permanent cards in your graveyard, Akawalli gets an additional +2/+2 and can't be blocked by more than one creature.",
             "colours": [
@@ -11635,7 +11635,7 @@
         },
         {
             "id": "ba612d76-f889-5e7a-9838-8ad336fe7ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ae96c-012c-4bd4-81f0-5944fc03a8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b1ae96c-012c-4bd4-81f0-5944fc03a8a9.jpg?1",
             "name": "Amalia Benavides Aguirre",
             "text": "Ward\u2014\nPay 3 life.\nWhenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other creatures if its power is exactly 20.",
             "colours": [
@@ -11676,7 +11676,7 @@
         },
         {
             "id": "195b35d5-b888-5327-ae7e-af33e1bec9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc97d16-c54c-4a2b-9691-39e8a41c7777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc97d16-c54c-4a2b-9691-39e8a41c7777.jpg?1",
             "name": "Anim Pakal, Thousandth Moon",
             "text": "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal, then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where X is the number of +1/+1 counters on Anim Pakal.",
             "colours": [
@@ -11717,7 +11717,7 @@
         },
         {
             "id": "054f2fac-092b-5916-89cf-d1482d3c925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82bb486-7009-4b53-973f-477fc13ad7e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82bb486-7009-4b53-973f-477fc13ad7e7.jpg?1",
             "name": "Bartolom\u00e9 del Presidio",
             "text": "Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolom\u00e9 del Presidio.",
             "colours": [
@@ -11759,7 +11759,7 @@
         },
         {
             "id": "23c77d59-e524-5968-bf0f-3b0c7bf0f02b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380ed1dc-afa2-4b00-8da6-6177295965b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380ed1dc-afa2-4b00-8da6-6177295965b5.jpg?1",
             "name": "Caparocti Sunborn",
             "text": "Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you control. If you do, discover 3.",
             "colours": [
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "a4aaf3a2-7b5a-5f0b-a4c4-033b7ba15ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e13dad-e326-4b8e-91c7-dc0d6c3bf51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e13dad-e326-4b8e-91c7-dc0d6c3bf51d.jpg?1",
             "name": "Captain Storm, Cosmium Raider",
             "text": "Whenever an artifact enters the battlefield under your control, put a +1/+1 counter on target Pirate you control.",
             "colours": [
@@ -11841,7 +11841,7 @@
         },
         {
             "id": "b6cfb36d-c699-5598-8cc6-102c9fa69f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fede45-8c95-45eb-915c-c3ee5101dfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fede45-8c95-45eb-915c-c3ee5101dfcc.jpg?1",
             "name": "Kutzil, Malamet Exemplar",
             "text": "Your opponents can't cast spells during your turn.\nWhenever one or more creatures you control each with power greater than its base power deals combat damage to a player, draw a card.",
             "colours": [
@@ -11882,7 +11882,7 @@
         },
         {
             "id": "7fbf5b47-c636-51d0-abe6-95f11f4ef255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e6494-6f64-4adf-96ca-65a17100b8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e6494-6f64-4adf-96ca-65a17100b8fe.jpg?1",
             "name": "The Mycotyrant",
             "text": "Trample\nThe Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings.\nAt the beginning of your end step, create X 1/1 black Fungus creature tokens with \"This creature can't block,\" where X is the number of times you descended this turn.",
             "colours": [
@@ -11923,7 +11923,7 @@
         },
         {
             "id": "af0083df-758e-5a0a-86c6-570ec397bcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6059b64c-3064-46de-af47-6dc6542dca23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6059b64c-3064-46de-af47-6dc6542dca23.jpg?1",
             "name": "Nicanzil, Current Conductor",
             "text": "Whenever a creature you control explores a land card, you may put a land card from your hand onto the battlefield tapped.\nWhenever a creature you control explores a nonland card, put a +1/+1 counter on Nicanzil, Current Conductor.",
             "colours": [
@@ -11964,7 +11964,7 @@
         },
         {
             "id": "ebf1df23-2bc3-5c68-998e-76d3131e235f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfc085d-4c11-416c-ae00-d41d32f32bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfc085d-4c11-416c-ae00-d41d32f32bb4.jpg?1",
             "name": "Quintorius Kand",
             "text": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n\u22123: Discover 4.\n\u22126: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
             "colours": [
@@ -12005,7 +12005,7 @@
         },
         {
             "id": "66ad3ab4-2918-5373-a21b-920592535701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a16ca40-2210-4f94-bfb1-960b34a7d98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a16ca40-2210-4f94-bfb1-960b34a7d98e.jpg?1",
             "name": "Saheeli, the Sun's Brilliance",
             "text": "{U}{R}, {T}: Create a token that's a copy of another target creature or artifact you control, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -12046,7 +12046,7 @@
         },
         {
             "id": "54cc50e0-017f-5987-a6d2-74e9866321ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6e7f53-d8c4-4356-a31d-ed3d5e0627cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6e7f53-d8c4-4356-a31d-ed3d5e0627cc.jpg?1",
             "name": "Sovereign Okinec Ahau",
             "text": "Ward {2}\nWhenever Sovereign Okinec Ahau attacks, for each creature you control with power greater than that creature's base power, put a number of +1/+1 counters on that creature equal to the difference.",
             "colours": [
@@ -12087,7 +12087,7 @@
         },
         {
             "id": "f538802c-8bf0-5e5a-aba2-526ff50b4473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30c23d7-8a3b-4162-89dd-5f7895c55625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30c23d7-8a3b-4162-89dd-5f7895c55625.jpg?1",
             "name": "Uchbenbak, the Great Mistake",
             "text": "Vigilance, menace\nDescend 8 \u2014 {4}{U}{B}: Return Uchbenbak, the Great Mistake from your graveyard to the battlefield with a finality counter on it. Activate only if there are eight or more permanent cards in your graveyard and only as a sorcery.",
             "colours": [
@@ -12128,7 +12128,7 @@
         },
         {
             "id": "328474d6-a636-5809-b1a9-b50d89795a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58c496-2b70-48a9-befa-9cc7baef8597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f58c496-2b70-48a9-befa-9cc7baef8597.jpg?1",
             "name": "Vito, Fanatic of Aclazotz",
             "text": "Flying\nWhenever you sacrifice another permanent, you gain 2 life if this is the first time this ability has resolved this turn. If it's the second time, each opponent loses 2 life. If it's the third time, create a 4/3 white and black Vampire Demon creature token with flying.",
             "colours": [
@@ -12169,7 +12169,7 @@
         },
         {
             "id": "8028315f-36de-58f0-ac50-0204caa496cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd2cf8-95e4-4df5-a803-66e7c4eb065a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd2cf8-95e4-4df5-a803-66e7c4eb065a.jpg?1",
             "name": "Zoyowa Lava-Tongue",
             "text": "Deathtouch\nAt the beginning of your end step, if you descended this turn, each opponent may discard a card or sacrifice a permanent. Zoyowa Lava-Tongue deals 3 damage to each opponent who didn't.",
             "colours": [
@@ -12210,7 +12210,7 @@
         },
         {
             "id": "a69b835a-495a-53c9-8054-1820413266a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [],
@@ -12244,7 +12244,7 @@
         },
         {
             "id": "f0c117f4-54bb-5596-baf2-47bfc9c6e3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7a6892-5f6b-49aa-9b4f-3fcf20236306.jpg?1",
             "name": "Throne of the Grim Captain // The Grim Captain",
             "text": "",
             "colours": [
@@ -12284,7 +12284,7 @@
         },
         {
             "id": "97be3b78-3dd8-5dc8-99cd-1407b931a9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [
@@ -12322,7 +12322,7 @@
         },
         {
             "id": "760119c9-7eb0-5431-bf41-1c0ef9387d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e87dff94-71ed-469e-a10e-3ddfbd4a8bec.jpg?1",
             "name": "Ojer Taq, Deepest Foundation // Temple of Civilization",
             "text": "",
             "colours": [],
@@ -12354,7 +12354,7 @@
         },
         {
             "id": "45d11672-2dec-574e-9ff8-fbca25d67b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [
@@ -12392,7 +12392,7 @@
         },
         {
             "id": "1e4ca96e-efa4-584e-b613-a95a53769bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a1fbfb8f-600e-4b29-98c5-7c6714d35347.jpg?1",
             "name": "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time",
             "text": "",
             "colours": [],
@@ -12424,7 +12424,7 @@
         },
         {
             "id": "a8aae7c7-c478-56e2-974b-7dc6b7db5edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95775b13-2761-424e-9828-2275ec987368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95775b13-2761-424e-9828-2275ec987368.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [
@@ -12463,7 +12463,7 @@
         },
         {
             "id": "41232c29-a075-53e1-9b43-1ec89d089882",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95775b13-2761-424e-9828-2275ec987368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95775b13-2761-424e-9828-2275ec987368.jpg?1",
             "name": "Aclazotz, Deepest Betrayal // Temple of the Dead",
             "text": "",
             "colours": [],
@@ -12495,7 +12495,7 @@
         },
         {
             "id": "f551bcb3-dd2b-569e-b2fb-cf7139c9ab40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [
@@ -12533,7 +12533,7 @@
         },
         {
             "id": "21139b7d-3432-5a9d-bffb-264cb602a743",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5140d5d0-15ad-45b2-8ae8-aa53b1cd8132.jpg?1",
             "name": "Ojer Axonil, Deepest Might // Temple of Power",
             "text": "",
             "colours": [],
@@ -12565,7 +12565,7 @@
         },
         {
             "id": "38c70afb-c100-574a-b629-f67ba0af0d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [
@@ -12603,7 +12603,7 @@
         },
         {
             "id": "18e323e8-1e14-5ed6-b316-48cc9085462c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/6/d6ed63e0-d6f1-455a-b29c-e2c91dcfcc6e.jpg?1",
             "name": "Ojer Kaslem, Deepest Growth // Temple of Cultivation",
             "text": "",
             "colours": [],
@@ -12635,7 +12635,7 @@
         },
         {
             "id": "0c39d9f8-fbc4-5386-b26d-9f5fa3d678e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebe99d-4994-450e-9abb-f0bc3750f098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebe99d-4994-450e-9abb-f0bc3750f098.jpg?1",
             "name": "The Ancient One",
             "text": "Descend 8 \u2014 The Ancient One can't attack or block unless there are eight or more permanent cards in your graveyard.\n{2}{U}{B}: Draw a card, then discard a card. When you discard a card this way, target player mills cards equal to its mana value.",
             "colours": [
@@ -12676,7 +12676,7 @@
         },
         {
             "id": "b2c16d25-1329-590c-87a1-29a7328c2a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4639ca-d4dc-4630-b696-a8107767cf1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4639ca-d4dc-4630-b696-a8107767cf1a.jpg?1",
             "name": "Belligerent Yearling",
             "text": "Trample\nWhenever another Dinosaur enters the battlefield under your control, you may have Belligerent Yearling's base power become equal to that creature's power until end of turn.",
             "colours": [
@@ -12712,7 +12712,7 @@
         },
         {
             "id": "f4e26835-a3b1-523c-ab83-f0ea5407053a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22897e93-bb69-4ad3-bdcc-723c7020a378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22897e93-bb69-4ad3-bdcc-723c7020a378.jpg?1",
             "name": "Bonehoard Dracosaur",
             "text": "Flying, first strike\nAt the beginning of your upkeep, exile the top two cards of your library. You may play them this turn. If you exiled a land card this way, create a 3/1 red Dinosaur creature token. If you exiled a nonland card this way, create a Treasure token.",
             "colours": [
@@ -12749,7 +12749,7 @@
         },
         {
             "id": "ae75aa6c-8c3c-5099-a669-ddad3c0308ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8d613-7697-413b-a107-0a25c1662835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be8d613-7697-413b-a107-0a25c1662835.jpg?1",
             "name": "Rampaging Ceratops",
             "text": "Rampaging Ceratops can't be blocked except by three or more creatures.",
             "colours": [
@@ -12785,7 +12785,7 @@
         },
         {
             "id": "fb171192-4b4f-59cc-99e4-3ce39b23dcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffe37-f466-4eea-8efc-50b53e2c27da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467ffe37-f466-4eea-8efc-50b53e2c27da.jpg?1",
             "name": "Scytheclaw Raptor",
             "text": "Whenever a player casts a spell, if it's not their turn, Scytheclaw Raptor deals 4 damage to them.",
             "colours": [
@@ -12821,7 +12821,7 @@
         },
         {
             "id": "d6ff6f08-b88d-500d-a026-b4f4919761c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35957bfb-c75f-4181-9726-19956992a6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35957bfb-c75f-4181-9726-19956992a6e6.jpg?1",
             "name": "Trumpeting Carnosaur",
             "text": "Trample\nWhen Trumpeting Carnosaur enters the battlefield, discover 5.\n{2}{R}, Discard Trumpeting Carnosaur: It deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -12857,7 +12857,7 @@
         },
         {
             "id": "f5b99fb6-9d66-5f72-b50c-80df662acad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158ad2e4-5e81-439b-9629-a9d217c45d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158ad2e4-5e81-439b-9629-a9d217c45d83.jpg?1",
             "name": "Earthshaker Dreadmaw",
             "text": "Trample\nWhen Earthshaker Dreadmaw enters the battlefield, draw a card for each other Dinosaur you control.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "66956536-1c2c-5603-8a62-594917804405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591b6a9-ac99-42ad-9b01-c09a3e90201b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591b6a9-ac99-42ad-9b01-c09a3e90201b.jpg?1",
             "name": "Ghalta, Stampede Tyrant",
             "text": "Trample\nWhen Ghalta, Stampede Tyrant enters the battlefield, put any number of creature cards from your hand onto the battlefield.",
             "colours": [
@@ -12932,7 +12932,7 @@
         },
         {
             "id": "f007f9cd-4d90-5575-a277-aae8ec71e507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b95a76-688c-4bd9-a759-f83f1aa18e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b95a76-688c-4bd9-a759-f83f1aa18e2a.jpg?1",
             "name": "Hulking Raptor",
             "text": "Ward {2}\nAt the beginning of your precombat main phase, add {G}{G}.",
             "colours": [
@@ -12968,7 +12968,7 @@
         },
         {
             "id": "7df81431-c6dd-504c-91b1-59ca0529162c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83cb05bc-5137-477e-b7f4-e914f7fa543f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83cb05bc-5137-477e-b7f4-e914f7fa543f.jpg?1",
             "name": "Pugnacious Hammerskull",
             "text": "Whenever Pugnacious Hammerskull attacks while you don't control another Dinosaur, put a stun counter on it.",
             "colours": [
@@ -13004,7 +13004,7 @@
         },
         {
             "id": "6cbf7eea-0737-5054-8912-079b757a647f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb1c91a-398c-437a-9a77-5b8515fc3ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cb1c91a-398c-437a-9a77-5b8515fc3ef2.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -13040,7 +13040,7 @@
         },
         {
             "id": "2a298154-24a8-594a-ad4f-a5fae1fde812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cef59-bc7a-48e0-b05a-d9bdd6e05927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cef59-bc7a-48e0-b05a-d9bdd6e05927.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "Vigilance, trample, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13083,7 +13083,7 @@
         },
         {
             "id": "66ab685c-e934-5052-972e-591c25ec52d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f2aa6b-a092-4348-a24f-5edf46544eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f2aa6b-a092-4348-a24f-5edf46544eb7.jpg?1",
             "name": "Itzquinth, Firstborn of Gishath",
             "text": "Haste\nWhen Itzquinth, Firstborn of Gishath enters the battlefield, you may pay {2}. When you do, target Dinosaur you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -13123,7 +13123,7 @@
         },
         {
             "id": "42fdaa9f-634f-528b-8d8f-8b3c3f4d02de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0817334-d7ba-4de9-ade7-67beef358d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0817334-d7ba-4de9-ade7-67beef358d1f.jpg?1",
             "name": "Palani's Hatcher",
             "text": "Other Dinosaurs you control have haste.\nWhen Palani's Hatcher enters the battlefield, create two 0/1 green Dinosaur Egg creature tokens.\nAt the beginning of combat on your turn, if you control one or more Eggs, sacrifice an Egg, then create a 3/3 green Dinosaur creature token.",
             "colours": [
@@ -13161,7 +13161,7 @@
         },
         {
             "id": "752dfd16-7cd8-5da5-8170-1a4a9e853715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d60e0bc-1ce1-4b91-9952-16b394b5a348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d60e0bc-1ce1-4b91-9952-16b394b5a348.jpg?1",
             "name": "Get Lost",
             "text": "Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens.",
             "colours": [
@@ -13195,7 +13195,7 @@
         },
         {
             "id": "17cbf82c-79c1-50ea-b68f-e7b8cb6f9b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e827612d-5a43-4a29-b0c1-ab7f3285ad98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e827612d-5a43-4a29-b0c1-ab7f3285ad98.jpg?1",
             "name": "Resplendent Angel",
             "text": "Flying\nAt the beginning of each end step, if you gained 5 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.\n{3}{W}{W}{W}: Until end of turn, Resplendent Angel gets +2/+2 and gains lifelink.",
             "colours": [
@@ -13231,7 +13231,7 @@
         },
         {
             "id": "e9e6f23a-4a14-5ad5-81dc-faf62b3e8143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604e2bfc-655d-4d3e-98aa-374780ca4016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604e2bfc-655d-4d3e-98aa-374780ca4016.jpg?1",
             "name": "Tishana's Tidebinder",
             "text": "Flash\nWhen Tishana's Tidebinder enters the battlefield, counter up to one target activated or triggered ability. If an ability of an artifact, creature, or planeswalker is countered this way, that permanent loses all abilities for as long as Tishana's Tidebinder remains on the battlefield.",
             "colours": [
@@ -13268,7 +13268,7 @@
         },
         {
             "id": "10b72655-aac7-5bff-94dd-f6e79a86f52c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c5b98d-73cd-4b69-9933-4867da6e8389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c5b98d-73cd-4b69-9933-4867da6e8389.jpg?1",
             "name": "Bloodletter of Aclazotz",
             "text": "Flying\nIf an opponent would lose life during your turn, they lose twice that much life instead.",
             "colours": [
@@ -13305,7 +13305,7 @@
         },
         {
             "id": "7277115b-4b3f-5254-aa52-b6400f6476bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e732f7-85d7-4b2e-b332-9be30bfba3d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e732f7-85d7-4b2e-b332-9be30bfba3d5.jpg?1",
             "name": "Bringer of the Last Gift",
             "text": "Flying\nWhen Bringer of the Last Gift enters the battlefield, if you cast it, each player sacrifices all other creatures they control. Then each player returns all creature cards from their graveyard that weren't put there this way to the battlefield.",
             "colours": [
@@ -13342,7 +13342,7 @@
         },
         {
             "id": "b5610a6b-2149-58f0-a0f0-5a53ca8559b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ff99a-9ecc-4f1b-9c85-e0820f3a5729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6ff99a-9ecc-4f1b-9c85-e0820f3a5729.jpg?1",
             "name": "Starving Revenant",
             "text": "When Starving Revenant enters the battlefield, surveil 2. Then for each card you put on top of your library, you draw a card and you lose 3 life.\nDescend 8 \u2014 Whenever you draw a card, if there are eight or more permanent cards in your graveyard, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -13379,7 +13379,7 @@
         },
         {
             "id": "caec88df-bfbb-5854-94d1-ba5772a12687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -13422,7 +13422,7 @@
         },
         {
             "id": "64569a27-df1e-574a-a784-1f26689232c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cdeebd8-28d4-42a5-9a99-3c72771359ea.jpg?1",
             "name": "Huatli, Poet of Unity // Roar of the Fifth People",
             "text": "",
             "colours": [
@@ -13463,7 +13463,7 @@
         },
         {
             "id": "49985e27-e056-517f-a28f-f12d712b0f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c4b837-1557-4dda-a324-9646ce702dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c4b837-1557-4dda-a324-9646ce702dfd.jpg?1",
             "name": "The Skullspore Nexus",
             "text": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nWhenever one or more nontoken creatures you control die, create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.\n{2}, {T}: Double target creature's power until end of turn.",
             "colours": [
@@ -13499,7 +13499,7 @@
         },
         {
             "id": "43f32809-0855-56ca-bb11-9d53cadcbd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -13540,7 +13540,7 @@
         },
         {
             "id": "5a587554-a633-5267-a4d2-0a18482a3b86",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95a9d11a-ecf0-471e-9dc3-a5baa6725044.jpg?1",
             "name": "Kellan, Daring Traveler // Journey On",
             "text": "",
             "colours": [
@@ -13577,7 +13577,7 @@
         },
         {
             "id": "4bc137f8-7fbd-5a46-b518-df1bd477ca21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda9470-7150-48bf-8fbf-1cb0cc80d2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda9470-7150-48bf-8fbf-1cb0cc80d2e1.jpg?1",
             "name": "Molten Collapse",
             "text": "Choose one. If you descended this turn, you may choose both instead.\n\u2022 Destroy target creature or planeswalker.\n\u2022 Destroy target noncreature, nonland permanent with mana value 1 or less.",
             "colours": [
@@ -13613,7 +13613,7 @@
         },
         {
             "id": "1ddbebb2-fa6d-5481-9240-8edec2216bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e435c3bf-2b64-4db4-b9a2-322095b566bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e435c3bf-2b64-4db4-b9a2-322095b566bf.jpg?1",
             "name": "Wail of the Forgotten",
             "text": "Descend 8 \u2014 Choose one. If there are eight or more permanent cards in your graveyard as you cast this spell, choose one or more instead.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Target opponent discards a card.\n\u2022 Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -13649,7 +13649,7 @@
         },
         {
             "id": "f2bc10a7-25d8-5908-ab9a-d28ff8fe8c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff7858d-f18d-4e5a-9467-ebef3ef53ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff7858d-f18d-4e5a-9467-ebef3ef53ac1.jpg?1",
             "name": "Roaming Throne",
             "text": "Ward {2}\nAs Roaming Throne enters the battlefield, choose a creature type.\nRoaming Throne is the chosen type in addition to its other types.\nIf a triggered ability of another creature you control of the chosen type triggers, it triggers an additional time.",
             "colours": [],
@@ -13682,7 +13682,7 @@
         },
         {
             "id": "10fdba40-033e-508a-8791-3233802f1522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d842f91-a04c-4b11-8ac9-0c0536b82d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d842f91-a04c-4b11-8ac9-0c0536b82d03.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -13718,7 +13718,7 @@
         },
         {
             "id": "0de04c7c-f731-51ee-a009-8e735c8f9346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6392d30-07c4-4c63-acb4-ad12d08c080b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6392d30-07c4-4c63-acb4-ad12d08c080b.jpg?1",
             "name": "Echoing Deeps",
             "text": "You may have Echoing Deeps enter the battlefield tapped as a copy of any land card in a graveyard, except it's a Cave in addition to its other types.\n{T}: Add {C}.",
             "colours": [],
@@ -13750,7 +13750,7 @@
         },
         {
             "id": "05afa715-06ac-576d-8a8d-7df5bb281585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc7725d-eb04-4778-8f5e-4c1239ed08b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc7725d-eb04-4778-8f5e-4c1239ed08b8.jpg?1",
             "name": "Restless Anchorage",
             "text": "Restless Anchorage enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{1}{W}{U}: Until end of turn, Restless Anchorage becomes a 2/3 white and blue Bird creature with flying. It's still a land.\nWhenever Restless Anchorage attacks, create a Map token.",
             "colours": [],
@@ -13783,7 +13783,7 @@
         },
         {
             "id": "d84c2655-31a6-51f7-98f3-b7ff88b9b758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802788a-8a40-40e7-9d33-58191d1d678a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7802788a-8a40-40e7-9d33-58191d1d678a.jpg?1",
             "name": "Restless Prairie",
             "text": "Restless Prairie enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}: Restless Prairie becomes a 3/3 green and white Llama creature until end of turn. It's still a land.\nWhenever Restless Prairie attacks, other creatures you control get +1/+1 until end of turn.",
             "colours": [],
@@ -13816,7 +13816,7 @@
         },
         {
             "id": "4c0d1004-8408-57db-a933-7cd0f3c0ad99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315e121-cf10-4442-91c0-036ca5bbc652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315e121-cf10-4442-91c0-036ca5bbc652.jpg?1",
             "name": "Restless Reef",
             "text": "Restless Reef enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}: Until end of turn, Restless Reef becomes a 4/4 blue and black Shark creature with deathtouch. It's still a land.\nWhenever Restless Reef attacks, target player mills four cards.",
             "colours": [],
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "5b95bbbf-ef03-56d5-aa0c-07ec811479bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2634eb9f-d797-4af4-90d3-7a39fae8300b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2634eb9f-d797-4af4-90d3-7a39fae8300b.jpg?1",
             "name": "Restless Ridgeline",
             "text": "Restless Ridgeline enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Restless Ridgeline becomes a 3/4 red and green Dinosaur creature until end of turn. It's still a land.\nWhenever Restless Ridgeline attacks, another target attacking creature gets +2/+0 until end of turn. Untap that creature.",
             "colours": [],
@@ -13882,7 +13882,7 @@
         },
         {
             "id": "c949d99f-b5b0-5b7a-bbd5-51eaa670b459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9200f9b5-20fc-4ff0-97f7-ef22da5acb72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9200f9b5-20fc-4ff0-97f7-ef22da5acb72.jpg?1",
             "name": "Restless Vents",
             "text": "Restless Vents enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{1}{B}{R}: Until end of turn, Restless Vents becomes a 2/3 black and red Insect creature with menace. It's still a land.\nWhenever Restless Vents attacks, you may discard a card. If you do, draw a card.",
             "colours": [],
@@ -13915,7 +13915,7 @@
         },
         {
             "id": "a373f6d0-8f23-5e2b-bb98-e1d9d35aa0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c80368-0fe6-481a-bee0-7d9f65afb233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c80368-0fe6-481a-bee0-7d9f65afb233.jpg?1",
             "name": "Quintorius Kand",
             "text": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n\u22123: Discover 4.\n\u22126: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
             "colours": [
@@ -13956,7 +13956,7 @@
         },
         {
             "id": "08dc4efb-1e2e-518d-bcb7-e22c36198727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d2fe5-674d-4b3d-b658-ae6901e8044f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d2fe5-674d-4b3d-b658-ae6901e8044f.jpg?1",
             "name": "Abuelo's Awakening",
             "text": "Return target artifact or non-Aura enchantment card from your graveyard to the battlefield with X additional +1/+1 counters on it. It's a 1/1 Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -13990,7 +13990,7 @@
         },
         {
             "id": "adff9ae1-933b-5b2a-a0a6-f19c1cf88cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5efc5e-1582-4bb7-9ae1-bc4c0487ee94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5efc5e-1582-4bb7-9ae1-bc4c0487ee94.jpg?1",
             "name": "Fabrication Foundry",
             "text": "{T}: Add {W}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.\n{2}{W}, {T}, Exile one or more other artifacts you control with total mana value X: Return target artifact card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -14024,7 +14024,7 @@
         },
         {
             "id": "ea0d914f-dae2-5087-b3a6-933adf319e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685b735e-52a6-4fd6-a12e-d059c13d4afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685b735e-52a6-4fd6-a12e-d059c13d4afc.jpg?1",
             "name": "Kutzil's Flanker",
             "text": "Flash\nWhen Kutzil's Flanker enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Kutzil's Flanker for each creature that left the battlefield under your control this turn.\n\u2022 You gain 2 life and scry 2.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -14061,7 +14061,7 @@
         },
         {
             "id": "e93dffaa-f89f-5c28-8edb-33a2b2b1c5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a046c0df-7dba-4a05-b4b4-a76321b15480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a046c0df-7dba-4a05-b4b4-a76321b15480.jpg?1",
             "name": "Sanguine Evangelist",
             "text": "Battle cry\nWhen Sanguine Evangelist enters the battlefield or dies, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -14098,7 +14098,7 @@
         },
         {
             "id": "572cb3d6-339a-5519-b456-1fedaf99f177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [
@@ -14134,7 +14134,7 @@
         },
         {
             "id": "e1f0d32a-b10d-5d41-9e12-5518c49077d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1",
             "name": "Thousand Moons Smithy // Barracks of the Thousand",
             "text": "",
             "colours": [],
@@ -14169,7 +14169,7 @@
         },
         {
             "id": "4cd93cdc-ad41-54c4-ba08-3bbc70df38c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -14203,7 +14203,7 @@
         },
         {
             "id": "1927ed25-1535-5917-b4c4-e36e5c5216f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8a23e3f-57c8-4cbb-bb6c-d5fdf49a2d9c.jpg?1",
             "name": "Unstable Glyphbridge // Sandswirl Wanderglyph",
             "text": "",
             "colours": [
@@ -14240,7 +14240,7 @@
         },
         {
             "id": "f8b95775-f106-5833-856e-20d95ead785b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1e97-d1c7-450e-a935-50b386b6b762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1e97-d1c7-450e-a935-50b386b6b762.jpg?1",
             "name": "Warden of the Inner Sky",
             "text": "As long as Warden of the Inner Sky has three or more counters on it, it has flying and vigilance.\nTap three untapped artifacts and/or creatures you control: Put a +1/+1 counter on Warden of the Inner Sky. Scry 1. Activate only as a sorcery.",
             "colours": [
@@ -14277,7 +14277,7 @@
         },
         {
             "id": "4dbf6ee8-d7c2-52b1-91d7-d6d12c38baf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -14311,7 +14311,7 @@
         },
         {
             "id": "0215052b-69d2-5ebc-9c39-0a802f9e9253",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c8157978-259e-4af1-890e-ea56a55a9997.jpg?1",
             "name": "Braided Net // Braided Quipu",
             "text": "",
             "colours": [
@@ -14345,7 +14345,7 @@
         },
         {
             "id": "6a0af0f9-3302-52f3-810a-d9ccce83ebb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790d70a9-ff02-4676-a804-ee0e030dfe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790d70a9-ff02-4676-a804-ee0e030dfe3b.jpg?1",
             "name": "Deeproot Pilgrimage",
             "text": "Whenever one or more nontoken Merfolk you control become tapped, create a 1/1 blue Merfolk creature token with hexproof.",
             "colours": [
@@ -14379,7 +14379,7 @@
         },
         {
             "id": "56e7b95c-f3c0-52bc-b52d-8eba42951694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "1c21b95b-6a47-591a-859a-9e6bda216ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d9cbb83-a89f-411b-88c8-c01718f265e0.jpg?1",
             "name": "The Enigma Jewel // Locus of Enlightenment",
             "text": "",
             "colours": [
@@ -14451,7 +14451,7 @@
         },
         {
             "id": "fa524300-996d-5c35-ab8e-f5425e9eb67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [
@@ -14487,7 +14487,7 @@
         },
         {
             "id": "bc79f063-cc10-5e70-ab0b-d506ada99cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/581327f5-6e79-4720-9695-198b287a92bb.jpg?1",
             "name": "The Everflowing Well // The Myriad Pools",
             "text": "",
             "colours": [],
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "8f4da1dc-be0f-510a-b1fc-d1aac87e1300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2a1f9-7846-4f96-b20d-ceb638e9ed42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2a1f9-7846-4f96-b20d-ceb638e9ed42.jpg?1",
             "name": "Kitesail Larcenist",
             "text": "Flying, ward {1}\nWhen Kitesail Larcenist enters the battlefield, for each player, choose up to one other target artifact or creature that player controls. For as long as Kitesail Larcenist remains on the battlefield, the chosen permanents become Treasure artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color\" and lose all other abilities.",
             "colours": [
@@ -14559,7 +14559,7 @@
         },
         {
             "id": "db391da6-e32a-5227-bd0f-e2eb87e290cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c87307e-59f0-4747-b0d2-e8b65f4b260e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c87307e-59f0-4747-b0d2-e8b65f4b260e.jpg?1",
             "name": "Subterranean Schooner",
             "text": "Whenever Subterranean Schooner attacks, target creature that crewed it this turn explores.\nCrew 1",
             "colours": [
@@ -14595,7 +14595,7 @@
         },
         {
             "id": "909da4eb-201b-57a3-b65a-a717f88f98c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3eb24e-bba4-463b-ad7e-e3daebda1e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3eb24e-bba4-463b-ad7e-e3daebda1e74.jpg?1",
             "name": "Corpses of the Lost",
             "text": "Skeletons you control get +1/+0 and have haste.\nWhen Corpses of the Lost enters the battlefield, create a 2/2 black Skeleton Pirate creature token.\nAt the beginning of your end step, if you descended this turn, you may pay 1 life. If you do, return Corpses of the Lost to its owner's hand.",
             "colours": [
@@ -14629,7 +14629,7 @@
         },
         {
             "id": "e738981f-1ada-5d88-bf50-6dde2a09c353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0db433-7ca2-48d6-b60c-0a9a9149378a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0db433-7ca2-48d6-b60c-0a9a9149378a.jpg?1",
             "name": "Preacher of the Schism",
             "text": "Deathtouch\nWhenever Preacher of the Schism attacks the player with the most life or tied for most life, create a 1/1 white Vampire creature token with lifelink.\nWhenever Preacher of the Schism attacks while you have the most life or are tied for most life, you draw a card and you lose 1 life.",
             "colours": [
@@ -14666,7 +14666,7 @@
         },
         {
             "id": "87688b52-5113-557e-b1b4-f9d5fe91a2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cdb01-d303-438c-9c87-ca334ac68582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a40cdb01-d303-438c-9c87-ca334ac68582.jpg?1",
             "name": "Queen's Bay Paladin",
             "text": "Whenever Queen's Bay Paladin enters the battlefield or attacks, return up to one target Vampire card from your graveyard to the battlefield with a finality counter on it. You lose life equal to its mana value.",
             "colours": [
@@ -14703,7 +14703,7 @@
         },
         {
             "id": "404ad07e-3c71-5d11-b0c7-869e0e59feb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc2f3d3-6bac-4ca7-9c42-badf649269f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc2f3d3-6bac-4ca7-9c42-badf649269f5.jpg?1",
             "name": "Souls of the Lost",
             "text": "As an additional cost to cast this spell, discard a card or sacrifice a permanent.\nFathomless descent \u2014 Souls of the Lost's power is equal to the number of permanent cards in your graveyard and its toughness is equal to that number plus 1.",
             "colours": [
@@ -14739,7 +14739,7 @@
         },
         {
             "id": "f2e10670-e226-5194-a930-e327167aebd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8754c3b-2deb-45af-9024-1f070496b45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8754c3b-2deb-45af-9024-1f070496b45b.jpg?1",
             "name": "Stalactite Stalker",
             "text": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on Stalactite Stalker.\n{2}{B}, Sacrifice Stalactite Stalker: Target creature gets -X/-X until end of turn, where X is Stalactite Stalker's power.",
             "colours": [
@@ -14776,7 +14776,7 @@
         },
         {
             "id": "ecfe6f19-6826-54f2-98f1-e4cc58458373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [
@@ -14812,7 +14812,7 @@
         },
         {
             "id": "be88500c-b388-5980-b6d4-96c44536a981",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/3577ac1a-7c14-4463-a8c0-530f37f3d935.jpg?1",
             "name": "Tarrian's Journal // The Tomb of Aclazotz",
             "text": "",
             "colours": [],
@@ -14848,7 +14848,7 @@
         },
         {
             "id": "3e4d8447-4ece-5d1c-8cb5-6ffb07577e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39776030-4a89-4b22-952b-4a7f33f655b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39776030-4a89-4b22-952b-4a7f33f655b5.jpg?1",
             "name": "Terror Tide",
             "text": "Fathomless descent \u2014 All creatures get -X/-X until end of turn, where X is the number of permanent cards in your graveyard.",
             "colours": [
@@ -14882,7 +14882,7 @@
         },
         {
             "id": "db43f4a0-330f-5191-928b-9e0f230a04db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [
@@ -14918,7 +14918,7 @@
         },
         {
             "id": "648ec2a1-aef1-5233-aded-e57641491a44",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db940d06-5e3d-4831-a200-de614c093aca.jpg?1",
             "name": "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift",
             "text": "",
             "colours": [],
@@ -14954,7 +14954,7 @@
         },
         {
             "id": "96977cb5-eab7-5ad3-8dae-149136ee012b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -14990,7 +14990,7 @@
         },
         {
             "id": "e015cc79-fcb6-5712-88a8-8513f79bca4c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/3/c3c5e4a1-7668-41a0-acd3-d45809b6a95e.jpg?1",
             "name": "Dire Flail // Dire Blunderbuss",
             "text": "",
             "colours": [
@@ -15026,7 +15026,7 @@
         },
         {
             "id": "9658fd0c-94d2-5c21-a5c7-fa7dc5586cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e794c1-33a3-462f-b8e5-479c3acf91d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e794c1-33a3-462f-b8e5-479c3acf91d3.jpg?1",
             "name": "Hit the Mother Lode",
             "text": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference.",
             "colours": [
@@ -15061,7 +15061,7 @@
         },
         {
             "id": "3921693b-0752-57a6-9131-2e93c065319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba4238b-e7fb-4859-87e4-c192e7e6c047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba4238b-e7fb-4859-87e4-c192e7e6c047.jpg?1",
             "name": "Magmatic Galleon",
             "text": "When Magmatic Galleon enters the battlefield, it deals 5 damage to target creature an opponent controls.\nWhenever one or more creatures your opponents control are dealt excess noncombat damage, create a Treasure token.\nCrew 2",
             "colours": [
@@ -15097,7 +15097,7 @@
         },
         {
             "id": "d6a013b5-76e6-59c5-832a-86ad2f07635c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9bec4a-084b-4972-9a6b-58050088168b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9bec4a-084b-4972-9a6b-58050088168b.jpg?1",
             "name": "Poetic Ingenuity",
             "text": "Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.\nWhenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. This ability triggers only once each turn.",
             "colours": [
@@ -15131,7 +15131,7 @@
         },
         {
             "id": "c3517f50-9474-5c62-b602-af533a07e245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fea4c57-326e-4783-b5b5-0b28fcf6fe7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fea4c57-326e-4783-b5b5-0b28fcf6fe7f.jpg?1",
             "name": "Bedrock Tortoise",
             "text": "As long as it's your turn, creatures you control have hexproof.\nEach creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -15167,7 +15167,7 @@
         },
         {
             "id": "766a6710-e69f-5b2b-955a-4ee1910ab3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8f827d-300a-4d75-b894-c6dd2e5997ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8f827d-300a-4d75-b894-c6dd2e5997ce.jpg?1",
             "name": "Cosmium Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n\u2022 Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -15201,7 +15201,7 @@
         },
         {
             "id": "af702d72-2f65-5131-872c-c8e01a05407f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [
@@ -15237,7 +15237,7 @@
         },
         {
             "id": "f52142c7-caa7-58e7-a08a-5ae2a2b5ce45",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36651c33-d570-4d48-a1d3-bac736d3f043.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "",
             "colours": [],
@@ -15271,7 +15271,7 @@
         },
         {
             "id": "2e547af8-b3af-521f-aac2-ca0c057c19cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112da23d-3f13-4438-b027-10c5493808bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112da23d-3f13-4438-b027-10c5493808bd.jpg?1",
             "name": "Intrepid Paleontologist",
             "text": "{T}: Add one mana of any color.\n{2}: Exile target card from a graveyard.\nYou may cast Dinosaur creature spells from among cards you own exiled with Intrepid Paleontologist. If you cast a spell this way, that creature enters the battlefield with a finality counter on it.",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "c7b76ea0-b86f-51db-a3dd-ceba01f4286e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d47f-8a4b-47fc-9c5d-641f57631af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0987d47f-8a4b-47fc-9c5d-641f57631af0.jpg?1",
             "name": "Jadelight Spelunker",
             "text": "When Jadelight Spelunker enters the battlefield, it explores X times.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "61fb8d6b-3c60-544c-8b18-b31ca8690e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0563531-ccd5-4dc4-88dd-a1e438507cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0563531-ccd5-4dc4-88dd-a1e438507cba.jpg?1",
             "name": "Sentinel of the Nameless City",
             "text": "Vigilance\nWhenever Sentinel of the Nameless City enters the battlefield or attacks, create a Map token.",
             "colours": [
@@ -15384,7 +15384,7 @@
         },
         {
             "id": "99fb02b3-d05d-5b70-a55a-15ccf11b1ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a31f6e4-9fc7-46b3-85f8-82025817a35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a31f6e4-9fc7-46b3-85f8-82025817a35d.jpg?1",
             "name": "The Belligerent",
             "text": "Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the top card of your library any time, and you may play lands and cast spells from the top of your library.\nCrew 3",
             "colours": [
@@ -15424,7 +15424,7 @@
         },
         {
             "id": "6ddb62cf-51c7-528f-98be-0984db8e65eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78301-333a-428e-9af9-588a103cc527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78301-333a-428e-9af9-588a103cc527.jpg?1",
             "name": "Deepfathom Echo",
             "text": "At the beginning of combat on your turn, Deepfathom Echo explores. Then you may have it become a copy of another creature you control until end of turn.",
             "colours": [
@@ -15463,7 +15463,7 @@
         },
         {
             "id": "7b612c46-42ee-50d1-a649-7e9d3f97ad44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d165f708-65e9-4dbb-8a8c-085c5a2881d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d165f708-65e9-4dbb-8a8c-085c5a2881d6.jpg?1",
             "name": "Squirming Emergence",
             "text": "Fathomless descent \u2014 Return to the battlefield target nonland permanent card in your graveyard with mana value less than or equal to the number of permanent cards in your graveyard.",
             "colours": [
@@ -15499,7 +15499,7 @@
         },
         {
             "id": "863b2f60-f7a0-5dd6-909c-231cca0b9578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -15531,7 +15531,7 @@
         },
         {
             "id": "c6ad4f67-f146-561a-9af7-f4dfbd9bb4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5e03b08d-f0f1-40e8-af48-1622430bab38.jpg?1",
             "name": "Matzalantli, the Great Door // The Core",
             "text": "",
             "colours": [],
@@ -15563,7 +15563,7 @@
         },
         {
             "id": "386bddec-429a-50e8-87fa-dfcc0f981cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a710ed-6a2a-4702-9648-7807e8c24edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53a710ed-6a2a-4702-9648-7807e8c24edc.jpg?1",
             "name": "The Millennium Calendar",
             "text": "Whenever you untap one or more permanents during your untap step, put that many time counters on The Millennium Calendar.\n{2}, {T}: Double the number of time counters on The Millennium Calendar.\nWhen there are 1,000 or more time counters on The Millennium Calendar, sacrifice it and each opponent loses 1,000 life.",
             "colours": [],
@@ -15595,7 +15595,7 @@
         },
         {
             "id": "fd8b94e7-d518-534a-9c7f-0facf84d13fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8cca6-d92c-40e8-b657-b708a08b63ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8cca6-d92c-40e8-b657-b708a08b63ed.jpg?1",
             "name": "Tarrian's Soulcleaver",
             "text": "Equipped creature has vigilance.\nWhenever another artifact or creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature.\nEquip {2}",
             "colours": [],
@@ -15629,7 +15629,7 @@
         },
         {
             "id": "1b036bfb-451e-595f-9b8d-6083caa9cc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d3058-cc7d-4bb7-a312-4d2d7365ef19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d3058-cc7d-4bb7-a312-4d2d7365ef19.jpg?1",
             "name": "Threefold Thunderhulk",
             "text": "Threefold Thunderhulk enters the battlefield with three +1/+1 counters on it.\nWhenever Threefold Thunderhulk enters the battlefield or attacks, create a number of 1/1 colorless Gnome artifact creature tokens equal to its power.\n{2}, Sacrifice another artifact: Put a +1/+1 counter on Threefold Thunderhulk.",
             "colours": [],
@@ -15662,7 +15662,7 @@
         },
         {
             "id": "8b5dac36-303a-5a94-8615-1dfcbc3bdc91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "ae0cc7e5-bd90-5d00-9a01-ffe1dd6c1f98",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/2018a8e6-7699-440f-94d5-91cf6ac3edb5.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "",
             "colours": [],
@@ -15722,7 +15722,7 @@
         },
         {
             "id": "6d703da8-11a3-5c08-bac7-163e31926877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4843c-8033-4775-9ffe-4f3980fabfeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f4843c-8033-4775-9ffe-4f3980fabfeb.jpg?1",
             "name": "Sunken Citadel",
             "text": "Sunken Citadel enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.\n{T}: Add two mana of the chosen color. Spend this mana only to activate abilities of land sources.",
             "colours": [],
@@ -15754,7 +15754,7 @@
         },
         {
             "id": "0debfcd6-f09c-5d01-87d9-62db4ec6a0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716a32c-91a6-470a-a686-d5eb3d27f46e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4716a32c-91a6-470a-a686-d5eb3d27f46e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15791,7 +15791,7 @@
         },
         {
             "id": "ea6de305-b334-532f-8a8b-083227c886f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06c72cb-03ce-48eb-b5dc-b2301c6871a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06c72cb-03ce-48eb-b5dc-b2301c6871a2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "dd273d2e-9bcb-5e58-afac-91bfcc8b4621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e3ed2c-342b-44aa-8e3e-0c53602397c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e3ed2c-342b-44aa-8e3e-0c53602397c3.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15865,7 +15865,7 @@
         },
         {
             "id": "7acde3a9-8029-5876-87b7-e0fb903f417e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f9dab5-4b13-4a98-8a64-76e69f0ba511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f9dab5-4b13-4a98-8a64-76e69f0ba511.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15902,7 +15902,7 @@
         },
         {
             "id": "db27fc4f-d97d-50ef-a942-d11f205bb537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f893107-84b0-4e3f-b1f5-b04632f192c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f893107-84b0-4e3f-b1f5-b04632f192c5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15939,7 +15939,7 @@
         },
         {
             "id": "1b193b42-8ab7-5f25-b2b9-63aeb10e7e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0b0b4f-2b31-4fe1-aedb-be9d34fce688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0b0b4f-2b31-4fe1-aedb-be9d34fce688.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15976,7 +15976,7 @@
         },
         {
             "id": "8dff7df4-2465-57cf-a655-b080fa7569b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82fc4bc-ac81-4ad6-8b33-781d047f60d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82fc4bc-ac81-4ad6-8b33-781d047f60d5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16013,7 +16013,7 @@
         },
         {
             "id": "4b6a107d-dffc-583f-b095-ba0c2173b8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8e09c2-3384-4d00-a2d0-65d6b8056e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8e09c2-3384-4d00-a2d0-65d6b8056e30.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16050,7 +16050,7 @@
         },
         {
             "id": "c45f48f7-49a7-58eb-b756-dc059692c30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954219a-fd4b-4fb1-945f-7950efc1d975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f954219a-fd4b-4fb1-945f-7950efc1d975.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16087,7 +16087,7 @@
         },
         {
             "id": "e724da3a-fd41-5cdb-b639-b03449261da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1069841a-0642-4fb6-b831-d45ff7fda3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1069841a-0642-4fb6-b831-d45ff7fda3af.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16124,7 +16124,7 @@
         },
         {
             "id": "2245132f-5fa6-503c-9230-7db0f57102fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee66a2c-0684-4324-82fc-60c13a55602e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee66a2c-0684-4324-82fc-60c13a55602e.jpg?1",
             "name": "Jadelight Spelunker",
             "text": "When Jadelight Spelunker enters the battlefield, it explores X times.",
             "colours": [
@@ -16161,7 +16161,7 @@
         },
         {
             "id": "4cb52155-331b-500d-88a0-e25fedf3b048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3ed0f5-b476-4595-bdff-531488961a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3ed0f5-b476-4595-bdff-531488961a87.jpg?1",
             "name": "Hit the Mother Lode",
             "text": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference.",
             "colours": [
@@ -16195,7 +16195,7 @@
         },
         {
             "id": "ae3e80ce-44c9-5c0a-87be-1ced8eaacd49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24643b00-9062-42bd-9ecd-f6990ddbca91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24643b00-9062-42bd-9ecd-f6990ddbca91.jpg?1",
             "name": "Spyglass Siren",
             "text": "Flying\nWhen Spyglass Siren enters the battlefield, create a Map token.",
             "colours": [
@@ -16232,7 +16232,7 @@
         },
         {
             "id": "a7f931a4-0828-505d-bf89-2e0eada89465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444190a9-5ad7-4132-aae4-247ad3d9ea01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444190a9-5ad7-4132-aae4-247ad3d9ea01.jpg?1",
             "name": "Deep-Cavern Bat",
             "text": "Flying, lifelink\nWhen Deep-Cavern Bat enters the battlefield, look at target opponent's hand. You may exile a nonland card from it until Deep-Cavern Bat leaves the battlefield.",
             "colours": [
@@ -16268,7 +16268,7 @@
         },
         {
             "id": "48b79211-8b51-5a7f-b6ac-dc677e4701ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb48483-5990-46cf-b200-032500c4a6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb48483-5990-46cf-b200-032500c4a6b3.jpg?1",
             "name": "Geological Appraiser",
             "text": "When Geological Appraiser enters the battlefield, if you cast it, discover 3.",
             "colours": [
@@ -16305,7 +16305,7 @@
         },
         {
             "id": "43a114ce-0f55-5f7c-a2c5-e00a5cf3da6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f338f13-eac2-4088-a33c-cb389fbe967a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f338f13-eac2-4088-a33c-cb389fbe967a.jpg?1",
             "name": "Cenote Scout",
             "text": "When Cenote Scout enters the battlefield, it explores.",
             "colours": [
@@ -16342,7 +16342,7 @@
         },
         {
             "id": "1a9d0c05-e986-5062-b1f0-08098283b3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aade7c6c-fa34-4f69-9b5d-cf57a5341ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aade7c6c-fa34-4f69-9b5d-cf57a5341ccc.jpg?1",
             "name": "Bartolom\u00e9 del Presidio",
             "text": "Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolom\u00e9 del Presidio.",
             "colours": [
@@ -16384,7 +16384,7 @@
         },
         {
             "id": "479e911d-ce0e-5e90-93c7-be72198cbd40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6675d55-5960-4da4-a31c-45654ab9974d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6675d55-5960-4da4-a31c-45654ab9974d.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16419,7 +16419,7 @@
         },
         {
             "id": "38e8a848-e9d9-5edc-90dd-4d7460c0ca4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc626a1-cfb0-4e1f-80fc-7c1ff07ee424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc626a1-cfb0-4e1f-80fc-7c1ff07ee424.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16454,7 +16454,7 @@
         },
         {
             "id": "21e9a9c1-aa60-5b55-b568-54b54dc4a589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f9b3b8-090e-4152-8d44-52d92375905b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f9b3b8-090e-4152-8d44-52d92375905b.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16489,7 +16489,7 @@
         },
         {
             "id": "06d530fd-f068-599d-9ebe-05e870779ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89bcbd5-772a-4ff2-b48b-6fea07830578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89bcbd5-772a-4ff2-b48b-6fea07830578.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16524,7 +16524,7 @@
         },
         {
             "id": "60319026-82e9-55e9-9f21-25a9d173238b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b773b4e-7af3-4836-8c7f-3897f968a33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b773b4e-7af3-4836-8c7f-3897f968a33e.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16559,7 +16559,7 @@
         },
         {
             "id": "237f6389-2174-55ff-84a6-26a34f80b679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9dbec-ad25-488b-8472-4bd85fd6c757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9dbec-ad25-488b-8472-4bd85fd6c757.jpg?1",
             "name": "Cavern of Souls",
             "text": "",
             "colours": [],
@@ -16594,7 +16594,7 @@
         },
         {
             "id": "f7f1c18a-ecbe-5b99-ad80-2fcce898fc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c3b739-89b3-4ad8-aab9-76e8f87cf123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c3b739-89b3-4ad8-aab9-76e8f87cf123.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -16622,7 +16622,7 @@
         },
         {
             "id": "e24726ce-7c3e-57fe-a261-7854152027d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0d80ce-9397-4c6d-9a07-31172d46f42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0d80ce-9397-4c6d-9a07-31172d46f42a.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "f326fd73-8e67-59c0-9b29-3772bc573f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe7c36a-77b7-4418-9e2d-b6aeea61502e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe7c36a-77b7-4418-9e2d-b6aeea61502e.jpg?1",
             "name": "Gnome Soldier",
             "text": "",
             "colours": [],
@@ -16690,7 +16690,7 @@
         },
         {
             "id": "53c31212-83ec-5487-b11a-e5de4593b4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0484390e-1167-4407-84de-7ddc726e8926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0484390e-1167-4407-84de-7ddc726e8926.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -16725,7 +16725,7 @@
         },
         {
             "id": "53f2e6e3-6a5b-5c8a-a897-a95bf644e8aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d353ad-7160-41fa-809c-d76b36478a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d353ad-7160-41fa-809c-d76b36478a2a.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -16760,7 +16760,7 @@
         },
         {
             "id": "3e43a418-8c17-5ed2-b92b-42dbe4c96b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00841e4b-0995-4fb5-93d6-e177beba4934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00841e4b-0995-4fb5-93d6-e177beba4934.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -16795,7 +16795,7 @@
         },
         {
             "id": "201e2405-5ffc-50f4-80e0-a1e5df6fc25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff66e3-ea24-4542-887f-c41abb1759e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff66e3-ea24-4542-887f-c41abb1759e6.jpg?1",
             "name": "Fungus",
             "text": "",
             "colours": [
@@ -16830,7 +16830,7 @@
         },
         {
             "id": "c38fcdac-0cef-58a9-aae8-5071361460ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec83fe2-173b-4aa6-bfa1-892b092bd1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec83fe2-173b-4aa6-bfa1-892b092bd1f6.jpg?1",
             "name": "Skeleton Pirate",
             "text": "",
             "colours": [
@@ -16866,7 +16866,7 @@
         },
         {
             "id": "f7f3d0b9-14a8-5d0e-90fa-3c12688444ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0702f9-769b-40c0-96a7-508dc8f2652c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0702f9-769b-40c0-96a7-508dc8f2652c.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -16901,7 +16901,7 @@
         },
         {
             "id": "b99d12bc-ca42-5446-b731-e1ac531ee248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb7151-cf71-49bc-8d99-b0230d5465e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbb7151-cf71-49bc-8d99-b0230d5465e5.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -16936,7 +16936,7 @@
         },
         {
             "id": "b0b8168a-9a4e-540e-b086-9372074c0e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e24a8f-3663-47c6-94b1-4525ae9da3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e24a8f-3663-47c6-94b1-4525ae9da3b5.jpg?1",
             "name": "Dinosaur Egg",
             "text": "",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "7af4122b-94af-5e15-9d75-54f15bbb442a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92f2858-e524-4d23-b947-d4dff20e7f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92f2858-e524-4d23-b947-d4dff20e7f59.jpg?1",
             "name": "Fungus Dinosaur",
             "text": "",
             "colours": [
@@ -17008,7 +17008,7 @@
         },
         {
             "id": "3100cd00-1cab-50ce-a8a1-848a984781c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [
@@ -17046,7 +17046,7 @@
         },
         {
             "id": "30bd97e4-466f-5f43-8a2c-2ed182bfd961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072cd10b-98d3-452e-bf8d-13a75cc3d72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072cd10b-98d3-452e-bf8d-13a75cc3d72e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17083,7 +17083,7 @@
         },
         {
             "id": "6cdd4a0c-4ac3-5cca-8626-57bf2b08a6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3005eb0a-5c96-4a07-a6b9-a907d1095cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3005eb0a-5c96-4a07-a6b9-a907d1095cdf.jpg?1",
             "name": "Vampire Demon",
             "text": "",
             "colours": [
@@ -17121,7 +17121,7 @@
         },
         {
             "id": "f70d7ddc-2d93-55bf-937e-1719faea6c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg?1",
             "name": "Gnome",
             "text": "",
             "colours": [],
@@ -17153,7 +17153,7 @@
         },
         {
             "id": "cd91506e-6a64-5e5c-948e-851ed31ac543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64839118-09d2-4645-9d3c-f80755ac781f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64839118-09d2-4645-9d3c-f80755ac781f.jpg?1",
             "name": "Map",
             "text": "",
             "colours": [],
@@ -17184,7 +17184,7 @@
         },
         {
             "id": "f7e12dcc-910d-5b82-b637-0b972542ead5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfaedeb-f8ec-4f0e-b243-c850770a86f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfaedeb-f8ec-4f0e-b243-c850770a86f2.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17215,7 +17215,7 @@
         },
         {
             "id": "886bac3e-f93f-5f3d-9d82-eabd315b3779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004f309-5833-4058-ac71-d203c648897f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004f309-5833-4058-ac71-d203c648897f.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],
@@ -17243,7 +17243,7 @@
         },
         {
             "id": "390a4800-1f2f-595f-bcfa-8a968f6fa64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f2a22b-26a5-4eb6-8430-74f5de4832ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f2a22b-26a5-4eb6-8430-74f5de4832ba.jpg?1",
             "name": "Ability Punchcard",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/LEA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LEA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2b304dc1-8d7d-50a7-a310-2d0e5427935f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c83259-9b90-47c2-b48e-c7d78519e792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c83259-9b90-47c2-b48e-c7d78519e792.jpg?1",
             "name": "Animate Wall",
             "text": "Target wall can now attack. Target wall's power and toughness are unchanged, even if its power is 0.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "22bf9c94-5e17-5b7d-ae82-e18f992a2ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ddce7-b9c5-431d-a0b0-46d4aa93cbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6ddce7-b9c5-431d-a0b0-46d4aa93cbcb.jpg?1",
             "name": "Armageddon",
             "text": "All lands in play are destroyed.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "a1aa90b2-1c25-5c8f-8fed-46c295ef03b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9ea46a-411f-40ce-a873-a905180093f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9ea46a-411f-40ce-a873-a905180093f4.jpg?1",
             "name": "Balance",
             "text": "Whichever player has more lands in play must discard enough lands of his or her choice to equalize the number of lands both players have in play. Cards in hand and creatures in play must be equalized the same way. Creatures lost in this manner may not be regenerated.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "e645151c-9c01-5246-890d-becf25c794c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11600105-56c6-4073-a4a6-8469030b39c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11600105-56c6-4073-a4a6-8469030b39c9.jpg?1",
             "name": "Benalish Hero",
             "text": "Bands",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "5d993530-bac0-5533-b005-d098ea6071ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15967a39-303f-457d-bcde-51837c8d63e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15967a39-303f-457d-bcde-51837c8d63e1.jpg?1",
             "name": "Black Ward",
             "text": "Target creature gains protection from black.",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "b933aca1-28f1-5d5b-9bdc-39304ff2f338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fba951-c5bb-497c-9292-ce1b2a1e1247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fba951-c5bb-497c-9292-ce1b2a1e1247.jpg?1",
             "name": "Blaze of Glory",
             "text": "Target defending creature can and must block all attacking creatures it can legally block. For example, a normal non-flying target defender can and must block all normal non-flying attackers at once, but it cannot block any flying attackers. Controller of target defender may distribute damage among attackers as desired. Play before defense is chosen.",
             "colours": [
@@ -197,7 +197,7 @@
         },
         {
             "id": "f32aac96-64ef-5e9c-8fab-4456f5f35e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131fd27-18da-47ca-b59f-135bcac83abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131fd27-18da-47ca-b59f-135bcac83abd.jpg?1",
             "name": "Blessing",
             "text": "oo\nW Target creature gains +1/+1 until end of turn.",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "120a6ac1-3ade-5bec-8d86-621a731eaac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f9f0f2-e1cc-4740-888c-1336c6de0a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f9f0f2-e1cc-4740-888c-1336c6de0a27.jpg?1",
             "name": "Blue Ward",
             "text": "Target creature gains protection from blue.",
             "colours": [
@@ -263,7 +263,7 @@
         },
         {
             "id": "dbb22974-ea92-5579-a923-fcf1cd64be68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0da8d56-3178-44c2-9344-95d2346d326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0da8d56-3178-44c2-9344-95d2346d326f.jpg?1",
             "name": "Castle",
             "text": "Your untapped creatures gain +0/+2. Attacking creatures lose this bonus.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "35f986fe-6ece-5ea5-9171-e7d5143b20a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1a7f-e8ba-40b5-92b7-af1e963a0319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848b1a7f-e8ba-40b5-92b7-af1e963a0319.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevents all damage against you from one blue source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "618ccc94-8a8f-5297-b4e6-b37905729848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae32d20-b438-4f43-b603-e8f706ecfb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae32d20-b438-4f43-b603-e8f706ecfb03.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevents all damage against you from one green source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "5b0ccc9a-8cb0-5917-97e2-27ea377c6db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd94c5-42f6-4148-be6e-2a3a4226cc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd94c5-42f6-4148-be6e-2a3a4226cc0e.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevents all damage against you from one red source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "7473cc4e-3dba-542c-b4c8-fe7166cb4d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92df19c9-e127-42d9-8dd2-7fa5a7095428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92df19c9-e127-42d9-8dd2-7fa5a7095428.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevents all damage against you from one white source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "cfdd4922-8a07-5c94-b1c5-62121ab37b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2379f78-c03f-447f-b3c9-10a918d556e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2379f78-c03f-447f-b3c9-10a918d556e9.jpg?1",
             "name": "Consecrate Land",
             "text": "All enchantments on target land are destroyed. Land cannot be destroyed or further enchanted until Consecrate Land has been destroyed.",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "68d62155-7920-5d65-8f99-3c69a4a12ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13186bc9-8d9c-433b-ba15-121ef94dd68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13186bc9-8d9c-433b-ba15-121ef94dd68a.jpg?1",
             "name": "Conversion",
             "text": "All mountains are considered plains while Conversion is in play. Pay o\nWo\nW during upkeep or Conversion is discarded.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "4660fa94-7346-5bc3-bc05-caae99f003ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057986c7-20c0-4157-b4df-beae4ef5c66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057986c7-20c0-4157-b4df-beae4ef5c66d.jpg?1",
             "name": "Crusade",
             "text": "All white creatures gain +1/+1.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "aeb78872-677a-53a9-b91a-de8c7b814a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5466cc-aa57-4a7f-8b21-d92b2fe02e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5466cc-aa57-4a7f-8b21-d92b2fe02e13.jpg?1",
             "name": "Death Ward",
             "text": "Regenerates target creature.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "cd10b3e5-780b-57e1-a825-77fce7cce5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2722d7e2-61c6-4934-9c21-875ee78fd06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2722d7e2-61c6-4934-9c21-875ee78fd06c.jpg?1",
             "name": "Disenchant",
             "text": "Target enchantment or artifact must be discarded.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "731d6876-056c-5873-8fd8-a5e3794b1540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3455b006-9ea5-4aef-8ad2-d0701eb0cacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3455b006-9ea5-4aef-8ad2-d0701eb0cacf.jpg?1",
             "name": "Farmstead",
             "text": "Target land's controller gains 1 life each upkeep if o\nWo\nW is spent. Target land still generates mana as usual.",
             "colours": [
@@ -608,7 +608,7 @@
         },
         {
             "id": "7de3b02f-3de7-581c-b23f-435ac582dbad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6118b2-fe01-425a-a2ed-6d7c42286c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6118b2-fe01-425a-a2ed-6d7c42286c8e.jpg?1",
             "name": "Green Ward",
             "text": "Target creature gains protection from green.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "4145bd67-79d4-5c23-af1d-db7ef44fa038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f84d676-5327-454c-a033-b4498a9d28e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f84d676-5327-454c-a033-b4498a9d28e2.jpg?1",
             "name": "Guardian Angel",
             "text": "Prevents X damage from being dealt to any one target. Any further damage to the same target this turn can be canceled by spending 1 mana per point of damage to be canceled.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "c80e8d50-823e-5df8-a820-0901eb8cdf54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de37e-84d5-4dc7-b36c-e14da5924729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28de37e-84d5-4dc7-b36c-e14da5924729.jpg?1",
             "name": "Healing Salve",
             "text": "Gain 3 life, or prevent up to 3 damage from being dealt to a single target.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "0e532415-391e-56c2-b10f-29ac5e4b9186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01041d2-687e-4972-81c8-16690809275b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01041d2-687e-4972-81c8-16690809275b.jpg?1",
             "name": "Holy Armor",
             "text": "Target creature gains +0/+2. oo\nW Target creature gets extra +0/+1 until end of turn.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "66a6b1ba-51c6-5d79-8e34-d0958b5f0b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e945a4cd-0eb1-4f54-898d-169ce2748a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e945a4cd-0eb1-4f54-898d-169ce2748a03.jpg?1",
             "name": "Holy Strength",
             "text": "Target creature gains +1/+2.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "cf0fd935-7303-56a9-b9bd-1cadd70294c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e8a42-89de-42bc-8d5f-33426d207c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15e8a42-89de-42bc-8d5f-33426d207c3a.jpg?1",
             "name": "Island Sanctuary",
             "text": "You may decline to draw a card from your library during draw phase. In exchange, until start of your next turn the only creatures that can damage you are those that fly or have islandwalk.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "79c65929-ec55-5c5d-8a61-69d61ff3d87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f30ad61-fcb7-4d55-ba86-94de1bf545e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f30ad61-fcb7-4d55-ba86-94de1bf545e4.jpg?1",
             "name": "Karma",
             "text": "Karma does 1 damage to player for each swamp player has in play. Damage occurs during player's upkeep. Affects both players.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "5914987f-9629-5f00-bc01-38775f9edb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb633f5-cc4d-4157-8217-def90cb15e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb633f5-cc4d-4157-8217-def90cb15e24.jpg?1",
             "name": "Lance",
             "text": "Target creature gains first strike.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "34703503-e481-52de-9b59-df3f81a1a21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaac88da-d19e-4771-944c-3709963d04e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaac88da-d19e-4771-944c-3709963d04e7.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Flying, bands",
             "colours": [
@@ -897,7 +897,7 @@
         },
         {
             "id": "f2c18dec-8757-5f3a-b65d-a46faec3a127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6303233b-35eb-49ca-b844-ba6b9fe1cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6303233b-35eb-49ca-b844-ba6b9fe1cbd2.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW and tap: Destroys a black card in play. Cannot be used to cancel a black spell as it is being cast.",
             "colours": [
@@ -931,7 +931,7 @@
         },
         {
             "id": "613e79c1-1e0d-5bda-a728-f32583b38070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf1aab-1e58-4a5a-bc66-cb3f7c86e0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daf1aab-1e58-4a5a-bc66-cb3f7c86e0e8.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "340d1f1d-ca26-560a-a749-1f9d178a3107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9cef4-0f2d-478a-b119-fe1967687f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9cef4-0f2d-478a-b119-fe1967687f74.jpg?1",
             "name": "Personal Incarnation",
             "text": "Caster can redirect any or all damage done to Personal Incarnation to self instead. The source of the damage is unchanged. If Personal Incarnation is destroyed, caster loses half his or her remaining life points, rounding up the loss.",
             "colours": [
@@ -998,7 +998,7 @@
         },
         {
             "id": "a2d40bbc-395a-5873-a0bb-2c138c1bd117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2facf462-55cd-4da4-997f-2cf4add75628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2facf462-55cd-4da4-997f-2cf4add75628.jpg?1",
             "name": "Purelace",
             "text": "Changes the color of one card either being played or already in play to white. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "914dd48d-b0f9-503a-83ea-5ef7274d0ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c64c01-c2aa-470b-88c6-3d3e4a969649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c64c01-c2aa-470b-88c6-3d3e4a969649.jpg?1",
             "name": "Red Ward",
             "text": "Target creature gains protection from red.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "edba49ed-f92c-57d4-b3b5-ff889997aab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fff6e6f-4ebd-4ec8-9443-59efb22d376c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fff6e6f-4ebd-4ec8-9443-59efb22d376c.jpg?1",
             "name": "Resurrection",
             "text": "Take a creature from your graveyard and put it directly into play. You can't tap it until your next turn.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "a10a3368-7d24-5fce-a54b-343a58bdae8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943baea8-b173-4863-a3ab-dd217d483cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943baea8-b173-4863-a3ab-dd217d483cd9.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage you have taken from any one source this turn is added to your life total instead of subtracted from it.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "94b0396b-fbc6-560d-b41a-6d1a65fca97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ba7b76-f3d0-47d0-8a35-0c08e67200fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ba7b76-f3d0-47d0-8a35-0c08e67200fb.jpg?1",
             "name": "Righteousness",
             "text": "Target defending creature gains +7/+7 until end of turn.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "799abda3-a719-5205-adb7-aeb26f706f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efba235e-04e5-449c-906c-0ac33f6d7929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efba235e-04e5-449c-906c-0ac33f6d7929.jpg?1",
             "name": "Samite Healer",
             "text": "Tap to prevent 1 damage to any target.",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "4bd37a8c-2e55-5451-9716-1dc9b1b0ce71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b92bd-797e-413f-a8b0-32e0937a1ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b92bd-797e-413f-a8b0-32e0937a1ee0.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "52b0a40b-22db-5632-8ca7-a1c55bc68195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ac5006-91bd-4803-93da-f87cf196dd2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ac5006-91bd-4803-93da-f87cf196dd2f.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nDoes not tap when attacking.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "6c789760-0018-5c69-b36a-5cb819c80706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ea9eb-abc1-4862-aa2d-8fb808d79490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ea9eb-abc1-4862-aa2d-8fb808d79490.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Target creature is removed from game entirely; return to owner's deck only when game is over. Creature's controller gains life points equal to creature's power.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "954dfa06-45e8-516a-abf6-73e9e734db04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd9ab01-a833-4fa4-8dee-151bd9800835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd9ab01-a833-4fa4-8dee-151bd9800835.jpg?1",
             "name": "Veteran Bodyguard",
             "text": "Unless Bodyguard is tapped, any damage done to you by unblocked creatures is done instead to Bodyguard. You may not take this damage yourself, though you can prevent it if possible.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "53e8e411-6329-51e3-b840-60ba16ebd5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4723-b36c-4015-b361-736a6523e8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4723-b36c-4015-b361-736a6523e8f5.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -1352,7 +1352,7 @@
         },
         {
             "id": "eb39e5eb-fff7-539c-8f58-5ecbd897f26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50abfba8-c9f9-4ebf-965a-4b425fe83129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50abfba8-c9f9-4ebf-965a-4b425fe83129.jpg?1",
             "name": "White Knight",
             "text": "Protection from black, first strike",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "b56436d1-6aaa-546c-937b-f9ea007197b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b22665-1501-420a-82ad-f71f6768bcf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b22665-1501-420a-82ad-f71f6768bcf8.jpg?1",
             "name": "White Ward",
             "text": "Target creature gains protection from white.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "608d0aa6-2a48-5596-842a-63abe1ec29cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2788d69-6a3a-42f0-8736-cc6b57755ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2788d69-6a3a-42f0-8736-cc6b57755ecd.jpg?1",
             "name": "Wrath of God",
             "text": "All creatures in play are destroyed and cannot regenerate.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "27e92f54-0084-57c2-85e5-197e026fab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c3b2a3-0daa-4d42-832d-fcdfda6555ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c3b2a3-0daa-4d42-832d-fcdfda6555ea.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "1c17ce18-bf3e-558b-9389-632588f93851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e7ddf2-5604-41e7-bb9d-ddd03d3e9d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e7ddf2-5604-41e7-bb9d-ddd03d3e9d0b.jpg?1",
             "name": "Ancestral Recall",
             "text": "Draw 3 cards or force opponent to draw 3 cards.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "e035e37e-cb8e-5f12-a5db-fe7f927a3457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664b46f5-0424-4f4e-9f26-6bd2cf5e0357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664b46f5-0424-4f4e-9f26-6bd2cf5e0357.jpg?1",
             "name": "Animate Artifact",
             "text": "Target artifact is now a creature with both power and toughness equal to its casting cost; target retains all its original abilities as well. This will destroy artifacts with 0 casting cost.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "5b2fbe34-84d6-553b-a276-fc95be592646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d666ef-39bf-4fbf-8201-5f1056539da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d666ef-39bf-4fbf-8201-5f1056539da2.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Counters a red spell being cast or destroys a red card in play.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "fdd488e3-cbe3-5684-b7b8-38997728f653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b19a12-6914-430e-81ce-dcfca47884df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b19a12-6914-430e-81ce-dcfca47884df.jpg?1",
             "name": "Braingeyser",
             "text": "Draw X cards or force opponent to draw X cards.",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "f060a053-c376-5aa9-91ca-908a9a4c72eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d33dd-4eb2-4446-9813-1923d8e2d2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d33dd-4eb2-4446-9813-1923d8e2d2f3.jpg?1",
             "name": "Clone",
             "text": "Upon summoning, Clone acquires all normal characteristics, including color, of any one creature in play on either side; any enchantments on original creature are not copied. Clone retains these characteristics even after original creature is destroyed. Clone cannot be played if there are no creatures in play.",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "cbe924ee-7b84-5d9f-8917-dbc618d5df9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b52f459-c703-4a0b-9114-ff69eec61287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b52f459-c703-4a0b-9114-ff69eec61287.jpg?1",
             "name": "Control Magic",
             "text": "You control target creature until enchantment is discarded or game ends. You can't tap target creature this turn, but if it was already tapped it stays tapped until you can untap it. If destroyed, target creature is put in its owner's graveyard.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "a654be23-d457-54b9-89bf-d04708d21ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5ed955-1193-4e6a-a3e2-f54c1f9bf063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5ed955-1193-4e6a-a3e2-f54c1f9bf063.jpg?1",
             "name": "Copy Artifact",
             "text": "Select any artifact in play. This enchantment acts as a duplicate of that artifact; enchantment copy is affected by cards that affect either enchantments or artifacts.\nEnchantment copy remains even if original artifact is destroyed.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "a431d592-5825-5ed3-8201-cd7571860083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df55e3f-14de-46ef-b6b1-616618724d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df55e3f-14de-46ef-b6b1-616618724d9e.jpg?1",
             "name": "Counterspell",
             "text": "Counters target spell as it is being cast.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "3d70b00c-3c10-5e66-a11b-3751dbabf87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4bd7d1-77e5-46e5-a594-c24469e88c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4bd7d1-77e5-46e5-a594-c24469e88c4c.jpg?1",
             "name": "Creature Bond",
             "text": "If target creature is destroyed, Creature Bond does an amount of damage equal to creature's toughness to creature's controller.",
             "colours": [
@@ -1770,7 +1770,7 @@
         },
         {
             "id": "48ae8d15-eb7f-5ef4-8952-849237cbd53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3830c5-cc66-453e-9e53-0636e00ee0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3830c5-cc66-453e-9e53-0636e00ee0ee.jpg?1",
             "name": "Drain Power",
             "text": "Tap all opponent's lands, taking all this mana and all mana in opponent's mana pool into your mana pool. You can't tap fewer than all opponent's lands.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "548f6bc3-0a88-5987-bc52-b345a7a6f336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb8f591-d763-49bf-8ef9-86265aaa72f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb8f591-d763-49bf-8ef9-86265aaa72f7.jpg?1",
             "name": "Feedback",
             "text": "Feedback does 1 damage to controller of target enchantment during each upkeep.",
             "colours": [
@@ -1834,7 +1834,7 @@
         },
         {
             "id": "6ba1a1f5-1959-5dc7-9e97-45bc45e40fb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c7784b-6b79-4268-a714-895c82809aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c7784b-6b79-4268-a714-895c82809aff.jpg?1",
             "name": "Flight",
             "text": "Target creature is now a flying creature.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "596c1f92-9661-5d65-9330-aa00138c0e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ac51-e6a7-48d7-8759-166070ca13d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1858ac51-e6a7-48d7-8759-166070ca13d8.jpg?1",
             "name": "Invisibility",
             "text": "Target creature can be blocked only by walls.",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "df47b61f-551a-5288-9746-8de91d5af3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3f4b11-ad1b-48e2-a500-787d351b0174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3f4b11-ad1b-48e2-a500-787d351b0174.jpg?1",
             "name": "Jump",
             "text": "Target creature is a flying creature until end of turn.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "1630aa04-271c-59b2-bdd6-e616dd730b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11add837-7ee4-4104-b031-c161bce459ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11add837-7ee4-4104-b031-c161bce459ae.jpg?1",
             "name": "Lifetap",
             "text": "You gain 1 life each time any forest of opponent's becomes tapped.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "e4a2b1cc-84e2-5d2e-8786-b3f4b8f8b1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210c4a90-fc7a-4c76-aeaa-20a005e45386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210c4a90-fc7a-4c76-aeaa-20a005e45386.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk in play gain islandwalk and +1/+1 while this card is in play.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "6a1886ab-1744-5a05-9a83-d1ef9595af97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd4202c-0477-45aa-82fd-83c85d6d4bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd4202c-0477-45aa-82fd-83c85d6d4bef.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of any card being played or already in play by replacing one basic land type with another. For example, you can change \"swampwalk\" to \"plainswalk.\"",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "304ecd98-07f7-5242-abef-84a8793bf997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36204ddd-ddf7-4b44-ae3c-b4a5a41ac9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36204ddd-ddf7-4b44-ae3c-b4a5a41ac9cb.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "85f136e4-2225-57f2-a7dc-5dfd954ecfce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3e0b3-5284-464f-8c62-0f7801c966f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3e0b3-5284-464f-8c62-0f7801c966f5.jpg?1",
             "name": "Mana Short",
             "text": "All opponent's lands are tapped, and opponent's mana pool is emptied.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "5a120339-05d7-5049-aec2-ef09f2a17a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b871039-6a66-4ac3-95e7-24759c1f2f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b871039-6a66-4ac3-95e7-24759c1f2f92.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "14959484-e122-52a9-a405-94b59eb3ad1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0631c7c8-9aa5-4333-8e20-20247fc47033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0631c7c8-9aa5-4333-8e20-20247fc47033.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nController must spend U during upkeep to maintain or Phantasmal Forces are destroyed.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "f9a670d0-10e8-58bc-8546-e336fbedec02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c371aa1-1619-41e3-8364-7bc9b8cf5d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c371aa1-1619-41e3-8364-7bc9b8cf5d14.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Target land changes to any basic land type of caster's choice. Land type is set when cast and may not be further altered by this enchantment.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "9a5a5647-6004-521c-ac24-8717505ce425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d2cf5-e8d0-4fb2-b950-252d52084b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e46d2cf5-e8d0-4fb2-b950-252d52084b63.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "45b22f88-db04-5121-a378-0f358c38ca6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7cb23-d229-43c5-addd-dcf423984b0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7cb23-d229-43c5-addd-dcf423984b0c.jpg?1",
             "name": "Pirate Ship",
             "text": "Tap to do 1 damage to any target. Cannot attack unless opponent has islands in play, though controller may still tap. Pirate Ship is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2256,7 +2256,7 @@
         },
         {
             "id": "4fdbe46e-e92f-5fcc-9bb1-d2bcba4eaf57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc982b6-35b2-4e33-ace2-86cb79123e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc982b6-35b2-4e33-ace2-86cb79123e4f.jpg?1",
             "name": "Power Leak",
             "text": "Target enchantment costs 2 extra mana each turn during upkeep. If target enchantment's controller cannot or will not pay this extra mana, Power Leak does 1 damage to him or her for each unpaid mana.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "7157f9fc-c989-5f60-b894-8305f9cdfc7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b342dd3-09b9-4108-bf12-a65d4cef4eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b342dd3-09b9-4108-bf12-a65d4cef4eb9.jpg?1",
             "name": "Power Sink",
             "text": "Target spell is countered unless its caster spends X more mana; caster of target spell can't choose to let it be countered. If caster of target spell doesn't have enough mana, all available mana from lands and mana pool must be paid but target spell will still be countered.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "7a874dfe-b338-5ea0-884f-9f5c777ec1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dc1103-7bf1-47f6-9006-d3ed9ccd7a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dc1103-7bf1-47f6-9006-d3ed9ccd7a6a.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "Tap to do 1 damage to any target.",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "477c092f-c30f-5d95-b7bd-bf25cdd31c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a86e6e-bfff-46af-9d36-c912901fea92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a86e6e-bfff-46af-9d36-c912901fea92.jpg?1",
             "name": "Psionic Blast",
             "text": "Psionic Blast does 4 damage to any target, but it does 2 damage to you as well.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "63ebd8c5-6779-504a-b248-0bdf6ccdf2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f5b68a-6b0e-431e-89f0-ff60f17687a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f5b68a-6b0e-431e-89f0-ff60f17687a5.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever target land is tapped, Psychic Venom does 2 damage to target land's controller.",
             "colours": [
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "f9bc9c80-659a-53f1-8fe4-981bff249836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b333b7-db4d-4439-b0de-60414cbf8d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b333b7-db4d-4439-b0de-60414cbf8d7b.jpg?1",
             "name": "Sea Serpent",
             "text": "Serpent cannot attack unless opponent has islands in play.\nSerpent is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "09224989-61eb-5508-8361-79f7413f9703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d992b336-3b6e-43e1-8662-d85664349b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d992b336-3b6e-43e1-8662-d85664349b44.jpg?1",
             "name": "Siren's Call",
             "text": "All of opponent's creatures that can attack must do so. Any non-wall creatures that cannot attack are destroyed at end of turn. Play only during opponent's turn, before opponent's attack. Creatures summoned this turn are unaffected by Siren's Call.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "0ca9de33-b216-5db1-8199-9b004b1f0a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427790c-e322-446e-8d7d-a6b48ad41a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d427790c-e322-446e-8d7d-a6b48ad41a42.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of any card being played or already in play by replacing one color word with another. For example, you can change \"Counters red spells\" to \"Counters black spells.\" Cannot change mana symbols.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "31371fdf-4292-54a0-a138-87b07d020ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845734da-ab03-4dbc-bb5f-96481d3b8e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845734da-ab03-4dbc-bb5f-96481d3b8e88.jpg?1",
             "name": "Spell Blast",
             "text": "Target spell is countered; X is cost of target spell.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "906eab23-4f12-5ce0-b88d-890ba533e47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cef408-5b4b-49f6-9531-be544815b93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cef408-5b4b-49f6-9531-be544815b93f.jpg?1",
             "name": "Stasis",
             "text": "Players do not get an untap phase. Pay o\nU during your upkeep or Stasis is destroyed.",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "29ca858e-31f0-5e75-bba3-bb7a45d9bee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83316930-d6ad-46ce-9b40-48eea856d95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83316930-d6ad-46ce-9b40-48eea856d95b.jpg?1",
             "name": "Steal Artifact",
             "text": "You control target artifact until enchantment is discarded or game ends. If target artifact was tapped when stolen, it stays tapped until you can untap it. If destroyed, target artifact is put in its owner's graveyard.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "05cbd19a-d524-5109-8df1-75dea6269186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23749375-1416-47a4-9251-52f41fe2fae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23749375-1416-47a4-9251-52f41fe2fae9.jpg?1",
             "name": "Thoughtlace",
             "text": "Changes the color of one card either being played or already in play to blue. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "daae9119-9316-538f-b9ae-ba871f5cb185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0139f60-d48e-46fb-9f5a-1e3d7558c834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0139f60-d48e-46fb-9f5a-1e3d7558c834.jpg?1",
             "name": "Time Walk",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "6306bc8b-629a-5487-828c-b3d757972728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a49dc44-616e-4bdd-8220-0bb71eccc512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a49dc44-616e-4bdd-8220-0bb71eccc512.jpg?1",
             "name": "Timetwister",
             "text": "Set Timetwister aside in a new graveyard pile. Shuffle your hand, library, and graveyard together into a new library and draw a new hand of seven cards, leaving all cards in play where they are; opponent must do the same.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "1853ba5e-1859-5f9b-8aa7-bc434b34a4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e811f-26a3-4a7c-bd13-3b1cc3e184eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e811f-26a3-4a7c-bd13-3b1cc3e184eb.jpg?1",
             "name": "Twiddle",
             "text": "Caster may tap or untap any one land, creature, or artifact in play.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "888c0ccc-2de9-50c7-9bb1-175880894460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8512f2c1-6361-4b79-843f-80b6bceeeb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8512f2c1-6361-4b79-843f-80b6bceeeb99.jpg?1",
             "name": "Unsummon",
             "text": "Return creature to owner's hand; enchantments on creature are CARD ed. Unsummon cannot be played during the damage-dealing phase of an attack.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "2561a0da-cb24-5246-bd0f-52e4b1ccbde7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768f3a05-bd06-4a23-b9f2-94f6e618fd9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768f3a05-bd06-4a23-b9f2-94f6e618fd9f.jpg?1",
             "name": "Vesuvan Doppelganger",
             "text": "Upon summoning, Doppelganger acquires all normal characteristics (except color) of any one creature in play on either side; any enchantments on the original creature are not copied. During controller's upkeep, Doppelganger may take on the characteristics of a different creature in play instead. Doppelganger may continue to copy a creature even after that creature leaves play, but if it switches it won't be able to switch back.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "5d1822d2-b796-551b-b8db-0d7ca279dd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80582b1-09db-45f8-b362-0e5207a5a8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80582b1-09db-45f8-b362-0e5207a5a8e6.jpg?1",
             "name": "Volcanic Eruption",
             "text": "Destroys X mountains of your choice, and does X damage to each player and each creature in play.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "e94ce1de-53e7-589c-b264-8826780bd7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da56fdf3-6a8f-4833-a5c3-197650cc4889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da56fdf3-6a8f-4833-a5c3-197650cc4889.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "08913973-f7d6-52c7-b113-ca317a8d84e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41faed1a-ded8-49ee-8e2a-c60d377775d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41faed1a-ded8-49ee-8e2a-c60d377775d7.jpg?1",
             "name": "Wall of Water",
             "text": "oo\nU +1/+0 until end of turn.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "29d37155-b404-5972-a4b4-de7c1d57d552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de940d6-98c0-46a9-b5fd-e2b0899ea19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de940d6-98c0-46a9-b5fd-e2b0899ea19e.jpg?1",
             "name": "Water Elemental",
             "text": "",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "a5421ca2-32e5-5b31-bc12-979c626fc6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd7861d-925f-4b4c-a4ab-60be6f43d50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd7861d-925f-4b4c-a4ab-60be6f43d50b.jpg?1",
             "name": "Animate Dead",
             "text": "Any creature in either player's graveyard comes into play on your side with -1 to its original power. If this enchantment is removed, or at end of game, target creature is returned to its owner's graveyard. Target creature may be killed as normal.",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "460935e9-fb06-5a06-98ba-e0b2883c01ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43572906-ea74-4411-a549-5dc401591d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43572906-ea74-4411-a549-5dc401591d2a.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures in play gain +1/+1.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "79be3c98-be7a-5d7e-b7e3-1174b6dafa03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1662949-0d69-49a3-8c69-daf10717ed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1662949-0d69-49a3-8c69-daf10717ed4e.jpg?1",
             "name": "Black Knight",
             "text": "Protection from white, first strike",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "e9d3658d-3b1f-586c-ae28-fc571620e0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701874e-986e-4b81-9268-90b6171e6187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701874e-986e-4b81-9268-90b6171e6187.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "cee140cd-3ed0-536e-9a5e-aeb41cbb2f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9853b0ce-4763-4877-9741-f9145a3659c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9853b0ce-4763-4877-9741-f9145a3659c6.jpg?1",
             "name": "Contract from Below",
             "text": "Discard your current hand and draw eight new cards, adding the first drawn to your ante. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "4dc84cea-65a5-5f08-b764-46516d15e92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5f3c61-1e54-4eea-bf82-311cfa988e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf5f3c61-1e54-4eea-bf82-311cfa988e6a.jpg?1",
             "name": "Cursed Land",
             "text": "Cursed Land does 1 damage to target land's controller during each upkeep.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "508ac644-b955-5708-80e5-bcdc36e12e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb6664d-23ca-456e-9916-afcd6f26aa7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb6664d-23ca-456e-9916-afcd6f26aa7f.jpg?1",
             "name": "Dark Ritual",
             "text": "Add 3 black mana to your mana pool.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "0bc207f2-a026-5163-b065-cae388c2a7cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78db688-93a2-47f5-9aa5-9158a72cd973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78db688-93a2-47f5-9aa5-9158a72cd973.jpg?1",
             "name": "Darkpact",
             "text": "Without looking at it first, swap top card of your library with either card of the ante; this swap is permanent. You must have a card in your library to cast this spell. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "f9e9b0f1-8869-5da9-8ad7-dc81681f9913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371c126-f19a-472a-ba5f-3b1366274ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2371c126-f19a-472a-ba5f-3b1366274ea0.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Destroy a green spell as it is being cast. This action may be played as an interrupt, and does not affect green cards already in play.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "33c9d266-9aa0-53d2-8fdc-f82ca024ad21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff1cefc-62cb-4525-b0c5-2b09603b4314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff1cefc-62cb-4525-b0c5-2b09603b4314.jpg?1",
             "name": "Deathlace",
             "text": "Changes the color of one card either being played or already in play to black. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "ac4202e5-116b-552f-a03a-c6023db2cfe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd891fc6-d9d6-494e-ae65-8bea8f44b575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd891fc6-d9d6-494e-ae65-8bea8f44b575.jpg?1",
             "name": "Demonic Attorney",
             "text": "If opponent doesn't concede the game immediately, each player must ante an additional card from the top of his or her library. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "eb7ab5c5-70ac-5081-b9dd-a218e6ff8f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9bb8b1-fb79-4b99-ba09-c6e6c860de50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c9bb8b1-fb79-4b99-ba09-c6e6c860de50.jpg?1",
             "name": "Demonic Hordes",
             "text": "Tap to destroy 1 land. Pay o\nBo\nBo\nB during upkeep or the Hordes become tapped and you lose a land of opponent's choice.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "09ba97e8-43f1-5288-8703-b10f7c1afec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711d4d54-5520-4de8-9b93-79902ed8e562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711d4d54-5520-4de8-9b93-79902ed8e562.jpg?1",
             "name": "Demonic Tutor",
             "text": "You may search your library for one card and take it into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "4d49377c-186e-5ee5-b7ba-bf2ace531292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d077a49-73d4-4958-b42a-31b814e110e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d077a49-73d4-4958-b42a-31b814e110e8.jpg?1",
             "name": "Drain Life",
             "text": "Drain Life does 1 damage to a single target for each B spent in addition to the casting cost. Caster gains 1 life for each damage inflicted. If you drain life from a creature, you cannot gain more life than the creature's toughness.",
             "colours": [
@@ -3371,7 +3371,7 @@
         },
         {
             "id": "d001d4f4-6312-5bb1-8621-ce580507c406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23614289-0d73-4747-a849-5cb67cc97d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23614289-0d73-4747-a849-5cb67cc97d6a.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "0ec1cbb1-e7f6-5196-b6a7-53eaa2fb8f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0551d66e-8cd4-48f0-aa17-15f26be9d85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0551d66e-8cd4-48f0-aa17-15f26be9d85f.jpg?1",
             "name": "Evil Presence",
             "text": "Target land is now a swamp.",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "06f4a6aa-babf-542c-aa8c-f7c569997001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd927be-e63f-4371-a1d8-7a0489cb187e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd927be-e63f-4371-a1d8-7a0489cb187e.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked by any creatures other than artifact creatures and black creatures.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "ac39a7ba-8c4a-5459-9657-d6c5f7d45895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bd76c8-4cff-4c15-9686-7a299b589814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bd76c8-4cff-4c15-9686-7a299b589814.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "af4f979d-ba13-5cec-a788-89f0616e7917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d10bc7-daeb-4c0d-9e4a-8eae8d11699f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d10bc7-daeb-4c0d-9e4a-8eae8d11699f.jpg?1",
             "name": "Gloom",
             "text": "White spells cost 3 more mana to cast. Circles of Protection cost 3 more mana to use.",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "c4737240-d764-5e55-b5d1-24ed6083978a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ec17e1-174b-4d07-a27f-91a333c4b2fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ec17e1-174b-4d07-a27f-91a333c4b2fb.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gains +X/+0 until end of turn.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "8b2db882-51f7-581c-ac85-117c87647d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b900f-2d9b-442b-9699-058483604ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43b900f-2d9b-442b-9699-058483604ec9.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nAn opponent damaged by Specter must discard a card at random from his or her hand. Ignore this effect if opponent has no cards left in hand.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "52c72312-401b-5441-a6a8-d0d5f4e4955f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4250caec-0e37-41be-9ec4-8938deb5f0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4250caec-0e37-41be-9ec4-8938deb5f0d0.jpg?1",
             "name": "Lich",
             "text": "You lose all life. If you gain life later in the game, instead draw one card from your library for each life. For each point of damage you suffer, you must destroy one of your cards in play. Creatures destroyed in this way cannot be regenerated. You lose if this enchantment is destroyed or if you suffer a point of damage without sending a card to the graveyard.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "0d47279a-a159-53ac-9185-24189ed8ecf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2926777a-4f6e-4965-ba83-22cf7df02602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2926777a-4f6e-4965-ba83-22cf7df02602.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nYou must sacrifice one of your own creatures during upkeep or Lord of the Pit does 7 damage to you. You may still attack with Lord of the Pit even if you failed to sacrifice a creature.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "54896cc7-cdfd-578b-9869-777d06d0a8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9e106-a248-49d2-b8c8-6bbcd56ce739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9e106-a248-49d2-b8c8-6bbcd56ce739.jpg?1",
             "name": "Mind Twist",
             "text": "Opponent must discard X cards at random from hand. If opponent doesn't have enough cards in hand, entire hand is discarded.",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "9f1d1b9a-a7ac-5749-9506-d79cd1fe4592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ad58a-6f9b-420a-bac1-40929f5e616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13ad58a-6f9b-420a-bac1-40929f5e616a.jpg?1",
             "name": "Nether Shadow",
             "text": "If Shadow is in graveyard with any combination of cards above it that includes at least three creatures, it can be returned to play during upkeep for its normal casting cost. Shadow can attack on same turn summoned or returned to play.",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "88eb5732-3937-519a-b5f0-771669428bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8105973c-a94d-444c-ba20-ab0fa978bee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8105973c-a94d-444c-ba20-ab0fa978bee8.jpg?1",
             "name": "Nettling Imp",
             "text": "Tap to force a particular one of opponent's non-wall creatures to attack. If target creature cannot attack, it is destroyed at end of turn. This tap should be played during opponent's turn, before the attack. May not be used on creatures summoned this turn.",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "96e1d01d-5d3c-5b36-b1ee-e6e77ebb45ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cdd6a7-f772-4ccb-914f-63f52ed54d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cdd6a7-f772-4ccb-914f-63f52ed54d6b.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness both equal the number of swamps its controller has in play.",
             "colours": [
@@ -3793,7 +3793,7 @@
         },
         {
             "id": "42d4be3c-97e9-5f54-a585-68aa27f8bc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be33a155-de26-43d1-88f1-c926f1b7cb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be33a155-de26-43d1-88f1-c926f1b7cb7c.jpg?1",
             "name": "Paralyze",
             "text": "Target creature is not untapped as normal during untap phase unless 4 mana are spent. Tap target creature when Paralyze is cast.",
             "colours": [
@@ -3826,7 +3826,7 @@
         },
         {
             "id": "3a6a0d86-c65c-5623-99ca-0de799e5bdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a6350-b16b-4e10-a273-e6cbb55dcb7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d42a6350-b16b-4e10-a273-e6cbb55dcb7a.jpg?1",
             "name": "Pestilence",
             "text": "oo\nB Do 1 damage to each creature and to both players. Pestilence must be discarded at end of any turn in which there are no creatures in play at end of turn.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "52bdd23d-6a8f-5101-80c9-68b9d888055f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3724e40-0622-4aee-9334-6c9fff88bcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3724e40-0622-4aee-9334-6c9fff88bcd5.jpg?1",
             "name": "Plague Rats",
             "text": "The Xs below are the number of Plague Rats in play, counting both sides. Thus if there are 2 Plague Rats in play, each has power and toughness 2/2.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "353d0742-ac6c-5c57-99bb-d9936e8604d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce07bede-2219-427c-a61a-56518751de42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce07bede-2219-427c-a61a-56518751de42.jpg?1",
             "name": "Raise Dead",
             "text": "Return creature from your graveyard to your hand.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "764d1489-df08-5a67-a8da-5c48b23ab25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59590768-fa96-4869-8763-9d5ab6ac22ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59590768-fa96-4869-8763-9d5ab6ac22ad.jpg?1",
             "name": "Royal Assassin",
             "text": "Tap to destroy any tapped creature.",
             "colours": [
@@ -3955,7 +3955,7 @@
         },
         {
             "id": "3cda4428-1519-577a-8c5a-fa88f8e96eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12164aee-6a27-4246-8d15-2d6dd20d92e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12164aee-6a27-4246-8d15-2d6dd20d92e9.jpg?1",
             "name": "Sacrifice",
             "text": "Destroy one of your creatures without regenerating it, and add to your mana pool a number of black mana equal to black creature's casting cost.",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "cb7125d4-0821-56ea-84da-2b96f105da6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be6dcf-5e25-4b8c-9cd0-badf3771f81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be6dcf-5e25-4b8c-9cd0-badf3771f81e.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -4019,7 +4019,7 @@
         },
         {
             "id": "ec8d49a5-0c45-5b5b-a865-6fef793d963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426984e0-88e1-4a2d-9a1c-798b95864df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426984e0-88e1-4a2d-9a1c-798b95864df3.jpg?1",
             "name": "Scavenging Ghoul",
             "text": "At the end of each turn, put one counter on the Ghoul for each other creature that was destroyed without regenerating during the turn. If Ghoul dies, you may use a counter to regenerate it; counters remain until used.",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "1b8edacc-510b-5355-8db5-44763f995bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/510840f4-7c0e-4b47-8ebf-23c20cac4bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/510840f4-7c0e-4b47-8ebf-23c20cac4bd9.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nVampire gets a +1/+1 counter each time a creature dies during a turn in which Vampire damaged it, unless the dead creature is regenerated.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "effd01ab-78f5-51c0-b4db-3850d8b66bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c3a78d-cc79-4187-929a-8aa1d1469990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c3a78d-cc79-4187-929a-8aa1d1469990.jpg?1",
             "name": "Simulacrum",
             "text": "All damage done to you so far this turn is instead retroactively applied to one of your creatures in play. If this damage kills the creature it can be regenerated; even if there's more than enough damage to kill the creature, you don't suffer any of it. Further damage this turn is treated normally.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "962e3157-5720-5b9c-a4ea-9527fdfbb606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b31611-9053-4eaf-b392-21bb644fef5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b31611-9053-4eaf-b392-21bb644fef5f.jpg?1",
             "name": "Sinkhole",
             "text": "Destroys any one land.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "0a46dd05-7bb0-5f29-9a15-af9601cacbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21004958-2c7e-4a55-bc80-411c4d780106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21004958-2c7e-4a55-bc80-411c4d780106.jpg?1",
             "name": "Terror",
             "text": "Destroys target creature without possibility of regeneration. Does not affect black creatures and artifact creatures.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "ef192ed1-2f4a-527e-b3ec-1129b4bf822b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90563f90-0127-4164-b43b-f0321dc63a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90563f90-0127-4164-b43b-f0321dc63a1d.jpg?1",
             "name": "Unholy Strength",
             "text": "Target creature gains +2/+1.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "b4717a30-5747-501f-970c-b9c35b8ae274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae20d442-a544-4a03-9ebf-5ecb137c67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae20d442-a544-4a03-9ebf-5ecb137c67dd.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "4862a946-679b-5305-ab8a-e40776851727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e07a2-fbdf-4c4c-996a-fce40bab5de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5e07a2-fbdf-4c4c-996a-fce40bab5de5.jpg?1",
             "name": "Warp Artifact",
             "text": "Warp Artifact does 1 damage to target artifact's controller at start of each turn.",
             "colours": [
@@ -4278,7 +4278,7 @@
         },
         {
             "id": "f7b537bb-ec8e-5894-9ec8-12239fc95a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ca06a1-9b9a-49a2-9c47-9b72228621bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ca06a1-9b9a-49a2-9c47-9b72228621bc.jpg?1",
             "name": "Weakness",
             "text": "Target creature loses -2/-1; if this drops the creature's toughness below 1, it is dead.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "42cada5b-dbdf-5840-9001-4a935c176417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6f8e9-7bc1-4151-b55f-acf877b1a7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6f8e9-7bc1-4151-b55f-acf877b1a7a6.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying; oo\nB Regenerates",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "f43fc579-c9ea-576f-966e-b2275ce19eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c21429-98d3-416b-be00-6aa9c4c5a006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c21429-98d3-416b-be00-6aa9c4c5a006.jpg?1",
             "name": "Word of Command",
             "text": "You may look at opponent's hand and choose any card opponent can legally play using mana from his or her mana pool or lands. Opponent must play this card immediately; you make all the decisions it calls for. This spell may not be countered after you have looked at opponent's hand.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "8bc67a2a-9df2-5f27-a372-266cb978c485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4255a0-d445-4c00-b936-bbf07851e1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4255a0-d445-4c00-b936-bbf07851e1c8.jpg?1",
             "name": "Zombie Master",
             "text": "All zombies in play gain swampwalk and \"oo\nB Regenerates\" for as long as this card remains in play.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "7aec3b0e-923c-5af6-9d00-49d33e9089a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c05e4-8df3-450b-8a98-5028e73b14c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c05e4-8df3-450b-8a98-5028e73b14c1.jpg?1",
             "name": "Burrowing",
             "text": "Target creature gains mountainwalk.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "d2eeffa5-34f1-5daf-b9e1-c39e3f2b7a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ea2048-57bc-43d5-8987-33ca727f1a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ea2048-57bc-43d5-8987-33ca727f1a97.jpg?1",
             "name": "Chaoslace",
             "text": "Changes the color of one card either being played or already in play to red. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "f39505a8-56c6-52c9-937d-a9888a13ea71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8712c49e-f171-4669-bed9-87575a37af11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8712c49e-f171-4669-bed9-87575a37af11.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate does X damage to one target. If target dies this turn, it is removed from game entirely and cannot be regenerated. Return target to its owner's deck only when game is over.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "4a9490f1-0ef2-58c6-900f-1843bdac02ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf1eab-bc32-4835-b566-8634b1fe81b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf1eab-bc32-4835-b566-8634b1fe81b0.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\noo\nR +1/+0 until end of turn; if more than o\nRo\nRo\nR is spent in this way, Dragon Whelp is destroyed at end of turn.",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "347fb6f4-843f-5838-b594-800fb74f3d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03482c9c-1f25-4d73-9243-17462ea37ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03482c9c-1f25-4d73-9243-17462ea37ac4.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "Tap to destroy a wall.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "0ab08584-90c8-5e25-8864-5cf41efe9e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4d87a3-5f8b-4152-9a8b-538ab49d62e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4d87a3-5f8b-4152-9a8b-538ab49d62e8.jpg?1",
             "name": "Dwarven Warriors",
             "text": "Tap to make a creature of power no greater than 2 unblockable until end of turn. Other cards may be used to increase target creature's power beyond 2 after defense is chosen.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "f6b8cd82-851f-5ebc-b345-be774439fa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b5864-44c0-4bc8-8705-9504f83b2c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b5864-44c0-4bc8-8705-9504f83b2c03.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "a5cceeaa-a07b-5401-80e6-4b684ae45cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d492b7-b0b3-420e-8d00-6dacb11de77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d492b7-b0b3-420e-8d00-6dacb11de77e.jpg?1",
             "name": "Earthbind",
             "text": "Earthbind does 2 damage to target flying creature, which also loses flying ability.",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "e1356b6c-0173-5076-ae61-e5a8932e8f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68ac362-6cdc-48a6-bdd3-4f8ea32add64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68ac362-6cdc-48a6-bdd3-4f8ea32add64.jpg?1",
             "name": "Earthquake",
             "text": "Does X damage to each player and each non-flying creature in play.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "7f6a554a-b169-50ed-875b-64b8af6944c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb71ac4-796d-4011-9002-1129bc09c284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb71ac4-796d-4011-9002-1129bc09c284.jpg?1",
             "name": "False Orders",
             "text": "You decide whether and how one defending creature blocks, though you can't make a choice the defender couldn't legally make. Play after defender has chosen defense but before damage is dealt.",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "174f78a0-6094-5ca6-ad04-a9c97aec6f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da237992-2919-4e37-8f56-2164095f59b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da237992-2919-4e37-8f56-2164095f59b5.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4764,7 +4764,7 @@
         },
         {
             "id": "195d63e4-3ad8-5ac0-8e20-1bccc8e1d390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7623c00-144b-4a8f-9c6c-f5e9e4f65ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7623c00-144b-4a8f-9c6c-f5e9e4f65ece.jpg?1",
             "name": "Fireball",
             "text": "Fireball does X damage total, divided evenly (round down) among any number of targets. Pay 1 extra mana for each target beyond the first.",
             "colours": [
@@ -4795,7 +4795,7 @@
         },
         {
             "id": "aed82be0-1119-5e14-901c-3a0a634698a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb27381-505d-4e47-bf66-9e7ba91a5075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb27381-505d-4e47-bf66-9e7ba91a5075.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR +1/+0",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "b84e0ae2-8059-57bc-9f96-3cce76badc38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a05a4-0ce3-4abe-bb60-08af53cf08e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a05a4-0ce3-4abe-bb60-08af53cf08e5.jpg?1",
             "name": "Flashfires",
             "text": "All plains in play are destroyed.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "15e40e30-e542-5bb7-8a47-883a71e6f15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b43916-fe2d-417a-a550-d7c795023297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b43916-fe2d-417a-a550-d7c795023297.jpg?1",
             "name": "Fork",
             "text": "Any sorcery or instant spell just cast is doubled. Treat Fork as an exact copy of target spell except that Fork remains red. Copy and original may have different targets.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "3a8b0b9d-ce12-5182-a70d-481fc4d01fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5129b422-7a35-4bc5-b14b-c814012a0d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5129b422-7a35-4bc5-b14b-c814012a0d8f.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "oo\nR Goblins gain flying ability until end of turn. Controller may not choose to make Goblins fly after they have been blocked.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "dde409a5-9a3a-568b-8612-4d3ff1915f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5873672d-37ea-4c0f-97f3-12b74fde112d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5873672d-37ea-4c0f-97f3-12b74fde112d.jpg?1",
             "name": "Goblin King",
             "text": "Goblins in play gain mountainwalk and +1/+1 while this card remains in play.",
             "colours": [
@@ -4957,7 +4957,7 @@
         },
         {
             "id": "9ef18237-6f91-5e42-8b25-5734b28756db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf2b2-6848-4fbd-b89a-8d8da8ae1cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf2b2-6848-4fbd-b89a-8d8da8ae1cdc.jpg?1",
             "name": "Granite Gargoyle",
             "text": "Flying; oo\nR +0/+1 until end of turn.",
             "colours": [
@@ -4990,7 +4990,7 @@
         },
         {
             "id": "e82a4022-c732-511b-82ec-9c4f732a7a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ae5276-b607-4f23-a9d2-e8cc7b8e3693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ae5276-b607-4f23-a9d2-e8cc7b8e3693.jpg?1",
             "name": "Gray Ogre",
             "text": "",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "a7955714-78cc-5230-83d0-eb3bd2aa01c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddb98e8-13fe-4786-83f7-b72c56db135a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddb98e8-13fe-4786-83f7-b72c56db135a.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -5056,7 +5056,7 @@
         },
         {
             "id": "04a1cf0c-7c18-59ed-80fa-b58d3230c3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a9088f-8755-47cb-aa93-51d992ccab90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a9088f-8755-47cb-aa93-51d992ccab90.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -5089,7 +5089,7 @@
         },
         {
             "id": "3d471026-1fca-52ec-a2be-3f7a04fc4fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56421a8-34ae-4033-943f-c59a7bf2b6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56421a8-34ae-4033-943f-c59a7bf2b6f9.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Cannot be used to block any creature of power more than 1.",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "30707455-efcd-5433-b61f-ac041fd984f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3fd83-969c-4add-888f-86f4306b067c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3fd83-969c-4add-888f-86f4306b067c.jpg?1",
             "name": "Keldon Warlord",
             "text": "The Xs below are the number of non-wall creatures on your side, including Warlord. Thus if you have 2 other non-wall creatures, Warlord is 3/3. If one of those creatures is killed during the turn, Warlord immediately becomes 2/2.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "c65fcd18-dc47-50d4-bdb1-518bbf0ef820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573ef03-4730-45aa-93dd-e45ac1dbaf4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573ef03-4730-45aa-93dd-e45ac1dbaf4a.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt does 3 damage to one target.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "1d0129d0-c309-5cfd-8bfa-eaf6c23769e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb99a26-beeb-4aca-bb02-b2d2ce0595f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb99a26-beeb-4aca-bb02-b2d2ce0595f9.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever either player taps land for mana, each land produces 1 extra mana of the appropriate type.",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "0babd4f5-5eb3-50a8-ad2c-8891c613cf25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6121f72f-680f-4bb4-ae4d-37ee4ebed4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6121f72f-680f-4bb4-ae4d-37ee4ebed4d8.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever any land is tapped, Manabarbs does 1 damage to the land's controller.",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "0581bf53-8935-5476-b230-08e75da69aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4eb3db3-6a7c-488a-9433-d5d1d3133816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4eb3db3-6a7c-488a-9433-d5d1d3133816.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -5282,7 +5282,7 @@
         },
         {
             "id": "d0b91299-b163-54a9-9ba8-6cb0e43e5e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97208b1-a91b-4129-8a00-2f97b418accc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97208b1-a91b-4129-8a00-2f97b418accc.jpg?1",
             "name": "Orcish Artillery",
             "text": "Tap to do 2 damage to any target, but you suffer 3 damage as well.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "83c72bb2-5cdf-5a61-849e-751fe7516448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911538ea-322c-4c40-a9c3-35e47fe60fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911538ea-322c-4c40-a9c3-35e47fe60fce.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "When attacking, all of your attacking creatures gain +1/+0.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "72ab1ee8-662f-5189-ad60-93e961d10e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62858604-ca5a-4f69-a045-a7515ebfabf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62858604-ca5a-4f69-a045-a7515ebfabf2.jpg?1",
             "name": "Power Surge",
             "text": "Before untapping lands at the start of a turn, each player takes 1 damage for each land he or she controls but did not tap during the previous turn.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "28a8715a-6372-5462-80a5-737e42f57150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e4f56d-1f4f-49f2-8534-0d09196a3327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e4f56d-1f4f-49f2-8534-0d09196a3327.jpg?1",
             "name": "Raging River",
             "text": "When you attack, non-flying defending creatures must be divided as opponent wishes between the left and right sides of the River. You then choose on which side of the River to place each attacking creature, and attacking creatures can only be blocked by flying creatures or those on the same side of the River.",
             "colours": [
@@ -5409,7 +5409,7 @@
         },
         {
             "id": "412bfec8-a55f-594f-ac19-0ce6204afc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776ad9be-3309-4f1d-9f27-6219d9477662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776ad9be-3309-4f1d-9f27-6219d9477662.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Counters a blue spell being cast or destroys a blue card in play.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "729e7476-95e1-52d7-90ae-be95f0f53798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/731a4b86-c213-4d8e-bf01-0a0e8cff0ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/731a4b86-c213-4d8e-bf01-0a0e8cff0ff1.jpg?1",
             "name": "Roc of Kher Ridges",
             "text": "Flying",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "2eb79bb1-e34c-5303-b1ef-38710f4e89fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410ac9e6-fbc1-4cc8-84db-84e2eb1bab97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410ac9e6-fbc1-4cc8-84db-84e2eb1bab97.jpg?1",
             "name": "Rock Hydra",
             "text": "Put X +1/+1 counters (heads) on Hydra. Each point of damage Hydra suffers destroys one head unless R is spent. During upkeep, new heads may be grown for o\nRo\nRo\nR apiece.",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "d322346d-70c8-5cf5-9cf9-7e1293aa4a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13bf496-f3c0-4c13-8282-e7abfab6a198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13bf496-f3c0-4c13-8282-e7abfab6a198.jpg?1",
             "name": "Sedge Troll",
             "text": "Troll gains +1/+1 if controller has any swamps in play. oo\nB Regenerates",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "d7d630fc-cc86-53ae-87b3-853a78164950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50dc7fc1-cb6a-4c68-b993-1a25cf16226e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50dc7fc1-cb6a-4c68-b993-1a25cf16226e.jpg?1",
             "name": "Shatter",
             "text": "Shatter destroys target artifact.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "87188ba2-baa8-538c-baf4-debdc3c29edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefbf149-f988-4f8b-9f53-56f5878116a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefbf149-f988-4f8b-9f53-56f5878116a6.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying, oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "75dea13c-11ac-530e-b1c9-383bc6129329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67788e-d713-47c3-ab9f-b8a6212ae24f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67788e-d713-47c3-ab9f-b8a6212ae24f.jpg?1",
             "name": "Smoke",
             "text": "Each player can only untap one creature during his or her untap phase.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "180c774b-6d75-5758-ab6a-0c0dca7bba6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaedb9-25f8-4304-9085-e12505b93312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaedb9-25f8-4304-9085-e12505b93312.jpg?1",
             "name": "Stone Giant",
             "text": "Tap to make one of your own creatures a flying creature until end of turn. Target creature, which must have toughness less than Stone Giant's power, is destroyed at end of turn.",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "38833469-bac9-5edf-ab12-3182e4aad7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ff74cb-a2ed-4123-ac42-f72f9820049e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ff74cb-a2ed-4123-ac42-f72f9820049e.jpg?1",
             "name": "Stone Rain",
             "text": "Destroys any one land.",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "03fdba94-cbe3-5422-9832-ecd9a41d3a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21ebc9f-a93e-4d18-b3e8-8459e3abbf31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21ebc9f-a93e-4d18-b3e8-8459e3abbf31.jpg?1",
             "name": "Tunnel",
             "text": "Destroys 1 wall. Target wall cannot be regenerated.",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "3384d608-23a3-51ab-8009-c111787d6a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c687dc-ee0c-4e54-a2b3-5d8e633b3245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c687dc-ee0c-4e54-a2b3-5d8e633b3245.jpg?1",
             "name": "Two-Headed Giant of Foriys",
             "text": "Trample\nMay block two attacking creatures; divide damage between them however controller likes.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "7d8283ea-b60e-5d4f-8505-9717492f7f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff21a6f-83a7-4bf3-a078-294e303232cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff21a6f-83a7-4bf3-a078-294e303232cc.jpg?1",
             "name": "Uthden Troll",
             "text": "oo\nR Regenerates",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "c5fd5a58-1445-557c-85bb-e76f655542ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf12cd-fb70-444e-9641-73ffa0e8f16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcf12cd-fb70-444e-9641-73ffa0e8f16e.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "ad4195d1-31cb-5e00-b559-da852b67e674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140e567c-6e4a-42b0-8084-d6c9695ae802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140e567c-6e4a-42b0-8084-d6c9695ae802.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "4ae3911d-f48e-5218-adc5-bb79f917c6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b369c4-faa8-45c8-a1b9-98f228b69682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b369c4-faa8-45c8-a1b9-98f228b69682.jpg?1",
             "name": "Wheel of Fortune",
             "text": "Both players must discard their hands and draw seven new cards.",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "ee469ce3-fa83-5890-9311-50774b3e199d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9ac9e6-1395-4fbd-80e2-645f0d910c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9ac9e6-1395-4fbd-80e2-645f0d910c29.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Target creature's power and toughness are increased by half the number of forests you have in play, rounding down for power and up for toughness.",
             "colours": [
@@ -5926,7 +5926,7 @@
         },
         {
             "id": "9a4936c7-2b0d-5043-ae37-9d6ed48b950a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e173c8ce-2352-405e-ad00-e3bb94ced1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e173c8ce-2352-405e-ad00-e3bb94ced1ad.jpg?1",
             "name": "Berserk",
             "text": "Until end of turn, target creature's current power doubles and it gains trample ability. If it attacks, target creature is destroyed at end of turn. This spell cannot be cast after current turn's attack is completed.",
             "colours": [
@@ -5957,7 +5957,7 @@
         },
         {
             "id": "e9cb448e-c625-5b5e-b6b4-8eed9a359834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fe6449-1f23-43dc-adee-d144cd505b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fe6449-1f23-43dc-adee-d144cd505b5c.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying// Tap to add one mana of any color to your mana pool. This tap may be played as an interrupt.",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "19b63ade-88e7-5c10-91fd-34e62e9d7251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3838c2a3-7fab-4976-9c1b-2891aee24e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3838c2a3-7fab-4976-9c1b-2891aee24e52.jpg?1",
             "name": "Camouflage",
             "text": "You may rearrange your attacking creatures and place them face down, revealing which is which only after defense is chosen. If this results in impossible blocks, such as non-flying creatures blocking flying creatures, illegal blockers cannot block this turn.",
             "colours": [
@@ -6021,7 +6021,7 @@
         },
         {
             "id": "5519d329-90ca-5fc0-896e-1f17a83a36df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1862c47-71cc-45a3-8805-a5ddc62e55ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1862c47-71cc-45a3-8805-a5ddc62e55ea.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, you may add colorless mana to your mana pool for 1 life each. These additions are played with the speed of an interrupt. Life spent this way is not considered damage.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "0c2c0ea4-fc9f-5c2c-b32b-630d1fc3eb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd91814-6177-4a3d-a1c1-a3be7d7c7957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd91814-6177-4a3d-a1c1-a3be7d7c7957.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nAny non-wall creature blocking Cockatrice is destroyed, as is any creature blocked by Cockatrice. Creatures destroyed in this way deal their damage before dying.",
             "colours": [
@@ -6085,7 +6085,7 @@
         },
         {
             "id": "b859e07a-6506-59ad-9ddb-449a15c79fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfed1a95-bd67-4e16-a781-81866028af2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfed1a95-bd67-4e16-a781-81866028af2f.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "c0512381-6e2d-533e-94ee-43f1a7bf9fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb9d405-f2b5-4e10-a405-feafd2a87d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb9d405-f2b5-4e10-a405-feafd2a87d90.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -6152,7 +6152,7 @@
         },
         {
             "id": "a3249a03-d73f-55c0-b27d-aa7dd000434d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a575a9af-e1de-4a1d-91d8-440585377e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a575a9af-e1de-4a1d-91d8-440585377e4f.jpg?1",
             "name": "Fastbond",
             "text": "You may put as many lands into play as you want each turn. Fastbond does 1 damage to you for every land beyond the first that you play in a single turn.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "ef85fb5f-8cab-5f69-9dd2-59f6782cb848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba606d-bb55-43ba-aa0c-299649958788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba606d-bb55-43ba-aa0c-299649958788.jpg?1",
             "name": "Fog",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is dealt.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "e0aedb56-be8f-50e7-99de-274c4bb2e91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21551cb6-3a53-42dd-9bbd-4bc56304d6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21551cb6-3a53-42dd-9bbd-4bc56304d6d3.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nYou must pay o\nGo\nGo\nGo\nG during upkeep or Force of Nature does 8 damage to you. You may still attack with Force of Nature even if you failed to pay the upkeep.",
             "colours": [
@@ -6247,7 +6247,7 @@
         },
         {
             "id": "d087d94e-05dd-559b-b2ea-fdb9c65e9a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad89f0d-b09b-40a0-84d6-3ee60dec7e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad89f0d-b09b-40a0-84d6-3ee60dec7e23.jpg?1",
             "name": "Fungusaur",
             "text": "Each time Fungusaur is damaged but not destroyed, put a +1/+1 counter on it.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "327b5837-a9b6-57c3-97c3-980460b59faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b15221-c8b0-4861-9f8b-8a65834ad499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b15221-c8b0-4861-9f8b-8a65834ad499.jpg?1",
             "name": "Gaea's Liege",
             "text": "When defending, Gaea's Liege has power and toughness equal to the number of forests you have in play; when it's attacking, they are equal to the number of forests opponent has in play. Tap to turn any one land into a forest until Gaea's Liege leaves play. Mark changed lands with counters, removing the counters when Gaea's Liege leaves play.",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "c2d7fc5f-09eb-5f6e-ac5a-37363728010c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dbefe-3366-408e-9fcf-7dc00f8cc201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dbefe-3366-408e-9fcf-7dc00f8cc201.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gains +3/+3 until end of turn.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "0e34f75e-e3e8-53ec-a446-36c0562a926b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77636b4c-faea-4bf5-b88c-dd5bb88dc930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77636b4c-faea-4bf5-b88c-dd5bb88dc930.jpg?1",
             "name": "Giant Spider",
             "text": "Does not fly, but can block flying creatures.",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "5a6b23d0-6859-5f88-983b-e03c9931780c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d603a-3231-4a8c-bf39-1617586ea870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d603a-3231-4a8c-bf39-1617586ea870.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "1cf51e00-236b-5c4b-a7fb-9a0aeb423eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f5a19f-16e4-4d35-89e1-969ac8202f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f5a19f-16e4-4d35-89e1-969ac8202f88.jpg?1",
             "name": "Hurricane",
             "text": "All players and flying creatures suffer X damage.",
             "colours": [
@@ -6442,7 +6442,7 @@
         },
         {
             "id": "1b8fc8f8-dfaf-575a-afd6-e90e197f17f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9914836e-2fa6-4390-94b2-431427848a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9914836e-2fa6-4390-94b2-431427848a54.jpg?1",
             "name": "Ice Storm",
             "text": "Destroys any one land.",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "4914c3e8-2ea5-529e-af34-da31f4b6b7c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd38716-874c-4e3c-a315-837839a6258c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd38716-874c-4e3c-a315-837839a6258c.jpg?1",
             "name": "Instill Energy",
             "text": "You may untap target creature both during your untap phase and one additional time during your turn. Target creature may attack the turn it comes into play.",
             "colours": [
@@ -6506,7 +6506,7 @@
         },
         {
             "id": "966cd12b-ddb8-5dc5-ae69-7c9c0f8935c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93c5869-7777-44bb-967a-e9439b25ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93c5869-7777-44bb-967a-e9439b25ced4.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -6539,7 +6539,7 @@
         },
         {
             "id": "54fdd74b-45b1-58d0-a424-7942bce3d612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b72dcd-9ea1-4729-baae-ecd262fdff67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b72dcd-9ea1-4729-baae-ecd262fdff67.jpg?1",
             "name": "Kudzu",
             "text": "When target land is tapped, it is destroyed. Unless that was the last land in play, Kudzu is not discarded; instead, the player whose land it just destroyed may place it on another land of his or her choice.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "4a43d2d8-4465-57b2-af9f-6fa73b3dc62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9232508-d363-4ef3-987a-741f6bff331f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9232508-d363-4ef3-987a-741f6bff331f.jpg?1",
             "name": "Ley Druid",
             "text": "Tap Druid to untap a land of your choice. This action can be played as an interrupt.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "c9952ca6-3d06-50c5-b0e9-47fe6726d869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292577e-6232-44fa-a9c2-cc09949c6ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e292577e-6232-44fa-a9c2-cc09949c6ed3.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Destroy a black spell as it is being cast. This use may be played as an interrupt, and does not affect black cards already in play.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "5caac84e-5d0e-5a30-9723-aebf4a833f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38cb601b-a35c-412e-b386-e77dad3daa54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38cb601b-a35c-412e-b386-e77dad3daa54.jpg?1",
             "name": "Lifelace",
             "text": "Changes the color of one card either being played or already in play to green. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "67c8fd62-a3be-55a5-9064-1512dce373bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e753a2-a7d0-4d37-ae65-b5a1b5039a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e753a2-a7d0-4d37-ae65-b5a1b5039a6e.jpg?1",
             "name": "Living Artifact",
             "text": "Put a counter on target artifact for each life you lose. During upkeep you may trade one counter for one life, but you can only trade in one counter each turn.",
             "colours": [
@@ -6701,7 +6701,7 @@
         },
         {
             "id": "bb6003e9-527b-5912-9514-1843dc869d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80be0580-7948-4d8e-8c0f-5e2797ac411b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80be0580-7948-4d8e-8c0f-5e2797ac411b.jpg?1",
             "name": "Living Lands",
             "text": "Treat all forests in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. The living lands have no color; they are not considered green cards.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "302e86fb-7c0f-5e54-a86f-e4e07726cd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1cc9e-4f99-4c26-ac1b-8ef069fa8ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f1cc9e-4f99-4c26-ac1b-8ef069fa8ceb.jpg?1",
             "name": "Llanowar Elves",
             "text": "Tap to add 1 green mana to your mana pool. This tap can be played as an interrupt.",
             "colours": [
@@ -6766,7 +6766,7 @@
         },
         {
             "id": "f5b464d6-f0b3-591f-8ab3-e5889780443c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a87b26e-0431-42e9-b44f-94ba8546111a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a87b26e-0431-42e9-b44f-94ba8546111a.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. If a creature has the ability to block more than one creature, Lure does not prevent this. If there is more than one attacking creature with Lure, defender may choose which of them each defending creature blocks.",
             "colours": [
@@ -6799,7 +6799,7 @@
         },
         {
             "id": "a65fe493-250f-52f5-80af-a834c111910e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8917dc8-01c0-4e72-9310-c4d501775411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8917dc8-01c0-4e72-9310-c4d501775411.jpg?1",
             "name": "Natural Selection",
             "text": "Look at top three cards of any player's library. You may opt to rearrange those three cards or shuffle the entire library.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "a6064531-356e-5a9d-910c-fb59ff57e997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b7aa34-b4f8-41b4-82ce-ab2e204c3bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b7aa34-b4f8-41b4-82ce-ab2e204c3bf4.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Target creature regenerates.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "4a102b79-3e73-5505-ada4-8f7038deae5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc73ec-3728-4246-90c7-5f4eb7051ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badc73ec-3728-4246-90c7-5f4eb7051ed5.jpg?1",
             "name": "Regrowth",
             "text": "Return any card from your graveyard to your hand.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "38334b47-e568-5c1d-ae4e-f4dd90bf00e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929c38-91e6-457c-937a-d1884f4bba44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929c38-91e6-457c-937a-d1884f4bba44.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "68091432-8d00-5562-90eb-b51a482ac716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814cf35c-f1ad-4bf4-8c10-a5592c3b1be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814cf35c-f1ad-4bf4-8c10-a5592c3b1be8.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk",
             "colours": [
@@ -6961,7 +6961,7 @@
         },
         {
             "id": "d9dedeb6-eb90-553f-9f49-08ca5cf65253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c4d4b-2645-4cd9-823e-3c9bb2eb48f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1c4d4b-2645-4cd9-823e-3c9bb2eb48f9.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "1470385e-e891-59a8-9577-930d40dd955b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cce01-b3bd-4307-aae5-9a7c8fa386ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cce01-b3bd-4307-aae5-9a7c8fa386ab.jpg?1",
             "name": "Thicket Basilisk",
             "text": "Any non-wall creature blocking Basilisk is destroyed, as is any creature blocked by Basilisk. Creatures destroyed this way deal their damage before dying.",
             "colours": [
@@ -7025,7 +7025,7 @@
         },
         {
             "id": "4b1b5ad1-e5d8-5db9-9ec9-b3452d49ec60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2570a4-eef9-430d-b6c2-cd51d29b9d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2570a4-eef9-430d-b6c2-cd51d29b9d01.jpg?1",
             "name": "Timber Wolves",
             "text": "Bands",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "fc5a1fc7-deb1-5e12-b7fa-b57b1c2b9015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cc5a6-3a69-4812-add4-eb5eb6389238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cc5a6-3a69-4812-add4-eb5eb6389238.jpg?1",
             "name": "Tranquility",
             "text": "All enchantments in play must be discarded.",
             "colours": [
@@ -7089,7 +7089,7 @@
         },
         {
             "id": "c152cc9c-6ae0-5395-8b15-4805f43dbc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed67d61-cf47-446b-b454-eb404a8686b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed67d61-cf47-446b-b454-eb404a8686b7.jpg?1",
             "name": "Tsunami",
             "text": "All islands in play are destroyed.",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "b9fd3523-92aa-50fc-a18d-96b943ce6a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87178b-1221-4d7a-a7a5-20d7f01b8089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f87178b-1221-4d7a-a7a5-20d7f01b8089.jpg?1",
             "name": "Verduran Enchantress",
             "text": "While Enchantress is in play, you may immediately draw a card from your library each time you cast an enchantment.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "e3a964d1-4d7c-5f50-937a-9acfdb26ca0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a4558-db6e-41b2-aff6-b164d93282a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2a4558-db6e-41b2-aff6-b164d93282a0.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerates",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "a81c09b7-fa97-5d51-a863-766ef3bdd147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc743a03-867c-4bb0-8fb0-2bcaa0a8a756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc743a03-867c-4bb0-8fb0-2bcaa0a8a756.jpg?1",
             "name": "Wall of Ice",
             "text": "",
             "colours": [
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "b1d09fde-c795-5a7f-9fae-1ce3baf441d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df80424-3bd9-4982-ad79-e55d9ba3b43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df80424-3bd9-4982-ad79-e55d9ba3b43d.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -7254,7 +7254,7 @@
         },
         {
             "id": "d55ea838-65d9-5786-87c8-c94a1aa921ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220a03ca-8c9b-4acb-821d-f6577fbb20fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220a03ca-8c9b-4acb-821d-f6577fbb20fb.jpg?1",
             "name": "Wanderlust",
             "text": "Wanderlust does 1 damage to target creature's controller during upkeep.",
             "colours": [
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "9aedecd6-b119-5587-8894-3119038a77ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d6081e-f686-4263-a0a2-21c0d9af5fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d6081e-f686-4263-a0a2-21c0d9af5fdb.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "44726e0f-a668-52cc-8541-5205dc26d360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c7890a-86dc-4a97-a7ce-1436fa22d0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c7890a-86dc-4a97-a7ce-1436fa22d0c0.jpg?1",
             "name": "Web",
             "text": "Target creature gains +0/+2 and can now block flying creatures, though it does not gain the power to fly.",
             "colours": [
@@ -7353,7 +7353,7 @@
         },
         {
             "id": "a73440ee-3ff6-52d2-a8b1-edb483c49834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd896dfa-66c0-4327-8e5b-489bbe350c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd896dfa-66c0-4327-8e5b-489bbe350c95.jpg?1",
             "name": "Wild Growth",
             "text": "When tapped, target land provides 1 green mana in addition to the mana it normally provides.",
             "colours": [
@@ -7386,7 +7386,7 @@
         },
         {
             "id": "33b9ca30-0296-52b7-a8e2-7d4715404b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f594b7aa-d44e-47c4-989b-565f881e25f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f594b7aa-d44e-47c4-989b-565f881e25f1.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Ankh does 2 damage to anyone who puts a new land into play.",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "f592d20b-1974-569e-82ab-aa59f3a66765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a74c89-6f86-4ec8-af17-391cd5026054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a74c89-6f86-4ec8-af17-391cd5026054.jpg?1",
             "name": "Basalt Monolith",
             "text": "Tap to add 3 colorless mana to your mana pool. Does not untap as normal during untap phase, but can be untapped at any time for 3 mana. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7440,7 +7440,7 @@
         },
         {
             "id": "d4d8c9f9-31ed-53ed-ab67-eba86e2198fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0faa7f2-b547-42c4-a810-839da50dadfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0faa7f2-b547-42c4-a810-839da50dadfe.jpg?1",
             "name": "Black Lotus",
             "text": "Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7467,7 +7467,7 @@
         },
         {
             "id": "3cbbae60-d9e0-5ef4-9dff-0ee9810cef84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac72f8-5b1e-4d67-a796-ef69cde27424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac72f8-5b1e-4d67-a796-ef69cde27424.jpg?1",
             "name": "Black Vise",
             "text": "If opponent has more than four cards in hand during upkeep, black vise does 1 damage to opponent for each card in excess of four.",
             "colours": [],
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "f337d434-8b68-5bb0-bf4d-af096f722fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47417cb-1ea7-4f65-ba06-e27a99373114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47417cb-1ea7-4f65-ba06-e27a99373114.jpg?1",
             "name": "Celestial Prism",
             "text": "o2: Provides 1 mana of any color. This use can be played as an interrupt.",
             "colours": [],
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "249e6587-885e-5fbc-8593-b13114de5e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92274971-7c4a-4326-b0fe-75e2d124f718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92274971-7c4a-4326-b0fe-75e2d124f718.jpg?1",
             "name": "Chaos Orb",
             "text": "o1: Flip Chaos Orb onto the playing area from a height of at least one foot. Chaos Orb must turn completely over at least once or it is discarded with no effect. When Chaos Orb lands, any cards in play that it touches are destroyed, as is Chaos Orb.",
             "colours": [],
@@ -7548,7 +7548,7 @@
         },
         {
             "id": "ed68798d-872d-5bf6-82e2-6122ed4b25a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f916a2-0ace-44b5-99dc-72979af34db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f916a2-0ace-44b5-99dc-72979af34db9.jpg?1",
             "name": "Clockwork Beast",
             "text": "Put seven +1/+0 counters on Beast. After Beast attacks or blocks a creature, discard a counter. During the untap phase, controller may buy back lost counters for 1 mana per counter instead of untapping Beast; this taps Beast if it wasn't tapped already.",
             "colours": [],
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "0d67f98a-5fd5-55e4-84b8-f571fea1dd1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7824e2a-4eff-4f72-9216-0db30a4f4252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7824e2a-4eff-4f72-9216-0db30a4f4252.jpg?1",
             "name": "Conservator",
             "text": "o3: Prevent the loss of up to 2 life.",
             "colours": [],
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "3f1d01ec-a192-5cb2-8c2f-348bbca84877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30935e4a-013e-4c46-ad05-304df8e5dfa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30935e4a-013e-4c46-ad05-304df8e5dfa4.jpg?1",
             "name": "Copper Tablet",
             "text": "Copper Tablet does 1 damage to each player during his or her upkeep.",
             "colours": [],
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "3f41a94d-ecd3-56eb-b4be-48b7e7f7dc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76693233-7961-4b7e-80f2-ed90e494c4aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76693233-7961-4b7e-80f2-ed90e494c4aa.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Any blue spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7659,7 +7659,7 @@
         },
         {
             "id": "49177581-b077-5528-bf49-3ddabce4cfbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894c5cf2-8ae2-427a-bcbc-67df0bdfee9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894c5cf2-8ae2-427a-bcbc-67df0bdfee9d.jpg?1",
             "name": "Cyclopean Tomb",
             "text": "o2: Turn any one non-swamp land into swamp during upkeep. Mark the changed lands with tokens. If Cyclopean Tomb is destroyed, remove one token of your choice each upkeep, returning that land to its original nature.",
             "colours": [],
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "7e658839-6217-5fdd-ab8e-cf554f7910d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb6cda-e512-40a8-9c1f-335b713409ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65eb6cda-e512-40a8-9c1f-335b713409ff.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever anyone loses a land, Egg does 2 damage to that player for each land lost.",
             "colours": [],
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "c9fdfe37-f685-5cfc-93be-603a5cb15d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca571ee8-07a2-43b8-9acf-89cbfd3cf7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca571ee8-07a2-43b8-9acf-89cbfd3cf7c9.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3: Opponent must discard one card of his or her choice. Can only be used during your turn.",
             "colours": [],
@@ -7740,7 +7740,7 @@
         },
         {
             "id": "09947465-87b1-57b3-a9b8-7577ccb3a793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2004c1-8efe-407f-bf48-27b807422eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2004c1-8efe-407f-bf48-27b807422eea.jpg?1",
             "name": "Forcefield",
             "text": "o1: Lose only 1 life to an unblocked creature.",
             "colours": [],
@@ -7767,7 +7767,7 @@
         },
         {
             "id": "f312d00f-072f-5e53-a819-a95a6f22b2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da248001-ed75-4b68-9532-37d3cd5afc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da248001-ed75-4b68-9532-37d3cd5afc4c.jpg?1",
             "name": "Gauntlet of Might",
             "text": "All red creatures gain +1/+1 and all mountains provide an extra red mana when tapped.",
             "colours": [],
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "b46d8839-8c5e-5750-8446-32f1fba6f576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafc2350-5d64-4379-9198-79a114654d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafc2350-5d64-4379-9198-79a114654d45.jpg?1",
             "name": "Glasses of Urza",
             "text": "You may look at opponent's hand.",
             "colours": [],
@@ -7823,7 +7823,7 @@
         },
         {
             "id": "784c27df-1796-5d92-8d37-1bb82c1dcd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3792c6ef-c4e6-4923-9a51-7d28fbc5c393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3792c6ef-c4e6-4923-9a51-7d28fbc5c393.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1: You may give one creature the ability to band until end of turn.",
             "colours": [],
@@ -7850,7 +7850,7 @@
         },
         {
             "id": "fcf21c7c-b0a3-5835-b832-c791c6268572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f8f6e1-a451-4262-90d3-5107caf54175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f8f6e1-a451-4262-90d3-5107caf54175.jpg?1",
             "name": "Howling Mine",
             "text": "Each player draws one extra card each turn during his or her draw phase.",
             "colours": [],
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "f6ffcf8f-af06-5e23-9b98-f96f29d82aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dc1596-a2e7-4d60-9f99-89babaef8a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dc1596-a2e7-4d60-9f99-89babaef8a06.jpg?1",
             "name": "Icy Manipulator",
             "text": "o1: You may tap any land, creature, or artifact in play on either side.",
             "colours": [],
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "eedfcb4e-e08a-5070-98f5-15c3a107d8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ef2f37-b8ad-47ad-89ca-d6abcb7ff21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ef2f37-b8ad-47ad-89ca-d6abcb7ff21b.jpg?1",
             "name": "Illusionary Mask",
             "text": "oo\nX You can summon a creature face down so opponent doesn't know what it is. The X cost can be any amount of mana, even 0; it serves to hide the true casting cost of the creature, which you still have to spend. As soon as a face-down creature receives damage, deals damage, or is tapped, you must turn it face up.",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "20a7a1b9-a056-54cc-b9fe-245ce6d0d250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5786de12-cade-43c2-a6b0-0c5b294b9d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5786de12-cade-43c2-a6b0-0c5b294b9d0e.jpg?1",
             "name": "Iron Star",
             "text": "o1: Any red spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7958,7 +7958,7 @@
         },
         {
             "id": "7ffb42ec-f0c8-568e-b83f-0678bcaa3681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964d8d8-dc97-4e5f-9f52-173f7e2c37fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964d8d8-dc97-4e5f-9f52-173f7e2c37fd.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Any white spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "f5615af0-ce72-51ca-b998-209fbb8c36c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a77e0f1-449d-4a7d-9fa0-ba7598f7a73a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a77e0f1-449d-4a7d-9fa0-ba7598f7a73a.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: You may take damage done to any creature on yourself instead, but you must take all of it. Source of damage is unchanged.",
             "colours": [],
@@ -8012,7 +8012,7 @@
         },
         {
             "id": "ca502ec9-12b3-5458-85e8-401a710d80d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d82d94b-ceef-4533-a4f2-b6442a61b839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d82d94b-ceef-4533-a4f2-b6442a61b839.jpg?1",
             "name": "Jade Statue",
             "text": "o2: Jade Statue becomes a creature for the duration of the current attack exchange. Can be a creature only during an attack or defense.",
             "colours": [],
@@ -8039,7 +8039,7 @@
         },
         {
             "id": "5b4feaeb-a044-5b52-a059-e8c7999d2e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8c421-5b92-481d-b2de-560c0231ab58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac8c421-5b92-481d-b2de-560c0231ab58.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4: You may draw one extra card.",
             "colours": [],
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "5b3b7079-c372-5c74-b0f6-b1c20f1ca809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd6a291-5282-4f49-8203-d9b416083c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd6a291-5282-4f49-8203-d9b416083c48.jpg?1",
             "name": "Juggernaut",
             "text": "Must attack each turn if possible. Can't be blocked by walls.",
             "colours": [],
@@ -8096,7 +8096,7 @@
         },
         {
             "id": "cd845e02-8333-5476-9a55-14071a11fdcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef7a1-148d-44ac-89ed-0ef379cca0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef7a1-148d-44ac-89ed-0ef379cca0c6.jpg?1",
             "name": "Kormus Bell",
             "text": "Treat all swamps in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. Swamps have no color; they are not considered black cards.",
             "colours": [],
@@ -8123,7 +8123,7 @@
         },
         {
             "id": "bd0c867e-977f-51d8-ba5c-930aca1a25f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340edcb-8cd5-4ccd-99e2-b9a29f72c495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2340edcb-8cd5-4ccd-99e2-b9a29f72c495.jpg?1",
             "name": "Library of Leng",
             "text": "There is no limit to size of your hand. If a card forces you to discard, you may choose to discard to top of your library rather than to graveyard. If discard is random, you may look at card before deciding where to discard it.",
             "colours": [],
@@ -8150,7 +8150,7 @@
         },
         {
             "id": "fe12d2bc-3059-5e2e-9864-d060fa94db4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a98ada6-923a-44a5-bdef-ea6a160b481e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a98ada6-923a-44a5-bdef-ea6a160b481e.jpg?1",
             "name": "Living Wall",
             "text": "Counts as a wall. o1: Regenerates.",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "a5d6cd48-7605-566f-98f3-64974a2bad5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19499cb7-eccb-4e69-af32-6002d447a160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19499cb7-eccb-4e69-af32-6002d447a160.jpg?1",
             "name": "Mana Vault",
             "text": "Tap to add 3 colorless mana to your mana pool. Mana Vault doesn't untap normally during untap phase; to untap it, you must pay 4 mana. If Mana Vault remains tapped during upkeep it does 1 damage to you. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "f04e8da0-627d-5997-8660-15631af07ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68a17-22ee-47c9-870a-83e911862b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68a17-22ee-47c9-870a-83e911862b94.jpg?1",
             "name": "Meekstone",
             "text": "Any creature with power greater than 2 may not be untapped as normal during the untap phase.",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "3876cd4c-db88-534e-877c-307fa2e2b160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e1427c-05cd-465b-be59-97ed6e39f7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e1427c-05cd-465b-be59-97ed6e39f7ba.jpg?1",
             "name": "Mox Emerald",
             "text": "Add 1 green mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "173fc1fb-c465-5d62-b34e-60d76df02fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bcd1ce-19b1-4d78-8b09-95242ca08d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bcd1ce-19b1-4d78-8b09-95242ca08d76.jpg?1",
             "name": "Mox Jet",
             "text": "Add 1 black mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "bdbc1b80-5371-5af3-9c7c-6ec166c2cf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebe4be7-e12a-4596-a899-fbd5b152e879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebe4be7-e12a-4596-a899-fbd5b152e879.jpg?1",
             "name": "Mox Pearl",
             "text": "Add 1 white mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8321,7 +8321,7 @@
         },
         {
             "id": "25292565-ce32-5533-a526-ce41d41c0516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945585f-4773-493d-a0fe-d707db910b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945585f-4773-493d-a0fe-d707db910b38.jpg?1",
             "name": "Mox Ruby",
             "text": "Add 1 red mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8350,7 +8350,7 @@
         },
         {
             "id": "5dd1158c-6210-5a8c-a9bb-63df7f25d10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82da0972-b17b-4600-9efd-e9430a0db04b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82da0972-b17b-4600-9efd-e9430a0db04b.jpg?1",
             "name": "Mox Sapphire",
             "text": "Add 1 blue mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "93e3a468-1767-5a8f-93d6-1dca85707915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12926dc8-8e6f-4a47-a12b-4d674189615a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12926dc8-8e6f-4a47-a12b-4d674189615a.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "o1: Destroys all creatures, enchantments, and artifacts in play. Disk begins tapped but can be untapped as usual. Disk destroys itself when used.",
             "colours": [],
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "f3ba896e-7170-53ac-93ab-dbef4b2eb30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8e9f5c-deba-4443-bf9d-fb2be75c5418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8e9f5c-deba-4443-bf9d-fb2be75c5418.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -8436,7 +8436,7 @@
         },
         {
             "id": "9365bbe8-ef38-53cd-949b-0dd87eca1467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af957200-c538-4f52-b105-6db7a7abb4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af957200-c538-4f52-b105-6db7a7abb4dc.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3: Rod of Ruin does 1 damage to any target.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "075d914c-d9c8-5130-8146-b2a75389d184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4300d24-1cae-4dd5-be7e-38cc677cf5bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4300d24-1cae-4dd5-be7e-38cc677cf5bd.jpg?1",
             "name": "Sol Ring",
             "text": "Add 2 colorless mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "d1682a39-ccfa-599f-8cb3-4dd621d4bcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b814198-814b-4619-a158-327af675f8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b814198-814b-4619-a158-327af675f8f2.jpg?1",
             "name": "Soul Net",
             "text": "o1: You gain 1 life every time a creature is destroyed, unless it is then regenerated.",
             "colours": [],
@@ -8517,7 +8517,7 @@
         },
         {
             "id": "3598ae2b-12fe-5ff0-8e13-ab5cf917ef03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d433a4-76c0-4f27-836d-4c0c13a511fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d433a4-76c0-4f27-836d-4c0c13a511fb.jpg?1",
             "name": "Sunglasses of Urza",
             "text": "White mana in your mana pool can be used as either white or red mana.",
             "colours": [],
@@ -8544,7 +8544,7 @@
         },
         {
             "id": "c6ac7b37-14f2-5406-84a4-0f963bf1c5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a7138-eae8-4ff9-9e17-680bfa717183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a7138-eae8-4ff9-9e17-680bfa717183.jpg?1",
             "name": "The Hive",
             "text": "o5: Creates one Giant Wasp, a 1/1 flying creature. Represent Wasps with tokens, making sure to indicate when each Wasp is tapped. Wasps can't attack during the turn created. Treat Wasps like artifact creatures in every way, except that they are removed from the game entirely if they ever leave play. If the Hive is destroyed, the Wasps must still be killed individually.",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "b7fa2cea-fda3-50da-bc19-3d3924a276b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2931ae0-7836-4000-b9ec-f2029ebf5d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2931ae0-7836-4000-b9ec-f2029ebf5d96.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Any black spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "1c2ca7fa-61fb-50f3-bbc3-98a87eba487a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902441dc-c976-4c92-b897-6376eaa0fe38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902441dc-c976-4c92-b897-6376eaa0fe38.jpg?1",
             "name": "Time Vault",
             "text": "Tap to gain an additional turn after the current one. Time Vault doesn't untap normally during untap phase; to untap it, you must skip a turn. Time Vault begins tapped.",
             "colours": [],
@@ -8625,7 +8625,7 @@
         },
         {
             "id": "8e7bfb2e-4109-5074-a96c-5b6fbd481c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9359f60c-9a27-4e53-b35b-964a121a6fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9359f60c-9a27-4e53-b35b-964a121a6fba.jpg?1",
             "name": "Winter Orb",
             "text": "Players can untap only one land each during untap phase. Creatures and artifacts are untapped as normal.",
             "colours": [],
@@ -8652,7 +8652,7 @@
         },
         {
             "id": "57c329c5-0179-5536-b7d1-88e360194702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcae01a2-171b-47cd-87be-f1e4e5314326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcae01a2-171b-47cd-87be-f1e4e5314326.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Any green spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8679,7 +8679,7 @@
         },
         {
             "id": "0b71a1cd-ae02-5540-b1da-457fa985fb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f6d10-9144-4ade-9ac6-a481cc66b875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717f6d10-9144-4ade-9ac6-a481cc66b875.jpg?1",
             "name": "Badlands",
             "text": "Counts as both mountains and swamp and is affected by spells that affect either. Tap to add either o\nR or o\nB to your mana pool.",
             "colours": [],
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "02748612-1f51-5ead-ac83-ad4b99ab7e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412ceddd-2b9a-4551-a6bf-ae2830a2010a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412ceddd-2b9a-4551-a6bf-ae2830a2010a.jpg?1",
             "name": "Bayou",
             "text": "Counts as both swamp and forest and is affected by spells that affect either. Tap to add either o\nB or o\nG to your mana pool.",
             "colours": [],
@@ -8745,7 +8745,7 @@
         },
         {
             "id": "295c94f5-b864-531c-8eb9-4e6a41885685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eafa00b-c628-40f6-86eb-88e1361fc7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eafa00b-c628-40f6-86eb-88e1361fc7a0.jpg?1",
             "name": "Plateau",
             "text": "Counts as both mountains and plains and is affected by spells that affect either. Tap to add either o\nR or o\nW to your mana pool.",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "af353fc0-f840-5b76-916a-f4ada4f7ad18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7e24c-2546-41b6-81ad-5e920b07e64e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7e24c-2546-41b6-81ad-5e920b07e64e.jpg?1",
             "name": "Savannah",
             "text": "Counts as both plains and forest and is affected by spells that affect either. Tap to add either o\nW or o\nG to your mana pool.",
             "colours": [],
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "41bee624-763f-5876-85a9-4db6770ebfed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebe39d4-21fb-46a4-a1ec-b97102e46c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bebe39d4-21fb-46a4-a1ec-b97102e46c15.jpg?1",
             "name": "Scrubland",
             "text": "Counts as both plains and swamp and is affected by spells that affect either. Tap to add either o\nW or o\nB to your mana pool.",
             "colours": [],
@@ -8844,7 +8844,7 @@
         },
         {
             "id": "a5d7c20b-6437-5533-aa5a-ca7a3f34d723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60df6592-0b3b-4b87-aeb2-8fa94b4fb7be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60df6592-0b3b-4b87-aeb2-8fa94b4fb7be.jpg?1",
             "name": "Taiga",
             "text": "Counts as both forest and mountains and is affected by spells that affect either. Tap to add either o\nG or o\nR to your mana pool.",
             "colours": [],
@@ -8877,7 +8877,7 @@
         },
         {
             "id": "a605c54b-a689-5a2f-b877-bfda0ce56b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6c759-aabf-44e7-ba8c-33c5df232b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6c759-aabf-44e7-ba8c-33c5df232b56.jpg?1",
             "name": "Tropical Island",
             "text": "Counts as both forest and islands and is affected by spells that affect either. Tap to add either o\nG or o\nU to your mana pool.",
             "colours": [],
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "2528555c-f5d6-5c40-b5cc-ffe6798706fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03e8c5b-f4ed-4fd7-ba05-db813ccc05eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03e8c5b-f4ed-4fd7-ba05-db813ccc05eb.jpg?1",
             "name": "Tundra",
             "text": "Counts as both islands and plains and is affected by spells that affect either. Tap to add either o\nU or o\nW to your mana pool.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "63020af6-192a-52de-ab67-7afaa76c9c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff76ac86-8a8a-47fe-9388-8950ca3e26c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff76ac86-8a8a-47fe-9388-8950ca3e26c3.jpg?1",
             "name": "Underground Sea",
             "text": "Counts as both swamp and islands and is affected by spells that affect either. Tap to add either o\nB or o\nU to your mana pool.",
             "colours": [],
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "ab963052-f43e-5d99-970d-30502610b353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1623d57-4729-4796-b3f7-f1837a05c6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1623d57-4729-4796-b3f7-f1837a05c6ed.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "764759be-ff7d-53d5-abe5-8ad0a745c8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51662253-789f-4a02-9937-688e36775024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51662253-789f-4a02-9937-688e36775024.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9046,7 +9046,7 @@
         },
         {
             "id": "a3fa938c-157a-5762-bf66-3187a5facb1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a57c0e-fa61-45ef-955d-d296403967d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a57c0e-fa61-45ef-955d-d296403967d5.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9081,7 +9081,7 @@
         },
         {
             "id": "ea3ed63f-cb6c-5296-a471-191c3ae7cbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ea08d-7991-4a57-a1e3-abd508426970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6ea08d-7991-4a57-a1e3-abd508426970.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "2e49af91-8005-516d-8ceb-fd714c45d7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176936d-72e2-4205-8871-4c5a4f1cb2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176936d-72e2-4205-8871-4c5a4f1cb2d8.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "2f4e125b-ef7c-5b61-904e-2230a1802c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeba4e1-9012-4962-8797-3a1f6a660952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edeba4e1-9012-4962-8797-3a1f6a660952.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "827201c7-c2c1-57c5-8769-ae3c5edb0d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eace2c85-976c-425e-9800-5a6ccbd91b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eace2c85-976c-425e-9800-5a6ccbd91b56.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9221,7 +9221,7 @@
         },
         {
             "id": "df6d7458-bd61-5b97-be4f-7d7de6fadeda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a96315d-edc6-4d68-a260-d14f61281dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a96315d-edc6-4d68-a260-d14f61281dc1.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9256,7 +9256,7 @@
         },
         {
             "id": "0c5dd930-00c3-5655-9fd0-c889f8a38eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1c8cb0-38eb-408b-94e8-16db83999b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1c8cb0-38eb-408b-94e8-16db83999b3b.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],
@@ -9291,7 +9291,7 @@
         },
         {
             "id": "75e9547d-7f05-5d15-839a-157242ea4edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c89d9-71c9-45f5-a9cb-6e253b0a7cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c89d9-71c9-45f5-a9cb-6e253b0a7cca.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/LEB.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LEB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "2e646d16-a318-545d-9e2f-397d552e5b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5b4738-20bb-465d-b67e-c6146dce9d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5b4738-20bb-465d-b67e-c6146dce9d0b.jpg?1",
             "name": "Animate Wall",
             "text": "Target wall can now attack. Target wall's power and toughness are unchanged, even if its power is 0.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "4b4558ed-4bda-5123-94d3-64590e3797ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c4edfa-7822-40bc-88d1-d051b3a64df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c4edfa-7822-40bc-88d1-d051b3a64df1.jpg?1",
             "name": "Armageddon",
             "text": "All lands in play are destroyed.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "fa7907ce-3f80-5075-a9fc-874d8e27b6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c32a0-ee97-4239-94e3-aabab91dab83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2c32a0-ee97-4239-94e3-aabab91dab83.jpg?1",
             "name": "Balance",
             "text": "Whichever player has more lands in play must discard enough lands of his or her choice to equalize the number of lands both players have in play. Cards in hand and creatures in play must be equalized the same way. Creatures lost in this manner may not be regenerated.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "3694886b-6253-54b7-aeb8-5d3dae38e218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62c68d0-9b1e-4abe-991d-a645effeb676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62c68d0-9b1e-4abe-991d-a645effeb676.jpg?1",
             "name": "Benalish Hero",
             "text": "Bands",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "874039c1-d145-5f98-9e5a-1b5dda66351f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5d3fe-5741-40f7-8f45-dadb818d79b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d5d3fe-5741-40f7-8f45-dadb818d79b0.jpg?1",
             "name": "Black Ward",
             "text": "Target creature gains protection from black.",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "e5e18503-db69-5536-a15d-a722f1ca4b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78aef20-e3bb-484c-9fa1-d2859408b04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f78aef20-e3bb-484c-9fa1-d2859408b04a.jpg?1",
             "name": "Blaze of Glory",
             "text": "Target defending creature can and must block all attacking creatures it can legally block. For example, a normal non-flying target defender can and must block all normal non-flying attackers at once, but it cannot block any flying attackers. Controller of target defender may distribute damage among attackers as desired. Play before defense is chosen.",
             "colours": [
@@ -197,7 +197,7 @@
         },
         {
             "id": "c94ff6f2-2694-515d-8c06-b19afc3c037a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd624c8-f06e-4181-865e-6a14ffc9302f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd624c8-f06e-4181-865e-6a14ffc9302f.jpg?1",
             "name": "Blessing",
             "text": "oo\nW Target creature gains +1/+1 until end of turn.",
             "colours": [
@@ -230,7 +230,7 @@
         },
         {
             "id": "cd7f4c22-091a-57fc-bdf3-7f8ae98b5108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafae6f4-0880-4532-9224-44545bfa5eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafae6f4-0880-4532-9224-44545bfa5eb4.jpg?1",
             "name": "Blue Ward",
             "text": "Target creature gains protection from blue.",
             "colours": [
@@ -263,7 +263,7 @@
         },
         {
             "id": "0d210195-f733-5c64-9ec0-8e0ee95ed0bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6b09-b24f-40cb-b219-ad8a1fd6692c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ba6b09-b24f-40cb-b219-ad8a1fd6692c.jpg?1",
             "name": "Castle",
             "text": "Your untapped creatures gain +0/+2. Attacking creatures lose this bonus.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "6f391170-b170-509e-923d-a03746448c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47b4cd-8da4-4544-b011-ba92b7009203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47b4cd-8da4-4544-b011-ba92b7009203.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevents all damage against you from one black source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "8655215e-4d47-5bc8-8dd2-99e392589c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a86eb1-f6a0-4a4e-bd59-e19e22ec487d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a86eb1-f6a0-4a4e-bd59-e19e22ec487d.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevents all damage against you from one blue source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "e135e756-0cf8-5f4e-91a7-24c5eecd348c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e041b0ea-4a57-4950-9f8e-72d6e6ab2968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e041b0ea-4a57-4950-9f8e-72d6e6ab2968.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevents all damage against you from one green source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "9871110e-e0e3-578a-bc9d-c694a82b19b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de9dc85-d566-4cb0-a2e3-1ed4e5fe2f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de9dc85-d566-4cb0-a2e3-1ed4e5fe2f14.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevents all damage against you from one red source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "a1dde3c2-7567-52cc-a5bf-cf34787d39c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671aca82-6c55-43ef-b452-d6a2e706a7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671aca82-6c55-43ef-b452-d6a2e706a7ae.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevents all damage against you from one white source. If a source does damage to you more than once in a turn, you must pay 1 mana each time to prevent the damage.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "876e7f33-8587-5ef1-8b1b-5f53e7351f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077cf242-f866-497f-a23c-70e1b04a748e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077cf242-f866-497f-a23c-70e1b04a748e.jpg?1",
             "name": "Consecrate Land",
             "text": "All enchantments on target land are destroyed. Land cannot be destroyed or further enchanted until Consecrate Land has been destroyed.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "d19c555b-fd57-53e3-bb68-8d621a2109d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a5bb5-23cd-4f9a-8c8e-d009fb7bdf59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a5bb5-23cd-4f9a-8c8e-d009fb7bdf59.jpg?1",
             "name": "Conversion",
             "text": "All mountains are considered plains while Conversion is in play. Pay o\nWo\nW during upkeep or Conversion is discarded.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "95735427-7021-54f4-a59b-db078792db2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5fbd9d-48bf-4600-8ca4-2ce2ca48128e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5fbd9d-48bf-4600-8ca4-2ce2ca48128e.jpg?1",
             "name": "Crusade",
             "text": "All white creatures gain +1/+1.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "50f5951c-4dfd-55af-a8a5-2c42c3377729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b119edd8-7801-475e-943a-6cbf10f2d303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b119edd8-7801-475e-943a-6cbf10f2d303.jpg?1",
             "name": "Death Ward",
             "text": "Regenerates target creature.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "4661a2e0-2536-51c2-aee7-560b0674023a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d61d0a5-7e92-4413-9121-925e1876b64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d61d0a5-7e92-4413-9121-925e1876b64d.jpg?1",
             "name": "Disenchant",
             "text": "Target enchantment or artifact must be discarded.",
             "colours": [
@@ -606,7 +606,7 @@
         },
         {
             "id": "9eec79ef-c101-56a3-9d61-95cca9f21015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49ecc66-dccb-4026-8c6e-0b275a635a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49ecc66-dccb-4026-8c6e-0b275a635a1f.jpg?1",
             "name": "Farmstead",
             "text": "Target land's controller gains 1 life each upkeep if o\nWo\nW is spent. Target land still generates mana as usual.",
             "colours": [
@@ -639,7 +639,7 @@
         },
         {
             "id": "6d6b1c10-5e60-50d4-a630-d69cf327db54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a488ce63-1adb-4051-9521-703bad8d02f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a488ce63-1adb-4051-9521-703bad8d02f6.jpg?1",
             "name": "Green Ward",
             "text": "Target creature gains protection from green.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "ba30b42c-5d5b-5cac-8c27-7eaed2d8f928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4e8259-b369-4b59-85fa-fe9edb1887c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4e8259-b369-4b59-85fa-fe9edb1887c5.jpg?1",
             "name": "Guardian Angel",
             "text": "Prevents X damage from being dealt to any one target. Any further damage to the same target this turn can be canceled by spending 1 mana per point of damage to be canceled.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "3346717e-fea3-5537-9914-e49203aa31e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9f2eeb-fea5-4b33-9723-8be3c1914f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9f2eeb-fea5-4b33-9723-8be3c1914f63.jpg?1",
             "name": "Healing Salve",
             "text": "Gain 3 life, or prevent up to 3 damage from being dealt to a single target.",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "6c7aebfa-8afd-5c76-a487-8d8d636ac09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab1d885-989c-4d71-8139-9e35d2f16d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab1d885-989c-4d71-8139-9e35d2f16d03.jpg?1",
             "name": "Holy Armor",
             "text": "Target creature gains +0/+2. oo\nW Target creature gets extra +0/+1 until end of turn.",
             "colours": [
@@ -767,7 +767,7 @@
         },
         {
             "id": "1c183fe0-f313-591b-907b-3f9eea14c918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de989395-50bf-458a-a010-e12abe2e15a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de989395-50bf-458a-a010-e12abe2e15a6.jpg?1",
             "name": "Holy Strength",
             "text": "Target creature gains +1/+2.",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "e4c7572f-6200-5f07-b05f-5446d29a32c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273fb2b6-3d11-4f0d-9fb0-0364353c2060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273fb2b6-3d11-4f0d-9fb0-0364353c2060.jpg?1",
             "name": "Island Sanctuary",
             "text": "You may decline to draw a card from your library during draw phase. In exchange, until start of your next turn the only creatures that may attack you are those that fly or have islandwalk.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "6b4009cf-6b07-5123-8c0e-3986494a9854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bea2eb6-dfae-4bdc-9ab3-b2b491c69c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bea2eb6-dfae-4bdc-9ab3-b2b491c69c59.jpg?1",
             "name": "Karma",
             "text": "For each swamp in play, Karma does 1 damage to the swamp owner during the swamp owner's upkeep.",
             "colours": [
@@ -862,7 +862,7 @@
         },
         {
             "id": "d0242d2c-cdb3-55cf-b986-9bea14cdc9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aa3a93-3765-49f0-8ff2-b6843509c34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7aa3a93-3765-49f0-8ff2-b6843509c34a.jpg?1",
             "name": "Lance",
             "text": "Target creature gains first strike.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "e4e21757-ebb8-590c-ae6b-f906c9236860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bff46a-6725-4918-9bdf-38efaaf50236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bff46a-6725-4918-9bdf-38efaaf50236.jpg?1",
             "name": "Mesa Pegasus",
             "text": "Flying, bands",
             "colours": [
@@ -928,7 +928,7 @@
         },
         {
             "id": "4210b6bc-31ad-5306-a301-9fc623e7345b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8493c-ae69-48d1-a050-a887ae27c83f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8493c-ae69-48d1-a050-a887ae27c83f.jpg?1",
             "name": "Northern Paladin",
             "text": "o\nWo\nW and tap: Destroys a black card in play. Cannot be used to cancel a black spell as it is being cast.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "3b9ca0fa-c7ed-55f5-8b38-184f75a86930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47024d6d-dc55-4c35-b2bb-1b8bb0ee4e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47024d6d-dc55-4c35-b2bb-1b8bb0ee4e38.jpg?1",
             "name": "Pearled Unicorn",
             "text": "",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "6e34bd86-a170-5b04-9df1-b5c22ac36793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb9f31-0818-4422-8533-99a4e6845a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bb9f31-0818-4422-8533-99a4e6845a02.jpg?1",
             "name": "Personal Incarnation",
             "text": "Caster can redirect any or all damage done to Personal Incarnation to self instead. The source of the damage is unchanged. If Personal Incarnation is destroyed, caster loses half his or her remaining life points, rounding up the loss.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "6e766144-0ae2-5211-a29b-6b6e92e2bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11986e-42bd-4f54-8624-7b34b1783a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af11986e-42bd-4f54-8624-7b34b1783a40.jpg?1",
             "name": "Purelace",
             "text": "Changes the color of one card either being played or already in play to white. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "7c41faad-311d-58c4-9a96-2cc9b068de33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057237bb-e1e6-4bcc-8639-ca0dcdd4846c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/057237bb-e1e6-4bcc-8639-ca0dcdd4846c.jpg?1",
             "name": "Red Ward",
             "text": "Target creature gains protection from red.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "1ccb7ce4-6c34-546f-ace4-2146886be164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e3c741-5095-48a6-bd93-b9c4db265004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e3c741-5095-48a6-bd93-b9c4db265004.jpg?1",
             "name": "Resurrection",
             "text": "Take a creature from your graveyard and put it directly into play. You can't tap it until your next turn.",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "dd12b726-a11a-5225-acb6-595a3f9cb396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cf22e4-cc5c-4723-a9cb-ae7ce7a55a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cf22e4-cc5c-4723-a9cb-ae7ce7a55a1a.jpg?1",
             "name": "Reverse Damage",
             "text": "All damage you have taken from any one source this turn is added to your life total instead of subtracted from it.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "0be4ca6f-2309-5a69-a568-6a33172ca5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b847a2d1-5912-4f88-a68f-06790d0795dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b847a2d1-5912-4f88-a68f-06790d0795dc.jpg?1",
             "name": "Righteousness",
             "text": "Target defending creature gains +7/+7 until end of turn.",
             "colours": [
@@ -1186,7 +1186,7 @@
         },
         {
             "id": "0d022914-c2d6-5c7d-af5f-28a449732666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbfb106-29d8-4065-b306-51dba0ed11a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbfb106-29d8-4065-b306-51dba0ed11a4.jpg?1",
             "name": "Samite Healer",
             "text": "Tap to prevent 1 damage to any target.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "2ccde13d-9f95-5dad-b10d-18ec3eb79b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d1945d-d228-4dc3-a593-859408b2016b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d1945d-d228-4dc3-a593-859408b2016b.jpg?1",
             "name": "Savannah Lions",
             "text": "",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "4bf63972-d46f-52a0-bceb-f7d8be54d6e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5669f9c8-2e94-47e2-a551-7efff317fb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5669f9c8-2e94-47e2-a551-7efff317fb34.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nDoes not tap when attacking.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "5feec087-0137-5171-b1b8-fdc92b3240c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255099be-c64e-4f6a-8463-4fc058d6908d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255099be-c64e-4f6a-8463-4fc058d6908d.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Target creature is removed from game entirely; return to owner's deck only when game is over. Creature's controller gains life points equal to creature's power.",
             "colours": [
@@ -1317,7 +1317,7 @@
         },
         {
             "id": "c11aa0e0-39f4-5288-b131-72ce5f4c4faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d888b7-26e2-465d-b5ee-bb2f2af5c621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8d888b7-26e2-465d-b5ee-bb2f2af5c621.jpg?1",
             "name": "Veteran Bodyguard",
             "text": "Unless Bodyguard is tapped, any damage done to you by unblocked creatures is done instead to Bodyguard. You may not take this damage yourself, though you can prevent it if possible.",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "5b0b3e1b-2c70-5fc4-972b-310563872d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be955e9a-e722-4cd7-8e3d-bab1889c255b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be955e9a-e722-4cd7-8e3d-bab1889c255b.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "416fec99-4c35-5ba2-8569-c2148b2d9a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a231e0b8-b3e3-4f4a-8baa-c56626b01685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a231e0b8-b3e3-4f4a-8baa-c56626b01685.jpg?1",
             "name": "White Knight",
             "text": "Protection from black, first strike",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "6e164f77-a25f-5dab-b978-e83d668568d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988dc3e-2ed8-4de3-9d1b-838003c9c9e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988dc3e-2ed8-4de3-9d1b-838003c9c9e3.jpg?1",
             "name": "White Ward",
             "text": "Target creature gains protection from white.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "618e4b6a-4a53-526d-a15a-fba92942996c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96dd2d61-a43d-4582-b730-71d4fac0fa23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96dd2d61-a43d-4582-b730-71d4fac0fa23.jpg?1",
             "name": "Wrath of God",
             "text": "All creatures in play are destroyed and cannot regenerate.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "4dd53ecf-d055-5ea1-8b55-6a63935ef413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a94a6d-26b1-4486-9444-ec366e6f4d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a94a6d-26b1-4486-9444-ec366e6f4d6e.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "011dd694-86e0-546e-899e-82bd1f5d240c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0a5c2-ac85-448e-9e87-12fc74fd4147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b0a5c2-ac85-448e-9e87-12fc74fd4147.jpg?1",
             "name": "Ancestral Recall",
             "text": "Draw 3 cards or force opponent to draw 3 cards.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "c4712f3b-15dd-500a-87cb-a85c381dd4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb575b27-d2ca-4d90-a650-dc670484f607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb575b27-d2ca-4d90-a650-dc670484f607.jpg?1",
             "name": "Animate Artifact",
             "text": "Target artifact is now a creature with both power and toughness equal to its casting cost; target retains all its original abilities as well. This will destroy artifacts with 0 casting cost.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "37ff98ca-83e4-5fb7-9d65-49cf930e1829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f07e272-6cc7-46d6-ad5c-473d1021c179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f07e272-6cc7-46d6-ad5c-473d1021c179.jpg?1",
             "name": "Blue Elemental Blast",
             "text": "Counters a red spell being cast or destroys a red card in play.",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "c1121a0a-8e38-5dfa-bb54-03adf4cabaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd8dbb-9538-4786-b20c-0ea2f446f323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd8dbb-9538-4786-b20c-0ea2f446f323.jpg?1",
             "name": "Braingeyser",
             "text": "Draw X cards or force opponent to draw X cards.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "417bdd87-f904-5ee0-acdb-8f77d7d3eb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af53b5fc-c31a-4f26-93bf-0c45c1f4e1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af53b5fc-c31a-4f26-93bf-0c45c1f4e1e5.jpg?1",
             "name": "Clone",
             "text": "Upon summoning, Clone acquires all characteristics, including color, of any one creature in play on either side; any creature enchantments on original creature are not copied. Clone retains these characteristics even after original creature is destroyed. Clone cannot be played if there are no creatures in play.",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "14166966-b025-5236-bdc6-09cc2fa0c0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133315bd-3c46-4eff-938e-4dba63631c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133315bd-3c46-4eff-938e-4dba63631c1b.jpg?1",
             "name": "Control Magic",
             "text": "You control target creature until enchantment is discarded or game ends. You can't tap target creature this turn, but if it was already tapped it stays tapped until you can untap it. If destroyed, target creature is put in its owner's graveyard.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "32c0ce62-a95a-5e04-97da-7f669c833518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe07d-1328-4165-b7a0-622b60cec481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe07d-1328-4165-b7a0-622b60cec481.jpg?1",
             "name": "Copy Artifact",
             "text": "Select any artifact in play. This enchantment acts as a duplicate of that artifact; enchantment copy is affected by cards that affect either enchantments or artifacts. Enchantment copy remains even if original artifact is destroyed.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "340bc5b9-5ffb-5236-a465-7ea6a02ec0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11bf7c-f439-4529-b29a-d711359807ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e11bf7c-f439-4529-b29a-d711359807ef.jpg?1",
             "name": "Counterspell",
             "text": "Counters target spell as it is being cast.",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "84228684-4e5c-5292-9163-ef15d1245d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce48b24-a65e-42d9-a147-8f89028fada7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce48b24-a65e-42d9-a147-8f89028fada7.jpg?1",
             "name": "Creature Bond",
             "text": "If target creature is destroyed, Creature Bond does an amount of damage equal to creature's toughness to creature's controller.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "73239221-d7ae-5d9c-980d-69280fdac38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9672caeb-5cf8-4b40-a371-005c911a67d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9672caeb-5cf8-4b40-a371-005c911a67d9.jpg?1",
             "name": "Drain Power",
             "text": "Tap all opponent's land, taking all this mana and all mana in opponent's mana pool into your mana pool. You can't tap fewer than all opponent's lands.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "5e96ae27-f64d-57e6-8c08-ff345e15f520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644288e8-e0b1-418f-b105-01a557a3e497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644288e8-e0b1-418f-b105-01a557a3e497.jpg?1",
             "name": "Feedback",
             "text": "Feedback does 1 damage to controller of target enchantment during each upkeep.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "55115de5-31da-51e6-9cb0-096f652962c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24584ffa-8ed1-4930-b6d8-ac1d02738ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24584ffa-8ed1-4930-b6d8-ac1d02738ed0.jpg?1",
             "name": "Flight",
             "text": "Target creature is now a flying creature.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "40bc65b6-360d-5632-a207-96be666df237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde97b8f-7c10-48d3-8ae2-9f86158973ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde97b8f-7c10-48d3-8ae2-9f86158973ec.jpg?1",
             "name": "Invisibility",
             "text": "Target creature can be blocked only by walls.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "b3e13894-c6a6-5a7f-b389-3f802c8b02eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e8a6e-1da8-4e6f-8433-9f0695926f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e8a6e-1da8-4e6f-8433-9f0695926f04.jpg?1",
             "name": "Jump",
             "text": "Target creature is a flying creature until end of turn.",
             "colours": [
@@ -1962,7 +1962,7 @@
         },
         {
             "id": "9cb644ca-753a-5930-b5be-fcc999565a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e7775b-b03b-4fc0-bcd9-3681cce5e70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e7775b-b03b-4fc0-bcd9-3681cce5e70c.jpg?1",
             "name": "Lifetap",
             "text": "You gain 1 life each time any forest of opponent's becomes tapped.",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "0bb43e99-c884-51a9-ad92-e6a88b5f535e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7ac1f-2243-4c70-95a4-2b7343c8d92d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d7ac1f-2243-4c70-95a4-2b7343c8d92d.jpg?1",
             "name": "Lord of Atlantis",
             "text": "All Merfolk in play gain islandwalk and +1/+1 while this card is in play.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "0658b6cc-a7cf-5b86-812b-12cf8be75523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa81390-4e0b-484b-a5be-a9449cd41860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa81390-4e0b-484b-a5be-a9449cd41860.jpg?1",
             "name": "Magical Hack",
             "text": "Change the text of any card being played or already in play by replacing one basic land type with another. For example, you can change \"swampwalk\" to \"plainswalk.\"",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "98796ed3-1de9-505f-a828-bc24e5369ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f76c8-3e6d-4de5-b408-2f2394faed5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f76c8-3e6d-4de5-b408-2f2394faed5c.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "3de9176c-6993-5433-85c6-fb47338c257d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da4f9a8-024b-4707-b300-ccb11bd87cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da4f9a8-024b-4707-b300-ccb11bd87cea.jpg?1",
             "name": "Mana Short",
             "text": "All opponent's lands are tapped, and opponent's mana pool is emptied. Opponent takes no damage from unspent mana.",
             "colours": [
@@ -2121,7 +2121,7 @@
         },
         {
             "id": "68b0f289-a393-55fa-8ad6-7c4960770c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca142de-906d-4143-8f77-4acea1f1e6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca142de-906d-4143-8f77-4acea1f1e6b1.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "71c27857-2164-561f-b3e9-a094c1f241a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c6d792-0abb-474e-8c05-c4e843242ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c6d792-0abb-474e-8c05-c4e843242ef0.jpg?1",
             "name": "Phantasmal Forces",
             "text": "Flying\nController must spend o\nU during upkeep to maintain or Phantasmal Forces are destroyed.",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "cbc64fd6-1cfd-54db-b015-d6f39aa1ba0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29369c-d909-45a7-be70-3181ddac9728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29369c-d909-45a7-be70-3181ddac9728.jpg?1",
             "name": "Phantasmal Terrain",
             "text": "Target land changes to any basic land type of caster's choice. Land type is set when cast and may not be further altered by this enchantment.",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "a6b9842f-2bf4-5d4b-a79b-e1b10bcd4d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782e90-383b-4aed-8fa0-99c8cf8b2cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782e90-383b-4aed-8fa0-99c8cf8b2cec.jpg?1",
             "name": "Phantom Monster",
             "text": "Flying",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "82f31f30-7aaf-5c77-aa6e-8396356ffccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925ce0a7-ae09-4220-9e67-314dbc231c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925ce0a7-ae09-4220-9e67-314dbc231c94.jpg?1",
             "name": "Pirate Ship",
             "text": "Tap to do 1 damage to any target. Cannot attack unless opponent has islands in play, though controller may still tap. Pirate Ship is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "532a4d32-82e8-50d2-ac5e-aab53d65aef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fdfb7b-1bcf-485a-be70-0130fc1fceef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fdfb7b-1bcf-485a-be70-0130fc1fceef.jpg?1",
             "name": "Power Leak",
             "text": "Target enchantment costs 2 extra mana during upkeep. If target enchantment's controller cannot or will not pay this extra mana, Power Leak does 1 damage to him or her for each unpaid mana.",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "821f788d-7dfb-51d4-939d-b8ccfb5b334e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954b04e3-861a-45c9-8897-9cb4a99f04c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954b04e3-861a-45c9-8897-9cb4a99f04c3.jpg?1",
             "name": "Power Sink",
             "text": "Target spell is countered unless its caster spends X more mana; caster of target spell can't choose to let it be countered. If caster of target spell doesn't have enough mana, all available mana from lands and mana pool must be paid but target spell will still be countered.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "eb3ddb8d-1515-5b2a-872b-9d0fe3d49f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c420abf2-05ec-4623-8a6c-353736a4edeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c420abf2-05ec-4623-8a6c-353736a4edeb.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "Tap to do 1 damage to any target.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "09982730-2223-52e0-a77e-2a575e5ef09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6b789-00c5-4d72-8fb3-6808bfbf0144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6b789-00c5-4d72-8fb3-6808bfbf0144.jpg?1",
             "name": "Psionic Blast",
             "text": "Psionic Blast does 4 damage to any target, but it does 2 damage to you as well.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "d24f81af-db8c-55a5-97bb-0f10f6dc2aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c8a81f-bf05-4504-ac87-4fd4b41e88c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c8a81f-bf05-4504-ac87-4fd4b41e88c1.jpg?1",
             "name": "Psychic Venom",
             "text": "Whenever target land is tapped, Psychic Venom does 2 damage to target land's controller.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "b3d9d798-a994-5dcb-8eca-af04f9f751bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b21f91-51fd-407d-bab2-63c11f23b680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b21f91-51fd-407d-bab2-63c11f23b680.jpg?1",
             "name": "Sea Serpent",
             "text": "Serpent cannot attack unless opponent has islands in play. Serpent is destroyed immediately if at any time controller has no islands in play.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "5832570f-33b6-5b47-9216-4344552542b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ce03f3-ddc0-4cf3-8f07-551c960e8639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ce03f3-ddc0-4cf3-8f07-551c960e8639.jpg?1",
             "name": "Siren's Call",
             "text": "All of opponent's creatures that can attack must do so. Any non-wall creatures that cannot attack are destroyed at end of turn. Play only during opponent's turn, before opponent's attack. Creatures summoned this turn are unaffected by Siren's Call.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "836b6e7f-e3cc-50e0-a0a0-440cfbdfc867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4da609-6c08-4a18-b7d9-fb2f9b11bab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4da609-6c08-4a18-b7d9-fb2f9b11bab2.jpg?1",
             "name": "Sleight of Mind",
             "text": "Change the text of any card being played or already in play by replacing one color word with another. For example, you can change \"Counters red spells\" to \"Counters black spells.\" Cannot change mana symbols.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "936cf5f7-9efb-5117-b6bd-41c8516841fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f599b73-1d55-4acc-8931-f5ab39d1d4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f599b73-1d55-4acc-8931-f5ab39d1d4e9.jpg?1",
             "name": "Spell Blast",
             "text": "Target spell is countered; X is cost of target spell.",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "9883d8ae-f767-5351-867e-f5fad2a1bb44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c76f5d-d866-4eb7-b2d2-fc6ecf982f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c76f5d-d866-4eb7-b2d2-fc6ecf982f8e.jpg?1",
             "name": "Stasis",
             "text": "Players do not get an untap phase. Pay o\nU during your upkeep or Stasis is destroyed.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "a05efb90-b8a2-52fe-ac44-70af1c6c8bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c14d4d-abaa-411a-aaa1-0b79fccee8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c14d4d-abaa-411a-aaa1-0b79fccee8c1.jpg?1",
             "name": "Steal Artifact",
             "text": "You control target artifact until enchantment is discarded or game ends. If target artifact was tapped when stolen, it stays tapped until you can untap it. If destroyed, target artifact is put in its owner's graveyard.",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "d70950cf-aa35-5d84-be25-b16d50103d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2b2b9e-5abf-4c41-a85c-ef95e6ab84d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2b2b9e-5abf-4c41-a85c-ef95e6ab84d6.jpg?1",
             "name": "Thoughtlace",
             "text": "Changes the color of one card either being played or already in play to blue. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "6cd228a2-686c-5324-9421-a55c3c221043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54992fda-45a9-4ed1-b380-34d167feec90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54992fda-45a9-4ed1-b380-34d167feec90.jpg?1",
             "name": "Time Walk",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "4a94a818-169e-56d0-8940-11ba01014a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f1958a-50cc-43cc-80e1-988800e44ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09f1958a-50cc-43cc-80e1-988800e44ca8.jpg?1",
             "name": "Timetwister",
             "text": "Set Timetwister aside in a new graveyard pile. Shuffle your hand, library, and graveyard together into a new library and draw a new hand of seven cards, leaving all cards in play where they are; opponent must do the same.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "6fc5dc32-20c9-5f71-b862-1bbb0ed42c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bd24da-f156-494e-86cb-80707863e40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bd24da-f156-494e-86cb-80707863e40b.jpg?1",
             "name": "Twiddle",
             "text": "Caster may tap or untap any one land, creature, or artifact in play. No effects are generated by the target card.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "9aaab08d-800f-5fb4-ae78-7866aeb0c3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686843c8-8c8a-4af6-bca8-e7f7583cc886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686843c8-8c8a-4af6-bca8-e7f7583cc886.jpg?1",
             "name": "Unsummon",
             "text": "Return creature to owner's hand; enchantments on creature are discarded. Unsummon cannot be played during the damage-dealing phase of an attack.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "6edf91de-2571-50ac-8946-505f88eed659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18e952b-ab4d-4f90-bf5e-4db490e4e203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18e952b-ab4d-4f90-bf5e-4db490e4e203.jpg?1",
             "name": "Vesuvan Doppelganger",
             "text": "Upon summoning, Doppelganger acquires all normal characteristics (except color) of any one creature in play on either side; any enchantments on the original creature are not copied. During controller's upkeep, Doppelganger may take on the characteristics of a different creature in play instead. Doppleganger may continue to copy a creature even after that creature leaves play, but if it switches it won't be able to switch back.",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "2b3b9d93-8b06-51b9-91c8-8f6316016d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca669988-e009-4b3e-af20-ee5885554d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca669988-e009-4b3e-af20-ee5885554d34.jpg?1",
             "name": "Volcanic Eruption",
             "text": "Destroys X mountains of your choice, and does X damage to each player and each creature in play.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "82e05b90-0eb7-5398-af57-8975b5337744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71904b59-55dd-4074-9d50-c5bb0fb7266f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71904b59-55dd-4074-9d50-c5bb0fb7266f.jpg?1",
             "name": "Wall of Air",
             "text": "Flying",
             "colours": [
@@ -2891,7 +2891,7 @@
         },
         {
             "id": "7e3bd38f-08f2-54f3-a4f7-3f221e3ddc2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34887689-0adb-4ead-87a5-1d8fd77b6278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34887689-0adb-4ead-87a5-1d8fd77b6278.jpg?1",
             "name": "Wall of Water",
             "text": "oo\nU +1/+0 until end of turn.",
             "colours": [
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "06e764b8-0450-5614-951d-21b0e594d8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f729e2-565b-4cdb-8b6f-0a14babe5680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f729e2-565b-4cdb-8b6f-0a14babe5680.jpg?1",
             "name": "Water Elemental",
             "text": "",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "94c91084-5d0b-5fee-afd6-405cefc05270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5059a-60a4-4135-863f-85a48bff8731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5059a-60a4-4135-863f-85a48bff8731.jpg?1",
             "name": "Animate Dead",
             "text": "Any creature in either player's graveyard comes into play on your side with -1 to its original power. If this enchantment is removed, or at end of game, target creature is returned to its owner's graveyard. Target creature may be killed as normal.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "04191054-a64f-557a-b230-075f74e6f57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf812f48-633c-46ab-b0c3-4819ab1b4e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf812f48-633c-46ab-b0c3-4819ab1b4e49.jpg?1",
             "name": "Bad Moon",
             "text": "All black creatures in play gain +1/+1.",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "72c9016c-10c3-5ecc-90c3-61f260c7f1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eced352-d49c-4e91-a368-52904d77a69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eced352-d49c-4e91-a368-52904d77a69d.jpg?1",
             "name": "Black Knight",
             "text": "Protection from white, first strike",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "5ef7ecba-a8ed-57ed-a00d-8439be31f09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da26289f-e0e6-4aae-8782-ebdbabf39819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da26289f-e0e6-4aae-8782-ebdbabf39819.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "bffdcbd9-13a2-5dcb-a74c-e32ec6c363cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f96e43-aebd-4de2-969a-37cd1d62f127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f96e43-aebd-4de2-969a-37cd1d62f127.jpg?1",
             "name": "Contract from Below",
             "text": "Discard your current hand and draw eight new cards, adding the first drawn to your ante. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "7bbbcfc3-0f78-5708-b13e-a3010f11b9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eea8122-00c2-4d00-b87b-12eea86b16ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eea8122-00c2-4d00-b87b-12eea86b16ba.jpg?1",
             "name": "Cursed Land",
             "text": "Cursed Land does 1 damage to target land's controller during each upkeep.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "bd31334e-07d3-5099-bd5e-f53ee99916a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0690f724-eb95-416b-b064-f1239e2a30e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0690f724-eb95-416b-b064-f1239e2a30e8.jpg?1",
             "name": "Dark Ritual",
             "text": "Add 3 black mana to your mana pool.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "8a4f09ad-0398-50ba-9bab-55a5bb43f154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b12bcb-a935-48be-a5e8-abbb890e91ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b12bcb-a935-48be-a5e8-abbb890e91ca.jpg?1",
             "name": "Darkpact",
             "text": "Without looking at it first, swap top card of your library with either card of the ante; this swap is permanent. You must have a card in your library to cast this spell. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "4a867653-e892-54fa-ad6e-99be07c94884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c942a9af-e449-4f10-916c-6eb9e944de6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c942a9af-e449-4f10-916c-6eb9e944de6a.jpg?1",
             "name": "Deathgrip",
             "text": "o\nBoo\nB Destroy a green spell as it is being cast. This action may be played as an interrupt, and does not affect green cards already in play.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "c6613047-d05f-505f-9f0a-a010e599d143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16fc59a-17da-462a-86ea-31f8a9ac18a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16fc59a-17da-462a-86ea-31f8a9ac18a1.jpg?1",
             "name": "Deathlace",
             "text": "Changes the color of one card either being played or already in play to black. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "da94f103-f91b-5a01-aff0-79f317c5a33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f37eac-e8fa-48d3-b936-74461ea1853c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f37eac-e8fa-48d3-b936-74461ea1853c.jpg?1",
             "name": "Demonic Attorney",
             "text": "If opponent doesn't concede the game immediately, each player must ante an additional card from the top of his or her library. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "24d8da49-81e3-5c2e-80e3-69308954d51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20c19b-7216-4f23-a3bb-70d4dcd3865e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20c19b-7216-4f23-a3bb-70d4dcd3865e.jpg?1",
             "name": "Demonic Hordes",
             "text": "Tap to destroy 1 land. Pay o\nBo\nBo\nB during upkeep or the Hordes become tapped and you lose a land of opponent's choice.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "657d58ca-104f-57a6-9440-88b11a3e2419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e571ef-1645-4584-ab53-e7ea5d443dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e571ef-1645-4584-ab53-e7ea5d443dea.jpg?1",
             "name": "Demonic Tutor",
             "text": "You may search your library for one card and take it into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -3371,7 +3371,7 @@
         },
         {
             "id": "4aa601c3-0972-5d50-9f47-6690202363b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbc6761-c4fc-4b4c-afb5-94ad4d21bc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbc6761-c4fc-4b4c-afb5-94ad4d21bc05.jpg?1",
             "name": "Drain Life",
             "text": "Drain Life does 1 damage to a single target for each o\nB spent in addition to the casting cost. Caster gains 1 life for each damage inflicted. If you drain life from a creature, you cannot gain more life than the creature's toughness.",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "68f29fed-7dcb-5940-8524-85acc67d2f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f3a1b9-d192-49d9-87bb-ca50e99edbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f3a1b9-d192-49d9-87bb-ca50e99edbd1.jpg?1",
             "name": "Drudge Skeletons",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -3435,7 +3435,7 @@
         },
         {
             "id": "23f18bd6-0e44-5155-8636-6583fc102d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e995f4b-efd3-4ac7-8fec-adb913294815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e995f4b-efd3-4ac7-8fec-adb913294815.jpg?1",
             "name": "Evil Presence",
             "text": "Target land is now a swamp.",
             "colours": [
@@ -3468,7 +3468,7 @@
         },
         {
             "id": "b27c4779-a0d6-5903-b100-c473ddb6a4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67830531-970a-4339-8673-40954376455d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67830531-970a-4339-8673-40954376455d.jpg?1",
             "name": "Fear",
             "text": "Target creature cannot be blocked by any creatures other than artifact creatures and black creatures.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "82c50a36-5a71-59c5-afe8-23f6fe391466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b6a352-40f5-4d7c-b2b6-2617539a1c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b6a352-40f5-4d7c-b2b6-2617539a1c1c.jpg?1",
             "name": "Frozen Shade",
             "text": "oo\nB +1/+1",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "5b9e0158-f6a0-5f29-adb2-766112ae5655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640770d9-c0f8-40fd-9467-ebc099a27a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640770d9-c0f8-40fd-9467-ebc099a27a4b.jpg?1",
             "name": "Gloom",
             "text": "White spells cost 3 more mana to cast. Circles of Protection cost 3 more mana to use.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "1b9aa14e-20b4-5da5-8eaf-c70ed696224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018459-d09b-489a-81be-933fd7d854c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018459-d09b-489a-81be-933fd7d854c1.jpg?1",
             "name": "Howl from Beyond",
             "text": "Target creature gains +X/+0 until end of turn.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "77612523-a819-5015-9815-87f1e393e29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc56a0-1dc0-4261-8f9c-5a88ce83f9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcc56a0-1dc0-4261-8f9c-5a88ce83f9e9.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nAn opponent damaged by Specter must discard a card at random from his or her hand. Ignore this effect if opponent has no cards left in hand.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "9dc18ee0-d355-55b4-a8bf-1d9731435e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a9c089-0aad-4c14-9bfc-c0b39c976777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a9c089-0aad-4c14-9bfc-c0b39c976777.jpg?1",
             "name": "Lich",
             "text": "You lose all life. If you gain life later in the game, instead draw one card from your library for each life. For each point of damage you suffer, you must destroy one of your cards in play. Creatures destroyed in this way cannot be regenerated. You lose if this enchantment is destroyed or if you suffer a point of damage without sending a card to the graveyard.",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "9a47152b-49a6-547e-bc64-98682de6915d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24626988-81df-44c9-9a8e-ecb9f82c383b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24626988-81df-44c9-9a8e-ecb9f82c383b.jpg?1",
             "name": "Lord of the Pit",
             "text": "Flying, trample\nYou must sacrifice one of your own creatures during upkeep or Lord of the Pit does 7 damage to you. You may still attack with Lord of the Pit even if you failed to sacrifice a creature.",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "a50d26a8-53de-58e2-827d-2b74fdfcd6ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb6cbbe-c3e9-4d14-a6b8-fb74e6a02b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb6cbbe-c3e9-4d14-a6b8-fb74e6a02b33.jpg?1",
             "name": "Mind Twist",
             "text": "Opponent must discard X cards at random from hand. If opponent doesn't have enough cards in hand, entire hand is discarded.",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "b9a79dc0-f694-5db4-bc42-b1a0ff2c678b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38396ae3-a48f-44c7-96bf-ea41b5aaeebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38396ae3-a48f-44c7-96bf-ea41b5aaeebc.jpg?1",
             "name": "Nether Shadow",
             "text": "If Shadow is in graveyard with any combination of cards above it that includes at least three creatures, it can be returned to play during upkeep for its normal casting cost. Shadow can attack on same turn summoned or returned to play.",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "20136dc6-ff36-5134-9235-d91f1b9f92c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576220c3-1e6b-43f3-a47e-5e8246ee7d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576220c3-1e6b-43f3-a47e-5e8246ee7d46.jpg?1",
             "name": "Nettling Imp",
             "text": "Tap to force a particular one of opponent's non-wall creatures to attack. If target creature cannot attack, it is destroyed at end of turn. This tap should be played during opponent's turn, before the attack. May not be used on creatures summoned this turn.",
             "colours": [
@@ -3790,7 +3790,7 @@
         },
         {
             "id": "72560582-e0a0-5d83-b6fc-e6889075c88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc78dced-27d2-441a-b63b-32356bc33747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc78dced-27d2-441a-b63b-32356bc33747.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness both equal the number of swamps its controller has in play.",
             "colours": [
@@ -3824,7 +3824,7 @@
         },
         {
             "id": "3ba38f1b-03df-5c0d-b559-a1d62f60c593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106d8401-f0e2-461e-b8ea-16d475db98da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106d8401-f0e2-461e-b8ea-16d475db98da.jpg?1",
             "name": "Paralyze",
             "text": "Target creature is not untapped as normal during untap phase unless 4 mana are spent. Tap target creature when Paralyze is cast.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "7e447cde-ff9c-5d23-b992-99d3ae3ee13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1313b7e6-4acb-435a-bde5-1def5e5350ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1313b7e6-4acb-435a-bde5-1def5e5350ac.jpg?1",
             "name": "Pestilence",
             "text": "o\nB: Do 1 damage to each creature and to both players. Pestilence must be discarded at end of any turn in which there are no creatures in play at end of turn.",
             "colours": [
@@ -3888,7 +3888,7 @@
         },
         {
             "id": "b494440f-d68f-50c9-9d16-e2e8ed89a46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995b58e6-5c69-4fdf-9c41-61cef7a610c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995b58e6-5c69-4fdf-9c41-61cef7a610c4.jpg?1",
             "name": "Plague Rats",
             "text": "The Xs below are the number of Plague Rats in play, counting both sides. Thus if there are 2 Plague Rats in play, each has power and toughness 2/2.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "2ea11ca6-a92d-5b15-b457-4ccee5f29885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0066c7a6-7775-43ba-81cd-35fbc5621bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0066c7a6-7775-43ba-81cd-35fbc5621bc3.jpg?1",
             "name": "Raise Dead",
             "text": "Return creature from your graveyard to your hand.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "e753af51-d3a9-5a4d-99f6-87a72ad0f89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e33c5e-6d99-4e7e-b611-4b271a47b4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e33c5e-6d99-4e7e-b611-4b271a47b4d2.jpg?1",
             "name": "Royal Assassin",
             "text": "Tap to destroy any tapped creature.",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "69a4e235-58df-5d6c-8f58-9c8fb31326d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abe7d62-6a99-4d1f-9b81-cff0485997a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abe7d62-6a99-4d1f-9b81-cff0485997a8.jpg?1",
             "name": "Sacrifice",
             "text": "Destroy one of your creatures without regenerating it, and add to your mana pool a number of black mana equal to creature's casting cost.",
             "colours": [
@@ -4017,7 +4017,7 @@
         },
         {
             "id": "0547b280-42e2-5696-972a-b57e5ade4c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30abb09-2f80-46cf-a839-b4dac5c23dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30abb09-2f80-46cf-a839-b4dac5c23dce.jpg?1",
             "name": "Scathe Zombies",
             "text": "",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "e7408228-9282-5bec-8328-724136d99e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bfa6bb-cf7b-4a79-83f5-178a633c499e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2bfa6bb-cf7b-4a79-83f5-178a633c499e.jpg?1",
             "name": "Scavenging Ghoul",
             "text": "At the end of each turn, put one counter on the Ghoul for each other creature that was destroyed without regenerating during the turn. If Ghoul dies, you may use a counter to regenerate it; counters remain until used.",
             "colours": [
@@ -4083,7 +4083,7 @@
         },
         {
             "id": "041eb3ba-68f0-51aa-b8dc-b8dcfcc75e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd5fbb-f689-4ff0-8f23-17e4cb0925a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbd5fbb-f689-4ff0-8f23-17e4cb0925a2.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nVampire gets a +1/+1 counter each time a creature dies during a turn in which Vampire damaged it, unless the dead creature is regenerated.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "101b4586-bdf9-5be6-85b9-d624d1a4625e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcda143-55f8-4d02-918f-975d9090d03f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcda143-55f8-4d02-918f-975d9090d03f.jpg?1",
             "name": "Simulacrum",
             "text": "All damage done to you so far this turn is instead retroactively applied to one of your creatures in play. If this damage kills the creature it can be regenerated; even if there's more than enough damage to kill the creature, you don't suffer any of it. Further damage this turn is treated normally.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "d066587f-d805-56e3-bc26-402f1c3b1bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea4387-f23c-430c-99d6-0248a4ab1713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea4387-f23c-430c-99d6-0248a4ab1713.jpg?1",
             "name": "Sinkhole",
             "text": "Destroys any one land.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "ce417f3f-8953-54f6-8f51-3b7e1e2ecebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8598b-35e5-414f-aee0-52137236f642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8598b-35e5-414f-aee0-52137236f642.jpg?1",
             "name": "Terror",
             "text": "Destroys target creature without possibility of regeneration. Does not affect black creatures and artifact creatures.",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "134fb7c3-b25c-58a6-92a9-121cc3ee9edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1c781d-1f27-40e3-9d79-0ebb6677e835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1c781d-1f27-40e3-9d79-0ebb6677e835.jpg?1",
             "name": "Unholy Strength",
             "text": "Target creature gains +2/+1.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "fb261176-27fd-5f1b-852d-2ad02835e2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7930666c-12ac-420b-8ced-0e924925b075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7930666c-12ac-420b-8ced-0e924925b075.jpg?1",
             "name": "Wall of Bone",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "c44f8b2c-6c6d-5a4a-96e6-3a8cc5f93ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a289787-2d30-4e0b-ac97-3767818d0387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a289787-2d30-4e0b-ac97-3767818d0387.jpg?1",
             "name": "Warp Artifact",
             "text": "Warp Artifact does 1 damage to target artifact's controller at start of each turn.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "f190c81f-b708-52c1-924f-957e59fc8136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16137fa6-1b5c-49e7-ad79-dda4b7019a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16137fa6-1b5c-49e7-ad79-dda4b7019a59.jpg?1",
             "name": "Weakness",
             "text": "Target creature loses -2/-1; if this drops the creature's toughness below 1, it is dead.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "27093f7d-ffb0-5844-a277-56139be49ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b60630c-f97c-43be-8410-53a68613b735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b60630c-f97c-43be-8410-53a68613b735.jpg?1",
             "name": "Will-o'-the-Wisp",
             "text": "Flying; oo\nB Regenerates",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "e5e250c7-3ccb-5e36-8beb-059535d6ae72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d37b529-8a41-4177-abef-614f363e69d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d37b529-8a41-4177-abef-614f363e69d1.jpg?1",
             "name": "Word of Command",
             "text": "You may look at opponent's hand and choose any card opponent can legally play using mana from his or her mana pool or lands. Opponent must play this card immediately; you make all the decisions it calls for. This spell may not be countered after you have looked at opponent's hand.",
             "colours": [
@@ -4406,7 +4406,7 @@
         },
         {
             "id": "1ed0d05d-3536-5a47-914e-42eea5baebc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bfda92-b932-46d8-b549-e2bc2b584a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bfda92-b932-46d8-b549-e2bc2b584a17.jpg?1",
             "name": "Zombie Master",
             "text": "All zombies in play gain swampwalk and \"oo\nB Regenerates\" for as long as this card remains in play.",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "84c96da8-aa05-5684-88fc-dce6b495d698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8795bab7-ced2-4a1d-8c57-636bc4c0a977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8795bab7-ced2-4a1d-8c57-636bc4c0a977.jpg?1",
             "name": "Burrowing",
             "text": "Target creature gains mountainwalk.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "db5c89a5-8c83-5f7b-aaea-f8e7c805631f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d980e9c0-db88-41f9-8dbf-89f0e1ac6c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d980e9c0-db88-41f9-8dbf-89f0e1ac6c20.jpg?1",
             "name": "Chaoslace",
             "text": "Changes the color of one card either being played or already in play to red. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "e3d68ddd-942a-56dd-8c44-49fd832d2b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb3a6b9-a119-49c0-9baf-b552fdd00b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb3a6b9-a119-49c0-9baf-b552fdd00b28.jpg?1",
             "name": "Disintegrate",
             "text": "Disintegrate does X damage to one target. If target dies this turn, it is removed from game entirely and cannot be regenerated. Return target to its owner's deck only when game is over.",
             "colours": [
@@ -4534,7 +4534,7 @@
         },
         {
             "id": "7ea698e4-9bd9-59a9-a759-8c4ac8bcb07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e009adf-aded-4d64-ba3e-ddc3448c967a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e009adf-aded-4d64-ba3e-ddc3448c967a.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\noo\nR +1/+0 until end of turn; if more than o\nRo\nRo\nR is spent in this way, Dragon Whelp is destroyed at end of turn.",
             "colours": [
@@ -4567,7 +4567,7 @@
         },
         {
             "id": "6f3c2477-2f04-5981-9258-1932b8391be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e552dfb6-b8a5-419d-b098-5aedc0500684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e552dfb6-b8a5-419d-b098-5aedc0500684.jpg?1",
             "name": "Dwarven Demolition Team",
             "text": "Tap to destroy a wall.",
             "colours": [
@@ -4600,7 +4600,7 @@
         },
         {
             "id": "f4af3479-b54d-5f48-b414-29f74721b4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de88cf-b9e5-4611-a16f-2787d8d9d269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0de88cf-b9e5-4611-a16f-2787d8d9d269.jpg?1",
             "name": "Dwarven Warriors",
             "text": "Tap to make a creature of power no greater than 2 unblockable until end of turn. Other cards may later be used to increase target creature's power beyond 2 after defense is chosen.",
             "colours": [
@@ -4634,7 +4634,7 @@
         },
         {
             "id": "46b8fb31-5370-523f-9168-d9aa6d777689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427e8cc-d908-4b88-931d-a540fc8bfe74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427e8cc-d908-4b88-931d-a540fc8bfe74.jpg?1",
             "name": "Earth Elemental",
             "text": "",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "90240413-36d5-5dfd-a76f-61c9861d3184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5955a9d-8a0e-4e57-9433-ed3392b2f308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5955a9d-8a0e-4e57-9433-ed3392b2f308.jpg?1",
             "name": "Earthbind",
             "text": "Earthbind does 2 damage to target flying creature, which also loses flying ability.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "fa320e2a-f1bc-58ff-8a2a-762140d6d347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86435875-ac92-4348-b41e-19570cf62a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86435875-ac92-4348-b41e-19570cf62a1c.jpg?1",
             "name": "Earthquake",
             "text": "Does X damage to each player and each non-flying creature in play.",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "d5e33baf-ad85-5f3b-ad69-d225ea04cacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ebc485-f1b7-436d-8c90-9acf2f7d92e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ebc485-f1b7-436d-8c90-9acf2f7d92e5.jpg?1",
             "name": "False Orders",
             "text": "You decide whether and how one defending creature blocks, though you can't make a choice the defender couldn't legally make. Play after defender has chosen defense but before damage is dealt.",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "56f8c120-24ab-5461-909b-cf43308c8061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376cb9e5-89fb-4091-8a20-140bb6de0ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376cb9e5-89fb-4091-8a20-140bb6de0ef6.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4795,7 +4795,7 @@
         },
         {
             "id": "c2751942-7426-5dd5-ae0a-90c8da1265bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285ab2e-836e-45b0-894e-574f733cf3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a285ab2e-836e-45b0-894e-574f733cf3db.jpg?1",
             "name": "Fireball",
             "text": "Fireball does X damage total, divided evenly (round down) among any number of targets. Pay 1 extra mana for each target beyond the first.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "30171700-f418-5af5-b63b-f9ea0c41b46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e4321-0216-4d6a-a57b-72ebff427b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e4321-0216-4d6a-a57b-72ebff427b09.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR +1/+0",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "66acebdc-6fdc-51f5-880c-5bd79e3c015c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2a91b9-c45f-4e3d-b3c4-944493bdd86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2a91b9-c45f-4e3d-b3c4-944493bdd86a.jpg?1",
             "name": "Flashfires",
             "text": "All plains in play are destroyed.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "d8df45dc-4f88-5dee-88c7-7dfa8430fbac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8144418b-e3e5-459f-8db2-f2e348fba4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8144418b-e3e5-459f-8db2-f2e348fba4da.jpg?1",
             "name": "Fork",
             "text": "Any sorcery or instant spell just cast is doubled. Treat Fork as an exact copy of target spell except that Fork remains red. Copy and original may have different targets.",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "988813af-944c-5355-a740-2a189a8a2202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdb52dd-4fc5-4594-b53b-ea169325be0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdb52dd-4fc5-4594-b53b-ea169325be0b.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "oo\nR Goblins gain flying ability until end of turn. Controller may not choose to make Goblins fly after they have been blocked.",
             "colours": [
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "2af24f79-08c5-54bc-a7de-03a19669bc00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65705a8d-6bb1-4289-b8b0-8546ccc478dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65705a8d-6bb1-4289-b8b0-8546ccc478dc.jpg?1",
             "name": "Goblin King",
             "text": "Goblins in play gain mountainwalk and +1/+1 while this card remains in play.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "4a010564-94bc-56d5-9fbf-afb4d0c9cf66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affb57f4-273a-425c-a1b3-d0a5407f43d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affb57f4-273a-425c-a1b3-d0a5407f43d5.jpg?1",
             "name": "Granite Gargoyle",
             "text": "Flying; oo\nR +0/+1 until end of turn.",
             "colours": [
@@ -5021,7 +5021,7 @@
         },
         {
             "id": "c7e1ada3-0b96-519c-b42d-135b60e11666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41023495-d3cb-4cb0-b95c-f717480a76a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41023495-d3cb-4cb0-b95c-f717480a76a5.jpg?1",
             "name": "Gray Ogre",
             "text": "",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "0113d0ae-30c1-5f04-a61d-64351dce2bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4905e98f-0c5a-4ec7-b85b-dc2c3549d5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4905e98f-0c5a-4ec7-b85b-dc2c3549d5d0.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "91b461e3-6506-502b-9adb-62ed21b633af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29573-99a1-42fc-8941-2466cda2465f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef29573-99a1-42fc-8941-2466cda2465f.jpg?1",
             "name": "Hurloon Minotaur",
             "text": "",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "9cef3df3-b846-52e6-858d-49a8fb3d7d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7be8a25-a744-426e-8e66-7fdff2789af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7be8a25-a744-426e-8e66-7fdff2789af4.jpg?1",
             "name": "Ironclaw Orcs",
             "text": "Cannot be used to block any creature of power more than 1.",
             "colours": [
@@ -5153,7 +5153,7 @@
         },
         {
             "id": "dcb9af0f-6963-5267-a494-2fe6a1253e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07deb9b-5b88-4658-8ae8-041568992019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07deb9b-5b88-4658-8ae8-041568992019.jpg?1",
             "name": "Keldon Warlord",
             "text": "The Xs below are the number of non-wall creatures on your side, including Warlord. Thus if you have 2 other non-wall creatures, Warlord is 3/3. If one of those creatures is killed during the turn, Warlord immediately becomes 2/2.",
             "colours": [
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "50654227-37ac-56b0-a2fb-a1a804dc9133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d3dcab-2260-479d-9ef6-dfb92d4f6061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d3dcab-2260-479d-9ef6-dfb92d4f6061.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt does 3 damage to one target.",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "ee38dc46-ba64-5ef0-885b-2394ea1b725f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44d3087-ced3-40e8-a63b-1733b7e7f34c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44d3087-ced3-40e8-a63b-1733b7e7f34c.jpg?1",
             "name": "Mana Flare",
             "text": "Whenever either player taps land for mana, each land produces 1 extra mana of the appropriate type.",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "a06b241a-00b1-565b-b841-635068536411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c01cae0-4d61-4bf7-a145-82d9bb11d816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c01cae0-4d61-4bf7-a145-82d9bb11d816.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever any land is tapped, Manabarbs does 1 damage to the land's controller.",
             "colours": [
@@ -5280,7 +5280,7 @@
         },
         {
             "id": "c2bcbd45-b335-51d3-a920-d587d0afb6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf039d-0ab9-4c42-a0a3-cbfa3ea1dd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf039d-0ab9-4c42-a0a3-cbfa3ea1dd6e.jpg?1",
             "name": "Mons's Goblin Raiders",
             "text": "",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "4d771d7e-547f-580b-a76a-fcbfc0a97930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2354ee-2ce0-4adb-b48c-0e30b952e545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2354ee-2ce0-4adb-b48c-0e30b952e545.jpg?1",
             "name": "Orcish Artillery",
             "text": "Tap to do 2 damage to any target, but you suffer 3 damage as well.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "fcced834-775f-50c1-81e5-7b3cfcbc91cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2752cf2-9a48-49a8-98ff-2e32a9121d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2752cf2-9a48-49a8-98ff-2e32a9121d78.jpg?1",
             "name": "Orcish Oriflamme",
             "text": "When attacking, all of your attacking creatures gain +1/+0.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "1ae90d89-e8f6-5cff-b0bf-36f125e2a978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52eb10a-a9eb-44b7-95ae-12fb551c8fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52eb10a-a9eb-44b7-95ae-12fb551c8fa5.jpg?1",
             "name": "Power Surge",
             "text": "Before untapping lands at the start of a turn, each player takes 1 damage for each land he or she controls but did not tap during the previous turn.",
             "colours": [
@@ -5409,7 +5409,7 @@
         },
         {
             "id": "61bfffcf-e05c-5972-b439-41b32a4b8690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14746bb-aa00-4be2-9740-d87f976296d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14746bb-aa00-4be2-9740-d87f976296d2.jpg?1",
             "name": "Raging River",
             "text": "When you attack, non-flying defending creatures must be divided as opponent wishes between the left and right sides of the River. You then choose on which side of the River to place each attacking creature, and attacking creatures can only be blocked by flying creatures or those on the same side of the River.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "d975fbda-c3bd-5d07-bfe2-65e0f4af14f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fafd3f9-f7de-4d6e-8824-6b60866fc50f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fafd3f9-f7de-4d6e-8824-6b60866fc50f.jpg?1",
             "name": "Red Elemental Blast",
             "text": "Counters a blue spell being cast or destroys a blue card in play.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "895e664f-2486-549c-9ebd-399145f864d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b9e3ae-c7e9-455f-abfe-220262719beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b9e3ae-c7e9-455f-abfe-220262719beb.jpg?1",
             "name": "Roc of Kher Ridges",
             "text": "Flying",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "51c1045f-0173-5047-83f7-c1a98ca52459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17a982d-466d-4fec-b85a-a44161e5dad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17a982d-466d-4fec-b85a-a44161e5dad5.jpg?1",
             "name": "Rock Hydra",
             "text": "Put X +1/+1 counters (heads) on Hydra. Each point of damage Hydra suffers destroys one head unless o\nR is spent. During upkeep, new heads may be grown for o\nRo\nRo\nR apiece.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "3fb1a1db-0edb-5b44-9954-b9b16414fd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec317b-52a6-4490-80e5-a56826b06771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ec317b-52a6-4490-80e5-a56826b06771.jpg?1",
             "name": "Sedge Troll",
             "text": "oo\nB Regenerates. Troll gains +1/+1 if controller has swamps in play.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "81e13939-7297-5c0e-ab0a-8509d0bb74ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ddf3f4-1305-4599-bf4c-f9e148bdda4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ddf3f4-1305-4599-bf4c-f9e148bdda4d.jpg?1",
             "name": "Shatter",
             "text": "Shatter destroys target artifact.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "1fab4a0e-c5e7-554f-a72b-7e7862acbbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e64822a-6817-4e1e-8155-3e95f8e3763f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e64822a-6817-4e1e-8155-3e95f8e3763f.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying, oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "0322ba30-a22b-519a-83dd-e64884653a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb0cb82-d930-43c3-a6d6-f947018d45d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb0cb82-d930-43c3-a6d6-f947018d45d6.jpg?1",
             "name": "Smoke",
             "text": "Each player can only untap one creature during his or her untap phase.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "7b199ae5-f53c-5a79-a975-2cb8c7e1ca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b5f545-a87d-4292-880f-5cd2f6755748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b5f545-a87d-4292-880f-5cd2f6755748.jpg?1",
             "name": "Stone Giant",
             "text": "Tap to make one of your own creatures a flying creature until end of turn. Target creature, which must have toughness less than Stone Giant's power, is destroyed at end of turn.",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "39b9acca-60c7-5739-a654-9725fd20e528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901831ad-1840-4287-b6a0-bea310598dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901831ad-1840-4287-b6a0-bea310598dc2.jpg?1",
             "name": "Stone Rain",
             "text": "Destroys any one land.",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "068f88f6-8228-5d06-8c6f-8eb9c1cb0a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc738025-a771-4186-b08c-7b37c0e9713b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc738025-a771-4186-b08c-7b37c0e9713b.jpg?1",
             "name": "Tunnel",
             "text": "Destroys 1 wall. Target wall cannot be regenerated.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "dd154c88-8235-5ca0-9925-11391b89669a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fcbb16-f8e7-4f6e-a806-541ef54aa025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fcbb16-f8e7-4f6e-a806-541ef54aa025.jpg?1",
             "name": "Two-Headed Giant of Foriys",
             "text": "Trample\nMay block two attacking creatures; divide damage between them however controller likes.",
             "colours": [
@@ -5794,7 +5794,7 @@
         },
         {
             "id": "ce318d91-f714-5314-b4ba-249a050cd9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f46e9a-6075-4fa5-8f60-f81e2024b13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f46e9a-6075-4fa5-8f60-f81e2024b13d.jpg?1",
             "name": "Uthden Troll",
             "text": "oo\nR Regenerates",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "3e7f7656-df0c-583c-b7e0-fdebf2d4ced2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88baaea5-69ec-4756-86c2-9c9d73ca8ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88baaea5-69ec-4756-86c2-9c9d73ca8ef1.jpg?1",
             "name": "Wall of Fire",
             "text": "oo\nR +1/+0 until end of turn.",
             "colours": [
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "5eeee0c2-8b98-5853-95eb-960e772762bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ba196-a107-41ac-b02a-5f8b10ecd130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329ba196-a107-41ac-b02a-5f8b10ecd130.jpg?1",
             "name": "Wall of Stone",
             "text": "",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "9abfc13a-e504-5419-84bf-dab7efe86f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1",
             "name": "Wheel of Fortune",
             "text": "Both players must discard their hands and draw seven new cards.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "b3c3b0f0-b472-5a68-b66f-2cf474e3dd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7dc8e-e02a-4ceb-8767-2875f86e6811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f7dc8e-e02a-4ceb-8767-2875f86e6811.jpg?1",
             "name": "Aspect of Wolf",
             "text": "Target creature's power and toughness are increased by half the number of forests you have in play, rounding down for power and up for toughness.",
             "colours": [
@@ -5957,7 +5957,7 @@
         },
         {
             "id": "e4c0ac51-5d98-5d36-901d-36d68ec4c8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d6f431-a7ea-4508-a52c-86d33e12e4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d6f431-a7ea-4508-a52c-86d33e12e4e4.jpg?1",
             "name": "Berserk",
             "text": "Until end of turn, target creature's current power doubles and it gains trample ability. If it attacks, target creature is destroyed at end of turn. This spell cannot be cast after current turn's attack is completed.",
             "colours": [
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "b89cfede-bd9c-54d8-a020-55b8eb8f9bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d7a68-8682-4073-a44b-f10f5613879c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d7a68-8682-4073-a44b-f10f5613879c.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\nTap to add one mana of any color to your mana pool. This tap may be played as an interrupt.",
             "colours": [
@@ -6021,7 +6021,7 @@
         },
         {
             "id": "b7fb288e-f597-5bfb-8a27-b58978c57bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55ff95-32a3-43ba-82e5-a5a3bc2cc9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f55ff95-32a3-43ba-82e5-a5a3bc2cc9e5.jpg?1",
             "name": "Camouflage",
             "text": "You may rearrange your attacking creatures and place them face down, revealing which is which only after defense is chosen. If this results in impossible blocks, such as non-flying creatures blocking flying creatures, illegal blockers cannot block this turn.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "4a69ad5a-4b5b-5775-908b-fe295a3db6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa6468a-335a-467d-aef6-e537af9d5c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa6468a-335a-467d-aef6-e537af9d5c1c.jpg?1",
             "name": "Channel",
             "text": "Until end of turn, you may add colorless mana to your mana pool, at a cost of 1 life each. These additions are played with the speed of an interrupt. Effects that prevent damage may not be used to counter this loss of life.",
             "colours": [
@@ -6083,7 +6083,7 @@
         },
         {
             "id": "798ae1a4-bc5a-59d9-8905-d7f37bdd5eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71dd0f-dffe-4671-b9e3-ddec70626688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc71dd0f-dffe-4671-b9e3-ddec70626688.jpg?1",
             "name": "Cockatrice",
             "text": "Flying\nAny non-wall creature blocking Cockatrice is destroyed, as is any creature blocked by Cockatrice. Creatures destroyed in this way deal their damage before dying.",
             "colours": [
@@ -6116,7 +6116,7 @@
         },
         {
             "id": "622f5419-ef70-570a-893c-4f1c1a069342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d5c1c7-a882-479a-9077-0784e83b462d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d5c1c7-a882-479a-9077-0784e83b462d.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -6149,7 +6149,7 @@
         },
         {
             "id": "ea5a852d-fa5e-5595-8b0e-8adb6a022606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3240d5e-b3d4-4368-b09b-c309bc935152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3240d5e-b3d4-4368-b09b-c309bc935152.jpg?1",
             "name": "Elvish Archers",
             "text": "First strike",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "6b623389-f575-5033-b405-059a976efb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48ed192-c1a1-437a-80dd-647a616b46e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48ed192-c1a1-437a-80dd-647a616b46e3.jpg?1",
             "name": "Fastbond",
             "text": "You may put as many lands into play as you want each turn. Fastbond does 1 damage to you for every land beyond the first that you play in a single turn.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "c1ca5f28-73d2-5997-a51c-f50ac5874a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e9597a-4489-47e9-8b15-888acb402ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e9597a-4489-47e9-8b15-888acb402ddd.jpg?1",
             "name": "Fog",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is dealt.",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "9a62b1bb-cbc5-5808-9824-dffd19a833e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25a61b3-c828-491c-868d-e4eff770c1bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25a61b3-c828-491c-868d-e4eff770c1bb.jpg?1",
             "name": "Force of Nature",
             "text": "Trample\nYou must pay o\nGo\nGo\nGo\nG during upkeep or Force of Nature does 8 damage to you. You may still attack with Force of Nature even if you failed to pay the upkeep.",
             "colours": [
@@ -6278,7 +6278,7 @@
         },
         {
             "id": "10b07e34-67f6-578a-b516-65ec1a3e19cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a58f0b-c772-4254-8686-182d26889f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a58f0b-c772-4254-8686-182d26889f9c.jpg?1",
             "name": "Fungusaur",
             "text": "Each time Fungusaur is damaged but not destroyed, put a +1/+1 counter on it.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "4ed4d91d-f008-56d7-b510-21f5c6edad5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554362d7-97b3-4a55-9292-15e90435088d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554362d7-97b3-4a55-9292-15e90435088d.jpg?1",
             "name": "Gaea's Liege",
             "text": "When defending, Gaea's Liege has power and toughness equal to the number of forests you have in play; when it's attacking, they are equal to the number of forests opponent has in play. Tap to turn any one land into a forest until Gaea's Liege leaves play. Mark changed lands with counters, removing the counters when Gaea's Liege leaves play.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "01107f75-2e0e-51f0-8dcb-3dce8b96fff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755a45bd-8fe6-4e4d-8065-024a2836751b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755a45bd-8fe6-4e4d-8065-024a2836751b.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gains +3/+3 until end of turn.",
             "colours": [
@@ -6376,7 +6376,7 @@
         },
         {
             "id": "6072aabc-56d1-5f2d-a39b-0139f10f74ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea35ce-8aa1-4818-8ad5-7e462452f10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea35ce-8aa1-4818-8ad5-7e462452f10e.jpg?1",
             "name": "Giant Spider",
             "text": "Does not fly, but can block flying creatures.",
             "colours": [
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "4b35d338-f8cd-5d65-86f8-49cc76756592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7aa2b93-0a84-4318-bf2d-58164f0a846f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7aa2b93-0a84-4318-bf2d-58164f0a846f.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -6442,7 +6442,7 @@
         },
         {
             "id": "aca2bee1-7244-5064-af35-b45bb455d233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3939f72-1ec6-4b2c-b37e-b1ebb024bb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3939f72-1ec6-4b2c-b37e-b1ebb024bb8f.jpg?1",
             "name": "Hurricane",
             "text": "All players and flying creatures suffer X damage.",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "220090b2-c5f8-504f-803d-5e48015bc0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c439c5a-b4a5-411b-9e68-fb8438ccdfb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c439c5a-b4a5-411b-9e68-fb8438ccdfb0.jpg?1",
             "name": "Ice Storm",
             "text": "Destroys any one land.",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "c0bc6296-8259-5e1f-a4cf-abdef148043d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58334cf9-5186-4fba-963c-fffb21f2b8de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58334cf9-5186-4fba-963c-fffb21f2b8de.jpg?1",
             "name": "Instill Energy",
             "text": "You may untap target creature both during your untap phase and one additional time during your turn. Target creature may attack the turn it comes into play.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "97467c42-0f9d-5dc8-a34b-acc114ab6eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9479ae-2b42-4137-9e62-ef4d7fd17d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9479ae-2b42-4137-9e62-ef4d7fd17d0c.jpg?1",
             "name": "Ironroot Treefolk",
             "text": "",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "2a132c39-996c-5665-afe5-fe089ff19e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced83afa-9718-4b8a-961b-394f8595c480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced83afa-9718-4b8a-961b-394f8595c480.jpg?1",
             "name": "Kudzu",
             "text": "When target land becomes tapped, it is destroyed. Unless that was the last land in play, Kudzu is not discarded; instead, the player whose land it just destroyed may place it on another land of his or her choice.",
             "colours": [
@@ -6603,7 +6603,7 @@
         },
         {
             "id": "c69e8737-137d-5e98-8a54-a24d82d67c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58867ec-0b1a-4804-bc2e-1c88d338c29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58867ec-0b1a-4804-bc2e-1c88d338c29e.jpg?1",
             "name": "Ley Druid",
             "text": "Tap Druid to untap a land of your choice. This action can be played as an interrupt.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "6500e96c-11d4-5d3b-9323-0d1b74b58fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3715abe2-5a8e-4bf4-ac02-6c755d86bb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3715abe2-5a8e-4bf4-ac02-6c755d86bb4c.jpg?1",
             "name": "Lifeforce",
             "text": "o\nGo\nG: Destroy a black spell as it is being cast. This use may be played as an interrupt, and does not affect black cards already in play.",
             "colours": [
@@ -6668,7 +6668,7 @@
         },
         {
             "id": "d67e0e36-1dd1-53aa-bc2f-84edc786cfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9379e159-43ac-4bd2-8b33-f3de8e20cfe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9379e159-43ac-4bd2-8b33-f3de8e20cfe0.jpg?1",
             "name": "Lifelace",
             "text": "Changes the color of one card either being played or already in play to green. Cost to cast, tap, maintain, or use a special ability of target card remains entirely unchanged.",
             "colours": [
@@ -6699,7 +6699,7 @@
         },
         {
             "id": "09107d1e-fda6-5e13-8b29-9e66cd55d2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf6678-f597-407d-9a95-02bbe6c4bcf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbf6678-f597-407d-9a95-02bbe6c4bcf3.jpg?1",
             "name": "Living Artifact",
             "text": "Put a counter on target artifact for each life you lose. During upkeep you may trade one counter for one life, but you can only trade in one counter each turn.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "b2746850-a960-59ff-a407-80edfcd28d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f132acbd-53e5-430a-8f93-8b7469633c0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f132acbd-53e5-430a-8f93-8b7469633c0e.jpg?1",
             "name": "Living Lands",
             "text": "Treat all forests in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. The living lands have no color; they are not considered green cards.",
             "colours": [
@@ -6763,7 +6763,7 @@
         },
         {
             "id": "e6ea1921-72aa-57c5-be67-04b72fc0f33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd80204-e9ba-483f-9b75-a69712545ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd80204-e9ba-483f-9b75-a69712545ba9.jpg?1",
             "name": "Llanowar Elves",
             "text": "Tap to add 1 green mana to your mana pool. This tap can be played as an interrupt.",
             "colours": [
@@ -6797,7 +6797,7 @@
         },
         {
             "id": "5c70cc67-9382-5018-ac4f-d4ff0dd026f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31495ab-e6ed-40a6-b82d-aa6092b049e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31495ab-e6ed-40a6-b82d-aa6092b049e2.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block target creature must do so. If a creature has the ability to block more than one creature, Lure does not prevent this. If there is more than one attacking creature with Lure, defender may choose which of them each defending creature blocks.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "b265c419-f858-5a74-aac1-b04572011c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a594299e-fc3a-4d46-bd58-1a9cf7ddbdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a594299e-fc3a-4d46-bd58-1a9cf7ddbdd7.jpg?1",
             "name": "Natural Selection",
             "text": "Look at top three cards of any player's library. You may opt to rearrange those three cards or shuffle the entire library.",
             "colours": [
@@ -6861,7 +6861,7 @@
         },
         {
             "id": "b46c0526-96a3-55ec-a58f-bb1f166adba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ad2d7f-34a5-4b17-ae11-16b322601d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ad2d7f-34a5-4b17-ae11-16b322601d73.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Target creature regenerates.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "1c119481-b437-5dd2-8083-b3f502d82262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898cd314-9060-4f1c-a821-1d61a292a12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/898cd314-9060-4f1c-a821-1d61a292a12b.jpg?1",
             "name": "Regrowth",
             "text": "Return any card from your graveyard to your hand.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "b6248eea-1ca9-5e8d-b074-20bc57829f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafe9639-e9d0-4aa2-8a16-f4ec24c140c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafe9639-e9d0-4aa2-8a16-f4ec24c140c0.jpg?1",
             "name": "Scryb Sprites",
             "text": "Flying",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "072a9489-b64f-5239-97eb-49d3b0ed9b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac8bdb0-2dfd-4531-a4d9-420f2f2a90be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac8bdb0-2dfd-4531-a4d9-420f2f2a90be.jpg?1",
             "name": "Shanodin Dryads",
             "text": "Forestwalk",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "8f2f1a46-ecba-503e-81e0-17ebb413e9dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a2c9-850e-400d-b0b3-edd8a946e380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da18a2c9-850e-400d-b0b3-edd8a946e380.jpg?1",
             "name": "Stream of Life",
             "text": "Target player gains X life.",
             "colours": [
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "f864b601-6c8d-5ab8-a0a0-209893028cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6321e16b-0b4b-4d36-ab94-97bf5816acf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6321e16b-0b4b-4d36-ab94-97bf5816acf4.jpg?1",
             "name": "Thicket Basilisk",
             "text": "Any non-wall creature blocking Basilisk is destroyed, as is any creature blocked by Basilisk. Creatures destroyed this way deal their damage before dying.",
             "colours": [
@@ -7056,7 +7056,7 @@
         },
         {
             "id": "6ea81f58-0f7f-596c-bb31-776e27e82f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa598db8-c0c7-4a9a-bd89-6d3da0d3dfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa598db8-c0c7-4a9a-bd89-6d3da0d3dfba.jpg?1",
             "name": "Timber Wolves",
             "text": "Bands",
             "colours": [
@@ -7089,7 +7089,7 @@
         },
         {
             "id": "0905b77a-a16d-550f-8469-8f2426f254ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee21b620-4dfa-4e06-872e-8d8ffce12f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee21b620-4dfa-4e06-872e-8d8ffce12f76.jpg?1",
             "name": "Tranquility",
             "text": "All enchantments in play must be discarded.",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "bb2a37de-ceac-5c14-8d98-1bbd1168c3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b6f5a-1ba2-409d-9b9b-91e2c1470f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b6f5a-1ba2-409d-9b9b-91e2c1470f62.jpg?1",
             "name": "Tsunami",
             "text": "All islands in play are destroyed.",
             "colours": [
@@ -7151,7 +7151,7 @@
         },
         {
             "id": "5d6d240c-29a5-5f07-8dbf-cd46c882cda3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f051c-6be3-4f92-8f66-9f72d75dbcf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f051c-6be3-4f92-8f66-9f72d75dbcf5.jpg?1",
             "name": "Verduran Enchantress",
             "text": "While Enchantress is in play, you may immediately draw a card from your library each time you cast an enchantment.",
             "colours": [
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "47b89da4-bf4b-5f38-8541-325d63e20412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fca52b-80b3-4b6b-9a49-110c66557894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fca52b-80b3-4b6b-9a49-110c66557894.jpg?1",
             "name": "Wall of Brambles",
             "text": "oo\nG Regenerates",
             "colours": [
@@ -7219,7 +7219,7 @@
         },
         {
             "id": "fa96e843-693f-5914-99a2-1c49a73c934e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05a648-7719-4ed3-aa3b-648463ee2869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05a648-7719-4ed3-aa3b-648463ee2869.jpg?1",
             "name": "Wall of Ice",
             "text": "",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "98c3fb5a-ec1d-5f51-a1f7-54e35d700775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5054a4-599d-49df-9a80-77eeed47891f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5054a4-599d-49df-9a80-77eeed47891f.jpg?1",
             "name": "Wall of Wood",
             "text": "",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "442981e3-98ec-5e25-9dea-e583c83376ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393f08a2-7aa8-443f-aab5-4287240e9167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393f08a2-7aa8-443f-aab5-4287240e9167.jpg?1",
             "name": "Wanderlust",
             "text": "Wanderlust does 1 damage to target creature's controller during upkeep.",
             "colours": [
@@ -7318,7 +7318,7 @@
         },
         {
             "id": "1b0edb7b-d6a3-5577-afdf-e253b7d39dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67175d-ac5c-4947-b243-d5206b552bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f67175d-ac5c-4947-b243-d5206b552bdc.jpg?1",
             "name": "War Mammoth",
             "text": "Trample",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "68c3b0d2-3f8c-5e88-a8fd-7e1ded6a7022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f84dc2-5a29-447d-97ab-a10afd9ee538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f84dc2-5a29-447d-97ab-a10afd9ee538.jpg?1",
             "name": "Web",
             "text": "Target creature gains +0/+2 and can now block flying creatures, though it does not gain the power to fly.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "4d0b1b76-14c7-53b6-aace-40bec393f21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f299eb-9cd6-40bc-ad44-22e3aeb5c930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f299eb-9cd6-40bc-ad44-22e3aeb5c930.jpg?1",
             "name": "Wild Growth",
             "text": "When tapped, target land provides 1 green mana in addition to the mana it normally provides.",
             "colours": [
@@ -7417,7 +7417,7 @@
         },
         {
             "id": "b8799a7d-def4-5562-bad1-ce2ec0adc148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0367e54-eb07-475a-b06b-f869a046a86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0367e54-eb07-475a-b06b-f869a046a86c.jpg?1",
             "name": "Ankh of Mishra",
             "text": "Ankh does 2 damage to anyone who puts a new land into play.",
             "colours": [],
@@ -7444,7 +7444,7 @@
         },
         {
             "id": "84ba630e-a657-5400-a650-55af3a5887ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d73362-43c1-4dd0-87dd-9aa7ae13ff2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d73362-43c1-4dd0-87dd-9aa7ae13ff2f.jpg?1",
             "name": "Basalt Monolith",
             "text": "Tap to add 3 colorless mana to your mana pool. Does not untap as normal during untap phase; spend o3 to untap. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "7415e72a-f2f7-53e5-bcec-0a8c61ff3a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a69a1c-c80f-4413-a6fd-ae54cabbce28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a69a1c-c80f-4413-a6fd-ae54cabbce28.jpg?1",
             "name": "Black Lotus",
             "text": "Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -7498,7 +7498,7 @@
         },
         {
             "id": "ac2c123f-5601-56d9-bd3b-8a98fb580ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d234f3d7-2f15-4fbf-92db-16c3433d644b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d234f3d7-2f15-4fbf-92db-16c3433d644b.jpg?1",
             "name": "Black Vise",
             "text": "If opponent has more than four cards in hand during upkeep, black vise does 1 damage to opponent for each card in excess of four.",
             "colours": [],
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "be3005a3-29fb-529a-8452-6af86ba3f60a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c5460-8d4c-47a7-8a9c-ab626daa520a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243c5460-8d4c-47a7-8a9c-ab626daa520a.jpg?1",
             "name": "Celestial Prism",
             "text": "o2: Provides 1 mana of any color. This use can be played as an interrupt.",
             "colours": [],
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "f7c254d4-621b-5df2-bb8d-6020749f55be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bec436c-2869-432a-b3cf-633a58af6d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bec436c-2869-432a-b3cf-633a58af6d4c.jpg?1",
             "name": "Chaos Orb",
             "text": "o1: Flip Chaos Orb onto the playing area from a height of at least one foot. Chaos Orb must turn completely over at least once or it is discarded with no effect. When Chaos Orb lands, any cards in play that it touches are destroyed, as is Chaos Orb.",
             "colours": [],
@@ -7579,7 +7579,7 @@
         },
         {
             "id": "86d70180-aa7f-587a-b7d8-f058109769ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efe95-ae57-4ff1-8f8a-0d6f3bd36d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efe95-ae57-4ff1-8f8a-0d6f3bd36d9c.jpg?1",
             "name": "Clockwork Beast",
             "text": "Put seven +1/+0 counters on Beast. After Beast attacks or blocks a creature, discard a counter. During the untap phase, controller may buy back lost counters for 1 mana per counter instead of tapping Beast; this taps Beast if it wasn't tapped already.",
             "colours": [],
@@ -7609,7 +7609,7 @@
         },
         {
             "id": "214a886d-5704-5c18-8251-ca3126663016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54af3-7c85-43da-b0ce-df4a44af4736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54af3-7c85-43da-b0ce-df4a44af4736.jpg?1",
             "name": "Conservator",
             "text": "o3: Prevent the loss of up to 2 life.",
             "colours": [],
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "57647c77-deef-5672-b9e8-3b702a634f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93842064-a0a8-4e4d-9c8a-e8a86448d225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93842064-a0a8-4e4d-9c8a-e8a86448d225.jpg?1",
             "name": "Copper Tablet",
             "text": "Copper Tablet does 1 damage to each player during his or her upkeep.",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "6ee10abb-c738-5bb1-8f96-7d3c2dd29c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44d892f-a975-4062-8a54-5777d2600504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e44d892f-a975-4062-8a54-5777d2600504.jpg?1",
             "name": "Crystal Rod",
             "text": "o1: Any blue spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "4e0fc1eb-c219-5df1-8ca5-aa51ea3f634a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00775f44-fbe6-41ee-9977-d13d1fb5b6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00775f44-fbe6-41ee-9977-d13d1fb5b6fb.jpg?1",
             "name": "Cyclopean Tomb",
             "text": "o2: Turn any one non-swamp land into swamp during upkeep. Mark the changed lands with tokens. If Cyclopean Tomb is destroyed, remove one token of your choice each upkeep, returning that land to its original nature.",
             "colours": [],
@@ -7717,7 +7717,7 @@
         },
         {
             "id": "bc02ffe6-a793-5057-801e-10a19f9b34af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8ecaee-0de3-45ee-8428-09dc400d63d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8ecaee-0de3-45ee-8428-09dc400d63d8.jpg?1",
             "name": "Dingus Egg",
             "text": "Whenever anyone loses a land, Egg does 2 damage to that player for each land lost.",
             "colours": [],
@@ -7744,7 +7744,7 @@
         },
         {
             "id": "bce77c6a-feb1-5aa0-b68e-b402d0d60751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae91e07c-ad6d-41d9-bd65-184f92761334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae91e07c-ad6d-41d9-bd65-184f92761334.jpg?1",
             "name": "Disrupting Scepter",
             "text": "o3: Opponent must discard one card of his or her choice. Can only be used during your turn.",
             "colours": [],
@@ -7771,7 +7771,7 @@
         },
         {
             "id": "434beda4-9cb7-5616-9adb-4cc55d29beb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34855fa8-959d-45a2-ad91-8b17019755be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34855fa8-959d-45a2-ad91-8b17019755be.jpg?1",
             "name": "Forcefield",
             "text": "o1: Lose only 1 life to an unblocked creature.",
             "colours": [],
@@ -7798,7 +7798,7 @@
         },
         {
             "id": "1c3459ab-998c-5db6-8350-9a9780d89744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e240-07b0-45fb-90af-f4fce18c604e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c0e240-07b0-45fb-90af-f4fce18c604e.jpg?1",
             "name": "Gauntlet of Might",
             "text": "All red creatures gain +1/+1 and all mountains provide an extra red mana when tapped.",
             "colours": [],
@@ -7827,7 +7827,7 @@
         },
         {
             "id": "f87b5e2c-0859-50c4-9b0d-44e40ae5d5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6953fd-ee48-49dc-9c9c-bfb9a9dc06d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6953fd-ee48-49dc-9c9c-bfb9a9dc06d0.jpg?1",
             "name": "Glasses of Urza",
             "text": "You may look at opponent's hand.",
             "colours": [],
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "a9720f7f-3cda-5f2e-8028-47a70ae079f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d3329-9053-4301-b867-1b49c248fe31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d3329-9053-4301-b867-1b49c248fe31.jpg?1",
             "name": "Helm of Chatzuk",
             "text": "o1: You may give one creature the ability to band until end of turn.",
             "colours": [],
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "6719b567-4ccf-569f-ae6e-3e03618f6483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37634ffe-788f-4262-88e8-5ab7c7ca74d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37634ffe-788f-4262-88e8-5ab7c7ca74d6.jpg?1",
             "name": "Howling Mine",
             "text": "Each player draws one extra card each turn during his or her draw phase.",
             "colours": [],
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "15c248ca-cd1f-5ec1-bd58-8b323ddffb67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27608e7-6539-4813-95b6-d8847cdc6a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27608e7-6539-4813-95b6-d8847cdc6a12.jpg?1",
             "name": "Icy Manipulator",
             "text": "o1: You may tap any land, creature, or artifact in play on either side. No effects are generated by the target card.",
             "colours": [],
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "20b4e2fc-4165-533f-ad73-b4debce5c02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ea96b1-4428-4951-88d4-f79338955981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ea96b1-4428-4951-88d4-f79338955981.jpg?1",
             "name": "Illusionary Mask",
             "text": "oo\nX You can summon a creature face down so opponent doesn't know what it is. The X cost can be any amount of mana, even 0; it serves to hide the true casting cost of the creature, which you still have to spend. As soon as a face-down creature receives damage, deals damage, or is tapped, you must turn it face up.",
             "colours": [],
@@ -7962,7 +7962,7 @@
         },
         {
             "id": "03410e19-420c-54a0-9f31-9330cd34898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08fff47-c3c8-40a9-b3d3-296954aa4ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08fff47-c3c8-40a9-b3d3-296954aa4ed4.jpg?1",
             "name": "Iron Star",
             "text": "o1: Any red spell cast by any player gives you 1 life.",
             "colours": [],
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "23673ab5-68ed-53d2-9d1b-b846401a3c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32516ab8-43be-4207-a7d5-4916933ce155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32516ab8-43be-4207-a7d5-4916933ce155.jpg?1",
             "name": "Ivory Cup",
             "text": "o1: Any white spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "7b9bf6e6-07c4-50f7-8f3c-96ded60b1921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeea32ba-dfe4-4a9b-b403-43c2abc80b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeea32ba-dfe4-4a9b-b403-43c2abc80b78.jpg?1",
             "name": "Jade Monolith",
             "text": "o1: You may take damage done to any creature on yourself instead, but you must take all of it. Source of damage is unchanged.",
             "colours": [],
@@ -8043,7 +8043,7 @@
         },
         {
             "id": "28b3a5d7-2987-5152-99fa-b66f6bb1b39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985164ba-0c30-42b1-a8b6-3be19251359c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985164ba-0c30-42b1-a8b6-3be19251359c.jpg?1",
             "name": "Jade Statue",
             "text": "o2: Jade Statue becomes a creature for the duration of the current attack exchange. Can be a creature only during an attack or defense.",
             "colours": [],
@@ -8070,7 +8070,7 @@
         },
         {
             "id": "9cceb7e5-42cd-5848-9d89-6fbfaf452507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48b1c51-c0fd-4c08-8631-80f507b04d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48b1c51-c0fd-4c08-8631-80f507b04d28.jpg?1",
             "name": "Jayemdae Tome",
             "text": "o4: You may draw one extra card.",
             "colours": [],
@@ -8097,7 +8097,7 @@
         },
         {
             "id": "59f45ff7-ad96-5a63-a462-83fffb9597a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870eb49c-f62d-4986-b492-601feb68a307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870eb49c-f62d-4986-b492-601feb68a307.jpg?1",
             "name": "Juggernaut",
             "text": "Must attack each turn if possible. Can't be blocked by walls.",
             "colours": [],
@@ -8127,7 +8127,7 @@
         },
         {
             "id": "ca3f8821-e537-5a1f-aa77-b0819673a0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2a4f9-8f80-4ee3-8068-73e686d6eeb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd2a4f9-8f80-4ee3-8068-73e686d6eeb9.jpg?1",
             "name": "Kormus Bell",
             "text": "Treat all swamps in play as 1/1 creatures. Now they can be enchanted, killed, and so forth, and they can be tapped either for mana or to attack. Swamps have no color; they are not considered black cards.",
             "colours": [],
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "910e0e45-0d29-570b-843b-e578373f69f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254bff2-a3a7-434e-980a-2d30355793fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0254bff2-a3a7-434e-980a-2d30355793fc.jpg?1",
             "name": "Library of Leng",
             "text": "There is no limit to size of your hand. If a card forces you to discard, you may choose to discard to top of your library rather than to graveyard. If discard is random, you may look at card before deciding where to discard it.",
             "colours": [],
@@ -8181,7 +8181,7 @@
         },
         {
             "id": "6efd1763-56b7-58e3-8e0a-402b3a067e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2cd1c8-8734-4534-ae92-def4d94ef5bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2cd1c8-8734-4534-ae92-def4d94ef5bc.jpg?1",
             "name": "Living Wall",
             "text": "Counts as a wall. o1: Regenerates.",
             "colours": [],
@@ -8211,7 +8211,7 @@
         },
         {
             "id": "7b845dc2-29bb-5d5b-b59e-81acbee9e722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f55e8-7f86-4ca9-b737-9a920d9cf282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11f55e8-7f86-4ca9-b737-9a920d9cf282.jpg?1",
             "name": "Mana Vault",
             "text": "Tap to add 3 colorless mana to your mana pool. Mana Vault doesn't untap normally during untap phase; to untap it, you must pay 4 mana. If Mana Vault remains tapped during upkeep it does 1 damage to you. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "eb9e0903-ef42-5a79-823d-b1968dc664bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b22007-9def-4c0f-921c-555483cc3deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b22007-9def-4c0f-921c-555483cc3deb.jpg?1",
             "name": "Meekstone",
             "text": "Any creature with power greater than 2 may not be untapped as normal during the untap phase.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "bc924c9e-b4fc-5a05-9803-59c108546a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d9476-76be-48e7-b6a0-49ced25cb092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5d9476-76be-48e7-b6a0-49ced25cb092.jpg?1",
             "name": "Mox Emerald",
             "text": "Add 1 green mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "ff19b91f-c815-558a-897a-4b8c4f3e61db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133204e4-fef8-4851-aa50-c96ffa35b802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133204e4-fef8-4851-aa50-c96ffa35b802.jpg?1",
             "name": "Mox Jet",
             "text": "Add 1 black mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "d43a8822-4241-5a60-897b-f141247a9fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da892c5-071f-416f-9e42-c4bff102eb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da892c5-071f-416f-9e42-c4bff102eb88.jpg?1",
             "name": "Mox Pearl",
             "text": "Add 1 white mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8352,7 +8352,7 @@
         },
         {
             "id": "75579c49-8efe-5cc4-b645-5fff52736424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdac742b-16db-4e03-be8f-c600dbd522d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdac742b-16db-4e03-be8f-c600dbd522d5.jpg?1",
             "name": "Mox Ruby",
             "text": "Add 1 red mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8381,7 +8381,7 @@
         },
         {
             "id": "8a513c25-1eec-5c18-9cf5-3068a1eb94bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb3178b-dac5-4b34-9d3e-4f5a170d1c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb3178b-dac5-4b34-9d3e-4f5a170d1c87.jpg?1",
             "name": "Mox Sapphire",
             "text": "Add 1 blue mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "622397bf-673a-5885-a4bf-7900ec745b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb21f21-668a-4d57-8d05-8db11fb82d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb21f21-668a-4d57-8d05-8db11fb82d99.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "o1: Destroys all creatures, enchantments, and artifacts in play. Disk begins tapped but can be untapped as usual. Disk destroys itself when used.",
             "colours": [],
@@ -8437,7 +8437,7 @@
         },
         {
             "id": "3074f009-6c15-5bf1-85dc-3f2f4e93f33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ed6669-e340-46d5-906b-e24e76464e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ed6669-e340-46d5-906b-e24e76464e75.jpg?1",
             "name": "Obsianus Golem",
             "text": "",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "2d3c3a23-39a4-5204-9a4f-86f5564e73ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45810c0a-0a35-4bd4-ba66-5a45f8973fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45810c0a-0a35-4bd4-ba66-5a45f8973fa4.jpg?1",
             "name": "Rod of Ruin",
             "text": "o3: Rod of Ruin does 1 damage to any target.",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "570b9c70-eb8b-5c23-b952-01797b13164f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fb91ec-20a8-4c13-9469-18885b1ecca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fb91ec-20a8-4c13-9469-18885b1ecca3.jpg?1",
             "name": "Sol Ring",
             "text": "Add 2 colorless mana to your mana pool. Tapping this artifact can be played as an interrupt.",
             "colours": [],
@@ -8521,7 +8521,7 @@
         },
         {
             "id": "e6992605-a1af-5a8d-937d-d66b31c1b8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ba41ec-4fff-4192-80ff-2afcd706ea59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ba41ec-4fff-4192-80ff-2afcd706ea59.jpg?1",
             "name": "Soul Net",
             "text": "o1: You gain 1 life every time a creature is destroyed, unless it is then regenerated.",
             "colours": [],
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "1b66c092-e1db-5340-985d-1bf81dac19dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fcf47d-0f1d-469e-a8c4-d5c97be7a1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fcf47d-0f1d-469e-a8c4-d5c97be7a1ef.jpg?1",
             "name": "Sunglasses of Urza",
             "text": "White mana in your mana pool can be used as either white or red mana.",
             "colours": [],
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "7dd52da8-08dd-5314-8b20-bfee51e278e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b83106-a10d-469a-99eb-56110ef34ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b83106-a10d-469a-99eb-56110ef34ba1.jpg?1",
             "name": "The Hive",
             "text": "o5: Creates one Giant Wasp, a 1/1 flying creature. Represent Wasps with tokens, making sure to indicate when each Wasp is tapped. Wasps can't attack during the turn created. Treat Wasps like artifact creatures in every way, except that they are removed from the game entirely if they ever leave play. If the Hive is destroyed, the Wasps must still be killed individually.",
             "colours": [],
@@ -8602,7 +8602,7 @@
         },
         {
             "id": "981789d7-4a6b-5db5-b197-c5da241a5998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655b6265-3030-4c68-af5b-b9e636b1a778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655b6265-3030-4c68-af5b-b9e636b1a778.jpg?1",
             "name": "Throne of Bone",
             "text": "o1: Any black spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8629,7 +8629,7 @@
         },
         {
             "id": "472bc7dc-5874-5c8f-9a65-f6c0f28d999f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1164f22f-2706-4f35-9f58-d0eb8c344396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1164f22f-2706-4f35-9f58-d0eb8c344396.jpg?1",
             "name": "Time Vault",
             "text": "Tap to gain an additional turn after the current one. Time Vault doesn't untap normally during untap phase; to untap it, you must skip a turn. Time Vault begins tapped.",
             "colours": [],
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "05a2b7c9-47d7-5b66-8658-c40c983ac77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847de6a4-a268-492e-a4d2-5b12237bc130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847de6a4-a268-492e-a4d2-5b12237bc130.jpg?1",
             "name": "Winter Orb",
             "text": "Players can untap only one land each during untap phase. Creatures and artifacts are untapped as normal.",
             "colours": [],
@@ -8683,7 +8683,7 @@
         },
         {
             "id": "2681fed4-9f19-53b3-b6cf-1fca7f27700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eee156-54bd-46fc-8804-a73aab87f0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eee156-54bd-46fc-8804-a73aab87f0ba.jpg?1",
             "name": "Wooden Sphere",
             "text": "o1: Any green spell cast by any player gives you 1 life.",
             "colours": [],
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "3146e838-1792-582e-88bb-ec0bf8735241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3393436-3426-4903-8f41-7abcbf6c18c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3393436-3426-4903-8f41-7abcbf6c18c2.jpg?1",
             "name": "Badlands",
             "text": "Counts as both mountains and swamp and is affected by spells that affect either. Tap to add either o\nR or o\nB to your mana pool.",
             "colours": [],
@@ -8743,7 +8743,7 @@
         },
         {
             "id": "49dde090-f045-5a13-ba57-782a8fbf0606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db2b6a-eaa8-4a08-9e86-370bbd058574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db2b6a-eaa8-4a08-9e86-370bbd058574.jpg?1",
             "name": "Bayou",
             "text": "Counts as both swamp and forest and is affected by spells that affect either. Tap to add either o\nB or o\nG to your mana pool.",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "1a8d61f7-a5ac-5461-82bf-e081633bc38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad0bbc4-f760-47a2-aab6-0dbb66ee3a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad0bbc4-f760-47a2-aab6-0dbb66ee3a95.jpg?1",
             "name": "Plateau",
             "text": "Counts as both mountains and plains and is affected by spells that affect either. Tap to add either o\nR or o\nW to your mana pool.",
             "colours": [],
@@ -8809,7 +8809,7 @@
         },
         {
             "id": "8161cb22-ccff-5844-9ee9-36e8fa40590d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9aeaa8-9a75-4719-992f-cbb316f72175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9aeaa8-9a75-4719-992f-cbb316f72175.jpg?1",
             "name": "Savannah",
             "text": "Counts as both plains and forest and is affected by spells that affect either. Tap to add either o\nW or o\nG to your mana pool.",
             "colours": [],
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "f48023cc-b84b-5517-83c9-9ff67ce509fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf99186-3167-4092-8efb-e7448609ceba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf99186-3167-4092-8efb-e7448609ceba.jpg?1",
             "name": "Scrubland",
             "text": "Counts as both plains and swamp and is affected by spells that affect either. Tap to add either o\nW or o\nB to your mana pool.",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "520a6a31-e483-5e66-a681-304a508aa2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ce1bf0-7561-418f-a217-3ce10f28be82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ce1bf0-7561-418f-a217-3ce10f28be82.jpg?1",
             "name": "Taiga",
             "text": "Counts as both forest and mountains and is affected by spells that affect either. Tap to add either o\nG or o\nR to your mana pool.",
             "colours": [],
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "e384e9fe-8204-5e83-b0da-d6d6720aa601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac19c5a1-ca13-4443-920b-83b567167ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac19c5a1-ca13-4443-920b-83b567167ed4.jpg?1",
             "name": "Tropical Island",
             "text": "Counts as both forest and islands and is affected by spells that affect either. Tap to add either o\nG or o\nU to your mana pool.",
             "colours": [],
@@ -8941,7 +8941,7 @@
         },
         {
             "id": "c50b0b0b-0068-5a93-ab38-e4dd17d7b854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b93ce48-219c-49ea-9ad0-b7357bea4606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b93ce48-219c-49ea-9ad0-b7357bea4606.jpg?1",
             "name": "Tundra",
             "text": "Counts as both islands and plains and is affected by spells that affect either. Tap to add either o\nU or o\nW to your mana pool.",
             "colours": [],
@@ -8974,7 +8974,7 @@
         },
         {
             "id": "48d3a108-3274-5407-b6fd-ffc0112fb9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e91ce41-053e-4203-8860-49cbf854cc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e91ce41-053e-4203-8860-49cbf854cc18.jpg?1",
             "name": "Underground Sea",
             "text": "Counts as both swamp and islands and is affected by spells that affect either. Tap to add either o\nB or o\nU to your mana pool.",
             "colours": [],
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "70b18ac5-0a70-58a3-af92-d5709be0c014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0324641d-af55-4c53-b4dc-c8262e967da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0324641d-af55-4c53-b4dc-c8262e967da5.jpg?1",
             "name": "Volcanic Island",
             "text": "Counts as both islands and mountains and is affected by spells that affect either. Tap to add either o\nU or o\nR to your mana pool.",
             "colours": [],
@@ -9040,7 +9040,7 @@
         },
         {
             "id": "119abc5e-4dcb-56ae-807d-fda05bc1f5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7331b03-be66-419c-94bc-ed494c042ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7331b03-be66-419c-94bc-ed494c042ea3.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "92b7e982-790c-5407-853a-9e1d3f8b3b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff493a-6336-416e-af5e-1eb6d10c080e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ff493a-6336-416e-af5e-1eb6d10c080e.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9112,7 +9112,7 @@
         },
         {
             "id": "0350483c-f9ac-5692-8238-ff5e39c0c1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e2b0ff-8fdf-4db0-85c0-c1010bacd36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e2b0ff-8fdf-4db0-85c0-c1010bacd36b.jpg?1",
             "name": "Plains",
             "text": "Tap to add o\nW to your mana pool.",
             "colours": [],
@@ -9148,7 +9148,7 @@
         },
         {
             "id": "60d23779-cb0d-5236-a94b-218299479a1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff33e91-8e52-43f2-b8ae-603b456b08fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff33e91-8e52-43f2-b8ae-603b456b08fc.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9184,7 +9184,7 @@
         },
         {
             "id": "2922a8a8-f3dc-554f-ae1e-d5e77f8bf5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c5cf64-9844-4b5b-8e6b-b97c50cce053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c5cf64-9844-4b5b-8e6b-b97c50cce053.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "89e18bbf-c8e0-5d67-9eee-c8193e9c4fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a612c4-b4ac-4dd2-a06e-92516599fafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a612c4-b4ac-4dd2-a06e-92516599fafd.jpg?1",
             "name": "Island",
             "text": "Tap to add o\nU to your mana pool.",
             "colours": [],
@@ -9256,7 +9256,7 @@
         },
         {
             "id": "12a742ea-5fbf-504c-a9c5-3c0c4c2b7496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1309a80-a761-4b80-8cf1-1a8b83190511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1309a80-a761-4b80-8cf1-1a8b83190511.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9292,7 +9292,7 @@
         },
         {
             "id": "300bd941-b06e-5a41-bcf3-d34f81469353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ad2444-9985-423c-ad36-387218866409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ad2444-9985-423c-ad36-387218866409.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "c6dfe056-bee2-599b-8516-5c044966fa2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3544148-49b2-4320-8e3a-5bab81e0f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3544148-49b2-4320-8e3a-5bab81e0f7fd.jpg?1",
             "name": "Swamp",
             "text": "Tap to add o\nB to your mana pool.",
             "colours": [],
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "477a849f-9eb7-57e0-b97e-580768ebe704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af9c715-8d72-4eae-b412-fc89138ff588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af9c715-8d72-4eae-b412-fc89138ff588.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9400,7 +9400,7 @@
         },
         {
             "id": "a8ff458f-c5db-58b1-8c2d-a4847ec26ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb88a03-7092-4d31-a9f1-4f16e39bc537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb88a03-7092-4d31-a9f1-4f16e39bc537.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "7cdc091f-c424-5b3c-998d-d2752919cf7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ad645-e605-4048-bf4c-d636584f315b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ad645-e605-4048-bf4c-d636584f315b.jpg?1",
             "name": "Mountain",
             "text": "Tap to add o\nR to your mana pool.",
             "colours": [],
@@ -9472,7 +9472,7 @@
         },
         {
             "id": "74d92721-f3a0-544c-8f34-ca0de97a9872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a922eb-49c7-45f0-92bc-671d7a8758f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a922eb-49c7-45f0-92bc-671d7a8758f4.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],
@@ -9508,7 +9508,7 @@
         },
         {
             "id": "e2f95b85-7bf3-5dce-8555-2d9fb844890b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad91fc-50c2-44e0-b88e-2c13610377f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad91fc-50c2-44e0-b88e-2c13610377f9.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "24aa6993-b0c7-5f2d-b99f-d6eefb5b66ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4075bbc-dbad-4a1e-a992-70aed713a459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4075bbc-dbad-4a1e-a992-70aed713a459.jpg?1",
             "name": "Forest",
             "text": "Tap to add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/LEG.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LEG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "11c51522-5e12-50d5-b537-55d0b5e52186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d074af2-8dbd-42d3-87eb-30f6e7d171ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d074af2-8dbd-42d3-87eb-30f6e7d171ff.jpg?1",
             "name": "Akron Legionnaire",
             "text": "None of your non-artifact creatures may attack except Akron Legionnaire.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "04991927-a413-52e1-a21d-03f612231f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2806c7f6-8fdd-4e65-9c71-f2e8b0cdede2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2806c7f6-8fdd-4e65-9c71-f2e8b0cdede2.jpg?1",
             "name": "Alabaster Potion",
             "text": "Target player gains X life or prevents X damage to any one creature or player.",
             "colours": [
@@ -69,7 +69,7 @@
         },
         {
             "id": "d2252942-4e1b-571e-9cdf-ca99e217235a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbce1c55-123c-4a05-bde4-18a1601fcc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbce1c55-123c-4a05-bde4-18a1601fcc5a.jpg?1",
             "name": "Amrou Kithkin",
             "text": "Creatures with power greater than 2 may not be assigned to block Kithkin. Blocker's power may be increased after blocking has been assigned.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "e7f975c2-3ce7-52e2-b1b9-ac8d947c303d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068c263-e5fa-4449-8887-418e9d0a4da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8068c263-e5fa-4449-8887-418e9d0a4da4.jpg?1",
             "name": "Angelic Voices",
             "text": "As long as the only creatures you control are white or artifact creatures all your creatures gain +1/+1.",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "ebf2ac99-ae5d-593a-8dc2-44d1fe9c98ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbd611b-ac97-4516-bad7-cc9ee4ef74f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbd611b-ac97-4516-bad7-cc9ee4ef74f7.jpg?1",
             "name": "Cleanse",
             "text": "All black creatures in play are destroyed.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "7a817107-fa2b-55e0-883b-c3ed2b06ba04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1f578f-fa3b-4447-953b-1490852b6c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1f578f-fa3b-4447-953b-1490852b6c80.jpg?1",
             "name": "Clergy of the Holy Nimbus",
             "text": "When Clergy are destroyed or take lethal damage, unless opponent pays o1 Clergy are regenerated.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "9c21c6f1-98ce-55bd-84dc-2446c9988b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09aee5c-8b9e-46c2-b4d4-508062f8af05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09aee5c-8b9e-46c2-b4d4-508062f8af05.jpg?1",
             "name": "D'Avenant Archer",
             "text": "oc\nT: Archer does 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -233,7 +233,7 @@
         },
         {
             "id": "81e98212-6726-50e8-9d35-95321e19e32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae0ba1-1383-4505-b4e7-4f17dd8f20c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae0ba1-1383-4505-b4e7-4f17dd8f20c5.jpg?1",
             "name": "Divine Intervention",
             "text": "Put two counters on this card. Remove a counter during your upkeep. When you remove the last counter from Divine Intervention, the game is over and considered a draw.",
             "colours": [
@@ -264,7 +264,7 @@
         },
         {
             "id": "4ae8b487-2e2c-5c59-b4d1-14936d6238e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78c2f3-2f40-48ad-9dc4-55d1fa399a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c78c2f3-2f40-48ad-9dc4-55d1fa399a56.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. You gain life points equal to casting cost of artifact.",
             "colours": [
@@ -295,7 +295,7 @@
         },
         {
             "id": "b5249544-5260-5071-b514-ae425010b97c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg?1",
             "name": "Divine Transformation",
             "text": "Target creature gains +3/+3.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "a9bcd66a-ed17-5f3e-9a85-a533266f044a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3651d4-969c-464d-a444-40a640d0c6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3651d4-969c-464d-a444-40a640d0c6ba.jpg?1",
             "name": "Elder Land Wurm",
             "text": "Trample\nWurm cannot attack until it has been assigned as a blocker.",
             "colours": [
@@ -362,7 +362,7 @@
         },
         {
             "id": "4aedad47-507d-5c9f-9305-d278b08f8384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c2880d-b37a-43ea-9fee-cd5a8ed75a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c2880d-b37a-43ea-9fee-cd5a8ed75a7e.jpg?1",
             "name": "Enchanted Being",
             "text": "Any damage dealt to Enchanted Being during combat by creatures with one or more enchantment cards played on them is reduced to 0.",
             "colours": [
@@ -395,7 +395,7 @@
         },
         {
             "id": "80df6eaa-2a40-5af3-bacb-15140dae4f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840c6586-a7a9-4ae8-96be-a995a0693eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840c6586-a7a9-4ae8-96be-a995a0693eb6.jpg?1",
             "name": "Equinox",
             "text": "Tap land enchanted with Equinox to counter a spell that destroys one or more of your lands. This ability is played as an interrupt.",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "86c408a9-7b87-5e8a-9aa3-0418b0128d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc64f19c-5b2b-4697-b4dc-2be9c3790794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc64f19c-5b2b-4697-b4dc-2be9c3790794.jpg?1",
             "name": "Fortified Area",
             "text": "All your walls gain +1/+0 and banding.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "6a28421d-7fcb-54ad-b243-d7dc73587ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1384e5-d140-4074-9548-250af09cb413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1384e5-d140-4074-9548-250af09cb413.jpg?1",
             "name": "Glyph of Life",
             "text": "Damage done to target wall by attacking creatures is added to your life point total.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "c45b65e6-87bc-55c6-badd-bcdd0a6bbbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a8653-1538-4f78-a3d3-a900a4d9499b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879a8653-1538-4f78-a3d3-a900a4d9499b.jpg?1",
             "name": "Great Defender",
             "text": "Target creature gains +0/+X until end of turn where X is the creature's casting cost.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "6050f22d-866d-5883-a3bd-665b6807c1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd860a1d-aa17-4579-b9b1-d101d2416387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd860a1d-aa17-4579-b9b1-d101d2416387.jpg?1",
             "name": "Great Wall",
             "text": "Creatures with plainswalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "8e2af06e-53c7-5f1c-ae21-a5f42e923408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e236816-0c49-4b48-b18b-03add5a80d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e236816-0c49-4b48-b18b-03add5a80d72.jpg?1",
             "name": "Greater Realm of Preservation",
             "text": "o1oo\nW Prevents all damage against you from one red or black source. If a source does damage to you more than once in a turn, you must pay o1o\nW each time you want to prevent the damage.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "332a5758-f8ef-5e2f-8f8d-b7dee65083c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461d7c11-3a7d-42c2-bb6b-0a43779e6842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461d7c11-3a7d-42c2-bb6b-0a43779e6842.jpg?1",
             "name": "Heaven's Gate",
             "text": "Changes the color of one or more target creatures to white until end of turn. You choose which and how many creatures are affected. Costs to tap, maintain, or use a special ability of target creatures remain entirely unchanged.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "185b9748-4858-50ce-9ee3-b59f0d8c8a55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c95a2b-bf44-4ff2-9c6a-916773346edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c95a2b-bf44-4ff2-9c6a-916773346edd.jpg?1",
             "name": "Holy Day",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is assigned.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "3140b56e-06fb-5fcc-94e6-7a679cb213a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2a7333-c9ce-4011-b00e-1304e1eec25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2a7333-c9ce-4011-b00e-1304e1eec25e.jpg?1",
             "name": "Indestructible Aura",
             "text": "Any damage dealt to target creature for remainder of turn is reduced to 0.",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "6996ecef-c1fe-525e-b099-2551c2b472c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc60077f-d577-4a6c-a78f-697317024c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc60077f-d577-4a6c-a78f-697317024c40.jpg?1",
             "name": "Infinite Authority",
             "text": "All creatures with toughness 3 or less blocking target creature or blocked by target creature are destroyed at end of combat. At the end of the turn put a +1/+1 counter on the target creature for each creature destroyed in this manner during the turn. Counters remain on creature even if enchantment leaves play.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "54f3030a-a119-5c7f-b79d-c3107e68b04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf9cccd-fe97-4632-a90a-9eeb0d41135e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf9cccd-fe97-4632-a90a-9eeb0d41135e.jpg?1",
             "name": "Ivory Guardians",
             "text": "Protection from red\nAll guardians gain +1/+1 if an opponent controls any red cards.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "13363413-17a7-5ad0-ab90-f1ce00089d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63a69ae-99ce-4d26-88b7-784793c43cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63a69ae-99ce-4d26-88b7-784793c43cd4.jpg?1",
             "name": "Keepers of the Faith",
             "text": "",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "dbef4677-f4c4-5796-bbf3-a32bf2f7cf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0651ad-6901-4f9b-8807-d66e53a4ada8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0651ad-6901-4f9b-8807-d66e53a4ada8.jpg?1",
             "name": "Kismet",
             "text": "All creatures, lands, and artifacts played by opponent come into play tapped.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "5ec3bb47-7a0b-54d8-b38b-4e644ab2ff3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53b20b0-67bc-4587-817b-efbf21cb2512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53b20b0-67bc-4587-817b-efbf21cb2512.jpg?1",
             "name": "Land Tax",
             "text": "During your upkeep, if an opponent controls more land than you, you may search your library and remove up to three basic land cards and put them into your hand. Reshuffle your library afterwards.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "f3de7ac8-b380-580a-84b1-034da548d117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecb1362-9a67-4d4c-8d69-9ac2ebf4d0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecb1362-9a67-4d4c-8d69-9ac2ebf4d0b0.jpg?1",
             "name": "Lifeblood",
             "text": "You gain 1 life point each time one of opponent's mountains becomes tapped.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "14e3f882-a766-5c2e-bdad-08fbfd4f4c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952ba126-0915-47f0-9b6a-a0a6dcd22c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952ba126-0915-47f0-9b6a-a0a6dcd22c6f.jpg?1",
             "name": "Moat",
             "text": "Non-flying creatures cannot attack.",
             "colours": [
@@ -901,7 +901,7 @@
         },
         {
             "id": "7555ce50-d5aa-515c-b08a-7ad4e7188b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85614b3-62a3-4da9-a74a-7ea40fad1b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f85614b3-62a3-4da9-a74a-7ea40fad1b52.jpg?1",
             "name": "Osai Vultures",
             "text": "Flying\nAt the end of any turn in which a creature is placed in the graveyard from play, put a counter on the Vultures. Remove two counters to give Vultures +1/+1 until end of turn.",
             "colours": [
@@ -934,7 +934,7 @@
         },
         {
             "id": "f4179384-5f32-51e1-825c-2d77cd9e0eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef99f07-c987-451a-b18a-2719eea654cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef99f07-c987-451a-b18a-2719eea654cd.jpg?1",
             "name": "Petra Sphinx",
             "text": "oc\nT: Target player names a card and then turns over the top card of his or her library. If it matches the named card, the card is put in the player's hand; otherwise it is put into the graveyard.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "3c540848-d4ca-5441-a098-51a295e39aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb86b2f-116d-4952-b35a-1398341baaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb86b2f-116d-4952-b35a-1398341baaf5.jpg?1",
             "name": "Presence of the Master",
             "text": "While Presence of the Master is in play, any new enchantments cast are countered.",
             "colours": [
@@ -998,7 +998,7 @@
         },
         {
             "id": "cf343112-4a3d-5752-8c7f-34c0b2601cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26e7c9c-e6de-47f4-8394-7e853408f84c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26e7c9c-e6de-47f4-8394-7e853408f84c.jpg?1",
             "name": "Rapid Fire",
             "text": "Play before defense is chosen. Target creature gains first strike until end of turn. If the creature does not already have rampage, then it also gains rampage: 2 until end of turn.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "aa0b0767-5034-52b0-a782-74a1d6a5029f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2e3a8a-b386-474d-b8e9-4c2d56a2b742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2e3a8a-b386-474d-b8e9-4c2d56a2b742.jpg?1",
             "name": "Remove Enchantments",
             "text": "Remove all enchantments you control and remove all enchantment cards played on all permanents you control. If this spell is cast during opponent's attack, also remove all enchantment cards played on attacking creatures. All enchantments you own are returned to your hand; all other enchantments are destroyed.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "3bceac63-f942-586c-a4d8-bfaa525a7baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b463e-9579-4e7b-87c2-342527b91e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96b463e-9579-4e7b-87c2-342527b91e7c.jpg?1",
             "name": "Righteous Avengers",
             "text": "Plainswalk",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "fb98161e-b515-50d8-8d34-bab313bfe2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df608b59-cc07-4e1d-b6d6-f15e69b15b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df608b59-cc07-4e1d-b6d6-f15e69b15b92.jpg?1",
             "name": "Seeker",
             "text": "Target creature cannot be blocked by any creatures except white creatures and artifact creatures.",
             "colours": [
@@ -1127,7 +1127,7 @@
         },
         {
             "id": "13c43247-a5ae-506d-a874-440f3c5e3943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5032bf0-f9c0-4ef0-8ec2-fe7ccea9bdf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5032bf0-f9c0-4ef0-8ec2-fe7ccea9bdf3.jpg?1",
             "name": "Shield Wall",
             "text": "All your creatures gain +0/+2 until end of turn.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "e5cd7252-19f6-51f3-af01-ecc5cb1363b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d35f8-3cf6-4843-9030-0e9a885d836c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2d35f8-3cf6-4843-9030-0e9a885d836c.jpg?1",
             "name": "Spirit Link",
             "text": "For every point of damage target creature does, you gain 1 life.",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "c5ad543a-676d-5b2b-81ba-591d408dab40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654dd1e0-a91d-44ee-af20-c025bf360c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654dd1e0-a91d-44ee-af20-c025bf360c3f.jpg?1",
             "name": "Spiritual Sanctuary",
             "text": "All players with plains under his or her control gains 1 life point during upkeep.",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "5e031eba-cc13-5f54-b3ce-0c003f303dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg?1",
             "name": "Thunder Spirit",
             "text": "First strike, flying.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "733c99cf-d28d-5cbb-8123-10ad1b037af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f649cb5-e19c-453f-b062-4fd452d92257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f649cb5-e19c-453f-b062-4fd452d92257.jpg?1",
             "name": "Tundra Wolves",
             "text": "First strike",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "585e27c4-9f7a-515a-9802-dd31c429c27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d00299-e183-4b3d-b015-18808e7135b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d00299-e183-4b3d-b015-18808e7135b9.jpg?1",
             "name": "Visions",
             "text": "You may look at the top five cards of any library. You may then choose to shuffle that library.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "3ed8ac93-6565-5245-9d01-267ff9593750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664ad588-3002-4f63-93bd-38663171018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664ad588-3002-4f63-93bd-38663171018f.jpg?1",
             "name": "Wall of Caltrops",
             "text": "If Wall of Caltrops and one or more other walls join to block an attacker and no other creatures besides walls block that attacker, Wall of Caltrops gains banding ability until end of turn.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "ef7ec323-2920-5f2b-8d09-7b9a32dde212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5758e82-f901-42b7-b705-0e68ca7ba59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5758e82-f901-42b7-b705-0e68ca7ba59e.jpg?1",
             "name": "Wall of Light",
             "text": "Protection from black",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "e974bf34-a99a-5fee-bc91-9a4e96b21687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba93c50a-2440-4e92-9cba-d97e20b1d29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba93c50a-2440-4e92-9cba-d97e20b1d29c.jpg?1",
             "name": "Acid Rain",
             "text": "Destroys all forests in play.",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "d425d50e-6e80-57d1-a664-c1dcafbb2a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff78eef1-efaa-4a12-bf5d-fec83c14aff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff78eef1-efaa-4a12-bf5d-fec83c14aff8.jpg?1",
             "name": "Anti-Magic Aura",
             "text": "All enchantments on target creature are destroyed. Target creature cannot be further targeted by instants, sorceries, or enchantments.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "b529e9ac-989b-59ca-91c8-70ad8ef2d37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f13a2-0896-4230-8957-6ad1cb2b895b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb5f13a2-0896-4230-8957-6ad1cb2b895b.jpg?1",
             "name": "Azure Drake",
             "text": "Flying",
             "colours": [
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "60f52971-4f40-5d4a-8098-4d8897171339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bc57aa-d4d9-4bd9-ba09-984370c7e23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04bc57aa-d4d9-4bd9-ba09-984370c7e23b.jpg?1",
             "name": "Backfire",
             "text": "For each point of damage done to you from target creature Backfire does one point of damage to target creature's controller.",
             "colours": [
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "b91d537b-803f-57a3-b778-fca2dc594d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8286edd-644b-4135-8dca-af97f3920de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8286edd-644b-4135-8dca-af97f3920de3.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to owner's hand; enchantments on target permanent are destroyed.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "27f3fb1a-d5a2-5409-8cdc-6742404db038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1e7796-fbfb-4976-879f-bb748429d5c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1e7796-fbfb-4976-879f-bb748429d5c7.jpg?1",
             "name": "Brine Hag",
             "text": "On the turn during which Hag is placed in the graveyard, all creatures who dealt damage to Hag that turn become 0/2 creatures. Use counters to mark these creatures.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "20b4c0c7-99a0-5e04-a8b4-9fa63ebd491d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0855a5a8-8c40-4396-9ad1-8fa0fc6a0c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0855a5a8-8c40-4396-9ad1-8fa0fc6a0c59.jpg?1",
             "name": "Devouring Deep",
             "text": "Islandwalk",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "e79bb28c-e531-5cad-bdaa-a3de1ebadc7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07edbbf4-c3d6-4ec1-ae9b-4ae202fb6998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07edbbf4-c3d6-4ec1-ae9b-4ae202fb6998.jpg?1",
             "name": "Dream Coat",
             "text": "Caster may change target creature's color to any other color. This ability is played as an interrupt. Limit of one change per turn. Cost to tap, maintain, or use a special ability of target creature remains entirely unchanged.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "07e8321b-194d-5966-a367-b9012fa01978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc045e-01a8-4f14-a86d-0a67ec35d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc045e-01a8-4f14-a86d-0a67ec35d6b7.jpg?1",
             "name": "Elder Spawn",
             "text": "Elder Spawn cannot be blocked by red creatures. Sacrifice one of your islands during your upkeep or Elder Spawn does 6 damage to you and is buried.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "6cb043bc-c7c3-5fb6-8716-6bab4c55a538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf52f8a0-d027-47f1-bb91-508ef1a74409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf52f8a0-d027-47f1-bb91-508ef1a74409.jpg?1",
             "name": "Enchantment Alteration",
             "text": "Switch target enchantment from one creature to another or from one land to another. The controller of the enchantment does not change. New target of enchantment must be valid or this spell has no effect. Treat this as if the enchantment had just been cast on the new target.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "fbe83fc3-59b1-5f48-8408-afe0c9936fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e69940-bdc8-48ff-a296-540343910adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e69940-bdc8-48ff-a296-540343910adf.jpg?1",
             "name": "Energy Tap",
             "text": "Target untapped creature you control becomes tapped. Add an amount of colorless mana equal to target creature's casting cost to your mana pool.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "d8ff3b14-1714-5e3d-926c-aec8115f5ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63e119-3b1b-4964-a4b9-b10170ff542b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a63e119-3b1b-4964-a4b9-b10170ff542b.jpg?1",
             "name": "Field of Dreams",
             "text": "The top card of each player's library is always face up.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "f19ea71b-d13c-5b2a-99a6-d667d1167fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3cd450-f1cd-416b-9271-37d95815c089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3cd450-f1cd-416b-9271-37d95815c089.jpg?1",
             "name": "Flash Counter",
             "text": "Counters target interrupt or instant spell.",
             "colours": [
@@ -1805,7 +1805,7 @@
         },
         {
             "id": "8382cc1d-37cd-55a2-b30e-498bcf8d7422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae88c06-f28c-4fbc-a28c-5eb203a04722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae88c06-f28c-4fbc-a28c-5eb203a04722.jpg?1",
             "name": "Flash Flood",
             "text": "Destroy target red permanent, or return target mountain to owner's hand. Enchantments on target land are destroyed.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "4d4b0796-90a3-59a2-8c70-bd6eb5218d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e64028-ae96-4950-aa6c-9d347409fad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e64028-ae96-4950-aa6c-9d347409fad3.jpg?1",
             "name": "Force Spike",
             "text": "Target spell is countered unless its caster spends an additional o1.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "4268218f-cbd2-5304-bb65-8369f2dd0764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0266dd4-31da-480b-9a44-4e217f748f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0266dd4-31da-480b-9a44-4e217f748f06.jpg?1",
             "name": "Gaseous Form",
             "text": "Damage done to target creature by creatures it blocks, or that block it, is reduced to 0. Creature deals no damage during combat.",
             "colours": [
@@ -1900,7 +1900,7 @@
         },
         {
             "id": "040b2b91-c7ed-5d58-8dcf-cf464acbe8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee39da13-4b8a-4796-a7c2-aaa11992d573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee39da13-4b8a-4796-a7c2-aaa11992d573.jpg?1",
             "name": "Glyph of Delusion",
             "text": "Put X counters on one target creature that target wall blocked during this turn; X is the power of the blocked creature. Creature does not untap as normal while it has one or more of these counters on it. Remove one counter during creature's controller's upkeep.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "0ddb65ad-b6ff-5b5a-8a17-7cd7a7da484f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733933dd-c871-4f75-8b08-d7c010dddbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/733933dd-c871-4f75-8b08-d7c010dddbe6.jpg?1",
             "name": "In the Eye of Chaos",
             "text": "All instants and interrupts are countered unless their caster pays an additional o\nX, where X is the casting cost of the spell being cast.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "9d1270ef-f7bc-5a39-8b59-d2cdbbdaa9ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d9fde-d7da-4a0e-a337-b63023c6d74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903d9fde-d7da-4a0e-a337-b63023c6d74b.jpg?1",
             "name": "Invoke Prejudice",
             "text": "If opponent casts a Summon spell that does not match the color of one of the creatures under your control, that spell is countered unless the caster pays an additional o\nX where X is the casting cost of the Summon spell.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "b850d43e-465d-5908-bb24-05c0b69305a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d78db-d982-4c28-9308-2d57dc2b947e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48d78db-d982-4c28-9308-2d57dc2b947e.jpg?1",
             "name": "Juxtapose",
             "text": "Target player and caster each choose one of the creatures they control with the highest casting cost. Exchange control of these creatures. Then do the same for artifacts. Juxtapose does not tap or untap these cards. The control of any enchantment cards played on these permanents is unchanged. If one player does not have an artifact or creature do not trade that type of card.",
             "colours": [
@@ -2026,7 +2026,7 @@
         },
         {
             "id": "775ee10b-4795-5857-941e-2d7453474dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c406b25-03f8-4aaa-9ea7-48bf754166b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c406b25-03f8-4aaa-9ea7-48bf754166b7.jpg?1",
             "name": "Land Equilibrium",
             "text": "If your opponent controls at least as much land as you do, he or she must sacrifice a land for each land he or she puts into play.",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "67d70c16-209e-59df-b744-f439187420db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e691adef-3027-4e6a-889f-9f4e2df36a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e691adef-3027-4e6a-889f-9f4e2df36a7c.jpg?1",
             "name": "Mana Drain",
             "text": "Counters target spell. At the beginning of your next main phase, add o\nX to your mana pool, where X is the casting cost of target spell.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "24e91a88-a77c-5c29-bb3a-4b61ceda1c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b659475-c8b7-493d-af63-04f34d8cc3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b659475-c8b7-493d-af63-04f34d8cc3b1.jpg?1",
             "name": "Part Water",
             "text": "X target creatures gain islandwalk until end of turn.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "b23e462a-6cc4-56ff-accd-124ad87bc02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec082062-5394-4340-bc29-0efd2af4b822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec082062-5394-4340-bc29-0efd2af4b822.jpg?1",
             "name": "Psionic Entity",
             "text": "oc\nT: Psionic Entity does 2 damage to any target but does 3 damage to itself.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "a7be223f-e961-5160-8c62-7fa340b64957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1103d4d-b50a-4e2c-b18a-a181bc819881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1103d4d-b50a-4e2c-b18a-a181bc819881.jpg?1",
             "name": "Psychic Purge",
             "text": "Psychic Purge does 1 damage to any target. If a spell cast by opponent or a permanent under opponent's control causes you to discard this card, opponent loses 5 life. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "f160bae7-ee96-5b28-a01c-7d955133d705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d26ddc-ad1e-4a97-85fb-34da685c3142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d26ddc-ad1e-4a97-85fb-34da685c3142.jpg?1",
             "name": "Puppet Master",
             "text": "If target creature is placed in the graveyard, return creature to owner's hand. All enchantments on target creature are destroyed. You may pay o\nUo\nUo\nU to return Puppet Master to its owner's hand if target creature returns to its owner's hand.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "c748b0a1-b117-5fa0-b233-e0edfa4be6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33296718-0625-4422-a65c-b21cf99c52ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33296718-0625-4422-a65c-b21cf99c52ec.jpg?1",
             "name": "Recall",
             "text": "Sacrifice X cards from your hand and then bring X cards from your graveyard to your hand. Then remove Recall from the game.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "c6712ebd-6359-5a58-b7f4-47f44bf8afe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b07dc4-21ad-410b-8f8a-2b034253bfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b07dc4-21ad-410b-8f8a-2b034253bfee.jpg?1",
             "name": "Relic Bind",
             "text": "When target artifact is tapped, the controller of Relic Bind can choose to do 1 damage to any player or give 1 life to any player.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "c8382bad-fdb5-5a74-af52-e40c4899d8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63de147c-2e62-41b9-8ada-93406387f08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63de147c-2e62-41b9-8ada-93406387f08b.jpg?1",
             "name": "Remove Soul",
             "text": "Counter target summon spell.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "822d74e7-3e55-5ca7-be6c-0c96475ae60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c829d83-d5b8-4be7-80f7-55b42f52b309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c829d83-d5b8-4be7-80f7-55b42f52b309.jpg?1",
             "name": "Reset",
             "text": "All your lands untap. Reset can only be played on an opponent's turn after his or her upkeep phase.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "cc48ddb5-c30b-5329-aa86-565d3f93c0c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d1f470-058d-41b7-acaf-4f68431de9ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d1f470-058d-41b7-acaf-4f68431de9ed.jpg?1",
             "name": "Reverberation",
             "text": "Damage from one sorcery spell is redirected to its caster.",
             "colours": [
@@ -2373,7 +2373,7 @@
         },
         {
             "id": "5f2ce379-cb59-5d73-945c-f5390b14f2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d1f02d-533e-4b77-a72a-ff5f91ae0626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d1f02d-533e-4b77-a72a-ff5f91ae0626.jpg?1",
             "name": "Sea Kings' Blessing",
             "text": "Changes the color of one or more target creatures to blue until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or use a special ability of target creature(s) remains entirely unchanged.",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "323b6051-24b8-5388-a7bc-f16cbcebeea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a814f1-7f8d-4c2c-b706-ee0ed5892f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a814f1-7f8d-4c2c-b706-ee0ed5892f7b.jpg?1",
             "name": "Segovian Leviathan",
             "text": "Islandwalk",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "2aed96a7-c2f0-5efa-b9d1-90e5cc65e6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d6fac6-9a23-465f-a813-92e1ed1cd742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6d6fac6-9a23-465f-a813-92e1ed1cd742.jpg?1",
             "name": "Silhouette",
             "text": "Until end of turn, damage done to target creature by spells or effects that target it is reduced to 0.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "2696fc21-8e28-572b-9d9e-4aa42c4b093d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7524fd0d-a675-41d6-bc99-bd3ba336893b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7524fd0d-a675-41d6-bc99-bd3ba336893b.jpg?1",
             "name": "Spectral Cloak",
             "text": "Target creature cannot be the target of instants, sorceries, fast effects, or enchantments unless creature is tapped.",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "5c3cbcc2-d370-5724-be48-950d4fd65da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa920e-b93f-41c2-b505-a9350353be8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa920e-b93f-41c2-b505-a9350353be8b.jpg?1",
             "name": "Telekinesis",
             "text": "Target creature deals no damage during combat this turn. Creature becomes tapped and may not untap as normal during its controller's next two untap phases.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "34ad101e-d0ed-516e-8af6-1f1cf4888f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f86e13-f942-423e-b175-930d768cb811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f86e13-f942-423e-b175-930d768cb811.jpg?1",
             "name": "Teleport",
             "text": "Target creature cannot be blocked until end of turn. Play after attack is declared and before defense is chosen.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "3893def6-fccf-552b-8b46-1be0a97a2a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61510e88-97d0-410a-9431-ebf12990e33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61510e88-97d0-410a-9431-ebf12990e33d.jpg?1",
             "name": "Time Elemental",
             "text": "o2o\nUo\nUoc\nT: Return target permanent to owner's hand. Cannot target permanents with enchantment cards played on them.\nIf Time Elemental blocks or attacks it is destroyed and does 5 damage to controller.",
             "colours": [
@@ -2596,7 +2596,7 @@
         },
         {
             "id": "2a98eff4-6b97-57a8-bbb4-0a8e7f2e7870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf05e5c9-b7e4-4bd8-ab73-b54565710527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf05e5c9-b7e4-4bd8-ab73-b54565710527.jpg?1",
             "name": "Undertow",
             "text": "Creatures with islandwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "16953d03-8753-5e09-a729-6b123b2a2ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fb92c0-bb1e-463a-a6b6-887a5d0cb873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fb92c0-bb1e-463a-a6b6-887a5d0cb873.jpg?1",
             "name": "Venarian Gold",
             "text": "Put X counters on target creature. Target creature becomes tapped when Venarian Gold is cast. Creature does not untap as normal if it has any of these counters on it. Remove one counter during creature's controller's upkeep phase.",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "85bbe0b5-e3a1-5d73-86e8-7c3f23e67c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6c0a27-d410-4ded-a842-70e1656ea21e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6c0a27-d410-4ded-a842-70e1656ea21e.jpg?1",
             "name": "Wall of Vapor",
             "text": "Damage done to Wall of Vapor by creatures it blocks is reduced to 0.",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "bf8a877b-abfd-5fac-9f22-02687976c426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd9af40-b46c-44b4-878e-8eb026c96b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd9af40-b46c-44b4-878e-8eb026c96b51.jpg?1",
             "name": "Wall of Wonder",
             "text": "o2o\nUoo\nU Gain +4/-4 and allow Wall of Wonder to attack this turn.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "b7e8d67c-e2e2-55ee-81d1-1880fcd35af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a173fd-e10c-45f8-a6e5-ad7a747a8050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a173fd-e10c-45f8-a6e5-ad7a747a8050.jpg?1",
             "name": "Zephyr Falcon",
             "text": "Flying\nAttacking does not cause Zephyr Falcon to tap.",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "935da0d0-4fed-5e61-bd8c-cb3850859634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e2cf8-5ecb-485a-92a2-b4e0a7959f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69e2cf8-5ecb-485a-92a2-b4e0a7959f1f.jpg?1",
             "name": "Abomination",
             "text": "All green or white creatures blocking or blocked by Abomination are destroyed at the end of combat.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e9746ea2-4546-5b19-83f6-4b3efb1c32ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18787a2d-6688-47e9-94bc-ccf229df823f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18787a2d-6688-47e9-94bc-ccf229df823f.jpg?1",
             "name": "All Hallow's Eve",
             "text": "Put two counters on this card. Remove a counter during your upkeep. When you remove the last counter from All Hallow's Eve, all players take all creatures from their graveyards and put them directly into play. Treat these creatures as though they were just summoned. You choose what order they come into play.",
             "colours": [
@@ -2823,7 +2823,7 @@
         },
         {
             "id": "86665152-ea0e-5932-a222-4ec1a75d9f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca19b39-4201-463c-bd40-fbffa31c9eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca19b39-4201-463c-bd40-fbffa31c9eda.jpg?1",
             "name": "Blight",
             "text": "If target land becomes tapped, it is destroyed at the end of the turn.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "940ff3f3-7748-5e44-b6e1-613610fa3426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg?1",
             "name": "Carrion Ants",
             "text": "o1: +1/+1 until end of turn.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "89a165f5-7976-5219-87fc-c96e184bd927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb0e884-5bb4-41f3-b04b-6f638357c166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb0e884-5bb4-41f3-b04b-6f638357c166.jpg?1",
             "name": "Chains of Mephistopheles",
             "text": "Every time a player draws a card, that player must first discard a card from his or her hand. If there are no cards in player's hand, take top card from library and place it in the graveyard instead of drawing. This enchantment does not apply to the first card drawn by a player during the draw phase.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "abc5e16b-b289-561b-a8e5-b3bbeb9fae4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc6ac2-19e0-4765-852b-e303a5bb4040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc6ac2-19e0-4765-852b-e303a5bb4040.jpg?1",
             "name": "Cosmic Horror",
             "text": "First strike\nPay o3o\nBo\nBo\nB during your upkeep or Cosmic Horror does 7 damage to you and is destroyed.",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "2fa0d3e0-d0f8-53d7-bee8-77faba54b567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479ccc50-2d72-4adc-901e-fbd4eef2cf92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479ccc50-2d72-4adc-901e-fbd4eef2cf92.jpg?1",
             "name": "Cyclopean Mummy",
             "text": "If Mummy is placed in the graveyard from play, remove it from the game.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "a12b855b-7277-5252-af5b-3b5f89234f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b04dab-45b7-418b-a0f0-bcf35145fc53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b04dab-45b7-418b-a0f0-bcf35145fc53.jpg?1",
             "name": "Darkness",
             "text": "Creatures attack and block as normal, but none deal any damage. All attacking creatures are still tapped. Play any time before attack damage is assigned.",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "47e5daf6-bafc-5978-9014-30fd4f3c34df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec14bc-95e9-47ce-b51e-d5eac9b345fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ec14bc-95e9-47ce-b51e-d5eac9b345fe.jpg?1",
             "name": "Demonic Torment",
             "text": "Target creature deals no damage during combat. Creature cannot attack.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "608d8365-b614-5e57-87e2-73ba15e371f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060f747-f65c-4ee0-923a-76298cb51a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060f747-f65c-4ee0-923a-76298cb51a03.jpg?1",
             "name": "Evil Eye of Orms-by-Gore",
             "text": "None of your creatures can attack except for Evil Eyes. Evil Eye can only be blocked by walls.",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "eb25d39d-7d45-5322-a6b5-82f869fe9b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4174e4-0be8-49b5-8c52-22001790f6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4174e4-0be8-49b5-8c52-22001790f6eb.jpg?1",
             "name": "Fallen Angel",
             "text": "Flying\nSacrifice a creature to give Fallen Angel +2/+1 until end of turn.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "e3c21be2-a20c-5dbb-a77f-b442c7d257cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20275678-3488-43d8-a93b-993e2267ab07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20275678-3488-43d8-a93b-993e2267ab07.jpg?1",
             "name": "Ghosts of the Damned",
             "text": "oc\nT: Target creature gets -1/-0 until end of turn.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "77063398-d2bd-591c-8f7f-3a8594e3d243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a612e5-a680-4c5b-8ce7-432a86240a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a612e5-a680-4c5b-8ce7-432a86240a6c.jpg?1",
             "name": "Giant Slug",
             "text": "o5: During controller's next upkeep Giant Slug gains landwalk ability of controller's choice until end of turn. The type of landwalk chosen must correspond with one of the five basic land types.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "f9e68a21-b3e9-597c-b8e7-52e7caa6fdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332bfce9-052d-42e9-a407-4a1dd59e0f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332bfce9-052d-42e9-a407-4a1dd59e0f2a.jpg?1",
             "name": "Glyph of Doom",
             "text": "All creatures blocked by target wall are destroyed at the end of combat.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "e2547fe0-8576-5524-a0ff-bb0a19ddf997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111a16a2-e875-4756-80db-290f9e8606db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111a16a2-e875-4756-80db-290f9e8606db.jpg?1",
             "name": "Greed",
             "text": "oo\nB Draw an extra card and lose 2 life. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "55819b20-b066-5b0d-8407-8e8243aba632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa37c8-98fa-4984-b09b-cf65ad84e97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1aa37c8-98fa-4984-b09b-cf65ad84e97b.jpg?1",
             "name": "Headless Horseman",
             "text": "",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "dc8de30c-4916-5660-ba09-f55a7e503d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64164d1b-75f4-456e-a717-90ce554dc16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64164d1b-75f4-456e-a717-90ce554dc16c.jpg?1",
             "name": "Hell Swarm",
             "text": "All creatures get -1/-0 until end of turn.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "a9b066dd-028f-5569-99ac-bab5752696cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336b3b8f-d104-4f06-ad4f-c92b8a9038ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336b3b8f-d104-4f06-ad4f-c92b8a9038ca.jpg?1",
             "name": "Hell's Caretaker",
             "text": "oc\nT: During your upkeep sacrifice a creature and take a creature from your graveyard and put it directly into play. Treat this creature as though it were just summoned.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "7760329d-5af4-5f46-9b0d-c26a24873f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362f1fe9-20af-434c-9957-7a1a564d89e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362f1fe9-20af-434c-9957-7a1a564d89e6.jpg?1",
             "name": "Hellfire",
             "text": "All non-black creatures are destroyed. Hellfire does X + 3 damage to you; X is the number of creatures placed in the graveyard.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "f08606fc-ed57-5088-b483-70c14872c38d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68dc2-c048-41ec-b237-c36fdd99c27d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f68dc2-c048-41ec-b237-c36fdd99c27d.jpg?1",
             "name": "Horror of Horrors",
             "text": "Allows caster to sacrifice a swamp to regenerate a target black creature.",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "36ae1e1d-ed0e-5ef0-9583-b808981c5f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12671381-beb7-41b8-9484-97f8aca5c981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12671381-beb7-41b8-9484-97f8aca5c981.jpg?1",
             "name": "Imprison",
             "text": "Pay 1 each time target creature attempts to attack, block, or tap. That action is prevented and the creature becomes tapped. Destroy enchantment if mana is not paid.",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "964c44cd-3763-5a54-ae69-d85bf01944b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5333f-2761-42b8-ae8b-1d360b109daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a5333f-2761-42b8-ae8b-1d360b109daf.jpg?1",
             "name": "Infernal Medusa",
             "text": "All non-wall creatures blocking Medusa are destroyed at the end of combat, as are all creatures blocked by Medusa.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "03a1e3b8-2c6a-571e-9ed8-0479478c56ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c993c74c-a574-423b-81c8-96b0a7a6e529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c993c74c-a574-423b-81c8-96b0a7a6e529.jpg?1",
             "name": "Jovial Evil",
             "text": "Jovial Evil does 2 damage to opponent for each white creature he or she controls.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "7debb295-1e36-5de7-84da-1218fcb95e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baae02e4-7db9-4a7b-a4ee-ecb22fcb77bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baae02e4-7db9-4a7b-a4ee-ecb22fcb77bd.jpg?1",
             "name": "Lesser Werewolf",
             "text": "oo\nB Lesser Werewolf gets -1/-0 until end of turn. Put a -0/-1 counter on target creature that blocks or is blocked by the Werewolf. Use this ability after defense is chosen but before damage is dealt. You may not use this ability to reduce the Lesser Werewolf's power below 0.",
             "colours": [
@@ -3534,7 +3534,7 @@
         },
         {
             "id": "ef2099bc-9fdc-5ece-a15f-19e4e8e963d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601eed5c-436d-425b-a45f-07881ad893c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/601eed5c-436d-425b-a45f-07881ad893c8.jpg?1",
             "name": "Lost Soul",
             "text": "Swampwalk",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "4fe0e29e-e4fa-56e1-9621-97211387b906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg?1",
             "name": "Mold Demon",
             "text": "When Mold Demon is brought into play, controller must sacrifice two swamps or Mold Demon is buried.",
             "colours": [
@@ -3602,7 +3602,7 @@
         },
         {
             "id": "481ea771-cfa8-526f-95d2-602953bcfaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e72f8cb-5bc3-4711-9b7c-a6eea9a0beaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e72f8cb-5bc3-4711-9b7c-a6eea9a0beaf.jpg?1",
             "name": "Nether Void",
             "text": "All spells cast are countered unless their casters pay an additional o3.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "f981bc41-6f91-5bf0-8a05-38aa4bc5eb80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc564f84-0d6e-4e09-a58d-a694d918cf12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc564f84-0d6e-4e09-a58d-a694d918cf12.jpg?1",
             "name": "Pit Scorpion",
             "text": "If Scorpion damages opponent, opponent gets a poison counter. If opponent ever has ten or more poison counters, opponent loses game.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "9bfb49d7-ab44-5d3b-a965-558e13edbcc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2aa9e-af6a-41c6-99a8-ca9335730ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2aa9e-af6a-41c6-99a8-ca9335730ddb.jpg?1",
             "name": "Quagmire",
             "text": "Creatures with swampwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "be893e09-7d98-58a5-9c0a-bf718ac291b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e04a1b9-c561-4e34-86d9-129ea0346631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e04a1b9-c561-4e34-86d9-129ea0346631.jpg?1",
             "name": "Shimian Night Stalker",
             "text": "o\nBoc\nT: Redirect all damage done to you from any one attacking creature to the Shimian Night Stalker.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "193d7287-eeb6-5088-b6d5-b816e739d7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb266-5bd1-4998-ae94-56f0f3354167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30bb266-5bd1-4998-ae94-56f0f3354167.jpg?1",
             "name": "Spirit Shackle",
             "text": "Put a -0/-2 counter on target creature every time it becomes tapped. Counters remain even if enchantment is removed.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "39dd18cc-462e-5fb3-aa74-7a7a47981364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3020304-7a39-411e-b055-3ade72b4bff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3020304-7a39-411e-b055-3ade72b4bff8.jpg?1",
             "name": "Syphon Soul",
             "text": "Syphon Soul does 2 damage to all players except caster. Caster gains life points equal to the amount of damage done by Syphon Soul.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "52dfb274-6e76-53f6-b8cd-d4ba4701b9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f49b3d-7fcb-4169-9298-cdf7a1dbe3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f49b3d-7fcb-4169-9298-cdf7a1dbe3f5.jpg?1",
             "name": "Takklemaggot",
             "text": "Put a 0/-1 counter on target creature during its controller's upkeep. If the creature is placed in the graveyard, its controller chooses a new target for Takklemaggot. If there are no legal targets, Takklemaggot becomes an enchantment and does 1 damage to the controller of the last creature Takklemaggot was on, during his or her upkeep. Takklemaggot does not revert to a creature enchantment even if other creatures are afterwards brought into play.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "5641f5a1-6aef-563d-89dc-47aa6915b423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27d68-3e58-4ade-976d-36381beed451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a27d68-3e58-4ade-976d-36381beed451.jpg?1",
             "name": "The Abyss",
             "text": "All players bury one target non-artifact creature under their control, if they have any, during their upkeep.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "c6b6edda-23ce-5330-933b-94bcfa949fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c45416-a826-42e9-9967-8838158cf16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c45416-a826-42e9-9967-8838158cf16d.jpg?1",
             "name": "The Wretched",
             "text": "At the end of combat take control of all creatures that blocked The Wretched. The Wretched does not tap or untap these creatures. You lose control of these creatures if The Wretched leaves play or if you lose control of The Wretched.",
             "colours": [
@@ -3895,7 +3895,7 @@
         },
         {
             "id": "fd1ea316-80f1-54e5-a33c-ab07336fc096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7177f-1354-4008-aaaa-2c8b823ed5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7177f-1354-4008-aaaa-2c8b823ed5e9.jpg?1",
             "name": "Touch of Darkness",
             "text": "Changes the color of one or more target creatures to black until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or to use a special ability of target creatures remains entirely unchanged.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "8f78bf44-85a3-54a1-a2ad-816974db5af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f7eb2-eadf-46ec-aed4-63152051f3c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f7eb2-eadf-46ec-aed4-63152051f3c1.jpg?1",
             "name": "Transmutation",
             "text": "Until end of turn, target creature's power and toughness are switched. Effects that alter power alter toughness instead, and vice versa.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "13bce7a8-7e65-599b-8a7c-a7a245fca182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8f8d8-eac0-451c-a167-be84667a8e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8f8d8-eac0-451c-a167-be84667a8e3d.jpg?1",
             "name": "Underworld Dreams",
             "text": "Underworld Dreams does one damage to opponent for each card he or she draws.",
             "colours": [
@@ -3988,7 +3988,7 @@
         },
         {
             "id": "1282d553-ff57-571d-8a8f-b71c1975e23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6a6f50-7b86-461e-80a7-e35d0e7cf52f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6a6f50-7b86-461e-80a7-e35d0e7cf52f.jpg?1",
             "name": "Vampire Bats",
             "text": "Flying, oo\nB +1/+0 until end of turn. No more than o\nBo\nB may be spent in this way per turn.",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "e95de950-a9e4-53ad-9c49-35fdee7f463c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7533a72-77d1-40cd-b3a1-7597d566c428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7533a72-77d1-40cd-b3a1-7597d566c428.jpg?1",
             "name": "Walking Dead",
             "text": "oo\nB Regenerates",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "46f5045f-a04c-5652-9d16-55c19c6c4da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a17b74-a9c9-419a-8369-9ab4fec213f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a17b74-a9c9-419a-8369-9ab4fec213f2.jpg?1",
             "name": "Wall of Putrid Flesh",
             "text": "Protection from white\nDamage done to wall by creatures with enchantment cards played on them is reduced to 0.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "c21e45b0-6512-57a1-b481-6d6672726a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb351900-cffd-4d23-b82f-5fb12a4874d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb351900-cffd-4d23-b82f-5fb12a4874d9.jpg?1",
             "name": "Wall of Shadows",
             "text": "Damage Wall of Shadows receives from creatures it blocks is reduced to 0. Effects that target only walls may not target Wall of Shadows.",
             "colours": [
@@ -4120,7 +4120,7 @@
         },
         {
             "id": "3c1cec32-4af2-528a-bdee-3cf3dcf37c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55da1e86-fe18-486a-b510-f941e6f6e378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55da1e86-fe18-486a-b510-f941e6f6e378.jpg?1",
             "name": "Wall of Tombstones",
             "text": "At the end of your upkeep, the * below is set to the number of creatures in your graveyard.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "6e860b2d-cfcb-52d0-a851-65563806c15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad402e65-6fac-4005-a2d4-592983df0c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad402e65-6fac-4005-a2d4-592983df0c30.jpg?1",
             "name": "Active Volcano",
             "text": "Destroy target blue permanent or return target island to owner's hand. Enchantments on target land are destroyed.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "ee9d3291-4c9a-50d2-8a99-d1e2106489b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06673800-22a7-4ee3-92fa-7c7cd4865d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06673800-22a7-4ee3-92fa-7c7cd4865d30.jpg?1",
             "name": "Aerathi Berserker",
             "text": "Rampage: 3",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "2b873b8c-164a-508d-a2ee-b830e54b3067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d5b9fe-b66a-48c9-94c4-db783e605f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d5b9fe-b66a-48c9-94c4-db783e605f37.jpg?1",
             "name": "Backdraft",
             "text": "Backdraft does half of the damage (rounded down) done by one sorcery cast this turn to the caster of the sorcery.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "d2170d22-5ed7-54ea-ad7f-3276510e4526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f885d776-2953-4ed4-b63f-91dc2b42783b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f885d776-2953-4ed4-b63f-91dc2b42783b.jpg?1",
             "name": "Beasts of Bogardan",
             "text": "Protection from red\nGains +1/+1 if an opponent controls any white cards.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "560a9204-7473-5fb6-ac58-744d927fa26e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921011ff-1696-4575-9198-abe993a0ee7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921011ff-1696-4575-9198-abe993a0ee7a.jpg?1",
             "name": "Blazing Effigy",
             "text": "When placed in the graveyard from play, Effigy does 3 damage to target creature. If an Effigy is damaged by another Effigy in this manner and is placed in the graveyard that turn, it deals the amount of damage received from the other Effigy in addition to its normal 3.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "b8c56ee1-097d-5fc1-95ea-2315fc1ed017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf1a9c-8b94-4ee7-92db-65b531149990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf1a9c-8b94-4ee7-92db-65b531149990.jpg?1",
             "name": "Blood Lust",
             "text": "Target creatures gain +4/-4 until end of turn. If this reduces creature's toughness below 1, creature's toughness is 1.",
             "colours": [
@@ -4346,7 +4346,7 @@
         },
         {
             "id": "efb2e80d-0ee3-5ac1-9722-eb30ffe8c4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f7479-b3a0-4c27-9602-78babb8d2e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209f7479-b3a0-4c27-9602-78babb8d2e99.jpg?1",
             "name": "Caverns of Despair",
             "text": "All players may attack with no more than two creatures each turn and block with no more than two creatures each turn.",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "d6da3fe9-2974-592b-9920-1e9a607fca2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5883762-ca0a-4932-8d2a-41a45796a5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5883762-ca0a-4932-8d2a-41a45796a5f8.jpg?1",
             "name": "Chain Lightning",
             "text": "Chain Lightning does 3 damage to one target. Each time Chain Lightning does damage, the target or target's controller may then pay o\nRo\nR to have Chain Lightning do 3 damage to any target of that player's choice.",
             "colours": [
@@ -4410,7 +4410,7 @@
         },
         {
             "id": "0f399135-929d-50d7-8cac-4dd4596cf367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432d6ae-a17f-484b-ad55-4b4b6674ba8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432d6ae-a17f-484b-ad55-4b4b6674ba8d.jpg?1",
             "name": "Crevasse",
             "text": "Creatures with mountainwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "cb095146-6d10-53f9-981c-efa45e0ef8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg?1",
             "name": "Crimson Kobolds",
             "text": "This card is a red spell when cast and Kobolds are a red creature.",
             "colours": [
@@ -4474,7 +4474,7 @@
         },
         {
             "id": "e5f8703a-76b4-5a88-ad63-ced142387262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f73f9c-1c4e-4343-bfa0-cc5c4a7a562e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f73f9c-1c4e-4343-bfa0-cc5c4a7a562e.jpg?1",
             "name": "Crimson Manticore",
             "text": "Flying\no\nRoc\nT: Manticore does 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "c3a321a6-4bbe-502d-be48-87241c47aa8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6b119-7db4-49dd-aaa4-044b8c133f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af6b119-7db4-49dd-aaa4-044b8c133f13.jpg?1",
             "name": "Crookshank Kobolds",
             "text": "This card is a red spell when cast and Kobolds are a red creature.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "32559338-0de7-5357-80e4-ef1a33ccdfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09a6b9b-eb0e-475d-8558-08e347412790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09a6b9b-eb0e-475d-8558-08e347412790.jpg?1",
             "name": "Disharmony",
             "text": "Target attacking creature comes under your control untapped. Return to former controller at end of turn. This creature is no longer considered to have attacked. Play before defense is chosen.",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "7202b9a9-0b78-5fc3-bca2-4756c1cbda8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a50f72-9524-4440-9380-9d3e0b693351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a50f72-9524-4440-9380-9d3e0b693351.jpg?1",
             "name": "Dwarven Song",
             "text": "Changes the color of one or more target creatures to red until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or use a special ability of target creatures remains entirely unchanged.",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "7b3ed14e-1e89-57be-aafa-2b944e040d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cdc38e-1d96-4de2-98e2-713f5d4d2180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cdc38e-1d96-4de2-98e2-713f5d4d2180.jpg?1",
             "name": "Eternal Warrior",
             "text": "Attacking does not tap target creature.",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "12f9e555-70e8-5646-8bf9-db3e8f559f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b9983e-20d4-4d12-9e2c-ec6d9a345787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b9983e-20d4-4d12-9e2c-ec6d9a345787.jpg?1",
             "name": "Falling Star",
             "text": "Flip Star onto the playing area from a height of at least one foot. Star must turn at least 360 degrees or it has no effect. When Falling Star lands, Falling Star does 3 damage to each creature that it touches. Any creatures damaged by Falling Star that are not destroyed become tapped.",
             "colours": [
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "5c13c76b-bcf4-5773-ad92-35ccb23fe283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b265bc-a94d-403b-8232-8fdfa0f8d9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b265bc-a94d-403b-8232-8fdfa0f8d9d5.jpg?1",
             "name": "Feint",
             "text": "All creatures blocking target attacking creature become tapped. Target attacking creature and all creatures blocking it deal no damage during combat.",
             "colours": [
@@ -4697,7 +4697,7 @@
         },
         {
             "id": "2c29490f-d8ed-5291-8685-67e1dc4101f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3247a7dd-f48c-4cb4-8475-4864acccef7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3247a7dd-f48c-4cb4-8475-4864acccef7a.jpg?1",
             "name": "Firestorm Phoenix",
             "text": "Flying\nIf Phoenix is placed in the graveyard from play, return it to owner's hand instead. It may not be summoned again until owner's next turn.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "3a02b4e7-ec81-5e0b-98ae-192bf2246b34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955d54f-7b37-4e43-8183-51677fb1ee11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955d54f-7b37-4e43-8183-51677fb1ee11.jpg?1",
             "name": "Frost Giant",
             "text": "Rampage: 2",
             "colours": [
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "8af2099b-9fb0-54d6-95ab-acc85ac16381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86190bb-1f41-4128-b9fb-dfb1d178359d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86190bb-1f41-4128-b9fb-dfb1d178359d.jpg?1",
             "name": "Giant Strength",
             "text": "Target creature gains +2/+2",
             "colours": [
@@ -4796,7 +4796,7 @@
         },
         {
             "id": "f1cbd9eb-c6d3-5248-841c-7077d0ee2e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9c153c-9224-491b-bc84-8a9f0a83ee5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9c153c-9224-491b-bc84-8a9f0a83ee5a.jpg?1",
             "name": "Glyph of Destruction",
             "text": "Target wall you control gains +10/+0 when blocking. Any damage dealt to target wall is reduced to zero. Target wall is destroyed at end of turn.",
             "colours": [
@@ -4827,7 +4827,7 @@
         },
         {
             "id": "b4fbe9ef-0763-50db-9be2-cdfda2ac3c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2749332-e99a-4a0c-b3a3-5578b552fa11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2749332-e99a-4a0c-b3a3-5578b552fa11.jpg?1",
             "name": "Gravity Sphere",
             "text": "All creatures lose flying ability.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "39273797-77d8-515a-b95f-0649d38508c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d499a9-fe7c-4a1a-9eb3-a7fd9f85ae08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d499a9-fe7c-4a1a-9eb3-a7fd9f85ae08.jpg?1",
             "name": "Hyperion Blacksmith",
             "text": "oc\nT: Target artifact controlled by opponent becomes tapped or untapped.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "6d8bba47-ceff-5e5b-bdce-0666585af390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3d34fa-398c-4ea0-a392-6690bd3a615c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3d34fa-398c-4ea0-a392-6690bd3a615c.jpg?1",
             "name": "Immolation",
             "text": "Target creature gains +2/-2.",
             "colours": [
@@ -4927,7 +4927,7 @@
         },
         {
             "id": "b52a5ad9-3920-5c32-981b-d207b06a480c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741b14f8-625d-41be-a734-0efe042a6ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741b14f8-625d-41be-a734-0efe042a6ee8.jpg?1",
             "name": "Kobold Drill Sergeant",
             "text": "All your Kobolds gain +0/+1 and Trample.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "bf47889a-892b-560f-8648-fadbc02dd7b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg?1",
             "name": "Kobold Overlord",
             "text": "First strike\nAll your Kobolds gain first strike.",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "c386689e-322e-5a59-b79b-dfbe44e08e7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c63eb-8d4e-4d8b-8637-308459ef036b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c63eb-8d4e-4d8b-8637-308459ef036b.jpg?1",
             "name": "Kobold Taskmaster",
             "text": "All your Kobolds gain +1/+0.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "803ce90e-d290-5101-94bc-f8bc8802e81c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0320d9-7c2a-456a-9159-1b4fae67bfb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0320d9-7c2a-456a-9159-1b4fae67bfb5.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "This card is a red spell when cast and Kobolds are a red creature.",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "6624739f-883b-5194-9f7b-f35ae7713a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3d9b29-948c-4768-b5ea-db2512817c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3d9b29-948c-4768-b5ea-db2512817c30.jpg?1",
             "name": "Land's Edge",
             "text": "Any player may discard a card from hand at any time. If that player discards a land, Land's Edge does 2 damage to target player of the discarding player's choice.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "3253cff5-c72b-51d7-9ea5-4f88a1f2f10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09242f08-3bfc-4082-b32f-703c7fed62a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09242f08-3bfc-4082-b32f-703c7fed62a0.jpg?1",
             "name": "Mountain Yeti",
             "text": "Mountainwalk, protection from white.",
             "colours": [
@@ -5126,7 +5126,7 @@
         },
         {
             "id": "975c6f81-6b63-5562-83fb-18542be410f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e47e1-8639-48f7-94c4-5f9e9666839a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e47e1-8639-48f7-94c4-5f9e9666839a.jpg?1",
             "name": "Primordial Ooze",
             "text": "Must attack each turn if possible. Gains +1/+1 at end of your upkeep. Use counters. Then pay o1 per counter or Ooze deals 1 damage to you for each counter and becomes tapped.",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "a5e53790-5fac-52e2-8db0-30a12dc0e5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2646284b-a94d-4c99-98d4-7becbb473e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2646284b-a94d-4c99-98d4-7becbb473e2b.jpg?1",
             "name": "Pyrotechnics",
             "text": "Pyrotechnics does 4 damage divided any way you choose among any number of targets.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "274a1532-1be8-53f6-9bc5-bf76729e3b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3b33bf-3074-406e-86f3-2a9843cf4862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3b33bf-3074-406e-86f3-2a9843cf4862.jpg?1",
             "name": "Quarum Trench Gnomes",
             "text": "oc\nT: Target plains produces o1 instead of o\nW until end of game. Use counters.",
             "colours": [
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "8ff26340-95f8-5fd7-8d7e-42c1e3720526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec10a51c-d2c3-4d14-9a71-9e59155bf980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec10a51c-d2c3-4d14-9a71-9e59155bf980.jpg?1",
             "name": "Raging Bull",
             "text": "",
             "colours": [
@@ -5256,7 +5256,7 @@
         },
         {
             "id": "fbcadb52-7bc6-53d6-b28c-9ba7cdd1ae2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg?1",
             "name": "Spinal Villain",
             "text": "oc\nT: Destroy target blue creature.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "6df54ceb-8978-5106-8ca7-22a6b1e3da9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0afa6-7003-454d-9b8a-e3328aaf29ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0afa6-7003-454d-9b8a-e3328aaf29ed.jpg?1",
             "name": "Storm World",
             "text": "If any player has less than four cards in hand at the end of his or her upkeep, Storm World does one damage to that player for each card less than four.",
             "colours": [
@@ -5322,7 +5322,7 @@
         },
         {
             "id": "7f277fad-f4b1-5188-b0ad-7a840a0f7001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb562143-fdf0-4eed-83ac-551627c576d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb562143-fdf0-4eed-83ac-551627c576d2.jpg?1",
             "name": "Tempest Efreet",
             "text": "oc\nT: Pick a card at random from opponent's hand and place it in yours. Bury Tempest Efreet in opponent's graveyard. The change in ownership is permanent. Play as an interrupt, but opponent may prevent effect by paying 10 life or conceding game before the card to be switched is chosen\u2014if this is done, Tempest Efreet is buried. Effects that prevent or redirect damage may not be used to counter this loss of life. Remove this card from deck if not playing for ante.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "e6c85ec7-b012-53ea-af29-6b49f5bd0062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ffb265-872f-47b3-974c-92bcbebd557e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ffb265-872f-47b3-974c-92bcbebd557e.jpg?1",
             "name": "The Brute",
             "text": "Target creature gains +1/+0\no\nRo\nRoo\nR Regenerates",
             "colours": [
@@ -5388,7 +5388,7 @@
         },
         {
             "id": "9760f211-9f93-58db-bbfd-aab0f4249173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf53dfe-5d48-4811-b2f5-5a5c1cb462ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf53dfe-5d48-4811-b2f5-5a5c1cb462ca.jpg?1",
             "name": "Wall of Dust",
             "text": "Creatures blocked by Wall of Dust cannot attack during your opponent's next turn. Use counters to mark these creatures.",
             "colours": [
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "7c51edf1-2b5c-5975-a550-3a19431a5b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12e97c1-ca28-432a-8140-3f08bb4485a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12e97c1-ca28-432a-8140-3f08bb4485a3.jpg?1",
             "name": "Wall of Earth",
             "text": "",
             "colours": [
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "30d33f97-5dc3-5fdd-886c-24f8f0448698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38059a8-be69-4cc1-969b-951c610f2f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38059a8-be69-4cc1-969b-951c610f2f11.jpg?1",
             "name": "Wall of Heat",
             "text": "",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "697032a5-757d-59ce-a748-ea046dbf07f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg?1",
             "name": "Wall of Opposition",
             "text": "o1: +1/+0 until end of turn.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "82b7ec4c-2a59-5580-91f0-a132c8b20b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186fd917-8d65-4de5-8546-a32a5f6d3bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186fd917-8d65-4de5-8546-a32a5f6d3bab.jpg?1",
             "name": "Winds of Change",
             "text": "All players shuffle their hands into their libraries, and then draw the same number of cards they originally held.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "5cabc9a2-65cf-55a1-a6a3-e541ff86af21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a161d-ad7b-4e5b-8f2d-d3753cb9daa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640a161d-ad7b-4e5b-8f2d-d3753cb9daa3.jpg?1",
             "name": "Aisling Leprechaun",
             "text": "All creatures that block or are blocked by Leprechaun become green creatures. Use counters to indicate changed creatures. Cost to tap, maintain, or use a special ability of target creature remains entirely unchanged.",
             "colours": [
@@ -5584,7 +5584,7 @@
         },
         {
             "id": "10b3a27c-5ce5-527a-8119-6f63323abcbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095078b0-0f26-442f-9d3b-45e30cdb33c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095078b0-0f26-442f-9d3b-45e30cdb33c4.jpg?1",
             "name": "Arboria",
             "text": "If a player does not cast a spell or put a card into play on his or her turn, no creatures may attack that player until after his or her next turn.",
             "colours": [
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "e7e65bcf-65e4-53bb-b6bc-f5996c842b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f1509e-6ed5-4009-a031-ea84b43cbd1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f1509e-6ed5-4009-a031-ea84b43cbd1b.jpg?1",
             "name": "Avoid Fate",
             "text": "Counters target interrupt or enchantment. Can only counter spells that target a permanent under your control.",
             "colours": [
@@ -5648,7 +5648,7 @@
         },
         {
             "id": "f6fa4651-107d-55b1-8192-cc9974fa1508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df25ffdd-995d-46ae-856b-f6368f9438ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df25ffdd-995d-46ae-856b-f6368f9438ed.jpg?1",
             "name": "Barbary Apes",
             "text": "",
             "colours": [
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "41d3bdcd-910f-591a-9773-328eea425ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2187a64-2823-4f58-ad35-70f8913db2dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2187a64-2823-4f58-ad35-70f8913db2dc.jpg?1",
             "name": "Cat Warriors",
             "text": "Forestwalk",
             "colours": [
@@ -5715,7 +5715,7 @@
         },
         {
             "id": "bdda0e11-80af-59e0-a1d2-b64a14865bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82c87b1-de37-4423-a1a4-533a1d8108b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82c87b1-de37-4423-a1a4-533a1d8108b2.jpg?1",
             "name": "Cocoon",
             "text": "Tap target creature you control and put three counters on it. Target creature does not untap as normal while it has one or more of these counters on it. Remove one counter during your upkeep. During the upkeep phase after the one in which the last counter was removed, Cocoon is destroyed and target creature gains a +1/+1 counter and flying ability.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "a8ad1bb7-3b26-5b41-9832-395216aa27a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcfae4-86c9-4d8a-bcfe-f0a928ec29db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcfae4-86c9-4d8a-bcfe-f0a928ec29db.jpg?1",
             "name": "Concordant Crossroads",
             "text": "Creatures may attack or use abilities that include the oc\nT symbol during the turn they are brought into play.",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "db995c07-c39b-50de-a4b1-94b1530439fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707dadf0-735f-445d-9240-e49660913314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707dadf0-735f-445d-9240-e49660913314.jpg?1",
             "name": "Craw Giant",
             "text": "Trample\nRampage: 2",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "2c021b4c-af1b-5eab-94f4-6354d712c897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d78f0fc-3ab2-46ee-b5a9-55ae97d08c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d78f0fc-3ab2-46ee-b5a9-55ae97d08c1a.jpg?1",
             "name": "Deadfall",
             "text": "Creatures with forestwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "1269f848-d369-5a77-bb62-95b84a6b310c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d41f08b-68fb-45f2-bdc9-488baedc7d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d41f08b-68fb-45f2-bdc9-488baedc7d6f.jpg?1",
             "name": "Durkwood Boars",
             "text": "",
             "colours": [
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "6206691a-ed43-5cfe-9a5c-ba61d250a61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1d349b-b5ab-4b2b-9b39-f8d8f6374aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1d349b-b5ab-4b2b-9b39-f8d8f6374aa5.jpg?1",
             "name": "Elven Riders",
             "text": "Cannot be blocked by any creatures except walls and flying creatures.",
             "colours": [
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "66495412-96c6-5c0b-994e-0dbe9e258e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e81250-52c3-49f6-be43-17c34339e177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e81250-52c3-49f6-be43-17c34339e177.jpg?1",
             "name": "Emerald Dragonfly",
             "text": "Flying, o\nGoo\nG First strike until end of turn.",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "c90d5031-4984-55e9-a90d-cfca2be8a536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520db5fb-d961-45a3-af74-6f054b8be3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520db5fb-d961-45a3-af74-6f054b8be3ab.jpg?1",
             "name": "Eureka",
             "text": "Both players may take any permanent in their hand and put it directly into play. Players take turns playing one card from their hand until neither wants to play more permanents. No other spells or effects of any kind may be used while Eureka is in effect. If a spell has an X in its casting cost, X is 0.",
             "colours": [
@@ -5975,7 +5975,7 @@
         },
         {
             "id": "49eb3c61-9d95-56ac-bcce-12d663d20d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26fa79a-ede8-4c80-98d5-f49696f8104d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26fa79a-ede8-4c80-98d5-f49696f8104d.jpg?1",
             "name": "Fire Sprites",
             "text": "Flying\no\nGoc\nT: Add o\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "9bbbbdc5-04a6-5700-aaed-99d7392d0b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141b9e3-7129-41e5-8b44-d3867e1c7e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141b9e3-7129-41e5-8b44-d3867e1c7e1d.jpg?1",
             "name": "Floral Spuzzem",
             "text": "If Floral Spuzzem attacks an opponent and is not blocked, then Floral Spuzzem may choose to destroy a target artifact under that opponent's control and deal no damage.",
             "colours": [
@@ -6042,7 +6042,7 @@
         },
         {
             "id": "db374883-6b63-5319-baee-e67c445fd63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5fc19-3b10-476f-9a73-e8bf4b5fbec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e5fc19-3b10-476f-9a73-e8bf4b5fbec0.jpg?1",
             "name": "Giant Turtle",
             "text": "Giant Turtle may not attack if it attacked during your last turn.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "3925efd6-5fc4-5982-8b80-b6b6f8b5cded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67e8214-a192-4143-9d5e-d0e254e1bf6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67e8214-a192-4143-9d5e-d0e254e1bf6e.jpg?1",
             "name": "Glyph of Reincarnation",
             "text": "Play after combat is over. All surviving creatures blocked by target wall this turn are buried. For each creature buried in this manner, choose one creature from attacker's graveyard and return it to play under attacker's control. Treat these creatures as if they were just summoned. If there are not enough creatures in attacker's graveyard, all creatures in attacker's graveyard are returned to play.",
             "colours": [
@@ -6106,7 +6106,7 @@
         },
         {
             "id": "90d8f347-eceb-5be6-b5da-7f96ce4c9ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27180bad-9bbc-462b-8832-626dc403a3fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27180bad-9bbc-462b-8832-626dc403a3fd.jpg?1",
             "name": "Hornet Cobra",
             "text": "First strike",
             "colours": [
@@ -6139,7 +6139,7 @@
         },
         {
             "id": "ab6b0028-442e-5e7d-a79b-aa552c313304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2313bb-6f9b-49d6-b069-9f3b77b6e107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2313bb-6f9b-49d6-b069-9f3b77b6e107.jpg?1",
             "name": "Ichneumon Druid",
             "text": "Ichneumon Druid does 4 damage to any opponent casting an instant. This does not apply to the first instant cast by that opponent in each turn.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "b22043e4-cd5b-5435-9e87-6adad2326fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg?1",
             "name": "Killer Bees",
             "text": "Flying\noo\nG +1/+1 until end of turn.",
             "colours": [
@@ -6206,7 +6206,7 @@
         },
         {
             "id": "60e3edb5-58c6-52d3-bc77-35369a6ca58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0341da27-3d77-4959-b7fa-5929b2cc7141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0341da27-3d77-4959-b7fa-5929b2cc7141.jpg?1",
             "name": "Living Plane",
             "text": "Treat all land in play as both lands and 1/1 creatures. They may not be tapped for mana the first turn they are brought into play.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "d8e574d3-7144-594d-b0f1-d457296320de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bf56e-2d74-4e4d-a667-885853979377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e6bf56e-2d74-4e4d-a667-885853979377.jpg?1",
             "name": "Master of the Hunt",
             "text": "o2o\nGoo\nG Put a Wolves of the Hunt token into play. Treat this token as a 1/1 green creature with the ability bands with other Wolves of the Hunt.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "17d02e1f-c7e9-5bd8-9919-654cc86b1ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9903c043-9a7a-4994-b532-136d4c46edfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9903c043-9a7a-4994-b532-136d4c46edfd.jpg?1",
             "name": "Moss Monster",
             "text": "",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "a939cedb-3624-5a8d-b6fc-d05f79b5aa52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg?1",
             "name": "Pixie Queen",
             "text": "Flying\no\nGo\nGo\nGoc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -6338,7 +6338,7 @@
         },
         {
             "id": "bafbdba4-117c-5028-a2fa-26525658d1d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0370330d-83d9-44d2-a1ed-c4827edc60fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0370330d-83d9-44d2-a1ed-c4827edc60fd.jpg?1",
             "name": "Pradesh Gypsies",
             "text": "o1o\nGoc\nT: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "eb2cd02b-555a-5e0c-8502-9aa48d0f287c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9b9eb8-6367-4ab5-8e00-a9c9e1d69032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9b9eb8-6367-4ab5-8e00-a9c9e1d69032.jpg?1",
             "name": "Rabid Wombat",
             "text": "Wombat gains +2/+2 for each creature enchantment on it. Attacking does not cause Rabid Wombat to tap.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "a4e27505-74b8-5815-806e-8844b7b41d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3ab1a-5714-4b69-bc51-3752312b2d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3ab1a-5714-4b69-bc51-3752312b2d1f.jpg?1",
             "name": "Radjan Spirit",
             "text": "oc\nT: Target creature loses flying ability until end of turn.",
             "colours": [
@@ -6438,7 +6438,7 @@
         },
         {
             "id": "36bf70e3-9a2d-55d5-8a08-2529058a522f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d3ce01-e344-4608-b709-320be3600019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d3ce01-e344-4608-b709-320be3600019.jpg?1",
             "name": "Rebirth",
             "text": "Each player may choose to be healed to 20 life. Any player choosing to be healed antes an additional card from the top of his or her library. Remove this card from your deck before playing if you are not playing for ante.",
             "colours": [
@@ -6469,7 +6469,7 @@
         },
         {
             "id": "f83fe8a1-f522-5808-b045-6935b1b0931e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969c104e-daf4-480d-99a2-dd93c498b48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969c104e-daf4-480d-99a2-dd93c498b48e.jpg?1",
             "name": "Reincarnation",
             "text": "If target creature is placed in graveyard this turn, bring a creature from that graveyard directly into play under the control of the owner of the target creature. Treat this creature as though it were just summoned.",
             "colours": [
@@ -6500,7 +6500,7 @@
         },
         {
             "id": "d8b6aead-97e5-5a87-8a18-31c10359a40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07892b6c-08d2-47b5-8d64-0e4d1bdc3080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07892b6c-08d2-47b5-8d64-0e4d1bdc3080.jpg?1",
             "name": "Revelation",
             "text": "All players play with the cards in their hands face up on the table.",
             "colours": [
@@ -6533,7 +6533,7 @@
         },
         {
             "id": "30abae36-744a-529f-a3f9-f3f32847b70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4974c8-34c5-4290-b325-7586a67f6d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4974c8-34c5-4290-b325-7586a67f6d56.jpg?1",
             "name": "Rust",
             "text": "Counter target artifact effect, which must require an activation cost.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "0118ea0d-4957-58d7-8e6b-fe368578b940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddcc557-871d-425b-b4ee-bc0c9bc717aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddcc557-871d-425b-b4ee-bc0c9bc717aa.jpg?1",
             "name": "Shelkin Brownie",
             "text": "oc\nT: Remove the bands with other ability from target creature until end of turn.",
             "colours": [
@@ -6597,7 +6597,7 @@
         },
         {
             "id": "c8ef7ca0-20ba-595e-9890-a0c11b1c174f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b66d0cc-84d7-41ad-b0e7-74ebf604543f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b66d0cc-84d7-41ad-b0e7-74ebf604543f.jpg?1",
             "name": "Storm Seeker",
             "text": "Storm Seeker does 1 damage to opponent for every card in his or her hand.",
             "colours": [
@@ -6628,7 +6628,7 @@
         },
         {
             "id": "ba419cad-6632-5ac5-8896-5c7615e9e8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d6097-8021-46cd-a8c3-01013245e347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d6097-8021-46cd-a8c3-01013245e347.jpg?1",
             "name": "Subdue",
             "text": "Target creature deals no damage during combat but gains X toughness until end of turn; X is target creature's casting cost.",
             "colours": [
@@ -6659,7 +6659,7 @@
         },
         {
             "id": "9ecb374f-fc0d-54d3-a26b-f590306026a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f486df00-7c4a-4ff0-bb0b-c8b5432ac742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f486df00-7c4a-4ff0-bb0b-c8b5432ac742.jpg?1",
             "name": "Sylvan Library",
             "text": "You may draw two extra cards during your draw phase, then either put two of the cards drawn this turn back on top of your library (in any order), or lose 4 lives per card not replaced. Effects that prevent or redirect damage may not be used to counter this loss of life.",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "483f8346-bb6c-50df-bade-04cb80b9f51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f323c3bb-cece-4035-b1a7-c4817cf7a08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f323c3bb-cece-4035-b1a7-c4817cf7a08c.jpg?1",
             "name": "Sylvan Paradise",
             "text": "Changes the color of one or more target creatures to green until end of turn. You choose which and how many creatures are affected. Cost to tap, maintain, or use a special ability of target creatures remains entirely unchanged.",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "e8c7f3ba-f72f-5cac-86bb-33a3bff58fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254e0403-67d8-4e73-8d89-c901ebeba49f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254e0403-67d8-4e73-8d89-c901ebeba49f.jpg?1",
             "name": "Typhoon",
             "text": "Typhoon does 1 damage to each opponent for each island he or she controls.",
             "colours": [
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "c5d95ac2-9635-542d-b3b7-391b6e77c407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887f22af-8b92-422a-9cd5-f3977674bcdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887f22af-8b92-422a-9cd5-f3977674bcdc.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for any one basic land and put it into play. This does not count towards your one land per turn limit. Reshuffle your library afterwards.",
             "colours": [
@@ -6783,7 +6783,7 @@
         },
         {
             "id": "146d1889-65ce-523a-b6d6-40a58c2fcdbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba294e7-7097-4bc3-b396-72e85dd4f441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba294e7-7097-4bc3-b396-72e85dd4f441.jpg?1",
             "name": "Whirling Dervish",
             "text": "Protection from black\nGains +1/+1 (use counters) at the end of each turn in which it does damage to opponent.",
             "colours": [
@@ -6817,7 +6817,7 @@
         },
         {
             "id": "f6284f28-12a4-5573-86b3-98a9cd570b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8b1f49-550e-405f-b17c-1d94589494ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8b1f49-550e-405f-b17c-1d94589494ad.jpg?1",
             "name": "Willow Satyr",
             "text": "oc\nT: Gain control of target legend. If Willow Satyr becomes untapped, you lose control of this legend; you may choose not to untap Willow Satyr as normal. You also lose control of legend if Willow Satyr leaves play, if you lose control of Willow Satyr, or if the game ends.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "e7ab9874-04dc-577b-ba2a-1d3b2ccb1e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb846366-2105-4999-8af1-a11687f42e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb846366-2105-4999-8af1-a11687f42e17.jpg?1",
             "name": "Winter Blast",
             "text": "X target creatures become tapped. Winter Blast does 2 damage to each target creature that has flying.",
             "colours": [
@@ -6881,7 +6881,7 @@
         },
         {
             "id": "19ad9944-c2e0-5c66-8f2d-7db887f256d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5aee52-095e-4c69-93eb-5adac11ed1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5aee52-095e-4c69-93eb-5adac11ed1fc.jpg?1",
             "name": "Wolverine Pack",
             "text": "Rampage: 2",
             "colours": [
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "013417c9-81f6-58c0-852a-0c5773203b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71122-2951-43eb-8ca8-1cda6d231013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71122-2951-43eb-8ca8-1cda6d231013.jpg?1",
             "name": "Wood Elemental",
             "text": "*s in the lower right-hand corner are set to the number of untapped forests you sacrifice when Wood Elemental is brought into play.",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "72e5915f-cdb3-543f-a3d2-13f7727b0ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60252226-a102-4d88-9b80-42d021b5184d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60252226-a102-4d88-9b80-42d021b5184d.jpg?1",
             "name": "Adun Oakenshield",
             "text": "o\nGo\nRo\nBoc\nT: Select one creature from your graveyard and place it in your hand.",
             "colours": [
@@ -6987,7 +6987,7 @@
         },
         {
             "id": "22c1e09e-8fd3-562c-99f0-81e259267b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57264bd9-94f6-4d4d-baff-2b2900585635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57264bd9-94f6-4d4d-baff-2b2900585635.jpg?1",
             "name": "Angus Mackenzie",
             "text": "o\nWo\nUo\nGoc\nT: Creatures attack and block as normal, but none deal any damage during combat. All attacking creatures are still tapped. Use this ability any time before attack damage is dealt.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "68e7f3ce-0a8b-57c7-8f0d-3ba5736f9002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbc62-ceb5-4540-ae38-901e5deafc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbc62-ceb5-4540-ae38-901e5deafc75.jpg?1",
             "name": "Arcades Sabboth",
             "text": "Flying\noo\nW +0/+1 until end of turn.\nYour untapped creatures gain +0/+2. Attacking creatures do not get this bonus. Pay o\nWo\nGo\nU during your upkeep or Arcades Sabboth is buried.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "d8cac55c-ed33-556a-be60-44cfd5d9d811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce83cf-965b-4e45-8efb-63f814df7a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acce83cf-965b-4e45-8efb-63f814df7a35.jpg?1",
             "name": "Axelrod Gunnarson",
             "text": "Trample\nEach time a creature is placed in the graveyard during a turn in which Axelrod damaged it, you gain 1 life and Axelrod does 1 damage to target player.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "9d577d2e-a5ce-5309-9183-57dfd2b173da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bd3d4b-d01a-475d-bf3b-cf96f43bc9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bd3d4b-d01a-475d-bf3b-cf96f43bc9ef.jpg?1",
             "name": "Ayesha Tanaka",
             "text": "Banding\noc\nT: Artifact effect which requires an activation cost is countered unless its controller spends o\nW. This ability is played as an interrupt.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "c640a280-c135-5f08-935c-5e163bca7b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea52228-f8ad-4623-9e05-f162473bfc03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea52228-f8ad-4623-9e05-f162473bfc03.jpg?1",
             "name": "Barktooth Warbeard",
             "text": "",
             "colours": [
@@ -7180,7 +7180,7 @@
         },
         {
             "id": "2753bbff-d5e7-5dd8-9bbb-dc85f3d51412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a42691-98bb-4234-9b56-085e6677f3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a42691-98bb-4234-9b56-085e6677f3e4.jpg?1",
             "name": "Bartel Runeaxe",
             "text": "Bartel Runeaxe cannot be the target of enchant creature spells. Attacking does not cause Bartel Runeaxe to tap.",
             "colours": [
@@ -7220,7 +7220,7 @@
         },
         {
             "id": "8d74bc45-aca9-5f99-9ce0-d386f8e0f495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ae30e8-2dcd-46b8-925b-cc24e11fb95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ae30e8-2dcd-46b8-925b-cc24e11fb95d.jpg?1",
             "name": "Boris Devilboon",
             "text": "o2o\nBo\nRoc\nT: Put a minor demon token into play. Treat this token as a 1/1 red and black creature.",
             "colours": [
@@ -7258,7 +7258,7 @@
         },
         {
             "id": "43b3744b-1cf9-5f0e-99a5-78656a03666a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd7d7e1-f928-4429-9a59-ba0590a78e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd7d7e1-f928-4429-9a59-ba0590a78e98.jpg?1",
             "name": "Chromium",
             "text": "Flying, Rampage: 2\nPay o\nBo\nUo\nW during your upkeep or Chromium is buried.",
             "colours": [
@@ -7298,7 +7298,7 @@
         },
         {
             "id": "d8ec196f-b7bc-551e-85b8-6c40ba331128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd1278-1486-4516-8846-007ce1985ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd1278-1486-4516-8846-007ce1985ee9.jpg?1",
             "name": "Dakkon Blackblade",
             "text": "The *s below equal the number of lands you control.",
             "colours": [
@@ -7338,7 +7338,7 @@
         },
         {
             "id": "ec4b1732-0447-5073-8a0a-ea0f4446fa7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4ce350-b6ed-4e0e-8c70-efc6e5f18a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4ce350-b6ed-4e0e-8c70-efc6e5f18a5d.jpg?1",
             "name": "Gabriel Angelfire",
             "text": "During your upkeep, Gabriel gains one of the following abilities until your next upkeep: flying, first strike, trample, or rampage: 3.",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "eae8f11c-49b5-5412-8a36-370c8765bc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ef316b-dd22-40d1-82e8-8890976684c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ef316b-dd22-40d1-82e8-8890976684c0.jpg?1",
             "name": "Gosta Dirk",
             "text": "First strike\nCreatures with islandwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "90c67a70-5fb0-5036-b95c-97bce453d37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d70b6-a88c-49f4-9415-19919c4468ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473d70b6-a88c-49f4-9415-19919c4468ae.jpg?1",
             "name": "Gwendlyn Di Corci",
             "text": "oc\nT: Target player discards one card from his or her hand at random. This power may only be used during your turn.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "6ea8a616-76c5-5f6d-a49d-37db204e9a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e939761-3542-4044-9038-d1d30c6a38fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e939761-3542-4044-9038-d1d30c6a38fc.jpg?1",
             "name": "Halfdane",
             "text": "When Halfdane comes into play he is 3/3. During your upkeep, Halfdane acquires the current power and toughness of target creature other than Halfdane. If there are no legal targets, Halfdane becomes 3/3.",
             "colours": [
@@ -7492,7 +7492,7 @@
         },
         {
             "id": "69cabfcb-ef26-5a95-835a-15ebd8033755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc3a85-c6b9-4fd2-a6a2-d3210708e5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc3a85-c6b9-4fd2-a6a2-d3210708e5ea.jpg?1",
             "name": "Hazezon Tamar",
             "text": "On your next upkeep after Hazezon is put into play, put * token Sand Warriors into play, where * is the number of lands under your control. Treat the Warriors as 1/1 white, green, and red creatures. If Hazezon leaves play, all Sand Warriors are also removed from game.",
             "colours": [
@@ -7532,7 +7532,7 @@
         },
         {
             "id": "bf61d85e-5d45-5be3-b4df-842cef79e21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8e501-6857-4a52-a3b9-2bf0bee5b08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8e501-6857-4a52-a3b9-2bf0bee5b08c.jpg?1",
             "name": "Hunding Gjornersen",
             "text": "Rampage: 1",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "770a46bd-d300-519c-94f3-1d4ad3a49be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5a45b1-169b-468e-9251-424c09cd7f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee5a45b1-169b-468e-9251-424c09cd7f0f.jpg?1",
             "name": "Jacques le Vert",
             "text": "All your green creatures gain +0/+2.",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "eba70b87-1e30-5a0c-8803-63ff5ce07d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6ef678-4ce9-48d6-aa4f-2afd9a1ad724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6ef678-4ce9-48d6-aa4f-2afd9a1ad724.jpg?1",
             "name": "Jasmine Boreal",
             "text": "",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "52c59855-7571-5927-a62f-144fb8aae3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b80124-2b59-425c-93cc-9b032e631c6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b80124-2b59-425c-93cc-9b032e631c6e.jpg?1",
             "name": "Jedit Ojanen",
             "text": "",
             "colours": [
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "1b0fc555-c168-5e10-b82b-af7acecaf55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f841918-813b-4784-ab57-907185b0a355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f841918-813b-4784-ab57-907185b0a355.jpg?1",
             "name": "Jerrard of the Closed Fist",
             "text": "",
             "colours": [
@@ -7723,7 +7723,7 @@
         },
         {
             "id": "c81a5b45-7948-5b34-8667-3d0d9d34bb1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851d5b4-7991-49d4-8a52-bf233f960cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b851d5b4-7991-49d4-8a52-bf233f960cbf.jpg?1",
             "name": "Johan",
             "text": "If Johan does not attack and is not tapped, any of your creatures may attack without tapping.",
             "colours": [
@@ -7763,7 +7763,7 @@
         },
         {
             "id": "c069947b-cb8c-574e-bc8f-04300cfe2cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b1e60d-54dd-41cd-b9a2-00890725a3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b1e60d-54dd-41cd-b9a2-00890725a3df.jpg?1",
             "name": "Kasimir the Lone Wolf",
             "text": "",
             "colours": [
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "4b6b1964-111d-5d61-9ae4-c26ffecc25c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a524a-fdc7-432d-994b-953808528349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4a524a-fdc7-432d-994b-953808528349.jpg?1",
             "name": "Kei Takahashi",
             "text": "oc\nT: Prevent up to 2 damage to one creature.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "c45bc7ec-1f35-5e46-895e-072a4bcf58ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914ed2-9207-4689-9166-11d2f8949fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6914ed2-9207-4689-9166-11d2f8949fdd.jpg?1",
             "name": "Lady Caleria",
             "text": "oc\nT: Lady Caleria does 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "fabe1e0f-3fa0-5e47-a911-420f2f576334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e122e9-ffa3-48dd-94d6-8f2886668e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e122e9-ffa3-48dd-94d6-8f2886668e59.jpg?1",
             "name": "Lady Evangela",
             "text": "o\nBo\nWoc\nT: Target creature does no damage during combat this turn.",
             "colours": [
@@ -7917,7 +7917,7 @@
         },
         {
             "id": "87ac0e4e-1c81-5f07-b5d7-8f2330e28774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2779553-74eb-42ba-97d0-96269f48c269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2779553-74eb-42ba-97d0-96269f48c269.jpg?1",
             "name": "Lady Orca",
             "text": "",
             "colours": [
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "b9e71596-36e7-53db-9410-14afeb6e12a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9211949-66a5-4039-ac6d-3e42b008b58e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9211949-66a5-4039-ac6d-3e42b008b58e.jpg?1",
             "name": "Livonya Silone",
             "text": "First strike, Legendary Land-walk.",
             "colours": [
@@ -7992,7 +7992,7 @@
         },
         {
             "id": "06ea4bd5-292d-52d0-b1ed-57298aa3e444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02aabb-c464-4672-b37b-d5d713ef8939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02aabb-c464-4672-b37b-d5d713ef8939.jpg?1",
             "name": "Lord Magnus",
             "text": "First strike\nCreatures with plainswalk or forestwalk may be blocked as if they did not have either ability.",
             "colours": [
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "c3adc9a3-a3f3-5b47-a3e2-c93669345e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67330004-6720-46d9-9de0-c79230110583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67330004-6720-46d9-9de0-c79230110583.jpg?1",
             "name": "Marhault Elsdragon",
             "text": "Rampage: 1",
             "colours": [
@@ -8068,7 +8068,7 @@
         },
         {
             "id": "f886ce0b-5c9e-576e-80e6-c37b824e3a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f17ce3-711b-4bd9-addf-dd440fa7d2b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f17ce3-711b-4bd9-addf-dd440fa7d2b7.jpg?1",
             "name": "Nebuchadnezzar",
             "text": "o\nXoc\nT: Name a card. Opponent reveals X cards from his or her hand at random, or entire hand if he or she does not have enough cards. Opponent then discards any of those cards that match the one you named. May only use this power during your turn.",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "900f92ee-bc2d-5080-8d8c-eb5a46d520ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729feb73-4581-4f9d-ba47-bece72481b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729feb73-4581-4f9d-ba47-bece72481b86.jpg?1",
             "name": "Nicol Bolas",
             "text": "Flying\nAn opponent damaged by Nicol Bolas must discard entire hand. Ignore this effect if opponent has no cards left in hand. Pay o\nUo\nBo\nR during your upkeep or Nicol Bolas is buried.",
             "colours": [
@@ -8146,7 +8146,7 @@
         },
         {
             "id": "27ea505d-e047-5c3b-9953-7c9ec58d5ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad64874d-ce33-4e0a-bcca-723f129ef415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad64874d-ce33-4e0a-bcca-723f129ef415.jpg?1",
             "name": "Palladia-Mors",
             "text": "Flying, Trample\nPay o\nWo\nGo\nR during your upkeep or Palladia-Mors is buried.",
             "colours": [
@@ -8186,7 +8186,7 @@
         },
         {
             "id": "dca88195-868d-57f1-9639-7c8b2c5fccdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304f9d39-3ea2-4274-b23e-e4eaabbc1c4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304f9d39-3ea2-4274-b23e-e4eaabbc1c4b.jpg?1",
             "name": "Pavel Maliki",
             "text": "o\nBoo\nR +1/+0 until end of turn.",
             "colours": [
@@ -8223,7 +8223,7 @@
         },
         {
             "id": "cb52c789-bf9a-51cf-a059-70fac32417e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dcf48c-2700-4024-807e-9244e4c649ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dcf48c-2700-4024-807e-9244e4c649ac.jpg?1",
             "name": "Princess Lucrezia",
             "text": "oc\nT: Add o\nU to your mana pool.\nThis ability is played as an interrupt.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "28386f0b-271a-5a78-8c29-600d8588cb1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf6a3a3-4a06-4eb7-981a-b70cf05b2473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf6a3a3-4a06-4eb7-981a-b70cf05b2473.jpg?1",
             "name": "Ragnar",
             "text": "o\nWo\nUo\nGoc\nT: Regenerate target creature.",
             "colours": [
@@ -8301,7 +8301,7 @@
         },
         {
             "id": "e769e526-3c66-5b8b-969f-92d98bdf4dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c66c61-aadf-433b-9958-fc9b44b327b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c66c61-aadf-433b-9958-fc9b44b327b9.jpg?1",
             "name": "Ramirez DePietro",
             "text": "First strike",
             "colours": [
@@ -8339,7 +8339,7 @@
         },
         {
             "id": "aa7c2070-91d2-54d7-9e1b-5832ad36f263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079c74e-a39a-40f9-9c7e-9319c0c189c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079c74e-a39a-40f9-9c7e-9319c0c189c6.jpg?1",
             "name": "Ramses Overdark",
             "text": "oc\nT: Destroys a target creature which has an enchantment card played on it.",
             "colours": [
@@ -8377,7 +8377,7 @@
         },
         {
             "id": "e4d22f5c-e825-5e40-ada5-bcdd0b32ded7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503256f8-3aab-49d0-b78b-6502aa29ce52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503256f8-3aab-49d0-b78b-6502aa29ce52.jpg?1",
             "name": "Rasputin Dreamweaver",
             "text": "Put seven counters on Rasputin when brought into play. You may remove a counter to prevent one damage to Rasputin or add o1 to your mana pool. This ability is played as an interrupt. Put one counter on Rasputin during your upkeep if he started the turn untapped. You may not have more than seven of these counters on Rasputin at any time.",
             "colours": [
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "59fcbe91-3831-5410-852c-2a044a34a695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11f90e7-ced1-4d80-8083-99acbf459ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11f90e7-ced1-4d80-8083-99acbf459ad7.jpg?1",
             "name": "Riven Turnbull",
             "text": "oc\nT: Add o\nB to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -8453,7 +8453,7 @@
         },
         {
             "id": "e8483533-37a9-552a-af3c-55b9fcf00caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0891f0-83ce-4eb7-b0a9-cbc8168bafff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0891f0-83ce-4eb7-b0a9-cbc8168bafff.jpg?1",
             "name": "Rohgahh of Kher Keep",
             "text": "All your Kobolds of Kher Keep gain +2/+2. Pay o\nRo\nRo\nR during your upkeep, or Rohgahh and all Kobolds of Kher Keep become tapped and come under opponent's control.",
             "colours": [
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "b063948d-2d92-578a-8000-6f37dcc57425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13e8dc9-8d0f-4a2c-8c0e-be70a3a7dc8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13e8dc9-8d0f-4a2c-8c0e-be70a3a7dc8e.jpg?1",
             "name": "Rubinia Soulsinger",
             "text": "oc\nT: Gain control of target creature. Rubinia does not tap or untap this creature. If Rubinia becomes untapped you lose control of this creature; you may choose not to untap Rubinia as normal during your untap phase. You also lose control of target creature if either Rubinia leaves play or you lose control of Rubinia.",
             "colours": [
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "737c4466-0af8-5090-b9fc-a711c06e1b93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31570ded-f5e3-44c4-b95f-294ac10b2cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31570ded-f5e3-44c4-b95f-294ac10b2cd2.jpg?1",
             "name": "Sir Shandlar of Eberyn",
             "text": "",
             "colours": [
@@ -8567,7 +8567,7 @@
         },
         {
             "id": "42e420b4-efe7-5c42-be15-23ea78138160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c12ee9e-db13-4b4d-a061-b6566f538f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c12ee9e-db13-4b4d-a061-b6566f538f09.jpg?1",
             "name": "Sivitri Scarzam",
             "text": "",
             "colours": [
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "4c1caee9-82b5-5108-b8bc-8f1078cdfdb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20dcb0-5350-40e0-82d3-c8d0186fc9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20dcb0-5350-40e0-82d3-c8d0186fc9d2.jpg?1",
             "name": "Sol'kanar the Swamp King",
             "text": "Swampwalk\nSol'kanar's controller gains 1 life each time a black spell is cast.",
             "colours": [
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "168406bb-37a7-5d7c-b60c-f18dbdb33fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a277775a-6b48-4238-a618-3ae94c4cc85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a277775a-6b48-4238-a618-3ae94c4cc85c.jpg?1",
             "name": "Stangg",
             "text": "When Stangg is brought into play, also put a Stangg Twin token into play. Stangg Twin token is a 3/4 green and red legend. If Stangg leaves play, remove Stangg Twin token from game. If Stangg Twin leaves play, bury Stangg.",
             "colours": [
@@ -8681,7 +8681,7 @@
         },
         {
             "id": "f609cf1c-409c-5393-ac0b-1e8012502304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587075f3-a568-4089-83ca-fe1e473c025d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587075f3-a568-4089-83ca-fe1e473c025d.jpg?1",
             "name": "Sunastian Falconer",
             "text": "oc\nT: Add o2 to your mana pool. This ability is played as an interrupt.",
             "colours": [
@@ -8719,7 +8719,7 @@
         },
         {
             "id": "2396d88c-b597-5de1-92c7-7e0ed7e22db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8384f87b-26c2-45b7-98ef-352c384f205e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8384f87b-26c2-45b7-98ef-352c384f205e.jpg?1",
             "name": "Tetsuo Umezawa",
             "text": "o\nRo\nBo\nBo\nUoc\nT: Destroy target tapped creature or target blocking creature. Tetsuo may not be a target of an enchant creature spell.",
             "colours": [
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "54bf1568-c0d3-5189-80bf-649d3bd1fbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83717eb2-220e-4086-be09-dee9174798b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83717eb2-220e-4086-be09-dee9174798b8.jpg?1",
             "name": "The Lady of the Mountain",
             "text": "",
             "colours": [
@@ -8796,7 +8796,7 @@
         },
         {
             "id": "dee65f5d-98b7-5300-a46f-2e9a4f952853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac56eda-5ed3-4abd-beec-f5063fbf930a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac56eda-5ed3-4abd-beec-f5063fbf930a.jpg?1",
             "name": "Tobias Andrion",
             "text": "",
             "colours": [
@@ -8834,7 +8834,7 @@
         },
         {
             "id": "0634c861-eb9a-5f3a-8df0-3de328232dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a4854-e62c-4be4-a9cc-1e14db4eede9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241a4854-e62c-4be4-a9cc-1e14db4eede9.jpg?1",
             "name": "Tor Wauki",
             "text": "oc\nT: Tor Wauki does 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -8872,7 +8872,7 @@
         },
         {
             "id": "4783f2d0-bb74-5f64-82e0-9edf9e922e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd99522-4a91-4ccd-91bf-5f32a6ac3510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd99522-4a91-4ccd-91bf-5f32a6ac3510.jpg?1",
             "name": "Torsten Von Ursus",
             "text": "",
             "colours": [
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "cda86298-0a05-5618-98c0-94867d36b96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfbcb4d-a9ae-4d76-8dde-7312fbad56b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfbcb4d-a9ae-4d76-8dde-7312fbad56b0.jpg?1",
             "name": "Tuknir Deathlock",
             "text": "Flying\no\nGo\nRoc\nT: Target creature gains +2/+2 until end of turn.",
             "colours": [
@@ -8948,7 +8948,7 @@
         },
         {
             "id": "e13c4418-9042-5e2a-bd2b-fcdc0026a0c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a40f34-fc26-4d05-9c52-6ffbf1766a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a40f34-fc26-4d05-9c52-6ffbf1766a3b.jpg?1",
             "name": "Ur-Drago",
             "text": "First strike\nCreatures with swampwalk may be blocked as if they did not have this ability.",
             "colours": [
@@ -8985,7 +8985,7 @@
         },
         {
             "id": "f4772000-8440-5f63-9505-7897a0b7851c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ea73ec-1325-4437-a23f-dcda1767c713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ea73ec-1325-4437-a23f-dcda1767c713.jpg?1",
             "name": "Vaevictis Asmadi",
             "text": "Flying\noo\nB Gain +1/+0 until end of turn.\noo\nR Gain +1/+0 until end of turn.\noo\nG Gain +1/+0 until end of turn.\nPay o\nBo\nRo\nG during your upkeep or Vaevictis Asmadi is buried.",
             "colours": [
@@ -9025,7 +9025,7 @@
         },
         {
             "id": "dec36047-ba60-5d1c-bd5a-77d78a15f42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6c7d89-32e7-4c3f-ac90-7db3a46eed4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6c7d89-32e7-4c3f-ac90-7db3a46eed4b.jpg?1",
             "name": "Xira Arien",
             "text": "Flying\no\nGo\nRo\nBoc\nT: Target player draws one card.",
             "colours": [
@@ -9065,7 +9065,7 @@
         },
         {
             "id": "af4419d9-7120-5e09-b553-679e34f9b7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d5aae6e-fe20-4363-9589-5a54bcbbb77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d5aae6e-fe20-4363-9589-5a54bcbbb77e.jpg?1",
             "name": "Al-abara's Carpet",
             "text": "o5oc\nT: Prevents all damage done to you by attacking non-flying creatures.",
             "colours": [],
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "4d43c97d-6895-54d5-b5ac-72315abd3135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4395b19-2118-4a09-8932-f9ce9bc54d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4395b19-2118-4a09-8932-f9ce9bc54d6d.jpg?1",
             "name": "Alchor's Tomb",
             "text": "o2oc\nT: Change the color of target permanent you control to a color of your choice. Use counters. Cost to cast, tap, maintain, or use a special ability of card remains unchanged.",
             "colours": [],
@@ -9119,7 +9119,7 @@
         },
         {
             "id": "114fa246-0937-563f-9164-cb14b3ac8e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9337996e-a119-4529-b422-f6d286c78e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9337996e-a119-4529-b422-f6d286c78e3f.jpg?1",
             "name": "Arena of the Ancients",
             "text": "All legends become tapped when Arena comes into play. Legends do not untap as normal during the untap phase.",
             "colours": [],
@@ -9146,7 +9146,7 @@
         },
         {
             "id": "34b56838-266b-561b-9437-094651dab3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c66e64-e357-457d-8302-b3a1fc0c56ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c66e64-e357-457d-8302-b3a1fc0c56ce.jpg?1",
             "name": "Black Mana Battery",
             "text": "o2oc\nT: Put one counter on Black Mana Battery.\noc\nT: Add o\nB to your mana pool. Remove as many counters as you wish. For each counter removed add o\nB to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "f8d363da-a391-5cc7-b9d9-f97bb9f55bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35393661-2c53-46f0-bb33-2390d552b060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35393661-2c53-46f0-bb33-2390d552b060.jpg?1",
             "name": "Blue Mana Battery",
             "text": "o2oc\nT: Put one counter on Blue Mana Battery.\noc\nT: Add o\nU to your mana pool. Remove as many counters as you wish. For each counter removed add o\nU to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9204,7 +9204,7 @@
         },
         {
             "id": "a094a1ae-e4e3-5546-8041-34ca8969dc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936a03a5-73ba-436c-9d49-70e176d118e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936a03a5-73ba-436c-9d49-70e176d118e6.jpg?1",
             "name": "Bronze Horse",
             "text": "Trample\nDamage done to Bronze Horse by spells which target it is reduced to zero as long as you control another creature.",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "0797316a-4523-5a86-840a-232e6bd4096f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f53d3-0a84-4c55-8495-786f0f0783db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700f53d3-0a84-4c55-8495-786f0f0783db.jpg?1",
             "name": "Forethought Amulet",
             "text": "Pay o3 during your upkeep or Forethought Amulet is destroyed. If you receive more than 2 damage from a sorcery or instant source, that damage is reduced to 2.",
             "colours": [],
@@ -9261,7 +9261,7 @@
         },
         {
             "id": "a8a9cc41-362e-5699-adb7-1b3cd6dd2fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8f11b5-3ba8-4913-b76a-fb469a74864d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8f11b5-3ba8-4913-b76a-fb469a74864d.jpg?1",
             "name": "Gauntlets of Chaos",
             "text": "o5: Sacrifice Gauntlets of Chaos. Take control of target land, creature, or artifact. Then give former controller of that permanent control of a target permanent of the same type under your control. You each control these permanents until game ends. Gauntlets of Chaos does not tap or untap these permanents. Enchantments on traded permanents are destroyed.",
             "colours": [],
@@ -9288,7 +9288,7 @@
         },
         {
             "id": "d73792b8-7fc6-596c-b242-cc1cefdc74e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4671fa01-4a9e-4cd9-8154-b0d45e11b702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4671fa01-4a9e-4cd9-8154-b0d45e11b702.jpg?1",
             "name": "Green Mana Battery",
             "text": "o2oc\nT: Put one counter on Green Mana Battery.\noc\nT: Add o\nG to your mana pool. Remove as many counters as you wish. For each counter removed add o\nG to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9317,7 +9317,7 @@
         },
         {
             "id": "8b5f3249-1e52-5aee-a9b1-7de4bb5162d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eff8d9-86de-4f19-bf00-5f20dc1373d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17eff8d9-86de-4f19-bf00-5f20dc1373d4.jpg?1",
             "name": "Horn of Deafening",
             "text": "o2oc\nT: Target creature deals no damage during combat this turn.",
             "colours": [],
@@ -9344,7 +9344,7 @@
         },
         {
             "id": "40bbd54e-1da7-563e-a1f2-83691c57728b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65947312-75c2-4baa-805c-238a154156ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65947312-75c2-4baa-805c-238a154156ef.jpg?1",
             "name": "Knowledge Vault",
             "text": "o2oc\nT: Take a card from your library without looking at it and place it face down under Knowledge Vault. Sacrifice Knowledge Vault to discard entire hand and take the cards under the vault into your hand. If Knowledge Vault leaves play, put all cards under it in your graveyard.",
             "colours": [],
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "84fcd23e-8267-5f1b-bd17-519957053304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558f23c-c2ce-40d0-b894-f8ccbff8f622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558f23c-c2ce-40d0-b894-f8ccbff8f622.jpg?1",
             "name": "Kry Shield",
             "text": "o2oc\nT: Target creature you control deals no damage this turn, but gains +0/+X until end of turn, where X is the casting cost of target creature.",
             "colours": [],
@@ -9398,7 +9398,7 @@
         },
         {
             "id": "6b770bbb-edc8-5c98-b710-1266098ded5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50052f9a-d667-4a96-a9b1-b4169ee495e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50052f9a-d667-4a96-a9b1-b4169ee495e6.jpg?1",
             "name": "Life Chisel",
             "text": "Sacrifice a creature during your upkeep to gain life equal to creature's toughness.",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "fc20170d-4dd8-5121-9810-8448c531b768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99a3abc-e2a3-4eee-8f72-b1b25dcd1d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99a3abc-e2a3-4eee-8f72-b1b25dcd1d0b.jpg?1",
             "name": "Life Matrix",
             "text": "o4oc\nT: During your upkeep, put one counter on target creature. You may remove this counter at any time to regenerate that creature.",
             "colours": [],
@@ -9452,7 +9452,7 @@
         },
         {
             "id": "c3744515-4616-505e-8268-1abdd18b2b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eedc11-0b47-430c-8391-577a2d05c2ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eedc11-0b47-430c-8391-577a2d05c2ae.jpg?1",
             "name": "Mana Matrix",
             "text": "Pay up to o2 less than required whenever casting an instant, interrupt, or enchantment spell.",
             "colours": [],
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "d1e09988-4cab-50e5-a4c5-3043ec0f864d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459b71d7-34c1-43b9-93ff-364f95aa4789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459b71d7-34c1-43b9-93ff-364f95aa4789.jpg?1",
             "name": "Marble Priest",
             "text": "All walls able to block Marble Priest must do so. Walls able to block more than one creature can still do so. If blocking wall is compelled to block more creatures than it is legally able to, defender chooses which of these attacking creatures to block, but must block as many creatures as it legally can. Damage dealt to Marble Priest from walls during combat is reduced to 0.",
             "colours": [],
@@ -9509,7 +9509,7 @@
         },
         {
             "id": "05b8a1d8-1df1-5193-9140-80452edd2789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f05d5e-bb7d-4554-b880-f0c6b4688357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f05d5e-bb7d-4554-b880-f0c6b4688357.jpg?1",
             "name": "Mirror Universe",
             "text": "oc\nT: Sacrifice Mirror Universe during your upkeep, and trade your number of live points with opponent. For example, if you had 2 life points and your opponent had 10, you would now have 10 life points and your opponent would have 2. Effects that prevent or redirect damage may not be used to counter this change of life.",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "7c0e57b8-7b89-5a92-bbe6-8183649fbb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daac2a6b-27c8-4567-9e0c-7b262628d331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daac2a6b-27c8-4567-9e0c-7b262628d331.jpg?1",
             "name": "North Star",
             "text": "o4oc\nT: You may cast one spell this turn by paying its casting cost with any type of mana. For example, o2o\nGo\nG becomes o4. However, the card still retains its original color. This ability is played as an interrupt.",
             "colours": [],
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "7b1ee3de-ed56-50bd-bcaa-2a0a424502d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60e209-aa29-48aa-9128-9bb175403c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60e209-aa29-48aa-9128-9bb175403c0c.jpg?1",
             "name": "Nova Pentacle",
             "text": "o3oc\nT: Redirect damage done to you from one source to target creature of opponent's choice.",
             "colours": [],
@@ -9590,7 +9590,7 @@
         },
         {
             "id": "b98b67d9-2e25-5abd-beb7-5b7ef31b77bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27f0fe-c032-4f61-9f3d-98a6d2e2c426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27f0fe-c032-4f61-9f3d-98a6d2e2c426.jpg?1",
             "name": "Planar Gate",
             "text": "Pay up to o2 less than required whenever casting a summon spell.",
             "colours": [],
@@ -9617,7 +9617,7 @@
         },
         {
             "id": "b423e2f6-c41d-5726-9fbf-5147d9e4bcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cc5d6-70f8-4a3c-92bd-8f49774bdce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cc5d6-70f8-4a3c-92bd-8f49774bdce2.jpg?1",
             "name": "Red Mana Battery",
             "text": "o2oc\nT: Put one counter on Red Mana Battery.\noc\nT: Add o\nR to your mana pool. Remove as many counters as you wish. For each counter removed add o\nR to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "3552fe1e-1997-5e3a-8d31-8bb87fbca661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062cbae-ce5e-43be-9932-c81a0a3622e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c062cbae-ce5e-43be-9932-c81a0a3622e8.jpg?1",
             "name": "Relic Barrier",
             "text": "oc\nT: Target artifact becomes tapped.",
             "colours": [],
@@ -9673,7 +9673,7 @@
         },
         {
             "id": "8a3eefec-4b22-508d-97fc-cbcfe4b58e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61706102-67fd-4167-bd7d-ec6da41db362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61706102-67fd-4167-bd7d-ec6da41db362.jpg?1",
             "name": "Ring of Immortals",
             "text": "o3oc\nT: Counter target interrupt or enchantment. Can only counter spells which target a permanent under your control. This ability is played as an interrupt.",
             "colours": [],
@@ -9700,7 +9700,7 @@
         },
         {
             "id": "b65ad9ed-dee4-5f65-a656-f6d61f1c49a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c970830-95cf-4471-af28-43da635073d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c970830-95cf-4471-af28-43da635073d0.jpg?1",
             "name": "Sentinel",
             "text": "The * in the lower right hand corner is 1 when cast. While blocking, you may choose to change * to equal one plus the power of target creature sentinel blocks this turn. While attacking, you may choose to change * to equal one plus the power of target creature that blocks Sentinel this turn.",
             "colours": [],
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "f88e6347-97f5-5ed7-b353-fd3851c30d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c350c38-6cbb-4b8b-823f-45d6a16568cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c350c38-6cbb-4b8b-823f-45d6a16568cc.jpg?1",
             "name": "Serpent Generator",
             "text": "o4oc\nT: Put a Poison Snake token into play. Treat this token as a 1/1 artifact creature. If this creature damages opponent, opponent gets a poison counter. If opponent ever has ten or more poison counters, opponent loses game.",
             "colours": [],
@@ -9757,7 +9757,7 @@
         },
         {
             "id": "be370790-9f48-5692-86e3-9adcfda47da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37fd4cc-ab5c-4c65-80ff-8f905b31e801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37fd4cc-ab5c-4c65-80ff-8f905b31e801.jpg?1",
             "name": "Sword of the Ages",
             "text": "Sword of the Ages comes into play tapped.\noc\nT: Sacrifice Sword of the Ages and as many creatures as you choose. Sword does the combined power of these creatures in damage to one target. Sacrificed creatures and Sword are then removed from the game entirely.",
             "colours": [],
@@ -9784,7 +9784,7 @@
         },
         {
             "id": "a1d4efdf-f807-5d34-bd04-3c896be47719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3756f7-0d99-4562-b32d-66de18a58fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3756f7-0d99-4562-b32d-66de18a58fdf.jpg?1",
             "name": "Triassic Egg",
             "text": "o3oc\nT: Put one counter on Triassic Egg. If there are at least two such counters, you may sacrifice Triassic Egg to take any creature from your hand or graveyard and put it directly into play. Treat this creature as though it were just summoned.",
             "colours": [],
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "51a7bdb8-9078-5c31-8b28-1045b957f16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0418672d-056e-416d-91b4-8ee6e47201dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0418672d-056e-416d-91b4-8ee6e47201dc.jpg?1",
             "name": "Voodoo Doll",
             "text": "Put one counter on Voodoo Doll during your upkeep. If Voodoo Doll is not tapped at end of your turn, it does X damage to you and is destroyed. X equals the number of counters on Voodoo Doll.\no\nXo\nXoc\nT: Voodoo Doll does X damage to any one target.",
             "colours": [],
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "38eb264d-ca29-5c5e-b067-bbe4a211dc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fbbe41-d21b-4028-905f-054c44d30eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fbbe41-d21b-4028-905f-054c44d30eb2.jpg?1",
             "name": "White Mana Battery",
             "text": "o2oc\nT: Put one counter on White Mana Battery.\noc\nT: Add o\nW to your mana pool. Remove as many counters as you wish. For each counter removed add o\nW to your mana pool. This ability is played as an interrupt.",
             "colours": [],
@@ -9867,7 +9867,7 @@
         },
         {
             "id": "5e61872e-fc24-5a87-a340-00a282a846e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32865e68-5842-4f17-b2ea-4ffa743b511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32865e68-5842-4f17-b2ea-4ffa743b511f.jpg?1",
             "name": "Adventurers' Guildhouse",
             "text": "All your green legends gain bands with other legends.",
             "colours": [],
@@ -9894,7 +9894,7 @@
         },
         {
             "id": "26beca12-5a81-53b9-91a6-6dd2845b3d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65356e6-0ead-49fd-b069-be1ea9b1c105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65356e6-0ead-49fd-b069-be1ea9b1c105.jpg?1",
             "name": "Cathedral of Serra",
             "text": "All your white legends gain bands with other legends.",
             "colours": [],
@@ -9921,7 +9921,7 @@
         },
         {
             "id": "2ae796c6-ab14-5c32-b1c4-19d26558498f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816d30e-1e52-4323-b30e-1688fba23368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2816d30e-1e52-4323-b30e-1688fba23368.jpg?1",
             "name": "Hammerheim",
             "text": "oc\nT: Add o\nR to your mana pool\noc\nT: Remove all landwalking ability from target creature until end of turn.",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "fb2bab3e-27f1-54f9-8f92-89db750eeef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d2422a-bb7d-4cdd-9aac-e5a936a4be3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d2422a-bb7d-4cdd-9aac-e5a936a4be3b.jpg?1",
             "name": "Karakas",
             "text": "oc\nT: Add o\nW to your mana pool\noc\nT: Return target legend to owner's hand; enchantments on target legend are destroyed.",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "f933b066-686b-5be8-9dff-09156878af0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314fd1d7-4bd8-4d95-b7c2-1aa6660ab88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314fd1d7-4bd8-4d95-b7c2-1aa6660ab88a.jpg?1",
             "name": "Mountain Stronghold",
             "text": "All your red legends may band with other legends.",
             "colours": [],
@@ -10010,7 +10010,7 @@
         },
         {
             "id": "6ac3b062-9d5d-5856-b89a-8f264564ad76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79427109-c1f3-476d-a029-0049217237b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79427109-c1f3-476d-a029-0049217237b5.jpg?1",
             "name": "Pendelhaven",
             "text": "oc\nT: Add o\nG to your mana pool\noc\nT: Target 1/1 creature gains +1/+2 until end of turn.",
             "colours": [],
@@ -10041,7 +10041,7 @@
         },
         {
             "id": "eafc027a-1cfc-5945-b209-b4a1b69adbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66641d88-b3f0-4bcd-8d2d-29aa2de69e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66641d88-b3f0-4bcd-8d2d-29aa2de69e30.jpg?1",
             "name": "Seafarer's Quay",
             "text": "All your blue legends gain bands with other legends.",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "5282ac88-2396-52fe-b8f6-736d6061c740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bc9b1d-5818-4d9e-b771-e49af4ff9a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bc9b1d-5818-4d9e-b771-e49af4ff9a5c.jpg?1",
             "name": "The Tabernacle at Pendrell Vale",
             "text": "All creatures now require an upkeep cost of o1 in addition to any other upkeep costs they may have. If the upkeep cost for a creature is not paid, the creature is destroyed.",
             "colours": [],
@@ -10097,7 +10097,7 @@
         },
         {
             "id": "52a98eb6-2120-5352-b1c5-b2607b18c08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43c01b7-443d-4061-a934-6863d230c9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43c01b7-443d-4061-a934-6863d230c9b8.jpg?1",
             "name": "Tolaria",
             "text": "oc\nT: Add o\nU to your mana pool\noc\nT: During upkeep remove the banding or bands with other ability from target creature until end of turn.",
             "colours": [],
@@ -10128,7 +10128,7 @@
         },
         {
             "id": "5782d956-9fb7-58ff-9d0d-969356a054df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de534ff-fb48-4692-bd0f-dd237ca28502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de534ff-fb48-4692-bd0f-dd237ca28502.jpg?1",
             "name": "Unholy Citadel",
             "text": "All your black legends gain bands with other legends.",
             "colours": [],
@@ -10155,7 +10155,7 @@
         },
         {
             "id": "079e2bfa-a3bc-5b4e-ab66-51e592dcb78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a261d0-7678-46f7-9285-d541486567d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a261d0-7678-46f7-9285-d541486567d8.jpg?1",
             "name": "Urborg",
             "text": "oc\nT: Add o\nB to your mana pool\noc\nT: Remove first strike ability or swampwalk ability from target creature until end of turn.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/LGN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LGN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d047cdf7-3205-5261-83ec-80a202ce2748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814245de-6105-43ef-acbf-d12d304b6331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814245de-6105-43ef-acbf-d12d304b6331.jpg?1",
             "name": "Akroma, Angel of Wrath",
             "text": "Flying, first strike, trample, haste, protection from black, protection from red\nAttacking doesn't cause Akroma, Angel of Wrath to tap.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "3f83b84d-9fa6-550e-85bb-6599b721a8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798893df-e720-471d-822d-50284de23efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798893df-e720-471d-822d-50284de23efd.jpg?1",
             "name": "Akroma's Devoted",
             "text": "Attacking doesn't cause Clerics to tap.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "7e90d907-1c9b-5542-a174-c9064c0487e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2fa0a3-e40f-49e4-a4fd-427e7e808afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2fa0a3-e40f-49e4-a4fd-427e7e808afd.jpg?1",
             "name": "Aven Redeemer",
             "text": "Flying\n{T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "a5b97da9-bb84-58ec-a6d8-c86a73a468b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386a7062-6da8-4663-a218-75d894f7c0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386a7062-6da8-4663-a218-75d894f7c0e0.jpg?1",
             "name": "Aven Warhawk",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Bird and/or Soldier card you reveal in your hand.)\nFlying",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "0417d9d5-d5ae-5fb8-ba69-5efbaca7ad95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b1cad7-4e96-4ebe-8c99-4ed9217becf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b1cad7-4e96-4ebe-8c99-4ed9217becf3.jpg?1",
             "name": "Beacon of Destiny",
             "text": "{T}: The next time a source of your choice would deal damage to you this turn, that damage is dealt to Beacon of Destiny instead.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "3c35ffd7-29ae-5b3f-8c4a-eafc2178b35a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4dc1d3-53a1-411b-abf9-f5e4e80edc63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4dc1d3-53a1-411b-abf9-f5e4e80edc63.jpg?1",
             "name": "Celestial Gatekeeper",
             "text": "Flying\nWhen Celestial Gatekeeper is put into a graveyard from play, remove it from the game, then return up to two target Bird and/or Cleric cards from your graveyard to play.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "85de5708-6658-511b-b419-ffe8dc4a2143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65680bda-b999-4c2a-99a8-b03287e00807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65680bda-b999-4c2a-99a8-b03287e00807.jpg?1",
             "name": "Cloudreach Cavalry",
             "text": "Cloudreach Cavalry gets +2/+2 and has flying as long as you control a Bird.",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "5d4390f7-56f4-5dcc-8725-540df590b46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de13fba8-3fee-4ce2-b84d-b518a99eefe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de13fba8-3fee-4ce2-b84d-b518a99eefe0.jpg?1",
             "name": "Daru Mender",
             "text": "Morph {W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Daru Mender is turned face up, regenerate target creature.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "3904d239-d9a6-5cf0-ab53-5e481e9af8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b14a24-c74a-4465-9b36-8f5309e0a333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b14a24-c74a-4465-9b36-8f5309e0a333.jpg?1",
             "name": "Daru Sanctifier",
             "text": "Morph {1}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Daru Sanctifier is turned face up, destroy target enchantment.",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "61da696b-7e69-5c29-be3e-b6b43ee903f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5866a4-f4c0-45bc-9b33-b77387441d34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5866a4-f4c0-45bc-9b33-b77387441d34.jpg?1",
             "name": "Daru Stinger",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Soldier card you reveal in your hand.)\n{T}: Daru Stinger deals damage equal to the number of +1/+1 counters on it to target attacking or blocking creature.",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "d5afbdb3-7bb2-5dc0-aa5d-0a3ad27a0b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b1c88-20a0-479e-91fb-16bb77f699fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236b1c88-20a0-479e-91fb-16bb77f699fe.jpg?1",
             "name": "Defender of the Order",
             "text": "Morph {W}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Defender of the Order is turned face up, creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "9d950aec-8dab-5ef3-9265-464123dfdc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffbae4-7aad-493c-86a0-c6e6425da8fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ffbae4-7aad-493c-86a0-c6e6425da8fd.jpg?1",
             "name": "Deftblade Elite",
             "text": "Provoke (When this attacks, you may have target creature defending player controls untap and block it if able.)\n{1}{W}: Prevent all combat damage that would be dealt to and dealt by Deftblade Elite this turn.",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "81817245-40bd-5a65-b5f5-155150de2e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1346fa14-1d9f-4c6a-887d-d3a93de00743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1346fa14-1d9f-4c6a-887d-d3a93de00743.jpg?1",
             "name": "Essence Sliver",
             "text": "Whenever a Sliver deals damage, its controller gains that much life.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "1d8c017c-a253-532a-b766-e091e4c4ad89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc66291-fdcc-4106-8875-94d2b0a70deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc66291-fdcc-4106-8875-94d2b0a70deb.jpg?1",
             "name": "Gempalm Avenger",
             "text": "Cycling {2}{W} ({2}{W}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Avenger, all Soldiers get +1/+1 and gain first strike until end of turn.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "42e4a16b-b177-5a3c-89ee-285ae7540a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad94e39-0aac-46bb-a7f2-bd88c537cb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad94e39-0aac-46bb-a7f2-bd88c537cb9c.jpg?1",
             "name": "Glowrider",
             "text": "Noncreature spells cost {1} more to play.",
             "colours": [
@@ -528,7 +528,7 @@
         },
         {
             "id": "2d5b72e5-9059-5d9c-9a50-b07d74f6bc44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb518bf0-17ad-4bbf-b922-42ee76ffcbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb518bf0-17ad-4bbf-b922-42ee76ffcbea.jpg?1",
             "name": "Liege of the Axe",
             "text": "Attacking doesn't cause Liege of the Axe to tap.\nMorph {1}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Liege of the Axe is turned face up, untap it.",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "beaf0f12-253b-53a4-bc86-6c60fbd25c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eaaded-b18a-4614-b5b5-b4bb49a2e1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eaaded-b18a-4614-b5b5-b4bb49a2e1b1.jpg?1",
             "name": "Lowland Tracker",
             "text": "First strike\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "166556b7-bcbd-5007-8cc7-b480785ec13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7087cb1e-f2e2-4b75-bacf-bc4153e398e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7087cb1e-f2e2-4b75-bacf-bc4153e398e3.jpg?1",
             "name": "Planar Guide",
             "text": "{3}{W}, Remove Planar Guide from the game: Remove all creatures from the game. At end of turn, return those cards to play under their owners' control.",
             "colours": [
@@ -633,7 +633,7 @@
         },
         {
             "id": "322df5e0-d0f4-58c7-b43a-7af3619e8b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82846d31-4981-4ef1-85c3-703569146a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82846d31-4981-4ef1-85c3-703569146a84.jpg?1",
             "name": "Plated Sliver",
             "text": "All Slivers get +0/+1.",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "949a2212-6695-5ee7-900f-783442803a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66afc4-3d6d-4ce7-acfc-a4ad34aa3e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c66afc4-3d6d-4ce7-acfc-a4ad34aa3e99.jpg?1",
             "name": "Starlight Invoker",
             "text": "{7}{W}: You gain 5 life.",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "9a9eaa8e-aed2-51c4-8117-bce5386bb429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b69d619-c31b-472b-9ae8-d4503704680d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b69d619-c31b-472b-9ae8-d4503704680d.jpg?1",
             "name": "Stoic Champion",
             "text": "Whenever a player cycles a card, Stoic Champion gets +2/+2 until end of turn.",
             "colours": [
@@ -738,7 +738,7 @@
         },
         {
             "id": "02f2ebd1-adb1-5671-a51a-f3663f20a99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5d519a-9f11-4b10-97ad-edccfda639bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5d519a-9f11-4b10-97ad-edccfda639bb.jpg?1",
             "name": "Sunstrike Legionnaire",
             "text": "Sunstrike Legionnaire doesn't untap during your untap step.\nWhenever another creature comes into play, untap Sunstrike Legionnaire.\n{T}: Tap target creature with converted mana cost 3 or less.",
             "colours": [
@@ -773,7 +773,7 @@
         },
         {
             "id": "176bc9ee-496f-5cb3-bb2f-8665816b04f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3d19c-d4c6-4c5c-85eb-11d55959a89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c3d19c-d4c6-4c5c-85eb-11d55959a89c.jpg?1",
             "name": "Swooping Talon",
             "text": "Flying\n{1}: Swooping Talon loses flying until end of turn.\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "780d80a9-8a52-5da7-ac3e-7b1db1c1a279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b463b3e1-e314-4a65-a89e-0712f630b016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b463b3e1-e314-4a65-a89e-0712f630b016.jpg?1",
             "name": "Wall of Hope",
             "text": "(Walls can't attack.)\nWhenever Wall of Hope is dealt damage, you gain that much life.",
             "colours": [
@@ -842,7 +842,7 @@
         },
         {
             "id": "dcf9aae3-2dd0-5a2f-94e5-9b1322d46179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264369a-ab81-4938-9fa6-7c3e069442f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264369a-ab81-4938-9fa6-7c3e069442f4.jpg?1",
             "name": "Ward Sliver",
             "text": "As Ward Sliver comes into play, choose a color.\nAll Slivers have protection from the chosen color.",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "bbfdedc1-2598-5202-bb3e-66ac9e149f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b18b09-b1ff-479d-bd1c-cb8620a34fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b18b09-b1ff-479d-bd1c-cb8620a34fe4.jpg?1",
             "name": "Whipgrass Entangler",
             "text": "{1}{W}: Until end of turn, target creature gains \"This creature can't attack or block unless its controller pays {1} for each Cleric in play. (This cost is paid as attackers or blockers are declared.)\"",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "227ea980-8fd8-5266-adc8-41415ebeeef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9cb8ed-7abb-4e71-b42f-5041dd0c0394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9cb8ed-7abb-4e71-b42f-5041dd0c0394.jpg?1",
             "name": "White Knight",
             "text": "First strike, protection from black",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "d4111022-5cd5-5b1a-b6bb-9b4c2238a7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c45fd87-7b44-4e1a-b30f-41220b69d9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c45fd87-7b44-4e1a-b30f-41220b69d9e6.jpg?1",
             "name": "Windborn Muse",
             "text": "Flying\nCreatures can't attack you unless their controller pays {2} for each creature attacking you. (This cost is paid as attackers are declared.)",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "cf0627e3-ee37-5dd8-9602-72a7b33fa46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd58d164-861d-4c80-ad2f-6283ed82faa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd58d164-861d-4c80-ad2f-6283ed82faa1.jpg?1",
             "name": "Wingbeat Warrior",
             "text": "Flying\nMorph {2}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Wingbeat Warrior is turned face up, target creature gains first strike until end of turn.",
             "colours": [
@@ -1016,7 +1016,7 @@
         },
         {
             "id": "6ff28085-564d-59dc-a768-51a01f947d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ead30e-9f96-4fca-b619-fdc8d1b5e2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ead30e-9f96-4fca-b619-fdc8d1b5e2e0.jpg?1",
             "name": "Aven Envoy",
             "text": "Flying",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "685ddf02-5523-5ff4-b35f-bc13dfcbbc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88528929-4953-452a-b85e-dac15786e094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88528929-4953-452a-b85e-dac15786e094.jpg?1",
             "name": "Cephalid Pathmage",
             "text": "Cephalid Pathmage is unblockable.\n{T}, Sacrifice Cephalid Pathmage: Target creature is unblockable this turn.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "d8fef6b0-8295-5024-b8f0-dfe7c848677c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02a40a4-fa61-4595-810a-3796e0d71507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02a40a4-fa61-4595-810a-3796e0d71507.jpg?1",
             "name": "Chromeshell Crab",
             "text": "Morph {4}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Chromeshell Crab is turned face up, you may exchange control of target creature you control and target creature an opponent controls.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "20d52b3c-730e-56b7-b077-bdbfe88a9677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbda6799-3b55-4714-8305-713e1e198a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbda6799-3b55-4714-8305-713e1e198a15.jpg?1",
             "name": "Covert Operative",
             "text": "Covert Operative is unblockable.",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "f4a05b3d-6951-5926-84ad-4f664565d463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ced7275-3935-4bba-877d-81282bd171fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ced7275-3935-4bba-877d-81282bd171fd.jpg?1",
             "name": "Crookclaw Elder",
             "text": "Flying\nTap two untapped Birds you control: Draw a card.\nTap two untapped Wizards you control: Target creature gains flying until end of turn.",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "fee47ed7-aa28-59c6-b172-00d05d1e3f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2f5dca-e01f-41e3-bb6f-a60162118c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2f5dca-e01f-41e3-bb6f-a60162118c6d.jpg?1",
             "name": "Dermoplasm",
             "text": "Flying\nMorph {2}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Dermoplasm is turned face up, you may put a creature card with morph from your hand into play face up. If you do, return Dermoplasm to its owner's hand.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "dd2d1938-1abe-545f-b1d6-a86751d20194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e36cf11-5dfb-4593-8335-f739b7c7829c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e36cf11-5dfb-4593-8335-f739b7c7829c.jpg?1",
             "name": "Dreamborn Muse",
             "text": "At the beginning of each player's upkeep, that player puts the top X cards from his or her library into his or her graveyard, where X is the number of cards in his or her hand.",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "df3dc7ea-127d-5d69-aa37-da37fd6a4d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63390760-35a7-4b4c-8c68-5c84f90d0c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63390760-35a7-4b4c-8c68-5c84f90d0c58.jpg?1",
             "name": "Echo Tracer",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Echo Tracer is turned face up, return target creature to its owner's hand.",
             "colours": [
@@ -1294,7 +1294,7 @@
         },
         {
             "id": "1cba44ba-6466-55a9-9d82-ef832fd40256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1020538-89c8-4986-9687-78ab326acb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1020538-89c8-4986-9687-78ab326acb3e.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "48d395ec-9777-59a7-bd16-a9bd0b2d7fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bda65b-2e26-4531-9f6a-952df314c8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bda65b-2e26-4531-9f6a-952df314c8f7.jpg?1",
             "name": "Gempalm Sorcerer",
             "text": "Cycling {2}{U} ({2}{U}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Sorcerer, all Wizards gain flying until end of turn.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "ea36f9f2-011d-5239-a37b-83c84d68d908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16184709-f370-40cc-91f2-849a44ac451a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16184709-f370-40cc-91f2-849a44ac451a.jpg?1",
             "name": "Glintwing Invoker",
             "text": "{7}{U}: Glintwing Invoker gets +3/+3 and gains flying until end of turn.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "55fc0d0e-1c46-550e-8c7b-c09c6b7880ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a355c58-cd28-4d2d-9df1-91b4196b01ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a355c58-cd28-4d2d-9df1-91b4196b01ef.jpg?1",
             "name": "Keeneye Aven",
             "text": "Flying\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "cd45e77e-80ea-502a-a647-a53928b0eeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75eef50-b474-44bb-8222-3e473928304a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75eef50-b474-44bb-8222-3e473928304a.jpg?1",
             "name": "Keeper of the Nine Gales",
             "text": "Flying\n{T}, Tap two untapped Birds you control: Return target permanent to its owner's hand.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "e5593a9e-7da1-5622-bb79-56aafbd0235c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce1755-9f4a-4741-b6e5-288595ec494d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ce1755-9f4a-4741-b6e5-288595ec494d.jpg?1",
             "name": "Master of the Veil",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Master of the Veil is turned face up, you may turn target creature with morph face down.",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "8ee62e2e-1e3a-52bf-9a2e-3be262d6f222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1109bdd-a5ce-4e63-adee-54e43a4c4a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1109bdd-a5ce-4e63-adee-54e43a4c4a1e.jpg?1",
             "name": "Merchant of Secrets",
             "text": "When Merchant of Secrets comes into play, draw a card.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "9e84dd67-1d4d-516a-8ef1-e4be5b5b4c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f6c73c-8162-499f-8d16-92f17c0c2bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f6c73c-8162-499f-8d16-92f17c0c2bee.jpg?1",
             "name": "Mistform Seaswift",
             "text": "Flying\n{1}: Mistform Seaswift's type becomes the creature type of your choice until end of turn.\nMorph {1}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "2053371e-6a38-5697-bed7-e84e32dea646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a53c29-6753-4f6b-b4ee-00c1adf7e9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a53c29-6753-4f6b-b4ee-00c1adf7e9c6.jpg?1",
             "name": "Mistform Sliver",
             "text": "All Slivers have \"{1}: This creature's type becomes the creature type of your choice in addition to its other types until end of turn.\"",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "f7964cf4-2d23-5da4-b326-268eac991968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be21c3-9b83-430b-be0a-792de9a680e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be21c3-9b83-430b-be0a-792de9a680e3.jpg?1",
             "name": "Mistform Ultimus",
             "text": "Mistform Ultimus is every creature type (even if this card isn't in play).\nMistform Ultimus may attack as though it weren't a Wall.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "668e3bad-5731-52d6-aac1-9cecf848ce83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5cbfb9-9bd0-4f8b-a444-a480de4b9662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5cbfb9-9bd0-4f8b-a444-a480de4b9662.jpg?1",
             "name": "Mistform Wakecaster",
             "text": "Flying\n{1}: Mistform Wakecaster's type becomes the creature type of your choice until end of turn.\n{2}{U}{U}, {T}: Choose a creature type. The type of each creature you control becomes that type until end of turn.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "a8b6c9d9-c5c9-5144-9d92-69bc5b8a6564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cb3e72-bb64-4b1e-a54b-1fe4fb4ad4c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cb3e72-bb64-4b1e-a54b-1fe4fb4ad4c9.jpg?1",
             "name": "Primoc Escapee",
             "text": "Flying\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "85af368f-a552-5cb8-85e0-f47d6ecb84b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d07de3-b176-4ac7-aaa7-497c06c08b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d07de3-b176-4ac7-aaa7-497c06c08b55.jpg?1",
             "name": "Riptide Director",
             "text": "{2}{U}{U}, {T}: Draw a card for each Wizard you control.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "e05fb82f-de0f-542a-aafa-9574f40ed57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314a802-85d6-4d7b-ae9a-ca64eec652cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314a802-85d6-4d7b-ae9a-ca64eec652cf.jpg?1",
             "name": "Riptide Mangler",
             "text": "{1}{U}: Change Riptide Mangler's power to target creature's power. (It doesn't change back at end of turn.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "22a426df-d521-500c-9e9b-7287163f9366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68c4c2-91b5-4ffe-9dff-a6834038aa94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f68c4c2-91b5-4ffe-9dff-a6834038aa94.jpg?1",
             "name": "Shifting Sliver",
             "text": "Slivers can't be blocked except by Slivers.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "aecf601c-b7c6-5758-861e-bd0742cb3aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf966ff-0fd0-404d-be91-5b0c21035d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf966ff-0fd0-404d-be91-5b0c21035d73.jpg?1",
             "name": "Synapse Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may draw a card.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "1103143b-89f1-5608-8e82-ee23b45a2f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55924a25-e749-48f6-8ef1-1fa8376f96b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55924a25-e749-48f6-8ef1-1fa8376f96b1.jpg?1",
             "name": "Voidmage Apprentice",
             "text": "Morph {2}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Voidmage Apprentice is turned face up, counter target spell.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "02c68aea-ec27-5f67-9b3b-bd4733fc631a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1496d941-88fd-433e-8fae-1218316ef3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1496d941-88fd-433e-8fae-1218316ef3a9.jpg?1",
             "name": "Wall of Deceit",
             "text": "(Walls can't attack.)\n{3}: Turn Wall of Deceit face down.\nMorph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "5eff3001-2c9c-51ae-9711-f0a3aa4ee619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df94a4e-1371-4b75-a557-eeb83c23cf9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df94a4e-1371-4b75-a557-eeb83c23cf9d.jpg?1",
             "name": "Warped Researcher",
             "text": "Whenever a player cycles a card, Warped Researcher gains flying until end of turn and can't be the target of spells or abilities this turn.",
             "colours": [
@@ -1956,7 +1956,7 @@
         },
         {
             "id": "01ff277a-47a4-5612-b00f-7f6c735da1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12172d0e-0c73-4482-9f83-2c23ace9b7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12172d0e-0c73-4482-9f83-2c23ace9b7a0.jpg?1",
             "name": "Weaver of Lies",
             "text": "Morph {4}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Weaver of Lies is turned face up, turn any number of target creatures with morph other than Weaver of Lies face down.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "327e9043-f65e-550f-bf97-d902fd488ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb33b35b-33c9-4d59-9ed6-7ad40ea82cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb33b35b-33c9-4d59-9ed6-7ad40ea82cb0.jpg?1",
             "name": "Willbender",
             "text": "Morph {1}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Willbender is turned face up, change the target of target spell or ability with a single target.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "9a3e4479-ef2c-503a-a417-2e192f3b8c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8f63-daf2-4dbe-bb07-2b246145cdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8f63-daf2-4dbe-bb07-2b246145cdab.jpg?1",
             "name": "Aphetto Exterminator",
             "text": "Morph {3}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Aphetto Exterminator is turned face up, target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "4f5563be-d910-5df4-b376-068123c9f801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45ebf65-77b8-41bc-b913-d864c4a00549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45ebf65-77b8-41bc-b913-d864c4a00549.jpg?1",
             "name": "Bane of the Living",
             "text": "Morph {X}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Bane of the Living is turned face up, all creatures get -X/-X until end of turn.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "2201379c-1d42-5ce4-93e5-9654eb2f4a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805de325-6f14-4a52-bb85-f9a9545d82a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805de325-6f14-4a52-bb85-f9a9545d82a4.jpg?1",
             "name": "Blood Celebrant",
             "text": "{B}, Pay 1 life: Add one mana of any color to your mana pool.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "c3ef71c2-bd0d-5e59-b09c-1f6a67ba3811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09c2c8-526b-4693-bbaa-109911ce5281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09c2c8-526b-4693-bbaa-109911ce5281.jpg?1",
             "name": "Corpse Harvester",
             "text": "{1}{B}, {T}, Sacrifice a creature: Search your library for a Zombie card and a swamp card, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "eb2c7395-9e59-5b37-981a-e055d91a7089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507097eb-6b50-47ae-a545-df76b743b2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507097eb-6b50-47ae-a545-df76b743b2bd.jpg?1",
             "name": "Crypt Sliver",
             "text": "All Slivers have \"{T}: Regenerate target Sliver.\"",
             "colours": [
@@ -2198,7 +2198,7 @@
         },
         {
             "id": "c3e81d27-f6b0-5ff5-96f7-490bde928d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb685932-5df5-4f26-9633-b1daa8925359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb685932-5df5-4f26-9633-b1daa8925359.jpg?1",
             "name": "Dark Supplicant",
             "text": "{T}, Sacrifice three Clerics: Search your graveyard, hand, and/or library for a card named Scion of Darkness and put it into play. If you search your library this way, shuffle it.",
             "colours": [
@@ -2233,7 +2233,7 @@
         },
         {
             "id": "36c49a97-1d92-57f4-96dc-f4147ec89efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54fb4b2-ecce-4a6c-8d76-4b5879ba836f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54fb4b2-ecce-4a6c-8d76-4b5879ba836f.jpg?1",
             "name": "Deathmark Prelate",
             "text": "{2}{B}, {T}, Sacrifice a Zombie: Destroy target non-Zombie creature. It can't be regenerated. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "e9af6c42-21b5-5d1f-921b-98047449bab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc8758b-68cc-45ab-85d0-b870cef7dd85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc8758b-68cc-45ab-85d0-b870cef7dd85.jpg?1",
             "name": "Drinker of Sorrow",
             "text": "Drinker of Sorrow can't block.\nWhenever Drinker of Sorrow deals combat damage, sacrifice a permanent.",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "5aa61697-2235-5253-ad0b-ad0299d0ffce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3b483-01a8-4f54-9a3a-0d3f5aa3cd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3b483-01a8-4f54-9a3a-0d3f5aa3cd8b.jpg?1",
             "name": "Dripping Dead",
             "text": "Dripping Dead can't block.\nWhenever Dripping Dead deals combat damage to a creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -2336,7 +2336,7 @@
         },
         {
             "id": "d4e55da6-30ec-56ae-a67c-154dbe93a322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830a4048-48ac-4856-9af9-5052ec146518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830a4048-48ac-4856-9af9-5052ec146518.jpg?1",
             "name": "Earthblighter",
             "text": "{2}{B}, {T}, Sacrifice a Goblin: Destroy target land.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "bfd6cf0d-7236-521f-a191-5dfa0e862539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e214da0-68c0-4cf6-ba12-e2b2394909c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e214da0-68c0-4cf6-ba12-e2b2394909c1.jpg?1",
             "name": "Embalmed Brawler",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nWhenever Embalmed Brawler attacks or blocks, you lose 1 life for each +1/+1 counter on it.",
             "colours": [
@@ -2405,7 +2405,7 @@
         },
         {
             "id": "ffa601ca-22dd-50ea-9aed-99593816fe81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9943ac-9e3f-4ee0-b5fd-3b0fb17097d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9943ac-9e3f-4ee0-b5fd-3b0fb17097d8.jpg?1",
             "name": "Gempalm Polluter",
             "text": "Cycling {B}{B} ({B}{B}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Polluter, you may have target player lose 1 life for each Zombie in play.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "9a0c80ee-63c7-5d90-9838-65da46a6e5e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e67323-df54-4043-a6b6-18bb89ef1f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e67323-df54-4043-a6b6-18bb89ef1f62.jpg?1",
             "name": "Ghastly Remains",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nAt the beginning of your upkeep, if Ghastly Remains is in your graveyard, you may pay {B}{B}{B}. If you do, return Ghastly Remains to your hand.",
             "colours": [
@@ -2473,7 +2473,7 @@
         },
         {
             "id": "519d3cec-277e-5bfa-af7b-e9e73329c235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac74e64-8831-4af2-9c6d-22c533389144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac74e64-8831-4af2-9c6d-22c533389144.jpg?1",
             "name": "Goblin Turncoat",
             "text": "Sacrifice a Goblin: Regenerate Goblin Turncoat.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "b5479269-b96f-513d-ad78-aceacac17aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa432e4e-ff23-4ad2-8d0a-403efee86f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa432e4e-ff23-4ad2-8d0a-403efee86f11.jpg?1",
             "name": "Graveborn Muse",
             "text": "At the beginning of your upkeep, you draw X cards and you lose X life, where X is the number of Zombies you control.",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "ed2b2260-41f9-5814-8f6b-5f9cd330450b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477802a-349d-41e1-b050-58da0d806abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477802a-349d-41e1-b050-58da0d806abf.jpg?1",
             "name": "Havoc Demon",
             "text": "Flying\nWhen Havoc Demon is put into a graveyard from play, all creatures get -5/-5 until end of turn.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "f9ceb186-7297-51d2-ad6a-0b9483d8a6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db779fd-0e01-417b-aee2-786db2c0b8c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db779fd-0e01-417b-aee2-786db2c0b8c8.jpg?1",
             "name": "Hollow Specter",
             "text": "Flying\nWhenever Hollow Specter deals combat damage to a player, you may pay {X}. If you do, that player reveals X cards from his or her hand and you choose one of them. That player discards that card.",
             "colours": [
@@ -2611,7 +2611,7 @@
         },
         {
             "id": "15ad5e18-3f8a-55b6-8063-83f4c91336d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a028a30-6242-4d87-9501-d1826ecb69b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a028a30-6242-4d87-9501-d1826ecb69b0.jpg?1",
             "name": "Infernal Caretaker",
             "text": "Morph {3}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Infernal Caretaker is turned face up, return all Zombie cards from all graveyards to their owners' hands.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "faf52df1-c6cc-5ecd-ae23-dd2cbcb26b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d3b33d-25b4-42b4-a93e-2a6b69832030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9d3b33d-25b4-42b4-a93e-2a6b69832030.jpg?1",
             "name": "Noxious Ghoul",
             "text": "Whenever Noxious Ghoul or another Zombie comes into play, all non-Zombie creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "12ea9045-f0ca-5190-b7f3-71707554e20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410b933-99d0-4383-b54b-4839a76eb6fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410b933-99d0-4383-b54b-4839a76eb6fe.jpg?1",
             "name": "Phage the Untouchable",
             "text": "When Phage the Untouchable comes into play, if you didn't play it from your hand, you lose the game.\nWhenever Phage deals combat damage to a creature, destroy that creature. It can't be regenerated.\nWhenever Phage deals combat damage to a player, that player loses the game.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "9eab83c7-206a-5ee8-a007-44e67ae1a9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497c2629-1263-48a4-9c31-7f052808b2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497c2629-1263-48a4-9c31-7f052808b2b8.jpg?1",
             "name": "Scion of Darkness",
             "text": "Trample\nWhenever Scion of Darkness deals combat damage to a player, you may put target creature card from that player's graveyard into play under your control.\nCycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "b6e4f9d8-c3d5-5908-b5c6-ee5873e26e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b8c392-da68-4894-b6e8-eb430141a0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b8c392-da68-4894-b6e8-eb430141a0d7.jpg?1",
             "name": "Skinthinner",
             "text": "Morph {3}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Skinthinner is turned face up, destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "959a16e0-a64e-546c-9c54-a45e541d5243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea393a4-58c8-4a42-bd95-a3312504f2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea393a4-58c8-4a42-bd95-a3312504f2e2.jpg?1",
             "name": "Smokespew Invoker",
             "text": "{7}{B}: Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "c25dddbd-32fd-5ef7-aee7-4dd707720f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a2ccc-8847-452b-b030-27d8506675bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/216a2ccc-8847-452b-b030-27d8506675bd.jpg?1",
             "name": "Sootfeather Flock",
             "text": "Flying\nMorph {3}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2854,7 +2854,7 @@
         },
         {
             "id": "414ea154-acd2-5b0b-83cb-8ab0d7889707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec97e3c-7b75-4abb-a50e-86bc8cc3bf06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec97e3c-7b75-4abb-a50e-86bc8cc3bf06.jpg?1",
             "name": "Spectral Sliver",
             "text": "All Slivers have \"{2}: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "522370cc-6f34-57a5-9555-a42fdeb49db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04ab6b6-27ee-4c93-a87c-cbc3743f4faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04ab6b6-27ee-4c93-a87c-cbc3743f4faf.jpg?1",
             "name": "Toxin Sliver",
             "text": "Whenever a Sliver deals combat damage to a creature, destroy that creature. It can't be regenerated.",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "de83ec85-da7c-5436-8dc9-b29513635b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2641bd5-c845-47a1-8038-bb28b06f896e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2641bd5-c845-47a1-8038-bb28b06f896e.jpg?1",
             "name": "Vile Deacon",
             "text": "Whenever Vile Deacon attacks, it gets +X/+X until end of turn, where X is the number of Clerics in play.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "258488cc-0015-55ff-82cf-d49d7522ee1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a82948-503f-4ad4-9e3c-c080c16afd63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a82948-503f-4ad4-9e3c-c080c16afd63.jpg?1",
             "name": "Withered Wretch",
             "text": "{1}: Remove target card in a graveyard from the game.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "2e2d15b4-ec05-59a1-ae4f-79f9aad359da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37db470-3aef-4fc4-98ce-63b5fb2546f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37db470-3aef-4fc4-98ce-63b5fb2546f6.jpg?1",
             "name": "Zombie Brute",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Zombie card you reveal in your hand.)\nTrample",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "6bdef813-2ded-5692-9e32-053b7aca9a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d6f7a6-7b6a-44f4-be04-7c02806b9f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d6f7a6-7b6a-44f4-be04-7c02806b9f09.jpg?1",
             "name": "Blade Sliver",
             "text": "All Slivers get +1/+0.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "a1808ac4-998c-522d-88cd-1b61f67079e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743779d4-fee8-4b8d-a5ac-27f355e006e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743779d4-fee8-4b8d-a5ac-27f355e006e5.jpg?1",
             "name": "Bloodstoke Howler",
             "text": "Morph {6}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Bloodstoke Howler is turned face up, Beasts you control get +3/+0 until end of turn.",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "6b73fc2b-3973-5e8e-a4a9-fdf45c8049e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c3f62-f275-46e1-8c26-c219683effb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c3f62-f275-46e1-8c26-c219683effb1.jpg?1",
             "name": "Clickslither",
             "text": "Haste\nSacrifice a Goblin: Clickslither gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "77ded0b9-2884-54db-b382-42179de0c1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadb40c8-3d54-4705-82dc-54e8d6e315d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadb40c8-3d54-4705-82dc-54e8d6e315d5.jpg?1",
             "name": "Crested Craghorn",
             "text": "Haste\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "9ab4fefb-f4fb-57c7-bad5-c4b94457136b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68534-2d9a-47e9-9d2a-cb6df4362aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a68534-2d9a-47e9-9d2a-cb6df4362aa9.jpg?1",
             "name": "Flamewave Invoker",
             "text": "{7}{R}: Flamewave Invoker deals 5 damage to target player.",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "835baff3-9990-5137-910b-064f517e049c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6bc3c0-2d6e-4a09-84c4-b26a352186bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6bc3c0-2d6e-4a09-84c4-b26a352186bb.jpg?1",
             "name": "Frenetic Raptor",
             "text": "Beasts can't block.",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "d35f9114-8c85-545b-823a-fa25a5d8bae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2687c311-fd0c-4fe0-bce8-e3f412216796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2687c311-fd0c-4fe0-bce8-e3f412216796.jpg?1",
             "name": "Gempalm Incinerator",
             "text": "Cycling {1}{R} ({1}{R}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins in play.",
             "colours": [
@@ -3268,7 +3268,7 @@
         },
         {
             "id": "d4122d7e-ed59-5538-9257-52463fa805c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ec836f-6dcf-45f9-8e95-487762742a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ec836f-6dcf-45f9-8e95-487762742a1e.jpg?1",
             "name": "Goblin Assassin",
             "text": "Whenever Goblin Assassin or another Goblin comes into play, each player flips a coin. Each player whose coin comes up tails sacrifices a creature.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "a36c7ee2-ab86-51ef-b9d8-99cdb44a6075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c0cae-852c-444c-8994-68a6d81b4cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c0cae-852c-444c-8994-68a6d81b4cd4.jpg?1",
             "name": "Goblin Clearcutter",
             "text": "{T}, Sacrifice a forest: Add three mana in any combination of red and/or green to your mana pool.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "63bcb884-820d-545e-a457-5b50703ebe8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9462cb4e-a38c-4a41-bad2-4ea3b22b0edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9462cb4e-a38c-4a41-bad2-4ea3b22b0edb.jpg?1",
             "name": "Goblin Dynamo",
             "text": "{T}: Goblin Dynamo deals 1 damage to target creature or player.\n{X}{R}, {T}, Sacrifice Goblin Dynamo: Goblin Dynamo deals X damage to target creature or player.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "f0de9259-f2c4-5006-8816-442467e04bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2370d319-d1d2-4bca-9275-ff72fb400709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2370d319-d1d2-4bca-9275-ff72fb400709.jpg?1",
             "name": "Goblin Firebug",
             "text": "When Goblin Firebug leaves play, sacrifice a land.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "4fd98cde-ac72-5642-8f1a-c8ed16bfdd99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c77cac8-fe95-4925-a815-8c514cc41b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c77cac8-fe95-4925-a815-8c514cc41b22.jpg?1",
             "name": "Goblin Goon",
             "text": "Goblin Goon can't attack unless you control more creatures than defending player.\nGoblin Goon can't block unless you control more creatures than attacking player.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "99673d00-9c00-51cf-b6e3-3ec67ee76030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c948872-295c-41b9-8094-db7db7578b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c948872-295c-41b9-8094-db7db7578b0d.jpg?1",
             "name": "Goblin Grappler",
             "text": "Provoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "c92b123a-7f8a-51a5-9d4c-fa7957acaef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bbe84a-8857-467a-a4a1-e57086cc9501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bbe84a-8857-467a-a4a1-e57086cc9501.jpg?1",
             "name": "Goblin Lookout",
             "text": "{T}, Sacrifice a Goblin: All Goblins get +2/+0 until end of turn.",
             "colours": [
@@ -3510,7 +3510,7 @@
         },
         {
             "id": "61056a91-7fe0-5ae7-8304-cd1b75be50ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9aea1a-6f50-4f66-9f36-2e214dce41b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9aea1a-6f50-4f66-9f36-2e214dce41b4.jpg?1",
             "name": "Hunter Sliver",
             "text": "All Slivers have provoke. (When a Sliver attacks, its controller may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -3544,7 +3544,7 @@
         },
         {
             "id": "943a48ef-2055-5d6e-9a94-ee99f6627d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc3c5f3-f71b-4a1e-bd90-365d23889925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc3c5f3-f71b-4a1e-bd90-365d23889925.jpg?1",
             "name": "Imperial Hellkite",
             "text": "Flying\nMorph {6}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Imperial Hellkite is turned face up, you may search your library for a Dragon card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "0e445688-9fac-5a5f-aef6-a910a0d172bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe13c3-3c8b-4faa-bdd4-491039bfa82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe13c3-3c8b-4faa-bdd4-491039bfa82b.jpg?1",
             "name": "Kilnmouth Dragon",
             "text": "Amplify 3 (As this card comes into play, put three +1/+1 counters on it for each Dragon card you reveal in your hand.)\nFlying\n{T}: Kilnmouth Dragon deals damage equal to the number of +1/+1 counters on it to target creature or player.",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "84629309-151a-57f1-9eda-1ab4cd8b8982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc94fb-9e3f-4075-bb6a-8f04862dc585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc94fb-9e3f-4075-bb6a-8f04862dc585.jpg?1",
             "name": "Lavaborn Muse",
             "text": "At the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Lavaborn Muse deals 3 damage to him or her.",
             "colours": [
@@ -3646,7 +3646,7 @@
         },
         {
             "id": "e19f2099-717e-5910-ae33-10bfd85ad949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8451ab3f-5d61-4f35-ab70-5a5060caf53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8451ab3f-5d61-4f35-ab70-5a5060caf53d.jpg?1",
             "name": "Macetail Hystrodon",
             "text": "First strike, haste\nCycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3680,7 +3680,7 @@
         },
         {
             "id": "4f6b945d-e7a4-5ccf-81dd-30a8caf519c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091d908-456f-4127-857d-b22fdb4f2fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091d908-456f-4127-857d-b22fdb4f2fd9.jpg?1",
             "name": "Magma Sliver",
             "text": "All Slivers have \"{T}: Target Sliver gets +X/+0 until end of turn, where X is the number of Slivers in play.\"",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "dd404ecf-1ad2-5130-94b6-1c8ad1a760f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013cbc4-09f4-484f-b328-9f7403225149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013cbc4-09f4-484f-b328-9f7403225149.jpg?1",
             "name": "Ridgetop Raptor",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "fe8314d6-fcec-5394-8562-49c65711d160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6343c0-3fb5-4bac-bea7-cba36498cd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6343c0-3fb5-4bac-bea7-cba36498cd69.jpg?1",
             "name": "Rockshard Elemental",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nMorph {4}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "07fc0ee6-8f6d-51c4-8983-87e3e24d583d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42658b33-9a12-403b-bc7d-807fbe1f1a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42658b33-9a12-403b-bc7d-807fbe1f1a36.jpg?1",
             "name": "Shaleskin Plower",
             "text": "Morph {4}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Shaleskin Plower is turned face up, destroy target land.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "80345ec8-caef-54a8-b748-11f781a49916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c1d41-8666-4c1d-9498-0e259472958d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c1d41-8666-4c1d-9498-0e259472958d.jpg?1",
             "name": "Skirk Alarmist",
             "text": "Haste\n{T}: Turn target face-down creature you control face up. At end of turn, sacrifice it.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "928fdb7c-d1c2-5f41-ab9c-f389aedb0007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2d1a-4027-46d9-b780-bcac8d60ecdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359b2d1a-4027-46d9-b780-bcac8d60ecdb.jpg?1",
             "name": "Skirk Drill Sergeant",
             "text": "Whenever Skirk Drill Sergeant or another Goblin is put into a graveyard from play, you may pay {2}{R}. If you do, reveal the top card of your library. If it's a Goblin card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "2f5f5637-725a-5dfe-850d-dba261431406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd2ff12-c6f7-4986-801f-225ad6f59278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd2ff12-c6f7-4986-801f-225ad6f59278.jpg?1",
             "name": "Skirk Marauder",
             "text": "Morph {2}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Skirk Marauder is turned face up, it deals 2 damage to target creature or player.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "e31beb95-9126-5eb3-9c1a-6939d3e2950b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416de0f4-1540-4286-a1ac-4f57301c54e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416de0f4-1540-4286-a1ac-4f57301c54e9.jpg?1",
             "name": "Skirk Outrider",
             "text": "Skirk Outrider gets +2/+2 and has trample as long as you control a Beast.",
             "colours": [
@@ -3954,7 +3954,7 @@
         },
         {
             "id": "0eb9319b-6e9a-5e84-8ab7-c7bbc9175793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cfde2-42fa-4278-ae4e-7e4dd993cda8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cfde2-42fa-4278-ae4e-7e4dd993cda8.jpg?1",
             "name": "Unstable Hulk",
             "text": "Morph {3}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Unstable Hulk is turned face up, it gets +6/+6 and gains trample until end of turn. You skip your next turn.",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "61f87fab-ac2e-5461-b092-f3e173020262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc942957-1067-428c-8ee1-01f9e260efe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc942957-1067-428c-8ee1-01f9e260efe1.jpg?1",
             "name": "Warbreak Trumpeter",
             "text": "Morph {X}{X}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Warbreak Trumpeter is turned face up, put X 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "c2c583b1-7e04-58e7-a297-98f64748221e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c4674-dd9f-4848-8447-721f842a0213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c4674-dd9f-4848-8447-721f842a0213.jpg?1",
             "name": "Berserk Murlodont",
             "text": "Whenever a Beast becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -4057,7 +4057,7 @@
         },
         {
             "id": "11f318e6-0da0-59fc-8dc4-c15597c03962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52118ff1-ad76-4b97-9fdc-6adfe80140f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52118ff1-ad76-4b97-9fdc-6adfe80140f8.jpg?1",
             "name": "Branchsnap Lorian",
             "text": "Trample\nMorph {G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4091,7 +4091,7 @@
         },
         {
             "id": "51ca5353-fca4-546c-be46-7ea3b0076015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a171f5e2-ed3d-4675-a4fc-953ebb907aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a171f5e2-ed3d-4675-a4fc-953ebb907aa0.jpg?1",
             "name": "Brontotherium",
             "text": "Trample\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "57c66987-de4e-5dca-8751-b7f651f049c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33803c12-1d78-49fe-a3a3-7f47c60a96b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33803c12-1d78-49fe-a3a3-7f47c60a96b6.jpg?1",
             "name": "Brood Sliver",
             "text": "Whenever a Sliver deals combat damage to a player, its controller may put a 1/1 colorless Sliver creature token into play.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "ab6da8d9-b56b-5e5d-955c-136f59157f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a073459e-1f00-47e0-a1b3-d30203aa35d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a073459e-1f00-47e0-a1b3-d30203aa35d1.jpg?1",
             "name": "Caller of the Claw",
             "text": "You may play Caller of the Claw any time you could play an instant.\nWhen Caller of the Claw comes into play, put a 2/2 green Bear creature token into play for each nontoken creature put into your graveyard from play this turn.",
             "colours": [
@@ -4193,7 +4193,7 @@
         },
         {
             "id": "0b0efc90-f094-5a6f-b2ad-8ad842da6342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccdc9d7-71b5-4304-8d19-a63952e17a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccdc9d7-71b5-4304-8d19-a63952e17a6b.jpg?1",
             "name": "Canopy Crawler",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Beast card you reveal in your hand.)\n{T}: Target creature gets +1/+1 until end of turn for each +1/+1 counter on Canopy Crawler.",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "3f6f3eb7-d2d6-5dd2-afc5-87a66ed3a880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7a0b8f-6942-40b0-8efc-234ae77855b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7a0b8f-6942-40b0-8efc-234ae77855b4.jpg?1",
             "name": "Defiant Elf",
             "text": "Trample",
             "colours": [
@@ -4261,7 +4261,7 @@
         },
         {
             "id": "12310578-7547-5e61-881d-be553a74ff25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2c8de5-bc80-4fad-af09-6d0a639f6e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2c8de5-bc80-4fad-af09-6d0a639f6e18.jpg?1",
             "name": "Elvish Soultiller",
             "text": "When Elvish Soultiller is put into a graveyard from play, choose a creature type. Shuffle all creature cards of that type from your graveyard into your library.",
             "colours": [
@@ -4296,7 +4296,7 @@
         },
         {
             "id": "634c9d56-a13f-5176-8f40-1ee0bd0f73c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebfb5a6-9052-47be-b931-834b5064df31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cebfb5a6-9052-47be-b931-834b5064df31.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "d1ae017c-2312-52a5-bc8e-d4ed262ba9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e0c5e5-b293-419e-aac5-3b81af4b6498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e0c5e5-b293-419e-aac5-3b81af4b6498.jpg?1",
             "name": "Feral Throwback",
             "text": "Amplify 2 (As this card comes into play, put two +1/+1 counters on it for each Beast card you reveal in your hand.)\nProvoke (When this attacks, you may have target creature defending player controls untap and block it if able.)",
             "colours": [
@@ -4364,7 +4364,7 @@
         },
         {
             "id": "8f1d2c61-f191-5256-b1e5-71a5195ae1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d89f5-3e77-4dc0-935b-e6f6a3e968d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d89f5-3e77-4dc0-935b-e6f6a3e968d2.jpg?1",
             "name": "Gempalm Strider",
             "text": "Cycling {2}{G}{G} ({2}{G}{G}, Discard this card from your hand: Draw a card.)\nWhen you cycle Gempalm Strider, all Elves get +2/+2 until end of turn.",
             "colours": [
@@ -4398,7 +4398,7 @@
         },
         {
             "id": "98e6c52d-9fa9-5087-ac6b-7c48052550f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974b0881-bd26-4074-93dd-a1e3600347c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974b0881-bd26-4074-93dd-a1e3600347c4.jpg?1",
             "name": "Glowering Rogon",
             "text": "Amplify 1 (As this card comes into play, put a +1/+1 counter on it for each Beast card you reveal in your hand.)",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "e5cc1438-666c-53ab-b84b-3a3248291b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525c356-88ca-4e2e-8f06-663be101e34f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525c356-88ca-4e2e-8f06-663be101e34f.jpg?1",
             "name": "Hundroog",
             "text": "Cycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "d2680f13-b8b2-5078-9d9a-c18158eafd00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ef4cda-e55b-45a8-9c02-4e77e5b15a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ef4cda-e55b-45a8-9c02-4e77e5b15a9e.jpg?1",
             "name": "Krosan Cloudscraper",
             "text": "At the beginning of your upkeep, sacrifice Krosan Cloudscraper unless you pay {G}{G}.\nMorph {7}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4501,7 +4501,7 @@
         },
         {
             "id": "8168b98b-0d78-5c87-a8c8-b32011d58e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d1c6c6-16b3-4a52-aeda-683b1aeb0e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d1c6c6-16b3-4a52-aeda-683b1aeb0e7f.jpg?1",
             "name": "Krosan Vorine",
             "text": "Provoke (When this attacks, you may have target creature defending player controls untap and block it if able.)\nKrosan Vorine can't be blocked by more than one creature.",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "c09f8235-9bd2-5a83-9399-369145573f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7474849-a6b4-4f3b-a836-37b88c26047b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7474849-a6b4-4f3b-a836-37b88c26047b.jpg?1",
             "name": "Nantuko Vigilante",
             "text": "Morph {1}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Nantuko Vigilante is turned face up, destroy target artifact or enchantment.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "3aabf95b-e31c-5a9e-a66d-c7d559d99d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b1628d-aacd-4e19-9ebb-bcd9b2842c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b1628d-aacd-4e19-9ebb-bcd9b2842c91.jpg?1",
             "name": "Needleshot Gourna",
             "text": "Needleshot Gourna may block as though it had flying.",
             "colours": [
@@ -4606,7 +4606,7 @@
         },
         {
             "id": "eba773f3-d908-59a4-b268-bb14f5dee69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a0810-3970-454f-8381-700d6c6aefdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7a0810-3970-454f-8381-700d6c6aefdc.jpg?1",
             "name": "Patron of the Wild",
             "text": "Morph {2}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Patron of the Wild is turned face up, target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "f3275338-4cb9-5b79-8437-c8d69360d0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777432f-7965-4ad8-8d53-93919ae767d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777432f-7965-4ad8-8d53-93919ae767d4.jpg?1",
             "name": "Primal Whisperer",
             "text": "Primal Whisperer gets +2/+2 for each face-down creature in play.\nMorph {3}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "03122b07-59f6-5352-8a9e-0d5cb972e5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a60b2d-aeeb-4dbf-bf1a-20a274fe323f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a60b2d-aeeb-4dbf-bf1a-20a274fe323f.jpg?1",
             "name": "Quick Sliver",
             "text": "You may play Quick Sliver any time you could play an instant.\nAny player may play Sliver cards any time he or she could play an instant.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "67147a39-a02b-561d-9957-8e4053cbac75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf5a106-5fb7-40e4-82a7-db559302a923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf5a106-5fb7-40e4-82a7-db559302a923.jpg?1",
             "name": "Root Sliver",
             "text": "Root Sliver can't be countered.\nSliver spells can't be countered.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "7993e139-846b-52ae-9096-6ce8f256f782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13321-e429-4497-aef2-93a9df421d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13321-e429-4497-aef2-93a9df421d38.jpg?1",
             "name": "Seedborn Muse",
             "text": "Untap all permanents you control during each other player's untap step.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "90e39758-c6dc-5def-943a-b41a5e52f747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d0235d-7176-44a2-8e95-eb231f4af441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d0235d-7176-44a2-8e95-eb231f4af441.jpg?1",
             "name": "Stonewood Invoker",
             "text": "{7}{G}: Stonewood Invoker gets +5/+5 until end of turn.",
             "colours": [
@@ -4812,7 +4812,7 @@
         },
         {
             "id": "174d052d-a88b-5cdd-9004-a485a01dfd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045ae4ec-07f2-4098-a2d9-4bfcbd0273b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045ae4ec-07f2-4098-a2d9-4bfcbd0273b2.jpg?1",
             "name": "Timberwatch Elf",
             "text": "{T}: Target creature gets +X/+X until end of turn, where X is the number of Elves in play.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "df838e91-e28e-5c70-87ff-ef75456111e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12115b-2667-47f7-bd24-17c982a4f79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12115b-2667-47f7-bd24-17c982a4f79a.jpg?1",
             "name": "Totem Speaker",
             "text": "Whenever a Beast comes into play, you may gain 3 life.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "32a54d96-3a03-5625-992e-5a1b7478ea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104735d7-6cea-4d4a-8cc8-e1934883da97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104735d7-6cea-4d4a-8cc8-e1934883da97.jpg?1",
             "name": "Tribal Forcemage",
             "text": "Morph {1}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Tribal Forcemage is turned face up, creatures of the type of your choice get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "ecb1a118-5fca-5f8e-b6fb-306b44c32f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d599d35f-1b73-498b-9a21-831c908a95d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d599d35f-1b73-498b-9a21-831c908a95d8.jpg?1",
             "name": "Vexing Beetle",
             "text": "Vexing Beetle can't be countered.\nVexing Beetle gets +3/+3 as long as no opponent controls a creature.",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "139786eb-5640-58e2-9981-53301246748c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e5579e-dab7-49db-a141-a5bc5b5aee90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e5579e-dab7-49db-a141-a5bc5b5aee90.jpg?1",
             "name": "Wirewood Channeler",
             "text": "{T}: Add X mana of any one color to your mana pool, where X is the number of Elves in play.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "964d0b5d-3838-5a7d-b7f0-fc46bd24de0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55b4fc-366f-4906-9eaa-9085f6a22612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea55b4fc-366f-4906-9eaa-9085f6a22612.jpg?1",
             "name": "Wirewood Hivemaster",
             "text": "Whenever another nontoken Elf comes into play, you may put a 1/1 green Insect creature token into play.",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/LRW.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LRW.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d712035d-7510-5298-8433-0e8e83460c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1470a6-d09d-4a2a-84a6-d56e32ed237a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1470a6-d09d-4a2a-84a6-d56e32ed237a.jpg?1",
             "name": "Ajani Goldmane",
             "text": "+1: You gain 2 life.\n-1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n-6: Put a white Avatar creature token into play with \"This creature's power and toughness are each equal to your life total.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "0b83cbf6-73bd-5186-a285-342e9e5160db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b598cf2-c327-422b-9527-1b28645ba70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b598cf2-c327-422b-9527-1b28645ba70c.jpg?1",
             "name": "Arbiter of Knollridge",
             "text": "Vigilance\nWhen Arbiter of Knollridge comes into play, each player's life total becomes the highest life total among all players.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "84c75b0c-b035-57c9-9f23-5606ae1b6b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee73fe8-d52b-43bb-ab91-5545192be676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee73fe8-d52b-43bb-ab91-5545192be676.jpg?1",
             "name": "Austere Command",
             "text": "Choose two Destroy all artifacts; or destroy all enchantments; or destroy all creatures with converted mana cost 3 or less; or destroy all creatures with converted mana cost 4 or greater.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "d87fd174-be97-5202-bd08-4d31eff4c2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2258bd3-e38b-4029-a9fb-f9ae86dbbc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2258bd3-e38b-4029-a9fb-f9ae86dbbc3a.jpg?1",
             "name": "Avian Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nFlying",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "c8e73f26-14dd-5518-895a-c41b5caf29a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e234ce-6d61-4d62-a8cd-fa985a6aba60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e234ce-6d61-4d62-a8cd-fa985a6aba60.jpg?1",
             "name": "Battle Mastery",
             "text": "Enchant creature\nEnchanted creature has double strike.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "4694d5a5-bc6f-543f-aeef-7eb3704f12a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg?1",
             "name": "Brigid, Hero of Kinsbaile",
             "text": "First strike\n{T}: Brigid, Hero of Kinsbaile deals 2 damage to each attacking or blocking creature target player controls.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "1064caa6-76e1-541e-a9ee-185fab7a7c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000c3e4-d71a-43c8-8ded-f3da54bc088d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c000c3e4-d71a-43c8-8ded-f3da54bc088d.jpg?1",
             "name": "Burrenton Forge-Tender",
             "text": "Protection from red\nSacrifice Burrenton Forge-Tender: Prevent all damage a red source of your choice would deal this turn.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "70cdbd36-ec45-5271-84fc-8b4e3ebf1c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7610d2f-e35f-42fa-a3fb-fcae54bf5a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7610d2f-e35f-42fa-a3fb-fcae54bf5a1d.jpg?1",
             "name": "Cenn's Heir",
             "text": "Whenever Cenn's Heir attacks, it gets +1/+1 until end of turn for each other attacking Kithkin.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "d4316b40-e194-5b2a-8073-4cf09958be59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0c586-a1a5-4907-801a-7815c4dceb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0c586-a1a5-4907-801a-7815c4dceb39.jpg?1",
             "name": "Changeling Hero",
             "text": "Changeling (This card is every creature type at all times.)\nChampion a creature (When this comes into play, sacrifice it unless you remove another creature you control from the game. When this leaves play, that card returns to play.)\nLifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "bbdbfee9-845a-5127-9c00-feeede0536b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e344859-7248-4498-8303-252f196a007b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e344859-7248-4498-8303-252f196a007b.jpg?1",
             "name": "Cloudgoat Ranger",
             "text": "When Cloudgoat Ranger comes into play, put three 1/1 white Kithkin Soldier creature tokens into play.\nTap three untapped Kithkin you control: Cloudgoat Ranger gets +2/+0 and gains flying until end of turn.",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "c5b57141-fbae-56d4-8f04-7edeec9f48a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9044585-4d44-42fb-ad7b-e0e224fbc502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9044585-4d44-42fb-ad7b-e0e224fbc502.jpg?1",
             "name": "Crib Swap",
             "text": "Changeling (This card is every creature type at all times.)\nRemove target creature from the game. Its controller puts a 1/1 colorless Shapeshifter creature token with changeling into play.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "df35dbcc-d67a-5177-a9de-79403166bde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8968bc0-518f-4c41-bf00-2bf295065e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8968bc0-518f-4c41-bf00-2bf295065e33.jpg?1",
             "name": "Dawnfluke",
             "text": "Flash\nWhen Dawnfluke comes into play, prevent the next 3 damage that would be dealt to target creature or player this turn.\nEvoke {W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -421,7 +421,7 @@
         },
         {
             "id": "7d2a2d2e-4c45-5838-ba31-c9efd1acb360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1cec6f-5308-4bff-b19a-df9e3325bb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1cec6f-5308-4bff-b19a-df9e3325bb06.jpg?1",
             "name": "Entangling Trap",
             "text": "Whenever you clash, tap target creature an opponent controls. If you won, that creature doesn't untap during its controller's next untap step. (This ability triggers after the clash ends.)",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "9e2191b4-046f-5f89-8804-91d92d9692bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg?1",
             "name": "Favor of the Mighty",
             "text": "Each creature with the highest converted mana cost has protection from all colors.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "3eaa5fe9-cfdd-5473-bc94-3df0a5429780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8152999d-5e65-4ea6-b1e7-94b41808faa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8152999d-5e65-4ea6-b1e7-94b41808faa0.jpg?1",
             "name": "Galepowder Mage",
             "text": "Flying\nWhenever Galepowder Mage attacks, remove another target creature from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "a3a73eac-8a49-5447-acbe-474c02bcf77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5305b5c6-2af6-4b5c-9a57-0a2d2628e2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5305b5c6-2af6-4b5c-9a57-0a2d2628e2f4.jpg?1",
             "name": "Goldmeadow Dodger",
             "text": "Goldmeadow Dodger can't be blocked by creatures with power 4 or greater.",
             "colours": [
@@ -558,7 +558,7 @@
         },
         {
             "id": "28743c04-4365-542f-988f-6c03aee3c09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7508c-2815-40eb-92f7-3e66dfb28484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a7508c-2815-40eb-92f7-3e66dfb28484.jpg?1",
             "name": "Goldmeadow Harrier",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -593,7 +593,7 @@
         },
         {
             "id": "eb7ce02e-149c-55d3-81fe-e915f12f1fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7a9110-6aea-460b-91fa-5f8a507160e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7a9110-6aea-460b-91fa-5f8a507160e7.jpg?1",
             "name": "Goldmeadow Stalwart",
             "text": "As an additional cost to play Goldmeadow Stalwart, reveal a Kithkin card from your hand or pay {3}.",
             "colours": [
@@ -628,7 +628,7 @@
         },
         {
             "id": "a6952215-551c-5fa2-86c0-5bac634329b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10ccaef-2a75-43d6-95f2-c3690ae5c87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c10ccaef-2a75-43d6-95f2-c3690ae5c87a.jpg?1",
             "name": "Harpoon Sniper",
             "text": "{W}, {T}: Harpoon Sniper deals X damage to target attacking or blocking creature, where X is the number of Merfolk you control.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "fd9ae846-ca31-5d1f-9f54-36c55f6271f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a785a2-462d-4321-9e48-eb98698b7591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a785a2-462d-4321-9e48-eb98698b7591.jpg?1",
             "name": "Hillcomber Giant",
             "text": "Mountainwalk",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "fec8d20f-f53f-5af8-a983-4aaf3e6c035a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11187c6-f213-45db-9de3-314df1f43589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11187c6-f213-45db-9de3-314df1f43589.jpg?1",
             "name": "Hoofprints of the Stag",
             "text": "Whenever you draw a card, you may put a hoofprint counter on Hoofprints of the Stag.\n{2}{W}, Remove four hoofprint counters from Hoofprints of the Stag: Put a 4/4 white Elemental creature token with flying into play. Play this ability only during your turn.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "4816525a-5c61-57d4-b79b-be0d5c01e419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3073f3f5-bff8-4ec1-a68f-c83d63435843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3073f3f5-bff8-4ec1-a68f-c83d63435843.jpg?1",
             "name": "Judge of Currents",
             "text": "Whenever a Merfolk you control becomes tapped, you may gain 1 life.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "bfd4ee68-aab4-5075-93ae-bd994d53842f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6053c20-3632-43e2-8560-259d0c12f235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6053c20-3632-43e2-8560-259d0c12f235.jpg?1",
             "name": "Kinsbaile Balloonist",
             "text": "Flying\nWhenever Kinsbaile Balloonist attacks, you may have target creature gain flying until end of turn.",
             "colours": [
@@ -803,7 +803,7 @@
         },
         {
             "id": "fa4cf6f4-2502-50cd-9a68-6713dfb69300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6145bcd5-a583-4a04-9a13-a64ecdf4425a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6145bcd5-a583-4a04-9a13-a64ecdf4425a.jpg?1",
             "name": "Kinsbaile Skirmisher",
             "text": "When Kinsbaile Skirmisher comes into play, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -838,7 +838,7 @@
         },
         {
             "id": "ef24efc7-1bbd-59d8-999f-b666853ea4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75283b6-1b70-4e89-bf21-f85c21454aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75283b6-1b70-4e89-bf21-f85c21454aae.jpg?1",
             "name": "Kithkin Greatheart",
             "text": "As long as you control a Giant, Kithkin Greatheart gets +1/+1 and has first strike.",
             "colours": [
@@ -873,7 +873,7 @@
         },
         {
             "id": "7648eaed-6f6c-59d3-b8f7-10900759f482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64735178-3dc5-4a95-92fa-e15bd04e5733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64735178-3dc5-4a95-92fa-e15bd04e5733.jpg?1",
             "name": "Kithkin Harbinger",
             "text": "When Kithkin Harbinger comes into play, you may search your library for a Kithkin card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "d77fc601-7828-572a-8885-ad0dc49d9d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44032574-a5bc-4366-af65-9824fd4302a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44032574-a5bc-4366-af65-9824fd4302a2.jpg?1",
             "name": "Kithkin Healer",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "3c92fb4e-8665-5a25-81ae-288f7f6084e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb33901-1f97-4080-a9dd-922ef29f42c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb33901-1f97-4080-a9dd-922ef29f42c9.jpg?1",
             "name": "Knight of Meadowgrain",
             "text": "First strike\nLifelink (Whenever this creature deals damage, you gain that much life.)",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "4b85ce47-5393-58ab-aaa3-725f97b1efa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ba1c8-b93a-4169-9ba0-d3fc5bf57676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64ba1c8-b93a-4169-9ba0-d3fc5bf57676.jpg?1",
             "name": "Lairwatch Giant",
             "text": "Lairwatch Giant can block an additional creature.\nWhenever Lairwatch Giant blocks two or more creatures, it gains first strike until end of turn.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "bf19bbe8-f380-56c0-8455-c726a46ba4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg?1",
             "name": "Militia's Pride",
             "text": "Whenever a nontoken creature you control attacks, you may pay {W}. If you do, put a 1/1 white Kithkin Soldier creature token into play tapped and attacking.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "9359c573-7cc0-59d9-96a4-e9354919a6c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfff880-cbf6-4085-bc05-c72658b75f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfff880-cbf6-4085-bc05-c72658b75f25.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type at all times.)\n{X}: Creatures you control become X/X and gain all creature types until end of turn.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "defa2e4a-f5d1-50c5-bdcb-035ab19ba63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc326b79-363e-4c14-86e4-23041f2d6b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc326b79-363e-4c14-86e4-23041f2d6b4f.jpg?1",
             "name": "Neck Snap",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "7ab88704-f9e1-5bb6-b3d7-6ed06d83591c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fdb060-8f4d-453a-9516-92c390fbc85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fdb060-8f4d-453a-9516-92c390fbc85a.jpg?1",
             "name": "Oaken Brawler",
             "text": "When Oaken Brawler comes into play, clash with an opponent. If you win, put a +1/+1 counter on Oaken Brawler. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "e7bcad5c-8164-5338-8bdf-fbac006cbb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7fffe8-709c-4cb4-bbad-e4a0c35b616a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7fffe8-709c-4cb4-bbad-e4a0c35b616a.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring comes into play, remove another target nonland permanent from the game.\nWhen Oblivion Ring leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "e05445a7-987a-5c3f-8616-9bfc27ab8859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2de26e-4cb3-4d7e-b884-54d6056dc9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2de26e-4cb3-4d7e-b884-54d6056dc9e9.jpg?1",
             "name": "Plover Knights",
             "text": "Flying, first strike",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "062fd783-14b0-5a04-b452-40d54e39a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2156a-8a77-4954-b557-1bdaf3ba171a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb2156a-8a77-4954-b557-1bdaf3ba171a.jpg?1",
             "name": "Pollen Lullaby",
             "text": "Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win, creatures that player controls don't untap during the player's next untap step. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "f784396b-bcca-5f3d-815f-833b5dfac379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154a335d-188d-49c3-af6d-c8e702b4b3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154a335d-188d-49c3-af6d-c8e702b4b3ba.jpg?1",
             "name": "Purity",
             "text": "Flying\nIf a spell or ability would deal damage to you, prevent that damage. You gain life equal to the damage prevented this way.\nWhen Purity is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "8895a3c9-eed9-5a91-88be-cc0c224686ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab09d6d7-e2f0-4e78-a9a3-ac37f02f4096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab09d6d7-e2f0-4e78-a9a3-ac37f02f4096.jpg?1",
             "name": "Sentry Oak",
             "text": "Defender\nAt the beginning of combat on your turn, you may clash with an opponent. If you win, Sentry Oak gets +2/+0 and loses defender until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "4f41d0a1-c5f5-5066-9fd4-79b34aeb25d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f550f44f-8b8f-4c1d-a583-9fd986d3061c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f550f44f-8b8f-4c1d-a583-9fd986d3061c.jpg?1",
             "name": "Shields of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nCreatures target player controls get +0/+1 and gain all creature types until end of turn.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "ac9897cf-3025-5d26-bba8-4acb208266e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6c24b1-af9d-4a9c-9167-faa8a397a361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6c24b1-af9d-4a9c-9167-faa8a397a361.jpg?1",
             "name": "Soaring Hope",
             "text": "Enchant creature\nWhen Soaring Hope comes into play, you gain 3 life.\nEnchanted creature has flying.\n{W}: Put Soaring Hope on top of its owner's library.",
             "colours": [
@@ -1387,7 +1387,7 @@
         },
         {
             "id": "e465e08b-b77b-50fd-83ef-0899c06804bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa0c72-427b-4797-b5b1-15f07fc5fa07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa0c72-427b-4797-b5b1-15f07fc5fa07.jpg?1",
             "name": "Springjack Knight",
             "text": "Whenever Springjack Knight attacks, clash with an opponent. If you win, target creature gains double strike until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "c0b773d4-a88e-593c-a083-baa6d7ed6c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a4c124-216b-44b1-b49a-3db3f033e4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a4c124-216b-44b1-b49a-3db3f033e4cd.jpg?1",
             "name": "Summon the School",
             "text": "Put two 1/1 blue Merfolk Wizard creature tokens into play.\nTap four untapped Merfolk you control: Return Summon the School from your graveyard to your hand.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "1457ce13-1ea1-5c9d-9223-fd9e02be6435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b61fb2-11e5-45ae-873d-85f79f161950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b61fb2-11e5-45ae-873d-85f79f161950.jpg?1",
             "name": "Surge of Thoughtweft",
             "text": "Creatures you control get +1/+1 until end of turn. If you control a Kithkin, draw a card.",
             "colours": [
@@ -1492,7 +1492,7 @@
         },
         {
             "id": "9c2135d7-f3aa-535f-9727-991e1c4e1948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg?1",
             "name": "Thoughtweft Trio",
             "text": "First strike, vigilance\nChampion a Kithkin (When this comes into play, sacrifice it unless you remove another Kithkin you control from the game. When this leaves play, that card returns to play.)\nThoughtweft Trio can block any number of creatures.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "78f4982d-f85c-5404-8ff1-ae71386a2be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b5d72-ac5b-43d2-b5dc-0cc4bf63e43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b5d72-ac5b-43d2-b5dc-0cc4bf63e43d.jpg?1",
             "name": "Triclopean Sight",
             "text": "Flash\nEnchant creature\nWhen Triclopean Sight comes into play, untap enchanted creature.\nEnchanted creature gets +1/+1 and has vigilance.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "6398fe9c-2688-59c1-b023-c7e94792d000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36fe821-e9b1-453d-8e44-f8dce111a6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36fe821-e9b1-453d-8e44-f8dce111a6de.jpg?1",
             "name": "Veteran of the Depths",
             "text": "Whenever Veteran of the Depths becomes tapped, you may put a +1/+1 counter on it.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "228357b1-305d-573d-bb8d-ac35ed7b78e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg?1",
             "name": "Wellgabber Apothecary",
             "text": "{1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "8c51ae85-2c32-5a93-b1ed-56eaea9cbda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56389c91-a470-4c43-9368-98df4d38f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56389c91-a470-4c43-9368-98df4d38f7fd.jpg?1",
             "name": "Wispmare",
             "text": "Flying\nWhen Wispmare comes into play, destroy target enchantment.\nEvoke {W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "1096034a-1b5a-516b-8af4-2fca450f2f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585f1c8e-6898-4def-8e3f-d45cd263f776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585f1c8e-6898-4def-8e3f-d45cd263f776.jpg?1",
             "name": "Wizened Cenn",
             "text": "Other Kithkin creatures you control get +1/+1.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "843a8237-161b-5940-a0ef-06cc4a30f9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44c623e-9ae1-495d-b72d-166f2ed4cf2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44c623e-9ae1-495d-b72d-166f2ed4cf2c.jpg?1",
             "name": "Aethersnipe",
             "text": "When \u00c6thersnipe comes into play, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1734,7 +1734,7 @@
         },
         {
             "id": "a8cecdb4-a4db-5083-90ae-ea93e06f73ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068518d2-f061-4061-b208-158e991156b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068518d2-f061-4061-b208-158e991156b6.jpg?1",
             "name": "Amoeboid Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{T}: Target creature gains all creature types until end of turn.\n{T}: Target creature loses all creature types until end of turn.",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "70999b8b-3d59-5a73-875e-64a5ab7b4b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd13d2c1-3db7-4fdc-9321-57c9d6e8c3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd13d2c1-3db7-4fdc-9321-57c9d6e8c3ae.jpg?1",
             "name": "Aquitect's Will",
             "text": "Put a flood counter on target land. That land is an Island in addition to its other types as long as it has a flood counter on it. If you control a Merfolk, draw a card.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "5082bf73-d9fc-51bd-9e50-0cda7273fe83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240d225-9fbf-438a-93c3-5fef325035e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240d225-9fbf-438a-93c3-5fef325035e8.jpg?1",
             "name": "Benthicore",
             "text": "When Benthicore comes into play, put two 1/1 blue Merfolk Wizard creature tokens into play.\nTap two untapped Merfolk you control: Untap Benthicore. It gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "289d778c-1508-5948-8eb3-b7561f938ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8052d90b-bc49-4a9e-9211-159a54aa2bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8052d90b-bc49-4a9e-9211-159a54aa2bcd.jpg?1",
             "name": "Broken Ambitions",
             "text": "Counter target spell unless its controller pays {X}. Clash with an opponent. If you win, that spell's controller puts the top four cards of his or her library into his or her graveyard. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "57a525f4-aa03-5d62-9371-2625e5abe5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642be353-a46a-4d14-a35a-7716fd552870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642be353-a46a-4d14-a35a-7716fd552870.jpg?1",
             "name": "Captivating Glance",
             "text": "Enchant creature\nAt the end of your turn, clash with an opponent. If you win, gain control of enchanted creature. Otherwise, that player gains control of enchanted creature. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "e6f027c2-fc8e-57b7-9070-3bded2d56144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829e3d6e-5d7c-4cc4-a7a6-7cbf5a7442ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829e3d6e-5d7c-4cc4-a7a6-7cbf5a7442ba.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two Counter target spell; or return target permanent to its owner's hand; or tap all creatures your opponents control; or draw a card.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "9ccbcc46-fee2-5fab-b39c-7f93609d84cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ebd6ff-2b1c-4e93-81cc-81998459c5c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ebd6ff-2b1c-4e93-81cc-81998459c5c7.jpg?1",
             "name": "Deeptread Merrow",
             "text": "{U}: Deeptread Merrow gains islandwalk until end of turn.",
             "colours": [
@@ -1970,7 +1970,7 @@
         },
         {
             "id": "ef65bf00-4d8b-5597-ae28-f6ab5be81b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149aa77e-fc10-4b9b-8f38-cc6db5be7b79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149aa77e-fc10-4b9b-8f38-cc6db5be7b79.jpg?1",
             "name": "Drowner of Secrets",
             "text": "Tap an untapped Merfolk you control: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "41a0767f-5881-5296-8a55-22f3c6afd338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f577831b-2aa2-44a1-bd6b-ef111bc2e211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f577831b-2aa2-44a1-bd6b-ef111bc2e211.jpg?1",
             "name": "Ego Erasure",
             "text": "Changeling (This card is every creature type at all times.)\nCreatures target player controls get -2/-0 and lose all creature types until end of turn.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "c71c907f-5c72-5023-bf27-f4231eae4c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fa774-fb6d-4a2f-96d5-a449a423312e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fa774-fb6d-4a2f-96d5-a449a423312e.jpg?1",
             "name": "Ethereal Whiskergill",
             "text": "Flying\nEthereal Whiskergill can't attack unless defending player controls an Island.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "b305a14b-3eed-59d1-97d6-345a231bd2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9bdc319-4e06-420b-ba54-6cb994d4e279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9bdc319-4e06-420b-ba54-6cb994d4e279.jpg?1",
             "name": "Faerie Harbinger",
             "text": "Flash\nFlying\nWhen Faerie Harbinger comes into play, you may search your library for a Faerie card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "d55e8047-dc13-5c35-88d8-5cd71823970c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defb9f0b-195e-4aeb-92c1-8f827ad6724b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defb9f0b-195e-4aeb-92c1-8f827ad6724b.jpg?1",
             "name": "Faerie Trickery",
             "text": "Counter target non-Faerie spell. If that spell is countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "fa30f14e-a55b-5ec1-a1d9-3ab07e8171f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4237352-4e0e-4f40-946b-2a61753674d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4237352-4e0e-4f40-946b-2a61753674d4.jpg?1",
             "name": "Fallowsage",
             "text": "Whenever Fallowsage becomes tapped, you may draw a card.",
             "colours": [
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "24af9461-ce43-5900-b229-146d93630b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9be91-f3a1-49ce-8a3e-2ecd30e2e692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9be91-f3a1-49ce-8a3e-2ecd30e2e692.jpg?1",
             "name": "Familiar's Ruse",
             "text": "As an additional cost to play Familiar's Ruse, return a creature you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "f9efdbe5-0ea6-518c-aaf7-fec4edd10e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg?1",
             "name": "Fathom Trawl",
             "text": "Reveal cards from the top of your library until you reveal three nonland cards. Put the nonland cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "4e3940fe-d7d5-589f-b9af-f96353056624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg?1",
             "name": "Forced Fruition",
             "text": "Whenever an opponent plays a spell, that player draws seven cards.",
             "colours": [
@@ -2275,7 +2275,7 @@
         },
         {
             "id": "1c5226f7-ae03-545f-b5d0-264ad2850af9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a71800f-3e67-4cfb-a3b1-8c073a91b909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a71800f-3e67-4cfb-a3b1-8c073a91b909.jpg?1",
             "name": "Glen Elendra Pranksters",
             "text": "Flying\nWhenever you play a spell during an opponent's turn, you may return target creature you control to its owner's hand.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "daafe653-0e32-544c-8796-10f08be61c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05a4ce4-dbd5-4c47-8b40-c145c7f5d06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05a4ce4-dbd5-4c47-8b40-c145c7f5d06c.jpg?1",
             "name": "Glimmerdust Nap",
             "text": "Enchant tapped creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "e1e1cc96-4a34-55f1-ae59-6327b2d82c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec6ab7-afbe-46ea-a7a6-6b678256f33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eec6ab7-afbe-46ea-a7a6-6b678256f33e.jpg?1",
             "name": "Guile",
             "text": "Guile can't be blocked except by three or more creatures.\nIf a spell or ability you control would counter a spell, instead remove that spell from the game and you may play that card without paying its mana cost.\nWhen Guile is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "c24c28b9-ec54-567f-85be-ae0cfa3bdcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7ce6e-0d84-4d66-a1dd-26ddac73d47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce7ce6e-0d84-4d66-a1dd-26ddac73d47b.jpg?1",
             "name": "Inkfathom Divers",
             "text": "Islandwalk\nWhen Inkfathom Divers comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "59554d01-b3a8-50be-9257-f0a47a74c6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdffb058-1af0-41bb-956a-ae10e092c389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdffb058-1af0-41bb-956a-ae10e092c389.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n-1: Target player draws a card.\n-10: Target player puts the top twenty cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "b19a81d2-c174-58f9-8794-9524697d48d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad0c3b4-fd24-44ad-8b30-4176f07be3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad0c3b4-fd24-44ad-8b30-4176f07be3d6.jpg?1",
             "name": "Merrow Commerce",
             "text": "At the end of your turn, untap all Merfolk you control.",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "9f632ee4-2fbd-5cc1-8169-a85afb5ac506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af11c-1090-4f0a-8eea-64a3b639e535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af11c-1090-4f0a-8eea-64a3b639e535.jpg?1",
             "name": "Merrow Harbinger",
             "text": "Islandwalk\nWhen Merrow Harbinger comes into play, you may search your library for a Merfolk card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "a5a515c8-36ce-5c9e-ac64-48aa90fb0747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57434d9-6fa5-43a6-98b9-044d2259d699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57434d9-6fa5-43a6-98b9-044d2259d699.jpg?1",
             "name": "Merrow Reejerey",
             "text": "Other Merfolk creatures you control get +1/+1.\nWhenever you play a Merfolk spell, you may tap or untap target permanent.",
             "colours": [
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "c420d3ad-3a65-5717-8a34-3c0a5a4a99cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg?1",
             "name": "Mistbind Clique",
             "text": "Flash\nFlying\nChampion a Faerie (When this comes into play, sacrifice it unless you remove another Faerie you control from the game. When this leaves play, that card returns to play.)\nWhen a Faerie is championed with Mistbind Clique, tap all lands target player controls.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "f7f20fb8-d1c9-5b6d-8757-f2409f9d072b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97cfefa-ade7-49f6-b2aa-1118b9db4935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97cfefa-ade7-49f6-b2aa-1118b9db4935.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter comes into play, draw two cards.\nEvoke {2}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "b332ec72-d1b2-55a0-811f-db52a1bc7b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a439c0ca-0cb2-4293-825e-1a72159953b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a439c0ca-0cb2-4293-825e-1a72159953b9.jpg?1",
             "name": "Paperfin Rascal",
             "text": "When Paperfin Rascal comes into play, clash with an opponent. If you win, put a +1/+1 counter on Paperfin Rascal. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "b17ec02b-0b99-572c-b0b0-67d1ee3966df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ae53-443c-4a27-b8f0-639a9a2b8598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252ae53-443c-4a27-b8f0-639a9a2b8598.jpg?1",
             "name": "Pestermite",
             "text": "Flash\nFlying\nWhen Pestermite comes into play, you may tap or untap target permanent.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "9993fc86-2ca1-58b8-98cd-e64c50ad5e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6b6fc5-5077-4812-b8e9-906783dbaf67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6b6fc5-5077-4812-b8e9-906783dbaf67.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "94b62495-e5b8-5e30-8d84-eb445e572a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab1db58-66b6-4b92-9dcd-e044fa383469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab1db58-66b6-4b92-9dcd-e044fa383469.jpg?1",
             "name": "Protective Bubble",
             "text": "Enchant creature\nEnchanted creature is unblockable and has shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "5aaa0934-ed94-5b02-b01f-0fbad10ea468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d3ae1f-5442-4725-a16a-502f13359a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d3ae1f-5442-4725-a16a-502f13359a85.jpg?1",
             "name": "Ringskipper",
             "text": "Flying\nWhen Ringskipper is put into a graveyard from play, clash with an opponent. If you win, return Ringskipper to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "76cc8370-eee1-51cd-846e-4c6c15275ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c536c1ce-a012-4d77-ab29-8574be164731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c536c1ce-a012-4d77-ab29-8574be164731.jpg?1",
             "name": "Scattering Stroke",
             "text": "Counter target spell. Clash with an opponent. If you win, at the beginning of your next main phase, you may add {X} to your mana pool, where X is that spell's converted mana cost. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2827,7 +2827,7 @@
         },
         {
             "id": "53cd4bcd-2017-54fa-a472-5504368bfd65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75fc1eb-09ac-4800-a55d-c0e723f5786b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75fc1eb-09ac-4800-a55d-c0e723f5786b.jpg?1",
             "name": "Scion of Oona",
             "text": "Flash\nFlying\nOther Faerie creatures you control get +1/+1.\nOther Faeries you control have shroud. (A permanent with shroud can't be the target of spells or abilities.)",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "a1abe36e-7015-53c2-b9e6-2befb6d9b494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48daf7e-2f8e-4179-a145-a6b36dd11d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48daf7e-2f8e-4179-a145-a6b36dd11d44.jpg?1",
             "name": "Sentinels of Glen Elendra",
             "text": "Flash\nFlying",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "ed2a06c3-a3f5-5673-97a7-50d8f4198c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg?1",
             "name": "Shapesharer",
             "text": "Changeling (This card is every creature type at all times.)\n{2}{U}: Target Shapeshifter becomes a copy of target creature until your next turn.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "3b3df2f3-63cf-5b24-ba39-224f02554ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e07a38a-2d88-4b01-9634-f24cbc8d96d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e07a38a-2d88-4b01-9634-f24cbc8d96d6.jpg?1",
             "name": "Silvergill Adept",
             "text": "As an additional cost to play Silvergill Adept, reveal a Merfolk card from your hand or pay {3}.\nWhen Silvergill Adept comes into play, draw a card.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "809af707-0ad7-52cd-9498-7c637e277014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8875c883-8d56-406b-bd89-42199a6e79f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8875c883-8d56-406b-bd89-42199a6e79f5.jpg?1",
             "name": "Silvergill Douser",
             "text": "{T}: Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "67cf3648-4174-5cc9-a762-15b3ea31bb33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5320da-7214-4348-84d8-74bf951c9f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5320da-7214-4348-84d8-74bf951c9f2f.jpg?1",
             "name": "Sower of Temptation",
             "text": "Flying\nWhen Sower of Temptation comes into play, gain control of target creature as long as Sower of Temptation remains in play.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "021875f5-e4da-5807-aea6-9403c9336bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ba4a9-a282-4d4b-b25a-179e05e458f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ba4a9-a282-4d4b-b25a-179e05e458f4.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "Flash\nFlying\nWhen Spellstutter Sprite comes into play, counter target spell with converted mana cost X or less, where X is the number of Faeries you control.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "18d0575d-4f6c-5897-8935-ceae3cfceedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047709e7-c44f-47e4-a9cc-1d941264e454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/047709e7-c44f-47e4-a9cc-1d941264e454.jpg?1",
             "name": "Stonybrook Angler",
             "text": "{1}{U}, {T}: You may tap or untap target creature.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "5e11de0d-fe85-514e-8e18-7a0117b09382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed908f4-630c-4f3c-9e61-4725b88b93ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed908f4-630c-4f3c-9e61-4725b88b93ff.jpg?1",
             "name": "Streambed Aquitects",
             "text": "{T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn.\n{T}: Target land becomes an Island until end of turn.",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "9b8c0013-5e7e-5d65-9f4a-b8463605ffca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5b00cb-ebc3-44e8-970d-724150eb7876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5b00cb-ebc3-44e8-970d-724150eb7876.jpg?1",
             "name": "Surgespanner",
             "text": "Whenever Surgespanner becomes tapped, you may pay {1}{U}. If you do, return target permanent to its owner's hand.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "8b7b3075-2ac8-5460-b6c3-83b07bba128a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e526ebbf-2041-4c3e-9a20-73bbf6f90251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e526ebbf-2041-4c3e-9a20-73bbf6f90251.jpg?1",
             "name": "Tideshaper Mystic",
             "text": "{T}: Target land becomes the basic land type of your choice until end of turn. Play this ability only during your turn.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "1e1df2e9-5e93-534b-880e-d07ac43ff1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b078e-e324-4775-9d38-08943017a48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a72b078e-e324-4775-9d38-08943017a48e.jpg?1",
             "name": "Turtleshell Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{U}: Switch Turtleshell Changeling's power and toughness until end of turn.",
             "colours": [
@@ -3245,7 +3245,7 @@
         },
         {
             "id": "bca9e94e-dd9b-59e1-88e7-ebbb1bde09a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg?1",
             "name": "Wanderwine Prophets",
             "text": "Champion a Merfolk (When this comes into play, sacrifice it unless you remove another Merfolk you control from the game. When this leaves play, that card returns to play.)\nWhenever Wanderwine Prophets deals combat damage to a player, you may sacrifice a Merfolk. If you do, take an extra turn after this one.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "2c82c07a-5b12-5d52-888c-92266918a403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1934c34a-c163-4fac-a80d-8b17e8d64efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1934c34a-c163-4fac-a80d-8b17e8d64efa.jpg?1",
             "name": "Whirlpool Whelm",
             "text": "Clash with an opponent, then return target creature to its owner's hand. If you win, you may put that creature on top of its owner's library instead. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3312,7 +3312,7 @@
         },
         {
             "id": "860e56e2-c33f-52c7-93e1-764130b23690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3c1f39-b6ac-4663-9623-bd573a1117b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3c1f39-b6ac-4663-9623-bd573a1117b0.jpg?1",
             "name": "Wings of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nTarget creature becomes 4/4, gains all creature types, and gains flying until end of turn.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "df3778ca-c634-5d56-a75a-6606a298703b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8996-388f-4704-a4c8-ef99d4701805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8996-388f-4704-a4c8-ef99d4701805.jpg?1",
             "name": "Zephyr Net",
             "text": "Enchant creature\nEnchanted creature has defender and flying.",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "ec6d12d6-3c02-5784-99a1-26c702fe0a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a1fc03-5719-49ed-9d53-d8ea5693373e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a1fc03-5719-49ed-9d53-d8ea5693373e.jpg?1",
             "name": "Black Poplar Shaman",
             "text": "{2}{B}: Regenerate target Treefolk.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "02d7b486-f029-5ac8-99dc-a40b1dee459c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2459953-a4b5-4a9c-85ed-928b684d7240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2459953-a4b5-4a9c-85ed-928b684d7240.jpg?1",
             "name": "Bog Hoodlums",
             "text": "Bog Hoodlums can't block.\nWhen Bog Hoodlums comes into play, clash with an opponent. If you win, put a +1/+1 counter on Bog Hoodlums. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "824901ed-9593-528d-adf7-f295d48d8b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb4916d-ab50-45c9-bf7e-e7a7e761aef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb4916d-ab50-45c9-bf7e-e7a7e761aef4.jpg?1",
             "name": "Boggart Birth Rite",
             "text": "Return target Goblin card from your graveyard to your hand.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "9b73cc2d-2e57-5f05-b365-76ccb881141c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea8d2b8-bcac-410d-aa5a-e4a74f7d5315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea8d2b8-bcac-410d-aa5a-e4a74f7d5315.jpg?1",
             "name": "Boggart Harbinger",
             "text": "When Boggart Harbinger comes into play, you may search your library for a Goblin card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "7688a486-23c2-51a2-8757-cd103553a4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed9a638-c3f9-48dd-9633-5c52146e0dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed9a638-c3f9-48dd-9633-5c52146e0dcd.jpg?1",
             "name": "Boggart Loggers",
             "text": "Forestwalk\n{2}{B}, Sacrifice Boggart Loggers: Destroy target Treefolk or Forest.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "87f6b8e9-061c-51bd-a15c-548b283533c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg?1",
             "name": "Boggart Mob",
             "text": "Champion a Goblin (When this comes into play, sacrifice it unless you remove another Goblin you control from the game. When this leaves play, that card returns to play.)\nWhenever a Goblin you control deals combat damage to a player, you may put a 1/1 black Goblin Rogue creature token into play.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "b65d054b-4ee7-59c7-9196-cf1d3663574a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b870a7aa-0836-4e3e-8be9-3299bdaded81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b870a7aa-0836-4e3e-8be9-3299bdaded81.jpg?1",
             "name": "Cairn Wanderer",
             "text": "Changeling (This card is every creature type at all times.)\nAs long as a creature card with flying is in a graveyard, Cairn Wanderer has flying. The same is true for fear, first strike, double strike, deathtouch, haste, landwalk, lifelink, protection, reach, trample, shroud, and vigilance.",
             "colours": [
@@ -3625,7 +3625,7 @@
         },
         {
             "id": "32f34f06-c4b2-5059-8667-41f7829e6558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg?1",
             "name": "Colfenor's Plans",
             "text": "When Colfenor's Plans comes into play, remove the top seven cards of your library from the game face down.\nYou may look at and play cards removed from the game with Colfenor's Plans.\nSkip your draw step.\nYou can't play more than one spell each turn.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "95ccf54f-275a-546b-affc-6f4b81e9e30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg?1",
             "name": "Dread",
             "text": "Fear\nWhenever a creature deals damage to you, destroy it.\nWhen Dread is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "6961c7b9-f5c3-53cc-9a9b-5b7fdaf07796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5c2487-5da0-4d9a-beb2-598feeb068a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5c2487-5da0-4d9a-beb2-598feeb068a1.jpg?1",
             "name": "Dreamspoiler Witches",
             "text": "Flying\nWhenever you play a spell during an opponent's turn, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "db70e6d9-f309-57bf-87e0-cbab571be038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe41509-02db-415c-964e-971ea1d5485c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe41509-02db-415c-964e-971ea1d5485c.jpg?1",
             "name": "Exiled Boggart",
             "text": "When Exiled Boggart is put into a graveyard from play, discard a card.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "15d5d12d-25be-5044-95b6-821f6040f3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c08701-7038-4d6b-bbf8-056fd8ffb226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c08701-7038-4d6b-bbf8-056fd8ffb226.jpg?1",
             "name": "Eyeblight's Ending",
             "text": "Destroy target non-Elf creature.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "b1dd00c8-e970-51be-8fac-516868c751b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc973d3-39cf-4d0c-a3e9-70af2be3cd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc973d3-39cf-4d0c-a3e9-70af2be3cd68.jpg?1",
             "name": "Facevaulter",
             "text": "{B}, Sacrifice a Goblin: Facevaulter gets +2/+2 until end of turn.",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "6dd6b5d2-f16e-5a52-bb9b-39bc16b93b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33727782-dafd-4a7c-96dd-6ffaf667cc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33727782-dafd-4a7c-96dd-6ffaf667cc6b.jpg?1",
             "name": "Faerie Tauntings",
             "text": "Whenever you play a spell during an opponent's turn, you may have each opponent lose 1 life.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "d9239199-edea-5c60-9369-adf479c4551e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f3744a-71c4-4a54-9e1c-92420526b792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f3744a-71c4-4a54-9e1c-92420526b792.jpg?1",
             "name": "Final Revels",
             "text": "Choose one All creatures get +2/+0 until end of turn; or all creatures get -0/-2 until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "a6db408d-712e-5e8e-b3db-6c1359abf7b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000670f-1151-4abf-a7ec-b35a6e587183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000670f-1151-4abf-a7ec-b35a6e587183.jpg?1",
             "name": "Fodder Launch",
             "text": "As an additional cost to play Fodder Launch, sacrifice a Goblin.\nTarget creature gets -5/-5 until end of turn. Fodder Launch deals 5 damage to that creature's controller.",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "3b7f5ba7-1a5d-5ccb-ab0c-52e8d3169811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc04f820-9505-4ccd-98e7-1bb861161af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc04f820-9505-4ccd-98e7-1bb861161af5.jpg?1",
             "name": "Footbottom Feast",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "a8eb1bd7-913e-59b6-a11a-49e87be9a47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7218726-dfa2-4d13-a210-5d54024e2d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7218726-dfa2-4d13-a210-5d54024e2d27.jpg?1",
             "name": "Ghostly Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{B}: Ghostly Changeling gets +1/+1 until end of turn.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "327e27d3-0880-58f4-a29f-90f0c5acd34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666a328-cc51-4be1-abef-06bbe41dd866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9666a328-cc51-4be1-abef-06bbe41dd866.jpg?1",
             "name": "Hoarder's Greed",
             "text": "You lose 2 life and draw two cards, then clash with an opponent. If you win, repeat this process. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "30329e3c-cd61-5aea-93b3-73c7cd5437be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45598727-a8b1-4b3e-87c6-70c36f0d4fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45598727-a8b1-4b3e-87c6-70c36f0d4fe8.jpg?1",
             "name": "Hornet Harasser",
             "text": "When Hornet Harasser is put into a graveyard from play, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "6b8f6fdb-53a1-5395-bf6f-5734ebb38cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5b8db-4a56-45bd-9704-a1316016ec5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd5b8db-4a56-45bd-9704-a1316016ec5b.jpg?1",
             "name": "Hunter of Eyeblights",
             "text": "When Hunter of Eyeblights comes into play, put a +1/+1 counter on target creature you don't control.\n{2}{B}, {T}: Destroy target creature with a counter on it.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "ea801f2c-b1a9-59b5-a28e-1cf5978b21c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg?1",
             "name": "Knucklebone Witch",
             "text": "Whenever a Goblin you control is put into a graveyard from play, you may put a +1/+1 counter on Knucklebone Witch.",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "a328988f-dd91-5855-9213-3c9bc106a431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1662fcb1-f142-43ff-b682-6827dea2ff7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1662fcb1-f142-43ff-b682-6827dea2ff7e.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n-2: Search your library for a card, then shuffle your library and put that card on top of it.\n-8: Put all creature cards in all graveyards into play under your control.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "acab84b4-cbd8-5807-ae5e-a6f72e75a123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7614e3e7-708f-4717-b798-97f0c391a673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7614e3e7-708f-4717-b798-97f0c391a673.jpg?1",
             "name": "Lys Alana Scarblade",
             "text": "{T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control.",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "84caad14-f852-5463-8242-5b960373ae4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b1655b-ab0a-40d9-8d4d-55d13310ede1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b1655b-ab0a-40d9-8d4d-55d13310ede1.jpg?1",
             "name": "Mad Auntie",
             "text": "Other Goblin creatures you control get +1/+1.\n{T}: Regenerate another target Goblin.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "c7364e04-e120-5908-9d61-f3ea86fa36cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79029161-a2c9-4cf6-94c0-31400daa0e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79029161-a2c9-4cf6-94c0-31400daa0e8e.jpg?1",
             "name": "Makeshift Mannequin",
             "text": "Return target creature card from your graveyard to play with a mannequin counter on it. As long as that creature has a mannequin counter on it, it has \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "3bbd7b6b-b9a6-56d3-8f21-c01a295481f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040e1039-1943-4c2d-aa98-b7f9519de321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040e1039-1943-4c2d-aa98-b7f9519de321.jpg?1",
             "name": "Marsh Flitter",
             "text": "Flying\nWhen Marsh Flitter comes into play, put two 1/1 black Goblin Rogue creature tokens into play.\nSacrifice a Goblin: Marsh Flitter becomes 3/3 until end of turn.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "4084fa60-05ee-5a72-97d7-a163fc4a3848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effb7761-98a8-4cb8-883a-ddcb91d30c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effb7761-98a8-4cb8-883a-ddcb91d30c08.jpg?1",
             "name": "Moonglove Winnower",
             "text": "Deathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "8363719d-769c-535d-bfc0-ce37fd5c18fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a62a282-5f94-444b-9095-4c36fabdad57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a62a282-5f94-444b-9095-4c36fabdad57.jpg?1",
             "name": "Mournwhelk",
             "text": "When Mournwhelk comes into play, target player discards two cards.\nEvoke {3}{B} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -4379,7 +4379,7 @@
         },
         {
             "id": "a8806d15-3b45-50c1-a1c2-3f19705c8a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4e4d2-2358-48d2-9a2a-3d17afea28f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b4e4d2-2358-48d2-9a2a-3d17afea28f5.jpg?1",
             "name": "Nameless Inversion",
             "text": "Changeling (This card is every creature type at all times.)\nTarget creature gets +3/-3 and loses all creature types until end of turn.",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "a3445c8f-6449-544d-9e88-e73514cb03a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f077d2-34ab-45fa-84db-eb408c5a9996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66f077d2-34ab-45fa-84db-eb408c5a9996.jpg?1",
             "name": "Nath's Buffoon",
             "text": "Protection from Elves",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "c6c86b94-09b5-5725-b382-d419a9d6512c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d943b877-805d-4bc8-a3ae-abec00fa51a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d943b877-805d-4bc8-a3ae-abec00fa51a6.jpg?1",
             "name": "Nectar Faerie",
             "text": "Flying\n{B}, {T}: Target Faerie or Elf gains lifelink until end of turn. (Whenever it deals damage, its controller gains that much life.)",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "c275e4cb-4eca-5442-909e-44efd10dd8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg?1",
             "name": "Nettlevine Blight",
             "text": "Enchant creature or land\nEnchanted permanent has \"At the end of your turn, sacrifice this permanent and attach Nettlevine Blight to a creature or land you control.\"",
             "colours": [
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "4bf50a90-b38e-527f-8251-dae35822ed87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa341824-bf3a-49ce-a8a0-ee53f537d626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa341824-bf3a-49ce-a8a0-ee53f537d626.jpg?1",
             "name": "Nightshade Stinger",
             "text": "Flying\nNightshade Stinger can't block.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "48edfe39-f25b-5d87-a12f-32eba761ee63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9675b8ea-47f9-440e-9535-de879da53f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9675b8ea-47f9-440e-9535-de879da53f76.jpg?1",
             "name": "Oona's Prowler",
             "text": "Flying\nDiscard a card: Oona's Prowler gets -2/-0 until end of turn. Any player may play this ability.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "f5652c93-dce6-57c3-a297-90c10d4ae9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568586ca-8a02-4a77-bd65-c0b4a74c429d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568586ca-8a02-4a77-bd65-c0b4a74c429d.jpg?1",
             "name": "Peppersmoke",
             "text": "Target creature gets -1/-1 until end of turn. If you control a Faerie, draw a card.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "c41c6e2c-c5ce-5573-9b0a-4c1a9b3c60a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf7fd-c49e-42fa-bbdd-8ca5d4c89b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752bf7fd-c49e-42fa-bbdd-8ca5d4c89b2b.jpg?1",
             "name": "Profane Command",
             "text": "Choose two Target player loses X life; or return target creature card with converted mana cost X or less from your graveyard to play; or target creature gets -X/-X until end of turn; or up to X target creatures gain fear until end of turn.",
             "colours": [
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "853dbcd9-9eb3-5dd6-869a-c7f8ab017e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099badba-1c8a-4a74-80e9-133f2bafb94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099badba-1c8a-4a74-80e9-133f2bafb94d.jpg?1",
             "name": "Prowess of the Fair",
             "text": "Whenever another nontoken Elf is put into your graveyard from play, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -4690,7 +4690,7 @@
         },
         {
             "id": "74fafc88-d68b-54f5-97fe-6d2dc18e6300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a15a9d-46d7-4181-8131-50ba46a11c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a15a9d-46d7-4181-8131-50ba46a11c7b.jpg?1",
             "name": "Quill-Slinger Boggart",
             "text": "Whenever a player plays a Kithkin spell, you may have target player lose 1 life.",
             "colours": [
@@ -4725,7 +4725,7 @@
         },
         {
             "id": "061fe681-9068-56f9-ba21-5c5f67ef30f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60c51c2-3a24-4376-850c-cebd4d75adca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60c51c2-3a24-4376-850c-cebd4d75adca.jpg?1",
             "name": "Scarred Vinebreeder",
             "text": "{2}{B}, Remove an Elf card in your graveyard from the game: Scarred Vinebreeder gets +3/+3 until end of turn.",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "4afff67e-8e8f-5bc6-9af1-796919d27990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea19eb5e-0d70-42e6-bda2-b13757e08ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea19eb5e-0d70-42e6-bda2-b13757e08ca6.jpg?1",
             "name": "Shriekmaw",
             "text": "Fear\nWhen Shriekmaw comes into play, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "47995907-16ac-5a93-bc73-f7af8eb0b9e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1d8e26-304b-4571-9b33-7713265d9bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1d8e26-304b-4571-9b33-7713265d9bbf.jpg?1",
             "name": "Skeletal Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{B}: Regenerate Skeletal Changeling.",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "22027565-643e-5d07-b30f-6c7a4eb61edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e77c10-b569-485f-ba3e-16ef0c57dd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e77c10-b569-485f-ba3e-16ef0c57dd81.jpg?1",
             "name": "Spiderwig Boggart",
             "text": "When Spiderwig Boggart comes into play, target creature gains fear until end of turn.",
             "colours": [
@@ -4863,7 +4863,7 @@
         },
         {
             "id": "8d145e52-0bf1-5fe5-bff4-9f4adf068508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7184715-3ed3-4f56-9bf3-ff431cca86be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7184715-3ed3-4f56-9bf3-ff431cca86be.jpg?1",
             "name": "Squeaking Pie Sneak",
             "text": "As an additional cost to play Squeaking Pie Sneak, reveal a Goblin card from your hand or pay {3}.\nFear",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "4ac0ff5b-3eb5-5746-9611-b0587b1fa537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5b51c3-60a8-45b2-9de0-605388091e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5b51c3-60a8-45b2-9de0-605388091e8a.jpg?1",
             "name": "Thieving Sprite",
             "text": "Flying\nWhen Thieving Sprite comes into play, target player reveals X cards from his or her hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "186fe99a-d71e-5141-9211-5098f0123964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140265a2-61c3-4731-989c-9d55c27400ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140265a2-61c3-4731-989c-9d55c27400ec.jpg?1",
             "name": "Thorntooth Witch",
             "text": "Whenever you play a Treefolk spell, you may have target creature get +3/-3 until end of turn.",
             "colours": [
@@ -4968,7 +4968,7 @@
         },
         {
             "id": "fb23c3c4-7059-5442-b195-6611a593cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df8c148-e87d-4043-9d8b-ec72bf8b6d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df8c148-e87d-4043-9d8b-ec72bf8b6d5d.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "8c14cddd-2a0a-574f-ad8e-0ee400f18722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc98177b-34a6-44e1-9abd-6fd8df09fc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc98177b-34a6-44e1-9abd-6fd8df09fc70.jpg?1",
             "name": "Warren Pilferers",
             "text": "When Warren Pilferers comes into play, return target creature card from your graveyard to your hand. If that card is a Goblin card, Warren Pilferers gains haste until end of turn.",
             "colours": [
@@ -5035,7 +5035,7 @@
         },
         {
             "id": "07276404-49cd-5185-b0f6-1d9759685e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f7fb79-19a8-483a-bf91-e687f7da4e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f7fb79-19a8-483a-bf91-e687f7da4e9c.jpg?1",
             "name": "Weed Strangle",
             "text": "Destroy target creature. Clash with an opponent. If you win, you gain life equal to that creature's toughness. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "0d774eda-c985-57eb-9f41-e35c81b802b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116839f-6a3a-4a2e-a3ab-ea177c012746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116839f-6a3a-4a2e-a3ab-ea177c012746.jpg?1",
             "name": "Adder-Staff Boggart",
             "text": "When Adder-Staff Boggart comes into play, clash with an opponent. If you win, put a +1/+1 counter on Adder-Staff Boggart. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -5102,7 +5102,7 @@
         },
         {
             "id": "d6914b7f-6b4b-5164-9c39-8e068dfde1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056eb9-4257-4530-8ff4-6909a2cedf47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63056eb9-4257-4530-8ff4-6909a2cedf47.jpg?1",
             "name": "Ashling the Pilgrim",
             "text": "{1}{R}: Put a +1/+1 counter on Ashling the Pilgrim. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling the Pilgrim, and it deals that much damage to each creature and each player.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "de596bca-1ff5-58b4-b14a-8ba122dd5446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg?1",
             "name": "Ashling's Prerogative",
             "text": "As Ashling's Prerogative comes into play, choose odd or even. (Zero is even.)\nEach creature with converted mana cost of the chosen value has haste.\nEach creature without converted mana cost of the chosen value comes into play tapped.",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "48cb95c3-f6b0-5c6f-9fb7-ff982f01d4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8595e9a1-010e-48a7-91e4-3d2722c8dbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8595e9a1-010e-48a7-91e4-3d2722c8dbc0.jpg?1",
             "name": "Axegrinder Giant",
             "text": "",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "8fc25ba5-320d-51b0-8178-d6b10dbd2c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac629-a8c9-4b84-a8ea-b775d7913238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac629-a8c9-4b84-a8ea-b775d7913238.jpg?1",
             "name": "Blades of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nUp to two target creatures each get +2/+0 and gain all creature types until end of turn.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "53582834-2c7e-5879-9dd5-36d5f02b003a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75aaca31-8ed5-4e8a-8332-1cca77903f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75aaca31-8ed5-4e8a-8332-1cca77903f88.jpg?1",
             "name": "Blind-Spot Giant",
             "text": "Blind-Spot Giant can't attack or block unless you control another Giant.",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "67d6dc5e-6828-5ace-9139-8fc0ba4f8a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc26374-d8de-4740-b1ec-ac92cfedbebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc26374-d8de-4740-b1ec-ac92cfedbebc.jpg?1",
             "name": "Boggart Forager",
             "text": "{R}, Sacrifice Boggart Forager: Target player shuffles his or her library.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "7e892daf-230e-5b43-a923-c8e3a70da7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3c0ea9-270d-4738-9462-7f48fecb4bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3c0ea9-270d-4738-9462-7f48fecb4bf4.jpg?1",
             "name": "Boggart Shenanigans",
             "text": "Whenever another Goblin you control is put into a graveyard from play, you may have Boggart Shenanigans deal 1 damage to target player.",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "a7a2379d-b10e-5b05-bbfa-fde1a29f1efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6341b73b-a035-45a2-908d-879c8eed4bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6341b73b-a035-45a2-908d-879c8eed4bbd.jpg?1",
             "name": "Boggart Sprite-Chaser",
             "text": "As long as you control a Faerie, Boggart Sprite-Chaser gets +1/+1 and has flying.",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "df5f934b-ce05-540a-aeb7-6b707a02658b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8337bf-9fe8-45a0-974c-8911306b19ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8337bf-9fe8-45a0-974c-8911306b19ea.jpg?1",
             "name": "Caterwauling Boggart",
             "text": "Each Goblin you control can't be blocked except by two or more creatures.\nEach Elemental you control can't be blocked except by two or more creatures.",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "04d2a65d-8ab3-5bec-b3f3-9bf84d34bb76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e103a3-555c-4b68-9768-42637bfd2478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e103a3-555c-4b68-9768-42637bfd2478.jpg?1",
             "name": "Ceaseless Searblades",
             "text": "Whenever you play an activated ability of an Elemental, Ceaseless Searblades gets +1/+0 until end of turn.",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "bdc84b1f-fcc3-5320-9988-2225c6d5c046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317e7ab7-7639-4877-aae2-3746563f2ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317e7ab7-7639-4877-aae2-3746563f2ec9.jpg?1",
             "name": "Chandra Nalaar",
             "text": "+1: Chandra Nalaar deals 1 damage to target player.\n-X: Chandra Nalaar deals X damage to target creature.\n-8: Chandra Nalaar deals 10 damage to target player and each creature he or she controls.",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "125eeb55-4f0b-5ec0-9f8d-12ee9ade6e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2e8f24-2ee1-4516-bf60-7fe6a0c4baec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f2e8f24-2ee1-4516-bf60-7fe6a0c4baec.jpg?1",
             "name": "Changeling Berserker",
             "text": "Changeling (This card is every creature type at all times.)\nHaste\nChampion a creature (When this comes into play, sacrifice it unless you remove another creature you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "bc6ec1ad-3a02-5fab-b73b-56cc531a269c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a4ec08-5029-4f7b-a93b-a5dad4be5113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a4ec08-5029-4f7b-a93b-a5dad4be5113.jpg?1",
             "name": "Consuming Bonfire",
             "text": "Choose one Consuming Bonfire deals 4 damage to target non-Elemental creature; or Consuming Bonfire deals 7 damage to target Treefolk creature.",
             "colours": [
@@ -5556,7 +5556,7 @@
         },
         {
             "id": "9e7f8940-4ec8-5c9a-a9e1-0195be5f5c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0386925-53bc-4902-ac30-cbdcb099936d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0386925-53bc-4902-ac30-cbdcb099936d.jpg?1",
             "name": "Crush Underfoot",
             "text": "Choose a Giant creature you control. It deals damage equal to its power to target creature.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "21783532-942c-50ad-acca-2fdfc7dbe04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88b32a-986c-4317-b4a3-119f67e13b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88b32a-986c-4317-b4a3-119f67e13b83.jpg?1",
             "name": "Faultgrinder",
             "text": "Trample\nWhen Faultgrinder comes into play, destroy target land.\nEvoke {4}{R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "996cccb8-9484-5ad2-a1d2-54994c6f68f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4732342-71a4-4079-b549-f4454945273a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4732342-71a4-4079-b549-f4454945273a.jpg?1",
             "name": "Fire-Belly Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{R}: Fire-Belly Changeling gets +1/+0 until end of turn. Play this ability no more than twice each turn.",
             "colours": [
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "419008ea-4561-5fca-a024-719925bd6fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ea1c8-ca58-4240-adb7-71cd49664414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ea1c8-ca58-4240-adb7-71cd49664414.jpg?1",
             "name": "Flamekin Bladewhirl",
             "text": "As an additional cost to play Flamekin Bladewhirl, reveal an Elemental card from your hand or pay {3}.",
             "colours": [
@@ -5694,7 +5694,7 @@
         },
         {
             "id": "79a77f55-165a-5746-8b8f-4a73dca55de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301abe8f-916a-4e5b-bf25-f1e12ae9cee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301abe8f-916a-4e5b-bf25-f1e12ae9cee2.jpg?1",
             "name": "Flamekin Brawler",
             "text": "{R}: Flamekin Brawler gets +1/+0 until end of turn.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "f9e4c83d-7397-5d00-9458-25c4f611ab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f330c0f4-13d2-4432-9ced-f044bef98ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f330c0f4-13d2-4432-9ced-f044bef98ec8.jpg?1",
             "name": "Flamekin Harbinger",
             "text": "When Flamekin Harbinger comes into play, you may search your library for an Elemental card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -5764,7 +5764,7 @@
         },
         {
             "id": "6d026b77-b25d-5f41-ab2b-2f3bce48d427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7878e5-fcb0-4de5-8dda-fcdb4b138ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7878e5-fcb0-4de5-8dda-fcdb4b138ec1.jpg?1",
             "name": "Flamekin Spitfire",
             "text": "{3}{R}: Flamekin Spitfire deals 1 damage to target creature or player.",
             "colours": [
@@ -5799,7 +5799,7 @@
         },
         {
             "id": "eae0738e-4677-5f6a-b1b6-73931d662138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f72f461-98d7-45e0-9968-9afb240fbf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f72f461-98d7-45e0-9968-9afb240fbf1e.jpg?1",
             "name": "Giant Harbinger",
             "text": "When Giant Harbinger comes into play, you may search your library for a Giant card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "cfdb33c2-4459-5476-bc4d-e99317c8a0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fa2db-4c73-401a-b9a4-b039554be625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fa2db-4c73-401a-b9a4-b039554be625.jpg?1",
             "name": "Giant's Ire",
             "text": "Giant's Ire deals 4 damage to target player. If you control a Giant, draw a card.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "28a21701-487e-5d54-9bb2-22f862734499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc845-7165-40f3-a082-21a502b3f0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fdc845-7165-40f3-a082-21a502b3f0f6.jpg?1",
             "name": "Glarewielder",
             "text": "Haste\nWhen Glarewielder comes into play, up to two target creatures can't block this turn.\nEvoke {1}{R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "78007150-1ebe-5c52-9a1f-1c0e803cf813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f32852-2a18-453d-910a-829c3a2b5b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f32852-2a18-453d-910a-829c3a2b5b1b.jpg?1",
             "name": "Goatnapper",
             "text": "When Goatnapper comes into play, untap target Goat and gain control of it until end of turn. It gains haste until end of turn.",
             "colours": [
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "771f45e1-2fb0-5a3a-a64f-65edce4d0705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f71692-6389-462f-933e-b18b5aa7d76b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f71692-6389-462f-933e-b18b5aa7d76b.jpg?1",
             "name": "Hamletback Goliath",
             "text": "Whenever another creature comes into play, you may put X +1/+1 counters on Hamletback Goliath, where X is that creature's power.",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "cbd339fb-18a8-59f1-a699-9dc1d74c2a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg?1",
             "name": "Hearthcage Giant",
             "text": "When Hearthcage Giant comes into play, put two 3/1 red Elemental Shaman creature tokens into play.\nSacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "3fbe5c80-413e-5006-99c8-0c96ed0b046c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432470c-7f68-4429-970a-3da8eabcf0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a432470c-7f68-4429-970a-3da8eabcf0b8.jpg?1",
             "name": "Heat Shimmer",
             "text": "Put a token into play that's a copy of target creature. It has haste and \"At end of turn, remove this permanent from the game.\"",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "1217f146-ffa8-5d43-9929-84f8fe062572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f560199-7703-4e2a-8e2d-5728f6efef46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f560199-7703-4e2a-8e2d-5728f6efef46.jpg?1",
             "name": "Hostility",
             "text": "Haste\nIf a spell you control would deal damage to an opponent, prevent that damage. Put a 3/1 red Elemental Shaman creature token with haste into play for each 1 damage prevented this way.\nWhen Hostility is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "485b75ec-22c8-5e41-abb3-8a5ccec4336b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e0b97-c2a9-4cd6-957e-87e9b22f7b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e0b97-c2a9-4cd6-957e-87e9b22f7b48.jpg?1",
             "name": "Hurly-Burly",
             "text": "Choose one Hurly-Burly deals 1 damage to each creature without flying; or Hurly-Burly deals 1 damage to each creature with flying.",
             "colours": [
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "101c62b3-9d27-564d-8fe2-91bc8d1952d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8829b3c-5267-44c6-b709-c2dfc683b0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8829b3c-5267-44c6-b709-c2dfc683b0a8.jpg?1",
             "name": "Incandescent Soulstoke",
             "text": "Other Elemental creatures you control get +1/+1.\n{1}{R}, {T}: You may put an Elemental creature card from your hand into play. That creature gains haste until end of turn. Sacrifice it at end of turn.",
             "colours": [
@@ -6143,7 +6143,7 @@
         },
         {
             "id": "1b2a8b46-8cb6-59aa-ba80-a56601249cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512367a2-f8f6-4c28-9eb3-8e04d2694e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512367a2-f8f6-4c28-9eb3-8e04d2694e4b.jpg?1",
             "name": "Incendiary Command",
             "text": "Choose two Incendiary Command deals 4 damage to target player; or Incendiary Command deals 2 damage to each creature; or destroy target nonbasic land; or each player discards all the cards in his or her hand, then draws that many cards.",
             "colours": [
@@ -6175,7 +6175,7 @@
         },
         {
             "id": "b0f882fc-4b46-5509-aa39-0c4cc17d5e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ceb9ae9-d153-446f-8835-1c53672fc9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ceb9ae9-d153-446f-8835-1c53672fc9ca.jpg?1",
             "name": "Ingot Chewer",
             "text": "When Ingot Chewer comes into play, destroy target artifact.\nEvoke {R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "e2fc64c9-e44d-5585-a5d0-82ea89cb1b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99a113a-013a-411b-9f16-975cebd5ea5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99a113a-013a-411b-9f16-975cebd5ea5f.jpg?1",
             "name": "Inner-Flame Acolyte",
             "text": "When Inner-Flame Acolyte comes into play, target creature gets +2/+0 and gains haste until end of turn.\nEvoke {R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "61884589-3719-5022-b3a2-15a273ebb043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced8a0-1caa-4737-b863-eb244a3d388a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced8a0-1caa-4737-b863-eb244a3d388a.jpg?1",
             "name": "Inner-Flame Igniter",
             "text": "{2}{R}: Creatures you control get +1/+0 until end of turn. If this is the third time this ability has resolved this turn, creatures you control gain first strike until end of turn.",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "caddad48-59a1-56c4-9b25-9c3b9af2211c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2c0c8b-5442-44fb-9686-d3dff5742501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2c0c8b-5442-44fb-9686-d3dff5742501.jpg?1",
             "name": "Lash Out",
             "text": "Lash Out deals 3 damage to target creature. Clash with an opponent. If you win, Lash Out deals 3 damage to that creature's controller. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -6311,7 +6311,7 @@
         },
         {
             "id": "3127789f-5373-503f-b0dd-50ecd94eee2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaa7f6a-9639-4bee-aa12-20054d7975d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdaa7f6a-9639-4bee-aa12-20054d7975d5.jpg?1",
             "name": "Lowland Oaf",
             "text": "{T}: Target Goblin creature you control gets +1/+0 and gains flying until end of turn. Sacrifice that creature at end of turn.",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "dff4ad41-1cc3-50c8-8100-f2850b978096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50575eab-6c23-4f63-9667-458416c5caa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50575eab-6c23-4f63-9667-458416c5caa5.jpg?1",
             "name": "Mudbutton Torchrunner",
             "text": "When Mudbutton Torchrunner is put into a graveyard from play, it deals 3 damage to target creature or player.",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "cbf2ef16-dbf8-5121-81e0-8e0dcbe437c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f89bcf-46f8-4598-a949-7f10134606aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f89bcf-46f8-4598-a949-7f10134606aa.jpg?1",
             "name": "Needle Drop",
             "text": "Needle Drop deals 1 damage to target creature or player that was dealt damage this turn.\nDraw a card.",
             "colours": [
@@ -6413,7 +6413,7 @@
         },
         {
             "id": "2e3ae227-7eba-5af1-aca4-1e0fd2c4a971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg?1",
             "name": "Nova Chaser",
             "text": "Trample\nChampion an Elemental (When this comes into play, sacrifice it unless you remove another Elemental you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "3720a2a8-a6d2-528c-a756-033abf1de838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2c8cb-4852-4bde-b2cf-72ceb9b0dd3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2c8cb-4852-4bde-b2cf-72ceb9b0dd3e.jpg?1",
             "name": "Rebellion of the Flamekin",
             "text": "Whenever you clash, you may pay {1}. If you do, put a 3/1 red Elemental Shaman creature token into play. If you won, that token gains haste until end of turn. (This ability triggers after the clash ends.)",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "b746c640-8bca-50a6-98ba-40f8edf0339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c6227b-bd43-47e8-927f-f8a78c532591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c6227b-bd43-47e8-927f-f8a78c532591.jpg?1",
             "name": "Smokebraider",
             "text": "{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to play Elemental spells or activated abilities of Elementals.",
             "colours": [
@@ -6518,7 +6518,7 @@
         },
         {
             "id": "3712e236-3d82-5391-b94b-0db29e8cd242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf72b4d-a399-49fb-a890-653b184a9e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf72b4d-a399-49fb-a890-653b184a9e95.jpg?1",
             "name": "Soulbright Flamekin",
             "text": "{2}: Target creature gains trample until end of turn. If this is the third time this ability has resolved this turn, you may add {R}{R}{R}{R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -6553,7 +6553,7 @@
         },
         {
             "id": "d799a598-2c60-5d20-8847-a91136c16c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428ba328-a0d8-4c52-ac2c-e9698486cc08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428ba328-a0d8-4c52-ac2c-e9698486cc08.jpg?1",
             "name": "Stinkdrinker Daredevil",
             "text": "Giant spells you play cost {2} less to play.",
             "colours": [
@@ -6588,7 +6588,7 @@
         },
         {
             "id": "f94b0d25-867e-591c-a572-614a6e16c226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62a4703-9e8d-4164-a529-b2dbc4069aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62a4703-9e8d-4164-a529-b2dbc4069aa8.jpg?1",
             "name": "Sunrise Sovereign",
             "text": "Other Giant creatures you control get +2/+2 and have trample.",
             "colours": [
@@ -6623,7 +6623,7 @@
         },
         {
             "id": "d21232ce-62c2-5163-a554-56e6ab9f51eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2ec11-eb65-488d-a857-b5020113c429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2ec11-eb65-488d-a857-b5020113c429.jpg?1",
             "name": "Tar Pitcher",
             "text": "{T}, Sacrifice a Goblin: Tar Pitcher deals 2 damage to target creature or player.",
             "colours": [
@@ -6658,7 +6658,7 @@
         },
         {
             "id": "4fbef074-c393-53f9-8647-15284ceee46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a898e-6a97-4fd9-980e-3bfd8d755386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a898e-6a97-4fd9-980e-3bfd8d755386.jpg?1",
             "name": "Tarfire",
             "text": "Tarfire deals 2 damage to target creature or player.",
             "colours": [
@@ -6693,7 +6693,7 @@
         },
         {
             "id": "41724361-c6c8-5e03-943e-ab4688e64593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864f207-2878-461b-8ff6-76475abc324d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864f207-2878-461b-8ff6-76475abc324d.jpg?1",
             "name": "Thundercloud Shaman",
             "text": "When Thundercloud Shaman comes into play, it deals damage equal to the number of Giants you control to each non-Giant creature.",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "937387ef-b35b-5dd9-a8d5-e88800010239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76f09bc-b49a-4ad2-be2d-2a191d41b86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76f09bc-b49a-4ad2-be2d-2a191d41b86d.jpg?1",
             "name": "Wild Ricochet",
             "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -6760,7 +6760,7 @@
         },
         {
             "id": "dcd7bf2d-3df8-5825-9f78-895469346fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a128ea6-cd00-4410-8dc4-cf66ce6f0fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a128ea6-cd00-4410-8dc4-cf66ce6f0fa1.jpg?1",
             "name": "Battlewand Oak",
             "text": "Whenever a Forest comes into play under your control, Battlewand Oak gets +2/+2 until end of turn.\nWhenever you play a Treefolk spell, Battlewand Oak gets +2/+2 until end of turn.",
             "colours": [
@@ -6795,7 +6795,7 @@
         },
         {
             "id": "e8fcbe58-5adf-5ed3-bdd8-eef8fef53922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1b54-56d9-496a-b910-90cc55996ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310a1b54-56d9-496a-b910-90cc55996ad4.jpg?1",
             "name": "Bog-Strider Ash",
             "text": "Swampwalk\nWhenever a player plays a Goblin spell, you may pay {G}. If you do, you gain 2 life.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "308b969f-0a93-536d-9a81-7beaac3ad231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734a0a8-aa21-4fc0-b20d-5fea172884f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734a0a8-aa21-4fc0-b20d-5fea172884f6.jpg?1",
             "name": "Briarhorn",
             "text": "Flash\nWhen Briarhorn comes into play, target creature gets +3/+3 until end of turn.\nEvoke {1}{G} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6864,7 +6864,7 @@
         },
         {
             "id": "5388109b-5c4f-5e62-a568-bbb17ddb21be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b9719-2861-477e-bb78-225fd03d7bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5b9719-2861-477e-bb78-225fd03d7bbc.jpg?1",
             "name": "Changeling Titan",
             "text": "Changeling (This card is every creature type at all times.)\nChampion a creature (When this comes into play, sacrifice it unless you remove another creature you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -6898,7 +6898,7 @@
         },
         {
             "id": "5643d5aa-b3a4-5682-b83c-2cd718102ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742366f-e726-406e-bcbe-51a3bfd0151e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742366f-e726-406e-bcbe-51a3bfd0151e.jpg?1",
             "name": "Cloudcrown Oak",
             "text": "Reach (This can block creatures with flying.)",
             "colours": [
@@ -6933,7 +6933,7 @@
         },
         {
             "id": "c803a91d-9f5a-5af4-ac3e-5b47c5937734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c759c561-829d-483d-a433-fe1213f20236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c759c561-829d-483d-a433-fe1213f20236.jpg?1",
             "name": "Cloudthresher",
             "text": "Flash\nReach (This can block creatures with flying.)\nWhen Cloudthresher comes into play, it deals 2 damage to each creature with flying and each player.\nEvoke {2}{G}{G} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -6967,7 +6967,7 @@
         },
         {
             "id": "693b5541-6682-5d9a-b1aa-5eb1a2b81fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg?1",
             "name": "Dauntless Dourbark",
             "text": "Dauntless Dourbark's power and toughness are each equal to the number of Forests you control plus the number of Treefolk you control.\nDauntless Dourbark has trample as long as you control another Treefolk.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "64767abc-dcca-5ce9-b634-fee0b34fdeda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5154fc12-a8f2-4a16-8b1f-f7415c87566d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5154fc12-a8f2-4a16-8b1f-f7415c87566d.jpg?1",
             "name": "Elvish Branchbender",
             "text": "{T}: Until end of turn, target Forest becomes an X/X Treefolk creature in addition to its other types, where X is the number of Elves you control.",
             "colours": [
@@ -7037,7 +7037,7 @@
         },
         {
             "id": "af2fb7b6-552a-5c9a-a062-ac887049aab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b9d31-3079-45e3-acb3-a74169aa332e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564b9d31-3079-45e3-acb3-a74169aa332e.jpg?1",
             "name": "Elvish Eulogist",
             "text": "Sacrifice Elvish Eulogist: You gain 1 life for each Elf card in your graveyard.",
             "colours": [
@@ -7072,7 +7072,7 @@
         },
         {
             "id": "791b6fa2-bdf7-5359-afde-70387b21a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854f9a9-160c-4c96-b871-0f85914597d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854f9a9-160c-4c96-b871-0f85914597d0.jpg?1",
             "name": "Elvish Handservant",
             "text": "Whenever a player plays a Giant spell, you may put a +1/+1 counter on Elvish Handservant.",
             "colours": [
@@ -7107,7 +7107,7 @@
         },
         {
             "id": "75fe0a7b-fa16-55a5-8456-25ba0c3fd75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de789231-8358-4cbd-b8eb-1da4ce5b34c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de789231-8358-4cbd-b8eb-1da4ce5b34c0.jpg?1",
             "name": "Elvish Harbinger",
             "text": "When Elvish Harbinger comes into play, you may search your library for an Elf card, reveal it, then shuffle your library and put that card on top of it.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -7142,7 +7142,7 @@
         },
         {
             "id": "ec18f396-9469-5208-9ed6-ad5c866a1f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d5049-c1a6-4186-952e-bd7481b1974a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9d5049-c1a6-4186-952e-bd7481b1974a.jpg?1",
             "name": "Elvish Promenade",
             "text": "Put a 1/1 green Elf Warrior creature token into play for each Elf you control.",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "25abbac9-2e6e-5e2e-9c0f-c16655283610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7ffca1-c73c-4de1-b811-bd1876ea6d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7ffca1-c73c-4de1-b811-bd1876ea6d6f.jpg?1",
             "name": "Epic Proportions",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +5/+5 and has trample.",
             "colours": [
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "dd6f709e-ee0a-5c6c-9dae-34237b95d4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg?1",
             "name": "Eyes of the Wisent",
             "text": "Whenever an opponent plays a blue spell during your turn, you may put a 4/4 green Elemental creature token into play.",
             "colours": [
@@ -7246,7 +7246,7 @@
         },
         {
             "id": "d61bb6f2-01ca-5e94-aafc-0a9bb9365bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05edfbbc-34e8-4046-966c-3a979468b95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05edfbbc-34e8-4046-966c-3a979468b95e.jpg?1",
             "name": "Fertile Ground",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool.",
             "colours": [
@@ -7280,7 +7280,7 @@
         },
         {
             "id": "9fe479be-885b-5fda-9cea-afc19a3c07db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f77c7e-d35f-477e-acc4-a393044319ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f77c7e-d35f-477e-acc4-a393044319ea.jpg?1",
             "name": "Fistful of Force",
             "text": "Target creature gets +2/+2 until end of turn. Clash with an opponent. If you win, that creature gets an additional +2/+2 and gains trample until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -7312,7 +7312,7 @@
         },
         {
             "id": "c404bfb3-6dfe-5112-909e-4e07a2907ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f13a2-9243-4ce9-9f71-bed74355b781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f13a2-9243-4ce9-9f71-bed74355b781.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "+1: Untap two target lands.\n-1: Put a 3/3 green Beast creature token into play.\n-4: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -7348,7 +7348,7 @@
         },
         {
             "id": "271ab442-2158-545b-b5a4-4a273a7aaf0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bf7254-4302-41a0-bc87-d7dc437ff38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bf7254-4302-41a0-bc87-d7dc437ff38d.jpg?1",
             "name": "Gilt-Leaf Ambush",
             "text": "Put two 1/1 green Elf Warrior creature tokens into play. Clash with an opponent. If you win, those creatures gain deathtouch until end of turn. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost. Whenever a creature with deathtouch deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -7383,7 +7383,7 @@
         },
         {
             "id": "997808e4-122b-56d6-91c5-aaf9f5af56ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cc889-9bc1-48dd-b1d1-95daa73b8fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cc889-9bc1-48dd-b1d1-95daa73b8fbe.jpg?1",
             "name": "Gilt-Leaf Seer",
             "text": "{G}, {T}: Look at the top two cards of your library, then put them back in any order.",
             "colours": [
@@ -7418,7 +7418,7 @@
         },
         {
             "id": "e15bc5ce-e372-510d-87bf-79883c5fc1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311c5f1d-7e3b-4397-b05b-f20bde2dc164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311c5f1d-7e3b-4397-b05b-f20bde2dc164.jpg?1",
             "name": "Guardian of Cloverdell",
             "text": "When Guardian of Cloverdell comes into play, put three 1/1 white Kithkin Soldier creature tokens into play.\n{G}, Sacrifice a Kithkin: You gain 1 life.",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "ecb84a76-d818-53cd-86b1-383a0078b555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802a7fe-9c8b-4bc3-95d8-4a5dafcf2c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b802a7fe-9c8b-4bc3-95d8-4a5dafcf2c75.jpg?1",
             "name": "Heal the Scars",
             "text": "Regenerate target creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -7485,7 +7485,7 @@
         },
         {
             "id": "f1deb83f-232d-5e1d-8cbf-bd6981b7f5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb783652-6450-4789-8ec1-b057b39c6a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb783652-6450-4789-8ec1-b057b39c6a4b.jpg?1",
             "name": "Hunt Down",
             "text": "Target creature blocks target creature this turn if able.",
             "colours": [
@@ -7517,7 +7517,7 @@
         },
         {
             "id": "14ef47ee-b10f-5876-8854-89e5359078f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbf6137-4f50-4915-b608-7a03512476a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbf6137-4f50-4915-b608-7a03512476a2.jpg?1",
             "name": "Immaculate Magistrate",
             "text": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "6a90afb9-3c6f-57d8-959a-c770bbbdd098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fce74-fed9-4bf7-949d-7df6bef29238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fce74-fed9-4bf7-949d-7df6bef29238.jpg?1",
             "name": "Imperious Perfect",
             "text": "Other Elf creatures you control get +1/+1.\n{G}, {T}: Put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -7587,7 +7587,7 @@
         },
         {
             "id": "91e0e1e7-17cf-5d2d-b534-4c3ed87b8265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356793ec-3285-4bda-9b8e-23bf2d60f124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356793ec-3285-4bda-9b8e-23bf2d60f124.jpg?1",
             "name": "Incremental Growth",
             "text": "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
             "colours": [
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "c2655774-61c3-543c-ac74-371d06355a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fd5232-2dac-4bd9-a1f6-eb1a40154367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fd5232-2dac-4bd9-a1f6-eb1a40154367.jpg?1",
             "name": "Jagged-Scar Archers",
             "text": "Jagged-Scar Archers's power and toughness are each equal to the number of Elves you control.\n{T}: Jagged-Scar Archers deals damage equal to its power to target creature with flying.",
             "colours": [
@@ -7654,7 +7654,7 @@
         },
         {
             "id": "b0e9093f-b458-5185-82c1-4178c355e992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d0d7fd-a580-41af-8e9d-fee74094ec47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d0d7fd-a580-41af-8e9d-fee74094ec47.jpg?1",
             "name": "Kithkin Daggerdare",
             "text": "{G}, {T}: Target attacking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -7689,7 +7689,7 @@
         },
         {
             "id": "2e1e648a-ebb3-5f6d-af75-7380ef1d7fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b6f90-c609-4ffd-9136-9fd7a833ebb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b6f90-c609-4ffd-9136-9fd7a833ebb3.jpg?1",
             "name": "Kithkin Mourncaller",
             "text": "Whenever an attacking Kithkin or Elf is put into your graveyard from play, you may draw a card.",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "1ed98de7-475e-5878-8b0c-2c9531000477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f209d6-c194-4208-864d-f8a44b88997f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f209d6-c194-4208-864d-f8a44b88997f.jpg?1",
             "name": "Lace with Moonglove",
             "text": "Target creature gains deathtouch until end of turn. (Whenever it deals damage to a creature, destroy that creature.)\nDraw a card.",
             "colours": [
@@ -7756,7 +7756,7 @@
         },
         {
             "id": "97d32887-471c-5b34-8c3c-b27c59a669bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667fd7ab-de75-48e7-8d4b-a96130ae4666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667fd7ab-de75-48e7-8d4b-a96130ae4666.jpg?1",
             "name": "Lammastide Weave",
             "text": "Name a card, then target player puts the top card of his or her library into his or her graveyard. If that card is the named card, you gain life equal to its converted mana cost.\nDraw a card.",
             "colours": [
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "3d2c874d-37f8-5715-9193-7af51c7f848c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg?1",
             "name": "Leaf Gilder",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -7823,7 +7823,7 @@
         },
         {
             "id": "14519ca4-3d9c-5bc3-80d5-6e9fe0cdaf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264fd6c5-8d73-4928-aed7-5ed637426780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/264fd6c5-8d73-4928-aed7-5ed637426780.jpg?1",
             "name": "Lignify",
             "text": "Enchant creature\nEnchanted creature is a 0/4 Treefolk with no abilities.",
             "colours": [
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "e64f2b80-32e7-59cf-9d6c-982e8213eb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d21f992-f982-415e-9d77-d11d8c931741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d21f992-f982-415e-9d77-d11d8c931741.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "Whenever you play an Elf spell, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -7894,7 +7894,7 @@
         },
         {
             "id": "dcf57709-b5a4-58c0-abfe-2dbdccf61200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cf01d6-7d5d-4638-9884-733797c9f502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cf01d6-7d5d-4638-9884-733797c9f502.jpg?1",
             "name": "Masked Admirers",
             "text": "When Masked Admirers comes into play, draw a card.\nWhenever you play a creature spell, you may pay {G}{G}. If you do, return Masked Admirers from your graveyard to your hand.",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "73e5001f-771a-5180-aa52-53112fb717f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a2b029-02ba-46b0-88a2-99025727cc56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a2b029-02ba-46b0-88a2-99025727cc56.jpg?1",
             "name": "Nath's Elite",
             "text": "All creatures able to block Nath's Elite do so.\nWhen Nath's Elite comes into play, clash with an opponent. If you win, put a +1/+1 counter on Nath's Elite. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "9f1fe642-8b37-52e0-83b0-b2c1522ab06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fe818e-6dbc-4100-8552-b0393c87b052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fe818e-6dbc-4100-8552-b0393c87b052.jpg?1",
             "name": "Oakgnarl Warrior",
             "text": "Vigilance, trample",
             "colours": [
@@ -7999,7 +7999,7 @@
         },
         {
             "id": "eb0a4d88-395c-5c90-a498-3694bd89b3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d2c5b9-cef9-4763-8e65-e3b1418c0ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d2c5b9-cef9-4763-8e65-e3b1418c0ad3.jpg?1",
             "name": "Primal Command",
             "text": "Choose two Target player gains 7 life; or put target noncreature permanent on top of its owner's library; or target player shuffles his or her graveyard into his or her library; or search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -8031,7 +8031,7 @@
         },
         {
             "id": "5f6fd6e2-209f-5061-a30d-893dde1173e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe6051f-6252-4ad1-90ab-d21705a708d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe6051f-6252-4ad1-90ab-d21705a708d1.jpg?1",
             "name": "Rootgrapple",
             "text": "Destroy target noncreature permanent. If you control a Treefolk, draw a card.",
             "colours": [
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "fa2bd2d2-8d89-51b0-a3d0-dbe6f425ff45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca605c0-6270-4238-bb77-0bbfd7568807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca605c0-6270-4238-bb77-0bbfd7568807.jpg?1",
             "name": "Seedguide Ash",
             "text": "When Seedguide Ash is put into a graveyard from play, you may search your library for up to three Forest cards and put them into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -8101,7 +8101,7 @@
         },
         {
             "id": "7abf6ff8-6e23-5b90-aa8c-c3cfe38952de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20ef13-e97f-454c-8295-7bb8a7c4e4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20ef13-e97f-454c-8295-7bb8a7c4e4be.jpg?1",
             "name": "Spring Cleaning",
             "text": "Destroy target enchantment. Clash with an opponent. If you win, destroy all enchantments your opponents control. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "190de764-72e0-5908-b827-08bdeff0830e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b55fa6-4c94-4ab4-bc30-4fb8b1d3e38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b55fa6-4c94-4ab4-bc30-4fb8b1d3e38f.jpg?1",
             "name": "Sylvan Echoes",
             "text": "Whenever you clash and win, you may draw a card. (This ability triggers after the clash ends.)",
             "colours": [
@@ -8165,7 +8165,7 @@
         },
         {
             "id": "aa0afa4c-daa1-57c8-a87d-87e57bc74ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg?1",
             "name": "Timber Protector",
             "text": "Other Treefolk creatures you control get +1/+1.\nOther Treefolk and Forests you control are indestructible.",
             "colours": [
@@ -8200,7 +8200,7 @@
         },
         {
             "id": "5b73280b-3442-50b4-a8d3-398ef664b2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef45cdc-2e1c-40c7-8978-b09a50f511fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef45cdc-2e1c-40c7-8978-b09a50f511fb.jpg?1",
             "name": "Treefolk Harbinger",
             "text": "When Treefolk Harbinger comes into play, you may search your library for a Treefolk or Forest card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "41ea75fe-fad9-566a-ab7c-56c94cf77309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cede0be-1bdd-4392-beaf-b83d0b780eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cede0be-1bdd-4392-beaf-b83d0b780eb7.jpg?1",
             "name": "Vigor",
             "text": "Trample\nIf damage would be dealt to a creature you control other than Vigor, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way.\nWhen Vigor is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -8270,7 +8270,7 @@
         },
         {
             "id": "798f3c7c-1b73-51e8-90ad-912edb30f2ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5fe17-5499-427b-9267-3b3a9676a087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab5fe17-5499-427b-9267-3b3a9676a087.jpg?1",
             "name": "Warren-Scourge Elf",
             "text": "Protection from Goblins",
             "colours": [
@@ -8305,7 +8305,7 @@
         },
         {
             "id": "e5163cd6-0967-58f2-8fa4-2e2db8a74bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa41edf8-88a1-46dd-8315-b0afe7e14b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa41edf8-88a1-46dd-8315-b0afe7e14b7e.jpg?1",
             "name": "Woodland Changeling",
             "text": "Changeling (This card is every creature type at all times.)",
             "colours": [
@@ -8339,7 +8339,7 @@
         },
         {
             "id": "93246a5d-8bfb-564d-8105-8fa03c1d7489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adead0-f8b4-4c49-b4ce-d9253980ee03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92adead0-f8b4-4c49-b4ce-d9253980ee03.jpg?1",
             "name": "Woodland Guidance",
             "text": "Return target card from your graveyard to your hand. Clash with an opponent. If you win, untap all Forests you control. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)\nRemove Woodland Guidance from the game.",
             "colours": [
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "b731c4cd-39b9-58f3-b7a0-12183e18df2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97f29a-1551-4e75-80e8-2dd31cb6c0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97f29a-1551-4e75-80e8-2dd31cb6c0db.jpg?1",
             "name": "Wren's Run Packmaster",
             "text": "Champion an Elf (When this comes into play, sacrifice it unless you remove another Elf you control from the game. When this leaves play, that card returns to play.)\n{2}{G}: Put a 2/2 green Wolf creature token into play.\nEach Wolf you control has deathtouch. (When it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "5f6a9851-c6f2-5638-a324-289b30eb6a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c411a0-b8dd-4394-852a-a29dbcec953b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c411a0-b8dd-4394-852a-a29dbcec953b.jpg?1",
             "name": "Wren's Run Vanquisher",
             "text": "As an additional cost to play Wren's Run Vanquisher, reveal an Elf card from your hand or pay {3}.\nDeathtouch (Whenever this creature deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "aa98af82-e8a9-5301-b2b1-d18f940fd07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21cfc2-9671-4bf3-b922-2f436f284cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa21cfc2-9671-4bf3-b922-2f436f284cb1.jpg?1",
             "name": "Brion Stoutarm",
             "text": "Lifelink (Whenever this creature deals damage, you gain that much life.)\n{R}, {T}, Sacrifice a creature other than Brion Stoutarm: Brion Stoutarm deals damage equal to the sacrificed creature's power to target player.",
             "colours": [
@@ -8480,7 +8480,7 @@
         },
         {
             "id": "1d8c1972-5a1d-5ccf-8a89-17084779a075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b006b169-295d-4ead-8e8e-29a9c3246025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b006b169-295d-4ead-8e8e-29a9c3246025.jpg?1",
             "name": "Doran, the Siege Tower",
             "text": "Each creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -8521,7 +8521,7 @@
         },
         {
             "id": "a10f3494-8288-5894-9272-5e5e353e1c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c16e1b-f4ce-409f-928a-42c666adac9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c16e1b-f4ce-409f-928a-42c666adac9d.jpg?1",
             "name": "Gaddock Teeg",
             "text": "Noncreature spells with converted mana cost 4 or greater can't be played.\nNoncreature spells with {X} in their mana costs can't be played.",
             "colours": [
@@ -8560,7 +8560,7 @@
         },
         {
             "id": "73e644a6-5a57-51fe-a000-5ac9dd28bc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b9ea46-ae9b-4729-b206-0ba3ddc7660d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b9ea46-ae9b-4729-b206-0ba3ddc7660d.jpg?1",
             "name": "Horde of Notions",
             "text": "Vigilance, trample, haste\n{W}{U}{B}{R}{G}: You may play target Elemental card from your graveyard without paying its mana cost.",
             "colours": [
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "97c6e6c6-7d0a-52d6-828e-27e126ba5af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c69bd-a8bf-4085-85fa-364b8e92b88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c69bd-a8bf-4085-85fa-364b8e92b88a.jpg?1",
             "name": "Nath of the Gilt-Leaf",
             "text": "At the beginning of your upkeep, you may have target opponent discard a card at random.\nWhenever an opponent discards a card, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "acb5837c-4c4b-5e80-9f03-b71e816bb9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aefaf-1b96-4c08-a73e-98e401655965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1aefaf-1b96-4c08-a73e-98e401655965.jpg?1",
             "name": "Sygg, River Guide",
             "text": "Islandwalk\n{1}{W}: Target Merfolk you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "f4033c80-962b-57e8-9704-327b1db3d059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08a1377-dede-47c8-8447-c9df125f3b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08a1377-dede-47c8-8447-c9df125f3b14.jpg?1",
             "name": "Wort, Boggart Auntie",
             "text": "Fear\nAt the beginning of your upkeep, you may return target Goblin card from your graveyard to your hand.",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "8cfcd931-c773-57d0-8a1f-05121d194eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6b558b-74a5-497d-8be4-474c375d7ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6b558b-74a5-497d-8be4-474c375d7ca7.jpg?1",
             "name": "Wydwen, the Biting Gale",
             "text": "Flash\nFlying\n{U}{B}, Pay 1 life: Return Wydwen, the Biting Gale to its owner's hand.",
             "colours": [
@@ -8760,7 +8760,7 @@
         },
         {
             "id": "6294454d-37ec-53b3-8463-3dc5707c92ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fea28-3813-4e65-8b90-6d335fdf0a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fea28-3813-4e65-8b90-6d335fdf0a0b.jpg?1",
             "name": "Colfenor's Urn",
             "text": "Whenever a creature with toughness 4 or greater is put into your graveyard from play, you may remove it from the game.\nAt end of turn, if three or more cards have been removed from the game with Colfenor's Urn, sacrifice it. If you do, return those cards to play under their owner's control.",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "9166e6c8-922b-55c9-9547-5fef623ebd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd836fe0-932c-4d5c-9a52-94fc423c3d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd836fe0-932c-4d5c-9a52-94fc423c3d57.jpg?1",
             "name": "Deathrender",
             "text": "Equipped creature gets +2/+2.\nWhenever equipped creature is put into a graveyard from play, you may put a creature card from your hand into play and attach Deathrender to it.\nEquip {2}",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "f607f056-5beb-5e18-ae2f-9090d7c1d63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbf10e-32f2-41c5-a7a2-5f24662892d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcbf10e-32f2-41c5-a7a2-5f24662892d2.jpg?1",
             "name": "Dolmen Gate",
             "text": "Prevent all combat damage that would be dealt to attacking creatures you control.",
             "colours": [],
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "fe56bf4d-60c3-5d86-af3d-cd30e88c48c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20925a3-dd4f-477c-806a-a3ec0fd2e00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20925a3-dd4f-477c-806a-a3ec0fd2e00d.jpg?1",
             "name": "Herbal Poultice",
             "text": "{3}, Sacrifice Herbal Poultice: Regenerate target creature.",
             "colours": [],
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "a5f72e58-bf83-5e25-8cce-e6819af5ba70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97377416-35e8-4cf3-be1f-edc2ec3f6eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97377416-35e8-4cf3-be1f-edc2ec3f6eb2.jpg?1",
             "name": "Moonglove Extract",
             "text": "Sacrifice Moonglove Extract: Moonglove Extract deals 2 damage to target creature or player.",
             "colours": [],
@@ -8902,7 +8902,7 @@
         },
         {
             "id": "aa04739d-8c69-5170-ac4a-7a8675399425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd3898-cb06-4bb9-9d52-b319e1fa2217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbfd3898-cb06-4bb9-9d52-b319e1fa2217.jpg?1",
             "name": "Rings of Brighthearth",
             "text": "Whenever you play an activated ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "6c86028f-a89a-5ff1-b35e-e82c0d47622a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be88336-83c7-422d-8826-13ceb8db5534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be88336-83c7-422d-8826-13ceb8db5534.jpg?1",
             "name": "Runed Stalactite",
             "text": "Equipped creature gets +1/+1 and is every creature type.\nEquip {2}",
             "colours": [],
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "29b00632-304f-5d09-b4a2-441eadb63b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8b09d0-fbd2-4441-9d87-02450412e0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8b09d0-fbd2-4441-9d87-02450412e0db.jpg?1",
             "name": "Springleaf Drum",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "e9804db3-35cf-59c7-bd64-78c0041f603d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e472d4f5-add4-4de3-8718-31a47a35277c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e472d4f5-add4-4de3-8718-31a47a35277c.jpg?1",
             "name": "Thorn of Amethyst",
             "text": "Noncreature spells cost {1} more to play.",
             "colours": [],
@@ -9016,7 +9016,7 @@
         },
         {
             "id": "df7c1ebe-315d-505e-a323-f445c2213477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18743fd4-2a15-40a2-ac90-e3f0fef07e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18743fd4-2a15-40a2-ac90-e3f0fef07e37.jpg?1",
             "name": "Thousand-Year Elixir",
             "text": "You may play the activated abilities of creatures you control as though those creatures had haste.\n{1}, {T}: Untap target creature.",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "f6468ec7-87a7-5ed4-9925-64c84125eb0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0138c42-77ea-45f0-b2ca-cda03f3f50d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0138c42-77ea-45f0-b2ca-cda03f3f50d1.jpg?1",
             "name": "Twinning Glass",
             "text": "{1}, {T}: You may play a nonland card from your hand without paying its mana cost if it has the same name as a spell that was played this turn.",
             "colours": [],
@@ -9072,7 +9072,7 @@
         },
         {
             "id": "fd9a8d8f-260d-5056-82f7-eb062949e65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea7b2c0-c641-478f-b8d9-17aa17fa1cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea7b2c0-c641-478f-b8d9-17aa17fa1cbe.jpg?1",
             "name": "Wanderer's Twig",
             "text": "{1}, Sacrifice Wanderer's Twig: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -9100,7 +9100,7 @@
         },
         {
             "id": "4c538ca4-52a8-544a-9598-af957e05fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff3a82d-e794-4c3b-994d-b28b8eb7eac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff3a82d-e794-4c3b-994d-b28b8eb7eac4.jpg?1",
             "name": "Ancient Amphitheater",
             "text": "As Ancient Amphitheater comes into play, you may reveal a Giant card from your hand. If you don't, Ancient Amphitheater comes into play tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "d5f8de32-daa2-5e61-8912-3482c058cecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098685c9-cd85-4279-a3b5-b495485bba35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098685c9-cd85-4279-a3b5-b495485bba35.jpg?1",
             "name": "Auntie's Hovel",
             "text": "As Auntie's Hovel comes into play, you may reveal a Goblin card from your hand. If you don't, Auntie's Hovel comes into play tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -9162,7 +9162,7 @@
         },
         {
             "id": "17b27a89-ee32-53ea-9b4b-8a4b244f1f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4bbbb5-4218-4b2a-9ca2-de4d5f5dda19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4bbbb5-4218-4b2a-9ca2-de4d5f5dda19.jpg?1",
             "name": "Gilt-Leaf Palace",
             "text": "As Gilt-Leaf Palace comes into play, you may reveal an Elf card from your hand. If you don't, Gilt-Leaf Palace comes into play tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "8b59c32b-3d30-531f-b57b-bb41d5045f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c678643-6640-49e1-a5b0-2954123bcabc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c678643-6640-49e1-a5b0-2954123bcabc.jpg?1",
             "name": "Howltooth Hollow",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {B} to your mana pool.\n{B}, {T}: You may play the removed card without paying its mana cost if each player has no cards in hand.",
             "colours": [],
@@ -9223,7 +9223,7 @@
         },
         {
             "id": "10507154-fa7a-55d3-b0af-30bdc4242e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38234590-812c-4d29-80c1-32b9e1282580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38234590-812c-4d29-80c1-32b9e1282580.jpg?1",
             "name": "Mosswort Bridge",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {G} to your mana pool.\n{G}, {T}: You may play the removed card without paying its mana cost if creatures you control have total power 10 or greater.",
             "colours": [],
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "7ec0d252-a89b-5c21-ac47-08dec64be939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4afa65-7933-4a64-b50f-a9a9f832b112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4afa65-7933-4a64-b50f-a9a9f832b112.jpg?1",
             "name": "Secluded Glen",
             "text": "As Secluded Glen comes into play, you may reveal a Faerie card from your hand. If you don't, Secluded Glen comes into play tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -9284,7 +9284,7 @@
         },
         {
             "id": "db77e9fe-f266-5002-aa66-dbbbf61331d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216656e-90e8-45fc-a0f6-0d0d79d0a021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216656e-90e8-45fc-a0f6-0d0d79d0a021.jpg?1",
             "name": "Shelldock Isle",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {U} to your mana pool.\n{U}, {T}: You may play the removed card without paying its mana cost if a library has twenty or fewer cards in it.",
             "colours": [],
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "e3f9a706-1348-5358-b4da-e07151a27b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e85acc-ed12-4036-8193-739721c3e178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e85acc-ed12-4036-8193-739721c3e178.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "dc872f75-9844-5059-a3c1-f096d1b8d44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec6abed-8fbb-4d3e-8f89-64ea1b3913db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec6abed-8fbb-4d3e-8f89-64ea1b3913db.jpg?1",
             "name": "Spinerock Knoll",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {R} to your mana pool.\n{R}, {T}: You may play the removed card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
             "colours": [],
@@ -9372,7 +9372,7 @@
         },
         {
             "id": "cd1033fb-7e0d-55d8-83cc-9a8885d571a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539001dc-69f0-42c0-b5c3-37d7b12eb79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539001dc-69f0-42c0-b5c3-37d7b12eb79e.jpg?1",
             "name": "Vivid Crag",
             "text": "Vivid Crag comes into play tapped with two charge counters on it.\n{T}: Add {R} to your mana pool.\n{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "0150dec1-c0d8-5a4f-93c8-de395cd91ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3c2935-84ee-446d-b247-2f574ea84a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3c2935-84ee-446d-b247-2f574ea84a8f.jpg?1",
             "name": "Vivid Creek",
             "text": "Vivid Creek comes into play tapped with two charge counters on it.\n{T}: Add {U} to your mana pool.\n{T}, Remove a charge counter from Vivid Creek: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9432,7 +9432,7 @@
         },
         {
             "id": "380656e2-f4b7-5d9f-a4c6-01c449891dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6646babe-edd8-4367-ba8f-89af4f859dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6646babe-edd8-4367-ba8f-89af4f859dd8.jpg?1",
             "name": "Vivid Grove",
             "text": "Vivid Grove comes into play tapped with two charge counters on it.\n{T}: Add {G} to your mana pool.\n{T}, Remove a charge counter from Vivid Grove: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9462,7 +9462,7 @@
         },
         {
             "id": "ad02fa8c-e1b5-5c96-afa1-d35d8e98dd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f806c7-0063-4270-b37c-5363c41a7621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f806c7-0063-4270-b37c-5363c41a7621.jpg?1",
             "name": "Vivid Marsh",
             "text": "Vivid Marsh comes into play tapped with two charge counters on it.\n{T}: Add {B} to your mana pool.\n{T}, Remove a charge counter from Vivid Marsh: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "2d326d13-b3b6-54e3-b07c-99ded6eb8aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a535790b-d416-4807-bca0-acf6b192101c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a535790b-d416-4807-bca0-acf6b192101c.jpg?1",
             "name": "Vivid Meadow",
             "text": "Vivid Meadow comes into play tapped with two charge counters on it.\n{T}: Add {W} to your mana pool.\n{T}, Remove a charge counter from Vivid Meadow: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "ede85584-e8b3-5b2e-b56f-5a8f2c6957c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccec69de-7203-4810-a8ec-8748705ee3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccec69de-7203-4810-a8ec-8748705ee3a2.jpg?1",
             "name": "Wanderwine Hub",
             "text": "As Wanderwine Hub comes into play, you may reveal a Merfolk card from your hand. If you don't, Wanderwine Hub comes into play tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -9553,7 +9553,7 @@
         },
         {
             "id": "55313bd0-6d1b-5fd1-8539-39ef73176442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df6a31a-5c49-4506-b8f8-84c9ab4a2ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df6a31a-5c49-4506-b8f8-84c9ab4a2ece.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway (This land comes into play tapped. When it does, look at the top four cards of your library, remove one from the game face down, then put the rest on the bottom of your library.)\n{T}: Add {W} to your mana pool.\n{W}, {T}: You may play the removed card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -9583,7 +9583,7 @@
         },
         {
             "id": "5ffbe829-8a22-52f1-95e8-7ff447c19334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e41010-a7d2-4e78-8f7b-502347f8c47d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e41010-a7d2-4e78-8f7b-502347f8c47d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9621,7 +9621,7 @@
         },
         {
             "id": "f6e6b0e4-34e2-55ae-a5bd-097688eb8be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5db4d0-61f4-4cc6-89c4-02a2060b556d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5db4d0-61f4-4cc6-89c4-02a2060b556d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9659,7 +9659,7 @@
         },
         {
             "id": "a17c3246-d67c-51e0-8f5f-fe6517272bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d4bb5-9da7-4d21-9cdc-1732ea61121a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d4bb5-9da7-4d21-9cdc-1732ea61121a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "cae39c87-fbd5-517f-baf9-e06b8518a7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5900e-100c-44e8-97e9-b0c15379fea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd5900e-100c-44e8-97e9-b0c15379fea1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9735,7 +9735,7 @@
         },
         {
             "id": "97183a9e-2a66-58df-b8d5-490b50f723b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885738f-a51d-418c-b194-0ba8ef6af556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5885738f-a51d-418c-b194-0ba8ef6af556.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9773,7 +9773,7 @@
         },
         {
             "id": "f6ceed64-7813-5064-9c26-7c97e39e60a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ffadeb-cf20-4da9-a140-1fdcc7484c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ffadeb-cf20-4da9-a140-1fdcc7484c7a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "bc9c4be7-5fb1-5e66-b69a-042eb91ba829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d714d196-8cbc-4b53-8219-21044a017bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d714d196-8cbc-4b53-8219-21044a017bce.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9849,7 +9849,7 @@
         },
         {
             "id": "6a7fc913-a939-507d-bac9-f2f5e759dd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d9548-f495-43ef-af66-e13a84c1f12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d9548-f495-43ef-af66-e13a84c1f12a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9887,7 +9887,7 @@
         },
         {
             "id": "b06f3c21-8077-5143-90ee-9e286455c63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f799604-bbbf-4d57-83c8-13a0eafa974e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f799604-bbbf-4d57-83c8-13a0eafa974e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9925,7 +9925,7 @@
         },
         {
             "id": "20846bde-8778-5927-9f06-601ef514b51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9dc477-a3e4-4fc0-af62-c8b8eb68d360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9dc477-a3e4-4fc0-af62-c8b8eb68d360.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9963,7 +9963,7 @@
         },
         {
             "id": "2176f831-b6e1-5b03-8c64-c9f8d099c337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4ad69e-843c-4f33-be2f-711568f8aac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4ad69e-843c-4f33-be2f-711568f8aac7.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10001,7 +10001,7 @@
         },
         {
             "id": "b6eafa2c-084d-52da-889b-012af093ce8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38625a65-868f-4cbf-a512-9142f1eddf4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38625a65-868f-4cbf-a512-9142f1eddf4a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10039,7 +10039,7 @@
         },
         {
             "id": "44b34316-729e-5332-bc97-bb04dfe37902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83beeef7-2bb5-4c3a-9be4-79a968696d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83beeef7-2bb5-4c3a-9be4-79a968696d65.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10077,7 +10077,7 @@
         },
         {
             "id": "53700962-2535-5de3-a21c-ff74b254fa3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e0823-cbf3-4cf7-8fe1-a032cf33ee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e0823-cbf3-4cf7-8fe1-a032cf33ee66.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10115,7 +10115,7 @@
         },
         {
             "id": "b5e09225-bc11-5cf1-9333-dc23b3710a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd842290-fd0d-419d-b793-bd84b43f5d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd842290-fd0d-419d-b793-bd84b43f5d9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "db3b7481-ec28-5f3f-abf3-ec80e3e407e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaaad2-5512-46f8-9bdb-84aa3ef0c2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0eaaad2-5512-46f8-9bdb-84aa3ef0c2ac.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "af87faff-e6f7-5f45-9716-755b0fa55ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3a661e-d890-4211-bc9c-8266001ebfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3a661e-d890-4211-bc9c-8266001ebfba.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10229,7 +10229,7 @@
         },
         {
             "id": "892764f6-77b2-501b-bc48-c0d61954addc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081c1f03-3251-42dc-b356-3454ebdabc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081c1f03-3251-42dc-b356-3454ebdabc2e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10267,7 +10267,7 @@
         },
         {
             "id": "625403b7-37d0-5661-a0d3-9c1100849421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608a10-6bd4-4579-a08a-f7e2da383794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f608a10-6bd4-4579-a08a-f7e2da383794.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10305,7 +10305,7 @@
         },
         {
             "id": "1e58945b-d8b0-5ac6-9b16-ecc1eaa38c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7104a533-42df-4430-87dc-e0adeb7f2320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7104a533-42df-4430-87dc-e0adeb7f2320.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10343,7 +10343,7 @@
         },
         {
             "id": "8bccbab9-7c5c-5b31-917b-eb5427b6471f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "b0b8ed9f-ec8b-59bb-9fe5-3b367a9c3275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c791044-be86-47d8-8c1b-299f6ab254e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c791044-be86-47d8-8c1b-299f6ab254e6.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "4a600caa-ca0a-5aac-b3de-38899af4e50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1",
             "name": "Kithkin Soldier",
             "text": "",
             "colours": [
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "de575099-679b-5fa4-bfdc-ac1339abefac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg?1",
             "name": "Merfolk Wizard",
             "text": "",
             "colours": [
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "84647b7c-b2dd-5033-8d00-9858c1991cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg?1",
             "name": "Goblin Rogue",
             "text": "",
             "colours": [
@@ -10516,7 +10516,7 @@
         },
         {
             "id": "c41f0130-98d9-53c5-8d14-2d2b9864db4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg?1",
             "name": "Elemental Shaman",
             "text": "",
             "colours": [
@@ -10551,7 +10551,7 @@
         },
         {
             "id": "3123891e-65ca-55e0-a1c4-0fbaa5528aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -10585,7 +10585,7 @@
         },
         {
             "id": "1537811d-76c4-59f0-bf3a-8f85a1ccb897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10619,7 +10619,7 @@
         },
         {
             "id": "4439bff3-437b-5152-bc45-2bc023f0b292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -10654,7 +10654,7 @@
         },
         {
             "id": "0ac06155-35dc-574c-9937-2da6f006e4ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -10688,7 +10688,7 @@
         },
         {
             "id": "6a0a382f-100d-51fe-be51-b0db4877cfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7d89ca-8611-4bda-b5c8-0350ce091102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7d89ca-8611-4bda-b5c8-0350ce091102.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/LTR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/LTR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9b3292e8-01ad-5489-8116-a27f8bdf1bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93de9042-cc62-4ade-8d8d-68fdbc84bfae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93de9042-cc62-4ade-8d8d-68fdbc84bfae.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -37,7 +37,7 @@
         },
         {
             "id": "33413ff7-336f-5340-888f-cbca91e3caa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4410076-e1fe-45f3-a0ca-a91ab0133ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4410076-e1fe-45f3-a0ca-a91ab0133ff4.jpg?1",
             "name": "Banish from Edoras",
             "text": "",
             "colours": [
@@ -69,7 +69,7 @@
         },
         {
             "id": "40b249cb-e103-5c37-9dcb-1ec6a206f2f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae7a4d-9117-43c5-a048-80a0ddadc034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae7a4d-9117-43c5-a048-80a0ddadc034.jpg?1",
             "name": "The Battle of Bywater",
             "text": "",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d4f0c01f-9b7b-5233-9783-cabad66364a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac68519-ed7f-4f38-9549-c02975f88eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ac68519-ed7f-4f38-9549-c02975f88eed.jpg?1",
             "name": "Bill the Pony",
             "text": "",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "15714ad7-584b-53f1-8ead-2f064dc5ed4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg?1",
             "name": "Boromir, Warden of the Tower",
             "text": "",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "8890df6e-d22e-5dc0-8730-03962a9f1bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966ee6-bf1b-4bb6-9277-8de6f3918ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966ee6-bf1b-4bb6-9277-8de6f3918ae2.jpg?1",
             "name": "Dawn of a New Age",
             "text": "",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "fe23cdbf-630c-56bc-8907-867bff6c7213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5f92bf-e4e7-487a-834c-964fdd6ad674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5f92bf-e4e7-487a-834c-964fdd6ad674.jpg?1",
             "name": "D\u00fanedain Blade",
             "text": "",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "704de46c-382b-5e06-8469-f5f5400fb671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd3bc0-77bd-40fe-b4f1-835a04cb6e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1bd3bc0-77bd-40fe-b4f1-835a04cb6e41.jpg?1",
             "name": "Eagles of the North",
             "text": "",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "707db285-cc31-5956-92c2-b8e2f394f239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb65ba-d605-4b79-a700-4a08ec5a90b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb65ba-d605-4b79-a700-4a08ec5a90b4.jpg?1",
             "name": "Eastfarthing Farmer",
             "text": "",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "67398b56-bf76-5804-9d40-7c9cf9e246d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be412c0-45d4-4856-a8cf-63a5a822dc5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be412c0-45d4-4856-a8cf-63a5a822dc5c.jpg?1",
             "name": "East-Mark Cavalier",
             "text": "",
             "colours": [
@@ -352,7 +352,7 @@
         },
         {
             "id": "f29f6e6a-f483-55d1-b416-74c9c413c42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59710c4-24de-419e-a8a0-e8392d450c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59710c4-24de-419e-a8a0-e8392d450c23.jpg?1",
             "name": "\u00c9owyn, Lady of Rohan",
             "text": "",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "20f13999-4704-538d-807d-cbe09d78ba07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f990e7-54a3-4893-8510-645b2065447b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f990e7-54a3-4893-8510-645b2065447b.jpg?1",
             "name": "Errand-Rider of Gondor",
             "text": "",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "8e2a55cf-1ba0-5bed-95db-fb5bedb3091b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff3330-dcca-4435-87e7-871be91a68b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ff3330-dcca-4435-87e7-871be91a68b0.jpg?1",
             "name": "Escape from Orthanc",
             "text": "",
             "colours": [
@@ -456,7 +456,7 @@
         },
         {
             "id": "f5bd70a1-e09e-5997-b940-d2159d0b9b2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa6dded-ab08-43d0-b2fb-008854582cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa6dded-ab08-43d0-b2fb-008854582cba.jpg?1",
             "name": "Esquire of the King",
             "text": "",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "956e6d01-3c5a-5d18-92f4-b8e5bc7631ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2250a-9af1-40de-9f09-7e8c7daec520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2250a-9af1-40de-9f09-7e8c7daec520.jpg?1",
             "name": "Faramir, Field Commander",
             "text": "",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "dba83adc-decf-5a6a-8970-8d25ae3bdd56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203b2cd-48e5-471a-85fe-dc81012e5d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2203b2cd-48e5-471a-85fe-dc81012e5d61.jpg?1",
             "name": "Flowering of the White Tree",
             "text": "",
             "colours": [
@@ -566,7 +566,7 @@
         },
         {
             "id": "cb73984f-9c08-530d-94bc-5b7c24b75248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0cda3a-20d7-425a-89fe-b0a3cd7ced03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0cda3a-20d7-425a-89fe-b0a3cd7ced03.jpg?1",
             "name": "Fog on the Barrow-Downs",
             "text": "",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "f20cf347-a9d5-5ffb-a35b-8cbbc778ea20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56274b88-6e3f-4538-bb0c-eb5e52a58ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56274b88-6e3f-4538-bb0c-eb5e52a58ef3.jpg?1",
             "name": "Forge Anew",
             "text": "",
             "colours": [
@@ -635,7 +635,7 @@
         },
         {
             "id": "b5dbf4a8-bf04-50e9-a7cf-c44a760fd527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg?1",
             "name": "Frodo, Sauron's Bane",
             "text": "",
             "colours": [
@@ -676,7 +676,7 @@
         },
         {
             "id": "adadd47a-0b15-54a0-b47e-5dcefbdc519a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "0e6123cc-508c-531d-a3bd-59578eb09a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019eab42-9e0c-4958-ac97-74d3db5580f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019eab42-9e0c-4958-ac97-74d3db5580f3.jpg?1",
             "name": "Hobbit's Sting",
             "text": "",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "0a9559b8-6279-5f11-a4d6-dc096557a8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5684483b-9a6a-499b-a5e1-e2815ee03cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5684483b-9a6a-499b-a5e1-e2815ee03cdb.jpg?1",
             "name": "Landroval, Horizon Witness",
             "text": "",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "e91f682c-9a33-5a13-9226-df0c6338a272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e40481-aeaa-4b3d-a020-e9b6d7c11992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e40481-aeaa-4b3d-a020-e9b6d7c11992.jpg?1",
             "name": "Lost to Legend",
             "text": "",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "5f3ea33a-80f1-5437-821b-53ffaf000c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cd0756-7bf3-4cb6-9687-1f9346b0bb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cd0756-7bf3-4cb6-9687-1f9346b0bb92.jpg?1",
             "name": "Nimble Hobbit",
             "text": "",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "a5804f3e-985b-5895-a447-ffecfaf0b09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e2c80d-7581-46ba-8237-7886b91c19b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e2c80d-7581-46ba-8237-7886b91c19b3.jpg?1",
             "name": "Now for Wrath, Now for Ruin!",
             "text": "",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "2ad5a4d0-5e54-5715-97c3-d10c46e92df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85708748-40ca-4066-a287-7a6a189ff3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85708748-40ca-4066-a287-7a6a189ff3df.jpg?1",
             "name": "Protector of Gondor",
             "text": "",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "edd3f8d9-d90d-52f0-982b-cffbaaa91d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3fa8a-6c50-4f7f-9ae3-0810eec5e3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3fa8a-6c50-4f7f-9ae3-0810eec5e3db.jpg?1",
             "name": "Reprieve",
             "text": "",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "a0b5488f-f649-5c1f-ab86-c4510d6c4cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75338f49-1f02-4333-87e4-5779ef14e688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75338f49-1f02-4333-87e4-5779ef14e688.jpg?1",
             "name": "Rosie Cotton of South Lane",
             "text": "",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "c12477c2-8713-500c-8ba3-3121812ae1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214c270e-29ca-4d69-bea6-9252ae7707ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214c270e-29ca-4d69-bea6-9252ae7707ad.jpg?1",
             "name": "Samwise the Stouthearted",
             "text": "",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "62a5eae4-59cd-587e-98f6-fd574ee53d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002f647a-25f8-461b-8617-52674f5d577c.jpg?1",
             "name": "Second Breakfast",
             "text": "",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "8db96eb4-371e-50b2-a2ba-3c42df50c682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b687f-2571-4c55-a497-d24b9e18bc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444b687f-2571-4c55-a497-d24b9e18bc0f.jpg?1",
             "name": "Shire Shirriff",
             "text": "",
             "colours": [
@@ -1100,7 +1100,7 @@
         },
         {
             "id": "8fc0bb7f-19c7-5f27-ba15-395516531125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e20c2b8-ffe3-4d14-8588-f89719358e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e20c2b8-ffe3-4d14-8588-f89719358e3d.jpg?1",
             "name": "Slip On the Ring",
             "text": "",
             "colours": [
@@ -1132,7 +1132,7 @@
         },
         {
             "id": "d68d0d4f-5216-57eb-8e93-f8dfe3ed626c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79999df-af8c-4724-9631-20eee5a00e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79999df-af8c-4724-9631-20eee5a00e49.jpg?1",
             "name": "Soldier of the Grey Host",
             "text": "",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "3043b5a1-b4ec-553d-85f3-6e18a9498ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acb8240-8e0e-4adf-a884-4986c116e704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acb8240-8e0e-4adf-a884-4986c116e704.jpg?1",
             "name": "Stalwarts of Osgiliath",
             "text": "",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "3a018e50-684e-531f-b1c3-08f674a713a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae65f96-7bfd-4390-88bf-764c26bf4668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae65f96-7bfd-4390-88bf-764c26bf4668.jpg?1",
             "name": "Tale of Tin\u00faviel",
             "text": "",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "8c186cc7-b14f-53f8-979a-c1eb6283a78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da7fc15-f894-496e-ba18-a02d42e9bedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da7fc15-f894-496e-ba18-a02d42e9bedc.jpg?1",
             "name": "Took Reaper",
             "text": "",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "7e33f35e-c2fe-5fcd-a0e3-42a811e79479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf2cd-5b33-4c8a-a610-8e6a15404dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf2cd-5b33-4c8a-a610-8e6a15404dde.jpg?1",
             "name": "War of the Last Alliance",
             "text": "",
             "colours": [
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "1b73e76d-88c8-5cd9-b7cc-abc984c80387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ed2e4b-c732-472a-a589-f1f53086d9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ed2e4b-c732-472a-a589-f1f53086d9ee.jpg?1",
             "name": "Westfold Rider",
             "text": "",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "2be6553a-0be1-541c-9aa6-7e1c92145339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116d4030-acd2-4aa2-8254-aaaff1264459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116d4030-acd2-4aa2-8254-aaaff1264459.jpg?1",
             "name": "You Cannot Pass!",
             "text": "",
             "colours": [
@@ -1372,7 +1372,7 @@
         },
         {
             "id": "3986a32f-44b8-52b4-8d1b-d1e60356d843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e1ec49-ad4f-4623-aeeb-dba07d6e6251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e1ec49-ad4f-4623-aeeb-dba07d6e6251.jpg?1",
             "name": "Arwen's Gift",
             "text": "",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "bbd3058f-54d5-5235-a579-a406aa8a6e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11c04f-6f17-4da4-bbf6-0bd09de6e544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb11c04f-6f17-4da4-bbf6-0bd09de6e544.jpg?1",
             "name": "The Bath Song",
             "text": "",
             "colours": [
@@ -1438,7 +1438,7 @@
         },
         {
             "id": "562a96d5-0032-542b-96a0-36d3d3671a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612452e-b8a8-4a5a-82a8-01fd463cfc77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612452e-b8a8-4a5a-82a8-01fd463cfc77.jpg?1",
             "name": "Bewitching Leechcraft",
             "text": "",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "c3c4ac6a-efcd-5a85-a72a-dde842c52b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac63cb-fa4d-4340-8062-1029c8bd5ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac63cb-fa4d-4340-8062-1029c8bd5ec8.jpg?1",
             "name": "Bill Ferny, Bree Swindler",
             "text": "",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "d20f5466-0361-50b3-b16a-2de5c6ca2cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42db2313-b13d-4292-bef2-bf86f989d32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42db2313-b13d-4292-bef2-bf86f989d32f.jpg?1",
             "name": "Birthday Escape",
             "text": "",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "93a4d344-a5c8-5d96-bc7c-c31a24a9b9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9379675-1a32-4e2b-8aaf-5f908c595f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9379675-1a32-4e2b-8aaf-5f908c595f31.jpg?1",
             "name": "Borne Upon a Wind",
             "text": "",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "928e5797-b84a-596c-9f1a-ba1e32d89ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c222577d-a3c7-41d9-b11b-62065bdb98ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c222577d-a3c7-41d9-b11b-62065bdb98ef.jpg?1",
             "name": "Captain of Umbar",
             "text": "",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "7a5833e0-cc55-5f02-a0d0-27d348a4a081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651503a2-5d1e-408a-9cdc-0cee05ab3ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651503a2-5d1e-408a-9cdc-0cee05ab3ef0.jpg?1",
             "name": "Council's Deliberation",
             "text": "",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "2659535e-6a30-55ed-9dc4-9f660f632126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2984bc6-7c12-46e4-8dd3-b23e29a7a7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2984bc6-7c12-46e4-8dd3-b23e29a7a7ec.jpg?1",
             "name": "Deceive the Messenger",
             "text": "",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "aedc2dee-caa0-5957-bb37-d8ae58ec4339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e0b4ff-85b5-485f-a78f-1a58bb343238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e0b4ff-85b5-485f-a78f-1a58bb343238.jpg?1",
             "name": "Dreadful as the Storm",
             "text": "",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "d668c848-9f90-5ee2-a4ef-508b596f52db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62a5e55-fa1b-4c70-9293-740dd513d52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62a5e55-fa1b-4c70-9293-740dd513d52e.jpg?1",
             "name": "Elrond, Lord of Rivendell",
             "text": "",
             "colours": [
@@ -1745,7 +1745,7 @@
         },
         {
             "id": "7e1ba2ce-076e-5859-ae7b-00e7749ac45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9cfcc7-be64-4871-8d52-851e43fe3305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9cfcc7-be64-4871-8d52-851e43fe3305.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "53ae60b7-4e99-5dc4-8bae-7fb0399a752d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1057de-5710-415c-9a51-1d8bd86021a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1057de-5710-415c-9a51-1d8bd86021a3.jpg?1",
             "name": "Glorious Gale",
             "text": "",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "b5abcf92-bf7c-58b8-abab-e33184e8bf91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg?1",
             "name": "Goldberry, River-Daughter",
             "text": "",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "30df98ea-7c04-52f7-bef5-835a90d521a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd89994-bdff-47ca-a65d-10afcc7e773e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd89994-bdff-47ca-a65d-10afcc7e773e.jpg?1",
             "name": "Grey Havens Navigator",
             "text": "",
             "colours": [
@@ -1890,7 +1890,7 @@
         },
         {
             "id": "8ec4ecf0-c686-559c-9b68-2cc5e6219102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcc27e7-cbe4-45c2-b157-7251a10e7ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcc27e7-cbe4-45c2-b157-7251a10e7ba4.jpg?1",
             "name": "Hithlain Knots",
             "text": "",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "d110cfd7-0211-5f15-8b40-df17ffb582eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7725dc2-2654-4ffb-b6b3-510ae64ec6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7725dc2-2654-4ffb-b6b3-510ae64ec6af.jpg?1",
             "name": "Horses of the Bruinen",
             "text": "",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "b479ff36-4d5a-5fb8-840d-06d9cc81385e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab74cd-978a-49eb-9d38-bc8b472b3cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab74cd-978a-49eb-9d38-bc8b472b3cef.jpg?1",
             "name": "Ioreth of the Healing House",
             "text": "",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "4de0be3a-ce97-58f3-8c3b-e39032b6feae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9c323-ac9b-4864-bd57-81b557f44114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9c323-ac9b-4864-bd57-81b557f44114.jpg?1",
             "name": "Isolation at Orthanc",
             "text": "",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "fb7a277c-1865-5bf6-a76c-87db4e725680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c29762-6859-4564-9e1d-a87fa63b951a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c29762-6859-4564-9e1d-a87fa63b951a.jpg?1",
             "name": "Ithilien Kingfisher",
             "text": "",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "0fa45604-526f-5b99-ba99-5895ab258275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661338ff-a192-4007-a144-63d00f2e9ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661338ff-a192-4007-a144-63d00f2e9ecb.jpg?1",
             "name": "Knights of Dol Amroth",
             "text": "",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "74668c89-536f-51a2-802c-d96904a83eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce44270-a684-4489-9077-521456e6dfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce44270-a684-4489-9077-521456e6dfaa.jpg?1",
             "name": "L\u00f3rien Revealed",
             "text": "",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "7435f2fd-6b30-556f-8cb7-a7b06e53da4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg?1",
             "name": "Lost Isle Calling",
             "text": "",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "1fe36d78-8060-5a7e-8fc9-3bdd9cf4e2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2ee20-abbc-4a9d-8d30-4223242123e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2ee20-abbc-4a9d-8d30-4223242123e8.jpg?1",
             "name": "Meneldor, Swift Savior",
             "text": "",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "26b35b3d-f8f7-5fd0-894b-5413615d995e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c253ee40-41c9-4cb5-a1a3-94b0aaed09d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c253ee40-41c9-4cb5-a1a3-94b0aaed09d4.jpg?1",
             "name": "Nimrodel Watcher",
             "text": "",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "457b4c9c-40e9-5b59-b10c-6a8af0a0e4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa59141a-4645-4316-b714-bbf2c139786e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa59141a-4645-4316-b714-bbf2c139786e.jpg?1",
             "name": "Pelargir Survivor",
             "text": "",
             "colours": [
@@ -2267,7 +2267,7 @@
         },
         {
             "id": "e519bc4f-91fe-516c-b415-30beb8f0c7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg?1",
             "name": "Press the Enemy",
             "text": "",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "9cd1bfa0-4639-5937-97a8-2104fc88e1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg?1",
             "name": "Rangers of Ithilien",
             "text": "",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "c019f61c-6668-5088-af5a-a774aa2ae320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfccbab-29fa-4e92-8919-6cd4815fb655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfccbab-29fa-4e92-8919-6cd4815fb655.jpg?1",
             "name": "Saruman the White",
             "text": "",
             "colours": [
@@ -2377,7 +2377,7 @@
         },
         {
             "id": "704070ea-6537-5cb9-8c51-082d56bfe76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6c23b-e52e-4533-9625-884eb0a4d866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6c23b-e52e-4533-9625-884eb0a4d866.jpg?1",
             "name": "Saruman's Trickery",
             "text": "",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "5ccae70e-2215-5b20-95b3-f75c8e9519a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195821f4-ba3d-4412-930f-f3656b319dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195821f4-ba3d-4412-930f-f3656b319dfd.jpg?1",
             "name": "Scroll of Isildur",
             "text": "",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "c11e1655-c736-5092-91eb-57cd92c5de1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6400e8-7f99-4005-9a92-ffbc359d3871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6400e8-7f99-4005-9a92-ffbc359d3871.jpg?1",
             "name": "Soothing of Sm\u00e9agol",
             "text": "",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "0886a7ac-9776-5815-b032-f40589d37266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca1e1de-b916-445f-b3b2-0f4d0cc7ceeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca1e1de-b916-445f-b3b2-0f4d0cc7ceeb.jpg?1",
             "name": "Stern Scolding",
             "text": "",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "47a23eea-cdb5-5730-913a-df4f23d60faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52884e67-c742-4799-9afd-55bc70b2cf40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52884e67-c742-4799-9afd-55bc70b2cf40.jpg?1",
             "name": "Storm of Saruman",
             "text": "",
             "colours": [
@@ -2541,7 +2541,7 @@
         },
         {
             "id": "28de4ac2-ad7e-5a70-8844-c165747ed8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c50d4c8-2311-4394-b73f-389eb81e898b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c50d4c8-2311-4394-b73f-389eb81e898b.jpg?1",
             "name": "Surrounded by Orcs",
             "text": "",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "6aa7f6c2-6cc7-55b1-97e5-25f697c09270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f97505-c961-4890-acd0-32a63919ac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f97505-c961-4890-acd0-32a63919ac2a.jpg?1",
             "name": "Treason of Isengard",
             "text": "",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "8a2e0bab-8d47-53d3-b711-14d1d34d2d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8e8bb-75a0-4b5e-b4b3-5d8f3795032d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8e8bb-75a0-4b5e-b4b3-5d8f3795032d.jpg?1",
             "name": "The Watcher in the Water",
             "text": "",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "e24e1d5a-5bdf-567a-93ed-918dc8f0341a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adc3bff-0eb1-40e9-b954-5515babd07a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adc3bff-0eb1-40e9-b954-5515babd07a3.jpg?1",
             "name": "Willow-Wind",
             "text": "",
             "colours": [
@@ -2678,7 +2678,7 @@
         },
         {
             "id": "11b3efec-158e-561b-a241-0dcb7476bee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b83aa1-33ce-4b8d-ae5a-72f64eef5f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b83aa1-33ce-4b8d-ae5a-72f64eef5f09.jpg?1",
             "name": "Bitter Downfall",
             "text": "",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "f3997261-240f-5e7e-9130-07a5114f7fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63983d-c36b-4440-b9e1-baaa6c7c0ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63983d-c36b-4440-b9e1-baaa6c7c0ba9.jpg?1",
             "name": "The Black Breath",
             "text": "",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "917d80bd-4a05-5a96-98af-1e90392095cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg?1",
             "name": "Call of the Ring",
             "text": "",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "7c8d4766-9b13-590b-abc0-a284c97d31a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03837-37cc-4f6c-8e22-e3b0ff635462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03837-37cc-4f6c-8e22-e3b0ff635462.jpg?1",
             "name": "Cirith Ungol Patrol",
             "text": "",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "385fccc5-8b07-5118-98a5-a30b6db94991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121c12c4-83ea-463e-8fdf-30718968a2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121c12c4-83ea-463e-8fdf-30718968a2bd.jpg?1",
             "name": "Claim the Precious",
             "text": "",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "e48b284c-585c-5955-8e50-0b49aad3907c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695c05ab-e46e-46c7-bd2e-ef0b2307e449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695c05ab-e46e-46c7-bd2e-ef0b2307e449.jpg?1",
             "name": "Dunland Crebain",
             "text": "",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "0d9f0be7-1ce4-5d3c-8466-b51e78ee838a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e860dd40-07c5-47c3-92a8-1ee95a953c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e860dd40-07c5-47c3-92a8-1ee95a953c2f.jpg?1",
             "name": "Easterling Vanguard",
             "text": "",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "e42ad5d6-01fd-502e-9646-dce09f2178fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddda7d4-0226-404f-8418-f1f5720dcef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddda7d4-0226-404f-8418-f1f5720dcef8.jpg?1",
             "name": "Gollum, Patient Plotter",
             "text": "",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "813a27e0-642a-5290-b1e3-e77e4ade00d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1e790e-ff82-4888-8aee-9986c646241a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1e790e-ff82-4888-8aee-9986c646241a.jpg?1",
             "name": "Gollum's Bite",
             "text": "",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "8ea25c3d-026c-5376-bf97-588d7b813df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aafdb6-1c8c-4fc4-a52e-3e601be7fb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aafdb6-1c8c-4fc4-a52e-3e601be7fb0c.jpg?1",
             "name": "Gorbag of Minas Morgul",
             "text": "",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "b3eca218-38f9-54fe-a254-55061f42865d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c10e93-88eb-46b9-8adc-583661807990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c10e93-88eb-46b9-8adc-583661807990.jpg?1",
             "name": "Gothmog, Morgul Lieutenant",
             "text": "",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "7796e52d-52f2-555e-8f6e-3a746c66339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3bd86b-e8ca-4885-a823-78fb967e6caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3bd86b-e8ca-4885-a823-78fb967e6caf.jpg?1",
             "name": "Gr\u00edma Wormtongue",
             "text": "",
             "colours": [
@@ -3100,7 +3100,7 @@
         },
         {
             "id": "a7f879f2-a554-5e1c-a907-18122e8135e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61b28-afdd-4de9-829b-ffe5ca7c7f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc61b28-afdd-4de9-829b-ffe5ca7c7f19.jpg?1",
             "name": "Grond, the Gatebreaker",
             "text": "",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "ca51deab-4471-5c5f-a792-b81c57365dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c6c12-2513-4d1b-acf0-6a1f741d49dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673c6c12-2513-4d1b-acf0-6a1f741d49dd.jpg?1",
             "name": "Haunt of the Dead Marshes",
             "text": "",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "01f6ac51-abb5-5518-9956-e010ec943ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf08071-fbf8-463e-9a57-59dbf0280dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf08071-fbf8-463e-9a57-59dbf0280dd8.jpg?1",
             "name": "Isildur's Fateful Strike",
             "text": "",
             "colours": [
@@ -3208,7 +3208,7 @@
         },
         {
             "id": "51c139bd-4a22-53b2-a99a-246cefdbefcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812fee97-e145-4458-b495-bc6ad227335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812fee97-e145-4458-b495-bc6ad227335b.jpg?1",
             "name": "Lash of the Balrog",
             "text": "",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "276fde0f-41ee-500f-820c-40768d893487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87500b92-3d68-42f3-afa9-f8206b2ebcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87500b92-3d68-42f3-afa9-f8206b2ebcbb.jpg?1",
             "name": "Lobelia Sackville-Baggins",
             "text": "",
             "colours": [
@@ -3282,7 +3282,7 @@
         },
         {
             "id": "db18d235-c31e-5cfd-a140-4b1992f1628a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57815d4-b21f-4ceb-a3f1-73cff5f0e612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e57815d4-b21f-4ceb-a3f1-73cff5f0e612.jpg?1",
             "name": "March from the Black Gate",
             "text": "",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "ea035e62-c9a7-5cba-a616-1ffa3a3ddb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f035df-784a-4dc8-b7f5-77139a4e6e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f035df-784a-4dc8-b7f5-77139a4e6e99.jpg?1",
             "name": "Mirkwood Bats",
             "text": "",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "be388ea0-f2cf-5f75-93cc-b629dac2ad2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae2f15a-0629-453e-992c-a199af194a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae2f15a-0629-453e-992c-a199af194a3c.jpg?1",
             "name": "Mordor Muster",
             "text": "",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "935eba1c-d1aa-5336-b9b7-0c35feb34e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648bc8ae-1798-4c2f-a372-0487a90ba4d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648bc8ae-1798-4c2f-a372-0487a90ba4d3.jpg?1",
             "name": "Mordor Trebuchet",
             "text": "",
             "colours": [
@@ -3417,7 +3417,7 @@
         },
         {
             "id": "280a6f6c-9e32-567b-b5ce-f110882e4af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae08177-48ee-4404-834d-d3cd7482ae81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae08177-48ee-4404-834d-d3cd7482ae81.jpg?1",
             "name": "Morgul-Knife Wound",
             "text": "",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "dcefadcd-0490-5ee3-bbf3-7890cddf8838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34f88d7-15a1-434f-88d7-3d4fcf406d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34f88d7-15a1-434f-88d7-3d4fcf406d54.jpg?1",
             "name": "Nasty End",
             "text": "",
             "colours": [
@@ -3485,7 +3485,7 @@
         },
         {
             "id": "14b5deae-0d5a-5050-9b42-8bb5bdd1abf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833936c6-9381-4c0b-a81c-4a938be95040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833936c6-9381-4c0b-a81c-4a938be95040.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "ddc4895d-3043-59dd-bbff-7468e2a55a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a780abd-f276-40d3-b2af-d2e47d858d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a780abd-f276-40d3-b2af-d2e47d858d3d.jpg?1",
             "name": "Oath of the Grey Host",
             "text": "",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "3428febd-4e31-56ff-8dfc-8e3dd035d07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg?1",
             "name": "One Ring to Rule Them All",
             "text": "",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "a99e8451-669e-5dcb-93de-1ceb4d4fefd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c024bae-5631-4e20-ac69-df392ac9e109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c024bae-5631-4e20-ac69-df392ac9e109.jpg?1",
             "name": "Orcish Bowmasters",
             "text": "",
             "colours": [
@@ -3634,7 +3634,7 @@
         },
         {
             "id": "048d6fa3-ead2-5a0e-a977-ad226b356772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fae9ab-2302-4dea-a4e8-701938a0ef09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fae9ab-2302-4dea-a4e8-701938a0ef09.jpg?1",
             "name": "Orcish Medicine",
             "text": "",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "33696a33-914f-5401-a94b-d6aa850bf452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd4d735-8cda-47c1-865b-48b51ac8f666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd4d735-8cda-47c1-865b-48b51ac8f666.jpg?1",
             "name": "Sam's Desperate Rescue",
             "text": "",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "637aec80-1542-50d7-b222-b911f5b08c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg?1",
             "name": "Sauron, the Necromancer",
             "text": "",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "d981753e-7a5d-5fa2-9f25-9d6219c462f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47cab70-55cb-481c-b4cd-32a41251f210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47cab70-55cb-481c-b4cd-32a41251f210.jpg?1",
             "name": "Shadow of the Enemy",
             "text": "",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "14ac9612-6f26-5170-9514-fed07949324b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e69fa8-7339-4bfa-8e35-9cbfe0001d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e69fa8-7339-4bfa-8e35-9cbfe0001d8b.jpg?1",
             "name": "Shelob's Ambush",
             "text": "",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "de2448a1-04fe-5d6a-815e-5b59dcfefaf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ad561c-ccb4-480a-88a4-0555d0ef245e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ad561c-ccb4-480a-88a4-0555d0ef245e.jpg?1",
             "name": "Snarling Warg",
             "text": "",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "bc140348-74a3-5d18-a172-b16230a93614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2c8c25-1fa9-4cc4-a378-5eccc25bacf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2c8c25-1fa9-4cc4-a378-5eccc25bacf0.jpg?1",
             "name": "The Torment of Gollum",
             "text": "",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "17763f38-5973-509a-b290-e6ca1de5f440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6539e26-b63b-4725-9407-caaf451de084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6539e26-b63b-4725-9407-caaf451de084.jpg?1",
             "name": "Troll of Khazad-d\u00fbm",
             "text": "",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "185762a4-3f06-50d6-a6d4-2a75b7106056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936421a0-2c2a-4410-941d-4e6b88166bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936421a0-2c2a-4410-941d-4e6b88166bd1.jpg?1",
             "name": "Uruk-hai Berserker",
             "text": "",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "2055d801-2a16-570d-9e00-ef6aeaf8a5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b7d7f8-503d-4660-9a18-6a8e2fcaa25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b7d7f8-503d-4660-9a18-6a8e2fcaa25f.jpg?1",
             "name": "Voracious Fell Beast",
             "text": "",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "c09d214e-e175-5bbb-9319-6edcb7abecbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg?1",
             "name": "Witch-king of Angmar",
             "text": "",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "a8bad690-b02e-5a33-9b63-170766350794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91859de-1983-4c9c-a9e6-289c7dba1eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91859de-1983-4c9c-a9e6-289c7dba1eb4.jpg?1",
             "name": "Battle-Scarred Goblin",
             "text": "",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "f1f05aef-aa21-58cd-9c5d-b12e2ec1da82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcef75-6f98-4233-ae32-6fe41724c8e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcef75-6f98-4233-ae32-6fe41724c8e0.jpg?1",
             "name": "Book of Mazarbul",
             "text": "",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "8c96986c-9f2a-5d5f-9b5d-3501394454e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130f60d0-4fac-4e4e-a938-58f3b96e5335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/130f60d0-4fac-4e4e-a938-58f3b96e5335.jpg?1",
             "name": "Breaking of the Fellowship",
             "text": "",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "6e46a0cf-8816-56f8-b537-a6cb67eb9249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef878cb-27b6-47d8-ad11-bd20529b0e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef878cb-27b6-47d8-ad11-bd20529b0e7e.jpg?1",
             "name": "Cast into the Fire",
             "text": "",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "8e1420d4-266b-5e22-b6c9-2e1016885cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg?1",
             "name": "Display of Power",
             "text": "",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "11d6dc8d-063b-5ac4-bf8b-e7e9cdcc4fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd31ce9-9551-4efe-8bd2-b97d8efbf75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd31ce9-9551-4efe-8bd2-b97d8efbf75e.jpg?1",
             "name": "\u00c9omer, Marshal of Rohan",
             "text": "",
             "colours": [
@@ -4221,7 +4221,7 @@
         },
         {
             "id": "92209989-aca4-5241-a0e2-b13f399ce871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920fcaf-4988-4186-962d-cdda25d79e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d920fcaf-4988-4186-962d-cdda25d79e7b.jpg?1",
             "name": "\u00c9omer of the Riddermark",
             "text": "",
             "colours": [
@@ -4258,7 +4258,7 @@
         },
         {
             "id": "d8a2117b-facb-54ac-abc1-0791b95c5bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552730c5-e3a6-468f-91b2-82c272dda400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552730c5-e3a6-468f-91b2-82c272dda400.jpg?1",
             "name": "Erebor Flamesmith",
             "text": "",
             "colours": [
@@ -4293,7 +4293,7 @@
         },
         {
             "id": "6466cdca-c4bf-5718-baab-a0d0e8d05a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f81e68-cddd-47f4-b1d1-a297c3298c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f81e68-cddd-47f4-b1d1-a297c3298c25.jpg?1",
             "name": "Erkenbrand, Lord of Westfold",
             "text": "",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "d4c70311-25df-547f-b1cb-252324fea239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b4623-50a0-41f1-ad1e-7dd6ac3852df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b4623-50a0-41f1-ad1e-7dd6ac3852df.jpg?1",
             "name": "Fall of Cair Andros",
             "text": "",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "1f4cdc19-a3bd-5b5d-8d7c-257bf285cb99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37be98a4-0cba-46b4-be93-a9805fe77160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37be98a4-0cba-46b4-be93-a9805fe77160.jpg?1",
             "name": "Fear, Fire, Foes!",
             "text": "",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "ed8d98d8-965a-5e80-8e91-473c4aa785e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c321159-43e5-40fc-9f0c-4ecc4f6cfd20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c321159-43e5-40fc-9f0c-4ecc4f6cfd20.jpg?1",
             "name": "Fiery Inscription",
             "text": "",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "ff2f21f3-d76e-5513-b206-d65866f6f30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5871c5-bb94-4803-93ba-cd1a630b00d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5871c5-bb94-4803-93ba-cd1a630b00d6.jpg?1",
             "name": "Fire of Orthanc",
             "text": "",
             "colours": [
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "2bd6ffdf-e892-5c3f-9ed5-749d196ac32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fea0c66-c776-4dc7-a235-f3822521cacd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fea0c66-c776-4dc7-a235-f3822521cacd.jpg?1",
             "name": "Foray of Orcs",
             "text": "",
             "colours": [
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "e30e52e4-c773-53fe-8031-d6ac9fb52a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41c48-0715-49d9-98e5-e82b706da816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41c48-0715-49d9-98e5-e82b706da816.jpg?1",
             "name": "Gimli, Counter of Kills",
             "text": "",
             "colours": [
@@ -4534,7 +4534,7 @@
         },
         {
             "id": "fc9d3454-32ee-59bb-997f-b55efe44e3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999b6c-e501-48d0-ae51-a35b96f996ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999b6c-e501-48d0-ae51-a35b96f996ec.jpg?1",
             "name": "Gimli's Axe",
             "text": "",
             "colours": [
@@ -4568,7 +4568,7 @@
         },
         {
             "id": "c5f118c8-ed01-5e14-af2f-ac7be7d56a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efde011d-8732-49b3-9204-8b114a3d81ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efde011d-8732-49b3-9204-8b114a3d81ba.jpg?1",
             "name": "Gimli's Fury",
             "text": "",
             "colours": [
@@ -4600,7 +4600,7 @@
         },
         {
             "id": "e43008b2-3cf6-5a9a-9c7b-ea914e184dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868a2aa7-bcaf-409b-8802-d00ee1f2ae77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868a2aa7-bcaf-409b-8802-d00ee1f2ae77.jpg?1",
             "name": "Gl\u00f3in, Dwarf Emissary",
             "text": "",
             "colours": [
@@ -4639,7 +4639,7 @@
         },
         {
             "id": "4dc2bc5e-4ddb-5294-922e-e859db7ac34f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec120dae-8c40-4053-9341-1f7774464634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec120dae-8c40-4053-9341-1f7774464634.jpg?1",
             "name": "Goblin Fireleaper",
             "text": "",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "75cb1797-8b01-5498-a4cc-549cff1f69ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6385e769-f805-499d-9f47-494533362152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6385e769-f805-499d-9f47-494533362152.jpg?1",
             "name": "Grishn\u00e1kh, Brash Instigator",
             "text": "",
             "colours": [
@@ -4711,7 +4711,7 @@
         },
         {
             "id": "d81ddadd-4b84-5ad5-9a5f-3727f153955b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6050cf98-cdce-4825-9ab8-2294a2b63faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6050cf98-cdce-4825-9ab8-2294a2b63faf.jpg?1",
             "name": "Haradrim Spearmaster",
             "text": "",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "d2d4273d-cb74-54da-9029-7a6bd4f11b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg?1",
             "name": "Hew the Entwood",
             "text": "",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "df328f62-4a16-5c81-9185-cf024423f48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8397d13-eeaf-4b4e-b3cd-9a9ac231873a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8397d13-eeaf-4b4e-b3cd-9a9ac231873a.jpg?1",
             "name": "Improvised Club",
             "text": "",
             "colours": [
@@ -4812,7 +4812,7 @@
         },
         {
             "id": "e21ee1b0-c9ff-54d2-ab31-5de26c08d9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d5394-2248-4654-bec5-33b144752586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33d5394-2248-4654-bec5-33b144752586.jpg?1",
             "name": "Moria Marauder",
             "text": "",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "467dfbee-9a17-578a-8089-0f6b99084f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6989018c-37b1-4282-a4af-9cc97f160b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6989018c-37b1-4282-a4af-9cc97f160b4d.jpg?1",
             "name": "Oliphaunt",
             "text": "",
             "colours": [
@@ -4885,7 +4885,7 @@
         },
         {
             "id": "ad8ac3d6-5603-56a3-8c64-d6a9865ebcc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33bf593-62e0-491a-a31a-328bce6d8735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33bf593-62e0-491a-a31a-328bce6d8735.jpg?1",
             "name": "Olog-hai Crusher",
             "text": "",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "dbe3c4d2-73e2-562f-b976-fd13e7bce0f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e61a6-c602-4089-ae45-828d8e516a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e61a6-c602-4089-ae45-828d8e516a63.jpg?1",
             "name": "Quarrel's End",
             "text": "",
             "colours": [
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "9f918221-4b14-56f2-a80d-23fea66db3eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7292f7-1c7e-449c-9c52-7584d6a14c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7292f7-1c7e-449c-9c52-7584d6a14c2c.jpg?1",
             "name": "Rally at the Hornburg",
             "text": "",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "93d95103-767c-5f5e-b324-4a893af9bec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06541200-fa4c-4b98-bdc4-44708fd2ddf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06541200-fa4c-4b98-bdc4-44708fd2ddf6.jpg?1",
             "name": "Ranger's Firebrand",
             "text": "",
             "colours": [
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "aa0d762c-8373-50b3-a6f4-0b5da7d4fe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b7606a-6a4c-4bf0-b311-1883383161d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b7606a-6a4c-4bf0-b311-1883383161d2.jpg?1",
             "name": "Relentless Rohirrim",
             "text": "",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "7c5c9212-ade2-5edf-a96b-3d0b176e2489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbcac6-8ac9-44a8-9d1a-03d0799ac253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fbcac6-8ac9-44a8-9d1a-03d0799ac253.jpg?1",
             "name": "Rising of the Day",
             "text": "",
             "colours": [
@@ -5085,7 +5085,7 @@
         },
         {
             "id": "e1185b93-4dc4-5121-9e85-46c53fc15c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f506f9f-4c0d-44e8-9f81-8403d808d0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f506f9f-4c0d-44e8-9f81-8403d808d0e4.jpg?1",
             "name": "Rohirrim Lancer",
             "text": "",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "2b64717e-6f69-5426-82ad-a97d16289321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525b727-acde-427b-9c33-20964e8cf613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525b727-acde-427b-9c33-20964e8cf613.jpg?1",
             "name": "Rush the Room",
             "text": "",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "40c2fe04-10c3-5b1d-b4c5-1971f5e79435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b716fcc-c4cc-4987-be82-2897a9888d23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b716fcc-c4cc-4987-be82-2897a9888d23.jpg?1",
             "name": "Smite the Deathless",
             "text": "",
             "colours": [
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "371768fc-2054-5681-8329-b670079c9892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a82bc-49f3-4694-b688-808a541146db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85a82bc-49f3-4694-b688-808a541146db.jpg?1",
             "name": "Spiteful Banditry",
             "text": "",
             "colours": [
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "dc505921-b3ef-524c-ad8c-df31b311e425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1bd073-4351-4c56-9b07-4430d0d83084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1bd073-4351-4c56-9b07-4430d0d83084.jpg?1",
             "name": "Swarming of Moria",
             "text": "",
             "colours": [
@@ -5250,7 +5250,7 @@
         },
         {
             "id": "83d3f0fd-9148-57a7-9c93-e285418bf25f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b0bd0-24ea-45de-a2d3-37bbf6a3e6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b0bd0-24ea-45de-a2d3-37bbf6a3e6f9.jpg?1",
             "name": "There and Back Again",
             "text": "",
             "colours": [
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "3587abca-58c2-5a54-9050-37325d49e3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eeecb9e-fbde-429b-b3da-18a4dbadf6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eeecb9e-fbde-429b-b3da-18a4dbadf6de.jpg?1",
             "name": "Warbeast of Gorgoroth",
             "text": "",
             "colours": [
@@ -5318,7 +5318,7 @@
         },
         {
             "id": "ffbef8ce-0257-590c-8ab4-c5ee8e3e4c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7557170-39a2-49df-823e-958c3eb34801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7557170-39a2-49df-823e-958c3eb34801.jpg?1",
             "name": "Bag End Porter",
             "text": "",
             "colours": [
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "d9b6f57c-b936-52b1-b9fe-a78040752c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391699e-987a-499f-9fec-96f2362760b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391699e-987a-499f-9fec-96f2362760b9.jpg?1",
             "name": "Bombadil's Song",
             "text": "",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "7d8f9dd1-d341-51b0-8087-5d733197f0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c24b5fa-506d-4eaf-881b-bc282c74a16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c24b5fa-506d-4eaf-881b-bc282c74a16c.jpg?1",
             "name": "Brandywine Farmer",
             "text": "",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "f38edf12-2a77-51f5-bfc1-d5fc905d0bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daf449a-5f3e-44fd-968e-55d8517ae797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daf449a-5f3e-44fd-968e-55d8517ae797.jpg?1",
             "name": "Celeborn the Wise",
             "text": "",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "da127948-9346-56b6-a72b-36d33095e583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa57431-39e2-4152-8a30-1c1e8faef153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa57431-39e2-4152-8a30-1c1e8faef153.jpg?1",
             "name": "Chance-Met Elves",
             "text": "",
             "colours": [
@@ -5491,7 +5491,7 @@
         },
         {
             "id": "777c22a7-9c2b-5204-8952-22eff61e3ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71384418-173a-4f77-adab-56e52fa23692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71384418-173a-4f77-adab-56e52fa23692.jpg?1",
             "name": "Delighted Halfling",
             "text": "",
             "colours": [
@@ -5529,7 +5529,7 @@
         },
         {
             "id": "fab00dcb-e13e-59af-9413-136e2cdd62e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630e1e36-2f5d-44d4-9ff2-19ae75295016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630e1e36-2f5d-44d4-9ff2-19ae75295016.jpg?1",
             "name": "D\u00fanedain Rangers",
             "text": "",
             "colours": [
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "d3baabfe-a9c6-5b85-a793-0b414ace96f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616cfb94-3faf-44fe-bf04-e90643765e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616cfb94-3faf-44fe-bf04-e90643765e48.jpg?1",
             "name": "Elven Chorus",
             "text": "",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "9aa5653d-8c32-5782-976b-b7bf2860e198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d135b2-d2b8-499c-84d9-824370c19ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d135b2-d2b8-499c-84d9-824370c19ccc.jpg?1",
             "name": "Elven Farsight",
             "text": "",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "c8874974-d070-5d92-b139-ec11605a5fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b48836-6d37-46eb-8c41-a3eeecc72ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b48836-6d37-46eb-8c41-a3eeecc72ae1.jpg?1",
             "name": "Enraged Huorn",
             "text": "",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "c5c13457-99af-54f6-845a-ce11ac3a476b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4dbf80-187b-40e3-9e0b-526f78d9a34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4dbf80-187b-40e3-9e0b-526f78d9a34e.jpg?1",
             "name": "Entish Restoration",
             "text": "",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "e68ce95f-acfc-545c-974b-b4399a4bca99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7946af6-69ab-47a1-955c-1954a04752df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7946af6-69ab-47a1-955c-1954a04752df.jpg?1",
             "name": "Ent's Fury",
             "text": "",
             "colours": [
@@ -5728,7 +5728,7 @@
         },
         {
             "id": "2f423dda-aa05-5bab-9b85-9c83a19f1a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaab2c0-ea18-4b2f-b75b-506cbbea97e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbaab2c0-ea18-4b2f-b75b-506cbbea97e1.jpg?1",
             "name": "Fall of Gil-galad",
             "text": "",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "f3c66315-195e-5cdd-9ef8-5c326b846d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb0f946-2127-4aa3-88ac-9bd2e94d8983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb0f946-2127-4aa3-88ac-9bd2e94d8983.jpg?1",
             "name": "Fangorn, Tree Shepherd",
             "text": "",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "f221e698-583e-5d98-9de3-84b874881dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df34f21-798f-440d-8b09-ec5b5c0b8c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df34f21-798f-440d-8b09-ec5b5c0b8c12.jpg?1",
             "name": "Galadhrim Bow",
             "text": "",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "77d66745-9063-55bf-8031-2dafe809a239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4603f59-f899-4caf-a874-bf234d2045fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4603f59-f899-4caf-a874-bf234d2045fb.jpg?1",
             "name": "Galadhrim Guide",
             "text": "",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "7c574b96-38e1-500d-8328-3bbe6b64a3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d22d5d-3875-42ff-b51e-c6e21db201f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d22d5d-3875-42ff-b51e-c6e21db201f5.jpg?1",
             "name": "Generous Ent",
             "text": "",
             "colours": [
@@ -5903,7 +5903,7 @@
         },
         {
             "id": "0768c4b8-f151-580e-b4b7-a307390fe74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c54ee0c-1432-4f20-9a92-2cdfcbab30ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c54ee0c-1432-4f20-9a92-2cdfcbab30ac.jpg?1",
             "name": "Gift of Strands",
             "text": "",
             "colours": [
@@ -5937,7 +5937,7 @@
         },
         {
             "id": "6a4f1adb-db3c-5f85-91f1-96793c29a5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf7a546-8a8b-4396-ab64-9a5b9abffe79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf7a546-8a8b-4396-ab64-9a5b9abffe79.jpg?1",
             "name": "Glorfindel, Dauntless Rescuer",
             "text": "",
             "colours": [
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "6a7524e1-b528-5098-a6cb-855fafcabd3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b99e0-ffb7-4f98-8ee5-4357bb79dd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1b99e0-ffb7-4f98-8ee5-4357bb79dd2e.jpg?1",
             "name": "Last March of the Ents",
             "text": "",
             "colours": [
@@ -6008,7 +6008,7 @@
         },
         {
             "id": "44b27ba5-a476-5814-80b1-66efc71bdcb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg?1",
             "name": "Legolas, Master Archer",
             "text": "",
             "colours": [
@@ -6048,7 +6048,7 @@
         },
         {
             "id": "55a56fd3-d8df-5bd0-8d5f-4f5a23e66e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347256-2ac4-4b12-b288-0a8d578a1ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347256-2ac4-4b12-b288-0a8d578a1ff2.jpg?1",
             "name": "Long List of the Ents",
             "text": "",
             "colours": [
@@ -6082,7 +6082,7 @@
         },
         {
             "id": "6ac30f60-d016-5b89-889c-538a0470dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3639c1-ebc3-4a0b-ab93-549e45aff0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3639c1-ebc3-4a0b-ab93-549e45aff0f7.jpg?1",
             "name": "Lothl\u00f3rien Lookout",
             "text": "",
             "colours": [
@@ -6117,7 +6117,7 @@
         },
         {
             "id": "6142584c-6ec2-5c7e-ab5f-1a0e22eda8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d179dbbe-9c79-4dbc-955a-5209a3e2745a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d179dbbe-9c79-4dbc-955a-5209a3e2745a.jpg?1",
             "name": "Many Partings",
             "text": "",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "67387d5a-a288-5974-a068-51d6b1b79f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885a3277-ef10-4dcf-ac63-eb8971cd627c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885a3277-ef10-4dcf-ac63-eb8971cd627c.jpg?1",
             "name": "Meriadoc Brandybuck",
             "text": "",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "181a3981-f935-5ea3-8e4c-fce2c2dc4e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad961ba1-c74f-4a44-87fe-b30e2b63e378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad961ba1-c74f-4a44-87fe-b30e2b63e378.jpg?1",
             "name": "Mirkwood Spider",
             "text": "",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "9870b989-dc04-509e-a074-912da74b0d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315d7cc-fc2c-45b1-8340-11ff2af3beb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315d7cc-fc2c-45b1-8340-11ff2af3beb5.jpg?1",
             "name": "Mirrormere Guardian",
             "text": "",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "59122894-4b93-5552-9e9b-52a219322880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fd66d-fa7e-411d-9014-a56caa879d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fd66d-fa7e-411d-9014-a56caa879d93.jpg?1",
             "name": "Mushroom Watchdogs",
             "text": "",
             "colours": [
@@ -6293,7 +6293,7 @@
         },
         {
             "id": "506abb4b-e7d8-536c-a573-7fbb4829e37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5baee8d-88e7-4468-94a9-66ca8e2caf15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5baee8d-88e7-4468-94a9-66ca8e2caf15.jpg?1",
             "name": "Peregrin Took",
             "text": "",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "688a6f7d-d370-5922-9766-608767053b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60dc65-6813-4d57-877b-df195ed00d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc60dc65-6813-4d57-877b-df195ed00d00.jpg?1",
             "name": "Pippin's Bravery",
             "text": "",
             "colours": [
@@ -6366,7 +6366,7 @@
         },
         {
             "id": "9f88d10b-5dd4-579b-bb8d-395132ad74b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b889037f-b95f-4756-80aa-04097d2818c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b889037f-b95f-4756-80aa-04097d2818c3.jpg?1",
             "name": "Quickbeam, Upstart Ent",
             "text": "",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "a140b891-adf9-5f03-b3d3-9af316289b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg?1",
             "name": "Radagast the Brown",
             "text": "",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "e40babfb-a79b-5ded-9cb3-e2d6a4cd87ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b7f493-1b57-4b07-8510-30703282f879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b7f493-1b57-4b07-8510-30703282f879.jpg?1",
             "name": "Revive the Shire",
             "text": "",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "40630572-595c-52e2-8e91-d75e47c2b8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg?1",
             "name": "The Ring Goes South",
             "text": "",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "00281c06-7d6c-5df9-9851-e934d8b22a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bc14f9-c90c-499d-9024-3182d78e0a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bc14f9-c90c-499d-9024-3182d78e0a88.jpg?1",
             "name": "Shortcut to Mushrooms",
             "text": "",
             "colours": [
@@ -6541,7 +6541,7 @@
         },
         {
             "id": "9f3b7ee5-8d4c-5c3f-b5b7-a710593d712c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92cd3884-18d1-4200-b28e-a52349ef37aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92cd3884-18d1-4200-b28e-a52349ef37aa.jpg?1",
             "name": "Shower of Arrows",
             "text": "",
             "colours": [
@@ -6573,7 +6573,7 @@
         },
         {
             "id": "d4f13ffb-ba09-58af-b0c6-c75a928958f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7c41c-f416-457e-91ba-1f338f45eeac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc7c41c-f416-457e-91ba-1f338f45eeac.jpg?1",
             "name": "Stew the Coneys",
             "text": "",
             "colours": [
@@ -6605,7 +6605,7 @@
         },
         {
             "id": "4585507b-e37a-5021-b488-ce9561e695c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589b339-9067-4e9b-bfdb-c49f8b3ef2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6589b339-9067-4e9b-bfdb-c49f8b3ef2d4.jpg?1",
             "name": "Wose Pathfinder",
             "text": "",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "7774f19e-1737-59b3-8e6a-d50d0ecf21ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca5f48-0117-49d6-8b00-b8482e3545b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ca5f48-0117-49d6-8b00-b8482e3545b3.jpg?1",
             "name": "Aragorn, Company Leader",
             "text": "",
             "colours": [
@@ -6682,7 +6682,7 @@
         },
         {
             "id": "3ad5be8a-e07b-5079-b5cf-065b21d60fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d5321-ec09-456c-a9ea-c8ca2cfc6205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d5321-ec09-456c-a9ea-c8ca2cfc6205.jpg?1",
             "name": "Aragorn, the Uniter",
             "text": "",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "585e7eb7-2dd0-5cc2-b11a-916f7bda7bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f92d4-cd1d-4ca7-a6e2-6473b4d3c832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f92d4-cd1d-4ca7-a6e2-6473b4d3c832.jpg?1",
             "name": "Arwen, Mortal Queen",
             "text": "",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "7f7ff3fc-4c48-5358-9405-30a940dbbaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c544e301-13b4-4dec-b65c-d54809bb7736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c544e301-13b4-4dec-b65c-d54809bb7736.jpg?1",
             "name": "Arwen Und\u00f3miel",
             "text": "",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "c875f12e-8b08-5e7c-8a3a-484091016d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416880c3-cefb-45ea-bcc3-2ec7a70c8097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416880c3-cefb-45ea-bcc3-2ec7a70c8097.jpg?1",
             "name": "The Balrog, Durin's Bane",
             "text": "",
             "colours": [
@@ -6849,7 +6849,7 @@
         },
         {
             "id": "f9d57a26-8e57-50d1-86c1-0c4180a647e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527df93e-cc2b-4216-909a-4ada1abcbfd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527df93e-cc2b-4216-909a-4ada1abcbfd3.jpg?1",
             "name": "Bilbo, Retired Burglar",
             "text": "",
             "colours": [
@@ -6890,7 +6890,7 @@
         },
         {
             "id": "e6015db1-0a99-5f93-ac3d-9c8cb6d5c36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3fd9ff1-278b-4e6a-b30b-90250d8b5762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3fd9ff1-278b-4e6a-b30b-90250d8b5762.jpg?1",
             "name": "Butterbur, Bree Innkeeper",
             "text": "",
             "colours": [
@@ -6929,7 +6929,7 @@
         },
         {
             "id": "745d595a-274f-5e5f-a679-b644381be34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8654cf-431c-427b-b78f-0e48f6007e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8654cf-431c-427b-b78f-0e48f6007e9e.jpg?1",
             "name": "Denethor, Ruling Steward",
             "text": "",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "21220aa5-453c-59cb-a8d5-6b31f7df1838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd8813-4aaf-48bf-9243-3ec4099b8372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd8813-4aaf-48bf-9243-3ec4099b8372.jpg?1",
             "name": "Doors of Durin",
             "text": "",
             "colours": [
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "1a24e767-e41b-5fd9-9c58-bac026ffb8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26ffb2c-f7a5-4a4f-9b99-c8de9dfd49da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26ffb2c-f7a5-4a4f-9b99-c8de9dfd49da.jpg?1",
             "name": "Elrond, Master of Healing",
             "text": "",
             "colours": [
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "5999091a-16e1-5560-9de1-238c7afc673d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffb389-c9a3-41c4-b078-292a2bcf870d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffb389-c9a3-41c4-b078-292a2bcf870d.jpg?1",
             "name": "\u00c9owyn, Fearless Knight",
             "text": "",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "59a8387e-cb7c-5d4f-96f1-ede9e6bbe4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700923a-e9ff-4ced-87fe-1ab26554623a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700923a-e9ff-4ced-87fe-1ab26554623a.jpg?1",
             "name": "Faramir, Prince of Ithilien",
             "text": "",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "8aa4f067-2ae2-5cc0-bb2e-cece106e3190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04779a7e-b453-48b9-b392-6d6fd0b8d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04779a7e-b453-48b9-b392-6d6fd0b8d283.jpg?1",
             "name": "Flame of Anor",
             "text": "",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "f970838a-20a5-5735-85d8-d8eb6c292c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24076763-88ba-4dee-b548-9c27bd34fdb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24076763-88ba-4dee-b548-9c27bd34fdb7.jpg?1",
             "name": "Friendly Rivalry",
             "text": "",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "6c26c3b2-9c45-51b8-81fa-baa1adce0e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0399-9db8-4901-b72e-0010eb9b92b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c0399-9db8-4901-b72e-0010eb9b92b0.jpg?1",
             "name": "Frodo Baggins",
             "text": "",
             "colours": [
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "5887a825-058a-59af-9e4c-0714514ab167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5c3b3-9a70-4a1c-bfb3-db27e51c4b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5c3b3-9a70-4a1c-bfb3-db27e51c4b8d.jpg?1",
             "name": "Galadriel of Lothl\u00f3rien",
             "text": "",
             "colours": [
@@ -7286,7 +7286,7 @@
         },
         {
             "id": "201594d1-4828-5a29-995b-7f6c6dc6c2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b975e6-e709-481f-bfbc-41a832508283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b975e6-e709-481f-bfbc-41a832508283.jpg?1",
             "name": "Gandalf the Grey",
             "text": "",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "45f6b0b7-ea9b-51ec-b5b0-dd0efbab711b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebf2a25-9bee-4146-af83-f22aab6db2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebf2a25-9bee-4146-af83-f22aab6db2a8.jpg?1",
             "name": "Gandalf's Sanction",
             "text": "",
             "colours": [
@@ -7361,7 +7361,7 @@
         },
         {
             "id": "891d6f34-c369-51af-bb68-96e42a931e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4be38c-3f93-4ff4-bff4-94753b96f2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4be38c-3f93-4ff4-bff4-94753b96f2f3.jpg?1",
             "name": "Gimli, Mournful Avenger",
             "text": "",
             "colours": [
@@ -7403,7 +7403,7 @@
         },
         {
             "id": "66fe976b-6bd1-5f03-a5e4-ddd183d5e8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a42c951-1146-4f49-a690-7d385962b191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a42c951-1146-4f49-a690-7d385962b191.jpg?1",
             "name": "Gwaihir the Windlord",
             "text": "",
             "colours": [
@@ -7442,7 +7442,7 @@
         },
         {
             "id": "bb79e5e2-40e4-5e28-aad2-7ea6fc012b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857755-62e6-4d29-95f5-82f5d4bde522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857755-62e6-4d29-95f5-82f5d4bde522.jpg?1",
             "name": "King of the Oathbreakers",
             "text": "",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "0189f201-541e-5408-98c4-ba8b21fa58fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bd408c-9e6d-436d-9c4f-9ef3203aeb64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bd408c-9e6d-436d-9c4f-9ef3203aeb64.jpg?1",
             "name": "Legolas, Counter of Kills",
             "text": "",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "b204188d-e58c-5c9d-b824-115b823a692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce01ff8f-a037-484f-9148-c847ffaabc5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce01ff8f-a037-484f-9148-c847ffaabc5a.jpg?1",
             "name": "Lotho, Corrupt Shirriff",
             "text": "",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "fb4b8ca4-ba42-5534-89b2-3074d534ce31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e9a757-7ed4-4cc0-bb6f-a59fa69b32a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e9a757-7ed4-4cc0-bb6f-a59fa69b32a5.jpg?1",
             "name": "Mauh\u00far, Uruk-hai Captain",
             "text": "",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "0c710a11-2ebc-5af8-a3ee-c14f9a2fe853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5fe73-1684-4edc-9f9b-976b2246d5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c5fe73-1684-4edc-9f9b-976b2246d5ea.jpg?1",
             "name": "Merry, Esquire of Rohan",
             "text": "",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "46dbd044-1564-565f-bdcc-df602337b431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a88814-aa30-4297-b338-3d851bfe7256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a88814-aa30-4297-b338-3d851bfe7256.jpg?1",
             "name": "The Mouth of Sauron",
             "text": "",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "24c7a4f6-7955-52da-865b-22224297b3b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0362b7c4-fff5-4bc2-b32d-913f85c23cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0362b7c4-fff5-4bc2-b32d-913f85c23cc4.jpg?1",
             "name": "Old Man Willow",
             "text": "",
             "colours": [
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "5e3b012e-dfa5-5be4-9481-6e55c8345b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg?1",
             "name": "Pippin, Guard of the Citadel",
             "text": "",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "959f66ce-b87a-56cb-98da-e9bec5fd63f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d486def-7c3f-41e9-bb28-4582450a7b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d486def-7c3f-41e9-bb28-4582450a7b9e.jpg?1",
             "name": "Prince Imrahil the Fair",
             "text": "",
             "colours": [
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "dd1c0411-6333-54c3-94a1-f48bc5adce87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a65c-6f54-4d56-9c6f-8364c45a058c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a65c-6f54-4d56-9c6f-8364c45a058c.jpg?1",
             "name": "Ringsight",
             "text": "",
             "colours": [
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "21909cc1-0827-5704-81a8-a61a6caf417b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f440fa1-5387-41d6-a80f-5b19dbb21514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f440fa1-5387-41d6-a80f-5b19dbb21514.jpg?1",
             "name": "Rise of the Witch-king",
             "text": "",
             "colours": [
@@ -7875,7 +7875,7 @@
         },
         {
             "id": "9ab2a77a-e7fc-5e5c-ae40-d23ffe605089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b6f13e-63d0-46bf-aa57-23c2dbdf62dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b6f13e-63d0-46bf-aa57-23c2dbdf62dd.jpg?1",
             "name": "Samwise Gamgee",
             "text": "",
             "colours": [
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "7a3f0093-51cb-563e-8606-391f7d9222e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfcc7ec-87a2-4712-8d82-217bd8600891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfcc7ec-87a2-4712-8d82-217bd8600891.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -7961,7 +7961,7 @@
         },
         {
             "id": "090129f4-bf9c-5fb9-a592-288f1ed0c486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0929-b2c7-4b5f-94f2-8eaf4fb1a2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034e0929-b2c7-4b5f-94f2-8eaf4fb1a2a1.jpg?1",
             "name": "Sauron, the Dark Lord",
             "text": "",
             "colours": [
@@ -8004,7 +8004,7 @@
         },
         {
             "id": "56a37820-f546-5796-b5d5-eede345852fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b98850c-ad69-42da-b91a-8dc5e226c444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b98850c-ad69-42da-b91a-8dc5e226c444.jpg?1",
             "name": "Sauron's Ransom",
             "text": "",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "faf4bf7c-6195-5285-9b8a-b51f6deb7bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0984b2-bed6-41b1-9087-2cfd16749037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0984b2-bed6-41b1-9087-2cfd16749037.jpg?1",
             "name": "Shadow Summoning",
             "text": "",
             "colours": [
@@ -8074,7 +8074,7 @@
         },
         {
             "id": "092e1a40-7baf-5117-9135-da4fa23dd4df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d861d-7832-4c15-8d6c-8c07a9a57891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d861d-7832-4c15-8d6c-8c07a9a57891.jpg?1",
             "name": "Shadowfax, Lord of Horses",
             "text": "",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "28b2ace9-8e4f-574d-9f7b-ecee026085c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0731f64a-15da-4814-82e9-3a42e1657f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0731f64a-15da-4814-82e9-3a42e1657f36.jpg?1",
             "name": "Shagrat, Loot Bearer",
             "text": "",
             "colours": [
@@ -8153,7 +8153,7 @@
         },
         {
             "id": "b803bff5-785f-5bd8-9648-4b0659bd982e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e446bd-8295-4fca-957a-e4710a15d8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e446bd-8295-4fca-957a-e4710a15d8e8.jpg?1",
             "name": "Sharkey, Tyrant of the Shire",
             "text": "",
             "colours": [
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "4cc7aaf3-99c2-5eac-92d3-ff87fed3baa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c4b29-3363-45ce-9190-0f79e1a0ef7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14c4b29-3363-45ce-9190-0f79e1a0ef7f.jpg?1",
             "name": "Shelob, Child of Ungoliant",
             "text": "",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "0c0b7035-e342-5cc5-9617-1e20852a12a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13253f8d-1897-41e8-a904-9e57ac7eff0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13253f8d-1897-41e8-a904-9e57ac7eff0a.jpg?1",
             "name": "Sm\u00e9agol, Helpful Guide",
             "text": "",
             "colours": [
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "2ebdaac2-6699-5cc3-9a54-e9bee7a05576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54461d61-a745-467f-9fbe-b5e7a8edbdbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54461d61-a745-467f-9fbe-b5e7a8edbdbf.jpg?1",
             "name": "Strider, Ranger of the North",
             "text": "",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "8c9345d9-7983-5534-a1f9-aa99be3d4f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcd1ca-4943-46e4-bb5d-c14949e21e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6dcd1ca-4943-46e4-bb5d-c14949e21e23.jpg?1",
             "name": "Th\u00e9oden, King of Rohan",
             "text": "",
             "colours": [
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "824274bf-fd35-533f-824c-b51480baff76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab04c49-76a1-4896-8dca-8cb4c615f489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab04c49-76a1-4896-8dca-8cb4c615f489.jpg?1",
             "name": "Tom Bombadil",
             "text": "",
             "colours": [
@@ -8402,7 +8402,7 @@
         },
         {
             "id": "ea65d73c-b863-5c58-be73-5be7cd5ab1e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e914c7fc-be3c-4346-bf37-6e10f4998204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e914c7fc-be3c-4346-bf37-6e10f4998204.jpg?1",
             "name": "Ugl\u00fak of the White Hand",
             "text": "",
             "colours": [
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "548d68d4-152f-5994-bb8c-2287aba8637c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7b9eea-a224-4db1-a089-cb385f7af20c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7b9eea-a224-4db1-a089-cb385f7af20c.jpg?1",
             "name": "And\u00faril, Flame of the West",
             "text": "",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "f955c7de-4395-582c-b8a3-76d963b19f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb7284-78a5-4b5e-8f6d-6be540e0bef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0eb7284-78a5-4b5e-8f6d-6be540e0bef8.jpg?1",
             "name": "Barrow-Blade",
             "text": "",
             "colours": [],
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "56b1f40a-a555-5c90-9720-27e091df4fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1500126f-fbe4-4c39-bb06-1a36e2c4682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1500126f-fbe4-4c39-bb06-1a36e2c4682f.jpg?1",
             "name": "Ent-Draught Basin",
             "text": "",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "b817eb9d-48e7-5b63-bf2d-438469e3eb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296ebf7-45ed-4b38-acf2-b48d9fb3e706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296ebf7-45ed-4b38-acf2-b48d9fb3e706.jpg?1",
             "name": "Glamdring",
             "text": "",
             "colours": [],
@@ -8568,7 +8568,7 @@
         },
         {
             "id": "f31869fb-59b9-5b3a-a6c3-0a02f4d41ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14eaeec-d7ce-462a-90d3-2ae5ff605fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14eaeec-d7ce-462a-90d3-2ae5ff605fdb.jpg?1",
             "name": "Horn of Gondor",
             "text": "",
             "colours": [],
@@ -8600,7 +8600,7 @@
         },
         {
             "id": "ca77a15a-f7f5-5c2c-b86f-873219c6400c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd86b71f-d736-426f-bf15-013bc8da1a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd86b71f-d736-426f-bf15-013bc8da1a08.jpg?1",
             "name": "Horn of the Mark",
             "text": "",
             "colours": [],
@@ -8632,7 +8632,7 @@
         },
         {
             "id": "680df12c-678d-5ee8-857f-99e923a363ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b590d028-ea6a-4550-b5e2-ba328a81bbc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b590d028-ea6a-4550-b5e2-ba328a81bbc0.jpg?1",
             "name": "Inherited Envelope",
             "text": "",
             "colours": [],
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "c1765f91-dfe1-5ca5-915d-5288bac252d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b46aacf-b31a-4380-9e4b-82795fbaba3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b46aacf-b31a-4380-9e4b-82795fbaba3b.jpg?1",
             "name": "Lembas",
             "text": "",
             "colours": [],
@@ -8690,7 +8690,7 @@
         },
         {
             "id": "09abd31e-00fa-57e1-b930-dd8b8a176bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95036f-98f2-4ea7-93bb-542ad7064540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95036f-98f2-4ea7-93bb-542ad7064540.jpg?1",
             "name": "Mirror of Galadriel",
             "text": "",
             "colours": [],
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "aba95144-6c94-5ed0-ab52-6861bea46fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd1fc09-a09d-45e6-8a07-3a8a83b4e6ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd1fc09-a09d-45e6-8a07-3a8a83b4e6ec.jpg?1",
             "name": "Mithril Coat",
             "text": "",
             "colours": [],
@@ -8754,7 +8754,7 @@
         },
         {
             "id": "78a27b2c-c2ae-5e62-a5a1-af239e8b4c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5806e68-1054-458e-866d-1f2470f682b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5806e68-1054-458e-866d-1f2470f682b2.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "9b7b3c79-5b36-588b-989b-08449c1be334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb6a69-562c-4d95-858d-b067444cfd7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb6a69-562c-4d95-858d-b067444cfd7e.jpg?1",
             "name": "Palant\u00edr of Orthanc",
             "text": "",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "43a67d67-3bb9-547d-9280-84c735d5010d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d60fe-681b-495e-813c-c8418f3f29e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6d60fe-681b-495e-813c-c8418f3f29e5.jpg?1",
             "name": "Phial of Galadriel",
             "text": "",
             "colours": [],
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "661e5b7a-5787-54e3-a3fd-433ae6c94ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60b4f2e-ff47-4762-a803-30e81b665c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60b4f2e-ff47-4762-a803-30e81b665c09.jpg?1",
             "name": "Shire Scarecrow",
             "text": "",
             "colours": [],
@@ -8883,7 +8883,7 @@
         },
         {
             "id": "39ab81ef-0c7a-59d9-9df4-e7073a97e159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbec7e7-f5b9-407e-bf96-2e088710e791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbec7e7-f5b9-407e-bf96-2e088710e791.jpg?1",
             "name": "Sting, the Glinting Dagger",
             "text": "",
             "colours": [],
@@ -8917,7 +8917,7 @@
         },
         {
             "id": "8bb09cbb-443d-5422-90b4-b1a939fa71a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc02e193-df33-4eb1-adc1-b51ee931218a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc02e193-df33-4eb1-adc1-b51ee931218a.jpg?1",
             "name": "Stone of Erech",
             "text": "",
             "colours": [],
@@ -8947,7 +8947,7 @@
         },
         {
             "id": "d796f25b-eeda-534a-9c93-e2c8ed509968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ed742-dfb1-41e2-8f19-184555109e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ed742-dfb1-41e2-8f19-184555109e34.jpg?1",
             "name": "Wizard's Rockets",
             "text": "",
             "colours": [],
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "aed39ba4-ac8d-5640-9661-c18502c1a4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5038af-06b0-401e-8dea-a1a8483788ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5038af-06b0-401e-8dea-a1a8483788ae.jpg?1",
             "name": "Barad-d\u00fbr",
             "text": "",
             "colours": [],
@@ -9012,7 +9012,7 @@
         },
         {
             "id": "647201cf-d6dc-5d6c-9348-e5350bd2c697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c7b57-b62b-42d1-85d9-4b57624a3f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219c7b57-b62b-42d1-85d9-4b57624a3f54.jpg?1",
             "name": "Great Hall of the Citadel",
             "text": "",
             "colours": [],
@@ -9040,7 +9040,7 @@
         },
         {
             "id": "8465e7ef-4a81-5e9b-815b-a8db94214774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd698f10-b0fc-42fc-84ec-f5a0d96bfa1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd698f10-b0fc-42fc-84ec-f5a0d96bfa1d.jpg?1",
             "name": "The Grey Havens",
             "text": "",
             "colours": [],
@@ -9072,7 +9072,7 @@
         },
         {
             "id": "6cf7db9d-778e-5b35-9653-5870c438a98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38b6760-616f-4b11-8ce7-ac1223c7fd53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38b6760-616f-4b11-8ce7-ac1223c7fd53.jpg?1",
             "name": "Minas Tirith",
             "text": "",
             "colours": [],
@@ -9107,7 +9107,7 @@
         },
         {
             "id": "0e0ce59d-4a6b-5c04-968e-a9fa7fde6119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723d6-4ada-4c3f-b87b-8ab83a4bbb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723d6-4ada-4c3f-b87b-8ab83a4bbb8f.jpg?1",
             "name": "Mines of Moria",
             "text": "",
             "colours": [],
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "dcc21aef-945e-5532-9efd-a7e7fd86932b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg?1",
             "name": "Mount Doom",
             "text": "",
             "colours": [],
@@ -9177,7 +9177,7 @@
         },
         {
             "id": "dbab4b26-fa75-544a-8124-6f2eaba4186d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacd500c-1389-4314-a53e-0ad510d6fb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacd500c-1389-4314-a53e-0ad510d6fb79.jpg?1",
             "name": "Rivendell",
             "text": "",
             "colours": [],
@@ -9211,7 +9211,7 @@
         },
         {
             "id": "f8aa140c-16cc-5f05-af64-313e5afad680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5178a1b-588b-4414-a370-ac6eed51187a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5178a1b-588b-4414-a370-ac6eed51187a.jpg?1",
             "name": "The Shire",
             "text": "",
             "colours": [],
@@ -9245,7 +9245,7 @@
         },
         {
             "id": "cb082690-5abc-50a0-83df-c95de4462a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25932483-58cd-4ae5-82bf-ab455177d117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25932483-58cd-4ae5-82bf-ab455177d117.jpg?1",
             "name": "Shire Terrace",
             "text": "",
             "colours": [],
@@ -9273,7 +9273,7 @@
         },
         {
             "id": "19879902-f0c5-53aa-b4c1-e7893804102b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f724ae86-b968-4f49-8267-c2c34c22f1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f724ae86-b968-4f49-8267-c2c34c22f1b6.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9311,7 +9311,7 @@
         },
         {
             "id": "5323a02e-4b51-5846-b965-b738e1bfd1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb495cc-9908-455e-bec9-3993d595f4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb495cc-9908-455e-bec9-3993d595f4f9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9349,7 +9349,7 @@
         },
         {
             "id": "58915ced-ae13-5ffa-9034-73c7ffeab8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeca27a-6c5b-40b9-83a4-a3a2096ff6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbeca27a-6c5b-40b9-83a4-a3a2096ff6f8.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "5a126d7d-7224-5ffd-b748-127fe7ba6143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671516eb-b088-4a15-aec9-1781ca016e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671516eb-b088-4a15-aec9-1781ca016e11.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "22d9a3af-9586-5a7b-ac8a-8f445666d5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0fba6e-54d2-498c-83bc-41024307e608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0fba6e-54d2-498c-83bc-41024307e608.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9463,7 +9463,7 @@
         },
         {
             "id": "dd5b7377-ab8d-525a-9ba1-905e7557340f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86cd8fb-4ba7-4311-b0f3-b06fa112eda5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86cd8fb-4ba7-4311-b0f3-b06fa112eda5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9501,7 +9501,7 @@
         },
         {
             "id": "de2b1817-4044-5900-897f-dc6be40a23ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3731001-4e6a-4a91-9e7d-fc2ea039a60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3731001-4e6a-4a91-9e7d-fc2ea039a60b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "d47fcdea-cd66-508b-a78b-c4ac424fe1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf13285-d127-4534-9f49-aa86914da175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf13285-d127-4534-9f49-aa86914da175.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9577,7 +9577,7 @@
         },
         {
             "id": "dbe1201b-4cd7-5169-9a5e-c2c0d79fc5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe793e4-c034-4a22-929d-d743c0255bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe793e4-c034-4a22-929d-d743c0255bf1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9615,7 +9615,7 @@
         },
         {
             "id": "71e17af3-ed2c-5b7e-b556-ce1a5c500b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07264de1-4322-4adb-8f08-c0aa236747c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07264de1-4322-4adb-8f08-c0aa236747c7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9653,7 +9653,7 @@
         },
         {
             "id": "47bc6508-fbe0-5da8-906d-a24856d9aa56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9fbf5-de6f-4ef9-a6ab-56da4b341b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9fbf5-de6f-4ef9-a6ab-56da4b341b77.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9691,7 +9691,7 @@
         },
         {
             "id": "0dbc5f13-d6d0-5d84-bf3a-4758ccb1bc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8538a97f-302d-468a-8a6c-50c800d614e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8538a97f-302d-468a-8a6c-50c800d614e5.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "fd4ad7c0-5271-5da6-8b87-a9b6c8fc8ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0c7c5-ed63-41a5-93e1-a979a6f983b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba0c7c5-ed63-41a5-93e1-a979a6f983b9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9767,7 +9767,7 @@
         },
         {
             "id": "dfc1cadb-f399-5273-a613-f2eda5a44e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee8302-39ca-43c3-b139-62e591559306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee8302-39ca-43c3-b139-62e591559306.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9805,7 +9805,7 @@
         },
         {
             "id": "17efcc65-d71d-5928-8e8d-84a17c792204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f68bc-1842-4efd-b85a-d897cfd63bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f68bc-1842-4efd-b85a-d897cfd63bde.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9843,7 +9843,7 @@
         },
         {
             "id": "515d91ec-654c-5d4f-8316-e28c6b260418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d412d727-4fe8-4c21-a2cb-609395935dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d412d727-4fe8-4c21-a2cb-609395935dd8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "8dfaa766-5d3c-50ab-9074-f46622ccf1c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1902b98-7579-4b7a-8cb8-9bd0e0da5f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1902b98-7579-4b7a-8cb8-9bd0e0da5f67.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "58dbbe79-4466-51d1-a296-be45b544a036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1b83d9-078b-44dc-a118-4659201f4854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1b83d9-078b-44dc-a118-4659201f4854.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9957,7 +9957,7 @@
         },
         {
             "id": "4d7c9fb7-7502-5842-8070-8a8f989e129e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b488e-d725-4ef7-90f4-71091325c0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b488e-d725-4ef7-90f4-71091325c0b6.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "c03c4c6f-a319-5f74-a542-a5f462fc4f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efeaa30-9db9-4e68-a658-9064d6e67516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efeaa30-9db9-4e68-a658-9064d6e67516.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "c7df7048-2e3a-5192-9d25-4a834ee1f04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65a1fb5-cc2c-4556-b109-05c3d966ded9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65a1fb5-cc2c-4556-b109-05c3d966ded9.jpg?1",
             "name": "Saradoc, Master of Buckland",
             "text": "",
             "colours": [
@@ -10071,7 +10071,7 @@
         },
         {
             "id": "fb85173e-e30c-5b5d-8b0e-b18ab219e9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604d357-4196-421f-a5c3-c7cbe79f35cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7604d357-4196-421f-a5c3-c7cbe79f35cb.jpg?1",
             "name": "Elvish Mariner",
             "text": "",
             "colours": [
@@ -10107,7 +10107,7 @@
         },
         {
             "id": "4a162e51-288f-5284-a2b3-46ef677bc05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8495c3-96cf-40ab-b68a-1b5711b7659e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8495c3-96cf-40ab-b68a-1b5711b7659e.jpg?1",
             "name": "Ringwraiths",
             "text": "",
             "colours": [
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "3705f3e4-3899-5a6c-90e6-e81eb7068da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2549b70a-6bd0-4c9b-96b7-4ab775a30cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2549b70a-6bd0-4c9b-96b7-4ab775a30cd3.jpg?1",
             "name": "Assault on Osgiliath",
             "text": "",
             "colours": [
@@ -10176,7 +10176,7 @@
         },
         {
             "id": "15daffdb-78f2-58f3-bde9-0bb60d777c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165eb73-49a8-4337-aa5d-7d9d48b916c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165eb73-49a8-4337-aa5d-7d9d48b916c9.jpg?1",
             "name": "Elanor Gardner",
             "text": "",
             "colours": [
@@ -10214,7 +10214,7 @@
         },
         {
             "id": "66208885-03b9-5005-85a9-00bcc3ef3515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d4c97a-9319-4534-9a49-da000f41a02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d4c97a-9319-4534-9a49-da000f41a02d.jpg?1",
             "name": "Aragorn and Arwen, Wed",
             "text": "",
             "colours": [
@@ -10255,7 +10255,7 @@
         },
         {
             "id": "f7ecd2d6-6234-5a19-a49c-50f88cf7add3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82a4c78-d2fc-425a-8d0e-2e64509a08f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82a4c78-d2fc-425a-8d0e-2e64509a08f1.jpg?1",
             "name": "Sauron, the Lidless Eye",
             "text": "",
             "colours": [
@@ -10295,7 +10295,7 @@
         },
         {
             "id": "21d22fde-eb11-57a5-b00c-b5eb6f7bdcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d1b37c-a8c6-4690-8701-3395397711e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d1b37c-a8c6-4690-8701-3395397711e7.jpg?1",
             "name": "Frodo, Determined Hero",
             "text": "",
             "colours": [
@@ -10333,7 +10333,7 @@
         },
         {
             "id": "0c4cb33e-70f6-5878-8856-e29ffb2f0330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b422ce26-06fb-4748-9c01-32c4be914a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b422ce26-06fb-4748-9c01-32c4be914a77.jpg?1",
             "name": "Gandalf, White Rider",
             "text": "",
             "colours": [
@@ -10371,7 +10371,7 @@
         },
         {
             "id": "1176361c-4666-5c18-aaab-6948c3612fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af21576-3793-4796-ab60-112fbbb5fc0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af21576-3793-4796-ab60-112fbbb5fc0d.jpg?1",
             "name": "Knight of the Keep",
             "text": "",
             "colours": [
@@ -10405,7 +10405,7 @@
         },
         {
             "id": "be70f91b-088e-560f-8cd6-4189b7e6670d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg?1",
             "name": "Gollum, Scheming Guide",
             "text": "",
             "colours": [
@@ -10443,7 +10443,7 @@
         },
         {
             "id": "4efce628-10be-5529-8301-6d3d99a9ab72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da1d3e-dbcb-4b1e-a606-d4fc1a60a8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90da1d3e-dbcb-4b1e-a606-d4fc1a60a8fe.jpg?1",
             "name": "Witch-king, Bringer of Ruin",
             "text": "",
             "colours": [
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "5088fbe4-c82a-5bec-8962-6d014f8d46c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg?1",
             "name": "Fires of Mount Doom",
             "text": "",
             "colours": [
@@ -10516,7 +10516,7 @@
         },
         {
             "id": "9e84037f-9baf-53c7-b31e-43706b823828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bda198-7ab4-4c6b-9fb1-93ac54c06a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bda198-7ab4-4c6b-9fb1-93ac54c06a85.jpg?1",
             "name": "Goblin Assailant",
             "text": "",
             "colours": [
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "ca74febf-c641-592e-adad-af09d8a7e21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8229264e-af6c-4f1f-b86a-257889ace9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8229264e-af6c-4f1f-b86a-257889ace9ce.jpg?1",
             "name": "Galadriel, Gift-Giver",
             "text": "",
             "colours": [
@@ -10588,7 +10588,7 @@
         },
         {
             "id": "eb3cb717-1584-521a-9d6b-f702add80323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905e7424-2d0b-4877-a7dc-272ea9392ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905e7424-2d0b-4877-a7dc-272ea9392ff0.jpg?1",
             "name": "The Balrog, Flame of Ud\u00fbn",
             "text": "",
             "colours": [
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "15df7bd2-82f4-5ba4-9e08-a16296f92f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91dbeac4-1c39-4a4f-84e7-1b71f7468c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91dbeac4-1c39-4a4f-84e7-1b71f7468c8f.jpg?1",
             "name": "Bilbo's Ring",
             "text": "",
             "colours": [],
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "2f4bd8b0-a5b0-543d-b139-c6ad4621fbae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae4a761-6203-419c-8d49-499b6e74252c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae4a761-6203-419c-8d49-499b6e74252c.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -10702,7 +10702,7 @@
         },
         {
             "id": "d1dddf8e-94bc-5890-80d4-fe061e42bc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853e4841-7e2f-4f0c-8f4f-cbfac22c298c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853e4841-7e2f-4f0c-8f4f-cbfac22c298c.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "1acdf41c-5157-5476-bd33-2adcb454dd08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e186ef93-f369-4b4d-a683-36f338b6ce3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e186ef93-f369-4b4d-a683-36f338b6ce3f.jpg?1",
             "name": "Boromir, Warden of the Tower",
             "text": "",
             "colours": [
@@ -10786,7 +10786,7 @@
         },
         {
             "id": "733a458c-6a15-5e1a-81b2-219dd7e3d789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008b953a-da2b-4c30-9424-6d6e3e938251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008b953a-da2b-4c30-9424-6d6e3e938251.jpg?1",
             "name": "Faramir, Field Commander",
             "text": "",
             "colours": [
@@ -10825,7 +10825,7 @@
         },
         {
             "id": "f613f7cc-5533-5004-9334-5bbd09ba6a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d08e637-c2b3-4b38-9b07-5bba1f13efc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d08e637-c2b3-4b38-9b07-5bba1f13efc3.jpg?1",
             "name": "Frodo, Sauron's Bane",
             "text": "",
             "colours": [
@@ -10866,7 +10866,7 @@
         },
         {
             "id": "7869ca48-3ef0-5dad-ab8e-9ef2bd9d5c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9dc67a-5c26-4044-82b6-d5b6e195ae64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9dc67a-5c26-4044-82b6-d5b6e195ae64.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "e319f976-55ab-5e73-b885-a4711ff72454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c6a273-9307-432a-96f5-3e536da70f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c6a273-9307-432a-96f5-3e536da70f95.jpg?1",
             "name": "Samwise the Stouthearted",
             "text": "",
             "colours": [
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "56707047-134f-588a-96b0-6a93f8769e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308465a9-2143-49f2-b9d0-a09272dd1b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308465a9-2143-49f2-b9d0-a09272dd1b62.jpg?1",
             "name": "Elrond, Lord of Rivendell",
             "text": "",
             "colours": [
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "404aad16-523a-54a7-baff-fb7f56e667ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae80537-f355-4aa3-8952-b08f3d1a1e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae80537-f355-4aa3-8952-b08f3d1a1e41.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -11026,7 +11026,7 @@
         },
         {
             "id": "e7dd0108-465e-5474-b142-d91f04f66c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a881aa61-fc7c-4ffb-a129-f75be8b2e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a881aa61-fc7c-4ffb-a129-f75be8b2e498.jpg?1",
             "name": "Gollum, Patient Plotter",
             "text": "",
             "colours": [
@@ -11066,7 +11066,7 @@
         },
         {
             "id": "fc5a68c5-434e-506d-b5f0-6f54e6c25743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24521350-ffa6-46d9-95ed-6573c681e095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24521350-ffa6-46d9-95ed-6573c681e095.jpg?1",
             "name": "Sauron, the Necromancer",
             "text": "",
             "colours": [
@@ -11105,7 +11105,7 @@
         },
         {
             "id": "36517477-0505-5bd2-aa0f-cdad330c9111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944f01f2-b736-42ff-a871-6b6e726b231b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944f01f2-b736-42ff-a871-6b6e726b231b.jpg?1",
             "name": "Witch-king of Angmar",
             "text": "",
             "colours": [
@@ -11145,7 +11145,7 @@
         },
         {
             "id": "af01c812-a07e-5d12-85ce-04c988f2e594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72c5bd1-cca1-4735-b4fc-7a5182fb8cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72c5bd1-cca1-4735-b4fc-7a5182fb8cd6.jpg?1",
             "name": "Gimli, Counter of Kills",
             "text": "",
             "colours": [
@@ -11184,7 +11184,7 @@
         },
         {
             "id": "07c3bcaa-ef5b-55a2-bc72-1cbdd5425c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84cea85e-dfcc-438e-8b24-4b2e251b86dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84cea85e-dfcc-438e-8b24-4b2e251b86dc.jpg?1",
             "name": "Legolas, Master Archer",
             "text": "",
             "colours": [
@@ -11224,7 +11224,7 @@
         },
         {
             "id": "9652865c-7249-5619-a11c-7ec1d9ad8368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7cea33-4d46-450a-a54e-b8d70910eee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7cea33-4d46-450a-a54e-b8d70910eee8.jpg?1",
             "name": "Meriadoc Brandybuck",
             "text": "",
             "colours": [
@@ -11263,7 +11263,7 @@
         },
         {
             "id": "a59bca1d-9b5a-5447-a251-89be7f89edd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbdd288-83ec-4be9-b55f-17771fd5ecc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbdd288-83ec-4be9-b55f-17771fd5ecc4.jpg?1",
             "name": "Peregrin Took",
             "text": "",
             "colours": [
@@ -11302,7 +11302,7 @@
         },
         {
             "id": "07dc1dd3-e8a2-530f-9b6e-d1df96be4adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c3004-fe39-4ca3-bf14-f4af8b20fa80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c3004-fe39-4ca3-bf14-f4af8b20fa80.jpg?1",
             "name": "Aragorn, Company Leader",
             "text": "",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "affe7fa7-9d4a-58b6-b4f0-341c97681cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e287844c-a829-4f7f-8c4c-ab856e6815f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e287844c-a829-4f7f-8c4c-ab856e6815f6.jpg?1",
             "name": "Aragorn, the Uniter",
             "text": "",
             "colours": [
@@ -11390,7 +11390,7 @@
         },
         {
             "id": "3568f7c8-5f35-5a5c-900a-3beeb6f3c850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476e2a30-4410-432d-9c8a-beaaa40220c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476e2a30-4410-432d-9c8a-beaaa40220c1.jpg?1",
             "name": "Elrond, Master of Healing",
             "text": "",
             "colours": [
@@ -11432,7 +11432,7 @@
         },
         {
             "id": "8402dbd1-837f-5cf9-bdf0-4c4081534b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf5eee-c378-4ddf-a172-c0a703757fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf5eee-c378-4ddf-a172-c0a703757fff.jpg?1",
             "name": "Faramir, Prince of Ithilien",
             "text": "",
             "colours": [
@@ -11473,7 +11473,7 @@
         },
         {
             "id": "e43a1abb-6811-582f-b7ee-fa439faeca1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a266c-b2e9-4981-93ef-843cea95ca76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741a266c-b2e9-4981-93ef-843cea95ca76.jpg?1",
             "name": "Frodo Baggins",
             "text": "",
             "colours": [
@@ -11515,7 +11515,7 @@
         },
         {
             "id": "b48b9bf4-f91e-5f59-aab1-01d53b36c8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a971745b-5d5c-46bb-95ca-329b6ee7ed75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a971745b-5d5c-46bb-95ca-329b6ee7ed75.jpg?1",
             "name": "Galadriel of Lothl\u00f3rien",
             "text": "",
             "colours": [
@@ -11557,7 +11557,7 @@
         },
         {
             "id": "438d5de3-9c0f-5cd5-8fe8-54da21b031b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ff7dea-1ed2-4987-b42a-6d1d8c493f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ff7dea-1ed2-4987-b42a-6d1d8c493f5a.jpg?1",
             "name": "Gandalf the Grey",
             "text": "",
             "colours": [
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "5db7e47f-c04f-5304-bdea-6f123af26d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72778dc1-0d93-4ba8-a194-51df78d4beba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72778dc1-0d93-4ba8-a194-51df78d4beba.jpg?1",
             "name": "Gimli, Mournful Avenger",
             "text": "",
             "colours": [
@@ -11640,7 +11640,7 @@
         },
         {
             "id": "b72b1169-3d58-53e9-a3ef-5d5c8ee70a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe0cb4-71f0-4acb-af1a-a48775826487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe0cb4-71f0-4acb-af1a-a48775826487.jpg?1",
             "name": "Legolas, Counter of Kills",
             "text": "",
             "colours": [
@@ -11681,7 +11681,7 @@
         },
         {
             "id": "378586ba-6a2f-5f77-a479-1506055acc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d21bce-a381-4c5d-9e0f-b2cdc96a20b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d21bce-a381-4c5d-9e0f-b2cdc96a20b6.jpg?1",
             "name": "Merry, Esquire of Rohan",
             "text": "",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "00920b73-8588-5362-9491-0ff41bf0a241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25630509-c9ba-4faf-b154-32be8649d9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25630509-c9ba-4faf-b154-32be8649d9fa.jpg?1",
             "name": "Pippin, Guard of the Citadel",
             "text": "",
             "colours": [
@@ -11765,7 +11765,7 @@
         },
         {
             "id": "9fad50ed-5770-5f18-b957-c9017254b513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ecb73-2720-4c1c-8f67-78983f16e584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3ecb73-2720-4c1c-8f67-78983f16e584.jpg?1",
             "name": "Samwise Gamgee",
             "text": "",
             "colours": [
@@ -11806,7 +11806,7 @@
         },
         {
             "id": "883feeee-5c07-5146-8add-883485f3ff3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018238ae-b740-4185-8747-b68f6d1e7989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018238ae-b740-4185-8747-b68f6d1e7989.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -11851,7 +11851,7 @@
         },
         {
             "id": "e997918a-1829-59c8-a35d-6472d8d98b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83261ba-c239-4b6a-88eb-bdfc411916b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83261ba-c239-4b6a-88eb-bdfc411916b3.jpg?1",
             "name": "Sauron, the Dark Lord",
             "text": "",
             "colours": [
@@ -11894,7 +11894,7 @@
         },
         {
             "id": "ae03d20f-c0fd-564e-9d87-3d95440367f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ebf3a3-3dd1-48e0-ad84-c3295de2e032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ebf3a3-3dd1-48e0-ad84-c3295de2e032.jpg?1",
             "name": "Sm\u00e9agol, Helpful Guide",
             "text": "",
             "colours": [
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "15f1c7ab-4cd1-56bc-ab09-593fff6d821b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ce623-bcf8-4d42-8a88-450bea7d7529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ce623-bcf8-4d42-8a88-450bea7d7529.jpg?1",
             "name": "Tom Bombadil",
             "text": "",
             "colours": [
@@ -11982,7 +11982,7 @@
         },
         {
             "id": "236de2ae-b43c-51a2-bba1-b5ec76335b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65226a-12cd-416a-bb60-12e9b35f609b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce65226a-12cd-416a-bb60-12e9b35f609b.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12026,7 +12026,7 @@
         },
         {
             "id": "efbc5975-04b1-5c32-a07f-0f3757e2985b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b32f90-b32f-41a6-af0c-1c967ec49b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b32f90-b32f-41a6-af0c-1c967ec49b73.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12070,7 +12070,7 @@
         },
         {
             "id": "b7176c76-1079-5d73-8137-d2211affa5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9c9901-c329-4a68-96ab-f33d7c12aefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9c9901-c329-4a68-96ab-f33d7c12aefe.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12114,7 +12114,7 @@
         },
         {
             "id": "20b42ebf-64dd-56e4-9b65-f22c3f513b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16e3fe-cc9f-414e-8643-3f66c0ab2536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16e3fe-cc9f-414e-8643-3f66c0ab2536.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12158,7 +12158,7 @@
         },
         {
             "id": "77692ee1-fa24-5db8-8651-97c29fa2146f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92d5a03-a4c9-4432-b3bb-f5bb21f65db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a92d5a03-a4c9-4432-b3bb-f5bb21f65db0.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12202,7 +12202,7 @@
         },
         {
             "id": "73b1bcfe-e9a9-5b75-920e-42472e8b3047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a5630d-325f-4f7a-9885-b249c6480023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a5630d-325f-4f7a-9885-b249c6480023.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12246,7 +12246,7 @@
         },
         {
             "id": "8f93542f-670f-5707-8432-3d31f0defe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf96c268-c86b-4d5e-bf04-200c427e5fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf96c268-c86b-4d5e-bf04-200c427e5fa5.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12290,7 +12290,7 @@
         },
         {
             "id": "354190b4-0cd5-5093-8134-c2ef297eb1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4023a6de-3ac7-488a-b1a9-b1e26681d9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4023a6de-3ac7-488a-b1a9-b1e26681d9bc.jpg?1",
             "name": "Nazg\u00fbl",
             "text": "",
             "colours": [
@@ -12334,7 +12334,7 @@
         },
         {
             "id": "067fcb63-b786-5280-8505-8dada3c15378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b2b1ca-c05d-443a-af59-e608ffa251bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b2b1ca-c05d-443a-af59-e608ffa251bf.jpg?1",
             "name": "Barad-d\u00fbr",
             "text": "",
             "colours": [],
@@ -12369,7 +12369,7 @@
         },
         {
             "id": "013ab825-483e-5507-8d29-0fd2a58ef118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e8a91c-74ee-411b-9d74-4e72df24258b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e8a91c-74ee-411b-9d74-4e72df24258b.jpg?1",
             "name": "Minas Tirith",
             "text": "",
             "colours": [],
@@ -12404,7 +12404,7 @@
         },
         {
             "id": "836f4d60-2a69-5db3-bf4f-4b640a4b8e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6cbb58-8c82-49b5-ae9c-f3baaa8bcc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6cbb58-8c82-49b5-ae9c-f3baaa8bcc22.jpg?1",
             "name": "Mines of Moria",
             "text": "",
             "colours": [],
@@ -12439,7 +12439,7 @@
         },
         {
             "id": "d38c282b-e6fa-5b8a-bf5e-e7645e1c2d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a087f9-57c3-4743-b03b-7bfd2b86eefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a087f9-57c3-4743-b03b-7bfd2b86eefd.jpg?1",
             "name": "Mount Doom",
             "text": "",
             "colours": [],
@@ -12474,7 +12474,7 @@
         },
         {
             "id": "01edb97c-5a2d-5a55-ac33-a613bbe0bcec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650fa2f4-2916-427c-a0f9-37e2dbe8e1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650fa2f4-2916-427c-a0f9-37e2dbe8e1fc.jpg?1",
             "name": "Rivendell",
             "text": "",
             "colours": [],
@@ -12508,7 +12508,7 @@
         },
         {
             "id": "5a347f11-89a9-586b-813a-b51f07a531c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248ed7a6-982a-4ff4-ba9b-3c1f47e7605c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248ed7a6-982a-4ff4-ba9b-3c1f47e7605c.jpg?1",
             "name": "The Shire",
             "text": "",
             "colours": [],
@@ -12542,7 +12542,7 @@
         },
         {
             "id": "0ca56615-3ee3-5078-b7a9-5198f4b5f35a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c922a8-28b7-4831-8314-2ce41762955f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c922a8-28b7-4831-8314-2ce41762955f.jpg?1",
             "name": "The Battle of Bywater",
             "text": "",
             "colours": [
@@ -12575,7 +12575,7 @@
         },
         {
             "id": "e9f1d00f-23fb-56f6-96e5-2088ee012a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a867c49-1842-4207-99d7-655cade4d357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a867c49-1842-4207-99d7-655cade4d357.jpg?1",
             "name": "Dawn of a New Age",
             "text": "",
             "colours": [
@@ -12608,7 +12608,7 @@
         },
         {
             "id": "959085d7-6eee-51ca-afd1-e6a707550830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe33c8a-ae61-44d2-a996-d99bb2ce89e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe33c8a-ae61-44d2-a996-d99bb2ce89e6.jpg?1",
             "name": "Flowering of the White Tree",
             "text": "",
             "colours": [
@@ -12643,7 +12643,7 @@
         },
         {
             "id": "70bd5b28-bb7e-5647-8a08-7b5b65a4ed88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1bec-a90d-4d1b-8096-42a1455e86d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecc1bec-a90d-4d1b-8096-42a1455e86d2.jpg?1",
             "name": "Forge Anew",
             "text": "",
             "colours": [
@@ -12678,7 +12678,7 @@
         },
         {
             "id": "b144d912-05b3-5640-a17f-b3035be2438e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ebd6a8-2e93-40ee-951a-4fcf12c85e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ebd6a8-2e93-40ee-951a-4fcf12c85e3d.jpg?1",
             "name": "Borne Upon a Wind",
             "text": "",
             "colours": [
@@ -12711,7 +12711,7 @@
         },
         {
             "id": "500cc4b1-0f96-564a-b1f3-e2953aec7153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb2cce1-11b7-49ab-ba9c-1d95db26ca19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb2cce1-11b7-49ab-ba9c-1d95db26ca19.jpg?1",
             "name": "Goldberry, River-Daughter",
             "text": "",
             "colours": [
@@ -12748,7 +12748,7 @@
         },
         {
             "id": "2644765e-c539-59dc-b841-48b9e0f9b9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158662c6-04ee-4a79-9199-d0ba68c18650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158662c6-04ee-4a79-9199-d0ba68c18650.jpg?1",
             "name": "Press the Enemy",
             "text": "",
             "colours": [
@@ -12782,7 +12782,7 @@
         },
         {
             "id": "ef58cd93-8e85-5239-a5c8-46e328b72cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684c02e-ee8a-4d26-aa20-5620944bceeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2684c02e-ee8a-4d26-aa20-5620944bceeb.jpg?1",
             "name": "Rangers of Ithilien",
             "text": "",
             "colours": [
@@ -12820,7 +12820,7 @@
         },
         {
             "id": "0a1a255a-afbb-566b-ba30-37058620986b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47b68e6-6ad7-4773-a199-cd88c3d010b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47b68e6-6ad7-4773-a199-cd88c3d010b1.jpg?1",
             "name": "The Watcher in the Water",
             "text": "",
             "colours": [
@@ -12858,7 +12858,7 @@
         },
         {
             "id": "d8ccabc9-285c-5280-bee9-89c70ee2b682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ef1d06-7410-4dfb-8897-96aa29df9bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ef1d06-7410-4dfb-8897-96aa29df9bfd.jpg?1",
             "name": "Call of the Ring",
             "text": "",
             "colours": [
@@ -12892,7 +12892,7 @@
         },
         {
             "id": "29844906-c8be-58f9-9bb5-b7176399ca39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8eedbd-ba74-476f-97c4-ffee9fb66444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8eedbd-ba74-476f-97c4-ffee9fb66444.jpg?1",
             "name": "Isildur's Fateful Strike",
             "text": "",
             "colours": [
@@ -12928,7 +12928,7 @@
         },
         {
             "id": "53faba7f-17f4-596a-861e-62e3227f6cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c94c38-7ff7-4177-ba41-573b389301c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c94c38-7ff7-4177-ba41-573b389301c3.jpg?1",
             "name": "Lobelia Sackville-Baggins",
             "text": "",
             "colours": [
@@ -12967,7 +12967,7 @@
         },
         {
             "id": "de834bc2-ddba-5b65-8b95-520277306d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139e0697-12b7-40b4-a7c5-a296e0c1ed27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139e0697-12b7-40b4-a7c5-a296e0c1ed27.jpg?1",
             "name": "Display of Power",
             "text": "",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "3ab3381e-e6fd-5ba3-aee8-16a1a162f8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fdf85-ae3c-409d-a515-0051e25c116c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fdf85-ae3c-409d-a515-0051e25c116c.jpg?1",
             "name": "Fall of Cair Andros",
             "text": "",
             "colours": [
@@ -13035,7 +13035,7 @@
         },
         {
             "id": "8bd7ed28-6cfb-51c1-bbf8-f3fded0fdfa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74d1af-5cc6-422e-949c-de9e39b76154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74d1af-5cc6-422e-949c-de9e39b76154.jpg?1",
             "name": "Gl\u00f3in, Dwarf Emissary",
             "text": "",
             "colours": [
@@ -13073,7 +13073,7 @@
         },
         {
             "id": "87e92a14-3d24-5ef8-ae88-8d83f92e5bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0f4510-5f40-4733-8379-2526e4f1cc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0f4510-5f40-4733-8379-2526e4f1cc79.jpg?1",
             "name": "Hew the Entwood",
             "text": "",
             "colours": [
@@ -13106,7 +13106,7 @@
         },
         {
             "id": "5376ecd1-3e5d-58d3-bf53-82efaa3f58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e36249-02f5-4c11-9a2b-6be81eb6b490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e36249-02f5-4c11-9a2b-6be81eb6b490.jpg?1",
             "name": "Moria Marauder",
             "text": "",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "84492551-7c4a-5045-a7f5-adf58ce6e64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a04912-633d-4f67-b200-d55735438f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a04912-633d-4f67-b200-d55735438f76.jpg?1",
             "name": "Delighted Halfling",
             "text": "",
             "colours": [
@@ -13179,7 +13179,7 @@
         },
         {
             "id": "c7b6aea4-5f54-500d-90ad-ecccbc10e008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9523a73-6b62-48ee-9775-cf1f3b6babb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9523a73-6b62-48ee-9775-cf1f3b6babb3.jpg?1",
             "name": "Elven Chorus",
             "text": "",
             "colours": [
@@ -13212,7 +13212,7 @@
         },
         {
             "id": "378ec0c8-4348-59a2-aa4d-9a8b9eacd759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9684292b-804d-4019-a2f3-95c6ea6f97b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9684292b-804d-4019-a2f3-95c6ea6f97b7.jpg?1",
             "name": "Radagast the Brown",
             "text": "",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "eaae9675-24b3-50b9-b114-f40d833958cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ee6b2e-7e6d-4f8d-a75e-ff30722e08d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ee6b2e-7e6d-4f8d-a75e-ff30722e08d3.jpg?1",
             "name": "The Ring Goes South",
             "text": "",
             "colours": [
@@ -13284,7 +13284,7 @@
         },
         {
             "id": "4eefb7e7-b1e9-5790-9309-10185f8a25c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718ae3af-a365-4593-a44c-6684ef308d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718ae3af-a365-4593-a44c-6684ef308d4c.jpg?1",
             "name": "Arwen, Mortal Queen",
             "text": "",
             "colours": [
@@ -13325,7 +13325,7 @@
         },
         {
             "id": "a391990c-ec69-5086-993c-57718d60494e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e2fd90-95b0-4b12-846c-80bb979f0724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e2fd90-95b0-4b12-846c-80bb979f0724.jpg?1",
             "name": "Doors of Durin",
             "text": "",
             "colours": [
@@ -13363,7 +13363,7 @@
         },
         {
             "id": "1f540547-d016-580a-9876-60932ce7b8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4796aa-0aee-43c6-9c34-e4d66da776cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4796aa-0aee-43c6-9c34-e4d66da776cc.jpg?1",
             "name": "King of the Oathbreakers",
             "text": "",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "334e2023-1d62-54e8-8bfd-3bcdf62522c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d97af0-8af0-4124-b56f-2633d34e5574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d97af0-8af0-4124-b56f-2633d34e5574.jpg?1",
             "name": "Lotho, Corrupt Shirriff",
             "text": "",
             "colours": [
@@ -13446,7 +13446,7 @@
         },
         {
             "id": "27a2bac5-05f3-5b04-9ac6-0b214a1e46ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6d22a-8ccf-4e12-ab5c-5c5ba06809e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6d22a-8ccf-4e12-ab5c-5c5ba06809e5.jpg?1",
             "name": "Sauron's Ransom",
             "text": "",
             "colours": [
@@ -13482,7 +13482,7 @@
         },
         {
             "id": "73e63592-deed-5d10-bfda-f798c2ee0b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1922e391-54c3-4df5-a8b1-c7cd07598e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1922e391-54c3-4df5-a8b1-c7cd07598e08.jpg?1",
             "name": "Shagrat, Loot Bearer",
             "text": "",
             "colours": [
@@ -13522,7 +13522,7 @@
         },
         {
             "id": "4d2e92c9-7426-553e-aada-b293bcde38d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad2707-6805-4c10-a54e-c1cc63a7108f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ad2707-6805-4c10-a54e-c1cc63a7108f.jpg?1",
             "name": "Sharkey, Tyrant of the Shire",
             "text": "",
             "colours": [
@@ -13562,7 +13562,7 @@
         },
         {
             "id": "5f5504b6-5712-5d69-a43c-5c657b68185c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d427a8-a237-4053-b90d-0f1dd249e9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d427a8-a237-4053-b90d-0f1dd249e9c1.jpg?1",
             "name": "Shelob, Child of Ungoliant",
             "text": "",
             "colours": [
@@ -13604,7 +13604,7 @@
         },
         {
             "id": "fc39f008-95fa-5983-8a3b-f6c52716ee69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5236343-8035-477c-8221-b835d01b8a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5236343-8035-477c-8221-b835d01b8a8b.jpg?1",
             "name": "And\u00faril, Flame of the West",
             "text": "",
             "colours": [],
@@ -13638,7 +13638,7 @@
         },
         {
             "id": "c97069a1-5cff-557d-9005-1c4f3b484bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1128f94f-9980-4bb8-a5db-21a82ce9e680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1128f94f-9980-4bb8-a5db-21a82ce9e680.jpg?1",
             "name": "Glamdring",
             "text": "",
             "colours": [],
@@ -13672,7 +13672,7 @@
         },
         {
             "id": "5b42d559-4597-5574-8284-1adb878aa79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9ca30-c336-4977-91af-184ed98eea99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b9ca30-c336-4977-91af-184ed98eea99.jpg?1",
             "name": "Horn of Gondor",
             "text": "",
             "colours": [],
@@ -13704,7 +13704,7 @@
         },
         {
             "id": "f14f7e41-22c5-575e-b346-bcc2b60b6395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af151b54-3d90-4bb2-8cfa-36e7d865d227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af151b54-3d90-4bb2-8cfa-36e7d865d227.jpg?1",
             "name": "Horn of the Mark",
             "text": "",
             "colours": [],
@@ -13736,7 +13736,7 @@
         },
         {
             "id": "21b1da93-c40f-5d44-8932-e5db087a61bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65ec6ad-80d8-4c76-8b69-fc401a8f1ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65ec6ad-80d8-4c76-8b69-fc401a8f1ce8.jpg?1",
             "name": "Mithril Coat",
             "text": "",
             "colours": [],
@@ -13770,7 +13770,7 @@
         },
         {
             "id": "6398a529-ed1f-5c67-bb88-5a61f9ba07fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db80391f-1643-4b72-a397-d141bb5702ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db80391f-1643-4b72-a397-d141bb5702ee.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -13804,7 +13804,7 @@
         },
         {
             "id": "604470c5-cac5-5fdf-8fa6-bee364ae7278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c27c6ac-889f-4591-8789-4a6f1a264d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c27c6ac-889f-4591-8789-4a6f1a264d98.jpg?1",
             "name": "Palant\u00edr of Orthanc",
             "text": "",
             "colours": [],
@@ -13836,7 +13836,7 @@
         },
         {
             "id": "e97d0e93-e3a3-5efc-8eee-a74dfe80a421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d163a60b-c7ca-4d69-be6c-3a94c7f9a4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d163a60b-c7ca-4d69-be6c-3a94c7f9a4c7.jpg?1",
             "name": "Phial of Galadriel",
             "text": "",
             "colours": [],
@@ -13868,7 +13868,7 @@
         },
         {
             "id": "83a494b0-e949-5b7a-8e59-b5932375d710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf608ed2-f193-4bcc-99fc-a9cd0cf97993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf608ed2-f193-4bcc-99fc-a9cd0cf97993.jpg?1",
             "name": "Saradoc, Master of Buckland",
             "text": "",
             "colours": [
@@ -13906,7 +13906,7 @@
         },
         {
             "id": "5810213c-b332-5dfe-8104-1d69993061ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c05a4d9-37f9-42ac-8dca-b31480904b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c05a4d9-37f9-42ac-8dca-b31480904b51.jpg?1",
             "name": "Elvish Mariner",
             "text": "",
             "colours": [
@@ -13942,7 +13942,7 @@
         },
         {
             "id": "a82966cb-8783-5a28-b728-32d5768cd54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff818c30-0a50-4986-a236-ddaf41fddf12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff818c30-0a50-4986-a236-ddaf41fddf12.jpg?1",
             "name": "Ringwraiths",
             "text": "",
             "colours": [
@@ -13978,7 +13978,7 @@
         },
         {
             "id": "df263dba-74c5-56bf-9a39-2bb9887f6e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c07f3-5854-4243-b4ac-eed9a9711ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2c07f3-5854-4243-b4ac-eed9a9711ce9.jpg?1",
             "name": "Assault on Osgiliath",
             "text": "",
             "colours": [
@@ -14011,7 +14011,7 @@
         },
         {
             "id": "ae06b6fa-9c19-51fc-80b2-c693601ac24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b35ec3c-6da6-435d-b094-14a56cec58fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b35ec3c-6da6-435d-b094-14a56cec58fe.jpg?1",
             "name": "Elanor Gardner",
             "text": "",
             "colours": [
@@ -14049,7 +14049,7 @@
         },
         {
             "id": "63ab2030-3d6a-5f9d-beaa-493039906356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226694d7-ba9b-4e79-b45a-634769815e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226694d7-ba9b-4e79-b45a-634769815e74.jpg?1",
             "name": "Frodo, Determined Hero",
             "text": "",
             "colours": [
@@ -14087,7 +14087,7 @@
         },
         {
             "id": "ee928bc4-03d8-595d-a635-26bd0eaec945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187807bc-0058-49a1-9a67-01019c5440c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187807bc-0058-49a1-9a67-01019c5440c2.jpg?1",
             "name": "Gandalf, White Rider",
             "text": "",
             "colours": [
@@ -14125,7 +14125,7 @@
         },
         {
             "id": "84b2255d-a1d3-535c-a2f5-7d7b06975da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76aa1492-579f-4e36-8931-b2bf203e2d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76aa1492-579f-4e36-8931-b2bf203e2d76.jpg?1",
             "name": "Gollum, Scheming Guide",
             "text": "",
             "colours": [
@@ -14163,7 +14163,7 @@
         },
         {
             "id": "9e257d93-23e4-56d7-938a-28bc9790b444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0305f6-a0c6-4197-9aa6-789fa855cb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0305f6-a0c6-4197-9aa6-789fa855cb17.jpg?1",
             "name": "Witch-king, Bringer of Ruin",
             "text": "",
             "colours": [
@@ -14201,7 +14201,7 @@
         },
         {
             "id": "1e36df8b-ac5c-5561-9124-f7a36ab67308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d9aab-5673-4a6a-be86-13508b8929bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2d9aab-5673-4a6a-be86-13508b8929bd.jpg?1",
             "name": "Fires of Mount Doom",
             "text": "",
             "colours": [
@@ -14236,7 +14236,7 @@
         },
         {
             "id": "61e1231c-bb49-582e-8631-807f06f21d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbc8de9-6f74-468f-834c-46d10864e36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbc8de9-6f74-468f-834c-46d10864e36b.jpg?1",
             "name": "Galadriel, Gift-Giver",
             "text": "",
             "colours": [
@@ -14274,7 +14274,7 @@
         },
         {
             "id": "7b37991b-1dce-514b-b657-edb9fe3b5b3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31540016-1896-47f7-9c4d-f07598c75421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31540016-1896-47f7-9c4d-f07598c75421.jpg?1",
             "name": "Aragorn and Arwen, Wed",
             "text": "",
             "colours": [
@@ -14315,7 +14315,7 @@
         },
         {
             "id": "6c902346-27f2-5714-a76a-d85f07e9c7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c33afe-24fe-4aff-b30a-f4370815dfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c33afe-24fe-4aff-b30a-f4370815dfd6.jpg?1",
             "name": "The Balrog, Flame of Ud\u00fbn",
             "text": "",
             "colours": [
@@ -14355,7 +14355,7 @@
         },
         {
             "id": "dcf08870-2596-52a6-8b1d-f197e28ae8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b80de80-8b4e-46e2-9145-b9f3031d32d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b80de80-8b4e-46e2-9145-b9f3031d32d7.jpg?1",
             "name": "Sauron, the Lidless Eye",
             "text": "",
             "colours": [
@@ -14395,7 +14395,7 @@
         },
         {
             "id": "7042e93e-cf30-5de1-be1b-af603df94c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2bc8e-79cf-471e-8d9f-0e34703f1808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a2bc8e-79cf-471e-8d9f-0e34703f1808.jpg?1",
             "name": "Bilbo's Ring",
             "text": "",
             "colours": [],
@@ -14428,7 +14428,7 @@
         },
         {
             "id": "6b34cdf6-e464-5ec2-a5e1-fcc30f618834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ee958c-ae8c-49bd-9d85-0128ca19901c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ee958c-ae8c-49bd-9d85-0128ca19901c.jpg?1",
             "name": "Trailblazer's Boots",
             "text": "",
             "colours": [],
@@ -14457,7 +14457,7 @@
         },
         {
             "id": "67b9dca5-58e3-5979-b37e-2fc02b2dc9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecea0ba-da29-45f1-b72b-50b873309483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecea0ba-da29-45f1-b72b-50b873309483.jpg?1",
             "name": "Lobelia Sackville-Baggins",
             "text": "",
             "colours": [
@@ -14497,7 +14497,7 @@
         },
         {
             "id": "885282dc-8db3-5aa4-ab1e-ed202be83445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541faaf0-4832-47b5-bb92-881dd70d6309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541faaf0-4832-47b5-bb92-881dd70d6309.jpg?1",
             "name": "Wizard's Rockets",
             "text": "",
             "colours": [],
@@ -14527,7 +14527,7 @@
         },
         {
             "id": "f154f3d9-bf7b-563e-8971-cc1d0202da72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646ff18e-9d6a-4a55-838c-0bd88b8c9fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646ff18e-9d6a-4a55-838c-0bd88b8c9fae.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -14567,7 +14567,7 @@
         },
         {
             "id": "3b598e5f-d03f-5627-b70a-c2713065737e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87f082-1596-43fd-b971-720090ac6733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd87f082-1596-43fd-b971-720090ac6733.jpg?1",
             "name": "Delighted Halfling",
             "text": "",
             "colours": [
@@ -14605,7 +14605,7 @@
         },
         {
             "id": "6886c505-d8a9-55a4-9446-147f67285e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14d6a77-eb1e-4f1a-ac5c-7513952fd1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14d6a77-eb1e-4f1a-ac5c-7513952fd1ce.jpg?1",
             "name": "Bilbo, Retired Burglar",
             "text": "",
             "colours": [
@@ -14645,7 +14645,7 @@
         },
         {
             "id": "03ac29f3-ced3-5857-a8ff-610091d3c541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ea046-3008-4d4e-b316-e6c5e80422d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ea046-3008-4d4e-b316-e6c5e80422d3.jpg?1",
             "name": "Frodo Baggins",
             "text": "",
             "colours": [
@@ -14686,7 +14686,7 @@
         },
         {
             "id": "798391fd-b564-556a-9b16-1e14a01b84c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a2d7f8-0055-4d53-8e1e-9810d384cdb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a2d7f8-0055-4d53-8e1e-9810d384cdb8.jpg?1",
             "name": "The Balrog, Durin's Bane",
             "text": "",
             "colours": [
@@ -14727,7 +14727,7 @@
         },
         {
             "id": "07bbab5d-71d6-5d84-97f2-fe1d35513a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882ef7d-ddff-40f5-a4f5-bff5c8169dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882ef7d-ddff-40f5-a4f5-bff5c8169dc1.jpg?1",
             "name": "Flame of Anor",
             "text": "",
             "colours": [
@@ -14763,7 +14763,7 @@
         },
         {
             "id": "78fc2ba3-1b4e-5123-a5bd-b6a8485c6768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec04f9-0563-4490-b252-714df2ddbf58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ec04f9-0563-4490-b252-714df2ddbf58.jpg?1",
             "name": "Boromir, Warden of the Tower",
             "text": "",
             "colours": [
@@ -14803,7 +14803,7 @@
         },
         {
             "id": "b8780032-b29b-50ae-80fb-0eec70da732e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bb0051-3ba3-4e22-9098-42ee0d9b645c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bb0051-3ba3-4e22-9098-42ee0d9b645c.jpg?1",
             "name": "Lash of the Balrog",
             "text": "",
             "colours": [
@@ -14837,7 +14837,7 @@
         },
         {
             "id": "2329e8b8-2f60-5505-85fb-bc8a25f89404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3485e-2190-412a-a7b0-6a6ffdbef77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3485e-2190-412a-a7b0-6a6ffdbef77c.jpg?1",
             "name": "Sting, the Glinting Dagger",
             "text": "",
             "colours": [],
@@ -14871,7 +14871,7 @@
         },
         {
             "id": "8b12c07d-4a15-56e6-a8e7-b41e1cc6d7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb70f9-c8f6-4082-9d63-4efdd6a20527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbb70f9-c8f6-4082-9d63-4efdd6a20527.jpg?1",
             "name": "Aragorn, Company Leader",
             "text": "",
             "colours": [
@@ -14913,7 +14913,7 @@
         },
         {
             "id": "4b76dc38-2b07-54b5-aca4-702c0c1e81b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b90963-2a4c-4e0a-9d00-5d3df258c880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b90963-2a4c-4e0a-9d00-5d3df258c880.jpg?1",
             "name": "Dunland Crebain",
             "text": "",
             "colours": [
@@ -14950,7 +14950,7 @@
         },
         {
             "id": "fdba1416-2de8-583c-a894-dba56d7d4205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7fc17a-00e6-48f2-a1b9-970d7720f87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7fc17a-00e6-48f2-a1b9-970d7720f87d.jpg?1",
             "name": "Saruman of Many Colors",
             "text": "",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "34215407-85ed-5155-b077-db0a1c0ef310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02fac3-8990-4bd1-8e34-beec6332088c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02fac3-8990-4bd1-8e34-beec6332088c.jpg?1",
             "name": "Storm of Saruman",
             "text": "",
             "colours": [
@@ -15029,7 +15029,7 @@
         },
         {
             "id": "fd833db5-3dc4-53cf-9016-f98d797a890b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dc9616-83e5-451f-aaa8-d0c81802fa13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08dc9616-83e5-451f-aaa8-d0c81802fa13.jpg?1",
             "name": "Pippin's Bravery",
             "text": "",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "350c1ce1-fa70-53be-92af-30fc2a47b3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486c2171-aa41-47d4-a499-d6cff078a587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486c2171-aa41-47d4-a499-d6cff078a587.jpg?1",
             "name": "Fangorn, Tree Shepherd",
             "text": "",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "d896b6f0-e0b9-5eb1-b82a-776d05014bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37271b8b-3c58-43aa-b120-f0aa12fb3ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37271b8b-3c58-43aa-b120-f0aa12fb3ad5.jpg?1",
             "name": "Nasty End",
             "text": "",
             "colours": [
@@ -15135,7 +15135,7 @@
         },
         {
             "id": "731d5c07-41ed-584f-97f0-71e5c618e60e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef083f43-4748-42e6-bc22-fc2570db5ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef083f43-4748-42e6-bc22-fc2570db5ca3.jpg?1",
             "name": "Foray of Orcs",
             "text": "",
             "colours": [
@@ -15169,7 +15169,7 @@
         },
         {
             "id": "465f8451-957b-5312-8d8e-d025f8b0bcb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66763118-6a1e-465a-bfe0-6fe18c419875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66763118-6a1e-465a-bfe0-6fe18c419875.jpg?1",
             "name": "Last March of the Ents",
             "text": "",
             "colours": [
@@ -15203,7 +15203,7 @@
         },
         {
             "id": "561787bf-0c29-5d79-a585-539f7ed9d6f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402d829d-9d99-48ac-9ffe-14405ec56302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402d829d-9d99-48ac-9ffe-14405ec56302.jpg?1",
             "name": "Quickbeam, Upstart Ent",
             "text": "",
             "colours": [
@@ -15241,7 +15241,7 @@
         },
         {
             "id": "09fc3c95-2d50-50b8-bd64-6e19a61bf78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa1dea-e74f-44c4-bfed-7dfaa3ecd332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baa1dea-e74f-44c4-bfed-7dfaa3ecd332.jpg?1",
             "name": "Minas Tirith",
             "text": "",
             "colours": [],
@@ -15276,7 +15276,7 @@
         },
         {
             "id": "462f08e7-d7ba-5c7b-9e5b-ffcc2d510f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882747f9-b4fe-42be-8fe9-f871cd0779bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882747f9-b4fe-42be-8fe9-f871cd0779bd.jpg?1",
             "name": "Mirkwood Bats",
             "text": "",
             "colours": [
@@ -15312,7 +15312,7 @@
         },
         {
             "id": "575bd80c-6206-5e42-9d98-e1053acf299b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce6be0-ebfe-4d50-87c6-8c1fc7536f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce6be0-ebfe-4d50-87c6-8c1fc7536f1f.jpg?1",
             "name": "Voracious Fell Beast",
             "text": "",
             "colours": [
@@ -15349,7 +15349,7 @@
         },
         {
             "id": "1e1b51c4-c337-5110-8cb1-2fa45d747151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77759762-8684-4513-92c5-72c86d43b8bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77759762-8684-4513-92c5-72c86d43b8bd.jpg?1",
             "name": "Witch-king of Angmar",
             "text": "",
             "colours": [
@@ -15389,7 +15389,7 @@
         },
         {
             "id": "ef84d8c0-4c7d-5701-b855-9e966008d44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357a1e7c-19f1-42ea-8a68-511a10ab699a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357a1e7c-19f1-42ea-8a68-511a10ab699a.jpg?1",
             "name": "Shadow of the Enemy",
             "text": "",
             "colours": [
@@ -15423,7 +15423,7 @@
         },
         {
             "id": "ebfe97f7-3f3b-53b6-892d-a42aea9b190d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1aa00f-aa33-4c89-9014-6184356649ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1aa00f-aa33-4c89-9014-6184356649ca.jpg?1",
             "name": "Barad-d\u00fbr",
             "text": "",
             "colours": [],
@@ -15458,7 +15458,7 @@
         },
         {
             "id": "b425054e-2a63-50c2-bf77-78776964bed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa65958a-f601-472e-a9b6-42650b97fa44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa65958a-f601-472e-a9b6-42650b97fa44.jpg?1",
             "name": "Oliphaunt",
             "text": "",
             "colours": [
@@ -15494,7 +15494,7 @@
         },
         {
             "id": "6dc09a5e-555c-5966-a4bd-84896e0dc0db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a06a653-eca1-4fee-add5-45d2594885c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a06a653-eca1-4fee-add5-45d2594885c3.jpg?1",
             "name": "Rising of the Day",
             "text": "",
             "colours": [
@@ -15528,7 +15528,7 @@
         },
         {
             "id": "586f0c82-3d81-5b2f-a6b0-edac55f88a69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c8be5-68be-4e29-baf5-0590ace77319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60c8be5-68be-4e29-baf5-0590ace77319.jpg?1",
             "name": "\u00c9omer, Marshal of Rohan",
             "text": "",
             "colours": [
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "7047a5b2-ee94-50af-a569-0f87f28a2b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9af0ce-db08-4ccf-a9f3-b7c1eea14423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9af0ce-db08-4ccf-a9f3-b7c1eea14423.jpg?1",
             "name": "Gothmog, Morgul Lieutenant",
             "text": "",
             "colours": [
@@ -15606,7 +15606,7 @@
         },
         {
             "id": "edc006d0-d07e-5e3a-9fb1-dc07f2619d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b6da81-dc24-45b3-b94c-0d6fa00fad0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b6da81-dc24-45b3-b94c-0d6fa00fad0c.jpg?1",
             "name": "\u00c9owyn, Fearless Knight",
             "text": "",
             "colours": [
@@ -15647,7 +15647,7 @@
         },
         {
             "id": "4a8aafeb-d8df-5278-8359-382706374c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9c814-df6b-4b54-a233-9bed31009bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9c814-df6b-4b54-a233-9bed31009bed.jpg?1",
             "name": "Prince Imrahil the Fair",
             "text": "",
             "colours": [
@@ -15688,7 +15688,7 @@
         },
         {
             "id": "9354d7b2-b54d-5629-847d-17d7e86a1677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c511371-97d7-47cc-934c-939dfbdd1c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c511371-97d7-47cc-934c-939dfbdd1c0b.jpg?1",
             "name": "Knights of Dol Amroth",
             "text": "",
             "colours": [
@@ -15725,7 +15725,7 @@
         },
         {
             "id": "f07b5dd5-e0ab-56a2-b95d-05235b092331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de055-5246-408b-80fe-cd01688c145e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de055-5246-408b-80fe-cd01688c145e.jpg?1",
             "name": "Orcish Bowmasters",
             "text": "",
             "colours": [
@@ -15762,7 +15762,7 @@
         },
         {
             "id": "9083f929-7a0b-53c6-a039-c45b37079782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52471b8-c962-496e-8634-127337eede01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52471b8-c962-496e-8634-127337eede01.jpg?1",
             "name": "Aragorn, the Uniter",
             "text": "",
             "colours": [
@@ -15808,7 +15808,7 @@
         },
         {
             "id": "89d924df-03b6-5c42-b3ac-868856cbcab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddc39b-9bc9-4106-86aa-a086b5f5c301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ddc39b-9bc9-4106-86aa-a086b5f5c301.jpg?1",
             "name": "Legolas, Master Archer",
             "text": "",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "720d317e-04a8-554d-8265-f8ea0583e403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8bd920-5e70-4c3d-bd15-ccb8d1c87e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8bd920-5e70-4c3d-bd15-ccb8d1c87e2e.jpg?1",
             "name": "Gimli, Mournful Avenger",
             "text": "",
             "colours": [
@@ -15890,7 +15890,7 @@
         },
         {
             "id": "436d9040-71f4-5d0e-9dea-f1e59f8b4b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ff889-fc9a-42f7-998d-0ab23c94ad8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ff889-fc9a-42f7-998d-0ab23c94ad8a.jpg?1",
             "name": "Merry, Esquire of Rohan",
             "text": "",
             "colours": [
@@ -15932,7 +15932,7 @@
         },
         {
             "id": "810fdfd6-2ecf-5737-bbc9-ff38ed992cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96ccfa-153c-459e-9e75-f87ff1ed334a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96ccfa-153c-459e-9e75-f87ff1ed334a.jpg?1",
             "name": "Pippin, Guard of the Citadel",
             "text": "",
             "colours": [
@@ -15974,7 +15974,7 @@
         },
         {
             "id": "ac6634a0-7177-5482-ae12-0dab3faec33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564871f-0f17-4196-bd1d-617b6738c87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564871f-0f17-4196-bd1d-617b6738c87d.jpg?1",
             "name": "Spiteful Banditry",
             "text": "",
             "colours": [
@@ -16008,7 +16008,7 @@
         },
         {
             "id": "acdfce1b-404f-544c-8c79-747f7066bcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56cbc2-6fc2-4443-90fe-59acd526f562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56cbc2-6fc2-4443-90fe-59acd526f562.jpg?1",
             "name": "Rosie Cotton of South Lane",
             "text": "",
             "colours": [
@@ -16047,7 +16047,7 @@
         },
         {
             "id": "d73da607-d6af-5ca0-bab3-c8e70a6e4c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b50fec-28e0-4eaf-9184-73cc7234577f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b50fec-28e0-4eaf-9184-73cc7234577f.jpg?1",
             "name": "Shire Shirriff",
             "text": "",
             "colours": [
@@ -16084,7 +16084,7 @@
         },
         {
             "id": "a8e19557-bc56-59c1-a0dc-4e1f15b92424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61741337-1f9d-42f2-8e79-c7bae436ec59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61741337-1f9d-42f2-8e79-c7bae436ec59.jpg?1",
             "name": "Gandalf the White",
             "text": "",
             "colours": [
@@ -16125,7 +16125,7 @@
         },
         {
             "id": "30a35770-8ebd-5f59-847c-053df00354f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9714aa30-1db2-4670-9a0b-72acfc3f703c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9714aa30-1db2-4670-9a0b-72acfc3f703c.jpg?1",
             "name": "The Grey Havens",
             "text": "",
             "colours": [],
@@ -16157,7 +16157,7 @@
         },
         {
             "id": "2d8e7abc-2fad-5afc-95a7-c0a596c8b9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab613e1-390c-4581-9c3e-4c4b26464d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab613e1-390c-4581-9c3e-4c4b26464d10.jpg?1",
             "name": "Lost Isle Calling",
             "text": "",
             "colours": [
@@ -16191,7 +16191,7 @@
         },
         {
             "id": "7a95bc7a-d831-54a4-8b20-39faaca6afef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769f0ce-b31b-4cb5-8635-2b9b70114180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769f0ce-b31b-4cb5-8635-2b9b70114180.jpg?1",
             "name": "Many Partings",
             "text": "",
             "colours": [
@@ -16225,7 +16225,7 @@
         },
         {
             "id": "d4b47ac8-666e-5fcc-8919-bb5180c2e860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f28ce3f-a82b-4d4c-8803-340873cc5814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f28ce3f-a82b-4d4c-8803-340873cc5814.jpg?1",
             "name": "Galadriel of Lothl\u00f3rien",
             "text": "",
             "colours": [
@@ -16267,7 +16267,7 @@
         },
         {
             "id": "c57affc1-6484-5e9d-a3c6-e119a4d2f3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a037b81-28a3-4ecb-9c18-e9cd5cabad16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a037b81-28a3-4ecb-9c18-e9cd5cabad16.jpg?1",
             "name": "Elrond, Master of Healing",
             "text": "",
             "colours": [
@@ -16309,7 +16309,7 @@
         },
         {
             "id": "5f6c4039-8530-59fe-9359-0cc2ae3be3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5a5971-2f93-40f3-b5a2-97b1f0129399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5a5971-2f93-40f3-b5a2-97b1f0129399.jpg?1",
             "name": "Frodo, Sauron's Bane",
             "text": "",
             "colours": [
@@ -16350,7 +16350,7 @@
         },
         {
             "id": "dc4a6746-3731-5be3-af6e-93c93efad9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16891fb5-1388-465c-8d86-97de0ee94ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16891fb5-1388-465c-8d86-97de0ee94ef1.jpg?1",
             "name": "Samwise the Stouthearted",
             "text": "",
             "colours": [
@@ -16390,7 +16390,7 @@
         },
         {
             "id": "6ed2be56-03df-5bc6-a063-6f8d2a22321a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ef56-4649-43f4-829c-af28278833a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3581ef56-4649-43f4-829c-af28278833a2.jpg?1",
             "name": "Gollum, Patient Plotter",
             "text": "",
             "colours": [
@@ -16430,7 +16430,7 @@
         },
         {
             "id": "86b023d0-5971-5ecd-9478-eeecf3fd8b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ea71a-9a64-4d1e-a8ca-1efce3b8346f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ea71a-9a64-4d1e-a8ca-1efce3b8346f.jpg?1",
             "name": "The One Ring",
             "text": "",
             "colours": [],
@@ -16464,7 +16464,7 @@
         },
         {
             "id": "c70a05ad-6c8e-5514-a89b-2e453aead9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6839fd15-5656-4006-a11b-d0e1cbea05b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6839fd15-5656-4006-a11b-d0e1cbea05b3.jpg?1",
             "name": "Denethor, Ruling Steward",
             "text": "",
             "colours": [
@@ -16505,7 +16505,7 @@
         },
         {
             "id": "e6c0292e-af8b-55c0-8855-2bf82f0755a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e354fe8-fc03-42a0-8795-3d267fea9da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e354fe8-fc03-42a0-8795-3d267fea9da0.jpg?1",
             "name": "Mines of Moria",
             "text": "",
             "colours": [],
@@ -16539,7 +16539,7 @@
         },
         {
             "id": "12d73473-bf4e-57f7-98e2-488253642d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59358af2-98b7-490b-b84f-1ddd3a5cb387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59358af2-98b7-490b-b84f-1ddd3a5cb387.jpg?1",
             "name": "Forge Anew",
             "text": "",
             "colours": [
@@ -16573,7 +16573,7 @@
         },
         {
             "id": "6e512c77-21ea-5af1-8e54-cea780104ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7814651-0542-4c64-a034-404fe40c8f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7814651-0542-4c64-a034-404fe40c8f29.jpg?1",
             "name": "Press the Enemy",
             "text": "",
             "colours": [
@@ -16607,7 +16607,7 @@
         },
         {
             "id": "1e572441-605c-5dc7-ae6e-69f98698cdaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039d3ce-0e5c-4fca-8c84-acf19971436d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039d3ce-0e5c-4fca-8c84-acf19971436d.jpg?1",
             "name": "Rangers of Ithilien",
             "text": "",
             "colours": [
@@ -16644,7 +16644,7 @@
         },
         {
             "id": "4b2b82e9-658e-5c2e-8135-21d2764d6726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951527ef-0561-43b6-8293-4f74dd3f157c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951527ef-0561-43b6-8293-4f74dd3f157c.jpg?1",
             "name": "The Watcher in the Water",
             "text": "",
             "colours": [
@@ -16682,7 +16682,7 @@
         },
         {
             "id": "44d3057e-fc87-51bf-9156-ab1c2e2e4f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f84040-6879-4da4-b46d-f5d32088b8c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f84040-6879-4da4-b46d-f5d32088b8c2.jpg?1",
             "name": "Isildur's Fateful Strike",
             "text": "",
             "colours": [
@@ -16718,7 +16718,7 @@
         },
         {
             "id": "510e029a-c42f-5e55-9751-e632d2abf247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcfd032-ab7f-48e1-a02a-7611aa7354e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcfd032-ab7f-48e1-a02a-7611aa7354e1.jpg?1",
             "name": "Fall of Cair Andros",
             "text": "",
             "colours": [
@@ -16752,7 +16752,7 @@
         },
         {
             "id": "e425ee6a-a982-5c6d-8cc5-041580aefc85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb35e78-97cc-4300-9da9-797eeef9491e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb35e78-97cc-4300-9da9-797eeef9491e.jpg?1",
             "name": "King of the Oathbreakers",
             "text": "",
             "colours": [
@@ -16793,7 +16793,7 @@
         },
         {
             "id": "644b8d22-6044-5d23-8cc8-92d7848c7750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2138bd-da85-46af-8f22-fe8b737f6080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2138bd-da85-46af-8f22-fe8b737f6080.jpg?1",
             "name": "Shelob, Child of Ungoliant",
             "text": "",
             "colours": [
@@ -16834,7 +16834,7 @@
         },
         {
             "id": "da2f9db2-b23f-5f0b-9a89-878bf724cb40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c30e7a3-836a-4239-84dc-bc000ad22afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c30e7a3-836a-4239-84dc-bc000ad22afd.jpg?1",
             "name": "Glamdring",
             "text": "",
             "colours": [],
@@ -16868,7 +16868,7 @@
         },
         {
             "id": "430b2a53-73f5-51ac-ac3f-b210c522a984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab4309-daca-42d9-ad0b-0457717c4503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab4309-daca-42d9-ad0b-0457717c4503.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -16903,7 +16903,7 @@
         },
         {
             "id": "53df89a4-8aa8-5438-a21f-f9f2c28a3b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6df0025-8f6a-43e1-8f07-36f18da3a485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6df0025-8f6a-43e1-8f07-36f18da3a485.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -16938,7 +16938,7 @@
         },
         {
             "id": "a7f12aa2-377c-58bb-b229-43e1ba2a69f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b674ef-f541-4ee8-9727-1c5b3c0c8f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b674ef-f541-4ee8-9727-1c5b3c0c8f4e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "194140f0-66d9-51af-aa9d-a1db03958201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea4e628-4ae2-4e33-a3b6-176ed87c1840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea4e628-4ae2-4e33-a3b6-176ed87c1840.jpg?1",
             "name": "Tentacle",
             "text": "",
             "colours": [
@@ -17006,7 +17006,7 @@
         },
         {
             "id": "7150c706-2db0-511c-b889-7d2fc93d4b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8b43e8-dd89-452e-b572-8559e19fdea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8b43e8-dd89-452e-b572-8559e19fdea2.jpg?1",
             "name": "Orc Army",
             "text": "",
             "colours": [
@@ -17041,7 +17041,7 @@
         },
         {
             "id": "47a358be-d201-542d-85e1-cf32d9d75d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db598f33-2ff9-4e0b-a067-05fecc03435f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db598f33-2ff9-4e0b-a067-05fecc03435f.jpg?1",
             "name": "Orc Army",
             "text": "",
             "colours": [
@@ -17076,7 +17076,7 @@
         },
         {
             "id": "c176be8a-06ef-5d2f-bd91-1d65ccfaf48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2b87e-f8f9-4756-9ea2-64bc5c13bb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d2b87e-f8f9-4756-9ea2-64bc5c13bb96.jpg?1",
             "name": "Smaug",
             "text": "",
             "colours": [
@@ -17112,7 +17112,7 @@
         },
         {
             "id": "68262339-1714-5dd5-947c-6c53866245c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d70342-9d3c-44cb-9026-db5e5941b9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d70342-9d3c-44cb-9026-db5e5941b9fc.jpg?1",
             "name": "Ballistic Boulder",
             "text": "",
             "colours": [],
@@ -17143,7 +17143,7 @@
         },
         {
             "id": "7fb92a7a-6cb2-58d1-a606-deb2a770881f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f04cd9-63ef-4dda-948a-0be76628900c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f04cd9-63ef-4dda-948a-0be76628900c.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -17174,7 +17174,7 @@
         },
         {
             "id": "161b2d5b-de0e-5b90-8a8f-fd23073a928a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcff41e-b6ff-4ddd-bcb6-8943f7d88aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcff41e-b6ff-4ddd-bcb6-8943f7d88aef.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -17205,7 +17205,7 @@
         },
         {
             "id": "9effde9d-e6e2-5820-a315-e32038382b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b7e3b5-2f3c-4eb7-abc9-322a049a9e1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b7e3b5-2f3c-4eb7-abc9-322a049a9e1a.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -17236,7 +17236,7 @@
         },
         {
             "id": "d7e8ec2d-f7a8-5356-9a08-eb7d3ab43fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2c363-c879-4c36-b08a-dd57e3da19ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a2c363-c879-4c36-b08a-dd57e3da19ae.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17266,7 +17266,7 @@
         },
         {
             "id": "50a05a15-a231-58a9-92a1-916e628d89c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg?1",
             "name": "The Ring // The Ring Tempts You",
             "text": "",
             "colours": [],
@@ -17294,7 +17294,7 @@
         },
         {
             "id": "6670b85a-2726-50b8-9c8d-0dde8ec08275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7215460e-8c06-47d0-94e5-d1832d0218af.jpg?1",
             "name": "The Ring // The Ring Tempts You",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M10.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M10.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "19b4fa74-a88f-5793-9b14-fe824aefa268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c50891-af21-4427-a495-0e66aef54809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c50891-af21-4427-a495-0e66aef54809.jpg?1",
             "name": "Ajani Goldmane",
             "text": "+1: You gain 2 life.\n-1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n-6: Put a white Avatar creature token onto the battlefield with \"This creature's power and toughness are each equal to your life total.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "ce97d815-3eea-5017-8102-3b803b565ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911124-3646-4014-b574-13fee44bfad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b911124-3646-4014-b574-13fee44bfad5.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "15198b4d-8302-50f2-93fb-3855dcf146b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebbb4e-9e1d-49f5-b05b-ae59df0deb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebbb4e-9e1d-49f5-b05b-ae59df0deb17.jpg?1",
             "name": "Armored Ascension",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "ab3c9995-0bca-5f1a-9a40-bc4e2ffe3df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6764ea7b-ccb3-4f39-b8ba-654a186210b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6764ea7b-ccb3-4f39-b8ba-654a186210b9.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "629745a6-f228-5b86-b140-539d4d5c46d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420de077-7ee0-446c-aefc-ca8d7ac698b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420de077-7ee0-446c-aefc-ca8d7ac698b5.jpg?1",
             "name": "Blinding Mage",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "a740b9a3-6944-579d-87c1-5ca44f99a324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c26b98-790e-403b-b94b-261a4c92e721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c26b98-790e-403b-b94b-261a4c92e721.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "cdd2de0a-f409-57b3-ab48-eaec7437ae33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f693c3db-a9e3-418c-afdd-e2e245461e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f693c3db-a9e3-418c-afdd-e2e245461e71.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "173e9717-287d-5b08-bd4c-c5d247ddc326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48444e14-c73b-47d1-9c55-0ff4dc3c6034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48444e14-c73b-47d1-9c55-0ff4dc3c6034.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "051980a5-d7f6-5f76-97c5-105ce256fbc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bda0b4b-ab5a-4d91-9dd1-7a5a145b67f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bda0b4b-ab5a-4d91-9dd1-7a5a145b67f5.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "d814d4e0-f586-5ff4-904a-a40181537b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12aad375-653e-47ed-b8e3-34dd90d43420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12aad375-653e-47ed-b8e3-34dd90d43420.jpg?1",
             "name": "Excommunicate",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "bb72f1a7-c482-5c89-8ec4-b7502ddf2746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6dfcf8-a09b-4402-af80-90fe15b2ce0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6dfcf8-a09b-4402-af80-90fe15b2ce0a.jpg?1",
             "name": "Glorious Charge",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "970be000-af2e-543f-89a3-2e4a541b2a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6784b663-b117-45a2-bde4-72e080058ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6784b663-b117-45a2-bde4-72e080058ea7.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -407,7 +407,7 @@
         },
         {
             "id": "711fc60a-a939-5634-999e-1e7ae9a2efb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84613ce-9b59-4ef6-8c76-5b208ff9de88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84613ce-9b59-4ef6-8c76-5b208ff9de88.jpg?1",
             "name": "Guardian Seraph",
             "text": "Flying\nIf a source an opponent controls would deal damage to you, prevent 1 of that damage.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "e39554d8-a4ae-5a62-8ef5-18a62bac9024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e8a22d-a94e-4dfa-86a3-edb80a03d82a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e8a22d-a94e-4dfa-86a3-edb80a03d82a.jpg?1",
             "name": "Harm's Way",
             "text": "The next 2 damage that a source of your choice would deal to you or a permanent you control this turn is dealt to target creature or player instead.",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "92be80fb-077b-59bf-b6d9-d2011450b623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae8ba7-bbf4-44ab-a8b6-742764a7bc5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae8ba7-bbf4-44ab-a8b6-742764a7bc5b.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "a7009a1e-0c68-52b0-9348-1fd06c5f0313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a40f09-d16a-43c7-b4fd-244f45883a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a40f09-d16a-43c7-b4fd-244f45883a47.jpg?1",
             "name": "Honor of the Pure",
             "text": "White creatures you control get +1/+1.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "fe8310e8-4d16-5d1c-bd81-1f9780426636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8765a0-c2ae-4b1a-a3f5-0243b43e6da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8765a0-c2ae-4b1a-a3f5-0243b43e6da0.jpg?1",
             "name": "Indestructibility",
             "text": "Enchant permanent\nEnchanted permanent is indestructible. (Effects that say \"destroy\" don't destroy that permanent. An indestructible creature can't be destroyed by damage.)",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "f0c05ac0-4522-5f58-acfc-b81d7753b749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d881c1-24e7-4ce7-8ab1-474cb040ddd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d881c1-24e7-4ce7-8ab1-474cb040ddd7.jpg?1",
             "name": "Lifelink",
             "text": "Enchant creature\nEnchanted creature has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "83644cf1-2008-5a57-891b-b4c8294eaee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4146a2-08a2-4a9c-b208-a2d02c68e713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4146a2-08a2-4a9c-b208-a2d02c68e713.jpg?1",
             "name": "Lightwielder Paladin",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Lightwielder Paladin deals combat damage to a player, you may exile target black or red permanent that player controls.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "79b73e02-4911-517f-ab33-cf911c2c60b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dfb34b-488d-4185-94ca-99db74af99a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dfb34b-488d-4185-94ca-99db74af99a5.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "6fc2c449-8db2-55ae-8601-45ab312d135f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb29703-96de-475a-9499-b3cd2a2d6566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb29703-96de-475a-9499-b3cd2a2d6566.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control. (Auras with nothing to enchant remain in graveyards.)",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "856b674c-95a8-58ff-8fa0-e5fa2e9189e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d34551e-36a4-49ea-9d2a-4c72575fe06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d34551e-36a4-49ea-9d2a-4c72575fe06a.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "a7575d37-2ff6-5b7a-9d5b-44dfa26dea05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa60be-f989-4aa8-a3fb-a95143d32131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa60be-f989-4aa8-a3fb-a95143d32131.jpg?1",
             "name": "Palace Guard",
             "text": "Palace Guard can block any number of creatures.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "a9d38e86-554c-5b69-a1ce-cb6b00a0cc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ee0d57-e404-4599-9b6e-f8ab8a95f9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ee0d57-e404-4599-9b6e-f8ab8a95f9fa.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "e6e04921-13e6-514f-9fa9-324162808f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4d69c-f61d-4122-9e0b-c88aa905d159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc4d69c-f61d-4122-9e0b-c88aa905d159.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "2e716162-3853-55fd-a05f-49c81749975f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3684a28-e819-4909-912e-dec4a9cf1b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3684a28-e819-4909-912e-dec4a9cf1b11.jpg?1",
             "name": "Rhox Pikemaster",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nOther Soldier creatures you control have first strike.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "929465e9-7a27-5a5a-8929-d85a8ad97507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d15407-c51b-47e7-befd-e9b8b5b3d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d15407-c51b-47e7-befd-e9b8b5b3d93d.jpg?1",
             "name": "Righteousness",
             "text": "Target blocking creature gets +7/+7 until end of turn.",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "113ddbb6-a86d-5304-8118-bc2c51a9561e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8528ef-5e7d-46da-a454-395cd38c213f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8528ef-5e7d-46da-a454-395cd38c213f.jpg?1",
             "name": "Safe Passage",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "aaaecfbb-7ceb-5733-aa11-ea78f24cdb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2befd-8a6d-43ba-97e3-5abae8067adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c2befd-8a6d-43ba-97e3-5abae8067adb.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "ac5511d7-e298-5b71-925f-bffc551e5980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287d4c56-1b75-4ac4-8be8-333b1aba982a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287d4c56-1b75-4ac4-8be8-333b1aba982a.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "8ea00b71-952e-57b2-8fe3-2e3966dc21d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1559d660-8a9d-422b-95d3-710a046583dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1559d660-8a9d-422b-95d3-710a046583dd.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn. (Spells cast before this resolves are unaffected.)",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "470a3557-5460-5052-82e9-25094c1e755e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea82996f-a05f-4831-9bbd-3281ebca9a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea82996f-a05f-4831-9bbd-3281ebca9a61.jpg?1",
             "name": "Silvercoat Lion",
             "text": "",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "d4e394ae-5b56-559a-ac94-f1e6d315ed28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aafbcc-113e-4816-95d2-a192f32ea9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aafbcc-113e-4816-95d2-a192f32ea9ea.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "4befb815-c514-5aca-8d60-a95c94932296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbdd169-958f-42df-812d-f75fbed9576f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbdd169-958f-42df-812d-f75fbed9576f.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature enters the battlefield, you gain 1 life.",
             "colours": [
@@ -1144,7 +1144,7 @@
         },
         {
             "id": "6816ccc7-6088-5c03-8e01-0eb0b46027fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2429a15-ccbe-463c-9218-968709d9e878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2429a15-ccbe-463c-9218-968709d9e878.jpg?1",
             "name": "Stormfront Pegasus",
             "text": "Flying",
             "colours": [
@@ -1178,7 +1178,7 @@
         },
         {
             "id": "0687da39-0c5f-5c33-8185-9e4886cad657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9c3f-c72d-4b7b-a2c2-5249fbf0990f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9c3f-c72d-4b7b-a2c2-5249fbf0990f.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -1210,7 +1210,7 @@
         },
         {
             "id": "4d077553-f5d8-5611-adc1-9d8051c895cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3439568c-606e-4b95-b4fc-4d31e12ff30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3439568c-606e-4b95-b4fc-4d31e12ff30a.jpg?1",
             "name": "Undead Slayer",
             "text": "{W}, {T}: Exile target Skeleton, Vampire, or Zombie.",
             "colours": [
@@ -1245,7 +1245,7 @@
         },
         {
             "id": "87a06a1a-7ea8-54c9-8b78-371d0120ddaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f506b5-2e24-47fd-a41e-1e834ce48cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f506b5-2e24-47fd-a41e-1e834ce48cd1.jpg?1",
             "name": "Veteran Armorsmith",
             "text": "Other Soldier creatures you control get +0/+1.",
             "colours": [
@@ -1280,7 +1280,7 @@
         },
         {
             "id": "015ddab8-d151-5dca-a7ed-88bd282deb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50e0950-e1ef-4c5c-b758-e707ef026d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50e0950-e1ef-4c5c-b758-e707ef026d54.jpg?1",
             "name": "Veteran Swordsmith",
             "text": "Other Soldier creatures you control get +1/+0.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "d18b48e9-969e-5971-aae6-c527bf9d5ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f30f77-75ea-4145-a4a1-106cc547f482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f30f77-75ea-4145-a4a1-106cc547f482.jpg?1",
             "name": "Wall of Faith",
             "text": "Defender (This creature can't attack.)\n{W}: Wall of Faith gets +0/+1 until end of turn.",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "af5abcb1-b61d-5056-baa6-d0a8cc7cea8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401c4880-5598-44e6-a54b-6ea18e542a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401c4880-5598-44e6-a54b-6ea18e542a72.jpg?1",
             "name": "White Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black.)",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "17f0c35c-bd56-5f37-9347-4839f18ccd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9de2b27-f7d1-4e2d-97b2-2bb236b6fb10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9de2b27-f7d1-4e2d-97b2-2bb236b6fb10.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "77e80580-d003-53bf-86e7-0d52382ecd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4e1cc3-4e47-4eff-9047-c6d1cc84d635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df4e1cc3-4e47-4eff-9047-c6d1cc84d635.jpg?1",
             "name": "Alluring Siren",
             "text": "{T}: Target creature an opponent controls attacks you this turn if able.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "1caeac6f-d0e0-562c-811a-038a7021eed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2667f1d1-18d3-4bb4-a071-dd65b237d733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2667f1d1-18d3-4bb4-a071-dd65b237d733.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1484,7 +1484,7 @@
         },
         {
             "id": "4fe605f8-6275-5704-bd91-21792739d827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f6340-865f-437c-983e-df39aad032ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881f6340-865f-437c-983e-df39aad032ab.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1518,7 +1518,7 @@
         },
         {
             "id": "7e8a98a7-deb6-5537-bd1f-ba93627cd3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb757102-4636-46ae-b202-c2095aeb187c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb757102-4636-46ae-b202-c2095aeb187c.jpg?1",
             "name": "Convincing Mirage",
             "text": "Enchant land\nAs Convincing Mirage enters the battlefield, choose a basic land type.\nEnchanted land is the chosen type.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "b4e9ea6e-a24b-5499-8450-25670b56dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be47536-d202-4a09-83cb-8a244b2aef4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be47536-d202-4a09-83cb-8a244b2aef4a.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "b6af30dd-99d6-51ff-9bab-ae4525836a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17965a3c-92b4-4f01-b076-e40c567eed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17965a3c-92b4-4f01-b076-e40c567eed33.jpg?1",
             "name": "Disorient",
             "text": "Target creature gets -7/-0 until end of turn.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "929e1ef3-279e-5cfb-b86a-0f32055dc296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102cec9-1cdc-4946-a2dd-caf04eaa8b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102cec9-1cdc-4946-a2dd-caf04eaa8b97.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "940f4a9e-fc4d-51f4-8d76-2c30cf58a9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3b0949-17e1-4f12-8999-d4638d32dd3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3b0949-17e1-4f12-8999-d4638d32dd3e.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "ad0e2d07-fca4-5839-b066-cfa5eb8a29b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c231101e-6620-46fc-a0ad-a53291d12dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c231101e-6620-46fc-a0ad-a53291d12dc2.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "e2c3279e-e3d0-5c3b-8c3e-fe4e7d6fc368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75d8c9-c15d-4474-9d3f-d35f49e46477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f75d8c9-c15d-4474-9d3f-d35f49e46477.jpg?1",
             "name": "Fabricate",
             "text": "Search your library for an artifact card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "8501568d-c179-500c-8c0b-0f3031695d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa49b9-4bd3-4d2e-9378-3df209680a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fa49b9-4bd3-4d2e-9378-3df209680a2c.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "67e9cf41-d028-5def-aedc-92cbf39fb986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d50518-5cfc-45de-a125-acabf97b8743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d50518-5cfc-45de-a125-acabf97b8743.jpg?1",
             "name": "Hive Mind",
             "text": "Whenever a player casts an instant or sorcery spell, each other player copies that spell. Each of those players may choose new targets for his or her copy.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "05f360a5-79f4-5360-8ddc-44e1f4e37124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabd1d9-e1c0-4f5e-88d6-a8d480cf30ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faabd1d9-e1c0-4f5e-88d6-a8d480cf30ba.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "cba86f1d-8c14-54f0-81bd-776204ea3da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d18c4d7-c779-473b-9b41-f22b439bb501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d18c4d7-c779-473b-9b41-f22b439bb501.jpg?1",
             "name": "Ice Cage",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "ee065864-9f0b-5ae1-80a0-7a44d2a18f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348f3e-8c08-4250-95a9-fc5ed63cd725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348f3e-8c08-4250-95a9-fc5ed63cd725.jpg?1",
             "name": "Illusionary Servant",
             "text": "Flying\nWhen Illusionary Servant becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "7cfd2977-6f16-57d3-8dbf-5e6f66575e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a771996a-0097-4fe5-a9c0-22a047f9cf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a771996a-0097-4fe5-a9c0-22a047f9cf2e.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n-1: Target player draws a card.\n-10: Target player puts the top twenty cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "499fd085-de83-5af2-a332-c3bccfffa5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edd7be9-9334-4684-b642-1aaf2000e054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edd7be9-9334-4684-b642-1aaf2000e054.jpg?1",
             "name": "Jump",
             "text": "Target creature gains flying until end of turn.",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "a008bdb4-fa47-53d9-aeed-d6485d8291ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1489a41b-1371-41b4-9b5e-03d95bdfdd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1489a41b-1371-41b4-9b5e-03d95bdfdd7c.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -2014,7 +2014,7 @@
         },
         {
             "id": "5355b507-7881-5219-9dd2-e5d382fbd32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3f76dd-6c72-4a26-a252-18dc2f6d3396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3f76dd-6c72-4a26-a252-18dc2f6d3396.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "e42f3da6-f98c-522b-9b62-249d8abec478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9826a2e-361e-4701-9177-0907c0c6dc9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9826a2e-361e-4701-9177-0907c0c6dc9f.jpg?1",
             "name": "Merfolk Sovereign",
             "text": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature is unblockable this turn.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "07180192-8736-5902-85a3-32acfb937e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37151305-e489-4df1-9b0a-c5e11c77d2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37151305-e489-4df1-9b0a-c5e11c77d2f1.jpg?1",
             "name": "Mind Control",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "e6009c2f-c44f-5649-910a-42a7232c766f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bea6b5-005c-48c8-9f2b-0dfb18039429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bea6b5-005c-48c8-9f2b-0dfb18039429.jpg?1",
             "name": "Mind Spring",
             "text": "Draw X cards.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "182aabc5-078a-54a6-a7cc-3be4fdd6d777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d196-332c-4266-aac8-a35754d74297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3877d196-332c-4266-aac8-a35754d74297.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "773d3f48-7cf8-5103-bf45-308c6c1e1c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235ca1b3-58aa-4cc0-8201-bcd2ef20ea58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235ca1b3-58aa-4cc0-8201-bcd2ef20ea58.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -2217,7 +2217,7 @@
         },
         {
             "id": "45e7b454-b831-57b3-a71e-6aaac1f34d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d274f4-452b-4ff2-b026-83667e9ba98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d274f4-452b-4ff2-b026-83667e9ba98f.jpg?1",
             "name": "Polymorph",
             "text": "Destroy target creature. It can't be regenerated. Its controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "dac201d5-0fb7-57a4-9f37-499d8c565e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02b8ee-84cb-44cb-ba14-9e725a9d03ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c02b8ee-84cb-44cb-ba14-9e725a9d03ee.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "36056ae2-a012-5fae-a278-6c48d1a483ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48af662-25a3-46a0-a48c-ba8cc417490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48af662-25a3-46a0-a48c-ba8cc417490c.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl enters the battlefield, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "6b9ae887-31ef-5ad5-af46-945153b9433d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d734-7e19-4c1e-a5c2-097b718df7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d734-7e19-4c1e-a5c2-097b718df7c4.jpg?1",
             "name": "Serpent of the Endless Sea",
             "text": "Serpent of the Endless Sea's power and toughness are each equal to the number of Islands you control.\nSerpent of the Endless Sea can't attack unless defending player controls an Island.",
             "colours": [
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "82166ccf-56e7-59fd-a8db-2e376c61fcb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133be4f4-1daa-41b6-b509-9e64c6b00059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133be4f4-1daa-41b6-b509-9e64c6b00059.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2381,7 +2381,7 @@
         },
         {
             "id": "f13f81d3-4c3c-581b-9128-450fd391a0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16ec84d-8644-419d-9f51-5efc9f761d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16ec84d-8644-419d-9f51-5efc9f761d74.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "8a12fb74-43a5-5862-9425-51df92d49e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0937274-d5cb-4790-8c10-804f537c5581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0937274-d5cb-4790-8c10-804f537c5581.jpg?1",
             "name": "Sphinx Ambassador",
             "text": "Flying\nWhenever Sphinx Ambassador deals combat damage to a player, search that player's library for a card, then that player names a card. If you searched for a creature card that isn't the named card, you may put it onto the battlefield under your control. Then that player shuffles his or her library.",
             "colours": [
@@ -2449,7 +2449,7 @@
         },
         {
             "id": "1f1948ff-8938-5c25-84d2-9b0ab6b67e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce03b4b4-612b-4fc9-b063-b0d367712eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce03b4b4-612b-4fc9-b063-b0d367712eaf.jpg?1",
             "name": "Telepathy",
             "text": "Your opponents play with their hands revealed.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "a54fcc8a-1f83-5e92-807f-d5e0893f93d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21c7628-0571-4c09-8763-8e434e5e87d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21c7628-0571-4c09-8763-8e434e5e87d2.jpg?1",
             "name": "Time Warp",
             "text": "Target player takes an extra turn after this one.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "f1b63129-4904-544b-b156-c64c10048a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbdf96b-e7c5-42e5-9a16-03daafde40af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbdf96b-e7c5-42e5-9a16-03daafde40af.jpg?1",
             "name": "Tome Scour",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "ed89e69a-cab6-581f-929b-0f48fc9af63c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cdf46e-cf63-406c-b8f7-121117c6f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cdf46e-cf63-406c-b8f7-121117c6f10b.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "f209599e-e3f6-53ed-ba67-f7f29c65b69a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38eec33-a40e-4739-ad2c-2f57008cef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38eec33-a40e-4739-ad2c-2f57008cef4e.jpg?1",
             "name": "Twincast",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "d8d6b53c-5ae5-5e0b-bf28-b7a29e81a6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db75881-4d4b-4dd9-8d40-c8f89c04f713.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db75881-4d4b-4dd9-8d40-c8f89c04f713.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "03b1d415-6a5d-5274-862a-c3ef9c6098cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc35a7-e38b-4c15-889a-d58c8b360315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc35a7-e38b-4c15-889a-d58c8b360315.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "81a1ef35-b5be-51f1-85ed-d367ecb96458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60db38a-1f8a-4b8e-afab-ab9a3ab46ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60db38a-1f8a-4b8e-afab-ab9a3ab46ef3.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "b1965c29-7166-5aad-9c51-0c94a81a6e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256f91a-e797-41d7-82a6-3dcd691bbeed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b256f91a-e797-41d7-82a6-3dcd691bbeed.jpg?1",
             "name": "Zephyr Sprite",
             "text": "Flying",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "61049ff0-47a8-5a99-aa7f-7797a23f6e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0b14d4-41de-42ac-9894-77bbcebaabfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0b14d4-41de-42ac-9894-77bbcebaabfc.jpg?1",
             "name": "Acolyte of Xathrid",
             "text": "{1}{B}, {T}: Target player loses 1 life.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "459b0968-7de6-5989-926c-06f9b8ef6458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14171597-9bf3-441c-a844-a0e1ac4bb1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14171597-9bf3-441c-a844-a0e1ac4bb1db.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "2e2db0ae-2900-545d-acf9-ffb9917cf21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e710e692-3802-4d5c-9ba9-e55a0c602f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e710e692-3802-4d5c-9ba9-e55a0c602f52.jpg?1",
             "name": "Black Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from white (This creature can't be blocked, targeted, dealt damage, or enchanted by anything white.)",
             "colours": [
@@ -2845,7 +2845,7 @@
         },
         {
             "id": "7ec86d79-05cc-5242-9e5c-2bc7e16827d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d17210c-be39-4abc-9d4d-4f2eca9573bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d17210c-be39-4abc-9d4d-4f2eca9573bd.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "575f0825-b2ee-5df0-a9ba-543ba7736362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639b48f0-3426-46cf-b857-4611f7de4826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639b48f0-3426-46cf-b857-4611f7de4826.jpg?1",
             "name": "Cemetery Reaper",
             "text": "Other Zombie creatures you control get +1/+1.\n{2}{B}, {T}: Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -2913,7 +2913,7 @@
         },
         {
             "id": "f0f1a731-81fc-5c75-9870-6bef45736952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f7a9a7-3679-4a18-a52a-e3a8ab16ad32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f7a9a7-3679-4a18-a52a-e3a8ab16ad32.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2947,7 +2947,7 @@
         },
         {
             "id": "a4287dc6-d8d5-535f-b063-f3938c9b635b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db2f958-947b-4b52-a5cd-e8f8b5576803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db2f958-947b-4b52-a5cd-e8f8b5576803.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "979e82f1-e593-5df2-84be-682cccbc10e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61268362-f2ba-469d-8e5a-0b8da96e54a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61268362-f2ba-469d-8e5a-0b8da96e54a5.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "190918eb-d3f3-5139-8a56-4a31563d925b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7af1b-97c9-4954-bb21-1e389fcb6361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f7af1b-97c9-4954-bb21-1e389fcb6361.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3043,7 +3043,7 @@
         },
         {
             "id": "7fc6b88d-6a19-5155-8d04-199c05e0bede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a329a0-a14a-49b9-adcd-397b566211ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a329a0-a14a-49b9-adcd-397b566211ee.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "a1d53c52-3c92-5ef0-a1df-83ed2a553b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19acff-f3dd-417a-a9ab-ea3e36c1ba61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e19acff-f3dd-417a-a9ab-ea3e36c1ba61.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "8b390e9e-a954-51dd-89d7-d7389ad60e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f964660-c2db-4995-bb16-65383362cf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f964660-c2db-4995-bb16-65383362cf19.jpg?1",
             "name": "Dread Warlock",
             "text": "Dread Warlock can't be blocked except by black creatures.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "fa067f42-db44-557c-9e04-85b258b67849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425836be-f5cd-4584-a2ff-a8cf166eccc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425836be-f5cd-4584-a2ff-a8cf166eccc0.jpg?1",
             "name": "Drudge Skeletons",
             "text": "{B}: Regenerate Drudge Skeletons. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "8c1da832-0e27-57b6-9ee5-9974999da8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d759602b-38c9-42fe-902a-0e696ccbdf13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d759602b-38c9-42fe-902a-0e696ccbdf13.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "70922895-fa92-58f4-91b5-f89bf9113476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595fff83-78d2-454f-8099-ee2da87c4826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595fff83-78d2-454f-8099-ee2da87c4826.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "4d25c643-36d6-546e-b1ca-322a97ae2efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e9113-6e97-43af-9e61-71c7917c0870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720e9113-6e97-43af-9e61-71c7917c0870.jpg?1",
             "name": "Haunting Echoes",
             "text": "Exile all cards from target player's graveyard other than basic land cards. For each card exiled this way, search that player's library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "9aee62cf-f5de-54bc-a4b6-ff5f59fc3386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e38e91-696e-4bf9-b46c-c9ed85c82b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e38e91-696e-4bf9-b46c-c9ed85c82b19.jpg?1",
             "name": "Howling Banshee",
             "text": "Flying\nWhen Howling Banshee enters the battlefield, each player loses 3 life.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "279798c9-a5d9-527a-9568-43814eb7cd8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695f390-f791-4d64-90b2-731d6d37df1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9695f390-f791-4d64-90b2-731d6d37df1c.jpg?1",
             "name": "Hypnotic Specter",
             "text": "Flying\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "5bdf223f-d659-5a74-98f8-5235385c9369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542b3ec9-7800-4dea-bf39-b51a11b58339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542b3ec9-7800-4dea-bf39-b51a11b58339.jpg?1",
             "name": "Kelinore Bat",
             "text": "Flying",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "4673dc75-2421-5c04-95ad-0ae85053ac08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6045789-a75b-4b7f-acde-0fdf7f3f262c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6045789-a75b-4b7f-acde-0fdf7f3f262c.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n-2: Search your library for a card, then shuffle your library and put that card on top of it.\n-8: Put all creature cards in all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "88dd9e41-7dc5-5ccb-9453-3865b6031009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6703c-38d4-4c86-b5b0-ebfde81bb1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6703c-38d4-4c86-b5b0-ebfde81bb1bf.jpg?1",
             "name": "Looming Shade",
             "text": "{B}: Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3447,7 +3447,7 @@
         },
         {
             "id": "01c55ca2-176d-52a3-82df-c2380b84c563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b04fca4-b4de-4343-ba58-d8aea39edc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b04fca4-b4de-4343-ba58-d8aea39edc19.jpg?1",
             "name": "Megrim",
             "text": "Whenever an opponent discards a card, Megrim deals 2 damage to that player.",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "a01d2d5b-a5cc-5c60-b8cf-5ff6b93f6cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ae0d9d-170b-4c96-8fa2-68b81eaa13c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95ae0d9d-170b-4c96-8fa2-68b81eaa13c9.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3511,7 +3511,7 @@
         },
         {
             "id": "3541af77-88a9-5383-8e87-acc6b50dc5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e089963a-f253-4e7a-9ddb-1880291a6a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e089963a-f253-4e7a-9ddb-1880291a6a23.jpg?1",
             "name": "Mind Shatter",
             "text": "Target player discards X cards at random.",
             "colours": [
@@ -3543,7 +3543,7 @@
         },
         {
             "id": "bc1d6a45-462b-5181-b5bc-f73e28b30249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d53fd-2d3b-4050-b5c5-1b75f525ca2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8d53fd-2d3b-4050-b5c5-1b75f525ca2c.jpg?1",
             "name": "Nightmare",
             "text": "Flying\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "cf893bbc-78a0-5e7c-b434-12cf929a2821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700dfa3a-299d-4d4e-bb32-d29a1f6aa670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700dfa3a-299d-4d4e-bb32-d29a1f6aa670.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "f2ce76a9-ccc1-5f3f-91bb-d86328d7579c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9dd0d9-8e35-4a8c-af6f-83c7d2a3ea7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9dd0d9-8e35-4a8c-af6f-83c7d2a3ea7d.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card in a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "23c9a26d-228b-5943-bd83-a73221b4ce86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94e3cdf-8312-4824-80b0-36be988e6eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94e3cdf-8312-4824-80b0-36be988e6eb4.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "789fc945-1d7c-5d52-b19f-bbec71669bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445d6a68-ed53-4c96-973a-c29282514f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445d6a68-ed53-4c96-973a-c29282514f41.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "87598bd3-0732-5fd7-8b9d-d52cea1b1a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975ed97-acb8-4bb6-804a-e5da725d876e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975ed97-acb8-4bb6-804a-e5da725d876e.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3743,7 +3743,7 @@
         },
         {
             "id": "7208de05-109c-56fe-95d8-39266ee7aaae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54800a5a-33fe-4291-a7b4-a1eb256dfa8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54800a5a-33fe-4291-a7b4-a1eb256dfa8f.jpg?1",
             "name": "Soul Bleed",
             "text": "Enchant creature\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 1 life.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "88aabf3b-9768-5908-8024-7dc676c8e0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97cf3d1-4929-4161-bc5e-f7fa0fb9af68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e97cf3d1-4929-4161-bc5e-f7fa0fb9af68.jpg?1",
             "name": "Tendrils of Corruption",
             "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "fa82ce0d-6461-59cf-83d0-28906e647483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f252826-d2bd-4e25-a500-423a727a7e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f252826-d2bd-4e25-a500-423a727a7e9e.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to him or her.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "c550afc5-38f8-585d-8dc1-0c4126e43ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523c3541-405f-47e5-8730-5c7ce0426a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523c3541-405f-47e5-8730-5c7ce0426a4e.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "86e2914f-a864-564e-a645-10684f47351e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac0b9c-0077-44c8-8982-4e7b7e7ad398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bac0b9c-0077-44c8-8982-4e7b7e7ad398.jpg?1",
             "name": "Vampire Aristocrat",
             "text": "Sacrifice a creature: Vampire Aristocrat gets +2/+2 until end of turn.",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "fa9af3dd-8d1d-5603-a4af-74281fc7b8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df4f1ea-dbaa-456c-884c-97f03b64fa17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df4f1ea-dbaa-456c-884c-97f03b64fa17.jpg?1",
             "name": "Vampire Nocturnus",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is black, Vampire Nocturnus and other Vampire creatures you control get +2/+1 and have flying.",
             "colours": [
@@ -3945,7 +3945,7 @@
         },
         {
             "id": "55c6dbe9-dcb5-5cfc-a49f-bd2bf30fc3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d80ce-284a-4d22-9ea8-f8d480377212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d80ce-284a-4d22-9ea8-f8d480377212.jpg?1",
             "name": "Wall of Bone",
             "text": "Defender (This creature can't attack.)\n{B}: Regenerate Wall of Bone. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3980,7 +3980,7 @@
         },
         {
             "id": "f27419f7-a7b5-5ce8-97a5-f3a640f91fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6cc262-ba0c-4cca-ae9c-24a1824753e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6cc262-ba0c-4cca-ae9c-24a1824753e4.jpg?1",
             "name": "Warpath Ghoul",
             "text": "",
             "colours": [
@@ -4014,7 +4014,7 @@
         },
         {
             "id": "4e5e9e9e-515c-5c57-8538-39af87ff4aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb8322c-63e1-4618-8ee3-7e635cc8bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb8322c-63e1-4618-8ee3-7e635cc8bf5e.jpg?1",
             "name": "Weakness",
             "text": "Enchant creature\nEnchanted creature gets -2/-1.",
             "colours": [
@@ -4048,7 +4048,7 @@
         },
         {
             "id": "162c5c9d-e4a8-5dad-9330-9ad737a503cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8ead-f295-4ca7-a309-6768e6e765cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8ead-f295-4ca7-a309-6768e6e765cf.jpg?1",
             "name": "Xathrid Demon",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature other than Xathrid Demon, then each opponent loses life equal to the sacrificed creature's power. If you can't sacrifice a creature, tap Xathrid Demon and you lose 7 life.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "7c1ac8da-e00e-5dae-afeb-17b08941f53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc295834-af33-45ae-be4d-7a1987f85561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc295834-af33-45ae-be4d-7a1987f85561.jpg?1",
             "name": "Zombie Goliath",
             "text": "",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "ad3f4ca2-c974-5463-86c2-c95cb37f50b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63bee5-d8e5-4c2f-8514-8c86d025f7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63bee5-d8e5-4c2f-8514-8c86d025f7c9.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4149,7 +4149,7 @@
         },
         {
             "id": "28d23ebf-cad0-56ac-a713-40d31612887a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a9d0-0add-4cf1-958c-9367c7441c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3259a9d0-0add-4cf1-958c-9367c7441c62.jpg?1",
             "name": "Ball Lightning",
             "text": "Trample (If this creature would deal enough damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player or planeswalker.)\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nAt the beginning of the end step, sacrifice Ball Lightning.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "2e759850-0016-58a8-89da-f6b6e033c468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485ebe59-0fdb-463f-a6ad-51881cfde3da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485ebe59-0fdb-463f-a6ad-51881cfde3da.jpg?1",
             "name": "Berserkers of Blood Ridge",
             "text": "Berserkers of Blood Ridge attacks each turn if able.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "d62fc0ba-833a-5141-972a-634744138bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3226c1aa-37b8-4499-9579-60618261f3e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3226c1aa-37b8-4499-9579-60618261f3e8.jpg?1",
             "name": "Bogardan Hellkite",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhen Bogardan Hellkite enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "fee99076-d8da-53dc-a4c7-b261883305f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a448bc9e-f5db-4507-ac40-7d8ee3598585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a448bc9e-f5db-4507-ac40-7d8ee3598585.jpg?1",
             "name": "Burning Inquiry",
             "text": "Each player draws three cards, then discards three cards at random.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "17a94ace-af65-51d2-b44a-40eff0170a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8c7aa0-2067-4513-a658-ed866279e671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8c7aa0-2067-4513-a658-ed866279e671.jpg?1",
             "name": "Burst of Speed",
             "text": "Creatures you control gain haste until end of turn. (They can attack and {T} even if they just came under your control.)",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "f84ab93d-fd82-5ca9-9143-766038085b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85b682f-f526-45a8-9a12-db3fe8c3c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85b682f-f526-45a8-9a12-db3fe8c3c8c3.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "224bec57-57c7-5141-92ee-f805897f7ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d844b29-3b5e-4824-befc-affe6aac6d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d844b29-3b5e-4824-befc-affe6aac6d87.jpg?1",
             "name": "Capricious Efreet",
             "text": "At the beginning of your upkeep, choose target nonland permanent you control and up to two target nonland permanents you don't control. Destroy one of them at random.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "141484a3-a0fd-5cfb-b9cf-7a6dc14c49c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce115a-28f8-4350-8e66-74e7a3727657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce115a-28f8-4350-8e66-74e7a3727657.jpg?1",
             "name": "Chandra Nalaar",
             "text": "+1: Chandra Nalaar deals 1 damage to target player.\n-X: Chandra Nalaar deals X damage to target creature.\n-8: Chandra Nalaar deals 10 damage to target player and each creature he or she controls.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "4e6fd3e6-3350-59b9-9278-3250ff5647f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adab786-c851-4de3-9349-65f7f01a81f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adab786-c851-4de3-9349-65f7f01a81f6.jpg?1",
             "name": "Dragon Whelp",
             "text": "Flying\n{R}: Dragon Whelp gets +1/+0 until end of turn. At the beginning of the end step, if this ability has been activated four or more times this turn, sacrifice Dragon Whelp.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "1ff8b183-e1f3-5c34-b972-b65780dc9fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb8ae1-a619-42bf-976f-2833777032d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fb8ae1-a619-42bf-976f-2833777032d2.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each creature without flying and each player.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "2a2c6531-c0d2-56de-bcd4-dd323128cda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6b2c8a-8019-4e4b-8f4e-058ab5284153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6b2c8a-8019-4e4b-8f4e-058ab5284153.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "1cfbb44c-7e0f-5809-8610-9d40cde9835f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc84106-aec3-4e52-8dcb-1ed545bf3058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc84106-aec3-4e52-8dcb-1ed545bf3058.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "be7427f2-1a04-5246-b809-1deff1d4af71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c13194-20c1-4a93-bbf4-2e02eeb9e0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c13194-20c1-4a93-bbf4-2e02eeb9e0e2.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "bc901968-77d1-54ae-8535-29e50ebbac33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bd59d-9d6d-434d-974f-3aa1cbd770b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674bd59d-9d6d-434d-974f-3aa1cbd770b5.jpg?1",
             "name": "Goblin Artillery",
             "text": "{T}: Goblin Artillery deals 2 damage to target creature or player and 3 damage to you.",
             "colours": [
@@ -4623,7 +4623,7 @@
         },
         {
             "id": "87b586b3-bccd-5cc4-b844-ee7fd84f3fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c8a4a4-1611-4188-9c59-8aefb016b5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c8a4a4-1611-4188-9c59-8aefb016b5ad.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "e0800520-1c7e-5124-994f-a1c686f4f45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3e1685-a34d-43fc-986f-442523cc0631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3e1685-a34d-43fc-986f-442523cc0631.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "43898865-b335-5823-8844-8f001635c1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425d61c-f224-4ba6-a32e-44e3a3954c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425d61c-f224-4ba6-a32e-44e3a3954c1b.jpg?1",
             "name": "Ignite Disorder",
             "text": "Ignite Disorder deals 3 damage divided as you choose among any number of target white and/or blue creatures.",
             "colours": [
@@ -4724,7 +4724,7 @@
         },
         {
             "id": "c6ef9981-3012-5488-94a6-03486003be7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f05a58-a801-483a-8648-8685a4eaa773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f05a58-a801-483a-8648-8685a4eaa773.jpg?1",
             "name": "Inferno Elemental",
             "text": "Whenever Inferno Elemental blocks or becomes blocked by a creature, Inferno Elemental deals 3 damage to that creature.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "3c34341d-a3d2-5a99-a238-3c5ce31dfc64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a47a2dc-f7f2-4103-9ebe-8cd8b83915ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a47a2dc-f7f2-4103-9ebe-8cd8b83915ae.jpg?1",
             "name": "Jackal Familiar",
             "text": "Jackal Familiar can't attack or block alone.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "3c986387-cc1b-5156-bb89-fc316cb3b73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004b84-ac1a-49a1-862b-ce86bcae2c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004b84-ac1a-49a1-862b-ce86bcae2c6b.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "652d63c8-0061-5307-b8bc-25b0b2da75af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cbcef1-81b1-4847-ada3-1ce84cdfdce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cbcef1-81b1-4847-ada3-1ce84cdfdce3.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "78380203-7623-50bc-ab48-577cd655ee9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435589bb-27c6-4a6d-9d63-394d5092b9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435589bb-27c6-4a6d-9d63-394d5092b9d8.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "c69451e8-2b15-592f-8898-b8c3a05ef513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8314a22b-11db-4882-835a-75f8f1ad15df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8314a22b-11db-4882-835a-75f8f1ad15df.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4922,7 +4922,7 @@
         },
         {
             "id": "6a70e3d2-e02a-5e2a-b222-1cd3a4d09d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63466db8-270e-4c68-8823-963f993de783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63466db8-270e-4c68-8823-963f993de783.jpg?1",
             "name": "Magma Phoenix",
             "text": "Flying\nWhen Magma Phoenix is put into a graveyard from the battlefield, it deals 3 damage to each creature and each player.\n{3}{R}{R}: Return Magma Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "b4bc1494-7bbe-5880-a820-5dc9a31aa3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7499cb21-a8ec-4938-884b-7085946af8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7499cb21-a8ec-4938-884b-7085946af8f8.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to that player.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "073b1930-c019-5d81-a1f3-d8591573d0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c6cbc8-e33a-4692-aff0-4de9bb65421d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c6cbc8-e33a-4692-aff0-4de9bb65421d.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "5c3e3371-9565-5e59-838b-c8fc0edc15c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea894b56-7427-4dda-a63a-65608252f13e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea894b56-7427-4dda-a63a-65608252f13e.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "f1700bec-c9dd-5322-9a63-cae2c99612e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df4f214-5db5-41ea-8e06-e8f0aaeac05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df4f214-5db5-41ea-8e06-e8f0aaeac05d.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -5087,7 +5087,7 @@
         },
         {
             "id": "fd74a5d3-beea-5ca2-b590-0282dac572f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa318c3a-70ae-499a-8022-b380f03fd53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa318c3a-70ae-499a-8022-b380f03fd53f.jpg?1",
             "name": "Raging Goblin",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "734dd7ac-581a-50f6-a5bb-1b8c1c1e05f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6526a501-9402-44c1-8e3c-ce01b4ed5b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6526a501-9402-44c1-8e3c-ce01b4ed5b87.jpg?1",
             "name": "Seismic Strike",
             "text": "Seismic Strike deals damage to target creature equal to the number of Mountains you control.",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "2a837b8a-e9c9-5ee6-b086-17245aeed711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5847aac2-edb9-4c83-b36c-3a57f037c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5847aac2-edb9-4c83-b36c-3a57f037c074.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5186,7 +5186,7 @@
         },
         {
             "id": "a91b9680-80f4-5676-ad64-0153775d79cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efc94a-b644-4cc4-9598-2ce16fe68420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efc94a-b644-4cc4-9598-2ce16fe68420.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "33813ecd-bd8f-5bc3-a4ef-dcfb67c9413e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5128dd-54dd-42a8-b126-f821f87ad069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5128dd-54dd-42a8-b126-f821f87ad069.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander enters the battlefield, put three 1/1 red Goblin creature tokens onto the battlefield.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -5254,7 +5254,7 @@
         },
         {
             "id": "e3b1053f-e4ff-51d1-8b9b-10c93351a088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8344ac6f-8b79-440a-ad4d-3bd24b4d3229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8344ac6f-8b79-440a-ad4d-3bd24b4d3229.jpg?1",
             "name": "Sparkmage Apprentice",
             "text": "When Sparkmage Apprentice enters the battlefield, it deals 1 damage to target creature or player.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "8583e246-b675-5dd7-a8e7-d1abe21d34e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e3aadb-88c9-4629-bf9f-7ea5dccaacb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e3aadb-88c9-4629-bf9f-7ea5dccaacb6.jpg?1",
             "name": "Stone Giant",
             "text": "{T}: Target creature you control with toughness less than Stone Giant's power gains flying until end of turn. Destroy that creature at the beginning of the end step.",
             "colours": [
@@ -5323,7 +5323,7 @@
         },
         {
             "id": "15ad984f-b89c-552c-89f0-9b21148fd246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ca754-7da8-49ad-a26c-8e20b37e411e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769ca754-7da8-49ad-a26c-8e20b37e411e.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "d7e5d2b5-ddb3-52f1-a3e5-3e90693f4336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232226ab-918c-49b6-9f5b-fa0e0a1ba1d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232226ab-918c-49b6-9f5b-fa0e0a1ba1d3.jpg?1",
             "name": "Viashino Spearhunter",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5390,7 +5390,7 @@
         },
         {
             "id": "9914ea8a-2053-55a8-a6de-0940d9845973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a365050-196b-4513-8143-c823a96da9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a365050-196b-4513-8143-c823a96da9a0.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "2797f077-f702-59df-86dd-6b7e76feaece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6e1fb5-a06b-4e10-8cc7-785e0f0b298e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6e1fb5-a06b-4e10-8cc7-785e0f0b298e.jpg?1",
             "name": "Warp World",
             "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of his or her library.",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "1d1a0c62-e67b-5d77-80e4-b4646532742f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa364a1c-14e4-4dda-aa1f-edb879a64a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa364a1c-14e4-4dda-aa1f-edb879a64a2d.jpg?1",
             "name": "Yawning Fissure",
             "text": "Each opponent sacrifices a land.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "59689e96-0e50-5fe7-90aa-302c502208f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1377f45-edee-4922-825b-6f22163ff63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1377f45-edee-4922-825b-6f22163ff63d.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5522,7 +5522,7 @@
         },
         {
             "id": "5e41048e-28c5-550c-9ad7-82ff221acad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee46d8b-559e-4c33-99fb-b55f00aeee72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee46d8b-559e-4c33-99fb-b55f00aeee72.jpg?1",
             "name": "Ant Queen",
             "text": "{1}{G}: Put a 1/1 green Insect creature token onto the battlefield.",
             "colours": [
@@ -5556,7 +5556,7 @@
         },
         {
             "id": "5111065e-83f8-5340-8118-7627dd3d2b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821bd93c-e25e-4a8d-b4ec-b459ef37f6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821bd93c-e25e-4a8d-b4ec-b459ef37f6c8.jpg?1",
             "name": "Awakener Druid",
             "text": "When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature as long as Awakener Druid is on the battlefield. It's still a land.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "59286d08-668e-5a2a-bc18-9e0f6f5b2eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f94309b-1049-4ab4-b7f0-745938c87b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f94309b-1049-4ab4-b7f0-745938c87b3f.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "7e2d4fae-c95b-5ea9-9ae2-f740c5ccb07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd0f8c8-1a1f-4d9b-a6e1-3654f3995012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd0f8c8-1a1f-4d9b-a6e1-3654f3995012.jpg?1",
             "name": "Borderland Ranger",
             "text": "When Borderland Ranger enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "f95c405b-723c-53a9-9073-bf436b5f651a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d225382c-cc6f-4224-82b5-4309b72feb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d225382c-cc6f-4224-82b5-4309b72feb0b.jpg?1",
             "name": "Bountiful Harvest",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "c31f2fa7-e71c-539f-9b65-47e93ec7ca5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74148e2e-ac21-414a-9b6c-410988d7fdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74148e2e-ac21-414a-9b6c-410988d7fdd0.jpg?1",
             "name": "Bramble Creeper",
             "text": "Whenever Bramble Creeper attacks, it gets +5/+0 until end of turn.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "a5cf3057-7e30-51ca-884c-7598b045e0eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03354b67-7df2-4b4b-a996-a37550e58561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03354b67-7df2-4b4b-a996-a37550e58561.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5762,7 +5762,7 @@
         },
         {
             "id": "690acccd-b452-5f8b-bf35-be5bc4c80852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875f73d-6108-488b-bd34-4cf2c23ce6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875f73d-6108-488b-bd34-4cf2c23ce6b3.jpg?1",
             "name": "Craw Wurm",
             "text": "",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "aace9e39-9048-569c-9105-03d68a3d1461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d779b14c-a100-4382-9e7c-0969efda73ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d779b14c-a100-4382-9e7c-0969efda73ec.jpg?1",
             "name": "Cudgel Troll",
             "text": "{G}: Regenerate Cudgel Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "77b27cbe-a314-5d68-a527-38516658a70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab810f1-21d6-4a98-b77a-e455370aa6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab810f1-21d6-4a98-b77a-e455370aa6cc.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "b6a5a6f6-9149-5ac1-9977-699fc13b222b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544bc214-e32d-4370-a15f-62812a0420be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544bc214-e32d-4370-a15f-62812a0420be.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "20aa30ac-f14b-5c2b-8fb7-0e02c377ccae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5666cb39-5fea-4eaa-a6da-1b2ffc5a3811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5666cb39-5fea-4eaa-a6da-1b2ffc5a3811.jpg?1",
             "name": "Elvish Piper",
             "text": "{G}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -5934,7 +5934,7 @@
         },
         {
             "id": "be3a2a6d-9a43-5080-83bb-c0bb98aabb3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3ea3-fb3c-4758-8035-20ec0a94b730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3ea3-fb3c-4758-8035-20ec0a94b730.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "fe8e4418-3eed-567c-ba98-9812af12bb34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf14b5-31d0-42e3-a319-2622b489f7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bf14b5-31d0-42e3-a319-2622b489f7c4.jpg?1",
             "name": "Emerald Oryx",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -6003,7 +6003,7 @@
         },
         {
             "id": "31024bab-7341-5d08-8a14-85afa47bc13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54069e65-eef4-4fb8-bb0d-932a4c9889b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54069e65-eef4-4fb8-bb0d-932a4c9889b3.jpg?1",
             "name": "Enormous Baloth",
             "text": "",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "005ff425-d8d7-550f-8ade-7d2a545031da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717a468-696c-4a84-b943-75046138f2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717a468-696c-4a84-b943-75046138f2bf.jpg?1",
             "name": "Entangling Vines",
             "text": "Enchant tapped creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -6071,7 +6071,7 @@
         },
         {
             "id": "9ad5ed11-6768-5a4e-ab47-daa359a8aa83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c61926-3671-4d5b-8d60-0b946b44c7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c61926-3671-4d5b-8d60-0b946b44c7ec.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -6103,7 +6103,7 @@
         },
         {
             "id": "c60a0c02-9695-5b99-bea9-7663356909a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799315b8-19ab-474e-bbe2-f928d4969daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799315b8-19ab-474e-bbe2-f928d4969daf.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "+1: Untap two target lands.\n-1: Put a 3/3 green Beast creature token onto the battlefield.\n-4: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -6139,7 +6139,7 @@
         },
         {
             "id": "88995d66-3237-55c9-ae85-e2d2ebd91394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df3116a-ce5c-44d1-9286-7deb5d516c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df3116a-ce5c-44d1-9286-7deb5d516c90.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "5a646be2-bedd-50be-afb0-667d151be016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1c68b1-fec9-4d96-b4ad-8d34719f1952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1c68b1-fec9-4d96-b4ad-8d34719f1952.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "4b57c65a-5957-502b-aff6-42efea6c2a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c8a79-1e8a-437d-836f-31155914c551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451c8a79-1e8a-437d-836f-31155914c551.jpg?1",
             "name": "Great Sable Stag",
             "text": "Great Sable Stag can't be countered.\nProtection from blue and from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything blue or black.)",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "732eabbd-030c-54a2-a23b-4266745f3d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37ba2c4-dd92-4b23-a830-5dbabc9a972b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37ba2c4-dd92-4b23-a830-5dbabc9a972b.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "Put a 2/2 green Wolf creature token onto the battlefield for each Forest you control.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "fe378e61-da0a-5c0b-8923-1539b5b31177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77064471-d0c1-4988-8c47-f767bf9635f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77064471-d0c1-4988-8c47-f767bf9635f3.jpg?1",
             "name": "Kalonian Behemoth",
             "text": "Shroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "e82a4650-10f2-5030-bf0b-c7faa2c673db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e047c-823b-4d18-a5e9-6de3e6989858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e047c-823b-4d18-a5e9-6de3e6989858.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "1cbab4e2-9da8-5bef-a853-d719b5135368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864c824-89a1-41f6-9481-83b2284471e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864c824-89a1-41f6-9481-83b2284471e0.jpg?1",
             "name": "Lurking Predators",
             "text": "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "a3750421-8ea9-5369-b110-8550c5847dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf3169c-f01c-47f4-ba4b-e199b7ade5fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf3169c-f01c-47f4-ba4b-e199b7ade5fc.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "At the beginning of your upkeep, put a 2/2 green Wolf creature token onto the battlefield.\n{T}: Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves.",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "3f555729-8bc1-59b8-bb81-e0254ee8f893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a324b-cf3e-4a0f-95c4-cd548586f7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438a324b-cf3e-4a0f-95c4-cd548586f7e5.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "59c16a58-58df-55ea-84b6-4e16ce763693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3a26c7-e028-4741-803d-6384925b8500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3a26c7-e028-4741-803d-6384925b8500.jpg?1",
             "name": "Mist Leopard",
             "text": "Shroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "272e1788-423d-5374-a2e3-cdf0b7c8f51e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216a729-6283-4c2b-90fe-ec8f3b9c570f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216a729-6283-4c2b-90fe-ec8f3b9c570f.jpg?1",
             "name": "Mold Adder",
             "text": "Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on Mold Adder.",
             "colours": [
@@ -6508,7 +6508,7 @@
         },
         {
             "id": "e7f6c351-7484-5b76-ad21-c6ecd5ebc9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae52b4dc-4acd-4fa5-a6b5-613e808cf0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae52b4dc-4acd-4fa5-a6b5-613e808cf0ab.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6540,7 +6540,7 @@
         },
         {
             "id": "f722c960-10b2-509e-b0ed-51746b959905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f9d732-c112-4a80-8b28-a9f036e9b04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f9d732-c112-4a80-8b28-a9f036e9b04a.jpg?1",
             "name": "Nature's Spiral",
             "text": "Return target permanent card from your graveyard to your hand. (A permanent card is an artifact, creature, enchantment, land, or planeswalker card.)",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "d33f95f4-1315-54f6-b304-e4759e8c74db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df372a-af2b-464a-b54c-039132f70d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42df372a-af2b-464a-b54c-039132f70d00.jpg?1",
             "name": "Oakenform",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "c2e60d63-8b42-5f52-87ac-f5adec7cf46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e16262-a9c1-45e1-b88a-322c752256cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e16262-a9c1-45e1-b88a-322c752256cf.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (If a creature you control would deal enough damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "c4bf05e3-9dfc-5672-a959-f6f46e35742c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde88869-5202-43e9-b0eb-4e40a50d311e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde88869-5202-43e9-b0eb-4e40a50d311e.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "3586c7c3-be63-5917-b9ea-ef86fb746bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a530d1e-2aff-4684-8f21-743a73f285ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a530d1e-2aff-4684-8f21-743a73f285ff.jpg?1",
             "name": "Protean Hydra",
             "text": "Protean Hydra enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Protean Hydra, prevent that damage and remove that many +1/+1 counters from it.\nWhenever a +1/+1 counter is removed from Protean Hydra, put two +1/+1 counters on it at the beginning of the end step.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "ac69f7ab-3705-57cd-98df-7309ad41f5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78472540-b085-4ee1-848c-de4631274919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78472540-b085-4ee1-848c-de4631274919.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "b19c5367-ada1-58cf-a039-6fdb77d3128c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1026f4-b11a-48aa-9191-e0bb51c515a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1026f4-b11a-48aa-9191-e0bb51c515a6.jpg?1",
             "name": "Regenerate",
             "text": "Regenerate target creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6770,7 +6770,7 @@
         },
         {
             "id": "66dc9783-fafb-5792-a65d-2dece74dbe0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268bd9d5-4da1-4cbf-83f9-47f7aac1cfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268bd9d5-4da1-4cbf-83f9-47f7aac1cfc3.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "e9ef92d2-4cea-5f29-8820-ea4b68b8f5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a33394-d26c-4dcd-948c-e7d370059b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a33394-d26c-4dcd-948c-e7d370059b11.jpg?1",
             "name": "Stampeding Rhino",
             "text": "Trample (If this creature would deal enough damage to its blockers to destroy them, you may have it deal the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "a795739f-1e13-5ef8-9efd-9057de95dc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3768ec-bb3b-44dc-9fa3-7cb3d3ee9f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee3768ec-bb3b-44dc-9fa3-7cb3d3ee9f8c.jpg?1",
             "name": "Windstorm",
             "text": "Windstorm deals X damage to each creature with flying.",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "ec31dce7-9c6d-5900-a18f-9e674d846cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16860147-14fd-40bc-804d-0716a77294ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16860147-14fd-40bc-804d-0716a77294ad.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player casts a white spell, you may gain 1 life.",
             "colours": [],
@@ -6898,7 +6898,7 @@
         },
         {
             "id": "4f9b7d35-b5b2-5db9-997b-e2260a1631a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f77859-c92c-4851-9bab-9232d8b74cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f77859-c92c-4851-9bab-9232d8b74cdb.jpg?1",
             "name": "Coat of Arms",
             "text": "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it. (For example, if two Goblin Warriors and a Goblin Shaman are on the battlefield, each gets +2/+2.)",
             "colours": [],
@@ -6926,7 +6926,7 @@
         },
         {
             "id": "da3b69cd-a7d6-574a-ae85-04f1b145290f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3aa1ce-8757-4541-8ac7-1e7e203b60fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3aa1ce-8757-4541-8ac7-1e7e203b60fc.jpg?1",
             "name": "Darksteel Colossus",
             "text": "Trample\nDarksteel Colossus is indestructible.\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "ba1fe1fb-6283-5285-b747-f0cd0b580d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daa7d29-b506-4576-9b0e-5897ab39c407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daa7d29-b506-4576-9b0e-5897ab39c407.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player casts a black spell, you may gain 1 life.",
             "colours": [],
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "42275ba6-770a-5eeb-935c-04801eeb9717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a08fdeb-c4ef-4602-b250-843cacf0fd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a08fdeb-c4ef-4602-b250-843cacf0fd6c.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player casts a red spell, you may gain 1 life.",
             "colours": [],
@@ -7013,7 +7013,7 @@
         },
         {
             "id": "6c4472b7-9280-55d1-ac7d-5fa1d108f07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc48cb-79aa-4e28-a736-ae9e4e2bc97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc48cb-79aa-4e28-a736-ae9e4e2bc97b.jpg?1",
             "name": "Gorgon Flail",
             "text": "Equipped creature gets +1/+1 and has deathtouch. (Creatures dealt damage by this creature are destroyed. You can divide its combat damage among any of the creatures blocking or blocked by it.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7043,7 +7043,7 @@
         },
         {
             "id": "4ab19fef-94be-5f65-9dd3-b5ffdcd46cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87c9191-1408-4aca-9061-bfb5b101c3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87c9191-1408-4aca-9061-bfb5b101c3ad.jpg?1",
             "name": "Howling Mine",
             "text": "At the beginning of each player's draw step, if Howling Mine is untapped, that player draws an additional card.",
             "colours": [],
@@ -7071,7 +7071,7 @@
         },
         {
             "id": "917ea779-fa63-565b-abca-000a359948bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c7c977-71bf-4554-a485-92e8fdef6b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c7c977-71bf-4554-a485-92e8fdef6b75.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player casts a blue spell, you may gain 1 life.",
             "colours": [],
@@ -7099,7 +7099,7 @@
         },
         {
             "id": "8bc06a62-a777-50d2-838f-79abdd6bbc79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b0f586-a100-4817-93f8-1ee2df39ce03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b0f586-a100-4817-93f8-1ee2df39ce03.jpg?1",
             "name": "Magebane Armor",
             "text": "Equipped creature gets +2/+4 and loses flying.\nPrevent all noncombat damage that would be dealt to equipped creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "8fe5e10f-c2af-5ed9-a6ea-059d7c05928e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b480c8-d899-4e63-b0e2-f4bec3a3ca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b480c8-d899-4e63-b0e2-f4bec3a3ca4f.jpg?1",
             "name": "Mirror of Fate",
             "text": "{T}, Sacrifice Mirror of Fate: Choose up to seven face-up exiled cards you own. Exile all the cards from your library, then put the chosen cards on top of your library.",
             "colours": [],
@@ -7157,7 +7157,7 @@
         },
         {
             "id": "82050b2c-0441-547f-9a73-91201e5c3344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb9825-ad45-44ad-ace2-eb6b66e3f724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bb9825-ad45-44ad-ace2-eb6b66e3f724.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "5a7b33fd-cd85-57c7-b152-a843a40626f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c300dcb0-1909-47d8-9818-46b2763d2bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c300dcb0-1909-47d8-9818-46b2763d2bf9.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, name a card.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "2e0d9f53-1630-5607-9eee-b42cccc2ffb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b782865-b9d1-41ed-8a7b-a36c17022190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b782865-b9d1-41ed-8a7b-a36c17022190.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -7247,7 +7247,7 @@
         },
         {
             "id": "21321545-1de6-55e5-a6bf-b816e7e0ef6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70120666-d5c7-4c9a-81b1-7a148fba235a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70120666-d5c7-4c9a-81b1-7a148fba235a.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "658aadfa-bea3-5f6b-8480-b8a5f22a1a2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f4d2b1-31d7-40d8-bd4e-cdd128076d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f4d2b1-31d7-40d8-bd4e-cdd128076d0f.jpg?1",
             "name": "Spellbook",
             "text": "You have no maximum hand size.",
             "colours": [],
@@ -7303,7 +7303,7 @@
         },
         {
             "id": "3fa060f2-18e7-5a88-8bc2-2ec5ca126c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9465c-cea2-491f-a6d6-9022cb3e969d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb9465c-cea2-491f-a6d6-9022cb3e969d.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable.\nEquipped creature has shroud. (It can't be the target of spells or abilities.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7333,7 +7333,7 @@
         },
         {
             "id": "7037a1a7-2e93-5e49-8b26-706735c38380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4263068-b440-4d43-8f24-014bbe392297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4263068-b440-4d43-8f24-014bbe392297.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player casts a green spell, you may gain 1 life.",
             "colours": [],
@@ -7361,7 +7361,7 @@
         },
         {
             "id": "23970d59-9553-50c9-93d1-fc436712b303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4998db-13c0-412f-b02c-9f041cc45c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d4998db-13c0-412f-b02c-9f041cc45c7e.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "39e8d864-5e11-5f35-bff3-f421cd7585d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6e950-38dd-46da-a1c3-58dc7495a9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc6e950-38dd-46da-a1c3-58dc7495a9f9.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7423,7 +7423,7 @@
         },
         {
             "id": "c52aabb8-1286-577e-940c-16cbe7794f64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab512e43-894e-40af-ab8a-f33f258dd885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab512e43-894e-40af-ab8a-f33f258dd885.jpg?1",
             "name": "Gargoyle Castle",
             "text": "{T}: Add {1} to your mana pool.\n{5}, {T}, Sacrifice Gargoyle Castle: Put a 3/4 colorless Gargoyle artifact creature token with flying onto the battlefield.",
             "colours": [],
@@ -7451,7 +7451,7 @@
         },
         {
             "id": "bd7704f8-45fd-516f-ad78-d30aeab9d2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee834e27-595d-4d12-8e69-e94e84ef337a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee834e27-595d-4d12-8e69-e94e84ef337a.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "f91dcb5e-5589-5cf7-b200-47b55785b6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5433b11b-efe9-4d94-8f71-6bf7c403494d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5433b11b-efe9-4d94-8f71-6bf7c403494d.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "8bd4c455-5f70-5b7d-bc2a-1498f05a42c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4e8ead-8c82-4258-bc59-551f7a74e042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4e8ead-8c82-4258-bc59-551f7a74e042.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "90861881-6202-53a5-8cb3-8c9d6665ffe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61902bad-c322-406d-aa4d-039efd4aa84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61902bad-c322-406d-aa4d-039efd4aa84f.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7572,7 +7572,7 @@
         },
         {
             "id": "7c16125e-5d53-5128-b247-332eaf1cbf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc084e24-22fe-4326-b894-54d79fbeba2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc084e24-22fe-4326-b894-54d79fbeba2f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "211beb57-789c-548d-9859-687e14f63cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322a6bc1-bb77-4913-a0b9-ac77316b30b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322a6bc1-bb77-4913-a0b9-ac77316b30b0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7648,7 +7648,7 @@
         },
         {
             "id": "24637d9d-d03b-5856-ba8b-f7148f73c0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f8793-83ed-437a-b06c-aec97205664b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f8793-83ed-437a-b06c-aec97205664b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "de9e1c22-6d3d-5be1-b1e0-6a5e53136011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851fac7-4f6e-4bba-928a-6485223ce1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851fac7-4f6e-4bba-928a-6485223ce1c8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "ba3e3cf3-9d8d-58ff-b918-a1a14c0b15dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172bb1b6-08c3-4ffd-b26d-b1c77dba06c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/172bb1b6-08c3-4ffd-b26d-b1c77dba06c3.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7762,7 +7762,7 @@
         },
         {
             "id": "3d3b727b-5348-54d8-993c-37ade48b2c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79df5b20-9e04-4b71-b39a-3142306719f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79df5b20-9e04-4b71-b39a-3142306719f9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "dc6314d3-b6d9-5df0-84de-68c91274c47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0bc4a-75a8-463b-9e96-a8607fc93102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0bc4a-75a8-463b-9e96-a8607fc93102.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "459b552b-3ae1-5f8c-9f1f-94b96796f473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855eabf3-1113-410c-b30c-41a94456e408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855eabf3-1113-410c-b30c-41a94456e408.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "25744d64-6be3-574d-8195-9b7db21491c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc185cc-5b8e-43ea-aa75-94ddffb74ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc185cc-5b8e-43ea-aa75-94ddffb74ad0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7914,7 +7914,7 @@
         },
         {
             "id": "71de0af5-9eb4-513a-b9a4-7eed66113cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef713de6-daf5-45e4-b23b-19bfd6edce36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef713de6-daf5-45e4-b23b-19bfd6edce36.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7952,7 +7952,7 @@
         },
         {
             "id": "70e838c5-7630-54cc-ba2e-6d1eda03f974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62050e5d-50b3-4c4d-b8c7-b85ff20c4d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62050e5d-50b3-4c4d-b8c7-b85ff20c4d71.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "d72f366e-8304-5362-b703-59c9834ce3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2326267f-2412-4217-af73-f5392167a3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2326267f-2412-4217-af73-f5392167a3a6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "556b8683-c9f7-5c8a-9125-2a7664b6bf29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed783a0c-ba7c-48f4-aac6-ad93a02bce6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed783a0c-ba7c-48f4-aac6-ad93a02bce6b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8066,7 +8066,7 @@
         },
         {
             "id": "0a563b17-89a3-52c6-84e2-440b42250e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64729d4b-991f-45d0-aaef-4ab26746c57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64729d4b-991f-45d0-aaef-4ab26746c57e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8104,7 +8104,7 @@
         },
         {
             "id": "7d274f8d-c862-518f-8bed-b0b5ab0ecce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcd666-7724-4c55-975e-20cfa759bba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fcd666-7724-4c55-975e-20cfa759bba7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "b59630e9-9622-5549-9185-f350a1d623aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f4c3f-60f2-4f68-92e1-88fee822bb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f4c3f-60f2-4f68-92e1-88fee822bb9a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "fc60a059-9c0a-56d6-83f9-f82260a0f85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394d804-c0e5-4901-a8ff-c1a765cc1e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394d804-c0e5-4901-a8ff-c1a765cc1e21.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "9b1a6e1f-2603-53ad-a9e6-df0e2a910afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7ba3a-0269-4a4b-8833-7e9e5f66013a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7ba3a-0269-4a4b-8833-7e9e5f66013a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8256,7 +8256,7 @@
         },
         {
             "id": "0473e4ac-5512-59b5-bf80-55103cd19f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3156ba12-cf21-48a5-aa08-74b447cafc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3156ba12-cf21-48a5-aa08-74b447cafc2c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "c7ac9b0f-0e5a-5614-9072-9dcc3d682b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb0e22-1e19-46e0-913e-94ccbf858bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb0e22-1e19-46e0-913e-94ccbf858bb9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8332,7 +8332,7 @@
         },
         {
             "id": "de0a2314-9c8f-52b1-bc5d-861615617700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160c268c-db2f-4105-8f40-0237b59ed333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160c268c-db2f-4105-8f40-0237b59ed333.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -8366,7 +8366,7 @@
         },
         {
             "id": "e76457ac-b6a8-5b90-96ee-68e2cd0a0fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccd622-264e-4867-b34b-324c94861241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dccd622-264e-4867-b34b-324c94861241.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8400,7 +8400,7 @@
         },
         {
             "id": "e2105da3-cad2-5005-b379-a532c03a8be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd51a6b5-1165-4df6-a30d-d46c729633f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd51a6b5-1165-4df6-a30d-d46c729633f7.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "c9d2973b-9b6e-5361-8bfc-ccb0114dc5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8cdaea-32da-4c18-bcd0-18bbbda54afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8cdaea-32da-4c18-bcd0-18bbbda54afb.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "99f7302e-21e5-543e-87bb-2c892b39d59e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b935437-e097-466b-a9d5-6dc0dc6a10f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b935437-e097-466b-a9d5-6dc0dc6a10f3.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "9a0f9606-cc9a-58c5-8c6f-7e0e03b7bea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67563770-a392-4f69-b93b-6029da639993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67563770-a392-4f69-b93b-6029da639993.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8536,7 +8536,7 @@
         },
         {
             "id": "d6503523-02c8-5086-a1b8-a7e18e8b68b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f63920d-18a0-4267-bb4e-a972ba86067d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f63920d-18a0-4267-bb4e-a972ba86067d.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "52ec8ec9-e235-5394-bd62-30a3b3c0dfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3aa149-00fa-4932-b004-f64c8b5d3ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3aa149-00fa-4932-b004-f64c8b5d3ca7.jpg?1",
             "name": "Gargoyle",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M11.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M11.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "363df90f-8afd-591d-93d8-2ef7a54bd3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d911053-a026-4b20-ba2d-dbcc367c1413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d911053-a026-4b20-ba2d-dbcc367c1413.jpg?1",
             "name": "Ajani Goldmane",
             "text": "+1: You gain 2 life.\n-1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n-6: Put a white Avatar creature token onto the battlefield. It has \"This creature's power and toughness are each equal to your life total.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "94f01d0d-0873-54d3-bacb-edbfda494b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b1057-ed1f-45a5-ba95-28aa51713764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089b1057-ed1f-45a5-ba95-28aa51713764.jpg?1",
             "name": "Ajani's Mantra",
             "text": "At the beginning of your upkeep, you may gain 1 life.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "bc217875-3352-5f5b-a4da-0c6246496392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70d1452-6b61-4c63-841f-4256ac498e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70d1452-6b61-4c63-841f-4256ac498e9f.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate. (For example, if an effect causes you to gain 3 life, you may put one +1/+1 counter on this creature.)",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "c0c301a3-5f80-5dcc-8fd3-4855e6496cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f05793-9e6f-4815-9a13-f791cb4b6aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f05793-9e6f-4815-9a13-f791cb4b6aa0.jpg?1",
             "name": "Angelic Arbiter",
             "text": "Flying\nEach opponent who cast a spell this turn can't attack with creatures.\nEach opponent who attacked with a creature this turn can't cast spells.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "314a4d68-44e6-5af0-ae28-8d81cfb983f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5647c21e-5926-462c-8b01-862f8cedf777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5647c21e-5926-462c-8b01-862f8cedf777.jpg?1",
             "name": "Armored Ascension",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "0b95bc00-6f00-5ce9-86db-2a55b71950fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ced22-1f2c-4fa6-a938-8ebe2c15cc8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72ced22-1f2c-4fa6-a938-8ebe2c15cc8d.jpg?1",
             "name": "Assault Griffin",
             "text": "Flying",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "4a72458c-029e-55eb-ac85-2e0a417fd5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff70c4ff-a241-4333-bd8f-9f0ed5a0333b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff70c4ff-a241-4333-bd8f-9f0ed5a0333b.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "a7aa509c-a77e-57bd-99f2-166de00aefc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2468c21b-d041-4e26-91cf-d53850e2a57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2468c21b-d041-4e26-91cf-d53850e2a57e.jpg?1",
             "name": "Blinding Mage",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "e69f6e07-4a03-573e-8ef7-319d729386fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ffb67-0454-48b1-8043-e7f8fb12bb54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ffb67-0454-48b1-8043-e7f8fb12bb54.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "b89859b8-4c0b-582e-b53a-0b8cc8be6a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce09da-6c1d-46ac-870e-ff58ceaba116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ce09da-6c1d-46ac-870e-ff58ceaba116.jpg?1",
             "name": "Cloud Crusader",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "f93b369c-925e-5214-b173-834a883e3d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfae21b5-aff2-4191-aa42-d756209beaaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfae21b5-aff2-4191-aa42-d756209beaaa.jpg?1",
             "name": "Condemn",
             "text": "Put target attacking creature on the bottom of its owner's library. Its controller gains life equal to its toughness.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "418cb111-b51d-5cca-8378-606c0d1705b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f6b25f-d11c-483a-a3e9-6b801d333482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f6b25f-d11c-483a-a3e9-6b801d333482.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "8937b089-91f9-5223-a7f5-f46f69bf07ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8969be61-afed-4483-902f-739acf57c43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8969be61-afed-4483-902f-739acf57c43c.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "cac58d74-5a05-5ede-880e-7b9056649be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec6e3f-bc90-4e21-a087-330f7e072fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec6e3f-bc90-4e21-a087-330f7e072fc6.jpg?1",
             "name": "Excommunicate",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "5b742f8c-540d-56f5-90b4-6d7fb591f89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6e31cb-98c5-4145-bdef-666f3cea7eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6e31cb-98c5-4145-bdef-666f3cea7eab.jpg?1",
             "name": "Goldenglow Moth",
             "text": "Flying\nWhenever Goldenglow Moth blocks, you may gain 4 life.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "6b3975b7-fd61-55b2-9428-a6e3ac38c1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0987b8-755e-42f1-bd6d-1401fecd4171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0987b8-755e-42f1-bd6d-1401fecd4171.jpg?1",
             "name": "Holy Strength",
             "text": "Enchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "a02fbbcc-04ca-5d5a-8886-f393a4500f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3831cb3b-0983-403b-9e0a-4720222817c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3831cb3b-0983-403b-9e0a-4720222817c4.jpg?1",
             "name": "Honor of the Pure",
             "text": "White creatures you control get +1/+1.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "384085b2-f6c2-5791-aa03-748de6c444f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12ec710-23f4-4ce6-90e1-272981a20c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12ec710-23f4-4ce6-90e1-272981a20c3d.jpg?1",
             "name": "Infantry Veteran",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "95878850-cc78-5648-9b33-48301dd90ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98151986-90de-4f76-9abd-507039e7c9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98151986-90de-4f76-9abd-507039e7c9ad.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "80d75282-1408-5037-8b67-12f7c237905e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7da2c3-95d7-464f-af3d-fd891fd148f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7da2c3-95d7-464f-af3d-fd891fd148f1.jpg?1",
             "name": "Knight Exemplar",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nOther Knight creatures you control get +1/+1 and are indestructible. (Lethal damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "8ddc1a9c-8837-5463-9cf4-0e978bd3a42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262de9ae-d641-4f0e-af6a-03ce0e1c91d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262de9ae-d641-4f0e-af6a-03ce0e1c91d3.jpg?1",
             "name": "Leyline of Sanctity",
             "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "a0fe6fa6-5583-5acb-a729-a3443a6af909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8e0f93-a450-4188-a735-d601a59ab108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8e0f93-a450-4188-a735-d601a59ab108.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "c5be10a6-df7d-5e4d-8f19-83cf4cea4590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0efc23-9284-4aa4-a0ed-1f1dfdce4cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0efc23-9284-4aa4-a0ed-1f1dfdce4cbb.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "ccd09e02-52c5-5bcd-b5bb-efd19f511096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e73c28-bf82-413e-bec2-adbb52fa6993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e73c28-bf82-413e-bec2-adbb52fa6993.jpg?1",
             "name": "Palace Guard",
             "text": "Palace Guard can block any number of creatures.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "c13b3024-19a6-5df5-b2c8-38c152423646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dca2c1f-3835-478b-860c-51b2036221b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dca2c1f-3835-478b-860c-51b2036221b2.jpg?1",
             "name": "Roc Egg",
             "text": "Defender (This creature can't attack.)\nWhen Roc Egg is put into a graveyard from the battlefield, put a 3/3 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "331c1332-47f8-5b62-acbc-22be289dd8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453aab0-5e11-4fac-af69-e7950c486d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d453aab0-5e11-4fac-af69-e7950c486d30.jpg?1",
             "name": "Safe Passage",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "978152f6-a91e-59da-948d-8b947fa366e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c53890f-8cf2-42ad-8b5f-66badc99630c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c53890f-8cf2-42ad-8b5f-66badc99630c.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "2df85154-4e40-5310-b3d4-7f350715bef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee65b44-eeb6-418b-b022-a0aef587c738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee65b44-eeb6-418b-b022-a0aef587c738.jpg?1",
             "name": "Serra Ascendant",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nAs long as you have 30 or more life, Serra Ascendant gets +5/+5 and has flying.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "71a75452-9503-5b4d-8f8d-a96e08f99f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d7ce0-866a-43eb-939e-3287ff00234d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296d7ce0-866a-43eb-939e-3287ff00234d.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "21fd8fd5-46af-591f-80c0-7b2539626a6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b70d17-e4ec-4731-8892-b444f82be7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b70d17-e4ec-4731-8892-b444f82be7a2.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn. (Spells cast before this resolves are unaffected.)",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "3dc27c84-e2a9-5481-84ec-8600bada94fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37523d3-7719-48e1-9b3e-2670772a509b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37523d3-7719-48e1-9b3e-2670772a509b.jpg?1",
             "name": "Silvercoat Lion",
             "text": "",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "2e4da88b-a65c-5fce-aac6-eb6ef43768ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d6d379-b991-48da-a6b3-a4a38931057c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d6d379-b991-48da-a6b3-a4a38931057c.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "a080e4b7-ed91-545f-a29c-d10d318d09e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beddd409-0154-45a5-a20d-833cf1b5e1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beddd409-0154-45a5-a20d-833cf1b5e1f4.jpg?1",
             "name": "Squadron Hawk",
             "text": "Flying\nWhen Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "fe048d76-fe3e-55e8-8a1b-ec3ba856898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dac80a-96ae-489a-8600-97d767ab78f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dac80a-96ae-489a-8600-97d767ab78f8.jpg?1",
             "name": "Stormfront Pegasus",
             "text": "Flying",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "f47b334b-7219-56f6-ada7-da65357b3243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8db2b8e-dce9-49b7-833f-381ee55288cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8db2b8e-dce9-49b7-833f-381ee55288cb.jpg?1",
             "name": "Sun Titan",
             "text": "Vigilance\nWhenever Sun Titan enters the battlefield or attacks, you may return target permanent card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "c6375ab0-a2b3-5770-a70e-cce2da6d60a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc42fe32-5f02-472c-a25e-d03e01546dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc42fe32-5f02-472c-a25e-d03e01546dc6.jpg?1",
             "name": "Tireless Missionaries",
             "text": "When Tireless Missionaries enters the battlefield, you gain 3 life.",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "58b90772-d07c-5dae-a0dd-ad8906b785e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a505d07f-61cf-4b00-a1d5-028747899eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a505d07f-61cf-4b00-a1d5-028747899eaa.jpg?1",
             "name": "Vengeful Archon",
             "text": "Flying\n{X}: Prevent the next X damage that would be dealt to you this turn. If damage is prevented this way, Vengeful Archon deals that much damage to target player.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "8c705ae2-1e5d-5c2d-86e2-c3b52871bd4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7d96db-109d-498e-ae10-1430718c33da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7d96db-109d-498e-ae10-1430718c33da.jpg?1",
             "name": "War Priest of Thune",
             "text": "When War Priest of Thune enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "c3bb8505-60ca-5594-aef1-98ee868c1864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a02b6-2c33-40d8-ad97-39b192d7e82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07a02b6-2c33-40d8-ad97-39b192d7e82d.jpg?1",
             "name": "White Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black.)",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "44346ca7-31ce-57a3-93a0-7b26983478d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35bfacf-b1a0-4c5a-9131-412682d483e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35bfacf-b1a0-4c5a-9131-412682d483e5.jpg?1",
             "name": "Wild Griffin",
             "text": "Flying",
             "colours": [
@@ -1354,7 +1354,7 @@
         },
         {
             "id": "7e1b3092-f8df-5b14-ac0d-768d535c4ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b551dab-1a81-406d-b708-b3b7300eb02e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b551dab-1a81-406d-b708-b3b7300eb02e.jpg?1",
             "name": "Aether Adept",
             "text": "When \u00c6ther Adept enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "c98835b2-a82c-5918-9a89-2555c0bc2992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f46eb67-a50d-4910-9919-1bb2ca1c0dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f46eb67-a50d-4910-9919-1bb2ca1c0dad.jpg?1",
             "name": "Air Servant",
             "text": "Flying\n{2}{U}: Tap target creature with flying.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "6637fa24-a893-57ee-9ffd-3d69ea426e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea89d38-765d-4902-b985-bcc15363c4f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea89d38-765d-4902-b985-bcc15363c4f2.jpg?1",
             "name": "Alluring Siren",
             "text": "{T}: Target creature an opponent controls attacks you this turn if able.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "b133e8fb-e72f-5139-b19d-1d76de3c1122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ef0757-8eb0-4384-bf8e-9a7340144dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ef0757-8eb0-4384-bf8e-9a7340144dfa.jpg?1",
             "name": "Armored Cancrix",
             "text": "",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "f1582c7d-1596-52ef-a957-72bfe931f02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8b752-086c-4d7c-a0a2-e359819c550e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8b752-086c-4d7c-a0a2-e359819c550e.jpg?1",
             "name": "Augury Owl",
             "text": "Flying\nWhen Augury Owl enters the battlefield, scry 3. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "e66d2587-c435-5479-9090-6efd93cf8780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6653bce7-b0fc-49e3-8f45-f0bfcade8870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6653bce7-b0fc-49e3-8f45-f0bfcade8870.jpg?1",
             "name": "Azure Drake",
             "text": "Flying",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "d4624ef7-9968-5fff-8365-af2f5c00fd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f570b1-e221-468c-a809-a79a56a51ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f570b1-e221-468c-a809-a79a56a51ced.jpg?1",
             "name": "Call to Mind",
             "text": "Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "4ed9ef6e-f132-5c70-bc02-d4d980651a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6932af-c7e7-49e9-963e-97e680a53da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a6932af-c7e7-49e9-963e-97e680a53da5.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "b16759df-8be3-59f9-b159-6d23ff9eafa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf51d88c-f7a4-4f82-ab2b-f2871abd7d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf51d88c-f7a4-4f82-ab2b-f2871abd7d5b.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "858033e1-41c6-581c-a936-60e4a88a71e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb738b9-231c-47e1-980d-1cc1fb71c2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb738b9-231c-47e1-980d-1cc1fb71c2f5.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "cb54ef2d-a10e-5124-9fc5-1b52405d4373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa1afb9-a2e5-44a1-b2f1-9de75efbbe93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa1afb9-a2e5-44a1-b2f1-9de75efbbe93.jpg?1",
             "name": "Conundrum Sphinx",
             "text": "Flying\nWhenever Conundrum Sphinx attacks, each player names a card. Then each player reveals the top card of his or her library. If the card a player revealed is the card he or she named, that player puts it into his or her hand. If it's not, that player puts it on the bottom of his or her library.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "c44db315-feb5-5d80-a603-830228051222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a8e4c-2bcf-4302-bef8-f126fe865f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a8e4c-2bcf-4302-bef8-f126fe865f08.jpg?1",
             "name": "Diminish",
             "text": "Target creature becomes 1/1 until end of turn.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "e95df514-73a6-5eba-b3d7-8fc092e6e583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc68a06-9d79-4be8-b4ce-ecd4d0e4ce29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc68a06-9d79-4be8-b4ce-ecd4d0e4ce29.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "3f4a82af-ee5c-5b12-b41e-2985140e8a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d7b86-5ea5-42a3-91b6-0b09db06756c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d7b86-5ea5-42a3-91b6-0b09db06756c.jpg?1",
             "name": "Foresee",
             "text": "Scry 4, then draw two cards. (To scry 4, look at the top four cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "c2a53fb7-3b8f-5065-960d-3220a02a2b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065addc8-c235-43cc-a54f-b582826e5df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065addc8-c235-43cc-a54f-b582826e5df1.jpg?1",
             "name": "Frost Titan",
             "text": "Whenever Frost Titan becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.\nWhenever Frost Titan enters the battlefield or attacks, tap target permanent. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "6624a3aa-9ef2-5004-8114-2ccb9d0a8b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa10b43f-eb63-4999-92a0-56826031b686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa10b43f-eb63-4999-92a0-56826031b686.jpg?1",
             "name": "Harbor Serpent",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "acbadbff-ca1b-5366-817b-31df270fe9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ad7d1-bdac-4409-87a2-58149bb58b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ad7d1-bdac-4409-87a2-58149bb58b0a.jpg?1",
             "name": "Ice Cage",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.",
             "colours": [
@@ -1923,7 +1923,7 @@
         },
         {
             "id": "db0f8a07-b20b-59aa-b72d-c44bd63539eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441af393-2f70-4765-ae95-730c1e1d864f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/441af393-2f70-4765-ae95-730c1e1d864f.jpg?1",
             "name": "Jace Beleren",
             "text": "+2: Each player draws a card.\n-1: Target player draws a card.\n-10: Target player puts the top twenty cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "2fdf6cc7-86a7-5901-81d9-179fc225f93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3662d1cc-1279-409f-9f0a-9c15c3407103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3662d1cc-1279-409f-9f0a-9c15c3407103.jpg?1",
             "name": "Jace's Erasure",
             "text": "Whenever you draw a card, you may have target player put the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "9c372b6d-e95e-50db-945e-ed69a4064ff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79bea30-3210-4944-b146-3624c9869f45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b79bea30-3210-4944-b146-3624c9869f45.jpg?1",
             "name": "Jace's Ingenuity",
             "text": "Draw three cards.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "fca30af1-0998-51ea-b5f4-25992720df8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb092-3bb0-445e-ab26-d939cac92a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbb092-3bb0-445e-ab26-d939cac92a73.jpg?1",
             "name": "Leyline of Anticipation",
             "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast nonland cards as though they had flash. (You may cast them any time you could cast an instant.)",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "0f1200f6-0f74-5c79-af79-8d8cf2414a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c7757d-8036-4b33-a1cb-07795d392588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c7757d-8036-4b33-a1cb-07795d392588.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "a6363ae6-5f84-5a09-a46c-a32914b90961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f365d82a-88a3-403b-92a6-91c9ccb3421f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f365d82a-88a3-403b-92a6-91c9ccb3421f.jpg?1",
             "name": "Maritime Guard",
             "text": "",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "961df276-5517-5fda-9cd6-324cdf77ef5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ffe61f-e52e-4d62-854b-10ac9cfbadd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ffe61f-e52e-4d62-854b-10ac9cfbadd3.jpg?1",
             "name": "Mass Polymorph",
             "text": "Exile all creatures you control, then reveal cards from the top of your library until you reveal that many creature cards. Put all creature cards revealed this way onto the battlefield, then shuffle the rest of the revealed cards into your library.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "8fe60d34-ff7c-547a-a5b4-bfc8326aacba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed43af3c-1070-45d9-9de6-17d07a6ef3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed43af3c-1070-45d9-9de6-17d07a6ef3c0.jpg?1",
             "name": "Merfolk Sovereign",
             "text": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature is unblockable this turn.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "e5108e45-e202-505e-9e3d-61cbb7302829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ae05cc-116b-4268-ba78-709aeff36ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ae05cc-116b-4268-ba78-709aeff36ab1.jpg?1",
             "name": "Merfolk Spy",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nWhenever Merfolk Spy deals combat damage to a player, that player reveals a card at random from his or her hand.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "78ec31cd-35eb-53fe-b775-e0f49c9020bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496f79d6-33ee-4e31-9601-2722b0bc9141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496f79d6-33ee-4e31-9601-2722b0bc9141.jpg?1",
             "name": "Mind Control",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "585f6835-bb38-5c39-85d8-a45f03e607fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae89bd67-3c72-449f-be72-d04bb7cca916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae89bd67-3c72-449f-be72-d04bb7cca916.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "e27ca6cd-994a-595e-b381-378fb153f595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572df99b-af44-4128-8b2c-e40b1cea816b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572df99b-af44-4128-8b2c-e40b1cea816b.jpg?1",
             "name": "Phantom Beast",
             "text": "When Phantom Beast becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "54c23a15-eecc-511c-b2b4-1c6c6ca6a22a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3868c3d-4fcd-444b-866f-0f8e50ce7b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3868c3d-4fcd-444b-866f-0f8e50ce7b67.jpg?1",
             "name": "Preordain",
             "text": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "594c6f5c-1431-5465-8d9b-8c3fe44667bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bae44b-c6f2-40bf-a427-aee5cfbdfea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bae44b-c6f2-40bf-a427-aee5cfbdfea9.jpg?1",
             "name": "Redirect",
             "text": "You may choose new targets for target spell.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "ee420d7c-391c-5336-bd50-4dd56acfc0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2808-58d9-4e27-a6c2-6db66191151e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b2808-58d9-4e27-a6c2-6db66191151e.jpg?1",
             "name": "Scroll Thief",
             "text": "Whenever Scroll Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "30b35b1d-3095-53c7-8575-3b875e378713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ba1c16-eeb2-405d-9f66-6de2f4354224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ba1c16-eeb2-405d-9f66-6de2f4354224.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "51e0ba71-b914-5012-9eb3-337b7643dc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7f3fb6-93ce-4bc9-8efd-11af5a46218f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e7f3fb6-93ce-4bc9-8efd-11af5a46218f.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "77930404-fe30-5e49-abb5-3aac3a02bf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1468c851-b20e-4c78-9fcb-45e60b7149db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1468c851-b20e-4c78-9fcb-45e60b7149db.jpg?1",
             "name": "Time Reversal",
             "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. Exile Time Reversal.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "73dac9ba-a085-5633-9c9b-ac89f636ae27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6445f013-8b50-4ea3-9013-df85289c2605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6445f013-8b50-4ea3-9013-df85289c2605.jpg?1",
             "name": "Tome Scour",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "2d6b8535-768e-5360-8922-c42499d69ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf943d-497a-4720-8be0-4bc2cd7642ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf943d-497a-4720-8be0-4bc2cd7642ee.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "5a30f463-92b4-57a8-8194-88c1b224392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10c195e-9b7e-423b-9629-544cceca1ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10c195e-9b7e-423b-9629-544cceca1ce9.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "c4e3aa94-9ab7-53a3-8496-f692118a5764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56229e1-904b-4761-bb7e-35a0c8202c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56229e1-904b-4761-bb7e-35a0c8202c2e.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "cce88633-4c1f-5d45-b518-23a5d0b28847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a3062e-8b83-4ee4-8139-8eee84df37fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a3062e-8b83-4ee4-8139-8eee84df37fe.jpg?1",
             "name": "Water Servant",
             "text": "{U}: Water Servant gets +1/-1 until end of turn.\n{U}: Water Servant gets -1/+1 until end of turn.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "26b6a7f3-481a-59bc-9027-bfc73437eb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eac7cb5-b9de-4c40-ab70-3084d8145f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eac7cb5-b9de-4c40-ab70-3084d8145f58.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "fccc7086-1ea4-57dc-90a7-e4ccb930575c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88583170-7b0e-4c02-b270-4859ba05d82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88583170-7b0e-4c02-b270-4859ba05d82b.jpg?1",
             "name": "Barony Vampire",
             "text": "",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "804be284-c4a8-509f-bd0f-1201ae67b049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c198d94-248c-4f81-b8d5-e1b5a0623ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c198d94-248c-4f81-b8d5-e1b5a0623ee7.jpg?1",
             "name": "Black Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nProtection from white (This creature can't be blocked, targeted, dealt damage, or enchanted by anything white.)",
             "colours": [
@@ -2787,7 +2787,7 @@
         },
         {
             "id": "2e49341d-df26-5541-b529-8fe05023544c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf166294-3359-4da4-84d0-006c75c183fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf166294-3359-4da4-84d0-006c75c183fd.jpg?1",
             "name": "Blood Tithe",
             "text": "Each opponent loses 3 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "37464cf9-33e6-5204-9674-1c3c6af1ed31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62f3371-8aa6-4fbf-b642-5ba6af219703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62f3371-8aa6-4fbf-b642-5ba6af219703.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "bc8eea77-d53b-5f1b-b712-565118c80955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a493521-810e-4932-bb44-16c80c3066c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a493521-810e-4932-bb44-16c80c3066c9.jpg?1",
             "name": "Bog Raiders",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "e71e4fba-3bc3-53b2-9481-f8d2b9826c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99b0735-cc3c-48dc-a7ad-b7d9eea45e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99b0735-cc3c-48dc-a7ad-b7d9eea45e54.jpg?1",
             "name": "Captivating Vampire",
             "text": "Other Vampire creatures you control get +1/+1.\nTap five untapped Vampires you control: Gain control of target creature. It becomes a Vampire in addition to its other types.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "0821bdfa-2f62-534f-8c40-0a94022848d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef351dcb-64c0-413a-81d3-38e7cd4a8f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef351dcb-64c0-413a-81d3-38e7cd4a8f78.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "511659fb-1e8c-5f49-9b9f-a47b21b36f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9938180e-31dc-45a1-a39a-dbaf12ad429b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9938180e-31dc-45a1-a39a-dbaf12ad429b.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of Swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "e3a4aa13-4a95-5355-b78c-f1f8e2055fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec3dd9f-3969-4fd7-97f7-e9868eb19a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec3dd9f-3969-4fd7-97f7-e9868eb19a64.jpg?1",
             "name": "Dark Tutelage",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "fe4dd6c4-2db7-5634-9ec6-5a7e0e01cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b32384-985b-484a-a96f-66b23f3d0208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b32384-985b-484a-a96f-66b23f3d0208.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "ab7cc67d-62ba-58e3-9c10-5c48cc7ad7ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fab4fc-c8de-47ef-a717-3adb58c2f5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fab4fc-c8de-47ef-a717-3adb58c2f5b6.jpg?1",
             "name": "Demon of Death's Gate",
             "text": "You may pay 6 life and sacrifice three black creatures rather than pay Demon of Death's Gate's mana cost.\nFlying, trample",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "19873706-58d9-5e80-a761-990ae016d720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98724907-0469-4016-87ff-02cbce8008fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98724907-0469-4016-87ff-02cbce8008fa.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "2aee8eaf-9bf5-59e1-9673-e53189d23b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5555c5-5d40-4976-ba77-54732108f120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5555c5-5d40-4976-ba77-54732108f120.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "6809dab7-fc80-5ce2-8d67-7307dbfe726f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a74bb-f158-4d0e-b840-222ecbf107d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a74bb-f158-4d0e-b840-222ecbf107d4.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "600f3784-9555-52c4-a194-05deb4b5e6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1445d6-ae16-492c-a378-d3aa5746c610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1445d6-ae16-492c-a378-d3aa5746c610.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "7fc293bb-36bb-541e-af68-191709e7ab93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa6d385-6b8e-45ad-83dc-b477799c05a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa6d385-6b8e-45ad-83dc-b477799c05a5.jpg?1",
             "name": "Grave Titan",
             "text": "Deathtouch\nWhenever Grave Titan enters the battlefield or attacks, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "791e1927-6d05-5566-b74d-a630b088ed4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ac2ce6-e5ca-44c8-bdb9-a53ed3303728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ac2ce6-e5ca-44c8-bdb9-a53ed3303728.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3281,7 +3281,7 @@
         },
         {
             "id": "c6f5717c-1c2e-5a1c-a726-460f2f2423fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96bc7-b92f-4df5-89b5-0793b9e56509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96bc7-b92f-4df5-89b5-0793b9e56509.jpg?1",
             "name": "Haunting Echoes",
             "text": "Exile all cards from target player's graveyard other than basic land cards. For each card exiled this way, search that player's library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "eb8a4e62-b6d2-517c-8e02-7750e08f1828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d40f1e-bb2f-4de2-8481-c11eb5130fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d40f1e-bb2f-4de2-8481-c11eb5130fa1.jpg?1",
             "name": "Howling Banshee",
             "text": "Flying\nWhen Howling Banshee enters the battlefield, each player loses 3 life.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "fa96b65b-ff97-5d63-857a-956877b25a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e012d4f3-c387-4910-981b-7532fd355296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e012d4f3-c387-4910-981b-7532fd355296.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3379,7 +3379,7 @@
         },
         {
             "id": "38bdf961-78b7-5c35-bb7e-72f25a1aede8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a15e31c-b208-4a52-b450-c058a75da9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a15e31c-b208-4a52-b450-c058a75da9f7.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n-2: Search your library for a card, then shuffle your library and put that card on top of it.\n-8: Put all creature cards in all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "be1f42be-a15f-575c-956a-0085dac1e877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d995382-57a6-40a4-9050-31f57cb8dae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d995382-57a6-40a4-9050-31f57cb8dae3.jpg?1",
             "name": "Liliana's Caress",
             "text": "Whenever an opponent discards a card, that player loses 2 life.",
             "colours": [
@@ -3447,7 +3447,7 @@
         },
         {
             "id": "9a010952-8cef-5359-b857-180658f14b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33122581-39fd-44a0-b928-f73e39a0c0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33122581-39fd-44a0-b928-f73e39a0c0f1.jpg?1",
             "name": "Liliana's Specter",
             "text": "Flying\nWhen Liliana's Specter enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "b22a680d-50f0-5b54-a94e-a7634cf1cead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e117056-030a-4ec6-a669-dbe6c7ccb840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e117056-030a-4ec6-a669-dbe6c7ccb840.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3513,7 +3513,7 @@
         },
         {
             "id": "a5439c8f-3f03-543f-b315-1283fc10a38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd01bab0-3241-4ebb-a378-f88cbdf16dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd01bab0-3241-4ebb-a378-f88cbdf16dc3.jpg?1",
             "name": "Nantuko Shade",
             "text": "{B}: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3548,7 +3548,7 @@
         },
         {
             "id": "b8d8dd0f-f391-50a6-a92e-55360b4fe501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7573a8-be2b-46a5-8862-db0980968088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7573a8-be2b-46a5-8862-db0980968088.jpg?1",
             "name": "Necrotic Plague",
             "text": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, sacrifice this creature.\"\nWhen enchanted creature is put into a graveyard, its controller chooses target creature one of his or her opponents controls. Return Necrotic Plague from its owner's graveyard to the battlefield attached to that creature.",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "f528946b-f957-5f04-b915-cf01946f4d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c217b672-c724-4fc2-936c-b3f0feaf6ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c217b672-c724-4fc2-936c-b3f0feaf6ea0.jpg?1",
             "name": "Nether Horror",
             "text": "",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "0f402ac4-bbd0-584f-92fa-7693f078befd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6232c3-f840-450a-8583-540aec0f17ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6232c3-f840-450a-8583-540aec0f17ed.jpg?1",
             "name": "Nightwing Shade",
             "text": "Flying\n{1}{B}: Nightwing Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3650,7 +3650,7 @@
         },
         {
             "id": "f9bcdb8f-d8b1-537d-904a-f6fd69016cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d088983-92c1-4f4d-8abf-dd20347495b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d088983-92c1-4f4d-8abf-dd20347495b5.jpg?1",
             "name": "Phylactery Lich",
             "text": "As Phylactery Lich enters the battlefield, put a phylactery counter on an artifact you control.\nPhylactery Lich is indestructible.\nWhen you control no permanents with phylactery counters on them, sacrifice Phylactery Lich.",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "a47127a6-c21b-520d-9ed8-14bf98eb1801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d56d13-b9de-44db-b235-4f7eea60f424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d56d13-b9de-44db-b235-4f7eea60f424.jpg?1",
             "name": "Quag Sickness",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 for each Swamp you control.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "acab6598-fe55-5cd9-959c-38dbd4adc3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ec6120-2de0-4166-be85-2d773fa7ebbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ec6120-2de0-4166-be85-2d773fa7ebbb.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "f671a4ab-379c-58a7-9962-01d3a1629a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f873c62a-7efc-40d8-8c0a-55e9a94847b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f873c62a-7efc-40d8-8c0a-55e9a94847b8.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -3787,7 +3787,7 @@
         },
         {
             "id": "6e5facba-4b8b-557e-9ba4-7c72c576a88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee3e6f2-a87f-415a-96f3-b72fa6f3eb07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee3e6f2-a87f-415a-96f3-b72fa6f3eb07.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card in a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "5f9fe2a1-9b95-5f1f-b6a6-cec4a31d4382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe5e62c-83ce-4c2b-a745-acd7670e115d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe5e62c-83ce-4c2b-a745-acd7670e115d.jpg?1",
             "name": "Rotting Legion",
             "text": "Rotting Legion enters the battlefield tapped.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "e1c550ad-b039-5d35-b4ec-bac7b6a6e5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0094664-9f03-414b-a890-6f535a1927ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0094664-9f03-414b-a890-6f535a1927ad.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3888,7 +3888,7 @@
         },
         {
             "id": "2429d1cb-a321-5f9e-8769-9c7e3ae7a508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705ee27-9725-42ee-8d3b-481cdb8c9250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3705ee27-9725-42ee-8d3b-481cdb8c9250.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "ef4c8a1e-8c48-5fa7-af4b-2eee5241970b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c31d9d-fd77-4275-b89c-f9b64073c54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c31d9d-fd77-4275-b89c-f9b64073c54b.jpg?1",
             "name": "Stabbing Pain",
             "text": "Target creature gets -1/-1 until end of turn. Tap that creature.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "5107689d-417b-5eab-bd26-6b5fb370eb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521652cf-96f7-46a6-9b25-3e988b605a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521652cf-96f7-46a6-9b25-3e988b605a10.jpg?1",
             "name": "Unholy Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+1.",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "9c3e9c3d-98a5-5983-94cf-2ff004a620cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179f847-e334-4f7f-9a4e-0013942a394f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179f847-e334-4f7f-9a4e-0013942a394f.jpg?1",
             "name": "Viscera Seer",
             "text": "Sacrifice a creature: Scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "f309f50d-6c31-58de-aab3-c177d5068ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64b7c8-d417-4162-8c27-5d3b16f2f381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64b7c8-d417-4162-8c27-5d3b16f2f381.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4053,7 +4053,7 @@
         },
         {
             "id": "5fe219fa-8a19-5b85-894a-fb57a7af85ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cede38-0f02-4ce0-b947-ce3d7d7c2882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cede38-0f02-4ce0-b947-ce3d7d7c2882.jpg?1",
             "name": "Ancient Hellkite",
             "text": "Flying\n{R}: Ancient Hellkite deals 1 damage to target creature defending player controls. Activate this ability only if Ancient Hellkite is attacking.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "9ccde4a0-4f8f-5ddf-a6b8-e416b389d1f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32014715-7faa-412a-b8b4-751102e6b8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32014715-7faa-412a-b8b4-751102e6b8a3.jpg?1",
             "name": "Arc Runner",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAt the beginning of the end step, sacrifice Arc Runner.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "2268b0d7-641d-54c7-8691-dd0b3f011b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033fce45-20d8-48cc-96d3-7f16c99da83d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033fce45-20d8-48cc-96d3-7f16c99da83d.jpg?1",
             "name": "Berserkers of Blood Ridge",
             "text": "Berserkers of Blood Ridge attacks each turn if able.",
             "colours": [
@@ -4157,7 +4157,7 @@
         },
         {
             "id": "e531d6cb-71cf-57ea-b4d1-e58cedd3d11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ec6fc4-efbf-4071-860e-ba244e27e2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ec6fc4-efbf-4071-860e-ba244e27e2d3.jpg?1",
             "name": "Bloodcrazed Goblin",
             "text": "Bloodcrazed Goblin can't attack unless an opponent has been dealt damage this turn.",
             "colours": [
@@ -4192,7 +4192,7 @@
         },
         {
             "id": "05d41b89-0bdb-5a56-8c0c-134336c4f5b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670dcc2-e8e3-4fd7-a1db-c3152b005d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b670dcc2-e8e3-4fd7-a1db-c3152b005d39.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "b1c879ae-3cfe-5778-97ea-7999d6f334df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44125d-28de-4ecf-a55b-1299daa5539e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac44125d-28de-4ecf-a55b-1299daa5539e.jpg?1",
             "name": "Chandra Nalaar",
             "text": "+1: Chandra Nalaar deals 1 damage to target player.\n-X: Chandra Nalaar deals X damage to target creature.\n-8: Chandra Nalaar deals 10 damage to target player and each creature he or she controls.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "29c7a4ed-4a85-5552-a71c-386e683fcf20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5111b5-4911-47f9-bea7-18c4550e167d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5111b5-4911-47f9-bea7-18c4550e167d.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "e52fa1ab-0c65-5455-9c81-c3cae5ba672e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a460bb-276f-45f7-b0da-8457eb3192eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a460bb-276f-45f7-b0da-8457eb3192eb.jpg?1",
             "name": "Chandra's Spitfire",
             "text": "Flying\nWhenever an opponent is dealt noncombat damage, Chandra's Spitfire gets +3/+0 until end of turn.",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "a720c4e1-a741-5298-bb45-8783663a533d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf23a422-25a7-4c8a-9cff-24563ec20ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf23a422-25a7-4c8a-9cff-24563ec20ea7.jpg?1",
             "name": "Combust",
             "text": "Combust can't be countered by spells or abilities.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "ccb03d42-21bb-5cac-a673-6d9141129fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f2eddc-b296-40d0-bf59-44899f1570e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f2eddc-b296-40d0-bf59-44899f1570e8.jpg?1",
             "name": "Cyclops Gladiator",
             "text": "Whenever Cyclops Gladiator attacks, you may have it deal damage equal to its power to target creature defending player controls. If you do, that creature deals damage equal to its power to Cyclops Gladiator.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "49497a6a-4348-53c0-be8a-920262e5a967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf8ae40-48e1-4386-9032-4caaf673c297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf8ae40-48e1-4386-9032-4caaf673c297.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4428,7 +4428,7 @@
         },
         {
             "id": "adf23180-c897-5ecb-be75-22c589adbd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abde258-08e0-4762-8142-38e08a960f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abde258-08e0-4762-8142-38e08a960f9d.jpg?1",
             "name": "Destructive Force",
             "text": "Each player sacrifices five lands. Destructive Force deals 5 damage to each creature.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "33ce40d4-78d5-5da3-9b43-88b9737aaa06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6007db49-f750-43c6-ac09-86a61efc1bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6007db49-f750-43c6-ac09-86a61efc1bb2.jpg?1",
             "name": "Earth Servant",
             "text": "Earth Servant gets +0/+1 for each Mountain you control.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "5f088a5c-ef07-5fc9-b451-a01c75c96426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9df1b79-bf3a-4da3-8d98-bdf175445f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9df1b79-bf3a-4da3-8d98-bdf175445f10.jpg?1",
             "name": "Ember Hauler",
             "text": "{1}, Sacrifice Ember Hauler: Ember Hauler deals 2 damage to target creature or player.",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "f416dd2d-c894-54a8-b16a-a2c8c4ffad8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e2db9a-d62e-4300-a9e6-a7665fcf2ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e2db9a-d62e-4300-a9e6-a7665fcf2ef7.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "ab234d03-8083-5b19-8fa6-c95a0a5de497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3af0acc-258e-4979-bab7-7792006ec7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3af0acc-258e-4979-bab7-7792006ec7bc.jpg?1",
             "name": "Fire Servant",
             "text": "If a red instant or sorcery spell you control would deal damage, it deals double that damage instead.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "aa293acb-3059-55b8-b7af-0f97055a9d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d3714-f629-4066-8eaa-08817ad01cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34d3714-f629-4066-8eaa-08817ad01cbb.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "d77abd4a-7ca7-5375-87ab-f2b05aeafcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1e41a8-018b-49b3-ad2d-38ec038d738c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1e41a8-018b-49b3-ad2d-38ec038d738c.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -4661,7 +4661,7 @@
         },
         {
             "id": "aacf55f1-837f-5868-88c7-dcc1eca0e6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d78658-21a4-4133-a29c-a80be8ec2cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d78658-21a4-4133-a29c-a80be8ec2cfc.jpg?1",
             "name": "Goblin Balloon Brigade",
             "text": "{R}: Goblin Balloon Brigade gains flying until end of turn.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "6e876c5d-7b48-5dc1-940f-c6bfc33c93e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78563012-b724-4b6e-94e9-8504d3f76d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78563012-b724-4b6e-94e9-8504d3f76d59.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "ae5107d7-a3e9-5f67-be96-66f30112c618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85516547-2c1a-432b-9fc5-8d2c91156c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85516547-2c1a-432b-9fc5-8d2c91156c77.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "12064e1c-4a16-5f36-aa02-cd0e7be59210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a55db6-d501-4d15-910a-1bd98df2ad0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a55db6-d501-4d15-910a-1bd98df2ad0d.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "98801534-b131-542a-b6ea-a07a86d035c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b6932-e62d-4d38-bd0e-9ab8d4a56762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b6932-e62d-4d38-bd0e-9ab8d4a56762.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle your library.\nWhen Hoarding Dragon is put into a graveyard from the battlefield, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "66e0a40f-45c3-5c37-9108-6175daa512c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba4dcc6-05a5-43e9-b445-bae83180aa79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba4dcc6-05a5-43e9-b445-bae83180aa79.jpg?1",
             "name": "Incite",
             "text": "Target creature becomes red until end of turn and attacks this turn if able.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "0c0bfb1e-04b7-54ed-9870-2e58e330cf19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4a028-6462-4373-9864-a8adfc78d52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e4a028-6462-4373-9864-a8adfc78d52b.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "b57d6560-76a7-571e-b82e-466d4feb766c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd025e6-4c36-4be2-aeab-000cd8bc094c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd025e6-4c36-4be2-aeab-000cd8bc094c.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4932,7 +4932,7 @@
         },
         {
             "id": "a11d5be3-e354-56d7-a4af-6784caf8ae03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2eec5-f892-4466-b6c6-960626ba5640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2eec5-f892-4466-b6c6-960626ba5640.jpg?1",
             "name": "Leyline of Punishment",
             "text": "If Leyline of Punishment is in your opening hand, you may begin the game with it on the battlefield.\nPlayers can't gain life.\nDamage can't be prevented.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "6ca7af0b-4b6a-59ba-90be-6da4f62bcff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768c957-3a1f-42f5-853a-96942f645df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e768c957-3a1f-42f5-853a-96942f645df5.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "5f9dd28b-2c18-5ea2-8254-28749c0e73f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3857c9b-136d-4e6a-bd3b-92dab1b71947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3857c9b-136d-4e6a-bd3b-92dab1b71947.jpg?1",
             "name": "Magma Phoenix",
             "text": "Flying\nWhen Magma Phoenix is put into a graveyard from the battlefield, it deals 3 damage to each creature and each player.\n{3}{R}{R}: Return Magma Phoenix from your graveyard to your hand.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "ed2683cb-d1b1-559e-9fb7-f91a2449ec1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a503697a-4940-4b8f-98b1-5ea9151866fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a503697a-4940-4b8f-98b1-5ea9151866fa.jpg?1",
             "name": "Manic Vandal",
             "text": "When Manic Vandal enters the battlefield, destroy target artifact.",
             "colours": [
@@ -5065,7 +5065,7 @@
         },
         {
             "id": "c7158f94-22c5-5bc6-925f-01cf3c5bca9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081dba98-2092-4225-8e9e-214fb9263b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081dba98-2092-4225-8e9e-214fb9263b1c.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "e7ca6b68-9677-57cc-b6dd-fbf9f0b78fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e577638-a7ed-4bcc-90fb-0cffe87d5a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e577638-a7ed-4bcc-90fb-0cffe87d5a28.jpg?1",
             "name": "Pyretic Ritual",
             "text": "Add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "07fba91f-0219-5309-89d7-4d3017a2119c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea518d8f-568e-4f4a-b729-fdf4c770b9d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea518d8f-568e-4f4a-b729-fdf4c770b9d0.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "d9813e96-8608-53be-91cf-82f7904e3a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd435013-0ab9-42f4-985c-66ea2b3760e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd435013-0ab9-42f4-985c-66ea2b3760e9.jpg?1",
             "name": "Reverberate",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "e4c80410-9ec9-5624-a996-1d69589fd9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386bfe05-602d-415d-8598-96a36b7b9a14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386bfe05-602d-415d-8598-96a36b7b9a14.jpg?1",
             "name": "Shiv's Embrace",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "fe705a28-74ba-53e3-b3da-84b179ca229b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94f88b-d928-4364-9126-231eabf14086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94f88b-d928-4364-9126-231eabf14086.jpg?1",
             "name": "Thunder Strike",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "01c0b574-36a3-5e43-a3f2-ca1c89c13a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda0bffa-c58c-4630-8899-a1b332a7b8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda0bffa-c58c-4630-8899-a1b332a7b8dc.jpg?1",
             "name": "Volcanic Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has mountainwalk. (It's unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "7d9c4f1c-1cfc-5fb2-a4d6-d56b4dbfe87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299cde5-55d1-4cda-933a-2ea2c9bdfa90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2299cde5-55d1-4cda-933a-2ea2c9bdfa90.jpg?1",
             "name": "Vulshok Berserker",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "c9507f31-33c4-5b14-88e8-5dcd264d7f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39aea56-5c56-4241-81c9-928c3253d7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39aea56-5c56-4241-81c9-928c3253d7c9.jpg?1",
             "name": "Wild Evocation",
             "text": "At the beginning of each player's upkeep, that player reveals a card at random from his or her hand. If it's a land card, the player puts it onto the battlefield. Otherwise, the player casts it without paying its mana cost if able.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "cb2c3060-26cb-5a4d-9aad-a640872606de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba17c6-2a96-460e-9ad1-a09174e7710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba17c6-2a96-460e-9ad1-a09174e7710a.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5397,7 +5397,7 @@
         },
         {
             "id": "3be99955-f307-582a-a6c0-0ac275001977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e354ce5-b4c1-4a9c-99d1-7624301b594b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e354ce5-b4c1-4a9c-99d1-7624301b594b.jpg?1",
             "name": "Autumn's Veil",
             "text": "Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.",
             "colours": [
@@ -5429,7 +5429,7 @@
         },
         {
             "id": "ad829a4e-c9dd-591e-8aca-97ab8fd3ab4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ea3786-c64c-4e36-8b3b-19da0c0b46d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ea3786-c64c-4e36-8b3b-19da0c0b46d3.jpg?1",
             "name": "Awakener Druid",
             "text": "When Awakener Druid enters the battlefield, target Forest becomes a 4/5 green Treefolk creature for as long as Awakener Druid is on the battlefield. It's still a land.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "e7e759a7-a3b3-5b5e-b7f1-366bdd77b808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af9ebf-8935-4107-aacd-4c643b68cb6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af9ebf-8935-4107-aacd-4c643b68cb6e.jpg?1",
             "name": "Back to Nature",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "f5c99765-4a02-5a8a-a753-b50454d6a8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c9d029-c568-4728-bf74-9d02b6772f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c9d029-c568-4728-bf74-9d02b6772f48.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5530,7 +5530,7 @@
         },
         {
             "id": "72043a9a-c2fe-5595-8fa0-c9c650f07b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc665c-d507-4de3-a8e8-731cc8487840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc665c-d507-4de3-a8e8-731cc8487840.jpg?1",
             "name": "Brindle Boar",
             "text": "Sacrifice Brindle Boar: You gain 4 life.",
             "colours": [
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "d8cdf095-df9a-54cd-863d-344e08c5d2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e94674-50c3-4302-b3d8-ac4d1eb33d6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e94674-50c3-4302-b3d8-ac4d1eb33d6b.jpg?1",
             "name": "Cudgel Troll",
             "text": "{G}: Regenerate Cudgel Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "5f27bb0b-7c59-5b0c-9673-17db759e0076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3dbe4-5c03-4be4-ab48-45b6689b6712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3dbe4-5c03-4be4-ab48-45b6689b6712.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5630,7 +5630,7 @@
         },
         {
             "id": "4fd02f1d-7807-5c58-a24d-390095de8309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c259509e-9f95-4566-b78a-ba34107539f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c259509e-9f95-4566-b78a-ba34107539f7.jpg?1",
             "name": "Dryad's Favor",
             "text": "Enchant creature\nEnchanted creature has forestwalk. (It's unblockable as long as defending player controls a Forest.)",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "d14151ef-4682-5eba-987b-49ce1d751b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9e14ba-2279-4b27-ae49-5276691eeae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9e14ba-2279-4b27-ae49-5276691eeae5.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5698,7 +5698,7 @@
         },
         {
             "id": "2a3dabe9-4940-50c7-ac27-cab141285396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb80b4c-35a1-461b-8bad-2679b1dd2e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb80b4c-35a1-461b-8bad-2679b1dd2e05.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "d04e3044-829a-5593-b184-fd279a716afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c685e4c3-eb7b-4b9e-9676-395d69d80974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c685e4c3-eb7b-4b9e-9676-395d69d80974.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -5768,7 +5768,7 @@
         },
         {
             "id": "131948a8-50f5-56ae-9d43-d983263911a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5498e4d-8ccd-4874-8ecc-3b1819b15f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5498e4d-8ccd-4874-8ecc-3b1819b15f85.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "8950a672-7223-52f2-b2cd-f0e37b37a2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f610a9-73b0-4ef8-b725-f3eee1b78fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f610a9-73b0-4ef8-b725-f3eee1b78fad.jpg?1",
             "name": "Gaea's Revenge",
             "text": "Gaea's Revenge can't be countered.\nHaste\nGaea's Revenge can't be the target of nongreen spells or abilities from nongreen sources.",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "93de1f8a-89fa-54e3-a43a-085fe92132eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0135ada3-e5ae-4382-a717-872839bf1d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0135ada3-e5ae-4382-a717-872839bf1d5a.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "+1: Untap two target lands.\n-1: Put a 3/3 green Beast creature token onto the battlefield.\n-4: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "d0e56a9b-79cb-59db-b4d4-1765863ad8fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863c9a10-d83f-415b-adf2-2d0f870410b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863c9a10-d83f-415b-adf2-2d0f870410b2.jpg?1",
             "name": "Garruk's Companion",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "ff7f7252-9ebb-57cd-9345-64a81cdcb846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaef299-7879-4f52-8ee4-701ed150b930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaef299-7879-4f52-8ee4-701ed150b930.jpg?1",
             "name": "Garruk's Packleader",
             "text": "Whenever another creature with power 3 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "bdd45d23-4e43-58d0-96de-a86dd0e0a5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340c33e0-2e41-4e08-a958-124860225735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340c33e0-2e41-4e08-a958-124860225735.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "2c2da919-1e40-5367-be31-6e4b284d3a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf40263-603b-46f4-9808-065bbec5c2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf40263-603b-46f4-9808-065bbec5c2f6.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "ec92b40c-f398-5cd7-93e6-bbf000c51d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f169d-8acd-4ee3-a54c-6df6cbeb7eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f169d-8acd-4ee3-a54c-6df6cbeb7eca.jpg?1",
             "name": "Greater Basilisk",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "a1d37e8f-1811-5c6b-a726-f03135c54416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b3bf7-bd09-4f0d-a670-2efc1c6d416f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6b3bf7-bd09-4f0d-a670-2efc1c6d416f.jpg?1",
             "name": "Hornet Sting",
             "text": "Hornet Sting deals 1 damage to target creature or player.",
             "colours": [
@@ -6070,7 +6070,7 @@
         },
         {
             "id": "401d44cb-ac1a-5153-8736-69cd06c03ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc0c0d2-bae4-4bec-b85c-498db713fd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc0c0d2-bae4-4bec-b85c-498db713fd4a.jpg?1",
             "name": "Hunters' Feast",
             "text": "Any number of target players each gain 6 life.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "0af5de96-8081-5dfa-812b-b0389abdde87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5318113-9dfb-492c-9151-de90951d881e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5318113-9dfb-492c-9151-de90951d881e.jpg?1",
             "name": "Leyline of Vitality",
             "text": "If Leyline of Vitality is in your opening hand, you may begin the game with it on the battlefield.\nCreatures you control get +0/+1.\nWhenever a creature enters the battlefield under your control, you may gain 1 life.",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "46722644-b19f-5022-aed6-814e146f37e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d1835a-913f-4979-953b-ddd933214538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d1835a-913f-4979-953b-ddd933214538.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "ced634da-a92c-5f83-9350-9c6ea01f7030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c8cfa-76b8-4a17-be63-947490b64d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c8cfa-76b8-4a17-be63-947490b64d85.jpg?1",
             "name": "Mitotic Slime",
             "text": "When Mitotic Slime is put into a graveyard from the battlefield, put two 2/2 green Ooze creature tokens onto the battlefield. They have \"When this creature is put into a graveyard, put two 1/1 green Ooze creature tokens onto the battlefield.\"",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "69765075-2986-505c-a418-5d340e440bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25599b-02ec-4ea7-a6e2-c90880927382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25599b-02ec-4ea7-a6e2-c90880927382.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "1605ffe7-6835-53b9-8b52-7714b9f860fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af72071d-e1d2-45f7-94ad-2bdf2c67e819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af72071d-e1d2-45f7-94ad-2bdf2c67e819.jpg?1",
             "name": "Nature's Spiral",
             "text": "Return target permanent card from your graveyard to your hand. (A permanent card is an artifact, creature, enchantment, land, or planeswalker card.)",
             "colours": [
@@ -6267,7 +6267,7 @@
         },
         {
             "id": "b2291064-ea51-5543-89ac-aec87fbe12b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694496c-45b9-4ddf-bfcd-b632441b8811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694496c-45b9-4ddf-bfcd-b632441b8811.jpg?1",
             "name": "Obstinate Baloth",
             "text": "When Obstinate Baloth enters the battlefield, you gain 4 life.\nIf a spell or ability an opponent controls causes you to discard Obstinate Baloth, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "80f4c406-8c5c-5264-8b4e-c425dafd2897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5a46d0-09fe-454c-a920-0343f846b832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5a46d0-09fe-454c-a920-0343f846b832.jpg?1",
             "name": "Overwhelming Stampede",
             "text": "Until end of turn, creatures you control gain trample and get +X/+X, where X is the greatest power among creatures you control. (If a creature you control would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6333,7 +6333,7 @@
         },
         {
             "id": "d414b367-19ba-590e-98c4-199065858a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5923f9d4-c2ec-466f-9e5b-17d24bda7f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5923f9d4-c2ec-466f-9e5b-17d24bda7f37.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "55b65445-fad0-5bd1-9998-a3bd65d52e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a75889d-8746-4516-934b-efce9c48dc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a75889d-8746-4516-934b-efce9c48dc70.jpg?1",
             "name": "Primal Cocoon",
             "text": "Enchant creature\nAt the beginning of your upkeep, put a +1/+1 counter on enchanted creature.\nWhen enchanted creature attacks or blocks, sacrifice Primal Cocoon.",
             "colours": [
@@ -6399,7 +6399,7 @@
         },
         {
             "id": "3e9e3503-c154-5dc8-9f07-a1681e3a017b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feee9327-b937-46ba-a2aa-6c015ab6cdd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feee9327-b937-46ba-a2aa-6c015ab6cdd5.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "dd46a5d3-7e73-5047-8499-77f3e62f880d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399526c2-f4c7-4407-8fed-1ca8a46181d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399526c2-f4c7-4407-8fed-1ca8a46181d2.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -6467,7 +6467,7 @@
         },
         {
             "id": "750c4b75-91a5-53e6-b394-98e30d843c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63d54c1-1b20-48c4-871d-0bb15e608996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f63d54c1-1b20-48c4-871d-0bb15e608996.jpg?1",
             "name": "Protean Hydra",
             "text": "Protean Hydra enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Protean Hydra, prevent that damage and remove that many +1/+1 counters from it.\nWhenever a +1/+1 counter is removed from Protean Hydra, put two +1/+1 counters on it at the beginning of the next end step.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "8572a135-e00e-55cf-a66e-d10f1a3aaee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ef778-2acf-40f0-9a64-6415d2109093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ef778-2acf-40f0-9a64-6415d2109093.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6535,7 +6535,7 @@
         },
         {
             "id": "4144c956-bac4-5531-919d-54cf0a4efdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bffe20-c469-4ac8-a8a9-361a244f4cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bffe20-c469-4ac8-a8a9-361a244f4cfe.jpg?1",
             "name": "Sacred Wolf",
             "text": "Sacred Wolf can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -6569,7 +6569,7 @@
         },
         {
             "id": "29a53cf4-f8c3-58f4-a657-18498b819ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5334998-3c84-4b04-a5c2-d66c9d99e93b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5334998-3c84-4b04-a5c2-d66c9d99e93b.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -6603,7 +6603,7 @@
         },
         {
             "id": "cbecb537-e662-57fe-82a0-1463ff92dda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73ea30-c6d2-4224-ae54-f6b89e006cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73ea30-c6d2-4224-ae54-f6b89e006cf4.jpg?1",
             "name": "Sylvan Ranger",
             "text": "When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "667ce243-69a0-5603-94f9-81895f41b44f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050a168-870e-4c47-bc74-bc1c90dd7b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050a168-870e-4c47-bc74-bc1c90dd7b3b.jpg?1",
             "name": "Wall of Vines",
             "text": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6674,7 +6674,7 @@
         },
         {
             "id": "efad9aec-7b9e-50c6-ab10-a621e87f2182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4516b135-3691-4be5-ab73-91fbdc6b24b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4516b135-3691-4be5-ab73-91fbdc6b24b6.jpg?1",
             "name": "Yavimaya Wurm",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6708,7 +6708,7 @@
         },
         {
             "id": "ac125b09-d683-5154-80f5-bfb81bd8c2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2caa08-1b25-4ace-9204-068777f82e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2caa08-1b25-4ace-9204-068777f82e69.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player casts a white spell, you may gain 1 life.",
             "colours": [],
@@ -6736,7 +6736,7 @@
         },
         {
             "id": "97d21040-09e3-547d-9951-6a14247d6a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e2a430-339c-46ae-a43f-61e11e018b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e2a430-339c-46ae-a43f-61e11e018b7b.jpg?1",
             "name": "Brittle Effigy",
             "text": "{4}, {T}, Exile Brittle Effigy: Exile target creature.",
             "colours": [],
@@ -6764,7 +6764,7 @@
         },
         {
             "id": "21029697-15fc-5857-993d-04f2bd0cea4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56dc98fb-a956-46f7-aca2-97929b4236ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56dc98fb-a956-46f7-aca2-97929b4236ee.jpg?1",
             "name": "Crystal Ball",
             "text": "{1}, {T}: Scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [],
@@ -6792,7 +6792,7 @@
         },
         {
             "id": "b5b82e15-1f01-5832-9436-b3d6bfa547cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1a71-c565-472d-8393-66b461f00f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1a71-c565-472d-8393-66b461f00f7e.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player casts a black spell, you may gain 1 life.",
             "colours": [],
@@ -6820,7 +6820,7 @@
         },
         {
             "id": "d43083ab-244a-59fc-852d-a2694221f7c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1406d2-b554-42d1-9e05-02fbd64523f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1406d2-b554-42d1-9e05-02fbd64523f3.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player casts a red spell, you may gain 1 life.",
             "colours": [],
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "03b1a0b3-00a6-55b9-8f56-d2ca2d6c26ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd4740-9b1f-40a6-a14d-2c0d642b848b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bd4740-9b1f-40a6-a14d-2c0d642b848b.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into your library.",
             "colours": [],
@@ -6876,7 +6876,7 @@
         },
         {
             "id": "00ea5f7e-02d1-5247-a10a-250e06a8d41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af328bc-bce5-4024-9da5-853ee16eaa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af328bc-bce5-4024-9da5-853ee16eaa8a.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender (This creature can't attack.)\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -6907,7 +6907,7 @@
         },
         {
             "id": "285b3dff-b2c9-5bd5-970d-7162f08f1f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763cb2dc-c8ea-4bfc-a576-ae1641057bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763cb2dc-c8ea-4bfc-a576-ae1641057bf7.jpg?1",
             "name": "Jinxed Idol",
             "text": "At the beginning of your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol.",
             "colours": [],
@@ -6935,7 +6935,7 @@
         },
         {
             "id": "a899e8ce-c9e6-5bb7-a28e-a125859d0140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591c366-cc55-4621-8fa4-3a598b7a3230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5591c366-cc55-4621-8fa4-3a598b7a3230.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -6966,7 +6966,7 @@
         },
         {
             "id": "8b4f808a-534c-57c8-bf2c-4767cdba9e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb47ef-9066-4ace-b88c-ea0d8f17ff8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb47ef-9066-4ace-b88c-ea0d8f17ff8c.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player casts a blue spell, you may gain 1 life.",
             "colours": [],
@@ -6994,7 +6994,7 @@
         },
         {
             "id": "03cc54a9-6ef0-5b23-9516-5857fe523cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331a0a01-0c12-4999-9bd7-f26991e4dad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331a0a01-0c12-4999-9bd7-f26991e4dad5.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -7025,7 +7025,7 @@
         },
         {
             "id": "3532a96e-57c4-5cd2-9013-4ac5672859c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a561bf-bddc-4ea7-bf71-9cdc07a71456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a561bf-bddc-4ea7-bf71-9cdc07a71456.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -7056,7 +7056,7 @@
         },
         {
             "id": "ffb2ac5f-363a-5c66-983a-e199abcd691f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53757410-4183-42b2-aa7f-a3d208bedcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53757410-4183-42b2-aa7f-a3d208bedcf9.jpg?1",
             "name": "Sorcerer's Strongbox",
             "text": "{2}, {T}: Flip a coin. If you win the flip, sacrifice Sorcerer's Strongbox and draw three cards.",
             "colours": [],
@@ -7084,7 +7084,7 @@
         },
         {
             "id": "42efd006-5a97-549d-8238-8277b8427dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9da673d-7cc0-4435-b5a5-5098630f7712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9da673d-7cc0-4435-b5a5-5098630f7712.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -7115,7 +7115,7 @@
         },
         {
             "id": "eb083b29-0b2d-56fa-80d2-75d8df93a34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0876b-5026-4a0a-bf2f-e831593643a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d0876b-5026-4a0a-bf2f-e831593643a7.jpg?1",
             "name": "Stone Golem",
             "text": "",
             "colours": [],
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "64e539d1-c459-597f-be68-05e6e3b4b99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc0138-46fc-493c-8a28-8630c4759193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc0138-46fc-493c-8a28-8630c4759193.jpg?1",
             "name": "Sword of Vengeance",
             "text": "Equipped creature gets +2/+0 and has first strike, vigilance, trample, and haste.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "85e63e64-5db9-51c9-8b54-440871dce9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99cde3-8ba5-44bf-bbaa-1a12c6cac925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c99cde3-8ba5-44bf-bbaa-1a12c6cac925.jpg?1",
             "name": "Temple Bell",
             "text": "{T}: Each player draws a card.",
             "colours": [],
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "e3f675c9-4dad-520a-a92b-3019fd272076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4095a274-57a9-442e-8c53-1e1d242fd824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4095a274-57a9-442e-8c53-1e1d242fd824.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion enters the battlefield with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: Triskelion deals 1 damage to target creature or player.",
             "colours": [],
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "2d733393-59e3-546e-b6ec-03d52ef8b6ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd61957-f3a2-4976-8f15-88258f71406a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd61957-f3a2-4976-8f15-88258f71406a.jpg?1",
             "name": "Voltaic Key",
             "text": "{1}, {T}: Untap target artifact.",
             "colours": [],
@@ -7263,7 +7263,7 @@
         },
         {
             "id": "1ab9b963-ef07-528e-aed1-39fbed972ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ab6393-df29-475b-b56d-c56eb95de05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ab6393-df29-475b-b56d-c56eb95de05d.jpg?1",
             "name": "Warlord's Axe",
             "text": "Equipped creature gets +3/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "64a6f5bd-450a-5f73-9a98-9ca072e5c4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83821b3-a6a6-4a15-9169-5c6d1942903d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83821b3-a6a6-4a15-9169-5c6d1942903d.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "Equipped creature is unblockable.\nEquipped creature has shroud. (It can't be the target of spells or abilities.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "daa2cfc0-9b42-5f4b-8376-002d76a348b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd67d9b-ba45-4f81-9654-a1fb8258c1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd67d9b-ba45-4f81-9654-a1fb8258c1fd.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player casts a green spell, you may gain 1 life.",
             "colours": [],
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "45c3f375-29f0-515e-a817-de943911ddc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b5408a-0fde-48d4-bcbf-b949a20b79c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b5408a-0fde-48d4-bcbf-b949a20b79c0.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "de5bcdb7-9587-512e-bba9-d621e255ed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb09397-c3cc-4ecc-aef7-bee4dfa6957f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb09397-c3cc-4ecc-aef7-bee4dfa6957f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "c4161f14-95cb-5778-a01d-25958e027897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d18532-2247-4e33-a760-bc42a727e9f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d18532-2247-4e33-a760-bc42a727e9f5.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7444,7 +7444,7 @@
         },
         {
             "id": "59c3c54c-9689-57a1-8b40-84ce366c7d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e92409-d301-49f5-a8a9-acd531a928d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e92409-d301-49f5-a8a9-acd531a928d4.jpg?1",
             "name": "Mystifying Maze",
             "text": "{T}: Add {1} to your mana pool.\n{4}, {T}: Exile target attacking creature an opponent controls. At the beginning of the next end step, return it to the battlefield tapped under its owner's control.",
             "colours": [],
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "af60ad65-d01d-5ed6-815f-c1a1ff29ca9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abacafc8-ae6f-4e7b-ad8b-4492ac29338f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abacafc8-ae6f-4e7b-ad8b-4492ac29338f.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "823fe76e-1776-5595-9afe-1cf67ded1830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeee9597-674f-4f72-90f4-5491f4432ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeee9597-674f-4f72-90f4-5491f4432ec5.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "271e81b3-1b86-5d7b-9377-c56e4a213d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b98de91-7fa3-4a9c-805b-5f573009c2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b98de91-7fa3-4a9c-805b-5f573009c2b0.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "de146c5b-fee2-56b8-9770-93f74b5aa642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a2ff8c-ac4a-425e-afd0-a9010bf87c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a2ff8c-ac4a-425e-afd0-a9010bf87c1c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "3ac3efc8-2ffd-5a09-97b5-31af26f71216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18bbfc-d624-44c5-b3bb-1e9a0fd1f784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b18bbfc-d624-44c5-b3bb-1e9a0fd1f784.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7638,7 +7638,7 @@
         },
         {
             "id": "c30808bb-9d44-5f8c-9430-ff441061deed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d968b76-8787-40de-821f-46bd2754fa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d968b76-8787-40de-821f-46bd2754fa8a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7676,7 +7676,7 @@
         },
         {
             "id": "62022902-a9f3-5a6e-9d17-1b094833fbf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46198629-2099-463d-ad5a-c919ae64cded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46198629-2099-463d-ad5a-c919ae64cded.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7714,7 +7714,7 @@
         },
         {
             "id": "fdea90de-7ac5-5b31-81aa-122435e55555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8d3740-40e9-40d4-833e-8f191a43ed14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8d3740-40e9-40d4-833e-8f191a43ed14.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "d98b9187-ad97-58fe-9aca-46181a47b49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3da4bf-1a5a-42a7-bd36-f1ca080c8a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3da4bf-1a5a-42a7-bd36-f1ca080c8a5a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "032e1901-aa78-5e0a-b405-95a2872b89b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b34fc0-dc7b-4823-9ff1-5e1e84016204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b34fc0-dc7b-4823-9ff1-5e1e84016204.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "9af02639-8af6-5df0-a2d6-35d5ab3e17d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3114ce5d-c99c-4c60-b088-48ec440eafdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3114ce5d-c99c-4c60-b088-48ec440eafdb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "4b51af34-701a-5c09-a2e5-7eb9d12fddbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd3031-8284-4098-a5e6-2fdfc4362752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd3031-8284-4098-a5e6-2fdfc4362752.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "57771146-3ff1-53c2-98d2-7d691af78e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7adaa8f-18e8-4f26-9867-535b41884cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7adaa8f-18e8-4f26-9867-535b41884cff.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7942,7 +7942,7 @@
         },
         {
             "id": "21e59ad6-0450-5c33-a5be-5617c9a723bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541cd2a1-034b-4f23-8468-40891ccff9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541cd2a1-034b-4f23-8468-40891ccff9fc.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7980,7 +7980,7 @@
         },
         {
             "id": "37c89416-678f-5304-8d3a-3212c3d0d433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3b5252-afab-4994-8303-3e0bee67b687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3b5252-afab-4994-8303-3e0bee67b687.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "e7fa090b-923a-52ea-90d1-d3292c68fa61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9b48f1-7c3a-4b1f-9a00-7b75eb6ea831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9b48f1-7c3a-4b1f-9a00-7b75eb6ea831.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "629961b2-3548-5d20-8c9e-4a976673192a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a92bef-0abb-49c0-94df-10d2da6845d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a92bef-0abb-49c0-94df-10d2da6845d0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "0c6931b9-769a-5fb3-a39a-6ac69588f54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44ab4e-79fb-42eb-9c46-cf73ee5f0db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a44ab4e-79fb-42eb-9c46-cf73ee5f0db5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8132,7 +8132,7 @@
         },
         {
             "id": "620ef407-d1ac-5faa-8b29-56fbd1c5cb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8b7f3-7c5b-4004-8dc4-9157288e279c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c8b7f3-7c5b-4004-8dc4-9157288e279c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "5643d688-a83e-5de4-9b31-159a92b68680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36b8794-c117-4d3d-bcde-39a3ae436f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36b8794-c117-4d3d-bcde-39a3ae436f1e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "1a5c8f2d-d3ed-525e-b724-86b64b57910d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301f00e-481d-4dbc-8fda-528d9d4ba848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301f00e-481d-4dbc-8fda-528d9d4ba848.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8246,7 +8246,7 @@
         },
         {
             "id": "c860b280-53db-5fbc-9da1-98251b59e2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee4121a-cd1f-4124-8242-f0eae8ef6580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee4121a-cd1f-4124-8242-f0eae8ef6580.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8284,7 +8284,7 @@
         },
         {
             "id": "00fc5c71-3bdb-5c7a-a79a-fc50a5b32040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83caa371-9c1d-46c7-a7c9-abcaa71ebc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83caa371-9c1d-46c7-a7c9-abcaa71ebc57.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "4024e327-527f-54d0-af52-8d4953c54313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863768b5-3cf9-415c-b4fd-371dc5afee18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863768b5-3cf9-415c-b4fd-371dc5afee18.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -8356,7 +8356,7 @@
         },
         {
             "id": "1de87b8f-316e-5f5a-a7ab-e53a2ee61973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84671e-cbe8-467e-9a8a-bbecba6158fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84671e-cbe8-467e-9a8a-bbecba6158fa.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8390,7 +8390,7 @@
         },
         {
             "id": "011a9246-7f7c-50c7-ab99-3fc13469c13b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b365694-e056-48b9-aae3-599180c0c29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b365694-e056-48b9-aae3-599180c0c29c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "7168a2ff-69b1-508f-a3cb-52bee903e83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664bd13a-80fd-4ffe-bc65-f02a7a087427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664bd13a-80fd-4ffe-bc65-f02a7a087427.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8458,7 +8458,7 @@
         },
         {
             "id": "6d30428c-f846-584a-8458-55de11d00213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea26341-372c-4657-8910-08e0131fe0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea26341-372c-4657-8910-08e0131fe0fc.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -8492,7 +8492,7 @@
         },
         {
             "id": "d305fa3e-e097-5f39-b89d-f2b386b9748e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24edd312-ef8e-48a0-8532-13e072daa00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24edd312-ef8e-48a0-8532-13e072daa00f.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/M12.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M12.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8443cd8b-0296-5f94-96b5-d7d7481d5792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdc19da-21af-45e7-ad1f-fcacd84a8d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdc19da-21af-45e7-ad1f-fcacd84a8d89.jpg?1",
             "name": "Aegis Angel",
             "text": "Flying\nWhen Aegis Angel enters the battlefield, another target permanent is indestructible for as long as you control Aegis Angel. (Effects that say \"destroy\" don't destroy that permanent. An indestructible creature can't be destroyed by damage.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "be6fd111-f405-5f3a-8057-2fe3b05a7b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82e6a81-6a45-45f9-829d-332859a32257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82e6a81-6a45-45f9-829d-332859a32257.jpg?1",
             "name": "Alabaster Mage",
             "text": "{1}{W}: Target creature you control gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "8857deb1-74c6-50f7-8009-e826f1699760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cd7438-fde2-4e26-9c34-52c476a971e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cd7438-fde2-4e26-9c34-52c476a971e9.jpg?1",
             "name": "Angelic Destiny",
             "text": "Enchant creature\nEnchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition to its other types.\nWhen enchanted creature dies, return Angelic Destiny to its owner's hand.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "51d4fd0e-cc2a-573e-9244-086da512b703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2b0942-423a-4378-b8cd-022a6b608a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2b0942-423a-4378-b8cd-022a6b608a2e.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "76488e69-d60d-5f55-8910-75e258159516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c839e-0aea-4754-af37-edf6292623e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c839e-0aea-4754-af37-edf6292623e1.jpg?1",
             "name": "Arbalest Elite",
             "text": "{2}{W}, {T}: Arbalest Elite deals 3 damage to target attacking or blocking creature. Arbalest Elite doesn't untap during your next untap step.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "49a75f79-7007-5c01-826f-d2d2f0c92383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaee06f-edc1-4c3a-9ecc-97882c1b911e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaee06f-edc1-4c3a-9ecc-97882c1b911e.jpg?1",
             "name": "Archon of Justice",
             "text": "Flying\nWhen Archon of Justice dies, exile target permanent.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "8ef6f2be-2e0e-5fff-a18a-c5dbd9424865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52daf505-d436-4ea6-a157-4268af2ff7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52daf505-d436-4ea6-a157-4268af2ff7a8.jpg?1",
             "name": "Armored Warhorse",
             "text": "",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "72b30265-ca8c-5883-9cec-08d3c3a5e0d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a791d03-bcbd-437a-8222-3de97d26f0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a791d03-bcbd-437a-8222-3de97d26f0d0.jpg?1",
             "name": "Assault Griffin",
             "text": "Flying",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "d6d63ec8-1b50-5ea4-9db2-542e6271245b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b702dc6d-4c05-4313-b303-c321847ad6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b702dc6d-4c05-4313-b303-c321847ad6a9.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "9ae8cfc4-f3dd-5cd9-bddd-b2f29d876e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a5603a-88c8-4b0c-b091-6d97e873859a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a5603a-88c8-4b0c-b091-6d97e873859a.jpg?1",
             "name": "Benalish Veteran",
             "text": "Whenever Benalish Veteran attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "dc2d6c80-8dab-5018-983f-cb3cd75dafcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f75e85-9454-4008-aa51-a1d5965752d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f75e85-9454-4008-aa51-a1d5965752d6.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "598b0ad4-563b-5aae-99a3-d2c616ff2d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed43ed8-9490-4433-843f-9020cd3470a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed43ed8-9490-4433-843f-9020cd3470a1.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "69d6623a-0aff-527b-815b-82767a89bc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b042f-f059-4e9f-a459-8682688f45cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b042f-f059-4e9f-a459-8682688f45cf.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -442,7 +442,7 @@
         },
         {
             "id": "81cab6f4-2749-55ee-85cc-e91c755f6cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e053-95c2-410f-b35d-8ea3e3607e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44e053-95c2-410f-b35d-8ea3e3607e82.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "110fc288-a785-56fc-87ba-7537d98ffc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03487e9-f584-4bbd-8335-4dd001a88b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03487e9-f584-4bbd-8335-4dd001a88b52.jpg?1",
             "name": "Elite Vanguard",
             "text": "",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "f288da73-12af-5d03-8e28-d316a00d35e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c58b63c-e3e5-4575-849c-9a6a00821286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c58b63c-e3e5-4575-849c-9a6a00821286.jpg?1",
             "name": "Gideon Jura",
             "text": "+2: During target opponent's next turn, creatures that player controls attack Gideon Jura if able.\n-2: Destroy target tapped creature.\n0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "e09f3d75-a45a-5453-acab-e964ffe3c5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0a0d33-8862-433b-a078-82472e5f9af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0a0d33-8862-433b-a078-82472e5f9af0.jpg?1",
             "name": "Gideon's Avenger",
             "text": "Whenever a creature an opponent controls becomes tapped, put a +1/+1 counter on Gideon's Avenger.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "3ebb1159-4281-52bc-bdd9-4214fcbbf6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71eb81-a077-4c85-a4ce-4ad664486bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71eb81-a077-4c85-a4ce-4ad664486bee.jpg?1",
             "name": "Gideon's Lawkeeper",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "52036ce0-e64b-56e2-ab48-1fa858a659b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e35a40-37dd-436c-b4ac-b17b04508c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e35a40-37dd-436c-b4ac-b17b04508c1f.jpg?1",
             "name": "Grand Abolisher",
             "text": "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "7fef7ed1-9e2b-5327-9e2b-25b018982f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a5517-e442-4fbc-b8c3-fea28e5e44d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1a5517-e442-4fbc-b8c3-fea28e5e44d2.jpg?1",
             "name": "Griffin Rider",
             "text": "As long as you control a Griffin creature, Griffin Rider gets +3/+3 and has flying.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "70536273-5cb6-5ad9-ac52-e85da6d74eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8f2fea-2bc1-49fc-91c9-83698f43262f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8f2fea-2bc1-49fc-91c9-83698f43262f.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "051a6915-eb4a-5fe0-8608-384e4d6463e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e6105c-8633-46f7-a7ca-2a5c36c6d548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e6105c-8633-46f7-a7ca-2a5c36c6d548.jpg?1",
             "name": "Guardians' Pledge",
             "text": "White creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "fb6e9fcc-e6a2-5c4d-84d0-92adc01457bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a6831-c352-4ca7-9f8f-43ea99a1cf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650a6831-c352-4ca7-9f8f-43ea99a1cf33.jpg?1",
             "name": "Honor of the Pure",
             "text": "White creatures you control get +1/+1.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "d4cfdf1a-5723-53ab-8124-4c110ff6e214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e207d4-9930-4aff-a7c8-b53bd1b5d566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e207d4-9930-4aff-a7c8-b53bd1b5d566.jpg?1",
             "name": "Lifelink",
             "text": "Enchant creature\nEnchanted creature has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "8cf4a13b-1bdb-543f-9416-26c78f7ef082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691dcce5-ac3d-4970-b3ff-3db485f9f5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691dcce5-ac3d-4970-b3ff-3db485f9f5c3.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you cast an enchantment spell, you may draw a card.",
             "colours": [
@@ -854,7 +854,7 @@
         },
         {
             "id": "bf7a6c63-cb03-5fd9-8e43-8ee504f2ebf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e1676-ae7d-46ee-af91-bb54e4d18a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e1676-ae7d-46ee-af91-bb54e4d18a78.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "3e8bc053-3c14-5276-b5a4-34749c6ae652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efc5a2a-eb76-410d-98e6-1455108faa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9efc5a2a-eb76-410d-98e6-1455108faa52.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "03887ccd-a747-5a39-9b75-5fa37e8487fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783ccfbb-4063-4614-8135-11787227ce97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783ccfbb-4063-4614-8135-11787227ce97.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "29985bf3-d4c9-5ffd-81d4-c33f40e7f1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296eaa6-f9fe-4fb8-af9c-04928d99e2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296eaa6-f9fe-4fb8-af9c-04928d99e2e2.jpg?1",
             "name": "Peregrine Griffin",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "9174dc25-e33b-5ab9-98af-469f90a86b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f10d57-687d-4ee3-8226-bae525d56e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f10d57-687d-4ee3-8226-bae525d56e9e.jpg?1",
             "name": "Personal Sanctuary",
             "text": "During your turn, prevent all damage that would be dealt to you.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "4ae95592-4b22-50d1-b985-c73c1f15f3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d8d723-743c-45d6-b11b-7213f4872cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d8d723-743c-45d6-b11b-7213f4872cf1.jpg?1",
             "name": "Pride Guardian",
             "text": "Defender (This creature can't attack.)\nWhenever Pride Guardian blocks, you gain 3 life.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "1797f899-fcf6-56c8-859b-67fd8dd3e749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ae6206-ff0d-4248-b9cb-4ffbf20504fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ae6206-ff0d-4248-b9cb-4ffbf20504fa.jpg?1",
             "name": "Roc Egg",
             "text": "Defender (This creature can't attack.)\nWhen Roc Egg dies, put a 3/3 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "6c52dc34-5513-5c17-a25b-dbda8ed3eabc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31fb9d-ec0d-4555-814d-62642d52c710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c31fb9d-ec0d-4555-814d-62642d52c710.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "f573cf74-ff54-5d57-b388-4cba2b5e8fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c340a3-0118-48d3-99ab-f4a0e7099325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c340a3-0118-48d3-99ab-f4a0e7099325.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -1156,7 +1156,7 @@
         },
         {
             "id": "8ca4e588-1e15-50d7-a58e-3ba32f672ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8444-ccce-411e-bc4f-e5abca749608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930c8444-ccce-411e-bc4f-e5abca749608.jpg?1",
             "name": "Spirit Mantle",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has protection from creatures. (It can't be blocked, targeted, or dealt damage by creatures.)",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "dbf3a8f1-aec4-57a6-98bc-1d6377ec2bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb09157-5d7a-4da2-92b6-9354489e607f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb09157-5d7a-4da2-92b6-9354489e607f.jpg?1",
             "name": "Stave Off",
             "text": "Target creature gains protection from the color of your choice until end of turn. (It can't be blocked, targeted, dealt damage, or enchanted by anything of that color.)",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "8f04aa47-fa8c-5763-8f3c-0a7c161a0ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3797f7f-489d-4735-af56-6359e0fa0a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3797f7f-489d-4735-af56-6359e0fa0a6b.jpg?1",
             "name": "Stonehorn Dignitary",
             "text": "When Stonehorn Dignitary enters the battlefield, target opponent skips his or her next combat phase.",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "9f346e40-8e28-5b2d-b6ff-a30926464d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0ba2d2-09d5-4755-a18f-40cf19d88f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0ba2d2-09d5-4755-a18f-40cf19d88f25.jpg?1",
             "name": "Stormfront Pegasus",
             "text": "Flying",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "503829b5-7b8f-5eff-8b79-b4379b7c3eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e77ed-9015-4407-b78c-494e46b67b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e77ed-9015-4407-b78c-494e46b67b07.jpg?1",
             "name": "Sun Titan",
             "text": "Vigilance\nWhenever Sun Titan enters the battlefield or attacks, you may return target permanent card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "f485837a-75dd-5bb0-8ab3-7adbf3dc14a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4669c-e526-4c24-9c25-38cb5c5ef59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4669c-e526-4c24-9c25-38cb5c5ef59b.jpg?1",
             "name": "Timely Reinforcements",
             "text": "If you have less life than an opponent, you gain 6 life. If you control fewer creatures than an opponent, put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "57a3bfa2-e40f-5bd7-8e72-6d8b406f5c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f04ca-cab7-4c86-a56c-79d6ae3b73e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f04ca-cab7-4c86-a56c-79d6ae3b73e6.jpg?1",
             "name": "Aether Adept",
             "text": "When \u00c6ther Adept enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1392,7 +1392,7 @@
         },
         {
             "id": "de83b22b-358b-5a2f-935a-8a91b34659e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6434841-6cca-4397-b1fa-5ce34dc0b7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6434841-6cca-4397-b1fa-5ce34dc0b7f3.jpg?1",
             "name": "Alluring Siren",
             "text": "{T}: Target creature an opponent controls attacks you this turn if able.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "1c5a40c9-1e5f-5fd0-8269-9cbc46a69612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd169064-9c7b-40bd-8be0-a89fcb28ae2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd169064-9c7b-40bd-8be0-a89fcb28ae2f.jpg?1",
             "name": "Amphin Cutthroat",
             "text": "",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "fdcc866b-a16f-5331-ba57-71c4207e6510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57626fd2-d101-4e23-946f-8309c9676fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57626fd2-d101-4e23-946f-8309c9676fe5.jpg?1",
             "name": "Aven Fleetwing",
             "text": "Flying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "35fb02d0-4aba-598b-9ca7-86859d2f638e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a473897f-49eb-4e0f-a5b6-ea75e10be91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a473897f-49eb-4e0f-a5b6-ea75e10be91a.jpg?1",
             "name": "Azure Mage",
             "text": "{3}{U}: Draw a card.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "a5ea754f-e9ba-53fb-bf03-d76b2d869cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6829959-dae1-4ddf-8a75-33a77e6b4612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6829959-dae1-4ddf-8a75-33a77e6b4612.jpg?1",
             "name": "Belltower Sphinx",
             "text": "Flying\nWhenever a source deals damage to Belltower Sphinx, that source's controller puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "d9e9795a-7d36-5ad4-bcfc-9032f861768c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b856-e3c0-4b06-a2b0-6663a9aafd26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464b856-e3c0-4b06-a2b0-6663a9aafd26.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "898c42c1-0536-557e-b321-d9231f9bf2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7e246d-92f8-4e6e-89fc-991b888fc1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7e246d-92f8-4e6e-89fc-991b888fc1e8.jpg?1",
             "name": "Chasm Drake",
             "text": "Flying\nWhenever Chasm Drake attacks, target creature you control gains flying until end of turn.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "2c3ce386-155d-5165-9f2e-fcf5c0da52cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8f212-d1c6-4140-a392-73d0e141e708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8f212-d1c6-4140-a392-73d0e141e708.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "a25e3d3f-a554-5261-9047-b1f7b66f33fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252243c-34e3-447b-b323-fffcbe128278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1252243c-34e3-447b-b323-fffcbe128278.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "2ba59650-d5cc-5a26-851e-7cca72802ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c621dd-9c60-4951-beaf-eb6b597c2f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c621dd-9c60-4951-beaf-eb6b597c2f0f.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -1731,7 +1731,7 @@
         },
         {
             "id": "f3009232-794e-5826-b4d4-1b4f9f553923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425a629-371f-4624-b7a1-b34818ecccad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c425a629-371f-4624-b7a1-b34818ecccad.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "f43ab53d-4b9b-5599-8753-ed9c6774087c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15316953-dcb2-4428-b90a-c90d3d4c45f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15316953-dcb2-4428-b90a-c90d3d4c45f3.jpg?1",
             "name": "Flight",
             "text": "Enchant creature\nEnchanted creature has flying.",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "eaeebd00-d559-5eec-8dab-c8b86ff9ce08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1724ec5b-5437-4688-aa10-b327a0ae2654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1724ec5b-5437-4688-aa10-b327a0ae2654.jpg?1",
             "name": "Frost Breath",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "8cd1df40-de09-5094-af91-17c2ff93dac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358baa9f-390f-4b99-a274-d28f3bd56824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358baa9f-390f-4b99-a274-d28f3bd56824.jpg?1",
             "name": "Frost Titan",
             "text": "Whenever Frost Titan becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.\nWhenever Frost Titan enters the battlefield or attacks, tap target permanent. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "aa22a75d-7587-5c11-a464-6b5eba651212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d4f1d-b378-49c3-b697-6566b3c455cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453d4f1d-b378-49c3-b697-6566b3c455cd.jpg?1",
             "name": "Harbor Serpent",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "21797dd3-6da2-5cd0-b100-f2cd43b45b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e14b62-c050-4d43-aeee-873f46d1e295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e14b62-c050-4d43-aeee-873f46d1e295.jpg?1",
             "name": "Ice Cage",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nWhen enchanted creature becomes the target of a spell or ability, destroy Ice Cage.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "f330a423-882c-5887-aeff-3e0122fd45df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f2a5b6-c26c-4355-b760-d87f074a4921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f2a5b6-c26c-4355-b760-d87f074a4921.jpg?1",
             "name": "Jace, Memory Adept",
             "text": "+1: Draw a card. Target player puts the top card of his or her library into his or her graveyard.\n0: Target player puts the top ten cards of his or her library into his or her graveyard.\n-7: Any number of target players each draw twenty cards.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "2e41d982-1c21-5ceb-97d7-660a955d90f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c6b294-3840-4007-a4e3-67309f6581dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c6b294-3840-4007-a4e3-67309f6581dd.jpg?1",
             "name": "Jace's Archivist",
             "text": "{U}, {T}: Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "4154f6da-2abe-57cf-9eeb-a4beb67a39f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970f4f34-f834-41a7-aff1-7cef82cefc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970f4f34-f834-41a7-aff1-7cef82cefc74.jpg?1",
             "name": "Jace's Erasure",
             "text": "Whenever you draw a card, you may have target player put the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "10fc828d-121d-5088-b280-ea0631f3aab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e5124a-67c0-44ed-8085-28bf37816423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e5124a-67c0-44ed-8085-28bf37816423.jpg?1",
             "name": "Levitation",
             "text": "Creatures you control have flying.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "81930905-9f68-509c-b05e-3c929c6c458b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09140f6-fa75-4bee-9ca0-3a71cd2b5a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09140f6-fa75-4bee-9ca0-3a71cd2b5a7b.jpg?1",
             "name": "Lord of the Unreal",
             "text": "Illusion creatures you control get +1/+1 and have hexproof. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "abe886ec-a4e8-50c9-b70d-0b849f6e549f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b123efa-8631-4a07-970d-ff4f980a0522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b123efa-8631-4a07-970d-ff4f980a0522.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "80bb22b0-5eee-510e-b582-07a221f24dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c273d3-ef0f-40c6-baf5-e39279d10509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c273d3-ef0f-40c6-baf5-e39279d10509.jpg?1",
             "name": "Master Thief",
             "text": "When Master Thief enters the battlefield, gain control of target artifact for as long as you control Master Thief.",
             "colours": [
@@ -2168,7 +2168,7 @@
         },
         {
             "id": "ab52be6b-b9ca-5774-92e1-d7b378d4f998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad3aaec-7c88-4925-8023-0cf61bf906c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad3aaec-7c88-4925-8023-0cf61bf906c2.jpg?1",
             "name": "Merfolk Looter",
             "text": "{T}: Draw a card, then discard a card.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "da973e22-3568-5de9-bb8c-4ea5eef5c9d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220dede5-472c-4a09-bdf0-73e722d9d4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220dede5-472c-4a09-bdf0-73e722d9d4d2.jpg?1",
             "name": "Merfolk Mesmerist",
             "text": "{U}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "0a023e18-c3e9-540f-8461-73fd3aef885e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7f77af-17d7-4746-bc83-f455b9b6f9ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7f77af-17d7-4746-bc83-f455b9b6f9ea.jpg?1",
             "name": "Mind Control",
             "text": "Enchant creature\nYou control enchanted creature.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "0dcbed7a-c4b9-5f99-bcf5-98f95833c0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90cf36-9841-4adf-b5cb-0a7bf103eb93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90cf36-9841-4adf-b5cb-0a7bf103eb93.jpg?1",
             "name": "Mind Unbound",
             "text": "At the beginning of your upkeep, put a lore counter on Mind Unbound, then draw a card for each lore counter on Mind Unbound.",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "c2f46e38-039a-555b-9ef1-e203cd0a2304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f21cd05-2fdb-4c37-90a4-220a3eda23ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f21cd05-2fdb-4c37-90a4-220a3eda23ef.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2336,7 +2336,7 @@
         },
         {
             "id": "7ede0ffa-395e-563c-b5b6-5af8b1268170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06cc574a-f687-4e41-b0a0-62a0eedea7c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06cc574a-f687-4e41-b0a0-62a0eedea7c2.jpg?1",
             "name": "Phantasmal Bear",
             "text": "When Phantasmal Bear becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "a944a114-75f7-5be9-b7f7-b3a854b932b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cd015c-0569-4e7f-9daf-b39e67fc7096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cd015c-0569-4e7f-9daf-b39e67fc7096.jpg?1",
             "name": "Phantasmal Dragon",
             "text": "Flying\nWhen Phantasmal Dragon becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "1bdad99f-2a1f-523d-a244-ba1914308708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e7bf8f-dba7-4005-8cee-634c9153931d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e7bf8f-dba7-4005-8cee-634c9153931d.jpg?1",
             "name": "Phantasmal Image",
             "text": "You may have Phantasmal Image enter the battlefield as a copy of any creature on the battlefield, except it's an Illusion in addition to its other types and it gains \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "684d6a4e-8f07-53cc-97e9-034d7480cc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c908ee-e70a-4406-a32d-ab5ab17e67b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c908ee-e70a-4406-a32d-ab5ab17e67b1.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "03128760-724a-5969-8d9a-b5495bf0926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdb01f8-209d-4f8b-a280-b45e1ab0b880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdb01f8-209d-4f8b-a280-b45e1ab0b880.jpg?1",
             "name": "Redirect",
             "text": "You may choose new targets for target spell.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "b58f8227-b79f-5874-b174-9bac2b8ce5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628213e9-bde9-43fd-a0d9-8c7fb17be879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628213e9-bde9-43fd-a0d9-8c7fb17be879.jpg?1",
             "name": "Skywinder Drake",
             "text": "Flying\nSkywinder Drake can block only creatures with flying.",
             "colours": [
@@ -2538,7 +2538,7 @@
         },
         {
             "id": "7bfac845-1113-5b2a-b2a4-e69737d7461b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a290648a-63c3-400b-98d3-5a5aa5505027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a290648a-63c3-400b-98d3-5a5aa5505027.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2572,7 +2572,7 @@
         },
         {
             "id": "eebf3ec8-0679-55dc-9e42-9de64fda00ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6500a1-5aea-4b83-b4dc-560fe547590d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6500a1-5aea-4b83-b4dc-560fe547590d.jpg?1",
             "name": "Time Reversal",
             "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. Exile Time Reversal.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "cb5d132d-f963-58ae-b07e-78834df331ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43d9a1e-0767-4a9b-81b4-4ff2f3dde1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43d9a1e-0767-4a9b-81b4-4ff2f3dde1d5.jpg?1",
             "name": "Turn to Frog",
             "text": "Target creature loses all abilities and becomes a 1/1 blue Frog until end of turn.",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "4a75e87a-6c1f-5332-b140-e7b35787c750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439b79-f6f4-4d01-8404-a1e02f2aeb55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439b79-f6f4-4d01-8404-a1e02f2aeb55.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2668,7 +2668,7 @@
         },
         {
             "id": "213d835d-7b46-590a-8cae-ef0c7132e9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75657d26-b0f8-4892-8684-533c103c921d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75657d26-b0f8-4892-8684-533c103c921d.jpg?1",
             "name": "Visions of Beyond",
             "text": "Draw a card. If a graveyard has twenty or more cards in it, draw three cards instead.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "1f8fb86c-05a6-5a03-9820-f3bf05997da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8033de8d-a396-4097-aedd-f9facb800b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8033de8d-a396-4097-aedd-f9facb800b33.jpg?1",
             "name": "Blood Seeker",
             "text": "Whenever a creature enters the battlefield under an opponent's control, you may have that player lose 1 life.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "600c74d6-cc94-55ae-a13d-cbb76a147ea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125c5cff-d4e9-4655-9cc5-3ce21e577569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125c5cff-d4e9-4655-9cc5-3ce21e577569.jpg?1",
             "name": "Bloodlord of Vaasgoth",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature enters the battlefield with three +1/+1 counters on it.)\nFlying\nWhenever you cast a Vampire creature spell, it gains bloodthirst 3.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "a6ff60dc-b0a2-5251-b980-f0363ebbe1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a078e438-fcf9-4648-95dc-3d4037f9b561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a078e438-fcf9-4648-95dc-3d4037f9b561.jpg?1",
             "name": "Bloodrage Vampire",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "66a4f968-7203-524d-b514-dbea85790f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab78cd-a899-4c5d-86b3-0666adadba87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbab78cd-a899-4c5d-86b3-0666adadba87.jpg?1",
             "name": "Brink of Disaster",
             "text": "Enchant creature or land\nWhen enchanted permanent becomes tapped, destroy it.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "92c831a3-4d0f-5f75-99d4-e00af045505d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1324b6-dba0-4aff-a403-a45d2b405f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1324b6-dba0-4aff-a403-a45d2b405f5b.jpg?1",
             "name": "Call to the Grave",
             "text": "At the beginning of each player's upkeep, that player sacrifices a non-Zombie creature.\nAt the beginning of the end step, if no creatures are on the battlefield, sacrifice Call to the Grave.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "5b3ab13e-ca5e-5c37-89c3-363ae53075ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56494d1e-0d7e-4c29-942c-b376ff07cdf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56494d1e-0d7e-4c29-942c-b376ff07cdf8.jpg?1",
             "name": "Cemetery Reaper",
             "text": "Other Zombie creatures you control get +1/+1.\n{2}{B}, {T}: Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "05b8518c-2709-5f2e-a7f0-52b55489760f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4780079-7f4c-4a43-883f-4722423c4fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4780079-7f4c-4a43-883f-4722423c4fec.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "d119bf49-d676-54b4-b754-55b952e66b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef144439-fc8e-4844-8ebb-3e36e05ac9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef144439-fc8e-4844-8ebb-3e36e05ac9a0.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player and you gain X life.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "5cb1063b-4c97-5d4e-b0bc-537a4d1cb1d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258a235-086e-429b-9ac1-3178f902658b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a258a235-086e-429b-9ac1-3178f902658b.jpg?1",
             "name": "Dark Favor",
             "text": "Enchant creature\nWhen Dark Favor enters the battlefield, you lose 1 life.\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "610fb277-a36b-5f34-9fbc-fcef521f9e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b101ff4a-8617-4c0a-8503-ed8c857ad000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b101ff4a-8617-4c0a-8503-ed8c857ad000.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "81bd72a9-d1c5-597d-ba0d-2e606281191e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735c2c79-9b4f-4f86-9dec-0749237fe9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735c2c79-9b4f-4f86-9dec-0749237fe9ce.jpg?1",
             "name": "Devouring Swarm",
             "text": "Flying\nSacrifice a creature: Devouring Swarm gets +1/+1 until end of turn.",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "87ae0da5-88f9-503f-a3fc-48b02eca0dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db75949-f8cd-4461-83c0-7eaee2196132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db75949-f8cd-4461-83c0-7eaee2196132.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "fa6cb603-b068-5686-ac3b-b5235e7e35a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10a691-a209-44a3-9925-8638a3c4e1d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca10a691-a209-44a3-9925-8638a3c4e1d1.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "ba6ddc52-ee69-5676-9cdc-16b1bc6cc04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630d4080-8183-41fb-8091-740719083765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630d4080-8183-41fb-8091-740719083765.jpg?1",
             "name": "Distress",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "5f23f1e9-83c3-5da5-9b35-75e5a098ef17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d5ca8-2a94-4d79-9314-c5ca2aa4d14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d5ca8-2a94-4d79-9314-c5ca2aa4d14b.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "4b632138-ac15-5a19-8a81-ea33a40199f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dcb25e-764b-47d6-bec4-225aaace77b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00dcb25e-764b-47d6-bec4-225aaace77b0.jpg?1",
             "name": "Drifting Shade",
             "text": "Flying\n{B}: Drifting Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3232,7 +3232,7 @@
         },
         {
             "id": "d9cbd2a9-f47f-5363-888f-cc646afd4882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560ee1a-1076-4ec5-a177-55ffe12e2165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4560ee1a-1076-4ec5-a177-55ffe12e2165.jpg?1",
             "name": "Duskhunter Bat",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFlying",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "04ae21af-a259-501b-a9f2-2a8a09da0e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c70da33-ce5d-4b8b-9c1d-9a356a7e196f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c70da33-ce5d-4b8b-9c1d-9a356a7e196f.jpg?1",
             "name": "Grave Titan",
             "text": "Deathtouch\nWhenever Grave Titan enters the battlefield or attacks, put two 2/2 black Zombie creature tokens onto the battlefield.",
             "colours": [
@@ -3300,7 +3300,7 @@
         },
         {
             "id": "dc807238-9db9-5479-a909-58fed3683503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11055d4e-3efe-493c-8c18-9e2642267511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11055d4e-3efe-493c-8c18-9e2642267511.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3334,7 +3334,7 @@
         },
         {
             "id": "99985454-6ff9-5e4c-93e8-076bdb377612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25925751-b6cb-45a3-915f-d5ec3edcda78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25925751-b6cb-45a3-915f-d5ec3edcda78.jpg?1",
             "name": "Hideous Visage",
             "text": "Creatures you control gain intimidate until end of turn. (Each of those creatures can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3366,7 +3366,7 @@
         },
         {
             "id": "94c453af-0f4d-57d4-b423-800de6175e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61ee72e-61ae-4558-8abe-f5eaf5b9fb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61ee72e-61ae-4558-8abe-f5eaf5b9fb8a.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3398,7 +3398,7 @@
         },
         {
             "id": "e9eb9506-1629-5759-af76-220f675c4780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af53d7f-7f02-4c35-b6f4-7365d121ba54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af53d7f-7f02-4c35-b6f4-7365d121ba54.jpg?1",
             "name": "Monomania",
             "text": "Target player chooses a card in his or her hand and discards the rest.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "8b15b6df-122a-51f6-90fb-d3d01e0be7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabd38e6-1e59-42d2-bd1a-555c77cf6747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabd38e6-1e59-42d2-bd1a-555c77cf6747.jpg?1",
             "name": "Onyx Mage",
             "text": "{1}{B}: Target creature you control gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "c6fd61c1-1af3-5be7-ac06-af91935e9864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c219bc-a140-4ecd-953a-eef2cc552d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c219bc-a140-4ecd-953a-eef2cc552d58.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "d1053985-b4de-5fe1-8288-3bec2570a3f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12e8109-8215-46b5-a0af-fe7e4b6b10b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12e8109-8215-46b5-a0af-fe7e4b6b10b0.jpg?1",
             "name": "Royal Assassin",
             "text": "{T}: Destroy target tapped creature.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "da0c8808-3f32-5a9c-9e45-55f63e62889c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e0f81-0591-4b28-978e-a2f1c46b7427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e0f81-0591-4b28-978e-a2f1c46b7427.jpg?1",
             "name": "Rune-Scarred Demon",
             "text": "Flying\nWhen Rune-Scarred Demon enters the battlefield, search your library for a card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "727a7585-cac0-53fe-92cf-7528f20c49a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0da3971-0145-4975-8bb1-8c2898d10ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0da3971-0145-4975-8bb1-8c2898d10ae7.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "360e0242-714b-5f70-8002-8b1328350258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c8159b-8c1d-480a-b517-dbd67bba1838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c8159b-8c1d-480a-b517-dbd67bba1838.jpg?1",
             "name": "Smallpox",
             "text": "Each player loses 1 life, discards a card, sacrifices a creature, then sacrifices a land.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "e29d2c0d-13d9-539c-bd4f-7a9db62d1b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25b3a89-3a99-4e02-bf0c-a3cf450da1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25b3a89-3a99-4e02-bf0c-a3cf450da1a1.jpg?1",
             "name": "Sorin Markov",
             "text": "+2: Sorin Markov deals 2 damage to target creature or player and you gain 2 life.\n-3: Target opponent's life total becomes 10.\n-7: You control target player during that player's next turn.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "1a58a7e1-808e-5562-a75d-10aba6886b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f14a435-811d-4057-93a9-ce74aa852a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f14a435-811d-4057-93a9-ce74aa852a09.jpg?1",
             "name": "Sorin's Thirst",
             "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "34f125eb-ab2d-56e7-97ff-32bf712fd272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb62846-c5da-4c7c-b0d7-9b677dce68d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb62846-c5da-4c7c-b0d7-9b677dce68d1.jpg?1",
             "name": "Sorin's Vengeance",
             "text": "Sorin's Vengeance deals 10 damage to target player and you gain 10 life.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "3a40af97-1e15-55a8-8b66-ac2968198edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8390d9b7-5adf-4039-8682-02bfba421ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8390d9b7-5adf-4039-8682-02bfba421ff9.jpg?1",
             "name": "Sutured Ghoul",
             "text": "Trample\nAs Sutured Ghoul enters the battlefield, exile any number of creature cards from your graveyard.\nSutured Ghoul's power is equal to the total power of the exiled cards and its toughness is equal to their total toughness.",
             "colours": [
@@ -3769,7 +3769,7 @@
         },
         {
             "id": "1e4f79e8-0216-5006-9ee2-361704377d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29268cef-da18-4c1d-9066-e0d513a61bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29268cef-da18-4c1d-9066-e0d513a61bf9.jpg?1",
             "name": "Taste of Blood",
             "text": "Taste of Blood deals 1 damage to target player and you gain 1 life.",
             "colours": [
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "320e8dfb-7057-5cf5-aeb4-71964b6a8a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2699c42-99bb-4b5a-82ec-9c6424c14ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2699c42-99bb-4b5a-82ec-9c6424c14ec1.jpg?1",
             "name": "Tormented Soul",
             "text": "Tormented Soul can't block and is unblockable.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "2579e676-bdcf-5b41-bebc-48c87aae11cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1286132d-1697-44da-ab97-387735265c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1286132d-1697-44da-ab97-387735265c01.jpg?1",
             "name": "Vampire Outcasts",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "b1718a39-096e-518f-b2f7-2ac876c1a0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e0ca97-bc57-4084-86b4-e2e06152cb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e0ca97-bc57-4084-86b4-e2e06152cb1c.jpg?1",
             "name": "Vengeful Pharaoh",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever combat damage is dealt to you or a planeswalker you control, if Vengeful Pharaoh is in your graveyard, destroy target attacking creature, then put Vengeful Pharaoh on top of your library.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "cb4f55bd-8018-5fb2-a494-77ac928ddd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94785274-fa79-47cc-9896-0f5f695abb21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94785274-fa79-47cc-9896-0f5f695abb21.jpg?1",
             "name": "Warpath Ghoul",
             "text": "",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "a375e5c8-bb6d-51be-a930-15db559d8e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663df3e8-12e5-46cf-9da7-39961feaa7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/663df3e8-12e5-46cf-9da7-39961feaa7f9.jpg?1",
             "name": "Wring Flesh",
             "text": "Target creature gets -3/-1 until end of turn.",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "4845ca9b-c9bc-5272-af3b-9ac3568d0299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1985e0bd-05b9-4eaf-9333-6262cf677acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1985e0bd-05b9-4eaf-9333-6262cf677acd.jpg?1",
             "name": "Zombie Goliath",
             "text": "",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "ec207d3c-1aba-5108-b4d0-18d991104e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a3e27-841a-4eb5-afcd-ddb87d4280f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84a3e27-841a-4eb5-afcd-ddb87d4280f7.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards: Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -4036,7 +4036,7 @@
         },
         {
             "id": "5d40fb51-5c2d-5fd4-a62c-1abb5a158d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8984c-7176-43e5-931b-c3b6f4747a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8984c-7176-43e5-931b-c3b6f4747a8b.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "0da55720-fd35-5e30-989b-36be3cff71e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85ecba6-fc22-48c7-9f00-066cc1fce6b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85ecba6-fc22-48c7-9f00-066cc1fce6b5.jpg?1",
             "name": "Blood Ogre",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "7dd697f2-6653-5ff1-a2ce-b9ca0b66797e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc17e5c1-a6b4-401b-95eb-1c01cd1da570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc17e5c1-a6b4-401b-95eb-1c01cd1da570.jpg?1",
             "name": "Bonebreaker Giant",
             "text": "",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "66a95a90-0221-5385-8f5b-f47b92396414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb37556-186f-4660-8b75-c52ef16a6d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb37556-186f-4660-8b75-c52ef16a6d8f.jpg?1",
             "name": "Chandra, the Firebrand",
             "text": "+1: Chandra, the Firebrand deals 1 damage to target creature or player.\n-2: When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\n-6: Chandra, the Firebrand deals 6 damage to each of up to six target creatures and/or players.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "6c63b5f1-574e-581c-8f58-e395cfb84522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3850f0-13ed-40c5-8423-8b196132a97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3850f0-13ed-40c5-8423-8b196132a97a.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "23c046a8-a5a7-56bb-9d2b-72d53965c82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8371c83-d7c5-4432-8511-cb3c1dc7d59f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8371c83-d7c5-4432-8511-cb3c1dc7d59f.jpg?1",
             "name": "Chandra's Phoenix",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever an opponent is dealt damage by a red instant or sorcery spell you control or by a red planeswalker you control, return Chandra's Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "835c34ce-2bb0-5dbb-b523-525a2b73f280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419b1813-9760-47b9-b6f3-e501586cfe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419b1813-9760-47b9-b6f3-e501586cfe4d.jpg?1",
             "name": "Circle of Flame",
             "text": "Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.",
             "colours": [
@@ -4271,7 +4271,7 @@
         },
         {
             "id": "00ace3ef-ff59-54ff-a3a8-5367479ed32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10346e2-46bd-4257-b191-c36c2577c534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10346e2-46bd-4257-b191-c36c2577c534.jpg?1",
             "name": "Combust",
             "text": "Combust can't be countered by spells or abilities.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "f8161aba-2135-5444-90c9-f3bebe6fefd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f69ccfc-e2a9-40af-b8ab-85bffe62c0f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f69ccfc-e2a9-40af-b8ab-85bffe62c0f4.jpg?1",
             "name": "Crimson Mage",
             "text": "{R}: Target creature you control gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "f2b8ea68-c3e4-5aec-8733-3be8ceb3fcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c96f7a0-99a3-4ba4-b0f0-9ea36c45d5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c96f7a0-99a3-4ba4-b0f0-9ea36c45d5d5.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "1c6e80d3-8eb5-500a-b232-1d273bb36f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a86f5d-cfbf-4d8e-9f8e-0f8288907396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a86f5d-cfbf-4d8e-9f8e-0f8288907396.jpg?1",
             "name": "Fireball",
             "text": "Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.\nFireball costs {1} more to cast for each target beyond the first.",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "2eb4c64f-d923-5fd7-9ddf-a435ba827083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbcc269-aaa3-42aa-9898-3f908aaae272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fbcc269-aaa3-42aa-9898-3f908aaae272.jpg?1",
             "name": "Firebreathing",
             "text": "Enchant creature\n{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "0c6ba9df-7849-5586-a2db-d327bd2d98db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01ab5c8-f9b7-482c-a900-1388b727b89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01ab5c8-f9b7-482c-a900-1388b727b89f.jpg?1",
             "name": "Flameblast Dragon",
             "text": "Flying\nWhenever Flameblast Dragon attacks, you may pay {X}{R}. If you do, Flameblast Dragon deals X damage to target creature or player.",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "33f4e6b4-0da2-5e38-9e50-95f00ed87c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a439015-0c1c-4322-a6f1-a34040162ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a439015-0c1c-4322-a6f1-a34040162ac4.jpg?1",
             "name": "Fling",
             "text": "As an additional cost to cast Fling, sacrifice a creature.\nFling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "5107b953-b25a-50cf-bb22-4a85a553f94e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b735e5-da9d-4740-acff-aac9dd24334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b735e5-da9d-4740-acff-aac9dd24334c.jpg?1",
             "name": "Furyborn Hellkite",
             "text": "Bloodthirst 6 (If an opponent was dealt damage this turn, this creature enters the battlefield with six +1/+1 counters on it.)\nFlying",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "febad064-af00-5aed-9748-606421511a84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24751fd-5e9b-4d7d-83ba-e306b439bbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24751fd-5e9b-4d7d-83ba-e306b439bbe1.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist dies, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "8b9df522-4d84-57b9-87a9-aaaf09916261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ddad0-23ea-4139-a200-c76c9c46e8c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ddad0-23ea-4139-a200-c76c9c46e8c5.jpg?1",
             "name": "Goblin Bangchuckers",
             "text": "{T}: Flip a coin. If you win the flip, Goblin Bangchuckers deals 2 damage to target creature or player. If you lose the flip, Goblin Bangchuckers deals 2 damage to itself.",
             "colours": [
@@ -4609,7 +4609,7 @@
         },
         {
             "id": "d053271a-bd05-574b-90a7-32783d27732b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2540ec6b-9ffa-4ab0-bbd3-ddf1efd2db60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2540ec6b-9ffa-4ab0-bbd3-ddf1efd2db60.jpg?1",
             "name": "Goblin Chieftain",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nOther Goblin creatures you control get +1/+1 and have haste.",
             "colours": [
@@ -4643,7 +4643,7 @@
         },
         {
             "id": "92c4b876-d935-5e73-95f1-bf1ef1fa7d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c11db78-f506-4af2-a7be-c7ac2c0ffcf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c11db78-f506-4af2-a7be-c7ac2c0ffcf3.jpg?1",
             "name": "Goblin Fireslinger",
             "text": "{T}: Goblin Fireslinger deals 1 damage to target player.",
             "colours": [
@@ -4678,7 +4678,7 @@
         },
         {
             "id": "f5363d31-4ed6-57ec-80d6-9829db065a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394cc2aa-0318-4ccd-a550-99a7eac933c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394cc2aa-0318-4ccd-a550-99a7eac933c3.jpg?1",
             "name": "Goblin Grenade",
             "text": "As an additional cost to cast Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
             "colours": [
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "5599f803-81b7-5d9b-91a0-574d450cec56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083ec3e7-950c-4e9d-aba5-02ed13d723f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083ec3e7-950c-4e9d-aba5-02ed13d723f0.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -4745,7 +4745,7 @@
         },
         {
             "id": "37d7cd90-fc01-589c-8da5-2ab9e20f7362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c466bbb3-9758-47e6-8996-3615f4c31924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c466bbb3-9758-47e6-8996-3615f4c31924.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "890ac95e-0e10-5631-9934-7009c5159ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde711c9-fdef-4024-8269-a59ee0748f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde711c9-fdef-4024-8269-a59ee0748f95.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste. (It can attack and {T} no matter when it came under its controller's control.)",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "cffc9d7f-7788-585a-bc8b-75fad832dc30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1087e015-a3c4-4207-8285-5bda6bb50e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1087e015-a3c4-4207-8285-5bda6bb50e52.jpg?1",
             "name": "Gorehorn Minotaurs",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "ecf1809d-3c76-5d55-8f91-2676860af720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbe2c9-31d5-4e54-922d-1bc6a865b251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbe2c9-31d5-4e54-922d-1bc6a865b251.jpg?1",
             "name": "Grim Lavamancer",
             "text": "{R}, {T}, Exile two cards from your graveyard: Grim Lavamancer deals 2 damage to target creature or player.",
             "colours": [
@@ -4884,7 +4884,7 @@
         },
         {
             "id": "7df565e0-58c7-5d76-a5fd-62799d28fad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af92296-455a-425e-9397-a96d09937767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af92296-455a-425e-9397-a96d09937767.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "20719b2a-60bc-5bb2-b48f-c7d795ac06a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04c24cb-3c3b-4a35-9694-db512bf394fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04c24cb-3c3b-4a35-9694-db512bf394fa.jpg?1",
             "name": "Inferno Titan",
             "text": "{R}: Inferno Titan gets +1/+0 until end of turn.\nWhenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "1e7a708d-9bed-5236-9279-33357aded913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf9c3aa-9434-4a62-9bcb-0699a85de9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf9c3aa-9434-4a62-9bcb-0699a85de9cb.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "ab493c68-da10-5dd3-a553-7c878103f43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106b6af-a13c-42be-9368-9109795de517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106b6af-a13c-42be-9368-9109795de517.jpg?1",
             "name": "Lightning Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "13124240-724b-5f3f-8ea5-981ee08657ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf081d5-e644-4f46-8bc8-a754b089acb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf081d5-e644-4f46-8bc8-a754b089acb4.jpg?1",
             "name": "Manabarbs",
             "text": "Whenever a player taps a land for mana, Manabarbs deals 1 damage to that player.",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "a02c4ee8-969f-5f46-a714-727aa535dab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985a5866-8c62-46af-a0c0-e69d01d87f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985a5866-8c62-46af-a0c0-e69d01d87f4f.jpg?1",
             "name": "Manic Vandal",
             "text": "When Manic Vandal enters the battlefield, destroy target artifact.",
             "colours": [
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "46f3e2f7-c81f-5575-8352-8f115085c051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062e2f3-bf4a-4a9a-962c-b45718a464bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7062e2f3-bf4a-4a9a-962c-b45718a464bc.jpg?1",
             "name": "Reverberate",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "e264b6b3-aa4e-585d-8257-1843e0dc5df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b61fa9d-3f69-4632-be0e-09924ca88501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b61fa9d-3f69-4632-be0e-09924ca88501.jpg?1",
             "name": "Scrambleverse",
             "text": "For each nonland permanent, choose a player at random. Then each player gains control of each permanent for which he or she was chosen. Untap those permanents.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "dcd1bd29-140a-5dee-bc91-faa2079f54ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fed52c-e84e-41c9-b683-d8b26fa03c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fed52c-e84e-41c9-b683-d8b26fa03c5f.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -5179,7 +5179,7 @@
         },
         {
             "id": "820c3364-89a8-5d6f-add0-c6763421e7dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ec8b61-e602-41f2-ac1a-64e150b2ce18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ec8b61-e602-41f2-ac1a-64e150b2ce18.jpg?1",
             "name": "Slaughter Cry",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "57e9f218-059d-5da3-ba43-549ca6f7e4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a50af-ca3e-461a-9dcb-444f56284165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a50af-ca3e-461a-9dcb-444f56284165.jpg?1",
             "name": "Stormblood Berserker",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nStormblood Berserker can't be blocked except by two or more creatures.",
             "colours": [
@@ -5246,7 +5246,7 @@
         },
         {
             "id": "7aa1b058-9ee4-5d4e-8133-437bfcdae54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9838784-8c6d-4e64-bc34-e21efde99093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9838784-8c6d-4e64-bc34-e21efde99093.jpg?1",
             "name": "Tectonic Rift",
             "text": "Destroy target land. Creatures without flying can't block this turn.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "7b6a5e26-a322-5f4b-8969-38468218dd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56134669-9575-44bc-9203-edbd75acecbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56134669-9575-44bc-9203-edbd75acecbd.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "a3000179-5ae2-5f0f-a8eb-972505bf7581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69b92-7435-4aa8-9d90-89ea078befb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69b92-7435-4aa8-9d90-89ea078befb1.jpg?1",
             "name": "Wall of Torches",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "99705701-3460-53cf-bc76-21c751aa89ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16443df-52c6-4c9d-a7ff-89a37e593a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16443df-52c6-4c9d-a7ff-89a37e593a0a.jpg?1",
             "name": "Warstorm Surge",
             "text": "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to target creature or player.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "0408ede8-9eb0-5e6c-b590-1502b9f8ea54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e5876-3eff-4075-9fa2-3ab6030848e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8e5876-3eff-4075-9fa2-3ab6030848e9.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5412,7 +5412,7 @@
         },
         {
             "id": "394e3c5c-3889-5ecd-a330-103c6c2e868a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23321b80-d7e7-48fd-985d-1e9dc3adcd35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23321b80-d7e7-48fd-985d-1e9dc3adcd35.jpg?1",
             "name": "Arachnus Spinner",
             "text": "Reach (This creature can block creatures with flying.)\nTap an untapped Spider you control: Search your graveyard and/or library for a card named Arachnus Web and put it onto the battlefield attached to target creature. If you search your library this way, shuffle it.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "aa67063e-cb93-54ad-9bfd-de35a29dc5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4900b0-f934-42d9-92fb-0bb16d2e8bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4900b0-f934-42d9-92fb-0bb16d2e8bb1.jpg?1",
             "name": "Arachnus Web",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the end step, if enchanted creature's power is 4 or greater, destroy Arachnus Web.",
             "colours": [
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "7b91e24b-f120-57de-9c81-339ddb9168e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b911fee0-c30b-4d68-a9e2-61c40ece68b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b911fee0-c30b-4d68-a9e2-61c40ece68b0.jpg?1",
             "name": "Autumn's Veil",
             "text": "Spells you control can't be countered by blue or black spells this turn, and creatures you control can't be the targets of blue or black spells this turn.",
             "colours": [
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "b82afda7-001f-5cff-bca3-b455f4f59662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d4236-1e54-43e3-83f1-063d49d16dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d4236-1e54-43e3-83f1-063d49d16dda.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5546,7 +5546,7 @@
         },
         {
             "id": "a5b4193e-1c71-51c8-9bd7-027d2ad39d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8191e3cb-ef28-40ea-9eab-23455435d49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8191e3cb-ef28-40ea-9eab-23455435d49e.jpg?1",
             "name": "Bountiful Harvest",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "0c903348-b6a8-58b8-9fc9-0e2067883241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc780658-fc10-481e-8319-d44a644e8fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc780658-fc10-481e-8319-d44a644e8fe8.jpg?1",
             "name": "Brindle Boar",
             "text": "Sacrifice Brindle Boar: You gain 4 life.",
             "colours": [
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "83672c74-6e85-5069-bfd0-8f6e041db4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086eb41-3524-4815-97c9-761ba86a30b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086eb41-3524-4815-97c9-761ba86a30b2.jpg?1",
             "name": "Carnage Wurm",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature enters the battlefield with three +1/+1 counters on it.)\nTrample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5646,7 +5646,7 @@
         },
         {
             "id": "63acd276-58d4-5980-9aed-cd4596a69040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e156b8d8-5309-494e-9709-44f98826a69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e156b8d8-5309-494e-9709-44f98826a69f.jpg?1",
             "name": "Cudgel Troll",
             "text": "{G}: Regenerate Cudgel Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "e1eeea75-a288-59a0-b885-705756438cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71dc232-9b7e-4c0e-ac05-8e48b4936aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f71dc232-9b7e-4c0e-ac05-8e48b4936aa9.jpg?1",
             "name": "Doubling Chant",
             "text": "For each creature you control, you may search your library for a creature card with the same name as that creature. Put those cards onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "5fd9c7c0-d3df-524c-9b6f-387a293d28bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b4ebbf-1613-42a0-97ff-2f36dc8d984a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b4ebbf-1613-42a0-97ff-2f36dc8d984a.jpg?1",
             "name": "Dungrove Elder",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nDungrove Elder's power and toughness are each equal to the number of Forests you control.",
             "colours": [
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "21536fe2-458f-59b3-8f14-b87c5f49b22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f37891-fac7-4868-a20b-0e879f7e0859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f37891-fac7-4868-a20b-0e879f7e0859.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5781,7 +5781,7 @@
         },
         {
             "id": "882a9596-22fd-5919-a630-742ccb56364c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84387fb5-7929-4d08-9d94-ba2d94460ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84387fb5-7929-4d08-9d94-ba2d94460ef3.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5813,7 +5813,7 @@
         },
         {
             "id": "f5f8f47b-5f7c-5de3-a576-ad86eae65b78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d586bf-bed3-4390-b81d-d101c2ae524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d586bf-bed3-4390-b81d-d101c2ae524c.jpg?1",
             "name": "Garruk, Primal Hunter",
             "text": "+1: Put a 3/3 green Beast creature token onto the battlefield.\n-3: Draw cards equal to the greatest power among creatures you control.\n-6: Put a 6/6 green Wurm creature token onto the battlefield for each land you control.",
             "colours": [
@@ -5849,7 +5849,7 @@
         },
         {
             "id": "4a18b2ac-9ab7-56eb-bc2c-8926c6cd12c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d8806c-43c5-4c6c-9420-6210a17ec2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d8806c-43c5-4c6c-9420-6210a17ec2b0.jpg?1",
             "name": "Garruk's Companion",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "7cf537ef-ad21-5c1b-8f7a-59501987dd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6959-9131-40a6-97ec-12baf6fb7ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6959-9131-40a6-97ec-12baf6fb7ca0.jpg?1",
             "name": "Garruk's Horde",
             "text": "Trample\nPlay with the top card of your library revealed.\nYou may cast the top card of your library if it's a creature card. (Do this only any time you could cast that creature card. You still pay the spell's costs.)",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "a34f571c-7482-5144-abc8-213dae4c2c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460133e5-00f1-47e2-91fe-c36802ef16a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460133e5-00f1-47e2-91fe-c36802ef16a8.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "936bedf0-4955-5b18-bbd2-26b1eeec40a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26710d5c-01d1-498b-9f54-521dfd195843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26710d5c-01d1-498b-9f54-521dfd195843.jpg?1",
             "name": "Gladecover Scout",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "9e92d8fb-70d1-5d42-90b4-d4637520d3f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994711cb-e85b-4acb-9460-17231e1d66ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994711cb-e85b-4acb-9460-17231e1d66ad.jpg?1",
             "name": "Greater Basilisk",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6020,7 +6020,7 @@
         },
         {
             "id": "c3a14f07-36a9-5020-a0c5-b091176a77e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4044a9f-43bd-4c32-9d53-29a27ad9be80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4044a9f-43bd-4c32-9d53-29a27ad9be80.jpg?1",
             "name": "Hunter's Insight",
             "text": "Choose target creature you control. Whenever that creature deals combat damage to a player or planeswalker this turn, draw that many cards.",
             "colours": [
@@ -6052,7 +6052,7 @@
         },
         {
             "id": "b676e689-0b06-598f-a575-11fe7dffd8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d6c8d3-04a1-4b35-b7d1-18bed82beaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d6c8d3-04a1-4b35-b7d1-18bed82beaf4.jpg?1",
             "name": "Jade Mage",
             "text": "{2}{G}: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -6087,7 +6087,7 @@
         },
         {
             "id": "59ee4636-718d-54ba-99f9-aea1999e0c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c6f877-6b00-4d57-8a88-36cd3b16edbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c6f877-6b00-4d57-8a88-36cd3b16edbc.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "799c6086-6159-50d8-ad9b-afcaf314f692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9704ea0-4dad-4b37-a316-d00766e2a723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9704ea0-4dad-4b37-a316-d00766e2a723.jpg?1",
             "name": "Lure",
             "text": "Enchant creature\nAll creatures able to block enchanted creature do so.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "9c696221-ace1-5f2b-b011-e1e98282a7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd7d075-031e-4766-89e9-03a8a7197019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd7d075-031e-4766-89e9-03a8a7197019.jpg?1",
             "name": "Lurking Crocodile",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nIslandwalk (This creature is unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -6190,7 +6190,7 @@
         },
         {
             "id": "362295f2-3f98-5675-88b2-f6a7c479e2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf9c75f-0319-416c-904a-49358f2f943c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf9c75f-0319-416c-904a-49358f2f943c.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6222,7 +6222,7 @@
         },
         {
             "id": "988ba5a0-3536-5136-8340-b484975b82dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0559d4-0015-44e4-8ec4-08bb1c54eec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0559d4-0015-44e4-8ec4-08bb1c54eec5.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn. (If a creature you control would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "ca6356ab-3928-50db-b5ff-2666aaaa9d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1a949-c874-4739-9c7d-ad6fcd2aad44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a1a949-c874-4739-9c7d-ad6fcd2aad44.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "7667a90c-7d35-562f-854b-f311fc04e751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6ddbca-b943-49d6-b341-509bb72dd5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6ddbca-b943-49d6-b341-509bb72dd5a6.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "44ee04fc-5fdc-566c-a94a-394c90b69940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc5521-df8f-4992-b93e-e430d8cc7715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcc5521-df8f-4992-b93e-e430d8cc7715.jpg?1",
             "name": "Primordial Hydra",
             "text": "Primordial Hydra enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Primordial Hydra.\nPrimordial Hydra has trample as long as it has ten or more +1/+1 counters on it.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "28d848c2-ab24-5894-a8e9-2c1df4b854a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45a787-6d8a-48d7-ad6c-fb20a9b468a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45a787-6d8a-48d7-ad6c-fb20a9b468a4.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "dcac23c8-ce81-530c-95ca-a8b8a13e722c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f67503-2f0f-43bf-9c4f-a254cc6c501a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f67503-2f0f-43bf-9c4f-a254cc6c501a.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "277d9f39-0421-56de-804a-fffc1457f69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d43ce-8297-47f6-a877-d723b9b43fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d43ce-8297-47f6-a877-d723b9b43fdb.jpg?1",
             "name": "Rites of Flourishing",
             "text": "At the beginning of each player's draw step, that player draws an additional card.\nEach player may play an additional land on each of his or her turns.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "21532172-dd48-5716-901f-ecfc9bee3b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caf2b93-1971-4702-9aa5-bd223eb37a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caf2b93-1971-4702-9aa5-bd223eb37a39.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6484,7 +6484,7 @@
         },
         {
             "id": "107dd4f3-aed0-5eb9-9cf7-bd268ce82241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4661dd-2075-48c3-b19b-fc7f8aaba1b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4661dd-2075-48c3-b19b-fc7f8aaba1b8.jpg?1",
             "name": "Sacred Wolf",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6518,7 +6518,7 @@
         },
         {
             "id": "4b2830ab-60a6-5a0f-af4e-e18feca90c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56c82ad-5eb1-4653-8f02-e9bb1f6f3154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56c82ad-5eb1-4653-8f02-e9bb1f6f3154.jpg?1",
             "name": "Skinshifter",
             "text": "{G}: Choose one \u2014 Until end of turn, Skinshifter becomes a 4/4 Rhino and gains trample; or until end of turn, Skinshifter becomes a 2/2 Bird and gains flying; or until end of turn, Skinshifter becomes a 0/8 Plant. Activate this ability only once each turn.",
             "colours": [
@@ -6553,7 +6553,7 @@
         },
         {
             "id": "bf99e023-cf03-540c-aaaa-660842493cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d34690-f7cc-4161-9a6f-bfc5393e40b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d34690-f7cc-4161-9a6f-bfc5393e40b2.jpg?1",
             "name": "Stampeding Rhino",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6587,7 +6587,7 @@
         },
         {
             "id": "014791f3-f285-5bd5-9b15-022b76e905fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b781626-f4ce-4d00-aa7c-0e07f58f688f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b781626-f4ce-4d00-aa7c-0e07f58f688f.jpg?1",
             "name": "Stingerfling Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhen Stingerfling Spider enters the battlefield, you may destroy target creature with flying.",
             "colours": [
@@ -6621,7 +6621,7 @@
         },
         {
             "id": "57a46832-c3ce-5db8-a64b-a51956c4c3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c8982-e1c2-48be-8094-683d00c2e52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c8982-e1c2-48be-8094-683d00c2e52b.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6653,7 +6653,7 @@
         },
         {
             "id": "b7177d9e-cdfc-5810-9fc7-5b0a8e99d6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c8d6ed-4764-433b-9617-363e46e5b250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c8d6ed-4764-433b-9617-363e46e5b250.jpg?1",
             "name": "Trollhide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\" (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6687,7 +6687,7 @@
         },
         {
             "id": "04fad352-ca5a-55e0-aad8-9898bee4dce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9d448-ebd5-4e01-af88-e755833c2451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd9d448-ebd5-4e01-af88-e755833c2451.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "c91df096-3f31-5066-8470-3ba20d3e080c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e42ead-df6e-4181-ae2b-a2abfc3f1d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e42ead-df6e-4181-ae2b-a2abfc3f1d7c.jpg?1",
             "name": "Adaptive Automaton",
             "text": "As Adaptive Automaton enters the battlefield, choose a creature type.\nAdaptive Automaton is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -6752,7 +6752,7 @@
         },
         {
             "id": "7b3793ef-84eb-5d15-9825-7de2bffaa4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992dc7c-61c0-4d5f-9c32-8febfad4ef6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992dc7c-61c0-4d5f-9c32-8febfad4ef6d.jpg?1",
             "name": "Angel's Feather",
             "text": "Whenever a player casts a white spell, you may gain 1 life.",
             "colours": [],
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "8a1f8043-b4f3-50d3-9e48-27b9b20041bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e36991-7b9f-4cc7-8da2-55b8baf19d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e36991-7b9f-4cc7-8da2-55b8baf19d70.jpg?1",
             "name": "Crown of Empires",
             "text": "{3}, {T}: Tap target creature. Gain control of that creature instead if you control artifacts named Scepter of Empires and Throne of Empires.",
             "colours": [],
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "ad5e7b2c-e7d0-55a0-8da7-00fdc4936d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09afa3b-c172-4cd7-b605-bacbfbd07c24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09afa3b-c172-4cd7-b605-bacbfbd07c24.jpg?1",
             "name": "Crumbling Colossus",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nWhen Crumbling Colossus attacks, sacrifice it at end of combat.",
             "colours": [],
@@ -6839,7 +6839,7 @@
         },
         {
             "id": "5f75e607-0243-5054-8cb1-76787075c68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f56b129-fe2d-4061-b1c9-f1f5a4db564a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f56b129-fe2d-4061-b1c9-f1f5a4db564a.jpg?1",
             "name": "Demon's Horn",
             "text": "Whenever a player casts a black spell, you may gain 1 life.",
             "colours": [],
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "ee71a086-7fbe-5195-8c92-eab8cf0db896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d732b87-08e5-41b6-8448-62dd6bf20d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d732b87-08e5-41b6-8448-62dd6bf20d9c.jpg?1",
             "name": "Dragon's Claw",
             "text": "Whenever a player casts a red spell, you may gain 1 life.",
             "colours": [],
@@ -6895,7 +6895,7 @@
         },
         {
             "id": "858ff5ba-269a-583b-b1e8-71fb32681309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddb054f-0617-4afb-8ed1-a067f234f8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddb054f-0617-4afb-8ed1-a067f234f8e7.jpg?1",
             "name": "Druidic Satchel",
             "text": "{2}, {T}: Reveal the top card of your library. If it's a creature card, put a 1/1 green Saproling creature token onto the battlefield. If it's a land card, put that card onto the battlefield under your control. If it's a noncreature, nonland card, you gain 2 life.",
             "colours": [],
@@ -6923,7 +6923,7 @@
         },
         {
             "id": "5ba6479e-63bf-5caf-82a5-7d2af3590d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64e25a3-fcde-4d8f-a376-0c83470ba84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64e25a3-fcde-4d8f-a376-0c83470ba84f.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
             "colours": [],
@@ -6951,7 +6951,7 @@
         },
         {
             "id": "9373d5ba-fdd1-51ff-82d0-f94b0cf71122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b4041d-7c95-4cb9-a18b-6568db05942b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b4041d-7c95-4cb9-a18b-6568db05942b.jpg?1",
             "name": "Greatsword",
             "text": "Equipped creature gets +3/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "e1fdc525-e5e3-588c-918f-ff4473b663e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a00d1e1-aaa4-4f4d-a887-1e477820d2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a00d1e1-aaa4-4f4d-a887-1e477820d2c6.jpg?1",
             "name": "Kite Shield",
             "text": "Equipped creature gets +0/+3.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7011,7 +7011,7 @@
         },
         {
             "id": "07e5678a-ecf6-5f65-a459-cc74f527476a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48052433-c4d3-434e-a609-e8400150a0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48052433-c4d3-434e-a609-e8400150a0f6.jpg?1",
             "name": "Kraken's Eye",
             "text": "Whenever a player casts a blue spell, you may gain 1 life.",
             "colours": [],
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "e416ee2e-ccce-55fa-b55d-5133e352916e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bf5f25-82b4-460c-94da-b84daa8a53d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bf5f25-82b4-460c-94da-b84daa8a53d9.jpg?1",
             "name": "Manalith",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "1305fedc-aa15-5327-be97-e73d69244070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb10af81-8ff3-4063-a67a-b760fdba95f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb10af81-8ff3-4063-a67a-b760fdba95f8.jpg?1",
             "name": "Pentavus",
             "text": "Pentavus enters the battlefield with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from Pentavus: Put a 1/1 colorless Pentavite artifact creature token with flying onto the battlefield.\n{1}, Sacrifice a Pentavite: Put a +1/+1 counter on Pentavus.",
             "colours": [],
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "4f42cb54-d564-5a9f-9692-82df7eac0e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c0357a-e98d-4c49-83ad-d7a8ebe7e2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c0357a-e98d-4c49-83ad-d7a8ebe7e2d1.jpg?1",
             "name": "Quicksilver Amulet",
             "text": "{4}, {T}: You may put a creature card from your hand onto the battlefield.",
             "colours": [],
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "b2b8624c-84a5-5807-8a35-710e6bcf5cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fc44-4b9a-418b-a4e0-26d2c3a1eca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fc44-4b9a-418b-a4e0-26d2c3a1eca4.jpg?1",
             "name": "Rusted Sentinel",
             "text": "Rusted Sentinel enters the battlefield tapped.",
             "colours": [],
@@ -7157,7 +7157,7 @@
         },
         {
             "id": "d5af9af2-6b17-5f86-a808-1641450d271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f1aaef-94cc-45ab-99c9-8ffdcf331a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f1aaef-94cc-45ab-99c9-8ffdcf331a7b.jpg?1",
             "name": "Scepter of Empires",
             "text": "{T}: Scepter of Empires deals 1 damage to target player. It deals 3 damage to that player instead if you control artifacts named Crown of Empires and Throne of Empires.",
             "colours": [],
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "9c3514e4-85a9-5c7f-9a10-fe160bc6dc35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246d2ce1-6926-4acc-810a-4894dc346b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246d2ce1-6926-4acc-810a-4894dc346b8b.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "82525319-0976-5875-88a8-94e6f59a2589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d3da9c-cb7a-4cea-b6e6-6722bd16c73c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d3da9c-cb7a-4cea-b6e6-6722bd16c73c.jpg?1",
             "name": "Sundial of the Infinite",
             "text": "{1}, {T}: End the turn. Activate this ability only during your turn. (Exile all spells and abilities on the stack. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [],
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "22c4c4b3-54b4-55b8-9773-87cc655106b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b82753b-284c-44ba-9d48-d28913f02a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b82753b-284c-44ba-9d48-d28913f02a5f.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control, and it can attack and {T} as soon as it comes under your control.)\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "72049d59-97fd-5594-affe-8ac012af3075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01b98a6-5683-4b1b-a14c-d0b50fc26beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01b98a6-5683-4b1b-a14c-d0b50fc26beb.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and has flying, first strike, and trample.",
             "colours": [],
@@ -7305,7 +7305,7 @@
         },
         {
             "id": "70b3b905-570d-5134-aa6f-d2518cddb71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87352716-4cf6-4b2f-bb0a-b7aafae64478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87352716-4cf6-4b2f-bb0a-b7aafae64478.jpg?1",
             "name": "Throne of Empires",
             "text": "{1}, {T}: Put a 1/1 white Soldier creature token onto the battlefield. Put five of those tokens onto the battlefield instead if you control artifacts named Crown of Empires and Scepter of Empires.",
             "colours": [],
@@ -7333,7 +7333,7 @@
         },
         {
             "id": "1c97eeed-1988-5271-9884-2cf6033475bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c6b15-40f3-4556-978f-878bedb13762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c6b15-40f3-4556-978f-878bedb13762.jpg?1",
             "name": "Worldslayer",
             "text": "Whenever equipped creature deals combat damage to a player, destroy all permanents other than Worldslayer.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "c60ec1f1-c7ac-5469-adaa-ec91f3f49a84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da965767-a8b1-4725-ae20-65c18e37ad27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da965767-a8b1-4725-ae20-65c18e37ad27.jpg?1",
             "name": "Wurm's Tooth",
             "text": "Whenever a player casts a green spell, you may gain 1 life.",
             "colours": [],
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "9dd8a8af-6691-5ba1-aae3-b81786a1e8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e910cf59-f7aa-44b1-bb8a-c2211179137c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e910cf59-f7aa-44b1-bb8a-c2211179137c.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "b64ef7a4-8517-51dd-97be-4fd071bfb7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99375bc-7465-4f20-897c-1bc61f65de61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99375bc-7465-4f20-897c-1bc61f65de61.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "2ea89c0c-edf0-5e59-acf5-18576a5345cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ad4371-6c81-4b4c-98eb-d5c289c8c0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ad4371-6c81-4b4c-98eb-d5c289c8c0e2.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "b56720ad-1e63-5c60-93f6-2cc62266cbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3601d4-4091-465e-8c18-0cd717258211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3601d4-4091-465e-8c18-0cd717258211.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7512,7 +7512,7 @@
         },
         {
             "id": "8a336c29-9574-595d-ba8b-f04721524409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2dd5e-465f-47fd-8f5d-fd65ba133164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c2dd5e-465f-47fd-8f5d-fd65ba133164.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "c57abe4d-2ee5-56ce-b003-c6af35fa93d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e02be-e41f-49b4-8393-c4cd2992e380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0e02be-e41f-49b4-8393-c4cd2992e380.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7574,7 +7574,7 @@
         },
         {
             "id": "12b9d487-097f-52cf-9518-ecc8f3d341c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f768de9b-3d31-468d-876d-2cb7c5c601a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f768de9b-3d31-468d-876d-2cb7c5c601a3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7612,7 +7612,7 @@
         },
         {
             "id": "c8ed2c94-0587-5158-8e25-8ec0001c31d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1cad1f-c81e-4b65-905f-350b02047ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1cad1f-c81e-4b65-905f-350b02047ea9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "910ad4aa-427c-58e5-9706-02a876c3eb82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e9aad-3b06-4cef-8b91-0087bc5881f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08e9aad-3b06-4cef-8b91-0087bc5881f8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "e362bca7-3bec-537d-987f-ab7b2b8113c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59dcb79-1ab1-4204-b50b-14bc3f709c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59dcb79-1ab1-4204-b50b-14bc3f709c46.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7726,7 +7726,7 @@
         },
         {
             "id": "079b1740-ff70-5182-aaa2-64c1b223fb76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29cf026-521f-4345-a885-da27f7981759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29cf026-521f-4345-a885-da27f7981759.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7764,7 +7764,7 @@
         },
         {
             "id": "4f5d5da4-8610-5b6c-b579-0d0ae9f916c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a585d9-abf8-41ff-b6f6-c9396d36906b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a585d9-abf8-41ff-b6f6-c9396d36906b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7802,7 +7802,7 @@
         },
         {
             "id": "99ae6496-c0b6-5360-b578-dcb97505c6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4f4d9-6168-4f83-b632-c369d2d6c256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4f4d9-6168-4f83-b632-c369d2d6c256.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7840,7 +7840,7 @@
         },
         {
             "id": "340d040a-cd66-57a5-8757-de96a832997b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589524db-68b9-46eb-a8ab-55986f37fbed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589524db-68b9-46eb-a8ab-55986f37fbed.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "694b863a-fe6f-5cfc-844b-0a07d2fc8679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29134a2-548b-4c80-8017-7e50a44c3585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29134a2-548b-4c80-8017-7e50a44c3585.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7916,7 +7916,7 @@
         },
         {
             "id": "8deec4d7-055b-5a77-9ae7-ad44e826078b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9e399-74fb-4650-ad43-439d79dc31ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd9e399-74fb-4650-ad43-439d79dc31ed.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "dd036b05-80f2-509a-b547-ce2c301ee888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ffa5f-9bab-4c49-bd8f-aa7d970c25c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ffa5f-9bab-4c49-bd8f-aa7d970c25c4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7992,7 +7992,7 @@
         },
         {
             "id": "1468744c-b465-52d0-8de8-6d1d12804c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930f28b-0415-42db-9591-e688a2d6bcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b930f28b-0415-42db-9591-e688a2d6bcd5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "ac4f6d01-e2d8-58a1-923d-1e7a0c64a486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d51676-2399-4db9-8c31-c8063be7b94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d51676-2399-4db9-8c31-c8063be7b94a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8068,7 +8068,7 @@
         },
         {
             "id": "e85b1fa1-b54d-5548-a0ed-9c7b3e7344e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c81a162-9735-4c3f-8eee-43b4f3b5a59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c81a162-9735-4c3f-8eee-43b4f3b5a59c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "20a6b5fd-3a69-57e4-9ff5-f996763e73c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8d9be0-255a-482a-b055-f483859266c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8d9be0-255a-482a-b055-f483859266c5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8144,7 +8144,7 @@
         },
         {
             "id": "ee1e1132-69de-5af0-b664-f3e106c6c0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce797d6-6773-4f34-be40-2e3443af6466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ce797d6-6773-4f34-be40-2e3443af6466.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8182,7 +8182,7 @@
         },
         {
             "id": "d0351a0d-3757-5c45-8179-61427ceef17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6302ae7-0947-4a8d-ace4-5e6741aea9ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6302ae7-0947-4a8d-ace4-5e6741aea9ba.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "3c110dde-8d76-5499-a56d-18fccf861f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2dbbc-8bf4-45fd-a5c1-7597c885fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac2dbbc-8bf4-45fd-a5c1-7597c885fc6b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "8d2b5f33-4813-5be9-9c8d-a50a06eb7b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c1369-68a2-4e67-979f-64decb6133a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84c1369-68a2-4e67-979f-64decb6133a1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8296,7 +8296,7 @@
         },
         {
             "id": "a5c506f0-baca-5b71-a9ab-1fe10032e198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a793d3b8-aa7a-4679-ae28-e0ca2f265b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a793d3b8-aa7a-4679-ae28-e0ca2f265b1f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8334,7 +8334,7 @@
         },
         {
             "id": "428b7707-df47-55e0-86c3-7c0bf17b176d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6311cc7-8431-43a3-83ec-b2a5f07acf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6311cc7-8431-43a3-83ec-b2a5f07acf56.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8368,7 +8368,7 @@
         },
         {
             "id": "db8f7904-eafa-5c1f-a08e-91a909836667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2a26d0-2687-41f6-99b9-6ed4e5e8a5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2a26d0-2687-41f6-99b9-6ed4e5e8a5e4.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8402,7 +8402,7 @@
         },
         {
             "id": "8fbd3b00-1bd5-5c38-8949-a6f7f38687b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7e3f4-0153-425a-8edc-2747bbb89638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7e3f4-0153-425a-8edc-2747bbb89638.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8436,7 +8436,7 @@
         },
         {
             "id": "ea617788-3a90-5539-8968-d60333f7d83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb48d4f-e39f-4d51-9bb1-efca7dbfdc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb48d4f-e39f-4d51-9bb1-efca7dbfdc83.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8470,7 +8470,7 @@
         },
         {
             "id": "11f2f297-5b6a-5e31-904e-d177240eb85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2df53f-060d-464a-9c97-908e49e2dc2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2df53f-060d-464a-9c97-908e49e2dc2c.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8504,7 +8504,7 @@
         },
         {
             "id": "8f416b23-6b1e-5cd1-b6d3-8b7a19265ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc847c-7a37-4c7f-b02c-30b3e4c91fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dc847c-7a37-4c7f-b02c-30b3e4c91fb6.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8538,7 +8538,7 @@
         },
         {
             "id": "88954fda-9466-5a2c-b0c4-50389d7ed2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f88c3e-3532-489a-8f31-e07e8040f28e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f88c3e-3532-489a-8f31-e07e8040f28e.jpg?1",
             "name": "Pentavite",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M13.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M13.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "73a51320-80f3-526b-86ec-35e116533b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7f410a-7934-48ae-a90b-ffd096aed43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7f410a-7934-48ae-a90b-ffd096aed43d.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.\n-3: Target creature gains flying and double strike until end of turn.\n-8: Put X 2/2 white Cat creature tokens onto the battlefield, where X is your life total.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "d8719c7b-cf44-5b55-86d6-b1abc7fbccf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570c4d9-cd42-4aca-9421-ac44e057a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3570c4d9-cd42-4aca-9421-ac44e057a785.jpg?1",
             "name": "Ajani's Sunstriker",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "b53f0355-e14b-51a7-afec-2a5edf7dbc51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6d650-4e96-43a3-8b94-7f044d3b2f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e6d650-4e96-43a3-8b94-7f044d3b2f82.jpg?1",
             "name": "Angel's Mercy",
             "text": "You gain 7 life.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "512e7ced-2a9d-59ab-8e40-54368fea529d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22125507-31e3-424c-9527-d994e4525d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22125507-31e3-424c-9527-d994e4525d75.jpg?1",
             "name": "Angelic Benediction",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may tap target creature.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "8ac2b09d-6c98-533d-93b4-fdcb71957895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f5cb3f-c27d-4b35-930f-00d806393796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f5cb3f-c27d-4b35-930f-00d806393796.jpg?1",
             "name": "Attended Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhen Attended Knight enters the battlefield, put a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "be17a632-833c-5314-902a-ee4fdbf9b03d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60a0c43-9f47-404a-8acf-508173e7062f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60a0c43-9f47-404a-8acf-508173e7062f.jpg?1",
             "name": "Aven Squire",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "b4cc47dc-8c2e-5b93-b7ed-52f5c46a734c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182dbd5-8eae-4f4b-86aa-2bfc24481800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182dbd5-8eae-4f4b-86aa-2bfc24481800.jpg?1",
             "name": "Battleflight Eagle",
             "text": "Flying\nWhen Battleflight Eagle enters the battlefield, target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "802c7499-3313-5e34-a59e-c9145f164dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c18f5-89cd-4d33-8d5b-12dacad9f9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c18f5-89cd-4d33-8d5b-12dacad9f9b3.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "5612119f-4401-587c-9ddf-67aabd820b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79258432-ea35-4f2a-9e4a-4abb53f335c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79258432-ea35-4f2a-9e4a-4abb53f335c6.jpg?1",
             "name": "Captain's Call",
             "text": "Put three 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "b29c4bde-b14c-5446-a64b-17cf0295bcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295096bb-1857-4224-bc7b-307b38cfd338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295096bb-1857-4224-bc7b-307b38cfd338.jpg?1",
             "name": "Crusader of Odric",
             "text": "Crusader of Odric's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "6bdcd5e2-7f1c-5891-a7e1-242c23d65670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b713c1f7-9346-4f4e-8fcd-5ada5b3f95c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b713c1f7-9346-4f4e-8fcd-5ada5b3f95c0.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "336a78a8-7ffb-5fd0-8a88-894dd76ee5a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc52c269-d44f-449c-af59-4c425aa10bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc52c269-d44f-449c-af59-4c425aa10bbf.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "2eae30b8-f75e-574a-aec5-a5db2f1cfcc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8618b737-faa0-4a0c-a3f2-bee685c00580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8618b737-faa0-4a0c-a3f2-bee685c00580.jpg?1",
             "name": "Erase",
             "text": "Exile target enchantment.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "b0df3a2b-5250-5a20-9504-bbce9fad9796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799ed076-4724-47bb-94a0-11b42a9826eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799ed076-4724-47bb-94a0-11b42a9826eb.jpg?1",
             "name": "Faith's Reward",
             "text": "Return to the battlefield all permanent cards in your graveyard that were put there from the battlefield this turn.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "50e9802b-c4a2-5b92-90d3-56605e0a3fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8672cfd-e34b-4587-9e24-015e03c7574d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8672cfd-e34b-4587-9e24-015e03c7574d.jpg?1",
             "name": "Glorious Charge",
             "text": "Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "84be9a51-6181-5034-9c57-b51ae6ecc615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddae4f7a-525c-4306-81b5-b0991840a11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddae4f7a-525c-4306-81b5-b0991840a11e.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -541,7 +541,7 @@
         },
         {
             "id": "10d0889f-e026-5daa-934a-05bd37e294ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3defc506-537e-4659-815d-5dab15fbf199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3defc506-537e-4659-815d-5dab15fbf199.jpg?1",
             "name": "Guardian Lions",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "82d3ac9e-f3e1-57ba-a289-966ea9d716be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383c9aa5-30ad-4a2a-8b64-65d4b333c613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/383c9aa5-30ad-4a2a-8b64-65d4b333c613.jpg?1",
             "name": "Guardians of Akrasa",
             "text": "Defender (This creature can't attack.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "a8f8331d-4560-5ea7-b73c-f5788fd38645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35716e37-1bb2-41e2-bb55-e65126b01ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35716e37-1bb2-41e2-bb55-e65126b01ce3.jpg?1",
             "name": "Healer of the Pride",
             "text": "Whenever another creature enters the battlefield under your control, you gain 2 life.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "435c1a7b-72d5-5bc9-946a-16641f1aa884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec71e9-0024-4f8f-b499-541fb7607fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec71e9-0024-4f8f-b499-541fb7607fcd.jpg?1",
             "name": "Intrepid Hero",
             "text": "{T}: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "d711f887-0f23-5e61-8cab-e065e700e611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646cb67-e0ac-4f2d-af21-618ff3613d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646cb67-e0ac-4f2d-af21-618ff3613d69.jpg?1",
             "name": "Knight of Glory",
             "text": "Protection from black (This creature can't be blocked, targeted, dealt damage, or enchanted by anything black.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "3562020a-ca51-5bf2-80ac-2d503fc547a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a73ec-39be-4d23-8c25-17d7c174dcee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2a73ec-39be-4d23-8c25-17d7c174dcee.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "73f0db3c-9cd2-5509-80c4-d50e8b4f98f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1552a8-27b4-4a95-9022-6fdd59aca28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1552a8-27b4-4a95-9022-6fdd59aca28f.jpg?1",
             "name": "Odric, Master Tactician",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Odric, Master Tactician and at least three other creatures attack, you choose which creatures block this combat and how those creatures block.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "261e75f7-a78e-5d9b-9052-c2a32c190eee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442e3b2-9d65-40c4-a3b9-8cb821980d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442e3b2-9d65-40c4-a3b9-8cb821980d80.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "6dc0a17f-4462-59d5-86ef-cc295539bb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e2f3ae-bf92-478b-9c63-acc3f175f02a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e2f3ae-bf92-478b-9c63-acc3f175f02a.jpg?1",
             "name": "Pillarfield Ox",
             "text": "",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "69b95218-f636-5ff8-ac3c-271029d0180e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5047b71-2359-4d9a-a168-a8eec43c5f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5047b71-2359-4d9a-a168-a8eec43c5f1b.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "0d12b8fc-cc83-52d9-b43d-566948ed494d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01597ede-94e7-44a4-93c2-7fd1db11e92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01597ede-94e7-44a4-93c2-7fd1db11e92a.jpg?1",
             "name": "Prized Elephant",
             "text": "Prized Elephant gets +1/+1 as long as you control a Forest.\n{G}: Prized Elephant gains trample until end of turn. (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "4e63e3eb-9a33-5077-8d9d-61db835a7116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bd6ca4-c4ed-41c3-834c-23e0c1741b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bd6ca4-c4ed-41c3-834c-23e0c1741b72.jpg?1",
             "name": "Rain of Blades",
             "text": "Rain of Blades deals 1 damage to each attacking creature.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "f6c2aed4-f18b-5659-9beb-ecc0c14d656f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ea185a-7b38-49f3-be73-be8180fb6295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ea185a-7b38-49f3-be73-be8180fb6295.jpg?1",
             "name": "Rhox Faithmender",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nIf you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "1b18fe55-a628-5915-8465-ff3328e5f675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc65c3f-ad29-4368-bf45-8345a7ec6f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc65c3f-ad29-4368-bf45-8345a7ec6f31.jpg?1",
             "name": "Safe Passage",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "c4539aa6-0f3e-5d95-add3-40f72c26a64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e5de6-3f95-4e1c-99ae-574074998d5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1e5de6-3f95-4e1c-99ae-574074998d5e.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "af6fde2d-00ea-5ce6-a723-f029d727e693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10387b49-4978-4bb9-9139-2ddab3e184ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10387b49-4978-4bb9-9139-2ddab3e184ea.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar's power and toughness are each equal to your life total.\nWhen Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "ab79fa55-a3ce-5901-8cfe-edb5d22334cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef0e34f-5065-46af-bea3-d748ca25707c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef0e34f-5065-46af-bea3-d748ca25707c.jpg?1",
             "name": "Serra Avenger",
             "text": "You can't cast Serra Avenger during your first, second, or third turns of the game.\nFlying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "3b79cdd6-2d4d-597c-a882-bb1a93c4f225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe4d19d-1c9f-4b05-bde2-a9290b52c28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe4d19d-1c9f-4b05-bde2-a9290b52c28d.jpg?1",
             "name": "Show of Valor",
             "text": "Target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "61c57110-e47d-5fac-a1d1-26ed6a75f58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d33e866-cfd8-44e6-8070-df8df1ce965d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d33e866-cfd8-44e6-8070-df8df1ce965d.jpg?1",
             "name": "Silvercoat Lion",
             "text": "",
             "colours": [
@@ -1186,7 +1186,7 @@
         },
         {
             "id": "a3150aef-1b92-56b7-bdd0-5c9d560c9579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cc38bc-55a4-446a-b054-48fb90216946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cc38bc-55a4-446a-b054-48fb90216946.jpg?1",
             "name": "Sublime Archangel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nOther creatures you control have exalted. (If a creature has multiple instances of exalted, each triggers separately.)",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "838abc68-f8ae-5412-905e-aa58b6757769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5f0c2-99e6-42b7-aa16-61d5815d060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c5f0c2-99e6-42b7-aa16-61d5815d060d.jpg?1",
             "name": "Touch of the Eternal",
             "text": "At the beginning of your upkeep, count the number of permanents you control. Your life total becomes that number.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "4fa10079-8db8-5a27-83d2-1898b5a3ca91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e092a0d-c031-4a76-86c1-7f83878a06e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e092a0d-c031-4a76-86c1-7f83878a06e8.jpg?1",
             "name": "War Falcon",
             "text": "Flying\nWar Falcon can't attack unless you control a Knight or a Soldier.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "0005d268-3fd0-5424-bc6b-573ecd713aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28eb320-aea7-466e-8718-de8652a2b191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28eb320-aea7-466e-8718-de8652a2b191.jpg?1",
             "name": "War Priest of Thune",
             "text": "When War Priest of Thune enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "43871ba3-83e7-5425-8373-fd8d8ad21be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102e48e0-8a5f-499d-ac62-005d3c075ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102e48e0-8a5f-499d-ac62-005d3c075ef3.jpg?1",
             "name": "Warclamp Mastiff",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "124da89d-9501-51a4-921e-2c019feac9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6d1be-55ad-4ee4-b044-88438e9b78cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c6d1be-55ad-4ee4-b044-88438e9b78cc.jpg?1",
             "name": "Archaeomancer",
             "text": "When Archaeomancer enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1390,7 +1390,7 @@
         },
         {
             "id": "e1b03c1f-90eb-56e6-9554-4eeb1b347301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6aab1-c400-4d87-b68e-f36552e7417f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6aab1-c400-4d87-b68e-f36552e7417f.jpg?1",
             "name": "Arctic Aven",
             "text": "Flying\nArctic Aven gets +1/+1 as long as you control a Plains.\n{W}: Arctic Aven gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "740622cc-af9a-5a1a-810b-af4c151c2305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6ec8a6-ad88-45c9-ab4b-dd7de2418bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6ec8a6-ad88-45c9-ab4b-dd7de2418bb7.jpg?1",
             "name": "Augur of Bolas",
             "text": "When Augur of Bolas enters the battlefield, look at the top three cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1461,7 +1461,7 @@
         },
         {
             "id": "50b1aaf0-f6a2-52f4-bace-3dd5eebd4203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be15a4-693f-4e22-a46c-38bb440c073c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be15a4-693f-4e22-a46c-38bb440c073c.jpg?1",
             "name": "Battle of Wits",
             "text": "At the beginning of your upkeep, if you have 200 or more cards in your library, you win the game.",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "0d2de508-9375-5105-a8f5-d6ec075b0c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f0e3e-b209-4eda-81e5-b5e474a143d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2f0e3e-b209-4eda-81e5-b5e474a143d5.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "801a979b-c030-5dc7-927c-08eaa9be69e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba912207-a8bf-4ffb-9967-34029cb09f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba912207-a8bf-4ffb-9967-34029cb09f7f.jpg?1",
             "name": "Courtly Provocateur",
             "text": "{T}: Target creature attacks this turn if able.\n{T}: Target creature blocks this turn if able.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "609f8720-c3d3-5d29-ac1c-0b6b44c6e38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c573ab-9013-4c2b-a039-ce5b20dba264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c573ab-9013-4c2b-a039-ce5b20dba264.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "5e784dc9-34fc-58cf-aeb0-0f6b923f8614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220afb1-8638-4b54-b6af-0043b4cc1cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220afb1-8638-4b54-b6af-0043b4cc1cef.jpg?1",
             "name": "Downpour",
             "text": "Tap up to three target creatures.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "51d85fca-2b46-5cf4-bddc-4dbb45cce649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd05474-5cec-4c71-85e7-79cf25958525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd05474-5cec-4c71-85e7-79cf25958525.jpg?1",
             "name": "Encrust",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "1c9dd617-639d-5fbe-82c5-421855a23c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd965f9-bdaa-4434-a9c8-53fc57e997db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd965f9-bdaa-4434-a9c8-53fc57e997db.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "c3a65b43-d395-5cf2-8f7a-ea92ab521a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcbc71b3-544b-4b81-8922-52744892989b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcbc71b3-544b-4b81-8922-52744892989b.jpg?1",
             "name": "Faerie Invaders",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "4fb872cb-d9c4-56d1-8788-2f1fb5c5a112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a69dc-c6f3-459b-9dcd-b3363c26ca34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5a69dc-c6f3-459b-9dcd-b3363c26ca34.jpg?1",
             "name": "Fog Bank",
             "text": "Defender (This creature can't attack.)\nFlying\nPrevent all combat damage that would be dealt to and dealt by Fog Bank.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "9a508050-555c-59c2-98ac-bb4467648702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f7357-08b0-403e-8913-8965662a905e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0f7357-08b0-403e-8913-8965662a905e.jpg?1",
             "name": "Harbor Serpent",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nHarbor Serpent can't attack unless there are five or more Islands on the battlefield.",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "fe716009-6845-57bf-8aa2-47e07ec9d86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a22f992-ef16-45be-8bac-bd7418ed068f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a22f992-ef16-45be-8bac-bd7418ed068f.jpg?1",
             "name": "Hydrosurge",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "ed396d6b-3ce1-5c88-803c-5d695c145b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785fd0b8-7e98-44f5-8012-b9dadb31f9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785fd0b8-7e98-44f5-8012-b9dadb31f9b0.jpg?1",
             "name": "Index",
             "text": "Look at the top five cards of your library, then put them back in any order.",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "4bb72ebc-4c39-55b7-bd9e-7cd7ecd6c93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a335-2f01-4ba7-a037-453dbb1045e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b2a335-2f01-4ba7-a037-453dbb1045e9.jpg?1",
             "name": "Jace, Memory Adept",
             "text": "+1: Draw a card. Target player puts the top card of his or her library into his or her graveyard.\n0: Target player puts the top ten cards of his or her library into his or her graveyard.\n-7: Any number of target players each draw twenty cards.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "94a69517-867c-56e6-b7d0-f9edbce24669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16829504-385c-4154-8e6d-f3fbaf273890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16829504-385c-4154-8e6d-f3fbaf273890.jpg?1",
             "name": "Jace's Phantasm",
             "text": "Flying\nJace's Phantasm gets +4/+4 as long as an opponent has ten or more cards in his or her graveyard.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "38b09125-a56c-5ff9-a4a9-8d6e40d96f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a50590-9091-4632-bf8c-792e1e0a75a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a50590-9091-4632-bf8c-792e1e0a75a8.jpg?1",
             "name": "Kraken Hatchling",
             "text": "",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "16400baf-a248-586b-bf14-808abb0df528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7decbd3-c754-451c-8d63-4f31f81412d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7decbd3-c754-451c-8d63-4f31f81412d2.jpg?1",
             "name": "Master of the Pearl Trident",
             "text": "Other Merfolk creatures you control get +1/+1 and have islandwalk. (They are unblockable as long as defending player controls an Island.)",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "40d85e8e-b1f1-56ea-aa32-437612f68bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360fe4e-c9a6-42fa-a97a-8b5a0c19ef93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a360fe4e-c9a6-42fa-a97a-8b5a0c19ef93.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "a208bcee-b0bd-5368-836b-c7f33ed7cca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5870d18e-0303-4722-b7f2-a751f8e372be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5870d18e-0303-4722-b7f2-a751f8e372be.jpg?1",
             "name": "Mind Sculpt",
             "text": "Target opponent puts the top seven cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "112ddf1f-3aeb-5795-b8bf-808f45beb440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da17a86-3666-46b8-932e-daafd6a0cd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da17a86-3666-46b8-932e-daafd6a0cd69.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "48f695fa-0c00-52f1-bf6e-bd1c6ef5782e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1088f33e-cb5f-4248-ae8e-280c4e41f291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1088f33e-cb5f-4248-ae8e-280c4e41f291.jpg?1",
             "name": "Omniscience",
             "text": "You may cast nonland cards from your hand without paying their mana costs.",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "a27446d7-6e68-5616-b414-d79e185c5a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eef8431-f63c-44e0-940c-e1a38c338214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eef8431-f63c-44e0-940c-e1a38c338214.jpg?1",
             "name": "Redirect",
             "text": "You may choose new targets for target spell.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "985b24fc-0c7d-57c9-a990-bcda1734c1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e1bb0-ffe8-4e5b-9a9a-f542ab439d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09e1bb0-ffe8-4e5b-9a9a-f542ab439d3c.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "5bbf835e-d415-507d-b21c-6da1a80d0f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc201a82-fb48-4bb4-b072-e206e6872aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc201a82-fb48-4bb4-b072-e206e6872aa5.jpg?1",
             "name": "Scroll Thief",
             "text": "Whenever Scroll Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "c16a43df-9667-59b8-b636-c28cc193b093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e352497-1454-4917-b38c-4cc45424d876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e352497-1454-4917-b38c-4cc45424d876.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "51a71cf3-771e-5afb-81bd-4daa87b91141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d2f5ab-c6be-4661-843c-51b4977a9bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d2f5ab-c6be-4661-843c-51b4977a9bea.jpg?1",
             "name": "Spelltwine",
             "text": "Exile target instant or sorcery card from your graveyard and target instant or sorcery card from an opponent's graveyard. Copy those cards. Cast the copies if able without paying their mana costs. Exile Spelltwine.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "b5ce85b2-d557-5207-b34d-1a49c23a6d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4462978c-0076-466b-a64b-0f54d09d4f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4462978c-0076-466b-a64b-0f54d09d4f27.jpg?1",
             "name": "Sphinx of Uthuun",
             "text": "Flying\nWhen Sphinx of Uthuun enters the battlefield, reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "962af17c-828f-565b-994e-8e9353dbd14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9797351-eb0c-4774-8dbb-61a2404d66d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9797351-eb0c-4774-8dbb-61a2404d66d9.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "8e11e9a5-8a67-5027-86b8-b493fa5b840c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d62aaf3-0fd4-44ba-8eeb-18ac759dfe84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d62aaf3-0fd4-44ba-8eeb-18ac759dfe84.jpg?1",
             "name": "Switcheroo",
             "text": "Exchange control of two target creatures.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "28000960-fe86-5bce-b0fc-254fd7752222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1a6867-921d-4912-afae-c3c445ad81e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1a6867-921d-4912-afae-c3c445ad81e7.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, put a 2/2 blue Drake creature token with flying onto the battlefield.",
             "colours": [
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "3ffb8c00-7223-551f-881b-895c7a4ad74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg?1",
             "name": "Talrand's Invocation",
             "text": "Put two 2/2 blue Drake creature tokens with flying onto the battlefield.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "063cf2eb-3dce-5488-b906-2e6184530cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c796ef9-4061-4f82-9ee9-3bc446804ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c796ef9-4061-4f82-9ee9-3bc446804ee9.jpg?1",
             "name": "Tricks of the Trade",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and is unblockable.",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "13076da1-5077-57a8-81b0-ea8f8b961928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84402e82-bae7-470a-8b2f-929dac888018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84402e82-bae7-470a-8b2f-929dac888018.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "9d83a693-e7fe-51e4-8c25-59d0d4864c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bbd25-5ddd-4502-b582-b7d89c9f97a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bbd25-5ddd-4502-b582-b7d89c9f97a5.jpg?1",
             "name": "Vedalken Entrancer",
             "text": "{U}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2560,7 +2560,7 @@
         },
         {
             "id": "076bf295-c6d3-5f3a-b475-9d6d280d7bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc30e31-4796-4e98-992c-a56cd51ad3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc30e31-4796-4e98-992c-a56cd51ad3c9.jpg?1",
             "name": "Void Stalker",
             "text": "{2}{U}, {T}: Put Void Stalker and target creature on top of their owners' libraries, then those players shuffle their libraries.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "1e1ac4d6-e243-5f6d-8d1b-42566f281841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg?1",
             "name": "Watercourser",
             "text": "{U}: Watercourser gets +1/-1 until end of turn.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "f102fa44-7718-5a6c-b74d-0e7fe34805a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3c6dc6-4a16-4a01-822e-353ff84b363c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3c6dc6-4a16-4a01-822e-353ff84b363c.jpg?1",
             "name": "Welkin Tern",
             "text": "Flying\nWelkin Tern can block only creatures with flying.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "9d872868-5067-5cee-87ad-0c9fdc590f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dcb8d2-0da9-40fc-b0c0-2c76b3d277bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dcb8d2-0da9-40fc-b0c0-2c76b3d277bc.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "08d03e4e-6f7e-547b-b672-bb7da54a82ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24577bb2-61b0-4675-84e6-5d675b28fc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24577bb2-61b0-4675-84e6-5d675b28fc0e.jpg?1",
             "name": "Blood Reckoning",
             "text": "Whenever a creature attacks you or a planeswalker you control, that creature's controller loses 1 life.",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "91350720-e5d2-5a3f-80ec-ad280df16963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c10705-6e0e-46f6-a64c-0095b2796aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c10705-6e0e-46f6-a64c-0095b2796aaf.jpg?1",
             "name": "Bloodhunter Bat",
             "text": "Flying\nWhen Bloodhunter Bat enters the battlefield, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "0ca3149b-2bc9-505d-bb82-b76bb935514a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b87e0-d5e4-44f2-8220-325443ee9f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0b87e0-d5e4-44f2-8220-325443ee9f31.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "39f03f22-4d66-5e7a-9415-6071688dffd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2d53b8-7847-4b94-9711-eca29facccba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2d53b8-7847-4b94-9711-eca29facccba.jpg?1",
             "name": "Cower in Fear",
             "text": "Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "021fdfa6-0892-522e-8cd5-c4b2dce64ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96a5d6-6527-4018-923e-7e850fda106a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a96a5d6-6527-4018-923e-7e850fda106a.jpg?1",
             "name": "Crippling Blight",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 and can't block.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "04235c6c-f85e-512f-acee-f6a42623eebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aae919b-7da6-42b1-84b4-fbc2971dad1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aae919b-7da6-42b1-84b4-fbc2971dad1e.jpg?1",
             "name": "Dark Favor",
             "text": "Enchant creature\nWhen Dark Favor enters the battlefield, you lose 1 life.\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "472e4e60-e148-5070-a8e3-8216977a3619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d6d7b-1e87-47b7-baf3-d201458ad996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d6d7b-1e87-47b7-baf3-d201458ad996.jpg?1",
             "name": "Diabolic Revelation",
             "text": "Search your library for up to X cards and put those cards into your hand. Then shuffle your library.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "afd75423-f235-5e78-bc07-21e2494709a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dd57f8-27bc-4ad9-a79e-48a68af33b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dd57f8-27bc-4ad9-a79e-48a68af33b02.jpg?1",
             "name": "Disciple of Bolas",
             "text": "When Disciple of Bolas enters the battlefield, sacrifice another creature. You gain X life and draw X cards, where X is that creature's power.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "1d381318-0d8b-5296-a796-ca7e365ddff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7473bb-d092-4d76-b3c3-5036222dbdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7473bb-d092-4d76-b3c3-5036222dbdf7.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2995,7 +2995,7 @@
         },
         {
             "id": "59409e7e-5488-5244-8445-889e4b517887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7201d43-ae2e-4faa-a508-8555079c3bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7201d43-ae2e-4faa-a508-8555079c3bc7.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "99408690-6cfc-5bb3-8048-bf1d2ee7e61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb031da-d41a-496a-b78e-0773f6504303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb031da-d41a-496a-b78e-0773f6504303.jpg?1",
             "name": "Duskmantle Prowler",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3062,7 +3062,7 @@
         },
         {
             "id": "4ee1448f-022e-50a9-ab15-039f881fb9ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5150aa90-1284-4261-8625-2528139f0015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5150aa90-1284-4261-8625-2528139f0015.jpg?1",
             "name": "Duty-Bound Dead",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{3}{B}: Regenerate Duty-Bound Dead. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "2c9a3a8a-228e-57cb-9a53-230f5d1cc6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58df0c6d-3fd2-4d87-81e2-6640e6e75985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58df0c6d-3fd2-4d87-81e2-6640e6e75985.jpg?1",
             "name": "Essence Drain",
             "text": "Essence Drain deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "f7872890-bf93-5c14-9ee6-56d1f009ea5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4097d5dc-46d3-4054-818f-a4ad8d7effe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4097d5dc-46d3-4054-818f-a4ad8d7effe2.jpg?1",
             "name": "Giant Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "111a7a58-860f-55ca-8624-977d4336007a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8422e109-de8d-46ea-a7f8-d5ccb6340497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8422e109-de8d-46ea-a7f8-d5ccb6340497.jpg?1",
             "name": "Harbor Bandit",
             "text": "Harbor Bandit gets +1/+1 as long as you control an Island.\n{1}{U}: Harbor Bandit is unblockable this turn.",
             "colours": [
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "0b150421-dca3-56e9-969c-ae7ded06b8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e339853-5b6b-47b7-8d88-e9d3befb803f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e339853-5b6b-47b7-8d88-e9d3befb803f.jpg?1",
             "name": "Knight of Infamy",
             "text": "Protection from white (This creature can't be blocked, targeted, dealt damage, or enchanted by anything white.)\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3233,7 +3233,7 @@
         },
         {
             "id": "65abbbeb-78ed-517a-807e-055e275e7651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd2d81e-1388-4f34-9917-2289971cf8da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd2d81e-1388-4f34-9917-2289971cf8da.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.\n-3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.\n-6: You get an emblem with \"Swamps you control have \u2018{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "6e84ea5f-2c26-5b72-ac31-47d47d5019ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf0c01d-a4a0-43fb-970d-e428e9ac63d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf0c01d-a4a0-43fb-970d-e428e9ac63d7.jpg?1",
             "name": "Liliana's Shade",
             "text": "When Liliana's Shade enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.\n{B}: Liliana's Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "aef14ede-00d8-57d6-9629-05135dacf6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90484815-2529-4a81-9f1b-f0f7382e4b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90484815-2529-4a81-9f1b-f0f7382e4b66.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -3337,7 +3337,7 @@
         },
         {
             "id": "4ae19376-b895-5d88-af47-4035c8d7cbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab454fb8-347f-4d4d-84bb-195c9d51b06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab454fb8-347f-4d4d-84bb-195c9d51b06b.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "61210625-568f-5cad-81f5-f0a5bf2ac1cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8676f02-cf1e-4d40-a0c5-6e5a97417898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8676f02-cf1e-4d40-a0c5-6e5a97417898.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "c83a7592-5879-5d52-b27c-e866597b389f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48bc86b-df0a-4a9c-8aad-c3ffb742a5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48bc86b-df0a-4a9c-8aad-c3ffb742a5ff.jpg?1",
             "name": "Mutilate",
             "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
             "colours": [
@@ -3433,7 +3433,7 @@
         },
         {
             "id": "86f8b444-0047-536c-94f1-7b6b16a577f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc382f3-fdb9-4987-acf4-bf1ac4fd2ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc382f3-fdb9-4987-acf4-bf1ac4fd2ef7.jpg?1",
             "name": "Nefarox, Overlord of Grixis",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever Nefarox, Overlord of Grixis attacks alone, defending player sacrifices a creature.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "5f878d93-ee9e-569b-97bc-1457fa61c9eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefd084-548d-4326-901e-832a1b5f5391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aefd084-548d-4326-901e-832a1b5f5391.jpg?1",
             "name": "Phylactery Lich",
             "text": "As Phylactery Lich enters the battlefield, put a phylactery counter on an artifact you control.\nPhylactery Lich is indestructible.\nWhen you control no permanents with phylactery counters on them, sacrifice Phylactery Lich.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "d0c680be-4ab8-519b-9700-a869e8db68f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48188942-d0ba-4503-bd75-c7a5329bb7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48188942-d0ba-4503-bd75-c7a5329bb7c8.jpg?1",
             "name": "Public Execution",
             "text": "Destroy target creature an opponent controls. Each other creature that player controls gets -2/-0 until end of turn.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "827a6245-3970-5fbb-8f5d-b416b2e56058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0642111c-f668-4acb-9df5-f0b920352407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0642111c-f668-4acb-9df5-f0b920352407.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats enters the battlefield, target opponent discards a card.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "f11730f2-5e97-56dc-8800-8af27fbd66ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2b187e-c489-4652-a638-390fc9ecef0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d2b187e-c489-4652-a638-390fc9ecef0e.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3601,7 +3601,7 @@
         },
         {
             "id": "a8fb628c-412f-5591-9cdc-da73a05c8cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00a2b22-a473-44ae-919f-29bc8be05543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00a2b22-a473-44ae-919f-29bc8be05543.jpg?1",
             "name": "Servant of Nefarox",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "1389690c-8159-58c2-9596-41d508cc02ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca9e99b-e46c-4f7a-9c51-e2cfe8810450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca9e99b-e46c-4f7a-9c51-e2cfe8810450.jpg?1",
             "name": "Shimian Specter",
             "text": "Flying\nWhenever Shimian Specter deals combat damage to a player, that player reveals his or her hand. You choose a nonland card from it. Search that player's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "1634e202-7f16-57e8-8e6a-2bb1df01fd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f6600b-36c4-43bd-8c01-cfbca402ecd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f6600b-36c4-43bd-8c01-cfbca402ecd6.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "796d99ec-fc14-52fb-bc2d-d3dcb7b0b912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87810963-9c62-4ff2-b33b-51fcc1b628ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87810963-9c62-4ff2-b33b-51fcc1b628ac.jpg?1",
             "name": "Tormented Soul",
             "text": "Tormented Soul can't block and is unblockable.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "b8633374-5684-5594-b2a1-411cf35c2cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba96d96-8d9e-47c8-ab39-17479564aadf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba96d96-8d9e-47c8-ab39-17479564aadf.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "5162957f-dfb9-5994-8931-a2cbd902f5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daccbbb-6600-4467-810f-277f01a11771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8daccbbb-6600-4467-810f-277f01a11771.jpg?1",
             "name": "Vampire Nocturnus",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is black, Vampire Nocturnus and other Vampire creatures you control get +2/+1 and have flying.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "78804616-fdb9-50c2-a6b7-afedd93925e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f49232-2853-427f-8c20-322e09a3ccde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3f49232-2853-427f-8c20-322e09a3ccde.jpg?1",
             "name": "Veilborn Ghoul",
             "text": "Veilborn Ghoul can't block.\nWhenever a Swamp enters the battlefield under your control, you may return Veilborn Ghoul from your graveyard to your hand.",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "f10f36d4-5794-57c2-a13e-d349278347f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965b5a48-d0ff-47ce-b44e-a1611fab1876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965b5a48-d0ff-47ce-b44e-a1611fab1876.jpg?1",
             "name": "Vile Rebirth",
             "text": "Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3871,7 +3871,7 @@
         },
         {
             "id": "d457eb9c-d5bb-52e8-98d8-b2f871e2be3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecfc1ab-b7a1-43a8-b1d1-0c1c4358e89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecfc1ab-b7a1-43a8-b1d1-0c1c4358e89f.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "8ee895d6-5c4f-54bc-8c4a-46a0cd02165b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71298c75-533e-4ccd-a1f5-875f63a1e89b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71298c75-533e-4ccd-a1f5-875f63a1e89b.jpg?1",
             "name": "Wit's End",
             "text": "Target player discards his or her hand.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "61f82d27-9f83-5c0f-be8d-faf71b93601e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07524e0-303d-465d-b112-ca605b9b27fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07524e0-303d-465d-b112-ca605b9b27fc.jpg?1",
             "name": "Xathrid Gorgon",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{2}{B}, {T}: Put a petrification counter on target creature. It gains defender and becomes a colorless artifact in addition to its other types. Its activated abilities can't be activated. (A creature with defender can't attack.)",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "0c019a95-4852-5b61-b93b-41fa57d8271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8638edec-ddcd-4f50-9c2f-2e1668e3d175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8638edec-ddcd-4f50-9c2f-2e1668e3d175.jpg?1",
             "name": "Zombie Goliath",
             "text": "",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "fc216486-22f0-52a0-b6bc-dfbbf09d38c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910d3c33-8cda-487b-8b44-87a9d06d6749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910d3c33-8cda-487b-8b44-87a9d06d6749.jpg?1",
             "name": "Arms Dealer",
             "text": "{1}{R}, Sacrifice a Goblin: Arms Dealer deals 4 damage to target creature.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "a33d6408-0871-57c6-9839-8d34eb25423d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28442f9-06cf-4273-80a3-2b054f5881a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28442f9-06cf-4273-80a3-2b054f5881a4.jpg?1",
             "name": "Bladetusk Boar",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -4075,7 +4075,7 @@
         },
         {
             "id": "7d0dd3e2-abc7-57a1-9e02-09e3620f9563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8dc0efb-5847-4061-b386-9b4099361a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8dc0efb-5847-4061-b386-9b4099361a58.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4110,7 +4110,7 @@
         },
         {
             "id": "475afe64-6be5-5bd4-a672-535b5f28f181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb039db-7367-4af1-8d85-4951f58e2732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb039db-7367-4af1-8d85-4951f58e2732.jpg?1",
             "name": "Chandra, the Firebrand",
             "text": "+1: Chandra, the Firebrand deals 1 damage to target creature or player.\n-2: When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\n-6: Chandra, the Firebrand deals 6 damage to each of up to six target creatures and/or players.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "1f552e47-2b5a-508d-8c2f-2d5877d052a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25335fee-d320-4622-bcf4-292400dee52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25335fee-d320-4622-bcf4-292400dee52b.jpg?1",
             "name": "Chandra's Fury",
             "text": "Chandra's Fury deals 4 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "1e4ee3b4-f7ec-578b-87d8-950bd356a567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6761eacf-03fc-4ccd-a4a6-eca5357b5c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6761eacf-03fc-4ccd-a4a6-eca5357b5c5b.jpg?1",
             "name": "Cleaver Riot",
             "text": "Creatures you control gain double strike until end of turn. (They deal both first-strike and regular combat damage.)",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "aa1cbe58-fefa-5fe2-9833-7821f700bfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5459409-5103-4a97-a6fb-3e3ab896eb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5459409-5103-4a97-a6fb-3e3ab896eb66.jpg?1",
             "name": "Craterize",
             "text": "Destroy target land.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "395d4648-fc79-581e-9fdc-6d06e2ad33ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0811f91-ed92-4a8e-badd-ae5054e7707d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0811f91-ed92-4a8e-badd-ae5054e7707d.jpg?1",
             "name": "Crimson Muckwader",
             "text": "Crimson Muckwader gets +1/+1 as long as you control a Swamp.\n{2}{B}: Regenerate Crimson Muckwader. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "f9a922e1-b301-5025-869c-f6ce572ee929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed599d52-f2d9-4913-ad88-70f8aa4af7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed599d52-f2d9-4913-ad88-70f8aa4af7b9.jpg?1",
             "name": "Dragon Hatchling",
             "text": "Flying\n{R}: Dragon Hatchling gets +1/+0 until end of turn.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "b9d6d25f-065f-5d45-92e7-32b95cad4c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88515c2-4b4f-4d16-9f50-149ef012e961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88515c2-4b4f-4d16-9f50-149ef012e961.jpg?1",
             "name": "Fervor",
             "text": "Creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "f4f06594-b013-5f70-ab7b-f2f9e99b5d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39716c6-6c4f-4cd3-9d9c-893f883e6e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39716c6-6c4f-4cd3-9d9c-893f883e6e70.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "e3fae620-b080-5347-b2e1-e776ccc404f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8824674-ced2-448e-9bf0-03c1c43a5315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8824674-ced2-448e-9bf0-03c1c43a5315.jpg?1",
             "name": "Firewing Phoenix",
             "text": "Flying\n{1}{R}{R}{R}: Return Firewing Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "22f8b08f-02d6-5b78-8a11-038c85181e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca215b1-7b98-49ce-afae-eeb61058125a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca215b1-7b98-49ce-afae-eeb61058125a.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "aeb832d1-327f-5458-9a1f-cc047e0861ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e73d9c-8c17-4c3c-b535-e21f03e577bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e73d9c-8c17-4c3c-b535-e21f03e577bc.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "3208bcd9-53d3-580b-ae23-349167ad1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d131369-db00-4a11-bd47-4401188b0f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d131369-db00-4a11-bd47-4401188b0f35.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist dies, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "06770c5c-c004-5229-9832-ce9a98283a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e56b0-becc-4bc2-9ba3-23b3ca8bfe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13e56b0-becc-4bc2-9ba3-23b3ca8bfe58.jpg?1",
             "name": "Goblin Battle Jester",
             "text": "Whenever you cast a red spell, target creature can't block this turn.",
             "colours": [
@@ -4546,7 +4546,7 @@
         },
         {
             "id": "261f00f6-bfae-5cba-804d-5f2d4ff7d319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ddeef1-f6f9-48c0-a93c-7bb3877c0e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ddeef1-f6f9-48c0-a93c-7bb3877c0e59.jpg?1",
             "name": "Hamletback Goliath",
             "text": "Whenever another creature enters the battlefield, you may put X +1/+1 counters on Hamletback Goliath, where X is that creature's power.",
             "colours": [
@@ -4581,7 +4581,7 @@
         },
         {
             "id": "3bd30bb4-9dea-56df-9e81-0a8519284e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35494897-b72b-46c4-8b36-b3b8865559bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35494897-b72b-46c4-8b36-b3b8865559bd.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "6f6ac82f-7964-5c58-a987-e1cf8b99088e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa078518-0ce2-4c6f-9061-aa7e22ed7493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa078518-0ce2-4c6f-9061-aa7e22ed7493.jpg?1",
             "name": "Krenko, Mob Boss",
             "text": "{T}: Put X 1/1 red Goblin creature tokens onto the battlefield, where X is the number of Goblins you control.",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "26240a77-96c1-5021-8e10-b7e4bd05a6ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84df41e9-e973-4441-b17f-434517134d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84df41e9-e973-4441-b17f-434517134d46.jpg?1",
             "name": "Krenko's Command",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "af9f9a60-9ae7-5f39-8e3e-94395552950f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac85679e-17c7-4525-8eed-979d04feb8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac85679e-17c7-4525-8eed-979d04feb8f1.jpg?1",
             "name": "Magmaquake",
             "text": "Magmaquake deals X damage to each creature without flying and each planeswalker.",
             "colours": [
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "5933b0ea-ce62-5d29-be1e-ad1a7bb1fa44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c6e09-3a14-4cc4-ba6b-f1f45e7d9f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7c6e09-3a14-4cc4-ba6b-f1f45e7d9f2a.jpg?1",
             "name": "Mark of Mutiny",
             "text": "Gain control of target creature until end of turn. Put a +1/+1 counter on it and untap it. That creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "2e848bd5-e16b-5414-9365-5e4c22ca8443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f342fe9-aa73-4222-b908-d4035b5746be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f342fe9-aa73-4222-b908-d4035b5746be.jpg?1",
             "name": "Mindclaw Shaman",
             "text": "When Mindclaw Shaman enters the battlefield, target opponent reveals his or her hand. You may cast an instant or sorcery card from it without paying its mana cost.",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "106a40e3-7d29-55e4-bd49-28d96c22be89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f1b5d-1b16-4f35-9cce-2f089905fddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2f1b5d-1b16-4f35-9cce-2f089905fddd.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies can't attack or block alone.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "727403d8-c530-51a2-aa03-b6520ec7bb2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd32a9e-1d39-4792-9657-69d17e5e0134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd32a9e-1d39-4792-9657-69d17e5e0134.jpg?1",
             "name": "Reckless Brute",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nReckless Brute attacks each turn if able.",
             "colours": [
@@ -4850,7 +4850,7 @@
         },
         {
             "id": "5bed790f-4851-5883-87cc-3086b9a4a473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5996feb4-02ac-45e8-a7f2-966cf74391dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5996feb4-02ac-45e8-a7f2-966cf74391dc.jpg?1",
             "name": "Reverberate",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4882,7 +4882,7 @@
         },
         {
             "id": "e1fa03e3-9510-5a65-ae3f-992d5465e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5b622c-83a4-477e-a99c-2674e2bd6bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5b622c-83a4-477e-a99c-2674e2bd6bb9.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -4917,7 +4917,7 @@
         },
         {
             "id": "50e57ed0-8be5-5adf-9517-a65c029066e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94b7c-0216-473c-87a6-71e5a64d7799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a94b7c-0216-473c-87a6-71e5a64d7799.jpg?1",
             "name": "Searing Spear",
             "text": "Searing Spear deals 3 damage to target creature or player.",
             "colours": [
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "d20d6408-52a3-51b6-9c45-f283504cb155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277cbd0d-c8da-4a37-965c-6a60771df2f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277cbd0d-c8da-4a37-965c-6a60771df2f7.jpg?1",
             "name": "Slumbering Dragon",
             "text": "Flying\nSlumbering Dragon can't attack or block unless it has five or more +1/+1 counters on it.\nWhenever a creature attacks you or a planeswalker you control, put a +1/+1 counter on Slumbering Dragon.",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "bf9f48d0-70bb-59e6-9bb7-116a924204a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723cb7e3-3f48-41fa-aa08-bdc59225e44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723cb7e3-3f48-41fa-aa08-bdc59225e44f.jpg?1",
             "name": "Smelt",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "a8201bce-861c-5ed3-a623-bdf85fd25f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0476e0f-61df-46a6-aaf1-8ee79c701160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0476e0f-61df-46a6-aaf1-8ee79c701160.jpg?1",
             "name": "Thundermaw Hellkite",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Thundermaw Hellkite enters the battlefield, it deals 1 damage to each creature with flying your opponents control. Tap those creatures.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "f0e82cfa-c495-5272-ad22-89864ab5988f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd53740-43bb-4ea2-aa01-937a5786ccda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd53740-43bb-4ea2-aa01-937a5786ccda.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "c2d8d96a-ef84-5e47-86ed-3e3b9f1161df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac9f745-236a-4302-acf2-21c14c6e6eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac9f745-236a-4302-acf2-21c14c6e6eab.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "9c9739d7-7c3b-597d-9664-a941a92f25da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275ede4-22d6-41db-91e9-3b0295abb8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275ede4-22d6-41db-91e9-3b0295abb8a9.jpg?1",
             "name": "Turn to Slag",
             "text": "Turn to Slag deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "a22888a9-1582-5a17-bea3-df355a6e06ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5bab70-3c28-48db-9ed3-64706f64f4fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5bab70-3c28-48db-9ed3-64706f64f4fa.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -5179,7 +5179,7 @@
         },
         {
             "id": "0a5bf01e-c04c-5a66-b0a8-3817df77ca27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1963f08-1765-4f3e-92be-479773de47a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1963f08-1765-4f3e-92be-479773de47a0.jpg?1",
             "name": "Volcanic Strength",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has mountainwalk. (It's unblockable as long as defending player controls a Mountain.)",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "8cd69997-bdf1-574a-8ea7-d628995e14ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242e0b6-76c8-4cc6-b914-1dc7842d5a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b242e0b6-76c8-4cc6-b914-1dc7842d5a9c.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "c4b9e162-99d9-59f1-81bb-d8b31ac07c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e513b8-25c2-4645-abcc-a6e9d5f51e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e513b8-25c2-4645-abcc-a6e9d5f51e09.jpg?1",
             "name": "Wild Guess",
             "text": "As an additional cost to cast Wild Guess, discard a card.\nDraw two cards.",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "3f5e4645-8b53-52f0-b7b8-56a7edcf51a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3d4b5-0453-4bf0-b018-23b0c3b9ae11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef3d4b5-0453-4bf0-b018-23b0c3b9ae11.jpg?1",
             "name": "Worldfire",
             "text": "Exile all permanents. Exile all cards from all hands and graveyards. Each player's life total becomes 1.",
             "colours": [
@@ -5311,7 +5311,7 @@
         },
         {
             "id": "007e7aeb-7d23-51fb-8252-1b63881afdb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7bef5a-e0ab-46d3-a802-620bf2a7546f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7bef5a-e0ab-46d3-a802-620bf2a7546f.jpg?1",
             "name": "Acidic Slime",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Acidic Slime enters the battlefield, destroy target artifact, enchantment, or land.",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "0ea513ec-c1e3-51cd-9193-04423fabc13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6b117-0c14-4455-92fc-29555ee75d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6b117-0c14-4455-92fc-29555ee75d97.jpg?1",
             "name": "Arbor Elf",
             "text": "{T}: Untap target Forest.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "f505cac2-a76c-55a3-8cd5-a8ec94e99778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f341ed2c-353b-49a3-b200-94ae43cb8e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f341ed2c-353b-49a3-b200-94ae43cb8e24.jpg?1",
             "name": "Bond Beetle",
             "text": "When Bond Beetle enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -5414,7 +5414,7 @@
         },
         {
             "id": "69dabc80-76ee-5f99-bb46-a761ea0fa86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c3cf16-ba81-4558-b1a6-79942a02f629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c3cf16-ba81-4558-b1a6-79942a02f629.jpg?1",
             "name": "Boundless Realms",
             "text": "Search your library for up to X basic land cards, where X is the number of lands you control, and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "2baa6de2-96c7-5de5-9101-42d0f472b7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7a4494-2ced-4405-9204-d2617961a1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7a4494-2ced-4405-9204-d2617961a1d6.jpg?1",
             "name": "Bountiful Harvest",
             "text": "You gain 1 life for each land you control.",
             "colours": [
@@ -5478,7 +5478,7 @@
         },
         {
             "id": "d6a28ccf-e304-5bf8-aa8e-305b1209991d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a5f7db-ea4e-4af5-9d4a-0335db6ea0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a5f7db-ea4e-4af5-9d4a-0335db6ea0e9.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "5bb2b358-a9d5-5fc5-a44e-09a695614216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a5f77-7c1f-4da4-9ae6-3947504a8dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a5f77-7c1f-4da4-9ae6-3947504a8dea.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "46ac4537-310e-563f-b5b6-818395da2a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1a2d9a-e14c-4c44-8cf1-a2ce09bdae27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1a2d9a-e14c-4c44-8cf1-a2ce09bdae27.jpg?1",
             "name": "Duskdale Wurm",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "79bff4a9-9eb3-53e9-b9e6-b4d587a35538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f3f63d-0f04-4945-9895-940c916a2547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f3f63d-0f04-4945-9895-940c916a2547.jpg?1",
             "name": "Elderscale Wurm",
             "text": "Trample\nWhen Elderscale Wurm enters the battlefield, if your life total is less than 7, your life total becomes 7.\nAs long as you have 7 or more life, damage that would reduce your life total to less than 7 reduces it to 7 instead.",
             "colours": [
@@ -5615,7 +5615,7 @@
         },
         {
             "id": "c2cf6ae1-f244-5625-91da-25317a3cb09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8eba57-8c51-490b-995f-53eeb7ad574f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8eba57-8c51-490b-995f-53eeb7ad574f.jpg?1",
             "name": "Elvish Archdruid",
             "text": "Other Elf creatures you control get +1/+1.\n{T}: Add {G} to your mana pool for each Elf you control.",
             "colours": [
@@ -5650,7 +5650,7 @@
         },
         {
             "id": "686e4cf2-6f63-59ac-8d76-66d668ba7d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ea2998-ed91-43b8-bd81-b01a6c24a5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ea2998-ed91-43b8-bd81-b01a6c24a5b0.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -5685,7 +5685,7 @@
         },
         {
             "id": "da73dc10-1286-5c38-a2d0-92ae64f49690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b69d33-96dd-4844-aefa-27a885cb2ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b69d33-96dd-4844-aefa-27a885cb2ffc.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "f9c30eac-dc99-5085-80eb-54de011b0cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e380b99-0173-4083-a4a2-222ad98b904a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e380b99-0173-4083-a4a2-222ad98b904a.jpg?1",
             "name": "Flinthoof Boar",
             "text": "Flinthoof Boar gets +1/+1 as long as you control a Mountain.\n{R}: Flinthoof Boar gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -5752,7 +5752,7 @@
         },
         {
             "id": "57ae6f28-6f61-5f75-aeee-74f160fcc848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d591ad-4f3d-4cc6-a888-e30b46ee0771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d591ad-4f3d-4cc6-a888-e30b46ee0771.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5784,7 +5784,7 @@
         },
         {
             "id": "0946c734-2e89-5bb9-bf9d-6f729881dd0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97413ae3-037e-4786-85a3-e92604acd771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97413ae3-037e-4786-85a3-e92604acd771.jpg?1",
             "name": "Fungal Sprouting",
             "text": "Put X 1/1 green Saproling creature tokens onto the battlefield, where X is the greatest power among creatures you control.",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "41068a76-cd6a-556d-84bf-c9b733434010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9945307b-d49d-4d21-bba0-2aebba68d57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9945307b-d49d-4d21-bba0-2aebba68d57a.jpg?1",
             "name": "Garruk, Primal Hunter",
             "text": "+1: Put a 3/3 green Beast creature token onto the battlefield.\n-3: Draw cards equal to the greatest power among creatures you control.\n-6: Put a 6/6 green Wurm creature token onto the battlefield for each land you control.",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "73fae159-c38b-5a6b-88fd-bdf7b9e4c4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa6257-614b-4f39-b7fa-ea5f12f94b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa6257-614b-4f39-b7fa-ea5f12f94b64.jpg?1",
             "name": "Garruk's Packleader",
             "text": "Whenever another creature with power 3 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -5886,7 +5886,7 @@
         },
         {
             "id": "a652e71c-b731-52a1-972a-6f4a3d15e5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6933959a-485f-41a1-a8d9-3bfa416a0faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6933959a-485f-41a1-a8d9-3bfa416a0faa.jpg?1",
             "name": "Ground Seal",
             "text": "When Ground Seal enters the battlefield, draw a card.\nCards in graveyards can't be the targets of spells or abilities.",
             "colours": [
@@ -5918,7 +5918,7 @@
         },
         {
             "id": "131f4662-ee3a-5757-b72e-9149d14e993f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0034d32c-cc82-48d7-a913-d58cc3d3afeb.jpg?1",
             "name": "Mwonvuli Beast Tracker",
             "text": "When Mwonvuli Beast Tracker enters the battlefield, search your library for a creature card with deathtouch, hexproof, reach, or trample and reveal it. Shuffle your library and put that card on top of it.",
             "colours": [
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "1c9cf673-2db5-54d3-b52e-5cfe4288428f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2db6f65-5160-4c10-8a24-f8d4f106adcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2db6f65-5160-4c10-8a24-f8d4f106adcd.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -5985,7 +5985,7 @@
         },
         {
             "id": "b4251e1e-d773-5829-b1f0-0d8d1e60238e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d7d96-5a86-45ef-a30b-b11ece22f060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d7d96-5a86-45ef-a30b-b11ece22f060.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "91f4cde8-72bb-57ae-8d8e-722f9069bd93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e054ea5-3657-4198-9715-6acc0e362da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e054ea5-3657-4198-9715-6acc0e362da3.jpg?1",
             "name": "Predatory Rampage",
             "text": "Creatures you control get +3/+3 until end of turn. Each creature your opponents control blocks this turn if able.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "18602865-c7d3-53f7-bb2e-447067534aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e074cc1d-8f94-4155-974e-574c1dd82e1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e074cc1d-8f94-4155-974e-574c1dd82e1f.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "a9a3e49b-5d9b-5aaf-b0bf-6fc61aaff778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb77f6a8-a9d6-4fdd-996e-70877199ebab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb77f6a8-a9d6-4fdd-996e-70877199ebab.jpg?1",
             "name": "Primal Huntbeast",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "8ad92b7f-de56-573e-996b-c9c6221cff82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937deb52-8888-4298-9ae5-0361c6fdbba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937deb52-8888-4298-9ae5-0361c6fdbba2.jpg?1",
             "name": "Primordial Hydra",
             "text": "Primordial Hydra enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Primordial Hydra.\nPrimordial Hydra has trample as long as it has ten or more +1/+1 counters on it.",
             "colours": [
@@ -6149,7 +6149,7 @@
         },
         {
             "id": "943f9187-1dab-5f5c-8d47-82896d631be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dba7f54-e49e-4f10-b5c5-46bb20871871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dba7f54-e49e-4f10-b5c5-46bb20871871.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you cast a white, blue, black, or red spell, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "781e925d-3b83-5253-8203-509fd8f6929e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b982558f-5b82-4918-9b54-c7ac1e6f8da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b982558f-5b82-4918-9b54-c7ac1e6f8da5.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "73f4e4b1-727d-5d8c-a591-42246df8db08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26858a53-1054-407a-b2a2-34a7c4ae0f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26858a53-1054-407a-b2a2-34a7c4ae0f10.jpg?1",
             "name": "Ranger's Path",
             "text": "Search your library for up to two Forest cards and put them onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -6249,7 +6249,7 @@
         },
         {
             "id": "de1147e8-13d2-5e16-92c0-a478b6770b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9aae03-f29b-4da6-a0cb-edd67bb111f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9aae03-f29b-4da6-a0cb-edd67bb111f5.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "12b3668d-1ac1-5453-9b19-6949cfe6c7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529b2f-03f0-469d-92d4-e2a2a933d5dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529b2f-03f0-469d-92d4-e2a2a933d5dc.jpg?1",
             "name": "Roaring Primadox",
             "text": "At the beginning of your upkeep, return a creature you control to its owner's hand.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "9b9d82ae-f3f0-5476-ab87-5e466e8bd630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f55ff4b-f0e1-498b-982b-e6ec01d30d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f55ff4b-f0e1-498b-982b-e6ec01d30d95.jpg?1",
             "name": "Sentinel Spider",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "b70c1bba-851d-5959-8f45-3192e498c0e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e27503e-059e-4c44-a817-678e67254111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e27503e-059e-4c44-a817-678e67254111.jpg?1",
             "name": "Serpent's Gift",
             "text": "Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "1aed0ab9-64ca-5a61-9a96-0cc34571318c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1bb9-dbfd-4094-bda0-9a19817ce4bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1bb9-dbfd-4094-bda0-9a19817ce4bc.jpg?1",
             "name": "Silklash Spider",
             "text": "Reach (This creature can block creatures with flying.)\n{X}{G}{G}: Silklash Spider deals X damage to each creature with flying.",
             "colours": [
@@ -6415,7 +6415,7 @@
         },
         {
             "id": "421feca8-2b00-589a-be20-b42a576c7713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522777b1-a89f-4969-a962-0137018ec86c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522777b1-a89f-4969-a962-0137018ec86c.jpg?1",
             "name": "Spiked Baloth",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "2f73b011-3a64-5ba0-986a-a0c1f7302e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28667c8b-d02c-4e57-a050-1549207b65d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28667c8b-d02c-4e57-a050-1549207b65d1.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, put a 3/3 green Beast creature token onto the battlefield.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "0717fbf0-b455-59ad-b0e0-7dce7dee2288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16928c9-0470-46ec-b92d-0d6ff9f23ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16928c9-0470-46ec-b92d-0d6ff9f23ef7.jpg?1",
             "name": "Timberpack Wolf",
             "text": "Timberpack Wolf gets +1/+1 for each other creature you control named Timberpack Wolf.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "77fbef90-f386-59c6-875d-123f4a97bb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1fb9f8-c070-40c9-89cd-c74eb8dbbf1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1fb9f8-c070-40c9-89cd-c74eb8dbbf1a.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "137e14b7-75c7-5fe5-bdf1-d4c26636cb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fc4a5f-1c59-4139-a506-72baebb1168f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fc4a5f-1c59-4139-a506-72baebb1168f.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "eb2bb4c5-b173-5f3d-899b-96578309e2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acb6dc-a9bd-4f12-9025-623416bdfc32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80acb6dc-a9bd-4f12-9025-623416bdfc32.jpg?1",
             "name": "Yeva, Nature's Herald",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nYou may cast green creature cards as though they had flash.",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "512c6ede-df28-5bb1-adb2-ba10a0c1080e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg?1",
             "name": "Yeva's Forcemage",
             "text": "When Yeva's Forcemage enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -6655,7 +6655,7 @@
         },
         {
             "id": "8d3a3400-b08a-58b9-a984-e4433bdad645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b1fea-5c2c-4848-8109-548f56b99d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3b1fea-5c2c-4848-8109-548f56b99d49.jpg?1",
             "name": "Nicol Bolas, Planeswalker",
             "text": "+3: Destroy target noncreature permanent.\n-2: Gain control of target creature.\n-9: Nicol Bolas, Planeswalker deals 7 damage to target player. That player discards seven cards, then sacrifices seven permanents.",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "9e8e7e4e-1a30-53da-80dd-a4680a2cf1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d63c3-85a5-4c2d-bdba-6213527b5e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d63c3-85a5-4c2d-bdba-6213527b5e9a.jpg?1",
             "name": "Akroma's Memorial",
             "text": "Creatures you control have flying, first strike, vigilance, trample, haste, and protection from black and from red.",
             "colours": [],
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "0dfe8c80-4df0-5fe0-862a-78a66b9a8709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac35e28-dd0e-4dc8-b8e6-4a1e33706214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac35e28-dd0e-4dc8-b8e6-4a1e33706214.jpg?1",
             "name": "Chronomaton",
             "text": "{1}, {T}: Put a +1/+1 counter on Chronomaton.",
             "colours": [],
@@ -6756,7 +6756,7 @@
         },
         {
             "id": "201dbc48-1666-54e3-ad48-798ef9eca467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b087992-9c30-4434-acb3-a12ee6f207b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b087992-9c30-4434-acb3-a12ee6f207b3.jpg?1",
             "name": "Clock of Omens",
             "text": "Tap two untapped artifacts you control: Untap target artifact.",
             "colours": [],
@@ -6784,7 +6784,7 @@
         },
         {
             "id": "be21fdd4-0800-5fec-bcf8-6d6ac01dff14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57877b1c-e91d-4941-81bd-008dff1272ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57877b1c-e91d-4941-81bd-008dff1272ed.jpg?1",
             "name": "Door to Nothingness",
             "text": "Door to Nothingness enters the battlefield tapped.\n{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice Door to Nothingness: Target player loses the game.",
             "colours": [],
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "e001b8c2-e945-5cb5-905f-2074dbfa0728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813d6a95-719d-474d-942a-b4c5156af7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813d6a95-719d-474d-942a-b4c5156af7ba.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
             "colours": [],
@@ -6846,7 +6846,7 @@
         },
         {
             "id": "d0034940-0ae4-5e20-a527-2e96cd3e9b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07bc36-2207-48f4-a151-4ccb0c6d851d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07bc36-2207-48f4-a151-4ccb0c6d851d.jpg?1",
             "name": "Gem of Becoming",
             "text": "{3}, {T}, Sacrifice Gem of Becoming: Search your library for an Island card, a Swamp card, and a Mountain card. Reveal those cards and put them into your hand. Then shuffle your library.",
             "colours": [],
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "eba13bd0-36ba-5532-9c6e-3a70e353ff04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33704052-aeb1-4798-a64d-778e1879eeb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33704052-aeb1-4798-a64d-778e1879eeb9.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "d4abeaf3-7dc8-5909-b890-ef90f147dde2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0802b908-d4e1-4f58-a085-55782fc08d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0802b908-d4e1-4f58-a085-55782fc08d51.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "9f36f835-5221-5123-80a9-496814c7b49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f95cf4c-1845-4260-8571-91c03d582da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f95cf4c-1845-4260-8571-91c03d582da3.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "d514640d-dcef-513e-91c8-3189560c9c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a761426e-2138-438e-8f3b-024486165260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a761426e-2138-438e-8f3b-024486165260.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "8d5217ed-e242-5707-b05d-f4bfaafd6b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cece8-39ac-48fe-bfbe-494ec76d80ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774cece8-39ac-48fe-bfbe-494ec76d80ee.jpg?1",
             "name": "Primal Clay",
             "text": "As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types. (A creature with defender can't attack.)",
             "colours": [],
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "3c134ac4-c2c4-597c-9fc6-96e22b5c07fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c740a8-1bbc-4ec8-a72c-01aee9e48f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c740a8-1bbc-4ec8-a72c-01aee9e48f3d.jpg?1",
             "name": "Ring of Evos Isle",
             "text": "{2}: Equipped creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's blue.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "4b07ee1b-6676-53ab-ab6d-72e7a38ebe5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2082e04f-f972-424e-a724-7a5975215538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2082e04f-f972-424e-a724-7a5975215538.jpg?1",
             "name": "Ring of Kalonia",
             "text": "Equipped creature has trample. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's green.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7083,7 +7083,7 @@
         },
         {
             "id": "f211492a-8e4a-5139-be1b-6dec8d424c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e94f-5b06-4df0-ba87-4499b1ee4dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee2e94f-5b06-4df0-ba87-4499b1ee4dba.jpg?1",
             "name": "Ring of Thune",
             "text": "Equipped creature has vigilance. (Attacking doesn't cause it to tap.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's white.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "8e97435c-b25d-5db8-9ac0-3fcf0ce3acc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e9fc1-03ff-4ae5-9488-51bf2e627486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546e9fc1-03ff-4ae5-9488-51bf2e627486.jpg?1",
             "name": "Ring of Valkas",
             "text": "Equipped creature has haste. (It can attack and {T} no matter when it came under your control.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's red.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7143,7 +7143,7 @@
         },
         {
             "id": "f5a8e998-92f3-50db-82d9-f75fc223f2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e2aa59-63dc-4e28-8cdc-2ca868ff8f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47e2aa59-63dc-4e28-8cdc-2ca868ff8f59.jpg?1",
             "name": "Ring of Xathrid",
             "text": "{2}: Regenerate equipped creature. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)\nAt the beginning of your upkeep, put a +1/+1 counter on equipped creature if it's black.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7173,7 +7173,7 @@
         },
         {
             "id": "c6587a62-2ac8-5679-8dd2-5cebbf2ae576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c9d3bf-c858-42f4-bb61-3292f9a7141b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c9d3bf-c858-42f4-bb61-3292f9a7141b.jpg?1",
             "name": "Sands of Delirium",
             "text": "{X}, {T}: Target player puts the top X cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -7201,7 +7201,7 @@
         },
         {
             "id": "f98efe0c-231f-5863-a908-82d15505eb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7381a-ec4a-4f1b-b81c-bdf9f9d64f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7381a-ec4a-4f1b-b81c-bdf9f9d64f31.jpg?1",
             "name": "Staff of Nin",
             "text": "At the beginning of your upkeep, draw a card.\n{T}: Staff of Nin deals 1 damage to target creature or player.",
             "colours": [],
@@ -7229,7 +7229,7 @@
         },
         {
             "id": "cb734ab6-76c0-534a-ad09-b29f3aa4754b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23038e62-9c7b-4e2a-8661-035966b6ed4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23038e62-9c7b-4e2a-8661-035966b6ed4a.jpg?1",
             "name": "Stuffy Doll",
             "text": "As Stuffy Doll enters the battlefield, choose a player.\nStuffy Doll is indestructible.\nWhenever Stuffy Doll is dealt damage, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -7260,7 +7260,7 @@
         },
         {
             "id": "1d0fbd0e-0348-5113-a1f4-0572e25572ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdfb60b-948b-40fb-b18e-08f0300624b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdfb60b-948b-40fb-b18e-08f0300624b3.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "71051836-c7f6-55ee-aaaf-ff20f0100058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20604b28-d096-40f8-a30c-3bc89e708676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20604b28-d096-40f8-a30c-3bc89e708676.jpg?1",
             "name": "Trading Post",
             "text": "{1}, {T}, Discard a card: You gain 4 life.\n{1}, {T}, Pay 1 life: Put a 0/1 white Goat creature token onto the battlefield.\n{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.\n{1}, {T}, Sacrifice an artifact: Draw a card.",
             "colours": [],
@@ -7316,7 +7316,7 @@
         },
         {
             "id": "c479c178-bc6e-503d-97f9-d8e5bf8cd46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd222c07-0b28-41cb-9237-ad7991ab078f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd222c07-0b28-41cb-9237-ad7991ab078f.jpg?1",
             "name": "Cathedral of War",
             "text": "Cathedral of War enters the battlefield tapped.\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "ba6127ca-7758-5692-b84a-6ba80395b88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e49c561-570c-43dd-a369-48bc7ad7edac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e49c561-570c-43dd-a369-48bc7ad7edac.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "aeb53bdc-a5fd-5adc-b850-9fc54a0d025f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b41b86b-58e1-4601-b8ed-0ad31f03a78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b41b86b-58e1-4601-b8ed-0ad31f03a78d.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7406,7 +7406,7 @@
         },
         {
             "id": "132d60ff-6620-5cd5-a861-d57d72ef5ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d107e1-8293-4486-9b68-4897b8b7043c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d107e1-8293-4486-9b68-4897b8b7043c.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7434,7 +7434,7 @@
         },
         {
             "id": "1162dec2-ca9c-5a34-88bb-40f10ab60c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9d29ee-1a21-4c3e-99c1-f815d40e8f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9d29ee-1a21-4c3e-99c1-f815d40e8f19.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7465,7 +7465,7 @@
         },
         {
             "id": "88ed46de-2628-5b7f-a5e7-8bc1b752891d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8274ef-a46a-4f5f-8ad1-6ce828f24210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8274ef-a46a-4f5f-8ad1-6ce828f24210.jpg?1",
             "name": "Hellion Crucible",
             "text": "{T}: Add {1} to your mana pool.\n{1}{R}, {T}: Put a pressure counter on Hellion Crucible.\n{1}{R}, {T}, Remove two pressure counters from Hellion Crucible and sacrifice it: Put a 4/4 red Hellion creature token with haste onto the battlefield. (It can attack and {T} as soon as it comes under your control.)",
             "colours": [],
@@ -7495,7 +7495,7 @@
         },
         {
             "id": "5654c84a-340d-5fac-a709-0c0406bacf2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92583e4-9749-4c11-9d32-fb81260c5b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92583e4-9749-4c11-9d32-fb81260c5b63.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "ce1b6174-7b7c-5374-bac0-704f2cc15f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76364643-bfcb-4c50-9224-bf9e35648ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76364643-bfcb-4c50-9224-bf9e35648ddf.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7554,7 +7554,7 @@
         },
         {
             "id": "5a35527e-b69d-517d-b6cb-8d95a7460ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15663129-9deb-4c34-84a0-f94cf1a723f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15663129-9deb-4c34-84a0-f94cf1a723f0.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "b5999522-3387-5199-9519-a225c72ecee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a001b-7815-469b-bd0c-c92453d80e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080a001b-7815-469b-bd0c-c92453d80e9a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "219a350d-fa58-58b0-b887-88dff368328a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f8fa19-a872-4542-bf24-8bba9f0a64a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f8fa19-a872-4542-bf24-8bba9f0a64a1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7661,7 +7661,7 @@
         },
         {
             "id": "1fda811c-7837-561d-a58a-a67217247813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e094ea-3dee-47a6-997e-842113774973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e094ea-3dee-47a6-997e-842113774973.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7699,7 +7699,7 @@
         },
         {
             "id": "35d8b1c3-b33f-5538-ac33-bab020158536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80e0478-8c53-4406-acc0-b7662c9c382d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80e0478-8c53-4406-acc0-b7662c9c382d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7737,7 +7737,7 @@
         },
         {
             "id": "858edcf2-9bd3-5e58-8e85-16e571d0a1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd86b167-3fc8-4e5a-9e21-b4ce5a7a05cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd86b167-3fc8-4e5a-9e21-b4ce5a7a05cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7775,7 +7775,7 @@
         },
         {
             "id": "2858952a-8c2f-5ddb-ab3e-745acea5f066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad64d3a-1868-4404-8692-d3c54071140d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad64d3a-1868-4404-8692-d3c54071140d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "af61b110-56fc-5db6-adff-67d47eea630f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e3d45d-8c6e-430a-82d3-86f66286735d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e3d45d-8c6e-430a-82d3-86f66286735d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "0148e313-3b35-5def-99fd-9be854fb884b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956fd08b-d403-4565-84b3-e3ca0132ea89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956fd08b-d403-4565-84b3-e3ca0132ea89.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7889,7 +7889,7 @@
         },
         {
             "id": "52fa0f8a-e488-585c-86e0-8b341f6deb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b16e93-ee53-4c1b-9dea-6db7977e9c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b16e93-ee53-4c1b-9dea-6db7977e9c2f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "38b391e1-289e-5402-8892-7be81aac5683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7827d75-eb0e-4ebf-876e-7a2f9e373fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7827d75-eb0e-4ebf-876e-7a2f9e373fb3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7965,7 +7965,7 @@
         },
         {
             "id": "2542f237-548a-536f-b372-80cf8e49c8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9364178a-1963-4665-b8c1-a5096ece07e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9364178a-1963-4665-b8c1-a5096ece07e2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "31f7cb3a-0909-515a-8b54-473192ea2caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4ddbe5-1be4-47ee-b07a-74c8bec4d752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4ddbe5-1be4-47ee-b07a-74c8bec4d752.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "2d96fcea-ab9e-5be5-858a-6cec3597b279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67cf0c1-5658-4f88-9fbd-63c1dbf77ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67cf0c1-5658-4f88-9fbd-63c1dbf77ee0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8079,7 +8079,7 @@
         },
         {
             "id": "ae904c9e-957b-5efa-be8d-0ce4a2a9f2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a3144f-9b4f-4d1a-b384-6228c99b38b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a3144f-9b4f-4d1a-b384-6228c99b38b7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "bc6113e8-bc75-5215-b380-6a3984d1b1b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17990059-8368-45f8-8325-c82fc181450a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17990059-8368-45f8-8325-c82fc181450a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8155,7 +8155,7 @@
         },
         {
             "id": "816c9f6b-0ea1-5cc5-b004-ecc770dad026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cefc72a-83ba-42e4-a036-a9f45363c8cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cefc72a-83ba-42e4-a036-a9f45363c8cf.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8193,7 +8193,7 @@
         },
         {
             "id": "114750bd-3a31-57e2-bb33-163eae83d230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a55233-2e1a-4515-8fd1-354605c0c36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a55233-2e1a-4515-8fd1-354605c0c36b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8231,7 +8231,7 @@
         },
         {
             "id": "16249867-92d9-5473-b213-8237cdcae416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdf7380-56cb-4d34-ad05-43029341a57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fdf7380-56cb-4d34-ad05-43029341a57a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "ae2a9bbc-ca04-52b7-bf7d-a9f0e724ecb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65aa4dcf-6e3a-4381-b5f6-5056d741ff67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65aa4dcf-6e3a-4381-b5f6-5056d741ff67.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8307,7 +8307,7 @@
         },
         {
             "id": "34f57d78-b9e2-5ed7-b7d1-7b0128940010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa35174e-c0c8-4643-bc32-9a7b7c7e7d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa35174e-c0c8-4643-bc32-9a7b7c7e7d00.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "d8d21108-a7c6-506a-bac1-98543a8ae18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97868f6-a9ce-4ce9-bc3f-b535f3202602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97868f6-a9ce-4ce9-bc3f-b535f3202602.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "25db1f75-e203-596e-a69c-79288fe596db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0f1de9-464c-4f12-bd1d-a4a5b88fe803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0f1de9-464c-4f12-bd1d-a4a5b88fe803.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -8413,7 +8413,7 @@
         },
         {
             "id": "9224d123-1274-5a2a-9b46-cbee8cbc4e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272c08-c5f2-413f-87ea-b135aca2d9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86272c08-c5f2-413f-87ea-b135aca2d9c5.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "67f59d92-2f7e-51ea-9fb9-298bdca35cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93679bb9-ee1c-4eea-bcdd-72785d5788af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93679bb9-ee1c-4eea-bcdd-72785d5788af.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -8481,7 +8481,7 @@
         },
         {
             "id": "5eb47612-36a1-5b9b-8f96-0666df0980e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1966d7e6-cd4a-47ff-bc3e-f8e0db8a3439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1966d7e6-cd4a-47ff-bc3e-f8e0db8a3439.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8515,7 +8515,7 @@
         },
         {
             "id": "a8d5380a-d799-5464-ae84-8cce56f4b336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e67efea-8a80-42ec-8e77-07d387d933d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e67efea-8a80-42ec-8e77-07d387d933d4.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8549,7 +8549,7 @@
         },
         {
             "id": "43952e52-6db2-531e-a791-00658bf1ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43b811-ec0f-4ad7-a152-f7f077bafaa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43b811-ec0f-4ad7-a152-f7f077bafaa4.jpg?1",
             "name": "Hellion",
             "text": "",
             "colours": [
@@ -8583,7 +8583,7 @@
         },
         {
             "id": "95cacb3b-7dc9-5f09-8c65-ad527476113d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94010f1-cd4b-4f65-8a0e-2df6eec058ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94010f1-cd4b-4f65-8a0e-2df6eec058ec.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8617,7 +8617,7 @@
         },
         {
             "id": "c01d7c89-e275-5ac5-84ca-bd5de2278f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd67de8a-3879-4d03-a716-6e907d597b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd67de8a-3879-4d03-a716-6e907d597b25.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "162c4cad-9cdf-5945-a81e-b2f988e36afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d87f38-c342-4186-8768-c3f1aceb680a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d87f38-c342-4186-8768-c3f1aceb680a.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8685,7 +8685,7 @@
         },
         {
             "id": "9cc21c43-7881-50f6-953f-bc567351c8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd1b0b9-f1bb-4808-be3f-5b3faf185cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd1b0b9-f1bb-4808-be3f-5b3faf185cf1.jpg?1",
             "name": "Liliana of the Dark Realms Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M14.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M14.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "79b0e970-207d-56b9-8fe3-aeb2c486444a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e44e04-8330-49ca-906c-bb9bf0bc84ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e44e04-8330-49ca-906c-bb9bf0bc84ce.jpg?1",
             "name": "Ajani, Caller of the Pride",
             "text": "+1: Put a +1/+1 counter on up to one target creature.-3: Target creature gains flying and double strike until end of turn.-8: Put X 2/2 white Cat creature tokens onto the battlefield, where X is your life total.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "8363e365-c16e-5f64-9d23-412bd6d54488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583bfbc1-638b-4de5-b865-0b00a69dd073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583bfbc1-638b-4de5-b865-0b00a69dd073.jpg?1",
             "name": "Ajani's Chosen",
             "text": "Whenever an enchantment enters the battlefield under your control, put a 2/2 white Cat creature token onto the battlefield. If that enchantment is an Aura, you may attach it to the token.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "0f9d7968-6ff2-5b12-944e-9f91a40c31ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f26bc2-53d7-4448-8021-de35aa82fcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f26bc2-53d7-4448-8021-de35aa82fcc6.jpg?1",
             "name": "Angelic Accord",
             "text": "At the beginning of each end step, if you gained 4 or more life this turn, put a 4/4 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "369d23c0-6d3d-59de-89d2-05e1b04a43c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f88e-8a51-494b-a008-fbfe624f97f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f88e-8a51-494b-a008-fbfe624f97f7.jpg?1",
             "name": "Angelic Wall",
             "text": "Defender (This creature can't attack.)\nFlying",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "07b21ac6-fefe-50c6-a22a-3560bd22f545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531cba81-afd7-4be4-adec-87edb77ba2a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531cba81-afd7-4be4-adec-87edb77ba2a9.jpg?1",
             "name": "Archangel of Thune",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhenever you gain life, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "63d3dd7d-5076-545a-8d15-ef366f0367ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dc4ab-1c45-4495-91b6-27d62087380c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dc4ab-1c45-4495-91b6-27d62087380c.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "59626b40-2528-537e-8c03-bb30bf9773f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823bf8-2fca-49e1-ba40-9b61c9ae55b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06823bf8-2fca-49e1-ba40-9b61c9ae55b3.jpg?1",
             "name": "Banisher Priest",
             "text": "When Banisher Priest enters the battlefield, exile target creature an opponent controls until Banisher Priest leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "3b567d6c-60e1-50de-abff-1868df1e96f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4273cf50-db65-4b1f-95e1-f24ba6582c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4273cf50-db65-4b1f-95e1-f24ba6582c8b.jpg?1",
             "name": "Blessing",
             "text": "Enchant creature{W}: Enchanted creature gets +1/+1 until end of turn.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "40aade37-70df-5cae-84cb-4492c1e252ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bb68b-1830-470a-8cea-91edc7db0c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bb68b-1830-470a-8cea-91edc7db0c57.jpg?1",
             "name": "Bonescythe Sliver",
             "text": "Sliver creatures you control have double strike. (They deal both first-strike and regular combat damage.)",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "cdfa87d6-8d34-572f-9652-7193555ece3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7838-ae58-4306-ba0f-e914601b31b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7838-ae58-4306-ba0f-e914601b31b6.jpg?1",
             "name": "Brave the Elements",
             "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn. (They can't be blocked, targeted, dealt damage, or enchanted by anything of that color.)",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "060b9f07-8a7a-593e-a829-ee36c39fed78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78802af4-46b5-4bac-8cdf-5b77d0b19895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78802af4-46b5-4bac-8cdf-5b77d0b19895.jpg?1",
             "name": "Capashen Knight",
             "text": "First strike (This creature deals combat damage before creatures without first strike.){1}{W}: Capashen Knight gets +1/+0 until end of turn.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "723d05d9-a927-56a7-8cf6-b98c9cc91c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8d1320-0f1a-4c66-86c9-9f8da0f1d9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8d1320-0f1a-4c66-86c9-9f8da0f1d9ef.jpg?1",
             "name": "Celestial Flare",
             "text": "Target player sacrifices an attacking or blocking creature.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "64fe23b2-3d41-54aa-8b14-2b897820fc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg?1",
             "name": "Charging Griffin",
             "text": "Flying\nWhenever Charging Griffin attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "d60deda4-f12c-5154-a5da-de71bd079c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792574a-4d8f-4c80-a958-7c0edbe391fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792574a-4d8f-4c80-a958-7c0edbe391fc.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "beab512f-a9d1-5284-88b5-30420176637b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5fb3-bb41-4efa-9721-2c2d169b05cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5fb3-bb41-4efa-9721-2c2d169b05cd.jpg?1",
             "name": "Dawnstrike Paladin",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "57255fbc-f882-54e2-b7c9-08c5a8c8bc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a286954-fb40-4440-9f0e-a28367c6823c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a286954-fb40-4440-9f0e-a28367c6823c.jpg?1",
             "name": "Devout Invocation",
             "text": "Tap any number of untapped creatures you control. Put a 4/4 white Angel creature token with flying onto the battlefield for each creature tapped this way.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "43fd21a5-e611-5fe7-bf25-fc78f7300217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c19a11-ff0f-4dbd-b872-30276b8ecf22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c19a11-ff0f-4dbd-b872-30276b8ecf22.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "3348d475-d115-5642-9e86-b1c8f360151e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfb0f4a-e273-4ffb-91cd-dd1a7b6f6a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfb0f4a-e273-4ffb-91cd-dd1a7b6f6a8f.jpg?1",
             "name": "Fiendslayer Paladin",
             "text": "First strike (This creature deals combat damage before creatures without first strike.) Lifelink (Damage dealt by this creature also causes you to gain that much life.)Fiendslayer Paladin can't be the target of black or red spells your opponents control.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "112d93dc-1321-50c0-8a4b-b313778fee82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eff4028-d4f9-4822-81d6-9f5e5e6f3011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eff4028-d4f9-4822-81d6-9f5e5e6f3011.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014 Creatures you control get +2/+0 until end of turn; or creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "21d3b92c-6f6c-56a2-bc5b-9659b22f0d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6626-a85f-4116-9721-19e39b83cba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40d6626-a85f-4116-9721-19e39b83cba0.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "dae06817-41b1-5ce9-a87c-5f02ca011da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4399e19-d05d-4bb3-9aff-c4133ddd2850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4399e19-d05d-4bb3-9aff-c4133ddd2850.jpg?1",
             "name": "Hive Stirrings",
             "text": "Put two 1/1 colorless Sliver creature tokens onto the battlefield.",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "0e06672d-5b27-5265-91dd-a3d8b255c4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f672328-3361-498e-a9f4-2d8e69a8b072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f672328-3361-498e-a9f4-2d8e69a8b072.jpg?1",
             "name": "Imposing Sovereign",
             "text": "Creatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "b5ca86cf-56df-56d5-928d-f5f37a72a667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086a062-d39b-4e2a-bde0-f4d6d1797a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086a062-d39b-4e2a-bde0-f4d6d1797a5f.jpg?1",
             "name": "Indestructibility",
             "text": "Enchant permanent\nEnchanted permanent has indestructible. (Effects that say \"destroy\" don't destroy that permanent. A creature with indestructible can't be destroyed by damage.)",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "c9423178-0be4-5944-8532-53bf9d8d580e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bec89b3-640e-4093-a6e9-5639610769b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bec89b3-640e-4093-a6e9-5639610769b9.jpg?1",
             "name": "Master of Diversion",
             "text": "Whenever Master of Diversion attacks, tap target creature defending player controls.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "cfff65e2-c752-59e1-8aa3-2b0bebc6e82e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c7ff88-c23e-4be6-989b-99d055db36df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c7ff88-c23e-4be6-989b-99d055db36df.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "85a9eb97-87b8-5197-b9cb-913db37dacf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5222e200-df1b-46c6-a194-c341e8c1d516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5222e200-df1b-46c6-a194-c341e8c1d516.jpg?1",
             "name": "Path of Bravery",
             "text": "As long your life total is greater than or equal to your starting life total, creatures you control get +1/+1.\nWhenever one or more creatures you control attack, you gain life equal to the number of attacking creatures.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "12303685-25f8-566d-a2d3-fb913bcd2cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb836f0-527d-445b-877e-7158a4579c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb836f0-527d-445b-877e-7158a4579c33.jpg?1",
             "name": "Pay No Heed",
             "text": "Prevent all damage a source of your choice would deal this turn.",
             "colours": [
@@ -914,7 +914,7 @@
         },
         {
             "id": "ee9b56bb-ef0d-57e6-aa42-c15df0193af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d3bba-18b0-4c56-a90b-8e28935a6a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d3bba-18b0-4c56-a90b-8e28935a6a7a.jpg?1",
             "name": "Pillarfield Ox",
             "text": "",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "04e4d2f2-c1e8-522c-b59f-92b13d7d932f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99873316-4872-4500-a225-cf483e1ebaa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99873316-4872-4500-a225-cf483e1ebaa9.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "83b53117-b0fd-58ff-9643-eee69d156b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c28560-e6ac-4be9-a253-22c4613b0d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c28560-e6ac-4be9-a253-22c4613b0d90.jpg?1",
             "name": "Sentinel Sliver",
             "text": "Sliver creatures you control have vigilance. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "366df186-4f4a-5e3a-bac5-8913e878199c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9789cac-5774-4f72-82c3-18f11f9d4a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9789cac-5774-4f72-82c3-18f11f9d4a62.jpg?1",
             "name": "Seraph of the Sword",
             "text": "Flying\nPrevent all combat damage that would be dealt to Seraph of the Sword.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "8a7dec6f-0a44-57f9-a4e8-b96f09922e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475f2a7b-9bd5-4ad7-868a-7652d06f3f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475f2a7b-9bd5-4ad7-868a-7652d06f3f6c.jpg?1",
             "name": "Serra Angel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "02a8804e-3794-5143-bfa6-19a9886d9f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07932c2-7b97-4abe-be2b-02fc04de780f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07932c2-7b97-4abe-be2b-02fc04de780f.jpg?1",
             "name": "Show of Valor",
             "text": "Target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "1a104f30-0abd-53dd-a645-d5274c8a7a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e7a30f-bb29-4c6b-bf70-53e9e4292814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e7a30f-bb29-4c6b-bf70-53e9e4292814.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "a609898a-5720-51f5-8f25-c253d3557e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b13b1-31f0-4676-88a7-53f3a190e9a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2b13b1-31f0-4676-88a7-53f3a190e9a2.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn. (Spells cast before this resolves are unaffected.)",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "f66ebfa9-51e5-5e50-abdd-6da62226379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca09fed-f9b3-49ee-be89-404581a4cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca09fed-f9b3-49ee-be89-404581a4cbd2.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1212,7 +1212,7 @@
         },
         {
             "id": "c3334be4-b4f0-5dea-bacf-3704510689ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f45133-6134-4664-9952-67c03d60f9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f45133-6134-4664-9952-67c03d60f9a0.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "41d030f4-3a85-5d7d-a294-a25e7f947cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15d6329-ffb1-43fd-8558-60c8315f5b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15d6329-ffb1-43fd-8558-60c8315f5b91.jpg?1",
             "name": "Steelform Sliver",
             "text": "Sliver creatures you control get +0/+1.",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "5589e2e3-a97c-54b7-9c6e-5a5d6b72e816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6ec61b-c039-4526-a359-a7947eeba5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6ec61b-c039-4526-a359-a7947eeba5c3.jpg?1",
             "name": "Stonehorn Chanter",
             "text": "{5}{W}: Stonehorn Chanter gains vigilance and lifelink until end of turn. (Attacking doesn't cause it to tap. Damage dealt by it also causes you to gain that much life.)",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "f21c0b06-7f95-5f64-89a5-87908249afdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1f83c-a9ef-463e-97b5-2ca3b7232f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a1f83c-a9ef-463e-97b5-2ca3b7232f82.jpg?1",
             "name": "Suntail Hawk",
             "text": "Flying",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "233a32f4-78d4-5aba-b62a-da94c9ed80a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c733fef-8372-4a40-b340-7aa32922799e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c733fef-8372-4a40-b340-7aa32922799e.jpg?1",
             "name": "Wall of Swords",
             "text": "Defender (This creature can't attack)\nFlying",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "348b4bd3-d29f-5632-869d-58806645376f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc279d-952a-4b8d-b6ff-37166daa2dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc279d-952a-4b8d-b6ff-37166daa2dd5.jpg?1",
             "name": "Air Servant",
             "text": "Flying{2}{U}: Tap target creature with flying.",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "02b9e725-0b0b-55de-9b78-e221a85bf5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d0ae8f-3d46-4692-a23c-c461f8aa6a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d0ae8f-3d46-4692-a23c-c461f8aa6a58.jpg?1",
             "name": "Archaeomancer",
             "text": "When Archaeomancer enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "3f3780ef-e321-56a9-92a9-824c76567880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b455b0f-a69c-43b4-bbf5-605ed41f10e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b455b0f-a69c-43b4-bbf5-605ed41f10e0.jpg?1",
             "name": "Armored Cancrix",
             "text": "",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "81f4f75d-e355-5307-808a-7b51b90cf33c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954eec32-7e40-452d-94c2-f704b819f338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/954eec32-7e40-452d-94c2-f704b819f338.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "9c1e75d7-a475-5e45-b94d-77c54ee12d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca9c638-f923-4e85-bd3c-c95854b4f0fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca9c638-f923-4e85-bd3c-c95854b4f0fb.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "e079250b-7447-500d-a95f-68dc387bae18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e648262-3b9b-4c58-8e29-48356e3cb064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e648262-3b9b-4c58-8e29-48356e3cb064.jpg?1",
             "name": "Clone",
             "text": "You may have Clone enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "bb181d19-884a-5933-9126-9f32b6802a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f7caca-14ee-4d6a-97c3-e19898f86635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f7caca-14ee-4d6a-97c3-e19898f86635.jpg?1",
             "name": "Colossal Whale",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Colossal Whale attacks, you may exile target creature defending player controls until Colossal Whale leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "d855f7e4-0fbd-5f37-9e00-913fc8a1058c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ef366b-26f5-473a-ab96-e668ed54d691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ef366b-26f5-473a-ab96-e668ed54d691.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "e133ed37-16b0-5d6b-9c75-a249ff340fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cd7fe-639c-45a5-97af-9529904e3975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cd7fe-639c-45a5-97af-9529904e3975.jpg?1",
             "name": "Dismiss into Dream",
             "text": "Each creature your opponents control is an Illusion in addition to its other types and has \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "d209721e-df84-50b6-8ca4-4ccbc71e114d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b415d2-53fe-4540-aea6-9cd2c498134c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b415d2-53fe-4540-aea6-9cd2c498134c.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "e54edfc7-3f53-5722-8437-64819f60a0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdc821e-0e4b-43ff-86d6-134ac0b4e958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdc821e-0e4b-43ff-86d6-134ac0b4e958.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "86fa56eb-dd1a-518e-bceb-0f4b89e35dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0b7e3-fe3f-4710-9b92-9ffdb242e92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf0b7e3-fe3f-4710-9b92-9ffdb242e92e.jpg?1",
             "name": "Domestication",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your end step, if enchanted creature's power is 4 or greater, sacrifice Domestication.",
             "colours": [
@@ -1785,7 +1785,7 @@
         },
         {
             "id": "96e51654-6928-5a53-a7ff-f49934b8392d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b225fe-c07d-4d8a-bf2b-c1777bd29061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b225fe-c07d-4d8a-bf2b-c1777bd29061.jpg?1",
             "name": "Elite Arcanist",
             "text": "When Elite Arcanist enters the battlefield, you may exile an instant card from your hand.{X}, {T}: Copy the exiled card. You may cast the copy without paying its mana cost. X is the converted mana cost of the exiled card.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "6b33b471-b1d0-5cb5-a887-994fd2aa6d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bd28e3-1612-41b3-88a0-bb5c1ee60ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bd28e3-1612-41b3-88a0-bb5c1ee60ace.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "39296abc-ee62-5334-81d1-41fff454eb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3f777-7660-48ae-8c32-6777ec8427d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d3f777-7660-48ae-8c32-6777ec8427d4.jpg?1",
             "name": "Frost Breath",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "cc416055-897c-511c-85c6-25e6c2a97d89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425f5d1b-9989-4fd1-88e2-6c3108aefa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425f5d1b-9989-4fd1-88e2-6c3108aefa0b.jpg?1",
             "name": "Galerider Sliver",
             "text": "Sliver creatures you control have flying.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "1e17747b-d014-5474-9823-c823806db2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d875e9-713d-4ddb-ae0a-db8483366319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d875e9-713d-4ddb-ae0a-db8483366319.jpg?1",
             "name": "Glimpse the Future",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "612a42b6-6388-581d-aad5-7c8cc1a1f5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09346ff-6e63-499b-9265-c15a7b2cdece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09346ff-6e63-499b-9265-c15a7b2cdece.jpg?1",
             "name": "Illusionary Armor",
             "text": "Enchant creature\nEnchanted creature gets +4/+4.\nWhen enchanted creature becomes the target of a spell or ability, sacrifice Illusionary Armor.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "336b4308-eb3e-5700-a1c0-e5e14e33801b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2801a4ad-5d44-4414-af62-458c7f90dad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2801a4ad-5d44-4414-af62-458c7f90dad6.jpg?1",
             "name": "Jace, Memory Adept",
             "text": "+1: Draw a card. Target player puts the top card of his or her library into his or her graveyard.0: Target player puts the top ten cards of his or her library into his or her graveyard.-7: Any number of target players each draw twenty cards.",
             "colours": [
@@ -2020,7 +2020,7 @@
         },
         {
             "id": "9ac48b02-94cd-587a-983a-9b6fece797c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67852a6-ae75-44e7-9e2d-d458c7b9d869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67852a6-ae75-44e7-9e2d-d458c7b9d869.jpg?1",
             "name": "Jace's Mindseeker",
             "text": "Flying\nWhen Jace's Mindseeker enters the battlefield, target opponent puts the top five cards of his or her library into his or her graveyard. You may cast an instant or sorcery card from among them without paying its mana cost.",
             "colours": [
@@ -2055,7 +2055,7 @@
         },
         {
             "id": "df89f70b-4d5f-55eb-a967-cf23f98b29f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c89aa2-3375-4681-ad26-b5d5c7d3d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c89aa2-3375-4681-ad26-b5d5c7d3d842.jpg?1",
             "name": "Merfolk Spy",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nWhenever Merfolk Spy deals combat damage to a player, that player reveals a card at random from his or her hand.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "1cf0f2a3-86d2-55b7-9824-7f83b2d0796b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd3172-0b45-4dc8-adc6-9e0ba112e664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd3172-0b45-4dc8-adc6-9e0ba112e664.jpg?1",
             "name": "Messenger Drake",
             "text": "Flying\nWhen Messenger Drake dies, draw a card.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "a8652317-cc3e-529c-81fb-f0b9cd70092c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6276afe2-1bd9-456e-82d5-389909ae5ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6276afe2-1bd9-456e-82d5-389909ae5ab0.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "c340fe15-4210-506b-b8a0-198cacf3a7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39714ec8-b43c-4d61-9e53-46ac62da2c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39714ec8-b43c-4d61-9e53-46ac62da2c9f.jpg?1",
             "name": "Nephalia Seakite",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -2190,7 +2190,7 @@
         },
         {
             "id": "ac6b17d8-2ac9-51f2-830c-0838a2899014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b242f3-9398-4d65-a2c7-4de56ee58933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b242f3-9398-4d65-a2c7-4de56ee58933.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "44fe079e-7976-594c-ab9f-434caa1e7a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12a1a64-5b32-4b85-8fae-c407d7926547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12a1a64-5b32-4b85-8fae-c407d7926547.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior can't be blocked.",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "b9feebf4-6770-5bdc-b400-383a7839e519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bef3d-c785-4b25-9b91-8f676aa9906f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066bef3d-c785-4b25-9b91-8f676aa9906f.jpg?1",
             "name": "Quicken",
             "text": "The next sorcery card you cast this turn can be cast as though it had flash. (It can be cast any time you could cast an instant.)\nDraw a card.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "b6bc1425-3f72-5419-b4a9-4bdb5398c248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd793eb0-0ddb-4b49-88c6-b3565574b92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd793eb0-0ddb-4b49-88c6-b3565574b92f.jpg?1",
             "name": "Scroll Thief",
             "text": "Whenever Scroll Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "692f4b20-0ef5-5514-af15-cf2d7c07e526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5333de10-a6d4-47ff-ab57-4edb49535739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5333de10-a6d4-47ff-ab57-4edb49535739.jpg?1",
             "name": "Seacoast Drake",
             "text": "Flying",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "c85ed2cc-e348-590b-9d71-b237f84441e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7050735c-b232-47a6-a342-01795bfd0d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7050735c-b232-47a6-a342-01795bfd0d46.jpg?1",
             "name": "Sensory Deprivation",
             "text": "Enchant creature\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "0988a9c9-f778-5ba9-a238-45b5c716606d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d7af6a-bfd1-4e89-965a-68336507a9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d7af6a-bfd1-4e89-965a-68336507a9ee.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with converted mana cost X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "40a17b80-957b-5216-8235-3a9f5a9bbd1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e032d1dd-6efc-4f6c-ad3b-30fe74845edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e032d1dd-6efc-4f6c-ad3b-30fe74845edf.jpg?1",
             "name": "Tidebinder Mage",
             "text": "When Tidebinder Mage enters the battlefield, tap target red or green creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Tidebinder Mage.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "6e6f53ff-4c92-5530-96c2-c9504ed4e49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0c48f6-8b2e-4eff-aa1e-10e6ccae426a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0c48f6-8b2e-4eff-aa1e-10e6ccae426a.jpg?1",
             "name": "Time Ebb",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "a1955781-e999-5583-9a4a-409a48fdb7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed4cfec-5cea-4987-890e-825b2802e9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed4cfec-5cea-4987-890e-825b2802e9f9.jpg?1",
             "name": "Tome Scour",
             "text": "Target player puts the top five cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "c5dbb37b-6430-55d5-aa6d-fc1328342d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eaa5a-3f9d-4166-b418-fd82fff86c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1eaa5a-3f9d-4166-b418-fd82fff86c73.jpg?1",
             "name": "Trained Condor",
             "text": "Flying\nWhenever Trained Condor attacks, another target creature you control gains flying until end of turn.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "caec1bba-e63a-585b-bafb-f2820194d092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8784dd-83f9-41f8-aedc-f0f81073ffcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8784dd-83f9-41f8-aedc-f0f81073ffcb.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "c2687d2d-b498-52c4-962e-3cc9e385af6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4000b46-7843-4c07-8332-a10f207e2cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4000b46-7843-4c07-8332-a10f207e2cdc.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "6df9af5c-7ed2-5a1d-a1a8-97cfcc4222b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316d281-21a4-460d-9062-f0737249484e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2316d281-21a4-460d-9062-f0737249484e.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "d84c0fdf-676e-5d3f-b1d1-9a715c2e5276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7562e-3e25-447d-b9f4-eb96960511b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7562e-3e25-447d-b9f4-eb96960511b8.jpg?1",
             "name": "Water Servant",
             "text": "{U}: Water Servant gets +1/-1 until end of turn.{U}: Water Servant gets -1/+1 until end of turn.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "24b8a566-d4bf-55e3-a50b-7e7e30c6d99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f566741d-a847-4f24-b6fc-7873f0797d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f566741d-a847-4f24-b6fc-7873f0797d59.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "1c38487c-efcf-527a-8bfb-0f8fd52774d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ea2808-0dde-4065-ae7d-905aae98703f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ea2808-0dde-4065-ae7d-905aae98703f.jpg?1",
             "name": "Zephyr Charge",
             "text": "{1}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "edf69359-e3df-506c-b37d-72fce1fd1531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08313b-14c9-4e0b-aad7-05cbd90b1ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08313b-14c9-4e0b-aad7-05cbd90b1ed8.jpg?1",
             "name": "Accursed Spirit",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "8fcd1837-56a2-58d6-a87c-a2611276f060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3053af2-715c-4549-9003-bf4279029a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3053af2-715c-4549-9003-bf4279029a95.jpg?1",
             "name": "Altar's Reap",
             "text": "As an additional cost to cast Altar's Reap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "e2bf8ab7-42a6-512f-945f-0a33d2a3ef94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd9a1-da2e-44ef-9f2e-352dc9f92c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd9a1-da2e-44ef-9f2e-352dc9f92c50.jpg?1",
             "name": "Artificer's Hex",
             "text": "Enchant Equipment\nAt the beginning of your upkeep, if enchanted Equipment is attached to a creature, destroy that creature.",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "36d7256f-e51b-503f-b2d1-b991f1863e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61752b13-255a-44d0-9fb0-5ed5680b954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61752b13-255a-44d0-9fb0-5ed5680b954e.jpg?1",
             "name": "Blightcaster",
             "text": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "e1580707-2ee7-58cd-b269-57f167d3910f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fcbbd1-ee51-42a3-ad11-2fd41728c35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fcbbd1-ee51-42a3-ad11-2fd41728c35d.jpg?1",
             "name": "Blood Bairn",
             "text": "Sacrifice another creature: Blood Bairn gets +2/+2 until end of turn.",
             "colours": [
@@ -2927,7 +2927,7 @@
         },
         {
             "id": "07b0050a-2237-50c9-aa15-f07c2ce957d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7559cf3e-7fad-4bcf-8551-045f9150e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7559cf3e-7fad-4bcf-8551-045f9150e014.jpg?1",
             "name": "Bogbrew Witch",
             "text": "{2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "4d2f4fed-2618-5078-9a04-a638b5d7e896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b5476-5f5f-46b5-b627-398e9fcd04aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c21b5476-5f5f-46b5-b627-398e9fcd04aa.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "cd20da7b-b0e9-55d4-8b09-9dd4000d1292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6adc5e-9221-4a18-8d41-4675797e5d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6adc5e-9221-4a18-8d41-4675797e5d46.jpg?1",
             "name": "Corpse Hauler",
             "text": "{2}{B}, Sacrifice Corpse Hauler: Return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "800963d7-35d4-5696-9a26-55b552f6b56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a85ae1-7880-4612-9878-c22225bfdce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a85ae1-7880-4612-9878-c22225bfdce1.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of Swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "58d0844e-aa1b-5ba2-b5a8-5724ec20d0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1591ae-07aa-4013-bc6d-4cafd09927f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1591ae-07aa-4013-bc6d-4cafd09927f0.jpg?1",
             "name": "Dark Favor",
             "text": "Enchant creature\nWhen Dark Favor enters the battlefield, you lose 1 life.\nEnchanted creature gets +3/+1.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "47ac7946-9504-573b-a6fe-a647b0993819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf82c3b-7a35-43dd-8bf3-ebc68dc1b8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf82c3b-7a35-43dd-8bf3-ebc68dc1b8fc.jpg?1",
             "name": "Dark Prophecy",
             "text": "Whenever a creature you control dies, you draw a card and lose 1 life.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "4bff7df1-f3b0-5465-afcd-939ecf21314c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17b58c-9738-4cdb-a408-e1595c384b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17b58c-9738-4cdb-a408-e1595c384b92.jpg?1",
             "name": "Deathgaze Cockatrice",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "3f3f8d24-bafc-5e89-b5b5-52e4a1173cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7c8b-f29f-4574-96c0-daac17fc75bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75a7c8b-f29f-4574-96c0-daac17fc75bb.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "22cf21cb-55ab-5d19-8729-691b02055ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d96a37-bdbe-46ae-926f-8742699a0b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d96a37-bdbe-46ae-926f-8742699a0b20.jpg?1",
             "name": "Doom Blade",
             "text": "Destroy target nonblack creature.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "0b41d2da-2e6d-57d4-84c2-039913f96cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccfa743c-b30a-4576-8205-8f00970d1076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccfa743c-b30a-4576-8205-8f00970d1076.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "b13a3fd2-9370-504a-a8f5-f96d0b8c0267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee5261-416c-41e9-9ad7-bf7bd169aa08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaee5261-416c-41e9-9ad7-bf7bd169aa08.jpg?1",
             "name": "Festering Newt",
             "text": "When Festering Newt dies, target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "636ce0e7-4eaa-5837-8259-29d880b21515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56653d9e-0c29-440b-8724-cae746abb1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56653d9e-0c29-440b-8724-cae746abb1a9.jpg?1",
             "name": "Gnawing Zombie",
             "text": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "40f1b541-656f-588d-a20f-eb3a2f87f985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b69f74-3b54-4db4-abf3-b71db8cc9562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b69f74-3b54-4db4-abf3-b71db8cc9562.jpg?1",
             "name": "Grim Return",
             "text": "Choose target creature card in a graveyard that was put there from the battlefield this turn. Put that card onto the battlefield under your control.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "fb7325c3-bf60-595f-8a77-a41dccc8ba54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98370735-5303-40d4-9e80-cdb40dee18e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98370735-5303-40d4-9e80-cdb40dee18e2.jpg?1",
             "name": "Lifebane Zombie",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhen Lifebane Zombie enters the battlefield, target opponent reveals his or her hand. You choose a green or white creature card from it and exile that card.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "c63b699b-4d36-5dd0-865c-d77965ecdf3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cbe506-7332-4d29-9404-b7c6e1e791d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cbe506-7332-4d29-9404-b7c6e1e791d8.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "+1: Search your library for a Swamp card, reveal it, and put it into your hand. Then shuffle your library.-3: Target creature gets +X/+X or -X/-X until end of turn, where X is the number of Swamps you control.-6: You get an emblem with \"Swamps you control have \u2018{T}: Add {B}{B}{B}{B} to your mana pool.'\"",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "7df76af5-be2a-55cc-956e-b3fc20c76822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a734c33c-4fa0-4f7a-943c-14a8aecea1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a734c33c-4fa0-4f7a-943c-14a8aecea1a6.jpg?1",
             "name": "Liliana's Reaver",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Liliana's Reaver deals combat damage to a player, that player discards a card and you put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "856a4767-ebd6-56ca-b767-a135c4b21460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532105d-c550-4c20-8465-a6a19169efbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3532105d-c550-4c20-8465-a6a19169efbd.jpg?1",
             "name": "Liturgy of Blood",
             "text": "Destroy target creature. Add {B}{B}{B} to your mana pool.",
             "colours": [
@@ -3496,7 +3496,7 @@
         },
         {
             "id": "afcbf4ca-ce34-5f68-8e04-1fabb7c70c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c2f0fb-3291-489c-92cf-8d326f2e6735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c2f0fb-3291-489c-92cf-8d326f2e6735.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "c79ab5d6-16e9-57fb-8d69-7de56b13b58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362e8f06-3d52-4368-a686-8fec3417b034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362e8f06-3d52-4368-a686-8fec3417b034.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "2740ba91-65e5-58d3-8a70-8efd015a81a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dca75a1-443d-4f8e-b12b-2aada3a8e3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dca75a1-443d-4f8e-b12b-2aada3a8e3e4.jpg?1",
             "name": "Minotaur Abomination",
             "text": "",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "c5d2fc1d-954e-5839-8686-6fb0b332a74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cf63e7-9143-4236-a887-afd3628d0c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7cf63e7-9143-4236-a887-afd3628d0c03.jpg?1",
             "name": "Nightmare",
             "text": "FlyingNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "8ebabcfc-cbf1-5017-a597-d0a99c3967d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3112a8a-dc80-4099-966c-8fa1807a189b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3112a8a-dc80-4099-966c-8fa1807a189b.jpg?1",
             "name": "Nightwing Shade",
             "text": "Flying{1}{B}: Nightwing Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3666,7 +3666,7 @@
         },
         {
             "id": "f22f008b-874b-5778-90cb-d13f2101ca3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a759dcd2-ca07-4428-a3ea-b2e829b1fcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a759dcd2-ca07-4428-a3ea-b2e829b1fcb4.jpg?1",
             "name": "Quag Sickness",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 for each Swamp you control.",
             "colours": [
@@ -3700,7 +3700,7 @@
         },
         {
             "id": "b3e86392-ec88-50bc-ab24-e0971e55b020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073f81e8-8c0c-4430-bd3e-95ed3625340f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073f81e8-8c0c-4430-bd3e-95ed3625340f.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "ae609756-a310-5f4f-a569-2748b76e86fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e807d-b2eb-4b62-8663-8ad17eed2a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50e807d-b2eb-4b62-8663-8ad17eed2a39.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "60026a8e-4703-54a6-92e8-3587cd848e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a78dbdc-1c5a-4b48-8cd1-64f7b4c29dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a78dbdc-1c5a-4b48-8cd1-64f7b4c29dd6.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "ba44cd54-e63c-5bf9-ab77-f0b42b1b25c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c2323-6589-457a-af51-5528a98e7b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202c2323-6589-457a-af51-5528a98e7b30.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "A deck can have any number of cards named Shadowborn Apostle.{B}, Sacrifice six creatures named Shadowborn Apostle: Search your library for a Demon creature card and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "2a3309d4-4931-5bcb-8e92-0f91442e20d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884c05b-c10e-4f1d-a8bd-8b5118657972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884c05b-c10e-4f1d-a8bd-8b5118657972.jpg?1",
             "name": "Shadowborn Demon",
             "text": "Flying\nWhen Shadowborn Demon enters the battlefield, destroy target non-Demon creature.\nAt the beginning of your upkeep, if there are fewer than six creature cards in your graveyard, sacrifice a creature.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "edbcc56f-232c-5619-8f7e-6dc8c670c431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b2ffdd-f8a4-49e4-aab1-a8096ba2b7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b2ffdd-f8a4-49e4-aab1-a8096ba2b7cb.jpg?1",
             "name": "Shrivel",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "a1866d66-b882-5168-b646-e8857118ccfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cb40e3-c3ed-4b3f-88ad-6f1305297c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cb40e3-c3ed-4b3f-88ad-6f1305297c6f.jpg?1",
             "name": "Syphon Sliver",
             "text": "Sliver creatures you control have lifelink. (Damage dealt by a Sliver creature you control also causes you to gain that much life.)",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "2e010cce-cf13-5df3-8208-67c57b3f859d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b96fed2-0be9-4181-94ae-10f031e2aeb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b96fed2-0be9-4181-94ae-10f031e2aeb2.jpg?1",
             "name": "Tenacious Dead",
             "text": "When Tenacious Dead dies, you may pay {1}{B}. If you do, return it to the battlefield tapped under its owner's control.",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "b9adc9aa-50ab-5a33-8f5d-8668e1ded41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5ae910-ee1d-4958-92d9-0b06872913c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5ae910-ee1d-4958-92d9-0b06872913c6.jpg?1",
             "name": "Undead Minotaur",
             "text": "",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "d973974d-ad04-57fa-b31e-df7e72984130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e07929b-450c-45b0-85e6-512ad280a122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e07929b-450c-45b0-85e6-512ad280a122.jpg?1",
             "name": "Vampire Warlord",
             "text": "Sacrifice another creature: Regenerate Vampire Warlord. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "45d751ef-8ea0-5a6a-9ce7-1f3f9a32dcef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd46f2b-1458-44b1-9c65-960b261b81a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd46f2b-1458-44b1-9c65-960b261b81a5.jpg?1",
             "name": "Vile Rebirth",
             "text": "Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "4d1efa04-f564-57de-bfa1-a1feb9ffc42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b77692-08aa-40b6-b21b-c29a2dc87709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b77692-08aa-40b6-b21b-c29a2dc87709.jpg?1",
             "name": "Wring Flesh",
             "text": "Target creature gets -3/-1 until end of turn.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "14fb34c4-7524-5a21-aa22-b3bdce7f134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26494f96-1d97-4435-a116-3ade1becaab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26494f96-1d97-4435-a116-3ade1becaab4.jpg?1",
             "name": "Xathrid Necromancer",
             "text": "Whenever Xathrid Necromancer or another Human creature you control dies, put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "3526eef2-d3e5-596c-9c97-03936db26828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6652ed29-ee90-4abc-a6cf-6b18a6cbae86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6652ed29-ee90-4abc-a6cf-6b18a6cbae86.jpg?1",
             "name": "Academy Raider",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever Academy Raider deals combat damage to a player, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "01de46db-c92e-5171-b353-72859ca41141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babcfccf-83db-40e7-8a2c-f77358ba3cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babcfccf-83db-40e7-8a2c-f77358ba3cc0.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "e6daf287-f98a-50a8-bc8b-675a11bab984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4125304-fd68-4051-96d5-625ffa9b0d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4125304-fd68-4051-96d5-625ffa9b0d3c.jpg?1",
             "name": "Awaken the Ancient",
             "text": "Enchant Mountain\nEnchanted Mountain is a 7/7 red Giant creature with haste. It's still a land.",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "42181e21-2578-5526-a3b5-827d9d480e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0912d-b4b9-497c-bce7-ed80b79bab32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e0912d-b4b9-497c-bce7-ed80b79bab32.jpg?1",
             "name": "Barrage of Expendables",
             "text": "{R}, Sacrifice a creature: Barrage of Expendables deals 1 damage to target creature or player.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "84f48c79-60dc-539d-935f-65ef9eda6c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68490b8c-e9d1-4f5c-9001-750be0e0569f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68490b8c-e9d1-4f5c-9001-750be0e0569f.jpg?1",
             "name": "Battle Sliver",
             "text": "Sliver creatures you control get +2/+0.",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "ab8b624d-b690-524c-abe2-fd060d572408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63227937-86cc-45e0-9e9e-8c7ab80cbaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63227937-86cc-45e0-9e9e-8c7ab80cbaef.jpg?1",
             "name": "Blur Sliver",
             "text": "Sliver creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "d7aa337f-b036-56fa-8f65-2eda51bbca6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df3a7c9-5c8d-438c-a5ad-3c9754c6ea5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df3a7c9-5c8d-438c-a5ad-3c9754c6ea5d.jpg?1",
             "name": "Burning Earth",
             "text": "Whenever a player taps a nonbasic land for mana, Burning Earth deals 1 damage to that player.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "10a98c62-bda4-5ef6-aeef-bee4501502e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3469d73e-6de1-4b91-83e3-b1714ac29268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3469d73e-6de1-4b91-83e3-b1714ac29268.jpg?1",
             "name": "Canyon Minotaur",
             "text": "",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "b1781259-65cf-5045-84a8-d30e5356dca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4f983-a4b4-46df-830d-ab3d892c93bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4f983-a4b4-46df-830d-ab3d892c93bb.jpg?1",
             "name": "Chandra, Pyromaster",
             "text": "+1: Chandra, Pyromaster deals 1 damage to target player and 1 damage to up to one target creature that player controls. That creature can't block this turn.0: Exile the top card of your library. You may play it this turn.-7: Exile the top ten cards of your library. Choose an instant or sorcery card exiled this way and copy it three times. You may cast the copies without paying their mana costs.",
             "colours": [
@@ -4441,7 +4441,7 @@
         },
         {
             "id": "858e1496-03b5-5be6-8152-e7969c5fe10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d1b479-f6f6-4fec-a5a6-1a74d426fb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d1b479-f6f6-4fec-a5a6-1a74d426fb13.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "9c550df3-a05f-5232-8d27-05adf001af77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08d3ce-a3a7-49ca-aa2f-4dcdacbf923d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca08d3ce-a3a7-49ca-aa2f-4dcdacbf923d.jpg?1",
             "name": "Chandra's Phoenix",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever an opponent is dealt damage by a red instant or sorcery spell you control or by a red planeswalker you control, return Chandra's Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "656f2799-a4d5-5c69-bdce-0f1a344e270b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b8e733-22a7-4696-83b3-297cbe75dadc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b8e733-22a7-4696-83b3-297cbe75dadc.jpg?1",
             "name": "Cyclops Tyrant",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)Cyclops Tyrant can't block creatures with power 2 or less.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "ecf05d38-afb3-5071-9ca7-1ee71ff0034c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7827a7f9-132e-40aa-b881-423440a273bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7827a7f9-132e-40aa-b881-423440a273bd.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4573,7 +4573,7 @@
         },
         {
             "id": "7abc79b8-142e-5cbc-9d28-e317b01cc5f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2048f7-0c68-4142-9aad-de9b91fe5958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2048f7-0c68-4142-9aad-de9b91fe5958.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender (This creature can't attack.)\nWhen Dragon Egg dies, put a 2/2 red Dragon creature token with flying onto the battlefield. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "d7f5fab3-8fbe-5a2f-9715-7dbb737401cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f2e830-a8ef-4c91-978d-23b5f851edae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f2e830-a8ef-4c91-978d-23b5f851edae.jpg?1",
             "name": "Dragon Hatchling",
             "text": "Flying{R}: Dragon Hatchling gets +1/+0 until end of turn.",
             "colours": [
@@ -4642,7 +4642,7 @@
         },
         {
             "id": "0348110e-2c57-58a0-bf1a-fe22c986b596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba659ce-b15c-4af9-bba1-0fb79b23f444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba659ce-b15c-4af9-bba1-0fb79b23f444.jpg?1",
             "name": "Flames of the Firebrand",
             "text": "Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three target creatures and/or players.",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "8dd44fd8-00b8-59ce-968d-e812eb399d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2726d3c-c182-4d8a-a723-0de2c5c4b152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2726d3c-c182-4d8a-a723-0de2c5c4b152.jpg?1",
             "name": "Fleshpulper Giant",
             "text": "When Fleshpulper Giant enters the battlefield, you may destroy target creature with toughness 2 or less.",
             "colours": [
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "5d5d9bbe-f2ee-5bea-a104-b0dc611806e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620c581-fef7-45e8-ba20-d00903c2f4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620c581-fef7-45e8-ba20-d00903c2f4c5.jpg?1",
             "name": "Goblin Diplomats",
             "text": "{T}: Each creature attacks this turn if able.",
             "colours": [
@@ -4742,7 +4742,7 @@
         },
         {
             "id": "5f269514-8236-5eca-b0ae-1cf93e68fc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b69456-c267-4f0d-bd0f-e2da96b9e053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b69456-c267-4f0d-bd0f-e2da96b9e053.jpg?1",
             "name": "Goblin Shortcutter",
             "text": "When Goblin Shortcutter enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "20b09853-6e7f-5771-a5dd-dde7111d912f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f1041-8bbe-46fa-bbe4-40cd993f53a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4f1041-8bbe-46fa-bbe4-40cd993f53a2.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -4809,7 +4809,7 @@
         },
         {
             "id": "27167a9e-cc99-5adf-8bc1-1ffbc44d877b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87186a8a-45da-4cde-a167-c16a6abc4d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87186a8a-45da-4cde-a167-c16a6abc4d24.jpg?1",
             "name": "Lightning Talons",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4843,7 +4843,7 @@
         },
         {
             "id": "c6cfc20f-f155-5ece-be66-5e6207690e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d5e3dc-f307-4f91-a5ee-e7c5d03d8102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d5e3dc-f307-4f91-a5ee-e7c5d03d8102.jpg?1",
             "name": "Marauding Maulhorn",
             "text": "Marauding Maulhorn attacks each combat if able unless you control a creature named Advocate of the Beast.",
             "colours": [
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "4e61786d-5960-5db4-911a-4dadc40ade22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg?1",
             "name": "Mindsparker",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever an opponent casts a white or blue instant or sorcery spell, Mindsparker deals 2 damage to that player.",
             "colours": [
@@ -4911,7 +4911,7 @@
         },
         {
             "id": "39aab18d-a102-548b-9290-1ce3da6c1a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd182be-1604-47e1-858f-3c304fd0ee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd182be-1604-47e1-858f-3c304fd0ee63.jpg?1",
             "name": "Molten Birth",
             "text": "Put two 1/1 red Elemental creature tokens onto the battlefield. Then flip a coin. If you win the flip, return Molten Birth to its owner's hand.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "9204e81b-94aa-56d6-b930-78bb681ac6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff2d740-22cc-4719-ac58-28621951e68d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff2d740-22cc-4719-ac58-28621951e68d.jpg?1",
             "name": "Ogre Battledriver",
             "text": "Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4978,7 +4978,7 @@
         },
         {
             "id": "f23bf371-fac1-5c43-9d04-60cd83baebeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e0a702-6984-4ccd-9ce8-4518c9b19e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e0a702-6984-4ccd-9ce8-4518c9b19e22.jpg?1",
             "name": "Pitchburn Devils",
             "text": "When Pitchburn Devils dies, it deals 3 damage to target creature or player.",
             "colours": [
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "507d3675-e47d-57e8-8a1b-d409c37434dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4df1dd-886d-4fe7-b3f7-2dca044de41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4df1dd-886d-4fe7-b3f7-2dca044de41c.jpg?1",
             "name": "Regathan Firecat",
             "text": "",
             "colours": [
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "4bf888ed-8055-5767-82fb-5074e12bc365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce2b55-45bf-4852-a74a-d0b17c6c9c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce2b55-45bf-4852-a74a-d0b17c6c9c3f.jpg?1",
             "name": "Scourge of Valkas",
             "text": "Flying\nWhenever Scourge of Valkas or another Dragon enters the battlefield under your control, it deals X damage to target creature or player, where X is the number of Dragons you control.{R}: Scourge of Valkas gets +1/+0 until end of turn.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "e8f244a6-b21f-5640-9669-dec20d323642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a02a3-8b65-44a7-82ef-2d3dc05d00ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a02a3-8b65-44a7-82ef-2d3dc05d00ab.jpg?1",
             "name": "Seismic Stomp",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "bb16a2b4-7e98-5648-8844-c5e5c375b92e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a42fcd6-32ce-4a20-af4d-83bd32a7ed3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a42fcd6-32ce-4a20-af4d-83bd32a7ed3e.jpg?1",
             "name": "Shiv's Embrace",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.{R}: Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "1674e010-6bac-55d3-8122-718d83f148e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815cf4a-b694-432b-b618-0893f8f3dc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815cf4a-b694-432b-b618-0893f8f3dc1b.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "882465eb-6c38-584c-99cf-3f76f3508438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbec2ea-7b60-4c51-9782-52ccdd96c4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbec2ea-7b60-4c51-9782-52ccdd96c4b7.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -5213,7 +5213,7 @@
         },
         {
             "id": "31126d22-78c0-50c1-bb35-4f8082199054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90515c37-93cc-4bb2-8237-21e39076c995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90515c37-93cc-4bb2-8237-21e39076c995.jpg?1",
             "name": "Smelt",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5245,7 +5245,7 @@
         },
         {
             "id": "b7e7ab11-d3ca-504e-872c-9bb65a863640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee9254b-3d98-4477-a82e-1450cf3ee96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee9254b-3d98-4477-a82e-1450cf3ee96e.jpg?1",
             "name": "Striking Sliver",
             "text": "Sliver creatures you control have first strike. (They deal combat damage before creatures without first strike.)",
             "colours": [
@@ -5279,7 +5279,7 @@
         },
         {
             "id": "949f9690-fbf2-5912-8121-82904a125528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655d837-945f-4ff5-8952-cff5f7b2d18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3655d837-945f-4ff5-8952-cff5f7b2d18f.jpg?1",
             "name": "Thorncaster Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature attacks, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -5313,7 +5313,7 @@
         },
         {
             "id": "d947c61a-c8d1-5e8e-8a55-55fe59791b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa445d-d734-4e4f-800d-fe7bea86eb70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61aa445d-d734-4e4f-800d-fe7bea86eb70.jpg?1",
             "name": "Thunder Strike",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "3a496905-95a3-5af5-8a05-a63e04b182f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2b0fdb-2209-4b98-87e1-1eb870706cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2b0fdb-2209-4b98-87e1-1eb870706cec.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -5377,7 +5377,7 @@
         },
         {
             "id": "f68354f4-2bce-5d13-9162-b3372c613b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c4556f-652b-4df0-a501-d413d32e7a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c4556f-652b-4df0-a501-d413d32e7a91.jpg?1",
             "name": "Wild Guess",
             "text": "As an additional cost to cast Wild Guess, discard a card.\nDraw two cards.",
             "colours": [
@@ -5409,7 +5409,7 @@
         },
         {
             "id": "cbbbc766-4928-50b5-995e-c683ac5f88f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962273bb-2186-4e33-99c5-65eedc4a93e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962273bb-2186-4e33-99c5-65eedc4a93e9.jpg?1",
             "name": "Wild Ricochet",
             "text": "You may choose new targets for target instant or sorcery spell. Then copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -5441,7 +5441,7 @@
         },
         {
             "id": "d1af1c8e-2668-5354-9cb1-e9e0d137ee39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e349c204-3a93-4bf7-b79a-5f5f261ea2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e349c204-3a93-4bf7-b79a-5f5f261ea2d3.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, put a 1/1 red Elemental creature token onto the battlefield.",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "3f6217c4-f348-5cdf-9766-695acfd2f20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1320400-5aa8-48d6-be84-197b4559456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1320400-5aa8-48d6-be84-197b4559456f.jpg?1",
             "name": "Advocate of the Beast",
             "text": "At the beginning of your end step, put a +1/+1 counter on target Beast creature you control.",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "2b448b7a-81a6-55e8-bfb6-866c4aabcbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1bd3ff-f3cd-4e9d-ae2e-2c51d0aaec7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1bd3ff-f3cd-4e9d-ae2e-2c51d0aaec7f.jpg?1",
             "name": "Bramblecrush",
             "text": "Destroy target noncreature permanent.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "e52b7a2f-421b-5b28-943b-303dc3bee654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585c11e2-4c30-436c-9dbd-354b154f6def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585c11e2-4c30-436c-9dbd-354b154f6def.jpg?1",
             "name": "Briarpack Alpha",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Briarpack Alpha enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "2b6c22b0-e549-58af-a993-1434efe37917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b4a78-afdd-4067-810e-1fa0ddf8fb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30b4a78-afdd-4067-810e-1fa0ddf8fb0e.jpg?1",
             "name": "Brindle Boar",
             "text": "Sacrifice Brindle Boar: You gain 4 life.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "5375b781-1fb9-5c11-b02f-a63a98e2a23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82cc190-7ec0-4493-b3dc-dad0cbffa2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82cc190-7ec0-4493-b3dc-dad0cbffa2f8.jpg?1",
             "name": "Deadly Recluse",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5645,7 +5645,7 @@
         },
         {
             "id": "0a0750cd-1705-5366-911d-98fa0431f180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d0e6a6-629a-45a7-bfcb-25ba7156788b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d0e6a6-629a-45a7-bfcb-25ba7156788b.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "0cfc8032-7d9d-5069-8a0e-0c79f412934c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd181-59d8-4d4c-a8b6-e6b38704009c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46cd181-59d8-4d4c-a8b6-e6b38704009c.jpg?1",
             "name": "Enlarge",
             "text": "Target creature gets +7/+7 and gains trample until end of turn. It must be blocked this turn if able. (If a creature with trample would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "9711ad15-1aeb-598e-9117-85fcf025feb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b55d04f-c52f-4b94-b25c-f5c7d8c1c18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b55d04f-c52f-4b94-b25c-f5c7d8c1c18e.jpg?1",
             "name": "Fog",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "f6fd9a27-5bbe-5447-a52d-b7e28adcbd31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d0c67-e9f4-46d9-bd74-13a8606fdfe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a96d0c67-e9f4-46d9-bd74-13a8606fdfe3.jpg?1",
             "name": "Garruk, Caller of Beasts",
             "text": "+1: Reveal the top five cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.-3: You may put a green creature card from your hand onto the battlefield.-7: You get an emblem with \"Whenever you cast a creature spell, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "cdddf1d7-e08e-5ad4-9896-7dee906ac040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b24651-1814-440e-a415-a96c03e51544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b24651-1814-440e-a415-a96c03e51544.jpg?1",
             "name": "Garruk's Horde",
             "text": "Trample Play with the top card of your library revealed.\nYou may cast the top card of your library if it's a creature card. (Do this only any time you could cast that creature card. You still pay the spell's costs.)",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "2ba31a82-8c51-5920-9c06-f1cc8cd860fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b32578-a074-4a46-b742-84b974748903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b32578-a074-4a46-b742-84b974748903.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "532f8a13-05d7-5511-9a63-c34dcbafb56c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253ebe04-9605-424e-8cff-51d3a54f91a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253ebe04-9605-424e-8cff-51d3a54f91a7.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5880,7 +5880,7 @@
         },
         {
             "id": "e0602c94-44b5-5d30-bca1-14460b5a7996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e112d77d-f019-4709-b31a-b02952df0e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e112d77d-f019-4709-b31a-b02952df0e35.jpg?1",
             "name": "Gladecover Scout",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5915,7 +5915,7 @@
         },
         {
             "id": "aa731742-89d3-5ff3-a72a-3d54f1f4f456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712f0ce4-9189-4c75-9c2b-d370bce89052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712f0ce4-9189-4c75-9c2b-d370bce89052.jpg?1",
             "name": "Groundshaker Sliver",
             "text": "Sliver creatures you control have trample. (If a Sliver you control would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5949,7 +5949,7 @@
         },
         {
             "id": "a7619894-502e-5f07-bba1-d0c2a4cb6121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fc5ff1-b8bd-44d5-a659-17eeae06736a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20fc5ff1-b8bd-44d5-a659-17eeae06736a.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "Put a 2/2 green Wolf creature token onto the battlefield for each Forest you control.",
             "colours": [
@@ -5981,7 +5981,7 @@
         },
         {
             "id": "8a85aef4-5ca0-571a-a59a-530541792690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7a6df7-acfc-4047-b119-505f4277225c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7a6df7-acfc-4047-b119-505f4277225c.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6013,7 +6013,7 @@
         },
         {
             "id": "0f4d8de4-eca4-5598-be8c-cdd87d5fdc66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa6c8d-b5b5-4b68-9ad4-c9d8169659d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfa6c8d-b5b5-4b68-9ad4-c9d8169659d6.jpg?1",
             "name": "Into the Wilds",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a land card, you may put it onto the battlefield.",
             "colours": [
@@ -6045,7 +6045,7 @@
         },
         {
             "id": "a32a2437-b491-54ac-a06e-3731c83a038a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438bd3c1-98f2-4fcc-8521-995c6c5c1a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438bd3c1-98f2-4fcc-8521-995c6c5c1a79.jpg?1",
             "name": "Kalonian Hydra",
             "text": "TrampleKalonian Hydra enters the battlefield with four +1/+1 counters on it.\nWhenever Kalonian Hydra attacks, double the number of +1/+1 counters on each creature you control.",
             "colours": [
@@ -6079,7 +6079,7 @@
         },
         {
             "id": "5fbfd623-4b13-5e03-a56e-2bba50102607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135946fc-fe67-401f-821d-d7145c63f030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135946fc-fe67-401f-821d-d7145c63f030.jpg?1",
             "name": "Kalonian Tusker",
             "text": "",
             "colours": [
@@ -6113,7 +6113,7 @@
         },
         {
             "id": "25557867-c115-5b39-ae0f-0e0b92ecd142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb3410b-d6c3-4e42-b3c9-fb557f9a16f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb3410b-d6c3-4e42-b3c9-fb557f9a16f0.jpg?1",
             "name": "Lay of the Land",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6145,7 +6145,7 @@
         },
         {
             "id": "cd6bf4f4-644d-59c4-8f41-ea323c1b174c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45433b-e124-44d7-9463-dada39310148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe45433b-e124-44d7-9463-dada39310148.jpg?1",
             "name": "Manaweft Sliver",
             "text": "Sliver creatures you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "9fd10c9d-a9d3-5979-91f9-2f876f68974f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7745f6a9-400c-4200-9732-86c54247de46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7745f6a9-400c-4200-9732-86c54247de46.jpg?1",
             "name": "Megantic Sliver",
             "text": "Sliver creatures you control get +3/+3.",
             "colours": [
@@ -6213,7 +6213,7 @@
         },
         {
             "id": "85143f97-476d-51f3-bf72-a7c75ac954e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bac967b-f684-4916-b7f4-8fffdd752a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bac967b-f684-4916-b7f4-8fffdd752a93.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "908307dc-33ef-5ec2-96ba-b818dd4cce7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg?1",
             "name": "Oath of the Ancient Wood",
             "text": "Whenever Oath of the Ancient Wood or another enchantment enters the battlefield under your control, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -6277,7 +6277,7 @@
         },
         {
             "id": "54ad540a-5ee2-563f-be4a-00ec30b4b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbac2e5-cc3a-4be1-9891-6098b1066de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbac2e5-cc3a-4be1-9891-6098b1066de8.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "33727667-72fb-5b83-ae80-f4ba7c8e0dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e37de8-66a1-4afa-aa6f-1151f849dfa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e37de8-66a1-4afa-aa6f-1151f849dfa8.jpg?1",
             "name": "Predatory Sliver",
             "text": "Sliver creatures you control get +1/+1.",
             "colours": [
@@ -6343,7 +6343,7 @@
         },
         {
             "id": "1a1376d4-eee1-5997-b077-df070c8a93b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e750d55d-d5e8-4abe-99cf-f6b8ba86cf16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e750d55d-d5e8-4abe-99cf-f6b8ba86cf16.jpg?1",
             "name": "Primeval Bounty",
             "text": "Whenever you cast a creature spell, put a 3/3 green Beast creature token onto the battlefield.\nWhenever you cast a noncreature spell, put three +1/+1 counters on target creature you control.\nWhenever a land enters the battlefield under your control, you gain 3 life.",
             "colours": [
@@ -6375,7 +6375,7 @@
         },
         {
             "id": "acf6499d-acf3-5521-b535-f609305eac34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24976e3a-9f34-4dce-8bb3-efecfdfff160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24976e3a-9f34-4dce-8bb3-efecfdfff160.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "77871027-8a37-5b04-b44a-55830d7f172d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b84b6dc-d78d-4d6a-9e9a-2b40854a102b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b84b6dc-d78d-4d6a-9e9a-2b40854a102b.jpg?1",
             "name": "Rootwalla",
             "text": "{1}{G}: Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "949f761c-54d2-5cf1-ba97-c21dcb124eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8610ff1-064b-4c75-a8df-d3b076370d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8610ff1-064b-4c75-a8df-d3b076370d1e.jpg?1",
             "name": "Rumbling Baloth",
             "text": "",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "970ccb5c-35a8-588f-9424-a9dc4b05f1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5346ed7-2e17-4d8c-9c4b-b5efdd26380d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5346ed7-2e17-4d8c-9c4b-b5efdd26380d.jpg?1",
             "name": "Savage Summoning",
             "text": "Savage Summoning can't be countered.\nThe next creature card you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -6507,7 +6507,7 @@
         },
         {
             "id": "8a6a6e9a-6084-593a-9000-2579e24224a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec30153a-36b5-42f8-beed-9efab09f1051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec30153a-36b5-42f8-beed-9efab09f1051.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -6541,7 +6541,7 @@
         },
         {
             "id": "4d029808-52a7-5217-b922-afaea0b5ea15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256cd0-6fe9-4905-9886-fb1457292db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256cd0-6fe9-4905-9886-fb1457292db5.jpg?1",
             "name": "Sporemound",
             "text": "Whenever a land enters the battlefield under your control, put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "df55f7be-b10b-519d-a26a-a65a1cb1fe10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b9c400-dc8f-4fe6-a868-fdf0d247086a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b9c400-dc8f-4fe6-a868-fdf0d247086a.jpg?1",
             "name": "Trollhide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\" (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6609,7 +6609,7 @@
         },
         {
             "id": "79e60c6e-c744-5acf-8ba3-df08f4379582",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e635174-7f7d-4c04-a6aa-8674da6863ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e635174-7f7d-4c04-a6aa-8674da6863ff.jpg?1",
             "name": "Vastwood Hydra",
             "text": "Vastwood Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Vastwood Hydra dies, you may distribute a number of +1/+1 counters equal to the number of +1/+1 counters on Vastwood Hydra among any number of creatures you control.",
             "colours": [
@@ -6643,7 +6643,7 @@
         },
         {
             "id": "dabee451-41f8-5416-b056-12563e3eb8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e37e6-6f19-4dfa-bd13-6e261177c1cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e37e6-6f19-4dfa-bd13-6e261177c1cf.jpg?1",
             "name": "Verdant Haven",
             "text": "Enchant land\nWhen Verdant Haven enters the battlefield, you gain 2 life.\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -6677,7 +6677,7 @@
         },
         {
             "id": "208744aa-1889-5fc0-9807-3c98e54884de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da15100b-2934-438c-9917-84ad8bdc4181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da15100b-2934-438c-9917-84ad8bdc4181.jpg?1",
             "name": "Voracious Wurm",
             "text": "Voracious Wurm enters the battlefield with X +1/+1 counters on it, where X is the amount of life you've gained this turn.",
             "colours": [
@@ -6711,7 +6711,7 @@
         },
         {
             "id": "84d42d80-f307-536b-b352-f04a862d189f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb7d122-34e8-48e1-a978-831c78a37d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb7d122-34e8-48e1-a978-831c78a37d0c.jpg?1",
             "name": "Windstorm",
             "text": "Windstorm deals X damage to each creature with flying.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "2dbe53bc-9ecc-5260-b3ff-03fc206ee236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5ce47d-ea4f-4e15-adb6-5bb66981ed24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5ce47d-ea4f-4e15-adb6-5bb66981ed24.jpg?1",
             "name": "Witchstalker",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever an opponent casts a blue or black spell during your turn, put a +1/+1 counter on Witchstalker.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "3e8a16d5-7547-53d9-af26-c7a6d9c5c242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c73dbf3-e68e-4f21-b6ca-94302bf5574c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c73dbf3-e68e-4f21-b6ca-94302bf5574c.jpg?1",
             "name": "Woodborn Behemoth",
             "text": "As long as you control eight or more lands, Woodborn Behemoth gets +4/+4 and has trample. (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "7bd48e60-46f2-5009-b8e2-aa04f56c93a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a4c2ab-c5bc-4e07-8671-a688ebd5471c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a4c2ab-c5bc-4e07-8671-a688ebd5471c.jpg?1",
             "name": "Accorder's Shield",
             "text": "Equipped creature gets +0/+3 and has vigilance. (Attacking doesn't cause it to tap.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "3b7321a8-63a0-5e2e-a624-f001a2c31ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af87c24-a534-462b-968b-dccf6ac63299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af87c24-a534-462b-968b-dccf6ac63299.jpg?1",
             "name": "Bubbling Cauldron",
             "text": "{1}, {T}, Sacrifice a creature: You gain 4 life.{1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.",
             "colours": [],
@@ -6869,7 +6869,7 @@
         },
         {
             "id": "a78b88d0-8058-5b68-9764-57aa373c720d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c95a0a1-9c2c-44df-b0fe-c22efb6d87ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c95a0a1-9c2c-44df-b0fe-c22efb6d87ee.jpg?1",
             "name": "Darksteel Forge",
             "text": "Artifacts you control have indestructible. (Effects that say \"destroy\" don't destroy them. Artifact creatures with indestructible can't be destroyed by damage.)",
             "colours": [],
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "18fb72e8-437f-530e-9e4c-a203834ee425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290a80b6-2e9e-495f-81b6-845ee80fb9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290a80b6-2e9e-495f-81b6-845ee80fb9c2.jpg?1",
             "name": "Darksteel Ingot",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.){T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "7b5a51cc-3f83-50b9-96e5-07243a69de3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6bf1a-7152-496f-a4c7-e720ef4294d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a6bf1a-7152-496f-a4c7-e720ef4294d8.jpg?1",
             "name": "Door of Destinies",
             "text": "As Door of Destinies enters the battlefield, choose a creature type.\nWhenever you cast a spell of the chosen type, put a charge counter on Door of Destinies.\nCreatures you control of the chosen type get +1/+1 for each charge counter on Door of Destinies.",
             "colours": [],
@@ -6953,7 +6953,7 @@
         },
         {
             "id": "0bffb575-588f-5431-b2a4-89d11fa9a376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d19d950-9e63-4b15-8531-f4b16f5b82fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d19d950-9e63-4b15-8531-f4b16f5b82fa.jpg?1",
             "name": "Elixir of Immortality",
             "text": "{2}, {T}: You gain 5 life. Shuffle Elixir of Immortality and your graveyard into their owner's library.",
             "colours": [],
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "5e984032-58b2-5b2f-b5ff-4ea3a64905bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f653742-b92a-4cfa-b3b5-8d20aabdb5dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f653742-b92a-4cfa-b3b5-8d20aabdb5dd.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7011,7 +7011,7 @@
         },
         {
             "id": "ab80793c-6b37-5380-9e89-b144d19db129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c825c138-97de-44b9-8aec-70608ae035b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c825c138-97de-44b9-8aec-70608ae035b6.jpg?1",
             "name": "Guardian of the Ages",
             "text": "Defender (This creature can't attack.)\nWhen a creature attacks you or a planeswalker you control, if Guardian of the Ages has defender, it loses defender and gains trample.",
             "colours": [],
@@ -7042,7 +7042,7 @@
         },
         {
             "id": "7343766d-ad54-51e9-bcbf-9fc09898e2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc1e07-7894-4f22-936d-bf5df3f8d5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dc1e07-7894-4f22-936d-bf5df3f8d5a5.jpg?1",
             "name": "Haunted Plate Mail",
             "text": "Equipped creature gets +4/+4.{0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate this ability only if you control no creatures.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7072,7 +7072,7 @@
         },
         {
             "id": "6388406f-0779-50df-bcf2-cc3aaccef646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f28acb-8ccb-4b89-ba7f-ff7ce59852aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f28acb-8ccb-4b89-ba7f-ff7ce59852aa.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "d7d7391c-5d25-5048-940c-82248388caba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde6763-2102-4adb-8048-fc9fe921205b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde6763-2102-4adb-8048-fc9fe921205b.jpg?1",
             "name": "Pyromancer's Gauntlet",
             "text": "If a red instant or sorcery spell you control or a red planeswalker you control would deal damage to a permanent or player, it deals that much damage plus 2 to that permanent or player instead.",
             "colours": [],
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "7956bde2-f18b-55ca-b932-0ded3bc5ecc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9045df-3eff-4236-9bbb-77537b302e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9045df-3eff-4236-9bbb-77537b302e27.jpg?1",
             "name": "Ratchet Bomb",
             "text": "{T}: Put a charge counter on Ratchet Bomb.{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
             "colours": [],
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "782ca033-bc37-5baf-a152-48d4d538278b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219ab03a-2b3b-4eef-8a42-2cbe793d2f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219ab03a-2b3b-4eef-8a42-2cbe793d2f33.jpg?1",
             "name": "Ring of Three Wishes",
             "text": "Ring of Three Wishes enters the battlefield with three wish counters on it.{5}, {T}, Remove a wish counter from Ring of Three Wishes: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "f79b79ad-1d26-5674-bd35-c3abaff7a50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0e90b8-bc38-4e1c-92ca-ac562cc57e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0e90b8-bc38-4e1c-92ca-ac562cc57e31.jpg?1",
             "name": "Rod of Ruin",
             "text": "{3}, {T}: Rod of Ruin deals 1 damage to target creature or player.",
             "colours": [],
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "b4e9ae08-751f-5746-a2f0-cc83b15a3439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3129645a-221c-4eb5-88fd-12cc742a1dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3129645a-221c-4eb5-88fd-12cc742a1dfe.jpg?1",
             "name": "Sliver Construct",
             "text": "",
             "colours": [],
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "647accf9-5f5c-53ca-846c-60285de37ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624fe171-8bd8-4156-b40e-74e2a847d380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624fe171-8bd8-4156-b40e-74e2a847d380.jpg?1",
             "name": "Staff of the Death Magus",
             "text": "Whenever you cast a black spell or a Swamp enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "4bcf4670-ee5e-560c-80c4-edc5bc613669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6befbd-4fe3-4338-b8ea-13b8b70a7664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6befbd-4fe3-4338-b8ea-13b8b70a7664.jpg?1",
             "name": "Staff of the Flame Magus",
             "text": "Whenever you cast a red spell or a Mountain enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7300,7 +7300,7 @@
         },
         {
             "id": "6d19452e-c89f-5168-a6d4-1082d6cdddb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86bf36b-b83f-4451-8cdc-2a4ccffb93c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86bf36b-b83f-4451-8cdc-2a4ccffb93c7.jpg?1",
             "name": "Staff of the Mind Magus",
             "text": "Whenever you cast a blue spell or an Island enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "eb89799d-deeb-5fb6-936d-30e7d6eb0ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a1f830-d19a-4ebf-9573-09b677693dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a1f830-d19a-4ebf-9573-09b677693dd6.jpg?1",
             "name": "Staff of the Sun Magus",
             "text": "Whenever you cast a white spell or a Plains enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7356,7 +7356,7 @@
         },
         {
             "id": "a34e42ec-0b13-5ec7-a994-1c50aa4e5aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d207f03d-4c7b-444f-bf95-e63f7004d525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d207f03d-4c7b-444f-bf95-e63f7004d525.jpg?1",
             "name": "Staff of the Wild Magus",
             "text": "Whenever you cast a green spell or a Forest enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "97086dd0-c41b-535c-bcb2-26e1709aa1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d1fc0f-5c8b-4e47-aaf8-8888c025f70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d1fc0f-5c8b-4e47-aaf8-8888c025f70f.jpg?1",
             "name": "Strionic Resonator",
             "text": "{2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy. (A triggered ability uses the words \"when,\" \"whenever,\" or \"at.\")",
             "colours": [],
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "adb8b2cb-4907-5501-8ce2-506f4cf085f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132c5358-c258-4b86-862a-2d140011dc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132c5358-c258-4b86-862a-2d140011dc3f.jpg?1",
             "name": "Trading Post",
             "text": "{1}, {T}, Discard a card: You gain 4 life.{1}, {T}, Pay 1 life: Put a 0/1 white Goat creature token onto the battlefield.{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.{1}, {T}, Sacrifice an artifact: Draw a card.",
             "colours": [],
@@ -7440,7 +7440,7 @@
         },
         {
             "id": "c89c8827-c118-544d-a805-541477725e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769159b-5a6a-45e5-b69b-8db2a6ef5418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7769159b-5a6a-45e5-b69b-8db2a6ef5418.jpg?1",
             "name": "Vial of Poison",
             "text": "{1}, Sacrifice Vial of Poison: Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [],
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "a71a8084-4df9-57ac-8131-05c84b8a1bbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad5a84b-ae9b-4ed1-a4de-b91bbf8ed0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad5a84b-ae9b-4ed1-a4de-b91bbf8ed0a5.jpg?1",
             "name": "Encroaching Wastes",
             "text": "{T}: Add {1} to your mana pool.{4}, {T}, Sacrifice Encroaching Wastes: Destroy target nonbasic land.",
             "colours": [],
@@ -7496,7 +7496,7 @@
         },
         {
             "id": "14761310-7d63-5b20-aaea-9890adce183d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927ed667-c228-4b96-a9f6-7cbadade8134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927ed667-c228-4b96-a9f6-7cbadade8134.jpg?1",
             "name": "Mutavault",
             "text": "{T}: Add {1} to your mana pool.{1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "d8bfceb1-fd8b-52ef-b802-0a4401bf8b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd26b14-a920-4b82-91b8-8de0e7d03f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd26b14-a920-4b82-91b8-8de0e7d03f6e.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {1} to your mana pool.{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "80883bcc-dd8f-5ba9-a87f-463db64f5d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ca29a-7fb3-426f-922b-5a2b905a5565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334ca29a-7fb3-426f-922b-5a2b905a5565.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7590,7 +7590,7 @@
         },
         {
             "id": "235fd614-de6d-5dc2-a1d7-2d9d19d73b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8098d41-38dc-4f82-b65e-d3bc7d8e0fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8098d41-38dc-4f82-b65e-d3bc7d8e0fcc.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7628,7 +7628,7 @@
         },
         {
             "id": "8e987378-0c30-54ed-8d85-4d7df1aeb275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d9f61-b94d-4ba3-b709-791ec647a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d9f61-b94d-4ba3-b709-791ec647a716.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "b6bdcad0-63ed-5e7a-9a36-3e25807e8a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90742ab3-89fb-4ac1-9bf0-0e2d17252bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90742ab3-89fb-4ac1-9bf0-0e2d17252bff.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7704,7 +7704,7 @@
         },
         {
             "id": "1cf4fdf5-85f9-5e51-acbf-d16436a8c50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94de0250-53a6-45c8-85a7-a473f271102e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94de0250-53a6-45c8-85a7-a473f271102e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "5c67be85-200f-59a9-9a76-4aa7273a8ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2814990-4c7a-44ae-8d76-157156aa79bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2814990-4c7a-44ae-8d76-157156aa79bb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "a4240019-2093-58c2-a4f1-2eb2489abb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d37787-be3a-4ed3-94b8-e675f2beecf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d37787-be3a-4ed3-94b8-e675f2beecf0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "1751a521-5849-5e20-8d65-84fc928ff2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59cd300-c4f3-4ba6-8018-134eaf6a399c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59cd300-c4f3-4ba6-8018-134eaf6a399c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7856,7 +7856,7 @@
         },
         {
             "id": "b72fbdf6-e73a-5bd7-8fac-7011e21d40eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4510090f-b42d-4df1-af71-64a77dfbc1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4510090f-b42d-4df1-af71-64a77dfbc1b2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7894,7 +7894,7 @@
         },
         {
             "id": "a9fb6ea7-4e3c-51c5-be9c-2ba76e552ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce9570-e5d7-44e5-bc93-6d03dd1a3794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cce9570-e5d7-44e5-bc93-6d03dd1a3794.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "295080c6-5d3c-558b-8a14-62c92cc1e654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4394a-14c9-4a6e-898c-056108b16e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce4394a-14c9-4a6e-898c-056108b16e09.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7970,7 +7970,7 @@
         },
         {
             "id": "50bee390-5ec7-576d-a8f0-f0fc4d29833d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07504e2d-9d70-4957-bee6-abab92368a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07504e2d-9d70-4957-bee6-abab92368a33.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8008,7 +8008,7 @@
         },
         {
             "id": "7d3bb0b1-6adb-5af6-a8d2-6008b794731d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82bb8b-2a95-4935-a728-6898f64ce39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82bb8b-2a95-4935-a728-6898f64ce39a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "88ea4bb0-1e3b-5999-b75d-20cfef6f7ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffc2e95-dd9b-4581-988f-850d9e240a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffc2e95-dd9b-4581-988f-850d9e240a30.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8084,7 +8084,7 @@
         },
         {
             "id": "ba485772-4c20-5b39-b1a1-811136888938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67057abf-749d-4512-968a-832c56324e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67057abf-749d-4512-968a-832c56324e13.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8122,7 +8122,7 @@
         },
         {
             "id": "0da3cca4-2343-536f-8e2c-469cd1d9a44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c28158-fb96-4006-bc65-425dba031395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c28158-fb96-4006-bc65-425dba031395.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8160,7 +8160,7 @@
         },
         {
             "id": "20a1fbef-a42d-595e-864b-934d9809bac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5277ee-f1e0-4777-9011-d7a23c855919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5277ee-f1e0-4777-9011-d7a23c855919.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "1c8ebaac-e166-54d6-9b78-29df71faa1c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd98de13-d556-4cf3-99f3-d1c0db85cb3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd98de13-d556-4cf3-99f3-d1c0db85cb3f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "53d27a73-9c44-5579-ab4e-173db0947438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04db1116-3819-4a57-a001-dfa7578f0f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04db1116-3819-4a57-a001-dfa7578f0f12.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8274,7 +8274,7 @@
         },
         {
             "id": "d8cb8522-01d2-5c56-ae5e-16390090c18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b3dce8-9c28-41f6-823f-a7d64dd9e33a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b3dce8-9c28-41f6-823f-a7d64dd9e33a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8312,7 +8312,7 @@
         },
         {
             "id": "234c2a42-59db-55aa-a13a-6c5472f4acda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68353af0-9cd0-43c0-9b39-8f904c618e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68353af0-9cd0-43c0-9b39-8f904c618e3a.jpg?1",
             "name": "Sliver",
             "text": "",
             "colours": [],
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "4208994e-f2ce-5e38-bb3d-40067c58aa9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826320b7-4ccf-4ace-8c2c-15052b6bad73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826320b7-4ccf-4ace-8c2c-15052b6bad73.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "7a31461f-de1f-510e-af84-58c841687c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41ce71-52df-4bc1-884d-b09419d8dd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41ce71-52df-4bc1-884d-b09419d8dd13.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "7f3996d0-a560-5d15-bdf9-da6965786680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e90524-bad8-4d24-85be-9402401e7b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e90524-bad8-4d24-85be-9402401e7b42.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "79987e55-364d-53c5-966f-2a56bff108b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d82a8d-4c57-401f-92c3-8fd9ba20174a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d82a8d-4c57-401f-92c3-8fd9ba20174a.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "23b163a2-b372-56f9-a1d2-17777a908e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efaa5b5-984d-4eff-81b6-9b4989f149eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efaa5b5-984d-4eff-81b6-9b4989f149eb.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8512,7 +8512,7 @@
         },
         {
             "id": "6d87df30-3dc9-5aa7-9823-a36be9d4ae94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed37fa8e-5930-4e57-8ead-73894ac40c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed37fa8e-5930-4e57-8ead-73894ac40c19.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "d4a228fe-0702-5871-83bb-6bef95c79a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7315d5-26d9-4ecc-bca2-b75c6fb12597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7315d5-26d9-4ecc-bca2-b75c6fb12597.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "80cc69dd-7da2-5f51-aed2-c9fde5de7f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fc2dc9-40df-46d8-98c0-ca4919bd5524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fc2dc9-40df-46d8-98c0-ca4919bd5524.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "a520baa5-a891-5f8a-b35f-09a9cc2622b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd66b96-eccb-44ce-9125-063d34af2ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd66b96-eccb-44ce-9125-063d34af2ff8.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8648,7 +8648,7 @@
         },
         {
             "id": "c3fdc9ac-a844-5c97-acf9-6bd0f990e7aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309f1bd4-78af-4722-9d45-b5f40b001570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309f1bd4-78af-4722-9d45-b5f40b001570.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "e81a58c7-0994-5d6f-b3b7-5f91d759622f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f327de6e-c9f1-478d-9940-b500df8cef10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f327de6e-c9f1-478d-9940-b500df8cef10.jpg?1",
             "name": "Liliana of the Dark Realms Emblem",
             "text": "",
             "colours": [],
@@ -8711,7 +8711,7 @@
         },
         {
             "id": "756851aa-7534-5254-8e51-b9859dd4d8eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16429cb-9b00-4411-9ffc-252b38ad0b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16429cb-9b00-4411-9ffc-252b38ad0b8c.jpg?1",
             "name": "Garruk, Caller of Beasts Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M15.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M15.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "51887cb6-f868-59b3-81a0-1da796187b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9302ba8-7ff2-4eaa-a32d-eedd94f0bb79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9302ba8-7ff2-4eaa-a32d-eedd94f0bb79.jpg?1",
             "name": "Ajani Steadfast",
             "text": "+1: Until end of turn, up to one target creature gets +1/+1 and gains first strike, vigilance, and lifelink.\n\u22122: Put a +1/+1 counter on each creature you control and a loyalty counter on each other planeswalker you control.\n\u22127: You get an emblem with \"If a source would deal damage to you or a planeswalker you control, prevent all but 1 of that damage.\"",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "2458e513-4186-5765-adec-ed760a7404bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411cacd-910b-4eda-8f67-03b426c94ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e411cacd-910b-4eda-8f67-03b426c94ebe.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "9ede43f0-8c1c-5da3-80bf-bd83cb4189ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79662d5-3b6f-4c5a-8540-63c201027b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79662d5-3b6f-4c5a-8540-63c201027b66.jpg?1",
             "name": "Avacyn, Guardian Angel",
             "text": "Flying, vigilance\n{1}{W}: Prevent all damage that would be dealt to another target creature this turn by sources of the color of your choice.\n{5}{W}{W}: Prevent all damage that would be dealt to target player this turn by sources of the color of your choice.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "eac62124-5958-5a83-95d8-2de5ada52734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8313a1-af64-4ffb-9110-e70d297b9343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8313a1-af64-4ffb-9110-e70d297b9343.jpg?1",
             "name": "Battle Mastery",
             "text": "Enchant creature\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "e5f07546-cd6d-51fc-9402-a9b58dbf04d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85003365-7c5f-4283-995d-e466deef444b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85003365-7c5f-4283-995d-e466deef444b.jpg?1",
             "name": "Boonweaver Giant",
             "text": "When Boonweaver Giant enters the battlefield, you may search your graveyard, hand, and/or library for an Aura card and put it onto the battlefield attached to Boonweaver Giant. If you search your library this way, shuffle it.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "be2ff809-3e7c-5125-87d3-721456a3b8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5eefd2-d8ad-43b7-a5d9-6a2ad7f19b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5eefd2-d8ad-43b7-a5d9-6a2ad7f19b6e.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature on the battlefield.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "d17a8045-110b-5e1b-ba7f-2f39809d5efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9b4111-ca9f-435b-81c4-0abf65d1384b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9b4111-ca9f-435b-81c4-0abf65d1384b.jpg?1",
             "name": "Constricting Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, you may exile target creature an opponent controls until this creature leaves the battlefield.\"",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "14185911-f5ed-5a69-9962-4402c2eb6fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedfd1e-5073-47e2-9137-5f2bf4e436e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efedfd1e-5073-47e2-9137-5f2bf4e436e3.jpg?1",
             "name": "Dauntless River Marshal",
             "text": "Dauntless River Marshal gets +1/+1 as long as you control an Island.\n{3}{U}: Tap target creature.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "473d6f6d-3760-5f7a-b3a5-9f979f381622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c8b3d-4675-49ad-8d86-8a5d6ca9cae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217c8b3d-4675-49ad-8d86-8a5d6ca9cae5.jpg?1",
             "name": "Devouring Light",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "0f787f39-064c-5b96-9fff-db072c9a7001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c1ddf8-e38a-44df-9195-40e2b0d4cd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c1ddf8-e38a-44df-9195-40e2b0d4cd5f.jpg?1",
             "name": "Divine Favor",
             "text": "Enchant creature\nWhen Divine Favor enters the battlefield, you gain 3 life.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "ab224d3a-8097-5593-8d31-23f70560851a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9c2cc-2516-43d5-a7dc-27509f402077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9c2cc-2516-43d5-a7dc-27509f402077.jpg?1",
             "name": "Ephemeral Shields",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "8c241143-13c1-5e0a-9ca3-b4cd10d5db13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36341d37-064e-449e-8be7-a2716ae7e317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36341d37-064e-449e-8be7-a2716ae7e317.jpg?1",
             "name": "First Response",
             "text": "At the beginning of each upkeep, if you lost life last turn, put a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "8245e39e-2de6-5a9e-894f-7066475b9c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90488074-730c-47a3-9a4b-9fec1da775ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90488074-730c-47a3-9a4b-9fec1da775ad.jpg?1",
             "name": "Geist of the Moors",
             "text": "Flying",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "1653f7a5-80ba-5ca9-a5e1-0cce230135c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea54b97-9182-4d46-9d70-3cc7f9b18ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea54b97-9182-4d46-9d70-3cc7f9b18ada.jpg?1",
             "name": "Heliod's Pilgrim",
             "text": "When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "9ebe0ea4-f67d-5f0f-a030-9fd858ef55ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b44eb0d-5a3a-4624-aee4-11d6978fb4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b44eb0d-5a3a-4624-aee4-11d6978fb4b0.jpg?1",
             "name": "Hushwing Gryff",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nCreatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "1ab00080-a2f0-566c-acdc-a883e948519e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c73b7-a242-4fca-ab96-194750c984a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c73b7-a242-4fca-ab96-194750c984a7.jpg?1",
             "name": "Kinsbaile Skirmisher",
             "text": "When Kinsbaile Skirmisher enters the battlefield, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "465248ba-4e70-5413-a258-ab85197abd9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc7e2c3-6de6-453d-ade6-8571e7d53df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc7e2c3-6de6-453d-ade6-8571e7d53df3.jpg?1",
             "name": "Marked by Honor",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "3d72255f-0234-5950-9b4c-d62d5b52b611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a2d2f-ca94-463f-ada4-2b12bce6312f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/316a2d2f-ca94-463f-ada4-2b12bce6312f.jpg?1",
             "name": "Mass Calcify",
             "text": "Destroy all nonwhite creatures.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "7c9cee47-15d6-5d5d-86fd-8f6276984061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f5c19-9650-4fdc-a316-866eddd29c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31f5c19-9650-4fdc-a316-866eddd29c1a.jpg?1",
             "name": "Meditation Puzzle",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nYou gain 8 life.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "3b8199a2-3127-500f-91dd-8931ea32020a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b6390b-607b-4e10-946d-a4ac24908e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b6390b-607b-4e10-946d-a4ac24908e08.jpg?1",
             "name": "Midnight Guard",
             "text": "Whenever another creature enters the battlefield, untap Midnight Guard.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "f02671a6-fcd4-5384-83d2-6cde763f9e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53555768-edad-4441-b6a7-ea2a7cb38abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53555768-edad-4441-b6a7-ea2a7cb38abd.jpg?1",
             "name": "Oppressive Rays",
             "text": "Enchant creature\nEnchanted creature can't attack or block unless its controller pays {3}.\nActivated abilities of enchanted creature cost {3} more to activate.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "d2e29bf7-f0d7-51cd-93c4-eef194a2602a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32e198-8ddd-44bc-be57-17e1ff72d666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d32e198-8ddd-44bc-be57-17e1ff72d666.jpg?1",
             "name": "Oreskos Swiftclaw",
             "text": "",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "fa7554b7-9e57-533a-9976-85b82dcc0668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361c66c3-b4eb-48aa-a967-255a8db60977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361c66c3-b4eb-48aa-a967-255a8db60977.jpg?1",
             "name": "Paragon of New Dawns",
             "text": "Other white creatures you control get +1/+1.\n{W}, {T}: Another target white creature you control gains vigilance until end of turn. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -787,7 +787,7 @@
         },
         {
             "id": "f2e34f02-b6b2-515e-8da1-d1af853427be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ff99e-a23d-4440-8c5c-cfb4942f1906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ff99e-a23d-4440-8c5c-cfb4942f1906.jpg?1",
             "name": "Pillar of Light",
             "text": "Exile target creature with toughness 4 or greater.",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "2d6e2203-ecef-51c4-be99-66465c56ecee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32faaece-2775-4ab5-8376-d9f68959d5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32faaece-2775-4ab5-8376-d9f68959d5ac.jpg?1",
             "name": "Preeminent Captain",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nWhenever Preeminent Captain attacks, you may put a Soldier creature card from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -854,7 +854,7 @@
         },
         {
             "id": "f60c8c59-7e44-5731-8d31-1b2de65b1946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a74f052-05f7-4e5e-a765-7882a00d0f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a74f052-05f7-4e5e-a765-7882a00d0f6a.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "3564ac46-0eb9-5ee6-a84d-5aa28d8274e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d812f-4936-48e4-acbe-abccf9ab21c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662d812f-4936-48e4-acbe-abccf9ab21c7.jpg?1",
             "name": "Razorfoot Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "95528b92-9bba-5699-a6c7-2bd6017384db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37b31b8-d868-4dff-9ab0-723ce41ee7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37b31b8-d868-4dff-9ab0-723ce41ee7e4.jpg?1",
             "name": "Resolute Archangel",
             "text": "Flying\nWhen Resolute Archangel enters the battlefield, if your life total is less than your starting life total, it becomes equal to your starting life total.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "d4b527c1-6f8b-50be-958d-11ec329757fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fccce64-abac-4b90-bbe5-dbba8434b3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fccce64-abac-4b90-bbe5-dbba8434b3b4.jpg?1",
             "name": "Return to the Ranks",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nReturn X target creature cards with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "e25e0350-7698-59b4-8691-99200a0e6d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6481bf34-192c-4102-8336-4d2d007d9e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6481bf34-192c-4102-8336-4d2d007d9e3c.jpg?1",
             "name": "Sanctified Charge",
             "text": "Creatures you control get +2/+1 until end of turn. White creatures you control also gain first strike until end of turn. (They deal combat damage before creatures without first strike.)",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "b1f52059-3699-574b-9daf-a91e9570ff68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3366f6c3-3899-4585-b6d2-24406703cf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3366f6c3-3899-4585-b6d2-24406703cf34.jpg?1",
             "name": "Selfless Cathar",
             "text": "{1}{W}, Sacrifice Selfless Cathar: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "e5a08f16-525a-5084-9edc-9a232c7898e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c857a8-7df6-4a50-ae58-4aab76d7d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c857a8-7df6-4a50-ae58-4aab76d7d58c.jpg?1",
             "name": "Seraph of the Masses",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nSeraph of the Masses's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "b9510039-5d9e-5257-b4a6-4f04069b83d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d750b4-b58f-4465-8648-c86d678e0936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d750b4-b58f-4465-8648-c86d678e0936.jpg?1",
             "name": "Solemn Offering",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "3f31f6dc-9239-5369-bbd3-c79cde2034b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e391d3-cf19-4f73-9d39-22587e0f3c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e391d3-cf19-4f73-9d39-22587e0f3c0d.jpg?1",
             "name": "Soul of Theros",
             "text": "Vigilance\n{4}{W}{W}: Creatures you control get +2/+2 and gain first strike and lifelink until end of turn.\n{4}{W}{W}, Exile Soul of Theros from your graveyard: Creatures you control get +2/+2 and gain first strike and lifelink until end of turn.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "8a6c3ab9-af93-595b-bd90-a2a29eaccfea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a298e-0a41-487d-b629-aa89d25baad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a298e-0a41-487d-b629-aa89d25baad0.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "d888bf72-89d5-5743-a204-498e409299a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b7a2-a4ff-485c-9fe5-04c88e5e8886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b7a2-a4ff-485c-9fe5-04c88e5e8886.jpg?1",
             "name": "Spectra Ward",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has protection from all colors. This effect doesn't remove Auras. (It can't be blocked, targeted, or dealt damage by anything that's white, blue, black, red, or green.)",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "af42c649-173c-59db-8a23-f237282ea2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2a3aaa-e78a-48cc-b7d3-7f65e467054c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2a3aaa-e78a-48cc-b7d3-7f65e467054c.jpg?1",
             "name": "Spirit Bonds",
             "text": "Whenever a nontoken creature enters the battlefield under your control, you may pay {W}. If you do, put a 1/1 white Spirit creature token with flying onto the battlefield.\n{1}{W}, Sacrifice a Spirit: Target non-Spirit creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "77536ee6-2039-523a-a4f4-f4f631fbb70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d851b9-c290-4fcc-860d-a3250923b850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d851b9-c290-4fcc-860d-a3250923b850.jpg?1",
             "name": "Sungrace Pegasus",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "f10c15f3-189f-55fb-a36c-f871deeac9b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47b7386-168f-4b8e-9a26-9da6d697a501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47b7386-168f-4b8e-9a26-9da6d697a501.jpg?1",
             "name": "Tireless Missionaries",
             "text": "When Tireless Missionaries enters the battlefield, you gain 3 life.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "e1cd349e-bbe3-5c0d-afe7-3980c5f395bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6498d3-bf1f-4bf1-a602-7c21fb44c106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6498d3-bf1f-4bf1-a602-7c21fb44c106.jpg?1",
             "name": "Triplicate Spirits",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut three 1/1 white Spirit creature tokens with flying onto the battlefield. (They can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "e858e82d-2423-52b2-a94d-ef365bb23b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734e29ed-9732-4a94-909b-226bb4955930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734e29ed-9732-4a94-909b-226bb4955930.jpg?1",
             "name": "Wall of Essence",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Essence is dealt combat damage, you gain that much life.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "c0bccbb9-e1b3-5870-9f24-c62b0161d6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7406c-8c49-4ef6-a349-902833ea8ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a7406c-8c49-4ef6-a349-902833ea8ec5.jpg?1",
             "name": "Warden of the Beyond",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWarden of the Beyond gets +2/+2 as long as an opponent owns a card in exile.",
             "colours": [
@@ -1424,7 +1424,7 @@
         },
         {
             "id": "51c7f491-5d0d-5fbc-a798-6aa610b6f511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e145e85d-1eaa-4ec6-9208-ca6491577302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e145e85d-1eaa-4ec6-9208-ca6491577302.jpg?1",
             "name": "Aeronaut Tinkerer",
             "text": "Aeronaut Tinkerer has flying as long as you control an artifact. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -1459,7 +1459,7 @@
         },
         {
             "id": "f3a57e02-f18c-5080-b980-ce8b69398cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f1b48f-6528-46bd-a384-2358af25e500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f1b48f-6528-46bd-a384-2358af25e500.jpg?1",
             "name": "Aetherspouts",
             "text": "For each attacking creature, its owner puts it on the top or bottom of his or her library.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "f15f4769-06fb-5aca-893e-c1e59d89d222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafd2e27-01d0-4894-886e-2b8776904ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafd2e27-01d0-4894-886e-2b8776904ab9.jpg?1",
             "name": "Amphin Pathmage",
             "text": "{2}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "6ae90bd5-d43e-537f-9de9-e2390997c8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cf5b23-9427-4313-8af8-abf2f3800948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cf5b23-9427-4313-8af8-abf2f3800948.jpg?1",
             "name": "Chasm Skulker",
             "text": "Whenever you draw a card, put a +1/+1 counter on Chasm Skulker.\nWhen Chasm Skulker dies, put X 1/1 blue Squid creature tokens with islandwalk onto the battlefield, where X is the number of +1/+1 counters on Chasm Skulker. (They can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "db066f95-c051-5aab-aa2b-a07f63979832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483189ed-d3d9-4612-ab95-f4ae4e091238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483189ed-d3d9-4612-ab95-f4ae4e091238.jpg?1",
             "name": "Chief Engineer",
             "text": "Artifact spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting an artifact spell pays for {1} or one mana of that creature's color.)",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "520a5983-f2bf-5b11-8f30-cc0037ab71bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef107d-c19f-4af3-9236-c66123075b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef107d-c19f-4af3-9236-c66123075b41.jpg?1",
             "name": "Chronostutter",
             "text": "Put target creature into its owner's library second from the top.",
             "colours": [
@@ -1628,7 +1628,7 @@
         },
         {
             "id": "60206434-f0d3-50a1-a065-4be35ba216d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34cd305-d823-4996-9f8f-806386491f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34cd305-d823-4996-9f8f-806386491f5d.jpg?1",
             "name": "Coral Barrier",
             "text": "Defender (This creature can't attack.)\nWhen Coral Barrier enters the battlefield, put a 1/1 blue Squid creature token with islandwalk onto the battlefield. (It can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "1289f55c-a5d8-5a52-a299-5b26f55a3723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb110a55-c8f9-4627-82c2-edb10db4f380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb110a55-c8f9-4627-82c2-edb10db4f380.jpg?1",
             "name": "Diffusion Sliver",
             "text": "Whenever a Sliver creature you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {2}.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "fad5e848-1a7b-5b22-80cc-1496395cc950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcc571a-6d9c-4408-a352-ff96f9472b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcc571a-6d9c-4408-a352-ff96f9472b44.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "3366e96c-774d-5fe4-9dd4-a174232d3edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd1187d-f43f-4508-b312-7af0bb8b9789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd1187d-f43f-4508-b312-7af0bb8b9789.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "4db5276f-45c8-5812-be57-1fbd6ae52874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f531a657-9e60-453a-b72c-2ba04913698f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f531a657-9e60-453a-b72c-2ba04913698f.jpg?1",
             "name": "Encrust",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
             "colours": [
@@ -1794,7 +1794,7 @@
         },
         {
             "id": "1acbc7df-417e-50a7-aa20-a4a6c9cebd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8351efc5-a392-4ec8-877f-15d5b3dc0929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8351efc5-a392-4ec8-877f-15d5b3dc0929.jpg?1",
             "name": "Ensoul Artifact",
             "text": "Enchant artifact\nEnchanted artifact is a creature with base power and toughness 5/5 in addition to its other types.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "431cc542-a074-54a5-8c1d-7f51ffd49d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619268d2-f7a8-48cd-b17b-197e82474b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619268d2-f7a8-48cd-b17b-197e82474b13.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "106ba125-ccbe-5e5c-a0a2-726596c4da8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520ad9d0-5f41-4183-a04e-58a61ad7202b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520ad9d0-5f41-4183-a04e-58a61ad7202b.jpg?1",
             "name": "Fugitive Wizard",
             "text": "",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "24ca66fe-155e-5cd5-bfc4-c61821319d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf55bf-ee38-4e68-81ca-0fdb8af779ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bf55bf-ee38-4e68-81ca-0fdb8af779ef.jpg?1",
             "name": "Glacial Crasher",
             "text": "Trample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nGlacial Crasher can't attack unless there is a Mountain on the battlefield.",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "594f91ce-6f1e-593c-9db9-1c911b2e5905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd4dacb-912e-4e54-ab60-16a5262d0fbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd4dacb-912e-4e54-ab60-16a5262d0fbb.jpg?1",
             "name": "Hydrosurge",
             "text": "Target creature gets -5/-0 until end of turn.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "5e191f94-fa5c-5567-84d6-e514bf6d2d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58545789-0f48-46d9-9cbc-ec9a0065d2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58545789-0f48-46d9-9cbc-ec9a0065d2f8.jpg?1",
             "name": "Illusory Angel",
             "text": "Flying\nCast Illusory Angel only if you've cast another spell this turn.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "d91f6808-812d-5dd6-b96e-edececbe5985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7021c9f7-82f3-4470-aaa1-8fa25e207069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7021c9f7-82f3-4470-aaa1-8fa25e207069.jpg?1",
             "name": "Into the Void",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "642fae34-37de-5cdb-acb7-cb2146283fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348d6493-681a-4ea9-9154-ea09f2648e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348d6493-681a-4ea9-9154-ea09f2648e8a.jpg?1",
             "name": "Invisibility",
             "text": "Enchant creature\nEnchanted creature can't be blocked except by Walls.",
             "colours": [
@@ -2065,7 +2065,7 @@
         },
         {
             "id": "dd773d02-bbb9-513e-8c30-63e17f1de08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99713bb4-186f-42b6-aa66-e94ec8858e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99713bb4-186f-42b6-aa66-e94ec8858e6a.jpg?1",
             "name": "Jace, the Living Guildpact",
             "text": "+1: Look at the top two cards of your library. Put one of them into your graveyard.\n\u22123: Return another target nonland permanent to its owner's hand.\n\u22128: Each player shuffles his or her hand and graveyard into his or her library. You draw seven cards.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "d061027d-78e8-566a-ab88-4d71f46b18b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4932ba-e272-4f22-89f5-a6153ca570b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4932ba-e272-4f22-89f5-a6153ca570b5.jpg?1",
             "name": "Jace's Ingenuity",
             "text": "Draw three cards.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "27e420f2-8baf-57b6-86a5-8a6f498eb547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425da4aa-4374-41b0-a665-568a04f57c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425da4aa-4374-41b0-a665-568a04f57c38.jpg?1",
             "name": "Jalira, Master Polymorphist",
             "text": "{2}{U}, {T}, Sacrifice another creature: Reveal cards from the top of your library until you reveal a nonlegendary creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2170,7 +2170,7 @@
         },
         {
             "id": "b4ed4f59-0449-5733-a380-e884282017dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af346ac-32a6-49a8-986d-834b2c8c0478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af346ac-32a6-49a8-986d-834b2c8c0478.jpg?1",
             "name": "Jorubai Murk Lurker",
             "text": "Jorubai Murk Lurker gets +1/+1 as long as you control a Swamp.\n{1}{B}: Target creature gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "59593000-6afe-52a8-91ab-c95d9871bf2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a964c5ed-b0ed-47cb-a0f0-79d28ef7f70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a964c5ed-b0ed-47cb-a0f0-79d28ef7f70b.jpg?1",
             "name": "Kapsho Kitefins",
             "text": "Flying\nWhenever Kapsho Kitefins or another creature enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "fb173ffb-86bd-5ae0-b320-04f78bf9965d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b1720b-ab7a-4b52-a6d0-11c4fc573d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b1720b-ab7a-4b52-a6d0-11c4fc573d17.jpg?1",
             "name": "Master of Predicaments",
             "text": "Flying\nWhenever Master of Predicaments deals combat damage to a player, choose a card in your hand. That player guesses whether the card's converted mana cost is greater than 4. If the player guessed wrong, you may cast the card without paying its mana cost.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "c0360f65-eef9-5847-be34-a4e613086561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3160d28-230d-4bce-9050-6ab5895302ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3160d28-230d-4bce-9050-6ab5895302ee.jpg?1",
             "name": "Mercurial Pretender",
             "text": "You may have Mercurial Pretender enter the battlefield as a copy of any creature you control except it gains \"{2}{U}{U}: Return this creature to its owner's hand.\"",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "1b51f13b-4756-56d4-8e3d-45f96a52dc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10fafb6-3476-4cf1-a762-42fec628a579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10fafb6-3476-4cf1-a762-42fec628a579.jpg?1",
             "name": "Military Intelligence",
             "text": "Whenever you attack with two or more creatures, draw a card.",
             "colours": [
@@ -2339,7 +2339,7 @@
         },
         {
             "id": "729d307b-df81-58d0-b5ca-2af306526cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037d6277-1fc3-41a4-ade6-7cca10535b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037d6277-1fc3-41a4-ade6-7cca10535b0f.jpg?1",
             "name": "Mind Sculpt",
             "text": "Target opponent puts the top seven cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "abb6edfb-944a-5943-a018-f4a6e1ae78a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2ba6d-ada1-4f06-b135-37606b6588fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2ba6d-ada1-4f06-b135-37606b6588fc.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "ec9ed521-5658-5177-9d1d-e349b0273e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d239c66-3e3f-4dc4-bede-f264864583b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d239c66-3e3f-4dc4-bede-f264864583b1.jpg?1",
             "name": "Nimbus of the Isles",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "00ec9ff0-097b-5033-8c4f-527c8f73aacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afc32ed-c1a9-4c37-bfe0-562818c046fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afc32ed-c1a9-4c37-bfe0-562818c046fc.jpg?1",
             "name": "Paragon of Gathering Mists",
             "text": "Other blue creatures you control get +1/+1.\n{U}, {T}: Another target blue creature you control gains flying until end of turn.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "9bba4c6c-9acc-541d-b78e-6495db59967a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284cd35c-056f-45c2-822f-d50527f79625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284cd35c-056f-45c2-822f-d50527f79625.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "7deb4f3c-63e4-543f-874b-a3f773035fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83f369b-515a-43ba-8905-bc12e148beeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83f369b-515a-43ba-8905-bc12e148beeb.jpg?1",
             "name": "Polymorphist's Jest",
             "text": "Until end of turn, each creature target player controls loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "97cbce39-20d9-59c2-bdc7-abf88de72dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278fbdb9-51e3-4ed6-bcc5-c5b86f06c216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278fbdb9-51e3-4ed6-bcc5-c5b86f06c216.jpg?1",
             "name": "Quickling",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nWhen Quickling enters the battlefield, sacrifice it unless you return another creature you control to its owner's hand.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "f57c24a1-684f-5e3d-ab9f-5267cb7317fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac8a7c0-d935-4a60-ac32-dde73f5c75da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac8a7c0-d935-4a60-ac32-dde73f5c75da.jpg?1",
             "name": "Research Assistant",
             "text": "{3}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "74b1456f-bc46-59fa-ae7a-7bd6ebbf5fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7332471-c052-4a24-abf1-a5805d685658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7332471-c052-4a24-abf1-a5805d685658.jpg?1",
             "name": "Soul of Ravnica",
             "text": "Flying\n{5}{U}{U}: Draw a card for each color among permanents you control.\n{5}{U}{U}, Exile Soul of Ravnica from your graveyard: Draw a card for each color among permanents you control.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "3be527f3-df8c-5bfd-a091-a4dc0f37f848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13770d-dddb-4b78-9cd3-4a0dc50472f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af13770d-dddb-4b78-9cd3-4a0dc50472f4.jpg?1",
             "name": "Statute of Denial",
             "text": "Counter target spell. If you control a blue creature, draw a card, then discard a card.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "39c5eb98-1a63-5814-89e0-42ae4a5fc692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fde11c-ee26-4005-87f0-300f2be838fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fde11c-ee26-4005-87f0-300f2be838fc.jpg?1",
             "name": "Stormtide Leviathan",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\nAll lands are Islands in addition to their other types.\nCreatures without flying or islandwalk can't attack.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "685dfa07-71d0-5611-8af2-e57f8be55168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6867e6-1785-4eb2-bc7b-86bb671fae21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6867e6-1785-4eb2-bc7b-86bb671fae21.jpg?1",
             "name": "Turn to Frog",
             "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "d43e0721-1b97-5123-9956-ca5199213409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94efe426-0fb2-4a24-9b50-914e48105b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94efe426-0fb2-4a24-9b50-914e48105b57.jpg?1",
             "name": "Void Snare",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "3c13bfe9-16ab-5e0a-9f4b-ed6bd7aef9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a80677-0d0e-440f-a64f-10ebdb5014a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a80677-0d0e-440f-a64f-10ebdb5014a2.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender (This creature can't attack.)\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2804,7 +2804,7 @@
         },
         {
             "id": "cfe086f4-4380-5003-8b06-f436e909be11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea98c545-42d7-47f6-a155-4db092c178c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea98c545-42d7-47f6-a155-4db092c178c1.jpg?1",
             "name": "Welkin Tern",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWelkin Tern can block only creatures with flying.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "acde45b1-52e0-5cff-8273-a3a74fa169ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2513fe72-4e20-49e6-9970-839f1c635792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2513fe72-4e20-49e6-9970-839f1c635792.jpg?1",
             "name": "Accursed Spirit",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "28a34679-948a-5a07-9d0e-0bfc4fb230c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32efcfad-818c-4485-9022-cf94403f370b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32efcfad-818c-4485-9022-cf94403f370b.jpg?1",
             "name": "Black Cat",
             "text": "When Black Cat dies, target opponent discards a card at random.",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "84a658ac-ddeb-58c2-b2ad-379095245b4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454a83d-f018-446c-89fb-21460924e589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1454a83d-f018-446c-89fb-21460924e589.jpg?1",
             "name": "Blood Host",
             "text": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Blood Host and you gain 2 life.",
             "colours": [
@@ -2941,7 +2941,7 @@
         },
         {
             "id": "8adbd8d2-8671-5ec0-876f-4e38d19e3cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d80cc4-f3be-4306-8126-e60f7b00d384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d80cc4-f3be-4306-8126-e60f7b00d384.jpg?1",
             "name": "Carrion Crow",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nCarrion Crow enters the battlefield tapped.",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "043a5dbc-c7f3-5c24-b378-162b5aae9966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ddf81d-1746-41a7-951c-0bd68954505d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ddf81d-1746-41a7-951c-0bd68954505d.jpg?1",
             "name": "Caustic Tar",
             "text": "Enchant land\nEnchanted land has \"{T}: Target player loses 3 life.\"",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "59e48fc1-2269-5bae-ac88-8302dfa72525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff5d53c-5698-4d09-b557-89d10ce4fbbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff5d53c-5698-4d09-b557-89d10ce4fbbf.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "6980ca6d-b2a9-537f-922c-8441de6e7641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b7d05-19d7-4765-9bf8-05a7cb539c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b7d05-19d7-4765-9bf8-05a7cb539c3f.jpg?1",
             "name": "Covenant of Blood",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCovenant of Blood deals 4 damage to target creature or player and you gain 4 life.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "815f0247-c95a-57bc-9aba-bd5eea2779e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c1ba3-8b7c-413b-865d-0ca4b2f55903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c1ba3-8b7c-413b-865d-0ca4b2f55903.jpg?1",
             "name": "Crippling Blight",
             "text": "Enchant creature\nEnchanted creature gets -1/-1 and can't block.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "fbf77d69-5702-5755-a341-422a5ece50ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31c94f3-c45b-4ced-b523-15e80ae1a82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31c94f3-c45b-4ced-b523-15e80ae1a82d.jpg?1",
             "name": "Cruel Sadist",
             "text": "{B}, {T}, Pay 1 life: Put a +1/+1 counter on Cruel Sadist.\n{2}{B}, {T}, Remove X +1/+1 counters from Cruel Sadist: Cruel Sadist deals X damage to target creature.",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "5320338e-2c6d-546a-a68a-83c43967922e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70ceae6-8b25-4ce2-b89b-45300401fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70ceae6-8b25-4ce2-b89b-45300401fec5.jpg?1",
             "name": "Endless Obedience",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "8764d598-e63b-5bd0-abf0-ce0096e71163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9228ea53-4aea-45f5-bec5-4a0629ec8825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9228ea53-4aea-45f5-bec5-4a0629ec8825.jpg?1",
             "name": "Eternal Thirst",
             "text": "Enchant creature\nEnchanted creature has lifelink and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\" (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "bb9045ee-522d-565b-a087-1d0ab9a806b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96a9227-14ce-4d35-b5e6-0d0c657207c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96a9227-14ce-4d35-b5e6-0d0c657207c0.jpg?1",
             "name": "Feast on the Fallen",
             "text": "At the beginning of each upkeep, if an opponent lost life last turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "f6ef2f1e-0531-5b11-b714-ca48ee0a297e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3125137-bd18-488e-b45e-6fc23828c5bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3125137-bd18-488e-b45e-6fc23828c5bd.jpg?1",
             "name": "Festergloom",
             "text": "Nonblack creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "a1f54f0c-bcd6-5e14-a964-12099f284cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b2e842-6c92-47b0-bed4-e0e64485f168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b2e842-6c92-47b0-bed4-e0e64485f168.jpg?1",
             "name": "Flesh to Dust",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "b2bcc436-c93a-52cf-973d-8d08e7a59fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98951dea-df48-4f1b-a7cf-f14b2d36300f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98951dea-df48-4f1b-a7cf-f14b2d36300f.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "4b56094c-6ed4-5bb1-a5c2-f8e551bb3499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f2c2f6-d07f-42af-9944-70d3dac8348c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f2c2f6-d07f-42af-9944-70d3dac8348c.jpg?1",
             "name": "In Garruk's Wake",
             "text": "Destroy all creatures you don't control and all planeswalkers you don't control.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "7845e532-4f03-5f82-ac6b-d3452aeddd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4d8-6d18-4588-8da9-cd32658071f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4d8-6d18-4588-8da9-cd32658071f0.jpg?1",
             "name": "Indulgent Tormentor",
             "text": "Flying\nAt the beginning of your upkeep, draw a card unless target opponent sacrifices a creature or pays 3 life.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "8927b64c-0ef2-5118-884a-2cecb78345e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888ca52b-1270-4587-804d-1d08b07d7c5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888ca52b-1270-4587-804d-1d08b07d7c5d.jpg?1",
             "name": "Leeching Sliver",
             "text": "Whenever a Sliver you control attacks, defending player loses 1 life.",
             "colours": [
@@ -3441,7 +3441,7 @@
         },
         {
             "id": "fbec4c9b-c249-5e8a-b045-584315953101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6087f146-f468-472a-b248-fc7386ea3e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6087f146-f468-472a-b248-fc7386ea3e63.jpg?1",
             "name": "Liliana Vess",
             "text": "+1: Target player discards a card.\n\u22122: Search your library for a card, then shuffle your library and put that card on top of it.\n\u22128: Put all creature cards from all graveyards onto the battlefield under your control.",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "b872231f-b0ea-5f28-8cb0-637520b626e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718c56b8-b5e8-4c8a-a4a2-8c1c6d368d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718c56b8-b5e8-4c8a-a4a2-8c1c6d368d13.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "025e196f-f895-5aab-a338-c3ea3a26a2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c5bca1-b0f0-4032-b2ed-71bdbaa41993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c5bca1-b0f0-4032-b2ed-71bdbaa41993.jpg?1",
             "name": "Necrobite",
             "text": "Target creature gains deathtouch until end of turn. Regenerate it. (The next time that creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat. Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "0f7f1ded-12f8-5716-930f-88e07d9e7cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2045ddd-fa05-4769-aa7a-17b9ab8d6fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2045ddd-fa05-4769-aa7a-17b9ab8d6fc0.jpg?1",
             "name": "Necrogen Scudder",
             "text": "Flying\nWhen Necrogen Scudder enters the battlefield, you lose 3 life.",
             "colours": [
@@ -3576,7 +3576,7 @@
         },
         {
             "id": "dac7db24-3e93-551f-a9bf-c301bb00903b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6a8b3e-2709-4036-838b-56cc82b0d917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b6a8b3e-2709-4036-838b-56cc82b0d917.jpg?1",
             "name": "Necromancer's Assistant",
             "text": "When Necromancer's Assistant enters the battlefield, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "9d071b9b-a0c6-5f99-b2c8-20efe90bf6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba07e86-fdef-4f51-808e-7780883eefe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba07e86-fdef-4f51-808e-7780883eefe3.jpg?1",
             "name": "Necromancer's Stockpile",
             "text": "{1}{B}, Discard a creature card: Draw a card. If the discarded card was a Zombie card, put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "0f88b86c-d01a-524e-89c2-17c46fb5f6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11da48a7-903d-43f5-8085-1b3790ed079a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11da48a7-903d-43f5-8085-1b3790ed079a.jpg?1",
             "name": "Nightfire Giant",
             "text": "Nightfire Giant gets +1/+1 as long as you control a Mountain.\n{4}{R}: Nightfire Giant deals 2 damage to target creature or player.",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "14b20197-ca30-553c-8a17-600457115e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b28dc-c0d1-4b88-b18e-074ac0464e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b28dc-c0d1-4b88-b18e-074ac0464e03.jpg?1",
             "name": "Ob Nixilis, Unshackled",
             "text": "Flying, trample\nWhenever an opponent searches his or her library, that player sacrifices a creature and loses 10 life.\nWhenever another creature dies, put a +1/+1 counter on Ob Nixilis, Unshackled.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "301485d4-f07b-5d2a-b77d-55abe605e462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d7de75-b6e1-44f5-ae1c-e095b41e8d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d7de75-b6e1-44f5-ae1c-e095b41e8d0b.jpg?1",
             "name": "Paragon of Open Graves",
             "text": "Other black creatures you control get +1/+1.\n{2}{B}, {T}: Another target black creature you control gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "dce0ddaf-843a-5170-8b3a-147786d1a520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8e2442-0677-4ea6-8d70-4c39fbb552ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8e2442-0677-4ea6-8d70-4c39fbb552ed.jpg?1",
             "name": "Rotfeaster Maggot",
             "text": "When Rotfeaster Maggot enters the battlefield, exile target creature card from a graveyard. You gain life equal to that card's toughness.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "df962ee1-2a84-53c7-b293-38a98f2e86af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4911e9-01e6-4c41-9f2a-dfc25bedb2f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4911e9-01e6-4c41-9f2a-dfc25bedb2f7.jpg?1",
             "name": "Shadowcloak Vampire",
             "text": "Pay 2 life: Shadowcloak Vampire gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "59c6265e-f03c-5664-8d2b-2c9200b1981b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9cead6-7806-4c51-abd1-62c3b8f366b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9cead6-7806-4c51-abd1-62c3b8f366b5.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3849,7 +3849,7 @@
         },
         {
             "id": "b2911ae4-ce62-5a14-a963-b4e3cf66d5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9147b57e-e172-49ac-a556-91efbde0d325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9147b57e-e172-49ac-a556-91efbde0d325.jpg?1",
             "name": "Soul of Innistrad",
             "text": "Deathtouch\n{3}{B}{B}: Return up to three target creature cards from your graveyard to your hand.\n{3}{B}{B}, Exile Soul of Innistrad from your graveyard: Return up to three target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "20a3d5db-6d29-548c-90aa-fdab5e02cc52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c061b448-ee90-4c7d-a9c6-754a7c15966c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c061b448-ee90-4c7d-a9c6-754a7c15966c.jpg?1",
             "name": "Stab Wound",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 2 life.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "1ed57e7e-1462-5100-aade-e59e73ada56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d2b046-59bc-4e39-94ce-981179307bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d2b046-59bc-4e39-94ce-981179307bd3.jpg?1",
             "name": "Stain the Mind",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nName a nonland card. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "5f7d2f7d-a571-5bfd-9d52-46627b4c98d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8723f6-96b1-4441-8a57-435fb82d6db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8723f6-96b1-4441-8a57-435fb82d6db4.jpg?1",
             "name": "Typhoid Rats",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "6467a383-2ab0-5f68-908f-0f811176de13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06e6c8-05c0-4d87-9961-605b888bc794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06e6c8-05c0-4d87-9961-605b888bc794.jpg?1",
             "name": "Ulcerate",
             "text": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "4aa3bb35-2533-5214-865d-d09a310055ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fd00bb-b247-45b7-9cb2-0d65b92c0360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fd00bb-b247-45b7-9cb2-0d65b92c0360.jpg?1",
             "name": "Unmake the Graves",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -4047,7 +4047,7 @@
         },
         {
             "id": "5ca2bdd3-3f45-5036-8b56-b5f62bbbd26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d46b81-3131-4561-beca-ccf4a0973610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d46b81-3131-4561-beca-ccf4a0973610.jpg?1",
             "name": "Wall of Limbs",
             "text": "Defender (This creature can't attack.)\nWhenever you gain life, put a +1/+1 counter on Wall of Limbs.\n{5}{B}{B}, Sacrifice Wall of Limbs: Target player loses X life, where X is Wall of Limbs's power.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "03134532-9322-58a5-9c4e-91562775c412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d8f7d-3981-47c1-b7b8-748277fa452f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241d8f7d-3981-47c1-b7b8-748277fa452f.jpg?1",
             "name": "Waste Not",
             "text": "Whenever an opponent discards a creature card, put a 2/2 black Zombie creature token onto the battlefield.\nWhenever an opponent discards a land card, add {B}{B} to your mana pool.\nWhenever an opponent discards a noncreature, nonland card, draw a card.",
             "colours": [
@@ -4114,7 +4114,7 @@
         },
         {
             "id": "37df03cd-bd43-595c-8d88-b5bdf297c973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9f3b3b-de16-4ae5-844e-1373e0f84469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9f3b3b-de16-4ae5-844e-1373e0f84469.jpg?1",
             "name": "Witch's Familiar",
             "text": "",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "6695874d-d51a-55c4-860f-1d1fd89e8a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a9252-1e97-4e85-9648-66050f301f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a9252-1e97-4e85-9648-66050f301f8a.jpg?1",
             "name": "Xathrid Slyblade",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\n{3}{B}: Until end of turn, Xathrid Slyblade loses hexproof and gains first strike and deathtouch. (It deals combat damage before creatures without first strike. Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "dcac1eff-f85b-592b-81ed-2e180146038f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b39bdf-445c-40a8-8999-1e8fbbda4ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b39bdf-445c-40a8-8999-1e8fbbda4ae9.jpg?1",
             "name": "Zof Shade",
             "text": "{2}{B}: Zof Shade gets +2/+2 until end of turn.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "6e380915-268c-5c54-8cd5-51a2b4e4d6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe513d1-2509-4051-ba85-49a19479fa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe513d1-2509-4051-ba85-49a19479fa5c.jpg?1",
             "name": "Act on Impulse",
             "text": "Exile the top three cards of your library. Until end of turn, you may play cards exiled this way. (If you cast a spell this way, you still pay its costs. You can play a land this way only if you have an available land play remaining.)",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "a012db1a-4b0e-519b-9c94-0c3756127148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15a3f1a-83af-4541-8d1c-bf7844f969c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15a3f1a-83af-4541-8d1c-bf7844f969c9.jpg?1",
             "name": "Aggressive Mining",
             "text": "You can't play lands.\nSacrifice a land: Draw two cards. Activate this ability only once each turn.",
             "colours": [
@@ -4281,7 +4281,7 @@
         },
         {
             "id": "95d8e6cd-3869-58fd-9e7a-e6f0c178513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dacedc-f532-43b3-a783-e1dc7ccea53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5dacedc-f532-43b3-a783-e1dc7ccea53b.jpg?1",
             "name": "Altac Bloodseeker",
             "text": "Whenever a creature an opponent controls dies, Altac Bloodseeker gets +2/+0 and gains first strike and haste until end of turn. (It deals combat damage before creatures without first strike, and it can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "249428cf-5533-5ac7-bbbe-82b211d5801b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78b8268-b090-4012-a3ba-5daab491f78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78b8268-b090-4012-a3ba-5daab491f78d.jpg?1",
             "name": "Belligerent Sliver",
             "text": "Sliver creatures you control have \"This creature can't be blocked except by two or more creatures.\"",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "3c522c51-7989-54e2-9c79-5a969438dae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34774f01-5976-4ed1-b0f4-71dc7a679999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34774f01-5976-4ed1-b0f4-71dc7a679999.jpg?1",
             "name": "Blastfire Bolt",
             "text": "Blastfire Bolt deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "2535a39e-e60b-5f2b-8ea9-46c9257d4ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e29b2b-5fe3-4dee-b247-10cd139fe2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e29b2b-5fe3-4dee-b247-10cd139fe2d0.jpg?1",
             "name": "Borderland Marauder",
             "text": "Whenever Borderland Marauder attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "c72570e3-fb5d-5523-b62e-3d195ab7167a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a640a5b-c638-4ae6-ad02-eb5fe20f4662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a640a5b-c638-4ae6-ad02-eb5fe20f4662.jpg?1",
             "name": "Brood Keeper",
             "text": "Whenever an Aura becomes attached to Brood Keeper, put a 2/2 red Dragon creature token with flying onto the battlefield. It has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "c72858c9-61af-5485-870d-87f94e822b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058a7eb-0f78-46a4-bea5-afdfe920264f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058a7eb-0f78-46a4-bea5-afdfe920264f.jpg?1",
             "name": "Burning Anger",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to target creature or player.\"",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "5b9af6c1-4171-5068-9d30-50f0e0a56327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cc35d-4e97-4be2-8c53-cce68c3374ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92cc35d-4e97-4be2-8c53-cce68c3374ca.jpg?1",
             "name": "Chandra, Pyromaster",
             "text": "+1: Chandra, Pyromaster deals 1 damage to target player and 1 damage to up to one target creature that player controls. That creature can't block this turn.\n0: Exile the top card of your library. You may play it this turn.\n\u22127: Exile the top ten cards of your library. Choose an instant or sorcery card exiled this way and copy it three times. You may cast the copies without paying their mana costs.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "61d228aa-2646-5398-8bfa-77f0150b8aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cbfd4a-ac95-4191-84f9-199a9e1807c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cbfd4a-ac95-4191-84f9-199a9e1807c4.jpg?1",
             "name": "Circle of Flame",
             "text": "Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "e6028078-2a4e-5c25-b058-bca9ae7e5dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3738b0d1-06c0-4d6d-a307-478d994ff36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3738b0d1-06c0-4d6d-a307-478d994ff36e.jpg?1",
             "name": "Clear a Path",
             "text": "Destroy target creature with defender.",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "29034743-0bd3-51b7-af43-a39b57abfa46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2190a-5afd-4be1-810a-ac9a8178d629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a2190a-5afd-4be1-810a-ac9a8178d629.jpg?1",
             "name": "Cone of Flame",
             "text": "Cone of Flame deals 1 damage to target creature or player, 2 damage to another target creature or player, and 3 damage to a third target creature or player.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "1c0787f8-d526-5a42-8721-3eb25ef443bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536b8104-9d8d-444b-8535-62bcbe279de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536b8104-9d8d-444b-8535-62bcbe279de2.jpg?1",
             "name": "Crowd's Favor",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +1/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "b54dd950-f210-552c-84bc-d6f6c566b939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd0f742-5cdc-4fa9-b995-df6380c1755e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd0f742-5cdc-4fa9-b995-df6380c1755e.jpg?1",
             "name": "Crucible of Fire",
             "text": "Dragon creatures you control get +3/+3.",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "d16a2caf-6eea-53e2-a180-3212488b3edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbf66a4-8fd4-4c87-89e2-c6ad6c4de7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbf66a4-8fd4-4c87-89e2-c6ad6c4de7ab.jpg?1",
             "name": "Forge Devil",
             "text": "When Forge Devil enters the battlefield, it deals 1 damage to target creature and 1 damage to you.",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "39b4f1c1-4072-5676-a606-1d7b07e0c51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08835364-f82d-4047-8f35-bd8b64760dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08835364-f82d-4047-8f35-bd8b64760dfc.jpg?1",
             "name": "Foundry Street Denizen",
             "text": "Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "3f461d73-ce4a-5a1d-a39a-78417547a0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfe382-3a80-45f3-a022-54739c4b69a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfe382-3a80-45f3-a022-54739c4b69a6.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "6c190695-f971-55b8-8746-df3b0fe338cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0c422-4201-4d6f-9df7-659e8b78b541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0c422-4201-4d6f-9df7-659e8b78b541.jpg?1",
             "name": "Generator Servant",
             "text": "{T}, Sacrifice Generator Servant: Add {2} to your mana pool. If that mana is spent on a creature spell, it gains haste until end of turn. (That creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "8c8b051d-3483-5d71-b852-6692bb7711d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e1d85a-18e5-4c6a-85fd-a009bd8fda38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e1d85a-18e5-4c6a-85fd-a009bd8fda38.jpg?1",
             "name": "Goblin Kaboomist",
             "text": "At the beginning of your upkeep, put a colorless artifact token named Land Mine onto the battlefield with \"{R}, Sacrifice this artifact: This artifact deals 2 damage to target attacking creature without flying.\" Then flip a coin. If you lose the flip, Goblin Kaboomist deals 2 damage to itself.",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "cbe90bd0-ef73-5053-9e78-9b627416598c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9c697e-d2c0-413b-9142-ecf5d7cf5322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9c697e-d2c0-413b-9142-ecf5d7cf5322.jpg?1",
             "name": "Goblin Rabblemaster",
             "text": "Other Goblin creatures you control attack each turn if able.\nAt the beginning of combat on your turn, put a 1/1 red Goblin creature token with haste onto the battlefield.\nWhenever Goblin Rabblemaster attacks, it gets +1/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "de31a38e-fc01-5249-a598-e6ada7102c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9097ec4a-6c0e-4c27-8910-29ac47612031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9097ec4a-6c0e-4c27-8910-29ac47612031.jpg?1",
             "name": "Goblin Roughrider",
             "text": "",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "9c34e975-c1fc-503b-8559-a49d5ac7fdfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a81cc6-2660-4501-b589-f8c3a26ee483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a81cc6-2660-4501-b589-f8c3a26ee483.jpg?1",
             "name": "Hammerhand",
             "text": "Enchant creature\nWhen Hammerhand enters the battlefield, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste. (It can attack and {T} no matter when it came under your control.)",
             "colours": [
@@ -4959,7 +4959,7 @@
         },
         {
             "id": "8a039478-97f2-52e4-bd5c-050972358e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a79bcd-573c-4882-bfab-29eef00b07a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a79bcd-573c-4882-bfab-29eef00b07a4.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "ede78a9e-4746-5ca3-872f-c679be95d1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4c4a0f-0ee4-422d-b807-f64b77dd6831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4c4a0f-0ee4-422d-b807-f64b77dd6831.jpg?1",
             "name": "Hoarding Dragon",
             "text": "Flying\nWhen Hoarding Dragon enters the battlefield, you may search your library for an artifact card, exile it, then shuffle your library.\nWhen Hoarding Dragon dies, you may put the exiled card into its owner's hand.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "44ab2877-d92c-503c-b835-7d63d7020c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721a42f4-5884-418f-b1f9-7cb651559ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721a42f4-5884-418f-b1f9-7cb651559ad0.jpg?1",
             "name": "Inferno Fist",
             "text": "Enchant creature you control\nEnchanted creature gets +2/+0.\n{R}, Sacrifice Inferno Fist: Inferno Fist deals 2 damage to target creature or player.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "74318fce-59e2-5578-ab1d-0b201447d9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4189a909-2e20-4dc7-894c-21446da5b0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4189a909-2e20-4dc7-894c-21446da5b0cf.jpg?1",
             "name": "Kird Chieftain",
             "text": "Kird Chieftain gets +1/+1 as long as you control a Forest.\n{4}{G}: Target creature gets +2/+2 and gains trample until end of turn. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5094,7 +5094,7 @@
         },
         {
             "id": "5f4fc218-2ef5-5d01-bba6-2103583625a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ceeb0-03b6-48bc-a084-069176ebccb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ceeb0-03b6-48bc-a084-069176ebccb2.jpg?1",
             "name": "Krenko's Enforcer",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "98c4f2f6-9776-50cc-b09d-f682f9e703e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a0e9e-0e45-4af1-9f03-6fd3652933f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a0e9e-0e45-4af1-9f03-6fd3652933f9.jpg?1",
             "name": "Kurkesh, Onakke Ancient",
             "text": "Whenever you activate an ability of an artifact, if it isn't a mana ability, you may pay {R}. If you do, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -5166,7 +5166,7 @@
         },
         {
             "id": "862523ba-e2d2-5070-800d-51bd97af561c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b35586-e56d-4e7a-9a4e-8879529c082d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b35586-e56d-4e7a-9a4e-8879529c082d.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -5198,7 +5198,7 @@
         },
         {
             "id": "99b53baf-8c10-51f2-ba34-4140663e22ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5603e1f-593c-45f0-9e13-fe3492464443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5603e1f-593c-45f0-9e13-fe3492464443.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to target creature or player.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "e82b8837-40bb-5233-9261-c60a2a1fde88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c63c02-a75b-4880-b9fa-6f4bcf90ede5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c63c02-a75b-4880-b9fa-6f4bcf90ede5.jpg?1",
             "name": "Might Makes Right",
             "text": "At the beginning of combat on your turn, if you control each creature on the battlefield with the greatest power, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "3c18bb5d-48ec-518e-ab42-ef50e70bc5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d48ac-1685-4061-9907-31248ae38cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52d48ac-1685-4061-9907-31248ae38cc9.jpg?1",
             "name": "Miner's Bane",
             "text": "{2}{R}: Miner's Bane gets +1/+0 and gains trample until end of turn. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5296,7 +5296,7 @@
         },
         {
             "id": "80908ba2-9abc-5773-a7b1-1cd49b1ab414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad97067-2b6b-4e60-817c-6414e2739806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad97067-2b6b-4e60-817c-6414e2739806.jpg?1",
             "name": "Paragon of Fierce Defiance",
             "text": "Other red creatures you control get +1/+1.\n{R}, {T}: Another target red creature you control gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "031bc72b-dbaa-5456-9060-113c3639a559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8f65b-022f-4599-a416-e82a6d45ceba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8f65b-022f-4599-a416-e82a6d45ceba.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "f7abb4b4-7ceb-5158-8441-a2c190986f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00bd3a-833e-4226-a73e-17c9043c0994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00bd3a-833e-4226-a73e-17c9043c0994.jpg?1",
             "name": "Scrapyard Mongrel",
             "text": "As long as you control an artifact, Scrapyard Mongrel gets +2/+0 and has trample. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "a10010e0-ffbb-517f-b460-49a48851da55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0798cec-aaa3-4a52-99f8-d000ca7d59db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0798cec-aaa3-4a52-99f8-d000ca7d59db.jpg?1",
             "name": "Shrapnel Blast",
             "text": "As an additional cost to cast Shrapnel Blast, sacrifice an artifact.\nShrapnel Blast deals 5 damage to target creature or player.",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "1663c039-c872-5c55-b50c-a631af6c8447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc18f7-f4d4-421e-869e-c2e7598a9c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc18f7-f4d4-421e-869e-c2e7598a9c77.jpg?1",
             "name": "Siege Dragon",
             "text": "Flying\nWhen Siege Dragon enters the battlefield, destroy all Walls your opponents control.\nWhenever Siege Dragon attacks, if defending player controls no Walls, it deals 2 damage to each creature without flying that player controls.",
             "colours": [
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "023e35cd-d022-5d9b-81a6-dc8ae1879484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03543d10-202b-4b07-a34b-64216a745d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03543d10-202b-4b07-a34b-64216a745d84.jpg?1",
             "name": "Soul of Shandalar",
             "text": "First strike\n{3}{R}{R}: Soul of Shandalar deals 3 damage to target player and 3 damage to up to one target creature that player controls.\n{3}{R}{R}, Exile Soul of Shandalar from your graveyard: Soul of Shandalar deals 3 damage to target player and 3 damage to up to one target creature that player controls.",
             "colours": [
@@ -5500,7 +5500,7 @@
         },
         {
             "id": "230743a8-197f-55af-a7ab-5b192f731384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94c000-52e0-4215-83af-6351dc43e636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94c000-52e0-4215-83af-6351dc43e636.jpg?1",
             "name": "Stoke the Flames",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nStoke the Flames deals 4 damage to target creature or player.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "36d71457-4b27-5e2e-bc32-4fb083d83faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d3cde7-ac3f-4178-908f-0f51c4379b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d3cde7-ac3f-4178-908f-0f51c4379b44.jpg?1",
             "name": "Thundering Giant",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5566,7 +5566,7 @@
         },
         {
             "id": "d367d8db-fe95-56bb-acf9-73ace73c2ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea18c3f-0ca3-44ba-b8f5-87ce1797c58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea18c3f-0ca3-44ba-b8f5-87ce1797c58f.jpg?1",
             "name": "Torch Fiend",
             "text": "{R}, Sacrifice Torch Fiend: Destroy target artifact.",
             "colours": [
@@ -5600,7 +5600,7 @@
         },
         {
             "id": "533ee92e-e7fb-5bd2-9fdb-fc55bfd8d535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8ac968-3d00-40d8-80b5-e6fe08025de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8ac968-3d00-40d8-80b5-e6fe08025de2.jpg?1",
             "name": "Wall of Fire",
             "text": "Defender (This creature can't attack.)\n{R}: Wall of Fire gets +1/+0 until end of turn.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "493cbc3f-596b-5b16-af5f-4838e4fe48ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b24ea58-0690-45d7-a84b-265b6277b59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b24ea58-0690-45d7-a84b-265b6277b59a.jpg?1",
             "name": "Ancient Silverback",
             "text": "{G}: Regenerate Ancient Silverback. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "2c1fd672-4750-5d93-8802-366f0e4aa9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49270b2-ba15-4268-adb3-16d09c09adee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49270b2-ba15-4268-adb3-16d09c09adee.jpg?1",
             "name": "Back to Nature",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -5700,7 +5700,7 @@
         },
         {
             "id": "5f9bd31a-f7e8-57a0-9021-923bc9918e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd814ce3-9555-4e9d-a212-e40717f4e546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd814ce3-9555-4e9d-a212-e40717f4e546.jpg?1",
             "name": "Carnivorous Moss-Beast",
             "text": "{5}{G}{G}: Put a +1/+1 counter on Carnivorous Moss-Beast.",
             "colours": [
@@ -5736,7 +5736,7 @@
         },
         {
             "id": "158cc3f5-dcc4-5839-b5ab-95745b1a87a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90341fb4-ac97-43ff-ae2d-0fe5995e7fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90341fb4-ac97-43ff-ae2d-0fe5995e7fd7.jpg?1",
             "name": "Charging Rhino",
             "text": "Charging Rhino can't be blocked by more than one creature.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "724311e3-c71b-5a7e-99fd-c5a758d92991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7695cc-7b6b-499d-9f5a-729082fc72e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7695cc-7b6b-499d-9f5a-729082fc72e9.jpg?1",
             "name": "Chord of Calling",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5802,7 +5802,7 @@
         },
         {
             "id": "12164058-1c8d-5809-b3ec-ac7f5ee2ac2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5ca6a-f91d-443d-ad84-6fe1e80bfb51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb5ca6a-f91d-443d-ad84-6fe1e80bfb51.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "680a6374-4f12-5949-b00a-4fb66fa891a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0c7e7-81f5-4e75-8120-95488fd6ff60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0c7e7-81f5-4e75-8120-95488fd6ff60.jpg?1",
             "name": "Feral Incarnation",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut three 3/3 green Beast creature tokens onto the battlefield.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "2fe5e89c-edab-5529-baab-9a3c22cb28f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56b1112-ed25-46dd-85c8-58cc7a913198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56b1112-ed25-46dd-85c8-58cc7a913198.jpg?1",
             "name": "Gather Courage",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "dab6fc6a-0478-575e-859b-be424741b863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659eb716-bf21-4c0f-9a9a-906236ef536c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659eb716-bf21-4c0f-9a9a-906236ef536c.jpg?1",
             "name": "Genesis Hydra",
             "text": "When you cast Genesis Hydra, reveal the top X cards of your library. You may put a nonland permanent card with converted mana cost X or less from among them onto the battlefield. Then shuffle the rest into your library.\nGenesis Hydra enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "cd2951f3-6559-5221-bff8-14c506a3bf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4784dbd3-8ae0-45a0-8cde-908fba6af9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4784dbd3-8ae0-45a0-8cde-908fba6af9d2.jpg?1",
             "name": "Hornet Nest",
             "text": "Defender (This creature can't attack.)\nWhenever Hornet Nest is dealt damage, put that many 1/1 green Insect creature tokens with flying and deathtouch onto the battlefield. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "167c5417-720b-5d30-9c50-4247b44db8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494f761a-dbc4-4cfa-a258-e4de46bb825e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494f761a-dbc4-4cfa-a258-e4de46bb825e.jpg?1",
             "name": "Hornet Queen",
             "text": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen Hornet Queen enters the battlefield, put four 1/1 green Insect creature tokens with flying and deathtouch onto the battlefield.",
             "colours": [
@@ -6004,7 +6004,7 @@
         },
         {
             "id": "0e2f1527-403c-56be-8b66-dca3a53b4a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546686cb-4cb1-4107-bbf5-0af943236ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546686cb-4cb1-4107-bbf5-0af943236ad2.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "ba73d19f-5339-5761-b91e-da6eba9ca425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2971049-b916-4b76-b18f-8650d8d2545d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2971049-b916-4b76-b18f-8650d8d2545d.jpg?1",
             "name": "Hunter's Ambush",
             "text": "Prevent all combat damage that would be dealt by nongreen creatures this turn.",
             "colours": [
@@ -6068,7 +6068,7 @@
         },
         {
             "id": "1dfe8f9e-908a-59c7-b504-cdc8d71fcea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb5a98-94f4-419f-850b-e3a01f17080f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb5a98-94f4-419f-850b-e3a01f17080f.jpg?1",
             "name": "Invasive Species",
             "text": "When Invasive Species enters the battlefield, return another permanent you control to its owner's hand.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "4db72e2f-cb8d-5853-80d7-fe52b2a512f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabe0865-5420-463e-9138-ccd805be8b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabe0865-5420-463e-9138-ccd805be8b31.jpg?1",
             "name": "Kalonian Twingrove",
             "text": "Kalonian Twingrove's power and toughness are each equal to the number of Forests you control.\nWhen Kalonian Twingrove enters the battlefield, put a green Treefolk Warrior creature token onto the battlefield with \"This creature's power and toughness are each equal to the number of Forests you control.\"",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "2e2d46a8-b34c-5728-bdd0-3b5f472a143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d964629-6d1d-4253-ac23-92f2199323b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d964629-6d1d-4253-ac23-92f2199323b4.jpg?1",
             "name": "Life's Legacy",
             "text": "As an additional cost to cast Life's Legacy, sacrifice a creature.\nDraw cards equal to the sacrificed creature's power.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "b9e34285-6221-5869-b556-8ed5dcdf10a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca21890c-68be-4929-913e-d28ace6b40a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca21890c-68be-4929-913e-d28ace6b40a7.jpg?1",
             "name": "Living Totem",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Living Totem enters the battlefield, you may put a +1/+1 counter on another target creature.",
             "colours": [
@@ -6204,7 +6204,7 @@
         },
         {
             "id": "c82773e5-b3fe-5b3c-bc8c-75b5f3da0989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a232db-4ee3-4e9a-bd97-722106f7a7b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a232db-4ee3-4e9a-bd97-722106f7a7b6.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6236,7 +6236,7 @@
         },
         {
             "id": "c3e2aad5-9b48-5343-b497-07d87ec84d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8702c15-5f32-453e-8d58-cadfcdaeb3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8702c15-5f32-453e-8d58-cadfcdaeb3dc.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -6270,7 +6270,7 @@
         },
         {
             "id": "68449e8c-ed30-5fb9-a5ee-b002f1e0e2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb2476-488b-4610-8567-f0456601f7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07eb2476-488b-4610-8567-f0456601f7fd.jpg?1",
             "name": "Nissa, Worldwaker",
             "text": "+1: Target land you control becomes a 4/4 Elemental creature with trample. It's still a land.\n+1: Untap up to four target Forests.\n\u22127: Search your library for any number of basic land cards, put them onto the battlefield, then shuffle your library. Those lands become 4/4 Elemental creatures with trample. They're still lands.",
             "colours": [
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "69d2e990-ecac-56e7-92f2-cdfdb47b6c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c5cdd-9075-4bb7-88ae-9dc77a637700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6c5cdd-9075-4bb7-88ae-9dc77a637700.jpg?1",
             "name": "Nissa's Expedition",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nSearch your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6338,7 +6338,7 @@
         },
         {
             "id": "899c917b-96ce-569d-ae25-6bfcbd27085b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01702401-9dfe-4e52-9d6d-cf594261b009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01702401-9dfe-4e52-9d6d-cf594261b009.jpg?1",
             "name": "Overwhelm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -6370,7 +6370,7 @@
         },
         {
             "id": "cb563cb2-1732-52fa-b632-3d2431bf5fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c3fcca-480f-4acf-b74f-0f37b46fa799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c3fcca-480f-4acf-b74f-0f37b46fa799.jpg?1",
             "name": "Paragon of Eternal Wilds",
             "text": "Other green creatures you control get +1/+1.\n{G}, {T}: Another target green creature you control gains trample until end of turn. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "3245dbeb-5ca2-5df8-b6c0-4b47741e172d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e6eedf-8f5a-407e-b15b-48e19df20bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e6eedf-8f5a-407e-b15b-48e19df20bed.jpg?1",
             "name": "Phytotitan",
             "text": "When Phytotitan dies, return it to the battlefield tapped under its owner's control at the beginning of his or her next upkeep.",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "fd49a6df-b444-5439-8876-f97de55f695f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3de170-fdc5-4d46-9421-bb12460225ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3de170-fdc5-4d46-9421-bb12460225ca.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6472,7 +6472,7 @@
         },
         {
             "id": "c7292adc-6cc6-56d6-9167-79cd29948b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01388e24-d66f-40a8-af41-0f84dd8ed3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01388e24-d66f-40a8-af41-0f84dd8ed3fe.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "81d2cdc8-e64b-5536-b4bb-bd0d91ecda7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47227cfa-4cef-4874-b331-d2f628f29dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47227cfa-4cef-4874-b331-d2f628f29dae.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -6539,7 +6539,7 @@
         },
         {
             "id": "9fd0eced-8010-5b52-8e0c-5498dd2e8191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343994a6-b4f1-4ec5-997a-307b26601434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/343994a6-b4f1-4ec5-997a-307b26601434.jpg?1",
             "name": "Restock",
             "text": "Return two target cards from your graveyard to your hand. Exile Restock.",
             "colours": [
@@ -6571,7 +6571,7 @@
         },
         {
             "id": "9a605baf-511a-5b0c-abd9-e5d891b05250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f985df-177f-4535-b681-f9bc74045b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f985df-177f-4535-b681-f9bc74045b39.jpg?1",
             "name": "Roaring Primadox",
             "text": "At the beginning of your upkeep, return a creature you control to its owner's hand.",
             "colours": [
@@ -6605,7 +6605,7 @@
         },
         {
             "id": "5a2c9068-9342-503b-bae4-270e756e437b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995238-79cc-4381-9595-71ef11ea1e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1995238-79cc-4381-9595-71ef11ea1e36.jpg?1",
             "name": "Runeclaw Bear",
             "text": "",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "6cd8f499-0eaa-5f6c-8d6e-24648cab52b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be07e97-2ffc-40ad-a676-a74b8b680ea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be07e97-2ffc-40ad-a676-a74b8b680ea1.jpg?1",
             "name": "Satyr Wayfinder",
             "text": "When Satyr Wayfinder enters the battlefield, reveal the top four cards of your library. You may put a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6673,7 +6673,7 @@
         },
         {
             "id": "20fc62e0-c584-51a3-83f1-cdbc68799402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e974df6-d78a-43ea-ada5-17c53fcca97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e974df6-d78a-43ea-ada5-17c53fcca97b.jpg?1",
             "name": "Shaman of Spring",
             "text": "When Shaman of Spring enters the battlefield, draw a card.",
             "colours": [
@@ -6708,7 +6708,7 @@
         },
         {
             "id": "359aaa6d-2b67-5bb4-937e-93a683bb4ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40b8f1-428a-4244-ad8a-4e757aea2b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40b8f1-428a-4244-ad8a-4e757aea2b45.jpg?1",
             "name": "Siege Wurm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "1f2108c6-2c99-573d-b254-2b0a5ac90fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a2514-3c36-463a-bc0a-67ab4fb2666e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875a2514-3c36-463a-bc0a-67ab4fb2666e.jpg?1",
             "name": "Soul of Zendikar",
             "text": "Reach\n{3}{G}{G}: Put a 3/3 green Beast creature token onto the battlefield.\n{3}{G}{G}, Exile Soul of Zendikar from your graveyard: Put a 3/3 green Beast creature token onto the battlefield.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "7da5e8a6-1cd0-5077-b8f2-1c0a949fa585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9925c5-98d5-4eb9-8aaa-a96b63a5812d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9925c5-98d5-4eb9-8aaa-a96b63a5812d.jpg?1",
             "name": "Sunblade Elf",
             "text": "Sunblade Elf gets +1/+1 as long as you control a Plains.\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6812,7 +6812,7 @@
         },
         {
             "id": "4fa71fe1-6fa6-56b7-b145-3500648242b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e511b7-6d41-4aa2-b7bd-d4d6e075a819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e511b7-6d41-4aa2-b7bd-d4d6e075a819.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6844,7 +6844,7 @@
         },
         {
             "id": "6689b3f5-7cc4-532d-811d-4d5ddbb8d648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc77e-f003-4c25-8394-cda22e3ea039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc77e-f003-4c25-8394-cda22e3ea039.jpg?1",
             "name": "Undergrowth Scavenger",
             "text": "Undergrowth Scavenger enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "c6d148a0-4884-516a-a29c-784c9cc41728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db38bd9-bf58-41ca-84b9-f3582670143e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db38bd9-bf58-41ca-84b9-f3582670143e.jpg?1",
             "name": "Venom Sliver",
             "text": "Sliver creatures you control have deathtouch. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "7ed7148e-a2b6-511e-a159-c6c895e42f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec869b-fe2c-4f30-ae36-9ce5bdc555e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beec869b-fe2c-4f30-ae36-9ce5bdc555e1.jpg?1",
             "name": "Verdant Haven",
             "text": "Enchant land\nWhen Verdant Haven enters the battlefield, you gain 2 life.\nWhenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).",
             "colours": [
@@ -6947,7 +6947,7 @@
         },
         {
             "id": "f3a258bd-be66-521a-8840-5cdbe6328a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578f064-e9f8-4e87-8f46-7536af6c144e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4578f064-e9f8-4e87-8f46-7536af6c144e.jpg?1",
             "name": "Vineweft",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\n{4}{G}: Return Vineweft from your graveyard to your hand.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "77047ddb-d497-5829-85eb-a57bd5a5d096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ec859-59a6-45b2-bbd8-6f89453fe3ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ec859-59a6-45b2-bbd8-6f89453fe3ec.jpg?1",
             "name": "Wall of Mulch",
             "text": "Defender (This creature can't attack.)\n{G}, Sacrifice a Wall: Draw a card.",
             "colours": [
@@ -7015,7 +7015,7 @@
         },
         {
             "id": "ddd53358-202f-5f4a-8c98-615b9baca9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cd97cd-6d6e-4512-a050-6851b7527567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65cd97cd-6d6e-4512-a050-6851b7527567.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "{2}{G}, {T}, Put a verse counter on Yisan, the Wanderer Bard: Search your library for a creature card with converted mana cost equal to the number of verse counters on Yisan, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "b1d509b5-cff4-5370-a31e-b89316a0bf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3957b43-4d7e-41f9-b7a1-6f57d6603ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3957b43-4d7e-41f9-b7a1-6f57d6603ab8.jpg?1",
             "name": "Garruk, Apex Predator",
             "text": "+1: Destroy another target planeswalker.\n+1: Put a 3/3 black Beast creature token with deathtouch onto the battlefield.\n\u22123: Destroy target creature. You gain life equal to its toughness.\n\u22128: Target opponent gets an emblem with \"Whenever a creature attacks you, it gets +5/+5 and gains trample until end of turn.\"",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "46d18321-fa23-5a87-89fe-e26080efbb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4106de-20c7-48cf-8a36-8c6913b46c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4106de-20c7-48cf-8a36-8c6913b46c89.jpg?1",
             "name": "Sliver Hivelord",
             "text": "Sliver creatures you control have indestructible. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "0db612cb-8e95-5fca-ba12-d488ac193f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec56727f-6280-4625-96b9-9b599af0dada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec56727f-6280-4625-96b9-9b599af0dada.jpg?1",
             "name": "Avarice Amulet",
             "text": "Equipped creature gets +2/+0 and has vigilance and \"At the beginning of your upkeep, draw a card.\"\nWhen equipped creature dies, target opponent gains control of Avarice Amulet.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "725f6e58-5590-52ed-9e29-0f97f4c4faa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eddc4ee6-7855-4dc7-9488-5e019609bd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eddc4ee6-7855-4dc7-9488-5e019609bd09.jpg?1",
             "name": "Brawler's Plate",
             "text": "Equipped creature gets +2/+2 and has trample. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "366a86c6-ffd9-5209-bf54-cfe94b435e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ba6d7d-fad0-4af1-be12-44be326a031e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ba6d7d-fad0-4af1-be12-44be326a031e.jpg?1",
             "name": "Bronze Sable",
             "text": "",
             "colours": [],
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "cdca5406-72b1-534d-b2d7-d8ce3e1ff54b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415cc0e-979e-42cc-a56d-88d13153a7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0415cc0e-979e-42cc-a56d-88d13153a7de.jpg?1",
             "name": "The Chain Veil",
             "text": "At the beginning of your end step, if you didn't activate a loyalty ability of a planeswalker this turn, you lose 2 life.\n{4}, {T}: For each planeswalker you control, you may activate one of its loyalty abilities once this turn as though none of its loyalty abilities have been activated this turn.",
             "colours": [],
@@ -7256,7 +7256,7 @@
         },
         {
             "id": "b8829628-1444-50ae-8693-dd6b801ad847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38e70c-51ca-419a-b99d-a603a7f39290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f38e70c-51ca-419a-b99d-a603a7f39290.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender (This creature can't attack.)\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "65569aa2-507f-5e23-b610-ec4879a48c8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53498863-2e69-4b98-b0f0-7ae13dc1033e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53498863-2e69-4b98-b0f0-7ae13dc1033e.jpg?1",
             "name": "Grindclock",
             "text": "{T}: Put a charge counter on Grindclock.\n{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of charge counters on Grindclock.",
             "colours": [],
@@ -7315,7 +7315,7 @@
         },
         {
             "id": "0a589878-8ba9-5e86-9c87-4c6bcbd66569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7daae6f-fe19-4f42-b85d-75c996abe1be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7daae6f-fe19-4f42-b85d-75c996abe1be.jpg?1",
             "name": "Haunted Plate Mail",
             "text": "Equipped creature gets +4/+4.\n{0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate this ability only if you control no creatures.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "6d81c679-6106-5884-ace3-c24256a76606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46f4b0-1992-4060-8f21-643698d476f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46f4b0-1992-4060-8f21-643698d476f7.jpg?1",
             "name": "Hot Soup",
             "text": "Equipped creature can't be blocked.\nWhenever equipped creature is dealt damage, destroy it.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "3f71e2c9-d152-5a2a-af41-8a43c9f84743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc014e5-21a3-4023-a8ed-61329a96fb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc014e5-21a3-4023-a8ed-61329a96fb4e.jpg?1",
             "name": "Juggernaut",
             "text": "Juggernaut attacks each turn if able.\nJuggernaut can't be blocked by Walls.",
             "colours": [],
@@ -7406,7 +7406,7 @@
         },
         {
             "id": "bf3e622a-f8b5-510e-a6b5-69f7ab375cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a39c1a-7615-4ac8-8984-b8459d201cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a39c1a-7615-4ac8-8984-b8459d201cb2.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to target creature or player.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7434,7 +7434,7 @@
         },
         {
             "id": "d7013de2-d4fc-5d1d-80f7-55044df6e1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7865a7-8fe2-4b5d-a625-91585d1b7d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed7865a7-8fe2-4b5d-a625-91585d1b7d4a.jpg?1",
             "name": "Obelisk of Urd",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nAs Obelisk of Urd enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +2/+2.",
             "colours": [],
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "50c7953f-b0ef-5332-b8e7-9487f62494cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee98e86c-ac16-4159-8982-ed14d282811a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee98e86c-ac16-4159-8982-ed14d282811a.jpg?1",
             "name": "Ornithopter",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [],
@@ -7493,7 +7493,7 @@
         },
         {
             "id": "d2e911e5-ab9e-533b-84d5-95ed33d1c3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5f1810-a852-454f-b1d6-eb40ea4e0148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5f1810-a852-454f-b1d6-eb40ea4e0148.jpg?1",
             "name": "Perilous Vault",
             "text": "{5}, {T}, Exile Perilous Vault: Exile all nonland permanents.",
             "colours": [],
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "812d0333-8337-58f0-8e94-b520bde882ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ede7b6-ee03-4b4f-bc59-1759b02bd5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ede7b6-ee03-4b4f-bc59-1759b02bd5d5.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, name a nonland card.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -7553,7 +7553,7 @@
         },
         {
             "id": "d6ce54da-63aa-5581-813b-d1196e1a0bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c97632-3cf1-4b79-9d18-d8991654dcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c97632-3cf1-4b79-9d18-d8991654dcca.jpg?1",
             "name": "Profane Memento",
             "text": "Whenever a creature card is put into an opponent's graveyard from anywhere, you gain 1 life.",
             "colours": [],
@@ -7581,7 +7581,7 @@
         },
         {
             "id": "2c824aac-2cb4-5e31-a0b4-429fc33bfbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a35bd7-8f0f-421a-948d-810513e6b0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a35bd7-8f0f-421a-948d-810513e6b0a0.jpg?1",
             "name": "Rogue's Gloves",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7611,7 +7611,7 @@
         },
         {
             "id": "ed8f5aa5-ff54-50e4-a232-d45a9bdb1056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05fde97-ab24-40c9-a1db-8844c3e62fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05fde97-ab24-40c9-a1db-8844c3e62fc3.jpg?1",
             "name": "Sacred Armory",
             "text": "{2}: Target creature gets +1/+0 until end of turn.",
             "colours": [],
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "45bafed8-11ba-52df-8dec-3619846349b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6352ded6-14f5-47d6-b1cb-518f270e44e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6352ded6-14f5-47d6-b1cb-518f270e44e7.jpg?1",
             "name": "Scuttling Doom Engine",
             "text": "Scuttling Doom Engine can't be blocked by creatures with power 2 or less.\nWhen Scuttling Doom Engine dies, it deals 6 damage to target opponent.",
             "colours": [],
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "daf7b749-0ae4-51a9-b79d-029674c5221a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c2cc25-f3cd-4bfb-b9cc-53d1f42cd69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c2cc25-f3cd-4bfb-b9cc-53d1f42cd69a.jpg?1",
             "name": "Shield of the Avatar",
             "text": "If a source would deal damage to equipped creature, prevent X of that damage, where X is the number of creatures you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "f987df06-ee90-51dc-a6f6-2a642928f886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d37dec-98d6-4815-8f3e-7de26817990c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d37dec-98d6-4815-8f3e-7de26817990c.jpg?1",
             "name": "Soul of New Phyrexia",
             "text": "Trample\n{5}: Permanents you control gain indestructible until end of turn.\n{5}, Exile Soul of New Phyrexia from your graveyard: Permanents you control gain indestructible until end of turn.",
             "colours": [],
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "a2b01e8d-2406-560e-8719-b066b0724486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a341a4-8177-41cd-a3bc-eff5dee48c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a341a4-8177-41cd-a3bc-eff5dee48c94.jpg?1",
             "name": "Staff of the Death Magus",
             "text": "Whenever you cast a black spell or a Swamp enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7760,7 +7760,7 @@
         },
         {
             "id": "15e2730f-01da-5b94-9e6e-6cce5caf5e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd137db-296a-4c17-ba46-8b189d96c1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd137db-296a-4c17-ba46-8b189d96c1f9.jpg?1",
             "name": "Staff of the Flame Magus",
             "text": "Whenever you cast a red spell or a Mountain enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "378fc5f3-6d35-5a4c-89ce-7a697c68a171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf76bee3-2b69-4c7b-9b7c-1a9f4bbcfde0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf76bee3-2b69-4c7b-9b7c-1a9f4bbcfde0.jpg?1",
             "name": "Staff of the Mind Magus",
             "text": "Whenever you cast a blue spell or an Island enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "2f5a6c70-e2af-5e93-89d1-8ad7777701f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f51ff4-9b5c-4e26-b811-4000a4c8f965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f51ff4-9b5c-4e26-b811-4000a4c8f965.jpg?1",
             "name": "Staff of the Sun Magus",
             "text": "Whenever you cast a white spell or a Plains enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7844,7 +7844,7 @@
         },
         {
             "id": "40d50087-00eb-5a11-a908-e767f39e6c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64f31e8-0b49-4510-a4df-2e0bea793d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64f31e8-0b49-4510-a4df-2e0bea793d3e.jpg?1",
             "name": "Staff of the Wild Magus",
             "text": "Whenever you cast a green spell or a Forest enters the battlefield under your control, you gain 1 life.",
             "colours": [],
@@ -7872,7 +7872,7 @@
         },
         {
             "id": "d9a15df0-88c4-583e-b7a9-df64b41fd413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314bb937-1b1e-4daa-8b9e-2d282e8f433b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314bb937-1b1e-4daa-8b9e-2d282e8f433b.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "86053aa6-7671-5e99-b9dd-5c2df302fe61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088045cd-8aec-43ff-bb8f-d17927b79cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088045cd-8aec-43ff-bb8f-d17927b79cfb.jpg?1",
             "name": "Tyrant's Machine",
             "text": "{4}, {T}: Tap target creature.",
             "colours": [],
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "9e4a1b6d-9248-535b-a919-b48d377feeb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0175bafa-dc9f-464c-8f9e-dd4131732652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0175bafa-dc9f-464c-8f9e-dd4131732652.jpg?1",
             "name": "Will-Forged Golem",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "9494d613-3a08-5c18-8b88-10f881bf0d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc57d63-5a6d-4ff2-8079-544b2c4eade1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc57d63-5a6d-4ff2-8079-544b2c4eade1.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "9b17dbac-ab14-5a87-8858-1c7b430bcaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ad0c9-77a7-4d18-9707-1e5e3d4cf7e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ad0c9-77a7-4d18-9707-1e5e3d4cf7e8.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "1a63188f-f604-59e3-991d-b463ab186c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad4395-5766-44c3-b5af-3d65d49a3333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ad4395-5766-44c3-b5af-3d65d49a3333.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this land.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "947c738b-c813-51ff-badf-f3bfcee95dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2553b8ae-e5af-40ba-8b3b-d5652919c9bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2553b8ae-e5af-40ba-8b3b-d5652919c9bb.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8078,7 +8078,7 @@
         },
         {
             "id": "b6ae79c0-f142-58ed-9786-26958a1f42bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75b4559-8946-45bb-a580-318a13d1e89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75b4559-8946-45bb-a580-318a13d1e89e.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -8109,7 +8109,7 @@
         },
         {
             "id": "38f1cf4a-a253-55ac-8371-f5ee49fb2dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8090e148-2550-4156-89e3-052abda9f0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8090e148-2550-4156-89e3-052abda9f0e7.jpg?1",
             "name": "Radiant Fountain",
             "text": "When Radiant Fountain enters the battlefield, you gain 2 life.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -8137,7 +8137,7 @@
         },
         {
             "id": "7a499f0d-8def-5ff4-98cf-68afb3c6f019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07ded43-682b-417e-bcb4-0ef5186fd9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07ded43-682b-417e-bcb4-0ef5186fd9ad.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "ea931a9f-0967-5e98-ba61-da2d712fbfdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cef7ce-aa9f-4659-ac24-394c5ab9f77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cef7ce-aa9f-4659-ac24-394c5ab9f77c.jpg?1",
             "name": "Sliver Hive",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a Sliver spell.\n{5}, {T}: Put a 1/1 colorless Sliver creature token onto the battlefield. Activate this ability only if you control a Sliver.",
             "colours": [],
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "f84c5cd7-7c32-5033-b504-63b71fcb1503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa48b15c-7312-4f3f-b7aa-b2ad98234bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa48b15c-7312-4f3f-b7aa-b2ad98234bf1.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "2a3f20cd-bb50-563b-b1a8-c0ef7aa493d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb82b9a-0376-4d75-ba03-76b422aa9099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb82b9a-0376-4d75-ba03-76b422aa9099.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -8257,7 +8257,7 @@
         },
         {
             "id": "ed18787d-3787-57fd-b94b-cb67bd0ffb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e211fe-e843-4d05-a97d-b208b616179a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e211fe-e843-4d05-a97d-b208b616179a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "68b8b068-627a-50fe-83a4-4ce73ffd39b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe68013-a519-4dce-a28b-c6304dba8fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe68013-a519-4dce-a28b-c6304dba8fac.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "bacc7ee0-2dfd-5e8a-ba58-2b9c03b60968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1358ef70-1dae-4bb6-a2e2-88ff30d43b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1358ef70-1dae-4bb6-a2e2-88ff30d43b99.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "67e395eb-4512-57b8-896c-f6f5a3a12fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c9899-65c2-4f1b-8716-ab144766b385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514c9899-65c2-4f1b-8716-ab144766b385.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "e13a9a69-1e87-58df-b080-857af126541f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9f55eb-2c9e-4bc7-a67c-ab2eeb127201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9f55eb-2c9e-4bc7-a67c-ab2eeb127201.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "44bdd4e9-c0ea-5052-8b3f-92d9a6ef4cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ffcc0-ca8a-43ad-8e9e-31e5b94dd6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9ffcc0-ca8a-43ad-8e9e-31e5b94dd6e6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8485,7 +8485,7 @@
         },
         {
             "id": "799e2180-2c02-5a81-b731-75c301488e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d4230f-f024-4e5e-9054-0d32dace05cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d4230f-f024-4e5e-9054-0d32dace05cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "7fa850fe-7a80-5161-9c34-9729660c360c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a880c1ee-01e0-479f-a1c3-2739da8ac6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a880c1ee-01e0-479f-a1c3-2739da8ac6b9.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "19e3d2ff-c9f4-5152-849c-1518ace33dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719b570c-1773-4a0c-8ea3-e75b1c14c35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719b570c-1773-4a0c-8ea3-e75b1c14c35f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8599,7 +8599,7 @@
         },
         {
             "id": "48d98898-d237-5bf1-b93c-706d21638ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148e45-3163-4cf3-a729-600729f671a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148e45-3163-4cf3-a729-600729f671a5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8637,7 +8637,7 @@
         },
         {
             "id": "d0a4d56a-8848-548a-b235-4e34cb50e13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e7a70-672e-400d-971b-63dd128f5229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0e7a70-672e-400d-971b-63dd128f5229.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8675,7 +8675,7 @@
         },
         {
             "id": "40560c20-55e5-592f-85e5-6a8796ad1620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d11a38-3b0e-44d4-bf7d-28bed6303693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d11a38-3b0e-44d4-bf7d-28bed6303693.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8713,7 +8713,7 @@
         },
         {
             "id": "90704df5-237d-5b10-8c84-71d40b496f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa712fb1-8840-4e26-9211-2653919fed91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa712fb1-8840-4e26-9211-2653919fed91.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8751,7 +8751,7 @@
         },
         {
             "id": "0647ab41-7046-5e6d-9f87-30434c0a2c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5960dfdf-cba1-47d4-8e7c-f87f814b07ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5960dfdf-cba1-47d4-8e7c-f87f814b07ed.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8789,7 +8789,7 @@
         },
         {
             "id": "8213db54-e2aa-5781-8097-114cfbb515bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23596e2-72ea-478d-baa8-3df0e81b4cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23596e2-72ea-478d-baa8-3df0e81b4cdd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8827,7 +8827,7 @@
         },
         {
             "id": "fdb41e14-580f-54fe-a394-1b2ae73488f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc281cb-a583-45a7-85d1-c10d5900b966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc281cb-a583-45a7-85d1-c10d5900b966.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8865,7 +8865,7 @@
         },
         {
             "id": "4cf609ef-ab9b-5640-89dc-76cfc72c961f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d6124-1678-46b1-a12a-69644c689e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283d6124-1678-46b1-a12a-69644c689e29.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "671b1dfe-a9d8-5664-aab7-4420282c53e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ecd546-2638-4338-86b5-59ab3f1303a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ecd546-2638-4338-86b5-59ab3f1303a3.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8941,7 +8941,7 @@
         },
         {
             "id": "54ab0c57-87f9-52c0-a1f2-09d1402e67ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb07e09-bff6-45fd-b408-fd957f69a994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb07e09-bff6-45fd-b408-fd957f69a994.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "690ffb60-16a4-56fa-b8dd-fcd6ad1472c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ff824-f9a6-457a-b1ff-c06b246d06d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ff824-f9a6-457a-b1ff-c06b246d06d9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "d82efc36-676c-58cf-9b3a-816c7dfbcb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ae5f07-c869-49cf-b7c3-fe607ad3ee35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ae5f07-c869-49cf-b7c3-fe607ad3ee35.jpg?1",
             "name": "Aegis Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aegis Angel enters the battlefield, another target permanent gains indestructible for as long as you control Aegis Angel. (Effects that say \"destroy\" don't destroy it. A creature with indestructible can't be destroyed by damage.)",
             "colours": [
@@ -9050,7 +9050,7 @@
         },
         {
             "id": "6cff899f-86ac-590f-a093-7e1ea22100e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529d320-1240-429f-bf7a-4be29079b8bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1529d320-1240-429f-bf7a-4be29079b8bf.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -9081,7 +9081,7 @@
         },
         {
             "id": "91389a02-1e95-5a1f-b9f6-68cbd22851ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28c4e2-7b9b-436d-95cf-9c757eacf091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a28c4e2-7b9b-436d-95cf-9c757eacf091.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -9112,7 +9112,7 @@
         },
         {
             "id": "5fab3acd-e8d7-5040-8494-90ef9a0d2b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2d063-a9b1-4693-9841-923210bf09d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2d063-a9b1-4693-9841-923210bf09d7.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9145,7 +9145,7 @@
         },
         {
             "id": "a5f66571-2b8d-5b2b-9ffa-05fc00f13656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bf9f71-c592-4064-b7b3-172c26e5605b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bf9f71-c592-4064-b7b3-172c26e5605b.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -9176,7 +9176,7 @@
         },
         {
             "id": "866f6531-70d7-5f47-8aac-bdd0b4829a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d241c7-d753-411e-9456-667fb015ee28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d241c7-d753-411e-9456-667fb015ee28.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9209,7 +9209,7 @@
         },
         {
             "id": "d8f5344a-adce-5f8d-85bc-c2605a17b661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04970ef-7aa5-42ca-9bed-5c89d55b7e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04970ef-7aa5-42ca-9bed-5c89d55b7e4d.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "2e9e9ced-487f-5d75-b95e-113c5c3fa00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28be-091d-47f9-b41e-8926cd182a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28be-091d-47f9-b41e-8926cd182a63.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -9276,7 +9276,7 @@
         },
         {
             "id": "d785e0bf-0a0c-5082-bac0-f0fbfb33a3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccba369f-f4d1-493d-bc5f-271b7e4d8090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccba369f-f4d1-493d-bc5f-271b7e4d8090.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -9309,7 +9309,7 @@
         },
         {
             "id": "edef2772-796e-5e26-84ef-4aa9720e9530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44f74e9-aaa6-41d3-8070-bf0ead4a7d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44f74e9-aaa6-41d3-8070-bf0ead4a7d77.jpg?1",
             "name": "Furnace Whelp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Furnace Whelp gets +1/+0 until end of turn.",
             "colours": [
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "65c48806-83ee-5479-8096-2875dc3fa207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972d0b03-8602-4ada-86b9-4262941bae67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972d0b03-8602-4ada-86b9-4262941bae67.jpg?1",
             "name": "Seismic Strike",
             "text": "Seismic Strike deals damage to target creature equal to the number of Mountains you control.",
             "colours": [
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "376873b0-c22c-53f0-b355-3c14945b18ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c76430-c5c9-46a4-9a3b-9bbf259e4b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c76430-c5c9-46a4-9a3b-9bbf259e4b38.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -9406,7 +9406,7 @@
         },
         {
             "id": "9bd33bdb-1597-5e13-8e27-bd2eea7bd65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b625203-6c50-4b14-928c-6b0aec1375a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b625203-6c50-4b14-928c-6b0aec1375a2.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -9440,7 +9440,7 @@
         },
         {
             "id": "8c740ea3-0166-590e-884f-e16afac6b0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91725e5-9e36-461b-b523-8490418107f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91725e5-9e36-461b-b523-8490418107f2.jpg?1",
             "name": "Garruk's Packleader",
             "text": "Whenever another creature with power 3 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -9473,7 +9473,7 @@
         },
         {
             "id": "a451239a-4e12-5b74-8a03-51c81303700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd192de8-12b7-4c3f-913c-de9f26fdbb20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd192de8-12b7-4c3f-913c-de9f26fdbb20.jpg?1",
             "name": "Terra Stomper",
             "text": "Terra Stomper can't be countered.\nTrample (If this creature would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "e53a3c81-f470-5ab4-9d41-b9cb03131099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec96e95-5580-4110-86ec-561007ab0f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec96e95-5580-4110-86ec-561007ab0f1e.jpg?1",
             "name": "Sliver",
             "text": "",
             "colours": [],
@@ -9536,7 +9536,7 @@
         },
         {
             "id": "891a1cf6-59bc-582f-abee-6600303f17dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83070-573c-4a06-9a2d-1263d7600b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83070-573c-4a06-9a2d-1263d7600b66.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "9f066067-1b37-593d-8881-c492916f10cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dbf439-793a-4fe6-9d4e-0333f482e364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dbf439-793a-4fe6-9d4e-0333f482e364.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9604,7 +9604,7 @@
         },
         {
             "id": "d339f647-44e2-57e0-8b22-b3277ae3d2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c366546-6da9-4daa-b0c3-1401ace5568c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c366546-6da9-4daa-b0c3-1401ace5568c.jpg?1",
             "name": "Squid",
             "text": "",
             "colours": [
@@ -9638,7 +9638,7 @@
         },
         {
             "id": "1f94e698-6428-5165-9437-8a45a5d824f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48bf5f-5fe1-41ef-a63d-85daacd941f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48bf5f-5fe1-41ef-a63d-85daacd941f7.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "1e851ec5-fc7c-52e0-b201-7c350377c8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a1ebd-a0ac-4a03-8ac2-4678d6fb03fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a1ebd-a0ac-4a03-8ac2-4678d6fb03fa.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "64acacdf-5d42-5a9d-bcff-dcbd2ddca08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9661e23a-8914-493b-a08a-e9cd29b4666e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9661e23a-8914-493b-a08a-e9cd29b4666e.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "dcbda724-f208-5d0d-9faa-bb0f1eac5b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98993a45-4aff-4f9b-a030-7d72fbb4ec6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98993a45-4aff-4f9b-a030-7d72fbb4ec6c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9774,7 +9774,7 @@
         },
         {
             "id": "8bf8cff2-b156-52de-8bad-8b3bf5f70f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81e49b-bd38-4c0c-b9fe-ce33c15621d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81e49b-bd38-4c0c-b9fe-ce33c15621d6.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9808,7 +9808,7 @@
         },
         {
             "id": "04d5a8d1-4acc-562a-9a98-d9281ac14938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101a5b1-614e-43a0-9e7e-de5a248e2e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101a5b1-614e-43a0-9e7e-de5a248e2e43.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -9842,7 +9842,7 @@
         },
         {
             "id": "19dbccd7-6f00-5b81-aba2-27e6a1cecd86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569593a-d2f2-414c-9e61-2c34e8a5832d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2569593a-d2f2-414c-9e61-2c34e8a5832d.jpg?1",
             "name": "Treefolk Warrior",
             "text": "",
             "colours": [
@@ -9877,7 +9877,7 @@
         },
         {
             "id": "b4034a1c-afa9-56a2-ad50-d96ffdf03db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30093c6e-505e-4902-b535-707e364059b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30093c6e-505e-4902-b535-707e364059b4.jpg?1",
             "name": "Land Mine",
             "text": "",
             "colours": [],
@@ -9907,7 +9907,7 @@
         },
         {
             "id": "972f14ac-19ae-5bd3-9091-49bddd973efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ec39dd-8ba5-4a92-bfc8-4028a2c4691d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ec39dd-8ba5-4a92-bfc8-4028a2c4691d.jpg?1",
             "name": "Ajani Steadfast Emblem",
             "text": "",
             "colours": [],
@@ -9936,7 +9936,7 @@
         },
         {
             "id": "d706d4ff-ecf8-547e-8ac5-4d72792e8097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6fa6ba-045a-43f8-8b04-579ffe24f927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a6fa6ba-045a-43f8-8b04-579ffe24f927.jpg?1",
             "name": "Garruk, Apex Predator Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M19.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M19.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "bab977f8-f7a6-5fbf-bdbd-7422cdef00c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503c55d-74bb-4165-9273-127c01bb2214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503c55d-74bb-4165-9273-127c01bb2214.jpg?1",
             "name": "Aegis of the Heavens",
             "text": "Target creature gets +1/+7 until end of turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "5f52bb35-0bce-514b-a1a3-db6c6a0a52a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f7c45-db9f-4d48-b575-4d2f1904c963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/226f7c45-db9f-4d48-b575-4d2f1904c963.jpg?1",
             "name": "Aethershield Artificer",
             "text": "At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "f1921d05-db2a-5c05-927f-2e8ea17e42a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c565076-5db2-47ea-8ee0-4a4fd7bb353d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c565076-5db2-47ea-8ee0-4a4fd7bb353d.jpg?1",
             "name": "Ajani, Adversary of Tyrants",
             "text": "+1: Put a +1/+1 counter on each of up to two target creatures.\n\u22122: Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u22127: You get an emblem with \"At the beginning of your end step, create three 1/1 white Cat creature tokens with lifelink.\"",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "5024cc18-e37b-5aad-bde0-09867eed3725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aebbb57-31b3-4289-815e-4f529e29f3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aebbb57-31b3-4289-815e-4f529e29f3ea.jpg?1",
             "name": "Ajani's Last Stand",
             "text": "Whenever a creature or planeswalker you control dies, you may sacrifice Ajani's Last Stand. If you do, create a 4/4 white Avatar creature token with flying.\nWhen a spell or ability an opponent controls causes you to discard this card, if you control a Plains, create a 4/4 white Avatar creature token with flying.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "1f028cbd-9370-5a11-8f37-4f71e21c38ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f717e04-c078-4696-9ed6-e973033d7be0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f717e04-c078-4696-9ed6-e973033d7be0.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, you may put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "e875be87-ddbd-5050-a568-38f8ea46611a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9045fcb-b633-4c35-8058-6234311551ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9045fcb-b633-4c35-8058-6234311551ae.jpg?1",
             "name": "Ajani's Welcome",
             "text": "Whenever a creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "41e9c5a9-b640-5074-9abe-8708ba414ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bae0e4-1143-4dc4-afb1-e6b4201ff101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bae0e4-1143-4dc4-afb1-e6b4201ff101.jpg?1",
             "name": "Angel of the Dawn",
             "text": "Flying\nWhen Angel of the Dawn enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "38e8f17b-a318-530d-91be-b388ecb5f043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2e929-7ae3-4560-9cfa-53b89c8a6016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d2e929-7ae3-4560-9cfa-53b89c8a6016.jpg?1",
             "name": "Cavalry Drillmaster",
             "text": "When Cavalry Drillmaster enters the battlefield, target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "5f6e707d-616a-512b-851d-6c9ff2ff52ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be8eed7-c033-42cc-bd21-4512db7af66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be8eed7-c033-42cc-bd21-4512db7af66c.jpg?1",
             "name": "Cleansing Nova",
             "text": "Choose one \u2014\n\u2022 Destroy all creatures.\n\u2022 Destroy all artifacts and enchantments.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "7fa1d070-ee7a-5346-ac74-48b847c1fb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f461b1-c801-4f0c-8fd7-fe68b6078ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f461b1-c801-4f0c-8fd7-fe68b6078ac6.jpg?1",
             "name": "Daybreak Chaplain",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "5370de30-c805-5376-8336-7b75542bebbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e0f13-35a6-4a5e-8666-47bc5c275be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1e0f13-35a6-4a5e-8666-47bc5c275be7.jpg?1",
             "name": "Dwarven Priest",
             "text": "When Dwarven Priest enters the battlefield, you gain 1 life for each creature you control.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "4121aba6-246f-559b-972c-5c3aaf980d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e388c433-3a37-45f6-825a-d13d2223b6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e388c433-3a37-45f6-825a-d13d2223b6f7.jpg?1",
             "name": "Gallant Cavalry",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Gallant Cavalry enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "6174e1ed-f590-51dc-8e3a-a0fb30a85053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452591ca-7273-4e47-820b-3ff89697a036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452591ca-7273-4e47-820b-3ff89697a036.jpg?1",
             "name": "Herald of Faith",
             "text": "Flying\nWhenever Herald of Faith attacks, you gain 2 life.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "b847e188-ae16-5b23-ab33-233a393b2136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197743cd-249c-42ba-ac8d-027c088f8418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197743cd-249c-42ba-ac8d-027c088f8418.jpg?1",
             "name": "Hieromancer's Cage",
             "text": "When Hieromancer's Cage enters the battlefield, exile target nonland permanent an opponent controls until Hieromancer's Cage leaves the battlefield.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "68c1886c-5151-5e3b-85d5-fd7f4066afda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812cf63f-aa3d-405b-92e1-7ffa31352481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812cf63f-aa3d-405b-92e1-7ffa31352481.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "2ce01062-751c-5d25-95f5-9249b5186769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d36b5-37fb-4e52-ad85-c3a09a990ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1d36b5-37fb-4e52-ad85-c3a09a990ea0.jpg?1",
             "name": "Invoke the Divine",
             "text": "Destroy target artifact or enchantment. You gain 4 life.",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "41f8b27f-1b83-58ab-9042-aee19284c870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg?1",
             "name": "Isolate",
             "text": "Exile target permanent with converted mana cost 1.",
             "colours": [
@@ -574,7 +574,7 @@
         },
         {
             "id": "fbb97535-41be-5072-98b7-2565cfe28263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg?1",
             "name": "Knight of the Tusk",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "4033abc5-a23f-530d-ac74-6e12a426dc49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734ff6ac-000d-4fc6-b97b-07b9b21f745c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734ff6ac-000d-4fc6-b97b-07b9b21f745c.jpg?1",
             "name": "Knight's Pledge",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "f626d362-3d9c-5dea-88f9-637fec9f1ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ab022-967d-48ff-a1f9-4bd642dba1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366ab022-967d-48ff-a1f9-4bd642dba1ae.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, create a 2/2 white Knight creature token with vigilance. (Attacking doesn't cause it to tap.)\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "7fb16f62-c398-597f-94e3-2e365341687c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffcbcda-2ba3-45e7-80c0-85ea3b7eea0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ffcbcda-2ba3-45e7-80c0-85ea3b7eea0c.jpg?1",
             "name": "Lena, Selfless Champion",
             "text": "When Lena, Selfless Champion enters the battlefield, create a 1/1 white Soldier creature token for each nontoken creature you control.\nSacrifice Lena: Creatures you control with power less than Lena's power gain indestructible until end of turn.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "86a5422f-abe1-5090-ac5d-6eb7215d8d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724738ad-6a9b-4ef6-b637-558645cd8151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724738ad-6a9b-4ef6-b637-558645cd8151.jpg?1",
             "name": "Leonin Vanguard",
             "text": "At the beginning of combat on your turn, if you control three or more creatures, Leonin Vanguard gets +1/+1 until end of turn and you gain 1 life.",
             "colours": [
@@ -749,7 +749,7 @@
         },
         {
             "id": "a0d4b92b-2ac1-56ac-a858-7698d4e20324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e5e-6572-462a-9fa0-1b2e660099e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e5e-6572-462a-9fa0-1b2e660099e3.jpg?1",
             "name": "Leonin Warleader",
             "text": "Whenever Leonin Warleader attacks, create two 1/1 white Cat creature tokens with lifelink that are tapped and attacking.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "ca1ea422-4168-5a96-8f23-df6d456ca5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928d4250-c379-4134-a263-7811c80a8760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928d4250-c379-4134-a263-7811c80a8760.jpg?1",
             "name": "Loxodon Line Breaker",
             "text": "",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "0142bf67-cf22-58f2-9528-d6c591ee1663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db10390-725e-40f5-885b-a433e7b46f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db10390-725e-40f5-885b-a433e7b46f52.jpg?1",
             "name": "Luminous Bonds",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "52e702e5-6221-5a7d-b157-548b173355ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0857fa-f2cc-4c01-9fe5-8f74d08d1b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0857fa-f2cc-4c01-9fe5-8f74d08d1b29.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "6d87fbd0-7bd2-5ec9-bc6b-75c01c4d2a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e18bd43-6cee-40a3-88f5-c775fb705172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e18bd43-6cee-40a3-88f5-c775fb705172.jpg?1",
             "name": "Mentor of the Meek",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "4f588030-6648-5d70-bf16-c2af91c30ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45dcdd-ed92-43f6-b6d2-670b3252ed27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45dcdd-ed92-43f6-b6d2-670b3252ed27.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "60f75433-0c45-577a-a595-e3ab3c9b0648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c5bf25-937c-4e17-9ed4-b4c4579fa9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c5bf25-937c-4e17-9ed4-b4c4579fa9dc.jpg?1",
             "name": "Militia Bugler",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Militia Bugler enters the battlefield, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "233f6744-7ed9-5147-b230-18986bb97436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00101358-0e89-4bd1-b1f2-e889645b616e.jpg?1",
             "name": "Novice Knight",
             "text": "Defender (This creature can't attack.)\nAs long as Novice Knight is enchanted or equipped, it can attack as though it didn't have defender.",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "1c0d56ca-cd8b-547c-8766-073e2d0b177e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1dfb4-1983-41f7-956c-f2a1d1489b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1dfb4-1983-41f7-956c-f2a1d1489b54.jpg?1",
             "name": "Oreskos Swiftclaw",
             "text": "",
             "colours": [
@@ -1057,7 +1057,7 @@
         },
         {
             "id": "8d80759b-9206-58dc-adc4-f9c90d78dbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c04eafe-8be0-416e-a5b9-486a3b3b5984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c04eafe-8be0-416e-a5b9-486a3b3b5984.jpg?1",
             "name": "Pegasus Courser",
             "text": "Flying\nWhenever Pegasus Courser attacks, another target attacking creature gains flying until end of turn.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "a031722e-086e-569d-a0a5-66329c4de043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9620716d-9be8-4ebd-80d2-679373f4f897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9620716d-9be8-4ebd-80d2-679373f4f897.jpg?1",
             "name": "Remorseful Cleric",
             "text": "Flying\nSacrifice Remorseful Cleric: Exile all cards from target player's graveyard.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "84de6357-6e39-511f-8e6b-4f51c46871f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586854d1-edfd-4c66-873d-df459324dbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586854d1-edfd-4c66-873d-df459324dbfd.jpg?1",
             "name": "Resplendent Angel",
             "text": "Flying\nAt the beginning of each end step, if you gained 5 or more life this turn, create a 4/4 white Angel creature token with flying and vigilance.\n{3}{W}{W}{W}: Until end of turn, Resplendent Angel gets +2/+2 and gains lifelink.",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "3531d18e-cd79-5a50-a87b-1e8d77432d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbdd90c-1ae3-45e5-b1e5-5b8615a1511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbdd90c-1ae3-45e5-b1e5-5b8615a1511f.jpg?1",
             "name": "Revitalize",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "454c4f1b-9716-5b3d-aeb3-3a2560d12763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6691e62-8887-41e8-8e74-76ee2353d45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6691e62-8887-41e8-8e74-76ee2353d45e.jpg?1",
             "name": "Rustwing Falcon",
             "text": "Flying",
             "colours": [
@@ -1226,7 +1226,7 @@
         },
         {
             "id": "99dff78a-ee04-5e0c-9329-f0d6ff0bd6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21e0516-4430-4292-850b-f5c524d7f8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21e0516-4430-4292-850b-f5c524d7f8f8.jpg?1",
             "name": "Shield Mare",
             "text": "Shield Mare can't be blocked by red creatures.\nWhen Shield Mare enters the battlefield or becomes the target of a spell or ability an opponent controls, you gain 3 life.",
             "colours": [
@@ -1260,7 +1260,7 @@
         },
         {
             "id": "fdf689c9-fd4b-53c6-9adb-eb4a2785207d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57417c7-867b-4b64-bfe3-1744dfe9b44d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57417c7-867b-4b64-bfe3-1744dfe9b44d.jpg?1",
             "name": "Star-Crowned Stag",
             "text": "Whenever Star-Crowned Stag attacks, tap target creature defending player controls.",
             "colours": [
@@ -1294,7 +1294,7 @@
         },
         {
             "id": "46a59fcf-8a91-528e-9e10-544edd3e0862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3644df41-b690-4581-ac7d-c85cec75411f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3644df41-b690-4581-ac7d-c85cec75411f.jpg?1",
             "name": "Suncleanser",
             "text": "When Suncleanser enters the battlefield, choose one \u2014\n\u2022 Remove all counters from target creature. It can't have counters put on it for as long as Suncleanser remains on the battlefield.\n\u2022 Target opponent loses all counters. That player can't get counters for as long as Suncleanser remains on the battlefield.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "6c0f288a-e4d1-5ef8-8322-04ecc6bf87b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fbde22-d98d-4f12-b4d8-1bad2a9878b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fbde22-d98d-4f12-b4d8-1bad2a9878b2.jpg?1",
             "name": "Take Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "9eeb9afe-90f9-5640-aba9-5fdfb13633ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8320e35b-15b9-4f98-b9b8-9c951696408b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8320e35b-15b9-4f98-b9b8-9c951696408b.jpg?1",
             "name": "Trusty Packbeast",
             "text": "When Trusty Packbeast enters the battlefield, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "7abe8eaa-6be5-54cd-abf6-5230b6433ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad750bc-850b-483b-8910-eb6562f925bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad750bc-850b-483b-8910-eb6562f925bc.jpg?1",
             "name": "Valiant Knight",
             "text": "Other Knights you control get +1/+1.\n{3}{W}{W}: Knights you control gain double strike until end of turn.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "7a52e6c1-591d-5cea-80df-3e42c9c586dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6178ed-6353-4733-81e1-7b3dc592c3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6178ed-6353-4733-81e1-7b3dc592c3bd.jpg?1",
             "name": "Aether Tunnel",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and can't be blocked.",
             "colours": [
@@ -1464,7 +1464,7 @@
         },
         {
             "id": "bfb9ef8c-89eb-5646-a581-1a96e99d295e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b1d89-1e6a-4e95-be89-1f03182fc470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b1d89-1e6a-4e95-be89-1f03182fc470.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "843d95de-b3e1-5c39-8cf1-8842a446bdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12dfc1-81f2-44b2-baa2-73cc21363978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12dfc1-81f2-44b2-baa2-73cc21363978.jpg?1",
             "name": "Aven Wind Mage",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Aven Wind Mage gets +1/+1 until end of turn.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "316725e0-adcc-53ec-9611-8866f7cb112b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6966738-b4fc-4854-81b0-09de305854f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6966738-b4fc-4854-81b0-09de305854f2.jpg?1",
             "name": "Aviation Pioneer",
             "text": "When Aviation Pioneer enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1566,7 +1566,7 @@
         },
         {
             "id": "6379198d-58dd-5794-abc6-d303e8793ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4579e7fc-650d-41ba-8ed7-3bd6453a3ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4579e7fc-650d-41ba-8ed7-3bd6453a3ce3.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "b589a6bc-f0f3-53d0-835b-76095d3768cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff3fae-e072-4068-a1de-27de3d89c532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff3fae-e072-4068-a1de-27de3d89c532.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "197d24e5-c4bb-5c4d-858b-b4b896bd63cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1081df25-1137-4c4d-909b-40e78723652c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1081df25-1137-4c4d-909b-40e78723652c.jpg?1",
             "name": "Departed Deckhand",
             "text": "When Departed Deckhand becomes the target of a spell, sacrifice it.\nDeparted Deckhand can't be blocked except by Spirits.\n{3}{U}: Another target creature you control can't be blocked this turn except by Spirits.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "e3f3a2e3-4519-519e-b7bc-1d0aab3463bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c89c-41dc-4ac3-bbce-38ab86f435ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7c89c-41dc-4ac3-bbce-38ab86f435ea.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "13f3ff01-1980-5c63-86b5-a76657119f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b35b8-f321-46d8-a441-6b9a6efa9021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b35b8-f321-46d8-a441-6b9a6efa9021.jpg?1",
             "name": "Divination",
             "text": "Draw two cards.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "c26eedec-c34c-53c1-a442-34ad226fc924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d38bba-6eb9-4dd8-81aa-722def89b163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d38bba-6eb9-4dd8-81aa-722def89b163.jpg?1",
             "name": "Djinn of Wishes",
             "text": "Flying\nDjinn of Wishes enters the battlefield with three wish counters on it.\n{2}{U}{U}, Remove a wish counter from Djinn of Wishes: Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "2932f1b1-11c9-5672-a902-3aaec84521df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb38f190-30f0-49ca-99c3-d3cdf21075e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb38f190-30f0-49ca-99c3-d3cdf21075e8.jpg?1",
             "name": "Dwindle",
             "text": "Enchant creature\nEnchanted creature gets -6/-0.\nWhen enchanted creature blocks, destroy it. (The attacking creature remains blocked.)",
             "colours": [
@@ -1797,7 +1797,7 @@
         },
         {
             "id": "c99ca5d8-f631-566e-b421-d1d86906c10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f61eb-a121-4f43-93a4-c6f20c6aee84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f61eb-a121-4f43-93a4-c6f20c6aee84.jpg?1",
             "name": "Essence Scatter",
             "text": "Counter target creature spell.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "7684e317-996e-5ab7-8acc-82a8c6eadec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad82f5-5c5c-42ad-b66e-942f0d9631ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad82f5-5c5c-42ad-b66e-942f0d9631ca.jpg?1",
             "name": "Exclusion Mage",
             "text": "When Exclusion Mage enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "3c6a3997-3d4c-557a-a99b-03a587a1e074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa62c0-d24b-4bce-9f2b-d42402b0830c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aa62c0-d24b-4bce-9f2b-d42402b0830c.jpg?1",
             "name": "Frilled Sea Serpent",
             "text": "{5}{U}{U}: Frilled Sea Serpent can't be blocked this turn.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "6e1664b4-1d18-52fa-afe9-b5feb1007880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9e666-d9c9-4ccd-89a5-83de79677fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9e666-d9c9-4ccd-89a5-83de79677fa6.jpg?1",
             "name": "Gearsmith Prodigy",
             "text": "Gearsmith Prodigy gets +1/+0 as long as you control an artifact.",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "8afe2d9c-668f-5a48-982e-130aa101ca42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347760a1-03f5-4cc9-87ad-e08986b1ea21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347760a1-03f5-4cc9-87ad-e08986b1ea21.jpg?1",
             "name": "Ghostform",
             "text": "Up to two target creatures can't be blocked this turn.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "9b3361b7-7f43-5325-9963-821b3cbd19f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e925a7a-da5b-4d5d-b5ff-37645ac217f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e925a7a-da5b-4d5d-b5ff-37645ac217f9.jpg?1",
             "name": "Horizon Scholar",
             "text": "Flying\nWhen Horizon Scholar enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "f8a8073e-7086-5462-bfb3-6bbbb1cdec77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff03d37-d90a-4dcc-bacd-64fd71301354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff03d37-d90a-4dcc-bacd-64fd71301354.jpg?1",
             "name": "Metamorphic Alteration",
             "text": "Enchant creature\nAs Metamorphic Alteration enters the battlefield, choose a creature.\nEnchanted creature is a copy of the chosen creature.",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "b3273d7e-f111-5853-b139-086c2451ad9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3ffc69-f21b-410e-8993-8c1b4669fc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3ffc69-f21b-410e-8993-8c1b4669fc19.jpg?1",
             "name": "Mirror Image",
             "text": "You may have Mirror Image enter the battlefield as a copy of any creature you control.",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "c8efa832-ab31-5875-ac3f-1c0b4fa69a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35c1bd0-3d1a-4e46-b74d-11db6867e0d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35c1bd0-3d1a-4e46-b74d-11db6867e0d7.jpg?1",
             "name": "Mistcaller",
             "text": "Sacrifice Mistcaller: Until end of turn, if a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "2684bd97-b09a-5e1a-a662-63aa3bf34729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b19cad0-5754-4625-8303-c8310bc7cbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b19cad0-5754-4625-8303-c8310bc7cbd5.jpg?1",
             "name": "Mystic Archaeologist",
             "text": "{3}{U}{U}: Draw two cards.",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "aef0f3ec-f3f1-512f-8c49-d0759cef1fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949589c4-97bc-46b4-bc6c-4b2709fd5e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949589c4-97bc-46b4-bc6c-4b2709fd5e3a.jpg?1",
             "name": "Omenspeaker",
             "text": "When Omenspeaker enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2172,7 +2172,7 @@
         },
         {
             "id": "c594ab12-51f9-5076-91ff-4e0a8dfeff66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db534b4e-8bff-4924-baea-9988d195fb25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db534b4e-8bff-4924-baea-9988d195fb25.jpg?1",
             "name": "Omniscience",
             "text": "You may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "b619a560-96b4-59a2-8924-4adbcc3fa3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f2aaf5-6c1f-4663-865f-6cdd5640485a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f2aaf5-6c1f-4663-865f-6cdd5640485a.jpg?1",
             "name": "One with the Machine",
             "text": "Draw cards equal to the highest converted mana cost among artifacts you control.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "382cfc49-7b67-51d0-9466-417c8100d263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2256e07f-a35a-4393-9744-045564d5770b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2256e07f-a35a-4393-9744-045564d5770b.jpg?1",
             "name": "Patient Rebuilding",
             "text": "At the beginning of your upkeep, target opponent puts the top three cards of their library into their graveyard, then you draw a card for each land card put into that graveyard this way.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "4f4e5d1d-73ea-5fe0-9aa1-a0e5490dd7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d22fa-1623-463a-83c0-a9aa7c969ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d22fa-1623-463a-83c0-a9aa7c969ce2.jpg?1",
             "name": "Psychic Corrosion",
             "text": "Whenever you draw a card, each opponent puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "fb315a8e-dda0-52df-b51a-aa4940939fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19316cbb-d1af-4ab7-b588-78637503e986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19316cbb-d1af-4ab7-b588-78637503e986.jpg?1",
             "name": "Sai, Master Thopterist",
             "text": "Whenever you cast an artifact spell, create a 1/1 colorless Thopter artifact creature token with flying.\n{1}{U}, Sacrifice two artifacts: Draw a card.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "835be7ea-3243-53be-9b31-264b1937257b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a55f484-5734-469c-8d41-95ce44473ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a55f484-5734-469c-8d41-95ce44473ec1.jpg?1",
             "name": "Salvager of Secrets",
             "text": "When Salvager of Secrets enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "98b0f626-2ced-5719-b1b9-d5745efdfca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4664d4-fb00-4572-a60d-00336117b8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4664d4-fb00-4572-a60d-00336117b8a5.jpg?1",
             "name": "Scholar of Stars",
             "text": "When Scholar of Stars enters the battlefield, if you control an artifact, draw a card.",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "aad9f8ac-cfd8-57d8-9670-e70e3648a098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46588683-74c7-4041-a43b-95d51ba51a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46588683-74c7-4041-a43b-95d51ba51a94.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "4395ca2a-dbc7-508f-b560-926bfbea867b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586d5000-1fdb-4bfe-aa34-63b25ee94bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586d5000-1fdb-4bfe-aa34-63b25ee94bb9.jpg?1",
             "name": "Skilled Animator",
             "text": "When Skilled Animator enters the battlefield, target artifact you control becomes an artifact creature with base power and toughness 5/5 for as long as Skilled Animator remains on the battlefield.",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "63d2b8e6-5bcf-517a-abeb-163de10529aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c53e64-69cf-4296-8a1e-f8817f25c0b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c53e64-69cf-4296-8a1e-f8817f25c0b4.jpg?1",
             "name": "Sleep",
             "text": "Tap all creatures target player controls. Those creatures don't untap during that player's next untap step.",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "5ddf8f73-7170-589f-b9a9-fc88a81e1dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b6cbc-b25c-4221-ae65-a29fcf504f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6b6cbc-b25c-4221-ae65-a29fcf504f2f.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "1d93084a-f8e9-576b-9964-67ada1e3a333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d65c22b-7640-4433-930b-4bc381ac7361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d65c22b-7640-4433-930b-4bc381ac7361.jpg?1",
             "name": "Supreme Phantom",
             "text": "Flying\nOther Spirits you control get +1/+1.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "21726898-b6a4-5329-acd5-918117c1d9d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002d0f1-ff2c-4d1c-a7db-3252ef6bebbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9002d0f1-ff2c-4d1c-a7db-3252ef6bebbd.jpg?1",
             "name": "Surge Mare",
             "text": "Surge Mare can't be blocked by green creatures.\nWhenever Surge Mare deals damage to an opponent, you may draw a card. If you do, discard a card.\n{1}{U}: Surge Mare gets +2/-2 until end of turn.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "6edc6b13-32f5-5eb1-8630-dfd7cf043723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d062c-5853-44f9-b951-a264e9e0d72d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3d062c-5853-44f9-b951-a264e9e0d72d.jpg?1",
             "name": "Switcheroo",
             "text": "Exchange control of two target creatures.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "48a91232-a6e6-5a4c-97a8-c8f626539e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e12371-f05c-41cf-92ca-7cb17c2f7f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e12371-f05c-41cf-92ca-7cb17c2f7f1a.jpg?1",
             "name": "Tezzeret, Artifice Master",
             "text": "+1: Create a 1/1 colorless Thopter artifact creature token with flying.\n0: Draw a card. If you control three or more artifacts, draw two cards instead.\n\u22129: You get an emblem with \"At the beginning of your end step, search your library for a permanent card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "7b41090e-87f8-50e3-a853-3a6751250f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eda67da-02b5-4ecb-9038-10e026d454ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eda67da-02b5-4ecb-9038-10e026d454ec.jpg?1",
             "name": "Tolarian Scholar",
             "text": "",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "8994bb9f-fb84-5e52-a5f3-34f08c963927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0b6ce-eb70-4f42-9360-c7d09f48a5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f0b6ce-eb70-4f42-9360-c7d09f48a5c5.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "727aa305-6cbd-58cb-90f7-aa58774b2a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f12d70b-fff7-4d0c-982e-2fea70018a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f12d70b-fff7-4d0c-982e-2fea70018a78.jpg?1",
             "name": "Uncomfortable Chill",
             "text": "Creatures your opponents control get -2/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "baaa5a49-9d1a-557d-b786-f5519ec1a6fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb995c8-1bc2-4ff4-b8e9-f9b6bc0de0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb995c8-1bc2-4ff4-b8e9-f9b6bc0de0fe.jpg?1",
             "name": "Wall of Mist",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "684b1725-511c-5909-80d1-b2c8ed2c6e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5964daa-2f9e-4a4b-a091-91e7adc3e9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5964daa-2f9e-4a4b-a091-91e7adc3e9c3.jpg?1",
             "name": "Windreader Sphinx",
             "text": "Flying\nWhenever a creature with flying attacks, you may draw a card.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "3fac2447-9f15-50df-ba42-fe82f800644c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de2bd-9ba7-4b6f-94c2-dafb2011a48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2de2bd-9ba7-4b6f-94c2-dafb2011a48e.jpg?1",
             "name": "Abnormal Endurance",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "f49f9957-318d-535d-abdc-21cb270172b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe72bd9-825e-4451-9314-826882f75c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe72bd9-825e-4451-9314-826882f75c85.jpg?1",
             "name": "Blood Divination",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "af389ddf-3445-5fa4-92c5-1c10f8ad7095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05145a8d-0bfb-4f07-87cf-65875310bdb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05145a8d-0bfb-4f07-87cf-65875310bdb4.jpg?1",
             "name": "Bogstomper",
             "text": "",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "f0c7dd4c-a925-54b7-a3e9-5114cecd3f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a0de62-6e9f-4ee9-9d8d-ee6f6a115307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a0de62-6e9f-4ee9-9d8d-ee6f6a115307.jpg?1",
             "name": "Bone Dragon",
             "text": "Flying\n{3}{B}{B}, Exile seven other cards from your graveyard: Return Bone Dragon from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "caab9219-1025-54ec-923c-3b3f154ed0a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3867704d-d2ef-4185-b53d-84eba6a6776f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3867704d-d2ef-4185-b53d-84eba6a6776f.jpg?1",
             "name": "Child of Night",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "cf1552ac-6ae6-5dc6-9342-f1c70be18cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9699446-b6f5-4e6a-a263-059cbf6e4b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9699446-b6f5-4e6a-a263-059cbf6e4b7e.jpg?1",
             "name": "Death Baron",
             "text": "Skeletons you control and other Zombies you control get +1/+1 and have deathtouch.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "06d6e2fc-10b9-531c-a509-aed54f42013c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg?1",
             "name": "Demon of Catastrophes",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "af350288-41f2-54e4-876e-6d7539607e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf2d355-404e-4c21-9bc2-973d09a845a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf2d355-404e-4c21-9bc2-973d09a845a5.jpg?1",
             "name": "Diregraf Ghoul",
             "text": "Diregraf Ghoul enters the battlefield tapped.",
             "colours": [
@@ -3114,7 +3114,7 @@
         },
         {
             "id": "e4c7b77a-9c2a-5af9-9119-653fbee39fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f70ee8-7e59-43d6-a7b2-29cb5cd1d8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f70ee8-7e59-43d6-a7b2-29cb5cd1d8b3.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "a5f5d8b5-464c-519d-8ad2-3151dd77674c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b433b9fc-69fc-4a57-a16b-f1afd3033b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b433b9fc-69fc-4a57-a16b-f1afd3033b56.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "0b4c3e23-aea1-5885-ac68-8cbab0b06ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b03528-f4ec-4825-ba4c-c485cb4eab3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b03528-f4ec-4825-ba4c-c485cb4eab3a.jpg?1",
             "name": "Epicure of Blood",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "97fd3474-b619-5311-91cc-085ccd747e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cb52a4-5fec-41a0-8030-503a61e3d33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cb52a4-5fec-41a0-8030-503a61e3d33e.jpg?1",
             "name": "Fell Specter",
             "text": "Flying\nWhen Fell Specter enters the battlefield, target opponent discards a card.\nWhenever an opponent discards a card, that player loses 2 life.",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "99638102-5fe1-50e9-84f0-b7884b6b1a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa0ad8-854a-4b4e-9f87-e1dfaa11253c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa0ad8-854a-4b4e-9f87-e1dfaa11253c.jpg?1",
             "name": "Fraying Omnipotence",
             "text": "Each player loses half their life, then discards half the cards in their hand, then sacrifices half the creatures they control. Round up each time.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "42e1f68d-08d6-5cae-8470-4cebe917111e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d2a84-5e47-4f7a-83f7-ee4e670980c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d2a84-5e47-4f7a-83f7-ee4e670980c7.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "0091568f-57f2-50fb-977c-f81365445544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc5f62c-2d29-4a94-8501-13dc6a93c5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc5f62c-2d29-4a94-8501-13dc6a93c5a1.jpg?1",
             "name": "Graveyard Marshal",
             "text": "{2}{B}, Exile a creature card from your graveyard: Create a tapped 2/2 black Zombie creature token.",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "cea9d280-7d19-5718-9658-9e6f4d463089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7624c9aa-2f47-4fcc-a9fe-cc843e8de053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7624c9aa-2f47-4fcc-a9fe-cc843e8de053.jpg?1",
             "name": "Hired Blade",
             "text": "Flash (You may cast this spell any time you could cast an instant.)",
             "colours": [
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "823f8c2b-ec6d-5f38-b2f7-bd24039e1034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17aaa92-10ca-4f70-b45e-5a51e9192efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17aaa92-10ca-4f70-b45e-5a51e9192efb.jpg?1",
             "name": "Infectious Horror",
             "text": "Whenever Infectious Horror attacks, each opponent loses 2 life.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "6b1d1672-5f6e-5ff2-9b1f-cff4fb6e230c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e291f27-d74f-48e7-bcb4-ddcc558c2211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e291f27-d74f-48e7-bcb4-ddcc558c2211.jpg?1",
             "name": "Infernal Reckoning",
             "text": "Exile target colorless creature. You gain life equal to its power.",
             "colours": [
@@ -3451,7 +3451,7 @@
         },
         {
             "id": "bbc7abdf-7968-5422-b76a-ce561296eea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf7ff14-0de8-4ef9-8425-df15629adc4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf7ff14-0de8-4ef9-8425-df15629adc4b.jpg?1",
             "name": "Infernal Scarring",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -3485,7 +3485,7 @@
         },
         {
             "id": "d81f47f4-2372-510c-9434-95a0e1ccd412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e49567-8ad6-4ce9-a55d-4db5e0fd9532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e49567-8ad6-4ce9-a55d-4db5e0fd9532.jpg?1",
             "name": "Isareth the Awakener",
             "text": "Deathtouch\nWhenever Isareth the Awakener attacks, you may pay {X}. When you do, return target creature card with converted mana cost X from your graveyard to the battlefield with a corpse counter on it. If that creature would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "166ce0e2-4960-5719-b02d-aae4379b0979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd3acd-aa62-4708-9336-e3430fd0e541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bd3acd-aa62-4708-9336-e3430fd0e541.jpg?1",
             "name": "Lich's Caress",
             "text": "Destroy target creature. You gain 3 life.",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "96141099-a790-5b21-9001-2114198f1dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7939170-f84e-44c6-b8bc-a180cf7f85d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7939170-f84e-44c6-b8bc-a180cf7f85d9.jpg?1",
             "name": "Liliana, Untouched by Death",
             "text": "+1: Put the top three cards of your library into your graveyard. If at least one of them is a Zombie card, each opponent loses 2 life and you gain 2 life.\n\u22122: Target creature gets -X/-X until end of turn, where X is the number of Zombies you control.\n\u22123: You may cast Zombie cards from your graveyard this turn.",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "5a6ffcc1-8cfa-58eb-80fa-17ddd20bfcfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750e6246-c28d-46ed-9966-26706f6d3172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750e6246-c28d-46ed-9966-26706f6d3172.jpg?1",
             "name": "Liliana's Contract",
             "text": "When Liliana's Contract enters the battlefield, you draw four cards and you lose 4 life.\nAt the beginning of your upkeep, if you control four or more Demons with different names, you win the game.",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "0e0fa011-8c99-595a-b43b-3e2d0b30fcf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d5f95-c8a8-4d65-9546-26c2113db817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d5f95-c8a8-4d65-9546-26c2113db817.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "c9b22514-bee6-530e-bbbc-a70073141cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8423f50f-add7-4502-9ac0-8de1ccb2603d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8423f50f-add7-4502-9ac0-8de1ccb2603d.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "327c5879-522c-527a-aef3-671a935bfe6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45368bf3-d5e9-43e6-a67d-93c2e93acc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45368bf3-d5e9-43e6-a67d-93c2e93acc72.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "c7f0005c-e8e5-5513-95dc-bbf8147f0b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12efbc0-ce88-4622-ad07-2808e651ac5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12efbc0-ce88-4622-ad07-2808e651ac5a.jpg?1",
             "name": "Nightmare's Thirst",
             "text": "You gain 1 life. Target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "1e58b5d8-f20a-522e-b8ce-132b5aab3d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ced1022-abd9-4e22-a4f2-fef738295224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ced1022-abd9-4e22-a4f2-fef738295224.jpg?1",
             "name": "Open the Graves",
             "text": "Whenever a nontoken creature you control dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3782,7 +3782,7 @@
         },
         {
             "id": "772e6914-5e28-59a0-85d2-faa047fb6297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e359c3-2a18-4240-b38a-216372161cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e359c3-2a18-4240-b38a-216372161cd8.jpg?1",
             "name": "Phylactery Lich",
             "text": "Indestructible\nAs Phylactery Lich enters the battlefield, put a phylactery counter on an artifact you control.\nWhen you control no permanents with phylactery counters on them, sacrifice Phylactery Lich.",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "4748377c-726e-5f72-b7b7-66e760865314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995596a3-343d-4272-86bf-d76fd32ab78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995596a3-343d-4272-86bf-d76fd32ab78e.jpg?1",
             "name": "Plague Mare",
             "text": "Plague Mare can't be blocked by white creatures.\nWhen Plague Mare enters the battlefield, creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "40f74c44-c11f-522e-a3e8-3c6771c78b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ec702-75c4-4733-b500-eb15406778bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676ec702-75c4-4733-b500-eb15406778bb.jpg?1",
             "name": "Ravenous Harpy",
             "text": "Flying\n{1}, Sacrifice another creature: Put a +1/+1 counter on Ravenous Harpy.",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "2e983418-ac75-5e8a-a4bd-284c4c9c00fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d4ac21-2203-45f4-b5f2-dc186ccdbe69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d4ac21-2203-45f4-b5f2-dc186ccdbe69.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "0994bc88-c71a-55b4-91ec-7ca3233ef3b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73644e-884c-47cd-aeec-ab80360dd5ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc73644e-884c-47cd-aeec-ab80360dd5ae.jpg?1",
             "name": "Rise from the Grave",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "89ba214a-4c20-5236-9499-67a6cea4d936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee5cc4-a686-4ce6-aa6b-1b8a88e6dea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fee5cc4-a686-4ce6-aa6b-1b8a88e6dea3.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "0d6ef022-1f1c-547e-b534-880128d378d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f2740-a193-4b4c-af00-2dd22d74a4ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7f2740-a193-4b4c-af00-2dd22d74a4ba.jpg?1",
             "name": "Skymarch Bloodletter",
             "text": "Flying\nWhen Skymarch Bloodletter enters the battlefield, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "df84e252-df11-5e67-b8f8-7e90d0a3c2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5326d251-bb91-4653-b1fa-44f14c4e0b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5326d251-bb91-4653-b1fa-44f14c4e0b88.jpg?1",
             "name": "Sovereign's Bite",
             "text": "Target player loses 3 life and you gain 3 life.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "5534ffea-51f2-5e14-a08d-19fbe6c6f1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b737126-50b5-4678-91bf-197b64086fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b737126-50b5-4678-91bf-197b64086fe4.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "When Stitcher's Supplier enters the battlefield or dies, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -4088,7 +4088,7 @@
         },
         {
             "id": "bbbad4c4-7664-5ab8-807c-3943401de8f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300468ab-fbae-42ae-97bc-b08f795efa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300468ab-fbae-42ae-97bc-b08f795efa5c.jpg?1",
             "name": "Strangling Spores",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4120,7 +4120,7 @@
         },
         {
             "id": "3ca3bc7e-5c46-5085-bfe1-3d19870b232c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc5760e-8b27-4d37-9772-c9eda90b1d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc5760e-8b27-4d37-9772-c9eda90b1d95.jpg?1",
             "name": "Two-Headed Zombie",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4154,7 +4154,7 @@
         },
         {
             "id": "5763aa53-2515-5a1b-a89c-37d8df493b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167822a5-2ab5-42f5-afa4-562fe2d7501b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167822a5-2ab5-42f5-afa4-562fe2d7501b.jpg?1",
             "name": "Vampire Neonate",
             "text": "{2}, {T}: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4188,7 +4188,7 @@
         },
         {
             "id": "75bdf5cc-0580-50fa-8c5f-0948acb53e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee338221-ead9-4b89-8b0c-12745c4ca13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee338221-ead9-4b89-8b0c-12745c4ca13d.jpg?1",
             "name": "Vampire Sovereign",
             "text": "Flying\nWhen Vampire Sovereign enters the battlefield, target opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -4223,7 +4223,7 @@
         },
         {
             "id": "26bb13c3-f943-5134-9ab0-435cb5738995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344a26ab-524f-4daa-ae0a-9d94e34c96df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344a26ab-524f-4daa-ae0a-9d94e34c96df.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -4257,7 +4257,7 @@
         },
         {
             "id": "b2caf4cf-d15a-5054-b1a0-6bac11220d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160dde8-cd77-4967-a5f3-a676376c58f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9160dde8-cd77-4967-a5f3-a676376c58f7.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "f99222cb-1a21-59ef-b41a-c770187dc942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2435c810-2baf-4e3b-80ce-542b94694901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2435c810-2baf-4e3b-80ce-542b94694901.jpg?1",
             "name": "Alpine Moon",
             "text": "As Alpine Moon enters the battlefield, choose a nonbasic land card name.\nLands your opponents control with the chosen name lose all land types and abilities, and they gain \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "23068240-57a7-5b1c-9f42-63c08949f2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c827bccf-38f9-4a7c-bd0e-038594a9f63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c827bccf-38f9-4a7c-bd0e-038594a9f63b.jpg?1",
             "name": "Apex of Power",
             "text": "Exile the top seven cards of your library. Until end of turn, you may cast nonland cards exiled this way.\nIf this spell was cast from your hand, add ten mana of any one color.",
             "colours": [
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "9767d93d-c253-5c72-97a6-8aa19f0e36fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b012532-1186-4dc8-9d42-867e418b0280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b012532-1186-4dc8-9d42-867e418b0280.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to any target.\nIf X is 5 or more, this spell can't be countered and the damage can't be prevented.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "5b7a1757-d881-56c9-9d88-22ae6effc37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b7438d-e905-4627-9299-e2224377c8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b7438d-e905-4627-9299-e2224377c8e7.jpg?1",
             "name": "Boggart Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "f4057b39-9fe2-5cc4-bcbc-814c63d16b44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a678b-19d4-47a5-aa1c-c2437e5009c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a678b-19d4-47a5-aa1c-c2437e5009c0.jpg?1",
             "name": "Catalyst Elemental",
             "text": "Sacrifice Catalyst Elemental: Add {R}{R}.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "92c9285d-d10f-57e9-a72f-c8cbcfe21365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9737a83-8c58-44b5-816e-d8df8a577921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9737a83-8c58-44b5-816e-d8df8a577921.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)\nDraw a card.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "f1d3a50a-3b48-5826-a433-54ca9d4e9808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a57bfc-1de2-4b3a-84bc-19ec41087f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a57bfc-1de2-4b3a-84bc-19ec41087f0d.jpg?1",
             "name": "Dark-Dweller Oracle",
             "text": "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn. (You still pay its costs. You can play a land this way only if you have an available land play remaining.)",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "e6046c90-5b83-5eb7-af9d-c89a55ee5bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b73282-6207-4207-8b9c-86a8f9a263a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b73282-6207-4207-8b9c-86a8f9a263a2.jpg?1",
             "name": "Demanding Dragon",
             "text": "Flying\nWhen Demanding Dragon enters the battlefield, it deals 5 damage to target opponent unless that player sacrifices a creature.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "73ec237c-203f-5dde-9a7f-908b9604667b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg?1",
             "name": "Dismissive Pyromancer",
             "text": "{R}, {T}, Discard a card: Draw a card.\n{2}{R}, {T}, Sacrifice Dismissive Pyromancer: It deals 4 damage to target creature.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "40027480-2ea3-5e32-ba56-23ad614ed4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8875d8-fe8c-4721-aa8d-978bf72e9c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8875d8-fe8c-4721-aa8d-978bf72e9c26.jpg?1",
             "name": "Doublecast",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "1c1ac533-e2dc-5261-adca-819490904c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d330ce5b-de86-42ad-ac00-3ae1d3252956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d330ce5b-de86-42ad-ac00-3ae1d3252956.jpg?1",
             "name": "Dragon Egg",
             "text": "Defender (This creature can't attack.)\nWhen Dragon Egg dies, create a 2/2 red Dragon creature token with flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "4dce70b8-b75b-515d-afc9-95e356e5bb03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bee89d-d916-4095-830f-6270f8c4f0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60bee89d-d916-4095-830f-6270f8c4f0d8.jpg?1",
             "name": "Electrify",
             "text": "Electrify deals 4 damage to target creature.",
             "colours": [
@@ -4689,7 +4689,7 @@
         },
         {
             "id": "9a496890-12d1-50f5-977b-f9daf2363d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e38127d-63af-4d26-9ff5-358c8a61f39c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e38127d-63af-4d26-9ff5-358c8a61f39c.jpg?1",
             "name": "Fiery Finish",
             "text": "Fiery Finish deals 7 damage to target creature.",
             "colours": [
@@ -4721,7 +4721,7 @@
         },
         {
             "id": "bbf23452-16e4-51b4-861c-0638a8be8e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcca2f76-3db9-472b-b78e-a87b81e31d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcca2f76-3db9-472b-b78e-a87b81e31d0a.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "79e2d2ef-185e-5154-a14e-ecbffdcbf5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cef94d-d941-4e08-afec-a116626b74fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cef94d-d941-4e08-afec-a116626b74fb.jpg?1",
             "name": "Goblin Instigator",
             "text": "When Goblin Instigator enters the battlefield, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "4f6c0be9-ecbb-50db-b084-2e1790d5233e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b3a4fb-9024-45ef-a54b-cf3a9fa5b9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b3a4fb-9024-45ef-a54b-cf3a9fa5b9c2.jpg?1",
             "name": "Goblin Motivator",
             "text": "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4825,7 +4825,7 @@
         },
         {
             "id": "fc16b592-5cc8-5bb7-b918-716c0e1fe979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg?1",
             "name": "Goblin Trashmaster",
             "text": "Other Goblins you control get +1/+1.\nSacrifice a Goblin: Destroy target artifact.",
             "colours": [
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "9a72fcfd-5d43-55fb-8ade-8476d38f506b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc0f3e7-a287-4624-8266-ca617448fcaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc0f3e7-a287-4624-8266-ca617448fcaa.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -4895,7 +4895,7 @@
         },
         {
             "id": "ac4743a3-0a3f-5531-a235-d5735fcadc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f003678-0f17-4f1d-87d5-83613a82044b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f003678-0f17-4f1d-87d5-83613a82044b.jpg?1",
             "name": "Havoc Devils",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "71339529-1346-5a9c-a80e-bd4ec1b5f8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6d0a11-3a9c-4de0-9a46-06d2b9356eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6d0a11-3a9c-4de0-9a46-06d2b9356eb7.jpg?1",
             "name": "Hostile Minotaur",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -4963,7 +4963,7 @@
         },
         {
             "id": "54025c90-9ebf-5a00-9a72-45e5a2d45f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd11004-5b8f-4c71-bde0-eb75eed869b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd11004-5b8f-4c71-bde0-eb75eed869b0.jpg?1",
             "name": "Inferno Hellion",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nAt the beginning of each end step, if Inferno Hellion attacked or blocked this turn, its owner shuffles it into their library.",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "251fe70c-bd09-5a20-9811-1db3357ef141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4c37d-5eeb-42c9-9688-c2ed0d5044cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4c37d-5eeb-42c9-9688-c2ed0d5044cd.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "Flying\nWhenever another nontoken Dragon enters the battlefield under your control, create a 5/5 red Dragon creature token with flying.\n{1}{R}: Dragons you control get +1/+0 until end of turn.",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "cb5046b2-26f0-51c3-9acc-094d46bf985d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dab325-8f4f-4288-9f3f-960e52b4335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dab325-8f4f-4288-9f3f-960e52b4335b.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player or planeswalker.",
             "colours": [
@@ -5065,7 +5065,7 @@
         },
         {
             "id": "63e5f984-ae97-5038-8663-8bca44998e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca822a3-4793-4cbc-a2f3-f43985e7ce8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca822a3-4793-4cbc-a2f3-f43985e7ce8f.jpg?1",
             "name": "Lightning Mare",
             "text": "This spell can't be countered.\nLightning Mare can't be blocked by blue creatures.\n{1}{R}: Lightning Mare gets +1/+0 until end of turn.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "65637b74-b4da-5224-80f4-d09cee94e55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7337-c06f-4cbf-8fc0-0b20c221f1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7337-c06f-4cbf-8fc0-0b20c221f1dc.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to any target.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "d65447d0-3f36-5c71-aaba-53a0afed3f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e016da6-8800-47b4-9b96-1887677c795c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e016da6-8800-47b4-9b96-1887677c795c.jpg?1",
             "name": "Onakke Ogre",
             "text": "",
             "colours": [
@@ -5167,7 +5167,7 @@
         },
         {
             "id": "9494e4d2-25c5-57e2-86a4-a7c07afef211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553a70e-75de-4a8c-9b20-92cd4a317101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553a70e-75de-4a8c-9b20-92cd4a317101.jpg?1",
             "name": "Sarkhan, Fireblood",
             "text": "+1: You may discard a card. If you do, draw a card.\n+1: Add two mana in any combination of colors. Spend this mana only to cast Dragon spells.\n\u22127: Create four 5/5 red Dragon creature tokens with flying.",
             "colours": [
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "22353ec3-d531-5af7-9edf-7eca0abb62a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa8c8c-8013-46d5-8e80-3d9285fe81c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa8c8c-8013-46d5-8e80-3d9285fe81c8.jpg?1",
             "name": "Sarkhan's Unsealing",
             "text": "Whenever you cast a creature spell with power 4, 5, or 6, Sarkhan's Unsealing deals 4 damage to any target.\nWhenever you cast a creature spell with power 7 or greater, Sarkhan's Unsealing deals 4 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -5235,7 +5235,7 @@
         },
         {
             "id": "21da9955-4e13-5ce1-9576-028242004305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5a0e1e-5239-41f3-a63f-d9303b1b01fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5a0e1e-5239-41f3-a63f-d9303b1b01fc.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5267,7 +5267,7 @@
         },
         {
             "id": "240ca80d-f233-5a9e-937d-914e6220469e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede2b911-8eec-4993-ab1c-59b55dfb11b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede2b911-8eec-4993-ab1c-59b55dfb11b4.jpg?1",
             "name": "Siegebreaker Giant",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n{3}{R}: Target creature can't block this turn.",
             "colours": [
@@ -5302,7 +5302,7 @@
         },
         {
             "id": "69bfe778-ac67-5d98-b442-ba2f96b6df6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a13293d-89a7-400c-8309-9f62eeb4769c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a13293d-89a7-400c-8309-9f62eeb4769c.jpg?1",
             "name": "Smelt",
             "text": "Destroy target artifact.",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "7a99cfdb-0f1d-5c4d-8302-699a5113bfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0dbc86-cc12-49e7-9721-dd52b35efcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc0dbc86-cc12-49e7-9721-dd52b35efcbe.jpg?1",
             "name": "Sparktongue Dragon",
             "text": "Flying\nWhen Sparktongue Dragon enters the battlefield, you may pay {2}{R}. When you do, it deals 3 damage to any target.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "b3b3191d-aacb-55cc-9362-e429d877eaf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94df6198-10c0-44e7-8226-dc96d12957c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94df6198-10c0-44e7-8226-dc96d12957c4.jpg?1",
             "name": "Spit Flame",
             "text": "Spit Flame deals 4 damage to target creature.\nWhenever a Dragon enters the battlefield under your control, you may pay {R}. If you do, return Spit Flame from your graveyard to your hand.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "1e91fd4a-e4e3-5232-aebe-aa37193c884d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e618ab0-b092-499c-b5e9-d374433ff19c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e618ab0-b092-499c-b5e9-d374433ff19c.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5432,7 +5432,7 @@
         },
         {
             "id": "e315c8b1-35e4-527f-b688-f8017dd7cc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b4db74-0c34-442f-a3f9-38194a75ef7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b4db74-0c34-442f-a3f9-38194a75ef7b.jpg?1",
             "name": "Tectonic Rift",
             "text": "Destroy target land. Creatures without flying can't block this turn.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "72efc907-9c41-5b44-977d-531726b1c4a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bed78a-c579-424a-8fcc-322ce2630dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11bed78a-c579-424a-8fcc-322ce2630dbc.jpg?1",
             "name": "Thud",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nThud deals damage equal to the sacrificed creature's power to any target.",
             "colours": [
@@ -5496,7 +5496,7 @@
         },
         {
             "id": "2b41479f-cbb3-50bf-b0f8-bcd915f692bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dbbc83-5549-480f-bf98-da90495d2a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dbbc83-5549-480f-bf98-da90495d2a29.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "72357ee9-5ef3-5bf5-9426-f9879abef3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c676a5b0-bd46-46b3-b71b-a50b86c9b0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c676a5b0-bd46-46b3-b71b-a50b86c9b0bd.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "f4935829-ca79-5b18-9177-589cdd93ec27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82fdb2f-b199-44ff-9615-90fc074cb8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a82fdb2f-b199-44ff-9615-90fc074cb8b0.jpg?1",
             "name": "Viashino Pyromancer",
             "text": "When Viashino Pyromancer enters the battlefield, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "e1996af7-2bb5-5a57-a7ad-7b56eda93969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade02a6b-0025-418b-8e20-0eb538fd66b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade02a6b-0025-418b-8e20-0eb538fd66b1.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "fde7c3ea-ec9b-5d5f-9e52-b3ffdd69ed9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164960fc-6e80-4a53-90d7-5a18c0a28083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164960fc-6e80-4a53-90d7-5a18c0a28083.jpg?1",
             "name": "Volley Veteran",
             "text": "When Volley Veteran enters the battlefield, it deals damage to target creature an opponent controls equal to the number of Goblins you control.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "6536c1cd-ba12-5ff8-8c7c-3dd9ece61500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b01d243-9f68-47c7-980b-1418e5f2f3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b01d243-9f68-47c7-980b-1418e5f2f3e9.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
             "colours": [
@@ -5698,7 +5698,7 @@
         },
         {
             "id": "d2b1cdc4-449c-54d4-821c-4d905cee13ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999030b2-2f91-4c45-981f-acdbbf9034af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999030b2-2f91-4c45-981f-acdbbf9034af.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -5732,7 +5732,7 @@
         },
         {
             "id": "ce4568da-ea07-5288-8107-f90eb5808374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6eb55-4bf9-4418-b667-a9a761f91ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae6eb55-4bf9-4418-b667-a9a761f91ef9.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "b1d2c9e1-1570-58c8-a96f-df26c5fb8e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d4ce4f-8255-419b-9e7f-544d9798e5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d4ce4f-8255-419b-9e7f-544d9798e5c8.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "af5e083c-b044-5e46-9d86-c2de575764f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99796-ddc5-4ccd-b925-35622a8648b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99796-ddc5-4ccd-b925-35622a8648b8.jpg?1",
             "name": "Colossal Majesty",
             "text": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
             "colours": [
@@ -5833,7 +5833,7 @@
         },
         {
             "id": "ab7ef3d0-82f5-59f2-99c3-f37b057c9dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc8325b-c7a8-49a5-8a54-a419800ffb93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc8325b-c7a8-49a5-8a54-a419800ffb93.jpg?1",
             "name": "Daggerback Basilisk",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "e1a488b9-c3ca-567c-abd1-61bd19a21e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78271f34-f62e-4771-b430-b121097b8fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78271f34-f62e-4771-b430-b121097b8fb6.jpg?1",
             "name": "Declare Dominance",
             "text": "Target creature gets +3/+3 until end of turn. All creatures able to block it this turn do so.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "7cecd90a-080b-5dd7-aa45-753e19cb3f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ca91ea-dffd-44a9-a54a-c664d83c357b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ca91ea-dffd-44a9-a54a-c664d83c357b.jpg?1",
             "name": "Druid of Horns",
             "text": "Whenever you cast an Aura spell that targets Druid of Horns, create a 3/3 green Beast creature token.",
             "colours": [
@@ -5934,7 +5934,7 @@
         },
         {
             "id": "920924fa-3504-599e-9f90-16485ed58e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ceff1d-9e83-41cc-b54b-8bf90d985da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ceff1d-9e83-41cc-b54b-8bf90d985da9.jpg?1",
             "name": "Druid of the Cowl",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "9b630815-2ad9-527d-b6b1-d3f90e53f3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30171803-1e7b-430b-a0de-2dfd2f1115ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30171803-1e7b-430b-a0de-2dfd2f1115ac.jpg?1",
             "name": "Dryad Greenseeker",
             "text": "{T}: Look at the top card of your library. If it's a land card, you may reveal it and put it into your hand.",
             "colours": [
@@ -6003,7 +6003,7 @@
         },
         {
             "id": "e1bffd10-4fdb-5cab-ad5b-3379ab239242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3b0bc-84da-4b85-992b-d0700c97157c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3b0bc-84da-4b85-992b-d0700c97157c.jpg?1",
             "name": "Elvish Clancaller",
             "text": "Other Elves you control get +1/+1.\n{4}{G}{G}, {T}: Search your library for a card named Elvish Clancaller, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6038,7 +6038,7 @@
         },
         {
             "id": "8331fca5-00c8-520a-b680-460981c26ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0299b00-b16c-4e7d-b67a-ec160ea81a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0299b00-b16c-4e7d-b67a-ec160ea81a54.jpg?1",
             "name": "Elvish Rejuvenator",
             "text": "When Elvish Rejuvenator enters the battlefield, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6073,7 +6073,7 @@
         },
         {
             "id": "e6716189-7ecd-538a-a67e-81a57258e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d470e441-3520-4669-aaa5-f0c57829352a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d470e441-3520-4669-aaa5-f0c57829352a.jpg?1",
             "name": "Ghastbark Twins",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nGhastbark Twins can block an additional creature each combat.",
             "colours": [
@@ -6107,7 +6107,7 @@
         },
         {
             "id": "ca2812a8-b53e-50d8-9de9-fe65cac482a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06582256-37d4-442d-b452-9cd93d285d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06582256-37d4-442d-b452-9cd93d285d2f.jpg?1",
             "name": "Ghirapur Guide",
             "text": "{2}{G}: Target creature you control can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -6142,7 +6142,7 @@
         },
         {
             "id": "43339ee9-4e00-5e14-8cf9-7571df93a62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80996b0d-cd44-445e-96de-677e0018255c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80996b0d-cd44-445e-96de-677e0018255c.jpg?1",
             "name": "Giant Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6176,7 +6176,7 @@
         },
         {
             "id": "4132024e-f758-53eb-9399-d1cd22b610aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0338075-5e84-4a37-957a-9cf23ac261ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0338075-5e84-4a37-957a-9cf23ac261ab.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "ef1f8e94-3ec2-5278-8023-a339f7a2fd9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db84d8-d426-4c0d-b44e-5be7b0f5f5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1db84d8-d426-4c0d-b44e-5be7b0f5f5bf.jpg?1",
             "name": "Gigantosaurus",
             "text": "",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "d9cbb87f-1437-5fcd-a7dd-dbefc169bcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d4574a-3266-4497-b145-fb25820d8a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d4574a-3266-4497-b145-fb25820d8a7f.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "Creature spells you cast with power 4 or greater cost {2} less to cast.\nWhenever Goreclaw, Terror of Qal Sisma attacks, each creature you control with power 4 or greater gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "f271e2e6-b77f-5a67-94f6-dc1c4a7392ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eebdd18-6930-42e0-b589-fe15820db6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eebdd18-6930-42e0-b589-fe15820db6e1.jpg?1",
             "name": "Greenwood Sentinel",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "3b43311d-89f7-52da-b8c5-70c8b7199fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec59964-42c1-4c29-8c60-37b7f376c347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec59964-42c1-4c29-8c60-37b7f376c347.jpg?1",
             "name": "Highland Game",
             "text": "When Highland Game dies, you gain 2 life.",
             "colours": [
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "9dde01bc-c6a7-526d-a2e3-3d60c8384a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84127b83-e75a-4f12-92ca-46f50bb89699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84127b83-e75a-4f12-92ca-46f50bb89699.jpg?1",
             "name": "Hungering Hydra",
             "text": "Hungering Hydra enters the battlefield with X +1/+1 counters on it.\nHungering Hydra can't be blocked by more than one creature.\nWhenever Hungering Hydra is dealt damage, put that many +1/+1 counters on it. (It must survive the damage to get the counters.)",
             "colours": [
@@ -6383,7 +6383,7 @@
         },
         {
             "id": "df3a3b28-1427-556d-a6a7-bcd6385c9bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c40ba-2464-44ae-8d67-93c72ab3c425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/390c40ba-2464-44ae-8d67-93c72ab3c425.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6415,7 +6415,7 @@
         },
         {
             "id": "37dd0a64-6dbf-59d0-8f24-598b93ec1074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf71f42-6e42-46c0-9e8f-394d2c4519ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf71f42-6e42-46c0-9e8f-394d2c4519ee.jpg?1",
             "name": "Oakenform",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "1a0224a8-027a-543d-9176-7963af211a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00906b47-6316-4e00-bbf5-b801ab583f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00906b47-6316-4e00-bbf5-b801ab583f4f.jpg?1",
             "name": "Pelakka Wurm",
             "text": "Trample\nWhen Pelakka Wurm enters the battlefield, you gain 7 life.\nWhen Pelakka Wurm dies, draw a card.",
             "colours": [
@@ -6483,7 +6483,7 @@
         },
         {
             "id": "c8d83099-2b70-5d6e-a8eb-a822d817efdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a29ddb-fc76-407a-aa58-ec92d011bd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a29ddb-fc76-407a-aa58-ec92d011bd44.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "22af3431-122c-581a-a352-fe1178840696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg?1",
             "name": "Prodigious Growth",
             "text": "Enchant creature\nEnchanted creature gets +7/+7 and has trample.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "1caf6913-815b-5d1c-b6fb-4f128bec0339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe53385-d63f-4d07-94ed-3ea5a48c79c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe53385-d63f-4d07-94ed-3ea5a48c79c8.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6581,7 +6581,7 @@
         },
         {
             "id": "e141be0a-39ed-56ef-b9f0-81e547deb4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2951026c-69bb-4ffc-a24f-b0795a12aa79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2951026c-69bb-4ffc-a24f-b0795a12aa79.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -6616,7 +6616,7 @@
         },
         {
             "id": "2a34034e-c6be-5bb6-9c85-554dc7485c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f127214f-3e91-4988-b593-1568d0ae1718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f127214f-3e91-4988-b593-1568d0ae1718.jpg?1",
             "name": "Recollect",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -6648,7 +6648,7 @@
         },
         {
             "id": "ed235369-8a97-5fae-be80-1782306fe61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f04d5-af45-4494-ac11-a605d3a06643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f04d5-af45-4494-ac11-a605d3a06643.jpg?1",
             "name": "Rhox Oracle",
             "text": "When Rhox Oracle enters the battlefield, draw a card.",
             "colours": [
@@ -6683,7 +6683,7 @@
         },
         {
             "id": "96173b8b-302e-51a0-8495-c1e295f49ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b01fd2-139a-47ed-a8e3-021aa9c91b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b01fd2-139a-47ed-a8e3-021aa9c91b02.jpg?1",
             "name": "Root Snare",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -6715,7 +6715,7 @@
         },
         {
             "id": "524db2d7-f699-5287-b60b-b37f787aabe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b445a0f0-2cca-4223-bd27-940d2cb6d29c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b445a0f0-2cca-4223-bd27-940d2cb6d29c.jpg?1",
             "name": "Runic Armasaur",
             "text": "Whenever an opponent activates an ability of a creature or land that isn't a mana ability, you may draw a card.",
             "colours": [
@@ -6749,7 +6749,7 @@
         },
         {
             "id": "1d72c353-e7fa-59eb-ada6-e94f8868b316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175e21a3-00f7-4c51-8a8e-fbfd7089efda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175e21a3-00f7-4c51-8a8e-fbfd7089efda.jpg?1",
             "name": "Scapeshift",
             "text": "Sacrifice any number of lands. Search your library for up to that many land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "b4552ebd-bd49-5c0d-b238-b711787847e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffa2e83-bc78-4bde-9692-e5165c4ef63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffa2e83-bc78-4bde-9692-e5165c4ef63b.jpg?1",
             "name": "Talons of Wildwood",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)\n{2}{G}: Return Talons of Wildwood from your graveyard to your hand.",
             "colours": [
@@ -6815,7 +6815,7 @@
         },
         {
             "id": "76772427-8b4f-5f73-94b8-5399d795c18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812e942-eb78-48c8-857e-5f0ff1bd777b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812e942-eb78-48c8-857e-5f0ff1bd777b.jpg?1",
             "name": "Thorn Lieutenant",
             "text": "Whenever Thorn Lieutenant becomes the target of a spell or ability an opponent controls, create a 1/1 green Elf Warrior creature token.\n{5}{G}: Thorn Lieutenant gets +4/+4 until end of turn.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "fcfa637b-eb8a-5d81-9397-fdb6572de019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0f3812-bb6c-4d99-b505-9dfd84e3fd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0f3812-bb6c-4d99-b505-9dfd84e3fd95.jpg?1",
             "name": "Thornhide Wolves",
             "text": "",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "c028cf06-89b9-5458-9e82-64d16460f580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe574e49-723a-409b-9222-125eebb620ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe574e49-723a-409b-9222-125eebb620ff.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "ed739907-2e56-56ff-9086-959bd801223b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad8e5d-0c26-4588-8161-b22197715d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ad8e5d-0c26-4588-8161-b22197715d63.jpg?1",
             "name": "Vigilant Baloth",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "13b0f2a1-daa3-5e8d-abf5-f91438b8c2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9980835-cd32-4870-88df-c79cd5534968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9980835-cd32-4870-88df-c79cd5534968.jpg?1",
             "name": "Vine Mare",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nVine Mare can't be blocked by black creatures.",
             "colours": [
@@ -6985,7 +6985,7 @@
         },
         {
             "id": "529f85e6-ac3d-5125-88d5-75af9dbe573d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg?1",
             "name": "Vivien Reid",
             "text": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Destroy target artifact, enchantment, or creature with flying.\n\u22128: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "8494cb28-5b1c-58de-b2db-18bdc0c0742b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784c4711-223d-4b95-a163-87e57f87b8db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784c4711-223d-4b95-a163-87e57f87b8db.jpg?1",
             "name": "Vivien's Invocation",
             "text": "Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in a random order. When a creature is put onto the battlefield this way, it deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "c0d24bd8-f776-5f36-bab0-a78f9cd028ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327e768-d90d-4677-b4dd-10837ffe8be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327e768-d90d-4677-b4dd-10837ffe8be2.jpg?1",
             "name": "Wall of Vines",
             "text": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -7088,7 +7088,7 @@
         },
         {
             "id": "73a57b65-c23c-5d35-91a5-096d82759286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314bae2-4930-4f8a-8a52-853bc3feb88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5314bae2-4930-4f8a-8a52-853bc3feb88f.jpg?1",
             "name": "Aerial Engineer",
             "text": "As long as you control an artifact, Aerial Engineer gets +2/+0 and has flying.",
             "colours": [
@@ -7125,7 +7125,7 @@
         },
         {
             "id": "a330f8ef-791b-5790-a00e-52727a54e6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e90c638-d4b2-4243-bbc4-1cc10516c40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e90c638-d4b2-4243-bbc4-1cc10516c40f.jpg?1",
             "name": "Arcades, the Strategist",
             "text": "Flying, vigilance\nWhenever a creature with defender enters the battlefield under your control, draw a card.\nEach creature you control with defender assigns combat damage equal to its toughness rather than its power and can attack as though it didn't have defender.",
             "colours": [
@@ -7166,7 +7166,7 @@
         },
         {
             "id": "aa55a28b-519d-5532-abf6-5b74051967b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b9f9d7-a00d-4a90-9d7a-88ece10af328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b9f9d7-a00d-4a90-9d7a-88ece10af328.jpg?1",
             "name": "Brawl-Bash Ogre",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Brawl-Bash Ogre attacks, you may sacrifice another creature. If you do, Brawl-Bash Ogre gets +2/+2 until end of turn.",
             "colours": [
@@ -7203,7 +7203,7 @@
         },
         {
             "id": "2e5ac0dd-8760-5d1b-a054-2f19e48f62b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1de2c-1acc-47c8-9b5e-a9dae3da8a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c1de2c-1acc-47c8-9b5e-a9dae3da8a49.jpg?1",
             "name": "Chromium, the Mutable",
             "text": "Flash\nThis spell can't be countered.\nFlying\nDiscard a card: Until end of turn, Chromium, the Mutable becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.",
             "colours": [
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "84987c4d-70bf-5b40-be9e-30995c581d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a353510a-30de-4891-97b9-d7d556531c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a353510a-30de-4891-97b9-d7d556531c41.jpg?1",
             "name": "Draconic Disciple",
             "text": "{T}: Add one mana of any color.\n{7}, {T}, Sacrifice Draconic Disciple: Create a 5/5 red Dragon creature token with flying.",
             "colours": [
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "61e8b50a-ac23-5e2d-8912-dcb101f7bf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0def77-3528-40fb-a6b2-c3d1e31ade65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0def77-3528-40fb-a6b2-c3d1e31ade65.jpg?1",
             "name": "Enigma Drake",
             "text": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -7317,7 +7317,7 @@
         },
         {
             "id": "cfbeedb7-5559-5c66-a3d1-38c462efd19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c35bf8-ae43-41aa-aae9-4d7513f9058c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c35bf8-ae43-41aa-aae9-4d7513f9058c.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste. (They can attack and {T} this turn.)",
             "colours": [
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "9efa7534-f267-5e96-8ec0-ed88dff97fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "Flying\nWhen Nicol Bolas, the Ravager enters the battlefield, each opponent discards a card.\n{4}{U}{B}{R}: Exile Nicol Bolas, the Ravager, then return him to the battlefield transformed under his owner's control. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "ef9380b4-bff3-5f44-96ba-c65042673190",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "+2: Draw two cards.\n\u22123: Nicol Bolas, the Arisen deals 10 damage to target creature or planeswalker.\n\u22124: Put target creature or planeswalker card from a graveyard onto the battlefield under your control.\n\u221212: Exile all but the bottom card of target player's library.",
             "colours": [
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "f535ef50-bf20-5581-b18b-029cf1a25881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663bd13-243e-4b8c-9ca8-158576b58803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663bd13-243e-4b8c-9ca8-158576b58803.jpg?1",
             "name": "Palladia-Mors, the Ruiner",
             "text": "Flying, vigilance, trample\nPalladia-Mors, the Ruiner has hexproof if it hasn't dealt damage yet.",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "a6abe853-76b2-57b1-b56b-5eaaa92c7311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e058ff8-043c-498b-8310-0ca45466ac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e058ff8-043c-498b-8310-0ca45466ac27.jpg?1",
             "name": "Poison-Tip Archer",
             "text": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever another creature dies, each opponent loses 1 life.",
             "colours": [
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "04492ba4-fb9f-5384-add2-843324a54806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3188e533-9a72-4a02-b169-a918f7c095ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3188e533-9a72-4a02-b169-a918f7c095ba.jpg?1",
             "name": "Psychic Symbiont",
             "text": "Flying\nWhen Psychic Symbiont enters the battlefield, target opponent discards a card and you draw a card.",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "88f1ef3e-5735-5712-95f9-c5239a20f243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a75d3a-58cb-4ee0-88d3-52099cb57ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a75d3a-58cb-4ee0-88d3-52099cb57ac3.jpg?1",
             "name": "Regal Bloodlord",
             "text": "Flying\nAt the beginning of each end step, if you gained life this turn, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -7584,7 +7584,7 @@
         },
         {
             "id": "62f5fc8b-9fd3-510a-a003-de1544d4c147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31c544f-a748-4180-8366-9bb1622bb99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31c544f-a748-4180-8366-9bb1622bb99d.jpg?1",
             "name": "Satyr Enchanter",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -7621,7 +7621,7 @@
         },
         {
             "id": "1864b0b6-9b08-565f-b35b-8cceb1fc5a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650461af-081b-4cc9-a140-865a666f1443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650461af-081b-4cc9-a140-865a666f1443.jpg?1",
             "name": "Skyrider Patrol",
             "text": "Flying\nAt the beginning of combat on your turn, you may pay {G}{U}. When you do, put a +1/+1 counter on another target creature you control, and that creature gains flying until end of turn.",
             "colours": [
@@ -7658,7 +7658,7 @@
         },
         {
             "id": "20012eae-b7fa-53d1-be08-24f37897cbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fdc00-21eb-48dc-966a-6b634dc5a2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fdc00-21eb-48dc-966a-6b634dc5a2c4.jpg?1",
             "name": "Vaevictis Asmadi, the Dire",
             "text": "Flying\nWhenever Vaevictis Asmadi, the Dire attacks, for each player, choose target permanent that player controls. Those players sacrifice those permanents. Each player who sacrificed a permanent this way reveals the top card of their library, then puts it onto the battlefield if it's a permanent card.",
             "colours": [
@@ -7699,7 +7699,7 @@
         },
         {
             "id": "3e53d792-2be0-51ae-9ef7-32e26ea4787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45ac8dc-281f-4257-9658-80af65a0295b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45ac8dc-281f-4257-9658-80af65a0295b.jpg?1",
             "name": "Amulet of Safekeeping",
             "text": "Whenever you become the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {1}.\nCreature tokens get -1/-0.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "418e4362-3f37-5d6b-a0ff-9d0b4f12d07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg?1",
             "name": "Arcane Encyclopedia",
             "text": "{3}, {T}: Draw a card.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "cd44eae4-8f2d-5e09-864d-216063583d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff0730-6dd9-42d2-be0d-655d04adf229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff0730-6dd9-42d2-be0d-655d04adf229.jpg?1",
             "name": "Chaos Wand",
             "text": "{4}, {T}: Target opponent exiles cards from the top of their library until they exile an instant or sorcery card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of that library in a random order.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "342e0244-f1c4-5618-b5eb-b1c65f37c0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28b35c-28a5-4042-b21d-6d43658a16eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28b35c-28a5-4042-b21d-6d43658a16eb.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play land cards from your graveyard.",
             "colours": [],
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "9d68d878-5799-54bc-b37c-569ba5306791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ce930-c100-4ef5-b75a-a18051282f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ce930-c100-4ef5-b75a-a18051282f8c.jpg?1",
             "name": "Desecrated Tomb",
             "text": "Whenever one or more creature cards leave your graveyard, create a 1/1 black Bat creature token with flying.",
             "colours": [],
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "7f7c784f-4a3b-5f89-b250-2748533db6ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg?1",
             "name": "Diamond Mare",
             "text": "As Diamond Mare enters the battlefield, choose a color.\nWhenever you cast a spell of the chosen color, you gain 1 life.",
             "colours": [],
@@ -7870,7 +7870,7 @@
         },
         {
             "id": "03a1c4d8-4f2d-5f98-a1a0-cfd86f9f73d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b441fc8-bc89-47d4-8745-2525aeb6d98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b441fc8-bc89-47d4-8745-2525aeb6d98d.jpg?1",
             "name": "Dragon's Hoard",
             "text": "Whenever a Dragon enters the battlefield under your control, put a gold counter on Dragon's Hoard.\n{T}, Remove a gold counter from Dragon's Hoard: Draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "18172752-219c-5e87-8015-391046992e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608f431b-a05c-4610-94f7-928d87b2c056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608f431b-a05c-4610-94f7-928d87b2c056.jpg?1",
             "name": "Explosive Apparatus",
             "text": "{3}, {T}, Sacrifice Explosive Apparatus: It deals 2 damage to any target.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "2f004bc8-a9b2-5242-9938-4988f97428cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148c1bf-84a2-48cd-882e-ad0fd74b8f0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e148c1bf-84a2-48cd-882e-ad0fd74b8f0f.jpg?1",
             "name": "Field Creeper",
             "text": "",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "32f1a8b6-0662-52d0-b77e-3326e95d3db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26894980-8961-4479-85dd-5f01c899718b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26894980-8961-4479-85dd-5f01c899718b.jpg?1",
             "name": "Fountain of Renewal",
             "text": "At the beginning of your upkeep, you gain 1 life.\n{3}, Sacrifice Fountain of Renewal: Draw a card.",
             "colours": [],
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "89895162-7996-5301-b32d-16d3595c9d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381e9f97-9655-4f41-9829-4ac26c2ed6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381e9f97-9655-4f41-9829-4ac26c2ed6ac.jpg?1",
             "name": "Gargoyle Sentinel",
             "text": "Defender (This creature can't attack.)\n{3}: Until end of turn, Gargoyle Sentinel loses defender and gains flying.",
             "colours": [],
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "cb6a17cc-7ccd-5c4d-83fd-25a7137ceb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d532b01-8bf7-4a27-a438-db03bcd00694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d532b01-8bf7-4a27-a438-db03bcd00694.jpg?1",
             "name": "Gearsmith Guardian",
             "text": "Gearsmith Guardian gets +2/+0 as long as you control a blue creature.",
             "colours": [],
@@ -8047,7 +8047,7 @@
         },
         {
             "id": "456eb0f6-e68a-59cf-80f3-fe7da03da7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1f24f-d910-4ec6-95d2-0ecaf9f051aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf1f24f-d910-4ec6-95d2-0ecaf9f051aa.jpg?1",
             "name": "Magistrate's Scepter",
             "text": "{4}, {T}: Put a charge counter on Magistrate's Scepter.\n{T}, Remove three charge counters from Magistrate's Scepter: Take an extra turn after this one.",
             "colours": [],
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "f472feb1-d8c3-55d1-affc-3cc4bcbffdd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfba61f-9a6d-43e3-ad28-f74f737ef186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfba61f-9a6d-43e3-ad28-f74f737ef186.jpg?1",
             "name": "Manalith",
             "text": "{T}: Add one mana of any color.",
             "colours": [],
@@ -8103,7 +8103,7 @@
         },
         {
             "id": "f8665bb6-235a-532f-a42e-38591e290b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ca16ee-e415-4270-a453-47111d07a07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ca16ee-e415-4270-a453-47111d07a07f.jpg?1",
             "name": "Marauder's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "84e02853-53da-5238-9cd5-8d8744c19085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb0b15-d651-4730-8be9-d0e01145311b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb0b15-d651-4730-8be9-d0e01145311b.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "d64a11c1-67c4-55ca-a0bc-cd9d78d5d07f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2051fd0-99cf-4e11-a625-8294e6767e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2051fd0-99cf-4e11-a625-8294e6767e5b.jpg?1",
             "name": "Millstone",
             "text": "{2}, {T}: Target player puts the top two cards of their library into their graveyard.",
             "colours": [],
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "9a9bff27-0a48-544b-9b91-2d2b9cc95b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c7d24-7d5c-49de-b9f8-35c6d6c8c52a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3c7d24-7d5c-49de-b9f8-35c6d6c8c52a.jpg?1",
             "name": "Rogue's Gloves",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8222,7 +8222,7 @@
         },
         {
             "id": "07eee774-c636-56e3-8f85-b9867a96517f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497d08a8-cffe-4164-a941-d8c8c85644c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497d08a8-cffe-4164-a941-d8c8c85644c7.jpg?1",
             "name": "Sigiled Sword of Valeron",
             "text": "Equipped creature gets +2/+0, has vigilance, and is a Knight in addition to its other types.\nWhenever equipped creature attacks, create a 2/2 white Knight creature token with vigilance that's attacking.\nEquip {3}",
             "colours": [],
@@ -8252,7 +8252,7 @@
         },
         {
             "id": "7f220924-70a0-51bb-aa93-0a2a20503bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2c1fb7-3c1d-49a9-b2c2-78ba2264df38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2c1fb7-3c1d-49a9-b2c2-78ba2264df38.jpg?1",
             "name": "Skyscanner",
             "text": "Flying\nWhen Skyscanner enters the battlefield, draw a card.",
             "colours": [],
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "a3f3a97c-966b-5ffc-a117-a58f8323ecfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf01421-856e-4cdd-8938-148928626f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf01421-856e-4cdd-8938-148928626f56.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender (This creature can't attack.)\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "e9638864-c7c7-5bda-83be-2717d9d85b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b06b670-7238-4732-85fd-ac6abebea57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b06b670-7238-4732-85fd-ac6abebea57f.jpg?1",
             "name": "Transmogrifying Wand",
             "text": "Transmogrifying Wand enters the battlefield with three charge counters on it.\n{1}, {T}, Remove a charge counter from Transmogrifying Wand: Destroy target creature. Its controller creates a 2/4 white Ox creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "9f7127ac-bee3-54bc-b6bd-318c7673968f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41b554-2bb1-4f11-be29-233d36cc955a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db41b554-2bb1-4f11-be29-233d36cc955a.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8373,7 +8373,7 @@
         },
         {
             "id": "fef2730f-319e-5448-9805-6f4c6ba67c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f99756-d334-4dba-a375-ba3d91ecae62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f99756-d334-4dba-a375-ba3d91ecae62.jpg?1",
             "name": "Detection Tower",
             "text": "{T}: Add {C}.\n{1}, {T}: Until end of turn, your opponents and creatures your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.",
             "colours": [],
@@ -8401,7 +8401,7 @@
         },
         {
             "id": "f9dd7c40-e24c-5796-a7ee-a1a345675991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b376c8c9-cd35-4c2b-8b5b-95ea9735b366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b376c8c9-cd35-4c2b-8b5b-95ea9735b366.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "935132cd-4c0f-56fb-be93-a7cf9af91add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28e1e1-0813-4e4a-a7a7-058b7787272c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28e1e1-0813-4e4a-a7a7-058b7787272c.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "140dbb87-9a89-5905-9c64-7ab543e19e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b538a465-81c6-4282-9ac3-061167ac7dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b538a465-81c6-4282-9ac3-061167ac7dc3.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "82e92054-7cdd-554b-a208-a2a1eb64cf78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47ee724-da0f-4eb1-b07b-b07e04e9f5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47ee724-da0f-4eb1-b07b-b07e04e9f5b3.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "2761f630-ae18-5a6f-9c58-f29571c9c077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81766fd6-c7e0-4527-a63e-512d126c0421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81766fd6-c7e0-4527-a63e-512d126c0421.jpg?1",
             "name": "Reliquary Tower",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -8553,7 +8553,7 @@
         },
         {
             "id": "8a44649a-b6fa-57f6-a9e8-2ef2c11f0df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7657f02-d1dd-448e-bc0d-c6f25fbc35ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7657f02-d1dd-448e-bc0d-c6f25fbc35ea.jpg?1",
             "name": "Rupture Spire",
             "text": "Rupture Spire enters the battlefield tapped.\nWhen Rupture Spire enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "7c2b7a31-0b33-5f96-952a-e8439a42893f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac2b853-f788-4b29-a76d-880da61ad91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac2b853-f788-4b29-a76d-880da61ad91a.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8612,7 +8612,7 @@
         },
         {
             "id": "dc5a596c-89f5-5636-bbba-8db49b4747bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8c56fa-fae6-48ba-813d-0d971b640896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df8c56fa-fae6-48ba-813d-0d971b640896.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "f76dc7c5-89f9-5133-9cde-3785851a0b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07076412-18fe-4e15-bdb5-17111b4a66db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07076412-18fe-4e15-bdb5-17111b4a66db.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8674,7 +8674,7 @@
         },
         {
             "id": "e84f073d-ee62-549c-928e-5e0e577f8830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b33867-5ccf-49a1-8e9b-9d2ddac78f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b33867-5ccf-49a1-8e9b-9d2ddac78f17.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "e5560fc8-f4d7-5aa2-9569-30b105d486be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303224d6-9769-4127-8e33-9129f337e2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303224d6-9769-4127-8e33-9129f337e2a8.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "91a179f3-d132-5ba6-887b-5c9d31b6422d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b55c1-d74b-4688-a3b8-8480d99524c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b55c1-d74b-4688-a3b8-8480d99524c7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8774,7 +8774,7 @@
         },
         {
             "id": "8fdfbcc3-59b6-5531-a4cc-13acc6c6137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2715553-ba9c-4753-9a1f-d13d8e2ed24f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2715553-ba9c-4753-9a1f-d13d8e2ed24f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8812,7 +8812,7 @@
         },
         {
             "id": "32625ebc-826a-5b05-b934-2fdea15ab6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1859ba05-06bc-4e80-8c0b-fd2475c6ca55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1859ba05-06bc-4e80-8c0b-fd2475c6ca55.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8850,7 +8850,7 @@
         },
         {
             "id": "4f286450-7a9f-509e-816f-37df000c55bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3645e11b-6b46-44c0-9741-f70da15692d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3645e11b-6b46-44c0-9741-f70da15692d1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8888,7 +8888,7 @@
         },
         {
             "id": "1bf5f701-d1af-5bb8-bac2-57f5f157138b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91890c11-b139-474d-b12d-6afd6b7e6aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91890c11-b139-474d-b12d-6afd6b7e6aee.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8926,7 +8926,7 @@
         },
         {
             "id": "5e84a95e-96d8-59ec-9e61-a053e8911916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c33392-c382-4e8b-812e-8b2c64cdbe8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c33392-c382-4e8b-812e-8b2c64cdbe8e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8964,7 +8964,7 @@
         },
         {
             "id": "101bdef2-4bec-5bc8-8708-a4f0b73a360b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42044efb-b6a8-46c3-90dc-b7a745e819e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42044efb-b6a8-46c3-90dc-b7a745e819e5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9002,7 +9002,7 @@
         },
         {
             "id": "242db6c0-6ed1-5ac4-95fe-eb3b6c01d802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a0c382-23c4-44a5-a689-1f65fed388b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a0c382-23c4-44a5-a689-1f65fed388b7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9040,7 +9040,7 @@
         },
         {
             "id": "6ae8aa9e-e235-50a5-8a20-6c70422e3a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfe9801-b683-45d9-924c-6734110816bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bfe9801-b683-45d9-924c-6734110816bf.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9078,7 +9078,7 @@
         },
         {
             "id": "d82c379a-48df-54d0-9e3f-d7fcf2de0851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430341f3-7dd5-4161-96a2-e76350699b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/430341f3-7dd5-4161-96a2-e76350699b66.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "82037bd0-ca47-5fdb-bce2-6f31912898a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8808d9dd-70c0-46ff-bd9c-dd60240dd121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8808d9dd-70c0-46ff-bd9c-dd60240dd121.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "63045ec0-153b-5e85-b6c5-2dc5d52fc871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7f974d-2634-4fc7-aa4e-bfeb6f3169ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7f974d-2634-4fc7-aa4e-bfeb6f3169ea.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9192,7 +9192,7 @@
         },
         {
             "id": "8fcb8548-81e9-5270-8c70-dc6a08478dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2030b-f622-4cc3-ac83-258ae3645fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f2030b-f622-4cc3-ac83-258ae3645fd6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9230,7 +9230,7 @@
         },
         {
             "id": "6eedbcd5-d9d1-5368-a019-0123b2b5792c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6457f78b-aca6-4ebf-9e89-bf9321ceb35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6457f78b-aca6-4ebf-9e89-bf9321ceb35d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9268,7 +9268,7 @@
         },
         {
             "id": "f21a107d-1709-530c-81f6-8b97e37b7dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedbe1f9-b29f-4bdd-9718-615b7c2413b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedbe1f9-b29f-4bdd-9718-615b7c2413b4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "7cc23225-7add-5af9-97a3-058f41e640d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4004c8-c3d9-494e-a257-6d8443cbf1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4004c8-c3d9-494e-a257-6d8443cbf1b7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9344,7 +9344,7 @@
         },
         {
             "id": "99ee8aee-6842-5b09-9d08-8dba59d4fe36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52ff177-bafe-4e0a-a6c3-2cf012b1319f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b52ff177-bafe-4e0a-a6c3-2cf012b1319f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9382,7 +9382,7 @@
         },
         {
             "id": "fddc5fdd-bc0f-58bc-8871-79dfc26684cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e46627-3cf3-4aca-97ba-80f9e919608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e46627-3cf3-4aca-97ba-80f9e919608c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9420,7 +9420,7 @@
         },
         {
             "id": "481dcf3d-daba-5072-b109-9c8cbe207959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32df22d3-9b65-4b43-80d9-e4c43575ec74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32df22d3-9b65-4b43-80d9-e4c43575ec74.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9458,7 +9458,7 @@
         },
         {
             "id": "18e082fd-d579-5309-aed2-d38c4ce6066f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cc8ba-ab54-46d3-9c3a-91678fd8d381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cc8ba-ab54-46d3-9c3a-91678fd8d381.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9496,7 +9496,7 @@
         },
         {
             "id": "f19f289e-38d5-5195-bbe6-9297b7680175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a22ecc-3a5c-44a1-bb52-bbeffa2dbf17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a22ecc-3a5c-44a1-bb52-bbeffa2dbf17.jpg?1",
             "name": "Ajani, Wise Counselor",
             "text": "+2: You gain 1 life for each creature you control.\n\u22123: Creatures you control get +2/+2 until end of turn.\n\u22129: Put X +1/+1 counters on target creature, where X is your life total.",
             "colours": [
@@ -9531,7 +9531,7 @@
         },
         {
             "id": "cc9f9dc5-54e4-5437-92d4-6121d880ac15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38ad178-35a5-44ad-b80a-d746f3e6a45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38ad178-35a5-44ad-b80a-d746f3e6a45c.jpg?1",
             "name": "Ajani's Influence",
             "text": "Put two +1/+1 counters on target creature.\nLook at the top five cards of your library. You may reveal a white card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9562,7 +9562,7 @@
         },
         {
             "id": "cae46171-5854-55aa-be95-0f49ccd4d12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2e1a93-4b5c-4f89-9e11-1693dee64b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2e1a93-4b5c-4f89-9e11-1693dee64b63.jpg?1",
             "name": "Court Cleric",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nCourt Cleric gets +1/+1 as long as you control an Ajani planeswalker.",
             "colours": [
@@ -9596,7 +9596,7 @@
         },
         {
             "id": "b3886033-c32b-5d6e-ab73-f939904ef39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1d95b9-aa18-41e2-b972-93fda25e0b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1d95b9-aa18-41e2-b972-93fda25e0b11.jpg?1",
             "name": "Serra's Guardian",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)\nOther creatures you control have vigilance.",
             "colours": [
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "da71714d-726a-5023-9276-689b3ff064ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b4c374-42a4-4912-8a74-a11c3fa0e065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b4c374-42a4-4912-8a74-a11c3fa0e065.jpg?1",
             "name": "Silverbeak Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "ba88ef72-2bdc-52c5-a94b-3b0a63f6fef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277dbeea-103c-4c5b-8981-3f5f7e60c66a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277dbeea-103c-4c5b-8981-3f5f7e60c66a.jpg?1",
             "name": "Tezzeret, Cruel Machinist",
             "text": "+1: Draw a card.\n0: Until your next turn, target artifact you control becomes a 5/5 creature in addition to its other types.\n\u22127: Put any number of cards from your hand onto the battlefield face down. They're 5/5 artifact creatures.",
             "colours": [
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "8d3de2c4-b886-5151-acfe-560ee7ce4c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037f6792-ab41-4bcd-a0a3-a4af4a801eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/037f6792-ab41-4bcd-a0a3-a4af4a801eb7.jpg?1",
             "name": "Riddlemaster Sphinx",
             "text": "Flying\nWhen Riddlemaster Sphinx enters the battlefield, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "1b3ba2d7-eb1b-50be-a77a-73a0d8d8046a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad452a4-be42-4d2f-a161-2b327f423b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad452a4-be42-4d2f-a161-2b327f423b9c.jpg?1",
             "name": "Pendulum of Patterns",
             "text": "When Pendulum of Patterns enters the battlefield, you gain 3 life.\n{5}, {T}, Sacrifice Pendulum of Patterns: Draw a card.",
             "colours": [],
@@ -9757,7 +9757,7 @@
         },
         {
             "id": "952b8a27-8adf-588c-8902-dd310c6a49af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584e0528-01c2-49fb-aa4a-098172bb17a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584e0528-01c2-49fb-aa4a-098172bb17a7.jpg?1",
             "name": "Tezzeret's Gatebreaker",
             "text": "When Tezzeret's Gatebreaker enters the battlefield, look at the top five cards of your library. You may reveal a blue or artifact card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n{5}{U}, {T}, Sacrifice Tezzeret's Gatebreaker: Creatures you control can't be blocked this turn.",
             "colours": [],
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "40947aad-7965-5c73-9b62-b87d22809c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf74535-31e3-4d2c-b42a-072580fa4ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf74535-31e3-4d2c-b42a-072580fa4ba0.jpg?1",
             "name": "Tezzeret's Strider",
             "text": "As long as you control a Tezzeret planeswalker, Tezzeret's Strider has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [],
@@ -9816,7 +9816,7 @@
         },
         {
             "id": "6c634c11-ac14-5715-9291-11245dbef4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2cbc2c-dbe3-4ecb-8fbe-785cb80b9e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2cbc2c-dbe3-4ecb-8fbe-785cb80b9e76.jpg?1",
             "name": "Liliana, the Necromancer",
             "text": "+1: Target player loses 2 life.\n\u22121: Return target creature card from your graveyard to your hand.\n\u22127: Destroy up to two target creatures. Put up to two creature cards from graveyards onto the battlefield under your control.",
             "colours": [
@@ -9851,7 +9851,7 @@
         },
         {
             "id": "5e25c2a3-a36f-5a70-8223-5b1aa87fa92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39502fd-193c-4526-8dd8-0cd8c822552c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39502fd-193c-4526-8dd8-0cd8c822552c.jpg?1",
             "name": "Arisen Gorgon",
             "text": "Arisen Gorgon has deathtouch as long as you control a Liliana planeswalker. (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -9885,7 +9885,7 @@
         },
         {
             "id": "f467af65-bf88-586b-8bbb-8dedb8fc4e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee347d62-867e-40c2-bf4a-0ac2f627e24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee347d62-867e-40c2-bf4a-0ac2f627e24c.jpg?1",
             "name": "Gravewaker",
             "text": "Flying\n{5}{B}{B}: Return target creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "15a8c192-340a-5383-8d63-335074ea3de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e960fb5a-70cc-490d-99cf-99bc65485cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e960fb5a-70cc-490d-99cf-99bc65485cfb.jpg?1",
             "name": "Liliana's Spoils",
             "text": "Target opponent discards a card.\nLook at the top five cards of your library. You may reveal a black card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9950,7 +9950,7 @@
         },
         {
             "id": "9c4b2d15-24a1-5855-9e5c-d32434a7b806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27ce41-69e7-4b86-9b9c-1a724d0728e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27ce41-69e7-4b86-9b9c-1a724d0728e9.jpg?1",
             "name": "Tattered Mummy",
             "text": "When Tattered Mummy dies, each opponent loses 2 life.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "a9321096-a3a5-58e4-9881-46170038ac2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59715c84-8eed-41ad-aaf9-cfcce4445254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59715c84-8eed-41ad-aaf9-cfcce4445254.jpg?1",
             "name": "Sarkhan, Dragonsoul",
             "text": "+2: Sarkhan, Dragonsoul deals 1 damage to each opponent and each creature your opponents control.\n\u22123: Sarkhan, Dragonsoul deals 4 damage to target player or planeswalker.\n\u22129: Search your library for any number of Dragon creature cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "af270220-0b76-596d-b453-e4c8a856524a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750304-c536-47d4-922d-a3654c37ffbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750304-c536-47d4-922d-a3654c37ffbc.jpg?1",
             "name": "Kargan Dragonrider",
             "text": "As long as you control a Dragon, Kargan Dragonrider has flying. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10053,7 +10053,7 @@
         },
         {
             "id": "405d731f-ef9a-5599-a730-9b51d68e4960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96a7320-089a-4a7e-813f-49ca1620df76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96a7320-089a-4a7e-813f-49ca1620df76.jpg?1",
             "name": "Sarkhan's Dragonfire",
             "text": "Sarkhan's Dragonfire deals 3 damage to any target.\nLook at the top five cards of your library. You may reveal a red card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10084,7 +10084,7 @@
         },
         {
             "id": "5017943d-c644-53da-a710-5125691e6d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07135c4d-b4de-4054-800a-11090ed32692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07135c4d-b4de-4054-800a-11090ed32692.jpg?1",
             "name": "Sarkhan's Whelp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever you activate an ability of a Sarkhan planeswalker, Sarkhan's Whelp deals 1 damage to any target.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "fd890cf5-a0d5-55f3-b510-55fe1368aeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d389b8db-5866-4146-a379-f24b6463622b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d389b8db-5866-4146-a379-f24b6463622b.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -10150,7 +10150,7 @@
         },
         {
             "id": "d1ef30b7-200d-50f4-9046-5fcc255858d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c185555-acd4-461a-821a-b21b7b0914a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c185555-acd4-461a-821a-b21b7b0914a5.jpg?1",
             "name": "Vivien of the Arkbow",
             "text": "+2: Put two +1/+1 counters on up to one target creature.\n\u22123: Target creature you control deals damage equal to its power to target creature you don't control.\n\u22129: Creatures you control get +4/+4 and gain trample until end of turn.",
             "colours": [
@@ -10185,7 +10185,7 @@
         },
         {
             "id": "032ae729-531d-509a-8e58-3bbc09538525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323f3c76-5e79-43e6-ae78-f555810edbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323f3c76-5e79-43e6-ae78-f555810edbc3.jpg?1",
             "name": "Aggressive Mammoth",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther creatures you control have trample.",
             "colours": [
@@ -10218,7 +10218,7 @@
         },
         {
             "id": "ed8801eb-adce-5831-9be7-3391c4e4e883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320e9f2-963d-468a-bf7a-726ef11e886d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320e9f2-963d-468a-bf7a-726ef11e886d.jpg?1",
             "name": "Skalla Wolf",
             "text": "When Skalla Wolf enters the battlefield, look at the top five cards of your library. You may reveal a green card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "35d27d78-63ff-5608-80c1-874a8baebb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60b6c02-c1f1-4ab9-bd62-ae3b447a898f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e60b6c02-c1f1-4ab9-bd62-ae3b447a898f.jpg?1",
             "name": "Ursine Champion",
             "text": "{5}{G}: Ursine Champion gets +3/+3 and becomes a Bear Berserker until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -10286,7 +10286,7 @@
         },
         {
             "id": "a01f0c66-1737-5922-b6f0-04dc9874b4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b406cf-738b-4e65-ac00-b1c36ded5f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b406cf-738b-4e65-ac00-b1c36ded5f96.jpg?1",
             "name": "Vivien's Jaguar",
             "text": "Reach (This creature can block creatures with flying.)\n{2}{G}: Return Vivien's Jaguar from your graveyard to your hand. Activate this ability only if you control a Vivien planeswalker.",
             "colours": [
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "f2b2679f-0d84-5602-8014-241725c94023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f163cfbf-6df6-4af5-9fe4-23b0d511586a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f163cfbf-6df6-4af5-9fe4-23b0d511586a.jpg?1",
             "name": "Nexus of Fate",
             "text": "Take an extra turn after this one.\nIf Nexus of Fate would be put into a graveyard from anywhere, reveal Nexus of Fate and shuffle it into its owner's library instead.",
             "colours": [
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "1cae284a-cf71-5705-af66-671db364be00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd0b4d6-9753-46a3-924c-2adf3dad2819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd0b4d6-9753-46a3-924c-2adf3dad2819.jpg?1",
             "name": "Sun Sentinel",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "4d0fff67-d6dd-54a5-b261-424da0b7789a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194d52c7-cdaf-49bc-ae32-350a526af239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194d52c7-cdaf-49bc-ae32-350a526af239.jpg?1",
             "name": "Air Elemental",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "d4379480-73c3-56f3-aea2-513f88dcd156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2115c3-aa6d-4c81-af55-5b740287b8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2115c3-aa6d-4c81-af55-5b740287b8aa.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -10449,7 +10449,7 @@
         },
         {
             "id": "3841e192-8dc5-5a21-a8f5-3e0fdd749cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574f73a7-9ff7-4ce3-9f56-002af968d35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574f73a7-9ff7-4ce3-9f56-002af968d35a.jpg?1",
             "name": "Mist-Cloaked Herald",
             "text": "Mist-Cloaked Herald can't be blocked.",
             "colours": [
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "8df0dc39-f72a-5c3f-9e68-451eea2f96ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e109e2-b8ff-47d0-a962-dc996c1656e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e109e2-b8ff-47d0-a962-dc996c1656e8.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -10516,7 +10516,7 @@
         },
         {
             "id": "a99c941b-0234-5da7-9e6d-3c3906c2aff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd574a9-2034-402c-9fd6-83c4b9db83d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd574a9-2034-402c-9fd6-83c4b9db83d1.jpg?1",
             "name": "Grasping Scoundrel",
             "text": "Grasping Scoundrel gets +1/+0 as long as it's attacking.",
             "colours": [
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "6527ad57-3614-5b55-ac81-ba53d5970ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9395fce4-11bf-4934-8323-5be4862c9779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9395fce4-11bf-4934-8323-5be4862c9779.jpg?1",
             "name": "Radiating Lightning",
             "text": "Radiating Lightning deals 3 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "9c74e719-0d75-56a3-8afc-1c2d542fb99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73542493-cd0b-4bb7-a5b8-8f889c76e4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73542493-cd0b-4bb7-a5b8-8f889c76e4d6.jpg?1",
             "name": "Llanowar Elves",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -10615,7 +10615,7 @@
         },
         {
             "id": "7966e532-da34-58bf-bbd3-2961f0e8de37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc31e017-81e6-43bf-bf8e-ea0faca5d9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc31e017-81e6-43bf-bf8e-ea0faca5d9b7.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -10649,7 +10649,7 @@
         },
         {
             "id": "98f2eb2d-8171-5396-8d00-e1563e07ddcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d08909-a214-433b-a3b7-4baf916cd458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d08909-a214-433b-a3b7-4baf916cd458.jpg?1",
             "name": "Core Set 2019 Checklist",
             "text": "",
             "colours": [],
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "09221971-b901-542c-a839-079950297c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f8f97-0c27-49d6-ae9a-a0fe2a7ce38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f8f97-0c27-49d6-ae9a-a0fe2a7ce38b.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "f87c31d2-4f52-54f5-9dab-6787fcaed895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -10744,7 +10744,7 @@
         },
         {
             "id": "eb1006a1-f909-5f3e-9810-9eb2213c4ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ca5ee-7b93-4248-8f4a-b88261ee1eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8ca5ee-7b93-4248-8f4a-b88261ee1eed.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -10778,7 +10778,7 @@
         },
         {
             "id": "2d7abecf-0830-5436-a81a-df51cd82f8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1d69f9-d9d7-47a9-9236-351f81ffa9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1d69f9-d9d7-47a9-9236-351f81ffa9ae.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -10812,7 +10812,7 @@
         },
         {
             "id": "ec5cc094-4b68-5646-a452-1fbc10c452c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07929ced-5c81-4b05-82e1-522fec1cf5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07929ced-5c81-4b05-82e1-522fec1cf5c0.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -10846,7 +10846,7 @@
         },
         {
             "id": "d6b17c7e-4dd6-5518-8f9b-575651d1aad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1349fcb-db31-4b1d-8063-e5c28b4472cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1349fcb-db31-4b1d-8063-e5c28b4472cc.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -10880,7 +10880,7 @@
         },
         {
             "id": "cf854a2a-2089-551a-8f99-1cf082580a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed08aac1-9e82-4049-9926-618f15222024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed08aac1-9e82-4049-9926-618f15222024.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -10914,7 +10914,7 @@
         },
         {
             "id": "2a011e54-7a5d-5059-8a10-3747237c6ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a5ec2-8898-4645-84d7-b7218682be9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43a5ec2-8898-4645-84d7-b7218682be9b.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -10948,7 +10948,7 @@
         },
         {
             "id": "6ac36883-a7fc-58ec-a0dd-e7f2f5438363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9eae0-2c0b-4225-8fa5-96f04a239d47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9eae0-2c0b-4225-8fa5-96f04a239d47.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "18a83d46-635f-5658-8ae9-9296d5d9ea77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f736760-60d5-412d-9877-753eb7b5f926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f736760-60d5-412d-9877-753eb7b5f926.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -11016,7 +11016,7 @@
         },
         {
             "id": "71b67905-6aed-5be8-a504-5ad9f23228b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832691a5-c638-481b-a413-3fdfc604a132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832691a5-c638-481b-a413-3fdfc604a132.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -11050,7 +11050,7 @@
         },
         {
             "id": "779d776f-7ebf-58b2-b886-64df927f86bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808b9201-6fc5-4613-85d6-6e66c6e36a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808b9201-6fc5-4613-85d6-6e66c6e36a8e.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -11085,7 +11085,7 @@
         },
         {
             "id": "1161e9df-c6ac-52a4-b867-3d3b8bf3ae8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0044cd9-2136-423e-aa2a-829e8f007535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0044cd9-2136-423e-aa2a-829e8f007535.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -11116,7 +11116,7 @@
         },
         {
             "id": "be0e87b4-77f4-5245-8c17-2258d9b75d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c97e5b2-a024-4aa7-a9b8-45f441aad138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c97e5b2-a024-4aa7-a9b8-45f441aad138.jpg?1",
             "name": "Ajani, Adversary of Tyrants Emblem",
             "text": "",
             "colours": [],
@@ -11145,7 +11145,7 @@
         },
         {
             "id": "bded6656-958c-5db6-85f0-a4137251923d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa83538-e94d-4842-ba9c-812187ecfa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa83538-e94d-4842-ba9c-812187ecfa0b.jpg?1",
             "name": "Tezzeret, Artifice Master Emblem",
             "text": "",
             "colours": [],
@@ -11174,7 +11174,7 @@
         },
         {
             "id": "b44e98da-44b0-59a6-a904-c9fdd643f0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf97003-eef0-4c01-aee1-8a8264d8ef95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf97003-eef0-4c01-aee1-8a8264d8ef95.jpg?1",
             "name": "Vivien Reid Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M20.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M20.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "431735d7-9961-546d-9513-8d3680a8eb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9c182-cbb3-4791-90dd-0e533ddeebda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9c182-cbb3-4791-90dd-0e533ddeebda.jpg?1",
             "name": "Aerial Assault",
             "text": "Destroy target tapped creature. You gain 1 life for each creature you control with flying.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "dcfdaecb-d1b7-5671-a4ba-1286ac0c21a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79883468-a37c-4894-8d05-6a4d150b7d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79883468-a37c-4894-8d05-6a4d150b7d59.jpg?1",
             "name": "Ajani, Strength of the Pride",
             "text": "+1: You gain life equal to the number of creatures you control plus the number of planeswalkers you control.\n\u22122: Create a 2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.\"\n0: If you have at least 15 life more than your starting life total, exile Ajani, Strength of the Pride and each artifact and creature your opponents control.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "08751dfc-cd35-59ea-886b-b8cbd7633b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba18114-af6c-48cd-82c9-eb6541d566bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba18114-af6c-48cd-82c9-eb6541d566bf.jpg?1",
             "name": "Ancestral Blade",
             "text": "When Ancestral Blade enters the battlefield, create a 1/1 white Soldier creature token, then attach Ancestral Blade to it.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "2f7267a2-2fc6-5466-b449-3654a5eb6fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f39777-b80a-4618-9310-a9e5b91bb2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f39777-b80a-4618-9310-a9e5b91bb2a2.jpg?1",
             "name": "Angel of Vitality",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nAngel of Vitality gets +2/+2 as long as you have 25 or more life.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "b6645784-7dc1-568a-b039-628d2da0d97d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35100197-7914-450e-9205-57cb4fc345d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35100197-7914-450e-9205-57cb4fc345d6.jpg?1",
             "name": "Angelic Gift",
             "text": "Enchant creature\nWhen Angelic Gift enters the battlefield, draw a card.\nEnchanted creature has flying.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "2b4b675b-6957-5288-9790-15286545b760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f69602-b5fd-46d6-8dae-d77df35e378c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f69602-b5fd-46d6-8dae-d77df35e378c.jpg?1",
             "name": "Apostle of Purifying Light",
             "text": "Protection from black (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything black.)\n{2}: Exile target card from a graveyard.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "055a4663-72d6-540b-85b7-6d9d749904df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db6393a-88b0-4973-9832-1482f69917ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db6393a-88b0-4973-9832-1482f69917ff.jpg?1",
             "name": "Battalion Foot Soldier",
             "text": "When Battalion Foot Soldier enters the battlefield, you may search your library for any number of cards named Battalion Foot Soldier, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "7cd1c389-210a-5370-8661-87bad052538e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca42da05-330d-4050-a580-dc00f6faff24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca42da05-330d-4050-a580-dc00f6faff24.jpg?1",
             "name": "Bishop of Wings",
             "text": "Whenever an Angel enters the battlefield under your control, you gain 4 life.\nWhenever an Angel you control dies, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "2bee79e0-1678-5d6f-9ab2-61bcf91c79d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecdc315-95e5-450c-bedc-998eea46cf8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecdc315-95e5-450c-bedc-998eea46cf8c.jpg?1",
             "name": "Brought Back",
             "text": "Choose up to two target permanent cards in your graveyard that were put there from the battlefield this turn. Return them to the battlefield tapped.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "b001fc2c-767b-5799-abfb-1ae982cf5146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b1919e-c0c1-4ac7-9061-a337b6fe7273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b1919e-c0c1-4ac7-9061-a337b6fe7273.jpg?1",
             "name": "Cavalier of Dawn",
             "text": "Vigilance\nWhen Cavalier of Dawn enters the battlefield, destroy up to one target nonland permanent. Its controller creates a 3/3 colorless Golem artifact creature token.\nWhen Cavalier of Dawn dies, return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "d30660ed-a90c-5845-86ca-d25bf9b56972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3d90ef-6f70-4897-85c1-4e1beeb33363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3d90ef-6f70-4897-85c1-4e1beeb33363.jpg?1",
             "name": "Dawning Angel",
             "text": "Flying\nWhen Dawning Angel enters the battlefield, you gain 4 life.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "e6c49af5-d688-5952-90ec-371baa1d892a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce89a0b-d0e4-4c71-b131-0d3b0b76bc3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce89a0b-d0e4-4c71-b131-0d3b0b76bc3b.jpg?1",
             "name": "Daybreak Chaplain",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "83f3e30a-247d-57e9-b864-d9d189ce352c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcde8fe-d4a4-4c6e-926e-c4a1b45045e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcde8fe-d4a4-4c6e-926e-c4a1b45045e4.jpg?1",
             "name": "Devout Decree",
             "text": "Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "4fa0ddcf-c8c4-592b-852c-f0670dbe9372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6a2b01-da95-46fa-8673-30ffdfdee0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6a2b01-da95-46fa-8673-30ffdfdee0a5.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "4d5571ef-68fc-5878-8eb0-e3d9e533b665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021963bf-87fc-432f-b9a1-4f627885a7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021963bf-87fc-432f-b9a1-4f627885a7a9.jpg?1",
             "name": "Eternal Isolation",
             "text": "Put target creature with power 4 or greater on the bottom of its owner's library.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "4c515a98-2f75-5fb7-befb-0a9591c6ff3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f54b57-9516-424a-86a3-54843efadb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f54b57-9516-424a-86a3-54843efadb0c.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "45d89a5f-bf65-5a9f-bc68-7ad795369fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d5436-b881-45ac-b8ec-248d88714021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d5436-b881-45ac-b8ec-248d88714021.jpg?1",
             "name": "Gauntlets of Light",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and assigns combat damage equal to its toughness rather than its power.\nEnchanted creature has \"{2}{W}: Untap this creature.\"",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "0e5e6a9b-718c-5f14-94f8-6ad582ba1664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa83dc2-4ec0-4e4f-8bfd-4f6d6df06a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa83dc2-4ec0-4e4f-8bfd-4f6d6df06a2d.jpg?1",
             "name": "Glaring Aegis",
             "text": "Enchant creature\nWhen Glaring Aegis enters the battlefield, tap target creature an opponent controls.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "99598aa7-08b1-5037-a490-71996e8c2f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90883bac-bcd8-4fa9-a17c-c2402fb0714e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90883bac-bcd8-4fa9-a17c-c2402fb0714e.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything of that color.)\nScry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "2974550e-a8df-591a-b21d-c34f7a67ce58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c32c4f2-4fa5-4874-8413-eac822121a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c32c4f2-4fa5-4874-8413-eac822121a0b.jpg?1",
             "name": "Griffin Protector",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "a5774e77-7412-5a43-b046-470d04803771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13aaa4-d40a-4fb2-9fd6-62bf76db6a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13aaa4-d40a-4fb2-9fd6-62bf76db6a13.jpg?1",
             "name": "Griffin Sentinel",
             "text": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "52c725a4-06f5-5d1f-9769-b827362aff71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d6cea1-83d1-4045-b4da-40560af86df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d6cea1-83d1-4045-b4da-40560af86df9.jpg?1",
             "name": "Hanged Executioner",
             "text": "Flying\nWhen Hanged Executioner enters the battlefield, create a 1/1 white Spirit creature token with flying.\n{3}{W}, Exile Hanged Executioner: Exile target creature.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "8d2ef763-d299-51dc-8f60-37673521cc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c62f724-7fb4-4498-b5c1-cf65d86d8e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c62f724-7fb4-4498-b5c1-cf65d86d8e95.jpg?1",
             "name": "Herald of the Sun",
             "text": "Flying\n{3}{W}: Put a +1/+1 counter on another target creature with flying.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "1b5670df-da15-569a-8d83-3ed6e53f3555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43479f67-57b2-4a99-8928-10fc9dde33b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43479f67-57b2-4a99-8928-10fc9dde33b9.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "85c32940-0055-5326-9103-e625449d94e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d14836-0ab4-4df3-a996-76b0dda23ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d14836-0ab4-4df3-a996-76b0dda23ff6.jpg?1",
             "name": "Inspiring Captain",
             "text": "When Inspiring Captain enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "f89368ce-de20-5828-b377-eb7de4bb3aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b1acf-dd87-42ca-ad19-c27d21066030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8b1acf-dd87-42ca-ad19-c27d21066030.jpg?1",
             "name": "Leyline of Sanctity",
             "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "fb0fd200-cd85-5066-9598-0f67144099b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19610e6d-61bf-4c79-bfb2-e855eb944d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19610e6d-61bf-4c79-bfb2-e855eb944d11.jpg?1",
             "name": "Loxodon Lifechanter",
             "text": "When Loxodon Lifechanter enters the battlefield, you may have your life total become the total toughness of creatures you control.\n{5}{W}: Loxodon Lifechanter gets +X/+X until end of turn, where X is your life total.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "0f9d7c08-2cd7-52c3-b581-196a14cc723d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae7971-953b-454a-84dd-ae2974946da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cae7971-953b-454a-84dd-ae2974946da9.jpg?1",
             "name": "Loyal Pegasus",
             "text": "Flying\nLoyal Pegasus can't attack or block alone.",
             "colours": [
@@ -950,7 +950,7 @@
         },
         {
             "id": "7b0af0f4-4115-5852-add0-aa7ad39e87df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e463146-40a7-4274-a5a6-adf71df05c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e463146-40a7-4274-a5a6-adf71df05c4f.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolems you control get +1/+1.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "e164a265-e173-5550-8a0f-7b704cb6209f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbc462b-3736-4441-96ee-8dc5615b4529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbc462b-3736-4441-96ee-8dc5615b4529.jpg?1",
             "name": "Moment of Heroism",
             "text": "Target creature gets +2/+2 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "c5d34f95-1670-5766-b824-c4d580d76cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b1446-7c9f-4b62-9877-e3d1060948aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b1446-7c9f-4b62-9877-e3d1060948aa.jpg?1",
             "name": "Moorland Inquisitor",
             "text": "{2}{W}: Moorland Inquisitor gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "51124b46-0a7b-5eed-a784-5593a12a6461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31279d7c-5246-40b2-a8c7-0be4a5f24a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31279d7c-5246-40b2-a8c7-0be4a5f24a29.jpg?1",
             "name": "Pacifism",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "18cb8331-ad67-518e-a4e9-bb483911ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eddac86-947e-48c1-9f02-4634a7918c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eddac86-947e-48c1-9f02-4634a7918c98.jpg?1",
             "name": "Planar Cleansing",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "f132a5cb-b9cc-5c02-9d01-55890124ceec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a7a53-314e-4b1f-aa33-0f312d06df71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a7a53-314e-4b1f-aa33-0f312d06df71.jpg?1",
             "name": "Raise the Alarm",
             "text": "Create two 1/1 white Soldier creature tokens.",
             "colours": [
@@ -1151,7 +1151,7 @@
         },
         {
             "id": "0004a4fb-92c6-59b2-bdbe-ceb584a9e401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f4e79b-b103-4380-afa0-61a2b1773c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f4e79b-b103-4380-afa0-61a2b1773c9e.jpg?1",
             "name": "Rule of Law",
             "text": "Each player can't cast more than one spell each turn.",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "b0ed1b16-2f51-5fe5-a0d8-558f06fb9155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95881b-8fbf-4d82-b631-5e4404ccc28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95881b-8fbf-4d82-b631-5e4404ccc28a.jpg?1",
             "name": "Sephara, Sky's Blade",
             "text": "You may pay {W} and tap four untapped creatures you control with flying rather than pay this spell's mana cost.\nFlying, lifelink\nOther creatures you control with flying have indestructible. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "7055553e-17d3-5ff4-95ae-cf15d208b824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b83ffd-bd08-48c6-98a3-811abc203f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b83ffd-bd08-48c6-98a3-811abc203f60.jpg?1",
             "name": "Soulmender",
             "text": "{T}: You gain 1 life.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "c173957a-8ee3-5851-bf44-71030982a8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7d6112-ffb2-41d8-98ed-1a7b22841dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7d6112-ffb2-41d8-98ed-1a7b22841dfd.jpg?1",
             "name": "Squad Captain",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nSquad Captain enters the battlefield with a +1/+1 counter on it for each other creature you control.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "0768c06e-5ff0-50ee-852b-5ef1e25bb8af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80382963-a9d7-4c2d-8671-8dd3fdd4dbdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80382963-a9d7-4c2d-8671-8dd3fdd4dbdc.jpg?1",
             "name": "Starfield Mystic",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Starfield Mystic.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "7fdb64c5-b115-5573-af0f-cd19f4093d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d92614e-05da-4b5c-a98b-addf8ab2de7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d92614e-05da-4b5c-a98b-addf8ab2de7b.jpg?1",
             "name": "Steadfast Sentry",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Steadfast Sentry dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "c4eeba01-481b-5fb6-bee2-b6a6e2a87241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73f186b-c897-4a98-bc25-8e4aa348d8c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73f186b-c897-4a98-bc25-8e4aa348d8c9.jpg?1",
             "name": "Yoked Ox",
             "text": "",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "cc97e2e9-2017-5d78-b770-17f73931b7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da808-6698-4e55-9fac-430a6effe2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da808-6698-4e55-9fac-430a6effe2b1.jpg?1",
             "name": "Aether Gust",
             "text": "Choose target spell or permanent that's red or green. Its owner puts it on the top or bottom of their library.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "dd0b2c75-2141-55b2-b92d-c8c962f4f693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6686e6-4535-49be-b0b3-e76464656cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6686e6-4535-49be-b0b3-e76464656cd2.jpg?1",
             "name": "Agent of Treachery",
             "text": "When Agent of Treachery enters the battlefield, gain control of target permanent.\nAt the beginning of your end step, if you control three or more permanents you don't own, draw three cards.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "7e3da5ec-3e56-5fc1-a2b5-f28fc7c9c4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27efec0-40c4-48bc-a21a-3af28a6529b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27efec0-40c4-48bc-a21a-3af28a6529b5.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "db17a20c-5c80-5d85-9aa0-ba840fc53d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2080556a-6c76-4819-9eb2-c4dd4c9dbd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2080556a-6c76-4819-9eb2-c4dd4c9dbd67.jpg?1",
             "name": "Anticipate",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "f4dd638b-1a79-58f4-a8b8-4d6752148093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f527d1-25c0-49b9-83d5-1278ca72d009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f527d1-25c0-49b9-83d5-1278ca72d009.jpg?1",
             "name": "Atemsis, All-Seeing",
             "text": "Flying\n{2}{U}, {T}: Draw two cards, then discard a card.\nWhenever Atemsis, All-Seeing deals damage to an opponent, you may reveal your hand. If cards with at least six different converted mana costs are revealed this way, that player loses the game.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "06a1e493-adc3-59f6-ae27-e4c23d45bd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1414939c-7f15-4eb3-abeb-6e75c52d2b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1414939c-7f15-4eb3-abeb-6e75c52d2b52.jpg?1",
             "name": "Befuddle",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "5aeadc61-d6ae-58b9-84c0-6eb9d0fe5d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dd873-af44-45eb-9b82-a3622cc58b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5dd873-af44-45eb-9b82-a3622cc58b35.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "4de2bf60-726d-50b8-ba61-3c1c5297d81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47996512-d547-491f-b481-a9c83dff04db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47996512-d547-491f-b481-a9c83dff04db.jpg?1",
             "name": "Boreal Elemental",
             "text": "Flying\nSpells your opponents cast that target Boreal Elemental cost {2} more to cast.",
             "colours": [
@@ -1660,7 +1660,7 @@
         },
         {
             "id": "cdf320ae-4c56-5db4-aca6-2730ab3bddc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0857765f-afd7-418a-a93b-c0bd1b1f037e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0857765f-afd7-418a-a93b-c0bd1b1f037e.jpg?1",
             "name": "Brineborn Cutthroat",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on Brineborn Cutthroat.",
             "colours": [
@@ -1695,7 +1695,7 @@
         },
         {
             "id": "c60d416b-3666-5ff5-b5d2-8b898f3924fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bd5c34-fa7e-4fa8-a5b1-c3aa928cc834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bd5c34-fa7e-4fa8-a5b1-c3aa928cc834.jpg?1",
             "name": "Captivating Gyre",
             "text": "Return up to three target creatures to their owners' hands.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "8266d33b-4f42-5e16-8294-18bca630403b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5356b11-e505-4838-aecb-327689eeead1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5356b11-e505-4838-aecb-327689eeead1.jpg?1",
             "name": "Cavalier of Gales",
             "text": "Flying\nWhen Cavalier of Gales enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.\nWhen Cavalier of Gales dies, shuffle it into its owner's library, then scry 2.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "a26b863c-a732-5ba8-ad23-2bd802066e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f9e7d-3f56-4e28-9908-157735f6dfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b11f9e7d-3f56-4e28-9908-157735f6dfa9.jpg?1",
             "name": "Cerulean Drake",
             "text": "Flying\nProtection from red (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything red.)\nSacrifice Cerulean Drake: Counter target spell that targets you.",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "54bd02d2-8a4c-59d1-b243-676d0bc6bf59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2111753-a930-403f-9d94-a86dfcb069da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2111753-a930-403f-9d94-a86dfcb069da.jpg?1",
             "name": "Cloudkin Seer",
             "text": "Flying\nWhen Cloudkin Seer enters the battlefield, draw a card.",
             "colours": [
@@ -1831,7 +1831,7 @@
         },
         {
             "id": "12b77048-ebad-51b2-99e8-c7dcaccf7a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a68347-c0ef-46ff-9705-6d82d004d32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a68347-c0ef-46ff-9705-6d82d004d32c.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "fced1181-6474-5ab9-a312-14a8dd71acf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677cd48-de9f-4827-94d7-8a2301945742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677cd48-de9f-4827-94d7-8a2301945742.jpg?1",
             "name": "Drawn from Dreams",
             "text": "Look at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "7e1d2d5e-1d69-5785-bd62-219f9c8b9257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c81fda-c23d-437c-85f0-62d7b492ea32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3c81fda-c23d-437c-85f0-62d7b492ea32.jpg?1",
             "name": "Dungeon Geists",
             "text": "Flying\nWhen Dungeon Geists enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Dungeon Geists.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "29ce6552-fec3-5317-8684-c5aff5a27c45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa0337-94bd-4274-b2ee-6f43747c77b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa0337-94bd-4274-b2ee-6f43747c77b3.jpg?1",
             "name": "Faerie Miscreant",
             "text": "Flying\nWhen Faerie Miscreant enters the battlefield, if you control another creature named Faerie Miscreant, draw a card.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "1f4c9e51-6723-57cb-8535-b851e9296220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3621820-4ab5-42bf-8a02-d5c066db4653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3621820-4ab5-42bf-8a02-d5c066db4653.jpg?1",
             "name": "Flood of Tears",
             "text": "Return all nonland permanents to their owners' hands. If you return four or more nontoken permanents you control this way, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "debd6eab-fddf-53a6-b433-76ec70561213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324681da-a28e-47ec-9810-5678de53e494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324681da-a28e-47ec-9810-5678de53e494.jpg?1",
             "name": "Fortress Crab",
             "text": "",
             "colours": [
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "4235b175-aa6c-5cd5-b51f-54f2aefd19da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59698a5-be76-4ce2-a337-9052821f239f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59698a5-be76-4ce2-a337-9052821f239f.jpg?1",
             "name": "Frilled Sea Serpent",
             "text": "{5}{U}{U}: Frilled Sea Serpent can't be blocked this turn.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "ec2341a2-291e-5344-924f-22fbce4944a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e1a5af-442f-4fcf-be99-6f62176be36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e1a5af-442f-4fcf-be99-6f62176be36c.jpg?1",
             "name": "Frost Lynx",
             "text": "When Frost Lynx enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "4fe60068-722c-5288-a445-9f3ff3a65779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c9f3a-534b-42d4-9765-8d1cb15375aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16c9f3a-534b-42d4-9765-8d1cb15375aa.jpg?1",
             "name": "Hard Cover",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and has \"{T}: Draw a card, then discard a card.\"",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "a1a6a517-5d25-586f-8a60-8fe69bd861f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b70152-1d7b-45c4-8c85-011d2338e0a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b70152-1d7b-45c4-8c85-011d2338e0a8.jpg?1",
             "name": "Leyline of Anticipation",
             "text": "If Leyline of Anticipation is in your opening hand, you may begin the game with it on the battlefield.\nYou may cast spells as though they had flash.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "5775cfb2-fcd4-50bc-9c4c-a4f37ae46069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63832647-bb4d-4380-8acb-cf11e8727672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63832647-bb4d-4380-8acb-cf11e8727672.jpg?1",
             "name": "Masterful Replication",
             "text": "Choose one \u2014\n\u2022 Create two 3/3 colorless Golem artifact creature tokens.\n\u2022 Choose target artifact you control. Each other artifact you control becomes a copy of that artifact until end of turn.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "c4fe943b-975b-570a-8972-3e46d96d3fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce74849-2e08-4d08-b387-4693f1b9f653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce74849-2e08-4d08-b387-4693f1b9f653.jpg?1",
             "name": "Metropolis Sprite",
             "text": "Flying\n{U}: Metropolis Sprite gets +1/-1 until end of turn.",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "64ceb3ee-315f-56fc-9ea6-b9f3f2d3a2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543b3f69-19be-494b-928f-e16b92560e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543b3f69-19be-494b-928f-e16b92560e35.jpg?1",
             "name": "Moat Piranhas",
             "text": "Defender (This creature can't attack.)",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "639c607a-d4bf-5328-bb67-06f9fc769912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0240f9eb-e1b2-4b41-94b0-b00ad2850825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0240f9eb-e1b2-4b41-94b0-b00ad2850825.jpg?1",
             "name": "Mu Yanling, Sky Dancer",
             "text": "+2: Until your next turn, up to one target creature gets -2/-0 and loses flying.\n\u22123: Create a 4/4 blue Elemental Bird creature token with flying.\n\u22128: You get an emblem with \"Islands you control have \u2018{T}: Draw a card.'\"",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "731cf37a-0993-50db-974c-ab0fc46a7e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b83158-78b4-425e-8379-be3ef038295c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b83158-78b4-425e-8379-be3ef038295c.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2334,7 +2334,7 @@
         },
         {
             "id": "f0011bae-5c2b-5437-922f-6c15ffda5680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13becea1-e745-4c96-bfc2-6a277fb60ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13becea1-e745-4c96-bfc2-6a277fb60ee1.jpg?1",
             "name": "Octoprophet",
             "text": "When Octoprophet enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "d608da39-83c7-5be4-89c4-cf00325a4e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c66692-2880-4ea2-abaf-8926c6950826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c66692-2880-4ea2-abaf-8926c6950826.jpg?1",
             "name": "Portal of Sanctuary",
             "text": "{1}, {T}: Return target creature you control and each Aura attached to it to their owners' hands. Activate this ability only during your turn.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "7e6f4425-906c-5d03-b028-3c949fd84a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec947bb8-8cb0-4e1e-8873-fe9bb9761e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec947bb8-8cb0-4e1e-8873-fe9bb9761e01.jpg?1",
             "name": "Renowned Weaponsmith",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\n{U}, {T}: Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2435,7 +2435,7 @@
         },
         {
             "id": "7d279f93-77d4-549e-ae2c-6c94f26f2e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ad3e3e-176b-48f0-af2f-fa4fc4759775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ad3e3e-176b-48f0-af2f-fa4fc4759775.jpg?1",
             "name": "Sage's Row Denizen",
             "text": "Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "97e91df4-b9a8-52ac-afcc-969ecd5589d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80137c9a-ea56-4dc7-a503-43fe192c8fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80137c9a-ea56-4dc7-a503-43fe192c8fce.jpg?1",
             "name": "Scholar of the Ages",
             "text": "When Scholar of the Ages enters the battlefield, return up to two target instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "734098f3-1179-5e26-96ea-6bff698f1250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2babef35-27ab-45aa-88cd-f21dccae5125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2babef35-27ab-45aa-88cd-f21dccae5125.jpg?1",
             "name": "Sleep Paralysis",
             "text": "Enchant creature\nWhen Sleep Paralysis enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "d8f31d72-81f6-5f63-b34b-77c0e74bd372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67483891-36d1-46f2-8b4f-b8b7bd54bdcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67483891-36d1-46f2-8b4f-b8b7bd54bdcc.jpg?1",
             "name": "Spectral Sailor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\n{3}{U}: Draw a card.",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "19a7509f-08ff-5d72-96ca-954e91677ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1421115b-9a98-4ab2-bcb2-7d8899ce12db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1421115b-9a98-4ab2-bcb2-7d8899ce12db.jpg?1",
             "name": "Tale's End",
             "text": "Counter target activated ability, triggered ability, or legendary spell.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "68d068a4-95fc-5957-bb5d-9912481f3afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a960516-3864-4a7a-8117-d25dec0dd665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a960516-3864-4a7a-8117-d25dec0dd665.jpg?1",
             "name": "Unsummon",
             "text": "Return target creature to its owner's hand.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "fca55f88-b8d3-569e-921a-eb5b7d27c2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0ec2d2-c004-4f6b-ba1c-29d81ad77fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0ec2d2-c004-4f6b-ba1c-29d81ad77fd1.jpg?1",
             "name": "Warden of Evos Isle",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "a3cf1142-454e-521a-a0e5-2455f145c603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765065-b160-49b6-99ac-cd695bd0d903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765065-b160-49b6-99ac-cd695bd0d903.jpg?1",
             "name": "Winged Words",
             "text": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "9a95e2ff-1b3f-5e07-b51f-1e8d14dcb4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a8974-df86-43ee-b07f-fd2837c08a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86a8974-df86-43ee-b07f-fd2837c08a6a.jpg?1",
             "name": "Yarok's Wavecrasher",
             "text": "When Yarok's Wavecrasher enters the battlefield, return another creature you control to its owner's hand.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "d148d421-9027-574b-ae54-28d5b829b180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da749962-25f2-4ddc-9e55-bf74d216284e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da749962-25f2-4ddc-9e55-bf74d216284e.jpg?1",
             "name": "Zephyr Charge",
             "text": "{1}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "ba47753d-523e-58ca-9e23-5670d7d58cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8efd95-1c2f-4dd1-b70b-3cfb10ff3a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8efd95-1c2f-4dd1-b70b-3cfb10ff3a28.jpg?1",
             "name": "Agonizing Syphon",
             "text": "Agonizing Syphon deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -2803,7 +2803,7 @@
         },
         {
             "id": "19159ba1-939b-5e73-8ecb-52f00f91389c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ff5e66-4718-43c3-8a58-1a0a8e788f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ff5e66-4718-43c3-8a58-1a0a8e788f83.jpg?1",
             "name": "Audacious Thief",
             "text": "Whenever Audacious Thief attacks, you draw a card and you lose 1 life.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "acd3c80f-9dc7-51fa-802d-8fc2d156cdde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0130d04-05f2-44f5-bd6c-8b11f798b69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0130d04-05f2-44f5-bd6c-8b11f798b69e.jpg?1",
             "name": "Barony Vampire",
             "text": "",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "dfb588e6-4ae0-5022-b014-d3ee3a693bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af78f76e-30cd-4939-9577-5a4bd1f93e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af78f76e-30cd-4939-9577-5a4bd1f93e63.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)\nDraw a card.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "c29b0b6f-083c-5425-ad89-629bec06e82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd43d44b-de27-4139-9cb8-b1f4c04fb87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd43d44b-de27-4139-9cb8-b1f4c04fb87e.jpg?1",
             "name": "Blightbeetle",
             "text": "Protection from green (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything green.)\nCreatures your opponents control can't have +1/+1 counters put on them.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "9837fd2e-8c98-548e-90e7-595b9899c995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01efd5af-ed6d-4132-8f33-37f6a9fa55d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01efd5af-ed6d-4132-8f33-37f6a9fa55d0.jpg?1",
             "name": "Blood Burglar",
             "text": "As long as it's your turn, Blood Burglar has lifelink.(Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "543b877f-daef-5476-a7d0-1e3489ed1ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7892b516-0dce-491f-8b42-031d64397e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7892b516-0dce-491f-8b42-031d64397e26.jpg?1",
             "name": "Blood for Bones",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nReturn a creature card from your graveyard to the battlefield, then return another creature card from your graveyard to your hand.",
             "colours": [
@@ -3005,7 +3005,7 @@
         },
         {
             "id": "a06ad7df-1a94-522e-928d-3ebc0e49c9f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9169431-a5b1-42ea-bcf4-6c750d2a2dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9169431-a5b1-42ea-bcf4-6c750d2a2dbb.jpg?1",
             "name": "Bloodsoaked Altar",
             "text": "{T}, Pay 2 life, Discard a card, Sacrifice a creature: Create a 5/5 black Demon creature token with flying. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "d42a67ec-1a88-582c-a5dd-ebf462843bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29156f28-38d8-4f65-b416-089f3fd97109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29156f28-38d8-4f65-b416-089f3fd97109.jpg?1",
             "name": "Bloodthirsty Aerialist",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on Bloodthirsty Aerialist.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "8862b8e7-2d6f-562d-b494-2a87bc05ee64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e75a7e9-902a-4733-8cd4-767247174a4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e75a7e9-902a-4733-8cd4-767247174a4c.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -3104,7 +3104,7 @@
         },
         {
             "id": "f2a1580d-9565-5110-90bc-1d8909f743ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9ed2b9-5fb9-4633-8c9a-0594ae7c49c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9ed2b9-5fb9-4633-8c9a-0594ae7c49c7.jpg?1",
             "name": "Boneclad Necromancer",
             "text": "When Boneclad Necromancer enters the battlefield, you may exile target creature card from a graveyard. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "75e92c47-bb31-579c-bf5e-cb4551b4e91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03109b9-54a8-4d68-97c2-e42c7d5c2d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03109b9-54a8-4d68-97c2-e42c7d5c2d41.jpg?1",
             "name": "Cavalier of Night",
             "text": "Lifelink\nWhen Cavalier of Night enters the battlefield, you may sacrifice another creature. When you do, destroy target creature an opponent controls.\nWhen Cavalier of Night dies, return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3174,7 +3174,7 @@
         },
         {
             "id": "4811381a-b1cf-5ed1-b8a4-15a1135f9a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18069340-a698-4f75-82cc-cc94fcf82184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18069340-a698-4f75-82cc-cc94fcf82184.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "dbaf2f58-7b36-54de-af2f-26f3d192c526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430db1a-5cad-4444-ba93-57fb32e65606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430db1a-5cad-4444-ba93-57fb32e65606.jpg?1",
             "name": "Dread Presence",
             "text": "Whenever a Swamp enters the battlefield under your control, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Dread Presence deals 2 damage to any target and you gain 2 life.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "78c2e6b4-c62a-5460-a3f4-dab0046b16f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41ff5c-9617-4033-a4fa-99323640b9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41ff5c-9617-4033-a4fa-99323640b9c3.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "6459ac30-a1fc-5b8c-a726-fd777645cfe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77972745-8689-4733-9a9d-39ae9d6273a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77972745-8689-4733-9a9d-39ae9d6273a2.jpg?1",
             "name": "Embodiment of Agonies",
             "text": "Flying, deathtouch\nEmbodiment of Agonies enters the battlefield with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard. (For example, {2}{B} and {1}{B}{B} are different mana costs.)",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "1abeffd9-3c8d-58ca-b9df-76b25fec0ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b060bc4-2d0c-46f4-b2b4-21583c2428f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b060bc4-2d0c-46f4-b2b4-21583c2428f2.jpg?1",
             "name": "Epicure of Blood",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "1f0df1bd-3429-54ed-b13b-88febe6b56b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a7004c-1952-41df-b645-b34bcbc3e401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a7004c-1952-41df-b645-b34bcbc3e401.jpg?1",
             "name": "Fathom Fleet Cutthroat",
             "text": "When Fathom Fleet Cutthroat enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "0b4881f0-a9af-58db-9a41-ea4bef5432b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2890cb5-7899-42f4-9686-a8b5ac796c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2890cb5-7899-42f4-9686-a8b5ac796c23.jpg?1",
             "name": "Feral Abomination",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3409,7 +3409,7 @@
         },
         {
             "id": "878df754-ece4-5ff3-8db3-97d61acc3f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cbe5f2-5b6b-41de-9586-c7cc83464cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cbe5f2-5b6b-41de-9586-c7cc83464cf2.jpg?1",
             "name": "Gorging Vulture",
             "text": "Flying\nWhen Gorging Vulture enters the battlefield, put the top four cards of your library into your graveyard. You gain 1 life for each creature card put into your graveyard this way.",
             "colours": [
@@ -3443,7 +3443,7 @@
         },
         {
             "id": "c9e64918-a339-5866-9a4e-d1f08d422089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb714a0-e61b-4ccf-8de6-3a6bf87c8315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb714a0-e61b-4ccf-8de6-3a6bf87c8315.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "65013578-0efd-594e-9395-636956b93a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffbb50e-76ca-4bfd-b6d1-95ab8cf3bbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffbb50e-76ca-4bfd-b6d1-95ab8cf3bbf8.jpg?1",
             "name": "Gruesome Scourger",
             "text": "When Gruesome Scourger enters the battlefield, it deals damage to target opponent or planeswalker equal to the number of creatures you control.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "7d2bc4d2-fb15-5767-b8c8-6ec4812f9959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29425426-7bf2-4872-aa35-c12c22801edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29425426-7bf2-4872-aa35-c12c22801edd.jpg?1",
             "name": "Knight of the Ebon Legion",
             "text": "{2}{B}: Knight of the Ebon Legion gets +3/+3 and gains deathtouch until end of turn.\nAt the beginning of your end step, if a player lost 4 or more life this turn, put a +1/+1 counter on Knight of the Ebon Legion. (Damage causes loss of life.)",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "6a0ea842-c04f-5765-9a57-4b0ba203e046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a1cd92-9d75-4e22-a934-a26d84967015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a1cd92-9d75-4e22-a934-a26d84967015.jpg?1",
             "name": "Legion's End",
             "text": "Exile target creature an opponent controls with converted mana cost 2 or less and all other creatures that player controls with the same name as that creature. Then that player reveals their hand and exiles all cards with that name from their hand and graveyard.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "a56c7117-f92d-5f17-ac51-df38b46f3da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d5d429-e0c6-42cc-a477-da7dabb1c295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d5d429-e0c6-42cc-a477-da7dabb1c295.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3611,7 +3611,7 @@
         },
         {
             "id": "6ec57bb9-73ab-5d0e-b620-b08eb07bec62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de3feb-5f92-43eb-b5cf-00d2b511fe68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de3feb-5f92-43eb-b5cf-00d2b511fe68.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3643,7 +3643,7 @@
         },
         {
             "id": "312592b1-ded0-5c4c-814d-4be5aa71c285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b22bc-e81b-4f27-a52b-9f3edad25439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2b22bc-e81b-4f27-a52b-9f3edad25439.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3675,7 +3675,7 @@
         },
         {
             "id": "2039fba9-4482-55c6-b70b-7ecc4096abe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5758cc-1f84-455d-a983-8ec471727eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5758cc-1f84-455d-a983-8ec471727eaf.jpg?1",
             "name": "Noxious Grasp",
             "text": "Destroy target creature or planeswalker that's green or white. You gain 1 life.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "8fe4e796-97d0-5319-9f49-d108893649d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c61cb-dbf9-46c3-8795-8896ba1208d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c61cb-dbf9-46c3-8795-8896ba1208d5.jpg?1",
             "name": "Rotting Regisaur",
             "text": "At the beginning of your upkeep, discard a card.",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "0a2f85cd-f66d-5330-a9d5-314554f871a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6efdaf-bf1a-4776-8e4b-2970aa2ccd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6efdaf-bf1a-4776-8e4b-2970aa2ccd5a.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "04dd4c53-22ca-56cc-9bbb-6f40a80a7576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acc50b-856d-442d-9880-1a892b40643b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acc50b-856d-442d-9880-1a892b40643b.jpg?1",
             "name": "Scheming Symmetry",
             "text": "Choose two target players. Each of them searches their library for a card, then shuffles their library and puts that card on top of it.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "fd41578b-5e02-51fe-9e2e-a23084f51e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe9e325-fbe4-4f43-8d68-8525c4d5ce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe9e325-fbe4-4f43-8d68-8525c4d5ce8b.jpg?1",
             "name": "Sorcerer of the Fang",
             "text": "{5}{B}, {T}: Sorcerer of the Fang deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "77d443f7-0a96-5fdb-84db-aaf2db914e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764be3-dd3f-44b1-a4a6-807d1387590b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764be3-dd3f-44b1-a4a6-807d1387590b.jpg?1",
             "name": "Sorin, Imperious Bloodlord",
             "text": "+1: Target creature you control gains deathtouch and lifelink until end of turn. If it's a Vampire, put a +1/+1 counter on it.\n+1: You may sacrifice a Vampire. When you do, Sorin, Imperious Bloodlord deals 3 damage to any target and you gain 3 life.\n\u22123: You may put a Vampire creature card from your hand onto the battlefield.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "eadb8376-b491-5660-8b6f-82b136b9a139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9250f8-9085-4664-ada7-a2ef44deeac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9250f8-9085-4664-ada7-a2ef44deeac8.jpg?1",
             "name": "Soul Salvage",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "72a0b065-7e57-5b80-9a53-da08b01cec77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a9d636-6720-4d7e-8b81-12c20bce6495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a9d636-6720-4d7e-8b81-12c20bce6495.jpg?1",
             "name": "Thought Distortion",
             "text": "This spell can't be countered.\nTarget opponent reveals their hand. Exile all noncreature, nonland cards from that player's hand and graveyard.",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "ac252653-ebaa-5f7f-83f0-860f1142d650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbc0f7c-546f-4525-bb58-c99ab9b017d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbc0f7c-546f-4525-bb58-c99ab9b017d5.jpg?1",
             "name": "Undead Servant",
             "text": "When Undead Servant enters the battlefield, create a 2/2 black Zombie creature token for each card named Undead Servant in your graveyard.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "3e99571f-bfaa-5d86-9966-80c7a0dec2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e22edb-a815-413d-b62d-f32f8932b6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e22edb-a815-413d-b62d-f32f8932b6e6.jpg?1",
             "name": "Unholy Indenture",
             "text": "Enchant creature\nWhen enchanted creature dies, return that card to the battlefield under your control with a +1/+1 counter on it.",
             "colours": [
@@ -4011,7 +4011,7 @@
         },
         {
             "id": "32fbf642-6864-561f-bddf-4495208af5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c185b9-5d97-4a5a-af0b-8b9c44dcd235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c185b9-5d97-4a5a-af0b-8b9c44dcd235.jpg?1",
             "name": "Vampire of the Dire Moon",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "8c645b1e-671d-5047-9b63-7068924c498e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d405e1bc-bf58-4cce-8abe-57fb40ef0996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d405e1bc-bf58-4cce-8abe-57fb40ef0996.jpg?1",
             "name": "Vengeful Warchief",
             "text": "Whenever you lose life for the first time each turn, put a +1/+1 counter on Vengeful Warchief. (Damage causes loss of life.)",
             "colours": [
@@ -4080,7 +4080,7 @@
         },
         {
             "id": "5d53699e-bfa6-56d5-836d-439fd0854858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdf2bd9-87b9-470a-ad2e-0ebf98560f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdf2bd9-87b9-470a-ad2e-0ebf98560f87.jpg?1",
             "name": "Vilis, Broker of Blood",
             "text": "Flying\n{B}, Pay 2 life: Target creature gets -1/-1 until end of turn.\nWhenever you lose life, draw that many cards. (Damage causes loss of life.)",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "d5171138-eaef-5a1d-924c-29a232d66fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b122f8-fcd9-4b2a-92f6-f0ed7307ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16b122f8-fcd9-4b2a-92f6-f0ed7307ff58.jpg?1",
             "name": "Yarok's Fenlurker",
             "text": "When Yarok's Fenlurker enters the battlefield, each opponent exiles a card from their hand.\n{2}{B}: Yarok's Fenlurker gets +1/+1 until end of turn.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "27f4b8b2-e4df-570e-94d0-0018589a2395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20234668-53ce-4cc8-892f-30ee3ecfc34c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20234668-53ce-4cc8-892f-30ee3ecfc34c.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "3d08d245-104a-5d82-88d4-854aeb393c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c18c541-758b-4237-9961-9637e996e8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c18c541-758b-4237-9961-9637e996e8a5.jpg?1",
             "name": "Cavalier of Flame",
             "text": "{1}{R}: Creatures you control get +1/+0 and gain haste until end of turn.\nWhen Cavalier of Flame enters the battlefield, discard any number of cards, then draw that many cards.\nWhen Cavalier of Flame dies, it deals X damage to each opponent and each planeswalker they control, where X is the number of land cards in your graveyard.",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "6207e1e5-2e6d-5a76-b76e-4fa7fd3e9b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cabfcfe-012e-4cab-bba2-24052eac0946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cabfcfe-012e-4cab-bba2-24052eac0946.jpg?1",
             "name": "Chandra, Acolyte of Flame",
             "text": "0: Put a loyalty counter on each red planeswalker you control.\n0: Create two 1/1 red Elemental creature tokens. They gain haste. Sacrifice them at the beginning of the next end step.\n\u22122: You may cast target instant or sorcery card with converted mana cost 3 or less from your graveyard. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "a6225938-dffc-5e59-89a1-bf8125787394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d2a680-4f3b-4bfa-b77b-d2dfaced9f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d2a680-4f3b-4bfa-b77b-d2dfaced9f23.jpg?1",
             "name": "Chandra, Awakened Inferno",
             "text": "This spell can't be countered.\n+2: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n\u22123: Chandra, Awakened Inferno deals 3 damage to each non-Elemental creature.\n\u2212X: Chandra, Awakened Inferno deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "5d0e5e4f-0fee-5288-9d44-71d1691c6ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d678cf4c-60e3-40a1-a9cc-b0bd157bcf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d678cf4c-60e3-40a1-a9cc-b0bd157bcf36.jpg?1",
             "name": "Chandra, Novice Pyromancer",
             "text": "+1: Elementals you control get +2/+0 until end of turn.\n\u22121: Add {R}{R}.\n\u22122: Chandra, Novice Pyromancer deals 2 damage to any target.",
             "colours": [
@@ -4325,7 +4325,7 @@
         },
         {
             "id": "ff1482d8-6f1d-5edf-9835-cc29382fc8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f9c266-f32e-4483-9709-f83675331688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f9c266-f32e-4483-9709-f83675331688.jpg?1",
             "name": "Chandra's Embercat",
             "text": "{T}: Add {R}. Spend this mana only to cast an Elemental spell or a Chandra planeswalker spell.",
             "colours": [
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "908521f0-3203-5078-83f7-31cb890a1993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbfe793-6644-43ed-bbe1-e122c01c5e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbfe793-6644-43ed-bbe1-e122c01c5e53.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "f6e5982d-b907-56e3-8482-a89dedbe81b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b1d5c-f71e-4c68-8baf-c134e42ed6f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1b1d5c-f71e-4c68-8baf-c134e42ed6f2.jpg?1",
             "name": "Chandra's Regulator",
             "text": "Whenever you activate a loyalty ability of a Chandra planeswalker, you may pay {1}. If you do, copy that ability. You may choose new targets for the copy.\n{1}, {T}, Discard a Mountain card or a red card: Draw a card.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "344324d6-0a34-5f9b-a087-49138c066d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a857da7-5438-465b-821a-bd5bfd780c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a857da7-5438-465b-821a-bd5bfd780c69.jpg?1",
             "name": "Chandra's Spitfire",
             "text": "Flying\nWhenever an opponent is dealt noncombat damage, Chandra's Spitfire gets +3/+0 until end of turn.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "38c18480-20ba-5cb7-a4d7-50f78898658d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46b090-8b03-4498-840e-cf130510892c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a46b090-8b03-4498-840e-cf130510892c.jpg?1",
             "name": "Daggersail Aeronaut",
             "text": "As long as it's your turn, Daggersail Aeronaut has flying.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "64359c4f-a984-5135-9d52-7c591ac684e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d981b310-5e75-4f30-baf6-37f069f00aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d981b310-5e75-4f30-baf6-37f069f00aa3.jpg?1",
             "name": "Destructive Digger",
             "text": "{3}, {T}, Sacrifice an artifact or land: Draw a card.",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "49621d10-d617-543e-af30-36c68dfc49c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5195abc4-cfa7-45dd-aa96-2e56f818a17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5195abc4-cfa7-45dd-aa96-2e56f818a17b.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever Dragon Mage deals combat damage to a player, each player discards their hand, then draws seven cards.",
             "colours": [
@@ -4563,7 +4563,7 @@
         },
         {
             "id": "a5e59b58-95fe-59e4-9c7e-83b5ac297664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09af78f-efde-4107-8406-cb12fd11c686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d09af78f-efde-4107-8406-cb12fd11c686.jpg?1",
             "name": "Drakuseth, Maw of Flames",
             "text": "Flying\nWhenever Drakuseth, Maw of Flames attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "8e646d78-e770-58cf-aabb-e5e9d585b6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159d476e-2f20-4f9b-adfd-9c541dc3e199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/159d476e-2f20-4f9b-adfd-9c541dc3e199.jpg?1",
             "name": "Ember Hauler",
             "text": "{1}, Sacrifice Ember Hauler: It deals 2 damage to any target.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "88287869-a854-5d17-96ab-4342c5274ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df16df8-3270-4a09-8167-5b6a2068edb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df16df8-3270-4a09-8167-5b6a2068edb9.jpg?1",
             "name": "Fire Elemental",
             "text": "",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "84ec16fb-3ce3-58c4-a1e1-95d29f61b6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702a838-8577-49b6-8b7a-f9b6d2929481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702a838-8577-49b6-8b7a-f9b6d2929481.jpg?1",
             "name": "Flame Sweep",
             "text": "Flame Sweep deals 2 damage to each creature except for creatures you control with flying.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "54b61627-cd13-5ba1-9840-4c336b63df45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d7766-a662-443c-93c5-811dbdac2480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d7766-a662-443c-93c5-811dbdac2480.jpg?1",
             "name": "Fry",
             "text": "This spell can't be countered.\nFry deals 5 damage to target creature or planeswalker that's white or blue.",
             "colours": [
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "2a487fd8-8e37-51f2-bee8-78b6f38fa993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2df9cb-14f5-470f-b438-20f4ae8d0d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2df9cb-14f5-470f-b438-20f4ae8d0d59.jpg?1",
             "name": "Glint-Horn Buccaneer",
             "text": "Haste\nWhenever you discard a card, Glint-Horn Buccaneer deals 1 damage to each opponent.\n{1}{R}, Discard a card: Draw a card. Activate this ability only if Glint-Horn Buccaneer is attacking.",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "2b7d2ea5-a3c2-5f9d-a3d1-667006d6ebfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fbbf39-cd52-474a-908e-b7a78cb5eb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fbbf39-cd52-474a-908e-b7a78cb5eb5b.jpg?1",
             "name": "Goblin Bird-Grabber",
             "text": "{R}: Goblin Bird-Grabber gains flying until end of turn. Activate this ability only if you control a creature with flying.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "f0ec9841-4452-54ee-a65a-d1cbda94a1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911af4e-4abd-4cf9-8a86-ae5d680c6f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911af4e-4abd-4cf9-8a86-ae5d680c6f12.jpg?1",
             "name": "Goblin Ringleader",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Goblin Ringleader enters the battlefield, reveal the top four cards of your library. Put all Goblin cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "5f0e31ec-9734-5e35-97d7-17ff32aab413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dc1a65-271c-455a-ae0c-f652444a53ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dc1a65-271c-455a-ae0c-f652444a53ac.jpg?1",
             "name": "Goblin Smuggler",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Another target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4869,7 +4869,7 @@
         },
         {
             "id": "13229228-ebf6-5aa8-8278-2b2765984278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac778f6-8997-47ee-a676-3eb9f8d1592f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac778f6-8997-47ee-a676-3eb9f8d1592f.jpg?1",
             "name": "Infuriate",
             "text": "Target creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "a98292e3-ce51-56cb-bc5f-650dbc950d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c47fa-7060-48da-995c-e4037640a208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884c47fa-7060-48da-995c-e4037640a208.jpg?1",
             "name": "Keldon Raider",
             "text": "When Keldon Raider enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4936,7 +4936,7 @@
         },
         {
             "id": "88cc3c2b-f3d5-5aee-ba40-77d85848b2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeea9e5-3041-4439-bc52-fd00ec83c7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeea9e5-3041-4439-bc52-fd00ec83c7a1.jpg?1",
             "name": "Lavakin Brawler",
             "text": "Whenever Lavakin Brawler attacks, it gets +1/+0 until end of turn for each Elemental you control.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "ac3fb6b8-727a-542b-a188-0c7284da1679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93c8e2-fb27-43af-83a7-2bd4d40e0eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93c8e2-fb27-43af-83a7-2bd4d40e0eff.jpg?1",
             "name": "Leyline of Combustion",
             "text": "If Leyline of Combustion is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you and/or at least one permanent you control becomes the target of a spell or ability an opponent controls, Leyline of Combustion deals 2 damage to that player.",
             "colours": [
@@ -5003,7 +5003,7 @@
         },
         {
             "id": "3a1543ab-e61d-5b45-a6b2-415d8c9b9676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a51b9b-881f-4f02-b49e-68fcca234161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a51b9b-881f-4f02-b49e-68fcca234161.jpg?1",
             "name": "Maniacal Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.",
             "colours": [
@@ -5037,7 +5037,7 @@
         },
         {
             "id": "39db7789-71cc-587a-9f66-040fdba71190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4d2ee-e5e5-48e6-a7b8-9045dc8b10a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e4d2ee-e5e5-48e6-a7b8-9045dc8b10a7.jpg?1",
             "name": "Marauding Raptor",
             "text": "Creature spells you cast cost {1} less to cast.\nWhenever another creature enters the battlefield under your control, Marauding Raptor deals 2 damage to it. If a Dinosaur is dealt damage this way, Marauding Raptor gets +2/+0 until end of turn.",
             "colours": [
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "02dfa8b1-16c9-569e-88a1-86d3b68a24e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2f4165-f87f-454b-b955-e4477c864e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2f4165-f87f-454b-b955-e4477c864e95.jpg?1",
             "name": "Mask of Immolation",
             "text": "When Mask of Immolation enters the battlefield, create a 1/1 red Elemental creature token, then attach Mask of Immolation to it.\nEquipped creature has \"Sacrifice this creature: It deals 1 damage to any target.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "8198fe5e-b984-52ba-96f9-04b0841ad868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39934090-36a6-4183-9176-97ea932d2685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39934090-36a6-4183-9176-97ea932d2685.jpg?1",
             "name": "Pack Mastiff",
             "text": "{1}{R}: Each creature you control named Pack Mastiff gets +1/+0 until end of turn.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "d2309b76-3267-5239-81cb-dbfb2c5aa888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9bf6d8-ebf6-40ff-858a-3483d19bb584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9bf6d8-ebf6-40ff-858a-3483d19bb584.jpg?1",
             "name": "Rapacious Dragon",
             "text": "Flying\nWhen Rapacious Dragon enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "ac16521b-fe64-530b-b41c-01bd3ae1bdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68391b41-4a17-4450-a8ac-0ce8406fe8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68391b41-4a17-4450-a8ac-0ce8406fe8c1.jpg?1",
             "name": "Reckless Air Strike",
             "text": "Choose one \u2014\n\u2022 Reckless Air Strike deals 3 damage to target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "bb947042-cd1d-5fbf-875c-9404dc33d8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe580883-cdb1-4783-9feb-1e3bea83d209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe580883-cdb1-4783-9feb-1e3bea83d209.jpg?1",
             "name": "Reduce to Ashes",
             "text": "Reduce to Ashes deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -5237,7 +5237,7 @@
         },
         {
             "id": "5d314a54-a3e3-55fe-b6bc-bafb95deb228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e94c783-e474-4cbc-a38a-27ad8dd15a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e94c783-e474-4cbc-a38a-27ad8dd15a7b.jpg?1",
             "name": "Repeated Reverberation",
             "text": "When you next cast an instant spell, cast a sorcery spell, or activate a loyalty ability this turn, copy that spell or ability twice. You may choose new targets for the copies.",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "1a7c2e29-523e-54d8-a5e3-9125e83d3f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9141d96-ad3a-4e30-b356-44e136e1f62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9141d96-ad3a-4e30-b356-44e136e1f62f.jpg?1",
             "name": "Ripscale Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "f1d33129-82b3-523e-8ee0-b7f3434941e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbe031-1547-4fa5-ba9a-caa1b1f5eb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbe031-1547-4fa5-ba9a-caa1b1f5eb5d.jpg?1",
             "name": "Scampering Scorcher",
             "text": "When Scampering Scorcher enters the battlefield, create two 1/1 red Elemental creature tokens. Elementals you control gain haste until end of turn. (They can attack and {T} this turn.)",
             "colours": [
@@ -5337,7 +5337,7 @@
         },
         {
             "id": "1c0c6aa3-8090-5e48-b435-318497ed8125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb701a84-24bd-41ed-9f06-25c8338902a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb701a84-24bd-41ed-9f06-25c8338902a5.jpg?1",
             "name": "Scorch Spitter",
             "text": "Whenever Scorch Spitter attacks, it deals 1 damage to the player or planeswalker it's attacking.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "6be0ff10-3466-5cba-ba16-14a34277d863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c866bdb-ff94-4f3f-8429-e72c2cbb94ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c866bdb-ff94-4f3f-8429-e72c2cbb94ef.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5404,7 +5404,7 @@
         },
         {
             "id": "70bdda0e-aec1-546c-a962-6e9dbf25f100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf90bd1-fa00-4af6-aa76-bd6fca7b0ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf90bd1-fa00-4af6-aa76-bd6fca7b0ac4.jpg?1",
             "name": "Tectonic Rift",
             "text": "Destroy target land. Creatures without flying can't block this turn.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "dd7b1428-f450-5d3d-8a41-06c8b5d2bbea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289b649b-c93a-44ad-bdd6-866f8b2f1bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289b649b-c93a-44ad-bdd6-866f8b2f1bc2.jpg?1",
             "name": "Thunderkin Awakener",
             "text": "Haste\nWhenever Thunderkin Awakener attacks, choose target Elemental creature card in your graveyard with toughness less than Thunderkin Awakener's toughness. Return that card to the battlefield tapped and attacking. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "f3cb8d33-9c45-51dd-b09d-de9077b88b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837557f2-6151-489c-a997-00862173cd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837557f2-6151-489c-a997-00862173cd15.jpg?1",
             "name": "Uncaged Fury",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -5503,7 +5503,7 @@
         },
         {
             "id": "fbaa36e5-eaf0-5785-a3d1-c7142ba07f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5879c5-4b0a-42fa-a44f-580e0221a32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5879c5-4b0a-42fa-a44f-580e0221a32b.jpg?1",
             "name": "Unchained Berserker",
             "text": "Protection from white (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything white.)\nUnchained Berserker gets +2/+0 as long as it's attacking.",
             "colours": [
@@ -5538,7 +5538,7 @@
         },
         {
             "id": "0b77a867-5cb3-5b13-b645-133b03f4e03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd2e76-ad64-42ff-a6a2-c4cf1bec5932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd2e76-ad64-42ff-a6a2-c4cf1bec5932.jpg?1",
             "name": "Barkhide Troll",
             "text": "Barkhide Troll enters the battlefield with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from Barkhide Troll: Barkhide Troll gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "67a02663-6e5f-5e5e-a79b-46d0e445bcbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fb9767-29bf-4a69-b37c-0925d41f6b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fb9767-29bf-4a69-b37c-0925d41f6b46.jpg?1",
             "name": "Brightwood Tracker",
             "text": "{5}{G}, {T}: Look at the top four cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5607,7 +5607,7 @@
         },
         {
             "id": "86c201b9-7aa1-5392-b303-01333e18d0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4662a9c-3cbd-41f7-8c15-d048a3826a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4662a9c-3cbd-41f7-8c15-d048a3826a42.jpg?1",
             "name": "Cavalier of Thorns",
             "text": "Reach\nWhen Cavalier of Thorns enters the battlefield, reveal the top five cards of your library. Put a land card from among them onto the battlefield and the rest into your graveyard.\nWhen Cavalier of Thorns dies, you may exile it. If you do, put another target card from your graveyard on top of your library.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "2bd5a3f6-e330-57c1-b492-f7153ea6716f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b67ee8-3189-4426-8b1a-b540267768fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b67ee8-3189-4426-8b1a-b540267768fd.jpg?1",
             "name": "Centaur Courser",
             "text": "",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "3fd4e1b7-35c9-5335-b301-2843ffe34ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c431d7-d94b-46c4-bb89-f3db56214ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c431d7-d94b-46c4-bb89-f3db56214ab4.jpg?1",
             "name": "Elvish Reclaimer",
             "text": "Elvish Reclaimer gets +2/+2 as long as there are three or more land cards in your graveyard.\n{2}, {T}, Sacrifice a land: Search your library for a land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "62bab714-5ed4-5c69-8383-5b2da4609626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d08b7a-4ed9-4e4c-a52e-9bf2a16420a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d08b7a-4ed9-4e4c-a52e-9bf2a16420a9.jpg?1",
             "name": "Feral Invocation",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "d9a56d16-552b-5df5-8ff2-9d4760dc189c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2354cb24-5c70-4aaa-8636-46866f0950c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2354cb24-5c70-4aaa-8636-46866f0950c1.jpg?1",
             "name": "Ferocious Pup",
             "text": "When Ferocious Pup enters the battlefield, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "1d8c0fdc-7cbc-547b-b25e-2abbe3d4cea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e446e90-6e31-43ed-bcb1-a01422b503c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e446e90-6e31-43ed-bcb1-a01422b503c0.jpg?1",
             "name": "Gargos, Vicious Watcher",
             "text": "Vigilance\nHydra spells you cast cost {4} less to cast.\nWhenever a creature you control becomes the target of a spell, Gargos, Vicious Watcher fights up to one target creature you don't control.",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "1b40140e-b728-578e-921b-823dc6c183a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4e2b7-2687-4ad1-99e4-0f8411b5f50d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4e2b7-2687-4ad1-99e4-0f8411b5f50d.jpg?1",
             "name": "Gift of Paradise",
             "text": "Enchant land\nWhen Gift of Paradise enters the battlefield, you gain 3 life.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -5850,7 +5850,7 @@
         },
         {
             "id": "ef861263-5fb8-57b2-b39c-cabd4426177b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a1a70d-c146-453e-84c4-71cae4e0afaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a1a70d-c146-453e-84c4-71cae4e0afaa.jpg?1",
             "name": "Greenwood Sentinel",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -5885,7 +5885,7 @@
         },
         {
             "id": "6e8457dd-6d46-5a53-811e-9ab72c0dfdfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e619121-f2e8-4da5-8652-a2b5dae2e55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e619121-f2e8-4da5-8652-a2b5dae2e55c.jpg?1",
             "name": "Growth Cycle",
             "text": "Target creature gets +3/+3 until end of turn. It gets an additional +2/+2 until end of turn for each card named Growth Cycle in your graveyard.",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "ce9b808b-345b-5e30-a3b9-b08131b1d1f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe262f2-e35b-4c85-938d-3e9e9c764c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe262f2-e35b-4c85-938d-3e9e9c764c1b.jpg?1",
             "name": "Healer of the Glade",
             "text": "When Healer of the Glade enters the battlefield, you gain 3 life.",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "74870535-4f57-51ba-b23a-ffcd303c1fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8434fd-5ee5-4be9-a28d-9e04b1b94327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8434fd-5ee5-4be9-a28d-9e04b1b94327.jpg?1",
             "name": "Howling Giant",
             "text": "Reach (This creature can block creatures with flying.)\nWhen Howling Giant enters the battlefield, create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "8559c244-3988-5849-ab3a-65acbb0a8fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8968a942-72f6-42ad-ae9d-418a1dff0ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8968a942-72f6-42ad-ae9d-418a1dff0ab3.jpg?1",
             "name": "Leafkin Druid",
             "text": "{T}: Add {G}. If you control four or more creatures, add {G}{G} instead.",
             "colours": [
@@ -6021,7 +6021,7 @@
         },
         {
             "id": "78e1d68d-9bd2-5212-83ec-5343b25dd7f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68e8342-78d2-4826-a287-64c371b97d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68e8342-78d2-4826-a287-64c371b97d19.jpg?1",
             "name": "Leyline of Abundance",
             "text": "If Leyline of Abundance is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you tap a creature for mana, add an additional {G}.\n{6}{G}{G}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6053,7 +6053,7 @@
         },
         {
             "id": "8e609100-b8b1-5c85-8335-d4bec8ab3946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2638252-f329-4d83-a705-6e369462d83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2638252-f329-4d83-a705-6e369462d83a.jpg?1",
             "name": "Loaming Shaman",
             "text": "When Loaming Shaman enters the battlefield, target player shuffles any number of target cards from their graveyard into their library.",
             "colours": [
@@ -6088,7 +6088,7 @@
         },
         {
             "id": "82041177-5a26-584a-a882-cbb61c19357a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee9bca2-1195-4bd0-aa5c-16b3726a8ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee9bca2-1195-4bd0-aa5c-16b3726a8ff2.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "757cbebf-7c2a-5a1b-8030-afa5f773816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7776d0a-e068-4cac-8848-060a2ce15b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7776d0a-e068-4cac-8848-060a2ce15b95.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "4f0ca216-cd9b-5b64-a6d2-c685a8fa7d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dcd314-f4d2-461e-a66e-7b1d8f141879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84dcd314-f4d2-461e-a66e-7b1d8f141879.jpg?1",
             "name": "Natural End",
             "text": "Destroy target artifact or enchantment. You gain 3 life.",
             "colours": [
@@ -6186,7 +6186,7 @@
         },
         {
             "id": "41f25822-345e-59e3-98de-18ae3710d19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c95074-32c8-426e-b615-8ad5427c6c1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c95074-32c8-426e-b615-8ad5427c6c1c.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -6220,7 +6220,7 @@
         },
         {
             "id": "2db6f6c6-0dcc-5e88-a7af-b05767ee7342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b1f70-9861-4c66-a52f-c40002679e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b1f70-9861-4c66-a52f-c40002679e75.jpg?1",
             "name": "Nightpack Ambusher",
             "text": "Flash\nOther Wolves and Werewolves you control get +1/+1.\nAt the beginning of your end step, if you didn't cast a spell this turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "3c1b78cc-7161-5e7d-ab4c-4314885e2c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718352b9-1a68-44a1-947b-34f525f21223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718352b9-1a68-44a1-947b-34f525f21223.jpg?1",
             "name": "Overcome",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn. (They can deal excess combat damage to the player or planeswalker they're attacking.)",
             "colours": [
@@ -6286,7 +6286,7 @@
         },
         {
             "id": "323c6a32-71d2-5acc-8a75-209812c1298b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9a13eb-2daf-43e0-b175-c6ec5b9e191e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9a13eb-2daf-43e0-b175-c6ec5b9e191e.jpg?1",
             "name": "Overgrowth Elemental",
             "text": "When Overgrowth Elemental enters the battlefield, put a +1/+1 counter on another target Elemental you control.\nWhenever another creature you control dies, you gain 1 life. If that creature was an Elemental, put a +1/+1 counter on Overgrowth Elemental.",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "96e93ba3-88fe-56c5-8296-1f18037998b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1a0c7b-ce1c-4284-9362-04b21861f69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1a0c7b-ce1c-4284-9362-04b21861f69d.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "c11e0bc0-8b46-5e44-be73-796274af1aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99851c1b-8878-4c1e-906b-f6b70e53d714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99851c1b-8878-4c1e-906b-f6b70e53d714.jpg?1",
             "name": "Pulse of Murasa",
             "text": "Return target creature or land card from a graveyard to its owner's hand. You gain 6 life.",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "f3518cf6-5696-532e-b524-65746c8d91e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8ff93-6f62-4695-85ad-d70a0b928e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d8ff93-6f62-4695-85ad-d70a0b928e92.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "82bf7ddb-5752-5062-9ae5-a1005ead29fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9a718-01b9-46b2-85eb-55f6206ee5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b9a718-01b9-46b2-85eb-55f6206ee5e4.jpg?1",
             "name": "Season of Growth",
             "text": "Whenever a creature enters the battlefield under your control, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nWhenever you cast a spell that targets a creature you control, draw a card.",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "21b477cf-6113-57b9-b319-fd684b89de73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9864f811-db2e-4d6d-ad59-a491a790bdd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9864f811-db2e-4d6d-ad59-a491a790bdd4.jpg?1",
             "name": "Sedge Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6482,7 +6482,7 @@
         },
         {
             "id": "3c1e73e1-2a1f-589d-814c-de80f4f5c628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1e49b6-ed0f-42f5-af22-6f4aa23ce4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e1e49b6-ed0f-42f5-af22-6f4aa23ce4ef.jpg?1",
             "name": "Shared Summons",
             "text": "Search your library for up to two creature cards with different names, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "b7ddd95e-924c-561a-b80d-3405eb9a1a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e318600-21af-4003-bcfa-be926cd24c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e318600-21af-4003-bcfa-be926cd24c5c.jpg?1",
             "name": "Shifting Ceratops",
             "text": "This spell can't be countered.\nProtection from blue (This creature can't be blocked, targeted, dealt damage, enchanted, or equipped by anything blue.)\n{G}: Shifting Ceratops gains your choice of reach, trample, or haste until end of turn.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "fa226ce1-0696-5778-a002-a03b0c3c1518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e97e62e-4a77-4512-b5fa-400e01517e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e97e62e-4a77-4512-b5fa-400e01517e23.jpg?1",
             "name": "Silverback Shaman",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen Silverback Shaman dies, draw a card.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "0f19bb4a-95aa-5cbd-93ed-7b06bb762d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534eb449-3f1c-46ec-a965-0f5812e2c93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534eb449-3f1c-46ec-a965-0f5812e2c93e.jpg?1",
             "name": "Thicket Crasher",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther Elementals you control have trample.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "80f7fefa-0254-59a0-8e50-0d10d18656b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7367813-8be3-44a2-9a75-5f4e48cf34b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7367813-8be3-44a2-9a75-5f4e48cf34b1.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "cac60691-1936-55c1-a907-0fd3ef048fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa686c34-1c11-469f-93c2-f9891aea521f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa686c34-1c11-469f-93c2-f9891aea521f.jpg?1",
             "name": "Veil of Summer",
             "text": "Draw a card if an opponent has cast a blue or black spell this turn. Spells you control can't be countered this turn. You and permanents you control gain hexproof from blue and from black until end of turn. (You and they can't be the targets of blue or black spells or abilities your opponents control.)",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "24d6b9d8-b91d-5b08-a6e4-0882c9d67009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c5e27-c538-425e-b41f-1d6708428853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592c5e27-c538-425e-b41f-1d6708428853.jpg?1",
             "name": "Vivien, Arkbow Ranger",
             "text": "+1: Distribute two +1/+1 counters among up to two target creatures. They gain trample until end of turn.\n\u22123: Target creature you control deals damage equal to its power to target creature or planeswalker.\n\u22125: You may choose a creature card you own from outside the game, reveal it, and put it into your hand.",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "f09e3e1a-4245-523a-8fde-f083efd5ef0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bbe44f-864a-446c-bfc9-5f5188e663b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bbe44f-864a-446c-bfc9-5f5188e663b8.jpg?1",
             "name": "Voracious Hydra",
             "text": "Trample\nVoracious Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Voracious Hydra enters the battlefield, choose one \u2014\n\u2022 Double the number of +1/+1 counters on Voracious Hydra.\n\u2022 Voracious Hydra fights target creature you don't control.",
             "colours": [
@@ -6754,7 +6754,7 @@
         },
         {
             "id": "4dc8ad93-2ba1-5417-b4c6-77f93293c1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79719ed0-468d-4946-8dfc-fb7e2b2e305e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79719ed0-468d-4946-8dfc-fb7e2b2e305e.jpg?1",
             "name": "Vorstclaw",
             "text": "",
             "colours": [
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "231c4105-c716-5180-b84c-65e4703ab5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9396d-28f2-40b7-908e-51db51da57a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c9396d-28f2-40b7-908e-51db51da57a7.jpg?1",
             "name": "Wakeroot Elemental",
             "text": "{G}{G}{G}{G}{G}: Untap target land you control. It becomes a 5/5 Elemental creature with haste. It's still a land. (This effect lasts as long as that land remains on the battlefield.)",
             "colours": [
@@ -6823,7 +6823,7 @@
         },
         {
             "id": "7a2913ae-6696-5424-8602-3d3fad61e3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c419a2b-4389-49bc-91f1-a613ffcbfa0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c419a2b-4389-49bc-91f1-a613ffcbfa0b.jpg?1",
             "name": "Wolfkin Bond",
             "text": "Enchant creature\nWhen Wolfkin Bond enters the battlefield, create a 2/2 green Wolf creature token.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6857,7 +6857,7 @@
         },
         {
             "id": "884e47dd-8e85-59e1-ac5f-cf77f8ee748d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba18cc9a-411d-45c6-bcc3-9e02ef5e2d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba18cc9a-411d-45c6-bcc3-9e02ef5e2d92.jpg?1",
             "name": "Wolfrider's Saddle",
             "text": "When Wolfrider's Saddle enters the battlefield, create a 2/2 green Wolf creature token, then attach Wolfrider's Saddle to it.\nEquipped creature gets +1/+1 and can't be blocked by more than one creature.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6891,7 +6891,7 @@
         },
         {
             "id": "56b80285-5347-5044-b47c-4d6bc2117ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f5303-428a-478c-9bd5-2410f7fcc4dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f5303-428a-478c-9bd5-2410f7fcc4dd.jpg?1",
             "name": "Woodland Champion",
             "text": "Whenever one or more tokens enter the battlefield under your control, put that many +1/+1 counters on Woodland Champion.",
             "colours": [
@@ -6926,7 +6926,7 @@
         },
         {
             "id": "d5e7b3d0-156a-5ab6-ba8f-8710e63c5809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45117b-8369-48fc-8e5d-8986e662d123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45117b-8369-48fc-8e5d-8986e662d123.jpg?1",
             "name": "Corpse Knight",
             "text": "Whenever another creature enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "abb84007-3461-5530-bdee-8e7cf7cd8300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbcf6e7-d7cf-4103-85b3-8d9d104587e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfbcf6e7-d7cf-4103-85b3-8d9d104587e1.jpg?1",
             "name": "Corpse Knight",
             "text": "",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "2e2d5211-10e0-50cc-b9b1-2518b12a6f91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b96e41-caae-4e22-82f9-df5a054ea3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b96e41-caae-4e22-82f9-df5a054ea3b7.jpg?1",
             "name": "Creeping Trailblazer",
             "text": "Other Elementals you control get +1/+0.\n{2}{R}{G}: Creeping Trailblazer gets +1/+1 until end of turn for each Elemental you control.",
             "colours": [
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "37e03daa-a155-58ed-9396-87f71789df35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555709-c7cc-4c64-8a6f-8fe2bc149fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555709-c7cc-4c64-8a6f-8fe2bc149fcd.jpg?1",
             "name": "Empyrean Eagle",
             "text": "Flying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -7076,7 +7076,7 @@
         },
         {
             "id": "baa9160a-db98-5730-bdaf-1c688c16c59e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edec85ce-7daa-48c2-b25d-b22941e01e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edec85ce-7daa-48c2-b25d-b22941e01e73.jpg?1",
             "name": "Ironroot Warlord",
             "text": "Ironroot Warlord's power is equal to the number of creatures you control.\n{3}{G}{W}: Create a 1/1 white Soldier creature token.",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "c2308737-8599-57ad-ba10-92de2c88b934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f400655-f495-4b21-ab9e-57fe4d845d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f400655-f495-4b21-ab9e-57fe4d845d45.jpg?1",
             "name": "Kaalia, Zenith Seeker",
             "text": "Flying, vigilance\nWhen Kaalia, Zenith Seeker enters the battlefield, look at the top six cards of your library. You may reveal an Angel card, a Demon card, and/or a Dragon card from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "50109def-cd21-5dce-8d48-9f812005f30d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe28de73-76f3-4a9e-a020-dbe5921b9be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe28de73-76f3-4a9e-a020-dbe5921b9be5.jpg?1",
             "name": "Kethis, the Hidden Hand",
             "text": "Legendary spells you cast cost {1} less to cast.\nExile two legendary cards from your graveyard: Until end of turn, each legendary card in your graveyard gains \"You may play this card from your graveyard.\"",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "2a6f2820-7490-59c3-aa5d-b33b13cab592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594cb7dc-ea88-4909-ab40-1d40fecc9817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594cb7dc-ea88-4909-ab40-1d40fecc9817.jpg?1",
             "name": "Kykar, Wind's Fury",
             "text": "Flying\nWhenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.\nSacrifice a Spirit: Add {R}.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "268366a8-3059-5b36-b760-19db02808090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c6db4e-cc37-4473-b0f5-48d8a0b82f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c6db4e-cc37-4473-b0f5-48d8a0b82f33.jpg?1",
             "name": "Lightning Stormkin",
             "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "bb26db49-4ea6-5445-97ad-492bce69a48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618d21fe-8e3d-4887-b2e4-b92194ba1902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618d21fe-8e3d-4887-b2e4-b92194ba1902.jpg?1",
             "name": "Moldervine Reclamation",
             "text": "Whenever a creature you control dies, you gain 1 life and draw a card.",
             "colours": [
@@ -7307,7 +7307,7 @@
         },
         {
             "id": "4d306426-a1d9-5698-9f5a-8e41b53fb1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba1c64-c552-4aeb-b669-da885c8c75b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba1c64-c552-4aeb-b669-da885c8c75b2.jpg?1",
             "name": "Ogre Siegebreaker",
             "text": "{2}{B}{R}: Destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "0dce71af-9bf7-5e2c-a06e-a442b8e199b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb53a29d-2de2-4874-a6f3-0fecbfa14cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb53a29d-2de2-4874-a6f3-0fecbfa14cf2.jpg?1",
             "name": "Omnath, Locus of the Roil",
             "text": "When Omnath, Locus of the Roil enters the battlefield, it deals damage to any target equal to the number of Elementals you control.\nWhenever a land enters the battlefield under your control, put a +1/+1 counter on target Elemental you control. If you control eight or more lands, draw a card.",
             "colours": [
@@ -7384,7 +7384,7 @@
         },
         {
             "id": "b604550a-0b79-5445-9de8-c09564e3928b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82389aaa-9f32-4169-a71c-1aea5af9e935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82389aaa-9f32-4169-a71c-1aea5af9e935.jpg?1",
             "name": "Risen Reef",
             "text": "Whenever Risen Reef or another Elemental enters the battlefield under your control, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "22987757-b64d-52d9-9c6e-b989ba4c2bdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549634d8-1c33-401b-841d-a79ef4374dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549634d8-1c33-401b-841d-a79ef4374dd1.jpg?1",
             "name": "Skyknight Vanguard",
             "text": "Flying\nWhenever Skyknight Vanguard attacks, create a 1/1 white Soldier creature token that's tapped and attacking.",
             "colours": [
@@ -7457,7 +7457,7 @@
         },
         {
             "id": "b4549ba6-d10c-5f98-bb35-0db1c89e5e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f305027-dfd2-4b17-a6af-6b0576389623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f305027-dfd2-4b17-a6af-6b0576389623.jpg?1",
             "name": "Tomebound Lich",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhenever Tomebound Lich enters the battlefield or deals combat damage to a player, draw a card, then discard a card.",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "d3d86a4e-255d-52a4-9a6e-04ff2a9f9fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1001d43-e11b-4e5e-acd4-4a50ef89977f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1001d43-e11b-4e5e-acd4-4a50ef89977f.jpg?1",
             "name": "Yarok, the Desecrated",
             "text": "Deathtouch, lifelink\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "0ef14e6a-3853-5146-8f96-46b34af0fa0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6d7bbe-0418-4a58-a97b-13b50eb0b642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6d7bbe-0418-4a58-a97b-13b50eb0b642.jpg?1",
             "name": "Anvilwrought Raptor",
             "text": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
             "colours": [],
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "e4441670-5ff7-560b-92e6-8b8f7899953d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49283832-54f2-4619-b4a9-750493c93292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49283832-54f2-4619-b4a9-750493c93292.jpg?1",
             "name": "Bag of Holding",
             "text": "Whenever you discard a card, exile that card from your graveyard.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}, Sacrifice Bag of Holding: Return all cards exiled with Bag of Holding to their owner's hand.",
             "colours": [],
@@ -7594,7 +7594,7 @@
         },
         {
             "id": "39083845-ccae-5f27-88d9-eb330c030e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa35b2b5-3e91-4a6c-90b1-8581b4ecaf8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa35b2b5-3e91-4a6c-90b1-8581b4ecaf8b.jpg?1",
             "name": "Colossus Hammer",
             "text": "Equipped creature gets +10/+10 and loses flying.\nEquip {8} ({8}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "ddabaad6-ee3c-58f3-9e03-2a712a1c0a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeab4819-dd26-4f5c-8538-50f2caca292d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeab4819-dd26-4f5c-8538-50f2caca292d.jpg?1",
             "name": "Diamond Knight",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nAs Diamond Knight enters the battlefield, choose a color.\nWhenever you cast a spell of the chosen color, put a +1/+1 counter on Diamond Knight.",
             "colours": [],
@@ -7655,7 +7655,7 @@
         },
         {
             "id": "e0f6c2a4-0d3e-596b-ab5b-9a8d8b2d5bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55c6a1-1f26-4254-ac62-fdbe94278de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55c6a1-1f26-4254-ac62-fdbe94278de5.jpg?1",
             "name": "Diviner's Lockbox",
             "text": "{1}, {T}: Choose a card name, then reveal the top card of your library. If that card has the chosen name, sacrifice Diviner's Lockbox and draw three cards. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "63570c0d-34bf-5340-94a2-81eeb3da6624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa48620-4c3d-4f75-be1f-c12c4aa59f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa48620-4c3d-4f75-be1f-c12c4aa59f51.jpg?1",
             "name": "Golos, Tireless Pilgrim",
             "text": "When Golos, Tireless Pilgrim enters the battlefield, you may search your library for a land card, put that card onto the battlefield tapped, then shuffle your library.\n{2}{W}{U}{B}{R}{G}: Exile the top three cards of your library. You may play them this turn without paying their mana costs.",
             "colours": [],
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "639e88e0-5347-50ce-bbc9-bb86bedc3824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a135e09-b534-4836-9a10-3a9a4a9f8c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a135e09-b534-4836-9a10-3a9a4a9f8c53.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "Creature cards in graveyards and libraries can't enter the battlefield.\nPlayers can't cast spells from graveyards or libraries.",
             "colours": [],
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "4bdc0de6-3e6e-5d7b-8f3f-5edc609f9586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f723-0e0b-44a4-bfc6-f48f17a805d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f723-0e0b-44a4-bfc6-f48f17a805d9.jpg?1",
             "name": "Heart-Piercer Bow",
             "text": "Whenever equipped creature attacks, Heart-Piercer Bow deals 1 damage to target creature defending player controls.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "287f7b11-d4ff-57d0-b06b-717dab0327a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78e53c-1aec-4c49-bf58-165dd7b59d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b78e53c-1aec-4c49-bf58-165dd7b59d64.jpg?1",
             "name": "Icon of Ancestry",
             "text": "As Icon of Ancestry enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{3}, {T}: Look at the top three cards of your library. You may reveal a creature card of the chosen type from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -7808,7 +7808,7 @@
         },
         {
             "id": "2732a93b-2b38-547a-8a8f-24866017533c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715e637a-dfd8-45a0-b1ea-53e4abd29307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715e637a-dfd8-45a0-b1ea-53e4abd29307.jpg?1",
             "name": "Manifold Key",
             "text": "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "5ffb0c4f-b22e-53b5-a90d-22a3b5fe33fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ac5204-69ef-491d-9ca8-f522b99f1412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ac5204-69ef-491d-9ca8-f522b99f1412.jpg?1",
             "name": "Marauder's Axe",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "e38486f8-7f10-55e8-a6b0-82f0b2b25c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b748341f-557c-4b6a-a36c-c08c9cc05b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b748341f-557c-4b6a-a36c-c08c9cc05b90.jpg?1",
             "name": "Meteor Golem",
             "text": "When Meteor Golem enters the battlefield, destroy target nonland permanent an opponent controls.",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "a036efb1-6672-5126-846b-544cede09b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924a24e7-91b8-4ceb-a136-7a765d98c994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924a24e7-91b8-4ceb-a136-7a765d98c994.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast the top card of your library if it's an artifact card or a colorless nonland card.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -7925,7 +7925,7 @@
         },
         {
             "id": "653a05dc-0525-5443-bd6b-a0a1593184e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad608eb3-d387-4414-b194-703f38863896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad608eb3-d387-4414-b194-703f38863896.jpg?1",
             "name": "Pattern Matcher",
             "text": "When Pattern Matcher enters the battlefield, you may search your library for a card with the same name as another creature you control, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7956,7 +7956,7 @@
         },
         {
             "id": "93ac3f01-8375-5c4c-bfe1-e7852c80b9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9fdb01-ba52-4510-897e-0d69558fdaee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9fdb01-ba52-4510-897e-0d69558fdaee.jpg?1",
             "name": "Prismite",
             "text": "{2}: Add one mana of any color.",
             "colours": [],
@@ -7987,7 +7987,7 @@
         },
         {
             "id": "d89025fc-79e6-524b-bb47-c048d1a12000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5521cb92-03b0-44ab-a141-40dc0eb5a79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5521cb92-03b0-44ab-a141-40dc0eb5a79f.jpg?1",
             "name": "Retributive Wand",
             "text": "{3}, {T}: Retributive Wand deals 1 damage to any target.\nWhen Retributive Wand is put into a graveyard from the battlefield, it deals 5 damage to any target.",
             "colours": [],
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "3147f3de-acf2-5e66-b489-4d7e4486fbfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd2ebbe-71c6-405b-bad0-5680f0ff575c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd2ebbe-71c6-405b-bad0-5680f0ff575c.jpg?1",
             "name": "Salvager of Ruin",
             "text": "Sacrifice Salvager of Ruin: Choose target permanent card in your graveyard that was put there from the battlefield this turn. Return it to your hand.",
             "colours": [],
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "988dc032-6745-5ba0-aaec-b83924a0840c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f2d2e8-a9ed-42cc-9a8a-fc697a7251e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f2d2e8-a9ed-42cc-9a8a-fc697a7251e5.jpg?1",
             "name": "Scuttlemutt",
             "text": "{T}: Add one mana of any color.\n{T}: Target creature becomes the color or colors of your choice until end of turn.",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "c3efc1dd-d5d6-5b77-89db-91bee8ec12b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed61426-e652-4b48-b936-8be9b6b57731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed61426-e652-4b48-b936-8be9b6b57731.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "f5404ea9-21e9-5b58-abe3-11de6f13c482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4de70a-729b-4566-b6f3-c76f551405a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4de70a-729b-4566-b6f3-c76f551405a5.jpg?1",
             "name": "Stone Golem",
             "text": "",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "b086f8ca-d938-54ac-847e-99084aa0a638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57db6ba8-f6c1-41be-8bee-93e573d052d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57db6ba8-f6c1-41be-8bee-93e573d052d7.jpg?1",
             "name": "Vial of Dragonfire",
             "text": "{2}, {T}, Sacrifice Vial of Dragonfire: It deals 2 damage to target creature.",
             "colours": [],
@@ -8167,7 +8167,7 @@
         },
         {
             "id": "b33a9259-82d2-5754-81c7-79a13d161b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7ec5a3-3c40-4090-b9e3-11fb5b06fb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7ec5a3-3c40-4090-b9e3-11fb5b06fb8f.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "bf105aed-8bea-56f8-8e69-f74e63d22c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31514c67-4c55-4f28-9872-08e4d9bc6505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31514c67-4c55-4f28-9872-08e4d9bc6505.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "b70c9550-362c-5fa0-a5c1-1da1128d76db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9e9cb-68ab-4856-8ad6-30f66666dd93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde9e9cb-68ab-4856-8ad6-30f66666dd93.jpg?1",
             "name": "Cryptic Caves",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Cryptic Caves: Draw a card. Activate this ability only if you control five or more lands.",
             "colours": [],
@@ -8257,7 +8257,7 @@
         },
         {
             "id": "b4726b1b-3f63-5fff-9c1e-bc94525fa2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ff247f-82d1-4b79-9ac0-1471a1f0f58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ff247f-82d1-4b79-9ac0-1471a1f0f58b.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8288,7 +8288,7 @@
         },
         {
             "id": "545c25ee-cde6-56b3-8835-10b607691c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0fa2fb-6770-4a81-b830-4acfa957655a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0fa2fb-6770-4a81-b830-4acfa957655a.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "58298e4b-7194-5412-b7cd-004f0f5bbdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ca3f4-29aa-4c4c-8ff2-8cdd70c69943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ca3f4-29aa-4c4c-8ff2-8cdd70c69943.jpg?1",
             "name": "Field of the Dead",
             "text": "Field of the Dead enters the battlefield tapped.\n{T}: Add {C}.\nWhenever Field of the Dead or another land enters the battlefield under your control, if you control seven or more lands with different names, create a 2/2 black Zombie creature token.",
             "colours": [],
@@ -8344,7 +8344,7 @@
         },
         {
             "id": "f5fa0691-2dc5-5e4a-b3cd-16a73c51d511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b7a1d-943b-43f8-a70b-1a3a205476cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b7a1d-943b-43f8-a70b-1a3a205476cf.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "278921c5-23cd-5997-8771-2851004177ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013033-3995-4ba8-b0c3-0614c79aaaab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013033-3995-4ba8-b0c3-0614c79aaaab.jpg?1",
             "name": "Lotus Field",
             "text": "Hexproof\nLotus Field enters the battlefield tapped.\nWhen Lotus Field enters the battlefield, sacrifice two lands.\n{T}: Add three mana of any one color.",
             "colours": [],
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "f7c95ec2-4e2a-54e7-ac24-bfa48c932467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05dd57c-91ca-4c79-b6da-1e504d806f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05dd57c-91ca-4c79-b6da-1e504d806f28.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "da131434-b354-56a7-856d-718a05f2f194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9edd33-a64e-4526-a89f-edd31ac4b175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9edd33-a64e-4526-a89f-edd31ac4b175.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8465,7 +8465,7 @@
         },
         {
             "id": "0d39c56a-8754-50ec-82da-88907cbbbb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804db4ef-712f-4a39-a00f-51e99b05274c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804db4ef-712f-4a39-a00f-51e99b05274c.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8496,7 +8496,7 @@
         },
         {
             "id": "908ce15b-975a-5b39-b5bf-a9957e0858d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8ec3c-d2cb-477c-a7e8-ff497df646d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f8ec3c-d2cb-477c-a7e8-ff497df646d6.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8527,7 +8527,7 @@
         },
         {
             "id": "2b04be75-2d71-588b-b943-62ed99e00476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e327d94-5540-49f0-b1a2-a3fb614c9651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e327d94-5540-49f0-b1a2-a3fb614c9651.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8558,7 +8558,7 @@
         },
         {
             "id": "6a906bdb-6910-52c0-ac7f-58378e69706d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c284acd-4407-42ad-9f4c-359041223609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c284acd-4407-42ad-9f4c-359041223609.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8589,7 +8589,7 @@
         },
         {
             "id": "d9c19ac4-30bf-5996-b1ad-121e9620a36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cbb241-7268-42ac-a3ae-d326c9b6247f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cbb241-7268-42ac-a3ae-d326c9b6247f.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8620,7 +8620,7 @@
         },
         {
             "id": "880e6cb6-a4d1-543b-8a35-583591dc51a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a874dfe1-eb4d-4817-877f-8a4cd75107e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a874dfe1-eb4d-4817-877f-8a4cd75107e1.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "cf48bb66-3c37-54b1-8a67-d36f63f720ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1b12d2-2f4f-4cfd-9728-edf8232c99e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1b12d2-2f4f-4cfd-9728-edf8232c99e7.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "0ac4e7fb-3a73-5645-ba65-38e76b4f95bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa37aa-ef2e-49ff-9496-86b0e69128a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa37aa-ef2e-49ff-9496-86b0e69128a7.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8713,7 +8713,7 @@
         },
         {
             "id": "6264d4f0-ee9e-5e79-855a-9e58dc079bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0b1ba-fd3d-4f1c-9e8e-22280eeeff7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0b1ba-fd3d-4f1c-9e8e-22280eeeff7d.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8744,7 +8744,7 @@
         },
         {
             "id": "4fefe700-3104-50e8-812e-2e305bc8813d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fb4a34-c11e-45e9-a986-43c0a0ae5424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fb4a34-c11e-45e9-a986-43c0a0ae5424.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8782,7 +8782,7 @@
         },
         {
             "id": "183e8311-986f-5901-93e7-a46381871de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9495172-6fde-4aae-b47e-fc887440120e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9495172-6fde-4aae-b47e-fc887440120e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "ce37d84f-20ec-517a-a620-c81313fec96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd675c7-7dac-4ad1-9243-6d1eda0fa30c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd675c7-7dac-4ad1-9243-6d1eda0fa30c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "00141b2c-2eff-5228-8fbe-6383db16769d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa01578-faf9-4694-86a0-c81f5b2a0dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa01578-faf9-4694-86a0-c81f5b2a0dd8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8896,7 +8896,7 @@
         },
         {
             "id": "db340b60-f2fb-5a74-9cc3-cc8cc33b9374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7f4393-38f9-43b5-873b-58246183b874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7f4393-38f9-43b5-873b-58246183b874.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8934,7 +8934,7 @@
         },
         {
             "id": "819b16e6-ae68-571c-96ad-84985a63a32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a516f8-861b-4c3b-9d9b-0adc04ec689f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a516f8-861b-4c3b-9d9b-0adc04ec689f.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "e49bf6ed-4f89-511d-bde7-a0fa8999b5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3bac6-81c9-4bb5-aca6-371cec8efa0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3bac6-81c9-4bb5-aca6-371cec8efa0d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "ef97f930-9b11-5709-bec9-5d16ac3f971f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3448b8b-8baf-492a-a1d6-4bb676c43cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3448b8b-8baf-492a-a1d6-4bb676c43cab.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "328ba861-c227-521a-aff4-f93a86e6db06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a196e-8604-49d2-a66a-6f7c0eafd5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a196e-8604-49d2-a66a-6f7c0eafd5de.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9086,7 +9086,7 @@
         },
         {
             "id": "67936d08-a4a8-5e9a-bd84-d943bc1e564a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3a387a-4bc1-4338-9d1e-0fbcb6f03b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3a387a-4bc1-4338-9d1e-0fbcb6f03b82.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9124,7 +9124,7 @@
         },
         {
             "id": "d3c8cc8e-2e01-5925-85fb-999b7796ef31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9023215-035f-4f12-9f75-04b995b5d24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9023215-035f-4f12-9f75-04b995b5d24a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9162,7 +9162,7 @@
         },
         {
             "id": "38bf423b-6983-56f6-afdb-32c83420e268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba77dad-f157-4e31-9654-921967ea98c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba77dad-f157-4e31-9654-921967ea98c0.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9200,7 +9200,7 @@
         },
         {
             "id": "4066857f-e1f2-5095-9a60-ec713874fc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f7531-e137-463b-bec3-e86756b6ed71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399f7531-e137-463b-bec3-e86756b6ed71.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9238,7 +9238,7 @@
         },
         {
             "id": "5ed95bbd-023f-5120-8dc7-68be367478ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe67eb3-f10d-4f34-b4b0-fd00ee8cc325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe67eb3-f10d-4f34-b4b0-fd00ee8cc325.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9276,7 +9276,7 @@
         },
         {
             "id": "36558c4d-b702-5aff-be17-98681a1d4a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf7d0ad-8fe2-4065-89e3-c2ee04062695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf7d0ad-8fe2-4065-89e3-c2ee04062695.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "0c8071e4-e111-5c01-aa86-665edc0813f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f8188-3d9e-4937-bfcb-b73acd80878d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f8188-3d9e-4937-bfcb-b73acd80878d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9352,7 +9352,7 @@
         },
         {
             "id": "c4198bae-2c2b-51bc-8d57-5b9640232e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42352899-f2f2-4dea-863b-8d685e63b454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42352899-f2f2-4dea-863b-8d685e63b454.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "cca7e094-90a7-570a-8c4d-abd1c9d8c85b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feb2af-b363-4377-98b1-6a07df7f1acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feb2af-b363-4377-98b1-6a07df7f1acd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9428,7 +9428,7 @@
         },
         {
             "id": "dd838b36-2e58-502c-af14-db43abbea37a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56caba21-b773-4245-b3f8-3ae62725c14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56caba21-b773-4245-b3f8-3ae62725c14f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9466,7 +9466,7 @@
         },
         {
             "id": "5e678489-332b-5319-a5ab-4f79074775bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7e6ec-9bfe-4062-a538-2a748d2eed1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7e6ec-9bfe-4062-a538-2a748d2eed1f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "c36c2a16-d6b7-51c9-8c94-e505ab618d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd040a8-b818-465b-a78b-d68402982abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd040a8-b818-465b-a78b-d68402982abc.jpg?1",
             "name": "Rienne, Angel of Rebirth",
             "text": "Flying\nOther multicolored creatures you control get +1/+0.\nWhenever another multicolored creature you control dies, return it to its owner's hand at the beginning of the next end step.",
             "colours": [
@@ -9543,7 +9543,7 @@
         },
         {
             "id": "bfbeccc8-5444-5ac9-9875-15161657a158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba41e5f-66b8-4459-8a07-bbe893216f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba41e5f-66b8-4459-8a07-bbe893216f1e.jpg?1",
             "name": "Ajani, Inspiring Leader",
             "text": "+2: You gain 2 life. Put two +1/+1 counters on up to one target creature.\n\u22123: Exile target creature. Its controller gains 2 life.\n\u221210: Creatures you control gain flying and double strike until end of turn.",
             "colours": [
@@ -9578,7 +9578,7 @@
         },
         {
             "id": "05dfdeb6-db9b-5609-9aac-25128bef36e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edcb9b-f56b-4a34-b4bd-d22ee929041a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67edcb9b-f56b-4a34-b4bd-d22ee929041a.jpg?1",
             "name": "Goldmane Griffin",
             "text": "Flying, vigilance\nWhen Goldmane Griffin enters the battlefield, you may search your library and/or graveyard for a card named Ajani, Inspiring Leader, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9611,7 +9611,7 @@
         },
         {
             "id": "966742da-a549-5932-981f-62ea54e3dcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5fa4bb-e061-456f-808e-8d98b2c8abf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5fa4bb-e061-456f-808e-8d98b2c8abf5.jpg?1",
             "name": "Savannah Sage",
             "text": "When Savannah Sage enters the battlefield, you gain 2 life.",
             "colours": [
@@ -9645,7 +9645,7 @@
         },
         {
             "id": "2fd94c5a-2eed-59d1-9fde-06bbe95902bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6397d426-00e0-44da-b23c-44ccea65f5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6397d426-00e0-44da-b23c-44ccea65f5aa.jpg?1",
             "name": "Twinblade Paladin",
             "text": "Whenever you gain life, put a +1/+1 counter on Twinblade Paladin.\nAs long as you have 25 or more life, Twinblade Paladin has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -9679,7 +9679,7 @@
         },
         {
             "id": "5dde6bfe-34d2-59a4-bf3d-b555a318b783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae9595-8e76-4d8c-a08c-00434be75672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ae9595-8e76-4d8c-a08c-00434be75672.jpg?1",
             "name": "Mu Yanling, Celestial Wind",
             "text": "+1: Until your next turn, up to one target creature gets -5/-0.\n\u22123: Return up to two target creatures to their owners' hands.\n\u22127: Creatures you control with flying get +5/+5 until end of turn.",
             "colours": [
@@ -9714,7 +9714,7 @@
         },
         {
             "id": "9efec105-a0f7-5628-95c6-adca7f65ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e92e98-202f-4790-8411-17aebffe19fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e92e98-202f-4790-8411-17aebffe19fe.jpg?1",
             "name": "Celestial Messenger",
             "text": "Flash (You may cast this card any time you could cast an instant.)\nFlying\nCelestial Messenger gets +1/+1 as long as you control a Yanling planeswalker.",
             "colours": [
@@ -9748,7 +9748,7 @@
         },
         {
             "id": "2be113b4-b703-58d1-be21-e20e68b97931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bfbc4-1c9b-44f7-b4a7-068290db3bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bfbc4-1c9b-44f7-b4a7-068290db3bac.jpg?1",
             "name": "Waterkin Shaman",
             "text": "Whenever a creature with flying enters the battlefield under your control, Waterkin Shaman gets +1/+1 until end of turn.",
             "colours": [
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "73707c52-2398-5576-9012-c4630808ce87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aca389-6830-4297-97bc-e3a2a1a1d41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aca389-6830-4297-97bc-e3a2a1a1d41a.jpg?1",
             "name": "Yanling's Harbinger",
             "text": "Flying\nWhen Yanling's Harbinger enters the battlefield, you may search your library and/or graveyard for a card named Mu Yanling, Celestial Wind, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9815,7 +9815,7 @@
         },
         {
             "id": "354786a4-b8cd-5bc3-9789-059a0c07ff95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf20ea7b-e480-4b0e-b080-888f24d3c08d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf20ea7b-e480-4b0e-b080-888f24d3c08d.jpg?1",
             "name": "Sorin, Vampire Lord",
             "text": "+1: Up to one target creature gets +2/+0 until end of turn.\n\u22122: Sorin, Vampire Lord deals 4 damage to any target. You gain 4 life.\n\u22128: Until end of turn, each Vampire you control gains \"{T}: Gain control of target creature.\"",
             "colours": [
@@ -9850,7 +9850,7 @@
         },
         {
             "id": "62e411af-f997-5745-8094-7c863bb8cde1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25ea81f-9786-4622-978d-b082fb72622c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25ea81f-9786-4622-978d-b082fb72622c.jpg?1",
             "name": "Savage Gorger",
             "text": "Flying\nAt the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on Savage Gorger. (Damage causes loss of life.)",
             "colours": [
@@ -9883,7 +9883,7 @@
         },
         {
             "id": "f2979ff9-44d0-5632-82a4-1ed0f2df1944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416b000d-77d0-4c83-bbbd-d1107f746dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416b000d-77d0-4c83-bbbd-d1107f746dde.jpg?1",
             "name": "Sorin's Guide",
             "text": "When Sorin's Guide enters the battlefield, you may search your library and/or graveyard for a card named Sorin, Vampire Lord, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "f36017cf-df9f-583b-b55b-5e7fe8daf139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599e8ed3-4341-4373-8871-2768a90d98c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599e8ed3-4341-4373-8871-2768a90d98c1.jpg?1",
             "name": "Thirsting Bloodlord",
             "text": "Other Vampires you control get +1/+1.",
             "colours": [
@@ -9949,7 +9949,7 @@
         },
         {
             "id": "2c4461cc-fd30-50f9-9604-2b648717f64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c6c4b-62ab-4d44-a2d7-64b44d163606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c6c4b-62ab-4d44-a2d7-64b44d163606.jpg?1",
             "name": "Chandra, Flame's Fury",
             "text": "+1: Chandra, Flame's Fury deals 2 damage to any target.\n\u22122: Chandra, Flame's Fury deals 4 damage to target creature and 2 damage to that creature's controller.\n\u22128: Chandra, Flame's Fury deals 10 damage to target player and each creature that player controls.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "a7c64488-416f-59aa-a965-0bbe3dec232a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f13b6a7-fa62-4d94-a56c-f2e64c8c1666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f13b6a7-fa62-4d94-a56c-f2e64c8c1666.jpg?1",
             "name": "Chandra's Flame Wave",
             "text": "Chandra's Flame Wave deals 2 damage to target player and each creature that player controls. Search your library and/or graveyard for a card named Chandra, Flame's Fury, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10015,7 +10015,7 @@
         },
         {
             "id": "c63d90f8-0cc6-5505-9dfb-2e312f922771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57f8b5-fde9-498d-82bf-34bfb2370703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d57f8b5-fde9-498d-82bf-34bfb2370703.jpg?1",
             "name": "Pyroclastic Elemental",
             "text": "{1}{R}{R}: Pyroclastic Elemental deals 1 damage to target player.",
             "colours": [
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "14635f42-59f0-5a42-b117-33d21dfe93a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e317c-55c4-43b2-91aa-3e0009cfd7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e317c-55c4-43b2-91aa-3e0009cfd7d5.jpg?1",
             "name": "Wildfire Elemental",
             "text": "Whenever an opponent is dealt noncombat damage, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "f12523f2-916c-5bcd-9b8d-19db17ff57c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ead409-3bce-47c8-ace7-498c38522369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ead409-3bce-47c8-ace7-498c38522369.jpg?1",
             "name": "Vivien, Nature's Avenger",
             "text": "+1: Put three +1/+1 counters on up to one target creature.\n\u22121: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.\n\u22126: Target creature gets +10/+10 and gains trample until end of turn.",
             "colours": [
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "eb4dfa31-77bc-5a35-ba4a-546b196513a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4d0ed2-3fc5-4cb0-b886-e30b21e76872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4d0ed2-3fc5-4cb0-b886-e30b21e76872.jpg?1",
             "name": "Ethereal Elk",
             "text": "Trample\nWhen Ethereal Elk enters the battlefield, you may search your library and/or graveyard for a card named Vivien, Nature's Avenger, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10150,7 +10150,7 @@
         },
         {
             "id": "27df42ef-84ae-5145-8743-fbf9785c1396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a69558-aca0-413d-9762-2fa115b44abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a69558-aca0-413d-9762-2fa115b44abd.jpg?1",
             "name": "Gnarlback Rhino",
             "text": "Trample  (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever you cast a spell that targets Gnarlback Rhino, draw a card.",
             "colours": [
@@ -10183,7 +10183,7 @@
         },
         {
             "id": "7bb445ee-2072-5eb2-9f22-786cda2943de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c51c6bd-2ecc-4d92-a406-fcb31e889b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c51c6bd-2ecc-4d92-a406-fcb31e889b45.jpg?1",
             "name": "Vivien's Crocodile",
             "text": "Vivien's Crocodile gets +1/+1 as long as you control a Vivien planeswalker.",
             "colours": [
@@ -10217,7 +10217,7 @@
         },
         {
             "id": "e751bbfb-1c25-56fb-8924-e401cbe01f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e058dc51-b200-42ee-a345-a63cfaa397fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e058dc51-b200-42ee-a345-a63cfaa397fe.jpg?1",
             "name": "Angelic Guardian",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever one or more creatures you control attack, they gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "5c57289c-2c3d-53f8-bf05-be120458c3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbf17a0-2dbc-4e79-9cfa-ea49b1605105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbf17a0-2dbc-4e79-9cfa-ea49b1605105.jpg?1",
             "name": "Bastion Enforcer",
             "text": "",
             "colours": [
@@ -10284,7 +10284,7 @@
         },
         {
             "id": "1c033da6-da7b-5560-8066-120876f1604f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f32ff8-3b49-4ce8-96a0-ba0d99477de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f32ff8-3b49-4ce8-96a0-ba0d99477de1.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "2dad816e-1ef7-550f-baff-927218d4fb50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766418a-eb1d-4536-ae51-7f3e8969bb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766418a-eb1d-4536-ae51-7f3e8969bb78.jpg?1",
             "name": "Haazda Officer",
             "text": "When Haazda Officer enters the battlefield, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "5a0e121f-4029-5cd9-bae2-f6b871421704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696d6c4b-69d7-498b-87d4-0a03b16cc971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696d6c4b-69d7-498b-87d4-0a03b16cc971.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "9f78ffca-f760-5f31-b744-915922165e16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd3aca5-516f-4500-9d7f-95630401d3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd3aca5-516f-4500-9d7f-95630401d3ae.jpg?1",
             "name": "Imperial Outrider",
             "text": "",
             "colours": [
@@ -10419,7 +10419,7 @@
         },
         {
             "id": "e47ab002-1e17-5894-bddd-274d7fbe3e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d57e98-e05a-4a89-900e-20fe675a62ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d57e98-e05a-4a89-900e-20fe675a62ef.jpg?1",
             "name": "Ironclad Krovod",
             "text": "",
             "colours": [
@@ -10452,7 +10452,7 @@
         },
         {
             "id": "fcc224b4-f27e-56da-9b4a-131b52243f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e689e4a-fc54-46f4-b0c5-c0e65d88340e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e689e4a-fc54-46f4-b0c5-c0e65d88340e.jpg?1",
             "name": "Prowling Caracal",
             "text": "",
             "colours": [
@@ -10485,7 +10485,7 @@
         },
         {
             "id": "da74d0e9-949a-58d7-ab5f-98f40f354429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84784231-2675-4b5b-929f-a796c091a77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84784231-2675-4b5b-929f-a796c091a77c.jpg?1",
             "name": "Serra's Guardian",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)\nOther creatures you control have vigilance.",
             "colours": [
@@ -10518,7 +10518,7 @@
         },
         {
             "id": "dbf863b4-1ed9-5366-9054-8f984830b60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab07387-a9f2-4325-804e-6383408644fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab07387-a9f2-4325-804e-6383408644fd.jpg?1",
             "name": "Show of Valor",
             "text": "Target creature gets +2/+4 until end of turn.",
             "colours": [
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "72e54935-48e8-50dc-820e-5841a9d22a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fd27a8-2de6-454f-8174-a60918bfe60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fd27a8-2de6-454f-8174-a60918bfe60e.jpg?1",
             "name": "Siege Mastodon",
             "text": "",
             "colours": [
@@ -10582,7 +10582,7 @@
         },
         {
             "id": "44540cc0-df49-5ec4-99ce-0912a62c99ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fff340-8e2a-4182-9ece-af5749fa0d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fff340-8e2a-4182-9ece-af5749fa0d2e.jpg?1",
             "name": "Take Vengeance",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -10613,7 +10613,7 @@
         },
         {
             "id": "9be5f44f-99a9-50b3-a4fe-5c460c3a0956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e3a90c-1e5c-4646-b3d5-ff46d3fa7b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e3a90c-1e5c-4646-b3d5-ff46d3fa7b35.jpg?1",
             "name": "Trusted Pegasus",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Trusted Pegasus attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -10646,7 +10646,7 @@
         },
         {
             "id": "840dc5c0-a0fb-56e6-b498-fce4c8daa011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a74ccf-8165-4db1-a87c-52c2d8ea0058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a74ccf-8165-4db1-a87c-52c2d8ea0058.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -10679,7 +10679,7 @@
         },
         {
             "id": "8d640ae6-74a2-59a6-810d-31d1fb4972e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbdf06-f6b5-4bd8-80bf-6d7e57649684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbdf06-f6b5-4bd8-80bf-6d7e57649684.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior can't be blocked.",
             "colours": [
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "91b5eab6-d892-5e18-a039-cebe8bbcd51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980e24c-bcb4-479c-8012-f19f4e87f0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7980e24c-bcb4-479c-8012-f19f4e87f0bf.jpg?1",
             "name": "Riddlemaster Sphinx",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Riddlemaster Sphinx enters the battlefield, you may return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "5a08acdf-9102-557e-9efa-675302dd4c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46580c-a204-4b0b-8526-2310b1ca32b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef46580c-a204-4b0b-8526-2310b1ca32b4.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10779,7 +10779,7 @@
         },
         {
             "id": "2f9156cc-67e0-5512-8370-041654ccaf1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e41d8-317d-46ce-b858-54df716e0214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e41d8-317d-46ce-b858-54df716e0214.jpg?1",
             "name": "Bartizan Bats",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -10812,7 +10812,7 @@
         },
         {
             "id": "5b41762a-7993-5a12-92bc-6760b8709b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad005eef-d4e4-4f46-81a5-9bbce87014ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad005eef-d4e4-4f46-81a5-9bbce87014ce.jpg?1",
             "name": "Bogstomper",
             "text": "",
             "colours": [
@@ -10845,7 +10845,7 @@
         },
         {
             "id": "dc4538c3-5c55-5fe1-8b78-424d04c17103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c926d38-a741-47a9-8961-f5bcf2909939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c926d38-a741-47a9-8961-f5bcf2909939.jpg?1",
             "name": "Dark Remedy",
             "text": "Target creature gets +1/+3 until end of turn.",
             "colours": [
@@ -10876,7 +10876,7 @@
         },
         {
             "id": "5a0dc207-0029-55a2-bf55-5505a739f928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7debd8f7-2f34-4fdd-8eb6-fa8f9d2a60e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7debd8f7-2f34-4fdd-8eb6-fa8f9d2a60e8.jpg?1",
             "name": "Disentomb",
             "text": "Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "005128a5-0ca3-5de7-af80-728272d13938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f624f77-032f-4b28-bec2-95d3a3fcb806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f624f77-032f-4b28-bec2-95d3a3fcb806.jpg?1",
             "name": "Gravewaker",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{5}{B}{B}: Return target creature card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "4dc29d14-c224-508b-8847-0b008d1b8a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db03880-0138-44f8-8147-f2c07878a7d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db03880-0138-44f8-8147-f2c07878a7d8.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -10975,7 +10975,7 @@
         },
         {
             "id": "eff2ce72-a76a-5cb2-8cea-285793a73d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dacbb2-21e1-4220-bf43-75a0729cdc60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dacbb2-21e1-4220-bf43-75a0729cdc60.jpg?1",
             "name": "Sorin's Thirst",
             "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -11006,7 +11006,7 @@
         },
         {
             "id": "6fb959bd-f671-52c7-8ef9-b3bd816d50ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4b4a9-73a8-4135-b150-cd78d1558aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4b4a9-73a8-4135-b150-cd78d1558aca.jpg?1",
             "name": "Vampire Opportunist",
             "text": "{6}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -11039,7 +11039,7 @@
         },
         {
             "id": "77480c7c-d076-5c3f-b0f9-79d17d40d7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e94f0-5f64-4991-aa45-c2b05879be40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e94f0-5f64-4991-aa45-c2b05879be40.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "892697bd-a4ba-5616-b22e-287ca41f802d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f198c7e3-8a85-48f3-a7c2-93320fd4fb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f198c7e3-8a85-48f3-a7c2-93320fd4fb81.jpg?1",
             "name": "Engulfing Eruption",
             "text": "Engulfing Eruption deals 5 damage to target creature.",
             "colours": [
@@ -11103,7 +11103,7 @@
         },
         {
             "id": "e0675984-33ac-560e-a95f-581e7d32be40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f08297-f477-4330-a99e-3f0847c31364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f08297-f477-4330-a99e-3f0847c31364.jpg?1",
             "name": "Fearless Halberdier",
             "text": "",
             "colours": [
@@ -11137,7 +11137,7 @@
         },
         {
             "id": "4d7737fc-3e0e-58a4-8935-98eef2594c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfefb65-b6e4-44a1-baa9-d3c00ee8ba96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfefb65-b6e4-44a1-baa9-d3c00ee8ba96.jpg?1",
             "name": "Goblin Assailant",
             "text": "",
             "colours": [
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "a69968a6-8ee2-5bad-a338-814d25184465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1263ea-adc9-442b-b13e-9afb69596372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1263ea-adc9-442b-b13e-9afb69596372.jpg?1",
             "name": "Hostile Minotaur",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "1e4709d0-4e59-5ba4-a894-bb65f6194986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb9f15-be65-494c-9672-162d38c6f0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb9f15-be65-494c-9672-162d38c6f0a5.jpg?1",
             "name": "Immortal Phoenix",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Immortal Phoenix dies, return it to its owner's hand.",
             "colours": [
@@ -11237,7 +11237,7 @@
         },
         {
             "id": "bcd69a94-54b5-54d4-a6aa-d2389a134c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9bcbd-48fe-4a74-aae5-a447c99aa64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff9bcbd-48fe-4a74-aae5-a447c99aa64b.jpg?1",
             "name": "Nimble Birdsticker",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "7fdc2d47-7737-54f0-814a-3f7423fd7dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d43107-713d-4ff2-8cbd-237c7393229f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d43107-713d-4ff2-8cbd-237c7393229f.jpg?1",
             "name": "Rubblebelt Recluse",
             "text": "Rubblebelt Recluse attacks each combat if able.",
             "colours": [
@@ -11304,7 +11304,7 @@
         },
         {
             "id": "2c2eeb5a-aebc-5e9c-94b3-ffe6b6789407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227cf1b5-f85b-41fe-be98-66e383652039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227cf1b5-f85b-41fe-be98-66e383652039.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -11337,7 +11337,7 @@
         },
         {
             "id": "899a3f69-1528-594a-8003-a5284a6549b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35574c7-c21c-4d07-87b5-9935b8da9832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35574c7-c21c-4d07-87b5-9935b8da9832.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
             "colours": [
@@ -11370,7 +11370,7 @@
         },
         {
             "id": "4b116081-a7c3-550b-84df-151150ab152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e68b3bd-996e-4383-b134-f529bcb768de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e68b3bd-996e-4383-b134-f529bcb768de.jpg?1",
             "name": "Aggressive Mammoth",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nOther creatures you control have trample.",
             "colours": [
@@ -11403,7 +11403,7 @@
         },
         {
             "id": "017ca6ca-786a-53d4-9d7d-ea3b4f7a42d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9f200-cfbf-4d59-9294-2bbbd532fedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d9f200-cfbf-4d59-9294-2bbbd532fedf.jpg?1",
             "name": "Bristling Boar",
             "text": "Bristling Boar can't be blocked by more than one creature.",
             "colours": [
@@ -11436,7 +11436,7 @@
         },
         {
             "id": "67a00222-d84e-59f9-ab75-9d3b62a9f589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7fabb-dcb6-4c21-87ee-2893b63814be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7fabb-dcb6-4c21-87ee-2893b63814be.jpg?1",
             "name": "Canopy Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -11469,7 +11469,7 @@
         },
         {
             "id": "58426fe8-6bd9-595d-b6c0-facd81e7c3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c755ff-3fbb-4128-9357-0874eb61ff4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c755ff-3fbb-4128-9357-0874eb61ff4c.jpg?1",
             "name": "Frilled Sandwalla",
             "text": "{1}{G}: Frilled Sandwalla gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "a7cf1fa8-01a9-556b-9b04-565fe472a71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ca08a0-c58d-4c13-bf63-0401d89839b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ca08a0-c58d-4c13-bf63-0401d89839b4.jpg?1",
             "name": "Oakenform",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -11535,7 +11535,7 @@
         },
         {
             "id": "71c635c7-d4c1-5113-bf22-8a3309efbd53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1604-379f-4f03-97ae-9ec10921167c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1604-379f-4f03-97ae-9ec10921167c.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -11568,7 +11568,7 @@
         },
         {
             "id": "b0f4a723-571f-5ba6-b83b-6aa15a59a756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db41405-87a2-4a91-97f4-a8af2ffe8313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db41405-87a2-4a91-97f4-a8af2ffe8313.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -11599,7 +11599,7 @@
         },
         {
             "id": "60b4a9c4-3d29-5b6b-8fd0-6989d2b14061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6117cf-5cb3-41f3-8756-c01b5e9c760e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6117cf-5cb3-41f3-8756-c01b5e9c760e.jpg?1",
             "name": "Woodland Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "53988e4b-3d74-596f-995d-60cf887ba60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0819e8e-fb7e-43c7-a7cf-d768f43193ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0819e8e-fb7e-43c7-a7cf-d768f43193ac.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "",
             "colours": [
@@ -11668,7 +11668,7 @@
         },
         {
             "id": "f2cbf987-d22b-53f3-8380-c47500cfd063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491d9da-a58d-4423-b565-c5a99ef63132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491d9da-a58d-4423-b565-c5a99ef63132.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -11702,7 +11702,7 @@
         },
         {
             "id": "b3210763-b1ad-5c39-ac11-3e17e9686a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b17be6-2ee7-4f3b-88df-f298bb058f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b17be6-2ee7-4f3b-88df-f298bb058f46.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -11736,7 +11736,7 @@
         },
         {
             "id": "ca6d83fb-b49f-5c6a-9fb5-2a440611007e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5582cd9-97e7-426f-a084-c05e2113ad13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5582cd9-97e7-426f-a084-c05e2113ad13.jpg?1",
             "name": "Elemental Bird",
             "text": "",
             "colours": [
@@ -11771,7 +11771,7 @@
         },
         {
             "id": "82c844d0-9918-52d5-8bf1-201e32ea2acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb61889-9bc6-426d-8ce5-7b1c0e6e959b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb61889-9bc6-426d-8ce5-7b1c0e6e959b.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "15ce7217-21d5-55fe-8300-e0f4dd3af2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f0436e-9328-4266-9cf8-80b557a0c17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f0436e-9328-4266-9cf8-80b557a0c17c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -11839,7 +11839,7 @@
         },
         {
             "id": "4577d236-59d6-53d7-9331-15ff1a6effc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0574973b-a0d1-4e17-9ed7-42a98d25bb8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0574973b-a0d1-4e17-9ed7-42a98d25bb8d.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -11873,7 +11873,7 @@
         },
         {
             "id": "d5433564-9c16-55ad-bbfb-6dcb6b455128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd05e304-1a16-436d-a05c-4a38a839759b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd05e304-1a16-436d-a05c-4a38a839759b.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -11907,7 +11907,7 @@
         },
         {
             "id": "b43ba6b7-b2ce-536f-a00e-69731d200803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea4711-a951-4a1b-88cb-f628f97b6164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ea4711-a951-4a1b-88cb-f628f97b6164.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -11938,7 +11938,7 @@
         },
         {
             "id": "0060ce13-67e2-5607-a29b-721c743e6770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e54aad-ec80-4914-9ba8-91bd53924778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e54aad-ec80-4914-9ba8-91bd53924778.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "2a968099-56c5-537d-9a6d-4572aca7e147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775f2b3e-4e3b-4037-b7bb-117ababf8e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775f2b3e-4e3b-4037-b7bb-117ababf8e51.jpg?1",
             "name": "Chandra, Awakened Inferno Emblem",
             "text": "",
             "colours": [],
@@ -11995,7 +11995,7 @@
         },
         {
             "id": "67788734-e110-5b49-8be6-adc6fe6872f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc0849c-3a2b-4666-8fa9-755f3ea27706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc0849c-3a2b-4666-8fa9-755f3ea27706.jpg?1",
             "name": "Mu Yanling, Sky Dancer Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/M21.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/M21.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "043fe0a6-9b4d-53fa-8a70-822ac47c7c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c017fa9-7021-417a-9c2e-3df409644fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c017fa9-7021-417a-9c2e-3df409644fcf.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to any target.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -39,7 +39,7 @@
         },
         {
             "id": "3e14f46a-b9a6-518b-9160-f88b40ad409c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c392a7e5-6ff5-4c2f-9590-f8811a724f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c392a7e5-6ff5-4c2f-9590-f8811a724f44.jpg?1",
             "name": "Alpine Watchdog",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "5cb931df-3664-5562-a74d-6ee5158ab980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cca776-b0e4-4cd2-815f-36c1f86cf497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8cca776-b0e4-4cd2-815f-36c1f86cf497.jpg?1",
             "name": "Angelic Ascension",
             "text": "Exile target creature or planeswalker. Its controller creates a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "4bfeea76-d8f7-5e4b-a89f-81949daa4820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c977c67-b0c0-40b0-b129-28de094aaf40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c977c67-b0c0-40b0-b129-28de094aaf40.jpg?1",
             "name": "Anointed Chorister",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\n{4}{W}: Anointed Chorister gets +3/+3 until end of turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "11d84ff0-bea3-5683-87d0-c4af1fc60a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b57247-81cc-44ec-b5a9-0702111a98a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b57247-81cc-44ec-b5a9-0702111a98a8.jpg?1",
             "name": "Aven Gagglemaster",
             "text": "Flying\nWhen Aven Gagglemaster enters the battlefield, you gain 2 life for each creature you control with flying.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "1ce537ed-082e-5988-aa9e-87a721070ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd3014b-94bb-4a9f-92cf-239a2dcc7e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bd3014b-94bb-4a9f-92cf-239a2dcc7e97.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "7c578972-34bd-528a-80d2-f8c54ea430f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c85699-2daf-4e87-a3be-465d02bd64bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c85699-2daf-4e87-a3be-465d02bd64bb.jpg?1",
             "name": "Basri Ket",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains indestructible until end of turn.\n\u22122: Whenever one or more nontoken creatures attack this turn, create that many 1/1 white Soldier creature tokens that are tapped and attacking.\n\u22126: You get an emblem with \"At the beginning of combat on your turn, create a 1/1 white Soldier creature token, then put a +1/+1 counter on each creature you control.\"",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "0019b544-ed73-5c43-80d0-0826d38d709c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d1dd97-2675-4953-ab95-d47d23abfe05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d1dd97-2675-4953-ab95-d47d23abfe05.jpg?1",
             "name": "Basri's Acolyte",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen Basri's Acolyte enters the battlefield, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -287,7 +287,7 @@
         },
         {
             "id": "32909923-dfe2-5adf-881d-673a1716cd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1eae0-1bf8-4922-a9e3-45c01ece9005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1eae0-1bf8-4922-a9e3-45c01ece9005.jpg?1",
             "name": "Basri's Lieutenant",
             "text": "Vigilance, protection from multicolored\nWhen Basri's Lieutenant enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Basri's Lieutenant or another creature you control dies, if it had a +1/+1 counter on it, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "db960319-4880-5fa6-9db0-b8409fc91156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e6fdc0-bdd4-4bba-b8f1-bbc8dfad038e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e6fdc0-bdd4-4bba-b8f1-bbc8dfad038e.jpg?1",
             "name": "Basri's Solidarity",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "d735554e-15ae-5af7-9fb3-cc43514d976b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46666fba-d4a7-4687-8747-a42e4c6d853e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46666fba-d4a7-4687-8747-a42e4c6d853e.jpg?1",
             "name": "Celestial Enforcer",
             "text": "{1}{W}, {T}: Tap target creature. Activate this ability only if you control a creature with flying.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "fb0c0b23-7afe-55f8-ab67-54a325c7e5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600d3517-e370-47ae-ac4f-c7ef8995a89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600d3517-e370-47ae-ac4f-c7ef8995a89c.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "59df52f8-8b22-579c-acb9-2fd576785692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e8dba-5c86-4e32-8a52-61402f7fe9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e8dba-5c86-4e32-8a52-61402f7fe9f0.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -464,7 +464,7 @@
         },
         {
             "id": "7e84bd4c-c067-58e8-8a61-e819aa36a2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff87a671-054f-4357-8a62-450d36559a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff87a671-054f-4357-8a62-450d36559a1b.jpg?1",
             "name": "Daybreak Charger",
             "text": "When Daybreak Charger enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -498,7 +498,7 @@
         },
         {
             "id": "8c363ddb-c725-55a1-b13d-707237c3335b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c23869b-c99a-49dd-9e29-fcc0eb63fad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c23869b-c99a-49dd-9e29-fcc0eb63fad1.jpg?1",
             "name": "Defiant Strike",
             "text": "Target creature gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "6a7f21d2-3a0f-52ab-8f7e-94c6e34fb2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3de35fd-425d-46b8-bc7d-c2f05d86858d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3de35fd-425d-46b8-bc7d-c2f05d86858d.jpg?1",
             "name": "Dub",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has first strike, and is a Knight in addition to its other types. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "d182bba0-5e83-5d4c-92b0-6684ab627dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e742d49-e6f0-4016-ba4c-11878fad89cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e742d49-e6f0-4016-ba4c-11878fad89cb.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "4fbda3a7-9a2e-523c-8b63-ba54ed4b8be5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4733e6-6fe2-4460-ac9f-82feb583d790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4733e6-6fe2-4460-ac9f-82feb583d790.jpg?1",
             "name": "Falconer Adept",
             "text": "Whenever Falconer Adept attacks, create a 1/1 white Bird creature token with flying that's tapped and attacking.",
             "colours": [
@@ -633,7 +633,7 @@
         },
         {
             "id": "56a98be7-1df5-5b21-8c00-996fbabd40b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73148b3b-73d3-4f57-8b67-1e91fbe112b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73148b3b-73d3-4f57-8b67-1e91fbe112b9.jpg?1",
             "name": "Feat of Resistance",
             "text": "Put a +1/+1 counter on target creature you control. It gains protection from the color of your choice until end of turn. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything of that color.)",
             "colours": [
@@ -665,7 +665,7 @@
         },
         {
             "id": "68ea4434-9621-5234-a20f-8674784902d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3b99c-e48e-4f4d-ba7a-e9218137b432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3b99c-e48e-4f4d-ba7a-e9218137b432.jpg?1",
             "name": "Gale Swooper",
             "text": "Flying\nWhen Gale Swooper enters the battlefield, target creature gains flying until end of turn.",
             "colours": [
@@ -699,7 +699,7 @@
         },
         {
             "id": "1561202d-3f48-529e-83e0-88c40b749637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d154d3-7ae5-43ff-9978-d974285e2c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d154d3-7ae5-43ff-9978-d974285e2c89.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "2f01a003-8001-526d-b4f9-823e579b08df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea1ee60-5644-4f78-913d-32c36065957f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea1ee60-5644-4f78-913d-32c36065957f.jpg?1",
             "name": "Griffin Aerie",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, create a 2/2 white Griffin creature token with flying.",
             "colours": [
@@ -765,7 +765,7 @@
         },
         {
             "id": "906e4af4-3d7a-5099-990c-12f9d35362ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60e84e-be05-49da-9720-4225abe9d003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d60e84e-be05-49da-9720-4225abe9d003.jpg?1",
             "name": "Idol of Endurance",
             "text": "When Idol of Endurance enters the battlefield, exile all creature cards with converted mana cost 3 or less from your graveyard until Idol of Endurance leaves the battlefield.\n{1}{W}, {T}: Until end of turn, you may cast a creature spell from among the cards exiled with Idol of Endurance without paying its mana cost.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "5cd1f670-751d-5dea-81dc-a277225a0001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032f6c5a-8d88-4a55-a54b-28df42d801e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032f6c5a-8d88-4a55-a54b-28df42d801e1.jpg?1",
             "name": "Legion's Judgment",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -831,7 +831,7 @@
         },
         {
             "id": "5dd0e7a1-30e3-59a9-8ba8-803bf34f35ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f80411-0a95-4e0a-b7a8-af23ddf385cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f80411-0a95-4e0a-b7a8-af23ddf385cc.jpg?1",
             "name": "Light of Promise",
             "text": "Enchant creature\nEnchanted creature has \"Whenever you gain life, put that many +1/+1 counters on this creature.\"",
             "colours": [
@@ -865,7 +865,7 @@
         },
         {
             "id": "d0133387-1d3f-5906-af1d-4a514eca182f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a500e6-01f5-4a3a-8839-68b9b515e919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a500e6-01f5-4a3a-8839-68b9b515e919.jpg?1",
             "name": "Makeshift Battalion",
             "text": "Whenever Makeshift Battalion and at least two other creatures attack, put a +1/+1 counter on Makeshift Battalion.",
             "colours": [
@@ -900,7 +900,7 @@
         },
         {
             "id": "7050d1d1-9e22-5f4d-8b71-eccdd07bd2ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e628f-5fc5-4c17-a07d-448d361d7e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4e628f-5fc5-4c17-a07d-448d361d7e7c.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -939,7 +939,7 @@
         },
         {
             "id": "5ba544d1-5cb8-5ba4-adf5-481dfb3b561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b7a73-484e-48f1-944c-3d38866cdc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b7a73-484e-48f1-944c-3d38866cdc20.jpg?1",
             "name": "Nine Lives",
             "text": "Hexproof\nIf a source would deal damage to you, prevent that damage and put an incarnation counter on Nine Lives.\nWhen there are nine or more incarnation counters on Nine Lives, exile it.\nWhen Nine Lives leaves the battlefield, you lose the game.",
             "colours": [
@@ -973,7 +973,7 @@
         },
         {
             "id": "22c59fda-026a-58c6-b89b-6c70aff04128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b94bc1-68d1-41dc-914c-a33ecb9aeb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b94bc1-68d1-41dc-914c-a33ecb9aeb49.jpg?1",
             "name": "Pack Leader",
             "text": "Other Dogs you control get +1/+1.\nWhenever Pack Leader attacks, prevent all combat damage that would be dealt this turn to Dogs you control.",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "ad58e121-f580-5b9b-b9ef-80b2d366e56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f602ecc-c264-4f3e-adeb-d0186668653e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f602ecc-c264-4f3e-adeb-d0186668653e.jpg?1",
             "name": "Rambunctious Mutt",
             "text": "When Rambunctious Mutt enters the battlefield, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "037d5cf0-690c-5738-89ce-0d9657612404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bd4bce-8ab0-40b9-aad7-7d57a011bb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3bd4bce-8ab0-40b9-aad7-7d57a011bb0b.jpg?1",
             "name": "Revitalize",
             "text": "You gain 3 life.\nDraw a card.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "8938f316-7700-5c85-a790-d7cd90663885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61296b2d-4e5c-419a-8775-4e6af902c7b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61296b2d-4e5c-419a-8775-4e6af902c7b1.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen card name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "71279c87-cb41-5410-b588-5196eea5a34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a5478a-1a2c-4117-b543-da083ed2b562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a5478a-1a2c-4117-b543-da083ed2b562.jpg?1",
             "name": "Sanctum of Tranquil Light",
             "text": "{5}{W}: Tap target creature. This ability costs {1} less to activate for each Shrine you control.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "52a97e8b-5446-56c9-bb11-c73311f8af09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb59931-8941-46fb-8e1c-f80ff3730dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb59931-8941-46fb-8e1c-f80ff3730dd9.jpg?1",
             "name": "Seasoned Hallowblade",
             "text": "Discard a card: Tap Seasoned Hallowblade. It gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "19da977f-bd0c-5294-9b40-676d727afbc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6467d96-e43a-4b1e-b6ce-578d991077b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6467d96-e43a-4b1e-b6ce-578d991077b5.jpg?1",
             "name": "Secure the Scene",
             "text": "Exile target nonland permanent. Its controller creates a 1/1 white Soldier creature token.",
             "colours": [
@@ -1213,7 +1213,7 @@
         },
         {
             "id": "27e7feb4-9849-5908-9632-82075e26ede7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911759c-7177-402c-a95a-f9f46efaf521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911759c-7177-402c-a95a-f9f46efaf521.jpg?1",
             "name": "Selfless Savior",
             "text": "Sacrifice Selfless Savior: Another target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "3d2d2145-2a21-50aa-b288-11f2b6df3544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ffa89-e6ee-466c-8edc-dd24c8b52e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0ffa89-e6ee-466c-8edc-dd24c8b52e80.jpg?1",
             "name": "Siege Striker",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\nWhenever Siege Striker attacks, you may tap any number of untapped creatures you control. Siege Striker gets +1/+1 until end of turn for each creature tapped this way.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "ba3db924-b9ec-5dcf-b0c7-73c0503e80da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44b96a-8498-414a-a4ac-54c80dfa9f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f44b96a-8498-414a-a4ac-54c80dfa9f23.jpg?1",
             "name": "Speaker of the Heavens",
             "text": "Vigilance, lifelink\n{T}: Create a 4/4 white Angel creature token with flying. Activate this ability only if you have at least 7 life more than your starting life total and only any time you could cast a sorcery.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "6ab09c61-4fe7-5446-8447-c2a59ad60d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17f25a-32d1-469b-bb5f-f1761e227990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db17f25a-32d1-469b-bb5f-f1761e227990.jpg?1",
             "name": "Staunch Shieldmate",
             "text": "",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "05bc36cc-4347-5061-9d1e-5772e311142c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90c1ad0-83bd-471c-8d4c-e65bc2abaa18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90c1ad0-83bd-471c-8d4c-e65bc2abaa18.jpg?1",
             "name": "Swift Response",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "9a2bd06a-61cf-56c1-96b7-784f5eda2663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43d7bc-173c-41eb-bba9-a9d94dcfc5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b43d7bc-173c-41eb-bba9-a9d94dcfc5fa.jpg?1",
             "name": "Tempered Veteran",
             "text": "{W}, {T}: Put a +1/+1 counter on target creature with a +1/+1 counter on it.\n{4}{W}{W}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -1423,7 +1423,7 @@
         },
         {
             "id": "b51e3999-985e-550b-a64a-aba9c0e0c767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01cb8c-f080-456b-a91a-f1d7943a70b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01cb8c-f080-456b-a91a-f1d7943a70b2.jpg?1",
             "name": "Valorous Steed",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Valorous Steed enters the battlefield, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "c41fd96f-0995-5727-84ec-c890ac190370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b59819-4746-4c67-b6e5-4157d498a065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b59819-4746-4c67-b6e5-4157d498a065.jpg?1",
             "name": "Vryn Wingmare",
             "text": "Flying\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "6946abf5-70ea-5f10-ac99-a650b870aac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f234999b-54e9-40f5-a537-7d6ce169c710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f234999b-54e9-40f5-a537-7d6ce169c710.jpg?1",
             "name": "Warded Battlements",
             "text": "Defender (This creature can't attack.)\nAttacking creatures you control get +1/+0.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "bf4b9385-3847-56c2-a02c-6181263baef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb078fbb-beb9-4c0b-be93-ed1e73e6f8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb078fbb-beb9-4c0b-be93-ed1e73e6f8d8.jpg?1",
             "name": "Barrin, Tolarian Archmage",
             "text": "When Barrin, Tolarian Archmage enters the battlefield, return up to one other target creature or planeswalker to its owner's hand.\nAt the beginning of your end step, if a permanent was put into your hand from the battlefield this turn, draw a card.",
             "colours": [
@@ -1564,7 +1564,7 @@
         },
         {
             "id": "39888b37-6e61-521e-bf4d-95f43c11276a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e14910-ee2e-49ae-855e-46a8ab6cad82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e14910-ee2e-49ae-855e-46a8ab6cad82.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "c4b0ef6d-9e51-5328-9966-e6291576e6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ed9f08-56e8-4e24-aae2-05270d7c1ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ed9f08-56e8-4e24-aae2-05270d7c1ba8.jpg?1",
             "name": "Capture Sphere",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "aef030f4-9f94-50ff-8390-c139b7f91c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ba0a8-04e9-4df6-af20-a3ca4470cdcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ba0a8-04e9-4df6-af20-a3ca4470cdcc.jpg?1",
             "name": "Discontinuity",
             "text": "As long as it's your turn, this spell costs {2}{U}{U} less to cast.\nEnd the turn. (Exile all spells and abilities from the stack, including this card. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -1664,7 +1664,7 @@
         },
         {
             "id": "a29732cd-96f4-5d75-9a48-520d118e9e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc7176-abe0-47cf-a242-cf22a1f590be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc7176-abe0-47cf-a242-cf22a1f590be.jpg?1",
             "name": "Enthralling Hold",
             "text": "Enchant creature\nYou can't choose an untapped creature as this spell's target as you cast it.\nYou control enchanted creature.",
             "colours": [
@@ -1698,7 +1698,7 @@
         },
         {
             "id": "8eda09ee-8008-5cdc-9019-bf876dc3d46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14abb0-0e9f-448e-85d7-6cb71f756c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14abb0-0e9f-448e-85d7-6cb71f756c56.jpg?1",
             "name": "Frantic Inventory",
             "text": "Draw a card, then draw cards equal to the number of cards named Frantic Inventory in your graveyard.",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "cf5081c6-9170-5acf-9e87-7b7e6323d97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc485-d3c1-4826-933d-89f66df769d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393fc485-d3c1-4826-933d-89f66df769d4.jpg?1",
             "name": "Frost Breath",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1764,7 +1764,7 @@
         },
         {
             "id": "d91d2746-fef9-5c80-b20c-b76f18002c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2810631f-c55c-4947-a26f-4d3ce76024b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2810631f-c55c-4947-a26f-4d3ce76024b3.jpg?1",
             "name": "Ghostly Pilferer",
             "text": "Whenever Ghostly Pilferer becomes untapped, you may pay {2}. If you do, draw a card.\nWhenever an opponent casts a spell from anywhere other than their hand, draw a card.\nDiscard a card: Ghostly Pilferer can't be blocked this turn.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "823ea366-8342-5201-a831-ac3dd5bc5745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a188164c-01fe-4980-83a5-91d14e218cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a188164c-01fe-4980-83a5-91d14e218cf5.jpg?1",
             "name": "Jeskai Elder",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jeskai Elder deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "b696f264-dd18-5988-818f-00a21b54f4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce6289e-f665-4faa-8285-c843447f3e52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce6289e-f665-4faa-8285-c843447f3e52.jpg?1",
             "name": "Keen Glidemaster",
             "text": "{2}{U}: Target creature gains flying until end of turn.",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "69f3c1fa-7c4c-5c5c-b1c8-1fde8e77a738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb33529b-80bd-4f52-94cc-d8371c53ad75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb33529b-80bd-4f52-94cc-d8371c53ad75.jpg?1",
             "name": "Library Larcenist",
             "text": "Whenever Library Larcenist attacks, draw a card.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "b2249315-3d89-5a46-9638-1d5c048dc388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64832674-beb1-446e-b2f7-8a5e271139a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64832674-beb1-446e-b2f7-8a5e271139a5.jpg?1",
             "name": "Lofty Denial",
             "text": "Counter target spell unless its controller pays {1}. If you control a creature with flying, counter that spell unless its controller pays {4} instead.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "2d343392-9f38-57b8-ac75-8ae19b93e9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033afbd5-9937-4957-98ba-48e469a490bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/033afbd5-9937-4957-98ba-48e469a490bb.jpg?1",
             "name": "Miscast",
             "text": "Counter target instant or sorcery spell unless its controller pays {3}.",
             "colours": [
@@ -1970,7 +1970,7 @@
         },
         {
             "id": "203022a6-c681-56c0-a248-0648b5ece15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d961c441-b76b-4bd8-b510-a3e073207a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d961c441-b76b-4bd8-b510-a3e073207a1b.jpg?1",
             "name": "Mistral Singer",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "ffda1ffd-b843-5c2b-896b-ed28d1fd6205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323db259-d35e-467d-9a46-4adcb2fc107c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323db259-d35e-467d-9a46-4adcb2fc107c.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2036,7 +2036,7 @@
         },
         {
             "id": "be541ae3-6bb5-58e3-8f15-401ddd1225d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1501118-5837-49b5-9446-0bc3032035ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1501118-5837-49b5-9446-0bc3032035ca.jpg?1",
             "name": "Pursued Whale",
             "text": "When Pursued Whale enters the battlefield, each opponent creates a 1/1 red Pirate creature token with \"This creature can't block\" and \"Creatures you control attack each combat if able.\"\nSpells your opponents cast that target Pursued Whale cost {3} more to cast.",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "33ccf9d0-8329-5458-9642-612efc55b56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da367981-9d6f-419f-9f58-f969b6183336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da367981-9d6f-419f-9f58-f969b6183336.jpg?1",
             "name": "Rain of Revelation",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2104,7 +2104,7 @@
         },
         {
             "id": "771703db-a675-570d-9321-117d325b06aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360fe8c-41b0-4409-b03e-072f129fb352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360fe8c-41b0-4409-b03e-072f129fb352.jpg?1",
             "name": "Read the Tides",
             "text": "Choose one \u2014\n\u2022 Draw three cards.\n\u2022 Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "189c52d6-8397-5241-9b68-0676bc7b76f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b832abcc-9ffd-47bf-827a-01b303c610ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b832abcc-9ffd-47bf-827a-01b303c610ee.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -2168,7 +2168,7 @@
         },
         {
             "id": "a97161af-27e6-5e82-8f39-b1493a140a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5acb8ef-5a57-4d10-b59c-2dbf84635084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5acb8ef-5a57-4d10-b59c-2dbf84635084.jpg?1",
             "name": "Riddleform",
             "text": "Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.\n{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2200,7 +2200,7 @@
         },
         {
             "id": "920767e4-351c-533a-bc94-30f0a0a433c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbac0e4-f79f-476d-b410-d19ab3696606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbac0e4-f79f-476d-b410-d19ab3696606.jpg?1",
             "name": "Roaming Ghostlight",
             "text": "Flying\nWhen Roaming Ghostlight enters the battlefield, return up to one target non-Spirit creature to its owner's hand.",
             "colours": [
@@ -2234,7 +2234,7 @@
         },
         {
             "id": "515a5bd9-8c37-5d99-95d9-ad1fd18922d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19de7a5-c291-405b-a2e6-8d3ac56e6570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19de7a5-c291-405b-a2e6-8d3ac56e6570.jpg?1",
             "name": "Rookie Mistake",
             "text": "Until end of turn, target creature gets +0/+2 and another target creature gets -2/-0.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "37ba0484-9a11-5cbb-ba66-a48bf8ad2a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82be2ca-8350-4cf5-83b6-e8b60a9e21c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c82be2ca-8350-4cf5-83b6-e8b60a9e21c6.jpg?1",
             "name": "Rousing Read",
             "text": "Enchant creature\nWhen Rousing Read enters the battlefield, draw two cards, then discard a card.\nEnchanted creature gets +1/+1 and has flying.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "250d01e9-54cb-5315-bfb0-80549f1940f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b2fb65-5868-4cab-b45d-e103558ce7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b2fb65-5868-4cab-b45d-e103558ce7dc.jpg?1",
             "name": "Sanctum of Calm Waters",
             "text": "At the beginning of your precombat main phase, you may draw X cards, where X is the number of Shrines you control. If you do, discard a card.",
             "colours": [
@@ -2336,7 +2336,7 @@
         },
         {
             "id": "f355804e-cb74-53db-942b-6b5e69b23166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af15cc-fdd5-4d72-a53a-314fa5353527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91af15cc-fdd5-4d72-a53a-314fa5353527.jpg?1",
             "name": "See the Truth",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order. If this spell was cast from anywhere other than your hand, put each of those cards into your hand instead.",
             "colours": [
@@ -2370,7 +2370,7 @@
         },
         {
             "id": "9ddbda47-4142-59b2-be45-c466aa22e441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5a88e3-e73c-4b34-a645-06fe27e68cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5a88e3-e73c-4b34-a645-06fe27e68cee.jpg?1",
             "name": "Shacklegeist",
             "text": "Flying\nShacklegeist can block only creatures with flying.\nTap two untapped Spirits you control: Tap target creature you don't control.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "bc43978e-1da0-51b4-b848-6d53b084718c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d38ef7-5017-4ea3-b97f-a8fe12d03e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d38ef7-5017-4ea3-b97f-a8fe12d03e98.jpg?1",
             "name": "Shipwreck Dowser",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Shipwreck Dowser enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "3dd1c3fb-e670-5433-9dda-1434ff39356d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42d3dd-29df-44a1-89b8-994761eda77d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42d3dd-29df-44a1-89b8-994761eda77d.jpg?1",
             "name": "Spined Megalodon",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhenever Spined Megalodon attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "06696917-5f2d-54dc-a6c6-cd8c86cfcdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0540ee72-6370-4f70-9526-6f441b3cac1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0540ee72-6370-4f70-9526-6f441b3cac1e.jpg?1",
             "name": "Stormwing Entity",
             "text": "This spell costs {2}{U} less to cast if you've cast an instant or sorcery spell this turn.\nFlying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Stormwing Entity enters the battlefield, scry 2.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "8033683f-1340-594c-b7a8-bb9ac3a3cf44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1bcb44-a562-4f66-b862-6d0ef3546ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1bcb44-a562-4f66-b862-6d0ef3546ab4.jpg?1",
             "name": "Sublime Epiphany",
             "text": "Choose one or more \u2014\n\u2022 Counter target spell.\n\u2022 Counter target activated or triggered ability.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Create a token that's a copy of target creature you control.\n\u2022 Target player draws a card.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "4fa12f9c-7b31-5907-ab9a-1404348bbc56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c61e3-9f3d-4e7f-9046-0ea336dd8a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0c61e3-9f3d-4e7f-9046-0ea336dd8a2d.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "735dbf1c-a6ff-554e-b38e-481f1e8573dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d1722-96b0-4756-9da9-fe18b1c80649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d1722-96b0-4756-9da9-fe18b1c80649.jpg?1",
             "name": "Teferi's Ageless Insight",
             "text": "If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "3131b1b6-68b5-5ee0-985c-143b7e453ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5449d71c-5c1b-44c6-9407-0212aa3c3e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5449d71c-5c1b-44c6-9407-0212aa3c3e3a.jpg?1",
             "name": "Teferi's Protege",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2663,7 +2663,7 @@
         },
         {
             "id": "f5f33b1c-90b4-55b8-9901-09605512b6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26450d4-125f-423d-b074-3c959460c242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26450d4-125f-423d-b074-3c959460c242.jpg?1",
             "name": "Teferi's Tutelage",
             "text": "When Teferi's Tutelage enters the battlefield, draw a card, then discard a card.\nWhenever you draw a card, target opponent mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "f4dc6980-a12f-555e-a201-47e5d42a4f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1d595-a998-4652-931f-a1a72446f3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1d595-a998-4652-931f-a1a72446f3a6.jpg?1",
             "name": "Tide Skimmer",
             "text": "Flying\nWhenever you attack with two or more creatures with flying, draw a card.",
             "colours": [
@@ -2731,7 +2731,7 @@
         },
         {
             "id": "5e79e88d-f8a5-51cb-84b2-911e12bad722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2776694-6183-498d-9a38-e4c5c9e78179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2776694-6183-498d-9a38-e4c5c9e78179.jpg?1",
             "name": "Tolarian Kraken",
             "text": "Whenever you draw a card, you may pay {1}. When you do, you may tap or untap target creature.",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "ac48c967-b42f-58d5-8b18-66f767ee247c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0360d27b-37e1-4e00-9cfc-b574efc38ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0360d27b-37e1-4e00-9cfc-b574efc38ea0.jpg?1",
             "name": "Tome Anima",
             "text": "Tome Anima can't be blocked as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "8a1a369f-9bf4-53b2-bfa2-30abc1a4eecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc0bafd-debc-4b62-9fe0-56b4aad02484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc0bafd-debc-4b62-9fe0-56b4aad02484.jpg?1",
             "name": "Unsubstantiate",
             "text": "Return target spell or creature to its owner's hand.",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "6021ee28-4b7b-51bf-9e3f-092daa1399cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52e90c0-b012-4ce5-8462-1e33c7143de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52e90c0-b012-4ce5-8462-1e33c7143de5.jpg?1",
             "name": "Vodalian Arcanist",
             "text": "{T}: Add {C}. Spend this mana only to cast an instant or sorcery spell.",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "eceb35a5-94f6-5959-a6bc-66ca295400e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb47990-a5a9-4a22-a8bb-d229b17132c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb47990-a5a9-4a22-a8bb-d229b17132c6.jpg?1",
             "name": "Waker of Waves",
             "text": "Creatures your opponents control get -1/-0.\n{1}{U}, Discard Waker of Waves: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "3f826f5b-97cb-5cf1-bc88-a11a813959e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac0f66a-213f-463e-8ebb-35ff5940ea06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac0f66a-213f-463e-8ebb-35ff5940ea06.jpg?1",
             "name": "Wall of Runes",
             "text": "Defender (This creature can't attack.)\nWhen Wall of Runes enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "b34d5609-be96-5dc9-ad32-7ba22ec72c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348955a0-e988-48d7-a6a0-a8045fcffd25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348955a0-e988-48d7-a6a0-a8045fcffd25.jpg?1",
             "name": "Wishcoin Crab",
             "text": "",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "9eb69338-c78b-51f1-a54c-c81029909ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4c9574-1ee3-461e-848f-8f02c6a8b7ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4c9574-1ee3-461e-848f-8f02c6a8b7ee.jpg?1",
             "name": "Alchemist's Gift",
             "text": "Target creature gets +1/+1 and gains your choice of deathtouch or lifelink until end of turn. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it. Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "6e49b51d-e1e8-55c4-8127-320307502ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83437022-ba00-4370-83c2-ce1260336fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83437022-ba00-4370-83c2-ce1260336fcc.jpg?1",
             "name": "Archfiend's Vessel",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen Archfiend's Vessel enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, exile it. If you do, create a 5/5 black Demon creature token with flying.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "7e42973f-862d-5409-a6fa-8640fb403e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8bc2-ef66-474f-92a3-9c4df1670cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f8bc2-ef66-474f-92a3-9c4df1670cec.jpg?1",
             "name": "Bad Deal",
             "text": "You draw two cards and each opponent discards two cards. Each player loses 2 life.",
             "colours": [
@@ -3067,7 +3067,7 @@
         },
         {
             "id": "bdf689f5-3561-57e7-abdc-6cdc07091814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ff52a2-4223-4551-b388-b4dd21cc1437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ff52a2-4223-4551-b388-b4dd21cc1437.jpg?1",
             "name": "Blood Glutton",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3101,7 +3101,7 @@
         },
         {
             "id": "d3578b01-f934-5b3f-aff0-f042cda61f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067745-35b6-4abd-9ae9-712159a26c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8067745-35b6-4abd-9ae9-712159a26c89.jpg?1",
             "name": "Caged Zombie",
             "text": "{1}{B}, {T}: Each opponent loses 2 life. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "a324fb88-6544-5cf2-82de-e3930077b5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31df3d95-bbdb-449d-9601-4fa844c3c640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31df3d95-bbdb-449d-9601-4fa844c3c640.jpg?1",
             "name": "Carrion Grub",
             "text": "Carrion Grub gets +X/+0, where X is the greatest power among creature cards in your graveyard.\nWhen Carrion Grub enters the battlefield, mill four cards. (Put the top four cards of your library into your graveyard.)",
             "colours": [
@@ -3169,7 +3169,7 @@
         },
         {
             "id": "b87e0f89-d7a3-5e59-bfaa-a7605d8a5aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bba170-5176-4fab-a10d-e23d70128875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0bba170-5176-4fab-a10d-e23d70128875.jpg?1",
             "name": "Crypt Lurker",
             "text": "When Crypt Lurker enters the battlefield, you may sacrifice a creature or discard a creature card. If you do, draw a card.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "0fb4111f-564e-59a8-8312-10eda498cf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4513e1-9978-44ce-b7a5-4e2b5b63ad9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4513e1-9978-44ce-b7a5-4e2b5b63ad9e.jpg?1",
             "name": "Deathbloom Thallid",
             "text": "When Deathbloom Thallid dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "a0180d8b-6cfb-5c6d-8951-c00497010b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56149192-ddc1-45a4-b7aa-be311da5fe8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56149192-ddc1-45a4-b7aa-be311da5fe8e.jpg?1",
             "name": "Demonic Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+1, has flying, and is a Demon in addition to its other types.\nYou may cast Demonic Embrace from your graveyard by paying 3 life and discarding a card in addition to paying its other costs.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "13a974cb-f33f-5ac3-8886-5e3051edc175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c07ea0-27ff-46fb-a41f-3e378c977b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c07ea0-27ff-46fb-a41f-3e378c977b5d.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "85d83776-c1ca-5d29-9fc6-986a61504046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb4087-3a4c-4de8-8e29-f4cd71acb180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb4087-3a4c-4de8-8e29-f4cd71acb180.jpg?1",
             "name": "Eliminate",
             "text": "Destroy target creature or planeswalker with converted mana cost 3 or less.",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "c28e5e66-5cde-5236-b22d-c98174759403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a95546-c45a-4da5-b1e8-d5658b5b7d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a95546-c45a-4da5-b1e8-d5658b5b7d53.jpg?1",
             "name": "Fetid Imp",
             "text": "Flying\n{B}: Fetid Imp gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "697eedcb-fc2f-5232-a3ba-39973ab4be7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85a552-2119-4d9c-b7c1-c09c2d9f2f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b85a552-2119-4d9c-b7c1-c09c2d9f2f38.jpg?1",
             "name": "Finishing Blow",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -3405,7 +3405,7 @@
         },
         {
             "id": "88f9eece-adcd-525c-b648-38b1eddb57b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b4f7ec-ea2e-4d90-98cd-0c92bd9f64c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1b4f7ec-ea2e-4d90-98cd-0c92bd9f64c1.jpg?1",
             "name": "Gloom Sower",
             "text": "Whenever Gloom Sower becomes blocked by a creature, that creature's controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "f7056037-3a6b-5fba-918d-9f78d58bfd89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd537c-e40e-438f-a751-e0ad8f6e6283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd537c-e40e-438f-a751-e0ad8f6e6283.jpg?1",
             "name": "Goremand",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nFlying\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen Goremand enters the battlefield, each opponent sacrifices a creature.",
             "colours": [
@@ -3473,7 +3473,7 @@
         },
         {
             "id": "1d9232a3-d088-5d79-8eba-97aaf4fc66a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7737b578-8ae3-4846-b508-93ef40f25244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7737b578-8ae3-4846-b508-93ef40f25244.jpg?1",
             "name": "Grasp of Darkness",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "2ef98d9d-84ed-5ede-96ad-65a7ffee02fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928558ab-e29a-44cb-ac2f-88443571f41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/928558ab-e29a-44cb-ac2f-88443571f41a.jpg?1",
             "name": "Grim Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle your library. You lose 3 life.",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "bb32640c-de31-5eb2-91d0-75f21f9ddb34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac38a51f-9a3b-451c-b72d-6d4e0b296fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac38a51f-9a3b-451c-b72d-6d4e0b296fbd.jpg?1",
             "name": "Hooded Blightfang",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch attacks, each opponent loses 1 life and you gain 1 life.\nWhenever a creature you control with deathtouch deals damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "9419a761-94fa-5a33-80f7-fd6972cb891a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975e4b8e-add9-439c-9463-e2facee96c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975e4b8e-add9-439c-9463-e2facee96c10.jpg?1",
             "name": "Infernal Scarring",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -3609,7 +3609,7 @@
         },
         {
             "id": "51bf4b8d-3304-5235-a7c1-6e7d5e053cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fd1009-cd3d-4b53-b9f1-dbc47e8708ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fd1009-cd3d-4b53-b9f1-dbc47e8708ab.jpg?1",
             "name": "Kaervek, the Spiteful",
             "text": "Other creatures get -1/-1.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "54006ee4-a566-58cd-8779-2ee63b5fdfca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88496096-fd9a-451a-85d9-31ccc3580623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88496096-fd9a-451a-85d9-31ccc3580623.jpg?1",
             "name": "Kitesail Freebooter",
             "text": "Flying\nWhen Kitesail Freebooter enters the battlefield, target opponent reveals their hand. You choose a noncreature, nonland card from it. Exile that card until Kitesail Freebooter leaves the battlefield.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "084f076b-62aa-5a31-b6fa-dd20acc38d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e329a3e2-6702-4758-8aac-c3017e77b619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e329a3e2-6702-4758-8aac-c3017e77b619.jpg?1",
             "name": "Liliana, Waker of the Dead",
             "text": "+1: Each player discards a card. Each opponent who can't loses 3 life.\n\u22123: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.\n\u22127: You get an emblem with \"At the beginning of combat on your turn, put target creature card from a graveyard onto the battlefield under your control. It gains haste.\"",
             "colours": [
@@ -3722,7 +3722,7 @@
         },
         {
             "id": "6bbffe8e-c1cc-567f-bdb6-8c78ff31ad4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5d7f15-a86f-4eaa-8280-2e7f73c8ce3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5d7f15-a86f-4eaa-8280-2e7f73c8ce3a.jpg?1",
             "name": "Liliana's Devotee",
             "text": "Zombies you control get +1/+0.\nAt the beginning of your end step, if a creature died this turn, you may pay {1}{B}. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "93dfcf2c-1714-51b8-8e92-4213a27fa3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc48b87-62cb-48f6-8979-e6fb98717b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc48b87-62cb-48f6-8979-e6fb98717b52.jpg?1",
             "name": "Liliana's Standard Bearer",
             "text": "Flash\nWhen Liliana's Standard Bearer enters the battlefield, draw X cards, where X is the number of creatures that died under your control this turn.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "ec495d62-0d2c-51ed-b11b-153f2cc27dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1945fc78-8aa4-46fb-9571-eaa1c4729e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1945fc78-8aa4-46fb-9571-eaa1c4729e3d.jpg?1",
             "name": "Liliana's Steward",
             "text": "{T}, Sacrifice Liliana's Steward: Target opponent discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "175ec4e7-808b-5e69-badd-de143b3557b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e2bc57-8f18-4ba1-a11b-9d69d029f56a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e2bc57-8f18-4ba1-a11b-9d69d029f56a.jpg?1",
             "name": "Malefic Scythe",
             "text": "Malefic Scythe enters the battlefield with a soul counter on it.\nEquipped creature gets +1/+1 for each soul counter on Malefic Scythe.\nWhenever equipped creature dies, put a soul counter on Malefic Scythe.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "aa25b15c-9899-5599-b3b0-719edd5a0ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61b4b71-3cbb-4422-8ce7-657ca3bb6a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61b4b71-3cbb-4422-8ce7-657ca3bb6a82.jpg?1",
             "name": "Masked Blackguard",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\n{2}{B}: Masked Blackguard gets +1/+1 until end of turn.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "f7912e33-fa58-58fc-b194-f2437eb1431e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3185b01-0d91-4927-98e9-bc9df6c20917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3185b01-0d91-4927-98e9-bc9df6c20917.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "ea7c18c3-6b08-5519-b5f1-7b76085a16d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a8604-92d5-443b-9bc0-bd91c973ef07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a8604-92d5-443b-9bc0-bd91c973ef07.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "7c862bb1-53f1-53c7-a88e-21c147654346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c5252e-ff15-4f86-ad63-d8286427e70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c5252e-ff15-4f86-ad63-d8286427e70f.jpg?1",
             "name": "Necromentia",
             "text": "Choose a card name other than a basic land card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles their library, then creates a 2/2 black Zombie creature token for each card exiled from their hand this way.",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "8517e5f6-ba72-5fe6-aa43-b3184c6ffe6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac00055-640e-4749-8d23-d242e6d0b23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac00055-640e-4749-8d23-d242e6d0b23a.jpg?1",
             "name": "Peer into the Abyss",
             "text": "Target player draws cards equal to half the number of cards in their library and loses half their life. Round up each time.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "db612b5e-5232-550f-b9eb-42531fc5679d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b78aa8-a63a-4aa2-bb82-3fbf2595ed7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b78aa8-a63a-4aa2-bb82-3fbf2595ed7c.jpg?1",
             "name": "Pestilent Haze",
             "text": "Choose one \u2014\n\u2022 All creatures get -2/-2 until end of turn.\n\u2022 Remove two loyalty counters from each planeswalker.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "3eac6e88-416b-5e6a-af43-1dd690c3b9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ec88f-2063-404a-853e-c985e21d17b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ec88f-2063-404a-853e-c985e21d17b0.jpg?1",
             "name": "Rise Again",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "3fda88a2-5a44-5a01-a730-a456cc153ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1439412-618c-483d-89b9-5ea37f0f1edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1439412-618c-483d-89b9-5ea37f0f1edc.jpg?1",
             "name": "Sanctum of Stone Fangs",
             "text": "At the beginning of your precombat main phase, each opponent loses X life and you gain X life, where X is the number of Shrines you control.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "0d5eaae0-c7d9-52aa-a10d-4cf7fe6226ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfcd08a-cfb5-4d34-b950-f57a88c5cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfcd08a-cfb5-4d34-b950-f57a88c5cb8e.jpg?1",
             "name": "Sanguine Indulgence",
             "text": "This spell costs {3} less to cast if you've gained 3 or more life this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -4170,7 +4170,7 @@
         },
         {
             "id": "5b25893b-3557-57fc-94eb-15a3df7650cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5444cb-0ecd-4482-a8d8-09332f382dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5444cb-0ecd-4482-a8d8-09332f382dbd.jpg?1",
             "name": "Silversmote Ghoul",
             "text": "At the beginning of your end step, if you gained 3 or more life this turn, return Silversmote Ghoul from your graveyard to the battlefield tapped.\n{1}{B}, Sacrifice Silversmote Ghoul: Draw a card.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "4e46dffa-66fe-58ae-9028-80c77d53c94b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb8d414-7f80-4a61-a0f2-0f16bf53e1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb8d414-7f80-4a61-a0f2-0f16bf53e1b9.jpg?1",
             "name": "Skeleton Archer",
             "text": "When Skeleton Archer enters the battlefield, it deals 1 damage to any target.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "db8f40e6-5abe-5c53-89c7-2a4c58798dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00850e4-6be3-4246-ae45-c0e990e6d6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00850e4-6be3-4246-ae45-c0e990e6d6e1.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "2417bfad-0b47-5a34-bc3a-9535612dc500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99f770-2c39-4025-a8a2-a5890f61eb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df99f770-2c39-4025-a8a2-a5890f61eb53.jpg?1",
             "name": "Thieves' Guild Enforcer",
             "text": "Flash\nWhenever Thieves' Guild Enforcer or another Rogue enters the battlefield under your control, each opponent mills two cards.\nAs long as an opponent has eight or more cards in their graveyard, Thieves' Guild Enforcer gets +2/+1 and has deathtouch.",
             "colours": [
@@ -4312,7 +4312,7 @@
         },
         {
             "id": "3ba45256-36bb-5fa4-9721-1d5e05edb688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f60a6-b5c8-4704-8b61-94e8fc463e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f60a6-b5c8-4704-8b61-94e8fc463e5d.jpg?1",
             "name": "Village Rites",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "153f8955-1146-53be-a82f-ce739de7f43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe79ee4-c3f3-4a6b-a967-203ca3b70ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe79ee4-c3f3-4a6b-a967-203ca3b70ee5.jpg?1",
             "name": "Vito, Thorn of the Dusk Rose",
             "text": "Whenever you gain life, target opponent loses that much life.\n{3}{B}{B}: Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "b14d7137-24df-5eb3-b127-22243e197cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053b59b4-a22c-4228-aadc-ae9da6bb465e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053b59b4-a22c-4228-aadc-ae9da6bb465e.jpg?1",
             "name": "Walking Corpse",
             "text": "",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "cff036c2-37ba-5b5c-a583-28d28ee2176c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43a3eb7-3daf-4667-b824-1f5d801c9341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43a3eb7-3daf-4667-b824-1f5d801c9341.jpg?1",
             "name": "Witch's Cauldron",
             "text": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "f415d2be-239a-57e4-863c-dac8aa3fdedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca827d-0b35-48d7-acd6-13ecacc32b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faca827d-0b35-48d7-acd6-13ecacc32b82.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "8b046fe7-bc24-5231-a877-7260c63e7526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8cf3f9-4e3b-4af2-b5ef-a97eb1d2b674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8cf3f9-4e3b-4af2-b5ef-a97eb1d2b674.jpg?1",
             "name": "Bolt Hound",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhenever Bolt Hound attacks, other creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "40ec8b56-2dbb-5915-8098-de9fecb9d55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6075e0a3-a0ab-4a11-8ad2-7dabb071d309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6075e0a3-a0ab-4a11-8ad2-7dabb071d309.jpg?1",
             "name": "Bone Pit Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Bone Pit Brute enters the battlefield, target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "57a40adb-0eed-5f72-b70e-a9173327abc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb5e613-a803-42f3-840a-7089ac6b7e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb5e613-a803-42f3-840a-7089ac6b7e3d.jpg?1",
             "name": "Brash Taunter",
             "text": "Indestructible\nWhenever Brash Taunter is dealt damage, it deals that much damage to target opponent.\n{2}{R}, {T}: Brash Taunter fights another target creature.",
             "colours": [
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "0ec250b9-21e3-5679-b60d-025cecef9732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b4a80-41e1-4c5f-869a-682f08543f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19b4a80-41e1-4c5f-869a-682f08543f12.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "940935aa-b607-522d-84a6-bff36ddea294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3ca8c-c77c-43b8-84ad-796313ecc813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3ca8c-c77c-43b8-84ad-796313ecc813.jpg?1",
             "name": "Chandra, Heart of Fire",
             "text": "+1: Discard your hand, then exile the top three cards of your library. Until end of turn, you may play cards exiled this way.\n+1: Chandra, Heart of Fire deals 2 damage to any target.\n\u22129: Search your graveyard and library for any number of red instant and/or sorcery cards, exile them, then shuffle your library. You may cast them this turn. Add six {R}.",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "4b90cc3f-bd38-5675-91c8-d6ec3e68df8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed875705-b7b6-4464-b16f-61629ffed04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed875705-b7b6-4464-b16f-61629ffed04f.jpg?1",
             "name": "Chandra's Incinerator",
             "text": "This spell costs {X} less to cast, where X is the total amount of noncombat damage dealt to your opponents this turn.\nTrample\nWhenever a source you control deals noncombat damage to an opponent, Chandra's Incinerator deals that much damage to target creature or planeswalker that player controls.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "80f74d1f-408b-52cc-b162-91b655b77198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d3e366-4da5-42c8-bbd5-a0c178c0da28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d3e366-4da5-42c8-bbd5-a0c178c0da28.jpg?1",
             "name": "Chandra's Magmutt",
             "text": "{T}: Chandra's Magmutt deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "9b974d05-462a-5168-879d-aeac827884e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7744fcf-2336-489d-bc05-f3fce78713a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7744fcf-2336-489d-bc05-f3fce78713a9.jpg?1",
             "name": "Chandra's Pyreling",
             "text": "Whenever a source you control deals noncombat damage to an opponent, Chandra's Pyreling gets +1/+0 and gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "4bae68cd-faa5-5b6e-98c2-54d9226683c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d878dab-5ed2-4ef3-b2c7-472290892854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d878dab-5ed2-4ef3-b2c7-472290892854.jpg?1",
             "name": "Conspicuous Snoop",
             "text": "Play with the top card of your library revealed.\nYou may cast Goblin spells from the top of your library.\nAs long as the top card of your library is a Goblin card, Conspicuous Snoop has all activated abilities of that card.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "198e206d-90b2-5fee-b9d2-5357f5448896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8257c205-00cd-4d41-bd58-098575ea2343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8257c205-00cd-4d41-bd58-098575ea2343.jpg?1",
             "name": "Crash Through",
             "text": "Creatures you control gain trample until end of turn. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)\nDraw a card.",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "da7abdb3-ef74-5c0d-b218-0b8a9a8b5e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe6a3a9-8d62-47c4-a78b-9baa9133a540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe6a3a9-8d62-47c4-a78b-9baa9133a540.jpg?1",
             "name": "Destructive Tampering",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Creatures without flying can't block this turn.",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "ad70360d-196b-5825-aafd-0dd368772466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b77b4-4cc4-4e49-a7a4-667401e7e063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b77b4-4cc4-4e49-a7a4-667401e7e063.jpg?1",
             "name": "Double Vision",
             "text": "Whenever you cast your first instant or sorcery spell each turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "34c0b40e-2ab8-5919-8a06-103068c41e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b12e4b7-2c45-4795-94d3-901f89b8f290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b12e4b7-2c45-4795-94d3-901f89b8f290.jpg?1",
             "name": "Fiery Emancipation",
             "text": "If a source you control would deal damage to a permanent or player, it deals triple that damage to that permanent or player instead.",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "cf65453f-5057-5ef5-93ca-1dcc24fdb8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae12125-73a3-488b-98b8-9f982addac56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae12125-73a3-488b-98b8-9f982addac56.jpg?1",
             "name": "Furious Rise",
             "text": "At the beginning of your end step, if you control a creature with power 4 or greater, exile the top card of your library. You may play that card until you exile another card with Furious Rise.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "5108c24f-ff04-55b2-8fa6-ee7f7341748b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e6279-8a66-4124-9def-fa0c83c26db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e6279-8a66-4124-9def-fa0c83c26db9.jpg?1",
             "name": "Furor of the Bitten",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and attacks each combat if able.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "b171b413-d049-59d2-8adf-4fcdeff481f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b83bb7-00c8-4078-b27f-42a830a544b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b83bb7-00c8-4078-b27f-42a830a544b5.jpg?1",
             "name": "Gadrak, the Crown-Scourge",
             "text": "Flying\nGadrak, the Crown-Scourge can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "5efb1be1-e377-54fd-b2a4-089c260fb87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4bf664-3b92-4598-b905-2bc090958c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4bf664-3b92-4598-b905-2bc090958c8b.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist dies, you may have it deal 1 damage to any target.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "b6391ac8-3cdb-5763-900a-0751107241ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac8bdd-851f-449d-a108-70578eabf254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac8bdd-851f-449d-a108-70578eabf254.jpg?1",
             "name": "Goblin Wizardry",
             "text": "Create two 1/1 red Goblin Wizard creature tokens with prowess. (Whenever you cast a noncreature spell, they get +1/+1 until end of turn.)",
             "colours": [
@@ -5110,7 +5110,7 @@
         },
         {
             "id": "b0d707ec-a648-5904-b381-637f45848015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386e5cb2-39c8-453d-a642-c5d9f8495601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386e5cb2-39c8-453d-a642-c5d9f8495601.jpg?1",
             "name": "Havoc Jester",
             "text": "Whenever you sacrifice a permanent, Havoc Jester deals 1 damage to any target.",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "62dc9897-a55d-507a-9424-938cb9e51fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fb9f1-0d59-4874-aa52-ac665c3cc0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fb9f1-0d59-4874-aa52-ac665c3cc0e8.jpg?1",
             "name": "Heartfire Immolator",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{R}, Sacrifice Heartfire Immolator: It deals damage equal to its power to target creature or planeswalker.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "fc0d2389-d420-52a0-81b4-80f549388852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf663d3-850b-4a24-8e4b-08311adf4ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf663d3-850b-4a24-8e4b-08311adf4ed0.jpg?1",
             "name": "Hellkite Punisher",
             "text": "Flying\n{R}: Hellkite Punisher gets +1/+0 until end of turn.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "fc1239c8-e237-570c-92e6-62f3cda735d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfffc18-b36a-4dd5-909e-60ea9f8eb60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfffc18-b36a-4dd5-909e-60ea9f8eb60b.jpg?1",
             "name": "Hobblefiend",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n{1}, Sacrifice another creature: Put a +1/+1 counter on Hobblefiend.",
             "colours": [
@@ -5249,7 +5249,7 @@
         },
         {
             "id": "7265b62f-7956-593a-b842-64231cb852b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bfec5d-3182-415a-afe8-0b5511cfd656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bfec5d-3182-415a-afe8-0b5511cfd656.jpg?1",
             "name": "Igneous Cur",
             "text": "{1}{R}: Igneous Cur gets +2/+0 until end of turn.",
             "colours": [
@@ -5284,7 +5284,7 @@
         },
         {
             "id": "e9d1d8b3-184b-553f-a781-512c024de394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5e8221-fc2d-4d90-80f3-729606648c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5e8221-fc2d-4d90-80f3-729606648c54.jpg?1",
             "name": "Kinetic Augur",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nKinetic Augur's power is equal to the number of instant and sorcery cards in your graveyard.\nWhen Kinetic Augur enters the battlefield, discard up to two cards, then draw that many cards.",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "962dc950-12c1-598b-8d0d-156b04c598db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e42d07-57d9-4de4-8d41-eb42dd1573ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e42d07-57d9-4de4-8d41-eb42dd1573ed.jpg?1",
             "name": "Onakke Ogre",
             "text": "",
             "colours": [
@@ -5354,7 +5354,7 @@
         },
         {
             "id": "2c4229a9-718c-55f7-93ea-4e57fd98c537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd306cf-6625-4414-b9e5-4b909bb1bb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd306cf-6625-4414-b9e5-4b909bb1bb13.jpg?1",
             "name": "Pitchburn Devils",
             "text": "When Pitchburn Devils dies, it deals 3 damage to any target.",
             "colours": [
@@ -5388,7 +5388,7 @@
         },
         {
             "id": "b5b60d85-9fac-53f5-89d7-a4d88798590b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482ae7f4-3950-4766-8392-eea753e29426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482ae7f4-3950-4766-8392-eea753e29426.jpg?1",
             "name": "Sanctum of Shattered Heights",
             "text": "{1}, Discard a land card or Shrine card: Sanctum of Shattered Heights deals X damage to target creature or planeswalker, where X is the number of Shrines you control.",
             "colours": [
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "6938b285-b621-5aa8-90ed-fd6063227c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a1cce7-1472-42fc-bfd3-c9ed9e563f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a1cce7-1472-42fc-bfd3-c9ed9e563f03.jpg?1",
             "name": "Scorching Dragonfire",
             "text": "Scorching Dragonfire deals 3 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "62d114aa-0894-5c5b-afc7-9e6c5ba0cc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa8e8d-bcb8-47bf-b71a-df11c8d0f2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fa8e8d-bcb8-47bf-b71a-df11c8d0f2c9.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "80b05e9c-9081-5663-8f8f-435d32b2f527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62584e4f-dac1-4d99-ac0a-6a2451603889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62584e4f-dac1-4d99-ac0a-6a2451603889.jpg?1",
             "name": "Soul Sear",
             "text": "Soul Sear deals 5 damage to target creature or planeswalker. That permanent loses indestructible until end of turn.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "d611c797-fd23-557f-abce-87cd65aaecae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baefa06e-28ba-41b9-866e-1ed0c4969852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baefa06e-28ba-41b9-866e-1ed0c4969852.jpg?1",
             "name": "Spellgorger Weird",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.",
             "colours": [
@@ -5554,7 +5554,7 @@
         },
         {
             "id": "91d00acc-0a57-542d-8ea0-3aed30cd86f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034b8d6d-95ea-434a-967a-e6675a7ce88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034b8d6d-95ea-434a-967a-e6675a7ce88a.jpg?1",
             "name": "Subira, Tulzidi Caravanner",
             "text": "Haste\n{1}: Another target creature with power 2 or less can't be blocked this turn.\n{1}{R}, {T}, Discard your hand: Until end of turn, whenever a creature you control with power 2 or less deals combat damage to a player, draw a card.",
             "colours": [
@@ -5593,7 +5593,7 @@
         },
         {
             "id": "f23de900-1b77-554d-8701-d7e157e996c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a6f1c-a058-4cc8-b467-5dbecb5eeb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a6f1c-a058-4cc8-b467-5dbecb5eeb99.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5625,7 +5625,7 @@
         },
         {
             "id": "18d251fa-8201-598e-a80a-53987dddd25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432ecd5f-966f-4403-a973-51e175a524a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432ecd5f-966f-4403-a973-51e175a524a0.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "7d282659-47f0-5307-bf02-ab1cdd3af42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4af156d-0fbf-4a4e-b0c1-db7e95be4903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4af156d-0fbf-4a4e-b0c1-db7e95be4903.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "f5594fcb-3cdc-53a3-aed2-02074058bc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7052f1-9736-47b6-9da3-8c5ca925ab54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7052f1-9736-47b6-9da3-8c5ca925ab54.jpg?1",
             "name": "Traitorous Greed",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Add two mana of any one color. (The creature can attack and {T} this turn.)",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "6ffbe1cb-8d6f-5e48-9153-b2cb2158d586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fa5133-c238-47e8-befd-3729a3e4303a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fa5133-c238-47e8-befd-3729a3e4303a.jpg?1",
             "name": "Transmogrify",
             "text": "Exile target creature. That creature's controller reveals cards from the top of their library until they reveal a creature card. That player puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -5759,7 +5759,7 @@
         },
         {
             "id": "ce6052bf-3835-5638-a6f9-0b4893838e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c18541-e95e-4ae0-be18-3bfcafa24ca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c18541-e95e-4ae0-be18-3bfcafa24ca2.jpg?1",
             "name": "Turn to Slag",
             "text": "Turn to Slag deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "6aa9d405-5411-54f9-9d59-e2cf3b37569c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47e9653-2a3a-4d37-8f3d-3dab4f468338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47e9653-2a3a-4d37-8f3d-3dab4f468338.jpg?1",
             "name": "Turret Ogre",
             "text": "Reach (This creature can block creatures with flying.)\nWhen Turret Ogre enters the battlefield, if you control another creature with power 4 or greater, Turret Ogre deals 2 damage to each opponent.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "1cb10061-fea6-55b8-99f8-d3e687ce696f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e854e6a3-8684-43fa-9560-ef4c3b62c935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e854e6a3-8684-43fa-9560-ef4c3b62c935.jpg?1",
             "name": "Unleash Fury",
             "text": "Double the power of target creature until end of turn.",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "9fc0dd8d-5f2e-5d7b-bee0-3092ed13a110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22c791-6ef9-4f13-a14d-4f795f48bb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22c791-6ef9-4f13-a14d-4f795f48bb1c.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to any target.",
             "colours": [
@@ -5890,7 +5890,7 @@
         },
         {
             "id": "9de5df67-f0e7-5b08-ac99-cfb7b535e299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31b6817-9b63-4d6f-a945-459b44ad184c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31b6817-9b63-4d6f-a945-459b44ad184c.jpg?1",
             "name": "Volcanic Salvo",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nVolcanic Salvo deals 6 damage to each of up to two target creatures and/or planeswalkers.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "b50f15b1-c2fb-5801-8965-7df4c7e70014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8aff2c-1f7b-4507-b914-53f8c4706b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8aff2c-1f7b-4507-b914-53f8c4706b3d.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "4157e0cf-8c41-5fe0-afb1-052e4c1f4a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0ec3bd-d894-4861-abcb-7b2e4f4de05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0ec3bd-d894-4861-abcb-7b2e4f4de05c.jpg?1",
             "name": "Burlfist Oak",
             "text": "Whenever you draw a card, Burlfist Oak gets +2/+2 until end of turn.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "fb00a888-d815-5087-ae33-020d3fc10e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6a13a-ab38-49d1-8712-f9c9135a23c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f6a13a-ab38-49d1-8712-f9c9135a23c8.jpg?1",
             "name": "Canopy Stalker",
             "text": "Canopy Stalker must be blocked if able.\nWhen Canopy Stalker dies, you gain 1 life for each creature that died this turn.",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "efa86053-3a6f-592b-b713-94ddf4e15746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059c52b-5d25-4052-b48a-e9e219a7a546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059c52b-5d25-4052-b48a-e9e219a7a546.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "e87a0a8c-e03d-573e-a6c7-9c2fb268a090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a433310-3fe2-4156-864d-7a6b2638340b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a433310-3fe2-4156-864d-7a6b2638340b.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "55a76c6d-e57f-552a-809b-512c9cf4b097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b056a-ea80-4fdc-990d-0ee1e9a7bf64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b056a-ea80-4fdc-990d-0ee1e9a7bf64.jpg?1",
             "name": "Drowsing Tyrannodon",
             "text": "Defender (This creature can't attack.)\nAs long as you control a creature with power 4 or greater, Drowsing Tyrannodon can attack as though it didn't have defender.",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "8850bc6d-334b-5ce7-ae47-d7cbd340803e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg?1",
             "name": "Elder Gargaroth",
             "text": "Vigilance, reach, trample\nWhenever Elder Gargaroth attacks or blocks, choose one \u2014\n\u2022 Create a 3/3 green Beast creature token.\n\u2022 You gain 3 life.\n\u2022 Draw a card.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "b1e38119-ac98-523d-99f2-09757828d42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a9485a-d356-4cbe-b257-b62008a21328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a9485a-d356-4cbe-b257-b62008a21328.jpg?1",
             "name": "Feline Sovereign",
             "text": "Other Cats you control get +1/+1 and have protection from Dogs.\nWhenever one or more Cats you control deal combat damage to a player, destroy up to one target artifact or enchantment that player controls.",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "7cc8424d-f150-5679-ba2e-f4ffba06f20a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc2af0-5a1d-4319-a285-6a15cf86be83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bc2af0-5a1d-4319-a285-6a15cf86be83.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "9689b99a-4dd4-5408-91cc-2fd8f24faa20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037e3b2-cb62-4f88-943d-3edcd6827c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037e3b2-cb62-4f88-943d-3edcd6827c23.jpg?1",
             "name": "Fungal Rebirth",
             "text": "Return target permanent card from your graveyard to your hand. If a creature died this turn, create two 1/1 green Saproling creature tokens.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "62e570b2-7c2e-577b-9299-41193f21c343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2fdbec-bca2-4af5-9c2a-28b0b35b18a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2fdbec-bca2-4af5-9c2a-28b0b35b18a3.jpg?1",
             "name": "Garruk, Unleashed",
             "text": "+1: Up to one target creature gets +3/+3 and gains trample until end of turn.\n\u22122: Create a 3/3 green Beast creature token. Then if an opponent controls more creatures than you, put a loyalty counter on Garruk, Unleashed.\n\u22127: You get an emblem with \"At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -6310,7 +6310,7 @@
         },
         {
             "id": "a10128ac-1a69-5f49-9711-1e76cb969589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3928bbce-87b7-4b28-9af4-20362935c909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3928bbce-87b7-4b28-9af4-20362935c909.jpg?1",
             "name": "Garruk's Gorehorn",
             "text": "",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "31f348e3-b9f9-5958-8f6e-155b28862d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0fa0b6-5f3f-4669-84e8-2c38c9593d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e0fa0b6-5f3f-4669-84e8-2c38c9593d88.jpg?1",
             "name": "Garruk's Harbinger",
             "text": "Hexproof from black\nWhenever Garruk's Harbinger deals combat damage to a player or planeswalker, look at that many cards from the top of your library. You may reveal a creature card or Garruk planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6382,7 +6382,7 @@
         },
         {
             "id": "84fed12f-6a63-54c0-bf5f-08159b537598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a4860a-8bb6-45c0-b00a-b4a42da33ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a4860a-8bb6-45c0-b00a-b4a42da33ab9.jpg?1",
             "name": "Garruk's Uprising",
             "text": "When Garruk's Uprising enters the battlefield, if you control a creature with power 4 or greater, draw a card.\nCreatures you control have trample. (They can deal excess combat damage to the player or planeswalker they're attacking.)\nWhenever a creature with power 4 or greater enters the battlefield under your control, draw a card.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "7e0cac9c-f650-5252-bb53-632bd9b6febd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f22116a-8b6a-4bbe-999f-7329e1e2b2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f22116a-8b6a-4bbe-999f-7329e1e2b2d9.jpg?1",
             "name": "Gnarled Sage",
             "text": "Reach (This creature can block creatures with flying.)\nAs long as you've drawn two or more cards this turn, Gnarled Sage gets +0/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "56c8fa05-4358-5317-a854-18fde1834ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c037e3-7d1a-48ca-8ecc-276696592f62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c037e3-7d1a-48ca-8ecc-276696592f62.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -6485,7 +6485,7 @@
         },
         {
             "id": "e0cc7df4-8287-51c2-9f20-7ed902ce6a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c08c80f-f27c-4e3a-b048-143aea740096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c08c80f-f27c-4e3a-b048-143aea740096.jpg?1",
             "name": "Hunter's Edge",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "f355561b-bca4-5568-ae28-4b95a611cba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531e1fc0-a3aa-4b57-87b2-79a31af5c922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/531e1fc0-a3aa-4b57-87b2-79a31af5c922.jpg?1",
             "name": "Invigorating Surge",
             "text": "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on that creature.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "ff2c2e20-0ab0-5275-abe3-1b0b3e90df11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdcfce-3f32-48f9-83f8-87b9ccbf92e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcdcfce-3f32-48f9-83f8-87b9ccbf92e3.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -6588,7 +6588,7 @@
         },
         {
             "id": "067fe2bd-e82e-5eb5-8932-6f26bbc60c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888197f-5da4-4413-9cad-b37a12ba1e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3888197f-5da4-4413-9cad-b37a12ba1e60.jpg?1",
             "name": "Life Goes On",
             "text": "You gain 4 life. If a creature died this turn, you gain 8 life instead.",
             "colours": [
@@ -6620,7 +6620,7 @@
         },
         {
             "id": "04c7b2db-3b3e-57be-90ef-150f3bfdcfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e23afa-7e08-4049-baf0-d4d0134ba2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e23afa-7e08-4049-baf0-d4d0134ba2c8.jpg?1",
             "name": "Llanowar Visionary",
             "text": "When Llanowar Visionary enters the battlefield, draw a card.\n{T}: Add {G}.",
             "colours": [
@@ -6657,7 +6657,7 @@
         },
         {
             "id": "0f28c631-6e22-5250-8c5d-2e09c6d5790b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c4a0e7-9ca4-4291-94de-165cc2ded822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c4a0e7-9ca4-4291-94de-165cc2ded822.jpg?1",
             "name": "Ornery Dilophosaur",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Ornery Dilophosaur attacks, if you control a creature with power 4 or greater, Ornery Dilophosaur gets +2/+2 until end of turn.",
             "colours": [
@@ -6691,7 +6691,7 @@
         },
         {
             "id": "5bd1cfab-9306-5dd9-a9aa-73e192d9f8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abd95a-4ecc-479c-b200-5aaf7c993ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abd95a-4ecc-479c-b200-5aaf7c993ef8.jpg?1",
             "name": "Portcullis Vine",
             "text": "Defender (This creature can't attack.)\n{2}, {T}, Sacrifice a creature with defender: Draw a card.",
             "colours": [
@@ -6726,7 +6726,7 @@
         },
         {
             "id": "8cc7f84c-eb9c-5917-b78c-c5f07111a890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df520254-0c72-496b-9222-263ca9d3c5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df520254-0c72-496b-9222-263ca9d3c5d5.jpg?1",
             "name": "Pridemalkin",
             "text": "When Pridemalkin enters the battlefield, put a +1/+1 counter on target creature you control.\nEach creature you control with a +1/+1 counter on it has trample. (They can deal excess combat damage to the player or planeswalker they're attacking.)",
             "colours": [
@@ -6760,7 +6760,7 @@
         },
         {
             "id": "5ff6bd1d-a118-5037-8047-39afa0b86029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd8cee8-7ea0-4037-8a3b-39334dc064fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd8cee8-7ea0-4037-8a3b-39334dc064fb.jpg?1",
             "name": "Primal Might",
             "text": "Target creature you control gets +X/+X until end of turn. Then it fights up to one target creature you don't control.",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "31374819-ea43-5001-8fa9-39dbd6774b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20d20f7-bc4d-42fa-9f5b-5bb330eb7f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20d20f7-bc4d-42fa-9f5b-5bb330eb7f38.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -6828,7 +6828,7 @@
         },
         {
             "id": "5939c1da-fe61-58b4-b2c1-4e36af3867a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02392840-f0c4-462e-84ce-9a7cdd9f5efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02392840-f0c4-462e-84ce-9a7cdd9f5efb.jpg?1",
             "name": "Ranger's Guile",
             "text": "Target creature you control gets +1/+1 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "53681a43-0d28-564e-9f2c-80331741b0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1b4490-d96d-4448-835b-6cc453c1f344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1b4490-d96d-4448-835b-6cc453c1f344.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -6892,7 +6892,7 @@
         },
         {
             "id": "895c8730-c24f-5042-b325-05bf0d027155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd328139-0dc1-403b-ad79-b1cf3479ac33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd328139-0dc1-403b-ad79-b1cf3479ac33.jpg?1",
             "name": "Run Afoul",
             "text": "Target opponent sacrifices a creature with flying.",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "e7497a43-1bb0-5b8d-9447-2b53796bc903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe39e38e-76e5-4883-b530-d3e30e88ccad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe39e38e-76e5-4883-b530-d3e30e88ccad.jpg?1",
             "name": "Sabertooth Mauler",
             "text": "At the beginning of your end step, if a creature died this turn, put a +1/+1 counter on Sabertooth Mauler and untap it.",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "c8c294fc-2083-511a-8c51-98f7bd3db2aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca28cfd-1a1b-4176-8b07-993d3d7b7ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca28cfd-1a1b-4176-8b07-993d3d7b7ae4.jpg?1",
             "name": "Sanctum of Fruitful Harvest",
             "text": "At the beginning of your precombat main phase, add X mana of any one color, where X is the number of Shrines you control.",
             "colours": [
@@ -6994,7 +6994,7 @@
         },
         {
             "id": "e22cac69-1970-551c-b6a5-bac392e165df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487116ab-b885-406b-aa54-56cb67eb3ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487116ab-b885-406b-aa54-56cb67eb3ca5.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "6c282bbd-3a4e-5965-8405-e6cdb99e3daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947f64a-5ca0-4dda-8bbd-8472e72ecf18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1947f64a-5ca0-4dda-8bbd-8472e72ecf18.jpg?1",
             "name": "Setessan Training",
             "text": "Enchant creature you control\nWhen Setessan Training enters the battlefield, draw a card.\nEnchanted creature gets +1/+0 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "d135bcc5-9bcf-5570-9ed1-d4af5ee87854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776f5b4-1292-460f-9719-e1b603cee46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1776f5b4-1292-460f-9719-e1b603cee46c.jpg?1",
             "name": "Skyway Sniper",
             "text": "Reach (This creature can block creatures with flying.)\n{2}{G}: Skyway Sniper deals 1 damage to target creature with flying.",
             "colours": [
@@ -7099,7 +7099,7 @@
         },
         {
             "id": "637cfcc8-3eeb-56a3-94a0-4a51d085162f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46700ccc-0975-49d1-b3fc-edb1eda3b624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46700ccc-0975-49d1-b3fc-edb1eda3b624.jpg?1",
             "name": "Snarespinner",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Snarespinner blocks a creature with flying, Snarespinner gets +2/+0 until end of turn.",
             "colours": [
@@ -7133,7 +7133,7 @@
         },
         {
             "id": "25c584c3-bb63-5a37-a585-762082eeea7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ab63c8-0adc-4d74-aee5-a58ce5c0dad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ab63c8-0adc-4d74-aee5-a58ce5c0dad8.jpg?1",
             "name": "Sporeweb Weaver",
             "text": "Reach, hexproof from blue\nWhenever Sporeweb Weaver is dealt damage, you gain 1 life and create a 1/1 green Saproling creature token.",
             "colours": [
@@ -7169,7 +7169,7 @@
         },
         {
             "id": "523c83b0-ee94-5f0a-9ad9-f7efb5aad95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf27a3-9bcf-475c-a324-7c3af50496dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf27a3-9bcf-475c-a324-7c3af50496dd.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -7203,7 +7203,7 @@
         },
         {
             "id": "13c72999-4ee2-512e-be0a-c40461dcc911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da62557-9783-4e6c-9b5f-2b77dbf96909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da62557-9783-4e6c-9b5f-2b77dbf96909.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "3001f1f9-3062-5207-964b-31e995766280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41b6c8a-bd76-4b69-ae72-4c8acac379b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41b6c8a-bd76-4b69-ae72-4c8acac379b4.jpg?1",
             "name": "Track Down",
             "text": "Scry 3, then reveal the top card of your library. If it's a creature or land card, draw a card. (To scry 3, look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -7267,7 +7267,7 @@
         },
         {
             "id": "30a11174-b0ed-5100-bd23-6929ee570e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba47c1-a874-456e-bea3-e99e2d61cfba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bba47c1-a874-456e-bea3-e99e2d61cfba.jpg?1",
             "name": "Trufflesnout",
             "text": "When Trufflesnout enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on Trufflesnout.\n\u2022 You gain 4 life.",
             "colours": [
@@ -7301,7 +7301,7 @@
         },
         {
             "id": "10e9e12b-0485-5fe8-bebc-c78198b6c5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d81cfc-cff8-4478-92b6-efbfc5084165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d81cfc-cff8-4478-92b6-efbfc5084165.jpg?1",
             "name": "Warden of the Woods",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever Warden of the Woods becomes the target of a spell or ability an opponent controls, you may draw two cards.",
             "colours": [
@@ -7335,7 +7335,7 @@
         },
         {
             "id": "7831fb4c-78c6-542a-b935-3b4e1e5cef76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ff0b33-d153-4b0e-ac48-7e5ed70dea09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ff0b33-d153-4b0e-ac48-7e5ed70dea09.jpg?1",
             "name": "Wildwood Scourge",
             "text": "Wildwood Scourge enters the battlefield with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on Wildwood Scourge.",
             "colours": [
@@ -7369,7 +7369,7 @@
         },
         {
             "id": "fdfa8f7c-1476-59d7-b1cf-3a576f641574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43224e74-2c51-40bd-bc34-f66e990a3e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43224e74-2c51-40bd-bc34-f66e990a3e33.jpg?1",
             "name": "Alpine Houndmaster",
             "text": "When Alpine Houndmaster enters the battlefield, you may search your library for a card named Alpine Watchdog and/or a card named Igneous Cur, reveal them, put them into your hand, then shuffle your library.\nWhenever Alpine Houndmaster attacks, it gets +X/+0 until end of turn, where X is the number of other attacking creatures.",
             "colours": [
@@ -7406,7 +7406,7 @@
         },
         {
             "id": "978d8333-d395-5f56-98f8-ca5d0ff21609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a328a93a-e720-46d5-a190-cc65d1c90cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a328a93a-e720-46d5-a190-cc65d1c90cea.jpg?1",
             "name": "Conclave Mentor",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.\nWhen Conclave Mentor dies, you gain life equal to its power.",
             "colours": [
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "2b35e1e9-9b7d-5ae1-9733-40c1d5f99941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa781df-859f-4346-9424-b3713b17e1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fa781df-859f-4346-9424-b3713b17e1f6.jpg?1",
             "name": "Dire Fleet Warmonger",
             "text": "At the beginning of combat on your turn, you may sacrifice another creature. If you do, Dire Fleet Warmonger gets +2/+2 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "ea68e0a5-6841-5f40-bfab-9b2bc629705e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1bace4-a327-4eb6-a6ef-8394e76c06b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1bace4-a327-4eb6-a6ef-8394e76c06b7.jpg?1",
             "name": "Experimental Overload",
             "text": "Create an X/X blue and red Weird creature token, where X is the number of instant and sorcery cards in your graveyard. Then you may return an instant or sorcery card from your graveyard to your hand. Exile Experimental Overload.",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "9ae1d82f-8394-5b27-ad2f-17bde2a20ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642e0c48-1f77-41e0-abbe-f570b757cd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642e0c48-1f77-41e0-abbe-f570b757cd66.jpg?1",
             "name": "Indulging Patrician",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nAt the beginning of your end step, if you gained 3 or more life this turn, each opponent loses 3 life.",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "1e369dbc-6332-5a99-8abe-56336667f770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3a903-23e0-4b5a-9c7e-390d5ced8371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3a903-23e0-4b5a-9c7e-390d5ced8371.jpg?1",
             "name": "Leafkin Avenger",
             "text": "{T}: Add {G} for each creature with power 4 or greater you control.\n{7}{R}: Leafkin Avenger deals damage equal to its power to target player or planeswalker.",
             "colours": [
@@ -7588,7 +7588,7 @@
         },
         {
             "id": "c2c4f7c1-b0c7-55d2-9033-27260af6cdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be31fb0-115e-4e62-babd-16870f249f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be31fb0-115e-4e62-babd-16870f249f06.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "b7c270f4-bb13-5b73-b46f-e18b7a1eebbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21827eb-fa49-4784-a86b-aef164a5018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21827eb-fa49-4784-a86b-aef164a5018e.jpg?1",
             "name": "Niambi, Esteemed Speaker",
             "text": "Flash\nWhen Niambi, Esteemed Speaker enters the battlefield, you may return another target creature you control to its owner's hand. If you do, you gain life equal to that creature's converted mana cost.\n{1}{W}{U}, {T}, Discard a legendary card: Draw two cards.",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "eeca070e-245a-5d13-a1a2-9afa5e7f2a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e449f985-d149-49eb-87d9-7a325215f82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e449f985-d149-49eb-87d9-7a325215f82d.jpg?1",
             "name": "Obsessive Stitcher",
             "text": "{T}: Draw a card, then discard a card.\n{2}{U}{B}, {T}, Sacrifice Obsessive Stitcher: Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -7702,7 +7702,7 @@
         },
         {
             "id": "f464f0bc-2b9d-568f-8eee-5cae3739c98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbd37b1-49cb-4295-9a1f-fb85368a8f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbd37b1-49cb-4295-9a1f-fb85368a8f12.jpg?1",
             "name": "Radha, Heart of Keld",
             "text": "As long as it's your turn, Radha, Heart of Keld has first strike.\nYou may look at the top card of your library any time, and you may play lands from the top of your library.\n{4}{R}{G}: Radha gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "ce8b6fed-591b-5211-b958-726ba225c1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba91338c-1f6c-4b83-851f-98c3e9dea17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba91338c-1f6c-4b83-851f-98c3e9dea17b.jpg?1",
             "name": "Sanctum of All",
             "text": "At the beginning of your upkeep, you may search your library and/or graveyard for a Shrine card and put it onto the battlefield. If you search your library this way, shuffle it.\nIf an ability of another Shrine you control triggers while you control six or more Shrines, that ability triggers an additional time.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "6f497db1-b64b-5980-aeda-5a0dd0f860ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d387b19-a0a7-45c0-b1e9-71ca55fb4adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d387b19-a0a7-45c0-b1e9-71ca55fb4adc.jpg?1",
             "name": "Twinblade Assassins",
             "text": "At the beginning of your end step, if a creature died this turn, draw a card.",
             "colours": [
@@ -7826,7 +7826,7 @@
         },
         {
             "id": "1247a793-a4ba-5329-ba05-118c96a9f3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b9ea4-3d55-48cc-b426-c46b1d1bb397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354b9ea4-3d55-48cc-b426-c46b1d1bb397.jpg?1",
             "name": "Watcher of the Spheres",
             "text": "Flying\nCreature spells with flying you cast cost {1} less to cast.\nWhenever another creature with flying enters the battlefield under your control, Watcher of the Spheres gets +1/+1 until end of turn.",
             "colours": [
@@ -7863,7 +7863,7 @@
         },
         {
             "id": "729de37a-f21f-5b1f-adec-41f7ab187e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af78d76-ad5c-44ba-880d-b834bcde5398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3af78d76-ad5c-44ba-880d-b834bcde5398.jpg?1",
             "name": "Chromatic Orrery",
             "text": "You may spend mana as though it were mana of any color.\n{T}: Add {C}{C}{C}{C}{C}.\n{5}, {T}: Draw a card for each color among permanents you control.",
             "colours": [],
@@ -7895,7 +7895,7 @@
         },
         {
             "id": "8fdf95ad-af47-5683-8ad6-6f35321e6c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e01bcb4-e823-4da5-b433-e75be3356367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e01bcb4-e823-4da5-b433-e75be3356367.jpg?1",
             "name": "Chrome Replicator",
             "text": "When Chrome Replicator enters the battlefield, if you control two or more nonland, nontoken permanents with the same name as one another, create a 4/4 colorless Construct artifact creature token.",
             "colours": [],
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "77067f1a-c783-5e9c-9c66-a1dbb73f31cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7988fd09-32a4-406b-8e7f-e77393d680a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7988fd09-32a4-406b-8e7f-e77393d680a7.jpg?1",
             "name": "Epitaph Golem",
             "text": "{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -7957,7 +7957,7 @@
         },
         {
             "id": "9b02cd39-c55f-5be8-8b9b-1f59352b1093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd39a06-c53a-42c2-b2df-028358f03406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd39a06-c53a-42c2-b2df-028358f03406.jpg?1",
             "name": "Forgotten Sentinel",
             "text": "Forgotten Sentinel enters the battlefield tapped.",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "d171a62d-c76c-5eac-b830-a2e89d41b294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd761f3-6b43-4150-8595-dc3abd85b06c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd761f3-6b43-4150-8595-dc3abd85b06c.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on Mazemind Tome: Scry 1.\n{2}, {T}, Put a page counter on Mazemind Tome: Draw a card.\nWhen there are four or more page counters on Mazemind Tome, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "7de938bb-650f-526f-85c2-17535322ba79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to any target.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8046,7 +8046,7 @@
         },
         {
             "id": "385fa7a3-3d0c-5d1b-8666-7c4c8218e2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27305aad-f1bd-4895-8611-143bc0250bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27305aad-f1bd-4895-8611-143bc0250bee.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "0d677bb4-77d4-5834-8ea2-c9792dc57d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedce8ab-771a-4247-9504-72ae0629df83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eedce8ab-771a-4247-9504-72ae0629df83.jpg?1",
             "name": "Prismite",
             "text": "{2}: Add one mana of any color.",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "3bff6225-e956-5bee-b549-bb5e5fa22386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973c166e-3e93-4ed5-b4c5-84dc158a8e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973c166e-3e93-4ed5-b4c5-84dc158a8e4f.jpg?1",
             "name": "Short Sword",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8138,7 +8138,7 @@
         },
         {
             "id": "487015ea-4f89-53f2-adb7-0b3e34d2441b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e12530d-5509-46f1-8273-dce2c1f60965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e12530d-5509-46f1-8273-dce2c1f60965.jpg?1",
             "name": "Silent Dart",
             "text": "{4}, {T}, Sacrifice Silent Dart: It deals 3 damage to target creature.",
             "colours": [],
@@ -8166,7 +8166,7 @@
         },
         {
             "id": "3675eae9-25d4-5829-9793-ad1ee008ead7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab69fbd-0179-4b02-adba-71d2a0eeea5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab69fbd-0179-4b02-adba-71d2a0eeea5c.jpg?1",
             "name": "Skyscanner",
             "text": "Flying\nWhen Skyscanner enters the battlefield, draw a card.",
             "colours": [],
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "9a343ba7-a9f1-5833-a0c3-f3bf18de6517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbd2cab-538e-4932-a828-150e3e9d52ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bbd2cab-538e-4932-a828-150e3e9d52ad.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "7c9c19c2-27ee-5de1-b048-b69b3591d86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad357ed4-b4f2-45b5-b7c4-3c6013a4ea3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad357ed4-b4f2-45b5-b7c4-3c6013a4ea3d.jpg?1",
             "name": "Sparkhunter Masticore",
             "text": "As an additional cost to cast this spell, discard a card.\nProtection from planeswalkers\n{1}: Sparkhunter Masticore deals 1 damage to target planeswalker.\n{3}: Sparkhunter Masticore gains indestructible until end of turn.",
             "colours": [],
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "cea99f53-592a-543d-9f33-c80970d34a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c224bf0-5641-4160-9d5c-46141ea8372a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c224bf0-5641-4160-9d5c-46141ea8372a.jpg?1",
             "name": "Tormod's Crypt",
             "text": "{T}, Sacrifice Tormod's Crypt: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -8291,7 +8291,7 @@
         },
         {
             "id": "063f683a-a61b-56f3-ac52-39c801e3d8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d7a2c7-666d-4fc6-bac8-ef8eb66e355d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d7a2c7-666d-4fc6-bac8-ef8eb66e355d.jpg?1",
             "name": "Animal Sanctuary",
             "text": "{T}: Add {C}.\n{2}, {T}: Put a +1/+1 counter on target Bird, Cat, Dog, Goat, Ox, or Snake.",
             "colours": [],
@@ -8321,7 +8321,7 @@
         },
         {
             "id": "8b2d5936-e7bf-5e53-a5b4-aabab907b95f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89a0e2-1163-4a11-b0df-deef2e6c8108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89a0e2-1163-4a11-b0df-deef2e6c8108.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8352,7 +8352,7 @@
         },
         {
             "id": "83baa673-2d8e-5f0e-84ea-d557575bf54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8483586-9a07-4f54-a390-7dd97fcea5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8483586-9a07-4f54-a390-7dd97fcea5cb.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "4fd2a1fe-7f74-5ea9-a371-e3daad919592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b1afa0-9bb5-4566-a85e-86a5c03e0187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b1afa0-9bb5-4566-a85e-86a5c03e0187.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8414,7 +8414,7 @@
         },
         {
             "id": "26af9c7f-3f3a-5653-8a71-2ce76578deff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d313d051-7295-4884-8cbf-f2f835fd45f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d313d051-7295-4884-8cbf-f2f835fd45f4.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "656cecc7-252d-5706-8130-510e3020de6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f28d7a-6480-4725-9719-2354921e6410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f28d7a-6480-4725-9719-2354921e6410.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "a1089e2f-1717-54b2-b36d-57bb68935172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296c34b-120b-483e-8b49-6d432c04f9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0296c34b-120b-483e-8b49-6d432c04f9a4.jpg?1",
             "name": "Radiant Fountain",
             "text": "When Radiant Fountain enters the battlefield, you gain 2 life.\n{T}: Add {C}.",
             "colours": [],
@@ -8503,7 +8503,7 @@
         },
         {
             "id": "a128045a-d590-5a11-bfa1-9d3be9240e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daef8db-56a5-4b1e-b4bf-734d0516557c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9daef8db-56a5-4b1e-b4bf-734d0516557c.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8534,7 +8534,7 @@
         },
         {
             "id": "5afb11e8-9080-56e6-afa9-dbcaae583f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb3d45c-a28c-49d2-ab79-53ab42c7fdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb3d45c-a28c-49d2-ab79-53ab42c7fdfd.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "f1716f48-8ce5-57f3-acd8-657eaf62444b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e649fc68-fca5-4234-aff4-0ec2382a66d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e649fc68-fca5-4234-aff4-0ec2382a66d4.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8596,7 +8596,7 @@
         },
         {
             "id": "50670ecf-47ca-5788-b970-c5f41d6e5e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1652bb3c-c365-4046-b07e-3d861fa324c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1652bb3c-c365-4046-b07e-3d861fa324c6.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -8629,7 +8629,7 @@
         },
         {
             "id": "80adda58-223d-5fac-a61a-558d3da745de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97929f8-ae80-4b4a-9d9b-2f3c7605edc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97929f8-ae80-4b4a-9d9b-2f3c7605edc8.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "030de441-b3cc-5285-a02c-6e351db2e053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81634185-eb67-4d13-8b82-a662b8c9a7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81634185-eb67-4d13-8b82-a662b8c9a7f0.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "dd34648e-055c-594f-955b-5df9f11517b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5b0f0a-dc16-45e2-91ab-28e0b9f66d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5b0f0a-dc16-45e2-91ab-28e0b9f66d00.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8728,7 +8728,7 @@
         },
         {
             "id": "59b50588-3c2b-5507-87bf-6689ac07ed82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366499c-9d07-46bb-8488-6cd60056fa16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2366499c-9d07-46bb-8488-6cd60056fa16.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "7a30f8a8-af06-524f-877e-1f056f4429da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82851a5-5f70-488a-b21c-bdd65d2fca7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82851a5-5f70-488a-b21c-bdd65d2fca7c.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -8792,7 +8792,7 @@
         },
         {
             "id": "e957e5f4-77d9-535c-a9fd-ea03235de01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee9b4b-1510-4b78-bdde-2e0bb319ee33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee9b4b-1510-4b78-bdde-2e0bb319ee33.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8823,7 +8823,7 @@
         },
         {
             "id": "7bc9cdae-86a6-51a5-8923-3153ef4abe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d7428b-25a7-4185-8c3e-69017bd1ba6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d7428b-25a7-4185-8c3e-69017bd1ba6d.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8854,7 +8854,7 @@
         },
         {
             "id": "983bac6e-2e3d-5459-8798-480e84d3b6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be96696-aff8-4ef9-97dc-8221ef745de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be96696-aff8-4ef9-97dc-8221ef745de9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8892,7 +8892,7 @@
         },
         {
             "id": "daf4f9c6-393d-54b5-9a07-78c109bca43e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4e5bc1-f0c3-4ea7-a549-c36d932103b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4e5bc1-f0c3-4ea7-a549-c36d932103b1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "364598a6-6bce-53b0-9755-4e726858f269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a299a1e-1ce9-4668-a5f5-c587081acf6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a299a1e-1ce9-4668-a5f5-c587081acf6b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8968,7 +8968,7 @@
         },
         {
             "id": "a2cfefab-7490-512e-9cef-0bd3bbc22fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a66a1-367c-4035-a22e-00fab55be5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9a66a1-367c-4035-a22e-00fab55be5a0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "bfc6c856-244d-5cca-9c5b-639e94cf3f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017fb3fc-433e-4853-bbac-99fa04b40233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017fb3fc-433e-4853-bbac-99fa04b40233.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "f4dbcfc7-89d7-5b94-ac9f-b64bb35b2b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6d5-f6a1-47c3-a898-733fab10bbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6d5-f6a1-47c3-a898-733fab10bbf5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "9021fd6e-48d7-5c3d-858e-de0dd6bf5b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b3d647-3546-4ade-b395-f2370750a7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b3d647-3546-4ade-b395-f2370750a7a6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "e0a00c3e-6d17-5e85-9d1d-c704d828a576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be68e315-ffef-40a8-8a46-1c042b148c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be68e315-ffef-40a8-8a46-1c042b148c03.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9158,7 +9158,7 @@
         },
         {
             "id": "9ebb924e-395f-5e14-8be5-176d349d1dd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0863a079-1cc2-4388-85bb-a24eae251e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0863a079-1cc2-4388-85bb-a24eae251e99.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9196,7 +9196,7 @@
         },
         {
             "id": "0ef985c1-e2c4-5e7b-baa9-8014da1fc934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92c8925-ecfc-4ece-b83a-f12e98a938ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92c8925-ecfc-4ece-b83a-f12e98a938ab.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "b3c01104-639b-53a0-9613-b9c00afa9daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ff4fd5-c26f-4274-b899-1f995d4d8c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ff4fd5-c26f-4274-b899-1f995d4d8c25.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9272,7 +9272,7 @@
         },
         {
             "id": "9db2788f-544b-5631-8c27-e9470cc6adfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6fd37e-a5b3-48c6-b881-cedadfd94833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6fd37e-a5b3-48c6-b881-cedadfd94833.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9310,7 +9310,7 @@
         },
         {
             "id": "6bbebbf3-912c-5f84-a73d-24230fd8eedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3279314f-d639-4489-b2ab-3621bb3ca64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3279314f-d639-4489-b2ab-3621bb3ca64b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9348,7 +9348,7 @@
         },
         {
             "id": "dcf5782a-6dd7-5f23-9fd9-d1e58ca021e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df3e89-610c-4f42-a93a-e694342307cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4df3e89-610c-4f42-a93a-e694342307cc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9386,7 +9386,7 @@
         },
         {
             "id": "d2df9ae2-3b2e-5527-b3d0-c4bf5fd4142c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4558304-7c17-4aa0-bd50-cdd95547f1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4558304-7c17-4aa0-bd50-cdd95547f1a7.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9424,7 +9424,7 @@
         },
         {
             "id": "095be5f8-4abc-5122-a853-b320edc139a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ff397-2445-459a-ae4e-7bf1cd48f490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ff397-2445-459a-ae4e-7bf1cd48f490.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "8f2ad15b-e5ca-5d16-9e60-2ef6278ba21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bf5708-4222-46d2-b108-0ed4cf3c83c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8bf5708-4222-46d2-b108-0ed4cf3c83c3.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "a432cb96-ca34-555f-8840-d8f5b1b010a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4949a0b-e320-470a-ba54-07ac75b0053b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4949a0b-e320-470a-ba54-07ac75b0053b.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9559,7 +9559,7 @@
         },
         {
             "id": "a72ebfb7-6a0b-5d0a-87b0-5125a3b34756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d605c780-a42a-4816-8fb9-63e3114a8246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d605c780-a42a-4816-8fb9-63e3114a8246.jpg?1",
             "name": "Rin and Seri, Inseparable",
             "text": "Whenever you cast a Dog spell, create a 1/1 green Cat creature token.\nWhenever you cast a Cat spell, create a 1/1 white Dog creature token.\n{R}{G}{W}, {T}: Rin and Seri, Inseparable deals damage to any target equal to the number of Dogs you control. You gain life equal to the number of Cats you control.",
             "colours": [
@@ -9600,7 +9600,7 @@
         },
         {
             "id": "49a71576-8f2a-5e66-8829-625bfe7d9ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bacda35-bb91-4537-a14d-846650fa85f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bacda35-bb91-4537-a14d-846650fa85f6.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to any target.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -9635,7 +9635,7 @@
         },
         {
             "id": "d0a8af76-5f2f-576f-b328-a67287e2d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3906ea-df06-4299-a305-32e6ef476507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3906ea-df06-4299-a305-32e6ef476507.jpg?1",
             "name": "Basri Ket",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains indestructible until end of turn.\n\u22122: Whenever one or more nontoken creatures attack this turn, create that many 1/1 white Soldier creature tokens that are tapped and attacking.\n\u22126: You get an emblem with \"At the beginning of combat on your turn, create a 1/1 white Soldier creature token, then put a +1/+1 counter on each creature you control.\"",
             "colours": [
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "9a0efe80-9d99-5a55-82fa-0f646f13b37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba95c4fc-f0fc-4bfe-bef7-694c3d82a6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba95c4fc-f0fc-4bfe-bef7-694c3d82a6c7.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -9719,7 +9719,7 @@
         },
         {
             "id": "c42fe6da-19e6-573b-b96c-6ac5e8350e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2edac86-02d4-4201-9b72-2ec64f163a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2edac86-02d4-4201-9b72-2ec64f163a72.jpg?1",
             "name": "Liliana, Waker of the Dead",
             "text": "+1: Each player discards a card. Each opponent who can't loses 3 life.\n\u22123: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard\n\u22127: You get an emblem with \"At the beginning of combat on your turn, put target creature card from a graveyard onto the battlefield under your control. It gains haste.\"",
             "colours": [
@@ -9758,7 +9758,7 @@
         },
         {
             "id": "1d5f0452-3033-5040-8efb-155a18594c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e494793-ec53-46dc-a5db-90dadc8cc015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e494793-ec53-46dc-a5db-90dadc8cc015.jpg?1",
             "name": "Chandra, Heart of Fire",
             "text": "+1: Discard your hand, then exile the top three cards of your library. Until end of turn, you may play cards exiled this way.\n+1: Chandra, Heart of Fire deals 2 damage to any target.\n\u22129: Search your graveyard and library for any number of red instant and/or sorcery cards, exile them, then shuffle your library. You may cast them this turn. Add six {R}.",
             "colours": [
@@ -9797,7 +9797,7 @@
         },
         {
             "id": "6445b1b1-3399-52dc-b2d1-0ef3801e17dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd16e1a6-0ece-44d5-8221-25892178e927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd16e1a6-0ece-44d5-8221-25892178e927.jpg?1",
             "name": "Garruk, Unleashed",
             "text": "+1: Up to one target creature gets +3/+3 and gains trample until end of turn.\n\u22122: Create a 3/3 green Beast creature token. Then if an opponent controls more creatures than you, put a loyalty counter on Garruk, Unleashed.\n\u22127: You get an emblem with \"At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "6e4dc7a9-c361-5d5c-895d-3e5e77bb6933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11e75a0-17f0-429a-a77a-268fe6257010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11e75a0-17f0-429a-a77a-268fe6257010.jpg?1",
             "name": "Ugin, the Spirit Dragon",
             "text": "+2: Ugin, the Spirit Dragon deals 3 damage to any target.\n\u2212X: Exile each permanent with converted mana cost X or less that's one or more colors.\n\u221210: You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield.",
             "colours": [],
@@ -9871,7 +9871,7 @@
         },
         {
             "id": "27a81cb8-5003-5125-9164-eb98ace7cdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca854101-5a9b-455d-bf47-ad8f3d57afa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca854101-5a9b-455d-bf47-ad8f3d57afa7.jpg?1",
             "name": "Basri Ket",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains indestructible until end of turn.\n\u22122: Whenever one or more nontoken creatures attack this turn, create that many 1/1 white Soldier creature tokens that are tapped and attacking.\n\u22126: You get an emblem with \"At the beginning of combat on your turn, create a 1/1 white Soldier creature token, then put a +1/+1 counter on each creature you control.\"",
             "colours": [
@@ -9910,7 +9910,7 @@
         },
         {
             "id": "c945537e-0dd8-55cd-a4d7-f225e2843993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6e3c8d-66c2-4e9d-a7c2-290b5695eec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f6e3c8d-66c2-4e9d-a7c2-290b5695eec2.jpg?1",
             "name": "Basri's Acolyte",
             "text": "Lifelink\nWhen Basri's Acolyte enters the battlefield, put a +1/+1 counter on each of up to two other target creatures you control.",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "304a63cb-bb95-5b64-a1de-4aeed771e22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26439775-7880-4e12-81eb-92185daca3fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26439775-7880-4e12-81eb-92185daca3fd.jpg?1",
             "name": "Basri's Lieutenant",
             "text": "Vigilance, protection from multicolored\nWhen Basri's Lieutenant enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Basri's Lieutenant or another creature you control dies, if it had a +1/+1 counter on it, create a 2/2 white Knight creature token with vigilance.",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "54073ee6-e09e-506f-a58c-dbd57b15557b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6daf0d-d581-434e-9b5f-cea1e7fd7967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6daf0d-d581-434e-9b5f-cea1e7fd7967.jpg?1",
             "name": "Basri's Solidarity",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "330fa447-ae91-56e1-a72a-916c45f04b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f802369f-bd9f-4c2f-835b-b0b9c1ea61a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f802369f-bd9f-4c2f-835b-b0b9c1ea61a7.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10063,7 +10063,7 @@
         },
         {
             "id": "0fec5858-1168-5933-8299-e5549afa40d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ba42c9-480c-4236-b217-01910e51b290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ba42c9-480c-4236-b217-01910e51b290.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "5e0ba6ef-f87c-58e8-bb32-9ea917d431c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a271b3-c3a9-47c6-bc8b-b580ede1968b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a271b3-c3a9-47c6-bc8b-b580ede1968b.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "a96fafad-76b9-5ad3-a2b0-d964ec7febe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fda4c0-d576-40e5-8e26-fc212c09691f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fda4c0-d576-40e5-8e26-fc212c09691f.jpg?1",
             "name": "Teferi, Master of Time",
             "text": "You may activate loyalty abilities of Teferi, Master of Time on any player's turn any time you could cast an instant.\n+1: Draw a card, then discard a card.\n\u22123: Target creature you don't control phases out.\n\u221210: Take two extra turns after this one.",
             "colours": [
@@ -10198,7 +10198,7 @@
         },
         {
             "id": "f2da525d-9b45-5ea1-a1d9-451fc51ed0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a3d8f-5513-42b1-a3d7-09cf781eaf94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a3d8f-5513-42b1-a3d7-09cf781eaf94.jpg?1",
             "name": "Teferi's Ageless Insight",
             "text": "If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.",
             "colours": [
@@ -10234,7 +10234,7 @@
         },
         {
             "id": "cf67232b-e5be-5c97-b644-8c7f5f755160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d63891-366b-473e-85c6-53886e26ca7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d63891-366b-473e-85c6-53886e26ca7a.jpg?1",
             "name": "Teferi's Protege",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -10271,7 +10271,7 @@
         },
         {
             "id": "0a13cd63-eb8d-522b-8a08-1506943100d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aefc721d-7c0b-4b3a-8131-f466bf3e7949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aefc721d-7c0b-4b3a-8131-f466bf3e7949.jpg?1",
             "name": "Teferi's Tutelage",
             "text": "When Teferi's Tutelage enters the battlefield, draw a card, then discard a card.\nWhenever you draw a card, target opponent mills two cards.",
             "colours": [
@@ -10305,7 +10305,7 @@
         },
         {
             "id": "b1fb9a61-6e04-5a2a-bac3-038b50d0bbf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dd3fda-d778-4be6-abd4-6cf704e352ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dd3fda-d778-4be6-abd4-6cf704e352ea.jpg?1",
             "name": "Liliana, Waker of the Dead",
             "text": "+1: Each player discards a card. Each opponent who can't loses 3 life.\n\u22123: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.\n\u22127: You get an emblem with \"At the beginning of combat on your turn, put target creature card from a graveyard onto the battlefield under your control. It gains haste.\"",
             "colours": [
@@ -10344,7 +10344,7 @@
         },
         {
             "id": "05d01186-eb40-5222-8a3a-1f48f982f214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d242d3-a817-4cdb-a51e-5f8202233743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d242d3-a817-4cdb-a51e-5f8202233743.jpg?1",
             "name": "Liliana's Devotee",
             "text": "Zombies you control get +1/+0.\nAt the beginning of your end step, if a creature died this turn, you may pay {1}{B}. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "fdc43560-b754-5e79-852a-e46b21d971df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd1c4b4-57b3-4779-9c7c-b23e73e6a74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd1c4b4-57b3-4779-9c7c-b23e73e6a74b.jpg?1",
             "name": "Liliana's Standard Bearer",
             "text": "Flash\nWhen Liliana's Standard Bearer enters the battlefield, draw X cards, where X is the number of creatures that died under your control this turn.",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "91cf7efd-8943-575e-824f-e7b46d977564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ab339-5f1a-425d-abfd-0b65a33d5c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9ab339-5f1a-425d-abfd-0b65a33d5c85.jpg?1",
             "name": "Liliana's Steward",
             "text": "{T}, Sacrifice Liliana's Steward: Target opponent discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "a85fe5e1-37ed-5891-8070-aec8eb690af5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e6a6bc-73ac-4000-967e-c37450665e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e6a6bc-73ac-4000-967e-c37450665e03.jpg?1",
             "name": "Chandra, Heart of Fire",
             "text": "+1: Discard your hand, then exile the top three cards of your library. Until end of turn, you may play cards exiled this way.\n+1: Chandra, Heart of Fire deals 2 damage to any target.\n\u22129: Search your graveyard and library for any number of red instant and/or sorcery cards, exile them, then shuffle your library. You may cast them this turn. Add six {R}.",
             "colours": [
@@ -10493,7 +10493,7 @@
         },
         {
             "id": "f6e32440-3544-5ccf-8df5-ef148514ef06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906cdb4-6a82-4611-abde-43566f9d01eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906cdb4-6a82-4611-abde-43566f9d01eb.jpg?1",
             "name": "Chandra's Incinerator",
             "text": "This spell costs {X} less to cast, where X is the total amount of noncombat damage dealt to your opponents this turn.\nTrample\nWhenever a source you control deals noncombat damage to an opponent, Chandra's Incinerator deals that much damage to target creature or planeswalker that player controls.",
             "colours": [
@@ -10529,7 +10529,7 @@
         },
         {
             "id": "efad8416-7efe-5c22-b36f-979bc1fe7978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ebe97-730c-43bb-86da-6ef0b34c104b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ebe97-730c-43bb-86da-6ef0b34c104b.jpg?1",
             "name": "Chandra's Magmutt",
             "text": "{T}: Chandra's Magmutt deals 1 damage to target player or planeswalker.",
             "colours": [
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "ad64f509-8cab-5283-a2e6-1a9aa1d57dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b807033-2273-4415-95b8-eb2dafed2967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b807033-2273-4415-95b8-eb2dafed2967.jpg?1",
             "name": "Chandra's Pyreling",
             "text": "Whenever a source you control deals noncombat damage to an opponent, Chandra's Pyreling gets +1/+0 and gains double strike until end of turn.",
             "colours": [
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "4c31e82b-c1b0-5d5b-b429-32d52caea3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e92f14-776d-4fa6-b872-1acadca1e372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e92f14-776d-4fa6-b872-1acadca1e372.jpg?1",
             "name": "Garruk, Unleashed",
             "text": "+1: Up to one target creature gets +3/+3 and gains trample until end of turn.\n\u22122: Create a 3/3 green Beast creature token. Then if an opponent controls more creatures than you, put a loyalty counter on Garruk, Unleashed.\n\u22127: You get an emblem with \"At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.\"",
             "colours": [
@@ -10642,7 +10642,7 @@
         },
         {
             "id": "9febf0f0-0876-592c-b850-4218cb6cf4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5c6492-4934-4d61-85ef-3dd64677dee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5c6492-4934-4d61-85ef-3dd64677dee3.jpg?1",
             "name": "Garruk's Gorehorn",
             "text": "",
             "colours": [
@@ -10678,7 +10678,7 @@
         },
         {
             "id": "862bd8d2-77ab-51f2-b2d6-9ee601e86f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faee64c-2338-4b01-8e26-7b68539a998b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faee64c-2338-4b01-8e26-7b68539a998b.jpg?1",
             "name": "Garruk's Harbinger",
             "text": "Hexproof from black\nWhenever Garruk's Harbinger deals combat damage to a player or planeswalker, look at that many cards from the top of your library. You may reveal a creature card or Garruk planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10714,7 +10714,7 @@
         },
         {
             "id": "5975656a-ef92-53d0-afa7-f69b3156ac8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce84db-d331-4e5b-bdd8-9b1b3bec50cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dce84db-d331-4e5b-bdd8-9b1b3bec50cc.jpg?1",
             "name": "Garruk's Uprising",
             "text": "When Garruk's Uprising enters the battlefield, if you control a creature with power 4 or greater, draw a card.\nCreatures you control have trample.\nWhenever a creature with power 4 or greater enters the battlefield under your control, draw a card.",
             "colours": [
@@ -10748,7 +10748,7 @@
         },
         {
             "id": "d6c798e1-56b7-5edf-9253-d2fdf7c6c79f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6778ff-6c1c-498a-bbfa-46c35b77a72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6778ff-6c1c-498a-bbfa-46c35b77a72a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10786,7 +10786,7 @@
         },
         {
             "id": "5d68fdec-6205-571f-804a-7dc74f7811fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24aa9fd2-54d9-40d9-9279-abd5bd6ff727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24aa9fd2-54d9-40d9-9279-abd5bd6ff727.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10824,7 +10824,7 @@
         },
         {
             "id": "7a85abdd-8744-5682-a768-709e5e92d569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b8665-31f2-4142-a076-54bccdaf5a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b8665-31f2-4142-a076-54bccdaf5a15.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10862,7 +10862,7 @@
         },
         {
             "id": "3cabbf32-9716-54d5-a2b0-cf3e65bb573f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162885d-3f55-4440-b40d-e38d378c4567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162885d-3f55-4440-b40d-e38d378c4567.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10900,7 +10900,7 @@
         },
         {
             "id": "16c6758e-a4b1-5a71-b003-e953b496340e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e049ae-bb12-41af-bbe4-ceded30bad67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e049ae-bb12-41af-bbe4-ceded30bad67.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10938,7 +10938,7 @@
         },
         {
             "id": "0282d6c1-49c2-53fc-ab4c-edb0db6ae522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51bacdd-040e-45f7-9256-85f93801a10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51bacdd-040e-45f7-9256-85f93801a10e.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -10975,7 +10975,7 @@
         },
         {
             "id": "d844bf3f-d1a3-5ace-9160-dc26aae1a3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf0dded-552a-4ad2-bb62-f1bfabad9bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf0dded-552a-4ad2-bb62-f1bfabad9bac.jpg?1",
             "name": "Grim Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle your library. You lose 3 life.",
             "colours": [
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "84075610-bcac-509d-acd3-0717da7c91e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0523c0a-b9b6-4946-b90d-ed8e13cf1915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0523c0a-b9b6-4946-b90d-ed8e13cf1915.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
             "colours": [
@@ -11046,7 +11046,7 @@
         },
         {
             "id": "8a150628-783f-50f4-9006-d36dd693f047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31233339-c5ec-40fb-badd-94ef7f0ff7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31233339-c5ec-40fb-badd-94ef7f0ff7c0.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -11080,7 +11080,7 @@
         },
         {
             "id": "38aac902-fd08-546a-86d5-8f0ce99b91c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91920a-7de3-4e9b-9cce-ff43ce0157b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a91920a-7de3-4e9b-9cce-ff43ce0157b8.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -11116,7 +11116,7 @@
         },
         {
             "id": "633734ac-e0aa-56ee-9ff2-4563deb0ad82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eab51a-8dad-4a37-9551-c6bf0dc6ecf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eab51a-8dad-4a37-9551-c6bf0dc6ecf5.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -11149,7 +11149,7 @@
         },
         {
             "id": "5a985f71-05af-5d0f-8276-1527016bdc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688b45d-9d74-4d9f-9a63-29c82b48d64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2688b45d-9d74-4d9f-9a63-29c82b48d64f.jpg?1",
             "name": "Basri, Devoted Paladin",
             "text": "+1: Put a +1/+1 counter on up to one target creature. It gains vigilance until end of turn.\n\u22121: Whenever a creature attacks this turn, put a +1/+1 counter on it.\n\u22126: Creatures you control get +2/+2 and gain flying until end of turn.",
             "colours": [
@@ -11184,7 +11184,7 @@
         },
         {
             "id": "5a848726-7e64-54d1-9d82-90b700dec99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2bc7ad-458d-445e-a0a9-7897b596fdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2bc7ad-458d-445e-a0a9-7897b596fdd0.jpg?1",
             "name": "Adherent of Hope",
             "text": "At the beginning of combat on your turn, if you control a Basri planeswalker, put a +1/+1 counter on Adherent of Hope.",
             "colours": [
@@ -11218,7 +11218,7 @@
         },
         {
             "id": "e31a8ca4-4d7d-5c5c-9632-35fcb158620d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577657ed-162f-4104-b0af-ee9733e90f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577657ed-162f-4104-b0af-ee9733e90f20.jpg?1",
             "name": "Basri's Aegis",
             "text": "Put a +1/+1 counter on each of up to two target creatures. You may search your library and/or graveyard for a card named Basri, Devoted Paladin, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11249,7 +11249,7 @@
         },
         {
             "id": "42e7acd1-5511-5ffb-b124-500bbf5f4330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba81e67-8fa5-441c-bf14-2d75c168a617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba81e67-8fa5-441c-bf14-2d75c168a617.jpg?1",
             "name": "Sigiled Contender",
             "text": "Sigiled Contender has lifelink as long as it has a +1/+1 counter on it. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -11283,7 +11283,7 @@
         },
         {
             "id": "f3b0d979-2575-522a-8fa8-2b1d5a05c5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d05287-ad7f-4de8-9f68-8f36c62fae72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d05287-ad7f-4de8-9f68-8f36c62fae72.jpg?1",
             "name": "Teferi, Timeless Voyager",
             "text": "+1: Draw a card.\n\u22123: Put target creature on top of its owner's library.\n\u22128: Each creature target opponent controls phases out. Until the end of your next turn, they can't phase in. (Treat them and anything attached to them as though they don't exist.)",
             "colours": [
@@ -11318,7 +11318,7 @@
         },
         {
             "id": "a98d6413-0bd5-577c-a788-6b812a79b180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae981da0-f32c-49d5-bcb0-2b9255a4e1fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae981da0-f32c-49d5-bcb0-2b9255a4e1fe.jpg?1",
             "name": "Historian of Zhalfir",
             "text": "Whenever Historian of Zhalfir attacks, if you control a Teferi planeswalker, draw a card.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "53ae3b74-6c04-5acd-887a-292762135057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0002ab72-834b-4c81-82b1-0d2760ea96b0.jpg?1",
             "name": "Mystic Skyfish",
             "text": "Whenever you draw your second card each turn, Mystic Skyfish gains flying until end of turn.",
             "colours": [
@@ -11385,7 +11385,7 @@
         },
         {
             "id": "44e9b27b-905f-5559-8dbe-3b54b455be83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67e4c42-a44f-456b-87e7-21ca56dc4630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67e4c42-a44f-456b-87e7-21ca56dc4630.jpg?1",
             "name": "Teferi's Wavecaster",
             "text": "Flash\nWhen Teferi's Wavecaster enters the battlefield, you may search your library and/or graveyard for a card named Teferi, Timeless Voyager, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11419,7 +11419,7 @@
         },
         {
             "id": "77f79f88-ea4a-521c-8773-db7d0f1c659b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921e3dc3-f8eb-4498-a6a8-b424952230cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921e3dc3-f8eb-4498-a6a8-b424952230cd.jpg?1",
             "name": "Liliana, Death Mage",
             "text": "+1: Return up to one target creature card from your graveyard to your hand.\n\u22123: Destroy target creature. Its controller loses 2 life.\n\u22127: Target opponent loses 2 life for each creature card in their graveyard.",
             "colours": [
@@ -11454,7 +11454,7 @@
         },
         {
             "id": "fc55d419-9056-5814-8fff-04eddb34dec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231f941-4acb-46f2-81ae-16e5a28e65af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231f941-4acb-46f2-81ae-16e5a28e65af.jpg?1",
             "name": "Liliana's Scorn",
             "text": "Destroy target creature. You may search your library and/or graveyard for a card named Liliana, Death Mage, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11485,7 +11485,7 @@
         },
         {
             "id": "b27208c9-8b0e-5e02-b11f-e343aabef0a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a64625f-937a-449e-b1fc-cd0f25b033f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a64625f-937a-449e-b1fc-cd0f25b033f6.jpg?1",
             "name": "Liliana's Scrounger",
             "text": "At the beginning of each end step, if a creature died this turn, you may put a loyalty counter on a Liliana planeswalker you control.",
             "colours": [
@@ -11519,7 +11519,7 @@
         },
         {
             "id": "4276487f-17d6-55e2-98ca-a77381c13d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3765b7-11e2-4837-b5e5-ca24adc0e33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3765b7-11e2-4837-b5e5-ca24adc0e33c.jpg?1",
             "name": "Spirit of Malevolence",
             "text": "When Spirit of Malevolence dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11552,7 +11552,7 @@
         },
         {
             "id": "96fa6bc6-2dfa-57b8-87a3-37223a12f809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e49ce44-5286-4310-88c2-f8a1402b113b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e49ce44-5286-4310-88c2-f8a1402b113b.jpg?1",
             "name": "Chandra, Flame's Catalyst",
             "text": "+1: Chandra, Flame's Catalyst deals 3 damage to each opponent.\n\u22122: You may cast target red instant or sorcery card from your graveyard. If that spell would be put into your graveyard this turn, exile it instead.\n\u22128: Discard your hand, then draw seven cards. Until end of turn, you may cast spells from your hand without paying their mana costs.",
             "colours": [
@@ -11587,7 +11587,7 @@
         },
         {
             "id": "35499aec-5e33-5245-a357-95c44ca43a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf0b50-155f-4e65-9e48-88b378ad93a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf0b50-155f-4e65-9e48-88b378ad93a1.jpg?1",
             "name": "Chandra's Firemaw",
             "text": "Haste\nWhen Chandra's Firemaw enters the battlefield, you may search your library and/or graveyard for a card named Chandra, Flame's Catalyst, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11620,7 +11620,7 @@
         },
         {
             "id": "2229dd8b-86b5-5d2b-af16-14422a90c37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b862e46-f5a2-4fce-98b5-2c5aa49ec648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b862e46-f5a2-4fce-98b5-2c5aa49ec648.jpg?1",
             "name": "Keral Keep Disciples",
             "text": "Whenever you activate a loyalty ability of a Chandra planeswalker, Keral Keep Disciples deals 1 damage to each opponent.",
             "colours": [
@@ -11654,7 +11654,7 @@
         },
         {
             "id": "a85fc0d9-26a8-5c3d-a9ac-17f29ad9348d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d123c-c16d-43fa-b183-8a59c7e1a11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6d123c-c16d-43fa-b183-8a59c7e1a11e.jpg?1",
             "name": "Storm Caller",
             "text": "When Storm Caller enters the battlefield, it deals 2 damage to each opponent.",
             "colours": [
@@ -11688,7 +11688,7 @@
         },
         {
             "id": "193f8e09-b8ca-509c-9b4c-264e29a05cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48133629-4a5b-4c91-b496-2ee94f6cbc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48133629-4a5b-4c91-b496-2ee94f6cbc4c.jpg?1",
             "name": "Garruk, Savage Herald",
             "text": "+1: Reveal the top card of your library. If it's a creature card, put it into your hand. Otherwise, put it on the bottom of your library.\n\u22122: Target creature you control deals damage equal to its power to another target creature.\n\u22127: Until end of turn, creatures you control gain \"You may have this creature assign its combat damage as though it weren't blocked.\"",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "ade144fa-2f01-5dfa-be1d-01287677f887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6099863-8d3d-44bf-8d3b-dc3602119617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6099863-8d3d-44bf-8d3b-dc3602119617.jpg?1",
             "name": "Garruk's Warsteed",
             "text": "Vigilance\nWhen Garruk's Warsteed enters the battlefield, you may search your library and/or graveyard for a card named Garruk, Savage Herald, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -11756,7 +11756,7 @@
         },
         {
             "id": "9c85e879-8136-5860-89fb-e2d82c8ba3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073cbc6-11de-4d4a-bcd7-792f9b7c5219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073cbc6-11de-4d4a-bcd7-792f9b7c5219.jpg?1",
             "name": "Predatory Wurm",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nPredatory Wurm gets +2/+2 as long as you control a Garruk planeswalker.",
             "colours": [
@@ -11789,7 +11789,7 @@
         },
         {
             "id": "19a596b1-90f7-5f7c-963f-62faa5ddb99f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceaf927-261e-4d61-9fac-eb8abbe87593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceaf927-261e-4d61-9fac-eb8abbe87593.jpg?1",
             "name": "Wildwood Patrol",
             "text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -11823,7 +11823,7 @@
         },
         {
             "id": "25675646-282c-5689-81d1-3c794117a309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0974b4-b306-4026-b0a8-22bd9da3e384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0974b4-b306-4026-b0a8-22bd9da3e384.jpg?1",
             "name": "Baneslayer Angel",
             "text": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "colours": [
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "0f063021-459f-594f-8968-823794af5da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ba79d6-7da0-46ba-a26a-dc484bdae41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ba79d6-7da0-46ba-a26a-dc484bdae41d.jpg?1",
             "name": "Glorious Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -11893,7 +11893,7 @@
         },
         {
             "id": "2984b348-efc5-58ab-9191-9c004808e643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811c396-8992-4c3c-b2f6-c866f1aefcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e811c396-8992-4c3c-b2f6-c866f1aefcc5.jpg?1",
             "name": "Idol of Endurance",
             "text": "When Idol of Endurance enters the battlefield, exile all creature cards with converted mana cost 3 or less from your graveyard until Idol of Endurance leaves the battlefield.\n{1}{W}, {T}: Until end of turn, you may cast a creature spell from among the cards exiled with Idol of Endurance without paying its mana cost.",
             "colours": [
@@ -11927,7 +11927,7 @@
         },
         {
             "id": "1153a85e-d45d-5086-859b-acc5c4c198ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011cfa46-6827-4418-881b-686eb34e06ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011cfa46-6827-4418-881b-686eb34e06ce.jpg?1",
             "name": "Mangara, the Diplomat",
             "text": "Lifelink\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, draw a card.\nWhenever an opponent casts their second spell each turn, draw a card.",
             "colours": [
@@ -11966,7 +11966,7 @@
         },
         {
             "id": "597eefbd-b0b5-5e7a-b78a-a2cee7b553e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada448c-6431-4172-b458-efa49c302dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dada448c-6431-4172-b458-efa49c302dfb.jpg?1",
             "name": "Nine Lives",
             "text": "Hexproof\nIf a source would deal damage to you, prevent that damage and put an incarnation counter on Nine Lives.\nWhen there are nine or more incarnation counters on Nine Lives, exile it.\nWhen Nine Lives leaves the battlefield, you lose the game.",
             "colours": [
@@ -12000,7 +12000,7 @@
         },
         {
             "id": "e3bf017d-5853-5123-98b3-c513be5b00a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f7a7ef-aa18-4738-97db-97e50ec3b801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f7a7ef-aa18-4738-97db-97e50ec3b801.jpg?1",
             "name": "Pack Leader",
             "text": "Other Dogs you control get +1/+1.\nWhenever Pack Leader attacks, prevent all combat damage that would be dealt this turn to Dogs you control.",
             "colours": [
@@ -12037,7 +12037,7 @@
         },
         {
             "id": "bd3f6487-805c-5225-b032-6ac65b906b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1223eaa0-dee9-4bff-a4d5-3b30aa973b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1223eaa0-dee9-4bff-a4d5-3b30aa973b84.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen card name.",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "87df54a3-5090-5bb5-9774-bc78962641ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e300294d-0bbd-4d28-b2bd-c5a976de212a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e300294d-0bbd-4d28-b2bd-c5a976de212a.jpg?1",
             "name": "Speaker of the Heavens",
             "text": "Vigilance, lifelink\n{T}: Create a 4/4 white Angel creature token with flying. Activate this ability only if you have at least 7 life more than your starting life total and only any time you could cast a sorcery.",
             "colours": [
@@ -12108,7 +12108,7 @@
         },
         {
             "id": "23029e04-3066-5de6-aa29-036ce22c44ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3765b7-bd99-4c66-8761-1c9cc5bd8666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3765b7-bd99-4c66-8761-1c9cc5bd8666.jpg?1",
             "name": "Barrin, Tolarian Archmage",
             "text": "When Barrin, Tolarian Archmage enters the battlefield, return up to one other target creature or planeswalker to its owner's hand.\nAt the beginning of your end step, if a permanent was put into your hand from the battlefield this turn, draw a card.",
             "colours": [
@@ -12147,7 +12147,7 @@
         },
         {
             "id": "1f1fe2b2-68e1-597c-bcbc-249bbfd0e225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f8208-0dba-49e0-ae53-b1c9347b92b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2f8208-0dba-49e0-ae53-b1c9347b92b6.jpg?1",
             "name": "Discontinuity",
             "text": "As long as it's your turn, this spell costs {2}{U}{U} less to cast.\nEnd the turn.",
             "colours": [
@@ -12181,7 +12181,7 @@
         },
         {
             "id": "52a6e270-a95c-5f45-b33d-3c495c425510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f96dc6-65ff-4527-8fe6-ff508da5b8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f96dc6-65ff-4527-8fe6-ff508da5b8b9.jpg?1",
             "name": "Ghostly Pilferer",
             "text": "Whenever Ghostly Pilferer becomes untapped, you may pay {2}. If you do, draw a card.\nWhenever an opponent casts a spell from anywhere other than their hand, draw a card.\nDiscard a card: Ghostly Pilferer can't be blocked this turn.",
             "colours": [
@@ -12218,7 +12218,7 @@
         },
         {
             "id": "2afe2c85-77fb-5734-8738-b3f0b95170a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143052f0-4fcc-4703-9147-75b65ddb8e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143052f0-4fcc-4703-9147-75b65ddb8e0f.jpg?1",
             "name": "Pursued Whale",
             "text": "When Pursued Whale enters the battlefield, each opponent creates a 1/1 red Pirate creature token with \"This creature can't block\" and \"Creatures you control attack each combat if able.\"\nSpells your opponents cast that target Pursued Whale cost {3} more to cast.",
             "colours": [
@@ -12254,7 +12254,7 @@
         },
         {
             "id": "5764ce75-6054-5e90-a5e1-86d5d23740cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de27dfa8-5790-4b42-ae57-b68814d66e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de27dfa8-5790-4b42-ae57-b68814d66e34.jpg?1",
             "name": "See the Truth",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order. If this spell was cast from anywhere other than your hand, put each of those cards into your hand instead.",
             "colours": [
@@ -12288,7 +12288,7 @@
         },
         {
             "id": "af746582-700f-5424-be4e-f76a8582ab44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6d0c71-d1c8-4eb0-96e7-b3325d5fb4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6d0c71-d1c8-4eb0-96e7-b3325d5fb4c0.jpg?1",
             "name": "Shacklegeist",
             "text": "Flying\nShacklegeist can block only creatures with flying.\nTap two untapped Spirits you control: Tap target creature you don't control.",
             "colours": [
@@ -12324,7 +12324,7 @@
         },
         {
             "id": "f255dc77-c7de-5586-85bc-2680cc1e7870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b9d2-e49d-4ac1-abda-88a83b58dc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c45b9d2-e49d-4ac1-abda-88a83b58dc30.jpg?1",
             "name": "Stormwing Entity",
             "text": "This spell costs {2}{U} less to cast if you've cast an instant or sorcery spell this turn.\nFlying\nProwess\nWhen Stormwing Entity enters the battlefield, scry 2.",
             "colours": [
@@ -12360,7 +12360,7 @@
         },
         {
             "id": "cfd3b24e-bae7-59f9-9634-90ccfc3f8937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c8712-0cfa-465c-a712-2bd1385d8049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c8712-0cfa-465c-a712-2bd1385d8049.jpg?1",
             "name": "Sublime Epiphany",
             "text": "Choose one or more \u2014\n\u2022 Counter target spell.\n\u2022 Counter target activated or triggered ability.\n\u2022 Return target nonland permanent to its owner's hand.\n\u2022 Create a token that's a copy of target creature you control.\n\u2022 Target player draws a card.",
             "colours": [
@@ -12394,7 +12394,7 @@
         },
         {
             "id": "c4074867-105a-5c21-8791-099ddb95d511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cf6c9-7e73-448c-abc1-35758d269472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496cf6c9-7e73-448c-abc1-35758d269472.jpg?1",
             "name": "Demonic Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+1, has flying, and is a Demon in addition to its other types.\nYou may cast Demonic Embrace from your graveyard by paying 3 life and discarding a card in addition to paying its other costs.",
             "colours": [
@@ -12430,7 +12430,7 @@
         },
         {
             "id": "fafd13e2-9ba1-587e-b403-7bf6a6b59183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3becd8e2-677a-4e54-8839-2b9f80573aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3becd8e2-677a-4e54-8839-2b9f80573aa1.jpg?1",
             "name": "Hooded Blightfang",
             "text": "Deathtouch\nWhenever a creature you control with deathtouch attacks, each opponent loses 1 life and you gain 1 life.\nWhenever a creature you control with deathtouch deals damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -12466,7 +12466,7 @@
         },
         {
             "id": "548ca45b-5cdf-54f4-90da-bc018fd386ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85082679-360f-48a2-a131-ce939f774749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85082679-360f-48a2-a131-ce939f774749.jpg?1",
             "name": "Kaervek, the Spiteful",
             "text": "Other creatures get -1/-1.",
             "colours": [
@@ -12505,7 +12505,7 @@
         },
         {
             "id": "75cca7f4-160f-5334-8cc7-a008c0aee672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9350ab9a-263b-4698-b4e7-2beb01c39134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9350ab9a-263b-4698-b4e7-2beb01c39134.jpg?1",
             "name": "Necromentia",
             "text": "Choose a card name other than a basic land card name. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles their library, then creates a 2/2 black Zombie creature token for each card exiled from their hand this way.",
             "colours": [
@@ -12539,7 +12539,7 @@
         },
         {
             "id": "7c12f551-aed1-5f24-a2d9-c346f1603701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46820e5-67a4-4b28-bd0c-7ed9443d7dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46820e5-67a4-4b28-bd0c-7ed9443d7dfb.jpg?1",
             "name": "Peer into the Abyss",
             "text": "Target player draws cards equal to half the number of cards in their library and loses half their life. Round up each time.",
             "colours": [
@@ -12573,7 +12573,7 @@
         },
         {
             "id": "83a0830b-6cf8-5201-9aa4-e92fd34f0deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8962e7d-b14d-41b5-8805-17490b6c32bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8962e7d-b14d-41b5-8805-17490b6c32bf.jpg?1",
             "name": "Thieves' Guild Enforcer",
             "text": "Flash\nWhenever Thieves' Guild Enforcer or another Rogue enters the battlefield under your control, each opponent mills two cards.\nAs long as an opponent has eight or more cards in their graveyard, Thieves' Guild Enforcer gets +2/+1 and has deathtouch.",
             "colours": [
@@ -12610,7 +12610,7 @@
         },
         {
             "id": "9a472dc4-de91-5e62-aa97-225e6a378068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a52a83-0087-4df3-995a-45e15bf664b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a52a83-0087-4df3-995a-45e15bf664b4.jpg?1",
             "name": "Vito, Thorn of the Dusk Rose",
             "text": "Whenever you gain life, target opponent loses that much life.\n{3}{B}{B}: Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -12649,7 +12649,7 @@
         },
         {
             "id": "fa3cff1a-b70e-54c2-90ba-9e948e653cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea0d236-bfd2-4f47-8592-2669834d01f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea0d236-bfd2-4f47-8592-2669834d01f1.jpg?1",
             "name": "Brash Taunter",
             "text": "Indestructible\nWhenever Brash Taunter is dealt damage, it deals that much damage to target opponent.\n{2}{R}, {T}: Brash Taunter fights another target creature.",
             "colours": [
@@ -12685,7 +12685,7 @@
         },
         {
             "id": "7a7c6116-a678-5182-b0da-3bfd7c0280bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e3cb0a-3a23-4b00-9a79-bd2d16d0b1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e3cb0a-3a23-4b00-9a79-bd2d16d0b1b2.jpg?1",
             "name": "Conspicuous Snoop",
             "text": "Play with the top card of your library revealed.\nYou may cast Goblin spells from the top of your library.\nAs long as the top card of your library is a Goblin card, Conspicuous Snoop has all activated abilities of that card.",
             "colours": [
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "4b59b687-4336-5509-9ac3-0c82aeba4e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4955455-c708-4f96-ba21-0a6de0e74336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4955455-c708-4f96-ba21-0a6de0e74336.jpg?1",
             "name": "Double Vision",
             "text": "Whenever you cast your first instant or sorcery spell each turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -12756,7 +12756,7 @@
         },
         {
             "id": "c2d28ec0-668c-5b0b-80e1-0a40dc2917f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33957ca8-babe-45d2-bcf2-15ed1add5ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33957ca8-babe-45d2-bcf2-15ed1add5ec9.jpg?1",
             "name": "Fiery Emancipation",
             "text": "If a source you control would deal damage to a permanent or player, it deals triple that damage to that permanent or player instead.",
             "colours": [
@@ -12790,7 +12790,7 @@
         },
         {
             "id": "0dda41a3-559c-5553-8e4a-b147ea8e38e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333228c5-af16-4ebd-acfc-3776b21ef044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333228c5-af16-4ebd-acfc-3776b21ef044.jpg?1",
             "name": "Gadrak, the Crown-Scourge",
             "text": "Flying\nGadrak, the Crown-Scourge can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn.",
             "colours": [
@@ -12828,7 +12828,7 @@
         },
         {
             "id": "c49c2379-d93e-545f-9251-43585a1869e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380fd52-8fee-4956-a9fa-986019bcb423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380fd52-8fee-4956-a9fa-986019bcb423.jpg?1",
             "name": "Subira, Tulzidi Caravanner",
             "text": "Haste\n{1}: Another target creature with power 2 or less can't be blocked this turn.\n{1}{R}, {T}, Discard your hand: Until end of turn, whenever a creature you control with power 2 or less deals combat damage to a player, draw a card.",
             "colours": [
@@ -12867,7 +12867,7 @@
         },
         {
             "id": "1be1135f-83ee-519b-ad48-7e97dc0520b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ea21-fef4-4000-9b22-c8d07420827b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ea21-fef4-4000-9b22-c8d07420827b.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -12903,7 +12903,7 @@
         },
         {
             "id": "20b81307-f56d-5f15-896a-f99f2a0318b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6252e7-aa4f-4d7b-a655-6564c5c124e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6252e7-aa4f-4d7b-a655-6564c5c124e6.jpg?1",
             "name": "Transmogrify",
             "text": "Exile target creature. That creature's controller reveals cards from the top of their library until they reveal a creature card. That player puts that card onto the battlefield, then shuffles the rest into their library.",
             "colours": [
@@ -12937,7 +12937,7 @@
         },
         {
             "id": "3287f681-2d33-5477-8cb9-8002dbc58562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a95e99-4398-4263-90bc-1b0c544b18b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a95e99-4398-4263-90bc-1b0c544b18b1.jpg?1",
             "name": "Volcanic Salvo",
             "text": "This spell costs {X} less to cast, where X is the total power of creatures you control.\nVolcanic Salvo deals 6 damage to each of up to two target creatures and/or planeswalkers.",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "1fecbcb2-2b39-5e4d-8daf-60d98ce30c45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1507b7bc-cf3d-42c7-a4c8-e5b22cea9ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1507b7bc-cf3d-42c7-a4c8-e5b22cea9ec0.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "You may play two additional lands on each of your turns.",
             "colours": [
@@ -13010,7 +13010,7 @@
         },
         {
             "id": "33207345-915a-59ef-a727-fedae6703cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee9b3ad-0774-4952-b49b-be390182b245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee9b3ad-0774-4952-b49b-be390182b245.jpg?1",
             "name": "Elder Gargaroth",
             "text": "Vigilance, reach, trample\nWhenever Elder Gargaroth attacks or blocks, choose one \u2014\n\u2022 Create a 3/3 green Beast creature token.\n\u2022 You gain 3 life.\n\u2022 Draw a card.",
             "colours": [
@@ -13046,7 +13046,7 @@
         },
         {
             "id": "3b0b5d0f-d876-5373-832d-fad4b4d49d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbea5a3c-03b7-44da-b8f7-534a962b8e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbea5a3c-03b7-44da-b8f7-534a962b8e1e.jpg?1",
             "name": "Feline Sovereign",
             "text": "Other Cats you control get +1/+1 and have protection from Dogs.\nWhenever one or more Cats you control deal combat damage to a player, destroy up to one target artifact or enchantment that player controls.",
             "colours": [
@@ -13082,7 +13082,7 @@
         },
         {
             "id": "32553924-05b7-580a-8740-c6eac3f040e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9fb88e-d13d-46d0-a3c5-da886f43ffb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9fb88e-d13d-46d0-a3c5-da886f43ffb9.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -13116,7 +13116,7 @@
         },
         {
             "id": "077244e4-aec5-593b-9590-adf1c2d9e8bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ccd23e-c883-474b-93e5-4131aa1e6e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ccd23e-c883-474b-93e5-4131aa1e6e8a.jpg?1",
             "name": "Jolrael, Mwonvuli Recluse",
             "text": "Whenever you draw your second card each turn, create a 2/2 green Cat creature token.\n{4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.",
             "colours": [
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "1e313405-c7ab-5cda-9c5d-d724a7b66321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffcaab7-674b-4e34-b09d-41414bd0022e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffcaab7-674b-4e34-b09d-41414bd0022e.jpg?1",
             "name": "Primal Might",
             "text": "Target creature you control gets +X/+X until end of turn. Then it fights up to one target creature you don't control.",
             "colours": [
@@ -13189,7 +13189,7 @@
         },
         {
             "id": "19fdf946-c2a1-571d-9ab0-101940ee7ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e999a48-27ab-429c-95cc-249d931bbbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e999a48-27ab-429c-95cc-249d931bbbd5.jpg?1",
             "name": "Sporeweb Weaver",
             "text": "Reach, hexproof from blue\nWhenever Sporeweb Weaver is dealt damage, you gain 1 life and create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13225,7 +13225,7 @@
         },
         {
             "id": "255c977d-38e8-5c67-b5b4-9be0b6f4d859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b942b9-fcf4-421d-a470-73a90f0408a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b942b9-fcf4-421d-a470-73a90f0408a5.jpg?1",
             "name": "Niambi, Esteemed Speaker",
             "text": "Flash\nWhen Niambi, Esteemed Speaker enters the battlefield, you may return another target creature you control to its owner's hand. If you do, you gain life equal to that creature's converted mana cost.\n{1}{W}{U}, {T}, Discard a legendary card: Draw two cards.",
             "colours": [
@@ -13266,7 +13266,7 @@
         },
         {
             "id": "09416767-8fe9-5863-ab61-76bef6d048a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7777bc17-88cf-41fb-9169-77149c01eec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7777bc17-88cf-41fb-9169-77149c01eec8.jpg?1",
             "name": "Radha, Heart of Keld",
             "text": "As long as it's your turn, Radha, Heart of Keld has first strike.\nYou may look at the top card of your library any time, and you may play lands from the top of your library.\n{4}{R}{G}: Radha gets +X/+X until end of turn, where X is the number of lands you control.",
             "colours": [
@@ -13307,7 +13307,7 @@
         },
         {
             "id": "3a6e0ee5-2af3-5474-ac7b-1683632dfd9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b401c8b-dea9-4df7-8929-52370d47bf91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b401c8b-dea9-4df7-8929-52370d47bf91.jpg?1",
             "name": "Sanctum of All",
             "text": "At the beginning of your upkeep, you may search your library and/or graveyard for a Shrine card and put it onto the battlefield. If you search your library this way, shuffle it.\nIf an ability of another Shrine you control triggers while you control six or more Shrines, that ability triggers an additional time.",
             "colours": [
@@ -13353,7 +13353,7 @@
         },
         {
             "id": "7bf1c6f7-6ec3-59bc-ac63-c7996ec6c00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d9ddf6-9283-4c93-9932-70362068ce72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d9ddf6-9283-4c93-9932-70362068ce72.jpg?1",
             "name": "Chromatic Orrery",
             "text": "You may spend mana as though it were mana of any color.\n{T}: Add {C}{C}{C}{C}{C}.\n{5}, {T}: Draw a card for each color among permanents you control.",
             "colours": [],
@@ -13385,7 +13385,7 @@
         },
         {
             "id": "9f07875a-ab6b-5feb-97b3-f83c13080343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a202f3-23e3-490a-bae9-42f2fe267ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a202f3-23e3-490a-bae9-42f2fe267ce7.jpg?1",
             "name": "Mazemind Tome",
             "text": "{T}, Put a page counter on Mazemind Tome: Scry 1.\n{2}, {T}, Put a page counter on Mazemind Tome: Draw a card.\nWhen there are four or more page counters on Mazemind Tome, exile it. If you do, you gain 4 life.",
             "colours": [],
@@ -13415,7 +13415,7 @@
         },
         {
             "id": "815a55a3-f6b4-5bc4-8a48-d796bbb529b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29d9617-734a-4516-882e-661b3effb569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29d9617-734a-4516-882e-661b3effb569.jpg?1",
             "name": "Sparkhunter Masticore",
             "text": "As an additional cost to cast this spell, discard a card.\nProtection from planeswalkers\n{1}: Sparkhunter Masticore deals 1 damage to target planeswalker.\n{3}: Sparkhunter Masticore gains indestructible until end of turn.",
             "colours": [],
@@ -13448,7 +13448,7 @@
         },
         {
             "id": "62ad3c92-19a9-5717-b6d9-572f280fc3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ec7b76-4e97-4f47-b7af-ef9c2435b20e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ec7b76-4e97-4f47-b7af-ef9c2435b20e.jpg?1",
             "name": "Animal Sanctuary",
             "text": "{T}: Add {C}.\n{2}, {T}: Put a +1/+1 counter on target Bird, Cat, Dog, Goat, Ox, or Snake.",
             "colours": [],
@@ -13478,7 +13478,7 @@
         },
         {
             "id": "6481dc40-001b-5939-9a8d-b85bd4471f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb5cd32-3e9e-407e-a501-a56793017324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb5cd32-3e9e-407e-a501-a56793017324.jpg?1",
             "name": "Fabled Passage",
             "text": "{T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.",
             "colours": [],
@@ -13508,7 +13508,7 @@
         },
         {
             "id": "69f5a578-5e74-5d41-837e-d4f00599ef9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b63d6-09d6-44d9-ba57-fa6c576507c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b63d6-09d6-44d9-ba57-fa6c576507c4.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -13541,7 +13541,7 @@
         },
         {
             "id": "706daedc-2ffd-5993-af42-6686b63daa42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc9f2-05ed-462b-922e-75531bccacca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34fc9f2-05ed-462b-922e-75531bccacca.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -13574,7 +13574,7 @@
         },
         {
             "id": "3f28e6fa-0a1a-5b9c-be97-ed17472effeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11a16d-25c9-43e7-8776-313347bab820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a11a16d-25c9-43e7-8776-313347bab820.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "e53903c1-46e9-52ac-9453-6b48290169a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6a3602-8e44-4df6-9607-ba5ce2d2e733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6a3602-8e44-4df6-9607-ba5ce2d2e733.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "9f845317-38ae-5a18-9b44-a57a207e0801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7449-235f-43f0-b75d-e1b0e98c3a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097d7449-235f-43f0-b75d-e1b0e98c3a7d.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -13673,7 +13673,7 @@
         },
         {
             "id": "6d43057f-3da6-5663-bcf3-1eeb80808c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be82997-ad17-4977-b3a9-099889fb0aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be82997-ad17-4977-b3a9-099889fb0aa3.jpg?1",
             "name": "Pack Leader",
             "text": "",
             "colours": [
@@ -13709,7 +13709,7 @@
         },
         {
             "id": "37e02e05-7754-5a48-904c-d67e3b098d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a129ff7-72f9-4171-902d-a1b49eebfb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a129ff7-72f9-4171-902d-a1b49eebfb62.jpg?1",
             "name": "Selfless Savior",
             "text": "",
             "colours": [
@@ -13745,7 +13745,7 @@
         },
         {
             "id": "adc607e8-4797-5197-b4b5-48f2bb815c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474d7e8-6b34-4d88-bb78-c43c24d5eb58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5474d7e8-6b34-4d88-bb78-c43c24d5eb58.jpg?1",
             "name": "Frantic Inventory",
             "text": "",
             "colours": [
@@ -13779,7 +13779,7 @@
         },
         {
             "id": "7165c42c-7210-5564-b5a9-e666de59034a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753d3152-da9d-48af-98b0-34efb990205d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753d3152-da9d-48af-98b0-34efb990205d.jpg?1",
             "name": "Eliminate",
             "text": "",
             "colours": [
@@ -13813,7 +13813,7 @@
         },
         {
             "id": "e59c4baf-3f6b-5009-a52e-b0a9a678f5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13406fc3-4061-46b4-8738-09494c85550f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13406fc3-4061-46b4-8738-09494c85550f.jpg?1",
             "name": "Heartfire Immolator",
             "text": "",
             "colours": [
@@ -13850,7 +13850,7 @@
         },
         {
             "id": "7993b03d-4c35-50f4-a5ea-bcb6b591cf8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880c9523-717e-4903-a09e-d6c47614383d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880c9523-717e-4903-a09e-d6c47614383d.jpg?1",
             "name": "Llanowar Visionary",
             "text": "",
             "colours": [
@@ -13887,7 +13887,7 @@
         },
         {
             "id": "1468602a-b4fb-5c4a-a498-d01e1c01feb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e12d954-3ec2-46e3-b01f-1fd63159e8a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e12d954-3ec2-46e3-b01f-1fd63159e8a4.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -13922,7 +13922,7 @@
         },
         {
             "id": "c874bb19-716e-5350-ab05-04c3ae7ece4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e33dff-23d5-4f31-8dd6-270657e150d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e33dff-23d5-4f31-8dd6-270657e150d8.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -13957,7 +13957,7 @@
         },
         {
             "id": "76ed2e95-f655-5b86-a404-257876628a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaae25-d0cd-416a-a44a-5b258fd1d9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaae25-d0cd-416a-a44a-5b258fd1d9fd.jpg?1",
             "name": "Griffin",
             "text": "",
             "colours": [
@@ -13992,7 +13992,7 @@
         },
         {
             "id": "5f43c683-7b4e-566b-8ded-a6f4311df06e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076f934b-a244-45f1-bcb3-7c5e882e9911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076f934b-a244-45f1-bcb3-7c5e882e9911.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "d27f5b6a-7f5d-55d7-81e6-6192087ed01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb2914-bba2-4cb6-802e-af2aeef46de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdb2914-bba2-4cb6-802e-af2aeef46de8.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -14062,7 +14062,7 @@
         },
         {
             "id": "a4dd1ba2-1b49-5196-9796-cc643e718d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54c7f9f-a1ea-4bf0-8ab3-cca49f393f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54c7f9f-a1ea-4bf0-8ab3-cca49f393f4a.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -14097,7 +14097,7 @@
         },
         {
             "id": "15f25eca-ba72-5b13-ab15-1e6bf04d5dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f170f84-6c36-43e2-91e6-3c7a136944b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f170f84-6c36-43e2-91e6-3c7a136944b1.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -14132,7 +14132,7 @@
         },
         {
             "id": "916b1421-f426-55b4-ac9a-fd9f7372e045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7094d6-6e23-47f2-a9da-4dd680294ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7094d6-6e23-47f2-a9da-4dd680294ac8.jpg?1",
             "name": "Goblin Wizard",
             "text": "",
             "colours": [
@@ -14168,7 +14168,7 @@
         },
         {
             "id": "cf9ffa43-3ce7-59ac-9f09-ac718e93a505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3002d9-7754-4c7f-a051-382cd7a86e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3002d9-7754-4c7f-a051-382cd7a86e80.jpg?1",
             "name": "Pirate",
             "text": "",
             "colours": [
@@ -14203,7 +14203,7 @@
         },
         {
             "id": "11346e2d-6867-5b89-868d-baad1f9ead92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "95dfeb5e-37c9-5637-9711-aee284aa5702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6541414-c506-449d-b3a8-79f47be531a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6541414-c506-449d-b3a8-79f47be531a9.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -14273,7 +14273,7 @@
         },
         {
             "id": "02f6f528-e3f3-596d-aac6-17589d10f095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71a5aa4-a960-4c42-b8ac-7003f6e83e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71a5aa4-a960-4c42-b8ac-7003f6e83e95.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -14308,7 +14308,7 @@
         },
         {
             "id": "570c3c71-b13b-509d-a61e-4d3ff221a8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d9c67-69ee-48c4-af4c-18cc3c2ef3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d9c67-69ee-48c4-af4c-18cc3c2ef3cd.jpg?1",
             "name": "Weird",
             "text": "",
             "colours": [
@@ -14345,7 +14345,7 @@
         },
         {
             "id": "c7a731ba-0a37-517c-b02c-f57f37c9c118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4001c4c6-647c-4ffc-9803-81df43b77e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4001c4c6-647c-4ffc-9803-81df43b77e12.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -14377,7 +14377,7 @@
         },
         {
             "id": "754fd11c-fb97-5a58-bf3a-fb4e7f179eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4306be80-d7c9-4bcf-a3de-4bf159475546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4306be80-d7c9-4bcf-a3de-4bf159475546.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -14408,7 +14408,7 @@
         },
         {
             "id": "380d3b56-c427-5911-b92c-81230f3ad738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d37b555-5931-4084-8f83-e9853e14eccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d37b555-5931-4084-8f83-e9853e14eccf.jpg?1",
             "name": "Basri Ket Emblem",
             "text": "",
             "colours": [],
@@ -14436,7 +14436,7 @@
         },
         {
             "id": "0017cb36-348b-57a4-81f5-c5b5159705ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b572a46c-8bd0-4af8-bc76-2c65841c27b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b572a46c-8bd0-4af8-bc76-2c65841c27b9.jpg?1",
             "name": "Garruk, Unleashed Emblem",
             "text": "",
             "colours": [],
@@ -14464,7 +14464,7 @@
         },
         {
             "id": "9a0f790a-f3bf-5578-a43c-d8d389202485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968f207e-8e60-4dad-935c-71e0267c2399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968f207e-8e60-4dad-935c-71e0267c2399.jpg?1",
             "name": "Liliana, Waker of the Dead Emblem",
             "text": "",
             "colours": [],
@@ -14492,7 +14492,7 @@
         },
         {
             "id": "cffaaddc-a438-57e0-a721-a22f1f350763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8107b3-8539-4b9c-8d0d-c512c940838f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8107b3-8539-4b9c-8d0d-c512c940838f.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -14526,7 +14526,7 @@
         },
         {
             "id": "6bcccfbf-347f-58c6-aa82-fd740a61e8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/MAT.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MAT.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5a5da967-1730-5e78-a2ce-fc0d078a2317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786f05d-78a2-41b6-a185-111e8c1b216b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786f05d-78a2-41b6-a185-111e8c1b216b.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -43,7 +43,7 @@
         },
         {
             "id": "588c17e9-2bc5-57af-9923-ebb0abd42f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce799e-cb9e-4d74-8b13-a5f4559e13a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ce799e-cb9e-4d74-8b13-a5f4559e13a9.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -80,7 +80,7 @@
         },
         {
             "id": "9104e97e-3e86-5b6a-adeb-e337726dd325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ed1d8-4d5c-48f8-8513-031bd8977d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553ed1d8-4d5c-48f8-8513-031bd8977d75.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -118,7 +118,7 @@
         },
         {
             "id": "12ab2ed8-1044-51c1-805f-dcbaf3e91c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a3ba1-af6c-4ddc-aa82-34bfc30867d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61a3ba1-af6c-4ddc-aa82-34bfc30867d0.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -158,7 +158,7 @@
         },
         {
             "id": "c1456b56-31de-5913-9036-a33dc3a06c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027a75f-4faf-4e96-9035-d1f622b9b607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027a75f-4faf-4e96-9035-d1f622b9b607.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "d6b67e7d-27d7-5074-93e6-ff214bdc6ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d0d7d-544b-4736-914d-10d5d752eb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d0d7d-544b-4736-914d-10d5d752eb42.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "5a1a4e5f-c010-537d-8441-fa64a38abf1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81a9eb1-240b-40fd-9282-0f5abec63449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81a9eb1-240b-40fd-9282-0f5abec63449.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "91905e90-ed40-5fa5-8a69-7aef7175574f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72a9deb-9329-4930-a906-136c26490d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72a9deb-9329-4930-a906-136c26490d52.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "01ff9b73-c200-5538-8264-4d8311d629a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991c27ed-f53c-48c6-8c12-282f44b8d441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991c27ed-f53c-48c6-8c12-282f44b8d441.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -350,7 +350,7 @@
         },
         {
             "id": "86825e3f-6efd-5372-9198-2b33af002ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2785902-2757-406b-bc75-6f05e0edc98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2785902-2757-406b-bc75-6f05e0edc98d.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "1a1b774e-fd44-5faf-8399-cf0244e1ba6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5330e6b7-eca3-46a4-8905-8f1de16f76af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5330e6b7-eca3-46a4-8905-8f1de16f76af.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -429,7 +429,7 @@
         },
         {
             "id": "a09ac030-3564-5eac-b773-27a761735e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424eb4c7-647e-4168-9471-f299e8e77f5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424eb4c7-647e-4168-9471-f299e8e77f5f.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -465,7 +465,7 @@
         },
         {
             "id": "2315960e-5f62-5442-8b36-9742669698f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e0b5cf-39e8-454f-a942-f7865416ef81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e0b5cf-39e8-454f-a942-f7865416ef81.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "ad6bd8f3-b63f-5e56-a518-b74df148bc97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dc6b0f-09bb-4489-8022-42c700eb1191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dc6b0f-09bb-4489-8022-42c700eb1191.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "076fdeec-78fd-5b76-aa2a-718ceaa232bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbb4d8f-8ae3-4052-9c6a-e56e96cec832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbb4d8f-8ae3-4052-9c6a-e56e96cec832.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "02582576-2d92-5c99-8641-588b7fec41c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3069f-5f5a-4e11-8a63-46399eb85a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3069f-5f5a-4e11-8a63-46399eb85a95.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "dfd7fdd9-346a-53f0-a3bd-112e6c0afe6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8361d9e2-b9fc-4d46-a1ba-a24139157f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8361d9e2-b9fc-4d46-a1ba-a24139157f26.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -663,7 +663,7 @@
         },
         {
             "id": "4a9d870a-281c-5837-9697-22b5c47717c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179a0525-a142-46f6-9b5b-06a2fbb25556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179a0525-a142-46f6-9b5b-06a2fbb25556.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -705,7 +705,7 @@
         },
         {
             "id": "f101e92e-9ad8-5704-b268-fb9ce53e95b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239165bb-7819-4d54-a84c-2911934253d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239165bb-7819-4d54-a84c-2911934253d6.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "5fffcba2-2fdd-5944-b9b2-fb4e7e6e5f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8525ae50-7438-492a-98ae-53f0ffeaab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8525ae50-7438-492a-98ae-53f0ffeaab51.jpg?1",
             "name": "Animist's Might",
             "text": "This spell costs {2} less to cast if it targets a legendary creature you control.\nTarget creature you control deals damage equal to twice its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "30262c48-6453-5dd5-95a6-0ae3e6e390ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5adc-e14b-4c84-896f-ef5f01f7ff57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5adc-e14b-4c84-896f-ef5f01f7ff57.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "2f1a5cf5-b4a1-5b3b-8556-e2582fb1e134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248c76d3-b5cb-4582-be17-7cd1d0cb0f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248c76d3-b5cb-4582-be17-7cd1d0cb0f58.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "37634611-feb2-5292-b8f9-b446d86cb734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a911e-8291-48ca-bfc6-8907e3b57011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72a911e-8291-48ca-bfc6-8907e3b57011.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "81838d73-de46-51ba-9613-6487255da134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b647377-d47e-4630-8ccc-933ef6127880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b647377-d47e-4630-8ccc-933ef6127880.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "4e90436c-ba41-50e9-8899-d0e7b36f99bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfe6957-d971-413f-b075-01b995f1d7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfe6957-d971-413f-b075-01b995f1d7a3.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -966,7 +966,7 @@
         },
         {
             "id": "bea79a6e-0000-5d49-bfdb-5a52fc10ae0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a707ab3-b9b5-422a-8b0f-e963d3ad6606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a707ab3-b9b5-422a-8b0f-e963d3ad6606.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "a02b76bd-ebb6-5268-8f4a-14519038c97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d925d13-fcd6-417b-b2b2-bbdd114aae78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d925d13-fcd6-417b-b2b2-bbdd114aae78.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "d1f589e1-e296-5aa4-956b-e7cfb8fc0ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcb225c-d18f-4b84-b2fc-91ed84ec30aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcb225c-d18f-4b84-b2fc-91ed84ec30aa.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -1087,7 +1087,7 @@
         },
         {
             "id": "3284b38b-9d41-559c-83e6-cc980a67cab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039e43f2-cf3b-4c60-ac55-d2aafb20eb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039e43f2-cf3b-4c60-ac55-d2aafb20eb34.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "91ff47cc-c9a3-5992-b3ec-72b2c494473b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a90d613-a327-4dc7-b0c1-0003fe0171ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a90d613-a327-4dc7-b0c1-0003fe0171ef.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "15809e11-4a1d-57c1-96a6-d9f8443266a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6917d51b-eb61-4e7e-8336-8b4adf8d1e39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6917d51b-eb61-4e7e-8336-8b4adf8d1e39.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -1211,7 +1211,7 @@
         },
         {
             "id": "ade59540-c145-51c2-8fc4-590c134a1ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0c3860-1dab-4897-8f36-f9be263bba03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0c3860-1dab-4897-8f36-f9be263bba03.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "f631ce85-d4bb-5a4a-b72a-1fe0dec78069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb93216-885c-4ec5-8b88-6cd51f593c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb93216-885c-4ec5-8b88-6cd51f593c8b.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "563bd4f6-becc-5cc4-8919-86caa1d97141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569fb73-3555-4eb8-933a-130770dd56d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4569fb73-3555-4eb8-933a-130770dd56d1.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "59b9f0fa-5acb-5cfa-968f-c17a1b05534e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b599f53-614c-4b1f-9899-15d5d1e35879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b599f53-614c-4b1f-9899-15d5d1e35879.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "18f312fc-a910-570c-a218-dcc587724c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eb0859-d24e-4703-8930-1cd4ac1fb3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90eb0859-d24e-4703-8930-1cd4ac1fb3b6.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "940c4eb6-8499-52f7-b3b1-e3783eab1c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9acf30-b4f4-4e99-9763-a3055e91fefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9acf30-b4f4-4e99-9763-a3055e91fefb.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "5bc9e4cf-394f-5e0d-8b7a-cdccafb1cc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827ecc44-0b00-4515-8953-bc91fa03705a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827ecc44-0b00-4515-8953-bc91fa03705a.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "f8348d8d-dd1b-5f82-9f70-d2467a801891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd7ce4-550d-41ab-8559-97efb234a0a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebd7ce4-550d-41ab-8559-97efb234a0a1.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy. (You still pay its costs. A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "58b7a3d3-14de-5504-90c8-8d33ed7c2f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1ff886-d3c8-43e5-8bf0-ba4f0b259781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1ff886-d3c8-43e5-8bf0-ba4f0b259781.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start. (You may cast that card from your graveyard by discarding a card in addition to paying its other costs. Then exile it.)",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "91c6f058-4cdd-53d5-a90b-2fe14ccc8a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb68233-3683-41bd-9b6e-4f07a1b54244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb68233-3683-41bd-9b6e-4f07a1b54244.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -1652,7 +1652,7 @@
         },
         {
             "id": "72029802-35c9-572e-9b64-44716f7f4062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae89461-4bce-4b49-b875-03afc2469fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae89461-4bce-4b49-b875-03afc2469fe7.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "9de80e2d-a414-5e63-a39c-1e9a63996b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7651eb7-3cbe-43de-8800-085be19e7f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7651eb7-3cbe-43de-8800-085be19e7f77.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace. (They're affected by summoning sickness.)",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "b38f69ff-2e90-5374-99e2-5a490b5feace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb53ce7-845c-4c62-98a9-4fc33c67a07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb53ce7-845c-4c62-98a9-4fc33c67a07b.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "409cfbd3-2498-5884-8824-acc586548aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f3fdb0-47ad-4df6-a95c-a2c81aaf7af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f3fdb0-47ad-4df6-a95c-a2c81aaf7af5.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -1828,7 +1828,7 @@
         },
         {
             "id": "8a38a326-6926-5b99-8927-86b72407033b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6225f139-f6eb-4eb5-9776-159a599d8255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6225f139-f6eb-4eb5-9776-159a599d8255.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "dd3c9bf3-e465-5b02-bdc0-a320d0e96ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba71725-d6df-44d7-a93b-934573759711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba71725-d6df-44d7-a93b-934573759711.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "2eeb9964-29fa-5a17-b7c1-8e36c253f907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a543f0-72fe-4a30-a4a0-356971c1c68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a543f0-72fe-4a30-a4a0-356971c1c68a.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "e029e773-cb99-57d2-a5c5-39b9b6b40d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4219b5ea-a252-4d76-a60a-9674340e8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4219b5ea-a252-4d76-a60a-9674340e8ed3.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "ea2fc876-3890-5ed3-998b-de9d39558bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c07dda8-06dd-499a-9825-dc6b9a73e455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c07dda8-06dd-499a-9825-dc6b9a73e455.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -2029,7 +2029,7 @@
         },
         {
             "id": "196b7c99-b0d8-5b78-9164-ed10e1fe7503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a932af-f5bb-452d-803a-b75bd3552b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a932af-f5bb-452d-803a-b75bd3552b35.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "9e7f463a-4142-51fa-8dcb-67092f78a606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c18b82-ec70-4233-9717-f9d522b3d022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c18b82-ec70-4233-9717-f9d522b3d022.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "351cef28-9fe9-5385-bc06-59d2eae902d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19d4ace-cf49-482d-8533-fa7a948b44e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19d4ace-cf49-482d-8533-fa7a948b44e3.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "20692def-7a2b-596a-a536-f1e1fd04e1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f76739e-03fb-401a-8444-ac7fd16f21ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f76739e-03fb-401a-8444-ac7fd16f21ef.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "cd122077-902e-5cce-a873-30da9a058930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259de7b-74d2-4ef4-94d3-4a0f14dbaa44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259de7b-74d2-4ef4-94d3-4a0f14dbaa44.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "0b85caff-4c51-5ba2-b534-acab343fafdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59286512-1ec2-4d0a-aaa0-63a4a691bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59286512-1ec2-4d0a-aaa0-63a4a691bcda.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "8254ae49-058e-5df0-b212-67691dac20f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1631c564-67de-4011-be2d-c7ee96a43cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1631c564-67de-4011-be2d-c7ee96a43cb7.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "c90dea94-d29d-5392-866f-4d3ebc9e9400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ab028c-a560-4f8a-a063-2682daca799c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ab028c-a560-4f8a-a063-2682daca799c.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "3fea9219-80de-5ccd-8f52-1331189e873d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f673a7-961d-4ba3-bfc5-46107af46a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f673a7-961d-4ba3-bfc5-46107af46a61.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "51f17ea8-af8b-5544-b242-662d933f7624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fd77b6-59ed-431b-9ecf-d37e4f9c14ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36fd77b6-59ed-431b-9ecf-d37e4f9c14ac.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "bda2ae37-4f11-5c82-8133-d31246500210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c154811-2f4c-4f21-8ee1-f70557b8f423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c154811-2f4c-4f21-8ee1-f70557b8f423.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "533b13cf-9db5-5e7c-bd2b-62e8e6fd72a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f2e7f-3ce9-475e-b854-1560d5a9a8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f2e7f-3ce9-475e-b854-1560d5a9a8e8.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "b5b0f284-6f1b-5780-8936-6b9c0a860267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fe078-cc60-493b-9b61-37894e1eddd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791fe078-cc60-493b-9b61-37894e1eddd3.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "e8b8807b-6fc7-5a6e-b2df-e6587fe9091f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79527ca-15f5-427a-9245-6b7f4230a8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79527ca-15f5-427a-9245-6b7f4230a8b7.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B}",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "7cd11a65-9476-5a13-aa8a-d343f15c838e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88cc697-3b79-421b-9b7f-37f9aeccda36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88cc697-3b79-421b-9b7f-37f9aeccda36.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "cec3f5a8-d2f1-5a1f-a45d-373412ae19e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd3a3a-f9f8-4d83-951f-d187f2bab0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd3a3a-f9f8-4d83-951f-d187f2bab0a4.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -2649,7 +2649,7 @@
         },
         {
             "id": "6528147b-b1ed-515c-ab82-5b179baff821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d58c593-327c-4798-8bb8-811c831efb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d58c593-327c-4798-8bb8-811c831efb49.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "783d4f50-5868-534d-91bc-e22fa1b02ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4c2c09-1929-4850-b797-69b671916980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4c2c09-1929-4850-b797-69b671916980.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -2730,7 +2730,7 @@
         },
         {
             "id": "8d3f1898-d0b5-5e2a-af30-c0c8fb76c8e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f43d7-8979-466a-be73-8e073b0afdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f43d7-8979-466a-be73-8e073b0afdd1.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "3a381ba1-3fa6-517f-a49f-6020c395f377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7267a33-c9b2-485d-afbc-a27e4792abf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7267a33-c9b2-485d-afbc-a27e4792abf4.jpg?1",
             "name": "Animist's Might",
             "text": "This spell costs {2} less to cast if it targets a legendary creature you control.\nTarget creature you control deals damage equal to twice its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "ec5c28e1-2640-581c-9caa-4ab1873e934e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4437a7d7-d25c-412d-b739-a122e25e1449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4437a7d7-d25c-412d-b739-a122e25e1449.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "37ba121f-b65d-5237-897f-cdfa3991b50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3998ebe6-bbfd-4d9c-9741-2fe7484dc6e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3998ebe6-bbfd-4d9c-9741-2fe7484dc6e5.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "badf5b71-d3da-5cdf-9984-6b02ea3acd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7bb58c-304a-4fb4-9ae6-bc98126cca4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7bb58c-304a-4fb4-9ae6-bc98126cca4e.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "a74519dd-3a79-573d-97e9-5386a25264c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3e0eb1-8b0c-4c6e-b394-6968d39fbd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3e0eb1-8b0c-4c6e-b394-6968d39fbd00.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "4f0c5504-3614-5995-85b9-230fac5ec477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577522b4-b3f6-43b6-92a4-4e8420ff3b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577522b4-b3f6-43b6-92a4-4e8420ff3b12.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "9199ff8a-2c3c-5a10-a57a-0024ca1cc64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ceddfa5-3a89-4ac4-8fd1-0c9918ffedc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ceddfa5-3a89-4ac4-8fd1-0c9918ffedc8.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "da704f94-7801-5d3a-a152-3b98fffae54a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d4a5b9-2594-413d-a0c1-32b09f54d9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d4a5b9-2594-413d-a0c1-32b09f54d9d2.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -3074,7 +3074,7 @@
         },
         {
             "id": "151e1b42-10c6-58db-968c-0eb7eb3d0598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896a7953-c8af-4a08-b31b-33fe65c14a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896a7953-c8af-4a08-b31b-33fe65c14a2c.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "0e9c8958-5048-56fd-b336-056e2587ae85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006eb5ef-ac0a-4e39-831c-4019512bce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006eb5ef-ac0a-4e39-831c-4019512bce60.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "b3e4dee6-eac0-5266-8398-6c1964b02e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702d2f0-b576-438c-94b6-39afe2c70821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702d2f0-b576-438c-94b6-39afe2c70821.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -3194,7 +3194,7 @@
         },
         {
             "id": "e6fff2b6-e24c-5767-91bb-bc0d5e3b01f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fd9efb-afec-426f-8333-a2797b8b603f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fd9efb-afec-426f-8333-a2797b8b603f.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}.",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "54b77586-84e5-50c8-af2c-36e2c48c4752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373475d5-42a7-42ad-a235-685c3d160f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373475d5-42a7-42ad-a235-685c3d160f60.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "3fcd3c41-7d31-58fa-85c4-6ba4d84e5136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fa8aaa-46e5-467b-a237-feae3b2f6ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fa8aaa-46e5-467b-a237-feae3b2f6ddc.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -3324,7 +3324,7 @@
         },
         {
             "id": "feb16889-2d0e-500f-b3bd-d8a154184035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dbb880-1cf8-41fa-84d8-41db8dde35f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23dbb880-1cf8-41fa-84d8-41db8dde35f2.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -3365,7 +3365,7 @@
         },
         {
             "id": "7a944d9e-4078-5e08-845f-ee3a1bd7e25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5b27a6-caf8-4489-b949-d4d69841b9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5b27a6-caf8-4489-b949-d4d69841b9ef.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3409,7 +3409,7 @@
         },
         {
             "id": "7ec9fe5d-a3e5-5046-9289-25b39053bc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f2d1fe-e337-4a98-b861-094250068432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f2d1fe-e337-4a98-b861-094250068432.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "52de5142-f06c-5e5b-8810-b0c5f5d38511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e510b-aa06-403b-a53b-49a4ad66f286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86e510b-aa06-403b-a53b-49a4ad66f286.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "beda4162-e2a7-56ce-8070-e2fef0082889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e244a5-85ae-413e-9c79-aa07103c7057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e244a5-85ae-413e-9c79-aa07103c7057.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -3538,7 +3538,7 @@
         },
         {
             "id": "2d173e40-85d4-5bbd-8187-3737b8f0b11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce21e701-bb96-4040-a7ea-a5e0c11eae9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce21e701-bb96-4040-a7ea-a5e0c11eae9b.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "8d7e1771-48f4-5b45-9c56-8367783127b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d999f-ea24-40d8-86ef-180627196749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d999f-ea24-40d8-86ef-180627196749.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -3634,7 +3634,7 @@
         },
         {
             "id": "21fbffc3-5f10-5269-9bf6-bebc3c6d51d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840a442f-a220-408f-b670-0c73e2ffa704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840a442f-a220-408f-b670-0c73e2ffa704.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -3677,7 +3677,7 @@
         },
         {
             "id": "79f2367f-1cab-59a6-8f38-fc08020ef20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28216a47-709f-41fc-834c-7e4c99c806f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28216a47-709f-41fc-834c-7e4c99c806f7.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "28d5d55a-9398-5df3-a5ab-09329e5bf23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7973b-a5b9-41e9-9382-e5107315faa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7973b-a5b9-41e9-9382-e5107315faa5.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "680938a9-ad5f-5bb9-89c9-09514d7df0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8102736a-220d-41d8-acea-79971d73db9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8102736a-220d-41d8-acea-79971d73db9a.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "7b9c0d5f-9a23-51ac-acfb-3c479b7c58c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c868b7-1600-449a-abd2-9836bce0e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c868b7-1600-449a-abd2-9836bce0e1f1.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "0ecca4a8-59ca-541b-b8de-6119bb4547c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e688bd-7652-418f-84e6-18452295623a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e688bd-7652-418f-84e6-18452295623a.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "3bb9e5f1-5e09-5570-88a4-588d330780c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c857c0-1cb4-4032-a72f-cf8d84171c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c857c0-1cb4-4032-a72f-cf8d84171c9d.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "b86ed114-28bb-5ed9-8a71-d8bb9c81cdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de88aa7f-c6e6-49a0-a68d-87a2ab1741e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de88aa7f-c6e6-49a0-a68d-87a2ab1741e3.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "de852333-e062-598a-8172-5ba707b32de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b1d426-db36-4a6d-9eb7-d093e0c0ee6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b1d426-db36-4a6d-9eb7-d093e0c0ee6a.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -4021,7 +4021,7 @@
         },
         {
             "id": "14a9719d-effb-5bf7-a3d4-b6c07ea33d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8976d8-f77d-460f-82fa-d324cbd3d4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab8976d8-f77d-460f-82fa-d324cbd3d4b5.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "7ddde71a-b7f4-5ddd-9e8c-b091d5010d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165275-505c-4fe7-ad2e-4e522bdb014a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165275-505c-4fe7-ad2e-4e522bdb014a.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "3c936346-332d-5e4b-b7c4-3997f1518537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c881938-da5d-4f2c-b62b-0cfbf29ae558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c881938-da5d-4f2c-b62b-0cfbf29ae558.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "3b2922e3-f919-5317-9e3b-f24d87ced6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d20243-0771-4dae-b225-4379de6be35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d20243-0771-4dae-b225-4379de6be35a.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "336413a2-2db9-500c-8c6b-cdb8f50d8f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041111e8-3b0e-4337-a7d6-20cc455ea173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041111e8-3b0e-4337-a7d6-20cc455ea173.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -4204,7 +4204,7 @@
         },
         {
             "id": "fb536f6c-fb8a-55c6-8d96-3358cf2ba18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c214f916-2ec0-495c-82d5-438e321bf8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c214f916-2ec0-495c-82d5-438e321bf8e6.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "0e719629-da61-5ac4-8dc6-490b9f74306b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e86e46-ba47-4ecd-8fac-7938b9947065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e86e46-ba47-4ecd-8fac-7938b9947065.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "99646091-0e6b-51a0-973e-bf9c432c972b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b57b9-54e8-4f5c-b53a-cd5fc2fb2a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8b57b9-54e8-4f5c-b53a-cd5fc2fb2a34.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "33296ce3-fbf7-5e8e-b5a9-4554cc8633a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ef89a1-b6fd-48db-bcb5-faac2fe9fe28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ef89a1-b6fd-48db-bcb5-faac2fe9fe28.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "1efe3ee0-2045-555f-bbd9-209c7d36ac74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbc432e-c35c-4f8c-bbdd-068eaa468378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbc432e-c35c-4f8c-bbdd-068eaa468378.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "5d37fa91-aa3a-552c-9a2a-f4e76671759e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec9b42-ab99-4c93-a52f-ccbe258b8954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec9b42-ab99-4c93-a52f-ccbe258b8954.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "0e812b64-4f16-584c-a5f1-3d4c257cafeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0133c618-faab-4b40-8da0-fc91edf49785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0133c618-faab-4b40-8da0-fc91edf49785.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -4468,7 +4468,7 @@
         },
         {
             "id": "86dcba51-91e1-557a-ba65-21178cd4a41e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d18cfb3-5498-4d31-8276-8d7ec893d98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d18cfb3-5498-4d31-8276-8d7ec893d98f.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "1e806a27-40a5-5225-a297-bbb838b992d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c781217-a678-4059-89ff-b5ec494dd367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c781217-a678-4059-89ff-b5ec494dd367.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "5afa94b8-bae6-5d9d-b4cf-6bc0364fa592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae882b47-e51f-42bc-89ef-2772de097b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae882b47-e51f-42bc-89ef-2772de097b88.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B}",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "422f9b48-b706-575b-a104-0e4cfc82a51f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cb68f5-1e44-4d91-9ec0-d6d0559ee4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3cb68f5-1e44-4d91-9ec0-d6d0559ee4a8.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "fd9bbb10-b1d6-5a29-beeb-94d22b5296e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32bf755-6b7a-4324-b219-ba953354933b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32bf755-6b7a-4324-b219-ba953354933b.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "bc20d313-1fd9-598d-9c2c-f1db27f6d6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9798fd-149b-4840-a1b1-b7c596940739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9798fd-149b-4840-a1b1-b7c596940739.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "b4d7241b-30d9-58c0-8cd8-70f31059f01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee11cfe8-4f20-468c-80ca-6af23b23184d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee11cfe8-4f20-468c-80ca-6af23b23184d.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -4737,7 +4737,7 @@
         },
         {
             "id": "913bdd2b-16b0-5b33-a2ee-ef649b546d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c41c82-937e-483a-97bf-58a14401bf11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c41c82-937e-483a-97bf-58a14401bf11.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "ca34451e-9a8e-508e-992c-23bcaf85dec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a82d30-b3ca-4bea-b055-00eee555567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a82d30-b3ca-4bea-b055-00eee555567d.jpg?1",
             "name": "Animist's Might",
             "text": "This spell costs {2} less to cast if it targets a legendary creature you control.\nTarget creature you control deals damage equal to twice its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "8ed85e23-7c77-530e-9f4d-9984835ab5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdff8723-1bc5-486f-a061-4f3ce8679c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdff8723-1bc5-486f-a061-4f3ce8679c52.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -4843,7 +4843,7 @@
         },
         {
             "id": "930a6697-b47c-5ce7-b161-a7e1fc845a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad606af-3ab5-4755-9690-540026c2edaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad606af-3ab5-4755-9690-540026c2edaa.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "f2b4f1aa-a4e5-559c-aa37-4324c4071814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ad15af-cb84-43c1-9078-459b24c5d45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ad15af-cb84-43c1-9078-459b24c5d45d.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "a041b6b1-d634-5675-8171-268cb6dc0b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8664feec-ea45-4a94-b6b1-98dd2663a268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8664feec-ea45-4a94-b6b1-98dd2663a268.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "d666bc2d-fb4b-50c1-9d13-1be92ce6d38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463fc067-9e8b-41a0-afa1-6be81861cfb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/463fc067-9e8b-41a0-afa1-6be81861cfb8.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "9cca8f6c-a780-56d0-b212-a7e16387ab99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d717f-242f-4e70-9f6d-8885eac13cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9d717f-242f-4e70-9f6d-8885eac13cf4.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -5035,7 +5035,7 @@
         },
         {
             "id": "a7162635-ebee-5a99-b655-5b3c1339fe93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb1105-d272-4727-929a-1716154e3e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb1105-d272-4727-929a-1716154e3e1c.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "2ba900bc-5d13-5c83-b2a2-d920e0650b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae13fac-af48-4e00-a483-e4bfc63e8af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae13fac-af48-4e00-a483-e4bfc63e8af8.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "b05dff15-339b-53c1-ade8-aa2d549b3f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e1b8e6-5cfd-4cbe-860e-a59b47643c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e1b8e6-5cfd-4cbe-860e-a59b47643c14.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "13579466-222f-5e63-a6a6-54fe4a0a7f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e82b7-d9a8-44dc-9376-03705df0c4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e82b7-d9a8-44dc-9376-03705df0c4d0.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "a0f3a491-ffa4-5a55-90e9-2619ac9cf062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e5b20e-1a72-441b-9e4c-2e7a40f096ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e5b20e-1a72-441b-9e4c-2e7a40f096ae.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "3e67d4d3-4375-5256-8553-0ecaa384f8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef36c1e9-ef1c-457f-8e02-3d773f4a1e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef36c1e9-ef1c-457f-8e02-3d773f4a1e45.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "dccc7c5a-9614-56ab-ab25-7fb31e2cf559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78266c-cbeb-4fd2-a29c-6bb9d326f057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78266c-cbeb-4fd2-a29c-6bb9d326f057.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "c438dcd7-b3e9-5a46-a740-0b4d5e4ca989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763a3015-9b22-4d81-a8c9-08046d1e5aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763a3015-9b22-4d81-a8c9-08046d1e5aef.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -5356,7 +5356,7 @@
         },
         {
             "id": "92e8ff3d-193a-545b-b0a6-10fd97386f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87993488-e31d-4456-bf87-c5a0a81e5560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87993488-e31d-4456-bf87-c5a0a81e5560.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5399,7 +5399,7 @@
         },
         {
             "id": "4d210c9e-b3f5-5020-bb14-5c7524be643f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c9437-a7e3-4098-992c-ffc929ee0e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c9437-a7e3-4098-992c-ffc929ee0e6e.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "a38958bc-c8a2-5c2a-9e7c-3f2fce478cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aaebb8-be81-4523-bcb8-fc86a2941c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aaebb8-be81-4523-bcb8-fc86a2941c45.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "2115136b-830c-5190-b9f4-0d011728da30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f311fc01-9b47-42b3-874b-2cb65a9e412c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f311fc01-9b47-42b3-874b-2cb65a9e412c.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "90b7086f-09eb-5ee1-938b-3303b565dac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d56cd5-f038-4653-987e-d1a5485ac86e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16d56cd5-f038-4653-987e-d1a5485ac86e.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -5570,7 +5570,7 @@
         },
         {
             "id": "be9c7ff4-9b64-52ba-b434-589cc801c517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f469c3-d50c-4066-8f46-75ce3c3f1616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f469c3-d50c-4066-8f46-75ce3c3f1616.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -5619,7 +5619,7 @@
         },
         {
             "id": "ae1b254f-ca96-5b2a-88a0-d75c8bfd72ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c9077d-fdbf-4087-85a5-1d59c2ba7678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c9077d-fdbf-4087-85a5-1d59c2ba7678.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "bb32fd21-aae9-5c4a-b37d-0ca53b909590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aafbdf8-b1cd-4dbb-863c-0d44494eec2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aafbdf8-b1cd-4dbb-863c-0d44494eec2b.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "5ddd600e-68d2-51c6-9404-3f4d3543251f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcff20d-4498-4c70-8167-c3621a293a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcff20d-4498-4c70-8167-c3621a293a72.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "69ee380e-676f-5bf9-9770-5d68c914fa5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9808e72-4143-421f-a498-dbebbd598544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9808e72-4143-421f-a498-dbebbd598544.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -5789,7 +5789,7 @@
         },
         {
             "id": "7ac52b0f-3995-5f11-a1a1-966f6c0d05b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafdd59-e22f-4f0d-aa09-77617402f04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafdd59-e22f-4f0d-aa09-77617402f04d.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -5833,7 +5833,7 @@
         },
         {
             "id": "a3b03804-f4e7-5965-a4e5-58c80e1563af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a21f8cf-5a0c-4a33-a2ed-b89b57bb4000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a21f8cf-5a0c-4a33-a2ed-b89b57bb4000.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "6c59f10a-7541-5306-9c9e-161e4b9e15d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d3d06c-8bbd-49e5-94ff-f0a9830d063e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d3d06c-8bbd-49e5-94ff-f0a9830d063e.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -5918,7 +5918,7 @@
         },
         {
             "id": "9cb35b1b-6f7a-5c91-8ae3-cce95caed6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10e9f0-24fe-4d7c-b883-37319a9ef5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10e9f0-24fe-4d7c-b883-37319a9ef5b5.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -5961,7 +5961,7 @@
         },
         {
             "id": "0a870842-a882-59be-ab10-8a557117328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc3541-c398-4d43-b1c4-4d1e1e3e1ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dc3541-c398-4d43-b1c4-4d1e1e3e1ebf.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "6f05ae2a-48f2-5d55-8a91-f3cfd0fe7b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1064ec-ca4f-4498-b6c6-685276973009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1064ec-ca4f-4498-b6c6-685276973009.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -6029,7 +6029,7 @@
         },
         {
             "id": "041362a0-8b66-5a48-81b2-a6e011c52481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1436-913c-453a-8c05-4ec5bcaac4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1436-913c-453a-8c05-4ec5bcaac4b5.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -6066,7 +6066,7 @@
         },
         {
             "id": "26c2d0ae-dcff-58fd-aa6a-b644dd7366df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254b512-5ca5-4ce9-ad1d-8f90ab24f6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5254b512-5ca5-4ce9-ad1d-8f90ab24f6c3.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -6106,7 +6106,7 @@
         },
         {
             "id": "8cd2ec4d-1ed9-56c8-9fee-140d9f3bee8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62243fa-32ce-4015-8e8c-ec898d1ca1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62243fa-32ce-4015-8e8c-ec898d1ca1e1.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -6143,7 +6143,7 @@
         },
         {
             "id": "f6e6e3d4-8248-5e78-81be-5f5b3731120b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c08ba6-a8a6-4cf5-83a5-c087e3272f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c08ba6-a8a6-4cf5-83a5-c087e3272f66.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "faef59a9-3ad0-5911-92f6-a8c99eca2ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24d4b9-fa3c-4390-a4b9-3e4fdfdf72b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24d4b9-fa3c-4390-a4b9-3e4fdfdf72b6.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "c20864a4-17e3-577b-ad79-f018393ec68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d71a7-2967-4006-9fe4-864868bcc642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d71a7-2967-4006-9fe4-864868bcc642.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -6265,7 +6265,7 @@
         },
         {
             "id": "d1630079-f0f8-5797-8629-b758432741e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0250da3-908c-4ec6-94a5-3dd16c6b1985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0250da3-908c-4ec6-94a5-3dd16c6b1985.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -6305,7 +6305,7 @@
         },
         {
             "id": "21a80795-38b5-5b21-ae93-8a07924b9ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795222e3-1352-4adb-8a42-dde43d08e413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795222e3-1352-4adb-8a42-dde43d08e413.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -6344,7 +6344,7 @@
         },
         {
             "id": "f40ee40b-7609-5c21-89d6-e4233a7a9691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea9f761-a113-40bb-9346-fa13075e1b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea9f761-a113-40bb-9346-fa13075e1b9d.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "70a9a35b-cc7c-52dc-9605-2db4863bab03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160f048a-8813-454d-af84-1e53f33af9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160f048a-8813-454d-af84-1e53f33af9f6.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "bccd8dc7-d06b-5c80-b9e5-f6acd0660522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6765e4-0bbd-4711-b77e-b7628efcfb07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6765e4-0bbd-4711-b77e-b7628efcfb07.jpg?1",
             "name": "Leyline Immersion",
             "text": "Enchant legendary creature\nEnchanted creature has ward {2} and \"{T}: Add five mana in any combination of colors. Spend this mana only to cast spells.\"",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "42cc8a31-4e0a-5778-9937-d51c989fc2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3f0e26-7784-452d-acc8-9f7181e0f7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3f0e26-7784-452d-acc8-9f7181e0f7d5.jpg?1",
             "name": "Nissa, Resurgent Animist",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color. Then if this is the second time this ability has resolved this turn, reveal cards from the top of your library until you reveal an Elf or Elemental card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6507,7 +6507,7 @@
         },
         {
             "id": "31bd8863-256a-5b8d-b149-e4d0a2a798d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f71273-4d96-4371-b6e0-98519449cdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f71273-4d96-4371-b6e0-98519449cdcf.jpg?1",
             "name": "Open the Way",
             "text": "X can't be greater than the number of players in the game.\nReveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "4f69047e-58d8-5e74-95a5-4489a74a0daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c3a774-986d-4702-81c3-915138d3d718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c3a774-986d-4702-81c3-915138d3d718.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "9fca4e3e-010c-5b48-b633-202559584213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e61d0-95b2-433b-b835-86f00bfb840b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581e61d0-95b2-433b-b835-86f00bfb840b.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -6627,7 +6627,7 @@
         },
         {
             "id": "17bafc88-6250-5e44-a3e7-bbba3bec7fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94685e-e8a0-46a5-83cf-41ccebed62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94685e-e8a0-46a5-83cf-41ccebed62cc.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "beaaa099-327a-5ab8-8aea-43431f90dc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ee4e0e-1139-42c1-b014-242c306321e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ee4e0e-1139-42c1-b014-242c306321e7.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -6715,7 +6715,7 @@
         },
         {
             "id": "d0bae3e2-c916-5f50-9cfb-ee092fd98b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053705f-df87-4f4c-8060-b43433b1d688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053705f-df87-4f4c-8060-b43433b1d688.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "9b241011-ccb0-5317-b4c3-8f9e32afa112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1536bef-bc0c-437b-bb4a-335c4ec9fbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1536bef-bc0c-437b-bb4a-335c4ec9fbf3.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "d3fee9f4-7dc1-53f7-a114-4ee9c074e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444b2d-a842-4e2c-b29b-7e578a49b3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444b2d-a842-4e2c-b29b-7e578a49b3e0.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6844,7 +6844,7 @@
         },
         {
             "id": "8f9884de-b88a-5500-a0d7-9b1d22dfa5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4891486a-9c35-4666-83b0-9fcb1da5d126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4891486a-9c35-4666-83b0-9fcb1da5d126.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "afcfb6ab-1974-5506-876f-f64c40a4cd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0443321b-e999-4bdd-8d8e-65fbaa6cabb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0443321b-e999-4bdd-8d8e-65fbaa6cabb4.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "3e4fa56d-9da0-5aa5-b739-0d569ce15d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487e81a-bb02-4d5c-86bb-fe626fa91c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8487e81a-bb02-4d5c-86bb-fe626fa91c27.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -6973,7 +6973,7 @@
         },
         {
             "id": "2dee90e3-4bb7-5900-83d8-cdcea677ab88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275cea3-01ba-41ea-9665-a07a57ecfe50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7275cea3-01ba-41ea-9665-a07a57ecfe50.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "9a3d0f3a-c74d-5edc-9a1d-4f5aa30809d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c167658d-1ad0-4e78-ac99-dd2ad5265311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c167658d-1ad0-4e78-ac99-dd2ad5265311.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "8adbace2-16da-5d08-8752-da4e303ef961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f613db0-3303-4d54-a060-1bd8b37a208f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f613db0-3303-4d54-a060-1bd8b37a208f.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -7112,7 +7112,7 @@
         },
         {
             "id": "3cdb74a2-9fbc-5a4c-8d15-debe38b0ee8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413eedd5-ea42-4b6f-9282-3040e517d936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413eedd5-ea42-4b6f-9282-3040e517d936.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "22c7fe5c-f895-533b-9c35-f23e5a30b03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5b2e19-dc3d-43fd-9090-050fedf93663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5b2e19-dc3d-43fd-9090-050fedf93663.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "2c062807-6ddf-5c65-be56-5fe027be074c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2ed3-be60-4814-a82c-a0e3fbb97e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421c2ed3-be60-4814-a82c-a0e3fbb97e63.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -7243,7 +7243,7 @@
         },
         {
             "id": "258dda74-9ddd-5a15-a74f-79db67c5a4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3f755-d70d-46d7-80dd-428ca1a355c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c3f755-d70d-46d7-80dd-428ca1a355c4.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "861628e3-1a96-530e-89a7-58239eed6d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18484227-b96a-40fb-9788-656d00705d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18484227-b96a-40fb-9788-656d00705d80.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -7332,7 +7332,7 @@
         },
         {
             "id": "b28a1904-0fde-5f28-bba3-a99bbe60a632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9fcc42-1146-49c8-93c8-3a15063488c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9fcc42-1146-49c8-93c8-3a15063488c7.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "eb68b448-1704-581f-8912-46537e61fa73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7c1a22-eb7a-454e-bcd2-80ba0dc46ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7c1a22-eb7a-454e-bcd2-80ba0dc46ffa.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "a5ea391e-58fa-5991-adb8-a1c8a339b57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e6527-06f8-4783-93fc-8738673116c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04e6527-06f8-4783-93fc-8738673116c1.jpg?1",
             "name": "Karn, Legacy Reforged",
             "text": "Karn, Legacy Reforged's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -7456,7 +7456,7 @@
         },
         {
             "id": "0c5eb7f4-38ec-5a23-91a5-06ac47b7382f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0712155b-a3fb-4e7d-8600-36845d71aab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0712155b-a3fb-4e7d-8600-36845d71aab6.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "95a84f80-3513-5091-a8fe-4239e61b3506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2899c19-d6bd-4399-a838-a21ed81ccc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2899c19-d6bd-4399-a838-a21ed81ccc3f.jpg?1",
             "name": "Coppercoat Vanguard",
             "text": "Each other Human you control gets +1/+0 and has ward {1}.",
             "colours": [
@@ -7527,7 +7527,7 @@
         },
         {
             "id": "f3976f97-2732-56b4-98cc-81cef3d0c1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4acba2-3aef-47bb-9bec-06408c3d1783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4acba2-3aef-47bb-9bec-06408c3d1783.jpg?1",
             "name": "Deification",
             "text": "As Deification enters the battlefield, choose a planeswalker type.\nPlaneswalkers you control of the chosen type have hexproof.\nAs long as you control a creature, if damage dealt to a planeswalker you control of the chosen type would result in all loyalty counters on it being removed, instead all but one of those counters are removed.",
             "colours": [
@@ -7563,7 +7563,7 @@
         },
         {
             "id": "5d3fd52b-7535-5c6d-b3d0-0c944dd63e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d771-67ab-4e05-97ca-e2deee1f2dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d81d771-67ab-4e05-97ca-e2deee1f2dce.jpg?1",
             "name": "Harnessed Snubhorn",
             "text": "Vigilance\nWhenever Harnessed Snubhorn deals combat damage to a player, return target artifact or enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "ee2554b9-a01d-5bff-96aa-b1ed2b95a52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c43285-a8f7-4fcc-be8c-115c04d3f657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c43285-a8f7-4fcc-be8c-115c04d3f657.jpg?1",
             "name": "Metropolis Reformer",
             "text": "Flying, vigilance\nYou have hexproof.\nWhenever Metropolis Reformer is dealt damage, you gain that much life.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "97858cfc-3453-573f-807f-c22c8d4814a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e907fe-3c02-4e23-b19f-a478a54f3397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e907fe-3c02-4e23-b19f-a478a54f3397.jpg?1",
             "name": "Tazri, Stalwart Survivor",
             "text": "Each creature you control has \"{T}: Add one mana of any of this creature's colors. Spend this mana only to activate an ability of a creature. Activate only if this creature has another activated ability.\"\n{W}{U}{B}{R}{G}, {T}: Mill five cards. Put all creature cards with activated abilities that aren't mana abilities from among the milled cards into your hand.",
             "colours": [
@@ -7684,7 +7684,7 @@
         },
         {
             "id": "d92fcda2-aa41-5e9b-b621-5d8deca4cbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ebdda-e000-4333-9f2f-7d17e17a7cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23ebdda-e000-4333-9f2f-7d17e17a7cf2.jpg?1",
             "name": "Filter Out",
             "text": "Return all noncreature, nonland permanents to their owners' hands.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "5e91b890-10f4-5eb7-8538-ecd9d52ec010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153dfc34-767e-4df2-a1dc-4361e94d65ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153dfc34-767e-4df2-a1dc-4361e94d65ed.jpg?1",
             "name": "Tolarian Contempt",
             "text": "When Tolarian Contempt enters the battlefield, put a rejection counter on each creature your opponents control.\nAt the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "07aae319-ec69-5abf-bdf2-994e892ef94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22299956-82c6-46dd-ac7d-b56146ab7ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22299956-82c6-46dd-ac7d-b56146ab7ed8.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "4fd2f2f4-5e3c-592f-b241-8f09f87cb4e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b6a634-0a9c-4e96-84cc-16a6c70b669d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b6a634-0a9c-4e96-84cc-16a6c70b669d.jpg?1",
             "name": "Vesuvan Drifter",
             "text": "Flying\nYou may look at the top card of your library any time.\nAt the beginning of each combat, you may reveal the top card of your library. If you reveal a creature card this way, Vesuvan Drifter becomes a copy of that card until end of turn, except it has flying.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "631996ee-8f82-5923-aeed-e3efa0ecbdf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3acf-aed9-4503-8b10-29661da4e307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53aa3acf-aed9-4503-8b10-29661da4e307.jpg?1",
             "name": "Ayara's Oathsworn",
             "text": "Menace\nWhenever Ayara's Oathsworn deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it. Then if it has exactly four +1/+1 counters on it, search your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -7867,7 +7867,7 @@
         },
         {
             "id": "bf114b40-5b7a-5ef9-bc4f-e62ec57cb573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaefcbb-98d4-40b8-b51c-2d26f6945b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaefcbb-98d4-40b8-b51c-2d26f6945b6f.jpg?1",
             "name": "Blot Out",
             "text": "Target opponent exiles a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "b8994996-1337-5226-b7af-3f83141c7bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f66c02-29dc-4798-8d88-76681215fb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f66c02-29dc-4798-8d88-76681215fb78.jpg?1",
             "name": "Death-Rattle Oni",
             "text": "Flash\nThis spell costs {2} less to cast for each creature that died this turn.\nWhen Death-Rattle Oni enters the battlefield, destroy all other creatures that were dealt damage this turn.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "34f5f635-c455-5fa7-8782-90efb6831f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b11a6b-239b-4a2c-84d5-4e44a5366184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b11a6b-239b-4a2c-84d5-4e44a5366184.jpg?1",
             "name": "Markov Baron",
             "text": "Convoke\nLifelink\nOther Vampires you control get +1/+1.\nMadness {2}{B}",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "23abb6a5-2dbb-5d5d-89c8-870975dc71be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4453891-a94e-4057-87a3-168e9ef6d6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4453891-a94e-4057-87a3-168e9ef6d6d2.jpg?1",
             "name": "Urborg Scavengers",
             "text": "Whenever Urborg Scavengers enters the battlefield or attacks, exile target card from a graveyard. Put a +1/+1 counter on Urborg Scavengers.\nUrborg Scavengers has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.",
             "colours": [
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "d9b1d5f4-8fae-5fc5-b9aa-1422f1c655e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d352a7-4575-4f92-9ded-53a23afbca5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d352a7-4575-4f92-9ded-53a23afbca5a.jpg?1",
             "name": "Arni Metalbrow",
             "text": "Whenever a creature you control attacks or a creature enters the battlefield under your control attacking, you may pay {1}{R}. If you do, you may put a creature card with mana value less than that creature's mana value from your hand onto the battlefield tapped and attacking.",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "63c98b32-8835-5c57-808f-98d7b220e6eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40366946-d9e7-4770-bca2-f6d1dcb73ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40366946-d9e7-4770-bca2-f6d1dcb73ff5.jpg?1",
             "name": "Kolaghan Warmonger",
             "text": "Haste\nWhenever Kolaghan Warmonger attacks, look at the top six cards of your library. You may reveal a Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "615fe45b-23cf-5c1a-a634-09fddaa78504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f7a00-18a3-4831-b005-e31b5bfb2922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f7a00-18a3-4831-b005-e31b5bfb2922.jpg?1",
             "name": "Plargg and Nassari",
             "text": "At the beginning of your upkeep, each player exiles cards from the top of their library until they exile a nonland card. An opponent chooses a nonland card exiled this way. You may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
             "colours": [
@@ -8136,7 +8136,7 @@
         },
         {
             "id": "95e13a1e-b031-533a-814c-b4f99e627cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677b021e-207c-42f8-9d53-1f58fe7fcd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677b021e-207c-42f8-9d53-1f58fe7fcd6d.jpg?1",
             "name": "Reckless Handling",
             "text": "Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.",
             "colours": [
@@ -8171,7 +8171,7 @@
         },
         {
             "id": "f74bd13d-9f77-532c-9468-6d94ec4dd6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd065a13-00af-4a90-9cd2-304f3d12dd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd065a13-00af-4a90-9cd2-304f3d12dd4b.jpg?1",
             "name": "Tranquil Frillback",
             "text": "When Tranquil Frillback enters the battlefield, you may pay {G} up to three times. When you pay this cost one or more times, choose up to that many \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Exile target player's graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -8209,7 +8209,7 @@
         },
         {
             "id": "6273cad7-84e3-52b9-80b5-bb1ab379f3a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f0663-0a32-43ca-863b-1ddd4171b325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f0663-0a32-43ca-863b-1ddd4171b325.jpg?1",
             "name": "Undercity Upheaval",
             "text": "Undergrowth \u2014 Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -8244,7 +8244,7 @@
         },
         {
             "id": "ed02267b-47e0-59c0-b80e-5913566082b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4699973-2910-46fb-97e2-07f7ef1b27ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4699973-2910-46fb-97e2-07f7ef1b27ea.jpg?1",
             "name": "Calix, Guided by Fate",
             "text": "Constellation \u2014 Whenever Calix, Guided by Fate or another enchantment enters the battlefield under your control, put a +1/+1 counter on target creature.\nWhenever Calix or an enchanted creature you control deals combat damage to a player, you may create a token that's a copy of a nonlegendary enchantment you control. Do this only once each turn.",
             "colours": [
@@ -8288,7 +8288,7 @@
         },
         {
             "id": "e51b5f1b-9ed0-5e17-ba2b-0399c3ed3173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d12125-4fcf-4e1f-bc7b-90bf53357731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d12125-4fcf-4e1f-bc7b-90bf53357731.jpg?1",
             "name": "Campus Renovation",
             "text": "Return up to one target artifact or enchantment card from your graveyard to the battlefield. Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "3309f301-d5c2-5fd2-9d01-7adbd677f9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bf0249-5853-47f3-96e4-f24e4e70c1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bf0249-5853-47f3-96e4-f24e4e70c1ff.jpg?1",
             "name": "Cosmic Rebirth",
             "text": "Choose target permanent card in your graveyard. If it has mana value 3 or less, you may put it onto the battlefield. If you don't put it onto the battlefield, put it into your hand.\nYou gain 3 life.",
             "colours": [
@@ -8362,7 +8362,7 @@
         },
         {
             "id": "2f7674c3-13a7-51b0-85ad-a9f8c0eeabdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc7b44-f4a1-4edb-9fde-aa26830200e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dc7b44-f4a1-4edb-9fde-aa26830200e0.jpg?1",
             "name": "Danitha, New Benalia's Light",
             "text": "Vigilance, trample, lifelink\nOnce during each of your turns, you may cast an Aura or Equipment spell from your graveyard.",
             "colours": [
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "e62eac67-3244-5cf0-ba9a-786c20107003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac806b3-17d2-4671-b4ca-0a8b85482bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac806b3-17d2-4671-b4ca-0a8b85482bdc.jpg?1",
             "name": "Feast of the Victorious Dead",
             "text": "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.",
             "colours": [
@@ -8442,7 +8442,7 @@
         },
         {
             "id": "0f5b599a-1277-59cc-ac19-70aa17d49b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e14c1e-99d5-49e1-b9ce-92393c1d408f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e14c1e-99d5-49e1-b9ce-92393c1d408f.jpg?1",
             "name": "Gold-Forged Thopteryx",
             "text": "Flying, lifelink\nEach legendary permanent you control has ward {2}.",
             "colours": [
@@ -8483,7 +8483,7 @@
         },
         {
             "id": "372cb7b6-cb0f-5c1a-952f-369a092dcbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d423ca-ccd5-4bf1-9d81-4b6d4ca025ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d423ca-ccd5-4bf1-9d81-4b6d4ca025ac.jpg?1",
             "name": "Jirina, Dauntless General",
             "text": "When Jirina, Dauntless General enters the battlefield, exile target player's graveyard.\nSacrifice Jirina: Humans you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -8526,7 +8526,7 @@
         },
         {
             "id": "708dcc48-0674-5283-9ea7-66a50fdcb2f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01a0413-1cf6-4936-bec5-b1f5174b099f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01a0413-1cf6-4936-bec5-b1f5174b099f.jpg?1",
             "name": "The Kenriths' Royal Funeral",
             "text": "When The Kenriths' Royal Funeral enters the battlefield, exile up to two target legendary creature cards from your graveyard. You draw X cards and you lose X life, where X is the greatest mana value among cards exiled this way.\nLegendary spells you cast cost {1} less to cast for each card exiled with The Kenriths' Royal Funeral.",
             "colours": [
@@ -8566,7 +8566,7 @@
         },
         {
             "id": "56024a79-1965-53ba-ad17-c7589808b9e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4611fd39-a212-4d04-8c9e-d5d9c2bf3c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4611fd39-a212-4d04-8c9e-d5d9c2bf3c7d.jpg?1",
             "name": "Kiora, Sovereign of the Deep",
             "text": "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8609,7 +8609,7 @@
         },
         {
             "id": "8f50b910-8c19-5463-a4e9-67d0c1406169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669271c6-27d3-40d3-8054-4555d38269f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/669271c6-27d3-40d3-8054-4555d38269f3.jpg?1",
             "name": "Nahiri, Forged in Fury",
             "text": "Affinity for Equipment\nWhenever an equipped creature you control attacks, exile the top card of your library. You may play that card this turn. You may cast Equipment spells this way without paying their mana costs.",
             "colours": [
@@ -8652,7 +8652,7 @@
         },
         {
             "id": "8c4e55b5-2464-5e20-92f6-4cfe04d33f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d002e-4ab2-48bc-ba95-9dc1c90d210d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d002e-4ab2-48bc-ba95-9dc1c90d210d.jpg?1",
             "name": "Nahiri's Resolve",
             "text": "Creatures you control get +1/+0 and have haste.\nAt the beginning of your end step, exile any number of nontoken artifacts and/or creatures you control. Return those cards to the battlefield under their owner's control at the beginning of your next upkeep.",
             "colours": [
@@ -8690,7 +8690,7 @@
         },
         {
             "id": "338d6170-4082-5850-bd5d-bccb78be611a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143471-c144-40b9-9fcf-5c6c9ad45dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a143471-c144-40b9-9fcf-5c6c9ad45dfa.jpg?1",
             "name": "Narset, Enlightened Exile",
             "text": "Creatures you control have prowess.\nWhenever Narset, Enlightened Exile attacks, exile target noncreature, nonland card with mana value less than Narset's power from a graveyard and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -8735,7 +8735,7 @@
         },
         {
             "id": "d01683f1-ddcd-5dff-9815-8634d357f969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a2fea-e6b6-48f1-bff8-e556dd1daae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263a2fea-e6b6-48f1-bff8-e556dd1daae5.jpg?1",
             "name": "Nashi, Moon's Legacy",
             "text": "Menace, ward {1}\nWhenever Nashi, Moon's Legacy attacks, exile up to one target legendary or Rat card from your graveyard and copy it. You may cast the copy.",
             "colours": [
@@ -8780,7 +8780,7 @@
         },
         {
             "id": "93e69210-9cb9-5726-88f7-db1c5d4f2c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7554713b-825c-4c4a-9a44-9e76910a9bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7554713b-825c-4c4a-9a44-9e76910a9bfd.jpg?1",
             "name": "Niv-Mizzet, Supreme",
             "text": "Flying, hexproof from monocolored\nEach instant and sorcery card in your graveyard that's exactly two colors has jump-start.",
             "colours": [
@@ -8829,7 +8829,7 @@
         },
         {
             "id": "0d65de0e-c6ed-51b1-838b-4191dabcc0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8abcef7-31b0-4c17-9807-b26079fb6ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8abcef7-31b0-4c17-9807-b26079fb6ed8.jpg?1",
             "name": "Ob Nixilis, Captive Kingpin",
             "text": "Flying, trample\nWhenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "439ab7f9-de2d-5d3d-b143-4df344d21c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ed071-7672-44c4-bd19-66954ea0c83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ed071-7672-44c4-bd19-66954ea0c83c.jpg?1",
             "name": "Pia Nalaar, Consul of Revival",
             "text": "Thopters you control have haste.\nWhenever you play a land from exile or cast a spell from exile, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -8914,7 +8914,7 @@
         },
         {
             "id": "6571011b-212d-514c-aa00-e55317e7646e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c919f25-a57b-4671-ba30-de98262f8d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c919f25-a57b-4671-ba30-de98262f8d7a.jpg?1",
             "name": "Rebuild the City",
             "text": "Choose target land. Create three tokens that are copies of it, except they're 3/3 creatures in addition to their other types and they have vigilance and menace.",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "fb946aee-2e40-5578-8bb8-483180aeb155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25ce46-9d1a-4d5d-b35d-ea7abb8c5e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25ce46-9d1a-4d5d-b35d-ea7abb8c5e5c.jpg?1",
             "name": "Rocco, Street Chef",
             "text": "At the beginning of your end step, each player exiles the top card of their library. Until your next end step, each player may play the card they exiled this way.\nWhenever a player plays a land from exile or casts a spell from exile, you put a +1/+1 counter on target creature and create a Food token.",
             "colours": [
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "494b06e8-71ec-5466-91b3-970d5d99e15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363a562f-95bc-45fa-961d-50d98ed7b401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363a562f-95bc-45fa-961d-50d98ed7b401.jpg?1",
             "name": "Samut, Vizier of Naktamun",
             "text": "First strike, vigilance, haste\nWhenever a creature you control deals combat damage to a player, if that creature entered the battlefield this turn, draw a card.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "b18f59db-9579-5163-bec4-7a45a5cad309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d075d-71b6-4f04-946e-e2abc9d374fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d075d-71b6-4f04-946e-e2abc9d374fa.jpg?1",
             "name": "Sarkhan, Soul Aflame",
             "text": "Dragon spells you cast cost {1} less to cast.\nWhenever a Dragon enters the battlefield under your control, you may have Sarkhan, Soul Aflame become a copy of it until end of turn, except its name is Sarkhan, Soul Aflame and it's legendary in addition to its other types.",
             "colours": [
@@ -9086,7 +9086,7 @@
         },
         {
             "id": "26d9ffbb-17d5-5ba7-9eac-9cf36f08c2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfd30b-24eb-4b2c-a1de-3f7e1f2a5cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfd30b-24eb-4b2c-a1de-3f7e1f2a5cb2.jpg?1",
             "name": "Sigarda, Font of Blessings",
             "text": "Flying\nOther permanents you control have hexproof.\nYou may look at the top card of your library any time.\nYou may cast Angel spells and Human spells from the top of your library.",
             "colours": [
@@ -9128,7 +9128,7 @@
         },
         {
             "id": "6a045a28-efb4-5be1-81ea-df7b77f20dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64972370-4b5d-4664-9a5f-c1df947024bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64972370-4b5d-4664-9a5f-c1df947024bd.jpg?1",
             "name": "Tyvar the Bellicose",
             "text": "Whenever one or more Elves you control attack, they gain deathtouch until end of turn.\nEach creature you control has \"Whenever a mana ability of this creature resolves, put a number of +1/+1 counters on it equal to the amount of mana this creature produced. This ability triggers only once each turn.\"",
             "colours": [
@@ -9171,7 +9171,7 @@
         },
         {
             "id": "bbb9cc66-bd71-54fa-9ea3-58540ea1d6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69c4055-786c-4afd-a3c5-095dbf85d178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69c4055-786c-4afd-a3c5-095dbf85d178.jpg?1",
             "name": "Drannith Ruins",
             "text": "{T}: Add {C}.\n{2}, {T}: Put two +1/+1 counters on target non-Human creature that entered the battlefield this turn.",
             "colours": [],
@@ -9203,7 +9203,7 @@
         },
         {
             "id": "6fbfddea-c454-59c0-94e7-1d5d72d552a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e93920-2331-494d-bd8c-8d1ee5d7ccee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e93920-2331-494d-bd8c-8d1ee5d7ccee.jpg?1",
             "name": "Spark Rupture",
             "text": "When Spark Rupture enters the battlefield, draw a card.\nEach planeswalker with one or more loyalty counters on it loses all abilities and is a creature with power and toughness each equal to the number of loyalty counters on it.",
             "colours": [
@@ -9239,7 +9239,7 @@
         },
         {
             "id": "15c5d63b-3fbd-5f20-8dc4-1211963e1120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa34cf-51f8-4433-9e10-1c7e8f940962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1aa34cf-51f8-4433-9e10-1c7e8f940962.jpg?1",
             "name": "Jolrael, Voice of Zhalfir",
             "text": "At the beginning of combat on your turn, up to one target land you control becomes an X/X green and blue Bird creature with flying and haste until end of turn, where X is the number of cards in your hand. It's still a land.\nWhenever a land creature you control deals combat damage to a player, draw a card.",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/MBS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MBS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c6e259b6-498f-5d1e-81d5-a67e9e2a075b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0a4370-729d-40e7-b68b-21902648492d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0a4370-729d-40e7-b68b-21902648492d.jpg?1",
             "name": "Accorder Paladin",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "14d7ae7a-83b8-548e-b16b-f1990cde026b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c42dac-f0b3-41aa-b3b2-f203e265131d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c42dac-f0b3-41aa-b3b2-f203e265131d.jpg?1",
             "name": "Ardent Recruit",
             "text": "Metalcraft \u2014 Ardent Recruit gets +2/+2 as long as you control three or more artifacts.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "6fb2027e-6261-565b-82d1-5d97f572657a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5f605c-9d16-493e-bc44-0e15bdf8c0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5f605c-9d16-493e-bc44-0e15bdf8c0bf.jpg?1",
             "name": "Banishment Decree",
             "text": "Put target artifact, creature, or enchantment on top of its owner's library.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "780ab3a7-df81-548e-84d9-67e50c7a7b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9af543-5273-4754-ab7d-75d0b632240f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9af543-5273-4754-ab7d-75d0b632240f.jpg?1",
             "name": "Choking Fumes",
             "text": "Put a -1/-1 counter on each attacking creature.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "0fe79ebc-e7ad-52d6-8027-b3e2d6afc85b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7c7a65-5a96-4986-877b-b34583092bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7c7a65-5a96-4986-877b-b34583092bb6.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. You gain life equal to its converted mana cost.",
             "colours": [
@@ -170,7 +170,7 @@
         },
         {
             "id": "3a5770d1-8e86-5a7b-a115-064c763e336b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff909bc-0bda-4e8a-b7a3-ebc963552246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff909bc-0bda-4e8a-b7a3-ebc963552246.jpg?1",
             "name": "Frantic Salvage",
             "text": "Put any number of target artifact cards from your graveyard on top of your library.\nDraw a card.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "991c2a9b-404c-5e82-bb74-410be6afbda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2889bba-58a8-46e1-959c-0fd38c1732f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2889bba-58a8-46e1-959c-0fd38c1732f9.jpg?1",
             "name": "Gore Vassal",
             "text": "Sacrifice Gore Vassal: Put a -1/-1 counter on target creature. Then if that creature's toughness is 1 or greater, regenerate it.",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "e321f712-b409-5d7f-807d-b846ac85e6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3853ec-e307-46e0-96d7-0706b5c45c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3853ec-e307-46e0-96d7-0706b5c45c5e.jpg?1",
             "name": "Hero of Bladehold",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhenever Hero of Bladehold attacks, put two 1/1 white Soldier creature tokens onto the battlefield tapped and attacking.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "9fc0be95-26bf-595a-95b2-57e0ce41aad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30731756-81a8-480b-938f-48c1d0cb95d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30731756-81a8-480b-938f-48c1d0cb95d7.jpg?1",
             "name": "Kemba's Legion",
             "text": "Vigilance\nKemba's Legion can block an additional creature for each Equipment attached to Kemba's Legion.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "922a2e0f-6778-59ee-aec6-cf8d11140fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0900e1-df78-466d-b747-33f22c273d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0900e1-df78-466d-b747-33f22c273d67.jpg?1",
             "name": "Leonin Relic-Warder",
             "text": "When Leonin Relic-Warder enters the battlefield, you may exile target artifact or enchantment.\nWhen Leonin Relic-Warder leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "465d569f-1b9e-5b12-9baf-543aff89f749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb723d-aa4c-4a38-98de-1faefffab56b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb723d-aa4c-4a38-98de-1faefffab56b.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "858ed157-109c-5c38-8d1f-06c441c26512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a76016-96a1-40f5-9002-4b3bed65cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a76016-96a1-40f5-9002-4b3bed65cd5c.jpg?1",
             "name": "Loxodon Partisan",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "c40afd05-ec34-5caf-9aa7-86fa9be75ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f54188-2cfc-4964-add7-b452f32d57ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f54188-2cfc-4964-add7-b452f32d57ef.jpg?1",
             "name": "Master's Call",
             "text": "Put two 1/1 colorless Myr artifact creature tokens onto the battlefield.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "b0a7a503-6420-52e7-9697-7967147216d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf7a821-3587-4aad-8411-fca5c96ab5c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf7a821-3587-4aad-8411-fca5c96ab5c4.jpg?1",
             "name": "Mirran Crusader",
             "text": "Double strike, protection from black and from green",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "073b8f73-3fa5-5600-b9e0-5391a65494eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b7536d-6b0b-4906-ba88-7fcfe9b854ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b7536d-6b0b-4906-ba88-7fcfe9b854ee.jpg?1",
             "name": "Phyrexian Rebirth",
             "text": "Destroy all creatures, then put an X/X colorless Horror artifact creature token onto the battlefield, where X is the number of creatures destroyed this way.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "a88e514b-7413-58bd-8b86-d90944f1cbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978c49d-483a-42fe-971c-858288d07e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a978c49d-483a-42fe-971c-858288d07e40.jpg?1",
             "name": "Priests of Norn",
             "text": "Vigilance\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "a7f3aaad-9f80-58d1-87a1-1619b627271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b665e-8236-4ab9-bee4-414f075461d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b665e-8236-4ab9-bee4-414f075461d2.jpg?1",
             "name": "Tine Shrike",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -581,7 +581,7 @@
         },
         {
             "id": "66e9287c-8617-545c-8d7d-786f0f787645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac76f857-faf6-482d-a82e-7ff681f8007b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac76f857-faf6-482d-a82e-7ff681f8007b.jpg?1",
             "name": "Victory's Herald",
             "text": "Flying\nWhenever Victory's Herald attacks, attacking creatures gain flying and lifelink until end of turn.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "cae5ae9b-0e89-5751-8d16-eb35f4639b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a879940e-6632-47c5-a30e-d29a82d16e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a879940e-6632-47c5-a30e-d29a82d16e9d.jpg?1",
             "name": "White Sun's Zenith",
             "text": "Put X 2/2 white Cat creature tokens onto the battlefield. Shuffle White Sun's Zenith into its owner's library.",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "540948b9-6c76-5c82-a45f-435ff255f68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8150f78-e187-4949-9746-fec64d1675d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8150f78-e187-4949-9746-fec64d1675d1.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "f20d18b4-6f02-5948-b649-bcc93ba4edc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f6b20c-9871-433c-8557-44493447e914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f6b20c-9871-433c-8557-44493447e914.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "Flying\nWhenever an opponent draws a card, you may draw two cards.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "d227b963-34b4-5e8d-ad5b-99c619636704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7276c584-76ed-4c20-a5ea-627c8f7751e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7276c584-76ed-4c20-a5ea-627c8f7751e6.jpg?1",
             "name": "Corrupted Conscience",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has infect. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "9ba907d6-6013-578f-a3b3-db01fcb782e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a31710-c1d6-45e4-9dbe-a75453a74da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a31710-c1d6-45e4-9dbe-a75453a74da0.jpg?1",
             "name": "Cryptoplasm",
             "text": "At the beginning of your upkeep, you may have Cryptoplasm become a copy of another target creature. If you do, Cryptoplasm gains this ability.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "c1403e31-b5e9-57dd-b80a-e39786ced0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158da0aa-8317-498b-89ed-2f84317fe256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158da0aa-8317-498b-89ed-2f84317fe256.jpg?1",
             "name": "Distant Memories",
             "text": "Search your library for a card, exile it, then shuffle your library. Any opponent may have you put that card into your hand. If no player does, you draw three cards.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "f2c6d0e3-befa-53f4-8540-80c633bf4ea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126e0e5-9b23-496f-8a09-7a35499f9a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126e0e5-9b23-496f-8a09-7a35499f9a09.jpg?1",
             "name": "Fuel for the Cause",
             "text": "Counter target spell, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "755e94ec-da81-5b2e-8352-67c3b762dc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e576ad-3e03-424c-8857-88ec8898a92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e576ad-3e03-424c-8857-88ec8898a92e.jpg?1",
             "name": "Mirran Spy",
             "text": "Flying\nWhenever you cast an artifact spell, you may untap target creature.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "54cee391-fa58-5337-81b0-caf320b77dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abd4521-62c8-4b2f-a406-a8ddfa8f475a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abd4521-62c8-4b2f-a406-a8ddfa8f475a.jpg?1",
             "name": "Mitotic Manipulation",
             "text": "Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "53b70775-8f36-5326-bc88-a17cccc45b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7084f3-9335-401f-9a62-6f131351338d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7084f3-9335-401f-9a62-6f131351338d.jpg?1",
             "name": "Neurok Commando",
             "text": "Shroud\nWhenever Neurok Commando deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "c723f0a0-7d1f-52cd-a83c-61f4fdca3381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673bebb4-9c82-40ca-8552-b9030e961005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673bebb4-9c82-40ca-8552-b9030e961005.jpg?1",
             "name": "Oculus",
             "text": "When Oculus is put into a graveyard from the battlefield, you may draw a card.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "4b2423de-3900-5bde-b3b2-c916b6b4846a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb209cf5-ac7b-4521-b488-ef72451e3a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb209cf5-ac7b-4521-b488-ef72451e3a25.jpg?1",
             "name": "Quicksilver Geyser",
             "text": "Return up to two target nonland permanents to their owners' hands.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "18f1846d-a13c-5b40-92b3-9a7805517a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f157d08a-7cd7-4120-a8bb-1b50fa0ba99b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f157d08a-7cd7-4120-a8bb-1b50fa0ba99b.jpg?1",
             "name": "Serum Raker",
             "text": "Flying\nWhen Serum Raker is put into a graveyard from the battlefield, each player discards a card.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "744158c6-3dba-51a4-afee-a4396a780538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14e2a4-484b-46e4-a5a1-c66cb13be178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14e2a4-484b-46e4-a5a1-c66cb13be178.jpg?1",
             "name": "Spire Serpent",
             "text": "Defender\nMetalcraft \u2014 As long as you control three or more artifacts, Spire Serpent gets +2/+2 and can attack as though it didn't have defender.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "888e02ba-8b8b-51cf-b6e4-57b413fff7bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb40de7c-1905-4615-844b-4abc231fb01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb40de7c-1905-4615-844b-4abc231fb01e.jpg?1",
             "name": "Steel Sabotage",
             "text": "Choose one \u2014 Counter target artifact spell; or return target artifact to its owner's hand.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "b6c66f9e-a854-58fa-a968-c91da24535d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe4fea1-bb23-46e4-b7b0-e83f8b99ce5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe4fea1-bb23-46e4-b7b0-e83f8b99ce5d.jpg?1",
             "name": "Treasure Mage",
             "text": "When Treasure Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 6 or greater, reveal that card, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "9a11ec13-0ec5-59c8-9fb9-ec7a607e93b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc91fc7-7927-4c5d-888a-f40cbf658866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc91fc7-7927-4c5d-888a-f40cbf658866.jpg?1",
             "name": "Turn the Tide",
             "text": "Creatures your opponents control get -2/-0 until end of turn.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "2de0258e-d595-527d-b163-5eaa1283d296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13bb9b-c4e9-4b82-852a-dbd5602b1aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c13bb9b-c4e9-4b82-852a-dbd5602b1aa9.jpg?1",
             "name": "Vedalken Anatomist",
             "text": "{2}{U}, {T}: Put a -1/-1 counter on target creature. You may tap or untap that creature.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "b8fdd6e6-2c6c-523e-85e9-7e58d565870b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4f4db7-913c-4dd2-931e-630d90eb98ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e4f4db7-913c-4dd2-931e-630d90eb98ab.jpg?1",
             "name": "Vedalken Infuser",
             "text": "At the beginning of your upkeep, you may put a charge counter on target artifact.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "9d48363b-3022-579a-8fb8-2b53e875dc73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a3631-f2d6-4a64-a04a-893f452e3a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a3631-f2d6-4a64-a04a-893f452e3a60.jpg?1",
             "name": "Vivisection",
             "text": "As an additional cost to cast Vivisection, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "c646a6ef-6de0-540a-a48b-82049555c577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bdcf52-50b8-42c0-9665-931d83f5f314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bdcf52-50b8-42c0-9665-931d83f5f314.jpg?1",
             "name": "Black Sun's Zenith",
             "text": "Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its owner's library.",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "a6dd7462-64bf-5d42-a063-5c280d0d25d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a54115f-150a-4ae2-a5c7-20e2ba884dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a54115f-150a-4ae2-a5c7-20e2ba884dd1.jpg?1",
             "name": "Caustic Hound",
             "text": "When Caustic Hound is put into a graveyard from the battlefield, each player loses 4 life.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "83379d1f-299d-5a0e-9331-ac3cda192497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0017de60-ee1c-4675-b04e-cdfa2c2a596e.jpg?1",
             "name": "Flensermite",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "f42f27b9-71dd-56a4-ba5e-8abcd14bc12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee9f3-80fe-43b0-be5b-0c93103e1077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5ee9f3-80fe-43b0-be5b-0c93103e1077.jpg?1",
             "name": "Flesh-Eater Imp",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nSacrifice a creature: Flesh-Eater Imp gets +1/+1 until end of turn.",
             "colours": [
@@ -1421,7 +1421,7 @@
         },
         {
             "id": "cba9b662-1710-5952-affc-f66cc1ac53d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c665cfc-7e9a-444b-96b5-e8e4ef57a98a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c665cfc-7e9a-444b-96b5-e8e4ef57a98a.jpg?1",
             "name": "Go for the Throat",
             "text": "Destroy target nonartifact creature.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "24cc4504-9d0f-584c-bb65-3ea09c572ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f31fb-af96-4c8c-80fa-219ebd7c3d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7f31fb-af96-4c8c-80fa-219ebd7c3d4d.jpg?1",
             "name": "Gruesome Encore",
             "text": "Put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. Exile it at the beginning of the next end step. If that creature would leave the battlefield, exile it instead of putting it anywhere else.",
             "colours": [
@@ -1485,7 +1485,7 @@
         },
         {
             "id": "e0f16d8f-5ccf-50b7-905b-a0283506a293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ff5fbd-7ce8-4188-8228-0eab0d69a7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ff5fbd-7ce8-4188-8228-0eab0d69a7a1.jpg?1",
             "name": "Horrifying Revelation",
             "text": "Target player discards a card, then puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "92b62e2c-32ad-5792-be9b-06d84b22e229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd32ec2-02a8-41fc-bf45-c9585bb2b3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd32ec2-02a8-41fc-bf45-c9585bb2b3ee.jpg?1",
             "name": "Massacre Wurm",
             "text": "When Massacre Wurm enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls is put into a graveyard from the battlefield, that player loses 2 life.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "63e533c1-fb45-55b8-af54-6eb37ed4bee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6a8817-05fc-400e-9464-b7d925c5c312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6a8817-05fc-400e-9464-b7d925c5c312.jpg?1",
             "name": "Morbid Plunder",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -1584,7 +1584,7 @@
         },
         {
             "id": "c799d4ce-8444-52bf-a936-f40344a43883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035ff58-9df3-4db4-b9d0-97d58080ecfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c035ff58-9df3-4db4-b9d0-97d58080ecfe.jpg?1",
             "name": "Nested Ghoul",
             "text": "Whenever a source deals damage to Nested Ghoul, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "d9f69074-8941-5315-b985-7d1106e45d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0059d21b-0725-4806-8691-2451db36787f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0059d21b-0725-4806-8691-2451db36787f.jpg?1",
             "name": "Phyresis",
             "text": "Enchant creature\nEnchanted creature has infect. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "ea0d4fa2-26e3-58be-b808-351b801bf17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aaa8b9-987b-4809-8a54-aa29bdc18805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aaa8b9-987b-4809-8a54-aa29bdc18805.jpg?1",
             "name": "Phyrexian Crusader",
             "text": "First strike, protection from red and from white\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "8ec0ee7c-9f5e-5093-9a9d-cbbc7eafe1b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11889da-d5dd-4bb3-b3d0-0d90698f4f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11889da-d5dd-4bb3-b3d0-0d90698f4f34.jpg?1",
             "name": "Phyrexian Rager",
             "text": "When Phyrexian Rager enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "0b54d5be-3e44-52be-9659-8940671b8ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0024556-0317-4c28-83c3-0a6020d72a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0024556-0317-4c28-83c3-0a6020d72a2b.jpg?1",
             "name": "Phyrexian Vatmother",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nAt the beginning of your upkeep, you get a poison counter.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "495bb943-0d08-5457-ac86-fd6a5746a7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c374193-4ebb-4f33-a24d-e567aea57b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c374193-4ebb-4f33-a24d-e567aea57b01.jpg?1",
             "name": "Sangromancer",
             "text": "Flying\nWhenever a creature an opponent controls is put into a graveyard from the battlefield, you may gain 3 life.\nWhenever an opponent discards a card, you may gain 3 life.",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "5f3072f2-2f43-57b3-8975-44a1cd5c1ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ded51b-2ced-46d6-a1d4-0f49d4b1ed2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ded51b-2ced-46d6-a1d4-0f49d4b1ed2d.jpg?1",
             "name": "Scourge Servant",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "7d2d3c51-ad9c-55af-a016-381e3093ee57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7915d9-b941-4675-9a1b-18e579977144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7915d9-b941-4675-9a1b-18e579977144.jpg?1",
             "name": "Septic Rats",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Septic Rats attacks, if defending player is poisoned, it gets +1/+1 until end of turn.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "d1a09a6c-890e-5841-8df3-32346faeae51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a771-4f5c-4295-b070-8cb857a0279e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de42a771-4f5c-4295-b070-8cb857a0279e.jpg?1",
             "name": "Spread the Sickness",
             "text": "Destroy target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "41b3044a-1fda-5d2d-a6cd-a1843e4b4750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae09e1a-c257-45e9-88c8-7b1a7a6d714b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae09e1a-c257-45e9-88c8-7b1a7a6d714b.jpg?1",
             "name": "Virulent Wound",
             "text": "Put a -1/-1 counter on target creature. When that creature is put into a graveyard this turn, its controller gets a poison counter.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "0a15e0db-7af2-59c5-a6e0-004504a07bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8187e90-6a60-4ed0-9b3a-3a679743b7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8187e90-6a60-4ed0-9b3a-3a679743b7d0.jpg?1",
             "name": "Blisterstick Shaman",
             "text": "When Blisterstick Shaman enters the battlefield, it deals 1 damage to target creature or player.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "9470bc79-9ead-5851-9b33-e949767944b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5641730-428d-4484-866e-ec1ac669537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5641730-428d-4484-866e-ec1ac669537f.jpg?1",
             "name": "Burn the Impure",
             "text": "Burn the Impure deals 3 damage to target creature. If that creature has infect, Burn the Impure deals 3 damage to that creature's controller.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "f1b73c2f-0dfd-5eee-8e86-da5490b56813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b68e85-a381-441d-aa18-491f9e202a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b68e85-a381-441d-aa18-491f9e202a10.jpg?1",
             "name": "Concussive Bolt",
             "text": "Concussive Bolt deals 4 damage to target player.\nMetalcraft \u2014 If you control three or more artifacts, creatures that player controls can't block this turn.",
             "colours": [
@@ -2028,7 +2028,7 @@
         },
         {
             "id": "acda07e5-0235-59d3-9323-6c539a9a6819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29d5e01-6f83-4749-8340-774054bd2956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29d5e01-6f83-4749-8340-774054bd2956.jpg?1",
             "name": "Crush",
             "text": "Destroy target noncreature artifact.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "6abf881d-cf4b-5144-b1cb-d3b5d72e2a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1a696b-642a-419f-bd43-09af39a9401b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1a696b-642a-419f-bd43-09af39a9401b.jpg?1",
             "name": "Galvanoth",
             "text": "At the beginning of your upkeep, you may look at the top card of your library. If it's an instant or sorcery card, you may cast it without paying its mana cost.",
             "colours": [
@@ -2094,7 +2094,7 @@
         },
         {
             "id": "30141d2f-f9e5-5091-887b-c9e3c6252d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27dcb0c8-e6d5-4f6b-a74f-e495b5e42606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27dcb0c8-e6d5-4f6b-a74f-e495b5e42606.jpg?1",
             "name": "Gnathosaur",
             "text": "Sacrifice an artifact: Gnathosaur gains trample until end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "f3b72539-aa3e-54c4-ac72-3a5d063bd965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e220c87-1223-4998-b0e5-23e2d930fa6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e220c87-1223-4998-b0e5-23e2d930fa6b.jpg?1",
             "name": "Goblin Wardriver",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)",
             "colours": [
@@ -2163,7 +2163,7 @@
         },
         {
             "id": "467eb10b-57b8-5b61-a91a-59288a9dea42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83715873-9330-4d29-b106-cf1e6a66d1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83715873-9330-4d29-b106-cf1e6a66d1e9.jpg?1",
             "name": "Hellkite Igniter",
             "text": "Flying, haste\n{1}{R}: Hellkite Igniter gets +X/+0 until end of turn, where X is the number of artifacts you control.",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "9f0dc611-43a5-53f7-8829-9a74fabf7675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a516bce-3d2d-4e0f-afc7-27be3d88848c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a516bce-3d2d-4e0f-afc7-27be3d88848c.jpg?1",
             "name": "Hero of Oxid Ridge",
             "text": "Haste\nBattle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhenever Hero of Oxid Ridge attacks, creatures with power 1 or less can't block this turn.",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "4cea3d65-b73d-59e1-ba02-c0039db4a77f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb91ecb-1962-4cd1-80c1-c9e2485822ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb91ecb-1962-4cd1-80c1-c9e2485822ae.jpg?1",
             "name": "Into the Core",
             "text": "Exile two target artifacts.",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "e7536336-92cb-5d6b-a686-bd1a4191b426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978cc53c-c038-4442-bd46-e0b9e8cdd924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978cc53c-c038-4442-bd46-e0b9e8cdd924.jpg?1",
             "name": "Koth's Courier",
             "text": "Forestwalk",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "2b16661c-01f3-545f-ac05-f0a493c98239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189fea03-24db-4574-bbc2-4d3bc9e629a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189fea03-24db-4574-bbc2-4d3bc9e629a5.jpg?1",
             "name": "Kuldotha Flamefiend",
             "text": "When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "9da766ee-24f6-559c-842f-2a06741ae2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda5434-c0a5-4551-8e30-b1923f0001b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda5434-c0a5-4551-8e30-b1923f0001b8.jpg?1",
             "name": "Kuldotha Ringleader",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nKuldotha Ringleader attacks each turn if able.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "f6dbdc09-4bf2-5b46-8792-d1e54397b716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b939ded0-7033-4fee-864c-9e235d8720bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b939ded0-7033-4fee-864c-9e235d8720bb.jpg?1",
             "name": "Metallic Mastery",
             "text": "Gain control of target artifact until end of turn. Untap that artifact. It gains haste until end of turn.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "47a95386-5d6d-5420-b01a-2a65b85294a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7407d-f677-403b-893c-361df456009a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7407d-f677-403b-893c-361df456009a.jpg?1",
             "name": "Ogre Resister",
             "text": "",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "8feeea81-6d1a-53d0-bd7f-29611dc53162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f251c71-0e83-424d-9e0e-85790289087c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f251c71-0e83-424d-9e0e-85790289087c.jpg?1",
             "name": "Rally the Forces",
             "text": "Attacking creatures get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -2466,7 +2466,7 @@
         },
         {
             "id": "7e84cb8c-2bdc-5ed1-9c77-de663eb3c636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg?1",
             "name": "Red Sun's Zenith",
             "text": "Red Sun's Zenith deals X damage to target creature or player. If a creature dealt damage this way would be put into a graveyard this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "a4901b5f-a359-5d89-911a-37192d9f0607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e318b03-2aad-462b-a2a9-8b6bdf0e93d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e318b03-2aad-462b-a2a9-8b6bdf0e93d6.jpg?1",
             "name": "Slagstorm",
             "text": "Choose one \u2014 Slagstorm deals 3 damage to each creature; or Slagstorm deals 3 damage to each player.",
             "colours": [
@@ -2530,7 +2530,7 @@
         },
         {
             "id": "401ad583-530e-518e-9c2c-d4555974ee84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ac77ab-e51a-4c5c-ab6b-3fb610a5fa27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ac77ab-e51a-4c5c-ab6b-3fb610a5fa27.jpg?1",
             "name": "Spiraling Duelist",
             "text": "Metalcraft \u2014 Spiraling Duelist has double strike as long as you control three or more artifacts.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "a41d050d-c7f3-5583-91ec-2d638e980d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26da4278-ba44-4555-8837-e24627b46533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26da4278-ba44-4555-8837-e24627b46533.jpg?1",
             "name": "Blightwidow",
             "text": "Reach (This creature can block creatures with flying.)\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "4819ce30-18ee-58fe-8217-191f55cc06c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a7b3-18b6-4b1d-85cc-2253e605390c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a7b3-18b6-4b1d-85cc-2253e605390c.jpg?1",
             "name": "Creeping Corrosion",
             "text": "Destroy all artifacts.",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "c93160df-d260-5414-910a-9a69de8fa5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cf62a2-d03a-495d-924a-bf79524175fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cf62a2-d03a-495d-924a-bf79524175fa.jpg?1",
             "name": "Fangren Marauder",
             "text": "Whenever an artifact is put into a graveyard from the battlefield, you may gain 5 life.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "9e9d599d-8b14-5187-9249-2afef50e3ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45da44df-a83a-4974-bc22-5243dcda7cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45da44df-a83a-4974-bc22-5243dcda7cbd.jpg?1",
             "name": "Glissa's Courier",
             "text": "Mountainwalk",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "8a3a1680-762c-5b06-ac86-3b1dbb2b3bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02335747-54e3-4827-ae19-4e362863da9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02335747-54e3-4827-ae19-4e362863da9b.jpg?1",
             "name": "Green Sun's Zenith",
             "text": "Search your library for a green creature card with converted mana cost X or less, put it onto the battlefield, then shuffle your library. Shuffle Green Sun's Zenith into its owner's library.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "6754ebf2-0cd1-5f7d-bf85-13702e7526e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ed14c8-38c6-4da5-a6ee-f814478161d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ed14c8-38c6-4da5-a6ee-f814478161d2.jpg?1",
             "name": "Lead the Stampede",
             "text": "Look at the top five cards of your library. You may reveal any number of creature cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "e46fc639-21f8-5e58-807e-3b1c21ab3786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a935b4-347c-46d9-a7c5-8c5079948959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a935b4-347c-46d9-a7c5-8c5079948959.jpg?1",
             "name": "Melira's Keepers",
             "text": "Melira's Keepers can't have counters placed on it.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "3b95c925-4632-507f-ba39-3902ae4805b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbb5778-fa9a-4a1f-be4f-627630c3e3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbb5778-fa9a-4a1f-be4f-627630c3e3ca.jpg?1",
             "name": "Mirran Mettle",
             "text": "Target creature gets +2/+2 until end of turn.\nMetalcraft \u2014 That creature gets +4/+4 until end of turn instead if you control three or more artifacts.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "e5f15a00-36a9-5926-80af-ffe023fb6f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb135aa1-9f46-4d60-a1a4-97aa0e852ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb135aa1-9f46-4d60-a1a4-97aa0e852ced.jpg?1",
             "name": "Phyrexian Hydra",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nIf damage would be dealt to Phyrexian Hydra, prevent that damage. Put a -1/-1 counter on Phyrexian Hydra for each 1 damage prevented this way.",
             "colours": [
@@ -2867,7 +2867,7 @@
         },
         {
             "id": "6a68e7d9-fb42-5674-af16-5725f31dcfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2918d6-50f7-4bc1-aef2-930a5c84be8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2918d6-50f7-4bc1-aef2-930a5c84be8d.jpg?1",
             "name": "Pistus Strike",
             "text": "Destroy target creature with flying. Its controller gets a poison counter.",
             "colours": [
@@ -2899,7 +2899,7 @@
         },
         {
             "id": "fc6a5c69-36e5-5bd5-b2c4-8f5e645c6f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52341830-8cea-421f-b901-9229004f2d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52341830-8cea-421f-b901-9229004f2d45.jpg?1",
             "name": "Plaguemaw Beast",
             "text": "{T}, Sacrifice a creature: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "622670ab-28bc-5c0b-89b0-9b3290b74a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67c8bea-d4c9-4759-8a37-10546b234472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67c8bea-d4c9-4759-8a37-10546b234472.jpg?1",
             "name": "Praetor's Counsel",
             "text": "Return all cards from your graveyard to your hand. Exile Praetor's Counsel. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "ba6fab91-413f-5d9a-b6fe-37da6042f8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c597b9-5024-42bd-b500-5ef6a3accda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c597b9-5024-42bd-b500-5ef6a3accda6.jpg?1",
             "name": "Quilled Slagwurm",
             "text": "",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "ea28e0c3-a1eb-5c92-a048-5cd44c0e4bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a81dfcf-a7c4-41a4-b1e9-b9e9c3f75742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a81dfcf-a7c4-41a4-b1e9-b9e9c3f75742.jpg?1",
             "name": "Rot Wolf",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever a creature dealt damage by Rot Wolf this turn is put into a graveyard, you may draw a card.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "b800e27b-6886-5590-a7f2-2bf9cf0d7005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4d333-78f7-4710-9b26-36e285c0d9f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e4d333-78f7-4710-9b26-36e285c0d9f8.jpg?1",
             "name": "Tangle Mantis",
             "text": "Trample",
             "colours": [
@@ -3070,7 +3070,7 @@
         },
         {
             "id": "01b9bdce-0e71-5b3b-9224-29e3a45c991d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d393da0-4cb6-4ae8-b747-8e6d0fa7f55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d393da0-4cb6-4ae8-b747-8e6d0fa7f55a.jpg?1",
             "name": "Thrun, the Last Troll",
             "text": "Thrun, the Last Troll can't be countered.\nThrun can't be the target of spells or abilities your opponents control.\n{1}{G}: Regenerate Thrun.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "f1db9818-202f-5af6-a67c-aa930fbe652c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2798fdff-0b39-41b6-b0ec-c4f449ca3314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2798fdff-0b39-41b6-b0ec-c4f449ca3314.jpg?1",
             "name": "Unnatural Predation",
             "text": "Target creature gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "24c15f17-f091-5a6e-9a9e-d99fa8bd5c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc13aee-5a74-4dab-a6af-7dc31255981d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc13aee-5a74-4dab-a6af-7dc31255981d.jpg?1",
             "name": "Viridian Corrupter",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Viridian Corrupter enters the battlefield, destroy target artifact.",
             "colours": [
@@ -3175,7 +3175,7 @@
         },
         {
             "id": "2cc1026b-3dd1-5476-9b47-4c0b8b7a0eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129fa334-f561-4fbd-9f51-2fa044b674e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129fa334-f561-4fbd-9f51-2fa044b674e1.jpg?1",
             "name": "Viridian Emissary",
             "text": "When Viridian Emissary is put into a graveyard from the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "deca8f5b-6828-5f8e-9b54-8888e1d689f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755e0fbf-4f00-4b05-a535-27e78e96d6b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/755e0fbf-4f00-4b05-a535-27e78e96d6b6.jpg?1",
             "name": "Glissa, the Traitor",
             "text": "First strike, deathtouch\nWhenever a creature an opponent controls is put into a graveyard from the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "b8f9c6a9-42c3-59a2-a037-50a8776ad5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c8470-1cc8-4383-8782-c022867d46e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3c8470-1cc8-4383-8782-c022867d46e8.jpg?1",
             "name": "Tezzeret, Agent of Bolas",
             "text": "+1: Look at the top five cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\n-1: Target artifact becomes a 5/5 artifact creature.\n-4: Target player loses X life and you gain X life, where X is twice the number of artifacts you control.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "cc737241-cb41-574e-84e7-d034e5217ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69959c54-1350-4c64-8e5a-fc8447bb979c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69959c54-1350-4c64-8e5a-fc8447bb979c.jpg?1",
             "name": "Bladed Sentinel",
             "text": "{W}: Bladed Sentinel gains vigilance until end of turn.",
             "colours": [],
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "83b13871-d088-5b31-a3af-270b38424039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7928bb14-7631-4830-a756-26d1ea832ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7928bb14-7631-4830-a756-26d1ea832ba2.jpg?1",
             "name": "Blightsteel Colossus",
             "text": "Trample, infect\nBlightsteel Colossus is indestructible.\nIf Blightsteel Colossus would be put into a graveyard from anywhere, reveal Blightsteel Colossus and shuffle it into its owner's library instead.",
             "colours": [],
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "f013d4b6-8744-537e-b0dc-300d228ab013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14613bc-0083-48d6-ac10-b2839657e84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14613bc-0083-48d6-ac10-b2839657e84b.jpg?1",
             "name": "Bonehoard",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +X/+X, where X is the number of creature cards in all graveyards.\nEquip {2}",
             "colours": [],
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "ab08087a-836d-5d8d-b701-3f20068b9e13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37928b90-ab31-4c73-99b2-fe31feb2afea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37928b90-ab31-4c73-99b2-fe31feb2afea.jpg?1",
             "name": "Brass Squire",
             "text": "{T}: Attach target Equipment you control to target creature you control.",
             "colours": [],
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "8e3253ab-a984-508b-a100-e86595da3dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ccb013-4641-400f-a035-86030ac55582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ccb013-4641-400f-a035-86030ac55582.jpg?1",
             "name": "Copper Carapace",
             "text": "Equipped creature gets +2/+2 and can't block.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "f9081998-9a10-5399-87b8-db1fba11d8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414ba7-0f59-4c73-931c-e599d149d3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414ba7-0f59-4c73-931c-e599d149d3ba.jpg?1",
             "name": "Core Prowler",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Core Prowler is put into a graveyard from the battlefield, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "618dc4ac-b6c6-510d-9e7d-f6e281e419f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba60731f-ed96-4eba-b2de-94965745f35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba60731f-ed96-4eba-b2de-94965745f35a.jpg?1",
             "name": "Darksteel Plate",
             "text": "Darksteel Plate is indestructible.\nEquipped creature is indestructible.\nEquip {2}",
             "colours": [],
@@ -3507,7 +3507,7 @@
         },
         {
             "id": "db31e7f8-e825-5ce3-b75e-f60b570fcd3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1fe29f-cf84-45d3-b8fe-e4de1d2bebbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1fe29f-cf84-45d3-b8fe-e4de1d2bebbf.jpg?1",
             "name": "Decimator Web",
             "text": "{4}, {T}: Target opponent loses 2 life, gets a poison counter, then puts the top six cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "6e0cdf5b-2285-50bf-92cc-88efafc58884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d54f08-53f0-41b2-8b86-8244515224eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d54f08-53f0-41b2-8b86-8244515224eb.jpg?1",
             "name": "Dross Ripper",
             "text": "{2}{B}: Dross Ripper gets +1/+1 until end of turn.",
             "colours": [],
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "7104146e-c5cb-557f-b2bf-94f602bd59c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd47a02-5a6e-4daa-9877-f65c8639c569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd47a02-5a6e-4daa-9877-f65c8639c569.jpg?1",
             "name": "Flayer Husk",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +1/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "45ab90f9-e2cd-51bf-9182-6a2b06d2347a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5970d053-e2e8-471b-b342-2e9b9177724c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5970d053-e2e8-471b-b342-2e9b9177724c.jpg?1",
             "name": "Gust-Skimmer",
             "text": "{U}: Gust-Skimmer gains flying until end of turn.",
             "colours": [],
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "13280ead-e2b3-5621-8736-35865b2e8b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b913f3-6581-45ae-9cdb-274c2ccd8899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b913f3-6581-45ae-9cdb-274c2ccd8899.jpg?1",
             "name": "Hexplate Golem",
             "text": "",
             "colours": [],
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "a3a3d64d-187e-50ee-a9b5-2c5289371098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ea522-a0f6-45a8-8985-6fcca95d60cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1ea522-a0f6-45a8-8985-6fcca95d60cc.jpg?1",
             "name": "Ichor Wellspring",
             "text": "When Ichor Wellspring enters the battlefield or is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -3691,7 +3691,7 @@
         },
         {
             "id": "dbb4f70f-3084-59b7-ada3-ce6d6c0660df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393454c2-b256-4a6e-9bc2-56a47cab5073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393454c2-b256-4a6e-9bc2-56a47cab5073.jpg?1",
             "name": "Knowledge Pool",
             "text": "Imprint \u2014 When Knowledge Pool enters the battlefield, each player exiles the top three cards of his or her library.\nWhenever a player casts a spell from his or her hand, that player exiles it. If the player does, he or she may cast another nonland card exiled with Knowledge Pool without paying that card's mana cost.",
             "colours": [],
@@ -3719,7 +3719,7 @@
         },
         {
             "id": "b178fa6e-3f1c-539c-92d2-b1672c21fbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45350c4b-def2-4b93-ab66-9f32bd426cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45350c4b-def2-4b93-ab66-9f32bd426cff.jpg?1",
             "name": "Lumengrid Gargoyle",
             "text": "Flying",
             "colours": [],
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "fb1d2d5c-2374-56be-90cb-fbbfbf7ebcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2f7dc-3ada-4490-8c1f-1d03bd4840f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed2f7dc-3ada-4490-8c1f-1d03bd4840f5.jpg?1",
             "name": "Magnetic Mine",
             "text": "Whenever another artifact is put into a graveyard from the battlefield, Magnetic Mine deals 2 damage to that artifact's controller.",
             "colours": [],
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "8dfbf825-8018-50c2-bf35-ded05597ce8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cade6dde-1edf-44b8-a37e-a22f9207db51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cade6dde-1edf-44b8-a37e-a22f9207db51.jpg?1",
             "name": "Mirrorworks",
             "text": "Whenever another nontoken artifact enters the battlefield under your control, you may pay {2}. If you do, put a token that's a copy of that artifact onto the battlefield.",
             "colours": [],
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "3f16a163-d8fe-5130-93cf-74176bd5dd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd23da5-421f-41d0-bb60-59560da7dece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd23da5-421f-41d0-bb60-59560da7dece.jpg?1",
             "name": "Mortarpod",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +0/+1 and has \"Sacrifice this creature: This creature deals 1 damage to target creature or player.\"\nEquip {2}",
             "colours": [],
@@ -3836,7 +3836,7 @@
         },
         {
             "id": "bc856aff-f8d8-5bfb-8b6c-3d7bb25394e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507979fd-5459-4933-8707-adc303750ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507979fd-5459-4933-8707-adc303750ce9.jpg?1",
             "name": "Myr Sire",
             "text": "When Myr Sire is put into a graveyard from the battlefield, put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [],
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "685446ae-f6e3-52a5-b9b4-07e7a7068ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a76840-47f7-4e1e-b68b-00cb7da98cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a76840-47f7-4e1e-b68b-00cb7da98cdf.jpg?1",
             "name": "Myr Turbine",
             "text": "{T}: Put a 1/1 colorless Myr artifact creature token onto the battlefield.\n{T}, Tap five untapped Myr you control: Search your library for a Myr creature card, put it onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "9684e32f-0a83-5aeb-af19-cc217cf3157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff75f16-413c-4618-b766-67bd8ff4d161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff75f16-413c-4618-b766-67bd8ff4d161.jpg?1",
             "name": "Myr Welder",
             "text": "Imprint \u2014 {T}: Exile target artifact card from a graveyard.\nMyr Welder has all activated abilities of all cards exiled with it.",
             "colours": [],
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "ba0f14ba-1c80-5ca5-8122-3a8041bb54ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55710eb0-ae16-420a-9f99-6a245e0f4c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55710eb0-ae16-420a-9f99-6a245e0f4c14.jpg?1",
             "name": "Peace Strider",
             "text": "When Peace Strider enters the battlefield, you gain 3 life.",
             "colours": [],
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "5de1a2fd-de8a-5c82-a417-fb6c8b40e6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112062-1a1b-462b-85d3-821ea91778b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9112062-1a1b-462b-85d3-821ea91778b8.jpg?1",
             "name": "Phyrexian Digester",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "c29bc973-cc0f-585e-ba78-59beb141f5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f6ed6c-8095-4a81-b428-36b2916eec88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f6ed6c-8095-4a81-b428-36b2916eec88.jpg?1",
             "name": "Phyrexian Juggernaut",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nPhyrexian Juggernaut attacks each turn if able.",
             "colours": [],
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "23c5d6b2-79b9-5e12-bc82-b53676de22b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7bec21-61b0-4e72-848b-82f38e1910e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7bec21-61b0-4e72-848b-82f38e1910e0.jpg?1",
             "name": "Phyrexian Revoker",
             "text": "As Phyrexian Revoker enters the battlefield, name a nonland card.\nActivated abilities of sources with the chosen name can't be activated.",
             "colours": [],
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "767f194d-2199-516b-98f9-6ee7f19fb728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b449a5-634f-47b1-a757-86a6849f6777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b449a5-634f-47b1-a757-86a6849f6777.jpg?1",
             "name": "Pierce Strider",
             "text": "When Pierce Strider enters the battlefield, target opponent loses 3 life.",
             "colours": [],
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "37083086-1079-5d9f-a396-64af892e6966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6a88da-0b51-42d1-aa63-8c4b5e5c03c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6a88da-0b51-42d1-aa63-8c4b5e5c03c3.jpg?1",
             "name": "Piston Sledge",
             "text": "When Piston Sledge enters the battlefield, attach it to target creature you control.\nEquipped creature gets +3/+1.\nEquip\u2014\nSacrifice an artifact.",
             "colours": [],
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "20f88dbb-bd22-5f21-9df9-e6e95c20a1b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f932690-9a38-4a3f-8805-a192208152a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f932690-9a38-4a3f-8805-a192208152a3.jpg?1",
             "name": "Plague Myr",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "ce194166-35b9-5eb9-a91b-6400acc4869f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd84701-857e-4948-8cb8-39b8a321a177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd84701-857e-4948-8cb8-39b8a321a177.jpg?1",
             "name": "Psychosis Crawler",
             "text": "Psychosis Crawler's power and toughness are each equal to the number of cards in your hand.\nWhenever you draw a card, each opponent loses 1 life.",
             "colours": [],
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "22126eb2-3ae1-5dfd-8ee6-0e58e9e04939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a1b4-7f88-4c8a-9ef4-bdfbd2f9e9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a1b4-7f88-4c8a-9ef4-bdfbd2f9e9cc.jpg?1",
             "name": "Razorfield Rhino",
             "text": "Metalcraft \u2014 Razorfield Rhino gets +2/+2 as long as you control three or more artifacts.",
             "colours": [],
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "e04093f9-d57f-50ea-a0bb-54b124d1a14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2228ee5-507a-46ba-82ae-72ba3088a568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2228ee5-507a-46ba-82ae-72ba3088a568.jpg?1",
             "name": "Rusted Slasher",
             "text": "Sacrifice an artifact: Regenerate Rusted Slasher.",
             "colours": [],
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "0495b6b4-2b4c-5927-8d99-e78e74eb30a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c1a5b-237b-4ecb-be73-3c6dafd5ae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c1a5b-237b-4ecb-be73-3c6dafd5ae53.jpg?1",
             "name": "Shimmer Myr",
             "text": "Flash\nYou may cast artifact cards as though they had flash.",
             "colours": [],
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "6efb52c4-3c98-552b-8a38-fb1f43417b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41269f-007d-43ba-a682-d3929cc69696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb41269f-007d-43ba-a682-d3929cc69696.jpg?1",
             "name": "Shriekhorn",
             "text": "Shriekhorn enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Shriekhorn: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -4302,7 +4302,7 @@
         },
         {
             "id": "ac4e9caf-42a9-5d68-9924-d6b38d09d871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be065962-f2ed-4ab9-be6b-bfc66d63ff4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be065962-f2ed-4ab9-be6b-bfc66d63ff4e.jpg?1",
             "name": "Signal Pest",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nSignal Pest can't be blocked except by creatures with flying or reach.",
             "colours": [],
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "ecb24e70-7dc6-584f-9ff5-a86d580adc76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dba839-bd1e-4ce8-ab90-005eb1f0102e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dba839-bd1e-4ce8-ab90-005eb1f0102e.jpg?1",
             "name": "Silverskin Armor",
             "text": "Equipped creature gets +1/+1 and is an artifact in addition to its other types.\nEquip {2}",
             "colours": [],
@@ -4363,7 +4363,7 @@
         },
         {
             "id": "f33c7615-56df-56d1-94ba-a51bcc16c546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11bc5d8-378a-441f-b92a-a60005745f25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11bc5d8-378a-441f-b92a-a60005745f25.jpg?1",
             "name": "Skinwing",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+2 and has flying.\nEquip {6}",
             "colours": [],
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "3f3c1745-2be0-5347-be4d-9855e9c62050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c0735-1816-489b-9793-89d1060d78f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c0735-1816-489b-9793-89d1060d78f7.jpg?1",
             "name": "Sphere of the Suns",
             "text": "Sphere of the Suns enters the battlefield tapped and with three charge counters on it.\n{T}, Remove a charge counter from Sphere of the Suns: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "f1ef7511-9605-5138-adcb-fc9ec73c627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc820134-ae9a-4c99-a869-cee7f1f6d79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc820134-ae9a-4c99-a869-cee7f1f6d79b.jpg?1",
             "name": "Spin Engine",
             "text": "{R}: Target creature can't block Spin Engine this turn.",
             "colours": [],
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "6b9b11cb-fce3-5a52-94b3-8252dcc9f43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59313b00-ac75-484a-ad74-db9d8960c0f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59313b00-ac75-484a-ad74-db9d8960c0f8.jpg?1",
             "name": "Spine of Ish Sah",
             "text": "When Spine of Ish Sah enters the battlefield, destroy target permanent.\nWhen Spine of Ish Sah is put into a graveyard from the battlefield, return Spine of Ish Sah to its owner's hand.",
             "colours": [],
@@ -4482,7 +4482,7 @@
         },
         {
             "id": "f75af259-d0e1-593e-80e1-ea5957f3a8ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d7ff8f-7733-4323-8575-c50b3e730dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d7ff8f-7733-4323-8575-c50b3e730dbc.jpg?1",
             "name": "Strandwalker",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+4 and has reach.\nEquip {4}",
             "colours": [],
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "73e9af3f-d3d4-5e5b-a02b-592077d738f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580b4818-2a01-46ad-b4d9-7d895a625bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580b4818-2a01-46ad-b4d9-7d895a625bb3.jpg?1",
             "name": "Sword of Feast and Famine",
             "text": "Equipped creature gets +2/+2 and has protection from black and from green.\nWhenever equipped creature deals combat damage to a player, that player discards a card and you untap all lands you control.\nEquip {2}",
             "colours": [],
@@ -4542,7 +4542,7 @@
         },
         {
             "id": "f0aa4f26-80a5-5a87-9781-cbee6833442e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3c301-8d8e-45fe-902a-af03a79525be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3c301-8d8e-45fe-902a-af03a79525be.jpg?1",
             "name": "Tangle Hulk",
             "text": "{2}{G}: Regenerate Tangle Hulk.",
             "colours": [],
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "b187f3ce-a666-54b8-859f-66be5cd7a0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644ab412-0603-447d-b8ef-dfd79f78e2a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644ab412-0603-447d-b8ef-dfd79f78e2a5.jpg?1",
             "name": "Thopter Assembly",
             "text": "Flying\nAt the beginning of your upkeep, if you control no Thopters other than Thopter Assembly, return Thopter Assembly to its owner's hand and put five 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.",
             "colours": [],
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "ba2c7c77-00e2-5b7f-abfd-aa3cc9e60dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3bb4ab-6fe7-4926-a929-3e37691f287a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3bb4ab-6fe7-4926-a929-3e37691f287a.jpg?1",
             "name": "Titan Forge",
             "text": "{3}, {T}: Put a charge counter on Titan Forge.\n{T}, Remove three charge counters from Titan Forge: Put a 9/9 colorless Golem artifact creature token onto the battlefield.",
             "colours": [],
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "4b9645d2-5454-585e-8edc-65162a4c8957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7e986f-5b28-46d2-8ec2-ee719b07dbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7e986f-5b28-46d2-8ec2-ee719b07dbfd.jpg?1",
             "name": "Training Drone",
             "text": "Training Drone can't attack or block unless it's equipped.",
             "colours": [],
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "28337c42-4fb1-581c-b829-f16197779c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2154e3c6-ab69-4661-b1ef-a50cc0f6f763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2154e3c6-ab69-4661-b1ef-a50cc0f6f763.jpg?1",
             "name": "Viridian Claw",
             "text": "Equipped creature gets +1/+0 and has first strike.\nEquip {1}",
             "colours": [],
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "85bade45-2337-50a0-88ae-9b9244372fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9b696-5203-4235-9bdd-f2a389d69813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9b696-5203-4235-9bdd-f2a389d69813.jpg?1",
             "name": "Contested War Zone",
             "text": "Whenever a creature deals combat damage to you, that creature's controller gains control of Contested War Zone.\n{T}: Add {1} to your mana pool.\n{1}, {T}: Attacking creatures get +1/+0 until end of turn.",
             "colours": [],
@@ -4724,7 +4724,7 @@
         },
         {
             "id": "8ba201f1-3028-5530-815d-06016aadb10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50c1c3-885e-47d3-ada7-cc0edbf09df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec50c1c3-885e-47d3-ada7-cc0edbf09df1.jpg?1",
             "name": "Inkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Inkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying and infect until end of turn. It's still a land. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "fb10965b-21de-5338-b0f6-14199dab47d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb24b22-d812-466b-b8bf-6562283ee335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb24b22-d812-466b-b8bf-6562283ee335.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4788,7 +4788,7 @@
         },
         {
             "id": "03c15c6f-df43-5f7d-9420-a65897b215ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76a9b20-746c-42e5-9977-f5dce6aef0f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76a9b20-746c-42e5-9977-f5dce6aef0f2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "162a0be6-c3d2-5bd0-8a29-83f662d447e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c7b858-61e1-43ea-95b6-2a0079a802d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c7b858-61e1-43ea-95b6-2a0079a802d2.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "1c996bb5-21ed-5d10-9c7c-5ee5beaa8daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37736b90-7ecd-4b74-aeb6-50d3a81bc31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37736b90-7ecd-4b74-aeb6-50d3a81bc31d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -4896,7 +4896,7 @@
         },
         {
             "id": "fd68d601-a412-51ce-afcc-d9399ee505a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98a492-5c4e-4527-8c03-2ab2442ba7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98a492-5c4e-4527-8c03-2ab2442ba7e1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -4932,7 +4932,7 @@
         },
         {
             "id": "b6117ab6-e976-5cb7-a2e2-6ed5e952c928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c794f2c8-9c64-4b93-b7d9-3040f325d43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c794f2c8-9c64-4b93-b7d9-3040f325d43c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -4968,7 +4968,7 @@
         },
         {
             "id": "b5ceafff-ebee-523d-a78d-f47edee9692d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a55065-555a-4bdb-8ab1-8830ca5ba6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a55065-555a-4bdb-8ab1-8830ca5ba6fd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "2b3deca9-48a1-5d9f-98b0-3d0f69864fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318699f3-3ee4-4355-aebd-8a5a9006e07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318699f3-3ee4-4355-aebd-8a5a9006e07d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "374414bd-e7c2-5639-8a79-90270840a03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c84076-d503-48df-9b6c-9d4a835501b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c84076-d503-48df-9b6c-9d4a835501b6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "c38dc173-1096-55f2-bbc2-475f847c5336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8aa7c-0195-4ce9-9de4-4e6d780455aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b8aa7c-0195-4ce9-9de4-4e6d780455aa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "4deea936-a240-5438-9385-a36f95b532d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760dcba4-c0f1-4843-9c39-393c629aae8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760dcba4-c0f1-4843-9c39-393c629aae8e.jpg?1",
             "name": "Germ",
             "text": "",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "65392510-3980-5122-a0e1-40f6e08304b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46769d11-a7ae-43ac-8c00-e1681955949b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46769d11-a7ae-43ac-8c00-e1681955949b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "739eae77-2810-5d5e-8c6b-203db53cdd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d84926d-5892-4c62-a943-fac9f0ddc569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d84926d-5892-4c62-a943-fac9f0ddc569.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "6f296fb6-0425-553d-9744-e16a81199d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg?1",
             "name": "Horror",
             "text": "",
             "colours": [],
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "6bab41d8-75fc-5971-9e78-e24e3a03a8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e230e-f604-4803-9cbd-fd08d2863db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4e230e-f604-4803-9cbd-fd08d2863db4.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "0cda0fd0-632a-576b-be49-b41982770b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fcdd2b-dd90-458d-9b8b-5b1b9a3f8bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92fcdd2b-dd90-458d-9b8b-5b1b9a3f8bd3.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MH1.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MH1.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e562c426-78dd-5f0e-86b7-3756069f5d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9693e59b-032d-4ddc-a7d1-88a0f52dcc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9693e59b-032d-4ddc-a7d1-88a0f52dcc6c.jpg?1",
             "name": "Morophon, the Boundless",
             "text": "Changeling (This card is every creature type.)\nAs Morophon, the Boundless enters the battlefield, choose a creature type.\nSpells of the chosen type you cast cost {W}{U}{B}{R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\nOther creatures you control of the chosen type get +1/+1.",
             "colours": [],
@@ -42,7 +42,7 @@
         },
         {
             "id": "2a6226fe-5f33-5727-aad6-655fdc7cb5db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175b6e34-9cb3-4c8d-9cc0-960082a9ee71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175b6e34-9cb3-4c8d-9cc0-960082a9ee71.jpg?1",
             "name": "Answered Prayers",
             "text": "Whenever a creature enters the battlefield under your control, you gain 1 life. If Answered Prayers isn't a creature, it becomes a 3/3 Angel creature with flying in addition to its other types until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "76469a16-5cbc-59fe-8679-b9d2cad9bce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be49ed9-a078-4a57-a84a-03cfaf184fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be49ed9-a078-4a57-a84a-03cfaf184fef.jpg?1",
             "name": "Astral Drift",
             "text": "Whenever you cycle Astral Drift or cycle another card while Astral Drift is on the battlefield, you may exile target creature. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "5f5cc949-a06e-570e-965c-b8ca65611b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacf7dd0-5855-4e7b-b75c-8119cc3d1460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacf7dd0-5855-4e7b-b75c-8119cc3d1460.jpg?1",
             "name": "Battle Screech",
             "text": "Create two 1/1 white Bird creature tokens with flying.\nFlashback\u2014\nTap three untapped white creatures you control. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "eac8641e-6856-518b-b87c-a3895903e21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edc5da-4477-49f6-bbcc-f208fdaae0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edc5da-4477-49f6-bbcc-f208fdaae0d3.jpg?1",
             "name": "Dismantling Blow",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nDestroy target artifact or enchantment. If this spell was kicked, draw two cards.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "263f44d1-59b7-5203-a568-4eea375aa2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed0f6a5-ed40-44fc-a5e1-3f8bb968d1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed0f6a5-ed40-44fc-a5e1-3f8bb968d1d9.jpg?1",
             "name": "Enduring Sliver",
             "text": "Outlast {2} ({2}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nOther Sliver creatures you control have outlast {2}.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "5246b5b0-e2b4-5f85-9dbe-96b95b79e0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da5f3f8-5eef-498f-ba2c-2f3fbc3745aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da5f3f8-5eef-498f-ba2c-2f3fbc3745aa.jpg?1",
             "name": "Ephemerate",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "2ed0d815-cbd4-56c6-b0d9-7dc2e768787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14167f33-00e2-41f9-b545-b476562881c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14167f33-00e2-41f9-b545-b476562881c6.jpg?1",
             "name": "Face of Divinity",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nAs long as another Aura is attached to enchanted creature, it has first strike and lifelink.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "0c26c14a-ff7c-5969-bf28-57dd9ccf5928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5c4368-4f2e-4f5f-8944-8b0d49ab3e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5c4368-4f2e-4f5f-8944-8b0d49ab3e38.jpg?1",
             "name": "First Sliver's Chosen",
             "text": "Sliver creatures you control have exalted. (Whenever a creature you control attacks alone, it gets +1/+1 until end of turn for each instance of exalted among permanents you control.)",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "6f951fbf-d74d-5b55-9711-c07a9d010ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9736d6f4-5ff6-4006-b45d-8e630382d160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9736d6f4-5ff6-4006-b45d-8e630382d160.jpg?1",
             "name": "Force of Virtue",
             "text": "If it's not your turn, you may exile a white card from your hand rather than pay this spell's mana cost.\nFlash\nCreatures you control get +1/+1.",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "70bfcc81-2397-5bca-b699-9979ff4e751a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f4711-20a8-4023-8201-9a74deab10be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f4711-20a8-4023-8201-9a74deab10be.jpg?1",
             "name": "Generous Gift",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Elephant creature token.",
             "colours": [
@@ -369,7 +369,7 @@
         },
         {
             "id": "6d901cda-edd6-5d60-8499-b08aa35a4464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff59aa2-5e97-4e6c-b568-470ac2371bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff59aa2-5e97-4e6c-b568-470ac2371bd7.jpg?1",
             "name": "Gilded Light",
             "text": "You gain shroud until end of turn. (You can't be the target of spells or abilities.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -401,7 +401,7 @@
         },
         {
             "id": "1142eab0-65e4-5dcd-b05d-28f6f5115b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e117771-5a8b-4812-b487-32ba34b7f724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e117771-5a8b-4812-b487-32ba34b7f724.jpg?1",
             "name": "Giver of Runes",
             "text": "{T}: Another target creature you control gains protection from colorless or from the color of your choice until end of turn.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "083e0561-f36a-5b98-b427-1fdc6d1f0ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83298c8a-02c4-4ada-9a41-4b973bb58ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83298c8a-02c4-4ada-9a41-4b973bb58ac6.jpg?1",
             "name": "Impostor of the Sixth Pride",
             "text": "Changeling (This card is every creature type.)",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "5bd742b5-c9c1-5942-a868-8a791ef99348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c46961-cf1a-4f20-83aa-3d256db2388f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c46961-cf1a-4f20-83aa-3d256db2388f.jpg?1",
             "name": "Irregular Cohort",
             "text": "Changeling (This card is every creature type.)\nWhen Irregular Cohort enters the battlefield, create a 2/2 colorless Shapeshifter creature token with changeling.",
             "colours": [
@@ -504,7 +504,7 @@
         },
         {
             "id": "8b767836-5dc3-56d7-9d30-45efd3492dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e83abd-6f15-491e-9253-90af9f6f1025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e83abd-6f15-491e-9253-90af9f6f1025.jpg?1",
             "name": "King of the Pride",
             "text": "Other Cats you control get +2/+1.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "85ca3985-2e6d-57b8-babd-0e3715b13a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d919fc0-0117-4dad-a368-e76b216cdd2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d919fc0-0117-4dad-a368-e76b216cdd2a.jpg?1",
             "name": "Knight of Old Benalia",
             "text": "Suspend 5\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)\nWhen Knight of Old Benalia enters the battlefield, other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "01bf4315-ca1c-5318-860d-44ef3c06fabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f8d9a-3760-449e-b8a6-72b2a641ff23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f8d9a-3760-449e-b8a6-72b2a641ff23.jpg?1",
             "name": "Lancer Sliver",
             "text": "Sliver creatures you control have first strike.",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "7bdc464b-5c06-5cb6-a2e1-3fa34a8b8005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17428c-e31d-42f3-8811-6734abd96b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17428c-e31d-42f3-8811-6734abd96b0b.jpg?1",
             "name": "Martyr's Soul",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Martyr's Soul enters the battlefield, if you control no tapped lands, put two +1/+1 counters on it.",
             "colours": [
@@ -642,7 +642,7 @@
         },
         {
             "id": "db8381e4-12c5-504d-8e10-90f36f2617f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d4f6b0-ea17-4374-a80c-ba4dd207e9d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d4f6b0-ea17-4374-a80c-ba4dd207e9d6.jpg?1",
             "name": "On Thin Ice",
             "text": "Enchant snow land you control\nWhen On Thin Ice enters the battlefield, exile target creature an opponent controls until On Thin Ice leaves the battlefield.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "1281ba11-7337-5e8f-8ef3-13a839c54239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3928b4-813a-4120-8799-de34235d60ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3928b4-813a-4120-8799-de34235d60ac.jpg?1",
             "name": "Ranger-Captain of Eos",
             "text": "When Ranger-Captain of Eos enters the battlefield, you may search your library for a creature card with converted mana cost 1 or less, reveal it, put it into your hand, then shuffle your library.\nSacrifice Ranger-Captain of Eos: Your opponents can't cast noncreature spells this turn.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "be828a72-5356-5aaa-a131-6cac0da61c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb025c0c-7fdf-4f71-afd5-ef11cd2804eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb025c0c-7fdf-4f71-afd5-ef11cd2804eb.jpg?1",
             "name": "Recruit the Worthy",
             "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreate a 1/1 white Soldier creature token.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "dd605264-128a-5af2-9b41-5fe1134753a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1349c3d-39ad-40ba-897e-59e5b76de853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1349c3d-39ad-40ba-897e-59e5b76de853.jpg?1",
             "name": "Reprobation",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a Coward creature with base power and toughness 0/1. (It keeps all supertypes but loses all other types and creature types.)",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "5e25efe7-aad4-5fd8-baae-8742c29697e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6384e266-d0dc-4af1-b3ab-ecaf9be2553c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6384e266-d0dc-4af1-b3ab-ecaf9be2553c.jpg?1",
             "name": "Rhox Veteran",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhenever Rhox Veteran attacks, tap target creature an opponent controls.",
             "colours": [
@@ -815,7 +815,7 @@
         },
         {
             "id": "9050ec4e-4f7a-507e-b2a4-fc2fa620c80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbaec5-502d-48c2-9e71-c12cd0bccc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5dbaec5-502d-48c2-9e71-c12cd0bccc6a.jpg?1",
             "name": "Segovian Angel",
             "text": "Flying, vigilance",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "d6a2e961-dd91-5ae0-97c9-9e1e1fb8255c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf4af9-4b14-43e7-9d50-0e6a895cece1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bf4af9-4b14-43e7-9d50-0e6a895cece1.jpg?1",
             "name": "Serra the Benevolent",
             "text": "+2: Creatures you control with flying get +1/+1 until end of turn.\n\u22123: Create a 4/4 white Angel creature token with flying and vigilance.\n\u22126: You get an emblem with \"If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.\"",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "7e777eb6-0be7-5a93-8fca-518a7980aabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ed8e57-61bb-4e89-9484-ff2be800a449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ed8e57-61bb-4e89-9484-ff2be800a449.jpg?1",
             "name": "Settle Beyond Reality",
             "text": "Choose one or both \u2014\n\u2022 Exile target creature you don't control.\n\u2022 Exile target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "9fbf10c4-92ec-50dc-a13b-341c713edd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a50984b-5bf5-4432-a149-96492d1683de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a50984b-5bf5-4432-a149-96492d1683de.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "7c02548c-e041-5642-852a-942da1d7f5f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a293c45-1e73-4527-be2f-2dcd5c47b610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a293c45-1e73-4527-be2f-2dcd5c47b610.jpg?1",
             "name": "Sisay, Weatherlight Captain",
             "text": "Sisay, Weatherlight Captain gets +1/+1 for each color among other legendary permanents you control.\n{W}{U}{B}{R}{G}: Search your library for a legendary permanent card with converted mana cost less than Sisay's power, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -990,7 +990,7 @@
         },
         {
             "id": "e7cdcc00-86f6-5e50-ad08-4439d4044b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ab5f70-8f69-467f-9fa5-f69181edcb80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ab5f70-8f69-467f-9fa5-f69181edcb80.jpg?1",
             "name": "Soul-Strike Technique",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has vigilance.\nWhen enchanted creature dies, manifest the top card of your library. (Put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "77948998-dc98-5cca-b185-de27b458775c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59dfb0f-45c7-431f-b5a3-d9b429fc6dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59dfb0f-45c7-431f-b5a3-d9b429fc6dde.jpg?1",
             "name": "Splicer's Skill",
             "text": "Create a 3/3 colorless Golem artifact creature token.\nSplice onto instant or sorcery {3}{W} (As you cast an instant or sorcery spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "7efec06e-1f43-5f6c-aa24-c82ee95ba32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de3e3b0-6ecf-4bf6-9595-0e5e59ef1d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de3e3b0-6ecf-4bf6-9595-0e5e59ef1d6a.jpg?1",
             "name": "Stirring Address",
             "text": "Target creature you control gets +2/+2 until end of turn.\nOverload {5}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "a61c48a7-0a79-5b14-846c-3cd429a18a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65f118-3812-4698-8f43-669ceb6b7982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65f118-3812-4698-8f43-669ceb6b7982.jpg?1",
             "name": "Trustworthy Scout",
             "text": "{1}{W}, Exile Trustworthy Scout from your graveyard: Search your library for a card named Trustworthy Scout, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "cee731fd-1c44-5a9e-9a7c-339bc25dde37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9fadff-a506-4546-b994-71e9e971b44e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9fadff-a506-4546-b994-71e9e971b44e.jpg?1",
             "name": "Valiant Changeling",
             "text": "This spell costs {1} less to cast for each creature type among creatures you control. This effect can't reduce the amount of mana this spell costs by more than {5}.\nChangeling (This card is every creature type.)\nDouble strike",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "449b04a8-34ec-503e-9444-10b5e8b20de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32776159-3fb6-4a70-be84-837ccd1d54a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32776159-3fb6-4a70-be84-837ccd1d54a7.jpg?1",
             "name": "Vesperlark",
             "text": "Flying\nWhen Vesperlark leaves the battlefield, return target creature card with power 1 or less from your graveyard to the battlefield.\nEvoke {1}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "577256ff-2ac5-5ff9-a561-832db3b6c02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e5388a-1c1e-4809-99d0-bbdd93436c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e5388a-1c1e-4809-99d0-bbdd93436c5e.jpg?1",
             "name": "Wall of One Thousand Cuts",
             "text": "Defender, flying\n{W}: Wall of One Thousand Cuts can attack this turn as though it didn't have defender.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "9f66a541-2444-5c32-8c46-a2c757b4a74f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb17913-fe4d-4acd-9b75-71f5a90f898b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb17913-fe4d-4acd-9b75-71f5a90f898b.jpg?1",
             "name": "Winds of Abandon",
             "text": "Exile target creature you don't control. For each creature exiled this way, its controller searches their library for a basic land card. Those players put those cards onto the battlefield tapped, then shuffle their libraries.\nOverload {4}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "5ec483c8-3f56-5914-bcba-6f255d4bf270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8326bd2-83a8-4600-b12a-0bda47168f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8326bd2-83a8-4600-b12a-0bda47168f7b.jpg?1",
             "name": "Wing Shards",
             "text": "Target player sacrifices an attacking creature.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "bdb89c18-7a83-5e7d-8f73-432cdd3ef487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b824c-414d-4dd5-848f-bff678a289ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b824c-414d-4dd5-848f-bff678a289ba.jpg?1",
             "name": "Zhalfirin Decoy",
             "text": "{T}: Tap target creature. Activate this ability only if you had a creature enter the battlefield under your control this turn.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "4d2be325-dab5-5a47-855b-abf8e668bcfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b852b6-4388-4a41-a5c0-bba37a5c1451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b852b6-4388-4a41-a5c0-bba37a5c1451.jpg?1",
             "name": "Archmage's Charm",
             "text": "Choose one \u2014\n\u2022 Counter target spell.\n\u2022 Target player draws two cards.\n\u2022 Gain control of target nonland permanent with converted mana cost 1 or less.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "5545bb18-2684-55e7-b28e-6e942769d633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1",
             "name": "Bazaar Trademage",
             "text": "Flying\nWhen Bazaar Trademage enters the battlefield, draw two cards, then discard three cards.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "9b681af1-d399-56bb-8d6a-a1dc4dda9754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dfa26-d3ad-4fe8-9db4-ddd753a4b679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dfa26-d3ad-4fe8-9db4-ddd753a4b679.jpg?1",
             "name": "Blizzard Strix",
             "text": "Flash\nFlying\nWhen Blizzard Strix enters the battlefield, if you control another snow permanent, exile target permanent other than Blizzard Strix. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "61a91e1b-3a05-55b8-a085-4df74a2e9406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f57005c-414d-4c83-9b4f-cd26e547d54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f57005c-414d-4c83-9b4f-cd26e547d54d.jpg?1",
             "name": "Chillerpillar",
             "text": "{4}{S}{S}: Monstrosity 2. (If this creature isn't monstrous, put two +1/+1 counters on it and it becomes monstrous. {S} can be paid with one mana from a snow permanent.)\nAs long as Chillerpillar is monstrous, it has flying.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "8795b044-854d-5344-af3d-32f00373028a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0d0c81-8698-41db-a687-47af028e910e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0d0c81-8698-41db-a687-47af028e910e.jpg?1",
             "name": "Choking Tethers",
             "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "29fcf4e8-6602-5d4a-95fd-c9a8df481fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300a431c-48a9-4d63-8256-cb6bdaa67b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300a431c-48a9-4d63-8256-cb6bdaa67b4c.jpg?1",
             "name": "Cunning Evasion",
             "text": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "4157b29a-afa4-50c8-8705-30dce1564d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff590af2-2d6c-4f16-a9b8-1a6dab6e9ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff590af2-2d6c-4f16-a9b8-1a6dab6e9ad5.jpg?1",
             "name": "Echo of Eons",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "3c694226-9983-51dc-aa1c-f5482caefeb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744c42c-6bcc-42c0-9346-102b8368c377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e744c42c-6bcc-42c0-9346-102b8368c377.jpg?1",
             "name": "Everdream",
             "text": "Draw a card.\nSplice onto instant or sorcery {2}{U} (As you cast an instant or sorcery spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "9e6b9d3f-de43-57cc-b045-1d930f939167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ffa65-542f-4b83-9fcb-d3384b74633c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ffa65-542f-4b83-9fcb-d3384b74633c.jpg?1",
             "name": "Exclude",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "a677ada9-8a7f-52d6-8e8f-c214c307229f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7bda8-949a-42aa-9254-f39b791cb9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7bda8-949a-42aa-9254-f39b791cb9a8.jpg?1",
             "name": "Eyekite",
             "text": "Flying\nEyekite gets +2/+0 as long as you've drawn two or more cards this turn.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "8a6a7227-2977-5928-adaf-f09659f16d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d51a2b-450c-4e6d-a660-67d58d1dd4ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d51a2b-450c-4e6d-a660-67d58d1dd4ba.jpg?1",
             "name": "Fact or Fiction",
             "text": "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "57ef3008-8f5b-56d5-8848-5af821fa3cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg?1",
             "name": "Faerie Seer",
             "text": "Flying\nWhen Faerie Seer enters the battlefield, scry 2.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "9e4849c5-fd8e-523b-829d-6445471867e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be371c-c688-44ad-ab71-bd4c9f242d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9be371c-c688-44ad-ab71-bd4c9f242d58.jpg?1",
             "name": "Force of Negation",
             "text": "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1756,7 +1756,7 @@
         },
         {
             "id": "d7acd526-125a-5bb5-af2d-e39ae9ef4e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639cb483-ffe2-4abc-a050-5cdc8aebd5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639cb483-ffe2-4abc-a050-5cdc8aebd5a2.jpg?1",
             "name": "Future Sight",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "bc8c654b-0e11-5b76-ab2e-95528773ef27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1444-a609-4c23-935d-fa25aef16179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84b1444-a609-4c23-935d-fa25aef16179.jpg?1",
             "name": "Iceberg Cancrix",
             "text": "Whenever another snow permanent enters the battlefield under your control, you may have target player put the top two cards of their library into their graveyard.",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "14d89315-826f-5abd-896f-aa5bb332c2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa4199-df9b-494a-af7a-2491e8b0ef70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eaa4199-df9b-494a-af7a-2491e8b0ef70.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "5ec9eb79-f5c4-5497-90b6-11c4b151668d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5d2a6e-22cd-4493-9e58-e9c2aa3a31ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5d2a6e-22cd-4493-9e58-e9c2aa3a31ab.jpg?1",
             "name": "Marit Lage's Slumber",
             "text": "Whenever Marit Lage's Slumber or another snow permanent enters the battlefield under your control, scry 1.\nAt the beginning of your upkeep, if you control ten or more snow permanents, sacrifice Marit Lage's Slumber. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "0ebdbff9-e756-511f-a17d-43951169d0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8423d8d-744a-4bbe-a853-8ad756451bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8423d8d-744a-4bbe-a853-8ad756451bdb.jpg?1",
             "name": "Mirrodin Besieged",
             "text": "As Mirrodin Besieged enters the battlefield, choose Mirran or Phyrexian.\n\u2022 Mirran \u2014 Whenever you cast an artifact spell, create a 1/1 colorless Myr artifact creature token.\n\u2022 Phyrexian \u2014 At the beginning of your end step, draw a card, then discard a card. Then if there are fifteen or more artifact cards in your graveyard, target opponent loses the game.",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "2ba3549e-249d-5b97-a420-aea6e8a3dfda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c8f074-e260-4f8e-85d1-1904ca928b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c8f074-e260-4f8e-85d1-1904ca928b51.jpg?1",
             "name": "Mist-Syndicate Naga",
             "text": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Mist-Syndicate Naga deals combat damage to a player, create a token that's a copy of Mist-Syndicate Naga.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "90ffebd3-e13e-5fc0-8e40-6eb18e5bd22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ab7f30-ca75-4656-9738-1d965f18a22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ab7f30-ca75-4656-9738-1d965f18a22d.jpg?1",
             "name": "Moonblade Shinobi",
             "text": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Moonblade Shinobi deals combat damage to a player, create a 1/1 blue Illusion creature token with flying.",
             "colours": [
@@ -1995,7 +1995,7 @@
         },
         {
             "id": "21f33421-e7e1-5a0b-ae96-9aedd5273917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caefbac6-b2a0-4a70-a912-25173eafd7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caefbac6-b2a0-4a70-a912-25173eafd7b3.jpg?1",
             "name": "Oneirophage",
             "text": "Flying\nWhenever you draw a card, put a +1/+1 counter on Oneirophage.",
             "colours": [
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "b6d9219f-ed2e-5bbf-8676-bf453db7b6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f106e515-511a-48c7-b7a7-3ca820950122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f106e515-511a-48c7-b7a7-3ca820950122.jpg?1",
             "name": "Phantasmal Form",
             "text": "Until end of turn, up to two target creatures each have base power and toughness 3/3, gain flying, and become blue Illusions in addition to their other colors and types.\nDraw a card.",
             "colours": [
@@ -2062,7 +2062,7 @@
         },
         {
             "id": "794c8e4c-dce6-5557-a6ab-8a31f80b8538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392b557-e809-4371-92d7-6e93caed4f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392b557-e809-4371-92d7-6e93caed4f1b.jpg?1",
             "name": "Phantom Ninja",
             "text": "Phantom Ninja can't be blocked.",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "7e5246f0-05e2-589e-a5cb-1eb0330efed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08c5ac8-5c0b-4c89-8f06-e5aadfccee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08c5ac8-5c0b-4c89-8f06-e5aadfccee01.jpg?1",
             "name": "Pondering Mage",
             "text": "When Pondering Mage enters the battlefield, look at the top three cards of your library, then put them back in any order. You may shuffle your library. Draw a card.",
             "colours": [
@@ -2132,7 +2132,7 @@
         },
         {
             "id": "bc065b64-735e-558e-91ca-409bd1482211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae544bf-7229-4b82-99ad-32c3af36e30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae544bf-7229-4b82-99ad-32c3af36e30f.jpg?1",
             "name": "Prohibit",
             "text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nCounter target spell if its converted mana cost is 2 or less. If this spell was kicked, counter that spell if its converted mana cost is 4 or less instead.",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "d8fdd084-dfd6-5777-9fd1-8e8bbf7aca20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42230b38-c81a-4d76-ad17-1166f5f62312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42230b38-c81a-4d76-ad17-1166f5f62312.jpg?1",
             "name": "Rain of Revelation",
             "text": "Draw three cards, then discard a card.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "c7f91972-6df9-59a3-9c46-7ae6e835415b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd683b0b-1ac1-4fa7-9657-d3b29db2ae51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd683b0b-1ac1-4fa7-9657-d3b29db2ae51.jpg?1",
             "name": "Rebuild",
             "text": "Return all artifacts to their owners' hands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "407360b3-d2ed-59a0-8b93-cb7695f33711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6466cb-d1d0-4461-b48d-7497bdc9c474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6466cb-d1d0-4461-b48d-7497bdc9c474.jpg?1",
             "name": "Scour All Possibilities",
             "text": "Scry 2, then draw a card.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "8e7a8561-08df-57d1-8ee6-4b54199298b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e63efe-b5ec-426e-8860-a881c495c39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e63efe-b5ec-426e-8860-a881c495c39e.jpg?1",
             "name": "Scuttling Sliver",
             "text": "Sliver creatures you control have \"{2}: Untap this creature.\"",
             "colours": [
@@ -2295,7 +2295,7 @@
         },
         {
             "id": "fdce3e84-8726-532f-addc-73632a86f70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c876e-ae1c-4b54-8d8a-9f3fd76ca64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c876e-ae1c-4b54-8d8a-9f3fd76ca64c.jpg?1",
             "name": "Smoke Shroud",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nWhen a Ninja enters the battlefield under your control, you may return Smoke Shroud from your graveyard to the battlefield attached to that creature.",
             "colours": [
@@ -2329,7 +2329,7 @@
         },
         {
             "id": "04328cef-e6ac-5a8c-8cd9-75079103a8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efadce19-07f4-47af-abc0-a436bafcdd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efadce19-07f4-47af-abc0-a436bafcdd65.jpg?1",
             "name": "Spell Snuff",
             "text": "Counter target spell.\nFateful hour \u2014 If you have 5 or less life, draw a card.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "337f4bba-b255-563a-9d27-25eb09cec31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b75bef5-a039-4edf-8e43-56b8d089605e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b75bef5-a039-4edf-8e43-56b8d089605e.jpg?1",
             "name": "Stream of Thought",
             "text": "Target player puts the top four cards of their library into their graveyard. You shuffle up to four cards from your graveyard into your library.\nReplicate {2}{U}{U} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)",
             "colours": [
@@ -2393,7 +2393,7 @@
         },
         {
             "id": "cb605bce-c626-5971-859c-24b025a2caea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ef4f41-211c-4302-b112-1d85ab33952f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ef4f41-211c-4302-b112-1d85ab33952f.jpg?1",
             "name": "String of Disappearances",
             "text": "Return target creature to its owner's hand. Then that creature's controller may pay {U}{U}. If the player does, they may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "62aeb473-b062-5399-aaf8-dcafc670c078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c180888-6acd-401b-815a-6ed434482681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c180888-6acd-401b-815a-6ed434482681.jpg?1",
             "name": "Tribute Mage",
             "text": "When Tribute Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 2, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2460,7 +2460,7 @@
         },
         {
             "id": "eec53509-aea8-5619-b4f8-ac890b599725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4d408-df74-45f7-925b-3cbff9a0304c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4d408-df74-45f7-925b-3cbff9a0304c.jpg?1",
             "name": "Twisted Reflection",
             "text": "Choose one \u2014\n\u2022 Target creature gets -6/-0 until end of turn.\n\u2022 Switch target creature's power and toughness until end of turn.\nEntwine {B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "d9d11455-6b40-5b67-8b4b-08a8fab793db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fb3c0-5159-4d1f-8490-ce4c9a60f567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7fb3c0-5159-4d1f-8490-ce4c9a60f567.jpg?1",
             "name": "Urza, Lord High Artificer",
             "text": "When Urza, Lord High Artificer enters the battlefield, create a 0/0 colorless Construct artifact creature token with \"This creature gets +1/+1 for each artifact you control.\"\nTap an untapped artifact you control: Add {U}.\n{5}: Shuffle your library, then exile the top card. Until end of turn, you may play that card without paying its mana cost.",
             "colours": [
@@ -2530,7 +2530,7 @@
         },
         {
             "id": "a195ca9c-d782-5b9c-ad1b-2dae1deb6522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f01a3c-0a66-48da-a7d2-46260e3b721f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f01a3c-0a66-48da-a7d2-46260e3b721f.jpg?1",
             "name": "Watcher for Tomorrow",
             "text": "Hideaway (This creature enters the battlefield tapped. When it does, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library.)\nWhen Watcher for Tomorrow leaves the battlefield, put the exiled card into its owner's hand.",
             "colours": [
@@ -2565,7 +2565,7 @@
         },
         {
             "id": "4670c73c-252f-599b-af51-066fe3630788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d26568-be8f-4a04-82b6-4c37b55d4cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d26568-be8f-4a04-82b6-4c37b55d4cfd.jpg?1",
             "name": "Windcaller Aven",
             "text": "Flying\nCycling {U} ({U}, Discard this card: Draw a card.)\nWhen you cycle Windcaller Aven, target creature gains flying until end of turn.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "a9b11422-ad1f-5fec-84dd-0c41951f0999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdaf6b6-aca7-49e5-a4da-bf8c08b4a055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdaf6b6-aca7-49e5-a4da-bf8c08b4a055.jpg?1",
             "name": "Winter's Rest",
             "text": "Enchant creature\nWhen Winter's Rest enters the battlefield, tap enchanted creature.\nAs long as you control another snow permanent, enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2636,7 +2636,7 @@
         },
         {
             "id": "8eee2fa0-66e8-5981-ae1d-dc245a7289de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f627e521-2b8f-4d0f-a9d3-cc4e331ce57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f627e521-2b8f-4d0f-a9d3-cc4e331ce57d.jpg?1",
             "name": "Azra Smokeshaper",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen Azra Smokeshaper enters the battlefield, target creature you control gains indestructible until end of turn.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "be5c7f18-7cba-52ff-8e77-eccceff95605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa8f485-0f3d-4a0b-bcdf-6c27d1d2bce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa8f485-0f3d-4a0b-bcdf-6c27d1d2bce0.jpg?1",
             "name": "Cabal Therapist",
             "text": "Menace\nAt the beginning of your precombat main phase, you may sacrifice a creature. When you do, choose a nonland card name, then target player reveals their hand and discards all cards with that name.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "16765cc5-8ecf-5d31-a960-5819865e8fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19da90-880e-4eca-8cf7-6d7baf090d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19da90-880e-4eca-8cf7-6d7baf090d53.jpg?1",
             "name": "Carrion Feeder",
             "text": "Carrion Feeder can't block.\nSacrifice a creature: Put a +1/+1 counter on Carrion Feeder.",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "3aa0a1cc-e913-59ed-ab66-9bc08428b1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08151d00-513a-4957-aa16-01c0f0245112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08151d00-513a-4957-aa16-01c0f0245112.jpg?1",
             "name": "Changeling Outcast",
             "text": "Changeling (This card is every creature type.)\nChangeling Outcast can't block and can't be blocked.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "0c1fff15-c9fd-5568-a595-9d64d4798929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90a1c44-ee0f-4c12-bfaf-6f371bcce167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90a1c44-ee0f-4c12-bfaf-6f371bcce167.jpg?1",
             "name": "Cordial Vampire",
             "text": "Whenever Cordial Vampire or another creature dies, put a +1/+1 counter on each Vampire you control.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "c8399b4a-007c-5ef1-894e-ef3fef3d1124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96916db2-5121-4ff1-880c-369744f11ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96916db2-5121-4ff1-880c-369744f11ecf.jpg?1",
             "name": "Crypt Rats",
             "text": "{X}: Crypt Rats deals X damage to each creature and each player. Spend only black mana on X.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "09780323-a2ed-5755-a99a-626be76c6c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f480df6d-e227-4ccb-ad6d-a4ad48a360ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f480df6d-e227-4ccb-ad6d-a4ad48a360ad.jpg?1",
             "name": "Dead of Winter",
             "text": "All nonsnow creatures get -X/-X until end of turn, where X is the number of snow permanents you control.",
             "colours": [
@@ -2873,7 +2873,7 @@
         },
         {
             "id": "02660666-aca7-5372-8e9b-a478e14d30d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcb4398-edd1-41a7-a496-b12bce22ceb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcb4398-edd1-41a7-a496-b12bce22ceb6.jpg?1",
             "name": "Defile",
             "text": "Target creature gets -1/-1 until end of turn for each Swamp you control.",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "f0f4c52d-11de-51ec-9c54-b9de5d2a1f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eabbed2-1399-4cf1-9eba-b53c56caced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eabbed2-1399-4cf1-9eba-b53c56caced4.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "a1d84b30-1a98-50e5-a93e-62b37ea73555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a835b7e-cd63-486d-8b58-2f443f686e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a835b7e-cd63-486d-8b58-2f443f686e32.jpg?1",
             "name": "Dregscape Sliver",
             "text": "Each Sliver creature card in your graveyard has unearth {2}.\nUnearth {2} ({2}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2971,7 +2971,7 @@
         },
         {
             "id": "ce0bef32-9ba7-583f-8956-fec6bfa66de0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337b6047-3f8d-4530-9e45-b5ce397a2829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337b6047-3f8d-4530-9e45-b5ce397a2829.jpg?1",
             "name": "Endling",
             "text": "{B}: Endling gains menace until end of turn.\n{B}: Endling gains deathtouch until end of turn.\n{B}: Endling gains undying until end of turn. (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)\n{1}: Endling gets +1/-1 or -1/+1 until end of turn.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "80fee7ef-d6a9-5970-a7db-3d243e75b968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4472ad84-b548-4ed8-a315-ecf9ba9d49ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4472ad84-b548-4ed8-a315-ecf9ba9d49ff.jpg?1",
             "name": "Feaster of Fools",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nDevour 2 (As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with twice that many +1/+1 counters on it.)",
             "colours": [
@@ -3040,7 +3040,7 @@
         },
         {
             "id": "4eb52b3f-cd5c-5119-a4fb-cfda5feb06f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59f4e5c-fdc7-485f-aadb-2a71b3701dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59f4e5c-fdc7-485f-aadb-2a71b3701dcc.jpg?1",
             "name": "First-Sphere Gargantua",
             "text": "When First-Sphere Gargantua enters the battlefield, you draw a card and you lose 1 life.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "1a3e16a9-5272-5916-8211-cc939211efea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f497b0d-4448-4201-bd55-c147da1a216d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f497b0d-4448-4201-bd55-c147da1a216d.jpg?1",
             "name": "Force of Despair",
             "text": "If it's not your turn, you may exile a black card from your hand rather than pay this spell's mana cost.\nDestroy all creatures that entered the battlefield this turn.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "47a3ac67-cc2e-55f7-9601-409805189720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514ce0d-8d61-4cce-b2ad-8f417869d04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9514ce0d-8d61-4cce-b2ad-8f417869d04e.jpg?1",
             "name": "Gluttonous Slug",
             "text": "Menace\nEvolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3142,7 +3142,7 @@
         },
         {
             "id": "f14d46ff-58c5-5b31-9471-fa1c1be65e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128c516b-7eb1-4f81-8b54-428bd0649d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128c516b-7eb1-4f81-8b54-428bd0649d92.jpg?1",
             "name": "Graveshifter",
             "text": "Changeling (This card is every creature type.)\nWhen Graveshifter enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "2e1e08bb-4896-5ffe-924a-05114838623f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888b4b76-6af9-4479-8cfd-cde3b8694fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888b4b76-6af9-4479-8cfd-cde3b8694fe5.jpg?1",
             "name": "Headless Specter",
             "text": "Flying\nHellbent \u2014 Whenever Headless Specter deals combat damage to a player, if you have no cards in hand, that player discards a card at random.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "1d6e0a0f-9b28-5ac0-84c7-8e88a8938faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ccb0a-5e73-462e-a035-87d4dac59779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682ccb0a-5e73-462e-a035-87d4dac59779.jpg?1",
             "name": "Mind Rake",
             "text": "Target player discards two cards.\nOverload {1}{B} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "1bd21467-c325-546f-9318-7a1cdef54423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c216e13-3779-4734-b481-9aad7aba9925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c216e13-3779-4734-b481-9aad7aba9925.jpg?1",
             "name": "Mob",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "3f1295c5-b09a-5eb1-9bd2-ef5edee7c3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1f3e1-d986-4c0b-850e-5e8f2eaa0642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1f3e1-d986-4c0b-850e-5e8f2eaa0642.jpg?1",
             "name": "Nether Spirit",
             "text": "At the beginning of your upkeep, if Nether Spirit is the only creature card in your graveyard, you may return Nether Spirit to the battlefield.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "5d6bfc24-5a0a-542f-a754-e5cc5d7d7282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be60eb-15ec-4112-919c-995062a9ed54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be60eb-15ec-4112-919c-995062a9ed54.jpg?1",
             "name": "Ninja of the New Moon",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)",
             "colours": [
@@ -3343,7 +3343,7 @@
         },
         {
             "id": "cd20f4cc-912a-52d5-82ec-958b44f89ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f32b0e9-5eb2-4b26-8c06-5d4561f0295d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f32b0e9-5eb2-4b26-8c06-5d4561f0295d.jpg?1",
             "name": "Plague Engineer",
             "text": "Deathtouch\nAs Plague Engineer enters the battlefield, choose a creature type.\nCreatures of the chosen type your opponents control get -1/-1.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "42a0ce6e-53dc-5acb-86b7-4f134d2046f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333406d5-abcc-4629-a33b-395d0662ba1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333406d5-abcc-4629-a33b-395d0662ba1b.jpg?1",
             "name": "Putrid Goblin",
             "text": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "fb14fa55-29d8-574f-bc28-063c3d3d81f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a05edf6-ade4-4052-924d-6057faa51693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a05edf6-ade4-4052-924d-6057faa51693.jpg?1",
             "name": "Rank Officer",
             "text": "When Rank Officer enters the battlefield, you may discard a card. If you do, create a 2/2 black Zombie creature token.\n{1}{B}, {T}, Exile a creature card from your graveyard: Each opponent loses 2 life.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "03b00e5d-e96f-5be8-bb31-387a23579a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b547513d-8b69-41cd-84c9-4b08b6426f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b547513d-8b69-41cd-84c9-4b08b6426f1d.jpg?1",
             "name": "Ransack the Lab",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "359f84cf-4e79-57a1-a172-e7ebd7dce0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6db664e-f0c4-4e60-add7-89b9f210cbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6db664e-f0c4-4e60-add7-89b9f210cbc7.jpg?1",
             "name": "Return from Extinction",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return two target creature cards that share a creature type from your graveyard to your hand.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "e465962f-dea6-53b4-b34c-001c21c39af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64080d0d-163b-450d-8919-79a0465f3645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64080d0d-163b-450d-8919-79a0465f3645.jpg?1",
             "name": "Sadistic Obsession",
             "text": "Enchant creature\nEnchanted creature has \"{B}, {T}: Put a -1/-1 counter on target creature.\"",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "2f68d0a9-2f6b-5d92-93c1-269730f4d093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f224f64-513f-4c01-9b1b-bb89e366f1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f224f64-513f-4c01-9b1b-bb89e366f1c4.jpg?1",
             "name": "Shatter Assumptions",
             "text": "Choose one \u2014\n\u2022 Target opponent reveals their hand and discards all colorless nonland cards.\n\u2022 Target opponent reveals their hand and discards all multicolored cards.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "aa3a3b85-74f0-5e00-9d82-50ec4da29613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c37d70-799d-464a-972c-11a78ae31272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c37d70-799d-464a-972c-11a78ae31272.jpg?1",
             "name": "Silumgar Scavenger",
             "text": "Flying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhenever another creature you control dies, put a +1/+1 counter on Silumgar Scavenger. It gains haste until end of turn if it exploited that creature.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "7edee90d-2ed7-5f60-b2b9-f60a4307e630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82aec21-441b-4fcd-b666-61723bd79531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82aec21-441b-4fcd-b666-61723bd79531.jpg?1",
             "name": "Sling-Gang Lieutenant",
             "text": "When Sling-Gang Lieutenant enters the battlefield, create two 1/1 red Goblin creature tokens.\nSacrifice a Goblin: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3647,7 +3647,7 @@
         },
         {
             "id": "29b73da6-2bb7-567f-8214-9be5276e909f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa3e132-125a-492f-aab7-c560ea36b779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa3e132-125a-492f-aab7-c560ea36b779.jpg?1",
             "name": "Smiting Helix",
             "text": "Smiting Helix deals 3 damage to any target and you gain 3 life.\nFlashback {R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3681,7 +3681,7 @@
         },
         {
             "id": "4a38a9df-9dcb-5a6b-b2b1-37f1d251dd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07b3736-25e7-46f2-bea5-543ec13995b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07b3736-25e7-46f2-bea5-543ec13995b1.jpg?1",
             "name": "Throatseeker",
             "text": "Unblocked attacking Ninjas you control have lifelink.",
             "colours": [
@@ -3716,7 +3716,7 @@
         },
         {
             "id": "d63132d6-b995-52db-8879-6e75ebbad4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbb742-0317-4266-bcf5-cfea8d21f108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbb742-0317-4266-bcf5-cfea8d21f108.jpg?1",
             "name": "Umezawa's Charm",
             "text": "Choose one \u2014\n\u2022 Target creature gets +2/+2 until end of turn.\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 You gain 2 life.",
             "colours": [
@@ -3748,7 +3748,7 @@
         },
         {
             "id": "a31a30f1-f300-5b9f-aa0b-edb4e7ccada8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3049e-9397-4bef-914b-e9664661419c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e3049e-9397-4bef-914b-e9664661419c.jpg?1",
             "name": "Undead Augur",
             "text": "Whenever Undead Augur or another Zombie you control dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "bf4feb3e-b558-5217-bea2-c4450b1cc27d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62abd0c-ec3e-45d7-989d-da269812aeef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62abd0c-ec3e-45d7-989d-da269812aeef.jpg?1",
             "name": "Unearth",
             "text": "Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "f3dddb73-8f41-5026-af95-4119337ae836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a1d73-d102-469b-82ca-ec18f616375e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5a1d73-d102-469b-82ca-ec18f616375e.jpg?1",
             "name": "Venomous Changeling",
             "text": "Changeling (This card is every creature type.)\nDeathtouch",
             "colours": [
@@ -3849,7 +3849,7 @@
         },
         {
             "id": "6ced6272-7077-539b-9401-5944d8b92255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d4dd61-cc7e-4fc5-afce-73a4b326cfdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d4dd61-cc7e-4fc5-afce-73a4b326cfdb.jpg?1",
             "name": "Warteye Witch",
             "text": "Whenever Warteye Witch or another creature you control dies, scry 1.",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "af7df0aa-b3a1-54ea-a1e6-881d1aa8663a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690cbcc-f8fd-41f7-9e28-e61c12b04014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8690cbcc-f8fd-41f7-9e28-e61c12b04014.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "ff8c65bc-90f9-5347-abfb-8716dab1d846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54423c1-ebea-4b5c-b563-1d14c104eb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54423c1-ebea-4b5c-b563-1d14c104eb91.jpg?1",
             "name": "Alpine Guide",
             "text": "When Alpine Guide enters the battlefield, you may search your library for a Mountain card, put that card onto the battlefield tapped, then shuffle your library.\nAlpine Guide attacks each combat if able.\nWhen Alpine Guide leaves the battlefield, sacrifice a Mountain.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "5c67b1c5-b9aa-5eeb-b400-de9f955eafd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a96eb1-f87c-4b1d-82c7-f239bcbc62b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a96eb1-f87c-4b1d-82c7-f239bcbc62b8.jpg?1",
             "name": "Aria of Flame",
             "text": "When Aria of Flame enters the battlefield, each opponent gains 10 life.\nWhenever you cast an instant or sorcery spell, put a verse counter on Aria of Flame, then it deals damage equal to the number of verse counters on it to target player or planeswalker.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "88b101c7-90b2-528d-bc2e-a6fbd5a4a22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7066c9ab-9420-46f9-a6c7-ce4d5273e2fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7066c9ab-9420-46f9-a6c7-ce4d5273e2fa.jpg?1",
             "name": "Bladeback Sliver",
             "text": "Hellbent \u2014 As long as you have no cards in hand, Sliver creatures you control have \"{T}: This creature deals 1 damage to target player or planeswalker.\"",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "3f1e2733-bf77-5c0a-b801-4f862b903af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb81f44-8f22-4d28-a452-a50bef69a3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb81f44-8f22-4d28-a452-a50bef69a3e3.jpg?1",
             "name": "Bogardan Dragonheart",
             "text": "Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.",
             "colours": [
@@ -4059,7 +4059,7 @@
         },
         {
             "id": "cba431dc-f8fe-5719-a0ad-abeec2b3ac5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b657f0-6636-4d8a-9176-81027816e0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b657f0-6636-4d8a-9176-81027816e0ec.jpg?1",
             "name": "Cleaving Sliver",
             "text": "Sliver creatures you control get +2/+0.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "701ccf86-db93-5492-b9bb-b2093e2fd123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b8f98-ee51-4c94-a3eb-c79eb2b50d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882b8f98-ee51-4c94-a3eb-c79eb2b50d78.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to any target.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "79c86f85-a790-5cfa-a796-fd0096c6aa23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3c0d8-0a3e-43b0-b81e-a3d22ce6a4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3c0d8-0a3e-43b0-b81e-a3d22ce6a4b2.jpg?1",
             "name": "Fists of Flame",
             "text": "Draw a card. Until end of turn, target creature gains trample and gets +1/+0 for each card you've drawn this turn.",
             "colours": [
@@ -4157,7 +4157,7 @@
         },
         {
             "id": "1487e6a5-e384-5475-a5b8-007ab33996ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa2d10-3725-4b3a-94fe-3c6648db9a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa2d10-3725-4b3a-94fe-3c6648db9a2a.jpg?1",
             "name": "Force of Rage",
             "text": "If it's not your turn, you may exile a red card from your hand rather than pay this spell's mana cost.\nCreate two 3/1 red Elemental creature tokens with trample and haste. Sacrifice those tokens at the beginning of your next upkeep.",
             "colours": [
@@ -4189,7 +4189,7 @@
         },
         {
             "id": "bfe60f2c-9d7b-57e7-8874-38832aaef00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b67031-76b8-4511-a6dc-433d9450496e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b67031-76b8-4511-a6dc-433d9450496e.jpg?1",
             "name": "Geomancer's Gambit",
             "text": "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle their library.\nDraw a card.",
             "colours": [
@@ -4221,7 +4221,7 @@
         },
         {
             "id": "78fd346b-0ba8-596f-9917-a5d576f4b831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d4928-e976-4c7c-ba09-cce95d1797b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d4928-e976-4c7c-ba09-cce95d1797b2.jpg?1",
             "name": "Goatnap",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If that creature is a Goat, it also gets +3/+0 until end of turn.",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "68ef70e2-d4dd-593d-b03b-6c50e542f422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543660a-6797-4719-bbe7-ff6e40709599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543660a-6797-4719-bbe7-ff6e40709599.jpg?1",
             "name": "Goblin Champion",
             "text": "Haste\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "89e56452-be00-5008-b088-189fbba2ec6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c4d47-5252-40af-961d-c08bc688028a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c4d47-5252-40af-961d-c08bc688028a.jpg?1",
             "name": "Goblin Engineer",
             "text": "When Goblin Engineer enters the battlefield, you may search your library for an artifact card, put it into your graveyard, then shuffle your library.\n{R}, {T}, Sacrifice an artifact: Return target artifact card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "6584eb09-166f-5759-95b9-a826ca9b33bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092e6db-1196-43bf-b7c9-07498fa7ca90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2092e6db-1196-43bf-b7c9-07498fa7ca90.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "b6e664da-c469-5116-814e-eadf0f1188c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ec7cbe-16a0-4dbb-91fe-7e445a5268c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ec7cbe-16a0-4dbb-91fe-7e445a5268c8.jpg?1",
             "name": "Goblin Oriflamme",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [
@@ -4389,7 +4389,7 @@
         },
         {
             "id": "783d45c3-d2d3-55bf-b9ff-05185294c74c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4155d1-0a87-4d2c-a1a0-06b2553eaae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4155d1-0a87-4d2c-a1a0-06b2553eaae4.jpg?1",
             "name": "Goblin War Party",
             "text": "Choose one \u2014\n\u2022 Create three 1/1 red Goblin creature tokens.\n\u2022 Creatures you control get +1/+1 and gain haste until end of turn.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "f4dbe19d-ffde-5991-bc45-c83245365258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f05b162-90aa-4c95-903f-775a17d20359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f05b162-90aa-4c95-903f-775a17d20359.jpg?1",
             "name": "Hollowhead Sliver",
             "text": "Sliver creatures you control have \"{T}, Discard a card: Draw a card.\"",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "58f2e1da-9796-5750-b5e1-75dcb59db63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf524-5322-4287-ac49-face12655874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf524-5322-4287-ac49-face12655874.jpg?1",
             "name": "Igneous Elemental",
             "text": "This spell costs {2} less to cast if there is a land card in your graveyard.\nWhen Igneous Elemental enters the battlefield, you may have it deal 2 damage to target creature.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "223dc54a-32f3-5b9e-91ba-7c3d6aa6cd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16dd041-451d-4914-8c46-aa315a90d802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16dd041-451d-4914-8c46-aa315a90d802.jpg?1",
             "name": "Lava Dart",
             "text": "Lava Dart deals 1 damage to any target.\nFlashback\u2014\nSacrifice a Mountain. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "8d06f8df-2bc8-5662-ab54-fcde5b632e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db1674-d72b-4c1f-b436-490e5363bee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db1674-d72b-4c1f-b436-490e5363bee7.jpg?1",
             "name": "Magmatic Sinkhole",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nMagmatic Sinkhole deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "50a9c918-b886-5ade-b964-bc683ab8d800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea32e5-b164-4a8d-9312-c35ae5cd8b2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ea32e5-b164-4a8d-9312-c35ae5cd8b2a.jpg?1",
             "name": "Orcish Hellraiser",
             "text": "Echo {R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Orcish Hellraiser dies, it deals 2 damage to target player or planeswalker.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "15dcea20-41fd-5658-a651-4c9d817e76b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789333b-21ee-4613-8eba-52a719b0f1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e789333b-21ee-4613-8eba-52a719b0f1e5.jpg?1",
             "name": "Ore-Scale Guardian",
             "text": "This spell costs {1} less to cast for each land card in your graveyard.\nFlying, haste",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "3ea708ba-1942-572a-9bc0-f23740b3cb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11616853-34b1-4bb1-9590-461e12970ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11616853-34b1-4bb1-9590-461e12970ec3.jpg?1",
             "name": "Pashalik Mons",
             "text": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "25b757a3-e699-5a73-aef8-b8f524d1380f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd06d55-a40f-4b0e-905b-3cd0ce12eb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd06d55-a40f-4b0e-905b-3cd0ce12eb82.jpg?1",
             "name": "Pillage",
             "text": "Destroy target artifact or land. It can't be regenerated.",
             "colours": [
@@ -4691,7 +4691,7 @@
         },
         {
             "id": "6e45e58e-60d5-5d26-9df8-a2444eab5a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fb9418-a22b-4f92-b494-f68c29bcb92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fb9418-a22b-4f92-b494-f68c29bcb92a.jpg?1",
             "name": "Planebound Accomplice",
             "text": "{R}: You may put a planeswalker card from your hand onto the battlefield. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "af86452b-0066-5477-a21d-5e1b91b166dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02b3f1-d70f-4e44-bc1c-7fc90ec611dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02b3f1-d70f-4e44-bc1c-7fc90ec611dc.jpg?1",
             "name": "Pyrophobia",
             "text": "Pyrophobia deals 3 damage to target creature. Cowards can't block this turn.",
             "colours": [
@@ -4758,7 +4758,7 @@
         },
         {
             "id": "b48bb565-434b-59d9-9f5a-bc6108f2ff58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573ee0-156a-4bf3-95eb-5e7b63c638e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27573ee0-156a-4bf3-95eb-5e7b63c638e7.jpg?1",
             "name": "Quakefoot Cyclops",
             "text": "When Quakefoot Cyclops enters the battlefield, up to two target creatures can't block this turn.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle Quakefoot Cyclops, target creature can't block this turn.",
             "colours": [
@@ -4792,7 +4792,7 @@
         },
         {
             "id": "8fc9b897-cfe9-57db-bf49-a23c8d70b29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52337d8d-e0ee-4229-848d-9bbd989e15b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52337d8d-e0ee-4229-848d-9bbd989e15b7.jpg?1",
             "name": "Ravenous Giant",
             "text": "At the beginning of your upkeep, Ravenous Giant deals 1 damage to you.",
             "colours": [
@@ -4826,7 +4826,7 @@
         },
         {
             "id": "999b0738-ecc7-5d12-a802-aca8800d4ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754a8db-060e-470f-94c0-37f12d82978a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754a8db-060e-470f-94c0-37f12d82978a.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4858,7 +4858,7 @@
         },
         {
             "id": "e9d00cb3-a8e9-57d3-a65a-8ae8a96ffe5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e139ad1-1079-49e9-babd-6399c44ad333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e139ad1-1079-49e9-babd-6399c44ad333.jpg?1",
             "name": "Seasoned Pyromancer",
             "text": "When Seasoned Pyromancer enters the battlefield, discard two cards, then draw two cards. For each nonland card discarded this way, create a 1/1 red Elemental creature token.\n{3}{R}{R}, Exile Seasoned Pyromancer from your graveyard: Create two 1/1 red Elemental creature tokens.",
             "colours": [
@@ -4893,7 +4893,7 @@
         },
         {
             "id": "91128ce7-eafb-5d6a-9c72-42f9bb9bc7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580c6fe2-ab43-491e-a1b2-d076a5c2a74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580c6fe2-ab43-491e-a1b2-d076a5c2a74e.jpg?1",
             "name": "Shenanigans",
             "text": "Destroy target artifact.\nDredge 1 (If you would draw a card, instead you may put exactly one card from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -4925,7 +4925,7 @@
         },
         {
             "id": "cb1e8b86-5924-5b28-b467-c24da0ffd01d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b9479d-7b6a-40c8-94ea-fdf0ec980b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b9479d-7b6a-40c8-94ea-fdf0ec980b42.jpg?1",
             "name": "Spinehorn Minotaur",
             "text": "As long as you've drawn two or more cards this turn, Spinehorn Minotaur has double strike.",
             "colours": [
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "baedc703-1c8d-5277-b0a5-5f5d507b47c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506d58f-9825-4384-9012-1d037543fb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6506d58f-9825-4384-9012-1d037543fb59.jpg?1",
             "name": "Spiteful Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature is dealt damage, it deals that much damage to target player or planeswalker.\"",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "d976a0fe-fc4d-56d6-8165-eb8c7d476205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36223e7e-bfa7-4393-b2a4-047f1dd30b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36223e7e-bfa7-4393-b2a4-047f1dd30b93.jpg?1",
             "name": "Tectonic Reformation",
             "text": "Each land card in your hand has cycling {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "55218336-e6fc-5c10-880f-c354c7f449e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02cc57-f589-4c5d-b306-cceb0ab3ce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02cc57-f589-4c5d-b306-cceb0ab3ce8b.jpg?1",
             "name": "Throes of Chaos",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -5058,7 +5058,7 @@
         },
         {
             "id": "cd18bdb4-0d54-53df-9156-904153fa60d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c91e364-c157-494e-bb1b-f2cef004900f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c91e364-c157-494e-bb1b-f2cef004900f.jpg?1",
             "name": "Urza's Rage",
             "text": "Kicker {8}{R} (You may pay an additional {8}{R} as you cast this spell.)\nThis spell can't be countered.\nUrza's Rage deals 3 damage to any target. If this spell was kicked, instead it deals 10 damage to that permanent or player and the damage can't be prevented.",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "e369423d-53cb-5517-a162-4869a3213236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265d65e-3f26-46d9-8b8b-e75048a02e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1265d65e-3f26-46d9-8b8b-e75048a02e95.jpg?1",
             "name": "Vengeful Devil",
             "text": "Haste\nMorbid \u2014 {T}: Vengeful Devil deals 1 damage to any target. Activate this ability only if a creature died this turn.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "4ac7d18b-d002-5e57-8170-6b12f45ec0f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d1def0-1450-44ec-b7c4-0fa50fe12c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d1def0-1450-44ec-b7c4-0fa50fe12c15.jpg?1",
             "name": "Viashino Sandsprinter",
             "text": "Trample, haste\nAt the beginning of the end step, return Viashino Sandsprinter to its owner's hand. (Return it only if it's on the battlefield.)\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "e2da36bd-2c48-59bc-a672-8d3babc49ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb119b-dd15-40d2-8f75-c92f5d41d1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb119b-dd15-40d2-8f75-c92f5d41d1e1.jpg?1",
             "name": "Volatile Claws",
             "text": "Until end of turn, creatures you control get +2/+0 and gain all creature types.",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "a2ad1ffd-50e3-5205-8f5f-0194a38cf012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046dfb0-9ca3-4219-a6b0-d7503bc2fbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046dfb0-9ca3-4219-a6b0-d7503bc2fbd0.jpg?1",
             "name": "Ayula, Queen Among Bears",
             "text": "Whenever another Bear enters the battlefield under your control, choose one \u2014\n\u2022 Put two +1/+1 counters on target Bear.\n\u2022 Target Bear you control fights target creature you don't control.",
             "colours": [
@@ -5227,7 +5227,7 @@
         },
         {
             "id": "52673fa7-e826-553b-8e0b-26788770deff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg?1",
             "name": "Ayula's Influence",
             "text": "Discard a land card: Create a 2/2 green Bear creature token.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "05555154-b595-5a3c-93a3-199b17ac16a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6cf54-79ff-44e8-af83-786fd72867dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec6cf54-79ff-44e8-af83-786fd72867dd.jpg?1",
             "name": "Bellowing Elk",
             "text": "As long as you had another creature enter the battlefield under your control this turn, Bellowing Elk has trample and indestructible.",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "6325de3c-6b1e-5490-9fa1-9b1ad3f1fafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085107a2-c1ec-473c-81d8-23e5a7197776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085107a2-c1ec-473c-81d8-23e5a7197776.jpg?1",
             "name": "Collector Ouphe",
             "text": "Activated abilities of artifacts can't be activated.",
             "colours": [
@@ -5327,7 +5327,7 @@
         },
         {
             "id": "87b68b24-3aec-5b96-a2ab-3eba622e095c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f99d23-5d3e-4f36-b1c7-3a893e4b4c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f99d23-5d3e-4f36-b1c7-3a893e4b4c32.jpg?1",
             "name": "Conifer Wurm",
             "text": "Trample\n{3}{G}: Conifer Wurm gets +X/+X until end of turn, where X is the number of snow permanents you control.",
             "colours": [
@@ -5363,7 +5363,7 @@
         },
         {
             "id": "65d0d52f-aa9d-5d20-bae9-a7997f1c1bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg?1",
             "name": "Crashing Footfalls",
             "text": "Suspend 4\u2014{G} (Rather than cast this card from your hand, pay {G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nCreate two 4/4 green Rhino creature tokens with trample.",
             "colours": [
@@ -5395,7 +5395,7 @@
         },
         {
             "id": "7d2a984a-beb2-53c6-b687-a55811cf9c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287775f-7bec-4e8f-bb8d-daf5ce92e4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3287775f-7bec-4e8f-bb8d-daf5ce92e4a8.jpg?1",
             "name": "Deep Forest Hermit",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deep Forest Hermit enters the battlefield, create four 1/1 green Squirrel creature tokens.\nSquirrels you control get +1/+1.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "4959b143-a8f8-5915-a488-dec5223c6323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a24943-0121-4c64-9624-2e4cff37e6ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a24943-0121-4c64-9624-2e4cff37e6ca.jpg?1",
             "name": "Elvish Fury",
             "text": "Buyback {4} (You may pay an additional {4} as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "f9e7ef93-a694-563c-a422-b5ca9cff781b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d315-5790-417d-adf5-270df1ff34b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d315-5790-417d-adf5-270df1ff34b0.jpg?1",
             "name": "Excavating Anurid",
             "text": "When Excavating Anurid enters the battlefield, you may sacrifice a land. If you do, draw a card.\nThreshold \u2014 As long as seven or more cards are in your graveyard, Excavating Anurid gets +1/+1 and has vigilance.",
             "colours": [
@@ -5497,7 +5497,7 @@
         },
         {
             "id": "e9a04f5c-0d20-5794-aa62-94220e8114ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg?1",
             "name": "Force of Vigor",
             "text": "If it's not your turn, you may exile a green card from your hand rather than pay this spell's mana cost.\nDestroy up to two target artifacts and/or enchantments.",
             "colours": [
@@ -5529,7 +5529,7 @@
         },
         {
             "id": "af2870fc-609c-5c80-a2ad-97f52922d3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4fc18-6f2c-45e4-a2c7-c2068b4f1a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4fc18-6f2c-45e4-a2c7-c2068b4f1a92.jpg?1",
             "name": "Frostwalla",
             "text": "{S}: Frostwalla gets +2/+2 until end of turn. Activate this ability only once each turn. ({S} can be paid with one mana from a snow permanent.)",
             "colours": [
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "40ce5d37-9d88-523e-8270-8584524cd694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b741d88-513a-4f47-a4fd-af42c5e44b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b741d88-513a-4f47-a4fd-af42c5e44b6d.jpg?1",
             "name": "Genesis",
             "text": "At the beginning of your upkeep, if Genesis is in your graveyard, you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5599,7 +5599,7 @@
         },
         {
             "id": "703b529e-6791-5ba9-9f76-3e673ee2d9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615a5e9-deec-46cc-9444-de81cb0da9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615a5e9-deec-46cc-9444-de81cb0da9c0.jpg?1",
             "name": "Glacial Revelation",
             "text": "Reveal the top six cards of your library. You may put any number of snow permanent cards from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "3b494fa8-3f74-5b03-b724-0a6eaba5cdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f5cc05-5d9d-4709-b3c5-a6249c294acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f5cc05-5d9d-4709-b3c5-a6249c294acc.jpg?1",
             "name": "Hexdrinker",
             "text": "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 3-7\n4/4\nProtection from instants\nLEVEL 8+\n6/6\nProtection from everything",
             "colours": [
@@ -5665,7 +5665,7 @@
         },
         {
             "id": "6b880c14-f27f-52d7-a1a1-0ac890a182dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391ba8b-7d9a-4077-8eeb-1b2ced14d973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6391ba8b-7d9a-4077-8eeb-1b2ced14d973.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle your library. (Do this before you draw.)",
             "colours": [
@@ -5700,7 +5700,7 @@
         },
         {
             "id": "1b1f89e1-bdf7-5690-aecb-bc4247e467c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d3d8d-e78b-40b8-aed5-888a2d0baa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d3d8d-e78b-40b8-aed5-888a2d0baa60.jpg?1",
             "name": "Llanowar Tribe",
             "text": "{T}: Add {G}{G}{G}.",
             "colours": [
@@ -5735,7 +5735,7 @@
         },
         {
             "id": "38d99cde-cc2b-5914-93e7-b7b902545198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efae4d84-8134-461a-a352-a5bdff7259a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efae4d84-8134-461a-a352-a5bdff7259a7.jpg?1",
             "name": "Mother Bear",
             "text": "{3}{G}{G}, Exile Mother Bear from your graveyard: Create two 2/2 green Bear creature tokens. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -5769,7 +5769,7 @@
         },
         {
             "id": "cb4f93b2-f08c-58db-b7d8-000572d3f3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480ddde1-81d3-4939-b232-cb1ced6cfc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480ddde1-81d3-4939-b232-cb1ced6cfc4d.jpg?1",
             "name": "Murasa Behemoth",
             "text": "Trample\nMurasa Behemoth gets +3/+3 as long as there is a land card in your graveyard.",
             "colours": [
@@ -5803,7 +5803,7 @@
         },
         {
             "id": "be55fe9a-70c3-538c-a126-767252899bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a7e43a-4028-41e5-b5dd-be8ef6a1b510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a7e43a-4028-41e5-b5dd-be8ef6a1b510.jpg?1",
             "name": "Nantuko Cultivator",
             "text": "When Nantuko Cultivator enters the battlefield, you may discard any number of land cards. Put that many +1/+1 counters on Nantuko Cultivator and draw that many cards.",
             "colours": [
@@ -5838,7 +5838,7 @@
         },
         {
             "id": "07822b6e-3994-580c-8a54-7f8c2ac99b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6374ad-71be-422e-bd76-4f08fbf43048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6374ad-71be-422e-bd76-4f08fbf43048.jpg?1",
             "name": "Nimble Mongoose",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nThreshold \u2014 Nimble Mongoose gets +2/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "243062be-c978-5130-8985-325accc87ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771fc5d-b9a1-4637-8241-3f54616b64af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771fc5d-b9a1-4637-8241-3f54616b64af.jpg?1",
             "name": "Regrowth",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "43c3e889-eef0-5be7-a0e0-b0fa3fa71745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce0ab73-4df6-479f-8710-61ef87cce3b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce0ab73-4df6-479f-8710-61ef87cce3b4.jpg?1",
             "name": "Rime Tender",
             "text": "{T}: Untap another target snow permanent.",
             "colours": [
@@ -5941,7 +5941,7 @@
         },
         {
             "id": "ed027ec2-60ec-5feb-9b5d-698058a2fe50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8491f-9c51-41c0-994e-d3f0f5f6a411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8491f-9c51-41c0-994e-d3f0f5f6a411.jpg?1",
             "name": "Saddled Rimestag",
             "text": "Saddled Rimestag gets +2/+2 as long as you had another creature enter the battlefield under your control this turn.",
             "colours": [
@@ -5977,7 +5977,7 @@
         },
         {
             "id": "847842c2-0f79-5567-ba6c-57ad49b1561a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7e77c-ede5-41bd-b766-9a76ce691607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea7e77c-ede5-41bd-b766-9a76ce691607.jpg?1",
             "name": "Savage Swipe",
             "text": "Target creature you control gets +2/+2 until end of turn if its power is 2. Then it fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "0190c529-444c-5425-b85e-6e8492220123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d9bae-2753-486c-be79-2438208ac353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d9bae-2753-486c-be79-2438208ac353.jpg?1",
             "name": "Scale Up",
             "text": "Until end of turn, target creature you control becomes a green Wurm with base power and toughness 6/4.\nOverload {4}{G}{G} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "949fece0-2493-5b2e-a517-c806cb403f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42fd52-34ea-4d1b-80dc-58fb0593bb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d42fd52-34ea-4d1b-80dc-58fb0593bb5b.jpg?1",
             "name": "Spore Frog",
             "text": "Sacrifice Spore Frog: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "654d2880-0526-5a4e-86f1-9672876dbd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6161d2ed-7cff-4c90-9e74-1d179a6c1498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6161d2ed-7cff-4c90-9e74-1d179a6c1498.jpg?1",
             "name": "Springbloom Druid",
             "text": "When Springbloom Druid enters the battlefield, you may sacrifice a land. If you do, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "1d12e001-2ba5-595d-be2d-08d31dbf2de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914d43c-bc5a-47c5-a01c-59ddb1ee8eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6914d43c-bc5a-47c5-a01c-59ddb1ee8eca.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "5664c69f-10a5-5e43-9073-d43093e69a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69026075-adfa-48b0-b30e-04b0a76904c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69026075-adfa-48b0-b30e-04b0a76904c3.jpg?1",
             "name": "Tempered Sliver",
             "text": "Sliver creatures you control have \"Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.\"",
             "colours": [
@@ -6178,7 +6178,7 @@
         },
         {
             "id": "6121a776-2f11-558c-9881-67acbb0665f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadffd6b-d707-4fc5-a600-44eb9124b195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadffd6b-d707-4fc5-a600-44eb9124b195.jpg?1",
             "name": "Thornado",
             "text": "Destroy target creature with flying.\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "aa1121c3-bc14-548e-a92a-7a3ee5d218b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677166cf-4e1e-43ac-a67b-afaf33c0d14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677166cf-4e1e-43ac-a67b-afaf33c0d14e.jpg?1",
             "name": "Treefolk Umbra",
             "text": "Enchant creature\nEnchanted creature gets +0/+2 and assigns combat damage equal to its toughness rather than its power.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "bffa81a2-e5ce-5cf0-bd4f-6e7d2b15a204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1722a55-850c-4924-be98-45539f4676a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1722a55-850c-4924-be98-45539f4676a2.jpg?1",
             "name": "Treetop Ambusher",
             "text": "Dash {1}{G} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)\nWhenever Treetop Ambusher attacks, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "7763d98e-d8d3-53eb-9aeb-2a411d201156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f3b68e-f616-4687-bc2d-075165162cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f3b68e-f616-4687-bc2d-075165162cd1.jpg?1",
             "name": "Trumpeting Herd",
             "text": "Create a 3/3 green Elephant creature token.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6311,7 +6311,7 @@
         },
         {
             "id": "38858409-ca21-5278-b343-18f76f86ca8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf3188c-879b-4b18-88b4-6237d7162271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf3188c-879b-4b18-88b4-6237d7162271.jpg?1",
             "name": "Twin-Silk Spider",
             "text": "Reach\nWhen Twin-Silk Spider enters the battlefield, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -6345,7 +6345,7 @@
         },
         {
             "id": "8c7ec91f-91d0-5d95-923d-b6a20efc3825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f594d07-932e-4fe6-832d-d0a0be3530aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f594d07-932e-4fe6-832d-d0a0be3530aa.jpg?1",
             "name": "Unbound Flourishing",
             "text": "Whenever you cast a permanent spell with a mana cost that contains {X}, double the value of X.\nWhenever you cast an instant or sorcery spell or activate an ability, if that spell's mana cost or that ability's activation cost contains {X}, copy that spell or ability. You may choose new targets for the copy.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "78745b7c-47df-53d3-9401-06f9d3e5a117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ef5786-7786-4418-b245-038b58fd7123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ef5786-7786-4418-b245-038b58fd7123.jpg?1",
             "name": "Wall of Blossoms",
             "text": "Defender\nWhen Wall of Blossoms enters the battlefield, draw a card.",
             "colours": [
@@ -6412,7 +6412,7 @@
         },
         {
             "id": "0f80489e-a99a-5b99-a98f-5e46a1c084d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a9fa51-78c3-42e6-8c2e-39658f59ed87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a9fa51-78c3-42e6-8c2e-39658f59ed87.jpg?1",
             "name": "Weather the Storm",
             "text": "You gain 3 life.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "372b1cfc-428e-5ae7-abc8-ff18301b2df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91571765-8da8-49f9-a776-7778d86cfb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91571765-8da8-49f9-a776-7778d86cfb99.jpg?1",
             "name": "Webweaver Changeling",
             "text": "Changeling (This card is every creature type.)\nReach\nWhen Webweaver Changeling enters the battlefield, if there are three or more creature cards in your graveyard, you gain 5 life.",
             "colours": [
@@ -6478,7 +6478,7 @@
         },
         {
             "id": "8ca67e47-2a30-5b03-aa5f-74cca2f81104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d9776-b6ce-4ad6-8acc-69115ba5de76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5d9776-b6ce-4ad6-8acc-69115ba5de76.jpg?1",
             "name": "Winding Way",
             "text": "Choose creature or land. Reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -6510,7 +6510,7 @@
         },
         {
             "id": "e72320c5-aa3a-5fd9-88d0-56f0d71f9e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eddb834-ea01-44e2-afca-bd9a4ebbdb94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eddb834-ea01-44e2-afca-bd9a4ebbdb94.jpg?1",
             "name": "Abominable Treefolk",
             "text": "Trample\nAbominable Treefolk's power and toughness are each equal to the number of snow permanents you control.\nWhen Abominable Treefolk enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "c962ac68-e335-5ae0-b20f-f697622325d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933191-dad6-43d5-b02e-a94ad8033f2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933191-dad6-43d5-b02e-a94ad8033f2f.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "Sliver creatures you control have flying and haste.",
             "colours": [
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "46f38cd4-d64a-5177-a63e-67c4dce6d515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1d0ac1-e805-4213-a46e-cf124680d082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1d0ac1-e805-4213-a46e-cf124680d082.jpg?1",
             "name": "Collected Conjuring",
             "text": "Exile the top six cards of your library. You may cast up to two sorcery cards with converted mana cost 3 or less from among them without paying their mana costs. Put the exiled cards not cast this way on the bottom of your library in a random order.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "e9336e26-040a-5ff1-9c27-520d85302b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea751fe2-b64a-4265-8885-a9016b29b5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea751fe2-b64a-4265-8885-a9016b29b5b3.jpg?1",
             "name": "Eladamri's Call",
             "text": "Search your library for a creature card, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "487feb56-2948-5e84-81c4-84600eb8307f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036ab83-94a3-4634-9f0a-dde7af3be450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7036ab83-94a3-4634-9f0a-dde7af3be450.jpg?1",
             "name": "Etchings of the Chosen",
             "text": "As Etchings of the Chosen enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\n{1}, Sacrifice a creature of the chosen type: Target creature you control gains indestructible until end of turn.",
             "colours": [
@@ -6686,7 +6686,7 @@
         },
         {
             "id": "798004e0-32fe-5d27-af0f-421ee936bb3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900c9dfd-ece1-4b09-a801-0fa05e1994b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900c9dfd-ece1-4b09-a801-0fa05e1994b9.jpg?1",
             "name": "Fallen Shinobi",
             "text": "Ninjutsu {2}{U}{B} ({2}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Fallen Shinobi deals combat damage to a player, that player exiles the top two cards of their library. Until end of turn, you may play those cards without paying their mana costs.",
             "colours": [
@@ -6723,7 +6723,7 @@
         },
         {
             "id": "635067e9-a9a1-558f-adb5-18ca30cd8829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d4fbe1-8a2f-4958-bb85-1a1e5f1e8d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d4fbe1-8a2f-4958-bb85-1a1e5f1e8d87.jpg?1",
             "name": "The First Sliver",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nSliver spells you cast have cascade.",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "ae780ff2-fe02-5c52-b3af-fd7cb75a115c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d68905-e13e-4751-b028-90c795c11cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d68905-e13e-4751-b028-90c795c11cd5.jpg?1",
             "name": "Good-Fortune Unicorn",
             "text": "Whenever another creature enters the battlefield under your control, put a +1/+1 counter on that creature.",
             "colours": [
@@ -6803,7 +6803,7 @@
         },
         {
             "id": "6157b0c4-d9da-58ef-b828-fadaa2e7aeae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0049e68d-0caf-474f-9523-dad343f1250a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0049e68d-0caf-474f-9523-dad343f1250a.jpg?1",
             "name": "Hogaak, Arisen Necropolis",
             "text": "You can't spend mana to cast this spell.\nConvoke, delve (Each creature you tap while casting this spell pays for {1} or one mana of that creature's color. Each card you exile from your graveyard pays for {1}.)\nYou may cast Hogaak, Arisen Necropolis from your graveyard.\nTrample",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "1a455a84-993f-5009-bccf-934799fcf297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a55cfed-e76c-4ade-ac78-a546e05fe8da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a55cfed-e76c-4ade-ac78-a546e05fe8da.jpg?1",
             "name": "Ice-Fang Coatl",
             "text": "Flash\nFlying\nWhen Ice-Fang Coatl enters the battlefield, draw a card.\nIce-Fang Coatl has deathtouch as long as you control at least three other snow permanents.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "87f317b5-3564-5c3d-a386-7503ed71f12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919cd266-b796-4a1c-937f-76b565c82495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919cd266-b796-4a1c-937f-76b565c82495.jpg?1",
             "name": "Ingenious Infiltrator",
             "text": "Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "403deb98-804a-593e-9b9f-ccc1c3e0d62c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bd74b-c458-49d6-90ac-6075454e43dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179bd74b-c458-49d6-90ac-6075454e43dd.jpg?1",
             "name": "Kaya's Guile",
             "text": "Choose two \u2014\n\u2022 Each opponent sacrifices a creature.\n\u2022 Exile all cards from each opponent's graveyard.\n\u2022 Create a 1/1 white and black Spirit creature token with flying.\n\u2022 You gain 4 life.\nEntwine {3} (Choose all if you pay the entwine cost.)",
             "colours": [
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "d9e9a2de-baca-5e66-86fb-f56d6d090272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3651483f-6077-4b4e-b2c7-9d57f22c65dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3651483f-6077-4b4e-b2c7-9d57f22c65dc.jpg?1",
             "name": "Kess, Dissident Mage",
             "text": "Flying\nDuring each of your turns, you may cast an instant or sorcery card from your graveyard. If a card cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "91c8a396-bfd9-5591-bbae-0886734c437d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f0c9d6-cffc-4d8c-b455-e9feb8748aa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f0c9d6-cffc-4d8c-b455-e9feb8748aa7.jpg?1",
             "name": "Lavabelly Sliver",
             "text": "Sliver creatures you control have \"When this creature enters the battlefield, it deals 1 damage to target player or planeswalker and you gain 1 life.\"",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "8a59bed1-52b6-52ef-a93b-89e4090093f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5734012b-31db-4125-8fea-c88666969cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5734012b-31db-4125-8fea-c88666969cd6.jpg?1",
             "name": "Lightning Skelemental",
             "text": "Trample, haste\nWhenever Lightning Skelemental deals combat damage to a player, that player discards two cards.\nAt the beginning of the end step, sacrifice Lightning Skelemental.",
             "colours": [
@@ -7064,7 +7064,7 @@
         },
         {
             "id": "69b54775-ac39-524e-b35c-533f3d238f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8572dfd-9da1-4727-b549-47f9b119f6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8572dfd-9da1-4727-b549-47f9b119f6ac.jpg?1",
             "name": "Munitions Expert",
             "text": "Flash\nWhen Munitions Expert enters the battlefield, you may have it deal damage to target creature or planeswalker equal to the number of Goblins you control.",
             "colours": [
@@ -7100,7 +7100,7 @@
         },
         {
             "id": "aab190b2-134e-5cb5-92c4-524c56aa95d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17cbf6-3f38-4bc6-8448-881e19cffe06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a17cbf6-3f38-4bc6-8448-881e19cffe06.jpg?1",
             "name": "Nature's Chant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -7134,7 +7134,7 @@
         },
         {
             "id": "cfdc49c6-186c-5b14-9910-6a158b81807d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b7e59a-5302-4a73-816a-b759adff3ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b7e59a-5302-4a73-816a-b759adff3ee6.jpg?1",
             "name": "Reap the Past",
             "text": "Return X cards at random from your graveyard to your hand. Exile Reap the Past.",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "3e19523d-eafe-5614-aa7b-e6f4dca65e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cda35eb-ae42-43be-9015-3c468c7ebede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cda35eb-ae42-43be-9015-3c468c7ebede.jpg?1",
             "name": "Rotwidow Pack",
             "text": "Reach\n{3}{B}{G}, Exile a creature card from your graveyard: Create a 1/2 green Spider creature token with reach, then each opponent loses 1 life for each Spider you control.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "f7d2721f-77fe-54d6-8209-81a984ed6d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00ac82-a884-40c4-9d09-3190a1099726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a00ac82-a884-40c4-9d09-3190a1099726.jpg?1",
             "name": "Ruination Rioter",
             "text": "When Ruination Rioter dies, you may have it deal damage to any target equal to the number of land cards in your graveyard.",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "520ded19-3038-5ad2-885f-870f4a267f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea23111b-ccc1-4d5c-a9d2-9db14c728820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea23111b-ccc1-4d5c-a9d2-9db14c728820.jpg?1",
             "name": "Soulherder",
             "text": "Whenever a creature is exiled from the battlefield, put a +1/+1 counter on Soulherder.\nAt the beginning of your end step, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "5d070e6b-b945-51fc-808f-11f5454fc5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28642fbe-90c8-4beb-9950-91af28d93326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28642fbe-90c8-4beb-9950-91af28d93326.jpg?1",
             "name": "Thundering Djinn",
             "text": "Flying\nWhenever Thundering Djinn attacks, it deals damage to any target equal to the number of cards you've drawn this turn.",
             "colours": [
@@ -7313,7 +7313,7 @@
         },
         {
             "id": "0e062c5e-803d-5c89-a85a-0f57677c5c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaea2e54-ee50-47b9-a2a5-e3353831248c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaea2e54-ee50-47b9-a2a5-e3353831248c.jpg?1",
             "name": "Unsettled Mariner",
             "text": "Changeling (This card is every creature type.)\nWhenever you or a permanent you control becomes the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {1}.",
             "colours": [
@@ -7349,7 +7349,7 @@
         },
         {
             "id": "7d55b1c0-0586-5936-b039-07e7d5618a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a706ecf-3277-40e3-871c-4ba4ead16e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a706ecf-3277-40e3-871c-4ba4ead16e20.jpg?1",
             "name": "Wrenn and Six",
             "text": "+1: Return up to one target land card from your graveyard to your hand.\n\u22121: Wrenn and Six deals 1 damage to any target.\n\u22127: You get an emblem with \"Instant and sorcery cards in your graveyard have retrace.\"",
             "colours": [
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "14170061-9bc4-58a8-a7fc-c61a3b6f61c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169356e0-46dc-4096-8e66-36726454f104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169356e0-46dc-4096-8e66-36726454f104.jpg?1",
             "name": "Altar of Dementia",
             "text": "Sacrifice a creature: Target player puts a number of cards equal to the sacrificed creature's power from the top of their library into their graveyard.",
             "colours": [],
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "73c95d0a-5d66-5493-b5b0-a105656be6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149ede-3201-451a-a640-d0c10b024dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d149ede-3201-451a-a640-d0c10b024dbc.jpg?1",
             "name": "Amorphous Axe",
             "text": "Equipped creature gets +3/+0 and is every creature type.\nEquip {3}",
             "colours": [],
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "cdd2af65-c719-5ec1-8146-b0560b4b9979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2462fdf-a594-47d0-8e10-b55901e350d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2462fdf-a594-47d0-8e10-b55901e350d9.jpg?1",
             "name": "Arcum's Astrolabe",
             "text": "({S} can be paid with one mana from a snow permanent.)\nWhen Arcum's Astrolabe enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "c66345a9-b381-53f6-9fe4-ba881652cf0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345ee24-ffa3-44d1-a983-f25f54cda3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345ee24-ffa3-44d1-a983-f25f54cda3f3.jpg?1",
             "name": "Birthing Boughs",
             "text": "{4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling. (It has every creature type.)",
             "colours": [],
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "a4b45b47-ff89-51af-8633-abe953511fd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edafd52f-2dda-4981-baee-404f47ee8969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edafd52f-2dda-4981-baee-404f47ee8969.jpg?1",
             "name": "Farmstead Gleaner",
             "text": "Farmstead Gleaner doesn't untap during your untap step.\n{2}, {Q}: Put a +1/+1 counter on Farmstead Gleaner. ({Q} is the untap symbol.)",
             "colours": [],
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "8aae49ea-d8c8-5419-875e-fea09ebf76b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b022a628-4883-427a-8477-0e87d1a71028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b022a628-4883-427a-8477-0e87d1a71028.jpg?1",
             "name": "Fountain of Ichor",
             "text": "{T}: Add one mana of any color.\n{3}: Fountain of Ichor becomes a 3/3 Dinosaur artifact creature until end of turn.",
             "colours": [],
@@ -7562,7 +7562,7 @@
         },
         {
             "id": "47ca1d09-fd28-5e01-bfb2-05aa0f161e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2671c36-96fa-49e3-90dc-52820b2c8a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2671c36-96fa-49e3-90dc-52820b2c8a62.jpg?1",
             "name": "Icehide Golem",
             "text": "({S} can be paid with one mana from a snow permanent.)",
             "colours": [],
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "d5f1e8fe-92ab-501f-9d6f-a1c30ea5486f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c7cba5-6111-40ce-828a-e811301bb283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c7cba5-6111-40ce-828a-e811301bb283.jpg?1",
             "name": "Lesser Masticore",
             "text": "As an additional cost to cast this spell, discard a card.\n{4}: Lesser Masticore deals 1 damage to target creature.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -7626,7 +7626,7 @@
         },
         {
             "id": "f5d3dba6-3294-5966-85b2-3a9469050829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd05b01-dc73-4dd2-970a-32ec6e153c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd05b01-dc73-4dd2-970a-32ec6e153c86.jpg?1",
             "name": "Mox Tantalite",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}: Add one mana of any color.",
             "colours": [],
@@ -7654,7 +7654,7 @@
         },
         {
             "id": "e5b0638d-e305-569d-a97e-50121fba9a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945f5e0-c143-47ca-910e-32ad9ac34487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8945f5e0-c143-47ca-910e-32ad9ac34487.jpg?1",
             "name": "Scrapyard Recombiner",
             "text": "Modular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\n{T}, Sacrifice an artifact: Search your library for a Construct card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -7685,7 +7685,7 @@
         },
         {
             "id": "c379ab48-a36e-5951-b56e-8e762378efae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c081e5cf-81e2-4afb-a912-8267de29e88d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c081e5cf-81e2-4afb-a912-8267de29e88d.jpg?1",
             "name": "Sword of Sinew and Steel",
             "text": "Equipped creature gets +2/+2 and has protection from black and from red.\nWhenever equipped creature deals combat damage to a player, destroy up to one target planeswalker and up to one target artifact.\nEquip {2}",
             "colours": [],
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "26abe3ef-aa4f-557a-a80a-91ee0af68071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be8d24e-1370-4e85-90f2-66b6d6e9c4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be8d24e-1370-4e85-90f2-66b6d6e9c4a4.jpg?1",
             "name": "Sword of Truth and Justice",
             "text": "Equipped creature gets +2/+2 and has protection from white and from blue.\nWhenever equipped creature deals combat damage to a player, put a +1/+1 counter on a creature you control, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEquip {2}",
             "colours": [],
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "d3bd7037-a4cd-5ad3-bc0b-d8301c0acfce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71148fd3-0c2c-459e-b8f5-735a0a8dd87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71148fd3-0c2c-459e-b8f5-735a0a8dd87f.jpg?1",
             "name": "Talisman of Conviction",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Talisman of Conviction deals 1 damage to you.",
             "colours": [],
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "e59e7b88-6e1c-57b7-af2f-e0ee3ad1e15b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9dbadd-c1b6-44fe-92ac-6f69d7178342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9dbadd-c1b6-44fe-92ac-6f69d7178342.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "7caab30b-835a-53c2-b7e2-c3d7a6b5cd76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd52688a-39fd-430f-b950-cb56e0004396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd52688a-39fd-430f-b950-cb56e0004396.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Talisman of Curiosity deals 1 damage to you.",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "7bd57a2d-691b-5be6-a7b6-443df108aff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826f99c7-f534-4183-8f0d-efe1609808ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826f99c7-f534-4183-8f0d-efe1609808ac.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Talisman of Hierarchy deals 1 damage to you.",
             "colours": [],
@@ -7869,7 +7869,7 @@
         },
         {
             "id": "0e70cf6f-c09a-5f9b-8225-9f521b7171ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc25a254-edd2-4817-ab80-7373239da7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc25a254-edd2-4817-ab80-7373239da7d2.jpg?1",
             "name": "Talisman of Resilience",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Talisman of Resilience deals 1 damage to you.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "c5196bfa-540e-5cc4-8206-1355f80ce47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg?1",
             "name": "Universal Automaton",
             "text": "Changeling (This card is every creature type.)",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "83e9c3bd-df91-5c34-937e-380802388916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4d8706-1b2f-41e9-8329-d0186b401227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4d8706-1b2f-41e9-8329-d0186b401227.jpg?1",
             "name": "Barren Moor",
             "text": "Barren Moor enters the battlefield tapped.\n{T}: Add {B}.\nCycling {B} ({B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7961,7 +7961,7 @@
         },
         {
             "id": "706e5744-2e24-561b-a055-894ce937991b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9149-6fd9-44fc-b765-3e646c7d83d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86e9149-6fd9-44fc-b765-3e646c7d83d6.jpg?1",
             "name": "Cave of Temptation",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Sacrifice Cave of Temptation: Put two +1/+1 counters on target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [],
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "8e4f4bb0-dbc5-5994-8023-dc305a3569d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aab13c-9d9d-4507-ae5d-da979990ae1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aab13c-9d9d-4507-ae5d-da979990ae1b.jpg?1",
             "name": "Fiery Islet",
             "text": "{T}, Pay 1 life: Add {U} or {R}.\n{1}, {T}, Sacrifice Fiery Islet: Draw a card.",
             "colours": [],
@@ -8020,7 +8020,7 @@
         },
         {
             "id": "643bf100-6993-52a4-a405-c6bfdc8533ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d41b5e4-6b9a-419a-ba49-611c4699eda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d41b5e4-6b9a-419a-ba49-611c4699eda2.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave enters the battlefield tapped.\n{T}: Add {R}.\nCycling {R} ({R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8050,7 +8050,7 @@
         },
         {
             "id": "c760fc87-d82c-5e09-b63a-c142a55b48ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb5d83f-2b7c-4c22-ac37-938e7cd1654a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb5d83f-2b7c-4c22-ac37-938e7cd1654a.jpg?1",
             "name": "Frostwalk Bastion",
             "text": "{T}: Add {C}.\n{1}{S}: Until end of turn, Frostwalk Bastion becomes a 2/3 Construct artifact creature. It's still a land. ({S} can be paid with one mana from a snow permanent.)\nWhenever Frostwalk Bastion deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "c641bd5d-6769-5cf4-a966-aecc476cc82f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cbd10a-b9a6-4c00-8280-72bb4add4390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5cbd10a-b9a6-4c00-8280-72bb4add4390.jpg?1",
             "name": "Hall of Heliod's Generosity",
             "text": "{T}: Add {C}.\n{1}{W}, {T}: Put target enchantment card from your graveyard on top of your library.",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "47a61cf8-231d-55c3-ba33-8eb568ca72bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0fcc2-2409-4e00-95d5-418ffa161c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0fcc2-2409-4e00-95d5-418ffa161c20.jpg?1",
             "name": "Lonely Sandbar",
             "text": "Lonely Sandbar enters the battlefield tapped.\n{T}: Add {U}.\nCycling {U} ({U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "4acc28ae-caf6-5a71-9bce-179410c9042d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2744ac83-a79f-4042-8720-688b5adda382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2744ac83-a79f-4042-8720-688b5adda382.jpg?1",
             "name": "Nurturing Peatland",
             "text": "{T}, Pay 1 life: Add {B} or {G}.\n{1}, {T}, Sacrifice Nurturing Peatland: Draw a card.",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "249ffe13-c104-5035-9b0b-90f804fc8c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37da81e-be12-45a2-9128-376f1ad7b3e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37da81e-be12-45a2-9128-376f1ad7b3e8.jpg?1",
             "name": "Prismatic Vista",
             "text": "{T}, Pay 1 life, Sacrifice Prismatic Vista: Search your library for a basic land card, put it onto the battlefield, then shuffle your library.",
             "colours": [],
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "920f8550-4289-5201-9f7a-97d2f23c2fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb40724c-62ca-43ab-b4cd-b5fd8e454bfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb40724c-62ca-43ab-b4cd-b5fd8e454bfe.jpg?1",
             "name": "Secluded Steppe",
             "text": "Secluded Steppe enters the battlefield tapped.\n{T}: Add {W}.\nCycling {W} ({W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8231,7 +8231,7 @@
         },
         {
             "id": "6cbcb7b0-7168-5eb8-86d1-85ff2d706432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac07e230-0297-4e1d-bdfe-119010e0ad8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac07e230-0297-4e1d-bdfe-119010e0ad8e.jpg?1",
             "name": "Silent Clearing",
             "text": "{T}, Pay 1 life: Add {W} or {B}.\n{1}, {T}, Sacrifice Silent Clearing: Draw a card.",
             "colours": [],
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "2e0cc274-32ab-527d-969b-282696f08c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36820fa-ee86-4206-9a0d-737a67cf5208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36820fa-ee86-4206-9a0d-737a67cf5208.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "{T}, Pay 1 life: Add {R} or {W}.\n{1}, {T}, Sacrifice Sunbaked Canyon: Draw a card.",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "21eb0e94-ed88-5bda-8277-d2bf16cb0fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73571bd-b6e5-4338-a9b1-d847a8ad43d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73571bd-b6e5-4338-a9b1-d847a8ad43d1.jpg?1",
             "name": "Tranquil Thicket",
             "text": "Tranquil Thicket enters the battlefield tapped.\n{T}: Add {G}.\nCycling {G} ({G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "a53ad2ab-0436-5906-a73e-725f8fb3d504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab6bfbd-d2e1-4c4c-9f91-6f69c5b8e3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab6bfbd-d2e1-4c4c-9f91-6f69c5b8e3bb.jpg?1",
             "name": "Waterlogged Grove",
             "text": "{T}, Pay 1 life: Add {G} or {U}.\n{1}, {T}, Sacrifice Waterlogged Grove: Draw a card.",
             "colours": [],
@@ -8354,7 +8354,7 @@
         },
         {
             "id": "8561bc1c-5170-540d-be31-05b69bbdb807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a961768-6166-4852-b518-23eb4cced47d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a961768-6166-4852-b518-23eb4cced47d.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "W",
             "colours": [],
@@ -8389,7 +8389,7 @@
         },
         {
             "id": "8808be9a-ae34-5460-a66a-205cf2046b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac1fceb-8427-409c-98a4-9a5c1ff980b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac1fceb-8427-409c-98a4-9a5c1ff980b4.jpg?1",
             "name": "Snow-Covered Island",
             "text": "U",
             "colours": [],
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "4d99ecc1-8eb3-5c89-8c68-e6cec675a519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c835f235-4196-4281-9788-13e5d54a92d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c835f235-4196-4281-9788-13e5d54a92d0.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "B",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "1fa76119-95c7-5c19-9f67-c1cf8064caf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2209e6f-1d9d-43bb-a314-a8fefc509e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2209e6f-1d9d-43bb-a314-a8fefc509e78.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "R",
             "colours": [],
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "2c2dc850-d97a-5a1f-a0e7-40ce8ff80e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c59fc48-704b-4187-b9d3-2a2cff6dd54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c59fc48-704b-4187-b9d3-2a2cff6dd54b.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "G",
             "colours": [],
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "eaae1532-4362-54f9-8855-477ce59eab99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a00405-13ad-4531-9bfb-fea0ca57f196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a00405-13ad-4531-9bfb-fea0ca57f196.jpg?1",
             "name": "Flusterstorm",
             "text": "Counter target instant or sorcery spell unless its controller pays {1}.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -8560,7 +8560,7 @@
         },
         {
             "id": "43f9f350-30f7-533a-a744-5d2c3a07c46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33fda72-e61d-478f-bc33-ff1a23b5f45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33fda72-e61d-478f-bc33-ff1a23b5f45b.jpg?1",
             "name": "Shapeshifter",
             "text": "",
             "colours": [],
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "c63a75f7-220d-576f-9e80-0b2faaac1a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91808554-23ab-44f9-92a1-87ee7d58cd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91808554-23ab-44f9-92a1-87ee7d58cd9a.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8626,7 +8626,7 @@
         },
         {
             "id": "eeed4bdc-bea8-554a-9f62-c7271246d1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c72f53-db47-48d1-85f0-626440b0c88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c72f53-db47-48d1-85f0-626440b0c88c.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8661,7 +8661,7 @@
         },
         {
             "id": "b9a3b02c-8af5-55be-9323-013819463ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61b83cf-791a-48bf-81c8-c6c940b89d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61b83cf-791a-48bf-81c8-c6c940b89d83.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8696,7 +8696,7 @@
         },
         {
             "id": "6b081b5c-f513-562a-9a96-045bb28fe835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccb29b-8b69-4813-94bb-d96e117b609e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebccb29b-8b69-4813-94bb-d96e117b609e.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "d5d9997c-f3da-5fc6-b99d-7b037f5cc097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b993828-e139-4cb6-a329-487accc1c515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b993828-e139-4cb6-a329-487accc1c515.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "61a6dd3f-8531-5e6e-bf76-12ece28a6514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c722fe8-05f1-4da0-a23b-25e20359fcef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c722fe8-05f1-4da0-a23b-25e20359fcef.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8803,7 +8803,7 @@
         },
         {
             "id": "792e0bc2-7b2e-5307-bb46-d1682fb34d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b57672-c346-42f5-ac3e-82466a13b957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b57672-c346-42f5-ac3e-82466a13b957.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8838,7 +8838,7 @@
         },
         {
             "id": "a80c9961-5303-587a-8b48-5e3d5a8dee97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/addc39de-db64-41d8-9185-67a09d3e326d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/addc39de-db64-41d8-9185-67a09d3e326d.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "ce3f025c-00d3-5c8d-becb-e4130e7f003b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5522b39-802a-4508-a671-2f73b0633032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5522b39-802a-4508-a671-2f73b0633032.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8908,7 +8908,7 @@
         },
         {
             "id": "26ae6f11-46bd-5975-a3ed-e3d2cea8be46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6610846-00d8-4cc2-a90a-4dc043ba7fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6610846-00d8-4cc2-a90a-4dc043ba7fa6.jpg?1",
             "name": "Bear",
             "text": "",
             "colours": [
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "3e931821-df8c-5887-b360-6a18c72fa609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae11d5f-f29d-44f4-8d90-cdada1040435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae11d5f-f29d-44f4-8d90-cdada1040435.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "ef6763e4-1adc-5a73-af81-9360158d9f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007c828b-5854-41ac-9c18-f9d41c69ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007c828b-5854-41ac-9c18-f9d41c69ed33.jpg?1",
             "name": "Rhino",
             "text": "",
             "colours": [
@@ -9013,7 +9013,7 @@
         },
         {
             "id": "26784dd1-b95f-5e3c-bc1b-fd5a874b9fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01591603-d903-419d-9957-cf0ae7f79240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01591603-d903-419d-9957-cf0ae7f79240.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -9048,7 +9048,7 @@
         },
         {
             "id": "db984bd7-474c-5634-81ab-d5a23a73b29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -9083,7 +9083,7 @@
         },
         {
             "id": "7b27265b-043d-5a37-bcbb-c4f6b6ea77cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf24e9fa-7d7f-4693-a9ed-b8e725d0ad5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf24e9fa-7d7f-4693-a9ed-b8e725d0ad5c.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "bd5f51ee-08a2-5368-9dd0-cb3052e719ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f212cd-4fc6-42fe-b268-22d8e3b2b7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f212cd-4fc6-42fe-b268-22d8e3b2b7eb.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "40823ee3-88e6-5f75-b1e6-d8273309f57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -9184,7 +9184,7 @@
         },
         {
             "id": "ef95c68a-b227-5c19-b017-02ebfa99c966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e26b2-1f7d-4a30-a0ef-1aa91e91d551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e26b2-1f7d-4a30-a0ef-1aa91e91d551.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -9216,7 +9216,7 @@
         },
         {
             "id": "61c054a4-231d-52d3-9631-0d062ddf13a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87dbb0b0-d898-491a-8ed9-efefca04e6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87dbb0b0-d898-491a-8ed9-efefca04e6e6.jpg?1",
             "name": "Serra the Benevolent Emblem",
             "text": "",
             "colours": [],
@@ -9246,7 +9246,7 @@
         },
         {
             "id": "ea5403b7-aada-5c51-84a3-7f597f7f4947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8a9fc-755a-4bff-8e13-41fbf4d9e546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8a9fc-755a-4bff-8e13-41fbf4d9e546.jpg?1",
             "name": "Wrenn and Six Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MH2.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MH2.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "37a15f87-1ebe-5bb4-926a-d77adf80689c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db113c47-c403-4c7f-9fa9-212c977df8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db113c47-c403-4c7f-9fa9-212c977df8d1.jpg?1",
             "name": "Abiding Grace",
             "text": "At the beginning of your end step, choose one \u2014\n\u2022 You gain 1 life.\n\u2022 Return target creature card with mana value 1 from your graveyard to the battlefield.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "e4c4c0a2-8be3-5d27-b5ec-ba665f8164ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4a2cb0-4129-451e-a946-a21ea646cc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4a2cb0-4129-451e-a946-a21ea646cc28.jpg?1",
             "name": "Arcbound Javelineer",
             "text": "{T}, Remove X +1/+1 counters from Arcbound Javelineer: It deals X damage to target attacking or blocking creature.\nModular 1 (This creature enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "81eb425e-861c-5a30-8ebd-9bd9f5284638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d66e724-49ee-4f08-a160-584350de1d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d66e724-49ee-4f08-a160-584350de1d95.jpg?1",
             "name": "Arcbound Mouser",
             "text": "Lifelink\nModular 1 (This creature enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "189f11b3-9ce8-54d2-8ced-c913c941a824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0a1a4-9216-47f8-a4e3-20fe0de6a518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb0a1a4-9216-47f8-a4e3-20fe0de6a518.jpg?1",
             "name": "Arcbound Prototype",
             "text": "Modular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "cf858f04-b890-592e-8fc0-01a56c103827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c8631-e630-402b-a559-f1b1aa49763c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c8631-e630-402b-a559-f1b1aa49763c.jpg?1",
             "name": "Barbed Spike",
             "text": "When Barbed Spike enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying, then attach Barbed Spike to it.\nEquipped creature gets +1/+0.\nEquip {2}",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f22ebf80-4dc1-56a3-be02-caee37c2774e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31506792-d0ab-4c13-9ab8-6fa433220dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31506792-d0ab-4c13-9ab8-6fa433220dbf.jpg?1",
             "name": "Blacksmith's Skill",
             "text": "Target permanent gains hexproof and indestructible until end of turn. If it's an artifact creature, it gets +2/+2 until end of turn.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "69010cbb-e00a-5b4d-810e-71a633866400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792610fd-736d-43b0-8899-dbb5accddca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792610fd-736d-43b0-8899-dbb5accddca0.jpg?1",
             "name": "Blossoming Calm",
             "text": "You gain hexproof until your next turn. You gain 2 life.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "cb3c1e88-dc18-5525-a059-71bece848b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723ec2ef-aa82-449d-88b0-405d06454fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723ec2ef-aa82-449d-88b0-405d06454fc2.jpg?1",
             "name": "Break Ties",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.\nReinforce 1\u2014{W} ({W}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "a891c42d-07a1-5607-a2bd-47eadf333f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c71a1f-191b-45f6-bb34-fba3e981a711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c71a1f-191b-45f6-bb34-fba3e981a711.jpg?1",
             "name": "Caprichrome",
             "text": "Flash\nVigilance\nDevour artifact 1 (As this enters the battlefield, you may sacrifice any number of artifacts. This creature enters the battlefield with that many +1/+1 counters on it.)",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "a44e851c-452a-5496-a868-07abab4587a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b5a0a5-5486-409a-b324-668ae03fc62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b5a0a5-5486-409a-b324-668ae03fc62a.jpg?1",
             "name": "Constable of the Realm",
             "text": "Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)\nWhenever one or more +1/+1 counters are put on Constable of the Realm, exile up to one other target nonland permanent until Constable of the Realm leaves the battlefield.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "d0411f21-e175-5f7a-81a5-5bb19a1d5e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9723a1-7c5f-49ea-a8c6-24ee572d839f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9723a1-7c5f-49ea-a8c6-24ee572d839f.jpg?1",
             "name": "Disciple of the Sun",
             "text": "Lifelink\nWhen Disciple of the Sun enters the battlefield, return target permanent card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "e7c90d84-033a-5ebb-994c-b8f17977da4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3537373-ef54-4578-9d05-6216420ee349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3537373-ef54-4578-9d05-6216420ee349.jpg?1",
             "name": "Esper Sentinel",
             "text": "Whenever an opponent casts their first noncreature spell each turn, draw a card unless that player pays {X}, where X is Esper Sentinel's power.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "b11949bb-8bea-52a2-8601-7863d1be5866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e07ed-24ef-40f7-91fc-fe212d948ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237e07ed-24ef-40f7-91fc-fe212d948ca8.jpg?1",
             "name": "Fairgrounds Patrol",
             "text": "{1}{W}, Exile Fairgrounds Patrol from your graveyard: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only as a sorcery.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "77c306d7-9b1c-5a29-a62b-70dc0bc2bd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1365aa-e814-471b-8c9e-cf4c5011bcc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1365aa-e814-471b-8c9e-cf4c5011bcc3.jpg?1",
             "name": "Glorious Enforcer",
             "text": "Flying, lifelink\nAt the beginning of each combat, if you have more life than an opponent, Glorious Enforcer gains double strike until end of turn.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "fb3a7f0f-11d7-5b4d-8c58-73fb10aabbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b4061-3009-46e4-8602-8349c6367cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754b4061-3009-46e4-8602-8349c6367cbf.jpg?1",
             "name": "Guardian Kirin",
             "text": "Flying\nWhenever another creature you control dies, put a +1/+1 counter on Guardian Kirin.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "6031f50a-a6c1-5e81-9d70-859cd9e4ed7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b5429-8512-4ab6-9ecd-fa270e0144f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b5429-8512-4ab6-9ecd-fa270e0144f3.jpg?1",
             "name": "Healer's Flock",
             "text": "Flying, lifelink",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "af439825-2439-59bc-8956-9a046e770401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee638303-fa02-41b6-8954-156544566b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee638303-fa02-41b6-8954-156544566b57.jpg?1",
             "name": "Knighted Myr",
             "text": "{2}{W}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Knighted Myr, it gains double strike until end of turn.",
             "colours": [
@@ -591,7 +591,7 @@
         },
         {
             "id": "3f1d0578-3c6a-52fd-8424-57cc069218ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a9e86-133e-4626-a239-73ef88d9ae12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a9e86-133e-4626-a239-73ef88d9ae12.jpg?1",
             "name": "Landscaper Colos",
             "text": "When Landscaper Colos enters the battlefield, put target card from an opponent's graveyard on the bottom of their library.\nBasic landcycling {1}{W} ({1}{W}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "a337a6a0-be50-5d98-9da0-5b0274cb4002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6633cab9-23f9-474e-96f1-ca7c0c67691c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6633cab9-23f9-474e-96f1-ca7c0c67691c.jpg?1",
             "name": "Late to Dinner",
             "text": "Return target creature card from your graveyard to the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "8a7b093a-8b62-53c5-ab35-27e3b22bf5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d92f037-a121-428a-ac53-98437366ecfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d92f037-a121-428a-ac53-98437366ecfd.jpg?1",
             "name": "Lens Flare",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nLens Flare deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "ef4cf126-985e-5c57-a21e-3315c503d786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c62efb9-11f2-4f82-af08-4587d58d6e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c62efb9-11f2-4f82-af08-4587d58d6e3d.jpg?1",
             "name": "Marble Gargoyle",
             "text": "Flying\n{W}: Marble Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "3faf9d65-b3ae-5533-9531-0750455611b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2963205e-b181-44d1-809f-6577e29fa812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2963205e-b181-44d1-809f-6577e29fa812.jpg?1",
             "name": "Nykthos Paragon",
             "text": "Whenever you gain life, you may put that many +1/+1 counters on each creature you control. Do this only once each turn.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "a0cba89b-c9a5-53f0-b894-05b280fddcb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053d6b3b-72d4-4a55-a79e-0a601aecf108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053d6b3b-72d4-4a55-a79e-0a601aecf108.jpg?1",
             "name": "Out of Time",
             "text": "When Out of Time enters the battlefield, untap all creatures, then phase them out until Out of Time leaves the battlefield. Put a time counter on Out of Time for each creature phased out this way.\nVanishing (At the beginning of your upkeep, remove a time counter from this enchantment. When the last is removed, sacrifice it.)",
             "colours": [
@@ -804,7 +804,7 @@
         },
         {
             "id": "becee9de-7340-50bd-8c0b-d40aefb96389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeb9fd0-c46a-4246-838f-a5b7a8ea8eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeb9fd0-c46a-4246-838f-a5b7a8ea8eef.jpg?1",
             "name": "Piercing Rays",
             "text": "Exile target tapped creature.\nForecast \u2014 {2}{W}, Reveal Piercing Rays from your hand: Tap target untapped creature. (Activate this ability only during your upkeep and only once each turn.)",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "efdbf638-dbe6-5813-ba0b-dafbac1e1468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825969b9-3c70-4fca-8cab-696e9ca7cdb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825969b9-3c70-4fca-8cab-696e9ca7cdb2.jpg?1",
             "name": "Prismatic Ending",
             "text": "Converge \u2014 Exile target nonland permanent if its mana value is less than or equal to the number of colors of mana spent to cast this spell.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "7f7c551c-182a-581b-ae77-4d228aba9aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01880c6f-be00-48b5-913f-ec6c80ced184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01880c6f-be00-48b5-913f-ec6c80ced184.jpg?1",
             "name": "Resurgent Belief",
             "text": "Suspend 2\u2014{1}{W} (Rather than cast this card from your hand, pay {1}{W} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nReturn all enchantment cards from your graveyard to the battlefield. (Auras with nothing to enchant remain in your graveyard.)",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "65fe24d8-84a3-5aef-b8b9-95988dd1c629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c3cca4-23c0-4c14-ab56-51ba011f5974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c3cca4-23c0-4c14-ab56-51ba011f5974.jpg?1",
             "name": "Sanctifier en-Vec",
             "text": "Protection from black and from red\nWhen Sanctifier en-Vec enters the battlefield, exile all cards that are black or red from all graveyards.\nIf a black or red permanent, spell, or card not on the battlefield would be put into a graveyard, exile it instead.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "6441701d-0dae-5c5a-9b2d-8f93a951c191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d368f-e1e0-41ab-9da0-f07c01c8ae38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87d368f-e1e0-41ab-9da0-f07c01c8ae38.jpg?1",
             "name": "Scour the Desert",
             "text": "Exile target creature card from your graveyard. Create X 1/1 white Bird creature tokens with flying, where X is the exiled card's toughness.",
             "colours": [
@@ -975,7 +975,7 @@
         },
         {
             "id": "7b3add30-ec6e-5565-85a8-ef819294b815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0345668-0cc1-41d2-8e4f-de7726fd0365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0345668-0cc1-41d2-8e4f-de7726fd0365.jpg?1",
             "name": "Search the Premises",
             "text": "Whenever a creature attacks you or a planeswalker you control, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "47613356-7f2f-5289-b4e6-7430f4dc6929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6534049-3045-4546-b1e8-e5b1b0df5f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6534049-3045-4546-b1e8-e5b1b0df5f56.jpg?1",
             "name": "Serra's Emissary",
             "text": "Flying\nAs Serra's Emissary enters the battlefield, choose a card type.\nYou and creatures you control have protection from the chosen card type.",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "e1eb68dd-7d00-522f-a860-30957ad40ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5705397-525b-4106-92ab-fe8ec9f561a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5705397-525b-4106-92ab-fe8ec9f561a2.jpg?1",
             "name": "Skyblade's Boon",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\n{2}{W}: Return Skyblade's Boon to its owner's hand. Activate only if Skyblade's Boon is on the battlefield or in your graveyard.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "0a0f438a-9c6d-5125-ab75-02d91490e324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6234f-309f-4e03-9263-66da48b57153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6234f-309f-4e03-9263-66da48b57153.jpg?1",
             "name": "Solitude",
             "text": "Flash\nLifelink\nWhen Solitude enters the battlefield, exile up to one other target creature. That creature's controller gains life equal to its power.\nEvoke\u2014\nExile a white card from your hand.",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "c0a36974-0541-505c-bcd5-724469f13815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4541217f-5e86-491b-918b-ed7a2eb3e4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4541217f-5e86-491b-918b-ed7a2eb3e4eb.jpg?1",
             "name": "Soul of Migration",
             "text": "Flying\nWhen Soul of Migration enters the battlefield, create two 1/1 white Bird creature tokens with flying.\nEvoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "2e83e51e-61f3-585c-ba4c-8eb595af0bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4e0e11-2f16-42ad-b835-c9410c4bd7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4e0e11-2f16-42ad-b835-c9410c4bd7e3.jpg?1",
             "name": "Thraben Watcher",
             "text": "Flying, vigilance\nOther nontoken creatures you control get +1/+1 and have vigilance.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "ffa57cee-f996-58f4-8383-1f39d83acc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fe8889-0ec8-421a-83a4-5d00ab4804db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fe8889-0ec8-421a-83a4-5d00ab4804db.jpg?1",
             "name": "Timeless Dragon",
             "text": "Flying\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)\nEternalize {2}{W}{W} ({2}{W}{W}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Dragon with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "60386fe5-bf83-5a4e-8e59-39d5e849cace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9955a344-dcd8-404d-9757-f62ed158ba22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9955a344-dcd8-404d-9757-f62ed158ba22.jpg?1",
             "name": "Unbounded Potential",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on each of up to two target creatures.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEntwine {3}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "7a244a46-f22e-5134-afa0-3dc491182aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a304f7e-0b9e-4ef6-9ad8-34350839f7d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a304f7e-0b9e-4ef6-9ad8-34350839f7d9.jpg?1",
             "name": "Aeromoeba",
             "text": "Flying\nDiscard a card: Switch Aeromoeba's power and toughness until end of turn.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "34d86643-5932-5768-9c41-7daaff57e5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8387bc7c-2e0a-4ff2-9882-e5e7c92c8463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8387bc7c-2e0a-4ff2-9882-e5e7c92c8463.jpg?1",
             "name": "Burdened Aerialist",
             "text": "When Burdened Aerialist enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhenever you sacrifice a token, Burdened Aerialist gains flying until end of turn.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "94493140-6d74-5ca1-8d4c-77f799b88026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9f061-67b8-4427-9fcb-b3ccfee8fc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9f061-67b8-4427-9fcb-b3ccfee8fc5d.jpg?1",
             "name": "Dress Down",
             "text": "Flash\nWhen Dress Down enters the battlefield, draw a card.\nCreatures lose all abilities.\nAt the beginning of the end step, sacrifice Dress Down.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "2c994738-4e1a-5ba7-bf35-23143c108e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8056f-4c8e-4a2b-b32f-c50c2cb7601a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc8056f-4c8e-4a2b-b32f-c50c2cb7601a.jpg?1",
             "name": "Etherium Spinner",
             "text": "Whenever you cast a spell with mana value 4 or greater, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "2dc483cc-43e8-55cc-9608-73f62a0b260a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cb828c-a19b-4e6d-853f-85e5ea7cadf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0cb828c-a19b-4e6d-853f-85e5ea7cadf8.jpg?1",
             "name": "Filigree Attendant",
             "text": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "acfc5721-0db2-5528-be74-05382550e12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ac05-bd87-4605-8443-0469276e1e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ac05-bd87-4605-8443-0469276e1e3a.jpg?1",
             "name": "Floodhound",
             "text": "{3}, {T}: Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "9e6493c0-8ba9-5ca4-a501-82f82c630981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d00175-5e5e-40dd-a71b-5ba56d763134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d00175-5e5e-40dd-a71b-5ba56d763134.jpg?1",
             "name": "Foul Watcher",
             "text": "Flying\nWhen Foul Watcher enters the battlefield, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\nDelirium \u2014 Foul Watcher gets +1/+0 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "5732999c-5cbc-5767-8e68-a1f02ea3d864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413ac8fb-5156-4f90-81f5-1879e273c9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/413ac8fb-5156-4f90-81f5-1879e273c9e2.jpg?1",
             "name": "Fractured Sanity",
             "text": "Each opponent mills fourteen cards.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Fractured Sanity, each opponent mills four cards.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "062a2a61-1fbc-5662-b166-b1a5d526e449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8cd89e-d849-4107-a629-98eae4c91489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8cd89e-d849-4107-a629-98eae4c91489.jpg?1",
             "name": "Ghost-Lit Drifter",
             "text": "Flying\n{2}{U}: Another target creature gains flying until end of turn.\nChannel \u2014 {X}{U}, Discard Ghost-Lit Drifter: X target creatures gain flying until end of turn.",
             "colours": [
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "3d2c8485-b300-50c8-95e6-443c369313bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501599d6-1072-4124-b05d-01f96de153f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501599d6-1072-4124-b05d-01f96de153f3.jpg?1",
             "name": "Hard Evidence",
             "text": "Create a 0/3 blue Crab creature token.\nInvestigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "a270560f-a23d-5dbf-9c71-7ceed2dc0b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71725895-38cd-4017-bbf0-0b7dc9b5db60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71725895-38cd-4017-bbf0-0b7dc9b5db60.jpg?1",
             "name": "Inevitable Betrayal",
             "text": "Suspend 3\u2014{1}{U}{U} (Rather than cast this card from your hand, pay {1}{U}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nSearch target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -1637,7 +1637,7 @@
         },
         {
             "id": "93b96650-55c8-5b79-95c5-2b641c7409fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7833a-a6b6-4aca-b574-66a6aea471ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b7833a-a6b6-4aca-b574-66a6aea471ea.jpg?1",
             "name": "Junk Winder",
             "text": "Affinity for tokens (This spell costs {1} less to cast for each token you control.)\nWhenever a token enters the battlefield under your control, tap target nonland permanent an opponent controls. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1671,7 +1671,7 @@
         },
         {
             "id": "fe525402-6ba3-52d8-8ad1-be6f35bcd496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985bdb0c-ce6c-4506-8163-76f3b2fdf5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985bdb0c-ce6c-4506-8163-76f3b2fdf5fb.jpg?1",
             "name": "Lose Focus",
             "text": "Replicate {U} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nCounter target spell unless its controller pays {2}.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "06b68235-b2d4-51e4-a604-3e0092307f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeda3d-3741-4b80-bfef-63bcc599d75b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aeda3d-3741-4b80-bfef-63bcc599d75b.jpg?1",
             "name": "Lucid Dreams",
             "text": "Draw X cards, where X is the number of card types among cards in your graveyard.",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "b2437450-05fd-5e92-a4f0-298b178b2a21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec38124-46ae-4a38-aab2-8a73cc22b1ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec38124-46ae-4a38-aab2-8a73cc22b1ef.jpg?1",
             "name": "Mental Journey",
             "text": "Draw three cards.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "4bc16cb7-51fe-514b-ba2f-69c39d255cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4aae1-7665-4df7-bd51-a1d95bf8a17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4aae1-7665-4df7-bd51-a1d95bf8a17d.jpg?1",
             "name": "Murktide Regent",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nFlying\nMurktide Regent enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.\nWhenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on Murktide Regent.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "2e469591-d75c-52dd-9f58-f69c447b6c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f6615e-194d-43aa-815a-34dca2ff4fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f6615e-194d-43aa-815a-34dca2ff4fea.jpg?1",
             "name": "Mystic Redaction",
             "text": "At the beginning of your upkeep, scry 1.\nWhenever you discard a card, each opponent mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "ba119b30-3cb5-50b4-aa6d-c9a39882bd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f288ee5-4bf9-476a-a89f-b6b8fa7e87dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f288ee5-4bf9-476a-a89f-b6b8fa7e87dc.jpg?1",
             "name": "Parcel Myr",
             "text": "{2}, Sacrifice Parcel Myr: Draw a card.",
             "colours": [
@@ -1873,7 +1873,7 @@
         },
         {
             "id": "ecff8d32-5815-5e33-bfcd-f981ca946c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f09ddb-0dec-47a7-92d4-efbeaf8cd85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f09ddb-0dec-47a7-92d4-efbeaf8cd85c.jpg?1",
             "name": "Phantasmal Dreadmaw",
             "text": "Trample\nWhen Phantasmal Dreadmaw becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "565de634-8e4b-594e-94b3-c6b220e37234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cee3a-6e0e-43c2-85e5-531b19297c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347cee3a-6e0e-43c2-85e5-531b19297c3d.jpg?1",
             "name": "Raving Visionary",
             "text": "{U}, {T}: Draw a card, then discard a card.\nDelirium \u2014 {2}{U}, {T}: Draw a card. Activate only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1945,7 +1945,7 @@
         },
         {
             "id": "9cf9ae29-7919-5112-8eb3-dd3f9219e004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95cc841-4e4f-4896-a073-f2e246ca62e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95cc841-4e4f-4896-a073-f2e246ca62e4.jpg?1",
             "name": "Recalibrate",
             "text": "Return target creature to its owner's hand. If you've discarded a card this turn, draw a card.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "0804eb6a-dacb-57ae-96fc-f8ec2a1f59a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e658cb2-11c5-4b59-a91c-f26ac28e82af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e658cb2-11c5-4b59-a91c-f26ac28e82af.jpg?1",
             "name": "Rise and Shine",
             "text": "Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on each artifact that became a creature this way.\nOverload {4}{U}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2011,7 +2011,7 @@
         },
         {
             "id": "edfcf1b9-88ba-5fcf-8ad4-c4afa317c385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg?1",
             "name": "Rishadan Dockhand",
             "text": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\n{1}, {T}: Tap target land.",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "92879e5d-fbcb-57a5-8d74-7e8113699d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg?1",
             "name": "Said // Done",
             "text": "Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2080,7 +2080,7 @@
         },
         {
             "id": "5896af19-9c32-583f-96ae-2ec7cfca638c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43ab3ed2-2b50-4488-a21f-60965222970a.jpg?1",
             "name": "Said // Done",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "7d7d940d-32bb-54c6-bbb8-46cdb995b92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e4ce27-aba2-4a3f-8de7-d442323d8be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e4ce27-aba2-4a3f-8de7-d442323d8be2.jpg?1",
             "name": "Scuttletide",
             "text": "{1}, Discard a card: Create a 0/3 blue Crab creature token.\nDelirium \u2014 Crabs you control get +1/+1 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "203a2502-8efb-5d2a-bd75-6ea237d1bd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191d1ab9-cd9e-4351-9acd-d7a57b963253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191d1ab9-cd9e-4351-9acd-d7a57b963253.jpg?1",
             "name": "Shattered Ego",
             "text": "Enchant creature\nEnchanted creature gets -3/-0.\n{3}{U}{U}: Put enchanted creature into its owner's library third from the top.",
             "colours": [
@@ -2178,7 +2178,7 @@
         },
         {
             "id": "95b6612f-dd2b-5651-bb6d-d66b7b1a0f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135db79f-6f07-486c-ae3a-d4244aaf6dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135db79f-6f07-486c-ae3a-d4244aaf6dc8.jpg?1",
             "name": "So Shiny",
             "text": "Enchant creature\nWhen So Shiny enters the battlefield, if you control a token, tap enchanted creature, then scry 2.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "8919813d-d600-5844-8c51-b889296610ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfaed69-bc4c-4c73-abc3-00dce5e0177e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfaed69-bc4c-4c73-abc3-00dce5e0177e.jpg?1",
             "name": "Specimen Collector",
             "text": "When Specimen Collector enters the battlefield, create a 1/1 green Squirrel creature token and a 0/3 blue Crab creature token.\nWhen Specimen Collector dies, create a token that's a copy of target token you control.",
             "colours": [
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "070e236e-0c26-5819-9ca7-18b2a178b91b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7ca8b6-d7e0-4af2-a578-bf45a8731c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7ca8b6-d7e0-4af2-a578-bf45a8731c19.jpg?1",
             "name": "Steelfin Whale",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhenever an artifact enters the battlefield under your control, untap Steelfin Whale.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "31c59d84-a47a-5278-8097-152e625ccde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716534cb-aa89-4de7-9aa5-8d8aa4422a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716534cb-aa89-4de7-9aa5-8d8aa4422a6a.jpg?1",
             "name": "Step Through",
             "text": "Return two target creatures to their owners' hands.\nWizardcycling {2} ({2}, Discard this card: Search your library for a Wizard card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "584d7124-cc7f-508a-9304-16cc17dd3751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701256d5-1389-48b7-9581-d6037209bd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701256d5-1389-48b7-9581-d6037209bd06.jpg?1",
             "name": "Subtlety",
             "text": "Flash\nFlying\nWhen Subtlety enters the battlefield, choose up to one target creature spell or planeswalker spell. Its owner puts it on the top or bottom of their library.\nEvoke\u2014\nExile a blue card from your hand.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "c2c6de27-0085-5b5e-90e3-3e717f72f801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40af215c-d3f7-42f0-85cd-77a3fcd919ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40af215c-d3f7-42f0-85cd-77a3fcd919ba.jpg?1",
             "name": "Suspend",
             "text": "Exile target creature and put two time counters on it. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, they remove a time counter. When the last is removed, they play it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -2386,7 +2386,7 @@
         },
         {
             "id": "9c9ca5b3-d6a3-5d5a-b12e-0ff7a3bbf36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f9ece1-669a-47c9-96c3-1e1dbf87421c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f9ece1-669a-47c9-96c3-1e1dbf87421c.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}. (Whenever another Merfolk you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "3c31282d-7694-5c08-ab46-cefe8a25174c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22dcb4e-ac39-4bee-b8d0-1b6ed038834e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22dcb4e-ac39-4bee-b8d0-1b6ed038834e.jpg?1",
             "name": "Sweep the Skies",
             "text": "Converge \u2014 Create a 1/1 colorless Thopter artifact creature token with flying for each color of mana spent to cast this spell.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "f9b24510-d75a-5c50-a218-41f7e2832cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996c1952-8d10-4296-8960-ff8993833649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996c1952-8d10-4296-8960-ff8993833649.jpg?1",
             "name": "Thought Monitor",
             "text": "Affinity for artifacts\nFlying\nWhen Thought Monitor enters the battlefield, draw two cards.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "6541bc80-e3f0-5058-857f-2a667bd0184f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff414bc-6736-428b-bb60-9d62793a5ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff414bc-6736-428b-bb60-9d62793a5ae5.jpg?1",
             "name": "Tide Shaper",
             "text": "Kicker {1} (You may pay an additional {1} as you cast this spell.)\nWhen Tide Shaper enters the battlefield, if it was kicked, target land becomes an Island for as long as Tide Shaper remains on the battlefield.\nTide Shaper gets +1/+1 as long as an opponent controls an Island.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "e2e6a29d-744b-5484-adc3-3c1406934357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfc6a8-7880-4810-8c0a-d9ea931138f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfc6a8-7880-4810-8c0a-d9ea931138f2.jpg?1",
             "name": "Vedalken Infiltrator",
             "text": "Vedalken Infiltrator can't be blocked.\nMetalcraft \u2014 Vedalken Infiltrator gets +1/+0 as long as you control three or more artifacts.",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "8791a150-567e-584e-aff9-21ab74f27b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d089f1-718e-4853-a634-64114735fba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d089f1-718e-4853-a634-64114735fba5.jpg?1",
             "name": "Archfiend of Sorrows",
             "text": "Flying\nWhen Archfiend of Sorrows enters the battlefield, creatures your opponents control get -2/-2 until end of turn.\nUnearth {3}{B}{B} ({3}{B}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2601,7 +2601,7 @@
         },
         {
             "id": "e5bf7106-c055-5ea7-9672-25294bc5dba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be9d9a4-d7ee-4854-abc2-85cabf993ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be9d9a4-d7ee-4854-abc2-85cabf993ec9.jpg?1",
             "name": "Archon of Cruelty",
             "text": "Flying\nWhenever Archon of Cruelty enters the battlefield or attacks, target opponent sacrifices a creature or planeswalker, discards a card, and loses 3 life. You draw a card and gain 3 life.",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "f617eeaa-b3ae-5894-9d71-60a77d5943e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee98955-4c47-4d45-9377-608dfa755337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee98955-4c47-4d45-9377-608dfa755337.jpg?1",
             "name": "Bone Shards",
             "text": "As an additional cost to cast this spell, sacrifice a creature or discard a card.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "c53b438f-9953-53a3-b443-0d43d3be3035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ca9568-06b6-4c57-b1f6-8a74ec2a2b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ca9568-06b6-4c57-b1f6-8a74ec2a2b91.jpg?1",
             "name": "Break the Ice",
             "text": "Destroy target land that is snow or could produce {C}.\nOverload {4}{B}{B} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2703,7 +2703,7 @@
         },
         {
             "id": "32b7e6bb-9fba-55f6-b220-e50641d4f069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b279a03f-85ab-43f2-b5ca-1bc10563e5ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b279a03f-85ab-43f2-b5ca-1bc10563e5ad.jpg?1",
             "name": "Cabal Initiate",
             "text": "Discard a card: Cabal Initiate gains lifelink until end of turn.\nThreshold \u2014 Cabal Initiate gets +1/+2 as long as seven or more cards are in your graveyard.",
             "colours": [
@@ -2738,7 +2738,7 @@
         },
         {
             "id": "6ed4c05b-0c16-5503-98cf-27b74c6ff8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22dd28d-eb65-410a-af17-51b5064c6033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22dd28d-eb65-410a-af17-51b5064c6033.jpg?1",
             "name": "Clattering Augur",
             "text": "Clattering Augur can't block.\nWhen Clattering Augur enters the battlefield, you draw a card and you lose 1 life.\n{2}{B}{B}: Return Clattering Augur from your graveyard to your hand.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "c191679f-c789-5644-97bb-b1fd58139c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeae088-9ac5-4d2f-a15c-d8675a471ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeae088-9ac5-4d2f-a15c-d8675a471ac5.jpg?1",
             "name": "Damn",
             "text": "Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "5d25e879-61ee-5a0c-87bc-555e849dfa35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5db87-4a78-4b8d-b5c2-918ccd1ba4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5db87-4a78-4b8d-b5c2-918ccd1ba4e3.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf a card would be put into an opponent's graveyard from anywhere, instead exile it with a void counter on it.\n{T}, Sacrifice Dauthi Voidwalker: Choose an exiled card an opponent owns with a void counter on it. You may play it this turn without paying its mana cost.",
             "colours": [
@@ -2847,7 +2847,7 @@
         },
         {
             "id": "4ef50b2a-ec09-581a-8466-8ae71c8226af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f395828-9d6d-4ffa-be92-b681350031b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f395828-9d6d-4ffa-be92-b681350031b0.jpg?1",
             "name": "Discerning Taste",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. You gain life equal to the greatest power among creature cards put into your graveyard this way.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "234ab16d-6b70-5711-8a6c-b3586b1fa6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39eb0e67-f989-4430-b2d6-b8b647f0b7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39eb0e67-f989-4430-b2d6-b8b647f0b7ca.jpg?1",
             "name": "Echoing Return",
             "text": "Return target creature card and all other cards with the same name as that card from your graveyard to your hand.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "03140fdb-6383-5745-b645-46758e587fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f71309d-1b62-461d-b939-87f2932937a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f71309d-1b62-461d-b939-87f2932937a7.jpg?1",
             "name": "Feast of Sanity",
             "text": "Whenever you discard a card, Feast of Sanity deals 1 damage to any target and you gain 1 life.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "85809469-8bbf-596c-8534-a6de994b215f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297eaa16-890b-41dc-a470-fa8c313e6e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297eaa16-890b-41dc-a470-fa8c313e6e1b.jpg?1",
             "name": "Flay Essence",
             "text": "Exile target creature or planeswalker. You gain life equal to the number of counters on it.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "c4b8354a-ab94-5c48-a26c-d86c23782abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8cf47-cfe4-4a11-a57d-bebeb2fae437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8cf47-cfe4-4a11-a57d-bebeb2fae437.jpg?1",
             "name": "Gilt-Blade Prowler",
             "text": "{1}, {T}, Pay 1 life: Draw a card. Activate only if you've discarded a card this turn.",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "8b47aa60-e9e1-51ba-aefd-9fcf7b950d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6befbc4-1320-4f26-bd9f-b1814fedda10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6befbc4-1320-4f26-bd9f-b1814fedda10.jpg?1",
             "name": "Grief",
             "text": "Menace\nWhen Grief enters the battlefield, target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nEvoke\u2014\nExile a black card from your hand.",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "93a0c626-25f9-5fcf-aa25-bd2a228dadfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7da32a3-8e33-4603-abd2-8db144062f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7da32a3-8e33-4603-abd2-8db144062f6a.jpg?1",
             "name": "Hell Mongrel",
             "text": "Discard a card: Hell Mongrel gets +1/+1 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3082,7 +3082,7 @@
         },
         {
             "id": "60e3d9ab-b6ec-5b4c-815b-f6508e73aa2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836ae711-e62f-49ec-850e-d25f6fd2a4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836ae711-e62f-49ec-850e-d25f6fd2a4d4.jpg?1",
             "name": "Kitchen Imp",
             "text": "Flying, haste\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3118,7 +3118,7 @@
         },
         {
             "id": "a5723a00-bd54-5342-a1dc-c206e9aea193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ac1b48-dcfd-48a1-b999-ccc642596d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ac1b48-dcfd-48a1-b999-ccc642596d28.jpg?1",
             "name": "Legion Vanguard",
             "text": "{1}, Sacrifice another creature: Legion Vanguard explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "489ac6ff-8135-5db0-b435-d7d68bedd1ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a59a6f-6ef0-4acc-8358-a4e2cebdb7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a59a6f-6ef0-4acc-8358-a4e2cebdb7d5.jpg?1",
             "name": "Loathsome Curator",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nMenace\nWhen Loathsome Curator exploits a creature, destroy target creature you don't control with mana value 3 or less.",
             "colours": [
@@ -3188,7 +3188,7 @@
         },
         {
             "id": "0932efe2-a421-5d05-8912-0016a01ab3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4b7d1-16ed-4cc3-8db3-12fb8f25658c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4b7d1-16ed-4cc3-8db3-12fb8f25658c.jpg?1",
             "name": "Magus of the Bridge",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 2/2 black Zombie creature token.\nWhen a creature is put into an opponent's graveyard from the battlefield, exile Magus of the Bridge.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "216ef4eb-253e-52d7-8656-f5385923f1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f200ea9a-198b-4ba2-ad2b-ea4a133b7f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f200ea9a-198b-4ba2-ad2b-ea4a133b7f40.jpg?1",
             "name": "Necrogoyf",
             "text": "Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "0cbf105c-36fc-5cff-8daf-444c29184976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfb84f-582a-4fe2-9710-8b480a268571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4dfb84f-582a-4fe2-9710-8b480a268571.jpg?1",
             "name": "Necromancer's Familiar",
             "text": "Flying\nHellbent \u2014 Necromancer's Familiar has lifelink as long as you have no cards in hand.\n{B}, Discard a card: Necromancer's Familiar gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -3297,7 +3297,7 @@
         },
         {
             "id": "11376e91-39ff-5428-ba80-9cf2a590f52c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9851f290-f502-49f8-9b48-67f7966d4e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9851f290-f502-49f8-9b48-67f7966d4e34.jpg?1",
             "name": "Nested Shambler",
             "text": "When Nested Shambler dies, create X tapped 1/1 green Squirrel creature tokens, where X is Nested Shambler's power.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "1b0701b4-4ef7-5e88-b4d7-6f2d8fdb3245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f390c3-af1c-424f-9721-e26e9321e5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f390c3-af1c-424f-9721-e26e9321e5a3.jpg?1",
             "name": "Persist",
             "text": "Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "bd4e3e5a-e9ab-5a17-9609-0f4df4334ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afc6f7d-ab59-4d64-bd11-6bd0fd4bfcd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2afc6f7d-ab59-4d64-bd11-6bd0fd4bfcd2.jpg?1",
             "name": "Profane Tutor",
             "text": "Suspend 2\u2014{1}{B} (Rather than cast this card from your hand, pay {1}{B} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -3403,7 +3403,7 @@
         },
         {
             "id": "d1947c1d-376e-5588-8725-6c4a41b1f9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c99e55-c605-4519-a52a-39dfdbabb44a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c99e55-c605-4519-a52a-39dfdbabb44a.jpg?1",
             "name": "Radiant Epicure",
             "text": "Converge \u2014 When Radiant Epicure enters the battlefield, each opponent loses X life and you gain X life, where X is the number of colors of mana spent to cast this spell.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "1deb3a21-57e1-51b0-adac-20d1197105b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db209732-c290-4999-a1aa-2369dfa8790c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db209732-c290-4999-a1aa-2369dfa8790c.jpg?1",
             "name": "Sinister Starfish",
             "text": "{T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "39da9411-38a6-56a0-9689-ecfc4dbe9cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cc8aeb-221d-46a1-b03f-df8499bba26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cc8aeb-221d-46a1-b03f-df8499bba26d.jpg?1",
             "name": "Sudden Edict",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget player sacrifices a creature.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "5515729d-86c2-55b0-b77b-481acc04acfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed4901c-9b1e-4e0e-ae71-81cb10779f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed4901c-9b1e-4e0e-ae71-81cb10779f07.jpg?1",
             "name": "Tizerus Charger",
             "text": "Escape\u2014{4}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nTizerus Charger escapes with your choice of a +1/+1 counter or a flying counter on it.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "9dccdb6b-43ce-5e3e-9284-dbdde8f36bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3526751-0101-4d91-a496-c53cd92326e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3526751-0101-4d91-a496-c53cd92326e0.jpg?1",
             "name": "Tourach, Dread Cantor",
             "text": "Kicker {B}{B} (You may pay an additional {B}{B} as you cast this spell.)\nProtection from white\nWhenever an opponent discards a card, put a +1/+1 counter on Tourach, Dread Cantor.\nWhen Tourach enters the battlefield, if it was kicked, target opponent discards two cards at random.",
             "colours": [
@@ -3580,7 +3580,7 @@
         },
         {
             "id": "61a8a6d8-1ede-5bff-ae9b-1c9f9173b8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d97fd7d-c29f-4db0-b909-2f6aa9c39d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d97fd7d-c29f-4db0-b909-2f6aa9c39d65.jpg?1",
             "name": "Tourach's Canticle",
             "text": "Target opponent reveals their hand. You choose a card from it. That player discards that card, then discards a card at random.",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "184173f6-96c5-5766-bf76-293763b82e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affc1d27-55f6-46e9-a67c-f15b6832813d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affc1d27-55f6-46e9-a67c-f15b6832813d.jpg?1",
             "name": "Tragic Fall",
             "text": "Target creature gets -3/-3 until end of turn.\nHellbent \u2014 That creature gets -13/-13 until end of turn instead if you have no cards in hand.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "b8ee2130-9975-5565-9664-628cf1bf790f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1a23a-084a-429b-823a-a8e7e5f26e0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f1a23a-084a-429b-823a-a8e7e5f26e0d.jpg?1",
             "name": "Underworld Hermit",
             "text": "When Underworld Hermit enters the battlefield, create a number of 1/1 green Squirrel creature tokens equal to your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3681,7 +3681,7 @@
         },
         {
             "id": "cb24ae3a-882e-54be-ba49-82f43707b883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492b368b-de32-45c1-8459-238aae54f9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492b368b-de32-45c1-8459-238aae54f9fc.jpg?1",
             "name": "Unmarked Grave",
             "text": "Search your library for a nonlegendary card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "1fe41038-d72a-5315-b863-5e95184d84c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3166b10-5bc3-4db6-bb5b-81045d98e446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3166b10-5bc3-4db6-bb5b-81045d98e446.jpg?1",
             "name": "Vermin Gorger",
             "text": "{T}, Sacrifice another creature: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "2ad7d4b0-1112-5cf5-9c93-0bbe8c232a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d890ae71-da2b-44fa-8cfa-9c3016c9f696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d890ae71-da2b-44fa-8cfa-9c3016c9f696.jpg?1",
             "name": "Vile Entomber",
             "text": "Deathtouch\nWhen Vile Entomber enters the battlefield, search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "8e514156-e361-51a1-9420-3b943c052e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c1b08-3184-478f-92be-88db6cda33c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c7c1b08-3184-478f-92be-88db6cda33c5.jpg?1",
             "name": "World-Weary",
             "text": "Enchant creature\nEnchanted creature gets -4/-4.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3822,7 +3822,7 @@
         },
         {
             "id": "746ecc8b-4e8b-5140-abe6-81562949ba13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b5f6da-5e0f-4cce-92fe-7aa69124e265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b5f6da-5e0f-4cce-92fe-7aa69124e265.jpg?1",
             "name": "Young Necromancer",
             "text": "When Young Necromancer enters the battlefield, you may exile two cards from your graveyard. When you do, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3857,7 +3857,7 @@
         },
         {
             "id": "cd9fbb80-8140-521c-93bb-dcd6e2b7458b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcafff1a-e220-40ff-8c00-de6037219bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcafff1a-e220-40ff-8c00-de6037219bc6.jpg?1",
             "name": "Arcbound Slasher",
             "text": "Modular 4 (This creature enters the battlefield with four +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nRiot (This creature enters the battlefield with your choice of an additional +1/+1 counter or haste.)",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "e077aacd-54c8-5bbb-8e07-0debc0286aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881175c4-fee5-4c39-ad25-145ef73569ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881175c4-fee5-4c39-ad25-145ef73569ce.jpg?1",
             "name": "Arcbound Tracker",
             "text": "Menace\nModular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nWhenever you cast a spell other than your first spell each turn, put a +1/+1 counter on Arcbound Tracker.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "7a0371f0-58c7-56b9-9f12-2eb918c42852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154ed1d3-e24a-48ba-8f7b-be254c08d1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154ed1d3-e24a-48ba-8f7b-be254c08d1cc.jpg?1",
             "name": "Arcbound Whelp",
             "text": "Flying\n{R}: Arcbound Whelp gets +1/+0 until end of turn.\nModular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "83a799fe-b8d4-5dc3-88b4-aee546e69842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1e907-0e77-42ee-9eca-eae632020204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc1e907-0e77-42ee-9eca-eae632020204.jpg?1",
             "name": "Battle Plan",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "4fe88e3b-f614-524a-b82b-57daa33153b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404fc9c-ef02-479c-9638-0cc163f0b48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4404fc9c-ef02-479c-9638-0cc163f0b48f.jpg?1",
             "name": "Blazing Rootwalla",
             "text": "{R}: Blazing Rootwalla gets +2/+0 until end of turn. Activate only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "44db0613-6767-5cd0-b1c9-1f8045ac5973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6286fd93-bb97-4721-8a40-1c5a884c2edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6286fd93-bb97-4721-8a40-1c5a884c2edb.jpg?1",
             "name": "Bloodbraid Marauder",
             "text": "Bloodbraid Marauder can't block.\nDelirium \u2014 This spell has cascade as long as there are four or more card types among cards in your graveyard. (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "11941f28-14a0-56e2-ad46-262b536230a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b5b2e-dabf-4672-b476-4873781f636e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32b5b2e-dabf-4672-b476-4873781f636e.jpg?1",
             "name": "Breya's Apprentice",
             "text": "When Breya's Apprentice enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\n{T}, Sacrifice an artifact: Choose one \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play that card.\n\u2022 Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "297daae4-aea2-52e7-8347-4d2bc2ccb14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37962700-e4d9-419e-8972-d3fd955ff40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37962700-e4d9-419e-8972-d3fd955ff40e.jpg?1",
             "name": "Calibrated Blast",
             "text": "Reveal cards from the top of your library until you reveal a nonland card. Put the revealed cards on the bottom of your library in a random order. When you reveal a nonland card this way, Calibrated Blast deals damage equal to that card's mana value to any target.\nFlashback {3}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "1ad4cc57-6629-50fd-8336-7fddee83fbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71052204-d35c-4603-9af6-a1691f438d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71052204-d35c-4603-9af6-a1691f438d48.jpg?1",
             "name": "Captain Ripley Vance",
             "text": "Whenever you cast your third spell each turn, put a +1/+1 counter on Captain Ripley Vance, then it deals damage equal to its power to any target.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "91d781ae-b01c-5996-9789-a76df55008fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936ebbd-512a-49a6-ab23-16ac34b4a3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c936ebbd-512a-49a6-ab23-16ac34b4a3a9.jpg?1",
             "name": "Chef's Kiss",
             "text": "Gain control of target spell that targets only a single permanent or player. Copy it, then reselect the targets at random for the spell and the copy. The new targets can't be you or a permanent you control.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "34c7209b-75b9-5bab-a193-71a6fd7dccfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ced112a-e775-4f97-97b3-74877e9dce12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ced112a-e775-4f97-97b3-74877e9dce12.jpg?1",
             "name": "Dragon's Rage Channeler",
             "text": "Whenever you cast a noncreature spell, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\nDelirium \u2014 As long as there are four or more card types among cards in your graveyard, Dragon's Rage Channeler gets +2/+2, has flying, and attacks each combat if able.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "6e52960a-8607-5a5f-98c5-26b1d9792e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8024ce-12c9-4139-934d-fb230103daa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae8024ce-12c9-4139-934d-fb230103daa1.jpg?1",
             "name": "A-Dragon's Rage Channeler",
             "text": "",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "6d39cf23-abef-5606-a810-672cb08045a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed4077-4ed5-48fb-91c9-a9195d652978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed4077-4ed5-48fb-91c9-a9195d652978.jpg?1",
             "name": "Faithless Salvaging",
             "text": "Discard a card, then draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "ab3572c6-348a-55e4-b1a7-3213b23486d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg?1",
             "name": "Fast // Furious",
             "text": "Discard a card, then draw two cards.",
             "colours": [
@@ -4346,7 +4346,7 @@
         },
         {
             "id": "75d613c2-0d81-5e3b-8909-84f149b7ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b209759-6215-49e8-a6a0-a6c94040adb2.jpg?1",
             "name": "Fast // Furious",
             "text": "Furious deals 3 damage to each creature without flying.",
             "colours": [
@@ -4378,7 +4378,7 @@
         },
         {
             "id": "b12be851-2866-5fcc-896a-1ed979949e98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93c6ba8-666b-4c05-8137-8ffa1d5d928b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93c6ba8-666b-4c05-8137-8ffa1d5d928b.jpg?1",
             "name": "Flame Blitz",
             "text": "At the beginning of your end step, Flame Blitz deals 5 damage to each planeswalker.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -4410,7 +4410,7 @@
         },
         {
             "id": "56855e11-cd4d-5baa-82b1-4011cdc187d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ab05b5-d6f5-439c-9aed-1a58ceb282ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ab05b5-d6f5-439c-9aed-1a58ceb282ad.jpg?1",
             "name": "Flametongue Yearling",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nFlametongue Yearling enters the battlefield with a +1/+1 counter on it for each time it was kicked.\nWhen Flametongue Yearling enters the battlefield, it deals damage equal to its power to target creature.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "35b762b0-741a-544d-a178-bde5dd7712d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd281158-8180-40b9-a5b7-03cfc712d81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd281158-8180-40b9-a5b7-03cfc712d81a.jpg?1",
             "name": "Fury",
             "text": "Double strike\nWhen Fury enters the battlefield, it deals 4 damage divided as you choose among any number of target creatures and/or planeswalkers.\nEvoke\u2014\nExile a red card from your hand.",
             "colours": [
@@ -4483,7 +4483,7 @@
         },
         {
             "id": "c3d7c426-71e5-58dc-9d40-1190f5893758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06373318-e548-4664-b227-17e3b6fd0a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06373318-e548-4664-b227-17e3b6fd0a88.jpg?1",
             "name": "Galvanic Relay",
             "text": "Exile the top card of your library. During your next turn, you may play that card.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -4517,7 +4517,7 @@
         },
         {
             "id": "a580932d-339a-56ea-937d-b2fd9de5e841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b672c59-7376-455d-961e-ce94d47a5ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b672c59-7376-455d-961e-ce94d47a5ca4.jpg?1",
             "name": "Gargadon",
             "text": "Trample\nSuspend 4\u2014{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "975f39f4-20fa-59b8-898e-e3f090c3f793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee1fcbc-3573-42c5-b3e3-1f44a6400cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee1fcbc-3573-42c5-b3e3-1f44a6400cd0.jpg?1",
             "name": "Glimpse of Tomorrow",
             "text": "Suspend 3\u2014{R}{R}\nShuffle all permanents you own into your library, then reveal that many cards from the top of your library. Put all non-Aura permanent cards revealed this way onto the battlefield, then do the same for Aura cards, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "3f226ac8-07c4-5c6d-ba52-617246e09079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f0fd37-eb34-418d-b136-03d816c93034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36f0fd37-eb34-418d-b136-03d816c93034.jpg?1",
             "name": "Goblin Traprunner",
             "text": "Whenever Goblin Traprunner attacks, flip three coins. For each flip you win, create a 1/1 red Goblin creature token that's tapped and attacking.",
             "colours": [
@@ -4622,7 +4622,7 @@
         },
         {
             "id": "5bf19897-929a-5bc2-8296-b3212962c7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0595a6-a9e5-4ea8-b733-382e6c365759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0595a6-a9e5-4ea8-b733-382e6c365759.jpg?1",
             "name": "Gouged Zealot",
             "text": "Reach\nDelirium \u2014 Whenever Gouged Zealot attacks, if there are four or more card types among cards in your graveyard, Gouged Zealot deals 1 damage to each creature defending player controls.",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "dbf1c895-2122-598c-b0df-c4654e2c3747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22579ac0-ad3f-4000-a65a-46a17a7f1aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22579ac0-ad3f-4000-a65a-46a17a7f1aa5.jpg?1",
             "name": "Harmonic Prodigy",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nIf an ability of a Shaman or another Wizard you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "f92b2d9c-9942-507f-9fb5-35bacb3eaef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f07603-fd79-437a-9b12-495fc5a39b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f07603-fd79-437a-9b12-495fc5a39b68.jpg?1",
             "name": "Kaleidoscorch",
             "text": "Converge \u2014 Kaleidoscorch deals X damage to any target, where X is the number of colors of mana spent to cast this spell.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4726,7 +4726,7 @@
         },
         {
             "id": "19e23990-573f-528c-86a9-b3588c407384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72fcda4-feb4-46e4-87d9-88bd95474fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72fcda4-feb4-46e4-87d9-88bd95474fe9.jpg?1",
             "name": "Lightning Spear",
             "text": "Equipped creature gets +1/+0 and has trample.\n{2}{R}, Sacrifice Lightning Spear: It deals 3 damage to any target.\nEquip {1}",
             "colours": [
@@ -4760,7 +4760,7 @@
         },
         {
             "id": "7c289f95-f878-54fe-b049-23320d95519c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e2e8b5-660d-4469-a4fe-2367dfadb709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e2e8b5-660d-4469-a4fe-2367dfadb709.jpg?1",
             "name": "Mine Collapse",
             "text": "If it's your turn, you may sacrifice a Mountain rather than pay this spell's mana cost.\nMine Collapse deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "d09d7383-18fb-5957-a397-e1c8d7371639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a356c-b10d-42f2-bb2f-c3fd9affa4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a356c-b10d-42f2-bb2f-c3fd9affa4bd.jpg?1",
             "name": "Mount Velus Manticore",
             "text": "At the beginning of combat on your turn, you may discard a card. When you do, Mount Velus Manticore deals X damage to any target, where X is the number of card types the discarded card has.",
             "colours": [
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "4ceeba04-139b-5375-854d-0417af4a1cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6d08be-a6fc-44a5-932d-b6a8705534c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6d08be-a6fc-44a5-932d-b6a8705534c0.jpg?1",
             "name": "Obsidian Charmaw",
             "text": "This spell costs {1} less to cast for each land your opponents control that could produce {C}.\nFlying\nWhen Obsidian Charmaw enters the battlefield, destroy target nonbasic land an opponent controls.",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "03245f9c-8df0-5763-89fe-9fdfd55acfa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9738cda-adb1-47fb-9f4c-ecd930228c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9738cda-adb1-47fb-9f4c-ecd930228c4d.jpg?1",
             "name": "Ragavan, Nimble Pilferer",
             "text": "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\nDash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "ce2b0e14-d016-5755-a5ed-cdc33ffa6a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8f3008-a3ba-4f73-afa6-ad81074b3196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8f3008-a3ba-4f73-afa6-ad81074b3196.jpg?1",
             "name": "Revolutionist",
             "text": "When Revolutionist enters the battlefield, return target instant or sorcery card from your graveyard to your hand.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "c8752782-2de4-514e-bc73-f8d375ae72cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32691e3f-dea9-45ac-96fe-96b34d5116a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32691e3f-dea9-45ac-96fe-96b34d5116a9.jpg?1",
             "name": "Skophos Reaver",
             "text": "As long as it's your turn, Skophos Reaver gets +2/+0.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "18aad247-fbbe-5d81-93fc-51631927125e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a271f3-ea5f-4947-aac3-b4cffdfa87ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a271f3-ea5f-4947-aac3-b4cffdfa87ac.jpg?1",
             "name": "Slag Strider",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{1}, Sacrifice an artifact: Slag Strider deals 1 damage to any target.",
             "colours": [
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "a41fa9e7-3ac7-5df4-8ab3-7041a86c5c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c1918b-2f7a-4cab-9547-029ebc589000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c1918b-2f7a-4cab-9547-029ebc589000.jpg?1",
             "name": "Spreading Insurrection",
             "text": "Gain control of target creature you don't control until end of turn. Untap that creature. It gains haste until end of turn.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "630aa7b3-3cce-510e-93c8-e3c6cecb87c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c2814-a617-4123-acdf-1b01b2768210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7c2814-a617-4123-acdf-1b01b2768210.jpg?1",
             "name": "Strike It Rich",
             "text": "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "02c756db-2e95-5811-b220-3a25adafb4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55082c8a-d792-4cd8-94b1-d80c65804463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55082c8a-d792-4cd8-94b1-d80c65804463.jpg?1",
             "name": "Tavern Scoundrel",
             "text": "Whenever you win a coin flip, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{1}, {T}, Sacrifice another permanent: Flip a coin.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "f00bdb93-10ca-5f1c-a496-bd927a5dd483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b73d294-6ab1-4051-9b0f-d8e335d37674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b73d294-6ab1-4051-9b0f-d8e335d37674.jpg?1",
             "name": "Unholy Heat",
             "text": "Unholy Heat deals 2 damage to target creature or planeswalker.\nDelirium \u2014 Unholy Heat deals 6 damage instead if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "70f7824d-a4b0-5392-855c-5a44f256a45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d5d2b5-3769-4341-b84e-03771dbb7491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d5d2b5-3769-4341-b84e-03771dbb7491.jpg?1",
             "name": "A-Unholy Heat",
             "text": "",
             "colours": [
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "f9380142-47eb-52b7-8846-0556d638939e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457e346-a5de-4624-b577-f59d4c186537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457e346-a5de-4624-b577-f59d4c186537.jpg?1",
             "name": "Viashino Lashclaw",
             "text": "{T}, Discard a card: Creatures you control gain haste until end of turn.",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "f75dbc69-1235-5f1e-8d85-87fe0e10e162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad86b17-3fed-418a-938c-c49adb409531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad86b17-3fed-418a-938c-c49adb409531.jpg?1",
             "name": "Abundant Harvest",
             "text": "Choose land or nonland. Reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "a915abd3-3577-5bee-81ae-79c30c5dec36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9b1b8-dffe-427d-be1e-2c6b8395bd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe9b1b8-dffe-427d-be1e-2c6b8395bd54.jpg?1",
             "name": "Aeve, Progenitor Ooze",
             "text": "Storm (When you cast this spell, copy it for each spell cast before it this turn. Copies become tokens.)\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "70f751cc-feee-5f1d-8721-e2e865b69707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1271251b-7d79-4cb4-80bb-98574aa63249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1271251b-7d79-4cb4-80bb-98574aa63249.jpg?1",
             "name": "Bannerhide Krushok",
             "text": "Trample\nReinforce 2\u2014{1}{G} ({1}{G}, Discard this card: Put two +1/+1 counters on target creature.)\nScavenge {5}{G}{G} ({5}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "8823bb45-52f3-5e0b-b6a2-8c8242c4593c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217881d-26dc-44c0-81d8-8c78c44bc5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217881d-26dc-44c0-81d8-8c78c44bc5f0.jpg?1",
             "name": "Blessed Respite",
             "text": "Target player shuffles their graveyard into their library. Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -5344,7 +5344,7 @@
         },
         {
             "id": "786db635-7c4f-51ed-80cd-fb28968549ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1785cf85-1ac0-4246-9b89-1a8221a8e1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1785cf85-1ac0-4246-9b89-1a8221a8e1b2.jpg?1",
             "name": "Chatterfang, Squirrel General",
             "text": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)\nIf one or more tokens would be created under your control, those tokens plus that many 1/1 green Squirrel creature tokens are created instead.\n{B}, Sacrifice X Squirrels: Target creature gets +X/-X until end of turn.",
             "colours": [
@@ -5385,7 +5385,7 @@
         },
         {
             "id": "16613a30-fb25-5060-a506-d57655df7724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34f0ac1-6894-4761-b62c-b85d927acf09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34f0ac1-6894-4761-b62c-b85d927acf09.jpg?1",
             "name": "Chatterstorm",
             "text": "Create a 1/1 green Squirrel creature token.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "fc29d230-0403-564e-9c78-902e66f885b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee33ff3-d3d6-4519-9d9f-72e342d8b215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee33ff3-d3d6-4519-9d9f-72e342d8b215.jpg?1",
             "name": "Chitterspitter",
             "text": "At the beginning of your upkeep, you may sacrifice a token. If you do, put an acorn counter on Chitterspitter.\nSquirrels you control get +1/+1 for each acorn counter on Chitterspitter.\n{G}, {T}: Create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -5453,7 +5453,7 @@
         },
         {
             "id": "5ba7cf2a-eecc-589e-ad0c-7099358fd62f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b77a34-9b69-4b01-9f2c-2ff8de47fc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b77a34-9b69-4b01-9f2c-2ff8de47fc12.jpg?1",
             "name": "Crack Open",
             "text": "Destroy target artifact or enchantment. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5485,7 +5485,7 @@
         },
         {
             "id": "58e2d31f-3631-5dbe-b9bc-f892761bec8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333f02f7-3b8a-41e3-9ae5-2151539e64ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333f02f7-3b8a-41e3-9ae5-2151539e64ad.jpg?1",
             "name": "Deepwood Denizen",
             "text": "Vigilance\n{5}{G}, {T}: Draw a card. This ability costs {1} less to activate for each +1/+1 counter on creatures you control.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "032ae38c-deb0-5abe-9434-e07f396d29d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af03fc3-5eb6-404e-96d9-e291a1e11ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af03fc3-5eb6-404e-96d9-e291a1e11ec3.jpg?1",
             "name": "Duskshell Crawler",
             "text": "When Duskshell Crawler enters the battlefield, put a +1/+1 counter on target creature.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -5554,7 +5554,7 @@
         },
         {
             "id": "bba0bda1-9086-533a-91c2-60cfd687952b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e0404-4846-4891-acfa-bd0951ecf9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0e0404-4846-4891-acfa-bd0951ecf9c6.jpg?1",
             "name": "Endurance",
             "text": "Flash\nReach\nWhen Endurance enters the battlefield, up to one target player puts all the cards from their graveyard on the bottom of their library in a random order.\nEvoke\u2014\nExile a green card from your hand.",
             "colours": [
@@ -5591,7 +5591,7 @@
         },
         {
             "id": "39f7da46-44b4-5b1f-8309-8f60b0467bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de8307a-7da3-4a4c-98dc-d6624b1f869d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de8307a-7da3-4a4c-98dc-d6624b1f869d.jpg?1",
             "name": "Fae Offering",
             "text": "At the beginning of each end step, if you've cast both a creature spell and a noncreature spell this turn, create a Clue token, a Food token, and a Treasure token.",
             "colours": [
@@ -5623,7 +5623,7 @@
         },
         {
             "id": "e8b1fe41-463f-561f-b231-b4d91f97daf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4b23a5-d997-4f02-b136-44ee7be51c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4b23a5-d997-4f02-b136-44ee7be51c7b.jpg?1",
             "name": "Flourishing Strike",
             "text": "Choose one \u2014\n\u2022 Flourishing Strike deals 5 damage to target creature with flying.\n\u2022 Target creature gets +3/+3 until end of turn.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "68a8c8e6-1696-5988-9118-52076bffb67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f08381e-34f5-4d08-b737-8c37964719e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f08381e-34f5-4d08-b737-8c37964719e0.jpg?1",
             "name": "Foundation Breaker",
             "text": "When Foundation Breaker enters the battlefield, you may destroy target artifact or enchantment.\nEvoke {1}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -5689,7 +5689,7 @@
         },
         {
             "id": "1b2989a3-2070-50a9-b8ec-c7b148b5ac93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b486c9cf-b0a6-44a4-b4c1-b3f5eed6c294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b486c9cf-b0a6-44a4-b4c1-b3f5eed6c294.jpg?1",
             "name": "Funnel-Web Recluse",
             "text": "Reach\nMorbid \u2014 When Funnel-Web Recluse enters the battlefield, if a creature died this turn, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "1bddc1db-30dc-5515-99f0-880aa56a3cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488996b2-06c8-4866-bf0d-4664640c2be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488996b2-06c8-4866-bf0d-4664640c2be1.jpg?1",
             "name": "Gaea's Will",
             "text": "Suspend 4\u2014{G}\nUntil end of turn, you may play lands and cast spells from your graveyard.\nIf a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -5758,7 +5758,7 @@
         },
         {
             "id": "d6733510-296c-52c2-83cd-f4f829b14cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03250752-bd85-485a-b19a-fa344c4ffd50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03250752-bd85-485a-b19a-fa344c4ffd50.jpg?1",
             "name": "Glimmer Bairn",
             "text": "Sacrifice a token: Glimmer Bairn gets +2/+2 until end of turn.",
             "colours": [
@@ -5794,7 +5794,7 @@
         },
         {
             "id": "dd42029e-2aa7-5ebe-bfc7-a372072a23e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad2438-0b98-4b07-bba9-dff26aa1fc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bad2438-0b98-4b07-bba9-dff26aa1fc3a.jpg?1",
             "name": "Glinting Creeper",
             "text": "Converge \u2014 Glinting Creeper enters the battlefield with two +1/+1 counters on it for each color of mana spent to cast it.\nGlinting Creeper can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -5828,7 +5828,7 @@
         },
         {
             "id": "0a16f035-219d-54dd-b37a-80cbcfc56f25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9cef5-c55f-47d9-9d2f-300dab8fcb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9cef5-c55f-47d9-9d2f-300dab8fcb0b.jpg?1",
             "name": "Herd Baloth",
             "text": "Whenever one or more +1/+1 counters are put on Herd Baloth, you may create a 4/4 green Beast creature token.",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "9fe00ec6-4efb-5672-8361-45b31217f1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba51852-af8f-49d8-8fb6-22d52a1742b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba51852-af8f-49d8-8fb6-22d52a1742b8.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {B}, {R}, or {G}.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "8be5e8e1-056a-55c9-a6d8-4b4d1b1d2c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81500be-c959-4f38-bcf2-d63519168f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81500be-c959-4f38-bcf2-d63519168f67.jpg?1",
             "name": "Jade Avenger",
             "text": "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "68aa0ff7-db4d-5ada-884c-0f5b0afb175b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8db60d-3adf-45e1-b4d0-3b5e24f5e01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8db60d-3adf-45e1-b4d0-3b5e24f5e01d.jpg?1",
             "name": "Jewel-Eyed Cobra",
             "text": "Deathtouch\nWhen Jewel-Eyed Cobra dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5973,7 +5973,7 @@
         },
         {
             "id": "b627a97f-d93a-5621-bc0d-1f9a43d9f9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386da156-59cd-4b96-9276-a7cb2ddd0421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386da156-59cd-4b96-9276-a7cb2ddd0421.jpg?1",
             "name": "Orchard Strider",
             "text": "When Orchard Strider enters the battlefield, create two Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "3d7d671d-b317-54b0-a5c4-ed7dbe1895d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dbd212-f1e8-429a-bf00-b2ea966d880e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97dbd212-f1e8-429a-bf00-b2ea966d880e.jpg?1",
             "name": "Rift Sower",
             "text": "{T}: Add one mana of any color.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -6042,7 +6042,7 @@
         },
         {
             "id": "a171ca5b-21d9-5eb0-8b34-0c10baa7e85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42e22d-f60e-40c5-b069-5e1708f3bebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42e22d-f60e-40c5-b069-5e1708f3bebc.jpg?1",
             "name": "Sanctum Weaver",
             "text": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
             "colours": [
@@ -6079,7 +6079,7 @@
         },
         {
             "id": "4a592365-8d77-51d4-92ce-0d260b655c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb48c2e-ee0f-4fae-9c22-247870c10d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb48c2e-ee0f-4fae-9c22-247870c10d5b.jpg?1",
             "name": "Scurry Oak",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever one or more +1/+1 counters are put on Scurry Oak, you may create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -6113,7 +6113,7 @@
         },
         {
             "id": "6febda23-d8db-5d34-aacd-604ce7ada5b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956a2a42-6a91-45b5-99f1-87c2cf1dd608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956a2a42-6a91-45b5-99f1-87c2cf1dd608.jpg?1",
             "name": "Smell Fear",
             "text": "Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nTarget creature you control fights up to one target creature you don't control.",
             "colours": [
@@ -6145,7 +6145,7 @@
         },
         {
             "id": "bf913d4a-4ffe-5d8e-9653-25858944c371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6ab503-5e9a-4339-a0e7-a909b2908f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6ab503-5e9a-4339-a0e7-a909b2908f41.jpg?1",
             "name": "Squirrel Sanctuary",
             "text": "When Squirrel Sanctuary enters the battlefield, create a 1/1 green Squirrel creature token.\nWhenever a nontoken creature you control dies, you may pay {1}. If you do, return Squirrel Sanctuary to its owner's hand.",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "ef7206ea-4035-5f0b-9be2-9244d488557a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f739d55-30d6-4879-872a-82c6778113de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f739d55-30d6-4879-872a-82c6778113de.jpg?1",
             "name": "Squirrel Sovereign",
             "text": "Other Squirrels you control get +1/+1.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "7fa2b918-4c94-57d5-bc74-d74e032fb17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg?1",
             "name": "Sylvan Anthem",
             "text": "Green creatures you control get +1/+1.\nWhenever a green creature enters the battlefield under your control, scry 1.",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "7d0db270-7867-5eae-b17d-43faf4a87b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b08596-f6c7-4366-a4ed-21a11fbc901a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b08596-f6c7-4366-a4ed-21a11fbc901a.jpg?1",
             "name": "Terramorph",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "ec7313ae-020f-5223-b174-ba0b6dfa515d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172da14-9a87-4cf9-aff5-aca3470a67ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6172da14-9a87-4cf9-aff5-aca3470a67ef.jpg?1",
             "name": "Thrasta, Tempest's Roar",
             "text": "This spell costs {3} less to cast for each other spell cast this turn.\nTrample, haste\nTrample over planeswalkers (This creature can deal excess combat damage to the controller of the planeswalker it's attacking.)\nThrasta, Tempest's Roar has hexproof as long as it entered the battlefield this turn.",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "921bad4c-b100-51b6-a988-b2e0e93c8f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22c07e2-91d2-4edb-bd2b-cca6d4cefcc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22c07e2-91d2-4edb-bd2b-cca6d4cefcc9.jpg?1",
             "name": "Timeless Witness",
             "text": "When Timeless Witness enters the battlefield, return target card from your graveyard to your hand.\nEternalize {5}{G}{G} ({5}{G}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Human Shaman with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -6355,7 +6355,7 @@
         },
         {
             "id": "05b1bbe5-5e39-51e6-940e-352de3185cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5be54d-660e-42ab-b5ea-5e1cf3bad0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5be54d-660e-42ab-b5ea-5e1cf3bad0bc.jpg?1",
             "name": "Tireless Provisioner",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a Food token or a Treasure token. (Food is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\" Treasure is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6390,7 +6390,7 @@
         },
         {
             "id": "d4bdc3c4-08cb-5fee-b4ac-001500fd9731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab83a39-d90d-403e-b74d-fe99c8b2aacd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab83a39-d90d-403e-b74d-fe99c8b2aacd.jpg?1",
             "name": "Urban Daggertooth",
             "text": "Vigilance\nEnrage \u2014 Whenever Urban Daggertooth is dealt damage, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "3ed1ee79-8985-525d-a7b0-a0fe80820a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83031ea8-a6c9-4318-af16-bba701dd76bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83031ea8-a6c9-4318-af16-bba701dd76bb.jpg?1",
             "name": "Verdant Command",
             "text": "Choose two \u2014\n\u2022 Target player creates two tapped 1/1 green Squirrel creature tokens.\n\u2022 Counter target loyalty ability of a planeswalker.\n\u2022 Exile target card from a graveyard.\n\u2022 Target player gains 3 life.",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "bb0d88ef-8ea4-5e9e-9449-a02d99654564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5198ac65-118c-4616-8315-d71d41b883ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5198ac65-118c-4616-8315-d71d41b883ad.jpg?1",
             "name": "Wren's Run Hydra",
             "text": "Reach\nWren's Run Hydra enters the battlefield with X +1/+1 counters on it.\nReinforce X\u2014{X}{G}{G} ({X}{G}{G}, Discard this card: Put X +1/+1 counters on target creature.)",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "b52cb624-9eb4-5c02-b583-f10a42e05591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54c510-19bf-4da4-a51b-1caadf960654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54c510-19bf-4da4-a51b-1caadf960654.jpg?1",
             "name": "Arcbound Shikari",
             "text": "First strike\nWhen Arcbound Shikari enters the battlefield, put a +1/+1 counter on each other artifact creature you control.\nModular 2 (This creature enters the battlefield with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [
@@ -6532,7 +6532,7 @@
         },
         {
             "id": "cd40b240-991a-50f7-8dbc-b900187fd96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8546eaa-1e64-4e70-b6a5-85892bab8c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8546eaa-1e64-4e70-b6a5-85892bab8c47.jpg?1",
             "name": "Arcus Acolyte",
             "text": "Reach, lifelink\nOutlast {RW} ({RW}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nEach other creature you control without a +1/+1 counter on it has outlast {RW}.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "901d71b1-77da-542e-bd5d-703c0c6ab5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a9a7d-d9ca-4c11-80ab-e39d5943a315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99a9a7d-d9ca-4c11-80ab-e39d5943a315.jpg?1",
             "name": "Asmoranomardicadaistinaculdacar",
             "text": "As long as you've discarded a card this turn, you may pay {BR} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters the battlefield, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "59049ca3-0cbb-58f8-af19-b51f6a0cdd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4785739-821d-49b0-a298-3c2b95e16972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4785739-821d-49b0-a298-3c2b95e16972.jpg?1",
             "name": "Breathless Knight",
             "text": "Flying, lifelink\nWhenever Breathless Knight or another creature enters the battlefield under your control, if that creature entered from a graveyard or you cast it from a graveyard, put a +1/+1 counter on Breathless Knight.",
             "colours": [
@@ -6651,7 +6651,7 @@
         },
         {
             "id": "e08c8e8d-c6b1-5e07-ac95-803a45b986ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1c2a8-688b-4f63-8d58-e325efc6052a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce1c2a8-688b-4f63-8d58-e325efc6052a.jpg?1",
             "name": "Captured by Lagacs",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nWhen Captured by Lagacs enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two target creatures.)",
             "colours": [
@@ -6687,7 +6687,7 @@
         },
         {
             "id": "2256eea9-574e-5d43-beff-766e6c908143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09e9b65-ff0e-4efe-b96a-ede69c96e2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09e9b65-ff0e-4efe-b96a-ede69c96e2ea.jpg?1",
             "name": "Carth the Lion",
             "text": "Whenever Carth the Lion enters the battlefield or a planeswalker you control dies, look at the top seven cards of your library. You may reveal a planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nPlaneswalkers' loyalty abilities you activate cost an additional  to activate.",
             "colours": [
@@ -6729,7 +6729,7 @@
         },
         {
             "id": "7865399b-cae1-51b9-a659-fae243390308",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d8da1-a183-470a-b4ed-2e35ac5ab9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d8da1-a183-470a-b4ed-2e35ac5ab9a9.jpg?1",
             "name": "Chrome Courier",
             "text": "Flying\nWhen Chrome Courier enters the battlefield, reveal the top two cards of your library. Put one of them into your hand and the other into your graveyard. If you put an artifact card into your hand this way, you gain 3 life.",
             "colours": [
@@ -6766,7 +6766,7 @@
         },
         {
             "id": "96cf6577-a58f-5c40-bb73-3b102049d970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d54ec2-a458-4e13-97b8-be99b7338548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d54ec2-a458-4e13-97b8-be99b7338548.jpg?1",
             "name": "Combine Chrysalis",
             "text": "Creature tokens you control have flying.\n{2}{G}{U}, {T}, Sacrifice a token: Create a 4/4 green Beast creature token. Activate only as a sorcery.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "7f38cd7c-eb22-5b85-bad6-53e75d512bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0013a9c4-77a1-418d-85c2-bd68b65cd3d4.jpg?1",
             "name": "Dakkon, Shadow Slayer",
             "text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n\u22123: Exile target creature.\n\u22126: You may put an artifact card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "0339991b-f176-5833-8b0e-7da99bd7f562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091e8dc-b546-4b74-9dc9-aef55f60d13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9091e8dc-b546-4b74-9dc9-aef55f60d13a.jpg?1",
             "name": "Dihada's Ploy",
             "text": "Draw two cards, then discard a card. You gain life equal to the number of cards you've discarded this turn.\nJump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "c599288b-7492-5821-ad27-bd901fa9ae7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995529d1-e2b0-4cce-bd40-56c7ef3c33da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995529d1-e2b0-4cce-bd40-56c7ef3c33da.jpg?1",
             "name": "Drey Keeper",
             "text": "When Drey Keeper enters the battlefield, create two 1/1 green Squirrel creature tokens.\n{3}{B}: Squirrels you control get +1/+0 and gain menace until end of turn.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "6cd3dbef-d86a-5e85-967c-6f3352677908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315ae21a-4d95-488e-812b-0d018219af6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315ae21a-4d95-488e-812b-0d018219af6c.jpg?1",
             "name": "Ethersworn Sphinx",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card with lesser mana value. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -6955,7 +6955,7 @@
         },
         {
             "id": "b8ac34f1-8ac7-53fd-9b76-060ac0f2b49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c54b7c6-f94c-4349-8725-319c54240409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c54b7c6-f94c-4349-8725-319c54240409.jpg?1",
             "name": "Foundry Helix",
             "text": "As an additional cost to cast this spell, sacrifice a permanent.\nFoundry Helix deals 4 damage to any target. If the sacrificed permanent was an artifact, you gain 4 life.",
             "colours": [
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "38f03b7e-f44a-554b-ad1d-c9f4876db2de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23774462-9f17-4b50-a2ac-b2edd706bbfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23774462-9f17-4b50-a2ac-b2edd706bbfe.jpg?1",
             "name": "Garth One-Eye",
             "text": "{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy. (You still pay its costs.)",
             "colours": [
@@ -7037,7 +7037,7 @@
         },
         {
             "id": "0347fbcf-2de8-5c4e-93bb-569c46ebb9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600dca0f-5964-45e7-86df-f16a5b4a0106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600dca0f-5964-45e7-86df-f16a5b4a0106.jpg?1",
             "name": "General Ferrous Rokiric",
             "text": "Hexproof from monocolored\nWhenever you cast a multicolored spell, create a 4/4 red and white Golem artifact creature token.",
             "colours": [
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "022b3dd6-a6c7-506f-bf99-27a19430b061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d228005-91f1-451e-ab6f-1f86316708a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d228005-91f1-451e-ab6f-1f86316708a7.jpg?1",
             "name": "Geyadrone Dihada",
             "text": "Protection from permanents with corruption counters on them\n+1: Each opponent loses 2 life and you gain 2 life. Put a corruption counter on up to one other target creature or planeswalker.\n\u22123: Gain control of target creature or planeswalker until end of turn. Untap it and put a corruption counter on it. It gains haste until end of turn.\n\u22127: Gain control of each permanent with a corruption counter on it.",
             "colours": [
@@ -7121,7 +7121,7 @@
         },
         {
             "id": "038fb204-7715-5533-b910-52bc58bf2f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a3423-501d-4b22-95a6-743233be521e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a3423-501d-4b22-95a6-743233be521e.jpg?1",
             "name": "Goblin Anarchomancer",
             "text": "Each spell you cast that's red or green costs {1} less to cast.",
             "colours": [
@@ -7160,7 +7160,7 @@
         },
         {
             "id": "d4ddd301-0455-5b3f-8b5f-f5d36838f79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d7c3c-02f2-4c42-bcfa-0b83de30f607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d7c3c-02f2-4c42-bcfa-0b83de30f607.jpg?1",
             "name": "Graceful Restoration",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to the battlefield with an additional +1/+1 counter on it.\n\u2022 Return up to two target creature cards with power 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "60b27752-6378-5bba-8b0a-936f9febede2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af2825-18c2-4463-b6ba-42eaa070ccc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af2825-18c2-4463-b6ba-42eaa070ccc1.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n+1: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n\u22122: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n\u22125: Each opponent loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -7235,7 +7235,7 @@
         },
         {
             "id": "1f5b63a5-768d-56d5-b61b-f839482228d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e68f3d-ef94-4651-a256-c72017f64b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e68f3d-ef94-4651-a256-c72017f64b21.jpg?1",
             "name": "Lazotep Chancellor",
             "text": "Whenever you discard a card, you may pay {1}. If you do, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "344ebfca-3a74-5819-a151-1be263315158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd08da-6717-49ee-94ba-2562224f5baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfd08da-6717-49ee-94ba-2562224f5baa.jpg?1",
             "name": "Lonis, Cryptozoologist",
             "text": "Whenever another nontoken creature enters the battlefield under your control, investigate.\n{T}, Sacrifice X Clues: Target opponent reveals the top X cards of their library. You may put a nonland permanent card with mana value X or less from among them onto the battlefield under your control. That player puts the rest on the bottom of their library in a random order.",
             "colours": [
@@ -7316,7 +7316,7 @@
         },
         {
             "id": "d87624b2-9aad-5de3-b0fd-c6fbcd9cc01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9775175-6763-4826-afc8-dc520a235c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9775175-6763-4826-afc8-dc520a235c36.jpg?1",
             "name": "Master of Death",
             "text": "When Master of Death enters the battlefield, surveil 2.\nAt the beginning of your upkeep, if Master of Death is in your graveyard, you may pay 1 life. If you do, return it to your hand.",
             "colours": [
@@ -7355,7 +7355,7 @@
         },
         {
             "id": "53a2b4a5-db12-5bd5-bce6-2582712e9136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41b3d7a-f8e1-46b8-a689-6125dcd9cb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41b3d7a-f8e1-46b8-a689-6125dcd9cb17.jpg?1",
             "name": "Moderation",
             "text": "You can't cast more than one spell each turn.\nWhenever you cast a spell, draw a card.",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "fdc3ee1f-6310-5350-9dc0-c91441d4dccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82d946-1efb-4253-84ab-93c88d2d1d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e82d946-1efb-4253-84ab-93c88d2d1d84.jpg?1",
             "name": "Piru, the Volatile",
             "text": "Flying, lifelink\nAt the beginning of your upkeep, sacrifice Piru, the Volatile unless you pay {R}{W}{B}.\nWhen Piru dies, it deals 7 damage to each nonlegendary creature.",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "aee62f4e-1c56-53c0-bac8-4744fe4312e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116329d-6de7-402c-821d-e9aeba9ad2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d116329d-6de7-402c-821d-e9aeba9ad2b1.jpg?1",
             "name": "Priest of Fell Rites",
             "text": "{T}, Pay 3 life, Sacrifice Priest of Fell Rites: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.\nUnearth {3}{W}{B} ({3}{W}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "42d8848b-6238-5f45-bb6f-c1ed25f92e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b92ae-eb84-4548-a5e5-a07c79b77f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b92ae-eb84-4548-a5e5-a07c79b77f7f.jpg?1",
             "name": "Prophetic Titan",
             "text": "Delirium \u2014 When Prophetic Titan enters the battlefield, choose one. If there are four or more card types among cards in your graveyard, choose both instead.\n\u2022 Prophetic Titan deals 4 damage to any target.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "468202d6-ac9b-599a-b285-d85eb43ec11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6576b-605c-4007-a2a7-0d7550520d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6576b-605c-4007-a2a7-0d7550520d6d.jpg?1",
             "name": "Rakdos Headliner",
             "text": "Haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "a8cf40cf-8cdc-510d-8ecd-cc5c91a8b023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f44a15c-1bb4-4fb8-88a0-e4d3f2dee1b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f44a15c-1bb4-4fb8-88a0-e4d3f2dee1b4.jpg?1",
             "name": "Ravenous Squirrel",
             "text": "Whenever you sacrifice an artifact or creature, put a +1/+1 counter on Ravenous Squirrel.\n{1}{B}{G}, Sacrifice an artifact or creature: You gain 1 life and draw a card.",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "d0245e59-81bc-58ec-974d-49f6335d7568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg?1",
             "name": "Road // Ruin",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "32f25efe-29ab-5926-a6e8-ebe09c8c26cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f336b4d4-9a84-4a87-a8ea-a83a842890ee.jpg?1",
             "name": "Road // Ruin",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nRuin deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -7659,7 +7659,7 @@
         },
         {
             "id": "5c90b22c-6747-518c-9bff-2edb76df45d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d22f24-f752-4bc8-ba97-061b2c060ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d22f24-f752-4bc8-ba97-061b2c060ec8.jpg?1",
             "name": "Storm God's Oracle",
             "text": "{1}: Storm God's Oracle gets +1/-1 until end of turn.\nWhen Storm God's Oracle dies, it deals 3 damage to any target.",
             "colours": [
@@ -7697,7 +7697,7 @@
         },
         {
             "id": "c8395ba1-79c0-5c6a-88f0-bfbf55cbf023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0babfe00-9bad-48fc-b3b1-df8280242fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0babfe00-9bad-48fc-b3b1-df8280242fd2.jpg?1",
             "name": "Sythis, Harvest's Hand",
             "text": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "ccb85cb5-9903-5f25-91d4-9ddc338161d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e94ad-0e12-48bb-aae1-2c842943114a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e94ad-0e12-48bb-aae1-2c842943114a.jpg?1",
             "name": "Terminal Agony",
             "text": "Destroy target creature.\nMadness {B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -7774,7 +7774,7 @@
         },
         {
             "id": "0c7ac7ef-8309-5d9c-9948-af923774e24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2605df98-0b02-4aab-bc36-01e93c693743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2605df98-0b02-4aab-bc36-01e93c693743.jpg?1",
             "name": "Territorial Kavu",
             "text": "Domain \u2014 Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.\nWhenever Territorial Kavu attacks, choose one \u2014\n\u2022 Discard a card. If you do, draw a card.\n\u2022 Exile up to one target card from a graveyard.",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "bb679e2e-59ba-5c19-8418-2d416596f7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a269277-7f4e-40de-a2b4-53aa50cfd665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a269277-7f4e-40de-a2b4-53aa50cfd665.jpg?1",
             "name": "Wavesifter",
             "text": "Flying\nWhen Wavesifter enters the battlefield, investigate twice. (To investigate, create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nEvoke {G}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -7849,7 +7849,7 @@
         },
         {
             "id": "f0e7a4a5-3f8d-5dde-a378-b6019e7998be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfab9e33-0d07-46e6-be06-1eaffe26cbfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfab9e33-0d07-46e6-be06-1eaffe26cbfd.jpg?1",
             "name": "Yusri, Fortune's Flame",
             "text": "Flying\nWhenever Yusri, Fortune's Flame attacks, choose a number between 1 and 5. Flip that many coins. For each flip you win, draw a card. For each flip you lose, Yusri deals 2 damage to you. If you won five flips this way, you may cast spells from your hand this turn without paying their mana costs.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "8a5ba1bf-3ecb-552c-9a77-49f5bc54d21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90744c2c-6dd7-4623-8cbf-b138b83ee88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90744c2c-6dd7-4623-8cbf-b138b83ee88f.jpg?1",
             "name": "Academy Manufactor",
             "text": "If you would create a Clue, Food, or Treasure token, instead create one of each.",
             "colours": [],
@@ -7923,7 +7923,7 @@
         },
         {
             "id": "520e18b6-c118-57a9-9045-9dd3873daf0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b3a98f-2b3c-438b-b78c-eef8d917f68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b3a98f-2b3c-438b-b78c-eef8d917f68e.jpg?1",
             "name": "Altar of the Goyf",
             "text": "Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of card types among cards in all graveyards.\nLhurgoyf creatures you control have trample.",
             "colours": [],
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "8e0f6bde-da2a-5a7f-99c6-2d7b039a9545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94266c32-774f-42fa-84d7-7b646c950587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94266c32-774f-42fa-84d7-7b646c950587.jpg?1",
             "name": "Batterbone",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1 and has vigilance and lifelink.\nEquip {5}",
             "colours": [],
@@ -7984,7 +7984,7 @@
         },
         {
             "id": "1d1893c3-2f98-5626-b354-1748328f838a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a36a1-b2e3-4779-b8a7-66f01c488bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a36a1-b2e3-4779-b8a7-66f01c488bf0.jpg?1",
             "name": "Bottle Golems",
             "text": "Trample\nWhen Bottle Golems dies, you gain life equal to its power.",
             "colours": [],
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "0eb43c00-9e9f-5764-aafa-8d82b0011b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9a9f6-5be5-47aa-8e2f-576d06c5abb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9a9f6-5be5-47aa-8e2f-576d06c5abb9.jpg?1",
             "name": "Brainstone",
             "text": "{2}, {T}, Sacrifice Brainstone: Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [],
@@ -8045,7 +8045,7 @@
         },
         {
             "id": "1ab21c82-3c73-5c52-bfbd-a7713daaed49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a37428-e969-4c0c-8e1c-55d1adf9c171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43a37428-e969-4c0c-8e1c-55d1adf9c171.jpg?1",
             "name": "Dermotaxi",
             "text": "Imprint \u2014 As Dermotaxi enters the battlefield, exile a creature card from a graveyard.\nTap two untapped creatures you control: Until end of turn, Dermotaxi becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "c6752631-71a3-55cf-b58a-ad29bd99e064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317a8ed5-1ec2-4a5d-a606-8c6ba781c8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317a8ed5-1ec2-4a5d-a606-8c6ba781c8a3.jpg?1",
             "name": "Diamond Lion",
             "text": "{T}, Discard your hand, Sacrifice Diamond Lion: Add three mana of any one color. Activate only as an instant.",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "7680da45-392c-5b86-96df-9164599a2ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd401525-b874-4af2-99a3-c2c83e22547e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd401525-b874-4af2-99a3-c2c83e22547e.jpg?1",
             "name": "Fodder Tosser",
             "text": "{T}, Discard a card: Fodder Tosser deals 2 damage to target player or planeswalker.",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "cc1d3799-8da6-51a4-9a77-a373fe5a0d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2855-6b14-44dd-a398-7dc2bbae081f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cc2855-6b14-44dd-a398-7dc2bbae081f.jpg?1",
             "name": "Kaldra Compleat",
             "text": "Living weapon\nIndestructible\nEquipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"\nEquip {7}",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "67ad2b48-2b8e-583b-b5f5-f8d4d808cff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6101a-da40-4785-8ccb-4e779bbbdb55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c6101a-da40-4785-8ccb-4e779bbbdb55.jpg?1",
             "name": "Liquimetal Torque",
             "text": "{T}: Add {C}.\n{T}: Target nonland permanent becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -8203,7 +8203,7 @@
         },
         {
             "id": "78532063-e9e5-5761-b911-cdf4a65b4f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736aae2-5136-4f8f-9283-baf6b542a6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4736aae2-5136-4f8f-9283-baf6b542a6a8.jpg?1",
             "name": "Monoskelion",
             "text": "Monoskelion enters the battlefield with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from Monoskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "1b31525f-16f0-5d0a-a7d8-cb2c2b1546c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9072a5-bd7f-4007-a34a-ebe251c95356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9072a5-bd7f-4007-a34a-ebe251c95356.jpg?1",
             "name": "Myr Scrapling",
             "text": "Sacrifice Myr Scrapling: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "76f97ff8-a66c-522b-bf47-d13bfd54e2d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0bb5dc-75a6-4bd6-81f8-611197fb0fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0bb5dc-75a6-4bd6-81f8-611197fb0fba.jpg?1",
             "name": "Nettlecyst",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1 for each artifact and/or enchantment you control.\nEquip {2}",
             "colours": [],
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "04f24e88-2479-53e9-8304-c92fda486f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b0f0f-daf6-4071-82e7-39c015447ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025b0f0f-daf6-4071-82e7-39c015447ce4.jpg?1",
             "name": "Ornithopter of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8332,7 +8332,7 @@
         },
         {
             "id": "69d774ad-9cd5-549b-ad03-993f39743c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdb1eb-2546-4c1a-bfab-ef61bdadd364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbdb1eb-2546-4c1a-bfab-ef61bdadd364.jpg?1",
             "name": "Sanctuary Raptor",
             "text": "Flying\nWhenever Sanctuary Raptor attacks, if you control three or more tokens, Sanctuary Raptor gets +2/+0 and gains first strike until end of turn.",
             "colours": [],
@@ -8363,7 +8363,7 @@
         },
         {
             "id": "34888b02-a686-57d5-afa7-7cb95677e748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7da55c-7f05-46b2-aa3c-17f8d5df46bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e7da55c-7f05-46b2-aa3c-17f8d5df46bb.jpg?1",
             "name": "Scion of Draco",
             "text": "Domain \u2014 This spell costs {2} less to cast for each basic land type among lands you control.\nFlying\nEach creature you control has vigilance if it's white, hexproof if it's blue, lifelink if it's black, first strike if it's red, and trample if it's green.",
             "colours": [],
@@ -8397,7 +8397,7 @@
         },
         {
             "id": "87404031-4ab5-5e33-85fd-e9d28fc3d84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6af084-eee7-4259-a58b-a866e0cf171b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6af084-eee7-4259-a58b-a866e0cf171b.jpg?1",
             "name": "Sojourner's Companion",
             "text": "Affinity for artifacts\nArtifact landcycling {2} ({2}, Discard this card: Search your library for an artifact land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -8428,7 +8428,7 @@
         },
         {
             "id": "f3baa6f6-e959-56ba-aa21-9ad94ee92f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb64d-cc0c-400d-971f-78c28d42043b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51fb64d-cc0c-400d-971f-78c28d42043b.jpg?1",
             "name": "Sol Talisman",
             "text": "Suspend 3\u2014{1} (Rather than cast this card from your hand, pay {1} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}: Add {C}{C}.",
             "colours": [],
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "82ce247b-693a-50cf-9f22-983169c33a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dcff03-0ef9-4485-80db-5447e9ca4ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8dcff03-0ef9-4485-80db-5447e9ca4ef9.jpg?1",
             "name": "Steel Dromedary",
             "text": "Steel Dromedary enters the battlefield tapped with two +1/+1 counters on it.\nSteel Dromedary doesn't untap during your untap step if it has a +1/+1 counter on it.\nAt the beginning of combat on your turn, you may move a +1/+1 counter from Steel Dromedary onto target creature.",
             "colours": [],
@@ -8490,7 +8490,7 @@
         },
         {
             "id": "1ab41f4c-6b24-57d9-8556-9776d1d0e850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16fabbe-4557-4067-b882-f2e5dbd8b458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16fabbe-4557-4067-b882-f2e5dbd8b458.jpg?1",
             "name": "Sword of Hearth and Home",
             "text": "Equipped creature gets +2/+2 and has protection from green and from white.\nWhenever equipped creature deals combat damage to a player, exile up to one target creature you own, then search your library for a basic land card. Put both cards onto the battlefield under your control, then shuffle.\nEquip {2}",
             "colours": [],
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "67418a30-da25-53a2-a6d5-ca808f3a858d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05900f1d-f065-4656-a8a2-2f719d3fdea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05900f1d-f065-4656-a8a2-2f719d3fdea8.jpg?1",
             "name": "Tormod's Cryptkeeper",
             "text": "Vigilance\n{T}, Sacrifice Tormod's Cryptkeeper: Exile all cards from target player's graveyard.",
             "colours": [],
@@ -8554,7 +8554,7 @@
         },
         {
             "id": "c17b1c09-8833-55e0-b179-30c224b45280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039d62b0-3309-4424-a2ea-5a0d88d4bd72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039d62b0-3309-4424-a2ea-5a0d88d4bd72.jpg?1",
             "name": "The Underworld Cookbook",
             "text": "{T}, Discard a card: Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{4}, {T}, Sacrifice The Underworld Cookbook: Return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -8584,7 +8584,7 @@
         },
         {
             "id": "a453830c-3252-5974-ab60-cc6e1a3a73a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc098a4-24fa-492f-91f0-2e8b482c823b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc098a4-24fa-492f-91f0-2e8b482c823b.jpg?1",
             "name": "Vectis Gloves",
             "text": "Equipped creature gets +2/+0 and has artifact landwalk. (It can't be blocked as long as defending player controls an artifact land.)\nEquip {2}",
             "colours": [],
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "ff6a689c-066a-5ed3-86a6-6962d8d58482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f906219-7a6a-427b-93c4-4d958cbd171c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f906219-7a6a-427b-93c4-4d958cbd171c.jpg?1",
             "name": "Void Mirror",
             "text": "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.",
             "colours": [],
@@ -8645,7 +8645,7 @@
         },
         {
             "id": "fde4274c-143f-5781-8a2d-7a976c87f982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1cce91-7c81-45d9-bbec-b085e794791d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1cce91-7c81-45d9-bbec-b085e794791d.jpg?1",
             "name": "Zabaz, the Glimmerwasp",
             "text": "Modular 1\nIf a modular triggered ability would put one or more +1/+1 counters on a creature you control, that many plus one +1/+1 counters are put on it instead.\n{R}: Destroy target artifact you control.\n{W}: Zabaz, the Glimmerwasp gains flying until end of turn.",
             "colours": [],
@@ -8683,7 +8683,7 @@
         },
         {
             "id": "eacc9461-eb57-5cb3-80f5-53e12fe4f636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ac5405-df7b-4097-914a-022cb18e20d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ac5405-df7b-4097-914a-022cb18e20d4.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8714,7 +8714,7 @@
         },
         {
             "id": "0a214ff3-53f8-553a-b591-3582c89c54cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f0be9-b9f7-45d2-9499-c5d849d7289f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f0be9-b9f7-45d2-9499-c5d849d7289f.jpg?1",
             "name": "Darkmoss Bridge",
             "text": "Darkmoss Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "98c43a3d-fec1-55b8-9103-80045be75986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b46b8d8-723a-4752-b97d-29ef83bd294c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b46b8d8-723a-4752-b97d-29ef83bd294c.jpg?1",
             "name": "Drossforge Bridge",
             "text": "Drossforge Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "cc5dbcc1-8c94-5987-b8a7-1dcde3125f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe2a1fa-196f-497f-a15f-0b3b04da9cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe2a1fa-196f-497f-a15f-0b3b04da9cbb.jpg?1",
             "name": "Goldmire Bridge",
             "text": "Goldmire Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8810,7 +8810,7 @@
         },
         {
             "id": "c906dbd7-1cd9-537b-a77f-151bb313968a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3ba6d-eb7f-4f5b-9a3b-c6239c3baa42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3ba6d-eb7f-4f5b-9a3b-c6239c3baa42.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "b4ed5b8a-8e02-5c2b-9066-0005c097ce65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f36a6e2-3e51-4a30-a225-10cfe6650b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f36a6e2-3e51-4a30-a225-10cfe6650b9d.jpg?1",
             "name": "Mistvault Bridge",
             "text": "Mistvault Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "618347b5-eec2-599a-ba6b-d980629d76a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88231c0d-0cc8-44ec-bf95-81d1710ac141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88231c0d-0cc8-44ec-bf95-81d1710ac141.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8904,7 +8904,7 @@
         },
         {
             "id": "ae0e75fc-b4b3-5b43-b4ec-c41d2af0ff20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032eba04-0a63-4823-85e1-64861330a8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032eba04-0a63-4823-85e1-64861330a8d7.jpg?1",
             "name": "Power Depot",
             "text": "Power Depot enters the battlefield tapped.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast artifact spells or activate abilities of artifacts.\nModular 1",
             "colours": [],
@@ -8933,7 +8933,7 @@
         },
         {
             "id": "91a67d40-7eef-5698-a103-c1b3dc6d485c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea7395-430e-4036-92c9-17a850ec2371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea7395-430e-4036-92c9-17a850ec2371.jpg?1",
             "name": "Razortide Bridge",
             "text": "Razortide Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "31222abc-7d80-5b7d-a81c-9419f44ab69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2207467a-b82a-47ae-8867-15a859328fe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2207467a-b82a-47ae-8867-15a859328fe9.jpg?1",
             "name": "Rustvale Bridge",
             "text": "Rustvale Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8997,7 +8997,7 @@
         },
         {
             "id": "541be1a7-4131-5604-8028-a5e98bcd42e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e491c5-8c07-449b-b2f1-ffa052e6d311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e491c5-8c07-449b-b2f1-ffa052e6d311.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -9028,7 +9028,7 @@
         },
         {
             "id": "dadf31cc-05f1-5dcf-8c03-b3df7d3681cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80dc025-c2c4-48c2-8354-7d9ddb430eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80dc025-c2c4-48c2-8354-7d9ddb430eb9.jpg?1",
             "name": "Silverbluff Bridge",
             "text": "Silverbluff Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9060,7 +9060,7 @@
         },
         {
             "id": "993312f0-e06d-5d20-b214-8e315f71000b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51b48e9-a75a-4acd-9462-5e1ac2b0d803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51b48e9-a75a-4acd-9462-5e1ac2b0d803.jpg?1",
             "name": "Slagwoods Bridge",
             "text": "Slagwoods Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "5c1ff42a-ffdc-5a01-8a1d-3517fcba1a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d2b895-8921-4615-a674-fb85eed5ea3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d2b895-8921-4615-a674-fb85eed5ea3f.jpg?1",
             "name": "Tanglepool Bridge",
             "text": "Tanglepool Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9124,7 +9124,7 @@
         },
         {
             "id": "0398f334-e03a-594d-8ae0-34a9c9f4b31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d483643-6a11-47f7-a0aa-190e0179525f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d483643-6a11-47f7-a0aa-190e0179525f.jpg?1",
             "name": "Thornglint Bridge",
             "text": "Thornglint Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9156,7 +9156,7 @@
         },
         {
             "id": "fcfeffd1-6b2b-5bc1-9ae1-17de53cca3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e0f201-42cb-46a1-901a-65bb4fc18f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e0f201-42cb-46a1-901a-65bb4fc18f6c.jpg?1",
             "name": "Urza's Saga",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Urza's Saga gains \"{T}: Add {C}.\"\nII \u2014 Urza's Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with \u2018\nThis creature gets +1/+1 for each artifact you control.'\"\nIII \u2014 Search your library for an artifact card with mana cost {0} or {1}, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -9190,7 +9190,7 @@
         },
         {
             "id": "dcbd60a9-189b-5389-b38e-a3fee3f29395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c229ea-90da-4aa0-bfda-b162fb3b5b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c229ea-90da-4aa0-bfda-b162fb3b5b8b.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -9221,7 +9221,7 @@
         },
         {
             "id": "32910797-1a99-58eb-b6a8-f02792fe8d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4b6e22-93b2-4896-bba5-0ceaa5d8ea3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4b6e22-93b2-4896-bba5-0ceaa5d8ea3c.jpg?1",
             "name": "Yavimaya, Cradle of Growth",
             "text": "Each land is a Forest in addition to its other land types.",
             "colours": [],
@@ -9254,7 +9254,7 @@
         },
         {
             "id": "bdf5a083-643a-5f6f-8bc9-0236b35d0a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332352c2-98f2-4eb8-b49a-026a39df227b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332352c2-98f2-4eb8-b49a-026a39df227b.jpg?1",
             "name": "Angelic Curator",
             "text": "Flying, protection from artifacts",
             "colours": [
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "42976d5f-cc7a-5a46-9501-139ea9059320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915b4638-b1ec-4045-80e6-f05fb1e2a87c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915b4638-b1ec-4045-80e6-f05fb1e2a87c.jpg?1",
             "name": "Karmic Guide",
             "text": "Flying, protection from black\nEcho {3}{W}{W} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Karmic Guide enters the battlefield, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "9b2ebbde-d3c1-536a-bbf7-2ec2325b252e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27885a9a-3bcd-476d-97a9-acaec0553a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27885a9a-3bcd-476d-97a9-acaec0553a60.jpg?1",
             "name": "Seal of Cleansing",
             "text": "Sacrifice Seal of Cleansing: Destroy target artifact or enchantment.",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "ce31aa05-faa4-5819-bf7d-7c9cf998f2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9031a7f-8821-443c-9c9d-552fb25b2101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9031a7f-8821-443c-9c9d-552fb25b2101.jpg?1",
             "name": "Solitary Confinement",
             "text": "At the beginning of your upkeep, sacrifice Solitary Confinement unless you discard a card.\nSkip your draw step.\nYou have shroud. (You can't be the target of spells or abilities.)\nPrevent all damage that would be dealt to you.",
             "colours": [
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "f2343a8e-4997-5c9c-9b45-3a7446164cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da64eec-d8a9-4156-9d26-56f81e1ffc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da64eec-d8a9-4156-9d26-56f81e1ffc44.jpg?1",
             "name": "Soul Snare",
             "text": "{W}, Sacrifice Soul Snare: Exile target creature that's attacking you or a planeswalker you control.",
             "colours": [
@@ -9427,7 +9427,7 @@
         },
         {
             "id": "40470d4d-f834-59ae-9af3-de01926a221a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1920dae4-fb92-4f19-ae4b-eb3276b8dac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1920dae4-fb92-4f19-ae4b-eb3276b8dac7.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -9462,7 +9462,7 @@
         },
         {
             "id": "19843d61-66b0-5839-b8d5-61513ad46fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8b69ff-22ef-451f-8322-b54eec79bacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a8b69ff-22ef-451f-8322-b54eec79bacf.jpg?1",
             "name": "Sea Drake",
             "text": "Flying\nWhen Sea Drake enters the battlefield, return two target lands you control to their owner's hand.",
             "colours": [
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "de6a3d2b-91a9-57cc-84e2-2f7a4b99a8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfc7060-e374-486f-8029-d3fdfe4b61e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfc7060-e374-486f-8029-d3fdfe4b61e7.jpg?1",
             "name": "Seal of Removal",
             "text": "Sacrifice Seal of Removal: Return target creature to its owner's hand.",
             "colours": [
@@ -9530,7 +9530,7 @@
         },
         {
             "id": "33aeff18-856c-515b-8940-c0e50687e3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe74b1-c487-42bb-a1a1-4d13f3a86ff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befe74b1-c487-42bb-a1a1-4d13f3a86ff7.jpg?1",
             "name": "Upheaval",
             "text": "Return all permanents to their owners' hands.",
             "colours": [
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "02014519-e81b-5650-ac5d-989d044b9d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675d6729-23da-4f0b-b222-fe54fe24dd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675d6729-23da-4f0b-b222-fe54fe24dd90.jpg?1",
             "name": "Wonder",
             "text": "Flying\nAs long as Wonder is in your graveyard and you control an Island, creatures you control have flying.",
             "colours": [
@@ -9598,7 +9598,7 @@
         },
         {
             "id": "182f75f1-1221-5164-86ce-0e4d2c32678c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0b5f0-ed45-4b30-9c24-1c12011e3513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0b5f0-ed45-4b30-9c24-1c12011e3513.jpg?1",
             "name": "Bone Shredder",
             "text": "Flying\nEcho {2}{B} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Bone Shredder enters the battlefield, destroy target nonartifact, nonblack creature.",
             "colours": [
@@ -9634,7 +9634,7 @@
         },
         {
             "id": "d69000d7-f977-50a5-9e94-b949f73a43de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27691efa-052d-4afe-b9ef-159858ca660f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27691efa-052d-4afe-b9ef-159858ca660f.jpg?1",
             "name": "Braids, Cabal Minion",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact, creature, or land.",
             "colours": [
@@ -9672,7 +9672,7 @@
         },
         {
             "id": "4bc4bb42-8b3a-5ef5-8128-0f77dd703f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f8d1f-163c-4c4f-beee-431b64ec8a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851f8d1f-163c-4c4f-beee-431b64ec8a99.jpg?1",
             "name": "Greed",
             "text": "{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -9705,7 +9705,7 @@
         },
         {
             "id": "3193fdfe-8562-5339-91b4-8e1b056f28d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317686d8-b762-4598-b74a-8b1fa6b899ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317686d8-b762-4598-b74a-8b1fa6b899ba.jpg?1",
             "name": "Patriarch's Bidding",
             "text": "Each player chooses a creature type. Each player returns all creature cards of a type chosen this way from their graveyard to the battlefield.",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "e2fe9757-712a-586a-b438-5c6eeb0654fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fcf1-2ccd-47d2-9a24-f44b766a0b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fcf1-2ccd-47d2-9a24-f44b766a0b68.jpg?1",
             "name": "Skirge Familiar",
             "text": "Flying\nDiscard a card: Add {B}.",
             "colours": [
@@ -9774,7 +9774,7 @@
         },
         {
             "id": "22aed906-f3cc-548b-b24f-c8881d3d41e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a4b0c9-a35b-4b55-ab27-7246bbca0d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a4b0c9-a35b-4b55-ab27-7246bbca0d16.jpg?1",
             "name": "Chance Encounter",
             "text": "Whenever you win a coin flip, put a luck counter on Chance Encounter.\nAt the beginning of your upkeep, if Chance Encounter has ten or more luck counters on it, you win the game.",
             "colours": [
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "8583c792-2e7b-5b6b-8300-c5066e3c8296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63ed449-d249-4639-85d2-f8fe75496d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63ed449-d249-4639-85d2-f8fe75496d5c.jpg?1",
             "name": "Flame Rift",
             "text": "Flame Rift deals 4 damage to each player.",
             "colours": [
@@ -9840,7 +9840,7 @@
         },
         {
             "id": "28d2eeff-34fb-5511-af99-66b3014f4a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f55e-9239-4a97-a19e-9b08fb34502e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e262f55e-9239-4a97-a19e-9b08fb34502e.jpg?1",
             "name": "Goblin Bombardment",
             "text": "Sacrifice a creature: Goblin Bombardment deals 1 damage to any target.",
             "colours": [
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "44078b38-73e6-52e6-88c9-ccb351fbde4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f8ee19-3a88-40fa-85d8-386ffe06efd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f8ee19-3a88-40fa-85d8-386ffe06efd7.jpg?1",
             "name": "Gorilla Shaman",
             "text": "{X}{X}{1}: Destroy target noncreature artifact with mana value X.",
             "colours": [
@@ -9909,7 +9909,7 @@
         },
         {
             "id": "de5b009e-2fd0-511f-8cf1-44a56f0ffedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bd329b-5707-42fc-af1c-084cc604e805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bd329b-5707-42fc-af1c-084cc604e805.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "c3edfdb3-468a-5dca-a44b-b44814171e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b93e65e-8a10-444f-8b0a-9327dd30cce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b93e65e-8a10-444f-8b0a-9327dd30cce2.jpg?1",
             "name": "Mogg Salvage",
             "text": "If an opponent controls an Island and you control a Mountain, you may cast this spell without paying its mana cost.\nDestroy target artifact.",
             "colours": [
@@ -9980,7 +9980,7 @@
         },
         {
             "id": "f8e7a25c-f8aa-5426-abb9-53eac370b831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d62bc-5f3c-4b3b-88f2-693249635349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d18d62bc-5f3c-4b3b-88f2-693249635349.jpg?1",
             "name": "Enchantress's Presence",
             "text": "Whenever you cast an enchantment spell, draw a card.",
             "colours": [
@@ -10013,7 +10013,7 @@
         },
         {
             "id": "4e3e9c80-50c8-5faf-a061-5ff28c47a9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9eb595-e8fa-4a5e-abca-d30613c0e28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9eb595-e8fa-4a5e-abca-d30613c0e28f.jpg?1",
             "name": "Hunting Pack",
             "text": "Create a 4/4 green Beast creature token.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -10046,7 +10046,7 @@
         },
         {
             "id": "8bb275ef-7881-5f24-8679-92baa28795bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320fdf89-e158-41c5-b0bf-fee9dec36a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320fdf89-e158-41c5-b0bf-fee9dec36a75.jpg?1",
             "name": "Quirion Ranger",
             "text": "Return a Forest you control to its owner's hand: Untap target creature. Activate only once each turn.",
             "colours": [
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "99203757-aa58-5170-b998-59519df8109d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6bfc95-ec7e-46dd-88fd-b0e1ba48bfbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6bfc95-ec7e-46dd-88fd-b0e1ba48bfbc.jpg?1",
             "name": "Squirrel Mob",
             "text": "Squirrel Mob gets +1/+1 for each other Squirrel on the battlefield.",
             "colours": [
@@ -10117,7 +10117,7 @@
         },
         {
             "id": "6b5dc0ce-bd6e-510e-9718-ca48a6061dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6d49f-1577-4d17-a633-0c282769728a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6d49f-1577-4d17-a633-0c282769728a.jpg?1",
             "name": "Titania, Protector of Argoth",
             "text": "When Titania, Protector of Argoth enters the battlefield, return target land card from your graveyard to the battlefield.\nWhenever a land you control is put into a graveyard from the battlefield, create a 5/3 green Elemental creature token.",
             "colours": [
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "fe6374ad-e5db-56a0-a4ea-ce1e29551fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8511fe7-63f9-4942-8972-d40bf5d7e949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8511fe7-63f9-4942-8972-d40bf5d7e949.jpg?1",
             "name": "Yavimaya Elder",
             "text": "When Yavimaya Elder dies, you may search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle.\n{2}, Sacrifice Yavimaya Elder: Draw a card.",
             "colours": [
@@ -10193,7 +10193,7 @@
         },
         {
             "id": "e3b1f43a-dfd6-53e2-befe-cd195652f33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8089e7f-7619-43fe-8e0b-31ce5d988a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8089e7f-7619-43fe-8e0b-31ce5d988a1b.jpg?1",
             "name": "Chainer, Nightmare Adept",
             "text": "Discard a card: You may cast a creature spell from your graveyard this turn. Activate only once each turn.\nWhenever a nontoken creature enters the battlefield under your control, if you didn't cast it from your hand, it gains haste until your next turn.",
             "colours": [
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "6c0a2687-f3ca-5554-8c14-548361cb70b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg?1",
             "name": "Fire // Ice",
             "text": "Fire deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -10269,7 +10269,7 @@
         },
         {
             "id": "5dd6c679-ae1f-5bf7-8f2a-64637431fdc2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0e09b054-4d33-4a12-bf2a-9b0009f33044.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -10303,7 +10303,7 @@
         },
         {
             "id": "69a68954-0c44-5c48-9823-3c60eefacabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f8f3d-2fe6-44fa-802f-0c56e3f9998e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f8f3d-2fe6-44fa-802f-0c56e3f9998e.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "7ab7a67e-668f-5321-a049-f0558c857292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0824e77-c84b-464a-aa0c-44af5f6faa50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0824e77-c84b-464a-aa0c-44af5f6faa50.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -10382,7 +10382,7 @@
         },
         {
             "id": "13bfb7eb-7f2d-5364-8043-1db7bfd8d527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba03e105-a76c-4769-a35a-d780448890ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba03e105-a76c-4769-a35a-d780448890ec.jpg?1",
             "name": "Sterling Grove",
             "text": "Other enchantments you control have shroud. (They can't be the targets of spells or abilities.)\n{1}, Sacrifice Sterling Grove: Search your library for an enchantment card, reveal it, then shuffle and put that card on top.",
             "colours": [
@@ -10417,7 +10417,7 @@
         },
         {
             "id": "2f75c0dc-603b-54c5-acf7-09cae3bf3166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683c4e13-525c-45c9-8832-bfe67965c34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683c4e13-525c-45c9-8832-bfe67965c34e.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -10454,7 +10454,7 @@
         },
         {
             "id": "2ecba824-4c05-5cdf-8377-e46e4b9d757e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dde91a9-7d2d-4a7b-861a-3d1c16ec79d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dde91a9-7d2d-4a7b-861a-3d1c16ec79d9.jpg?1",
             "name": "Cursed Totem",
             "text": "Activated abilities of creatures can't be activated.",
             "colours": [],
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "185472b2-b06e-5ad9-af22-a7b4d8d22f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e53f0-cfca-4b40-9867-94ea771463cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e94e53f0-cfca-4b40-9867-94ea771463cd.jpg?1",
             "name": "Extruder",
             "text": "Echo {4} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nSacrifice an artifact: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "48beb241-a211-5a7d-810a-c1c6eaf49340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513ba8b6-9583-405f-84a5-9d2ca42f9597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513ba8b6-9583-405f-84a5-9d2ca42f9597.jpg?1",
             "name": "Millikin",
             "text": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -10547,7 +10547,7 @@
         },
         {
             "id": "5431f747-fc17-5dd3-99a9-cd44834eeaff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9e6af4-522c-4dfa-895a-6946fe983e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9e6af4-522c-4dfa-895a-6946fe983e3c.jpg?1",
             "name": "Nevinyrral's Disk",
             "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [],
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "da691221-b485-56be-827a-c8960bca1f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ccef-5322-4f99-9fce-3b4303347240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ccef-5322-4f99-9fce-3b4303347240.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Discard a card: Regenerate Patchwork Gnomes. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [],
@@ -10608,7 +10608,7 @@
         },
         {
             "id": "0259083e-8c96-5214-8f88-dff5771cb54b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618c8ecc-686d-41de-b9b1-1a7ee9cc7c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/618c8ecc-686d-41de-b9b1-1a7ee9cc7c14.jpg?1",
             "name": "Zuran Orb",
             "text": "Sacrifice a land: You gain 2 life.",
             "colours": [],
@@ -10637,7 +10637,7 @@
         },
         {
             "id": "e629b1a5-131d-5373-9399-5efc5599bd34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efb0d3-2c72-46ff-bdc1-1069967365a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1efb0d3-2c72-46ff-bdc1-1069967365a0.jpg?1",
             "name": "Cabal Coffers",
             "text": "{2}, {T}: Add {B} for each Swamp you control.",
             "colours": [],
@@ -10670,7 +10670,7 @@
         },
         {
             "id": "cf42be59-b7f1-5ce6-8007-27fee5d178c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5d6972-3f64-486c-a325-7351b910dafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5d6972-3f64-486c-a325-7351b910dafe.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -10701,7 +10701,7 @@
         },
         {
             "id": "39f3b2ae-5458-5708-ac49-7e813b3f0975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a9cb87-e572-4885-8561-1d4b158ec7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a9cb87-e572-4885-8561-1d4b158ec7e4.jpg?1",
             "name": "Riptide Laboratory",
             "text": "{T}: Add {C}.\n{1}{U}, {T}: Return target Wizard you control to its owner's hand.",
             "colours": [],
@@ -10732,7 +10732,7 @@
         },
         {
             "id": "3539872a-b5c1-5ed1-a5b2-c65ad8187d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538baaf-cb79-45f8-a06b-9f5e773920fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538baaf-cb79-45f8-a06b-9f5e773920fa.jpg?1",
             "name": "Dakkon, Shadow Slayer",
             "text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n\u22123: Exile target creature.\n\u22126: You may put an artifact card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "a5066582-b28a-5701-90a2-0f129b8a0e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ef067b-58ac-4b88-a983-83316d157fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ef067b-58ac-4b88-a983-83316d157fcb.jpg?1",
             "name": "Geyadrone Dihada",
             "text": "Protection from permanents with corruption counters on them\n+1: Each opponent loses 2 life and you gain 2 life. Put a corruption counter on up to one other target creature or planeswalker.\n\u22123: Gain control of target creature or planeswalker until end of turn. Untap it and put a corruption counter on it. It gains haste until end of turn.\n\u22127: Gain control of each permanent with a corruption counter on it.",
             "colours": [
@@ -10818,7 +10818,7 @@
         },
         {
             "id": "56dc37ff-ef60-56ce-a551-628edcb0724c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808a3770-057a-4985-ba5c-870d7b1cd527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808a3770-057a-4985-ba5c-870d7b1cd527.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n+1: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n\u22122: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n\u22125: Each opponent loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -10859,7 +10859,7 @@
         },
         {
             "id": "a9410b61-f238-5988-921c-607aa42138da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febad44a-eaf0-4122-87c5-a12d17f28392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febad44a-eaf0-4122-87c5-a12d17f28392.jpg?1",
             "name": "Solitude",
             "text": "Flash\nLifelink\nWhen Solitude enters the battlefield, exile up to one other target creature. That creature's controller gains life equal to its power.\nEvoke\u2014\nExile a white card from your hand.",
             "colours": [
@@ -10896,7 +10896,7 @@
         },
         {
             "id": "a4941073-a383-563c-82c1-11c661b40172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c358d75-01ad-4487-8104-425124b96aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c358d75-01ad-4487-8104-425124b96aae.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -10930,7 +10930,7 @@
         },
         {
             "id": "04a35c99-a392-5250-81d7-ba59632e0484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade923f-f064-4b5a-a6c0-348ca3e0dbed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade923f-f064-4b5a-a6c0-348ca3e0dbed.jpg?1",
             "name": "Subtlety",
             "text": "Flash\nFlying\nWhen Subtlety enters the battlefield, choose up to one target creature spell or planeswalker spell. Its owner puts it on the top or bottom of their library.\nEvoke\u2014\nExile a blue card from your hand.",
             "colours": [
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "f061a2bd-630c-5054-bc83-aa1888c147cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc69e6-5973-4e8e-a8d2-33657924d86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc69e6-5973-4e8e-a8d2-33657924d86a.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}.",
             "colours": [
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "04176768-b6a3-550b-8517-17b910238886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea859431-c1bf-4d07-9845-430bc217cb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea859431-c1bf-4d07-9845-430bc217cb91.jpg?1",
             "name": "Grief",
             "text": "Menace\nWhen Grief enters the battlefield, target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nEvoke\u2014\nExile a black card from your hand.",
             "colours": [
@@ -11044,7 +11044,7 @@
         },
         {
             "id": "d6e151a7-1372-5162-bb14-29089ba02fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c38dc8-574b-4e53-9b60-8fbb64a29175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c38dc8-574b-4e53-9b60-8fbb64a29175.jpg?1",
             "name": "Tourach, Dread Cantor",
             "text": "Kicker {B}{B}\nProtection from white\nWhenever an opponent discards a card, put a +1/+1 counter on Tourach, Dread Cantor.\nWhen Tourach enters the battlefield, if it was kicked, target opponent discards two cards at random.",
             "colours": [
@@ -11084,7 +11084,7 @@
         },
         {
             "id": "2297b8c1-a9c0-5bd6-806c-1a40216c50c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071daca8-ccc6-4707-843e-adac40dd1588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071daca8-ccc6-4707-843e-adac40dd1588.jpg?1",
             "name": "Fury",
             "text": "Double strike\nWhen Fury enters the battlefield, it deals 4 damage divided as you choose among any number of target creatures and/or planeswalkers.\nEvoke\u2014\nExile a red card from your hand.",
             "colours": [
@@ -11121,7 +11121,7 @@
         },
         {
             "id": "7e372f2d-5409-5916-95cc-4e1bc2137c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0dbf20-bb76-4f4b-960f-68bbb99bde33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0dbf20-bb76-4f4b-960f-68bbb99bde33.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -11158,7 +11158,7 @@
         },
         {
             "id": "86e57d21-1353-5f6f-b673-fc0ca198df03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e685f9-cc0f-4dc6-98dc-4727944de445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e685f9-cc0f-4dc6-98dc-4727944de445.jpg?1",
             "name": "Ragavan, Nimble Pilferer",
             "text": "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\nDash {1}{R}",
             "colours": [
@@ -11197,7 +11197,7 @@
         },
         {
             "id": "ca164fb9-4ef2-5f23-8224-1c5e747e0532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819b7-c193-446d-b7cf-75a09e1d58a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b819b7-c193-446d-b7cf-75a09e1d58a4.jpg?1",
             "name": "Chatterfang, Squirrel General",
             "text": "Forestwalk\nIf one or more tokens would be created under your control, those tokens plus that many 1/1 green Squirrel creature tokens are created instead.\n{B}, Sacrifice X Squirrels: Target creature gets +X/-X until end of turn.",
             "colours": [
@@ -11238,7 +11238,7 @@
         },
         {
             "id": "747a9215-6dd5-54e3-91fe-3c5a7a57e64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6d14a-1328-4032-ad9e-cd85cd365bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6d14a-1328-4032-ad9e-cd85cd365bd3.jpg?1",
             "name": "Endurance",
             "text": "Flash\nReach\nWhen Endurance enters the battlefield, up to one target player puts all the cards from their graveyard on the bottom of their library in a random order.\nEvoke\u2014\nExile a green card from your hand.",
             "colours": [
@@ -11275,7 +11275,7 @@
         },
         {
             "id": "c9516fef-1b36-536f-be16-7f1350f944b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abf3165-6260-4dcf-8f06-6e808bff0289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9abf3165-6260-4dcf-8f06-6e808bff0289.jpg?1",
             "name": "Thrasta, Tempest's Roar",
             "text": "This spell costs {3} less to cast for each other spell cast this turn.\nTrample, trample over planeswalkers, haste\nThrasta, Tempest's Roar has hexproof as long as it entered the battlefield this turn.",
             "colours": [
@@ -11313,7 +11313,7 @@
         },
         {
             "id": "57f8b73b-b746-51af-9561-07e7ce1f35b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb9fd5-359e-4da2-8d91-80ef50a8e390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb9fd5-359e-4da2-8d91-80ef50a8e390.jpg?1",
             "name": "Titania, Protector of Argoth",
             "text": "When Titania, Protector of Argoth enters the battlefield, return target land card from your graveyard to the battlefield.\nWhenever a land you control is put into a graveyard from the battlefield, create a 5/3 green Elemental creature token.",
             "colours": [
@@ -11352,7 +11352,7 @@
         },
         {
             "id": "4a6b166b-7e9e-55dd-be2e-a712de9509b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157ce8f8-625c-407a-b015-3b5326da69a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157ce8f8-625c-407a-b015-3b5326da69a0.jpg?1",
             "name": "Mirari's Wake",
             "text": "Creatures you control get +1/+1.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -11388,7 +11388,7 @@
         },
         {
             "id": "66b8e70c-90b9-5cfb-b515-ab86fdd0b2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7fa4d-5190-4f2b-a8ae-933bdab3bfc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7fa4d-5190-4f2b-a8ae-933bdab3bfc5.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade",
             "colours": [
@@ -11429,7 +11429,7 @@
         },
         {
             "id": "4642c150-a748-5283-b8a3-3d56c8297885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4978ecd-3c2e-49e2-98e0-0172887e4319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4978ecd-3c2e-49e2-98e0-0172887e4319.jpg?1",
             "name": "Vindicate",
             "text": "Destroy target permanent.",
             "colours": [
@@ -11465,7 +11465,7 @@
         },
         {
             "id": "e3e7fdc1-5f7c-5dbf-86a8-bf08201fb573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec628a-4b66-4ab8-9e00-c1582da722ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec628a-4b66-4ab8-9e00-c1582da722ff.jpg?1",
             "name": "Scion of Draco",
             "text": "Domain \u2014 This spell costs {2} less to cast for each basic land type among lands you control.\nFlying\nEach creature you control has vigilance if it's white, hexproof if it's blue, lifelink if it's black, first strike if it's red, and trample if it's green.",
             "colours": [],
@@ -11499,7 +11499,7 @@
         },
         {
             "id": "512ab9da-8eaa-57dd-b2d2-ecb7d4e7678c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27d2f06-42ed-42fd-874c-8c278cdb66dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27d2f06-42ed-42fd-874c-8c278cdb66dc.jpg?1",
             "name": "Sword of Hearth and Home",
             "text": "Equipped creature gets +2/+2 and has protection from green and from white.\nWhenever equipped creature deals combat damage to a player, exile up to one target creature you own, then search your library for a basic land card. Put both cards onto the battlefield under your control, then shuffle.\nEquip {2}",
             "colours": [],
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "85f94792-2e14-5b22-b091-e13c52bd4106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd01460-901c-4d75-bc29-e97ed26afc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd01460-901c-4d75-bc29-e97ed26afc39.jpg?1",
             "name": "Cabal Coffers",
             "text": "{2}, {T}: Add {B} for each Swamp you control.",
             "colours": [],
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "bc0517a9-c7e1-5064-a637-8dd5e41bbd83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d596bc0-c972-4a36-8cf6-cd8f72169021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d596bc0-c972-4a36-8cf6-cd8f72169021.jpg?1",
             "name": "Mishra's Factory",
             "text": "{T}: Add {C}.\n{1}: Mishra's Factory becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{T}: Target Assembly-Worker creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -11594,7 +11594,7 @@
         },
         {
             "id": "db32a243-4b44-5681-903e-a5057fff4b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7667b9c-073d-456d-8c43-5e56316cef92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7667b9c-073d-456d-8c43-5e56316cef92.jpg?1",
             "name": "Blossoming Calm",
             "text": "You gain hexproof until your next turn. You gain 2 life.\nRebound",
             "colours": [
@@ -11628,7 +11628,7 @@
         },
         {
             "id": "1ca86e65-b447-549f-a1b7-1009d9da93b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676758ee-dac8-4c97-8a62-fff25bcbb6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676758ee-dac8-4c97-8a62-fff25bcbb6df.jpg?1",
             "name": "Esper Sentinel",
             "text": "Whenever an opponent casts their first noncreature spell each turn, draw a card unless that player pays {X}, where X is Esper Sentinel's power.",
             "colours": [
@@ -11666,7 +11666,7 @@
         },
         {
             "id": "e8a111ea-2ed4-5fa7-ae77-76fdfdf30dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4613fc96-a98d-4ea8-b1e2-0a776dfd4d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4613fc96-a98d-4ea8-b1e2-0a776dfd4d5a.jpg?1",
             "name": "Late to Dinner",
             "text": "Return target creature card from your graveyard to the battlefield. Create a Food token.",
             "colours": [
@@ -11700,7 +11700,7 @@
         },
         {
             "id": "e8f2fa9f-9707-5d0f-afc7-f3f8d6ec00ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d044aa-abed-47dd-b3a1-268fab03f8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d044aa-abed-47dd-b3a1-268fab03f8af.jpg?1",
             "name": "Lens Flare",
             "text": "Affinity for artifacts\nLens Flare deals 5 damage to target attacking or blocking creature.",
             "colours": [
@@ -11734,7 +11734,7 @@
         },
         {
             "id": "c24a7f4a-2219-5ae2-b0e1-26583aa0778d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f6052b-b90b-4630-9cd7-26920897d976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f6052b-b90b-4630-9cd7-26920897d976.jpg?1",
             "name": "Nykthos Paragon",
             "text": "Whenever you gain life, you may put that many +1/+1 counters on each creature you control. Do this only once each turn.",
             "colours": [
@@ -11772,7 +11772,7 @@
         },
         {
             "id": "e857461d-61fe-537a-9dd6-0bbd6ecfe64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbd1cb1-799e-45aa-acd8-36ef924b0cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbd1cb1-799e-45aa-acd8-36ef924b0cdf.jpg?1",
             "name": "Search the Premises",
             "text": "Whenever a creature attacks you or a planeswalker you control, investigate.",
             "colours": [
@@ -11806,7 +11806,7 @@
         },
         {
             "id": "76bbb580-cfbf-5805-a895-8262a92bbd66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de657fb-e68e-4400-9a12-60aaaa075fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de657fb-e68e-4400-9a12-60aaaa075fc4.jpg?1",
             "name": "Serra's Emissary",
             "text": "Flying\nAs Serra's Emissary enters the battlefield, choose a card type.\nYou and creatures you control have protection from the chosen card type.",
             "colours": [
@@ -11842,7 +11842,7 @@
         },
         {
             "id": "87d16fe7-6831-5246-860c-87cc84369d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dcf74-110c-421f-87db-c2133d7a8281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dcf74-110c-421f-87db-c2133d7a8281.jpg?1",
             "name": "Dress Down",
             "text": "Flash\nWhen Dress Down enters the battlefield, draw a card.\nCreatures lose all abilities.\nAt the beginning of the end step, sacrifice Dress Down.",
             "colours": [
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "f08a54bd-2b0b-5a79-baab-22671f8bdebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d6402-a941-46cc-b1d6-352d5aa5cc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d6402-a941-46cc-b1d6-352d5aa5cc3f.jpg?1",
             "name": "Floodhound",
             "text": "{3}, {T}: Investigate.",
             "colours": [
@@ -11913,7 +11913,7 @@
         },
         {
             "id": "ede806de-5743-5898-a278-f44d1bde44e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a3b565-2880-48f1-bbfe-1eeafcb76c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a3b565-2880-48f1-bbfe-1eeafcb76c2b.jpg?1",
             "name": "Fractured Sanity",
             "text": "Each opponent mills fourteen cards.\nCycling {1}{U}\nWhen you cycle Fractured Sanity, each opponent mills four cards.",
             "colours": [
@@ -11947,7 +11947,7 @@
         },
         {
             "id": "77c06662-3345-5156-b848-85f947c7664f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad586c86-6d5b-49ac-8908-098eddae26e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad586c86-6d5b-49ac-8908-098eddae26e6.jpg?1",
             "name": "Murktide Regent",
             "text": "Delve\nFlying\nMurktide Regent enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.\nWhenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on Murktide Regent.",
             "colours": [
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "187d2a1d-e528-5f59-aaed-e62dab8d88af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bec76f-243b-41b6-9e47-17a61f18ae53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bec76f-243b-41b6-9e47-17a61f18ae53.jpg?1",
             "name": "Mystic Redaction",
             "text": "At the beginning of your upkeep, scry 1.\nWhenever you discard a card, each opponent mills two cards.",
             "colours": [
@@ -12017,7 +12017,7 @@
         },
         {
             "id": "1bff8e86-909c-5461-b879-ccee441e4b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2484b24-ca5e-421d-8dbf-41df7094c8a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2484b24-ca5e-421d-8dbf-41df7094c8a8.jpg?1",
             "name": "Phantasmal Dreadmaw",
             "text": "Trample\nWhen Phantasmal Dreadmaw becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -12054,7 +12054,7 @@
         },
         {
             "id": "04305f86-457c-5aee-93e1-d335e31053b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9011c3a-c9db-4e92-89d5-29f139017573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9011c3a-c9db-4e92-89d5-29f139017573.jpg?1",
             "name": "Rise and Shine",
             "text": "Target noncreature artifact you control becomes a 0/0 artifact creature. Put four +1/+1 counters on each artifact that became a creature this way.\nOverload {4}{U}{U}",
             "colours": [
@@ -12088,7 +12088,7 @@
         },
         {
             "id": "8894a091-08ad-5af1-9145-ac936600c5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c98ef7-be05-4bcf-be4b-62a437297330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c98ef7-be05-4bcf-be4b-62a437297330.jpg?1",
             "name": "Thought Monitor",
             "text": "Affinity for artifacts\nFlying\nWhen Thought Monitor enters the battlefield, draw two cards.",
             "colours": [
@@ -12125,7 +12125,7 @@
         },
         {
             "id": "675fd3de-8b62-5414-a2de-9a3e77523da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d9873-f4e9-418f-aee8-8623b2576f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38d9873-f4e9-418f-aee8-8623b2576f6c.jpg?1",
             "name": "Archon of Cruelty",
             "text": "Flying\nWhenever Archon of Cruelty enters the battlefield or attacks, target opponent sacrifices a creature or planeswalker, discards a card, and loses 3 life. You draw a card and gain 3 life.",
             "colours": [
@@ -12161,7 +12161,7 @@
         },
         {
             "id": "25cf89af-3f6a-50b4-8cb4-be66713dfa00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c7b777-c002-45c7-b2bb-d21dab591445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c7b777-c002-45c7-b2bb-d21dab591445.jpg?1",
             "name": "Kitchen Imp",
             "text": "Flying, haste\nMadness {B}",
             "colours": [
@@ -12197,7 +12197,7 @@
         },
         {
             "id": "5bcf6617-bc10-5c23-89a5-28fbe7311781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec0c309-5e11-40b2-a38f-66503b357f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec0c309-5e11-40b2-a38f-66503b357f5d.jpg?1",
             "name": "Magus of the Bridge",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, create a 2/2 black Zombie creature token.\nWhen a creature is put into an opponent's graveyard from the battlefield, exile Magus of the Bridge.",
             "colours": [
@@ -12234,7 +12234,7 @@
         },
         {
             "id": "eeb0c12b-8bba-547d-84c1-a7274261ebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beb3062-b3a2-4af5-867c-e6389554c1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beb3062-b3a2-4af5-867c-e6389554c1f5.jpg?1",
             "name": "Persist",
             "text": "Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.",
             "colours": [
@@ -12269,7 +12269,7 @@
         },
         {
             "id": "643d712f-fa28-5a0a-8344-78b54a82baa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d1d680-9a27-4850-9175-cc71220ea33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d1d680-9a27-4850-9175-cc71220ea33d.jpg?1",
             "name": "Sudden Edict",
             "text": "Split second\nTarget player sacrifices a creature.",
             "colours": [
@@ -12303,7 +12303,7 @@
         },
         {
             "id": "4e5cbf85-5d0c-5296-9841-005471474cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735a5082-72f4-4812-adcc-d8095d8eee51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735a5082-72f4-4812-adcc-d8095d8eee51.jpg?1",
             "name": "Underworld Hermit",
             "text": "When Underworld Hermit enters the battlefield, create a number of 1/1 green Squirrel creature tokens equal to your devotion to black.",
             "colours": [
@@ -12340,7 +12340,7 @@
         },
         {
             "id": "02d397c1-d8e1-5b21-92ce-b2fe9e58561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16d9113-d279-4a6d-9cf0-f5e104f77852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16d9113-d279-4a6d-9cf0-f5e104f77852.jpg?1",
             "name": "World-Weary",
             "text": "Enchant creature\nEnchanted creature gets -4/-4.\nBasic landcycling {1}{B}",
             "colours": [
@@ -12376,7 +12376,7 @@
         },
         {
             "id": "35c1fe32-c344-5638-89cf-0ed34f2b7379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958aa5c-176d-4f6e-be52-ef2afbe8d452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958aa5c-176d-4f6e-be52-ef2afbe8d452.jpg?1",
             "name": "Faithless Salvaging",
             "text": "Discard a card, then draw a card.\nRebound",
             "colours": [
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "740e6a2e-84c2-549e-b8ef-4d8f1a5826d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d35091-c272-4679-aa20-7889e9cdcd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d35091-c272-4679-aa20-7889e9cdcd41.jpg?1",
             "name": "Flametongue Yearling",
             "text": "Multikicker {2}\nFlametongue Yearling enters the battlefield with a +1/+1 counter on it for each time it was kicked.\nWhen Flametongue Yearling enters the battlefield, it deals damage equal to its power to target creature.",
             "colours": [
@@ -12446,7 +12446,7 @@
         },
         {
             "id": "57bfa94e-be5d-5501-af24-223cdd4e715b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88167b74-c25f-4a9b-a4f5-33a51e01d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88167b74-c25f-4a9b-a4f5-33a51e01d498.jpg?1",
             "name": "Gargadon",
             "text": "Trample\nSuspend 4\u2014{1}{R}",
             "colours": [
@@ -12482,7 +12482,7 @@
         },
         {
             "id": "554a101d-7d7b-56d5-858e-135029dd276d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4290d31a-ce74-4a22-8266-9e44d23d506f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4290d31a-ce74-4a22-8266-9e44d23d506f.jpg?1",
             "name": "Harmonic Prodigy",
             "text": "Prowess\nIf an ability of a Shaman or another Wizard you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -12519,7 +12519,7 @@
         },
         {
             "id": "864604a6-ecc8-51fe-8c51-5a7aec922b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7a09e-a28f-4153-81b0-c8dbb1aaa0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7a09e-a28f-4153-81b0-c8dbb1aaa0e7.jpg?1",
             "name": "Obsidian Charmaw",
             "text": "This spell costs {1} less to cast for each land your opponents control that could produce {C}.\nFlying\nWhen Obsidian Charmaw enters the battlefield, destroy target nonbasic land an opponent controls.",
             "colours": [
@@ -12555,7 +12555,7 @@
         },
         {
             "id": "de35b17d-42a1-5c72-8fb4-c503a9f755d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae42f372-2a17-4905-99d1-3371ca0ed6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae42f372-2a17-4905-99d1-3371ca0ed6ae.jpg?1",
             "name": "Abundant Harvest",
             "text": "Choose land or nonland. Reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12589,7 +12589,7 @@
         },
         {
             "id": "db4d83e8-e345-58ed-9946-036e2fbd860c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3139cce8-3467-4c50-add2-5b78fb33b90a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3139cce8-3467-4c50-add2-5b78fb33b90a.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "Exalted\n{T}: Add {B}, {R}, or {G}.",
             "colours": [
@@ -12629,7 +12629,7 @@
         },
         {
             "id": "3640de24-4048-50bd-9469-ebdca0ad8eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793f5aef-15ad-4ad7-b390-201b3c0c149d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793f5aef-15ad-4ad7-b390-201b3c0c149d.jpg?1",
             "name": "Jade Avenger",
             "text": "Bushido 2",
             "colours": [
@@ -12666,7 +12666,7 @@
         },
         {
             "id": "b57e763d-adaf-525c-9317-c1f02978b43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afd2ecd-c2e5-49f2-bf35-dcec2addcebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afd2ecd-c2e5-49f2-bf35-dcec2addcebb.jpg?1",
             "name": "Sylvan Anthem",
             "text": "Green creatures you control get +1/+1.\nWhenever a green creature enters the battlefield under your control, scry 1.",
             "colours": [
@@ -12700,7 +12700,7 @@
         },
         {
             "id": "f7bc6e1a-cf09-56e5-a967-3d22b9d47887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f47b0-2254-4df2-b3dc-74c1d3811d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f47b0-2254-4df2-b3dc-74c1d3811d2f.jpg?1",
             "name": "Timeless Witness",
             "text": "When Timeless Witness enters the battlefield, return target card from your graveyard to your hand.\nEternalize {5}{G}{G}",
             "colours": [
@@ -12737,7 +12737,7 @@
         },
         {
             "id": "31650fa0-1cf2-5f87-b0be-3074effb52e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a3f30-0839-4678-a37c-475ee189811e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070a3f30-0839-4678-a37c-475ee189811e.jpg?1",
             "name": "Verdant Command",
             "text": "Choose two \u2014\n\u2022 Target player creates two tapped 1/1 green Squirrel creature tokens.\n\u2022 Counter target loyalty ability of a planeswalker.\n\u2022 Exile target card from a graveyard.\n\u2022 Target player gains 3 life.",
             "colours": [
@@ -12771,7 +12771,7 @@
         },
         {
             "id": "cdb942ad-6513-5c00-a4e2-2d0f80356532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896eceec-7dcc-48fb-acc2-1ca5ee28ea3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896eceec-7dcc-48fb-acc2-1ca5ee28ea3b.jpg?1",
             "name": "Arcbound Shikari",
             "text": "First strike\nWhen Arcbound Shikari enters the battlefield, put a +1/+1 counter on each other artifact creature you control.\nModular 2",
             "colours": [
@@ -12811,7 +12811,7 @@
         },
         {
             "id": "ee374622-a64a-5991-8d89-ad0f3fb507b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ee002-fbd4-4bbe-a17c-876972750646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33ee002-fbd4-4bbe-a17c-876972750646.jpg?1",
             "name": "Arcus Acolyte",
             "text": "Reach, lifelink\nOutlast {RW}\nEach other creature you control without a +1/+1 counter on it has outlast {RW}.",
             "colours": [
@@ -12851,7 +12851,7 @@
         },
         {
             "id": "87193fa5-dec1-543c-b572-97c5be17bbe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac6ff5-4caa-48ee-a9a4-de7c1300e326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ac6ff5-4caa-48ee-a9a4-de7c1300e326.jpg?1",
             "name": "Combine Chrysalis",
             "text": "Creature tokens you control have flying.\n{2}{G}{U}, {T}, Sacrifice a token: Create a 4/4 green Beast creature token. Activate only as a sorcery.",
             "colours": [
@@ -12887,7 +12887,7 @@
         },
         {
             "id": "2aab330b-bdc4-5bb0-9c0f-17b99dfb4506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05467b80-0781-4f03-8027-59dbb44d8826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05467b80-0781-4f03-8027-59dbb44d8826.jpg?1",
             "name": "Dakkon, Shadow Slayer",
             "text": "Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.\n+1: Surveil 2.\n\u22123: Exile target creature.\n\u22126: You may put an artifact card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -12930,7 +12930,7 @@
         },
         {
             "id": "50e275b8-6823-5f79-96a2-4658d25018d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3a54c0-98f0-47be-aae1-608479f4b9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3a54c0-98f0-47be-aae1-608479f4b9cf.jpg?1",
             "name": "Ethersworn Sphinx",
             "text": "Affinity for artifacts\nFlying\nCascade",
             "colours": [
@@ -12969,7 +12969,7 @@
         },
         {
             "id": "ed87244e-2d60-59dc-b59f-d62913cc1f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92aed86-4786-42c5-a599-7b3178eed478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92aed86-4786-42c5-a599-7b3178eed478.jpg?1",
             "name": "Garth One-Eye",
             "text": "{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy.",
             "colours": [
@@ -13017,7 +13017,7 @@
         },
         {
             "id": "b90f35ab-7e70-5e62-ab95-69aee562c7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a0636e-cf3c-4bf2-8d01-b830bed999ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a0636e-cf3c-4bf2-8d01-b830bed999ef.jpg?1",
             "name": "General Ferrous Rokiric",
             "text": "Hexproof from monocolored\nWhenever you cast a multicolored spell, create a 4/4 red and white Golem artifact creature token.",
             "colours": [
@@ -13058,7 +13058,7 @@
         },
         {
             "id": "9f4edf19-e45f-5a01-9770-aef1c2cdfdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1985f4-f3e4-4ddd-bed9-a0566e411620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1985f4-f3e4-4ddd-bed9-a0566e411620.jpg?1",
             "name": "Geyadrone Dihada",
             "text": "Protection from permanents with corruption counters on them\n+1: Each opponent loses 2 life and you gain 2 life. Put a corruption counter on up to one other target creature or planeswalker.\n\u22123: Gain control of target creature or planeswalker until end of turn. Untap it and put a corruption counter on it. It gains haste until end of turn.\n\u22127: Gain control of each permanent with a corruption counter on it.",
             "colours": [
@@ -13101,7 +13101,7 @@
         },
         {
             "id": "b83a6a83-4ad7-522f-b1fc-5b8f7a1d5efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627c68-c4a9-4579-85f1-6a1a5e6f6fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c627c68-c4a9-4579-85f1-6a1a5e6f6fce.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "As long as Grist, the Hunger Tide isn't on the battlefield, it's a 1/1 Insect creature in addition to its other types.\n+1: Create a 1/1 black and green Insect creature token, then mill a card. If an Insect card was milled this way, put a loyalty counter on Grist and repeat this process.\n\u22122: You may sacrifice a creature. When you do, destroy target creature or planeswalker.\n\u22125: Each opponent loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "06f84d80-6329-5e91-9ef8-0b04747fe381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e2d11-0f87-43f2-a961-99a47486f8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3e2d11-0f87-43f2-a961-99a47486f8fa.jpg?1",
             "name": "Lazotep Chancellor",
             "text": "Whenever you discard a card, you may pay {1}. If you do, amass 2.",
             "colours": [
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "88dbf42a-03a4-5ff3-9bf1-3340f99f77e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6baff7b-bdfe-4b64-802d-f73c455dac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6baff7b-bdfe-4b64-802d-f73c455dac35.jpg?1",
             "name": "Lonis, Cryptozoologist",
             "text": "Whenever another nontoken creature enters the battlefield under your control, investigate.\n{T}, Sacrifice X Clues: Target opponent reveals the top X cards of their library. You may put a nonland permanent card with mana value X or less from among them onto the battlefield under your control. That player puts the rest on the bottom of their library in a random order.",
             "colours": [
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "b56adcb6-9695-5427-9e6d-21f6d1d0539f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcab41d9-e002-4183-bbbe-b1f955217b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcab41d9-e002-4183-bbbe-b1f955217b3c.jpg?1",
             "name": "Moderation",
             "text": "You can't cast more than one spell each turn.\nWhenever you cast a spell, draw a card.",
             "colours": [
@@ -13259,7 +13259,7 @@
         },
         {
             "id": "878d585e-2165-5f9c-b051-2dd1e03e25af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a63c64-bbf4-46cc-bffe-0992bea502cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a63c64-bbf4-46cc-bffe-0992bea502cc.jpg?1",
             "name": "Priest of Fell Rites",
             "text": "{T}, Pay 3 life, Sacrifice Priest of Fell Rites: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.\nUnearth {3}{W}{B}",
             "colours": [
@@ -13298,7 +13298,7 @@
         },
         {
             "id": "6ebf083b-1921-5751-b162-579066e40e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e8b65-16ec-4aef-ac26-8afd78d8bfe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27e8b65-16ec-4aef-ac26-8afd78d8bfe5.jpg?1",
             "name": "Prophetic Titan",
             "text": "Delirium \u2014 When Prophetic Titan enters the battlefield, choose one. If there are four or more card types among cards in your graveyard, choose both instead.\n\u2022 Prophetic Titan deals 4 damage to any target.\n\u2022 Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13337,7 +13337,7 @@
         },
         {
             "id": "56519556-e0cf-57e5-8ef1-99227b9a1a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2caad15a-b567-47b5-b055-e52bfed5b889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2caad15a-b567-47b5-b055-e52bfed5b889.jpg?1",
             "name": "Rakdos Headliner",
             "text": "Haste\nEcho\u2014\nDiscard a card.",
             "colours": [
@@ -13375,7 +13375,7 @@
         },
         {
             "id": "6ddd925f-cf16-576c-984b-404f242a1270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505b77d0-8651-4b40-a2e9-6dd00ac3c575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505b77d0-8651-4b40-a2e9-6dd00ac3c575.jpg?1",
             "name": "Ravenous Squirrel",
             "text": "Whenever you sacrifice an artifact or creature, put a +1/+1 counter on Ravenous Squirrel.\n{1}{B}{G}, Sacrifice an artifact or creature: You gain 1 life and draw a card.",
             "colours": [
@@ -13413,7 +13413,7 @@
         },
         {
             "id": "dd1061df-c0f4-5059-8f04-d7c8a9f57fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg?1",
             "name": "Road // Ruin",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13448,7 +13448,7 @@
         },
         {
             "id": "28d5a9ff-b2ec-5d4b-9ae5-8ab1bff853d0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edf8a080-2327-4ae0-97bc-ed488a619797.jpg?1",
             "name": "Road // Ruin",
             "text": "Aftermath (Cast this spell only from your graveyard. Then exile it.)\nRuin deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -13483,7 +13483,7 @@
         },
         {
             "id": "8e171166-b2bd-5d2f-8405-70162a8e2be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebe313-3452-415c-a93f-52c7467531a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ebe313-3452-415c-a93f-52c7467531a3.jpg?1",
             "name": "Sythis, Harvest's Hand",
             "text": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
             "colours": [
@@ -13524,7 +13524,7 @@
         },
         {
             "id": "799b7249-9b7d-5681-ace9-8e30381d4025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b32e-e9c3-4245-887c-fe30c5f3148f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b32e-e9c3-4245-887c-fe30c5f3148f.jpg?1",
             "name": "Dermotaxi",
             "text": "Imprint \u2014 As Dermotaxi enters the battlefield, exile a creature card from a graveyard.\nTap two untapped creatures you control: Until end of turn, Dermotaxi becomes a copy of the exiled card, except it's a Vehicle artifact in addition to its other types.",
             "colours": [],
@@ -13556,7 +13556,7 @@
         },
         {
             "id": "c308f5aa-0700-50a8-9e10-f8da2fe2c8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0ae99-d84a-4f27-bed8-889747c78529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0ae99-d84a-4f27-bed8-889747c78529.jpg?1",
             "name": "Kaldra Compleat",
             "text": "Living weapon\nIndestructible\nEquipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"\nEquip {7}",
             "colours": [],
@@ -13590,7 +13590,7 @@
         },
         {
             "id": "4aeae54e-cfaf-5ae5-8f80-3b7fbca69937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138dfbb-a4e3-49db-b908-95d0b2b7e82f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2138dfbb-a4e3-49db-b908-95d0b2b7e82f.jpg?1",
             "name": "Urza's Saga",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Urza's Saga gains \"{T}: Add {C}.\"\nII \u2014 Urza's Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with \u2018\nThis creature gets +1/+1 for each artifact you control.'\"\nIII \u2014 Search your library for an artifact card with mana cost {0} or {1}, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13624,7 +13624,7 @@
         },
         {
             "id": "de7f21d1-dadd-512c-94a6-eb2e7d237306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37304f74-a925-444c-bff6-7811f7f06966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37304f74-a925-444c-bff6-7811f7f06966.jpg?1",
             "name": "Blacksmith's Skill",
             "text": "Target permanent gains hexproof and indestructible until end of turn. If it's an artifact creature, it gets +2/+2 until end of turn.",
             "colours": [
@@ -13659,7 +13659,7 @@
         },
         {
             "id": "6409d567-63b2-58ef-bcad-c10e36a6d153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9900b8-da89-433b-ada5-f17c82e60c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9900b8-da89-433b-ada5-f17c82e60c64.jpg?1",
             "name": "Marble Gargoyle",
             "text": "Flying\n{W}: Marble Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -13697,7 +13697,7 @@
         },
         {
             "id": "b2376ef7-e713-5aa5-bc51-dc6210e59aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd77468-7aad-4add-8385-e3310cd5d5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd77468-7aad-4add-8385-e3310cd5d5cd.jpg?1",
             "name": "Out of Time",
             "text": "When Out of Time enters the battlefield, untap all creatures, then phase them out until Out of Time leaves the battlefield. Put a time counter on Out of Time for each creature phased out this way.\nVanishing",
             "colours": [
@@ -13733,7 +13733,7 @@
         },
         {
             "id": "bafac74c-f4f8-5c71-8a6b-0bd02c536c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaa24a9-eece-4067-b7e2-6bc8993cea5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaa24a9-eece-4067-b7e2-6bc8993cea5a.jpg?1",
             "name": "Prismatic Ending",
             "text": "Converge \u2014 Exile target nonland permanent if its mana value is less than or equal to the number of colors of mana spent to cast this spell.",
             "colours": [
@@ -13768,7 +13768,7 @@
         },
         {
             "id": "43a6ae44-81b0-5cdf-9753-f2886623396d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e60c9e-0b9c-4daa-8a61-52111e03f49f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e60c9e-0b9c-4daa-8a61-52111e03f49f.jpg?1",
             "name": "Resurgent Belief",
             "text": "Suspend 2\u2014{1}{W}\nReturn all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -13804,7 +13804,7 @@
         },
         {
             "id": "bfb8b749-277f-55d8-90f1-34870699f525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d4ef76-4d57-40df-93f6-c67c017798ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8d4ef76-4d57-40df-93f6-c67c017798ce.jpg?1",
             "name": "Sanctifier en-Vec",
             "text": "Protection from black and from red\nWhen Sanctifier en-Vec enters the battlefield, exile all cards that are black or red from all graveyards.\nIf a black or red permanent, spell, or card not on the battlefield would be put into a graveyard, exile it instead.",
             "colours": [
@@ -13843,7 +13843,7 @@
         },
         {
             "id": "ed86ebe7-178f-52fc-9b05-8a9e36e50343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e612763-6611-40e7-ab47-3161f8275b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e612763-6611-40e7-ab47-3161f8275b9d.jpg?1",
             "name": "Soul Snare",
             "text": "{W}, Sacrifice Soul Snare: Exile target creature that's attacking you or a planeswalker you control.",
             "colours": [
@@ -13878,7 +13878,7 @@
         },
         {
             "id": "18c02204-0326-563a-b971-4704ea570c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476cc60-e59d-4f34-abc9-f3eafdc2890d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476cc60-e59d-4f34-abc9-f3eafdc2890d.jpg?1",
             "name": "Timeless Dragon",
             "text": "Flying\nPlainscycling {2}\nEternalize {2}{W}{W}",
             "colours": [
@@ -13916,7 +13916,7 @@
         },
         {
             "id": "312c9d62-1bee-5027-b19e-de16923d9681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de0eb6-94f5-440f-8201-cc7dad2f0805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25de0eb6-94f5-440f-8201-cc7dad2f0805.jpg?1",
             "name": "Aeromoeba",
             "text": "Flying\nDiscard a card: Switch Aeromoeba's power and toughness until end of turn.",
             "colours": [
@@ -13954,7 +13954,7 @@
         },
         {
             "id": "89f8d747-0cbb-57c6-b825-9e0bff758810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c015a6-dc4c-49f6-8d39-4c7b598e5a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c015a6-dc4c-49f6-8d39-4c7b598e5a61.jpg?1",
             "name": "Inevitable Betrayal",
             "text": "Suspend 3\u2014{1}{U}{U}\nSearch target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -13990,7 +13990,7 @@
         },
         {
             "id": "cce47761-f152-59eb-9d6c-a082b00203a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39d88fd-7762-4d02-af7c-b13e7db5b23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39d88fd-7762-4d02-af7c-b13e7db5b23e.jpg?1",
             "name": "Rishadan Dockhand",
             "text": "Islandwalk\n{1}, {T}: Tap target land.",
             "colours": [
@@ -14028,7 +14028,7 @@
         },
         {
             "id": "87fb9b01-1ed1-587f-93b8-ab8bc7f3213b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5688978-1744-4986-bda3-09629541b827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5688978-1744-4986-bda3-09629541b827.jpg?1",
             "name": "Step Through",
             "text": "Return two target creatures to their owners' hands.\nWizardcycling {2}",
             "colours": [
@@ -14063,7 +14063,7 @@
         },
         {
             "id": "cbaf543f-95c6-5524-b54e-303d78857607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7252a6-0add-4bba-a0cc-9068f8701775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7252a6-0add-4bba-a0cc-9068f8701775.jpg?1",
             "name": "Svyelun of Sea and Sky",
             "text": "Svyelun of Sea and Sky has indestructible as long as you control at least two other Merfolk.\nWhenever Svyelun attacks, draw a card.\nOther Merfolk you control have ward {1}.",
             "colours": [
@@ -14104,7 +14104,7 @@
         },
         {
             "id": "cf58208c-7c6f-570b-aeb7-a99a45fd3929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1fb951-89c2-49c9-9ee9-3c8d0d6c4c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff1fb951-89c2-49c9-9ee9-3c8d0d6c4c86.jpg?1",
             "name": "Tide Shaper",
             "text": "Kicker {1}\nWhen Tide Shaper enters the battlefield, if it was kicked, target land becomes an Island for as long as Tide Shaper remains on the battlefield.\nTide Shaper gets +1/+1 as long as an opponent controls an Island.",
             "colours": [
@@ -14142,7 +14142,7 @@
         },
         {
             "id": "ba44d76c-fd07-5444-995c-cc63060a2579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15299d85-ee28-41a3-9952-f50e8e1d40eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15299d85-ee28-41a3-9952-f50e8e1d40eb.jpg?1",
             "name": "Bone Shards",
             "text": "As an additional cost to cast this spell, sacrifice a creature or discard a card.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -14177,7 +14177,7 @@
         },
         {
             "id": "9504916a-c84f-5155-bf62-8700b56fb156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95b26-0bbf-4fa1-80c1-f621f1a1b947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95b26-0bbf-4fa1-80c1-f621f1a1b947.jpg?1",
             "name": "Damn",
             "text": "Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W}",
             "colours": [
@@ -14214,7 +14214,7 @@
         },
         {
             "id": "0897ac9a-e0e2-5961-b06b-586197dce98c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d54f0dd-5d27-483b-8af9-92a1c5a785f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d54f0dd-5d27-483b-8af9-92a1c5a785f2.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "Shadow\nIf a card would be put into an opponent's graveyard from anywhere, instead exile it with a void counter on it.\n{T}, Sacrifice Dauthi Voidwalker: Choose an exiled card an opponent owns with a void counter on it. You may play it this turn without paying its mana cost.",
             "colours": [
@@ -14253,7 +14253,7 @@
         },
         {
             "id": "c278e4a7-f7ce-53ee-ac48-116cffe7a434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3af4da8-07fe-4781-ad36-375b75012939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3af4da8-07fe-4781-ad36-375b75012939.jpg?1",
             "name": "Necrogoyf",
             "text": "Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B}",
             "colours": [
@@ -14291,7 +14291,7 @@
         },
         {
             "id": "07a13bb5-82b5-5350-812c-ad1a7ced242c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8595c6-5237-4ed1-98e4-8615bb0eb8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8595c6-5237-4ed1-98e4-8615bb0eb8e1.jpg?1",
             "name": "Nested Shambler",
             "text": "When Nested Shambler dies, create X tapped 1/1 green Squirrel creature tokens, where X is Nested Shambler's power.",
             "colours": [
@@ -14328,7 +14328,7 @@
         },
         {
             "id": "6a9e6512-8aa9-5690-90f4-8f92d1d82c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a8dbf-d5b1-4337-8c3e-bc0c8308e426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92a8dbf-d5b1-4337-8c3e-bc0c8308e426.jpg?1",
             "name": "Persist",
             "text": "Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.",
             "colours": [
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "63922c26-4949-5f2b-88bf-5e2682736d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f7fdb-9c38-43f8-acb9-6ea1797387a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7f7fdb-9c38-43f8-acb9-6ea1797387a6.jpg?1",
             "name": "Profane Tutor",
             "text": "Suspend 2\u2014{1}{B}\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -14400,7 +14400,7 @@
         },
         {
             "id": "1de83188-2953-5aa2-ae09-ad652d8368b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7caf6c-9f5b-45c4-99ab-2968c3d574e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7caf6c-9f5b-45c4-99ab-2968c3d574e9.jpg?1",
             "name": "Tourach, Dread Cantor",
             "text": "Kicker {B}{B}\nProtection from white\nWhenever an opponent discards a card, put a +1/+1 counter on Tourach, Dread Cantor.\nWhen Tourach enters the battlefield, if it was kicked, target opponent discards two cards at random.",
             "colours": [
@@ -14441,7 +14441,7 @@
         },
         {
             "id": "197be68d-89e8-5591-b6fd-0f5c0d9b5bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36590526-2f1b-4959-ba9e-55f3ebcffd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36590526-2f1b-4959-ba9e-55f3ebcffd1e.jpg?1",
             "name": "Vile Entomber",
             "text": "Deathtouch\nWhen Vile Entomber enters the battlefield, search your library for a card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -14479,7 +14479,7 @@
         },
         {
             "id": "f10b8c10-ee91-54eb-b3f1-ad47057f2599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45121709-9f0e-4f60-8dd7-ebc31acdb124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45121709-9f0e-4f60-8dd7-ebc31acdb124.jpg?1",
             "name": "Blazing Rootwalla",
             "text": "{R}: Blazing Rootwalla gets +2/+0 until end of turn. Activate only once each turn.\nMadness {0}",
             "colours": [
@@ -14516,7 +14516,7 @@
         },
         {
             "id": "a036bf8d-05fa-5146-90c9-b40a57b05a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d81763-46c0-4e5e-9292-04a8aa461682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d81763-46c0-4e5e-9292-04a8aa461682.jpg?1",
             "name": "Calibrated Blast",
             "text": "Reveal cards from the top of your library until you reveal a nonland card. Put the revealed cards on the bottom of your library in a random order. When you reveal a nonland card this way, Calibrated Blast deals damage equal to that card's mana value to any target.\nFlashback {3}{R}{R}",
             "colours": [
@@ -14552,7 +14552,7 @@
         },
         {
             "id": "5e8a6084-1031-59b9-a610-07f101803bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0a4bba-4512-4718-89b5-f02331f3aa5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0a4bba-4512-4718-89b5-f02331f3aa5f.jpg?1",
             "name": "Galvanic Relay",
             "text": "Exile the top card of your library. During your next turn, you may play that card.\nStorm",
             "colours": [
@@ -14587,7 +14587,7 @@
         },
         {
             "id": "c99614e9-5ae9-5589-9bcc-8b890ce8efbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988137f8-40a3-4308-b297-a9a4d171181d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988137f8-40a3-4308-b297-a9a4d171181d.jpg?1",
             "name": "Glimpse of Tomorrow",
             "text": "Suspend 3\u2014{R}{R}\nShuffle all permanents you own into your library, then reveal that many cards from the top of your library. Put all non-Aura permanent cards revealed this way onto the battlefield, then do the same for Aura cards, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14623,7 +14623,7 @@
         },
         {
             "id": "2dda8abc-dfbe-54d4-aeea-e26177de6b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeb96a-1e2c-47fa-9cfc-7d1ead1cfab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eeb96a-1e2c-47fa-9cfc-7d1ead1cfab6.jpg?1",
             "name": "Mine Collapse",
             "text": "If it's your turn, you may sacrifice a Mountain rather than pay this spell's mana cost.\nMine Collapse deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -14658,7 +14658,7 @@
         },
         {
             "id": "521c9344-4bbc-5ac8-9f1c-53301aa63341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a03422-4106-4d06-b26a-06b1e3b0cb2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a03422-4106-4d06-b26a-06b1e3b0cb2a.jpg?1",
             "name": "Aeve, Progenitor Ooze",
             "text": "Storm\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.",
             "colours": [
@@ -14698,7 +14698,7 @@
         },
         {
             "id": "ea44c218-be76-54bf-a1ba-fee2ba24259f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ba5ac8-e8fa-4979-9ef9-c3d75ee7f982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ba5ac8-e8fa-4979-9ef9-c3d75ee7f982.jpg?1",
             "name": "Chatterfang, Squirrel General",
             "text": "Forestwalk\nIf one or more tokens would be created under your control, those tokens plus that many 1/1 green Squirrel creature tokens are created instead.\n{B}, Sacrifice X Squirrels: Target creature gets +X/-X until end of turn.",
             "colours": [
@@ -14740,7 +14740,7 @@
         },
         {
             "id": "42727da1-af1a-5edc-a4b3-cd7126af3e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1b91d8-39c4-4ab1-996b-2a5a78243fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1b91d8-39c4-4ab1-996b-2a5a78243fd4.jpg?1",
             "name": "Chatterstorm",
             "text": "Create a 1/1 green Squirrel creature token.\nStorm",
             "colours": [
@@ -14775,7 +14775,7 @@
         },
         {
             "id": "89ec351d-1484-57a9-927d-5b9aa78a7468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3283b-e74c-4991-9369-cf3415db41e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3283b-e74c-4991-9369-cf3415db41e0.jpg?1",
             "name": "Gaea's Will",
             "text": "Suspend 4\u2014{G}\nUntil end of turn, you may play lands and cast spells from your graveyard.\nIf a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -14811,7 +14811,7 @@
         },
         {
             "id": "d4200f85-a9db-5ce8-be49-b02e004402b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0691a6a-bfbd-411b-b147-bf9702e7d149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0691a6a-bfbd-411b-b147-bf9702e7d149.jpg?1",
             "name": "Glimmer Bairn",
             "text": "Sacrifice a token: Glimmer Bairn gets +2/+2 until end of turn.",
             "colours": [
@@ -14848,7 +14848,7 @@
         },
         {
             "id": "c2502044-3a73-55f5-ac09-a6265ae5cfae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417f14c-a853-42c6-a992-29139484260a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417f14c-a853-42c6-a992-29139484260a.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "Exalted\n{T}: Add {B}, {R}, or {G}.",
             "colours": [
@@ -14889,7 +14889,7 @@
         },
         {
             "id": "2807bb92-920a-526d-8f03-0d0ac52c34c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512e5b8-2394-42d9-9dbf-345137710cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d512e5b8-2394-42d9-9dbf-345137710cde.jpg?1",
             "name": "Squirrel Sovereign",
             "text": "Other Squirrels you control get +1/+1.",
             "colours": [
@@ -14927,7 +14927,7 @@
         },
         {
             "id": "0b6ab7a9-6022-5e0b-baf4-3f2275ce669b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab161d9-45d7-48b7-af47-21e3dbae4d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab161d9-45d7-48b7-af47-21e3dbae4d85.jpg?1",
             "name": "Titania, Protector of Argoth",
             "text": "When Titania, Protector of Argoth enters the battlefield, return target land card from your graveyard to the battlefield.\nWhenever a land you control is put into a graveyard from the battlefield, create a 5/3 green Elemental creature token.",
             "colours": [
@@ -14967,7 +14967,7 @@
         },
         {
             "id": "35922c91-19e9-5d64-86a0-b2c7dd2099a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6fac09-34e1-495a-ba70-8110845fbefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6fac09-34e1-495a-ba70-8110845fbefb.jpg?1",
             "name": "Asmoranomardicadaistinaculdacar",
             "text": "As long as you've discarded a card this turn, you may pay {BR} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters the battlefield, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.",
             "colours": [
@@ -15010,7 +15010,7 @@
         },
         {
             "id": "44f7fb26-b981-500c-95bd-a3480de7326e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d9b79-bcf8-4c6e-8b0b-6cd71b615d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c7d9b79-bcf8-4c6e-8b0b-6cd71b615d39.jpg?1",
             "name": "Carth the Lion",
             "text": "Whenever Carth the Lion enters the battlefield or a planeswalker you control dies, look at the top seven cards of your library. You may reveal a planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nPlaneswalkers' loyalty abilities you activate cost an additional  to activate.",
             "colours": [
@@ -15053,7 +15053,7 @@
         },
         {
             "id": "0adb358f-5ae4-5a49-91db-b5cb5693c35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875244ac-d129-407a-bd9b-9fb59958bef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875244ac-d129-407a-bd9b-9fb59958bef9.jpg?1",
             "name": "Chainer, Nightmare Adept",
             "text": "Discard a card: You may cast a creature spell from your graveyard this turn. Activate only once each turn.\nWhenever a nontoken creature enters the battlefield under your control, if you didn't cast it from your hand, it gains haste until your next turn.",
             "colours": [
@@ -15095,7 +15095,7 @@
         },
         {
             "id": "513c2f7e-2216-5dfd-952e-0926c80b55c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662c23f8-feb3-43e3-add5-cf136cd54a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662c23f8-feb3-43e3-add5-cf136cd54a1a.jpg?1",
             "name": "Garth One-Eye",
             "text": "{T}: Choose a card name that hasn't been chosen from among Disenchant, Braingeyser, Terror, Shivan Dragon, Regrowth, and Black Lotus. Create a copy of the card with the chosen name. You may cast the copy.",
             "colours": [
@@ -15144,7 +15144,7 @@
         },
         {
             "id": "9ee80811-9f1e-5591-b335-d6da8764cff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f07a80-05b5-4108-9e68-f8da05866acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f07a80-05b5-4108-9e68-f8da05866acc.jpg?1",
             "name": "Goblin Anarchomancer",
             "text": "Each spell you cast that's red or green costs {1} less to cast.",
             "colours": [
@@ -15184,7 +15184,7 @@
         },
         {
             "id": "76a3771a-6dd1-5f8d-8aa8-e99564b1c61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53945b5e-75da-48e5-ac87-5c02f318fdf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53945b5e-75da-48e5-ac87-5c02f318fdf0.jpg?1",
             "name": "Piru, the Volatile",
             "text": "Flying, lifelink\nAt the beginning of your upkeep, sacrifice Piru, the Volatile unless you pay {R}{W}{B}.\nWhen Piru dies, it deals 7 damage to each nonlegendary creature.",
             "colours": [
@@ -15229,7 +15229,7 @@
         },
         {
             "id": "3b0e276f-177a-5db7-bf1c-9f46239ad8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27424714-b656-41b8-b19f-022e472afc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27424714-b656-41b8-b19f-022e472afc7f.jpg?1",
             "name": "Shardless Agent",
             "text": "Cascade",
             "colours": [
@@ -15271,7 +15271,7 @@
         },
         {
             "id": "ca3320b7-9d27-5e61-830b-e3f29a2b51b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddb6d98-3a3a-4332-a64e-97aec71777a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddb6d98-3a3a-4332-a64e-97aec71777a4.jpg?1",
             "name": "Terminal Agony",
             "text": "Destroy target creature.\nMadness {B}{R}",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "0302370f-fd91-5951-9004-b28200994b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b25acb5-3bd3-4835-9b6b-32a751c7ce97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b25acb5-3bd3-4835-9b6b-32a751c7ce97.jpg?1",
             "name": "Territorial Kavu",
             "text": "Domain \u2014 Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.\nWhenever Territorial Kavu attacks, choose one \u2014\n\u2022 Discard a card. If you do, draw a card.\n\u2022 Exile up to one target card from a graveyard.",
             "colours": [
@@ -15348,7 +15348,7 @@
         },
         {
             "id": "2abeb6d5-537c-537e-aeb2-ba2d04c372fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef23258-511f-43f8-b84f-bd2256b5c86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef23258-511f-43f8-b84f-bd2256b5c86b.jpg?1",
             "name": "Brainstone",
             "text": "{2}, {T}, Sacrifice Brainstone: Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [],
@@ -15379,7 +15379,7 @@
         },
         {
             "id": "c6851edc-6574-52b2-940a-394f93340efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4310ee5-a65d-4113-a57c-bb121601e963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4310ee5-a65d-4113-a57c-bb121601e963.jpg?1",
             "name": "Diamond Lion",
             "text": "{T}, Discard your hand, Sacrifice Diamond Lion: Add three mana of any one color. Activate only as an instant.",
             "colours": [],
@@ -15414,7 +15414,7 @@
         },
         {
             "id": "adfb900c-7c37-52f9-ad7b-e173d16acec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b548fdf-7130-4a94-bd7e-09591b395513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b548fdf-7130-4a94-bd7e-09591b395513.jpg?1",
             "name": "Liquimetal Torque",
             "text": "{T}: Add {C}.\n{T}: Target nonland permanent becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -15445,7 +15445,7 @@
         },
         {
             "id": "d70aaae2-a9e9-5e10-b2af-759a0f07a345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff376d1a-85b4-4d8d-8862-5de0aae6fa4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff376d1a-85b4-4d8d-8862-5de0aae6fa4e.jpg?1",
             "name": "Monoskelion",
             "text": "Monoskelion enters the battlefield with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from Monoskelion: It deals 1 damage to any target.",
             "colours": [],
@@ -15479,7 +15479,7 @@
         },
         {
             "id": "237db7cb-3ea4-5ef7-8510-b2482e649a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ac45cf-4dc8-47b9-8ca8-e72464f745d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ac45cf-4dc8-47b9-8ca8-e72464f745d6.jpg?1",
             "name": "Ornithopter of Paradise",
             "text": "Flying\n{T}: Add one mana of any color.",
             "colours": [],
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "d9babe0d-38ca-57c8-8154-53d99082e9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b3983d-93aa-4a33-a064-23c87ab6ed51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b3983d-93aa-4a33-a064-23c87ab6ed51.jpg?1",
             "name": "Scion of Draco",
             "text": "Domain \u2014 This spell costs {2} less to cast for each basic land type among lands you control.\nFlying\nEach creature you control has vigilance if it's white, hexproof if it's blue, lifelink if it's black, first strike if it's red, and trample if it's green.",
             "colours": [],
@@ -15548,7 +15548,7 @@
         },
         {
             "id": "fcfa85c8-d6ff-589a-af32-f2b84a4352e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f81658-4008-45a1-9a3d-a39369b6c96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f81658-4008-45a1-9a3d-a39369b6c96f.jpg?1",
             "name": "Sol Talisman",
             "text": "Suspend 3\u2014{1}\n{T}: Add {C}{C}.",
             "colours": [],
@@ -15580,7 +15580,7 @@
         },
         {
             "id": "9cdf38ce-0201-5732-835f-02afd037bb5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c530cf5-601a-4e9c-b81e-5bddff0c1196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c530cf5-601a-4e9c-b81e-5bddff0c1196.jpg?1",
             "name": "Sword of Hearth and Home",
             "text": "Equipped creature gets +2/+2 and has protection from green and from white.\nWhenever equipped creature deals combat damage to a player, exile up to one target creature you own, then search your library for a basic land card. Put both cards onto the battlefield under your control, then shuffle.\nEquip {2}",
             "colours": [],
@@ -15614,7 +15614,7 @@
         },
         {
             "id": "06e10288-bb9b-5bc6-9472-9a0129c5bc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24504e-b397-4b98-b8e8-8166457f7a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24504e-b397-4b98-b8e8-8166457f7a2e.jpg?1",
             "name": "The Underworld Cookbook",
             "text": "{T}, Discard a card: Create a Food token.\n{4}, {T}, Sacrifice The Underworld Cookbook: Return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -15645,7 +15645,7 @@
         },
         {
             "id": "beb27252-4df7-519d-bbcb-fe196803e75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f982bda-3153-4ef7-9eab-a658732b5db7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f982bda-3153-4ef7-9eab-a658732b5db7.jpg?1",
             "name": "Void Mirror",
             "text": "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.",
             "colours": [],
@@ -15677,7 +15677,7 @@
         },
         {
             "id": "365afb20-e706-586e-b17e-44642b4b5e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716c415e-5eb8-4644-ac64-5ba7c3f0ea65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716c415e-5eb8-4644-ac64-5ba7c3f0ea65.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15709,7 +15709,7 @@
         },
         {
             "id": "85e31db0-769e-51d8-a677-8d810653e70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19a6f20-8ca1-4a8b-8488-bcb5d86868dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19a6f20-8ca1-4a8b-8488-bcb5d86868dc.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15741,7 +15741,7 @@
         },
         {
             "id": "8fe78eb0-850f-5d0b-a6d8-eab0aa8d6b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cad746-a1dc-4739-9707-9c12c42e141a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cad746-a1dc-4739-9707-9c12c42e141a.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15773,7 +15773,7 @@
         },
         {
             "id": "a4737272-0b06-5265-a54a-6466b2327c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c6ba55-2470-4dde-a7fa-137a60716c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c6ba55-2470-4dde-a7fa-137a60716c96.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15805,7 +15805,7 @@
         },
         {
             "id": "a0e2d24e-d722-5646-bd47-875937f1afb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981b3a2e-de94-428d-8e5d-5a7ba6afe4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981b3a2e-de94-428d-8e5d-5a7ba6afe4a2.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -15837,7 +15837,7 @@
         },
         {
             "id": "bb2e12ac-0186-51d0-964f-227243dacd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0063a44-6cde-4d7e-81e1-61bae08831ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0063a44-6cde-4d7e-81e1-61bae08831ee.jpg?1",
             "name": "Yavimaya, Cradle of Growth",
             "text": "Each land is a Forest in addition to its other land types.",
             "colours": [],
@@ -15871,7 +15871,7 @@
         },
         {
             "id": "cbe32e44-5077-5a06-9d20-579e4cfb63ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44fbfa3-3698-4b79-a7bd-6b6f86bea82a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44fbfa3-3698-4b79-a7bd-6b6f86bea82a.jpg?1",
             "name": "Out of Time",
             "text": "When Out of Time enters the battlefield, untap all creatures, then phase them out until Out of Time leaves the battlefield. Put a time counter on Out of Time for each creature phased out this way.\nVanishing",
             "colours": [
@@ -15906,7 +15906,7 @@
         },
         {
             "id": "5609ef81-d09a-5d1d-bd60-7e5eaa892bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2387da7-5372-4533-a632-624dd08120ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2387da7-5372-4533-a632-624dd08120ab.jpg?1",
             "name": "Resurgent Belief",
             "text": "Suspend 2\u2014{1}{W}\nReturn all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -15941,7 +15941,7 @@
         },
         {
             "id": "28e5aaed-94b7-59b7-960a-e459ed7189b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed75e0-f016-4c62-b96e-de97f7fdb6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ed75e0-f016-4c62-b96e-de97f7fdb6d8.jpg?1",
             "name": "Sanctifier en-Vec",
             "text": "Protection from black and from red\nWhen Sanctifier en-Vec enters the battlefield, exile all cards that are black or red from all graveyards.\nIf a black or red permanent, spell, or card not on the battlefield would be put into a graveyard, exile it instead.",
             "colours": [
@@ -15979,7 +15979,7 @@
         },
         {
             "id": "8425b4ee-541e-5561-a273-565b728fee44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044902aa-29a1-4627-a4fc-0beccd2a10b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044902aa-29a1-4627-a4fc-0beccd2a10b3.jpg?1",
             "name": "Timeless Dragon",
             "text": "Flying\nPlainscycling {2}\nEternalize {2}{W}{W}",
             "colours": [
@@ -16016,7 +16016,7 @@
         },
         {
             "id": "cf614be5-243f-5913-abb1-6f8e9de7aacb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb9a0f9-0af6-42ac-9e42-f315f4882939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb9a0f9-0af6-42ac-9e42-f315f4882939.jpg?1",
             "name": "Inevitable Betrayal",
             "text": "Suspend 3\u2014{1}{U}{U}\nSearch target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
             "colours": [
@@ -16051,7 +16051,7 @@
         },
         {
             "id": "047deb7c-09ed-5d90-a071-9a1dcf68ee98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6f1da-ddef-44d0-af1b-e0c4024d9985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f6f1da-ddef-44d0-af1b-e0c4024d9985.jpg?1",
             "name": "Rishadan Dockhand",
             "text": "Islandwalk\n{1}, {T}: Tap target land.",
             "colours": [
@@ -16088,7 +16088,7 @@
         },
         {
             "id": "6fbb8561-ea4f-5059-b2ac-1c2effe7708f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b39f1d-6d8b-4d5d-a956-094de5c26ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b39f1d-6d8b-4d5d-a956-094de5c26ba8.jpg?1",
             "name": "Suspend",
             "text": "Exile target creature and put two time counters on it. If it doesn't have suspend, it gains suspend.",
             "colours": [
@@ -16122,7 +16122,7 @@
         },
         {
             "id": "756fca49-691b-5713-8498-47743bef64b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402060d4-10d6-4cee-aa8b-cd083bf5df43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402060d4-10d6-4cee-aa8b-cd083bf5df43.jpg?1",
             "name": "Damn",
             "text": "Destroy target creature. A creature destroyed this way can't be regenerated.\nOverload {2}{W}{W}",
             "colours": [
@@ -16158,7 +16158,7 @@
         },
         {
             "id": "6ee206c8-1453-56cb-a2f1-a7e34d5eb805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29632951-3c3d-478c-8c5a-9a34f30a5c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29632951-3c3d-478c-8c5a-9a34f30a5c28.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "Shadow\nIf a card would be put into an opponent's graveyard from anywhere, instead exile it with a void counter on it.\n{T}, Sacrifice Dauthi Voidwalker: Choose an exiled card an opponent owns with a void counter on it. You may play it this turn without paying its mana cost.",
             "colours": [
@@ -16196,7 +16196,7 @@
         },
         {
             "id": "5476f12f-7a1b-5be3-92a9-3bd920f19675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2d158-d69e-4854-b84f-9f271e36101c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2d158-d69e-4854-b84f-9f271e36101c.jpg?1",
             "name": "Necrogoyf",
             "text": "Necrogoyf's power is equal to the number of creature cards in all graveyards.\nAt the beginning of each player's upkeep, that player discards a card.\nMadness {1}{B}{B}",
             "colours": [
@@ -16233,7 +16233,7 @@
         },
         {
             "id": "0a7b2595-642f-5c87-bb62-6fa47aa54a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44989011-7833-42e3-8fae-6ed0c7220e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44989011-7833-42e3-8fae-6ed0c7220e28.jpg?1",
             "name": "Profane Tutor",
             "text": "Suspend 2\u2014{1}{B}\nSearch your library for a card, put that card into your hand, then shuffle.",
             "colours": [
@@ -16268,7 +16268,7 @@
         },
         {
             "id": "9b1fa2e0-39f3-5d49-98de-aa70d2edf4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d05400a-862f-4dcc-8ebc-edb0b5deaadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d05400a-862f-4dcc-8ebc-edb0b5deaadd.jpg?1",
             "name": "Unmarked Grave",
             "text": "Search your library for a nonlegendary card, put that card into your graveyard, then shuffle.",
             "colours": [
@@ -16302,7 +16302,7 @@
         },
         {
             "id": "cd0a0756-0977-51d9-8338-d6f7aeabf909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3af226-9f55-481a-87ec-da2861ac60e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3af226-9f55-481a-87ec-da2861ac60e0.jpg?1",
             "name": "Bloodbraid Marauder",
             "text": "Bloodbraid Marauder can't block.\nDelirium \u2014 This spell has cascade as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -16339,7 +16339,7 @@
         },
         {
             "id": "fb15b4fb-01c3-5afd-b7a7-9dc3c4950164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a7da2c-3156-403b-8722-d1fa5eb5192e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a7da2c-3156-403b-8722-d1fa5eb5192e.jpg?1",
             "name": "Breya's Apprentice",
             "text": "When Breya's Apprentice enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.\n{T}, Sacrifice an artifact: Choose one \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play that card.\n\u2022 Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -16377,7 +16377,7 @@
         },
         {
             "id": "8228d372-60cb-53a6-a496-0770657997c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8284eb-a604-4e86-a140-7c703b52c806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8284eb-a604-4e86-a140-7c703b52c806.jpg?1",
             "name": "Calibrated Blast",
             "text": "Reveal cards from the top of your library until you reveal a nonland card. Put the revealed cards on the bottom of your library in a random order. When you reveal a nonland card this way, Calibrated Blast deals damage equal to that card's mana value to any target.\nFlashback {3}{R}{R}",
             "colours": [
@@ -16412,7 +16412,7 @@
         },
         {
             "id": "63fc9053-f4fe-523f-acf0-95f60fea7eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c706922d-c892-43d0-a4f5-91283999d291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c706922d-c892-43d0-a4f5-91283999d291.jpg?1",
             "name": "Chef's Kiss",
             "text": "Gain control of target spell that targets only a single permanent or player. Copy it, then reselect the targets at random for the spell and the copy. The new targets can't be you or a permanent you control.",
             "colours": [
@@ -16446,7 +16446,7 @@
         },
         {
             "id": "fb3e720e-42eb-54d1-8b00-ddebe0529e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d332ab-67bf-4db8-953a-6843efbb455c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d332ab-67bf-4db8-953a-6843efbb455c.jpg?1",
             "name": "Glimpse of Tomorrow",
             "text": "Suspend 3\u2014{R}{R}\nShuffle all permanents you own into your library, then reveal that many cards from the top of your library. Put all non-Aura permanent cards revealed this way onto the battlefield, then do the same for Aura cards, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -16481,7 +16481,7 @@
         },
         {
             "id": "d9f72619-78f0-52af-be7b-5c3ce35256ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2009ab97-1d0f-4c59-9357-3ff4952ce3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2009ab97-1d0f-4c59-9357-3ff4952ce3be.jpg?1",
             "name": "Aeve, Progenitor Ooze",
             "text": "Storm\nAeve, Progenitor Ooze isn't legendary if it's a token.\nAeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.",
             "colours": [
@@ -16520,7 +16520,7 @@
         },
         {
             "id": "4c9b5e15-d4cc-5cb2-b656-9101084254eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7687d1-d168-4279-b21d-fcfc7573c7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7687d1-d168-4279-b21d-fcfc7573c7b5.jpg?1",
             "name": "Chitterspitter",
             "text": "At the beginning of your upkeep, you may sacrifice a token. If you do, put an acorn counter on Chitterspitter.\nSquirrels you control get +1/+1 for each acorn counter on Chitterspitter.\n{G}, {T}: Create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -16554,7 +16554,7 @@
         },
         {
             "id": "480d0b04-c353-540a-aeb4-213fd547489b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecd084d-20c6-43cf-b5d5-8ba3d692a50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecd084d-20c6-43cf-b5d5-8ba3d692a50a.jpg?1",
             "name": "Gaea's Will",
             "text": "Suspend 4\u2014{G}\nUntil end of turn, you may play lands and cast spells from your graveyard.\nIf a card would be put into your graveyard from anywhere this turn, exile that card instead.",
             "colours": [
@@ -16589,7 +16589,7 @@
         },
         {
             "id": "dfc77d68-2f73-5aab-a53b-518b590d5b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd218c-3e14-4b82-9e03-16a0fad1b530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd218c-3e14-4b82-9e03-16a0fad1b530.jpg?1",
             "name": "Sanctum Weaver",
             "text": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
             "colours": [
@@ -16626,7 +16626,7 @@
         },
         {
             "id": "982c13aa-1dd6-5a9d-a25b-38ad0c1f6141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879f780-e17f-4e68-931e-6e45f9df28e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2879f780-e17f-4e68-931e-6e45f9df28e1.jpg?1",
             "name": "Asmoranomardicadaistinaculdacar",
             "text": "As long as you've discarded a card this turn, you may pay {BR} to cast this spell.\nWhen Asmoranomardicadaistinaculdacar enters the battlefield, you may search your library for a card named The Underworld Cookbook, reveal it, put it into your hand, then shuffle.\nSacrifice two Foods: Target creature deals 6 damage to itself.",
             "colours": [
@@ -16668,7 +16668,7 @@
         },
         {
             "id": "d9626b00-e739-56b5-8b4b-5095752aa275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf4ca15-10b9-4dcc-86dc-be15eeda87a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf4ca15-10b9-4dcc-86dc-be15eeda87a4.jpg?1",
             "name": "Carth the Lion",
             "text": "Whenever Carth the Lion enters the battlefield or a planeswalker you control dies, look at the top seven cards of your library. You may reveal a planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nPlaneswalkers' loyalty abilities you activate cost an additional  to activate.",
             "colours": [
@@ -16710,7 +16710,7 @@
         },
         {
             "id": "d5e65e51-73b9-5b65-a43e-a5467aa62d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c398de-b96d-4fa6-89c4-3ce8183dc27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c398de-b96d-4fa6-89c4-3ce8183dc27e.jpg?1",
             "name": "Master of Death",
             "text": "When Master of Death enters the battlefield, surveil 2.\nAt the beginning of your upkeep, if Master of Death is in your graveyard, you may pay 1 life. If you do, return it to your hand.",
             "colours": [
@@ -16749,7 +16749,7 @@
         },
         {
             "id": "9574edd1-178d-50c9-aa66-3960874ff112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064c2f03-5290-4e87-9d2f-cfbd247c9646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064c2f03-5290-4e87-9d2f-cfbd247c9646.jpg?1",
             "name": "Piru, the Volatile",
             "text": "Flying, lifelink\nAt the beginning of your upkeep, sacrifice Piru, the Volatile unless you pay {R}{W}{B}.\nWhen Piru dies, it deals 7 damage to each nonlegendary creature.",
             "colours": [
@@ -16793,7 +16793,7 @@
         },
         {
             "id": "d895b0ca-cf2f-5b67-8cef-937f5d3fbe23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2474c3e8-7b52-477b-ada8-22e221037925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2474c3e8-7b52-477b-ada8-22e221037925.jpg?1",
             "name": "Territorial Kavu",
             "text": "Domain \u2014 Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.\nWhenever Territorial Kavu attacks, choose one \u2014\n\u2022 Discard a card. If you do, draw a card.\n\u2022 Exile up to one target card from a graveyard.",
             "colours": [
@@ -16832,7 +16832,7 @@
         },
         {
             "id": "241eeabf-8e5f-5987-8324-53099a514e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc06edb-d7dd-40e4-abbb-03ec2d467193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc06edb-d7dd-40e4-abbb-03ec2d467193.jpg?1",
             "name": "Yusri, Fortune's Flame",
             "text": "Flying\nWhenever Yusri, Fortune's Flame attacks, choose a number between 1 and 5. Flip that many coins. For each flip you win, draw a card. For each flip you lose, Yusri deals 2 damage to you. If you won five flips this way, you may cast spells from your hand this turn without paying their mana costs.",
             "colours": [
@@ -16873,7 +16873,7 @@
         },
         {
             "id": "37257ed9-afbe-52d8-a081-a8b9805f8ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb31a63-a4c9-4432-9029-eb5a50c769b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb31a63-a4c9-4432-9029-eb5a50c769b4.jpg?1",
             "name": "Academy Manufactor",
             "text": "If you would create a Clue, Food, or Treasure token, instead create one of each.",
             "colours": [],
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "0f5a3683-0214-569d-9916-639198285845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2116f1a3-f621-4bef-b5bd-fa4a644f76b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2116f1a3-f621-4bef-b5bd-fa4a644f76b1.jpg?1",
             "name": "Diamond Lion",
             "text": "{T}, Discard your hand, Sacrifice Diamond Lion: Add three mana of any one color. Activate only as an instant.",
             "colours": [],
@@ -16940,7 +16940,7 @@
         },
         {
             "id": "9ff2c337-a520-5571-8302-c981b3f2c96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f3852d-e99a-418e-a235-da47ed38aabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f3852d-e99a-418e-a235-da47ed38aabe.jpg?1",
             "name": "Nettlecyst",
             "text": "Living weapon\nEquipped creature gets +1/+1 for each artifact and/or enchantment you control.\nEquip {2}",
             "colours": [],
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "911050fe-18a4-546c-a37e-bb17386e1fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18052761-39c3-4342-b6e6-38dc5b7b05dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18052761-39c3-4342-b6e6-38dc5b7b05dd.jpg?1",
             "name": "Sol Talisman",
             "text": "Suspend 3\u2014{1}\n{T}: Add {C}{C}.",
             "colours": [],
@@ -17003,7 +17003,7 @@
         },
         {
             "id": "d157b20f-ae11-55c6-a887-c140907d7c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c216e5-856d-4464-96f7-17b5289d5396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c216e5-856d-4464-96f7-17b5289d5396.jpg?1",
             "name": "Void Mirror",
             "text": "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.",
             "colours": [],
@@ -17034,7 +17034,7 @@
         },
         {
             "id": "5d802e96-c38e-54c8-b634-b070cb6ee24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58a96f-939c-4b9b-a4c2-fb83d896eefb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58a96f-939c-4b9b-a4c2-fb83d896eefb.jpg?1",
             "name": "Zabaz, the Glimmerwasp",
             "text": "Modular 1\nIf a modular triggered ability would put one or more +1/+1 counters on a creature you control, that many plus one +1/+1 counters are put on it instead.\n{R}: Destroy target artifact you control.\n{W}: Zabaz, the Glimmerwasp gains flying until end of turn.",
             "colours": [],
@@ -17072,7 +17072,7 @@
         },
         {
             "id": "bfd186b5-e698-583d-9a96-15530aa43df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ced5cf-b51a-4dab-97f7-50fb18e5c463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ced5cf-b51a-4dab-97f7-50fb18e5c463.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17103,7 +17103,7 @@
         },
         {
             "id": "55b43cef-e9de-5d62-8dc2-74491241811d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8397e6-d13a-4996-8fde-b8a9895de287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8397e6-d13a-4996-8fde-b8a9895de287.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17134,7 +17134,7 @@
         },
         {
             "id": "d53c0a56-2548-5ece-8bad-ed09112e1ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d8e67a-5150-4782-98d1-da2ca79607ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d8e67a-5150-4782-98d1-da2ca79607ad.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17165,7 +17165,7 @@
         },
         {
             "id": "58bbf59a-b4bd-58f0-8b8b-9747789966bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ecfc9-8d6b-4fdb-9001-64dc3e4e7a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ecfc9-8d6b-4fdb-9001-64dc3e4e7a3f.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17196,7 +17196,7 @@
         },
         {
             "id": "064b0bae-29ab-578c-b210-8a73443d93d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7057b04-e22f-4e33-9f08-b9fbd2e54bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7057b04-e22f-4e33-9f08-b9fbd2e54bf5.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17227,7 +17227,7 @@
         },
         {
             "id": "904bb8b4-f746-5f1f-8c18-082fc3d6f59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7c2820-e36e-4024-a542-02ca42bb7e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7c2820-e36e-4024-a542-02ca42bb7e2f.jpg?1",
             "name": "Yavimaya, Cradle of Growth",
             "text": "Each land is a Forest in addition to its other land types.",
             "colours": [],
@@ -17260,7 +17260,7 @@
         },
         {
             "id": "2210b34e-1821-5bbd-a039-6a4a7733a5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa2449-6b74-4319-858f-caa9282da5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5aa2449-6b74-4319-858f-caa9282da5c1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17297,7 +17297,7 @@
         },
         {
             "id": "eae53b01-b037-55e5-8efc-2a0ef422c887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14e6193-f60b-46c8-a7eb-02a437138568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14e6193-f60b-46c8-a7eb-02a437138568.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17334,7 +17334,7 @@
         },
         {
             "id": "f34e51c1-7c9c-517d-9753-a90e50de9bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423927e6-2419-4d88-b0c4-425e5cac1a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423927e6-2419-4d88-b0c4-425e5cac1a3f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17371,7 +17371,7 @@
         },
         {
             "id": "62b78512-f9e7-5f75-95b4-b394587023f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d781a5-2f5e-499f-b210-c4a5c50a180c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d781a5-2f5e-499f-b210-c4a5c50a180c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17408,7 +17408,7 @@
         },
         {
             "id": "95e0346e-d6df-5be8-b103-d8373325fdf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8546d1-bfea-4cf7-bfa1-48555ea81bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8546d1-bfea-4cf7-bfa1-48555ea81bd4.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17445,7 +17445,7 @@
         },
         {
             "id": "35cb261c-c1f4-52df-9363-e638725c2b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959cb185-a280-493c-b85c-69b74e042c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/959cb185-a280-493c-b85c-69b74e042c15.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17482,7 +17482,7 @@
         },
         {
             "id": "8a0a06d9-8bdd-5d1f-b29f-fd20687b6487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be3032-c55b-43b5-9ae0-f4e7470f4f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be3032-c55b-43b5-9ae0-f4e7470f4f83.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17519,7 +17519,7 @@
         },
         {
             "id": "7b0ce595-0135-5e59-bb04-156fdc19b8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a0d49-71ae-42c4-a896-6828dc4f1e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5a0d49-71ae-42c4-a896-6828dc4f1e85.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17556,7 +17556,7 @@
         },
         {
             "id": "3ae61fb7-3293-5880-a32a-a9c530041d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e93212-da68-48f8-9aeb-ee5eb92e9a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e93212-da68-48f8-9aeb-ee5eb92e9a54.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17593,7 +17593,7 @@
         },
         {
             "id": "1da41dd8-bf56-5fdc-952b-9f26e082d1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17393110-c57e-487b-b07e-dc21a164efa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17393110-c57e-487b-b07e-dc21a164efa7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17630,7 +17630,7 @@
         },
         {
             "id": "8f52b2f8-87c2-54c4-b133-87a2ca4fa99f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9839e4e-94dd-4087-b7a9-3089f1828397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9839e4e-94dd-4087-b7a9-3089f1828397.jpg?1",
             "name": "Sanctum Prelate",
             "text": "As Sanctum Prelate enters the battlefield, choose a number.\nNoncreature spells with mana value equal to the chosen number can't be cast.",
             "colours": [
@@ -17664,7 +17664,7 @@
         },
         {
             "id": "40ccb40a-60f4-5df4-8eff-f8c1efcea7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c332e-a5c9-40fb-a2fa-b4888aecc9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2c332e-a5c9-40fb-a2fa-b4888aecc9c7.jpg?1",
             "name": "Yusri, Fortune's Flame",
             "text": "Flying\nWhenever Yusri, Fortune's Flame attacks, choose a number between 1 and 5. Flip that many coins. For each flip you win, draw a card. For each flip you lose, Yusri deals 2 damage to you. If you won five flips this way, you may cast spells from your hand this turn without paying their mana costs.",
             "colours": [
@@ -17705,7 +17705,7 @@
         },
         {
             "id": "c4b05382-12cb-5258-8d3d-d651126026ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e40dd-f435-4abc-a3e8-fd3d3a94e910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e40dd-f435-4abc-a3e8-fd3d3a94e910.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -17740,7 +17740,7 @@
         },
         {
             "id": "d22b1f7f-bd5a-5691-ba2e-6999608aab5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5.jpg?1",
             "name": "Crab",
             "text": "",
             "colours": [
@@ -17775,7 +17775,7 @@
         },
         {
             "id": "281298b5-2b46-58ad-9317-5c6432a07a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e0681-603e-4180-bc86-3dadf214e61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53e0681-603e-4180-bc86-3dadf214e61a.jpg?1",
             "name": "Phyrexian Germ",
             "text": "",
             "colours": [
@@ -17811,7 +17811,7 @@
         },
         {
             "id": "66c1dec4-4e0e-50d3-852e-142972e48d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ab74f3-897a-4dd9-b460-f31a0f496bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ab74f3-897a-4dd9-b460-f31a0f496bb4.jpg?1",
             "name": "Timeless Dragon",
             "text": "",
             "colours": [
@@ -17847,7 +17847,7 @@
         },
         {
             "id": "007e7abf-e733-5bf0-8c22-37881e5bb218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e466a1b-a120-420a-884f-99c6629dcbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e466a1b-a120-420a-884f-99c6629dcbc7.jpg?1",
             "name": "Timeless Witness",
             "text": "",
             "colours": [
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "68c08e04-c7bc-5c2c-8653-80c3960b1b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3031bec1-c6dc-441f-9391-458bb1577c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3031bec1-c6dc-441f-9391-458bb1577c56.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17919,7 +17919,7 @@
         },
         {
             "id": "1381dd95-3d82-5215-887b-4c7178baa411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46d82e0-ef99-473c-a09c-8f552db759bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46d82e0-ef99-473c-a09c-8f552db759bf.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -17955,7 +17955,7 @@
         },
         {
             "id": "b053b0fa-87ef-5444-9e60-0946d493e14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41268b47-df00-41db-92d7-991c7945e4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41268b47-df00-41db-92d7-991c7945e4c6.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -17990,7 +17990,7 @@
         },
         {
             "id": "022298f4-4249-5c29-b611-1a014734e0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -18025,7 +18025,7 @@
         },
         {
             "id": "1e44ddb7-8c59-5857-90f3-62ea867a0a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cddb130-a354-4373-9dc4-60c7d57eec8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cddb130-a354-4373-9dc4-60c7d57eec8b.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -18060,7 +18060,7 @@
         },
         {
             "id": "20cf468e-53c0-55c9-81f0-7ed254feac63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ddd05-1aae-46fc-95ce-866710d1c5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ddd05-1aae-46fc-95ce-866710d1c5c6.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -18095,7 +18095,7 @@
         },
         {
             "id": "3d30fcdc-6e3d-5535-8bb3-34d175b2fb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb9e14-b299-4064-a41b-0fb6b078942e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb9e14-b299-4064-a41b-0fb6b078942e.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [
@@ -18133,7 +18133,7 @@
         },
         {
             "id": "7ad2c163-6575-5d2d-ac75-aeb04fa45a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1033-ce07-40ef-9315-beb759af9465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce1033-ce07-40ef-9315-beb759af9465.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -18170,7 +18170,7 @@
         },
         {
             "id": "7d9ff3f2-78bb-56dc-b1a3-6eac61cede64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcf6efe-9f94-4a55-9994-701e596691ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcf6efe-9f94-4a55-9994-701e596691ad.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -18201,7 +18201,7 @@
         },
         {
             "id": "e7b91ed4-09bc-5999-9f8c-e60a09b645ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb129b0d-1349-4e88-a6a7-b7968b26ee7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb129b0d-1349-4e88-a6a7-b7968b26ee7e.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -18232,7 +18232,7 @@
         },
         {
             "id": "3b93e4cb-767f-55f7-b59f-05f4c78db185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7caaf39-8f16-4f1d-bee6-a45674306319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7caaf39-8f16-4f1d-bee6-a45674306319.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -18264,7 +18264,7 @@
         },
         {
             "id": "17aa22b9-8fe3-518a-89fa-5fd2def16e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fdfb0ba-d086-4e7c-97e0-70d1e8328ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fdfb0ba-d086-4e7c-97e0-70d1e8328ded.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -18295,7 +18295,7 @@
         },
         {
             "id": "af87e130-3b6a-589f-959b-301f7269a7fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e32ba6-108a-421f-9dad-3d03f7ebe239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e32ba6-108a-421f-9dad-3d03f7ebe239.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -18326,7 +18326,7 @@
         },
         {
             "id": "1f1c1d57-2f8f-5e0e-9d59-3f7dfd405b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e542094-8d95-463c-ae6c-8f2cd56434b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e542094-8d95-463c-ae6c-8f2cd56434b2.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -18358,7 +18358,7 @@
         },
         {
             "id": "68325c67-cbb6-5db7-aedd-7248ad6e408e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630c0d1c-9ddb-4e76-a82a-9cdd8a5b487b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630c0d1c-9ddb-4e76-a82a-9cdd8a5b487b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -18389,7 +18389,7 @@
         },
         {
             "id": "74d281e4-6c2a-53c2-b0ea-253ef143d22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ab4943-3943-4b83-8da3-90a1fb0988b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ab4943-3943-4b83-8da3-90a1fb0988b3.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MH3.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MH3.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "02791d8b-58da-5d60-939d-c78899a1db53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72449552-aa2c-4ae3-846f-df523c5e6078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72449552-aa2c-4ae3-846f-df523c5e6078.jpg?1",
             "name": "Breaker of Creation",
             "text": "When you cast this spell, you gain 1 life for each colorless permanent you control.\nHexproof from each color\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "410b91e9-36e3-590c-bfe7-10cc8c74e72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560debcd-feb4-4534-991e-a7aa1cca2409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560debcd-feb4-4534-991e-a7aa1cca2409.jpg?1",
             "name": "Devourer of Destiny",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of your first upkeep, look at the top four cards of your library. You may put one of those cards back on top of your library. Exile the rest.\nWhen you cast this spell, exile target permanent that's one or more colors.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "9aa66138-80e5-556a-9c8e-cebbe0a67692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7faf5812-2067-4386-bb83-150723d67d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7faf5812-2067-4386-bb83-150723d67d02.jpg?1",
             "name": "Drownyard Lurker",
             "text": "Vigilance\nWhen you cast or cycle Drownyard Lurker, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "bb0aab6d-0741-5f9d-bdd8-6a9d12a980f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28b9bee-d726-407b-9e5b-2231384df81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28b9bee-d726-407b-9e5b-2231384df81e.jpg?1",
             "name": "Echoes of Eternity",
             "text": "If a triggered ability of a colorless spell you control or another colorless permanent you control triggers, that ability triggers an additional time.\nWhenever you cast a colorless spell, copy it. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [],
@@ -130,7 +130,7 @@
         },
         {
             "id": "e90f91e6-0aea-5caf-b0d6-f3fd932da900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce97bb8-b0ee-4473-8c26-a3ec91abec97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce97bb8-b0ee-4473-8c26-a3ec91abec97.jpg?1",
             "name": "Eldrazi Ravager",
             "text": "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\nSacrifice two Eldrazi: Return Eldrazi Ravager from your graveyard to your hand.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -160,7 +160,7 @@
         },
         {
             "id": "0ca5ef79-ca0b-5fc6-b108-2dc6f3d970d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b914bfd9-5be3-4459-a68a-9b3ea2747bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b914bfd9-5be3-4459-a68a-9b3ea2747bbc.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -197,7 +197,7 @@
         },
         {
             "id": "9ff09957-8a19-5826-829c-967017a4c7b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c2a3c7-1486-4ff9-88ec-79ec67a437f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c2a3c7-1486-4ff9-88ec-79ec67a437f8.jpg?1",
             "name": "Glaring Fleshraker",
             "text": "Whenever you cast a colorless spell, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nWhenever another colorless creature enters the battlefield under your control, Glaring Fleshraker deals 1 damage to each opponent.",
             "colours": [],
@@ -230,7 +230,7 @@
         },
         {
             "id": "abda2134-de62-534f-b5eb-2b49f95981d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7baf9549-1869-4bd3-a52a-2f0b30ba0b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7baf9549-1869-4bd3-a52a-2f0b30ba0b16.jpg?1",
             "name": "Herigast, Erupting Nullkite",
             "text": "Emerge {6}{R}{R} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, you may exile your hand. If you do, draw three cards.\nFlying\nEach creature spell you cast has emerge. The emerge cost is equal to its mana cost.",
             "colours": [],
@@ -268,7 +268,7 @@
         },
         {
             "id": "d2b86473-616c-50f7-89ec-8f0d0c5bd11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c47679-0fac-466f-be3c-794f23576e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c47679-0fac-466f-be3c-794f23576e55.jpg?1",
             "name": "It That Heralds the End",
             "text": "Colorless spells you cast with mana value 7 or greater cost {1} less to cast.\nOther colorless creatures you control get +1/+1.",
             "colours": [],
@@ -301,7 +301,7 @@
         },
         {
             "id": "9da7f8de-25d5-5caf-8c09-0f534d0fe609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04066abb-44d2-4730-9cc3-2584bc4c7d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04066abb-44d2-4730-9cc3-2584bc4c7d8c.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -337,7 +337,7 @@
         },
         {
             "id": "ad7d9412-4564-5a17-b0ff-c85f89065f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92585587-cfdc-406a-9114-4f6dd8802c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92585587-cfdc-406a-9114-4f6dd8802c37.jpg?1",
             "name": "Kozilek's Command",
             "text": "Choose two \u2014\n\u2022 Target player creates X 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\n\u2022 Target player scries X, then draws a card.\n\u2022 Exile target creature with mana value X or less.\n\u2022 Exile up to X target cards from graveyards.",
             "colours": [],
@@ -368,7 +368,7 @@
         },
         {
             "id": "38728faa-eeb6-55b0-9f6c-f48a6c0fc88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e259868-d29a-4c03-8ec3-49e914f849fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e259868-d29a-4c03-8ec3-49e914f849fb.jpg?1",
             "name": "Null Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target multicolored spell.\n\u2022 Destroy target multicolored permanent.",
             "colours": [],
@@ -398,7 +398,7 @@
         },
         {
             "id": "6f7e51c2-dc49-5aa6-b83c-8d543d15f027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9f1bb8-c91b-40cd-a416-abbff0d65306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9f1bb8-c91b-40cd-a416-abbff0d65306.jpg?1",
             "name": "Nulldrifter",
             "text": "When you cast this spell, draw two cards.\nFlying\nAnnihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [],
@@ -433,7 +433,7 @@
         },
         {
             "id": "fef8ba31-4834-5144-8177-7fd7d16d2a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d7ae4-9c4b-4a5a-a109-7630a07aeb45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/534d7ae4-9c4b-4a5a-a109-7630a07aeb45.jpg?1",
             "name": "Twisted Riddlekeeper",
             "text": "Emerge {5}{C}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, tap up to two target permanents. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nFlying",
             "colours": [],
@@ -466,7 +466,7 @@
         },
         {
             "id": "8183ba2c-988a-50c5-92c4-98498ffb1730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd00d56a-86bd-41d8-82b6-975404ef8067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd00d56a-86bd-41d8-82b6-975404ef8067.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -502,7 +502,7 @@
         },
         {
             "id": "90e2259b-cd91-5547-853e-b820e2134692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5f3a1a-8514-4598-be3d-c3be719f6951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5f3a1a-8514-4598-be3d-c3be719f6951.jpg?1",
             "name": "Warped Tusker",
             "text": "Reach\nWhen you cast or cycle Warped Tusker, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -536,7 +536,7 @@
         },
         {
             "id": "3bb1c660-988c-561a-9e14-3f388c1c0f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc119b8-429c-4ab6-adba-b65b03810e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc119b8-429c-4ab6-adba-b65b03810e98.jpg?1",
             "name": "Wastescape Battlemage",
             "text": "Kicker {G} and/or {1}{U}\nWhen you cast this spell, if it was kicked with its {G} kicker, exile target artifact or enchantment an opponent controls.\nWhen you cast this spell, if it was kicked with its {1}{U} kicker, return target creature an opponent controls to its owner's hand.",
             "colours": [],
@@ -572,7 +572,7 @@
         },
         {
             "id": "2e429867-a992-5cce-9d5d-44cf934f6d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c134b-a416-467e-a158-def84c92c6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c134b-a416-467e-a158-def84c92c6af.jpg?1",
             "name": "Aerie Auxiliary",
             "text": "Flying\nWhen Aerie Auxiliary enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -607,7 +607,7 @@
         },
         {
             "id": "8a94d048-e6b1-51c0-8c05-2267f800b3b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d918133-d4e2-4674-a3cb-58edef1c6758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d918133-d4e2-4674-a3cb-58edef1c6758.jpg?1",
             "name": "Ajani Fells the Godsire",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile target creature an opponent controls with power 3 or greater.\nII \u2014 Create a 2/1 white Cat Warrior creature token, then put a vigilance counter on a creature you control.\nIII \u2014 Target creature you control gains double strike until end of turn.",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "4cc01edd-4bbc-5d96-ab62-ca8907583364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ad225-1249-4e94-898c-ca21b132e62d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56ad225-1249-4e94-898c-ca21b132e62d.jpg?1",
             "name": "Argent Dais",
             "text": "Argent Dais enters the battlefield with two oil counters on it.\nWhenever two or more creatures attack, put an oil counter on Argent Dais.\n{2}, {T}, Remove two oil counters from Argent Dais: Exile another target nonland permanent. Its controller draws two cards.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "01af488b-2004-5f7b-92ed-613c42acca47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5cab75-546c-4760-97b7-4591de9e6662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5cab75-546c-4760-97b7-4591de9e6662.jpg?1",
             "name": "Charitable Levy",
             "text": "Noncreature spells cost {1} more to cast.\nWhenever a player casts a noncreature spell, put a collection counter on Charitable Levy. Then if there are three or more collection counters on it, sacrifice it. If you do, draw a card, then you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "a3aeec60-595a-5847-a678-3fe0b7f2b95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ba710-eddb-40ca-b2fe-0e4e778aab9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ba710-eddb-40ca-b2fe-0e4e778aab9c.jpg?1",
             "name": "Dog Umbra",
             "text": "Flash\nEnchant creature\nAs long as another player controls enchanted creature, it can't attack or block. Otherwise, Dog Umbra has umbra armor. (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "abf0e10d-e128-58c7-83fd-6bf8526fb880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1dfbfc-90e0-48fa-98f1-39929f823619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1dfbfc-90e0-48fa-98f1-39929f823619.jpg?1",
             "name": "Envoy of the Ancestors",
             "text": "Outlast {W} ({W}, {T}: Put a +1/+1 counter on this creature. Outlast only as a sorcery.)\nModified creatures you control have lifelink. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "ad20260f-e1bd-59c4-a578-eaefb04bcaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65f4ae3-6b21-4827-9851-8a53628e254f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65f4ae3-6b21-4827-9851-8a53628e254f.jpg?1",
             "name": "Essence Reliquary",
             "text": "{T}: Return another target permanent you control and all Auras you control attached to it to their owner's hand. Activate only during your turn.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "843bdfed-0fb0-54d7-9936-7d0ef5319f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68baee-f503-407d-931f-2a550470a55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f68baee-f503-407d-931f-2a550470a55f.jpg?1",
             "name": "Expel the Unworthy",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nChoose target creature with mana value 3 or less. If this spell was kicked, instead choose target creature. Exile the chosen creature, then its controller gains life equal to its mana value.",
             "colours": [
@@ -842,7 +842,7 @@
         },
         {
             "id": "6ea65582-7b07-5eb0-a388-0ea914785d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b41b59-0296-443b-8a62-8d5c4641ef66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b41b59-0296-443b-8a62-8d5c4641ef66.jpg?1",
             "name": "Flare of Fortitude",
             "text": "You may sacrifice a nontoken white creature rather than pay this spell's mana cost.\nUntil end of turn, your life total can't change, and permanents you control gain hexproof and indestructible.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "e0279383-d355-573f-a17e-ec621b53effe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f48c8f-b6f9-43b2-91c3-8d6e95d62db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f48c8f-b6f9-43b2-91c3-8d6e95d62db9.jpg?1",
             "name": "Glyph Elemental",
             "text": "Bestow {1}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Glyph Elemental.\nEnchanted creature gets +1/+1 for each +1/+1 counter on Glyph Elemental.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "31f79b60-43a2-5dc1-b1bc-f366b985d61c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8032c909-3170-45ab-a552-a8dc683b0a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8032c909-3170-45ab-a552-a8dc683b0a6e.jpg?1",
             "name": "Guardian of the Forgotten",
             "text": "Vigilance\nWhenever a modified creature you control dies, manifest the top card of your library. (Equipment, Auras you control, and counters are modifications. To manifest a card, put the top card of your library onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "a527d5f5-9f4d-53d2-b494-4c4e52068184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c3cad2-1e25-4abe-878d-9194de6fcc27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c3cad2-1e25-4abe-878d-9194de6fcc27.jpg?1",
             "name": "Guide of Souls",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life and get {E} (an energy counter).\nWhenever you attack, you may pay {E}{E}{E}. When you do, put two +1/+1 counters and a flying counter on target attacking creature. It becomes an Angel in addition to its other types.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "7f4e041e-0278-5b22-9765-6723755533d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a85b6d-fb2b-4359-9dd6-081d8722e580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a85b6d-fb2b-4359-9dd6-081d8722e580.jpg?1",
             "name": "Hexgold Slith",
             "text": "When Hexgold Slith enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Hexgold Slith attacks, you may pay {E}{E}. If you do, it gains first strike until end of turn.\nWhenever Hexgold Slith deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "83ad96e8-e01b-58cf-820e-d2c86a3a74d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdbef00-bc1b-4dd6-aef5-aeb5ce454344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdbef00-bc1b-4dd6-aef5-aeb5ce454344.jpg?1",
             "name": "Indebted Spirit",
             "text": "Bestow {2}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nAfterlife 1 (When this permanent is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying.)\nEnchanted creature gets +1/+1 and has afterlife 1.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "242f794d-c10c-51c9-a67f-caa4772466d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9143fc7c-f4eb-4f06-97b9-f912237a055f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9143fc7c-f4eb-4f06-97b9-f912237a055f.jpg?1",
             "name": "Inspired Inventor",
             "text": "When Inspired Inventor enters the battlefield, choose one \u2014\n\u2022 You get {E}{E}{E} (three energy counters).\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Create a 1/1 colorless Servo artifact creature token.",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "91031d68-29c0-515f-9633-118c4d10a7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f773a79f-ad0f-45c9-bcf5-44ba5e992729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f773a79f-ad0f-45c9-bcf5-44ba5e992729.jpg?1",
             "name": "Jolted Awake",
             "text": "Choose up to one target artifact or creature card in your graveyard. You get {E}{E} (two energy counters). Then you may pay an amount of {E} equal to that card's mana value. If you do, return it from your graveyard to the battlefield.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "440234d7-451c-5214-bbbf-b7497972156c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b922f71-18e6-4a74-b792-d477d4a1deca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b922f71-18e6-4a74-b792-d477d4a1deca.jpg?1",
             "name": "Mandibular Kite",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1 and has flying.\nEquip {3}{W}",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "664b67e7-c7b3-5753-a3af-b1f708b7b29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e115a-c0dc-4901-9a1f-87754304e378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774e115a-c0dc-4901-9a1f-87754304e378.jpg?1",
             "name": "Metastatic Evangel",
             "text": "Whenever another nontoken creature enters the battlefield under your control, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "044b5388-caf5-5088-9f30-0b68d24ad214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37510bb-245c-47bc-bbf3-2b202b67d383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37510bb-245c-47bc-bbf3-2b202b67d383.jpg?1",
             "name": "Muster the Departed",
             "text": "When Muster the Departed enters the battlefield, create a 1/1 white Spirit creature token with flying.\nMorbid \u2014 At the beginning of your end step, if a creature died this turn, populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "6c41fe29-0a3a-5eb8-bcf4-b4668770df5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3a9f8f-b74f-44f1-a8b5-d21a55358a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3a9f8f-b74f-44f1-a8b5-d21a55358a6c.jpg?1",
             "name": "Nyxborn Unicorn",
             "text": "Bestow {3}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nEnchanted creature gets +2/+2 and has mentor.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "e06e4b32-af41-50a1-b6df-70150c43311b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cf6f57-230f-497e-a14e-ad1e8737fd42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cf6f57-230f-497e-a14e-ad1e8737fd42.jpg?1",
             "name": "Ocelot Pride",
             "text": "First strike, lifelink\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your end step, if you gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's blessing, for each token you control that entered the battlefield this turn, create a token that's a copy of it.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "4508bde5-72d3-503b-a6e0-756bc70b21a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aef7c8-58b3-463c-91d3-2d1ff8a815ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aef7c8-58b3-463c-91d3-2d1ff8a815ee.jpg?1",
             "name": "Pearl-Ear, Imperial Advisor",
             "text": "Lifelink\nEnchantment spells you cast have affinity for Auras. (They cost {1} less to cast for each Aura you control.)\nWhenever you cast an Aura spell that targets a modified permanent you control, draw a card. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -1339,7 +1339,7 @@
         },
         {
             "id": "24488650-34e7-576c-8533-4735246dba55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55707746-da6e-46e5-a5ca-7ac843fdc38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55707746-da6e-46e5-a5ca-7ac843fdc38e.jpg?1",
             "name": "Phelia, Exuberant Shepherd",
             "text": "Flash\nWhenever Phelia, Exuberant Shepherd attacks, exile up to one other target nonland permanent. At the beginning of the next end step, return that card to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on Phelia.",
             "colours": [
@@ -1378,7 +1378,7 @@
         },
         {
             "id": "6fe5f480-a737-5d92-b6a1-29b594bf9f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0821e622-88b8-4b82-a696-954da1dde915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0821e622-88b8-4b82-a696-954da1dde915.jpg?1",
             "name": "Proud Pack-Rhino",
             "text": "When Proud Pack-Rhino enters the battlefield, choose one \u2014\n\u2022 Put a shield counter on target permanent. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1412,7 +1412,7 @@
         },
         {
             "id": "b14b9b1c-8060-5db9-8520-8f71219b8a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7df20-1ccf-459b-b81c-ab8763c77ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7df20-1ccf-459b-b81c-ab8763c77ccf.jpg?1",
             "name": "Rosecot Knight",
             "text": "Vigilance\nWhen Rosecot Knight enters the battlefield, look at the top six cards of your library. You may reveal an artifact or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, put a +1/+1 counter on Rosecot Knight.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "56291a1e-dcd9-593b-95e7-67ea58e5288f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10539e3-d4bc-4f71-a00f-8e94bb97509d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10539e3-d4bc-4f71-a00f-8e94bb97509d.jpg?1",
             "name": "Solstice Zealot",
             "text": "When Solstice Zealot enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Tap target creature.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "2bd36d2c-750f-54bc-afe6-248e7e50e423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd16222e-349c-4a2b-a7c8-8eb35a8ab332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd16222e-349c-4a2b-a7c8-8eb35a8ab332.jpg?1",
             "name": "Static Prison",
             "text": "When Static Prison enters the battlefield, exile target nonland permanent an opponent controls until Static Prison leaves the battlefield. You get {E}{E} (two energy counters).\nAt the beginning of your precombat main phase, sacrifice Static Prison unless you pay {E}.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "34583a06-d3ce-5963-a0f5-9626c1a6c7f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd28a646-f38f-4cdf-948c-969cd979e5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd28a646-f38f-4cdf-948c-969cd979e5e6.jpg?1",
             "name": "Thraben Charm",
             "text": "Choose one \u2014\n\u2022 Thraben Charm deals damage equal to twice the number of creatures you control to target creature.\n\u2022 Destroy target enchantment.\n\u2022 Exile any number of target players' graveyards.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "ce4e660f-e971-53fe-a1f2-1c323f78f848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5495f34-423e-4012-808c-b267e6fabf2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5495f34-423e-4012-808c-b267e6fabf2c.jpg?1",
             "name": "Voltstorm Angel",
             "text": "Flying\nWhen Voltstorm Angel enters the battlefield, you get {E}{E}{E} (three energy counters).\nAt the beginning of combat on your turn, you may pay {E}{E}. When you do, choose one \u2014\n\u2022 Voltstorm Angel gains vigilance and lifelink until end of turn.\n\u2022 Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "71ced676-d4f3-5da5-98e2-a6be14cb5dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d885c-5b57-457f-a658-fd0b79cf98cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d885c-5b57-457f-a658-fd0b79cf98cc.jpg?1",
             "name": "White Orchid Phantom",
             "text": "Flying, first strike\nWhen White Orchid Phantom enters the battlefield, destroy up to one target nonbasic land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "4eee2d26-8ef5-5d1c-9dc4-3e443d3cbbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23abf47-22fa-4dca-bd42-fafa1c8b592f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23abf47-22fa-4dca-bd42-fafa1c8b592f.jpg?1",
             "name": "Wing It",
             "text": "Target creature gets +2/+2 until end of turn. Put a flying counter on it. Scry 1.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "444ba7ac-40cb-5f4c-b715-55569cb5c7f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef1882e-b422-4f30-8a6c-bd71c2601660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef1882e-b422-4f30-8a6c-bd71c2601660.jpg?1",
             "name": "Wrath of the Skies",
             "text": "You get X {E} (energy counters), then you may pay any amount of {E}. Destroy each artifact, creature, and enchantment with mana value less than or equal to the amount of {E} paid this way.",
             "colours": [
@@ -1685,7 +1685,7 @@
         },
         {
             "id": "4c66fd7a-707d-560f-8923-344339ce8e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f5195-10ab-4b32-a5de-a79341cd536a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f5195-10ab-4b32-a5de-a79341cd536a.jpg?1",
             "name": "Aether Spike",
             "text": "Choose target spell. You get {E}{E} (two energy counters), then you may pay any amount of {E}. Counter that spell unless its controller pays {1} for each {E} paid this way.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "e07f2836-14ee-5a83-8be3-79fde0041210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8aeca5-622a-45be-8168-07e7c00e3092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8aeca5-622a-45be-8168-07e7c00e3092.jpg?1",
             "name": "Amphibian Downpour",
             "text": "Flash\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies. Copies become tokens.)\nEnchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1.",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "0b3a0f36-8e1c-5635-ab35-3e0410367e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3feccebc-c792-420d-b96c-51494b5c41db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3feccebc-c792-420d-b96c-51494b5c41db.jpg?1",
             "name": "Bespoke Battlewagon",
             "text": "{T}: You get {E}{E} (two energy counters).\n{T}, Pay {E}{E}: Tap target creature.\n{T}, Pay {E}{E}{E}: Draw a card.\nPay {E}{E}{E}{E}: Bespoke Battlewagon becomes an artifact creature until end of turn.\nCrew 4",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "85444a87-aa7b-509a-acc9-6af666903b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed48f805-b57c-4d7f-a3c2-d16ae71bce2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed48f805-b57c-4d7f-a3c2-d16ae71bce2d.jpg?1",
             "name": "Brainsurge",
             "text": "Draw four cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "b7273086-1327-5cfc-bfe2-0bac73bd1e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95af55-d1dd-4fe6-adb0-3ad6db20d986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc95af55-d1dd-4fe6-adb0-3ad6db20d986.jpg?1",
             "name": "Consign to Memory",
             "text": "Replicate {1} (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nCounter target triggered ability or colorless spell.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "c8e344d4-aeb6-5f3e-9328-8b2948ec4a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea5e71-d0a3-4065-918b-9b2af98589ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea5e71-d0a3-4065-918b-9b2af98589ba.jpg?1",
             "name": "Copycrook",
             "text": "You may have Copycrook enter the battlefield as a copy of any creature on the battlefield, except it has \"Whenever this creature attacks, it connives.\" (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "758c23a7-75d9-58a1-aff2-fc0a817bc7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27534c8a-cb71-43bc-b706-80a525396222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27534c8a-cb71-43bc-b706-80a525396222.jpg?1",
             "name": "Corrupted Shapeshifter",
             "text": "Devoid (This card has no color.)\nAs Corrupted Shapeshifter enters the battlefield, it becomes your choice of a 3/3 creature with flying, a 2/5 creature with vigilance, or a 0/12 creature with defender.",
             "colours": [],
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "46f35ab1-553b-57df-bfa5-3de7baf21dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0835c7-58ca-4f16-984a-c590ce6a229a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0835c7-58ca-4f16-984a-c590ce6a229a.jpg?1",
             "name": "Deem Inferior",
             "text": "This spell costs {1} less to cast for each card you've drawn this turn.\nThe owner of target nonland permanent puts it into their library second from the top or on the bottom.",
             "colours": [
@@ -1957,7 +1957,7 @@
         },
         {
             "id": "a209562e-4b50-5534-94dc-87393218fcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37684797-7503-460d-9f74-047b1ab2fac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37684797-7503-460d-9f74-047b1ab2fac3.jpg?1",
             "name": "Depth Defiler",
             "text": "Devoid (This card has no color.)\nKicker {C} (You may pay an additional {C} as you cast this spell.)\nWhen you cast this spell, choose one. If it was kicked, choose both instead.\n\u2022 Return target creature to its owner's hand.\n\u2022 Target player draws two cards, then discards a card.",
             "colours": [],
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "0c127932-ffc2-55e5-b817-0ef7d94a48e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7dc03e-2a61-482a-b7eb-6cdb7f375fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7dc03e-2a61-482a-b7eb-6cdb7f375fd8.jpg?1",
             "name": "Dreamtide Whale",
             "text": "Vanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever a player casts their second spell each turn, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "0423c2bc-6f15-5459-9062-c21a50742a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f92dce7-45d4-4d9e-abfc-e4bfce9562c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f92dce7-45d4-4d9e-abfc-e4bfce9562c9.jpg?1",
             "name": "Electrozoa",
             "text": "Flash\nFlying\nWhen Electrozoa enters the battlefield, you get {E}{E} (two energy counters).\nAt the beginning of your precombat main phase, tap Electrozoa unless you pay {E}.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "e6e89362-eb3d-5897-b4ba-49437fddf728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f818d7-320c-47b9-a083-40007f3d91ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f818d7-320c-47b9-a083-40007f3d91ea.jpg?1",
             "name": "Emrakul's Messenger",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever you draw your second card each turn, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "31768fbb-b480-5ce7-aecf-0f1fa7ea32d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a98efb-9b0a-496b-ac21-8d70527ea544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a98efb-9b0a-496b-ac21-8d70527ea544.jpg?1",
             "name": "Flare of Denial",
             "text": "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "10d150a0-4fbd-5afc-a97a-653a2a67d723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00212714-a410-4cbc-bf1c-f90d7d77378c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00212714-a410-4cbc-bf1c-f90d7d77378c.jpg?1",
             "name": "Harbinger of the Seas",
             "text": "Nonbasic lands are Islands.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "576d2423-d76f-5cfa-968a-89c55b8c89c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26973cad-26d7-4d42-a58a-85c3dce3b9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26973cad-26d7-4d42-a58a-85c3dce3b9fd.jpg?1",
             "name": "Hope-Ender Coatl",
             "text": "Devoid (This card has no color.)\nFlash\nWhen you cast this spell, counter target spell an opponent controls unless they pay {1}.\nFlying",
             "colours": [],
@@ -2198,7 +2198,7 @@
         },
         {
             "id": "d6b52215-6c8f-520c-9d42-014e08cd036c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b44ffe-db9e-4db5-9806-098411c9ece0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b44ffe-db9e-4db5-9806-098411c9ece0.jpg?1",
             "name": "Kozilek's Unsealing",
             "text": "Devoid (This card has no color.)\nWhenever you cast a creature spell with mana value 4, 5, or 6, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\nWhenever you cast a creature spell with mana value 7 or greater, draw three cards.",
             "colours": [],
@@ -2228,7 +2228,7 @@
         },
         {
             "id": "18b918c9-af6d-5138-8ed5-6391a978bbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f2bdfd-1cbc-456e-aba7-4e0b6485cf8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f2bdfd-1cbc-456e-aba7-4e0b6485cf8a.jpg?1",
             "name": "Petrifying Meddler",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, tap up to one target creature and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nReach",
             "colours": [],
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "08cd7471-6e11-54b0-b60e-d5592646e95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84317f9d-5a24-4f74-9c3e-0a8b5c15bb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84317f9d-5a24-4f74-9c3e-0a8b5c15bb5f.jpg?1",
             "name": "Roil Cartographer",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you get {E} (an energy counter).\n{T}, Pay six {E}: Draw three cards.",
             "colours": [
@@ -2297,7 +2297,7 @@
         },
         {
             "id": "28ba6129-362f-5cfb-8ddc-9e5310649eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f481ab3-ca6c-4a5c-aa32-d087464fc4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f481ab3-ca6c-4a5c-aa32-d087464fc4da.jpg?1",
             "name": "Sage of the Unknowable",
             "text": "{T}: Add {C}. Spend this mana only to cast a colorless spell or to activate an ability.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "96aa47a6-9a78-57b5-97b8-f99918b0a348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a587f5-5910-405e-8982-c889dbbc7f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a587f5-5910-405e-8982-c889dbbc7f98.jpg?1",
             "name": "Serum Visionary",
             "text": "When Serum Visionary enters the battlefield, draw a card, then scry 2.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "3336474a-97a4-52d5-8ad4-1378f9f4377c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da72736-574d-4d99-98ba-3a91c374cd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da72736-574d-4d99-98ba-3a91c374cd10.jpg?1",
             "name": "Shadow of the Second Sun",
             "text": "Enchant player\nAt the beginning of enchanted player's postcombat main phase, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "913df8e4-c396-5e27-b3b5-5bc7e869a5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac5ac7-b2f9-4e6f-af41-7e42ac816374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ac5ac7-b2f9-4e6f-af41-7e42ac816374.jpg?1",
             "name": "Strix Serenade",
             "text": "Counter target artifact, creature, or planeswalker spell. Its controller creates a 2/2 blue Bird creature token with flying.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "34b4c375-dad5-5b75-9bd1-dcca15020b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee66a06e-a461-46af-a318-550bc35de5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee66a06e-a461-46af-a318-550bc35de5d0.jpg?1",
             "name": "Tamiyo Meets the Story Circle",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Until your next turn, whenever a creature attacks you or a planeswalker you control, it gets -2/-0 until end of turn.\nII \u2014 Discard any number of cards, then investigate twice for each card discarded this way.\nIII \u2014 Shuffle up to three target cards from your graveyard into your library.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "61c5b907-b692-5562-bce1-5d67534fcf1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a3fc3f-f5cd-45f1-a3d5-d90c9dd4f6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a3fc3f-f5cd-45f1-a3d5-d90c9dd4f6c7.jpg?1",
             "name": "Tempest Harvester",
             "text": "When Tempest Harvester enters the battlefield, you get {E}{E} (two energy counters).\n{T}, Pay {E}: Draw a card, then discard a card.",
             "colours": [
@@ -2506,7 +2506,7 @@
         },
         {
             "id": "cc4f98d1-1add-56b4-9e69-752b8ad082b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e68700-c71c-46db-b6a4-beae924cf97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e68700-c71c-46db-b6a4-beae924cf97a.jpg?1",
             "name": "Triton Wavebreaker",
             "text": "Bestow {1}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nAs long as Triton Wavebreaker is a creature, it has prowess. (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nEnchanted creature gets +1/+1 and has prowess.",
             "colours": [
@@ -2542,7 +2542,7 @@
         },
         {
             "id": "3a1de3f6-3b8d-508c-a396-82e5021f30f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b13321-98f1-4e8c-802d-65498e43ec24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b13321-98f1-4e8c-802d-65498e43ec24.jpg?1",
             "name": "Tune the Narrative",
             "text": "Draw a card. You get {E}{E} (two energy counters).",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "0405fbef-3910-5997-8895-d59da67155a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13786a-f967-456b-bbc6-f4312467a827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13786a-f967-456b-bbc6-f4312467a827.jpg?1",
             "name": "Ugin's Binding",
             "text": "Devoid (This card has no color.)\nReturn target nonland permanent you don't control to its owner's hand.\nWhenever you cast a colorless spell with mana value 7 or greater, you may exile Ugin's Binding from your graveyard. When you do, return each nonland permanent you don't control to its owner's hand.",
             "colours": [],
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "710cd074-c5c1-507c-8fd9-8cab17108edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95b8eb1-4dbb-4bb9-aa31-b7a12e3b4618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95b8eb1-4dbb-4bb9-aa31-b7a12e3b4618.jpg?1",
             "name": "Unfathomable Truths",
             "text": "Devoid (This card has no color.)\nDraw three cards and create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "0d2d7b81-2d82-5c26-ab22-59b8982de648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3050ac06-4c16-4155-a97f-f6bc92709ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3050ac06-4c16-4155-a97f-f6bc92709ee4.jpg?1",
             "name": "Utter Insignificance",
             "text": "Flash\nEnchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.\n{2}{C}: Exile enchanted creature.",
             "colours": [
@@ -2672,7 +2672,7 @@
         },
         {
             "id": "5849ba01-735a-59fb-89e6-a12d6c4ef09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6e3232-8bb8-4504-9597-dfdfc6d634bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6e3232-8bb8-4504-9597-dfdfc6d634bd.jpg?1",
             "name": "Volatile Stormdrake",
             "text": "Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters the battlefield, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "44655c66-f06b-5afa-9707-3fd1cbb5ef81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da14d86-0780-4821-a799-96f64b377df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da14d86-0780-4821-a799-96f64b377df4.jpg?1",
             "name": "Accursed Marauder",
             "text": "When Accursed Marauder enters the battlefield, each player sacrifices a nontoken creature.",
             "colours": [
@@ -2747,7 +2747,7 @@
         },
         {
             "id": "a7531dc2-d9fa-5769-86ec-277a392a791a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7995b44-7932-4d28-9a4c-a32ba35c60d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7995b44-7932-4d28-9a4c-a32ba35c60d7.jpg?1",
             "name": "Arcbound Condor",
             "text": "Flying\nModular 3 (This creature enters the battlefield with three +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nWhenever another artifact enters the battlefield under your control, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "351d9157-e823-55ff-8967-3008972d3795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eac71d-54f9-46c2-aa1d-c04c37e61f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eac71d-54f9-46c2-aa1d-c04c37e61f74.jpg?1",
             "name": "Breathe Your Last",
             "text": "Destroy target creature or planeswalker. You gain 1 life for each of its colors.",
             "colours": [
@@ -2814,7 +2814,7 @@
         },
         {
             "id": "ddb45742-fab2-5989-880f-681a2834148b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5dd2c1-b6e0-4914-b5c9-7dd451c29e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5dd2c1-b6e0-4914-b5c9-7dd451c29e22.jpg?1",
             "name": "Chthonian Nightmare",
             "text": "When Chthonian Nightmare enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay X {E}, Sacrifice a creature, Return Chthonian Nightmare to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "f362acdd-02bd-5a0e-9710-9910badda67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9068b3a4-9130-42d8-a26b-52010b7daa8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9068b3a4-9130-42d8-a26b-52010b7daa8b.jpg?1",
             "name": "Consuming Corruption",
             "text": "Consuming Corruption deals X damage to target creature or planeswalker and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "91df80c1-197f-5f5d-92ac-761ce4af622e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f328d6e0-d808-4abe-b6a2-cc557b27c329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f328d6e0-d808-4abe-b6a2-cc557b27c329.jpg?1",
             "name": "Crabomination",
             "text": "Emerge from artifact {5}{B}{B} (You may cast this spell by sacrificing an artifact and paying the emerge cost reduced by that artifact's mana value.)\nWhen Crabomination enters the battlefield, target opponent exiles the top card of their library, a card at random from their graveyard, and a card at random from their hand. You may cast a spell from among cards exiled this way without paying its mana cost.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "589c89e9-d149-5d15-9640-3bf6e9a456c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d701aa-df93-4f0e-b1e3-d081487eb456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d701aa-df93-4f0e-b1e3-d081487eb456.jpg?1",
             "name": "The Creation of Avacyn",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Search your library for a card, exile it face down, then shuffle.\nII \u2014 Turn the exiled card face up. If it's a creature card, you lose life equal to its mana value.\nIII \u2014 You may put the exiled card onto the battlefield if it's a creature card. If you don't put it onto the battlefield, put it into its owner's hand.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "fd41eb3c-8592-5274-bd4a-0494e33c53b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831506ea-017a-40ff-91c1-ff2d70dc0013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831506ea-017a-40ff-91c1-ff2d70dc0013.jpg?1",
             "name": "Dreadmobile",
             "text": "Menace\n{1}, Sacrifice another artifact or creature: Put a +1/+1 counter on Dreadmobile.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "34248229-f58c-553a-adca-9395f9cc6f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961a3a53-344b-44d5-bc8e-f43437e6b558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961a3a53-344b-44d5-bc8e-f43437e6b558.jpg?1",
             "name": "Dreamdrinker Vampire",
             "text": "Lifelink\n{1}{B}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Dreamdrinker Vampire, it gains menace until end of turn.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "a9531fb0-6a9d-5d03-b535-1edceddff956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e68656-3204-4bb5-9f31-8036083fcba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e68656-3204-4bb5-9f31-8036083fcba6.jpg?1",
             "name": "Drossclaw",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, each opponent loses 1 life.\nEquip {2}",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "1905b86c-a20e-534c-870d-f3ac1f6704a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9d9075-2d1e-4848-b661-816d539e05eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9d9075-2d1e-4848-b661-816d539e05eb.jpg?1",
             "name": "Emperor of Bones",
             "text": "At the beginning of combat on your turn, exile up to one target card from a graveyard.\n{1}{B}: Adapt 2.\nWhenever one or more +1/+1 counters are put on Emperor of Bones, put a creature card exiled with Emperor of Bones onto the battlefield under your control with a finality counter on it. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "3abdb988-ee5f-568f-8582-44f86be8ec31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428e255d-bdda-4265-91cf-d02962e818e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428e255d-bdda-4265-91cf-d02962e818e4.jpg?1",
             "name": "Etched Slith",
             "text": "Menace\nWhenever Etched Slith deals combat damage to a player, put a +1/+1 counter on it. When you do, you may remove a counter from another target permanent or opponent.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "265004b8-2140-5555-98fd-c73a6a79f780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abd093b-c1d6-400e-bc26-1aa045fe47b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abd093b-c1d6-400e-bc26-1aa045fe47b8.jpg?1",
             "name": "Etherium Pteramander",
             "text": "Flying\nEtherium Pteramander can block only creatures with flying.\n{6}{B}: Adapt 4. This ability costs {1} less to activate for each other artifact you control. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "3e181565-80ae-51ca-a257-0f85253f9803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00573bd-5bbb-4531-a0bb-a40f62b92b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00573bd-5bbb-4531-a0bb-a40f62b92b88.jpg?1",
             "name": "Eviscerator's Insight",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards.\nFlashback {4}{B} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "d78d59cc-901d-559a-b508-6f8179196a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd368a9-5efe-4755-89be-a05cfa2b71c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd368a9-5efe-4755-89be-a05cfa2b71c0.jpg?1",
             "name": "Fetid Gargantua",
             "text": "{2}{B}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Fetid Gargantua, you may draw two cards. If you do, you lose 2 life.",
             "colours": [
@@ -3231,7 +3231,7 @@
         },
         {
             "id": "01c0a75b-3bf1-51e3-9960-da9e843a3858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19efb9ce-62eb-4cbf-b01e-979f3fd09ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19efb9ce-62eb-4cbf-b01e-979f3fd09ba6.jpg?1",
             "name": "Flare of Malice",
             "text": "You may sacrifice a nontoken black creature rather than pay this spell's mana cost.\nEach opponent sacrifices a creature or planeswalker with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "9d9ac668-fbfc-59f9-8a7f-cf5a832c65e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b054a9-7565-4fdd-b6a5-2786c5bb5b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b054a9-7565-4fdd-b6a5-2786c5bb5b7e.jpg?1",
             "name": "Gravedig",
             "text": "Choose one \u2014\n\u2022 Target player creates a 2/2 black Zombie creature token.\n\u2022 Return target creature card from your graveyard to your hand.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "095261f9-a35e-56de-95bb-2454c0efc90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9c275d-e8cc-40c2-8baf-7a0d154aa7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df9c275d-e8cc-40c2-8baf-7a0d154aa7cf.jpg?1",
             "name": "Grim Servant",
             "text": "Menace\nWhen Grim Servant enters the battlefield, search your library for a card with mana value less than or equal to your devotion to black, reveal it, put it into your hand, then shuffle. You lose 3 life. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "69d09b89-cdfb-5fe3-8171-084b61e50d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2958c96-97f8-4961-813c-938b83e20d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2958c96-97f8-4961-813c-938b83e20d07.jpg?1",
             "name": "Kami of Jealous Thirst",
             "text": "Deathtouch\n{4}{B}: Each opponent loses 2 life and you gain 2 life. This ability costs {4}{B} less to activate if you've drawn three or more cards this turn. Activate only once each turn.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "a53b2279-d530-5f25-9587-831fe2246f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f52a0-f6fb-4ad8-8d50-c8209de95ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657f52a0-f6fb-4ad8-8d50-c8209de95ab8.jpg?1",
             "name": "Lethal Throwdown",
             "text": "As an additional cost to cast this spell, sacrifice a creature or sacrifice a modified creature. (Equipment, Auras you control, and counters are modifications.)\nDestroy target creature or planeswalker. If the modified creature was sacrificed, draw a card.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "561ab67c-2a60-5ca4-a7a0-2ea8cc976a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16f8670-f038-400a-83e7-a53a7f8c47ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16f8670-f038-400a-83e7-a53a7f8c47ac.jpg?1",
             "name": "Marionette Apprentice",
             "text": "Fabricate 1 (When this creature enters the battlefield, put a +1/+1 counter on it or create a 1/1 colorless Servo artifact creature token.)\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, each opponent loses 1 life.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "93b18ee7-08bf-585a-80ad-6fe27fa9d438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af5b195-101a-4265-98a7-522a968cf218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af5b195-101a-4265-98a7-522a968cf218.jpg?1",
             "name": "Mindless Conscription",
             "text": "When Mindless Conscription enters the battlefield and whenever you draw your third card each turn, amass Zombies 3. (Put three +1/+1 counters on an Army you control. It's also a Zombie. If you don't control an Army, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "dd2f7f8d-0b6c-5e6a-a50a-dc8b9cdbcbd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc0109c-f939-4424-820e-d6e60cacd794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc0109c-f939-4424-820e-d6e60cacd794.jpg?1",
             "name": "Necrodominance",
             "text": "Skip your draw step.\nAt the beginning of your end step, you may pay any amount of life. If you do, draw that many cards.\nYour maximum hand size is five.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "6beb5ea1-2135-5c15-837e-ee47b92b8c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3945e-5089-4751-b7b3-5961c39d2a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3945e-5089-4751-b7b3-5961c39d2a33.jpg?1",
             "name": "Nethergoyf",
             "text": "Nethergoyf's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nEscape\u2014{2}{B}, Exile any number of other cards from your graveyard with four or more card types among them. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3542,7 +3542,7 @@
         },
         {
             "id": "5b1c1595-0ff7-5122-90cd-13b2c691aef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813020ef-9d98-4f79-a953-85e7e7e5d3e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813020ef-9d98-4f79-a953-85e7e7e5d3e1.jpg?1",
             "name": "Quest for the Necropolis",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a quest counter on Quest for the Necropolis.\n{5}{B}, Sacrifice Quest for the Necropolis: Put target creature card from a graveyard onto the battlefield under your control. This ability costs {1} less to activate for each quest counter on Quest for the Necropolis. Activate only as a sorcery.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "3886296c-9119-5a91-8823-03894745ab05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b338e078-629c-4cac-bd1d-e1f0a132728d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b338e078-629c-4cac-bd1d-e1f0a132728d.jpg?1",
             "name": "Refurbished Familiar",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nWhen Refurbished Familiar enters the battlefield, each opponent discards a card. For each opponent who can't, you draw a card.",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "33a10cfc-d13d-5e15-8f6b-932ae2e633d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b83d-710b-4680-855a-02ba1f72abf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b83d-710b-4680-855a-02ba1f72abf0.jpg?1",
             "name": "Retrofitted Transmogrant",
             "text": "{3}{B}: Return Retrofitted Transmogrant from your graveyard to the battlefield tapped with two +1/+1 counters on it.",
             "colours": [
@@ -3645,7 +3645,7 @@
         },
         {
             "id": "dd1407e1-b970-5cc0-bd05-8f823dc0b191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201d1bc-e3fe-4f59-bd48-3683996ac308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201d1bc-e3fe-4f59-bd48-3683996ac308.jpg?1",
             "name": "Ripples of Undeath",
             "text": "At the beginning of your precombat main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "5cb278da-b220-5033-8cda-27ee257315bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e2805f-59fa-4a6d-97bc-266191b2aa8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e2805f-59fa-4a6d-97bc-266191b2aa8d.jpg?1",
             "name": "Scurrilous Sentry",
             "text": "Menace\nWhenever Scurrilous Sentry enters the battlefield or attacks, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "9cf1c168-a91f-57d0-a4b0-d7ee57c0c2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6aba35-bee5-4058-a2df-d73506d225c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6aba35-bee5-4058-a2df-d73506d225c2.jpg?1",
             "name": "Shilgengar, Sire of Famine",
             "text": "Flying\nSacrifice another creature: Create a Blood token. If you sacrificed an Angel this way, create a number of Blood tokens equal to its toughness instead.\n{WB}{WB}{WB}, Sacrifice six Blood tokens: Return each creature card from your graveyard to the battlefield with a finality counter on it. Those creatures are Vampires in addition to their other types.",
             "colours": [
@@ -3756,7 +3756,7 @@
         },
         {
             "id": "786439eb-32e9-5ac9-922d-94f7605fe194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b334e4c6-d316-4141-8889-f95afcc04701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b334e4c6-d316-4141-8889-f95afcc04701.jpg?1",
             "name": "Warren Soultrader",
             "text": "Pay 1 life, Sacrifice another creature: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "2461aba8-093a-56d1-b471-fc233524d8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c2390f-71f1-4e42-83da-d603ca86a8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c2390f-71f1-4e42-83da-d603ca86a8d0.jpg?1",
             "name": "Wither and Bloom",
             "text": "Target creature gets -3/-3 until end of turn.\n{1}{B}, Exile Wither and Bloom from your graveyard: Put a +1/+1 counter on target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "93b21db2-7673-585c-abf8-254616974c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9b30e0-3934-4e4c-bdd9-5b7696b45948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9b30e0-3934-4e4c-bdd9-5b7696b45948.jpg?1",
             "name": "Wurmcoil Larva",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Larva dies, create a 1/2 black Phyrexian Wurm artifact creature token with deathtouch and a 2/1 black Phyrexian Wurm artifact creature token with lifelink.",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "3aeff659-75db-51b6-8364-902094db22ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8732e62-cdee-4d32-82a8-8a71a04be7a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8732e62-cdee-4d32-82a8-8a71a04be7a1.jpg?1",
             "name": "Aether Revolt",
             "text": "Revolt \u2014 As long as a permanent you controlled left the battlefield this turn, if a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.\nWhenever you get one or more {E}, Aether Revolt deals that much damage to any target.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "ee0375ba-2584-52f6-9298-ebc4a04da059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac0e78b-0fdd-44f9-8b7b-c4f28a32782e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ac0e78b-0fdd-44f9-8b7b-c4f28a32782e.jpg?1",
             "name": "Amped Raptor",
             "text": "First strike\nWhen Amped Raptor enters the battlefield, you get {E}{E} (two energy counters). Then if you cast it from your hand, exile cards from the top of your library until you exile a nonland card. You may cast that card by paying an amount of {E} equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "08af11d6-5493-5b56-9a7b-b5e4ce8d0f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40463be5-89e2-410b-9a4b-770f70d14293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40463be5-89e2-410b-9a4b-770f70d14293.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "f733d252-2706-5ca9-b205-157041808c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a01edd-dbc0-4ed4-b827-9b608290e9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a01edd-dbc0-4ed4-b827-9b608290e9a1.jpg?1",
             "name": "Detective's Phoenix",
             "text": "Bestow\u2014{R}, Collect evidence 6. (To pay this bestow cost, pay {R} and exile cards with total mana value 6 or greater from your graveyard.)\nFlying, haste\nEnchanted creature gets +2/+2 and has flying and haste.\nYou may cast Detective's Phoenix from your graveyard using its bestow ability.",
             "colours": [
@@ -4011,7 +4011,7 @@
         },
         {
             "id": "14ec75b3-3500-5ac1-afb6-c61e7ae25226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67774a1-f5f8-4b7b-871d-88a1b5e57d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67774a1-f5f8-4b7b-871d-88a1b5e57d27.jpg?1",
             "name": "Eldrazi Linebreaker",
             "text": "Devoid (This card has no color.)\nTrample\nAt the beginning of combat on your turn, target creature you control gains haste and gets +X/+0 until end of turn, where X is the number of Eldrazi you control.",
             "colours": [],
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "3de8237d-713a-519b-8946-c78cb2ce5c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfac301-55db-49a7-9a0d-918c907703da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfac301-55db-49a7-9a0d-918c907703da.jpg?1",
             "name": "Fanged Flames",
             "text": "Devoid (This card has no color.)\nFanged Flames deals 4 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [],
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "a0a41612-27ca-5b16-b3db-d1bad8d45b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497a10c6-131b-464e-95e4-e47708a24d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497a10c6-131b-464e-95e4-e47708a24d48.jpg?1",
             "name": "Flare of Duplication",
             "text": "You may sacrifice a nontoken red creature rather than pay this spell's mana cost.\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "322531f6-7b3b-5860-85fe-f72eb0380dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981fdd21-a650-4360-9ea5-550399d1da91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981fdd21-a650-4360-9ea5-550399d1da91.jpg?1",
             "name": "Frogmyr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n//PRT-Prototype_\nMech//\n{3}{R}\nPrototype (You may cast this spell with different mana cost, color, and size. It keeps its abilities and types.)\n2/2",
             "colours": [],
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "736e5898-943f-52d5-84d7-8f0dd9c5965a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d91b5-7c09-4a9c-9dc8-fdd4c049009c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d91b5-7c09-4a9c-9dc8-fdd4c049009c.jpg?1",
             "name": "Furnace Hellkite",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\n{R}: Furnace Hellkite gets +1/+0 until end of turn.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "0a0ecc26-2faf-5f5b-8121-de983a204c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aa6e33-221f-414c-9b51-850d97a7e051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32aa6e33-221f-414c-9b51-850d97a7e051.jpg?1",
             "name": "Galvanic Discharge",
             "text": "Choose target creature or planeswalker. You get {E}{E}{E} (three energy counters), then you may pay any amount of {E}. Galvanic Discharge deals that much damage to that permanent.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "38abcca7-5ee7-5bd6-a49b-9220533a95a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adea3ee-138f-455b-a001-586883c44758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adea3ee-138f-455b-a001-586883c44758.jpg?1",
             "name": "Ghostfire Slice",
             "text": "Devoid (This card has no color.)\nThis spell costs {2} less to cast if an opponent controls a multicolored permanent.\nGhostfire Slice deals 4 damage to any target.",
             "colours": [],
@@ -4241,7 +4241,7 @@
         },
         {
             "id": "05dfa15e-1a10-5c75-8e62-26c55b2333bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133ad0dd-5b61-4c38-9264-0b0e75b95d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133ad0dd-5b61-4c38-9264-0b0e75b95d95.jpg?1",
             "name": "Glimpse the Impossible",
             "text": "Exile the top three cards of your library. You may play those cards this turn. At the beginning of the next end step, if any of those cards remain exiled, put them into your graveyard, then create a 0/1 colorless Eldrazi Spawn creature token for each card put into your graveyard this way. Those tokens have \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "0bf9374c-6fa8-577c-84e4-e293478228dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b30243d-511b-47b8-bbed-0395d3de903d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b30243d-511b-47b8-bbed-0395d3de903d.jpg?1",
             "name": "Infernal Captor",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Infernal Captor exploits a creature, gain control of target artifact or creature until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "eae1c717-0afa-59c8-a04f-9f253c8f16eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f918c-bd02-4a63-b4c2-ca204c77b208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2f918c-bd02-4a63-b4c2-ca204c77b208.jpg?1",
             "name": "Inventor's Axe",
             "text": "Flash\nWhen Inventor's Axe enters the battlefield, you get {E}{E} (two energy counters).\nWhen Inventor's Axe enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip\u2014\nPay {E}{E}.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "dbc3b11a-79b5-56ff-8786-db3ef3f2a4ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1457aa8-9f70-4586-b595-6a722879f6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1457aa8-9f70-4586-b595-6a722879f6ae.jpg?1",
             "name": "Mogg Mob",
             "text": "Sacrifice Mogg Mob: It deals 3 damage divided as you choose among one, two, or three targets.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "4851c79b-ebcd-5291-9181-1e26ee2b98c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5ba065-2806-4e99-a330-168cfe76250f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5ba065-2806-4e99-a330-168cfe76250f.jpg?1",
             "name": "Molten Gatekeeper",
             "text": "Whenever another creature enters the battlefield under your control, Molten Gatekeeper deals 1 damage to each opponent.\nUnearth {R} ({R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "56d32dd5-271c-5d1b-a5a7-02a6667f4f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f8bb8d-c46a-4531-9525-6981a222b468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f8bb8d-c46a-4531-9525-6981a222b468.jpg?1",
             "name": "Party Thrasher",
             "text": "Noncreature spells you cast from exile have convoke. (Each creature you tap while casting a noncreature spell from exile pays for {1} or one mana of that creature's color.)\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "00cb0247-c29c-5781-99ed-ee67097561d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d64e1a8-cb4f-4968-b3e0-c9ca7c7894a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d64e1a8-cb4f-4968-b3e0-c9ca7c7894a3.jpg?1",
             "name": "Phyrexian Ironworks",
             "text": "Whenever you attack, you get {E} (an energy counter).\n{T}, Pay {E}{E}{E}: Create a 3/3 colorless Phyrexian Golem artifact creature token. Activate only as a sorcery.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "8c8b5487-38d3-5ecc-8632-abb2d2721052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff7c0bb-1210-4aeb-b5f8-1387eb633b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff7c0bb-1210-4aeb-b5f8-1387eb633b0f.jpg?1",
             "name": "Powerbalance",
             "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, you may cast that card without paying its mana cost if the two spells have the same mana value.",
             "colours": [
@@ -4516,7 +4516,7 @@
         },
         {
             "id": "d8319975-b97a-5661-998f-2b1e118a0114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebadb7dc-69a4-43c9-a2f8-d846b231c71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebadb7dc-69a4-43c9-a2f8-d846b231c71c.jpg?1",
             "name": "Ral and the Implicit Maze",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Ral and the Implicit Maze deals 2 damage to each creature and planeswalker your opponents control.\nII \u2014 You may discard a card. If you do, exile the top two cards of your library. You may play them until the end of your next turn.\nIII \u2014 Create a Spellgorger Weird token. (It's a {2}{R} 2/2 Weird creature with \"Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.\")",
             "colours": [
@@ -4550,7 +4550,7 @@
         },
         {
             "id": "c81a249e-e167-5820-ae3c-d2a3c9cb0312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1bb8ac-7125-4537-b2da-e23a8c28df79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1bb8ac-7125-4537-b2da-e23a8c28df79.jpg?1",
             "name": "Reckless Pyrosurfer",
             "text": "Haste\nLandfall \u2014 Whenever a land enters the battlefield under your control, Reckless Pyrosurfer gains battle cry until end of turn. (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn. Each instance of battle cry triggers separately.)",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "1c99e4a9-057e-5e5d-aeb1-a42842be8319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f57902-85d1-4c40-b79c-6cffafb4557a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f57902-85d1-4c40-b79c-6cffafb4557a.jpg?1",
             "name": "Reiterating Bolt",
             "text": "Replicate\u2014\nPay {E}{E}{E}. (When you cast this spell, copy it for each time you paid its replicate cost. You may choose new targets for the copies.)\nReiterating Bolt deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "b2c4fa52-16e7-5ee0-958f-90dbac672681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099c65d5-9dd3-41d3-9102-3f6cb30c7b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099c65d5-9dd3-41d3-9102-3f6cb30c7b8e.jpg?1",
             "name": "Sarpadian Simulacrum",
             "text": "Haste\n{3}{R}, Sacrifice Sarpadian Simulacrum: It deals 4 damage to target creature.",
             "colours": [
@@ -4652,7 +4652,7 @@
         },
         {
             "id": "e1779632-c645-5376-a734-f43c5612f8a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33e3b25-76f5-4263-a309-9ea97f2d8248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f33e3b25-76f5-4263-a309-9ea97f2d8248.jpg?1",
             "name": "Siege Smash",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target creature gets +3/+2 and gains trample until end of turn.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "b8590cac-2714-5dcb-aa4b-6b684d50eb07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a3b943-7b38-4316-87d9-15e0c08abea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a3b943-7b38-4316-87d9-15e0c08abea5.jpg?1",
             "name": "Skittering Precursor",
             "text": "Devoid (This card has no color.)\nMenace\nWhenever you sacrifice a nontoken permanent, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "fa697373-70aa-5eac-9019-ceef8717dec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf34b0f8-a68a-428f-9f2c-9556229367ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf34b0f8-a68a-428f-9f2c-9556229367ec.jpg?1",
             "name": "Skoa, Embermage",
             "text": "When Skoa, Embermage enters the battlefield, it deals 4 damage to any target.\nGrandeur \u2014 Discard another card named Skoa, Embermage, Sacrifice two Mountains: Skoa deals 4 damage to any target.",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "41c24fa2-edcd-5eaf-bbdf-5202b3a4bb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dad40bf-2cd0-47f5-a878-9a289d1d58d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dad40bf-2cd0-47f5-a878-9a289d1d58d0.jpg?1",
             "name": "Smelted Chargebug",
             "text": "Menace\nWhen Smelted Chargebug enters the battlefield, you get {E}{E} (two energy counters).\nWhenever Smelted Chargebug attacks, you may pay {E}. If you do, another target attacking creature gets +1/+0 and gains menace until end of turn.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "4f0f36da-60fc-52e6-9e55-de4b638a1a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecac9885-6f4e-4413-90dc-c8b44f883357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecac9885-6f4e-4413-90dc-c8b44f883357.jpg?1",
             "name": "Spawn-Gang Commander",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, create three 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\n{1}{C}, Sacrifice an Eldrazi: Spawn-Gang Commander deals 2 damage to any target.",
             "colours": [],
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "172c14e1-bc59-572c-aa72-f3a8118d6108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465857f2-df08-4f7b-b4fe-b16831ac0eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465857f2-df08-4f7b-b4fe-b16831ac0eb1.jpg?1",
             "name": "Thriving Skyclaw",
             "text": "Flying\nWhen Thriving Skyclaw enters the battlefield, you get {E}{E}{E} (three energy counters).\nWhenever Thriving Skyclaw attacks, you may pay {E}{E}{E}. If you do, put a +1/+1 counter on it.",
             "colours": [
@@ -4859,7 +4859,7 @@
         },
         {
             "id": "b0265b85-7ae6-5a09-babe-27a16d3964db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9949f5-8d6c-4ea9-b203-99e8a57a6c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9949f5-8d6c-4ea9-b203-99e8a57a6c60.jpg?1",
             "name": "Unstable Amulet",
             "text": "When Unstable Amulet enters the battlefield, you get {E}{E} (two energy counters).\nWhenever you cast a spell from anywhere other than your hand, Unstable Amulet deals 1 damage to each opponent.\n{T}, Pay {E}{E}: Exile the top card of your library. You may play it until you exile another card with Unstable Amulet.",
             "colours": [
@@ -4894,7 +4894,7 @@
         },
         {
             "id": "287fdf3e-6d47-5819-bd9f-2135af961b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9b8532-4f1a-4653-9cbb-befba8169e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9b8532-4f1a-4653-9cbb-befba8169e5a.jpg?1",
             "name": "Voidpouncer",
             "text": "Devoid (This card has no color.)\nKicker {2}{C} (You may pay an additional {2}{C} as you cast this spell.)\nIf Voidpouncer was kicked, it enters the battlefield with two +1/+1 counters and a trample counter on it and with haste.",
             "colours": [],
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "33c71b11-67e2-51b1-b4e8-2c429197525d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eb9a82-91f7-4741-a029-a07a3ff6af78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eb9a82-91f7-4741-a029-a07a3ff6af78.jpg?1",
             "name": "Wheel of Potential",
             "text": "You get {E}{E}{E} (three energy counters), then you may pay X {E}.\nEach player may exile their hand and draw X cards. If X is 7 or more, you may play cards you own exiled this way until the end of your next turn.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "eed83a21-137e-56be-9ab2-4544b9060e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feba5d6-99a6-4e9b-8a7d-90d955868fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feba5d6-99a6-4e9b-8a7d-90d955868fc3.jpg?1",
             "name": "Basking Broodscale",
             "text": "Devoid (This card has no color.)\n{1}{G}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Basking Broodscale, you may create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "8d95401a-8b91-5c1b-b5eb-eb7e23fd6c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4820d223-4ea1-4850-931c-3d2ab5eb003b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4820d223-4ea1-4850-931c-3d2ab5eb003b.jpg?1",
             "name": "Birthing Ritual",
             "text": "At the beginning of your end step, if you control a creature, look at the top seven cards of your library. Then you may sacrifice a creature. If you do, you may put a creature card with mana value X or less from among those cards onto the battlefield, where X is 1 plus the sacrificed creature's mana value. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "11feee44-ebca-5f59-afac-b8d5ea926a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f260bd08-68b6-44f4-ace9-e298cb13d82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f260bd08-68b6-44f4-ace9-e298cb13d82e.jpg?1",
             "name": "Collective Resistance",
             "text": "Escalate {G} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Target creature gains hexproof and indestructible until end of turn.",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "18bf5cfc-c0f9-57a9-8592-b3949d4f545f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98164430-64c1-465f-b786-45753c965f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98164430-64c1-465f-b786-45753c965f44.jpg?1",
             "name": "Colossal Dreadmask",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +6/+6 and has trample.\nEquip {3}{G}{G}",
             "colours": [
@@ -5094,7 +5094,7 @@
         },
         {
             "id": "484f3599-cb82-519e-a078-b6569a65d6a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdabdda-bd46-4ea2-8b37-5d7f6cec6aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdabdda-bd46-4ea2-8b37-5d7f6cec6aff.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "d3d31def-d7fc-5c85-b16c-956ccddc650c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f79ba7-7b65-4387-b498-f770816ce8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f79ba7-7b65-4387-b498-f770816ce8dd.jpg?1",
             "name": "Eldrazi Repurposer",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell and when Eldrazi Repurposer dies, create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "199bd3be-d81e-567a-ae41-8de1c6d35f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d89283e-9783-4006-9294-4ae0473d2ce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d89283e-9783-4006-9294-4ae0473d2ce6.jpg?1",
             "name": "Evolution Witness",
             "text": "{1}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Evolution Witness, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "f326634c-927c-593d-acfc-c8a76fc33d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9fb33a-3b39-4aff-93b8-aedafe0ea694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9fb33a-3b39-4aff-93b8-aedafe0ea694.jpg?1",
             "name": "Fanatic of Rhonas",
             "text": "{T}: Add {G}.\nFerocious \u2014 {T}: Add {G}{G}{G}{G}. Activate only if you control a creature with power 4 or greater.\nEternalize {2}{G}{G} ({2}{G}{G}, Exile this card from your graveyard: Create a token that's a copy of it, except it's a 4/4 black Zombie Snake Druid with no mana cost. Eternalize only as a sorcery.)",
             "colours": [
@@ -5243,7 +5243,7 @@
         },
         {
             "id": "737c15c5-e881-52a6-828e-97cc0edc62c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae8a77b-4001-4da2-b684-d0fab370a162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae8a77b-4001-4da2-b684-d0fab370a162.jpg?1",
             "name": "Fangs of Kalonia",
             "text": "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on each creature that had a +1/+1 counter put on it this way.\nOverload {4}{G}{G} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")",
             "colours": [
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "3b908dd3-a9ca-53d7-aae4-121760e6c2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda2fa87-81c0-41ac-8831-556ce392c058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda2fa87-81c0-41ac-8831-556ce392c058.jpg?1",
             "name": "Flare of Cultivation",
             "text": "You may sacrifice a nontoken green creature rather than pay this spell's mana cost.\nSearch your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -5310,7 +5310,7 @@
         },
         {
             "id": "5b2e2819-265b-580a-8f4f-453b9e7f5ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b6c7ab-f42f-40d2-9cb6-89291d57e27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b6c7ab-f42f-40d2-9cb6-89291d57e27f.jpg?1",
             "name": "Fowl Strike",
             "text": "Destroy target creature with flying.\nReinforce 2\u2014{2}{G} ({2}{G}, Discard this card: Put two +1/+1 counters on target creature.)",
             "colours": [
@@ -5342,7 +5342,7 @@
         },
         {
             "id": "6f9ee059-17d1-5d10-b1ce-fa984edd7202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fa0b62-d474-4dc7-9631-9d0a9d99e5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fa0b62-d474-4dc7-9631-9d0a9d99e5e2.jpg?1",
             "name": "Gift of the Viper",
             "text": "Put a +1/+1 counter, a reach counter, and a deathtouch counter on target creature. Untap it.",
             "colours": [
@@ -5374,7 +5374,7 @@
         },
         {
             "id": "ecdd8036-5da7-596c-9e0d-7668f6d3fb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa6ed13-7bba-40c0-8e0e-4ffd3cea6241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa6ed13-7bba-40c0-8e0e-4ffd3cea6241.jpg?1",
             "name": "Horrific Assault",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control. If you control an Eldrazi, you gain 3 life.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "1f760ed3-f217-56ef-b776-e90754471071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b44f01b-17e8-4d49-8f38-fd1128114b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b44f01b-17e8-4d49-8f38-fd1128114b2f.jpg?1",
             "name": "The Hunger Tide Rises",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Create a 1/1 black and green Insect creature token.\nIV \u2014 Sacrifice any number of creatures. Search your library and/or graveyard for a creature card with mana value less than or equal to the number of creatures sacrificed this way and put it onto the battlefield. If you search your library this way, shuffle.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "1cac1d46-56be-5690-ab52-a1227e2fc58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d28ae5c-eec3-445a-81d6-42bf9789afce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d28ae5c-eec3-445a-81d6-42bf9789afce.jpg?1",
             "name": "Hydra Trainer",
             "text": "You may exert Hydra Trainer as it attacks. When you do, target creature gets +X/+X until end of turn, where X is the number of counters on permanents you control. (An exerted creature won't untap during your next untap step.)\n{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "9f523b19-c1ef-5858-b948-0fed2a01c3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d58e9b-b1d9-4174-a30d-426d2e0ace07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d58e9b-b1d9-4174-a30d-426d2e0ace07.jpg?1",
             "name": "Lion Umbra",
             "text": "Enchant modified creature (Equipment, Auras its controller controls, and counters are modifications.)\nEnchanted creature gets +3/+3 and has vigilance and reach.\nUmbra armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "20f72f1a-8ca3-5efb-b395-0867e7afbc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a178cfe8-f9fa-4255-88d0-54a0bed079f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a178cfe8-f9fa-4255-88d0-54a0bed079f5.jpg?1",
             "name": "Malevolent Rumble",
             "text": "Reveal the top four cards of your library. You may put a permanent card from among them into your hand. Put the rest into your graveyard. Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "603f6ca3-4d99-5a18-9c3f-73ecbabaeaf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162fcdec-bf3c-43ba-9ada-212f7dec5fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162fcdec-bf3c-43ba-9ada-212f7dec5fbd.jpg?1",
             "name": "Monstrous Vortex",
             "text": "Whenever you cast a creature spell with power 5 or greater, discover X, where X is that spell's mana value. (Exile cards from the top of your library until you exile a nonland card with that mana value or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "4c4f9a34-774a-55c1-8cb3-b172ab524709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9252d-241f-45ea-9d80-663150963b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9252d-241f-45ea-9d80-663150963b59.jpg?1",
             "name": "Nightshade Dryad",
             "text": "Deathtouch\n{T}: Add {C}.\n{T}: Add one mana of any color.",
             "colours": [
@@ -5611,7 +5611,7 @@
         },
         {
             "id": "aa075f9d-1302-59cb-97da-d35f7501114b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902a969e-9f22-4e92-93eb-9d4536ca82e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902a969e-9f22-4e92-93eb-9d4536ca82e5.jpg?1",
             "name": "Nyxborn Hydra",
             "text": "Bestow {X}{G}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nReach, trample\nNyxborn Hydra enters the battlefield with X +1/+1 counters on it.\nEnchanted creature gets +1/+1 for each +1/+1 counter on Nyxborn Hydra and has reach and trample.",
             "colours": [
@@ -5646,7 +5646,7 @@
         },
         {
             "id": "5f82e093-44ee-5fc9-9dbe-8a622e6cda9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28493c98-a11c-4bcc-bf55-412c884ffa7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28493c98-a11c-4bcc-bf55-412c884ffa7a.jpg?1",
             "name": "Path of Annihilation",
             "text": "Devoid (This card has no color.)\nWhen Path of Annihilation enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\nEldrazi you control have \"{T}: Add one mana of any color.\"\nWhenever you cast a creature spell with mana value 7 or greater, you gain 4 life.",
             "colours": [],
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "ad6a8fc8-94bf-5da1-9ad6-711642e8df5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eda3db-b47d-4f1e-a93d-e2ea747d935c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4eda3db-b47d-4f1e-a93d-e2ea747d935c.jpg?1",
             "name": "Primal Prayers",
             "text": "When Primal Prayers enters the battlefield, you get {E}{E} (two energy counters).\nYou may cast creature spells with mana value 3 or less by paying {E} rather than paying their mana costs. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "ad13706b-0d65-5586-acdd-0575a5fc4549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b2d89-d641-4815-8e6c-5dba0d31419e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b2d89-d641-4815-8e6c-5dba0d31419e.jpg?1",
             "name": "Propagator Drone",
             "text": "Devoid (This card has no color.)\nCreature tokens you control have evolve. (They have \"Whenever a creature enters the battlefield under your control, if it has greater power or toughness than this token, put a +1/+1 counter on this token.\" They see this creature enter.)\n{3}{G}: Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"",
             "colours": [],
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "9f47fd7a-c051-5f02-a730-8d729739263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634e05c9-96da-467a-870d-3af68da53071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634e05c9-96da-467a-870d-3af68da53071.jpg?1",
             "name": "Signature Slam",
             "text": "Put a +1/+1 counter on target creature you control, then each modified creature you control deals damage equal to its power to target creature you don't control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5776,7 +5776,7 @@
         },
         {
             "id": "4cecf2b1-82ae-56a9-99ca-73c4c79477ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9246b68-580f-4f53-883d-7900880e4b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9246b68-580f-4f53-883d-7900880e4b0d.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace. (You may cast permanent cards from your graveyard by discarding a land card in addition to paying their other costs.)",
             "colours": [
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "fc5bda91-33bd-5d33-b97d-25a4f244c28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfadb17-76ad-4d4d-9fa7-33c4b88b4c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfadb17-76ad-4d4d-9fa7-33c4b88b4c0a.jpg?1",
             "name": "Sowing Mycospawn",
             "text": "Devoid (This card has no color.)\nKicker {1}{C} (You may pay an additional {1}{C} as you cast this spell.)\nWhen you cast this spell, search your library for a land card, put it onto the battlefield, then shuffle.\nWhen you cast this spell, if it was kicked, exile target land.",
             "colours": [],
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "232adf27-a52e-57cc-9006-35215af05a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a3ea87-005e-4985-b2a5-21711d0b71c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a3ea87-005e-4985-b2a5-21711d0b71c0.jpg?1",
             "name": "Springheart Nantuko",
             "text": "Bestow {1}{G}\nEnchanted creature gets +1/+1.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may pay {1}{G} if Springheart Nantuko is attached to a creature you control. If you do, create a token that's a copy of that creature. If you didn't create a token this way, create a 1/1 green Insect creature token.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "ff438f9c-b91e-550c-ad09-5f178b952e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6625df2e-7046-411a-ae86-c46ac0953a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6625df2e-7046-411a-ae86-c46ac0953a0b.jpg?1",
             "name": "Temperamental Oozewagg",
             "text": "{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nModified creatures you control have trample. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "93657372-7c9b-5b40-b6d4-dfb5ef15175a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c249aa6-c65c-4572-8e2e-c3899638ecce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c249aa6-c65c-4572-8e2e-c3899638ecce.jpg?1",
             "name": "Territory Culler",
             "text": "Devoid (This card has no color.)\nReach\nLandfall \u2014 Whenever a land enters the battlefield under your control, look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [],
@@ -5956,7 +5956,7 @@
         },
         {
             "id": "cf20d4e0-05df-5fff-85dd-768d3f92211a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328b02ca-d8eb-401d-9c41-93f8eb909312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328b02ca-d8eb-401d-9c41-93f8eb909312.jpg?1",
             "name": "Thief of Existence",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, exile up to one target noncreature, nonland permanent an opponent controls with mana value 4 or less. If you do, Thief of Existence gains \"When this creature leaves the battlefield, target opponent draws a card.\"",
             "colours": [],
@@ -5988,7 +5988,7 @@
         },
         {
             "id": "0d0ef2d8-f0ea-55b3-9ffc-2fb64a4cf645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812af562-853a-48a3-b428-ad891c54be5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812af562-853a-48a3-b428-ad891c54be5c.jpg?1",
             "name": "Trickster's Elk",
             "text": "Bestow {1}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached.)\nEnchanted creature loses all abilities and is a green Elk creature with base power and toughness 3/3.",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "2d63cec1-e3ed-55e7-baf8-6d72e1cd1297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c19f67-834c-4709-9038-7916ac0921eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c19f67-834c-4709-9038-7916ac0921eb.jpg?1",
             "name": "Wumpus Aberration",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, if {C} wasn't spent to cast it, target opponent may put a creature card from their hand onto the battlefield.\nTrample",
             "colours": [],
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "7f62a152-f57e-59ff-934e-1f7d51af4e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7149359-bb3f-413c-b21d-e4cd88618e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7149359-bb3f-413c-b21d-e4cd88618e56.jpg?1",
             "name": "Abstruse Appropriation",
             "text": "Devoid (This card has no color.)\nExile target nonland permanent. You may cast that card for as long as it remains exiled, and you may spend colorless mana as though it were mana of any color to cast that spell.",
             "colours": [],
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "3a2ad1db-5528-5308-820a-766887fa9279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19266b5a-ff78-436c-b0f1-457e80bb647e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19266b5a-ff78-436c-b0f1-457e80bb647e.jpg?1",
             "name": "Arna Kenner\u00fcd, Skycaptain",
             "text": "Flying, lifelink\nWard\u2014\nDiscard a card.\nWhenever a modified creature you control attacks, double the number of each kind of counter on it. Then for each nontoken permanent attached to it, create a token that's a copy of that permanent attached to that creature.",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "a92205db-6497-5911-af3d-b6232a3899bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9ad04d-c4d4-4d06-93bb-a881be733717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9ad04d-c4d4-4d06-93bb-a881be733717.jpg?1",
             "name": "Conduit Goblin",
             "text": "When Conduit Goblin enters the battlefield, you get {E}{E} (two energy counters).\nAt the beginning of combat on your turn, you may pay {E}. If you do, another target creature you control gets +1/+0 and gains haste until end of turn.",
             "colours": [
@@ -6170,7 +6170,7 @@
         },
         {
             "id": "12069abb-426a-5e47-bb1c-2eea7ce6d2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62993aa2-4804-43cc-910a-c51e794f8508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62993aa2-4804-43cc-910a-c51e794f8508.jpg?1",
             "name": "Cranial Ram",
             "text": "Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +X/+1, where X is the number of artifacts you control.\nEquip {2}",
             "colours": [
@@ -6206,7 +6206,7 @@
         },
         {
             "id": "572e4801-4d0d-5cab-8183-9fc8b9f05630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09a8de1-98b3-49e0-82f6-d90f1048de44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a09a8de1-98b3-49e0-82f6-d90f1048de44.jpg?1",
             "name": "Cursed Wombat",
             "text": "{2}{B}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nPermanents you control have \"Whenever one or more +1/+1 counters are put on this permanent, put an additional +1/+1 counter on it. This ability triggers only once each turn.\"",
             "colours": [
@@ -6243,7 +6243,7 @@
         },
         {
             "id": "e1ca3b0e-9280-5ef7-ac23-2626c9837e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce6839-92d1-497b-9760-6fdc7388614e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce6839-92d1-497b-9760-6fdc7388614e.jpg?1",
             "name": "Cyclops Superconductor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Cyclops Superconductor enters the battlefield, you get {E}{E}{E} (three energy counters).\nWhen Cyclops Superconductor dies, you may pay {E}{E}{E}. When you do, Cyclops Superconductor deals damage equal to its power to any target.",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "53df824f-d506-5a67-8280-e97b93d3f5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663e9e3-1989-4ddb-9508-9cc055d2ebe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4663e9e3-1989-4ddb-9508-9cc055d2ebe9.jpg?1",
             "name": "Emissary of Soulfire",
             "text": "When Emissary of Soulfire enters the battlefield, you get {E}{E}{E} (three energy counters).\nPay {E}{E}: Put an exalted counter on target creature you control. Activate only as a sorcery. (Whenever a creature you control attacks alone, it gets +1/+1 until end of turn for each instance of exalted among permanents you control.)",
             "colours": [
@@ -6317,7 +6317,7 @@
         },
         {
             "id": "c817bb23-307e-5aeb-b463-a8aa10fde884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdb095d-b826-4e3e-8c61-0d408e52d6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdb095d-b826-4e3e-8c61-0d408e52d6b8.jpg?1",
             "name": "Expanding Ooze",
             "text": "{B}{G}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever Expanding Ooze attacks, put a +1/+1 counter on target modified creature you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "4db7e6f9-34b4-5887-8f88-c5d9dcb63e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9afac99-a094-41a8-8323-90dec29691c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9afac99-a094-41a8-8323-90dec29691c4.jpg?1",
             "name": "Faithful Watchdog",
             "text": "Vigilance\nFaithful Watchdog enters the battlefield with three +1/+1 counters on it.",
             "colours": [
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "091dcfd4-feec-5bd8-870a-4e48382b8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbcc962-65c4-496d-8034-75c8d204dba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbcc962-65c4-496d-8034-75c8d204dba3.jpg?1",
             "name": "Genku, Future Shaper",
             "text": "Whenever another nontoken permanent you control leaves the battlefield, choose one that hasn't been chosen this turn. Create a creature token with those characteristics.\n\u2022 2/2 white Fox with vigilance.\n\u2022 1/2 blue Moonfolk with flying.\n\u2022 1/1 black Rat with lifelink.\n{3}{W}{U}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6431,7 +6431,7 @@
         },
         {
             "id": "73a2f007-3c00-57cd-8311-97550fb73d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d42bd9-0307-42ec-a4cd-b39b69b607d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d42bd9-0307-42ec-a4cd-b39b69b607d0.jpg?1",
             "name": "Golden-Tail Trainer",
             "text": "Aura and Equipment spells you cast cost {X} less to cast, where X is Golden-Tail Trainer's power.\nWhenever Golden-Tail Trainer attacks, other modified creatures you control get +X/+X until end of turn, where X is Golden-Tail Trainer's power. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "860928cf-17e9-53c9-8fc1-d71f1ca531f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b69aaf-0aae-4f6e-a27f-0129882dfe1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62b69aaf-0aae-4f6e-a27f-0129882dfe1d.jpg?1",
             "name": "Horrid Shadowspinner",
             "text": "Lifelink\nWhenever Horrid Shadowspinner attacks, you may draw cards equal to its power. If you do, discard that many cards.",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "33b46870-f94a-5c52-ae96-4cfad384e5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541209fa-38b6-4d61-a72d-26bfb6ad5ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541209fa-38b6-4d61-a72d-26bfb6ad5ead.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "03015878-fb30-5020-b03f-e87c7c880c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee6a8a-c3a8-43bc-beb9-be30d03ab952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee6a8a-c3a8-43bc-beb9-be30d03ab952.jpg?1",
             "name": "Invert Polarity",
             "text": "Choose target spell, then flip a coin. If you win the flip, gain control of that spell and you may choose new targets for it. If you lose the flip, counter that spell.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "c456fc6e-1ca5-518b-8f17-9eb057ef7891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9537d-c6b9-46ef-834b-87750d79f1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d9537d-c6b9-46ef-834b-87750d79f1ae.jpg?1",
             "name": "Izzet Generatorium",
             "text": "If you would get one or more {E} (energy counters), you get that many plus one {E} instead.\n{T}: Draw a card. Activate only if you've paid or lost four or more {E} this turn.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "1ecb8709-4a82-5e08-81fd-d1e358723e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585e4e02-4873-4a65-a9ad-30cf0d5b6f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585e4e02-4873-4a65-a9ad-30cf0d5b6f79.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -6660,7 +6660,7 @@
         },
         {
             "id": "041e10fd-833e-5d6e-866f-6a412f1f0c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b67489-5eb0-4406-9bf3-27e50dc632eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b67489-5eb0-4406-9bf3-27e50dc632eb.jpg?1",
             "name": "Nadu, Winged Wisdom",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand. This ability triggers only twice each turn.\"",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "52f7d503-dd20-5f85-8c62-97005958ba6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcf68cf-0dac-4b29-90d5-c18c685182e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcf68cf-0dac-4b29-90d5-c18c685182e6.jpg?1",
             "name": "The Necrobloom",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 0/1 green Plant creature token. If you control seven or more lands with different names, create a 2/2 black Zombie creature token instead.\nLand cards in your graveyard have dredge 2. (You may return a land card from your graveyard to your hand and mill two cards instead of drawing a card.)",
             "colours": [
@@ -6745,7 +6745,7 @@
         },
         {
             "id": "f508210a-1ef0-549c-a9f9-4d71aeaa7a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cf39f2-7382-405d-a14b-7eb8726cd38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cf39f2-7382-405d-a14b-7eb8726cd38a.jpg?1",
             "name": "Obstinate Gargoyle",
             "text": "Obstinate Gargoyle has flying as long as it's modified. (Equipment, Auras you control, and counters are modifications.)\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6782,7 +6782,7 @@
         },
         {
             "id": "bc9614ef-1304-5986-a728-70880d4670e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg?1",
             "name": "Ondu Knotmaster // Throw a Line",
             "text": "Lifelink\nWhenever another modified creature you control dies, put two +1/+1 counters on Ondu Knotmaster.",
             "colours": [
@@ -6819,7 +6819,7 @@
         },
         {
             "id": "5a8e7f91-4790-5004-9ad5-2777874da6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/7/27912e61-97ef-406b-bb88-4fe89a54726e.jpg?1",
             "name": "Ondu Knotmaster // Throw a Line",
             "text": "Distribute two +1/+1 counters among one or two target creatures. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6855,7 +6855,7 @@
         },
         {
             "id": "ac065932-5493-5e8c-a9b9-dd0469692ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419cd0b-2449-4cc5-9ead-b9e45e271700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e419cd0b-2449-4cc5-9ead-b9e45e271700.jpg?1",
             "name": "Phlage, Titan of Fire's Fury",
             "text": "When Phlage enters the battlefield, sacrifice it unless it escaped.\nWhenever Phlage enters the battlefield or attacks, it deals 3 damage to any target and you gain 3 life.\nEscape\u2014{R}{R}{W}{W}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "b83057ae-433e-598f-965c-5c970a668f98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc9a10b-c9f9-4129-a671-ced0917ce78b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc9a10b-c9f9-4129-a671-ced0917ce78b.jpg?1",
             "name": "Planar Genesis",
             "text": "Look at the top four cards of your library. You may put a land card from among them onto the battlefield tapped. If you don't, put a card from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6931,7 +6931,7 @@
         },
         {
             "id": "eb4cffdc-c32b-5679-9234-3943762e8cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68924203-c3d9-41ce-8ca8-c6dd491eb3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68924203-c3d9-41ce-8ca8-c6dd491eb3ca.jpg?1",
             "name": "Psychic Frog",
             "text": "Whenever Psychic Frog deals combat damage to a player or planeswalker, draw a card.\nDiscard a card: Put a +1/+1 counter on Psychic Frog.\nExile three cards from your graveyard: Psychic Frog gains flying until end of turn.",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "6bae738d-fba6-5bf9-9f81-12f7e4f51b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5968f641-48b5-4b97-8072-ddd8073cd4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5968f641-48b5-4b97-8072-ddd8073cd4d7.jpg?1",
             "name": "Pyretic Rebirth",
             "text": "Return target artifact or creature card from your graveyard to your hand. Pyretic Rebirth deals damage equal to that card's mana value to up to one target creature or planeswalker.",
             "colours": [
@@ -7004,7 +7004,7 @@
         },
         {
             "id": "0ae63b32-dbcd-5cea-9146-f3f7069e935a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e72a934-12e0-4e56-af67-566c2d5b01c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e72a934-12e0-4e56-af67-566c2d5b01c1.jpg?1",
             "name": "Riddle Gate Gargoyle",
             "text": "Flying\nWhen Riddle Gate Gargoyle enters the battlefield, you get {E}{E}{E} (three energy counters).\nWhenever you attack, you may pay {E}{E}. When you do, target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -7041,7 +7041,7 @@
         },
         {
             "id": "30c90adb-d95e-5daf-a3a4-e464eade96d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ac88b2-a92e-4a12-9ba3-5a4b8cdb58dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ac88b2-a92e-4a12-9ba3-5a4b8cdb58dc.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -7084,7 +7084,7 @@
         },
         {
             "id": "55596b28-3a7e-5f4d-aeee-73186aa23f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ce8e9-64b9-403c-bee0-66a4c47ca6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470ce8e9-64b9-403c-bee0-66a4c47ca6d4.jpg?1",
             "name": "Scurry of Gremlins",
             "text": "When Scurry of Gremlins enters the battlefield, create two 1/1 red Gremlin creature tokens. Then you get an amount of {E} (energy counters) equal to the number of creatures you control.\nPay {E}{E}{E}{E}: Creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "ebf28291-11c1-5140-a218-eee767332da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185371c-2dde-48ad-ab27-08be04b3c522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9185371c-2dde-48ad-ab27-08be04b3c522.jpg?1",
             "name": "Snapping Voidcraw",
             "text": "Devoid (This card has no color.)\n{T}: Add {C}{C}.\n{3}{C}, {T}: Draw a card.",
             "colours": [],
@@ -7156,7 +7156,7 @@
         },
         {
             "id": "17faa53a-33e9-5015-992b-dd1a048ae83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3aedae-e4bb-48e3-9f8b-bea0430df306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3aedae-e4bb-48e3-9f8b-bea0430df306.jpg?1",
             "name": "Sneaky Snacker",
             "text": "Flying\nWhen you draw your third card in a turn, return Sneaky Snacker from your graveyard to the battlefield tapped.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "654d91ae-f8b5-5f0a-a609-d2d1fec2254b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ea14e-44ac-4f69-bfea-cb6bf1bfbd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3ea14e-44ac-4f69-bfea-cb6bf1bfbd74.jpg?1",
             "name": "Titans' Vanguard",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell and whenever Titans' Vanguard attacks, put a +1/+1 counter on each colorless creature you control.\nTrample",
             "colours": [],
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "afe19133-5882-54da-bd94-fc39e2353965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15570c0-4210-4959-8584-987ec85f8283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15570c0-4210-4959-8584-987ec85f8283.jpg?1",
             "name": "Wight of the Reliquary",
             "text": "Vigilance\nWight of the Reliquary gets +1/+1 for each creature card in your graveyard.\n{T}, Sacrifice another creature: Search your library for a land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7267,7 +7267,7 @@
         },
         {
             "id": "614503bf-187d-59b2-9271-1fa4f5e79fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54dbeb1-51f8-40e2-912a-ec25457de5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54dbeb1-51f8-40e2-912a-ec25457de5a2.jpg?1",
             "name": "Writhing Chrysalis",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\nReach\nWhenever you sacrifice another Eldrazi, put a +1/+1 counter on Writhing Chrysalis.",
             "colours": [],
@@ -7301,7 +7301,7 @@
         },
         {
             "id": "1a246652-3682-5efb-bc97-8cf82ca0c3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad8671-4761-4014-a8a3-af45627e6e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad8671-4761-4014-a8a3-af45627e6e79.jpg?1",
             "name": "Disruptor Flute",
             "text": "Flash\nAs Disruptor Flute enters the battlefield, choose a card name.\nSpells with the chosen name cost {3} more to cast.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7331,7 +7331,7 @@
         },
         {
             "id": "04d61069-61b8-5e6e-a03c-b6377030efa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e1ff6d-190a-497f-89c3-35e0979c93b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e1ff6d-190a-497f-89c3-35e0979c93b5.jpg?1",
             "name": "Idol of False Gods",
             "text": "{1}{C}, {T}: Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this creature: Add {C}.\"\nWhenever another Eldrazi you control dies, put a +1/+1 counter on Idol of False Gods.\nAs long as Idol of False Gods has eight or more +1/+1 counters on it, it's a 0/0 creature in addition to its other types and it has annihilator 2.",
             "colours": [],
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "6e9099be-3ffd-504c-bcfe-7c7296463e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87315b3-d3a3-4eef-8a20-90587b36f551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87315b3-d3a3-4eef-8a20-90587b36f551.jpg?1",
             "name": "Solar Transformer",
             "text": "Solar Transformer enters the battlefield tapped.\nWhen Solar Transformer enters the battlefield, you get {E}{E}{E} (three energy counters).\n{T}: Add {C}.\n{T}, Pay {E}: Add one mana of any color.",
             "colours": [],
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "8bdef6a5-46f7-5e5d-979f-a95c3f8f0b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f11089-658f-42e6-aeb0-09b512ad2479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f11089-658f-42e6-aeb0-09b512ad2479.jpg?1",
             "name": "Vexing Bauble",
             "text": "Whenever a player casts a spell, if no mana was spent to cast it, counter that spell.\n{1}, {T}, Sacrifice Vexing Bauble: Draw a card.",
             "colours": [],
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "aeb657d8-fc52-519c-baa6-8093f6b363ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76bc2da-8f4b-4153-8a7b-c601b19affaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76bc2da-8f4b-4153-8a7b-c601b19affaf.jpg?1",
             "name": "Winter Moon",
             "text": "Players can't untap more than one nonbasic land during their untap steps.",
             "colours": [],
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "1e4983e2-644a-5deb-9847-1e9fce802950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90f9e6-9251-4203-9599-cc4032a5e6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a90f9e6-9251-4203-9599-cc4032a5e6e1.jpg?1",
             "name": "Archway of Innovation",
             "text": "Archway of Innovation enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn has improvise. (Your artifacts can help cast that spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "ec41dbde-c951-5454-8210-e9fcad225741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd148edc-9e43-41aa-bb50-f912115d3e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd148edc-9e43-41aa-bb50-f912115d3e72.jpg?1",
             "name": "Arena of Glory",
             "text": "Arena of Glory enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{R}, {T}, Exert Arena of Glory: Add {R}{R}. If that mana is spent on a creature spell, it gains haste until end of turn. (An exerted permanent won't untap during your next untap step.)",
             "colours": [],
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "c094f759-c561-513c-b307-9ca4e0bb3b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/579743fe-f71e-4cb2-8629-d6b02ed1591d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/579743fe-f71e-4cb2-8629-d6b02ed1591d.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -7546,7 +7546,7 @@
         },
         {
             "id": "c521d694-8b14-53c4-9320-6d94a5740c7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b277752b-430a-4f09-8a98-b72f813dd52e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b277752b-430a-4f09-8a98-b72f813dd52e.jpg?1",
             "name": "Bountiful Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Bountiful Landscape: Search your library for a basic Forest, Island, or Mountain card, put it onto the battlefield tapped, then shuffle.\nCycling {G}{U}{R} ({G}{U}{R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7578,7 +7578,7 @@
         },
         {
             "id": "cbcb9d30-f6c0-5bbf-acf3-c0fd63d3ebee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2312c49-1627-47ad-8113-78a999a97d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2312c49-1627-47ad-8113-78a999a97d8d.jpg?1",
             "name": "Contaminated Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Contaminated Landscape: Search your library for a basic Plains, Island, or Swamp card, put it onto the battlefield tapped, then shuffle.\nCycling {W}{U}{B} ({W}{U}{B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "9ceed8dd-1373-584b-a654-6d8798b2e37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae6828e-ff19-45db-8b59-61616353491f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae6828e-ff19-45db-8b59-61616353491f.jpg?1",
             "name": "Deceptive Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Deceptive Landscape: Search your library for a basic Plains, Swamp, or Forest card, put it onto the battlefield tapped, then shuffle.\nCycling {W}{B}{G} ({W}{B}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "587bebb1-e19a-56af-8c80-cfe94ee23ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f85e12c-196b-4459-b81f-0c9c854e9f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f85e12c-196b-4459-b81f-0c9c854e9f57.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "2dd99920-7cf9-5c46-8d3c-aa161ac1e844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fb0fa7-0c5c-4a75-9461-c51403c30282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fb0fa7-0c5c-4a75-9461-c51403c30282.jpg?1",
             "name": "Foreboding Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Foreboding Landscape: Search your library for a basic Swamp, Forest, or Island card, put it onto the battlefield tapped, then shuffle.\nCycling {B}{G}{U} ({B}{G}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7706,7 +7706,7 @@
         },
         {
             "id": "f8b3c5f2-5d6e-5ec1-8c64-0956a6ee7775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62907e7b-e531-4f51-9a69-7e60ae525775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62907e7b-e531-4f51-9a69-7e60ae525775.jpg?1",
             "name": "Monumental Henge",
             "text": "Monumental Henge enters the battlefield tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. (Artifacts, legendaries, and Sagas are historic.)",
             "colours": [],
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "ef9d4fb9-a6f6-5bbf-b654-b6986c3d1489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bd07e-cf80-4d64-af29-f4cec6632b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bd07e-cf80-4d64-af29-f4cec6632b3e.jpg?1",
             "name": "Perilous Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Perilous Landscape: Search your library for a basic Island, Mountain, or Plains card, put it onto the battlefield tapped, then shuffle.\nCycling {U}{R}{W} ({U}{R}{W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "549699dc-f041-593b-af40-90d76450c283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e288374-2b71-4ace-b1d2-a19fee6cb4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e288374-2b71-4ace-b1d2-a19fee6cb4af.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -7802,7 +7802,7 @@
         },
         {
             "id": "e790b126-ba6d-5ba2-8394-cd515429b01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661fc907-7003-45c6-820c-9616e9a71c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661fc907-7003-45c6-820c-9616e9a71c30.jpg?1",
             "name": "Seething Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Seething Landscape: Search your library for a basic Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle.\nCycling {U}{B}{R} ({U}{B}{R}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "75ebcc1a-8fb3-536b-9f9d-c412826a4432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28c7-6e92-439d-a163-91682d4f11dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3da28c7-6e92-439d-a163-91682d4f11dc.jpg?1",
             "name": "Shattered Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Shattered Landscape: Search your library for a basic Mountain, Plains, or Swamp card, put it onto the battlefield tapped, then shuffle.\nCycling {R}{W}{B} ({R}{W}{B}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "7cb34093-8dfb-595a-9fe5-ede07143b696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe070f4-8877-4280-b8fd-869f3ac34ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe070f4-8877-4280-b8fd-869f3ac34ab6.jpg?1",
             "name": "Sheltering Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Sheltering Landscape: Search your library for a basic Mountain, Forest, or Plains card, put it onto the battlefield tapped, then shuffle.\nCycling {R}{G}{W} ({R}{G}{W}, Discard this card: Draw a card.)",
             "colours": [],
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "f8279d95-b679-5816-82e1-e3e32f398a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059164e1-894d-4586-9800-e60d6fbd6eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059164e1-894d-4586-9800-e60d6fbd6eb6.jpg?1",
             "name": "Shifting Woodland",
             "text": "Shifting Woodland enters the battlefield tapped unless you control a Forest.\n{T}: Add {G}.\nDelirium \u2014 {2}{G}{G}: Shifting Woodland becomes a copy of target permanent card in your graveyard until end of turn. Activate only if there are four or more card types among cards in your graveyard.",
             "colours": [],
@@ -7930,7 +7930,7 @@
         },
         {
             "id": "d4003a6b-2200-5214-b07f-0deda2011fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87870792-e429-4eba-8193-cdce5c7b6c55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87870792-e429-4eba-8193-cdce5c7b6c55.jpg?1",
             "name": "Snow-Covered Wastes",
             "text": "",
             "colours": [],
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "f7e0779d-e40f-5974-b524-409971f71514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5fbb30-abfc-4e79-8ce5-bbb04a241c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5fbb30-abfc-4e79-8ce5-bbb04a241c9f.jpg?1",
             "name": "Spymaster's Vault",
             "text": "Spymaster's Vault enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{B}, {T}: Target creature you control connives X, where X is the number of creatures that died this turn. (Draw X cards, then discard X cards. Put a +1/+1 counter on that creature for each nonland card discarded this way.)",
             "colours": [],
@@ -7996,7 +7996,7 @@
         },
         {
             "id": "e6de2375-a845-5147-821f-637bee301f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f48b9-a972-4e2c-af95-05ab078e01f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f48b9-a972-4e2c-af95-05ab078e01f2.jpg?1",
             "name": "Tranquil Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Tranquil Landscape: Search your library for a basic Forest, Plains, or Island card, put it onto the battlefield tapped, then shuffle.\nCycling {G}{W}{U} ({G}{W}{U}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "fd23e0b2-37a4-5f79-81b8-057cd09232a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e3e7b3-7ba9-47a2-b46c-a40bffb445e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e3e7b3-7ba9-47a2-b46c-a40bffb445e2.jpg?1",
             "name": "Twisted Landscape",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Twisted Landscape: Search your library for a basic Swamp, Mountain, or Forest card, put it onto the battlefield tapped, then shuffle.\nCycling {B}{R}{G} ({B}{R}{G}, Discard this card: Draw a card.)",
             "colours": [],
@@ -8064,7 +8064,7 @@
         },
         {
             "id": "767fd71b-7f44-5e8a-b681-1ef52e137fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020e1348-1a35-4cc8-bad6-9fbddfa79277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020e1348-1a35-4cc8-bad6-9fbddfa79277.jpg?1",
             "name": "Ugin's Labyrinth",
             "text": "Imprint \u2014 When Ugin's Labyrinth enters the battlefield, you may exile a colorless card with mana value 7 or greater from your hand.\n{T}: Add {C}. If a card is exiled with Ugin's Labyrinth, add {C}{C} instead.\n{T}: Return the exiled card to its owner's hand.",
             "colours": [],
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "1c7aa0bd-cffb-51c4-a34e-4f6941bc15e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926916ed-2f22-4ba9-9427-194886ad6c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926916ed-2f22-4ba9-9427-194886ad6c1e.jpg?1",
             "name": "Urza's Cave",
             "text": "{T}: Add {C}.\n{3}, {T}, Sacrifice Urza's Cave: Search your library for a land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "810d9bdc-8ecb-5ae5-8131-5dbda9df6ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1d13f7-fd38-4f0b-a8e0-1eac78668117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1d13f7-fd38-4f0b-a8e0-1eac78668117.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "4b8ed103-5009-54f1-b40d-49b65edc9409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11ea8a-f895-438d-a3b7-f070238e4161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11ea8a-f895-438d-a3b7-f070238e4161.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -8189,7 +8189,7 @@
         },
         {
             "id": "9191bfd4-a5f4-543c-9f72-b0ccb3fae2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "918cccd3-05d3-5fab-a130-bf2ff405a1df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -8271,7 +8271,7 @@
         },
         {
             "id": "3a98f320-5bb3-5602-9d25-3cd5d8ef88f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg?1",
             "name": "Razorgrass Ambush // Razorgrass Field",
             "text": "Razorgrass Ambush deals 3 damage to target attacking or blocking creature.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -8303,7 +8303,7 @@
         },
         {
             "id": "2c24bc35-425b-5fa8-9548-eebc4e25c52b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57065dca-f90e-4184-bbc4-95d726a4160b.jpg?1",
             "name": "Razorgrass Ambush // Razorgrass Field",
             "text": "As Razorgrass Field enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.\n\n\nInstant\n{1}{W}",
             "colours": [],
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "a737a715-d53d-57e4-8186-21e3a56a048d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1",
             "name": "Witch Enchanter // Witch-Blessed Meadow",
             "text": "When Witch Enchanter enters the battlefield, destroy target artifact or enchantment an opponent controls.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -8368,7 +8368,7 @@
         },
         {
             "id": "734f8f5c-bd2b-5553-bce7-fcd4525d72dc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1",
             "name": "Witch Enchanter // Witch-Blessed Meadow",
             "text": "As Witch-Blessed Meadow enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.\n\n\nHuman\n{3}{W}",
             "colours": [],
@@ -8398,7 +8398,7 @@
         },
         {
             "id": "ec35f2dd-baf4-5bd2-ab08-85d14b251db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg?1",
             "name": "Hydroelectric Specimen // Hydroelectric Laboratory",
             "text": "Flash\nWhen Hydroelectric Specimen enters the battlefield, you may change the target of target instant or sorcery spell with a single target to Hydroelectric Specimen.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "829e4875-8236-5261-812d-07228edbd9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/8689ecd7-e9a6-458b-99d2-6dbaca527f00.jpg?1",
             "name": "Hydroelectric Specimen // Hydroelectric Laboratory",
             "text": "As Hydroelectric Laboratory enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.\n\n\nWeird\n{2}{U}",
             "colours": [],
@@ -8462,7 +8462,7 @@
         },
         {
             "id": "4735928e-7ad1-542c-b43c-268ec6eddc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1",
             "name": "Sink into Stupor // Soporific Springs",
             "text": "Return target spell or nonland permanent an opponent controls to its owner's hand.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -8494,7 +8494,7 @@
         },
         {
             "id": "22e9a471-886f-5f0c-b474-e4f00363a746",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1",
             "name": "Sink into Stupor // Soporific Springs",
             "text": "As Soporific Springs enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{1}{U}{U}",
             "colours": [],
@@ -8524,7 +8524,7 @@
         },
         {
             "id": "614f1d54-6bc9-5578-a9c3-d4d446b4a9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -8565,7 +8565,7 @@
         },
         {
             "id": "36f3308d-943e-544c-a920-258b4a90d311",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -8606,7 +8606,7 @@
         },
         {
             "id": "f34f3fed-44f9-5ae2-9e49-f1d19e5296b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg?1",
             "name": "Boggart Trawler // Boggart Bog",
             "text": "When Boggart Trawler enters the battlefield, exile target player's graveyard.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -8640,7 +8640,7 @@
         },
         {
             "id": "0a761b9f-fa88-5ad3-b90a-fae894f4f07a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0d484a6-5610-4f1d-95ec-eda273c255e4.jpg?1",
             "name": "Boggart Trawler // Boggart Bog",
             "text": "As Boggart Bog enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.\n\n\nGoblin\n{2}{B}",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "b045ab78-84a0-568c-b71c-1992e6f57bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1",
             "name": "Fell the Profane // Fell Mire",
             "text": "Destroy target creature or planeswalker.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "36d72a5a-db59-55ce-be93-608e84b07a68",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1",
             "name": "Fell the Profane // Fell Mire",
             "text": "As Fell Mire enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.\n\n\nInstant\n{2}{B}{B}",
             "colours": [],
@@ -8732,7 +8732,7 @@
         },
         {
             "id": "27310488-922d-5d07-9b2a-b4139d26aa63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "ebc1ce75-2aeb-5771-ab19-0213c15f8160",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7474fc-0042-4be9-81f3-5f66f4b16740.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "c5e406cf-a4da-5d13-9557-7a372366bb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg?1",
             "name": "Pinnacle Monk // Mystic Peak",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Pinnacle Monk enters the battlefield, return target instant or sorcery card from your graveyard to your hand.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "c7642483-b8d2-5d8c-ae06-052493ac7038",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24d4f26e-7f96-4b38-867e-4fac819b2679.jpg?1",
             "name": "Pinnacle Monk // Mystic Peak",
             "text": "As Mystic Peak enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.\n\n\nMonk\n{3}{R}{R}",
             "colours": [],
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "c398deca-20aa-5b75-bed8-3739eeb2f63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "fd5c0567-a45a-590c-b2cd-d8ffb8648940",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -8961,7 +8961,7 @@
         },
         {
             "id": "94499941-afe4-533a-a698-3277da40f2b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1",
             "name": "Sundering Eruption // Volcanic Fissure",
             "text": "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle. Creatures without flying can't block this turn.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -8993,7 +8993,7 @@
         },
         {
             "id": "da6decde-3150-5434-9600-b3e3ded5c670",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1",
             "name": "Sundering Eruption // Volcanic Fissure",
             "text": "As Volcanic Fissure enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.\n\n\nSorcery\n{2}{R}",
             "colours": [],
@@ -9023,7 +9023,7 @@
         },
         {
             "id": "39bc978e-fe2d-5132-bead-0bda7020716c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1",
             "name": "Bridgeworks Battle // Tanglespan Bridgeworks",
             "text": "Target creature you control gets +2/+2 until end of turn. It fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -9055,7 +9055,7 @@
         },
         {
             "id": "2a6616d0-99a8-5c50-8213-21dea885c24b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1",
             "name": "Bridgeworks Battle // Tanglespan Bridgeworks",
             "text": "As Tanglespan Bridgeworks enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.\n\n\nSorcery\n{2}{G}",
             "colours": [],
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "d49ece9c-e674-56b4-b436-75d5ee89eb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1",
             "name": "Disciple of Freyalise // Garden of Freyalise",
             "text": "When Disciple of Freyalise enters the battlefield, you may sacrifice another creature. If you do, you gain X life and draw X cards, where X is that creature's power.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "cb2159ac-76b6-5494-a884-1018100b6d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1",
             "name": "Disciple of Freyalise // Garden of Freyalise",
             "text": "As Garden of Freyalise enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElf\n{3}{G}{G}{G}",
             "colours": [],
@@ -9150,7 +9150,7 @@
         },
         {
             "id": "7ff0f7cb-d87a-590b-82e1-a5a56f60084c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -9190,7 +9190,7 @@
         },
         {
             "id": "35154104-4cb6-574c-84ef-bf808124ef9a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68239b41-b7db-4044-b672-6808c2c342ec.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -9231,7 +9231,7 @@
         },
         {
             "id": "cddd8253-4b21-573a-9b7b-4a85597c88f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg?1",
             "name": "Bloodsoaked Insight // Sanguine Morass",
             "text": "This spell costs {1} less to cast for each 1 life your opponents have lost this turn.\nTarget opponent exiles the top three cards of their library. Until the end of your next turn, you may play those cards. If you cast a spell this way, mana of any type can be spent to cast it.\n\n\nLand\n{T}: Add {B} or {R}.",
             "colours": [
@@ -9265,7 +9265,7 @@
         },
         {
             "id": "4d9c0824-80a6-54dc-9b8a-c54f052e3874",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a08e0d2-1e60-47f5-9228-4c11a127089d.jpg?1",
             "name": "Bloodsoaked Insight // Sanguine Morass",
             "text": "Sanguine Morass enters the battlefield tapped.\n{T}: Add {B} or {R}.\n\n\nSorcery\n{5}{BR}{BR}",
             "colours": [],
@@ -9296,7 +9296,7 @@
         },
         {
             "id": "bb762192-6788-53c7-b5ea-811ae295629c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1",
             "name": "Drowner of Truth // Drowned Jungle",
             "text": "Devoid (This card has no color.)\nWhen you cast this spell, if {C} was spent to cast it, create two 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this creature: Add {C}.\"\n\n\nLand\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "e96debeb-7222-5071-8c2e-992e13914fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1",
             "name": "Drowner of Truth // Drowned Jungle",
             "text": "Drowned Jungle enters the battlefield tapped.\n{T}: Add {G} or {U}.\n\n\nEldrazi\n{5}{GW}{GW}",
             "colours": [],
@@ -9360,7 +9360,7 @@
         },
         {
             "id": "5b8e03cd-1735-53cb-ab9f-9748eefafa6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg?1",
             "name": "Glasswing Grace // Age-Graced Chapel",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying and lifelink.\n\n\nLand\n{T}: Add {W} or {B}.",
             "colours": [
@@ -9396,7 +9396,7 @@
         },
         {
             "id": "3cb0c74f-6cf1-540a-b132-77790368249a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90630b20-fc83-475f-bcd5-8bcfee0cf241.jpg?1",
             "name": "Glasswing Grace // Age-Graced Chapel",
             "text": "Age-Graced Chapel enters the battlefield tapped.\n{T}: Add {W} or {B}.\n\n\nAura\n{3}{WB}{WB}",
             "colours": [],
@@ -9427,7 +9427,7 @@
         },
         {
             "id": "578e7410-549e-5ebb-9048-7a60485c91e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg?1",
             "name": "Legion Leadership // Legion Stronghold",
             "text": "Until end of turn, double target creature's power and it gains first strike.\n\n\nLand\n{T}: Add {R} or {W}.",
             "colours": [
@@ -9461,7 +9461,7 @@
         },
         {
             "id": "5613d3c9-6860-5b89-8ea6-daaef693b522",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/7676abd9-0a3d-4721-b17b-778d2e3c2e25.jpg?1",
             "name": "Legion Leadership // Legion Stronghold",
             "text": "Legion Stronghold enters the battlefield tapped.\n{T}: Add {R} or {W}.\n\n\nInstant\n{1}{GU}",
             "colours": [],
@@ -9492,7 +9492,7 @@
         },
         {
             "id": "310d79cf-56f7-5837-a77e-9bae78afbc9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg?1",
             "name": "Revitalizing Repast // Old-Growth Grove",
             "text": "Put a +1/+1 counter on target creature. It gains indestructible until end of turn.\n\n\nLand\n{T}: Add {B} or {G}.",
             "colours": [
@@ -9526,7 +9526,7 @@
         },
         {
             "id": "5fb52d28-4da3-58d4-a246-c7e66069f856",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03522b6b-31ec-4126-8885-5dbb2248688b.jpg?1",
             "name": "Revitalizing Repast // Old-Growth Grove",
             "text": "Old-Growth Grove enters the battlefield tapped.\n{T}: Add {B} or {G}.\n\n\nInstant\n{BG}",
             "colours": [],
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "05070f60-1fb1-5a87-97b7-7c898a7309ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg?1",
             "name": "Rush of Inspiration // Crackling Falls",
             "text": "Draw two cards. Then discard a card at random unless you pay {E}{E} (two energy counters).\n\n\nLand\n{T}: Add {U} or {R}.",
             "colours": [
@@ -9591,7 +9591,7 @@
         },
         {
             "id": "caeefefc-7359-59a7-8b12-e7abfac50c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70a25a3a-c12a-49d3-8a91-a108dfa9d3c5.jpg?1",
             "name": "Rush of Inspiration // Crackling Falls",
             "text": "Crackling Falls enters the battlefield tapped.\n{T}: Add {U} or {R}.\n\n\nInstant\n{1}{UR}{UR}",
             "colours": [],
@@ -9622,7 +9622,7 @@
         },
         {
             "id": "7ccb4f69-c1dc-57a6-b7d6-24bba2a33f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg?1",
             "name": "Strength of the Harvest // Haven of the Harvest",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each creature and/or enchantment you control.\n\n\nLand\n{T}: Add {G} or {W}.",
             "colours": [
@@ -9658,7 +9658,7 @@
         },
         {
             "id": "7c11eb6c-210b-59a8-b009-1c64638e4cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7143aa7-b16d-4e63-910c-6ceec55483f3.jpg?1",
             "name": "Strength of the Harvest // Haven of the Harvest",
             "text": "Haven of the Harvest enters the battlefield tapped.\n{T}: Add {G} or {W}.\n\n\nAura\n{2}{RW}",
             "colours": [],
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "408eea78-22e9-59c0-a714-502075b40436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg?1",
             "name": "Stump Stomp // Burnwillow Clearing",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.\n\n\nLand\n{T}: Add {R} or {G}.",
             "colours": [
@@ -9723,7 +9723,7 @@
         },
         {
             "id": "5aff678d-f25d-54f0-bda0-3896343bfc95",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49974246-0a3b-4ec9-b5ea-2a89df9bb0b5.jpg?1",
             "name": "Stump Stomp // Burnwillow Clearing",
             "text": "Burnwillow Clearing enters the battlefield tapped.\n{T}: Add {R} or {G}.\n\n\nSorcery\n{1}{RG}",
             "colours": [],
@@ -9754,7 +9754,7 @@
         },
         {
             "id": "4781e96c-6301-5160-abd4-60e11f997e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg?1",
             "name": "Suppression Ray // Orderly Plaza",
             "text": "Tap all creatures target player controls. You may pay X {E}, then choose up to X creatures tapped this way. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)\n\n\nLand\n{T}: Add {W} or {U}.",
             "colours": [
@@ -9788,7 +9788,7 @@
         },
         {
             "id": "e385bca3-0e93-59b3-9621-148992ee4d17",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cccd328-457a-48ab-97fb-4bc319db2e60.jpg?1",
             "name": "Suppression Ray // Orderly Plaza",
             "text": "Orderly Plaza enters the battlefield tapped.\n{T}: Add {W} or {U}.\n\n\nSorcery\n{3}{WU}{WU}",
             "colours": [],
@@ -9819,7 +9819,7 @@
         },
         {
             "id": "2b2da129-2c69-5d23-a4a6-7d1998afb9ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg?1",
             "name": "Waterlogged Teachings // Inundated Archive",
             "text": "Search your library for an instant card or a card with flash, reveal it, put it into your hand, then shuffle.\n\n\nLand\n{T}: Add {U} or {B}.",
             "colours": [
@@ -9853,7 +9853,7 @@
         },
         {
             "id": "bb8edab3-b547-59ee-9ac9-88a234fd1af4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/060f9675-4921-4cbb-bae2-54c85c679fd4.jpg?1",
             "name": "Waterlogged Teachings // Inundated Archive",
             "text": "Inundated Archive enters the battlefield tapped.\n{T}: Add {U} or {B}.\n\n\nInstant\n{3}{UB}",
             "colours": [],
@@ -9884,7 +9884,7 @@
         },
         {
             "id": "1c6cacb6-be04-51d4-9308-f96dd93e5da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2647b5ac-1cd1-4069-a8df-2cd291a527b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2647b5ac-1cd1-4069-a8df-2cd291a527b4.jpg?1",
             "name": "Angel of the Ruins",
             "text": "Flying\nWhen Angel of the Ruins enters the battlefield, exile up to two target artifacts and/or enchantments.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -9919,7 +9919,7 @@
         },
         {
             "id": "6e4ea43a-94b8-52e5-b432-560997c2fe11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21637fbe-d9d3-4d5b-a361-0687385d4738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21637fbe-d9d3-4d5b-a361-0687385d4738.jpg?1",
             "name": "Decree of Justice",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.",
             "colours": [
@@ -9951,7 +9951,7 @@
         },
         {
             "id": "521f1d4b-d46f-589c-b751-e3986c0444a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed5bc3d-4056-40b0-a47a-2841692614b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed5bc3d-4056-40b0-a47a-2841692614b3.jpg?1",
             "name": "Distinguished Conjurer",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.\n{4}{W}, {T}: Exile another target creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "83894c8c-77c0-5974-aada-c02649216e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee241079-1e5a-4224-b9cb-4fd3e0da687c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee241079-1e5a-4224-b9cb-4fd3e0da687c.jpg?1",
             "name": "Orim's Chant",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nTarget player can't cast spells this turn. If this spell was kicked, creatures can't attack this turn.",
             "colours": [
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "42dd85df-9c12-5389-911f-5eacec78d7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c6ba1-1abc-478f-9b7c-97e9e3c92fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c6ba1-1abc-478f-9b7c-97e9e3c92fb0.jpg?1",
             "name": "Recruiter of the Guard",
             "text": "When Recruiter of the Guard enters the battlefield, you may search your library for a creature card with toughness 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "b77387cf-6699-5577-bb61-2bae0fb88f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f055754-58cf-474a-a3a9-59490dbf9dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f055754-58cf-474a-a3a9-59490dbf9dce.jpg?1",
             "name": "Sevinne's Reclamation",
             "text": "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "4257b849-4e55-5b4f-bce6-6a05cdc0a86d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33818e-6f6e-47a9-ae5d-406bdd47b292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33818e-6f6e-47a9-ae5d-406bdd47b292.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014{1}{U}, Pay 3 life. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "733f028f-8cc0-56d7-9f8d-342015fc7ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8920e7e4-d89e-4ff9-8922-27fdc2f8ed6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8920e7e4-d89e-4ff9-8922-27fdc2f8ed6e.jpg?1",
             "name": "Estrid's Invocation",
             "text": "You may have Estrid's Invocation enter the battlefield as a copy of an enchantment you control, except it has \"At the beginning of your upkeep, you may exile this enchantment. If you do, return it to the battlefield under its owner's control.\"",
             "colours": [
@@ -10153,7 +10153,7 @@
         },
         {
             "id": "b2612df4-4767-5ee3-b65d-f6ce68dcb93c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc2852-11c4-40da-b26f-6f236349f608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6ddc2852-11c4-40da-b26f-6f236349f608.jpg?1",
             "name": "Kappa Cannoneer",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nWard {4}\nWhenever Kappa Cannoneer or another artifact enters the battlefield under your control, put a +1/+1 counter on Kappa Cannoneer and it can't be blocked this turn.",
             "colours": [
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "46b6ed83-6920-532d-aca1-c4384c67b00e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25576181-a5a4-4baf-a2b4-fbfe13fb9df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25576181-a5a4-4baf-a2b4-fbfe13fb9df6.jpg?1",
             "name": "Reef Worm",
             "text": "When Reef Worm dies, create a 3/3 blue Fish creature token with \"When this creature dies, create a 6/6 blue Whale creature token with \u2018\nWhen this creature dies, create a 9/9 blue Kraken creature token.'\"",
             "colours": [
@@ -10225,7 +10225,7 @@
         },
         {
             "id": "2ac29122-d69f-5f89-a02d-2894cd02d4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1cc39f-898c-4e92-82a0-a17606b60574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1cc39f-898c-4e92-82a0-a17606b60574.jpg?1",
             "name": "Shrieking Drake",
             "text": "Flying\nWhen Shrieking Drake enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -10259,7 +10259,7 @@
         },
         {
             "id": "e1980ca7-9176-5156-84d1-f6c48c7d9117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76878b19-2916-4f3f-bee5-20846bc9e2db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76878b19-2916-4f3f-bee5-20846bc9e2db.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards, put them into your graveyard, then shuffle.",
             "colours": [
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "66ae25d9-4d13-5e8b-bf3b-b35ac184dca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f087b1c-97e0-4379-a94d-beac53685314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f087b1c-97e0-4379-a94d-beac53685314.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "({PB} can be paid with either {B} or 2 life.)\nLifelink\nFor each {B} in a cost, you may pay 2 life rather than pay that mana.\nWhenever you cast a black spell, put a +1/+1 counter on K'rrik, Son of Yawgmoth.",
             "colours": [
@@ -10332,7 +10332,7 @@
         },
         {
             "id": "15ba2572-774e-59a8-ac6b-50df29a391d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9926d7-91b7-4067-b590-a0430bf68d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9926d7-91b7-4067-b590-a0430bf68d16.jpg?1",
             "name": "Nadier's Nightblade",
             "text": "Whenever a token you control leaves the battlefield, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "9d65a815-f542-5209-855a-0c3ee0b3d84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a402cff8-be7f-4473-b880-a6a2eedfda86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a402cff8-be7f-4473-b880-a6a2eedfda86.jpg?1",
             "name": "Ophiomancer",
             "text": "At the beginning of each upkeep, if you control no Snakes, create a 1/1 black Snake creature token with deathtouch.",
             "colours": [
@@ -10402,7 +10402,7 @@
         },
         {
             "id": "492ce888-c5fe-5a99-9fac-8915ea7aa5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa02b7d-db31-4924-b75e-eb02f332ca3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa02b7d-db31-4924-b75e-eb02f332ca3a.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -10436,7 +10436,7 @@
         },
         {
             "id": "58c3ebcf-a175-5a9d-834f-2669c8a6528b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83379f7f-3766-43f5-bd5e-e11ef9070ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83379f7f-3766-43f5-bd5e-e11ef9070ddb.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "3693c99f-1206-5a98-b0c7-3d4c2b7cd917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768daa5-41b0-49e1-b71a-63f733b4dc3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6768daa5-41b0-49e1-b71a-63f733b4dc3d.jpg?1",
             "name": "Cursed Mirror",
             "text": "{T}: Add {R}.\nAs Cursed Mirror enters the battlefield, you may have it become a copy of any creature on the battlefield until end of turn, except it has haste.",
             "colours": [
@@ -10502,7 +10502,7 @@
         },
         {
             "id": "962b0255-09ae-5989-a56e-ccd838b75238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9e213-992a-45f8-8c4d-3ca0250a2061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9e213-992a-45f8-8c4d-3ca0250a2061.jpg?1",
             "name": "Fledgling Dragon",
             "text": "Flying\nThreshold \u2014 As long as seven or more cards are in your graveyard, Fledgling Dragon gets +3/+3 and has \"{R}: Fledgling Dragon gets +1/+0 until end of turn.\"",
             "colours": [
@@ -10536,7 +10536,7 @@
         },
         {
             "id": "4450031a-e584-5022-a6be-97adebec35b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb2fe4-f0ef-4366-a568-c36b538f0196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb2fe4-f0ef-4366-a568-c36b538f0196.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -10576,7 +10576,7 @@
         },
         {
             "id": "332b83d9-1007-5f1f-a702-4c8b8a14bb2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173369d2-dc39-4bfe-a602-b47156570365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173369d2-dc39-4bfe-a602-b47156570365.jpg?1",
             "name": "Meltdown",
             "text": "Destroy each artifact with mana value X or less.",
             "colours": [
@@ -10610,7 +10610,7 @@
         },
         {
             "id": "66689ef5-7f41-5a21-a9de-6776b5b4f0b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb34a09-d911-49ac-ac39-fad7ee1b41ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb34a09-d911-49ac-ac39-fad7ee1b41ef.jpg?1",
             "name": "Meteoric Mace",
             "text": "Equipped creature gets +4/+0 and has trample.\nEquip {4}\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -10644,7 +10644,7 @@
         },
         {
             "id": "d911421a-1b46-55df-a34d-0bad4aeb8b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa9354d-3496-47f4-81c9-aead15efb8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa9354d-3496-47f4-81c9-aead15efb8bb.jpg?1",
             "name": "Annoyed Altisaur",
             "text": "Reach, trample\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
             "colours": [
@@ -10678,7 +10678,7 @@
         },
         {
             "id": "c356051d-8370-5302-b258-f6b966966110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f1a736-8b12-4f58-a031-bf1733f65c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f1a736-8b12-4f58-a031-bf1733f65c51.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -10710,7 +10710,7 @@
         },
         {
             "id": "969ca6ce-eb1b-50de-89ad-61b4f24c02b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb11921b-1b28-483f-a707-4de21a6daa31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb11921b-1b28-483f-a707-4de21a6daa31.jpg?1",
             "name": "Priest of Titania",
             "text": "{T}: Add {G} for each Elf on the battlefield.",
             "colours": [
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "4fd1a161-3b9c-535b-9b33-86e0e01529fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83036e21-21ea-4324-aa07-11757f80c417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83036e21-21ea-4324-aa07-11757f80c417.jpg?1",
             "name": "Sylvan Safekeeper",
             "text": "Sacrifice a land: Target creature you control gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -10782,7 +10782,7 @@
         },
         {
             "id": "9ad885a8-66c5-5027-97b6-04c225fdf99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237f5cc-2b9b-4929-9697-72078bac4c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237f5cc-2b9b-4929-9697-72078bac4c77.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "Return an Elf you control to its owner's hand: Untap target creature. Activate only once each turn.",
             "colours": [
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "6ceb0d71-e802-5513-819e-69a629809d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf3929c-957f-4ea2-a27d-7d53979844af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf3929c-957f-4ea2-a27d-7d53979844af.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -10862,7 +10862,7 @@
         },
         {
             "id": "f8ee5841-00a6-52bf-820d-a4fa29e18fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71c8c39-3fbb-4a42-9cf6-b3224f5a56fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71c8c39-3fbb-4a42-9cf6-b3224f5a56fc.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "1fac7252-fc9f-594f-b5f0-35236cbb181a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddf44fe-9e4e-42a6-a6f8-11ada3ce8a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddf44fe-9e4e-42a6-a6f8-11ada3ce8a94.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "442a8e90-e5ec-5187-8868-04fa899568b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d423365c-a32c-4060-b178-3221e3200387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d423365c-a32c-4060-b178-3221e3200387.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "14948afe-b927-50b3-8009-d6e2ad7226e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5d53cb-bf80-43b0-b839-b11a64ff4c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5d53cb-bf80-43b0-b839-b11a64ff4c1b.jpg?1",
             "name": "Junk Diver",
             "text": "Flying\nWhen Junk Diver dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -10998,7 +10998,7 @@
         },
         {
             "id": "4a726983-7b5f-56c0-a57d-5701e5e6e9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1225264f-b298-4b56-b208-c5da87bd6867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1225264f-b298-4b56-b208-c5da87bd6867.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -11028,7 +11028,7 @@
         },
         {
             "id": "52e5ee35-4b38-5538-9414-0dd23e3ef52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630febf5-58ff-4dab-a5a8-575ebc5435a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630febf5-58ff-4dab-a5a8-575ebc5435a6.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "972648aa-a151-5eb1-98c2-50f5a631d03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77850b2-6478-449e-bdb9-5b92650e3504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77850b2-6478-449e-bdb9-5b92650e3504.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -11088,7 +11088,7 @@
         },
         {
             "id": "293295e9-2eed-5aac-a289-1bbab90e5e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4589226-6072-409b-b598-ebd87f675a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4589226-6072-409b-b598-ebd87f675a6a.jpg?1",
             "name": "Urza's Incubator",
             "text": "As Urza's Incubator enters the battlefield, choose a creature type.\nCreature spells of the chosen type cost {2} less to cast.",
             "colours": [],
@@ -11116,7 +11116,7 @@
         },
         {
             "id": "35bfa538-a36b-54ce-8fed-5f69583ab426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace686ad-9e3f-41b3-b8eb-d1b6d45eb4e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace686ad-9e3f-41b3-b8eb-d1b6d45eb4e1.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone enters the battlefield tapped.\n{T}: Add {C}{C}.",
             "colours": [],
@@ -11144,7 +11144,7 @@
         },
         {
             "id": "b854fc5a-6cfd-55d5-8bfd-4ca0632a5b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c184406c-b22c-4b9b-9d3a-3e7b17efd8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c184406c-b22c-4b9b-9d3a-3e7b17efd8a0.jpg?1",
             "name": "Barbarian Ring",
             "text": "{T}: Add {R}. Barbarian Ring deals 1 damage to you.\nThreshold \u2014 {R}, {T}, Sacrifice Barbarian Ring: It deals 2 damage to any target. Activate only if seven or more cards are in your graveyard.",
             "colours": [],
@@ -11174,7 +11174,7 @@
         },
         {
             "id": "ca100dbd-60c0-517c-bf67-070a5bfa736d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb9c743-8793-48e6-bb3d-0d9b76fd1a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb9c743-8793-48e6-bb3d-0d9b76fd1a62.jpg?1",
             "name": "Cephalid Coliseum",
             "text": "",
             "colours": [],
@@ -11204,7 +11204,7 @@
         },
         {
             "id": "dbd87492-aa7e-590e-a529-4449a7fb0ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd51f8f0-779b-40bb-b65c-5907f816676e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd51f8f0-779b-40bb-b65c-5907f816676e.jpg?1",
             "name": "Deserted Temple",
             "text": "",
             "colours": [],
@@ -11232,7 +11232,7 @@
         },
         {
             "id": "4bdc2dfb-1f04-5057-9396-064434f61833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1d8a22-e730-4344-bba9-7c495500f065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1d8a22-e730-4344-bba9-7c495500f065.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "836961bd-fdae-5f9b-b943-199be94b1d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47f6d2-9f65-47a4-bfc4-15619befe53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b47f6d2-9f65-47a4-bfc4-15619befe53d.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "5d4eddee-41cf-5de9-a69a-1649d7c95506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecd4f-4cde-4d8f-a9b7-d7c6098be981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecd4f-4cde-4d8f-a9b7-d7c6098be981.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11335,7 +11335,7 @@
         },
         {
             "id": "05e950d6-90c3-5522-8bc8-4df81f6ef746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1ac28-ee04-4892-97ea-2cfdebbafcad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb1ac28-ee04-4892-97ea-2cfdebbafcad.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "e99a9359-e3fb-5f77-8e24-527eef208f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e3909e-e00a-4855-a0be-b1c538f89cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e3909e-e00a-4855-a0be-b1c538f89cb8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11413,7 +11413,7 @@
         },
         {
             "id": "4cecd9e2-c702-5c5c-959d-ed6a2d049d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9744bb5-9ad1-4287-9929-1146377d975b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9744bb5-9ad1-4287-9929-1146377d975b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11452,7 +11452,7 @@
         },
         {
             "id": "810f3de8-149d-5870-8479-570faf86428e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4c78b4-7178-4a60-ba22-086fb18146df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4c78b4-7178-4a60-ba22-086fb18146df.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11491,7 +11491,7 @@
         },
         {
             "id": "1965c503-85a6-5012-adef-42446aca4179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21a874-525e-4d11-bd8e-bc44918bec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21a874-525e-4d11-bd8e-bc44918bec40.jpg?1",
             "name": "Snow-Covered Wastes",
             "text": "",
             "colours": [],
@@ -11525,7 +11525,7 @@
         },
         {
             "id": "6af8cf39-4f25-5269-a0bd-155230f075e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0281fba-d771-4431-931f-920db2f14c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0281fba-d771-4431-931f-920db2f14c47.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11564,7 +11564,7 @@
         },
         {
             "id": "44fcee29-f798-5cc8-b898-abf763ee1e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bd857b-87d0-4a0f-9aac-0b1b661bb3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bd857b-87d0-4a0f-9aac-0b1b661bb3bd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11603,7 +11603,7 @@
         },
         {
             "id": "af5c4112-c59e-5417-a005-d9bdca6f9bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64daf0ac-678b-4683-9351-a6daf9c9f849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64daf0ac-678b-4683-9351-a6daf9c9f849.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11642,7 +11642,7 @@
         },
         {
             "id": "20aee50c-8e86-57c0-a0a4-85ca21b5a61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54250-74a9-4f77-bf60-bf13585c1a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f54250-74a9-4f77-bf60-bf13585c1a1b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11681,7 +11681,7 @@
         },
         {
             "id": "e6f5c0c1-64ca-5f4a-8a14-b5b820b34dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e672fc-673b-4476-b9cc-a395dc60b471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e672fc-673b-4476-b9cc-a395dc60b471.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11720,7 +11720,7 @@
         },
         {
             "id": "8a6f72b0-9feb-5cb0-82d8-2a4cf15d4bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537fb023-4352-406f-8435-51b37b99a6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537fb023-4352-406f-8435-51b37b99a6be.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11759,7 +11759,7 @@
         },
         {
             "id": "a8ebc342-480f-532a-8e34-0864e7067416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e36d5-3f1d-4423-a8db-f4c38898fa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e36d5-3f1d-4423-a8db-f4c38898fa30.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11798,7 +11798,7 @@
         },
         {
             "id": "661d2683-7a76-554c-9542-6e3cabd8d8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0928b-0469-4e3a-a8c8-1df26abb6707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b0928b-0469-4e3a-a8c8-1df26abb6707.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11837,7 +11837,7 @@
         },
         {
             "id": "8b911a1f-44f0-5054-b249-a0aef91cf933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac34881-de32-42c7-af60-f992638e1da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac34881-de32-42c7-af60-f992638e1da2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11876,7 +11876,7 @@
         },
         {
             "id": "f9752529-9629-5dc9-bb00-bb5b37a2ae98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6527c8ce-4a63-45f2-ae8e-c651e8713716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6527c8ce-4a63-45f2-ae8e-c651e8713716.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11915,7 +11915,7 @@
         },
         {
             "id": "4c28aba1-ba5f-505c-a913-d99bc9421268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae70f03f-cf60-418b-98e3-bc868e739656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae70f03f-cf60-418b-98e3-bc868e739656.jpg?1",
             "name": "Echoes of Eternity",
             "text": "If a triggered ability of a colorless spell you control or another colorless permanent you control triggers, that ability triggers an additional time.\nWhenever you cast a colorless spell, copy it. You may choose new targets for the copy.",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "5b6d2ae2-13ac-5718-b896-6d0475e54d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9500a456-1d7a-4463-975c-da0ad5af6baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9500a456-1d7a-4463-975c-da0ad5af6baa.jpg?1",
             "name": "Flare of Fortitude",
             "text": "You may sacrifice a nontoken white creature rather than pay this spell's mana cost.\nUntil end of turn, your life total can't change, and permanents you control gain hexproof and indestructible.",
             "colours": [
@@ -11983,7 +11983,7 @@
         },
         {
             "id": "854ea9b2-cdb1-52a5-8100-51b6450f43c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b8a75-9e31-4a44-95b8-c83b9a49646f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86b8a75-9e31-4a44-95b8-c83b9a49646f.jpg?1",
             "name": "Ocelot Pride",
             "text": "First strike, lifelink\nAscend\nAt the beginning of your end step, if you gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's blessing, for each token you control that entered the battlefield this turn, create a token that's a copy of it.",
             "colours": [
@@ -12020,7 +12020,7 @@
         },
         {
             "id": "8ccdce5a-2ec9-527c-bb57-2dce839edba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2706178a-8a9a-4e40-b716-6aef4185ca39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2706178a-8a9a-4e40-b716-6aef4185ca39.jpg?1",
             "name": "Orim's Chant",
             "text": "Kicker {W}\nTarget player can't cast spells this turn. If this spell was kicked, creatures can't attack this turn.",
             "colours": [
@@ -12054,7 +12054,7 @@
         },
         {
             "id": "2d939f00-ea40-5c54-aaa9-a170bf8db1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8e1c7-031f-47cd-b854-ea2b746bd6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8e1c7-031f-47cd-b854-ea2b746bd6c3.jpg?1",
             "name": "White Orchid Phantom",
             "text": "Flying, first strike\nWhen White Orchid Phantom enters the battlefield, destroy up to one target nonbasic land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -12092,7 +12092,7 @@
         },
         {
             "id": "e11e5eac-89d4-5238-839f-bc3669f7ee31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e3a66-d59e-43f8-9ce1-054680f5d46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e3a66-d59e-43f8-9ce1-054680f5d46b.jpg?1",
             "name": "Wrath of the Skies",
             "text": "You get X {E}, then you may pay any amount of {E}. Destroy each artifact, creature, and enchantment with mana value less than or equal to the amount of {E} paid this way.",
             "colours": [
@@ -12127,7 +12127,7 @@
         },
         {
             "id": "6af881bf-d05d-5fff-a6fa-9a073912aa7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746533fe-7fe2-4985-8655-9aca4b08b419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746533fe-7fe2-4985-8655-9aca4b08b419.jpg?1",
             "name": "Flare of Denial",
             "text": "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -12162,7 +12162,7 @@
         },
         {
             "id": "8b511304-bee6-54f6-b72f-c7e0c3f0fc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eccf31d-869d-4003-a92b-71b4f4b479ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eccf31d-869d-4003-a92b-71b4f4b479ee.jpg?1",
             "name": "Strix Serenade",
             "text": "Counter target artifact, creature, or planeswalker spell. Its controller creates a 2/2 blue Bird creature token with flying.",
             "colours": [
@@ -12196,7 +12196,7 @@
         },
         {
             "id": "55bb0bea-e978-5f94-bac8-a3e862bd0f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80423f5-98b1-47be-bcc1-bd88848c2fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80423f5-98b1-47be-bcc1-bd88848c2fc7.jpg?1",
             "name": "Ugin's Binding",
             "text": "Devoid\nReturn target nonland permanent you don't control to its owner's hand.\nWhenever you cast a colorless spell with mana value 7 or greater, you may exile Ugin's Binding from your graveyard. When you do, return each nonland permanent you don't control to its owner's hand.",
             "colours": [],
@@ -12228,7 +12228,7 @@
         },
         {
             "id": "e31198cf-eea9-53f3-816e-4a7083e1c2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb819762-02e8-4d32-8245-c44b809c34bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb819762-02e8-4d32-8245-c44b809c34bb.jpg?1",
             "name": "Volatile Stormdrake",
             "text": "Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters the battlefield, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
             "colours": [
@@ -12265,7 +12265,7 @@
         },
         {
             "id": "005a3653-7584-5f6d-a1a5-c5a1c847fb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb26867-8b4d-4535-98d4-829d702197a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb26867-8b4d-4535-98d4-829d702197a4.jpg?1",
             "name": "Chthonian Nightmare",
             "text": "When Chthonian Nightmare enters the battlefield, you get {E}{E}{E}.\nPay X {E}, Sacrifice a creature, Return Chthonian Nightmare to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -12300,7 +12300,7 @@
         },
         {
             "id": "5739f3f7-97c8-5dbb-aa9e-3f16ad5722b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1822be1-9316-40c7-871d-25b0a5dea755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1822be1-9316-40c7-871d-25b0a5dea755.jpg?1",
             "name": "Flare of Malice",
             "text": "You may sacrifice a nontoken black creature rather than pay this spell's mana cost.\nEach opponent sacrifices a creature or planeswalker with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "57aebde0-6b38-52f0-a898-152ff7bc9011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18591d-a8e2-49ea-b31e-7358e4143024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c18591d-a8e2-49ea-b31e-7358e4143024.jpg?1",
             "name": "Warren Soultrader",
             "text": "Pay 1 life, Sacrifice another creature: Create a Treasure token.",
             "colours": [
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "1e1e3ea0-d813-52c3-ad62-7d56a1d7aab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348dd804-315c-479a-9605-3ab9ae60aac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348dd804-315c-479a-9605-3ab9ae60aac2.jpg?1",
             "name": "Flare of Duplication",
             "text": "You may sacrifice a nontoken red creature rather than pay this spell's mana cost.\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -12409,7 +12409,7 @@
         },
         {
             "id": "318a3d96-9d64-5dbf-8aa3-7d6c2014aff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb8272-e60f-4aa1-8f98-6110715a78fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bb8272-e60f-4aa1-8f98-6110715a78fa.jpg?1",
             "name": "Party Thrasher",
             "text": "Noncreature spells you cast from exile have convoke.\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -12447,7 +12447,7 @@
         },
         {
             "id": "de5a9750-6736-5548-a213-2689fc432a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a64a5c4-ebae-472b-8f90-dcdd8ab8bc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a64a5c4-ebae-472b-8f90-dcdd8ab8bc26.jpg?1",
             "name": "Powerbalance",
             "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, you may cast that card without paying its mana cost if the two spells have the same mana value.",
             "colours": [
@@ -12482,7 +12482,7 @@
         },
         {
             "id": "d0742b02-9035-5f5f-bf25-e3e19fedc497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a00e86-39c0-4c8b-8285-ab527f2a0c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a00e86-39c0-4c8b-8285-ab527f2a0c57.jpg?1",
             "name": "Wheel of Potential",
             "text": "You get {E}{E}{E}, then you may pay X {E}.\nEach player may exile their hand and draw X cards. If X is 7 or more, you may play cards you own exiled this way until the end of your next turn.",
             "colours": [
@@ -12517,7 +12517,7 @@
         },
         {
             "id": "ddd67ecb-36f0-5e1f-91bf-06d7413cad09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004bbc84-b57b-4393-889e-dff95e8f334c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004bbc84-b57b-4393-889e-dff95e8f334c.jpg?1",
             "name": "Birthing Ritual",
             "text": "At the beginning of your end step, if you control a creature, look at the top seven cards of your library. Then you may sacrifice a creature. If you do, you may put a creature card with mana value X or less from among those cards onto the battlefield, where X is 1 plus the sacrificed creature's mana value. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12551,7 +12551,7 @@
         },
         {
             "id": "b71d3efd-efe2-519c-b4b2-9c2d0bbc2bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719cbb26-54a9-402f-9043-e177552fd1c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719cbb26-54a9-402f-9043-e177552fd1c0.jpg?1",
             "name": "Flare of Cultivation",
             "text": "You may sacrifice a nontoken green creature rather than pay this spell's mana cost.\nSearch your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "5e078ee2-b98a-556a-af18-1d762de54b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f718cfb2-a30b-424c-8e95-0e3daa03d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f718cfb2-a30b-424c-8e95-0e3daa03d6b7.jpg?1",
             "name": "Primal Prayers",
             "text": "When Primal Prayers enters the battlefield, you get {E}{E}.\nYou may cast creature spells with mana value 3 or less by paying {E} rather than paying their mana costs. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -12621,7 +12621,7 @@
         },
         {
             "id": "c8d4681b-aed8-50c9-801e-1e2894bc4bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511bfe7-b107-4ec5-b363-f718c19d9579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f511bfe7-b107-4ec5-b363-f718c19d9579.jpg?1",
             "name": "Sowing Mycospawn",
             "text": "Devoid\nKicker {1}{C}\nWhen you cast this spell, search your library for a land card, put it onto the battlefield, then shuffle.\nWhen you cast this spell, if it was kicked, exile target land.",
             "colours": [],
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "d622dfb1-5d67-521e-9640-42f76e92bd0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf723c91-e3ae-4a71-93b2-65d05bfa9b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf723c91-e3ae-4a71-93b2-65d05bfa9b60.jpg?1",
             "name": "Springheart Nantuko",
             "text": "Bestow {1}{G}\nEnchanted creature gets +1/+1.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may pay {1}{G} if Springheart Nantuko is attached to a creature you control. If you do, create a token that's a copy of that creature. If you didn't create a token this way, create a 1/1 green Insect creature token.",
             "colours": [
@@ -12694,7 +12694,7 @@
         },
         {
             "id": "fafd8310-5b76-55fd-ae37-0650c27c5d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771d4911-3dc8-4dc7-b2c9-e2158ee394bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771d4911-3dc8-4dc7-b2c9-e2158ee394bf.jpg?1",
             "name": "Abstruse Appropriation",
             "text": "Devoid\nExile target nonland permanent. You may cast that card for as long as it remains exiled, and you may spend colorless mana as though it were mana of any color to cast that spell.",
             "colours": [],
@@ -12727,7 +12727,7 @@
         },
         {
             "id": "662bffaa-0bbc-56bf-a700-3929ebcbc54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef099f25-2b0b-4028-8490-fbc859e35f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef099f25-2b0b-4028-8490-fbc859e35f6c.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -12772,7 +12772,7 @@
         },
         {
             "id": "af898970-7ac2-5550-85d9-9f951cc459cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d2cae8-9eb3-4bb2-878b-1a9032445e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d2cae8-9eb3-4bb2-878b-1a9032445e4f.jpg?1",
             "name": "Psychic Frog",
             "text": "Whenever Psychic Frog deals combat damage to a player or planeswalker, draw a card.\nDiscard a card: Put a +1/+1 counter on Psychic Frog.\nExile three cards from your graveyard: Psychic Frog gains flying until end of turn.",
             "colours": [
@@ -12811,7 +12811,7 @@
         },
         {
             "id": "a862116c-4ca7-5b5c-912f-713bcf038bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d58d50-875c-498e-bdde-ffda391ce839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d58d50-875c-498e-bdde-ffda391ce839.jpg?1",
             "name": "Emerald Medallion",
             "text": "Green spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12841,7 +12841,7 @@
         },
         {
             "id": "84409f95-8786-54e3-ad66-181382c0ce40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b25772-8512-4270-851b-289cd182d819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b25772-8512-4270-851b-289cd182d819.jpg?1",
             "name": "Jet Medallion",
             "text": "Black spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12871,7 +12871,7 @@
         },
         {
             "id": "9bbe43eb-84a7-5ceb-9d28-db4921d544fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bce47b-ba52-4a6c-a0ed-f533489a077c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bce47b-ba52-4a6c-a0ed-f533489a077c.jpg?1",
             "name": "Pearl Medallion",
             "text": "White spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12901,7 +12901,7 @@
         },
         {
             "id": "4e09bba5-c256-5eef-ba70-65e050491ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3935034b-611f-4ce7-9bba-14c3b31eb597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3935034b-611f-4ce7-9bba-14c3b31eb597.jpg?1",
             "name": "Ruby Medallion",
             "text": "Red spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12931,7 +12931,7 @@
         },
         {
             "id": "4b6a0726-09a4-524f-82e8-fb07a865d216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec271e4-1813-4ee7-bfd5-5a0c39d2d25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec271e4-1813-4ee7-bfd5-5a0c39d2d25d.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Blue spells you cast cost {1} less to cast.",
             "colours": [],
@@ -12961,7 +12961,7 @@
         },
         {
             "id": "48d4f921-42af-5f7e-bd21-e1bf4d6ddeaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472905ac-1eb9-4951-8180-b8c35fbab3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472905ac-1eb9-4951-8180-b8c35fbab3d7.jpg?1",
             "name": "Archway of Innovation",
             "text": "Archway of Innovation enters the battlefield tapped unless you control an Island.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn has improvise.",
             "colours": [],
@@ -12993,7 +12993,7 @@
         },
         {
             "id": "25f09039-7008-58cf-bb2e-d05daed7e8a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7d07bb-b875-4a6d-8b87-4187e823af75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7d07bb-b875-4a6d-8b87-4187e823af75.jpg?1",
             "name": "Arena of Glory",
             "text": "Arena of Glory enters the battlefield tapped unless you control a Mountain.\n{T}: Add {R}.\n{R}, {T}, Exert Arena of Glory: Add {R}{R}. If that mana is spent on a creature spell, it gains haste until end of turn.",
             "colours": [],
@@ -13025,7 +13025,7 @@
         },
         {
             "id": "8e889e5b-60f3-55e1-805c-40407bae7cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f941fee-aea1-4afb-ada4-7bbab39c2f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f941fee-aea1-4afb-ada4-7bbab39c2f6c.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13057,7 +13057,7 @@
         },
         {
             "id": "901b3776-c39b-5d7e-be54-59c93bc3c7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996ab8e-5fa4-4d39-8c7b-12e4258bf8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7996ab8e-5fa4-4d39-8c7b-12e4258bf8a9.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13089,7 +13089,7 @@
         },
         {
             "id": "2f9cfbee-a919-5b2c-b6c5-e55946ce281b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ae1a74-cbff-4d36-bfee-d1b6494114b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ae1a74-cbff-4d36-bfee-d1b6494114b4.jpg?1",
             "name": "Monumental Henge",
             "text": "Monumental Henge enters the battlefield tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Look at the top five cards of your library. You may reveal a historic card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -13121,7 +13121,7 @@
         },
         {
             "id": "01d3d6d0-8b5a-5900-9c25-2a4269bd5c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f22229-95d4-4a84-a581-e23816db2494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f22229-95d4-4a84-a581-e23816db2494.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "1c72c43a-daf6-5ede-87e6-275745b9b0eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c221d8-fbe4-4901-9f7b-1d04e08b261e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c221d8-fbe4-4901-9f7b-1d04e08b261e.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13187,7 +13187,7 @@
         },
         {
             "id": "287a186a-4e78-57bc-ab11-43ef54cd4607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e97b5-6750-4fae-8481-1244e311da7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e97b5-6750-4fae-8481-1244e311da7e.jpg?1",
             "name": "Shifting Woodland",
             "text": "Shifting Woodland enters the battlefield tapped unless you control a Forest.\n{T}: Add {G}.\nDelirium \u2014 {2}{G}{G}: Shifting Woodland becomes a copy of target permanent card in your graveyard until end of turn. Activate only if there are four or more card types among cards in your graveyard.",
             "colours": [],
@@ -13219,7 +13219,7 @@
         },
         {
             "id": "396422d1-4909-55e6-bc72-aaf81ef7df3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33535dbf-203b-44c9-be20-67fafa0927ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33535dbf-203b-44c9-be20-67fafa0927ee.jpg?1",
             "name": "Spymaster's Vault",
             "text": "Spymaster's Vault enters the battlefield tapped unless you control a Swamp.\n{T}: Add {B}.\n{B}, {T}: Target creature you control connives X, where X is the number of creatures that died this turn.",
             "colours": [],
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "bfe23197-bffa-5b86-a66b-6e7921da8c3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1506f3-5121-4b83-b199-6594b41e7883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1506f3-5121-4b83-b199-6594b41e7883.jpg?1",
             "name": "Ugin's Labyrinth",
             "text": "Imprint \u2014 When Ugin's Labyrinth enters the battlefield, you may exile a colorless card with mana value 7 or greater from your hand.\n{T}: Add {C}. If a card is exiled with Ugin's Labyrinth, add {C}{C} instead.\n{T}: Return the exiled card to its owner's hand.",
             "colours": [],
@@ -13281,7 +13281,7 @@
         },
         {
             "id": "03c291b0-855f-5e21-a871-1bed3ab237d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26343f80-4d60-407a-a44a-ee6295d2e5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26343f80-4d60-407a-a44a-ee6295d2e5ec.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13313,7 +13313,7 @@
         },
         {
             "id": "e0818b53-9ea9-56ba-900e-1282ed05b80e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fa77b-d103-446f-95d0-e4b11dfac05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492fa77b-d103-446f-95d0-e4b11dfac05f.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -13345,7 +13345,7 @@
         },
         {
             "id": "6451c9d5-c3d4-52c9-89a1-f14aea416831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49fd832-1185-4eb5-8bd3-bccc8835dbee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49fd832-1185-4eb5-8bd3-bccc8835dbee.jpg?1",
             "name": "Herigast, Erupting Nullkite",
             "text": "Emerge {6}{R}{R}\nWhen you cast this spell, you may exile your hand. If you do, draw three cards.\nFlying\nEach creature spell you cast has emerge. The emerge cost is equal to its mana cost.",
             "colours": [],
@@ -13383,7 +13383,7 @@
         },
         {
             "id": "4acb0149-3207-5843-a701-dd53b651f3f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd6f74-a3bb-4d12-9dbe-1d0a4dde85cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41dd6f74-a3bb-4d12-9dbe-1d0a4dde85cb.jpg?1",
             "name": "Pearl-Ear, Imperial Advisor",
             "text": "Lifelink\nEnchantment spells you cast have affinity for Auras.\nWhenever you cast an Aura spell that targets a modified permanent you control, draw a card.",
             "colours": [
@@ -13423,7 +13423,7 @@
         },
         {
             "id": "bd9efd3b-4008-5667-beeb-830d2aefa9f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95505d46-fc4f-4e2d-8e08-380d392b74a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95505d46-fc4f-4e2d-8e08-380d392b74a4.jpg?1",
             "name": "Phelia, Exuberant Shepherd",
             "text": "Flash\nWhenever Phelia, Exuberant Shepherd attacks, exile up to one other target nonland permanent. At the beginning of the next end step, return that card to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on Phelia.",
             "colours": [
@@ -13462,7 +13462,7 @@
         },
         {
             "id": "be1aa573-db05-50b0-8352-f8493ab7ce7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a325a92-522b-4f2d-a3dd-2a9eb56d1478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a325a92-522b-4f2d-a3dd-2a9eb56d1478.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "Lifelink\nFor each {B} in a cost, you may pay 2 life rather than pay that mana.\nWhenever you cast a black spell, put a +1/+1 counter on K'rrik, Son of Yawgmoth.",
             "colours": [
@@ -13503,7 +13503,7 @@
         },
         {
             "id": "c1b80421-aa3d-544a-9971-c5dcf813e6fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68425ba0-7216-46aa-a9c3-c552e4a44203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68425ba0-7216-46aa-a9c3-c552e4a44203.jpg?1",
             "name": "Shilgengar, Sire of Famine",
             "text": "Flying\nSacrifice another creature: Create a Blood token. If you sacrificed an Angel this way, create a number of Blood tokens equal to its toughness instead.\n{WB}{WB}{WB}, Sacrifice six Blood tokens: Return each creature card from your graveyard to the battlefield with a finality counter on it. Those creatures are Vampires in addition to their other types.",
             "colours": [
@@ -13544,7 +13544,7 @@
         },
         {
             "id": "4da901a0-b94a-5985-ba9b-8adc300f93b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95089b00-b159-4c95-952d-bc29e463a1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95089b00-b159-4c95-952d-bc29e463a1e7.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -13585,7 +13585,7 @@
         },
         {
             "id": "748ea911-1a47-5f51-9967-cf489a509c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac72836-a656-4bdb-adc8-04cf20b77aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac72836-a656-4bdb-adc8-04cf20b77aba.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "cc681541-4cd7-5143-ab72-dca8aecb818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86029eaa-b5d3-40ba-8eba-6e6002ea4325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86029eaa-b5d3-40ba-8eba-6e6002ea4325.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -13666,7 +13666,7 @@
         },
         {
             "id": "bffd593c-b54a-59fa-9ce2-27a5a51534c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ea0c62-a9b3-4e8f-9ede-1f0122149737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ea0c62-a9b3-4e8f-9ede-1f0122149737.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace.",
             "colours": [
@@ -13706,7 +13706,7 @@
         },
         {
             "id": "404835ed-5804-5cdb-9e07-48ee0b0fed54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b5403e-7d57-4696-a6dc-c339c1969925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b5403e-7d57-4696-a6dc-c339c1969925.jpg?1",
             "name": "Arna Kenner\u00fcd, Skycaptain",
             "text": "Flying, lifelink\nWard\u2014\nDiscard a card.\nWhenever a modified creature you control attacks, double the number of each kind of counter on it. Then for each nontoken permanent attached to it, create a token that's a copy of that permanent attached to that creature.",
             "colours": [
@@ -13750,7 +13750,7 @@
         },
         {
             "id": "3abf92cb-d769-592f-8a6b-0a8975d88b85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e5d5a-01cc-4d01-88fb-ab556e2383cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468e5d5a-01cc-4d01-88fb-ab556e2383cb.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -13796,7 +13796,7 @@
         },
         {
             "id": "9d8bc666-813a-5912-8b8a-8730f7a42d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853b432-e5cc-4637-b496-5e9e4620727f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853b432-e5cc-4637-b496-5e9e4620727f.jpg?1",
             "name": "Genku, Future Shaper",
             "text": "Whenever another nontoken permanent you control leaves the battlefield, choose one that hasn't been chosen this turn. Create a creature token with those characteristics.\n\u2022 2/2 white Fox with vigilance.\n\u2022 1/2 blue Moonfolk with flying.\n\u2022 1/1 black Rat with lifelink.\n{3}{W}{U}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -13838,7 +13838,7 @@
         },
         {
             "id": "04c1697b-ff03-56d0-ac25-a417a9865132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26585ae8-5f96-4e6a-a008-752aacce433a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26585ae8-5f96-4e6a-a008-752aacce433a.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -13880,7 +13880,7 @@
         },
         {
             "id": "bd222010-1fb4-5eb1-a280-53848c31c9e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7782562f-cd13-4770-930c-95ad4263f24d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7782562f-cd13-4770-930c-95ad4263f24d.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -13925,7 +13925,7 @@
         },
         {
             "id": "7ef7a802-3e3f-5060-b151-4bf455e93dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0083d7-508a-4206-a4bd-72bb009626ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0083d7-508a-4206-a4bd-72bb009626ce.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "fb97780c-d4f7-553c-a6e6-b5e48a1766eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8281df8a-2fde-454a-813c-d9f86bb35d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8281df8a-2fde-454a-813c-d9f86bb35d36.jpg?1",
             "name": "Nadu, Winged Wisdom",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand. This ability triggers only twice each turn.\"",
             "colours": [
@@ -14009,7 +14009,7 @@
         },
         {
             "id": "63abefdb-0025-59ab-9efd-8f78bb3b9c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c5c8e0-0744-4bd3-a5a1-ca71c287569b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c5c8e0-0744-4bd3-a5a1-ca71c287569b.jpg?1",
             "name": "The Necrobloom",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 0/1 green Plant creature token. If you control seven or more lands with different names, create a 2/2 black Zombie creature token instead.\nLand cards in your graveyard have dredge 2.",
             "colours": [
@@ -14052,7 +14052,7 @@
         },
         {
             "id": "030f5963-dd91-58fb-a310-3f7b257f67cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08742bb-d980-4912-a2fd-b8edac1fe554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08742bb-d980-4912-a2fd-b8edac1fe554.jpg?1",
             "name": "Phlage, Titan of Fire's Fury",
             "text": "When Phlage enters the battlefield, sacrifice it unless it escaped.\nWhenever Phlage enters the battlefield or attacks, it deals 3 damage to any target and you gain 3 life.\nEscape\u2014{R}{R}{W}{W}, Exile five other cards from your graveyard.",
             "colours": [
@@ -14094,7 +14094,7 @@
         },
         {
             "id": "244de6c9-97c9-5b0f-a054-ee3b2f64266b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5522e2-5182-4ce3-8690-3b4f133b1e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5522e2-5182-4ce3-8690-3b4f133b1e6e.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "d34e8e6e-c9a8-5783-ad82-d4ccbf3feecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77f5c3-b027-416b-8d9c-1b96c7bd504e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77f5c3-b027-416b-8d9c-1b96c7bd504e.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -14174,7 +14174,7 @@
         },
         {
             "id": "14c848d0-7d9f-5257-a1ed-d17fe8851070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08c318-f57e-4557-a6ce-8fa23a732b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff08c318-f57e-4557-a6ce-8fa23a732b05.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "",
             "colours": [],
@@ -14210,7 +14210,7 @@
         },
         {
             "id": "6a5266da-e429-5ff4-839a-83735edad4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bace1-28d2-4429-ae8d-b867c202afbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bace1-28d2-4429-ae8d-b867c202afbd.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -14246,7 +14246,7 @@
         },
         {
             "id": "eb635d64-3e6a-5bb6-9801-3956121fedce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339f83ca-4f46-4246-be23-5ca4add31d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339f83ca-4f46-4246-be23-5ca4add31d81.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -14282,7 +14282,7 @@
         },
         {
             "id": "9d0586da-121d-5a2c-89cd-dfda9f5b70bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5bc75-4d04-4a8e-9830-0f0c73f5a39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa5bc75-4d04-4a8e-9830-0f0c73f5a39f.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -14319,7 +14319,7 @@
         },
         {
             "id": "21d71927-6ebe-58b4-b15d-cad94203159e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca489d-a1e3-4a39-8c83-c2836ee0a240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca489d-a1e3-4a39-8c83-c2836ee0a240.jpg?1",
             "name": "It That Heralds the End",
             "text": "Colorless spells you cast with mana value 7 or greater cost {1} less to cast.\nOther colorless creatures you control get +1/+1.",
             "colours": [],
@@ -14352,7 +14352,7 @@
         },
         {
             "id": "43f8d9c8-43bf-5dff-a1c0-e92bbb45513c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d08a8-32ed-423e-aa8a-51c70025592c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d08a8-32ed-423e-aa8a-51c70025592c.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -14388,7 +14388,7 @@
         },
         {
             "id": "f9361ae7-2454-510f-bcc1-63e1aff0af1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7114c9c8-5370-42e0-8aaf-dc05e2422a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7114c9c8-5370-42e0-8aaf-dc05e2422a76.jpg?1",
             "name": "Null Elemental Blast",
             "text": "Choose one \u2014\n\u2022 Counter target multicolored spell.\n\u2022 Destroy target multicolored permanent.",
             "colours": [],
@@ -14418,7 +14418,7 @@
         },
         {
             "id": "b4dea9c6-8f0b-52d1-9c7a-c480d434b044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d5409-0375-4a77-8019-ddaade86e144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d5409-0375-4a77-8019-ddaade86e144.jpg?1",
             "name": "Nulldrifter",
             "text": "When you cast this spell, draw two cards.\nFlying, annihilator 1\nEvoke {2}{U}",
             "colours": [],
@@ -14453,7 +14453,7 @@
         },
         {
             "id": "777fbf2f-1c66-5f61-9190-a0936c30c4f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d577b0a9-b680-4dd2-9df2-865bab48a318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d577b0a9-b680-4dd2-9df2-865bab48a318.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -14489,7 +14489,7 @@
         },
         {
             "id": "b5ea1e5e-6625-5404-b771-41f9a120c9cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b1bd25-bab3-408d-bdc5-7fd4d2dd2e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b1bd25-bab3-408d-bdc5-7fd4d2dd2e83.jpg?1",
             "name": "Charitable Levy",
             "text": "Noncreature spells cost {1} more to cast.\nWhenever a player casts a noncreature spell, put a collection counter on Charitable Levy. Then if there are three or more collection counters on it, sacrifice it. If you do, draw a card, then you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -14523,7 +14523,7 @@
         },
         {
             "id": "9e2640e7-aa42-57dd-a0e5-16d71d0b5cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9ba97a-9eda-465a-891d-f3be9c2abeb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9ba97a-9eda-465a-891d-f3be9c2abeb2.jpg?1",
             "name": "Flare of Fortitude",
             "text": "You may sacrifice a nontoken white creature rather than pay this spell's mana cost.\nUntil end of turn, your life total can't change, and permanents you control gain hexproof and indestructible.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "18838485-9688-5be9-8db8-4102dd2ccf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51015ef-184c-44bb-b3d2-c74a0549efac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51015ef-184c-44bb-b3d2-c74a0549efac.jpg?1",
             "name": "Jolted Awake",
             "text": "Choose up to one target artifact or creature card in your graveyard. You get {E}{E}. Then you may pay an amount of {E} equal to that card's mana value. If you do, return it from your graveyard to the battlefield.\nCycling {2}",
             "colours": [
@@ -14593,7 +14593,7 @@
         },
         {
             "id": "7a85ce1e-8a3f-5fe5-b9a1-c206016222ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7ef64-9223-4c5d-bb2f-8a9f033729ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae7ef64-9223-4c5d-bb2f-8a9f033729ec.jpg?1",
             "name": "Metastatic Evangel",
             "text": "Whenever another nontoken creature enters the battlefield under your control, proliferate.",
             "colours": [
@@ -14631,7 +14631,7 @@
         },
         {
             "id": "8867cfa0-bc32-5d41-b28d-1be12c194c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2ff4-8b8c-410b-8636-7e6a539fd291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2ff4-8b8c-410b-8636-7e6a539fd291.jpg?1",
             "name": "Ocelot Pride",
             "text": "First strike, lifelink\nAscend\nAt the beginning of your end step, if you gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's blessing, for each token you control that entered the battlefield this turn, create a token that's a copy of it.",
             "colours": [
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "c8928311-e2ab-53bb-b34d-13d6219a5204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6920d07-f406-4458-9446-209202c1d9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6920d07-f406-4458-9446-209202c1d9ca.jpg?1",
             "name": "Recruiter of the Guard",
             "text": "When Recruiter of the Guard enters the battlefield, you may search your library for a creature card with toughness 2 or less, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -14705,7 +14705,7 @@
         },
         {
             "id": "d57cad80-612d-594a-abb3-66f4275c2bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eca3c-8718-4890-ac1b-f267deb55836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109eca3c-8718-4890-ac1b-f267deb55836.jpg?1",
             "name": "White Orchid Phantom",
             "text": "Flying, first strike\nWhen White Orchid Phantom enters the battlefield, destroy up to one target nonbasic land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "b8945f73-69a9-5f95-a75e-8109d87fc343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7325714a-bd27-4215-9826-3785089ffa23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7325714a-bd27-4215-9826-3785089ffa23.jpg?1",
             "name": "Wrath of the Skies",
             "text": "You get X {E}, then you may pay any amount of {E}. Destroy each artifact, creature, and enchantment with mana value less than or equal to the amount of {E} paid this way.",
             "colours": [
@@ -14778,7 +14778,7 @@
         },
         {
             "id": "a71140f3-cdad-5671-875c-2811b5c5630a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb10f7af-8c6d-4228-8600-5b1de3e3abcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb10f7af-8c6d-4228-8600-5b1de3e3abcb.jpg?1",
             "name": "Aether Spike",
             "text": "Choose target spell. You get {E}{E}, then you may pay any amount of {E}. Counter that spell unless its controller pays {1} for each {E} paid this way.",
             "colours": [
@@ -14812,7 +14812,7 @@
         },
         {
             "id": "066ded7e-5c33-5d9f-af26-55238955aa81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6997b-a8b1-4655-a9b0-5f9a305ca96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a6997b-a8b1-4655-a9b0-5f9a305ca96e.jpg?1",
             "name": "Brainsurge",
             "text": "Draw four cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -14846,7 +14846,7 @@
         },
         {
             "id": "aa68a9dd-c104-5e66-929c-5cbd488c9b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149c119-83ea-46f5-9e22-33a674ddddb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149c119-83ea-46f5-9e22-33a674ddddb6.jpg?1",
             "name": "Flare of Denial",
             "text": "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -14881,7 +14881,7 @@
         },
         {
             "id": "cdf5e753-9dfc-527d-97b1-32f8c23e7b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974f71e8-2c42-4267-b0b5-5826930e4f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974f71e8-2c42-4267-b0b5-5826930e4f1f.jpg?1",
             "name": "Kappa Cannoneer",
             "text": "Improvise\nWard {4}\nWhenever Kappa Cannoneer or another artifact enters the battlefield under your control, put a +1/+1 counter on Kappa Cannoneer and it can't be blocked this turn.",
             "colours": [
@@ -14919,7 +14919,7 @@
         },
         {
             "id": "f8e8afeb-4cb6-5a81-9399-38cca00d1c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57b700d-2a28-40b5-a6da-1a967c90a601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57b700d-2a28-40b5-a6da-1a967c90a601.jpg?1",
             "name": "Shadow of the Second Sun",
             "text": "Enchant player\nAt the beginning of enchanted player's postcombat main phase, there is an additional beginning phase after this phase. (The end step happens after the added untap, upkeep, and draw steps.)",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "2de41d02-6d3b-54d7-8068-c44414943b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad6d5d0-2b45-4d89-8335-f238f6454201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ad6d5d0-2b45-4d89-8335-f238f6454201.jpg?1",
             "name": "Tune the Narrative",
             "text": "Draw a card. You get {E}{E}.",
             "colours": [
@@ -14989,7 +14989,7 @@
         },
         {
             "id": "5791aafb-0caa-5fea-9ab8-3629568e266d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5fb32c-6348-4d39-8d74-b345452b3875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5fb32c-6348-4d39-8d74-b345452b3875.jpg?1",
             "name": "Volatile Stormdrake",
             "text": "Flying, hexproof from activated and triggered abilities\nWhen Volatile Stormdrake enters the battlefield, exchange control of Volatile Stormdrake and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
             "colours": [
@@ -15026,7 +15026,7 @@
         },
         {
             "id": "3fde5e91-38df-54c8-acbc-648414d48e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a63029-1fb2-4fdc-bca9-0a530c7b42d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a63029-1fb2-4fdc-bca9-0a530c7b42d9.jpg?1",
             "name": "Accursed Marauder",
             "text": "When Accursed Marauder enters the battlefield, each player sacrifices a nontoken creature.",
             "colours": [
@@ -15064,7 +15064,7 @@
         },
         {
             "id": "700059b6-6a24-502c-8041-a24f91ee0924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cbd637-30d1-4c3c-95ce-b6c6f9248d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cbd637-30d1-4c3c-95ce-b6c6f9248d15.jpg?1",
             "name": "Chthonian Nightmare",
             "text": "When Chthonian Nightmare enters the battlefield, you get {E}{E}{E}.\nPay X {E}, Sacrifice a creature, Return Chthonian Nightmare to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -15099,7 +15099,7 @@
         },
         {
             "id": "fed11c59-2cb4-52eb-9fdc-123b286ea2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2803b9-ad7b-4f0e-b622-2b8e84cdd591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2803b9-ad7b-4f0e-b622-2b8e84cdd591.jpg?1",
             "name": "Consuming Corruption",
             "text": "Consuming Corruption deals X damage to target creature or planeswalker and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -15133,7 +15133,7 @@
         },
         {
             "id": "7f20a86e-9697-5bd3-b399-a6da80fee109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb9479-d019-4ffe-a508-1db81a28847f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bbb9479-d019-4ffe-a508-1db81a28847f.jpg?1",
             "name": "Flare of Malice",
             "text": "You may sacrifice a nontoken black creature rather than pay this spell's mana cost.\nEach opponent sacrifices a creature or planeswalker with the greatest mana value among creatures and planeswalkers they control.",
             "colours": [
@@ -15168,7 +15168,7 @@
         },
         {
             "id": "9f4b26df-3d55-5816-9ded-36034736131e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77251806-c2b6-448c-a95e-a1943ca0bfd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77251806-c2b6-448c-a95e-a1943ca0bfd8.jpg?1",
             "name": "Grim Servant",
             "text": "Menace\nWhen Grim Servant enters the battlefield, search your library for a card with mana value less than or equal to your devotion to black, reveal it, put it into your hand, then shuffle. You lose 3 life.",
             "colours": [
@@ -15205,7 +15205,7 @@
         },
         {
             "id": "2e99c5d7-b531-5df1-b573-15f031dc4f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b5a3dd-0b5a-434e-afee-a83b0279fd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b5a3dd-0b5a-434e-afee-a83b0279fd15.jpg?1",
             "name": "Marionette Apprentice",
             "text": "Fabricate 1\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, each opponent loses 1 life.",
             "colours": [
@@ -15242,7 +15242,7 @@
         },
         {
             "id": "5d05e53c-3acf-5d71-8766-b59e2593518d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f810a2d7-efbe-4ea1-83d1-d594a8eaf88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f810a2d7-efbe-4ea1-83d1-d594a8eaf88b.jpg?1",
             "name": "Necrodominance",
             "text": "Skip your draw step.\nAt the beginning of your end step, you may pay any amount of life. If you do, draw that many cards.\nYour maximum hand size is five.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.",
             "colours": [
@@ -15278,7 +15278,7 @@
         },
         {
             "id": "2aa7e199-22ec-57af-92f3-8128b6adf831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab57e89-a420-4a3a-b2ba-34bb427e40d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab57e89-a420-4a3a-b2ba-34bb427e40d4.jpg?1",
             "name": "Toxic Deluge",
             "text": "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
             "colours": [
@@ -15312,7 +15312,7 @@
         },
         {
             "id": "eac1f1a2-1a61-5ef7-ae43-20f01de3baf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7b6b5-5cc6-4edd-8e0b-1eb59d22d958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7b6b5-5cc6-4edd-8e0b-1eb59d22d958.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "3458595b-27c9-5f48-bca0-c9fbb227c3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fd4d15-413f-41c5-b3e0-71bbb52851bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fd4d15-413f-41c5-b3e0-71bbb52851bc.jpg?1",
             "name": "Warren Soultrader",
             "text": "Pay 1 life, Sacrifice another creature: Create a Treasure token.",
             "colours": [
@@ -15385,7 +15385,7 @@
         },
         {
             "id": "0bd67721-7862-5c2b-a9bc-5df944fbe570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365e0cc-ce69-41f3-a90b-06817aa858ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7365e0cc-ce69-41f3-a90b-06817aa858ac.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -15426,7 +15426,7 @@
         },
         {
             "id": "21707c84-c7b0-5dd1-90dc-58a7a21de04b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170483c2-4e50-4cc8-9481-3330057d91bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170483c2-4e50-4cc8-9481-3330057d91bb.jpg?1",
             "name": "Flare of Duplication",
             "text": "You may sacrifice a nontoken red creature rather than pay this spell's mana cost.\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -15461,7 +15461,7 @@
         },
         {
             "id": "fcb4421d-9f85-57a9-9c2a-b58de89e867f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d3315d-2472-4fb5-8aba-611037043cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d3315d-2472-4fb5-8aba-611037043cbf.jpg?1",
             "name": "Galvanic Discharge",
             "text": "Choose target creature or planeswalker. You get {E}{E}{E}, then you may pay any amount of {E}. Galvanic Discharge deals that much damage to that permanent.",
             "colours": [
@@ -15495,7 +15495,7 @@
         },
         {
             "id": "5e25058b-c3ac-5751-9ee6-de2e28c31ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eedd92-8386-4ca9-ad72-afa03fa4bb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19eedd92-8386-4ca9-ad72-afa03fa4bb28.jpg?1",
             "name": "Meltdown",
             "text": "Destroy each artifact with mana value X or less.",
             "colours": [
@@ -15529,7 +15529,7 @@
         },
         {
             "id": "c76a649d-78bc-5844-ab3e-43e4f2c6591d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0e5378-310b-44b6-8fc8-26c94eaceafc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0e5378-310b-44b6-8fc8-26c94eaceafc.jpg?1",
             "name": "Party Thrasher",
             "text": "Noncreature spells you cast from exile have convoke.\nAt the beginning of your precombat main phase, you may discard a card. If you do, exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "b2fd021b-e4af-5c9e-93f8-1e13b33edca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b61aa8e-bb16-4ed5-b8d3-4e2f0c6d3812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b61aa8e-bb16-4ed5-b8d3-4e2f0c6d3812.jpg?1",
             "name": "Skoa, Embermage",
             "text": "When Skoa, Embermage enters the battlefield, it deals 4 damage to any target.\nGrandeur \u2014 Discard another card named Skoa, Embermage, Sacrifice two Mountains: Skoa deals 4 damage to any target.",
             "colours": [
@@ -15606,7 +15606,7 @@
         },
         {
             "id": "e13b5e08-5af4-5685-8ae1-0d43ef045a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f01df9-c4fa-4598-84c1-217bde6b1841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f01df9-c4fa-4598-84c1-217bde6b1841.jpg?1",
             "name": "Unstable Amulet",
             "text": "When Unstable Amulet enters the battlefield, you get {E}{E}.\nWhenever you cast a spell from anywhere other than your hand, Unstable Amulet deals 1 damage to each opponent.\n{T}, Pay {E}{E}: Exile the top card of your library. You may play it until you exile another card with Unstable Amulet.",
             "colours": [
@@ -15641,7 +15641,7 @@
         },
         {
             "id": "3bf56854-5dee-5f7d-b8b4-4b5066e2f6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9baaa353-e4ab-48e3-824c-712946ba0229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9baaa353-e4ab-48e3-824c-712946ba0229.jpg?1",
             "name": "Wheel of Potential",
             "text": "You get {E}{E}{E}, then you may pay X {E}.\nEach player may exile their hand and draw X cards. If X is 7 or more, you may play cards you own exiled this way until the end of your next turn.",
             "colours": [
@@ -15676,7 +15676,7 @@
         },
         {
             "id": "d2c21dfb-b7be-5c78-9a4e-ad7479559f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e17861-e0e6-4660-8705-6c71f10d1f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e17861-e0e6-4660-8705-6c71f10d1f19.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -15717,7 +15717,7 @@
         },
         {
             "id": "ad35ab12-dda6-5141-9ec3-6a29e1c7b305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4ecfa6-5e38-4c0a-91e2-f93cb492f374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4ecfa6-5e38-4c0a-91e2-f93cb492f374.jpg?1",
             "name": "Evolution Witness",
             "text": "{1}{G}: Adapt 2.\nWhenever one or more +1/+1 counters are put on Evolution Witness, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -15755,7 +15755,7 @@
         },
         {
             "id": "b6338070-dabe-5bc3-ab97-f959ae628b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b057c3e0-9d1e-4136-be70-ff34701a2cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b057c3e0-9d1e-4136-be70-ff34701a2cb7.jpg?1",
             "name": "Flare of Cultivation",
             "text": "You may sacrifice a nontoken green creature rather than pay this spell's mana cost.\nSearch your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -15790,7 +15790,7 @@
         },
         {
             "id": "3106e380-a313-54a5-8712-c39ec6fe40ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3726c01c-e314-4ca6-a82d-17178b100b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3726c01c-e314-4ca6-a82d-17178b100b64.jpg?1",
             "name": "Lion Umbra",
             "text": "Enchant modified creature\nEnchanted creature gets +3/+3 and has vigilance and reach.\nUmbra armor",
             "colours": [
@@ -15826,7 +15826,7 @@
         },
         {
             "id": "2f95f749-1a11-567a-bd68-e3938a05fee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0970efb6-427f-4d5b-9b66-eda4b91015bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0970efb6-427f-4d5b-9b66-eda4b91015bd.jpg?1",
             "name": "Monstrous Vortex",
             "text": "Whenever you cast a creature spell with power 5 or greater, discover X, where X is that spell's mana value.",
             "colours": [
@@ -15860,7 +15860,7 @@
         },
         {
             "id": "91b583fd-6ae0-57c4-a9a1-e673ffb165ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777b6f4-38de-4cba-b050-361b0f5bc560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c777b6f4-38de-4cba-b050-361b0f5bc560.jpg?1",
             "name": "Priest of Titania",
             "text": "{T}: Add {G} for each Elf on the battlefield.",
             "colours": [
@@ -15897,7 +15897,7 @@
         },
         {
             "id": "aa84dba3-4c6f-5c01-abd7-78a5bed1d120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40017c2c-7631-4db8-8fcc-596108cfc7d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40017c2c-7631-4db8-8fcc-596108cfc7d3.jpg?1",
             "name": "Primal Prayers",
             "text": "When Primal Prayers enters the battlefield, you get {E}{E}.\nYou may cast creature spells with mana value 3 or less by paying {E} rather than paying their mana costs. If you cast a spell this way, you may cast it as though it had flash.",
             "colours": [
@@ -15932,7 +15932,7 @@
         },
         {
             "id": "988bdb79-c326-5c2b-9717-bc15a2e80d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ff685-8694-4939-8f92-d91bb7ae5b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ff685-8694-4939-8f92-d91bb7ae5b76.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace.",
             "colours": [
@@ -15972,7 +15972,7 @@
         },
         {
             "id": "b63e754b-6691-5f40-a8f7-bda8ca2ce120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecbe0a4-c5b7-4f21-adcc-aea0dc20700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecbe0a4-c5b7-4f21-adcc-aea0dc20700e.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -16014,7 +16014,7 @@
         },
         {
             "id": "a18fdcc9-12eb-5082-9ac8-12e7a0ad5c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d59081-ad4e-4b9a-bb25-2105a88268b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d59081-ad4e-4b9a-bb25-2105a88268b3.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -16056,7 +16056,7 @@
         },
         {
             "id": "43d67a5f-201c-5d92-a431-68d5e3ceeab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d344f-5659-400e-8b8f-ad293ccf6308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d344f-5659-400e-8b8f-ad293ccf6308.jpg?1",
             "name": "Psychic Frog",
             "text": "Whenever Psychic Frog deals combat damage to a player or planeswalker, draw a card.\nDiscard a card: Put a +1/+1 counter on Psychic Frog.\nExile three cards from your graveyard: Psychic Frog gains flying until end of turn.",
             "colours": [
@@ -16095,7 +16095,7 @@
         },
         {
             "id": "b24afd27-c9a0-5583-9dd5-01b3c5508fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407e5c6-3f1d-4716-877a-f537dd183eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407e5c6-3f1d-4716-877a-f537dd183eac.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -16138,7 +16138,7 @@
         },
         {
             "id": "9806f8ab-0171-5939-9a6e-b8c100214db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115400ae-a43b-4b3d-9ea0-be1e7224dea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115400ae-a43b-4b3d-9ea0-be1e7224dea5.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16170,7 +16170,7 @@
         },
         {
             "id": "78308344-3b26-5008-9a65-3b5e9877bc4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3016d92-a5ee-44d7-aa0a-775fa04a7c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3016d92-a5ee-44d7-aa0a-775fa04a7c6a.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16202,7 +16202,7 @@
         },
         {
             "id": "1a63a81a-8ff8-5161-ba01-393d4bce3fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe15dc63-761f-4f24-8aa3-716552d45c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe15dc63-761f-4f24-8aa3-716552d45c64.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -16232,7 +16232,7 @@
         },
         {
             "id": "bfb0632c-4d5e-54a0-b8bd-f698019b32c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d79c3-93fa-4232-959f-2bbc62954dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d79c3-93fa-4232-959f-2bbc62954dfd.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16264,7 +16264,7 @@
         },
         {
             "id": "707f7ecc-f57f-5c78-8cb0-89a55c2b13d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0de06-7782-4d2b-93ba-ef42cd5f79b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c0de06-7782-4d2b-93ba-ef42cd5f79b4.jpg?1",
             "name": "Snow-Covered Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -16298,7 +16298,7 @@
         },
         {
             "id": "d3900da8-302c-5eb9-851a-e51bf5e7f760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b1ba-78be-47ab-8dad-13233f4d4dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2227b1ba-78be-47ab-8dad-13233f4d4dfc.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16330,7 +16330,7 @@
         },
         {
             "id": "e89f9ca7-9eef-5c0d-b13e-18142077859b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3164be2f-28c9-4a33-bd70-d5089396538c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3164be2f-28c9-4a33-bd70-d5089396538c.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -16362,7 +16362,7 @@
         },
         {
             "id": "9b08944d-5b7c-5f72-8dc0-e9b1c0803366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "When Ajani, Nacatl Pariah enters the battlefield, create a 2/1 white Cat Warrior creature token.\nWhenever one or more other Cats you control die, you may exile Ajani, then return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -16403,7 +16403,7 @@
         },
         {
             "id": "44d3b919-7458-531c-a563-876c50d5287b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e91ba1d4-3bca-45a2-ad9f-7abbcfe50dbd.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "+2: Put a +1/+1 counter on each Cat you control.\n0: Create a 2/1 white Cat Warrior creature token. When you do, if you control a red permanent other than Ajani, Nacatl Avenger, he deals damage equal to the number of creatures you control to any target.\n\u22124: Each opponent chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest.",
             "colours": [
@@ -16444,7 +16444,7 @@
         },
         {
             "id": "d7bd8437-9999-5615-b6bc-9a64f37a5c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "Flying\nWhenever Tamiyo, Inquisitive Student attacks, investigate.\nWhen you draw your third card in a turn, exile Tamiyo, then return her to the battlefield transformed under her owner's control.",
             "colours": [
@@ -16485,7 +16485,7 @@
         },
         {
             "id": "d0c7070d-3d72-543c-98a0-1d5d7c41a4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b234fee-a2b6-4661-9f98-4da6fc26aebc.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "+2: Until your next turn, whenever a creature attacks you or a planeswalker you control, it gets -1/-0 until end of turn.\n\u22123: Return target instant or sorcery card from your graveyard to your hand. If it's a green card, add one mana of any color.\n\u22127: Draw cards equal to half the number of cards in your library, rounded up. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -16526,7 +16526,7 @@
         },
         {
             "id": "e9c637f0-03cc-5a79-92cb-e79c35d048ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "Lifelink\nExtort\nAt the beginning of your postcombat main phase, if you gained 3 or more life this turn, exile Sorin of House Markov, then return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -16567,7 +16567,7 @@
         },
         {
             "id": "4daa9ac4-55f4-5d7a-acc3-ba306f6fb6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/0347bf13-1ccb-4d4d-a5f2-68181d494b85.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "Extort\n+2: Create a Food token.\n\u22121: Sorin, Ravenous Neonate deals damage equal to the amount of life you gained this turn to any target.\n\u22126: Gain control of target creature. It becomes a Vampire in addition to its other types. Put a lifelink counter on it if you control a white permanent other than that creature or Sorin.",
             "colours": [
@@ -16608,7 +16608,7 @@
         },
         {
             "id": "23d299d9-3bcb-5fce-859c-f04af29cdcf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell during your turn, flip a coin. If you lose the flip, Ral, Monsoon Mage deals 1 damage to you. If you win the flip, you may exile Ral. If you do, return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -16649,7 +16649,7 @@
         },
         {
             "id": "7e576dd5-de16-5262-acf5-c8578f828191",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a7344ed-f94d-4983-a654-3896cf2e2396.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "Ral, Leyline Prodigy enters the battlefield with an additional loyalty counter on him for each instant and sorcery spell you've cast this turn.\n+1: Until your next turn, instant and sorcery spells you cast cost {1} less to cast.\n\u22122: Ral deals 2 damage divided as you choose among one or two targets. Draw a card if you control a blue permanent other than Ral.\n\u22128: Exile the top eight cards of your library. You may cast instant and sorcery spells from among them this turn without paying their mana costs.",
             "colours": [
@@ -16690,7 +16690,7 @@
         },
         {
             "id": "42c2b899-4538-563c-837b-c792604d216e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "Deathtouch\nWhenever Grist, Voracious Larva or another creature enters the battlefield under your control, if it entered from your graveyard or you cast it from your graveyard, you may pay {G}. If you do, exile Grist, then return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "d19f485e-7c41-51ff-ac0c-03a058df6feb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/201eb299-4e89-432c-9bdc-7e862ef20d92.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "+1: Create a 1/1 black and green Insect creature token, then mill two cards. Put a deathtouch counter on the token if a black card was milled this way.\n\u22122: Destroy target artifact or enchantment.\n\u22126: For each creature card in your graveyard, create a token that's a copy of it, except it's a 1/1 black and green Insect.",
             "colours": [
@@ -16771,7 +16771,7 @@
         },
         {
             "id": "949a5bb9-cc63-5f03-af79-da5931158845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a3155-7453-4861-8d20-89be442c0e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a3155-7453-4861-8d20-89be442c0e08.jpg?1",
             "name": "Argent Dais",
             "text": "Argent Dais enters the battlefield with two oil counters on it.\nWhenever two or more creatures attack, put an oil counter on Argent Dais.\n{2}, {T}, Remove two oil counters from Argent Dais: Exile another target nonland permanent. Its controller draws two cards.",
             "colours": [
@@ -16805,7 +16805,7 @@
         },
         {
             "id": "61fbb6e1-0f10-5d9a-9781-407ef44e7b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298de33f-cb39-47c5-9579-54d91eb34414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298de33f-cb39-47c5-9579-54d91eb34414.jpg?1",
             "name": "Guide of Souls",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life and get {E}.\nWhenever you attack, you may pay {E}{E}{E}. When you do, put two +1/+1 counters and a flying counter on target attacking creature. It becomes an Angel in addition to its other types.",
             "colours": [
@@ -16842,7 +16842,7 @@
         },
         {
             "id": "e26e4b53-c383-5a53-b80e-3b397e19b4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2d9f8-e5cb-4783-b314-df2b6f75b154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2d9f8-e5cb-4783-b314-df2b6f75b154.jpg?1",
             "name": "Amphibian Downpour",
             "text": "Flash\nStorm\nEnchant creature\nEnchanted creature loses all abilities and is a blue Frog creature with base power and toughness 1/1.",
             "colours": [
@@ -16878,7 +16878,7 @@
         },
         {
             "id": "116634bb-0bd1-5086-9da5-3001ba629e32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966e2066-ef45-4882-a420-247115a319b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966e2066-ef45-4882-a420-247115a319b9.jpg?1",
             "name": "Dreamtide Whale",
             "text": "Vanishing 2\nWhenever a player casts their second spell each turn, proliferate.",
             "colours": [
@@ -16914,7 +16914,7 @@
         },
         {
             "id": "221eec74-9318-5deb-8b15-9649f5166f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee81433e-a8e4-4bf1-89d8-6b9b040e8eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee81433e-a8e4-4bf1-89d8-6b9b040e8eb4.jpg?1",
             "name": "Harbinger of the Seas",
             "text": "Nonbasic lands are Islands.",
             "colours": [
@@ -16951,7 +16951,7 @@
         },
         {
             "id": "0590492f-329e-5a23-b4dd-2d4e9361b4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ac511f-6c28-45f9-968b-9ac72872641b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ac511f-6c28-45f9-968b-9ac72872641b.jpg?1",
             "name": "Crabomination",
             "text": "Emerge from artifact {5}{B}{B}\nWhen Crabomination enters the battlefield, target opponent exiles the top card of their library, a card at random from their graveyard, and a card at random from their hand. You may cast a spell from among cards exiled this way without paying its mana cost.",
             "colours": [
@@ -16988,7 +16988,7 @@
         },
         {
             "id": "0367cd48-233d-59e6-8de9-204764b4e162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfbba55-38b1-4994-ba6f-de09af4098dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfbba55-38b1-4994-ba6f-de09af4098dc.jpg?1",
             "name": "Emperor of Bones",
             "text": "At the beginning of combat on your turn, exile up to one target card from a graveyard.\n{1}{B}: Adapt 2.\nWhenever one or more +1/+1 counters are put on Emperor of Bones, put a creature card exiled with Emperor of Bones onto the battlefield under your control with a finality counter on it. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -17025,7 +17025,7 @@
         },
         {
             "id": "199aee48-81c6-57a8-b957-5a781e88b553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653589ff-8186-49cf-8ff5-baf299501daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653589ff-8186-49cf-8ff5-baf299501daa.jpg?1",
             "name": "Nethergoyf",
             "text": "Nethergoyf's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nEscape\u2014{2}{B}, Exile any number of other cards from your graveyard with four or more card types among them.",
             "colours": [
@@ -17061,7 +17061,7 @@
         },
         {
             "id": "4efb75c1-813f-5759-9513-406fdcaec0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0136a022-6b16-4b33-a817-946ded4e9dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0136a022-6b16-4b33-a817-946ded4e9dd5.jpg?1",
             "name": "Ripples of Undeath",
             "text": "At the beginning of your precombat main phase, mill three cards. Then you may pay {1} and 3 life. If you do, put a card from among those cards into your hand.",
             "colours": [
@@ -17095,7 +17095,7 @@
         },
         {
             "id": "74804cf1-d40d-59f8-9e35-a0fe648b35ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2f7432-9216-4ef7-ab7b-c5d8e1cae395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2f7432-9216-4ef7-ab7b-c5d8e1cae395.jpg?1",
             "name": "Aether Revolt",
             "text": "Revolt \u2014 As long as a permanent you controlled left the battlefield this turn, if a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals that much damage plus 2 instead.\nWhenever you get one or more {E}, Aether Revolt deals that much damage to any target.",
             "colours": [
@@ -17129,7 +17129,7 @@
         },
         {
             "id": "7e964ff6-860c-58c5-8df0-561c15e96b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db16e02b-1b7f-4976-b9eb-41350337616c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db16e02b-1b7f-4976-b9eb-41350337616c.jpg?1",
             "name": "Detective's Phoenix",
             "text": "Bestow\u2014{R}, Collect evidence 6.\nFlying, haste\nEnchanted creature gets +2/+2 and has flying and haste.\nYou may cast Detective's Phoenix from your graveyard using its bestow ability.",
             "colours": [
@@ -17166,7 +17166,7 @@
         },
         {
             "id": "83c6f4b8-bb49-5d1b-bc09-4895cb74b9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fce56-307a-44bf-8c46-0e1328550e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fce56-307a-44bf-8c46-0e1328550e17.jpg?1",
             "name": "Fanatic of Rhonas",
             "text": "{T}: Add {G}.\nFerocious \u2014 {T}: Add {G}{G}{G}{G}. Activate only if you control a creature with power 4 or greater.\nEternalize {2}{G}{G}",
             "colours": [
@@ -17203,7 +17203,7 @@
         },
         {
             "id": "448d0b65-fd7d-5f67-bd7e-da69af563384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9458db2e-2013-492d-b086-9cf9dc230294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9458db2e-2013-492d-b086-9cf9dc230294.jpg?1",
             "name": "Invert Polarity",
             "text": "Choose target spell, then flip a coin. If you win the flip, gain control of that spell and you may choose new targets for it. If you lose the flip, counter that spell.",
             "colours": [
@@ -17239,7 +17239,7 @@
         },
         {
             "id": "9c355a30-6cd4-5872-ad0b-c374d33ec485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915715f7-5487-47aa-ada5-de1bce282164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915715f7-5487-47aa-ada5-de1bce282164.jpg?1",
             "name": "Wight of the Reliquary",
             "text": "Vigilance\nWight of the Reliquary gets +1/+1 for each creature card in your graveyard.\n{T}, Sacrifice another creature: Search your library for a land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -17278,7 +17278,7 @@
         },
         {
             "id": "55ce785d-bb72-5a38-a962-8d9f09038c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e764e3e9-653c-44d7-b96a-530d51ca5c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e764e3e9-653c-44d7-b96a-530d51ca5c2f.jpg?1",
             "name": "Disruptor Flute",
             "text": "Flash\nAs Disruptor Flute enters the battlefield, choose a card name.\nSpells with the chosen name cost {3} more to cast.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -17308,7 +17308,7 @@
         },
         {
             "id": "3e034b67-ca2e-5dbd-a18e-8dcd75f36abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea94321-7311-4543-bdc0-23938a8904c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea94321-7311-4543-bdc0-23938a8904c3.jpg?1",
             "name": "Winter Moon",
             "text": "Players can't untap more than one nonbasic land during their untap steps.",
             "colours": [],
@@ -17338,7 +17338,7 @@
         },
         {
             "id": "5c5d3ba1-4206-5922-89f9-633e72b3483e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de472d0-cca2-4bc3-ab0a-9f79fa6325ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de472d0-cca2-4bc3-ab0a-9f79fa6325ce.jpg?1",
             "name": "Bloodstained Mire",
             "text": "{T}, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a Swamp or Mountain card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17370,7 +17370,7 @@
         },
         {
             "id": "5361051d-c1d5-54b0-972b-342ef57fccb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431eca69-ba8c-47c8-a325-22a844f83e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431eca69-ba8c-47c8-a325-22a844f83e80.jpg?1",
             "name": "Flooded Strand",
             "text": "{T}, Pay 1 life, Sacrifice Flooded Strand: Search your library for a Plains or Island card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17402,7 +17402,7 @@
         },
         {
             "id": "46da3208-d8bc-5403-b464-25d926d2cc70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797b30b0-bc82-43fd-a842-d5879e2441bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797b30b0-bc82-43fd-a842-d5879e2441bd.jpg?1",
             "name": "Polluted Delta",
             "text": "{T}, Pay 1 life, Sacrifice Polluted Delta: Search your library for an Island or Swamp card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17434,7 +17434,7 @@
         },
         {
             "id": "49225ddc-6bfe-5a55-af7b-13b215d3b91a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de8387d-a707-4c2b-9661-c586b7d0db50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de8387d-a707-4c2b-9661-c586b7d0db50.jpg?1",
             "name": "Windswept Heath",
             "text": "{T}, Pay 1 life, Sacrifice Windswept Heath: Search your library for a Forest or Plains card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17466,7 +17466,7 @@
         },
         {
             "id": "848f5225-2899-5df8-a3b9-f7d61f47ef2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af6676-e780-4ebf-b2d3-0bc3436e527c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af6676-e780-4ebf-b2d3-0bc3436e527c.jpg?1",
             "name": "Wooded Foothills",
             "text": "{T}, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a Mountain or Forest card, put it onto the battlefield, then shuffle.",
             "colours": [],
@@ -17498,7 +17498,7 @@
         },
         {
             "id": "3ecb147d-a567-57df-9b21-6e93fffc36e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -17538,7 +17538,7 @@
         },
         {
             "id": "577c5fb8-abb4-5c37-bf54-acb8839f0958",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f897d650-f1a2-4366-a025-f12c10310d96.jpg?1",
             "name": "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger",
             "text": "",
             "colours": [
@@ -17578,7 +17578,7 @@
         },
         {
             "id": "46a667e4-ea37-53e8-88fd-7896307d1a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -17618,7 +17618,7 @@
         },
         {
             "id": "5f9c7ee5-31b9-5bf2-8736-e1fc9de778ee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3c4fb55-5b01-4013-b7f3-d8ec3585cde2.jpg?1",
             "name": "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [
@@ -17658,7 +17658,7 @@
         },
         {
             "id": "88e228e7-100f-5739-a0cc-aa115d18076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -17698,7 +17698,7 @@
         },
         {
             "id": "9410fe70-626e-5e11-b56c-1748bf23996b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/4018dda4-c78b-4e8e-ab8b-391e16c4e0f7.jpg?1",
             "name": "Sorin of House Markov // Sorin, Ravenous Neonate",
             "text": "",
             "colours": [
@@ -17738,7 +17738,7 @@
         },
         {
             "id": "e27c6e4c-fa75-50a3-af50-c62485ba6e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -17778,7 +17778,7 @@
         },
         {
             "id": "c6ec4e04-a2b2-5f04-a039-4ffbb2523b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5befad9-00b4-4589-a11c-951d2f5cb9cd.jpg?1",
             "name": "Ral, Monsoon Mage // Ral, Leyline Prodigy",
             "text": "",
             "colours": [
@@ -17818,7 +17818,7 @@
         },
         {
             "id": "96da87d0-8d8d-50ae-a797-8f4b3c9c0127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -17857,7 +17857,7 @@
         },
         {
             "id": "799a7c35-eb97-510a-acd8-6dc2d5bcdcbb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/964ba7c1-96ba-43e3-b11b-e0c4ec78d61b.jpg?1",
             "name": "Grist, Voracious Larva // Grist, the Plague Swarm",
             "text": "",
             "colours": [
@@ -17897,7 +17897,7 @@
         },
         {
             "id": "0f0ec9f1-e34e-54c7-8c10-5d017b11aa63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e4a2ce-96d3-4a76-afe6-ef85146f5e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e4a2ce-96d3-4a76-afe6-ef85146f5e5c.jpg?1",
             "name": "Emrakul, the World Anew",
             "text": "When you cast this spell, gain control of all creatures target player controls.\nFlying, protection from spells and from permanents that were cast this turn\nWhen Emrakul, the World Anew leaves the battlefield, sacrifice all creatures you control.\nMadness\u2014\nPay six {C}.",
             "colours": [],
@@ -17933,7 +17933,7 @@
         },
         {
             "id": "57c897f7-af13-50dd-9115-bc845b6698fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a86d7d-a7a4-4a26-b92a-0518af2d9646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a86d7d-a7a4-4a26-b92a-0518af2d9646.jpg?1",
             "name": "Herigast, Erupting Nullkite",
             "text": "Emerge {6}{R}{R}\nWhen you cast this spell, you may exile your hand. If you do, draw three cards.\nFlying\nEach creature spell you cast has emerge. The emerge cost is equal to its mana cost.",
             "colours": [],
@@ -17970,7 +17970,7 @@
         },
         {
             "id": "fcf84a6f-348a-5ba7-8a29-a29cad2219df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ff41a5-3ad9-4d3a-8b03-402459f502c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ff41a5-3ad9-4d3a-8b03-402459f502c1.jpg?1",
             "name": "Kozilek, the Broken Reality",
             "text": "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.",
             "colours": [],
@@ -18005,7 +18005,7 @@
         },
         {
             "id": "af11440c-bebb-541f-a3e3-e93ea2a8013e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73da8a4-301e-4a80-9430-1d5cae8bb7f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a73da8a4-301e-4a80-9430-1d5cae8bb7f9.jpg?1",
             "name": "Ulamog, the Defiler",
             "text": "When you cast this spell, target opponent exiles half their library, rounded up.\nWard\u2014\nSacrifice two permanents.\nUlamog, the Defiler enters the battlefield with a number of +1/+1 counters on it equal to the greatest mana value among cards in exile.\nUlamog has annihilator X, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -18040,7 +18040,7 @@
         },
         {
             "id": "3317592d-0770-5b38-9b87-01166f186269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6752d23-e4f4-40b0-9d15-f668b46ca2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6752d23-e4f4-40b0-9d15-f668b46ca2af.jpg?1",
             "name": "Pearl-Ear, Imperial Advisor",
             "text": "Lifelink\nEnchantment spells you cast have affinity for Auras.\nWhenever you cast an Aura spell that targets a modified permanent you control, draw a card.",
             "colours": [
@@ -18079,7 +18079,7 @@
         },
         {
             "id": "5a42414c-e95e-5ec5-87d0-473fcad6fa5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644f2e7a-354f-4338-9d4f-5a06a1ad412d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644f2e7a-354f-4338-9d4f-5a06a1ad412d.jpg?1",
             "name": "Phelia, Exuberant Shepherd",
             "text": "Flash\nWhenever Phelia, Exuberant Shepherd attacks, exile up to one other target nonland permanent. At the beginning of the next end step, return that card to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on Phelia.",
             "colours": [
@@ -18117,7 +18117,7 @@
         },
         {
             "id": "723185d0-c127-5c74-bc16-2587967ba0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b27dba9-ffee-4b2c-b4d4-67c24511cffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b27dba9-ffee-4b2c-b4d4-67c24511cffb.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "Lifelink\nFor each {B} in a cost, you may pay 2 life rather than pay that mana.\nWhenever you cast a black spell, put a +1/+1 counter on K'rrik, Son of Yawgmoth.",
             "colours": [
@@ -18157,7 +18157,7 @@
         },
         {
             "id": "a8655b11-f8fd-56c0-b276-135fe97bd20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c7ff3-e483-41f3-b49f-7cdc261527c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c7ff3-e483-41f3-b49f-7cdc261527c0.jpg?1",
             "name": "Shilgengar, Sire of Famine",
             "text": "Flying\nSacrifice another creature: Create a Blood token. If you sacrificed an Angel this way, create a number of Blood tokens equal to its toughness instead.\n{WB}{WB}{WB}, Sacrifice six Blood tokens: Return each creature card from your graveyard to the battlefield with a finality counter on it. Those creatures are Vampires in addition to their other types.",
             "colours": [
@@ -18197,7 +18197,7 @@
         },
         {
             "id": "fcd72e81-ffa8-535b-8678-38bc3b44d437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8e160a-487a-44dd-9075-6cae6f3df3d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8e160a-487a-44dd-9075-6cae6f3df3d8.jpg?1",
             "name": "Ashling, Flame Dancer",
             "text": "You don't lose unspent red mana as steps and phases end.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, discard a card, then draw a card. If this is the second time this ability has resolved this turn, Ashling, Flame Dancer deals 2 damage to each opponent and each creature they control. If it's the third time, add {R}{R}{R}{R}.",
             "colours": [
@@ -18237,7 +18237,7 @@
         },
         {
             "id": "7d6bc4fa-0da4-5f0e-a260-b3134e4bcf1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616106e-b75e-4de4-860e-15369e4abf84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616106e-b75e-4de4-860e-15369e4abf84.jpg?1",
             "name": "Laelia, the Blade Reforged",
             "text": "Haste\nWhenever Laelia, the Blade Reforged attacks, exile the top card of your library. You may play that card this turn.\nWhenever one or more cards are put into exile from your library and/or your graveyard, put a +1/+1 counter on Laelia.",
             "colours": [
@@ -18276,7 +18276,7 @@
         },
         {
             "id": "68d2e2e8-4906-5853-96d5-634b21eb613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc45370c-79f4-428b-ac65-8397e1190cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc45370c-79f4-428b-ac65-8397e1190cfd.jpg?1",
             "name": "Eladamri, Korvecdal",
             "text": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\n{G}, {T}, Tap two untapped creatures you control: Reveal a card from your hand or the top card of your library. If you reveal a creature card this way, put it onto the battlefield. Activate only during your turn.",
             "colours": [
@@ -18316,7 +18316,7 @@
         },
         {
             "id": "56a7354a-70af-5183-9f63-d2c4f7315b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3070e7-dce0-4121-bbef-c4357f8265ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3070e7-dce0-4121-bbef-c4357f8265ab.jpg?1",
             "name": "Six",
             "text": "Reach\nWhenever Six attacks, mill three cards. You may put a land card from among them into your hand.\nAs long as it's your turn, nonland permanent cards in your graveyard have retrace.",
             "colours": [
@@ -18355,7 +18355,7 @@
         },
         {
             "id": "2c67ff28-463a-5a79-b504-5166f846b426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b2b01e-68f7-48d5-aad6-31605765a3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b2b01e-68f7-48d5-aad6-31605765a3b1.jpg?1",
             "name": "Arna Kenner\u00fcd, Skycaptain",
             "text": "Flying, lifelink\nWard\u2014\nDiscard a card.\nWhenever a modified creature you control attacks, double the number of each kind of counter on it. Then for each nontoken permanent attached to it, create a token that's a copy of that permanent attached to that creature.",
             "colours": [
@@ -18398,7 +18398,7 @@
         },
         {
             "id": "912c752d-51f4-5844-ab94-677010600b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61061110-a8f4-41ac-a89e-93359050919d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61061110-a8f4-41ac-a89e-93359050919d.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one \u2014\n\u2022 Breya deals 3 damage to target player or planeswalker.\n\u2022 Target creature gets -4/-4 until end of turn.\n\u2022 You gain 5 life.",
             "colours": [
@@ -18443,7 +18443,7 @@
         },
         {
             "id": "9144f76c-7d8a-5d27-8d25-5a5372e3982b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3f892-fffb-46ed-90c0-ade2fb4b9d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c3f892-fffb-46ed-90c0-ade2fb4b9d19.jpg?1",
             "name": "Genku, Future Shaper",
             "text": "Whenever another nontoken permanent you control leaves the battlefield, choose one that hasn't been chosen this turn. Create a creature token with those characteristics.\n\u2022 2/2 white Fox with vigilance.\n\u2022 1/2 blue Moonfolk with flying.\n\u2022 1/1 black Rat with lifelink.\n{3}{W}{U}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -18484,7 +18484,7 @@
         },
         {
             "id": "13e8d096-faff-5a0e-870c-25d1fe784bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c8f6d5-28e5-46d5-9559-d69ed39e7b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c8f6d5-28e5-46d5-9559-d69ed39e7b87.jpg?1",
             "name": "Imskir Iron-Eater",
             "text": "Affinity for artifacts\nWhen Imskir Iron-Eater enters the battlefield, you draw X cards and you lose X life, where X is half the number of artifacts you control, rounded down.\n{3}{R}, Sacrifice an artifact: Imskir deals damage equal to the sacrificed artifact's mana value to any target.",
             "colours": [
@@ -18525,7 +18525,7 @@
         },
         {
             "id": "19852bc3-4f46-5ba5-976b-95cd8cf95469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e42cd7b-8ce5-46a6-a44b-2b1dc8477d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e42cd7b-8ce5-46a6-a44b-2b1dc8477d86.jpg?1",
             "name": "Kaalia of the Vast",
             "text": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
             "colours": [
@@ -18569,7 +18569,7 @@
         },
         {
             "id": "af3c3a96-e00b-58e4-918a-29db33d09c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de61cb1-3baa-4471-b7dc-1a2088a8e6d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4de61cb1-3baa-4471-b7dc-1a2088a8e6d7.jpg?1",
             "name": "Kudo, King Among Bears",
             "text": "Other creatures have base power and toughness 2/2 and are Bears in addition to their other types.",
             "colours": [
@@ -18610,7 +18610,7 @@
         },
         {
             "id": "efc94284-cdb8-5099-95fb-cb317d2f58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a7d66d-c602-46b2-8ec6-7116acbe8e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a7d66d-c602-46b2-8ec6-7116acbe8e3a.jpg?1",
             "name": "Nadu, Winged Wisdom",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand. This ability triggers only twice each turn.\"",
             "colours": [
@@ -18651,7 +18651,7 @@
         },
         {
             "id": "e9259c6c-5a6e-5044-ac22-769c3a5afba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe4969b-2b18-4958-af28-88bdf92dac2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe4969b-2b18-4958-af28-88bdf92dac2c.jpg?1",
             "name": "The Necrobloom",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 0/1 green Plant creature token. If you control seven or more lands with different names, create a 2/2 black Zombie creature token instead.\nLand cards in your graveyard have dredge 2.",
             "colours": [
@@ -18693,7 +18693,7 @@
         },
         {
             "id": "2971feab-e867-5805-be80-6aff61ce167c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bacad-abb8-41bd-9a33-08b75f4a8817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480bacad-abb8-41bd-9a33-08b75f4a8817.jpg?1",
             "name": "Phlage, Titan of Fire's Fury",
             "text": "When Phlage enters the battlefield, sacrifice it unless it escaped.\nWhenever Phlage enters the battlefield or attacks, it deals 3 damage to any target and you gain 3 life.\nEscape\u2014{R}{R}{W}{W}, Exile five other cards from your graveyard.",
             "colours": [
@@ -18734,7 +18734,7 @@
         },
         {
             "id": "b7b69928-d643-527b-917d-901546cb214d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb64dd7b-c1b8-4fd4-99d6-9a75f64a6296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb64dd7b-c1b8-4fd4-99d6-9a75f64a6296.jpg?1",
             "name": "Rosheen, Roaring Prophet",
             "text": "When Rosheen, Roaring Prophet enters the battlefield, mill six cards. You may put a card with {X} in its mana cost from among them into your hand.\n{T}: Reveal any number of cards with {X} in their mana cost in your hand. Add {C}{C} for each card revealed this way. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -18776,7 +18776,7 @@
         },
         {
             "id": "377020f2-f3eb-5ae2-8952-913c23198025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1714304b-7216-46e8-afba-439ac320ceb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1714304b-7216-46e8-afba-439ac320ceb7.jpg?1",
             "name": "Powerbalance",
             "text": "Whenever an opponent casts a spell, you may reveal the top card of your library. If you do, you may cast that card without paying its mana cost if the two spells have the same mana value.",
             "colours": [
@@ -18810,7 +18810,7 @@
         },
         {
             "id": "2ded6de3-83f3-530b-af2c-54e9408e0b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a98ff2-6e78-4133-ad4e-c62c396ba1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a98ff2-6e78-4133-ad4e-c62c396ba1e0.jpg?1",
             "name": "Flusterstorm",
             "text": "Counter target instant or sorcery spell unless its controller pays {1}.\nStorm",
             "colours": [
@@ -18841,7 +18841,7 @@
         },
         {
             "id": "84800bbe-66a9-5fd6-9d0d-5cc69cfc9e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9319a-a257-472a-9ab3-676d41adf877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c9319a-a257-472a-9ab3-676d41adf877.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18879,7 +18879,7 @@
         },
         {
             "id": "ef6e78b2-de0d-5842-b3dc-776234334e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c9001f-a8ee-4693-b8f7-59f10ad8f63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c9001f-a8ee-4693-b8f7-59f10ad8f63a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18917,7 +18917,7 @@
         },
         {
             "id": "a3744826-e7e1-52ec-af49-f9635ea8475f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5754638d-14ce-452d-bb45-d1d8f1151a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5754638d-14ce-452d-bb45-d1d8f1151a96.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18955,7 +18955,7 @@
         },
         {
             "id": "b5fb48f9-2600-5848-8853-fc424b7fce4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e906bdc0-3b04-46ed-a162-92a366319cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e906bdc0-3b04-46ed-a162-92a366319cbf.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18993,7 +18993,7 @@
         },
         {
             "id": "f139dcb5-ff4f-5a98-a800-d178f75c7e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a63c166-93c2-4c56-a202-1f9dc40fd557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a63c166-93c2-4c56-a202-1f9dc40fd557.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -19031,7 +19031,7 @@
         },
         {
             "id": "b0a97442-4428-5ac1-ae75-592bea27c715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e8c5ea-12a2-44b6-a0b6-6c7cea1119f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e8c5ea-12a2-44b6-a0b6-6c7cea1119f3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -19069,7 +19069,7 @@
         },
         {
             "id": "49919d42-86af-5e88-8ae9-faecde4dd352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be9bbc9-77f2-4a61-b19f-30f2e61b8e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be9bbc9-77f2-4a61-b19f-30f2e61b8e88.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -19107,7 +19107,7 @@
         },
         {
             "id": "a1894399-9835-5631-ba79-14faff2d1de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa04994a-4295-4be6-90c8-8f67fabd2e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa04994a-4295-4be6-90c8-8f67fabd2e99.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -19145,7 +19145,7 @@
         },
         {
             "id": "84e2902d-1424-55e6-807d-e27e4ca6a156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b20aa40-2b88-4cac-ad15-f730fde60643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b20aa40-2b88-4cac-ad15-f730fde60643.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -19183,7 +19183,7 @@
         },
         {
             "id": "9925eaed-421f-53fe-8dcd-e73d4d0c2beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1814fc7a-0f2a-407c-9d71-e7a7339ce82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1814fc7a-0f2a-407c-9d71-e7a7339ce82c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -19221,7 +19221,7 @@
         },
         {
             "id": "682a161e-1e43-5cf3-8eb5-3a55b19676a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb0e442-cd29-4dde-a7c5-6eed5df5cfe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb0e442-cd29-4dde-a7c5-6eed5df5cfe9.jpg?1",
             "name": "Glaring Fleshraker",
             "text": "",
             "colours": [],
@@ -19253,7 +19253,7 @@
         },
         {
             "id": "2271e8bc-8443-5a6c-afbd-50a2cc97cc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7310b5b-a0ba-4779-a7d0-aecab2608991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7310b5b-a0ba-4779-a7d0-aecab2608991.jpg?1",
             "name": "Wastescape Battlemage",
             "text": "",
             "colours": [],
@@ -19288,7 +19288,7 @@
         },
         {
             "id": "e43b7eab-4d2a-53f4-84ae-84427488321e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca4a34-016a-4bc6-b0b3-745fc99254e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca4a34-016a-4bc6-b0b3-745fc99254e3.jpg?1",
             "name": "Jolted Awake",
             "text": "",
             "colours": [
@@ -19322,7 +19322,7 @@
         },
         {
             "id": "34b98f93-bc2d-5435-9da9-344642c15f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8028519d-8f1e-43c1-9e1a-2162a91c7e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8028519d-8f1e-43c1-9e1a-2162a91c7e16.jpg?1",
             "name": "Bespoke Battlewagon",
             "text": "",
             "colours": [
@@ -19357,7 +19357,7 @@
         },
         {
             "id": "c68f9280-83e9-5a1c-8b6d-45f38b2922de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9b743b-340d-4a15-a71d-d3108adbdc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9b743b-340d-4a15-a71d-d3108adbdc45.jpg?1",
             "name": "Roil Cartographer",
             "text": "",
             "colours": [
@@ -19393,7 +19393,7 @@
         },
         {
             "id": "23689285-fbf6-5044-81f6-7682bcc97805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb0ba5-67c5-4b04-b604-27182878be1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bb0ba5-67c5-4b04-b604-27182878be1a.jpg?1",
             "name": "Accursed Marauder",
             "text": "",
             "colours": [
@@ -19430,7 +19430,7 @@
         },
         {
             "id": "60c3de45-8c59-5e66-9e9e-193931c3f8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce50742-3eef-417e-8042-046969e9ea01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce50742-3eef-417e-8042-046969e9ea01.jpg?1",
             "name": "Amped Raptor",
             "text": "",
             "colours": [
@@ -19465,7 +19465,7 @@
         },
         {
             "id": "e3fb0eff-5b06-5c37-9aaa-ca1773239d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a7c05e-abe8-44fc-b64b-1d59b7629f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a7c05e-abe8-44fc-b64b-1d59b7629f51.jpg?1",
             "name": "Unstable Amulet",
             "text": "",
             "colours": [
@@ -19499,7 +19499,7 @@
         },
         {
             "id": "ea3f76f1-8ce7-5bc7-a508-4675bbcac5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a78f479-aa17-417a-a81b-e8747656ba23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a78f479-aa17-417a-a81b-e8747656ba23.jpg?1",
             "name": "Izzet Generatorium",
             "text": "",
             "colours": [
@@ -19534,7 +19534,7 @@
         },
         {
             "id": "217b60de-5c64-5def-a81a-24a556b35d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4a6113-1db4-42d0-92b8-5fdc431d96ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4a6113-1db4-42d0-92b8-5fdc431d96ea.jpg?1",
             "name": "Scurry of Gremlins",
             "text": "",
             "colours": [
@@ -19569,7 +19569,7 @@
         },
         {
             "id": "00b9ad30-63a7-591f-9612-4ae91267c6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3a5a5-9cb1-4ee5-b7b2-d870c9a56097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3a5a5-9cb1-4ee5-b7b2-d870c9a56097.jpg?1",
             "name": "Snapping Voidcraw",
             "text": "",
             "colours": [],
@@ -19604,7 +19604,7 @@
         },
         {
             "id": "5c687ab9-5ff0-57f9-9c14-d6a20b38c0ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907e314e-b346-4bc0-8754-3d436cbe1360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907e314e-b346-4bc0-8754-3d436cbe1360.jpg?1",
             "name": "Titans' Vanguard",
             "text": "",
             "colours": [],
@@ -19638,7 +19638,7 @@
         },
         {
             "id": "ea7e2411-f22c-5539-b552-70182906a6ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2f68d-7192-407b-a59f-efa8578d9975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a2f68d-7192-407b-a59f-efa8578d9975.jpg?1",
             "name": "Solar Transformer",
             "text": "",
             "colours": [],
@@ -19667,7 +19667,7 @@
         },
         {
             "id": "518c2d6c-2fca-5d48-96ad-165823e21762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097049b-c25e-43ea-8de5-d708b058a556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097049b-c25e-43ea-8de5-d708b058a556.jpg?1",
             "name": "Tranquil Landscape",
             "text": "",
             "colours": [],
@@ -19700,7 +19700,7 @@
         },
         {
             "id": "7739c063-2628-5653-b5c9-4bb5ab62f382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d647d67-f963-43b4-ade8-6c90e91f65ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d647d67-f963-43b4-ade8-6c90e91f65ac.jpg?1",
             "name": "Twisted Landscape",
             "text": "",
             "colours": [],
@@ -19733,7 +19733,7 @@
         },
         {
             "id": "2eaa66cd-5e8a-5f41-b5f5-2a9c4fdcfc5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450bfe1d-a51b-4e45-a0f4-fc72ed94caa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450bfe1d-a51b-4e45-a0f4-fc72ed94caa4.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -19761,7 +19761,7 @@
         },
         {
             "id": "a3a80ea5-71d6-53db-bad7-cf358cf02df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0645cf05-4660-4a6e-b789-7e0f6b7660c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0645cf05-4660-4a6e-b789-7e0f6b7660c0.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -19793,7 +19793,7 @@
         },
         {
             "id": "e9d0c3ba-e49f-509b-8227-f39558f12f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe9d826-2642-4dc8-9dfd-0526394d43ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe9d826-2642-4dc8-9dfd-0526394d43ac.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -19828,7 +19828,7 @@
         },
         {
             "id": "dbe4ac1a-dff9-5388-8576-e73064037539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bacab2-a4c6-4ba5-a208-6bd09ae4cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74bacab2-a4c6-4ba5-a208-6bd09ae4cf9f.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -19863,7 +19863,7 @@
         },
         {
             "id": "d9743436-0dec-5c72-bfc5-54668a38d036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c5bcf-1fdd-4d73-a92b-223292da00ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5c5bcf-1fdd-4d73-a92b-223292da00ca.jpg?1",
             "name": "Cat Warrior",
             "text": "",
             "colours": [
@@ -19899,7 +19899,7 @@
         },
         {
             "id": "7c686f3c-cba1-533b-ab0f-9461135cb7c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d906e-e5c2-48ad-b7b0-f740ea4447ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31d906e-e5c2-48ad-b7b0-f740ea4447ff.jpg?1",
             "name": "Fox",
             "text": "",
             "colours": [
@@ -19934,7 +19934,7 @@
         },
         {
             "id": "cb355e8f-f11b-5c4d-8e3d-8ef722795c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17648a0-f680-429d-8dda-2b0c14f3d80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e17648a0-f680-429d-8dda-2b0c14f3d80a.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -19969,7 +19969,7 @@
         },
         {
             "id": "024bf013-7a87-531a-a8ad-277eea89f07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aa2f5e-9809-4e97-b9b2-9c9a322a8e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aa2f5e-9809-4e97-b9b2-9c9a322a8e21.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20004,7 +20004,7 @@
         },
         {
             "id": "fa9eac92-3a7d-5b17-8320-f046addea8c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7222593-5ade-4512-bfee-6126d4d0cc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7222593-5ade-4512-bfee-6126d4d0cc19.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -20039,7 +20039,7 @@
         },
         {
             "id": "bc7e93bc-db60-52f7-aeb7-ccc93c41e1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e081becb-40f1-4151-aea3-5a9a9bd672c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e081becb-40f1-4151-aea3-5a9a9bd672c6.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -20074,7 +20074,7 @@
         },
         {
             "id": "edf11a1d-f2a7-5888-9243-6dde2db4dbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9155825a-6449-4b36-aa14-4c227075ed51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9155825a-6449-4b36-aa14-4c227075ed51.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -20109,7 +20109,7 @@
         },
         {
             "id": "6a48d751-7da2-5ec5-9e3d-0697870d6a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10136b4b-ccc1-48ce-bc8c-295660464cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10136b4b-ccc1-48ce-bc8c-295660464cf7.jpg?1",
             "name": "Moonfolk",
             "text": "",
             "colours": [
@@ -20144,7 +20144,7 @@
         },
         {
             "id": "e8749ef0-5281-5142-9c43-c89478006681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a7adb3-8e66-4e63-95f2-1a5f5827b676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a7adb3-8e66-4e63-95f2-1a5f5827b676.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [
@@ -20180,7 +20180,7 @@
         },
         {
             "id": "faebb681-5591-50ad-977a-337a4ec0686e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b8f3b4-d0f3-4f2f-8e6f-7da1e852dac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b8f3b4-d0f3-4f2f-8e6f-7da1e852dac1.jpg?1",
             "name": "Whale",
             "text": "",
             "colours": [
@@ -20215,7 +20215,7 @@
         },
         {
             "id": "001dd45c-851b-5eb3-9a53-fc9fb2c0e322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef58164-4155-4e5b-8c16-f16f2ab65baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef58164-4155-4e5b-8c16-f16f2ab65baa.jpg?1",
             "name": "Fanatic of Rhonas",
             "text": "",
             "colours": [
@@ -20252,7 +20252,7 @@
         },
         {
             "id": "be06fa30-58eb-5c66-a6a0-8ba4e57af9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec719dc-6b07-4b1d-a79c-84ebced33422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec719dc-6b07-4b1d-a79c-84ebced33422.jpg?1",
             "name": "Phyrexian Germ",
             "text": "",
             "colours": [
@@ -20288,7 +20288,7 @@
         },
         {
             "id": "ed84d86c-78c7-527a-a8ed-ba64a1429eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7800c9-6808-4f33-87ad-50ad8c79f2d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7800c9-6808-4f33-87ad-50ad8c79f2d7.jpg?1",
             "name": "Phyrexian Wurm",
             "text": "",
             "colours": [
@@ -20325,7 +20325,7 @@
         },
         {
             "id": "2a288bf4-93b7-5dee-8e23-6d58e0cfc0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482ab42-875c-46fc-aa0b-b18154488985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482ab42-875c-46fc-aa0b-b18154488985.jpg?1",
             "name": "Phyrexian Wurm",
             "text": "",
             "colours": [
@@ -20362,7 +20362,7 @@
         },
         {
             "id": "c8266738-dc3a-5b7e-8a53-2ef29c92d37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3054ecd-0f8a-439d-ab7c-129d5aa0ccb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3054ecd-0f8a-439d-ab7c-129d5aa0ccb2.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -20397,7 +20397,7 @@
         },
         {
             "id": "affc1692-059c-5ac7-952c-e53bfc9d1542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9be7c2-efe5-4d37-a43e-ddcd50a77aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9be7c2-efe5-4d37-a43e-ddcd50a77aa9.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -20432,7 +20432,7 @@
         },
         {
             "id": "03a1849a-11cc-587a-b68a-4d4ee2e68232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909387e1-dc33-446c-825f-07c915ad73ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909387e1-dc33-446c-825f-07c915ad73ee.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -20467,7 +20467,7 @@
         },
         {
             "id": "90194dcf-b927-5f58-87bc-4924425daa4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505a3bc6-deab-410e-a58e-e3b5f0f21e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505a3bc6-deab-410e-a58e-e3b5f0f21e3d.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -20503,7 +20503,7 @@
         },
         {
             "id": "2c5e04d9-23ef-503d-aa81-5678f40fc581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af08a84-4a57-4c94-a290-31d93f79db83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af08a84-4a57-4c94-a290-31d93f79db83.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -20538,7 +20538,7 @@
         },
         {
             "id": "b1ada3a2-f010-583d-85f8-6d7d496a70a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b63bd0-0b61-4a87-928f-95fc6b5a3150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b63bd0-0b61-4a87-928f-95fc6b5a3150.jpg?1",
             "name": "Spellgorger Weird",
             "text": "",
             "colours": [
@@ -20573,7 +20573,7 @@
         },
         {
             "id": "52626921-713d-5fbe-823b-c222119520aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e9d51-c7bf-41c0-a6f0-c0bbc6d3b434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e9d51-c7bf-41c0-a6f0-c0bbc6d3b434.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -20608,7 +20608,7 @@
         },
         {
             "id": "11535942-2557-5fbb-9d19-cc263ebb9d89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3a058-3e25-4bb9-895b-ad2285c50bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3a058-3e25-4bb9-895b-ad2285c50bca.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -20643,7 +20643,7 @@
         },
         {
             "id": "d43a8a70-5a2c-5c27-b20f-c0c8d0766750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bc4cb0-60d4-4c8f-a420-8bfe635154cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bc4cb0-60d4-4c8f-a420-8bfe635154cd.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -20680,7 +20680,7 @@
         },
         {
             "id": "410b9b26-6c7e-59e7-a366-695781154d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef77c8eb-aa24-46d5-8036-6651c7602383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef77c8eb-aa24-46d5-8036-6651c7602383.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20717,7 +20717,7 @@
         },
         {
             "id": "30b07a0a-3f08-54ee-be36-82e81be8faf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3364c1cf-e036-4ba2-a8ae-20e995610311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3364c1cf-e036-4ba2-a8ae-20e995610311.jpg?1",
             "name": "Blood",
             "text": "",
             "colours": [],
@@ -20748,7 +20748,7 @@
         },
         {
             "id": "27887612-3a17-5445-afde-bb96a6da5aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604b9ca-6c5a-459e-b509-955c3428530a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e604b9ca-6c5a-459e-b509-955c3428530a.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -20779,7 +20779,7 @@
         },
         {
             "id": "c71c9643-4101-5306-9514-9a7004d811df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fe0b7c-2d73-4c21-98ca-ee3a7d7f20c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fe0b7c-2d73-4c21-98ca-ee3a7d7f20c8.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -20810,7 +20810,7 @@
         },
         {
             "id": "c682b365-1b9b-5833-a24c-3a069e47764f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee5119d-f76c-44c7-bf82-34aabb4d2e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee5119d-f76c-44c7-bf82-34aabb4d2e69.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -20843,7 +20843,7 @@
         },
         {
             "id": "3363ed10-f27c-5516-979e-24cb9e524dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165814-3eb8-4d94-b9c8-ecc798afe7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23165814-3eb8-4d94-b9c8-ecc798afe7a0.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -20875,7 +20875,7 @@
         },
         {
             "id": "258bb001-94da-5756-8510-0e20289462ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1141c3fe-1adf-48ab-ac05-079b081788cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1141c3fe-1adf-48ab-ac05-079b081788cc.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -20906,7 +20906,7 @@
         },
         {
             "id": "85dcec74-7d88-516b-9819-ada71d71e0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88e2bea-9c95-447e-bc9d-7d7f8ea40567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88e2bea-9c95-447e-bc9d-7d7f8ea40567.jpg?1",
             "name": "Tamiyo, Seasoned Scholar",
             "text": "",
             "colours": [],
@@ -20934,7 +20934,7 @@
         },
         {
             "id": "ddc9a92f-9fc8-5a18-ba5c-73d8e1202cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c516212-ad39-4396-8e05-ae57f100309f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c516212-ad39-4396-8e05-ae57f100309f.jpg?1",
             "name": "Energy Reserve",
             "text": "",
             "colours": [],
@@ -20962,7 +20962,7 @@
         },
         {
             "id": "fdc7aa74-0ebb-5ec9-987d-82b3714dd8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a016157-6f3f-4fb2-b962-1f548d378545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a016157-6f3f-4fb2-b962-1f548d378545.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -20990,7 +20990,7 @@
         },
         {
             "id": "05897422-e2c4-5f20-93af-97fe0ba44515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32795e1-5548-43ef-8cd6-c605a19ef708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32795e1-5548-43ef-8cd6-c605a19ef708.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -21022,7 +21022,7 @@
         },
         {
             "id": "ac0893be-5124-5b96-be09-690fcd16b1d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c923eed-3d09-4b38-a884-513700aebca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c923eed-3d09-4b38-a884-513700aebca3.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -21057,7 +21057,7 @@
         },
         {
             "id": "8b7dac8b-69c6-56c3-8fd9-f25fb52ba236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b1dfdc-09cf-4b87-a6c1-a78ba51e1133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b1dfdc-09cf-4b87-a6c1-a78ba51e1133.jpg?1",
             "name": "Gremlin",
             "text": "",
             "colours": [
@@ -21092,7 +21092,7 @@
         },
         {
             "id": "34320c28-6922-5da5-99c8-9ef5b135c14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909f85b2-0d7b-42ac-a0b7-402e20cedab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909f85b2-0d7b-42ac-a0b7-402e20cedab4.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -21127,7 +21127,7 @@
         },
         {
             "id": "77d0369d-a75c-5b97-9f61-0ed7f830f121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e85e215-29d0-4ff6-9e42-9ce84b5280cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e85e215-29d0-4ff6-9e42-9ce84b5280cf.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -21164,7 +21164,7 @@
         },
         {
             "id": "7c5cdbc2-a953-53bd-81dd-9a5c8fbedb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a7e037-9f56-4a77-a09e-caeafbb86d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a7e037-9f56-4a77-a09e-caeafbb86d7c.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MID.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MID.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f10c65cc-1a64-552e-b53c-f825ca89d5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18092f68-b96e-4084-9eba-b240d2195d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18092f68-b96e-4084-9eba-b240d2195d81.jpg?1",
             "name": "Adeline, Resplendent Cathar",
             "text": "Vigilance\nAdeline, Resplendent Cathar's power is equal to the number of creatures you control.\nWhenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.",
             "colours": [
@@ -43,7 +43,7 @@
         },
         {
             "id": "cf968d16-027f-5970-a3a3-cb2f49e8dca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1",
             "name": "Ambitious Farmhand // Seasoned Cathar",
             "text": "When Ambitious Farmhand enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nCoven \u2014 {1}{W}{W}: Transform Ambitious Farmhand. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "12b1f13f-af09-5197-85f7-104ec020bdd5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1",
             "name": "Ambitious Farmhand // Seasoned Cathar",
             "text": "Lifelink",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "13d054c7-4c25-5425-8b39-01fed17ebca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg?1",
             "name": "Beloved Beggar // Generous Soul",
             "text": "Disturb {4}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "0fb19178-de6a-5410-9506-4fed53ffbd36",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6109b54e-56c5-4014-9f6d-d5f7a0fd725d.jpg?1",
             "name": "Beloved Beggar // Generous Soul",
             "text": "Flying, vigilance\nIf Generous Soul would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -182,7 +182,7 @@
         },
         {
             "id": "295b974a-b0ee-59f3-829e-6f9912c9c9b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg?1",
             "name": "Bereaved Survivor // Dauntless Avenger",
             "text": "When another creature you control dies, transform Bereaved Survivor.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "dac4f4fa-81e7-5a11-a425-19817f894866",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4adee830-62fd-4ab4-b1c6-a8bbe15331d1.jpg?1",
             "name": "Bereaved Survivor // Dauntless Avenger",
             "text": "Whenever Dauntless Avenger attacks, return target creature card with mana value 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "87f85d5d-834c-589d-9738-1983bba0ded8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1555cdcb-3471-4ee7-99c3-d05311bf433c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1555cdcb-3471-4ee7-99c3-d05311bf433c.jpg?1",
             "name": "Blessed Defiance",
             "text": "Target creature you control gets +2/+0 and gains lifelink until end of turn. When that creature dies this turn, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -284,7 +284,7 @@
         },
         {
             "id": "521e339e-756d-5f38-bf2b-f4070e304ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeef24b-b937-408e-a32e-1a546d3e7b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eeef24b-b937-408e-a32e-1a546d3e7b0f.jpg?1",
             "name": "Borrowed Time",
             "text": "When Borrowed Time enters the battlefield, exile target nonland permanent an opponent controls until Borrowed Time leaves the battlefield.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "c1527b1d-ced8-5f09-ae7f-5401a36eb7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "When this creature enters the battlefield or transforms into Brutal Cathar, exile target creature an opponent controls until this creature leaves the battlefield.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "87690b59-8c3b-519a-a1f5-c621dece7f24",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dbac7ce-a6fa-466e-b6ba-173cf2dec98e.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "First strike\nWard\u2014\nPay 3 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "92e0f198-040e-57c9-9ba8-52f77a4b5e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfe6ea-cd43-4ec4-83a1-1f0f74e27f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedfe6ea-cd43-4ec4-83a1-1f0f74e27f56.jpg?1",
             "name": "Candlegrove Witch",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Candlegrove Witch gains flying until end of turn.",
             "colours": [
@@ -429,7 +429,7 @@
         },
         {
             "id": "6aae96ba-4c2f-5ab9-9e63-082dbe5f83f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32869a36-f21e-4348-a787-871daa6151df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32869a36-f21e-4348-a787-871daa6151df.jpg?1",
             "name": "Candletrap",
             "text": "Enchant creature\nEnchanted creature has defender.\nPrevent all combat damage that would be dealt by enchanted creature.\nCoven \u2014 {2}{W}, Sacrifice Candletrap: Exile enchanted creature. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "32fd4594-c94a-57bb-8e46-84ea6e84047a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cbc1c2-b76e-4da3-aa43-00e10b2ce532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cbc1c2-b76e-4da3-aa43-00e10b2ce532.jpg?1",
             "name": "Cathar Commando",
             "text": "Flash\n{1}, Sacrifice Cathar Commando: Destroy target artifact or enchantment.",
             "colours": [
@@ -498,7 +498,7 @@
         },
         {
             "id": "f87cf043-7e7d-5ad9-90c4-73e41c900171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d044a9-0149-4302-86e5-90623e54e36b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d044a9-0149-4302-86e5-90623e54e36b.jpg?1",
             "name": "Cathar's Call",
             "text": "Enchant creature\nEnchanted creature has vigilance and \"At the beginning of your end step, create a 1/1 white Human creature token.\"",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "d519cdc0-a79d-5cee-95d1-1c16f676f6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67547253-ab98-4d3a-bf95-3e109cf60a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67547253-ab98-4d3a-bf95-3e109cf60a85.jpg?1",
             "name": "Celestus Sanctifier",
             "text": "If it's neither day nor night, it becomes day as Celestus Sanctifier enters the battlefield.\nWhenever day becomes night or night becomes day, look at the top two cards of your library. Put one of them into your graveyard.",
             "colours": [
@@ -567,7 +567,7 @@
         },
         {
             "id": "e4c2e25a-d7f5-56dc-8237-ae4050a7949f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg?1",
             "name": "Chaplain of Alms // Chapel Shieldgeist",
             "text": "First strike\nWard {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nDisturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "928536d7-8475-5394-9952-29a1b168046f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/20e94e17-2e4c-41cd-8cc5-39ab41037287.jpg?1",
             "name": "Chaplain of Alms // Chapel Shieldgeist",
             "text": "Flying, first strike\nEach creature you control has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nIf Chapel Shieldgeist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -637,7 +637,7 @@
         },
         {
             "id": "93e1791d-78b8-5af2-9c58-d51bdd2e2894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8ea28-7de1-4908-8e2d-b1aeff651015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8ea28-7de1-4908-8e2d-b1aeff651015.jpg?1",
             "name": "Clarion Cathars",
             "text": "When Clarion Cathars enters the battlefield, create a 1/1 white Human creature token.",
             "colours": [
@@ -672,7 +672,7 @@
         },
         {
             "id": "1a655a52-ec4a-5635-aff4-0191b485936e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7819d5-12a9-4719-91b2-8dd1ba6f3800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7819d5-12a9-4719-91b2-8dd1ba6f3800.jpg?1",
             "name": "Curse of Silence",
             "text": "Enchant player\nAs Curse of Silence enters the battlefield, choose a card name.\nSpells with the chosen name enchanted player casts cost {2} more to cast.\nWhenever enchanted player casts a spell with the chosen name, you may sacrifice Curse of Silence. If you do, draw a card.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "1bf7dfc9-eef6-514d-8def-2c827da0bd60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75855c-88dc-4491-8045-080debfeb7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b75855c-88dc-4491-8045-080debfeb7b5.jpg?1",
             "name": "Duelcraft Trainer",
             "text": "First strike\nCoven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "d0c91a01-91ab-54a6-844e-110e2879df19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying, double strike\nYou have hexproof.\nIf your life total would be reduced to 0 or less, instead transform Enduring Angel and your life total becomes 3. Then if Enduring Angel didn't transform this way, you lose the game.",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "ecda1506-87f2-5e5c-8c9d-d13e695a5531",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a204c2a3-a899-4b70-8825-7e085b655ed0.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying\nYou have hexproof.\nAngelic Enforcer's power and toughness are each equal to your life total.\nWhenever Angelic Enforcer attacks, double your life total.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "4ea85441-084c-5fd5-b199-91d972a09078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca8d6f8-c6f1-437c-99e2-4281eae14a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca8d6f8-c6f1-437c-99e2-4281eae14a6f.jpg?1",
             "name": "Fateful Absence",
             "text": "Destroy target creature or planeswalker. Its controller investigates. (They create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -850,7 +850,7 @@
         },
         {
             "id": "c4463eec-180c-5aab-8df8-61032a908aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4354c6-ea21-46c0-93c4-744dbacbfcf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4354c6-ea21-46c0-93c4-744dbacbfcf4.jpg?1",
             "name": "Flare of Faith",
             "text": "Target creature gets +2/+2 until end of turn. If it's a Human, instead it gets +3/+3 and gains indestructible until end of turn.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "3d429a43-5ba4-5c93-8b73-d2382a02a779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58891dae-1c59-4f53-82ec-5b4c47133182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58891dae-1c59-4f53-82ec-5b4c47133182.jpg?1",
             "name": "Gavony Dawnguard",
             "text": "Ward {1}\nIf it's neither day nor night, it becomes day as Gavony Dawnguard enters the battlefield.\nWhenever day becomes night or night becomes day, look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "fb6c5c0a-bb71-5c5a-88b6-2d15b004b655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c53b007-96aa-4db6-8c3e-529d1e845b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c53b007-96aa-4db6-8c3e-529d1e845b19.jpg?1",
             "name": "Gavony Silversmith",
             "text": "When Gavony Silversmith enters the battlefield, put a +1/+1 counter on each of up to two target creatures.",
             "colours": [
@@ -954,7 +954,7 @@
         },
         {
             "id": "5eb37ea3-b3c0-5059-acd2-b8f128a5b86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1309ea-4411-4116-841f-5aef8611400c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1309ea-4411-4116-841f-5aef8611400c.jpg?1",
             "name": "Gavony Trapper",
             "text": "{2}, {T}: Tap target creature.",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "252edc2e-5c64-5f76-86e4-53a49200787a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97321072-1f7f-413b-9246-e6b3ec7a8c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97321072-1f7f-413b-9246-e6b3ec7a8c30.jpg?1",
             "name": "Hedgewitch's Mask",
             "text": "Equipped creature gets +1/+1.\nEquipped creature can't be blocked by creatures with power 4 or greater.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1023,7 +1023,7 @@
         },
         {
             "id": "f2f6f3f8-e31e-5ff2-8d74-87f365153bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a9c49f-fcd3-4572-bac7-6eb06fdc0815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a9c49f-fcd3-4572-bac7-6eb06fdc0815.jpg?1",
             "name": "Homestead Courage",
             "text": "Put a +1/+1 counter on target creature you control. It gains vigilance until end of turn.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "90af122d-e6d2-51ab-9cbf-a5e19b50fddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773199f9-c83b-4a77-8342-9f1552ecf595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/773199f9-c83b-4a77-8342-9f1552ecf595.jpg?1",
             "name": "Intrepid Adversary",
             "text": "Lifelink\nWhen Intrepid Adversary enters the battlefield, you may pay {1}{W} any number of times. When you pay this cost one or more times, put that many valor counters on Intrepid Adversary.\nCreatures you control get +1/+1 for each valor counter on Intrepid Adversary.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "12fbc3ed-001e-53a3-9cd3-730812fa18cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d41ac4-3273-4722-aaa6-ceeba66cf591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d41ac4-3273-4722-aaa6-ceeba66cf591.jpg?1",
             "name": "Loyal Gryff",
             "text": "Flash\nFlying\nWhen Loyal Gryff enters the battlefield, you may return another creature you control to its owner's hand.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "32ec1f14-eabe-544f-b58e-ffaa718462db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg?1",
             "name": "Lunarch Veteran // Luminous Phantom",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.\nDisturb {1}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "1647f9b2-2f43-5b1e-badf-138b00360bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2704743-2e23-40b9-a367-c73d2db45afc.jpg?1",
             "name": "Lunarch Veteran // Luminous Phantom",
             "text": "Flying\nWhenever another creature you control leaves the battlefield, you gain 1 life.\nIf Luminous Phantom would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "7233d817-024f-59b6-9e08-21c796a663cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg?1",
             "name": "Mourning Patrol // Morning Apparition",
             "text": "Vigilance\nDisturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "43157e91-b4ed-581b-a195-821c90b12fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d3687e2-09e0-4753-aa02-88a19bde3330.jpg?1",
             "name": "Mourning Patrol // Morning Apparition",
             "text": "Flying, vigilance\nIf Morning Apparition would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "97f82d30-6cc9-5a93-8a3c-1ce28ec6e18b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016f837-cc19-43f1-adb9-96bdd3195407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016f837-cc19-43f1-adb9-96bdd3195407.jpg?1",
             "name": "Odric's Outrider",
             "text": "Whenever Odric's Outrider or another creature you control dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1301,7 +1301,7 @@
         },
         {
             "id": "84260dd7-a7d7-53ba-9746-438fb33524ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f077f07e-4660-4483-b6ea-16cca0956892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f077f07e-4660-4483-b6ea-16cca0956892.jpg?1",
             "name": "Ritual Guardian",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Ritual Guardian gains lifelink until end of turn.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "725848a0-6588-504e-9d9b-cee059a3b0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8293903-4604-4516-866e-27a306b6fd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8293903-4604-4516-866e-27a306b6fd7c.jpg?1",
             "name": "Ritual of Hope",
             "text": "Creatures you control get +1/+1 until end of turn.\nCoven \u2014 If you control three or more creatures with different powers, creatures you control get +2/+1 until end of turn instead.",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "c2ec7748-a817-5bd6-897d-1173cebe1d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9006c1-2e6f-4bca-a1c4-3cf2a8b6e964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9006c1-2e6f-4bca-a1c4-3cf2a8b6e964.jpg?1",
             "name": "Search Party Captain",
             "text": "This spell costs {1} less to cast for each creature you attacked with this turn.\nWhen Search Party Captain enters the battlefield, draw a card.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "fa5f6ea3-6634-591f-9df8-4aeda06db41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb22626d-84ef-40d1-a4f2-771b45198eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb22626d-84ef-40d1-a4f2-771b45198eaa.jpg?1",
             "name": "Sigarda's Splendor",
             "text": "As Sigarda's Splendor enters the battlefield, note your life total.\nAt the beginning of your upkeep, draw a card if your life total is greater than or equal to the last noted life total for Sigarda's Splendor. Then note your life total.\nWhenever you cast a white spell, you gain 1 life.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "2e371926-8d4b-5e12-a4c5-d447eec20f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a2b41a-34b0-428e-80ec-3ffd601093a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1a2b41a-34b0-428e-80ec-3ffd601093a2.jpg?1",
             "name": "Sigardian Savior",
             "text": "Flying\nWhen Sigardian Savior enters the battlefield, if you cast it, return up to two target creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1473,7 +1473,7 @@
         },
         {
             "id": "72d0bacf-d8da-55c3-ad96-3d4f6b9ef2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1031bb-af9f-4446-8b36-b0bb9aa5997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1031bb-af9f-4446-8b36-b0bb9aa5997a.jpg?1",
             "name": "Soul-Guide Gryff",
             "text": "Flying\nWhen Soul-Guide Gryff enters the battlefield, exile up to one target card from a graveyard.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "9b0f4130-fd15-5620-ad8c-77c06f631505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee507688-9890-47c4-bb04-43c51eb48e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee507688-9890-47c4-bb04-43c51eb48e22.jpg?1",
             "name": "Sungold Barrage",
             "text": "Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "8cbb3552-62b4-5a6c-b394-2389863e52f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e1afd0-49d4-4657-ab75-98b0bfbfb245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e1afd0-49d4-4657-ab75-98b0bfbfb245.jpg?1",
             "name": "Sungold Sentinel",
             "text": "Whenever Sungold Sentinel enters the battlefield or attacks, exile up to one target card from a graveyard.\nCoven \u2014 {1}{W}: Choose a color. Sungold Sentinel gains hexproof from that color until end of turn and can't be blocked by creatures of that color this turn. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "b00532a8-231b-54aa-b552-f12bb3ae79d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b39ef1-29d4-4c8d-aece-a3f1ce008e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b39ef1-29d4-4c8d-aece-a3f1ce008e2d.jpg?1",
             "name": "Sunset Revelry",
             "text": "If an opponent has more life than you, you gain 4 life.\nIf an opponent controls more creatures than you, create two 1/1 white Human creature tokens.\nIf an opponent has more cards in hand than you, draw a card.",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "8fbe0122-96d0-56b9-9597-b3c5fa2491ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0700298-30d2-45a6-bd64-4fd7fa4d7d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0700298-30d2-45a6-bd64-4fd7fa4d7d30.jpg?1",
             "name": "Thraben Exorcism",
             "text": "Exile target Spirit, creature with disturb, or enchantment.",
             "colours": [
@@ -1641,7 +1641,7 @@
         },
         {
             "id": "db50a92b-842d-5029-82ce-614db9742a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f48622a-abf3-407f-921f-77c29d59ba8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f48622a-abf3-407f-921f-77c29d59ba8e.jpg?1",
             "name": "Unruly Mob",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Unruly Mob.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "d1b58df4-7ac7-5e4e-98cd-b8bbc6245bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264615c-eb99-4cb3-844a-2b4a94ba5203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e264615c-eb99-4cb3-844a-2b4a94ba5203.jpg?1",
             "name": "Vanquish the Horde",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nDestroy all creatures.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "a3f7eeea-918b-50c5-82b5-3a9bc03c0329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg?1",
             "name": "Baithook Angler // Hook-Haunt Drifter",
             "text": "Disturb {1}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "f7669195-e6de-5426-bc86-a7116a20e359",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36e71d16-0964-489d-bea2-9cec7991fc99.jpg?1",
             "name": "Baithook Angler // Hook-Haunt Drifter",
             "text": "Flying\nIf Hook-Haunt Drifter would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "985ee93c-16df-5e13-b3b2-59b1988ac0d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b74fc-1355-4668-838b-e8927794608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b74fc-1355-4668-838b-e8927794608c.jpg?1",
             "name": "Component Collector",
             "text": "If it's neither day nor night, it becomes day as Component Collector enters the battlefield.\nWhenever day becomes night or night becomes day, you may tap or untap target nonland permanent.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "f50da26d-f479-51bd-a946-7230e27cb0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a211d505-4d40-4914-a9da-220770d6ddbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a211d505-4d40-4914-a9da-220770d6ddbc.jpg?1",
             "name": "Consider",
             "text": "Look at the top card of your library. You may put that card into your graveyard.\nDraw a card.",
             "colours": [
@@ -1846,7 +1846,7 @@
         },
         {
             "id": "b65a9471-c70f-5301-9f83-b166b8de8538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg?1",
             "name": "Covetous Castaway // Ghostly Castigator",
             "text": "When Covetous Castaway dies, mill three cards. (Put the top three cards of your library into your graveyard.)\nDisturb {3}{U}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1880,7 +1880,7 @@
         },
         {
             "id": "44d7534d-add2-55e8-bab1-b124e49dbca1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/03a3ea4b-d292-4602-985f-7a7971ca73ec.jpg?1",
             "name": "Covetous Castaway // Ghostly Castigator",
             "text": "Flying\nWhen Ghostly Castigator enters the battlefield, you may shuffle up to three target cards from your graveyard into your library.\nIf Ghostly Castigator would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "b15a71f6-5940-5c9f-9d02-21197e8179a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a5b3b2-4f27-4c97-9d87-d7bdcc06d36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a5b3b2-4f27-4c97-9d87-d7bdcc06d36a.jpg?1",
             "name": "Curse of Surveillance",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, any number of target players other than that player each draw cards equal to the number of Curses attached to that player.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "d69f5a61-fe28-5677-8a33-5b092b332384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform Delver of Secrets.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "fc7dc7f8-31f1-58f1-aec3-5da76f43d585",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "Flying",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "29ff5371-5959-517b-b67f-2696aea94e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648281fe-89fb-4d8d-b944-3af28fb044f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648281fe-89fb-4d8d-b944-3af28fb044f6.jpg?1",
             "name": "Devious Cover-Up",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may shuffle up to four target cards from your graveyard into your library.",
             "colours": [
@@ -2053,7 +2053,7 @@
         },
         {
             "id": "553df376-6655-5792-826f-aa95cd0c4ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4689b3f2-e4b7-448e-b3d4-ab33194aafb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4689b3f2-e4b7-448e-b3d4-ab33194aafb2.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "6664281e-83d9-5443-b2b2-086739e2535d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b05d44-d987-45e1-bbd9-842dbe58c2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b05d44-d987-45e1-bbd9-842dbe58c2b5.jpg?1",
             "name": "Drownyard Amalgam",
             "text": "When Drownyard Amalgam enters the battlefield, target player mills three cards. (They put the top three cards of their library into their graveyard.)\n{2}{U}: Drownyard Amalgam can't be blocked this turn.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "a36ce463-0ec4-5006-9359-07f7ff04cd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fb1fff-12be-4bd5-8dba-c36e84d49651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fb1fff-12be-4bd5-8dba-c36e84d49651.jpg?1",
             "name": "Fading Hope",
             "text": "Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "8a2e3354-2fcd-5047-b61a-43187fab3995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0668413-859d-4ec4-a4d8-17ec7f5b1b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0668413-859d-4ec4-a4d8-17ec7f5b1b8b.jpg?1",
             "name": "Falcon Abomination",
             "text": "Flying\nWhen Falcon Abomination enters the battlefield, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -2187,7 +2187,7 @@
         },
         {
             "id": "832437ff-7da1-5bc2-94ed-897d095f05fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004c1078-0dea-4885-97b5-497f3f15c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/004c1078-0dea-4885-97b5-497f3f15c8c3.jpg?1",
             "name": "A-Falcon Abomination",
             "text": "",
             "colours": [
@@ -2221,7 +2221,7 @@
         },
         {
             "id": "106e0b72-aaad-5fd0-bf3b-f6ec8178e498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db186a1-3dc5-4ed2-8cd4-1e4f13094885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db186a1-3dc5-4ed2-8cd4-1e4f13094885.jpg?1",
             "name": "Firmament Sage",
             "text": "If it's neither day nor night, it becomes day as Firmament Sage enters the battlefield.\nWhenever day becomes night or night becomes day, draw a card.",
             "colours": [
@@ -2256,7 +2256,7 @@
         },
         {
             "id": "6e141203-87ac-58bb-9379-7e3a9c9b53b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cdbe4e3-f030-46fa-ae84-edf261b61706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cdbe4e3-f030-46fa-ae84-edf261b61706.jpg?1",
             "name": "Flip the Switch",
             "text": "Counter target spell unless its controller pays {4}. Create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -2288,7 +2288,7 @@
         },
         {
             "id": "352d1c55-678f-566c-8ce0-25acd9f8b5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg?1",
             "name": "Galedrifter // Waildrifter",
             "text": "Flying\nDisturb {4}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "5d7019fb-0782-5177-9573-2e417c2919cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb34c472-c6ff-4d83-ac8b-a8f279593f98.jpg?1",
             "name": "Galedrifter // Waildrifter",
             "text": "Flying\nIf Waildrifter would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "6450471f-494c-53c1-b869-7f059ab254b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3d1ac-bec2-4bba-a6cf-a823996dde2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3d1ac-bec2-4bba-a6cf-a823996dde2d.jpg?1",
             "name": "Geistwave",
             "text": "Return target nonland permanent to its owner's hand. If you controlled that permanent, draw a card.",
             "colours": [
@@ -2389,7 +2389,7 @@
         },
         {
             "id": "89d20b1a-e989-504c-b41d-90f72870e0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559846b-03d6-4a2c-97e1-c71f107e9f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559846b-03d6-4a2c-97e1-c71f107e9f24.jpg?1",
             "name": "Grafted Identity",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nEnchant creature\nYou control enchanted creature.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "a4bc221d-5e3e-5566-8e0e-be9d0dabd5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bebd764-e5ed-4164-a9f8-3c595691eb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bebd764-e5ed-4164-a9f8-3c595691eb49.jpg?1",
             "name": "Grafted Identity",
             "text": "",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "f640fa71-5a11-57c6-a3bc-c4b2b7e29c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c0dcac-f3d4-4d6e-9c6e-9295bb1cd47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c0dcac-f3d4-4d6e-9c6e-9295bb1cd47f.jpg?1",
             "name": "Larder Zombie",
             "text": "Defender\nTap three untapped creatures you control: Look at the top card of your library. You may put it into your graveyard.",
             "colours": [
@@ -2496,7 +2496,7 @@
         },
         {
             "id": "f02ee053-d0f7-5821-9120-8638487a9b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fb8900-d28d-4e33-96a7-66fcbc117adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78fb8900-d28d-4e33-96a7-66fcbc117adf.jpg?1",
             "name": "Lier, Disciple of the Drowned",
             "text": "Spells can't be countered.\nEach instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "6aba2654-fc6a-5361-b718-ae0604e6deb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a6bf25-4e94-4760-b4f5-69c78ac98fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a6bf25-4e94-4760-b4f5-69c78ac98fb5.jpg?1",
             "name": "A-Lier, Disciple of the Drowned",
             "text": "",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "dc2bb006-7f3d-5885-b010-8abf46602b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68593c6d-8d1b-4c36-84a1-f1144669825e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68593c6d-8d1b-4c36-84a1-f1144669825e.jpg?1",
             "name": "Locked in the Cemetery",
             "text": "Enchant creature\nWhen Locked in the Cemetery enters the battlefield, if there are five or more cards in your graveyard, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "92b79f11-5b30-5de3-b27a-c062d6731386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "{U}, Sacrifice Malevolent Hermit: Counter target noncreature spell unless its controller pays {3}.\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "34d3d6f8-b162-5b00-80c8-a316234837af",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e79269af-63eb-43d2-afee-c38fa14a0c5b.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "234ba496-bd60-56db-acc5-0f7d851ed14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fd1b-3dd9-492a-9ed4-0b6743074730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc00fd1b-3dd9-492a-9ed4-0b6743074730.jpg?1",
             "name": "Memory Deluge",
             "text": "Look at the top X cards of your library, where X is the amount of mana spent to cast this spell. Put two of them into your hand and the rest on the bottom of your library in a random order.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2713,7 +2713,7 @@
         },
         {
             "id": "79525cf3-7def-59a3-915f-3bbbb7a76eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg?1",
             "name": "Mysterious Tome // Chilling Chronicle",
             "text": "{2}, {T}: Draw a card. Transform Mysterious Tome.",
             "colours": [
@@ -2745,7 +2745,7 @@
         },
         {
             "id": "d81d2f12-496a-5046-a7cd-465ba04dedb2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caa57b63-bb11-45e8-8795-de92ca61f4f1.jpg?1",
             "name": "Mysterious Tome // Chilling Chronicle",
             "text": "{1}, {T}: Tap target nonland permanent. Transform Chilling Chronicle.",
             "colours": [
@@ -2777,7 +2777,7 @@
         },
         {
             "id": "6388141e-c971-507b-8ad7-d117c0dcdfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c801346-0052-4f4b-a497-1567a34679fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c801346-0052-4f4b-a497-1567a34679fb.jpg?1",
             "name": "Nebelgast Intruder",
             "text": "Flash\nFlying\nWhen Nebelgast Intruder enters the battlefield, up to one target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "d4fcdcce-861a-53ef-ae61-6c578c8d9ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf2b49a-56f9-4093-960f-9ec7af8983b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf2b49a-56f9-4093-960f-9ec7af8983b5.jpg?1",
             "name": "Ominous Roost",
             "text": "When Ominous Roost enters the battlefield or whenever you cast a spell from your graveyard, create a 1/1 blue Bird creature token with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "4e48def6-8c1d-572a-af25-24671ef6de8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9716d384-88d1-415e-882f-7fed9be1adc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9716d384-88d1-415e-882f-7fed9be1adc6.jpg?1",
             "name": "Organ Hoarder",
             "text": "When Organ Hoarder enters the battlefield, look at the top three cards of your library, then put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "eba77cde-5080-5dd2-877f-dcaa2b7b0ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebee20-869e-45ed-9ddc-843faf4032ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebee20-869e-45ed-9ddc-843faf4032ad.jpg?1",
             "name": "Otherworldly Gaze",
             "text": "Look at the top three cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nFlashback {1}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2909,7 +2909,7 @@
         },
         {
             "id": "dddfeab5-6c74-5ce8-8cd5-1ab3c9d3b922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg?1",
             "name": "Overwhelmed Archivist // Archive Haunt",
             "text": "When Overwhelmed Archivist enters the battlefield, draw a card, then discard a card.\nDisturb {3}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "e83597e3-e262-5c77-b746-e94837ce04ce",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/832288fd-8031-4c2b-ad3e-b1ec9f94d379.jpg?1",
             "name": "Overwhelmed Archivist // Archive Haunt",
             "text": "Flying\nWhenever Archive Haunt attacks, draw a card, then discard a card.\nIf Archive Haunt would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "62a16a17-5e83-5311-9722-a81f64adfc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2b0c63-c929-42ec-aada-dddb2a26550c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2b0c63-c929-42ec-aada-dddb2a26550c.jpg?1",
             "name": "Patrician Geist",
             "text": "Flying\nOther Spirits you control get +1/+1.\nSpells you cast from your graveyard cost {1} less to cast.",
             "colours": [
@@ -3016,7 +3016,7 @@
         },
         {
             "id": "45d498bd-510b-5e6d-a984-0693af708f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17c4ab2-f455-4195-86d2-b8d039fb27dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a17c4ab2-f455-4195-86d2-b8d039fb27dd.jpg?1",
             "name": "A-Patrician Geist",
             "text": "",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "0de7483a-3fa2-59bd-af3c-a6f99a1abf55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1990ed41-3739-40f6-8797-359f88af05f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1990ed41-3739-40f6-8797-359f88af05f9.jpg?1",
             "name": "Phantom Carriage",
             "text": "Flying\nWhen Phantom Carriage enters the battlefield, you may search your library for a card with flashback or disturb, put it into your graveyard, then shuffle.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "e71dd4d0-2741-54eb-8483-3b803208a251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a920c-5bd9-4aee-863a-26b4bfd4bf08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a920c-5bd9-4aee-863a-26b4bfd4bf08.jpg?1",
             "name": "A-Phantom Carriage",
             "text": "",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "a0329187-f970-562c-bba2-bb0194634d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)\nAt the beginning of your upkeep, if you control three or more creature tokens, you may transform Poppet Stitcher.",
             "colours": [
@@ -3154,7 +3154,7 @@
         },
         {
             "id": "0fd308b7-9f33-5044-aff1-625c8408caac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/999038b3-7d64-4554-b341-0675d4af8d8b.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Creature tokens you control lose all abilities and have base power and toughness 3/3.\nAt the beginning of your upkeep, you may transform Poppet Factory.",
             "colours": [
@@ -3188,7 +3188,7 @@
         },
         {
             "id": "aad14172-0916-5288-86ed-e0b93ff6495a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7d72-927a-40ce-8de4-04a3f21c134b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93be7d72-927a-40ce-8de4-04a3f21c134b.jpg?1",
             "name": "Revenge of the Drowned",
             "text": "Target creature's owner puts it on the top or bottom of their library. You create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "36232801-3227-5177-8fc2-90e1e2d0be51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b022ba8-07b6-4993-99c8-89c6dcb19e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b022ba8-07b6-4993-99c8-89c6dcb19e60.jpg?1",
             "name": "Secrets of the Key",
             "text": "Investigate. If this spell was cast from a graveyard, investigate twice instead. (To investigate, create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nFlashback {3}{U}",
             "colours": [
@@ -3252,7 +3252,7 @@
         },
         {
             "id": "d1a801a7-bfd3-53ba-aa90-10cb48e96579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f295833-a83e-4b18-8007-c7f5d78e5624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f295833-a83e-4b18-8007-c7f5d78e5624.jpg?1",
             "name": "Shipwreck Sifters",
             "text": "When Shipwreck Sifters enters the battlefield, draw a card, then discard a card.\nWhenever you discard a Spirit card or a card with disturb, put a +1/+1 counter on Shipwreck Sifters.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "380c6ba9-9af3-50be-a0b4-fadf855a6eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59feb0fa-3d5f-4712-899c-272f3976ff0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59feb0fa-3d5f-4712-899c-272f3976ff0d.jpg?1",
             "name": "A-Shipwreck Sifters",
             "text": "",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "45b02210-a7cd-5080-926f-2530b1e3dfc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9771d9e8-97d5-44af-8612-dc5c44d65ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9771d9e8-97d5-44af-8612-dc5c44d65ceb.jpg?1",
             "name": "Skaab Wrangler",
             "text": "Tap three untapped creatures you control: Tap target creature.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "afa03201-81a4-5109-8a67-b16e2f3e0c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa9aa8-86d2-4f1e-ac65-ace7e73a853c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57fa9aa8-86d2-4f1e-ac65-ace7e73a853c.jpg?1",
             "name": "Sludge Monster",
             "text": "Whenever Sludge Monster enters the battlefield or attacks, put a slime counter on up to one other target creature.\nNon-Horror creatures with slime counters on them lose all abilities and have base power and toughness 2/2.",
             "colours": [
@@ -3390,7 +3390,7 @@
         },
         {
             "id": "11931050-93b1-596e-a3f8-2056a0f8313e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67fe04-814f-4051-bd13-7c8ee40a6c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67fe04-814f-4051-bd13-7c8ee40a6c08.jpg?1",
             "name": "Spectral Adversary",
             "text": "Flash\nFlying\nWhen Spectral Adversary enters the battlefield, you may pay {1}{U} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Spectral Adversary, then up to that many other target artifacts, creatures, and/or enchantments phase out.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "ae07bc34-bff9-567b-8cfd-0b8f641a6435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f68eb3-9b40-4967-a52e-f95aec6e3fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f68eb3-9b40-4967-a52e-f95aec6e3fbf.jpg?1",
             "name": "Startle",
             "text": "Target creature gets -2/-0 until end of turn. Create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)\nDraw a card.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "56bbd7ec-2e7a-503a-8c98-f1d6128c1003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a95edb-9f5b-4e42-8b27-0b3d978dcefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a95edb-9f5b-4e42-8b27-0b3d978dcefe.jpg?1",
             "name": "Stormrider Spirit",
             "text": "Flash\nFlying",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "68907426-a42c-5c2f-a4ec-675df6271eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "Suspicious Stowaway can't be blocked.\nWhenever Suspicious Stowaway deals combat damage to a player, draw a card, then discard a card.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "ae246422-37b8-51b2-a6cd-4cecb425f3cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "Seafaring Werewolf can't be blocked.\nWhenever Seafaring Werewolf deals combat damage to a player, draw a card.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "b9eedd3b-ab15-5671-88d6-7773e648e656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6750e203-1215-4203-b5b8-3f1b18940839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6750e203-1215-4203-b5b8-3f1b18940839.jpg?1",
             "name": "Triskaidekaphile",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, if you have exactly thirteen cards in your hand, you win the game.\n{3}{U}: Draw a card.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "ab5d5b44-922b-585d-bd13-6f0efa3a57ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8148063c-a509-43ac-a291-c9410c30c2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8148063c-a509-43ac-a291-c9410c30c2f2.jpg?1",
             "name": "Unblinking Observer",
             "text": "{T}: Add {U}. Spend this mana only to pay a disturb cost or cast an instant or sorcery spell.",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "12d64263-ad40-5b61-acda-0583b0e1cfdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6a06-9c36-45a3-a591-183cb5c0f800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6a06-9c36-45a3-a591-183cb5c0f800.jpg?1",
             "name": "Vivisection",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "3189d243-436a-5d3b-862e-8a1e9e4a9cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a9d45-6197-44b6-b0fc-17aeae281b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a9d45-6197-44b6-b0fc-17aeae281b2f.jpg?1",
             "name": "Arrogant Outlaw",
             "text": "When Arrogant Outlaw enters the battlefield, if an opponent lost life this turn, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "5fb25610-27a6-543a-bb03-e4011443bc94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "Whenever Baneblade Scoundrel becomes blocked, each creature blocking it gets -1/-1 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -3745,7 +3745,7 @@
         },
         {
             "id": "cd28b695-3e8a-5b31-a534-3b2ccb4ac9f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b63f2ae-5bfd-452f-b1f5-8459bcecd3bb.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "Whenever Baneclaw Marauder becomes blocked, each creature blocking it gets -1/-1 until end of turn.\nWhenever a creature blocking Baneclaw Marauder dies, that creature's controller loses 1 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "9e4a27d7-2252-52a0-814c-d71e44b62fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4412c901-0ec8-437a-9d1e-ce318bbe2b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4412c901-0ec8-437a-9d1e-ce318bbe2b03.jpg?1",
             "name": "Bat Whisperer",
             "text": "When Bat Whisperer enters the battlefield, if an opponent lost life this turn, create a 1/1 black Bat creature token with flying.",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "1ab43c60-cb2d-5d53-91ce-f126d56eb906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d4713d-321a-447f-a318-88b552ec5d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d4713d-321a-447f-a318-88b552ec5d0c.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "cd9cd29f-0fe1-566d-8de9-c529c7368675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607b1066-1ca0-45e1-a55c-30aed77cc8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/607b1066-1ca0-45e1-a55c-30aed77cc8dc.jpg?1",
             "name": "Blood Pact",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "74e7d0fe-fe3e-5e39-8b91-ae3ed8e9acf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac827f7-a587-4adf-8408-2d9ccd9c1343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac827f7-a587-4adf-8408-2d9ccd9c1343.jpg?1",
             "name": "Bloodline Culling",
             "text": "Choose one \u2014\n\u2022 Target creature gets -5/-5 until end of turn.\n\u2022 Creature tokens get -2/-2 until end of turn.",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "5f7bc06f-3935-568c-864f-095a2eb65157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d5e536-7774-4949-8127-727ae4d8fc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d5e536-7774-4949-8127-727ae4d8fc80.jpg?1",
             "name": "Bloodtithe Collector",
             "text": "Flying\nWhen Bloodtithe Collector enters the battlefield, if an opponent lost life this turn, each opponent discards a card.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "4a083762-4c6b-5489-a575-180b7633b4a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e6941-ad6e-4d2f-93c0-be79e75bdf06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8e6941-ad6e-4d2f-93c0-be79e75bdf06.jpg?1",
             "name": "Champion of the Perished",
             "text": "Whenever another Zombie enters the battlefield under your control, put a +1/+1 counter on Champion of the Perished.",
             "colours": [
@@ -3985,7 +3985,7 @@
         },
         {
             "id": "9f776bf3-f2b7-5075-9fd0-aa9adbd427c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg?1",
             "name": "Covert Cutpurse // Covetous Geist",
             "text": "When Covert Cutpurse enters the battlefield, destroy target creature you don't control that was dealt damage this turn.\nDisturb {4}{B} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "cbbf6e08-a555-5014-baf5-b97157ce010d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5db99746-8aee-42b8-acb0-ed69933d0ff8.jpg?1",
             "name": "Covert Cutpurse // Covetous Geist",
             "text": "Flying, deathtouch\nIf Covetous Geist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -4055,7 +4055,7 @@
         },
         {
             "id": "759d9b9e-7db7-5f12-81d0-4c4585af9b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c8942-d43e-4456-ac98-3220cb954c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c8942-d43e-4456-ac98-3220cb954c65.jpg?1",
             "name": "Crawl from the Cellar",
             "text": "Return target creature card from your graveyard to your hand. Put a +1/+1 counter on up to one target Zombie you control.\nFlashback {3}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "805adae5-5bf2-53cc-8dc1-bcce235023d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Enchant player\nAs this permanent transforms into Curse of Leeches, attach it to a player.\nAt the beginning of enchanted player's upkeep, they lose 1 life and you gain 1 life.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "c8aac324-8ba3-504a-bfb8-17611bd252aa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0a3c8532-92f5-41db-92b4-a871aa05e0c7.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Lifelink\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -4161,7 +4161,7 @@
         },
         {
             "id": "34195e97-2d9d-567c-a447-011277601cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3abdcc-83a8-45c3-9bfd-23f929705018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3abdcc-83a8-45c3-9bfd-23f929705018.jpg?1",
             "name": "Defenestrate",
             "text": "Destroy target creature without flying.",
             "colours": [
@@ -4193,7 +4193,7 @@
         },
         {
             "id": "2ca5751e-8d89-5576-8685-49ebf0fd68c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153be768-ddad-44f2-bcdd-c40353c807d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153be768-ddad-44f2-bcdd-c40353c807d7.jpg?1",
             "name": "Diregraf Horde",
             "text": "When Diregraf Horde enters the battlefield, create two 2/2 black Zombie creature tokens with decayed. When you do, exile up to two target cards from graveyards. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "007d25f9-c442-54a4-8dde-673564814b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd571b-8316-4c60-a042-8bcf4816b126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd571b-8316-4c60-a042-8bcf4816b126.jpg?1",
             "name": "Dreadhound",
             "text": "When Dreadhound enters the battlefield, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhenever a creature dies or a creature card is put into a graveyard from a library, each opponent loses 1 life.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "42f83d7a-2fa1-5e90-99f3-0f650b6e36e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a72721-2a4a-4d48-a7b0-2370b90b8619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a72721-2a4a-4d48-a7b0-2370b90b8619.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "f4d6ccf8-b53d-59f7-85c5-4c53277e9457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7975a3c-570a-4bff-a60d-d274f758b93f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7975a3c-570a-4bff-a60d-d274f758b93f.jpg?1",
             "name": "Eaten Alive",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nExile target creature or planeswalker.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "9b5af7fa-8358-5b79-a930-0b48fdce5760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg?1",
             "name": "Ecstatic Awakener // Awoken Demon",
             "text": "{2}{B}, Sacrifice another creature: Draw a card, then transform Ecstatic Awakener. Activate only once each turn.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "fc9e9fca-4b6f-5bec-b1d7-3b2e25ae2394",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/b/bbdad18e-e262-41f9-b252-1cbdcdd1b5f9.jpg?1",
             "name": "Ecstatic Awakener // Awoken Demon",
             "text": "",
             "colours": [
@@ -4395,7 +4395,7 @@
         },
         {
             "id": "77405d87-9cfb-586e-9967-523d5fb6a57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e4b75c-e993-4983-8933-977be314bba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e4b75c-e993-4983-8933-977be314bba6.jpg?1",
             "name": "Foul Play",
             "text": "Destroy target creature with power 2 or less. Investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -4427,7 +4427,7 @@
         },
         {
             "id": "0b560a42-38ab-5859-bf6e-7bef87f24a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bd6a6-e8e4-4626-a43c-0b77339dd28b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bd6a6-e8e4-4626-a43c-0b77339dd28b.jpg?1",
             "name": "Ghoulish Procession",
             "text": "Whenever one or more nontoken creatures die, create a 2/2 black Zombie creature token with decayed. This ability triggers only once each turn. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4459,7 +4459,7 @@
         },
         {
             "id": "e473c2e9-1146-5929-93b8-f3d3a284e9c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63461076-a13d-488d-bd82-ceac441341c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63461076-a13d-488d-bd82-ceac441341c8.jpg?1",
             "name": "Gisa, Glorious Resurrector",
             "text": "If a creature an opponent controls would die, exile it instead.\nAt the beginning of your upkeep, put all creature cards exiled with Gisa, Glorious Resurrector onto the battlefield under your control. They gain decayed. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "00b8c874-ae08-5023-aef0-65d2e3e29d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "Ward\u2014\nDiscard a card.\nWhenever Graveyard Trespasser enters the battlefield or attacks, exile up to one target card from a graveyard. If a creature card was exiled this way, each opponent loses 1 life and you gain 1 life.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -4535,7 +4535,7 @@
         },
         {
             "id": "910565f2-f015-5372-804c-0ca68c9321d6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/daa2a273-488f-4285-a069-ad159ad2d393.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "Ward\u2014\nDiscard a card.\nWhenever Graveyard Glutton enters the battlefield or attacks, exile up to two target cards from graveyards. For each creature card exiled this way, each opponent loses 1 life and you gain 1 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "b190de68-b285-5ee8-b079-362ecc69ae47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg?1",
             "name": "Heirloom Mirror // Inherited Fiend",
             "text": "{1}, {T}, Pay 1 life, Discard a card: Draw a card, mill a card, then put a ritual counter on Heirloom Mirror. Then if it has three or more ritual counters on it, remove them and transform it. Activate only as a sorcery.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "7ed8b27e-ff39-5b07-ad51-3819ed223864",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6dd05f0-a3c0-4bd6-a1d1-a74540623093.jpg?1",
             "name": "Heirloom Mirror // Inherited Fiend",
             "text": "Flying\n{2}{B}: Exile target creature card from a graveyard. Put a +1/+1 counter on Inherited Fiend.",
             "colours": [
@@ -4637,7 +4637,7 @@
         },
         {
             "id": "00819278-741b-5cbc-abfb-c5ae296605eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68284193-a38e-40d2-8d15-92d223756751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68284193-a38e-40d2-8d15-92d223756751.jpg?1",
             "name": "Hobbling Zombie",
             "text": "Deathtouch\nWhen Hobbling Zombie dies, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "3beb95f1-6e57-5a47-b59e-220694ba4c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fae7302-0439-4b96-88c8-4ecfae322e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fae7302-0439-4b96-88c8-4ecfae322e7b.jpg?1",
             "name": "A-Hobbling Zombie",
             "text": "",
             "colours": [
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "fda01cd3-db33-520f-a742-41de3fbd511e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17824929-f131-4b8d-addb-66c25323155e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17824929-f131-4b8d-addb-66c25323155e.jpg?1",
             "name": "Infernal Grasp",
             "text": "Destroy target creature. You lose 2 life.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "efed3167-f840-57be-af4b-741cb1869178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff971ba7-68b8-482a-9cb1-741f6893550c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff971ba7-68b8-482a-9cb1-741f6893550c.jpg?1",
             "name": "Jadar, Ghoulcaller of Nephalia",
             "text": "At the beginning of your end step, if you control no creatures with decayed, create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "32b418d0-d22a-511f-b224-0eae9dafa776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Whenever Jerren, Corrupted Bishop enters the battlefield or another nontoken Human you control dies, you lose 1 life and create a 1/1 white Human creature token.\n{2}: Target Human you control gains lifelink until end of turn.\nAt the beginning of your end step, if you have exactly 13 life, you may pay {4}{B}{B}. If you do, transform Jerren.",
             "colours": [
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "90122fb3-563b-54fd-96da-d3589e001638",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/f/0f6e668d-2502-4e82-b4c2-ef34c9afa27e.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Flying, trample, lifelink\nSacrifice another creature: Draw a card.",
             "colours": [
@@ -4854,7 +4854,7 @@
         },
         {
             "id": "c1220317-fe4c-5f8c-8abb-bbd8e8da9ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8846c-3950-4588-97e8-3aa70bcd2403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a8846c-3950-4588-97e8-3aa70bcd2403.jpg?1",
             "name": "Lord of the Forsaken",
             "text": "Flying, trample\n{B}, Sacrifice another creature: Target player mills three cards.\nPay 1 life: Add {C}. Spend this mana only to cast a spell from your graveyard.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "1973ece9-f53c-5d8d-8198-a10252045b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829786e2-260b-4bc6-935b-1868b37e2d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829786e2-260b-4bc6-935b-1868b37e2d33.jpg?1",
             "name": "Mask of Griselbrand",
             "text": "Equipped creature has flying and lifelink.\nWhenever equipped creature dies, you may pay X life, where X is its power. If you do, draw X cards.\nEquip {3}",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "c918b5d5-48c1-50b1-a924-3babf7992b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08950015-eee5-4327-888c-82dfd13bb9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08950015-eee5-4327-888c-82dfd13bb9ad.jpg?1",
             "name": "The Meathook Massacre",
             "text": "When The Meathook Massacre enters the battlefield, each creature gets -X/-X until end of turn.\nWhenever a creature you control dies, each opponent loses 1 life.\nWhenever a creature an opponent controls dies, you gain 1 life.",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "3bd54180-0f46-5e4e-9904-eefe6d065865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353c37d7-1c20-43fe-b9d9-6336856c9ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353c37d7-1c20-43fe-b9d9-6336856c9ef4.jpg?1",
             "name": "A-The Meathook Massacre",
             "text": "",
             "colours": [
@@ -4997,7 +4997,7 @@
         },
         {
             "id": "730bb5cd-b6af-508c-8467-968380e40338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a53982e-3d66-4808-bcb5-46ff40567872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a53982e-3d66-4808-bcb5-46ff40567872.jpg?1",
             "name": "Morbid Opportunist",
             "text": "Whenever one or more other creatures die, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "a0c67b6f-7b78-557e-835b-9e5dce38cb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318fe8a2-a68a-4c7e-9581-ae6800826164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318fe8a2-a68a-4c7e-9581-ae6800826164.jpg?1",
             "name": "Morkrut Behemoth",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {1}{B}.\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "ecca5622-57fd-54d5-a507-05ea0841d4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75b89f1-e032-4d8c-b2b6-1b76e8644801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75b89f1-e032-4d8c-b2b6-1b76e8644801.jpg?1",
             "name": "Necrosynthesis",
             "text": "Enchant creature\nEnchanted creature has \"Whenever another creature dies, put a +1/+1 counter on this creature.\"\nWhen enchanted creature dies, look at the top X cards of your library, where X is its power. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "a0489278-4ff9-571d-ac9c-4ad0084362a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef6a68-60a4-4a20-8b57-8b7a7c5ed0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ef6a68-60a4-4a20-8b57-8b7a7c5ed0c6.jpg?1",
             "name": "No Way Out",
             "text": "Target opponent discards two cards. You create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "4bd6608b-eec4-58f5-869d-9af0ed02872c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a541ac79-a969-42b4-b989-f6e37572ec90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a541ac79-a969-42b4-b989-f6e37572ec90.jpg?1",
             "name": "Novice Occultist",
             "text": "When Novice Occultist dies, you draw a card and you lose 1 life.",
             "colours": [
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "38e94e95-05b3-5f83-bc5e-944288f621e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1adede-22ad-4c1c-9501-ad731fbe1742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1adede-22ad-4c1c-9501-ad731fbe1742.jpg?1",
             "name": "Olivia's Midnight Ambush",
             "text": "Target creature gets -2/-2 until end of turn. If it's night, that creature gets -13/-13 until end of turn instead.",
             "colours": [
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "75e530b8-88bd-5b77-8932-35e2dae17429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97398ad2-675b-4a34-aab7-935dd6714f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97398ad2-675b-4a34-aab7-935dd6714f1c.jpg?1",
             "name": "Rotten Reunion",
             "text": "Exile up to one target card from a graveyard. Create a 2/2 black Zombie creature token with decayed. (It can't block. When it attacks, sacrifice it at end of combat.)\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "2c5c972d-133d-5b99-9d5b-d913cbe82bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "3476f68f-ca7f-5436-88cc-046c474f7cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/55f0666a-5c3e-492b-b4ea-42fa7f24661b.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -5305,7 +5305,7 @@
         },
         {
             "id": "b4aa775e-e5f3-52c1-8fd4-59a59a5151a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94b5270-840b-4905-815a-057029d7352f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94b5270-840b-4905-815a-057029d7352f.jpg?1",
             "name": "Siege Zombie",
             "text": "Tap three untapped creatures you control: Each opponent loses 1 life.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "90da1a95-4425-5b46-b3e3-657fb4fb4eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb83e33c-810e-4de3-800d-2038f38a1eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb83e33c-810e-4de3-800d-2038f38a1eda.jpg?1",
             "name": "Slaughter Specialist",
             "text": "When Slaughter Specialist enters the battlefield, each opponent creates a 1/1 white Human creature token.\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Slaughter Specialist.",
             "colours": [
@@ -5376,7 +5376,7 @@
         },
         {
             "id": "e4304fa0-0576-5817-ab4b-def0974929f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa819123-bf13-44ea-9a6e-06c8ab023e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa819123-bf13-44ea-9a6e-06c8ab023e44.jpg?1",
             "name": "Stromkirk Bloodthief",
             "text": "At the beginning of your end step, if an opponent lost life this turn, put a +1/+1 counter on target Vampire you control.",
             "colours": [
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "8e11c3c3-b287-522a-bed0-ece45b9b98ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b9b8fc-c30d-49e7-bb6c-219380d73a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b9b8fc-c30d-49e7-bb6c-219380d73a82.jpg?1",
             "name": "Tainted Adversary",
             "text": "Deathtouch\nWhen Tainted Adversary enters the battlefield, you may pay {2}{B} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Tainted Adversary, then create twice that many 2/2 black Zombie creature tokens with decayed. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)",
             "colours": [
@@ -5447,7 +5447,7 @@
         },
         {
             "id": "c401e10c-5568-59b9-a399-3bcf052f7837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e2ea59-36f1-4e95-bfe8-7008b085194f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e2ea59-36f1-4e95-bfe8-7008b085194f.jpg?1",
             "name": "Vampire Interloper",
             "text": "Flying\nVampire Interloper can't block.",
             "colours": [
@@ -5482,7 +5482,7 @@
         },
         {
             "id": "baf76046-9d4d-558a-8ade-afa40015548f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg?1",
             "name": "Vengeful Strangler // Strangling Grasp",
             "text": "Vengeful Strangler can't block.\nWhen Vengeful Strangler dies, return it to the battlefield transformed under your control attached to target creature or planeswalker an opponent controls.",
             "colours": [
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "4ea72248-3a36-5f04-a84b-c86108fd2071",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4054ae6-0227-4d99-8cb5-72e8b5d0b726.jpg?1",
             "name": "Vengeful Strangler // Strangling Grasp",
             "text": "Enchant creature or planeswalker an opponent controls\nAt the beginning of your upkeep, enchanted permanent's controller sacrifices a nonland permanent and loses 1 life.",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "c0b433e9-15df-5983-8eb2-3aab58034a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983da138-f0f5-46c4-90c2-d3c34cc37d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983da138-f0f5-46c4-90c2-d3c34cc37d1f.jpg?1",
             "name": "Abandon the Post",
             "text": "Up to two target creatures can't block this turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5583,7 +5583,7 @@
         },
         {
             "id": "743b896d-496d-5ddf-87d2-25bb3beee16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58592f7-1df5-428d-9dde-e6acd9a5d1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58592f7-1df5-428d-9dde-e6acd9a5d1d5.jpg?1",
             "name": "Ardent Elementalist",
             "text": "When Ardent Elementalist enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -5618,7 +5618,7 @@
         },
         {
             "id": "fbb68108-d16b-56cc-ba58-6fcac3dd43a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed557e51-32bd-476f-99f8-d7b1738495c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed557e51-32bd-476f-99f8-d7b1738495c5.jpg?1",
             "name": "Bloodthirsty Adversary",
             "text": "Haste\nWhen Bloodthirsty Adversary enters the battlefield, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Bloodthirsty Adversary, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "8c97aba3-1b9b-54af-9124-63319e6e3784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10addf9a-daca-4b84-a9d3-f98f7b955af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10addf9a-daca-4b84-a9d3-f98f7b955af9.jpg?1",
             "name": "Brimstone Vandal",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nIf it's neither day nor night, it becomes day as Brimstone Vandal enters the battlefield.\nWhenever day becomes night or night becomes day, Brimstone Vandal deals 1 damage to each opponent.",
             "colours": [
@@ -5688,7 +5688,7 @@
         },
         {
             "id": "f7cdad15-4e2c-5229-89f3-eb662b0f77b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ded7af-8086-465e-a980-3099217d324c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ded7af-8086-465e-a980-3099217d324c.jpg?1",
             "name": "Burn Down the House",
             "text": "Choose one \u2014\n\u2022 Burn Down the House deals 5 damage to each creature and each planeswalker.\n\u2022 Create three 1/1 red Devil creature tokens with \"When this creature dies, it deals 1 damage to any target.\" They gain haste until end of turn.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "79ca672f-302c-5c74-bd32-370786da475b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d4e6b-564d-46da-8e32-09ed08c8ddc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4d4e6b-564d-46da-8e32-09ed08c8ddc5.jpg?1",
             "name": "Burn the Accursed",
             "text": "Burn the Accursed deals 5 damage to target creature and 2 damage to that creature's controller. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "d9269477-c24f-5388-a7f2-c7cdbde611bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b045c28a-39f9-4cd9-8f3a-a626b697f409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b045c28a-39f9-4cd9-8f3a-a626b697f409.jpg?1",
             "name": "Cathartic Pyre",
             "text": "Choose one \u2014\n\u2022 Cathartic Pyre deals 3 damage to target creature or planeswalker.\n\u2022 Discard up to two cards, then draw that many cards.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "b10ecbc4-a8da-5630-b084-f8881bfc0153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371b7795-5cfc-4e2b-b26c-2def52c61dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371b7795-5cfc-4e2b-b26c-2def52c61dbf.jpg?1",
             "name": "Curse of Shaken Faith",
             "text": "Enchant player\nWhenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, Curse of Shaken Faith deals 2 damage to them.",
             "colours": [
@@ -5823,7 +5823,7 @@
         },
         {
             "id": "38aab4f2-47fe-5e10-8908-0f924efdedf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff3289-00fb-4e91-b34f-6255e9de8e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff3289-00fb-4e91-b34f-6255e9de8e9e.jpg?1",
             "name": "Electric Revelation",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -5855,7 +5855,7 @@
         },
         {
             "id": "83831857-3269-526d-944f-d189cbcc997d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40998e0-d7d0-4d79-a40a-9a381debd2cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40998e0-d7d0-4d79-a40a-9a381debd2cb.jpg?1",
             "name": "Falkenrath Perforator",
             "text": "Whenever Falkenrath Perforator attacks, it deals 1 damage to defending player.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "934664a9-40b1-57f7-a947-dc250e51ecaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a743a3b6-3278-4644-a2d5-acf495c273ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a743a3b6-3278-4644-a2d5-acf495c273ed.jpg?1",
             "name": "Falkenrath Pit Fighter",
             "text": "{1}{R}, Discard a card, Sacrifice a Vampire: Draw two cards. Activate only if an opponent lost life this turn.",
             "colours": [
@@ -5926,7 +5926,7 @@
         },
         {
             "id": "d62a337e-8eb2-5007-ac74-8c859a24f6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe6937-ceda-4367-a101-562fd5e0e09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbe6937-ceda-4367-a101-562fd5e0e09d.jpg?1",
             "name": "Famished Foragers",
             "text": "When Famished Foragers enters the battlefield, if an opponent lost life this turn, add {R}{R}{R}.\n{2}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "1a534ce0-2442-51cf-92be-6422a52e2d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "{1}{R}: Fangblade Brigand gets +1/+0 and gains first strike until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "b051b605-cb99-5739-8100-283201fff38b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2feb859-bfae-4bc4-8181-5737dd5c3b08.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "{1}{R}: Fangblade Eviscerator gets +1/+0 and gains first strike until end of turn.\n{4}{R}: Creatures you control get +2/+0 until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "a97339f0-5589-55b9-9d07-aefa5213dadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626b0477-6165-443a-8a75-dfeac26ac9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626b0477-6165-443a-8a75-dfeac26ac9f9.jpg?1",
             "name": "Festival Crasher",
             "text": "Whenever you cast an instant or sorcery spell, Festival Crasher gets +2/+0 until end of turn.",
             "colours": [
@@ -6067,7 +6067,7 @@
         },
         {
             "id": "b51bbd9a-6ac1-5a3a-afb7-37e7be6d869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg?1",
             "name": "Flame Channeler // Embodiment of Flame",
             "text": "When a spell you control deals damage, transform Flame Channeler.",
             "colours": [
@@ -6102,7 +6102,7 @@
         },
         {
             "id": "dc2a1b47-2cfa-545e-953c-68d883c89d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/e/be91fcba-4599-4ecb-824d-55112096c34a.jpg?1",
             "name": "Flame Channeler // Embodiment of Flame",
             "text": "Whenever a spell you control deals damage, put a flame counter on Embodiment of Flame.\n{1}, Remove a flame counter from Embodiment of Flame: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "0ddae50e-b65b-5549-a606-60f5d3943d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b247ce7-9c58-404f-bed1-84abb37575ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b247ce7-9c58-404f-bed1-84abb37575ab.jpg?1",
             "name": "Geistflame Reservoir",
             "text": "Whenever you cast an instant or sorcery spell, put a charge counter on Geistflame Reservoir.\n{1}{R}, {T}, Remove any number of charge counters from Geistflame Reservoir: It deals that much damage to any target.\n{1}{R}, {T}: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6171,7 +6171,7 @@
         },
         {
             "id": "1f28c694-4ca8-50bf-bc9c-bb61b19f2ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "Trample\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6208,7 +6208,7 @@
         },
         {
             "id": "cdeb455a-03fe-5ab6-ac32-304b6ac13fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35fdb976-291c-4824-9518-dd8c9f93fcde.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "Trample\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "a4f1fdc2-e84b-50c8-a6b0-ffbf84c9fd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b1148-4aa6-4d78-bedd-e31573282921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b1148-4aa6-4d78-bedd-e31573282921.jpg?1",
             "name": "Immolation",
             "text": "Enchant creature\nEnchanted creature gets +2/-2.",
             "colours": [
@@ -6278,7 +6278,7 @@
         },
         {
             "id": "b199282c-9d0d-538d-994d-b352e10fc772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a732ca-cd68-465f-8e44-783e1fe34e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a732ca-cd68-465f-8e44-783e1fe34e44.jpg?1",
             "name": "Lambholt Harrier",
             "text": "{3}{R}: Target creature can't block this turn.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "71cc680f-6c82-573e-9bea-bfe05d316027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de68154-3b82-4a94-98a6-cfc49d359e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de68154-3b82-4a94-98a6-cfc49d359e4e.jpg?1",
             "name": "Light Up the Night",
             "text": "Light Up the Night deals X damage to any target. It deals X plus 1 damage instead if that target is a creature or planeswalker.\nFlashback\u2014{3}{R}, Remove X loyalty counters from among planeswalkers you control. If you cast this spell this way, X can't be 0. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "156b05ab-16c1-5c11-90fb-091e1568017c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb18c4-1386-4ea0-97c1-4bdd1e7eb5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb18c4-1386-4ea0-97c1-4bdd1e7eb5a6.jpg?1",
             "name": "Lunar Frenzy",
             "text": "Target creature you control gets +X/+0 and gains first strike and trample until end of turn.",
             "colours": [
@@ -6378,7 +6378,7 @@
         },
         {
             "id": "3f042954-6ce2-59d0-8431-7173b89b031f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4f266b-c41c-4047-ae6f-b2226c7459e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4f266b-c41c-4047-ae6f-b2226c7459e8.jpg?1",
             "name": "Moonrager's Slash",
             "text": "This spell costs {2} less to cast if it's night.\nMoonrager's Slash deals 3 damage to any target.",
             "colours": [
@@ -6410,7 +6410,7 @@
         },
         {
             "id": "611946ae-c2e9-581f-bccc-fa2df2c350b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc55fd-161a-4d77-82f0-27075210e7e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fc55fd-161a-4d77-82f0-27075210e7e7.jpg?1",
             "name": "Moonveil Regent",
             "text": "Flying\nWhenever you cast a spell, you may discard your hand. If you do, draw a card for each of that spell's colors.\nWhen Moonveil Regent dies, it deals X damage to any target, where X is the number of colors among permanents you control.",
             "colours": [
@@ -6446,7 +6446,7 @@
         },
         {
             "id": "fa1795f1-75dc-5dd1-a1ff-7bdac4eeb42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1814fc8-011f-4cd4-825b-f00ae6ec0fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1814fc8-011f-4cd4-825b-f00ae6ec0fe0.jpg?1",
             "name": "Mounted Dreadknight",
             "text": "Trample\nMounted Dreadknight enters the battlefield with a +1/+1 counter on it if an opponent lost life this turn.",
             "colours": [
@@ -6481,7 +6481,7 @@
         },
         {
             "id": "9c8d99c3-d541-5a4a-803e-789adec9a2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee17e12-e08f-4449-9f49-05f20e0d1670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee17e12-e08f-4449-9f49-05f20e0d1670.jpg?1",
             "name": "Neonate's Rush",
             "text": "This spell costs {1} less to cast if you control a Vampire.\nNeonate's Rush deals 1 damage to target creature and 1 damage to its controller. Draw a card.",
             "colours": [
@@ -6513,7 +6513,7 @@
         },
         {
             "id": "924201aa-0db8-58c6-a952-b71f620b5de2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6e0cb6-283b-448e-89c6-8b6e8e21e38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6e0cb6-283b-448e-89c6-8b6e8e21e38b.jpg?1",
             "name": "Obsessive Astronomer",
             "text": "If it's neither day nor night, it becomes day as Obsessive Astronomer enters the battlefield.\nWhenever day becomes night or night becomes day, discard up to two cards, then draw that many cards.",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "fa180baf-a5c1-5d3c-8530-2d7139cb3f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebadb1e-32cd-41d6-b26e-49134973d05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebadb1e-32cd-41d6-b26e-49134973d05c.jpg?1",
             "name": "Pack's Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If you control a Wolf or Werewolf, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "2938aa79-4cd8-5498-9923-5e2c3e048418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a6c60-a8c4-44c2-b1ea-d3befbabdf43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f1a6c60-a8c4-44c2-b1ea-d3befbabdf43.jpg?1",
             "name": "Play with Fire",
             "text": "Play with Fire deals 2 damage to any target. If a player is dealt damage this way, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "7911b744-a386-577b-b937-724ababf6ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db384e-9555-4ccc-a305-ee448252e685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9db384e-9555-4ccc-a305-ee448252e685.jpg?1",
             "name": "Purifying Dragon",
             "text": "Flying\nWhenever Purifying Dragon attacks, it deals 1 damage to target creature defending player controls. If that creature is a Zombie, Purifying Dragon deals 2 damage to it instead.",
             "colours": [
@@ -6648,7 +6648,7 @@
         },
         {
             "id": "762477e4-b10f-5074-b48b-86eee18a6ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0dd378c-5050-48c9-9a16-6d91afa62d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0dd378c-5050-48c9-9a16-6d91afa62d21.jpg?1",
             "name": "Raze the Effigy",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Target attacking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "ecef4bce-b292-5c98-ba1c-3a67347613da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "At the beginning of combat on your turn, target creature you control gets +1/+0 and gains haste until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6717,7 +6717,7 @@
         },
         {
             "id": "0e7e3490-16b8-581a-9dbe-f966c531877e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a33af331-0746-4adf-935a-bf61ff9d8d4b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 and gains trample and haste until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6753,7 +6753,7 @@
         },
         {
             "id": "535db88a-d4e3-5ad6-8d06-36a5fa0fece5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532e079f-55b7-4b92-b489-aed4d3becae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532e079f-55b7-4b92-b489-aed4d3becae7.jpg?1",
             "name": "Seize the Storm",
             "text": "Create a red Elemental creature token with trample and \"This creature's power and toughness are each equal to the number of instant and sorcery cards in your graveyard plus the number of cards with flashback you own in exile.\"\nFlashback {6}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6785,7 +6785,7 @@
         },
         {
             "id": "eac190d0-1c00-5d5b-a146-fc1cd2415e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, put a number of ember counters on Smoldering Egg equal to the amount of mana spent to cast that spell. Then if Smoldering Egg has seven or more ember counters on it, remove them and transform Smoldering Egg.",
             "colours": [
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "77bae4f3-039b-5c55-a68f-2a8eff571300",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41b6381f-4ff8-49e9-bf00-cfe32851318b.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Ashmouth Dragon deals 2 damage to any target.",
             "colours": [
@@ -6858,7 +6858,7 @@
         },
         {
             "id": "7c970d76-48a9-508f-b45e-049ef7d3e026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "Whenever you cast an instant or sorcery spell, Spellrune Painter gets +1/+1 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "2d4ece62-383d-56db-8acb-db6ecef0db56",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2a5b43d-e21b-4294-9ea2-5bd0264e71d3.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "Whenever you cast an instant or sorcery spell, Spellrune Howler gets +2/+2 until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "018ebada-7dbb-5503-b731-9c3d39cdcb56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50df2dd-8d14-4d92-ab4e-bf9f9f147e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50df2dd-8d14-4d92-ab4e-bf9f9f147e91.jpg?1",
             "name": "Stolen Vitality",
             "text": "Target creature gets +3/+1 until end of turn. If it's your turn, that creature gains trample until end of turn. Otherwise, it gains first strike until end of turn.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "79276ac9-62e2-5d1f-973e-8459e590313d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de6e92-e0e8-444e-baba-09c97510b1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de6e92-e0e8-444e-baba-09c97510b1ab.jpg?1",
             "name": "Sunstreak Phoenix",
             "text": "Flying\nIf it's neither day nor night, it becomes day as Sunstreak Phoenix enters the battlefield.\nWhenever day becomes night or night becomes day, you may pay {1}{R}. If you do, return Sunstreak Phoenix from your graveyard to the battlefield tapped.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "e0b70c92-7792-5e86-bb22-c8b33d44b199",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "Daybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7038,7 +7038,7 @@
         },
         {
             "id": "8491c394-b6a0-5f5f-b549-636eddc53ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d7b2d05-ce5c-4b73-8fa6-d9b69619d58c.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7074,7 +7074,7 @@
         },
         {
             "id": "af1a8225-2047-509e-90d9-190ce76b019a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c68bad-c7ee-4dbc-ad06-8c4d9446884e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c68bad-c7ee-4dbc-ad06-8c4d9446884e.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -7109,7 +7109,7 @@
         },
         {
             "id": "3eb5c969-9db9-5178-a0ed-c63a35579083",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "Haste\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "92763eaf-2618-5a04-90bd-f3e7c8204ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1bf48d2b-eb68-4f47-a80a-4751a4fa20a7.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "Wolves and Werewolves you control have haste.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7182,7 +7182,7 @@
         },
         {
             "id": "43bfa2f7-0f38-50c9-9945-b89c8e732b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceb4303-5d02-45f2-86f8-7e8deb774d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cceb4303-5d02-45f2-86f8-7e8deb774d58.jpg?1",
             "name": "Voldaren Ambusher",
             "text": "When Voldaren Ambusher enters the battlefield, if an opponent lost life this turn, it deals X damage to up to one target creature or planeswalker, where X is the number of Vampires you control.",
             "colours": [
@@ -7217,7 +7217,7 @@
         },
         {
             "id": "c845251d-e81e-51aa-9140-65718988130f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27a7c78-3a64-42fc-8808-15b1f41976a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27a7c78-3a64-42fc-8808-15b1f41976a1.jpg?1",
             "name": "Voldaren Stinger",
             "text": "Voldaren Stinger has first strike as long as it's attacking.\n{2}{R}: Voldaren Stinger gets +2/+0 until end of turn.",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "e00c7329-3f4b-537f-88ec-1c8d575414ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa98767-ae27-4cf0-98ea-93e659f160f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa98767-ae27-4cf0-98ea-93e659f160f4.jpg?1",
             "name": "Augur of Autumn",
             "text": "You may look at the top card of your library any time.\nYou may play lands from the top of your library.\nCoven \u2014 As long as you control three or more creatures with different powers, you may cast creature spells from the top of your library.",
             "colours": [
@@ -7289,7 +7289,7 @@
         },
         {
             "id": "bff7597b-00a9-5994-8f30-b43dd0d0ff64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "Reach\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "8dc87470-c124-5afb-a5ef-ebafbbb805a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71ccc444-54c8-4f7c-a425-82bc3eea1eb0.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "Reach\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "ac65f159-b949-5847-b50a-2b9f2ed28b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e22ed6-9d39-4feb-8c64-64cdd8313816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e22ed6-9d39-4feb-8c64-64cdd8313816.jpg?1",
             "name": "Bounding Wolf",
             "text": "Flash\nReach",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "222d00de-a710-52cb-b85a-0b6b30daae71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621b58aa-c809-4baf-b2c8-3a46969598d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621b58aa-c809-4baf-b2c8-3a46969598d7.jpg?1",
             "name": "Bramble Armor",
             "text": "When Bramble Armor enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "d78efdb6-2737-5046-bb13-470342ccc3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e215a7bd-112f-4228-a99e-5a8cb4be5cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e215a7bd-112f-4228-a99e-5a8cb4be5cee.jpg?1",
             "name": "Briarbridge Tracker",
             "text": "Vigilance\nWhen Briarbridge Tracker enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nAs long as you control a token, Briarbridge Tracker gets +2/+0.",
             "colours": [
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "1734b7f3-55db-5c9b-83e4-1dcf35b157eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24e2f49-70f9-445f-af03-2ef43798004a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24e2f49-70f9-445f-af03-2ef43798004a.jpg?1",
             "name": "Brood Weaver",
             "text": "Reach\nWhen Brood Weaver dies, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -7502,7 +7502,7 @@
         },
         {
             "id": "d446b043-9525-5a30-b817-530d4be25d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "6d6607b8-ad80-5d29-ab93-e3af12458b09",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3849ad37-f80d-4ffc-9240-25a63326b3dd.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7575,7 +7575,7 @@
         },
         {
             "id": "305e85c4-aee7-56b0-8cbc-8088a03091d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3bd60-1ff6-4136-9188-d0620fd299a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c3bd60-1ff6-4136-9188-d0620fd299a7.jpg?1",
             "name": "Candlelit Cavalry",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Candlelit Cavalry gains trample until end of turn.",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "fae554ca-f70c-55b7-9e09-e5d9cccda791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27476d9c-006d-4227-a5f2-49c7234b84a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27476d9c-006d-4227-a5f2-49c7234b84a1.jpg?1",
             "name": "Clear Shot",
             "text": "Target creature you control gets +1/+1 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "e5fed8cb-ef33-52dd-8d84-426b06565dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540fa4b-93e8-4749-a839-9a6e816c1145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540fa4b-93e8-4749-a839-9a6e816c1145.jpg?1",
             "name": "Consuming Blob",
             "text": "Consuming Blob's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nAt the beginning of your end step, create a green Ooze creature token with \"This creature's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\"",
             "colours": [
@@ -7678,7 +7678,7 @@
         },
         {
             "id": "af49b8eb-3d7e-517b-9479-9b713c27e898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81da535-04e4-4dc8-9e12-7b417aba2f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81da535-04e4-4dc8-9e12-7b417aba2f39.jpg?1",
             "name": "Contortionist Troupe",
             "text": "Contortionist Troupe enters the battlefield with X +1/+1 counters on it.\nCoven \u2014 At the beginning of your end step, if you control three or more creatures with different powers, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "8a5d7d75-bae3-5113-ab19-2ac15b610788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a09dd-a202-4487-899f-348744143ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234a09dd-a202-4487-899f-348744143ba5.jpg?1",
             "name": "Dawnhart Mentor",
             "text": "When Dawnhart Mentor enters the battlefield, create a 1/1 white Human creature token.\nCoven \u2014 {5}{G}: Target creature you control gets +3/+3 and gains trample until end of turn. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "f6690db2-16b0-5cd5-8d4e-f35cfa83e2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4b5ad9-3de6-4d53-93a0-3b8d2e484687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4b5ad9-3de6-4d53-93a0-3b8d2e484687.jpg?1",
             "name": "Dawnhart Rejuvenator",
             "text": "When Dawnhart Rejuvenator enters the battlefield, you gain 3 life.\n{T}: Add one mana of any color.",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "cf2d69ec-47c6-52d1-945b-2ec636a1fe02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg?1",
             "name": "Deathbonnet Sprout // Deathbonnet Hulk",
             "text": "At the beginning of your upkeep, mill a card. Then if there are three or more creature cards in your graveyard, transform Deathbonnet Sprout. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -7820,7 +7820,7 @@
         },
         {
             "id": "cd81875f-bbec-5088-86c4-5b904235b673",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a2cda10b-7cd5-4cf5-87bd-c3b8c6aa2b47.jpg?1",
             "name": "Deathbonnet Sprout // Deathbonnet Hulk",
             "text": "At the beginning of your upkeep, you may exile a card from a graveyard. If a creature card was exiled this way, put a +1/+1 counter on Deathbonnet Hulk.",
             "colours": [
@@ -7855,7 +7855,7 @@
         },
         {
             "id": "e152d970-a574-5028-a470-cd886ee16abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11e4420-06f3-48e2-91d1-a9199483add2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11e4420-06f3-48e2-91d1-a9199483add2.jpg?1",
             "name": "Defend the Celestus",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures you control.",
             "colours": [
@@ -7887,7 +7887,7 @@
         },
         {
             "id": "50cd6c05-4f84-5708-81fb-e687fcbdd3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0aa3eb-0aa8-42da-b437-a3f336df585d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0aa3eb-0aa8-42da-b437-a3f336df585d.jpg?1",
             "name": "Dryad's Revival",
             "text": "Return target card from your graveyard to your hand.\nFlashback {4}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -7919,7 +7919,7 @@
         },
         {
             "id": "e1d365f7-5c80-512e-b3df-eb466148ff98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0a0c8-158e-4a6f-976e-3de9f57c3463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0a0c8-158e-4a6f-976e-3de9f57c3463.jpg?1",
             "name": "Duel for Dominance",
             "text": "Coven \u2014 Choose target creature you control and target creature you don't control. If you control three or more creatures with different powers, put a +1/+1 counter on the chosen creature you control. Then the chosen creatures fight each other. (They each deal damage equal to their power to the other.)",
             "colours": [
@@ -7951,7 +7951,7 @@
         },
         {
             "id": "38879b38-8198-5e5e-8ea0-26bd0cb7055f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5339f6e-9ed7-4734-91c9-c2ed59ca1052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5339f6e-9ed7-4734-91c9-c2ed59ca1052.jpg?1",
             "name": "Eccentric Farmer",
             "text": "When Eccentric Farmer enters the battlefield, mill three cards, then you may return a land card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -7986,7 +7986,7 @@
         },
         {
             "id": "c2d3ccd6-a0af-5b34-83d3-e9a65ef398e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543cf53-8cf5-49d0-9c60-8b11e21da953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9543cf53-8cf5-49d0-9c60-8b11e21da953.jpg?1",
             "name": "Harvesttide Sentry",
             "text": "Coven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, Harvesttide Sentry can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "f81fcd65-a396-5d42-937a-aa715d2ba86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "Trample\n{3}{G}: Put a +1/+1 counter on target creature.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8058,7 +8058,7 @@
         },
         {
             "id": "f75dc67c-ae5a-5ea7-b624-909d12c1012b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28e2119b-ed78-4b98-a956-f2b453d0b164.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "Trample\nOther Wolves and Werewolves you control have trample.\n{3}{G}: Put a +1/+1 counter on target creature.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "b7aa17f5-776d-5842-bb7a-dc98f31a1f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a48a42e-5cc5-4f9a-8745-99936f4cae5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a48a42e-5cc5-4f9a-8745-99936f4cae5f.jpg?1",
             "name": "Howl of the Hunt",
             "text": "Flash\nEnchant creature\nWhen Howl of the Hunt enters the battlefield, if enchanted creature is a Wolf or Werewolf, untap that creature.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "f3380d77-93d7-5516-bbd0-e8907b156623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a853679-e9dd-4c05-8688-248de8f12760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a853679-e9dd-4c05-8688-248de8f12760.jpg?1",
             "name": "Might of the Old Ways",
             "text": "Target creature gets +2/+2 until end of turn.\nCoven \u2014 Then if you control three or more creatures with different powers, draw a card.",
             "colours": [
@@ -8160,7 +8160,7 @@
         },
         {
             "id": "5afe118d-3d8b-5541-a0c6-c529c0bfbfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "{1}, Sacrifice Outland Liberator: Destroy target artifact or enchantment.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "0cb004e6-6f72-53c9-8e46-f8e4df500063",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60e53d61-fcc3-4def-8206-052b46f62deb.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "{1}, Sacrifice Frenzied Trapbreaker: Destroy target artifact or enchantment.\nWhenever Frenzied Trapbreaker attacks, destroy target artifact or enchantment defending player controls.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8233,7 +8233,7 @@
         },
         {
             "id": "570ce268-ce71-5ca3-9614-b33433220c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f545d-bdbf-42c7-837a-a7076bbe5027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f545d-bdbf-42c7-837a-a7076bbe5027.jpg?1",
             "name": "Path to the Festival",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nFlashback {4}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "8b785007-c2a3-5697-8fb0-fef01ebed937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2686431-8d9c-4b9c-998f-38b5ae113d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2686431-8d9c-4b9c-998f-38b5ae113d4a.jpg?1",
             "name": "Pestilent Wolf",
             "text": "{2}{G}: Pestilent Wolf gains deathtouch until end of turn.",
             "colours": [
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "0b196e1a-520a-5392-b48e-675c7d5b28c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5469e696-bbf1-43e3-9c25-fe089b36caed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5469e696-bbf1-43e3-9c25-fe089b36caed.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "144995c9-b272-576b-90fd-a7c99c1de885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3ce5c5-ea31-4f6d-84dd-430f52c49c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3ce5c5-ea31-4f6d-84dd-430f52c49c4e.jpg?1",
             "name": "Primal Adversary",
             "text": "Trample\nWhen Primal Adversary enters the battlefield, you may pay {1}{G} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Primal Adversary, then up to that many target lands you control become 3/3 Wolf creatures with haste that are still lands.",
             "colours": [
@@ -8367,7 +8367,7 @@
         },
         {
             "id": "cfb4499b-b783-5c20-9b21-31be95771e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e25c252-4177-4193-914c-b6933d9c0d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e25c252-4177-4193-914c-b6933d9c0d7d.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -8399,7 +8399,7 @@
         },
         {
             "id": "c7fb8c3b-26a0-5312-9ce6-bbb7fe4dd175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143fadd-0162-4e0c-89fc-89dc3501d13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3143fadd-0162-4e0c-89fc-89dc3501d13c.jpg?1",
             "name": "Rise of the Ants",
             "text": "Create two 3/3 green Insect creature tokens. You gain 2 life.\nFlashback {6}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "369df800-2efc-5520-b87d-b682e5ec580e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8b3a09-75e8-428c-91f7-8fac62fadc98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8b3a09-75e8-428c-91f7-8fac62fadc98.jpg?1",
             "name": "Saryth, the Viper's Fang",
             "text": "Other tapped creatures you control have deathtouch.\nOther untapped creatures you control have hexproof.\n{1}, {T}: Untap another target creature or land you control.",
             "colours": [
@@ -8470,7 +8470,7 @@
         },
         {
             "id": "9490232f-d9be-508a-92a1-9ddd2bd2c6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12e978-4deb-4ccc-8ae6-462bc4598c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b12e978-4deb-4ccc-8ae6-462bc4598c90.jpg?1",
             "name": "Shadowbeast Sighting",
             "text": "Create a 4/4 green Beast creature token.\nFlashback {6}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "65a6a7db-d3ec-5f2f-b361-8e80aa0336e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b614b21-69ed-4788-97d7-ad502b634abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b614b21-69ed-4788-97d7-ad502b634abb.jpg?1",
             "name": "Snarling Wolf",
             "text": "{1}{G}: Snarling Wolf gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -8536,7 +8536,7 @@
         },
         {
             "id": "cfaa2f30-bdaa-5982-8986-812b23d22417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f1f69c-122d-472a-b82d-fed7c253a4cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f1f69c-122d-472a-b82d-fed7c253a4cd.jpg?1",
             "name": "Storm the Festival",
             "text": "Look at the top five cards of your library. You may put up to two permanent cards with mana value 5 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\nFlashback {7}{G}{G}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "23012e9a-ae6f-520a-ad9d-815bb2b06a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba75dc52-7ab2-43ec-afac-0a9bcf24cde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba75dc52-7ab2-43ec-afac-0a9bcf24cde9.jpg?1",
             "name": "Tapping at the Window",
             "text": "Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest into your graveyard.\nFlashback {2}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8602,7 +8602,7 @@
         },
         {
             "id": "81d440aa-cb24-5ac4-b13a-3e3a7b71c799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215b6a-82e3-4ce8-b288-d7341761cad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b215b6a-82e3-4ce8-b288-d7341761cad0.jpg?1",
             "name": "Timberland Guide",
             "text": "When Timberland Guide enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8637,7 +8637,7 @@
         },
         {
             "id": "e9baf11a-3238-5296-9a2b-4ca4b940af77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "Vigilance\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8674,7 +8674,7 @@
         },
         {
             "id": "1e7cafcb-3626-53bf-a1c9-23da753a6f86",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e96f9a6-c215-42b1-aa02-8e6143fe5bd7.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "Vigilance\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "0bf51c8d-b481-5be5-8645-7f7d27d37846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "When Tovolar's Huntmaster enters the battlefield, create two 2/2 green Wolf creature tokens.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8747,7 +8747,7 @@
         },
         {
             "id": "24229b27-335a-538e-b6c0-95705dbcbbc0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3983a304-5040-4b8d-945a-bf4ede3104a8.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "Whenever Tovolar's Packleader enters the battlefield or attacks, create two 2/2 green Wolf creature tokens.\n{2}{G}{G}: Another target Wolf or Werewolf you control fights target creature you don't control.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "ec3f73e7-0da0-55b7-b1e0-370d78c48fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34076a93-9e8f-45d4-a1d7-31f40210a5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34076a93-9e8f-45d4-a1d7-31f40210a5b6.jpg?1",
             "name": "Turn the Earth",
             "text": "Choose up to three target cards in graveyards. The owners of those cards shuffle them into their libraries. You gain 2 life.\nFlashback {1}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "6a80d9d4-93c1-515a-a75a-e719cdaed501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6748a844-e185-4e3b-ac1d-8a735666d8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6748a844-e185-4e3b-ac1d-8a735666d8ae.jpg?1",
             "name": "Unnatural Growth",
             "text": "At the beginning of each combat, double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "e705572d-4baa-5f58-abbe-ec00d982dc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c40c71c-4cdc-4a28-8ea3-4636c936f8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c40c71c-4cdc-4a28-8ea3-4636c936f8aa.jpg?1",
             "name": "Willow Geist",
             "text": "Trample\nWhenever one or more cards leave your graveyard, put a +1/+1 counter on Willow Geist.\nWhen Willow Geist dies, you gain life equal to its power.",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "4fa35034-d0dc-5335-945a-1b08388e663a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7757e99-8d51-4b92-b346-6961845def24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7757e99-8d51-4b92-b346-6961845def24.jpg?1",
             "name": "Wrenn and Seven",
             "text": "+1: Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.\n0: Put any number of land cards from your hand onto the battlefield tapped.\n\u22123: Create a green Treefolk creature token with reach and \"This creature's power and toughness are each equal to the number of lands you control.\"\n\u22128: Return all permanent cards from your graveyard to your hand. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -8924,7 +8924,7 @@
         },
         {
             "id": "050334fc-2f00-5bcd-bbed-03b096e29716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4c7a2-6243-43ed-8c1c-e3edee43a583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba4c7a2-6243-43ed-8c1c-e3edee43a583.jpg?1",
             "name": "Angelfire Ignition",
             "text": "Put two +1/+1 counters on target creature. It gains vigilance, trample, lifelink, indestructible, and haste until end of turn.\nFlashback {2}{R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "0105938f-dd59-5806-9037-1b5576dbda9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab520b7-ad87-4c8e-a454-5c022e378564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ab520b7-ad87-4c8e-a454-5c022e378564.jpg?1",
             "name": "Arcane Infusion",
             "text": "Look at the top four cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{U}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8994,7 +8994,7 @@
         },
         {
             "id": "7450d1d0-1622-5a70-b874-a5464b530be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Daybound (If a player casts no spells during their own turn, it becomes night next turn.)\n+1: Until your next turn, you may cast creature spells as though they had flash, and each creature you control enters the battlefield with an additional +1/+1 counter on it.\n\u22123: Create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -9035,7 +9035,7 @@
         },
         {
             "id": "1956efa1-c954-5f26-854b-75d264419c54",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50d4b0df-a1d8-494f-a019-70ce34161320.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)\n+2: Add {R}{G}.\n0: Until end of turn, Arlinn, the Moon's Fury becomes a 5/5 Werewolf creature with trample, indestructible, and haste.",
             "colours": [
@@ -9076,7 +9076,7 @@
         },
         {
             "id": "c3fefc24-1c3f-5509-84cb-a80bea21353f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a73f77-aab5-47e3-bfc1-97f6374f40fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a73f77-aab5-47e3-bfc1-97f6374f40fc.jpg?1",
             "name": "Bladestitched Skaab",
             "text": "Other Zombies you control get +1/+0.",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "0b85833f-5a7f-58c1-a25d-84dcb53fc5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccfebf1-add1-4f62-bffa-9023dea5b7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ccfebf1-add1-4f62-bffa-9023dea5b7c4.jpg?1",
             "name": "Can't Stay Away",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains \"If this creature would die, exile it instead.\"\nFlashback {3}{W}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9149,7 +9149,7 @@
         },
         {
             "id": "7c2f5297-e6b5-5659-aec3-59dbe6f742e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe4f48d-179a-47d7-aed6-9751dd2f7d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe4f48d-179a-47d7-aed6-9751dd2f7d8c.jpg?1",
             "name": "Corpse Cobble",
             "text": "As an additional cost to cast this spell, sacrifice any number of creatures.\nCreate an X/X blue and black Zombie creature token with menace, where X is the total power of the sacrificed creatures.\nFlashback {3}{U}{B} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "34ac63a5-b7f4-52db-8c5c-eb604c691498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847b22f-6660-4654-91a9-e0adb8606bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9847b22f-6660-4654-91a9-e0adb8606bab.jpg?1",
             "name": "Croaking Counterpart",
             "text": "Create a token that's a copy of target non-Frog creature, except it's a 1/1 green Frog.\nFlashback {3}{G}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9219,7 +9219,7 @@
         },
         {
             "id": "2c5f9bb6-8bb8-5522-bebc-06c0ed85803e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb2f0a7-f3a6-4487-b847-4ef26ad5ecad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb2f0a7-f3a6-4487-b847-4ef26ad5ecad.jpg?1",
             "name": "Dawnhart Wardens",
             "text": "Vigilance\nCoven \u2014 At the beginning of combat on your turn, if you control three or more creatures with different powers, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -9258,7 +9258,7 @@
         },
         {
             "id": "f1c8c16b-0a29-58e5-a782-128f8ad542b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Lifelink\nCards in graveyards can't be the targets of spells or abilities.\nDisturb {2}{W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "3ecbb2c7-3b07-557c-9088-4642dc903396",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35cf2d72-931f-47b1-a1b4-916f0383551a.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Flying\nWhenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")\nIf Dennick, Pious Apparition would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "1f62e4d7-700b-5815-8bc1-aedbfc9b3f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg?1",
             "name": "Devoted Grafkeeper // Departed Soulkeeper",
             "text": "When Devoted Grafkeeper enters the battlefield, mill two cards.\nWhenever you cast a spell from your graveyard, tap target creature you don't control.\nDisturb {1}{W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -9377,7 +9377,7 @@
         },
         {
             "id": "8237df0e-a4a4-5daa-8a1f-aa600e03621f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/965e6bd5-dc32-406c-bc99-ceb15be4d3f2.jpg?1",
             "name": "Devoted Grafkeeper // Departed Soulkeeper",
             "text": "Flying\nDeparted Soulkeeper can block only creatures with flying.\nIf Departed Soulkeeper would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -9413,7 +9413,7 @@
         },
         {
             "id": "c855e474-9f8c-57be-ae96-3ca15bc288d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg?1",
             "name": "A-Devoted Grafkeeper // A-Departed Soulkeeper",
             "text": "",
             "colours": [
@@ -9449,7 +9449,7 @@
         },
         {
             "id": "8169d2bb-5aed-57d1-b5d8-d131c43bb771",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/5132a045-fe39-4e45-8abd-d0c1069caee7.jpg?1",
             "name": "A-Devoted Grafkeeper // A-Departed Soulkeeper",
             "text": "",
             "colours": [
@@ -9484,7 +9484,7 @@
         },
         {
             "id": "16240e97-9066-58b5-a45b-c0fafa60dd4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4a7c01-95ca-43bf-bc53-875cfb4bffa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4a7c01-95ca-43bf-bc53-875cfb4bffa1.jpg?1",
             "name": "Dire-Strain Rampage",
             "text": "Destroy target artifact, enchantment, or land. If a land was destroyed this way, its controller may search their library for up to two basic land cards, put them onto the battlefield tapped, then shuffle. Otherwise, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.\nFlashback {3}{R}{G}",
             "colours": [
@@ -9520,7 +9520,7 @@
         },
         {
             "id": "f93af46b-3fd3-5bf5-b9aa-b0c2fb577e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51ed1ea-661e-49c6-9751-1eb7bb651bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51ed1ea-661e-49c6-9751-1eb7bb651bb1.jpg?1",
             "name": "Diregraf Rebirth",
             "text": "This spell costs {1} less to cast for each creature that died this turn.\nReturn target creature card from your graveyard to the battlefield.\nFlashback {5}{B}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "d8b0d757-7eb1-5aea-b72e-3a654ae9b19c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50752ca9-ea85-4c4b-9bf5-4f8759a7dcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50752ca9-ea85-4c4b-9bf5-4f8759a7dcec.jpg?1",
             "name": "Faithful Mending",
             "text": "You gain 2 life, draw two cards, then discard two cards.\nFlashback {1}{W}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9588,7 +9588,7 @@
         },
         {
             "id": "3d06ea9b-0eba-50b6-a72b-4813821e7178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed8c0ef-2b53-49b5-bc2f-428628cb3975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed8c0ef-2b53-49b5-bc2f-428628cb3975.jpg?1",
             "name": "Fleshtaker",
             "text": "Whenever you sacrifice another creature, you gain 1 life and scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{1}, Sacrifice another creature: Fleshtaker gets +2/+2 until end of turn.",
             "colours": [
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "87fd67c9-62c8-579b-a215-c363c23da22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53289e69-74da-46d2-91c2-a11378ba76ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53289e69-74da-46d2-91c2-a11378ba76ef.jpg?1",
             "name": "Florian, Voldaren Scion",
             "text": "First strike\nAt the beginning of your postcombat main phase, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -9666,7 +9666,7 @@
         },
         {
             "id": "b0b940bc-628d-5bc1-8d8e-f2c544e04811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8ee5b-e1f5-4bc8-8ca3-d8308d71f2b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f8ee5b-e1f5-4bc8-8ca3-d8308d71f2b9.jpg?1",
             "name": "Galvanic Iteration",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nFlashback {1}{U}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "ea67373e-2b7a-5c60-8b8e-dd074527d676",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a507ea6-d818-4443-b468-cf65c3e7031c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a507ea6-d818-4443-b468-cf65c3e7031c.jpg?1",
             "name": "Ghoulcaller's Harvest",
             "text": "Create X 2/2 black Zombie creature tokens with decayed, where X is half the number of creature cards in your graveyard, rounded up. (A creature with decayed can't block. When it attacks, sacrifice it at end of combat.)\nFlashback {3}{B}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "aeda2c8d-3685-5fa3-86f8-ae068e0640cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec421f1-4ee8-4816-ab5c-372e87aae231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec421f1-4ee8-4816-ab5c-372e87aae231.jpg?1",
             "name": "Grizzly Ghoul",
             "text": "Trample\nGrizzly Ghoul enters the battlefield with a +1/+1 counter on it for each creature that died this turn.",
             "colours": [
@@ -9775,7 +9775,7 @@
         },
         {
             "id": "770b3537-e3f5-5a75-bedf-dbb3f6949da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2877523-6321-47e6-8be4-755ec21676c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2877523-6321-47e6-8be4-755ec21676c6.jpg?1",
             "name": "Hallowed Respite",
             "text": "Exile target nonlegendary creature, then return it to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on it. Otherwise, tap it.\nFlashback {1}{W}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "1bb43027-59b4-51f3-a467-a40fc086a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce09c0df-d022-4ebf-8f7f-8a913249e75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce09c0df-d022-4ebf-8f7f-8a913249e75f.jpg?1",
             "name": "Hungry for More",
             "text": "Create a 3/1 black and red Vampire creature token with trample, lifelink, and haste. Sacrifice it at the beginning of the next end step.\nFlashback {1}{B}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9845,7 +9845,7 @@
         },
         {
             "id": "95103ddf-fd4b-5ebb-9dc8-0052ca3da3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b30a99-601b-40b9-b012-30fa4be5fd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b30a99-601b-40b9-b012-30fa4be5fd3c.jpg?1",
             "name": "Join the Dance",
             "text": "Create two 1/1 white Human creature tokens.\nFlashback {3}{G}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "94bae36e-66ea-5ae3-a449-5a556d9cf32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673cd775-d417-4652-a91d-825ad5c89e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673cd775-d417-4652-a91d-825ad5c89e8a.jpg?1",
             "name": "Katilda, Dawnhart Prime",
             "text": "Protection from Werewolves\nHuman creatures you control have \"{T}: Add one mana of any of this creature's colors.\"\n{4}{G}{W}, {T}: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "ebe8980b-a6a3-5139-aaf6-8d11e37e0c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "Whenever Kessig Naturalist attacks, add {R} or {G}. Until end of turn, you don't lose this mana as steps and phases end.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9961,7 +9961,7 @@
         },
         {
             "id": "33a44fdf-9467-5415-b92d-b6d72bff24be",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ab5f2e6-0e0a-4f7d-a959-3d07948ff317.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "Other Wolves and Werewolves you control get +1/+1.\nWhenever Lord of the Ulvenwald attacks, add {R} or {G}. Until end of turn, you don't lose this mana as steps and phases end.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9999,7 +9999,7 @@
         },
         {
             "id": "ee7adcd4-52f5-57cd-8277-1b553a6b70b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532fca6b-f788-43f8-b29f-7273e7a48449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532fca6b-f788-43f8-b29f-7273e7a48449.jpg?1",
             "name": "Liesa, Forgotten Archangel",
             "text": "Flying, lifelink\nWhenever another nontoken creature you control dies, return that card to its owner's hand at the beginning of the next end step.\nIf a creature an opponent controls would die, exile it instead.",
             "colours": [
@@ -10039,7 +10039,7 @@
         },
         {
             "id": "05a2281d-457f-5385-869f-5eaa3711e160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "Whenever Ludevic, Necrogenius enters the battlefield or attacks, mill a card.\n{X}{U}{U}{B}{B}, Exile X creature cards from your graveyard: Transform Ludevic. X can't be 0. Activate only as a sorcery.",
             "colours": [
@@ -10080,7 +10080,7 @@
         },
         {
             "id": "40dfd18b-ad5e-5681-b7d4-3426cb898014",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/788288f6-7944-48f4-91b0-f452e209c9ce.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "As this creature transforms into Olag, Ludevic's Hubris, it becomes a copy of a creature card exiled with it, except its name is Olag, Ludevic's Hubris, it's 4/4, and it's a legendary blue and black Zombie in addition to its other colors and types. Put a number of +1/+1 counters on Olag equal to the number of creature cards exiled with it.",
             "colours": [
@@ -10120,7 +10120,7 @@
         },
         {
             "id": "5391aca1-89c6-53ea-be08-bb78e3bd64d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b203be6f-c565-4d8f-b200-b537569a0292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b203be6f-c565-4d8f-b200-b537569a0292.jpg?1",
             "name": "Old Stickfingers",
             "text": "When you cast this spell, reveal cards from the top of your library until you reveal X creature cards. Put all creature cards revealed this way into your graveyard, then put the rest on the bottom of your library in a random order.\nOld Stickfingers's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -10160,7 +10160,7 @@
         },
         {
             "id": "f27c51ca-a19b-594a-8b9b-3c9c179bc6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31e307a-9689-4e11-8c5f-96b7a4b50bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31e307a-9689-4e11-8c5f-96b7a4b50bed.jpg?1",
             "name": "Rem Karolus, Stalwart Slayer",
             "text": "Flying, haste\nIf a spell would deal damage to you or another permanent you control, prevent that damage.\nIf a spell would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -10201,7 +10201,7 @@
         },
         {
             "id": "83f1d52e-a13e-59e5-b6de-8179577f6929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1a16f9-13d4-4188-8e1e-0f2394349c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb1a16f9-13d4-4188-8e1e-0f2394349c7a.jpg?1",
             "name": "Rite of Harmony",
             "text": "Whenever a creature or enchantment enters the battlefield under your control this turn, draw a card.\nFlashback {2}{G}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10237,7 +10237,7 @@
         },
         {
             "id": "c4e8f1a9-1382-59cc-8286-67266bf2a9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f8d52-565e-4900-8357-fd29f2022dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f8d52-565e-4900-8357-fd29f2022dc1.jpg?1",
             "name": "Rite of Oblivion",
             "text": "As an additional cost to cast this spell, sacrifice a nonland permanent.\nExile target nonland permanent.\nFlashback {2}{W}{B} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
             "colours": [
@@ -10271,7 +10271,7 @@
         },
         {
             "id": "989faa25-f8a6-58a5-b960-9f3320c13a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3743cf9c-226f-43a3-b385-375a25414792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3743cf9c-226f-43a3-b385-375a25414792.jpg?1",
             "name": "Rootcoil Creeper",
             "text": "{T}: Add one mana of any color.\n{T}: Add two mana of any one color. Spend this mana only to cast spells from your graveyard.\n{G}{U}, {T}, Exile Rootcoil Creeper: Return target card with flashback you own from exile to your hand.",
             "colours": [
@@ -10308,7 +10308,7 @@
         },
         {
             "id": "c3dd074c-2b42-51bf-b791-f7f84be7a9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b1dcd7-6dd9-4134-bc6c-9dc7754006a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b1dcd7-6dd9-4134-bc6c-9dc7754006a2.jpg?1",
             "name": "Sacred Fire",
             "text": "Sacred Fire deals 2 damage to any target and you gain 2 life.\nFlashback {4}{R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10342,7 +10342,7 @@
         },
         {
             "id": "accfa508-c69a-5546-b200-f6bfd6c3c9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cf357-c231-4512-aa9a-ab4a60007136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6cf357-c231-4512-aa9a-ab4a60007136.jpg?1",
             "name": "Sigarda, Champion of Light",
             "text": "Flying, trample\nHumans you control get +1/+1.\nCoven \u2014 Whenever Sigarda attacks, if you control three or more creatures with different powers, look at the top five cards of your library. You may reveal a Human creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10382,7 +10382,7 @@
         },
         {
             "id": "ab2df273-6324-5079-bd6a-3f4c572fae2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d329e2d4-e483-4981-8a0b-6a9a717d50cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d329e2d4-e483-4981-8a0b-6a9a717d50cd.jpg?1",
             "name": "Siphon Insight",
             "text": "Look at the top two cards of target opponent's library. Exile one of them face down and put the other on the bottom of that library. You may look at and play the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\nFlashback {1}{U}{B}",
             "colours": [
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "6b13d83e-6026-55e2-9038-cd6459ffec18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94e888b-6eeb-4ef3-ab21-5ed2bf0036a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94e888b-6eeb-4ef3-ab21-5ed2bf0036a3.jpg?1",
             "name": "Slogurk, the Overslime",
             "text": "Trample\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Slogurk, the Overslime.\nRemove three +1/+1 counters from Slogurk: Return it to its owner's hand.\nWhen Slogurk leaves the battlefield, return up to three target land cards from your graveyard to your hand.",
             "colours": [
@@ -10458,7 +10458,7 @@
         },
         {
             "id": "a558119d-ae11-5088-9a6a-0312495280f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49618f-2e9e-4674-9953-153ccc76cce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c49618f-2e9e-4674-9953-153ccc76cce2.jpg?1",
             "name": "Storm Skreelix",
             "text": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, Storm Skreelix gets +2/+0 until end of turn.",
             "colours": [
@@ -10495,7 +10495,7 @@
         },
         {
             "id": "760a76c4-bc08-5780-898d-9d4da3880a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0081b1-40fd-44ad-b154-efe2f27fed6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0081b1-40fd-44ad-b154-efe2f27fed6b.jpg?1",
             "name": "Sunrise Cavalier",
             "text": "Trample, haste\nIf it's neither day nor night, it becomes day as Sunrise Cavalier enters the battlefield.\nWhenever day becomes night or night becomes day, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -10532,7 +10532,7 @@
         },
         {
             "id": "39c5ef1d-b358-539e-b3fc-41573cc30c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2e18d4-986c-4a44-8f26-1b8689339cfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2e18d4-986c-4a44-8f26-1b8689339cfb.jpg?1",
             "name": "Teferi, Who Slows the Sunset",
             "text": "+1: Choose up to one target artifact, up to one target creature, and up to one target land. Untap the chosen permanents you control. Tap the chosen permanents you don't control. You gain 2 life.\n\u22122: Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\n\u22127: You get an emblem with \"Untap all permanents you control during each opponent's untap step\" and \"You draw a card during each opponent's draw step.\"",
             "colours": [
@@ -10572,7 +10572,7 @@
         },
         {
             "id": "21dd2fa3-93db-5255-9553-232ed6c9955f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "Whenever a Wolf or Werewolf you control deals combat damage to a player, draw a card.\nAt the beginning of your upkeep, if you control three or more Wolves and/or Werewolves, it becomes night. Then transform any number of Human Werewolves you control.\nDaybound",
             "colours": [
@@ -10613,7 +10613,7 @@
         },
         {
             "id": "25891f92-590d-5834-8e0e-492996255bee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f953fad3-0cd1-48aa-8ed9-d7d2e293e6e2.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "Whenever a Wolf or Werewolf you control deals combat damage to a player, draw a card.\n{X}{R}{G}: Target Wolf or Werewolf you control gets +X/+0 and gains trample until end of turn.\nNightbound",
             "colours": [
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "9ca6be69-b310-5be1-a842-24abe2ce58e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdd9df1-6a3b-4f03-8eca-00ed22c02566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfdd9df1-6a3b-4f03-8eca-00ed22c02566.jpg?1",
             "name": "Unnatural Moonrise",
             "text": "It becomes night. Until end of turn, target creature gets +1/+0 and gains trample and \"Whenever this creature deals combat damage to a player, draw a card.\"\nFlashback {2}{R}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10687,7 +10687,7 @@
         },
         {
             "id": "8955b15c-162e-5f2f-a3e7-538031a3e6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454666bb-f81d-4845-84aa-d6f8f80ce86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454666bb-f81d-4845-84aa-d6f8f80ce86a.jpg?1",
             "name": "Vadrik, Astral Archmage",
             "text": "If it's neither day nor night, it becomes day as Vadrik, Astral Archmage enters the battlefield.\nInstant and sorcery spells you cast cost {X} less to cast, where X is Vadrik's power.\nWhenever day becomes night or night becomes day, put a +1/+1 counter on Vadrik.",
             "colours": [
@@ -10728,7 +10728,7 @@
         },
         {
             "id": "02337410-6162-5634-b77a-fe1a7464458d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07cbf04-2864-4407-800e-4d55c10d3426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07cbf04-2864-4407-800e-4d55c10d3426.jpg?1",
             "name": "Vampire Socialite",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Vampire Socialite enters the battlefield, if an opponent lost life this turn, put a +1/+1 counter on each other Vampire you control.\nAs long as an opponent lost life this turn, each other Vampire you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -10765,7 +10765,7 @@
         },
         {
             "id": "1280443a-97ef-554d-803a-b1eba8ec8de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f02a544-716c-4f09-8ae9-dbfe7ef136d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f02a544-716c-4f09-8ae9-dbfe7ef136d7.jpg?1",
             "name": "Wake to Slaughter",
             "text": "Choose up to two target creature cards in your graveyard. An opponent chooses one of them. Return that card to your hand. Return the other to the battlefield under your control. It gains haste. Exile it at the beginning of the next end step.\nFlashback {4}{B}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "d13957a4-3f58-5bbb-a862-780eeae0ee48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e9edd3-151d-4bf6-b491-03db9db32234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e9edd3-151d-4bf6-b491-03db9db32234.jpg?1",
             "name": "Winterthorn Blessing",
             "text": "Put a +1/+1 counter on up to one target creature you control. Tap up to one target creature you don't control, and that creature doesn't untap during its controller's next untap step.\nFlashback {1}{G}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10835,7 +10835,7 @@
         },
         {
             "id": "bc06cbe5-e4ff-54d9-b504-a5c7b3333124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39226a07-d44e-41a6-b9f1-685ef505d015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39226a07-d44e-41a6-b9f1-685ef505d015.jpg?1",
             "name": "The Celestus",
             "text": "If it's neither day nor night, it becomes day as The Celestus enters the battlefield.\n{T}: Add one mana of any color.\n{3}, {T}: If it's night, it becomes day. Otherwise, it becomes night. Activate only as a sorcery.\nWhenever day becomes night or night becomes day, you gain 1 life. You may draw a card. If you do, discard a card.",
             "colours": [],
@@ -10867,7 +10867,7 @@
         },
         {
             "id": "141d1f58-946a-5630-bdf1-9df88e80010e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad1524-9e75-47e0-b817-47110634802a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cad1524-9e75-47e0-b817-47110634802a.jpg?1",
             "name": "Crossroads Candleguide",
             "text": "When Crossroads Candleguide enters the battlefield, exile up to one target card from a graveyard.\n{2}: Add one mana of any color.",
             "colours": [],
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "41faef03-46c3-5383-91af-1441066834ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b589ab-45a0-480a-a891-581c34f8a9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b589ab-45a0-480a-a891-581c34f8a9bf.jpg?1",
             "name": "Jack-o'-Lantern",
             "text": "{1}, {T}, Sacrifice Jack-o'-Lantern: Exile up to one target card from a graveyard. Draw a card.\n{1}, Exile Jack-o'-Lantern from your graveyard: Add one mana of any color.",
             "colours": [],
@@ -10926,7 +10926,7 @@
         },
         {
             "id": "b6b5758c-a97a-5b69-bc76-acc21b8aaf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87778e37-af92-402e-b037-5fbd6112b682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87778e37-af92-402e-b037-5fbd6112b682.jpg?1",
             "name": "Moonsilver Key",
             "text": "{1}, {T}, Sacrifice Moonsilver Key: Search your library for an artifact card with a mana ability or a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -10954,7 +10954,7 @@
         },
         {
             "id": "ea6f4366-b2b0-5bd8-ac96-497f5d728053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg?1",
             "name": "Mystic Skull // Mystic Monstrosity",
             "text": "{1}, {T}: Add one mana of any color.\n{5}, {T}: Transform Mystic Skull.",
             "colours": [],
@@ -10982,7 +10982,7 @@
         },
         {
             "id": "dc22eeea-7a68-59c7-8422-a596d4189386",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/115a9a44-131d-45f3-852a-40fd18e4afb6.jpg?1",
             "name": "Mystic Skull // Mystic Monstrosity",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"",
             "colours": [],
@@ -11013,7 +11013,7 @@
         },
         {
             "id": "fa514288-97e0-5ea7-8fd2-0c9272f6e19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556ec6ab-a19f-4caa-8bfa-145555402caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556ec6ab-a19f-4caa-8bfa-145555402caf.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -11043,7 +11043,7 @@
         },
         {
             "id": "757f1e1a-076f-5742-afab-5659af57dd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2c05a8-db56-4397-9b6c-5accb2d3f81f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2c05a8-db56-4397-9b6c-5accb2d3f81f.jpg?1",
             "name": "Silver Bolt",
             "text": "{3}, {T}, Sacrifice Silver Bolt: It deals 3 damage to target creature. If a Werewolf is dealt damage this way, destroy it.",
             "colours": [],
@@ -11071,7 +11071,7 @@
         },
         {
             "id": "003cf175-385c-5e76-b62a-04ff30703fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd40276-016b-475f-906f-74d31dceaf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd40276-016b-475f-906f-74d31dceaf70.jpg?1",
             "name": "Stuffed Bear",
             "text": "{2}: Stuffed Bear becomes a 4/4 green Bear artifact creature until end of turn.",
             "colours": [],
@@ -11099,7 +11099,7 @@
         },
         {
             "id": "351012c3-c774-5f06-8c0e-0f26017f011f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38367ee5-154b-44cb-8974-422038d039df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38367ee5-154b-44cb-8974-422038d039df.jpg?1",
             "name": "Deserted Beach",
             "text": "Deserted Beach enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "ba05d48d-8b06-5598-8d61-971b6fa899ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb471f90-46f2-4037-87fc-f523fc9d004f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb471f90-46f2-4037-87fc-f523fc9d004f.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11160,7 +11160,7 @@
         },
         {
             "id": "9e79b341-6d00-55e0-be68-e6a748eadcbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d510eece-4f55-4198-83fe-5291a76ffdcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d510eece-4f55-4198-83fe-5291a76ffdcc.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles.",
             "colours": [],
@@ -11188,7 +11188,7 @@
         },
         {
             "id": "a014a45e-0f72-5ec4-bfd2-5afda91512ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b200e822-be36-4e59-bd0e-9d0188a68df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b200e822-be36-4e59-bd0e-9d0188a68df8.jpg?1",
             "name": "Haunted Ridge",
             "text": "Haunted Ridge enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11221,7 +11221,7 @@
         },
         {
             "id": "f2aa39ee-e000-57d3-8e08-6db4b5114124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice a creature: Put a soul counter on Hostile Hostel. Then if there are three or more soul counters on it, remove those counters, transform it, then untap it. Activate only as a sorcery.",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "3cb1937e-97e5-53d9-b75b-93b4e74196f7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac83c27f-55d6-4e5a-93a4-febb0c183289.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "Whenever Creeping Inn attacks, you may exile a creature card from your graveyard. If you do, each opponent loses X life and you gain X life, where X is the number of creature cards exiled with Creeping Inn.\n{4}: Creeping Inn phases out.",
             "colours": [
@@ -11291,7 +11291,7 @@
         },
         {
             "id": "2a2e75fd-9a21-5d4d-b83f-2d5c385e2a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a76e0f-49fc-4087-8859-98f4a4deacdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a76e0f-49fc-4087-8859-98f4a4deacdf.jpg?1",
             "name": "Overgrown Farmland",
             "text": "Overgrown Farmland enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "2b247b13-c724-53ee-bd2d-f832a6ae7ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaff0a1e-b65a-422f-8f9f-65fac037047d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaff0a1e-b65a-422f-8f9f-65fac037047d.jpg?1",
             "name": "Rockfall Vale",
             "text": "Rockfall Vale enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -11357,7 +11357,7 @@
         },
         {
             "id": "f335b77f-53ce-5cb9-b544-4f51d7939f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7579824a-6e46-442b-95ff-03fea4adbba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7579824a-6e46-442b-95ff-03fea4adbba6.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "Shipwreck Marsh enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11390,7 +11390,7 @@
         },
         {
             "id": "e409e1f5-59bd-51f0-be9c-4152342944c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1902d-0b09-4bbe-9059-a0779450ee05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed1902d-0b09-4bbe-9059-a0779450ee05.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11427,7 +11427,7 @@
         },
         {
             "id": "bd8177b8-d7e7-5646-a284-86d746c3e5d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acefadb-8b2f-4319-a5e9-1e8fd9ef3086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acefadb-8b2f-4319-a5e9-1e8fd9ef3086.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11464,7 +11464,7 @@
         },
         {
             "id": "53feba3f-3821-50eb-878f-d8a6f91ee1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3bd34-4d12-4728-a53a-b5ae434d74b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3bd34-4d12-4728-a53a-b5ae434d74b0.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11501,7 +11501,7 @@
         },
         {
             "id": "30f70fd7-525a-55d3-99a4-f5d6c9fbdf4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2cfa62-c972-4373-b405-a075697d009c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed2cfa62-c972-4373-b405-a075697d009c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11538,7 +11538,7 @@
         },
         {
             "id": "fd072f4b-fa3d-55fd-8fce-9f4030d811ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ba59d8-c13c-4966-845f-c090e9f061cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ba59d8-c13c-4966-845f-c090e9f061cb.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "b2280552-f148-54a4-8217-7d136e5063f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fef662-993c-4522-8b3f-7c1d3bb1d946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38fef662-993c-4522-8b3f-7c1d3bb1d946.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11612,7 +11612,7 @@
         },
         {
             "id": "44970d1e-88c1-565c-bf1b-abc6af8b365e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba24a61-e529-4490-8536-6276ea77c511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba24a61-e529-4490-8536-6276ea77c511.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11649,7 +11649,7 @@
         },
         {
             "id": "a0639963-8ec4-5013-9d71-5b8cd0b89675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c0731-555a-4bef-9d9e-b877f0339417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c0731-555a-4bef-9d9e-b877f0339417.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "ea2a2ba8-dec2-55c7-af4a-2de52d404cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8ff40e-2d40-4557-8209-d2c84eb4ccf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8ff40e-2d40-4557-8209-d2c84eb4ccf2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "0c1b7f25-d6cd-5897-bebf-003b5c97bb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122b5548-5ff5-43e4-b799-75c709b1c32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122b5548-5ff5-43e4-b799-75c709b1c32d.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11760,7 +11760,7 @@
         },
         {
             "id": "12ba2109-11e1-5562-bb15-57dbd0274276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3628a023-3f69-4b7f-a6cc-42e4293ecfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3628a023-3f69-4b7f-a6cc-42e4293ecfdd.jpg?1",
             "name": "Wrenn and Seven",
             "text": "+1: Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.\n0: Put any number of land cards from your hand onto the battlefield tapped.\n\u22123: Create a green Treefolk creature token with reach and \"This creature's power and toughness are each equal to the number of lands you control.\"\n\u22128: Return all permanent cards from your graveyard to your hand. You get an emblem with \"You have no maximum hand size.\"",
             "colours": [
@@ -11798,7 +11798,7 @@
         },
         {
             "id": "3fd7e042-f38d-527e-a7d8-4685c437f511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Daybound\n+1: Until your next turn, you may cast creature spells as though they had flash, and each creature you control enters the battlefield with an additional +1/+1 counter on it.\n\u22123: Create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -11839,7 +11839,7 @@
         },
         {
             "id": "475c8a1d-471b-5f3e-a38c-6f5d8b347728",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f93ade1b-ee36-44c9-ac82-f0c3124ffde3.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "Nightbound\n+2: Add {R}{G}.\n0: Until end of turn, Arlinn, the Moon's Fury becomes a 5/5 Werewolf creature with trample, indestructible, and haste.",
             "colours": [
@@ -11880,7 +11880,7 @@
         },
         {
             "id": "3ab9c25b-29b0-55f1-8d4b-fa4af73edda0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94bc06c-6351-43d3-a58d-b28dc6d4705c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94bc06c-6351-43d3-a58d-b28dc6d4705c.jpg?1",
             "name": "Teferi, Who Slows the Sunset",
             "text": "+1: Choose up to one target artifact, up to one target creature, and up to one target land. Untap the chosen permanents you control. Tap the chosen permanents you don't control. You gain 2 life.\n\u22122: Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\n\u22127: You get an emblem with \"Untap all permanents you control during each opponent's untap step\" and \"You draw a card during each opponent's draw step.\"",
             "colours": [
@@ -11920,7 +11920,7 @@
         },
         {
             "id": "d99b271d-f536-5915-8f24-c8d8258d53d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c092d9c5-538f-4667-9070-bdce7f8b522a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c092d9c5-538f-4667-9070-bdce7f8b522a.jpg?1",
             "name": "Deserted Beach",
             "text": "Deserted Beach enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11953,7 +11953,7 @@
         },
         {
             "id": "86a2b881-0180-5193-a19c-fdff17758b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f67a64-b97d-473a-be9d-c8044ff86605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f67a64-b97d-473a-be9d-c8044ff86605.jpg?1",
             "name": "Haunted Ridge",
             "text": "Haunted Ridge enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11986,7 +11986,7 @@
         },
         {
             "id": "4c33d27d-81de-57cc-9221-2978181e386d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46aa097-ad92-4f9a-be52-e4e485a8fe99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46aa097-ad92-4f9a-be52-e4e485a8fe99.jpg?1",
             "name": "Overgrown Farmland",
             "text": "Overgrown Farmland enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -12019,7 +12019,7 @@
         },
         {
             "id": "d90a0378-4141-586a-b509-c7d314db4eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcc5d4-babd-4b66-95fa-c5ec6c49e93a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcc5d4-babd-4b66-95fa-c5ec6c49e93a.jpg?1",
             "name": "Rockfall Vale",
             "text": "Rockfall Vale enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -12052,7 +12052,7 @@
         },
         {
             "id": "09fbb7b1-eebd-5107-8bb8-c9bc5a9f9ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad2562-fc26-40a1-9e6c-21f4f88dc2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ad2562-fc26-40a1-9e6c-21f4f88dc2d8.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "Shipwreck Marsh enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -12085,7 +12085,7 @@
         },
         {
             "id": "e56c6f8e-adde-502e-bfa0-07bc52f23149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "",
             "colours": [
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "5e2ceecd-3161-50c0-ac36-cd44c2560544",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a459833f-8cf4-43c0-9523-eb37de450bc1.jpg?1",
             "name": "Brutal Cathar // Moonrage Brute",
             "text": "",
             "colours": [
@@ -12161,7 +12161,7 @@
         },
         {
             "id": "bbfbd4af-b08a-55ca-8387-2ae8f2b9c19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482c0eab-326b-41db-9be6-f98d15bbd0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482c0eab-326b-41db-9be6-f98d15bbd0af.jpg?1",
             "name": "Candlegrove Witch",
             "text": "",
             "colours": [
@@ -12198,7 +12198,7 @@
         },
         {
             "id": "b2c92d64-66d7-5dab-b542-3dfb3cc50682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da534-738e-4507-821f-f30956045646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783da534-738e-4507-821f-f30956045646.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "",
             "colours": [
@@ -12237,7 +12237,7 @@
         },
         {
             "id": "c9626980-d33e-5921-9f4d-7ae8e7e47686",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783da534-738e-4507-821f-f30956045646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/783da534-738e-4507-821f-f30956045646.jpg?1",
             "name": "Suspicious Stowaway // Seafaring Werewolf",
             "text": "",
             "colours": [
@@ -12274,7 +12274,7 @@
         },
         {
             "id": "ea873dbb-db1d-59df-a4b1-ddc23c8ee235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "",
             "colours": [
@@ -12312,7 +12312,7 @@
         },
         {
             "id": "4184eb6e-bced-5600-bf22-40c27a9c4303",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b13fbff-8b72-459a-ac72-3429be6e192d.jpg?1",
             "name": "Baneblade Scoundrel // Baneclaw Marauder",
             "text": "",
             "colours": [
@@ -12348,7 +12348,7 @@
         },
         {
             "id": "0213e762-d29e-5ada-91c6-bf0ba369640e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "",
             "colours": [
@@ -12385,7 +12385,7 @@
         },
         {
             "id": "5a5913ef-4f7a-590c-a1c0-040644f1ff80",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41932ef6-0f64-40c1-946c-679976326e2d.jpg?1",
             "name": "Graveyard Trespasser // Graveyard Glutton",
             "text": "",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "90f9b1ba-afee-5034-9bbc-88f173532548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "",
             "colours": [
@@ -12458,7 +12458,7 @@
         },
         {
             "id": "39aeadfe-9b78-5bb2-9053-8345a2beb281",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1463082-62bb-4aa6-8763-b865ef1fdb68.jpg?1",
             "name": "Shady Traveler // Stalking Predator",
             "text": "",
             "colours": [
@@ -12494,7 +12494,7 @@
         },
         {
             "id": "1f7dd0fc-6046-51ad-b51e-035bacedf3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "",
             "colours": [
@@ -12531,7 +12531,7 @@
         },
         {
             "id": "02b97bcd-3058-5fa5-9e1b-21652be29823",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/35e17f53-021b-484b-9ede-524742fe8aae.jpg?1",
             "name": "Fangblade Brigand // Fangblade Eviscerator",
             "text": "",
             "colours": [
@@ -12567,7 +12567,7 @@
         },
         {
             "id": "edc204dc-f2f9-5aa5-99de-ac3d42ba2d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "",
             "colours": [
@@ -12604,7 +12604,7 @@
         },
         {
             "id": "dcade9bb-d061-5f93-8c15-e2fba766b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28bc2848-b6fb-444d-b909-01c712696547.jpg?1",
             "name": "Harvesttide Infiltrator // Harvesttide Assailant",
             "text": "",
             "colours": [
@@ -12640,7 +12640,7 @@
         },
         {
             "id": "29563237-0610-5ac1-b892-66077c5c15e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "",
             "colours": [
@@ -12677,7 +12677,7 @@
         },
         {
             "id": "2639054a-d2fa-5e5d-9ab0-14590ff5536f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/8/c882efbc-8443-4521-9e6a-807997a6439b.jpg?1",
             "name": "Reckless Stormseeker // Storm-Charged Slasher",
             "text": "",
             "colours": [
@@ -12713,7 +12713,7 @@
         },
         {
             "id": "03df0b18-20fb-5a47-bc75-fdcbcd9bbda3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "",
             "colours": [
@@ -12751,7 +12751,7 @@
         },
         {
             "id": "8ffe8af6-6b6d-554d-be08-90cf2d25c92e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d4d2aac-84ed-434e-921e-b724e3854cf2.jpg?1",
             "name": "Spellrune Painter // Spellrune Howler",
             "text": "",
             "colours": [
@@ -12787,7 +12787,7 @@
         },
         {
             "id": "5f7ad8e0-4115-5a28-acb0-7f7a2bf0c35f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "",
             "colours": [
@@ -12825,7 +12825,7 @@
         },
         {
             "id": "169bc3fe-3455-5839-abdf-2ac315cf089f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8ca358b8-dee7-462d-aee1-f2e271d38370.jpg?1",
             "name": "Tavern Ruffian // Tavern Smasher",
             "text": "",
             "colours": [
@@ -12861,7 +12861,7 @@
         },
         {
             "id": "ff29a4ba-5f08-58a1-bec4-b76a1bc46132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "",
             "colours": [
@@ -12898,7 +12898,7 @@
         },
         {
             "id": "4c545fd3-f58f-5804-8271-84b071d36922",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a622635e-482d-4621-8874-3945af74e9ca.jpg?1",
             "name": "Village Watch // Village Reavers",
             "text": "",
             "colours": [
@@ -12934,7 +12934,7 @@
         },
         {
             "id": "3e6d1b67-1658-572a-9837-e2be8757273d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "",
             "colours": [
@@ -12972,7 +12972,7 @@
         },
         {
             "id": "9c4e07b8-cfb9-5b23-896e-df00754fa6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/7247d5ab-2897-4c89-a030-2947328a0c9e.jpg?1",
             "name": "Bird Admirer // Wing Shredder",
             "text": "",
             "colours": [
@@ -13008,7 +13008,7 @@
         },
         {
             "id": "fe2e87d2-9137-5dd2-9e75-a69e99c69b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "",
             "colours": [
@@ -13045,7 +13045,7 @@
         },
         {
             "id": "7d1e631a-8a9e-576f-8af2-3340f4e5eb38",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b50c98e-6c3b-4129-ae93-10c0bf9270fc.jpg?1",
             "name": "Burly Breaker // Dire-Strain Demolisher",
             "text": "",
             "colours": [
@@ -13081,7 +13081,7 @@
         },
         {
             "id": "609d9b83-1654-5b83-9ad7-fa04c1b699dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac558d9d-5c7d-4671-ae0b-94c099e1b111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac558d9d-5c7d-4671-ae0b-94c099e1b111.jpg?1",
             "name": "Dawnhart Mentor",
             "text": "",
             "colours": [
@@ -13118,7 +13118,7 @@
         },
         {
             "id": "24d91edc-d425-56e6-844d-f1e4415cc61f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0e267-c361-4224-9b7a-2a3d1c5ac8b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0e267-c361-4224-9b7a-2a3d1c5ac8b4.jpg?1",
             "name": "Dawnhart Rejuvenator",
             "text": "",
             "colours": [
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "3f5db88a-c842-5b81-bb3c-bfbbeb5656e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "",
             "colours": [
@@ -13192,7 +13192,7 @@
         },
         {
             "id": "5038a68d-90a1-59bc-9789-9ae4ac742693",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83218607-240e-4473-8b0b-6b4670b010e6.jpg?1",
             "name": "Hound Tamer // Untamed Pup",
             "text": "",
             "colours": [
@@ -13228,7 +13228,7 @@
         },
         {
             "id": "bdc48922-e194-5bb2-8d15-7ad4e3feaa7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "",
             "colours": [
@@ -13265,7 +13265,7 @@
         },
         {
             "id": "c5f47619-454a-5bd9-a4f9-356b63ee3843",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1",
             "name": "Outland Liberator // Frenzied Trapbreaker",
             "text": "",
             "colours": [
@@ -13301,7 +13301,7 @@
         },
         {
             "id": "eb78c8c1-6f1e-517b-acd1-a82d43afa2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a07fd28-0b65-4ff0-96c6-7e88fc89b0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a07fd28-0b65-4ff0-96c6-7e88fc89b0a5.jpg?1",
             "name": "Saryth, the Viper's Fang",
             "text": "",
             "colours": [
@@ -13340,7 +13340,7 @@
         },
         {
             "id": "df31259e-32b9-5a07-99a3-35131f7f5f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "",
             "colours": [
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "5337f113-b1fd-5068-ab12-9fd2de4f8b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/552bb3a5-0c2c-4dc5-aee8-1048b04e69f9.jpg?1",
             "name": "Tireless Hauler // Dire-Strain Brawler",
             "text": "",
             "colours": [
@@ -13413,7 +13413,7 @@
         },
         {
             "id": "27ef4628-f66b-5e6e-8682-feac25f113d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "",
             "colours": [
@@ -13450,7 +13450,7 @@
         },
         {
             "id": "fbd27c73-fdae-5fe3-8202-07fd6055c354",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86e3848f-ee6a-4f9f-a231-4a22335a6808.jpg?1",
             "name": "Tovolar's Huntmaster // Tovolar's Packleader",
             "text": "",
             "colours": [
@@ -13486,7 +13486,7 @@
         },
         {
             "id": "ea2712fb-2ca0-55cb-8434-bf2ff1dccb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "",
             "colours": [
@@ -13527,7 +13527,7 @@
         },
         {
             "id": "10d29748-f5ba-5985-9571-94d9f62db638",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e48c24fe-a584-4b93-8275-240d1c202b26.jpg?1",
             "name": "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
             "text": "",
             "colours": [
@@ -13568,7 +13568,7 @@
         },
         {
             "id": "265dde3c-967b-5c4e-9bd2-0ee83397d65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c410dc-123c-4431-9ccb-3f17e6555d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c410dc-123c-4431-9ccb-3f17e6555d68.jpg?1",
             "name": "Dawnhart Wardens",
             "text": "",
             "colours": [
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "714a97fa-fa5a-5573-89ea-4db1d65e95c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef98a2c-4b48-45e3-bbcb-9fd338f5a05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef98a2c-4b48-45e3-bbcb-9fd338f5a05a.jpg?1",
             "name": "Katilda, Dawnhart Prime",
             "text": "",
             "colours": [
@@ -13648,7 +13648,7 @@
         },
         {
             "id": "6a786f93-a683-5e01-aed5-c562792bb3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "",
             "colours": [
@@ -13687,7 +13687,7 @@
         },
         {
             "id": "6f8311df-09ae-5566-b87a-44536b4be31a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3ee3f0ed-e4ea-483e-bacc-d58bcf9e07b5.jpg?1",
             "name": "Kessig Naturalist // Lord of the Ulvenwald",
             "text": "",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "4ccceecf-4286-5707-9647-98722cc397a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -13766,7 +13766,7 @@
         },
         {
             "id": "bf95c01c-6b7d-5455-a9b2-22015b6d9fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/925dee92-9c8d-4eef-a326-2fdae72b4328.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -13806,7 +13806,7 @@
         },
         {
             "id": "68d45fcc-98ec-54b1-beb7-b75b0a004c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f71585a-3ea8-40f8-8e02-e155477fd8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f71585a-3ea8-40f8-8e02-e155477fd8b5.jpg?1",
             "name": "Adeline, Resplendent Cathar",
             "text": "Vigilance\nAdeline, Resplendent Cathar's power is equal to the number of creatures you control.\nWhenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "c7d342ae-4e83-5638-b5d6-d6794acf446f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d67b9ec-7f53-4df6-b2cc-afd7efda6bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d67b9ec-7f53-4df6-b2cc-afd7efda6bb4.jpg?1",
             "name": "Lier, Disciple of the Drowned",
             "text": "Spells can't be countered.\nEach instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.",
             "colours": [
@@ -13884,7 +13884,7 @@
         },
         {
             "id": "d0e72986-90b3-51b5-9217-3e343dafd9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473f95a-b004-41ad-9729-0242c8b2a5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473f95a-b004-41ad-9729-0242c8b2a5ee.jpg?1",
             "name": "Gisa, Glorious Resurrector",
             "text": "If a creature an opponent controls would die, exile it instead.\nAt the beginning of your upkeep, put all creature cards exiled with Gisa, Glorious Resurrector onto the battlefield under your control. They gain decayed.",
             "colours": [
@@ -13923,7 +13923,7 @@
         },
         {
             "id": "783f4f0a-6972-5600-8e3f-88f25ce86f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ec5be-501c-4a5d-8b2a-f974c6cf06c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f29ec5be-501c-4a5d-8b2a-f974c6cf06c6.jpg?1",
             "name": "Jadar, Ghoulcaller of Nephalia",
             "text": "At the beginning of your end step, if you control no creatures with decayed, create a 2/2 black Zombie creature token with decayed.",
             "colours": [
@@ -13962,7 +13962,7 @@
         },
         {
             "id": "d17751e2-20f5-5846-a59f-6ed2fca8ef92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Whenever Jerren, Corrupted Bishop enters the battlefield or another nontoken Human you control dies, you lose 1 life and create a 1/1 white Human creature token.\n{2}: Target Human you control gains lifelink until end of turn.\nAt the beginning of your end step, if you have exactly 13 life, you may pay {4}{B}{B}. If you do, transform Jerren.",
             "colours": [
@@ -14001,7 +14001,7 @@
         },
         {
             "id": "dce9236c-17c2-5531-be19-2754a72872f5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d2910638-c932-40cc-8f09-526d7c1fb938.jpg?1",
             "name": "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
             "text": "Flying, trample, lifelink\nSacrifice another creature: Draw a card.",
             "colours": [
@@ -14039,7 +14039,7 @@
         },
         {
             "id": "0badba9d-4b10-53f6-a79b-07f7d2579573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Lifelink\nCards in graveyards can't be the targets of spells or abilities.\nDisturb {2}{W}{U}",
             "colours": [
@@ -14080,7 +14080,7 @@
         },
         {
             "id": "5de39a9c-6fe7-5145-b6d1-8db371736aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ecb54b26-7f0d-4f84-abcc-4dd9bfe57848.jpg?1",
             "name": "Dennick, Pious Apprentice // Dennick, Pious Apparition",
             "text": "Flying\nWhenever one or more creature cards are put into graveyards from anywhere, investigate. This ability triggers only once each turn.\nIf Dennick, Pious Apparition would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14121,7 +14121,7 @@
         },
         {
             "id": "01ba390c-e8d8-55b1-9b8e-7659052f0b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b100ae-5795-4583-88a1-a428b090a80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b100ae-5795-4583-88a1-a428b090a80f.jpg?1",
             "name": "Florian, Voldaren Scion",
             "text": "First strike\nAt the beginning of your postcombat main phase, look at the top X cards of your library, where X is the total amount of life your opponents lost this turn. Exile one of those cards and put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -14162,7 +14162,7 @@
         },
         {
             "id": "ea8f1dec-7ac6-5eec-9b89-5de3cc2c8c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a4ecfa-8173-4c9b-a28f-dc06e63491de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a4ecfa-8173-4c9b-a28f-dc06e63491de.jpg?1",
             "name": "Liesa, Forgotten Archangel",
             "text": "Flying, lifelink\nWhenever another nontoken creature you control dies, return that card to its owner's hand at the beginning of the next end step.\nIf a creature an opponent controls would die, exile it instead.",
             "colours": [
@@ -14202,7 +14202,7 @@
         },
         {
             "id": "39e16458-2330-5531-8aa4-6e57ad6991a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "Whenever Ludevic, Necrogenius enters the battlefield or attacks, mill a card.\n{X}{U}{U}{B}{B}, Exile X creature cards from your graveyard: Transform Ludevic. X can't be 0. Activate only as a sorcery.",
             "colours": [
@@ -14243,7 +14243,7 @@
         },
         {
             "id": "ec907727-b46e-549f-9d54-c066c89c4ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38f63648-ef60-43b1-be2a-638185ef266d.jpg?1",
             "name": "Ludevic, Necrogenius // Olag, Ludevic's Hubris",
             "text": "As this creature transforms into Olag, Ludevic's Hubris, it becomes a copy of a creature card exiled with it, except its name is Olag, Ludevic's Hubris, it's 4/4, and it's a legendary blue and black Zombie in addition to its other colors and types. Put a number of +1/+1 counters on Olag equal to the number of creature cards exiled with it.",
             "colours": [
@@ -14283,7 +14283,7 @@
         },
         {
             "id": "65988925-a62b-57f2-8f0b-d49084f00210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a0dc21-c202-4cef-9e67-26b9dd24d565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a0dc21-c202-4cef-9e67-26b9dd24d565.jpg?1",
             "name": "Old Stickfingers",
             "text": "When you cast this spell, reveal cards from the top of your library until you reveal X creature cards. Put all creature cards revealed this way into your graveyard, then put the rest on the bottom of your library in a random order.\nOld Stickfingers's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -14323,7 +14323,7 @@
         },
         {
             "id": "059a66ff-914c-5c13-b72a-8f3c1abab159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54105a7-c369-40a8-8b37-610821c0fd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54105a7-c369-40a8-8b37-610821c0fd08.jpg?1",
             "name": "Rem Karolus, Stalwart Slayer",
             "text": "Flying, haste\nIf a spell would deal damage to you or another permanent you control, prevent that damage.\nIf a spell would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
             "colours": [
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "6d5e744e-daa1-59cb-bf05-77f8bd086b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b66f1b-9341-461d-9f10-a808be1ac324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b66f1b-9341-461d-9f10-a808be1ac324.jpg?1",
             "name": "Sigarda, Champion of Light",
             "text": "Flying, trample\nHumans you control get +1/+1.\nCoven \u2014 Whenever Sigarda attacks, if you control three or more creatures with different powers, look at the top five cards of your library. You may reveal a Human creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14404,7 +14404,7 @@
         },
         {
             "id": "729588c9-b436-5116-93e8-f1109ae69a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a03a8-df78-43fb-a811-478be5983e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27a03a8-df78-43fb-a811-478be5983e91.jpg?1",
             "name": "Slogurk, the Overslime",
             "text": "Trample\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Slogurk, the Overslime.\nRemove three +1/+1 counters from Slogurk: Return it to its owner's hand.\nWhen Slogurk leaves the battlefield, return up to three target land cards from your graveyard to your hand.",
             "colours": [
@@ -14444,7 +14444,7 @@
         },
         {
             "id": "b8dbb572-c6e6-5ae6-beac-b0dbb0a64488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e4a483-727d-45f4-bf20-47d94d37e0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e4a483-727d-45f4-bf20-47d94d37e0d0.jpg?1",
             "name": "Vadrik, Astral Archmage",
             "text": "If it's neither day nor night, it becomes day as Vadrik, Astral Archmage enters the battlefield.\nInstant and sorcery spells you cast cost {X} less to cast, where X is Vadrik's power.\nWhenever day becomes night or night becomes day, put a +1/+1 counter on Vadrik.",
             "colours": [
@@ -14485,7 +14485,7 @@
         },
         {
             "id": "107e694d-ae13-51bc-aa5b-ace492adcf7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719030bb-59f9-4d42-b7be-7f06e9cada4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719030bb-59f9-4d42-b7be-7f06e9cada4d.jpg?1",
             "name": "Curse of Silence",
             "text": "Enchant player\nAs Curse of Silence enters the battlefield, choose a card name.\nSpells with the chosen name enchanted player casts cost {2} more to cast.\nWhenever enchanted player casts a spell with the chosen name, you may sacrifice Curse of Silence. If you do, draw a card.",
             "colours": [
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "19c789ca-ba96-572f-8cb3-767cbb681f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying, double strike\nYou have hexproof.\nIf your life total would be reduced to 0 or less, instead transform Enduring Angel and your life total becomes 3. Then if Enduring Angel didn't transform this way, you lose the game.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "279fa126-de86-52cb-a31b-f8e41661aa90",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71c5c242-572c-4f24-b4c2-64c470070090.jpg?1",
             "name": "Enduring Angel // Angelic Enforcer",
             "text": "Flying\nYou have hexproof.\nAngelic Enforcer's power and toughness are each equal to your life total.\nWhenever Angelic Enforcer attacks, double your life total.",
             "colours": [
@@ -14594,7 +14594,7 @@
         },
         {
             "id": "00d0df58-8fe1-5ae3-8899-f62700e0cbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf1ab2-4d6b-4e81-b537-82889aab767d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bf1ab2-4d6b-4e81-b537-82889aab767d.jpg?1",
             "name": "Fateful Absence",
             "text": "Destroy target creature or planeswalker. Its controller investigates.",
             "colours": [
@@ -14628,7 +14628,7 @@
         },
         {
             "id": "64eaa9c2-c1d8-56b3-a97e-02bd7e4f4e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651d249f-6771-41ed-8ccf-c8fa85419a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651d249f-6771-41ed-8ccf-c8fa85419a75.jpg?1",
             "name": "Intrepid Adversary",
             "text": "Lifelink\nWhen Intrepid Adversary enters the battlefield, you may pay {1}{W} any number of times. When you pay this cost one or more times, put that many valor counters on Intrepid Adversary.\nCreatures you control get +1/+1 for each valor counter on Intrepid Adversary.",
             "colours": [
@@ -14665,7 +14665,7 @@
         },
         {
             "id": "1b403902-0ac7-505e-a950-cf9ee2d9a4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56271daf-f5d1-4256-852a-5b746c83e666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56271daf-f5d1-4256-852a-5b746c83e666.jpg?1",
             "name": "Sigarda's Splendor",
             "text": "As Sigarda's Splendor enters the battlefield, note your life total.\nAt the beginning of your upkeep, draw a card if your life total is greater than or equal to the last noted life total for Sigarda's Splendor. Then note your life total.\nWhenever you cast a white spell, you gain 1 life.",
             "colours": [
@@ -14699,7 +14699,7 @@
         },
         {
             "id": "7c8ae116-70ef-5fa5-8926-43e77ed3f298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1b95e-7f1a-4918-85f6-41df3f7d3cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab1b95e-7f1a-4918-85f6-41df3f7d3cce.jpg?1",
             "name": "Sigardian Savior",
             "text": "Flying\nWhen Sigardian Savior enters the battlefield, if you cast it, return up to two target creature cards with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -14735,7 +14735,7 @@
         },
         {
             "id": "405b743c-6fb0-5ccb-9441-7b09e0be0276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd31f9-2bdb-42f6-8436-d6dd4b546856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd31f9-2bdb-42f6-8436-d6dd4b546856.jpg?1",
             "name": "Sungold Sentinel",
             "text": "Whenever Sungold Sentinel enters the battlefield or attacks, exile up to one target card from a graveyard.\nCoven \u2014 {1}{W}: Choose a color. Sungold Sentinel gains hexproof from that color until end of turn and can't be blocked by creatures of that color this turn. Activate only if you control three or more creatures with different powers.",
             "colours": [
@@ -14772,7 +14772,7 @@
         },
         {
             "id": "baf64e45-bb54-52b1-bbef-0038fc69ff22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0153894b-ef77-4a0d-b93d-5b06fdcbd9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0153894b-ef77-4a0d-b93d-5b06fdcbd9f3.jpg?1",
             "name": "Vanquish the Horde",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nDestroy all creatures.",
             "colours": [
@@ -14806,7 +14806,7 @@
         },
         {
             "id": "f39a9faf-529b-5af2-922a-070ca1046db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f9995c-c8f4-48d8-8ee0-65c168af2005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f9995c-c8f4-48d8-8ee0-65c168af2005.jpg?1",
             "name": "Curse of Surveillance",
             "text": "Enchant player\nAt the beginning of enchanted player's upkeep, any number of target players other than that player each draw cards equal to the number of Curses attached to that player.",
             "colours": [
@@ -14843,7 +14843,7 @@
         },
         {
             "id": "66510916-582d-5d44-927e-5b3889389148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5a33a7-50be-497c-bb5e-e044cf12edce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5a33a7-50be-497c-bb5e-e044cf12edce.jpg?1",
             "name": "Grafted Identity",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nEnchant creature\nYou control enchanted creature.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -14880,7 +14880,7 @@
         },
         {
             "id": "1d93b6ef-e162-5487-a36e-3517d5657a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "{U}, Sacrifice Malevolent Hermit: Counter target noncreature spell unless its controller pays {3}.\nDisturb {2}{U}",
             "colours": [
@@ -14917,7 +14917,7 @@
         },
         {
             "id": "867aa5e8-b9ee-5cbc-ae7e-8a22e26da2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/d/7d0d1d48-559f-48f9-b486-50fc81533443.jpg?1",
             "name": "Malevolent Hermit // Benevolent Geist",
             "text": "Flying\nNoncreature spells you control can't be countered.\nIf Benevolent Geist would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14954,7 +14954,7 @@
         },
         {
             "id": "b4ed2f0d-4428-5e4b-b372-6ca838004980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2d6292-d444-48a0-9dca-207ebcdbd4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2d6292-d444-48a0-9dca-207ebcdbd4f5.jpg?1",
             "name": "Memory Deluge",
             "text": "Look at the top X cards of your library, where X is the amount of mana spent to cast this spell. Put two of them into your hand and the rest on the bottom of your library in a random order.\nFlashback {5}{U}{U}",
             "colours": [
@@ -14988,7 +14988,7 @@
         },
         {
             "id": "4d3312f5-6224-5da5-a68c-51c98902b793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0eb016-8842-4ff2-a202-f32213b06e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0eb016-8842-4ff2-a202-f32213b06e18.jpg?1",
             "name": "Patrician Geist",
             "text": "Flying\nOther Spirits you control get +1/+1.\nSpells you cast from your graveyard cost {1} less to cast.",
             "colours": [
@@ -15025,7 +15025,7 @@
         },
         {
             "id": "817807ae-1230-54c4-a0e5-56b858e8e72c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 black Zombie creature token with decayed.\nAt the beginning of your upkeep, if you control three or more creature tokens, you may transform Poppet Stitcher.",
             "colours": [
@@ -15062,7 +15062,7 @@
         },
         {
             "id": "c89048fd-f699-5642-87da-6de5d4542fee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46dbfdcb-ac63-450b-b57b-2b0a63105096.jpg?1",
             "name": "Poppet Stitcher // Poppet Factory",
             "text": "Creature tokens you control lose all abilities and have base power and toughness 3/3.\nAt the beginning of your upkeep, you may transform Poppet Factory.",
             "colours": [
@@ -15096,7 +15096,7 @@
         },
         {
             "id": "ddcee35d-1104-58ea-b538-8b5026a5d57e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b1195a-61ab-44ac-8079-355d5b862630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b1195a-61ab-44ac-8079-355d5b862630.jpg?1",
             "name": "Sludge Monster",
             "text": "Whenever Sludge Monster enters the battlefield or attacks, put a slime counter on up to one other target creature.\nNon-Horror creatures with slime counters on them lose all abilities and have base power and toughness 2/2.",
             "colours": [
@@ -15132,7 +15132,7 @@
         },
         {
             "id": "72d15706-f62a-5800-8942-6e0e1c065436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320b73c-408a-4dc5-bfc9-3d2717a21397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320b73c-408a-4dc5-bfc9-3d2717a21397.jpg?1",
             "name": "Spectral Adversary",
             "text": "Flash\nFlying\nWhen Spectral Adversary enters the battlefield, you may pay {1}{U} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Spectral Adversary, then up to that many other target artifacts, creatures, and/or enchantments phase out.",
             "colours": [
@@ -15168,7 +15168,7 @@
         },
         {
             "id": "974e8752-24d2-5d64-850c-7a7a24e176c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed68800-3fc6-4b0e-a624-8be3beeed92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed68800-3fc6-4b0e-a624-8be3beeed92f.jpg?1",
             "name": "Triskaidekaphile",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, if you have exactly thirteen cards in your hand, you win the game.\n{3}{U}: Draw a card.",
             "colours": [
@@ -15206,7 +15206,7 @@
         },
         {
             "id": "c8de3efc-05e3-5c27-9161-15c1315f1408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0069688d-6fc8-466e-8b53-11f0ada87b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0069688d-6fc8-466e-8b53-11f0ada87b21.jpg?1",
             "name": "Bloodline Culling",
             "text": "Choose one \u2014\n\u2022 Target creature gets -5/-5 until end of turn.\n\u2022 Creature tokens get -2/-2 until end of turn.",
             "colours": [
@@ -15240,7 +15240,7 @@
         },
         {
             "id": "246ad66c-5321-5c59-bb37-b41341f6c145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b384260-9bf9-40f4-8a49-cc4936531a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b384260-9bf9-40f4-8a49-cc4936531a89.jpg?1",
             "name": "Champion of the Perished",
             "text": "Whenever another Zombie enters the battlefield under your control, put a +1/+1 counter on Champion of the Perished.",
             "colours": [
@@ -15277,7 +15277,7 @@
         },
         {
             "id": "90c4f64e-5da4-5ef2-9938-e4b62f12fe13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Enchant player\nAs this permanent transforms into Curse of Leeches, attach it to a player.\nAt the beginning of enchanted player's upkeep, they lose 1 life and you gain 1 life.\nDaybound",
             "colours": [
@@ -15314,7 +15314,7 @@
         },
         {
             "id": "6f1f9d88-d36c-552b-8ca1-ba444cb21d62",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c59e550f-74a7-4cdb-9194-911cdbdfb247.jpg?1",
             "name": "Curse of Leeches // Leeching Lurker",
             "text": "Lifelink\nNightbound",
             "colours": [
@@ -15351,7 +15351,7 @@
         },
         {
             "id": "ac35fbfd-bf43-5c90-a68f-6f50d0baabb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bfb784-03e9-408f-b7f5-18c1dab4f12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bfb784-03e9-408f-b7f5-18c1dab4f12f.jpg?1",
             "name": "Lord of the Forsaken",
             "text": "Flying, trample\n{B}, Sacrifice another creature: Target player mills three cards.\nPay 1 life: Add {C}. Spend this mana only to cast a spell from your graveyard.",
             "colours": [
@@ -15387,7 +15387,7 @@
         },
         {
             "id": "031b0df6-5f62-5156-8007-b12331e48a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1490037d-bd86-449d-baf4-cbedcdae3922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1490037d-bd86-449d-baf4-cbedcdae3922.jpg?1",
             "name": "Mask of Griselbrand",
             "text": "Equipped creature has flying and lifelink.\nWhenever equipped creature dies, you may pay X life, where X is its power. If you do, draw X cards.\nEquip {3}",
             "colours": [
@@ -15425,7 +15425,7 @@
         },
         {
             "id": "1954bd8d-28b6-51a9-a3b4-80fc72dcb0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52593d64-182f-45ff-82c6-fb7649d36736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52593d64-182f-45ff-82c6-fb7649d36736.jpg?1",
             "name": "The Meathook Massacre",
             "text": "When The Meathook Massacre enters the battlefield, each creature gets -X/-X until end of turn.\nWhenever a creature you control dies, each opponent loses 1 life.\nWhenever a creature an opponent controls dies, you gain 1 life.",
             "colours": [
@@ -15461,7 +15461,7 @@
         },
         {
             "id": "fe7c40d9-bf5f-5688-90c9-7a6dec09c9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea62ec7-46cc-4023-8ddf-709dcde0896a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea62ec7-46cc-4023-8ddf-709dcde0896a.jpg?1",
             "name": "Slaughter Specialist",
             "text": "When Slaughter Specialist enters the battlefield, each opponent creates a 1/1 white Human creature token.\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Slaughter Specialist.",
             "colours": [
@@ -15498,7 +15498,7 @@
         },
         {
             "id": "9f8c9b05-05d1-50ff-acff-b474e81ed7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e4136-6ceb-4dc2-9b4b-e6fd3fb1ac1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e4136-6ceb-4dc2-9b4b-e6fd3fb1ac1d.jpg?1",
             "name": "Tainted Adversary",
             "text": "Deathtouch\nWhen Tainted Adversary enters the battlefield, you may pay {2}{B} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Tainted Adversary, then create twice that many 2/2 black Zombie creature tokens with decayed.",
             "colours": [
@@ -15534,7 +15534,7 @@
         },
         {
             "id": "48fde43d-4bb6-5908-a138-1e3f2bd7857a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196e21ed-6523-40a5-9d53-5864c7dca2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196e21ed-6523-40a5-9d53-5864c7dca2cf.jpg?1",
             "name": "Bloodthirsty Adversary",
             "text": "Haste\nWhen Bloodthirsty Adversary enters the battlefield, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Bloodthirsty Adversary, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -15570,7 +15570,7 @@
         },
         {
             "id": "de31d8b0-808d-501b-a58c-b08a6d6ec31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2dbfa-4bd5-44d5-a487-0f88c239fbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2dbfa-4bd5-44d5-a487-0f88c239fbbc.jpg?1",
             "name": "Burn Down the House",
             "text": "Choose one \u2014\n\u2022 Burn Down the House deals 5 damage to each creature and each planeswalker.\n\u2022 Create three 1/1 red Devil creature tokens with \"When this creature dies, it deals 1 damage to any target.\" They gain haste until end of turn.",
             "colours": [
@@ -15604,7 +15604,7 @@
         },
         {
             "id": "5ae4f5b3-23ff-5b36-8339-7e67e165ac76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636f014-95aa-45cd-a0c8-635364ea3baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d636f014-95aa-45cd-a0c8-635364ea3baa.jpg?1",
             "name": "Curse of Shaken Faith",
             "text": "Enchant player\nWhenever enchanted player casts a spell other than the first spell they cast each turn or copies a spell, Curse of Shaken Faith deals 2 damage to them.",
             "colours": [
@@ -15641,7 +15641,7 @@
         },
         {
             "id": "d35214b9-b8c6-585d-8b09-74d5f300acfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddde36d5-adca-4576-8f31-bf11b8e90a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddde36d5-adca-4576-8f31-bf11b8e90a15.jpg?1",
             "name": "Falkenrath Pit Fighter",
             "text": "{1}{R}, Discard a card, Sacrifice a Vampire: Draw two cards. Activate only if an opponent lost life this turn.",
             "colours": [
@@ -15678,7 +15678,7 @@
         },
         {
             "id": "f860933f-a11d-5908-a68e-99d11420112e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587e5c52-9c4b-4462-b214-47556d0906b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587e5c52-9c4b-4462-b214-47556d0906b6.jpg?1",
             "name": "Geistflame Reservoir",
             "text": "Whenever you cast an instant or sorcery spell, put a charge counter on Geistflame Reservoir.\n{1}{R}, {T}, Remove any number of charge counters from Geistflame Reservoir: It deals that much damage to any target.\n{1}{R}, {T}: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -15712,7 +15712,7 @@
         },
         {
             "id": "4cb591da-6262-5a96-9c2d-29c35aa1d728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f655087-4af9-46d3-a11e-830ac15ce08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f655087-4af9-46d3-a11e-830ac15ce08c.jpg?1",
             "name": "Light Up the Night",
             "text": "Light Up the Night deals X damage to any target. It deals X plus 1 damage instead if that target is a creature or planeswalker.\nFlashback\u2014{3}{R}, Remove X loyalty counters from among planeswalkers you control. If you cast this spell this way, X can't be 0.",
             "colours": [
@@ -15746,7 +15746,7 @@
         },
         {
             "id": "9c5c3f2d-33f9-521c-a232-36cb6fc72f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff73df-e69a-4abf-900e-85b95106a17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eff73df-e69a-4abf-900e-85b95106a17e.jpg?1",
             "name": "Moonveil Regent",
             "text": "Flying\nWhenever you cast a spell, you may discard your hand. If you do, draw a card for each of that spell's colors.\nWhen Moonveil Regent dies, it deals X damage to any target, where X is the number of colors among permanents you control.",
             "colours": [
@@ -15782,7 +15782,7 @@
         },
         {
             "id": "cc177246-8a73-5705-a189-78ee873291c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Defender\nWhenever you cast an instant or sorcery spell, put a number of ember counters on Smoldering Egg equal to the amount of mana spent to cast that spell. Then if Smoldering Egg has seven or more ember counters on it, remove them and transform Smoldering Egg.",
             "colours": [
@@ -15819,7 +15819,7 @@
         },
         {
             "id": "8449064f-f7e0-5519-930d-60560606fe04",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b41e193f-fb9b-4b26-89b6-856b1710a19d.jpg?1",
             "name": "Smoldering Egg // Ashmouth Dragon",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Ashmouth Dragon deals 2 damage to any target.",
             "colours": [
@@ -15855,7 +15855,7 @@
         },
         {
             "id": "d37474dd-b29b-5188-9f21-5ccad1612689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d375b7f-e4c3-48f0-b967-3ce50c2728c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d375b7f-e4c3-48f0-b967-3ce50c2728c4.jpg?1",
             "name": "Sunstreak Phoenix",
             "text": "Flying\nIf it's neither day nor night, it becomes day as Sunstreak Phoenix enters the battlefield.\nWhenever day becomes night or night becomes day, you may pay {1}{R}. If you do, return Sunstreak Phoenix from your graveyard to the battlefield tapped.",
             "colours": [
@@ -15891,7 +15891,7 @@
         },
         {
             "id": "677a35e6-d4b7-54b4-a286-25f0d99ba4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dfb33e-761d-420f-8202-c1a714ff0832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dfb33e-761d-420f-8202-c1a714ff0832.jpg?1",
             "name": "Augur of Autumn",
             "text": "You may look at the top card of your library any time.\nYou may play lands from the top of your library.\nCoven \u2014 As long as you control three or more creatures with different powers, you may cast creature spells from the top of your library.",
             "colours": [
@@ -15928,7 +15928,7 @@
         },
         {
             "id": "5835c1cf-2ffe-5412-82ad-398b972158e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1db00c-c9fd-48d8-b7d5-c39f8e213232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1db00c-c9fd-48d8-b7d5-c39f8e213232.jpg?1",
             "name": "Briarbridge Tracker",
             "text": "Vigilance\nWhen Briarbridge Tracker enters the battlefield, investigate.\nAs long as you control a token, Briarbridge Tracker gets +2/+0.",
             "colours": [
@@ -15965,7 +15965,7 @@
         },
         {
             "id": "53e6d59b-8d6b-5a7c-bb09-b052ad2800c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8819ff-cd97-440c-8256-f3e3b4fc3c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8819ff-cd97-440c-8256-f3e3b4fc3c41.jpg?1",
             "name": "Consuming Blob",
             "text": "Consuming Blob's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\nAt the beginning of your end step, create a green Ooze creature token with \"This creature's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.\"",
             "colours": [
@@ -16001,7 +16001,7 @@
         },
         {
             "id": "5759147a-77d3-5a0d-8bc3-6b93bc4d714c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e39fdb5-a4cd-49fb-843f-30136ce54b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e39fdb5-a4cd-49fb-843f-30136ce54b34.jpg?1",
             "name": "Primal Adversary",
             "text": "Trample\nWhen Primal Adversary enters the battlefield, you may pay {1}{G} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on Primal Adversary, then up to that many target lands you control become 3/3 Wolf creatures with haste that are still lands.",
             "colours": [
@@ -16037,7 +16037,7 @@
         },
         {
             "id": "05c18043-ee84-53bf-882b-45d181dd47e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28be27e6-66e6-4997-b8a0-f4d9c597e536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28be27e6-66e6-4997-b8a0-f4d9c597e536.jpg?1",
             "name": "Storm the Festival",
             "text": "Look at the top five cards of your library. You may put up to two permanent cards with mana value 5 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\nFlashback {7}{G}{G}{G}",
             "colours": [
@@ -16071,7 +16071,7 @@
         },
         {
             "id": "5bc3b947-7568-5083-894f-85aa1804e203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61baa102-9bc0-4f97-89e1-cca4dbd823bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61baa102-9bc0-4f97-89e1-cca4dbd823bd.jpg?1",
             "name": "Unnatural Growth",
             "text": "At the beginning of each combat, double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -16105,7 +16105,7 @@
         },
         {
             "id": "1eb1eae0-e908-560f-adca-14e9c4d7be9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99947ee-3a73-47aa-bd71-d29a0066314e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99947ee-3a73-47aa-bd71-d29a0066314e.jpg?1",
             "name": "Willow Geist",
             "text": "Trample\nWhenever one or more cards leave your graveyard, put a +1/+1 counter on Willow Geist.\nWhen Willow Geist dies, you gain life equal to its power.",
             "colours": [
@@ -16142,7 +16142,7 @@
         },
         {
             "id": "39c8d2c6-3056-5c99-bb89-73389b83741c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742eaaed-4162-4179-94e6-0c1a943a46b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742eaaed-4162-4179-94e6-0c1a943a46b9.jpg?1",
             "name": "Angelfire Ignition",
             "text": "Put two +1/+1 counters on target creature. It gains vigilance, trample, lifelink, indestructible, and haste until end of turn.\nFlashback {2}{R}{W}",
             "colours": [
@@ -16178,7 +16178,7 @@
         },
         {
             "id": "d7dbea2e-654f-5bf9-9164-54317867eeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d1d7a4-6276-4f7e-bc50-5e48eef8f6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d1d7a4-6276-4f7e-bc50-5e48eef8f6f8.jpg?1",
             "name": "Can't Stay Away",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains \"If this creature would die, exile it instead.\"\nFlashback {3}{W}{B}",
             "colours": [
@@ -16214,7 +16214,7 @@
         },
         {
             "id": "af9ca1ad-02ca-50f5-a5fc-ba754cc0eb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cbd312-a0ee-4dc8-9d23-9d54aa0a70b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cbd312-a0ee-4dc8-9d23-9d54aa0a70b3.jpg?1",
             "name": "Croaking Counterpart",
             "text": "Create a token that's a copy of target non-Frog creature, except it's a 1/1 green Frog.\nFlashback {3}{G}{U}",
             "colours": [
@@ -16250,7 +16250,7 @@
         },
         {
             "id": "76869cd2-7b47-5e40-adfa-7e9341a89746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fdcf0e-7102-4ac1-afb9-093f1670a878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19fdcf0e-7102-4ac1-afb9-093f1670a878.jpg?1",
             "name": "Dire-Strain Rampage",
             "text": "Destroy target artifact, enchantment, or land. If a land was destroyed this way, its controller may search their library for up to two basic land cards, put them onto the battlefield tapped, then shuffle. Otherwise, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.\nFlashback {3}{R}{G}",
             "colours": [
@@ -16286,7 +16286,7 @@
         },
         {
             "id": "a32245d6-68a2-565c-84f3-95f887e4b9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20ae02-a7d5-40b2-8be2-bc8c0dc0f6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20ae02-a7d5-40b2-8be2-bc8c0dc0f6d8.jpg?1",
             "name": "Galvanic Iteration",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nFlashback {1}{U}{R}",
             "colours": [
@@ -16322,7 +16322,7 @@
         },
         {
             "id": "bf3afce1-0fcb-5660-81ae-943d5520a614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb2dc53-57aa-4327-8700-6396fd86e3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb2dc53-57aa-4327-8700-6396fd86e3d1.jpg?1",
             "name": "Ghoulcaller's Harvest",
             "text": "Create X 2/2 black Zombie creature tokens with decayed, where X is half the number of creature cards in your graveyard, rounded up.\nFlashback {3}{B}{G}",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "0b705360-f0c9-5e41-9fb4-ecaf4f1c5fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2e89f2-6101-4ada-b925-2ae6f754b39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2e89f2-6101-4ada-b925-2ae6f754b39e.jpg?1",
             "name": "Hallowed Respite",
             "text": "Exile target nonlegendary creature, then return it to the battlefield under its owner's control. If it entered under your control, put a +1/+1 counter on it. Otherwise, tap it.\nFlashback {1}{W}{U}",
             "colours": [
@@ -16394,7 +16394,7 @@
         },
         {
             "id": "0fb50319-5c5f-5ca7-8253-ef2a4b60ff49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae388-c917-4917-9401-6852a384d274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c73ae388-c917-4917-9401-6852a384d274.jpg?1",
             "name": "Rite of Harmony",
             "text": "Whenever a creature or enchantment enters the battlefield under your control this turn, draw a card.\nFlashback {2}{G}{W}",
             "colours": [
@@ -16430,7 +16430,7 @@
         },
         {
             "id": "e5820482-daf4-527d-ac26-7cc233a95243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94d7713-5c26-4e65-9f0e-3b4f46efcdc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94d7713-5c26-4e65-9f0e-3b4f46efcdc4.jpg?1",
             "name": "Siphon Insight",
             "text": "Look at the top two cards of target opponent's library. Exile one of them face down and put the other on the bottom of that library. You may look at and play the exiled card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.\nFlashback {1}{U}{B}",
             "colours": [
@@ -16466,7 +16466,7 @@
         },
         {
             "id": "8b240e95-3c78-5054-9bcc-da459849d829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dc5a7d-759c-4d6d-ace2-81731f5c4c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6dc5a7d-759c-4d6d-ace2-81731f5c4c35.jpg?1",
             "name": "Wake to Slaughter",
             "text": "Choose up to two target creature cards in your graveyard. An opponent chooses one of them. Return that card to your hand. Return the other to the battlefield under your control. It gains haste. Exile it at the beginning of the next end step.\nFlashback {4}{B}{R}",
             "colours": [
@@ -16502,7 +16502,7 @@
         },
         {
             "id": "a8525221-1bc6-568e-85cb-f389b6e33d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45a290-5ab8-4200-91e4-ea03d45c34b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f45a290-5ab8-4200-91e4-ea03d45c34b6.jpg?1",
             "name": "The Celestus",
             "text": "If it's neither day nor night, it becomes day as The Celestus enters the battlefield.\n{T}: Add one mana of any color.\n{3}, {T}: If it's night, it becomes day. Otherwise, it becomes night. Activate only as a sorcery.\nWhenever day becomes night or night becomes day, you gain 1 life. You may draw a card. If you do, discard a card.",
             "colours": [],
@@ -16534,7 +16534,7 @@
         },
         {
             "id": "d8962e25-4c2d-5b2f-b4a4-2e0eb54b8395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241616ef-5698-491c-995d-1ff2ca0d455f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241616ef-5698-491c-995d-1ff2ca0d455f.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, choose a card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -16564,7 +16564,7 @@
         },
         {
             "id": "72577c64-449e-519c-905c-081bbbbb8c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice a creature: Put a soul counter on Hostile Hostel. Then if there are three or more soul counters on it, remove those counters, transform it, then untap it. Activate only as a sorcery.",
             "colours": [],
@@ -16596,7 +16596,7 @@
         },
         {
             "id": "1c3be0aa-6ba2-5b86-b022-faa54421f3db",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14d27a38-6ed1-499e-ab30-26e04a56c071.jpg?1",
             "name": "Hostile Hostel // Creeping Inn",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice a creature: Put a soul counter on Hostile Hostel. Then if there are three or more soul counters on it, remove those counters, transform it, then untap it. Activate only as a sorcery.",
             "colours": [
@@ -16634,7 +16634,7 @@
         },
         {
             "id": "c839dfb3-cbb3-5d19-8223-8b4442eae318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b94de4-099e-43d7-8f24-d5450b09f1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b94de4-099e-43d7-8f24-d5450b09f1f1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -16671,7 +16671,7 @@
         },
         {
             "id": "f759aba0-a9bd-52ee-9aed-99e499f81534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6b919-e7c0-4844-a65c-d8b83b3e5287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e6b919-e7c0-4844-a65c-d8b83b3e5287.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -16708,7 +16708,7 @@
         },
         {
             "id": "e39f8634-c477-5836-9235-f302d92a7e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b9030-f04a-4f42-8dd8-2eae0ce7e420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b9030-f04a-4f42-8dd8-2eae0ce7e420.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -16745,7 +16745,7 @@
         },
         {
             "id": "46e0c17f-101f-56c4-a8aa-55dfb95d84cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92e9e94-e5e9-4b2c-b9e5-35de42ca7b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92e9e94-e5e9-4b2c-b9e5-35de42ca7b8e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16782,7 +16782,7 @@
         },
         {
             "id": "a499b95b-8f0f-56e2-ba4e-077e5bc6979e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8de02c-7954-4424-8b95-a21d8e104bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8de02c-7954-4424-8b95-a21d8e104bd4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16819,7 +16819,7 @@
         },
         {
             "id": "d8a65e0b-37e8-50b3-99b5-b9460552e822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ade554-861c-423f-9aa3-e36da95b20dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ade554-861c-423f-9aa3-e36da95b20dc.jpg?1",
             "name": "Champion of the Perished",
             "text": "Whenever another Zombie enters the battlefield under your control, put a +1/+1 counter on Champion of the Perished.",
             "colours": [
@@ -16855,7 +16855,7 @@
         },
         {
             "id": "7d723124-a3ff-5e96-be73-12a3dc44b91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6db2d37-3533-4830-ab63-6724ece6fbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6db2d37-3533-4830-ab63-6724ece6fbea.jpg?1",
             "name": "Triskaidekaphile",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, if you have exactly thirteen cards in your hand, you win the game.\n{3}{U}: Draw a card.",
             "colours": [
@@ -16892,7 +16892,7 @@
         },
         {
             "id": "b15c8864-8faa-59de-9afc-1259e351ae6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0f88d0-49b8-451b-948d-46401d49020e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0f88d0-49b8-451b-948d-46401d49020e.jpg?1",
             "name": "Gavony Dawnguard",
             "text": "Ward {1}\nIf it's neither day nor night, it becomes day as Gavony Dawnguard enters the battlefield.\nWhenever day becomes night or night becomes day, look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -16929,7 +16929,7 @@
         },
         {
             "id": "d23c113b-400f-588a-835b-68a61f40fcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f40a0-5f58-4157-aed9-b1a52e922c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3f40a0-5f58-4157-aed9-b1a52e922c3c.jpg?1",
             "name": "Consider",
             "text": "Look at the top card of your library. You may put that card into your graveyard.\nDraw a card.",
             "colours": [
@@ -16963,7 +16963,7 @@
         },
         {
             "id": "1a327055-585a-574e-a488-528434929a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0655bae1-d33b-4bac-856a-ca4518f192e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0655bae1-d33b-4bac-856a-ca4518f192e8.jpg?1",
             "name": "Infernal Grasp",
             "text": "Destroy target creature. You lose 2 life.",
             "colours": [
@@ -16997,7 +16997,7 @@
         },
         {
             "id": "b3f5b3f5-7377-5728-884c-49ead4c1151d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42901bec-a8d0-46a3-a710-bfb7bd87f155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42901bec-a8d0-46a3-a710-bfb7bd87f155.jpg?1",
             "name": "Play with Fire",
             "text": "Play with Fire deals 2 damage to any target. If a player is dealt damage this way, scry 1.",
             "colours": [
@@ -17031,7 +17031,7 @@
         },
         {
             "id": "4f35ff67-1be3-55fa-bc8d-1e1cbaf81172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd0f3-933d-4e73-9ac5-c743b8394e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd0f3-933d-4e73-9ac5-c743b8394e80.jpg?1",
             "name": "Join the Dance",
             "text": "Create two 1/1 white Human creature tokens.\nFlashback {3}{G}{W}",
             "colours": [
@@ -17067,7 +17067,7 @@
         },
         {
             "id": "4201fbf8-0646-5234-bce1-0bdca04be8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7667345-e11b-4cad-ac4c-84eb1c5656c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7667345-e11b-4cad-ac4c-84eb1c5656c5.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -17102,7 +17102,7 @@
         },
         {
             "id": "0c360f56-026d-582b-9a9f-afe878c099df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c865bc02-0562-408c-b18e-0e66da906fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c865bc02-0562-408c-b18e-0e66da906fc6.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17137,7 +17137,7 @@
         },
         {
             "id": "d1a28b9a-8f82-5413-a1f1-3284bd2f3f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b2f0-16d3-4db0-a737-c7b8dcb9d5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b2f0-16d3-4db0-a737-c7b8dcb9d5de.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -17172,7 +17172,7 @@
         },
         {
             "id": "1a35533c-585f-57c6-a1f0-15a30c970419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c0f400-41be-488b-be84-b07289b1ef62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c0f400-41be-488b-be84-b07289b1ef62.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -17207,7 +17207,7 @@
         },
         {
             "id": "974e8ef7-5b3c-5f02-9887-027e2578687f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb8607-1066-451d-a719-74ad32358278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb8607-1066-451d-a719-74ad32358278.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17242,7 +17242,7 @@
         },
         {
             "id": "51112885-432d-52a4-97be-107f00bbdf70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f9c505-a833-4240-83a0-fbd160bdbf0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f9c505-a833-4240-83a0-fbd160bdbf0f.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -17277,7 +17277,7 @@
         },
         {
             "id": "c827d437-be61-5b73-8d1a-b3576f6629a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -17312,7 +17312,7 @@
         },
         {
             "id": "3378a201-b957-5508-931e-f85e221d6801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55c70b8-0fa5-4d08-9061-f53d6f949908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55c70b8-0fa5-4d08-9061-f53d6f949908.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -17347,7 +17347,7 @@
         },
         {
             "id": "f553735d-b495-5c5f-b28e-464065ef8859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53e20ee-b43c-45aa-9921-2c6f7ddc27fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53e20ee-b43c-45aa-9921-2c6f7ddc27fb.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -17382,7 +17382,7 @@
         },
         {
             "id": "6382a9a1-d8c1-53e6-b1f3-e2f4f082a584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa10292-f358-48c1-a516-9a1eecf62b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa10292-f358-48c1-a516-9a1eecf62b1d.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -17417,7 +17417,7 @@
         },
         {
             "id": "4e36e853-a4a6-55fa-be91-2414b16ed170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bee18a-46d6-4f60-9e19-5fc670a20a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bee18a-46d6-4f60-9e19-5fc670a20a4d.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -17452,7 +17452,7 @@
         },
         {
             "id": "f491d91a-8f4e-54a5-9513-5d89bad9f4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4345b-61b1-4026-a01c-c9f2036c5c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4345b-61b1-4026-a01c-c9f2036c5c8a.jpg?1",
             "name": "Treefolk",
             "text": "",
             "colours": [
@@ -17487,7 +17487,7 @@
         },
         {
             "id": "134c10aa-8ee5-5bcf-a813-169abcb94318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364e04d9-9a8a-49df-921c-7a9bf62dc731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/364e04d9-9a8a-49df-921c-7a9bf62dc731.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -17522,7 +17522,7 @@
         },
         {
             "id": "c5487613-a4b3-5943-8405-51c497f272a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe08d-b469-4471-8a7d-cf75850ba312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8fe08d-b469-4471-8a7d-cf75850ba312.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -17559,7 +17559,7 @@
         },
         {
             "id": "b9f7553d-55f1-5a3d-a0bc-2c36967c544f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5fb489-6e46-4359-9c3c-ef1702526e5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5fb489-6e46-4359-9c3c-ef1702526e5a.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -17596,7 +17596,7 @@
         },
         {
             "id": "4109db31-6037-50fc-a8ba-07c1a21b59f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eca06-2ef2-47ef-a0ab-6766bbd3ab8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eca06-2ef2-47ef-a0ab-6766bbd3ab8b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17627,7 +17627,7 @@
         },
         {
             "id": "c24f7648-d86a-5c66-93c1-104ddd0f95d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a970bebc-08e1-4125-a4c5-8883dfd5a5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a970bebc-08e1-4125-a4c5-8883dfd5a5ca.jpg?1",
             "name": "Teferi, Who Slows the Sunset Emblem",
             "text": "",
             "colours": [],
@@ -17655,7 +17655,7 @@
         },
         {
             "id": "a0aeb1e1-284f-51b4-bc3a-44cb3d26c067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62eda69-f0c2-4977-8603-150d5d4bec49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62eda69-f0c2-4977-8603-150d5d4bec49.jpg?1",
             "name": "Wrenn and Seven Emblem",
             "text": "",
             "colours": [],
@@ -17683,7 +17683,7 @@
         },
         {
             "id": "5b43434b-ed87-5548-bbe4-3f4bc4525c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],
@@ -17710,7 +17710,7 @@
         },
         {
             "id": "90a53819-1a62-5b90-b7eb-d9bcffc2ce6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MIR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MIR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "5476b4a0-5ce9-5b16-9272-5d2be623c26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4644694d-52e6-4d00-8cad-748899eeea84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4644694d-52e6-4d00-8cad-748899eeea84.jpg?1",
             "name": "Afterlife",
             "text": "Bury target creature and put an Essence token into play under the control of that creature's controller. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "2f2593aa-3f74-5844-bf8f-bfdb5dfaaf6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155f2aa6-6c47-4a06-b0ef-2d9205cd133e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155f2aa6-6c47-4a06-b0ef-2d9205cd133e.jpg?1",
             "name": "Alarum",
             "text": "Untap target nonattacking creature. That creature gets +1/+3 until end of turn.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "bbec9fac-89f2-5f39-8f47-45fa4478a867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6f9ec3-6033-4cd4-a52e-31a559559a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6f9ec3-6033-4cd4-a52e-31a559559a93.jpg?1",
             "name": "Auspicious Ancestor",
             "text": "If Auspicious Ancestor is put into the graveyard from play, gain 3 life.\no1: Gain 1 life. Use this ability only when a white spell is successfully cast and only once for each such spell.",
             "colours": [
@@ -100,7 +100,7 @@
         },
         {
             "id": "9be86536-0da7-54a0-b4ad-9ab60a63f549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a243bd7-af98-4e44-af6e-3b0b71d4837b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a243bd7-af98-4e44-af6e-3b0b71d4837b.jpg?1",
             "name": "Benevolent Unicorn",
             "text": "Whenever a spell assigns damage to a creature or player, that damage is reduced by 1.",
             "colours": [
@@ -133,7 +133,7 @@
         },
         {
             "id": "6cd5e890-d14a-5269-9088-629f1aca0d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2192a-78a5-4579-94ce-cccf773a809d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2192a-78a5-4579-94ce-cccf773a809d.jpg?1",
             "name": "Blinding Light",
             "text": "Tap all nonwhite creatures.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "aa523d97-5660-5a3f-af64-ace2084564d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4c4a-ccdd-4f3c-80cf-356ab7836e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4c4a-ccdd-4f3c-80cf-356ab7836e16.jpg?1",
             "name": "Celestial Dawn",
             "text": "All nonland cards you own that are not in play are white. All nonland permanents you control are white. All lands you control are plains. All colored mana symbols in all costs on all of these cards and permanents are o\nW.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "18c19c12-3fa4-51cb-83f2-9b67b8983ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9319039-db2f-47bf-9ef0-8d3a381d54fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9319039-db2f-47bf-9ef0-8d3a381d54fb.jpg?1",
             "name": "Civic Guildmage",
             "text": "o\nG, oc\nT: Target creature gets +0/+1 until end of turn.\no\nU, oc\nT: Put target creature you control on top of owner's library.",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "52a26957-27b9-530a-bae7-887aa9885543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ece98-5506-4a18-b900-8d1a6cd87385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ece98-5506-4a18-b900-8d1a6cd87385.jpg?1",
             "name": "Dazzling Beauty",
             "text": "Play only when defense is chosen.\nTarget unblocked creature is considered blocked.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "a9b1eb34-43c7-5e32-bae5-aabe06ad43c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86a2ae-aaf3-4d4d-ae06-ec3d4a539550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86a2ae-aaf3-4d4d-ae06-ec3d4a539550.jpg?1",
             "name": "Disempower",
             "text": "Put target artifact or enchantment on top of owner's library.",
             "colours": [
@@ -293,7 +293,7 @@
         },
         {
             "id": "33858ef7-7ad2-5e18-84ba-6589df5b411c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e27cbc-d986-437a-9195-6f5e065a49a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71e27cbc-d986-437a-9195-6f5e065a49a2.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "a748daf4-d7b7-5dda-a273-53bbf2ef7669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b84697e-d72d-4169-bf16-753144da281f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b84697e-d72d-4169-bf16-753144da281f.jpg?1",
             "name": "Divine Offering",
             "text": "Destroy target artifact. Gain an amount of life equal to that artifact's casting cost.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "f5dfd3cf-2410-55ed-ad14-e251ebe36bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75629aa3-426e-4e25-a7ab-71e03436e061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75629aa3-426e-4e25-a7ab-71e03436e061.jpg?1",
             "name": "Divine Retribution",
             "text": "For each attacking creature, Divine Retribution deals 1 damage to target attacking creature.",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "8d576f77-1cf4-5b7f-8ecc-ae69d9d88efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a32778b-e6ff-45ca-8b22-dc97a406faa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a32778b-e6ff-45ca-8b22-dc97a406faa4.jpg?1",
             "name": "Ekundu Griffin",
             "text": "Flying, first strike",
             "colours": [
@@ -419,7 +419,7 @@
         },
         {
             "id": "0102c858-3387-5864-a4b5-3a9425d617e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbac1d27-15e2-4e2f-82ab-625a16e096cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbac1d27-15e2-4e2f-82ab-625a16e096cb.jpg?1",
             "name": "Enlightened Tutor",
             "text": "Search your library for an artifact or enchantment card and reveal that card to all players. Shuffle your library and put the revealed card back on top of it.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "f6d3aa0c-31f5-58c8-9256-e2278e5aa83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f2d15e-490b-4754-8197-ac91653698f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f2d15e-490b-4754-8197-ac91653698f7.jpg?1",
             "name": "Ethereal Champion",
             "text": "Pay 1 life: Prevent 1 damage to Ethereal Champion.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "d6f33310-1155-5c55-83d7-c61d39daec95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5657403-7c86-4eb6-84b0-75eedb04a5a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5657403-7c86-4eb6-84b0-75eedb04a5a2.jpg?1",
             "name": "Favorable Destiny",
             "text": "As long as enchanted creature's controller controls at least one other creature, enchanted creature cannot be the target of spells or effects.\nAs long as enchanted creature is white, it gets +1/+2.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "c54d9785-b675-50dd-9a15-e08c589edf0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dedd5e-e2ee-46ec-8541-27f1548b2a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90dedd5e-e2ee-46ec-8541-27f1548b2a2a.jpg?1",
             "name": "Femeref Healer",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "966010c1-bdbc-5831-9fa8-6642db470084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a2e07-b449-4d94-93e3-e756e891c542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915a2e07-b449-4d94-93e3-e756e891c542.jpg?1",
             "name": "Femeref Knight",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\noo\nW Attacking does not cause Femeref Knight to tap this turn.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "ed83d5ce-1aaa-5eba-944a-198fd9bc0cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60192ded-689b-4cc5-9293-bff52924089b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60192ded-689b-4cc5-9293-bff52924089b.jpg?1",
             "name": "Femeref Scouts",
             "text": "",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "60ceaabd-1890-5146-bce2-446467de56f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c9ca9-3611-46df-8108-45ba383b4ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c9ca9-3611-46df-8108-45ba383b4ee6.jpg?1",
             "name": "Healing Salve",
             "text": "Target player gains 3 life, or prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "0dc12e86-a212-55b6-b22c-203594aa472c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28f6e5-c9ef-416e-b315-967d857e7600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb28f6e5-c9ef-416e-b315-967d857e7600.jpg?1",
             "name": "Illumination",
             "text": "Counter target artifact or enchantment spell. That spell's caster gains an amount of life equal to the spell's casting cost.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "c805d06e-1707-5746-a4cd-19489b562106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c8e952-f040-4e5b-88f3-f80ad4b3f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c8e952-f040-4e5b-88f3-f80ad4b3f2f1.jpg?1",
             "name": "Iron Tusk Elephant",
             "text": "Trample",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "7efbd9d2-53fb-5342-a719-990055c81719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0706acf6-587e-4f29-944a-fdf25aeacb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0706acf6-587e-4f29-944a-fdf25aeacb6d.jpg?1",
             "name": "Ivory Charm",
             "text": "Choose one All creatures get -2/-0 until end of turn; or prevent 1 damage to any creature or player; or tap target creature.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "d5c6bec2-4b21-58c0-ade3-5653b37d201b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f764d7-4c18-40ef-8373-ef1e2a88007e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f764d7-4c18-40ef-8373-ef1e2a88007e.jpg?1",
             "name": "Jabari's Influence",
             "text": "Play only after combat.\nGain control of target nonartifact, nonblack creature that attacked you this turn and put a -1/-0 counter on it.",
             "colours": [
@@ -775,7 +775,7 @@
         },
         {
             "id": "0640ae40-bed2-5284-bf73-9d8142093858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0125f79-ff68-4fb9-b309-8d277259f323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0125f79-ff68-4fb9-b309-8d277259f323.jpg?1",
             "name": "Mangara's Blessing",
             "text": "Gain 5 life.\nWhen a spell or ability an opponent controls causes you to discard Mangara's Blessing, you gain 2 life and return Mangara's Blessing from your graveyard to your hand at end of turn.",
             "colours": [
@@ -806,7 +806,7 @@
         },
         {
             "id": "6f93e735-0721-51b7-aba2-02d4e2146e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796153-3f7f-4d94-8ad4-5a4b2c8e09bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d796153-3f7f-4d94-8ad4-5a4b2c8e09bb.jpg?1",
             "name": "Mangara's Equity",
             "text": "When you play Mangara's Equity, choose black or red.\nDuring your upkeep, pay o1o\nW or bury Mangara's Equity.\nFor each 1 damage a creature of the chosen color deals to you or a white creature you control, Mangara's Equity deals 1 damage to that creature.",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "ddbce2d2-5bd5-5a35-9ff0-ef2b5464e780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8292b6e7-92ac-4bbb-906c-1fe47e260a24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8292b6e7-92ac-4bbb-906c-1fe47e260a24.jpg?1",
             "name": "Melesse Spirit",
             "text": "Flying, protection from black",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "6b5442bd-4d21-5406-b591-95895952cd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162dd988-0beb-48e4-9eaa-a08ddb835648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162dd988-0beb-48e4-9eaa-a08ddb835648.jpg?1",
             "name": "Mtenda Griffin",
             "text": "Flying\no\nW, oc\nT: Return Mtenda Griffin to owner's hand and return target Griffin card in your graveyard to your hand. Use this ability only during your upkeep.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "dc0679c5-bdc8-59a9-9df7-fcee5cf7f82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f30a3d-1421-4706-b17f-39a9ec7a0d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f30a3d-1421-4706-b17f-39a9ec7a0d8b.jpg?1",
             "name": "Mtenda Herder",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "9060d72b-3c76-5e15-a8d2-8028026a6fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f399cb-dddb-422a-8d36-938b82b59e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f399cb-dddb-422a-8d36-938b82b59e10.jpg?1",
             "name": "Noble Elephant",
             "text": "Banding, trample",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "4e23a427-c11a-51d0-a69c-89480f3e2bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814f8976-6612-438f-a04a-8edb63edb1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814f8976-6612-438f-a04a-8edb63edb1e7.jpg?1",
             "name": "Null Chamber",
             "text": "You and target opponent each name any card except a basic land. Those cards cannot be played.",
             "colours": [
@@ -1004,7 +1004,7 @@
         },
         {
             "id": "a91056a7-755b-57fc-bada-9c45e359f086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c891df1b-bae6-4d6d-85ee-42901c149f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c891df1b-bae6-4d6d-85ee-42901c149f98.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature cannot attack or block.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "29f4026c-9200-5070-b4e9-d515da46f836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac3411-3286-4698-b5d9-d4bb2db30770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ac3411-3286-4698-b5d9-d4bb2db30770.jpg?1",
             "name": "Pearl Dragon",
             "text": "Flying\no1oo\nW +0/+1 until end of turn",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "9cfaaad4-67b9-5f2a-b30a-a104a044198b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e3de4-f173-4bcc-a5fb-089eee7108d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4e3de4-f173-4bcc-a5fb-089eee7108d3.jpg?1",
             "name": "Prismatic Circle",
             "text": "Cumulative upkeep o1\nWhen you play Prismatic Circle, choose a color.\no1: Prevent all damage to you from a source of the chosen color. Treat further damage from that source normally.",
             "colours": [
@@ -1101,7 +1101,7 @@
         },
         {
             "id": "06bc148c-fc3e-552b-8dbe-65591dfa2e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb48053-da60-477a-b1eb-a9ab9ea682af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb48053-da60-477a-b1eb-a9ab9ea682af.jpg?1",
             "name": "Rashida Scalebane",
             "text": "oc\nT: Bury target attacking or blocking Dragon. Gain an amount of life equal to that Dragon's power.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "5bef75d1-11d4-53c1-98e0-18e9afec92b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21205189-0d00-44d5-9772-820e607dba25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21205189-0d00-44d5-9772-820e607dba25.jpg?1",
             "name": "Ritual of Steel",
             "text": "Draw a card at the beginning of the upkeep of the turn after Ritual of Steel comes into play.\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "19a0190f-81bc-569e-ae39-d36f11a9458f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6622f325-6bc3-49dc-ba8e-154e70772dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6622f325-6bc3-49dc-ba8e-154e70772dd5.jpg?1",
             "name": "Sacred Mesa",
             "text": "During your upkeep, sacrifice a Pegasus or bury Sacred Mesa.\no1oo\nW Put a Wild Pegasus token into play. Treat this token as a 1/1 white creature with flying that counts as a Pegasus.",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "799dde78-9eca-5051-9e16-c549e1fd7178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe8fa5-5ca8-43ce-863e-61802126e485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbe8fa5-5ca8-43ce-863e-61802126e485.jpg?1",
             "name": "Shadowbane",
             "text": "Prevent all damage to you or a creature you control from any one source. If that source is black, gain 1 life for each 1 damage prevented in this way.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "86e6bd5e-5b30-5747-9b7a-2f9ba8d4bd74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f0d06-cd14-49f3-ad3c-0d419a0c30bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f0d06-cd14-49f3-ad3c-0d419a0c30bc.jpg?1",
             "name": "Sidar Jabari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Sidar Jabari attacks, tap target creature defending player controls.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "7739870b-32c9-50fd-9e41-ba3437ed5dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f9427-ef5c-49fd-81e1-ddf130d69da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f9427-ef5c-49fd-81e1-ddf130d69da0.jpg?1",
             "name": "Soul Echo",
             "text": "When you play Soul Echo, put X echo counters on it.\nAt the beginning of your upkeep, if there are no echo counters on Soul Echo, bury it; otherwise, target opponent may choose that for each 1 damage dealt to you until your next upkeep, you instead remove 1 echo counter from Soul Echo.\nYou do not lose the game as a result of having less than 1 life.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "e31e3ecd-2a88-5550-adb1-19aba621f6cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bea61-8fd2-4802-90b4-651bebbe9638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0bea61-8fd2-4802-90b4-651bebbe9638.jpg?1",
             "name": "Spectral Guardian",
             "text": "As long as Spectral Guardian is untapped, noncreature artifacts cannot be the target of spells or effects.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "cd934160-f38d-5dc9-bc33-da9bf6ea7121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dc838-3022-42f1-bc92-8e8358c27ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4dc838-3022-42f1-bc92-8e8358c27ea4.jpg?1",
             "name": "Sunweb",
             "text": "Flying\nSunweb cannot block creatures with power 2 or less.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "7d2781a8-3f77-5d21-aca0-16e3d5e82824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96267012-24da-43ae-97af-69ca3d7704f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96267012-24da-43ae-97af-69ca3d7704f8.jpg?1",
             "name": "Teremko Griffin",
             "text": "Banding, flying",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "6febdfd8-eedc-5c25-96e7-8295aa446d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3573-2cc5-47ca-b65f-080aab7fdddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3573-2cc5-47ca-b65f-080aab7fdddc.jpg?1",
             "name": "Unyaro Griffin",
             "text": "Flying\nSacrifice Unyaro Griffin: Counter target red spell that assigns damage to you or a creature you control. Play this ability as an interrupt.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "5e40a834-b2f3-5b99-812e-58a27be82e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02e3c10-cc21-4e06-a987-b03aee61bd50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02e3c10-cc21-4e06-a987-b03aee61bd50.jpg?1",
             "name": "Vigilant Martyr",
             "text": "Sacrifice Vigilant Martyr: Regenerate target creature.\no\nWo\nW, oc\nT, Sacrifice Vigilant Martyr: Counter target spell that targets an enchantment in play. Play this ability as an interrupt.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "2af935e1-5af3-547e-a075-969bd0c73cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd25787d-b90c-4b25-8259-1ac41d4dcd15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd25787d-b90c-4b25-8259-1ac41d4dcd15.jpg?1",
             "name": "Wall of Resistance",
             "text": "Flying\nAt the end of any turn in which Wall of Resistance is dealt damage, put a +0/+1 counter on it.",
             "colours": [
@@ -1498,7 +1498,7 @@
         },
         {
             "id": "a84e8a79-238f-558e-ae6c-9b36f0c2c64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389daf-c7d8-4bd1-b4ea-5082f5d280c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d389daf-c7d8-4bd1-b4ea-5082f5d280c0.jpg?1",
             "name": "Ward of Lights",
             "text": "You may choose to play Ward of Lights as an instant; if you do, bury it at end of turn.\nEnchanted creature gains protection from a color of your choice. The protection granted by Ward of Lights does not bury Ward of Lights.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "4b914cd8-14ff-5da0-97ef-cf3f81a97883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14343d-c2cd-4a67-ae54-6b6a4677ca85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a14343d-c2cd-4a67-ae54-6b6a4677ca85.jpg?1",
             "name": "Yare",
             "text": "Target creature defending player controls gets +3/+0 until end of turn. That creature may be assigned to block up to three creatures this turn. All blocks must be legal.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "67f57ede-0568-5a0d-a742-c0a738569bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e63cb-6da5-4f65-a976-e79d201e9fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb0e63cb-6da5-4f65-a976-e79d201e9fc7.jpg?1",
             "name": "Zhalfirin Commander",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1o\nWoo\nW Target Knight gets +1/+1 until end of turn.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "6fb0ea39-61da-5f54-9ae4-4f1345355db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb65d104-bd50-481e-a70e-62aeb2f2c12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb65d104-bd50-481e-a70e-62aeb2f2c12b.jpg?1",
             "name": "Zhalfirin Knight",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no\nWoo\nW First strike until end of turn",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "87c59eb0-3d69-55d3-80c7-a40db1ab72c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b24a80-b5e1-484f-9e21-886cb6b5db48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b24a80-b5e1-484f-9e21-886cb6b5db48.jpg?1",
             "name": "Zuberi, Golden Feather",
             "text": "Flying\nZuberi, Golden Feather counts as a Griffin.\nAll other Griffins get +1/+1.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "59e77d3c-017d-59b5-8354-8f5491b4489c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d1298b-9f56-4540-8d6b-7eecfe38cf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d1298b-9f56-4540-8d6b-7eecfe38cf62.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your library. Put two of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "95d6afc2-cbc6-5496-9cb9-d9446e0dcf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ba4e0-f6f3-4b6c-b6cb-ab2b93d64601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ba4e0-f6f3-4b6c-b6cb-ab2b93d64601.jpg?1",
             "name": "Azimaet Drake",
             "text": "Flying\noo\nU +1/+0 until end of turn. You cannot spend more than o\nU in this way each turn.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "94ee710a-b1c5-5ff0-845b-05fb9d632ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45268a-b757-4ad2-bab0-869058ee9186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df45268a-b757-4ad2-bab0-869058ee9186.jpg?1",
             "name": "Bay Falcon",
             "text": "Flying\nAttacking does not cause Bay Falcon to tap.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "6ee65f07-0f61-555d-823b-4abca5654c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e7a165-e135-4b85-943d-8352b6e65870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e7a165-e135-4b85-943d-8352b6e65870.jpg?1",
             "name": "Bazaar of Wonders",
             "text": "When Bazaar of Wonders comes into play, remove all cards in all graveyards from the game.\nWhenever a spell is played, counter it if a card with the same name is in play or in any graveyard.",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "a64a4985-34ea-5183-b0c2-3fc8c88509f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98413-740d-47fd-bed6-2d3d05a72b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c98413-740d-47fd-bed6-2d3d05a72b31.jpg?1",
             "name": "Boomerang",
             "text": "Return target permanent to owner's hand.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "7a4da54f-0802-5be6-92db-9ffccc648a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c599f95-c0dd-4dd8-a8d7-9481df0cf649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c599f95-c0dd-4dd8-a8d7-9481df0cf649.jpg?1",
             "name": "Cerulean Wyvern",
             "text": "Flying, protection from green",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "bbd009fe-3a12-5080-b063-3a538a744c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6e21e6-fb3e-49c1-b5a0-499faf66d279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f6e21e6-fb3e-49c1-b5a0-499faf66d279.jpg?1",
             "name": "Cloak of Invisibility",
             "text": "Enchanted creature gains phasing and cannot be blocked except by Walls.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "9e91a149-b355-5ad9-a3b8-f4a123a0c04d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9dfa0-bdb3-4419-ae4b-cc394552af74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f9dfa0-bdb3-4419-ae4b-cc394552af74.jpg?1",
             "name": "Coral Fighters",
             "text": "If Coral Fighters attacks and is not blocked, look at the top card of defending player's library. You may choose to put that card on the bottom of that player's library.",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "b9695fca-ea47-557b-992c-a66a56ce7921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87b3c06-5479-4060-8d3a-d161fd5830c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87b3c06-5479-4060-8d3a-d161fd5830c1.jpg?1",
             "name": "Daring Apprentice",
             "text": "oc\nT, Sacrifice Daring Apprentice: Counter target spell.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "e9c340ef-5f89-5e12-ab95-d067c9e322b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9271d-6dbf-4640-9222-721a7a3ccc08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9271d-6dbf-4640-9222-721a7a3ccc08.jpg?1",
             "name": "Dissipate",
             "text": "Counter target spell. Remove that spell card from the game.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "274c4f97-a565-5951-9dc3-7204ef63b660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b599422e-5f78-4d4f-bc67-684caf69458f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b599422e-5f78-4d4f-bc67-684caf69458f.jpg?1",
             "name": "Dream Cache",
             "text": "Draw three cards. Choose two cards from your hand and put both on either the top or the bottom of your library.",
             "colours": [
@@ -2022,7 +2022,7 @@
         },
         {
             "id": "d72674be-d656-5543-b795-47ab241a72b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec06bc9-553c-4e01-8b43-a4eeaa511b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec06bc9-553c-4e01-8b43-a4eeaa511b4d.jpg?1",
             "name": "Dream Fighter",
             "text": "Whenever Dream Fighter blocks or is blocked by a creature, Dream Fighter and that creature phase out.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "4d5bf919-6733-5fe7-b39f-df2504e661a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e060d7-42ed-49ab-bc5c-2f3210cbd0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e060d7-42ed-49ab-bc5c-2f3210cbd0d1.jpg?1",
             "name": "Energy Vortex",
             "text": "When you play Energy Vortex, choose target opponent.\nAt the beginning of your upkeep, remove all energy counters from Energy Vortex.\nDuring chosen opponent's upkeep, he or she pays o1 for each energy counter on Energy Vortex, or it deals 3 damage to him or her.\noo\nX Put X energy counters on Energy Vortex. Use this ability only during your upkeep.",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "6a9b82dc-95d3-523c-a4b2-1213af3e9e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2cf195-01bf-4076-a0c6-ca5403d84f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2cf195-01bf-4076-a0c6-ca5403d84f7d.jpg?1",
             "name": "Ether Well",
             "text": "Put target creature on top of owner's library. If that creature is red, you may choose to put it on the bottom of owner's library instead.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "89eb396a-c21a-590f-a1c3-606539a75b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63af3c26-5b1f-46f6-9aa2-036c615bf5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63af3c26-5b1f-46f6-9aa2-036c615bf5ea.jpg?1",
             "name": "Flash",
             "text": "Choose a creature card from your hand and put that creature into play as though it were just played. Pay the creature's casting cost reduced by up to o2. If you cannot, bury the creature.",
             "colours": [
@@ -2149,7 +2149,7 @@
         },
         {
             "id": "910d60c3-2b48-573b-9af9-3495f286bca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2f594d-e608-444b-b81f-836de2452868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2f594d-e608-444b-b81f-836de2452868.jpg?1",
             "name": "Floodgate",
             "text": "If Floodgate gains flying, bury it.\nIf Floodgate leaves play, it deals to each nonblue creature without flying 1 damage for each two islands you control.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "2c0c052c-9dcd-56da-bf0b-3cdb299cfec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8192bca7-03e5-4ea1-ae77-8bc811c19417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8192bca7-03e5-4ea1-ae77-8bc811c19417.jpg?1",
             "name": "Hakim, Loreweaver",
             "text": "Flying\no\nUoo\nU Put target creature enchantment card from your graveyard on Hakim, Loreweaver. Treat that enchantment as though it were just played. Use this ability only during your upkeep and only if there are no enchantments on Hakim.\no\nUo\nU, oc\nT: Destroy all enchantments on Hakim.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "ee103e90-c409-566c-9f0b-19095cbb2eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6673d49-c3f6-41f6-84c6-1957fff71509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6673d49-c3f6-41f6-84c6-1957fff71509.jpg?1",
             "name": "Harmattan Efreet",
             "text": "Flying\no1o\nUoo\nU Target creature gains flying until end of turn.",
             "colours": [
@@ -2251,7 +2251,7 @@
         },
         {
             "id": "21660c9a-0847-5171-850b-1202de7d6df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0c085a-e17d-4003-bb58-f97555365fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0c085a-e17d-4003-bb58-f97555365fcf.jpg?1",
             "name": "Jolt",
             "text": "Tap or untap target artifact, creature, or land.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -2282,7 +2282,7 @@
         },
         {
             "id": "0c9573f2-c0fa-5f9d-9d86-7bb8c50d596c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10b5ce7-16c9-48f3-a1da-8a91092d053a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10b5ce7-16c9-48f3-a1da-8a91092d053a.jpg?1",
             "name": "Kukemssa Pirates",
             "text": "If Kukemssa Pirates attacks and is not blocked, you may choose to have it deal no damage to defending player this turn. If you do, gain control of target artifact that player controls.",
             "colours": [
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "707a488e-ffe4-567f-b004-59304b1ecc9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099eacf-1898-493c-ae87-d5ff4a3646a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9099eacf-1898-493c-ae87-d5ff4a3646a2.jpg?1",
             "name": "Kukemssa Serpent",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)\no\nU, Sacrifice an island: Target land an opponent controls is an island until end of turn.",
             "colours": [
@@ -2349,7 +2349,7 @@
         },
         {
             "id": "72f496de-70bd-5b03-8731-e10011d1c928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0245553c-b483-47df-940b-5d7deb108642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0245553c-b483-47df-940b-5d7deb108642.jpg?1",
             "name": "Meddle",
             "text": "Target spell, which targets a single creature, targets another creature of your choice instead. The new target must be legal.",
             "colours": [
@@ -2380,7 +2380,7 @@
         },
         {
             "id": "2b351303-ce53-5178-bc50-b31811117e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63453ed9-5cf1-4cad-b173-a067f22a4405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63453ed9-5cf1-4cad-b173-a067f22a4405.jpg?1",
             "name": "Memory Lapse",
             "text": "Counter target spell. Put that spell on top of owner's library.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "cc40bfe6-d8d1-5a8a-bd86-fe36aad43653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f34166-8946-4bcc-84af-3540c42ac7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f34166-8946-4bcc-84af-3540c42ac7f7.jpg?1",
             "name": "Merfolk Raiders",
             "text": "Phasing; islandwalk (If defending player controls any islands, this creature is unblockable.)",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "a23873f5-23b9-5c71-ab5f-3be659a3faea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63139890-e860-4791-9bb6-b79bb361ef8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63139890-e860-4791-9bb6-b79bb361ef8b.jpg?1",
             "name": "Merfolk Seer",
             "text": "o1oo\nU Draw a card. Use this ability only when Merfolk Seer is put into the graveyard from play and only once.",
             "colours": [
@@ -2479,7 +2479,7 @@
         },
         {
             "id": "35a27a60-8139-501b-b407-91694e4b8106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952eb6ae-a530-4f4f-92f0-a6602beaa7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952eb6ae-a530-4f4f-92f0-a6602beaa7b2.jpg?1",
             "name": "Mind Bend",
             "text": "Change the text of target permanent by replacing all instances of one color word or basic land type with another. (For example, you may change \"nonred creature\" to \"nongreen creature\" or \"plainswalk\" to \"swampwalk.\")",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "a99448b1-710e-5445-9a03-1f5642a16b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf17780-801d-4ab8-91f4-a803ede51395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf17780-801d-4ab8-91f4-a803ede51395.jpg?1",
             "name": "Mind Harness",
             "text": "Play only on a red or green creature.\nCumulative upkeep o1\nGain control of enchanted creature.",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "e9bca768-7084-5366-a0fc-d85ac8164a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9b4be4-74c8-4fe5-a5e4-de57c11e8ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9b4be4-74c8-4fe5-a5e4-de57c11e8ec1.jpg?1",
             "name": "Mist Dragon",
             "text": "o0: Flying\no0: Loses flying\no3o\nUoo\nU Phases out",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "2fd2e10a-a268-5c33-aaf7-a57b7f81e866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d98101f-e32a-4a4a-a649-faa920d111ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d98101f-e32a-4a4a-a649-faa920d111ee.jpg?1",
             "name": "Mystical Tutor",
             "text": "Search your library for an instant, interrupt, mana source, or sorcery card and reveal that card to all players. Shuffle your library and put the revealed card back on top of it.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "f637988d-3152-5174-9f62-fa6d884562d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e56e720-5e8b-4685-969c-e073de78b9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e56e720-5e8b-4685-969c-e073de78b9a1.jpg?1",
             "name": "Political Trickery",
             "text": "Choose target land you control and target land an opponent controls. Exchange control of those lands.",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "064e4a22-f012-5b39-afb1-60f2dd6a568c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbae8702-a152-4c53-8a76-691a221f2475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbae8702-a152-4c53-8a76-691a221f2475.jpg?1",
             "name": "Polymorph",
             "text": "Bury target creature. That creature's controller reveals cards from the top of his or her library until a creature card is revealed and then puts that creature into play under his or her control as though it were just played. The player shuffles all other revealed cards into his or her library.",
             "colours": [
@@ -2669,7 +2669,7 @@
         },
         {
             "id": "d7891392-09f3-587d-a6ff-b67da33429fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49717583-e0bb-47d6-92d0-8959af13391f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49717583-e0bb-47d6-92d0-8959af13391f.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless that spell's caster pays an additional o\nX. That player draws and pays all mana from lands and mana pool until o\nX is paid; he or she may also draw and pay mana from other sources if desired.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "7578d1ee-c2b9-5200-a19a-d5af203e55e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1129585-6d59-4217-9404-747a100f1e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1129585-6d59-4217-9404-747a100f1e8c.jpg?1",
             "name": "Prismatic Lace",
             "text": "Target permanent becomes the color(s) of your choice. Costs to tap, maintain, or use an ability of that permanent remain unchanged.",
             "colours": [
@@ -2731,7 +2731,7 @@
         },
         {
             "id": "a9b5375d-7c1e-55a5-9f24-bbaa212b7908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507c474-5c4b-4292-b7bc-3ab4b48ea290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5507c474-5c4b-4292-b7bc-3ab4b48ea290.jpg?1",
             "name": "Psychic Transfer",
             "text": "Compare your life total with target player's life total. If the difference is 5 or less and you have at least 1 life, exchange life totals with that player.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "9a69d5fc-412d-5af0-9a80-db43652e2f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4361c600-7a97-46bf-8cc1-f3713d3c28ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4361c600-7a97-46bf-8cc1-f3713d3c28ab.jpg?1",
             "name": "Ray of Command",
             "text": "Untap target creature an opponent controls and gain control of it until end of turn. That creature is unaffected by summoning sickness this turn. Tap the creature if you lose control of it at end of this turn.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "c1bb27c9-f1ac-506b-8fe8-80648343b232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b94eed-2a45-4a6b-a06b-a2021b174bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b94eed-2a45-4a6b-a06b-a2021b174bc5.jpg?1",
             "name": "Reality Ripple",
             "text": "Target artifact, creature, or land phases out.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "ec327bd1-5dc5-583e-9e8c-d85740a04eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bea2ea-04d3-4835-843a-ebbed0ef5831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2bea2ea-04d3-4835-843a-ebbed0ef5831.jpg?1",
             "name": "Reality Ripple",
             "text": "",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "a2b59e0a-5179-5d02-9648-1253776e3e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450b79d9-5ab8-4699-8052-a278c316a5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450b79d9-5ab8-4699-8052-a278c316a5c3.jpg?1",
             "name": "Sandbar Crocodile",
             "text": "Phasing",
             "colours": [
@@ -2892,7 +2892,7 @@
         },
         {
             "id": "007e9122-9daf-53d3-9972-15cc08cd9a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2944e5df-eef9-42be-a591-5ac15e306ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2944e5df-eef9-42be-a591-5ac15e306ad8.jpg?1",
             "name": "Sapphire Charm",
             "text": "Choose one Target player draws a card at the beginning of the next turn's upkeep; or target creature an opponent controls phases out; or target creature gains flying until end of turn.",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "a268439a-5a5c-5c87-a5f9-aae29524a9ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124308ac-1bf6-4a79-8aaa-f3be8eeb3e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124308ac-1bf6-4a79-8aaa-f3be8eeb3e78.jpg?1",
             "name": "Sea Scryer",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source. o1, oc\nT: Add o\nU to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "ec6a76c8-2bf3-53ae-8af7-135a28b2eff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9304e1-f403-404d-9fe9-169da75e0d62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9304e1-f403-404d-9fe9-169da75e0d62.jpg?1",
             "name": "Shaper Guildmage",
             "text": "o\nW, oc\nT: Target creature gains first strike until end of turn.\no\nB, oc\nT: Target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "f14b09f0-fbb1-5b79-95bc-742cf2bc5c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c892daa-57fe-4712-b64a-6099d531bb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c892daa-57fe-4712-b64a-6099d531bb26.jpg?1",
             "name": "Shimmer",
             "text": "When you play Shimmer, choose a land type.\nAll lands of the chosen type gain phasing.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "d561d8cf-760e-54d4-9307-b635c17aff44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3666dd-a90e-43c2-bd78-ea9c1af08a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3666dd-a90e-43c2-bd78-ea9c1af08a0e.jpg?1",
             "name": "Soar",
             "text": "You may choose to play Soar as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +0/+1 and gains flying.",
             "colours": [
@@ -3057,7 +3057,7 @@
         },
         {
             "id": "d5bc82aa-d34c-557c-8fa8-e703cf8d16a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a7c22e-fe96-4960-96d4-ee85abec3281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a7c22e-fe96-4960-96d4-ee85abec3281.jpg?1",
             "name": "Suq'Ata Firewalker",
             "text": "Suq'Ata Firewalker cannot be the target of red spells or effects.\noc\nT: Suq'Ata Firewalker deals 1 damage to target creature or player.",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "8b90c74f-d130-5724-8ee8-4e56a8d49743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d12315-4220-470d-9628-b9a3ea904ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d12315-4220-470d-9628-b9a3ea904ca7.jpg?1",
             "name": "Taniwha",
             "text": "Phasing, trample\nAt the beginning of your upkeep, all lands you control phase out.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "c1769e4e-fa28-5b5b-832a-459a04038ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb813ef5-8441-4024-a585-1ea24145e1bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb813ef5-8441-4024-a585-1ea24145e1bd.jpg?1",
             "name": "Teferi's Curse",
             "text": "Play only on an artifact or creature.\nEnchanted permanent gains phasing.",
             "colours": [
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "38e1cc38-9fcb-5984-9e36-e921378625ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24823df-5651-4578-a0c8-f9f52f66abe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24823df-5651-4578-a0c8-f9f52f66abe4.jpg?1",
             "name": "Teferi's Drake",
             "text": "Flying, phasing",
             "colours": [
@@ -3192,7 +3192,7 @@
         },
         {
             "id": "8944a2d4-16e5-51f5-a55e-ef3c84a5f6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048f2368-0e2f-4197-b977-353d38b38ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048f2368-0e2f-4197-b977-353d38b38ccc.jpg?1",
             "name": "Teferi's Imp",
             "text": "Flying, phasing\nWhen Teferi's Imp phases out, choose and discard a card.\nWhen Teferi's Imp phases in, draw a card.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "7b0f084b-7c24-546c-aa2b-375971f7c6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12630ac5-a6c4-4852-abd9-5a0bc71bbf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12630ac5-a6c4-4852-abd9-5a0bc71bbf83.jpg?1",
             "name": "Thirst",
             "text": "When Thirst comes into play, tap enchanted creature.\nDuring your upkeep, pay o\nU or bury Thirst.\nEnchanted creature does not untap during its controller's untap phase.",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "d3d4639b-7452-5a81-8b86-8e23e27335ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a9689b-bf1e-404e-ba08-0b04de4288fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a9689b-bf1e-404e-ba08-0b04de4288fb.jpg?1",
             "name": "Tidal Wave",
             "text": "Put a Wave token into play. Treat this token as a 5/5 blue creature that counts as a Wall. Bury the token at end of any turn.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "6d625080-fbbd-52d8-acb8-a0dde05f1dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea65e2-68d8-429f-9be7-e6e5e12a2a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ea65e2-68d8-429f-9be7-e6e5e12a2a4d.jpg?1",
             "name": "Vaporous Djinn",
             "text": "Flying\nDuring your upkeep, pay o\nUo\nU or Vaporous Djinn phases out.",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "b2c9255f-f875-5408-af91-adf758da5550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ee762-72cb-43e3-88a1-6f1f0b9ee66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111ee762-72cb-43e3-88a1-6f1f0b9ee66e.jpg?1",
             "name": "Wave Elemental",
             "text": "o\nU, oc\nT, Sacrifice Wave Elemental: Tap up to three target creatures without flying.",
             "colours": [
@@ -3355,7 +3355,7 @@
         },
         {
             "id": "ea75b13d-b141-5f76-86db-a19c62ac6b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08798c53-46f3-4a51-9284-491730605b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08798c53-46f3-4a51-9284-491730605b2b.jpg?1",
             "name": "Abyssal Hunter",
             "text": "o\nB, oc\nT: Tap target creature. Abyssal Hunter deals to that creature an amount of damage equal to Abyssal Hunter's power.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "21b899af-6fec-584d-acaa-8d22d8e6d5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686aebd0-0d34-47e3-bbbd-ad08d2a3a864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686aebd0-0d34-47e3-bbbd-ad08d2a3a864.jpg?1",
             "name": "Ashen Powder",
             "text": "Put target creature card from an opponent's graveyard into play under your control.",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "6c502fe2-b243-51aa-befc-0032654f51f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b96810d-72d3-4dee-a29f-cdf85ea5ce6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b96810d-72d3-4dee-a29f-cdf85ea5ce6f.jpg?1",
             "name": "Barbed-Back Wurm",
             "text": "oo\nB Target green creature blocking Barbed-Back Wurm gets -1/-1 until end of turn.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "c7bdac6d-ecb2-569c-a9cc-bdb582533cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b620a9f4-358d-4436-85b8-b0c16602ff57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b620a9f4-358d-4436-85b8-b0c16602ff57.jpg?1",
             "name": "Binding Agony",
             "text": "For each 1 damage dealt to enchanted creature, Binding Agony deals 1 damage to that creature's controller.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "96bb1246-fcc0-5103-91f9-ab7cba719e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f2b33c-8d4d-406e-98de-b92d92a3012a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f2b33c-8d4d-406e-98de-b92d92a3012a.jpg?1",
             "name": "Blighted Shaman",
             "text": "oc\nT, Sacrifice a creature: Target creature gets +2/+2 until end of turn.\noc\nT, Sacrifice a swamp: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -3521,7 +3521,7 @@
         },
         {
             "id": "e02961ee-0103-5cdf-b23f-e87aa2df584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfde1ca-52f9-477d-a36e-6e4f7ca2e4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfde1ca-52f9-477d-a36e-6e4f7ca2e4d8.jpg?1",
             "name": "Bone Harvest",
             "text": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3552,7 +3552,7 @@
         },
         {
             "id": "0ae1127e-f367-5ec9-bdaa-efcd90e088ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9da69-5e57-4719-a712-630c9464fada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9da69-5e57-4719-a712-630c9464fada.jpg?1",
             "name": "Breathstealer",
             "text": "oo\nB +1/-1 until end of turn",
             "colours": [
@@ -3585,7 +3585,7 @@
         },
         {
             "id": "17eb7844-6d60-5f89-a474-1df18bec0222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e954b2-c8ce-4b6c-a118-4a14ffa72063.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e954b2-c8ce-4b6c-a118-4a14ffa72063.jpg?1",
             "name": "Cadaverous Knight",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1o\nBoo\nB Regenerate",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "c29fc8f4-5b5a-5277-87d5-e63f51836fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6c7750-bc3b-4790-bc9d-88e2cf16881e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e6c7750-bc3b-4790-bc9d-88e2cf16881e.jpg?1",
             "name": "Carrion",
             "text": "Sacrifice a creature: Put into play a number of Maggot tokens equal to the sacrificed creature's power. Treat these tokens as 0/1 black creatures.",
             "colours": [
@@ -3650,7 +3650,7 @@
         },
         {
             "id": "b0e6a24b-9eaa-5e65-9bca-036f115299c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46daebe4-199e-4580-8a52-1aebc8492d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46daebe4-199e-4580-8a52-1aebc8492d8c.jpg?1",
             "name": "Catacomb Dragon",
             "text": "Flying\nWhenever Catacomb Dragon is blocked by any nonartifact, non-Dragon creature, that creature's power is halved, rounded up, until end of turn.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "c1f6a2d8-f885-5c09-8c8c-bbfed0836623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c15fb-01a1-446e-9e88-71e8e95d9bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41c15fb-01a1-446e-9e88-71e8e95d9bce.jpg?1",
             "name": "Choking Sands",
             "text": "Destroy target nonswamp land. If that land is a nonbasic land, Choking Sands deals 2 damage to the land's controller.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "f3ae4aa6-0677-5643-bd51-1c1dbeee8f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7bcd36-13e2-4ac7-a449-246cecb3fc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7bcd36-13e2-4ac7-a449-246cecb3fc0f.jpg?1",
             "name": "Crypt Cobra",
             "text": "If Crypt Cobra attacks and is not blocked, defending player gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "f2f2014a-dfa7-5215-b237-871f1c2912e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f983dcb-b077-465f-a70b-6bd0e425556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f983dcb-b077-465f-a70b-6bd0e425556c.jpg?1",
             "name": "Dark Banishing",
             "text": "Bury target nonblack creature.",
             "colours": [
@@ -3778,7 +3778,7 @@
         },
         {
             "id": "7b24a110-ded9-542b-8405-04e5969da0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5fc7ce-0618-4145-b8aa-bc871e4afa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5fc7ce-0618-4145-b8aa-bc871e4afa99.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "140c074b-f7d4-5a10-a2dd-4c9c0047019e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc3fa22-a4c4-423d-969b-98c65b23e782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc3fa22-a4c4-423d-969b-98c65b23e782.jpg?1",
             "name": "Dirtwater Wraith",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)\noo\nB +1/+0 until end of turn.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "2a01f8da-317b-583a-b754-f9dd122839f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f030a5-62c6-439d-93b6-43f2cf927a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f030a5-62c6-439d-93b6-43f2cf927a7f.jpg?1",
             "name": "Drain Life",
             "text": "For each o\nB you spend in addition to the casting cost, Drain Life deals 1 damage to target creature or player. Gain 1 life for each 1 damage dealt, but not more than the toughness of the creature or the life total of the player Drain Life damages.",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "79fa383f-c15e-5808-bbd4-f4b0c04eef4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c48e08-9a77-4ba2-8041-90998f7e3812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c48e08-9a77-4ba2-8041-90998f7e3812.jpg?1",
             "name": "Dread Specter",
             "text": "Whenever Dread Specter blocks or is blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "2295ae3d-03d2-5055-b499-3a1c607c43b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937c8016-43c8-418b-9057-b5d6715f71f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937c8016-43c8-418b-9057-b5d6715f71f7.jpg?1",
             "name": "Ebony Charm",
             "text": "Choose one Target opponent loses 1 life and you gain 1 life; or remove from the game up to three cards in any player's graveyard; or target creature cannot be blocked this turn except by artifact or black creatures.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "c6c43457-f5f2-54b6-affb-331b7f11dc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf808509-c6c2-4dcb-b35b-e61291faf5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf808509-c6c2-4dcb-b35b-e61291faf5d9.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchanted creature gets -2/-2.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "aca595c5-6dc5-520f-ac82-e61400ec4cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2d34-1aae-47c7-8b7a-e3354bbbd662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672e2d34-1aae-47c7-8b7a-e3354bbbd662.jpg?1",
             "name": "Feral Shadow",
             "text": "Flying",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "a065f1ab-e69b-5a2c-a85f-f214f0fc4a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be39d50-1e36-4dac-a923-81fc9f229b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be39d50-1e36-4dac-a923-81fc9f229b8d.jpg?1",
             "name": "Fetid Horror",
             "text": "oo\nB +1/+1 until end of turn",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "d4e5d5e5-f8e8-5c86-a4d9-4e78c25474fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6168af2-e49b-4c57-91c0-2cac9290a560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6168af2-e49b-4c57-91c0-2cac9290a560.jpg?1",
             "name": "Forbidden Crypt",
             "text": "For each card you would draw, instead choose target card in your graveyard and put it into your hand. If you cannot, you lose the game.\nWhenever a card is put into your graveyard, remove that card from the game.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "99b54ed9-432c-5da0-a6d8-31c0952fe62a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbfc7c-164d-47b8-8f05-987864fca89b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9dbfc7c-164d-47b8-8f05-987864fca89b.jpg?1",
             "name": "Forsaken Wastes",
             "text": "Players cannot gain life.\nDuring each player's upkeep, that player loses 1 life.\nIf Forsaken Wastes is the target of a successfully cast spell, that spell's caster loses 5 life.",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "0782288d-43c8-5b3b-af03-0789b2d295f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe072da-0524-492b-af3d-7c2600e915ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe072da-0524-492b-af3d-7c2600e915ab.jpg?1",
             "name": "Grave Servitude",
             "text": "You may choose to play Grave Servitude as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +3/-1 and is black.",
             "colours": [
@@ -4134,7 +4134,7 @@
         },
         {
             "id": "0ffd105a-2b82-53ea-99d0-64023cf1734a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e16f8bc-3200-4a0a-b298-c7e7b4e8376c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e16f8bc-3200-4a0a-b298-c7e7b4e8376c.jpg?1",
             "name": "Gravebane Zombie",
             "text": "If Gravebane Zombie is put into the graveyard from play, put Gravebane Zombie on top of owner's library.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "e80b7b59-e59a-56bd-a22f-0df4456f3b5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33124133-ed2c-4b86-a135-ac76f4fe4da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33124133-ed2c-4b86-a135-ac76f4fe4da5.jpg?1",
             "name": "Harbinger of Night",
             "text": "During your upkeep, put a -1/-1 counter on each creature.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "c8866d3a-bbc1-5539-beed-7bfeedc345db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62c43bd-59fe-46e3-83f8-c4b37cbc4931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62c43bd-59fe-46e3-83f8-c4b37cbc4931.jpg?1",
             "name": "Infernal Contract",
             "text": "Pay half your life, rounded up: Draw four cards.",
             "colours": [
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "b74191e1-0bf0-5b25-a0f6-3318b29a8a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097910fb-7c48-4535-8ffc-b521d08294b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097910fb-7c48-4535-8ffc-b521d08294b0.jpg?1",
             "name": "Kaervek's Hex",
             "text": "Kaervek's Hex deals 1 damage to each nonblack creature and an additional 1 damage to each green creature.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "9cd0d3dc-ebfb-58be-b364-eb197d536024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120822b8-02ae-411f-bda5-a774c21db66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120822b8-02ae-411f-bda5-a774c21db66c.jpg?1",
             "name": "Mire Shade",
             "text": "o\nB, Sacrifice a swamp: Put a +1/+1 counter on Mire Shade. Play this ability as a sorcery.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "dbbd5bb1-2c23-5979-a9dc-13f45f89201e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0015fee8-068a-421e-9143-bcb575371f9a.jpg?1",
             "name": "Nocturnal Raid",
             "text": "All black creatures get +2/+0 until end of turn.",
             "colours": [
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "543c03cf-69ec-5a5b-841f-763e486a72a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79223c17-ecb1-47f1-8e24-eea464cc9b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79223c17-ecb1-47f1-8e24-eea464cc9b1e.jpg?1",
             "name": "Painful Memories",
             "text": "Look at target opponent's hand. Choose one of those cards and put it on top of his or her library.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "fe30d169-a7f3-5df5-a415-60dbaaf92d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc55d48-6d6f-429d-8281-e66a9996d574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc55d48-6d6f-429d-8281-e66a9996d574.jpg?1",
             "name": "Phyrexian Tribute",
             "text": "Sacrifice two creatures: Destroy target artifact.",
             "colours": [
@@ -4388,7 +4388,7 @@
         },
         {
             "id": "7ca32f33-50fa-542d-a10c-baba804dc66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4704bf02-c6be-4983-9bc7-a1d464d21b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4704bf02-c6be-4983-9bc7-a1d464d21b31.jpg?1",
             "name": "Purraj of Urborg",
             "text": "First strike when attacking\noo\nB Put a +1/+1 counter on Purraj of Urborg. Use this ability only when a black spell is successfully cast and only once for each such spell.",
             "colours": [
@@ -4424,7 +4424,7 @@
         },
         {
             "id": "9cc440ac-1202-5a0b-bcb3-eb54c668b1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee67033-7f0f-49b4-8472-3bc4fbb8ffe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee67033-7f0f-49b4-8472-3bc4fbb8ffe1.jpg?1",
             "name": "Ravenous Vampire",
             "text": "Flying\nDuring your upkeep, sacrifice a nonartifact creature and put a +1/+1 counter on Ravenous Vampire, or tap Ravenous Vampire.",
             "colours": [
@@ -4457,7 +4457,7 @@
         },
         {
             "id": "7d7747d8-d6f3-5337-b41f-1fd199856575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd83049-aec1-4911-bc70-39adba04b174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd83049-aec1-4911-bc70-39adba04b174.jpg?1",
             "name": "Reign of Terror",
             "text": "Bury all white creatures or bury all green creatures. Lose 2 life for each creature put into the graveyard in this way.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "d2bb93c8-aa1c-5758-8cea-017ec2ac76ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237cff4-af6f-4745-bda1-e3ed2267fa89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237cff4-af6f-4745-bda1-e3ed2267fa89.jpg?1",
             "name": "Restless Dead",
             "text": "oo\nB Regenerate",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "54cf24d8-cc9b-563a-b4ea-0e220355385d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe08c3-5024-486c-ba03-19d371ceccb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42fe08c3-5024-486c-ba03-19d371ceccb0.jpg?1",
             "name": "Sewer Rats",
             "text": "o\nB, Pay 1 life: +1/+0 until end of turn. You cannot spend more than o\nBo\nBo\nB in this way each turn.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "5e1cb8fe-9a62-5c21-b992-bb08c560e7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3fc11e-db36-430c-920b-31195913c16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3fc11e-db36-430c-920b-31195913c16a.jpg?1",
             "name": "Shadow Guildmage",
             "text": "o\nU, oc\nT: Put target creature you control on top of owner's library.\no\nR, oc\nT: Shadow Guildmage deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -4590,7 +4590,7 @@
         },
         {
             "id": "e71084b2-bbb1-511c-827f-9a9f97b94fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c782cc-c951-4c6f-a93f-774ae6c1c214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c782cc-c951-4c6f-a93f-774ae6c1c214.jpg?1",
             "name": "Shallow Grave",
             "text": "Put the top creature card from your graveyard into play as though it were just played. That creature is unaffected by summoning sickness. Remove the creature from the game at end of any turn.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "8c0617b5-0945-52f5-925f-01b53022653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d94b21-7568-4e5c-a8ec-ff5bb48a4f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d94b21-7568-4e5c-a8ec-ff5bb48a4f36.jpg?1",
             "name": "Shauku, Endbringer",
             "text": "Flying\nShauku, Endbringer cannot attack if there is another creature in play.\nDuring your upkeep, lose 3 life.\noc\nT: Remove target creature from the game and put a +1/+1 counter on Shauku.",
             "colours": [
@@ -4656,7 +4656,7 @@
         },
         {
             "id": "4bd6e3fc-41a9-5d5c-9fe5-e907c011ee70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca7e96-0545-4f36-85c0-944d5c0b760a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ca7e96-0545-4f36-85c0-944d5c0b760a.jpg?1",
             "name": "Skulking Ghost",
             "text": "Flying\nIf Skulking Ghost is the target of a spell or effect, bury Skulking Ghost.",
             "colours": [
@@ -4689,7 +4689,7 @@
         },
         {
             "id": "79bc43f9-6704-53b7-a33e-fe3bde36bc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa084e1-05c2-4691-b9fe-3e3c717e5c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fa084e1-05c2-4691-b9fe-3e3c717e5c9d.jpg?1",
             "name": "Soul Rend",
             "text": "Bury target creature if it is white.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "428f5ad5-702b-5bba-9ad2-3c42f428f1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3bf717-2b88-4704-a7e9-f62dbb3d3d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3bf717-2b88-4704-a7e9-f62dbb3d3d3d.jpg?1",
             "name": "Soulshriek",
             "text": "Target creature you control gets +*/+0 until end of turn, where * is equal to the number of creature cards in your graveyard. Bury that creature at end of turn.",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "d1a6778b-e974-5669-93a8-4da65d5e1296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845c4b06-090f-4217-acb2-8900b7dab37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845c4b06-090f-4217-acb2-8900b7dab37c.jpg?1",
             "name": "Spirit of the Night",
             "text": "Flying, trample, protection from black\nFirst strike when attacking\nSpirit of the Night is unaffected by summoning sickness.",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "05467085-f6a1-5b57-b580-20c63d73bdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fed2498-20ce-48ad-a56e-2c7e297c0c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fed2498-20ce-48ad-a56e-2c7e297c0c66.jpg?1",
             "name": "Stupor",
             "text": "Target opponent discards a card at random, then chooses and discards a card.",
             "colours": [
@@ -4818,7 +4818,7 @@
         },
         {
             "id": "e54bea45-3077-5a74-9c16-ea01eaec6a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb223-784a-4540-8a8e-6007d10a9505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74feb223-784a-4540-8a8e-6007d10a9505.jpg?1",
             "name": "Tainted Specter",
             "text": "Flying\no1o\nBo\nB, oc\nT: Target player chooses a card from his or her hand and then chooses either to discard that card or put it on top of his or her library. If the card is discarded, Tainted Specter deals 1 damage to each creature and player. Play this ability as a sorcery.",
             "colours": [
@@ -4851,7 +4851,7 @@
         },
         {
             "id": "ffb49fa3-82ca-5a9d-92d3-7ffbdf4870bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fe2f99-7ec2-490c-8ec3-aa2fb4680826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fe2f99-7ec2-490c-8ec3-aa2fb4680826.jpg?1",
             "name": "Tombstone Stairwell",
             "text": "Cumulative upkeep o1o\nB\nDuring each upkeep, each player puts into play a Tombspawn token for each summon card in his or her graveyard. Treat these tokens as 2/2 black creatures that are unaffected by summoning sickness and count as Zombies. At end of any turn or if Tombstone Stairwell leaves play, bury all of these tokens.",
             "colours": [
@@ -4884,7 +4884,7 @@
         },
         {
             "id": "b125bd97-89a4-52db-bd5e-c2e3e34143b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc9ff0f-adec-4d39-b281-98c5862f506b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc9ff0f-adec-4d39-b281-98c5862f506b.jpg?1",
             "name": "Urborg Panther",
             "text": "o\nB, Sacrifice Urborg Panther: Destroy target creature blocking Urborg Panther.\nSacrifice Feral Shadow, Breathstealer, and Urborg Panther: Search your library for Spirit of the Night and put it into play as though it were just played. Shuffle your library afterwards.",
             "colours": [
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "f5d3124a-d680-5944-a21e-ecd8fd699a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde6d3d1-75db-445f-9f17-632ee0292211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde6d3d1-75db-445f-9f17-632ee0292211.jpg?1",
             "name": "Wall of Corpses",
             "text": "o\nB, Sacrifice Wall of Corpses: Destroy target creature blocked by Wall of Corpses.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "3228047a-1dcc-50ea-b330-33ae533a6060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6499cb-6073-4c94-8c82-47f489094df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6499cb-6073-4c94-8c82-47f489094df5.jpg?1",
             "name": "Withering Boon",
             "text": "Pay 3 life: Counter target summon spell.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "6c8c107d-5d4f-51d4-9de5-4db14c095f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab85551f-c9cc-409c-9fb5-a45de695e521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab85551f-c9cc-409c-9fb5-a45de695e521.jpg?1",
             "name": "Zombie Mob",
             "text": "Zombie Mob comes into play with one +1/+1 counter for each summon card in your graveyard. Remove all of those summon cards from the game.",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "635ec7c0-556d-50b1-ae98-55258983880d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5694cb42-7489-40c5-b21a-aeb36636015f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5694cb42-7489-40c5-b21a-aeb36636015f.jpg?1",
             "name": "Agility",
             "text": "Enchanted creature gets +1/+1 and gains flanking (whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn).",
             "colours": [
@@ -5048,7 +5048,7 @@
         },
         {
             "id": "7ab17ab2-c15a-56e3-a63f-d964a9b139c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380af0a-8a8f-44fd-9456-14a68a2830d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7380af0a-8a8f-44fd-9456-14a68a2830d3.jpg?1",
             "name": "Aleatory",
             "text": "Play only after defense is chosen.\nFlip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "19eb715e-59b4-5039-bcca-608bd51b05b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e999fdc3-9269-44d7-9015-e16f5e5b73eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e999fdc3-9269-44d7-9015-e16f5e5b73eb.jpg?1",
             "name": "Armorer Guildmage",
             "text": "o\nB, oc\nT: Target creature gets +1/+0 until end of turn.\no\nG, oc\nT: Target creature gets +0/+1 until end of turn.",
             "colours": [
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "a1bbd14f-09b0-535f-b74a-678431dab570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2955e-e714-419e-9e3d-7ae3d7fae041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a2955e-e714-419e-9e3d-7ae3d7fae041.jpg?1",
             "name": "Barreling Attack",
             "text": "Target creature gains trample until end of turn. That creature gets +1/+1 until end of turn for each creature that blocks it.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "98398874-ef12-525d-8719-73b9f1ca6f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff91a17-0a5f-456f-a431-8505ba29e679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff91a17-0a5f-456f-a431-8505ba29e679.jpg?1",
             "name": "Blind Fury",
             "text": "All creatures lose trample until end of turn. Double all combat damage assigned to creatures this turn.",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "b0f796e2-d75e-564c-8a0b-40bec45ec567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d000d8-24e1-4cf3-bed9-e68a89c8f569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d000d8-24e1-4cf3-bed9-e68a89c8f569.jpg?1",
             "name": "Blistering Barrier",
             "text": "",
             "colours": [
@@ -5210,7 +5210,7 @@
         },
         {
             "id": "9eaa86b4-e194-590d-a0a3-40185f88f6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb398027-5a29-4c81-aab5-b1a2b82fd655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb398027-5a29-4c81-aab5-b1a2b82fd655.jpg?1",
             "name": "Builder's Bane",
             "text": "Destroy X target artifacts. For each artifact put into the graveyard in this way, Builder's Bane deals 1 damage to that artifact's controller.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "645b7343-2f59-5ca9-a09d-09660e8a9ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a194488a-1d6f-4bc3-8f30-82e2c3c91389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a194488a-1d6f-4bc3-8f30-82e2c3c91389.jpg?1",
             "name": "Burning Palm Efreet",
             "text": "o1o\nRoo\nR Burning Palm Efreet deals 2 damage to target creature with flying and that creature loses flying until end of turn.",
             "colours": [
@@ -5274,7 +5274,7 @@
         },
         {
             "id": "df9bac2a-6b72-5adf-9e99-37857c74e99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486547cd-d2e7-4c46-9f7b-81c4267d65cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486547cd-d2e7-4c46-9f7b-81c4267d65cc.jpg?1",
             "name": "Burning Shield Askari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no\nRoo\nR First strike until end of turn",
             "colours": [
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "47cdb84d-2574-5352-bf2f-295e813341d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf8ccb8-57fb-491c-b07d-93348b33a765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf8ccb8-57fb-491c-b07d-93348b33a765.jpg?1",
             "name": "Chaos Charm",
             "text": "Choose one Target creature is unaffected by summoning sickness this turn; or Chaos Charm deals 1 damage to target creature; or destroy target Wall.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "6c4e170c-e2da-5118-83ea-8af0862669b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41cb92-578b-4fc8-b1e6-56604088fcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd41cb92-578b-4fc8-b1e6-56604088fcd5.jpg?1",
             "name": "Chaosphere",
             "text": "Creatures with flying cannot block creatures without flying.\nCreatures without flying can block creatures with flying.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "7470d1b1-0d68-5079-b9ce-42d9f54fd537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f044c470-50ce-4a6c-b8ab-665357c3c11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f044c470-50ce-4a6c-b8ab-665357c3c11e.jpg?1",
             "name": "Cinder Cloud",
             "text": "Destroy target creature. If a white creature is put into the graveyard in this way, Cinder Cloud deals to that creature's controller an amount of damage equal to the creature's power.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "667b4083-19de-5885-b920-1782d60dedd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05835e35-f4f8-4513-b5a1-9e31b21168f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05835e35-f4f8-4513-b5a1-9e31b21168f0.jpg?1",
             "name": "Consuming Ferocity",
             "text": "Play only on a non-Wall creature.\nEnchanted creature gets +1/+0.\nDuring your upkeep, put a +1/+0 counter on enchanted creature. At the end of any upkeep, if that creature has three of these counters on it, bury the creature and it deals to its controller an amount of damage equal to its power.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "fc665e8e-227d-5db1-9f8c-c3ebd61b88ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f2314-67fe-4a31-8015-9762edf15187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694f2314-67fe-4a31-8015-9762edf15187.jpg?1",
             "name": "Crimson Hellkite",
             "text": "Flying\no\nX, oc\nT: Crimson Hellkite deals X damage to target creature. Spend only red mana in this way.",
             "colours": [
@@ -5469,7 +5469,7 @@
         },
         {
             "id": "9b12cb4c-09b7-5b01-ac1e-c9e41b03c11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63836c-37af-49c1-84a1-8650ed072805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e63836c-37af-49c1-84a1-8650ed072805.jpg?1",
             "name": "Crimson Roc",
             "text": "Flying\nIf Crimson Roc blocks any creature without flying, Crimson Roc gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "5bdc9766-acc7-505d-8d6d-e3b6d90b6339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7142196-c379-4932-9402-97642ad2ebdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7142196-c379-4932-9402-97642ad2ebdb.jpg?1",
             "name": "Dwarven Miner",
             "text": "o2o\nR, oc\nT: Destroy target nonbasic land.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "dc2093e4-8f54-5242-9173-178ac9e3236a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b09e65-5e69-48f8-be9b-a1e9706f18bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b09e65-5e69-48f8-be9b-a1e9706f18bf.jpg?1",
             "name": "Dwarven Nomad",
             "text": "oc\nT: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -5569,7 +5569,7 @@
         },
         {
             "id": "80332f73-beed-50ed-88ca-0ca669795a58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047d292-8f5c-4a6b-b74e-c8dbf3e0ab24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047d292-8f5c-4a6b-b74e-c8dbf3e0ab24.jpg?1",
             "name": "Ekundu Cyclops",
             "text": "If any creature you control attacks, Ekundu Cyclops also attacks if able.",
             "colours": [
@@ -5602,7 +5602,7 @@
         },
         {
             "id": "58a6a9f2-4e4f-5007-bb4a-a7b50a044bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8c9f5-61dd-4dcc-bd40-8f366374ea18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e8c9f5-61dd-4dcc-bd40-8f366374ea18.jpg?1",
             "name": "Emberwilde Djinn",
             "text": "Flying\nDuring each player's upkeep, he or she may pay o\nRo\nR or 2 life to gain control of Emberwilde Djinn.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "7170320e-d569-58d5-98b1-d0c1e77b8f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83589c25-58a2-4172-8f60-6033a61f34c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83589c25-58a2-4172-8f60-6033a61f34c6.jpg?1",
             "name": "Final Fortune",
             "text": "Take another turn after this one. You lose the game at the end of that turn.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "e81fb050-f107-5e9c-badd-b5f11f7a4b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d39dc35-87c9-4984-8a11-443da414e629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d39dc35-87c9-4984-8a11-443da414e629.jpg?1",
             "name": "Firebreathing",
             "text": "oo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -5699,7 +5699,7 @@
         },
         {
             "id": "2eb86e1c-07ad-51c7-897d-b8db5b3ffe31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e813d-b0b3-4040-b87a-4fa2be681ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e813d-b0b3-4040-b87a-4fa2be681ec5.jpg?1",
             "name": "Flame Elemental",
             "text": "o\nR, oc\nT, Sacrifice Flame Elemental: Flame Elemental deals an amount of damage equal to its power to target creature.",
             "colours": [
@@ -5732,7 +5732,7 @@
         },
         {
             "id": "551c4b17-7c88-5c15-86fd-9e835a848492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd7755f-7ca5-4948-8baf-976823906891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd7755f-7ca5-4948-8baf-976823906891.jpg?1",
             "name": "Flare",
             "text": "Flare deals 1 damage to target creature or player.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "cdbf13b7-4e49-56e6-9174-e07c469d06cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c6b8-9f87-41f1-9e81-b5995e3ed6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b9c6b8-9f87-41f1-9e81-b5995e3ed6b7.jpg?1",
             "name": "Goblin Elite Infantry",
             "text": "If Goblin Elite Infantry blocks or is blocked, it gets -1/-1 until end of turn.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "1bc21728-ddca-5ca5-8606-0549c3bfad05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b87068-aaa6-41de-9b9a-76ca4210a485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b87068-aaa6-41de-9b9a-76ca4210a485.jpg?1",
             "name": "Goblin Scouts",
             "text": "Put three Goblin Scout tokens into play. Treat these tokens as 1/1 red creatures with mountainwalk that count as Goblins (if defending player controls any mountains, these creatures are unblockable).",
             "colours": [
@@ -5828,7 +5828,7 @@
         },
         {
             "id": "8d6c5b48-d23e-549a-bfa7-dc32c06ecb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686b847c-242c-4b91-9fa9-69c9c9f187a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686b847c-242c-4b91-9fa9-69c9c9f187a7.jpg?1",
             "name": "Goblin Soothsayer",
             "text": "o\nR, oc\nT, Sacrifice a Goblin: All red creatures get +1/+1 until end of turn.",
             "colours": [
@@ -5862,7 +5862,7 @@
         },
         {
             "id": "726c818d-25b1-5162-b4c3-df227578b6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6529852-8b3e-4a70-a4a1-029e012231c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6529852-8b3e-4a70-a4a1-029e012231c6.jpg?1",
             "name": "Goblin Tinkerer",
             "text": "o\nR, oc\nT: Destroy target artifact. That artifact deals an amount of damage equal to its casting cost to Goblin Tinkerer.",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "cd91a286-01b6-5945-b61b-24829496ee58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7285f52-5df0-4f90-9cf7-a57295d90fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7285f52-5df0-4f90-9cf7-a57295d90fd4.jpg?1",
             "name": "Hammer of Bogardan",
             "text": "Hammer of Bogardan deals 3 damage to target creature or player.\no2o\nRo\nRoo\nR Return Hammer of Bogardan to your hand. Use this ability only during your upkeep and only if Hammer of Bogardan is in your graveyard.",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "0a5c46c4-bd5c-59c6-af40-9092e15cee7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee84e61e-d99a-489b-a3b1-cb45fc81bce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee84e61e-d99a-489b-a3b1-cb45fc81bce6.jpg?1",
             "name": "Hivis of the Scale",
             "text": "You may choose not to untap Hivis of the Scale during your untap phase.\noc\nT: Gain control of target Dragon. If Hivis becomes untapped or you lose control of Hivis, lose control of that Dragon.",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "aeb3f535-9aac-566c-8021-e6ce013393c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f633f-538c-4581-b3cc-9285ed6bc4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c3f633f-538c-4581-b3cc-9285ed6bc4fe.jpg?1",
             "name": "Illicit Auction",
             "text": "Choose target creature. Each player may bid life for control of that creature. You begin the bidding with a high bid of 0. Proceeding in turn order, each player may top the high bid. The auction ends when the high bid stands. The high bidder loses an amount of life equal to the high bid and gains control of the creature.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "b294fe05-1e5e-5460-bb71-6f5586ffaa54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409b2be8-5bb6-45e0-ab87-ca73b4e3a396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409b2be8-5bb6-45e0-ab87-ca73b4e3a396.jpg?1",
             "name": "Incinerate",
             "text": "Incinerate deals 3 damage to target creature or player. A creature damaged by Incinerate cannot regenerate this turn.",
             "colours": [
@@ -6025,7 +6025,7 @@
         },
         {
             "id": "89889f4e-800b-5e3f-bd2c-efbc9616b258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1624ab-e50e-48a3-acf7-457069914616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1624ab-e50e-48a3-acf7-457069914616.jpg?1",
             "name": "Kaervek's Torch",
             "text": "Interrupts that target Kaervek's Torch each cost an additional o2 to play.\nKaervek's Torch deals X damage to target creature or player.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "e599e4e6-3459-5bc1-ae67-a2b5b17c1b7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271febe5-98ea-403d-87be-7865cf9f426d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271febe5-98ea-403d-87be-7865cf9f426d.jpg?1",
             "name": "Lightning Reflexes",
             "text": "You may choose to play Lightning Reflexes as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +1/+0 and gains first strike.",
             "colours": [
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "26f10de5-6a3a-5041-a552-48e9bf91b849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2dc1a7-4b70-4643-90a8-fdc7877c01ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2dc1a7-4b70-4643-90a8-fdc7877c01ca.jpg?1",
             "name": "Pyric Salamander",
             "text": "oo\nR +1/+0 until end of turn. Bury Pyric Salamander at end of turn.",
             "colours": [
@@ -6122,7 +6122,7 @@
         },
         {
             "id": "182f6ac8-fb50-5eaf-9b59-8347055c58e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a196c21b-e9f5-4ae8-8a1e-668685ef4cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a196c21b-e9f5-4ae8-8a1e-668685ef4cf0.jpg?1",
             "name": "Raging Spirit",
             "text": "o2: Raging Spirit is colorless until end of turn.",
             "colours": [
@@ -6155,7 +6155,7 @@
         },
         {
             "id": "7452429d-9736-5109-a648-777e57ec269d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e41febe-6fad-451e-afe8-20d3ca3c88a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e41febe-6fad-451e-afe8-20d3ca3c88a4.jpg?1",
             "name": "Reckless Embermage",
             "text": "o1oo\nR Reckless Embermage deals 1 damage to target creature or player and 1 damage to itself.",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "b1426643-faf9-5609-814b-c1f41371c1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9285b14a-fc8e-457a-b803-202e05be41e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9285b14a-fc8e-457a-b803-202e05be41e5.jpg?1",
             "name": "Reign of Chaos",
             "text": "Destroy target plains and target white creature, or destroy target island and target blue creature.",
             "colours": [
@@ -6220,7 +6220,7 @@
         },
         {
             "id": "5c39c972-3079-5fce-aec6-0d2f6867c29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf66916-7f6b-412f-acd6-f96ad4539a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf66916-7f6b-412f-acd6-f96ad4539a46.jpg?1",
             "name": "Searing Spear Askari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1oo\nR Searing Spear Askari cannot be blocked by only one creature this turn.",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "39094de7-ad11-5f63-94db-63220e5a963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce37492e-4f07-4171-97d4-84f28fb4e2be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce37492e-4f07-4171-97d4-84f28fb4e2be.jpg?1",
             "name": "Sirocco",
             "text": "Target player reveals his or her hand to all players. For each blue interrupt card that player holds, he or she pays 4 life or discards that card.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "9d8e8169-1d46-5b38-a18a-fe7c6de73ed5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b774d2-1272-4cd2-b5f8-dfe3ca6e41ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b774d2-1272-4cd2-b5f8-dfe3ca6e41ee.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to target creature an amount of damage equal to the number of mountains you control.",
             "colours": [
@@ -6316,7 +6316,7 @@
         },
         {
             "id": "3224787a-ac24-532b-8d8c-cc0229655210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64bc56f-9e0b-478e-9af4-5333ec2da1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64bc56f-9e0b-478e-9af4-5333ec2da1c3.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "7358d516-8ea4-5217-827c-f7cdefeeb4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132e8aac-9698-45fa-8d64-b460fd5deffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132e8aac-9698-45fa-8d64-b460fd5deffc.jpg?1",
             "name": "Subterranean Spirit",
             "text": "Protection from red\noc\nT: Subterranean Spirit deals 1 damage to each creature without flying.",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "60888647-3b5c-5d41-a60a-1073c7dcd15f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51657034-2c30-40a2-a215-a00277f01642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51657034-2c30-40a2-a215-a00277f01642.jpg?1",
             "name": "Talruum Minotaur",
             "text": "Talruum Minotaur is unaffected by summoning sickness.",
             "colours": [
@@ -6415,7 +6415,7 @@
         },
         {
             "id": "a2d530da-4622-593f-a780-177c24128f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cc89c8-a3ea-469e-b499-f48acec4f538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cc89c8-a3ea-469e-b499-f48acec4f538.jpg?1",
             "name": "Telim'Tor",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Telim'Tor attacks, all attacking creatures with flanking get +1/+1 until end of turn.",
             "colours": [
@@ -6451,7 +6451,7 @@
         },
         {
             "id": "590f18b6-685d-5b4c-bd25-b5cacee82416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088a60f0-2224-4e00-a06a-1d376c8d82a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088a60f0-2224-4e00-a06a-1d376c8d82a4.jpg?1",
             "name": "Telim'Tor's Edict",
             "text": "Remove from the game target permanent you own or control.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -6482,7 +6482,7 @@
         },
         {
             "id": "28bf4334-5bab-5aff-917a-68e118fb1670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19528a24-4968-4742-a2d1-06f94e60f290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19528a24-4968-4742-a2d1-06f94e60f290.jpg?1",
             "name": "Torrent of Lava",
             "text": "Torrent of Lava deals X damage to each creature without flying.\nEach creature gains \"oc\nT: Prevent 1 damage to this creature from Torrent of Lava.\"",
             "colours": [
@@ -6513,7 +6513,7 @@
         },
         {
             "id": "8ed6762f-95ef-56bb-95d2-ce86be8bd384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4947cbf9-69dc-44e3-a22e-a6129f331f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4947cbf9-69dc-44e3-a22e-a6129f331f3c.jpg?1",
             "name": "Viashino Warrior",
             "text": "",
             "colours": [
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "a32af02c-1d2f-59d6-a41d-363569b4d349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda123a7-d121-483a-8ff0-a541ccdbc7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda123a7-d121-483a-8ff0-a541ccdbc7ca.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nVolcanic Dragon is unaffected by summoning sickness.",
             "colours": [
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "4864614c-3a53-565b-8aab-88d6ac9a7ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911787db-9023-46f8-9501-3ad26b6ca51d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911787db-9023-46f8-9501-3ad26b6ca51d.jpg?1",
             "name": "Volcanic Geyser",
             "text": "Volcanic Geyser deals X damage to target creature or player.",
             "colours": [
@@ -6611,7 +6611,7 @@
         },
         {
             "id": "7708a2d6-919d-52d5-88a0-f22318beb74c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d99204c-b42d-48bc-9a93-fae5660665c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d99204c-b42d-48bc-9a93-fae5660665c7.jpg?1",
             "name": "Wildfire Emissary",
             "text": "Protection from white\no1oo\nR +1/+0 until end of turn",
             "colours": [
@@ -6644,7 +6644,7 @@
         },
         {
             "id": "fc75fbc0-4ac1-5f5b-a679-10bddb753015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a105b7f4-c93b-4b54-acf8-7212907d9cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a105b7f4-c93b-4b54-acf8-7212907d9cd6.jpg?1",
             "name": "Zirilan of the Claw",
             "text": "o1o\nRo\nR, oc\nT: Search your library for a Dragon card and put it into play as though it were just played. Shuffle your library afterwards. That creature is unaffected by summoning sickness. Remove the creature from the game at end of any turn.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "5e7d26fa-2b75-546a-b4c4-a6b3bbb472a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c495e1f3-0845-4556-83e6-de8b9d518d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c495e1f3-0845-4556-83e6-de8b9d518d1d.jpg?1",
             "name": "Afiya Grove",
             "text": "Afiya Grove comes into play with three +1/+1 counters on it.\nDuring your upkeep, put one of these counters on target creature.\nIf Afiya Grove has none of these counters on it, bury it.",
             "colours": [
@@ -6711,7 +6711,7 @@
         },
         {
             "id": "06274f11-4c80-54df-bd19-0ff5ff8d3886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdb9e7-d79e-4d24-8678-a37ab6e3a413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdb9e7-d79e-4d24-8678-a37ab6e3a413.jpg?1",
             "name": "Armor of Thorns",
             "text": "You may choose to play Armor of Thorns as an instant; if you do, bury it at end of turn.\nPlay only on a nonblack creature.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "0637f38f-fd82-584f-94e4-3d2d13360f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1220fdd1-e4b0-4175-9b8a-178f6a84b8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1220fdd1-e4b0-4175-9b8a-178f6a84b8e6.jpg?1",
             "name": "Barbed Foliage",
             "text": "Whenever a creature attacks you, it loses flanking until end of turn.\nWhenever a creature without flying attacks you, Barbed Foliage deals 1 damage to it.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "d266838d-1bb6-5c84-a6df-71f67fb7ebb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c20edc3-5ad0-42c1-a5ec-3e680fb03297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c20edc3-5ad0-42c1-a5ec-3e680fb03297.jpg?1",
             "name": "Brushwagg",
             "text": "If Brushwagg blocks or is blocked, it gets -2/+2 until end of turn.",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "977de1b3-0aad-5785-b355-05fad4fc8b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c5e4d6-b716-4994-b226-b1eb799bec25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c5e4d6-b716-4994-b226-b1eb799bec25.jpg?1",
             "name": "Canopy Dragon",
             "text": "Trample\no1oo\nG Flying and loses trample until end of turn",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "14180949-64d4-5f7c-bde1-684999418b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e0337-d9ac-4bf2-b2b5-aadc97433030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e0337-d9ac-4bf2-b2b5-aadc97433030.jpg?1",
             "name": "Crash of Rhinos",
             "text": "Trample",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "4140f4e8-686a-587d-8468-6e5a6f31bcf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b53861-97aa-4fff-9526-7d496d1717a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b53861-97aa-4fff-9526-7d496d1717a4.jpg?1",
             "name": "Cycle of Life",
             "text": "Return Cycle of Life to owner's hand: Target creature you summoned this turn is 0/1 until the beginning of your next upkeep. At the beginning of your next upkeep, put a +1/+1 counter on that creature.",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "8975e752-db69-52f6-b027-0148bbea56d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ea46a1-ea65-4802-812c-4f0e0f3088d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ea46a1-ea65-4802-812c-4f0e0f3088d2.jpg?1",
             "name": "Decomposition",
             "text": "Play only on a black creature.\nEnchanted creature gains \"Cumulative upkeep\u20141 life.\"\nIf enchanted creature is put into the graveyard, its controller loses 2 life.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "19f5d02b-5f97-5ae9-bb29-d8c8e51bcff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e18b5-baef-4fe9-807e-097b972c879f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e18b5-baef-4fe9-807e-097b972c879f.jpg?1",
             "name": "Early Harvest",
             "text": "Target player untaps all basic lands he or she controls.",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "f0ab2a9e-f37e-5e3d-a439-63adaa88dcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482c390-69cf-484e-a06c-8d63f770c7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1482c390-69cf-484e-a06c-8d63f770c7de.jpg?1",
             "name": "Fallow Earth",
             "text": "Put target land on top of owner's library.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "ff2051d3-6404-5295-a7f4-fb89530f23a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e859180f-084c-4023-848a-96f22b8f9698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e859180f-084c-4023-848a-96f22b8f9698.jpg?1",
             "name": "Femeref Archers",
             "text": "oc\nT: Femeref Archers deals 4 damage to target attacking creature with flying.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "14a8ef67-fa96-5cc0-af89-96fded5be883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d822598-2f0f-45fa-9643-0368e2c0e18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d822598-2f0f-45fa-9643-0368e2c0e18b.jpg?1",
             "name": "Fog",
             "text": "Creatures deal no combat damage this turn.",
             "colours": [
@@ -7065,7 +7065,7 @@
         },
         {
             "id": "7360c7a9-92c0-5664-bf78-7fa1cc856c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e1195d-443f-4826-a748-bc6e7e24153a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e1195d-443f-4826-a748-bc6e7e24153a.jpg?1",
             "name": "Foratog",
             "text": "o\nG, Sacrifice a forest: +2/+2 until end of turn",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "c5974b3c-61a8-5c15-a045-8fff4f53701c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b56c895-37d3-4475-a542-dc6d21c46f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b56c895-37d3-4475-a542-dc6d21c46f06.jpg?1",
             "name": "Giant Mantis",
             "text": "Giant Mantis can block creatures with flying.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "8cff347b-e73f-59fb-a79a-551171c15eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a252a1f5-bba5-4525-8141-57caea9624e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a252a1f5-bba5-4525-8141-57caea9624e9.jpg?1",
             "name": "Gibbering Hyenas",
             "text": "Gibbering Hyenas cannot block black creatures.",
             "colours": [
@@ -7164,7 +7164,7 @@
         },
         {
             "id": "fb737dbc-f0bf-59b5-840c-7b658c473995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f495b27-3eed-4962-b69a-b86f9fc6a9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f495b27-3eed-4962-b69a-b86f9fc6a9a7.jpg?1",
             "name": "Granger Guildmage",
             "text": "o\nW, oc\nT: Target creature gains first strike until end of turn.\no\nR, oc\nT: Granger Guildmage deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -7200,7 +7200,7 @@
         },
         {
             "id": "936d59b9-2ebb-5df1-9c21-7d885806b782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e4551f-9f6c-4421-ad66-a270df6d3463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e4551f-9f6c-4421-ad66-a270df6d3463.jpg?1",
             "name": "Hall of Gemstone",
             "text": "During each player's upkeep, that player chooses a color.\nUntil end of turn, each mana-producing land produces mana of the chosen color instead of its normal color.",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "763b5b9d-6551-5845-a9dd-25d67ab02167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31588ea3-31d2-4118-9b9f-4ce820c16a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31588ea3-31d2-4118-9b9f-4ce820c16a15.jpg?1",
             "name": "Jolrael's Centaur",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nJolrael's Centaur cannot be the target of spells or effects.",
             "colours": [
@@ -7267,7 +7267,7 @@
         },
         {
             "id": "e388ba37-a6a4-58ad-ac2b-a72263ce7707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c343b8-bbfd-4bc5-b80a-4bc4565cdd40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c343b8-bbfd-4bc5-b80a-4bc4565cdd40.jpg?1",
             "name": "Jungle Patrol",
             "text": "o1o\nG, oc\nT: Put a Wood token into play. Treat this token as a 0/1 green creature that counts as a Wall.\nSacrifice a Wood token: Add o\nR to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "2819327b-f43b-5c3c-b997-c1fc1bc4347f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f81b9-1fa1-4062-a9b3-048179274c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17f81b9-1fa1-4062-a9b3-048179274c05.jpg?1",
             "name": "Jungle Wurm",
             "text": "For each creature assigned to block it beyond the first, Jungle Wurm gets -1/-1 until end of turn.",
             "colours": [
@@ -7335,7 +7335,7 @@
         },
         {
             "id": "1a31fb94-f149-5d84-9f44-5c501bccb9d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16396594-4f59-4600-8e39-d99544062265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16396594-4f59-4600-8e39-d99544062265.jpg?1",
             "name": "Karoo Meerkat",
             "text": "Protection from blue",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "65d039ab-9cc8-5cce-9a1f-0c590628975b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd269842-4c31-4398-9451-be0d941397ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd269842-4c31-4398-9451-be0d941397ac.jpg?1",
             "name": "Locust Swarm",
             "text": "Flying\noo\nG Regenerate\noo\nG Untap Locust Swarm. Use this ability only once each turn.",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "edb8c20f-d274-558c-8d58-953fd8208d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7165f1d8-7b31-4a81-aab4-c6cd4ff2e67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7165f1d8-7b31-4a81-aab4-c6cd4ff2e67d.jpg?1",
             "name": "Lure of Prey",
             "text": "Play only if an opponent successfully cast a summon spell this turn.\nPut a green summon card from your hand into play as though it were just played.",
             "colours": [
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "d9cea628-64aa-556b-ae31-3c2dfa90c01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfec2de-cff3-4015-9a43-a58be525a2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfec2de-cff3-4015-9a43-a58be525a2da.jpg?1",
             "name": "Maro",
             "text": "Maro has power and toughness each equal to the number of cards in your hand.",
             "colours": [
@@ -7465,7 +7465,7 @@
         },
         {
             "id": "5b4dc4e6-0fa6-5adc-9af0-2d57e64e765c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41066eb-be5e-4a6d-9156-64f5e56c7ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41066eb-be5e-4a6d-9156-64f5e56c7ab3.jpg?1",
             "name": "Mindbender Spores",
             "text": "Flying\nWhenever Mindbender Spores blocks any creature, put four fungus counters on that creature. During its controller's untap phase, remove a fungus counter from the creature. As long as the creature has any fungus counters on it, it does not untap during its controller's untap phase.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "0f5ac0fc-5828-5158-b948-3579925da8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05cf5b-2a0d-432a-b8e7-10335c2a18e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb05cf5b-2a0d-432a-b8e7-10335c2a18e8.jpg?1",
             "name": "Mtenda Lion",
             "text": "If Mtenda Lion attacks, defending player may pay o\nU to have it deal no combat damage this turn.",
             "colours": [
@@ -7533,7 +7533,7 @@
         },
         {
             "id": "f79c163d-0ce4-5095-9336-f1b4db658e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f7c47c-416e-4f73-89ec-024a29dfb5e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f7c47c-416e-4f73-89ec-024a29dfb5e9.jpg?1",
             "name": "Natural Balance",
             "text": "Each player controlling six or more lands sacrifices enough lands to reduce his or her land total to five.\nEach player controlling four or fewer lands may search his or her library for enough basic land to bring his or her land total to five and put those lands into play. Those players shuffle their libraries afterwards.",
             "colours": [
@@ -7564,7 +7564,7 @@
         },
         {
             "id": "f9174da1-8341-533a-9193-7e694f9671d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5aa60d-91aa-4eee-9d13-55a357c8eced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b5aa60d-91aa-4eee-9d13-55a357c8eced.jpg?1",
             "name": "Nettletooth Djinn",
             "text": "During your upkeep, Nettletooth Djinn deals 1 damage to you.",
             "colours": [
@@ -7597,7 +7597,7 @@
         },
         {
             "id": "9a41a0f5-8a64-5e3c-8695-632c3e86bb9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ce9668-78ef-44a5-ba9c-49fa740b8cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ce9668-78ef-44a5-ba9c-49fa740b8cb5.jpg?1",
             "name": "Preferred Selection",
             "text": "At the beginning of your draw phase, look at the top two cards of your library and choose one. Put that card on the bottom of your library, or sacrifice Preferred Selection and pay o2o\nGo\nG to draw the card.",
             "colours": [
@@ -7628,7 +7628,7 @@
         },
         {
             "id": "90460444-2189-5c1f-8a1a-36f2c2d7a49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9a64fb-1e8d-4ed8-b4c5-3d44db9c1d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9a64fb-1e8d-4ed8-b4c5-3d44db9c1d3b.jpg?1",
             "name": "Quirion Elves",
             "text": "When you play Quirion Elves, choose a color.\noc\nT: Add one mana of the chosen color to your mana pool. Play this ability as a mana source.\noc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "48204728-b341-5d20-8268-b3e36ae8e132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd8043-4099-42bb-9d54-4efc8b38fe18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd8043-4099-42bb-9d54-4efc8b38fe18.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put it into play, tapped. Shuffle your library afterwards.",
             "colours": [
@@ -7693,7 +7693,7 @@
         },
         {
             "id": "19326ed0-4337-58f2-b431-ee5f900d825f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3d7a4f-8ccc-44cf-bacc-5055c7e1edbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3d7a4f-8ccc-44cf-bacc-5055c7e1edbc.jpg?1",
             "name": "Regeneration",
             "text": "oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -7726,7 +7726,7 @@
         },
         {
             "id": "b5ecfb49-2aaa-5f04-83ec-e435136efc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26724a51-87dd-4159-b012-71598e4cf5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26724a51-87dd-4159-b012-71598e4cf5eb.jpg?1",
             "name": "Roots of Life",
             "text": "When you play Roots of Life, choose islands or swamps.\nWhenever a land of the chosen type that target opponent controls becomes tapped, gain 1 life.",
             "colours": [
@@ -7757,7 +7757,7 @@
         },
         {
             "id": "462bf035-0bd4-5017-9b03-7845f87db66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ead72b-f3f5-4065-a33c-0992cf1fdb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ead72b-f3f5-4065-a33c-0992cf1fdb34.jpg?1",
             "name": "Sabertooth Cobra",
             "text": "If Sabertooth Cobra damages a player, he or she gets a poison counter. During that player's next upkeep, he or she gets another poison counter unless he or she pays o2 before then to prevent this effect. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "259ba38c-1801-52b4-ba2d-1a09ed0a1887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdce7d3c-cc17-4010-85ec-402a6f256360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdce7d3c-cc17-4010-85ec-402a6f256360.jpg?1",
             "name": "Sandstorm",
             "text": "Sandstorm deals 1 damage to each attacking creature.",
             "colours": [
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "1dd6f12a-8a69-5853-a7f1-f32600fba0a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42746e1-f422-4453-a860-3993d5796479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e42746e1-f422-4453-a860-3993d5796479.jpg?1",
             "name": "Seedling Charm",
             "text": "Choose one Return target creature enchantment to owner's hand; or regenerate target green creature; or target creature gains trample until end of turn.",
             "colours": [
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "e18e5ae4-d709-5344-8aaa-5801ce82d5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c868f5-0f90-4f7e-bafb-c45d2372fe06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c868f5-0f90-4f7e-bafb-c45d2372fe06.jpg?1",
             "name": "Seeds of Innocence",
             "text": "Bury all artifacts. Each artifact's controller gains an amount of life equal to that artifact's casting cost.",
             "colours": [
@@ -7883,7 +7883,7 @@
         },
         {
             "id": "39c97901-2d81-5f5c-8380-a01a0a19e072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff19d9d-8069-4f8d-a81b-e2fcd94c13b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/aff19d9d-8069-4f8d-a81b-e2fcd94c13b3.jpg?1",
             "name": "Serene Heart",
             "text": "Destroy all local enchantments.",
             "colours": [
@@ -7914,7 +7914,7 @@
         },
         {
             "id": "66787a53-ebe2-5783-94f8-2bd3c8994920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12cc4e9-010a-4ff7-a026-dcb6113a36fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12cc4e9-010a-4ff7-a026-dcb6113a36fb.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger cannot be blocked by more than one creature.",
             "colours": [
@@ -7947,7 +7947,7 @@
         },
         {
             "id": "25106200-0622-5772-a85f-93a0efc5a5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d90914-ddfc-49c2-8e58-fdc3693040f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d90914-ddfc-49c2-8e58-fdc3693040f2.jpg?1",
             "name": "Superior Numbers",
             "text": "Superior Numbers deals to target creature 1 damage for each creature you control in excess of the number of creatures target opponent controls.",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "614e0813-ae57-5153-8e1a-6776048b4c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801f34a6-9f22-43c2-b1e5-194395cc7da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801f34a6-9f22-43c2-b1e5-194395cc7da1.jpg?1",
             "name": "Tranquil Domain",
             "text": "Destroy all global enchantments.",
             "colours": [
@@ -8009,7 +8009,7 @@
         },
         {
             "id": "7905102a-c7cd-54ad-97a8-aecef23f137e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f473c-e11e-4047-91f9-81b80f0a3562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f473c-e11e-4047-91f9-81b80f0a3562.jpg?1",
             "name": "Tropical Storm",
             "text": "Tropical Storm deals X damage to each creature with flying and 1 damage to each blue creature.",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "4f293dcf-b501-59f9-950a-56667096a443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cdee9f-7ea9-4397-a230-ce610be5d3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cdee9f-7ea9-4397-a230-ce610be5d3af.jpg?1",
             "name": "Uktabi Faerie",
             "text": "Flying\no3o\nG, Sacrifice Uktabi Faerie: Destroy target artifact.",
             "colours": [
@@ -8073,7 +8073,7 @@
         },
         {
             "id": "23c4b87f-1f53-5dd3-8275-a7ef94aec5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f287ff-1b1b-454a-9360-fac34c8e1f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f287ff-1b1b-454a-9360-fac34c8e1f24.jpg?1",
             "name": "Uktabi Wildcats",
             "text": "Uktabi Wildcats has power and toughness each equal to the number of forests you control.\no\nG, Sacrifice a forest: Regenerate",
             "colours": [
@@ -8106,7 +8106,7 @@
         },
         {
             "id": "c6fd3479-316f-5874-9ac6-2f90ed13f293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a73d-8810-42f7-b20a-a6dd53586220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a73d-8810-42f7-b20a-a6dd53586220.jpg?1",
             "name": "Unseen Walker",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)\no1o\nGoo\nG Target creature gains forestwalk until end of turn.",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "2c2efed9-b246-5409-b97d-3bb60985c65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bdd944-e86c-4e5e-b75c-9bbf4fb27ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bdd944-e86c-4e5e-b75c-9bbf4fb27ccd.jpg?1",
             "name": "Unyaro Bee Sting",
             "text": "Unyaro Bee Sting deals 2 damage to target creature or player.",
             "colours": [
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "6bd19445-c2f2-5e7d-b930-7eddbb7a1661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253a1d97-ec45-41c9-ba81-bbb6ab584b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253a1d97-ec45-41c9-ba81-bbb6ab584b2b.jpg?1",
             "name": "Village Elder",
             "text": "o\nG, oc\nT, Sacrifice a forest: Regenerate target creature.",
             "colours": [
@@ -8204,7 +8204,7 @@
         },
         {
             "id": "de47aade-4eca-5a31-bb9e-bf22d14ff21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f91ec4e-6818-46f4-94da-f3f8c4489fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f91ec4e-6818-46f4-94da-f3f8c4489fb2.jpg?1",
             "name": "Waiting in the Weeds",
             "text": "For each untapped forest he or she controls, each player puts a Cat token into play under his or her control. Treat these tokens as 1/1 green creatures.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "d31b98de-c104-5875-a6a1-a203b48432e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb151d2-c313-44d2-972e-33487f070c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb151d2-c313-44d2-972e-33487f070c23.jpg?1",
             "name": "Wall of Roots",
             "text": "Put a -0/-1 counter on Wall of Roots: Add o\nG to your mana pool. Play this ability as a mana source. Use this ability only once each turn.",
             "colours": [
@@ -8269,7 +8269,7 @@
         },
         {
             "id": "114d7215-080d-5cf9-9699-146462374727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7809131c-747c-4c33-a3ca-13e573a92b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7809131c-747c-4c33-a3ca-13e573a92b66.jpg?1",
             "name": "Wild Elephant",
             "text": "Trample",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "5aeb81bd-bf82-56ee-9950-17cbbb1cf3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00115bc-b551-4bf5-a121-bebb37201575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00115bc-b551-4bf5-a121-bebb37201575.jpg?1",
             "name": "Worldly Tutor",
             "text": "Search your library for a creature card and reveal that card to all players. Shuffle your library and put the revealed card back on top of it.",
             "colours": [
@@ -8333,7 +8333,7 @@
         },
         {
             "id": "c49cdef6-e33c-55a0-869e-76d0f6be5fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d64600-84fc-42a5-a6a6-b26f98fac0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d64600-84fc-42a5-a6a6-b26f98fac0a4.jpg?1",
             "name": "Asmira, Holy Avenger",
             "text": "Flying\nAt the end of each turn, put a +1/+1 counter on Asmira, Holy Avenger for each creature put into your graveyard from play that turn.",
             "colours": [
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "972dc843-b9d1-5fcf-a7dc-5c942ee1c341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03586-8d04-4114-a7ce-b8c8ab5ff857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b03586-8d04-4114-a7ce-b8c8ab5ff857.jpg?1",
             "name": "Benthic Djinn",
             "text": "Islandwalk (If defending player controls any islands, this creature is unblockable.)\nDuring your upkeep, lose 2 life.",
             "colours": [
@@ -8406,7 +8406,7 @@
         },
         {
             "id": "b5e9f356-02aa-5a0e-9c3a-7b7a1f2e01ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bef70b-61c7-4df5-b4df-09cd6ab2015c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bef70b-61c7-4df5-b4df-09cd6ab2015c.jpg?1",
             "name": "Cadaverous Bloom",
             "text": "Choose a card in your hand and remove it from the game: Add o\nBo\nB or o\nGo\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "ca0a846b-99b4-5381-acc6-2f065625b985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2c05-0d2f-4d02-aef3-e1078d78e5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9d2c05-0d2f-4d02-aef3-e1078d78e5ff.jpg?1",
             "name": "Circle of Despair",
             "text": "o1, Sacrifice a creature: Prevent all damage to any creature or player from any one source.",
             "colours": [
@@ -8472,7 +8472,7 @@
         },
         {
             "id": "21aac4c5-5a75-5b61-8fcf-39183cbe3912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52981ea-1173-4f4b-a929-705a11c6e381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52981ea-1173-4f4b-a929-705a11c6e381.jpg?1",
             "name": "Delirium",
             "text": "Play only on target opponent's turn.\nTap target creature that player controls. That creature deals to the player an amount of damage equal to its power. The creature neither deals nor receives combat damage this turn.",
             "colours": [
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "cad7972d-2ddc-55de-87e1-eae70e5c384d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be67b950-dfe3-4159-aa53-63df25d2a926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be67b950-dfe3-4159-aa53-63df25d2a926.jpg?1",
             "name": "Discordant Spirit",
             "text": "At end of target opponent's turn, put a +1/+1 counter on Discordant Spirit for each 1 damage dealt to you this turn.\nAt end of your turn, remove all these counters from Discordant Spirit.",
             "colours": [
@@ -8540,7 +8540,7 @@
         },
         {
             "id": "6a683d79-bc22-5121-aa8d-271db94f3ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598a9b4-15bb-4645-92ed-8eedef75dc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9598a9b4-15bb-4645-92ed-8eedef75dc24.jpg?1",
             "name": "Emberwilde Caliph",
             "text": "Flying, trample\nEmberwilde Caliph attacks each turn if able.\nFor each 1 damage Emberwilde Caliph successfully deals, lose 1 life.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "7590cf45-e102-5714-ae55-94ef5a5bce7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711f4cff-0256-44b2-a2fe-1cae6e9edb2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711f4cff-0256-44b2-a2fe-1cae6e9edb2b.jpg?1",
             "name": "Energy Bolt",
             "text": "Energy Bolt deals X damage to target player, or target player gains X life.",
             "colours": [
@@ -8608,7 +8608,7 @@
         },
         {
             "id": "aa51352c-d09d-5ee5-8fd2-e147a97847c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4468b-f7de-44fe-898a-4125d26d242f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d4468b-f7de-44fe-898a-4125d26d242f.jpg?1",
             "name": "Frenetic Efreet",
             "text": "Flying\no0: Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, Frenetic Efreet phases out. Otherwise, bury Frenetic Efreet.",
             "colours": [
@@ -8643,7 +8643,7 @@
         },
         {
             "id": "2d9dd4fa-c822-5223-9fcb-25a6f3ee38eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69dc4ac-7354-465e-b859-d8556f3b1498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69dc4ac-7354-465e-b859-d8556f3b1498.jpg?1",
             "name": "Grim Feast",
             "text": "At the beginning of your upkeep, Grim Feast deals 1 damage to you.\nWhenever a creature is put into target opponent's graveyard from play, gain an amount of life equal to that creature's toughness.",
             "colours": [
@@ -8676,7 +8676,7 @@
         },
         {
             "id": "6732d483-4117-53e4-b9de-e22a275816ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a2359f-6586-42a6-a855-c0049b448cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a2359f-6586-42a6-a855-c0049b448cb9.jpg?1",
             "name": "Harbor Guardian",
             "text": "Harbor Guardian can block creatures with flying.\nIf Harbor Guardian attacks, defending player may draw a card.",
             "colours": [
@@ -8711,7 +8711,7 @@
         },
         {
             "id": "cbcaab40-b4a9-5e7a-abda-ce80496976e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce9c58f-6470-4e0f-8f6b-457fbaac7451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce9c58f-6470-4e0f-8f6b-457fbaac7451.jpg?1",
             "name": "Haunting Apparition",
             "text": "Flying\nHaunting Apparition has power equal to 1 plus the number of green creature cards in target opponent's graveyard.",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "b490120a-ecdc-55b2-ae5d-47e0eea1f61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2ae5c-58b9-4690-8039-d50cca9ef6cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d2ae5c-58b9-4690-8039-d50cca9ef6cf.jpg?1",
             "name": "Hazerider Drake",
             "text": "Flying, protection from red",
             "colours": [
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "0a4a07e3-2512-5f17-b947-a6bfb0ae801c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb9591-399a-4196-a52d-f2954d287a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fb9591-399a-4196-a52d-f2954d287a10.jpg?1",
             "name": "Jungle Troll",
             "text": "oo\nR Regenerate\noo\nG Regenerate",
             "colours": [
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "95c1a248-78e5-5695-bcb8-2c14e6faf426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a42ef95-92ec-40fe-ab30-a476f012a525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a42ef95-92ec-40fe-ab30-a476f012a525.jpg?1",
             "name": "Kaervek's Purge",
             "text": "Destroy target creature with casting cost equal to X. If that creature is put into the graveyard in this way, Kaervek's Purge deals to the creature's controller an amount of damage equal to the creature's power.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "0956cb8d-75ae-5f31-b962-a5dfb45d391e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05d1cac-7012-4d22-82d3-0f82b168fe68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05d1cac-7012-4d22-82d3-0f82b168fe68.jpg?1",
             "name": "Leering Gargoyle",
             "text": "Flying\noc\nT: Leering Gargoyle gets -2/+2 and loses flying until end of turn.",
             "colours": [
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "a32d2450-7969-551d-a69d-0a547344bc3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760b6703-ac92-45f6-8c32-60f760eba866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760b6703-ac92-45f6-8c32-60f760eba866.jpg?1",
             "name": "Malignant Growth",
             "text": "Cumulative upkeep o1\nDuring your upkeep, put a growth counter on Malignant Growth.\nDuring target opponent's draw phase, he or she draws an additional card for each growth counter on Malignant Growth. For each card that opponent draws in this way, Malignant Growth deals 1 damage to him or her.",
             "colours": [
@@ -8917,7 +8917,7 @@
         },
         {
             "id": "f008bf58-0303-5d48-a273-8fb6ff4c7ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbc1b-4c2a-44c1-8e62-c0f94fd2ba8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312bbc1b-4c2a-44c1-8e62-c0f94fd2ba8e.jpg?1",
             "name": "Phyrexian Purge",
             "text": "Pay 3 life per target: Destroy any number of target creatures.",
             "colours": [
@@ -8950,7 +8950,7 @@
         },
         {
             "id": "e65518e8-f7e6-5de9-b5f1-ae638b386eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb774a9b-d29f-4f41-9fb8-a0189205e16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb774a9b-d29f-4f41-9fb8-a0189205e16f.jpg?1",
             "name": "Prismatic Boon",
             "text": "X target creatures gain protection from a single color of your choice until end of turn.",
             "colours": [
@@ -8983,7 +8983,7 @@
         },
         {
             "id": "9b52e8c2-0082-5bcd-ab81-aec804f3e70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5e58b-46f3-437c-89ac-24235a65bd1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed5e58b-46f3-437c-89ac-24235a65bd1f.jpg?1",
             "name": "Purgatory",
             "text": "Whenever a summon card is put into your graveyard from play, put that card face up under Purgatory.\nDuring your upkeep, you may pay o4 and 2 life to put any card under Purgatory into play as though it were just played.\nIf Purgatory leaves play, remove all cards under if from the game.",
             "colours": [
@@ -9016,7 +9016,7 @@
         },
         {
             "id": "88f310d7-0428-5ef2-a3b3-719d50279b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1853c-d5b9-4361-8a2f-36946a62847b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1853c-d5b9-4361-8a2f-36946a62847b.jpg?1",
             "name": "Radiant Essence",
             "text": "As long as target opponent controls any black permanents, Radiant Essence gets +1/+2.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "21c5fd06-731a-55b8-aae4-ef183328ac83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2bf39b-9665-426b-b618-eb731d24a1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2bf39b-9665-426b-b618-eb731d24a1ee.jpg?1",
             "name": "Reflect Damage",
             "text": "Redirect all damage dealt by any one source to that source's controller.",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "8a13df15-0c31-5b43-a7fc-30f9b8790210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9edf28-79c0-42a5-af0f-6df9c3a1f546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9edf28-79c0-42a5-af0f-6df9c3a1f546.jpg?1",
             "name": "Reparations",
             "text": "Whenever target opponent successfully casts a spell that targets you or a creature you control, you may draw a card.",
             "colours": [
@@ -9117,7 +9117,7 @@
         },
         {
             "id": "d1219e4c-9dd7-5c43-814d-ae76cfc90e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79949237-dcce-4ac1-bdc6-7c6d8b5f5fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79949237-dcce-4ac1-bdc6-7c6d8b5f5fde.jpg?1",
             "name": "Rock Basilisk",
             "text": "Whenever Rock Basilisk blocks or is blocked by a non-Wall creature, destroy that creature at end of combat.",
             "colours": [
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "75d9b42d-c01e-548f-9b14-1aac27274544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb73313b-d39a-46ab-abfc-76f94a75dfca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb73313b-d39a-46ab-abfc-76f94a75dfca.jpg?1",
             "name": "Savage Twister",
             "text": "Savage Twister deals X damage to each creature.",
             "colours": [
@@ -9185,7 +9185,7 @@
         },
         {
             "id": "9a13db33-4528-506c-9e4a-ecfaa2edded1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24e74e9-ce88-48af-a113-b4fe76f963d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24e74e9-ce88-48af-a113-b4fe76f963d4.jpg?1",
             "name": "Sawback Manticore",
             "text": "o4: Flying until end of turn\no1: Sawback Manticore deals 2 damage to target attacking or blocking creature. Use this ability only once each turn and only if Sawback Manticore is attacking or blocking.",
             "colours": [
@@ -9220,7 +9220,7 @@
         },
         {
             "id": "2e38c646-8ae6-51a1-b71c-81c278bc4bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cf9da8-f078-4f6e-8077-bb24a7ed487f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cf9da8-f078-4f6e-8077-bb24a7ed487f.jpg?1",
             "name": "Sealed Fate",
             "text": "Look at the top X cards of target opponent's library. Remove one of those cards from the game and put the rest back on top of that player's library in any order.",
             "colours": [
@@ -9253,7 +9253,7 @@
         },
         {
             "id": "ea0e4a40-8745-5235-bfc8-62278ccfe540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9743dc-031b-4932-80a6-1c8ec1dea069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e9743dc-031b-4932-80a6-1c8ec1dea069.jpg?1",
             "name": "Shauku's Minion",
             "text": "o\nBo\nR, oc\nT: Shauku's Minion deals 2 damage to target white creature.",
             "colours": [
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "3f409fec-8622-5c6d-9c7d-e0d0ab993d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176d625f-1410-4ad6-a279-9a184fac6507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176d625f-1410-4ad6-a279-9a184fac6507.jpg?1",
             "name": "Spatial Binding",
             "text": "Pay 1 life: Target permanent cannot phase out until the beginning of your next upkeep.",
             "colours": [
@@ -9322,7 +9322,7 @@
         },
         {
             "id": "4771ffc4-bd8b-5c37-8953-71269c0fdfa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389d6c7-2a8a-48d6-a09d-aa195d830576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389d6c7-2a8a-48d6-a09d-aa195d830576.jpg?1",
             "name": "Unfulfilled Desires",
             "text": "o1, Pay 1 life: Draw a card, then choose and discard a card.",
             "colours": [
@@ -9355,7 +9355,7 @@
         },
         {
             "id": "fc2db3d8-f280-586f-b850-46ed8d6a90e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe8a5b8-1a87-46f5-920f-fbbb05bfd563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe8a5b8-1a87-46f5-920f-fbbb05bfd563.jpg?1",
             "name": "Vitalizing Cascade",
             "text": "Gain X+3 life.",
             "colours": [
@@ -9388,7 +9388,7 @@
         },
         {
             "id": "8e58ce6d-6bdd-5731-9e2c-63dfb54b4f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c41d0f-f1db-4797-b245-7de12ffa3a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c41d0f-f1db-4797-b245-7de12ffa3a0d.jpg?1",
             "name": "Warping Wurm",
             "text": "Phasing\nDuring your upkeep, pay o2o\nGo\nU or Warping Wurm phases out.\nWhen Warping Wurm phases in, put a +1/+1 counter on it.",
             "colours": [
@@ -9423,7 +9423,7 @@
         },
         {
             "id": "aa66a392-2c0e-56a3-ab0f-0da26fba1549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ba095-dd78-4999-87a9-63f7165846e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69ba095-dd78-4999-87a9-63f7165846e4.jpg?1",
             "name": "Wellspring",
             "text": "When Wellspring comes into play, gain control of enchanted land.\nAt the end of each of your turns, lose control of enchanted land.\nAt the beginning of each of your turns, gain control of enchanted land.",
             "colours": [
@@ -9458,7 +9458,7 @@
         },
         {
             "id": "aba9ba30-bb9b-5c22-9ade-bf7e4a955428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65285030-0714-43bf-bb91-a79dcba1ccc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65285030-0714-43bf-bb91-a79dcba1ccc5.jpg?1",
             "name": "Windreaper Falcon",
             "text": "Flying, protection from blue",
             "colours": [
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "c3d709be-d8b1-5917-899c-d9f63362778f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a663ee9d-78f1-4c89-af9e-c788e165fa91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a663ee9d-78f1-4c89-af9e-c788e165fa91.jpg?1",
             "name": "Zebra Unicorn",
             "text": "For each 1 damage Zebra Unicorn deals, gain 1 life.",
             "colours": [
@@ -9528,7 +9528,7 @@
         },
         {
             "id": "ceba66ba-68ab-5d20-9543-baeafad93c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfdea79-2a7c-489d-8466-e6090c2a0919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfdea79-2a7c-489d-8466-e6090c2a0919.jpg?1",
             "name": "Acidic Dagger",
             "text": "o4, oc\nT: Destroy any non-Wall creature receiving combat damage from target creature this turn. If targeted creature leaves play, bury Acidic Dagger. Use this ability only before defense is chosen.",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "fa926f95-101e-5d58-86da-dd865085f59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046475e5-36d1-4b5f-af31-6df715c7a368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046475e5-36d1-4b5f-af31-6df715c7a368.jpg?1",
             "name": "Amber Prison",
             "text": "You may choose not to untap Amber Prison during your untap phase.\no4, oc\nT: Tap target artifact, creature, or land. As long as Amber Prison remains tapped, that permanent does not untap during its controller's untap phase.",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "eee5fb17-a896-5419-83f5-2afe0bac2969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbd94c8-611c-4b20-99ca-dd2d7661d644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbd94c8-611c-4b20-99ca-dd2d7661d644.jpg?1",
             "name": "Amulet of Unmaking",
             "text": "o5, oc\nT, Remove Amulet of Unmaking from the game: Remove target artifact, creature, or land from the game. Play this ability as a sorcery.",
             "colours": [],
@@ -9609,7 +9609,7 @@
         },
         {
             "id": "b509c617-e067-5bd9-95ff-c6dbf3bb849c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff538f9-10b4-4327-aea6-a86759daf488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff538f9-10b4-4327-aea6-a86759daf488.jpg?1",
             "name": "Basalt Golem",
             "text": "Basalt Golem cannot be blocked by artifact creatures.\nWhenever Basalt Golem is blocked by any creature, bury that creature at end of combat and put a Stone token into play under the control of the creature's controller. Treat this token as a 0/2 artifact creature that counts as a Wall.",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "4578bfe7-059e-53ed-ab8d-7e1aaebb8227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f46aea3-ea00-46c4-b207-522ceeeae68b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f46aea3-ea00-46c4-b207-522ceeeae68b.jpg?1",
             "name": "Bone Mask",
             "text": "o2, oc\nT: Prevent all damage to you from any one source. For each 1 damage prevented in this way, remove the top card of your library from the game.",
             "colours": [],
@@ -9666,7 +9666,7 @@
         },
         {
             "id": "d13e6b70-0e42-59f6-9513-fd64b7b9a8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a81b3f1-babc-4bd7-8b87-754c8389ae85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a81b3f1-babc-4bd7-8b87-754c8389ae85.jpg?1",
             "name": "Charcoal Diamond",
             "text": "Charcoal Diamond comes into play tapped.\noc\nT: Add o\nB to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9695,7 +9695,7 @@
         },
         {
             "id": "8294d3b4-d1f4-5889-aa86-6ac1d47d28f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3bc470-cfcc-4835-b46f-c08d698ee1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3bc470-cfcc-4835-b46f-c08d698ee1ab.jpg?1",
             "name": "Chariot of the Sun",
             "text": "o2, oc\nT: Target creature you control gains flying and has its toughness reduced to 1 until end of turn.",
             "colours": [],
@@ -9722,7 +9722,7 @@
         },
         {
             "id": "9b280a01-013a-5d49-ae98-05f5359abcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d3280-f3e1-42ea-93e1-dbab7336fb73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1d3280-f3e1-42ea-93e1-dbab7336fb73.jpg?1",
             "name": "Crystal Golem",
             "text": "At end of your turn, Crystal Golem phases out.",
             "colours": [],
@@ -9752,7 +9752,7 @@
         },
         {
             "id": "f625e4cd-6da9-5c29-8698-d0c8f75bbcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc99ee76-45b6-4f1d-b0b0-7da8775ca90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc99ee76-45b6-4f1d-b0b0-7da8775ca90c.jpg?1",
             "name": "Cursed Totem",
             "text": "Players cannot play any creature abilities requiring an activation cost.",
             "colours": [],
@@ -9779,7 +9779,7 @@
         },
         {
             "id": "7b3a0a44-c808-55e4-9798-e17dfc5eed50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60450239-6055-4561-9f8c-565b4e4d9cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60450239-6055-4561-9f8c-565b4e4d9cb1.jpg?1",
             "name": "Elixir of Vitality",
             "text": "Elixir of Vitality comes into play tapped.\noc\nT, Sacrifice Elixir of Vitality: Gain 4 life.\no8, oc\nT, Sacrifice Elixir of Vitality: Gain 8 life.",
             "colours": [],
@@ -9806,7 +9806,7 @@
         },
         {
             "id": "8feeab09-671d-5795-aa97-14594b93976c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2747ab-00c8-4f59-b9a6-54ff4e99f6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a2747ab-00c8-4f59-b9a6-54ff4e99f6c8.jpg?1",
             "name": "Ersatz Gnomes",
             "text": "oc\nT: Target spell is colorless. Play this ability as an interrupt.\noc\nT: Target permanent is colorless until end of turn.",
             "colours": [],
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "cea77127-6950-55ad-a97c-461764a29efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcca5bbe-df01-45ea-a6ac-4e3d1cf237c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcca5bbe-df01-45ea-a6ac-4e3d1cf237c8.jpg?1",
             "name": "Fire Diamond",
             "text": "Fire Diamond comes into play tapped.\noc\nT: Add o\nR to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9865,7 +9865,7 @@
         },
         {
             "id": "577b32b0-9bd6-5e14-8ee2-4be20893ebf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558ddf-2bc6-4870-bd24-2467d870ffe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3558ddf-2bc6-4870-bd24-2467d870ffe5.jpg?1",
             "name": "Grinning Totem",
             "text": "o2, oc\nT, Sacrifice Grinning Totem: Search target opponent's library for any card and put it face up in front of you. That player shuffles his or her library afterwards. You may play the card as though it were in your hand. If you do not play the card by the beginning of your next upkeep, put it into its owner's graveyard.",
             "colours": [],
@@ -9892,7 +9892,7 @@
         },
         {
             "id": "515d70a0-0e76-52a3-af98-fc924cc77da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf04f2cd-d9f8-4e0c-adaf-6d38bc14dd7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf04f2cd-d9f8-4e0c-adaf-6d38bc14dd7a.jpg?1",
             "name": "Horrible Hordes",
             "text": "Rampage 1 (For each creature assigned to block it beyond the first, this creature gets +1/+1 until end of turn.)",
             "colours": [],
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "a5f66604-a257-5473-8bf0-0f1007a1c859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44c5e24-98f9-4a4d-9ecc-c862363eb66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44c5e24-98f9-4a4d-9ecc-c862363eb66d.jpg?1",
             "name": "Igneous Golem",
             "text": "o2: Trample until end of turn",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "484ba4cc-1291-52c3-a396-54c415a13360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9afb9e-eab3-4969-9a44-2c01bf730e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9afb9e-eab3-4969-9a44-2c01bf730e68.jpg?1",
             "name": "Lead Golem",
             "text": "If Lead Golem attacks, it does not untap during your next untap phase.",
             "colours": [],
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "f251d62d-d267-5985-ad48-3c2f582988d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bacc32-d6ba-420c-9b49-299c08e5fb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bacc32-d6ba-420c-9b49-299c08e5fb39.jpg?1",
             "name": "Lion's Eye Diamond",
             "text": "Sacrifice Lion's Eye Diamond, Discard your hand: Add three mana of any one color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10009,7 +10009,7 @@
         },
         {
             "id": "8bec994e-ae78-5225-ae3e-d14f024b57d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81137c17-18b8-484e-8334-28f143c08177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81137c17-18b8-484e-8334-28f143c08177.jpg?1",
             "name": "Mana Prism",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source. o1, oc\nT: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10036,7 +10036,7 @@
         },
         {
             "id": "0175cfa2-29a3-52d9-8fc5-aff161dd90b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557ebacf-4a8f-4548-a142-533b7adfdac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/557ebacf-4a8f-4548-a142-533b7adfdac3.jpg?1",
             "name": "Mangara's Tome",
             "text": "When Mangara's Tome comes into play, search your library and choose any five cards. Shuffle these cards and put them face down under Mangara's Tome. Shuffle your library afterwards.\nIf you lose control of Mangara's Tome, remove all cards under it from the game.\no2: Instead of drawing a card, put the top card from under Mangara's Tome into your hand.",
             "colours": [],
@@ -10063,7 +10063,7 @@
         },
         {
             "id": "473c323b-4de3-5ea0-b571-e8cde4513b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4731eb16-3088-4d4d-80a4-7e39d00c1a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4731eb16-3088-4d4d-80a4-7e39d00c1a87.jpg?1",
             "name": "Marble Diamond",
             "text": "Marble Diamond comes into play tapped.\noc\nT: Add o\nW to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10092,7 +10092,7 @@
         },
         {
             "id": "fb6c6e85-1efb-5090-9b84-5e79a5ac4fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c00691-26b1-4e7a-bdf5-4b15f0eb45ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c00691-26b1-4e7a-bdf5-4b15f0eb45ce.jpg?1",
             "name": "Misers' Cage",
             "text": "At end of target opponent's upkeep, if that player has five or more cards in hand, Misers' Cage deals 2 damage to him or her.",
             "colours": [],
@@ -10119,7 +10119,7 @@
         },
         {
             "id": "2734c45a-65c2-5323-a82f-9ca593bb41c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cea56a-b64f-452a-8e4b-40363aabb452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87cea56a-b64f-452a-8e4b-40363aabb452.jpg?1",
             "name": "Moss Diamond",
             "text": "Moss Diamond comes into play tapped.\noc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10148,7 +10148,7 @@
         },
         {
             "id": "2d0af40c-4146-595f-a148-fdcb9e3c7feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920b7a-fd56-4fa8-96c9-fb66c2af6fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920b7a-fd56-4fa8-96c9-fb66c2af6fbf.jpg?1",
             "name": "Patagia Golem",
             "text": "o3: Flying until end of turn",
             "colours": [],
@@ -10178,7 +10178,7 @@
         },
         {
             "id": "f1c8a62f-8e44-52bf-b3b3-e3905dccafd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411c350-a940-4172-b558-f5dc44b4fb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3411c350-a940-4172-b558-f5dc44b4fb33.jpg?1",
             "name": "Paupers' Cage",
             "text": "At end of target opponent's upkeep, if that player has two or fewer cards in hand, Paupers' Cage deals 2 damage to him or her.",
             "colours": [],
@@ -10205,7 +10205,7 @@
         },
         {
             "id": "7a486d99-c6e3-5e76-9463-4dc28ca9e0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8197b9-0cd1-4fa1-9668-d1b5f1759151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8197b9-0cd1-4fa1-9668-d1b5f1759151.jpg?1",
             "name": "Phyrexian Dreadnought",
             "text": "Trample\nWhen Phyrexian Dreadnought comes into play, sacrifice any number of creatures with total power of 12 or more, or bury Phyrexian Dreadnought.",
             "colours": [],
@@ -10236,7 +10236,7 @@
         },
         {
             "id": "62de14f9-dbf2-5fde-a482-e80734274d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966a4e7-bf0f-4880-a4ba-8641fb7e4519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0966a4e7-bf0f-4880-a4ba-8641fb7e4519.jpg?1",
             "name": "Phyrexian Vault",
             "text": "o2, oc\nT, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -10263,7 +10263,7 @@
         },
         {
             "id": "b36edac5-ce2c-5466-b444-def51ecba05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72562860-6097-4c63-9858-ae130805f4d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72562860-6097-4c63-9858-ae130805f4d6.jpg?1",
             "name": "Razor Pendulum",
             "text": "At the end of each player's turn, if that player has 5 or less life, Razor Pendulum deals 2 damage to him or her.",
             "colours": [],
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "d8518a67-189b-5cc9-b6f5-cc99579a3f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a955-ce9a-4386-b6ac-c00fd25de882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e4a955-ce9a-4386-b6ac-c00fd25de882.jpg?1",
             "name": "Sand Golem",
             "text": "If a spell or effect controlled by an opponent causes you to discard Sand Golem, put Sand Golem from your graveyard into play at end of turn with a +1/+1 counter on it.",
             "colours": [],
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "d96ce806-04e8-50fd-b009-865bbc6acd60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959aef9-77bb-45a3-939e-324bd59aec89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959aef9-77bb-45a3-939e-324bd59aec89.jpg?1",
             "name": "Sky Diamond",
             "text": "Sky Diamond comes into play tapped.\noc\nT: Add o\nU to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10349,7 +10349,7 @@
         },
         {
             "id": "b0300715-0221-58a1-95c0-c5178db6e758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e8971d-baeb-4e4f-8c4d-0e8109e4505e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e8971d-baeb-4e4f-8c4d-0e8109e4505e.jpg?1",
             "name": "Teeka's Dragon",
             "text": "Flying, trample; rampage 4 (For each creature assigned to block it beyond the first, this creature gets +4/+4 until end of turn.)\nTeeka's Dragon counts as a Dragon.",
             "colours": [],
@@ -10379,7 +10379,7 @@
         },
         {
             "id": "c0a06c3d-b5d4-5a9d-9799-408a09c57671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59733b76-3b44-4543-8bb2-a160232cee27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59733b76-3b44-4543-8bb2-a160232cee27.jpg?1",
             "name": "Telim'Tor's Darts",
             "text": "o2, oc\nT: Telim'Tor's Darts deals 1 damage to target player.",
             "colours": [],
@@ -10406,7 +10406,7 @@
         },
         {
             "id": "6faa10af-e9b8-586e-976d-bd983b04fbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf946b8-8574-406a-83fd-966ed912921f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecf946b8-8574-406a-83fd-966ed912921f.jpg?1",
             "name": "Unerring Sling",
             "text": "o3, oc\nT, Tap an untapped creature you control: Unerring Sling deals an amount of damage equal to that creature's power to target attacking or blocking creature with flying.",
             "colours": [],
@@ -10433,7 +10433,7 @@
         },
         {
             "id": "d81d3a17-9fd7-5bac-92c7-c1469772e169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520f4a24-fb1a-4964-887c-2f08a752fae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520f4a24-fb1a-4964-887c-2f08a752fae2.jpg?1",
             "name": "Ventifact Bottle",
             "text": "o1o\nX, oc\nT: Put X charge counters on Ventifact Bottle. Play this ability as a sorcery.\nAt the beginning of your main phase, if Ventifact Bottle has any charge counters on it, tap Ventifact Bottle and remove all charge counters from it to add to your mana pool an amount of colorless mana equal to the number of charge counters removed.",
             "colours": [],
@@ -10460,7 +10460,7 @@
         },
         {
             "id": "f6dce6fa-fc9e-5023-981b-c6b09427f714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a78abdb-d1ac-49cb-a74b-9de21c06364a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a78abdb-d1ac-49cb-a74b-9de21c06364a.jpg?1",
             "name": "Bad River",
             "text": "Bad River comes into play tapped.\noc\nT, Sacrifice Bad River: Search your library for an island or swamp card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "22695aad-3a70-5369-b9ab-7cae6065e737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afb6e29-058e-44c5-a3fa-56c462f070a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afb6e29-058e-44c5-a3fa-56c462f070a0.jpg?1",
             "name": "Crystal Vein",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Crystal Vein: Add two colorless mana to your mana pool.",
             "colours": [],
@@ -10514,7 +10514,7 @@
         },
         {
             "id": "fc5f2ee5-3f49-5f64-93a8-ee2b1ecb75d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7610f3-f182-404e-80b9-ccd94e174db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7610f3-f182-404e-80b9-ccd94e174db0.jpg?1",
             "name": "Flood Plain",
             "text": "Flood Plain comes into play tapped.\noc\nT, Sacrifice Flood Plain: Search your library for a plains or island card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "488d36d1-f662-5359-bee9-41a44a87c0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5efac-ef98-4be2-abcc-1aa38bf66b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f5efac-ef98-4be2-abcc-1aa38bf66b06.jpg?1",
             "name": "Grasslands",
             "text": "Grasslands comes into play tapped.\noc\nT, Sacrifice Grasslands: Search your library for a forest or plains card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10568,7 +10568,7 @@
         },
         {
             "id": "c0875b00-793e-58cc-abbe-73d1e66146d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4e5c2-4f03-47c1-9843-b98c239ccfea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4e5c2-4f03-47c1-9843-b98c239ccfea.jpg?1",
             "name": "Mountain Valley",
             "text": "Mountain Valley comes into play tapped.\noc\nT, Sacrifice Mountain Valley: Search your library for a mountain or forest card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10595,7 +10595,7 @@
         },
         {
             "id": "af680651-f514-59f3-bdc9-3f844fdb6c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e21c347-7aaf-42ae-abf3-f1283c5b54e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e21c347-7aaf-42ae-abf3-f1283c5b54e6.jpg?1",
             "name": "Rocky Tar Pit",
             "text": "Rocky Tar Pit comes into play tapped.\noc\nT, Sacrifice Rocky Tar Pit: Search your library for a swamp or mountain card. Put that land into play. Shuffle your library afterwards.",
             "colours": [],
@@ -10622,7 +10622,7 @@
         },
         {
             "id": "48cf8376-94b5-5121-a255-976cec395e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed7ca8-fd91-46e3-9149-a3de23c7078e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed7ca8-fd91-46e3-9149-a3de23c7078e.jpg?1",
             "name": "Teferi's Isle",
             "text": "Phasing\nTeferi's Isle comes into play tapped.\noc\nT: Add o\nUo\nU to your mana pool.",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "095122c1-18f2-5258-b265-70eb3f1401b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f32ad-3bdd-4c46-b3f0-522ac9763591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888f32ad-3bdd-4c46-b3f0-522ac9763591.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10690,7 +10690,7 @@
         },
         {
             "id": "0fe3ba7a-4cee-5094-931b-daf0c4d658cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b078ef66-a83b-4e12-bcba-838bc3809322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b078ef66-a83b-4e12-bcba-838bc3809322.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10727,7 +10727,7 @@
         },
         {
             "id": "b26ce97a-5a95-5c76-9d29-0e77fd6978df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15978d-41e6-4eaa-9456-0de3b912d437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac15978d-41e6-4eaa-9456-0de3b912d437.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10764,7 +10764,7 @@
         },
         {
             "id": "796ea6a2-a2b0-5fbe-8b5f-927abde3497a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bbbf38-5d1a-4013-aff9-6167709897f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81bbbf38-5d1a-4013-aff9-6167709897f0.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "e6ad28a9-8091-5ed4-9b0b-5b6551ee2afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df84bf1b-8698-4c3e-baa9-926f0efc6a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df84bf1b-8698-4c3e-baa9-926f0efc6a12.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "2b0a6b66-ca9e-5331-8df3-4a6bcb0801ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776912e7-fa16-4d71-b830-0a5d35f38297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776912e7-fa16-4d71-b830-0a5d35f38297.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10875,7 +10875,7 @@
         },
         {
             "id": "8b311f21-b14c-5dd6-b7f3-6f8184c449c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e571f07-167f-4a7d-8f98-0c98d7d15e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e571f07-167f-4a7d-8f98-0c98d7d15e81.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10912,7 +10912,7 @@
         },
         {
             "id": "05788e22-a768-5f5c-af18-c5836abc79ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39fc1e0-caf0-4cfa-bbf2-fea7ca32c00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a39fc1e0-caf0-4cfa-bbf2-fea7ca32c00d.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10949,7 +10949,7 @@
         },
         {
             "id": "a8f19ee5-ee06-5a1a-8ef4-38b6d40bcfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28477-8be1-4caf-8185-64f47905ccb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d28477-8be1-4caf-8185-64f47905ccb1.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "0fe7d94e-dedf-5e29-bb63-5780065aead9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4be2d6-d168-4e67-8d75-a04f637b56dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4be2d6-d168-4e67-8d75-a04f637b56dd.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "ce3d8396-397c-56c1-b337-00ae99478e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65181db5-3fc5-497b-ba61-385efdf740ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65181db5-3fc5-497b-ba61-385efdf740ed.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11060,7 +11060,7 @@
         },
         {
             "id": "72772625-a921-547e-a23b-85f1075bfef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5083de34-d127-45df-9252-ff09b5cf8b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5083de34-d127-45df-9252-ff09b5cf8b47.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11097,7 +11097,7 @@
         },
         {
             "id": "bbde108f-db73-564a-b802-eea50334cc47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004cdc-0baf-415d-8e87-7f36667c4628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97004cdc-0baf-415d-8e87-7f36667c4628.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11134,7 +11134,7 @@
         },
         {
             "id": "a9338e82-b840-5236-b38a-76b22e3315a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207a468f-79c3-486e-ac5a-4516361b7b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207a468f-79c3-486e-ac5a-4516361b7b4d.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11171,7 +11171,7 @@
         },
         {
             "id": "0ecf027e-0132-5685-9fd1-30543ac2fa92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681b9c8a-6140-4086-bc72-37f0058a8e9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681b9c8a-6140-4086-bc72-37f0058a8e9f.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11208,7 +11208,7 @@
         },
         {
             "id": "0f202bf8-d277-53c6-a916-e732e91dde3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cef9230-34fa-496f-8835-5dfaac627f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cef9230-34fa-496f-8835-5dfaac627f70.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11245,7 +11245,7 @@
         },
         {
             "id": "dc947b92-322e-5277-90a6-43543763989d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae7a81-9a61-4112-af22-369c525b2eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae7a81-9a61-4112-af22-369c525b2eb1.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11282,7 +11282,7 @@
         },
         {
             "id": "762a918f-23b5-5e43-9b0e-bf2928b34bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b3f80-20bf-4693-b106-cfb31a3d7f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6b3f80-20bf-4693-b106-cfb31a3d7f83.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11319,7 +11319,7 @@
         },
         {
             "id": "2174580e-abe4-54da-b611-9c7231976255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a67bf6-818b-4afe-af15-3d955dc5e884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a67bf6-818b-4afe-af15-3d955dc5e884.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11356,7 +11356,7 @@
         },
         {
             "id": "42320053-e36e-5123-86e0-a223e8ff1027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dfef30-acca-4b15-a05e-d33289055218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dfef30-acca-4b15-a05e-d33289055218.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MKM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MKM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "81495a8a-9228-5d55-816f-c1d6e4c4978c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a70f0ae-d49b-4cc8-9f76-895039c3dc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a70f0ae-d49b-4cc8-9f76-895039c3dc39.jpg?1",
             "name": "Case of the Shattered Pact",
             "text": "When this Case enters the battlefield, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nTo solve \u2014 There are five colors among permanents you control. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 At the beginning of combat on your turn, target creature you control gains flying, double strike, and vigilance until end of turn.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "6a6ef4b7-48cb-5bbf-829a-71bed2d33201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6e71a1-713e-4eca-bd65-9f0638c16794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6e71a1-713e-4eca-bd65-9f0638c16794.jpg?1",
             "name": "Absolving Lammasu",
             "text": "Flying\nWhen Absolving Lammasu enters the battlefield, all suspected creatures are no longer suspected.\nWhen Absolving Lammasu dies, you gain 3 life and suspect up to one target creature an opponent controls. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "796cc9f8-6c1b-5aab-8595-f76ca47d5c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg?1",
             "name": "Assemble the Players",
             "text": "You may look at the top card of your library any time.\nOnce each turn, you may cast a creature spell with power 2 or less from the top of your library.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "a8a47dc9-6b25-58cc-9346-f655a37b463d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg?1",
             "name": "Aurelia's Vindicator",
             "text": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "014eac08-1133-53c4-a8bf-b8b6308cfab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5180c85c-6add-4066-83c4-27fb1fd4de16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5180c85c-6add-4066-83c4-27fb1fd4de16.jpg?1",
             "name": "Auspicious Arrival",
             "text": "Target creature gets +2/+2 until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "b2c3c176-704f-5835-ad42-19441c284040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5148def-cf1a-460e-8dfd-856103940892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5148def-cf1a-460e-8dfd-856103940892.jpg?1",
             "name": "Call a Surprise Witness",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Put a flying counter on it. It's a Spirit in addition to its other types.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "b050a894-4431-5285-8d16-ed530ba87000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a52038-9d1c-4be1-8dbe-6f0ee916ba94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a52038-9d1c-4be1-8dbe-6f0ee916ba94.jpg?1",
             "name": "Case File Auditor",
             "text": "When Case File Auditor enters the battlefield and whenever you solve a Case, look at the top six cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nYou may spend mana as though it were mana of any color to cast Case spells.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "f9f02dd6-c004-5c46-916e-93746ed52de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2278d7-215e-49f9-ae2b-9df099c67b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2278d7-215e-49f9-ae2b-9df099c67b6d.jpg?1",
             "name": "Case File Auditor",
             "text": "",
             "colours": [
@@ -281,7 +281,7 @@
         },
         {
             "id": "b760b99d-88af-50da-8794-17951af4f638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0862bf07-8a76-4e80-bba2-20d22f8eee30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0862bf07-8a76-4e80-bba2-20d22f8eee30.jpg?1",
             "name": "Case of the Gateway Express",
             "text": "When this Case enters the battlefield, choose target creature you don't control. Each creature you control deals 1 damage to that creature.\nTo solve \u2014 Three or more creatures attacked this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Creatures you control get +1/+0.",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "3a4f2981-77ea-5b59-a990-31a9bdbc08a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32927bf2-63c1-4402-99dc-3a0f2f8e0f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32927bf2-63c1-4402-99dc-3a0f2f8e0f9c.jpg?1",
             "name": "Case of the Pilfered Proof",
             "text": "Whenever a Detective enters the battlefield under your control and whenever a Detective you control is turned face up, put a +1/+1 counter on it.\nTo solve \u2014 You control three or more Detectives. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 If one or more tokens would be created under your control, those tokens plus a Clue token are created instead. (It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "3c892f85-0f5e-50a8-8684-82585cd44d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63941b-3f78-4bd3-8b05-ca12aaaa006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63941b-3f78-4bd3-8b05-ca12aaaa006c.jpg?1",
             "name": "Case of the Uneaten Feast",
             "text": "Whenever a creature enters the battlefield under your control, you gain 1 life.\nTo solve \u2014 You've gained 5 or more life this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Sacrifice this Case: Creature cards in your graveyard gain \"You may cast this card from your graveyard\" until end of turn.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "7e7be949-6fb5-5a04-890b-f69b9f8aeaa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b284304-c3bf-4413-9fd3-b44eb4eb642a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b284304-c3bf-4413-9fd3-b44eb4eb642a.jpg?1",
             "name": "Defenestrated Phantom",
             "text": "Flying\nDisguise {4}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "d6f664ef-967c-5083-993d-ba7426808d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be219928-3d0e-4d00-b124-152ce8a8c13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be219928-3d0e-4d00-b124-152ce8a8c13b.jpg?1",
             "name": "Delney, Streetwise Lookout",
             "text": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
             "colours": [
@@ -457,7 +457,7 @@
         },
         {
             "id": "320ad70d-2ecc-5108-9740-f0aea1cb8959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a1cd28-d2a5-4d1a-aa03-a6a5958ae432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a1cd28-d2a5-4d1a-aa03-a6a5958ae432.jpg?1",
             "name": "Doorkeeper Thrull",
             "text": "Flash\nFlying\nArtifacts and creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "c496e009-821b-554e-8f2d-635e57552c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076d9f76-a247-4727-9e0f-a0289c51059e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076d9f76-a247-4727-9e0f-a0289c51059e.jpg?1",
             "name": "Due Diligence",
             "text": "Enchant creature\nWhen Due Diligence enters the battlefield, target creature you control other than enchanted creature gets +2/+2 and gains vigilance until end of turn.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "ab329b2d-9671-5af9-ab2a-af64623404ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee2945d-bf6d-4328-a482-df24c2973b56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee2945d-bf6d-4328-a482-df24c2973b56.jpg?1",
             "name": "Essence of Antiquity",
             "text": "Disguise {2}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Essence of Antiquity is turned face up, creatures you control gain hexproof until end of turn. Untap them.",
             "colours": [
@@ -562,7 +562,7 @@
         },
         {
             "id": "a5db9915-2b20-5623-8855-7888117ee600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06a243d-acc8-42cd-926c-98a4cc96ab21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06a243d-acc8-42cd-926c-98a4cc96ab21.jpg?1",
             "name": "Forum Familiar",
             "text": "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Forum Familiar is turned face up, return another target permanent you control to its owner's hand and put a +1/+1 counter on Forum Familiar.",
             "colours": [
@@ -596,7 +596,7 @@
         },
         {
             "id": "9aa2f238-9fc4-5cfe-9e17-b0f2ad56afd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f5d048-226f-49a4-a2ce-a6fa99aa9e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f5d048-226f-49a4-a2ce-a6fa99aa9e8a.jpg?1",
             "name": "Griffnaut Tracker",
             "text": "Flying\nWhen Griffnaut Tracker enters the battlefield, exile up to two target cards from a single graveyard.",
             "colours": [
@@ -631,7 +631,7 @@
         },
         {
             "id": "8247a633-efa4-56b3-967c-16ac18bc0783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277fe72-dc33-4d19-a439-63b5344c6034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5277fe72-dc33-4d19-a439-63b5344c6034.jpg?1",
             "name": "Haazda Vigilante",
             "text": "Whenever Haazda Vigilante enters the battlefield or attacks, put a +1/+1 counter on target creature you control with power 2 or less.",
             "colours": [
@@ -666,7 +666,7 @@
         },
         {
             "id": "1f510559-fe57-5845-bdac-9dc342f6f6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1548d181-3f83-457a-b2d3-eb88cfb2afda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1548d181-3f83-457a-b2d3-eb88cfb2afda.jpg?1",
             "name": "Inside Source",
             "text": "When Inside Source enters the battlefield, create a 2/2 white and blue Detective creature token.\n{3}, {T}: Target Detective you control gets +2/+0 and gains vigilance until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -701,7 +701,7 @@
         },
         {
             "id": "21b42fe6-c247-5280-8214-1e33a07bc546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cfb366-ae2a-4b3d-9a80-383a32db1509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cfb366-ae2a-4b3d-9a80-383a32db1509.jpg?1",
             "name": "Karlov Watchdog",
             "text": "Vigilance\nPermanents your opponents control can't be turned face up during your turn.\nWhenever you attack with three or more creatures, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -735,7 +735,7 @@
         },
         {
             "id": "49981f47-9db0-5279-9d33-809c2a903033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f663cd86-39e6-467b-85b7-dd27536251a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f663cd86-39e6-467b-85b7-dd27536251a6.jpg?1",
             "name": "Krovod Haunch",
             "text": "Equipped creature gets +2/+0.\n{2}, {T}, Sacrifice Krovod Haunch: You gain 3 life.\nWhen Krovod Haunch is put into a graveyard from the battlefield, you may pay {1}{W}. If you do, create two 1/1 white Dog creature tokens.\nEquip {2}",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "d4d7fc15-1602-508b-87a1-e9a867712b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73475d29-2673-4614-86d3-404232426aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73475d29-2673-4614-86d3-404232426aa8.jpg?1",
             "name": "Make Your Move",
             "text": "Destroy target artifact, enchantment, or creature with power 4 or greater.",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "4f770fac-6ca2-508e-bff2-e6e29be07cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45d2e0c-d70d-40e5-8c3d-db6803393516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45d2e0c-d70d-40e5-8c3d-db6803393516.jpg?1",
             "name": "Makeshift Binding",
             "text": "When Makeshift Binding enters the battlefield, exile target creature an opponent controls until Makeshift Binding leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "d34e79f3-0595-540c-8ed1-ee32d72a431d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf6a392-3fc4-45d1-b85d-3b1381b3ab7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf6a392-3fc4-45d1-b85d-3b1381b3ab7d.jpg?1",
             "name": "Marketwatch Phantom",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, Marketwatch Phantom gains flying until end of turn.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "334ed088-b831-5940-922d-ce6b08310678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37860682-4973-4a0f-a43a-3056037bd2dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37860682-4973-4a0f-a43a-3056037bd2dc.jpg?1",
             "name": "Museum Nightwatch",
             "text": "When Museum Nightwatch dies, create a 2/2 white and blue Detective creature token.\nDisguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -906,7 +906,7 @@
         },
         {
             "id": "7b7b72d7-e625-5bed-8348-c22974c9a94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0438d482-b74c-4d5e-a2bc-7063c1ae73fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0438d482-b74c-4d5e-a2bc-7063c1ae73fa.jpg?1",
             "name": "Neighborhood Guardian",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -942,7 +942,7 @@
         },
         {
             "id": "2e57188e-f3ee-55b4-ae23-bb60ddbf4ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg?1",
             "name": "No Witnesses",
             "text": "Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "6a07841c-45cd-5eb9-87c4-9037e85d8f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700294fc-7c16-4f7d-bce0-7452d8e9c401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700294fc-7c16-4f7d-bce0-7452d8e9c401.jpg?1",
             "name": "Not on My Watch",
             "text": "Exile target attacking creature.",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "680c33fb-90c6-54b2-a796-2e4c2964c9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad38866-fc5f-4f62-89c1-afc0f50765aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad38866-fc5f-4f62-89c1-afc0f50765aa.jpg?1",
             "name": "Novice Inspector",
             "text": "When Novice Inspector enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1045,7 +1045,7 @@
         },
         {
             "id": "d5e6343d-c4eb-5ea5-b62c-6568cfc63cfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b92629-4196-4943-91fd-8c8d5f3fcaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b92629-4196-4943-91fd-8c8d5f3fcaef.jpg?1",
             "name": "On the Job",
             "text": "Creatures you control get +2/+1 until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "f559ade9-0849-5d9d-9c9a-f61dd3b6c380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88d077-5082-4a67-91e4-97aafb9a5e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f88d077-5082-4a67-91e4-97aafb9a5e91.jpg?1",
             "name": "Perimeter Enforcer",
             "text": "Flying, lifelink\nWhenever another Detective enters the battlefield under your control and whenever a Detective you control is turned face up, Perimeter Enforcer gets +1/+1 until end of turn.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "2fe03732-9171-5dba-bea0-94d070fcd066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a009ba2-c7b9-4cf6-bb90-9d6fd589e932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a009ba2-c7b9-4cf6-bb90-9d6fd589e932.jpg?1",
             "name": "Sanctuary Wall",
             "text": "Defender\n{2}{W}, {T}: Tap target creature. You may put a stun counter on it. If you do, put a stun counter on Sanctuary Wall. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "49ae4680-8e41-5ed4-9389-3c9853652eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ebfe5d-8819-495d-bf72-b9c28c6fd23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ebfe5d-8819-495d-bf72-b9c28c6fd23e.jpg?1",
             "name": "Seasoned Consultant",
             "text": "Whenever you attack with three or more creatures, Seasoned Consultant gets +2/+0 until end of turn.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "a444a816-47ee-5623-986a-31de6d7e7358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c65a79e-f28a-4f30-95a4-1ea55fd84564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c65a79e-f28a-4f30-95a4-1ea55fd84564.jpg?1",
             "name": "Tenth District Hero",
             "text": "{1}{W}, Collect evidence 2: Tenth District Hero becomes a Human Detective with base power and toughness 4/4 and gains vigilance.\n{2}{W}, Collect evidence 4: If Tenth District Hero is a Detective, it becomes a legendary creature named Mileva, the Stalwart, it has base power and toughness 5/5, and it gains \"Other creatures you control have indestructible.\"",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "36090590-c863-5e82-89c2-62fe288f2266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg?1",
             "name": "Unyielding Gatekeeper",
             "text": "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Unyielding Gatekeeper is turned face up, exile another target nonland permanent. If you controlled it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue Detective creature token.",
             "colours": [
@@ -1257,7 +1257,7 @@
         },
         {
             "id": "f3398b7a-62d1-564d-ae28-8e57404ec860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg?1",
             "name": "Wojek Investigator",
             "text": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "3a45d036-c2cb-5a95-94e6-8a68573760e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bb0b1-c374-4af7-b018-fa7efaf14b25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684bb0b1-c374-4af7-b018-fa7efaf14b25.jpg?1",
             "name": "Wojek Investigator",
             "text": "",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "164e9959-037b-585b-b633-b8bf22aba992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cc39b-8f3b-4297-b118-86fa624308b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36cc39b-8f3b-4297-b118-86fa624308b4.jpg?1",
             "name": "Wrench",
             "text": "Equipped creature gets +1/+1 and has vigilance and \"{3}, {T}: Tap target creature.\"\n{2}, Sacrifice Wrench: Draw a card.\nEquip {2}",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "a2c331ea-107f-569c-bfea-40aaa4210b91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8112f133-535e-4264-8357-9cbf97957710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8112f133-535e-4264-8357-9cbf97957710.jpg?1",
             "name": "Agency Outfitter",
             "text": "Flying\nWhen Agency Outfitter enters the battlefield, you may search your graveyard, hand and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "185f4b1b-50a4-5410-833b-2f22c8f4890c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e522b043-fbd8-48a4-9f20-39e2a66a35ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e522b043-fbd8-48a4-9f20-39e2a66a35ec.jpg?1",
             "name": "Behind the Mask",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nUntil end of turn, target artifact or creature becomes an artifact creature with base power and toughness 4/3. If evidence was collected, it has base power and toughness 1/1 until end of turn instead.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "b9424422-4e63-58de-8461-e1286a97a9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b6b5a-acdf-4255-a294-0964d9c62686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283b6b5a-acdf-4255-a294-0964d9c62686.jpg?1",
             "name": "Benthic Criminologists",
             "text": "Whenever Benthic Criminologists enters the battlefield or attacks, you may sacrifice an artifact. If you do, draw a card.",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "bf480f09-1a55-5428-8522-b17b5a1a0563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b863ee0-d9f3-4b1e-993d-5212731d9353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b863ee0-d9f3-4b1e-993d-5212731d9353.jpg?1",
             "name": "Bubble Smuggler",
             "text": "Disguise {5}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nAs Bubble Smuggler is turned face up, put four +1/+1 counters on it.",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "38639726-2da7-52f1-a624-952676bd8862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea29c34-4b55-4170-9120-0a8dda61f2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea29c34-4b55-4170-9120-0a8dda61f2eb.jpg?1",
             "name": "Burden of Proof",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+2 as long as it's a Detective you control. Otherwise, it has base power and toughness 1/1 and can't block Detectives.",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "1f49936c-0570-5bdb-94a7-db05f9048ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeae6fb-3834-4891-924e-3d1fb3e19e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aeae6fb-3834-4891-924e-3d1fb3e19e09.jpg?1",
             "name": "Candlestick",
             "text": "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, surveil 2.\" (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n{2}, Sacrifice Candlestick: Draw a card.\nEquip {2}",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "c656fccb-f542-506d-80fa-becb3dd9f998",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266be5bd-71ba-4511-8b71-d0b03885a28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266be5bd-71ba-4511-8b71-d0b03885a28d.jpg?1",
             "name": "Case of the Filched Falcon",
             "text": "When this Case enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nTo solve \u2014 You control three or more artifacts. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 {2}{U}, Sacrifice this Case: Put four +1/+1 counters on target noncreature artifact. It becomes a 0/0 Bird creature with flying in addition to its other types.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "f3849490-6130-5ae6-af7c-7e37c0aad588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9a596-61de-4fcf-aae0-41836c3deca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9a596-61de-4fcf-aae0-41836c3deca5.jpg?1",
             "name": "Case of the Ransacked Lab",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nTo solve \u2014 You've cast four or more instant and sorcery spells this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Whenever you cast an instant or sorcery spell, draw a card.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "029f1c1d-a7e0-55a6-ac90-09d48c0cc414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f082111b-9b1c-4a25-8c5d-d6ef77533a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f082111b-9b1c-4a25-8c5d-d6ef77533a9b.jpg?1",
             "name": "Cold Case Cracker",
             "text": "Flying\nWhen Cold Case Cracker dies, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "def94cd4-cdfe-5093-ac1b-7111960af362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e791fc-bf9f-49b6-b5f2-a24d4b3e360e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e791fc-bf9f-49b6-b5f2-a24d4b3e360e.jpg?1",
             "name": "Conspiracy Unraveler",
             "text": "Flying\nYou may collect evidence 10 rather than pay the mana cost for spells that you cast. (To collect evidence 10, exile cards with total mana value 10 or greater from your graveyard.)",
             "colours": [
@@ -1717,7 +1717,7 @@
         },
         {
             "id": "98b4033d-f1a5-59a2-ade1-c3e611106bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg?1",
             "name": "Coveted Falcon",
             "text": "Flying\nWhenever Coveted Falcon attacks, gain control of target permanent you own but don't control.\nDisguise {1}{U}\nWhen Coveted Falcon is turned face up, target opponent gains control of any number of target permanents you control. Draw a card for each one they gained control of this way.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "e7cb61e7-9bb0-5014-8473-8d38a680b578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4ac597-38f0-48b5-ac2d-dfb0b169f834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4ac597-38f0-48b5-ac2d-dfb0b169f834.jpg?1",
             "name": "Crimestopper Sprite",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nFlying\nWhen Crimestopper Sprite enters the battlefield, tap target creature. If evidence was collected, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "b6725d59-1cce-5d82-accf-a460ed1d205f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg?1",
             "name": "Cryptic Coat",
             "text": "When Cryptic Coat enters the battlefield, cloak the top card of your library, then attach Cryptic Coat to it. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature gets +1/+0 and can't be blocked.\n{1}{U}: Return Cryptic Coat to its owner's hand.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "4e188324-625e-597a-a48f-9d1a4b140306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3603c6-92df-45c7-b402-1f0a552ea398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3603c6-92df-45c7-b402-1f0a552ea398.jpg?1",
             "name": "Curious Inquiry",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, investigate.\" (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "7c43b9c6-bd52-570a-9373-13df10b37f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbb17af-e17e-438a-ad72-0c942e6706b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbb17af-e17e-438a-ad72-0c942e6706b6.jpg?1",
             "name": "Deduce",
             "text": "Draw a card. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1893,7 +1893,7 @@
         },
         {
             "id": "7a8957af-6a29-5e19-aa45-eef3feaaa90c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca93438-a132-45ca-9fa8-364aeb519594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca93438-a132-45ca-9fa8-364aeb519594.jpg?1",
             "name": "Dramatic Accusation",
             "text": "Enchant creature\nWhen Dramatic Accusation enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{U}{U}: Shuffle enchanted creature into its owner's library.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "a72a4491-68bc-5cd8-b65e-c91c1c79270c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486f1cc2-c162-448e-91a9-577d7d796584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486f1cc2-c162-448e-91a9-577d7d796584.jpg?1",
             "name": "Eliminate the Impossible",
             "text": "Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "81536096-df4d-5fa0-9193-a3f7d1e87b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f142d-9fb1-4673-b804-add1f08dacb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f142d-9fb1-4673-b804-add1f08dacb9.jpg?1",
             "name": "Exit Specialist",
             "text": "Exit Specialist can't be blocked by creatures with power 3 or greater.\nDisguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Exit Specialist is turned face up, return another target creature to its owner's hand.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "3941c7a1-e31f-5c41-b02b-07e127feb732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9caa4eb-ed8c-4d05-8029-2a42163938a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9caa4eb-ed8c-4d05-8029-2a42163938a7.jpg?1",
             "name": "Fae Flight",
             "text": "Flash\nEnchant creature\nWhen Fae Flight enters the battlefield, enchanted creature gains hexproof until end of turn.\nEnchanted creature gets +1/+0 and has flying.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "32868293-2972-5b33-8204-480a1eb72678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg?1",
             "name": "Forensic Gadgeteer",
             "text": "Whenever you cast an artifact spell, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "2fe33fb4-e16c-5fc6-9800-9de90d81c98f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1384df5d-d705-49cb-a982-1588cbf303d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1384df5d-d705-49cb-a982-1588cbf303d8.jpg?1",
             "name": "Forensic Researcher",
             "text": "{T}: Untap another target permanent you control.\n{T}, Collect evidence 3: Tap target creature you don't control. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "3327377d-7f08-52d5-a0ce-fe4192b22a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f359fc2-b9e4-4a01-9d04-442bb160b01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f359fc2-b9e4-4a01-9d04-442bb160b01e.jpg?1",
             "name": "Furtive Courier",
             "text": "Furtive Courier can't be blocked as long as you've sacrificed an artifact this turn.\nWhenever Furtive Courier attacks, draw a card, then discard a card.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "929770da-ffcb-5e0b-b8b1-a8c0598a4418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3b23b-04d6-4ac0-b698-596ea90b7781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3b23b-04d6-4ac0-b698-596ea90b7781.jpg?1",
             "name": "Hotshot Investigators",
             "text": "When Hotshot Investigators enters the battlefield, return up to one other target creature to its owner's hand. If you controlled it, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "197bb141-a564-5778-9a4e-c3260550c365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg?1",
             "name": "Intrude on the Mind",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. Create a 0/0 colorless Thopter artifact creature token with flying, then put a +1/+1 counter on it for each card put into your graveyard this way.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "a19c15ed-3e93-5f3a-b7c4-316ff0ab7b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2807dcfb-d99c-483b-835f-2606eae4bd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2807dcfb-d99c-483b-835f-2606eae4bd30.jpg?1",
             "name": "Jaded Analyst",
             "text": "Defender\nWhenever you draw your second card each turn, Jaded Analyst loses defender and gains vigilance until end of turn.",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "49fc8f61-c9ce-57b5-8dc4-38c38c661bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb11c7-7b7f-4bdb-a022-53e28ebadecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97fb11c7-7b7f-4bdb-a022-53e28ebadecc.jpg?1",
             "name": "Living Conundrum",
             "text": "Hexproof\nIf you would draw a card while your library has no cards in it, skip that draw instead.\nAs long as there are no cards in your library, Living Conundrum has base power and toughness 10/10 and has flying and vigilance.",
             "colours": [
@@ -2278,7 +2278,7 @@
         },
         {
             "id": "21ec39a7-6739-5815-baf2-b853ba693e83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6308dc62-d945-4761-aa4c-ef8e9271e901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6308dc62-d945-4761-aa4c-ef8e9271e901.jpg?1",
             "name": "Lost in the Maze",
             "text": "Flash\nWhen Lost in the Maze enters the battlefield, tap X target creatures. Put a stun counter on each of those creatures you don't control. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nTapped creatures you control have hexproof.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "197f82d1-c722-53ae-82ae-3616eba7ff94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8578839-046f-4afd-a0e7-4737ded9e6eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8578839-046f-4afd-a0e7-4737ded9e6eb.jpg?1",
             "name": "Mistway Spy",
             "text": "Flying\nDisguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Mistway Spy is turned face up, until end of turn, whenever a creature you control deals combat damage to a player, investigate.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "33a632b0-fdb1-5635-ae31-95348fceece7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabfada0-3c1b-4237-b06c-573071ccd68d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabfada0-3c1b-4237-b06c-573071ccd68d.jpg?1",
             "name": "Out Cold",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nTap up to two target creatures and put a stun counter on each of them. Investigate. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "622a2c0f-9eb8-5684-9011-e26310697c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg?1",
             "name": "Proft's Eidetic Memory",
             "text": "When Proft's Eidetic Memory enters the battlefield, draw a card.\nYou have no maximum hand size.\nAt the beginning of combat on your turn, if you've drawn more than one card this turn, put X +1/+1 counters on target creature you control, where X is the number of cards you've drawn this turn minus one.",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "8f6e3e2e-270e-5c44-8b8d-1c1e5ae38592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad378843-e2b0-48d6-90dc-b584e857473d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad378843-e2b0-48d6-90dc-b584e857473d.jpg?1",
             "name": "Projektor Inspector",
             "text": "Whenever Projektor Inspector or another Detective enters the battlefield under your control and whenever a Detective you control is turned face up, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "8cffa0cf-9f3a-59ce-97d4-a374f6e7c4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270570a3-8637-4e4e-92d9-e985474cd5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270570a3-8637-4e4e-92d9-e985474cd5d2.jpg?1",
             "name": "Reasonable Doubt",
             "text": "Counter target spell unless its controller pays {2}.\nSuspect up to one target creature. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "7e9918e7-d4b4-5e46-bcbb-d12b2627c7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg?1",
             "name": "Reenact the Crime",
             "text": "Exile target nonland card in a graveyard that was put there from anywhere this turn. Copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "d968be74-8caa-592c-ad9a-65e43cf77238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg?1",
             "name": "Steamcore Scholar",
             "text": "Flying, vigilance\nWhen Steamcore Scholar enters the battlefield, draw two cards. Then discard two cards unless you discard an instant or sorcery card or a creature card with flying.",
             "colours": [
@@ -2553,7 +2553,7 @@
         },
         {
             "id": "b82ce6de-3170-561b-af45-3a4fdb01eb4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9e5fd6-a5ea-4ae5-83f5-89ed6a658dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9e5fd6-a5ea-4ae5-83f5-89ed6a658dd3.jpg?1",
             "name": "Sudden Setback",
             "text": "The owner of target spell or nonland permanent puts it on the top or bottom of their library.",
             "colours": [
@@ -2587,7 +2587,7 @@
         },
         {
             "id": "61ab5459-8a88-5f4a-86e1-4d1d5398feef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc6af2-f6b1-429d-b3ac-06a2c392d2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbc6af2-f6b1-429d-b3ac-06a2c392d2b8.jpg?1",
             "name": "Sudden Setback",
             "text": "",
             "colours": [
@@ -2621,7 +2621,7 @@
         },
         {
             "id": "9ce2101a-1439-5f46-9cae-41269fb82a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b874d-6739-4063-9891-e9c040dd9618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b874d-6739-4063-9891-e9c040dd9618.jpg?1",
             "name": "Surveillance Monitor",
             "text": "When Surveillance Monitor enters the battlefield, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)\nWhenever you collect evidence, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "4aac12c9-5346-57b3-a562-c9f98fb69ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529568-c759-4ae0-b2e4-ab5a11d421a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19529568-c759-4ae0-b2e4-ab5a11d421a4.jpg?1",
             "name": "Surveillance Monitor",
             "text": "",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "25ceb03a-7166-53ae-9a5f-6b1b687024bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a458474-d721-46d7-b487-6a47dc063cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a458474-d721-46d7-b487-6a47dc063cfd.jpg?1",
             "name": "Unauthorized Exit",
             "text": "Return target nonland permanent to its owner's hand. Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "710e8210-332f-54ae-8019-d8819ee4eea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63f2c23-e877-42e3-9362-5d003a173c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63f2c23-e877-42e3-9362-5d003a173c6d.jpg?1",
             "name": "Agency Coroner",
             "text": "{2}{B}, Sacrifice another creature: Draw a card. If the sacrificed creature was suspected, draw two cards instead.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "ffe4b210-e324-5e7d-89d8-807d202e58fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf238c9-61de-4f3a-b82f-05af46e5e81b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf238c9-61de-4f3a-b82f-05af46e5e81b.jpg?1",
             "name": "Alley Assailant",
             "text": "Alley Assailant enters the battlefield tapped.\nDisguise {4}{B}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Alley Assailant is turned face up, target opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "16e1a122-0fff-5ced-80e8-03a1e83054b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg?1",
             "name": "Barbed Servitor",
             "text": "Indestructible\nWhen Barbed Servitor enters the battlefield, suspect it. (It has menace and can't block.)\nWhenever Barbed Servitor deals combat damage to a player, you draw a card and you lose 1 life.\nWhenever Barbed Servitor is dealt damage, target opponent loses that much life.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "1f547d04-18de-5e9a-b9cf-3fb99cb6a6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdafea8f-283d-4f19-a74a-669bfbdfed98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdafea8f-283d-4f19-a74a-669bfbdfed98.jpg?1",
             "name": "Basilica Stalker",
             "text": "Flying\nWhenever Basilica Stalker deals combat damage to a player, you gain 1 life and surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nDisguise {4}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "f2993b5f-022f-5d81-b72b-f382e114d3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e4c07a-3205-4193-8163-b0e63e6242a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e4c07a-3205-4193-8163-b0e63e6242a4.jpg?1",
             "name": "Case of the Gorgon's Kiss",
             "text": "When this Case enters the battlefield, destroy up to one target creature that was dealt damage this turn.\nTo solve \u2014 Three or more creature cards were put into graveyards from anywhere this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 This Case is a 4/4 Gorgon creature with deathtouch and lifelink in addition to its other types.",
             "colours": [
@@ -2907,7 +2907,7 @@
         },
         {
             "id": "89077f37-dcc0-545e-82ac-b0c4e316ffec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ead0e-477b-4b3d-b6bf-b2598ddc6f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ead0e-477b-4b3d-b6bf-b2598ddc6f04.jpg?1",
             "name": "Case of the Gorgon's Kiss",
             "text": "",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "541a82fa-3604-5ba7-a968-1994ab40096f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b120cbe-f0af-46c5-863f-03ecadf0435c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b120cbe-f0af-46c5-863f-03ecadf0435c.jpg?1",
             "name": "Case of the Stashed Skeleton",
             "text": "When this Case enters the battlefield, create a 2/1 black Skeleton creature token and suspect it. (It has menace and can't block.)\nTo solve \u2014 You control no suspected Skeletons. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 {1}{B}, Sacrifice this Case: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "d60d91ef-6ef7-564b-b3ab-19bf9c444fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3c3d15-b775-44a2-91ea-4abcc3cf2dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c3c3d15-b775-44a2-91ea-4abcc3cf2dba.jpg?1",
             "name": "Cerebral Confiscation",
             "text": "Choose one \u2014\n\u2022 Target opponent discards two cards.\n\u2022 Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "52f1315d-572f-5c9a-8557-cff8bb64887b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e069de0-3218-456c-b191-93e755634783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e069de0-3218-456c-b191-93e755634783.jpg?1",
             "name": "Clandestine Meddler",
             "text": "When Clandestine Meddler enters the battlefield, suspect up to one other target creature you control. (A suspected creature has menace and can't block.)\nWhenever one or more suspected creatures you control attack, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "170bd191-1e06-551f-ace2-b2fbbb5755fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b13406-3b4e-4c61-b19a-c1faf31ed676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b13406-3b4e-4c61-b19a-c1faf31ed676.jpg?1",
             "name": "Clandestine Meddler",
             "text": "",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "0031ac0c-95db-5dc6-aac1-311ea9649bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg?1",
             "name": "Deadly Cover-Up",
             "text": "As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "9a7b535f-b126-56b5-aa2b-7d8a505a4834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256c8b6e-4031-458b-8eb9-bbfe58405a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256c8b6e-4031-458b-8eb9-bbfe58405a0c.jpg?1",
             "name": "Extract a Confession",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nEach opponent sacrifices a creature. If evidence was collected, instead each opponent sacrifices a creature with the greatest power among creatures they control.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "b1829455-ff54-50ca-9389-bebbe613d7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6fa37-8351-403b-ae05-b67e9bf74bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6fa37-8351-403b-ae05-b67e9bf74bbb.jpg?1",
             "name": "Festerleech",
             "text": "Whenever Festerleech deals combat damage to a player, you mill two cards.\n{1}{B}: Festerleech gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "8d6b5c36-8c95-5bcc-ac38-7875d8b14455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg?1",
             "name": "Homicide Investigator",
             "text": "Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3221,7 +3221,7 @@
         },
         {
             "id": "5f75aa30-7159-5f5c-92fc-c5671a0a99ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg?1",
             "name": "Hunted Bonebrute",
             "text": "Menace\nWhen Hunted Bonebrute enters the battlefield, target opponent creates two 1/1 white Dog creature tokens.\nWhen Hunted Bonebrute dies, each opponent loses 3 life.\nDisguise {1}{B}",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "8b39bad3-e7c1-5b68-94e7-3487397fe617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg?1",
             "name": "Illicit Masquerade",
             "text": "Flash\nWhen Illicit Masquerade enters the battlefield, put an impostor counter on each creature you control.\nWhenever a creature you control with an impostor counter on it dies, exile it. Return up to one other target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3292,7 +3292,7 @@
         },
         {
             "id": "122e9834-22f1-51de-bb38-30d28c112ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02dbc2-ad01-47fd-b39e-f0a695029f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa02dbc2-ad01-47fd-b39e-f0a695029f26.jpg?1",
             "name": "It Doesn't Add Up",
             "text": "Return target creature card from your graveyard to the battlefield. Suspect it. (It has menace and can't block.)",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "a5ec3482-2296-5d21-b930-ae2124f31147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f69249-c6e4-40c1-9870-b9c45ce24c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f69249-c6e4-40c1-9870-b9c45ce24c39.jpg?1",
             "name": "Lead Pipe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, each opponent loses 1 life.\n{2}, Sacrifice Lead Pipe: Draw a card.\nEquip {2}",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "72944f0f-3029-5179-a160-b236a20d4bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc687588-9c57-411d-b666-b9699949d48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc687588-9c57-411d-b666-b9699949d48f.jpg?1",
             "name": "Leering Onlooker",
             "text": "Flying\n{2}{B}{B}, Exile Leering Onlooker from your graveyard: Create two tapped 1/1 black Bat creature tokens with flying.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "e09b3bfe-1e8e-5a46-b158-61bbd3abe896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3896705-bbd2-4ffb-a590-ee78e0eabdc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3896705-bbd2-4ffb-a590-ee78e0eabdc5.jpg?1",
             "name": "Long Goodbye",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nDestroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "e231de8b-2385-5d90-9870-74520e0509f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb6184c-e3d0-4275-b25b-95e4a64b26f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb6184c-e3d0-4275-b25b-95e4a64b26f3.jpg?1",
             "name": "Macabre Reconstruction",
             "text": "This spell costs {2} less to cast if a creature card was put into your graveyard from anywhere this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "7880ad48-a920-500b-9409-83a5498e21e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1c8800-9d33-485c-b776-042003b9ea92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1c8800-9d33-485c-b776-042003b9ea92.jpg?1",
             "name": "Massacre Girl, Known Killer",
             "text": "Menace\nCreatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls dies, if its toughness was less than 1, draw a card.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "c5a5633c-312e-5816-90a9-eb623aeababf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea6438b-0e6c-4d65-8bcd-34a988717c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea6438b-0e6c-4d65-8bcd-34a988717c81.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "6ee842c3-d31e-5a4e-a1b6-c8fee52ba42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce043cba-aea4-4156-b1d0-545eda06c400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce043cba-aea4-4156-b1d0-545eda06c400.jpg?1",
             "name": "Nightdrinker Moroii",
             "text": "Flying\nWhen Nightdrinker Moroii enters the battlefield, you lose 3 life.\nDisguise {B}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "0eb53275-5155-502b-81fc-e2ab0a839758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg?1",
             "name": "Outrageous Robbery",
             "text": "Target opponent exiles the top X cards of their library face down. You may look at and play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any type to cast it.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "84cb8b2f-086d-5a21-b3c7-ac37e499085f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0713025-581f-451b-97a3-97d891285dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0713025-581f-451b-97a3-97d891285dcc.jpg?1",
             "name": "Persuasive Interrogators",
             "text": "When Persuasive Interrogators enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, target opponent gets two poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "62104658-309c-5e48-9beb-6c580833bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc4c6f-4a84-4d42-89fa-7405f7ad6ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc4c6f-4a84-4d42-89fa-7405f7ad6ba0.jpg?1",
             "name": "Polygraph Orb",
             "text": "When Polygraph Orb enters the battlefield, look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.\n{2}, {T}, Collect evidence 3: Each opponent loses 3 life unless they discard a card or sacrifice a creature. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "124360ed-d621-5613-9ddb-06728a67e5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd64e5c-ea0b-4ea0-aba3-88e7e96ac7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd64e5c-ea0b-4ea0-aba3-88e7e96ac7ba.jpg?1",
             "name": "Presumed Dead",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield under its owner's control and suspect it.\" (A suspected creature has menace and can't block.)",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "e6f38724-1818-53ee-9d4c-fdbc4b7caab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2ca1e7-e0de-4d29-a81b-62185ccd295f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2ca1e7-e0de-4d29-a81b-62185ccd295f.jpg?1",
             "name": "Repeat Offender",
             "text": "{2}{B}: If Repeat Offender is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "038d09bf-3d2f-557e-b172-784071285d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023b0142-663a-47e7-a9f1-0b565a172b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023b0142-663a-47e7-a9f1-0b565a172b60.jpg?1",
             "name": "Rot Farm Mortipede",
             "text": "Whenever one or more creature cards leave your graveyard, Rot Farm Mortipede gets +1/+0 and gains menace and lifelink until end of turn.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "0dfa3bc9-f635-5571-b653-c476ec88c121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317800b3-6b2d-4de6-8e44-7e54dd623055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317800b3-6b2d-4de6-8e44-7e54dd623055.jpg?1",
             "name": "Slice from the Shadows",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -3807,7 +3807,7 @@
         },
         {
             "id": "5b4de9d1-d244-54d7-ad88-ed2dfc0a3f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc803ad-f8a2-4198-a8a6-8d987b3d00fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc803ad-f8a2-4198-a8a6-8d987b3d00fb.jpg?1",
             "name": "Slimy Dualleech",
             "text": "At the beginning of combat on your turn, target creature you control with power 2 or less gets +1/+0 and gains deathtouch until end of turn.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "cd4d3323-dfa6-56ab-aa1e-636b82785502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ab3e11-8584-406f-b9ae-9e1df4396cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ab3e11-8584-406f-b9ae-9e1df4396cbc.jpg?1",
             "name": "Snarling Gorehound",
             "text": "Menace\nWhenever another creature with power 2 or less enters the battlefield under your control, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "2c90d34d-6d39-5195-80de-83c56ff95e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22ac67-06ce-47cc-a515-d216d30b9cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f22ac67-06ce-47cc-a515-d216d30b9cae.jpg?1",
             "name": "Soul Enervation",
             "text": "Flash\nWhen Soul Enervation enters the battlefield, target creature gets -4/-4 until end of turn.\nWhenever one or more creature cards leave your graveyard, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3909,7 +3909,7 @@
         },
         {
             "id": "94c61119-e552-5c7a-8090-4419caf079da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg?1",
             "name": "Toxin Analysis",
             "text": "Target creature gains deathtouch and lifelink until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3941,7 +3941,7 @@
         },
         {
             "id": "499fb379-83bb-53e8-a528-14b60a547905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67a4c5e-215b-4f03-87f7-c1af4f9f0a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a67a4c5e-215b-4f03-87f7-c1af4f9f0a63.jpg?1",
             "name": "Undercity Eliminator",
             "text": "When Undercity Eliminator enters the battlefield, you may sacrifice an artifact or creature. When you do, exile target creature an opponent controls.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "ccc8b64f-679c-59a0-bb7d-64f8d2c6c95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg?1",
             "name": "Unscrupulous Agent",
             "text": "When Unscrupulous Agent enters the battlefield, target opponent exiles a card from their hand.",
             "colours": [
@@ -4011,7 +4011,7 @@
         },
         {
             "id": "6819ac4f-8ced-5b23-a0f2-428ecc1fa50e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg?1",
             "name": "Vein Ripper",
             "text": "Flying\nWard\u2014\nSacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4049,7 +4049,7 @@
         },
         {
             "id": "9d12b110-1b73-54a5-9279-41f609c64588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc52b53-3e4f-4d7d-851f-86c6e0ac67b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc52b53-3e4f-4d7d-851f-86c6e0ac67b2.jpg?1",
             "name": "Anzrag's Rampage",
             "text": "Destroy all artifacts you don't control, then exile the top X cards of your library, where X is the number of artifacts that were put into graveyards from the battlefield this turn. You may put a creature card exiled this way onto the battlefield. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -4083,7 +4083,7 @@
         },
         {
             "id": "80fd934b-567c-5998-b9e0-74039128ac93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87683f7-8a61-4e4a-8b8b-3bf812454096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87683f7-8a61-4e4a-8b8b-3bf812454096.jpg?1",
             "name": "Bolrac-Clan Basher",
             "text": "Double strike, trample\nDisguise {3}{R}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "bed53f1f-9d16-52d9-872a-3f3d0c6d1d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee07df-215f-45a6-9a5a-708143d73e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ee07df-215f-45a6-9a5a-708143d73e45.jpg?1",
             "name": "Case of the Burning Masks",
             "text": "When this Case enters the battlefield, it deals 3 damage to target creature an opponent controls.\nTo solve \u2014 Three or more sources you controlled dealt damage this turn. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Sacrifice this Case: Exile the top three cards of your library. Choose one of them. You may play that card this turn.",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "96337375-06a8-52ba-a0b1-98e767451d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18b1de-bc08-4522-b891-6117a8271534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb18b1de-bc08-4522-b891-6117a8271534.jpg?1",
             "name": "Case of the Crimson Pulse",
             "text": "When this Case enters the battlefield, discard a card, then draw two cards.\nTo solve \u2014 You have no cards in hand. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 At the beginning of your upkeep, discard your hand, then draw two cards.",
             "colours": [
@@ -4186,7 +4186,7 @@
         },
         {
             "id": "fc8c5ed5-70f1-5374-bae5-31ffb8602a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bc5f89-2f01-40c4-9883-4c90ab89fcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95bc5f89-2f01-40c4-9883-4c90ab89fcbb.jpg?1",
             "name": "Caught Red-Handed",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Suspect it. (It has menace and can't block.)",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "8663243b-81a2-57cc-8647-4b2dbf902c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d54d596-f7aa-4b05-ab13-19b246698c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d54d596-f7aa-4b05-ab13-19b246698c04.jpg?1",
             "name": "The Chase Is On",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "5ac59122-fa7e-5330-8747-4a1a76219ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e31fa6-a445-47c6-a73f-135087f6d760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e31fa6-a445-47c6-a73f-135087f6d760.jpg?1",
             "name": "Concealed Weapon",
             "text": "Equipped creature gets +3/+0.\nDisguise {2}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Concealed Weapon is turned face up, attach it to target creature you control.\nEquip {1}{R}",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "726af514-483d-5f90-86f5-5645ce97c3ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg?1",
             "name": "Connecting the Dots",
             "text": "Whenever a creature you control attacks, exile the top card of your library face down. (You can't look at it.)\n{1}{R}, Discard your hand, Sacrifice Connecting the Dots: Put all cards exiled with Connecting the Dots into their owners' hands.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "fec832b4-e5fe-526a-8263-e4379a472f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2cf2ae-9152-41c4-9dc4-a19da5812869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2cf2ae-9152-41c4-9dc4-a19da5812869.jpg?1",
             "name": "Convenient Target",
             "text": "Enchant creature\nWhen Convenient Target enters the battlefield, suspect enchanted creature. (It has menace and can't block.)\nEnchanted creature gets +1/+1.\n{2}{R}: Return Convenient Target from your graveyard to your hand.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "fd92ecac-d675-5477-83e6-c1f67d0f4cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aff1ea-1d25-49c3-a2d9-f435124a5969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aff1ea-1d25-49c3-a2d9-f435124a5969.jpg?1",
             "name": "Cornered Crook",
             "text": "When Cornered Crook enters the battlefield, you may sacrifice an artifact. When you do, Cornered Crook deals 3 damage to any target.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "d2798e4d-db07-516e-9b75-0abe3c64fd44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a5cd7c-b0b1-4ffa-a806-bb0e73baffad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a5cd7c-b0b1-4ffa-a806-bb0e73baffad.jpg?1",
             "name": "Crime Novelist",
             "text": "Whenever you sacrifice an artifact, put a +1/+1 counter on Crime Novelist and add {R}.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "75f8359d-ece3-5403-b592-4c38bd2ff528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca092fc-7c67-4a73-989e-5297bbaaea76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca092fc-7c67-4a73-989e-5297bbaaea76.jpg?1",
             "name": "Demand Answers",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or discard a card.\nDraw two cards.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "30f21c62-14ed-5568-8cd9-a1604afcdc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65209da-cf48-4d37-b045-7d181070fd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65209da-cf48-4d37-b045-7d181070fd05.jpg?1",
             "name": "Expedited Inheritance",
             "text": "Whenever a creature is dealt damage, its controller may exile that many cards from the top of their library. They may play those cards until the end of their next turn.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "bb7bc526-1d6d-553e-8dd9-41cc86a1fc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31aadd3d-5ce1-44ba-ac6d-b192a9ea491b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31aadd3d-5ce1-44ba-ac6d-b192a9ea491b.jpg?1",
             "name": "Expose the Culprit",
             "text": "Choose one or both \u2014\n\u2022 Turn target face-down creature face up.\n\u2022 Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -4528,7 +4528,7 @@
         },
         {
             "id": "5f6a0214-9adb-5133-8573-32afe645624d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538d6a8-a24a-40e3-b894-45a30882c92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4538d6a8-a24a-40e3-b894-45a30882c92a.jpg?1",
             "name": "Felonious Rage",
             "text": "Target creature you control gets +2/+0 and gains haste until end of turn. When that creature dies this turn, create a 2/2 white and blue Detective creature token.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "44fda5ff-8048-5702-99f9-e0c531284b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81e343-7242-44b1-9ce6-1dddd104f764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81e343-7242-44b1-9ce6-1dddd104f764.jpg?1",
             "name": "Frantic Scapegoat",
             "text": "Haste\nWhen Frantic Scapegoat enters the battlefield, suspect it. (It has menace and can't block.)\nWhenever one or more other creatures enter the battlefield under your control, if Frantic Scapegoat is suspected, you may suspect one of the other creatures. If you do, Frantic Scapegoat is no longer suspected.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "844f5a49-2688-5ed3-afee-07e18c07fdba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg?1",
             "name": "Fugitive Codebreaker",
             "text": "Prowess, haste\nDisguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Fugitive Codebreaker is turned face up, discard your hand, then draw three cards.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "6ba196f9-8ff4-51ba-ba4c-ec177b781829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ed3bfa-3294-45dd-825e-3afc2580f0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ed3bfa-3294-45dd-825e-3afc2580f0d4.jpg?1",
             "name": "Galvanize",
             "text": "Galvanize deals 3 damage to target creature. If you've drawn two or more cards this turn, Galvanize deals 5 damage to that creature instead.",
             "colours": [
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "069a00f2-e480-58a2-9a27-a467b7e4b2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6900a344-a155-4ee1-a3ac-d6c28e024270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6900a344-a155-4ee1-a3ac-d6c28e024270.jpg?1",
             "name": "Gearbane Orangutan",
             "text": "Reach\nWhen Gearbane Orangutan enters the battlefield, choose one \u2014\n\u2022 Destroy up to one target artifact.\n\u2022 Sacrifice an artifact. If you do, put two +1/+1 counters on Gearbane Orangutan.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "5a19475e-ebcd-5a8c-8fd3-6a24f42067a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6154a991-c602-4fca-91a3-3830060da60e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6154a991-c602-4fca-91a3-3830060da60e.jpg?1",
             "name": "Goblin Maskmaker",
             "text": "Whenever Goblin Maskmaker attacks, face-down spells you cast this turn cost {1} less to cast.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "f0a1de8c-7c98-5e32-a1d2-28b915af94d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb25ee-3c84-40a8-ba45-7e44893deecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cb25ee-3c84-40a8-ba45-7e44893deecf.jpg?1",
             "name": "Harried Dronesmith",
             "text": "At the beginning of combat on your turn, create a 1/1 colorless Thopter artifact creature token with flying. It gains haste until end of turn. Sacrifice it at the beginning of your next end step.",
             "colours": [
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "07a1f955-15ca-5f8f-80c6-611edac7381f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6aca64-a554-45c1-9f23-4f7878abeda5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6aca64-a554-45c1-9f23-4f7878abeda5.jpg?1",
             "name": "Incinerator of the Guilty",
             "text": "Flying, trample\nWhenever Incinerator of the Guilty deals combat damage to a player, you may collect evidence X. When you do, Incinerator of the Guilty deals X damage to each creature and each planeswalker that player controls. (To collect evidence X, exile cards with total mana value X or greater from your graveyard.)",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "9ba423e8-6033-52d3-96bb-317502c1ac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085f4595-4ae5-428e-a934-e918774df6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085f4595-4ae5-428e-a934-e918774df6fd.jpg?1",
             "name": "Innocent Bystander",
             "text": "Whenever Innocent Bystander is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "70fbec67-432d-57d1-b472-403405dbda01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6883788-e1ee-4ddd-add2-24d6bc367717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6883788-e1ee-4ddd-add2-24d6bc367717.jpg?1",
             "name": "Knife",
             "text": "As long as it's your turn, equipped creature gets +1/+0 and has first strike.\n{2}, Sacrifice Knife: Draw a card.\nEquip {2}",
             "colours": [
@@ -4876,7 +4876,7 @@
         },
         {
             "id": "026a8fcb-c5db-50c9-9c9c-13db04701f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg?1",
             "name": "Krenko, Baron of Tin Street",
             "text": "Haste\n{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control.\nWhenever an artifact is put into a graveyard from the battlefield, you may pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "2ecdc2bc-c9b3-5789-8fc8-9db6a4cd6bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg?1",
             "name": "Krenko's Buzzcrusher",
             "text": "Flying, trample\nWhen Krenko's Buzzcrusher enters the battlefield, for each player, destroy up to one nonbasic land that player controls. For each land destroyed this way, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "6f5e3849-ac1a-5806-b415-5287374b46f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg?1",
             "name": "Lamplight Phoenix",
             "text": "Flying\nWhen Lamplight Phoenix dies, you may exile it and collect evidence 4. If you do, return Lamplight Phoenix to the battlefield tapped. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "5836f68b-62c3-5ba8-b3bd-6f4b4a627c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f096ff4a-85f4-46f1-9478-e8921f21309d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f096ff4a-85f4-46f1-9478-e8921f21309d.jpg?1",
             "name": "Offender at Large",
             "text": "Disguise {4}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Offender at Large enters the battlefield or is turned face up, up to one target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5023,7 +5023,7 @@
         },
         {
             "id": "9520de35-83de-5cbd-ae8c-abf340b72495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d56ebff-67c8-4bc7-a533-ddde4ce0c2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d56ebff-67c8-4bc7-a533-ddde4ce0c2af.jpg?1",
             "name": "Person of Interest",
             "text": "When Person of Interest enters the battlefield, suspect it. Create a 2/2 white and blue Detective creature token. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -5058,7 +5058,7 @@
         },
         {
             "id": "0a4aba16-619a-5f27-b122-fe007b2b261a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5671b-2651-4944-a50a-c768ec70229e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5671b-2651-4944-a50a-c768ec70229e.jpg?1",
             "name": "Pyrotechnic Performer",
             "text": "Disguise {R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhenever Pyrotechnic Performer or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "77438f5a-a166-532d-a200-b400ad772e52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da1a1d-e6ba-47e5-a545-0bacd427b782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18da1a1d-e6ba-47e5-a545-0bacd427b782.jpg?1",
             "name": "Reckless Detective",
             "text": "Whenever Reckless Detective attacks, you may sacrifice an artifact or discard a card. If you do, draw a card and Reckless Detective gets +2/+0 until end of turn.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "81099d80-6a55-5eae-b50e-150e300d5fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c137a44-9ab6-4e59-8324-34d9dca8f5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c137a44-9ab6-4e59-8324-34d9dca8f5a6.jpg?1",
             "name": "Red Herring",
             "text": "Haste\nRed Herring attacks each combat if able.\n{2}, Sacrifice Red Herring: Draw a card.",
             "colours": [
@@ -5166,7 +5166,7 @@
         },
         {
             "id": "1ad034a2-0165-5d09-84bb-2a69e90c5d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90f8691-210a-4bf0-9fc2-fb2efcf057fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90f8691-210a-4bf0-9fc2-fb2efcf057fb.jpg?1",
             "name": "Rubblebelt Braggart",
             "text": "Whenever Rubblebelt Braggart attacks, if it's not suspected, you may suspect it. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -5201,7 +5201,7 @@
         },
         {
             "id": "3df0a424-6fb7-5f8d-90fa-8c0461c5d59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298747bb-eb40-4b58-bb22-4ac2bc1d795c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298747bb-eb40-4b58-bb22-4ac2bc1d795c.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to any target.",
             "colours": [
@@ -5233,7 +5233,7 @@
         },
         {
             "id": "09298bbb-04ae-5668-826d-39fb525f97b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e280482-ed7e-4011-899e-096ff7bd4c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e280482-ed7e-4011-899e-096ff7bd4c41.jpg?1",
             "name": "Suspicious Detonation",
             "text": "This spell costs {3} less to cast if you've sacrificed an artifact this turn.\nThis spell can't be countered. (This includes by the ward ability.)\nSuspicious Detonation deals 4 damage to target creature.",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "164f49d7-d3a7-5bda-9bf4-d49758cbe473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bbf709-d8e9-4e3b-8ec8-206f1b2162b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22bbf709-d8e9-4e3b-8ec8-206f1b2162b3.jpg?1",
             "name": "Torch the Witness",
             "text": "Torch the Witness deals twice X damage to target creature. If excess damage was dealt to that creature this way, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "82d9ac51-be52-59f6-86a1-43a2a72607ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcc6106-71ad-40e4-8e1f-ddbfd655612b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcc6106-71ad-40e4-8e1f-ddbfd655612b.jpg?1",
             "name": "Torch the Witness",
             "text": "",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "99096027-dd20-5280-8726-2494bc967446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a247c9a0-0c65-47bc-92fd-bebe95cd35a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a247c9a0-0c65-47bc-92fd-bebe95cd35a3.jpg?1",
             "name": "Vengeful Tracker",
             "text": "Whenever an opponent sacrifices an artifact, Vengeful Tracker deals 2 damage to them.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "b1ae47e9-983d-5254-be0d-a947b60ad406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1aa6f8-2d34-4f4b-9184-0eab2e4745f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c1aa6f8-2d34-4f4b-9184-0eab2e4745f7.jpg?1",
             "name": "Aftermath Analyst",
             "text": "When Aftermath Analyst enters the battlefield, mill three cards.\n{3}{G}, Sacrifice Aftermath Analyst: Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "bbbcd5f9-6eb0-5c8b-8479-fe6dde72d048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffbbe21-0a1d-48b9-903e-81c109aa11de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffbbe21-0a1d-48b9-903e-81c109aa11de.jpg?1",
             "name": "Airtight Alibi",
             "text": "Flash\nEnchant creature\nWhen Airtight Alibi enters the battlefield, untap enchanted creature. It gains hexproof until end of turn. If it's suspected, it's no longer suspected.\nEnchanted creature gets +2/+2 and can't become suspected.",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "fe8add1e-3ac6-575b-9121-906f7ed25ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5563967f-09fd-4ccf-8892-4dd0c2544c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5563967f-09fd-4ccf-8892-4dd0c2544c98.jpg?1",
             "name": "Analyze the Pollen",
             "text": "As an additional cost to cast this spell, you may collect evidence 8. (Exile cards with total mana value 8 or greater from your graveyard.)\nSearch your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "32404393-7656-5378-b29e-5d303a9a7427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg?1",
             "name": "Archdruid's Charm",
             "text": "Choose one \u2014\n\u2022 Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n\u2022 Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control.\n\u2022 Exile target artifact or enchantment.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "52915c2b-9a9b-5be3-8b75-06a827a5ee6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg?1",
             "name": "Audience with Trostani",
             "text": "Create a 0/1 green Plant creature token, then draw cards equal to the number of differently named creature tokens you control.",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "8fd98136-4259-53d8-b644-a6769e34ca36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg?1",
             "name": "Axebane Ferox",
             "text": "Deathtouch, haste\nWard\u2014\nCollect evidence 4. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player exiles cards with total mana value 4 or greater from their graveyard.)",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "e8731553-a09c-55b9-8f00-1cf9bcf11110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bbfe93-8225-444c-835b-33ffa006ef66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bbfe93-8225-444c-835b-33ffa006ef66.jpg?1",
             "name": "Bite Down on Crime",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. This spell costs {2} less to cast if evidence was collected. (To collect evidence 6, exile cards with total mana value 6 or greater from your graveyard.)\nTarget creature you control gets +2/+0 until end of turn. It deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "ac60d13e-7e18-5e83-bd01-14502ed42a62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0929a1bd-e35c-4ca5-8c8c-dd304cf4b830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0929a1bd-e35c-4ca5-8c8c-dd304cf4b830.jpg?1",
             "name": "Case of the Locked Hothouse",
             "text": "You may play an additional land on each of your turns.\nTo solve \u2014 You control seven or more lands. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 You may look at the top card of your library any time, and you may play lands and cast creature and enchantment spells from the top of your library.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "20adc6a2-f0cc-5a87-a17b-f294e1ae0ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80f5c7-ae29-473c-ac64-04bcbc629385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80f5c7-ae29-473c-ac64-04bcbc629385.jpg?1",
             "name": "Case of the Trampled Garden",
             "text": "When this Case enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.\nTo solve \u2014 Creatures you control have total power 8 or greater. (If unsolved, solve at the beginning of your end step.)\nSolved \u2014 Whenever you attack, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "a652bd6b-62ed-5660-b1f1-61ee562b8f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ff56c1-4153-4e15-9ac6-06d93fa2ae50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ff56c1-4153-4e15-9ac6-06d93fa2ae50.jpg?1",
             "name": "Chalk Outline",
             "text": "Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "b9a10969-026f-5983-ab50-1a9383108508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdc58b-1e7e-402c-88f9-c789ff1dae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccdc58b-1e7e-402c-88f9-c789ff1dae31.jpg?1",
             "name": "Culvert Ambusher",
             "text": "When Culvert Ambusher enters the battlefield or is turned face up, target creature blocks this turn if able.\nDisguise {4}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "a5978836-dfd0-50f1-98df-ca5525a13c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941fa74-c7b9-4468-8080-de8057d3d27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4941fa74-c7b9-4468-8080-de8057d3d27b.jpg?1",
             "name": "Fanatical Strength",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -5779,7 +5779,7 @@
         },
         {
             "id": "3a0478d9-27ca-58c0-820c-60b21fe996f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb31e-9301-44f1-b138-0573fbf56a47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5ddcb31e-9301-44f1-b138-0573fbf56a47.jpg?1",
             "name": "Flourishing Bloom-Kin",
             "text": "Flourishing Bloom-Kin gets +1/+1 for each Forest you control.\nDisguise {4}{G}\nWhen Flourishing Bloom-Kin is turned face up, search your library for up to two Forest cards and reveal them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "5ec75087-073d-5702-bcd1-880309ecf9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e61e0f-d0f3-492a-92f1-36f72a91583a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e61e0f-d0f3-492a-92f1-36f72a91583a.jpg?1",
             "name": "Get a Leg Up",
             "text": "Until end of turn, target creature gets +1/+1 for each creature you control and gains reach.",
             "colours": [
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "cab2bab4-5dfc-5d44-ae6e-83d5ee3fd301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eff4d0-67ad-4900-b33d-605659b59161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8eff4d0-67ad-4900-b33d-605659b59161.jpg?1",
             "name": "Glint Weaver",
             "text": "Reach\nWhen Glint Weaver enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures, then you gain life equal to the greatest toughness among creatures you control.",
             "colours": [
@@ -5880,7 +5880,7 @@
         },
         {
             "id": "767c7bb2-78de-58b9-ae27-65e005d95f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e62346-cc62-4938-970c-b56beeb79fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e62346-cc62-4938-970c-b56beeb79fa6.jpg?1",
             "name": "Greenbelt Radical",
             "text": "Disguise {5}{G}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Greenbelt Radical is turned face up, put a +1/+1 counter on each creature you control. Creatures you control gain trample until end of turn.",
             "colours": [
@@ -5915,7 +5915,7 @@
         },
         {
             "id": "35372129-0942-58f5-80c9-2830c9d080e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad807c2-14a7-4464-bf57-c323fb3c0bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad807c2-14a7-4464-bf57-c323fb3c0bd0.jpg?1",
             "name": "Hard-Hitting Question",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -5947,7 +5947,7 @@
         },
         {
             "id": "fb4f6ba3-a8e4-57e7-a9a1-13a9e5997695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4627adcd-ace7-4777-a7e6-fc80ac6b9dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4627adcd-ace7-4777-a7e6-fc80ac6b9dfe.jpg?1",
             "name": "Hedge Whisperer",
             "text": "You may choose not to untap Hedge Whisperer during your untap step.\n{3}{G}, {T}, Collect evidence 4: Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as Hedge Whisperer remains tapped. It's still a land. Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "4f606ff1-eb79-5b33-aefb-6bec7c2e5db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87c1ed8-c644-4ad5-9a21-c7bd9a7e8d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87c1ed8-c644-4ad5-9a21-c7bd9a7e8d20.jpg?1",
             "name": "Hide in Plain Sight",
             "text": "Look at the top five cards of your library, cloak two of them, and put the rest on the bottom of your library in a random order. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "aa75be43-aa9d-5fc3-8cce-1b052ed483db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1392c5-91a5-4e6e-803d-ed032e4d594b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1392c5-91a5-4e6e-803d-ed032e4d594b.jpg?1",
             "name": "A Killer Among Us",
             "text": "When A Killer Among Us enters the battlefield, create a 1/1 white Human creature token, a 1/1 blue Merfolk creature token, and a 1/1 red Goblin creature token. Then secretly choose Human, Merfolk, or Goblin.\nSacrifice A Killer Among Us, Reveal the chosen creature type: If target attacking creature token is the chosen type, put three +1/+1 counters on it and it gains deathtouch until end of turn.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "bd657af5-2039-5fdd-b89e-5bd63bb7cb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848.jpg?1",
             "name": "Loxodon Eavesdropper",
             "text": "When Loxodon Eavesdropper enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you draw your second card each turn, Loxodon Eavesdropper gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "1c4be8c4-8806-5d58-b6be-197fb42ec4f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b747c7-b342-47f8-a190-16c393b20607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b747c7-b342-47f8-a190-16c393b20607.jpg?1",
             "name": "Nervous Gardener",
             "text": "Disguise {G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Nervous Gardener is turned face up, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "a45be06a-6400-519e-9a55-20558c0951b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58cfb23-4d99-4133-bf4b-d7e7c7d17cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58cfb23-4d99-4133-bf4b-d7e7c7d17cea.jpg?1",
             "name": "Pick Your Poison",
             "text": "Choose one \u2014\n\u2022 Each opponent sacrifices an artifact.\n\u2022 Each opponent sacrifices an enchantment.\n\u2022 Each opponent sacrifices a creature with flying.",
             "colours": [
@@ -6150,7 +6150,7 @@
         },
         {
             "id": "8d7a5713-129d-5033-a45f-81c9a56270e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d803b93-c1df-4a02-9dbb-d347c841d4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d803b93-c1df-4a02-9dbb-d347c841d4d7.jpg?1",
             "name": "Pompous Gadabout",
             "text": "Pompous Gadabout has hexproof as long as it's your turn.\nPompous Gadabout can't be blocked by creatures that don't have a name.",
             "colours": [
@@ -6185,7 +6185,7 @@
         },
         {
             "id": "3eed2098-8122-5df1-b6ea-5ddb38670cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg?1",
             "name": "The Pride of Hull Clade",
             "text": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "149cee39-275e-5e80-a898-1e39bd0246e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6881946c-5036-4d9f-926f-932c9a592aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6881946c-5036-4d9f-926f-932c9a592aff.jpg?1",
             "name": "Rope",
             "text": "Equipped creature gets +1/+2, has reach, and can't be blocked by more than one creature.\n{2}, Sacrifice Rope: Draw a card.\nEquip {3}",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "ca8d33da-f49f-5d78-8326-807e05fa0cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c7ff67-b9e1-4d2e-b1ae-da9b946da00b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c7ff67-b9e1-4d2e-b1ae-da9b946da00b.jpg?1",
             "name": "Rubblebelt Maverick",
             "text": "When Rubblebelt Maverick enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n{G}, Exile Rubblebelt Maverick from your graveyard: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "b0f001f5-bbd9-5631-8e19-325788064021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7480c-82cc-4ddd-b619-c1a609c29a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f7480c-82cc-4ddd-b619-c1a609c29a13.jpg?1",
             "name": "Sample Collector",
             "text": "Whenever Sample Collector attacks, you may collect evidence 3. When you do, put a +1/+1 counter on target creature you control. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "11efb9e1-2031-5ea0-8b72-d09395f58465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg?1",
             "name": "Sharp-Eyed Rookie",
             "text": "Vigilance\nWhenever a creature enters the battlefield under your control, if its power is greater than Sharp-Eyed Rookie's power or its toughness is greater than Sharp-Eyed Rookie's toughness, put a +1/+1 counter on Sharp-Eyed Rookie and investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6369,7 +6369,7 @@
         },
         {
             "id": "9e749f1a-45eb-56b9-af34-dfb344e798a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb21318-d32e-4724-8908-c0d7613de2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb21318-d32e-4724-8908-c0d7613de2f4.jpg?1",
             "name": "Slime Against Humanity",
             "text": "Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.\nA deck can have any number of cards named Slime Against Humanity.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "96379585-7d14-51b2-9423-1b9e6de685c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a31d4a-34bc-46b4-b20f-a5460191b35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a31d4a-34bc-46b4-b20f-a5460191b35d.jpg?1",
             "name": "They Went This Way",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "8c3a042b-5822-5d55-9650-f4bd226c7bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d0365e-6dee-4236-a997-6761e3cde90d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d0365e-6dee-4236-a997-6761e3cde90d.jpg?1",
             "name": "Topiary Panther",
             "text": "Trample\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "ff9f4fbc-e9cd-5d7a-b43e-158cb233bc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e29b890-35b9-4e2a-9b4c-9417ca7db31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e29b890-35b9-4e2a-9b4c-9417ca7db31d.jpg?1",
             "name": "Tunnel Tipster",
             "text": "At the beginning of your end step, if a face-down creature entered the battlefield under your control this turn, put a +1/+1 counter on Tunnel Tipster.\n{T}: Add {G}.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "56a80a30-013f-5b8c-9566-81589172ce30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8a22b8-368f-41e4-8d49-432c6c2ed11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8a22b8-368f-41e4-8d49-432c6c2ed11e.jpg?1",
             "name": "Undergrowth Recon",
             "text": "At the beginning of your upkeep, return target land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "6889e6ab-59b7-5766-8952-a28483e9c42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a914416-effd-4eda-b609-2773c53a08ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a914416-effd-4eda-b609-2773c53a08ec.jpg?1",
             "name": "Vengeful Creeper",
             "text": "Disguise {5}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Vengeful Creeper is turned face up, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "b7ac033f-bf61-5bd0-b06a-a27724f71255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d15d7-2724-4a9b-b5a7-8042d4b7da7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d15d7-2724-4a9b-b5a7-8042d4b7da7b.jpg?1",
             "name": "Vitu-Ghazi Inspector",
             "text": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nReach\nWhen Vitu-Ghazi Inspector enters the battlefield, if evidence was collected, put a +1/+1 counter on target creature and you gain 2 life.",
             "colours": [
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "c4fab116-558d-5dfe-a352-b9b519deb207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aeac7c-1275-49d4-9915-7604ae4bfdff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58aeac7c-1275-49d4-9915-7604ae4bfdff.jpg?1",
             "name": "Agrus Kos, Spirit of Justice",
             "text": "Double strike, vigilance\nWhenever Agrus Kos, Spirit of Justice enters the battlefield or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "4eb569cb-d88e-5d76-9e88-70290c840187",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41129b44-4fa7-473b-b2b7-48c6a58be03c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41129b44-4fa7-473b-b2b7-48c6a58be03c.jpg?1",
             "name": "Alquist Proft, Master Sleuth",
             "text": "Vigilance\nWhen Alquist Proft, Master Sleuth enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
             "colours": [
@@ -6691,7 +6691,7 @@
         },
         {
             "id": "97ade56c-db8d-533e-8116-390d6f69b0cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e9d8b8-4b32-4414-b32f-1f47523239c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e9d8b8-4b32-4414-b32f-1f47523239c5.jpg?1",
             "name": "Anzrag, the Quake-Mole",
             "text": "Whenever Anzrag, the Quake-Mole becomes blocked, untap each creature you control. After this combat phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
             "colours": [
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "25a19fd1-2582-55b2-bd17-85547fb693f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c7d29-71b4-4134-b591-5598f479d592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6c7d29-71b4-4134-b591-5598f479d592.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "bbe6811b-657b-528e-9ce3-89f405559829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f80c6e7-e9f9-4ca6-87f7-a52c96079e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f80c6e7-e9f9-4ca6-87f7-a52c96079e4a.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia, the Law Above deals 3 damage to each of your opponents and you gain 3 life.",
             "colours": [
@@ -6811,7 +6811,7 @@
         },
         {
             "id": "48b17106-dfb1-55db-b3ac-7a84c929787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b80feb8-5cc8-4e91-ac22-a733305a67de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b80feb8-5cc8-4e91-ac22-a733305a67de.jpg?1",
             "name": "Blood Spatter Analysis",
             "text": "When Blood Spatter Analysis enters the battlefield, it deals 3 damage to target creature an opponent controls.\nWhenever one or more creatures die, mill a card and put a bloodstain counter on Blood Spatter Analysis. Then sacrifice it if it has five or more bloodstain counters on it. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -6847,7 +6847,7 @@
         },
         {
             "id": "da8181e8-c003-545c-9611-7ac0f74a7301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c628476-0987-47d4-8d2a-cfc3977b2357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c628476-0987-47d4-8d2a-cfc3977b2357.jpg?1",
             "name": "Break Out",
             "text": "Look at the top six cards of your library. You may reveal a creature card from among them. If that card has mana value 2 or less, you may put it onto the battlefield and it gains haste until end of turn. If you didn't put the revealed card onto the battlefield this way, put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6883,7 +6883,7 @@
         },
         {
             "id": "7486fc59-7190-551c-9669-f5a73782caf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b50a8f-2788-41df-81ca-61194960b730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b50a8f-2788-41df-81ca-61194960b730.jpg?1",
             "name": "Break Out",
             "text": "",
             "colours": [
@@ -6919,7 +6919,7 @@
         },
         {
             "id": "64297291-457b-5b1d-8c64-51bd0694b1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e144609-e1f6-4bdc-8d14-b735ef4140d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e144609-e1f6-4bdc-8d14-b735ef4140d3.jpg?1",
             "name": "Buried in the Garden",
             "text": "Enchant land\nWhen Buried in the Garden enters the battlefield, exile target nonland permanent you don't control until Buried in the Garden leaves the battlefield.\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -6955,7 +6955,7 @@
         },
         {
             "id": "a2dd2668-6487-5f82-a010-e6912f4f796a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc9f352-5076-4b5f-9815-cf47abb63d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc9f352-5076-4b5f-9815-cf47abb63d5b.jpg?1",
             "name": "Coerced to Kill",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin in addition to its other types.",
             "colours": [
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "b145112e-b579-57cb-bb64-9e9ecef56220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0578f-4966-4ecd-81e1-83ae13126f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf0578f-4966-4ecd-81e1-83ae13126f13.jpg?1",
             "name": "Crowd-Control Warden",
             "text": "As Crowd-Control Warden enters the battlefield or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.\nDisguise {3}{RW}{RW} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "efe61e6b-5bea-5222-a32f-7406468d489f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893aef8-835d-4935-b532-d8670585e489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893aef8-835d-4935-b532-d8670585e489.jpg?1",
             "name": "Curious Cadaver",
             "text": "Flying\nWhen you sacrifice a Clue, return Curious Cadaver from your graveyard to your hand.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "09d8e7fa-f876-5103-b410-5d018d21cca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c68981c-037c-42e7-9b7f-6f07edab5f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c68981c-037c-42e7-9b7f-6f07edab5f2e.jpg?1",
             "name": "Deadly Complication",
             "text": "Choose one or both \u2014\n\u2022 Destroy target creature.\n\u2022 Put a +1/+1 counter on target suspected creature you control. You may have it become no longer suspected.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "f6113556-29a1-584e-a14c-80dc90fb926e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c05bf2d-7d4f-4717-b1ea-ec4284854f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c05bf2d-7d4f-4717-b1ea-ec4284854f4f.jpg?1",
             "name": "Detective's Satchel",
             "text": "When Detective's Satchel enters the battlefield, investigate twice. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn.",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "7037c6a6-2329-5e62-a365-ddd83f37d0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e0adb7-a030-4dcc-9284-cd91c7598a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e0adb7-a030-4dcc-9284-cd91c7598a22.jpg?1",
             "name": "Dog Walker",
             "text": "Vigilance\nDisguise {GU}{GU} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Dog Walker is turned face up, create two tapped 1/1 white Dog creature tokens.",
             "colours": [
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "02c11a99-531f-509c-8878-760e2769a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2daec58-78ed-4da5-b3b0-b04f12b0acbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2daec58-78ed-4da5-b3b0-b04f12b0acbd.jpg?1",
             "name": "Doppelgang",
             "text": "For each of X target permanents, create X tokens that are copies of that permanent.",
             "colours": [
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "1040fc8c-a70c-5e2f-a81a-330668ed19a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508d7096-2be3-4d4b-a55c-d4dbd3c9019c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508d7096-2be3-4d4b-a55c-d4dbd3c9019c.jpg?1",
             "name": "Drag the Canal",
             "text": "Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "c1a9c58d-e493-5a95-a054-81f228f14621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4410db5a-62af-43ac-979d-88a7c975f7bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4410db5a-62af-43ac-979d-88a7c975f7bd.jpg?1",
             "name": "Etrata, Deadly Fugitive",
             "text": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library.",
             "colours": [
@@ -7290,7 +7290,7 @@
         },
         {
             "id": "4a2ac383-205d-5cb2-a525-f044e34b9738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53a6ee7-86e1-4d2d-994c-214e0ec08dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53a6ee7-86e1-4d2d-994c-214e0ec08dad.jpg?1",
             "name": "Evidence Examiner",
             "text": "At the beginning of combat on your turn, you may collect evidence 4. (Exile cards with total mana value 4 or greater from your graveyard.)\nWhenever you collect evidence, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7327,7 +7327,7 @@
         },
         {
             "id": "2ea1917d-a6b9-59c4-800a-bbcafd90b80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554d5f2-7a33-4734-8cf3-dfae2ccc3596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554d5f2-7a33-4734-8cf3-dfae2ccc3596.jpg?1",
             "name": "Ezrim, Agency Chief",
             "text": "Flying\nWhen Ezrim, Agency Chief enters the battlefield, investigate twice. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "d3a700fe-8d25-539a-9162-c66043b5f51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20267dab-8898-4b44-8ef4-8a239967662c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20267dab-8898-4b44-8ef4-8a239967662c.jpg?1",
             "name": "Faerie Snoop",
             "text": "Flying\nDisguise {1}{UB}{UB} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Faerie Snoop is turned face up, look at the top two cards of your library. Put one into your hand and the other into your graveyard.",
             "colours": [
@@ -7405,7 +7405,7 @@
         },
         {
             "id": "48a6fc46-d0f4-51de-a396-75936fa230b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b489a54-ee43-4962-be7b-16e0e28800e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b489a54-ee43-4962-be7b-16e0e28800e0.jpg?1",
             "name": "Gadget Technician",
             "text": "When Gadget Technician enters the battlefield or is turned face up, create a 1/1 colorless Thopter artifact creature token with flying.\nDisguise {UR}{UR} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -7442,7 +7442,7 @@
         },
         {
             "id": "4112040a-1d5c-5ecc-a914-da9bf3ade6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabb5875-42ff-4e3a-a32e-aab392fccff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabb5875-42ff-4e3a-a32e-aab392fccff8.jpg?1",
             "name": "Gleaming Geardrake",
             "text": "Flying\nWhen Gleaming Geardrake enters the battlefield, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.",
             "colours": [
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "b2216055-28c2-5ef5-9f03-a7a1f45e4e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daee9d98-f8c6-4980-8f23-c6c636b69430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daee9d98-f8c6-4980-8f23-c6c636b69430.jpg?1",
             "name": "Granite Witness",
             "text": "Flying, vigilance\nDisguise {WU}{WU} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Granite Witness is turned face up, you may tap or untap target creature.",
             "colours": [
@@ -7520,7 +7520,7 @@
         },
         {
             "id": "ac7a6c1a-56ae-51f8-b629-fc1c633e19c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5cdb01-eaa4-4a0a-b42a-332bcf4d6fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5cdb01-eaa4-4a0a-b42a-332bcf4d6fff.jpg?1",
             "name": "Ill-Timed Explosion",
             "text": "Draw two cards. Then you may discard two cards. When you do, Ill-Timed Explosion deals X damage to each creature, where X is the greatest mana value among cards discarded this way.",
             "colours": [
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "930a4418-cf45-5363-a013-f80937d782e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb91a22-2040-4a37-85f8-5f22de8c5907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb91a22-2040-4a37-85f8-5f22de8c5907.jpg?1",
             "name": "Insidious Roots",
             "text": "Creature tokens you control have \"{T}: Add one mana of any color.\"\nWhenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature token, then put a +1/+1 counter on each Plant you control.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "717dc943-8cb6-523b-a053-eb03c4f06e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea66cd-587a-4ca9-9ca8-d7d2046bfbed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea66cd-587a-4ca9-9ca8-d7d2046bfbed.jpg?1",
             "name": "Izoni, Center of the Web",
             "text": "Menace\nWhenever Izoni, Center of the Web enters the battlefield or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with menace and reach.\nSacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life.",
             "colours": [
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "fd5d80f2-adb3-51fd-8fc6-a3452a72a5eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaa19ce-cace-499e-8b23-ef9e56b23700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eaa19ce-cace-499e-8b23-ef9e56b23700.jpg?1",
             "name": "Judith, Carnage Connoisseur",
             "text": "Whenever you cast an instant or sorcery spell, choose one \u2014\n\u2022 That spell gains deathtouch and lifelink.\n\u2022 Create a 2/2 red Imp creature token with \"When this creature dies, it deals 2 damage to each opponent.\"",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "c6a4a427-8945-5d64-8236-d8ea1146bd77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2827593-4951-4ba7-b73e-c27de56f2606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2827593-4951-4ba7-b73e-c27de56f2606.jpg?1",
             "name": "Kaya, Spirits' Justice",
             "text": "Whenever one or more creatures you control and/or creature cards in your graveyard are put into exile, you may choose a creature card from among them. Until end of turn, target token you control becomes a copy of it, except it has flying.\n+2: Surveil 2, then exile a card from a graveyard.\n+1: Create a 1/1 white and black Spirit creature token with flying.\n\u22122: Exile target creature you control. For each other player, exile up to one target creature that player controls.",
             "colours": [
@@ -7714,7 +7714,7 @@
         },
         {
             "id": "259cdf6a-1ecc-5ad6-8f5b-8d2415f4013d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Flying, vigilance\nWhenever Kellan, Inquisitive Prodigy attacks, destroy up to one target artifact. If you controlled that permanent, draw a card.",
             "colours": [
@@ -7756,7 +7756,7 @@
         },
         {
             "id": "b51e90f9-401b-5f89-8875-7ecb3bde7ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Investigate. You may play an additional land this turn.",
             "colours": [
@@ -7794,7 +7794,7 @@
         },
         {
             "id": "2989a41b-795c-530f-85af-e29121736041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c08ed44-2c13-4029-af2e-68585a76bb03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c08ed44-2c13-4029-af2e-68585a76bb03.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "Reach\nWhen Kraul Whipcracker enters the battlefield, destroy target token an opponent controls.",
             "colours": [
@@ -7835,7 +7835,7 @@
         },
         {
             "id": "985555b3-fd3a-59e4-9e8b-ff10c8ae3ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ceb4988-0a79-4757-9fcc-381ee8643d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ceb4988-0a79-4757-9fcc-381ee8643d0f.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "d7b8c510-8842-51ac-9424-765bbb0a594a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00faa272-91ad-407b-9175-8fa1d02585b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00faa272-91ad-407b-9175-8fa1d02585b8.jpg?1",
             "name": "Kylox, Visionary Inventor",
             "text": "Menace, ward {2}, haste\nWhenever Kylox, Visionary Inventor attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs.",
             "colours": [
@@ -7917,7 +7917,7 @@
         },
         {
             "id": "6c201c83-cdfd-5123-9aec-6b4abb868fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a8a1af-b1cf-47fc-ab42-7efa07a1c95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86a8a1af-b1cf-47fc-ab42-7efa07a1c95b.jpg?1",
             "name": "Kylox's Voltstrider",
             "text": "Collect evidence 6: Kylox's Voltstrider becomes an artifact creature until end of turn.\nWhenever Kylox's Voltstrider attacks, you may cast an instant or sorcery spell from among cards exiled with it. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.\nCrew 2",
             "colours": [
@@ -7955,7 +7955,7 @@
         },
         {
             "id": "d077b955-0bff-5433-b0c7-4cc2246df89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc264d1d-689d-41ac-b624-3fc7bb890e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc264d1d-689d-41ac-b624-3fc7bb890e58.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
             "colours": [
@@ -7998,7 +7998,7 @@
         },
         {
             "id": "59f47b57-652a-516b-a382-c0821a54cd03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e59be-f959-4f4a-8c2d-b7c441e88135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6e59be-f959-4f4a-8c2d-b7c441e88135.jpg?1",
             "name": "Leyline of the Guildpact",
             "text": "If Leyline of the Guildpact is in your opening hand, you may begin the game with it on the battlefield.\nEach nonland permanent you control is all colors.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "dcc68ad9-3362-59ba-a8f7-5be1a2464ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4101e3fe-b0e7-4f0f-b9ac-9b61a4d628b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4101e3fe-b0e7-4f0f-b9ac-9b61a4d628b3.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "bee0cf6d-36d6-5a6b-b12b-da3a136f326d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af12417c-b082-4379-a850-c72e2652c6fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af12417c-b082-4379-a850-c72e2652c6fb.jpg?1",
             "name": "Meddling Youths",
             "text": "Haste\nWhenever you attack with three or more creatures, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "e28826b3-0981-593b-910e-06a0f3261a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8fda6-8614-45cd-879c-0cb7fa29647e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a8fda6-8614-45cd-879c-0cb7fa29647e.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet, Guildpact deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
             "colours": [
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "f87f2154-b850-5e95-a291-0f53fb479407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0c695d-62f9-4805-9e2f-7032e8464136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0c695d-62f9-4805-9e2f-7032e8464136.jpg?1",
             "name": "No More Lies",
             "text": "Counter target spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -8200,7 +8200,7 @@
         },
         {
             "id": "215a62a0-ceb5-5f3e-9bb1-8d1ccdbfcce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a433ca4c-82d0-4e49-bc8e-98e18dd174e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a433ca4c-82d0-4e49-bc8e-98e18dd174e9.jpg?1",
             "name": "Officious Interrogation",
             "text": "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.",
             "colours": [
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "71bab7a8-7ad1-5235-99dd-00592eb6a842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a50807-058e-45dc-847c-8ffd13b1bd48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a50807-058e-45dc-847c-8ffd13b1bd48.jpg?1",
             "name": "Private Eye",
             "text": "Other Detectives you control get +1/+1.\nWhenever you draw your second card each turn, target Detective can't be blocked this turn.",
             "colours": [
@@ -8273,7 +8273,7 @@
         },
         {
             "id": "21c4a58c-3ccf-513c-ac66-9bee91af52e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6fd2d5-8eb2-4265-a1bf-d4ae635285af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6fd2d5-8eb2-4265-a1bf-d4ae635285af.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -8316,7 +8316,7 @@
         },
         {
             "id": "a5a3a8b5-42c3-5e1b-be19-e684b6e9c03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8c6b-7ef7-45db-99c9-4a6e7f177b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aaa8c6b-7ef7-45db-99c9-4a6e7f177b94.jpg?1",
             "name": "Rakish Scoundrel",
             "text": "Deathtouch\nWhen Rakish Scoundrel enters the battlefield or is turned face up, target creature gains indestructible until end of turn.\nDisguise {4}{BG}{BG} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "39136acc-3259-553b-955a-95d7028952a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20948cd2-e40c-4648-832f-ab0f1cc21610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20948cd2-e40c-4648-832f-ab0f1cc21610.jpg?1",
             "name": "Relive the Past",
             "text": "Return up to one target artifact card, up to one target land card, and up to one target non-Aura enchantment card from your graveyard to the battlefield. They are 5/5 Elemental creatures in addition to their other types.",
             "colours": [
@@ -8389,7 +8389,7 @@
         },
         {
             "id": "f65886f3-10eb-5192-879d-588070ea82c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71701c28-f113-4d38-8fd3-a19cd9749661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71701c28-f113-4d38-8fd3-a19cd9749661.jpg?1",
             "name": "Repulsive Mutation",
             "text": "Put X +1/+1 counters on target creature you control. Then counter up to one target spell unless its controller pays mana equal to the greatest power among creatures you control.",
             "colours": [
@@ -8423,7 +8423,7 @@
         },
         {
             "id": "a4b5e0e0-fde5-502c-8006-2ca1679472b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fae9044-a859-434d-8dc6-4f9d455ca5e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fae9044-a859-434d-8dc6-4f9d455ca5e1.jpg?1",
             "name": "Riftburst Hellion",
             "text": "Reach\nDisguise {4}{RG}{RG} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "72387799-de35-5ff9-b860-a03a5bd6bd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5288cf17-9d79-4d35-85f1-bf4d0a73494b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5288cf17-9d79-4d35-85f1-bf4d0a73494b.jpg?1",
             "name": "Rune-Brand Juggler",
             "text": "When Rune-Brand Juggler enters the battlefield, suspect up to one target creature you control. (A suspected creature has menace and can't block.)\n{3}{B}{R}, Sacrifice a suspected creature: Target creature gets -5/-5 until end of turn.",
             "colours": [
@@ -8496,7 +8496,7 @@
         },
         {
             "id": "dedd43ca-50c0-5408-aee3-5d8d91548108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cba5503-ba99-43d8-8062-66d905e0d86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cba5503-ba99-43d8-8062-66d905e0d86b.jpg?1",
             "name": "Sanguine Savior",
             "text": "Flying, lifelink\nDisguise {WB}{WB} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Sanguine Savior is turned face up, another target creature you control gains lifelink until end of turn.",
             "colours": [
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "ec930abd-7284-50b2-b69f-2d79011e4fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de36e63-8190-415f-b65b-bae1e595845d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de36e63-8190-415f-b65b-bae1e595845d.jpg?1",
             "name": "Shady Informant",
             "text": "When Shady Informant dies, it deals 2 damage to any target.\nDisguise {2}{BR}{BR} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8570,7 +8570,7 @@
         },
         {
             "id": "099c2ae3-7193-53d2-81b3-a8e42fad591b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f852937-381d-4445-99d3-2ecb8af6bb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f852937-381d-4445-99d3-2ecb8af6bb6a.jpg?1",
             "name": "Soul Search",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If the card's mana value is 1 or less, create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "f675558c-ee94-52e0-9069-5d16374beade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d4691-59d1-4e97-9b5d-8017788fbcb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d4691-59d1-4e97-9b5d-8017788fbcb3.jpg?1",
             "name": "Sumala Sentry",
             "text": "Reach\nWhenever a face-down permanent you control is turned face up, put a +1/+1 counter on it and a +1/+1 counter on Sumala Sentry.",
             "colours": [
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "3eeffce7-92ea-5be8-af06-33de173d486b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5a13dd-c2fd-432e-bc49-cc62d94d62a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5a13dd-c2fd-432e-bc49-cc62d94d62a0.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "Deathtouch\nAt the beginning of your end step, investigate for each opponent who lost life this turn.\nWhenever a Clue you control is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "a43fb179-8017-54d5-93c9-a4cf8c103da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4094b13f-28d4-48b6-8cce-3c44656745b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4094b13f-28d4-48b6-8cce-3c44656745b7.jpg?1",
             "name": "Tin Street Gossip",
             "text": "Vigilance\n{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn creatures face up.",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "f9d0029e-f3df-50e7-ad05-c5bd1fad56e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d22402-c41d-43d7-be1f-42be1e300726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d22402-c41d-43d7-be1f-42be1e300726.jpg?1",
             "name": "Tolsimir, Midnight's Light",
             "text": "Lifelink\nWhen Tolsimir, Midnight's Light enters the battlefield, create Voja Fenstalker, a legendary 5/5 green and white Wolf creature token with trample.\nWhenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an opponent controls blocks that Wolf this combat if able.",
             "colours": [
@@ -8762,7 +8762,7 @@
         },
         {
             "id": "098c42a4-52e9-5acc-9705-96e4acaad73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b9260b-0993-42c5-9bcf-87ab394d51db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b9260b-0993-42c5-9bcf-87ab394d51db.jpg?1",
             "name": "Treacherous Greed",
             "text": "As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.\nDraw three cards. Each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -8798,7 +8798,7 @@
         },
         {
             "id": "ba9c7a26-5a7b-5126-90c7-debe02aa687c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f3aca-6db7-41d3-95b2-c479d14b7fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/329f3aca-6db7-41d3-95b2-c479d14b7fa3.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -8841,7 +8841,7 @@
         },
         {
             "id": "af4abf8e-b3be-5955-8a4a-8ac99d0f4772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc669c8-6f39-4d52-82d3-a4005d41c8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc669c8-6f39-4d52-82d3-a4005d41c8a5.jpg?1",
             "name": "Undercover Crocodelf",
             "text": "Whenever Undercover Crocodelf deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nDisguise {3}{GW}{GW} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "023e6218-784f-50e4-b73b-9541f07a34f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163c6f2-dca1-4d6f-8f0d-7c3c55c6f75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163c6f2-dca1-4d6f-8f0d-7c3c55c6f75e.jpg?1",
             "name": "Undercover Crocodelf",
             "text": "",
             "colours": [
@@ -8921,7 +8921,7 @@
         },
         {
             "id": "d368d63c-0939-50b9-a686-588bdfe90dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ac346a-fc46-4023-aa60-4d55170697dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ac346a-fc46-4023-aa60-4d55170697dc.jpg?1",
             "name": "Urgent Necropsy",
             "text": "As an additional cost to cast this spell, collect evidence X, where X is the total mana value of the permanents this spell targets.\nDestroy up to one target artifact, up to one target creature, up to one target enchantment, and up to one target planeswalker.",
             "colours": [
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "9dab7895-e300-59b7-b6bc-b2bb1418e47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d381eb-6cb6-4505-aebe-995c1ddc8527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d381eb-6cb6-4505-aebe-995c1ddc8527.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand. (Put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -9002,7 +9002,7 @@
         },
         {
             "id": "18016e0e-c8f5-5c0d-96f5-924aa9a0bdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e8f8bd-1c8b-4a7c-96c4-57a247ce9ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e8f8bd-1c8b-4a7c-96c4-57a247ce9ccc.jpg?1",
             "name": "Warleader's Call",
             "text": "Creatures you control get +1/+1.\nWhenever a creature enters the battlefield under your control, Warleader's Call deals 1 damage to each opponent.",
             "colours": [
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "e87f1a1d-50eb-57ad-ac66-0eb7e6f4857d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3490c05-d12c-4483-acbc-1b4ae68877f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3490c05-d12c-4483-acbc-1b4ae68877f0.jpg?1",
             "name": "Wispdrinker Vampire",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.\n{5}{W}{B}: Creatures you control with power 2 or less gain deathtouch and lifelink until end of turn.",
             "colours": [
@@ -9077,7 +9077,7 @@
         },
         {
             "id": "dd1ef6ad-d69a-5b41-9b7a-15374bff3a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3340bd-1d8c-4c21-a59d-e092fcbe02e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3340bd-1d8c-4c21-a59d-e092fcbe02e3.jpg?1",
             "name": "Worldsoul's Rage",
             "text": "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped.",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "a62100e7-0bd7-52fb-929a-d2912a0411d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326845a7-7502-4dc3-8f3e-867d6c84e931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326845a7-7502-4dc3-8f3e-867d6c84e931.jpg?1",
             "name": "Yarus, Roar of the Old Gods",
             "text": "Other creatures you control have haste.\nWhenever one or more face-down creatures you control deal combat damage to a player, draw a card.\nWhenever a face-down creature you control dies, return it to the battlefield face down under its owner's control if it's a permanent card, then turn it face up.",
             "colours": [
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "7d7724c2-f8f9-5a65-acd0-1b720c3cde62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg?1",
             "name": "Cease // Desist",
             "text": "Exile up to two target cards from a single graveyard. Target player gains 2 life and draws a card.",
             "colours": [
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "f57b8326-c2a8-529b-b253-4e0552814561",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg?1",
             "name": "Cease // Desist",
             "text": "Destroy all artifacts and enchantments.",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "3adf27ae-6050-531c-bcd7-7f813cb0b2f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg?1",
             "name": "Flotsam // Jetsam",
             "text": "Mill three cards. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "ad68d7c0-3ecc-521f-83f3-7a6922756dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1500cbf-5619-465e-a97b-75e676ce789b.jpg?1",
             "name": "Flotsam // Jetsam",
             "text": "Each opponent mills three cards, then you may cast a spell from each opponent's graveyard without paying its mana cost. If a spell cast this way would be put into a graveyard, exile it instead.",
             "colours": [
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "63bc1b51-86fb-5901-91b5-15e15d7b5bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg?1",
             "name": "Fuss // Bother",
             "text": "Put a +1/+1 counter on each attacking creature you control.",
             "colours": [
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "b7a0fd32-d2e2-5bac-a48f-39bbcb547c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg?1",
             "name": "Fuss // Bother",
             "text": "Create three 1/1 colorless Thopter artifact creature tokens with flying. Surveil 2.",
             "colours": [
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "e3c80952-c9fb-5777-a69a-04cf35718a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg?1",
             "name": "Hustle // Bustle",
             "text": "Target creature attacks or blocks this turn if able.",
             "colours": [
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "373178c7-7664-545f-bf35-e867e93f9544",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg?1",
             "name": "Hustle // Bustle",
             "text": "Creatures you control get +2/+2 and gain trample until end of turn. You may turn a creature you control face up.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "7846184e-eee9-5122-bcd6-515d8c8a102f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg?1",
             "name": "Push // Pull",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "f060ec7b-3ec0-5a01-badc-b7b20587d211",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg?1",
             "name": "Push // Pull",
             "text": "Put up to two target creature cards from a single graveyard onto the battlefield under your control. They gain haste until end of turn. Sacrifice them at the beginning of the next end step.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "9982f02e-dfb9-5a60-a267-3576222a85b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a2563-6cfb-4d12-9513-b44d1a7a20ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a2563-6cfb-4d12-9513-b44d1a7a20ab.jpg?1",
             "name": "Cryptex",
             "text": "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on Cryptex. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)\nSacrifice Cryptex: Surveil 3, then draw three cards. Activate only if Cryptex has five or more unlock counters on it.",
             "colours": [],
@@ -9534,7 +9534,7 @@
         },
         {
             "id": "ec0b6cb5-684c-5b5d-a260-91d4e78062d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f952d8d-c089-432c-822a-8ef1e605ae38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f952d8d-c089-432c-822a-8ef1e605ae38.jpg?1",
             "name": "Gravestone Strider",
             "text": "{1}: Add one mana of any color. Activate only once each turn.\n{2}, Exile Gravestone Strider from your graveyard: Exile target card from a graveyard.",
             "colours": [],
@@ -9565,7 +9565,7 @@
         },
         {
             "id": "13f228a5-1bfa-5235-93b5-8837cf060110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ad039-1669-4735-9864-76f4c61fc59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080ad039-1669-4735-9864-76f4c61fc59e.jpg?1",
             "name": "Lumbering Laundry",
             "text": "{2}: Until end of turn, you may look at face-down creatures you don't control any time.\nDisguise {5} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
             "colours": [],
@@ -9596,7 +9596,7 @@
         },
         {
             "id": "f5bcce0b-6142-50ff-89fc-0203f7644fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70476534-2fc7-4872-a009-3380dd5ce2ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70476534-2fc7-4872-a009-3380dd5ce2ab.jpg?1",
             "name": "Magnetic Snuffler",
             "text": "When Magnetic Snuffler enters the battlefield, return target Equipment card from your graveyard to the battlefield attached to Magnetic Snuffler.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Magnetic Snuffler.",
             "colours": [],
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "6dd8a4cb-309d-58a9-a540-4db1a1453de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606a71f-8fb0-486b-955f-727ebf436946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c606a71f-8fb0-486b-955f-727ebf436946.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "991e0f85-385b-50eb-b1da-2b34ae45ff91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52608ba4-c47d-44e4-b624-dee2a3a42ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52608ba4-c47d-44e4-b624-dee2a3a42ae2.jpg?1",
             "name": "Sanitation Automaton",
             "text": "When Sanitation Automaton enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "a524ea2c-d122-51d1-8ac5-fcf1a65b1d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2565e1-dd7b-462b-8270-a17913277793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d2565e1-dd7b-462b-8270-a17913277793.jpg?1",
             "name": "Thinking Cap",
             "text": "Equipped creature gets +1/+2.\nEquip Detective {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9718,7 +9718,7 @@
         },
         {
             "id": "f1d619df-b539-558b-b796-3616383465a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8169f-b858-47a5-9c76-2e7c50ad4ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a8169f-b858-47a5-9c76-2e7c50ad4ecd.jpg?1",
             "name": "Branch of Vitu-Ghazi",
             "text": "{T}: Add {C}.\nDisguise {3} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen Branch of Vitu-Ghazi is turned face up, add two mana of any one color. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [],
@@ -9746,7 +9746,7 @@
         },
         {
             "id": "cb7372cc-5eeb-5633-8e2d-971843ae7023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf220c06-3cce-4bdd-aa58-83940c223e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf220c06-3cce-4bdd-aa58-83940c223e9c.jpg?1",
             "name": "Commercial District",
             "text": "({T}: Add {R} or {G}.)\nCommercial District enters the battlefield tapped.\nWhen Commercial District enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "1781db93-d1ec-5062-b4c3-da1819495363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6d541-e2cb-4d6e-acac-90a8f53b7006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6d541-e2cb-4d6e-acac-90a8f53b7006.jpg?1",
             "name": "Elegant Parlor",
             "text": "({T}: Add {R} or {W}.)\nElegant Parlor enters the battlefield tapped.\nWhen Elegant Parlor enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9818,7 +9818,7 @@
         },
         {
             "id": "1d888e36-a43f-56e9-a157-8c36144d147e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg?1",
             "name": "Escape Tunnel",
             "text": "{T}, Sacrifice Escape Tunnel: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n{T}, Sacrifice Escape Tunnel: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [],
@@ -9846,7 +9846,7 @@
         },
         {
             "id": "fc832b56-73ab-52f6-b7bc-863b119a64d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260f8ae-805b-4eae-badf-62de0f768867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5260f8ae-805b-4eae-badf-62de0f768867.jpg?1",
             "name": "Hedge Maze",
             "text": "({T}: Add {G} or {U}.)\nHedge Maze enters the battlefield tapped.\nWhen Hedge Maze enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9882,7 +9882,7 @@
         },
         {
             "id": "d1b9e8fb-2862-54e7-9c10-eadbf54cb11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17816e8-28b1-4295-a637-efb0e5c18873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17816e8-28b1-4295-a637-efb0e5c18873.jpg?1",
             "name": "Lush Portico",
             "text": "({T}: Add {G} or {W}.)\nLush Portico enters the battlefield tapped.\nWhen Lush Portico enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9918,7 +9918,7 @@
         },
         {
             "id": "98d5a2d1-64ee-56b8-ac96-bb87c2fc0e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652236c2-84ef-45e4-b5fc-ed6170bc3d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652236c2-84ef-45e4-b5fc-ed6170bc3d6c.jpg?1",
             "name": "Meticulous Archive",
             "text": "({T}: Add {W} or {U}.)\nMeticulous Archive enters the battlefield tapped.\nWhen Meticulous Archive enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "ea9fecbb-4369-5852-802c-db70209927ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b915f-3e82-4b05-b963-01ebff7a8f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f8b915f-3e82-4b05-b963-01ebff7a8f7b.jpg?1",
             "name": "Public Thoroughfare",
             "text": "Public Thoroughfare enters the battlefield tapped.\nWhen Public Thoroughfare enters the battlefield, sacrifice it unless you tap an untapped artifact or land you control.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9982,7 +9982,7 @@
         },
         {
             "id": "9cac4fe7-3790-531b-87ff-3d4a73fa1c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b598c93e-dae1-4d71-a9e4-917abf76d2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b598c93e-dae1-4d71-a9e4-917abf76d2d0.jpg?1",
             "name": "Raucous Theater",
             "text": "({T}: Add {B} or {R}.)\nRaucous Theater enters the battlefield tapped.\nWhen Raucous Theater enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "8061e12c-cd7b-507d-b8c2-fadf27b7a2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de039992-631b-4feb-a522-acdb0a6d1f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de039992-631b-4feb-a522-acdb0a6d1f26.jpg?1",
             "name": "Scene of the Crime",
             "text": "Scene of the Crime enters the battlefield tapped.\n{T}: Add {C}.\n{T}, Tap an untapped creature you control: Add one mana of any color.\n{2}, Sacrifice Scene of the Crime: Draw a card.",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "bd691e08-4492-525b-b644-6d0884260041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b656-1d67-499c-bf0f-417682a86c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c1b656-1d67-499c-bf0f-417682a86c7d.jpg?1",
             "name": "Shadowy Backstreet",
             "text": "({T}: Add {W} or {B}.)\nShadowy Backstreet enters the battlefield tapped.\nWhen Shadowy Backstreet enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "3f88972a-3ffb-539e-b514-228c5f56185f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17260fff-b239-4af4-9306-3236ae3fa5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17260fff-b239-4af4-9306-3236ae3fa5a5.jpg?1",
             "name": "Thundering Falls",
             "text": "({T}: Add {U} or {R}.)\nThundering Falls enters the battlefield tapped.\nWhen Thundering Falls enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "be48a761-6e79-5fa3-8490-e7888f6a9032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5801fb-2026-4f25-98bc-ebb2f99684b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b5801fb-2026-4f25-98bc-ebb2f99684b9.jpg?1",
             "name": "Undercity Sewers",
             "text": "({T}: Add {U} or {B}.)\nUndercity Sewers enters the battlefield tapped.\nWhen Undercity Sewers enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "fb93c13e-ee50-502f-9966-8b44914e8a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ca59cd-8779-4a84-a54b-e863b79c61f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ca59cd-8779-4a84-a54b-e863b79c61f0.jpg?1",
             "name": "Underground Mortuary",
             "text": "({T}: Add {B} or {G}.)\nUnderground Mortuary enters the battlefield tapped.\nWhen Underground Mortuary enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -10193,7 +10193,7 @@
         },
         {
             "id": "626f78bc-1374-5c58-9dc7-8ee28627cd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598f857d-ee17-4478-bb39-cc3ab77ab8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598f857d-ee17-4478-bb39-cc3ab77ab8d8.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "7d77484b-1033-54a2-af4a-1f8b080a859e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5f01e9-f85f-41e8-9527-88f76e7bfc02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5f01e9-f85f-41e8-9527-88f76e7bfc02.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10267,7 +10267,7 @@
         },
         {
             "id": "8dc7629b-77da-5ed6-a12b-c01515446b39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d0a415-26b8-4ba2-9503-b4ee2b93617c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d0a415-26b8-4ba2-9503-b4ee2b93617c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10304,7 +10304,7 @@
         },
         {
             "id": "97e51c26-7a92-5f11-869e-27a0d2153b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383b66e-e559-47d2-9967-9c2d5f898653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5383b66e-e559-47d2-9967-9c2d5f898653.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10341,7 +10341,7 @@
         },
         {
             "id": "af9de45c-409f-56bf-9ada-de3a3f3b748e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8126b842-ea58-4988-8b3f-0394cf766b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8126b842-ea58-4988-8b3f-0394cf766b91.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10378,7 +10378,7 @@
         },
         {
             "id": "cee7488e-5346-5a7a-a8e9-3b973d5803eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1a8a6-916b-4eef-8079-6775afcb63cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a1a8a6-916b-4eef-8079-6775afcb63cf.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10415,7 +10415,7 @@
         },
         {
             "id": "682bf5a1-7151-5a1a-a5dd-0f378ea652c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec05cb6c-6e7f-4d40-ba38-a9fc06158094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec05cb6c-6e7f-4d40-ba38-a9fc06158094.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10452,7 +10452,7 @@
         },
         {
             "id": "27a8b821-4c7a-594a-a59d-ef397ea5f0fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6908b583-4a52-4819-82a3-9db9c860aeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6908b583-4a52-4819-82a3-9db9c860aeb6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10489,7 +10489,7 @@
         },
         {
             "id": "6e055635-9822-59ab-bd02-6a12c8aa2fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df18762d-9980-4344-9d4f-e9d2cd8e0456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df18762d-9980-4344-9d4f-e9d2cd8e0456.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10526,7 +10526,7 @@
         },
         {
             "id": "6011504d-1dae-5968-a113-4b4aad18f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d0ef58-c0b3-4bcd-b470-0cf41219a4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d0ef58-c0b3-4bcd-b470-0cf41219a4e6.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10563,7 +10563,7 @@
         },
         {
             "id": "c4be0dd1-abad-5b23-ba5b-a63e55bfce48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbccfc-3585-4895-94d1-c3a67205e5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbccfc-3585-4895-94d1-c3a67205e5fe.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10600,7 +10600,7 @@
         },
         {
             "id": "93a8241c-45a7-5d3c-915a-5e8a12525a52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de754d20-5371-456b-9064-8f0687d2eab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de754d20-5371-456b-9064-8f0687d2eab7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10637,7 +10637,7 @@
         },
         {
             "id": "12dbef3e-4412-5647-ac0c-9c8532227280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a0cd6-8d3b-44bd-b609-c12fb851d17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8a0cd6-8d3b-44bd-b609-c12fb851d17b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10674,7 +10674,7 @@
         },
         {
             "id": "6053e63c-67ef-56b1-ad98-2b43931ba5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc485069-e081-4e83-bbad-d5faf7a5bd03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc485069-e081-4e83-bbad-d5faf7a5bd03.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10711,7 +10711,7 @@
         },
         {
             "id": "b57a1231-6966-5b92-914c-582a47626be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb8f264-cc26-476e-a3b7-53638dce7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb8f264-cc26-476e-a3b7-53638dce7395.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10748,7 +10748,7 @@
         },
         {
             "id": "a6aee678-4405-5edc-8487-b34fe009064b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88c5959-c033-46d0-94ea-df22988dc923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88c5959-c033-46d0-94ea-df22988dc923.jpg?1",
             "name": "Assemble the Players",
             "text": "You may look at the top card of your library any time.\nOnce each turn, you may cast a creature spell with power 2 or less from the top of your library.",
             "colours": [
@@ -10782,7 +10782,7 @@
         },
         {
             "id": "859784e1-61bf-54bb-aa13-4d909213b182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49598c0a-3b3c-42a2-9358-ff072de9d9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49598c0a-3b3c-42a2-9358-ff072de9d9f2.jpg?1",
             "name": "Auspicious Arrival",
             "text": "Target creature gets +2/+2 until end of turn. Investigate.",
             "colours": [
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "0fef2c11-e41a-5b14-ab1f-8315c8fba01d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e844d2-80de-4473-acd3-c39c1b11246f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e844d2-80de-4473-acd3-c39c1b11246f.jpg?1",
             "name": "Call a Surprise Witness",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Put a flying counter on it. It's a Spirit in addition to its other types.",
             "colours": [
@@ -10850,7 +10850,7 @@
         },
         {
             "id": "54131580-4a86-578b-9552-75b4e017f2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512dafb-3cba-4415-9f26-9345f1935b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f512dafb-3cba-4415-9f26-9345f1935b1e.jpg?1",
             "name": "Makeshift Binding",
             "text": "When Makeshift Binding enters the battlefield, exile target creature an opponent controls until Makeshift Binding leaves the battlefield. You gain 2 life.",
             "colours": [
@@ -10884,7 +10884,7 @@
         },
         {
             "id": "163c17a9-2545-5e95-b95f-ad977671a4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb67d2a1-4b0b-4d4a-8ae9-eaf0f831cdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb67d2a1-4b0b-4d4a-8ae9-eaf0f831cdb5.jpg?1",
             "name": "Not on My Watch",
             "text": "Exile target attacking creature.",
             "colours": [
@@ -10918,7 +10918,7 @@
         },
         {
             "id": "4c78c394-b1f4-54fe-893c-d917aaef837f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a5571e-02cb-4aa4-926d-d04f5ab04f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a5571e-02cb-4aa4-926d-d04f5ab04f29.jpg?1",
             "name": "On the Job",
             "text": "Creatures you control get +2/+1 until end of turn. Investigate.",
             "colours": [
@@ -10952,7 +10952,7 @@
         },
         {
             "id": "a991bdc7-8be1-5876-b98c-402feece2387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad92dbd-828e-425f-8cab-819a04ea9020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad92dbd-828e-425f-8cab-819a04ea9020.jpg?1",
             "name": "Deduce",
             "text": "Draw a card. Investigate.",
             "colours": [
@@ -10986,7 +10986,7 @@
         },
         {
             "id": "959cc734-b093-5a14-8e6f-7aa03cb94b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bff30e-c25c-4d89-8fbe-1a9effe63ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bff30e-c25c-4d89-8fbe-1a9effe63ba7.jpg?1",
             "name": "Dramatic Accusation",
             "text": "Enchant creature\nWhen Dramatic Accusation enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{U}{U}: Shuffle enchanted creature into its owner's library.",
             "colours": [
@@ -11022,7 +11022,7 @@
         },
         {
             "id": "b5643c0e-d297-5f04-ba47-7c3c9b231b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51724cc6-edf7-490d-8039-b11b91ae1eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51724cc6-edf7-490d-8039-b11b91ae1eb4.jpg?1",
             "name": "Fae Flight",
             "text": "Flash\nEnchant creature\nWhen Fae Flight enters the battlefield, enchanted creature gains hexproof until end of turn.\nEnchanted creature gets +1/+0 and has flying.",
             "colours": [
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "da665ca2-ff71-566d-b690-5bf6040000eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6c5c84-2721-4aaa-9185-69351a4ab105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6c5c84-2721-4aaa-9185-69351a4ab105.jpg?1",
             "name": "Intrude on the Mind",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. Create a 0/0 colorless Thopter artifact creature token with flying, then put a +1/+1 counter on it for each card put into your graveyard this way.",
             "colours": [
@@ -11092,7 +11092,7 @@
         },
         {
             "id": "4ad282e3-b576-5568-a5d6-a5dc230e7c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580e1986-d22b-4deb-914a-2d38d6da4145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580e1986-d22b-4deb-914a-2d38d6da4145.jpg?1",
             "name": "Reenact the Crime",
             "text": "Exile target nonland card in a graveyard that was put there from anywhere this turn. Copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -11126,7 +11126,7 @@
         },
         {
             "id": "df12fa84-b72f-5355-8274-27bdb27c4356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695437c-1b7e-4163-aade-ca79b9c70e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7695437c-1b7e-4163-aade-ca79b9c70e15.jpg?1",
             "name": "Unauthorized Exit",
             "text": "Return target nonland permanent to its owner's hand. Surveil 1.",
             "colours": [
@@ -11160,7 +11160,7 @@
         },
         {
             "id": "b814245c-605e-595d-9f22-41085db32fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef279e1-cbce-4766-9d56-02fa6c79d69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef279e1-cbce-4766-9d56-02fa6c79d69d.jpg?1",
             "name": "It Doesn't Add Up",
             "text": "Return target creature card from your graveyard to the battlefield. Suspect it.",
             "colours": [
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "c08afbfd-feda-5dc8-885d-0461a7668bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c98fcd3-8273-459f-857d-d0a34a1d285a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c98fcd3-8273-459f-857d-d0a34a1d285a.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -11228,7 +11228,7 @@
         },
         {
             "id": "7e5dd595-3627-5833-85bd-632b163e5f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e49c72-0fa2-4271-aabd-38a3e2b4779c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4e49c72-0fa2-4271-aabd-38a3e2b4779c.jpg?1",
             "name": "Slice from the Shadows",
             "text": "This spell can't be countered.\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "088e040c-48d4-5c6f-ba03-89723fddea88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef61777-be03-40c5-be9c-d573cf025813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef61777-be03-40c5-be9c-d573cf025813.jpg?1",
             "name": "Soul Enervation",
             "text": "Flash\nWhen Soul Enervation enters the battlefield, target creature gets -4/-4 until end of turn.\nWhenever one or more creature cards leave your graveyard, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11296,7 +11296,7 @@
         },
         {
             "id": "5b8724b2-8208-5a40-b3f6-fb59b9a6328c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba0604-3d9d-4f68-9086-6c7bf85a1354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ba0604-3d9d-4f68-9086-6c7bf85a1354.jpg?1",
             "name": "Anzrag's Rampage",
             "text": "Destroy all artifacts you don't control, then exile the top X cards of your library, where X is the number of artifacts that were put into graveyards from the battlefield this turn. You may put a creature card exiled this way onto the battlefield. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -11330,7 +11330,7 @@
         },
         {
             "id": "6f09d5ba-734d-53e5-bbc7-8a412c97859f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5d312-8664-4690-9823-8be4d1c06cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5d312-8664-4690-9823-8be4d1c06cd0.jpg?1",
             "name": "The Chase Is On",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn. Investigate.",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "e64feb99-46d5-5cd4-9460-094b822c8a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11c0f62-80a0-4e45-9ed2-295814475a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11c0f62-80a0-4e45-9ed2-295814475a3f.jpg?1",
             "name": "Convenient Target",
             "text": "Enchant creature\nWhen Convenient Target enters the battlefield, suspect enchanted creature.\nEnchanted creature gets +1/+1.\n{2}{R}: Return Convenient Target from your graveyard to your hand.",
             "colours": [
@@ -11400,7 +11400,7 @@
         },
         {
             "id": "0c193d4d-2b29-5fdd-94ce-a2c855892400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a35d1cb-5a61-49b7-a124-e8713655e4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a35d1cb-5a61-49b7-a124-e8713655e4c3.jpg?1",
             "name": "Demand Answers",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or discard a card.\nDraw two cards.",
             "colours": [
@@ -11434,7 +11434,7 @@
         },
         {
             "id": "4cd8e690-09e5-5527-bfb0-b3c15ae87017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaae9b6-510f-4039-8cca-fe7d7c57f1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbaae9b6-510f-4039-8cca-fe7d7c57f1c5.jpg?1",
             "name": "Expose the Culprit",
             "text": "Choose one or both \u2014\n\u2022 Turn target face-down creature face up.\n\u2022 Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them.",
             "colours": [
@@ -11468,7 +11468,7 @@
         },
         {
             "id": "f9a04478-ca15-5e97-a971-45f031359e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8faf9-4230-4bb5-ad2e-b520ab338c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8faf9-4230-4bb5-ad2e-b520ab338c35.jpg?1",
             "name": "Analyze the Pollen",
             "text": "As an additional cost to cast this spell, you may collect evidence 8.\nSearch your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
             "colours": [
@@ -11502,7 +11502,7 @@
         },
         {
             "id": "f1fa7428-7110-5614-9566-50b281d9f455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4b7b29-b1c1-4413-80d9-3c8585ed8eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4b7b29-b1c1-4413-80d9-3c8585ed8eb4.jpg?1",
             "name": "Audience with Trostani",
             "text": "Create a 0/1 green Plant creature token, then draw cards equal to the number of differently named creature tokens you control.",
             "colours": [
@@ -11536,7 +11536,7 @@
         },
         {
             "id": "8ac4d93e-cccf-5ebe-a181-cd4b90ba384e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee8b5b-ab55-4a26-9491-a0dc20cf54c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ee8b5b-ab55-4a26-9491-a0dc20cf54c8.jpg?1",
             "name": "Fanatical Strength",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -11570,7 +11570,7 @@
         },
         {
             "id": "806e9642-5b69-58bf-8a10-f0c1d1ff7158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9c1153-93d6-4250-bc42-2d9fd3042e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9c1153-93d6-4250-bc42-2d9fd3042e55.jpg?1",
             "name": "Coerced to Kill",
             "text": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin in addition to its other types.",
             "colours": [
@@ -11608,7 +11608,7 @@
         },
         {
             "id": "5f77df67-a32b-5eda-96a8-8d966c38b476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1aaebc-105a-4867-9727-24b8d7899e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1aaebc-105a-4867-9727-24b8d7899e28.jpg?1",
             "name": "Deadly Complication",
             "text": "Choose one or both \u2014\n\u2022 Destroy target creature.\n\u2022 Put a +1/+1 counter on target suspected creature you control. You may have it become no longer suspected.",
             "colours": [
@@ -11644,7 +11644,7 @@
         },
         {
             "id": "588544ab-8007-5b19-aeef-838972747d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9e0ae-38c0-4618-b664-16a9ad1661c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9e0ae-38c0-4618-b664-16a9ad1661c1.jpg?1",
             "name": "Insidious Roots",
             "text": "Creature tokens you control have \"{T}: Add one mana of any color.\"\nWhenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature token, then put a +1/+1 counter on each Plant you control.",
             "colours": [
@@ -11680,7 +11680,7 @@
         },
         {
             "id": "d3cd2ac1-e99d-5f5d-b430-f9199c9a2ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a78b4-9fe3-4f99-8678-2cf5d344bd0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7a78b4-9fe3-4f99-8678-2cf5d344bd0c.jpg?1",
             "name": "Officious Interrogation",
             "text": "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.",
             "colours": [
@@ -11716,7 +11716,7 @@
         },
         {
             "id": "2cb07172-362c-5c8b-81ab-ec3bcd5551fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26cd008-0a09-4a3d-a5de-2babf79ec6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26cd008-0a09-4a3d-a5de-2babf79ec6c6.jpg?1",
             "name": "Warleader's Call",
             "text": "Creatures you control get +1/+1.\nWhenever a creature enters the battlefield under your control, Warleader's Call deals 1 damage to each opponent.",
             "colours": [
@@ -11752,7 +11752,7 @@
         },
         {
             "id": "1bde860d-31d6-5fa6-b004-b711cc3a193c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62c3c3c-1196-45b0-832a-77ba26df3b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62c3c3c-1196-45b0-832a-77ba26df3b70.jpg?1",
             "name": "Worldsoul's Rage",
             "text": "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped.",
             "colours": [
@@ -11788,7 +11788,7 @@
         },
         {
             "id": "ebd980bd-32b1-5482-8929-e32a5bb9a4b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f000f6-6a24-4daa-8552-bfc2634e6d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f000f6-6a24-4daa-8552-bfc2634e6d83.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia, the Law Above deals 3 damage to each of your opponents and you gain 3 life.",
             "colours": [
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "05c2a9fe-28b3-57b3-9192-e3dfff0341f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39c4234-3b5a-4114-871a-ae8dd5659e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39c4234-3b5a-4114-871a-ae8dd5659e86.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "",
             "colours": [
@@ -11871,7 +11871,7 @@
         },
         {
             "id": "86fb2c18-1941-51ee-8e47-25344fe564d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f43e9f-8a0e-4534-ba4d-14cde33df864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f43e9f-8a0e-4534-ba4d-14cde33df864.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate.\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
             "colours": [
@@ -11914,7 +11914,7 @@
         },
         {
             "id": "555d9d6a-fdcd-52fa-965e-1b3440da5032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a701da-47d6-4c85-a428-adeb4a20678d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a701da-47d6-4c85-a428-adeb4a20678d.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "",
             "colours": [
@@ -11956,7 +11956,7 @@
         },
         {
             "id": "bd6e217f-c50d-51d2-9312-a3d68b7c1dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd713f-a0d0-4456-9678-d0a48e4bc334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15fd713f-a0d0-4456-9678-d0a48e4bc334.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet, Guildpact deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
             "colours": [
@@ -12005,7 +12005,7 @@
         },
         {
             "id": "5242832d-253c-5e5a-a1ff-e6373073b29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdad75c-82e3-4feb-9bc9-29b6251439cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdad75c-82e3-4feb-9bc9-29b6251439cb.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "",
             "colours": [
@@ -12053,7 +12053,7 @@
         },
         {
             "id": "399cfb63-129a-5734-9be5-47bf669935be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea612ae-6e7e-4a42-844f-2bc97153b6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea612ae-6e7e-4a42-844f-2bc97153b6b1.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -12096,7 +12096,7 @@
         },
         {
             "id": "6601393f-14bf-5e60-8497-3912e3525f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5c2b49-ae53-48b7-877a-7f9aa7b6fc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5c2b49-ae53-48b7-877a-7f9aa7b6fc4a.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "",
             "colours": [
@@ -12138,7 +12138,7 @@
         },
         {
             "id": "c11e2034-3429-5682-8d82-8ac046cfccfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536f271e-5daa-4ffe-9dd4-0ccc48d6fb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/536f271e-5daa-4ffe-9dd4-0ccc48d6fb66.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "Deathtouch\nAt the beginning of your end step, investigate for each opponent who lost life this turn.\nWhenever a Clue you control is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -12181,7 +12181,7 @@
         },
         {
             "id": "d0abc038-9a1a-5925-a581-16d333549e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4193a7bd-bba3-44f2-acf3-685847b8be27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4193a7bd-bba3-44f2-acf3-685847b8be27.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "",
             "colours": [
@@ -12223,7 +12223,7 @@
         },
         {
             "id": "19363e7f-8aa0-55fd-8d76-35c67b2b9bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a158690c-0a9a-4057-a6ee-f651bfb6664a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a158690c-0a9a-4057-a6ee-f651bfb6664a.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -12266,7 +12266,7 @@
         },
         {
             "id": "3d0286ac-5b96-5f5b-8bd5-1939b067fcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c420297-04c7-4659-b7cc-141a5c0ad1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c420297-04c7-4659-b7cc-141a5c0ad1e1.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "",
             "colours": [
@@ -12308,7 +12308,7 @@
         },
         {
             "id": "5e7411c1-4f90-5ab5-967a-6732000467e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7381c-c745-458c-bf55-457242781a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea7381c-c745-458c-bf55-457242781a09.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand.\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -12353,7 +12353,7 @@
         },
         {
             "id": "03897f17-8cf5-54a1-b020-be3b812feee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fa5a00-34d3-4ca4-afb9-62ab1c7afb14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fa5a00-34d3-4ca4-afb9-62ab1c7afb14.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "",
             "colours": [
@@ -12397,7 +12397,7 @@
         },
         {
             "id": "895798fd-83cd-5b9a-8523-1784c3a526c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9889ab-3527-414e-9c30-539f0608bd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9889ab-3527-414e-9c30-539f0608bd2b.jpg?1",
             "name": "Commercial District",
             "text": "Commercial District enters the battlefield tapped.\nWhen Commercial District enters the battlefield, surveil 1.",
             "colours": [],
@@ -12433,7 +12433,7 @@
         },
         {
             "id": "dcaef4cf-fc2e-55d6-a5ca-2ecd27b8cfb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0cef88-50bd-4baa-8d02-26ec4967a7be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0cef88-50bd-4baa-8d02-26ec4967a7be.jpg?1",
             "name": "Elegant Parlor",
             "text": "Elegant Parlor enters the battlefield tapped.\nWhen Elegant Parlor enters the battlefield, surveil 1.",
             "colours": [],
@@ -12469,7 +12469,7 @@
         },
         {
             "id": "20a8cb94-2afe-5cc8-aadb-3ef30a98c4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee215175-d48b-4630-a1b1-36e195db05dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee215175-d48b-4630-a1b1-36e195db05dd.jpg?1",
             "name": "Hedge Maze",
             "text": "Hedge Maze enters the battlefield tapped.\nWhen Hedge Maze enters the battlefield, surveil 1.",
             "colours": [],
@@ -12505,7 +12505,7 @@
         },
         {
             "id": "3f720e0a-e565-5ab4-bdfe-4d2cb832e0e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bd2920-9fbf-4853-ace3-66cd7015de32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bd2920-9fbf-4853-ace3-66cd7015de32.jpg?1",
             "name": "Lush Portico",
             "text": "Lush Portico enters the battlefield tapped.\nWhen Lush Portico enters the battlefield, surveil 1.",
             "colours": [],
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "82cfe850-83cd-5ec4-908f-e2d95fc271d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d4ba4b-03f3-4e64-b4e7-8c025fc70178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d4ba4b-03f3-4e64-b4e7-8c025fc70178.jpg?1",
             "name": "Meticulous Archive",
             "text": "Meticulous Archive enters the battlefield tapped.\nWhen Meticulous Archive enters the battlefield, surveil 1.",
             "colours": [],
@@ -12577,7 +12577,7 @@
         },
         {
             "id": "b84d24ab-094d-538d-8591-7d5a19a8b8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf0337-c7a3-45a0-bb14-c431526da2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faf0337-c7a3-45a0-bb14-c431526da2cd.jpg?1",
             "name": "Raucous Theater",
             "text": "Raucous Theater enters the battlefield tapped.\nWhen Raucous Theater enters the battlefield, surveil 1.",
             "colours": [],
@@ -12613,7 +12613,7 @@
         },
         {
             "id": "204c60c9-ccd5-554d-b1e5-663cefe565d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eae4ce-e0b3-482b-9136-6fc17333877e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27eae4ce-e0b3-482b-9136-6fc17333877e.jpg?1",
             "name": "Shadowy Backstreet",
             "text": "Shadowy Backstreet enters the battlefield tapped.\nWhen Shadowy Backstreet enters the battlefield, surveil 1.",
             "colours": [],
@@ -12649,7 +12649,7 @@
         },
         {
             "id": "dbb66a3b-8609-5de9-b949-a178a7864baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1792e4-2170-42ae-a335-fde6f5ef8932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1792e4-2170-42ae-a335-fde6f5ef8932.jpg?1",
             "name": "Thundering Falls",
             "text": "Thundering Falls enters the battlefield tapped.\nWhen Thundering Falls enters the battlefield, surveil 1.",
             "colours": [],
@@ -12685,7 +12685,7 @@
         },
         {
             "id": "300ef52d-06c0-5fc2-b41d-3ead553bacf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3239a1e5-a002-4389-b9a7-049b1d60e2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3239a1e5-a002-4389-b9a7-049b1d60e2ac.jpg?1",
             "name": "Undercity Sewers",
             "text": "Undercity Sewers enters the battlefield tapped.\nWhen Undercity Sewers enters the battlefield, surveil 1.",
             "colours": [],
@@ -12721,7 +12721,7 @@
         },
         {
             "id": "0a5b834f-4142-560c-80c2-c5b7c3d845f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8938e4-bfa5-47e1-8c71-9c6583346300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8938e4-bfa5-47e1-8c71-9c6583346300.jpg?1",
             "name": "Underground Mortuary",
             "text": "Underground Mortuary enters the battlefield tapped.\nWhen Underground Mortuary enters the battlefield, surveil 1.",
             "colours": [],
@@ -12757,7 +12757,7 @@
         },
         {
             "id": "cb1ac85a-c77c-55fd-a2a2-ed22f0c0d402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Flying, vigilance\nWhenever Kellan, Inquisitive Prodigy attacks, destroy up to one target artifact. If you controlled that permanent, draw a card.",
             "colours": [
@@ -12799,7 +12799,7 @@
         },
         {
             "id": "9962fa93-b09f-5d6f-a22e-887214c324b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f60fcb1e-6136-4330-ae9b-57742fbb114f.jpg?1",
             "name": "Kellan, Inquisitive Prodigy // Tail the Suspect",
             "text": "Investigate. You may play an additional land this turn.",
             "colours": [
@@ -12837,7 +12837,7 @@
         },
         {
             "id": "44dc9146-abc7-5f55-a3c0-9966a7531888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9acee3-12b7-41c6-8a5c-7985d052bc7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9acee3-12b7-41c6-8a5c-7985d052bc7a.jpg?1",
             "name": "Kaya, Spirits' Justice",
             "text": "Whenever one or more creatures you control and/or creature cards in your graveyard are put into exile, you may choose a creature card from among them. Until end of turn, target token you control becomes a copy of it, except it has flying.\n+2: Surveil 2, then exile a card from a graveyard.\n+1: Create a 1/1 white and black Spirit creature token with flying.\n\u22122: Exile target creature you control. For each other player, exile up to one target creature that player controls.",
             "colours": [
@@ -12877,7 +12877,7 @@
         },
         {
             "id": "23c1c826-4963-5519-a567-2395368ff089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975b5145-b30e-4ae3-b318-3b245bf12cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975b5145-b30e-4ae3-b318-3b245bf12cc3.jpg?1",
             "name": "Aurelia's Vindicator",
             "text": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -12914,7 +12914,7 @@
         },
         {
             "id": "512b27e6-dcc9-595c-8fce-86adf71d6d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6297104-b73c-439c-ac0c-b7fac01d49dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6297104-b73c-439c-ac0c-b7fac01d49dc.jpg?1",
             "name": "Delney, Streetwise Lookout",
             "text": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
             "colours": [
@@ -12954,7 +12954,7 @@
         },
         {
             "id": "392acb88-371d-5e53-9f32-c668cbfd33c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd24cf-ee30-4a05-a473-f3ec589c35dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61cd24cf-ee30-4a05-a473-f3ec589c35dd.jpg?1",
             "name": "Doorkeeper Thrull",
             "text": "Flash\nFlying\nArtifacts and creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "d772a586-5d4f-5716-b818-ee751d82882c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d12e748-e8d6-42d2-b501-c39cfcd6551d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d12e748-e8d6-42d2-b501-c39cfcd6551d.jpg?1",
             "name": "Neighborhood Guardian",
             "text": "Whenever another creature with power 2 or less enters the battlefield under your control, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -13026,7 +13026,7 @@
         },
         {
             "id": "0a6bd12e-1f39-5ec3-8784-552f70a78fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481b5d9a-872d-4a2f-a52a-d4a746ee04ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481b5d9a-872d-4a2f-a52a-d4a746ee04ab.jpg?1",
             "name": "Wojek Investigator",
             "text": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you.",
             "colours": [
@@ -13065,7 +13065,7 @@
         },
         {
             "id": "5fd6dce7-4df7-5bb0-a582-6b0ec31a3271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a33f43e-e57e-4d2c-b6f3-c785ab96214e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a33f43e-e57e-4d2c-b6f3-c785ab96214e.jpg?1",
             "name": "Conspiracy Unraveler",
             "text": "Flying\nYou may collect evidence 10 rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -13103,7 +13103,7 @@
         },
         {
             "id": "c272dd32-59fb-51dc-aa0e-55baf52ffc5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab507e5-7bf2-4fa0-9ac0-a6aaec90de83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab507e5-7bf2-4fa0-9ac0-a6aaec90de83.jpg?1",
             "name": "Forensic Gadgeteer",
             "text": "Whenever you cast an artifact spell, investigate.\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
             "colours": [
@@ -13141,7 +13141,7 @@
         },
         {
             "id": "cef5cd9a-2261-5d83-ac5b-b19cf1741018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9106abf-f589-48a2-90f8-d606a7367377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9106abf-f589-48a2-90f8-d606a7367377.jpg?1",
             "name": "Homicide Investigator",
             "text": "Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn.",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "639e8b17-6f48-59cf-a8b7-8774f8eb9153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab741b3-6230-46c3-9c43-8a0d735e9d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab741b3-6230-46c3-9c43-8a0d735e9d49.jpg?1",
             "name": "Massacre Girl, Known Killer",
             "text": "Menace\nCreatures you control have wither.\nWhenever a creature an opponent controls dies, if its toughness was less than 1, draw a card.",
             "colours": [
@@ -13218,7 +13218,7 @@
         },
         {
             "id": "a15b18bf-0d3c-55e5-b84c-e481af71944e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c134956-ba18-415e-b101-c1254415ea04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c134956-ba18-415e-b101-c1254415ea04.jpg?1",
             "name": "Persuasive Interrogators",
             "text": "When Persuasive Interrogators enters the battlefield, investigate.\nWhenever you sacrifice a Clue, target opponent gets two poison counters.",
             "colours": [
@@ -13255,7 +13255,7 @@
         },
         {
             "id": "4022642f-03a5-5f77-9e0b-9db5cacd63a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65121bff-89f0-436d-89a5-b8191dc91891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65121bff-89f0-436d-89a5-b8191dc91891.jpg?1",
             "name": "Vein Ripper",
             "text": "Flying\nWard\u2014\nSacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -13293,7 +13293,7 @@
         },
         {
             "id": "86298311-372c-58ab-9317-3d79ddb3d142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae07b33-dcee-41aa-9886-38336d2aff7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae07b33-dcee-41aa-9886-38336d2aff7a.jpg?1",
             "name": "Frantic Scapegoat",
             "text": "Haste\nWhen Frantic Scapegoat enters the battlefield, suspect it.\nWhenever one or more other creatures enter the battlefield under your control, if Frantic Scapegoat is suspected, you may suspect one of the other creatures. If you do, Frantic Scapegoat is no longer suspected.",
             "colours": [
@@ -13329,7 +13329,7 @@
         },
         {
             "id": "8ce83935-bda4-5055-9635-9b5686dad7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbb3378-291c-4de6-be98-dd09daa3b828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbb3378-291c-4de6-be98-dd09daa3b828.jpg?1",
             "name": "Fugitive Codebreaker",
             "text": "Prowess, haste\nDisguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard.\nWhen Fugitive Codebreaker is turned face up, discard your hand, then draw three cards.",
             "colours": [
@@ -13366,7 +13366,7 @@
         },
         {
             "id": "4741baea-a6b0-5825-a2f1-79d06e8a8e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874659c8-43e2-4298-844a-510f2b21830c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874659c8-43e2-4298-844a-510f2b21830c.jpg?1",
             "name": "Incinerator of the Guilty",
             "text": "Flying, trample\nWhenever Incinerator of the Guilty deals combat damage to a player, you may collect evidence X. When you do, Incinerator of the Guilty deals X damage to each creature and each planeswalker that player controls.",
             "colours": [
@@ -13403,7 +13403,7 @@
         },
         {
             "id": "f1cd2751-bb61-5e51-8942-5ed8a40a815c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f3c6-934a-4819-8057-b8c80f2a8696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe8f3c6-934a-4819-8057-b8c80f2a8696.jpg?1",
             "name": "Krenko, Baron of Tin Street",
             "text": "Haste\n{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control.\nWhenever an artifact is put into a graveyard from the battlefield, you may pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn.",
             "colours": [
@@ -13441,7 +13441,7 @@
         },
         {
             "id": "02d27163-fd8f-516a-94cf-cfc735ae38f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82849769-ee1b-4f70-935c-9cb97772ade1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82849769-ee1b-4f70-935c-9cb97772ade1.jpg?1",
             "name": "Culvert Ambusher",
             "text": "When Culvert Ambusher enters the battlefield or is turned face up, target creature blocks this turn if able.\nDisguise {4}{G}",
             "colours": [
@@ -13478,7 +13478,7 @@
         },
         {
             "id": "41dc7925-75ad-5cdc-a5a4-4e323afdda96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8bdb03-02d0-4b97-b058-959f1fff9118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8bdb03-02d0-4b97-b058-959f1fff9118.jpg?1",
             "name": "The Pride of Hull Clade",
             "text": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
             "colours": [
@@ -13520,7 +13520,7 @@
         },
         {
             "id": "9083d91a-61ed-5a06-a534-dc5bf8d247d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b1b18-179d-48e1-ab8a-9374eb1ae429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2b1b18-179d-48e1-ab8a-9374eb1ae429.jpg?1",
             "name": "Sharp-Eyed Rookie",
             "text": "Vigilance\nWhenever a creature enters the battlefield under your control, if its power is greater than Sharp-Eyed Rookie's power or its toughness is greater than Sharp-Eyed Rookie's toughness, put a +1/+1 counter on Sharp-Eyed Rookie and investigate.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "0face518-45ff-5254-a9aa-b7b3ca850303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2d61c-194a-482b-9c59-6800d6cc3a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2d61c-194a-482b-9c59-6800d6cc3a5b.jpg?1",
             "name": "Agrus Kos, Spirit of Justice",
             "text": "Double strike, vigilance\nWhenever Agrus Kos, Spirit of Justice enters the battlefield or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it.",
             "colours": [
@@ -13599,7 +13599,7 @@
         },
         {
             "id": "588cd5fe-e08f-5851-9878-383d946f20a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e528424e-a3b1-4902-b42d-1ba9ac412e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e528424e-a3b1-4902-b42d-1ba9ac412e73.jpg?1",
             "name": "Alquist Proft, Master Sleuth",
             "text": "Vigilance\nWhen Alquist Proft, Master Sleuth enters the battlefield, investigate.\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
             "colours": [
@@ -13641,7 +13641,7 @@
         },
         {
             "id": "c676ee72-94ab-55e1-b874-595540a305fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba703ed8-3c5e-479f-b7f1-b8070d4f83b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba703ed8-3c5e-479f-b7f1-b8070d4f83b7.jpg?1",
             "name": "Anzrag, the Quake-Mole",
             "text": "Whenever Anzrag, the Quake-Mole becomes blocked, untap each creature you control. After this combat phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
             "colours": [
@@ -13683,7 +13683,7 @@
         },
         {
             "id": "e8289052-bbba-52b6-9f96-2e56050cb357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5598d3-b66b-42a2-aa43-d2785c1bfe36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5598d3-b66b-42a2-aa43-d2785c1bfe36.jpg?1",
             "name": "Aurelia, the Law Above",
             "text": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia, the Law Above deals 3 damage to each of your opponents and you gain 3 life.",
             "colours": [
@@ -13725,7 +13725,7 @@
         },
         {
             "id": "4de85fb8-6935-5f07-8f51-4ae8ab44064e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf5e45d-0f1a-4c85-a944-770fc525dc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf5e45d-0f1a-4c85-a944-770fc525dc01.jpg?1",
             "name": "Curious Cadaver",
             "text": "Flying\nWhen you sacrifice a Clue, return Curious Cadaver from your graveyard to your hand.",
             "colours": [
@@ -13764,7 +13764,7 @@
         },
         {
             "id": "4389a678-30d0-51af-ad7b-a3848d1f6e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01cf59e-b98b-4a8d-8347-07e2c1527330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01cf59e-b98b-4a8d-8347-07e2c1527330.jpg?1",
             "name": "Etrata, Deadly Fugitive",
             "text": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library.",
             "colours": [
@@ -13806,7 +13806,7 @@
         },
         {
             "id": "d543fd1b-5d42-5c04-9a07-5cbac9d03a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f05677b-ceec-4774-b22f-ff95cc6c5943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f05677b-ceec-4774-b22f-ff95cc6c5943.jpg?1",
             "name": "Ezrim, Agency Chief",
             "text": "Flying\nWhen Ezrim, Agency Chief enters the battlefield, investigate twice.\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.",
             "colours": [
@@ -13847,7 +13847,7 @@
         },
         {
             "id": "f361b1d2-f16e-58b1-8ee5-4eabfe738ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387e53fd-58b2-45ac-a604-531b75442732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387e53fd-58b2-45ac-a604-531b75442732.jpg?1",
             "name": "Gleaming Geardrake",
             "text": "Flying\nWhen Gleaming Geardrake enters the battlefield, investigate.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.",
             "colours": [
@@ -13887,7 +13887,7 @@
         },
         {
             "id": "0fedf47e-b1c0-5d35-90c3-842de46accc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c5f282-9297-4763-a04d-4147e5349953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34c5f282-9297-4763-a04d-4147e5349953.jpg?1",
             "name": "Izoni, Center of the Web",
             "text": "Menace\nWhenever Izoni, Center of the Web enters the battlefield or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with menace and reach.\nSacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life.",
             "colours": [
@@ -13928,7 +13928,7 @@
         },
         {
             "id": "7f4e33bc-bc6d-5c49-bf34-411a3db79f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc220d51-b545-4414-9f2e-d3bfe53dcbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc220d51-b545-4414-9f2e-d3bfe53dcbd8.jpg?1",
             "name": "Judith, Carnage Connoisseur",
             "text": "Whenever you cast an instant or sorcery spell, choose one \u2014\n\u2022 That spell gains deathtouch and lifelink.\n\u2022 Create a 2/2 red Imp creature token with \"When this creature dies, it deals 2 damage to each opponent.\"",
             "colours": [
@@ -13969,7 +13969,7 @@
         },
         {
             "id": "76e21be4-0699-56b5-a922-f63c90f5b343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70bb7a-ba29-4fa5-b5f7-e2c71ca7df6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70bb7a-ba29-4fa5-b5f7-e2c71ca7df6f.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "Reach\nWhen Kraul Whipcracker enters the battlefield, destroy target token an opponent controls.",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "d553b2b0-692f-556c-b186-7e15ea50ac30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2260036c-cc6f-4016-8d8c-4953ce5b22d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2260036c-cc6f-4016-8d8c-4953ce5b22d3.jpg?1",
             "name": "Kylox, Visionary Inventor",
             "text": "Menace, ward {2}, haste\nWhenever Kylox, Visionary Inventor attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs.",
             "colours": [
@@ -14051,7 +14051,7 @@
         },
         {
             "id": "fc44bfe5-43b3-51f2-bbf7-8ca83ee3fee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd1791b-f12f-4e76-8276-cb1905bd2e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd1791b-f12f-4e76-8276-cb1905bd2e33.jpg?1",
             "name": "Lazav, Wearer of Faces",
             "text": "Whenever Lazav, Wearer of Faces attacks, exile target card from a graveyard, then investigate.\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
             "colours": [
@@ -14094,7 +14094,7 @@
         },
         {
             "id": "a6f1af62-fa44-53d7-ae08-3329313feb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d1e216-a150-4f57-bd1c-8c8c86023c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d1e216-a150-4f57-bd1c-8c8c86023c6d.jpg?1",
             "name": "Meddling Youths",
             "text": "Haste\nWhenever you attack with three or more creatures, investigate.",
             "colours": [
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "bb05a407-c711-5b08-b6c3-647aa4579006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f2fcaf-97d6-441a-bdde-fb105ffad1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f2fcaf-97d6-441a-bdde-fb105ffad1c5.jpg?1",
             "name": "Niv-Mizzet, Guildpact",
             "text": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet, Guildpact deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
             "colours": [
@@ -14182,7 +14182,7 @@
         },
         {
             "id": "30dd664c-476b-50fb-9e0a-74eb916f7abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5f435-144e-4466-be0f-781664cfddb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5f435-144e-4466-be0f-781664cfddb7.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -14225,7 +14225,7 @@
         },
         {
             "id": "c45c1acd-e0c0-56e3-846d-bb08b98bb009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0870d4-b5b8-4fd7-a21b-417f832e0d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba0870d4-b5b8-4fd7-a21b-417f832e0d7e.jpg?1",
             "name": "Teysa, Opulent Oligarch",
             "text": "Deathtouch\nAt the beginning of your end step, investigate for each opponent who lost life this turn.\nWhenever a Clue you control is put into a graveyard from the battlefield, create a 1/1 white and black Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -14268,7 +14268,7 @@
         },
         {
             "id": "f86fe1a2-029e-57aa-bfdd-ea3d82fd0208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acaae58-93b5-4544-84cc-98e134edb738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acaae58-93b5-4544-84cc-98e134edb738.jpg?1",
             "name": "Tolsimir, Midnight's Light",
             "text": "Lifelink\nWhen Tolsimir, Midnight's Light enters the battlefield, create Voja Fenstalker, a legendary 5/5 green and white Wolf creature token with trample.\nWhenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an opponent controls blocks that Wolf this combat if able.",
             "colours": [
@@ -14309,7 +14309,7 @@
         },
         {
             "id": "e8a62ad7-1a63-5ecf-8bfd-cb002c0d92aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839ff656-1886-4b31-8d72-dde696258a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839ff656-1886-4b31-8d72-dde696258a97.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -14352,7 +14352,7 @@
         },
         {
             "id": "17e08a2c-ca21-5c38-bbed-ded812de9974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0df81e-1700-41f0-bede-f3eb594351b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0df81e-1700-41f0-bede-f3eb594351b6.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand.\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "bc71f91a-8de0-5c7f-b240-11d3760d029c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74463d05-3928-4d55-84d4-21d65623a3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74463d05-3928-4d55-84d4-21d65623a3e6.jpg?1",
             "name": "Wispdrinker Vampire",
             "text": "Flying\nWhenever another creature with power 2 or less enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.\n{5}{W}{B}: Creatures you control with power 2 or less gain deathtouch and lifelink until end of turn.",
             "colours": [
@@ -14436,7 +14436,7 @@
         },
         {
             "id": "917e86d5-ad51-54ee-b451-f902da977528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2230bda5-42a9-40fa-bda4-1eabab5675f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2230bda5-42a9-40fa-bda4-1eabab5675f4.jpg?1",
             "name": "Yarus, Roar of the Old Gods",
             "text": "Other creatures you control have haste.\nWhenever one or more face-down creatures you control deal combat damage to a player, draw a card.\nWhenever a face-down creature you control dies, return it to the battlefield face down under its owner's control if it's a permanent card, then turn it face up.",
             "colours": [
@@ -14477,7 +14477,7 @@
         },
         {
             "id": "d05632f5-7d3b-5a9d-aba3-cc76eccd0679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9a827-b41d-4628-95e1-6546a8140c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9a827-b41d-4628-95e1-6546a8140c61.jpg?1",
             "name": "Magnetic Snuffler",
             "text": "When Magnetic Snuffler enters the battlefield, return target Equipment card from your graveyard to the battlefield attached to Magnetic Snuffler.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Magnetic Snuffler.",
             "colours": [],
@@ -14510,7 +14510,7 @@
         },
         {
             "id": "18945240-3690-5a88-b29a-1a751b73a492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd20526-024a-4a08-8f86-f5d7c2d7e8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd20526-024a-4a08-8f86-f5d7c2d7e8e7.jpg?1",
             "name": "Aurelia's Vindicator",
             "text": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen Aurelia's Vindicator is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Aurelia's Vindicator leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -14546,7 +14546,7 @@
         },
         {
             "id": "6ca947fe-9e66-58b1-8f19-7094899acdc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063654b-6e4e-4958-a63c-24cf933e4a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0063654b-6e4e-4958-a63c-24cf933e4a40.jpg?1",
             "name": "Delney, Streetwise Lookout",
             "text": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
             "colours": [
@@ -14585,7 +14585,7 @@
         },
         {
             "id": "1c1c6134-5640-5605-af50-55ca8d09e88d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8002174-8cff-4566-ba4d-d6caec14d69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8002174-8cff-4566-ba4d-d6caec14d69c.jpg?1",
             "name": "Conspiracy Unraveler",
             "text": "Flying\nYou may collect evidence 10 rather than pay the mana cost for spells that you cast.",
             "colours": [
@@ -14622,7 +14622,7 @@
         },
         {
             "id": "1f3563fa-905a-5499-8742-23cd860ebcb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae24a4c2-6a19-4e26-902a-cdf73d9f3608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae24a4c2-6a19-4e26-902a-cdf73d9f3608.jpg?1",
             "name": "Massacre Girl, Known Killer",
             "text": "",
             "colours": [
@@ -14661,7 +14661,7 @@
         },
         {
             "id": "21c51c89-fbab-55c3-8f99-6e46b29d5726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321fe5e9-50c4-4b96-883a-2d9b10f2172f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321fe5e9-50c4-4b96-883a-2d9b10f2172f.jpg?1",
             "name": "Incinerator of the Guilty",
             "text": "Flying, trample\nWhenever Incinerator of the Guilty deals combat damage to a player, you may collect evidence X. When you do, Incinerator of the Guilty deals X damage to each creature and each planeswalker that player controls.",
             "colours": [
@@ -14697,7 +14697,7 @@
         },
         {
             "id": "d49acd18-d7b7-513f-aaad-24b5a95424e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99027565-f009-48d6-a7d0-fec1afff0611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99027565-f009-48d6-a7d0-fec1afff0611.jpg?1",
             "name": "The Pride of Hull Clade",
             "text": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
             "colours": [
@@ -14738,7 +14738,7 @@
         },
         {
             "id": "9011ef5c-a7ae-5896-bbd7-6a7a1ed434ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fc7b85-a321-4259-9fe6-a107d6d79819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fc7b85-a321-4259-9fe6-a107d6d79819.jpg?1",
             "name": "Agrus Kos, Spirit of Justice",
             "text": "Double strike, vigilance\nWhenever Agrus Kos, Spirit of Justice enters the battlefield or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it.",
             "colours": [
@@ -14779,7 +14779,7 @@
         },
         {
             "id": "389f6c13-4d1e-5eb8-a04a-748ccb1ec012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c4f8d2-1e9c-41e1-9991-8125cd7151a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c4f8d2-1e9c-41e1-9991-8125cd7151a5.jpg?1",
             "name": "Alquist Proft, Master Sleuth",
             "text": "Vigilance\nWhen Alquist Proft, Master Sleuth enters the battlefield, investigate.\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
             "colours": [
@@ -14820,7 +14820,7 @@
         },
         {
             "id": "3380cfac-b949-5f5a-a974-f66f6a835e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c7933b-a65a-4032-a652-1a29b26de2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c7933b-a65a-4032-a652-1a29b26de2c8.jpg?1",
             "name": "Anzrag, the Quake-Mole",
             "text": "Whenever Anzrag, the Quake-Mole becomes blocked, untap each creature you control. After this combat phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
             "colours": [
@@ -14861,7 +14861,7 @@
         },
         {
             "id": "272ea0d9-3881-5ea8-8f9b-4cacbe7717d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b70f7a-8e77-4a99-8d13-7465a190630e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b70f7a-8e77-4a99-8d13-7465a190630e.jpg?1",
             "name": "Etrata, Deadly Fugitive",
             "text": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library.",
             "colours": [
@@ -14902,7 +14902,7 @@
         },
         {
             "id": "bbb93d2d-657c-5a4b-bcb0-5ff9eddb988a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8ed51-897f-4587-a234-dd3e051fab3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8ed51-897f-4587-a234-dd3e051fab3f.jpg?1",
             "name": "Rakdos, Patron of Chaos",
             "text": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents. If they don't, you draw two cards.",
             "colours": [
@@ -14944,7 +14944,7 @@
         },
         {
             "id": "e118125c-23c4-57d8-96da-d7a414262664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe1969-e30c-4f07-90b0-3d9699a09f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe1969-e30c-4f07-90b0-3d9699a09f1b.jpg?1",
             "name": "Trostani, Three Whispers",
             "text": "{1}{G}: Target creature gains deathtouch until end of turn.\n{RW}: Target creature gains vigilance until end of turn.\n{2}{W}: Target creature gains double strike until end of turn.",
             "colours": [
@@ -14986,7 +14986,7 @@
         },
         {
             "id": "9f3e53e7-4236-5901-b8c2-bf0dcb290714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1b9d5f-fb88-49ea-ab56-ea6e78ea2077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1b9d5f-fb88-49ea-ab56-ea6e78ea2077.jpg?1",
             "name": "Vannifar, Evolved Enigma",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Cloak a card from your hand.\n\u2022 Put a +1/+1 counter on each colorless creature you control.",
             "colours": [
@@ -15030,7 +15030,7 @@
         },
         {
             "id": "1dbeb71c-d9fd-5bf1-a6d3-1def6660859e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d327d7d-1c01-4af1-8a6f-ce6cded4119d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d327d7d-1c01-4af1-8a6f-ce6cded4119d.jpg?1",
             "name": "No Witnesses",
             "text": "Each player who controls the most creatures investigates. Then destroy all creatures.",
             "colours": [
@@ -15064,7 +15064,7 @@
         },
         {
             "id": "91947789-1ea5-5b27-babe-bcd073eb20a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2adffd5-ddc1-41ef-9442-2fbc17153f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2adffd5-ddc1-41ef-9442-2fbc17153f3d.jpg?1",
             "name": "Tenth District Hero",
             "text": "{1}{W}, Collect evidence 2: Tenth District Hero becomes a Human Detective with base power and toughness 4/4 and gains vigilance.\n{2}{W}, Collect evidence 4: If Tenth District Hero is a Detective, it becomes a legendary creature named Mileva, the Stalwart, it has base power and toughness 5/5, and it gains \"Other creatures you control have indestructible.\"",
             "colours": [
@@ -15100,7 +15100,7 @@
         },
         {
             "id": "3b380219-8526-520b-b035-08e5989064ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349bcef-4ec5-4160-96ef-302d825f3888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349bcef-4ec5-4160-96ef-302d825f3888.jpg?1",
             "name": "Unyielding Gatekeeper",
             "text": "Disguise {1}{W}\nWhen Unyielding Gatekeeper is turned face up, exile another target nonland permanent. If you controlled it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue Detective creature token.",
             "colours": [
@@ -15137,7 +15137,7 @@
         },
         {
             "id": "e936ceb6-0fab-570a-9ab1-e79de43697cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e5b027-7cd5-4343-b029-f4d197e1f1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e5b027-7cd5-4343-b029-f4d197e1f1da.jpg?1",
             "name": "Coveted Falcon",
             "text": "Flying\nWhenever Coveted Falcon attacks, gain control of target permanent you own but don\u2018t control.\nDisguise {1}{U}\nWhen Coveted Falcon is turned face up, target opponent gains control of any number of target permanents you control. Draw a card for each one they gained control of this way.",
             "colours": [
@@ -15174,7 +15174,7 @@
         },
         {
             "id": "4b3af3c7-1043-5ad5-8e51-8c488223a032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3faa376-7391-4084-8b57-15d71ab07cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3faa376-7391-4084-8b57-15d71ab07cbd.jpg?1",
             "name": "Cryptic Coat",
             "text": "When Cryptic Coat enters the battlefield, cloak the top card of your library, then attach Cryptic Coat to it.\nEquipped creature gets +1/+0 and can't be blocked.\n{1}{U}: Return Cryptic Coat to its owner's hand.",
             "colours": [
@@ -15210,7 +15210,7 @@
         },
         {
             "id": "d91f6dbc-9a1a-5c29-82a3-d0a32743f865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5a56a-3017-4f08-802d-e6f9d246c754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a5a56a-3017-4f08-802d-e6f9d246c754.jpg?1",
             "name": "Lost in the Maze",
             "text": "Flash\nWhen Lost in the Maze enters the battlefield, tap X target creatures. Put a stun counter on each of those creatures you don't control.\nTapped creatures you control have hexproof.",
             "colours": [
@@ -15244,7 +15244,7 @@
         },
         {
             "id": "ae89a0da-5dc2-5e27-8c36-dd5456a61fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3472756-0305-4567-b425-f7dbf9b3cc7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3472756-0305-4567-b425-f7dbf9b3cc7f.jpg?1",
             "name": "Proft's Eidetic Memory",
             "text": "When Proft's Eidetic Memory enters the battlefield, draw a card.\nYou have no maximum hand size.\nAt the beginning of combat on your turn, if you've drawn more than one card this turn, put X +1/+1 counters on target creature you control, where X is the number of cards you've drawn this turn minus one.",
             "colours": [
@@ -15280,7 +15280,7 @@
         },
         {
             "id": "29bed373-b1ce-5dfc-abba-92db55431d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f0ac41-3f03-4480-aea8-41ec0a024671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f0ac41-3f03-4480-aea8-41ec0a024671.jpg?1",
             "name": "Steamcore Scholar",
             "text": "Flying, vigilance\nWhen Steamcore Scholar enters the battlefield, draw two cards. Then discard two cards unless you discard an instant or sorcery card or a creature card with flying.",
             "colours": [
@@ -15317,7 +15317,7 @@
         },
         {
             "id": "b77e225b-12af-5999-aa1e-18d401171a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7330586a-9614-4373-b455-ee5fb09ed262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7330586a-9614-4373-b455-ee5fb09ed262.jpg?1",
             "name": "Barbed Servitor",
             "text": "Indestructible\nWhen Barbed Servitor enters the battlefield, suspect it.\nWhenever Barbed Servitor deals combat damage to a player, you draw a card and you lose 1 life.\nWhenever Barbed Servitor is dealt damage, target opponent loses that much life.",
             "colours": [
@@ -15354,7 +15354,7 @@
         },
         {
             "id": "0bff19db-6c74-5290-af82-2067e737a075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f667e6-c27d-4055-8ddb-ea6cbcde6e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f667e6-c27d-4055-8ddb-ea6cbcde6e4e.jpg?1",
             "name": "Deadly Cover-Up",
             "text": "As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -15388,7 +15388,7 @@
         },
         {
             "id": "d866142c-a604-52c2-bbae-4b4875191f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edff2c6-a259-4442-9e21-07572d0d1665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edff2c6-a259-4442-9e21-07572d0d1665.jpg?1",
             "name": "Hunted Bonebrute",
             "text": "Menace\nWhen Hunted Bonebrute enters the battlefield, target opponent creates two 1/1 white Dog creature tokens.\nWhen Hunted Bonebrute dies, each opponent loses 3 life.\nDisguise {1}{B}",
             "colours": [
@@ -15425,7 +15425,7 @@
         },
         {
             "id": "c3f39291-299e-564b-a96a-91eaf8b72f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436f52c-b780-4d16-a62f-e1b339356a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436f52c-b780-4d16-a62f-e1b339356a39.jpg?1",
             "name": "Illicit Masquerade",
             "text": "Flash\nWhen Illicit Masquerade enters the battlefield, put an impostor counter on each creature you control.\nWhenever a creature you control with an impostor counter on it dies, exile it. Return up to one other target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -15459,7 +15459,7 @@
         },
         {
             "id": "4e580ab1-04ad-54ed-8f98-fac4e54e4fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d8304d-59e3-4478-911d-54d77abfe69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d8304d-59e3-4478-911d-54d77abfe69c.jpg?1",
             "name": "Outrageous Robbery",
             "text": "Target opponent exiles the top X cards of their library face down. You may look at and play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any type to cast it.",
             "colours": [
@@ -15493,7 +15493,7 @@
         },
         {
             "id": "46806453-9d9c-533c-9019-861e6f11b782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597b8c60-d06b-425b-9fca-f2e3dfb45623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597b8c60-d06b-425b-9fca-f2e3dfb45623.jpg?1",
             "name": "Connecting the Dots",
             "text": "Whenever a creature you control attacks, exile the top card of your library face down. (You can't look at it.)\n{1}{R}, Discard your hand, Sacrifice Connecting the Dots: Put all cards exiled with Connecting the Dots into their owners' hands.",
             "colours": [
@@ -15527,7 +15527,7 @@
         },
         {
             "id": "75c0892d-9c6a-558e-b6c7-a4c6f7947588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538c112a-203e-4b3e-ae1d-6eb7824fe68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538c112a-203e-4b3e-ae1d-6eb7824fe68a.jpg?1",
             "name": "Expedited Inheritance",
             "text": "Whenever a creature is dealt damage, its controller may exile that many cards from the top of their library. They may play those cards until the end of their next turn.",
             "colours": [
@@ -15561,7 +15561,7 @@
         },
         {
             "id": "cad1b7b1-0f9a-5df7-ab83-9debe71cbcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebec98c-a935-48c3-ba2f-80c70079929d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ebec98c-a935-48c3-ba2f-80c70079929d.jpg?1",
             "name": "Krenko's Buzzcrusher",
             "text": "Flying, trample\nWhen Krenko's Buzzcrusher enters the battlefield, for each player, destroy up to one nonbasic land that player controls. For each land destroyed this way, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -15599,7 +15599,7 @@
         },
         {
             "id": "5764c446-1f0e-53d0-8d7a-a7617d94eca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9549ad7-5eb3-4672-a0f5-cad96db011c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9549ad7-5eb3-4672-a0f5-cad96db011c3.jpg?1",
             "name": "Lamplight Phoenix",
             "text": "Flying\nWhen Lamplight Phoenix dies, you may exile it and collect evidence 4. If you do, return Lamplight Phoenix to the battlefield tapped.",
             "colours": [
@@ -15635,7 +15635,7 @@
         },
         {
             "id": "136501dc-d51b-5509-8c6b-5933c53af7a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348027a1-1fb4-4473-b77e-b961e00a22b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348027a1-1fb4-4473-b77e-b961e00a22b7.jpg?1",
             "name": "Pyrotechnic Performer",
             "text": "Disguise {R}\nWhenever Pyrotechnic Performer or another creature you control is turned face up, that creature deals damage equal to its power to each opponent.",
             "colours": [
@@ -15672,7 +15672,7 @@
         },
         {
             "id": "be902e97-71ef-5f94-89c4-83fcc3c652c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c2c17b-889b-416b-af58-c4039efec2bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c2c17b-889b-416b-af58-c4039efec2bb.jpg?1",
             "name": "Archdruid's Charm",
             "text": "Choose one \u2014\n\u2022 Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n\u2022 Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control.\n\u2022 Exile target artifact or enchantment.",
             "colours": [
@@ -15706,7 +15706,7 @@
         },
         {
             "id": "86bec418-7629-5d69-85c7-ac4db035d5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a057ac-c9f9-4cf6-896f-e18976bdfb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a057ac-c9f9-4cf6-896f-e18976bdfb38.jpg?1",
             "name": "Axebane Ferox",
             "text": "Deathtouch, haste\nWard\u2014\nCollect evidence 4.",
             "colours": [
@@ -15743,7 +15743,7 @@
         },
         {
             "id": "e1666bfc-6467-5948-b1a8-595b90d4698d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c69f3-3c83-41e9-b389-21235a2dc5cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d2c69f3-3c83-41e9-b389-21235a2dc5cd.jpg?1",
             "name": "Hide in Plain Sight",
             "text": "Look at the top five cards of your library, cloak two of them, and put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -15777,7 +15777,7 @@
         },
         {
             "id": "d7dec1eb-d192-5430-89b8-1c1c700b601d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c0e63c-ca4e-4991-89f1-dc4c22189372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c0e63c-ca4e-4991-89f1-dc4c22189372.jpg?1",
             "name": "Undergrowth Recon",
             "text": "At the beginning of your upkeep, return target land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -15811,7 +15811,7 @@
         },
         {
             "id": "debc72bf-435d-54f0-bdc6-98353707acb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6644d62-3d2a-4db1-a387-736fcad9a851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6644d62-3d2a-4db1-a387-736fcad9a851.jpg?1",
             "name": "Assassin's Trophy",
             "text": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -15847,7 +15847,7 @@
         },
         {
             "id": "f7f7d0a9-9df0-5aef-9322-f1750083087b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a68f5-62ef-40c9-8a40-e7b79619f719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a68f5-62ef-40c9-8a40-e7b79619f719.jpg?1",
             "name": "Blood Spatter Analysis",
             "text": "When Blood Spatter Analysis enters the battlefield, it deals 3 damage to target creature an opponent controls.\nWhenever one or more creatures die, mill a card and put a bloodstain counter on Blood Spatter Analysis. Then sacrifice it if it has five or more bloodstain counters on it. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -15883,7 +15883,7 @@
         },
         {
             "id": "98d64cf1-add1-5071-ae34-46956ededdc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db9df42-042d-48a0-ac28-228b72a0b19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db9df42-042d-48a0-ac28-228b72a0b19a.jpg?1",
             "name": "Doppelgang",
             "text": "For each of X target permanents, create X tokens that are copies of that permanent.",
             "colours": [
@@ -15919,7 +15919,7 @@
         },
         {
             "id": "6813fe90-725c-5a7f-994b-98fcbef71dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066fed99-5aa5-42db-9472-240cfc2f4f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066fed99-5aa5-42db-9472-240cfc2f4f42.jpg?1",
             "name": "Drag the Canal",
             "text": "Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate.",
             "colours": [
@@ -15955,7 +15955,7 @@
         },
         {
             "id": "4f9a0747-fdb0-59fe-a991-ac628ffe2e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cddd86f-2eaa-41ad-8f97-bd18bfa2f766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cddd86f-2eaa-41ad-8f97-bd18bfa2f766.jpg?1",
             "name": "Ill-Timed Explosion",
             "text": "Draw two cards. Then you may discard two cards. When you do, Ill-Timed Explosion deals X damage to each creature, where X is the greatest mana value among cards discarded this way.",
             "colours": [
@@ -15991,7 +15991,7 @@
         },
         {
             "id": "2312b0aa-2821-527c-9e52-0495ba1a1ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b524c71-c2ac-4a08-8ab7-27b1c232a359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b524c71-c2ac-4a08-8ab7-27b1c232a359.jpg?1",
             "name": "Kylox's Voltstrider",
             "text": "Collect evidence 6: Kylox's Voltstrider becomes an artifact creature until end of turn.\nWhenever Kylox's Voltstrider attacks, you may cast an instant or sorcery spell from among cards exiled with it. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.\nCrew 2",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "3134c790-1fca-5d5f-9527-b6c106c05678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549370b-f32d-48f0-877c-05e6fd1daf7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549370b-f32d-48f0-877c-05e6fd1daf7b.jpg?1",
             "name": "Leyline of the Guildpact",
             "text": "If Leyline of the Guildpact is in your opening hand, you may begin the game with it on the battlefield.\nEach nonland permanent you control is all colors.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -16071,7 +16071,7 @@
         },
         {
             "id": "a7e3957c-9fed-55a8-be4e-a03d9e4caeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffadebd-a7ef-4a75-918a-284d509b11c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffadebd-a7ef-4a75-918a-284d509b11c5.jpg?1",
             "name": "Relive the Past",
             "text": "Return up to one target artifact card, up to one target land card, and up to one target non-Aura enchantment card from your graveyard to the battlefield. They are 5/5 Elemental creatures in addition to their other types.",
             "colours": [
@@ -16107,7 +16107,7 @@
         },
         {
             "id": "7a2ad7e6-56f3-581c-9e18-1e3b722a1c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0ee59f-439a-47ab-b543-e0e013419f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0ee59f-439a-47ab-b543-e0e013419f12.jpg?1",
             "name": "Treacherous Greed",
             "text": "As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.\nDraw three cards. Each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -16143,7 +16143,7 @@
         },
         {
             "id": "cee6d1e1-0024-5be8-98af-842cf1dd7426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe89b207-04a4-4cdc-95a2-07c7761b885e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe89b207-04a4-4cdc-95a2-07c7761b885e.jpg?1",
             "name": "Urgent Necropsy",
             "text": "As an additional cost to cast this spell, collect evidence X, where X is the total mana value of the permanents this spell targets.\nDestroy up to one target artifact, up to one target creature, up to one target enchantment, and up to one target planeswalker.",
             "colours": [
@@ -16179,7 +16179,7 @@
         },
         {
             "id": "73fdc534-bcdb-58a1-bde3-d95c04af9939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17938b40-a4a3-4150-a94c-ecddbed3ccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17938b40-a4a3-4150-a94c-ecddbed3ccfc.jpg?1",
             "name": "Cryptex",
             "text": "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on Cryptex.\nSacrifice Cryptex: Surveil 3, then draw three cards. Activate only if Cryptex has five or more unlock counters on it.",
             "colours": [],
@@ -16209,7 +16209,7 @@
         },
         {
             "id": "fff4430a-b314-5dab-9de0-fb5e7535b2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a8889-1323-4268-b34c-146c4136fd53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a8889-1323-4268-b34c-146c4136fd53.jpg?1",
             "name": "Long Goodbye",
             "text": "This spell can't be countered.\nDestroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -16243,7 +16243,7 @@
         },
         {
             "id": "8d62bb7b-1bfe-53df-9187-d83361a118fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b6cd91-8178-4c5c-9cb1-f3d970fe3b03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b6cd91-8178-4c5c-9cb1-f3d970fe3b03.jpg?1",
             "name": "Gleaming Geardrake",
             "text": "Flying\nWhen Gleaming Geardrake enters the battlefield, investigate.\nWhenever you sacrifice an artifact, put a +1/+1 counter on Gleaming Geardrake.",
             "colours": [
@@ -16283,7 +16283,7 @@
         },
         {
             "id": "7b006931-ae30-5462-bb66-7bb3edcbe5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd02c8-7b28-4128-b2fc-d961e565a147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fefd02c8-7b28-4128-b2fc-d961e565a147.jpg?1",
             "name": "Kraul Whipcracker",
             "text": "Reach\nWhen Kraul Whipcracker enters the battlefield, destroy target token an opponent controls.",
             "colours": [
@@ -16324,7 +16324,7 @@
         },
         {
             "id": "318d0ab3-2514-5852-bc78-de893fa69137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e478972-27a6-4a89-a8d7-cb1abdd9f0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e478972-27a6-4a89-a8d7-cb1abdd9f0d9.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to any target and you gain 3 life.",
             "colours": [
@@ -16360,7 +16360,7 @@
         },
         {
             "id": "669be5ab-16b2-50cd-890a-f0ba2634eafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c882d46-c26c-47f1-96ce-b0676f345b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c882d46-c26c-47f1-96ce-b0676f345b89.jpg?1",
             "name": "No More Lies",
             "text": "Counter target spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -16396,7 +16396,7 @@
         },
         {
             "id": "3d459fbd-76c6-5dc0-8f38-b0f115053a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd5e33-5a58-4321-8742-236d6cc6f4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3ddd5e33-5a58-4321-8742-236d6cc6f4f4.jpg?1",
             "name": "Axebane Ferox",
             "text": "Deathtouch, haste\nWard\u2014\nCollect evidence 4. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player exiles cards with total mana value 4 or greater from their graveyard.)",
             "colours": [
@@ -16432,7 +16432,7 @@
         },
         {
             "id": "c592c285-f1ee-5740-b4cd-e888e298c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eccc85-bdfe-48f4-a79e-76d9ef122815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eccc85-bdfe-48f4-a79e-76d9ef122815.jpg?1",
             "name": "Wojek Investigator",
             "text": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you.",
             "colours": [
@@ -16470,7 +16470,7 @@
         },
         {
             "id": "7c8de30e-0bae-56f2-bf2c-fc1bc1bf7cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5ede0-a098-4f21-8b7e-795a83e75aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5ede0-a098-4f21-8b7e-795a83e75aae.jpg?1",
             "name": "Melek, Reforged Researcher",
             "text": "Melek, Reforged Researcher's power and toughness are each equal to twice the number of instant and sorcery cards in your graveyard.\nThe first instant or sorcery spell you cast each turn costs {3} less to cast.",
             "colours": [
@@ -16508,7 +16508,7 @@
         },
         {
             "id": "a4cd2e06-df57-5bf5-9e53-5a36272b53a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7550-fe1a-4797-9583-70ab56cfac0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7550-fe1a-4797-9583-70ab56cfac0d.jpg?1",
             "name": "Tomik, Wielder of Law",
             "text": "Affinity for planeswalkers (This spell costs {1} less to cast for each planeswalker you control.)\nFlying, vigilance\nWhenever an opponent attacks with creatures, if two or more of those creatures are attacking you and/or planeswalkers you control, that opponent loses 3 life and you draw a card.",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "2b58868e-0dab-5a3e-9218-d94cbfbc4f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1bd2f-25bd-4fbd-877b-cef00ab7f92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1bd2f-25bd-4fbd-877b-cef00ab7f92f.jpg?1",
             "name": "Voja, Jaws of the Conclave",
             "text": "Vigilance, trample, ward {3}\nWhenever Voja, Jaws of the Conclave attacks, put X +1/+1 counters on each creature you control, where X is the number of Elves you control. Draw a card for each Wolf you control.",
             "colours": [
@@ -16585,7 +16585,7 @@
         },
         {
             "id": "172269e3-9b8b-5e05-91e0-894fe07d4f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7be0f36-9acd-457b-bdfa-77be787be5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7be0f36-9acd-457b-bdfa-77be787be5c3.jpg?1",
             "name": "Vein Ripper",
             "text": "Flying\nWard\u2014\nSacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -16622,7 +16622,7 @@
         },
         {
             "id": "6f222117-73e0-5b15-8f8d-529bfa2cdbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf03be-294a-4539-954c-79853f4351a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aaf03be-294a-4539-954c-79853f4351a9.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "f4991ff1-b597-5f15-9a8e-9724ae5ee3fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd1de1-9657-4262-be11-8279b3408e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd1de1-9657-4262-be11-8279b3408e54.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -16692,7 +16692,7 @@
         },
         {
             "id": "ea2f86f5-bc5a-58d4-8ae6-116f9a5981c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ce61b-480a-4da6-80f6-63e096902ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ce61b-480a-4da6-80f6-63e096902ae6.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -16727,7 +16727,7 @@
         },
         {
             "id": "40d0e746-6be8-592b-921b-67f31f9c68ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677bd8b5-d751-4d17-9e6f-55eb2c30c3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677bd8b5-d751-4d17-9e6f-55eb2c30c3ed.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "a3a8ccfa-230d-5c26-8b80-d0993fd4ba97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02404852-5788-4adb-b2dc-98bf705d8d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02404852-5788-4adb-b2dc-98bf705d8d96.jpg?1",
             "name": "Skeleton",
             "text": "",
             "colours": [
@@ -16797,7 +16797,7 @@
         },
         {
             "id": "9ac7e305-d4ff-57c5-8aa0-d0b1272b7212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cd0d3-7973-49e6-9c1c-6f516a5d5fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cd0d3-7973-49e6-9c1c-6f516a5d5fe5.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16832,7 +16832,7 @@
         },
         {
             "id": "a52750b3-3a65-5300-96f3-0222857b9d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1385b-2be2-49a8-8400-186cd5525dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1385b-2be2-49a8-8400-186cd5525dad.jpg?1",
             "name": "Imp",
             "text": "",
             "colours": [
@@ -16867,7 +16867,7 @@
         },
         {
             "id": "f8dacdc5-2e85-5385-8f67-e1fcc92a738d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b37032-9660-4dfb-9629-c4e8eddc43b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b37032-9660-4dfb-9629-c4e8eddc43b0.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -16902,7 +16902,7 @@
         },
         {
             "id": "eb7bf20b-ea05-5471-8ba9-e9c3b3bb77b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92091012-856c-4b42-9e22-405112c39edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92091012-856c-4b42-9e22-405112c39edd.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -16937,7 +16937,7 @@
         },
         {
             "id": "4c84fc07-0117-5360-9426-02f030e51f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a109aa-99d4-4cfe-a9b1-1b40db5b7885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a109aa-99d4-4cfe-a9b1-1b40db5b7885.jpg?1",
             "name": "Detective",
             "text": "",
             "colours": [
@@ -16974,7 +16974,7 @@
         },
         {
             "id": "806b3bc5-ffdc-511c-a96f-92be64ad12d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -17011,7 +17011,7 @@
         },
         {
             "id": "e00e04e7-7717-50ba-9862-5b446921ecae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17048,7 +17048,7 @@
         },
         {
             "id": "c166de59-5e3f-5bab-a3dd-abbb9f2bdd0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2175200f-3ed4-4b39-ac76-a7d25967aa8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2175200f-3ed4-4b39-ac76-a7d25967aa8a.jpg?1",
             "name": "Voja Fenstalker",
             "text": "",
             "colours": [
@@ -17087,7 +17087,7 @@
         },
         {
             "id": "97bab7f2-472c-50d6-9686-180c947cc457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee022200-f589-4f06-8de8-d313e29f7be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee022200-f589-4f06-8de8-d313e29f7be8.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17118,7 +17118,7 @@
         },
         {
             "id": "9bf154c7-6242-5c33-9ff7-54eecc0771bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8c41b5-beec-4fd1-bbfa-20fbc7f44307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8c41b5-beec-4fd1-bbfa-20fbc7f44307.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17149,7 +17149,7 @@
         },
         {
             "id": "d2d3de02-7f08-5e0f-a3c4-8117096fa45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233d3d41-1559-464a-a41e-096eb3b8a968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233d3d41-1559-464a-a41e-096eb3b8a968.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17180,7 +17180,7 @@
         },
         {
             "id": "3ceaed1b-4c1a-50ef-b42a-fc1259368500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576b691a-9cb1-4c2e-93cf-42f52f587bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576b691a-9cb1-4c2e-93cf-42f52f587bff.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17211,7 +17211,7 @@
         },
         {
             "id": "9a9827e0-4bbe-56ff-8e04-064bd0c5cfa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef607895-d6d2-44ab-a6b4-84af55fce593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef607895-d6d2-44ab-a6b4-84af55fce593.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -17242,7 +17242,7 @@
         },
         {
             "id": "41e3bd0b-1a07-571a-997d-db549c64497f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ad97f4-cc41-493c-9848-c06f3cf778c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ad97f4-cc41-493c-9848-c06f3cf778c7.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -17274,7 +17274,7 @@
         },
         {
             "id": "2bd4585e-48e5-58a6-a684-9f1672cb99a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80c5f0a-5573-4dc2-8791-35e35bdf4c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80c5f0a-5573-4dc2-8791-35e35bdf4c78.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -17306,7 +17306,7 @@
         },
         {
             "id": "f5b1634e-a14b-51d6-a679-356f7f0ac60f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241b3b6d-a25f-4a43-b5d6-1d1079e7e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241b3b6d-a25f-4a43-b5d6-1d1079e7e498.jpg?1",
             "name": "A Mysterious Creature",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MM2.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MM2.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "3469ae47-c0d4-5252-89e4-154448a2efb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c9f6dd-308e-4c91-8bcc-975d273a0a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c9f6dd-308e-4c91-8bcc-975d273a0a33.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all colored permanents he or she controls.",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "b6e66ba1-5aa3-5a3e-a987-e7cd40e10be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79dedcf-ecba-49a1-81dc-7e3bdb7abefd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79dedcf-ecba-49a1-81dc-7e3bdb7abefd.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast Artisan of Kozilek, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "c7cc7830-911b-5a51-b5ab-3bd00447d432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3197aa08-9fb1-47d2-b873-432700cb790e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3197aa08-9fb1-47d2-b873-432700cb790e.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "Emrakul, the Aeons Torn can't be countered.\nWhen you cast Emrakul, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "03cbf8b6-6be5-5ae1-a40a-b5d17772d422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1deda0-c99d-4570-a5dd-f51eb5d12570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1deda0-c99d-4570-a5dd-f51eb5d12570.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from his or her hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -129,7 +129,7 @@
         },
         {
             "id": "30ccc583-cdf1-5cbc-8c1d-d32a5904cea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc70f3b-844e-428c-a8cd-d6c6a55b925a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc70f3b-844e-428c-a8cd-d6c6a55b925a.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast Kozilek, Butcher of Truth, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -161,7 +161,7 @@
         },
         {
             "id": "b418cb0d-e389-546f-80a1-4d333373db5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a056241d-513a-4de7-a604-bf8248c31225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a056241d-513a-4de7-a604-bf8248c31225.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast Ulamog, the Infinite Gyre, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -193,7 +193,7 @@
         },
         {
             "id": "dc8ddaf0-9007-50cc-8afe-fdd372718068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54baced-fabe-4ed6-9203-5bb5fbb64007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54baced-fabe-4ed6-9203-5bb5fbb64007.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each turn if able.",
             "colours": [],
@@ -223,7 +223,7 @@
         },
         {
             "id": "cd70ded6-4a05-5621-8c16-6e721c3f3452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfbc07e-d726-4d42-9394-6aa0f5fc3a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfbc07e-d726-4d42-9394-6aa0f5fc3a3a.jpg?1",
             "name": "Apostle's Blessing",
             "text": "({PW} can be paid with either {W} or 2 life.)\nTarget artifact or creature you control gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -255,7 +255,7 @@
         },
         {
             "id": "6d147a1a-a243-535b-9d17-8c533a0d0fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0be19-e041-4347-a51c-7e93a3d9e712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc0be19-e041-4347-a51c-7e93a3d9e712.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "c476c37c-9de6-5d26-a4f2-c23656258102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf72b23-a951-4e88-a52b-b3abe8f16bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf72b23-a951-4e88-a52b-b3abe8f16bf4.jpg?1",
             "name": "Battlegrace Angel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, it gains lifelink until end of turn.",
             "colours": [
@@ -323,7 +323,7 @@
         },
         {
             "id": "44a94851-8526-52a2-847c-18af3f803fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd38afd4-d7a4-493d-bdea-72be9a1d9a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd38afd4-d7a4-493d-bdea-72be9a1d9a07.jpg?1",
             "name": "Celestial Purge",
             "text": "Exile target black or red permanent.",
             "colours": [
@@ -355,7 +355,7 @@
         },
         {
             "id": "630ff113-a71a-5691-ad88-b9159927af19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04435b25-1a44-493f-810e-23d260f363a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04435b25-1a44-493f-810e-23d260f363a6.jpg?1",
             "name": "Conclave Phalanx",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen Conclave Phalanx enters the battlefield, you gain 1 life for each creature you control.",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "ea0c162b-7cb4-5c52-b817-8abb0af008a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61aded-0007-48fb-b1d6-1c69a8703400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61aded-0007-48fb-b1d6-1c69a8703400.jpg?1",
             "name": "Court Homunculus",
             "text": "Court Homunculus gets +1/+1 as long as you control another artifact.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "eda16b19-de1d-5584-bda2-ec24df6ab8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6f35e-26b4-465d-9026-ffaa869c7722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f6f35e-26b4-465d-9026-ffaa869c7722.jpg?1",
             "name": "Daybreak Coronet",
             "text": "Enchant creature with another Aura attached to it\nEnchanted creature gets +3/+3 and has first strike, vigilance, and lifelink.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "fb8e306c-50ce-5892-b213-9c85c31cda80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242aeb96-0163-4d3d-9cc1-43c37a9278f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242aeb96-0163-4d3d-9cc1-43c37a9278f5.jpg?1",
             "name": "Dispatch",
             "text": "Tap target creature.\nMetalcraft \u2014 If you control three or more artifacts, exile that creature.",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "c2d2179d-50a0-53e9-ae54-f17bb537ebde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ecbe1d-2ad7-4cbb-8392-f41f107356db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ecbe1d-2ad7-4cbb-8392-f41f107356db.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "Vigilance\nOther creatures you control get +2/+2.\nCreatures your opponents control get -2/-2.",
             "colours": [
@@ -528,7 +528,7 @@
         },
         {
             "id": "2483540d-79e0-5712-b251-09fb78781e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fa2bb8-005f-4a34-820e-9bfee7268691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7fa2bb8-005f-4a34-820e-9bfee7268691.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -560,7 +560,7 @@
         },
         {
             "id": "f09cf60e-125f-5af9-b8d4-53bb87c0c5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3e29ea-c907-4185-986c-f0dabd3b3855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3e29ea-c907-4185-986c-f0dabd3b3855.jpg?1",
             "name": "Hikari, Twilight Guardian",
             "text": "Flying\nWhenever you cast a Spirit or Arcane spell, you may exile Hikari, Twilight Guardian. If you do, return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -596,7 +596,7 @@
         },
         {
             "id": "97220d5d-c043-59c2-a8af-c3e269688df8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94810748-7c70-4491-a355-c7c56cc03df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94810748-7c70-4491-a355-c7c56cc03df0.jpg?1",
             "name": "Indomitable Archangel",
             "text": "Flying\nMetalcraft \u2014 Artifacts you control have shroud as long as you control three or more artifacts. (An artifact with shroud can't be the target of spells or abilities.)",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "ae68949e-9557-53d0-b194-fbf99e395251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197b59e-1652-496c-a038-e2eb88ecf017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6197b59e-1652-496c-a038-e2eb88ecf017.jpg?1",
             "name": "Iona, Shield of Emeria",
             "text": "Flying\nAs Iona, Shield of Emeria enters the battlefield, choose a color.\nYour opponents can't cast spells of the chosen color.",
             "colours": [
@@ -666,7 +666,7 @@
         },
         {
             "id": "fbfdd248-a110-502e-b70e-198c13d3cee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c92c0b-232b-4786-8cd6-6eb207eed8d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c92c0b-232b-4786-8cd6-6eb207eed8d5.jpg?1",
             "name": "Kami of Ancient Law",
             "text": "Sacrifice Kami of Ancient Law: Destroy target enchantment.",
             "colours": [
@@ -700,7 +700,7 @@
         },
         {
             "id": "efcba597-0170-5fab-81fe-9e7080102179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd85ac-e826-4b16-b9ab-864ae2cabed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7cd85ac-e826-4b16-b9ab-864ae2cabed1.jpg?1",
             "name": "Kor Duelist",
             "text": "As long as Kor Duelist is equipped, it has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -735,7 +735,7 @@
         },
         {
             "id": "c81a8a5b-7ab4-523c-841e-ed475a44c518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3346cb1-c593-4221-b27a-fa5d0caf620f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3346cb1-c593-4221-b27a-fa5d0caf620f.jpg?1",
             "name": "Leyline of Sanctity",
             "text": "If Leyline of Sanctity is in your opening hand, you may begin the game with it on the battlefield.\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -767,7 +767,7 @@
         },
         {
             "id": "d0fc28c6-24c5-5b47-9ea9-fd5130193c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78494f6-ef4e-4f31-b8e3-feab4bbcb279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78494f6-ef4e-4f31-b8e3-feab4bbcb279.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -799,7 +799,7 @@
         },
         {
             "id": "ccc439b2-9969-5c0c-8450-9a8331fa7cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c34f5d-0430-4036-a633-1a68a0d2fc65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c34f5d-0430-4036-a633-1a68a0d2fc65.jpg?1",
             "name": "Mirran Crusader",
             "text": "Double strike, protection from black and from green",
             "colours": [
@@ -834,7 +834,7 @@
         },
         {
             "id": "7d6e3f00-1a93-53c8-a4f3-d0c6512af1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9819bc-5da2-4b0c-b5d4-c99b2914bb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9819bc-5da2-4b0c-b5d4-c99b2914bb6f.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type at all times.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
             "colours": [
@@ -868,7 +868,7 @@
         },
         {
             "id": "6915b93d-9f06-5e7f-b37e-34cc345da370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fe00af-1634-45bd-bf1b-42997c4c3359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fe00af-1634-45bd-bf1b-42997c4c3359.jpg?1",
             "name": "Moonlit Strider",
             "text": "Sacrifice Moonlit Strider: Target creature you control gains protection from the color of your choice until end of turn.\nSoulshift 3 (When this creature dies, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "395a36ab-7a59-5465-b684-be9db9f6532a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff45f775-9d77-4a55-917e-2de57ce2cf31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff45f775-9d77-4a55-917e-2de57ce2cf31.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [
@@ -937,7 +937,7 @@
         },
         {
             "id": "9e7ab993-7bf2-51a8-9bf8-8c50d497ac05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff31eba-8ab3-403e-8d82-37a18b279bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff31eba-8ab3-403e-8d82-37a18b279bec.jpg?1",
             "name": "Oblivion Ring",
             "text": "When Oblivion Ring enters the battlefield, exile another target nonland permanent.\nWhen Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -969,7 +969,7 @@
         },
         {
             "id": "07b4f113-cd02-5d84-a45f-caf8ca4c414d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd220e4-2e2a-437e-aa4e-1007247c8e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd220e4-2e2a-437e-aa4e-1007247c8e4d.jpg?1",
             "name": "Otherworldly Journey",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -1003,7 +1003,7 @@
         },
         {
             "id": "cfdfd8c7-e2bd-57f4-8dbc-140dc41fe73e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b083211a-aa01-4944-ae6c-e7fcdec67bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b083211a-aa01-4944-ae6c-e7fcdec67bbf.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens onto the battlefield.",
             "colours": [
@@ -1035,7 +1035,7 @@
         },
         {
             "id": "6cf5d509-0c16-5b6c-845d-0dbdc1f779fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbf772f-ebdf-4c04-996f-0dbf1826049b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adbf772f-ebdf-4c04-996f-0dbf1826049b.jpg?1",
             "name": "Skyhunter Skirmisher",
             "text": "Flying\nDouble strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -1070,7 +1070,7 @@
         },
         {
             "id": "29fdbe20-f78c-50c3-b0bd-8e588f1b50bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964629e-d79e-46e4-b3fd-e7d1759cbc60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9964629e-d79e-46e4-b3fd-e7d1759cbc60.jpg?1",
             "name": "Spectral Procession",
             "text": "({2\nW} can be paid with any two mana or with {W}. This card's converted mana cost is 6.)\nPut three 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "5f53a33f-6796-50c2-9e09-7a540974142b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0f671-8597-4c40-b9ca-7c6bfe2983c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0f671-8597-4c40-b9ca-7c6bfe2983c1.jpg?1",
             "name": "Sunlance",
             "text": "Sunlance deals 3 damage to target nonwhite creature.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "3f679705-53bc-57b4-89ce-f4155a1e21c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7d4b63-0221-4bfe-b0a3-66a5e3054627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7d4b63-0221-4bfe-b0a3-66a5e3054627.jpg?1",
             "name": "Sunspear Shikari",
             "text": "As long as Sunspear Shikari is equipped, it has first strike and lifelink.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "d540afd1-2e9a-5d89-ae1e-96ffb8024268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73949ba2-81d8-40f0-bd50-0a610c89e2fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73949ba2-81d8-40f0-bd50-0a610c89e2fa.jpg?1",
             "name": "Taj-Nar Swordsmith",
             "text": "When Taj-Nar Swordsmith enters the battlefield, you may pay {X}. If you do, search your library for an Equipment card with converted mana cost X or less and put that card onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -1204,7 +1204,7 @@
         },
         {
             "id": "11838f25-8c8b-584e-92f5-0a349169807a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0d818-b463-4ef7-93b4-1ae341b52e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0d818-b463-4ef7-93b4-1ae341b52e2c.jpg?1",
             "name": "Terashi's Grasp",
             "text": "Destroy target artifact or enchantment. You gain life equal to its converted mana cost.",
             "colours": [
@@ -1238,7 +1238,7 @@
         },
         {
             "id": "0310277c-b6f1-5634-b43b-532497d41b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c47e0-c87b-4304-b412-00496c2c289f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c47e0-c87b-4304-b412-00496c2c289f.jpg?1",
             "name": "Waxmane Baku",
             "text": "Whenever you cast a Spirit or Arcane spell, you may put a ki counter on Waxmane Baku.\n{1}, Remove X ki counters from Waxmane Baku: Tap X target creatures.",
             "colours": [
@@ -1272,7 +1272,7 @@
         },
         {
             "id": "07198d73-16e9-5d88-8bde-a067fa50ddc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8691ca3-8772-40f6-a7dd-68fe8efd7cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8691ca3-8772-40f6-a7dd-68fe8efd7cf4.jpg?1",
             "name": "Aethersnipe",
             "text": "When \u00c6thersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1306,7 +1306,7 @@
         },
         {
             "id": "76c7717a-0167-50ba-8e9d-b8b55bbf1079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896fc879-1ead-4eeb-b764-7e3f7f98bcfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896fc879-1ead-4eeb-b764-7e3f7f98bcfb.jpg?1",
             "name": "Air Servant",
             "text": "Flying\n{2}{U}: Tap target creature with flying.",
             "colours": [
@@ -1340,7 +1340,7 @@
         },
         {
             "id": "f3d64884-6795-5b64-ade9-25fc461975ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d03f11-7448-47de-9fb4-3ceaf08dc1d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99d03f11-7448-47de-9fb4-3ceaf08dc1d4.jpg?1",
             "name": "Argent Sphinx",
             "text": "Flying\nMetalcraft \u2014 {U}: Exile Argent Sphinx. Return it to the battlefield under your control at the beginning of the next end step. Activate this ability only if you control three or more artifacts.",
             "colours": [
@@ -1374,7 +1374,7 @@
         },
         {
             "id": "eeb4f4a2-45d4-5607-8cb3-7ccc684c748e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3639ad50-6e39-48bd-9055-c32369d2f676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3639ad50-6e39-48bd-9055-c32369d2f676.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "6da157ab-7b7e-5cfe-8a5b-896f33700b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe76b0-86eb-4f5b-8877-657cb8a37fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe76b0-86eb-4f5b-8877-657cb8a37fc3.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Counter target spell.\n\u2022 Return target permanent to its owner's hand.\n\u2022 Tap all creatures your opponents control.\n\u2022 Draw a card.",
             "colours": [
@@ -1440,7 +1440,7 @@
         },
         {
             "id": "8d205fa4-a9d4-5d09-86a9-357a503ff186",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6693346f-3891-441f-a628-4dea4dd181b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6693346f-3891-441f-a628-4dea4dd181b0.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist enters the battlefield, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1476,7 +1476,7 @@
         },
         {
             "id": "100ff2c0-a886-5817-bfe7-7aae2f5a778d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97aaed2-5e10-4080-b373-31f67fbac1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97aaed2-5e10-4080-b373-31f67fbac1a9.jpg?1",
             "name": "Flashfreeze",
             "text": "Counter target red or green spell.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "cb5ac40c-f1cc-5912-bd5b-1ec9a3de5348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9021f91-0b92-44ff-9ccb-bcf1e81232c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9021f91-0b92-44ff-9ccb-bcf1e81232c2.jpg?1",
             "name": "Guile",
             "text": "Guile can't be blocked except by three or more creatures.\nIf a spell or ability you control would counter a spell, instead exile that spell and you may play that card without paying its mana cost.\nWhen Guile is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "ca2cfecc-052a-530b-98bf-5c9d0541f484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a9a786-8d15-4186-8030-4151bddcc0f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a9a786-8d15-4186-8030-4151bddcc0f7.jpg?1",
             "name": "Helium Squirter",
             "text": "Graft 3 (This creature enters the battlefield with three +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{1}: Target creature with a +1/+1 counter on it gains flying until end of turn.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "500788a0-0cf8-5b5c-be19-83c7a0be3c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73edeaaa-6a87-4cf1-b013-bab9a7bb94d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73edeaaa-6a87-4cf1-b013-bab9a7bb94d9.jpg?1",
             "name": "Hurkyl's Recall",
             "text": "Return all artifacts target player owns to his or her hand.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "123256fa-709e-5c87-a463-b5cbe5a1eff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40441345-23ca-47e4-b349-bd13d986e41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40441345-23ca-47e4-b349-bd13d986e41e.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "62560e10-8068-5424-86b2-65266a8d8ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea345b5d-3b4b-4b59-876b-bc56fbe8578a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea345b5d-3b4b-4b59-876b-bc56fbe8578a.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "279a1d2d-1087-521b-8a13-1b045f47d64a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e282a2-d258-4c23-852c-6b0f10ae1962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e282a2-d258-4c23-852c-6b0f10ae1962.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "246f3339-5b8b-5aa2-a311-01ccc4aa47cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42910ab0-902f-43e9-ba21-6a35f9334e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42910ab0-902f-43e9-ba21-6a35f9334e59.jpg?1",
             "name": "Narcolepsy",
             "text": "Enchant creature\nAt the beginning of each upkeep, if enchanted creature is untapped, tap it.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "c716513c-731b-5b94-877c-70afb663b198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f75658e-43de-4091-acf6-5d6d571f9e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f75658e-43de-4091-acf6-5d6d571f9e99.jpg?1",
             "name": "Novijen Sages",
             "text": "Graft 4 (This creature enters the battlefield with four +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{1}, Remove two +1/+1 counters from among creatures you control: Draw a card.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "57cc0d6f-87cd-5f16-a6f0-3d06d89f999b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357aa2a1-4f72-4890-aa46-d212292ab837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357aa2a1-4f72-4890-aa46-d212292ab837.jpg?1",
             "name": "Qumulox",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "6a12b45f-cde1-5c58-870d-0681b1bbfc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc595c63-af05-4c05-80e8-e1a90df26b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc595c63-af05-4c05-80e8-e1a90df26b0f.jpg?1",
             "name": "Remand",
             "text": "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "612b7964-91c5-5a24-aac7-051f45c40544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d67a29-a9b2-4234-ad28-35d143fe1e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d67a29-a9b2-4234-ad28-35d143fe1e21.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "c843990b-6460-5381-88e9-4edb183f2b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfe45f-0b1f-489b-a0a6-679668589726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfe45f-0b1f-489b-a0a6-679668589726.jpg?1",
             "name": "Somber Hoverguard",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "e6c2a165-ea56-5371-ab48-36182729c0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71106361-b5b9-403c-b3b1-afe3337e9e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71106361-b5b9-403c-b3b1-afe3337e9e3d.jpg?1",
             "name": "Steady Progress",
             "text": "Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)\nDraw a card.",
             "colours": [
@@ -1942,7 +1942,7 @@
         },
         {
             "id": "52a70528-5acc-5174-a4a7-296e244cc9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f8146e-ca33-4fa2-8f39-5a44b0db4bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f8146e-ca33-4fa2-8f39-5a44b0db4bd6.jpg?1",
             "name": "Stoic Rebuttal",
             "text": "Metalcraft \u2014 Stoic Rebuttal costs {1} less to cast if you control three or more artifacts.\nCounter target spell.",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "92b4ce3c-0567-506e-8c58-5dbd3516f102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c26b28-b542-41d4-bfe0-222400653ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c26b28-b542-41d4-bfe0-222400653ae9.jpg?1",
             "name": "Surrakar Spellblade",
             "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Surrakar Spellblade.\nWhenever Surrakar Spellblade deals combat damage to a player, you may draw X cards, where X is the number of charge counters on it.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "8d27dea1-7d45-50fa-af35-2ede16fa5388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af206bea-f441-4a5a-ba5a-d2d2fd5cb226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af206bea-f441-4a5a-ba5a-d2d2fd5cb226.jpg?1",
             "name": "Telling Time",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "1b6bda46-0153-5653-9b4d-ec993841c86c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339735-eb1a-46f0-8c3e-eae06f278eca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf339735-eb1a-46f0-8c3e-eae06f278eca.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "+1: Untap up to two target artifacts.\n\u2212X: Search your library for an artifact card with converted mana cost X or less and put it onto the battlefield. Then shuffle your library.\n\u22125: Artifacts you control become artifact creatures with base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "86d6c097-e7a6-5c04-8e8b-d459a1ef26c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f09f8e-f212-4b79-98fd-d1c6277a48c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8f09f8e-f212-4b79-98fd-d1c6277a48c2.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "({PU} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "cdf48a44-b0dd-5f51-a94f-382471207474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895485a4-06b6-449d-8cf1-db08e52790e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895485a4-06b6-449d-8cf1-db08e52790e4.jpg?1",
             "name": "Thoughtcast",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nDraw two cards.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "6ba1fb13-ecae-5208-958b-6660432a1a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df368f26-e9e7-476c-be59-a141392e3932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df368f26-e9e7-476c-be59-a141392e3932.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "14abc049-ca19-562b-8d5e-a215b8b97363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f26d0a-e9f3-442f-b5c6-8016cf736432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f26d0a-e9f3-442f-b5c6-8016cf736432.jpg?1",
             "name": "Vapor Snag",
             "text": "Return target creature to its owner's hand. Its controller loses 1 life.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "70083909-8e28-51b1-8239-ff84fddb0c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01978fe5-00a9-4add-ae2a-b4c2572ffb9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01978fe5-00a9-4add-ae2a-b4c2572ffb9a.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "9d8a217a-40be-5df8-93f1-3b7322bea834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa0a951-0018-41bb-8e82-c3844983a753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa0a951-0018-41bb-8e82-c3844983a753.jpg?1",
             "name": "Vigean Graftmage",
             "text": "Graft 2 (This creature enters the battlefield with two +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{1}{U}: Untap target creature with a +1/+1 counter on it.",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "a0536412-8de3-5619-88c5-3ab5682dcc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba4e555-7528-46fd-9cf8-aa1a70e2cc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba4e555-7528-46fd-9cf8-aa1a70e2cc6a.jpg?1",
             "name": "Water Servant",
             "text": "{U}: Water Servant gets +1/-1 until end of turn.\n{U}: Water Servant gets -1/+1 until end of turn.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "674357a0-1598-572e-a44c-c09586ef3193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5f287b-beaa-4b51-8db7-91982e2c0bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5f287b-beaa-4b51-8db7-91982e2c0bb0.jpg?1",
             "name": "Wings of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nUntil end of turn, target creature has base power and toughness 4/4, gains all creature types, and gains flying.",
             "colours": [
@@ -2350,7 +2350,7 @@
         },
         {
             "id": "abb78da0-c21c-5c3d-b234-808fda020e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349f13c9-9a4e-4460-873e-fec58798646c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349f13c9-9a4e-4460-873e-fec58798646c.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and put a 1/1 black Faerie Rogue creature token with flying onto the battlefield.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "e399ad69-6b33-5de4-9eb2-4049597d4ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d87d15f-e944-4ca3-a729-b7ecee4cf118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d87d15f-e944-4ca3-a729-b7ecee4cf118.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "23e28dd5-556e-54b8-afc7-e7237d3fa173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9847c5a-056e-45fb-9871-ca1dcaddb61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9847c5a-056e-45fb-9871-ca1dcaddb61d.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "c63523d1-50e4-519e-8d0b-663869263a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afa8918-86b7-4244-813f-ef7b51d77809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8afa8918-86b7-4244-813f-ef7b51d77809.jpg?1",
             "name": "Daggerclaw Imp",
             "text": "Flying\nDaggerclaw Imp can't block.",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "41f497ca-1cd1-5c70-994f-880efadc5b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cf51d8-9f91-42ff-99e9-4397f2251c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cf51d8-9f91-42ff-99e9-4397f2251c20.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2520,7 +2520,7 @@
         },
         {
             "id": "ad9eafee-206c-59ce-b9b3-b761a4b4a7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc323d-f30e-4463-bcf7-5d4d0df1fe98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc323d-f30e-4463-bcf7-5d4d0df1fe98.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "d0753a27-0cc2-5795-9a11-11c7b38772f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ef45f-c82c-4490-b353-b0b5b572f403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3ef45f-c82c-4490-b353-b0b5b572f403.jpg?1",
             "name": "Deathmark",
             "text": "Destroy target green or white creature.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "db1dc158-137f-5771-a024-7ade39604085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f9b26-e1b0-4818-8d70-40a000f274eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0f9b26-e1b0-4818-8d70-40a000f274eb.jpg?1",
             "name": "Devouring Greed",
             "text": "As an additional cost to cast Devouring Greed, you may sacrifice any number of Spirits.\nTarget player loses 2 life plus 2 life for each Spirit sacrificed this way. You gain that much life.",
             "colours": [
@@ -2620,7 +2620,7 @@
         },
         {
             "id": "05cba0ca-60c1-5914-ad19-aec6f18f3d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d286cf6-3e16-4941-9326-1818b1e06d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d286cf6-3e16-4941-9326-1818b1e06d69.jpg?1",
             "name": "Dismember",
             "text": "({PB} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "4d3c9f53-3157-535e-b9bc-452f6e67af22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3894e7-5740-4455-8093-57579b1549a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3894e7-5740-4455-8093-57579b1549a7.jpg?1",
             "name": "Dread Drone",
             "text": "When Dread Drone enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "e612722c-48ec-56aa-a941-b173ef26bb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723d783-e2c5-4c01-8adc-fade22e4936e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723d783-e2c5-4c01-8adc-fade22e4936e.jpg?1",
             "name": "Duskhunter Bat",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFlying",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "88b7525c-7dd0-5c76-9769-30e896db9cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97b9d0e-e150-46d5-b6fd-59793e82dae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97b9d0e-e150-46d5-b6fd-59793e82dae4.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you cast a creature spell, put X 1/1 black Thrull creature tokens onto the battlefield, where X is that spell's converted mana cost.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "1cc8dfb3-83a3-556d-bc55-7732d9508381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9f1fda-8a94-48fe-9682-5b2fdbc31bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d9f1fda-8a94-48fe-9682-5b2fdbc31bad.jpg?1",
             "name": "Ghostly Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{1}{B}: Ghostly Changeling gets +1/+1 until end of turn.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "bd3f9873-8159-5f67-8000-4bda62175e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8145805-daa8-43c0-9f22-e6829f6ed390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8145805-daa8-43c0-9f22-e6829f6ed390.jpg?1",
             "name": "Grim Affliction",
             "text": "Put a -1/-1 counter on target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "47588661-c6f2-56d2-9a01-80429c57ef28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a14b58-e0d9-4203-a9da-ad8e997a7936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7a14b58-e0d9-4203-a9da-ad8e997a7936.jpg?1",
             "name": "Instill Infection",
             "text": "Put a -1/-1 counter on target creature.\nDraw a card.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "43434c0a-1dfe-50f7-91b2-a378c1f31bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7da8f15-ea21-46fd-b24f-f8af4d5d5f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7da8f15-ea21-46fd-b24f-f8af4d5d5f1d.jpg?1",
             "name": "Midnight Banshee",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nAt the beginning of your upkeep, put a -1/-1 counter on each nonblack creature.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "3220df56-7753-58a3-8e7f-ee0f43936010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6f58-267a-4ae9-bf72-e0ae0be3b884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563c6f58-267a-4ae9-bf72-e0ae0be3b884.jpg?1",
             "name": "Nameless Inversion",
             "text": "Changeling (This card is every creature type at all times.)\nTarget creature gets +3/-3 and loses all creature types until end of turn.",
             "colours": [
@@ -2925,7 +2925,7 @@
         },
         {
             "id": "0219b4c7-2d9c-510f-93d4-d59380bd58b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d1e8a-b80e-4963-aeff-4b364a02a246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128d1e8a-b80e-4963-aeff-4b364a02a246.jpg?1",
             "name": "Necroskitter",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls with a -1/-1 counter on it dies, you may return that card to the battlefield under your control.",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "d43e2a16-2d30-5b07-847c-f64dae5ab8ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85343bc7-d670-439e-9a84-3c75eb171b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85343bc7-d670-439e-9a84-3c75eb171b12.jpg?1",
             "name": "Plagued Rusalka",
             "text": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "22ac70be-b20c-506b-8837-9707fa825bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a770a18f-c333-431b-b15a-69bb025601c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a770a18f-c333-431b-b15a-69bb025601c2.jpg?1",
             "name": "Profane Command",
             "text": "Choose two \u2014\n\u2022 Target player loses X life.\n\u2022 Return target creature card with converted mana cost X or less from your graveyard to the battlefield.\n\u2022 Target creature gets -X/-X until end of turn.\n\u2022 Up to X target creatures gain fear until end of turn.",
             "colours": [
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "5f5bb4c5-76f6-5e69-a07a-6047915fd567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440b7874-b71c-4cd8-987a-d2915b8a9974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440b7874-b71c-4cd8-987a-d2915b8a9974.jpg?1",
             "name": "Puppeteer Clique",
             "text": "Flying\nWhen Puppeteer Clique enters the battlefield, put target creature card from an opponent's graveyard onto the battlefield under your control. It gains haste. At the beginning of your next end step, exile it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "f961cefc-3a70-59ee-b7b7-de0208ddb7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528c4e3a-fdeb-4080-b2b7-82faa07a3383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528c4e3a-fdeb-4080-b2b7-82faa07a3383.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "{1}{B}: Return Reassembling Skeleton from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3095,7 +3095,7 @@
         },
         {
             "id": "b758c5e7-2b04-5875-925f-9553569ee754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5249a7-de7f-445f-a24f-9c429f45c779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c5249a7-de7f-445f-a24f-9c429f45c779.jpg?1",
             "name": "Scavenger Drake",
             "text": "Flying\nWhenever another creature dies, you may put a +1/+1 counter on Scavenger Drake.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "4cc68f76-dabd-5581-8cba-1aab1fb638e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f68a90c-1afb-43d3-aed2-4704f4599e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f68a90c-1afb-43d3-aed2-4704f4599e75.jpg?1",
             "name": "Scuttling Death",
             "text": "Sacrifice Scuttling Death: Target creature gets -1/-1 until end of turn.\nSoulshift 4 (When this creature dies, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "a8f5615a-5cfc-5bc4-8a78-0d3a90ce3063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5460a0-1aae-45bf-a2aa-5b95fd29d06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5460a0-1aae-45bf-a2aa-5b95fd29d06f.jpg?1",
             "name": "Shrivel",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "2d453aa3-af71-55e2-951d-d0d2563bc1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831462c0-476b-4106-8381-e4177626b570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831462c0-476b-4106-8381-e4177626b570.jpg?1",
             "name": "Sickle Ripper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "eed08515-dfc7-524a-8c91-0d0a83a2e0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f94c5a-684e-4a48-8280-f0e3db712d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f94c5a-684e-4a48-8280-f0e3db712d75.jpg?1",
             "name": "Sign in Blood",
             "text": "Target player draws two cards and loses 2 life.",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "70783945-2c15-58ed-8560-965aa55778b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003bc8f1-f282-491c-984d-1ce7ac027053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003bc8f1-f282-491c-984d-1ce7ac027053.jpg?1",
             "name": "Spread the Sickness",
             "text": "Destroy target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -3294,7 +3294,7 @@
         },
         {
             "id": "b6566e51-204f-555f-b7a9-691f2aba35a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e438caf-9373-4de8-b4ac-212f5036e677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e438caf-9373-4de8-b4ac-212f5036e677.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "f947bb42-d72d-5a4b-9c4e-8973ca39d27b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48304e24-9c74-4726-95ae-3b1a356f5998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48304e24-9c74-4726-95ae-3b1a356f5998.jpg?1",
             "name": "Thief of Hope",
             "text": "Whenever you cast a Spirit or Arcane spell, target opponent loses 1 life and you gain 1 life.\nSoulshift 2 (When this creature dies, you may return target Spirit card with converted mana cost 2 or less from your graveyard to your hand.)",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "71c42c27-51c8-564c-a610-8dd73e561048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4403436b-2605-495b-ab08-9a2001cc7f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4403436b-2605-495b-ab08-9a2001cc7f8b.jpg?1",
             "name": "Vampire Lacerator",
             "text": "At the beginning of your upkeep, you lose 1 life unless an opponent has 10 or less life.",
             "colours": [
@@ -3395,7 +3395,7 @@
         },
         {
             "id": "8ae6b3ce-d169-5e95-a3b3-eef62fe760d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c1d966-b3c5-4480-be58-054a88141e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c1d966-b3c5-4480-be58-054a88141e44.jpg?1",
             "name": "Vampire Outcasts",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nLifelink",
             "colours": [
@@ -3429,7 +3429,7 @@
         },
         {
             "id": "94133ac5-b27c-55a6-a476-2108bec1ac43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc87c53-0612-42a7-9c32-f7d1adf246af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc87c53-0612-42a7-9c32-f7d1adf246af.jpg?1",
             "name": "Waking Nightmare",
             "text": "Target player discards two cards.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "a6309475-ed56-5bb6-81e0-09e61f1bd89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d418362-aa0c-4e42-b473-f266ec3d0a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d418362-aa0c-4e42-b473-f266ec3d0a25.jpg?1",
             "name": "Banefire",
             "text": "Banefire deals X damage to target creature or player.\nIf X is 5 or more, Banefire can't be countered by spells or abilities and the damage can't be prevented.",
             "colours": [
@@ -3495,7 +3495,7 @@
         },
         {
             "id": "24a75fd6-beb2-56c9-8935-18745806bc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b17fb1-4a33-454f-9222-c6d5671c7e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b17fb1-4a33-454f-9222-c6d5671c7e2f.jpg?1",
             "name": "Blades of Velis Vel",
             "text": "Changeling (This card is every creature type at all times.)\nUp to two target creatures each get +2/+0 and gain all creature types until end of turn.",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "3d6c4b53-d1e5-52ac-9e97-ae1a53be40ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0dec-e4bc-413f-a081-db3421742986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97a0dec-e4bc-413f-a081-db3421742986.jpg?1",
             "name": "Blood Ogre",
             "text": "Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the battlefield with a +1/+1 counter on it.)\nFirst strike",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "ba3f85f4-3ac7-5c60-ace7-9fbfe1aa87c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb21ef9-fab4-427e-bcbf-5cbcbdacd059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb21ef9-fab4-427e-bcbf-5cbcbdacd059.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "3535cac0-3465-539a-a8da-8db170e60620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa32b2a-ce3c-441a-88d4-1ee853a7c265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa32b2a-ce3c-441a-88d4-1ee853a7c265.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "9028de2c-af25-5f9d-bcb4-f850bae7dc62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e6428f-5c78-45f7-9bf9-eb4de63325d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e6428f-5c78-45f7-9bf9-eb4de63325d5.jpg?1",
             "name": "Burst Lightning",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to target creature or player. If Burst Lightning was kicked, it deals 4 damage to that creature or player instead.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "47e10acb-5039-5a93-8cfd-be26bc1845e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acedb1-874c-48ea-820d-f1b1f8cb2553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acedb1-874c-48ea-820d-f1b1f8cb2553.jpg?1",
             "name": "Combust",
             "text": "Combust can't be countered by spells or abilities.\nCombust deals 5 damage to target white or blue creature. The damage can't be prevented.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "193785c7-f08e-5f8a-8dba-c9a0d95f39cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccfe45e-c00c-48ec-b520-ccbb63cfbecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccfe45e-c00c-48ec-b520-ccbb63cfbecc.jpg?1",
             "name": "Comet Storm",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature or player, then choose another target creature or player for each time Comet Storm was kicked. Comet Storm deals X damage to each of them.",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "330bffc6-3204-585d-9838-a4f50cb7398c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef2daf4-45ff-4604-b572-31dfaf1e70fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef2daf4-45ff-4604-b572-31dfaf1e70fe.jpg?1",
             "name": "Dragonsoul Knight",
             "text": "First strike\n{W}{U}{B}{R}{G}: Until end of turn, Dragonsoul Knight becomes a Dragon, gets +5/+3, and gains flying and trample.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "b9990c2c-c130-5ebf-8042-ceb9f3c21a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22014836-8a81-4385-bdb0-b9a080fa57af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22014836-8a81-4385-bdb0-b9a080fa57af.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "14992450-3a2a-5d7a-a071-956878088d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c043b7-1eec-4d11-986c-8fb3823fc3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c043b7-1eec-4d11-986c-8fb3823fc3b1.jpg?1",
             "name": "Goblin Fireslinger",
             "text": "{T}: Goblin Fireslinger deals 1 damage to target player.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "ed211520-bc05-5630-a103-47a9fb4cf096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aedc52-8fc9-4a5d-af42-f9db684c3003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aedc52-8fc9-4a5d-af42-f9db684c3003.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "484acd08-e23c-5ac4-adab-65dad6b50177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda652b4-3ae5-4a5b-be82-c0e47a886907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda652b4-3ae5-4a5b-be82-c0e47a886907.jpg?1",
             "name": "Gorehorn Minotaurs",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "d31b71f8-5e6b-55b3-a191-4ad0f95ae271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461987da-8860-4a04-8f93-d182523ca311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461987da-8860-4a04-8f93-d182523ca311.jpg?1",
             "name": "Gut Shot",
             "text": "({PR} can be paid with either {R} or 2 life.)\nGut Shot deals 1 damage to target creature or player.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "4a0d4039-7c77-57b2-aea9-86a9b99cbcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a7453-3c5d-4933-8fea-7696ac329f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26a7453-3c5d-4933-8fea-7696ac329f71.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "3aa9d29a-d909-569f-b4c0-52e17cc8293c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024e80e3-a36f-4c07-99d3-5dd8a2d8998f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024e80e3-a36f-4c07-99d3-5dd8a2d8998f.jpg?1",
             "name": "Incandescent Soulstoke",
             "text": "Other Elemental creatures you control get +1/+1.\n{1}{R}, {T}: You may put an Elemental creature card from your hand onto the battlefield. That creature gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "22478557-2cf4-574a-ad5f-86fa81fd851c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107b3dbc-fc02-4548-90cf-844da42db13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107b3dbc-fc02-4548-90cf-844da42db13f.jpg?1",
             "name": "Inner-Flame Igniter",
             "text": "{2}{R}: Creatures you control get +1/+0 until end of turn. If this is the third time this ability has resolved this turn, creatures you control gain first strike until end of turn.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "113656ea-6be0-5717-8c4a-9910fcb8d053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa701469-a15c-4e45-8455-089bd4040cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa701469-a15c-4e45-8455-089bd4040cf1.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Put a token that's a copy of target nonlegendary creature you control onto the battlefield. That token has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "90382a47-3cdf-511d-8965-342d00e37672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da834-7f4a-4f60-9151-de7ddcf29622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da834-7f4a-4f60-9151-de7ddcf29622.jpg?1",
             "name": "Lightning Bolt",
             "text": "Lightning Bolt deals 3 damage to target creature or player.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "808dc5d0-6258-5218-8f84-691584449b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4400ba-7e77-41d0-8177-ae3d366fb9bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4400ba-7e77-41d0-8177-ae3d366fb9bd.jpg?1",
             "name": "Skarrgan Firebird",
             "text": "Bloodthirst 3 (If an opponent was dealt damage this turn, this creature enters the battlefield with three +1/+1 counters on it.)\nFlying\n{R}{R}{R}: Return Skarrgan Firebird from your graveyard to your hand. Activate this ability only if an opponent was dealt damage this turn.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "ce31bcd5-5b46-5f95-8751-57ea0e952e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e1c601-5a3d-4819-ab54-2c9acc357d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e1c601-5a3d-4819-ab54-2c9acc357d69.jpg?1",
             "name": "Smash to Smithereens",
             "text": "Destroy target artifact. Smash to Smithereens deals 3 damage to that artifact's controller.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "e60540b7-8445-53d1-bbec-1e60339e9967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6090f5-dfee-4c3f-8257-7707fb6abf2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6090f5-dfee-4c3f-8257-7707fb6abf2c.jpg?1",
             "name": "Smokebraider",
             "text": "{T}: Add two mana in any combination of colors to your mana pool. Spend this mana only to cast Elemental spells or activate abilities of Elementals.",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "57aec187-da7d-5ae3-9c2e-90c05a76ae06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d622758-b182-4a2d-9746-9b03611c1212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d622758-b182-4a2d-9746-9b03611c1212.jpg?1",
             "name": "Soulbright Flamekin",
             "text": "{2}: Target creature gains trample until end of turn. If this is the third time this ability has resolved this turn, you may add {R}{R}{R}{R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -4244,7 +4244,7 @@
         },
         {
             "id": "4c54ec0c-e9c5-5425-a827-5262128675dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c14e44-20ff-4128-b07d-4b751fc82d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c14e44-20ff-4128-b07d-4b751fc82d4e.jpg?1",
             "name": "Spikeshot Elder",
             "text": "{1}{R}{R}: Spikeshot Elder deals damage equal to its power to target creature or player.",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "2a06ffb5-2126-5ad4-84a7-a64167c4ddfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7390a8-78c7-4bb2-9615-18c0f2ffd9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7390a8-78c7-4bb2-9615-18c0f2ffd9eb.jpg?1",
             "name": "Spitebellows",
             "text": "When Spitebellows leaves the battlefield, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "6a99851f-6e0d-5720-af9f-252117baf0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580fbbf8-ba7e-4889-a5ea-d066f3ea8cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580fbbf8-ba7e-4889-a5ea-d066f3ea8cea.jpg?1",
             "name": "Splinter Twin",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put a token that's a copy of this creature onto the battlefield. That token has haste. Exile it at the beginning of the next end step.\"",
             "colours": [
@@ -4347,7 +4347,7 @@
         },
         {
             "id": "ccf20fa9-7f5e-5210-ac86-44c3951100b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf24b25-e98c-4c32-91a2-9c5e10679472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf24b25-e98c-4c32-91a2-9c5e10679472.jpg?1",
             "name": "Stormblood Berserker",
             "text": "Bloodthirst 2 (If an opponent was dealt damage this turn, this creature enters the battlefield with two +1/+1 counters on it.)\nStormblood Berserker can't be blocked except by two or more creatures.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "d9609e12-1471-5881-aa1f-a6295d58deba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ec37d-c4ed-4af6-8c30-bcec13c108fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249ec37d-c4ed-4af6-8c30-bcec13c108fd.jpg?1",
             "name": "Thunderblust",
             "text": "Haste\nThunderblust has trample as long as it has a -1/-1 counter on it.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "5779ff89-4dde-5266-971a-98799a566f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22418cd-4c49-4754-aa75-17f6eaf1639a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22418cd-4c49-4754-aa75-17f6eaf1639a.jpg?1",
             "name": "Tribal Flames",
             "text": "Domain \u2014 Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -4448,7 +4448,7 @@
         },
         {
             "id": "f8d4f913-fd5d-5354-bcc3-352413f94071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a441fae0-a9c7-4d91-a69e-8ea1f8fa6947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a441fae0-a9c7-4d91-a69e-8ea1f8fa6947.jpg?1",
             "name": "Viashino Slaughtermaster",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)\n{B}{G}: Viashino Slaughtermaster gets +1/+1 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "56b02820-5632-5afc-83fe-055e5e31e700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5924430-1904-47b9-bcf0-3379babd395c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5924430-1904-47b9-bcf0-3379babd395c.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands. Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -4517,7 +4517,7 @@
         },
         {
             "id": "99f0633f-cd62-52e8-9e97-0fef09582a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927081a-4eea-48dd-a81a-2e751552751d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1927081a-4eea-48dd-a81a-2e751552751d.jpg?1",
             "name": "Worldheart Phoenix",
             "text": "Flying\nYou may cast Worldheart Phoenix from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost. If you do, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -4555,7 +4555,7 @@
         },
         {
             "id": "d2e9a9b5-9dea-597b-94ca-1ee5dcbee2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e1dcb2-9471-48d9-98c8-12194e3a88ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e1dcb2-9471-48d9-98c8-12194e3a88ac.jpg?1",
             "name": "Wrap in Flames",
             "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -4587,7 +4587,7 @@
         },
         {
             "id": "331bae39-d45b-54b6-936c-57e9c460abc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d30720-5baa-4779-a435-14fab778bad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d30720-5baa-4779-a435-14fab778bad6.jpg?1",
             "name": "Algae Gharial",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nWhenever another creature dies, you may put a +1/+1 counter on Algae Gharial.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "3413f257-8c38-5234-a578-d0f07d094046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15629398-bb20-4ff3-ab0e-061dcea916d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15629398-bb20-4ff3-ab0e-061dcea916d5.jpg?1",
             "name": "All Suns' Dawn",
             "text": "For each color, return up to one target card of that color from your graveyard to your hand. Exile All Suns' Dawn.",
             "colours": [
@@ -4653,7 +4653,7 @@
         },
         {
             "id": "fa83d223-63b5-556d-ae55-67f4db3c104e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cc16c-9ead-45b9-b56c-7512cd54cf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499cc16c-9ead-45b9-b56c-7512cd54cf7c.jpg?1",
             "name": "Ant Queen",
             "text": "{1}{G}: Put a 1/1 green Insect creature token onto the battlefield.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "45ff2217-ab82-537d-b43b-234419061b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9dd8d6-013a-4018-9186-988f5e8d0ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9dd8d6-013a-4018-9186-988f5e8d0ab9.jpg?1",
             "name": "Aquastrand Spider",
             "text": "Graft 2 (This creature enters the battlefield with two +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{G}: Target creature with a +1/+1 counter on it gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "c5bdea54-2d0e-5df8-b43c-6d306aa76303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c16134-692d-4fd1-bffa-f9342113cbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c16134-692d-4fd1-bffa-f9342113cbd8.jpg?1",
             "name": "Bestial Menace",
             "text": "Put a 1/1 green Snake creature token, a 2/2 green Wolf creature token, and a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "aa8e5c4e-1238-5461-a274-7688aff9b0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59eafb3-3ce6-4056-a7f7-8d0a8fc12294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59eafb3-3ce6-4056-a7f7-8d0a8fc12294.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "a5297ea7-bf97-53c6-a1fd-9457ff74e8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e149b2-6bac-4749-ab06-edde21dc408e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e149b2-6bac-4749-ab06-edde21dc408e.jpg?1",
             "name": "Cytoplast Root-Kin",
             "text": "Graft 4 (This creature enters the battlefield with four +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\nWhen Cytoplast Root-Kin enters the battlefield, put a +1/+1 counter on each other creature you control with a +1/+1 counter on it.\n{2}: Move a +1/+1 counter from target creature you control onto Cytoplast Root-Kin.",
             "colours": [
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "a8b50099-f208-5970-a985-ea095f81a648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2716f3a-97ce-419c-9a0f-930cbb660308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2716f3a-97ce-419c-9a0f-930cbb660308.jpg?1",
             "name": "Gnarlid Pack",
             "text": "Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nGnarlid Pack enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -4855,7 +4855,7 @@
         },
         {
             "id": "34fc4e5e-bde6-55cd-918c-4b682992437c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eef91c5-3861-40de-9bb7-67f44431428a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eef91c5-3861-40de-9bb7-67f44431428a.jpg?1",
             "name": "Karplusan Strider",
             "text": "Karplusan Strider can't be the target of blue or black spells.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "f4377244-f413-5f7d-9414-608aec39f668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1644535-cea4-4dda-aa09-225f8b30dddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1644535-cea4-4dda-aa09-225f8b30dddd.jpg?1",
             "name": "Kavu Primarch",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf Kavu Primarch was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -4923,7 +4923,7 @@
         },
         {
             "id": "21cb8dfa-062c-575d-ae6d-c3db52ae7a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03226d4-837a-4d95-a70b-082ce726765f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03226d4-837a-4d95-a70b-082ce726765f.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "d10e2701-fdcf-5c74-9807-2be8f205be7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eac937f-9d61-4da2-8946-187839e13590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eac937f-9d61-4da2-8946-187839e13590.jpg?1",
             "name": "Matca Rioters",
             "text": "Domain \u2014 Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "059dfb34-8cee-567c-bc6a-32c8f648ed29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0861a2-1858-47af-8154-20a977c2b298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0861a2-1858-47af-8154-20a977c2b298.jpg?1",
             "name": "Mutagenic Growth",
             "text": "({PG} can be paid with either {G} or 2 life.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5025,7 +5025,7 @@
         },
         {
             "id": "86ca93c4-3253-5af6-b604-645c81e4a7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55135987-719d-4b7d-a721-b100334a3c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55135987-719d-4b7d-a721-b100334a3c68.jpg?1",
             "name": "Nest Invader",
             "text": "When Nest Invader enters the battlefield, put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "43c3d222-1816-5516-8ff9-fe322170b451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b5322-bfd9-4e37-90b8-3d507ab687de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b5322-bfd9-4e37-90b8-3d507ab687de.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [
@@ -5097,7 +5097,7 @@
         },
         {
             "id": "21875dfe-76a0-5eff-b54f-c48048b55610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d7d3ca-8e0d-43ce-9cdb-310d017873ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d7d3ca-8e0d-43ce-9cdb-310d017873ca.jpg?1",
             "name": "Overwhelm",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "827d012f-ff7b-54ed-92e5-0ac1f774392d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4035157c-92ba-41b6-89c4-85a52578730b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4035157c-92ba-41b6-89c4-85a52578730b.jpg?1",
             "name": "Overwhelming Stampede",
             "text": "Until end of turn, creatures you control gain trample and get +X/+X, where X is the greatest power among creatures you control.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "957799d0-70af-5e68-a538-5dbc94073942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f37ffb3-96d7-4c91-8dd7-eb9061b6cf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f37ffb3-96d7-4c91-8dd7-eb9061b6cf7f.jpg?1",
             "name": "Pelakka Wurm",
             "text": "Trample\nWhen Pelakka Wurm enters the battlefield, you gain 7 life.\nWhen Pelakka Wurm dies, draw a card.",
             "colours": [
@@ -5195,7 +5195,7 @@
         },
         {
             "id": "6d4f0092-8099-5ce9-a6ae-951628c14477",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c24ae7-ae33-4324-8880-84f71262ffd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c24ae7-ae33-4324-8880-84f71262ffd9.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -5227,7 +5227,7 @@
         },
         {
             "id": "31589d7b-e410-5c6a-abd2-ca40b491fd5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea2bf31-4320-4605-ab5b-6b32472b82fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea2bf31-4320-4605-ab5b-6b32472b82fa.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "e35f807e-1a16-51d5-9529-b02de54c1f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07954800-e3b8-4d73-a763-56a64726c384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07954800-e3b8-4d73-a763-56a64726c384.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "8e1d71bf-b345-5b06-9e54-6b4ceddd51a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840c324-4dd4-41fe-9af2-593314ab685e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840c324-4dd4-41fe-9af2-593314ab685e.jpg?1",
             "name": "Root-Kin Ally",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTap two untapped creatures you control: Root-Kin Ally gets +2/+2 until end of turn.",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "ad9ec3f2-f923-57af-83f6-c186ef110dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28c2a8-ee7d-4eea-8046-a47e81ddd28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b28c2a8-ee7d-4eea-8046-a47e81ddd28d.jpg?1",
             "name": "Scatter the Seeds",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPut three 1/1 green Saproling creature tokens onto the battlefield.",
             "colours": [
@@ -5360,7 +5360,7 @@
         },
         {
             "id": "263fecae-3c4a-51d9-843d-7c7d655a0619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8860f5-64ad-4e2d-bab9-b7d416e4ddb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8860f5-64ad-4e2d-bab9-b7d416e4ddb9.jpg?1",
             "name": "Scion of the Wild",
             "text": "Scion of the Wild's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -5394,7 +5394,7 @@
         },
         {
             "id": "6a5be7b5-e934-56b6-ab07-1180723be36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fca009-8424-41b0-9807-7af979dde785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fca009-8424-41b0-9807-7af979dde785.jpg?1",
             "name": "Scute Mob",
             "text": "At the beginning of your upkeep, if you control five or more lands, put four +1/+1 counters on Scute Mob.",
             "colours": [
@@ -5428,7 +5428,7 @@
         },
         {
             "id": "f94e8013-617b-5c2d-9519-64872138ccaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68896747-bab9-4c29-9fd0-764bebde96c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68896747-bab9-4c29-9fd0-764bebde96c4.jpg?1",
             "name": "Simic Initiate",
             "text": "Graft 1 (This creature enters the battlefield with a +1/+1 counter on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)",
             "colours": [
@@ -5463,7 +5463,7 @@
         },
         {
             "id": "fb395431-616b-51b9-ba71-41bde01d2e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491b58f-3c54-41ea-b93b-c32fdc1e5917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a491b58f-3c54-41ea-b93b-c32fdc1e5917.jpg?1",
             "name": "Sundering Vitae",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -5495,7 +5495,7 @@
         },
         {
             "id": "d3859c19-1bed-52f9-8f3b-0d3c1df5e9c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d9dfe0-a793-4903-a83d-dc9041a87f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d9dfe0-a793-4903-a83d-dc9041a87f83.jpg?1",
             "name": "Sylvan Bounty",
             "text": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -5527,7 +5527,7 @@
         },
         {
             "id": "bd35b85f-0417-5fe7-a96d-213201988380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfdd410-391b-4b71-8139-f5a30653097a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfdd410-391b-4b71-8139-f5a30653097a.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "7da0f887-1e95-53cd-97e4-5fa438631a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88e954-7041-4063-8625-fa98d9be9394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c88e954-7041-4063-8625-fa98d9be9394.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -5593,7 +5593,7 @@
         },
         {
             "id": "ee9efb33-56fe-53f7-b8a9-0410519498ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e76688-bba3-4498-8c01-75cfa03c9ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e76688-bba3-4498-8c01-75cfa03c9ad8.jpg?1",
             "name": "Tukatongue Thallid",
             "text": "When Tukatongue Thallid dies, put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5627,7 +5627,7 @@
         },
         {
             "id": "394e8181-41ee-5978-bef6-532ecf96930d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203e3d4-8998-41d6-9f7e-b68af0f1f8b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6203e3d4-8998-41d6-9f7e-b68af0f1f8b5.jpg?1",
             "name": "Vines of Vastwood",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nTarget creature can't be the target of spells or abilities your opponents control this turn. If Vines of Vastwood was kicked, that creature gets +4/+4 until end of turn.",
             "colours": [
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "c09055ab-723e-5193-9df3-9d23a6345404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb10f5be-a82f-4f4f-8653-2d6927ac0ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb10f5be-a82f-4f4f-8653-2d6927ac0ca8.jpg?1",
             "name": "Wolfbriar Elemental",
             "text": "Multikicker {G} (You may pay an additional {G} any number of times as you cast this spell.)\nWhen Wolfbriar Elemental enters the battlefield, put a 2/2 green Wolf creature token onto the battlefield for each time it was kicked.",
             "colours": [
@@ -5693,7 +5693,7 @@
         },
         {
             "id": "d37425cd-19e5-5a32-b1bd-72f23f559315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325fa8a5-3464-4217-971d-cd4aa8e2e865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325fa8a5-3464-4217-971d-cd4aa8e2e865.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "d1b515db-6b1a-5d6c-ab9c-71d6e2109aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc9b519-f558-4aec-9d75-e2a8a3f48b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc9b519-f558-4aec-9d75-e2a8a3f48b8c.jpg?1",
             "name": "Apocalypse Hydra",
             "text": "Apocalypse Hydra enters the battlefield with X +1/+1 counters on it. If X is 5 or more, it enters the battlefield with an additional X +1/+1 counters on it.\n{1}{R}, Remove a +1/+1 counter from Apocalypse Hydra: Apocalypse Hydra deals 1 damage to target creature or player.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "80407c4b-f83f-57ff-bfa1-eb24edce3ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6135a9f2-e86d-4a34-857e-adea3c722fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6135a9f2-e86d-4a34-857e-adea3c722fea.jpg?1",
             "name": "Boros Swiftblade",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -5800,7 +5800,7 @@
         },
         {
             "id": "a27d5f46-612f-55a7-bda9-dbf081143a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbafd6c-15cc-492f-b1e4-c5baa61e4a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbafd6c-15cc-492f-b1e4-c5baa61e4a0b.jpg?1",
             "name": "Drooling Groodion",
             "text": "{2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "db4514d3-f5ba-52ef-962a-0403e7ea972b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d916a-5c87-4e16-b8e0-6d65b6d2ef53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d916a-5c87-4e16-b8e0-6d65b6d2ef53.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -5870,7 +5870,7 @@
         },
         {
             "id": "4316406e-ba39-58b8-9939-fe011bb55cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125126e1-1e48-42ed-ac94-02f62ab13d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125126e1-1e48-42ed-ac94-02f62ab13d05.jpg?1",
             "name": "Ethercaste Knight",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "c94b673d-0737-5ec6-8c7a-a112cf47d8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b551074-a9b4-45f0-a007-f07d7b2e12a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b551074-a9b4-45f0-a007-f07d7b2e12a8.jpg?1",
             "name": "Ghost Council of Orzhova",
             "text": "When Ghost Council of Orzhova enters the battlefield, target opponent loses 1 life and you gain 1 life.\n{1}, Sacrifice a creature: Exile Ghost Council of Orzhova. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -5946,7 +5946,7 @@
         },
         {
             "id": "f83035fc-d60a-59ec-83f4-ab555b2a7716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bbbfda-2909-45e3-bdbb-9e8964e608d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bbbfda-2909-45e3-bdbb-9e8964e608d1.jpg?1",
             "name": "Glassdust Hulk",
             "text": "Whenever another artifact enters the battlefield under your control, Glassdust Hulk gets +1/+1 until end of turn and can't be blocked this turn.\nCycling {WU} ({WU}, Discard this card: Draw a card.)",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "fa018623-103d-50c4-b2c3-2b1baedc1b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5137c28-632f-40f4-bf9d-877f5f070987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5137c28-632f-40f4-bf9d-877f5f070987.jpg?1",
             "name": "Horde of Notions",
             "text": "Vigilance, trample, haste\n{W}{U}{B}{R}{G}: You may play target Elemental card from your graveyard without paying its mana cost.",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "6cb209ae-1934-5d61-87d3-c019097f221e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a752d05-cd6f-4754-85fd-16f1308ac1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a752d05-cd6f-4754-85fd-16f1308ac1ea.jpg?1",
             "name": "Lorescale Coatl",
             "text": "Whenever you draw a card, you may put a +1/+1 counter on Lorescale Coatl.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "76a20841-426a-5c4a-abae-15c0b6feded6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38810fe4-dc72-439e-adf7-362af772b8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38810fe4-dc72-439e-adf7-362af772b8f8.jpg?1",
             "name": "Mystic Snake",
             "text": "Flash\nWhen Mystic Snake enters the battlefield, counter target spell.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "c1a6e091-1736-59bb-9dc0-f6d4f91106ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee31b6-874f-47fc-9e94-0f4e6413ef54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee31b6-874f-47fc-9e94-0f4e6413ef54.jpg?1",
             "name": "Necrogenesis",
             "text": "{2}: Exile target creature card from a graveyard. Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "1a1fa698-2bff-54f2-824e-8d58bbf424b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fd56e6-5d54-426e-9e44-ec2ad8a63724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fd56e6-5d54-426e-9e44-ec2ad8a63724.jpg?1",
             "name": "Niv-Mizzet, the Firemind",
             "text": "Flying\nWhenever you draw a card, Niv-Mizzet, the Firemind deals 1 damage to target creature or player.\n{T}: Draw a card.",
             "colours": [
@@ -6172,7 +6172,7 @@
         },
         {
             "id": "01311c55-7816-5d61-b2ba-1d87421225e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d01b08e-9cd6-4166-afcc-c58ea323e29f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d01b08e-9cd6-4166-afcc-c58ea323e29f.jpg?1",
             "name": "Pillory of the Sleepless",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"At the beginning of your upkeep, you lose 1 life.\"",
             "colours": [
@@ -6208,7 +6208,7 @@
         },
         {
             "id": "765a427b-81b8-5be0-b5c4-f140fbc0d88f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173d28f9-b356-457d-b356-22993460429c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173d28f9-b356-457d-b356-22993460429c.jpg?1",
             "name": "Plaxcaster Frogling",
             "text": "Graft 3 (This creature enters the battlefield with three +1/+1 counters on it. Whenever another creature enters the battlefield, you may move a +1/+1 counter from this creature onto it.)\n{2}: Target creature with a +1/+1 counter on it gains shroud until end of turn. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "5128268b-50b2-5756-8f4e-ea2247c32f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667b7583-23e0-4721-b2f9-4f06167532af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667b7583-23e0-4721-b2f9-4f06167532af.jpg?1",
             "name": "Savage Twister",
             "text": "Savage Twister deals X damage to each creature.",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "a5e88598-ceed-5ad0-8b97-ee3980eedb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39aea233-992a-4aea-86c1-f9c07c74efbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39aea233-992a-4aea-86c1-f9c07c74efbc.jpg?1",
             "name": "Shadowmage Infiltrator",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever Shadowmage Infiltrator deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -6316,7 +6316,7 @@
         },
         {
             "id": "979aa9e5-5a51-5a23-955b-b227f0e2f2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b5a580-c267-43f7-be77-fbc2928ff0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b5a580-c267-43f7-be77-fbc2928ff0ab.jpg?1",
             "name": "Sigil Blessing",
             "text": "Until end of turn, target creature you control gets +3/+3 and other creatures you control get +1/+1.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "0916d4b2-1503-5e3a-a5ed-9f978fa15356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a2f52-56b9-4eb5-b2ae-8dbee42a490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a2f52-56b9-4eb5-b2ae-8dbee42a490c.jpg?1",
             "name": "Vengeful Rebirth",
             "text": "Return target card from your graveyard to your hand. If you return a nonland card to your hand this way, Vengeful Rebirth deals damage equal to that card's converted mana cost to target creature or player.\nExile Vengeful Rebirth.",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "6c790f87-7523-5548-8a3e-aeef935e417a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d933dfd2-6def-4d07-92c2-93a771996fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d933dfd2-6def-4d07-92c2-93a771996fe6.jpg?1",
             "name": "Wrecking Ball",
             "text": "Destroy target creature or land.",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "d83e8cad-3e14-5fff-a0f9-0b0ad3336b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad79a3-050a-43f0-81ea-7f8c2ae00abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ad79a3-050a-43f0-81ea-7f8c2ae00abf.jpg?1",
             "name": "Ashenmoor Gouger",
             "text": "Ashenmoor Gouger can't block.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "8f129a5c-3b99-5b20-8b96-e79c88fe82c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc8f83-07a5-4ced-a0f4-78c75c287903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bcc8f83-07a5-4ced-a0f4-78c75c287903.jpg?1",
             "name": "Creakwood Liege",
             "text": "Other black creatures you control get +1/+1.\nOther green creatures you control get +1/+1.\nAt the beginning of your upkeep, you may put a 1/1 black and green Worm creature token onto the battlefield.",
             "colours": [
@@ -6491,7 +6491,7 @@
         },
         {
             "id": "fe299dcf-a9cb-5606-a882-63a8bad859a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d19fbe-0f6d-4e22-b56d-a63fd17a48ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d19fbe-0f6d-4e22-b56d-a63fd17a48ef.jpg?1",
             "name": "Dimir Guildmage",
             "text": "{3}{U}: Target player draws a card. Activate this ability only any time you could cast a sorcery.\n{3}{B}: Target player discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "d9dfa079-9428-5138-af1e-837f1dd77f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b128089-ed05-4a94-b83e-a5f783b8cec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b128089-ed05-4a94-b83e-a5f783b8cec8.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -6565,7 +6565,7 @@
         },
         {
             "id": "69f2bb1a-4059-5274-9991-136ab758b990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee5eda-41a9-4cae-bb2a-b63fd450d02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee5eda-41a9-4cae-bb2a-b63fd450d02d.jpg?1",
             "name": "Hearthfire Hobgoblin",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "cf04505f-9122-5e42-8b4e-f89947b6dd54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f002636-1971-468d-b171-7b8147829972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f002636-1971-468d-b171-7b8147829972.jpg?1",
             "name": "Nobilis of War",
             "text": "Flying\nAttacking creatures you control get +2/+0.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "c77d29c1-7056-5246-8103-0e9155a4304e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aea782-f054-41bc-8681-7e2246e6f3fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70aea782-f054-41bc-8681-7e2246e6f3fd.jpg?1",
             "name": "Restless Apparition",
             "text": "{WB}{WB}{WB}: Restless Apparition gets +3/+3 until end of turn.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "33c42eee-52ab-56fc-a010-b5cf5832331a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ed69a0-8793-45c0-8971-98a062b8b1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ed69a0-8793-45c0-8971-98a062b8b1fb.jpg?1",
             "name": "Selesnya Guildmage",
             "text": "{3}{G}: Put a 1/1 green Saproling creature token onto the battlefield.\n{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "de4d7ab9-bbe8-5985-a1eb-783516a5f953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4e3f7-bef1-419b-963e-9fee4ee23b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de4e3f7-bef1-419b-963e-9fee4ee23b0e.jpg?1",
             "name": "Shrewd Hatchling",
             "text": "Shrewd Hatchling enters the battlefield with four -1/-1 counters on it.\n{UR}: Target creature can't block Shrewd Hatchling this turn.\nWhenever you cast a blue spell, remove a -1/-1 counter from Shrewd Hatchling.\nWhenever you cast a red spell, remove a -1/-1 counter from Shrewd Hatchling.",
             "colours": [
@@ -6748,7 +6748,7 @@
         },
         {
             "id": "57933a16-5019-5e79-8c74-a278082feba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8903e1d-e255-4eda-bb8e-c6229a88c8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8903e1d-e255-4eda-bb8e-c6229a88c8a7.jpg?1",
             "name": "Swans of Bryn Argoll",
             "text": "Flying\nIf a source would deal damage to Swans of Bryn Argoll, prevent that damage. The source's controller draws cards equal to the damage prevented this way.",
             "colours": [
@@ -6785,7 +6785,7 @@
         },
         {
             "id": "8dbc018a-892d-561b-a5de-0b89f551347d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0bcfad-cb7e-4b12-b308-a4a1245bd835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0bcfad-cb7e-4b12-b308-a4a1245bd835.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "c8801149-3f76-5c62-acb9-a0bd4d229af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a82ecd-ce0c-456e-bb79-b3b8d6602e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a82ecd-ce0c-456e-bb79-b3b8d6602e1b.jpg?1",
             "name": "Alloy Myr",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -6853,7 +6853,7 @@
         },
         {
             "id": "f842237a-3f2d-5314-8967-b7a8e83283ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0dfbd3-4b19-4f56-b6c2-7107a3cba4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0dfbd3-4b19-4f56-b6c2-7107a3cba4ec.jpg?1",
             "name": "Blinding Souleater",
             "text": "{PW}, {T}: Tap target creature. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [],
@@ -6887,7 +6887,7 @@
         },
         {
             "id": "c77f1971-edf5-5ebe-a84d-f8fa0d83ac11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3dbd79-c0a3-44ec-bf52-611515c865c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3dbd79-c0a3-44ec-bf52-611515c865c4.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion dies, add {3} to your mana pool.",
             "colours": [],
@@ -6918,7 +6918,7 @@
         },
         {
             "id": "2515fcf6-fe2e-5457-ab8d-bff8f2a668c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef3dea8-b3e5-432e-a65d-442fe06ca976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef3dea8-b3e5-432e-a65d-442fe06ca976.jpg?1",
             "name": "Chimeric Mass",
             "text": "Chimeric Mass enters the battlefield with X charge counters on it.\n{1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"",
             "colours": [],
@@ -6946,7 +6946,7 @@
         },
         {
             "id": "14baa456-522e-5d71-ac9f-9150c049372d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eb220b-3ff1-4396-87e3-7aaaa1098691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eb220b-3ff1-4396-87e3-7aaaa1098691.jpg?1",
             "name": "Copper Carapace",
             "text": "Equipped creature gets +2/+2 and can't block.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6976,7 +6976,7 @@
         },
         {
             "id": "6581220c-9d1a-5db9-94de-b0311db49d3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9478c80-621a-4b5c-8ba9-fa790f0619d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9478c80-621a-4b5c-8ba9-fa790f0619d8.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "b0db95b7-e990-53f5-be8e-9498d9b65fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5aaf42f-aee0-4874-9408-3e9e5480a0ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5aaf42f-aee0-4874-9408-3e9e5480a0ff.jpg?1",
             "name": "Culling Dais",
             "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
             "colours": [],
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "70640661-c46c-5c6d-ba1c-739e0acd3719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60beab79-8992-4f87-89b4-9eab03509f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60beab79-8992-4f87-89b4-9eab03509f38.jpg?1",
             "name": "Darksteel Axe",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this artifact.)\nEquipped creature gets +2/+0.\nEquip {2}",
             "colours": [],
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "e9478ff2-04a1-516f-b230-e84a0e28b4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe653b-956a-4e0e-981b-37e1a6b08c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe653b-956a-4e0e-981b-37e1a6b08c2c.jpg?1",
             "name": "Etched Champion",
             "text": "Metalcraft \u2014 Etched Champion has protection from all colors as long as you control three or more artifacts.",
             "colours": [],
@@ -7097,7 +7097,7 @@
         },
         {
             "id": "4f75f06d-4c2c-5165-b30d-fac714d3e74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6be7947-b929-408d-ad67-3b07b93dd36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6be7947-b929-408d-ad67-3b07b93dd36e.jpg?1",
             "name": "Etched Monstrosity",
             "text": "Etched Monstrosity enters the battlefield with five -1/-1 counters on it.\n{W}{U}{B}{R}{G}, Remove five -1/-1 counters from Etched Monstrosity: Target player draws three cards.",
             "colours": [],
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "2b5ce2a9-dbde-5aeb-9e4d-a99baca77a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874c6926-1368-45fb-8ce6-2d1c3e231bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874c6926-1368-45fb-8ce6-2d1c3e231bf0.jpg?1",
             "name": "Etched Oracle",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\n{1}, Remove four +1/+1 counters from Etched Oracle: Target player draws three cards.",
             "colours": [],
@@ -7166,7 +7166,7 @@
         },
         {
             "id": "f010c67b-6a24-575f-8e28-e4d5347d554f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4477e730-6dff-44f1-97a5-8176be1b7f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4477e730-6dff-44f1-97a5-8176be1b7f67.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {1} to your mana pool for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -7194,7 +7194,7 @@
         },
         {
             "id": "5beee4c5-3ad7-58f5-a1d5-eaff3c63c256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c708dbd5-1d7b-4ed3-b5a7-93a02d8355ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c708dbd5-1d7b-4ed3-b5a7-93a02d8355ee.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "c37305a1-8c82-50f4-a8de-e8d0d20b0d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a51797a-8a37-4364-86a0-de087348bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a51797a-8a37-4364-86a0-de087348bc82.jpg?1",
             "name": "Flayer Husk",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +1/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "7369197c-c2bf-5b20-b6c5-54124db482c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2991802-e313-40de-b167-0ede5efff101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2991802-e313-40de-b167-0ede5efff101.jpg?1",
             "name": "Frogmite",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7283,7 +7283,7 @@
         },
         {
             "id": "baa8d556-1007-543e-96a7-7bbabd838c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c64d2e-1fbf-4858-8fa7-82bf2e41fe1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c64d2e-1fbf-4858-8fa7-82bf2e41fe1f.jpg?1",
             "name": "Glint Hawk Idol",
             "text": "Whenever another artifact enters the battlefield under your control, you may have Glint Hawk Idol become a 2/2 Bird artifact creature with flying until end of turn.\n{W}: Glint Hawk Idol becomes a 2/2 Bird artifact creature with flying until end of turn.",
             "colours": [],
@@ -7313,7 +7313,7 @@
         },
         {
             "id": "e9aca47f-5435-53f9-ad3c-dfee55e77f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddac7b40-f98e-497b-8075-4695ed3ee490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddac7b40-f98e-497b-8075-4695ed3ee490.jpg?1",
             "name": "Gust-Skimmer",
             "text": "{U}: Gust-Skimmer gains flying until end of turn.",
             "colours": [],
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "11ce0800-ea53-5a98-8fee-28fd9ae2d983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf0479c-4d90-4b81-8170-a42100f91d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf0479c-4d90-4b81-8170-a42100f91d89.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7376,7 +7376,7 @@
         },
         {
             "id": "025fbf5d-fede-58ea-939c-497768b28a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683a5707-cddb-494d-9b41-51b4584ded69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683a5707-cddb-494d-9b41-51b4584ded69.jpg?1",
             "name": "Lodestone Golem",
             "text": "Nonartifact spells cost {1} more to cast.",
             "colours": [],
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "68a15e39-f148-5799-bb3f-328d42adadc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617ddf01-3678-470d-b009-003d6a561dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/617ddf01-3678-470d-b009-003d6a561dbf.jpg?1",
             "name": "Lodestone Myr",
             "text": "Trample\nTap an untapped artifact you control: Lodestone Myr gets +1/+1 until end of turn.",
             "colours": [],
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "f3b1319b-c9e5-5b30-bd80-15d8d5fd701d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced123-3eb4-405e-b26d-30644f35a5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced123-3eb4-405e-b26d-30644f35a5b0.jpg?1",
             "name": "Long-Forgotten Gohei",
             "text": "Arcane spells you cast cost {1} less to cast.\nSpirit creatures you control get +1/+1.",
             "colours": [],
@@ -7466,7 +7466,7 @@
         },
         {
             "id": "12700cfb-815d-5e1d-9c2c-3c31a92a8fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e6b292-41e7-40f9-b9fe-34f27d4526af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e6b292-41e7-40f9-b9fe-34f27d4526af.jpg?1",
             "name": "Mortarpod",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +0/+1 and has \"Sacrifice this creature: This creature deals 1 damage to target creature or player.\"\nEquip {2}",
             "colours": [],
@@ -7496,7 +7496,7 @@
         },
         {
             "id": "38428eaf-113e-5a41-b79f-5f738c9599ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3a20ac-1860-4513-bb73-35d23b088b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3a20ac-1860-4513-bb73-35d23b088b04.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color to your mana pool. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -7526,7 +7526,7 @@
         },
         {
             "id": "5621fae1-b71a-57d4-916b-68e2037a02db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff51ae7-4b68-4770-915b-fb6bcf9ca1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff51ae7-4b68-4770-915b-fb6bcf9ca1ed.jpg?1",
             "name": "Myr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "541f26de-592d-5efc-b5d5-af5606b94879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc90d632-fc78-4ae6-83c6-314ee5744de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc90d632-fc78-4ae6-83c6-314ee5744de5.jpg?1",
             "name": "Precursor Golem",
             "text": "When Precursor Golem enters the battlefield, put two 3/3 colorless Golem artifact creature tokens onto the battlefield.\nWhenever a player casts an instant or sorcery spell that targets only a single Golem, that player copies that spell for each other Golem that spell could target. Each copy targets a different one of those Golems.",
             "colours": [],
@@ -7588,7 +7588,7 @@
         },
         {
             "id": "3215ca23-5730-5145-bbfa-956cee7b78a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbb0a4-b788-4fe7-8663-36adbe2036ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbb0a4-b788-4fe7-8663-36adbe2036ed.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -7619,7 +7619,7 @@
         },
         {
             "id": "76c91584-220e-5a17-aeaf-430056622eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797a4456-1677-49d5-bb4f-4fb062522f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797a4456-1677-49d5-bb4f-4fb062522f1e.jpg?1",
             "name": "Rusted Relic",
             "text": "Metalcraft \u2014 Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.",
             "colours": [],
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "47e44e78-b6d3-514f-a7be-836590c1df0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a9736-c84d-42a6-831c-3b1a8bad50b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0a9736-c84d-42a6-831c-3b1a8bad50b7.jpg?1",
             "name": "Sickleslicer",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+2.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "7b0acf05-5414-5ede-98fd-aa071ecf3696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df1e8a0-6a54-4be9-bd0c-ac70f0ae9aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df1e8a0-6a54-4be9-bd0c-ac70f0ae9aa6.jpg?1",
             "name": "Skyreach Manta",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\nFlying",
             "colours": [],
@@ -7708,7 +7708,7 @@
         },
         {
             "id": "9a9e432b-2911-55bc-8572-e9f59e356a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e0daf-aafe-4696-a977-ac5b822134e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e0daf-aafe-4696-a977-ac5b822134e2.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "d50ab590-465f-56b5-ae1d-74fffe98c4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f7dd0-290f-4ba4-aa2d-29ff148e7778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f7dd0-290f-4ba4-aa2d-29ff148e7778.jpg?1",
             "name": "Sphere of the Suns",
             "text": "Sphere of the Suns enters the battlefield tapped and with three charge counters on it.\n{T}, Remove a charge counter from Sphere of the Suns: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "9456061d-9907-5669-9d67-d1239f2d6aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6e159-f229-44a8-b542-78e3c3d6ec79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6e159-f229-44a8-b542-78e3c3d6ec79.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -7803,7 +7803,7 @@
         },
         {
             "id": "f18abb27-6da8-5ce3-b07c-2004c0bd3818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c158f888-1870-4be7-9afd-39e859f261a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c158f888-1870-4be7-9afd-39e859f261a6.jpg?1",
             "name": "Tumble Magnet",
             "text": "Tumble Magnet enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Tumble Magnet: Tap target artifact or creature.",
             "colours": [],
@@ -7831,7 +7831,7 @@
         },
         {
             "id": "cf584269-cbb1-5b4e-9f86-e86cda6ede0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1272beac-71ac-4a88-bd49-a5a907c182ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1272beac-71ac-4a88-bd49-a5a907c182ac.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "52c4be91-b07d-50b0-a8f2-262c736a87fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481a83e6-0e6c-4953-92d4-814000d19456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481a83e6-0e6c-4953-92d4-814000d19456.jpg?1",
             "name": "Azorius Chancery",
             "text": "Azorius Chancery enters the battlefield tapped.\nWhen Azorius Chancery enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "d00e838f-9d91-5d64-b6fe-ce778ef30660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0e338-fe48-4108-b1a4-0bc9bf4ed708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f0e338-fe48-4108-b1a4-0bc9bf4ed708.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -7918,7 +7918,7 @@
         },
         {
             "id": "72f4ed14-bdd3-5685-8bc6-2c1432014986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750975a0-112b-439f-ae4e-40480aa64823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750975a0-112b-439f-ae4e-40480aa64823.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison enters the battlefield tapped.\nWhen Boros Garrison enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "c40d6468-339d-57a0-87ca-b995cb4c630a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371077bd-9b4b-4c75-9494-c6a3cb1b304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371077bd-9b4b-4c75-9494-c6a3cb1b304d.jpg?1",
             "name": "Darksteel Citadel",
             "text": "Indestructible (Effects that say \"destroy\" don't destroy this land.)\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "3496ded9-3a71-57f3-b1ed-5cc0bf97b2ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b68dd-9a83-4e6e-9e34-53eb80311425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703b68dd-9a83-4e6e-9e34-53eb80311425.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct enters the battlefield tapped.\nWhen Dimir Aqueduct enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -8009,7 +8009,7 @@
         },
         {
             "id": "d1b618a1-4255-559e-bb96-6da1b4c14f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab30d54-6043-4361-b221-268813f06a72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab30d54-6043-4361-b221-268813f06a72.jpg?1",
             "name": "Eldrazi Temple",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {2} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
             "colours": [],
@@ -8037,7 +8037,7 @@
         },
         {
             "id": "e070deb8-c601-552c-878d-783885aca2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd49258-f7cd-4902-a17f-9a195958fc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd49258-f7cd-4902-a17f-9a195958fc13.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8065,7 +8065,7 @@
         },
         {
             "id": "688e5b80-1eb3-587c-8c83-8c6df5c9ec8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5124b-4d73-4aa9-9331-88e03779ffad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5124b-4d73-4aa9-9331-88e03779ffad.jpg?1",
             "name": "Eye of Ugin",
             "text": "Colorless Eldrazi spells you cast cost {2} less to cast.\n{7}, {T}: Search your library for a colorless creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "49011692-04ae-5526-a27f-17ff702cead0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580063b8-9b0d-4ce0-bf2b-63299e15219e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580063b8-9b0d-4ce0-bf2b-63299e15219e.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm enters the battlefield tapped.\nWhen Golgari Rot Farm enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -8126,7 +8126,7 @@
         },
         {
             "id": "3439ff7e-d227-5bc5-9093-d2ce119a1340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1325d187-4012-4875-9a0c-8520cbf386ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1325d187-4012-4875-9a0c-8520cbf386ac.jpg?1",
             "name": "Gruul Turf",
             "text": "Gruul Turf enters the battlefield tapped.\nWhen Gruul Turf enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "ae4832e2-8003-5b5a-b4b1-fbbef89a6b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2759-a3d8-45f8-b31e-d8789bde0f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2759-a3d8-45f8-b31e-d8789bde0f4f.jpg?1",
             "name": "Izzet Boilerworks",
             "text": "Izzet Boilerworks enters the battlefield tapped.\nWhen Izzet Boilerworks enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -8188,7 +8188,7 @@
         },
         {
             "id": "9df98f4e-6524-5eee-bce7-9b3f876c9eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6b961-303d-4585-801a-82690e3c66d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6b961-303d-4585-801a-82690e3c66d9.jpg?1",
             "name": "Orzhov Basilica",
             "text": "Orzhov Basilica enters the battlefield tapped.\nWhen Orzhov Basilica enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -8219,7 +8219,7 @@
         },
         {
             "id": "e32f09a0-09f9-596e-b372-86a9bdd33c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7e0892-7f4f-4dea-8eba-088250512071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7e0892-7f4f-4dea-8eba-088250512071.jpg?1",
             "name": "Rakdos Carnarium",
             "text": "Rakdos Carnarium enters the battlefield tapped.\nWhen Rakdos Carnarium enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "7d46291d-56ef-595f-8b56-c869eba2646d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbde99df-95bb-4941-981c-127c19f90488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbde99df-95bb-4941-981c-127c19f90488.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary enters the battlefield tapped.\nWhen Selesnya Sanctuary enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "1578cced-d0b0-53dc-b4a8-116e4ad38b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4c9c55-456f-4cc5-b727-4091708b0df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4c9c55-456f-4cc5-b727-4091708b0df1.jpg?1",
             "name": "Simic Growth Chamber",
             "text": "Simic Growth Chamber enters the battlefield tapped.\nWhen Simic Growth Chamber enters the battlefield, return a land you control to its owner's hand.\n{T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -8312,7 +8312,7 @@
         },
         {
             "id": "bab776c5-7084-5285-90e2-89d8a1413dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1ef4fc-9b03-4750-90c9-aaa0017579dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1ef4fc-9b03-4750-90c9-aaa0017579dc.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8343,7 +8343,7 @@
         },
         {
             "id": "5aac07aa-bf49-5b6b-98c1-a66f5cf75f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94559ea-b4c8-42e5-81b5-df45b2d711fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94559ea-b4c8-42e5-81b5-df45b2d711fd.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8374,7 +8374,7 @@
         },
         {
             "id": "d461a50f-61bc-58fa-84e5-28fd6f6c9fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaae110-ef18-44fa-b8a8-c68bd439581e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaae110-ef18-44fa-b8a8-c68bd439581e.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "21fb09ef-4b2e-508e-bfe0-6031a66fa198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d480a351-cb9d-4bcc-b5c4-cd197ae98d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d480a351-cb9d-4bcc-b5c4-cd197ae98d43.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "3b3ea474-8c13-5cf0-80de-328b45661723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8473,7 +8473,7 @@
         },
         {
             "id": "2af42eb8-cf37-5bcc-acaf-fc2c33288ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b53311-d007-42e8-94c0-c18052b6ef09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b53311-d007-42e8-94c0-c18052b6ef09.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "89b1fd11-e64b-50f0-86f0-b6f945a19c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414f9fa-dfda-4714-9f87-cb5e8914b07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4414f9fa-dfda-4714-9f87-cb5e8914b07a.jpg?1",
             "name": "Germ",
             "text": "",
             "colours": [
@@ -8542,7 +8542,7 @@
         },
         {
             "id": "b6afe76a-9a45-5137-bf59-206e7ae7cbf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9f471a-1822-4981-95a9-8923d83ddcbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9f471a-1822-4981-95a9-8923d83ddcbf.jpg?1",
             "name": "Thrull",
             "text": "",
             "colours": [
@@ -8576,7 +8576,7 @@
         },
         {
             "id": "3d55fbc5-53e0-5290-925d-85d38bc10fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbccfc7-427b-41e6-b770-92d73994bf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbccfc7-427b-41e6-b770-92d73994bf3b.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "c7dbe124-4f58-5649-828f-e3368d4ed796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599b5074-86a5-4666-8cf4-3deb83c09ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599b5074-86a5-4666-8cf4-3deb83c09ba0.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "52c46d94-2f16-5836-99d0-da960c87f1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa39099-1ce8-4d59-bc2e-6bb99d10e97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa39099-1ce8-4d59-bc2e-6bb99d10e97c.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8678,7 +8678,7 @@
         },
         {
             "id": "b55c7874-9928-5560-9363-817a95c560ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a452235-cebd-4e8f-b217-9b55fc1c3830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a452235-cebd-4e8f-b217-9b55fc1c3830.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -8712,7 +8712,7 @@
         },
         {
             "id": "61601928-3f3b-5630-a518-f339dc673ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb3368-fee3-4795-a23f-c97555ee7475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdb3368-fee3-4795-a23f-c97555ee7475.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "90745830-76bc-59b4-a11b-1100fbe50fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd82205-5d3e-4a8d-a31b-020efc6303d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd82205-5d3e-4a8d-a31b-020efc6303d0.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -8782,7 +8782,7 @@
         },
         {
             "id": "94a1b77a-1e22-551f-ba1f-0838a6549d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae65394e-0c97-4cde-8591-13d081192e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae65394e-0c97-4cde-8591-13d081192e26.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -8813,7 +8813,7 @@
         },
         {
             "id": "ad927c4e-b2bb-5385-8ce6-d7316cc51623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a8c1a6-a88a-4b23-bd80-95769ea4917c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a8c1a6-a88a-4b23-bd80-95769ea4917c.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MM3.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MM3.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "15844e0d-9a41-505e-8f09-59bcaf3f9650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac22a3b-4536-4372-a854-bc7f0919830b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac22a3b-4536-4372-a854-bc7f0919830b.jpg?1",
             "name": "Attended Knight",
             "text": "First strike\nWhen Attended Knight enters the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "2f86fa48-502d-5bc6-959a-ee10ec41a57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eea01e5-d3ea-4d05-8d17-cae7b982d882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eea01e5-d3ea-4d05-8d17-cae7b982d882.jpg?1",
             "name": "Banishing Stroke",
             "text": "Put target artifact, creature, or enchantment on the bottom of its owner's library.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "d9cec7c7-5d1b-5c0e-9a01-96bd34d28b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d53b9ef-fedc-4471-ac90-018d7033a9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d53b9ef-fedc-4471-ac90-018d7033a9fc.jpg?1",
             "name": "Blade Splicer",
             "text": "When Blade Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control have first strike.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "92eeff2b-e0bc-525f-8cd8-bcee557f9742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916becd7-3be9-4525-83cf-3dd133816f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916becd7-3be9-4525-83cf-3dd133816f69.jpg?1",
             "name": "Entreat the Angels",
             "text": "Create X 4/4 white Angel creature tokens with flying.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "2864e0cd-f5cd-574f-8d71-018c1bfaa0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a1d9ad-a434-43de-bcb3-143d07dbd775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1a1d9ad-a434-43de-bcb3-143d07dbd775.jpg?1",
             "name": "Eyes in the Skies",
             "text": "Create a 1/1 white Bird creature token with flying, then populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "b448d4cf-c2e8-5511-a067-ddbcc0b85ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcfcf9a7-bad6-4240-8e43-a6a81fc4fbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcfcf9a7-bad6-4240-8e43-a6a81fc4fbd0.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "601385d5-2441-5035-b9e7-4a26bb31d059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df30f49a-32a2-4e9f-8f2a-1b9fab98dc3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df30f49a-32a2-4e9f-8f2a-1b9fab98dc3f.jpg?1",
             "name": "Gideon's Lawkeeper",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "a4085eb4-95ef-5e46-9076-4a6afc8af638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad31171-ad46-4654-91f0-8027e00dedfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad31171-ad46-4654-91f0-8027e00dedfc.jpg?1",
             "name": "Graceful Reprieve",
             "text": "When target creature dies this turn, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "b6f11a93-f77d-5123-baee-83ee31b97557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa549-5eab-42df-b6a8-dd042d598191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa549-5eab-42df-b6a8-dd042d598191.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "2d2bf67f-de2d-549c-8c6c-56d90be67472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c77d014-8ea2-4203-88b4-53be3819bf3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c77d014-8ea2-4203-88b4-53be3819bf3c.jpg?1",
             "name": "Kor Hookmaster",
             "text": "When Kor Hookmaster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "e23db86a-46e9-5b73-8c88-15dd24c5ed17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7501662-1216-4e08-bd2b-e0a459057942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7501662-1216-4e08-bd2b-e0a459057942.jpg?1",
             "name": "Kor Skyfisher",
             "text": "Flying\nWhen Kor Skyfisher enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "1bc7525f-2954-5402-9d90-031229a60162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf1288a-8e2c-4a69-afcf-af293f66d007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf1288a-8e2c-4a69-afcf-af293f66d007.jpg?1",
             "name": "Lingering Souls",
             "text": "Create two 1/1 white Spirit creature tokens with flying.\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -407,7 +407,7 @@
         },
         {
             "id": "8012aebe-9845-51fb-a6be-6072bfc76c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb2588-60f7-4e3b-b625-3b3ada7bcc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cb2588-60f7-4e3b-b625-3b3ada7bcc28.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "Flying\nActivated abilities of creatures your opponents control can't be activated.",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "c8286107-f1f6-5084-9cde-e7cd86ebaf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31d5b6-0973-43d2-aae0-a3f3e7a61800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31d5b6-0973-43d2-aae0-a3f3e7a61800.jpg?1",
             "name": "Lone Missionary",
             "text": "When Lone Missionary enters the battlefield, you gain 4 life.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "4220910a-df68-54f4-8c53-97dfa455bbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c44c1e-60b8-49f7-af9a-d23dcd8a3771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c44c1e-60b8-49f7-af9a-d23dcd8a3771.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control get +1/+1.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "e1f7fcbe-6ece-5ec3-a243-185adbd4f54e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4206d5f8-edeb-4e0b-8e98-736f6ccdcf99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4206d5f8-edeb-4e0b-8e98-736f6ccdcf99.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "4df6983c-041f-58b0-9cdf-863354f53f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df0a2-1967-4ddd-84e3-3ecf3af98f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061df0a2-1967-4ddd-84e3-3ecf3af98f6b.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "32ca9f44-1e73-5ac5-91a0-3d99bafe2e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a4596-552a-45dc-88a6-41810d078d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a4596-552a-45dc-88a6-41810d078d66.jpg?1",
             "name": "Pitfall Trap",
             "text": "If exactly one creature is attacking, you may pay {W} rather than pay Pitfall Trap's mana cost.\nDestroy target attacking creature without flying.",
             "colours": [
@@ -613,7 +613,7 @@
         },
         {
             "id": "d4a9c43a-5439-56af-ac34-fa86d03b3855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3ba78b-c66a-4a93-abc6-18b63779eda3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3ba78b-c66a-4a93-abc6-18b63779eda3.jpg?1",
             "name": "Ranger of Eos",
             "text": "When Ranger of Eos enters the battlefield, you may search your library for up to two creature cards with converted mana cost 1 or less, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "ca02530d-db71-5096-a23b-af87dc85cea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958bcdd-d0ea-4ae0-9dd0-e6de5cf74128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958bcdd-d0ea-4ae0-9dd0-e6de5cf74128.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "908d81d6-a9e1-53fb-b523-560181cfc20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a945-1e7f-4598-a17b-5af0e7921ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a945-1e7f-4598-a17b-5af0e7921ca8.jpg?1",
             "name": "Rootborn Defenses",
             "text": "Populate. Creatures you control gain indestructible until end of turn. (To populate, create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "dc59d2d9-6937-5b69-bdad-7fbce211b307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e376bdf-076c-471a-9408-b36fc5b8405b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e376bdf-076c-471a-9408-b36fc5b8405b.jpg?1",
             "name": "S\u00e9ance",
             "text": "At the beginning of each upkeep, you may exile target creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a Spirit in addition to its other types. Exile it at the beginning of the next end step.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "2aa9dee2-f81d-5d09-9967-cc78d1862c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369340f-d170-4566-b8e8-e4dc918f7f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369340f-d170-4566-b8e8-e4dc918f7f85.jpg?1",
             "name": "Sensor Splicer",
             "text": "When Sensor Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control have vigilance.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "c5041bf0-7449-5042-8323-a03e68c45e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96266b3-a7cb-40ce-a328-ac13719fe5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96266b3-a7cb-40ce-a328-ac13719fe5f0.jpg?1",
             "name": "Soul Warden",
             "text": "Whenever another creature enters the battlefield, you gain 1 life.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "3c5996de-3d24-5355-b519-0653ad2a8256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7faede-f794-4bda-9d64-21390ba19266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7faede-f794-4bda-9d64-21390ba19266.jpg?1",
             "name": "Stony Silence",
             "text": "Activated abilities of artifacts can't be activated.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "1e28cf88-7b46-5bd8-8950-5c2d04d6224b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e564a2c-e8f0-4ef2-bb1f-1d607dcb0b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e564a2c-e8f0-4ef2-bb1f-1d607dcb0b63.jpg?1",
             "name": "Terminus",
             "text": "Put all creatures on the bottom of their owners' libraries.\nMiracle {W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "2f04cfc5-f0ad-591d-86e6-e2d002973550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ddc04b-49ce-41ca-aadc-e0e9234ac762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ddc04b-49ce-41ca-aadc-e0e9234ac762.jpg?1",
             "name": "Urbis Protector",
             "text": "When Urbis Protector enters the battlefield, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "9d56a27f-4b14-5829-96a4-047258af0535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fad4c2-7db2-4ed2-8b86-e386311512e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fad4c2-7db2-4ed2-8b86-e386311512e7.jpg?1",
             "name": "Wake the Reflections",
             "text": "Populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "d7afb942-c88e-53a3-858f-e2c03df56869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443e222b-4988-4d0f-9a7c-3e859b0211da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443e222b-4988-4d0f-9a7c-3e859b0211da.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "7d08edc7-cd9f-5ec4-89f5-aac423f9f400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7eca7a-5f42-4e58-a6c0-8d07517bda8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7eca7a-5f42-4e58-a6c0-8d07517bda8a.jpg?1",
             "name": "Augur of Bolas",
             "text": "When Augur of Bolas enters the battlefield, look at the top three cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "f1fdfef9-21d8-54e4-85e6-68d9a634bbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a7ed36-a552-4d46-929a-48f34ae9279a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a7ed36-a552-4d46-929a-48f34ae9279a.jpg?1",
             "name": "Azure Mage",
             "text": "{3}{U}: Draw a card.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "25b4ddc4-5c68-5eee-a1d3-b0ecd65256a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ad8a5a-9814-4fb5-90b1-95c0769be456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ad8a5a-9814-4fb5-90b1-95c0769be456.jpg?1",
             "name": "Cackling Counterpart",
             "text": "Create a token that's a copy of target creature you control.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "051934ee-90e9-5f23-b133-63770d910299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5987001-abe9-4418-956e-3a360483cab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5987001-abe9-4418-956e-3a360483cab7.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless he or she discards a land card.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "6c42dda0-3dff-5a5d-bf43-b6a481906576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f73e5f-6228-494f-b74e-aca3520dc2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f73e5f-6228-494f-b74e-aca3520dc2b2.jpg?1",
             "name": "Crippling Chill",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "9580af62-c91a-5e30-9a41-0f2600535b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f6afc-bf16-4ca7-a986-945a95d3bffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268f6afc-bf16-4ca7-a986-945a95d3bffc.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "b3d82a89-3345-5bb6-8f46-b6e1083f6674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a79b9-9f09-476e-b914-cade929dd852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26a79b9-9f09-476e-b914-cade929dd852.jpg?1",
             "name": "Deadeye Navigator",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Deadeye Navigator is paired with another creature, each of those creatures has \"{1}{U}: Exile this creature, then return it to the battlefield under your control.\"",
             "colours": [
@@ -1215,7 +1215,7 @@
         },
         {
             "id": "63d228ad-2fb1-5418-b35c-afa438df5904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179d2a5-4694-4dcc-9261-9f5201c53a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6179d2a5-4694-4dcc-9261-9f5201c53a67.jpg?1",
             "name": "Familiar's Ruse",
             "text": "As an additional cost to cast Familiar's Ruse, return a creature you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -1247,7 +1247,7 @@
         },
         {
             "id": "29171849-893b-506b-9a9b-6bc0f3c7a1f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44335ed-44ba-4c33-b3ed-d7529be23b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44335ed-44ba-4c33-b3ed-d7529be23b4e.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1280,7 +1280,7 @@
         },
         {
             "id": "93f8fd7f-1683-583f-b52f-5f8eebaf5b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccd7eda-5c10-4aa7-a70c-b52f685972e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fccd7eda-5c10-4aa7-a70c-b52f685972e4.jpg?1",
             "name": "Ghostly Flicker",
             "text": "Exile two target artifacts, creatures, and/or lands you control, then return those cards to the battlefield under your control.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "600b31a4-0a9f-5c04-bfcf-f9c03d5421d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11f693-716e-41de-a0ea-2a5178a284dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11f693-716e-41de-a0ea-2a5178a284dc.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "b96adaf5-394a-530c-820a-b9515b65873d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f4b833-0352-4dba-a3e7-6570cbeaad4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f4b833-0352-4dba-a3e7-6570cbeaad4f.jpg?1",
             "name": "Grasp of Phantoms",
             "text": "Put target creature on top of its owner's library.\nFlashback {7}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "f9b1084b-b5ad-5895-981c-b2dbb6aa4127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461dee11-e89c-4f2e-8f62-6327df19c295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461dee11-e89c-4f2e-8f62-6327df19c295.jpg?1",
             "name": "Kraken Hatchling",
             "text": "",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "ef7120eb-db84-5edb-bd00-8b43efe714e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8543f-5c5d-4b1a-ad96-f154f1914608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c8543f-5c5d-4b1a-ad96-f154f1914608.jpg?1",
             "name": "Mist Raven",
             "text": "Flying\nWhen Mist Raven enters the battlefield, return target creature to its owner's hand.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "b74773e8-2e59-5210-87f1-65003509fbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3a4e2-b3d2-4803-bcaf-5d63bff0feb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f3a4e2-b3d2-4803-bcaf-5d63bff0feb5.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, and put it into your hand. Then shuffle your library.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "e30eba44-b93d-5d5d-b556-ea4348842422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485c71e7-8c2d-41bf-bfa3-b200c43751c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485c71e7-8c2d-41bf-bfa3-b200c43751c3.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "8ce8bdc2-7f08-576d-b21e-5500a88acb54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7472958-dd1b-48a7-a960-ec2ef3b69ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7472958-dd1b-48a7-a960-ec2ef3b69ded.jpg?1",
             "name": "Phantasmal Image",
             "text": "You may have Phantasmal Image enter the battlefield as a copy of any creature on the battlefield, except it's an Illusion in addition to its other types and it gains \"When this creature becomes the target of a spell or ability, sacrifice it.\"",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "0f8b24e6-b8f7-5ff0-a7b3-5fff15bcf1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bf287-488c-4fdf-b9ff-fc2065697123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bf287-488c-4fdf-b9ff-fc2065697123.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "6d42f19d-7c2f-5b06-a026-d60b5c9932c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b075e2-6669-4074-a8df-91287970ecfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b075e2-6669-4074-a8df-91287970ecfc.jpg?1",
             "name": "Sea Gate Oracle",
             "text": "When Sea Gate Oracle enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "cec79f6f-39b6-593c-9a7b-8699decaaf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20296a5b-4e15-4f07-8bce-9a37abb35729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20296a5b-4e15-4f07-8bce-9a37abb35729.jpg?1",
             "name": "Serum Visions",
             "text": "Draw a card. Scry 2.",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "3a6672fc-7257-522e-b984-af7b4c531ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbdacc1-7a1b-4633-85f5-eb50c2bf406d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbdacc1-7a1b-4633-85f5-eb50c2bf406d.jpg?1",
             "name": "Snapcaster Mage",
             "text": "Flash\nWhen Snapcaster Mage enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "ae0f552f-f158-501f-be88-9d0181ad71a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d4fd57-74b6-42c7-88b1-110e5a8dfc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d4fd57-74b6-42c7-88b1-110e5a8dfc3c.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "827d2b86-145a-5e5f-8672-338096a820f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30ed6e1-d713-40ae-81f6-d2d66914bbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30ed6e1-d713-40ae-81f6-d2d66914bbb9.jpg?1",
             "name": "Spire Monitor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "b713d875-0a40-54a7-95b4-bb41dc823f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e44b411-ccb8-44c8-a021-2372c945f0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e44b411-ccb8-44c8-a021-2372c945f0d3.jpg?1",
             "name": "Tandem Lookout",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Tandem Lookout is paired with another creature, each of those creatures has \"Whenever this creature deals damage to an opponent, draw a card.\"",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "fa5b6d69-1115-55fe-a39e-3706cb0080d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729cdea3-59ca-4b32-9a8a-9b0cdb4b3aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729cdea3-59ca-4b32-9a8a-9b0cdb4b3aaf.jpg?1",
             "name": "Temporal Mastery",
             "text": "Take an extra turn after this one. Exile Temporal Mastery.\nMiracle {1}{U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -1811,7 +1811,7 @@
         },
         {
             "id": "775b884c-b9f3-5482-819c-8fbc663b72a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a0243a-4661-4c7c-8dd2-9237bf9238de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a0243a-4661-4c7c-8dd2-9237bf9238de.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "bb49f5d8-6b06-5a6a-951d-534ab1bd8868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ab28ee-f70d-441b-bb4e-8e781f26e2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ab28ee-f70d-441b-bb4e-8e781f26e2bc.jpg?1",
             "name": "Wall of Frost",
             "text": "Defender\nWhenever Wall of Frost blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "c757e073-9ba0-5587-9456-3eb207d67ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694873a-0b0c-4e9e-b9fc-249e80a09cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6694873a-0b0c-4e9e-b9fc-249e80a09cca.jpg?1",
             "name": "Wing Splicer",
             "text": "When Wing Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\nGolem creatures you control have flying.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "44159b52-21a7-58fe-a3e7-08fda4185c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79a71b-568f-4700-9b1d-e7965159da0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79a71b-568f-4700-9b1d-e7965159da0a.jpg?1",
             "name": "Wingcrafter",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Wingcrafter is paired with another creature, both creatures have flying.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "414c434b-eee3-53ca-907e-7fb526e565e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a41bec-7fb0-4060-918a-38cbbb329543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a41bec-7fb0-4060-918a-38cbbb329543.jpg?1",
             "name": "Abyssal Specter",
             "text": "Flying\nWhenever Abyssal Specter deals damage to a player, that player discards a card.",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "69abe39c-5ec9-5d33-b8f4-b63da63180ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c39f3-fcfb-4a73-a3f2-f17eb8bb9bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749c39f3-fcfb-4a73-a3f2-f17eb8bb9bc4.jpg?1",
             "name": "Bone Splinters",
             "text": "As an additional cost to cast Bone Splinters, sacrifice a creature.\nDestroy target creature.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "87f1aed0-455f-5fcc-8c35-af03f7890ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef04b-5434-480e-82a1-118ed1ff551f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4ef04b-5434-480e-82a1-118ed1ff551f.jpg?1",
             "name": "Corpse Connoisseur",
             "text": "When Corpse Connoisseur enters the battlefield, you may search your library for a creature card and put that card into your graveyard. If you do, shuffle your library.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "0d68355d-5f7f-5cda-8001-64edce92c2a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3cc81-2c08-4281-aa16-4c22f141f31d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e3cc81-2c08-4281-aa16-4c22f141f31d.jpg?1",
             "name": "Cower in Fear",
             "text": "Creatures your opponents control get -1/-1 until end of turn.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "72a19549-e1e1-5435-b102-ae5faa40ac9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795fdd00-5833-4732-bc73-0ebcd84aa330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/795fdd00-5833-4732-bc73-0ebcd84aa330.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "a8fe7829-a820-5606-ad30-f1358b52e9dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddf501c-af11-4e97-81f7-32c9ee384a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddf501c-af11-4e97-81f7-32c9ee384a27.jpg?1",
             "name": "Death's Shadow",
             "text": "Death's Shadow gets -X/-X, where X is your life total.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "2f93aa80-c076-5688-a410-a7bd32bc5126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0d9e7-4a0f-4f07-99ae-31c3c9f0037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0d9e7-4a0f-4f07-99ae-31c3c9f0037a.jpg?1",
             "name": "Delirium Skeins",
             "text": "Each player discards three cards.",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "e46c9d1a-6cc3-5d2a-8e1a-7f70ca3341a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89936685-8647-4a65-b764-62fc4b49293a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89936685-8647-4a65-b764-62fc4b49293a.jpg?1",
             "name": "Desecration Demon",
             "text": "Flying\nAt the beginning of each combat, any opponent may sacrifice a creature. If a player does, tap Desecration Demon and put a +1/+1 counter on it.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "37d28ed4-9562-56bd-bdc8-3b51db7b24e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db87a2be-4490-45af-89d7-540549d1d6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db87a2be-4490-45af-89d7-540549d1d6af.jpg?1",
             "name": "Dregscape Zombie",
             "text": "Unearth {B} ({B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "8a89d9be-3e40-5b7d-afa9-57185ec9b6c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c81d8-804b-4fe6-80df-8a4246fbf695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c81d8-804b-4fe6-80df-8a4246fbf695.jpg?1",
             "name": "Entomber Exarch",
             "text": "When Entomber Exarch enters the battlefield, choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target opponent reveals his or her hand. You choose a noncreature card from it. That player discards that card.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "31752da4-e7c8-5709-8401-d9f272ead242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb42b47-0ae4-4ca4-9e24-d398dca7bbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb42b47-0ae4-4ca4-9e24-d398dca7bbd1.jpg?1",
             "name": "Extractor Demon",
             "text": "Flying\nWhenever another creature leaves the battlefield, you may have target player put the top two cards of his or her library into his or her graveyard.\nUnearth {2}{B} ({2}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "dd86273c-fb26-5367-9328-78cb81b1a365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6e33d-9258-4bad-8f39-31afff272415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6e33d-9258-4bad-8f39-31afff272415.jpg?1",
             "name": "Falkenrath Noble",
             "text": "Flying\nWhenever Falkenrath Noble or another creature dies, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "94ee91af-09ea-5ea9-a2e8-5103ae1a25ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bdd28d-7467-494b-a52f-a84932da25f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4bdd28d-7467-494b-a52f-a84932da25f3.jpg?1",
             "name": "Gnawing Zombie",
             "text": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "ddf11d54-e83d-5d5a-953d-db23a91460ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a5c2e-7fe1-45eb-b01c-891ab961186f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2a5c2e-7fe1-45eb-b01c-891ab961186f.jpg?1",
             "name": "Griselbrand",
             "text": "Flying, lifelink\nPay 7 life: Draw seven cards.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "507d76ad-ca7c-566b-b328-ae7c679dde1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61df7bd-6a9b-42e9-9d27-12777afc39c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61df7bd-6a9b-42e9-9d27-12777afc39c5.jpg?1",
             "name": "Grisly Spectacle",
             "text": "Destroy target nonartifact creature. Its controller puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "5b459f13-99a4-5685-9d7b-154565cd512e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1fef26-7a5d-4e8d-95df-aac67dd25fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1fef26-7a5d-4e8d-95df-aac67dd25fd5.jpg?1",
             "name": "Grixis Slavedriver",
             "text": "When Grixis Slavedriver leaves the battlefield, create a 2/2 black Zombie creature token.\nUnearth {3}{B} ({3}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "18edf1ec-2fd3-5fe4-8164-f868dd05d3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7dd9fad-d8e3-4e46-b4d7-792d029736de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7dd9fad-d8e3-4e46-b4d7-792d029736de.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals his or her hand. You choose a nonland card from it with converted mana cost 3 or less. That player discards that card.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "cfa37e73-24fe-5c69-b8d6-91a87bbd6833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7125336c-4c2d-47a0-8caf-b755f4954176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7125336c-4c2d-47a0-8caf-b755f4954176.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of his or her choice.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "842afe2d-9d72-551b-93a7-63cac2cb0280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c44782-a12f-4ecc-a6e8-d569e2942a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c44782-a12f-4ecc-a6e8-d569e2942a9a.jpg?1",
             "name": "Mind Shatter",
             "text": "Target player discards X cards at random.",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "5d405c27-bb4e-553f-832c-26554ef5c729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f2a31-1c89-43cb-92f2-195026c9311a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978f2a31-1c89-43cb-92f2-195026c9311a.jpg?1",
             "name": "Mortician Beetle",
             "text": "Whenever a player sacrifices a creature, you may put a +1/+1 counter on Mortician Beetle.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "532a482b-47f8-5b5f-bfde-e9cc3fbcd4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b41fe67-daf0-47ed-8f0e-db216f8394d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b41fe67-daf0-47ed-8f0e-db216f8394d1.jpg?1",
             "name": "Night Terrors",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. Exile that card.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "3ffb44b8-52d2-5297-9cf5-8e6fd52d7d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55a961-9eb7-4b9b-9be3-d4a0a5b76efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da55a961-9eb7-4b9b-9be3-d4a0a5b76efb.jpg?1",
             "name": "Ogre Jailbreaker",
             "text": "Defender\nOgre Jailbreaker can attack as though it didn't have defender as long as you control a Gate.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "0df1aed1-d5d1-517e-9691-c991e9f97ba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dc02f8-43aa-4b66-8dfe-08ab9b110e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2dc02f8-43aa-4b66-8dfe-08ab9b110e0c.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper enters the battlefield, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "054e8720-bff1-5987-a882-d86ac7e01be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba44d21e-b1f4-4691-9895-6dda5015ad34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba44d21e-b1f4-4691-9895-6dda5015ad34.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "2a969b45-b5bf-5a39-8452-3d935af09fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3647ef4a-fbf3-4f64-8376-72c9247bbc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3647ef4a-fbf3-4f64-8376-72c9247bbc22.jpg?1",
             "name": "Seal of Doom",
             "text": "Sacrifice Seal of Doom: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "06a31bbc-95da-5586-a3ad-2e4a0447cce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9628c3bb-2fce-4321-bb6a-b0a3377649d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9628c3bb-2fce-4321-bb6a-b0a3377649d6.jpg?1",
             "name": "Sever the Bloodline",
             "text": "Exile target creature and all other creatures with the same name as that creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "1fcc7c15-0075-59c0-8db2-51a3c0650245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f3dce1-4e78-4a5f-bc35-0c008669308a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f3dce1-4e78-4a5f-bc35-0c008669308a.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "4c9335cd-8848-58e1-a5bd-416306b85464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a6d22-2e87-410c-b42a-6b54d83a7d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a6d22-2e87-410c-b42a-6b54d83a7d30.jpg?1",
             "name": "Vampire Aristocrat",
             "text": "Sacrifice a creature: Vampire Aristocrat gets +2/+2 until end of turn.",
             "colours": [
@@ -2894,7 +2894,7 @@
         },
         {
             "id": "087d1b96-fc16-5eb2-9a33-7f6274c5cc31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6572c70-7162-440d-a315-9fb31cc4849d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6572c70-7162-440d-a315-9fb31cc4849d.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying, deathtouch, lifelink",
             "colours": [
@@ -2929,7 +2929,7 @@
         },
         {
             "id": "a066c50f-437a-5ddf-a1fa-71072c96a6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7313d3-e6fb-4e82-b558-5fcfd5b71177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7313d3-e6fb-4e82-b558-5fcfd5b71177.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "f04c0bb0-638a-5e10-a35e-525132f463d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d50bce-785d-48a2-8270-7e7373de9c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d50bce-785d-48a2-8270-7e7373de9c51.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -2997,7 +2997,7 @@
         },
         {
             "id": "8ebd1f82-2c18-5871-ae9f-705fc430fdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d045477-7593-46f9-8b40-1356aff1132f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d045477-7593-46f9-8b40-1356aff1132f.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -3029,7 +3029,7 @@
         },
         {
             "id": "f3c0cd49-eda2-553f-a402-3b6148e93029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4f47a9-1c23-4d63-bb89-83c889615e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4f47a9-1c23-4d63-bb89-83c889615e50.jpg?1",
             "name": "Bonfire of the Damned",
             "text": "Bonfire of the Damned deals X damage to target player and each creature he or she controls.\nMiracle {X}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "d2bb3dfc-7f12-59b7-925a-a12214f9b421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c6a1a0-c79e-4770-bf6a-f672b6215f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c6a1a0-c79e-4770-bf6a-f672b6215f7a.jpg?1",
             "name": "Chandra's Outrage",
             "text": "Chandra's Outrage deals 4 damage to target creature and 2 damage to that creature's controller.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "22715fe9-677a-5fe6-bf40-b086a06e5d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90e1524-d94a-4aba-ab2a-ba2b006cadbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90e1524-d94a-4aba-ab2a-ba2b006cadbe.jpg?1",
             "name": "Dragon Fodder",
             "text": "Create two 1/1 red Goblin creature tokens.",
             "colours": [
@@ -3125,7 +3125,7 @@
         },
         {
             "id": "c5aa412f-275a-5ab9-a235-d0b63b68e13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e530cc-21b9-43c2-a6a9-f1d96e06c2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e530cc-21b9-43c2-a6a9-f1d96e06c2cd.jpg?1",
             "name": "Dynacharge",
             "text": "Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3157,7 +3157,7 @@
         },
         {
             "id": "9e3f27a5-4984-5ac8-9855-c7a480ca7ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473fb06e-5c71-4370-a5d7-7753d84d0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/473fb06e-5c71-4370-a5d7-7753d84d0fd6.jpg?1",
             "name": "Goblin Assault",
             "text": "At the beginning of your upkeep, create a 1/1 red Goblin creature token with haste.\nGoblin creatures attack each turn if able.",
             "colours": [
@@ -3189,7 +3189,7 @@
         },
         {
             "id": "75266ede-1151-52cf-8dbe-a3c3989108ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552b7314-5dd9-4722-841b-2e9d5647f854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552b7314-5dd9-4722-841b-2e9d5647f854.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of his or her library. If it's a land card, that player puts it into his or her hand.",
             "colours": [
@@ -3224,7 +3224,7 @@
         },
         {
             "id": "861e634b-61e9-5543-b98f-8990dffcb401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db88c0d5-9df8-4cb7-8951-9d41187b7fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db88c0d5-9df8-4cb7-8951-9d41187b7fb1.jpg?1",
             "name": "Hanweir Lancer",
             "text": "Soulbond (You may pair this creature with another unpaired creature when either enters the battlefield. They remain paired for as long as you control both of them.)\nAs long as Hanweir Lancer is paired with another creature, both creatures have first strike.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "798c1e39-8989-5c40-8ae7-28dd5bf61fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ee5320-a19b-4798-b1fb-125b738bd3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ee5320-a19b-4798-b1fb-125b738bd3b9.jpg?1",
             "name": "Hellrider",
             "text": "Haste\nWhenever a creature you control attacks, Hellrider deals 1 damage to defending player.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "2f5c42c8-9b08-5ac1-962e-12b9dafcb6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77b1ff-e73d-4181-9564-d71df348b2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77b1ff-e73d-4181-9564-d71df348b2fe.jpg?1",
             "name": "Madcap Skills",
             "text": "Enchant creature\nEnchanted creature gets +3/+0 and has menace.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "a2320faf-552d-5600-8719-8aa2761a3858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1c5b0-973d-467e-a797-51ca75c183c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af1c5b0-973d-467e-a797-51ca75c183c1.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to target creature or player. Scry 2.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "48e4b542-c47e-5455-8245-e9983e5adf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708557e2-c1b4-4e45-b568-17763b7a9924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708557e2-c1b4-4e45-b568-17763b7a9924.jpg?1",
             "name": "Mizzium Mortars",
             "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "46db1669-1614-55bd-bbb6-e8a1d3ce1416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc21927-efbf-4e3b-8df1-d901962c4b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc21927-efbf-4e3b-8df1-d901962c4b71.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies can't attack or block alone.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "cbe55e13-a31e-5255-8e7f-0018a37f1629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdd414b-3d9d-4347-acce-289209d09fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdd414b-3d9d-4347-acce-289209d09fc4.jpg?1",
             "name": "Molten Rain",
             "text": "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "983dba8f-5e46-5956-91dd-7691e6ba50af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c19ccf-999b-4c7d-ae5b-f93555d08a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c19ccf-999b-4c7d-ae5b-f93555d08a7a.jpg?1",
             "name": "Mudbutton Torchrunner",
             "text": "When Mudbutton Torchrunner dies, it deals 3 damage to target creature or player.",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "f7b9cb94-8c0d-530d-b3f1-2478221fefbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7472f4-37b0-439f-b4ac-80706d40d191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7472f4-37b0-439f-b4ac-80706d40d191.jpg?1",
             "name": "Past in Flames",
             "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "1039353a-3516-5adc-a4f0-8e8c3b08fcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561e7a13-6b85-456f-b074-4dc037bc14f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561e7a13-6b85-456f-b074-4dc037bc14f9.jpg?1",
             "name": "Pyrewild Shaman",
             "text": "Bloodrush \u2014 {1}{R}, Discard Pyrewild Shaman: Target attacking creature gets +3/+1 until end of turn.\nWhenever one or more creatures you control deal combat damage to a player, if Pyrewild Shaman is in your graveyard, you may pay {3}. If you do, return Pyrewild Shaman to your hand.",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "51b1cbf5-a57c-5232-b859-4296d90cfc13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac89aef-a0f5-494b-a085-5b3b016d7f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac89aef-a0f5-494b-a085-5b3b016d7f17.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature.",
             "colours": [
@@ -3591,7 +3591,7 @@
         },
         {
             "id": "603d14f9-1fae-57c0-a517-8784e1fe96d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9cea68-4390-4d73-a374-d6299cbc9271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9cea68-4390-4d73-a374-d6299cbc9271.jpg?1",
             "name": "Pyromancer Ascension",
             "text": "Whenever you cast an instant or sorcery spell that has the same name as a card in your graveyard, you may put a quest counter on Pyromancer Ascension.\nWhenever you cast an instant or sorcery spell while Pyromancer Ascension has two or more quest counters on it, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "e1b037eb-bed6-50b8-9991-a7f150a4b479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef60e595-c1fc-4d03-a4f0-e3ae24dd6556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef60e595-c1fc-4d03-a4f0-e3ae24dd6556.jpg?1",
             "name": "Rubblebelt Maaka",
             "text": "Bloodrush \u2014 {R}, Discard Rubblebelt Maaka: Target attacking creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "9130a3fe-f809-59aa-b4cc-cc0d221f3e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b9dd6d-e286-41e8-bd9d-0b42daa5c062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6b9dd6d-e286-41e8-bd9d-0b42daa5c062.jpg?1",
             "name": "Scorched Rusalka",
             "text": "{R}, Sacrifice a creature: Scorched Rusalka deals 1 damage to target player.",
             "colours": [
@@ -3691,7 +3691,7 @@
         },
         {
             "id": "6bdffe5c-2841-5ec1-b5e2-a8e80e97f87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565033d2-7cb9-4ee2-b952-45745b9a2ecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/565033d2-7cb9-4ee2-b952-45745b9a2ecc.jpg?1",
             "name": "Scourge Devil",
             "text": "When Scourge Devil enters the battlefield, creatures you control get +1/+0 until end of turn.\nUnearth {2}{R} ({2}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "a089ded0-4fab-5af5-a891-32f54436779c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8634068-0ada-4913-8246-c9ac7e9dbde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8634068-0ada-4913-8246-c9ac7e9dbde3.jpg?1",
             "name": "Skirsdag Cultist",
             "text": "{R}, {T}, Sacrifice a creature: Skirsdag Cultist deals 2 damage to target creature or player.",
             "colours": [
@@ -3760,7 +3760,7 @@
         },
         {
             "id": "1d7e724c-6d58-5027-8f7e-2a6d1961cd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804458a2-5376-462d-a2cd-fa596750c0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804458a2-5376-462d-a2cd-fa596750c0aa.jpg?1",
             "name": "Thunderous Wrath",
             "text": "Thunderous Wrath deals 5 damage to target creature or player.\nMiracle {R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "fe9c489c-5d15-54a9-964b-0f288b8003e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42347e7d-6f65-4904-b3c1-a272e4cd2509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42347e7d-6f65-4904-b3c1-a272e4cd2509.jpg?1",
             "name": "Traitorous Instinct",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
             "colours": [
@@ -3824,7 +3824,7 @@
         },
         {
             "id": "8927dcb0-c140-59fe-a507-76401ac30aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbca500a-f349-4873-a2d5-f8dfbd957a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbca500a-f349-4873-a2d5-f8dfbd957a3d.jpg?1",
             "name": "Vithian Stinger",
             "text": "{T}: Vithian Stinger deals 1 damage to target creature or player.\nUnearth {1}{R} ({1}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "2854d82c-4a8b-523b-bbaf-7102d93fc5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3784d4-80cd-4f78-afb3-d61f3bab5b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3784d4-80cd-4f78-afb3-d61f3bab5b2c.jpg?1",
             "name": "Zealous Conscripts",
             "text": "Haste\nWhen Zealous Conscripts enters the battlefield, gain control of target permanent until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -3894,7 +3894,7 @@
         },
         {
             "id": "83a8fca6-bb61-560a-9f6f-10dbefc31ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1476a3-2915-413c-9226-2d7dc8f0b8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd1476a3-2915-413c-9226-2d7dc8f0b8fa.jpg?1",
             "name": "Arachnus Spinner",
             "text": "Reach\nTap an untapped Spider you control: Search your graveyard and/or library for a card named Arachnus Web and put it onto the battlefield attached to target creature. If you search your library this way, shuffle it.",
             "colours": [
@@ -3928,7 +3928,7 @@
         },
         {
             "id": "33faface-8252-5f08-92c5-56aa2bddaa3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26278000-4b73-478f-8ee5-6dd8692e53d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26278000-4b73-478f-8ee5-6dd8692e53d6.jpg?1",
             "name": "Arachnus Web",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.\nAt the beginning of the end step, if enchanted creature's power is 4 or greater, destroy Arachnus Web.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "a8b01ee7-c989-569a-81b3-4d1af9be1544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9600bdc-6a1b-4f7a-aa7d-538fb89df937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9600bdc-6a1b-4f7a-aa7d-538fb89df937.jpg?1",
             "name": "Avacyn's Pilgrim",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [
@@ -3998,7 +3998,7 @@
         },
         {
             "id": "08e80ebb-ee38-5c89-b2c4-4d424c4dda3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c0792-1ff6-4c8c-b3d5-ff32644c366b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c0792-1ff6-4c8c-b3d5-ff32644c366b.jpg?1",
             "name": "Baloth Cage Trap",
             "text": "If an opponent had an artifact enter the battlefield under his or her control this turn, you may pay {1}{G} rather than pay Baloth Cage Trap's mana cost.\nCreate a 4/4 green Beast creature token.",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "55ff525f-f0ea-59ae-9379-e2684770cd0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b496a2-11f4-4655-b9e5-0c8c37b2bb9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b496a2-11f4-4655-b9e5-0c8c37b2bb9e.jpg?1",
             "name": "Call of the Herd",
             "text": "Create a 3/3 green Elephant creature token.\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "a5aeb31a-f303-53f6-ada2-ab0a6820b9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d66f5-e782-425c-9260-e8989a9cf50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34d66f5-e782-425c-9260-e8989a9cf50b.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen Craterhoof Behemoth enters the battlefield, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -4098,7 +4098,7 @@
         },
         {
             "id": "c7d46a72-20b0-5c91-9ebe-9fb3294bef4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556f696-5914-497e-8c84-8888cdf18b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556f696-5914-497e-8c84-8888cdf18b8f.jpg?1",
             "name": "Death-Hood Cobra",
             "text": "{1}{G}: Death-Hood Cobra gains reach until end of turn.\n{1}{G}: Death-Hood Cobra gains deathtouch until end of turn.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "fdf041e6-c9a9-5afc-bf94-c589a14a4ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f00a70e-b3a0-4279-a4d6-37f2d1a1880e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f00a70e-b3a0-4279-a4d6-37f2d1a1880e.jpg?1",
             "name": "Druid's Deliverance",
             "text": "Prevent all combat damage that would be dealt to you this turn. Populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "bf5dc7d2-e8c2-50fd-b1e1-b51b0fae19f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6899e09-0ec3-44d0-afd9-2a4e28635f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6899e09-0ec3-44d0-afd9-2a4e28635f20.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -4197,7 +4197,7 @@
         },
         {
             "id": "d94cdac3-30fc-5704-9bdc-4e7bf65e5e7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d114268-7768-4a7c-a6fb-78fec7d4495a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d114268-7768-4a7c-a6fb-78fec7d4495a.jpg?1",
             "name": "Fists of Ironwood",
             "text": "Enchant creature\nWhen Fists of Ironwood enters the battlefield, create two 1/1 green Saproling creature tokens.\nEnchanted creature has trample.",
             "colours": [
@@ -4231,7 +4231,7 @@
         },
         {
             "id": "7751f5bc-7a47-5afb-8122-295c478b11f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9796273-e50f-4d83-bebf-0e29af7312cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9796273-e50f-4d83-bebf-0e29af7312cd.jpg?1",
             "name": "Gaea's Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "c060765a-dffe-5155-8b69-63bdb91ae003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ceb1655-f487-47c3-8687-cde6e577ef12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ceb1655-f487-47c3-8687-cde6e577ef12.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "f8ba7677-fe60-566a-9fe4-7b02c1c08bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95da249-49db-4dae-9277-5d481ec480a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95da249-49db-4dae-9277-5d481ec480a9.jpg?1",
             "name": "Hungry Spriggan",
             "text": "Trample\nWhenever Hungry Spriggan attacks, it gets +3/+3 until end of turn.",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "c519368c-e9cd-541a-832a-fe28211e8bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142600e0-9646-4327-aaa4-bc3294cf9b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142600e0-9646-4327-aaa4-bc3294cf9b99.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "279a0f9f-be2c-581f-9fe3-e9cf18750f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665498f9-bb0a-4305-85dd-4c72767e108d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665498f9-bb0a-4305-85dd-4c72767e108d.jpg?1",
             "name": "Penumbra Spider",
             "text": "Reach\nWhen Penumbra Spider dies, create a 2/4 black Spider creature token with reach.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "d1be3f24-157c-5c95-bf52-77f83b950ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92144021-7425-44e1-a32b-13252f1b7036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92144021-7425-44e1-a32b-13252f1b7036.jpg?1",
             "name": "Primal Command",
             "text": "Choose two \u2014\n\u2022 Target player gains 7 life.\n\u2022 Put target noncreature permanent on top of its owner's library.\n\u2022 Target player shuffles his or her graveyard into his or her library.\n\u2022 Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4428,7 +4428,7 @@
         },
         {
             "id": "dc51a142-6e47-5797-a4b6-6850a7ad74e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b365778-1678-4c1f-ae32-7671a1429a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b365778-1678-4c1f-ae32-7671a1429a3e.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "3049eab3-cfb0-5eca-aa98-81bc5b0c092d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614d466e-f830-4a2f-8740-b416a15c67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614d466e-f830-4a2f-8740-b416a15c67dd.jpg?1",
             "name": "Scavenging Ooze",
             "text": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on Scavenging Ooze and you gain 1 life.",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "c440f5d9-834d-5087-a9e2-b1c659fd0f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98b47b-c35f-47ef-b686-07b3904f2854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98b47b-c35f-47ef-b686-07b3904f2854.jpg?1",
             "name": "Seal of Primordium",
             "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
             "colours": [
@@ -4526,7 +4526,7 @@
         },
         {
             "id": "63babd63-2019-56f8-bcc0-3c063575f81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4010a419-8291-4c8b-8cda-38c35fbd7b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4010a419-8291-4c8b-8cda-38c35fbd7b88.jpg?1",
             "name": "Slaughterhorn",
             "text": "Bloodrush \u2014 {G}, Discard Slaughterhorn: Target attacking creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "982d80ff-9f47-5547-90cd-1916d994c55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daf6a74-57f7-4c44-9413-a28002f3de4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0daf6a74-57f7-4c44-9413-a28002f3de4c.jpg?1",
             "name": "Slime Molding",
             "text": "Create an X/X green Ooze creature token.",
             "colours": [
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "b9a15d3b-682d-5707-a86e-d81dbd03e9f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5c1fde-298b-463c-b2e9-abd241e23062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5c1fde-298b-463c-b2e9-abd241e23062.jpg?1",
             "name": "Strength in Numbers",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
             "colours": [
@@ -4624,7 +4624,7 @@
         },
         {
             "id": "98aee8a2-61df-55a8-9be6-02ff2653830b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b71fb4-27ea-4846-87e4-efd2190faf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b71fb4-27ea-4846-87e4-efd2190faf36.jpg?1",
             "name": "Summoning Trap",
             "text": "If a creature spell you cast this turn was countered by a spell or ability an opponent controlled, you may pay {0} rather than pay Summoning Trap's mana cost.\nLook at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "49a7a564-68df-5edd-a77c-c8700999ef65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101ef33-90fa-4c31-994b-478f7def4e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7101ef33-90fa-4c31-994b-478f7def4e1b.jpg?1",
             "name": "Sylvan Ranger",
             "text": "When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "25358750-c060-5a66-b14d-05e3630bf3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b49dfb7-dbe7-4a2b-b9de-c620a0db2e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b49dfb7-dbe7-4a2b-b9de-c620a0db2e47.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "66e83a72-22f2-531b-9bcb-d6a2a0a5d2ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d286f930-28ca-4c59-8a53-99686ac6030e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d286f930-28ca-4c59-8a53-99686ac6030e.jpg?1",
             "name": "Thornscape Battlemage",
             "text": "Kicker {R} and/or {W} (You may pay an additional {R} and/or {W} as you cast this spell.)\nWhen Thornscape Battlemage enters the battlefield, if it was kicked with its {R} kicker, it deals 2 damage to target creature or player.\nWhen Thornscape Battlemage enters the battlefield, if it was kicked with its {W} kicker, destroy target artifact.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "1fcc8682-d5c6-5bd5-9673-2542325c18d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62f09c4-4ed2-429b-b8cc-a40c83fc60ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62f09c4-4ed2-429b-b8cc-a40c83fc60ff.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "faa2ce54-8f4e-5030-be62-c220336ad702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da9e7d8-5f01-4d55-a0a8-afe5e7d5f8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da9e7d8-5f01-4d55-a0a8-afe5e7d5f8e4.jpg?1",
             "name": "Ulvenwald Tracker",
             "text": "{1}{G}, {T}: Target creature you control fights another target creature.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "d1df5bff-7142-5327-8e9a-af59bcd1ca97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cf68c-b54c-46e1-a720-af57aac9e570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cf68c-b54c-46e1-a720-af57aac9e570.jpg?1",
             "name": "Vital Splicer",
             "text": "When Vital Splicer enters the battlefield, create a 3/3 colorless Golem artifact creature token.\n{1}: Regenerate target Golem you control.",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "b11a2ad4-06b7-508a-925e-37507ba371c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e328c6-3a84-49cf-a1a3-1d1e5373d274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8e328c6-3a84-49cf-a1a3-1d1e5373d274.jpg?1",
             "name": "Abrupt Decay",
             "text": "Abrupt Decay can't be countered by spells or abilities.\nDestroy target nonland permanent with converted mana cost 3 or less.",
             "colours": [
@@ -4904,7 +4904,7 @@
         },
         {
             "id": "7901d6e7-667e-5d8c-8a3e-c13ab32fb5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3b5e35-5448-4115-a9c5-6ac14013c904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba3b5e35-5448-4115-a9c5-6ac14013c904.jpg?1",
             "name": "Advent of the Wurm",
             "text": "Create a 5/5 green Wurm creature token with trample.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "5f1ef279-2973-55dc-9239-e1d8b0bc0232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d32427-da4d-4906-8c61-13054c87b349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d32427-da4d-4906-8c61-13054c87b349.jpg?1",
             "name": "Aethermage's Touch",
             "text": "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "89b918f0-31d0-5983-8f59-6cd7a9ce2c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6ace1f-c056-494d-a41f-75efa54312a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6ace1f-c056-494d-a41f-75efa54312a5.jpg?1",
             "name": "Agent of Masks",
             "text": "At the beginning of your upkeep, each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "271d4e29-affa-5b9d-817c-686917accb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc51eb-4ed8-433f-aee5-4aee31f6ad50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bc51eb-4ed8-433f-aee5-4aee31f6ad50.jpg?1",
             "name": "Agony Warp",
             "text": "Target creature gets -3/-0 until end of turn.\nTarget creature gets -0/-3 until end of turn.",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "2660753f-0d6b-5003-a7a7-9e0601b0e7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8f26e6-ce0d-4886-98dd-166ca49f1f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff8f26e6-ce0d-4886-98dd-166ca49f1f4b.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -5077,7 +5077,7 @@
         },
         {
             "id": "fab1aa4d-0cb5-5168-b361-acb63e93bef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94079dd-023a-41b2-9004-95bbb0e41267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94079dd-023a-41b2-9004-95bbb0e41267.jpg?1",
             "name": "Bronzebeak Moa",
             "text": "Whenever another creature enters the battlefield under your control, Bronzebeak Moa gets +3/+3 until end of turn.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "3622653c-1eba-52fe-b70a-81ae26bf130e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45e678-1ab0-451d-b412-be7c167e812a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c45e678-1ab0-451d-b412-be7c167e812a.jpg?1",
             "name": "Broodmate Dragon",
             "text": "Flying\nWhen Broodmate Dragon enters the battlefield, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "f0a47800-addf-5033-a004-d0b17bf7b801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45a453b-bc76-4768-88ea-a5117e29a49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e45a453b-bc76-4768-88ea-a5117e29a49e.jpg?1",
             "name": "Call of the Conclave",
             "text": "Create a 3/3 green Centaur creature token.",
             "colours": [
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "f37d2478-70f5-5084-9a1d-9f29f9d9a4a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb4d0dd-3363-45f0-9081-7b9c8c39d63f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb4d0dd-3363-45f0-9081-7b9c8c39d63f.jpg?1",
             "name": "Carnage Gladiator",
             "text": "Whenever a creature blocks, that creature's controller loses 1 life.\n{1}{B}{R}: Regenerate Carnage Gladiator.",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "4ce1ad94-a5e7-57f2-87ea-b599bd19fc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0743cd-26e3-4de5-b98b-3e16b6aff2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0743cd-26e3-4de5-b98b-3e16b6aff2ac.jpg?1",
             "name": "Centaur Healer",
             "text": "When Centaur Healer enters the battlefield, you gain 3 life.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "172a594b-7aa6-5bb4-ab4d-e5325b64c914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19719b9b-a384-4ebe-9a5a-7f51132f3c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19719b9b-a384-4ebe-9a5a-7f51132f3c44.jpg?1",
             "name": "Coiling Oracle",
             "text": "When Coiling Oracle enters the battlefield, reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put that card into your hand.",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "db2e35b1-9927-5db6-a0fd-e311a4305336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45b55df-2de8-4327-9b2d-cff1e5d37a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b45b55df-2de8-4327-9b2d-cff1e5d37a79.jpg?1",
             "name": "Cruel Ultimatum",
             "text": "Target opponent sacrifices a creature, discards three cards, then loses 5 life. You return a creature card from your graveyard to your hand, draw three cards, then gain 5 life.",
             "colours": [
@@ -5333,7 +5333,7 @@
         },
         {
             "id": "53149e59-98d8-56b8-ad2e-122280a727e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e7dff8-faae-46b8-8dd9-58830e1df61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e7dff8-faae-46b8-8dd9-58830e1df61e.jpg?1",
             "name": "Deputy of Acquittals",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Deputy of Acquittals enters the battlefield, you may return another target creature you control to its owner's hand.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "9040f1eb-9d04-5642-a7bc-2d2c0f5f258c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644e3ff9-94be-49f1-82f1-b844e025645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644e3ff9-94be-49f1-82f1-b844e025645a.jpg?1",
             "name": "Dinrova Horror",
             "text": "When Dinrova Horror enters the battlefield, return target permanent to its owner's hand, then that player discards a card.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "8dae9d9d-f2bd-5dc9-ac78-a4a764ac50b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d57a9dc-424e-4088-9df8-c9b9c8c688a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d57a9dc-424e-4088-9df8-c9b9c8c688a3.jpg?1",
             "name": "Domri Rade",
             "text": "+1: Look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand.\n\u22122: Target creature you control fights another target creature.\n\u22127: You get an emblem with \"Creatures you control have double strike, trample, hexproof, and haste.\"",
             "colours": [
@@ -5444,7 +5444,7 @@
         },
         {
             "id": "d1963e10-3944-5e1d-a507-da771bd9c516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4270d1d-97ae-412a-bf2e-b6b7dad3d6d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4270d1d-97ae-412a-bf2e-b6b7dad3d6d0.jpg?1",
             "name": "Evil Twin",
             "text": "You may have Evil Twin enter the battlefield as a copy of any creature on the battlefield, except it gains \"{U}{B}, {T}: Destroy target creature with the same name as this creature.\"",
             "colours": [
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "51b752e6-65cc-54c9-a969-408439e35449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53399f12-0d62-40bf-a532-1d02b6c2f19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53399f12-0d62-40bf-a532-1d02b6c2f19e.jpg?1",
             "name": "Falkenrath Aristocrat",
             "text": "Flying, haste\nSacrifice a creature: Falkenrath Aristocrat gains indestructible until end of turn. If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.",
             "colours": [
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "09a3e9c9-e3f1-5bae-bcae-cb3bbfda676c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844a8a51-45fb-4957-b1fe-0d86dfff3fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844a8a51-45fb-4957-b1fe-0d86dfff3fb5.jpg?1",
             "name": "Fiery Justice",
             "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
             "colours": [
@@ -5553,7 +5553,7 @@
         },
         {
             "id": "0cbc43ab-a77c-5187-983a-9278333a5197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ec0aa-1da9-4464-ac0e-c45079908070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29ec0aa-1da9-4464-ac0e-c45079908070.jpg?1",
             "name": "Ghor-Clan Rampager",
             "text": "Trample\nBloodrush \u2014 {R}{G}, Discard Ghor-Clan Rampager: Target attacking creature gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5589,7 +5589,7 @@
         },
         {
             "id": "f8934d3a-7ca6-57ef-8d72-436e6b1388ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f17a1fc-b6cc-4f62-96df-3cde940a3bea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f17a1fc-b6cc-4f62-96df-3cde940a3bea.jpg?1",
             "name": "Goblin Electromancer",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5626,7 +5626,7 @@
         },
         {
             "id": "e2b83d61-3bf6-5715-9d86-5dd8d118c048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d03f6eb-a146-45e8-a8e0-a46ec0c20c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d03f6eb-a146-45e8-a8e0-a46ec0c20c1d.jpg?1",
             "name": "Golgari Germination",
             "text": "Whenever a nontoken creature you control dies, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "e1e7876b-ea44-56f7-b327-f6060be0ccc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482d3d5-d4ad-4e0e-ab92-3246cf684d14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482d3d5-d4ad-4e0e-ab92-3246cf684d14.jpg?1",
             "name": "Golgari Rotwurm",
             "text": "{B}, Sacrifice a creature: Target player loses 1 life.",
             "colours": [
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "412f6161-9f67-5617-b179-4b305129ab94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5d3a87-89f6-4051-918c-736b0a4b8ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5d3a87-89f6-4051-918c-736b0a4b8ec2.jpg?1",
             "name": "Ground Assault",
             "text": "Ground Assault deals damage to target creature equal to the number of lands you control.",
             "colours": [
@@ -5731,7 +5731,7 @@
         },
         {
             "id": "a03cfecd-5061-5789-9711-dd6248d60e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003fb65-26ee-481f-a38d-7d3fe55878f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003fb65-26ee-481f-a38d-7d3fe55878f3.jpg?1",
             "name": "Gruul War Chant",
             "text": "Attacking creatures you control get +1/+0 and have menace.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "95743a63-a09a-5735-b823-74dba6aa24fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04eae11-6bc4-41d2-98cc-285621d5724b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04eae11-6bc4-41d2-98cc-285621d5724b.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014\n\u2022 Counter target noncreature spell unless its controller pays {2}.\n\u2022 Izzet Charm deals 2 damage to target creature.\n\u2022 Draw two cards, then discard two cards.",
             "colours": [
@@ -5799,7 +5799,7 @@
         },
         {
             "id": "40f2e7e1-e29f-5ad5-a72d-7b22d9dfd98a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafece7-c3a0-465b-84c2-e095890a7a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dafece7-c3a0-465b-84c2-e095890a7a8b.jpg?1",
             "name": "Kathari Bomber",
             "text": "Flying\nWhen Kathari Bomber deals combat damage to a player, create two 1/1 red Goblin creature tokens and sacrifice Kathari Bomber.\nUnearth {3}{B}{R} ({3}{B}{R}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -5836,7 +5836,7 @@
         },
         {
             "id": "564a80c1-e497-53af-8454-e8426d3b8580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ac1c79-4dff-4518-8a9e-8d381a046605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ac1c79-4dff-4518-8a9e-8d381a046605.jpg?1",
             "name": "Moroii",
             "text": "Flying\nAt the beginning of your upkeep, you lose 1 life.",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "2ead4f9f-6010-5667-ac46-700768410d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b93af3-f7b9-4b66-8a66-366134ebb896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b93af3-f7b9-4b66-8a66-366134ebb896.jpg?1",
             "name": "Mystic Genesis",
             "text": "Counter target spell. Create an X/X green Ooze creature token, where X is that spell's converted mana cost.",
             "colours": [
@@ -5906,7 +5906,7 @@
         },
         {
             "id": "845c2c52-27b3-5162-99e0-12a300842d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e949d80-d2c5-4ed1-9e53-c98a3b2749ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e949d80-d2c5-4ed1-9e53-c98a3b2749ff.jpg?1",
             "name": "Niv-Mizzet, Dracogenius",
             "text": "Flying\nWhenever Niv-Mizzet, Dracogenius deals damage to a player, you may draw a card.\n{U}{R}: Niv-Mizzet, Dracogenius deals 1 damage to target creature or player.",
             "colours": [
@@ -5945,7 +5945,7 @@
         },
         {
             "id": "7aec5519-f36b-5f08-97c7-43c03e78578c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4029c3a0-a999-453a-a838-7adb81e481ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4029c3a0-a999-453a-a838-7adb81e481ee.jpg?1",
             "name": "Obzedat, Ghost Council",
             "text": "When Obzedat, Ghost Council enters the battlefield, target opponent loses 2 life and you gain 2 life.\nAt the beginning of your end step, you may exile Obzedat. If you do, return it to the battlefield under its owner's control at the beginning of your next upkeep. It gains haste.",
             "colours": [
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "ca760cc7-93ea-55d4-a8e1-5727de915e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6411d49-b108-423c-825f-67fe8dbe1f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6411d49-b108-423c-825f-67fe8dbe1f58.jpg?1",
             "name": "Olivia Voldaren",
             "text": "Flying\n{1}{R}: Olivia Voldaren deals 1 damage to another target creature. That creature becomes a Vampire in addition to its other types. Put a +1/+1 counter on Olivia Voldaren.\n{3}{B}{B}: Gain control of target Vampire for as long as you control Olivia Voldaren.",
             "colours": [
@@ -6022,7 +6022,7 @@
         },
         {
             "id": "ccfb24af-803c-58ab-9a22-7577c3de856c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4628454-65f0-4cf7-82b5-3c33e0b3a705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4628454-65f0-4cf7-82b5-3c33e0b3a705.jpg?1",
             "name": "Pilfered Plans",
             "text": "Target player puts the top two cards of his or her library into his or her graveyard. Draw two cards.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "986809aa-110a-547c-9ab4-4e6f1bda453e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed2acec-bdae-4462-91b7-c24a60e6f9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed2acec-bdae-4462-91b7-c24a60e6f9c1.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "ba38fb1e-5124-5a0b-a29a-d6aeba701243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd24e81d-d3a8-4550-bad9-b818f48cc700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd24e81d-d3a8-4550-bad9-b818f48cc700.jpg?1",
             "name": "Rhox War Monk",
             "text": "Lifelink",
             "colours": [
@@ -6129,7 +6129,7 @@
         },
         {
             "id": "b43934e4-a39c-563c-af02-911a6057eec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c82373-9290-408a-859f-c17354441e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c82373-9290-408a-859f-c17354441e1c.jpg?1",
             "name": "Sedraxis Specter",
             "text": "Flying\nWhenever Sedraxis Specter deals combat damage to a player, that player discards a card.\nUnearth {1}{B} ({1}{B}: Return this card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.)",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "0614e4e1-c557-5b2f-87ea-78772ebaf20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93288c87-84ad-40c8-a998-a3e36075adfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93288c87-84ad-40c8-a998-a3e36075adfd.jpg?1",
             "name": "Simic Sky Swallower",
             "text": "Flying, trample\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "f8371693-6b34-5c9c-837f-3e005db82427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cad9de8-91fc-435f-9b56-66210813aebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cad9de8-91fc-435f-9b56-66210813aebd.jpg?1",
             "name": "Sin Collector",
             "text": "When Sin Collector enters the battlefield, target opponent reveals his or her hand. You choose an instant or sorcery card from it and exile that card.",
             "colours": [
@@ -6240,7 +6240,7 @@
         },
         {
             "id": "5e7d21e0-87e2-5210-bc78-364fae63160a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062404ff-f856-4e97-82e8-fee9083f4c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062404ff-f856-4e97-82e8-fee9083f4c42.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -6277,7 +6277,7 @@
         },
         {
             "id": "eff90a45-9735-51bd-8ab6-0480aed6464c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6998e90-89a9-43d7-8e89-cc20bc608545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6998e90-89a9-43d7-8e89-cc20bc608545.jpg?1",
             "name": "Soul Manipulation",
             "text": "Choose one or both \u2014\n\u2022 Counter target creature spell.\n\u2022 Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -6311,7 +6311,7 @@
         },
         {
             "id": "6ee7630a-44a5-53db-864e-99e195bd6f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f187c27-a2ad-4560-ba74-1012046303cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f187c27-a2ad-4560-ba74-1012046303cc.jpg?1",
             "name": "Soul Ransom",
             "text": "Enchant creature\nYou control enchanted creature.\nDiscard two cards: Soul Ransom's controller sacrifices it, then draws two cards. Only any opponent may activate this ability.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "82aa1867-5d10-5274-bdd3-6255be24eb44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ea4d-d0a6-44a4-bee6-24c03313d2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ea4d-d0a6-44a4-bee6-24c03313d2bc.jpg?1",
             "name": "Sphinx's Revelation",
             "text": "You gain X life and draw X cards.",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "a68feb20-7147-52eb-bc2b-8b9f693079a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82ff29-2b2c-4e4f-a6ac-e307e2921da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82ff29-2b2c-4e4f-a6ac-e307e2921da0.jpg?1",
             "name": "Spike Jester",
             "text": "Haste",
             "colours": [
@@ -6418,7 +6418,7 @@
         },
         {
             "id": "e26bbb1b-60b0-56ed-9e3d-d18538712dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a034412f-5d91-45ab-866e-c28ae6c17f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a034412f-5d91-45ab-866e-c28ae6c17f57.jpg?1",
             "name": "Sprouting Thrinax",
             "text": "When Sprouting Thrinax dies, create three 1/1 green Saproling creature tokens.",
             "colours": [
@@ -6456,7 +6456,7 @@
         },
         {
             "id": "37c1fca6-5be8-5ff2-a791-9d426c3034cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fd303a-0a51-4931-9735-704ce8179a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37fd303a-0a51-4931-9735-704ce8179a98.jpg?1",
             "name": "Stoic Angel",
             "text": "Flying, vigilance\nPlayers can't untap more than one creature during their untap steps.",
             "colours": [
@@ -6494,7 +6494,7 @@
         },
         {
             "id": "e13942c8-ad70-59fc-93cd-69377c3387b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5ee3d-3db2-45fc-adc0-9903231f16db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e5ee3d-3db2-45fc-adc0-9903231f16db.jpg?1",
             "name": "Sunhome Guildmage",
             "text": "{1}{R}{W}: Creatures you control get +1/+0 until end of turn.\n{2}{R}{W}: Create a 1/1 red and white Soldier creature token with haste.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "b7a051c9-09ec-5740-a34c-f80f0d4f613f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec07bce-abf0-4387-bb9f-a9ba5492c754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec07bce-abf0-4387-bb9f-a9ba5492c754.jpg?1",
             "name": "Talon Trooper",
             "text": "Flying",
             "colours": [
@@ -6568,7 +6568,7 @@
         },
         {
             "id": "58d300cc-5bc3-5569-9220-d00aab9f16c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322a64-f1a0-49c6-ad59-2b803598f7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322a64-f1a0-49c6-ad59-2b803598f7d1.jpg?1",
             "name": "Teleportal",
             "text": "Target creature you control gets +1/+0 until end of turn and can't be blocked this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -6602,7 +6602,7 @@
         },
         {
             "id": "93c0686d-b653-51a6-9deb-3ef76e12cea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2d815-d8b2-42ff-9889-acbe77a42583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2d815-d8b2-42ff-9889-acbe77a42583.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "edb64cc6-a124-5236-8338-83f96378be84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98e91c-9518-4dcf-90a1-610d2d977e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a98e91c-9518-4dcf-90a1-610d2d977e0c.jpg?1",
             "name": "Thundersong Trumpeter",
             "text": "{T}: Target creature can't attack or block this turn.",
             "colours": [
@@ -6673,7 +6673,7 @@
         },
         {
             "id": "2575c12c-ef53-504e-9d82-a75fad48c567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2562ab8-6491-4f13-bd20-4e4eacf840cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2562ab8-6491-4f13-bd20-4e4eacf840cb.jpg?1",
             "name": "Tower Gargoyle",
             "text": "Flying",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "ec08d035-c570-5e36-9e57-46e9299a0f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2846c5-9098-4983-84aa-d364f72135f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2846c5-9098-4983-84aa-d364f72135f3.jpg?1",
             "name": "Unflinching Courage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has trample and lifelink.",
             "colours": [
@@ -6748,7 +6748,7 @@
         },
         {
             "id": "42997767-c851-580e-9f01-477603bf8e05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a005974-ba57-42cf-a54f-4aba41cad144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a005974-ba57-42cf-a54f-4aba41cad144.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -6782,7 +6782,7 @@
         },
         {
             "id": "c0dfdfd1-09ef-5a65-a0db-b28a2f6c11ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdd22d7-b3b0-4cb5-846d-aa3d96a29c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdd22d7-b3b0-4cb5-846d-aa3d96a29c97.jpg?1",
             "name": "Vanish into Memory",
             "text": "Exile target creature. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to the battlefield under its owner's control. If you do, discard cards equal to that creature's toughness.",
             "colours": [
@@ -6816,7 +6816,7 @@
         },
         {
             "id": "494d58ed-02d6-57af-b55a-eca734e67b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993e42f4-fc60-4e37-8f69-7b82bb9e5d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993e42f4-fc60-4e37-8f69-7b82bb9e5d60.jpg?1",
             "name": "Voice of Resurgence",
             "text": "Whenever an opponent casts a spell during your turn or when Voice of Resurgence dies, create a green and white Elemental creature token with \"This creature's power and toughness are each equal to the number of creatures you control.\"",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "88527cec-ca18-5f71-8718-03ea167a67c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd95bba-0c3d-4f2c-94ea-bbd3f396292c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd95bba-0c3d-4f2c-94ea-bbd3f396292c.jpg?1",
             "name": "Wall of Denial",
             "text": "Defender, flying\nShroud (This creature can't be the target of spells or abilities.)",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "8fcdfb46-c0e9-51b6-b01c-24d8f1a6f338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191c4d56-9cee-4a7a-a2d4-e417952fef00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191c4d56-9cee-4a7a-a2d4-e417952fef00.jpg?1",
             "name": "Wayfaring Temple",
             "text": "Wayfaring Temple's power and toughness are each equal to the number of creatures you control.\nWhenever Wayfaring Temple deals combat damage to a player, populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "56cc8ce3-c20c-5fe3-89f4-3aca07e5dc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7188d8-d37f-49ec-ab52-8ea080725ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7188d8-d37f-49ec-ab52-8ea080725ca7.jpg?1",
             "name": "Woolly Thoctar",
             "text": "",
             "colours": [
@@ -6962,7 +6962,7 @@
         },
         {
             "id": "aa4d829e-bc94-5710-9a97-75d254ff322b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253e19db-28a1-4909-b235-e02631a38c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253e19db-28a1-4909-b235-e02631a38c35.jpg?1",
             "name": "Zur the Enchanter",
             "text": "Flying\nWhenever Zur the Enchanter attacks, you may search your library for an enchantment card with converted mana cost 3 or less and put it onto the battlefield. If you do, shuffle your library.",
             "colours": [
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "c3c967bb-7c91-51b7-bfc5-19af47b859ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b34ecd-6dd4-49b0-ab49-3c11f70e0c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b34ecd-6dd4-49b0-ab49-3c11f70e0c4a.jpg?1",
             "name": "Aethertow",
             "text": "Put target attacking or blocking creature on top of its owner's library.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -7037,7 +7037,7 @@
         },
         {
             "id": "51285174-a0f1-530c-9fb0-fe9f50c63b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc5666c-6f27-4ae9-8f0e-17e2a44bc646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc5666c-6f27-4ae9-8f0e-17e2a44bc646.jpg?1",
             "name": "Boros Reckoner",
             "text": "Whenever Boros Reckoner is dealt damage, it deals that much damage to target creature or player.\n{GU}: Boros Reckoner gains first strike until end of turn.",
             "colours": [
@@ -7074,7 +7074,7 @@
         },
         {
             "id": "47eca8df-3b9b-5366-bc84-5475c1fe1d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48335a70-151d-4d92-8365-e2ad9ac153ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48335a70-151d-4d92-8365-e2ad9ac153ac.jpg?1",
             "name": "Burning-Tree Emissary",
             "text": "When Burning-Tree Emissary enters the battlefield, add {R}{G} to your mana pool.",
             "colours": [
@@ -7111,7 +7111,7 @@
         },
         {
             "id": "f8323f96-6b03-5317-83e3-0536590e0516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509d27ed-f9cf-4130-8807-38a4ae857323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509d27ed-f9cf-4130-8807-38a4ae857323.jpg?1",
             "name": "Giantbaiting",
             "text": "Create a 4/4 red and green Giant Warrior creature token with haste. Exile it at the beginning of the next end step.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
             "colours": [
@@ -7145,7 +7145,7 @@
         },
         {
             "id": "728d82f2-79c3-5472-87c8-e154ca48a48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da824204-a7ed-46f1-b890-f21fcc39ce7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da824204-a7ed-46f1-b890-f21fcc39ce7e.jpg?1",
             "name": "Gift of Orzhova",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying and lifelink.",
             "colours": [
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "58264794-b1f2-5af7-ad5d-341a6d5b7943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edb89a4-e749-4043-913c-34ed20d10b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edb89a4-e749-4043-913c-34ed20d10b02.jpg?1",
             "name": "Mistmeadow Witch",
             "text": "{2}{W}{U}: Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "b5e92e16-1157-52be-9ae5-200c353578ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d2e144-04a3-41dd-810b-e9e0a04e8b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d2e144-04a3-41dd-810b-e9e0a04e8b39.jpg?1",
             "name": "Sundering Growth",
             "text": "Destroy target artifact or enchantment, then populate. (Create a token that's a copy of a creature token you control.)",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "c5c4c4d1-df18-51dd-ab9e-53d083527234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9916a-2806-4c3d-a152-5543071cc311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9916a-2806-4c3d-a152-5543071cc311.jpg?1",
             "name": "Tattermunge Witch",
             "text": "{R}{G}: Each blocked creature gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -7289,7 +7289,7 @@
         },
         {
             "id": "4ded582d-03ef-58aa-853f-c4245d2cbddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60c97a2-52db-4e4b-a075-0120a3ebca75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b60c97a2-52db-4e4b-a075-0120a3ebca75.jpg?1",
             "name": "Torrent of Souls",
             "text": "Return up to one target creature card from your graveyard to the battlefield if {B} was spent to cast Torrent of Souls. Creatures target player controls get +2/+0 and gain haste until end of turn if {R} was spent to cast Torrent of Souls. (Do both if {B}{R} was spent.)",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "f1d0d14f-9f1d-5191-b261-7735092da552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9103a97c-ffb6-4584-b7fc-58835ba942c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9103a97c-ffb6-4584-b7fc-58835ba942c2.jpg?1",
             "name": "Wort, the Raidmother",
             "text": "When Wort, the Raidmother enters the battlefield, create two 1/1 red and green Goblin Warrior creature tokens.\nEach red or green instant or sorcery spell you cast has conspire. (As you cast the spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose new targets for the copy.)",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "23a63ce8-af72-55e4-b5e7-40be5a5c70d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff1d33-e35a-4c7c-b2ba-207cf72ae5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ff1d33-e35a-4c7c-b2ba-207cf72ae5d4.jpg?1",
             "name": "Azorius Signet",
             "text": "{1}, {T}: Add {W}{U} to your mana pool.",
             "colours": [],
@@ -7393,7 +7393,7 @@
         },
         {
             "id": "1a2c4e14-2a91-5142-99b1-63e0795c42fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeab4ce-0828-40f1-a058-0d6695646f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeab4ce-0828-40f1-a058-0d6695646f4e.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -7423,7 +7423,7 @@
         },
         {
             "id": "58637223-0551-56c2-adcd-2767b1e5f5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09b060-575a-4cc3-9e27-b3c133b80235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef09b060-575a-4cc3-9e27-b3c133b80235.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -7454,7 +7454,7 @@
         },
         {
             "id": "d7e39103-1972-5655-af10-708696850ead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c89492-ef45-460e-9c78-83c8c8c80fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c89492-ef45-460e-9c78-83c8c8c80fe2.jpg?1",
             "name": "Damping Matrix",
             "text": "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7482,7 +7482,7 @@
         },
         {
             "id": "2c0772f0-5705-54fb-870d-94b963534422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501d0d13-b6a4-415c-916e-fdb0809a67d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501d0d13-b6a4-415c-916e-fdb0809a67d8.jpg?1",
             "name": "Dimir Signet",
             "text": "{1}, {T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "b281a86f-bd93-5b13-a322-641ce1b90f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca34c6fa-8019-4bdf-b748-4188ac79abf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca34c6fa-8019-4bdf-b748-4188ac79abf4.jpg?1",
             "name": "Golgari Signet",
             "text": "{1}, {T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "8834faab-1fbc-56dc-89b3-d77f030622b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d03f2e5-c778-4a85-a104-7cf367e5a5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d03f2e5-c778-4a85-a104-7cf367e5a5ea.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "Creature cards can't enter the battlefield from graveyards or libraries.\nPlayers can't cast cards in graveyards or libraries.",
             "colours": [],
@@ -7572,7 +7572,7 @@
         },
         {
             "id": "901b40ff-9b9c-5cd6-9d68-7243582a4e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c688f52-60ba-4acb-ba0e-40691c5b736c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c688f52-60ba-4acb-ba0e-40691c5b736c.jpg?1",
             "name": "Gruul Signet",
             "text": "{1}, {T}: Add {R}{G} to your mana pool.",
             "colours": [],
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "c506f605-73ef-5a77-aebe-a5bb259145ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a005a2-3eb8-4d8f-8608-2cbf5cf7887e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a005a2-3eb8-4d8f-8608-2cbf5cf7887e.jpg?1",
             "name": "Izzet Signet",
             "text": "{1}, {T}: Add {U}{R} to your mana pool.",
             "colours": [],
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "9c0564df-44bd-5722-9f45-a3048fc57cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b842616-c0cc-43d4-a52d-0159caebadd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b842616-c0cc-43d4-a52d-0159caebadd2.jpg?1",
             "name": "Orzhov Signet",
             "text": "{1}, {T}: Add {W}{B} to your mana pool.",
             "colours": [],
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "ed779dfa-bb3f-5821-8280-2d33131c3a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7feea129-3e71-45fc-9769-e6ec80e9f3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7feea129-3e71-45fc-9769-e6ec80e9f3e5.jpg?1",
             "name": "Rakdos Signet",
             "text": "{1}, {T}: Add {B}{R} to your mana pool.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "82f15659-6285-599f-a178-7b9b58323246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c5c5b-ffab-4a78-9f3a-0b80860b8c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c5c5b-ffab-4a78-9f3a-0b80860b8c53.jpg?1",
             "name": "Selesnya Signet",
             "text": "{1}, {T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -7727,7 +7727,7 @@
         },
         {
             "id": "49cc7f31-2494-5f74-b4a8-a179eb36c170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11488771-3d02-476e-bf6d-ad40ec691fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11488771-3d02-476e-bf6d-ad40ec691fd5.jpg?1",
             "name": "Simic Signet",
             "text": "{1}, {T}: Add {G}{U} to your mana pool.",
             "colours": [],
@@ -7758,7 +7758,7 @@
         },
         {
             "id": "70d63a45-a4ae-595e-82b5-874a43f7aade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a929bfef-7e6d-483d-9605-f4ba7d104656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a929bfef-7e6d-483d-9605-f4ba7d104656.jpg?1",
             "name": "Arcane Sanctum",
             "text": "Arcane Sanctum enters the battlefield tapped.\n{T}: Add {W}, {U}, or {B} to your mana pool.",
             "colours": [],
@@ -7790,7 +7790,7 @@
         },
         {
             "id": "a12b410a-ae23-54a7-9610-733280012f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a8cc61-7e36-4df7-9c89-c32fce129c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a8cc61-7e36-4df7-9c89-c32fce129c5a.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "8687707c-6f80-5972-b34b-cd0d089c026d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27addb51-f447-458a-8b3d-89de0a4c542a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27addb51-f447-458a-8b3d-89de0a4c542a.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "b1ebac58-b548-5380-ab7b-dc7b4e280016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78293-93f1-47a4-81b6-057857611d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d78293-93f1-47a4-81b6-057857611d78.jpg?1",
             "name": "Boros Guildgate",
             "text": "Boros Guildgate enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -7884,7 +7884,7 @@
         },
         {
             "id": "c63763bc-cbd2-51de-bdfd-3c467797cad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1045bdc7-6fbb-4b63-9798-a2a993f95bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1045bdc7-6fbb-4b63-9798-a2a993f95bc2.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -7912,7 +7912,7 @@
         },
         {
             "id": "f02984f6-468b-5102-882e-48e6d1b35618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f4726f-8b5a-4433-ad9b-af7e4c397987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f4726f-8b5a-4433-ad9b-af7e4c397987.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "Crumbling Necropolis enters the battlefield tapped.\n{T}: Add {U}, {B}, or {R} to your mana pool.",
             "colours": [],
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "6d8ebe42-604d-5478-ad32-4780e6cd4765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a31b8f9-5e12-4aa2-ab2c-84ad30315e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a31b8f9-5e12-4aa2-ab2c-84ad30315e8b.jpg?1",
             "name": "Dimir Guildgate",
             "text": "Dimir Guildgate enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7977,7 +7977,7 @@
         },
         {
             "id": "7b82a2be-62b6-5ec2-ba3b-8d3532ea94cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc31774-e185-4c0e-9779-046c4db3306d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc31774-e185-4c0e-9779-046c4db3306d.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8010,7 +8010,7 @@
         },
         {
             "id": "e46aba73-e372-5455-8cfd-df6648694619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5a55b9-1b28-4592-a2be-dfa393f7f12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5a55b9-1b28-4592-a2be-dfa393f7f12c.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8043,7 +8043,7 @@
         },
         {
             "id": "ad37dd71-b8f4-5065-9b6b-350af218913e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e2167-defb-46cc-a165-02ce6157137d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58e2167-defb-46cc-a165-02ce6157137d.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "72815c8c-1a2b-5845-8f0c-8e0b39572b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db3c84b-eb9e-4a90-88e4-444cca5fcf3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db3c84b-eb9e-4a90-88e4-444cca5fcf3c.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine enters the battlefield tapped.\n{T}: Add {R}, {G}, or {W} to your mana pool.",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "90ecf3e9-13f0-5611-b055-2e5b1185b65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659039ed-c269-4c2d-bce6-91d143f0618e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659039ed-c269-4c2d-bce6-91d143f0618e.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8136,7 +8136,7 @@
         },
         {
             "id": "681e29cd-87cc-568c-8949-501ed77d8a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cd0d88-53b5-4560-bce0-910b3b7be946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cd0d88-53b5-4560-bce0-910b3b7be946.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "50318f25-f68b-5342-a87a-370712722dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb4f13-77b0-4bd6-9bdd-c65dd08399a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befb4f13-77b0-4bd6-9bdd-c65dd08399a6.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "6df1dd2d-247a-5ec6-895e-ea11b416f476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c2b2fd-9cd9-49a9-8158-1c0506198393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c2b2fd-9cd9-49a9-8158-1c0506198393.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "42c9d83f-b1f5-53e4-a8a0-7519f543ef0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a5525-d49c-4669-95ee-d410f3350281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351a5525-d49c-4669-95ee-d410f3350281.jpg?1",
             "name": "Savage Lands",
             "text": "Savage Lands enters the battlefield tapped.\n{T}: Add {B}, {R}, or {G} to your mana pool.",
             "colours": [],
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "e1811dc1-d10d-5ac1-a1a8-7e2a1c803821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2661d4a-450a-433a-b893-b1ee15982494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2661d4a-450a-433a-b893-b1ee15982494.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "b462eb42-4738-58d4-936f-6c3a2f47deee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e5e16d-fc2f-4763-9e2b-2cce022e7a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e5e16d-fc2f-4763-9e2b-2cce022e7a11.jpg?1",
             "name": "Seaside Citadel",
             "text": "Seaside Citadel enters the battlefield tapped.\n{T}: Add {G}, {W}, or {U} to your mana pool.",
             "colours": [],
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "d3b3d7f6-1d49-51ed-892e-bfc4453a1ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f7fe6-faca-4911-b7bf-72f081dd5fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f7fe6-faca-4911-b7bf-72f081dd5fea.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -8355,7 +8355,7 @@
         },
         {
             "id": "370ce649-70a8-5802-bfaa-f6edc11ab551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d6756-8839-4753-a178-ef42da96dbb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d6756-8839-4753-a178-ef42da96dbb5.jpg?1",
             "name": "Shimmering Grotto",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "9f726bf8-596e-5a01-8262-caec7a867fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e32265-09f6-448f-9413-31327d11eea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e32265-09f6-448f-9413-31327d11eea5.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "35ebcf47-2062-5a74-90ed-2dd39e126387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15faa763-b897-4e86-b094-73f3236291a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15faa763-b897-4e86-b094-73f3236291a9.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "604ee7d8-32fa-595f-9c29-1baacd62a613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6277af10-b10b-450b-9d42-54c978337931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6277af10-b10b-450b-9d42-54c978337931.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "0305d004-4443-505c-98b3-8e147951fe73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd5abfa-ec18-49a4-9531-826d47c6301b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd5abfa-ec18-49a4-9531-826d47c6301b.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8512,7 +8512,7 @@
         },
         {
             "id": "1c3b5f9b-1b95-5bbd-be00-19c2b0806d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2c0e6f-44a9-410f-a501-b95c1def9d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2c0e6f-44a9-410f-a501-b95c1def9d88.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "2fce7c78-01a9-5ee8-999d-5917b9a09d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933a376-399c-4071-b44b-95605edd8fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2933a376-399c-4071-b44b-95605edd8fdb.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "de8e7c49-276b-58ca-8c38-5188fbd6a952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd8800-affa-4e64-825f-2a3b4516ed0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbd8800-affa-4e64-825f-2a3b4516ed0f.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "f378381d-6f5c-57f2-9abb-cb4fab793b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22110a53-493d-4af5-aea5-f6a8b4958a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22110a53-493d-4af5-aea5-f6a8b4958a84.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8648,7 +8648,7 @@
         },
         {
             "id": "d01a56cc-e672-511b-9b09-16003a1e6d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0413b3da-fec3-4221-bcec-2b964b45dd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0413b3da-fec3-4221-bcec-2b964b45dd00.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8682,7 +8682,7 @@
         },
         {
             "id": "3b426fd6-6cdc-5529-a531-fb1df8aa6711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbf199b-2c3f-441d-950e-c4a3d3086e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fbf199b-2c3f-441d-950e-c4a3d3086e4b.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8716,7 +8716,7 @@
         },
         {
             "id": "a37cf97e-f9ae-5c96-b3bf-f49a43cc6eb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4333372-80ea-42df-bf8a-d1f12bcb348e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4333372-80ea-42df-bf8a-d1f12bcb348e.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "6bee9d2a-319e-5b67-a899-29258d2f8cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff64dab-233b-42b0-88bb-d3e4f7eb4e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff64dab-233b-42b0-88bb-d3e4f7eb4e93.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "9308254b-38ac-54a1-87b5-e0325d8063ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83648ae-b9a5-40c1-825d-287b2d4ec838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83648ae-b9a5-40c1-825d-287b2d4ec838.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "df8502df-5d33-55e9-a756-f8fa94ef5b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ea880-0158-4faa-8018-f6626f25dd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ea880-0158-4faa-8018-f6626f25dd02.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "1545ee29-d9c1-57ff-acae-431cfd6d60cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9cea73-9421-4f91-b8f9-1a8081b3811a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9cea73-9421-4f91-b8f9-1a8081b3811a.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "78ec3c68-cfdb-5d1d-966a-466357082666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e78d072-183d-4272-9d9f-6801dced729d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e78d072-183d-4272-9d9f-6801dced729d.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "04980b0b-701b-5763-aefa-a81de18dc93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "e8a3b735-b487-54f5-a6a1-cb589433671f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b980ff-02ad-447e-8815-16cd0112ce60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b980ff-02ad-447e-8815-16cd0112ce60.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8990,7 +8990,7 @@
         },
         {
             "id": "801b4da1-9973-5d92-b53e-3ca496f67f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06eea30-810b-4623-9862-ec71c4bed11a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06eea30-810b-4623-9862-ec71c4bed11a.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -9027,7 +9027,7 @@
         },
         {
             "id": "7d6177c0-df09-58f5-a5b6-8b83d2c0e91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f827ad1-4931-404d-a0ff-bff8b98eae42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f827ad1-4931-404d-a0ff-bff8b98eae42.jpg?1",
             "name": "Goblin Warrior",
             "text": "",
             "colours": [
@@ -9064,7 +9064,7 @@
         },
         {
             "id": "87158278-d23f-5c6d-aba0-35859a8e1252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d49a56f-2a5e-4d42-b75c-f3f3735829d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d49a56f-2a5e-4d42-b75c-f3f3735829d3.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9100,7 +9100,7 @@
         },
         {
             "id": "7fd86b65-c9ff-54a6-9442-953c3750e345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "115d8a6c-40ed-5c40-b256-e66d7b653e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf98006-cc53-4a6c-b372-97b0970ffe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf98006-cc53-4a6c-b372-97b0970ffe4d.jpg?1",
             "name": "Domri Rade Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MMA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "eb17f73c-21e5-54c8-bfac-1da5b59f55c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d6999d-63d7-4719-9e1a-851e040593f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d6999d-63d7-4719-9e1a-851e040593f5.jpg?1",
             "name": "Adarkar Valkyrie",
             "text": "Flying, vigilance\n{T}: When target creature other than Adarkar Valkyrie dies this turn, return that card to the battlefield under your control.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "4ce23e56-7fe7-5a14-9347-c31e1062367a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ada83d-c499-45c2-bf8b-788a439fd1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ada83d-c499-45c2-bf8b-788a439fd1c3.jpg?1",
             "name": "Amrou Scout",
             "text": "{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "01011f44-5656-5aa0-bfff-1dbade305c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0191a7-9928-4b6e-ae4f-0db2d41ca71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0191a7-9928-4b6e-ae4f-0db2d41ca71a.jpg?1",
             "name": "Amrou Seekers",
             "text": "Amrou Seekers can't be blocked except by artifact creatures and/or white creatures.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "32bc582a-ad16-5574-8a5b-fcdf5b78c1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310deafe-124b-4813-a383-bc9a9d028cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310deafe-124b-4813-a383-bc9a9d028cfc.jpg?1",
             "name": "Angel's Grace",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "fafcdce8-4f45-5e94-8ddd-b521b51b2ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bc3347-6d07-4609-ae7b-4f4596a065b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bc3347-6d07-4609-ae7b-4f4596a065b7.jpg?1",
             "name": "Auriok Salvagers",
             "text": "{1}{W}: Return target artifact card with converted mana cost 1 or less from your graveyard to your hand.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "b839d665-58aa-59ca-9e51-3c0a755dd820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe4fba9-5ff4-4e4b-be28-2849fa3c7003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe4fba9-5ff4-4e4b-be28-2849fa3c7003.jpg?1",
             "name": "Avian Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nFlying",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "47a94eb8-2c86-5161-a63d-c9a0cfbef0ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b15737-1026-407f-b2a8-4f7932b2bb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b15737-1026-407f-b2a8-4f7932b2bb18.jpg?1",
             "name": "Blinding Beam",
             "text": "Choose one \u2014 Tap two target creatures; or creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "13a2f1b3-181a-5c9d-82e6-2c8483f517d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c809f77a-2c9a-4134-9c29-0709ee4f4957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c809f77a-2c9a-4134-9c29-0709ee4f4957.jpg?1",
             "name": "Bound in Silence",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "45ace07e-775c-5d44-958d-20442acf4065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bcc0fd-1eea-4eb0-8099-e0e94ffe00b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bcc0fd-1eea-4eb0-8099-e0e94ffe00b6.jpg?1",
             "name": "Cenn's Enlistment",
             "text": "Put two 1/1 white Kithkin Soldier creature tokens onto the battlefield.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "f931b623-5385-5e95-95af-dc8b403fb66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c55419c-f4d3-46b4-9a46-8cf84612819b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c55419c-f4d3-46b4-9a46-8cf84612819b.jpg?1",
             "name": "Cloudgoat Ranger",
             "text": "When Cloudgoat Ranger enters the battlefield, put three 1/1 white Kithkin Soldier creature tokens onto the battlefield.\nTap three untapped Kithkin you control: Cloudgoat Ranger gets +2/+0 and gains flying until end of turn.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "a4c54462-d0c2-5137-8bbd-3250d30e725f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0025826-efe4-4be2-9e1d-76505251060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0025826-efe4-4be2-9e1d-76505251060d.jpg?1",
             "name": "Court Homunculus",
             "text": "Court Homunculus gets +1/+1 as long as you control another artifact.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "834dedd1-59ab-54af-88c1-b0e23f75a83c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407b9797-fd17-4f40-8107-33512f6e8ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407b9797-fd17-4f40-8107-33512f6e8ab5.jpg?1",
             "name": "Dispeller's Capsule",
             "text": "{2}{W}, {T}, Sacrifice Dispeller's Capsule: Destroy target artifact or enchantment.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "75dbbd57-df8e-52ca-a9cc-948bbc0b2ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746d56ef-7ac5-403b-bca3-1cd267de97df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746d56ef-7ac5-403b-bca3-1cd267de97df.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "+1: Put a 1/1 white Soldier creature token onto the battlefield.\n+1: Target creature gets +3/+3 and gains flying until end of turn.\n-8: You get an emblem with \"Artifacts, creatures, enchantments, and lands you control are indestructible.\"",
             "colours": [
@@ -451,7 +451,7 @@
         },
         {
             "id": "b1c54eb5-9e0e-59f0-89c3-75e3ccfcc159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992efc14-29d0-4a33-976e-28bb0a5f6b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992efc14-29d0-4a33-976e-28bb0a5f6b52.jpg?1",
             "name": "Ethersworn Canonist",
             "text": "Each player who has cast a nonartifact spell this turn can't cast additional nonartifact spells.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "6e2ec13d-634f-5d86-b211-25d0f9b977ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2993319-5b3d-48ca-b78d-563a8b66d76d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2993319-5b3d-48ca-b78d-563a8b66d76d.jpg?1",
             "name": "Feudkiller's Verdict",
             "text": "You gain 10 life. Then if you have more life than an opponent, put a 5/5 white Giant Warrior creature token onto the battlefield.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "cc0c33ae-9e4b-5105-82eb-022b555121be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d332f494-386c-4aaa-9854-d78e75a91e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d332f494-386c-4aaa-9854-d78e75a91e81.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -556,7 +556,7 @@
         },
         {
             "id": "a6961568-6987-5224-a054-28eaa7f91980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157091f0-4416-4129-b417-cb6de7a970f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157091f0-4416-4129-b417-cb6de7a970f7.jpg?1",
             "name": "Gleam of Resistance",
             "text": "Creatures you control get +1/+2 until end of turn. Untap those creatures.\nBasic landcycling {1}{W} ({1}{W}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -588,7 +588,7 @@
         },
         {
             "id": "073a7490-0626-5809-bb03-3edde6a681f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d48857-2fb6-4163-8785-12436db1b37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d48857-2fb6-4163-8785-12436db1b37c.jpg?1",
             "name": "Hillcomber Giant",
             "text": "Mountainwalk",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "222edb9c-4a0b-5941-a16e-0df7110ad65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ad17b9-6604-4a60-8f22-62775f1086ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ad17b9-6604-4a60-8f22-62775f1086ce.jpg?1",
             "name": "Ivory Giant",
             "text": "When Ivory Giant enters the battlefield, tap all nonwhite creatures.\nSuspend 5\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -657,7 +657,7 @@
         },
         {
             "id": "4319155a-6f45-5470-8041-b0af5739b381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d84ac44-01d8-415e-af69-7c608ac8ae20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d84ac44-01d8-415e-af69-7c608ac8ae20.jpg?1",
             "name": "Kataki, War's Wage",
             "text": "All artifacts have \"At the beginning of your upkeep, sacrifice this artifact unless you pay {1}.\"",
             "colours": [
@@ -693,7 +693,7 @@
         },
         {
             "id": "8e3204ea-9c3c-527d-9748-80a347bedba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d091f-7718-434f-894d-2fe40e0e67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d091f-7718-434f-894d-2fe40e0e67dd.jpg?1",
             "name": "Kithkin Greatheart",
             "text": "As long as you control a Giant, Kithkin Greatheart gets +1/+1 and has first strike.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "0dd188f4-ff36-5bfa-b56f-9c32ab6bc006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dc0113-f03c-47c2-9424-4c546793d25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dc0113-f03c-47c2-9424-4c546793d25d.jpg?1",
             "name": "Meadowboon",
             "text": "When Meadowboon leaves the battlefield, put a +1/+1 counter on each creature target player controls.\nEvoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "4f40d51a-70d5-5066-a561-623128e49e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3974cd-7054-4381-b327-4aba1c693382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3974cd-7054-4381-b327-4aba1c693382.jpg?1",
             "name": "Otherworldly Journey",
             "text": "Exile target creature. At the beginning of the next end step, return that card to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -796,7 +796,7 @@
         },
         {
             "id": "4c60314c-e1e7-5778-8b1a-79caac1dbadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12788a7-5309-4a23-930d-009dc3305cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12788a7-5309-4a23-930d-009dc3305cef.jpg?1",
             "name": "Pallid Mycoderm",
             "text": "At the beginning of your upkeep, put a spore counter on Pallid Mycoderm.\nRemove three spore counters from Pallid Mycoderm: Put a 1/1 green Saproling creature token onto the battlefield.\nSacrifice a Saproling: Each creature you control that's a Fungus or a Saproling gets +1/+1 until end of turn.",
             "colours": [
@@ -830,7 +830,7 @@
         },
         {
             "id": "f851a8c9-4d07-5df7-82e2-d996ed2ad113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde60409-6b44-43ce-9441-af6020fe6355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde60409-6b44-43ce-9441-af6020fe6355.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -862,7 +862,7 @@
         },
         {
             "id": "4e709547-d634-547b-aafd-b25b776d90d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a4d2e0-1410-41f4-8070-2b0144c71e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a4d2e0-1410-41f4-8070-2b0144c71e1d.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "5d7ed4d5-b30f-53b2-b238-65949b08de32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a8a34-5f4c-43c3-9010-5c43453916f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/667a8a34-5f4c-43c3-9010-5c43453916f5.jpg?1",
             "name": "Saltfield Recluse",
             "text": "{T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "c9f19214-5c4e-536d-a9b5-1da7d4c9abb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e6cabf-0116-432a-99ae-fcbfec33e873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e6cabf-0116-432a-99ae-fcbfec33e873.jpg?1",
             "name": "Sanctum Gargoyle",
             "text": "Flying\nWhen Sanctum Gargoyle enters the battlefield, you may return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "b382dc10-55bc-5652-8f35-ea59b533034b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae0b42a-ae61-4aa8-95c6-49b7fe455603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae0b42a-ae61-4aa8-95c6-49b7fe455603.jpg?1",
             "name": "Sandsower",
             "text": "Tap three untapped creatures you control: Tap target creature.",
             "colours": [
@@ -1001,7 +1001,7 @@
         },
         {
             "id": "a05d7804-b057-5d6c-a91f-de4f46e5ef8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e01c926-bd9a-4d2f-b9fc-452584d056d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e01c926-bd9a-4d2f-b9fc-452584d056d9.jpg?1",
             "name": "Stir the Pride",
             "text": "Choose one \u2014 Creatures you control get +2/+2 until end of turn; or until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "b0505bec-a01f-510e-984a-dd79401a6ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93cdf08-d503-4084-8c09-c4080ea05c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93cdf08-d503-4084-8c09-c4080ea05c3a.jpg?1",
             "name": "Stonehewer Giant",
             "text": "Vigilance\n{1}{W}, {T}: Search your library for an Equipment card and put it onto the battlefield. Attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "4aa06d88-94ea-5c6c-ab53-df466223c254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab387bfd-2651-4883-b1a7-7bf197018bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab387bfd-2651-4883-b1a7-7bf197018bbe.jpg?1",
             "name": "Terashi's Grasp",
             "text": "Destroy target artifact or enchantment. You gain life equal to its converted mana cost.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "57287897-373a-55c3-8fde-fd19da35c99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ba07ca-7be4-400e-a104-f7bbd527b6b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ba07ca-7be4-400e-a104-f7bbd527b6b4.jpg?1",
             "name": "Test of Faith",
             "text": "Prevent the next 3 damage that would be dealt to target creature this turn, and put a +1/+1 counter on that creature for each 1 damage prevented this way.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "09e526e4-5ae2-5102-b9bd-aef7ff7514fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026aaea6-ed4f-4505-9779-7c28ff6c2284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026aaea6-ed4f-4505-9779-7c28ff6c2284.jpg?1",
             "name": "Veteran Armorer",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "770207bc-1d65-5963-ae86-eee5a6a0eed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376485a9-7cf5-43e0-919d-4de06b6aec61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376485a9-7cf5-43e0-919d-4de06b6aec61.jpg?1",
             "name": "Yosei, the Morning Star",
             "text": "Flying\nWhen Yosei, the Morning Star dies, target player skips his or her next untap step. Tap up to five target permanents that player controls.",
             "colours": [
@@ -1206,7 +1206,7 @@
         },
         {
             "id": "a122ff55-e315-53b6-a03e-227c78d92acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fee19e-6175-4701-90ae-08a1dcd93f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fee19e-6175-4701-90ae-08a1dcd93f00.jpg?1",
             "name": "Aethersnipe",
             "text": "When \u00c6thersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1240,7 +1240,7 @@
         },
         {
             "id": "d1b51619-cec6-506d-a039-d029befa34b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d61bfb-cc58-41a8-8532-e575e789eae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d61bfb-cc58-41a8-8532-e575e789eae3.jpg?1",
             "name": "Careful Consideration",
             "text": "Target player draws four cards, then discards three cards. If you cast this spell during your main phase, instead that player draws four cards, then discards two cards.",
             "colours": [
@@ -1272,7 +1272,7 @@
         },
         {
             "id": "76d2c903-0833-5bd5-b09d-f83394439fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0183c540-9b05-4e65-b2a5-b062754020da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0183c540-9b05-4e65-b2a5-b062754020da.jpg?1",
             "name": "Cryptic Command",
             "text": "Choose two \u2014 Counter target spell; or return target permanent to its owner's hand; or tap all creatures your opponents control; or draw a card.",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "28f09f85-1aa1-56c8-868e-85e0d753f6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c8590d-21f8-4bbf-8b71-1588428e2467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c8590d-21f8-4bbf-8b71-1588428e2467.jpg?1",
             "name": "Dampen Thought",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard.\nSplice onto Arcane {1}{U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1338,7 +1338,7 @@
         },
         {
             "id": "11090008-9822-5dca-ab03-21970583f5b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c426c11-0c9c-476f-9547-fd61eecab4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c426c11-0c9c-476f-9547-fd61eecab4db.jpg?1",
             "name": "Echoing Truth",
             "text": "Return target nonland permanent and all other permanents with the same name as that permanent to their owners' hands.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "df87a6e8-779b-5625-8e1a-db419b0bf507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d62dbee-9b25-41fb-ade0-fef4ba1cf8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d62dbee-9b25-41fb-ade0-fef4ba1cf8bb.jpg?1",
             "name": "Errant Ephemeron",
             "text": "Flying\nSuspend 4\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "45f09ab6-9200-5c1d-954c-02d02914f103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef14d4e-4727-4bc7-bc15-b0d31e19df8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef14d4e-4727-4bc7-bc15-b0d31e19df8c.jpg?1",
             "name": "Erratic Mutation",
             "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "76bc1bf4-444e-5036-b9f6-b3baa78d0031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0de335a-d31e-41e1-ab0d-7dbdd768ac82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0de335a-d31e-41e1-ab0d-7dbdd768ac82.jpg?1",
             "name": "Esperzoa",
             "text": "Flying\nAt the beginning of your upkeep, return an artifact you control to its owner's hand.",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "8f559bb4-367f-5691-aa5a-f99e7c2f05a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808d20da-b76c-4ebf-8477-4cab922a7aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808d20da-b76c-4ebf-8477-4cab922a7aab.jpg?1",
             "name": "Etherium Sculptor",
             "text": "Artifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -1507,7 +1507,7 @@
         },
         {
             "id": "bee5b3a6-be63-5f90-84a1-ee8924c203b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3029ea36-78f5-4d98-bd28-1e5292c85e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3029ea36-78f5-4d98-bd28-1e5292c85e8e.jpg?1",
             "name": "Faerie Mechanist",
             "text": "Flying\nWhen Faerie Mechanist enters the battlefield, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "b53385c6-f8af-5c39-8205-79275928a5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7dbbd-7947-4d1d-aaf8-a74e1ffdae97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7dbbd-7947-4d1d-aaf8-a74e1ffdae97.jpg?1",
             "name": "Gifts Ungiven",
             "text": "Search your library for up to four cards with different names and reveal them. Target opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -1575,7 +1575,7 @@
         },
         {
             "id": "87c48713-a9f5-5e32-9317-7fb0f3d9b8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e00cea-5dc0-43f6-bd95-d2776bdb19c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e00cea-5dc0-43f6-bd95-d2776bdb19c2.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "Flying\n{U}, Sacrifice Glen Elendra Archmage: Counter target noncreature spell.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "7d9e0682-cd6e-5249-a6a4-e71d3b5280f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993cdb5-132a-466e-aa2c-e8ab402aef2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3993cdb5-132a-466e-aa2c-e8ab402aef2d.jpg?1",
             "name": "Keiga, the Tide Star",
             "text": "Flying\nWhen Keiga, the Tide Star dies, gain control of target creature.",
             "colours": [
@@ -1647,7 +1647,7 @@
         },
         {
             "id": "8b65a938-8165-5c0a-a92b-22ab1255d78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9ba246-0f2c-4865-a6a5-f9fd4b813ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9ba246-0f2c-4865-a6a5-f9fd4b813ef1.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "Flying\nCreatures you control have \"Whenever this creature becomes the target of a spell or ability for the first time in a turn, counter that spell or ability.\"",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "49fbabcb-be56-5a4f-9e0a-cbed39243805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd63974-2a37-49bc-9eaf-a128c5ee3109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd63974-2a37-49bc-9eaf-a128c5ee3109.jpg?1",
             "name": "Latchkey Faerie",
             "text": "Flying\nProwl {2}{U} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Faerie or Rogue.)\nWhen Latchkey Faerie enters the battlefield, if its prowl cost was paid, draw a card.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "32bce47d-7a55-58a6-bcda-95c0ef072b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e39726-6229-4956-b3f9-7eb1d91227ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e39726-6229-4956-b3f9-7eb1d91227ef.jpg?1",
             "name": "Logic Knot",
             "text": "Delve (You may exile any number of cards from your graveyard as you cast this spell. It costs {1} less to cast for each card exiled this way.)\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "aed22900-3e24-5545-b18b-fab7ebba3313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19601ac-48a7-40c2-9159-af15af8520ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19601ac-48a7-40c2-9159-af15af8520ca.jpg?1",
             "name": "Meloku the Clouded Mirror",
             "text": "Flying\n{1}, Return a land you control to its owner's hand: Put a 1/1 blue Illusion creature token with flying onto the battlefield.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "8f797c15-2a9e-518f-9bc9-196a9ec3eb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acffb1-c1e8-4729-a350-64823b2f9d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acffb1-c1e8-4729-a350-64823b2f9d29.jpg?1",
             "name": "Mothdust Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nTap an untapped creature you control: Mothdust Changeling gains flying until end of turn.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "662e50ed-faf2-5ca2-9bca-c0a6f96538ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18233ee-3d90-4a28-8d93-918983bc9d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18233ee-3d90-4a28-8d93-918983bc9d11.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "df656d28-2840-586e-bdc6-04dacc114fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de38943-8f61-4be9-839b-370830c555cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de38943-8f61-4be9-839b-370830c555cf.jpg?1",
             "name": "Narcomoeba",
             "text": "Flying\nWhen Narcomoeba is put into your graveyard from your library, you may put it onto the battlefield.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "78aa1aaf-1c98-5a0a-9442-dbad610f8580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0e1481-a2a3-43d0-a33f-6f450c176e43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0e1481-a2a3-43d0-a33f-6f450c176e43.jpg?1",
             "name": "Pact of Negation",
             "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "86915d58-7dc4-5b9c-9c3a-8d6f89d27cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3cc8b1-19af-426e-8b8b-d94b3280c728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3cc8b1-19af-426e-8b8b-d94b3280c728.jpg?1",
             "name": "Peer Through Depths",
             "text": "Look at the top five cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "88ccd563-fb4c-5787-8142-e81450209179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f425b017-8c4d-457f-919a-f2686d71bcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f425b017-8c4d-457f-919a-f2686d71bcac.jpg?1",
             "name": "Perilous Research",
             "text": "Draw two cards, then sacrifice a permanent.",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "09576448-6c81-5ace-a671-a35c85a0096e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58a6a63-c7d8-4f2f-acaf-b0a871eb5a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58a6a63-c7d8-4f2f-acaf-b0a871eb5a7c.jpg?1",
             "name": "Pestermite",
             "text": "Flash\nFlying\nWhen Pestermite enters the battlefield, you may tap or untap target permanent.",
             "colours": [
@@ -2022,7 +2022,7 @@
         },
         {
             "id": "1619fed2-35c4-58b0-a400-e25c7c2a5179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134c8764-028e-4f7f-988d-ffd4d3827eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134c8764-028e-4f7f-988d-ffd4d3827eb6.jpg?1",
             "name": "Petals of Insight",
             "text": "Look at the top three cards of your library. You may put those cards on the bottom of your library in any order. If you do, return Petals of Insight to its owner's hand. Otherwise, draw three cards.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "ad859108-f820-5676-8e16-8dee55bbdb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273db8a7-9c29-47c7-a00d-cc462e107d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273db8a7-9c29-47c7-a00d-cc462e107d02.jpg?1",
             "name": "Reach Through Mists",
             "text": "Draw a card.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "f12aed20-d52d-54c1-85cd-6692a6d7bea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc160761-60b4-4911-b75f-df445ea399aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc160761-60b4-4911-b75f-df445ea399aa.jpg?1",
             "name": "Riftwing Cloudskate",
             "text": "Flying\nWhen Riftwing Cloudskate enters the battlefield, return target permanent to its owner's hand.\nSuspend 3\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "0a28f300-f5aa-5146-a49e-24c9e0915bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29f95fe-2efa-4788-84d8-2bd88d8650b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29f95fe-2efa-4788-84d8-2bd88d8650b4.jpg?1",
             "name": "Scion of Oona",
             "text": "Flash\nFlying\nOther Faerie creatures you control get +1/+1.\nOther Faeries you control have shroud.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "31b060aa-b63d-5afd-94df-02f45f5dd328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79418c88-5335-4a02-bcad-c1a611be25b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79418c88-5335-4a02-bcad-c1a611be25b7.jpg?1",
             "name": "Spell Snare",
             "text": "Counter target spell with converted mana cost 2.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "f68f3d1c-9e2b-5a9a-94da-a4dc5f1f2951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3899605d-2203-4ab6-9ff5-69490382eea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3899605d-2203-4ab6-9ff5-69490382eea4.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "Flash\nFlying\nWhen Spellstutter Sprite enters the battlefield, counter target spell with converted mana cost X or less, where X is the number of Faeries you control.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "c08deceb-e515-538e-b694-a2a1578e40b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8632ab0-9b6d-4d32-8af9-c61e9206497f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8632ab0-9b6d-4d32-8af9-c61e9206497f.jpg?1",
             "name": "Take Possession",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nEnchant permanent\nYou control enchanted permanent.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "7fafe986-dba7-5ea8-a0dd-ab7dbc652e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85756379-cdcb-4139-939d-36b22d39c001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85756379-cdcb-4139-939d-36b22d39c001.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -2292,7 +2292,7 @@
         },
         {
             "id": "aa821b91-35e7-5371-8edf-8bc66075a5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f29ba-ec1a-4362-b041-fe07214670f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/428f29ba-ec1a-4362-b041-fe07214670f8.jpg?1",
             "name": "Traumatic Visions",
             "text": "Counter target spell.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "73e12c4d-e03d-57f9-811d-48629be5b78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe73a5-dba9-422b-86c1-c957d9cb0622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fe73a5-dba9-422b-86c1-c957d9cb0622.jpg?1",
             "name": "Vedalken Dismisser",
             "text": "When Vedalken Dismisser enters the battlefield, put target creature on top of its owner's library.",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "3f778c62-f4c3-5888-9eec-9c60fbebf497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141d5bb-6437-4353-bec9-63d59f5d8207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d141d5bb-6437-4353-bec9-63d59f5d8207.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique enters the battlefield, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "f58b6851-c70d-55ec-a42e-9b60fa209cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894a8bc4-4ee0-45c6-86e9-aa91ddb505da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894a8bc4-4ee0-45c6-86e9-aa91ddb505da.jpg?1",
             "name": "Absorb Vis",
             "text": "Target player loses 4 life and you gain 4 life.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "a7f991a9-b995-57b2-9192-8a072bac3209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae897d-bbf9-47fe-a4d1-788cdf5c5de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ae897d-bbf9-47fe-a4d1-788cdf5c5de3.jpg?1",
             "name": "Auntie's Snitch",
             "text": "Auntie's Snitch can't block.\nProwl {1}{B} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhenever a Goblin or Rogue you control deals combat damage to a player, if Auntie's Snitch is in your graveyard, you may return Auntie's Snitch to your hand.",
             "colours": [
@@ -2463,7 +2463,7 @@
         },
         {
             "id": "7374cf13-98b0-5532-a033-73f657b21e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af270e2-3bf2-4a53-9160-4ccdab34f3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af270e2-3bf2-4a53-9160-4ccdab34f3b3.jpg?1",
             "name": "Blightspeaker",
             "text": "{T}: Target player loses 1 life.\n{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "9fb01731-8d11-5861-9ce2-dfb32095fc4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ce657c-2092-419a-b35f-7b9786adc621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ce657c-2092-419a-b35f-7b9786adc621.jpg?1",
             "name": "Bridge from Below",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, if Bridge from Below is in your graveyard, put a 2/2 black Zombie creature token onto the battlefield.\nWhen a creature is put into an opponent's graveyard from the battlefield, if Bridge from Below is in your graveyard, exile Bridge from Below.",
             "colours": [
@@ -2531,7 +2531,7 @@
         },
         {
             "id": "1db67744-4595-53cd-b508-7dcb9a603190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c008ad2-ad33-46ee-a3f1-af85368c8734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c008ad2-ad33-46ee-a3f1-af85368c8734.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2566,7 +2566,7 @@
         },
         {
             "id": "667d5cc0-e262-5ed2-bc2b-223fe58701d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0870b88-2794-4646-9f51-f3af03bc8bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0870b88-2794-4646-9f51-f3af03bc8bc8.jpg?1",
             "name": "Death Cloud",
             "text": "Each player loses X life, discards X cards, sacrifices X creatures, then sacrifices X lands.",
             "colours": [
@@ -2598,7 +2598,7 @@
         },
         {
             "id": "cbba1a0a-2dd9-55dc-b9bc-8006f9086933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179fc63a-cfa3-44be-9da5-d1bf33209207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179fc63a-cfa3-44be-9da5-d1bf33209207.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "e4926009-0db5-55f4-a194-86c4da65d3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a287887a-fc19-41e3-8914-8f984c1e4f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a287887a-fc19-41e3-8914-8f984c1e4f59.jpg?1",
             "name": "Death Rattle",
             "text": "Delve (You may exile any number of cards from your graveyard as you cast this spell. It costs {1} less to cast for each card exiled this way.)\nDestroy target nongreen creature. It can't be regenerated.",
             "colours": [
@@ -2664,7 +2664,7 @@
         },
         {
             "id": "b4ca7cc7-0378-57f2-a554-d7c633fa7eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78541e3-4e8f-41f8-b709-05b1b8e751d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d78541e3-4e8f-41f8-b709-05b1b8e751d9.jpg?1",
             "name": "Deepcavern Imp",
             "text": "Flying, haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -2699,7 +2699,7 @@
         },
         {
             "id": "61c7a278-59b9-5937-8042-dbf7367e709b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2f3899-2e2e-418f-b3e7-74426d6255f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2f3899-2e2e-418f-b3e7-74426d6255f4.jpg?1",
             "name": "Drag Down",
             "text": "Domain \u2014 Target creature gets -1/-1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2731,7 +2731,7 @@
         },
         {
             "id": "e8eca786-0d83-5574-ad44-0ed1f404fa27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893376-f82b-49b5-b641-85d2458ae261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e893376-f82b-49b5-b641-85d2458ae261.jpg?1",
             "name": "Dreamspoiler Witches",
             "text": "Flying\nWhenever you cast a spell during an opponent's turn, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -2766,7 +2766,7 @@
         },
         {
             "id": "7b07c101-98fb-50f7-b5b8-e800ba73cfbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12759ab-97c7-406a-bf57-eec74839f8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12759ab-97c7-406a-bf57-eec74839f8f6.jpg?1",
             "name": "Earwig Squad",
             "text": "Prowl {2}{B} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhen Earwig Squad enters the battlefield, if its prowl cost was paid, search target opponent's library for three cards and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "d44314e2-3f90-5317-980d-cfc7c6def138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60afc2-d383-4a52-8a0e-0d9dc68fed03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a60afc2-d383-4a52-8a0e-0d9dc68fed03.jpg?1",
             "name": "Executioner's Capsule",
             "text": "{1}{B}, {T}, Sacrifice Executioner's Capsule: Destroy target nonblack creature.",
             "colours": [
@@ -2833,7 +2833,7 @@
         },
         {
             "id": "87388ac2-cc09-546f-84f8-29f7f909d8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c9390-1b44-40c5-b370-1d9966cbfeae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c9390-1b44-40c5-b370-1d9966cbfeae.jpg?1",
             "name": "Extirpate",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "3fc0b19d-a63f-513c-a48c-f937852e46e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a25f62-0ef5-4941-b9af-1ce1a63fb5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a25f62-0ef5-4941-b9af-1ce1a63fb5e8.jpg?1",
             "name": "Facevaulter",
             "text": "{B}, Sacrifice a Goblin: Facevaulter gets +2/+2 until end of turn.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "2bd57741-2467-5c60-9298-bd02e7f2f42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352f7903-c2ab-4b08-b602-ee008eeb19cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352f7903-c2ab-4b08-b602-ee008eeb19cd.jpg?1",
             "name": "Faerie Macabre",
             "text": "Flying\nDiscard Faerie Macabre: Exile up to two target cards from graveyards.",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "ff9fdef1-17cb-571a-818b-21d702943367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978a9e84-2cce-41ec-b311-745a8ea6c238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978a9e84-2cce-41ec-b311-745a8ea6c238.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin dies, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "58ea9635-a9dd-583a-aa96-6a7b9c4d89af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e029c-cf98-4c98-b394-923247579ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e029c-cf98-4c98-b394-923247579ee5.jpg?1",
             "name": "Horobi's Whisper",
             "text": "If you control a Swamp, destroy target nonblack creature.\nSplice onto Arcane\u2014\nExile four cards from your graveyard. (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "059e3a43-f0cf-5b74-8fe0-f20df29a6157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80365-1613-4d26-abe3-8cec0d40146b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a80365-1613-4d26-abe3-8cec0d40146b.jpg?1",
             "name": "Kokusho, the Evening Star",
             "text": "Flying\nWhen Kokusho, the Evening Star dies, each opponent loses 5 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "4c54a41b-7461-5144-b7b2-4a54e6e1ccc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00215182-51bd-4c7e-9675-179749a25a07.jpg?1",
             "name": "Mad Auntie",
             "text": "Other Goblin creatures you control get +1/+1.\n{T}: Regenerate another target Goblin.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "4713dcda-3349-511e-9887-350d88e714d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1833f-a682-4795-a39a-8b03ead50b10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1833f-a682-4795-a39a-8b03ead50b10.jpg?1",
             "name": "Marsh Flitter",
             "text": "Flying\nWhen Marsh Flitter enters the battlefield, put two 1/1 black Goblin Rogue creature tokens onto the battlefield.\nSacrifice a Goblin: Marsh Flitter becomes 3/3 until end of turn.",
             "colours": [
@@ -3111,7 +3111,7 @@
         },
         {
             "id": "004b3b84-db1d-5191-91d9-0b5844b8cf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f45251-e71e-4601-9b51-dbc08ab036c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f45251-e71e-4601-9b51-dbc08ab036c2.jpg?1",
             "name": "Peppersmoke",
             "text": "Target creature gets -1/-1 until end of turn. If you control a Faerie, draw a card.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "b89be611-c214-5ab5-9928-3b673de32928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb65f5ff-1f0a-469c-831f-618254727111.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb65f5ff-1f0a-469c-831f-618254727111.jpg?1",
             "name": "Phthisis",
             "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5\u2014{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "031421f7-65ac-54a2-b0ec-0dfc18cdc141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7449f03-fed0-4f8d-89ca-28182b6598f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7449f03-fed0-4f8d-89ca-28182b6598f6.jpg?1",
             "name": "Rathi Trapper",
             "text": "{B}, {T}: Tap target creature.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "0a33f2e8-e9b3-5360-a3f9-2be629b52a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271436b-897a-4b24-a5d2-d29dbea8c1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7271436b-897a-4b24-a5d2-d29dbea8c1bf.jpg?1",
             "name": "Raven's Crime",
             "text": "Target player discards a card.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "7ead80a0-36cc-5282-99a6-57ab852f5a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07c59-23d3-44fe-9393-4ebb5450b644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc07c59-23d3-44fe-9393-4ebb5450b644.jpg?1",
             "name": "Skeletal Vampire",
             "text": "Flying\nWhen Skeletal Vampire enters the battlefield, put two 1/1 black Bat creature tokens with flying onto the battlefield.\n{3}{B}{B}, Sacrifice a Bat: Put two 1/1 black Bat creature tokens with flying onto the battlefield.\nSacrifice a Bat: Regenerate Skeletal Vampire.",
             "colours": [
@@ -3281,7 +3281,7 @@
         },
         {
             "id": "2049040a-5d82-54c6-977b-8a8f407cbcaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd740d1d-ad70-47de-aef1-aec5ab2135d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd740d1d-ad70-47de-aef1-aec5ab2135d2.jpg?1",
             "name": "Slaughter Pact",
             "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "fc123fef-083a-5957-bd6d-63f0974f70b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c40d4c-426d-4697-a173-e0a348308857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c40d4c-426d-4697-a173-e0a348308857.jpg?1",
             "name": "Stinkweed Imp",
             "text": "Flying\nWhenever Stinkweed Imp deals combat damage to a creature, destroy that creature.\nDredge 5 (If you would draw a card, instead you may put exactly five cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "257361a5-6efe-5690-9739-85a29ef608a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edbaa-68c8-4a1c-ab5f-d096e74c0d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edbaa-68c8-4a1c-ab5f-d096e74c0d01.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -3381,7 +3381,7 @@
         },
         {
             "id": "912300df-9050-5746-990d-390a51172b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0547b01-aabc-4114-b71c-ae44cb2bb871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0547b01-aabc-4114-b71c-ae44cb2bb871.jpg?1",
             "name": "Syphon Life",
             "text": "Target player loses 2 life and you gain 2 life.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "38a33600-5ddc-5322-9cfc-bf094c5a0da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244d864d-fc74-4147-aca6-d0498691b1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/244d864d-fc74-4147-aca6-d0498691b1a9.jpg?1",
             "name": "Thieving Sprite",
             "text": "Flying\nWhen Thieving Sprite enters the battlefield, target player reveals X cards from his or her hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.",
             "colours": [
@@ -3448,7 +3448,7 @@
         },
         {
             "id": "785c1577-c08a-567a-a4b4-74f472a44411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d4615-fe42-41b1-be74-4ad8355eb114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9d4615-fe42-41b1-be74-4ad8355eb114.jpg?1",
             "name": "Tombstalker",
             "text": "Flying\nDelve (You may exile any number of cards from your graveyard as you cast this spell. It costs {1} less to cast for each card exiled this way.)",
             "colours": [
@@ -3482,7 +3482,7 @@
         },
         {
             "id": "a1537f03-9ba3-5929-a7c8-93094ec3d6df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac647ea-e81e-46d4-9a65-613d6643362b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac647ea-e81e-46d4-9a65-613d6643362b.jpg?1",
             "name": "Warren Pilferers",
             "text": "When Warren Pilferers enters the battlefield, return target creature card from your graveyard to your hand. If that card is a Goblin card, Warren Pilferers gains haste until end of turn.",
             "colours": [
@@ -3517,7 +3517,7 @@
         },
         {
             "id": "0b768caf-a6c5-5bfc-adac-c019f666110c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524aa84d-7838-4664-b30c-3c242b46fc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524aa84d-7838-4664-b30c-3c242b46fc6b.jpg?1",
             "name": "Warren Weirding",
             "text": "Target player sacrifices a creature. If a Goblin is sacrificed this way, that player puts two 1/1 black Goblin Rogue creature tokens onto the battlefield, and those tokens gain haste until end of turn.",
             "colours": [
@@ -3552,7 +3552,7 @@
         },
         {
             "id": "d06290e5-4769-5e5b-a1e1-51b7a6ffcc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d76ed9-7a2c-466f-be39-1f7880744c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d76ed9-7a2c-466f-be39-1f7880744c33.jpg?1",
             "name": "Blind-Spot Giant",
             "text": "Blind-Spot Giant can't attack or block unless you control another Giant.",
             "colours": [
@@ -3587,7 +3587,7 @@
         },
         {
             "id": "184de455-c0d9-5134-9075-9a09c65fe483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310647b0-54a4-4c0a-acdd-5e8e91972a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310647b0-54a4-4c0a-acdd-5e8e91972a87.jpg?1",
             "name": "Blood Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "839763b8-7185-5493-a24d-b95d02a06850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8283d5c-9dc3-409b-b897-9bc61a6c9d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8283d5c-9dc3-409b-b897-9bc61a6c9d57.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "80c2d6d9-ca17-5bb1-ac66-9c608527e00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54582b89-a152-4686-8172-82db740dfea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54582b89-a152-4686-8172-82db740dfea2.jpg?1",
             "name": "Countryside Crusher",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a land card, put it into your graveyard and repeat this process.\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Countryside Crusher.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "049f4442-fba3-5e4e-bf48-8e7f20068181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756025a8-1096-4e7c-bbfe-6237e4a76216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756025a8-1096-4e7c-bbfe-6237e4a76216.jpg?1",
             "name": "Crush Underfoot",
             "text": "Choose a Giant creature you control. It deals damage equal to its power to target creature.",
             "colours": [
@@ -3721,7 +3721,7 @@
         },
         {
             "id": "4117174d-c04d-5d5f-b9b9-7890e884c11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827c728-5526-4abe-ad21-311594a0bc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0827c728-5526-4abe-ad21-311594a0bc13.jpg?1",
             "name": "Desperate Ritual",
             "text": "Add {R}{R}{R} to your mana pool.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3755,7 +3755,7 @@
         },
         {
             "id": "46cfc4cf-ff22-50a3-ab70-e3babb31c9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230cd568-f7ed-4571-a609-36522add91d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230cd568-f7ed-4571-a609-36522add91d0.jpg?1",
             "name": "Dragonstorm",
             "text": "Search your library for a Dragon permanent card and put it onto the battlefield. Then shuffle your library.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -3787,7 +3787,7 @@
         },
         {
             "id": "f6edb6b4-e23a-53e3-bf65-8a8552f7be51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7488515d-d90f-44c4-b2a9-8f76e46bbbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7488515d-d90f-44c4-b2a9-8f76e46bbbbe.jpg?1",
             "name": "Empty the Warrens",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "f90d39c1-d3a9-50aa-aed4-503a00360c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc517738-d731-4960-bc1e-5e86ca341ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc517738-d731-4960-bc1e-5e86ca341ba9.jpg?1",
             "name": "Fiery Fall",
             "text": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "000a83dc-9ee4-528d-866d-2ca2063e718c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2a382b-f63a-4520-ab6e-a5428a5e61db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2a382b-f63a-4520-ab6e-a5428a5e61db.jpg?1",
             "name": "Fury Charm",
             "text": "Choose one \u2014 Destroy target artifact; or target creature gets +1/+1 and gains trample until end of turn; or remove two time counters from target permanent or suspended card.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "59edb354-18f7-536e-b189-3b4709038c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa3b25c-a1e1-4eb0-9b65-3c4c6b2a8903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa3b25c-a1e1-4eb0-9b65-3c4c6b2a8903.jpg?1",
             "name": "Glacial Ray",
             "text": "Glacial Ray deals 2 damage to target creature or player.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "d8f8c47c-6bdf-51ff-9ace-f62c9dd7bdef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd49f85-7dbd-4cb6-b916-2adee29bb745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd49f85-7dbd-4cb6-b916-2adee29bb745.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to target creature or player.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "5a9277bb-651e-5871-8042-da4bdaa8b9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b922fc5-602b-4f92-9588-00a77a9d803c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b922fc5-602b-4f92-9588-00a77a9d803c.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate this ability only if Greater Gargadon is suspended.",
             "colours": [
@@ -3983,7 +3983,7 @@
         },
         {
             "id": "b1f81661-995d-5768-b0e2-2e0a6c1ce443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908980bf-0631-4c10-b0ae-39e5b50b9068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908980bf-0631-4c10-b0ae-39e5b50b9068.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {2}{R} to your mana pool. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4017,7 +4017,7 @@
         },
         {
             "id": "aa923abe-e78c-528e-a35b-6bbbe9876b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd39a59-688f-4465-8f00-540326c41128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd39a59-688f-4465-8f00-540326c41128.jpg?1",
             "name": "Hammerheim Deadeye",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Hammerheim Deadeye enters the battlefield, destroy target creature with flying.",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "e0dbd8fc-ccc0-531b-afd3-0af32c27f64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7445467-1222-4d9e-8a2f-879719c97b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7445467-1222-4d9e-8a2f-879719c97b29.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Put a token that's a copy of target nonlegendary creature you control onto the battlefield. That token has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "0a5c0300-7ba3-58b7-87fb-14d02fb57196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbec4-202d-47ee-9472-b41d41f75372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbec4-202d-47ee-9472-b41d41f75372.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "7fde22d1-63d9-50dd-ae6a-fc848c31dacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45b117-8ba1-4349-ac06-f690cde48c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc45b117-8ba1-4349-ac06-f690cde48c17.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, put a 1/1 red Goblin creature token onto the battlefield.",
             "colours": [
@@ -4158,7 +4158,7 @@
         },
         {
             "id": "7585cd24-0661-5698-8c03-5462b53124d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed531da-4e57-4694-bd6c-8669dcc3d119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed531da-4e57-4694-bd6c-8669dcc3d119.jpg?1",
             "name": "Molten Disaster",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf Molten Disaster was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "535daefb-20e2-5df3-b9d7-3eea0ccdf314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd618eb1-0013-461c-873e-a66377fa284a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd618eb1-0013-461c-873e-a66377fa284a.jpg?1",
             "name": "Pardic Dragon",
             "text": "Flying\n{R}: Pardic Dragon gets +1/+0 until end of turn.\nSuspend 2\u2014{R}{R}\nWhenever an opponent casts a spell, if Pardic Dragon is suspended, that player may put a time counter on Pardic Dragon.",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "893f164f-b791-5e18-81cd-3c36901c0516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ee7137-dbc4-4fe5-802a-42dada4445db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ee7137-dbc4-4fe5-802a-42dada4445db.jpg?1",
             "name": "Pyromancer's Swath",
             "text": "If an instant or sorcery source you control would deal damage to a creature or player, it deals that much damage plus 2 to that creature or player instead.\nAt the beginning of each end step, discard your hand.",
             "colours": [
@@ -4256,7 +4256,7 @@
         },
         {
             "id": "88732e50-69b3-57a9-b4a5-1cbc948574fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c5fcbf-00f5-41ee-9673-ad39fd2327c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c5fcbf-00f5-41ee-9673-ad39fd2327c6.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to target creature or player.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "a2b8e1ac-ad12-5c98-918e-5e17c003c050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9015b8a-7070-40de-8baa-4b4002429e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9015b8a-7070-40de-8baa-4b4002429e79.jpg?1",
             "name": "Rift Elemental",
             "text": "{1}{R}, Remove a time counter from a permanent you control or suspended card you own: Rift Elemental gets +2/+0 until end of turn.",
             "colours": [
@@ -4322,7 +4322,7 @@
         },
         {
             "id": "fb65e460-438a-50a4-ba75-38392849944e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784393a8-e231-4613-8849-576e6b61b354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784393a8-e231-4613-8849-576e6b61b354.jpg?1",
             "name": "Ryusei, the Falling Star",
             "text": "Flying\nWhen Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "84c45e5a-5263-5135-92f5-761c9624df1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fdf1-99cf-402b-a70e-de0e77933d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92fdf1-99cf-402b-a70e-de0e77933d81.jpg?1",
             "name": "Shrapnel Blast",
             "text": "As an additional cost to cast Shrapnel Blast, sacrifice an artifact.\nShrapnel Blast deals 5 damage to target creature or player.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "8a200fe3-b555-5677-a988-ad10dac7907f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a309d0-5da2-4976-b1ad-1b363c8dca42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a309d0-5da2-4976-b1ad-1b363c8dca42.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -4427,7 +4427,7 @@
         },
         {
             "id": "3ad8b61f-93b4-5611-85a8-8f3a049ed43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102b0df-04c0-418c-a316-c8ea8660e9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3102b0df-04c0-418c-a316-c8ea8660e9f7.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -4462,7 +4462,7 @@
         },
         {
             "id": "a3b8cf4b-4e12-5cbd-9ba1-ae15f76ae231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1527b360-2aa5-4680-89f0-4c9095afa3ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1527b360-2aa5-4680-89f0-4c9095afa3ef.jpg?1",
             "name": "Stinkdrinker Daredevil",
             "text": "Giant spells you cast cost {2} less to cast.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "eb9464c3-8963-5aae-a3e3-69709b845c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b6f51-d444-48f7-a7f0-743f2b8d0595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066b6f51-d444-48f7-a7f0-743f2b8d0595.jpg?1",
             "name": "Sudden Shock",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "5775de32-5115-52b2-813b-7563992e2694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc997628-22f3-4e6f-998f-e049fac8192c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc997628-22f3-4e6f-998f-e049fac8192c.jpg?1",
             "name": "Tar Pitcher",
             "text": "{T}, Sacrifice a Goblin: Tar Pitcher deals 2 damage to target creature or player.",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "a60e2b14-3ca5-5c0d-bfa4-ee3a93bd953c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d964912d-50cb-42d7-a72c-9c9066087a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d964912d-50cb-42d7-a72c-9c9066087a96.jpg?1",
             "name": "Thundercloud Shaman",
             "text": "When Thundercloud Shaman enters the battlefield, it deals damage equal to the number of Giants you control to each non-Giant creature.",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "eeb27f4c-8fb5-5806-ba7a-d07a37778336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b76021-77de-4155-98b2-24daab1a850e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b76021-77de-4155-98b2-24daab1a850e.jpg?1",
             "name": "Thundering Giant",
             "text": "Haste",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "db01d6ed-0d5c-5aab-936b-6f4938614691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d00132-6c25-42d3-bfe5-5f893b63a292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d00132-6c25-42d3-bfe5-5f893b63a292.jpg?1",
             "name": "Torrent of Stone",
             "text": "Torrent of Stone deals 4 damage to target creature.\nSplice onto Arcane\u2014\nSacrifice two Mountains. (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "2731230b-3bc5-57f8-b41e-fb2c7f8236dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fafa53-1e22-43f5-abf3-bbab8130f84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07fafa53-1e22-43f5-abf3-bbab8130f84d.jpg?1",
             "name": "Tribal Flames",
             "text": "Domain \u2014 Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "76cc6bab-2221-582d-bc09-e43398675f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523500d3-5614-4be8-95c7-d63ca279c1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523500d3-5614-4be8-95c7-d63ca279c1b1.jpg?1",
             "name": "War-Spike Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{R}: War-Spike Changeling gains first strike until end of turn.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "f8822e3b-4d08-515c-9996-fcf7fdcb28f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cd5c0-f56f-4419-b9d2-478d8455f2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346cd5c0-f56f-4419-b9d2-478d8455f2b8.jpg?1",
             "name": "Citanul Woodreaders",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nWhen Citanul Woodreaders enters the battlefield, if it was kicked, draw two cards.",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "ce2b37c5-5aa8-5974-93c1-9f212f8da736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f296a5a-9e6c-4432-bf9b-fafbcccb6e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f296a5a-9e6c-4432-bf9b-fafbcccb6e62.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would put one or more tokens onto the battlefield under your control, it puts twice that many of those tokens onto the battlefield instead.\nIf an effect would place one or more counters on a permanent you control, it places twice that many of those counters on that permanent instead.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "1ba3f49c-ce11-56e0-9209-f285f5c059b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7c7dea-c73d-47ee-9119-5c8a4357d79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7c7dea-c73d-47ee-9119-5c8a4357d79e.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "d9db8c69-c632-5f20-ab73-f1152e669962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b14c3cf-fb7b-4397-bb30-1efaf142959f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b14c3cf-fb7b-4397-bb30-1efaf142959f.jpg?1",
             "name": "Echoing Courage",
             "text": "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "d5a79241-2063-5fa3-9bd9-c06862938432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02902fcc-eefc-4e81-aafd-59fa203a71d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02902fcc-eefc-4e81-aafd-59fa203a71d7.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "384466f5-db22-54ac-aaea-c3aecab37384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2033c-3be6-413f-93b9-a375af9b5cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c2033c-3be6-413f-93b9-a375af9b5cf1.jpg?1",
             "name": "Giant Dustwasp",
             "text": "Flying\nSuspend 4\u2014{1}{G} (Rather than cast this card from your hand, you may pay {1}{G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "71168119-be35-52d0-a10d-119887c1d6bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98318dc-8ba5-4a33-b4a6-c36add8aa80e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98318dc-8ba5-4a33-b4a6-c36add8aa80e.jpg?1",
             "name": "Greater Mossdog",
             "text": "Dredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "d1585cf4-3805-56c3-b2dc-2093f498238a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afa824d-ad9b-44c1-9509-f9ecd34bde08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afa824d-ad9b-44c1-9509-f9ecd34bde08.jpg?1",
             "name": "Hana Kami",
             "text": "{1}{G}, Sacrifice Hana Kami: Return target Arcane card from your graveyard to your hand.",
             "colours": [
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "3afdfe8f-d280-52f4-9263-095b7a36ca77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d0f09b-cab8-42d8-ac93-1fd7c1244560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d0f09b-cab8-42d8-ac93-1fd7c1244560.jpg?1",
             "name": "Imperiosaur",
             "text": "Spend only mana produced by basic lands to cast Imperiosaur.",
             "colours": [
@@ -5038,7 +5038,7 @@
         },
         {
             "id": "1a7b26c5-697f-5e2b-b08b-25a0e37d3218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3528ed-e1a1-4020-acba-c079484de0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3528ed-e1a1-4020-acba-c079484de0ba.jpg?1",
             "name": "Incremental Growth",
             "text": "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "3540485b-d706-54fd-9d4d-5948c10aa6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d044c-b6ff-4434-a059-081832130212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0d044c-b6ff-4434-a059-081832130212.jpg?1",
             "name": "Jugan, the Rising Star",
             "text": "Flying\nWhen Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "d63db819-1d7d-5e20-a56e-23e731e28ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd600b0a-c7dd-4a5d-bd35-14ef4215c520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd600b0a-c7dd-4a5d-bd35-14ef4215c520.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5141,7 +5141,7 @@
         },
         {
             "id": "889c2d3f-27dc-5139-9194-8fd63e8d3036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8338bb-bf0d-4fc2-b247-4b2a183f27cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8338bb-bf0d-4fc2-b247-4b2a183f27cf.jpg?1",
             "name": "Krosan Grip",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "805ae955-3184-5ae0-83a8-fcc6863a50ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57d97cf-2252-47f3-9eff-6003626bc900.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57d97cf-2252-47f3-9eff-6003626bc900.jpg?1",
             "name": "Life from the Loam",
             "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "e5d2af6c-02aa-59e8-8415-0db675abc02f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ec6fc8-f778-4cca-8b67-66d6ff0efd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ec6fc8-f778-4cca-8b67-66d6ff0efd45.jpg?1",
             "name": "Masked Admirers",
             "text": "When Masked Admirers enters the battlefield, draw a card.\nWhenever you cast a creature spell, you may pay {G}{G}. If you do, return Masked Admirers from your graveyard to your hand.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "11b7ede1-e828-5f7f-aa0f-df0dabde8953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771cf62-b454-4c7f-918e-68335e695702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d771cf62-b454-4c7f-918e-68335e695702.jpg?1",
             "name": "Moldervine Cloak",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5274,7 +5274,7 @@
         },
         {
             "id": "a712db83-4e81-5080-a2c8-4e0cc538e328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501e4cb0-121e-450e-b522-eed90a2e34cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501e4cb0-121e-450e-b522-eed90a2e34cb.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman enters the battlefield, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than cast this card from your hand, you may pay {2}{G}{G} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "d3f615f8-07a7-53ed-87f5-dc3415274e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6415bf5-ead8-45a6-8d9c-d160c44cb775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6415bf5-ead8-45a6-8d9c-d160c44cb775.jpg?1",
             "name": "Penumbra Spider",
             "text": "Reach\nWhen Penumbra Spider dies, put a 2/4 black Spider creature token with reach onto the battlefield.",
             "colours": [
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "42177c55-1e63-59f2-865d-e66a6d557215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034215f1-62f5-49ce-a818-44577138b508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034215f1-62f5-49ce-a818-44577138b508.jpg?1",
             "name": "Reach of Branches",
             "text": "Put a 2/5 green Treefolk Shaman creature token onto the battlefield.\nWhenever a Forest enters the battlefield under your control, you may return Reach of Branches from your graveyard to your hand.",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "218040b4-a4aa-5ae8-8f11-910f41a84c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785d5a98-97b2-4a9e-83ee-2a74479add7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785d5a98-97b2-4a9e-83ee-2a74479add7b.jpg?1",
             "name": "Riftsweeper",
             "text": "When Riftsweeper enters the battlefield, choose target face-up exiled card. Its owner shuffles it into his or her library.",
             "colours": [
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "e6397612-820c-5364-ad97-ca855640bd07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5dfc70-5e39-41bd-a78b-f7dfc7f53bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5dfc70-5e39-41bd-a78b-f7dfc7f53bf4.jpg?1",
             "name": "Rude Awakening",
             "text": "Choose one \u2014 Untap all lands you control; or until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -5445,7 +5445,7 @@
         },
         {
             "id": "0b9bdc89-568e-5e66-bcd6-1919105bd47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0383f8d-8b8a-4a6b-8756-b27d8351a856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0383f8d-8b8a-4a6b-8756-b27d8351a856.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card and put it onto the battlefield. Then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -5477,7 +5477,7 @@
         },
         {
             "id": "2c889c8f-8e40-53e4-98a9-3c7411d5847b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7facb43f-275f-4f7f-a1b2-9c0e4b15addc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7facb43f-275f-4f7f-a1b2-9c0e4b15addc.jpg?1",
             "name": "Sporesower Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on each Fungus you control.\nRemove three spore counters from Sporesower Thallid: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5511,7 +5511,7 @@
         },
         {
             "id": "a3aed9ed-11f3-5727-bb2d-0729de974409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f0e2f5-6680-4abb-8724-32e0aa306dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f0e2f5-6680-4abb-8724-32e0aa306dd3.jpg?1",
             "name": "Sporoloth Ancient",
             "text": "At the beginning of your upkeep, put a spore counter on Sporoloth Ancient.\nCreatures you control have \"Remove two spore counters from this creature: Put a 1/1 green Saproling creature token onto the battlefield.\"",
             "colours": [
@@ -5545,7 +5545,7 @@
         },
         {
             "id": "d5a107fd-9ad7-5224-9022-06ee090d50dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8948f92-9bd5-4950-b901-6cf1528b5c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8948f92-9bd5-4950-b901-6cf1528b5c3f.jpg?1",
             "name": "Summoner's Pact",
             "text": "Search your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "00fc4df9-94bd-5c1f-ab5e-dbd04188e9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fed99a1-4cd6-40fc-8796-a92edc79bc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fed99a1-4cd6-40fc-8796-a92edc79bc76.jpg?1",
             "name": "Sylvan Bounty",
             "text": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -5609,7 +5609,7 @@
         },
         {
             "id": "ba7ef1e5-642c-55e4-8391-983f4ef98bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea82414-3f16-4c8c-8668-1f1ee7566c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea82414-3f16-4c8c-8668-1f1ee7566c7b.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -5643,7 +5643,7 @@
         },
         {
             "id": "5f04253d-ffbe-5c48-b4ce-ebe4e7e9744a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d20d28-76e9-4e6e-95c3-f88c51dfabfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d20d28-76e9-4e6e-95c3-f88c51dfabfd.jpg?1",
             "name": "Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid.\nRemove three spore counters from Thallid: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "94f7870f-3be1-5876-99c1-2208697dfd2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbb06b1-c2ca-4a69-835e-a47b576b7079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cbb06b1-c2ca-4a69-835e-a47b576b7079.jpg?1",
             "name": "Thallid Germinator",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid Germinator.\nRemove three spore counters from Thallid Germinator: Put a 1/1 green Saproling creature token onto the battlefield.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "a7ec1219-0350-57a8-8e5f-b3c3cb47baa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4363851-ecd6-41de-9bad-1fa02fb0b06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4363851-ecd6-41de-9bad-1fa02fb0b06e.jpg?1",
             "name": "Thallid Shell-Dweller",
             "text": "Defender\nAt the beginning of your upkeep, put a spore counter on Thallid Shell-Dweller.\nRemove three spore counters from Thallid Shell-Dweller: Put a 1/1 green Saproling creature token onto the battlefield.",
             "colours": [
@@ -5745,7 +5745,7 @@
         },
         {
             "id": "3364ab1f-6b88-558a-8bc2-30d1b1401ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f6e97-eb7a-470a-8673-4997256e79f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f6e97-eb7a-470a-8673-4997256e79f0.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one \u2014 Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle your library; or put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -5777,7 +5777,7 @@
         },
         {
             "id": "0f168065-1569-584f-8371-42ec60d54d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3815bd2-bc3c-46b8-b9e1-8eea25156440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3815bd2-bc3c-46b8-b9e1-8eea25156440.jpg?1",
             "name": "Tromp the Domains",
             "text": "Domain \u2014 Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "8073a0c6-42b4-5f75-8517-6f87ce7c90cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c2fce4-32b4-40cd-b467-a3ba3bf1fa10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c2fce4-32b4-40cd-b467-a3ba3bf1fa10.jpg?1",
             "name": "Verdeloth the Ancient",
             "text": "Kicker {X} (You may pay an additional {X} as you cast this spell.)\nSaproling creatures and other Treefolk creatures get +1/+1.\nWhen Verdeloth the Ancient enters the battlefield, if it was kicked, put X 1/1 green Saproling creature tokens onto the battlefield.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "0a605817-1495-5fbd-a882-c18d96469893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b014c3d9-0c24-42c3-8b70-eaf1064901ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b014c3d9-0c24-42c3-8b70-eaf1064901ce.jpg?1",
             "name": "Walker of the Grove",
             "text": "When Walker of the Grove leaves the battlefield, put a 4/4 green Elemental creature token onto the battlefield.\nEvoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "467b717e-0207-577f-bf1b-d44e8fc98da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb81647-e8ff-492e-a862-1b1ca142efe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb81647-e8ff-492e-a862-1b1ca142efe6.jpg?1",
             "name": "Woodfall Primus",
             "text": "Trample\nWhen Woodfall Primus enters the battlefield, destroy target noncreature permanent.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5914,7 +5914,7 @@
         },
         {
             "id": "68b3935f-96db-5717-ad94-0fe2b6b499dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d415c502-208f-4615-b5d9-57db7f966ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d415c502-208f-4615-b5d9-57db7f966ac1.jpg?1",
             "name": "Electrolyze",
             "text": "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.",
             "colours": [
@@ -5948,7 +5948,7 @@
         },
         {
             "id": "1ea5f7e0-1d0c-51d7-b6c9-beee97777282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337fd1aa-1c85-4aee-923b-c457e43cda72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337fd1aa-1c85-4aee-923b-c457e43cda72.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "White spells you cast cost {1} less to cast.\nBlue spells you cast cost {1} less to cast.\nSpells your opponents cast cost {1} more to cast.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "271a80df-d4c1-599e-a6ac-6a4a3d61e054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64553587-e707-41d2-a2f4-768dfa47e893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64553587-e707-41d2-a2f4-768dfa47e893.jpg?1",
             "name": "Jhoira of the Ghitu",
             "text": "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend. (At the beginning of your upkeep, remove a time counter from that card. When the last is removed, cast it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -6026,7 +6026,7 @@
         },
         {
             "id": "977fa373-00a4-5f87-98bb-9987cda039be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde4a6-128d-447f-9659-ceb3b345ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde4a6-128d-447f-9659-ceb3b345ed33.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "c3140c5d-3b07-5f53-b75d-70a24393647e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3eaaed-9af5-4220-a3d1-744de8147c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3eaaed-9af5-4220-a3d1-744de8147c52.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "51c22baa-7c3e-589a-b879-ab6e178cdc27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58beea98-bafd-46bf-8aec-d98893019374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58beea98-bafd-46bf-8aec-d98893019374.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "bec3cb35-cc69-5077-b071-2eb3063d023c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd667f-c330-474e-842b-49dfd3906375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd667f-c330-474e-842b-49dfd3906375.jpg?1",
             "name": "Mind Funeral",
             "text": "Target opponent reveals cards from the top of his or her library until four land cards are revealed. That player puts all cards revealed this way into his or her graveyard.",
             "colours": [
@@ -6165,7 +6165,7 @@
         },
         {
             "id": "6fb068b9-e7fc-5c78-a610-c217d177fc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5d0ba-bcb1-41db-80dd-ad22b8408105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a5d0ba-bcb1-41db-80dd-ad22b8408105.jpg?1",
             "name": "Progenitus",
             "text": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
             "colours": [
@@ -6210,7 +6210,7 @@
         },
         {
             "id": "89759631-3cfe-50d4-8c07-20e36b49f1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181e20e9-94a2-40b6-abc4-797f588866bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181e20e9-94a2-40b6-abc4-797f588866bf.jpg?1",
             "name": "Sarkhan Vol",
             "text": "+1: Creatures you control get +1/+1 and gain haste until end of turn.\n-2: Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n-6: Put five 4/4 red Dragon creature tokens with flying onto the battlefield.",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "c718f22f-5c40-5485-bf1e-5c5a30b07629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09521f23-52d6-482d-9f3b-c4d12fcc08cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09521f23-52d6-482d-9f3b-c4d12fcc08cc.jpg?1",
             "name": "Tidehollow Sculler",
             "text": "When Tidehollow Sculler enters the battlefield, target opponent reveals his or her hand and you choose a nonland card from it. Exile that card.\nWhen Tidehollow Sculler leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "8c921bc3-9ed0-5057-9ab3-7c95d979ac04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b14a8b3-1a85-400b-b17c-a28ed145d720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b14a8b3-1a85-400b-b17c-a28ed145d720.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -6321,7 +6321,7 @@
         },
         {
             "id": "ef2b1908-680e-5cfe-a354-cfa260f74e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700508bd-d425-40bc-abbf-7da2c97e0a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/700508bd-d425-40bc-abbf-7da2c97e0a74.jpg?1",
             "name": "Cold-Eyed Selkie",
             "text": "Islandwalk\nWhenever Cold-Eyed Selkie deals combat damage to a player, you may draw that many cards.",
             "colours": [
@@ -6358,7 +6358,7 @@
         },
         {
             "id": "9a241193-9dd9-5c15-813d-83f212077a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a62b9ea-18ea-4fbc-8e4d-0bacb4e4c47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a62b9ea-18ea-4fbc-8e4d-0bacb4e4c47e.jpg?1",
             "name": "Demigod of Revenge",
             "text": "Flying, haste\nWhen you cast Demigod of Revenge, return all cards named Demigod of Revenge from your graveyard to the battlefield.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "1d7a805b-cc70-5c7c-81dd-7a84caa72ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccd00e2-5aaf-45be-9360-70da3c573a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccd00e2-5aaf-45be-9360-70da3c573a28.jpg?1",
             "name": "Divinity of Pride",
             "text": "Flying, lifelink\nDivinity of Pride gets +4/+4 as long as you have 25 or more life.",
             "colours": [
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "a67cdc39-b259-54e8-be0f-ba7ac0033898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a4dd-a2cb-47a0-a1d5-da40d42013f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2019a4dd-a2cb-47a0-a1d5-da40d42013f3.jpg?1",
             "name": "Figure of Destiny",
             "text": "{GU}: Figure of Destiny becomes a 2/2 Kithkin Spirit.\n{GU}{GU}{GU}: If Figure of Destiny is a Spirit, it becomes a 4/4 Kithkin Spirit Warrior.\n{GU}{GU}{GU}{GU}{GU}{GU}: If Figure of Destiny is a Warrior, it becomes an 8/8 Kithkin Spirit Warrior Avatar with flying and first strike.",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "4fa21274-628f-5d50-9dd1-ebe46e6c3606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df8bd5-cc06-4a95-a089-938fb7e4b650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df8bd5-cc06-4a95-a089-938fb7e4b650.jpg?1",
             "name": "Kitchen Finks",
             "text": "When Kitchen Finks enters the battlefield, you gain 2 life.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6504,7 +6504,7 @@
         },
         {
             "id": "326f27d7-ae9f-5e04-a791-f7da1a0ef6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079df56-60f9-46e5-8f2e-032e62b6a5f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f079df56-60f9-46e5-8f2e-032e62b6a5f1.jpg?1",
             "name": "Manamorphose",
             "text": "Add two mana in any combination of colors to your mana pool.\nDraw a card.",
             "colours": [
@@ -6538,7 +6538,7 @@
         },
         {
             "id": "e08d3099-4023-561a-b670-af628f28234e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7ad50f-19e9-4dcd-97c2-49ab308b6030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7ad50f-19e9-4dcd-97c2-49ab308b6030.jpg?1",
             "name": "Murderous Redcap",
             "text": "When Murderous Redcap enters the battlefield, it deals damage equal to its power to target creature or player.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "9c517825-19f5-5962-92b6-5b1213415022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab4b6f-480c-40ac-a8cc-335a22b5acb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ab4b6f-480c-40ac-a8cc-335a22b5acb9.jpg?1",
             "name": "Oona, Queen of the Fae",
             "text": "Flying\n{X}{UB}: Choose a color. Target opponent exiles the top X cards of his or her library. For each card of the chosen color exiled this way, put a 1/1 blue and black Faerie Rogue creature token with flying onto the battlefield.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "7f9bce74-3c9b-57a3-8563-c1fc9f86b6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accad809-77f5-4a0f-9ec6-a368c9f27d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/accad809-77f5-4a0f-9ec6-a368c9f27d69.jpg?1",
             "name": "Plumeveil",
             "text": "Flash\nDefender, flying",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "66b8d585-717c-5947-8943-a5c5005d50ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b5512-2520-4fd5-87a3-f8a5c56769ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b5512-2520-4fd5-87a3-f8a5c56769ad.jpg?1",
             "name": "Worm Harvest",
             "text": "Put a 1/1 black and green Worm creature token onto the battlefield for each land card in your graveyard.\nRetrace (You may cast this card from your graveyard by discarding a land card in addition to paying its other costs.)",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "4e9211e8-1b47-56b9-a12b-f06b690ef481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ef7938-7c68-4aeb-9403-4ab1af944a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ef7938-7c68-4aeb-9403-4ab1af944a81.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice \u00c6ther Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice \u00c6ther Spellbomb: Draw a card.",
             "colours": [],
@@ -6714,7 +6714,7 @@
         },
         {
             "id": "9eb3f203-aebf-5196-b6a7-03d335d64b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6774c646-76d4-4991-a7f3-b753ef200ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6774c646-76d4-4991-a7f3-b753ef200ce5.jpg?1",
             "name": "Aether Vial",
             "text": "At the beginning of your upkeep, you may put a charge counter on \u00c6ther Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on \u00c6ther Vial from your hand onto the battlefield.",
             "colours": [],
@@ -6742,7 +6742,7 @@
         },
         {
             "id": "1eb85ade-b31d-52ba-825a-37b2eaa50c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c33a92-5621-40b4-a3a2-b67893edbc01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c33a92-5621-40b4-a3a2-b67893edbc01.jpg?1",
             "name": "Arcbound Ravager",
             "text": "Sacrifice an artifact: Put a +1/+1 counter on Arcbound Ravager.\nModular 1 (This enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6773,7 +6773,7 @@
         },
         {
             "id": "98255b51-d87e-5f6c-a0f7-d5802f851eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db438720-5bfb-4cd9-b565-434839045f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db438720-5bfb-4cd9-b565-434839045f60.jpg?1",
             "name": "Arcbound Stinger",
             "text": "Flying\nModular 1 (This enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "768cf879-4e63-5237-9e68-ce479a67747b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb48b77-9d25-47b0-8d3b-bf52b8db23e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb48b77-9d25-47b0-8d3b-bf52b8db23e8.jpg?1",
             "name": "Arcbound Wanderer",
             "text": "Modular\u2014\nSunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "815ac2d3-5afd-5b0c-bbdc-a5244e9cf6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc2453-5a2b-4104-bf82-84f935de7b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfc2453-5a2b-4104-bf82-84f935de7b99.jpg?1",
             "name": "Arcbound Worker",
             "text": "Modular 1 (This enters the battlefield with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
             "colours": [],
@@ -6866,7 +6866,7 @@
         },
         {
             "id": "d3e5e836-f896-548f-bfa5-38656ae0692e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09dad6d-ec9a-40b4-b136-7a8b58a42a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09dad6d-ec9a-40b4-b136-7a8b58a42a3b.jpg?1",
             "name": "Bonesplitter",
             "text": "Equipped creature gets +2/+0.\nEquip {1}",
             "colours": [],
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "4af95686-b777-5bf3-bec3-9c3e2e7be572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e472d9d-4e00-4f01-9daa-559e630403cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e472d9d-4e00-4f01-9daa-559e630403cc.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "4f26781c-cbed-527b-832a-5b5d29a563ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822a3a49-48dc-462f-8eb1-613429b7dc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822a3a49-48dc-462f-8eb1-613429b7dc1b.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -6952,7 +6952,7 @@
         },
         {
             "id": "88fff6a8-e92e-5a99-8014-502f542e4654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec35cbe-dd07-45c3-8fd4-802a20e6802b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec35cbe-dd07-45c3-8fd4-802a20e6802b.jpg?1",
             "name": "Epochrasite",
             "text": "Epochrasite enters the battlefield with three +1/+1 counters on it if you didn't cast it from your hand.\nWhen Epochrasite dies, exile it with three time counters on it and it gains suspend. (At the beginning of your upkeep, remove a time counter. When the last is removed, cast this card without paying its mana cost. It has haste.)",
             "colours": [],
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "d310e9a1-9f4a-5d25-a3a3-7a769b5ae71d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835b057-6652-48b0-82d4-8d932d716e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a835b057-6652-48b0-82d4-8d932d716e4b.jpg?1",
             "name": "Etched Oracle",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\n{1}, Remove four +1/+1 counters from Etched Oracle: Target player draws three cards.",
             "colours": [],
@@ -7014,7 +7014,7 @@
         },
         {
             "id": "4ff6f3d2-5f6f-525d-a729-7f8865b83f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d89d6b-9218-439a-a976-25ea02848d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d89d6b-9218-439a-a976-25ea02848d7f.jpg?1",
             "name": "Frogmite",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "12f0a42a-f86f-506c-9bc0-5208e27b8c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035c3112-222d-4362-9109-c8b872a59a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035c3112-222d-4362-9109-c8b872a59a2b.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -7073,7 +7073,7 @@
         },
         {
             "id": "224d6ae8-8e75-5c0e-9bee-7d2773849c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563350ab-1a32-4304-921f-1fd80cb3a630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563350ab-1a32-4304-921f-1fd80cb3a630.jpg?1",
             "name": "Myr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
             "colours": [],
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "3da99f8f-1d5a-5aae-b864-246ef733593f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8972a7c-ff64-4158-8277-2bd90e8db48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8972a7c-ff64-4158-8277-2bd90e8db48d.jpg?1",
             "name": "Myr Retriever",
             "text": "When Myr Retriever dies, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "166b42e0-92e5-5e48-b0d5-37980fb65307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cd6bcc-ca47-47cc-9fe4-c29e9c176485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cd6bcc-ca47-47cc-9fe4-c29e9c176485.jpg?1",
             "name": "Paradise Mantle",
             "text": "Equipped creature has \"{T}: Add one mana of any color to your mana pool.\"\nEquip {1}",
             "colours": [],
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "efa0f967-6bf6-5a44-b84a-b390a1be4a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a10d1-ca71-4cf3-9072-ee3a69c4885c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32a10d1-ca71-4cf3-9072-ee3a69c4885c.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "{R}, Sacrifice Pyrite Spellbomb: Pyrite Spellbomb deals 2 damage to target creature or player.\n{1}, Sacrifice Pyrite Spellbomb: Draw a card.",
             "colours": [],
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "4e2836f0-c029-5788-9f34-5e9fc5b4065d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c285b3a0-a27c-4416-a1b5-90219a5c7800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c285b3a0-a27c-4416-a1b5-90219a5c7800.jpg?1",
             "name": "Relic of Progenitus",
             "text": "{T}: Target player exiles a card from his or her graveyard.\n{1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.",
             "colours": [],
@@ -7223,7 +7223,7 @@
         },
         {
             "id": "f6fc557a-0ba2-5b39-b9cb-cb1838d0b4a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54f50fe-d4c0-49ba-9063-853c76ae3e19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54f50fe-d4c0-49ba-9063-853c76ae3e19.jpg?1",
             "name": "Runed Stalactite",
             "text": "Equipped creature gets +1/+1 and is every creature type.\nEquip {2}",
             "colours": [],
@@ -7253,7 +7253,7 @@
         },
         {
             "id": "d6a81240-9513-5710-8698-acc491770bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61229b83-2a77-43c7-bc02-5b7a54ba4a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61229b83-2a77-43c7-bc02-5b7a54ba4a87.jpg?1",
             "name": "Skyreach Manta",
             "text": "Sunburst (This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.)\nFlying",
             "colours": [],
@@ -7284,7 +7284,7 @@
         },
         {
             "id": "d1a7852b-37b9-5251-8eb2-9054d4395023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddc025-4396-4d88-8d72-6c06ea7125f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfddc025-4396-4d88-8d72-6c06ea7125f1.jpg?1",
             "name": "Sword of Fire and Ice",
             "text": "Equipped creature gets +2/+2 and has protection from red and from blue.\nWhenever equipped creature deals combat damage to a player, Sword of Fire and Ice deals 2 damage to target creature or player and you draw a card.\nEquip {2}",
             "colours": [],
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "c99f51a6-26ff-5225-9d4f-19e3bf7d8c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b662709a-d0b3-4c85-b849-6aedebb550eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b662709a-d0b3-4c85-b849-6aedebb550eb.jpg?1",
             "name": "Sword of Light and Shadow",
             "text": "Equipped creature gets +2/+2 and has protection from white and from black.\nWhenever equipped creature deals combat damage to a player, you gain 3 life and you may return up to one target creature card from your graveyard to your hand.\nEquip {2}",
             "colours": [],
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "b20fe602-b271-51fc-9095-b4647ecc9f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3257833-b237-49ef-856a-3c1d1c752cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3257833-b237-49ef-856a-3c1d1c752cf8.jpg?1",
             "name": "Vedalken Shackles",
             "text": "You may choose not to untap Vedalken Shackles during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as Vedalken Shackles remains tapped.",
             "colours": [],
@@ -7372,7 +7372,7 @@
         },
         {
             "id": "1a6659e9-3070-508a-a16f-c7c4bda5f9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2c9306-b065-4813-8817-ae46a7725b5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa2c9306-b065-4813-8817-ae46a7725b5e.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}, {T}: Put target artifact card from your graveyard on top of your library.",
             "colours": [],
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "638b73bb-c037-5328-9d42-888d70567d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e0482-d1e6-420f-9a8a-a675345fc09b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e0482-d1e6-420f-9a8a-a675345fc09b.jpg?1",
             "name": "Blinkmoth Nexus",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Blinkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying until end of turn. It's still a land.\n{1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "165dbc21-3b94-551c-9c67-404d8609dc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459042ef-0d5b-480f-9b8a-520e13ae9217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459042ef-0d5b-480f-9b8a-520e13ae9217.jpg?1",
             "name": "City of Brass",
             "text": "Whenever City of Brass becomes tapped, it deals 1 damage to you.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7460,7 +7460,7 @@
         },
         {
             "id": "d3d1a17d-a243-56cd-a850-504c797a27a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29307e6-f323-4b86-b9ce-4c2d6f995743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d29307e6-f323-4b86-b9ce-4c2d6f995743.jpg?1",
             "name": "Dakmor Salvage",
             "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [],
@@ -7490,7 +7490,7 @@
         },
         {
             "id": "d2a10e04-22b6-5771-8280-95040a26c948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8ea9d-3252-4f6b-9b01-edb2a49e98b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f8ea9d-3252-4f6b-9b01-edb2a49e98b9.jpg?1",
             "name": "Glimmervoid",
             "text": "At the beginning of the end step, if you control no artifacts, sacrifice Glimmervoid.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7518,7 +7518,7 @@
         },
         {
             "id": "8bdad128-00f1-52cc-a275-a429c523fb72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0af384a-6421-43f6-a6ed-166022912a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0af384a-6421-43f6-a6ed-166022912a36.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7546,7 +7546,7 @@
         },
         {
             "id": "92b08b42-8335-5c35-93a1-7e50aa4b73b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208067af-9dd2-4509-96cb-f3ae216e3551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208067af-9dd2-4509-96cb-f3ae216e3551.jpg?1",
             "name": "Vivid Crag",
             "text": "Vivid Crag enters the battlefield tapped with two charge counters on it.\n{T}: Add {R} to your mana pool.\n{T}, Remove a charge counter from Vivid Crag: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7576,7 +7576,7 @@
         },
         {
             "id": "ec60d494-a0da-5c3b-ab2e-937f7a69b5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5a9520-484f-4f6c-a302-af6764d6d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5a9520-484f-4f6c-a302-af6764d6d842.jpg?1",
             "name": "Vivid Creek",
             "text": "Vivid Creek enters the battlefield tapped with two charge counters on it.\n{T}: Add {U} to your mana pool.\n{T}, Remove a charge counter from Vivid Creek: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7606,7 +7606,7 @@
         },
         {
             "id": "ff1baa42-6024-5702-ac99-f3ffdea8269c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbb669a-5bcb-4189-b0ad-73ff900e102f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbb669a-5bcb-4189-b0ad-73ff900e102f.jpg?1",
             "name": "Vivid Grove",
             "text": "Vivid Grove enters the battlefield tapped with two charge counters on it.\n{T}: Add {G} to your mana pool.\n{T}, Remove a charge counter from Vivid Grove: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7636,7 +7636,7 @@
         },
         {
             "id": "719caa1a-cfb2-5e12-8a97-3996d522197f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8d99b-ce80-4cf2-a55c-1257d6b1d799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8d99b-ce80-4cf2-a55c-1257d6b1d799.jpg?1",
             "name": "Vivid Marsh",
             "text": "Vivid Marsh enters the battlefield tapped with two charge counters on it.\n{T}: Add {B} to your mana pool.\n{T}, Remove a charge counter from Vivid Marsh: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "e3ebbc63-f7ad-53a0-b129-2425f5cef8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f0d54-07b9-4668-8eed-4062b3b942da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f0d54-07b9-4668-8eed-4062b3b942da.jpg?1",
             "name": "Vivid Meadow",
             "text": "Vivid Meadow enters the battlefield tapped with two charge counters on it.\n{T}: Add {W} to your mana pool.\n{T}, Remove a charge counter from Vivid Meadow: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "424eae52-6b3b-59f9-8a03-9a682fe7d85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a41d0d-aaf5-4cb4-a9db-07992c57e436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a41d0d-aaf5-4cb4-a9db-07992c57e436.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -7731,7 +7731,7 @@
         },
         {
             "id": "c1353bba-95b5-5c2d-a138-6f9175747736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28adced8-4f86-4dc7-bd21-e20ba403219c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28adced8-4f86-4dc7-bd21-e20ba403219c.jpg?1",
             "name": "Kithkin Soldier",
             "text": "",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "e773321d-42e1-5116-8379-148e26427153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3317ef0-5104-41de-9e7a-2629ad658ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3317ef0-5104-41de-9e7a-2629ad658ae7.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "1a4acb2d-e5ef-57b0-9653-9c48f5458b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24ae780-d226-4deb-9a4a-91262763d0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24ae780-d226-4deb-9a4a-91262763d0cd.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -7834,7 +7834,7 @@
         },
         {
             "id": "f1a551ec-bdba-5acc-a5ac-60b5b5f283e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ed94-564b-415c-b590-d89c972384a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ed94-564b-415c-b590-d89c972384a1.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -7868,7 +7868,7 @@
         },
         {
             "id": "377beef1-7cf9-5725-80e4-13f5a3502631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bd708d-dc84-44d3-a563-536ade028bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bd708d-dc84-44d3-a563-536ade028bd0.jpg?1",
             "name": "Goblin Rogue",
             "text": "",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "2b7c9afc-3e4e-5ae4-b148-4e5e9dbd471b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d833298-a270-4b89-987c-5b6432bbc311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d833298-a270-4b89-987c-5b6432bbc311.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -7937,7 +7937,7 @@
         },
         {
             "id": "60575e5a-881b-5fe6-aa4a-0ae0d8ccbd02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738dce42-9852-4ced-8e9e-4639fad8b79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738dce42-9852-4ced-8e9e-4639fad8b79f.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -7971,7 +7971,7 @@
         },
         {
             "id": "ea0db304-776f-556c-a0a5-eedcf6c6ad5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529930fe-a1af-42fb-85a4-4999e787b25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529930fe-a1af-42fb-85a4-4999e787b25b.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "32aa33fc-99b2-54ad-9990-fa9b874f2fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ac66f-4b21-4acf-b51b-41c9d241d971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ac66f-4b21-4acf-b51b-41c9d241d971.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8039,7 +8039,7 @@
         },
         {
             "id": "25b6cf61-2957-59fc-b0bf-e268799eb338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9c63b7-ec72-443f-9216-5cb7bd07e940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9c63b7-ec72-443f-9216-5cb7bd07e940.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8073,7 +8073,7 @@
         },
         {
             "id": "68d70380-b934-5999-9ba5-acd59aadf216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15854c49-14fd-4947-8444-c5ab614cb416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15854c49-14fd-4947-8444-c5ab614cb416.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "5cf2b39f-2017-5f35-84c8-5ec778289e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75c1ada-2a49-49e8-800d-f11d08263dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75c1ada-2a49-49e8-800d-f11d08263dde.jpg?1",
             "name": "Treefolk Shaman",
             "text": "",
             "colours": [
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "6b5a3b83-2057-5f85-9676-8bb0633405e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb3b8a-f9d3-4ce1-b171-ba7b0c3f4830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb3b8a-f9d3-4ce1-b171-ba7b0c3f4830.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "92a66c18-cf1c-5a7f-b0cb-5b6f049e653c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b9eb1-ccdc-4540-9d53-7853539af189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b9eb1-ccdc-4540-9d53-7853539af189.jpg?1",
             "name": "Worm",
             "text": "",
             "colours": [
@@ -8215,7 +8215,7 @@
         },
         {
             "id": "2815b341-9e87-5933-b5f0-d8a2f238d311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014c0557-11b8-49da-8486-0dd14b919338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014c0557-11b8-49da-8486-0dd14b919338.jpg?1",
             "name": "Elspeth, Knight-Errant Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MMQ.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MMQ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f1c68663-178b-5cd5-910c-21f95eb3f87f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa2ecf9-b53c-4f1d-9028-ca3820d043cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa2ecf9-b53c-4f1d-9028-ca3820d043cb.jpg?1",
             "name": "Afterlife",
             "text": "Destroy target creature. It can't be regenerated. Its controller puts a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "a0d3faf1-0b41-5799-a658-73aea6ed5a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf393a3-831e-4d3a-8404-ee83f60970aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf393a3-831e-4d3a-8404-ee83f60970aa.jpg?1",
             "name": "Alabaster Wall",
             "text": "(Walls can't attack.)\noc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "ad09c304-d8f2-5f2e-a635-f232f83edf48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4402a-f263-4f82-b4c0-cf0aa58dc946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eb4402a-f263-4f82-b4c0-cf0aa58dc946.jpg?1",
             "name": "Armistice",
             "text": "o3o\nWoo\nW You draw a card and target opponent gains 3 life.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "a9a5fa0f-6fba-5821-a626-e1cf68a49f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b083fd8-6422-4cd3-a27d-41b6d88598c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b083fd8-6422-4cd3-a27d-41b6d88598c2.jpg?1",
             "name": "Arrest",
             "text": "Enchanted creature can't attack or block, and its activated abilities can't be played.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "b23bd8f5-11f8-5a21-893f-bd062a540e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d51d84-23d2-41ff-ab68-a633beddba06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d51d84-23d2-41ff-ab68-a633beddba06.jpg?1",
             "name": "Ballista Squad",
             "text": "o\nXo\nW, oc\nT: Ballista Squad deals X damage to target attacking or blocking creature.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "1b54738f-d419-5735-9729-24c9fb95afb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082e6ee3-cc1f-46c7-9d82-56751478b3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082e6ee3-cc1f-46c7-9d82-56751478b3cf.jpg?1",
             "name": "Charm Peddler",
             "text": "o\nW, oc\nT, Discard a card from your hand: The next time a source of your choice would deal damage to target creature this turn, prevent that damage.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "f28518c2-aca8-57e5-a9c5-0c9e68f4e2d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d36960-3c78-4032-9325-8002b2a48503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d36960-3c78-4032-9325-8002b2a48503.jpg?1",
             "name": "Charmed Griffin",
             "text": "Flying\nWhen Charmed Griffin comes into play, each other player may put an artifact or enchantment card into play from his or her hand.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "6cedfe89-0c02-5350-9d5a-731bcc18d661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c9d49d-61eb-4f33-b06b-03bdd990efd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c9d49d-61eb-4f33-b06b-03bdd990efd0.jpg?1",
             "name": "Cho-Arrim Alchemist",
             "text": "o1o\nWo\nW, oc\nT, Discard a card from your hand: The next time a source of your choice would deal damage to you this turn, prevent that damage and gain that much life.",
             "colours": [
@@ -275,7 +275,7 @@
         },
         {
             "id": "051d56e9-d7d3-53fd-95ac-d93cfd24c10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg?1",
             "name": "Cho-Arrim Bruiser",
             "text": "Whenever Cho-Arrim Bruiser attacks, you may tap up to two target creatures.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "798fdcfa-a539-55ed-adb1-f661c8a68e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427a3a1-24e1-4697-b5eb-1c0a24f89e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1427a3a1-24e1-4697-b5eb-1c0a24f89e75.jpg?1",
             "name": "Cho-Arrim Legate",
             "text": "Protection from black\nIf an opponent controls a swamp and you control a plains, you may play Cho-Arrim Legate without paying its mana cost.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "e35ff5d9-96da-5cc2-b16f-fcada63d68c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc51393-de63-4ce3-ab02-c695e4448018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc51393-de63-4ce3-ab02-c695e4448018.jpg?1",
             "name": "Cho-Manno, Revolutionary",
             "text": "Prevent all damage that would be dealt to Cho-Manno, Revolutionary.",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "c82b4e9d-b42b-5cd9-bc07-856b1be0d7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9f33c6-5294-4584-854d-c8c0f847aba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9f33c6-5294-4584-854d-c8c0f847aba8.jpg?1",
             "name": "Cho-Manno's Blessing",
             "text": "You may play Cho-Manno's Blessing any time you could play an instant.\nAs Cho-Manno's Blessing comes into play, choose a color.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Cho-Manno's Blessing.",
             "colours": [
@@ -416,7 +416,7 @@
         },
         {
             "id": "c0440638-8d8e-5a9f-bb6b-26e4bb8577d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae4c25f-2005-4ac0-a5f0-2fc250520995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae4c25f-2005-4ac0-a5f0-2fc250520995.jpg?1",
             "name": "Common Cause",
             "text": "Nonartifact creatures get +2/+2 as long as they all share a color.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "e3c7077f-6f6e-58be-96d2-c29e04ade09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4f3c1d-d25e-4263-ab2b-19534c852678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4f3c1d-d25e-4263-ab2b-19534c852678.jpg?1",
             "name": "Cornered Market",
             "text": "Players can't play spells or nonbasic lands with the same name as a card in play.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "91fef90f-0e95-5a57-a1c7-55c52f52dbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7009fd8-1d80-41bb-a1b0-fea9c909c63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7009fd8-1d80-41bb-a1b0-fea9c909c63d.jpg?1",
             "name": "Crackdown",
             "text": "Nonwhite creatures with power 3 or greater don't untap during their controllers' untap steps.",
             "colours": [
@@ -512,7 +512,7 @@
         },
         {
             "id": "d79b0ad8-85cd-562d-834a-0f8d40d99531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744c2177-3140-48a1-95a4-2f0a27ca5b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/744c2177-3140-48a1-95a4-2f0a27ca5b2f.jpg?1",
             "name": "Crossbow Infantry",
             "text": "oc\nT: Crossbow Infantry deals 1 damage to target attacking or blocking creature.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "f17a0ae5-41dc-56e6-97c3-e2608287b539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca7aeb-09db-4409-9ba2-c5c5500ad72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ca7aeb-09db-4409-9ba2-c5c5500ad72f.jpg?1",
             "name": "Devout Witness",
             "text": "o1o\nW, oc\nT, Discard a card from your hand: Destroy target artifact or enchantment.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "57d16e20-f99e-5648-8a06-62044b60ff10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366407d8-3ed9-4809-b9bb-388ebb9ea815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366407d8-3ed9-4809-b9bb-388ebb9ea815.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "80d15177-2df1-5e8c-862f-830a71f81dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690daa19-1842-4605-9bda-bf67e4ede3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690daa19-1842-4605-9bda-bf67e4ede3c4.jpg?1",
             "name": "Fountain Watch",
             "text": "Artifacts and enchantments you control can't be the target of spells or abilities.",
             "colours": [
@@ -650,7 +650,7 @@
         },
         {
             "id": "b4bb4b8d-da00-59f5-b71a-451434816b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070ea4a-c417-405f-b788-78fb7ca2eaa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070ea4a-c417-405f-b788-78fb7ca2eaa5.jpg?1",
             "name": "Fresh Volunteers",
             "text": "",
             "colours": [
@@ -685,7 +685,7 @@
         },
         {
             "id": "fb12f047-246b-5910-b47b-d471a87aef52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70147617-10e0-413d-be0a-a888b9cb6b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70147617-10e0-413d-be0a-a888b9cb6b97.jpg?1",
             "name": "Honor the Fallen",
             "text": "Remove all creature cards in all graveyards from the game. You gain 1 life for each card removed this way.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "af0536fd-aa89-58df-890b-8b48f27bbe79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676a2506-17f8-4b8e-be0c-eacc0fe972f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676a2506-17f8-4b8e-be0c-eacc0fe972f6.jpg?1",
             "name": "Ignoble Soldier",
             "text": "Whenever Ignoble Soldier becomes blocked, prevent all combat damage that would be dealt by it this turn.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "59300584-dcaf-5d60-b292-4e02a3692269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ece8504-389a-43e3-b178-7067722c4b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ece8504-389a-43e3-b178-7067722c4b75.jpg?1",
             "name": "Inviolability",
             "text": "Prevent all damage that would be dealt to enchanted creature.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "5aadd930-34ee-5c44-a7b5-30e913cd27e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ea3762-a419-412c-b2bd-0a40902d8d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ea3762-a419-412c-b2bd-0a40902d8d51.jpg?1",
             "name": "Ivory Mask",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "d44987a0-9a72-58f8-8235-57be5c203844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg?1",
             "name": "Jhovall Queen",
             "text": "Attacking doesn't cause Jhovall Queen to tap.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "f96a6789-9ce6-5012-be0f-9593b2f5ad74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1f7c51-0011-4ea5-b123-3c26293f5dab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1f7c51-0011-4ea5-b123-3c26293f5dab.jpg?1",
             "name": "Jhovall Rider",
             "text": "Trample",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "a2dacd18-7aae-5d08-86be-d6139908d342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b540da2-f8c6-48d6-af6d-db78958f0a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b540da2-f8c6-48d6-af6d-db78958f0a17.jpg?1",
             "name": "Last Breath",
             "text": "Remove target creature with power 2 or less from the game. Its controller gains 4 life.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "7ccd961a-bd38-55c0-8cfa-9485c3983dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50b5f5-8dac-4785-b1af-a0bd64ce7a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f50b5f5-8dac-4785-b1af-a0bd64ce7a92.jpg?1",
             "name": "Moment of Silence",
             "text": "Target player skips his or her combat phase this turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "f23bda86-82ee-5d8b-b412-7eb79b6dc390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eba9595-6789-4d7a-9e46-8d1f75993b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eba9595-6789-4d7a-9e46-8d1f75993b21.jpg?1",
             "name": "Moonlit Wake",
             "text": "Whenever a creature is put into a graveyard from play, you gain 1 life.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "e7702c38-b0fd-55f9-a510-fe63397e2a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3048ec-bcbf-4a69-b56f-83bbe82b68e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3048ec-bcbf-4a69-b56f-83bbe82b68e5.jpg?1",
             "name": "Muzzle",
             "text": "Prevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "756c3036-044f-5cdb-bda7-6a2d529111ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0968401d-522f-4def-92a1-d504471ac54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0968401d-522f-4def-92a1-d504471ac54e.jpg?1",
             "name": "Nightwind Glider",
             "text": "Flying, protection from black",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "860f70b6-8faf-5d01-8cb9-2fea2e465d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ff149-8516-456e-af8a-3dea78715acb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad5ff149-8516-456e-af8a-3dea78715acb.jpg?1",
             "name": "Noble Purpose",
             "text": "Whenever a creature you control deals combat damage, you gain that much life.",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "9cc1e02e-d8d3-5b16-90a4-05da8641e043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754ae359-363b-456a-bbca-52fbfbaa86b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/754ae359-363b-456a-bbca-52fbfbaa86b8.jpg?1",
             "name": "Orim's Cure",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying the mana cost of Orim's Cure.\nPrevent the next 4 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "ec803ebf-1403-5a13-9581-5dae806a340b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc20c1f0-9883-484c-88d8-1cab08d0b210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc20c1f0-9883-484c-88d8-1cab08d0b210.jpg?1",
             "name": "Pious Warrior",
             "text": "Whenever Pious Warrior is dealt combat damage, you gain that much life.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "f964f5f5-8100-5398-bd4a-eb153ab0d893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d2e2a-c608-4787-bbd9-e1871f681b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d2e2a-c608-4787-bbd9-e1871f681b58.jpg?1",
             "name": "Ramosian Captain",
             "text": "First strike\no5, oc\nT: Search your library for a Rebel card with converted mana cost 4 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "d60c0466-d164-5a36-88ef-f052e7e609b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867f5d82-71c2-455f-ab16-5a32bba46986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867f5d82-71c2-455f-ab16-5a32bba46986.jpg?1",
             "name": "Ramosian Commander",
             "text": "o6, oc\nT: Search your library for a Rebel card with converted mana cost 5 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "cde1cc99-8115-5868-867d-387a8bc86c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debe840a-ebc9-43c4-9bf7-7eb292b65bf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debe840a-ebc9-43c4-9bf7-7eb292b65bf9.jpg?1",
             "name": "Ramosian Lieutenant",
             "text": "o4, oc\nT: Search your library for a Rebel card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "7ee925dd-d36b-50be-b7fa-f4e683c26e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc0ff04-43e7-4a0d-b7e2-8bab72cc6cc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc0ff04-43e7-4a0d-b7e2-8bab72cc6cc0.jpg?1",
             "name": "Ramosian Rally",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying Ramosian Rally's mana cost.\nCreatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "a5f4f18a-7f24-5dd0-a558-2fee6d0ab76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2b036d-5721-4a6e-bf43-69148b90da10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2b036d-5721-4a6e-bf43-69148b90da10.jpg?1",
             "name": "Ramosian Sergeant",
             "text": "o3, oc\nT: Search your library for a Rebel card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "cf240ae5-4410-5bd5-a13d-f98fbb17e015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg?1",
             "name": "Ramosian Sky Marshal",
             "text": "Flying\no7, oc\nT: Search your library for a Rebel card with converted mana cost 6 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1360,7 +1360,7 @@
         },
         {
             "id": "53ef4efa-ed8d-5009-aee7-fab32310eb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113b8366-e6d0-423e-af4b-52c1e08ed446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113b8366-e6d0-423e-af4b-52c1e08ed446.jpg?1",
             "name": "Rappelling Scouts",
             "text": "Flying\no2oo\nW Rappelling Scouts gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "f4198239-6754-5db7-9229-4cc9e264151e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2bfb9-cc4a-4d33-99f9-17db4d9fc718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2bfb9-cc4a-4d33-99f9-17db4d9fc718.jpg?1",
             "name": "Renounce",
             "text": "Sacrifice any number of permanents. You gain 2 life for each one sacrificed this way.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "9141fc5f-48b8-523e-a027-fe7dd91b23fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0793175-e56b-4ff8-9e22-3a96a698068c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0793175-e56b-4ff8-9e22-3a96a698068c.jpg?1",
             "name": "Revered Elder",
             "text": "o1: Prevent the next 1 damage that would be dealt to Revered Elder this turn.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "430f9307-cd5e-5567-a118-35c4ae74a0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48364e19-a3ea-4980-925f-7918e57315f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48364e19-a3ea-4980-925f-7918e57315f1.jpg?1",
             "name": "Reverent Mantra",
             "text": "You may remove a white card in your hand from the game instead of paying Reverent Mantra's mana cost.\nAll creatures gain protection from the color of your choice until end of turn.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "c93b2785-10c8-54a8-8729-0e903269b0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d3bcb4-6cbd-4144-a95d-f61e68c10296.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d3bcb4-6cbd-4144-a95d-f61e68c10296.jpg?1",
             "name": "Righteous Aura",
             "text": "o\nW, Pay 2 life: The next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "41cfe630-38f0-56c6-b2ce-b1344d0cf5e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb6335-cfd8-438c-b936-09b850d61b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fb6335-cfd8-438c-b936-09b850d61b28.jpg?1",
             "name": "Righteous Indignation",
             "text": "Whenever a creature blocks a black or red creature, the blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "0433f382-d5dc-52de-aad0-f00cfff71e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b89d34b-1a67-4f5c-a731-54b56c5233ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b89d34b-1a67-4f5c-a731-54b56c5233ff.jpg?1",
             "name": "Security Detail",
             "text": "o\nWoo\nW Put a 1/1 white Soldier creature token into play. Play this ability only if you control no creatures and only once each turn.",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "6fd6d724-4647-52a6-a12d-9fb0f0a59281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b8f4be-9f4d-4373-8141-a03518ecd38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b8f4be-9f4d-4373-8141-a03518ecd38a.jpg?1",
             "name": "Soothing Balm",
             "text": "Target player gains 5 life.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "c90a4659-c536-5bbf-9036-29ff65556180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8521ae08-eb46-45ff-8fc4-62d8b07cfac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8521ae08-eb46-45ff-8fc4-62d8b07cfac2.jpg?1",
             "name": "Spiritual Focus",
             "text": "Whenever a spell or ability an opponent controls causes you to discard a card, you gain 2 life and you may draw a card.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "d3e6c48a-861a-5282-8a7f-efe8d89c824b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6381774b-fb91-46cc-9bf6-6eeb4d67a165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6381774b-fb91-46cc-9bf6-6eeb4d67a165.jpg?1",
             "name": "Steadfast Guard",
             "text": "Attacking doesn't cause Steadfast Guard to tap.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "0ca19244-8541-5832-8f16-c9b7bca32624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675378bb-7dc1-4bc8-b026-27e6e8e72e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675378bb-7dc1-4bc8-b026-27e6e8e72e18.jpg?1",
             "name": "Story Circle",
             "text": "As Story Circle comes into play, choose a color.\noo\nW The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "1a36b8c1-01e9-5913-953f-ac0316853c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a58c5b-28c2-4261-992c-2ecadb721880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a58c5b-28c2-4261-992c-2ecadb721880.jpg?1",
             "name": "Task Force",
             "text": "Whenever Task Force becomes the target of a spell or ability, it gets +0/+3 until end of turn.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "fd6d2580-e843-549d-966f-a9c9b5cfd371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd909c26-930d-4af0-b19a-c899847338b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd909c26-930d-4af0-b19a-c899847338b4.jpg?1",
             "name": "Thermal Glider",
             "text": "Flying, protection from red",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "00c6f15f-f4ae-5b10-82d2-611b94f29cf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bbd9d-3549-4352-9635-d772aab28503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334bbd9d-3549-4352-9635-d772aab28503.jpg?1",
             "name": "Tonic Peddler",
             "text": "o\nW, oc\nT, Discard a card from your hand: Target player gains 3 life.",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "22378f33-4956-528e-8fdc-2b065f72a292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba97681-1d1f-4ab6-a21b-fbbbe63a1c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eba97681-1d1f-4ab6-a21b-fbbbe63a1c74.jpg?1",
             "name": "Trap Runner",
             "text": "oc\nT: Target attacking unblocked creature becomes blocked. (This ability works on unblockable creatures.)",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "c3246af7-7c59-57d5-8f13-17995c4e72ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b101b5e-d478-4686-b3cf-bdc545f089e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b101b5e-d478-4686-b3cf-bdc545f089e5.jpg?1",
             "name": "Wave of Reckoning",
             "text": "Each creature deals to itself damage equal to its power.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "48a3d89e-65d9-50ef-a28c-89a063090145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0d8834-109e-4235-a145-75edc43da0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0d8834-109e-4235-a145-75edc43da0ec.jpg?1",
             "name": "Wishmonger",
             "text": "o2: Target creature gains protection from the color of its controller's choice until end of turn. Any player may play this ability.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "679720fe-21ad-5cdc-a30e-3c1594c04b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg?1",
             "name": "Aerial Caravan",
             "text": "Flying\no1o\nUo\nU: Remove the top card of your library from the game. Until end of turn, you may play that card as though it were in your hand. (Reveal the card as you remove it from the game.)",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "6d2bc0d8-6553-5fd3-96cd-d0935bb3ab87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34963e6-850e-4ce4-b04f-5e623ce5b73f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34963e6-850e-4ce4-b04f-5e623ce5b73f.jpg?1",
             "name": "Balloon Peddler",
             "text": "o\nU, oc\nT, Discard a card from your hand: Target creature gains flying until end of turn.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "b08249d9-f947-5733-8b42-e7ecbe6d57be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e483df-b58a-401e-85bc-0afda4bf7cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e483df-b58a-401e-85bc-0afda4bf7cac.jpg?1",
             "name": "Blockade Runner",
             "text": "oo\nU Blockade Runner is unblockable this turn.",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "2666c1d9-caa9-57b5-8d8d-86dc7d09bff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff71d13-c4b7-4125-ab10-db4abbb7a074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff71d13-c4b7-4125-ab10-db4abbb7a074.jpg?1",
             "name": "Brainstorm",
             "text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -2065,7 +2065,7 @@
         },
         {
             "id": "f65753cb-0578-5a4d-a230-ce4390a939d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc0ea8a-62f6-49e8-8eec-9748870bc596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc0ea8a-62f6-49e8-8eec-9748870bc596.jpg?1",
             "name": "Bribery",
             "text": "Search target opponent's library for a creature card and put that card into play under your control. That player then shuffles his or her library.",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "e9e7711b-f5a2-5da3-aa47-fe0d534bd112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b208dad2-a412-45fd-b19a-d370426ef5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b208dad2-a412-45fd-b19a-d370426ef5b8.jpg?1",
             "name": "Buoyancy",
             "text": "You may play Buoyancy any time you could play an instant.\nEnchanted creature has flying.",
             "colours": [
@@ -2131,7 +2131,7 @@
         },
         {
             "id": "c311ffd9-892d-5922-98a8-3200a621e37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860c613d-d031-4c2a-922b-39f4eec04e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860c613d-d031-4c2a-922b-39f4eec04e18.jpg?1",
             "name": "Chambered Nautilus",
             "text": "Whenever Chambered Nautilus becomes blocked, you may draw a card.",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "25d40aee-d74e-53e6-b8ff-166e46f76363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05972ea2-b0bc-40fd-bce4-07eebdb150d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05972ea2-b0bc-40fd-bce4-07eebdb150d5.jpg?1",
             "name": "Chameleon Spirit",
             "text": "As Chameleon Spirit comes into play, choose a color.\nChameleon Spirit's power and toughness are each equal to the number of permanents of the chosen color your opponents control.",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "c835ff99-7928-573a-b929-431c09a4dd36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63565b03-28e9-4534-b085-d5803e2623bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63565b03-28e9-4534-b085-d5803e2623bb.jpg?1",
             "name": "Charisma",
             "text": "Whenever enchanted creature deals damage to a creature, you control that creature as long as Charisma remains in play.",
             "colours": [
@@ -2235,7 +2235,7 @@
         },
         {
             "id": "d3c5da8f-496f-5031-8631-181716955f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14352c-ac8c-45b5-b930-63822408ba3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14352c-ac8c-45b5-b930-63822408ba3d.jpg?1",
             "name": "Cloud Sprite",
             "text": "Flying\nCloud Sprite may block only creatures with flying.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "d7849d12-af96-5f42-b550-ad02f63aa511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179d1f76-6f4c-4a77-815a-aae7a933c9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179d1f76-6f4c-4a77-815a-aae7a933c9ad.jpg?1",
             "name": "Coastal Piracy",
             "text": "Whenever a creature you control deals combat damage to an opponent, you may draw a card.",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "760c431b-d372-5165-8b41-f320286e0afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd03c80-7812-4704-9e07-9cf73b49c01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd03c80-7812-4704-9e07-9cf73b49c01f.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "65839450-3fb4-530a-90ca-5dda4d95b66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e46d3d-7c7f-487f-8cc6-078b17c113a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e46d3d-7c7f-487f-8cc6-078b17c113a0.jpg?1",
             "name": "Cowardice",
             "text": "Whenever a creature becomes the target of a spell or ability, return that creature to its owner's hand.",
             "colours": [
@@ -2365,7 +2365,7 @@
         },
         {
             "id": "6580d97a-15f6-501a-9541-d4821dac7c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067d8c46-c334-4b00-af06-2e28b6086c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067d8c46-c334-4b00-af06-2e28b6086c58.jpg?1",
             "name": "Customs Depot",
             "text": "Whenever you play a creature spell, you may pay o1. If you do, draw a card, then discard a card from your hand.",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "739d3f3c-c779-556c-849b-e8df9415ad11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438e15f7-59bb-4047-af1f-ef92cc1866b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438e15f7-59bb-4047-af1f-ef92cc1866b8.jpg?1",
             "name": "Darting Merfolk",
             "text": "oo\nU Return Darting Merfolk to its owner's hand.",
             "colours": [
@@ -2431,7 +2431,7 @@
         },
         {
             "id": "f0407b45-2b72-5ba1-aee3-4ebfa7fd994a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9e4043-e7a6-4c68-aa03-ef2f88e46451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9e4043-e7a6-4c68-aa03-ef2f88e46451.jpg?1",
             "name": "Dehydration",
             "text": "Enchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2465,7 +2465,7 @@
         },
         {
             "id": "a47dee60-889d-59fc-bb0b-4d4c8b2b799b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9356bdbb-d647-4f51-a7a3-18ecea898a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9356bdbb-d647-4f51-a7a3-18ecea898a7f.jpg?1",
             "name": "Diplomatic Escort",
             "text": "o\nU, oc\nT, Discard a card from your hand: Counter target spell or ability that targets a creature.",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "ca9491dc-1a42-5c70-971d-e1ec2031f85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1e610e-a4a2-460b-8e4c-13674badbce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1e610e-a4a2-460b-8e4c-13674badbce3.jpg?1",
             "name": "Diplomatic Immunity",
             "text": "Enchanted creature can't be the target of spells or abilities.\nDiplomatic Immunity can't be the target of spells or abilities.",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "3fa2d2f6-ec79-52a5-a376-20cbdd9d0b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee32f9-6120-4f15-a692-89a4cd8167c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee32f9-6120-4f15-a692-89a4cd8167c6.jpg?1",
             "name": "Drake Hatchling",
             "text": "Flying\noo\nU Drake Hatchling gets +1/+0 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "7d8cc2d8-437b-58c7-a731-dfc6228bd20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fca3c65-f20e-4978-bfbb-ee7f9e1d829f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fca3c65-f20e-4978-bfbb-ee7f9e1d829f.jpg?1",
             "name": "Embargo",
             "text": "Nonland permanents don't untap during their controllers' untap steps.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "9543ac13-9270-52d3-b201-fa9b320f7e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b22a0-d5cc-4dbb-aec3-763b8efaee7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b22a0-d5cc-4dbb-aec3-763b8efaee7e.jpg?1",
             "name": "Energy Flux",
             "text": "All artifacts gain \"At the beginning of your upkeep, sacrifice this artifact unless you pay o2.\"",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "16a5227e-419e-587f-a017-847db186ab24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99243564-9dbd-420c-922d-c17854c99d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99243564-9dbd-420c-922d-c17854c99d2a.jpg?1",
             "name": "Extravagant Spirit",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Extravagant Spirit unless you pay o1 for each card in your hand.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "722749fe-3809-5009-8769-c66b9ba003cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48872422-895f-45f0-ba2a-7cd307285c7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48872422-895f-45f0-ba2a-7cd307285c7d.jpg?1",
             "name": "False Demise",
             "text": "When enchanted creature is put into a graveyard, return that creature to play under your control.",
             "colours": [
@@ -2700,7 +2700,7 @@
         },
         {
             "id": "60b29eb7-8868-5546-8f5c-fc53241a4256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708593e6-787b-4f76-a86c-1d52857493ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708593e6-787b-4f76-a86c-1d52857493ea.jpg?1",
             "name": "Glowing Anemone",
             "text": "When Glowing Anemone comes into play, you may return target land to its owner's hand.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "2abd9f6e-0219-59e9-8fb6-737a88083650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e755bbef-bf34-49c0-ae72-d70e3599de52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e755bbef-bf34-49c0-ae72-d70e3599de52.jpg?1",
             "name": "Gush",
             "text": "You may return two islands you control to their owner's hand instead of paying Gush's mana cost.\nDraw two cards.",
             "colours": [
@@ -2767,7 +2767,7 @@
         },
         {
             "id": "31da8e0e-396c-5378-842a-c09c252587c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12eb6a6-14cc-4ad6-9684-ff33a39ba09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12eb6a6-14cc-4ad6-9684-ff33a39ba09f.jpg?1",
             "name": "High Seas",
             "text": "Red creature spells and green creature spells cost o1 more to play.",
             "colours": [
@@ -2799,7 +2799,7 @@
         },
         {
             "id": "34677c59-6422-5f46-ae3a-86fd6cfa4066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d505fbb-ec85-475b-a0e1-6670627ec017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d505fbb-ec85-475b-a0e1-6670627ec017.jpg?1",
             "name": "Hoodwink",
             "text": "Return target artifact, enchantment, or land to its owner's hand.",
             "colours": [
@@ -2831,7 +2831,7 @@
         },
         {
             "id": "ad3a80d0-aad5-5c91-89e3-8f9451cd4e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae62ce7-852b-42c6-9cbe-4807d8bf5740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae62ce7-852b-42c6-9cbe-4807d8bf5740.jpg?1",
             "name": "Indentured Djinn",
             "text": "Flying\nWhen Indentured Djinn comes into play, each other player may draw up to three cards.",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "303d6775-5155-5c13-bd48-060342c91d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07845861-f974-43b7-829c-79a4a41ac3e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07845861-f974-43b7-829c-79a4a41ac3e3.jpg?1",
             "name": "Karn's Touch",
             "text": "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost until end of turn. (It retains its abilities.)",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "2f62f355-5f33-5eb2-8322-3d3efa800568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ad59c-29e9-4498-a6fd-33bf21e8e7c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ad59c-29e9-4498-a6fd-33bf21e8e7c4.jpg?1",
             "name": "Misdirection",
             "text": "You may remove a blue card in your hand from the game instead of paying Misdirection's mana cost.\nTarget spell with a single target targets another target instead.",
             "colours": [
@@ -2929,7 +2929,7 @@
         },
         {
             "id": "c9660153-4777-587a-8f71-27b6c432048f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e23f5a1-bf3e-41e0-875f-fc2f8508e69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e23f5a1-bf3e-41e0-875f-fc2f8508e69f.jpg?1",
             "name": "Misstep",
             "text": "Creatures target player controls don't untap during that player's next untap step.",
             "colours": [
@@ -2961,7 +2961,7 @@
         },
         {
             "id": "9e33f708-f246-543b-950f-6704a0a25d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145903cb-9eaa-4f3c-a376-88dcd474ffda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145903cb-9eaa-4f3c-a376-88dcd474ffda.jpg?1",
             "name": "Overtaker",
             "text": "o3o\nU, oc\nT, Discard a card from your hand: Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "93fc4af6-0c43-5ea6-b859-d5705b106cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25d969-68d9-4580-bb29-f72bd5646a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef25d969-68d9-4580-bb29-f72bd5646a3d.jpg?1",
             "name": "Port Inspector",
             "text": "Whenever Port Inspector becomes blocked, you may look at defending player's hand.",
             "colours": [
@@ -3030,7 +3030,7 @@
         },
         {
             "id": "985af666-e535-5251-834d-73e5de8a3922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8e596b-f5ef-405a-8910-c5d0b5c8c0fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d8e596b-f5ef-405a-8910-c5d0b5c8c0fc.jpg?1",
             "name": "Rishadan Airship",
             "text": "Flying\nRishadan Airship may block only creatures with flying.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "dedbd6c4-1cd4-526b-8a42-0a6e441c1e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6efb653-97d8-4bc7-af8f-0b09fda655ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6efb653-97d8-4bc7-af8f-0b09fda655ff.jpg?1",
             "name": "Rishadan Brigand",
             "text": "Flying\nWhen Rishadan Brigand comes into play, each opponent sacrifices a permanent unless he or she pays o3.\nRishadan Brigand may block only creatures with flying.",
             "colours": [
@@ -3100,7 +3100,7 @@
         },
         {
             "id": "2f765215-8a97-53f2-ae46-38dd64438078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947fc270-11e3-46cd-9086-e880a5845c79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947fc270-11e3-46cd-9086-e880a5845c79.jpg?1",
             "name": "Rishadan Cutpurse",
             "text": "When Rishadan Cutpurse comes into play, each opponent sacrifices a permanent unless he or she pays o1.",
             "colours": [
@@ -3135,7 +3135,7 @@
         },
         {
             "id": "adbef0c3-52cc-5b1e-8953-9fb64cbfd4e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee964-1a44-46a1-8606-90e215805483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493ee964-1a44-46a1-8606-90e215805483.jpg?1",
             "name": "Rishadan Footpad",
             "text": "When Rishadan Footpad comes into play, each opponent sacrifices a permanent unless he or she pays o2.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "b4b88054-ea10-5dad-94ad-3c01d3dc9297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142479d8-8956-44a2-8c54-9dd6dc1774c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142479d8-8956-44a2-8c54-9dd6dc1774c0.jpg?1",
             "name": "Sailmonger",
             "text": "o2: Target creature gains flying until end of turn. Any player may play this ability.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "47165f3e-6087-5bcd-bc50-9adf5c0f8f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd7ce9-b920-409d-a4d2-a07fff280712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd7ce9-b920-409d-a4d2-a07fff280712.jpg?1",
             "name": "Sand Squid",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)\nYou may choose not to untap Sand Squid during your untap step.\noc\nT: Tap target creature. That creature does not untap during its controller's untap step as long as Sand Squid remains tapped.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "de2fdc6d-96dd-56a4-9f54-b83fec0da12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f50964-1b57-426a-ac46-c90c045c7e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f50964-1b57-426a-ac46-c90c045c7e40.jpg?1",
             "name": "Saprazzan Bailiff",
             "text": "When Saprazzan Bailiff comes into play, remove all artifact and enchantment cards in all graveyards from the game.\nWhen Saprazzan Bailiff leaves play, return all artifact and enchantment cards from all graveyards to their owners' hands.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "86f01e79-9f6d-51f8-bf91-753f9e2ef16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de7bf0f-5ad5-467b-ad80-28517951bbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de7bf0f-5ad5-467b-ad80-28517951bbe1.jpg?1",
             "name": "Saprazzan Breaker",
             "text": "oo\nU Put the top card of your library into your graveyard. If that card is a land card, Saprazzan Breaker is unblockable this turn.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "344d824d-d6f3-5437-a447-c31f24ed07c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg?1",
             "name": "Saprazzan Heir",
             "text": "Whenever Saprazzan Heir becomes blocked, you may draw three cards.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "cf8372f0-d928-57d8-994f-f6dcb5f56696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9adf84-ee7e-472b-bd96-9abf853afa83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9adf84-ee7e-472b-bd96-9abf853afa83.jpg?1",
             "name": "Saprazzan Legate",
             "text": "Flying\nIf an opponent controls a mountain and you control an island, you may play Saprazzan Legate without paying its mana cost.",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "d7622724-e9e8-5e5e-b074-7f40c4c49ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28048f1-4cf5-4389-9e69-9b5e1bc95396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28048f1-4cf5-4389-9e69-9b5e1bc95396.jpg?1",
             "name": "Saprazzan Outrigger",
             "text": "When Saprazzan Outrigger attacks or blocks, put it on top of its owner's library at end of combat.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "de062eaf-db22-5d86-b8fb-87871c14a449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62493f34-cea8-4d9f-8781-005947b69c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62493f34-cea8-4d9f-8781-005947b69c9d.jpg?1",
             "name": "Saprazzan Raider",
             "text": "When Saprazzan Raider becomes blocked, return it to its owner's hand.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "1ef27a43-79ab-569f-8902-cef99787d974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4787-9b29-4f57-b105-1f9eb4bb8861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4787-9b29-4f57-b105-1f9eb4bb8861.jpg?1",
             "name": "Shoving Match",
             "text": "Until end of turn, all creatures gain \"oc\nT: Tap target creature.\"",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "0890f001-c5eb-5730-bf6c-3d956f026a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def384ff-1b6f-4c4f-8151-3c72c29b63ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def384ff-1b6f-4c4f-8151-3c72c29b63ce.jpg?1",
             "name": "Soothsaying",
             "text": "o3o\nUoo\nU Shuffle your library.\noo\nX Look at the top X cards of your library and put them back in any order.",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "90b04539-38d2-5094-859d-fbbdfce300bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg?1",
             "name": "Squeeze",
             "text": "Sorcery spells cost o3 more to play.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "27726ce1-88c2-5a8c-a5a7-2eeb59e08bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dcd19e-8daf-4d53-946b-c07d5eca3cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dcd19e-8daf-4d53-946b-c07d5eca3cc9.jpg?1",
             "name": "Statecraft",
             "text": "Prevent all combat damage that would be dealt to and dealt by creatures you control.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "29c7ce28-96a6-56c6-b90a-12cf72b3efbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f7cd5-4e91-474a-9f60-a66f3f462b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7f7cd5-4e91-474a-9f60-a66f3f462b1c.jpg?1",
             "name": "Stinging Barrier",
             "text": "(Walls can't attack.)\no\nU, oc\nT: Stinging Barrier deals 1 damage to target creature or player.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "64cc2814-da4b-5fc4-aa46-9429b3215d29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12a0717-e9ea-4be3-a29f-179671ed4489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12a0717-e9ea-4be3-a29f-179671ed4489.jpg?1",
             "name": "Thwart",
             "text": "You may return three islands you control to their owner's hand instead of paying Thwart's mana cost.\nCounter target spell.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "4979d48e-69e5-5767-80fa-22c84b5c9f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68fd547-59fb-41e6-be55-1ec17fe2840b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68fd547-59fb-41e6-be55-1ec17fe2840b.jpg?1",
             "name": "Tidal Bore",
             "text": "You may return an island you control to its owner's hand instead of paying Tidal Bore's mana cost.\nTap or untap target creature.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "a3e7af11-07f1-5143-ba01-9da4ec11f2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356a9dcd-1a4b-4371-8f1d-aa7cb65e97e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356a9dcd-1a4b-4371-8f1d-aa7cb65e97e8.jpg?1",
             "name": "Tidal Kraken",
             "text": "Tidal Kraken is unblockable.",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "b66734fa-8d6b-545e-aa5b-927bf89256bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9212f685-d7af-4279-b17e-7201d8f63813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9212f685-d7af-4279-b17e-7201d8f63813.jpg?1",
             "name": "Timid Drake",
             "text": "Flying\nWhenever another creature comes into play, return Timid Drake to its owner's hand.",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "d8655418-ab9c-5a77-a4ea-a8f23f8e0155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaba189-b215-4d1c-9135-a86ce5ec955d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaba189-b215-4d1c-9135-a86ce5ec955d.jpg?1",
             "name": "Trade Routes",
             "text": "o1: Return target land you control to its owner's hand.\no1, Discard a land card from your hand: Draw a card.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "86fc6206-2118-5250-b6ca-b5ccf5d55e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c15159-8466-43e5-9dc5-a8cc94619931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c15159-8466-43e5-9dc5-a8cc94619931.jpg?1",
             "name": "War Tax",
             "text": "o\nXoo\nU Creatures can't attack this turn unless their controller pays o\nX for each attacking creature.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "ad3828cb-8f37-5a18-be9b-fcef8a965e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdce9e-94fa-4ed5-9b97-d2026cffe7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbdce9e-94fa-4ed5-9b97-d2026cffe7cb.jpg?1",
             "name": "Waterfront Bouncer",
             "text": "o\nU, oc\nT, Discard a card from your hand: Return target creature to its owner's hand.",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "0d0529d1-8ea3-5ec8-8a11-2abcd684ac91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb648e3-f5ad-4b33-afa3-d4cda0d369a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb648e3-f5ad-4b33-afa3-d4cda0d369a1.jpg?1",
             "name": "Alley Grifters",
             "text": "Whenever Alley Grifters becomes blocked, defending player discards a card from his or her hand.",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "5b4cf6bd-5be9-52e4-a842-d4d0be272a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05976e5c-b46c-431e-9dbd-1dc5fad3536c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05976e5c-b46c-431e-9dbd-1dc5fad3536c.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature is put into a graveyard from play, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add o\nB to your mana pool for each charge counter on Black Market.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "ef21a8d8-8c9e-54af-898c-8b870611fa80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2103a44-87e5-40cd-a0de-cd19456a8366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2103a44-87e5-40cd-a0de-cd19456a8366.jpg?1",
             "name": "Bog Smugglers",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "8f246b02-ca26-5fee-a483-af875baf0aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a926f9e-ee63-4b6e-8e5b-0650b74344a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a926f9e-ee63-4b6e-8e5b-0650b74344a5.jpg?1",
             "name": "Bog Witch",
             "text": "o\nB, oc\nT, Discard a card from your hand: Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "b0b04b78-8dd3-58ea-9e5c-08278373698b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec755ee-b4c0-47fd-9e61-9a3161766de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec755ee-b4c0-47fd-9e61-9a3161766de6.jpg?1",
             "name": "Cackling Witch",
             "text": "o\nXo\nB, oc\nT, Discard a card from your hand: Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "87ce062f-cc9b-5ef9-a382-53e380b8501f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6ce76-0ed0-4994-ae2c-d8e51ae09920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6ce76-0ed0-4994-ae2c-d8e51ae09920.jpg?1",
             "name": "Cateran Brute",
             "text": "o2, oc\nT: Search your library for a Mercenary card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "2e599de4-794f-5f1f-a94f-68c0998b28cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9b6da8-39da-4fce-89cf-ea972f981331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9b6da8-39da-4fce-89cf-ea972f981331.jpg?1",
             "name": "Cateran Enforcer",
             "text": "Cateran Enforcer can't be blocked except by artifact creatures and black creatures.\no4, oc\nT: Search your library for a Mercenary card with converted mana cost 4 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4080,7 +4080,7 @@
         },
         {
             "id": "2781fe11-19fe-58ce-bce3-531029d91d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768bdc1-4055-423a-a1cc-69b4c620e3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3768bdc1-4055-423a-a1cc-69b4c620e3e6.jpg?1",
             "name": "Cateran Kidnappers",
             "text": "o3, oc\nT: Search your library for a Mercenary card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4115,7 +4115,7 @@
         },
         {
             "id": "01a38117-53b8-5ac8-9b28-03953eab8b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg?1",
             "name": "Cateran Overlord",
             "text": "Sacrifice a creature: Regenerate Cateran Overlord.\no6, oc\nT: Search your library for a Mercenary card with converted mana cost 6 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "a7478f4c-1014-5438-9543-ffa3ddec81bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98bdbf1-32a6-4d9b-8e57-5d3aca6b05bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98bdbf1-32a6-4d9b-8e57-5d3aca6b05bc.jpg?1",
             "name": "Cateran Persuader",
             "text": "o1, oc\nT: Search your library for a Mercenary card with converted mana cost 1 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4185,7 +4185,7 @@
         },
         {
             "id": "ff5a7b50-6444-534b-84b9-108bf72dd583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg?1",
             "name": "Cateran Slaver",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)\no5, oc\nT: Search your library for a Mercenary card with converted mana cost 5 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4220,7 +4220,7 @@
         },
         {
             "id": "ed755125-190b-5361-a71b-e41da019eb16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3de1f9-9038-4352-b4bf-2e9c5c27495a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3de1f9-9038-4352-b4bf-2e9c5c27495a.jpg?1",
             "name": "Cateran Summons",
             "text": "Search your library for a Mercenary card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "3faf62d8-64b8-5fcd-8175-30c5dff72e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411c9f22-2df0-4a63-b2be-fa02612a6ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411c9f22-2df0-4a63-b2be-fa02612a6ef8.jpg?1",
             "name": "Conspiracy",
             "text": "As Conspiracy comes into play, choose a creature type.\nCreatures you control and creature cards in your graveyard, hand, and library are of the chosen type.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "5cfc4edf-737e-5465-b101-3d265bb783de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb652fc-5a21-4e02-a776-a38fb41ad18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb652fc-5a21-4e02-a776-a38fb41ad18c.jpg?1",
             "name": "Corrupt Official",
             "text": "o2oo\nB Regenerate Corrupt Official.\nWhenever Corrupt Official becomes blocked, defending player discards a card at random from his or her hand.",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "f737e62b-5a49-5b21-90be-09205f5231e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6aacc3e-fe37-4a08-83e6-7ee8c0c0af74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6aacc3e-fe37-4a08-83e6-7ee8c0c0af74.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "57c328a3-7313-5c7b-87b2-82101fb3b76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fff328-704e-462d-9613-82d05371f544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fff328-704e-462d-9613-82d05371f544.jpg?1",
             "name": "Deathgazer",
             "text": "Whenever Deathgazer blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "6e070061-0d93-515d-bf83-7b90b667ebaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd6685-37ca-47c7-8f64-1fb86e9610ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd6685-37ca-47c7-8f64-1fb86e9610ca.jpg?1",
             "name": "Deepwood Ghoul",
             "text": "Pay 2 life: Regenerate Deepwood Ghoul.",
             "colours": [
@@ -4419,7 +4419,7 @@
         },
         {
             "id": "00c4a226-ae9f-5d18-85cb-8690873508be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f01925-7fd0-472d-91a4-3309e615f22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f01925-7fd0-472d-91a4-3309e615f22f.jpg?1",
             "name": "Deepwood Legate",
             "text": "If an opponent controls a forest and you control a swamp, you may play Deepwood Legate without paying its mana cost.\noo\nB Deepwood Legate gets +1/+1 until end of turn.",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "322a6b45-298c-5f1f-a5b4-add14afb5d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da64094f-df6e-4c43-b4ae-03aab6b92816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da64094f-df6e-4c43-b4ae-03aab6b92816.jpg?1",
             "name": "Delraich",
             "text": "Trample\nYou may sacrifice three black creatures instead of paying Delraich's mana cost.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "ac13da9b-2ce6-527a-a9ba-d7efa5ebb90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffca723-360d-48de-a0a8-32288627f3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dffca723-360d-48de-a0a8-32288627f3df.jpg?1",
             "name": "Enslaved Horror",
             "text": "When Enslaved Horror comes into play, each other player may return a creature card from his or her graveyard to play.",
             "colours": [
@@ -4521,7 +4521,7 @@
         },
         {
             "id": "c6c31dcd-b647-5e17-b80c-a25c3017180e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66742db-4750-49ce-ad05-b825af7222c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66742db-4750-49ce-ad05-b825af7222c4.jpg?1",
             "name": "Extortion",
             "text": "Look at target player's hand and choose up to two cards from it. That player discards those cards.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "bad03c8a-5ffe-5dd0-b90c-9943ec794610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg?1",
             "name": "Forced March",
             "text": "Destroy all creatures with converted mana cost X or less.",
             "colours": [
@@ -4585,7 +4585,7 @@
         },
         {
             "id": "2daab5ad-d713-5932-9da0-d6cc667b488f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0054c1-6510-41dd-8695-9bf50296b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0054c1-6510-41dd-8695-9bf50296b615.jpg?1",
             "name": "Ghoul's Feast",
             "text": "Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4617,7 +4617,7 @@
         },
         {
             "id": "c27dfed6-6eeb-53bc-9b54-43ead6058322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c065cae-1ed5-445e-ace3-e81cf4c773de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c065cae-1ed5-445e-ace3-e81cf4c773de.jpg?1",
             "name": "Haunted Crossroads",
             "text": "oo\nB Put target creature card from your graveyard on top of your library.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "d9a5ca51-5800-5a93-b276-2b32929c23c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc826c88-fe3c-4004-8283-27910c550fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc826c88-fe3c-4004-8283-27910c550fae.jpg?1",
             "name": "Highway Robber",
             "text": "When Highway Robber comes into play, you gain 2 life and target opponent loses 2 life.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "61f4343a-fc09-549d-9e38-e0c7607037d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f57af-17d4-4a4c-ae46-fe37f97466fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f57af-17d4-4a4c-ae46-fe37f97466fa.jpg?1",
             "name": "Instigator",
             "text": "o1o\nBo\nB, oc\nT, Discard a card from your hand: Creatures target player controls attack this turn if able.",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "bb23960c-30aa-54f1-94a2-e4516bf1912e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2544c9d-adc2-4d67-8850-9af38e73ea1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2544c9d-adc2-4d67-8850-9af38e73ea1e.jpg?1",
             "name": "Insubordination",
             "text": "At the end of the turn of enchanted creature's controller, Insubordination deals 2 damage to that player unless enchanted creature attacked this turn.",
             "colours": [
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "62ccd550-33c7-58b0-8443-30efa3109c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e1724-91cf-422e-909b-ddb69a6f9f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e1724-91cf-422e-909b-ddb69a6f9f76.jpg?1",
             "name": "Intimidation",
             "text": "Creatures you control can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "2a3c83c6-1bdd-58ec-84e0-020dfff94ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a863da2-0639-4eed-8da9-2e9a38c04a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a863da2-0639-4eed-8da9-2e9a38c04a23.jpg?1",
             "name": "Larceny",
             "text": "Whenever a creature you control deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "69976122-4fa6-5075-a4d4-ae9da4f70a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b07c66d-5f37-4098-b7e6-03e6c684806b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b07c66d-5f37-4098-b7e6-03e6c684806b.jpg?1",
             "name": "Liability",
             "text": "Whenever a card is put into a player's graveyard from play, that player loses 1 life.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "1dfe8a4b-210c-587d-94eb-3b92dcde075c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab963aa-2304-4ee6-a8c7-c485c5133b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab963aa-2304-4ee6-a8c7-c485c5133b40.jpg?1",
             "name": "Maggot Therapy",
             "text": "You may play Maggot Therapy any time you could play an instant.\nEnchanted creature gets +2/-2.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "4484512f-e3eb-59d6-b6d9-fe6d4c6b6d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e98c4f7-b0f4-48c6-b502-3dc5802d827f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e98c4f7-b0f4-48c6-b502-3dc5802d827f.jpg?1",
             "name": "Midnight Ritual",
             "text": "Remove X target creature cards in your graveyard from the game. For each creature card removed this way, put a black 2/2 Zombie creature token into play.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "44f8d84e-3d80-50f1-8f8f-52d68ce2fc45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43cf59e-7583-4651-968a-2a7201c69b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a43cf59e-7583-4651-968a-2a7201c69b6b.jpg?1",
             "name": "Misshapen Fiend",
             "text": "Flying",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "2e6f6e95-e7ee-5463-b34c-29e4f24920f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfe33fb-71d5-4552-bcd3-f07e4e3847e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfe33fb-71d5-4552-bcd3-f07e4e3847e1.jpg?1",
             "name": "Molting Harpy",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Molting Harpy unless you pay o2.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "9243a691-4abd-5800-bd35-c8fb96582445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220217c5-408c-40df-8133-da16b13d4f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220217c5-408c-40df-8133-da16b13d4f21.jpg?1",
             "name": "Nether Spirit",
             "text": "At the beginning of your upkeep, if Nether Spirit is the only creature card in your graveyard, you may return Nether Spirit to play.",
             "colours": [
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "72309364-4efa-51dc-934e-e0204cb08bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg?1",
             "name": "Notorious Assassin",
             "text": "o2o\nB, oc\nT, Discard a card from your hand: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "ba2e6a3a-f1e6-5abc-8770-666ef9ba57ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc29dab-9211-46bc-a98c-a5dbd5b0980a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc29dab-9211-46bc-a98c-a5dbd5b0980a.jpg?1",
             "name": "Pretender's Claim",
             "text": "Whenever enchanted creature becomes blocked, tap all lands defending player controls.",
             "colours": [
@@ -5089,7 +5089,7 @@
         },
         {
             "id": "86b560de-c038-5196-974f-a9c3d45e097c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6ed1fb-2f7d-4a21-bbf3-660cad631975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6ed1fb-2f7d-4a21-bbf3-660cad631975.jpg?1",
             "name": "Primeval Shambler",
             "text": "oo\nB Primeval Shambler gets +1/+1 until end of turn.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "3999433b-12c1-59c5-81c5-322469107871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65104b23-58a6-41c0-b887-90a3fb959289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65104b23-58a6-41c0-b887-90a3fb959289.jpg?1",
             "name": "Putrefaction",
             "text": "Whenever a player plays a white spell or green spell, that player discards a card from his or her hand.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "e8f69916-a34f-52e9-9009-0d6f329ef4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c91c44e-6bfc-4595-9cdb-17d73f912c09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c91c44e-6bfc-4595-9cdb-17d73f912c09.jpg?1",
             "name": "Quagmire Lamprey",
             "text": "Whenever Quagmire Lamprey becomes blocked by a creature, put a -1/-1 counter on that creature.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "a73fd9dd-f197-54a9-92ce-5efe648d1e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bffa7f-919c-4c9b-9fdc-dde8204c61c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bffa7f-919c-4c9b-9fdc-dde8204c61c2.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy target land.",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "5d336df5-3421-5f46-93d5-b489ad100d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b60f86f-c78a-4dfb-bb18-e9bcf21b26c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b60f86f-c78a-4dfb-bb18-e9bcf21b26c4.jpg?1",
             "name": "Rampart Crawler",
             "text": "Rampart Crawler can't be blocked by Walls.",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "675b6d28-075b-5464-a341-23050f9a00d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad01a8e2-5dc5-49a3-ad1c-7d5bf006b774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad01a8e2-5dc5-49a3-ad1c-7d5bf006b774.jpg?1",
             "name": "Rouse",
             "text": "If you control a swamp, you may pay 2 life instead of paying Rouse's mana cost.\nTarget creature gets +2/+0 until end of turn.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "95d05fe7-91ee-547f-9469-296c92b04a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c97baa-9bc0-4894-867c-ad1f56c469fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c97baa-9bc0-4894-867c-ad1f56c469fd.jpg?1",
             "name": "Scandalmonger",
             "text": "o2: Target player discards a card from his or her hand. Any player may play this ability but only if he or she could play a sorcery.",
             "colours": [
@@ -5324,7 +5324,7 @@
         },
         {
             "id": "8f9979bb-c94c-589c-8fd3-559e1fad8a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d84fec-18f1-4231-a293-0dc1ff868a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d84fec-18f1-4231-a293-0dc1ff868a40.jpg?1",
             "name": "Sever Soul",
             "text": "Destroy target nonblack creature. It can't be regenerated. You gain life equal to its toughness.",
             "colours": [
@@ -5356,7 +5356,7 @@
         },
         {
             "id": "b622a8f5-bc65-5f34-a404-375597d5ec48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba34034a-1150-41c8-a340-543f529ae07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba34034a-1150-41c8-a340-543f529ae07f.jpg?1",
             "name": "Silent Assassin",
             "text": "o3o\nB: Destroy target blocking creature at end of combat.",
             "colours": [
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "d2781aea-7da9-5495-a28f-8cbb7fef94cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175ed19c-9635-45ee-bb2c-32b96270a246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175ed19c-9635-45ee-bb2c-32b96270a246.jpg?1",
             "name": "Skulking Fugitive",
             "text": "When Skulking Fugitive becomes the target of a spell or ability, sacrifice Skulking Fugitive.",
             "colours": [
@@ -5427,7 +5427,7 @@
         },
         {
             "id": "764063c5-cc64-5174-9c8e-719ac46de9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a3cca1-e50e-49b6-9e1a-f86640e3b177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a3cca1-e50e-49b6-9e1a-f86640e3b177.jpg?1",
             "name": "Snuff Out",
             "text": "If you control a swamp, you may pay 4 life instead of paying Snuff Out's mana cost.\nDestroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5459,7 +5459,7 @@
         },
         {
             "id": "4d3d7a36-5153-5a61-905f-394b605e6640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cd09ef-1655-4a62-b6c5-6eda33d2607a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cd09ef-1655-4a62-b6c5-6eda33d2607a.jpg?1",
             "name": "Soul Channeling",
             "text": "Pay 2 life: Regenerate enchanted creature.",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "42772e50-5923-545e-aeee-8eaa49be0563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1637b62-e364-4250-aad5-841c6a47a11e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1637b62-e364-4250-aad5-841c6a47a11e.jpg?1",
             "name": "Specter's Wail",
             "text": "Target player discards a card at random from his or her hand.",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "67d8c6c0-19f5-523f-a9f7-d4b1949da999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aa9108-470c-484d-908a-c31cf6935765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20aa9108-470c-484d-908a-c31cf6935765.jpg?1",
             "name": "Strongarm Thug",
             "text": "When Strongarm Thug comes into play, you may return a Mercenary card from your graveyard to your hand.",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "43b41ca4-bd9d-5bc6-854f-a28b64de5095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg?1",
             "name": "Thrashing Wumpus",
             "text": "oo\nB Thrashing Wumpus deals 1 damage to each creature and each player.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "7c80a2c0-5062-5062-af37-86e602cd97f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615f531-e8af-4f7b-a4ea-fb962149093f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f615f531-e8af-4f7b-a4ea-fb962149093f.jpg?1",
             "name": "Undertaker",
             "text": "o\nB, oc\nT, Discard a card from your hand: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5629,7 +5629,7 @@
         },
         {
             "id": "1614f689-9077-5673-b722-a230dd049576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db7a0e6-eea5-4fa6-ac14-401411b106cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2db7a0e6-eea5-4fa6-ac14-401411b106cc.jpg?1",
             "name": "Unmask",
             "text": "You may remove a black card in your hand from the game instead of paying Unmask's mana cost.\nLook at target player's hand and choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -5661,7 +5661,7 @@
         },
         {
             "id": "dcbd58db-4ebb-5348-ab47-c29a93956c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985f240-4289-4d48-978c-bb2ce2b54c36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3985f240-4289-4d48-978c-bb2ce2b54c36.jpg?1",
             "name": "Unnatural Hunger",
             "text": "At the beginning of the upkeep of enchanted creature's controller, Unnatural Hunger deals to that player damage equal to enchanted creature's power unless he or she sacrifices another creature.",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "14ef995f-14fe-5dba-b401-805a1eefd941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced38e-0f33-4bda-8e18-09f6ac03a3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ced38e-0f33-4bda-8e18-09f6ac03a3d7.jpg?1",
             "name": "Vendetta",
             "text": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
             "colours": [
@@ -5727,7 +5727,7 @@
         },
         {
             "id": "60e865be-7b26-54f7-8aa7-0f7edc57131a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b2d07a-9ea1-430d-b432-ae507f4fe73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b2d07a-9ea1-430d-b432-ae507f4fe73b.jpg?1",
             "name": "Wall of Distortion",
             "text": "(Walls can't attack.)\no2o\nB, oc\nT: Target player discards a card from his or her hand. Play this ability only if you could play a sorcery.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "ea97f39e-daec-5dcf-b324-833c8dd024a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafea45d-be00-428d-a127-70e6a14efe3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafea45d-be00-428d-a127-70e6a14efe3f.jpg?1",
             "name": "Arms Dealer",
             "text": "o1o\nR, Sacrifice a Goblin: Arms Dealer deals 4 damage to target creature.",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "b3537580-34b2-5fa0-980f-24a41b9d179d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27f6658-0f00-4934-8d12-cd0dda3958c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27f6658-0f00-4934-8d12-cd0dda3958c9.jpg?1",
             "name": "Battle Rampart",
             "text": "(Walls can't attack.)\noc\nT: Target creature gains haste until end of turn. (That creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -5830,7 +5830,7 @@
         },
         {
             "id": "e3ef1a41-318e-5e2f-9062-cdcb096dd68f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg?1",
             "name": "Battle Squadron",
             "text": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "96de848f-f68d-5984-acd6-f09fbb091f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b0fd1-bbb2-47c0-a4c3-4129a67473b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801b0fd1-bbb2-47c0-a4c3-4129a67473b9.jpg?1",
             "name": "Blaster Mage",
             "text": "o\nR, oc\nT, Discard a card from your hand: Destroy target Wall.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "842ffd5c-1df2-58d8-a5de-56e83ee5c3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa1e796-809c-49af-a84e-ec088f7f48f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa1e796-809c-49af-a84e-ec088f7f48f8.jpg?1",
             "name": "Blood Hound",
             "text": "Whenever you're dealt damage, you may put that many +1/+1 counters on Blood Hound.\nAt the end of your turn, remove all +1/+1 counters from Blood Hound.",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "2f85c9d2-1721-5070-8cff-ba782453ea22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1556a12-ff45-4a12-988a-63615b3799a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1556a12-ff45-4a12-988a-63615b3799a9.jpg?1",
             "name": "Blood Oath",
             "text": "Choose a card type. Target opponent reveals his or her hand. Blood Oath deals 3 damage to that player for each card of the chosen type revealed this way. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -5965,7 +5965,7 @@
         },
         {
             "id": "2aaaef87-72e0-586b-9245-3f70fccedd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4e783c-0717-4127-bd7b-885ca617ca29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f4e783c-0717-4127-bd7b-885ca617ca29.jpg?1",
             "name": "Brawl",
             "text": "Until end of turn, all creatures gain \"oc\nT: This creature deals damage equal to its power to target creature.\"",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "aed071b1-5078-512c-8524-7725f27a1353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d718421-c742-489c-a243-3adb19f6716a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d718421-c742-489c-a243-3adb19f6716a.jpg?1",
             "name": "Cave Sense",
             "text": "Enchanted creature gets +1/+1 and has mountainwalk. (It's unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "93e657e5-4c4c-5aa1-addf-fafc09d646e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d9d26-f304-467d-af79-914cc65f082e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440d9d26-f304-467d-af79-914cc65f082e.jpg?1",
             "name": "Cave-In",
             "text": "You may remove a red card in your hand from the game instead of paying Cave-In's mana cost.\nCave-In deals 2 damage to each creature and each player.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "f4eb2aa0-1d1e-5f70-977c-f249661884ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a8af9-2e86-4639-a6c9-209f115e95f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a8af9-2e86-4639-a6c9-209f115e95f8.jpg?1",
             "name": "Cavern Crawler",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)\noo\nR Cavern Crawler gets +1/-1 until end of turn.",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "90737596-1f65-5666-a118-51cb611e29b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c69d1-5295-419f-bb8f-af826bf92cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6c69d1-5295-419f-bb8f-af826bf92cb3.jpg?1",
             "name": "Ceremonial Guard",
             "text": "When Ceremonial Guard attacks or blocks, destroy it at end of combat.",
             "colours": [
@@ -6132,7 +6132,7 @@
         },
         {
             "id": "82cbb80b-862e-5394-ad0c-c54e09ce8810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg?1",
             "name": "Cinder Elemental",
             "text": "o\nXo\nR, oc\nT, Sacrifice Cinder Elemental: Cinder Elemental deals X damage to target creature or player.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "eff21e5d-75c5-5ac9-9c44-ef7cbc617be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9131c7-4e46-4c01-80b3-a6b055439346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9131c7-4e46-4c01-80b3-a6b055439346.jpg?1",
             "name": "Close Quarters",
             "text": "Whenever a creature you control becomes blocked, Close Quarters deals 1 damage to target creature or player.",
             "colours": [
@@ -6198,7 +6198,7 @@
         },
         {
             "id": "6db6621d-abf0-57b1-89ae-3b0baaf8dfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0907a5-938e-4ef4-aa85-e7c1ae4317a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f0907a5-938e-4ef4-aa85-e7c1ae4317a6.jpg?1",
             "name": "Crag Saurian",
             "text": "Whenever Crag Saurian is dealt damage, the controller of that damage's source gains control of Crag Saurian.",
             "colours": [
@@ -6232,7 +6232,7 @@
         },
         {
             "id": "0224c6e4-2e80-5764-82d3-c3e0cae6defd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a26bde3-8392-4476-b347-f223d52554a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a26bde3-8392-4476-b347-f223d52554a6.jpg?1",
             "name": "Crash",
             "text": "You may sacrifice a mountain instead of paying Crash's mana cost.\nDestroy target artifact.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "2645d487-3741-54ab-8afa-8d82aa70fd50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eee8c2e-bda7-4bf9-80fe-87d96024ca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eee8c2e-bda7-4bf9-80fe-87d96024ca8b.jpg?1",
             "name": "Flailing Manticore",
             "text": "Flying, first strike\no1: Flailing Manticore gets +1/+1 until end of turn. Any player may play this ability.\no1: Flailing Manticore gets -1/-1 until end of turn. Any player may play this ability.",
             "colours": [
@@ -6298,7 +6298,7 @@
         },
         {
             "id": "0b5aed27-3cb5-530a-adef-fec7d81018ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e520-b2b8-4c13-a4ea-f8810c927bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400e520-b2b8-4c13-a4ea-f8810c927bf7.jpg?1",
             "name": "Flailing Ogre",
             "text": "o1: Flailing Ogre gets +1/+1 until end of turn. Any player may play this ability.\no1: Flailing Ogre gets -1/-1 until end of turn. Any player may play this ability.",
             "colours": [
@@ -6332,7 +6332,7 @@
         },
         {
             "id": "a27f8a1e-cb17-543c-a769-73288eb0287e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb44b0f6-0608-40d6-9eaa-48e5a834701f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb44b0f6-0608-40d6-9eaa-48e5a834701f.jpg?1",
             "name": "Flailing Soldier",
             "text": "o1: Flailing Soldier gets +1/+1 until end of turn. Any player may play this ability.\no1: Flailing Soldier gets -1/-1 until end of turn. Any player may play this ability.",
             "colours": [
@@ -6367,7 +6367,7 @@
         },
         {
             "id": "005b1161-73b7-5175-96f1-0cd580d10a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ecd9ff-8c30-4e17-8cff-dd40d653c4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ecd9ff-8c30-4e17-8cff-dd40d653c4af.jpg?1",
             "name": "Flaming Sword",
             "text": "You may play Flaming Sword any time you could play an instant.\nTarget creature gets +1/+0 and has first strike.",
             "colours": [
@@ -6401,7 +6401,7 @@
         },
         {
             "id": "82839c70-473f-59c2-9c14-233dfc18dbbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a07fae-0f34-45e7-b22d-97eea9031022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a07fae-0f34-45e7-b22d-97eea9031022.jpg?1",
             "name": "Furious Assault",
             "text": "Whenever you play a creature spell, Furious Assault deals 1 damage to target player.",
             "colours": [
@@ -6433,7 +6433,7 @@
         },
         {
             "id": "4c2f8959-64ab-55aa-81d0-67fa656e9d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a88f507-3d78-4f7f-a91f-8489ad9250f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a88f507-3d78-4f7f-a91f-8489ad9250f2.jpg?1",
             "name": "Gerrard's Irregulars",
             "text": "Trample; haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6468,7 +6468,7 @@
         },
         {
             "id": "737f3dff-b4ab-51c2-89f9-4574fc363655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b959d7ad-a78e-439f-9225-4dbb89f490d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b959d7ad-a78e-439f-9225-4dbb89f490d7.jpg?1",
             "name": "Hammer Mage",
             "text": "o\nXo\nR, oc\nT, Discard a card from your hand: Destroy all artifacts with converted mana cost X or less.",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "db2bed1d-ec67-5070-80b4-866b9ac8f768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc33920a-f05c-46fa-b94b-278af0022b78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc33920a-f05c-46fa-b94b-278af0022b78.jpg?1",
             "name": "Hired Giant",
             "text": "When Hired Giant comes into play, each other player may search his or her library for a land card, put that card into play, then shuffle that library.",
             "colours": [
@@ -6537,7 +6537,7 @@
         },
         {
             "id": "1273f802-49a6-520d-ab6a-7c686a83174d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4389fbcd-182a-4cac-b14f-aa971948cf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4389fbcd-182a-4cac-b14f-aa971948cf8e.jpg?1",
             "name": "Kris Mage",
             "text": "o\nR, oc\nT, Discard a card from your hand: Kris Mage deals 1 damage to target creature or player.",
             "colours": [
@@ -6572,7 +6572,7 @@
         },
         {
             "id": "3df8ff78-b4bc-5288-9c27-774f36939e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc55e01-342e-4856-937e-14561b8d165b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc55e01-342e-4856-937e-14561b8d165b.jpg?1",
             "name": "Kyren Glider",
             "text": "Flying\nKyren Glider can't block.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "79821431-efca-54c8-885e-30cb57845a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0e9806-be8c-4b88-a4be-0111d1be81d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0e9806-be8c-4b88-a4be-0111d1be81d9.jpg?1",
             "name": "Kyren Legate",
             "text": "If an opponent controls a plains and you control a mountain, you may play Kyren Legate without paying its mana cost.\nHaste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "5fcafc4d-c4f2-5702-af2c-096e23612c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c263a17-bbc2-433e-93f8-72e57b818322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c263a17-bbc2-433e-93f8-72e57b818322.jpg?1",
             "name": "Kyren Negotiations",
             "text": "Tap an untapped creature you control: Kyren Negotiations deals 1 damage to target player.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "50f1a066-c694-5a14-8bfc-f769ffa3dd5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df99e19-0b1e-48ec-a146-38cf147eab61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df99e19-0b1e-48ec-a146-38cf147eab61.jpg?1",
             "name": "Kyren Sniper",
             "text": "At the beginning of your upkeep, you may have Kyren Sniper deal 1 damage to target player.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "756d620f-461c-5e44-8fbb-bb1b9cbb1f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d0fbe6-6ce1-4b95-afb7-a7386b5033cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d0fbe6-6ce1-4b95-afb7-a7386b5033cf.jpg?1",
             "name": "Lava Runner",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhenever Lava Runner becomes the target of a spell or ability, that spell or ability's controller sacrifices a land.",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "b1729cf2-9858-5dfa-86f0-659f88908d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c82a1d-5db1-4090-b446-cc5bc6dc811d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c82a1d-5db1-4090-b446-cc5bc6dc811d.jpg?1",
             "name": "Lightning Hounds",
             "text": "First strike",
             "colours": [
@@ -6774,7 +6774,7 @@
         },
         {
             "id": "fd51cac8-96b3-58a1-bceb-314c94869b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee0f17-de64-4abb-afad-4005275f1a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee0f17-de64-4abb-afad-4005275f1a3c.jpg?1",
             "name": "Lithophage",
             "text": "At the beginning of your upkeep, sacrifice Lithophage unless you sacrifice a mountain.",
             "colours": [
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "e1b656ad-a6c2-5907-bbd7-dcbee83f1591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e43349-429c-43f7-b808-c4bf37370a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9e43349-429c-43f7-b808-c4bf37370a9f.jpg?1",
             "name": "Lunge",
             "text": "Lunge deals 2 damage to target creature and 2 damage to target player.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "1fcf704e-d9f7-5fff-bb09-a59b4b9ee9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f83d39e-bf49-4968-829e-c0e9abf2fb86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f83d39e-bf49-4968-829e-c0e9abf2fb86.jpg?1",
             "name": "Magistrate's Veto",
             "text": "White creatures and blue creatures can't block.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "cfd17e89-e40a-5268-9276-f158163253f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14507fe6-80a9-4ed4-bf3e-4656f3d377c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14507fe6-80a9-4ed4-bf3e-4656f3d377c0.jpg?1",
             "name": "Mercadia's Downfall",
             "text": "Attacking creatures get +X/+0 until end of turn, where X is the number of nonbasic lands defending player controls.",
             "colours": [
@@ -6904,7 +6904,7 @@
         },
         {
             "id": "6ee67c75-4024-5735-9524-839d178baf02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d6c28-6468-4bde-9738-eb51594fa7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186d6c28-6468-4bde-9738-eb51594fa7c1.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "e942dae0-9355-5bd5-aea6-c226f2d5c44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbc44d-60fb-45fc-a588-14aab0340134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afbbc44d-60fb-45fc-a588-14aab0340134.jpg?1",
             "name": "Pulverize",
             "text": "You may sacrifice two mountains instead of paying Pulverize's mana cost.\nDestroy all artifacts.",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "70215b2a-8dc5-5ea8-8057-7f9dd6f2b1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052b743a-456d-49c3-881e-4f30c7645fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052b743a-456d-49c3-881e-4f30c7645fa5.jpg?1",
             "name": "Puppet's Verdict",
             "text": "Flip a coin. If you win the flip, destroy all creatures with power 2 or less. If you lose the flip, destroy all creatures with power 3 or greater.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "03baff19-c451-5287-8b6f-ad9a1f02d91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5cf073-2ba0-463e-bcd4-979ad18e28fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5cf073-2ba0-463e-bcd4-979ad18e28fc.jpg?1",
             "name": "Robber Fly",
             "text": "Flying\nWhenever Robber Fly becomes blocked, defending player discards his or her hand, then draws that many cards.",
             "colours": [
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "415b8716-dee1-5647-9b54-5bbb64af4e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff05df8-76f5-48c6-ac96-7b4e6a7050f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff05df8-76f5-48c6-ac96-7b4e6a7050f6.jpg?1",
             "name": "Rock Badger",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)",
             "colours": [
@@ -7071,7 +7071,7 @@
         },
         {
             "id": "0eb838f3-390f-5bb1-a2b9-cfb7dd2d25bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg?1",
             "name": "Seismic Mage",
             "text": "o2o\nR, oc\nT, Discard a card from your hand: Destroy target land.",
             "colours": [
@@ -7106,7 +7106,7 @@
         },
         {
             "id": "6082ec5f-c682-52cf-ba84-daeac2e227b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a918ca-3e60-46de-9f29-56bdc6430a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a918ca-3e60-46de-9f29-56bdc6430a77.jpg?1",
             "name": "Shock Troops",
             "text": "Sacrifice Shock Troops: Shock Troops deals 2 damage to target creature or player.",
             "colours": [
@@ -7141,7 +7141,7 @@
         },
         {
             "id": "344ead1c-4052-5b6a-9cab-a3b40b8b0a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca1eee-d97d-48c6-84f1-7d1f972c3ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ca1eee-d97d-48c6-84f1-7d1f972c3ca9.jpg?1",
             "name": "Sizzle",
             "text": "Sizzle deals 3 damage to each opponent.",
             "colours": [
@@ -7173,7 +7173,7 @@
         },
         {
             "id": "9c1b266a-0485-570b-be1e-9b961ed5f225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8325a-1203-4125-9111-94d9e2b1f14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba8325a-1203-4125-9111-94d9e2b1f14b.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, if Squee, Goblin Nabob is in your graveyard, you may return Squee to your hand.",
             "colours": [
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "4c567124-63d1-51eb-91f4-52e8b00548c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7ded-9249-42c8-bb17-4c6b8cd2a9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29cd7ded-9249-42c8-bb17-4c6b8cd2a9cc.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "d2355933-e5e1-51d7-82d9-78c9cbdc2abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0ee5d-10f6-4152-8416-1f2b749b439d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0ee5d-10f6-4152-8416-1f2b749b439d.jpg?1",
             "name": "Tectonic Break",
             "text": "Each player sacrifices X lands.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "45ae73db-6930-55a0-a56d-c4a0c11cf741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa8a13a-f09f-4b10-8fab-3ea4fdc643d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa8a13a-f09f-4b10-8fab-3ea4fdc643d1.jpg?1",
             "name": "Territorial Dispute",
             "text": "Players can't play lands.\nAt the beginning of your upkeep, sacrifice Territorial Dispute unless you sacrifice a land.",
             "colours": [
@@ -7305,7 +7305,7 @@
         },
         {
             "id": "19f96e81-4af0-5b3a-88b2-3f9dee2d9378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5708c87-108d-4ba1-a1e9-e83cb9b16b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5708c87-108d-4ba1-a1e9-e83cb9b16b6c.jpg?1",
             "name": "Thieves' Auction",
             "text": "Set aside all permanents. You choose one of those cards and put it into play tapped under your control. Then your opponent chooses one and puts it into play tapped under his or her control. Repeat this process until all cards set aside this way have been chosen. (Local enchantments with no permanent to enchant remain removed from the game.)",
             "colours": [
@@ -7337,7 +7337,7 @@
         },
         {
             "id": "2b09dee3-dfd4-5ad8-912d-857722db4b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f8c5ee-2179-4c05-adc9-0b66d02b59ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f8c5ee-2179-4c05-adc9-0b66d02b59ad.jpg?1",
             "name": "Thunderclap",
             "text": "You may sacrifice a mountain instead of paying Thunderclap's mana cost.\nThunderclap deals 3 damage to target creature.",
             "colours": [
@@ -7369,7 +7369,7 @@
         },
         {
             "id": "47111681-dba4-57dc-86b4-5a3b5cbf0553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8531efb1-d77d-451a-8621-424fc278ccf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8531efb1-d77d-451a-8621-424fc278ccf9.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "c679a52d-ab94-554c-9b2b-125ba3c414bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fed2c7-c922-41c3-b86b-a8ed41a1308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fed2c7-c922-41c3-b86b-a8ed41a1308d.jpg?1",
             "name": "Two-Headed Dragon",
             "text": "Flying\no1oo\nR Two-Headed Dragon gets +2/+0 until end of turn.\nTwo-Headed Dragon can't be blocked except by two or more creatures. It may block one additional creature. (All blocks must be legal.)",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "6f830d61-7a67-51a9-b1cc-3a37e89a2a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa3455-3ba0-41ad-aefd-40f183aed2a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa3455-3ba0-41ad-aefd-40f183aed2a6.jpg?1",
             "name": "Uphill Battle",
             "text": "Creatures your opponents play come into play tapped.",
             "colours": [
@@ -7467,7 +7467,7 @@
         },
         {
             "id": "cfdc365f-aa18-5955-a15a-7d9557e81c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c69dd00-46ce-42b2-a2ed-43b4cf04a975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c69dd00-46ce-42b2-a2ed-43b4cf04a975.jpg?1",
             "name": "Volcanic Wind",
             "text": "Volcanic Wind deals X damage divided as you choose among any number of target creatures, where X is the number of creatures in play.",
             "colours": [
@@ -7499,7 +7499,7 @@
         },
         {
             "id": "040b26e4-944a-5818-ad03-326ddb446328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e030d2eb-70c5-4ff7-8f03-ad5495cf9c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e030d2eb-70c5-4ff7-8f03-ad5495cf9c69.jpg?1",
             "name": "War Cadence",
             "text": "o\nXoo\nR Creatures can't block this turn unless their controller pays o\nX for each blocking creature.",
             "colours": [
@@ -7531,7 +7531,7 @@
         },
         {
             "id": "dbb1cd0f-4c3b-5749-aad7-d318f6df6fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577ac30-ee84-4d3c-b407-82578779dc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5577ac30-ee84-4d3c-b407-82578779dc90.jpg?1",
             "name": "Warmonger",
             "text": "o2: Warmonger deals 1 damage to each creature without flying and each player. Any player may play this ability.",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "06267158-a59b-5fad-a8a5-fecf53bd7205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e031c819-1237-4911-8a1d-87d6095a5faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e031c819-1237-4911-8a1d-87d6095a5faa.jpg?1",
             "name": "Warpath",
             "text": "Warpath deals 3 damage to each blocking creature and each blocked creature.",
             "colours": [
@@ -7598,7 +7598,7 @@
         },
         {
             "id": "7759f516-b520-5c29-93b6-c1905a329ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bcc06a-de86-4387-882d-ead33e9c9e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bcc06a-de86-4387-882d-ead33e9c9e01.jpg?1",
             "name": "Wild Jhovall",
             "text": "",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "20de66b0-569a-5b04-b7f6-161200ecd124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5362ead-9162-4160-bfa9-432f7d0e222d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5362ead-9162-4160-bfa9-432f7d0e222d.jpg?1",
             "name": "Word of Blasting",
             "text": "Destroy target Wall. It can't be regenerated. Word of Blasting deals damage equal to that Wall's converted mana cost to the Wall's controller.",
             "colours": [
@@ -7664,7 +7664,7 @@
         },
         {
             "id": "236a4bd1-807c-5287-964d-07767ac86705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203f98a-fb6e-4f16-88e3-553eba177450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1203f98a-fb6e-4f16-88e3-553eba177450.jpg?1",
             "name": "Ancestral Mask",
             "text": "Enchanted creature gets +2/+2 for each other enchantment in play.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "b094f051-ef64-521e-b220-b6c2ea7304d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedb483e-b2c6-46c6-b02b-a49599d33521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dedb483e-b2c6-46c6-b02b-a49599d33521.jpg?1",
             "name": "Bifurcate",
             "text": "Search your library for a copy of target creature card in play and put that card into play. Then shuffle your library.",
             "colours": [
@@ -7730,7 +7730,7 @@
         },
         {
             "id": "c01152ee-acc6-53f9-b313-534554d9ae41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7369cbf-6986-4a39-b07c-a283b40aee40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7369cbf-6986-4a39-b07c-a283b40aee40.jpg?1",
             "name": "Boa Constrictor",
             "text": "oc\nT: Boa Constrictor gets +3/+3 until end of turn.",
             "colours": [
@@ -7764,7 +7764,7 @@
         },
         {
             "id": "1b0d97c8-06bb-5433-ae30-d9f9c9b9619b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5913fc6-eeb0-411b-9264-1e75bea8489b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5913fc6-eeb0-411b-9264-1e75bea8489b.jpg?1",
             "name": "Briar Patch",
             "text": "Whenever a creature attacks you, it gets -1/-0 until end of turn.",
             "colours": [
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "ab8134fb-ff51-5a19-a69a-05c955a72117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e8e1cf-0a47-4ce4-889a-091229d0e466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e8e1cf-0a47-4ce4-889a-091229d0e466.jpg?1",
             "name": "Caller of the Hunt",
             "text": "As you play Caller of the Hunt, choose a creature type.\nCaller of the Hunt's power and toughness are each equal to the number of creatures in play of the chosen type.",
             "colours": [
@@ -7830,7 +7830,7 @@
         },
         {
             "id": "c182a03b-2f3f-5a4c-a9cb-833167d9ce9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a46e20-2910-4287-a5e0-bccac8cbabcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a46e20-2910-4287-a5e0-bccac8cbabcd.jpg?1",
             "name": "Caustic Wasps",
             "text": "Flying\nWhenever Caustic Wasps deals combat damage to a player, you may destroy target artifact that player controls.",
             "colours": [
@@ -7864,7 +7864,7 @@
         },
         {
             "id": "93c28d1c-eb7f-555a-be37-956e8070518a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87f3579-f314-4207-a02c-14e9cb269b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87f3579-f314-4207-a02c-14e9cb269b47.jpg?1",
             "name": "Clear the Land",
             "text": "Each player reveals the top five cards of his or her library, puts into play tapped all land cards revealed this way, and removes the rest from the game.",
             "colours": [
@@ -7896,7 +7896,7 @@
         },
         {
             "id": "39cdcd8b-88f8-54dc-a73d-0a94f5b13e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7d6a8-9190-403f-bbdd-ab71d9c89e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7d6a8-9190-403f-bbdd-ab71d9c89e4d.jpg?1",
             "name": "Collective Unconscious",
             "text": "Draw a card for each creature you control.",
             "colours": [
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "4ca0743d-ea66-52e4-aa24-a79a53ef759d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg?1",
             "name": "Dawnstrider",
             "text": "o\nG, oc\nT, Discard a card from your hand: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "9f5e9479-3a19-5042-bbe2-0ab5d7f06b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46be78e6-13bb-4500-87db-5ed5cae0145e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46be78e6-13bb-4500-87db-5ed5cae0145e.jpg?1",
             "name": "Deadly Insect",
             "text": "Deadly Insect can't be the target of spells or abilities.",
             "colours": [
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "97b57a74-2e93-5315-9d32-a497aa210fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbed0f5-2ac0-48d8-b5ab-b4cd7176fde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbed0f5-2ac0-48d8-b5ab-b4cd7176fde2.jpg?1",
             "name": "Deepwood Drummer",
             "text": "o\nG, oc\nT, Discard a card from your hand: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8032,7 +8032,7 @@
         },
         {
             "id": "b95a320b-67dd-582c-815a-ee2b94cbb163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a1ed74-027e-4c8e-ac7e-e58c5fccff14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a1ed74-027e-4c8e-ac7e-e58c5fccff14.jpg?1",
             "name": "Deepwood Elder",
             "text": "o\nXo\nGo\nG, oc\nT, Discard a card from your hand: X target lands become forests until end of turn.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "167c438b-989d-53a5-8cb7-5dbc3f2bc9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa2028e-4e73-4ff2-a9e2-9ac347d67893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa2028e-4e73-4ff2-a9e2-9ac347d67893.jpg?1",
             "name": "Deepwood Tantiv",
             "text": "Whenever Deepwood Tantiv becomes blocked, you gain 2 life.",
             "colours": [
@@ -8101,7 +8101,7 @@
         },
         {
             "id": "29af5e08-2618-5df7-8f9c-69a2f755520f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a9a76-741a-4ba3-bd4b-0eb87d678253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a9a76-741a-4ba3-bd4b-0eb87d678253.jpg?1",
             "name": "Deepwood Wolverine",
             "text": "Whenever Deepwood Wolverine becomes blocked, it gets +2/+0 until end of turn.",
             "colours": [
@@ -8135,7 +8135,7 @@
         },
         {
             "id": "d8d0d686-bf4f-5ea4-bf5b-8617f0756d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2437f2-1966-4e83-9f7e-6aaf76e21d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2437f2-1966-4e83-9f7e-6aaf76e21d11.jpg?1",
             "name": "Desert Twister",
             "text": "Destroy target permanent.",
             "colours": [
@@ -8167,7 +8167,7 @@
         },
         {
             "id": "29944b27-6b92-543e-9e43-5de8cb1b516a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ea4e2-2102-4b99-bea5-6fc4203f2b26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec4ea4e2-2102-4b99-bea5-6fc4203f2b26.jpg?1",
             "name": "Erithizon",
             "text": "Whenever Erithizon attacks, put a +1/+1 counter on target creature of defending player's choice.",
             "colours": [
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "8bc550b8-08e8-53ad-91c8-22a02a8ff09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afda489-8397-4ad4-89dc-e8bad92db133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afda489-8397-4ad4-89dc-e8bad92db133.jpg?1",
             "name": "Ferocity",
             "text": "Whenever enchanted creature blocks or becomes blocked, you may put a +1/+1 counter on it.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "30648153-eaa7-584e-960b-cac289fbf6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1bb9e-006c-495e-8f99-d451183d2669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a1bb9e-006c-495e-8f99-d451183d2669.jpg?1",
             "name": "Food Chain",
             "text": "Remove a creature you control from the game: Add X mana of any color to your mana pool, where X is the removed creature's converted mana cost plus one. This mana may be spent only to play creature spells.",
             "colours": [
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "d372719e-e01d-54f2-ba92-d8d7e3947d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be54e1d7-1388-4184-ad0d-dde4b0a3d02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be54e1d7-1388-4184-ad0d-dde4b0a3d02d.jpg?1",
             "name": "Foster",
             "text": "Whenever a creature you control is put into a graveyard, you may pay o1. If you do, reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest into your graveyard.",
             "colours": [
@@ -8299,7 +8299,7 @@
         },
         {
             "id": "6ab3e02a-019b-5232-ae2b-dc23e758a4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb62356-72bb-4dc1-a2f9-45a3aca62e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb62356-72bb-4dc1-a2f9-45a3aca62e41.jpg?1",
             "name": "Game Preserve",
             "text": "At the beginning of your upkeep, each player reveals the top card of his or her library. If all cards revealed this way are creature cards, put those cards into play under their owners' control. (Otherwise, put them back face-down on top of their owners' libraries.)",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "7a1941a1-aa54-5efe-87f8-ca9cc9150ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc5eb8a-4531-4408-90fe-9b352d71a052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc5eb8a-4531-4408-90fe-9b352d71a052.jpg?1",
             "name": "Giant Caterpillar",
             "text": "o\nG, Sacrifice Giant Caterpillar: Put a 1/1 green Butterfly creature token with flying into play at end of turn.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "c93b8543-0015-5f25-9e5c-1f72dc78c5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d9fe16-562a-4a86-84ed-15cd90b8afc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d9fe16-562a-4a86-84ed-15cd90b8afc0.jpg?1",
             "name": "Groundskeeper",
             "text": "o1oo\nG Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -8400,7 +8400,7 @@
         },
         {
             "id": "1eaf699f-a040-518f-80dc-c0b90daa5114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a6d10-054e-4d6f-aeb7-4204f02490c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a6d10-054e-4d6f-aeb7-4204f02490c7.jpg?1",
             "name": "Horned Troll",
             "text": "oo\nG Regenerate Horned Troll.",
             "colours": [
@@ -8434,7 +8434,7 @@
         },
         {
             "id": "0a743eaa-0317-50d6-ab52-d87aeed934a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c68a-5a6a-4d51-8dc7-5c62da81ec77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7416c68a-5a6a-4d51-8dc7-5c62da81ec77.jpg?1",
             "name": "Howling Wolf",
             "text": "When Howling Wolf comes into play, you may search your library for up to three Howling Wolf cards, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "50e1914f-4ebc-55e1-8a8c-32475bea9f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21c8b2d-ef0f-4839-acfc-20fd248c62cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21c8b2d-ef0f-4839-acfc-20fd248c62cf.jpg?1",
             "name": "Hunted Wumpus",
             "text": "When Hunted Wumpus comes into play, each other player may put a creature card from his or her hand into play under his or her control.",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "2a0b1415-c3c9-538f-8294-14cf13e3674b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406b343c-90b5-4a4d-91c3-2fddcc9a0e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/406b343c-90b5-4a4d-91c3-2fddcc9a0e05.jpg?1",
             "name": "Invigorate",
             "text": "If you control a forest, you may have an opponent gain 3 life instead of paying Invigorate's mana cost.\nTarget creature gets +4/+4 until end of turn.",
             "colours": [
@@ -8534,7 +8534,7 @@
         },
         {
             "id": "25faec42-eb6b-521a-8674-c5712f71228a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6862005-32d1-473e-a28b-5dfc4b7782cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6862005-32d1-473e-a28b-5dfc4b7782cd.jpg?1",
             "name": "Land Grant",
             "text": "If you have no land cards in hand, you may reveal your hand instead of paying Land Grant's mana cost.\nSearch your library for a forest card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -8566,7 +8566,7 @@
         },
         {
             "id": "5e7c6040-9957-592e-92e3-b1c3986147b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8990efd-708a-4019-bce0-2d6409ecc004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8990efd-708a-4019-bce0-2d6409ecc004.jpg?1",
             "name": "Ley Line",
             "text": "At the beginning of each player's upkeep, that player may put a +1/+1 counter on target creature.",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "60e65200-6cc9-5bad-884f-20c4d3678a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d897088-0667-4864-91c3-5f0ac7f9b220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d897088-0667-4864-91c3-5f0ac7f9b220.jpg?1",
             "name": "Lumbering Satyr",
             "text": "All creatures gain forestwalk. (They're unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -8633,7 +8633,7 @@
         },
         {
             "id": "421b9960-a327-5686-8dcc-3aa0e4d8127d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e0015e-9b16-4787-8b4f-02d8bddb1b80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e0015e-9b16-4787-8b4f-02d8bddb1b80.jpg?1",
             "name": "Lure",
             "text": "All creatures able to block enchanted creature do so if able.",
             "colours": [
@@ -8667,7 +8667,7 @@
         },
         {
             "id": "097ce26d-c05e-5490-9aa3-5983c5232db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a1e43-a173-45d6-ac55-363664bf6e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c58a1e43-a173-45d6-ac55-363664bf6e1b.jpg?1",
             "name": "Megatherium",
             "text": "Trample\nWhen Megatherium comes into play, sacrifice it unless you pay o1 for each card in your hand.",
             "colours": [
@@ -8701,7 +8701,7 @@
         },
         {
             "id": "c990b50a-091a-54c1-ba87-ac5daefac128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c6f647-f71b-4f61-9b16-774884ed52e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c6f647-f71b-4f61-9b16-774884ed52e2.jpg?1",
             "name": "Natural Affinity",
             "text": "All lands become 2/2 creatures until end of turn. They still count as lands.",
             "colours": [
@@ -8733,7 +8733,7 @@
         },
         {
             "id": "8d2e5d77-648d-52fb-82e3-15b31b4a8514",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0335d282-cd1a-4be3-8eb2-82aaee91401a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0335d282-cd1a-4be3-8eb2-82aaee91401a.jpg?1",
             "name": "Pangosaur",
             "text": "Whenever a player plays a land, return Pangosaur to its owner's hand.",
             "colours": [
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "34a52b56-a83c-58d2-a1d2-bf6515cdff50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b19b453-8393-424d-9578-3ab568c92882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b19b453-8393-424d-9578-3ab568c92882.jpg?1",
             "name": "Revive",
             "text": "Return target green card from your graveyard to your hand.",
             "colours": [
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "91d854bc-d4cb-54c4-a14f-82b9951186fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55367a94-b343-4a04-bfa9-47722e32cc45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55367a94-b343-4a04-bfa9-47722e32cc45.jpg?1",
             "name": "Rushwood Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)",
             "colours": [
@@ -8833,7 +8833,7 @@
         },
         {
             "id": "aa52ce2a-1ce0-59c9-be0c-d080c177b128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg?1",
             "name": "Rushwood Elemental",
             "text": "Trample\nAt the beginning of your upkeep, you may put a +1/+1 counter on Rushwood Elemental.",
             "colours": [
@@ -8867,7 +8867,7 @@
         },
         {
             "id": "999bf15c-20d2-54ff-afd3-92269b28ec9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afde98f-a429-4eff-9d06-8582267ac74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9afde98f-a429-4eff-9d06-8582267ac74b.jpg?1",
             "name": "Rushwood Herbalist",
             "text": "o\nG, oc\nT, Discard a card from your hand: Regenerate target creature.",
             "colours": [
@@ -8902,7 +8902,7 @@
         },
         {
             "id": "6f3eeb42-592e-5c92-a4e0-93af82accb1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b9c99-87d7-493c-9dc3-0c6aa4a61b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b9c99-87d7-493c-9dc3-0c6aa4a61b49.jpg?1",
             "name": "Rushwood Legate",
             "text": "If an opponent controls an island and you control a forest, you may play Rushwood Legate without paying its mana cost.",
             "colours": [
@@ -8936,7 +8936,7 @@
         },
         {
             "id": "7df73f74-0595-5404-a0e0-69671dcaa6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9269f52-1002-475d-a0f3-d652630591ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9269f52-1002-475d-a0f3-d652630591ca.jpg?1",
             "name": "Saber Ants",
             "text": "Whenever Saber Ants is dealt damage, you may put that many 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -8970,7 +8970,7 @@
         },
         {
             "id": "1530fcde-fcff-5010-a24a-82a2defecf3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e965d32c-3151-48e8-b256-0b7fa8a8a211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e965d32c-3151-48e8-b256-0b7fa8a8a211.jpg?1",
             "name": "Sacred Prey",
             "text": "When Sacred Prey becomes blocked, you gain 1 life.",
             "colours": [
@@ -9004,7 +9004,7 @@
         },
         {
             "id": "9b585ffc-b6fc-554e-ba3e-f0097ca789df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f222fe90-ac92-4ba9-b060-9b64075bf139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f222fe90-ac92-4ba9-b060-9b64075bf139.jpg?1",
             "name": "Silverglade Elemental",
             "text": "When Silverglade Elemental comes into play, you may search your library for a forest card and put that card into play. If you do, shuffle your library.",
             "colours": [
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "0c442d83-4204-5035-a6a5-2db8640bf840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc99b33-ce06-4a44-8b23-300b41b2b2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc99b33-ce06-4a44-8b23-300b41b2b2fe.jpg?1",
             "name": "Silverglade Pathfinder",
             "text": "o1o\nG, oc\nT, Discard a card from your hand: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -9073,7 +9073,7 @@
         },
         {
             "id": "5b97eeac-ef6c-535d-a2cc-f60aaf0dcc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059a70a5-d4fb-445e-af98-e81821df2c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059a70a5-d4fb-445e-af98-e81821df2c59.jpg?1",
             "name": "Snake Pit",
             "text": "Whenever an opponent plays a blue or black spell, you may put a 1/1 green Snake creature token into play.",
             "colours": [
@@ -9105,7 +9105,7 @@
         },
         {
             "id": "f353a038-93ab-5084-aa79-484fac3de6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e568503e-a886-4c8b-9d46-8520c2cdda48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e568503e-a886-4c8b-9d46-8520c2cdda48.jpg?1",
             "name": "Snorting Gahr",
             "text": "Whenever Snorting Gahr becomes blocked, it gets +2/+2 until end of turn.",
             "colours": [
@@ -9140,7 +9140,7 @@
         },
         {
             "id": "0852573b-33e0-53f6-99ea-a86a75042032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb7694f-af4c-4152-b868-528257d05154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb7694f-af4c-4152-b868-528257d05154.jpg?1",
             "name": "Spidersilk Armor",
             "text": "Creatures you control get +0/+1 and may block as though they had flying.",
             "colours": [
@@ -9172,7 +9172,7 @@
         },
         {
             "id": "1649a602-2b0a-5059-8e20-78126e5d495f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5765cb-00cd-4920-9fe8-68791048ec4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5765cb-00cd-4920-9fe8-68791048ec4a.jpg?1",
             "name": "Spontaneous Generation",
             "text": "Put a 1/1 green Saproling creature token into play for each card in your hand.",
             "colours": [
@@ -9204,7 +9204,7 @@
         },
         {
             "id": "57d40993-10fd-5d0f-9522-8f13890add59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5409b54-66ed-4add-bf43-cfeb074b1c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5409b54-66ed-4add-bf43-cfeb074b1c50.jpg?1",
             "name": "Squall",
             "text": "Squall deals 2 damage to each creature with flying.",
             "colours": [
@@ -9236,7 +9236,7 @@
         },
         {
             "id": "13cec50d-71b1-547a-884e-d213e62be04d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c845e1b8-6a39-456c-aa67-d180ae63e200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c845e1b8-6a39-456c-aa67-d180ae63e200.jpg?1",
             "name": "Squallmonger",
             "text": "o2: Squallmonger deals 1 damage to each creature with flying and each player. Any player may play this ability.",
             "colours": [
@@ -9270,7 +9270,7 @@
         },
         {
             "id": "b3a58689-1483-555e-85e4-daddcc8f0b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8abca3-6e31-49cd-b9bf-86ad68e1cc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8abca3-6e31-49cd-b9bf-86ad68e1cc83.jpg?1",
             "name": "Stamina",
             "text": "Attacking doesn't cause enchanted creature to tap.\nSacrifice Stamina: Regenerate enchanted creature.",
             "colours": [
@@ -9304,7 +9304,7 @@
         },
         {
             "id": "9c94d192-b8be-5ffc-94da-513c4b067cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61db44-80dc-4058-9c9d-65cd18e63fd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a61db44-80dc-4058-9c9d-65cd18e63fd4.jpg?1",
             "name": "Sustenance",
             "text": "o1, Sacrifice a land: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -9336,7 +9336,7 @@
         },
         {
             "id": "1d46afb0-3dfe-5fc7-8554-b52e03977b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0146a689-4817-4849-a90d-4cc64566960d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0146a689-4817-4849-a90d-4cc64566960d.jpg?1",
             "name": "Tiger Claws",
             "text": "You may play Tiger Claws any time you could play an instant.\nEnchanted creature gets +1/+1 and has trample.",
             "colours": [
@@ -9370,7 +9370,7 @@
         },
         {
             "id": "daa0bdb1-e59a-5374-8b23-4e74e14a1dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843e801e-1ceb-4e3f-82e6-3c092051ba8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843e801e-1ceb-4e3f-82e6-3c092051ba8c.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "5fafe883-8d82-5ec8-9602-d6cfdc50eb64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4797556c-df74-4e13-b8fb-8b0b58c92b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4797556c-df74-4e13-b8fb-8b0b58c92b4c.jpg?1",
             "name": "Venomous Breath",
             "text": "At end of combat, destroy all creatures that blocked or were blocked by target creature this turn.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "fb46813f-66b6-5ebe-b810-6644ebdea45f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479fc902-ce94-4a6b-af87-4645387a46c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479fc902-ce94-4a6b-af87-4645387a46c6.jpg?1",
             "name": "Venomous Dragonfly",
             "text": "Flying\nWhenever Venomous Dragonfly blocks or becomes blocked by a creature, destroy that creature at end of combat.",
             "colours": [
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "dc44433b-d18f-51b5-94d0-43ad3783cbc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed69d2-f5fb-4173-b939-5abdb48b82b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bed69d2-f5fb-4173-b939-5abdb48b82b4.jpg?1",
             "name": "Vernal Equinox",
             "text": "Any player may play creature and enchantment spells any time he or she could play an instant.",
             "colours": [
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "6af00dfd-76ea-55ef-a018-d9e05cac7d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c9158-faed-42ae-9f6b-71dee49ff79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9c9158-faed-42ae-9f6b-71dee49ff79f.jpg?1",
             "name": "Vine Dryad",
             "text": "Forestwalk (This creature is unblockable as long as defending player controls a forest.)\nYou may play Vine Dryad any time you could play an instant.\nYou may remove a green card in your hand from the game instead of paying Vine Dryad's mana cost.",
             "colours": [
@@ -9534,7 +9534,7 @@
         },
         {
             "id": "b2cc959a-ded1-54a0-a53a-8e756d083256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e660241f-0976-4206-8149-7dac8466a2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e660241f-0976-4206-8149-7dac8466a2a3.jpg?1",
             "name": "Vine Trellis",
             "text": "(Walls can't attack.)\noc\nT: Add one green mana to your mana pool.",
             "colours": [
@@ -9569,7 +9569,7 @@
         },
         {
             "id": "8a7f7fca-dcf9-594c-b98e-0e98be8e0bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676ccbb-91d2-4f26-b3a5-ccb1a21bdebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676ccbb-91d2-4f26-b3a5-ccb1a21bdebf.jpg?1",
             "name": "Assembly Hall",
             "text": "o4, oc\nT: Reveal a creature card in your hand, search your library for a copy of that card, and put the card into your hand. Then shuffle your library.",
             "colours": [],
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "e9e4e693-6417-5c2b-ba86-c3b0cc444b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e2e59-1527-4c61-9cc9-dcaf1181bd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e2e59-1527-4c61-9cc9-dcaf1181bd43.jpg?1",
             "name": "Barbed Wire",
             "text": "At the beginning of each player's upkeep, Barbed Wire deals 1 damage to that player.\no2: Prevent the next 1 damage that would be dealt by Barbed Wire this turn.",
             "colours": [],
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "9115773d-8455-53d0-a66b-9bf3941c555d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da9395-42e9-4408-832d-74ea4b01256b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da9395-42e9-4408-832d-74ea4b01256b.jpg?1",
             "name": "Bargaining Table",
             "text": "o\nX, oc\nT: Draw a card. X is the number of cards in an opponent's hand.",
             "colours": [],
@@ -9653,7 +9653,7 @@
         },
         {
             "id": "a1a74fb8-5eef-5aa3-be00-aa9789256544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab65242-17ad-4c22-9c70-aac8076d1b4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab65242-17ad-4c22-9c70-aac8076d1b4c.jpg?1",
             "name": "Credit Voucher",
             "text": "o2, oc\nT, Sacrifice Credit Voucher: Shuffle any number of cards from your hand into your library, then draw that many cards.",
             "colours": [],
@@ -9681,7 +9681,7 @@
         },
         {
             "id": "f1e4acc1-1bb7-57ea-9d61-edb3e803ab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85ad08d-1120-411a-8bbe-ac93a56476bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85ad08d-1120-411a-8bbe-ac93a56476bd.jpg?1",
             "name": "Crenellated Wall",
             "text": "(Walls can't attack.)\noc\nT: Target creature gets +0/+4 until end of turn.",
             "colours": [],
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "b3c9ceac-183f-510e-bd8d-aaca18645740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7084ba-cca6-4fb9-b21b-b79e7d74c5c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7084ba-cca6-4fb9-b21b-b79e7d74c5c0.jpg?1",
             "name": "Crooked Scales",
             "text": "o4, oc\nT: Choose target creature you control and target creature an opponent controls. Flip a coin. If you win the flip, destroy the creature the opponent controls. If you lose the flip, destroy the creature you control unless you pay o3 and reflip the coin.",
             "colours": [],
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "f06f1beb-865e-5cc5-b2d5-5192fde6b6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa6d6c-c1cd-46f3-8430-94f67be55bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8fa6d6c-c1cd-46f3-8430-94f67be55bf7.jpg?1",
             "name": "Crumbling Sanctuary",
             "text": "For each 1 damage that would be dealt to a player, that player removes the top card of his or her library from the game instead.",
             "colours": [],
@@ -9768,7 +9768,7 @@
         },
         {
             "id": "00c03a00-014f-5858-9a84-dbd8a3bfceb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab196d8d-5d1c-4f0e-a924-37774db02821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab196d8d-5d1c-4f0e-a924-37774db02821.jpg?1",
             "name": "Distorting Lens",
             "text": "oc\nT: Target permanent becomes the color of your choice until end of turn.",
             "colours": [],
@@ -9796,7 +9796,7 @@
         },
         {
             "id": "77bf111e-4e00-5fd2-82a4-e72b579c836a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d22400-39f6-444d-b508-783a7df7e945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78d22400-39f6-444d-b508-783a7df7e945.jpg?1",
             "name": "Eye of Ramos",
             "text": "oc\nT: Add one blue mana to your mana pool.\nSacrifice Eye of Ramos: Add one blue mana to your mana pool.",
             "colours": [],
@@ -9826,7 +9826,7 @@
         },
         {
             "id": "1858f8ca-4c2f-5fa2-a17f-e9c8e2a9913d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb99d982-8ab1-4d6a-ba24-58ac23a9b9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb99d982-8ab1-4d6a-ba24-58ac23a9b9e7.jpg?1",
             "name": "General's Regalia",
             "text": "o3: The next time a source of your choice would deal damage to you this turn, that damage is dealt to target creature you control instead.",
             "colours": [],
@@ -9854,7 +9854,7 @@
         },
         {
             "id": "2f46d828-c3a5-5cb2-a822-ad4752f5a7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0046226-7563-4345-aa4b-a2c732c2780a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0046226-7563-4345-aa4b-a2c732c2780a.jpg?1",
             "name": "Heart of Ramos",
             "text": "oc\nT: Add one red mana to your mana pool.\nSacrifice Heart of Ramos: Add one red mana to your mana pool.",
             "colours": [],
@@ -9884,7 +9884,7 @@
         },
         {
             "id": "ae08d275-a72c-561b-94f4-a646656b2765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028e5e18-b639-4461-87e4-5306371440b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/028e5e18-b639-4461-87e4-5306371440b5.jpg?1",
             "name": "Henge Guardian",
             "text": "o2: Henge Guardian gains trample until end of turn.",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "1f43bdff-8e10-5f4e-850a-e22741bc2847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e04462-1d10-47df-b456-211dd0a87891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e04462-1d10-47df-b456-211dd0a87891.jpg?1",
             "name": "Horn of Plenty",
             "text": "Whenever a player plays a spell, he or she may pay o1. If that player does, he or she draws a card at end of turn.",
             "colours": [],
@@ -9944,7 +9944,7 @@
         },
         {
             "id": "4e74c3c3-1f51-5eaf-979c-ddd0d345522a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f541-8e9d-43b0-b688-e3f2e7fa55c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f541-8e9d-43b0-b688-e3f2e7fa55c8.jpg?1",
             "name": "Horn of Ramos",
             "text": "oc\nT: Add one green mana to your mana pool.\nSacrifice Horn of Ramos: Add one green mana to your mana pool.",
             "colours": [],
@@ -9974,7 +9974,7 @@
         },
         {
             "id": "471a2ba6-ac9a-501c-8a5a-7896d04fffe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d212-faf2-4a6f-a338-d9e5014b56d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f7d212-faf2-4a6f-a338-d9e5014b56d5.jpg?1",
             "name": "Iron Lance",
             "text": "o3, oc\nT: Target creature gains first strike until end of turn.",
             "colours": [],
@@ -10002,7 +10002,7 @@
         },
         {
             "id": "62593a3b-b313-57da-9a7f-fd0425db1a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab076bc-e4c3-42a1-b701-9bc49bcc3cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab076bc-e4c3-42a1-b701-9bc49bcc3cdd.jpg?1",
             "name": "Jeweled Torque",
             "text": "As Jeweled Torque comes into play, choose a color.\nWhenever a player plays a spell of the chosen color, you may pay o2. If you do, you gain 2 life.",
             "colours": [],
@@ -10030,7 +10030,7 @@
         },
         {
             "id": "0cdbc754-a88a-5b87-944f-ff6e0485d9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e65a06a-e7af-422a-9481-446731009935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e65a06a-e7af-422a-9481-446731009935.jpg?1",
             "name": "Kyren Archive",
             "text": "At the beginning of your upkeep, you may remove the top card of your library from the game face down.\no5, Discard your hand, Sacrifice Kyren Archive: Put all cards removed from the game with Kyren Archive into their owner's hand.",
             "colours": [],
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "13943c74-8688-5cb5-866b-4d7017fcc459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8318bb-bc3c-45e9-bd57-60ae72b6f8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8318bb-bc3c-45e9-bd57-60ae72b6f8b0.jpg?1",
             "name": "Kyren Toy",
             "text": "o1, oc\nT: Put a charge counter on Kyren Toy.\noc\nT, Remove X charge counters from Kyren Toy: Add X plus one colorless mana to your mana pool.",
             "colours": [],
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "3198d04a-fdfb-58ab-9e7c-9ce9fa321ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4785ed7-c948-4ad2-b24d-2f45806d9fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4785ed7-c948-4ad2-b24d-2f45806d9fcc.jpg?1",
             "name": "Magistrate's Scepter",
             "text": "o4, oc\nT: Put a charge counter on Magistrate's Scepter.\noc\nT, Remove three charge counters from Magistrate's Scepter: Take another turn after this one.",
             "colours": [],
@@ -10114,7 +10114,7 @@
         },
         {
             "id": "69a28d00-0c9b-5d4e-8f31-52c66cee9948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ad3531-399c-4897-b0ee-ad2a26445a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ad3531-399c-4897-b0ee-ad2a26445a17.jpg?1",
             "name": "Mercadian Atlas",
             "text": "At the end of your turn, if you didn't play a land this turn, you may draw a card.",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "f2455441-5453-54b9-94cb-d5555f39014b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395a1a8a-785f-442b-8e95-8b4ca44af2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395a1a8a-785f-442b-8e95-8b4ca44af2a3.jpg?1",
             "name": "Mercadian Lift",
             "text": "o1, oc\nT: Put a winch counter on Mercadian Lift.\noc\nT, Remove X winch counters from Mercadian Lift: Put a creature card with converted mana cost X from your hand into play.",
             "colours": [],
@@ -10170,7 +10170,7 @@
         },
         {
             "id": "6fe07575-9bff-5fc9-a8b6-252121be4def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f6be53-7a20-4e6b-a6ce-11cba06af8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f6be53-7a20-4e6b-a6ce-11cba06af8cb.jpg?1",
             "name": "Monkey Cage",
             "text": "When a creature comes into play, sacrifice Monkey Cage and put into play a number of 2/2 green Ape creature tokens equal to that creature's converted mana cost.",
             "colours": [],
@@ -10198,7 +10198,7 @@
         },
         {
             "id": "4fd135ce-cdec-5b28-9eb9-e0944f45719e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89414770-2a19-4baf-9b18-76104b7b0b9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89414770-2a19-4baf-9b18-76104b7b0b9a.jpg?1",
             "name": "Panacea",
             "text": "o\nXo\nX, oc\nT: Prevent the next X damage that would be dealt to target creature or player this turn.",
             "colours": [],
@@ -10226,7 +10226,7 @@
         },
         {
             "id": "23454f96-f19c-550c-b316-28d89d34b419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a578599c-7d90-4881-b59a-9cf64b90d917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a578599c-7d90-4881-b59a-9cf64b90d917.jpg?1",
             "name": "Power Matrix",
             "text": "oc\nT: Target creature gets +1/+1 and gains flying, first strike, and trample until end of turn.",
             "colours": [],
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "7d1c7345-b7ed-51c0-8da0-276ee3039254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83093cdf-0b12-419c-a748-21acf166e195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83093cdf-0b12-419c-a748-21acf166e195.jpg?1",
             "name": "Puffer Extract",
             "text": "o\nX, oc\nT: Target creature you control gets +X/+X until end of turn. Destroy it at end of turn.",
             "colours": [],
@@ -10282,7 +10282,7 @@
         },
         {
             "id": "a2969c6f-6d31-5233-b521-67b6b499f249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fc9fc-a0f9-4f56-8368-2d7e1fec5ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5fc9fc-a0f9-4f56-8368-2d7e1fec5ba0.jpg?1",
             "name": "Rishadan Pawnshop",
             "text": "o2, oc\nT: Shuffle target card in play you control into its owner's library.",
             "colours": [],
@@ -10310,7 +10310,7 @@
         },
         {
             "id": "5a1ec2fa-47d4-5619-9d60-f989609e9683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f071957c-9bea-4d00-9ffd-30f98d57b8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f071957c-9bea-4d00-9ffd-30f98d57b8d2.jpg?1",
             "name": "Skull of Ramos",
             "text": "oc\nT: Add one black mana to your mana pool.\nSacrifice Skull of Ramos: Add one black mana to your mana pool.",
             "colours": [],
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "b45aed8a-1df5-5322-bd96-4a4a8bfe999a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3b999d-8e63-4647-a921-15e169022096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3b999d-8e63-4647-a921-15e169022096.jpg?1",
             "name": "Tooth of Ramos",
             "text": "oc\nT: Add one white mana to your mana pool.\nSacrifice Tooth of Ramos: Add one white mana to your mana pool.",
             "colours": [],
@@ -10370,7 +10370,7 @@
         },
         {
             "id": "4328ab7b-be98-5a8d-b92f-c8e04e1f6a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3992a-553c-4032-b144-55aad2f909f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3992a-553c-4032-b144-55aad2f909f1.jpg?1",
             "name": "Toymaker",
             "text": "o1, oc\nT, Discard a card from your hand: Target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost until end of turn. (It retains its abilities.)",
             "colours": [],
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "0ab05aef-dcd1-531d-8481-b0dc5342a517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400edfe9-9efa-43f9-b713-13ad4eae2fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400edfe9-9efa-43f9-b713-13ad4eae2fa4.jpg?1",
             "name": "Worry Beads",
             "text": "At the beginning of each player's upkeep, that player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -10429,7 +10429,7 @@
         },
         {
             "id": "c5a11a39-85cf-5914-a5b8-8ec6e27332ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b03c30-c2b8-4207-b675-26c59c40a7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b03c30-c2b8-4207-b675-26c59c40a7e5.jpg?1",
             "name": "Dust Bowl",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no3, oc\nT, Sacrifice a land: Destroy target nonbasic land.",
             "colours": [],
@@ -10457,7 +10457,7 @@
         },
         {
             "id": "2d077383-597c-595e-b660-3dd14a407fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f352c3-4b63-4174-b2b4-6c19fb8c06ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f352c3-4b63-4174-b2b4-6c19fb8c06ff.jpg?1",
             "name": "Fountain of Cho",
             "text": "Fountain of Cho comes into play tapped.\noc\nT: Put a storage counter on Fountain of Cho.\noc\nT, Remove any number of storage counters from Fountain of Cho: Add one white mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10487,7 +10487,7 @@
         },
         {
             "id": "05a58920-2e74-53aa-aef2-2c97eb96a871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0582b42f-5ae5-4be2-ba2d-ed62b3cb20c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0582b42f-5ae5-4be2-ba2d-ed62b3cb20c5.jpg?1",
             "name": "Henge of Ramos",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "137ab8c3-92ca-51a7-a473-5946996ee8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7aafb7-6870-4d09-a191-70786766c459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7aafb7-6870-4d09-a191-70786766c459.jpg?1",
             "name": "Hickory Woodlot",
             "text": "Hickory Woodlot comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Hickory Woodlot: Add two green mana to your mana pool. If there are no depletion counters on Hickory Woodlot, sacrifice it.",
             "colours": [],
@@ -10545,7 +10545,7 @@
         },
         {
             "id": "07563a4b-638a-5a4d-93bd-18c8d22d7898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c58683-65a6-4df9-8952-458e397b1374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c58683-65a6-4df9-8952-458e397b1374.jpg?1",
             "name": "High Market",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice a creature: You gain 1 life.",
             "colours": [],
@@ -10573,7 +10573,7 @@
         },
         {
             "id": "bb583cde-94fe-5f98-891e-53632e97357b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f787cb6-78cb-4baa-a9cf-cee8b7d8d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f787cb6-78cb-4baa-a9cf-cee8b7d8d6b1.jpg?1",
             "name": "Mercadian Bazaar",
             "text": "Mercadian Bazaar comes into play tapped.\noc\nT: Put a storage counter on Mercadian Bazaar.\noc\nT, Remove any number of storage counters from Mercadian Bazaar: Add one red mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "109559a0-b9a6-5224-8936-47f492378a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc9d1e0-c8f4-4bac-90d4-8167f7a1515a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc9d1e0-c8f4-4bac-90d4-8167f7a1515a.jpg?1",
             "name": "Peat Bog",
             "text": "Peat Bog comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Peat Bog: Add two black mana to your mana pool. If there are no depletion counters on Peat Bog, sacrifice it.",
             "colours": [],
@@ -10633,7 +10633,7 @@
         },
         {
             "id": "bd3043d9-d3d3-582d-9ebc-970936a83279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115cab84-60d7-4bf2-9beb-b4ed7b5ceaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115cab84-60d7-4bf2-9beb-b4ed7b5ceaf4.jpg?1",
             "name": "Remote Farm",
             "text": "Remote Farm comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Remote Farm: Add two white mana to your mana pool. If there are no depletion counters on Remote Farm, sacrifice it.",
             "colours": [],
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "5a243366-749e-506b-b91e-f7e835e5f63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477a1f53-5cdf-4b45-b584-2e36b31a3fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477a1f53-5cdf-4b45-b584-2e36b31a3fdb.jpg?1",
             "name": "Rishadan Port",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Tap target land.",
             "colours": [],
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "cf4d1432-726d-54fd-9525-9d772fa0f5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c315c72c-3e2f-4aff-b7d7-2f709ccec332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c315c72c-3e2f-4aff-b7d7-2f709ccec332.jpg?1",
             "name": "Rushwood Grove",
             "text": "Rushwood Grove comes into play tapped.\noc\nT: Put a storage counter on Rushwood Grove.\noc\nT, Remove any number of storage counters from Rushwood Grove: Add one green mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10721,7 +10721,7 @@
         },
         {
             "id": "381d605b-6d1c-52fd-94df-48b6fd943ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bc7c6b-2e3d-42d1-b2bb-b37b6f34d33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82bc7c6b-2e3d-42d1-b2bb-b37b6f34d33b.jpg?1",
             "name": "Sandstone Needle",
             "text": "Sandstone Needle comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Sandstone Needle: Add two red mana to your mana pool. If there are no depletion counters on Sandstone Needle, sacrifice it.",
             "colours": [],
@@ -10751,7 +10751,7 @@
         },
         {
             "id": "b7a85418-b075-5000-a64c-0f8fb0213afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a69122-19c0-47ec-8bea-478511ba88e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a69122-19c0-47ec-8bea-478511ba88e6.jpg?1",
             "name": "Saprazzan Cove",
             "text": "Saprazzan Cove comes into play tapped.\noc\nT: Put a storage counter on Saprazzan Cove.\noc\nT, Remove any number of storage counters from Saprazzan Cove: Add one blue mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10781,7 +10781,7 @@
         },
         {
             "id": "cd100140-bae3-58f2-8232-5f31bb5e35e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006871fd-2641-42cb-a2ac-a33d05fc5a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006871fd-2641-42cb-a2ac-a33d05fc5a35.jpg?1",
             "name": "Saprazzan Skerry",
             "text": "Saprazzan Skerry comes into play tapped with two depletion counters on it.\noc\nT, Remove a depletion counter from Saprazzan Skerry: Add two blue mana to your mana pool. If there are no depletion counters on Saprazzan Skerry, sacrifice it.",
             "colours": [],
@@ -10811,7 +10811,7 @@
         },
         {
             "id": "ab421e7e-7e06-57cd-9138-27163b98a0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc199d1-970b-489f-b713-8285151f16ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc199d1-970b-489f-b713-8285151f16ae.jpg?1",
             "name": "Subterranean Hangar",
             "text": "Subterranean Hangar comes into play tapped.\noc\nT: Put a storage counter on Subterranean Hangar.\noc\nT, Remove any number of storage counters from Subterranean Hangar: Add one black mana to your mana pool for each storage counter removed this way.",
             "colours": [],
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "90bc35fb-4324-58d4-b935-3f8e84eb13a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0481db-15ae-46b4-89a3-01c95a9626c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0481db-15ae-46b4-89a3-01c95a9626c7.jpg?1",
             "name": "Tower of the Magistrate",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Target creature gains protection from artifacts until end of turn.",
             "colours": [],
@@ -10869,7 +10869,7 @@
         },
         {
             "id": "3c75e5ee-810f-54ae-968d-3e42d270a023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edf5042-d185-424e-922d-c0bd4ce3e8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2edf5042-d185-424e-922d-c0bd4ce3e8b0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10907,7 +10907,7 @@
         },
         {
             "id": "de345860-f1ed-5fe4-806e-ffda52466c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44214f36-8bb3-4a32-8046-3ecdfff8407b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44214f36-8bb3-4a32-8046-3ecdfff8407b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10945,7 +10945,7 @@
         },
         {
             "id": "1ff3b87f-6358-5690-b3c9-a3d8aa6e0e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e536cc-e724-43d4-9fe3-dfb4952613cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e536cc-e724-43d4-9fe3-dfb4952613cb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10983,7 +10983,7 @@
         },
         {
             "id": "046ca9b7-5b11-5f77-9dda-8f329c9e24b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8fd867-8be1-4ee7-bb67-32c3f22db59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8fd867-8be1-4ee7-bb67-32c3f22db59e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11021,7 +11021,7 @@
         },
         {
             "id": "21ff94c9-782c-5f66-b85b-db1228c188c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae77e8-1230-4a6e-8c75-c99d2741a509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bae77e8-1230-4a6e-8c75-c99d2741a509.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11059,7 +11059,7 @@
         },
         {
             "id": "c1f855e1-40b6-5437-85ef-2d04a3b1d58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a38509a-2b74-42a0-af91-ed453e463b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a38509a-2b74-42a0-af91-ed453e463b95.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11097,7 +11097,7 @@
         },
         {
             "id": "1eabfcbf-ae04-5290-b5d3-f23785430fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d83856-2201-4c30-bfcf-9cab62545201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d83856-2201-4c30-bfcf-9cab62545201.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11135,7 +11135,7 @@
         },
         {
             "id": "0619e868-e046-54ad-8188-331e386b3912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fedd66-e547-492c-ad0d-9c7b527bdd17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fedd66-e547-492c-ad0d-9c7b527bdd17.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11173,7 +11173,7 @@
         },
         {
             "id": "94a2fb92-ebb8-5f9f-8683-38e9518e7331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72020810-bfa3-42d5-ad0d-6d02a6fe1b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72020810-bfa3-42d5-ad0d-6d02a6fe1b31.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11211,7 +11211,7 @@
         },
         {
             "id": "e341f86f-6b40-5e23-91a0-01f80597e73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2436ceb-05c0-40e6-b370-a6f02f4adbe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2436ceb-05c0-40e6-b370-a6f02f4adbe4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11249,7 +11249,7 @@
         },
         {
             "id": "1ca6a99e-0980-5a34-b0f6-79cf08ba2f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1017347b-6b1a-4a2f-9147-98acad779616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1017347b-6b1a-4a2f-9147-98acad779616.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11287,7 +11287,7 @@
         },
         {
             "id": "24635263-dfc2-5e04-9f58-808fb97ae799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0243d2-5fde-489f-8113-4ece0511cb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0243d2-5fde-489f-8113-4ece0511cb5c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11325,7 +11325,7 @@
         },
         {
             "id": "d103e41a-10e4-5d13-9366-0321a4412d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5fff1-7a60-4e50-893a-8177cd62bf82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b5fff1-7a60-4e50-893a-8177cd62bf82.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11363,7 +11363,7 @@
         },
         {
             "id": "3a5253fc-53dd-544e-8782-7a7ea09e838c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd12ed-e512-43d8-919d-478b18674deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbd12ed-e512-43d8-919d-478b18674deb.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11401,7 +11401,7 @@
         },
         {
             "id": "49508501-518b-5ebd-a756-c5033194fffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921ce16-8ed8-41d7-a2b4-9e62f44ac8d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1921ce16-8ed8-41d7-a2b4-9e62f44ac8d6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11439,7 +11439,7 @@
         },
         {
             "id": "ec26167c-d263-578c-b42b-e0cd6ac35a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f4311-9feb-4c63-8b4c-32ddd38382e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423f4311-9feb-4c63-8b4c-32ddd38382e0.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11477,7 +11477,7 @@
         },
         {
             "id": "d0ce4b65-ae5c-5393-9714-d5ae0eac2ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695de19e-801f-4f08-b44c-b0726e4aced0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695de19e-801f-4f08-b44c-b0726e4aced0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11515,7 +11515,7 @@
         },
         {
             "id": "233c7c1a-bec5-54e9-95f2-2c69f210111f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38e4ee7-6965-4e12-95d4-c9de1dbb014c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38e4ee7-6965-4e12-95d4-c9de1dbb014c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "e2ebdd87-99ae-55f4-89fa-6c2903e1d996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1973049-2d42-4091-9703-189ba374254d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1973049-2d42-4091-9703-189ba374254d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11591,7 +11591,7 @@
         },
         {
             "id": "da0abe46-d341-5aa2-9be1-3ea5ec0e8147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c4806b-a31a-4026-9876-eab4d0d1694b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c4806b-a31a-4026-9876-eab4d0d1694b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MOM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MOM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "dff87229-6257-5fe4-907e-694ad4f8974e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg?1",
             "name": "Invasion of Ravnica // Guildpact Paragon",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ravnica enters the battlefield, exile target nonland permanent an opponent controls that isn't exactly two colors.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "3e1b355c-0a6c-579a-a0d3-96010048ad39",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73f8fc4f-2f36-4932-8d04-3c2651c116dc.jpg?1",
             "name": "Invasion of Ravnica // Guildpact Paragon",
             "text": "Whenever you cast a spell that's exactly two colors, look at the top six cards of your library. You may reveal a card that's exactly two colors from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "eeacede0-193a-53ec-b9c6-ec616b960c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7017afb-4c7c-4c8d-9c9d-3f056a55561e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7017afb-4c7c-4c8d-9c9d-3f056a55561e.jpg?1",
             "name": "Aerial Boost",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "79bc98eb-7179-58d4-b472-4bbdc438ffa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165357cc-ec74-490f-aec3-7048bb43c8f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165357cc-ec74-490f-aec3-7048bb43c8f9.jpg?1",
             "name": "Alabaster Host Intercessor",
             "text": "When Alabaster Host Intercessor enters the battlefield, exile target creature an opponent controls until Alabaster Host Intercessor leaves the battlefield.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -132,7 +132,7 @@
         },
         {
             "id": "b1334ce9-0115-51bc-bc46-c1303be41f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbd934a-39c4-4ce7-af2a-34ca226d7f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbd934a-39c4-4ce7-af2a-34ca226d7f23.jpg?1",
             "name": "Alabaster Host Sanctifier",
             "text": "Lifelink",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "3769fbfe-178d-5ac1-ac29-ba0f3d97bf60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fb5876-5b47-4a05-be57-7ad3890c8953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09fb5876-5b47-4a05-be57-7ad3890c8953.jpg?1",
             "name": "Angelic Intervention",
             "text": "Target creature or planeswalker you control gains protection from colorless or from the color of your choice until end of turn. If it's a creature, put a +1/+1 counter on it. (It can't be blocked, targeted, dealt damage, enchanted, or equipped by anything with that quality.)",
             "colours": [
@@ -199,7 +199,7 @@
         },
         {
             "id": "6b4e232f-3750-5754-8397-0549d3f50e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed6263-bdd7-4013-ac8c-9b652d71a0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed6263-bdd7-4013-ac8c-9b652d71a0db.jpg?1",
             "name": "Archangel Elspeth",
             "text": "+1: Create a 1/1 white Soldier creature token with lifelink.\n\u22122: Put two +1/+1 counters on target creature. It becomes an Angel in addition to its other types and gains flying.\n\u22126: Return all nonland permanent cards with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "b1ef0362-a7c1-5b34-b855-9a7a6ac679c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d89bd5-95cc-41fc-aea2-2dde52231919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d89bd5-95cc-41fc-aea2-2dde52231919.jpg?1",
             "name": "Attentive Skywarden",
             "text": "Flying\nWhenever Attentive Skywarden deals combat damage to a player or battle, transform up to one target Incubator token you control.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "8f2bc04a-f900-5858-a34c-caaa9ce43239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896043a7-c7a2-4542-8739-7b4f09c6e1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896043a7-c7a2-4542-8739-7b4f09c6e1f1.jpg?1",
             "name": "Bola Slinger",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nWhenever this creature attacks, tap target artifact or creature an opponent controls.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "e56f58d4-9bbb-5cea-8163-c00ed7d321b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e1cc7d-e645-4b0e-b117-63f93528ed12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e1cc7d-e645-4b0e-b117-63f93528ed12.jpg?1",
             "name": "Boon-Bringer Valkyrie",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following abilities until end of turn.)\nFlying, first strike, lifelink",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "ef54fb63-ae5a-5fb5-ae5d-a0776e4170c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a45d4d-d16a-43c6-843c-916d4629aae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a45d4d-d16a-43c6-843c-916d4629aae1.jpg?1",
             "name": "Cut Short",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target planeswalker that was activated this turn or tapped creature.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "4c96883b-2428-59be-8d75-27d9ecdf1fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305a8d3-5403-4483-92af-863dc91c6084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7305a8d3-5403-4483-92af-863dc91c6084.jpg?1",
             "name": "Dusk Legion Duelist",
             "text": "Vigilance\nWhenever one or more +1/+1 counters are put on Dusk Legion Duelist, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -413,7 +413,7 @@
         },
         {
             "id": "cd624224-94be-5a95-8e48-704e79f20a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "Vigilance\nWhenever a source an opponent controls deals damage to you or a permanent you control, that source's controller loses 2 life unless they pay {1}.\n{2}{W}, Sacrifice three other creatures: Exile Elesh Norn, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "029993c5-80e2-5996-9c45-0db28f177b29",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8999135-ddb1-4e4c-b885-e25f23dac3d3.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Incubate 2 five times, then transform all Incubator tokens you control.\nII \u2014 Creatures you control get +1/+1 and gain double strike until end of turn.\nIII \u2014 Destroy all other permanents except for artifacts, lands, and Phyrexians. Exile The Argent Etchings, then return it to the battlefield (front face up).",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "ecfc1058-5e8d-50da-af6b-e51d21576d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03a480f-de67-4611-9db7-c0c3d020f597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03a480f-de67-4611-9db7-c0c3d020f597.jpg?1",
             "name": "Elspeth's Smite",
             "text": "Elspeth's Smite deals 3 damage to target attacking or blocking creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "02954227-4a8f-5827-80ff-94da80092b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0680eb-ceca-44d9-9654-78ea2ccfce17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0680eb-ceca-44d9-9654-78ea2ccfce17.jpg?1",
             "name": "Enduring Bondwarden",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nWhen this creature dies, put its counters on target creature you control.",
             "colours": [
@@ -557,7 +557,7 @@
         },
         {
             "id": "38a27611-d385-5aed-b0a4-adc36b0bdb6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2f3c52-8d6a-411a-aa62-cbb08a144351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b2f3c52-8d6a-411a-aa62-cbb08a144351.jpg?1",
             "name": "Golden-Scale Aeronaut",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nFlying",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "cd727ebf-260c-5a67-8eb1-9720c8a19ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9503a1e6-f0bf-44d0-a28b-56fbfcff1ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9503a1e6-f0bf-44d0-a28b-56fbfcff1ff2.jpg?1",
             "name": "Guardian of Ghirapur",
             "text": "Flying\nWhen Guardian of Ghirapur enters the battlefield, exile up to one other target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -628,7 +628,7 @@
         },
         {
             "id": "53a210da-e9bb-5c71-815a-c36fc7500333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "When Heliod, the Radiant Dawn enters the battlefield, return target enchantment card that isn't a God from your graveyard to your hand.\n{3}{PU}: Transform Heliod, the Radiant Dawn. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "a7a0ce43-9590-5d59-b64c-c1d94a442fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7113c93-6c6d-410f-aeec-abc5ee121cdf.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "You may cast spells as though they had flash.\nSpells you cast cost {1} less to cast for each card your opponents have drawn this turn.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "7764ceac-28bc-5465-ae2d-0afe9292071f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2777f8b5-2f8e-4cb8-9206-8a4978488657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2777f8b5-2f8e-4cb8-9206-8a4978488657.jpg?1",
             "name": "Infected Defector",
             "text": "When Infected Defector dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "b8a56698-abaa-57c9-9d50-068770d81041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17e624-219a-4e76-bfe0-f49c9ddd4a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f17e624-219a-4e76-bfe0-f49c9ddd4a6d.jpg?1",
             "name": "Inspired Charge",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "3ce43aa0-a3e8-5872-a8a6-68d9031e1221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg?1",
             "name": "Invasion of Belenon // Belenon War Anthem",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Belenon enters the battlefield, create a 2/2 white and blue Knight creature token with vigilance.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "2dad5bd1-5c96-5f61-8635-7412cb471338",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4fb0eb2d-9cb7-4e72-a970-5009b046df2a.jpg?1",
             "name": "Invasion of Belenon // Belenon War Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "2e436661-f64b-5541-b292-12b1644223a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg?1",
             "name": "Invasion of Dominaria // Serra Faithkeeper",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Dominaria enters the battlefield, you gain 4 life and draw a card.",
             "colours": [
@@ -877,7 +877,7 @@
         },
         {
             "id": "5965458e-584a-56fb-be09-3f70ebe73a32",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e784d3d-0c6d-4ce5-beb5-edd2adb32385.jpg?1",
             "name": "Invasion of Dominaria // Serra Faithkeeper",
             "text": "Flying, vigilance",
             "colours": [
@@ -911,7 +911,7 @@
         },
         {
             "id": "df0b4721-e8a6-510a-9edb-5d57333b6a96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg?1",
             "name": "Invasion of Gobakhan // Lightshield Array",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Gobakhan enters the battlefield, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A spell cast this way costs {2} more to cast.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "7c593a6e-750f-5c06-80df-c34807edee6f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11798730-6788-4e0b-a828-b46cab1a4fa7.jpg?1",
             "name": "Invasion of Gobakhan // Lightshield Array",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature that attacked this turn.\nSacrifice Lightshield Array: Creatures you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "d4b67c58-ae61-580e-8ced-c43619cfddad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg?1",
             "name": "Invasion of Theros // Ephara, Ever-Sheltering",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Theros enters the battlefield, search your library for an Aura, God, or Demigod card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1012,7 +1012,7 @@
         },
         {
             "id": "8dc7be16-fed7-53d9-9b98-7134ceb60053",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/433e9f1c-9d6c-4c7e-89d0-79595b4331f2.jpg?1",
             "name": "Invasion of Theros // Ephara, Ever-Sheltering",
             "text": "Ephara, Ever-Sheltering has lifelink and indestructible as long as you control at least three other enchantments.\nWhenever another enchantment enters the battlefield under your control, draw a card.",
             "colours": [
@@ -1051,7 +1051,7 @@
         },
         {
             "id": "e8af9899-ac9c-5ff7-9878-55622a285ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535b69f-247d-49c9-97e1-d988700578ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0535b69f-247d-49c9-97e1-d988700578ab.jpg?1",
             "name": "Kithkin Billyrider",
             "text": "Double strike",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "65baf74e-2939-5b3b-9053-d5a7f267ac1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a3108b-c33d-47c5-984b-01fa257fbd79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a3108b-c33d-47c5-984b-01fa257fbd79.jpg?1",
             "name": "Knight of the New Coalition",
             "text": "Vigilance\nWhen Knight of the New Coalition enters the battlefield, create a 2/2 white and blue Knight creature token with vigilance.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "0712e12f-dc48-5b5c-ac2c-eb8f0cf2654f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2ad652-2406-491a-9f22-23e974f943d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2ad652-2406-491a-9f22-23e974f943d7.jpg?1",
             "name": "Knight-Errant of Eos",
             "text": "Convoke\nWhen Knight-Errant of Eos enters the battlefield, look at the top six cards of your library. You may reveal up to two creature cards with mana value X or less from among them, where X is the number of creatures that convoked Knight-Errant of Eos. Put the revealed cards into your hand, then shuffle.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "a1c727fd-d8f3-59b5-9e88-b596fa679eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4705327-ada6-4575-82fc-351e183d060e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4705327-ada6-4575-82fc-351e183d060e.jpg?1",
             "name": "Kor Halberd",
             "text": "Equipped creature gets +1/+1 and has vigilance.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -1192,7 +1192,7 @@
         },
         {
             "id": "b4b99f38-8045-5d35-b12c-40c33e22398b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75665c2f-a100-4e3f-be8e-b5cc3c9a090b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75665c2f-a100-4e3f-be8e-b5cc3c9a090b.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "3dcce702-d858-5130-827e-3f63c095fc1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d387b608-ba4e-49c8-bd81-37594290a352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d387b608-ba4e-49c8-bd81-37594290a352.jpg?1",
             "name": "Norn's Inquisitor",
             "text": "When Norn's Inquisitor enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a permanent you control transforms into a Phyrexian, put a +1/+1 counter on it.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "359ca627-9ce4-5a52-bf23-c2dca18b383c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9ed068-b6bb-4c9e-a8c9-56aa9b62037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9ed068-b6bb-4c9e-a8c9-56aa9b62037a.jpg?1",
             "name": "Phyrexian Awakening",
             "text": "When Phyrexian Awakening enters the battlefield, incubate 4. (Create an Incubator token with four +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have vigilance.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "ddd1fd9d-3ec3-5af1-adae-35b61941bdad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150e17b1-b9fd-4ec4-b305-19596fed14d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150e17b1-b9fd-4ec4-b305-19596fed14d1.jpg?1",
             "name": "Phyrexian Censor",
             "text": "Each player can't cast more than one non-Phyrexian spell each turn.\nNon-Phyrexian creatures enter the battlefield tapped.",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "b44e9229-6462-5b47-831e-daef839767d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f7d03-ce71-498d-9dc5-2bd853ac0eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f86f7d03-ce71-498d-9dc5-2bd853ac0eae.jpg?1",
             "name": "Progenitor Exarch",
             "text": "When Progenitor Exarch enters the battlefield, incubate 3 X times. (To incubate 3, create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n{T}: Transform target Incubator token you control.",
             "colours": [
@@ -1371,7 +1371,7 @@
         },
         {
             "id": "8775e1c4-d96b-5bca-8cc9-364e4aa488a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a41675-47dd-40ca-a30c-0fd0faa32b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a41675-47dd-40ca-a30c-0fd0faa32b76.jpg?1",
             "name": "Realmbreaker's Grasp",
             "text": "Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "e9cb003e-7de4-5372-bc97-f6cd8dc3f530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc278d1-2ea4-4fbc-95cd-a9cd48c3c630.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc278d1-2ea4-4fbc-95cd-a9cd48c3c630.jpg?1",
             "name": "Scrollshift",
             "text": "Exile up to one target artifact, creature, or enchantment you control, then return it to the battlefield under its owner's control.\nDraw a card.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "414521ac-f25b-58d3-ba5d-82790106f43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccc29cc-025d-402e-9fe3-75998eb290c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ccc29cc-025d-402e-9fe3-75998eb290c9.jpg?1",
             "name": "Seal from Existence",
             "text": "Ward {3} (Whenever this enchantment becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nWhen Seal from Existence enters the battlefield, exile target nonland permanent an opponent controls until Seal from Existence leaves the battlefield.",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "4f4fe6e0-e113-52d4-873c-65e65d7aaa70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg?1",
             "name": "Seraph of New Capenna // Seraph of New Phyrexia",
             "text": "Flying\n{4}{PB}: Transform Seraph of New Capenna. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "3df0348a-a010-5942-b904-7dd413b965b3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fbd9ed1d-1972-4db8-bc43-b05b94956aa0.jpg?1",
             "name": "Seraph of New Capenna // Seraph of New Phyrexia",
             "text": "Flying\nWhenever Seraph of New Phyrexia attacks, you may sacrifice another creature or artifact. If you do, Seraph of New Phyrexia gets +2/+1 until end of turn.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "795ae882-8aec-5edb-b730-f7a0b0f692ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65b178-51d6-4dcb-a1cc-4b4dcb2237cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65b178-51d6-4dcb-a1cc-4b4dcb2237cd.jpg?1",
             "name": "Sigiled Sentinel",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nVigilance",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "ea6aa768-26f2-551f-8de6-b6d890b6ddeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg?1",
             "name": "Sun-Blessed Guardian // Furnace-Blessed Conqueror",
             "text": "{5}{PR}: Transform Sun-Blessed Guardian. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "fd832534-e3fb-59c5-94a7-f2f5e8550dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/630ce82b-0d09-4a12-8cba-0b0ed8415128.jpg?1",
             "name": "Sun-Blessed Guardian // Furnace-Blessed Conqueror",
             "text": "Whenever Furnace-Blessed Conqueror attacks, create a tapped and attacking token that's a copy of it. Put a +1/+1 counter on that token for each +1/+1 counter on Furnace-Blessed Conqueror. Sacrifice that token at the beginning of the next end step.",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "1bdd1570-7bbf-5ccd-852f-d039e915f36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ad785-21bb-4ce6-8776-31c67259fb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194ad785-21bb-4ce6-8776-31c67259fb99.jpg?1",
             "name": "Sunder the Gateway",
             "text": "Choose one \u2014\n\u2022 Destroy target nontoken artifact or enchantment an opponent controls. Incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n\u2022 Incubate 2, then transform an Incubator token you control.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "548dad81-f2d5-5ea8-9f87-c4c5180531f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e29c7d-ed4b-4eff-b3c2-d99e5b63ef8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e29c7d-ed4b-4eff-b3c2-d99e5b63ef8d.jpg?1",
             "name": "Sunfall",
             "text": "Exile all creatures. Incubate X, where X is the number of creatures exiled this way. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "8f0d8947-f6e0-5c14-9f2e-33a2207789db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d25ee5-0348-4206-bb6a-ccb0a599ac87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d25ee5-0348-4206-bb6a-ccb0a599ac87.jpg?1",
             "name": "Surge of Salvation",
             "text": "You and permanents you control gain hexproof until end of turn. Prevent all damage that black and/or red sources would deal to creatures you control this turn.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "527289ca-ea89-5689-97a9-ae4a123af455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0461fc-4298-45b9-90a0-939093cf2544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa0461fc-4298-45b9-90a0-939093cf2544.jpg?1",
             "name": "Swordsworn Cavalier",
             "text": "Swordsworn Cavalier has first strike as long as another Knight entered the battlefield under your control this turn.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "1cebb976-4b7f-5a14-9516-e39a1448982e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg?1",
             "name": "Tarkir Duneshaper // Burnished Dunestomper",
             "text": "{4}{PG}: Transform Tarkir Duneshaper. Activate only as a sorcery. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "99ef5197-f618-5e8b-b1dd-53d0bd4a3f91",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/d/fdc37acc-05ba-4457-8a03-d635497bfb1b.jpg?1",
             "name": "Tarkir Duneshaper // Burnished Dunestomper",
             "text": "Trample",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "7891b026-a621-528d-8f5c-88275c01a42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e206f2-1647-4456-8f2f-b67d053413e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e206f2-1647-4456-8f2f-b67d053413e2.jpg?1",
             "name": "Tiller of Flesh",
             "text": "Whenever you cast a spell that targets one or more permanents, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "e072239c-cdd4-5c50-81aa-e0e9f6dd90e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e5b49-c53f-4bf7-aac0-950d8708b957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277e5b49-c53f-4bf7-aac0-950d8708b957.jpg?1",
             "name": "Zhalfirin Lancer",
             "text": "Whenever another Knight enters the battlefield under your control, Zhalfirin Lancer gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -1927,7 +1927,7 @@
         },
         {
             "id": "9c0d4dd4-9e6a-52df-9fae-1ebaae2cef64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd05f97-ef8b-4cbe-a44b-6501aa5895b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd05f97-ef8b-4cbe-a44b-6501aa5895b0.jpg?1",
             "name": "Artistic Refusal",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one or both \u2014\n\u2022 Counter target spell.\n\u2022 Draw two cards, then discard a card.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "84c0a7a0-fb6f-5f65-b507-1949a6fd0ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee12ba-0e6c-485a-a1ff-61726ed72fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee12ba-0e6c-485a-a1ff-61726ed72fea.jpg?1",
             "name": "Assimilate Essence",
             "text": "Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "86f660a5-fced-5666-9897-ab5934298dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2ef728-a2c7-45ee-8594-372ed135b482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be2ef728-a2c7-45ee-8594-372ed135b482.jpg?1",
             "name": "Astral Wingspan",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEnchant creature\nWhen Astral Wingspan enters the battlefield, draw a card.\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "83a150cd-77d8-5da7-8bd2-8473c18df7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg?1",
             "name": "Captive Weird // Compleated Conjurer",
             "text": "Defender\n{3}{PR}: Transform Captive Weird. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "cf9d64bd-02a1-5daa-9252-76858b5582b0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70668650-0fb1-4486-a4e6-ab9a12be5626.jpg?1",
             "name": "Captive Weird // Compleated Conjurer",
             "text": "When this creature transforms into Compleated Conjurer, exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "0f61067d-d21c-5372-8054-d1e435158cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98db9ed-b43f-4bc1-b7a9-ce03a534d992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98db9ed-b43f-4bc1-b7a9-ce03a534d992.jpg?1",
             "name": "Change the Equation",
             "text": "Choose one \u2014\n\u2022 Counter target spell with mana value 2 or less.\n\u2022 Counter target red or green spell with mana value 6 or less.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "b239cf87-e26c-5275-a650-1c3c3376281a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febaaeae-5c0d-45fa-8169-b27b4996f18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febaaeae-5c0d-45fa-8169-b27b4996f18e.jpg?1",
             "name": "Chrome Host Seedshark",
             "text": "Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "5f3302d4-f77b-56f3-b18e-1ad3d185777e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5de96-9418-48f1-a18e-01a0108c4f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf5de96-9418-48f1-a18e-01a0108c4f97.jpg?1",
             "name": "Complete the Circuit",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nYou may cast sorcery spells this turn as though they had flash.\nWhen you next cast an instant or sorcery spell this turn, copy that spell twice. You may choose new targets for the copies.",
             "colours": [
@@ -2200,7 +2200,7 @@
         },
         {
             "id": "4c1e5421-f0ee-5abd-ad68-da29b8591b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e896a87-2a93-488c-a0c9-0bed8404da44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e896a87-2a93-488c-a0c9-0bed8404da44.jpg?1",
             "name": "Corruption of Towashi",
             "text": "When Corruption of Towashi enters the battlefield, incubate 4. (Create an Incubator token with four +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a permanent you control transforms or a permanent enters the battlefield under your control transformed, you may draw a card. Do this only once each turn.",
             "colours": [
@@ -2232,7 +2232,7 @@
         },
         {
             "id": "aee89355-5f7a-5530-9012-ad9ab95794f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a63d530-27c3-4cd7-ac37-c62b5a1afbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a63d530-27c3-4cd7-ac37-c62b5a1afbc1.jpg?1",
             "name": "Disturbing Conversion",
             "text": "Flash\nEnchant creature\nWhen Disturbing Conversion enters the battlefield, each player mills two cards.\nEnchanted creature gets -X/-0, where X is the number of cards in its controller's graveyard.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "c6edefa8-2e82-5760-b6ee-445150680c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bcc71f-72ec-4a76-9393-ed3ea61eeeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bcc71f-72ec-4a76-9393-ed3ea61eeeb6.jpg?1",
             "name": "Ephara's Dispersal",
             "text": "This spell costs {2} less to cast if it targets an attacking creature.\nReturn target creature to its owner's hand. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "84493439-d81e-5c50-a524-e170afd22783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e14dfd2-5805-46ef-bd19-dab7ac23fbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e14dfd2-5805-46ef-bd19-dab7ac23fbce.jpg?1",
             "name": "Expedition Lookout",
             "text": "Defender\nAs long as an opponent has eight or more cards in their graveyard, Expedition Lookout can attack as though it didn't have defender and it can't be blocked.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "765f0bb5-c883-58b2-9e65-212834b9f124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4303347-3fbd-4bbd-ab3f-e7ddbe0e0a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4303347-3fbd-4bbd-ab3f-e7ddbe0e0a9d.jpg?1",
             "name": "Eyes of Gitaxias",
             "text": "Incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nDraw a card.",
             "colours": [
@@ -2365,7 +2365,7 @@
         },
         {
             "id": "35c573b6-b4d8-59f2-923f-7223c868cf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3005f-a1c7-4ef5-911f-ccc0752f4181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3005f-a1c7-4ef5-911f-ccc0752f4181.jpg?1",
             "name": "Faerie Mastermind",
             "text": "Flash\nFlying\nWhenever an opponent draws their second card each turn, you draw a card.\n{3}{U}: Each player draws a card.",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "d29e2736-9775-5925-8cd0-063b9c2f8377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c55aff-baed-4fb5-a490-abd59b8df5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c55aff-baed-4fb5-a490-abd59b8df5e7.jpg?1",
             "name": "Furtive Analyst",
             "text": "Vigilance\n{2}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "da0e250a-8c63-5cdd-9ac4-549af96fb39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6bdac3-6762-41a4-821f-ab7034a823d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6bdac3-6762-41a4-821f-ab7034a823d9.jpg?1",
             "name": "Halo-Charged Skaab",
             "text": "When Halo-Charged Skaab enters the battlefield, each player mills two cards. Then you may put an instant, sorcery, or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "40c6e7c7-e2c5-5236-afc6-70c301dbe951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg?1",
             "name": "Invasion of Arcavios // Invocation of the Founders",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Arcavios enters the battlefield, search your library, graveyard, and/or outside the game for an instant or sorcery card you own, reveal it, and put it into your hand. If you search your library this way, shuffle.",
             "colours": [
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "1b2ed823-6eb1-5e0d-9fab-8e7178f35b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/c/1c3f661d-b9f7-48e7-afe3-3eaea1022bc1.jpg?1",
             "name": "Invasion of Arcavios // Invocation of the Founders",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "e339a3a4-dcfa-5779-947b-7aa1481b9416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg?1",
             "name": "Invasion of Kamigawa // Rooftop Saboteurs",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kamigawa enters the battlefield, tap target artifact or creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "f5384e38-600f-587f-8fae-a8fdad027948",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/3140320d-b932-441f-bff3-9bdf4419b88a.jpg?1",
             "name": "Invasion of Kamigawa // Rooftop Saboteurs",
             "text": "Flying\nWhenever Rooftop Saboteurs deals combat damage to a player or battle, draw a card.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "cbc5d711-26a7-5768-bdd9-068b2bcae46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1",
             "name": "Invasion of Segovia // Caetus, Sea Tyrant of Segovia",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Segovia enters the battlefield, create two 1/1 blue Kraken creature tokens with trample.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "ef32858d-de8a-551e-bb10-d6192d08575a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1",
             "name": "Invasion of Segovia // Caetus, Sea Tyrant of Segovia",
             "text": "Noncreature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a noncreature spell pays for {1} or one mana of that creature's color.)\nAt the beginning of your end step, untap up to four target creatures.",
             "colours": [
@@ -2676,7 +2676,7 @@
         },
         {
             "id": "fc751992-539f-5695-8aa2-8e975ffa4257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg?1",
             "name": "Invasion of Vryn // Overloaded Mage-Ring",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Vryn enters the battlefield, draw three cards, then discard a card.",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "24b7b0b2-0d94-56ea-850f-daf1e45316b3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0ef6737-8e85-42ca-8ee6-6a34f9462de3.jpg?1",
             "name": "Invasion of Vryn // Overloaded Mage-Ring",
             "text": "{1}, {T}, Sacrifice Overloaded Mage-Ring: Copy target spell you control. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "22cadebf-e1f3-5dd2-81e9-1d03df5ba19c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "Ward {2}\nWhenever you cast a noncreature spell with mana value 3 or greater, draw a card.\n{3}{U}: Exile Jin-Gitaxias, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you have seven or more cards in hand.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "0e47ebf9-0f24-5bee-bb02-659dc1091f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41c83142-b948-4ee5-a486-41306d2bb411.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Draw cards equal to the number of cards in your hand. You have no maximum hand size for as long as you control The Great Synthesis.\nII \u2014 Return all non-Phyrexian creatures to their owners' hands.\nIII \u2014 You may cast any number of spells from your hand without paying their mana costs. Exile The Great Synthesis, then return it to the battlefield (front face up).",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "483f55d5-9d00-5331-ab50-a399e68e25e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b8650-c283-4e54-abdc-32ec2fb1ee34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b8650-c283-4e54-abdc-32ec2fb1ee34.jpg?1",
             "name": "Meeting of Minds",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDraw two cards.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "b60a0ef7-8c55-55bc-ba53-8fd4e237308d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e758594-a48c-4508-b400-9028aec07f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e758594-a48c-4508-b400-9028aec07f63.jpg?1",
             "name": "Moment of Truth",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one into your graveyard, and one on the bottom of your library.",
             "colours": [
@@ -2883,7 +2883,7 @@
         },
         {
             "id": "581753a4-5c7f-5725-a4bf-dbd34b53f671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81752db1-374e-4723-b695-a2f4a634dfc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81752db1-374e-4723-b695-a2f4a634dfc6.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "b73fffa7-51b1-5fae-82bb-89875bb67803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b35399-79af-49fa-989e-867a85320cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b35399-79af-49fa-989e-867a85320cc2.jpg?1",
             "name": "Oculus Whelp",
             "text": "Flying\nAs long as you control a transformed permanent, Oculus Whelp has \"When Oculus Whelp dies, draw a card.\"",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "517c80f0-cce0-567d-8afe-be3ad2e4378d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0749c3c-e3f7-4c96-8c5b-4fd2401544c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0749c3c-e3f7-4c96-8c5b-4fd2401544c4.jpg?1",
             "name": "Omen Hawker",
             "text": "{T}: Add {C}{U}. Spend this mana only to activate abilities.",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "7052a910-3f61-591c-975d-ede410366cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2aa39-b876-4136-8e16-5272a8083235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d2aa39-b876-4136-8e16-5272a8083235.jpg?1",
             "name": "Oracle of Tragedy",
             "text": "When Oracle of Tragedy enters the battlefield or dies, choose one \u2014\n\u2022 Draw a card, then discard a card.\n\u2022 Shuffle up to four target cards with mana value 3 or greater from your graveyard into your library.",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "f509a4a7-371d-5cdf-a1f1-9d9f14d843a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg?1",
             "name": "Order of the Mirror // Order of the Alabaster Host",
             "text": "{3}{PW}: Transform Order of the Mirror. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "81b01436-3c4a-51ec-b1f0-934e86998490",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/103295ed-5ddc-4528-8848-4fd2cfec4b88.jpg?1",
             "name": "Order of the Mirror // Order of the Alabaster Host",
             "text": "Whenever Order of the Alabaster Host becomes blocked by a creature, that creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "64a870eb-541a-58a5-8cb7-fd559e887104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44178ece-af31-4a94-88bc-c9ce43bb4573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44178ece-af31-4a94-88bc-c9ce43bb4573.jpg?1",
             "name": "Preening Champion",
             "text": "Flying\nWhen Preening Champion enters the battlefield, create a 1/1 blue and red Elemental creature token.",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "c6f3f40a-42aa-5cad-a6bf-9f7c360df93b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6cb380-0b4d-4870-abef-928eb63e1702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6cb380-0b4d-4870-abef-928eb63e1702.jpg?1",
             "name": "Protocol Knight",
             "text": "When Protocol Knight enters the battlefield, tap target creature an opponent controls. Put a stun counter on that creature if you control another Knight. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "1a77ddbe-cad0-5218-aaa4-aef1fffd80f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Whenever you cast a legendary spell, untap Rona, Herald of Invasion.\n{T}: Draw a card, then discard a card.\n{5}{PB}: Transform Rona. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "b5774468-1349-515d-8c5c-3dc68af274b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f487b582-e73f-4325-939f-95fc5a9aba49.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Rona, Tolarian Obliterator, that source's controller exiles a card from their hand at random. If it's a land card, you may put it onto the battlefield under your control. Otherwise, you may cast it without paying its mana cost.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "bfc8c7a6-0555-5f96-b205-fd538a85e78d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3934d535-740d-471a-bbf1-c3b26b1cd596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3934d535-740d-471a-bbf1-c3b26b1cd596.jpg?1",
             "name": "Saiba Cryptomancer",
             "text": "Flash\nBackup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nHexproof",
             "colours": [
@@ -3279,7 +3279,7 @@
         },
         {
             "id": "57c9d0e8-2a3f-5228-bcd7-a1601b8dd51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41634103-7b58-4feb-84b7-90a07a7b474f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41634103-7b58-4feb-84b7-90a07a7b474f.jpg?1",
             "name": "See Double",
             "text": "This spell can't be copied.\nChoose one. If an opponent has eight or more cards in their graveyard, you may choose both.\n\u2022 Copy target spell. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)\n\u2022 Create a token that's a copy of target creature.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "ead58232-6381-547e-a0f9-6469dfa2c0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg?1",
             "name": "Skyclave Aerialist // Skyclave Invader",
             "text": "Flying\n{4}{PG}: Transform Skyclave Aerialist. Activate only as a sorcery. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "cef44c52-0795-527c-a36b-b2fc261b12c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/d/cd1c8e1a-bd38-47a2-a55a-682ebaede960.jpg?1",
             "name": "Skyclave Aerialist // Skyclave Invader",
             "text": "Flying\nWhen this creature transforms into Skyclave Invader, look at the top card of your library. If it's a land card, you may put it onto the battlefield. If you don't put the card onto the battlefield, put it into your hand.",
             "colours": [
@@ -3387,7 +3387,7 @@
         },
         {
             "id": "f4a9a10d-9a82-5eb0-9aa8-af99f3cb81e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38211d78-ebac-4150-ac11-7613a0e9e1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38211d78-ebac-4150-ac11-7613a0e9e1bc.jpg?1",
             "name": "Stasis Field",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 0/2, has defender, and loses all other abilities.",
             "colours": [
@@ -3421,7 +3421,7 @@
         },
         {
             "id": "6d806afd-7420-53d9-a2fd-ca8addde747c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e67031a-8216-4c66-b6fb-6628bd02d279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e67031a-8216-4c66-b6fb-6628bd02d279.jpg?1",
             "name": "Temporal Cleansing",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nThe owner of target nonland permanent puts it into their library second from the top or on the bottom.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "ad033535-2012-500a-889e-30c04412eb60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eaa0946-591f-4136-9d8a-e56934151383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eaa0946-591f-4136-9d8a-e56934151383.jpg?1",
             "name": "Thunderhead Squadron",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying",
             "colours": [
@@ -3488,7 +3488,7 @@
         },
         {
             "id": "13e438e3-6cd6-53e5-af6c-7ef09f3328d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e943948-2326-4446-9a16-64d6040b8856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e943948-2326-4446-9a16-64d6040b8856.jpg?1",
             "name": "Tidal Terror",
             "text": "Whenever Tidal Terror attacks, you may tap two other untapped creatures you control. If you do, Tidal Terror can't be blocked this turn.\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "c2b13953-70a5-56a2-89dc-9adf21b1b847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261c7e6-45be-44d1-8855-026359ba0ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3261c7e6-45be-44d1-8855-026359ba0ae7.jpg?1",
             "name": "Transcendent Message",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDraw X cards.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "7e5b0fce-5ae0-5236-b91c-acabfbdb2303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140cd8bd-b74d-4cb1-b78f-8de3cbd878ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140cd8bd-b74d-4cb1-b78f-8de3cbd878ff.jpg?1",
             "name": "Wicked Slumber",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTap up to two target creatures. Put a stun counter on either of them. Then put a stun counter on either of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "ae8d627b-b79f-5d94-8a63-62e388fc397a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38a32bc-133d-43d1-a6e3-80d39fe53d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38a32bc-133d-43d1-a6e3-80d39fe53d32.jpg?1",
             "name": "Xerex Strobe-Knight",
             "text": "Flying, vigilance\n{T}: Create a 2/2 white and blue Knight creature token with vigilance. Activate only if you've cast two or more spells this turn.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "bf85254c-6f84-5361-bad5-9046e741ae35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678966b-65f1-405c-b8db-5f2d4f434933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9678966b-65f1-405c-b8db-5f2d4f434933.jpg?1",
             "name": "Zephyr Singer",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying, vigilance\nWhen Zephyr Singer enters the battlefield, put a flying counter on each creature that convoked it.",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "0c677ddd-6fb1-5796-96fd-80610f7dc420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e446a380-0316-46f7-8ac9-22bce773b35f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e446a380-0316-46f7-8ac9-22bce773b35f.jpg?1",
             "name": "Zhalfirin Shapecraft",
             "text": "Target creature has base power and toughness 4/3 until end of turn.\nDraw a card.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "d612a3cf-a485-522b-969b-b50936b74689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg?1",
             "name": "Aetherblade Agent // Gitaxian Mindstinger",
             "text": "Deathtouch\n{4}{PU}: Transform Aetherblade Agent. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "05c89823-6d2e-5e16-8777-1b77d3b91f07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dad34ae5-56b4-4394-be02-e043dc1cc23d.jpg?1",
             "name": "Aetherblade Agent // Gitaxian Mindstinger",
             "text": "Deathtouch\nWhenever Gitaxian Mindstinger deals combat damage to a player or battle, draw a card.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "09cd09c6-ac3d-52dc-a45e-6d05da8946c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5931746-a55c-4528-9e4a-ee15edab3489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5931746-a55c-4528-9e4a-ee15edab3489.jpg?1",
             "name": "Archpriest of Shadows",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following abilities until end of turn.)\nDeathtouch\nWhenever this creature deals combat damage to a player or battle, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "2a3b4d0a-e5cf-5393-89e0-1ba98f03a416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "{T}, Sacrifice another creature or artifact: Ayara, Widow of the Realm deals X damage to target opponent or battle and you gain X life, where X is the sacrificed permanent's mana value.\n{5}{PR}: Transform Ayara. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "e3b6a0b8-2443-5d5b-bc0c-82d30ea98fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a21b1734-a773-4107-95c1-b44d5ccdfd82.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "At the beginning of combat on your turn, return up to one target artifact or creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -3884,7 +3884,7 @@
         },
         {
             "id": "878df494-8ec3-5ce0-a767-dd7ff9887f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28f5de4-2af6-44ff-9bb8-d874f8ae7dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28f5de4-2af6-44ff-9bb8-d874f8ae7dd1.jpg?1",
             "name": "Bladed Battle-Fan",
             "text": "Flash\nWhen Bladed Battle-Fan enters the battlefield, attach it to target creature you control. That creature gains indestructible until end of turn.\nEquipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "4bbc42a7-93f9-5bf6-ae70-9ed837ead736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg?1",
             "name": "Blightreaper Thallid // Blightsower Thallid",
             "text": "{3}{PG}: Transform Blightreaper Thallid. Activate only as a sorcery. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -3953,7 +3953,7 @@
         },
         {
             "id": "fbed7b16-3eee-50d6-af2b-9aba65b01c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1150ea9-02b5-4767-a529-6149d758830e.jpg?1",
             "name": "Blightreaper Thallid // Blightsower Thallid",
             "text": "When this creature transforms into Blightsower Thallid or dies, create a 1/1 green Phyrexian Saproling creature token.",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "cbf09c2e-4b98-5515-bed2-acc88b271c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ddcca8-5720-4341-acce-c6694ddc97f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ddcca8-5720-4341-acce-c6694ddc97f8.jpg?1",
             "name": "Bloated Processor",
             "text": "Sacrifice another Phyrexian: Put a +1/+1 counter on Bloated Processor.\nWhen Bloated Processor dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4026,7 +4026,7 @@
         },
         {
             "id": "4a780c9f-3977-586b-920c-13da1c8190b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf51a76-7a57-4462-ae18-a19e817e49e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf51a76-7a57-4462-ae18-a19e817e49e5.jpg?1",
             "name": "Breach the Multiverse",
             "text": "Each player mills ten cards. For each player, choose a creature or planeswalker card in that player's graveyard. Put those cards onto the battlefield under your control. Then each creature you control becomes a Phyrexian in addition to its other types.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "b6042cec-eb85-5a31-b729-a15a673f9c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05864d3a-d8bb-4ddf-b721-883632050cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05864d3a-d8bb-4ddf-b721-883632050cb1.jpg?1",
             "name": "Collective Nightmare",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets -3/-3 until end of turn.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "148007dd-8693-50fa-ae28-4e8e637e57b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc23af5-18dd-45f9-8d82-76b48aaf6d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc23af5-18dd-45f9-8d82-76b48aaf6d4d.jpg?1",
             "name": "Compleated Huntmaster",
             "text": "{1}, {T}, Sacrifice another creature or artifact: Incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "b196febd-040f-55aa-822c-5afa8f2f3467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7311ade8-eb75-40f8-b018-668762aa3b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7311ade8-eb75-40f8-b018-668762aa3b77.jpg?1",
             "name": "Consuming Aetherborn",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nLifelink",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "e8fc0534-d9f4-5af9-9f53-b2489537693d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg?1",
             "name": "Corrupted Conviction",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -4195,7 +4195,7 @@
         },
         {
             "id": "846e8d52-88bf-54d0-970f-683200563df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a02f-128c-44aa-b708-6fcda34b40c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec1a02f-128c-44aa-b708-6fcda34b40c0.jpg?1",
             "name": "Deadly Derision",
             "text": "Destroy target creature or planeswalker. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4227,7 +4227,7 @@
         },
         {
             "id": "8335547d-394e-516d-b59d-fc2d7bc62b34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef82b33-82ba-4521-846b-e651764ef46d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ef82b33-82ba-4521-846b-e651764ef46d.jpg?1",
             "name": "Dreg Recycler",
             "text": "{T}, Sacrifice an artifact or creature: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "5bf30b58-4e66-518a-910a-a6743fe3270f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616a548-269b-4530-97e8-c690ccc138f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4616a548-269b-4530-97e8-c690ccc138f3.jpg?1",
             "name": "Etched Familiar",
             "text": "When Etched Familiar dies, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "5d2c1a88-6d9d-5200-a449-889f784047eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f1afa2-ca71-49cf-953b-d5dfc60c178f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f1afa2-ca71-49cf-953b-d5dfc60c178f.jpg?1",
             "name": "Etched Host Doombringer",
             "text": "When Etched Host Doombringer enters the battlefield, choose one \u2014\n\u2022 Target opponent loses 2 life and you gain 2 life.\n\u2022 Choose target battle. If an opponent protects it, remove three defense counters from it. Otherwise, put three defense counters on it.",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "e3375bac-5213-5713-a179-2fdc54ab1211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c18b7-5321-4793-b54a-e48e39548b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358c18b7-5321-4793-b54a-e48e39548b9c.jpg?1",
             "name": "Failed Conversion",
             "text": "Enchant creature\nEnchanted creature gets -4/-4.\nWhen enchanted creature dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -4367,7 +4367,7 @@
         },
         {
             "id": "d4ded43a-bc1b-5515-a7fe-8175c49af3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4dcdb-6939-4d9f-8921-549e0ddc9f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4dcdb-6939-4d9f-8921-549e0ddc9f63.jpg?1",
             "name": "Final Flourish",
             "text": "Kicker\u2014\nSacrifice an artifact or creature. (You may sacrifice an artifact or creature in addition to any other costs as you cast this spell.)\nTarget creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -6/-6 until end of turn instead.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "bd071b93-b495-5b56-9ebd-428d1acd9688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9184bc57-0a16-4abf-a13a-6a03a175c28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9184bc57-0a16-4abf-a13a-6a03a175c28a.jpg?1",
             "name": "Flitting Guerrilla",
             "text": "Flying\nWhen Flitting Guerrilla dies, each player mills two cards. Then you may exile Flitting Guerrilla. When you do, put target creature or battle card from your graveyard on top of your library. (To mill two cards, a player puts the top two cards of their library into their graveyard.)",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "711db069-e298-51d4-8727-b6ae3a519647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e08244-bbdb-402a-8dde-93e17d989467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e08244-bbdb-402a-8dde-93e17d989467.jpg?1",
             "name": "Gift of Compleation",
             "text": "When Gift of Compleation enters the battlefield, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever a Phyrexian you control dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "0ec53856-8bfd-55a3-89b7-9046b9298633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ca46ac-0698-4651-940d-3fd20c266b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ca46ac-0698-4651-940d-3fd20c266b74.jpg?1",
             "name": "Glistening Deluge",
             "text": "All creatures get -1/-1 until end of turn. Creatures that are green and/or white get an additional -2/-2 until end of turn.",
             "colours": [
@@ -4498,7 +4498,7 @@
         },
         {
             "id": "c72ac6cf-c8c3-5d60-ab9e-727c9d99700d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a5338-133f-486d-9f73-0896226685c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025a5338-133f-486d-9f73-0896226685c0.jpg?1",
             "name": "Gloomfang Mauler",
             "text": "Swampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)\nBackup 2 (When this creature enters the battlefield, put two +1/+1 counters on target creature. If that's another creature, it gains the following ability until end of turn.)\nMenace",
             "colours": [
@@ -4532,7 +4532,7 @@
         },
         {
             "id": "1808ef40-f81c-5bab-aebc-1a93006dc2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22f11a1-0cbd-4b36-8dbd-37ba29ad4608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22f11a1-0cbd-4b36-8dbd-37ba29ad4608.jpg?1",
             "name": "Grafted Butcher",
             "text": "When Grafted Butcher enters the battlefield, Phyrexians you control gain menace until end of turn.\nOther Phyrexians you control get +1/+1.\n{3}{B}, Sacrifice an artifact or creature: Return Grafted Butcher from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "5c3009e4-70bf-5056-ab83-6d4d9d02faa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ce3c9-869d-461c-a3de-c8add3786f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ce3c9-869d-461c-a3de-c8add3786f73.jpg?1",
             "name": "Hoarding Broodlord",
             "text": "Convoke\nFlying\nWhen Hoarding Broodlord enters the battlefield, search your library for a card, exile it face down, then shuffle. For as long as that card remains exiled, you may play it.\nSpells you cast from exile have convoke.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "31077d0e-7d23-55d1-96c2-ee2dbc5b3d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fd7350-cc97-4c35-a072-2c826984293c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91fd7350-cc97-4c35-a072-2c826984293c.jpg?1",
             "name": "Ichor Drinker",
             "text": "Lifelink\n{B}, Exile Ichor Drinker from your graveyard: Incubate 2. Activate only as a sorcery. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "1f287881-df53-54b7-99d6-e9df29aeeb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd86fbf-eac2-456b-b4bb-437ff9be9b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd86fbf-eac2-456b-b4bb-437ff9be9b58.jpg?1",
             "name": "Ichor Shade",
             "text": "At the beginning of your end step, if an artifact or creature was put into a graveyard from the battlefield this turn, put a +1/+1 counter on Ichor Shade.",
             "colours": [
@@ -4675,7 +4675,7 @@
         },
         {
             "id": "4ecd4a4b-3934-5b33-b0cd-8f5c61331745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg?1",
             "name": "Invasion of Eldraine // Prickle Faeries",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Eldraine enters the battlefield, target opponent discards two cards.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "528c8dd2-e305-5493-996a-6cd03f11c757",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/2/92f5b177-b0c6-4573-b860-f75dad1941bd.jpg?1",
             "name": "Invasion of Eldraine // Prickle Faeries",
             "text": "Flying\nAt the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Prickle Faeries deals 2 damage to them.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "b97d18bf-f859-5188-98ea-bfdb84d91964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg?1",
             "name": "Invasion of Fiora // Marchesa, Resolute Monarch",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Fiora enters the battlefield, choose one or both \u2014\n\u2022 Destroy all legendary creatures.\n\u2022 Destroy all nonlegendary creatures.",
             "colours": [
@@ -4777,7 +4777,7 @@
         },
         {
             "id": "2eeb81d4-1282-5f31-9dff-76d8ebe172fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3af679b-6ee6-4a1d-8ec3-b659bdd90b4a.jpg?1",
             "name": "Invasion of Fiora // Marchesa, Resolute Monarch",
             "text": "Menace, deathtouch\nWhenever Marchesa, Resolute Monarch attacks, remove all counters from up to one target permanent.\nAt the beginning of your upkeep, if you haven't been dealt combat damage since your last turn, you draw a card and you lose 1 life.",
             "colours": [
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "adf06d13-4f72-51fe-8b96-df213a3941b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg?1",
             "name": "Invasion of Innistrad // Deluge of the Dead",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nFlash\nWhen Invasion of Innistrad enters the battlefield, target creature an opponent controls gets -13/-13 until end of turn.",
             "colours": [
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "4a1dac0f-7fc1-5e78-91c1-5af53d133fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77720d2e-2b7b-492b-852c-eea5061eb31b.jpg?1",
             "name": "Invasion of Innistrad // Deluge of the Dead",
             "text": "When Deluge of the Dead enters the battlefield, create two 2/2 black Zombie creature tokens.\n{2}{B}: Exile target card from a graveyard. If it was a creature card, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "37d884b9-a129-58ec-a9ec-3b61b61adcc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg?1",
             "name": "Invasion of Ulgrotha // Grandmother Ravi Sengir",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ulgrotha enters the battlefield, it deals 3 damage to any other target and you gain 3 life.",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "8d6f011b-0bd6-599e-a9dc-07a16dc43efd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49ec5e00-22f4-486e-8e99-e950725f6fbc.jpg?1",
             "name": "Invasion of Ulgrotha // Grandmother Ravi Sengir",
             "text": "Flying\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Grandmother Ravi Sengir and you gain 1 life.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "03574893-04b3-586b-963e-595c72b7ac26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edec35-1770-47f0-9ad2-32e597ee0327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70edec35-1770-47f0-9ad2-32e597ee0327.jpg?1",
             "name": "Merciless Repurposing",
             "text": "Exile target creature. Incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "7617a5c3-3301-5c60-b514-eb1a762343ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750b2090-7fd4-4048-a148-9a5fc7b6f265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750b2090-7fd4-4048-a148-9a5fc7b6f265.jpg?1",
             "name": "Mirrodin Avenged",
             "text": "Destroy target creature that was dealt damage this turn.\nDraw a card.",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "fe3bcbc2-40c4-5b15-bcbf-b3e15b654303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg?1",
             "name": "Nezumi Freewheeler // Hideous Fleshwheeler",
             "text": "Menace\nWhen Nezumi Freewheeler enters the battlefield, each player mills three cards. (To mill three cards, a player puts the top three cards of their library into their graveyard.)\n{5}{PW}: Transform Nezumi Freewheeler. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "55077e0d-30dd-5a2b-be8d-1dffc1513f47",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/6/76b5e289-6bc4-48ee-8d5b-6989bab9f901.jpg?1",
             "name": "Nezumi Freewheeler // Hideous Fleshwheeler",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature transforms into Hideous Fleshwheeler, put target permanent card with mana value 2 or less from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -5088,7 +5088,7 @@
         },
         {
             "id": "f6bc7bfc-139a-5296-bf60-ac7d7316a3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36fbff8-471e-4cf8-8946-e1e5cdf598af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36fbff8-471e-4cf8-8946-e1e5cdf598af.jpg?1",
             "name": "Nezumi Informant",
             "text": "When Nezumi Informant enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -5123,7 +5123,7 @@
         },
         {
             "id": "3e847461-bae5-5c9e-a3b5-7bd4d4db18ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be7576-bea6-4c20-b594-a058115f7acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be7576-bea6-4c20-b594-a058115f7acf.jpg?1",
             "name": "Phyrexian Gargantua",
             "text": "When Phyrexian Gargantua enters the battlefield, you draw two cards and you lose 2 life.",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "69c9d713-f7ce-55af-970e-16680c9eaa05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492e9369-0ca3-4c31-b747-75d615daf6e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492e9369-0ca3-4c31-b747-75d615daf6e4.jpg?1",
             "name": "Pile On",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature or planeswalker. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -5192,7 +5192,7 @@
         },
         {
             "id": "78652a5e-d320-544b-8aba-8c47ce17b0e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b66ef5-9b93-4042-a618-c1ade83d0004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b66ef5-9b93-4042-a618-c1ade83d0004.jpg?1",
             "name": "Render Inert",
             "text": "Remove up to five counters from target permanent.\nDraw a card.",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "45c68d58-8ce4-52c1-b749-16706a1a5878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e7386-4c2d-4fa9-b499-fa3681f2a50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e7386-4c2d-4fa9-b499-fa3681f2a50e.jpg?1",
             "name": "Scorn-Blade Berserker",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\n{1}, Sacrifice this creature: Draw a card.",
             "colours": [
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "a08e899a-7d8a-5ee1-932d-e880bcf8ee51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "Menace\nWhen Sheoldred enters the battlefield, each opponent sacrifices a nontoken creature or planeswalker.\n{4}{B}: Exile Sheoldred, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if an opponent has eight or more cards in their graveyard.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "1ac03fbd-8157-528f-a87f-352a9a484b23",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 For each opponent, destroy up to one target creature or planeswalker that player controls.\nII \u2014 Each opponent discards three cards, then mills three cards.\nIII \u2014 Put all creature cards from all graveyards onto the battlefield under your control. Exile The True Scriptures, then return it to the battlefield (front face up).",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "aeec7051-9526-5a9c-aea4-7035abb819f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65721bc1-87fa-45b9-8b45-ee77c1aab6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65721bc1-87fa-45b9-8b45-ee77c1aab6ac.jpg?1",
             "name": "Tenured Oilcaster",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nTenured Oilcaster gets +3/+0 as long as an opponent has eight or more cards in their graveyard.\nWhenever Tenured Oilcaster attacks or blocks, each player mills a card.",
             "colours": [
@@ -5371,7 +5371,7 @@
         },
         {
             "id": "496356ac-34f4-5c6c-ad5d-79820cf2d8c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40511-c9ff-466c-8eb9-cc7afc5c2eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d40511-c9ff-466c-8eb9-cc7afc5c2eab.jpg?1",
             "name": "Traumatic Revelation",
             "text": "Target opponent reveals their hand. You may choose a creature or battle card from it. If you do, that player discards that card. If you don't, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "c36f983d-50ff-5909-8c9f-7947bbb9184a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9825ac-c186-4a10-b9e3-e73b10f75ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9825ac-c186-4a10-b9e3-e73b10f75ed9.jpg?1",
             "name": "Unseal the Necropolis",
             "text": "Each player mills three cards. Then you return up to two creature cards from your graveyard to your hand. (To mill three cards, a player puts the top three cards of their library into their graveyard.)",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "4949a1fa-b375-597d-bc84-b968a2e7ce2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935cb9a2-11ba-45d9-ab38-dea23cecf521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935cb9a2-11ba-45d9-ab38-dea23cecf521.jpg?1",
             "name": "Vanquish the Weak",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "63f7dde0-328f-56f1-b8e4-51b06d85369c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e02737-0193-46e4-a506-cec86a44dc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e02737-0193-46e4-a506-cec86a44dc99.jpg?1",
             "name": "Akki Scrapchomper",
             "text": "{1}{R}, {T}, Sacrifice an artifact or land: Draw a card.",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "fa579150-cda8-5381-9803-494b8e43836a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443cb94-b27e-4a96-93cb-ac7880149bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2443cb94-b27e-4a96-93cb-ac7880149bcc.jpg?1",
             "name": "Beamtown Beatstick",
             "text": "Equipped creature gets +1/+0 and has menace. (It can't be blocked except by two or more creatures.)\nWhenever equipped creature deals combat damage to a player or battle, create a Treasure token.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5536,7 +5536,7 @@
         },
         {
             "id": "ab4c3a79-4131-5e0d-8a5d-2ab2b6374a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed97bf6f-726c-40aa-bc1c-14fa801da96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed97bf6f-726c-40aa-bc1c-14fa801da96a.jpg?1",
             "name": "Bloodfeather Phoenix",
             "text": "Flying\nBloodfeather Phoenix can't block.\nWhenever an instant or sorcery spell you control deals damage to an opponent or battle, you may pay {R}. If you do, return Bloodfeather Phoenix from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "41134eee-5b03-5838-a24a-32dc2950b346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2731e181-f59c-446c-bb86-8f93bfbb10e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2731e181-f59c-446c-bb86-8f93bfbb10e9.jpg?1",
             "name": "Burning Sun's Fury",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nUp to two target creatures each get +2/+0 and gain haste until end of turn.",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "d461f6df-e724-514e-adf2-620f1db0a694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146ea07-ec1c-448d-b67a-dd9f9e27c2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a146ea07-ec1c-448d-b67a-dd9f9e27c2e0.jpg?1",
             "name": "Chandra, Hope's Beacon",
             "text": "Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy. This ability triggers only once each turn.\n+2: Add two mana in any combination of colors.\n+1: Exile the top five cards of your library. Until the end of your next turn, you may cast an instant or sorcery spell from among those exiled cards.\n\u2212X: Chandra, Hope's Beacon deals X damage to each of up to two targets.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "69abc720-8184-5efb-bc12-97be81a628d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f455cc1-a822-44ef-ba7c-bfcff69bd45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f455cc1-a822-44ef-ba7c-bfcff69bd45e.jpg?1",
             "name": "City on Fire",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf a source you control would deal damage to a permanent or player, it deals triple that damage instead.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "d75d30f3-a8e5-562e-a291-8a942d99aeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6eb966-67af-4b18-8899-4a99a5179aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6eb966-67af-4b18-8899-4a99a5179aa3.jpg?1",
             "name": "Coming In Hot",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "1bc06916-8692-57f2-a049-5363d143baa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample\nWhen Etali, Primal Conqueror enters the battlefield, each player exiles cards from the top of their library until they exile a nonland card. You may cast any number of spells from among the nonland cards exiled this way without paying their mana costs.\n{9}{PG}: Transform Etali. Activate only as a sorcery.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "725d2df6-2ca9-569f-80b7-6c712d1252a8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/5/95c14c4d-6c16-4826-8d93-d89ad04aee09.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample, indestructible\nWhenever Etali, Primal Sickness deals combat damage to a player, they get that many poison counters. (A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "6b853553-2cfe-524e-957d-ef2b9caefe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e317d1d-3f20-4f0d-8b1e-31df351e8f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e317d1d-3f20-4f0d-8b1e-31df351e8f83.jpg?1",
             "name": "Fearless Skald",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nDouble strike",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "de0a0345-c529-5f44-8e54-fb8018f07fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445b3315-6587-4d57-ab7e-faab1eec0241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445b3315-6587-4d57-ab7e-faab1eec0241.jpg?1",
             "name": "Furnace Gremlin",
             "text": "{1}{R}: Furnace Gremlin gets +1/+0 until end of turn.\nWhen Furnace Gremlin dies, incubate X, where X is its power. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "ccf715cf-070a-5307-a393-9d7d0dfa6cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d142ded-a2df-41b0-9c02-056b5f34abab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d142ded-a2df-41b0-9c02-056b5f34abab.jpg?1",
             "name": "Furnace Host Charger",
             "text": "Haste\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "b180f6a6-fc1e-51fe-9dba-8cc306ef3b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91bfea6-0e80-4239-bede-7cb971e64c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91bfea6-0e80-4239-bede-7cb971e64c1a.jpg?1",
             "name": "Furnace Reins",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gains haste and \"Whenever this creature deals combat damage to a player or battle, create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "03c6c7c8-907d-55b0-820c-770c50278eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2551b01-4d88-47f3-b54d-96ec03e093f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2551b01-4d88-47f3-b54d-96ec03e093f8.jpg?1",
             "name": "Hangar Scrounger",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nWhenever this creature becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "eb3c64c2-668f-56e4-9c57-2a0f6ae768a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg?1",
             "name": "Harried Artisan // Phyrexian Skyflayer",
             "text": "Haste\n{3}{PW}: Transform Harried Artisan. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "721b95f0-3f0d-5b80-956f-d65b10fe6d65",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73e92389-4bd2-492e-b4d6-d7cb6baedc41.jpg?1",
             "name": "Harried Artisan // Phyrexian Skyflayer",
             "text": "Flying, haste",
             "colours": [
@@ -6035,7 +6035,7 @@
         },
         {
             "id": "396a6fd6-95a9-56cf-9d40-ace4e35efb8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f649bb-b163-44ae-801f-8884143c407f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f649bb-b163-44ae-801f-8884143c407f.jpg?1",
             "name": "Into the Fire",
             "text": "Choose one \u2014\n\u2022 Into the Fire deals 2 damage to each creature, planeswalker, and battle.\n\u2022 Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "f887ddca-842c-53f4-a217-23929168a6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg?1",
             "name": "Invasion of Kaldheim // Pyre of the World Tree",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kaldheim enters the battlefield, exile all cards from your hand, then draw that many cards. Until the end of your next turn, you may play cards exiled this way.",
             "colours": [
@@ -6103,7 +6103,7 @@
         },
         {
             "id": "fe0bf4bd-e649-5c01-9002-2c150cddfaab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7cedd62-efc8-464d-8387-220bb55e07e9.jpg?1",
             "name": "Invasion of Kaldheim // Pyre of the World Tree",
             "text": "Discard a land card: Pyre of the World Tree deals 2 damage to any target.\nWhenever you discard a land card, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6135,7 +6135,7 @@
         },
         {
             "id": "dca11ba5-ee8a-52bc-b12b-a07eecc2a6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg?1",
             "name": "Invasion of Karsus // Refraction Elemental",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Karsus enters the battlefield, it deals 3 damage to each creature and each planeswalker.",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "33309313-7420-515b-93f4-00541b4a3748",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/776b8951-cf15-47ff-b36f-f47706eddb6f.jpg?1",
             "name": "Invasion of Karsus // Refraction Elemental",
             "text": "Ward\u2014\nPay 2 life.\nWhenever you cast a spell, Refraction Elemental deals 2 damage to each opponent.",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "ed1304f7-e0a9-59ab-82e0-73dcb536144f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg?1",
             "name": "Invasion of Mercadia // Kyren Flamewright",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Mercadia enters the battlefield, you may discard a card. If you do, draw two cards.",
             "colours": [
@@ -6237,7 +6237,7 @@
         },
         {
             "id": "5670eab1-caaf-5eb2-a00f-10be900365ff",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/407d6723-bf58-403e-b2ac-ba52c51d356f.jpg?1",
             "name": "Invasion of Mercadia // Kyren Flamewright",
             "text": "{2}{R}, {T}, Discard a card: Create two 1/1 blue and red Elemental creature tokens. Creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -6272,7 +6272,7 @@
         },
         {
             "id": "164bfd10-f6f0-517a-8c97-7a95e09be464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg?1",
             "name": "Invasion of Regatha // Disciples of the Inferno",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Regatha enters the battlefield, it deals 4 damage to another target battle or opponent and 1 damage to up to one target creature.",
             "colours": [
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "0510e909-f1bc-5eae-8bf8-05e0abeaa01a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada79e04-bb69-4c92-a829-014f02b1e06a.jpg?1",
             "name": "Invasion of Regatha // Disciples of the Inferno",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nIf a noncreature source you control would deal damage to a creature, battle, or opponent, it deals that much damage plus 2 instead.",
             "colours": [
@@ -6341,7 +6341,7 @@
         },
         {
             "id": "bb42b46d-365b-58ab-940d-b804f3392633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg?1",
             "name": "Invasion of Tarkir // Defiant Thundermaw",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Tarkir enters the battlefield, reveal any number of Dragon cards from your hand. When you do, Invasion of Tarkir deals X plus 2 damage to any other target, where X is the number of cards revealed this way. (X can be 0.)",
             "colours": [
@@ -6375,7 +6375,7 @@
         },
         {
             "id": "1a45e310-8c99-5f04-a6a2-28c23cc02a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a98f71a0-7c99-4cee-8f70-877e698cca84.jpg?1",
             "name": "Invasion of Tarkir // Defiant Thundermaw",
             "text": "Flying, trample\nWhenever a Dragon you control attacks, it deals 2 damage to any target.",
             "colours": [
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "1caa011e-3b37-56a8-be67-a98323dc568e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac76be5-3a2c-499e-830a-bd02eec517ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac76be5-3a2c-499e-830a-bd02eec517ce.jpg?1",
             "name": "Karsus Depthguard",
             "text": "Defender\nAs long as Karsus Depthguard's power is 5 or greater, it can attack as though it didn't have defender.",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "d76f9500-071d-5566-ba40-451fdc84e22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg?1",
             "name": "Khenra Spellspear // Gitaxian Spellstalker",
             "text": "Trample\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{3}{PU}: Transform Khenra Spellspear. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -6480,7 +6480,7 @@
         },
         {
             "id": "746a6706-038b-5f21-a8c2-4c5d8cd390ef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/c/dc1454ce-bb49-4b4f-bbca-d77387fa4966.jpg?1",
             "name": "Khenra Spellspear // Gitaxian Spellstalker",
             "text": "Trample, ward {2}, prowess, prowess (Each instance of prowess triggers separately.)",
             "colours": [
@@ -6517,7 +6517,7 @@
         },
         {
             "id": "14925070-798b-57b2-ad2e-1d3e817a392d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45a5f4a-2174-4885-aa5a-c4c24cc732f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45a5f4a-2174-4885-aa5a-c4c24cc732f0.jpg?1",
             "name": "Lithomantic Barrage",
             "text": "This spell can't be countered.\nLithomantic Barrage deals 1 damage to target creature or planeswalker. It deals 5 damage instead if that target is white and/or blue.",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "a115dd07-7223-508d-bc8f-2ce057023266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625d6a-3844-4d23-ab35-ee3c3508db8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15625d6a-3844-4d23-ab35-ee3c3508db8d.jpg?1",
             "name": "Marauding Dreadship",
             "text": "Haste\nWhen Marauding Dreadship enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "c43f5199-5712-5eaf-b563-4d5d75158d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d00b8-1373-47b2-9be5-2199e0b12540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d00b8-1373-47b2-9be5-2199e0b12540.jpg?1",
             "name": "Mirran Banesplitter",
             "text": "Flash\nWhen Mirran Banesplitter enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6617,7 +6617,7 @@
         },
         {
             "id": "4fa4326b-3407-5095-84e8-8e9785bc2cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0453fea-3c88-4eb1-818a-9efa01986852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0453fea-3c88-4eb1-818a-9efa01986852.jpg?1",
             "name": "Nahiri's Warcrafting",
             "text": "Nahiri's Warcrafting deals 5 damage to target creature, planeswalker, or battle. Look at the top X cards of your library, where X is the excess damage dealt this way. You may exile one of those cards. Put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -6651,7 +6651,7 @@
         },
         {
             "id": "4f94f436-80a5-509e-80f7-b94f14ac6f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5446057-7330-40b9-a5d9-bad4876337cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5446057-7330-40b9-a5d9-bad4876337cd.jpg?1",
             "name": "Onakke Javelineer",
             "text": "Reach\n{T}: Onakke Javelineer deals 2 damage to target player or battle.",
             "colours": [
@@ -6686,7 +6686,7 @@
         },
         {
             "id": "a7d602db-4417-5f4e-a949-38777439a42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg?1",
             "name": "Pyretic Prankster // Glistening Goremonger",
             "text": "{3}{PB}: Transform Pyretic Prankster. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "218c4856-dfaf-55b4-9e9c-c8e55a96fe7e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee40c4b-2ca3-4cda-bc9e-451455c17adc.jpg?1",
             "name": "Pyretic Prankster // Glistening Goremonger",
             "text": "When Glistening Goremonger dies, each opponent sacrifices an artifact or creature.",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "f97cf180-f553-500e-8855-b8e5c0fe7a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0bb76-075c-49d7-9afb-e5bcf5b654f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d0bb76-075c-49d7-9afb-e5bcf5b654f7.jpg?1",
             "name": "Ral's Reinforcements",
             "text": "Create two 1/1 blue and red Elemental creature tokens.",
             "colours": [
@@ -6790,7 +6790,7 @@
         },
         {
             "id": "a207f344-541a-5dc1-a822-efd277c9f2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd6f04e-e83d-4580-ae3f-583ada848868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd6f04e-e83d-4580-ae3f-583ada848868.jpg?1",
             "name": "Ramosian Greatsword",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEquipped creature gets +3/+1 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6824,7 +6824,7 @@
         },
         {
             "id": "0e5132b6-0c80-531f-9658-d296e3973e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b80ddb-ce55-4ebc-b587-77843abc8bad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b80ddb-ce55-4ebc-b587-77843abc8bad.jpg?1",
             "name": "Rampaging Raptor",
             "text": "Trample, haste\n{2}{R}: Rampaging Raptor gets +2/+0 until end of turn.\nWhenever Rampaging Raptor deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls or battle that player protects.",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "da35ec76-de68-5707-99f4-f4bbc39b3ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ca435-aa84-4d35-80db-d1c74b878b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7ca435-aa84-4d35-80db-d1c74b878b12.jpg?1",
             "name": "Redcap Heelslasher",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nFirst strike",
             "colours": [
@@ -6895,7 +6895,7 @@
         },
         {
             "id": "9b09aa6d-2bf8-5f6e-ab4c-f4a69e733adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6c877a-25f7-4ee7-8cf0-33728ef085fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6c877a-25f7-4ee7-8cf0-33728ef085fc.jpg?1",
             "name": "Scrappy Bruiser",
             "text": "Whenever Scrappy Bruiser attacks, up to one target attacking creature gets +2/+0 and gains trample until end of turn. Return that creature to its owner's hand at end of combat. (Return it only if it's on the battlefield.)",
             "colours": [
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "c1979ee2-33dd-594d-924f-6103265fae36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f156b6-68c2-4787-b3f0-6d1079bb576f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f156b6-68c2-4787-b3f0-6d1079bb576f.jpg?1",
             "name": "Searing Barb",
             "text": "Searing Barb deals 2 damage to any target. If it's a creature, it can't block this turn. Incubate 1. (Create an Incubator token with a +1/+1 counter on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "4eb7630c-5067-5628-b351-e05e2a800134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032720a1-410b-4638-9294-35fd8e27375f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032720a1-410b-4638-9294-35fd8e27375f.jpg?1",
             "name": "Shatter the Source",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one \u2014\n\u2022 Shatter the Source deals 6 damage to target creature, planeswalker, or battle.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "6205b35f-10c1-5a10-8c62-eba899e19b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585631c-bd41-4b48-aac4-4b6f5636ecd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e585631c-bd41-4b48-aac4-4b6f5636ecd5.jpg?1",
             "name": "Shivan Branch-Burner",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying, haste",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "3bb70b19-c736-5fb3-a551-95693a9bf65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04113b3c-cc8f-4b15-9091-f82ea3df2e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04113b3c-cc8f-4b15-9091-f82ea3df2e7c.jpg?1",
             "name": "Stoke the Flames",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nStoke the Flames deals 4 damage to any target.",
             "colours": [
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "d1376554-d4c4-5e0b-bc41-aa8afd8862cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fd9ccb-2cb0-4fe1-9eb0-ba929bb527be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fd9ccb-2cb0-4fe1-9eb0-ba929bb527be.jpg?1",
             "name": "Thrashing Frontliner",
             "text": "Trample\nWhenever Thrashing Frontliner attacks a battle, it gets +1/+1 until end of turn.",
             "colours": [
@@ -7097,7 +7097,7 @@
         },
         {
             "id": "95583254-0f19-52cf-9346-de0db4609b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53088da-25b5-4c7e-9a11-456fbc814dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53088da-25b5-4c7e-9a11-456fbc814dfc.jpg?1",
             "name": "Trailblazing Historian",
             "text": "Haste\n{T}: Another target creature gains haste until end of turn.",
             "colours": [
@@ -7132,7 +7132,7 @@
         },
         {
             "id": "a660e82b-e1fa-52f1-8139-0832830ceb9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "First strike\nWhenever you cast an instant or sorcery spell, Urabrask deals 1 damage to target opponent. Add {R}.\n{R}: Exile Urabrask, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you've cast three or more instant and/or sorcery spells this turn.",
             "colours": [
@@ -7172,7 +7172,7 @@
         },
         {
             "id": "5790e3d9-3748-5267-a643-24a046f64221",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/712fb9e5-bd67-4173-a2d4-061aeb6253b5.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 The Great Work deals 3 damage to target opponent and each creature they control.\nII \u2014 Create three Treasure tokens.\nIII \u2014 Until end of turn, you may cast instant and sorcery spells from any graveyard. If a spell cast this way would be put into a graveyard, exile it instead. Exile The Great Work, then return it to the battlefield (front face up).",
             "colours": [
@@ -7209,7 +7209,7 @@
         },
         {
             "id": "22235f1a-f155-5a62-bd61-7c4612b8f134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69490262-afc2-4692-8fac-b771a972c8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69490262-afc2-4692-8fac-b771a972c8f8.jpg?1",
             "name": "Volcanic Spite",
             "text": "Volcanic Spite deals 3 damage to target creature, planeswalker, or battle. You may put a card from your hand on the bottom of your library. If you do, draw a card.",
             "colours": [
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "8d56aff8-24cd-52df-9b00-c8f445ba7d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbcd466-fb99-4388-a118-4534b85544f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbcd466-fb99-4388-a118-4534b85544f0.jpg?1",
             "name": "Voldaren Thrillseeker",
             "text": "Backup 2 (When this creature enters the battlefield, put two +1/+1 counters on target creature. If that's another creature, it gains the following ability until end of turn.)\n{1}, Sacrifice this creature: It deals damage equal to its power to any target.",
             "colours": [
@@ -7278,7 +7278,7 @@
         },
         {
             "id": "fde50677-361b-5e11-bb17-8cc4833ecbe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a87c5d-5efc-4ceb-b165-27f807117f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a87c5d-5efc-4ceb-b165-27f807117f71.jpg?1",
             "name": "War-Trained Slasher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever War-Trained Slasher attacks a battle, double its power until end of turn.",
             "colours": [
@@ -7313,7 +7313,7 @@
         },
         {
             "id": "86705079-980e-5271-9ec1-b07b2902b9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47999c-12d5-4e1a-a9c1-40a1757007f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a47999c-12d5-4e1a-a9c1-40a1757007f1.jpg?1",
             "name": "Wrenn's Resolve",
             "text": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "7232d6fd-c8be-56cd-a583-70ffe2b5c1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687d3261-dfbf-4c49-986f-20117b7ab5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687d3261-dfbf-4c49-986f-20117b7ab5e7.jpg?1",
             "name": "Ancient Imperiosaur",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTrample, ward {2}\nAncient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.",
             "colours": [
@@ -7381,7 +7381,7 @@
         },
         {
             "id": "64578c5e-b25f-5d84-8ad9-286917bad659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8278069a-bd92-40ee-b7d5-e740dddb00fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8278069a-bd92-40ee-b7d5-e740dddb00fa.jpg?1",
             "name": "Arachnoid Adaptation",
             "text": "Target creature gets +2/+2 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "163c7b7b-41a8-54f5-9f84-8855d010df5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08ed414-77bf-402a-82a8-9d4e1bd627a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08ed414-77bf-402a-82a8-9d4e1bd627a1.jpg?1",
             "name": "Atraxa's Fall",
             "text": "Destroy target artifact, battle, enchantment, or creature with flying.",
             "colours": [
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "6db66913-4386-5360-b5ea-bdcfa3bf7f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007324b3-b8a9-4a32-a5a1-ad78f3a07bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007324b3-b8a9-4a32-a5a1-ad78f3a07bc3.jpg?1",
             "name": "Blighted Burgeoning",
             "text": "Enchant land\nWhen Blighted Burgeoning enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -7479,7 +7479,7 @@
         },
         {
             "id": "fd0a4215-096b-503c-be1c-bf200bf83b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg?1",
             "name": "Bonded Herdbeast // Plated Kilnbeast",
             "text": "{4}{PR}: Transform Bonded Herdbeast. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "71b92adb-fc6e-5078-b47e-c580f4977a05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61972ddb-3421-4f22-a47a-89cea944dd02.jpg?1",
             "name": "Bonded Herdbeast // Plated Kilnbeast",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "cbbc3b8e-2f5f-5d2b-9d4f-831df34c5c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c249d9-37c0-451d-866b-e834c4c57214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c249d9-37c0-451d-866b-e834c4c57214.jpg?1",
             "name": "Chomping Kavu",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nThis creature can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "7d369fb5-4b98-59da-8373-60a0cd03486f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd3ecb-8c11-4a4c-a503-bc29f79a9dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd3ecb-8c11-4a4c-a503-bc29f79a9dcb.jpg?1",
             "name": "Converter Beast",
             "text": "When Converter Beast enters the battlefield, incubate 5. (Create an Incubator token with five +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -7620,7 +7620,7 @@
         },
         {
             "id": "44b98c9b-dffd-51cb-aa88-5d6c645373d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af527344-9d88-4641-8f6d-0263a6797df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af527344-9d88-4641-8f6d-0263a6797df3.jpg?1",
             "name": "Copper Host Crusher",
             "text": "Trample\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "5f6e9fcc-595a-5e82-8fb8-3763af34eea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eef541-6851-4312-ad2b-74f45c7ede6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eef541-6851-4312-ad2b-74f45c7ede6c.jpg?1",
             "name": "Cosmic Hunger",
             "text": "Target creature you control deals damage equal to its power to another target creature, planeswalker, or battle.",
             "colours": [
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "9f709e7c-0304-5a56-b329-1fde6a24ec70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1888c61-dc2d-4a33-9ba4-439d97f490be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1888c61-dc2d-4a33-9ba4-439d97f490be.jpg?1",
             "name": "Crystal Carapace",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has ward {2}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -7722,7 +7722,7 @@
         },
         {
             "id": "1a293440-02ed-5170-b8ed-009c4dfe7659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4066d41-0eb5-4dfd-93ec-2f242c3a27a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4066d41-0eb5-4dfd-93ec-2f242c3a27a4.jpg?1",
             "name": "Deeproot Wayfinder",
             "text": "Whenever Deeproot Wayfinder deals combat damage to a player or battle, surveil 1, then you may return a land card from your graveyard to the battlefield tapped. (To surveil 1, look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -7759,7 +7759,7 @@
         },
         {
             "id": "04f50ac8-456a-56f4-b928-9929e2c759b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1db4e3-e98c-49af-8682-3b7aa20bc31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1db4e3-e98c-49af-8682-3b7aa20bc31e.jpg?1",
             "name": "Doomskar Warrior",
             "text": "Backup 1\nTrample\nWhenever this creature deals combat damage to a player or battle, look at that many cards from the top of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7796,7 +7796,7 @@
         },
         {
             "id": "6ed0ead3-3856-5d56-9318-c2164917a78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bbfb58-8b22-4e8d-991c-855c29964d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bbfb58-8b22-4e8d-991c-855c29964d94.jpg?1",
             "name": "Fertilid's Favor",
             "text": "Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles. Put two +1/+1 counters on up to one target artifact or creature.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "ffae4b2f-c109-58e7-a75a-bb19e59c0a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5443f4f6-a549-4912-a919-69e3570a9933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5443f4f6-a549-4912-a919-69e3570a9933.jpg?1",
             "name": "Glistening Dawn",
             "text": "Incubate X twice, where X is the number of lands you control. (To incubate X, create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -7862,7 +7862,7 @@
         },
         {
             "id": "cf3c3827-be59-5984-b67d-c58aa4aa65e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg?1",
             "name": "Gnottvold Hermit // Chrome Host Hulk",
             "text": "{5}{PU}: Transform Gnottvold Hermit. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "7309a0c9-bca0-50bf-bbda-5da5b519d0c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70b2cdc5-35b9-443d-b499-c8b75c0d0a64.jpg?1",
             "name": "Gnottvold Hermit // Chrome Host Hulk",
             "text": "Whenever Chrome Host Hulk attacks, up to one other target creature has base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -7934,7 +7934,7 @@
         },
         {
             "id": "5933955b-4871-5abd-a7ff-febc0a0997dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg?1",
             "name": "Herbology Instructor // Malady Invoker",
             "text": "When Herbology Instructor enters the battlefield, you gain 3 life.\n{6}{PB}: Transform Herbology Instructor. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -7970,7 +7970,7 @@
         },
         {
             "id": "45bd5089-4189-5e79-b9fe-deda18f0206b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40ab763d-05ee-408d-aeba-eaf18c4f2e21.jpg?1",
             "name": "Herbology Instructor // Malady Invoker",
             "text": "When this creature transforms into Malady Invoker, target creature an opponent controls gets -0/-X until end of turn, where X is Malady Invoker's power.",
             "colours": [
@@ -8007,7 +8007,7 @@
         },
         {
             "id": "73bc51de-a0ad-5cde-a229-3ed3893c4764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg?1",
             "name": "Invasion of Ikoria // Zilortha, Apex of Ikoria",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ikoria enters the battlefield, search your library and/or graveyard for a non-Human creature card with mana value X or less and put it onto the battlefield. If you search your library this way, shuffle.",
             "colours": [
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "1f8a8202-28ff-5337-ba0c-c06acec25162",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/d/5d59c8f2-f6af-40a6-8dfe-8cc45bf231ce.jpg?1",
             "name": "Invasion of Ikoria // Zilortha, Apex of Ikoria",
             "text": "Reach\nFor each non-Human creature you control, you may have that creature assign its combat damage as though it weren't blocked.",
             "colours": [
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "97a63d3c-5572-5795-8a30-cf1b6b11e50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg?1",
             "name": "Invasion of Ixalan // Belligerent Regisaur",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ixalan enters the battlefield, look at the top five cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "ef7a0e27-b71e-5159-b030-cf9107f1508c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fa20fc16-e106-4953-ace4-5ac9c7fec97b.jpg?1",
             "name": "Invasion of Ixalan // Belligerent Regisaur",
             "text": "Trample\nWhenever you cast a spell, Belligerent Regisaur gains indestructible until end of turn.",
             "colours": [
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "41ef2441-1e98-5da7-948d-bc5e8bbd9a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg?1",
             "name": "Invasion of Muraganda // Primordial Plasm",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Muraganda enters the battlefield, put a +1/+1 counter on target creature you control. Then that creature fights up to one target creature you don't control.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "65aa2c3c-4d3e-5c4c-aacd-f2bcb0f03077",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93345804-dda4-42a2-84d4-8fcd376dd2d4.jpg?1",
             "name": "Invasion of Muraganda // Primordial Plasm",
             "text": "At the beginning of combat on your turn, another target creature gets +2/+2 and loses all abilities until end of turn.",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "0f8f82e4-f662-59ad-9cfb-fdf2c97c6519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg?1",
             "name": "Invasion of Shandalar // Leyline Surge",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Shandalar enters the battlefield, return up to three target permanent cards from your graveyard to your hand.",
             "colours": [
@@ -8247,7 +8247,7 @@
         },
         {
             "id": "06b6e4cc-e2f1-5147-bd20-d3305bf41e23",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f80764e-8fa2-44e2-84c6-3b55f1c40ee7.jpg?1",
             "name": "Invasion of Shandalar // Leyline Surge",
             "text": "At the beginning of your upkeep, you may put a permanent card from your hand onto the battlefield.",
             "colours": [
@@ -8279,7 +8279,7 @@
         },
         {
             "id": "f75922b9-2a6f-5a5c-b559-47ea7540601b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg?1",
             "name": "Invasion of Zendikar // Awakened Skyclave",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Zendikar enters the battlefield, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "d9333b7e-78ab-5b78-bc14-8bf10f90645d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8fed056f-a8f5-41ec-a7d2-a80a238872d1.jpg?1",
             "name": "Invasion of Zendikar // Awakened Skyclave",
             "text": "Vigilance, haste\nAs long as Awakened Skyclave is on the battlefield, it's a land in addition to its other types.\n{T}: Add one mana of any color.",
             "colours": [
@@ -8347,7 +8347,7 @@
         },
         {
             "id": "d25063db-c584-5dc9-a74a-9197a27964c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fee189f-539f-48fa-b217-4b2599375364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fee189f-539f-48fa-b217-4b2599375364.jpg?1",
             "name": "Iridescent Blademaster",
             "text": "{3}{G}: Iridescent Blademaster gets +2/+2 until end of turn.",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "f2549ebd-b2ce-5786-9100-ab138485d918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c644650-3861-4a78-9e39-a413b073ddac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c644650-3861-4a78-9e39-a413b073ddac.jpg?1",
             "name": "Kami of Whispered Hopes",
             "text": "If one or more +1/+1 counters would be put on a permanent you control, that many plus one +1/+1 counters are put on that permanent instead.\n{T}: Add X mana of any one color, where X is Kami of Whispered Hopes's power.",
             "colours": [
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "8ec5536e-c434-5e84-9254-faa20f89395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e04eed-9a6c-491b-8f1f-1c76ac40452d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e04eed-9a6c-491b-8f1f-1c76ac40452d.jpg?1",
             "name": "Overgrown Pest",
             "text": "When Overgrown Pest enters the battlefield, look at the top five cards of your library. You may reveal a land or double-faced card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "6355315b-6fa3-58fa-99d2-82e0c3766444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9eee658-29e8-4ab5-8a0e-31f2f28a9a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9eee658-29e8-4ab5-8a0e-31f2f28a9a92.jpg?1",
             "name": "Ozolith, the Shattered Spire",
             "text": "If one or more +1/+1 counters would be put on an artifact or creature you control, that many plus one +1/+1 counters are put on it instead.\n{1}{G}, {T}: Put a +1/+1 counter on target artifact or creature you control. Activate only as a sorcery.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [
@@ -8488,7 +8488,7 @@
         },
         {
             "id": "065979d3-a601-53b0-bed3-b641a4578fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a87c5d2-3ebc-442b-8618-963cfc63855f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a87c5d2-3ebc-442b-8618-963cfc63855f.jpg?1",
             "name": "Placid Rottentail",
             "text": "Vigilance\n{2}{G}, Exile Placid Rottentail from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
             "colours": [
@@ -8523,7 +8523,7 @@
         },
         {
             "id": "b30f5f2b-979b-529e-9491-ebf7901a8f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach\n{6}{PW}: Transform Polukranos Reborn. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -8562,7 +8562,7 @@
         },
         {
             "id": "a5e6fc8e-1736-53cc-99d8-6f13aeb02207",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/47f7d313-8333-41fe-8bfa-c96774dac228.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach, lifelink\nWhenever Polukranos, Engine of Ruin or another nontoken Hydra you control dies, create a 3/3 green and white Phyrexian Hydra creature token with reach and a 3/3 green and white Phyrexian Hydra creature token with lifelink.",
             "colours": [
@@ -8603,7 +8603,7 @@
         },
         {
             "id": "b70f34ca-edcf-5dd0-b476-5b5ff48a55f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6104d4-d0af-40da-8227-14243d778e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6104d4-d0af-40da-8227-14243d778e96.jpg?1",
             "name": "Portent Tracker",
             "text": "{T}: Untap target land.\n{T}: Choose target battle. If an opponent protects it, remove a defense counter from it. Otherwise, put a defense counter on it. Activate only as a sorcery.",
             "colours": [
@@ -8638,7 +8638,7 @@
         },
         {
             "id": "db9add44-2c3d-5ad8-9451-9de9efcccf51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a225cb30-9f3e-4cfa-bdd6-a7c73c95ea2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a225cb30-9f3e-4cfa-bdd6-a7c73c95ea2b.jpg?1",
             "name": "Ravenous Sailback",
             "text": "When Ravenous Sailback enters the battlefield, choose one \u2014\n\u2022 Ravenous Sailback gains haste until end of turn.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "ca9510e8-80ef-532d-9981-1f81b7bd07e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17b083-413b-4a09-a935-ac27594e3bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb17b083-413b-4a09-a935-ac27594e3bd6.jpg?1",
             "name": "Sandstalker Moloch",
             "text": "Flash\nWhen Sandstalker Moloch enters the battlefield, if an opponent cast a blue and/or black spell this turn, look at the top four cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8706,7 +8706,7 @@
         },
         {
             "id": "2577e6a8-fe84-52fe-8a87-393ac850b70c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084a8b94-0c5d-41e0-88e4-fe91ab92c09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084a8b94-0c5d-41e0-88e4-fe91ab92c09d.jpg?1",
             "name": "Seed of Hope",
             "text": "Mill two cards. You may put a permanent card from among the milled cards into your hand. You gain 2 life. (To mill two cards, put the top two cards of your library into your graveyard.)",
             "colours": [
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "43cfb7a4-6ff3-53f3-967b-33ff90b9b854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fabc49f-b665-4c56-b06e-03220f7918bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fabc49f-b665-4c56-b06e-03220f7918bb.jpg?1",
             "name": "Serpent-Blade Assailant",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nDeathtouch",
             "colours": [
@@ -8773,7 +8773,7 @@
         },
         {
             "id": "9388256e-aec2-5c7c-84cc-6b8f17a43d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf989a4d-3209-4071-b6e9-d2b99372ec10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf989a4d-3209-4071-b6e9-d2b99372ec10.jpg?1",
             "name": "Storm the Seedcore",
             "text": "Distribute four +1/+1 counters among up to four target creatures you control. Creatures you control gain vigilance and trample until end of turn.",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "a05db8bf-aab9-5c75-bcbc-2a31620a613a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f9565-4c04-449d-b337-0eff3fd0c295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f9565-4c04-449d-b337-0eff3fd0c295.jpg?1",
             "name": "Streetwise Negotiator",
             "text": "Backup 1 (When this creature enters the battlefield, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\nThis creature assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "ef292507-fbe1-5e94-9c29-fd0e3db6dd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb51be0-6a2e-464a-86d1-aa36179c8c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb51be0-6a2e-464a-86d1-aa36179c8c18.jpg?1",
             "name": "Tandem Takedown",
             "text": "Up to two target creatures you control each get +1/+0 until end of turn. They each deal damage equal to their power to another target creature, planeswalker, or battle.",
             "colours": [
@@ -8872,7 +8872,7 @@
         },
         {
             "id": "6c01b60d-9dbe-5bfb-8222-729179484003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e0ef1-a8e0-4c0a-a996-3eee89e37fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08e0ef1-a8e0-4c0a-a996-3eee89e37fee.jpg?1",
             "name": "Tangled Skyline",
             "text": "When Tangled Skyline enters the battlefield, you gain 5 life and incubate 5. (Create an Incubator token with five +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control have reach.",
             "colours": [
@@ -8904,7 +8904,7 @@
         },
         {
             "id": "78f5a1bd-f235-5043-93e1-38e5a67e85e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73cd60-cd89-4c7a-85a6-e0ae34ca101b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f73cd60-cd89-4c7a-85a6-e0ae34ca101b.jpg?1",
             "name": "Timberland Ancient",
             "text": "Reach, trample\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -8938,7 +8938,7 @@
         },
         {
             "id": "57d30a16-afbb-53e4-95de-51c16de0c9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cdeaba-fc21-44e6-bf99-aa1ff379401b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cdeaba-fc21-44e6-bf99-aa1ff379401b.jpg?1",
             "name": "Tribute to the World Tree",
             "text": "Whenever a creature enters the battlefield under your control, draw a card if its power is 3 or greater. Otherwise, put two +1/+1 counters on it.",
             "colours": [
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "dd70e577-5c14-534e-9eb6-538f726184c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e20076-5d24-4c59-b707-6d20e121032f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e20076-5d24-4c59-b707-6d20e121032f.jpg?1",
             "name": "Vengeant Earth",
             "text": "Target creature or land you control becomes a 4/4 Elemental creature with haste in addition to its other types until end of turn. It must be blocked this turn if able.",
             "colours": [
@@ -9004,7 +9004,7 @@
         },
         {
             "id": "7bd0a200-ca22-525a-9ffb-8f23a28efca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "Trample, reach\nWhen Vorinclex enters the battlefield, search your library for up to two Forest cards, reveal them, put them into your hand, then shuffle.\n{6}{G}{G}: Exile Vorinclex, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "5fa1e219-b6b0-56f2-8985-570df6b5859c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e24b5289-d3b5-4b4d-bb37-69bf2c3b48bc.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill ten cards. Put up to two creature cards from among the milled cards onto the battlefield.\nII \u2014 Distribute seven +1/+1 counters among any number of target creatures you control.\nIII \u2014 Until end of turn, creatures you control gain \"{1}: This creature fights target creature you don't control.\" Exile The Grand Evolution, then return it to the battlefield (front face up).",
             "colours": [
@@ -9081,7 +9081,7 @@
         },
         {
             "id": "751681dd-268d-5f09-963d-c029240b6e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0007efdf-417d-48a7-b119-3a2fda3e1158.jpg?1",
             "name": "War Historian",
             "text": "Reach\nWar Historian has indestructible as long as it attacked a battle this turn.",
             "colours": [
@@ -9116,7 +9116,7 @@
         },
         {
             "id": "d0c19a31-3c02-5d49-aab0-762e9ec34b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b29bf-0b64-410f-9a92-c88e5615c27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675b29bf-0b64-410f-9a92-c88e5615c27f.jpg?1",
             "name": "Wary Thespian",
             "text": "When Wary Thespian enters the battlefield or dies, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "a924b6af-95bf-58de-8749-b9b65c1ef0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c6fc26-df6e-44de-96e6-a6e34086edc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c6fc26-df6e-44de-96e6-a6e34086edc2.jpg?1",
             "name": "Wildwood Escort",
             "text": "When Wildwood Escort enters the battlefield, return target creature or battle card from your graveyard to your hand.\nIf Wildwood Escort would die, exile it instead.",
             "colours": [
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "c7c4e1f7-fb55-55f9-9604-27fbb5207e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f807d91-b157-44e8-a431-49782184f876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f807d91-b157-44e8-a431-49782184f876.jpg?1",
             "name": "Wrenn and Realmbreaker",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n+1: Up to one target land you control becomes a 3/3 Elemental creature with vigilance, hexproof, and haste until your next turn. It's still a land.\n\u22122: Mill three cards. You may put a permanent card from among the milled cards into your hand.\n\u22127: You get an emblem with \"You may play lands and cast permanent spells from your graveyard.\"",
             "colours": [
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "bb6bd117-b187-5639-ac7b-9e0a1dd0e7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc43a788-ab06-4d28-b45a-aa47801d6ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc43a788-ab06-4d28-b45a-aa47801d6ace.jpg?1",
             "name": "Baral and Kari Zev",
             "text": "First strike, menace\nWhenever you cast your first instant or sorcery spell each turn, you may cast a spell with lesser mana value that shares a card type with it from your hand without paying its mana cost. If you don't, create First Mate Ragavan, a legendary 2/1 red Monkey Pirate creature token. It gains haste until end of turn.",
             "colours": [
@@ -9264,7 +9264,7 @@
         },
         {
             "id": "4ecf9f14-5822-5de8-a2dd-5da5402e547b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bbf1c1-2868-4c9e-b5c4-1aae86faed6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bbf1c1-2868-4c9e-b5c4-1aae86faed6c.jpg?1",
             "name": "Borborygmos and Fblthp",
             "text": "Whenever Borborygmos and Fblthp enters the battlefield or attacks, draw a card, then you may discard any number of land cards. When you discard one or more cards this way, Borborygmos and Fblthp deals twice that much damage to target creature.\n{1}{U}: Put Borborygmos and Fblthp into its owner's library third from the top.",
             "colours": [
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "e70776dd-0124-5827-a12d-87ad71b27d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977c15c9-2aad-4d1d-86a6-1f9d78ad7af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977c15c9-2aad-4d1d-86a6-1f9d78ad7af6.jpg?1",
             "name": "Botanical Brawler",
             "text": "Trample\nBotanical Brawler enters the battlefield with two +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another permanent you control, if it's the first time +1/+1 counters have been put on that permanent this turn, put a +1/+1 counter on Botanical Brawler.",
             "colours": [
@@ -9346,7 +9346,7 @@
         },
         {
             "id": "500fe84b-f90d-5866-8f58-6548bfc23e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db1ae7b-ed48-409f-8d50-07c7e8c6c128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db1ae7b-ed48-409f-8d50-07c7e8c6c128.jpg?1",
             "name": "Djeru and Hazoret",
             "text": "As long as you have one or fewer cards in hand, Djeru and Hazoret has vigilance and haste.\nWhenever Djeru and Hazoret attacks, look at the top six cards of your library. You may exile a legendary creature card from among them. Put the rest on the bottom of your library in a random order. Until end of turn, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -9387,7 +9387,7 @@
         },
         {
             "id": "ec98507f-48c7-53e0-ad56-3402563ea371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda000f-3cf7-48b6-96ff-c23a3a64eab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbda000f-3cf7-48b6-96ff-c23a3a64eab5.jpg?1",
             "name": "Drana and Linvala",
             "text": "Flying, vigilance\nActivated abilities of creatures your opponents control can't be activated.\nDrana and Linvala has all activated abilities of all creatures your opponents control. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -9428,7 +9428,7 @@
         },
         {
             "id": "5a286ada-73b5-5856-9c9c-27a042626a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3227c07-9ef2-46a6-9b4f-bbd6ef12f4a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3227c07-9ef2-46a6-9b4f-bbd6ef12f4a5.jpg?1",
             "name": "Elvish Vatkeeper",
             "text": "When Elvish Vatkeeper enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n{5}: Transform target Incubator token you control. Double the number of +1/+1 counters on it.",
             "colours": [
@@ -9465,7 +9465,7 @@
         },
         {
             "id": "ece93143-6cae-5066-ae97-56ec212fcbf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa2d03-7713-44d4-8fca-45c6f77b174b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa2d03-7713-44d4-8fca-45c6f77b174b.jpg?1",
             "name": "Errant and Giada",
             "text": "Flash\nFlying\nYou may look at the top card of your library any time.\nYou may cast spells with flash or flying from the top of your library.",
             "colours": [
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "454df7bf-2a50-5d57-9c8a-edefb554ce55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ec900f-1e31-4440-a75a-20b256734d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ec900f-1e31-4440-a75a-20b256734d5b.jpg?1",
             "name": "Ghalta and Mavren",
             "text": "Trample\nWhenever you attack, choose one \u2014\n\u2022 Create a tapped and attacking X/X green Dinosaur creature token with trample, where X is the greatest power among other attacking creatures.\n\u2022 Create X 1/1 white Vampire creature tokens with lifelink, where X is the number of other attacking creatures.",
             "colours": [
@@ -9548,7 +9548,7 @@
         },
         {
             "id": "0afd0974-f8bd-5cbe-af35-86e4f4558a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c299066-dfdd-47a3-85e6-225508ba95fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c299066-dfdd-47a3-85e6-225508ba95fe.jpg?1",
             "name": "Glissa, Herald of Predation",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Incubate 2 twice. (To incubate 2, create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\n\u2022 Transform all Incubator tokens you control.\n\u2022 Phyrexians you control gain first strike and deathtouch until end of turn.",
             "colours": [
@@ -9590,7 +9590,7 @@
         },
         {
             "id": "49918a1c-eab4-5b05-b651-e06992738166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb5f0cc-c826-4e7b-882c-63f6e51fa932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb5f0cc-c826-4e7b-882c-63f6e51fa932.jpg?1",
             "name": "Halo Forager",
             "text": "Flying\nWhen Halo Forager enters the battlefield, you may pay {X}. When you do, you may cast target instant or sorcery card with mana value X from a graveyard without paying its mana cost. If that spell would be put into a graveyard, exile it instead.",
             "colours": [
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "41f6ad11-2d47-523a-a78d-5bdabfaed957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81039daf-0d54-4474-a833-fa287ec10cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81039daf-0d54-4474-a833-fa287ec10cf9.jpg?1",
             "name": "Hidetsugu and Kairi",
             "text": "Flying\nWhen Hidetsugu and Kairi enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.\nWhen Hidetsugu and Kairi dies, exile the top card of your library. Target opponent loses life equal to its mana value. If it's an instant or sorcery card, you may cast it without paying its mana cost.",
             "colours": [
@@ -9671,7 +9671,7 @@
         },
         {
             "id": "a325d9e9-2b5f-5ada-837a-414caf84e043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa97506-b943-4443-96b1-1b49f57d80aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa97506-b943-4443-96b1-1b49f57d80aa.jpg?1",
             "name": "Inga and Esika",
             "text": "Creatures you control have vigilance and \"{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\"\nWhenever you cast a creature spell, if three or more mana from creatures was spent to cast it, draw a card.",
             "colours": [
@@ -9712,7 +9712,7 @@
         },
         {
             "id": "60f7db0d-743f-59a4-b62f-16cef07ef47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg?1",
             "name": "Invasion of Alara // Awaken the Maelstrom",
             "text": "When Invasion of Alara enters the battlefield, exile cards from the top of your library until you exile two nonland cards with mana value 4 or less. You may cast one of those two cards without paying its mana cost. Put one of them into your hand. Then put the other cards exiled this way on the bottom of your library in a random order.",
             "colours": [
@@ -9754,7 +9754,7 @@
         },
         {
             "id": "99550742-8719-53e7-b929-7ee18bef6eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/318c363b-61cc-4e2f-8f86-a4287539ea07.jpg?1",
             "name": "Invasion of Alara // Awaken the Maelstrom",
             "text": "Awaken the Maelstrom is all colors.\nTarget player draws two cards. You may put an artifact card from your hand onto the battlefield. Create a token that's a copy of a permanent you control. Distribute three +1/+1 counters among one, two, or three creatures you control. Destroy target permanent an opponent controls.",
             "colours": [
@@ -9794,7 +9794,7 @@
         },
         {
             "id": "f25152f1-f5fd-599e-834c-aff8a94df8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg?1",
             "name": "Invasion of Amonkhet // Lazotep Convert",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Amonkhet enters the battlefield, each player mills three cards, then each opponent discards a card and you draw a card. (To mill three cards, a player puts the top three cards of their library into their graveyard.)",
             "colours": [
@@ -9830,7 +9830,7 @@
         },
         {
             "id": "7a132681-9f0b-51ec-b747-c53dab4ea9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/981f091a-17f8-412e-9752-69070ebed4ea.jpg?1",
             "name": "Invasion of Amonkhet // Lazotep Convert",
             "text": "You may have Lazotep Convert enter the battlefield as a copy of any creature card in a graveyard, except it's a 4/4 black Zombie in addition to its other colors and types.",
             "colours": [
@@ -9866,7 +9866,7 @@
         },
         {
             "id": "617af43d-0e84-5a50-b980-b92a4e45e159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg?1",
             "name": "Invasion of Azgol // Ashen Reaper",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Azgol enters the battlefield, target player sacrifices a creature or planeswalker and loses 1 life.",
             "colours": [
@@ -9902,7 +9902,7 @@
         },
         {
             "id": "d6283d24-3a58-5381-8ff6-1254bd4474ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae2e1244-f05b-45f9-8afc-59f190524798.jpg?1",
             "name": "Invasion of Azgol // Ashen Reaper",
             "text": "Menace\nAt the beginning of your end step, put a +1/+1 counter on Ashen Reaper if a permanent was put into a graveyard from the battlefield this turn.",
             "colours": [
@@ -9939,7 +9939,7 @@
         },
         {
             "id": "dc9b6914-986c-5dc5-8095-24a47c030db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg?1",
             "name": "Invasion of Ergamon // Truga Cliffcharger",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Ergamon enters the battlefield, create a Treasure token. Then you may discard a card. If you do, draw a card.",
             "colours": [
@@ -9975,7 +9975,7 @@
         },
         {
             "id": "0fa42ca1-2fc6-57f1-8423-cfd0073387f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e0fc49-f765-4bd1-a2b9-23e703388b50.jpg?1",
             "name": "Invasion of Ergamon // Truga Cliffcharger",
             "text": "Trample\nWhen Truga Cliffcharger enters the battlefield, you may discard a card. If you do, search your library for a land or battle card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "a73ff0d3-fd1e-54d2-8684-b836331a9130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg?1",
             "name": "Invasion of Kaladesh // Aetherwing, Golden-Scale Flagship",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kaladesh enters the battlefield, create a 1/1 colorless Thopter artifact creature token with flying.",
             "colours": [
@@ -10047,7 +10047,7 @@
         },
         {
             "id": "9c5743e3-6ccd-5049-bba3-56445bf06363",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f7231f6-8adc-4a68-9984-e56b974c087b.jpg?1",
             "name": "Invasion of Kaladesh // Aetherwing, Golden-Scale Flagship",
             "text": "Flying\nAetherwing, Golden-Scale Flagship's power is equal to the number of artifacts you control.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "8ce4e9f6-62a8-58f3-98e9-48937bd0aefc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg?1",
             "name": "Invasion of Kylem // Valor's Reach Tag Team",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Kylem enters the battlefield, up to two target creatures each get +2/+0 and gain vigilance and haste until end of turn.",
             "colours": [
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "9d26a474-3b3e-587b-ba8d-377bf5f95d68",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7ac3a39-b6a6-4647-bb6e-e82057704f8b.jpg?1",
             "name": "Invasion of Kylem // Valor's Reach Tag Team",
             "text": "Create two 3/2 red and white Warrior creature tokens with \"Whenever this creature and at least one other creature token attack, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -10155,7 +10155,7 @@
         },
         {
             "id": "2073ab80-b648-533b-8e0d-e8971f4642c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg?1",
             "name": "Invasion of Lorwyn // Winnowing Forces",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Lorwyn enters the battlefield, destroy target non-Elf creature an opponent controls with power X or less, where X is the number of lands you control.",
             "colours": [
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "dfa36ea4-066b-55e6-be1d-6b90b55d140c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/93f623da-616e-4067-9ea8-5dfbeef8ce0b.jpg?1",
             "name": "Invasion of Lorwyn // Winnowing Forces",
             "text": "Winnowing Forces's power and toughness are each equal to the number of lands you control.",
             "colours": [
@@ -10228,7 +10228,7 @@
         },
         {
             "id": "6b84c19a-052e-50f0-aa21-b4eb7eed4505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg?1",
             "name": "Invasion of Moag // Bloomwielder Dryads",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Moag enters the battlefield, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -10264,7 +10264,7 @@
         },
         {
             "id": "f711e6fd-636d-5e86-96bc-92b415b65b58",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e454bf31-5aa0-4109-a3f5-c3f9cc838682.jpg?1",
             "name": "Invasion of Moag // Bloomwielder Dryads",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your end step, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -10300,7 +10300,7 @@
         },
         {
             "id": "870a6cde-d063-5193-b61e-6e9552ad6078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg?1",
             "name": "Invasion of New Capenna // Holy Frazzle-Cannon",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of New Capenna enters the battlefield, you may sacrifice an artifact or creature. When you do, exile target artifact or creature an opponent controls.",
             "colours": [
@@ -10336,7 +10336,7 @@
         },
         {
             "id": "6217cf93-4374-5136-8342-cdc0121000e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f5926c8e-8049-418e-9a84-f8558e5ba9d1.jpg?1",
             "name": "Invasion of New Capenna // Holy Frazzle-Cannon",
             "text": "Whenever equipped creature attacks, put a +1/+1 counter on that creature and each other creature you control that shares a creature type with it.\nEquip {1}",
             "colours": [
@@ -10372,7 +10372,7 @@
         },
         {
             "id": "7bcacdcd-ec54-5be9-95b8-8afb7fb2156e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg?1",
             "name": "Invasion of New Phyrexia // Teferi Akosa of Zhalfir",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of New Phyrexia enters the battlefield, create X 2/2 white and blue Knight creature tokens with vigilance.",
             "colours": [
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "4c21b872-6111-5f66-804f-8e15ffb4075e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/b/1b83af86-e1a9-4be1-83dc-0c1ab81b129e.jpg?1",
             "name": "Invasion of New Phyrexia // Teferi Akosa of Zhalfir",
             "text": "+1: Draw two cards. Then discard two cards unless you discard a creature card.\n\u22122: You get an emblem with \"Knights you control get +1/+0 and have ward {1}.\"\n\u22123: Tap X untapped creatures you control. When you do, shuffle target nonland permanent an opponent controls with mana value X or less into its owner's library.",
             "colours": [
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "a9b6c94a-d9ce-5704-93bf-2a62af205b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg?1",
             "name": "Invasion of Pyrulea // Gargantuan Slabhorn",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Pyrulea enters the battlefield, scry 3, then reveal the top card of your library. If it's a land or double-faced card, draw a card.",
             "colours": [
@@ -10482,7 +10482,7 @@
         },
         {
             "id": "b133ffd1-43d3-5a9b-b89a-d48fe479bfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50180fda-6d67-41e9-8b2b-2e7c5876b8ab.jpg?1",
             "name": "Invasion of Pyrulea // Gargantuan Slabhorn",
             "text": "Trample, ward {2}\nOther transformed permanents you control have trample and ward {2}.",
             "colours": [
@@ -10518,7 +10518,7 @@
         },
         {
             "id": "ceb61e24-6e58-5ec0-aee0-61a52f8d87dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1",
             "name": "Invasion of Tolvada // The Broken Sky",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Tolvada enters the battlefield, return target nonbattle permanent card from your graveyard to the battlefield.",
             "colours": [
@@ -10554,7 +10554,7 @@
         },
         {
             "id": "9749345a-22e8-59a8-b16a-b26abc83d202",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00255899-aaaf-46c6-8037-bd0e3c06250c.jpg?1",
             "name": "Invasion of Tolvada // The Broken Sky",
             "text": "Creature tokens you control get +1/+0 and have lifelink.\nAt the beginning of your end step, create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -10588,7 +10588,7 @@
         },
         {
             "id": "18d50241-c3a3-57fd-9fb1-156c25cd52ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg?1",
             "name": "Invasion of Xerex // Vertex Paladin",
             "text": "(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)\nWhen Invasion of Xerex enters the battlefield, return up to one target creature to its owner's hand.",
             "colours": [
@@ -10624,7 +10624,7 @@
         },
         {
             "id": "582b4d0b-1e5c-5d34-917e-eb4f4626989d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c8c9c33-569c-4b67-a18d-4cd0f18d01f4.jpg?1",
             "name": "Invasion of Xerex // Vertex Paladin",
             "text": "Flying\nVertex Paladin's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "c3a9ad8f-4fa4-593b-89f9-e787bf3acb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dabe69-a88f-4e61-a5fb-c4b9ef1c7569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4dabe69-a88f-4e61-a5fb-c4b9ef1c7569.jpg?1",
             "name": "Joyful Stormsculptor",
             "text": "When Joyful Stormsculptor enters the battlefield, create two 1/1 blue and red Elemental creature tokens.\nWhenever you cast a spell that has convoke, Joyful Stormsculptor deals 1 damage to each opponent and each battle they protect.",
             "colours": [
@@ -10698,7 +10698,7 @@
         },
         {
             "id": "e1785f10-6812-5f68-99d2-ce60ae10286c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760ebdf-bea6-4c43-a187-4a02ebf95ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b760ebdf-bea6-4c43-a187-4a02ebf95ebf.jpg?1",
             "name": "Kogla and Yidaro",
             "text": "When Kogla and Yidaro enters the battlefield, choose one \u2014\n\u2022 It gains trample and haste until end of turn.\n\u2022 It fights target creature you don't control.\n{2}{R}{G}, Discard Kogla and Yidaro: Destroy up to one target artifact or enchantment. Shuffle Kogla and Yidaro into your library from your graveyard, then draw a card.",
             "colours": [
@@ -10740,7 +10740,7 @@
         },
         {
             "id": "b4857586-a288-541e-bd82-29cfea585fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e4a233-e40b-4e6a-9863-4d0fc052484c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e4a233-e40b-4e6a-9863-4d0fc052484c.jpg?1",
             "name": "Kroxa and Kunoros",
             "text": "Vigilance, menace, lifelink\nWhenever Kroxa and Kunoros enters the battlefield or attacks, you may exile five cards from your graveyard. When you do, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -10784,7 +10784,7 @@
         },
         {
             "id": "e43e9d60-d7cc-56e2-a846-b7272054b022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2418f5c-a85f-4249-8a53-c94b011b9714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2418f5c-a85f-4249-8a53-c94b011b9714.jpg?1",
             "name": "Marshal of Zhalfir",
             "text": "Other Knights you control get +1/+1.\n{W}{U}, {T}: Tap another target creature.",
             "colours": [
@@ -10821,7 +10821,7 @@
         },
         {
             "id": "29af7ddc-4a31-5100-99c4-fca29778612a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a5e7de-43cc-488b-99a4-7d173b42d5dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a5e7de-43cc-488b-99a4-7d173b42d5dc.jpg?1",
             "name": "Mirror-Shield Hoplite",
             "text": "Vigilance\nWhenever a creature you control becomes the target of a backup ability, copy that ability. You may choose new targets for the copy. This ability triggers only once each turn.",
             "colours": [
@@ -10858,7 +10858,7 @@
         },
         {
             "id": "52ae2f25-23fb-5275-9722-f5f7e07ddfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a84b6d7-3944-4223-ac16-aa5e59ac84cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a84b6d7-3944-4223-ac16-aa5e59ac84cb.jpg?1",
             "name": "Mutagen Connoisseur",
             "text": "Flying, vigilance\nMutagen Connoisseur gets +1/+0 for each transformed permanent you control.",
             "colours": [
@@ -10895,7 +10895,7 @@
         },
         {
             "id": "77ff02da-e3e9-5df5-a342-994ac785cfad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d94ecf-758b-4f68-a7be-6bf3ff1047f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d94ecf-758b-4f68-a7be-6bf3ff1047f4.jpg?1",
             "name": "Omnath, Locus of All",
             "text": "If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",
             "colours": [
@@ -10943,7 +10943,7 @@
         },
         {
             "id": "49a2714f-4c62-5c60-a99a-f245f9efb453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b152c-8376-42f9-9daf-e139dc29c9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19b152c-8376-42f9-9daf-e139dc29c9ca.jpg?1",
             "name": "Quintorius, Loremaster",
             "text": "Vigilance\nAt the beginning of your end step, exile target noncreature, nonland card from your graveyard. Create a 3/2 red and white Spirit creature token.\n{1}{R}{W}, {T}, Sacrifice a Spirit: Choose target card exiled with Quintorius. You may cast that card this turn without paying its mana cost. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.",
             "colours": [
@@ -10984,7 +10984,7 @@
         },
         {
             "id": "2ffb215a-710a-5833-8548-708d61a30084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a973e70f-9e3e-47a3-94b9-7bb8a198a438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a973e70f-9e3e-47a3-94b9-7bb8a198a438.jpg?1",
             "name": "Rampaging Geoderm",
             "text": "Trample, haste\nWhenever you attack, target attacking creature gets +1/+1 until end of turn. If it's attacking a battle, put a +1/+1 counter on it instead.",
             "colours": [
@@ -11021,7 +11021,7 @@
         },
         {
             "id": "cbf79129-a0ca-5613-bedd-19c28e6e2c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92c191e-329c-41f5-ae4f-1bb91fc001a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92c191e-329c-41f5-ae4f-1bb91fc001a0.jpg?1",
             "name": "Rankle and Torbran",
             "text": "Flying, first strike, haste\nWhenever Rankle and Torbran deals combat damage to a player or battle, choose any number \u2014\n\u2022 Each player creates a Treasure token.\n\u2022 Each player sacrifices a creature.\n\u2022 If a source would deal damage to a player or battle this turn, it deals that much damage plus 2 instead.",
             "colours": [
@@ -11062,7 +11062,7 @@
         },
         {
             "id": "02ad0267-a020-5abd-9ac6-5353e6bca43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594aefa2-7a5b-4ec1-841b-a6ef4f5aa2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594aefa2-7a5b-4ec1-841b-a6ef4f5aa2b1.jpg?1",
             "name": "Sculpted Perfection",
             "text": "When Sculpted Perfection enters the battlefield, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nPhyrexians you control get +1/+1.",
             "colours": [
@@ -11096,7 +11096,7 @@
         },
         {
             "id": "05e51f1c-622b-51db-a176-e7def724aaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b00c6e1-dfda-4c47-b1d8-4c114a921477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b00c6e1-dfda-4c47-b1d8-4c114a921477.jpg?1",
             "name": "Stormclaw Rager",
             "text": "{1}, Sacrifice another creature or artifact: Put a +1/+1 counter on Stormclaw Rager and draw a card. Activate only as a sorcery.",
             "colours": [
@@ -11133,7 +11133,7 @@
         },
         {
             "id": "4f94928f-8d22-576e-b3f4-3acb832625f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7ff937-de92-445f-976c-726fef5c91cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7ff937-de92-445f-976c-726fef5c91cc.jpg?1",
             "name": "Thalia and The Gitrog Monster",
             "text": "First strike, deathtouch\nYou may play an additional land on each of your turns.\nCreatures and nonbasic lands your opponents control enter the battlefield tapped.\nWhenever Thalia and The Gitrog Monster attacks, sacrifice a creature or land, then draw a card.",
             "colours": [
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "0e09aa03-a6fd-5580-a847-6c0888678c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c15e244-14cc-46a5-abd4-66a58d1c0dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c15e244-14cc-46a5-abd4-66a58d1c0dd0.jpg?1",
             "name": "Yargle and Multani",
             "text": "",
             "colours": [
@@ -11219,7 +11219,7 @@
         },
         {
             "id": "6c7a5c13-35aa-50dc-8632-cd94f35715b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2af874-1052-4cad-90ed-d80e49d4c68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2af874-1052-4cad-90ed-d80e49d4c68c.jpg?1",
             "name": "Zimone and Dina",
             "text": "Whenever you draw your second card each turn, target opponent loses 2 life and you gain 2 life.\n{T}, Sacrifice another creature: Draw a card. You may put a land card from your hand onto the battlefield tapped. If you control eight or more lands, repeat this process once.",
             "colours": [
@@ -11262,7 +11262,7 @@
         },
         {
             "id": "beaca6ee-7b13-5ada-8cf1-b11413c4cb14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacbcd82-36e6-424c-bd4e-ec3a584836c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eacbcd82-36e6-424c-bd4e-ec3a584836c5.jpg?1",
             "name": "Zurgo and Ojutai",
             "text": "Flying, haste\nZurgo and Ojutai has hexproof as long as it entered the battlefield this turn.\nWhenever one or more Dragons you control deal combat damage to a player or battle, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. You may return one of those Dragons to its owner's hand.",
             "colours": [
@@ -11305,7 +11305,7 @@
         },
         {
             "id": "5f16c80c-62f5-513e-8fa5-cb6b708c7c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694485d-a753-4e55-929c-d8e4a53c7d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694485d-a753-4e55-929c-d8e4a53c7d08.jpg?1",
             "name": "Flywheel Racer",
             "text": "Vigilance\n{T}: Add one mana of any color. Activate only if Flywheel Racer is a creature.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -11335,7 +11335,7 @@
         },
         {
             "id": "b03def35-15f3-5775-98a4-f54ab566629a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07baeb1-c873-42c2-8f1e-757f13572079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07baeb1-c873-42c2-8f1e-757f13572079.jpg?1",
             "name": "Halo Hopper",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
             "colours": [],
@@ -11366,7 +11366,7 @@
         },
         {
             "id": "528b28b7-178d-5a41-8faa-6a26df45c9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc3bf6e-e011-4334-a142-c09941c6f213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc3bf6e-e011-4334-a142-c09941c6f213.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11396,7 +11396,7 @@
         },
         {
             "id": "080dee5b-3e28-5117-8515-95d388a65d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93960b5e-b13c-4f7d-a826-8aad6bd210b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93960b5e-b13c-4f7d-a826-8aad6bd210b4.jpg?1",
             "name": "Phyrexian Archivist",
             "text": "Reach\n{2}, {T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -11428,7 +11428,7 @@
         },
         {
             "id": "8053f752-0eed-5456-93f1-3fe0cf72d6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608134-cfc3-48bf-92d8-35d732fcde54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608134-cfc3-48bf-92d8-35d732fcde54.jpg?1",
             "name": "Realmbreaker, the Invasion Tree",
             "text": "{2}, {T}: Target opponent mills three cards. Put a land card from their graveyard onto the battlefield tapped under your control. It gains \"If this land would leave the battlefield, exile it instead of putting it anywhere else.\"\n{1}0, {T}, Sacrifice Realmbreaker, the Invasion Tree: Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.",
             "colours": [],
@@ -11460,7 +11460,7 @@
         },
         {
             "id": "1de338ee-e241-52da-bfec-7465ad2b5016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae9f1d-e96d-444c-a0fd-5608243ee6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae9f1d-e96d-444c-a0fd-5608243ee6c8.jpg?1",
             "name": "Skittering Surveyor",
             "text": "When Skittering Surveyor enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -11491,7 +11491,7 @@
         },
         {
             "id": "3a3ca3b4-c565-5e8e-befa-e8e40e58ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670393d-86f0-46fb-b577-f73a1da2a3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1670393d-86f0-46fb-b577-f73a1da2a3ed.jpg?1",
             "name": "Sword of Once and Future",
             "text": "Equipped creature gets +2/+2 and has protection from blue and from black.\nWhenever equipped creature deals combat damage to a player, surveil 2. Then you may cast an instant or sorcery spell with mana value 2 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.\nEquip {2}",
             "colours": [],
@@ -11523,7 +11523,7 @@
         },
         {
             "id": "de2a1835-fcbe-5dbb-aa3c-df0ac34d7eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f302e-d884-4995-ba3c-8c22f9045318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f302e-d884-4995-ba3c-8c22f9045318.jpg?1",
             "name": "Urn of Godfire",
             "text": "{2}: Add one mana of any color.\n{6}, {T}, Sacrifice Urn of Godfire: Destroy target creature or enchantment.",
             "colours": [],
@@ -11551,7 +11551,7 @@
         },
         {
             "id": "657c6a43-f1cd-5672-90af-8cb4095f62bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85930f68-6f53-4921-9556-2887ac3abfd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85930f68-6f53-4921-9556-2887ac3abfd2.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11582,7 +11582,7 @@
         },
         {
             "id": "c43970b7-1134-5d74-a65f-29a1ecab2d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34684d6-2935-4776-9a86-b603ad8cf624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34684d6-2935-4776-9a86-b603ad8cf624.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11613,7 +11613,7 @@
         },
         {
             "id": "4493239a-9e3e-5e1d-b2f0-158064a095af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cd4f63-3484-4cee-8603-1f89cabee6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33cd4f63-3484-4cee-8603-1f89cabee6c3.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11644,7 +11644,7 @@
         },
         {
             "id": "837ae536-6529-56be-a838-1f069ed20e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed20a4-bc8a-44b1-b9b7-c82518c287b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed20a4-bc8a-44b1-b9b7-c82518c287b8.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11675,7 +11675,7 @@
         },
         {
             "id": "974d37f5-5e9d-50c7-8543-542c8bd264b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aeef1b1-a351-47ce-a686-a0eb0a35a894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aeef1b1-a351-47ce-a686-a0eb0a35a894.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -11706,7 +11706,7 @@
         },
         {
             "id": "451ce7a3-7461-5973-a97f-0c715391f6b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aefbfc-3f67-443d-8ec4-cc9beafb64ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66aefbfc-3f67-443d-8ec4-cc9beafb64ee.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -11737,7 +11737,7 @@
         },
         {
             "id": "1967ceae-7733-5eea-bd4b-a479deee287b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957efc4e-c2a9-46a2-b9e3-20dc419ffd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957efc4e-c2a9-46a2-b9e3-20dc419ffd05.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -11768,7 +11768,7 @@
         },
         {
             "id": "63bf2704-728d-555c-b57c-284cec3b3b2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b753e2-6e53-4ed1-9be4-66f8eb005a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b753e2-6e53-4ed1-9be4-66f8eb005a11.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -11799,7 +11799,7 @@
         },
         {
             "id": "a200199f-262d-5b9c-972d-cfda8d9f423b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3799dcb2-7cd7-4d28-b9af-249e3ebe3d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3799dcb2-7cd7-4d28-b9af-249e3ebe3d3b.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "ea47a507-0df0-5212-810c-e6b2a2e29814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2642cd-e3cc-4aab-8c00-4987284509b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2642cd-e3cc-4aab-8c00-4987284509b3.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11861,7 +11861,7 @@
         },
         {
             "id": "47a9e945-efa5-5ec7-8f35-b35d15f7acaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf269d-aca3-494c-8777-de90ae903af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf269d-aca3-494c-8777-de90ae903af2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11898,7 +11898,7 @@
         },
         {
             "id": "d2dba459-36dc-59d5-a520-199390521b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988bfa94-0c83-4057-a0c7-0ad885b8919c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988bfa94-0c83-4057-a0c7-0ad885b8919c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11935,7 +11935,7 @@
         },
         {
             "id": "8a72c48e-d746-54d9-8389-ee50c35bace7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888cdb76-d365-41df-8b6a-378ac58ca8b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888cdb76-d365-41df-8b6a-378ac58ca8b2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11972,7 +11972,7 @@
         },
         {
             "id": "60eab57f-fced-54de-ba77-d5ba92a22705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21041ed6-8f13-4909-a2c3-fa4894a2d1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21041ed6-8f13-4909-a2c3-fa4894a2d1e3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12009,7 +12009,7 @@
         },
         {
             "id": "01b9cc89-6e90-5dbc-8daf-530d9bb23be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80716ed1-8d0e-44e6-8b18-606e80d22181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80716ed1-8d0e-44e6-8b18-606e80d22181.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12046,7 +12046,7 @@
         },
         {
             "id": "1647a4e3-119f-54fa-9c34-4e47f6b46be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7f525c-d777-4adf-8920-8adfc73bbc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7f525c-d777-4adf-8920-8adfc73bbc55.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12083,7 +12083,7 @@
         },
         {
             "id": "89a88a78-8ab7-5be6-971c-0140c49247d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a790328-70b3-477d-bf02-8718870367ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a790328-70b3-477d-bf02-8718870367ae.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12120,7 +12120,7 @@
         },
         {
             "id": "ca2932ea-1ad9-5845-834a-3378fd14ef1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2039d727-3bb6-4a76-89ca-159ecf10cad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2039d727-3bb6-4a76-89ca-159ecf10cad8.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12157,7 +12157,7 @@
         },
         {
             "id": "031e3c5a-bf28-5f69-9568-ac2b09622764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c7de9-0046-4a76-a41a-fa1c3ef92f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c7de9-0046-4a76-a41a-fa1c3ef92f04.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12194,7 +12194,7 @@
         },
         {
             "id": "f785ae17-b374-5d9c-b076-102264d35747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19e24a8-5a4f-4a2d-b8dd-eb92aac7be78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19e24a8-5a4f-4a2d-b8dd-eb92aac7be78.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12231,7 +12231,7 @@
         },
         {
             "id": "6709cfdf-61a9-5fdd-ade6-0fc8feb33ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013612b4-fed9-4112-8018-9267ae608fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013612b4-fed9-4112-8018-9267ae608fd7.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12268,7 +12268,7 @@
         },
         {
             "id": "9287082a-e3a6-5918-a210-1ac5833d5347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a57c6a-3603-466c-8a81-a9eb8de92aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a57c6a-3603-466c-8a81-a9eb8de92aec.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12305,7 +12305,7 @@
         },
         {
             "id": "7cc4c0fd-f07d-5e1c-85e9-5ef58304e9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e19c7e1-1b4b-4c7e-b011-eff8ed7de0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e19c7e1-1b4b-4c7e-b011-eff8ed7de0fd.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12342,7 +12342,7 @@
         },
         {
             "id": "d45b8087-d2b3-55b7-8020-ea827c4b297c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6151d4-5129-4631-84a1-5cffc551c1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6151d4-5129-4631-84a1-5cffc551c1e9.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12379,7 +12379,7 @@
         },
         {
             "id": "910e2046-3ab0-5239-ba69-5b2a9ea16925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ce5575-2d62-43c9-9c4b-fca4aff6ae4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ce5575-2d62-43c9-9c4b-fca4aff6ae4d.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12416,7 +12416,7 @@
         },
         {
             "id": "678a79aa-21ee-517f-8be5-da9349c85662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "Vigilance\nWhenever a source an opponent controls deals damage to you or a permanent you control, that source's controller loses 2 life unless they pay {1}.\n{2}{W}, Sacrifice three other creatures: Exile Elesh Norn, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "53bdd792-627f-5a6d-ab8d-4031b747e2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/faf66a0b-9d34-487d-bdb4-5cac9391d77a.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Incubate 2 five times, then transform all Incubator tokens you control.\nII \u2014 Creatures you control get +1/+1 and gain double strike until end of turn.\nIII \u2014 Destroy all other permanents except for artifacts, lands, and Phyrexians. Exile The Argent Etchings, then return it to the battlefield (front face up).",
             "colours": [
@@ -12493,7 +12493,7 @@
         },
         {
             "id": "04cf9a35-9727-57d4-a939-d251a403fd23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "When Heliod, the Radiant Dawn enters the battlefield, return target enchantment card that isn't a God from your graveyard to your hand.\n{3}{PU}: Transform Heliod, the Radiant Dawn. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -12533,7 +12533,7 @@
         },
         {
             "id": "fd432d12-0702-579a-85df-eadce25ac30b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bfd786c2-6a2b-4f43-ba68-cbe31eeb4904.jpg?1",
             "name": "Heliod, the Radiant Dawn // Heliod, the Warped Eclipse",
             "text": "You may cast spells as though they had flash.\nSpells you cast cost {1} less to cast for each card your opponents have drawn this turn.",
             "colours": [
@@ -12575,7 +12575,7 @@
         },
         {
             "id": "4e2c63e1-fab4-5797-b59b-5bf3ecb64534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "Ward {2}\nWhenever you cast a noncreature spell with mana value 3 or greater, draw a card.\n{3}{U}: Exile Jin-Gitaxias, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you have seven or more cards in hand.",
             "colours": [
@@ -12615,7 +12615,7 @@
         },
         {
             "id": "a8a6d87c-e029-5992-a992-befac91dd90b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/5/151ba146-78fa-48de-b289-99f03b935794.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Draw cards equal to the number of cards in your hand. You have no maximum hand size for as long as you control The Great Synthesis.\nII \u2014 Return all non-Phyrexian creatures to their owners' hands.\nIII \u2014 You may cast any number of spells from your hand without paying their mana costs. Exile The Great Synthesis, then return it to the battlefield (front face up).",
             "colours": [
@@ -12652,7 +12652,7 @@
         },
         {
             "id": "4fb6598a-4d81-5db1-b35a-53c2265192e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Whenever you cast a legendary spell, untap Rona, Herald of Invasion.\n{T}: Draw a card, then discard a card.\n{5}{PB}: Transform Rona. Activate only as a sorcery. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -12692,7 +12692,7 @@
         },
         {
             "id": "bdd68e5d-bb57-5ce4-a696-329fd9b2831f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4bb6ca5-f529-403f-bdc7-63b7e7e86753.jpg?1",
             "name": "Rona, Herald of Invasion // Rona, Tolarian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Rona, Tolarian Obliterator, that source's controller exiles a card from their hand at random. If it's a land card, you may put it onto the battlefield under your control. Otherwise, you may cast it without paying its mana cost.",
             "colours": [
@@ -12733,7 +12733,7 @@
         },
         {
             "id": "108368e1-8808-5ca7-8c89-e09c4c33bb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "{T}, Sacrifice another creature or artifact: Ayara, Widow of the Realm deals X damage to target opponent or battle and you gain X life, where X is the sacrificed permanent's mana value.\n{5}{PR}: Transform Ayara. Activate only as a sorcery. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -12773,7 +12773,7 @@
         },
         {
             "id": "e198aa16-fe29-50e7-8ac5-46f00df159d3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99b2647f-e509-49c5-9dbd-d56fe0eda98d.jpg?1",
             "name": "Ayara, Widow of the Realm // Ayara, Furnace Queen",
             "text": "At the beginning of combat on your turn, return up to one target artifact or creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -12815,7 +12815,7 @@
         },
         {
             "id": "552ea12c-68a4-5bc6-abcc-7c1356bccca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "Menace\nWhen Sheoldred enters the battlefield, each opponent sacrifices a nontoken creature or planeswalker.\n{4}{B}: Exile Sheoldred, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if an opponent has eight or more cards in their graveyard.",
             "colours": [
@@ -12855,7 +12855,7 @@
         },
         {
             "id": "ab60b806-a5d5-546a-9c2a-7fd4b3f76a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/7367ddfd-508e-49de-9428-3384bbe80b55.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 For each opponent, destroy up to one target creature or planeswalker that player controls.\nII \u2014 Each opponent discards three cards, then mills three cards.\nIII \u2014 Put all creature cards from all graveyards onto the battlefield under your control. Exile The True Scriptures, then return it to the battlefield (front face up).",
             "colours": [
@@ -12892,7 +12892,7 @@
         },
         {
             "id": "4c10387e-abef-5de0-990f-053af3a67ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample\nWhen Etali, Primal Conqueror enters the battlefield, each player exiles cards from the top of their library until they exile a nonland card. You may cast any number of spells from among the nonland cards exiled this way without paying their mana costs.\n{9}{PG}: Transform Etali. Activate only as a sorcery.",
             "colours": [
@@ -12932,7 +12932,7 @@
         },
         {
             "id": "576435f3-d934-53e9-84e4-315b389e1fee",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1",
             "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
             "text": "Trample, indestructible\nWhenever Etali, Primal Sickness deals combat damage to a player, they get that many poison counters.",
             "colours": [
@@ -12974,7 +12974,7 @@
         },
         {
             "id": "dece52c4-d17c-5764-82a7-3f0fe7e9ecce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "First strike\nWhenever you cast an instant or sorcery spell, Urabrask deals 1 damage to target opponent. Add {R}.\n{R}: Exile Urabrask, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery and only if you've cast three or more instant and/or sorcery spells this turn.",
             "colours": [
@@ -13014,7 +13014,7 @@
         },
         {
             "id": "b8503e2d-58b8-552d-a501-6c1178c7d64e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52173f36-19d2-48be-a8e8-8cbe946759c0.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 The Great Work deals 3 damage to target opponent and each creature they control.\nII \u2014 Create three Treasure tokens.\nIII \u2014 Until end of turn, you may cast instant and sorcery spells from any graveyard. If a spell cast this way would be put into a graveyard, exile it instead. Exile The Great Work, then return it to the battlefield (front face up).",
             "colours": [
@@ -13051,7 +13051,7 @@
         },
         {
             "id": "90652088-73bb-5eeb-9c57-b8628090f93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach\n{6}{PW}: Transform Polukranos Reborn. Activate only as a sorcery. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -13090,7 +13090,7 @@
         },
         {
             "id": "234f5390-12d5-5de3-8bdc-179f19ad229d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e487de0a-cbf3-4fd7-87b9-cd5685bdaddd.jpg?1",
             "name": "Polukranos Reborn // Polukranos, Engine of Ruin",
             "text": "Reach, lifelink\nWhenever Polukranos, Engine of Ruin or another nontoken Hydra you control dies, create a 3/3 green and white Phyrexian Hydra creature token with reach and a 3/3 green and white Phyrexian Hydra creature token with lifelink.",
             "colours": [
@@ -13131,7 +13131,7 @@
         },
         {
             "id": "5b4134b4-2c87-55ff-b827-34b10d3a78af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "Trample, reach\nWhen Vorinclex enters the battlefield, search your library for up to two Forest cards, reveal them, put them into your hand, then shuffle.\n{6}{G}{G}: Exile Vorinclex, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
             "colours": [
@@ -13171,7 +13171,7 @@
         },
         {
             "id": "e3fc4c9b-4ff8-548f-98aa-c017b6798c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2903fa0d-a586-4886-981d-7b9b34aed83b.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill ten cards. Put up to two creature cards from among the milled cards onto the battlefield.\nII \u2014 Distribute seven +1/+1 counters among any number of target creatures you control.\nIII \u2014 Until end of turn, creatures you control gain \"{1}: This creature fights target creature you don't control.\" Exile The Grand Evolution, then return it to the battlefield (front face up).",
             "colours": [
@@ -13208,7 +13208,7 @@
         },
         {
             "id": "b2329698-c1e0-5682-9fab-8d4fd3cc7e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612a164-d73e-47b3-a06a-fd5429b51fa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b612a164-d73e-47b3-a06a-fd5429b51fa9.jpg?1",
             "name": "Baral and Kari Zev",
             "text": "First strike, menace\nWhenever you cast your first instant or sorcery spell each turn, you may cast a spell with lesser mana value that shares a card type with it from your hand without paying its mana cost. If you don't, create First Mate Ragavan, a legendary 2/1 red Monkey Pirate creature token. It gains haste until end of turn.",
             "colours": [
@@ -13248,7 +13248,7 @@
         },
         {
             "id": "30e08ec5-ce0d-5222-b5c1-9be9dd856394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df48f1c0-b336-4c68-8d11-41bceb36c83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df48f1c0-b336-4c68-8d11-41bceb36c83c.jpg?1",
             "name": "Borborygmos and Fblthp",
             "text": "Whenever Borborygmos and Fblthp enters the battlefield or attacks, draw a card, then you may discard any number of land cards. When you discard one or more cards this way, Borborygmos and Fblthp deals twice that much damage to target creature.\n{1}{U}: Put Borborygmos and Fblthp into its owner's library third from the top.",
             "colours": [
@@ -13291,7 +13291,7 @@
         },
         {
             "id": "873e9c29-295d-5877-a3a7-a6dbc9be7829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf166b-5383-443a-9ecc-027f72e0dfa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf166b-5383-443a-9ecc-027f72e0dfa5.jpg?1",
             "name": "Djeru and Hazoret",
             "text": "As long as you have one or fewer cards in hand, Djeru and Hazoret has vigilance and haste.\nWhenever Djeru and Hazoret attacks, look at the top six cards of your library. You may exile a legendary creature card from among them. Put the rest on the bottom of your library in a random order. Until end of turn, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -13332,7 +13332,7 @@
         },
         {
             "id": "48aa19dc-2718-59b1-b1a4-73ba302244d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a5fe67-beaa-4ee3-b22c-0b8aed6f6f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a5fe67-beaa-4ee3-b22c-0b8aed6f6f4d.jpg?1",
             "name": "Drana and Linvala",
             "text": "Flying, vigilance\nActivated abilities of creatures your opponents control can't be activated.\nDrana and Linvala has all activated abilities of all creatures your opponents control. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -13373,7 +13373,7 @@
         },
         {
             "id": "b5f25cec-f9b4-5996-b4a3-9cc88708306d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d8b20a-9288-4470-90d2-5b72fb4a9e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d8b20a-9288-4470-90d2-5b72fb4a9e68.jpg?1",
             "name": "Errant and Giada",
             "text": "Flash\nFlying\nYou may look at the top card of your library any time.\nYou may cast spells with flash or flying from the top of your library.",
             "colours": [
@@ -13414,7 +13414,7 @@
         },
         {
             "id": "94b0692f-c79a-55df-b95c-5f16c6d3d4e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adea9871-807e-471d-9a9f-ad6efcf07e80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adea9871-807e-471d-9a9f-ad6efcf07e80.jpg?1",
             "name": "Ghalta and Mavren",
             "text": "Trample\nWhenever you attack, choose one \u2014\n\u2022 Create a tapped and attacking X/X green Dinosaur creature token with trample, where X is the greatest power among other attacking creatures.\n\u2022 Create X 1/1 white Vampire creature tokens with lifelink, where X is the number of other attacking creatures.",
             "colours": [
@@ -13456,7 +13456,7 @@
         },
         {
             "id": "1dd8c7d5-6eff-53b9-bfde-a9308ad0a9a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e12422-c46b-41b2-8b5d-c965d5694bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e12422-c46b-41b2-8b5d-c965d5694bd2.jpg?1",
             "name": "Glissa, Herald of Predation",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Incubate 2 twice.\n\u2022 Transform all Incubator tokens you control.\n\u2022 Phyrexians you control gain first strike and deathtouch until end of turn.",
             "colours": [
@@ -13498,7 +13498,7 @@
         },
         {
             "id": "58d2ecf9-7456-588e-9707-0ab035f31dd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd881d-6e12-4c90-a198-1d7ec61924b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd881d-6e12-4c90-a198-1d7ec61924b6.jpg?1",
             "name": "Hidetsugu and Kairi",
             "text": "Flying\nWhen Hidetsugu and Kairi enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.\nWhen Hidetsugu and Kairi dies, exile the top card of your library. Target opponent loses life equal to its mana value. If it's an instant or sorcery card, you may cast it without paying its mana cost.",
             "colours": [
@@ -13540,7 +13540,7 @@
         },
         {
             "id": "f52ab886-42e9-5497-a03a-fb493f18ca08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced80468-2853-4fbd-928a-98381ca1d06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced80468-2853-4fbd-928a-98381ca1d06e.jpg?1",
             "name": "Inga and Esika",
             "text": "Creatures you control have vigilance and \"{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\"\nWhenever you cast a creature spell, if three or more mana from creatures was spent to cast it, draw a card.",
             "colours": [
@@ -13581,7 +13581,7 @@
         },
         {
             "id": "86061e55-e91a-5734-ada8-08e0a9fc205b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32dbdc6-3321-4d77-8d2f-acbcb1a29090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32dbdc6-3321-4d77-8d2f-acbcb1a29090.jpg?1",
             "name": "Kogla and Yidaro",
             "text": "When Kogla and Yidaro enters the battlefield, choose one \u2014\n\u2022 It gains trample and haste until end of turn.\n\u2022 It fights target creature you don't control.\n{2}{R}{G}, Discard Kogla and Yidaro: Destroy up to one target artifact or enchantment. Shuffle Kogla and Yidaro into your library from your graveyard, then draw a card.",
             "colours": [
@@ -13623,7 +13623,7 @@
         },
         {
             "id": "c49fa048-ac10-5a94-96ab-65902850ca40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1c9e3a-cd3f-412c-af59-c024081782cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1c9e3a-cd3f-412c-af59-c024081782cf.jpg?1",
             "name": "Kroxa and Kunoros",
             "text": "Vigilance, menace, lifelink\nWhenever Kroxa and Kunoros enters the battlefield or attacks, you may exile five cards from your graveyard. When you do, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -13667,7 +13667,7 @@
         },
         {
             "id": "1abd8fd9-bdfb-5d2e-ad65-e925c11b1979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b998493-d2c5-48dd-8d0c-b63b6795acf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b998493-d2c5-48dd-8d0c-b63b6795acf6.jpg?1",
             "name": "Omnath, Locus of All",
             "text": "If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",
             "colours": [
@@ -13715,7 +13715,7 @@
         },
         {
             "id": "74aae536-67cb-5578-b2d5-62488d60a2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac290f-69fb-4e18-a36c-356f04193ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cac290f-69fb-4e18-a36c-356f04193ab3.jpg?1",
             "name": "Quintorius, Loremaster",
             "text": "Vigilance\nAt the beginning of your end step, exile target noncreature, nonland card from your graveyard. Create a 3/2 red and white Spirit creature token.\n{1}{R}{W}, {T}, Sacrifice a Spirit: Choose target card exiled with Quintorius. You may cast that card this turn without paying its mana cost. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.",
             "colours": [
@@ -13756,7 +13756,7 @@
         },
         {
             "id": "2ee7b341-f00f-5091-bcec-e2b427c55b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e314fa27-8d87-425a-ae94-28bfd9005505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e314fa27-8d87-425a-ae94-28bfd9005505.jpg?1",
             "name": "Rankle and Torbran",
             "text": "Flying, first strike, haste\nWhenever Rankle and Torbran deals combat damage to a player or battle, choose any number \u2014\n\u2022 Each player creates a Treasure token.\n\u2022 Each player sacrifices a creature.\n\u2022 If a source would deal damage to a player or battle this turn, it deals that much damage plus 2 instead.",
             "colours": [
@@ -13797,7 +13797,7 @@
         },
         {
             "id": "82e724d5-4212-5982-beb7-7096361267a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c4eb73-7e50-4c22-8fa6-c770152ebdaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c4eb73-7e50-4c22-8fa6-c770152ebdaf.jpg?1",
             "name": "Thalia and The Gitrog Monster",
             "text": "First strike, deathtouch\nYou may play an additional land on each of your turns.\nCreatures and nonbasic lands your opponents control enter the battlefield tapped.\nWhenever Thalia and The Gitrog Monster attacks, sacrifice a creature or land, then draw a card.",
             "colours": [
@@ -13841,7 +13841,7 @@
         },
         {
             "id": "b0c6ab80-f899-503f-af34-6dc71c5f8c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46df4f25-3705-4d63-aadb-eb89c3476cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46df4f25-3705-4d63-aadb-eb89c3476cf4.jpg?1",
             "name": "Yargle and Multani",
             "text": "",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "1fe975ad-c35f-5e0d-9490-f3d8f7141fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9769de5-43d0-4a59-a219-1740c65281c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9769de5-43d0-4a59-a219-1740c65281c4.jpg?1",
             "name": "Zimone and Dina",
             "text": "Whenever you draw your second card each turn, target opponent loses 2 life and you gain 2 life.\n{T}, Sacrifice another creature: Draw a card. You may put a land card from your hand onto the battlefield tapped. If you control eight or more lands, repeat this process once.",
             "colours": [
@@ -13926,7 +13926,7 @@
         },
         {
             "id": "a9a4f79c-5370-5249-a85c-2c25c3491df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26911a0-447a-41d6-96e5-c93353778a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26911a0-447a-41d6-96e5-c93353778a2c.jpg?1",
             "name": "Zurgo and Ojutai",
             "text": "Flying, haste\nZurgo and Ojutai has hexproof as long as it entered the battlefield this turn.\nWhenever one or more Dragons you control deal combat damage to a player or battle, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. You may return one of those Dragons to its owner's hand.",
             "colours": [
@@ -13969,7 +13969,7 @@
         },
         {
             "id": "8302bccd-9646-540f-a478-5ef007f125cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99e67-901f-4c8d-8a09-e443b7eb928f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f99e67-901f-4c8d-8a09-e443b7eb928f.jpg?1",
             "name": "Archangel Elspeth",
             "text": "+1: Create a 1/1 white Soldier creature token with lifelink.\n\u22122: Put two +1/+1 counters on target creature. It becomes an Angel in addition to its other types and gains flying.\n\u22126: Return all nonland permanent cards with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -14007,7 +14007,7 @@
         },
         {
             "id": "36cff21d-84e3-5f9e-9557-ae8b7084c9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62707510-96ae-492f-8b14-a34d0c9fb859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62707510-96ae-492f-8b14-a34d0c9fb859.jpg?1",
             "name": "Chandra, Hope's Beacon",
             "text": "Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy. This ability triggers only once each turn.\n+2: Add two mana in any combination of colors.\n+1: Exile the top five cards of your library. Until the end of your next turn, you may cast an instant or sorcery spell from among those exiled cards.\n\u2212X: Chandra, Hope's Beacon deals X damage to each of up to two targets.",
             "colours": [
@@ -14045,7 +14045,7 @@
         },
         {
             "id": "faaa623c-d2d4-547f-973c-d0b64081ea45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17269aae-10bc-49ef-b6a7-94e0dd6cf677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17269aae-10bc-49ef-b6a7-94e0dd6cf677.jpg?1",
             "name": "Wrenn and Realmbreaker",
             "text": "Lands you control have \"{T}: Add one mana of any color.\"\n+1: Up to one target land you control becomes a 3/3 Elemental creature with vigilance, hexproof, and haste until your next turn. It's still a land.\n\u22122: Mill three cards. You may put a permanent card from among the milled cards into your hand.\n\u22127: You get an emblem with \"You may play lands and cast permanent spells from your graveyard.\"",
             "colours": [
@@ -14083,7 +14083,7 @@
         },
         {
             "id": "aa74a4bc-a063-5950-8238-2a4b0653dff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604233dc-0520-47d0-8d3d-816f45c9f087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604233dc-0520-47d0-8d3d-816f45c9f087.jpg?1",
             "name": "Essence of Orthodoxy",
             "text": "Flying\nWhenever Essence of Orthodoxy or another Phyrexian enters the battlefield under your control, incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)",
             "colours": [
@@ -14119,7 +14119,7 @@
         },
         {
             "id": "684f8097-df18-58b5-a4fe-15d093f5d12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1200a1-8671-464f-ab3b-bfc1fb0d6ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1200a1-8671-464f-ab3b-bfc1fb0d6ed8.jpg?1",
             "name": "Phyrexian Pegasus",
             "text": "Flying\nWhenever Phyrexian Pegasus attacks, another target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -14154,7 +14154,7 @@
         },
         {
             "id": "1d2a2313-8f71-506c-a1ce-42cd1d89fd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861bda4-d014-4908-aed5-3f3bf78704cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861bda4-d014-4908-aed5-3f3bf78704cf.jpg?1",
             "name": "Seedpod Caretaker",
             "text": "When Seedpod Caretaker enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on target artifact or creature you control.\n\u2022 Transform target Incubator token you control.",
             "colours": [
@@ -14189,7 +14189,7 @@
         },
         {
             "id": "88cb3b48-5772-514e-bedc-e0c7d5fdd96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg?1",
             "name": "Interdisciplinary Mascot",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWard {3}\nWhen Interdisciplinary Mascot enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14226,7 +14226,7 @@
         },
         {
             "id": "d1cff22c-8033-5df4-a673-74f6a01178fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434515bf-de57-4c00-b0b4-c9579cc1b84c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434515bf-de57-4c00-b0b4-c9579cc1b84c.jpg?1",
             "name": "Referee Squad",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nVigilance\nWhen Referee Squad enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -14260,7 +14260,7 @@
         },
         {
             "id": "baca352d-c614-50ff-a223-98d4e1b63cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14456a8e-016c-4407-8410-c490db3f5ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14456a8e-016c-4407-8410-c490db3f5ea9.jpg?1",
             "name": "Zephyr Winder",
             "text": "Flying\nWhenever Zephyr Winder deals combat damage to a player, untap up to one target creature.",
             "colours": [
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "8b34c0c2-bdf3-574b-aa0d-261e2e92aa31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974ddcab-bbe0-4bae-9c99-1fd5a5554d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974ddcab-bbe0-4bae-9c99-1fd5a5554d2e.jpg?1",
             "name": "Injector Crocodile",
             "text": "When Injector Crocodile dies, incubate 3. (Create an Incubator token with three +1/+1 counters on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
             "colours": [
@@ -14329,7 +14329,7 @@
         },
         {
             "id": "0857bdf2-803a-57ff-9d07-db87859b6b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0b3232-44ee-481d-81d9-46432f853a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0b3232-44ee-481d-81d9-46432f853a7d.jpg?1",
             "name": "Seer of Stolen Sight",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever one or more artifacts and/or creatures you control are put into a graveyard from the battlefield, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
             "colours": [
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "7bd3cede-cb6c-51ad-8f09-fbb2249c3299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a759d44-5496-437e-a714-acc398988b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a759d44-5496-437e-a714-acc398988b84.jpg?1",
             "name": "Terror of Towashi",
             "text": "Deathtouch\nWhenever Terror of Towashi attacks, you may pay {3}{B}. When you do, return target creature card from your graveyard to the battlefield. It's a Phyrexian in addition to its other types.",
             "colours": [
@@ -14401,7 +14401,7 @@
         },
         {
             "id": "5e8cfca1-704a-5bb6-ab92-83a84ae5e7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af130b37-d3e0-4839-8193-5c62a91f0218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af130b37-d3e0-4839-8193-5c62a91f0218.jpg?1",
             "name": "Axgard Artisan",
             "text": "Whenever one or more +1/+1 counters are put on Axgard Artisan for the first time each turn, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -14436,7 +14436,7 @@
         },
         {
             "id": "555071ca-fd3e-5e2d-b6e3-970aa0cea149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7a4ccb-c0c9-491f-9475-e78895fa9d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7a4ccb-c0c9-491f-9475-e78895fa9d03.jpg?1",
             "name": "Cragsmasher Yeti",
             "text": "Mountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)\nBackup 2 (When this creature enters the battlefield, put two +1/+1 counters on target creature. If that's another creature, it gains the following ability until end of turn.)\nTrample",
             "colours": [
@@ -14470,7 +14470,7 @@
         },
         {
             "id": "99116a05-b192-5d55-8658-27563600e1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dadbb3-7b8a-4656-973f-65a3284afe07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dadbb3-7b8a-4656-973f-65a3284afe07.jpg?1",
             "name": "Orthion, Hero of Lavabrink",
             "text": "{1}{R}, {T}: Create a token that's a copy of another target creature you control. It gains haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\n{6}{R}{R}{R}, {T}: Create five tokens that are copies of another target creature you control. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -14509,7 +14509,7 @@
         },
         {
             "id": "816c2e7f-e097-544d-bbdc-980fd56aa465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c6408b-9e24-4bf5-b0d0-a4cda3069b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c6408b-9e24-4bf5-b0d0-a4cda3069b1c.jpg?1",
             "name": "Fairgrounds Trumpeter",
             "text": "At the beginning of each end step, if a +1/+1 counter was put on a permanent under your control this turn, put a +1/+1 counter on Fairgrounds Trumpeter.",
             "colours": [
@@ -14543,7 +14543,7 @@
         },
         {
             "id": "24014a9e-9a71-5614-9fa2-41a707580cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c0fdf5-2f56-4480-9ccb-84471b3e5331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c0fdf5-2f56-4480-9ccb-84471b3e5331.jpg?1",
             "name": "Ruins Recluse",
             "text": "Reach, deathtouch\n{3}{G}: Put a +1/+1 counter on Ruins Recluse.",
             "colours": [
@@ -14577,7 +14577,7 @@
         },
         {
             "id": "fd194602-2332-50e9-83d2-ad3babab115d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10934d-9016-43c4-a7ab-56cc7d8f671f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c10934d-9016-43c4-a7ab-56cc7d8f671f.jpg?1",
             "name": "Surrak and Goreclaw",
             "text": "Trample\nOther creatures you control have trample.\nWhenever another nontoken creature enters the battlefield under your control, put a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -14616,7 +14616,7 @@
         },
         {
             "id": "4e8747e2-642b-56e8-9ecb-71afb5b7af49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "",
             "colours": [
@@ -14655,7 +14655,7 @@
         },
         {
             "id": "89cb157e-16dc-55d4-afd3-74efe0d3f70b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40307bcf-199c-4487-bfab-cb5fb841dee8.jpg?1",
             "name": "Elesh Norn // The Argent Etchings",
             "text": "",
             "colours": [
@@ -14691,7 +14691,7 @@
         },
         {
             "id": "f35925e8-e074-5448-ac33-fe54f1f9e158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "",
             "colours": [
@@ -14730,7 +14730,7 @@
         },
         {
             "id": "2297d0bf-14c5-5c2a-9f09-1747ac17d152",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4a4a53e-58cb-4c4a-8396-590e41227ef8.jpg?1",
             "name": "Jin-Gitaxias // The Great Synthesis",
             "text": "",
             "colours": [
@@ -14766,7 +14766,7 @@
         },
         {
             "id": "5fb4cbe9-b370-5205-bb89-101c677eab7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "",
             "colours": [
@@ -14805,7 +14805,7 @@
         },
         {
             "id": "c153f8a5-0537-5e54-bddd-ef806fbd0af9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/9/c9063b1d-573a-4979-8cb3-4afe4eee66d2.jpg?1",
             "name": "Sheoldred // The True Scriptures",
             "text": "",
             "colours": [
@@ -14841,7 +14841,7 @@
         },
         {
             "id": "7c8e0d52-0094-52c1-b92d-08342bf099bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "",
             "colours": [
@@ -14880,7 +14880,7 @@
         },
         {
             "id": "c6e5732c-f8f4-58c6-a67f-9021f2d0a7f0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b12e031a-3a1a-4544-973b-e4e5b0518db9.jpg?1",
             "name": "Urabrask // The Great Work",
             "text": "",
             "colours": [
@@ -14916,7 +14916,7 @@
         },
         {
             "id": "2db0afd1-ba8a-54e0-8f13-16a90fc1110c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "8a6a3698-cfca-5387-9120-06cf7fa2af89",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c462bdf7-9181-4e52-8bcc-d7d5fa49af1c.jpg?1",
             "name": "Vorinclex // The Grand Evolution",
             "text": "",
             "colours": [
@@ -14991,7 +14991,7 @@
         },
         {
             "id": "7136fee1-7a3a-5247-8212-dff9e416bfcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cc901-ae12-45e0-a9cf-e505c3a21dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cc901-ae12-45e0-a9cf-e505c3a21dd1.jpg?1",
             "name": "Boon-Bringer Valkyrie",
             "text": "Backup 1\nFlying, first strike, lifelink",
             "colours": [
@@ -15028,7 +15028,7 @@
         },
         {
             "id": "dcaa1173-3b3d-5668-95ee-4ea5a797644f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d1c7e-9c5c-434b-b974-504674852c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d1c7e-9c5c-434b-b974-504674852c3c.jpg?1",
             "name": "Dusk Legion Duelist",
             "text": "Vigilance\nWhenever one or more +1/+1 counters are put on Dusk Legion Duelist, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -15065,7 +15065,7 @@
         },
         {
             "id": "adb9cd9c-1f9d-5a37-8da1-e7bc4a8d7bdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90058f83-6af9-4776-aeaf-35dec519af88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90058f83-6af9-4776-aeaf-35dec519af88.jpg?1",
             "name": "Guardian of Ghirapur",
             "text": "Flying\nWhen Guardian of Ghirapur enters the battlefield, exile up to one other target creature or artifact you control. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -15101,7 +15101,7 @@
         },
         {
             "id": "8d26cdc5-ed9b-58f5-9f4e-1144113392f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10463a-d63c-43c3-97af-1d7ca672d782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e10463a-d63c-43c3-97af-1d7ca672d782.jpg?1",
             "name": "Knight-Errant of Eos",
             "text": "Convoke\nWhen Knight-Errant of Eos enters the battlefield, look at the top six cards of your library. You may reveal up to two creature cards with mana value X or less from among them, where X is the number of creatures that convoked Knight-Errant of Eos. Put the revealed cards into your hand, then shuffle.",
             "colours": [
@@ -15138,7 +15138,7 @@
         },
         {
             "id": "bd73274d-cb3c-5819-9c65-44050694b830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12381b-822f-4e45-bb53-fade9e51f10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12381b-822f-4e45-bb53-fade9e51f10e.jpg?1",
             "name": "Monastery Mentor",
             "text": "Prowess\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
             "colours": [
@@ -15175,7 +15175,7 @@
         },
         {
             "id": "cf04fad1-8c7c-5e6d-8d7c-254bad8befc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecf78c-1a96-465e-a877-8a3051b8a9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ecf78c-1a96-465e-a877-8a3051b8a9af.jpg?1",
             "name": "Progenitor Exarch",
             "text": "When Progenitor Exarch enters the battlefield, incubate 3 X times.\n{T}: Transform target Incubator token you control.",
             "colours": [
@@ -15213,7 +15213,7 @@
         },
         {
             "id": "e0359b42-2e80-5cf5-8b66-d04dce350792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b961b23d-a16f-4126-9293-2906dc2aba79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b961b23d-a16f-4126-9293-2906dc2aba79.jpg?1",
             "name": "Sunfall",
             "text": "Exile all creatures. Incubate X, where X is the number of creatures exiled this way.",
             "colours": [
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "de34cd1f-6b6a-5c1d-9e35-f6ed3c75000d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c77833-8cd7-446f-bb67-454f85a972a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c77833-8cd7-446f-bb67-454f85a972a4.jpg?1",
             "name": "Chrome Host Seedshark",
             "text": "Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value.",
             "colours": [
@@ -15284,7 +15284,7 @@
         },
         {
             "id": "27a7b478-832d-5b90-86ed-486bced2873b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68813ee-bb24-4066-9c32-ca3ca2db3d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68813ee-bb24-4066-9c32-ca3ca2db3d4f.jpg?1",
             "name": "Complete the Circuit",
             "text": "Convoke\nYou may cast sorcery spells this turn as though they had flash.\nWhen you next cast an instant or sorcery spell this turn, copy that spell twice. You may choose new targets for the copies.",
             "colours": [
@@ -15318,7 +15318,7 @@
         },
         {
             "id": "aa26d966-64dc-5571-b4a6-1b4edd3dbab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb3321c-6b3f-4e7e-8557-b90855ff48cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb3321c-6b3f-4e7e-8557-b90855ff48cd.jpg?1",
             "name": "Faerie Mastermind",
             "text": "Flash\nFlying\nWhenever an opponent draws their second card each turn, you draw a card.\n{3}{U}: Each player draws a card.",
             "colours": [
@@ -15355,7 +15355,7 @@
         },
         {
             "id": "6f71b78b-939c-580c-983b-01efb42d2cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa9084e-3a93-4fba-8c67-2b3065d6fd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa9084e-3a93-4fba-8c67-2b3065d6fd5c.jpg?1",
             "name": "See Double",
             "text": "This spell can't be copied.\nChoose one. If an opponent has eight or more cards in their graveyard, you may choose both.\n\u2022 Copy target spell. You may choose new targets for the copy.\n\u2022 Create a token that's a copy of target creature.",
             "colours": [
@@ -15389,7 +15389,7 @@
         },
         {
             "id": "4cb697b7-69e4-58cd-b7b8-4ddf366b0e0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc45791-af1f-4647-a567-29c64e1855df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc45791-af1f-4647-a567-29c64e1855df.jpg?1",
             "name": "Transcendent Message",
             "text": "Convoke\nDraw X cards.",
             "colours": [
@@ -15423,7 +15423,7 @@
         },
         {
             "id": "9eb2fc70-5a06-5d06-b2b3-5a2788a81f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41046d8a-a39b-42e4-9ed4-6cbdf60371b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41046d8a-a39b-42e4-9ed4-6cbdf60371b5.jpg?1",
             "name": "Zephyr Singer",
             "text": "Convoke\nFlying, vigilance\nWhen Zephyr Singer enters the battlefield, put a flying counter on each creature that convoked it.",
             "colours": [
@@ -15460,7 +15460,7 @@
         },
         {
             "id": "ea1c00eb-c7cc-56a7-8c4a-5f2da76d5c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4332d36c-0db6-43fc-823b-6b6876e64b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4332d36c-0db6-43fc-823b-6b6876e64b54.jpg?1",
             "name": "Archpriest of Shadows",
             "text": "Backup 1\nDeathtouch\nWhenever this creature deals combat damage to a player or battle, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "c752aeeb-a59e-53a6-862e-5e56981a616c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd459d06-2c0d-4999-bedd-8455371799fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd459d06-2c0d-4999-bedd-8455371799fe.jpg?1",
             "name": "Bloated Processor",
             "text": "Sacrifice another Phyrexian: Put a +1/+1 counter on Bloated Processor.\nWhen Bloated Processor dies, incubate X, where X is its power.",
             "colours": [
@@ -15533,7 +15533,7 @@
         },
         {
             "id": "dd0c8bf7-c04c-5cdb-b49b-3b13846cb69e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee99acde-796c-423b-81ed-13d33e210925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee99acde-796c-423b-81ed-13d33e210925.jpg?1",
             "name": "Breach the Multiverse",
             "text": "Each player mills ten cards. For each player, choose a creature or planeswalker card in that player's graveyard. Put those cards onto the battlefield under your control. Then each creature you control becomes a Phyrexian in addition to its other types.",
             "colours": [
@@ -15567,7 +15567,7 @@
         },
         {
             "id": "1e9257ed-d8cc-5ec2-937b-5b12506843f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21321e17-79fd-43f1-93ae-4b87f0d0951a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21321e17-79fd-43f1-93ae-4b87f0d0951a.jpg?1",
             "name": "Grafted Butcher",
             "text": "When Grafted Butcher enters the battlefield, Phyrexians you control gain menace until end of turn.\nOther Phyrexians you control get +1/+1.\n{3}{B}, Sacrifice an artifact or creature: Return Grafted Butcher from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -15604,7 +15604,7 @@
         },
         {
             "id": "191e912b-67e6-5e9b-9324-6bc7a7eb1c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbfb78e-cbab-4511-a887-60dad1a6cb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cbfb78e-cbab-4511-a887-60dad1a6cb6b.jpg?1",
             "name": "Hoarding Broodlord",
             "text": "Convoke\nFlying\nWhen Hoarding Broodlord enters the battlefield, search your library for a card, exile it face down, then shuffle. For as long as that card remains exiled, you may play it.\nSpells you cast from exile have convoke.",
             "colours": [
@@ -15640,7 +15640,7 @@
         },
         {
             "id": "e38d4813-9119-5cc2-838c-9e6d0237ff6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f8aab2-995b-4e55-8c23-6915eac6278c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f8aab2-995b-4e55-8c23-6915eac6278c.jpg?1",
             "name": "Pile On",
             "text": "Convoke\nDestroy target creature or planeswalker. Surveil 2.",
             "colours": [
@@ -15674,7 +15674,7 @@
         },
         {
             "id": "bc21b817-627d-5db5-963e-71186fe0ad51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56ccab-6a43-48b4-ad65-b618e07c001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56ccab-6a43-48b4-ad65-b618e07c001f.jpg?1",
             "name": "Bloodfeather Phoenix",
             "text": "Flying\nBloodfeather Phoenix can't block.\nWhenever an instant or sorcery spell you control deals damage to an opponent or battle, you may pay {R}. If you do, return Bloodfeather Phoenix from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -15710,7 +15710,7 @@
         },
         {
             "id": "47b5bb14-f141-5e79-b18a-49cb543fbb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b86e4-c36a-42d1-8322-93ffa379ca3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b86e4-c36a-42d1-8322-93ffa379ca3e.jpg?1",
             "name": "City on Fire",
             "text": "Convoke\nIf a source you control would deal damage to a permanent or player, it deals triple that damage instead.",
             "colours": [
@@ -15744,7 +15744,7 @@
         },
         {
             "id": "2c8f7d10-2721-58b5-a36a-f0121257f414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33ee0-fdfa-417d-b4d6-77d4d25233d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33ee0-fdfa-417d-b4d6-77d4d25233d3.jpg?1",
             "name": "Into the Fire",
             "text": "Choose one \u2014\n\u2022 Into the Fire deals 2 damage to each creature, planeswalker, and battle.\n\u2022 Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.",
             "colours": [
@@ -15778,7 +15778,7 @@
         },
         {
             "id": "45cfcb73-95ff-59e9-8a3d-8fc44d179015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c92c29-ed97-41ea-936f-0db39d86b17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c92c29-ed97-41ea-936f-0db39d86b17e.jpg?1",
             "name": "Nahiri's Warcrafting",
             "text": "Nahiri's Warcrafting deals 5 damage to target creature, planeswalker, or battle. Look at the top X cards of your library, where X is the excess damage dealt this way. You may exile one of those cards. Put the rest on the bottom of your library in a random order. You may play the exiled card this turn.",
             "colours": [
@@ -15812,7 +15812,7 @@
         },
         {
             "id": "18c0a2e6-f7c1-52dd-9cb2-30c57acfe46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81513aff-337b-45f3-8e3d-895cee6eb492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81513aff-337b-45f3-8e3d-895cee6eb492.jpg?1",
             "name": "Rampaging Raptor",
             "text": "Trample, haste\n{2}{R}: Rampaging Raptor gets +2/+0 until end of turn.\nWhenever Rampaging Raptor deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls or battle that player protects.",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "e44a669d-28a4-5285-be7a-a142b984459a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8fc4f0-06d4-4504-86fb-df385e2c818e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb8fc4f0-06d4-4504-86fb-df385e2c818e.jpg?1",
             "name": "Voldaren Thrillseeker",
             "text": "Backup 2\n{1}, Sacrifice this creature: It deals damage equal to its power to any target.",
             "colours": [
@@ -15885,7 +15885,7 @@
         },
         {
             "id": "14cf6ea2-c33f-5fe3-bc5e-0eda9bb6a10d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13a3a77-c877-4822-b2e9-5abafa4aae9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13a3a77-c877-4822-b2e9-5abafa4aae9a.jpg?1",
             "name": "Ancient Imperiosaur",
             "text": "Convoke\nTrample, ward {2}\nAncient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.",
             "colours": [
@@ -15921,7 +15921,7 @@
         },
         {
             "id": "5a85690a-f52e-511e-a5fb-3cfbb0b9f365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5cc6f-c8b8-42fa-8cb0-8899b594f094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf5cc6f-c8b8-42fa-8cb0-8899b594f094.jpg?1",
             "name": "Deeproot Wayfinder",
             "text": "Whenever Deeproot Wayfinder deals combat damage to a player or battle, surveil 1, then you may return a land card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -15958,7 +15958,7 @@
         },
         {
             "id": "541f867b-6c7e-5d8d-bb68-81653d50289a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47961516-abf7-45d3-aad6-bce3dbd1327f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47961516-abf7-45d3-aad6-bce3dbd1327f.jpg?1",
             "name": "Doomskar Warrior",
             "text": "Backup 1\nTrample\nWhenever this creature deals combat damage to a player or battle, look at that many cards from the top of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -15995,7 +15995,7 @@
         },
         {
             "id": "7b03832e-0287-5ea6-81b7-9a24b9774a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4cc2dc-9ae8-4da1-8d9d-b2999f37625e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4cc2dc-9ae8-4da1-8d9d-b2999f37625e.jpg?1",
             "name": "Glistening Dawn",
             "text": "Incubate X twice, where X is the number of lands you control.",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "617e2253-af02-51f6-897a-d38653d057c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27455b98-d2a1-41f9-b827-cce21c4c1d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27455b98-d2a1-41f9-b827-cce21c4c1d84.jpg?1",
             "name": "Ozolith, the Shattered Spire",
             "text": "If one or more +1/+1 counters would be put on an artifact or creature you control, that many plus one +1/+1 counters are put on it instead.\n{1}{G}, {T}: Put a +1/+1 counter on target artifact or creature you control. Activate only as a sorcery.\nCycling {2}",
             "colours": [
@@ -16065,7 +16065,7 @@
         },
         {
             "id": "76ea3e11-9e58-541e-a832-323f52943285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cde7d3-e4b9-4c2e-a541-c7644e527551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cde7d3-e4b9-4c2e-a541-c7644e527551.jpg?1",
             "name": "Tribute to the World Tree",
             "text": "Whenever a creature enters the battlefield under your control, draw a card if its power is 3 or greater. Otherwise, put two +1/+1 counters on it.",
             "colours": [
@@ -16099,7 +16099,7 @@
         },
         {
             "id": "11682441-2fe4-5a62-920f-e343c0ed2ad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182520ae-d98f-4ef0-ad32-252f932f5d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182520ae-d98f-4ef0-ad32-252f932f5d51.jpg?1",
             "name": "Realmbreaker, the Invasion Tree",
             "text": "{2}, {T}: Target opponent mills three cards. Put a land card from their graveyard onto the battlefield tapped under your control. It gains \"If this land would leave the battlefield, exile it instead of putting it anywhere else.\"\n{1}0, {T}, Sacrifice Realmbreaker, the Invasion Tree: Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.",
             "colours": [],
@@ -16131,7 +16131,7 @@
         },
         {
             "id": "13179baf-9c3e-5632-a350-19c7ecd14704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255e402f-5083-4ce4-a807-ba17b949e384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255e402f-5083-4ce4-a807-ba17b949e384.jpg?1",
             "name": "Sword of Once and Future",
             "text": "Equipped creature gets +2/+2 and has protection from blue and from black.\nWhenever equipped creature deals combat damage to a player, surveil 2. Then you may cast an instant or sorcery spell with mana value 2 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.\nEquip {2}",
             "colours": [],
@@ -16163,7 +16163,7 @@
         },
         {
             "id": "b26166e1-bd5d-5c74-9043-b459987a81a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a21edf-c63c-47c1-8670-1f8bcf879fcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a21edf-c63c-47c1-8670-1f8bcf879fcf.jpg?1",
             "name": "Essence of Orthodoxy",
             "text": "Flying\nWhenever Essence of Orthodoxy or another Phyrexian enters the battlefield under your control, incubate 2.",
             "colours": [
@@ -16198,7 +16198,7 @@
         },
         {
             "id": "a585d1ca-d620-5409-b206-5583a60c47d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd6e040-2394-43c4-8aa5-2b7bde8b3862.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd6e040-2394-43c4-8aa5-2b7bde8b3862.jpg?1",
             "name": "Interdisciplinary Mascot",
             "text": "Convoke\nWard {3}\nWhen Interdisciplinary Mascot enters the battlefield, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -16234,7 +16234,7 @@
         },
         {
             "id": "867a78b1-24d5-5341-8997-2d9ad4c4adbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465c7c4-5e13-4273-9ea5-d8f6e2db1265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465c7c4-5e13-4273-9ea5-d8f6e2db1265.jpg?1",
             "name": "Terror of Towashi",
             "text": "Deathtouch\nWhenever Terror of Towashi attacks, you may pay {3}{B}. When you do, return target creature card from your graveyard to the battlefield. It's a Phyrexian in addition to its other types.",
             "colours": [
@@ -16270,7 +16270,7 @@
         },
         {
             "id": "a0f49c42-e116-5425-a64b-45ff72dd5170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ad2b1a-668e-4c7d-8158-b25897be22c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ad2b1a-668e-4c7d-8158-b25897be22c8.jpg?1",
             "name": "Orthion, Hero of Lavabrink",
             "text": "{1}{R}, {T}: Create a token that's a copy of another target creature you control. It gains haste. Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\n{6}{R}{R}{R}, {T}: Create five tokens that are copies of another target creature you control. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -16308,7 +16308,7 @@
         },
         {
             "id": "0ac5b7bf-085b-5dff-b2cc-6b9d89f4c783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d017cf-32b0-4770-a647-b29cfd1ac2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d017cf-32b0-4770-a647-b29cfd1ac2d1.jpg?1",
             "name": "Surrak and Goreclaw",
             "text": "Trample\nOther creatures you control have trample.\nWhenever another nontoken creature enters the battlefield under your control, put a +1/+1 counter on it. It gains haste until end of turn.",
             "colours": [
@@ -16346,7 +16346,7 @@
         },
         {
             "id": "776ee23d-9d5d-5ab3-ba23-0e7445532237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf90c1a-fcad-45b7-8666-79d55edd71b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf90c1a-fcad-45b7-8666-79d55edd71b1.jpg?1",
             "name": "Norn's Inquisitor",
             "text": "When Norn's Inquisitor enters the battlefield, incubate 2.\nWhenever a permanent you control transforms into a Phyrexian, put a +1/+1 counter on it.",
             "colours": [
@@ -16383,7 +16383,7 @@
         },
         {
             "id": "741cae61-1474-5b17-af15-e56fb8da6000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469ff89d-95d5-41b7-a0e6-912fa1e892f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469ff89d-95d5-41b7-a0e6-912fa1e892f0.jpg?1",
             "name": "Scrappy Bruiser",
             "text": "Whenever Scrappy Bruiser attacks, up to one target attacking creature gets +2/+0 and gains trample until end of turn. Return that creature to its owner's hand at end of combat. (Return it only if it's on the battlefield.)",
             "colours": [
@@ -16420,7 +16420,7 @@
         },
         {
             "id": "589f612a-2b1d-5bf2-a1d0-044ff0739623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97ba4c-7785-4245-b091-692c8fdb68e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97ba4c-7785-4245-b091-692c8fdb68e9.jpg?1",
             "name": "Kami of Whispered Hopes",
             "text": "If one or more +1/+1 counters would be put on a permanent you control, that many plus one +1/+1 counters are put on that permanent instead.\n{T}: Add X mana of any one color, where X is Kami of Whispered Hopes's power.",
             "colours": [
@@ -16456,7 +16456,7 @@
         },
         {
             "id": "9f25ae3b-4282-5c44-8032-939cde31ec46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dcbfc4-9791-496e-b17a-7ff1b3978e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dcbfc4-9791-496e-b17a-7ff1b3978e0c.jpg?1",
             "name": "Botanical Brawler",
             "text": "Trample\nBotanical Brawler enters the battlefield with two +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another permanent you control, if it's the first time +1/+1 counters have been put on that permanent this turn, put a +1/+1 counter on Botanical Brawler.",
             "colours": [
@@ -16495,7 +16495,7 @@
         },
         {
             "id": "93ec638a-e667-547a-9e68-449640860c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca2b471-9418-4881-b7dc-92209942698b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca2b471-9418-4881-b7dc-92209942698b.jpg?1",
             "name": "Halo Forager",
             "text": "Flying\nWhen Halo Forager enters the battlefield, you may pay {X}. When you do, you may cast target instant or sorcery card with mana value X from a graveyard without paying its mana cost. If that spell would be put into a graveyard, exile it instead.",
             "colours": [
@@ -16534,7 +16534,7 @@
         },
         {
             "id": "c9f3a2e0-0e85-5fd0-92a2-9d7f273cb871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccb21e9-5169-4934-83c3-78ac00e5ffc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccb21e9-5169-4934-83c3-78ac00e5ffc7.jpg?1",
             "name": "Ghalta and Mavren",
             "text": "Trample\nWhenever you attack, choose one \u2014\n\u2022 Create a tapped and attacking X/X green Dinosaur creature token with trample, where X is the greatest power among other attacking creatures.\n\u2022 Create X 1/1 white Vampire creature tokens with lifelink, where X is the number of other attacking creatures.",
             "colours": [
@@ -16575,7 +16575,7 @@
         },
         {
             "id": "300015bd-7cf4-50d1-84ef-06a5c83e4e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0acfa-1a8d-4a94-8972-c9bb235e4897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b0acfa-1a8d-4a94-8972-c9bb235e4897.jpg?1",
             "name": "Omnath, Locus of All",
             "text": "If you would lose unspent mana, that mana becomes black instead.\nAt the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",
             "colours": [
@@ -16622,7 +16622,7 @@
         },
         {
             "id": "b73ea419-17f3-538f-a806-124a03513cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27b3b91-8bef-4d3c-84ef-5015ca9e472c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27b3b91-8bef-4d3c-84ef-5015ca9e472c.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "53b344e6-83a3-5eb3-a468-efe9b0e6ea29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774c68a-3d76-4fe1-b741-e6acf6b9214c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1774c68a-3d76-4fe1-b741-e6acf6b9214c.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16692,7 +16692,7 @@
         },
         {
             "id": "c9b9d4d4-fced-558c-92ef-81c86be7e966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a2f3c3-fbcb-4b21-8f86-232c0db80c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a2f3c3-fbcb-4b21-8f86-232c0db80c1f.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -16727,7 +16727,7 @@
         },
         {
             "id": "fe3dc071-a8eb-558f-8f1a-2cf95935cc5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb727dec-dd82-4072-b2ec-a4e31b58752f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb727dec-dd82-4072-b2ec-a4e31b58752f.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -16762,7 +16762,7 @@
         },
         {
             "id": "2ca6847c-e3f2-5003-8034-7b4c956afc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b2c61-b903-4669-b9a3-110418a35593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7b2c61-b903-4669-b9a3-110418a35593.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -16797,7 +16797,7 @@
         },
         {
             "id": "430515a3-9c84-5aaf-8fe6-63cda4fa6731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69504a4-8caf-40c7-b998-1558a00444fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69504a4-8caf-40c7-b998-1558a00444fc.jpg?1",
             "name": "First Mate Ragavan",
             "text": "",
             "colours": [
@@ -16835,7 +16835,7 @@
         },
         {
             "id": "618893aa-cc4f-5940-8887-ad6f9a38a3a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6ea55-c976-40e7-aa09-5ba77688bfe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b6ea55-c976-40e7-aa09-5ba77688bfe9.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -16870,7 +16870,7 @@
         },
         {
             "id": "e167b906-df66-5cce-962b-1086f473e884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10358f5-d653-49a0-9d81-a5d4e6dafe25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10358f5-d653-49a0-9d81-a5d4e6dafe25.jpg?1",
             "name": "Phyrexian Saproling",
             "text": "",
             "colours": [
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "bbab9684-dcc4-5a3a-af74-b040cc9d3a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16943,7 +16943,7 @@
         },
         {
             "id": "74a6afcf-21ee-526d-876d-15aabe19fffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439bfc-8942-473b-9e4f-863017788476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88439bfc-8942-473b-9e4f-863017788476.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16980,7 +16980,7 @@
         },
         {
             "id": "5e46e483-0a40-57e9-9aea-59830b06d88f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff78d9-7c4c-4b3b-a485-5328e985315b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff78d9-7c4c-4b3b-a485-5328e985315b.jpg?1",
             "name": "Phyrexian Hydra",
             "text": "",
             "colours": [
@@ -17018,7 +17018,7 @@
         },
         {
             "id": "3a9a5194-7a70-54b0-b3f1-ff840ecbc811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bb0ec0-729e-4dcb-bab4-9f31c1056ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1bb0ec0-729e-4dcb-bab4-9f31c1056ab3.jpg?1",
             "name": "Phyrexian Hydra",
             "text": "",
             "colours": [
@@ -17056,7 +17056,7 @@
         },
         {
             "id": "7658c38d-f21f-5b0a-8b1a-7f1048012f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7dada-ba7f-4233-ba21-f6f32698997a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0ba7dada-ba7f-4233-ba21-f6f32698997a.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17093,7 +17093,7 @@
         },
         {
             "id": "bf20a56d-0799-512a-aa35-fa2df7e4deca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d02a57e-6c76-491c-85f8-8f4d825be2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d02a57e-6c76-491c-85f8-8f4d825be2c2.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -17130,7 +17130,7 @@
         },
         {
             "id": "70b5f89e-ef3b-5912-bcec-80db98a589fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2661ea2-7ff6-4188-9d40-f18bb625ed52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2661ea2-7ff6-4188-9d40-f18bb625ed52.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -17167,7 +17167,7 @@
         },
         {
             "id": "a2f6e1f2-4191-594a-abe9-568e8c2e0e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17198,7 +17198,7 @@
         },
         {
             "id": "58bfc65d-9684-592a-94f7-b02435e46de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca1decc-90fd-4df8-997e-52f8789032f8.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17230,7 +17230,7 @@
         },
         {
             "id": "7e5474f9-a09d-5e2a-8cc4-51a674771cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17261,7 +17261,7 @@
         },
         {
             "id": "55391123-7e23-5afa-9183-4b721a922977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f953c3-09b9-42c7-816d-59fb0f8b541c.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17293,7 +17293,7 @@
         },
         {
             "id": "f4fd5aae-f65c-5d73-88ce-2a052c7616f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17324,7 +17324,7 @@
         },
         {
             "id": "4db065f6-6ce4-5ce5-a19a-02dfc694ba5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5ed737-657b-43bf-b222-941da7579a4a.jpg?1",
             "name": "Incubator // Phyrexian",
             "text": "",
             "colours": [],
@@ -17356,7 +17356,7 @@
         },
         {
             "id": "d976794c-c6a4-56c8-8f29-7a3668f30b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0041d8-cacd-4057-8f99-37810edb4b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0041d8-cacd-4057-8f99-37810edb4b7e.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -17388,7 +17388,7 @@
         },
         {
             "id": "7f3fe0f9-49b9-562c-947b-74661b9bdaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e82686-0574-4fb3-8c3b-c6dbe3b24c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e82686-0574-4fb3-8c3b-c6dbe3b24c8d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17419,7 +17419,7 @@
         },
         {
             "id": "4873fe20-675e-5db5-b9ba-8d996c2806ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728ad2d-c8a6-49e4-85bb-29934fa26208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728ad2d-c8a6-49e4-85bb-29934fa26208.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -17450,7 +17450,7 @@
         },
         {
             "id": "220ed608-fe2e-58e2-bfb7-4b68c0aca779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33aefd66-d1d2-44fd-a2cc-8661291c407e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33aefd66-d1d2-44fd-a2cc-8661291c407e.jpg?1",
             "name": "Teferi Akosa of Zhalfir Emblem",
             "text": "",
             "colours": [],
@@ -17478,7 +17478,7 @@
         },
         {
             "id": "afada065-4cf0-5ee1-b63a-ba76493499be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8ebb6-26dc-41eb-ae40-47c8e7b040a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa8ebb6-26dc-41eb-ae40-47c8e7b040a6.jpg?1",
             "name": "Wrenn and Realmbreaker Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/MOR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MOR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e02a08dd-aaf9-5cd0-aa3c-9db8616c1e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a029814e-d84d-43e5-b483-e918871b3333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a029814e-d84d-43e5-b483-e918871b3333.jpg?1",
             "name": "Ballyrush Banneret",
             "text": "Kithkin spells and Soldier spells you play cost {1} less to play.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "cd9faa11-55aa-572a-a589-13e2a23a628d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5357e0-ff69-4bb9-9a02-b0372e0ea5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5357e0-ff69-4bb9-9a02-b0372e0ea5e5.jpg?1",
             "name": "Battletide Alchemist",
             "text": "If a source would deal damage to a player, you may prevent X of that damage, where X is the number of Clerics you control.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "693dcc5a-7664-53a4-8b9b-d7d403bb0d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb44500-0c07-4fb6-9525-ab41621be1b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb44500-0c07-4fb6-9525-ab41621be1b0.jpg?1",
             "name": "Burrenton Bombardier",
             "text": "Flying\nReinforce 2\u2014{2}{W} ({2}{W}, Discard this card: Put two +1/+1 counters on target creature.)",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "08312da7-f275-54fc-93eb-132976e4b85e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afc1033-0004-43c1-9341-c5ed0b0048f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1afc1033-0004-43c1-9341-c5ed0b0048f2.jpg?1",
             "name": "Burrenton Shield-Bearers",
             "text": "Whenever Burrenton Shield-Bearers attacks, target creature gets +0/+3 until end of turn.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "87eb702a-67c4-57fe-8ed4-ef5ac8cc9090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998c949-4791-477f-ab8d-e625199623ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998c949-4791-477f-ab8d-e625199623ad.jpg?1",
             "name": "Cenn's Tactician",
             "text": "{W}, {T}: Put a +1/+1 counter on target Soldier creature.\nEach creature you control with a +1/+1 counter on it can block an additional creature.",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "e6943899-811b-5d11-80dd-dd447922fba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7e0c9f-000d-494d-86f6-95e8d2b59ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7e0c9f-000d-494d-86f6-95e8d2b59ac7.jpg?1",
             "name": "Changeling Sentinel",
             "text": "Changeling (This card is every creature type at all times.)\nVigilance",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "095212d1-d307-5484-88b5-1031e4b30da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0b26b0-cc31-458b-8a92-aa3392d0ca0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d0b26b0-cc31-458b-8a92-aa3392d0ca0f.jpg?1",
             "name": "Coordinated Barrage",
             "text": "Choose a creature type. Coordinated Barrage deals damage to target attacking or blocking creature equal to the number of permanents you control of the chosen type.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "1d34c63c-7148-53a7-b303-1bce88d66f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d83dae-747b-4acf-adfd-7822dd64cfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d83dae-747b-4acf-adfd-7822dd64cfcc.jpg?1",
             "name": "Daily Regimen",
             "text": "Enchant creature\n{1}{W}: Put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "87fd49d7-1291-5803-b2aa-f5f9e7851be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1fff8e-0379-4d56-b726-f5cc56e63d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1fff8e-0379-4d56-b726-f5cc56e63d48.jpg?1",
             "name": "Feudkiller's Verdict",
             "text": "You gain 10 life. Then if you have more life than an opponent, put a 5/5 white Giant Warrior creature token into play.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "b684510a-44ad-561d-a90e-23ba0fa924c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e333-60f2-4e19-ad0f-5259d4feab37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e333-60f2-4e19-ad0f-5259d4feab37.jpg?1",
             "name": "Forfend",
             "text": "Prevent all damage that would be dealt to creatures this turn.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "4a38da33-bca8-501b-a2ba-2a35679c7245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38748fbe-0d3e-4697-b9c4-d93a4ac59f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38748fbe-0d3e-4697-b9c4-d93a4ac59f9a.jpg?1",
             "name": "Graceful Reprieve",
             "text": "When target creature is put into a graveyard this turn, return that card to play under its owner's control.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "076cee76-9e81-546e-8883-fd2de61be1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e7a59-7322-46eb-9903-00131234b310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5e7a59-7322-46eb-9903-00131234b310.jpg?1",
             "name": "Idyllic Tutor",
             "text": "Search your library for an enchantment card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "5e37f45f-0dd7-5490-8d58-3ce1545e740e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf33cb6-d159-4af3-8403-d0ac10af9894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf33cb6-d159-4af3-8403-d0ac10af9894.jpg?1",
             "name": "Indomitable Ancients",
             "text": "",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "5dfeadcd-d8e7-5e36-bd22-11701b19acf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e219-9e84-4f54-88e2-3925e48c4827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e219-9e84-4f54-88e2-3925e48c4827.jpg?1",
             "name": "Kinsbaile Borderguard",
             "text": "Kinsbaile Borderguard comes into play with a +1/+1 counter on it for each other Kithkin you control.\nWhen Kinsbaile Borderguard is put into a graveyard from play, put a 1/1 white Kithkin Soldier creature token into play for each counter on it.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "f51efbaf-1503-5344-a0d9-19818d037c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3d840-95af-4664-ace0-625f89f06a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe3d840-95af-4664-ace0-625f89f06a41.jpg?1",
             "name": "Kinsbaile Cavalier",
             "text": "Knight creatures you control have double strike.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "dda6fbc8-4f3d-50a4-a4ee-fa4182617f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8671abe8-4333-4b23-a87e-58bcc65deef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8671abe8-4333-4b23-a87e-58bcc65deef2.jpg?1",
             "name": "Kithkin Zephyrnaut",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Kithkin Zephyrnaut, you may reveal it. If you do, Kithkin Zephyrnaut gets +2/+2 and gains flying and vigilance until end of turn.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "f612b7c8-ecc4-5b82-bf7a-ad2384880f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7a4e9-08c3-4600-9eb5-03ed01ea0738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7a4e9-08c3-4600-9eb5-03ed01ea0738.jpg?1",
             "name": "Meadowboon",
             "text": "When Meadowboon leaves play, put a +1/+1 counter on each creature target player controls.\nEvoke {3}{W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "e4596d33-8311-5ea7-a611-5ce6eb929f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5bca35-5098-4100-815b-de141c82eb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5bca35-5098-4100-815b-de141c82eb6a.jpg?1",
             "name": "Mosquito Guard",
             "text": "First strike\nReinforce 1\u2014{1}{W} ({1}{W}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -619,7 +619,7 @@
         },
         {
             "id": "131bdbf0-7636-5d48-96ad-469a81001c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c2f16-5661-4c17-8265-f4b88ff1e833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d1c2f16-5661-4c17-8265-f4b88ff1e833.jpg?1",
             "name": "Order of the Golden Cricket",
             "text": "Whenever Order of the Golden Cricket attacks, you may pay {W}. If you do, it gains flying until end of turn.",
             "colours": [
@@ -654,7 +654,7 @@
         },
         {
             "id": "71f9ac67-3499-516b-8b9c-60ddb388a736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41659773-8b26-41bf-afcc-805f373c0074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41659773-8b26-41bf-afcc-805f373c0074.jpg?1",
             "name": "Preeminent Captain",
             "text": "First strike\nWhenever Preeminent Captain attacks, you may put a Soldier creature card from your hand into play tapped and attacking.",
             "colours": [
@@ -689,7 +689,7 @@
         },
         {
             "id": "abbedd3e-a2cb-5d8f-bf45-319e4a89416c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0f1aa1-b5be-43f0-822d-c4fcf33270d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a0f1aa1-b5be-43f0-822d-c4fcf33270d9.jpg?1",
             "name": "Redeem the Lost",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Clash with an opponent. If you win, return Redeem the Lost to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "6b215c2d-c537-5609-9aee-8714777b76b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5629edd4-b5d3-43f8-8c7c-f9d916e35158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5629edd4-b5d3-43f8-8c7c-f9d916e35158.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves play, return up to two target creature cards with power 2 or less from your graveyard to play.\nEvoke {5}{W} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "c3992bdd-645f-55f1-bcb5-71cc2d1d58c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dbd4a4-2a6f-477a-a267-27859ad73369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85dbd4a4-2a6f-477a-a267-27859ad73369.jpg?1",
             "name": "Shinewend",
             "text": "Flying\nShinewend comes into play with a +1/+1 counter on it.\n{1}{W}, Remove a +1/+1 counter from Shinewend: Destroy target enchantment.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "d043700c-c9ff-5a8d-9b4f-927b9367292b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363c51c5-b0fc-4c84-b3d6-8cc17c2387a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363c51c5-b0fc-4c84-b3d6-8cc17c2387a4.jpg?1",
             "name": "Stonehewer Giant",
             "text": "Vigilance\n{1}{W}, {T}: Search your library for an Equipment card and put it into play. Attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "4c756906-cc0c-5c95-a08b-2e0d89e0e586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fa2293-f398-4ad8-895e-c739ddea56d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69fa2293-f398-4ad8-895e-c739ddea56d0.jpg?1",
             "name": "Stonybrook Schoolmaster",
             "text": "Whenever Stonybrook Schoolmaster becomes tapped, you may put a 1/1 blue Merfolk Wizard creature token into play.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "4756f7e3-d3c5-5422-97ff-5db2b2dcdea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162bba28-667d-4acd-97ed-3421d12e0453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162bba28-667d-4acd-97ed-3421d12e0453.jpg?1",
             "name": "Swell of Courage",
             "text": "Creatures you control get +2/+2 until end of turn.\nReinforce X\u2014{X}{W}{W} ({X}{W}{W}, Discard this card: Put X +1/+1 counters on target creature.)",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "de139dc6-5d5c-540b-a3dd-810df3742c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5c82f9-4bc5-4326-92c0-d2aa4b4838a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5c82f9-4bc5-4326-92c0-d2aa4b4838a5.jpg?1",
             "name": "Wandering Graybeard",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Wandering Graybeard, you may reveal it. If you do, you gain 4 life.",
             "colours": [
@@ -926,7 +926,7 @@
         },
         {
             "id": "0111ac5f-a597-5c1f-b2a0-2be7b745d1ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396c8c41-70b4-4189-9160-8b7367a817a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396c8c41-70b4-4189-9160-8b7367a817a2.jpg?1",
             "name": "Weight of Conscience",
             "text": "Enchant creature\nEnchanted creature can't attack.\nTap two untapped creatures you control that share a creature type: Remove enchanted creature from the game.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "b04f7bb0-9634-5d56-8b0f-380e5375e8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e67d62f-9629-463b-a445-4181f6fafd0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e67d62f-9629-463b-a445-4181f6fafd0f.jpg?1",
             "name": "Declaration of Naught",
             "text": "As Declaration of Naught comes into play, name a card.\n{U}: Counter target spell with that name.",
             "colours": [
@@ -992,7 +992,7 @@
         },
         {
             "id": "ae5b947d-43ff-5801-871f-567b0b52a38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b14ad2-0ac7-4ae1-8a9e-eb49c8c5cc40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b14ad2-0ac7-4ae1-8a9e-eb49c8c5cc40.jpg?1",
             "name": "Dewdrop Spy",
             "text": "Flash\nFlying\nWhen Dewdrop Spy comes into play, look at the top card of target player's library.",
             "colours": [
@@ -1027,7 +1027,7 @@
         },
         {
             "id": "48f67fe0-94a7-5231-94e1-a12853b8d498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "3fb7af23-7b1b-5b97-8277-662f6824be1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a28e4f9-3b68-40bb-bf77-850b08c6b096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a28e4f9-3b68-40bb-bf77-850b08c6b096.jpg?1",
             "name": "Distant Melody",
             "text": "Choose a creature type. Draw a card for each permanent you control of that type.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "71ac33ae-70c7-55b1-ba94-7617c3d91f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c0929f-bee6-416d-8571-6540ae4f6e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c0929f-bee6-416d-8571-6540ae4f6e4f.jpg?1",
             "name": "Fencer Clique",
             "text": "Flying\n{U}: Put Fencer Clique on top of its owner's library.",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "06cf5425-91ee-5887-9231-3cb709d8813f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71265bb0-bf51-4d9d-b94c-c90adf65c55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71265bb0-bf51-4d9d-b94c-c90adf65c55b.jpg?1",
             "name": "Floodchaser",
             "text": "Floodchaser comes into play with six +1/+1 counters on it.\nFloodchaser can't attack unless defending player controls an Island.\n{U}, Remove a +1/+1 counter from Floodchaser: Target land becomes an Island until end of turn.",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "a9b3fcb9-dd4e-5818-88d0-86e851b0572a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c4dceb-6889-4a79-87c2-98952f3478bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c4dceb-6889-4a79-87c2-98952f3478bb.jpg?1",
             "name": "Grimoire Thief",
             "text": "Whenever Grimoire Thief becomes tapped, remove the top three cards of target opponent's library from the game face down.\nYou may look at cards removed from the game with Grimoire Thief.\n{U}, Sacrifice Grimoire Thief: Turn all cards removed from the game with Grimoire Thief face up. Counter all spells with those names.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "30258a82-da21-52f5-87e5-e1748a7a824e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1bf0ad-f718-4118-9e9b-19041cfbb5cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1bf0ad-f718-4118-9e9b-19041cfbb5cf.jpg?1",
             "name": "Ink Dissolver",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Ink Dissolver, you may reveal it. If you do, each opponent puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1230,7 +1230,7 @@
         },
         {
             "id": "faf67ae3-8991-5cf8-9ba4-ab7d4d215052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0960dc0a-907b-4e02-a0b5-dd2613be8e65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0960dc0a-907b-4e02-a0b5-dd2613be8e65.jpg?1",
             "name": "Inspired Sprite",
             "text": "Flash\nFlying\nWhenever you play a Wizard spell, you may untap Inspired Sprite.\n{T}: Draw a card, then discard a card.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "43945f6f-2816-5171-a887-5f4726c7c677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d283c49-2e81-4b2e-956a-69152cc4704e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d283c49-2e81-4b2e-956a-69152cc4704e.jpg?1",
             "name": "Knowledge Exploitation",
             "text": "Prowl {3}{U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nSearch target opponent's library for an instant or sorcery card. You may play that card without paying its mana cost. Then that player shuffles his or her library.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "f99f9733-1158-5b07-a20f-12f4a014dffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32d51e-1ec0-46aa-b240-e28a1fb64d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32d51e-1ec0-46aa-b240-e28a1fb64d73.jpg?1",
             "name": "Latchkey Faerie",
             "text": "Flying\nProwl {2}{U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Faerie or Rogue.)\nWhen Latchkey Faerie comes into play, if its prowl cost was paid, draw a card.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "e2956c48-b49d-51d1-aa47-2bd941a52457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b4e77f-012f-47f4-8b44-930148250b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b4e77f-012f-47f4-8b44-930148250b1d.jpg?1",
             "name": "Merrow Witsniper",
             "text": "When Merrow Witsniper comes into play, target player puts the top card of his or her library into his or her graveyard.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "756fd41d-64fa-5c33-9ff2-05485ae1a548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7cd9b6-1ea8-423d-8aa0-8699fffbcf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7cd9b6-1ea8-423d-8aa0-8699fffbcf50.jpg?1",
             "name": "Mind Spring",
             "text": "Draw X cards.",
             "colours": [
@@ -1402,7 +1402,7 @@
         },
         {
             "id": "4d38b559-c441-5770-87a8-acb309bb825c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da9bc9-6ac5-432d-ac12-04088cc6c74d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95da9bc9-6ac5-432d-ac12-04088cc6c74d.jpg?1",
             "name": "Mothdust Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nTap an untapped creature you control: Mothdust Changeling gains flying until end of turn.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "4f46c0e4-67a0-5d76-9a4e-489fa5bf4b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a501252-e722-4ebf-bcf7-f53a42745fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a501252-e722-4ebf-bcf7-f53a42745fa7.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "a682d9e6-a14a-56fe-8c07-8148e525e9bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fa77d1-cd61-4ef8-a71f-7c92b1f3b074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1fa77d1-cd61-4ef8-a71f-7c92b1f3b074.jpg?1",
             "name": "Nevermaker",
             "text": "Flying\nWhen Nevermaker leaves play, put target nonland permanent on top of its owner's library.\nEvoke {3}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "13dc663a-9648-582d-b97d-2cc7fd26ac7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4b5890-21d3-4eb9-a959-645dd389dde6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4b5890-21d3-4eb9-a959-645dd389dde6.jpg?1",
             "name": "Notorious Throng",
             "text": "Prowl {5}{U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nPut X 1/1 black Faerie Rogue creature tokens with flying into play, where X is the damage dealt to your opponents this turn. If Notorious Throng's prowl cost was paid, take an extra turn after this one.",
             "colours": [
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "e76eef53-f0b4-5a45-8bec-670577b35e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927bab71-a208-4ff2-b6c9-51b63468db38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927bab71-a208-4ff2-b6c9-51b63468db38.jpg?1",
             "name": "Research the Deep",
             "text": "Draw a card. Clash with an opponent. If you win, return Research the Deep to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "189dfaad-f667-56c3-94e7-4f67f982112f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b3e46e-7a65-4c2a-989b-b626b20e1b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37b3e46e-7a65-4c2a-989b-b626b20e1b14.jpg?1",
             "name": "Sage of Fables",
             "text": "Each other Wizard creature you control comes into play with an additional +1/+1 counter on it.\n{2}, Remove a +1/+1 counter from a creature you control: Draw a card.",
             "colours": [
@@ -1604,7 +1604,7 @@
         },
         {
             "id": "d7d4649b-ebe6-53f8-80d0-61c778d5a668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ccd5f6-b363-433f-9e98-f65e10b10bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ccd5f6-b363-433f-9e98-f65e10b10bc9.jpg?1",
             "name": "Sage's Dousing",
             "text": "Counter target spell unless its controller pays {3}. If you control a Wizard, draw a card.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "a540dbdc-a0ae-5808-b99f-ae2a531b4e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9341e6-b899-418d-916f-550775af419f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9341e6-b899-418d-916f-550775af419f.jpg?1",
             "name": "Sigil Tracer",
             "text": "{1}{U}, Tap two untapped Wizards you control: Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -1674,7 +1674,7 @@
         },
         {
             "id": "e5110866-2adb-5587-a37b-329f8d21612e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9df4e-2ee7-4c77-91b0-ad6e624340cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec9df4e-2ee7-4c77-91b0-ad6e624340cd.jpg?1",
             "name": "Slithermuse",
             "text": "When Slithermuse leaves play, choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference.\nEvoke {3}{U} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "146b7bab-0363-5ce1-a7d7-19c4ea49ca3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3e9c6c-e11a-4771-ae1a-3c13cc97e92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3e9c6c-e11a-4771-ae1a-3c13cc97e92e.jpg?1",
             "name": "Stonybrook Banneret",
             "text": "Islandwalk\nMerfolk spells and Wizard spells you play cost {1} less to play.",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "97f9b50d-7b2c-587a-88b3-93b1c3eab0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ba05db-6b09-4b6a-b7fe-13c1e1058e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ba05db-6b09-4b6a-b7fe-13c1e1058e25.jpg?1",
             "name": "Stream of Unconsciousness",
             "text": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "2accbeb6-dc14-5ea2-85b0-d405aad195fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea92ba-d6e3-4fba-be81-86b10852a9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea92ba-d6e3-4fba-be81-86b10852a9d1.jpg?1",
             "name": "Supreme Exemplar",
             "text": "Flying\nChampion an Elemental (When this comes into play, sacrifice it unless you remove another Elemental you control from the game. When this leaves play, that card returns to play.)",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "6a0b021e-30fd-5991-a655-36192a7c4021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8175ec81-f4e2-45d2-a9d8-e8855e17ff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8175ec81-f4e2-45d2-a9d8-e8855e17ff4a.jpg?1",
             "name": "Thieves' Fortune",
             "text": "Prowl {U} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nLook at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1847,7 +1847,7 @@
         },
         {
             "id": "29be6065-fe26-575c-8ac6-24cbf3aa751a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53d8540-fb6d-4d4c-b467-ebfbfa53c880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53d8540-fb6d-4d4c-b467-ebfbfa53c880.jpg?1",
             "name": "Vendilion Clique",
             "text": "Flash\nFlying\nWhen Vendilion Clique comes into play, look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of his or her library, then draws a card.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "35d2419c-39c9-55a2-8fce-3f3f66d22906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5c04f-fd5e-4e4c-9146-f9e6ef20a159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5c04f-fd5e-4e4c-9146-f9e6ef20a159.jpg?1",
             "name": "Waterspout Weavers",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Waterspout Weavers, you may reveal it. If you do, each creature you control gains flying until end of turn.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "9b9d969f-109c-5a0a-9f65-bcd3761c224e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5caf12-9358-490b-aafa-fc4d2b8b9b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5caf12-9358-490b-aafa-fc4d2b8b9b22.jpg?1",
             "name": "Auntie's Snitch",
             "text": "Auntie's Snitch can't block.\nProwl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhenever a Goblin or Rogue you control deals combat damage to a player, if Auntie's Snitch is in your graveyard, you may return Auntie's Snitch to your hand.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "133f3ccf-4693-5a23-ac98-b61e6cc1157b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8145fed6-6b51-420a-84cf-4ea5e0aa1883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8145fed6-6b51-420a-84cf-4ea5e0aa1883.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and put a 1/1 black Faerie Rogue creature token with flying into play.",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "49a9461d-1570-5a47-9f33-e17728a79b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6355f5b-c136-466c-bcfd-f2bf561217cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6355f5b-c136-466c-bcfd-f2bf561217cf.jpg?1",
             "name": "Blightsoil Druid",
             "text": "{T}, Pay 1 life: Add {G} to your mana pool.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "ade172bb-ccf4-5013-8f74-05d4728fa89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0116416b-ed95-4fa2-abc5-446de5c3106b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0116416b-ed95-4fa2-abc5-446de5c3106b.jpg?1",
             "name": "Earwig Squad",
             "text": "Prowl {2}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhen Earwig Squad comes into play, if its prowl cost was paid, search target opponent's library for three cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2060,7 +2060,7 @@
         },
         {
             "id": "152dbb93-11be-54d6-95ea-481a1cb9783d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fb2b62-eea7-469f-b237-fdce20b8bdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fb2b62-eea7-469f-b237-fdce20b8bdcf.jpg?1",
             "name": "Fendeep Summoner",
             "text": "{T}: Up to two target Swamps each become 3/5 Treefolk Warrior creatures in addition to their other types until end of turn.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "6de17214-1ea0-5bdd-a845-9ddfd1bf5bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614a9456-0ebf-4fba-b085-225f8c7e4a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614a9456-0ebf-4fba-b085-225f8c7e4a98.jpg?1",
             "name": "Festercreep",
             "text": "Festercreep comes into play with a +1/+1 counter on it.\n{1}{B}, Remove a +1/+1 counter from Festercreep: All other creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "46dd4fa8-828e-5bdd-9494-a064a5e4732c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb237de0-bf73-445f-a42b-c3da4cd35973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb237de0-bf73-445f-a42b-c3da4cd35973.jpg?1",
             "name": "Final-Sting Faerie",
             "text": "Flying\nWhen Final-Sting Faerie comes into play, destroy target creature that was dealt damage this turn.",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "9efb01c8-2732-54ef-aeb0-5645a80a509a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78543dac-7367-429f-88a5-83cb803193ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78543dac-7367-429f-88a5-83cb803193ef.jpg?1",
             "name": "Frogtosser Banneret",
             "text": "Haste\nGoblin spells and Rogue spells you play cost {1} less to play.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "9a4dffea-beb7-56e1-a7dc-c24e5ddcadfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba98d363-194b-4bc0-b9fe-987c498ab6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba98d363-194b-4bc0-b9fe-987c498ab6fa.jpg?1",
             "name": "Maralen of the Mornsong",
             "text": "Players can't draw cards.\nAt the beginning of each player's draw step, that player loses 3 life, searches his or her library for a card, puts it into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "e6ecba3d-3375-5a0a-a728-766683ea4e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6b2715-4d19-4980-8f5c-3ae20af6af72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6b2715-4d19-4980-8f5c-3ae20af6af72.jpg?1",
             "name": "Mind Shatter",
             "text": "Target player discards X cards at random.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "890fcea5-929c-5b86-9323-dc2a66435c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955348b-70e9-49c3-9343-9becf977abe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6955348b-70e9-49c3-9343-9becf977abe8.jpg?1",
             "name": "Moonglove Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{B}: Moonglove Changeling gains deathtouch until end of turn. (Whenever it deals damage to a creature, destroy that creature.)",
             "colours": [
@@ -2302,7 +2302,7 @@
         },
         {
             "id": "e784222b-f93b-5c11-ad7e-b12633a4219f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac48152-81c0-4cdc-8e3c-bfbe7b068b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac48152-81c0-4cdc-8e3c-bfbe7b068b28.jpg?1",
             "name": "Morsel Theft",
             "text": "Prowl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nTarget player loses 3 life and you gain 3 life. If Morsel Theft's prowl cost was paid, draw a card.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "7e892934-14dc-5631-a9f6-b2a62fc66ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a61cd-3a26-4142-83ce-9c41cdb16eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a61cd-3a26-4142-83ce-9c41cdb16eb4.jpg?1",
             "name": "Nightshade Schemers",
             "text": "Flying\nKinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Nightshade Schemers, you may reveal it. If you do, each opponent loses 2 life.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "38934412-f61e-57a8-8b74-f6da63eaf358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932649ab-ed5e-405f-986f-855d8a7c8eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932649ab-ed5e-405f-986f-855d8a7c8eb2.jpg?1",
             "name": "Noggin Whack",
             "text": "Prowl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)\nTarget player reveals three cards from his or her hand. You choose two of them. That player discards those cards.",
             "colours": [
@@ -2407,7 +2407,7 @@
         },
         {
             "id": "3cf78189-5cc5-5d9c-9dd6-26a441b16338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632dcea3-53ad-4317-b8bc-457b1887e7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/632dcea3-53ad-4317-b8bc-457b1887e7b5.jpg?1",
             "name": "Offalsnout",
             "text": "Flash\nWhen Offalsnout leaves play, remove target card in a graveyard from the game.\nEvoke {B} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "3fee5cfe-7cc9-52df-90b1-77c6cd64eee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180abc09-b098-4a51-bf4f-c1ad7c5e1c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180abc09-b098-4a51-bf4f-c1ad7c5e1c30.jpg?1",
             "name": "Oona's Blackguard",
             "text": "Flying\nEach other Rogue creature you control comes into play with an additional +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it deals combat damage to a player, that player discards a card.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "3117ceda-34a3-5ac2-a8be-cee2c50085ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79713cf7-2715-44cc-9f15-4c809b82efb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79713cf7-2715-44cc-9f15-4c809b82efb6.jpg?1",
             "name": "Pack's Disdain",
             "text": "Choose a creature type. Target creature gets -1/-1 until end of turn for each permanent of the chosen type you control.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "b77c808a-a760-5e5f-ac7a-79f80158a505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55121b63-22a6-4923-82e9-c55f66742980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55121b63-22a6-4923-82e9-c55f66742980.jpg?1",
             "name": "Prickly Boggart",
             "text": "Fear",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "b57dd121-36f1-519b-8dcd-5f1e0489079b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdce79d-c8a6-4172-8211-7cf2dcb8bf2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdce79d-c8a6-4172-8211-7cf2dcb8bf2d.jpg?1",
             "name": "Pulling Teeth",
             "text": "Clash with an opponent. If you win, target player discards two cards. Otherwise, that player discards a card. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "c528ad02-04ec-5075-8059-5a023c1dc55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0aa3c8-9e11-4917-956b-35b77a100761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0aa3c8-9e11-4917-956b-35b77a100761.jpg?1",
             "name": "Revive the Fallen",
             "text": "Return target creature card in a graveyard to its owner's hand. Clash with an opponent. If you win, return Revive the Fallen to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "3dbc8925-5291-55ef-827f-dc78f25da1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5c2b6-fcb2-4865-a0e5-9af59d94ae5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd5c2b6-fcb2-4865-a0e5-9af59d94ae5a.jpg?1",
             "name": "Scarblade Elite",
             "text": "{T}, Remove an Assassin card in your graveyard from the game: Destroy target creature.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "6f54a402-9437-5268-a02e-d0cf21407fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81290ae9-9217-482a-ae1a-be1a0ef47b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81290ae9-9217-482a-ae1a-be1a0ef47b5d.jpg?1",
             "name": "Squeaking Pie Grubfellows",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Squeaking Pie Grubfellows, you may reveal it. If you do, each opponent discards a card.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "21f94ec1-402a-5431-a355-248f36c0811d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c376fd5f-596a-4208-b173-0b2e5165f2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c376fd5f-596a-4208-b173-0b2e5165f2e9.jpg?1",
             "name": "Stenchskipper",
             "text": "Flying\nAt end of turn, if you control no Goblins, sacrifice Stenchskipper.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "93a2eb43-4b14-5209-9cc6-f43f47f8befc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9818ad-db8d-41e2-945f-a8b487c2df76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9818ad-db8d-41e2-945f-a8b487c2df76.jpg?1",
             "name": "Stinkdrinker Bandit",
             "text": "Prowl {1}{B} (You may play this for its prowl cost if you dealt combat damage to a player this turn with a Goblin or Rogue.)\nWhenever a Rogue you control attacks and isn't blocked, it gets +2/+1 until end of turn.",
             "colours": [
@@ -2746,7 +2746,7 @@
         },
         {
             "id": "bd882e34-1f35-5c9c-8fd4-952597e6fe7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd0fa3-37d2-403e-99fe-8c9e57515e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd0fa3-37d2-403e-99fe-8c9e57515e9d.jpg?1",
             "name": "Violet Pall",
             "text": "Destroy target nonblack creature. Put a 1/1 black Faerie Rogue creature token with flying into play.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "18d77294-17b9-5e75-9b04-ec70877e979e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c1288b-5515-497f-b15d-520a29322f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c1288b-5515-497f-b15d-520a29322f5b.jpg?1",
             "name": "Warren Weirding",
             "text": "Target player sacrifices a creature. If a Goblin is sacrificed this way, that player puts two 1/1 black Goblin Rogue creature tokens into play, and those tokens gain haste until end of turn.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "43286367-366e-57b9-b3fe-b93b06a5bbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44d2eb4-e5a3-4401-86cb-311374a2de04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44d2eb4-e5a3-4401-86cb-311374a2de04.jpg?1",
             "name": "Weed-Pruner Poplar",
             "text": "At the beginning of your upkeep, target creature other than Weed-Pruner Poplar gets -1/-1 until end of turn.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "d7eb0e5e-8a92-5025-8c96-e48d64ea0419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1d40cc-2871-4a33-bc58-5250fd3d4f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1d40cc-2871-4a33-bc58-5250fd3d4f0e.jpg?1",
             "name": "Weirding Shaman",
             "text": "{3}{B}, Sacrifice a Goblin: Put two 1/1 black Goblin Rogue creature tokens into play.",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "6e42f17f-f918-5a3c-9f71-2d6ef9e71bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d90bc4-7f70-4203-b554-800c70c775ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d90bc4-7f70-4203-b554-800c70c775ef.jpg?1",
             "name": "Boldwyr Heavyweights",
             "text": "Trample\nWhen Boldwyr Heavyweights comes into play, each opponent may search his or her library for a creature card and put it into play. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "801a8d9e-7172-574a-bbfa-cdf8ebd49d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e9f546-7d34-4ec5-a017-913d7ebb7223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e9f546-7d34-4ec5-a017-913d7ebb7223.jpg?1",
             "name": "Boldwyr Intimidator",
             "text": "Cowards can't block Warriors.\n{R}: Target creature becomes a Coward until end of turn.\n{2}{R}: Target creature becomes a Warrior until end of turn.",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "db0e1b67-86cd-56bb-b74f-2f1c5c3df2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ccfc78-b2d6-4eb7-b8bf-ba8bd876d2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ccfc78-b2d6-4eb7-b8bf-ba8bd876d2b8.jpg?1",
             "name": "Borderland Behemoth",
             "text": "Trample\nBorderland Behemoth gets +4/+4 for each other Giant you control.",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "9711561b-b585-57dd-9817-ca015bafee6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb44df5b-6c89-46ae-b068-5056b8c4c189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb44df5b-6c89-46ae-b068-5056b8c4c189.jpg?1",
             "name": "Brighthearth Banneret",
             "text": "Elemental spells and Warrior spells you play cost {1} less to play.\nReinforce 1\u2014{1}{R} ({1}{R}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "344fe1d1-a8b4-5683-a72a-072c59d7d88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3f7a3-05e7-44c0-9e09-3f28378677c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3f7a3-05e7-44c0-9e09-3f28378677c1.jpg?1",
             "name": "Countryside Crusher",
             "text": "At the beginning of your upkeep, reveal the top card of your library. If it's a land card, put it into your graveyard and repeat this process.\nWhenever a land card is put into your graveyard from anywhere, put a +1/+1 counter on Countryside Crusher.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "2fd08585-c8dd-5bff-9444-418e5524af08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04d5eef-da88-496b-a902-b87b0b386f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04d5eef-da88-496b-a902-b87b0b386f96.jpg?1",
             "name": "Fire Juggler",
             "text": "Whenever Fire Juggler becomes blocked, clash with an opponent. If you win, Fire Juggler deals 4 damage to each creature blocking it. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "9679c6e0-2472-5285-ab4e-4167eab73e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e172b353-7a16-4831-b735-206230b22e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e172b353-7a16-4831-b735-206230b22e59.jpg?1",
             "name": "Hostile Realm",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature can't block this turn.\"",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "c4893b37-7fff-58e2-b7dd-ca8318f8fe9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993956c9-30d8-41ee-84c2-c06d0512aea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993956c9-30d8-41ee-84c2-c06d0512aea4.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "c64283ca-e43e-5463-a144-0c3e233a72b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68f5ac9-0345-4052-9f93-d9f7afc66932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68f5ac9-0345-4052-9f93-d9f7afc66932.jpg?1",
             "name": "Lightning Crafter",
             "text": "Champion a Goblin or Shaman (When this comes into play, sacrifice it unless you remove another Goblin or Shaman you control from the game. When this leaves play, that card returns to play.)\n{T}: Lightning Crafter deals 3 damage to target creature or player.",
             "colours": [
@@ -3197,7 +3197,7 @@
         },
         {
             "id": "606d01f1-90b6-53cc-9dc9-ffc88214fc2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f459acfa-a9db-43c6-b0e9-ed66d772a335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f459acfa-a9db-43c6-b0e9-ed66d772a335.jpg?1",
             "name": "Lunk Errant",
             "text": "Whenever Lunk Errant attacks alone, it gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -3232,7 +3232,7 @@
         },
         {
             "id": "d95ee617-3d1a-55b6-85b7-1da7ffa5c778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5e2771-ae35-4aff-a92d-7fc7f3ca915f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5e2771-ae35-4aff-a92d-7fc7f3ca915f.jpg?1",
             "name": "Mudbutton Clanger",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Mudbutton Clanger, you may reveal it. If you do, Mudbutton Clanger gets +1/+1 until end of turn.",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "c66dd10c-db78-5a8f-8849-87a448b11384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a1c7c8-1acd-4219-a272-69e855517a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a1c7c8-1acd-4219-a272-69e855517a74.jpg?1",
             "name": "Pyroclast Consul",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Pyroclast Consul, you may reveal it. If you do, Pyroclast Consul deals 2 damage to each creature.",
             "colours": [
@@ -3302,7 +3302,7 @@
         },
         {
             "id": "2df9436e-3388-52f4-88b0-5dd58e1516cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe140361-93b2-4382-b85e-8c263d2f446e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe140361-93b2-4382-b85e-8c263d2f446e.jpg?1",
             "name": "Rage Forger",
             "text": "When Rage Forger comes into play, put a +1/+1 counter on each other Shaman creature you control.\nWhenever a creature you control with a +1/+1 counter on it attacks, you may have that creature deal 1 damage to target player.",
             "colours": [
@@ -3337,7 +3337,7 @@
         },
         {
             "id": "f203002d-492a-5d11-bfbe-ff1840a80810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6f1afb-2451-4611-ac3e-3513a4651719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6f1afb-2451-4611-ac3e-3513a4651719.jpg?1",
             "name": "Release the Ants",
             "text": "Release the Ants deals 1 damage to target creature or player. Clash with an opponent. If you win, return Release the Ants to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "76cbec0c-b033-5891-9521-46f5c304b400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2eee8b-cc55-4a65-983f-0a91d7e4494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2eee8b-cc55-4a65-983f-0a91d7e4494a.jpg?1",
             "name": "Rivals' Duel",
             "text": "Choose two target creatures that share no creature types. Each of those creatures deals damage equal to its power to the other.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "63d40784-bdb7-58fc-a519-611f83a7acf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b0e072-c51a-4e97-a089-8e5b540355aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b0e072-c51a-4e97-a089-8e5b540355aa.jpg?1",
             "name": "Roar of the Crowd",
             "text": "Choose a creature type. Roar of the Crowd deals damage to target creature or player equal to the number of permanents you control of the chosen type.",
             "colours": [
@@ -3433,7 +3433,7 @@
         },
         {
             "id": "4d769e12-e240-5cea-939d-ab0d87b48f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4971a447-29c8-47b6-863c-f13a69b4148b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4971a447-29c8-47b6-863c-f13a69b4148b.jpg?1",
             "name": "Seething Pathblazer",
             "text": "Sacrifice an Elemental: Seething Pathblazer gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3468,7 +3468,7 @@
         },
         {
             "id": "fa1655ee-cf1e-5fbb-b397-e570a21cfa58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5eb69-dcd9-4784-bf4c-20b674f4c035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e5eb69-dcd9-4784-bf4c-20b674f4c035.jpg?1",
             "name": "Sensation Gorger",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Sensation Gorger, you may reveal it. If you do, each player discards his or her hand and draws four cards.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "7efb8402-403d-5907-a3a3-292416498099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43db4810-078e-487a-afef-57cbc1db0cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43db4810-078e-487a-afef-57cbc1db0cc7.jpg?1",
             "name": "Shard Volley",
             "text": "As an additional cost to play Shard Volley, sacrifice a land.\nShard Volley deals 3 damage to target creature or player.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "cafadf7d-76e1-5857-a83d-a4803bd92e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe332c46-90f0-4cc0-8bf1-35a3934ff8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe332c46-90f0-4cc0-8bf1-35a3934ff8a0.jpg?1",
             "name": "Shared Animosity",
             "text": "Whenever a creature you control attacks, it gets +1/+0 until end of turn for each other attacking creature that shares a creature type with it.",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "c40a933c-cb0f-56d8-82e6-b49a066d7ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f2104d-aeff-493f-8227-cb95bf3e2eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f2104d-aeff-493f-8227-cb95bf3e2eab.jpg?1",
             "name": "Spitebellows",
             "text": "When Spitebellows leaves play, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -3601,7 +3601,7 @@
         },
         {
             "id": "a58dcd67-497c-5de4-9fc4-1030dc627a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0fdb4-187a-4178-a702-884bef9e029d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0fdb4-187a-4178-a702-884bef9e029d.jpg?1",
             "name": "Stingmoggie",
             "text": "Stingmoggie comes into play with two +1/+1 counters on it.\n{3}{R}, Remove a +1/+1 counter from Stingmoggie: Destroy target artifact or land.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "09cbf6df-68e9-58b8-8dda-71e7d1e7ef3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820f1acf-7f0c-4ee5-9f18-b5627aac7c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820f1acf-7f0c-4ee5-9f18-b5627aac7c81.jpg?1",
             "name": "Stomping Slabs",
             "text": "Reveal the top seven cards of your library, then put those cards on the bottom of your library in any order. If a card named Stomping Slabs was revealed this way, Stomping Slabs deals 7 damage to target creature or player.",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "07b59dd9-303d-553d-a776-192f2404c6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db24aa7-4922-4b39-9964-f76df09cba12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db24aa7-4922-4b39-9964-f76df09cba12.jpg?1",
             "name": "Sunflare Shaman",
             "text": "{1}{R}, {T}: Sunflare Shaman deals X damage to target creature or player and X damage to itself, where X is the number of Elemental cards in your graveyard.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "55fe035a-c30a-5568-9bf4-69b8551334ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50b5df1-b658-4df0-900e-79c44599b93e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50b5df1-b658-4df0-900e-79c44599b93e.jpg?1",
             "name": "Taurean Mauler",
             "text": "Changeling (This card is every creature type at all times.)\nWhenever an opponent plays a spell, you may put a +1/+1 counter on Taurean Mauler.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "010b14c3-d0c4-505b-b8f2-c0f7055b57d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b0f9ca-b752-4dd6-982b-06bb3a27ddbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b0f9ca-b752-4dd6-982b-06bb3a27ddbc.jpg?1",
             "name": "Titan's Revenge",
             "text": "Titan's Revenge deals X damage to target creature or player. Clash with an opponent. If you win, return Titan's Revenge to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "8cb61f54-e1e3-5ec1-9160-0e755391b82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5db7e33-188f-4d66-a58b-7b5c5760a773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5db7e33-188f-4d66-a58b-7b5c5760a773.jpg?1",
             "name": "Vengeful Firebrand",
             "text": "Vengeful Firebrand has haste as long as a Warrior card is in your graveyard.\n{R}: Vengeful Firebrand gets +1/+0 until end of turn.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "f53603f3-e100-546f-b8a7-e0f58070e1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917081e0-8a5f-4edc-b5e9-9a7302bb5c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917081e0-8a5f-4edc-b5e9-9a7302bb5c06.jpg?1",
             "name": "War-Spike Changeling",
             "text": "Changeling (This card is every creature type at all times.)\n{R}: War-Spike Changeling gains first strike until end of turn.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "69a73eea-8ba3-54e1-915b-400a83e03215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904d3416-70bf-4043-8078-f5f033ecfb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904d3416-70bf-4043-8078-f5f033ecfb31.jpg?1",
             "name": "Ambassador Oak",
             "text": "When Ambassador Oak comes into play, put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "3ab69ca8-bd94-55ad-bfe8-6bee194612e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203f41a7-ecf5-4757-9162-01ffd2a42ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203f41a7-ecf5-4757-9162-01ffd2a42ee9.jpg?1",
             "name": "Bosk Banneret",
             "text": "Treefolk spells and Shaman spells you play cost {1} less to play.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "f5e932c7-44fa-5c84-a4bf-3025ed336f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3910f5b2-17da-41e4-bf40-1c40b513fa12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3910f5b2-17da-41e4-bf40-1c40b513fa12.jpg?1",
             "name": "Bramblewood Paragon",
             "text": "Each other Warrior creature you control comes into play with an additional +1/+1 counter on it.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -3942,7 +3942,7 @@
         },
         {
             "id": "602edcd7-8a29-5152-b8f5-92b604334bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5459f1e6-7019-427d-9e2d-e494b3cd52d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5459f1e6-7019-427d-9e2d-e494b3cd52d2.jpg?1",
             "name": "Chameleon Colossus",
             "text": "Changeling (This card is every creature type at all times.)\nProtection from black\n{2}{G}{G}: Chameleon Colossus gets +X/+X until end of turn, where X is its power.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "edc6e1eb-550f-51d2-9465-4c6442e80469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030b0a9d-d0cf-4f3a-97b3-3e1d59226ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/030b0a9d-d0cf-4f3a-97b3-3e1d59226ee6.jpg?1",
             "name": "Cream of the Crop",
             "text": "Whenever a creature comes into play under your control, you may look at the top X cards of your library, where X is that creature's power. If you do, put one of those cards on top of your library and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4008,7 +4008,7 @@
         },
         {
             "id": "b5734943-e22b-514d-b641-e27b94e7b699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b43aa-58f0-42fc-9ef0-a7925727d58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b43aa-58f0-42fc-9ef0-a7925727d58f.jpg?1",
             "name": "Deglamer",
             "text": "Choose target artifact or enchantment. Its owner shuffles it into his or her library.",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "2de19504-d19e-5650-a491-bf912be6e650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478208df-9776-4354-b8a9-8da16ae1f50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478208df-9776-4354-b8a9-8da16ae1f50a.jpg?1",
             "name": "Earthbrawn",
             "text": "Target creature gets +3/+3 until end of turn.\nReinforce 1\u2014{1}{G} ({1}{G}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "75e63236-10bd-59c3-a6bb-7a96e8c47b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2154a16-1fb8-45bb-9b9b-e995e701c330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2154a16-1fb8-45bb-9b9b-e995e701c330.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "61b1b191-3d7a-51fe-82b5-cb28654888ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ae521-a176-4d93-92b1-89ba674f86e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077ae521-a176-4d93-92b1-89ba674f86e4.jpg?1",
             "name": "Everbark Shaman",
             "text": "{T}, Remove a Treefolk card in your graveyard from the game: Search your library for two Forest cards and put them into play tapped. Then shuffle your library.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "de79ffe9-420b-5ab8-ad76-fa4bfec81155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8055f1-cf3a-4db4-844e-b10bbbb25255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8055f1-cf3a-4db4-844e-b10bbbb25255.jpg?1",
             "name": "Fertilid",
             "text": "Fertilid comes into play with two +1/+1 counters on it.\n{1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches his or her library for a basic land card and puts it into play tapped. Then that player shuffles his or her library.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "def4a4db-d80d-58e9-a43e-246b49c70f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc76a7f-516f-4d0b-b024-39d5c8096a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc76a7f-516f-4d0b-b024-39d5c8096a9f.jpg?1",
             "name": "Game-Trail Changeling",
             "text": "Changeling (This card is every creature type at all times.)\nTrample",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "e59113fd-c6fe-5f09-a728-7095609812b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913f9b3-abbd-424b-8dea-061e15364fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a913f9b3-abbd-424b-8dea-061e15364fb0.jpg?1",
             "name": "Gilt-Leaf Archdruid",
             "text": "Whenever you play a Druid spell, you may draw a card.\nTap seven untapped Druids you control: Gain control of all lands target player controls.",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "a351eb29-0728-5938-8159-5f7a5a03aaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f64e8a-2775-4f64-8728-36e7d613f54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f64e8a-2775-4f64-8728-36e7d613f54c.jpg?1",
             "name": "Greatbow Doyen",
             "text": "Other Archer creatures you control get +1/+1.\nWhenever an Archer you control deals damage to a creature, that Archer deals that much damage to that creature's controller.",
             "colours": [
@@ -4280,7 +4280,7 @@
         },
         {
             "id": "29dddc60-20f2-57f0-ae13-a32b3854ac30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726acbd-724e-46c5-a4cf-4aee7c2abb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a726acbd-724e-46c5-a4cf-4aee7c2abb16.jpg?1",
             "name": "Heritage Druid",
             "text": "Tap three untapped Elves you control: Add {G}{G}{G} to your mana pool.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "22807b67-5993-5a75-9389-be824b01f32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093f039a-47af-4284-a7ab-67971c2bc5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093f039a-47af-4284-a7ab-67971c2bc5b2.jpg?1",
             "name": "Hunting Triad",
             "text": "Put three 1/1 green Elf Warrior creature tokens into play.\nReinforce 3\u2014{3}{G} ({3}{G}, Discard this card: Put three +1/+1 counters on target creature.)",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "6bc5a893-ea54-5463-a9e7-7763828cbe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c666dc97-8780-4982-b9e7-7d4a358f922c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c666dc97-8780-4982-b9e7-7d4a358f922c.jpg?1",
             "name": "Leaf-Crowned Elder",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Leaf-Crowned Elder, you may reveal it. If you do, you may play that card without paying its mana cost.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "e26616e2-2add-5e35-8186-83cd6ad269df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9903cc-350c-44cf-9c0b-5df7922ed766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9903cc-350c-44cf-9c0b-5df7922ed766.jpg?1",
             "name": "Luminescent Rain",
             "text": "Choose a creature type. You gain 2 life for each permanent you control of that type.",
             "colours": [
@@ -4417,7 +4417,7 @@
         },
         {
             "id": "a3ab23a8-5077-548a-9b15-6ca99aaabf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac845bd-becd-4c58-9561-7cdf2adca058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac845bd-becd-4c58-9561-7cdf2adca058.jpg?1",
             "name": "Lys Alana Bowmaster",
             "text": "Reach (This can block creatures with flying.)\nWhenever you play an Elf spell, you may have Lys Alana Bowmaster deal 2 damage to target creature with flying.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "11793fd4-afb1-54e7-881d-f169d25d389b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e2c5c-26ad-4b13-934b-e545038b6729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e2c5c-26ad-4b13-934b-e545038b6729.jpg?1",
             "name": "Orchard Warden",
             "text": "Whenever another Treefolk creature comes into play under your control, you may gain life equal to that creature's toughness.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "bf47a0f6-3b32-5d02-a23d-6f67808aa3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2215c-fdc0-4135-83ef-ddf4151318ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e2215c-fdc0-4135-83ef-ddf4151318ba.jpg?1",
             "name": "Reach of Branches",
             "text": "Put a 2/5 green Treefolk Shaman creature token into play.\nWhenever a Forest comes into play under your control, you may return Reach of Branches from your graveyard to your hand.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "cbae8e41-9054-57f2-b727-cf884f7b78f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfe1d8e-ae3c-4144-a44b-e13ab33da95c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfe1d8e-ae3c-4144-a44b-e13ab33da95c.jpg?1",
             "name": "Recross the Paths",
             "text": "Reveal cards from the top of your library until you reveal a land card. Put that card into play and the rest on the bottom of your library in any order. Clash with an opponent. If you win, return Recross the Paths to its owner's hand. (Each clashing player reveals the top card of his or her library, then puts that card on the top or bottom. A player wins if his or her card had a higher converted mana cost.)",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "345d9eb0-3991-5ff9-91ca-cec3bbbd9acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a0ef5-a63e-4013-b3d9-b42f2c42c7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a0ef5-a63e-4013-b3d9-b42f2c42c7a4.jpg?1",
             "name": "Reins of the Vinesteed",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nWhen enchanted creature is put into a graveyard, you may return Reins of the Vinesteed from your graveyard to play attached to a creature that shares a creature type with that creature.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "49522c29-5ee5-54df-9a2b-037cc9004ea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26da029-9c95-4e9b-9a1b-62048c16acaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26da029-9c95-4e9b-9a1b-62048c16acaf.jpg?1",
             "name": "Rhys the Exiled",
             "text": "Whenever Rhys the Exiled attacks, you gain 1 life for each Elf you control.\n{B}, Sacrifice an Elf: Regenerate Rhys the Exiled.",
             "colours": [
@@ -4626,7 +4626,7 @@
         },
         {
             "id": "0de4b8c9-17e0-5057-b118-722a8a82364f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84829605-50eb-455d-a236-ebfa11e883c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84829605-50eb-455d-a236-ebfa11e883c5.jpg?1",
             "name": "Scapeshift",
             "text": "Sacrifice any number of lands. Search your library for that many land cards, put them into play tapped, then shuffle your library.",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "f4447a07-087f-58d9-9346-7340910d98bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9de6380-6203-41ae-b134-8633eb5df076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9de6380-6203-41ae-b134-8633eb5df076.jpg?1",
             "name": "Unstoppable Ash",
             "text": "Trample\nChampion a Treefolk or Warrior (When this comes into play, sacrifice it unless you remove another Treefolk or Warrior you control from the game. When this leaves play, that card returns to play.)\nWhenever a creature you control becomes blocked, it gets +0/+5 until end of turn.",
             "colours": [
@@ -4693,7 +4693,7 @@
         },
         {
             "id": "da5abe84-6b81-5a7d-8509-f4c5ccf30182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2675b8b-a321-4982-b1d9-5c55d27b9bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2675b8b-a321-4982-b1d9-5c55d27b9bfd.jpg?1",
             "name": "Walker of the Grove",
             "text": "When Walker of the Grove leaves play, put a 4/4 green Elemental creature token into play.\nEvoke {4}{G} (You may play this spell for its evoke cost. If you do, it's sacrificed when it comes into play.)",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "29b64465-ccff-5507-9a39-4b7b0eac93ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bed84-5a4a-4f16-af6c-789c542ce3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47bed84-5a4a-4f16-af6c-789c542ce3a7.jpg?1",
             "name": "Winnower Patrol",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Winnower Patrol, you may reveal it. If you do, put a +1/+1 counter on Winnower Patrol.",
             "colours": [
@@ -4762,7 +4762,7 @@
         },
         {
             "id": "2a1cd41d-f839-589c-8e2f-54f9024b883d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804ef999-0d44-420e-ad0c-a6dcf8e9c392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804ef999-0d44-420e-ad0c-a6dcf8e9c392.jpg?1",
             "name": "Wolf-Skull Shaman",
             "text": "Kinship At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Wolf-Skull Shaman, you may reveal it. If you do, put a 2/2 green Wolf creature token into play.",
             "colours": [
@@ -4797,7 +4797,7 @@
         },
         {
             "id": "f860f14f-9b41-5767-ba1b-426b1e32596c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bb3e3c-1a7d-4bc4-b69d-6a8e9f1b3fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bb3e3c-1a7d-4bc4-b69d-6a8e9f1b3fe7.jpg?1",
             "name": "Cloak and Dagger",
             "text": "Equipped creature gets +2/+0 and has shroud. (It can't be the target of spells or abilities.)\nWhenever a Rogue creature comes into play, you may attach Cloak and Dagger to it.\nEquip {3}",
             "colours": [],
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "7e2e20e2-2077-5cfb-84b4-e512a6181031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277eed87-6b78-456d-91fb-774c72b3ae8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277eed87-6b78-456d-91fb-774c72b3ae8c.jpg?1",
             "name": "Diviner's Wand",
             "text": "Equipped creature has \"Whenever you draw a card, this creature gets +1/+1 and gains flying until end of turn\" and \"{4}: Draw a card.\"\nWhenever a Wizard creature comes into play, you may attach Diviner's Wand to it.\nEquip {3}",
             "colours": [],
@@ -4861,7 +4861,7 @@
         },
         {
             "id": "0b050d4c-d831-50da-8fbd-10f3f2ec751c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4800be-5f77-42f5-914c-2a8e647e3af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac4800be-5f77-42f5-914c-2a8e647e3af5.jpg?1",
             "name": "Door of Destinies",
             "text": "As Door of Destinies comes into play, choose a creature type.\nWhenever you play a spell of that type, put a charge counter on Door of Destinies.\nCreatures you control of that type get +1/+1 for each charge counter on Door of Destinies.",
             "colours": [],
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "110efd2b-f97a-5d7c-bdc9-5cb4a087de81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7978371-9ea8-4264-9a2f-38226ea25018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7978371-9ea8-4264-9a2f-38226ea25018.jpg?1",
             "name": "Obsidian Battle-Axe",
             "text": "Equipped creature gets +2/+1 and has haste.\nWhenever a Warrior creature comes into play, you may attach Obsidian Battle-Axe to it.\nEquip {3}",
             "colours": [],
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "8b83fe22-0ab9-5fc4-9336-5a65fef6cbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab3225-64a9-411e-b22b-1869e958b8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ab3225-64a9-411e-b22b-1869e958b8e5.jpg?1",
             "name": "Thornbite Staff",
             "text": "Equipped creature has \"{2}, {T}: This creature deals 1 damage to target creature or player\" and \"Whenever a creature is put into a graveyard from play, untap this creature.\"\nWhenever a Shaman creature comes into play, you may attach Thornbite Staff to it.\nEquip {4}",
             "colours": [],
@@ -4953,7 +4953,7 @@
         },
         {
             "id": "c47bbca3-d316-560f-b530-5bd29c79e993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d0beb9-3381-423f-b54e-5490b892630a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d0beb9-3381-423f-b54e-5490b892630a.jpg?1",
             "name": "Veteran's Armaments",
             "text": "Equipped creature has \"Whenever this creature attacks or blocks, it gets +1/+1 until end of turn for each attacking creature.\"\nWhenever a Soldier creature comes into play, you may attach Veteran's Armaments to it.\nEquip {2}",
             "colours": [],
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "49f7e6a3-f229-5559-8b47-2a545b2c4ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4f8cc7-3d02-4cf2-920f-2cc32b58f397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4f8cc7-3d02-4cf2-920f-2cc32b58f397.jpg?1",
             "name": "Murmuring Bosk",
             "text": "({T}: Add {G} to your mana pool.)\nAs Murmuring Bosk comes into play, you may reveal a Treefolk card from your hand. If you don't, Murmuring Bosk comes into play tapped.\n{T}: Add {W} or {B} to your mana pool. Murmuring Bosk deals 1 damage to you.",
             "colours": [],
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "19712d57-2060-5100-b454-677e19d4b832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3c48b-f104-4292-9a4e-2ce87a65893c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca3c48b-f104-4292-9a4e-2ce87a65893c.jpg?1",
             "name": "Mutavault",
             "text": "{T}: Add {1} to your mana pool.\n{1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.",
             "colours": [],
@@ -5047,7 +5047,7 @@
         },
         {
             "id": "10dedaf2-27a4-5278-b1d3-03ca1301cec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c28c1d-0ebf-4e95-8d0a-56be10cc0ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c28c1d-0ebf-4e95-8d0a-56be10cc0ef2.jpg?1",
             "name": "Primal Beyond",
             "text": "As Primal Beyond comes into play, you may reveal an Elemental card from your hand. If you don't, Primal Beyond comes into play tapped.\n{T}: Add {1} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to play Elemental spells or activated abilities of Elementals.",
             "colours": [],
@@ -5075,7 +5075,7 @@
         },
         {
             "id": "6ad0fbd5-67ae-543e-bc47-4353a38bbbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bc170c-4a84-4c07-b481-b50b82f62f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bc170c-4a84-4c07-b481-b50b82f62f44.jpg?1",
             "name": "Rustic Clachan",
             "text": "As Rustic Clachan comes into play, you may reveal a Kithkin card from your hand. If you don't, Rustic Clachan comes into play tapped.\n{T}: Add {W} to your mana pool.\nReinforce 1\u2014{1}{W} ({1}{W}, Discard this card: Put a +1/+1 counter on target creature.)",
             "colours": [],
@@ -5105,7 +5105,7 @@
         },
         {
             "id": "2693e39f-f3c5-571a-91f0-1c619794439d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0661166a-7d6c-4cba-8190-8d3eedf7f58c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0661166a-7d6c-4cba-8190-8d3eedf7f58c.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -5140,7 +5140,7 @@
         },
         {
             "id": "71f2319e-6832-577e-801e-2e21d28505b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1666cae8-8750-4091-8e45-259e76268db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1666cae8-8750-4091-8e45-259e76268db9.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -5175,7 +5175,7 @@
         },
         {
             "id": "c708411b-0c07-54f8-a11f-3e686a91fe34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c82ec9-692e-48eb-9337-c350fe815a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c82ec9-692e-48eb-9337-c350fe815a3e.jpg?1",
             "name": "Treefolk Shaman",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/MRD.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/MRD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ca851196-6344-5b10-82a0-ef1cba6a921a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd037f62-7cef-4737-b575-942c5959f1ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd037f62-7cef-4737-b575-942c5959f1ea.jpg?1",
             "name": "Altar's Light",
             "text": "Remove target artifact or enchantment from the game.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "ce8578ff-7446-5af1-81fd-162b8e02e01d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ca260d-4ed8-4a99-b00a-0be15ba0df9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ca260d-4ed8-4a99-b00a-0be15ba0df9f.jpg?1",
             "name": "Arrest",
             "text": "Enchanted creature can't attack or block, and its activated abilities can't be played.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "abd0d2bb-01f6-5a8a-b491-7f52250b85c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51605471-1198-4296-a9b5-3bee14ac2091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51605471-1198-4296-a9b5-3bee14ac2091.jpg?1",
             "name": "Auriok Bladewarden",
             "text": "{T}: Target creature gets +X/+X until end of turn, where X is Auriok Bladewarden's power.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "f2b80e4f-4f3f-5fe8-bf7d-7c014a301b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd09c01-5a77-4992-96ae-c395a5966a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd09c01-5a77-4992-96ae-c395a5966a92.jpg?1",
             "name": "Auriok Steelshaper",
             "text": "Equip costs you pay cost {1} less.\nAs long as Auriok Steelshaper is equipped, Soldiers and Knights you control get +1/+1.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "083d2026-6a66-5b86-9738-1557873b5c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5c3f22-f228-4503-9d35-ee1b36a46ef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f5c3f22-f228-4503-9d35-ee1b36a46ef0.jpg?1",
             "name": "Auriok Transfixer",
             "text": "{W}, {T}: Tap target artifact.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "a3bb66d9-2327-59cd-adfa-4b14e8da1255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cd231b-7891-42b5-b5de-5112d1230c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cd231b-7891-42b5-b5de-5112d1230c37.jpg?1",
             "name": "Awe Strike",
             "text": "The next time target creature would deal damage this turn, prevent that damage. You gain life equal to the damage prevented this way.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "a5b02fbc-0908-5d82-a4db-c97e3b13c0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73f6e4c-9da7-45ec-b786-1b2f59d6b73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73f6e4c-9da7-45ec-b786-1b2f59d6b73b.jpg?1",
             "name": "Blinding Beam",
             "text": "Choose one Tap two target creatures; or creatures don't untap during target player's next untap step.\nEntwine {1} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "cbdd916f-11ef-5ce1-ac75-c149934a3525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5474bcc-4ffd-4b6d-98d0-891b766d5961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5474bcc-4ffd-4b6d-98d0-891b766d5961.jpg?1",
             "name": "Leonin Abunas",
             "text": "Artifacts you control can't be the targets of spells or abilities your opponents control.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "6d5e91b0-da0a-5ef1-b269-6057dc339486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f30b7a-75bb-44e6-b1a2-726df1b5b1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f30b7a-75bb-44e6-b1a2-726df1b5b1f3.jpg?1",
             "name": "Leonin Den-Guard",
             "text": "As long as Leonin Den-Guard is equipped, it gets +1/+1 and attacking doesn't cause it to tap.",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "d53968f1-4971-5d35-88d7-1477e9cd90ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b766e7-fe4a-47fb-949b-e046b5a38d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b766e7-fe4a-47fb-949b-e046b5a38d91.jpg?1",
             "name": "Leonin Elder",
             "text": "Whenever an artifact comes into play, you may gain 1 life.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "4e3dec9d-c032-5a83-a0fd-85789a0f45bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275a47e1-816c-44f9-bd05-b8b56410436f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275a47e1-816c-44f9-bd05-b8b56410436f.jpg?1",
             "name": "Leonin Skyhunter",
             "text": "Flying",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "5c4e569e-75ab-5c2c-b42d-6b24bf2f595e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg?1",
             "name": "Loxodon Mender",
             "text": "{W}, {T}: Regenerate target artifact.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "1a87ceaa-f28a-5bf6-9d7f-baa64a8c5c52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9e7029-bea3-4a33-bd05-774e802616d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9e7029-bea3-4a33-bd05-774e802616d4.jpg?1",
             "name": "Loxodon Peacekeeper",
             "text": "At the beginning of your upkeep, the player with the lowest life total gains control of Loxodon Peacekeeper. If two or more players are tied for lowest life total, you choose one of them, and that player gains control of Loxodon Peacekeeper.",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "67628edb-2fef-5b6b-8e8f-619991a5b671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg?1",
             "name": "Loxodon Punisher",
             "text": "Loxodon Punisher gets +2/+2 for each Equipment attached to it.",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "b3744e7e-3f9f-5f55-b3d7-62f81efebb74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4f880d-6262-429f-91b7-def417aa13bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4f880d-6262-429f-91b7-def417aa13bd.jpg?1",
             "name": "Luminous Angel",
             "text": "Flying\nAt the beginning of your upkeep, you may put a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "f3766d63-daf4-5841-9438-c124142c2784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be510c8-fc01-4374-ac04-7968d24480fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be510c8-fc01-4374-ac04-7968d24480fe.jpg?1",
             "name": "Raise the Alarm",
             "text": "Put two 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "c99da938-e268-52fb-a300-7fc76ca14ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6743fab2-75b4-4eb8-b416-b5f052473393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6743fab2-75b4-4eb8-b416-b5f052473393.jpg?1",
             "name": "Razor Barrier",
             "text": "Target permanent you control gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "f50077fa-e8bf-5543-b742-748bf3fd04bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc697a4c-f219-46fd-90f2-63c638cd5ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc697a4c-f219-46fd-90f2-63c638cd5ef7.jpg?1",
             "name": "Roar of the Kha",
             "text": "Choose one Creatures you control get +1/+1 until end of turn; or untap all creatures you control.\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "d6968813-2b39-5e6c-9e2b-9065c7e16e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg?1",
             "name": "Rule of Law",
             "text": "Each player can't play more than one spell each turn.",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "11c2e5a1-cfe9-549f-a32a-b2d60491ce72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg?1",
             "name": "Second Sunrise",
             "text": "Each player returns to play all artifact, creature, enchantment, and land cards that were put into his or her graveyard from play this turn.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "cb5b7c69-f62a-50ed-886e-da8c01dbd940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd46bfba-0685-4dcb-9b63-f90da8fb0ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd46bfba-0685-4dcb-9b63-f90da8fb0ce7.jpg?1",
             "name": "Skyhunter Cub",
             "text": "As long as Skyhunter Cub is equipped, it gets +1/+1 and has flying.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "f0a15fa2-b077-5f78-940d-2e1e54af3daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c162594c-31f4-4d07-87ee-2d6ee7704980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c162594c-31f4-4d07-87ee-2d6ee7704980.jpg?1",
             "name": "Skyhunter Patrol",
             "text": "Flying, first strike",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "a5e31eb7-42b9-5e38-804b-c1237262d750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0286b42a-295b-467c-a1d8-0b31774b7ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0286b42a-295b-467c-a1d8-0b31774b7ac5.jpg?1",
             "name": "Slith Ascendant",
             "text": "Flying\nWhenever Slith Ascendant deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "97e6c970-4b67-568f-a62c-01914b286cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg?1",
             "name": "Solar Tide",
             "text": "Choose one Destroy all creatures with power 2 or less; or destroy all creatures with power 3 or greater.\nEntwine\u2014\nSacrifice two lands. (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "17547075-f07e-5cff-a8f4-2adcedf8fe5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862682d-cbf3-4c35-83d0-76883b0ac105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f862682d-cbf3-4c35-83d0-76883b0ac105.jpg?1",
             "name": "Soul Nova",
             "text": "Remove target attacking creature and all Equipment attached to it from the game.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "42533543-d748-59f4-93e4-f33481770c1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392944d5-bff1-4125-86db-68d05682a430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392944d5-bff1-4125-86db-68d05682a430.jpg?1",
             "name": "Sphere of Purity",
             "text": "If an artifact would deal damage to you, prevent 1 of that damage.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "32727caf-24e4-584b-9bef-e80a68149369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c24cb4-4d7d-41df-b5c2-bd967a6a5d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c24cb4-4d7d-41df-b5c2-bd967a6a5d7e.jpg?1",
             "name": "Taj-Nar Swordsmith",
             "text": "When Taj-Nar Swordsmith comes into play, you may pay {X}. If you do, search your library for an Equipment card with converted mana cost X or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "83204ed4-53da-5880-bbab-a2b16f54a102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd05d7-eb2d-489d-ad1c-5527d3336a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd05d7-eb2d-489d-ad1c-5527d3336a6d.jpg?1",
             "name": "Tempest of Light",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "8592440a-ee14-5312-9353-7d7419e7c036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba18ec8-e82f-41be-9ed8-b1a4ae9b7426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8ba18ec8-e82f-41be-9ed8-b1a4ae9b7426.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "8bac1c12-e490-53da-950f-56f18575ef67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc339ed7-e1d4-4fe9-a4c4-b030d3e74c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc339ed7-e1d4-4fe9-a4c4-b030d3e74c00.jpg?1",
             "name": "Assert Authority",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nCounter target spell. If it's countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1009,7 +1009,7 @@
         },
         {
             "id": "5cb0855e-38d4-5dbf-af8d-19da6294311e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a194cb-53c9-4690-ba63-79beecaebe0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07a194cb-53c9-4690-ba63-79beecaebe0e.jpg?1",
             "name": "Broodstar",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying\nBroodstar's power and toughness are each equal to the number of artifacts you control.",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "e0f49a68-4681-519d-bdaa-c4f1a9ee510c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c6350-af52-45f1-8024-5f31aa62a0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427c6350-af52-45f1-8024-5f31aa62a0d0.jpg?1",
             "name": "Disarm",
             "text": "Unattach all Equipment from target creature.",
             "colours": [
@@ -1075,7 +1075,7 @@
         },
         {
             "id": "d3a3bb98-5f4c-51ea-87e3-f9f56b09448a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0010b89-afc4-4dee-bda3-2f34e552cba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0010b89-afc4-4dee-bda3-2f34e552cba5.jpg?1",
             "name": "Domineer",
             "text": "You control enchanted artifact creature.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "23a68ba3-d4f2-5987-9c9e-befc463249a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaa6a2-7c86-45b4-8892-b837e05f11a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffaa6a2-7c86-45b4-8892-b837e05f11a6.jpg?1",
             "name": "Dream's Grip",
             "text": "Choose one Tap target permanent; or untap target permanent.\nEntwine {1} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1141,7 +1141,7 @@
         },
         {
             "id": "35fc5261-176b-5c13-acb4-fdc4601aef6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742e23c-1991-4dce-b670-dea92a1cf4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742e23c-1991-4dce-b670-dea92a1cf4ec.jpg?1",
             "name": "Fabricate",
             "text": "Search your library for an artifact card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1173,7 +1173,7 @@
         },
         {
             "id": "cb378311-e382-5d29-8a80-6703de57f55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg?1",
             "name": "Fatespinner",
             "text": "At the beginning of each opponent's upkeep, that player chooses draw step, main phase, or combat phase. The player skips each instance of the chosen step or phase this turn.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "6b932420-9870-5fb0-85a2-61918f8ae8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b2d227-68b3-40e8-bef7-45ea43e17318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b2d227-68b3-40e8-bef7-45ea43e17318.jpg?1",
             "name": "Inertia Bubble",
             "text": "Enchanted artifact doesn't untap during its controller's untap step.",
             "colours": [
@@ -1242,7 +1242,7 @@
         },
         {
             "id": "c54a6018-7d37-5e99-a255-da0cdef50f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29de2f4c-81a6-42c7-94d1-f9109c3331ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29de2f4c-81a6-42c7-94d1-f9109c3331ff.jpg?1",
             "name": "Looming Hoverguard",
             "text": "Flying\nWhen Looming Hoverguard comes into play, put target artifact on top of its owner's library.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "11c64f80-0df1-59c3-8869-7a90da4d0c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg?1",
             "name": "Lumengrid Augur",
             "text": "{1}, {T}: Target player draws a card, then discards a card from his or her hand. If that player discards an artifact card this way, untap Lumengrid Augur.",
             "colours": [
@@ -1311,7 +1311,7 @@
         },
         {
             "id": "18e95a19-f035-5f84-8f33-b742bb831d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48068b80-9a98-45d0-8224-ee298cbf708f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48068b80-9a98-45d0-8224-ee298cbf708f.jpg?1",
             "name": "Lumengrid Sentinel",
             "text": "Flying\nWhenever an artifact comes into play under your control, you may tap target permanent.",
             "colours": [
@@ -1346,7 +1346,7 @@
         },
         {
             "id": "26bde397-a503-5bab-82f2-b781a024f05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aadd54-6e83-4bcf-9760-16479d919a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44aadd54-6e83-4bcf-9760-16479d919a56.jpg?1",
             "name": "Lumengrid Warden",
             "text": "",
             "colours": [
@@ -1381,7 +1381,7 @@
         },
         {
             "id": "720bfb82-f437-5307-b18e-a920ac4f3ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdcc966-7837-463f-ae26-1096f34ac8c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdcc966-7837-463f-ae26-1096f34ac8c0.jpg?1",
             "name": "March of the Machines",
             "text": "Each noncreature artifact is an artifact creature with power and toughness each equal to its converted mana cost. (Equipment that's a creature can't equip a creature.)",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "6af72e5f-d7b7-5c42-a56e-4c136b56bc69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd15b0-4ada-41c7-81e0-4f8956798685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd15b0-4ada-41c7-81e0-4f8956798685.jpg?1",
             "name": "Neurok Familiar",
             "text": "Flying\nWhen Neurok Familiar comes into play, reveal the top card of your library. If it's an artifact card, put it into your hand. Otherwise, put it into your graveyard.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "3df70f69-5f34-5ddc-a0a0-61b57c819b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b86a02-d40a-4615-8402-bd5700cb5101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b86a02-d40a-4615-8402-bd5700cb5101.jpg?1",
             "name": "Neurok Spy",
             "text": "Neurok Spy is unblockable as long as defending player controls an artifact.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "d5dfbacd-ddc0-5aa9-b331-c188f0d46a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35964fa6-800d-41d6-9f82-fb9c87deee56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35964fa6-800d-41d6-9f82-fb9c87deee56.jpg?1",
             "name": "Override",
             "text": "Counter target spell unless its controller pays {1} for each artifact you control.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "d665dad2-b054-5cf1-90d5-b0ddfaf56e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5a69-05b6-4fc4-8186-503a2e204330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ffd5a69-05b6-4fc4-8186-503a2e204330.jpg?1",
             "name": "Psychic Membrane",
             "text": "(Walls can't attack.)\nWhenever Psychic Membrane blocks, you may draw a card.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "8a2698ef-19c3-5997-92c6-ba8506f36876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg?1",
             "name": "Quicksilver Elemental",
             "text": "{U}: Quicksilver Elemental gains all activated abilities of target creature until end of turn. (If any of the abilities use that creature's name, use this creature's name instead.)\nYou may spend blue mana as though it were mana of any color to pay the activation costs of Quicksilver Elemental's abilities.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "15131557-224d-5fd2-905f-159d26981198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869775f-72fa-463f-a46a-7c3e955f8590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e869775f-72fa-463f-a46a-7c3e955f8590.jpg?1",
             "name": "Regress",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "881f48d0-870a-5c40-af38-aac6b3e5faa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d5b02-ef38-4dab-8ac6-78814ef27b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0d5b02-ef38-4dab-8ac6-78814ef27b55.jpg?1",
             "name": "Shared Fate",
             "text": "If a player would draw a card, that player removes the top card of an opponent's library from the game face down instead.\nEach player may look at and play cards he or she removed from the game with Shared Fate as though they were in his or her hand.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "5a2712fb-264c-588f-aae3-93fea68252de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85866351-a721-4b3c-9b6f-4d291daab657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85866351-a721-4b3c-9b6f-4d291daab657.jpg?1",
             "name": "Slith Strider",
             "text": "Whenever Slith Strider becomes blocked, draw a card.\nWhenever Slith Strider deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "cce0a90a-9cea-5ba1-8529-dead44ee59dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a46ac2-d96d-4d5a-94fc-a9fc83a9ea1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a46ac2-d96d-4d5a-94fc-a9fc83a9ea1d.jpg?1",
             "name": "Somber Hoverguard",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nFlying",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "7c225686-3cb3-5798-b0d5-b282d123ea30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg?1",
             "name": "Temporal Cascade",
             "text": "Choose one Each player shuffles his or her hand and graveyard into his or her library; or each player draws seven cards.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "e4e0fb33-fd90-5b1d-9072-e06d98e2a9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff1f608-203e-4413-8753-37fc49731c87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff1f608-203e-4413-8753-37fc49731c87.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards from your hand unless you discard an artifact card from your hand.",
             "colours": [
@@ -1778,7 +1778,7 @@
         },
         {
             "id": "0a2506d5-0ef8-5eb8-be55-6c98e8ad0364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb965a7-877a-4302-b507-25b0a9e32d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb965a7-877a-4302-b507-25b0a9e32d9b.jpg?1",
             "name": "Thoughtcast",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nDraw two cards.",
             "colours": [
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "0f911e87-c597-5d22-8f74-612d3fac1824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38da97-5141-4de6-bd7f-3fcbf46cfd96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b38da97-5141-4de6-bd7f-3fcbf46cfd96.jpg?1",
             "name": "Vedalken Archmage",
             "text": "Whenever you play an artifact spell, draw a card.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "779ffcd6-d98b-5637-b015-02ffa9104831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac6290-1401-41c5-90a1-99acb344719e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac6290-1401-41c5-90a1-99acb344719e.jpg?1",
             "name": "Wanderguard Sentry",
             "text": "When Wanderguard Sentry comes into play, look at target opponent's hand.",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "bf4577fc-a174-5f47-af4c-e9d895a04d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg?1",
             "name": "Barter in Blood",
             "text": "Each player sacrifices two creatures.",
             "colours": [
@@ -1911,7 +1911,7 @@
         },
         {
             "id": "dca63274-7322-5350-8dd9-f464373f02b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2e107-0277-4e5c-81a7-258bb2998f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2e107-0277-4e5c-81a7-258bb2998f3e.jpg?1",
             "name": "Betrayal of Flesh",
             "text": "Choose one Destroy target creature; or return target creature card from your graveyard to play.\nEntwine\u2014\nSacrifice three lands. (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "ff68ec8d-13b7-5387-882b-ff3f8822e21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a426922-5e96-48f3-b696-f5dc99258943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a426922-5e96-48f3-b696-f5dc99258943.jpg?1",
             "name": "Chimney Imp",
             "text": "Flying\nWhen Chimney Imp is put into a graveyard from play, target opponent puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "7102f022-452a-5e4e-865d-60ab7432c873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f375a49c-806a-4d8b-9513-6b4afc19497b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f375a49c-806a-4d8b-9513-6b4afc19497b.jpg?1",
             "name": "Consume Spirit",
             "text": "Spend only black mana on X.\nConsume Spirit deals X damage to target creature or player. You gain X life.",
             "colours": [
@@ -2009,7 +2009,7 @@
         },
         {
             "id": "13a5c287-f991-50b1-9a3f-fd3e086998af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a64356-3064-47a2-80be-5e2f56c85556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a64356-3064-47a2-80be-5e2f56c85556.jpg?1",
             "name": "Contaminated Bond",
             "text": "Whenever enchanted creature attacks or blocks, its controller loses 3 life.",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "92f2e2b2-894f-5e64-841b-c982455b2448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644359dc-3c4c-4291-876d-7390dc466877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644359dc-3c4c-4291-876d-7390dc466877.jpg?1",
             "name": "Disciple of the Vault",
             "text": "Whenever an artifact is put into a graveyard from play, you may have target opponent lose 1 life.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "ee45440a-2ba9-5e50-9553-73b7e59bc9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b088832c-6119-4460-98b7-ae25cf70b2c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b088832c-6119-4460-98b7-ae25cf70b2c5.jpg?1",
             "name": "Dross Harvester",
             "text": "Protection from white\nAt the end of your turn, you lose 4 life.\nWhenever a creature is put into a graveyard from play, you gain 2 life.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "967d38f8-e73f-56fc-bd1d-48d5b2dd4180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fff470a-3574-42be-8f0b-ac5e7a70f61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fff470a-3574-42be-8f0b-ac5e7a70f61a.jpg?1",
             "name": "Dross Prowler",
             "text": "Fear",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "5c539309-690a-5181-8d9e-0327cd7abc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2381b3-ebf8-4c65-8e89-e089c2e57145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2381b3-ebf8-4c65-8e89-e089c2e57145.jpg?1",
             "name": "Flayed Nim",
             "text": "Whenever Flayed Nim deals combat damage to a creature, that creature's controller loses that much life.\n{2}{B}: Regenerate Flayed Nim.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "736e764a-074c-540e-8630-f1f3ea2288e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35baa726-8c2f-4a0b-93d1-d7ecfae69fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35baa726-8c2f-4a0b-93d1-d7ecfae69fe4.jpg?1",
             "name": "Grim Reminder",
             "text": "Search your library for a nonland card and reveal it. Each opponent who played a card this turn with the same name as that card loses 6 life. Then shuffle the revealed card back into your library.\n{B}{B}: Return Grim Reminder from your graveyard to your hand. Play this ability only during your upkeep.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "eecc43a9-88e2-587e-a37f-ec8b7268eab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0460cf-ff87-4cf8-89b5-a8b9fb7322e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0460cf-ff87-4cf8-89b5-a8b9fb7322e0.jpg?1",
             "name": "Irradiate",
             "text": "Target creature gets -1/-1 until end of turn for each artifact you control.",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "cfe562f2-09b7-5ff9-b209-3099c338371e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27426b-3679-44e4-9249-f57b92baa3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27426b-3679-44e4-9249-f57b92baa3f3.jpg?1",
             "name": "Moriok Scavenger",
             "text": "When Moriok Scavenger comes into play, you may return target artifact creature card from your graveyard to your hand.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "11c9e1ee-6f83-537d-8d36-5d01980b2b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18291514-9ffb-4032-9c77-cec0200bf1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18291514-9ffb-4032-9c77-cec0200bf1b6.jpg?1",
             "name": "Necrogen Mists",
             "text": "At the beginning of each player's upkeep, that player discards a card from his or her hand.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "93e14b44-10fb-5d30-94f7-1294f65bf04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg?1",
             "name": "Nim Devourer",
             "text": "Nim Devourer gets +1/+0 for each artifact you control.\n{B}{B}: Return Nim Devourer from your graveyard to play, then sacrifice a creature. Play this ability only during your upkeep.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "f8cd3e57-5c63-5571-846b-c5e5eec97381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b66c698-02bd-48ef-a866-5251bdc02c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b66c698-02bd-48ef-a866-5251bdc02c16.jpg?1",
             "name": "Nim Lasher",
             "text": "Nim Lasher gets +1/+0 for each artifact you control.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "fb89a5f5-ef81-547c-842a-53477a54469f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c09a0-a374-46c1-978f-ec7478dc7ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59c09a0-a374-46c1-978f-ec7478dc7ab7.jpg?1",
             "name": "Nim Shambler",
             "text": "Nim Shambler gets +1/+0 for each artifact you control.\nSacrifice a creature: Regenerate Nim Shambler.",
             "colours": [
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "3ea6d665-0a7b-516f-9e32-0fc76a86e75b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a2c39b-b302-4cc3-b507-e4fe00614036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a2c39b-b302-4cc3-b507-e4fe00614036.jpg?1",
             "name": "Nim Shrieker",
             "text": "Flying\nNim Shrieker gets +1/+0 for each artifact you control.",
             "colours": [
@@ -2447,7 +2447,7 @@
         },
         {
             "id": "7ccfaf6d-50b1-51b7-886c-af38569f8829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96c3947-0eec-48a1-ba69-59734b4ac9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96c3947-0eec-48a1-ba69-59734b4ac9da.jpg?1",
             "name": "Promise of Power",
             "text": "Choose one You draw five cards and you lose 5 life; or put a black Demon creature token with flying into play with power and toughness each equal to the number of cards in your hand as the token comes into play.\nEntwine {4} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2479,7 +2479,7 @@
         },
         {
             "id": "5c59a293-4022-5b9e-90c7-04de82cae2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d109abda-982f-4907-8b64-ec63e138bc42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d109abda-982f-4907-8b64-ec63e138bc42.jpg?1",
             "name": "Reiver Demon",
             "text": "Flying\nWhen Reiver Demon comes into play, if you played it from your hand, destroy all nonartifact, nonblack creatures. They can't be regenerated.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "5e6b214f-ab14-548e-a220-da0309681130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbafa51-693b-485c-807d-64020540f16a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbafa51-693b-485c-807d-64020540f16a.jpg?1",
             "name": "Relic Bane",
             "text": "Enchanted artifact has \"At the beginning of your upkeep, you lose 2 life.\"",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "81ec8466-d1d7-5a95-a519-6c5e567a062e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a04ccb-cb57-4548-81db-e1b77b09f5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a04ccb-cb57-4548-81db-e1b77b09f5da.jpg?1",
             "name": "Slith Bloodletter",
             "text": "Whenever Slith Bloodletter deals combat damage to a player, put a +1/+1 counter on it.\n{1}{B}: Regenerate Slith Bloodletter.",
             "colours": [
@@ -2581,7 +2581,7 @@
         },
         {
             "id": "f17b171c-4c8c-5a95-9639-7c904d08adab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d100d-d20b-4018-8518-609113ec36d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d100d-d20b-4018-8518-609113ec36d7.jpg?1",
             "name": "Spoils of the Vault",
             "text": "Name a card. Reveal cards from the top of your library until you reveal the named card, then put that card into your hand. Remove all other cards revealed this way from the game, and you lose 1 life for each of the removed cards.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "bee16d9c-a26f-5358-9829-21b03dd49eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41651db-619a-4ab4-86cf-a0d32297dbdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41651db-619a-4ab4-86cf-a0d32297dbdf.jpg?1",
             "name": "Terror",
             "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "7dc00114-d2c5-5373-9ad0-c5c34ffea4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b68e084-0760-4817-a656-32dc4b094370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b68e084-0760-4817-a656-32dc4b094370.jpg?1",
             "name": "Vermiculos",
             "text": "Whenever an artifact comes into play, Vermiculos gets +4/+4 until end of turn.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "4fd5b63b-fbfb-5592-96db-944835562bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c32faa-c6d1-418a-aed6-ccc5849daa1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c32faa-c6d1-418a-aed6-ccc5849daa1f.jpg?1",
             "name": "Wail of the Nim",
             "text": "Choose one Regenerate each creature you control; or Wail of the Nim deals 1 damage to each creature and each player.\nEntwine {B} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "1cdc7f00-062f-5b5b-a77e-1c5067aac2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17320043-f81c-4e14-b9ba-c1309972c22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17320043-f81c-4e14-b9ba-c1309972c22b.jpg?1",
             "name": "Wall of Blood",
             "text": "(Walls can't attack.)\nPay 1 life: Wall of Blood gets +1/+1 until end of turn.",
             "colours": [
@@ -2745,7 +2745,7 @@
         },
         {
             "id": "fea2a4a3-7aff-53b2-96c2-e362b41d61ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg?1",
             "name": "Woebearer",
             "text": "Fear\nWhenever Woebearer deals combat damage to a player, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2779,7 +2779,7 @@
         },
         {
             "id": "452464b5-0fe5-5164-a547-bc65ab9818e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce975b-c3df-4472-a6c1-2546df11b74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ce975b-c3df-4472-a6c1-2546df11b74e.jpg?1",
             "name": "Wrench Mind",
             "text": "Target player discards two cards from his or her hand unless he or she discards an artifact card from his or her hand.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "dbf99b19-1209-57bd-9b16-3c9805b447a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg?1",
             "name": "Arc-Slogger",
             "text": "{R}, Remove the top ten cards of your library from the game: Arc-Slogger deals 2 damage to target creature or player.",
             "colours": [
@@ -2845,7 +2845,7 @@
         },
         {
             "id": "3dfe1802-c210-53ee-a342-a96f6daf9a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15397bc-c400-4f8d-b206-08a4d65e76ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15397bc-c400-4f8d-b206-08a4d65e76ff.jpg?1",
             "name": "Atog",
             "text": "Sacrifice an artifact: Atog gets +2/+2 until end of turn.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "c31098a0-2d77-50cd-89f1-2e242b48f2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d46aca2-4714-4d2c-9466-5f1c043b8726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d46aca2-4714-4d2c-9466-5f1c043b8726.jpg?1",
             "name": "Confusion in the Ranks",
             "text": "Whenever an artifact, creature, or enchantment comes into play, its controller chooses target permanent another player controls that shares a type with it. Exchange control of those permanents.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "e944b4e6-835f-5d23-b988-42b94b089047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237eedf5-8a8f-4668-a911-e2bf66f8221e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237eedf5-8a8f-4668-a911-e2bf66f8221e.jpg?1",
             "name": "Detonate",
             "text": "Destroy target artifact with converted mana cost X. It can't be regenerated. Detonate deals X damage to that artifact's controller.",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "70ddb182-17b1-53ba-84ac-5a8229d22967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455c8d4-6f20-4dcb-8e82-c2bb70d6bc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c455c8d4-6f20-4dcb-8e82-c2bb70d6bc3e.jpg?1",
             "name": "Electrostatic Bolt",
             "text": "Electrostatic Bolt deals 2 damage to target creature. If it's an artifact creature, Electrostatic Bolt deals 4 damage to it instead.",
             "colours": [
@@ -2975,7 +2975,7 @@
         },
         {
             "id": "e251a438-1100-519f-857a-d41fde44bdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91376ed-5868-4887-8389-5ef5b9471786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91376ed-5868-4887-8389-5ef5b9471786.jpg?1",
             "name": "Fiery Gambit",
             "text": "Flip a coin until you lose a flip or choose to stop flipping. If you lose a flip, Fiery Gambit has no effect. If you win one or more flips, Fiery Gambit deals 3 damage to target creature. If you win two or more flips, Fiery Gambit deals 6 damage to each opponent. If you win three or more flips, draw nine cards and untap all lands you control.",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "49bf94a1-f7aa-5893-9c9a-cbfc28569549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb94bc02-b348-43c2-9e78-e2e3fd541d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb94bc02-b348-43c2-9e78-e2e3fd541d6a.jpg?1",
             "name": "Fists of the Anvil",
             "text": "Target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "716dd69a-dffa-50f5-a8ab-17cc9cc45154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2873b6d5-af76-498c-bc2d-a26c36be3cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2873b6d5-af76-498c-bc2d-a26c36be3cbd.jpg?1",
             "name": "Forge Armor",
             "text": "As an additional cost to play Forge Armor, sacrifice an artifact.\nPut X +1/+1 counters on target creature, where X is the sacrificed artifact's converted mana cost.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "db541004-d404-5ce2-8de1-3063ffe5d9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7ce5d5-e51a-4dbc-82f2-b79c88769a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7ce5d5-e51a-4dbc-82f2-b79c88769a7b.jpg?1",
             "name": "Fractured Loyalty",
             "text": "Whenever enchanted creature becomes the target of a spell or ability, that spell or ability's controller gains control of enchanted creature. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "0421be4a-ebf3-5a3c-828b-e9fdea4cc053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7654d8a-7013-4311-b29e-b55aaa1bf502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7654d8a-7013-4311-b29e-b55aaa1bf502.jpg?1",
             "name": "Goblin Striker",
             "text": "First strike, haste",
             "colours": [
@@ -3140,7 +3140,7 @@
         },
         {
             "id": "1686a5d1-ab63-53dc-a76a-1881e04df7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570fa211-e937-4ad7-bc72-60f8adc3203d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570fa211-e937-4ad7-bc72-60f8adc3203d.jpg?1",
             "name": "Grab the Reins",
             "text": "Choose one Until end of turn, you gain control of target creature and it gains haste; or sacrifice a creature, then Grab the Reins deals damage equal to that creature's power to target creature or player.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "43f364aa-7c2c-5600-8b5e-a60243e9b6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30527c-0eb1-4b66-9028-1607a960019a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee30527c-0eb1-4b66-9028-1607a960019a.jpg?1",
             "name": "Incite War",
             "text": "Choose one Creatures target player controls attack this turn if able; or creatures you control gain first strike until end of turn.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "e2fec47e-46a4-5357-93c9-a3b7e268f343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd9e422-206e-4c25-9964-ed6592c16e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd9e422-206e-4c25-9964-ed6592c16e12.jpg?1",
             "name": "Krark-Clan Grunt",
             "text": "Sacrifice an artifact: Krark-Clan Grunt gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "cd9aa095-f999-5a2c-91e5-4acd94d45416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f9ea8-af2c-456f-acd0-ffa9ea0d98c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f9ea8-af2c-456f-acd0-ffa9ea0d98c1.jpg?1",
             "name": "Krark-Clan Shaman",
             "text": "Sacrifice an artifact: Krark-Clan Shaman deals 1 damage to each creature without flying.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "8fbcf505-3189-5011-8918-b94d259762ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431354a-fcfa-4f67-a822-6dcc4d13ac3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431354a-fcfa-4f67-a822-6dcc4d13ac3f.jpg?1",
             "name": "Mass Hysteria",
             "text": "All creatures have haste.",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "20f60883-8f56-56e9-b2e2-2f60ee5fd792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9734b1-c5fb-4b2b-bada-c45c3a725e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9734b1-c5fb-4b2b-bada-c45c3a725e01.jpg?1",
             "name": "Megatog",
             "text": "Sacrifice an artifact: Megatog gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "0c97e000-1408-5558-ae4e-fbea0d4600c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888b4d4-31f9-4322-8225-4d7e7a9f4dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888b4d4-31f9-4322-8225-4d7e7a9f4dd5.jpg?1",
             "name": "Molten Rain",
             "text": "Destroy target land. If that land is nonbasic, Molten Rain deals 2 damage to the land's controller.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "254f04c7-eccf-5336-b648-5aa7420319a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c77744-3a86-46cf-9e0f-5a217a1c08b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c77744-3a86-46cf-9e0f-5a217a1c08b9.jpg?1",
             "name": "Ogre Leadfoot",
             "text": "Whenever Ogre Leadfoot becomes blocked by an artifact creature, destroy that creature.",
             "colours": [
@@ -3406,7 +3406,7 @@
         },
         {
             "id": "da003b46-f9b7-5c6f-a5ec-5b90b1303467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8bd0c9-6b3a-489e-bf4d-b2062d530b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8bd0c9-6b3a-489e-bf4d-b2062d530b55.jpg?1",
             "name": "Rustmouth Ogre",
             "text": "Whenever Rustmouth Ogre deals combat damage to a player, you may destroy target artifact that player controls.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "6ad62466-e9c5-522f-9ced-23bcd15861d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9213d580-7953-455f-abbe-99d3db2705cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9213d580-7953-455f-abbe-99d3db2705cf.jpg?1",
             "name": "Seething Song",
             "text": "Add {R}{R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "eb0bee60-dfc8-570f-a665-551ef9395e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b3d7e6-df52-4cd1-92e7-5dfe8b0a9d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84b3d7e6-df52-4cd1-92e7-5dfe8b0a9d9e.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "b77211e4-683c-5806-a9df-0faf6827e069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056affab-4e2a-4b68-b864-d879becd3c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056affab-4e2a-4b68-b864-d879becd3c45.jpg?1",
             "name": "Shrapnel Blast",
             "text": "As an additional cost to play Shrapnel Blast, sacrifice an artifact.\nShrapnel Blast deals 5 damage to target creature or player.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "6f59dba2-c864-5547-986e-beb8bbfbf3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff7383-71da-46ae-849f-349c40815a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ff7383-71da-46ae-849f-349c40815a29.jpg?1",
             "name": "Slith Firewalker",
             "text": "Haste\nWhenever Slith Firewalker deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -3570,7 +3570,7 @@
         },
         {
             "id": "af3f8a3b-e17f-5e4f-9795-07ff0991c87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147c826a-b664-4afa-ae7f-284ddce80861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147c826a-b664-4afa-ae7f-284ddce80861.jpg?1",
             "name": "Spikeshot Goblin",
             "text": "{R}, {T}: Spikeshot Goblin deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3605,7 +3605,7 @@
         },
         {
             "id": "89782ed9-606d-5f35-9e76-63d1c69a81f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec59ed99-ce40-489a-b776-8874bec60393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec59ed99-ce40-489a-b776-8874bec60393.jpg?1",
             "name": "Trash for Treasure",
             "text": "As an additional cost to play Trash for Treasure, sacrifice an artifact.\nReturn target artifact card from your graveyard to play.",
             "colours": [
@@ -3637,7 +3637,7 @@
         },
         {
             "id": "2e9b8691-372b-51dc-9b14-1c99b1da232d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg?1",
             "name": "Vulshok Battlemaster",
             "text": "Haste\nWhen Vulshok Battlemaster comes into play, attach all Equipment in play to it. (Control of the Equipment doesn't change.)",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "d9b7221d-40f0-58a6-8f20-0655330f7496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23510414-974e-4510-9742-884ecd572ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23510414-974e-4510-9742-884ecd572ad8.jpg?1",
             "name": "Vulshok Berserker",
             "text": "Haste",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "02f6328b-9c67-5815-b58a-d83a97f155f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg?1",
             "name": "War Elemental",
             "text": "When War Elemental comes into play, sacrifice it unless an opponent was dealt damage this turn.\nWhenever damage is dealt to an opponent, put that many +1/+1 counters on War Elemental.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "b903c792-99ab-5320-913c-a937a82efb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b34e76b-86b3-464e-93e7-c3f2074028fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b34e76b-86b3-464e-93e7-c3f2074028fb.jpg?1",
             "name": "Battlegrowth",
             "text": "Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "c4ac67ed-8ab3-5f6d-b5c0-ac7cb4b51e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca1eb7b-e964-4c36-8fc5-e1d2a98e841f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca1eb7b-e964-4c36-8fc5-e1d2a98e841f.jpg?1",
             "name": "Bloodscent",
             "text": "All creatures able to block target creature this turn do so.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "a9cb4f21-7f54-50ab-9009-f77623821463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8779ec-0ebd-45a1-96c9-4b1146871ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d8779ec-0ebd-45a1-96c9-4b1146871ab7.jpg?1",
             "name": "Brown Ouphe",
             "text": "{1}{G}, {T}: Counter target activated ability from an artifact source. (Mana abilities can't be countered.)",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "54fc5081-f17b-5d7f-a486-bb47c1ad1830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg?1",
             "name": "Copperhoof Vorrac",
             "text": "Copperhoof Vorrac gets +1/+1 for each untapped permanent your opponents control.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "45d89b40-00c5-5efe-a744-b8bbd6c08b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b50bda-f19f-4991-977b-de794f11103d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b50bda-f19f-4991-977b-de794f11103d.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, enchantment, or land.",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "d73caaf3-659d-5ff0-87b2-d34ef320c377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53face79-d2bf-43dd-aa4e-d724c2b68c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53face79-d2bf-43dd-aa4e-d724c2b68c49.jpg?1",
             "name": "Deconstruct",
             "text": "Destroy target artifact. Then add {G}{G}{G} to your mana pool.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "56f5b809-f07c-5e81-bc89-41eca38123ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc8eef-f032-490a-b487-da1af71b7ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc8eef-f032-490a-b487-da1af71b7ff2.jpg?1",
             "name": "Fangren Hunter",
             "text": "Trample",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "a8051892-19a3-5101-9eeb-0fa83140b75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg?1",
             "name": "Glissa Sunseeker",
             "text": "First strike\n{T}: Destroy target artifact if its converted mana cost is equal to the amount of mana in your mana pool.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "07eb3db9-2a06-5de0-afce-59f2deae70cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e84098-c15c-40f4-9d8a-3fa5da26a268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e84098-c15c-40f4-9d8a-3fa5da26a268.jpg?1",
             "name": "Groffskithur",
             "text": "Whenever Groffskithur becomes blocked, you may return target card named Groffskithur from your graveyard to your hand.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "21588cba-df2c-5bf3-b4fa-41c67a929733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg?1",
             "name": "Hum of the Radix",
             "text": "Each artifact spell costs {1} more to play for each artifact its controller controls.",
             "colours": [
@@ -4075,7 +4075,7 @@
         },
         {
             "id": "6fb939cc-6091-5399-9106-fa863d212cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f4356f-8cfb-43ed-bdf9-6191bb563388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f4356f-8cfb-43ed-bdf9-6191bb563388.jpg?1",
             "name": "Journey of Discovery",
             "text": "Choose one Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library; or you may play up to two additional lands this turn.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "61feb004-c24d-59d5-81b5-44c9cc87c198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407dad3c-d721-412a-8b29-bc15be56d2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407dad3c-d721-412a-8b29-bc15be56d2fe.jpg?1",
             "name": "Living Hive",
             "text": "Trample\nWhenever Living Hive deals combat damage to a player, put that many 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -4142,7 +4142,7 @@
         },
         {
             "id": "7f6adf2e-dae6-55ba-bb4e-f0c8b36bf5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee355d1b-5d64-4328-94d6-7a58889b99bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee355d1b-5d64-4328-94d6-7a58889b99bc.jpg?1",
             "name": "Molder Slug",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact.",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "8d949caf-fe03-5016-9c45-54d4531b93b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3216148-f64e-434b-80b8-772f6eb831ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3216148-f64e-434b-80b8-772f6eb831ca.jpg?1",
             "name": "One Dozen Eyes",
             "text": "Choose one Put a 5/5 green Beast creature token into play; or put five 1/1 green Insect creature tokens into play.\nEntwine {G}{G}{G} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "e7c1ebf0-31ee-5dde-bb7b-a093f63ac3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fc3c5e-025d-4b21-af86-9c861658d32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fc3c5e-025d-4b21-af86-9c861658d32e.jpg?1",
             "name": "Plated Slagwurm",
             "text": "Plated Slagwurm can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "55bad9f7-2c22-545e-8299-bd65f5bbe094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e5bcc2-9203-4526-a9a9-fac6fd02a854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e5bcc2-9203-4526-a9a9-fac6fd02a854.jpg?1",
             "name": "Predator's Strike",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "7f8554e6-b78f-5303-b6a4-72808ec67523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bae45c-eaa8-4c6d-8042-df5cf26e294f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bae45c-eaa8-4c6d-8042-df5cf26e294f.jpg?1",
             "name": "Slith Predator",
             "text": "Trample\nWhenever Slith Predator deals combat damage to a player, put a +1/+1 counter on it.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "33ea24df-f7c3-5b94-bd80-7f262be850fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff07b6-be9f-498f-9f36-cbd64f1b10cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ff07b6-be9f-498f-9f36-cbd64f1b10cc.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "f9a12bf9-06eb-5863-9790-1eb6d19858e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1fde33-e86a-4146-9c90-4616a5fc0868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1fde33-e86a-4146-9c90-4616a5fc0868.jpg?1",
             "name": "Tel-Jilad Archers",
             "text": "Protection from artifacts\nTel-Jilad Archers may block as though it had flying.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "a8bf2066-2f9c-5497-ab06-7394d14d5af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefea84f-d657-491d-b60d-63e6a61e9eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefea84f-d657-491d-b60d-63e6a61e9eb2.jpg?1",
             "name": "Tel-Jilad Chosen",
             "text": "Protection from artifacts",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "03b66c98-4f51-5229-95e7-84501d20112c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3529277-8409-45fe-9f29-64354597e918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3529277-8409-45fe-9f29-64354597e918.jpg?1",
             "name": "Tel-Jilad Exile",
             "text": "{1}{G}: Regenerate Tel-Jilad Exile.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "52a30ada-50cc-5e8e-9632-a3bdf88c37d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0067c-2d38-46bd-b52e-070c2ce424f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f0067c-2d38-46bd-b52e-070c2ce424f0.jpg?1",
             "name": "Tooth and Nail",
             "text": "Choose one Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle your library; or put up to two creature cards from your hand into play.\nEntwine {2} (Choose both if you pay the entwine cost.)",
             "colours": [
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "ae6ac0d4-54c0-51dc-a009-9664c4334d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01233c2-6df0-4f0e-8668-3855868731ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01233c2-6df0-4f0e-8668-3855868731ea.jpg?1",
             "name": "Troll Ascetic",
             "text": "Troll Ascetic can't be the target of spells or abilities your opponents control.\n{1}{G}: Regenerate Troll Ascetic.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "94192555-f332-5d0f-8696-ca3a1fece3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6535f2ad-6cda-4be9-8e4f-6f062b63be31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6535f2ad-6cda-4be9-8e4f-6f062b63be31.jpg?1",
             "name": "Trolls of Tel-Jilad",
             "text": "{1}{G}: Regenerate target green creature.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "4140ad49-0d3d-5aa4-b125-83d808a2385e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfcb643-bbd1-419a-b1a8-daae1062c8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcfcb643-bbd1-419a-b1a8-daae1062c8bc.jpg?1",
             "name": "Turn to Dust",
             "text": "Destroy target Equipment. Then add {G} to your mana pool.",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "76ab6fb0-0446-59a0-b146-fea48dc167ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50679df-bf82-4bb2-9fe3-8ebd7a9decde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50679df-bf82-4bb2-9fe3-8ebd7a9decde.jpg?1",
             "name": "Viridian Joiner",
             "text": "{T}: Add an amount of {G} to your mana pool equal to Viridian Joiner's power.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "ef201401-a2b2-5e84-af64-e9b293d83ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932bf583-efd3-42e9-8a7b-7b3fe07fbcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932bf583-efd3-42e9-8a7b-7b3fe07fbcf0.jpg?1",
             "name": "Viridian Shaman",
             "text": "When Viridian Shaman comes into play, destroy target artifact.",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "a7880a99-cb3a-5079-80b2-71cb56c93f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f303e-371b-47dd-bbb8-7f3e44ef9af0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14f303e-371b-47dd-bbb8-7f3e44ef9af0.jpg?1",
             "name": "Wurmskin Forger",
             "text": "When Wurmskin Forger comes into play, distribute three +1/+1 counters among any number of target creatures.",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "44829535-d2be-519b-9484-3e1008ee49f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3792e8b-4ad7-4e2d-994c-c4eaac0fa55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3792e8b-4ad7-4e2d-994c-c4eaac0fa55f.jpg?1",
             "name": "Aether Spellbomb",
             "text": "{U}, Sacrifice \u00c6ther Spellbomb: Return target creature to its owner's hand.\n{1}, Sacrifice \u00c6ther Spellbomb: Draw a card.",
             "colours": [],
@@ -4715,7 +4715,7 @@
         },
         {
             "id": "0662f0e3-23b5-5eee-a7e0-d78fc0b6ec79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f792d7-75be-429e-8f62-0b563b103642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f792d7-75be-429e-8f62-0b563b103642.jpg?1",
             "name": "Alpha Myr",
             "text": "",
             "colours": [],
@@ -4746,7 +4746,7 @@
         },
         {
             "id": "b0c62122-52b3-5038-aff9-6b45f3e019bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc3824c-11ee-4fec-9397-823783b682d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc3824c-11ee-4fec-9397-823783b682d9.jpg?1",
             "name": "Altar of Shadows",
             "text": "At the beginning of your precombat main phase, add {B} to your mana pool for each charge counter on Altar of Shadows.\n{7}, {T}: Destroy target creature. Then put a charge counter on Altar of Shadows.",
             "colours": [],
@@ -4776,7 +4776,7 @@
         },
         {
             "id": "0addcced-63f4-570e-844a-2589e65ea266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77baad4-2bd6-492a-86ca-8e0088b751d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77baad4-2bd6-492a-86ca-8e0088b751d2.jpg?1",
             "name": "Banshee's Blade",
             "text": "Equipped creature gets +1/+1 for each charge counter on Banshee's Blade.\nWhenever equipped creature deals combat damage, put a charge counter on this card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "5127618b-f2cf-5a05-b69a-b2c843b0d415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff34d0b-a278-4990-beaf-5a64885460db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff34d0b-a278-4990-beaf-5a64885460db.jpg?1",
             "name": "Blinkmoth Urn",
             "text": "At the beginning of each player's precombat main phase, if Blinkmoth Urn is untapped, that player adds {1} to his or her mana pool for each artifact he or she controls.",
             "colours": [],
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "32c3fe49-1e7c-50a9-ba75-826d46e41b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465a7990-c9f9-4716-a833-fd41458b9cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465a7990-c9f9-4716-a833-fd41458b9cee.jpg?1",
             "name": "Bonesplitter",
             "text": "Equipped creature gets +2/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -4864,7 +4864,7 @@
         },
         {
             "id": "a0d692d6-7a9d-5b3d-86d9-600b23567da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe325c-8d3d-4543-9fcd-214525d4ab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfe325c-8d3d-4543-9fcd-214525d4ab2a.jpg?1",
             "name": "Bosh, Iron Golem",
             "text": "Trample\n{3}{R}, Sacrifice an artifact: Bosh, Iron Golem deals damage equal to the sacrificed artifact's converted mana cost to target creature or player.",
             "colours": [],
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "67a337b4-9d24-5f9c-893c-e7dfa8658fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018dcb37-221a-4552-9e72-2b9492883eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018dcb37-221a-4552-9e72-2b9492883eae.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: You gain 3 life.",
             "colours": [],
@@ -4930,7 +4930,7 @@
         },
         {
             "id": "884a487d-4469-58ef-b392-93f890463d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e223e822-a7a0-48d1-9bb7-88ee3d939c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e223e822-a7a0-48d1-9bb7-88ee3d939c6f.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion is put into a graveyard from play, add {3} to your mana pool.",
             "colours": [],
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "e750531f-d22b-53c6-b6a7-467682079c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02ca71-5e39-4a5f-aaba-a1e3e10a6a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a02ca71-5e39-4a5f-aaba-a1e3e10a6a3e.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void comes into play with X charge counters on it.\nWhenever a player plays a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "7524befc-0a52-595e-b48a-1697d32e8aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31a6dfd-93d2-49c8-a357-9a707b9c42bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31a6dfd-93d2-49c8-a357-9a707b9c42bd.jpg?1",
             "name": "Chromatic Sphere",
             "text": "{1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color to your mana pool. Draw a card.",
             "colours": [],
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "3b84c096-d20b-54a2-b09e-959bb5ff5e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058e68-70af-4a64-859c-c881e5578368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058e68-70af-4a64-859c-c881e5578368.jpg?1",
             "name": "Chrome Mox",
             "text": "Imprint When Chrome Mox comes into play, you may remove a nonartifact, nonland card in your hand from the game. (The removed card is imprinted on this artifact.)\n{T}: Add one mana of any of the imprinted card's colors to your mana pool.",
             "colours": [],
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "08a992e2-ccd6-54b1-a33f-f05f3ee4259e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c8db7-cf58-4571-b4ad-2b68d73495b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c8db7-cf58-4571-b4ad-2b68d73495b2.jpg?1",
             "name": "Clockwork Beetle",
             "text": "Clockwork Beetle comes into play with two +1/+1 counters on it.\nWhenever Clockwork Beetle attacks or blocks, remove a +1/+1 counter from it at end of combat.",
             "colours": [],
@@ -5076,7 +5076,7 @@
         },
         {
             "id": "610cde51-3a05-5dbb-a674-1fe8bbffff5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a7e1a6-347e-47bc-8a14-e584a45941e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a7e1a6-347e-47bc-8a14-e584a45941e1.jpg?1",
             "name": "Clockwork Condor",
             "text": "Flying\nClockwork Condor comes into play with three +1/+1 counters on it.\nWhenever Clockwork Condor attacks or blocks, remove a +1/+1 counter from it at end of combat.",
             "colours": [],
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "7079cdfc-9e0c-5819-8d95-9c0cb92e9c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6448da-b513-4bea-95f4-47bdfa0df078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6448da-b513-4bea-95f4-47bdfa0df078.jpg?1",
             "name": "Clockwork Dragon",
             "text": "Flying\nClockwork Dragon comes into play with six +1/+1 counters on it.\nWhenever Clockwork Dragon attacks or blocks, remove a +1/+1 counter from it at end of combat.\n{3}: Put a +1/+1 counter on Clockwork Dragon.",
             "colours": [],
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "7c70911f-51db-508f-9e0d-2a10232ea3d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e876938-1b8e-44cf-ade2-a42f8acdf24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e876938-1b8e-44cf-ade2-a42f8acdf24c.jpg?1",
             "name": "Clockwork Vorrac",
             "text": "Trample\nClockwork Vorrac comes into play with four +1/+1 counters on it.\nWhenever Clockwork Vorrac attacks or blocks, remove a +1/+1 counter from it at end of combat.\n{T}: Put a +1/+1 counter on Clockwork Vorrac.",
             "colours": [],
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "0e2d748e-016a-5067-aee1-3caab8e69c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e72f6-f573-4e37-9daa-abe6561ab086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e72f6-f573-4e37-9daa-abe6561ab086.jpg?1",
             "name": "Cobalt Golem",
             "text": "{1}{U}: Cobalt Golem gains flying until end of turn.",
             "colours": [],
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "18368775-5612-598b-bbb8-a67aa623b80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b2dc4-4fb3-4ddf-bdb6-c63e8c8efc09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52b2dc4-4fb3-4ddf-bdb6-c63e8c8efc09.jpg?1",
             "name": "Copper Myr",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "cb5d6b42-f7b8-5d6e-b771-a5c24c340079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c1d05b-92be-40d7-859f-75293a531a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1c1d05b-92be-40d7-859f-75293a531a84.jpg?1",
             "name": "Crystal Shard",
             "text": "{3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}.",
             "colours": [],
@@ -5266,7 +5266,7 @@
         },
         {
             "id": "18625edd-db2b-5feb-adb2-1f74586d8671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a57d6-bba6-463d-ad12-6f93c035d16b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9a57d6-bba6-463d-ad12-6f93c035d16b.jpg?1",
             "name": "Culling Scales",
             "text": "At the beginning of your upkeep, destroy target nonland permanent with the lowest converted mana cost among nonland permanents in play. (If two or more permanents are tied for lowest cost, target any one of them.)",
             "colours": [],
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "c0a937a4-2c1f-5412-bd06-e0c80623f473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2214e75-e469-41ae-8412-df725c097d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2214e75-e469-41ae-8412-df725c097d08.jpg?1",
             "name": "Damping Matrix",
             "text": "Activated abilities of artifacts and creatures can't be played unless they're mana abilities.",
             "colours": [],
@@ -5322,7 +5322,7 @@
         },
         {
             "id": "71e3eee1-0ecd-5485-894c-cdac080b400a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc312c0-14da-4b23-8293-6fa41bdd3167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc312c0-14da-4b23-8293-6fa41bdd3167.jpg?1",
             "name": "Dead-Iron Sledge",
             "text": "Whenever equipped creature blocks or becomes blocked by a creature, destroy that creature and equipped creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "80f47aad-b99f-5fc1-a483-ba9fe40f8f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc372-c5f9-4f98-9a15-0ea4a33017b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc372-c5f9-4f98-9a15-0ea4a33017b1.jpg?1",
             "name": "Dragon Blood",
             "text": "{3}, {T}: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "23241051-54fc-54aa-b4ff-89d48c1c7eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg?1",
             "name": "Dross Scorpion",
             "text": "Whenever Dross Scorpion or another artifact creature is put into a graveyard from play, you may untap target artifact.",
             "colours": [],
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "5f46e5f4-30f5-5158-9bfa-010a7cec0e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48a96f2-738f-433f-bfae-fbf378832a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48a96f2-738f-433f-bfae-fbf378832a3b.jpg?1",
             "name": "Duplicant",
             "text": "Imprint When Duplicant comes into play, you may remove target nontoken creature from the game. (The removed card is imprinted on this artifact.)\nAs long as a creature card is imprinted on Duplicant, Duplicant has that card's power, toughness, and creature types. It's still a Shapeshifter.",
             "colours": [],
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "6fde934b-be53-5358-9f82-9293f9ec565f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d18dd3b-980b-4833-93fd-79dc3a260da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d18dd3b-980b-4833-93fd-79dc3a260da4.jpg?1",
             "name": "Duskworker",
             "text": "Whenever Duskworker becomes blocked, regenerate it.\n{3}: Duskworker gets +1/+0 until end of turn.",
             "colours": [],
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "145426c9-3e4c-5edc-b015-690b72deb964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92cce55-22ee-40a7-bb94-4889093f142c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92cce55-22ee-40a7-bb94-4889093f142c.jpg?1",
             "name": "Elf Replica",
             "text": "{1}{G}, Sacrifice Elf Replica: Destroy target enchantment.",
             "colours": [],
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "47ad7c72-e712-5d7f-b366-62506592f74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1735bbb-402e-4657-8ad0-df2c56d5ee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1735bbb-402e-4657-8ad0-df2c56d5ee01.jpg?1",
             "name": "Empyrial Plate",
             "text": "Equipped creature gets +1/+1 for each card in your hand.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5536,7 +5536,7 @@
         },
         {
             "id": "1308e781-9fc1-572d-a99a-84e1b694eed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622a6523-3b12-4657-a656-00a57a3ae59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622a6523-3b12-4657-a656-00a57a3ae59c.jpg?1",
             "name": "Extraplanar Lens",
             "text": "Imprint When Extraplanar Lens comes into play, you may remove target land you control from the game. (The removed card is imprinted on this artifact.)\nWhenever a land with the same name as the imprinted card is tapped for mana, its controller adds one mana to his or her mana pool of any type that land produced.",
             "colours": [],
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "17426b58-1608-57fc-8350-a93ac13268b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98312bc3-9d2a-480c-bcf0-db8d70d632b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98312bc3-9d2a-480c-bcf0-db8d70d632b9.jpg?1",
             "name": "Farsight Mask",
             "text": "Whenever a source an opponent controls deals damage to you, if Farsight Mask is untapped, you may draw a card.",
             "colours": [],
@@ -5592,7 +5592,7 @@
         },
         {
             "id": "c8199596-de89-5ba9-a712-52ab3f057c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da0fcc6-6209-4b8e-997d-ad3cc4ff0856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da0fcc6-6209-4b8e-997d-ad3cc4ff0856.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike. (It deals both first-strike and regular combat damage.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "e90b88c9-b69b-5627-892f-e79d01735f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff504dcb-2eb8-4b3c-a8b9-29697739b649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff504dcb-2eb8-4b3c-a8b9-29697739b649.jpg?1",
             "name": "Frogmite",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)",
             "colours": [],
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "c9f5c36c-ec4e-5ebe-8fe2-ef777aee6981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934936d1-f470-47fa-ac28-344020c9fc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/934936d1-f470-47fa-ac28-344020c9fc76.jpg?1",
             "name": "Galvanic Key",
             "text": "You may play Galvanic Key any time you could play an instant.\n{3}, {T}: Untap target artifact.",
             "colours": [],
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "c5bb36a9-9b93-5c11-8f0b-fa7ecffc82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fd840-e633-46d3-991a-b9fea95a2f28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28fd840-e633-46d3-991a-b9fea95a2f28.jpg?1",
             "name": "Gate to the Aether",
             "text": "At the beginning of each player's upkeep, that player reveals the top card of his or her library. If it's an artifact, creature, enchantment, or land card, the player may put it into play.",
             "colours": [],
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "d35ed259-c7ee-5ee4-872c-76875c85afed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d5e4c8-dfd0-45bc-8000-ebfaccfefec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d5e4c8-dfd0-45bc-8000-ebfaccfefec3.jpg?1",
             "name": "Gilded Lotus",
             "text": "{T}: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -5737,7 +5737,7 @@
         },
         {
             "id": "4aa6dae9-0664-5051-9000-edb6cd5fde0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c37fc1-4842-4bc5-93ed-83fff9e420f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c37fc1-4842-4bc5-93ed-83fff9e420f2.jpg?1",
             "name": "Goblin Charbelcher",
             "text": "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. Goblin Charbelcher deals damage equal to the number of nonland cards revealed this way to target creature or player. If the revealed land card was a Mountain, Goblin Charbelcher deals double that damage instead. Put the revealed cards on the bottom of your library in any order.",
             "colours": [],
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "1e1e1eec-ba16-5b8b-8b80-bd26e5e3b2aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ed2990-e5bf-4567-9a41-1846108a8aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ed2990-e5bf-4567-9a41-1846108a8aeb.jpg?1",
             "name": "Goblin Dirigible",
             "text": "Flying\nGoblin Dirigible doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Goblin Dirigible.",
             "colours": [],
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "e9b6fbce-67d0-5d52-998a-504f3a34dcb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63282976-e08d-4b8c-bbfc-f6739fdaeaf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63282976-e08d-4b8c-bbfc-f6739fdaeaf9.jpg?1",
             "name": "Goblin Replica",
             "text": "{3}{R}, Sacrifice Goblin Replica: Destroy target artifact.",
             "colours": [],
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "b346418d-e819-5c12-9131-6582a489e240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229e8124-54ed-4c29-8c44-4962bd60f145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229e8124-54ed-4c29-8c44-4962bd60f145.jpg?1",
             "name": "Goblin War Wagon",
             "text": "Goblin War Wagon doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {2}. If you do, untap Goblin War Wagon.",
             "colours": [],
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "f8234e3b-ed3b-50ee-84d2-17aaff3500a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9b4040-ab49-476b-b101-5ef2b1824e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9b4040-ab49-476b-b101-5ef2b1824e10.jpg?1",
             "name": "Gold Myr",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "c5d3a332-7a2b-5438-892a-1f5f0b1e09bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9519f2a-e98d-4f84-885c-24a9849a996d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9519f2a-e98d-4f84-885c-24a9849a996d.jpg?1",
             "name": "Golem-Skin Gauntlets",
             "text": "Equipped creature gets +1/+0 for each Equipment attached to it.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -5923,7 +5923,7 @@
         },
         {
             "id": "aca7f6b4-f573-59d9-9e14-2ff257f89c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197af6a-24ac-4f3b-ab3c-736f4057748b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e197af6a-24ac-4f3b-ab3c-736f4057748b.jpg?1",
             "name": "Granite Shard",
             "text": "{3}, {T} or {R}, {T}: Granite Shard deals 1 damage to target creature or player.",
             "colours": [],
@@ -5953,7 +5953,7 @@
         },
         {
             "id": "f2d40670-fa05-5050-bbe2-c5767c84b349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg?1",
             "name": "Grid Monitor",
             "text": "You can't play creature spells.",
             "colours": [],
@@ -5984,7 +5984,7 @@
         },
         {
             "id": "51ebff86-42fa-518b-a178-db2f7af9296d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13328a9-fc03-4c1b-b1b7-61cd41766300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13328a9-fc03-4c1b-b1b7-61cd41766300.jpg?1",
             "name": "Heartwood Shard",
             "text": "{3}, {T} or {G}, {T}: Target creature gains trample until end of turn.",
             "colours": [],
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "3116f693-b007-5e71-a2d9-9db85686a515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8d47d-6ecb-424a-a908-a6501f308c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8d47d-6ecb-424a-a908-a6501f308c8e.jpg?1",
             "name": "Hematite Golem",
             "text": "{1}{R}: Hematite Golem gets +2/+0 until end of turn.",
             "colours": [],
@@ -6047,7 +6047,7 @@
         },
         {
             "id": "c245d9c0-8838-53aa-bd52-ae57b31017c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1bdbe2-4163-469b-aa8c-00fd8208ec27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1bdbe2-4163-469b-aa8c-00fd8208ec27.jpg?1",
             "name": "Icy Manipulator",
             "text": "{1}, {T}: Tap target artifact, creature, or land.",
             "colours": [],
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "acd896a7-edf9-5575-b5c2-f2fd5eeae669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e17883-0767-40b5-ac44-a52a1ea54993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e17883-0767-40b5-ac44-a52a1ea54993.jpg?1",
             "name": "Iron Myr",
             "text": "{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -6108,7 +6108,7 @@
         },
         {
             "id": "a3585853-9506-5b1c-b035-1e26e5aa0c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878b0159-6917-45d3-b9ea-562ac49f0b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/878b0159-6917-45d3-b9ea-562ac49f0b8f.jpg?1",
             "name": "Isochron Scepter",
             "text": "Imprint When Isochron Scepter comes into play, you may remove an instant card with converted mana cost 2 or less in your hand from the game. (The removed card is imprinted on this artifact.)\n{2}, {T}: You may copy the imprinted instant card and play the copy without paying its mana cost.",
             "colours": [],
@@ -6136,7 +6136,7 @@
         },
         {
             "id": "0facf220-1c21-5be3-8acf-76d10f74d123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987910b0-0419-45ff-bda6-c6683fd00e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987910b0-0419-45ff-bda6-c6683fd00e49.jpg?1",
             "name": "Jinxed Choker",
             "text": "At the end of your turn, target opponent gains control of Jinxed Choker and puts a charge counter on it.\nAt the beginning of your upkeep, Jinxed Choker deals damage to you equal to the number of charge counters on it.\n{3}: Put a charge counter on Jinxed Choker or remove one from it.",
             "colours": [],
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "47bf8c6d-3d74-578a-a873-03e76ea2dcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a5d49a-747e-4ec8-a20a-ca917c315774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a5d49a-747e-4ec8-a20a-ca917c315774.jpg?1",
             "name": "Krark's Thumb",
             "text": "If you would flip a coin, instead flip two coins and ignore one.",
             "colours": [],
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "ebce3430-1e96-576c-bcdd-5a017b653f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555efe5f-848f-44da-92b5-69c8e852f179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555efe5f-848f-44da-92b5-69c8e852f179.jpg?1",
             "name": "Leaden Myr",
             "text": "{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "270b6d4b-7a2b-536d-849d-d4e30a5783a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780199bc-dce4-4ed0-88fb-7d288f304e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780199bc-dce4-4ed0-88fb-7d288f304e69.jpg?1",
             "name": "Leonin Bladetrap",
             "text": "You may play Leonin Bladetrap any time you could play an instant.\n{2}, Sacrifice Leonin Bladetrap: Leonin Bladetrap deals 2 damage to each attacking creature without flying.",
             "colours": [],
@@ -6255,7 +6255,7 @@
         },
         {
             "id": "d326b076-522d-572e-85b2-0dee953d9510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abf4bbe-5b1c-4f6f-be32-5f61c66e1830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abf4bbe-5b1c-4f6f-be32-5f61c66e1830.jpg?1",
             "name": "Leonin Scimitar",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "cb0df8c9-b497-5526-8e9e-a805d0bc53c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395f719d-1f55-4f1a-a9fb-a178cd589f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395f719d-1f55-4f1a-a9fb-a178cd589f70.jpg?1",
             "name": "Leonin Sun Standard",
             "text": "{1}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [],
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "8988dfbc-8e24-5758-8f5b-79af5a0815a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ffa3c3-dd29-47eb-abf2-7951fadb5c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ffa3c3-dd29-47eb-abf2-7951fadb5c37.jpg?1",
             "name": "Leveler",
             "text": "When Leveler comes into play, remove your library from the game.",
             "colours": [],
@@ -6346,7 +6346,7 @@
         },
         {
             "id": "80d4204a-17d2-5f67-92f1-f0e94d501fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66372597-c182-4850-a630-231737b1482b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66372597-c182-4850-a630-231737b1482b.jpg?1",
             "name": "Liar's Pendulum",
             "text": "{2}, {T}: Name a card. Target opponent guesses whether a card with that name is in your hand. You may reveal your hand. If you do and your opponent guessed wrong, draw a card.",
             "colours": [],
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "53b1883f-4c6f-5342-9bf3-8e36f3ca57ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adde668-67af-4a08-a36a-2a49893ab20d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adde668-67af-4a08-a36a-2a49893ab20d.jpg?1",
             "name": "Lifespark Spellbomb",
             "text": "{G}, Sacrifice Lifespark Spellbomb: Until end of turn, target land becomes a 3/3 creature that's still a land.\n{1}, Sacrifice Lifespark Spellbomb: Draw a card.",
             "colours": [],
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "1250647d-4890-5043-a6a6-f4786006ea6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a800f326-3416-4917-a1cf-0f90255777d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a800f326-3416-4917-a1cf-0f90255777d3.jpg?1",
             "name": "Lightning Coils",
             "text": "Whenever a nontoken creature you control is put into a graveyard from play, put a charge counter on Lightning Coils.\nAt the beginning of your upkeep, if Lightning Coils has five or more charge counters on it, remove all of them from it and put that many 3/1 red Elemental creature tokens with haste into play. Remove them from the game at end of turn.",
             "colours": [],
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "25429a6d-fd7a-5235-a230-f4748b04589d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a28870-cf78-4323-9d82-cee764067764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a28870-cf78-4323-9d82-cee764067764.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and can't be the target of spells or abilities.\nEquip {0} ({0}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "817c05bf-b9af-5093-9fa0-a64e7e526ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faab1d25-dee5-4315-ba63-f8e14087a9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faab1d25-dee5-4315-ba63-f8e14087a9c0.jpg?1",
             "name": "Lodestone Myr",
             "text": "Trample\nTap an untapped artifact you control: Lodestone Myr gets +1/+1 until end of turn.",
             "colours": [],
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "2d4a07f8-ad17-5b90-8e09-3d8519fca861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6e375-5c47-4447-9453-adf0038693e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a6e375-5c47-4447-9453-adf0038693e3.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "Equipped creature gets +3/+0, has trample, and has \"Whenever this creature deals damage, you gain that much life.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6523,7 +6523,7 @@
         },
         {
             "id": "778a262f-8759-5dfc-89ff-a514ecec8acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1193164-5ee5-40ff-b244-f80d426bbf89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1193164-5ee5-40ff-b244-f80d426bbf89.jpg?1",
             "name": "Malachite Golem",
             "text": "{1}{G}: Malachite Golem gains trample until end of turn.",
             "colours": [],
@@ -6556,7 +6556,7 @@
         },
         {
             "id": "1c42d2bd-058a-5d29-94f8-3731c10c9b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f8021-aaf3-4b1c-b08c-fe667ce2d8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512f8021-aaf3-4b1c-b08c-fe667ce2d8e1.jpg?1",
             "name": "Mask of Memory",
             "text": "Whenever equipped creature deals combat damage to a player, you may draw two cards. If you do, discard a card from your hand.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -6586,7 +6586,7 @@
         },
         {
             "id": "c879425a-6b46-555b-abac-5f56b7790280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d11b14-43a9-4d1c-ba2c-3025d51d841e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d11b14-43a9-4d1c-ba2c-3025d51d841e.jpg?1",
             "name": "Mesmeric Orb",
             "text": "Whenever a permanent becomes untapped, that permanent's controller puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "8f6813a7-cfbd-59b1-beac-373b18a025d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0899f753-c229-4cdf-a60c-4978a6506def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0899f753-c229-4cdf-a60c-4978a6506def.jpg?1",
             "name": "Mind's Eye",
             "text": "Whenever an opponent draws a card, you may pay {1}. If you do, draw a card.",
             "colours": [],
@@ -6642,7 +6642,7 @@
         },
         {
             "id": "6b60ae25-d5a3-57aa-8102-ba5262ec796c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb1eaa-2871-491a-a4f5-3e358778ba40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fb1eaa-2871-491a-a4f5-3e358778ba40.jpg?1",
             "name": "Mindslaver",
             "text": "{4}, {T}, Sacrifice Mindslaver: You control target player's next turn. (You see all cards that player could see and make all decisions for the player. He or she doesn't lose life because of mana burn.)",
             "colours": [],
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "97708c05-2689-5840-8713-8888e878c0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c1442-036b-43e7-9f86-b81a54d6bc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347c1442-036b-43e7-9f86-b81a54d6bc41.jpg?1",
             "name": "Mindstorm Crown",
             "text": "At the beginning of your upkeep, draw a card if you had no cards in hand at the beginning of this turn. If you had a card in hand, Mindstorm Crown deals 1 damage to you.",
             "colours": [],
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "69d416fb-f290-58c9-a9a9-32275d36d265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9467839-b2a2-4cfe-a60e-12766e2ba983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9467839-b2a2-4cfe-a60e-12766e2ba983.jpg?1",
             "name": "Mirror Golem",
             "text": "Imprint When Mirror Golem comes into play, you may remove target card in a graveyard from the game. (The removed card is imprinted on this artifact.)\nMirror Golem has protection from each of the imprinted card's card types. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [],
@@ -6731,7 +6731,7 @@
         },
         {
             "id": "d60a0ae3-b61b-5b5b-aec5-a9e16cb3c0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fe67f-59f7-46f0-bfa4-fa4a65c9c33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783fe67f-59f7-46f0-bfa4-fa4a65c9c33c.jpg?1",
             "name": "Mourner's Shield",
             "text": "Imprint When Mourner's Shield comes into play, you may remove target card in a graveyard from the game. (The removed card is imprinted on this artifact.)\n{2}, {T}: Prevent all damage that would be dealt this turn by a source of your choice that shares a color with the imprinted card.",
             "colours": [],
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "bed0e680-9691-5266-91cf-8756bfbfec2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6ddde9-4427-4a0f-b05c-9cfd886aad2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6ddde9-4427-4a0f-b05c-9cfd886aad2d.jpg?1",
             "name": "Myr Adapter",
             "text": "Myr Adapter gets +1/+1 for each Equipment attached to it.",
             "colours": [],
@@ -6790,7 +6790,7 @@
         },
         {
             "id": "92e5b9a2-fb68-5eae-aba6-338bcb17b24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg?1",
             "name": "Myr Enforcer",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)",
             "colours": [],
@@ -6821,7 +6821,7 @@
         },
         {
             "id": "18dc0e7f-1f1f-5530-ab3e-5ffc7b82d0bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0f9ef-7404-4e05-b759-aaf1ebcfcb31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0f9ef-7404-4e05-b759-aaf1ebcfcb31.jpg?1",
             "name": "Myr Incubator",
             "text": "{6}, {T}, Sacrifice Myr Incubator: Search your library for any number of artifact cards, remove them from the game, then put that many 1/1 Myr artifact creature tokens into play. Then shuffle your library.",
             "colours": [],
@@ -6849,7 +6849,7 @@
         },
         {
             "id": "fa3e26b7-096d-5845-ac22-a90be7a41d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce711-8f68-4487-b67b-be35796ffcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98ce711-8f68-4487-b67b-be35796ffcff.jpg?1",
             "name": "Myr Mindservant",
             "text": "{2}, {T}: Shuffle your library.",
             "colours": [],
@@ -6880,7 +6880,7 @@
         },
         {
             "id": "0e0be462-2b51-5ce2-ae7a-9f64e0ea7343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929b28-c184-4e77-a40b-ee43b8a37d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d929b28-c184-4e77-a40b-ee43b8a37d79.jpg?1",
             "name": "Myr Prototype",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on Myr Prototype.\nMyr Prototype can't attack or block unless you pay {1} for each +1/+1 counter on it. (This cost is paid as attackers or blockers are declared.)",
             "colours": [],
@@ -6911,7 +6911,7 @@
         },
         {
             "id": "6a03e3ca-8041-56c0-b908-3c2027c77813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee766f7b-4e9c-442d-bf53-31c204646449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee766f7b-4e9c-442d-bf53-31c204646449.jpg?1",
             "name": "Myr Retriever",
             "text": "When Myr Retriever is put into a graveyard from play, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "840919e2-7c75-5ce5-84e1-dd9bffcffc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0950bfe7-2600-4e01-8f54-f03a5c023520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0950bfe7-2600-4e01-8f54-f03a5c023520.jpg?1",
             "name": "Necrogen Spellbomb",
             "text": "{B}, Sacrifice Necrogen Spellbomb: Target player discards a card from his or her hand.\n{1}, Sacrifice Necrogen Spellbomb: Draw a card.",
             "colours": [],
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "4d1a3bd1-2d9c-59ce-b7a1-28756d977a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fbd8a-1e2a-450e-98f2-26bbc9e9ac79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fbd8a-1e2a-450e-98f2-26bbc9e9ac79.jpg?1",
             "name": "Needlebug",
             "text": "Protection from artifacts\nYou may play Needlebug any time you could play an instant.",
             "colours": [],
@@ -7003,7 +7003,7 @@
         },
         {
             "id": "de2fc517-fcbc-557b-a0e3-2242e4212f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5790b-5388-4bf9-9caa-44d8cbb64708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa5790b-5388-4bf9-9caa-44d8cbb64708.jpg?1",
             "name": "Neurok Hoversail",
             "text": "Equipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -7033,7 +7033,7 @@
         },
         {
             "id": "9d9cfc11-23f2-549e-bb77-12946b49952b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8e3fa6-494c-412f-90cc-36d45cd2b175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8e3fa6-494c-412f-90cc-36d45cd2b175.jpg?1",
             "name": "Nightmare Lash",
             "text": "Equipped creature gets +1/+1 for each Swamp you control.\nEquip\u2014\nPay 3 life. (Pay 3 life: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "cf6c78bd-2497-5b65-bb2c-89fd9fde1484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11a56e7-30a4-44da-a58b-336f4c0c4882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11a56e7-30a4-44da-a58b-336f4c0c4882.jpg?1",
             "name": "Nim Replica",
             "text": "{2}{B}, Sacrifice Nim Replica: Target creature gets -1/-1 until end of turn.",
             "colours": [],
@@ -7096,7 +7096,7 @@
         },
         {
             "id": "efff191a-c928-5104-a8b4-f7be30494e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266df8c3-5872-4d83-90bc-8f6f854ac838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266df8c3-5872-4d83-90bc-8f6f854ac838.jpg?1",
             "name": "Nuisance Engine",
             "text": "{2}, {T}: Put a 0/1 Pest artifact creature token into play.",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "bbe06c84-7e26-5db8-b76b-91946c4d9c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddba1566-2778-4636-b4d3-9095fb2d83c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddba1566-2778-4636-b4d3-9095fb2d83c8.jpg?1",
             "name": "Oblivion Stone",
             "text": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice Oblivion Stone: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
             "colours": [],
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "4c88c7e1-4e4d-54fd-a2f1-d54e6d7d14fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa5c60-054f-4397-a110-21df58264caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddaa5c60-054f-4397-a110-21df58264caf.jpg?1",
             "name": "Omega Myr",
             "text": "",
             "colours": [],
@@ -7183,7 +7183,7 @@
         },
         {
             "id": "dc0ae0b0-0184-5012-be34-6bbba1408b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969ebd20-de69-44ba-a0c2-9e2a89480370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969ebd20-de69-44ba-a0c2-9e2a89480370.jpg?1",
             "name": "Ornithopter",
             "text": "Flying",
             "colours": [],
@@ -7214,7 +7214,7 @@
         },
         {
             "id": "de4f0614-5752-52ef-9e50-f1559a1db4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde295d-af41-4b9c-af48-3067befe9383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abde295d-af41-4b9c-af48-3067befe9383.jpg?1",
             "name": "Pearl Shard",
             "text": "{3}, {T} or {W}, {T}: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [],
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "bf99443f-28c0-57fb-bb96-006e8dea9f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a11f0a-7547-4fda-a8ed-caf76ce98f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a11f0a-7547-4fda-a8ed-caf76ce98f10.jpg?1",
             "name": "Pentavus",
             "text": "Pentavus comes into play with five +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from Pentavus: Put a 1/1 Pentavite artifact creature token with flying into play.\n{1}, Sacrifice a Pentavite: Put a +1/+1 counter on Pentavus.",
             "colours": [],
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "50811d69-2ac8-51e0-a0ba-d5d8bbf34c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa6682-bf11-4959-9d07-423a55f35199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28aa6682-bf11-4959-9d07-423a55f35199.jpg?1",
             "name": "Pewter Golem",
             "text": "{1}{B}: Regenerate Pewter Golem.",
             "colours": [],
@@ -7308,7 +7308,7 @@
         },
         {
             "id": "91945553-a222-52ea-9950-0a8621105bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bb5aee-b334-4c24-875b-56751d4add02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bb5aee-b334-4c24-875b-56751d4add02.jpg?1",
             "name": "Platinum Angel",
             "text": "Flying\nYou can't lose the game and your opponents can't win the game.",
             "colours": [],
@@ -7339,7 +7339,7 @@
         },
         {
             "id": "322daeea-5abe-59ba-87dd-0285dd8f20ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f5c84f-1924-4a4a-84c1-00dcb756e9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f5c84f-1924-4a4a-84c1-00dcb756e9c9.jpg?1",
             "name": "Power Conduit",
             "text": "{T}, Remove a counter from a permanent you control: Choose one Put a charge counter on target artifact; or put a +1/+1 counter on target creature.",
             "colours": [],
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "3c79fb75-2aa5-5233-aa8c-96a594d474e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e5c69c-43d0-4f5b-8720-40074eb122bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e5c69c-43d0-4f5b-8720-40074eb122bb.jpg?1",
             "name": "Proteus Staff",
             "text": "{2}{U}, {T}: Put target creature on the bottom of its owner's library. That creature's controller reveals cards from the top of his or her library until he or she reveals a creature card. The player puts that card into play and the rest on the bottom of his or her library in any order. Play this ability only any time you could play a sorcery.",
             "colours": [],
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "45fcc44f-59f3-525c-bc72-a1d887101b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83d1ed5-3a49-4cfa-bad2-e342ef28649e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83d1ed5-3a49-4cfa-bad2-e342ef28649e.jpg?1",
             "name": "Psychogenic Probe",
             "text": "Whenever a spell or ability causes a player to shuffle his or her library, Psychogenic Probe deals 2 damage to him or her.",
             "colours": [],
@@ -7425,7 +7425,7 @@
         },
         {
             "id": "c77e1c3d-6f63-5942-828c-fe65cbafc039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b9bab9-12ee-4da5-9d53-d0b82d9279cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b9bab9-12ee-4da5-9d53-d0b82d9279cd.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "{R}, Sacrifice Pyrite Spellbomb: Pyrite Spellbomb deals 2 damage to target creature or player.\n{1}, Sacrifice Pyrite Spellbomb: Draw a card.",
             "colours": [],
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "f6c1643d-5e74-5cf0-a404-4d1545052be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f2bf63-e3cf-4a58-86b7-f3bab3b90712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f2bf63-e3cf-4a58-86b7-f3bab3b90712.jpg?1",
             "name": "Quicksilver Fountain",
             "text": "At the beginning of each player's upkeep, that player puts a flood counter on target non-Island land he or she controls. That land is an Island as long as it has a flood counter on it.\nAt end of turn, if all lands in play are Islands, remove all flood counters from them.",
             "colours": [],
@@ -7483,7 +7483,7 @@
         },
         {
             "id": "37d303d7-af1f-5cbc-a57a-aadcd255d41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a08cd-72b3-4b3f-9f23-15697704acb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a08cd-72b3-4b3f-9f23-15697704acb3.jpg?1",
             "name": "Rust Elemental",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice an artifact other than Rust Elemental. If you can't, tap Rust Elemental and you lose 4 life.",
             "colours": [],
@@ -7514,7 +7514,7 @@
         },
         {
             "id": "d1719b64-8f30-5c97-8746-96c8178d811d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d23449c-4439-4425-ad53-84168a94b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d23449c-4439-4425-ad53-84168a94b1ce.jpg?1",
             "name": "Rustspore Ram",
             "text": "When Rustspore Ram comes into play, destroy target Equipment.",
             "colours": [],
@@ -7545,7 +7545,7 @@
         },
         {
             "id": "bf1af69e-8e86-5acf-80fe-c5013a4c47b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133b367c-b1a1-46f7-a539-a33ee655affb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133b367c-b1a1-46f7-a539-a33ee655affb.jpg?1",
             "name": "Scale of Chiss-Goria",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nYou may play Scale of Chiss-Goria any time you could play an instant.\n{T}: Target creature gets +0/+1 until end of turn.",
             "colours": [],
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "53ba04f7-47a3-51e6-baa5-ee3d6fcd96df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg?1",
             "name": "Scrabbling Claws",
             "text": "{T}: Target player removes a card in his or her graveyard from the game.\n{1}, Sacrifice Scrabbling Claws: Remove target card in a graveyard from the game. Draw a card.",
             "colours": [],
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "52ad0c9d-ea18-5244-b305-e1b254d9767d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aac5f6f-97c1-4546-94ed-016292e98c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aac5f6f-97c1-4546-94ed-016292e98c9d.jpg?1",
             "name": "Sculpting Steel",
             "text": "As Sculpting Steel comes into play, you may choose an artifact in play. If you do, Sculpting Steel comes into play as a copy of that artifact.",
             "colours": [],
@@ -7629,7 +7629,7 @@
         },
         {
             "id": "12587e5a-3b4f-56d5-b843-2a821faeee91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e7a81-fb3d-4bad-854a-b24138ca7415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e7a81-fb3d-4bad-854a-b24138ca7415.jpg?1",
             "name": "Scythe of the Wretched",
             "text": "Equipped creature gets +2/+2.\nWhenever a creature dealt damage by equipped creature this turn is put into a graveyard, return that card to play under your control. Attach Scythe of the Wretched to that creature.\nEquip {4}",
             "colours": [],
@@ -7659,7 +7659,7 @@
         },
         {
             "id": "084f78e9-5e62-55a3-9d05-266c5b7f19a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ec055-1a7d-426b-a87f-c85c60aa7fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126ec055-1a7d-426b-a87f-c85c60aa7fc3.jpg?1",
             "name": "Serum Tank",
             "text": "Whenever Serum Tank or another artifact comes into play, put a charge counter on Serum Tank.\n{3}, {T}, Remove a charge counter from Serum Tank: Draw a card.",
             "colours": [],
@@ -7687,7 +7687,7 @@
         },
         {
             "id": "038e6785-57cf-52fb-88b1-c58d77f79451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a73a2-fedb-40bd-8e29-82a7abd6f211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a73a2-fedb-40bd-8e29-82a7abd6f211.jpg?1",
             "name": "Silver Myr",
             "text": "{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -7720,7 +7720,7 @@
         },
         {
             "id": "164ca139-fabd-5a35-a19a-dfa932fac67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeffcd61-ea1f-4ccd-b3d3-79efa9d4a0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeffcd61-ea1f-4ccd-b3d3-79efa9d4a0cf.jpg?1",
             "name": "Skeleton Shard",
             "text": "{3}, {T} or {B}, {T}: Return target artifact creature card from your graveyard to your hand.",
             "colours": [],
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "2c5c62a1-1190-5489-bb8d-a56372790faf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a6e3f-909a-4ca0-a6aa-7354b9476df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684a6e3f-909a-4ca0-a6aa-7354b9476df2.jpg?1",
             "name": "Slagwurm Armor",
             "text": "Equipped creature gets +0/+6.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "7f1e3001-49f6-50d6-b058-fce4f87cc7ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31761a8-1146-4003-9653-881233787ac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e31761a8-1146-4003-9653-881233787ac4.jpg?1",
             "name": "Soldier Replica",
             "text": "{1}{W}, Sacrifice Soldier Replica: Soldier Replica deals 3 damage to target attacking or blocking creature.",
             "colours": [],
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "cbdf57dd-db66-52fd-8e44-ee3dffc3a540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f9955f-a522-47bf-b064-92dd21a76b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f9955f-a522-47bf-b064-92dd21a76b18.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum comes into play, you may search your library for a basic land card and put that card into play tapped. If you do, shuffle your library.\nWhen Solemn Simulacrum is put into a graveyard from play, you may draw a card.",
             "colours": [],
@@ -7844,7 +7844,7 @@
         },
         {
             "id": "e2429895-beca-5a8f-bc99-2df107558ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b4983a-2a95-4322-a315-27b4bd430d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b4983a-2a95-4322-a315-27b4bd430d39.jpg?1",
             "name": "Soul Foundry",
             "text": "Imprint When Soul Foundry comes into play, you may remove a creature card in your hand from the game. (The removed card is imprinted on this artifact.)\n{X}, {T}: Put a creature token into play that's a copy of the imprinted creature card. X is the converted mana cost of that card.",
             "colours": [],
@@ -7872,7 +7872,7 @@
         },
         {
             "id": "0cfde1f1-7795-515f-b52f-92e37e1def29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d44b4-1c3b-4109-aaad-8351bf8a7624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48d44b4-1c3b-4109-aaad-8351bf8a7624.jpg?1",
             "name": "Spellweaver Helix",
             "text": "Imprint When Spellweaver Helix comes into play, you may remove two target sorcery cards in a single graveyard from the game. (The removed cards are imprinted on this artifact.)\nWhenever a card is played, if it has the same name as one of the imprinted sorcery cards, you may copy the other and play the copy without paying its mana cost.",
             "colours": [],
@@ -7900,7 +7900,7 @@
         },
         {
             "id": "ed0116b1-6bc7-58a1-956d-0f868817f3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d641aaf-e2ff-4ccb-9e4e-27bbfc31ba8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d641aaf-e2ff-4ccb-9e4e-27bbfc31ba8c.jpg?1",
             "name": "Steel Wall",
             "text": "(Walls can't attack.)",
             "colours": [],
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "4dd3cda3-ee64-5eb2-b508-4846f2648add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdd01de-2ac6-4393-ad53-d52df137bc08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bdd01de-2ac6-4393-ad53-d52df137bc08.jpg?1",
             "name": "Sun Droplet",
             "text": "Whenever you're dealt damage, put that many charge counters on Sun Droplet.\nAt the beginning of each player's upkeep, you may remove a charge counter from Sun Droplet. If you do, you gain 1 life.",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "97a835d8-f52d-5d08-bacd-2e5740d81965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ffdb7-9f8e-4376-9431-cf1c1814f2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d23ffdb7-9f8e-4376-9431-cf1c1814f2c4.jpg?1",
             "name": "Sunbeam Spellbomb",
             "text": "{W}, Sacrifice Sunbeam Spellbomb: You gain 5 life.\n{1}, Sacrifice Sunbeam Spellbomb: Draw a card.",
             "colours": [],
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "9fc4c275-4670-5099-af68-6e7702d94988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a665bff-b57a-450c-9310-932b0686a03e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a665bff-b57a-450c-9310-932b0686a03e.jpg?1",
             "name": "Sword of Kaldra",
             "text": "Equipped creature gets +5/+5.\nWhenever equipped creature deals damage to a creature, remove that creature from the game.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "fb3ae02b-8802-52d6-8f6b-57cf3e3b6088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2ab6e-019e-4e72-be06-9c8cd97d54d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2ab6e-019e-4e72-be06-9c8cd97d54d4.jpg?1",
             "name": "Synod Sanctum",
             "text": "{2}, {T}: Remove target permanent you control from the game.\n{2}, Sacrifice Synod Sanctum: Return to play under your control all cards removed from the game with Synod Sanctum.",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "f879f3ab-f95a-5d46-9765-624e44808366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991037a2-fea2-49f5-8ace-ebbf9f678cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991037a2-fea2-49f5-8ace-ebbf9f678cff.jpg?1",
             "name": "Talisman of Dominance",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {U} or {B} to your mana pool. Talisman of Dominance deals 1 damage to you.",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "dfb9a097-19dc-509e-ad8f-cef6388e9b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00b65f7-70d0-4bbd-ac13-be24cc3374ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00b65f7-70d0-4bbd-ac13-be24cc3374ee.jpg?1",
             "name": "Talisman of Impulse",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {R} or {G} to your mana pool. Talisman of Impulse deals 1 damage to you.",
             "colours": [],
@@ -8111,7 +8111,7 @@
         },
         {
             "id": "51aea172-b039-538b-9b75-2ebcf16b598e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14011b3-56ce-4b93-833f-d8403809159c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14011b3-56ce-4b93-833f-d8403809159c.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {B} or {R} to your mana pool. Talisman of Indulgence deals 1 damage to you.",
             "colours": [],
@@ -8142,7 +8142,7 @@
         },
         {
             "id": "26aec3cf-6430-506d-b066-40573ab5d8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ff849e-2439-4690-8aa4-769039b6da4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ff849e-2439-4690-8aa4-769039b6da4c.jpg?1",
             "name": "Talisman of Progress",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {W} or {U} to your mana pool. Talisman of Progress deals 1 damage to you.",
             "colours": [],
@@ -8173,7 +8173,7 @@
         },
         {
             "id": "23d05da0-a519-5e3e-b7e9-8cd7e3875b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cc8a5a-b98b-4758-a168-bf2ef738fb05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cc8a5a-b98b-4758-a168-bf2ef738fb05.jpg?1",
             "name": "Talisman of Unity",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Talisman of Unity deals 1 damage to you.",
             "colours": [],
@@ -8204,7 +8204,7 @@
         },
         {
             "id": "4e6cd2b7-06e6-5c40-898c-fa1c6aaaab18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361a524c-17aa-43a0-8aea-1d26a9a1044c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361a524c-17aa-43a0-8aea-1d26a9a1044c.jpg?1",
             "name": "Tanglebloom",
             "text": "{1}, {T}: You gain 1 life.",
             "colours": [],
@@ -8232,7 +8232,7 @@
         },
         {
             "id": "04919084-641d-519d-813f-0a0e6cbbda86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ff2c28-770b-49cb-be10-35429233e048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ff2c28-770b-49cb-be10-35429233e048.jpg?1",
             "name": "Tangleroot",
             "text": "Whenever a player plays a creature spell, that player adds {G} to his or her mana pool.",
             "colours": [],
@@ -8262,7 +8262,7 @@
         },
         {
             "id": "456b5d44-92a6-5d2b-ae1c-d2945ff47c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522570eb-e654-4f8a-828c-3e456a0ad8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522570eb-e654-4f8a-828c-3e456a0ad8e6.jpg?1",
             "name": "Tel-Jilad Stylus",
             "text": "{T}: Put target permanent you own on the bottom of your library.",
             "colours": [],
@@ -8290,7 +8290,7 @@
         },
         {
             "id": "09c84d88-0429-554b-aa62-c00725bae836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409087ef-8232-489c-8b98-b601bb0a47a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409087ef-8232-489c-8b98-b601bb0a47a4.jpg?1",
             "name": "Thought Prison",
             "text": "Imprint When Thought Prison comes into play, you may have target player reveal his or her hand. If you do, choose a nonland card from it and remove that card from the game. (The removed card is imprinted on this artifact.)\nWhenever a player plays a spell that shares a color or converted mana cost with the imprinted card, Thought Prison deals 2 damage to that player.",
             "colours": [],
@@ -8318,7 +8318,7 @@
         },
         {
             "id": "db9deb44-c440-57e6-bda6-f40703792553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cab0e-8874-4534-bf79-0c1488a9f0a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561cab0e-8874-4534-bf79-0c1488a9f0a5.jpg?1",
             "name": "Timesifter",
             "text": "At the beginning of each player's upkeep, each player removes the top card of his or her library from the game. The player who removed the card with the highest converted mana cost takes an extra turn after this one. If two or more players' cards are tied for highest cost, the tied players repeat this process until the tie is broken.",
             "colours": [],
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "115b87d0-044c-5306-9c07-ab8635ac7130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8defd53c-3792-4ed3-aee9-cffda2b8a8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8defd53c-3792-4ed3-aee9-cffda2b8a8b6.jpg?1",
             "name": "Titanium Golem",
             "text": "{1}{W}: Titanium Golem gains first strike until end of turn.",
             "colours": [],
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "5084a2a8-2170-5e1d-a2fc-ca457b32afa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5a91db-1b86-4471-badc-884142c355ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5a91db-1b86-4471-badc-884142c355ca.jpg?1",
             "name": "Tooth of Chiss-Goria",
             "text": "Affinity for artifacts (This spell costs {1} less to play for each artifact you control.)\nYou may play Tooth of Chiss-Goria any time you could play an instant.\n{T}: Target creature gets +1/+0 until end of turn.",
             "colours": [],
@@ -8407,7 +8407,7 @@
         },
         {
             "id": "36a2e003-2cb2-51c9-a2fe-308ceac58967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5280aef-dfd2-4d52-bc87-4a6d1f2bd173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5280aef-dfd2-4d52-bc87-4a6d1f2bd173.jpg?1",
             "name": "Tower of Champions",
             "text": "{8}, {T}: Target creature gets +6/+6 until end of turn.",
             "colours": [],
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "69ee29de-5b36-580c-8c54-2d806f964eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb67150-53e4-4164-bea5-dd3659469b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb67150-53e4-4164-bea5-dd3659469b8e.jpg?1",
             "name": "Tower of Eons",
             "text": "{8}, {T}: You gain 10 life.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "dc84e7a3-0758-5378-8a43-eb71e1c52488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433bab44-b644-4e77-a187-bd924d21e91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433bab44-b644-4e77-a187-bd924d21e91f.jpg?1",
             "name": "Tower of Fortunes",
             "text": "{8}, {T}: Draw four cards.",
             "colours": [],
@@ -8491,7 +8491,7 @@
         },
         {
             "id": "aeaf9131-042f-5620-9874-aa68700dd415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76be1ca8-b68e-436d-86b6-2a2a07da1be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76be1ca8-b68e-436d-86b6-2a2a07da1be9.jpg?1",
             "name": "Tower of Murmurs",
             "text": "{8}, {T}: Target player puts the top eight cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -8519,7 +8519,7 @@
         },
         {
             "id": "5f49458c-b134-5a27-a93e-8a8da1e22099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b997abd-8eae-4e87-97fc-36dde95ef8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b997abd-8eae-4e87-97fc-36dde95ef8c7.jpg?1",
             "name": "Triskelion",
             "text": "Triskelion comes into play with three +1/+1 counters on it.\nRemove a +1/+1 counter from Triskelion: Triskelion deals 1 damage to target creature or player.",
             "colours": [],
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "3523ad3b-3dab-51e4-a836-9a3cfd2cd2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be892d73-d1f4-4c36-b674-01ae21ff1484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be892d73-d1f4-4c36-b674-01ae21ff1484.jpg?1",
             "name": "Viridian Longbow",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target creature or player.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8580,7 +8580,7 @@
         },
         {
             "id": "142cd1bb-d2bd-5460-944b-22ccda065dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b19949-90c9-46f1-85d4-d6eda0b7977e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b19949-90c9-46f1-85d4-d6eda0b7977e.jpg?1",
             "name": "Vorrac Battlehorns",
             "text": "Equipped creature has trample and can't be blocked by more than one creature.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "2bda989c-55a4-52dd-8bf9-50a647151369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e731de-32e9-4dae-804f-9b962b457cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e731de-32e9-4dae-804f-9b962b457cf3.jpg?1",
             "name": "Vulshok Battlegear",
             "text": "Equipped creature gets +3/+3.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8640,7 +8640,7 @@
         },
         {
             "id": "5f5495c9-6740-55e4-8cdc-ef2f7c9b8bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a04bbd-1d07-4b11-aa54-01790b9dd3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a04bbd-1d07-4b11-aa54-01790b9dd3a0.jpg?1",
             "name": "Vulshok Gauntlets",
             "text": "Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "1775236c-3a6f-5eef-83b0-51b762407250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b7b73b-4800-4fc7-9a5c-93e00ea88498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b7b73b-4800-4fc7-9a5c-93e00ea88498.jpg?1",
             "name": "Welding Jar",
             "text": "Sacrifice Welding Jar: Regenerate target artifact.",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "ddd2cf1d-b32a-50b6-b961-daf930626d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ab68b3-864e-4fe3-a5c5-faa33b45da0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ab68b3-864e-4fe3-a5c5-faa33b45da0f.jpg?1",
             "name": "Wizard Replica",
             "text": "Flying\n{U}, Sacrifice Wizard Replica: Counter target spell unless its controller pays {2}.",
             "colours": [],
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "03b8970f-fec8-5ffb-87b7-068ccb29db3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb1b869-3e2d-4447-a12d-e790883feeee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb1b869-3e2d-4447-a12d-e790883feeee.jpg?1",
             "name": "Worldslayer",
             "text": "Whenever equipped creature deals combat damage to a player, destroy all permanents other than Worldslayer.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery. This card comes into play unattached and stays in play if the creature leaves play.)",
             "colours": [],
@@ -8761,7 +8761,7 @@
         },
         {
             "id": "055333ec-a8cf-572b-8cbf-0f876016d9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936af0be-6e7b-49f0-ba84-d8bc1b60994d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936af0be-6e7b-49f0-ba84-d8bc1b60994d.jpg?1",
             "name": "Yotian Soldier",
             "text": "Attacking doesn't cause Yotian Soldier to tap.",
             "colours": [],
@@ -8792,7 +8792,7 @@
         },
         {
             "id": "ddb39aed-2186-5a21-ba04-03343d362a58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857fbd-8e0f-4bff-8f14-561c9925c484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc857fbd-8e0f-4bff-8f14-561c9925c484.jpg?1",
             "name": "Ancient Den",
             "text": "(Ancient Den isn't a spell.)\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -8823,7 +8823,7 @@
         },
         {
             "id": "417d2f23-189c-570b-9045-b2d436da736f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c79155-b6d8-46df-891f-487b24c4e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c79155-b6d8-46df-891f-487b24c4e0d5.jpg?1",
             "name": "Blinkmoth Well",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Tap target noncreature artifact.",
             "colours": [],
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "50fdbbf5-d4f1-5fe8-920a-c9b663a6dd19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f28ecdc-a4f0-4327-a78c-340be41555ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f28ecdc-a4f0-4327-a78c-340be41555ee.jpg?1",
             "name": "Cloudpost",
             "text": "Cloudpost comes into play tapped.\n{T}: Add {1} to your mana pool for each Locus in play.",
             "colours": [],
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "b0fde0a0-c51e-51b3-8a80-86d15872e9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ab98a1-664c-4775-a3dd-22a15e2f836b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ab98a1-664c-4775-a3dd-22a15e2f836b.jpg?1",
             "name": "Glimmervoid",
             "text": "At end of turn, if you control no artifacts, sacrifice Glimmervoid.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "a2431ece-7fe5-53ae-9e3a-591546241d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2877281d-c85d-4f32-b40d-828b93c4ee8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2877281d-c85d-4f32-b40d-828b93c4ee8e.jpg?1",
             "name": "Great Furnace",
             "text": "(Great Furnace isn't a spell.)\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "35255e8a-029e-53a2-82b0-0180711c0644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da5587d-6b6c-4645-8cc9-2866d1e6911b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da5587d-6b6c-4645-8cc9-2866d1e6911b.jpg?1",
             "name": "Seat of the Synod",
             "text": "(Seat of the Synod isn't a spell.)\n{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -8971,7 +8971,7 @@
         },
         {
             "id": "f202a313-7c77-53db-a919-08aa6285875a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96d7230-c7ca-4613-ae7e-88a0e6270b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96d7230-c7ca-4613-ae7e-88a0e6270b98.jpg?1",
             "name": "Stalking Stones",
             "text": "{T}: Add {1} to your mana pool.\n{6}: Stalking Stones becomes a 3/3 artifact creature that's still a land. (This effect doesn't end at end of turn.)",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "c22745b0-4f52-508a-923b-25aacf91fcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db07aa-43d3-41b5-924e-60f1756b9c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db07aa-43d3-41b5-924e-60f1756b9c69.jpg?1",
             "name": "Tree of Tales",
             "text": "(Tree of Tales isn't a spell.)\n{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -9030,7 +9030,7 @@
         },
         {
             "id": "1f08d5e7-8e2f-517a-be40-190cb2403680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73866487-33f4-4f64-b100-2c4ddadcd74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73866487-33f4-4f64-b100-2c4ddadcd74e.jpg?1",
             "name": "Vault of Whispers",
             "text": "(Vault of Whispers isn't a spell.)\n{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -9061,7 +9061,7 @@
         },
         {
             "id": "5fa6d528-88b1-5a67-9828-cf7cd8153bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac2d0d-43db-41f7-99dd-9ff55a4f2b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bac2d0d-43db-41f7-99dd-9ff55a4f2b3b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "1e2abaf2-e188-50a3-8bc6-9abf9592ef48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c160b1e7-8fad-4592-899c-995d09bc8b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c160b1e7-8fad-4592-899c-995d09bc8b52.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9137,7 +9137,7 @@
         },
         {
             "id": "d37c4d07-5bd9-5c03-b180-9fd86d4b44dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac11282-82d6-40db-8c28-5ed02268d2c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eac11282-82d6-40db-8c28-5ed02268d2c6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9175,7 +9175,7 @@
         },
         {
             "id": "aed1ac6c-e250-5d15-9611-1e8a31ebd19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546507c7-8fa8-44e3-aeb7-56fabf419d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546507c7-8fa8-44e3-aeb7-56fabf419d82.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "3cbb9b81-021e-5891-81e4-a7af7551a507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5235cd-5d25-498d-8e36-7a7c0791f212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5235cd-5d25-498d-8e36-7a7c0791f212.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9251,7 +9251,7 @@
         },
         {
             "id": "05d31f1f-f143-5e7c-a063-0c96c121b7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd90bb-b5d1-47a3-b566-3407db04dd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd90bb-b5d1-47a3-b566-3407db04dd55.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "abd6856d-ff3b-5e0f-93d7-e513de22b445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3309e-2893-4a39-876f-fd68ea057e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db3309e-2893-4a39-876f-fd68ea057e22.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "7b3f8b9d-58ae-5b32-9c42-3b674292685b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de46f610-fab8-4819-b86a-d1defed319a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de46f610-fab8-4819-b86a-d1defed319a1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9365,7 +9365,7 @@
         },
         {
             "id": "df6693a0-d5c5-507b-a20a-0065cc1a255a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bae27d4-9de5-4f95-8c56-79afc6cbeb0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bae27d4-9de5-4f95-8c56-79afc6cbeb0c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9403,7 +9403,7 @@
         },
         {
             "id": "e0a867a4-b61a-5ca4-bea0-abefbedfce6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45927890-52ef-448c-b302-4192afa27a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45927890-52ef-448c-b302-4192afa27a04.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9441,7 +9441,7 @@
         },
         {
             "id": "7060d213-98cb-5e2e-bc89-e73bb57b0cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b5147e-99b0-47fd-bec2-3baaf7e8ac4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b5147e-99b0-47fd-bec2-3baaf7e8ac4a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "de41ec0f-94cc-5421-9ef9-ad63cb6d1ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d48cef-cfaf-4223-9efb-d76762a896d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d48cef-cfaf-4223-9efb-d76762a896d6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "a61807d9-f69e-5897-a8dc-6371e4bbf479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b082f22f-6c01-4e8c-80ad-6fdae5c3f22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b082f22f-6c01-4e8c-80ad-6fdae5c3f22f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9555,7 +9555,7 @@
         },
         {
             "id": "3e2ad6d5-3b20-531a-8dc6-38a3ba249d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4399a832-4406-4a12-a5e5-81744d02ceec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4399a832-4406-4a12-a5e5-81744d02ceec.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9593,7 +9593,7 @@
         },
         {
             "id": "35d5c337-4eca-5382-b38e-9b5bdf656e6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba50901e-a030-4f52-8369-f4c9ca6b9c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba50901e-a030-4f52-8369-f4c9ca6b9c7a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9631,7 +9631,7 @@
         },
         {
             "id": "e8cf2834-e498-5ccf-9897-0a0853f0f1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22965406-d8d7-46ad-992e-7fc0e994698d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22965406-d8d7-46ad-992e-7fc0e994698d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9669,7 +9669,7 @@
         },
         {
             "id": "06ebc501-cc95-542c-bd8a-4fc76465612f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aec0b2-30f2-4f35-a9a3-24d87795d177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aec0b2-30f2-4f35-a9a3-24d87795d177.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "52d6b5fe-6d66-5843-abe6-e0b402b3fbba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174cb9a0-afa3-4f45-b317-238fa9d4f55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174cb9a0-afa3-4f45-b317-238fa9d4f55f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9745,7 +9745,7 @@
         },
         {
             "id": "e8367098-edb8-533f-859a-7b5897e0a0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f8d695-a3e4-4707-9db9-886849ce4c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f8d695-a3e4-4707-9db9-886849ce4c42.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9783,7 +9783,7 @@
         },
         {
             "id": "70f4c47f-bde7-5db9-bd89-a2fe00342b90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4bfc1c-20d5-40f4-8863-c69a89872159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c4bfc1c-20d5-40f4-8863-c69a89872159.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/NEM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/NEM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "23704f34-3b23-5f9b-b2ef-5cd0647886fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871ad2f3-1dd2-45ea-881d-529aad3b76ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871ad2f3-1dd2-45ea-881d-529aad3b76ec.jpg?1",
             "name": "Angelic Favor",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying Angelic Favor's mana cost.\nPlay Angelic Favor only during combat.\nPut a 4/4 white Angel creature token with flying into play. Remove it from the game at end of turn.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "80a631b5-a4e3-5f4d-92b9-c3b451d05275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf6f711-c0bc-4e12-b9d0-41581924e13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf6f711-c0bc-4e12-b9d0-41581924e13c.jpg?1",
             "name": "Avenger en-Dal",
             "text": "o2o\nW, oc\nT, Discard a card from your hand: Remove target attacking creature from the game. Its controller gains life equal to its toughness.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "725207e4-8744-5f47-bba6-7fcc36e98070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c25553-6554-4e31-9012-c50da1f0a171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c25553-6554-4e31-9012-c50da1f0a171.jpg?1",
             "name": "Blinding Angel",
             "text": "Flying\nWhenever Blinding Angel deals combat damage to a player, that player skips his or her next combat phase.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "b9f2d4e0-265f-5ef6-a27a-f1b3321944fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1f49bc-d144-466f-8795-c0dae7afdc10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c1f49bc-d144-466f-8795-c0dae7afdc10.jpg?1",
             "name": "Chieftain en-Dal",
             "text": "Whenever Chieftain en-Dal attacks, attacking creatures gain first strike until end of turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "c5dda98f-e980-51b9-9abb-53199cfb0a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b224b7-d5f7-4515-beca-523f305ee3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b224b7-d5f7-4515-beca-523f305ee3b8.jpg?1",
             "name": "Defender en-Vec",
             "text": "Fading 4 (This creature comes into play with four fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRemove a fade counter from Defender en-Vec: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "46a08e0a-48f3-57fa-963c-ab61e6bb5137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80032b-daeb-4661-9a66-61abe9d12ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c80032b-daeb-4661-9a66-61abe9d12ddd.jpg?1",
             "name": "Defiant Falcon",
             "text": "Flying\no4, oc\nT: Search your library for a Rebel card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "0787e30c-ac7b-51f6-bd21-436fbe62522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0bd267-59ec-41df-b0b7-37f6e6d6b073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0bd267-59ec-41df-b0b7-37f6e6d6b073.jpg?1",
             "name": "Defiant Vanguard",
             "text": "When Defiant Vanguard blocks, at end of combat, destroy it and all creatures it blocked this turn.\no5, oc\nT: Search your library for a Rebel card with converted mana cost 4 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "94de62d7-ec60-5a86-b01c-6f8d6326fcd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0ed1fb-d380-4e3e-a43f-c39660a996e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0ed1fb-d380-4e3e-a43f-c39660a996e9.jpg?1",
             "name": "Fanatical Devotion",
             "text": "Sacrifice a creature: Regenerate target creature.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "2c452b38-f610-5e5a-901a-7e2f21a08b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7451cc-4126-4518-a103-2558fa81323f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7451cc-4126-4518-a103-2558fa81323f.jpg?1",
             "name": "Lashknife",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying Lashknife's mana cost.\nEnchanted creature has first strike.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "d110e66e-0448-5fe4-9b42-1fb49a290318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d76b7e3-6890-4120-8575-732909c8bdff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d76b7e3-6890-4120-8575-732909c8bdff.jpg?1",
             "name": "Lawbringer",
             "text": "oc\nT, Sacrifice Lawbringer: Remove target red creature from the game.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "a8bfd02e-895e-599e-8194-4ee8da28a691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19451993-7a53-4a50-bfca-ddc9cdfbe168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19451993-7a53-4a50-bfca-ddc9cdfbe168.jpg?1",
             "name": "Lightbringer",
             "text": "oc\nT, Sacrifice Lightbringer: Remove target black creature from the game.",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "7479ec2e-9147-5558-b706-551df36aa13c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e574e522-2632-4cd4-8545-c582ac3b641f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e574e522-2632-4cd4-8545-c582ac3b641f.jpg?1",
             "name": "Lin Sivvi, Defiant Hero",
             "text": "o\nX, oc\nT: Search your library for a Rebel card with converted mana cost X or less and put that card into play. Then shuffle your library.\no3: Put target Rebel card from your graveyard on the bottom of your library.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "9914f5a4-2bc1-5045-890c-5585475ac795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2190649d-f898-4693-8ccf-80e6709d8496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2190649d-f898-4693-8ccf-80e6709d8496.jpg?1",
             "name": "Netter en-Dal",
             "text": "o\nW, oc\nT, Discard a card from your hand: Target creature can't attack this turn.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "62d606f3-6c3e-56d0-acf8-fecf960b3994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f53ab12-7c16-43b1-b9f9-a5e523cf431b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f53ab12-7c16-43b1-b9f9-a5e523cf431b.jpg?1",
             "name": "Noble Stand",
             "text": "Whenever a creature you control blocks, you gain 2 life.",
             "colours": [
@@ -485,7 +485,7 @@
         },
         {
             "id": "bd1cc7c5-94c5-5fa4-a769-2828e8e86887",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adafe5c4-8de0-4d38-919f-de96bc70c21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adafe5c4-8de0-4d38-919f-de96bc70c21b.jpg?1",
             "name": "Off Balance",
             "text": "Target creature can't attack or block this turn.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "97894068-daf3-5c2c-8e6a-382bb08da3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e0ea3e-9826-408d-835b-18dfecaac8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e0ea3e-9826-408d-835b-18dfecaac8af.jpg?1",
             "name": "Oracle's Attendants",
             "text": "oc\nT: All damage that would be dealt to target creature this turn by a source of your choice is dealt to Oracle's Attendants instead.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "743a7bc8-8668-5110-b92e-4fa89799e189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef789e8-e4cc-4f61-bc15-debc2487777f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef789e8-e4cc-4f61-bc15-debc2487777f.jpg?1",
             "name": "Parallax Wave",
             "text": "Fading 5\nRemove a fade counter from Parallax Wave: Remove target creature from the game.\nWhen Parallax Wave leaves play, each player returns to play all cards he or she owns removed from the game with Parallax Wave.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "f7bde977-6308-5ee1-9c8d-249f0caf2795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c921e-1b82-412c-9979-adfdf83440f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6c921e-1b82-412c-9979-adfdf83440f7.jpg?1",
             "name": "Seal of Cleansing",
             "text": "Sacrifice Seal of Cleansing: Destroy target artifact or enchantment.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "d53b1477-7158-599a-85ae-492ccd0c602d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3480efc4-1078-4c63-a94c-d00a7507f6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3480efc4-1078-4c63-a94c-d00a7507f6b1.jpg?1",
             "name": "Silkenfist Fighter",
             "text": "Whenever Silkenfist Fighter becomes blocked, untap it.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "8fd0d5a4-0233-5c2a-bd11-448aab0667f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93741517-90ed-46fe-a505-fe6299f188bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93741517-90ed-46fe-a505-fe6299f188bf.jpg?1",
             "name": "Silkenfist Order",
             "text": "Whenever Silkenfist Order becomes blocked, untap it.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "ff6c52a8-d4c8-598c-98b3-1a3ce918acf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132112a0-0fb0-4a80-927d-39d34cf10159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132112a0-0fb0-4a80-927d-39d34cf10159.jpg?1",
             "name": "Sivvi's Ruse",
             "text": "If an opponent controls a mountain and you control a plains, you may play Sivvi's Ruse without paying its mana cost.\nPrevent all damage that would be dealt this turn to creatures you control.",
             "colours": [
@@ -718,7 +718,7 @@
         },
         {
             "id": "b9a38bf6-c596-58e3-94f5-3268ad748e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d15f7b5-5070-4742-a05c-623822d874fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d15f7b5-5070-4742-a05c-623822d874fb.jpg?1",
             "name": "Sivvi's Valor",
             "text": "If you control a plains, you may tap an untapped creature you control instead of paying the mana cost of Sivvi's Valor.\nAll damage that would be dealt to target creature this turn is dealt to you instead.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "29677cb9-af46-5b88-b9bc-72d90105f03e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5eea354-2d92-4b57-aec7-25260ab7a70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5eea354-2d92-4b57-aec7-25260ab7a70f.jpg?1",
             "name": "Spiritual Asylum",
             "text": "Creatures and lands you control can't be the target of spells or abilities.\nWhen a creature you control attacks, sacrifice Spiritual Asylum.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "bdf28773-fc7d-5c7e-b3e3-c095320e47fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c25c67-4214-4318-a718-7d351e713f80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c25c67-4214-4318-a718-7d351e713f80.jpg?1",
             "name": "Topple",
             "text": "Remove target creature with the greatest power from the game. (If two or more creatures are tied for greatest power, target only one of them.)",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "83144a3c-6405-5323-8e07-7164d6962d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40377e3d-77d9-4d86-ac8c-4e27803e48d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40377e3d-77d9-4d86-ac8c-4e27803e48d8.jpg?1",
             "name": "Voice of Truth",
             "text": "Flying, protection from white",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "1ba175b0-328c-5f92-8dfd-0ad81686649c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab061406-38f4-40e7-a9ea-e3cbcaabc127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab061406-38f4-40e7-a9ea-e3cbcaabc127.jpg?1",
             "name": "Accumulated Knowledge",
             "text": "Draw a card, then draw cards equal to the number of Accumulated Knowledge cards in all graveyards.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "eed24d06-bd8d-5395-a801-624e0a55fed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36298f9f-12cc-43bd-adda-ccabd67a9568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36298f9f-12cc-43bd-adda-ccabd67a9568.jpg?1",
             "name": "Aether Barrier",
             "text": "Whenever a player plays a creature spell, that player sacrifices a permanent unless he or she pays o1.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "01d39ab4-ec57-5437-b8fa-e81f0b597d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7363c6f-53a3-4f41-b451-8120bc24f1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7363c6f-53a3-4f41-b451-8120bc24f1ee.jpg?1",
             "name": "Air Bladder",
             "text": "Enchanted creature has flying.\nEnchanted creature can block only creatures with flying.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "7c077ac0-6399-5a11-8830-f906f1597aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f97e50-3aeb-4c79-81b1-505a2f32d8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f97e50-3aeb-4c79-81b1-505a2f32d8ac.jpg?1",
             "name": "Cloudskate",
             "text": "Flying\nFading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "8026d95d-4dc9-5c4f-a5fb-988fcd5f0169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03bff25-0d5e-4dcf-8d75-6df846afea3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03bff25-0d5e-4dcf-8d75-6df846afea3b.jpg?1",
             "name": "Daze",
             "text": "You may return an island you control to its owner's hand instead of paying Daze's mana cost.\nCounter target spell unless its controller pays o1.",
             "colours": [
@@ -1012,7 +1012,7 @@
         },
         {
             "id": "9864a7df-53e6-57cc-a1b3-424ba3bace10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b2dcb1-8c3e-434c-865a-196d4d799706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b2dcb1-8c3e-434c-865a-196d4d799706.jpg?1",
             "name": "Dominate",
             "text": "Gain control of target creature with converted mana cost X or less. (This spell's effect doesn't end at end of turn.)",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "cae7cdcd-b1bf-5e89-9a43-620ca06e15cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055b344a-4eb1-4579-ac50-973b18e12fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055b344a-4eb1-4579-ac50-973b18e12fad.jpg?1",
             "name": "Ensnare",
             "text": "You may return two islands you control to their owner's hand instead of paying Ensnare's mana cost.\nTap all creatures.",
             "colours": [
@@ -1076,7 +1076,7 @@
         },
         {
             "id": "47e28523-014f-57b9-9c81-49ad3dfc5b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c549b817-8ad6-44d0-9761-5e4ff9e62c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c549b817-8ad6-44d0-9761-5e4ff9e62c71.jpg?1",
             "name": "Infiltrate",
             "text": "Target creature is unblockable this turn.",
             "colours": [
@@ -1108,7 +1108,7 @@
         },
         {
             "id": "b9fd30af-041c-546a-b2bc-6453158e3bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4d1c74-8b73-445c-b226-349c57a972f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4d1c74-8b73-445c-b226-349c57a972f6.jpg?1",
             "name": "Jolting Merfolk",
             "text": "Fading 4 (This creature comes into play with four fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRemove a fade counter from Jolting Merfolk: Tap target creature.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "01a4d8c8-02cf-5afb-b75c-28519519c160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05609a-f32d-4454-af24-a24452997dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05609a-f32d-4454-af24-a24452997dcb.jpg?1",
             "name": "Oraxid",
             "text": "Protection from red",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "d8ed0dbb-c1e4-52eb-b1c6-fe7efcbe9284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb282bb-d0b8-4822-8197-ff0523549309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb282bb-d0b8-4822-8197-ff0523549309.jpg?1",
             "name": "Pale Moon",
             "text": "Until end of turn, if a player taps a nonbasic land for mana, it produces colorless mana instead of its normal type.",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "17080c20-87cc-552c-91d0-ad9762e04666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe593eb-df3c-43e5-97a6-418f91e87cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe593eb-df3c-43e5-97a6-418f91e87cb3.jpg?1",
             "name": "Parallax Tide",
             "text": "Fading 5\nRemove a fade counter from Parallax Tide: Remove target land from the game.\nWhen Parallax Tide leaves play, each player returns to play all cards he or she owns removed from the game with Parallax Tide.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "4c99b31f-ca81-57e7-a6d8-29a95b7da261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9c84db-cf45-43e1-b38f-8bbf53cf088b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9c84db-cf45-43e1-b38f-8bbf53cf088b.jpg?1",
             "name": "Rising Waters",
             "text": "Lands don't untap during their controllers' untap steps.\nAt the beginning of each player's upkeep, that player untaps a land he or she controls.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "c827a8c0-8034-50f1-9ad9-3c4694b402c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86f36d-584d-49b2-8c66-19c262408950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e86f36d-584d-49b2-8c66-19c262408950.jpg?1",
             "name": "Rootwater Commando",
             "text": "Islandwalk (This creature is unblockable as long as defending player controls an island.)",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "69f255c6-48b5-5eac-a5aa-c700cdc394d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38addef3-1dd7-41a1-9706-3be5c86a58c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38addef3-1dd7-41a1-9706-3be5c86a58c9.jpg?1",
             "name": "Rootwater Thief",
             "text": "oo\nU Rootwater Thief gains flying until end of turn.\nWhenever Rootwater Thief deals combat damage to a player, you may pay o2. If you do, search that player's library for a card and remove that card from the game, then the player shuffles his or her library.",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "9596dfe2-bcf6-5159-bad5-0f7b3460d5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375f65a-6d88-4d3c-a7a7-8c7a5cc5807f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375f65a-6d88-4d3c-a7a7-8c7a5cc5807f.jpg?1",
             "name": "Seahunter",
             "text": "o3, oc\nT: Search your library for a Merfolk card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1377,7 +1377,7 @@
         },
         {
             "id": "2e4e4961-70e8-5187-b784-a4afbcc96f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487becfe-a9b1-4029-a487-2a32561570cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487becfe-a9b1-4029-a487-2a32561570cb.jpg?1",
             "name": "Seal of Removal",
             "text": "Sacrifice Seal of Removal: Return target creature to its owner's hand.",
             "colours": [
@@ -1409,7 +1409,7 @@
         },
         {
             "id": "5886769c-4230-5469-94b0-d623c7d5e33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8647649-5669-46c4-8840-9ff967fabd99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8647649-5669-46c4-8840-9ff967fabd99.jpg?1",
             "name": "Sliptide Serpent",
             "text": "o3oo\nU Return Sliptide Serpent to its owner's hand.",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "44d16998-8c7c-550f-86b5-9d3187067649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b2dadb-4ce3-4f7e-9ca7-79757543f04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b2dadb-4ce3-4f7e-9ca7-79757543f04d.jpg?1",
             "name": "Sneaky Homunculus",
             "text": "Sneaky Homunculus can't block or be blocked by creatures with power 2 or greater.",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "82b128f2-1e62-5fd8-b26c-69acbee43b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6215a5d9-d6d2-4f9f-8a0c-a65d1afd956a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6215a5d9-d6d2-4f9f-8a0c-a65d1afd956a.jpg?1",
             "name": "Stronghold Biologist",
             "text": "o\nUo\nU, oc\nT, Discard a card from your hand: Counter target creature spell.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "0dc24359-ba71-5300-9661-8b4207a34f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3567b4e-6e31-40b0-83ea-4a2a58bd637c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3567b4e-6e31-40b0-83ea-4a2a58bd637c.jpg?1",
             "name": "Stronghold Machinist",
             "text": "o\nUo\nU, oc\nT, Discard a card from your hand: Counter target noncreature spell.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "16419149-50cc-5e25-a935-4d25ee60bc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d672110d-b7c4-4233-9c46-73323be7204d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d672110d-b7c4-4233-9c46-73323be7204d.jpg?1",
             "name": "Stronghold Zeppelin",
             "text": "Flying\nStronghold Zeppelin can block only creatures with flying.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "d5ed69eb-0646-5de6-9bc0-28576c1be75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2741fe4-37fe-427f-ae85-5107991d4eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2741fe4-37fe-427f-ae85-5107991d4eee.jpg?1",
             "name": "Submerge",
             "text": "If an opponent controls a forest and you control an island, you may play Submerge without paying its mana cost.\nPut target creature on top of its owner's library.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "2b678ea3-56d6-57c8-a4ce-613662b32587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e24-1a70-48bd-8946-ff29e12c6f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31b2e24-1a70-48bd-8946-ff29e12c6f3d.jpg?1",
             "name": "Trickster Mage",
             "text": "o\nU, oc\nT, Discard a card from your hand: Tap or untap target artifact, creature, or land.",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "897c2bb7-835b-5f6b-983f-d7d6685bf049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2869efd2-060f-4af3-b0dc-b7dc5e1143b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2869efd2-060f-4af3-b0dc-b7dc5e1143b8.jpg?1",
             "name": "Wandering Eye",
             "text": "Flying\nAll players play with their hands revealed.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "3df91f21-0530-5b79-88e8-b720cacc3b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c87c93-8cf4-4d1a-9bb8-349600da55bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c87c93-8cf4-4d1a-9bb8-349600da55bc.jpg?1",
             "name": "Ascendant Evincar",
             "text": "Flying\nOther black creatures get +1/+1.\nNonblack creatures get -1/-1.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "fd329364-bb24-5c1a-ba5a-7fb80dedeb6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebf021-02a1-4a47-b581-c85a7a76cdec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebf021-02a1-4a47-b581-c85a7a76cdec.jpg?1",
             "name": "Battlefield Percher",
             "text": "Flying\nBattlefield Percher can block only creatures with flying.\no1oo\nB Battlefield Percher gets +1/+1 until end of turn.",
             "colours": [
@@ -1755,7 +1755,7 @@
         },
         {
             "id": "8e3897ca-c61a-5678-b6c8-934f35507dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95dcb2e-8945-47dd-ad40-b5bdcc3ea742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d95dcb2e-8945-47dd-ad40-b5bdcc3ea742.jpg?1",
             "name": "Belbe's Percher",
             "text": "Flying\nBelbe's Percher can block only creatures with flying.",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "3fe3d4ad-5a17-5f90-a524-1050c354742c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6fa78-3422-4ace-88ab-e985c558cba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6fa78-3422-4ace-88ab-e985c558cba7.jpg?1",
             "name": "Carrion Wall",
             "text": "(Walls can't attack.)\no1oo\nB Regenerate Carrion Wall.",
             "colours": [
@@ -1823,7 +1823,7 @@
         },
         {
             "id": "72ce993e-edd1-5b9b-9416-704b67f15ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794657cd-b292-41d7-a4a6-3f3dd20dc07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794657cd-b292-41d7-a4a6-3f3dd20dc07a.jpg?1",
             "name": "Dark Triumph",
             "text": "If you control a swamp, you may sacrifice a creature instead of paying Dark Triumph's mana cost.\nCreatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "a6eee561-c910-54c4-997a-0a107fe3ca71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223e583-8ef6-4d93-8ed0-3ccf4488f166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223e583-8ef6-4d93-8ed0-3ccf4488f166.jpg?1",
             "name": "Death Pit Offering",
             "text": "As Death Pit Offering comes into play, sacrifice all creatures you control.\nCreatures you control get +2/+2.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "8498c32f-d005-55b3-b97f-0efe8c580c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be981eef-9dd2-4233-82c9-03f9f2e82c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be981eef-9dd2-4233-82c9-03f9f2e82c59.jpg?1",
             "name": "Divining Witch",
             "text": "o1o\nB, oc\nT, Discard a card from your hand: Name a card. Remove the top six cards of your library from the game. Reveal cards from the top of your library until you reveal the named card, then put that card into your hand. Remove all other cards revealed this way from the game.",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "81d8bc41-0433-55bf-a345-2dc8a07e802d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05f5d93-50d1-4aa6-af05-383a6808345b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05f5d93-50d1-4aa6-af05-383a6808345b.jpg?1",
             "name": "Massacre",
             "text": "If an opponent controls a plains and you control a swamp, you may play Massacre without paying its mana cost.\nAll creatures get -2/-2 until end of turn.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "8461f912-4ada-55f4-9cab-3089cfb5fbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bece38b-e09e-4666-95b6-5e5b05867cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bece38b-e09e-4666-95b6-5e5b05867cd5.jpg?1",
             "name": "Mind Slash",
             "text": "o\nB, Sacrifice a creature: Look at target opponent's hand and choose a card from it. That player discards that card. Play this ability only if you could play a sorcery.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "7e759523-23c7-56fe-88d6-98a3be7faa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d91df-008b-48f2-a84f-550702fbcdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d91df-008b-48f2-a84f-550702fbcdb3.jpg?1",
             "name": "Mind Swords",
             "text": "If you control a swamp, you may sacrifice a creature instead of paying Mind Swords's mana cost.\nEach player removes two cards in his or her hand from the game.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "645c4cf6-5bf8-52aa-8d33-bb244747a1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13a3ed0-aa57-4082-b6b0-b1078c93c0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13a3ed0-aa57-4082-b6b0-b1078c93c0b2.jpg?1",
             "name": "Murderous Betrayal",
             "text": "o\nBo\nB, Pay half your life rounded up: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "dc8b1c59-a77f-5a41-b2e7-0b3a7bb073d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154789ac-bbea-467b-9655-76f378a53f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154789ac-bbea-467b-9655-76f378a53f40.jpg?1",
             "name": "Parallax Dementia",
             "text": "Fading 1 (This enchantment comes into play with one fade counter on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nEnchanted creature gets +3/+2.\nWhen Parallax Dementia leaves play, destroy enchanted creature. That creature can't be regenerated.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "5c0773b3-19df-5468-8770-688459373c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862c50c7-0840-46e0-a653-5b660fdfd4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862c50c7-0840-46e0-a653-5b660fdfd4bd.jpg?1",
             "name": "Parallax Nexus",
             "text": "Fading 5\nRemove a fade counter from Parallax Nexus: Target opponent removes a card in his or her hand from the game. Play this ability only if you could play a sorcery.\nWhen Parallax Nexus leaves play, each player returns to his or her hand all cards he or she owns removed from the game with Parallax Nexus.",
             "colours": [
@@ -2116,7 +2116,7 @@
         },
         {
             "id": "5764200e-7d6c-5bc3-b93b-8a95be21f6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeef7f3-5b87-440d-a851-95ae2bdb840d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efeef7f3-5b87-440d-a851-95ae2bdb840d.jpg?1",
             "name": "Phyrexian Driver",
             "text": "When Phyrexian Driver comes into play, all other Mercenaries get +1/+1 until end of turn.",
             "colours": [
@@ -2152,7 +2152,7 @@
         },
         {
             "id": "714bd855-78c5-5fbf-ad6e-13fc520261d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26f79b5-780a-4cbb-b49d-01673a411d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26f79b5-780a-4cbb-b49d-01673a411d1f.jpg?1",
             "name": "Phyrexian Prowler",
             "text": "Fading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRemove a fade counter from Phyrexian Prowler: Phyrexian Prowler gets +1/+1 until end of turn.",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "c71ec478-330c-5982-840d-53a9388448ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3614c2-39b4-4f67-adab-373dcb9e4553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3614c2-39b4-4f67-adab-373dcb9e4553.jpg?1",
             "name": "Plague Witch",
             "text": "o\nB, oc\nT, Discard a card from your hand: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "b3f55762-f258-5983-8482-31c09df7ea72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3597c3-3053-49f8-ab7e-a774e2fb082f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3597c3-3053-49f8-ab7e-a774e2fb082f.jpg?1",
             "name": "Rathi Assassin",
             "text": "o1o\nBo\nB, oc\nT: Destroy target tapped nonblack creature.\no3, oc\nT: Search your library for a Mercenary card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "3040688f-300f-5edb-a54c-467f74732bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca1184-ade0-4d6d-87f9-ad17f37679b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ca1184-ade0-4d6d-87f9-ad17f37679b3.jpg?1",
             "name": "Rathi Fiend",
             "text": "When Rathi Fiend comes into play, each player loses 3 life.\no3, oc\nT: Search your library for a Mercenary card with converted mana cost 3 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "11055170-4ad5-53f1-91d7-c5b1e077c18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc59fa5-144f-49e6-b6bd-2ba6d3f2eff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc59fa5-144f-49e6-b6bd-2ba6d3f2eff2.jpg?1",
             "name": "Rathi Intimidator",
             "text": "Rathi Intimidator can't be blocked except by artifact creatures and black creatures.\no2, oc\nT: Search your library for a Mercenary card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "814c11c7-b051-5f84-80ee-2bc54c59af3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396d9f58-a4ca-4197-94be-0f115427224e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396d9f58-a4ca-4197-94be-0f115427224e.jpg?1",
             "name": "Seal of Doom",
             "text": "Sacrifice Seal of Doom: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "fe0a1aea-3ef9-5f47-9ad7-0c4a0309af96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9bb47-3855-425d-924c-09dbde74735b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9bb47-3855-425d-924c-09dbde74735b.jpg?1",
             "name": "Spineless Thug",
             "text": "Spineless Thug can't block.",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "d2983259-5872-5415-b079-0c633c3e53aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5535d14a-7126-4a94-96a0-e17ad5c72070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5535d14a-7126-4a94-96a0-e17ad5c72070.jpg?1",
             "name": "Spiteful Bully",
             "text": "At the beginning of your upkeep, Spiteful Bully deals 3 damage to target creature you control.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "173587cb-0d00-561a-a4f2-f2df6605c550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa5472-5341-47cd-884e-fe2fcca12c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa5472-5341-47cd-884e-fe2fcca12c0d.jpg?1",
             "name": "Stronghold Discipline",
             "text": "Each player loses 1 life for each creature he or she controls.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "caa3c5e4-680c-52a9-9b60-22d71e1a9d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaff6a0-7831-45db-a50f-881c6cb7ce49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaff6a0-7831-45db-a50f-881c6cb7ce49.jpg?1",
             "name": "Vicious Hunger",
             "text": "Vicious Hunger deals 2 damage to target creature. You gain 2 life.",
             "colours": [
@@ -2500,7 +2500,7 @@
         },
         {
             "id": "698f5b94-4a21-5b1a-9b9f-9f96c60049d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdd66e-9ca1-456e-a61c-7c96cf6f7c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdd66e-9ca1-456e-a61c-7c96cf6f7c56.jpg?1",
             "name": "Volrath the Fallen",
             "text": "o1o\nB, Discard a creature card from your hand: Volrath the Fallen gets +X/+X until end of turn, where X is the discarded card's converted mana cost.",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "0cd5be94-3bcf-560a-982c-c911323e0557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de57c84-38b9-4606-b934-0ab270496582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5de57c84-38b9-4606-b934-0ab270496582.jpg?1",
             "name": "Ancient Hydra",
             "text": "Fading 5 (This creature comes into play with five fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\no1, Remove a fade counter from Ancient Hydra: Ancient Hydra deals 1 damage to target creature or player.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "d37e9370-ab98-5772-9381-7e28f0318038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982dab-4c27-45b3-9740-38fec3df7226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62982dab-4c27-45b3-9740-38fec3df7226.jpg?1",
             "name": "Arc Mage",
             "text": "o2o\nR, oc\nT, Discard a card from your hand: Arc Mage deals 2 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "fb2ac461-6aa5-5504-b6a1-819e98c73595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6e1de6-e7e0-4037-896a-f80c54b8ef5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6e1de6-e7e0-4037-896a-f80c54b8ef5c.jpg?1",
             "name": "Bola Warrior",
             "text": "o\nR, oc\nT, Discard a card from your hand: Target creature can't block this turn.",
             "colours": [
@@ -2642,7 +2642,7 @@
         },
         {
             "id": "9de780a3-afde-548f-9c19-ed40d1777456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebfc91c-d764-4e63-a428-82704f8bf1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebfc91c-d764-4e63-a428-82704f8bf1fd.jpg?1",
             "name": "Downhill Charge",
             "text": "You may sacrifice a mountain instead of paying Downhill Charge's mana cost.\nTarget creature gets +X/+0 until end of turn, where X is the number of mountains you control.",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "f0430846-3af3-5f81-916b-f329bc29d789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7717eeb9-c457-4a65-93a0-e91c7f6a1970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7717eeb9-c457-4a65-93a0-e91c7f6a1970.jpg?1",
             "name": "Flame Rift",
             "text": "Flame Rift deals 4 damage to each player.",
             "colours": [
@@ -2706,7 +2706,7 @@
         },
         {
             "id": "670114b1-b24d-5cd8-8159-988204a6706b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93f0066-1ff0-4e52-9959-9eb0def60957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93f0066-1ff0-4e52-9959-9eb0def60957.jpg?1",
             "name": "Flowstone Crusher",
             "text": "oo\nR Flowstone Crusher gets +1/-1 until end of turn.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "0ac417aa-a705-55b9-933c-741af737706d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644ab8-3cc3-413d-a918-44fc636087ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644ab8-3cc3-413d-a918-44fc636087ae.jpg?1",
             "name": "Flowstone Overseer",
             "text": "o\nRoo\nR Target creature gets +1/-1 until end of turn.",
             "colours": [
@@ -2774,7 +2774,7 @@
         },
         {
             "id": "6ad44289-0ed0-50e5-9854-e7b6f60027f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b02e1-0a20-4247-ae2a-056c5356f168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7b02e1-0a20-4247-ae2a-056c5356f168.jpg?1",
             "name": "Flowstone Slide",
             "text": "All creatures get +X/-X until end of turn.",
             "colours": [
@@ -2806,7 +2806,7 @@
         },
         {
             "id": "ff631882-6133-59e9-b87e-3e013110c472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1203053-0829-4f46-a361-62cb9cd17280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1203053-0829-4f46-a361-62cb9cd17280.jpg?1",
             "name": "Flowstone Strike",
             "text": "Target creature gets +1/-1 and gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "83760a97-6ef6-5d31-adb7-151ba5e4399b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc450922-0bbf-46c4-9955-79f4d41ee488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc450922-0bbf-46c4-9955-79f4d41ee488.jpg?1",
             "name": "Flowstone Surge",
             "text": "Creatures you control get +1/-1.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "a6da3092-79a9-5a07-9477-bc786253e8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89844c2f-f0a4-41c6-ad8c-d559fcaec85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89844c2f-f0a4-41c6-ad8c-d559fcaec85c.jpg?1",
             "name": "Flowstone Wall",
             "text": "(Walls can't attack.)\noo\nR Flowstone Wall gets +1/-1 until end of turn.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "5d9db8dd-bafb-5bb3-96d5-623340e5ac36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27fd65a-5631-491f-b158-45012832ccf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f27fd65a-5631-491f-b158-45012832ccf1.jpg?1",
             "name": "Laccolith Grunt",
             "text": "Whenever Laccolith Grunt becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Grunt deals no combat damage this turn.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "fc3dfbf6-a346-548a-8f5e-07b17ff0f796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb92039-03fd-4aee-be74-96997be629d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fb92039-03fd-4aee-be74-96997be629d6.jpg?1",
             "name": "Laccolith Rig",
             "text": "Whenever enchanted creature becomes blocked, you may have it deal damage equal to its power to target creature. If you do, enchanted creature deals no combat damage this turn.",
             "colours": [
@@ -2972,7 +2972,7 @@
         },
         {
             "id": "8216f307-a7cb-57c7-a7d3-74fbd41cee0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36bc466-0f74-46fd-add2-c1cf3b3fe46b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36bc466-0f74-46fd-add2-c1cf3b3fe46b.jpg?1",
             "name": "Laccolith Titan",
             "text": "Whenever Laccolith Titan becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Titan deals no combat damage this turn.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "f57c6709-e940-5ff5-a801-6dc176b89e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b103f-482b-47d5-84a2-3621ba23bd20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13b103f-482b-47d5-84a2-3621ba23bd20.jpg?1",
             "name": "Laccolith Warrior",
             "text": "Whenever Laccolith Warrior becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Warrior deals no combat damage this turn.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "65016745-2376-5229-af91-042290ee396c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb5b9e-320f-40de-8668-ee0c08f63ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86eb5b9e-320f-40de-8668-ee0c08f63ec1.jpg?1",
             "name": "Laccolith Whelp",
             "text": "Whenever Laccolith Whelp becomes blocked, you may have it deal damage equal to its power to target creature. If you do, Laccolith Whelp deals no combat damage this turn.",
             "colours": [
@@ -3075,7 +3075,7 @@
         },
         {
             "id": "5c15cebc-1d46-5793-ab06-209394977636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a33b3-7833-48e5-88c3-849a5771ef6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583a33b3-7833-48e5-88c3-849a5771ef6e.jpg?1",
             "name": "Mana Cache",
             "text": "At the end of each player's turn, put a charge counter on Mana Cache for each untapped land that player controls.\nRemove a charge counter from Mana Cache: Add one colorless mana to your mana pool. Any player may play this ability but only during his or her turn before the end phase.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "4bc9158f-95a4-5f4e-bb45-868d892a2279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f246e128-0a43-478a-a232-51020fab76d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f246e128-0a43-478a-a232-51020fab76d5.jpg?1",
             "name": "Mogg Alarm",
             "text": "You may sacrifice two mountains instead of paying Mogg Alarm's mana cost.\nPut two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "91c9b4f8-8b06-5402-a08a-790a65a6281d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403aa48c-b684-4c54-8863-460958055a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403aa48c-b684-4c54-8863-460958055a1f.jpg?1",
             "name": "Mogg Salvage",
             "text": "If an opponent controls an island and you control a mountain, you may play Mogg Salvage without paying its mana cost.\nDestroy target artifact.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "4ba12d75-018b-53ad-bdbf-f5270fda19b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8edaf6-d46e-4efb-8bc0-ec11e06eb499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8edaf6-d46e-4efb-8bc0-ec11e06eb499.jpg?1",
             "name": "Mogg Toady",
             "text": "Mogg Toady can't attack unless you control more creatures than defending player.\nMogg Toady can't block unless you control more creatures than attacking player.",
             "colours": [
@@ -3205,7 +3205,7 @@
         },
         {
             "id": "5769b6ca-dabf-5148-b693-7f47fba222da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba582d7-1dce-4664-8bd9-6b419596788c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba582d7-1dce-4664-8bd9-6b419596788c.jpg?1",
             "name": "Moggcatcher",
             "text": "o3, oc\nT: Search your library for a Goblin card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "a59ca6cf-e07f-5018-b5b4-533707f51784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db53c1fb-3641-44a3-b0b4-b7b2ba993646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db53c1fb-3641-44a3-b0b4-b7b2ba993646.jpg?1",
             "name": "Rupture",
             "text": "Sacrifice a creature. Rupture deals damage equal to that creature's power to each creature without flying and each player.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "dde7dd23-1843-5f26-bfdf-52eaf70a88e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eaf1f6-4bdc-4669-9a15-50b65e016ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eaf1f6-4bdc-4669-9a15-50b65e016ccf.jpg?1",
             "name": "Seal of Fire",
             "text": "Sacrifice Seal of Fire: Seal of Fire deals 2 damage to target creature or player.",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "4fa85078-1bae-50b7-9000-a3363857fb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce46919-d312-490c-8942-39fbb2d375bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce46919-d312-490c-8942-39fbb2d375bf.jpg?1",
             "name": "Shrieking Mogg",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhen Shrieking Mogg comes into play, tap all other creatures.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "7af43200-c591-59a6-82f8-76bd92347a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18050e-9aad-471e-a6ae-66e5fa2bbb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d18050e-9aad-471e-a6ae-66e5fa2bbb6f.jpg?1",
             "name": "Stronghold Gambit",
             "text": "Each player chooses a card in his or her hand. Then each player reveals his or her chosen card. The owner of the creature card revealed this way with the lowest converted mana cost puts that card into play. If two or more creature cards are tied for lowest cost, those cards are put into play.",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "e3577379-9337-5c2e-9252-fdff704de0c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff4e7d-fa50-48d2-8ab6-6b86e3a05e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ff4e7d-fa50-48d2-8ab6-6b86e3a05e86.jpg?1",
             "name": "Animate Land",
             "text": "Until end of turn, target land is a 3/3 creature that's still a land.",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "275734d9-9b06-5108-af6a-70b995cfe2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db5d6c2-b11f-442a-b172-c0c99c9bec07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db5d6c2-b11f-442a-b172-c0c99c9bec07.jpg?1",
             "name": "Blastoderm",
             "text": "Fading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nBlastoderm can't be the target of spells or abilities.",
             "colours": [
@@ -3436,7 +3436,7 @@
         },
         {
             "id": "3fc91c27-ea86-5eee-a040-e790d5438239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341a70be-2dbf-4365-9c7a-e52cb62a74fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341a70be-2dbf-4365-9c7a-e52cb62a74fa.jpg?1",
             "name": "Coiling Woodworm",
             "text": "Coiling Woodworm's power is equal to the number of forests in play.",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "fdfe3488-ad1f-5069-8408-317742d25d3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133f9e4f-2b1b-4a24-ad19-285a2c5845b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133f9e4f-2b1b-4a24-ad19-285a2c5845b5.jpg?1",
             "name": "Fog Patch",
             "text": "Play Fog Patch only during the declare blockers step.\nAttacking creatures become blocked. (This spell works on unblockable creatures.)",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "1db2c436-6f3c-51d9-a4f6-12546462def0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b29329-b9a3-4d59-b0f8-2abc67337760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b29329-b9a3-4d59-b0f8-2abc67337760.jpg?1",
             "name": "Harvest Mage",
             "text": "o\nG, oc\nT, Discard a card from your hand: Until end of turn, if you tap a land for mana, it produces one mana of any color instead of its normal type and amount.",
             "colours": [
@@ -3538,7 +3538,7 @@
         },
         {
             "id": "4b794aaf-515a-51e4-8420-030d0a447669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe0201-3df3-4d0c-8aa4-8f35f12c322c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbe0201-3df3-4d0c-8aa4-8f35f12c322c.jpg?1",
             "name": "Mossdog",
             "text": "Whenever Mossdog becomes the target of a spell or ability an opponent controls, put a +1/+1 counter on Mossdog.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "f65c24fc-87fe-5edc-b7e9-fa52ffe68081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da697da-7026-4dea-b494-8314d789160f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da697da-7026-4dea-b494-8314d789160f.jpg?1",
             "name": "Nesting Wurm",
             "text": "Trample\nWhen Nesting Wurm comes into play, you may search your library for up to three Nesting Wurm cards, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "198e1e3b-a435-55c3-8708-eacefbd1058c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230c7926-9a4b-4ead-b4c8-889f84210545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230c7926-9a4b-4ead-b4c8-889f84210545.jpg?1",
             "name": "Overlaid Terrain",
             "text": "As Overlaid Terrain comes into play, sacrifice all lands you control.\nLands you control have \"oc\nT: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "9c9c6258-e08d-547c-aa9e-7f886072f960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c46caa8-efc0-4b72-b122-61e5d86a5b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c46caa8-efc0-4b72-b122-61e5d86a5b86.jpg?1",
             "name": "Pack Hunt",
             "text": "Search your library for up to three copies of target creature, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -3671,7 +3671,7 @@
         },
         {
             "id": "523cd7f8-71bb-51fc-b953-0fb5658d83f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e24850-bd9b-40ab-878f-b8a554da1956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e24850-bd9b-40ab-878f-b8a554da1956.jpg?1",
             "name": "Refreshing Rain",
             "text": "If an opponent controls a swamp and you control a forest, you may play Refreshing Rain without paying its mana cost.\nTarget player gains 6 life.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "a3bbfada-e787-5e2c-9521-db69cc52b38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82d3432-2167-4a65-8221-cb7b338e60d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82d3432-2167-4a65-8221-cb7b338e60d0.jpg?1",
             "name": "Reverent Silence",
             "text": "If you control a forest, you may have each other player gain 6 life instead of paying Reverent Silence's mana cost.\nDestroy all enchantments.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "eba08829-de4a-5fe0-9dc6-649d60a2cb9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58388a29-b2a6-4d16-b872-f198563721d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58388a29-b2a6-4d16-b872-f198563721d9.jpg?1",
             "name": "Rhox",
             "text": "You may have Rhox deal combat damage to defending player as though it weren't blocked.\no2oo\nG Regenerate Rhox.",
             "colours": [
@@ -3770,7 +3770,7 @@
         },
         {
             "id": "89c4037f-6c13-51c6-9af4-4a59d5e7c677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3a293d-08d8-49e4-b0fa-91afa0a5591d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3a293d-08d8-49e4-b0fa-91afa0a5591d.jpg?1",
             "name": "Saproling Burst",
             "text": "Fading 7\nRemove a fade counter from Saproling Burst: Put a green Saproling creature token into play. It has \"This creature's power and toughness are each equal to the number of fade counters on Saproling Burst.\"\nWhen Saproling Burst leaves play, destroy all tokens put into play with Saproling Burst. They can't be regenerated.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "9f4df2c5-1b90-5ef1-81d8-bd8d81faf4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f50072b-aedd-4074-b1f7-f9ce477c26c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f50072b-aedd-4074-b1f7-f9ce477c26c2.jpg?1",
             "name": "Saproling Cluster",
             "text": "o1, Discard a card from your hand: Put a 1/1 green Saproling creature token into play. Any player may play this ability.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "6ec2c69b-9973-51c1-977b-8440e25b9d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57650f78-3bf0-485a-bba8-7e7e14e47508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57650f78-3bf0-485a-bba8-7e7e14e47508.jpg?1",
             "name": "Seal of Strength",
             "text": "Sacrifice Seal of Strength: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "348eba42-8e28-548a-b927-fbe79fd438b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c01d17e-45a2-4b6f-aaa5-2af9c8f26181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c01d17e-45a2-4b6f-aaa5-2af9c8f26181.jpg?1",
             "name": "Skyshroud Behemoth",
             "text": "Fading 2 (This creature comes into play with two fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nSkyshroud Behemoth comes into play tapped.",
             "colours": [
@@ -3900,7 +3900,7 @@
         },
         {
             "id": "49f7971f-d24c-5990-93a9-fa6dbaadf218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3e09ff-c917-4c0c-8ddb-e152b4b0b82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3e09ff-c917-4c0c-8ddb-e152b4b0b82c.jpg?1",
             "name": "Skyshroud Claim",
             "text": "Search your library for up to two forest cards and put them into play. Then shuffle your library.",
             "colours": [
@@ -3932,7 +3932,7 @@
         },
         {
             "id": "039835cd-d9c2-5055-8f05-a2e67c71df5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558c4f5-a716-4e46-9234-5f84f1bd57aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a558c4f5-a716-4e46-9234-5f84f1bd57aa.jpg?1",
             "name": "Skyshroud Cutter",
             "text": "If you control a forest, you may have each other player gain 5 life instead of paying Skyshroud Cutter's mana cost.",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "5a3cc916-859d-5e59-9e46-12ca4a94bc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4e44e-656e-4294-a53b-1f7aa96fab31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb4e44e-656e-4294-a53b-1f7aa96fab31.jpg?1",
             "name": "Skyshroud Poacher",
             "text": "o3, oc\nT: Search your library for an Elf card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "05dabfa2-2b17-5a27-8438-9d2660c3d355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410896ab-d3dc-478c-bfd1-c0cad5b1180a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410896ab-d3dc-478c-bfd1-c0cad5b1180a.jpg?1",
             "name": "Skyshroud Ridgeback",
             "text": "Fading 2 (This creature comes into play with two fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "d50135e5-8043-5b34-b7dd-a2fb9bc62616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ab55f-f677-45c8-bd32-56788a776b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ab55f-f677-45c8-bd32-56788a776b33.jpg?1",
             "name": "Skyshroud Sentinel",
             "text": "When Skyshroud Sentinel comes into play, you may search your library for up to three Skyshroud Sentinel cards, reveal them, and put them into your hand. If you do, shuffle your library.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "246a4001-264b-5275-af52-d3a37e488aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a295758a-ee46-4ed0-8539-67501a37010d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a295758a-ee46-4ed0-8539-67501a37010d.jpg?1",
             "name": "Stampede Driver",
             "text": "o1o\nG, oc\nT, Discard a card from your hand: Creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "19758357-86e1-5526-b683-d05a34615bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d85032-26e9-44af-ab52-56d9c24e337d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d85032-26e9-44af-ab52-56d9c24e337d.jpg?1",
             "name": "Treetop Bracers",
             "text": "Enchanted creature gets +1/+1 and can be blocked only by creatures with flying.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "7195e93c-ebb1-5d53-a9e4-fe13695acf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d927fdb-11c0-42b6-95d4-7af051e45213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d927fdb-11c0-42b6-95d4-7af051e45213.jpg?1",
             "name": "Wild Mammoth",
             "text": "At the beginning of your upkeep, if a player controls more creatures than any other, that player gains control of Wild Mammoth.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "8a3b9667-805e-5bf8-a87a-906c85089dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5126b782-d74c-40ca-a9b2-a6c78f94d138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5126b782-d74c-40ca-a9b2-a6c78f94d138.jpg?1",
             "name": "Woodripper",
             "text": "Fading 3 (This creature comes into play with three fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\no1, Remove a fade counter from Woodripper: Destroy target artifact.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "8e5bda55-b2d8-52a9-bb13-92c40225eade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0052158b-58d1-4416-a7ce-7c6a7595263c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0052158b-58d1-4416-a7ce-7c6a7595263c.jpg?1",
             "name": "Belbe's Armor",
             "text": "o\nX, oc\nT: Target creature gets -X/+X until end of turn.",
             "colours": [],
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "4a4a6d47-cdd9-548a-8c1d-c48e33799778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4eeea1-693e-475c-a209-8a0464df8081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4eeea1-693e-475c-a209-8a0464df8081.jpg?1",
             "name": "Belbe's Portal",
             "text": "As Belbe's Portal comes into play, choose a creature type.\no3, oc\nT: Put a creature card of the chosen type from your hand into play.",
             "colours": [],
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "e5c12057-dac7-5f1d-b8f2-5c437a561414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb3c7af-74e1-4072-953b-b3e9ccd8aa03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb3c7af-74e1-4072-953b-b3e9ccd8aa03.jpg?1",
             "name": "Complex Automaton",
             "text": "At the beginning of your upkeep, if you control seven or more permanents, return Complex Automaton to its owner's hand.",
             "colours": [],
@@ -4293,7 +4293,7 @@
         },
         {
             "id": "3aab0863-c8cd-5a9b-ae36-85e0576e094c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c258aa1-cd9f-45e9-b478-d689b78850cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c258aa1-cd9f-45e9-b478-d689b78850cd.jpg?1",
             "name": "Eye of Yawgmoth",
             "text": "o3, oc\nT, Sacrifice a creature: Reveal cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and remove the rest from the game.",
             "colours": [],
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "aac8774b-c1d8-5257-9f58-7cc946837345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e62aa7e-d9f9-42d4-9eed-5f51f88047c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e62aa7e-d9f9-42d4-9eed-5f51f88047c6.jpg?1",
             "name": "Flint Golem",
             "text": "Whenever Flint Golem becomes blocked, defending player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -4352,7 +4352,7 @@
         },
         {
             "id": "52f9692d-7ad8-54a4-8711-482b0d3bf9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1160e476-8a2b-4b90-b4db-f386a80ab067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1160e476-8a2b-4b90-b4db-f386a80ab067.jpg?1",
             "name": "Flowstone Armor",
             "text": "You may choose not to untap Flowstone Armor during your untap step.\no3, oc\nT: Target creature gets +1/-1 as long as Flowstone Armor remains tapped.",
             "colours": [],
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "5432d274-95df-551c-b05b-c2b51c3bcff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf016ec-2654-4c3e-8e2e-6c70c4604d28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf016ec-2654-4c3e-8e2e-6c70c4604d28.jpg?1",
             "name": "Flowstone Thopter",
             "text": "o1: Flowstone Thopter gets +1/-1 and gains flying until end of turn.",
             "colours": [],
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "c08b13d9-ef28-5fb7-9d43-dbb7c9fe0aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94cfd63-7f2b-4c0a-8dcb-f22cf83e1e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94cfd63-7f2b-4c0a-8dcb-f22cf83e1e27.jpg?1",
             "name": "Kill Switch",
             "text": "o2, oc\nT: Tap all other artifacts. They don't untap during their controllers' untap steps as long as Kill Switch remains tapped.",
             "colours": [],
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "c8f4aaa6-b47c-52de-a34b-79dc90344e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758617c-f0e4-43d5-8fb4-e33eb2c5b99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f758617c-f0e4-43d5-8fb4-e33eb2c5b99f.jpg?1",
             "name": "Parallax Inhibitor",
             "text": "o1, oc\nT, Sacrifice Parallax Inhibitor: Put a fade counter on each permanent with fading you control.",
             "colours": [],
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "be2366dc-b407-5cc4-8a0d-7c729a9fdc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28927927-3974-48c3-81c2-518089a10003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28927927-3974-48c3-81c2-518089a10003.jpg?1",
             "name": "Predator, Flagship",
             "text": "o2: Target creature gains flying until end of turn.\no5, oc\nT: Destroy target creature with flying.",
             "colours": [],
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "e8f2f520-ca11-5548-a222-40be0ec07f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f82f2e-a6db-491b-b253-82c34cd6c940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10f82f2e-a6db-491b-b253-82c34cd6c940.jpg?1",
             "name": "Rackling",
             "text": "At the beginning of each opponent's upkeep, Rackling deals X damage to that player, where X is the number of cards in his or her hand fewer than three.",
             "colours": [],
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "a960ebe2-624b-55f6-8a02-ca3e8d90fc7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97f86ce-4758-4ae3-af29-b08a4d771652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b97f86ce-4758-4ae3-af29-b08a4d771652.jpg?1",
             "name": "Rejuvenation Chamber",
             "text": "Fading 2 (This artifact comes into play with two fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\noc\nT: You gain 2 life.",
             "colours": [],
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "609ed521-2f76-52dc-9762-183502a7fc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2605448-8e0d-492b-a635-468923c64625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2605448-8e0d-492b-a635-468923c64625.jpg?1",
             "name": "Rusting Golem",
             "text": "Fading 5 (This creature comes into play with five fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nRusting Golem's power and toughness are each equal to the number of fade counters on it.",
             "colours": [],
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "70fa0a47-3e0d-5a41-85df-04599f6c9c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad62f313-8a8a-4ffa-ada2-b12b76288729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad62f313-8a8a-4ffa-ada2-b12b76288729.jpg?1",
             "name": "Tangle Wire",
             "text": "Fading 4 (This artifact comes into play with four fade counters on it. At the beginning of your upkeep, remove a fade counter from it. If you can't, sacrifice it.)\nAt the beginning of each player's upkeep, that player taps an untapped artifact, creature, or land he or she controls for each fade counter on Tangle Wire.",
             "colours": [],
@@ -4616,7 +4616,7 @@
         },
         {
             "id": "b70624a4-29e4-5265-8cb8-635f7d2ed07a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eb86c5-d6fe-4dde-ad07-c3109b3a1611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3eb86c5-d6fe-4dde-ad07-c3109b3a1611.jpg?1",
             "name": "Viseling",
             "text": "At the beginning of each opponent's upkeep, Viseling deals X damage to that player, where X is the number of cards in his or her hand minus four.",
             "colours": [],
@@ -4648,7 +4648,7 @@
         },
         {
             "id": "4a4794e0-9c60-5bf5-be66-e4f582bd8b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5529ca-5c20-4dfd-8595-96d6dfa6debe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5529ca-5c20-4dfd-8595-96d6dfa6debe.jpg?1",
             "name": "Kor Haven",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1o\nW, oc\nT: Prevent all combat damage that would be dealt by target attacking creature this turn.",
             "colours": [],
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "86ff84df-069b-5092-8b16-da75cb36b64c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42681dce-5c63-4e56-955e-39f085ea6ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42681dce-5c63-4e56-955e-39f085ea6ae9.jpg?1",
             "name": "Rath's Edge",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no4, oc\nT, Sacrifice a land: Rath's Edge deals 1 damage to target creature or player.",
             "colours": [],
@@ -4710,7 +4710,7 @@
         },
         {
             "id": "632f69d7-fab6-5163-b186-060b97bfac1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe66a2-8e70-414f-bedb-8f1f85f1d2d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe66a2-8e70-414f-bedb-8f1f85f1d2d9.jpg?1",
             "name": "Terrain Generator",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Put a basic land card from your hand into play tapped.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/NEO.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/NEO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8791a7d2-1849-540f-8061-202341471d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1ed43-ee6c-43a2-ba94-5bf71c63e070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b1ed43-ee6c-43a2-ba94-5bf71c63e070.jpg?1",
             "name": "Ancestral Katana",
             "text": "Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+1.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "df076713-0b94-56fd-91cf-4e588ce5641c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2c4063-7322-4041-a870-b95598a03e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2c4063-7322-4041-a870-b95598a03e29.jpg?1",
             "name": "Ao, the Dawn Sky",
             "text": "Flying, vigilance\nWhen Ao, the Dawn Sky dies, choose one \u2014\n\u2022 Look at the top seven cards of your library. Put any number of nonland permanent cards with total mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\n\u2022 Put two +1/+1 counters on each permanent you control that's a creature or Vehicle.",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "c203c94d-110b-597c-85f7-88c514b38c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b8946b-6604-49ca-98db-18a540b1b4e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4b8946b-6604-49ca-98db-18a540b1b4e5.jpg?1",
             "name": "Banishing Slash",
             "text": "Destroy up to one target artifact, enchantment, or tapped creature. Then if you control an artifact and an enchantment, create a 2/2 white Samurai creature token with vigilance.",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "c0341c9b-5572-5143-86e2-1034cc8cc1a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg?1",
             "name": "Befriending the Moths // Imperial Moth",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Target creature you control gets +1/+1 and gains flying until end of turn.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "e370560e-3cf4-5dd2-a653-04547f1e91e3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ad44884-ae0d-40ae-87a9-bad043d4e9ad.jpg?1",
             "name": "Befriending the Moths // Imperial Moth",
             "text": "Flying",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "637a1f88-8896-56da-95d8-0bc1725a253e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8419d27-8c6e-4f38-98b4-60dd9a910c43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8419d27-8c6e-4f38-98b4-60dd9a910c43.jpg?1",
             "name": "Blade-Blizzard Kitsune",
             "text": "Ninjutsu {3}{W} ({3}{W}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nDouble strike",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "a6f17516-a7f3-5a0c-bcab-326cb01aa4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdfad1f-d316-4023-9c79-8c24f1cd31d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdfad1f-d316-4023-9c79-8c24f1cd31d0.jpg?1",
             "name": "Born to Drive",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +1/+1 for each creature and/or Vehicle you control.\nChannel \u2014 {2}{W}, Discard Born to Drive: Create two 1/1 colorless Pilot creature tokens with \"This creature crews Vehicles as though its power were 2 greater.\"",
             "colours": [
@@ -250,7 +250,7 @@
         },
         {
             "id": "a938cd74-da65-5c56-a552-fbd66f4e48e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f7a506-0aa1-4c2d-b322-e0e9179d05fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f7a506-0aa1-4c2d-b322-e0e9179d05fb.jpg?1",
             "name": "Brilliant Restoration",
             "text": "Return all artifact and enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "1eae8cac-f52e-56ee-970f-85b9a10be3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13ddda7-da6e-415e-8886-295514f862d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a13ddda7-da6e-415e-8886-295514f862d4.jpg?1",
             "name": "Cloudsteel Kirin",
             "text": "Flying\nEquipped creature has flying and \"You can't lose the game and your opponents can't win the game.\"\nReconfigure {5} ({5}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -324,7 +324,7 @@
         },
         {
             "id": "200c76ad-46ba-529f-9d52-5e06ae5cd8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4900862f-90f4-450b-a775-219da4ce67ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4900862f-90f4-450b-a775-219da4ce67ef.jpg?1",
             "name": "Dragonfly Suit",
             "text": "Flying\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -358,7 +358,7 @@
         },
         {
             "id": "841a3ec3-6182-5cde-baf9-043d06ef73d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b0a9cc0-bb6d-47f7-b0d5-3956c46a1b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b0a9cc0-bb6d-47f7-b0d5-3956c46a1b3a.jpg?1",
             "name": "Eiganjo Exemplar",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "4e6dae10-127f-54e0-a176-d67be5fa5e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg?1",
             "name": "Era of Enlightenment // Hand of Enlightenment",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Scry 2.\nII \u2014 You gain 2 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "43e5e998-cc08-574a-a33c-8dd3ac64b9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f43827-2b9b-4fc9-a6e2-c682dfbf14f7.jpg?1",
             "name": "Era of Enlightenment // Hand of Enlightenment",
             "text": "First strike",
             "colours": [
@@ -466,7 +466,7 @@
         },
         {
             "id": "f840f1b5-e8ff-5cab-895a-80eda3d5f478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg?1",
             "name": "The Fall of Lord Konda // Fragment of Konda",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile target creature an opponent controls with mana value 4 or greater.\nII \u2014 Each player gains control of all permanents they own.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -500,7 +500,7 @@
         },
         {
             "id": "d8e2771c-b870-5c80-803e-fffce0f2dddb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d784409-df6d-45d4-8f8b-6e3fd57a8fde.jpg?1",
             "name": "The Fall of Lord Konda // Fragment of Konda",
             "text": "Defender\nWhen Fragment of Konda dies, draw a card.",
             "colours": [
@@ -536,7 +536,7 @@
         },
         {
             "id": "c68d4d14-fd1a-5b7c-b1f6-dd408cdf797a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1068723-d1ef-4007-97d9-b10dccdbade4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1068723-d1ef-4007-97d9-b10dccdbade4.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "5d8c9ea3-edb1-5341-8879-bd6a011bf41a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab91962-ebad-46f6-9f90-7477c224d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab91962-ebad-46f6-9f90-7477c224d93d.jpg?1",
             "name": "Go-Shintai of Shared Purpose",
             "text": "Vigilance\nAt the beginning of your end step, you may pay {1}. If you do, create a 1/1 colorless Spirit creature token for each Shrine you control.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "d6d8e065-4ac1-5e2b-a22f-162a8b4621f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631e7da-bd71-424a-a349-9bce0fd16b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d631e7da-bd71-424a-a349-9bce0fd16b1f.jpg?1",
             "name": "Golden-Tail Disciple",
             "text": "Lifelink",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "8b2ba96b-a9e1-5d12-9d1c-f198fd56eadd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a70e8fa-b71d-441e-b049-dacb09a9a7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a70e8fa-b71d-441e-b049-dacb09a9a7af.jpg?1",
             "name": "Hotshot Mechanic",
             "text": "Hotshot Mechanic crews Vehicles as though its power were 2 greater.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "7bd11a78-eaae-5fde-8ad2-81aa009a4d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6750dd-2303-493b-885d-1bfb5787b16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6750dd-2303-493b-885d-1bfb5787b16c.jpg?1",
             "name": "Imperial Oath",
             "text": "Create three 2/2 white Samurai creature tokens with vigilance. Scry 3.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "b052f767-68de-584c-a092-83ebdc424259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2c7b-c93b-4b97-999e-86faed8a26ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2c7b-c93b-4b97-999e-86faed8a26ee.jpg?1",
             "name": "Imperial Recovery Unit",
             "text": "Whenever Imperial Recovery Unit attacks, return target creature or Vehicle card with mana value 2 or less from your graveyard to your hand.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "cc15edae-a6c0-55af-9ea0-321c0f3d807e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13246172-7554-4edc-b6db-23dc91e4290a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13246172-7554-4edc-b6db-23dc91e4290a.jpg?1",
             "name": "Imperial Subduer",
             "text": "Whenever a Samurai or Warrior you control attacks alone, tap target creature you don't control.",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "d08a1773-d298-53da-be7c-8bf44cd77341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f2148-bb5d-4236-8d12-150deed0577e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83f2148-bb5d-4236-8d12-150deed0577e.jpg?1",
             "name": "Intercessor's Arrest",
             "text": "Enchant permanent\nEnchanted permanent can't attack, block, or crew Vehicles. Its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -818,7 +818,7 @@
         },
         {
             "id": "b71f19d8-10bd-59dd-988b-25841c4bdf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a598ab6-3254-49fe-b69f-e7c759129599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a598ab6-3254-49fe-b69f-e7c759129599.jpg?1",
             "name": "Invoke Justice",
             "text": "Return target permanent card from your graveyard to the battlefield, then distribute four +1/+1 counters among any number of creatures and/or Vehicles target player controls.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "f72b855c-53f7-5cf3-872a-91a61e887f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d446a-8607-45b8-a01f-dad17bab76e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1d446a-8607-45b8-a01f-dad17bab76e7.jpg?1",
             "name": "Kitsune Ace",
             "text": "Whenever a Vehicle you control attacks, choose one \u2014\n\u2022 That Vehicle gains first strike until end of turn.\n\u2022 Untap Kitsune Ace.",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "8d5cb4ba-2b5e-555a-a03f-34a807ae9505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfd21e-96f1-4e5b-8546-73bb5a887b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfd21e-96f1-4e5b-8546-73bb5a887b98.jpg?1",
             "name": "Kyodai, Soul of Kamigawa",
             "text": "Flash\nFlying\nWhen Kyodai, Soul of Kamigawa enters the battlefield, another target permanent gains indestructible for as long as you control Kyodai.\n{W}{U}{B}{R}{G}: Kyodai gets +5/+5 until end of turn.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "9cc9fbd6-869a-5d6c-bd05-4ea0bd0ae59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd960-c4ec-4dfa-a61d-f8577b9d3519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd960-c4ec-4dfa-a61d-f8577b9d3519.jpg?1",
             "name": "Light the Way",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on target creature or Vehicle. Untap it.\n\u2022 Return target permanent you control to its owner's hand.",
             "colours": [
@@ -964,7 +964,7 @@
         },
         {
             "id": "14594ecb-045f-5e99-b22d-e0747a611ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39555a72-a57b-45ee-9222-ce3b9e8de126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39555a72-a57b-45ee-9222-ce3b9e8de126.jpg?1",
             "name": "Light-Paws, Emperor's Voice",
             "text": "Whenever an Aura enters the battlefield under your control, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, Emperor's Voice, then shuffle.",
             "colours": [
@@ -1004,7 +1004,7 @@
         },
         {
             "id": "33be0ee4-1ca4-5827-960f-637e9e64bb17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1766e9-2fa7-4446-a255-7beea1467ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1766e9-2fa7-4446-a255-7beea1467ece.jpg?1",
             "name": "Lion Sash",
             "text": "{W}: Exile target card from a graveyard. If it was a permanent card, put a +1/+1 counter on Lion Sash.\nEquipped creature gets +1/+1 for each +1/+1 counter on Lion Sash.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "a1107b1a-1196-5ba1-91c5-5c5c7878d83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bbdeb0-9165-4874-a853-d19c20c250ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bbdeb0-9165-4874-a853-d19c20c250ef.jpg?1",
             "name": "Lucky Offering",
             "text": "Destroy target artifact with mana value 3 or less. You gain 3 life.",
             "colours": [
@@ -1075,7 +1075,7 @@
         },
         {
             "id": "a7d1e5e0-a8a4-5ca0-8bb4-77017b2fab70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553fb946-2706-475b-89f9-e4355ec9ea2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/553fb946-2706-475b-89f9-e4355ec9ea2b.jpg?1",
             "name": "March of Otherworldly Light",
             "text": "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "f27869d4-52b5-5002-afe9-2425834c2b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg?1",
             "name": "Michiko's Reign of Truth // Portrait of Michiko",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Target creature gets +1/+1 until end of turn for each artifact and/or enchantment you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -1144,7 +1144,7 @@
         },
         {
             "id": "f60b13fb-9d34-5328-84e8-d83647f72ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/74f12c23-5c15-4ae6-8f4d-c5e6c1878817.jpg?1",
             "name": "Michiko's Reign of Truth // Portrait of Michiko",
             "text": "Portrait of Michiko gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "50a05c3c-0f91-50ce-bb13-cdf4230e56ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f657f2dc-adc8-4a66-b081-a71b3a127389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f657f2dc-adc8-4a66-b081-a71b3a127389.jpg?1",
             "name": "Mothrider Patrol",
             "text": "Flying\n{3}{W}, {T}: Tap target creature.",
             "colours": [
@@ -1215,7 +1215,7 @@
         },
         {
             "id": "b1cb3669-7393-57de-936b-efec2b3d4abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cb553c-58c1-4cfd-b441-297b5f09b263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cb553c-58c1-4cfd-b441-297b5f09b263.jpg?1",
             "name": "Norika Yamazaki, the Poet",
             "text": "Vigilance\nWhenever a Samurai or Warrior you control attacks alone, you may cast target enchantment card from your graveyard this turn.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "e26ffa70-a351-596c-96fc-34d057ddf886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79243e97-fe45-4988-b299-f59a7c53ad31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79243e97-fe45-4988-b299-f59a7c53ad31.jpg?1",
             "name": "Regent's Authority",
             "text": "Target creature gets +2/+2 until end of turn. If it's an enchantment creature or legendary creature, instead put a +1/+1 counter on it and it gets +1/+1 until end of turn.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "6ee930e3-369d-5024-8404-db2b53f782bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a37d5b4-af3a-48b0-895f-91b652108ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a37d5b4-af3a-48b0-895f-91b652108ef6.jpg?1",
             "name": "Repel the Vile",
             "text": "Choose one \u2014\n\u2022 Exile target creature with power 4 or greater.\n\u2022 Exile target enchantment.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "28d0d299-8d59-55d4-8c5b-125097fd3d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nII \u2014 You may discard a card. When you do, return target permanent card with mana value 2 or less from your graveyard to the battlefield tapped.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "5a513108-8b70-58d9-b8d4-77f14d25e398",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a11a33ae-e7fa-4bd4-8cd8-3a3239a29bcc.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "Vigilance\nWhenever Architect of Restoration attacks or blocks, create a 1/1 colorless Spirit creature token.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "c29d1457-9927-5af2-bbdf-81aa7a7383a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c27ec5-5a9b-4080-9a53-00630335a915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c27ec5-5a9b-4080-9a53-00630335a915.jpg?1",
             "name": "Selfless Samurai",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gains lifelink until end of turn.\nSacrifice Selfless Samurai: Another target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "12f88423-1150-5c73-b9fa-6e79f4023a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d77d1e6-c804-46f7-ba00-6df6bca2ae08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d77d1e6-c804-46f7-ba00-6df6bca2ae08.jpg?1",
             "name": "Seven-Tail Mentor",
             "text": "When Seven-Tail Mentor enters the battlefield or dies, put a +1/+1 counter on target creature or Vehicle you control.",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "e5aa55a7-e84b-56b9-81af-e27c2692668d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c7ba6f-c58e-4347-92e4-51ae8f2d5a88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c7ba6f-c58e-4347-92e4-51ae8f2d5a88.jpg?1",
             "name": "Sky-Blessed Samurai",
             "text": "This spell costs {1} less to cast for each enchantment you control.\nFlying",
             "colours": [
@@ -1506,7 +1506,7 @@
         },
         {
             "id": "42ec02a1-5588-5d70-a40e-628d7a24699b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa91a9e-2fe2-43bc-aa9c-cfb8a71829ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa91a9e-2fe2-43bc-aa9c-cfb8a71829ff.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "f36f9d31-4fa6-55bb-96bf-ff07382ca5cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c577bb-5e21-4a3e-b0a7-713a4ff7dce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c577bb-5e21-4a3e-b0a7-713a4ff7dce6.jpg?1",
             "name": "Sunblade Samurai",
             "text": "Vigilance\nChannel \u2014 {2}, Discard Sunblade Samurai: Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
             "colours": [
@@ -1581,7 +1581,7 @@
         },
         {
             "id": "bac741ad-bf92-514e-b051-5f3af2cd7312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16ab44e-4257-4c0c-b705-8ac1e9c1d835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16ab44e-4257-4c0c-b705-8ac1e9c1d835.jpg?1",
             "name": "Touch the Spirit Realm",
             "text": "When Touch the Spirit Realm enters the battlefield, exile up to one target artifact or creature until Touch the Spirit Realm leaves the battlefield.\nChannel \u2014 {1}{W}, Discard Touch the Spirit Realm: Exile target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1613,7 +1613,7 @@
         },
         {
             "id": "bfca10a4-6141-5f8a-95de-d4c5a758f019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43708ec9-a85a-4244-86b4-67b30b41d854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43708ec9-a85a-4244-86b4-67b30b41d854.jpg?1",
             "name": "Wanderer's Intervention",
             "text": "Wanderer's Intervention deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "ba3bc840-d81c-5f26-afb7-c81460a512ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2d8a9-ab4c-4225-a570-22636293c17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab2d8a9-ab4c-4225-a570-22636293c17d.jpg?1",
             "name": "The Wandering Emperor",
             "text": "Flash\nAs long as The Wandering Emperor entered the battlefield this turn, you may activate her loyalty abilities any time you could cast an instant.\n+1: Put a +1/+1 counter on up to one target creature. It gains first strike until end of turn.\n\u22121: Create a 2/2 white Samurai creature token with vigilance.\n\u22122: Exile target tapped creature. You gain 2 life.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "2010a8e7-8fab-56dc-a8be-d40157617035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db14cb8-9ff8-41ee-a733-4f1130e73b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6db14cb8-9ff8-41ee-a733-4f1130e73b29.jpg?1",
             "name": "When We Were Young",
             "text": "Up to two target creatures each get +2/+2 until end of turn. If you control an artifact and an enchantment, those creatures also gain lifelink until end of turn.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "dc5ef955-2a52-55c4-a296-c214c51fb885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e971a72-31db-4b7e-b9b9-9f45e8c3f87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e971a72-31db-4b7e-b9b9-9f45e8c3f87e.jpg?1",
             "name": "Acquisition Octopus",
             "text": "Whenever Acquisition Octopus or equipped creature deals combat damage to a player, draw a card.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "5264ba34-4d48-5a9b-bed0-736439e02dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58141ad0-32ea-4e07-a133-ff7812d58c0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58141ad0-32ea-4e07-a133-ff7812d58c0e.jpg?1",
             "name": "Anchor to Reality",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nSearch your library for an Equipment or Vehicle card, put that card onto the battlefield, then shuffle. If it has mana value less than the sacrificed permanent's mana value, scry 2.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "50317638-1b9b-54e1-abcc-2ce9fc6fd243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7497f147-146d-4a76-b670-bd84e07352b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7497f147-146d-4a76-b670-bd84e07352b3.jpg?1",
             "name": "Armguard Familiar",
             "text": "Ward {2} (Whenever this permanent becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nEquipped creature gets +2/+1 and has ward {2}.\nReconfigure {4} ({4}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -1819,7 +1819,7 @@
         },
         {
             "id": "97eee1b7-ad6a-5e51-be18-dde48a8a103a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51378e10-2f17-445b-97e9-5c373234ba52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51378e10-2f17-445b-97e9-5c373234ba52.jpg?1",
             "name": "Awakened Awareness",
             "text": "Enchant artifact or creature\nWhen Awakened Awareness enters the battlefield, put X +1/+1 counters on enchanted permanent.\nAs long as enchanted permanent is a creature, it has base power and toughness 1/1.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "73392c5e-7eae-5eac-92ce-5809b04d65f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg?1",
             "name": "Behold the Unspeakable // Vision of the Unspeakable",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Creatures you don't control get -2/-0 until your next turn.\nII \u2014 If you have one or fewer cards in hand, draw four cards. Otherwise, scry 2, then draw two cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "e05c46ba-242c-5f04-9aef-6bde02141539",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/4/e4d52701-e0dc-474e-b08f-88147200d210.jpg?1",
             "name": "Behold the Unspeakable // Vision of the Unspeakable",
             "text": "Flying, trample\nVision of the Unspeakable gets +1/+1 for each card in your hand.",
             "colours": [
@@ -1922,7 +1922,7 @@
         },
         {
             "id": "042ff4f3-466b-5535-9e61-fb2ac8bfb8e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae9991-43a2-4afb-a882-fff6b0d89d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbae9991-43a2-4afb-a882-fff6b0d89d12.jpg?1",
             "name": "Covert Technician",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "6f3a0256-7742-580b-97b7-77070571f24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c201117-9850-4e92-9ecc-e4d71a70a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c201117-9850-4e92-9ecc-e4d71a70a959.jpg?1",
             "name": "Discover the Impossible",
             "text": "Look at the top five cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost if it's an instant spell with mana value 2 or less. If you don't, put that card into your hand.",
             "colours": [
@@ -1992,7 +1992,7 @@
         },
         {
             "id": "43f2229b-1f5a-5976-85ca-934fe3ae9d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053ab598-06a4-43ae-b9fd-c291bd05642c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053ab598-06a4-43ae-b9fd-c291bd05642c.jpg?1",
             "name": "Disruption Protocol",
             "text": "As an additional cost to cast this spell, tap an untapped artifact you control or pay {1}.\nCounter target spell.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "d77d838d-ff29-518c-9fe6-2c11b11220e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39bf1fa-b530-4353-a683-843466227109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f39bf1fa-b530-4353-a683-843466227109.jpg?1",
             "name": "Essence Capture",
             "text": "Counter target creature spell. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "219592e7-469f-5036-8a4f-a2d8c25d4cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5858176-9f85-403c-8338-48eb55db5c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5858176-9f85-403c-8338-48eb55db5c3d.jpg?1",
             "name": "Futurist Operative",
             "text": "As long as Futurist Operative is tapped, it's a Human Citizen with base power and toughness 1/1 and can't be blocked.\n{2}{U}: Untap Futurist Operative.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "e3ab4b2c-6630-5eb7-9bc1-41e1a4e2699d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672f626-3e46-447b-841f-6a04cd380653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8672f626-3e46-447b-841f-6a04cd380653.jpg?1",
             "name": "Futurist Sentinel",
             "text": "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "36263be5-4d4a-5e25-a1c6-a09c0cb0cf30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec1192c-25b8-4975-ae6c-86be28ac1840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec1192c-25b8-4975-ae6c-86be28ac1840.jpg?1",
             "name": "Go-Shintai of Lost Wisdom",
             "text": "Flying\nAt the beginning of your end step, you may pay {1}. When you do, target player mills X cards, where X is the number of Shrines you control. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "ced99533-689c-5dfb-89f8-44802b07df66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c44d4e-742f-4e4f-9bf4-921075bc427c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c44d4e-742f-4e4f-9bf4-921075bc427c.jpg?1",
             "name": "Guardians of Oboro",
             "text": "Defender\nModified creatures you control can attack as though they didn't have defender. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "9a60937c-36d1-5a60-8251-f74b6a445e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Return up to one target creature or planeswalker to its owner's hand.\nII \u2014 Return an artifact card from your graveyard to your hand. If you can't, draw a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "4916bf0d-3728-5b7d-9dc5-11d8e1ba9533",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea6d3242-8059-4203-aa06-58a6a3925eda.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "Flying\nWhenever you cast a spell, your opponents can't cast spells with the same mana value as that spell until your next turn.",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "3598306c-5b23-5910-a2e9-113947c163a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7b423a-bfd1-47aa-bd2c-64a169b96924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7b423a-bfd1-47aa-bd2c-64a169b96924.jpg?1",
             "name": "Invoke the Winds",
             "text": "Gain control of target artifact or creature. Untap it.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "a301bd29-045c-5fd9-afe4-c7e312f8aa36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b4876-5387-4f73-b8e2-8e7bdca8b0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57b4876-5387-4f73-b8e2-8e7bdca8b0bc.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn. (A copy of a permanent spell becomes a token.)\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -2355,7 +2355,7 @@
         },
         {
             "id": "8870d116-ed98-53a1-803f-c3e003c9609b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7979d8-21f3-40ba-8a2e-7ebad210e48b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7979d8-21f3-40ba-8a2e-7ebad210e48b.jpg?1",
             "name": "Kairi, the Swirling Sky",
             "text": "Flying, ward {3}\nWhen Kairi, the Swirling Sky dies, choose one \u2014\n\u2022 Return any number of target nonland permanents with total mana value 6 or less to their owners' hands.\n\u2022 Mill six cards, then return up to two instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "b723ebb2-a59f-54d5-8c64-f34c852d92b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100171d8-7436-44c8-b4cb-0101ffa05c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/100171d8-7436-44c8-b4cb-0101ffa05c25.jpg?1",
             "name": "March of Swirling Mist",
             "text": "As an additional cost to cast this spell, you may exile any number of blue cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nUp to X target creatures phase out. (While they're phased out, they're treated as though they don't exist. Each one phases in before its controller untaps during their next untap step.)",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "6adf63fd-0d34-5743-a805-873f63a3241f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28273a5b-57b3-4b7a-b017-5886c171c9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28273a5b-57b3-4b7a-b017-5886c171c9c9.jpg?1",
             "name": "Mindlink Mech",
             "text": "Flying\nWhenever Mindlink Mech becomes crewed for the first time each turn, until end of turn, Mindlink Mech becomes a copy of target nonlegendary creature that crewed it this turn, except it's 4/3, it's a Vehicle artifact in addition to its other types, and it has flying.\nCrew 1",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "1068214a-68c5-5948-b484-4ff16704fe03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0394c8df-2e8a-4477-93b7-569934d7b936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0394c8df-2e8a-4477-93b7-569934d7b936.jpg?1",
             "name": "Mirrorshell Crab",
             "text": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\nChannel \u2014 {2}{U}, Discard Mirrorshell Crab: Counter target spell or ability unless its controller pays {3}.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "e68a2447-a201-5376-ab10-721a0531a47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a15d8d9-0575-4add-ae8d-4576e8ed2cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a15d8d9-0575-4add-ae8d-4576e8ed2cbe.jpg?1",
             "name": "Mnemonic Sphere",
             "text": "{1}{U}, Sacrifice Mnemonic Sphere: Draw two cards.\nChannel \u2014 {U}, Discard Mnemonic Sphere: Draw a card.",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "748a0f72-e052-5159-8f32-7d4a95f22559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4bb9de-ba7c-4916-b8ed-e2e644c06b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4bb9de-ba7c-4916-b8ed-e2e644c06b58.jpg?1",
             "name": "Mobilizer Mech",
             "text": "Flying\nWhenever Mobilizer Mech becomes crewed, up to one other target Vehicle you control becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "ebadf36b-1cb6-5ac0-9162-de0a615ef665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg?1",
             "name": "The Modern Age // Vector Glider",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Draw a card, then discard a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "2b8e212e-c7b1-55da-8691-3d79f2cf88b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/e/ee60a8e9-3201-4a7e-8aa4-2c5e1042c8a5.jpg?1",
             "name": "The Modern Age // Vector Glider",
             "text": "Flying",
             "colours": [
@@ -2637,7 +2637,7 @@
         },
         {
             "id": "1e577b48-b7f3-592f-9518-610d8dc3f27a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e466d1-943d-41e6-a47d-c9d951ca4262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e466d1-943d-41e6-a47d-c9d951ca4262.jpg?1",
             "name": "Moon-Circuit Hacker",
             "text": "Ninjutsu {U} ({U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Moon-Circuit Hacker deals combat damage to a player, you may draw a card. If you do, discard a card unless Moon-Circuit Hacker entered the battlefield this turn.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "cfa82014-0d58-52dc-a010-0b0921561bb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fa6d4c-78dc-4b40-9ce8-a0e593d4001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fa6d4c-78dc-4b40-9ce8-a0e593d4001f.jpg?1",
             "name": "Moonfolk Puzzlemaker",
             "text": "Flying\nWhenever Moonfolk Puzzlemaker becomes tapped, scry 1.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "5bd75001-600a-51f6-9574-d7cd14da8838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8bc0e9-a536-4bca-92a6-8dca85e1e984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8bc0e9-a536-4bca-92a6-8dca85e1e984.jpg?1",
             "name": "Moonsnare Prototype",
             "text": "{T}, Tap an untapped artifact or creature you control: Add {C}.\nChannel \u2014 {4}{U}, Discard Moonsnare Prototype: The owner of target nonland permanent puts it on the top or bottom of their library.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "a6144caf-43a5-558b-a35b-dc66c8bb305d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8b209f-f577-45cc-9d18-03c1d67d391e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8b209f-f577-45cc-9d18-03c1d67d391e.jpg?1",
             "name": "Moonsnare Specialist",
             "text": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen Moonsnare Specialist enters the battlefield, return up to one target creature to its owner's hand.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "1d29625e-1460-5342-83c4-362891d7594f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a37719a-2a87-4870-8f25-12544ca2f2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a37719a-2a87-4870-8f25-12544ca2f2cf.jpg?1",
             "name": "Network Disruptor",
             "text": "Flying\nWhen Network Disruptor enters the battlefield, tap target permanent.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "8843a444-2fa1-5ca5-9247-8076059f23bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9163cb04-ee28-4127-b53a-89c546996d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9163cb04-ee28-4127-b53a-89c546996d7d.jpg?1",
             "name": "Planar Incision",
             "text": "Exile target artifact or creature, then return it to the battlefield under its owner's control with a +1/+1 counter on it.",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "c05700a5-8627-5df9-bc06-8486b63c59aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f683e-5a28-4ae7-b53b-851b957123ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3f683e-5a28-4ae7-b53b-851b957123ba.jpg?1",
             "name": "Prosperous Thief",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever one or more Ninja or Rogue creatures you control deal combat damage to a player, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "af19f7d1-3948-57bf-9c3c-0538ee5f17cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d859de3a-0be1-4e66-b438-1c3d4ee756cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d859de3a-0be1-4e66-b438-1c3d4ee756cd.jpg?1",
             "name": "The Reality Chip",
             "text": "You may look at the top card of your library any time.\nAs long as The Reality Chip is attached to a creature, you may play lands and cast spells from the top of your library.\nReconfigure {2}{U} ({2}{U}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -2926,7 +2926,7 @@
         },
         {
             "id": "8c039d47-b2d0-5c4e-8d32-36d96a84d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc954d7-322a-45b8-9e25-6e9a97fbde61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc954d7-322a-45b8-9e25-6e9a97fbde61.jpg?1",
             "name": "Reality Heist",
             "text": "This spell costs {1} less to cast for each artifact you control.\nLook at the top seven cards of your library. You may reveal up to two artifact cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "1b7ab75f-6648-5331-ba83-bac991b5b23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bb3b5-b648-460c-b0ea-89ecfe0ff226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475bb3b5-b648-460c-b0ea-89ecfe0ff226.jpg?1",
             "name": "Replication Specialist",
             "text": "Flying\nWhenever a nontoken artifact enters the battlefield under your control, you may pay {1}{U}. If you do, create a token that's a copy of that artifact.",
             "colours": [
@@ -2993,7 +2993,7 @@
         },
         {
             "id": "c895297f-04b5-5d87-8833-ce4a71a02ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dd7f1a-5d43-4218-a9d8-7cc4f6a18ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3dd7f1a-5d43-4218-a9d8-7cc4f6a18ecd.jpg?1",
             "name": "Saiba Trespassers",
             "text": "Channel \u2014 {3}{U}, Discard Saiba Trespassers: Tap up to two target creatures you don't control. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -3029,7 +3029,7 @@
         },
         {
             "id": "2ef73e00-881b-5100-b090-935773268f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0fb5-e994-41b1-a73d-4e68f7afdf34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fe0fb5-e994-41b1-a73d-4e68f7afdf34.jpg?1",
             "name": "Short Circuit",
             "text": "Flash\nEnchant artifact or creature\nAs long as enchanted permanent is a creature, it gets -3/-0 and loses flying.",
             "colours": [
@@ -3063,7 +3063,7 @@
         },
         {
             "id": "f985e590-c531-5601-b7da-1bae66669292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50259b-8ca8-4fbe-8ae3-6b0312d70980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50259b-8ca8-4fbe-8ae3-6b0312d70980.jpg?1",
             "name": "Skyswimmer Koi",
             "text": "Flying\nWhenever an artifact enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "73523ca1-8d92-5450-a834-8a02b40913ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb42273-935b-4bda-849e-c163606cf89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb42273-935b-4bda-849e-c163606cf89e.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "9009dacd-36f7-5e52-9cb1-0bf52d07fcd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50870bfd-7779-4a1c-b18f-57fac7e193b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50870bfd-7779-4a1c-b18f-57fac7e193b1.jpg?1",
             "name": "Suit Up",
             "text": "Until end of turn, target creature or Vehicle becomes an artifact creature with base power and toughness 4/5.\nDraw a card.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "e003f340-9c0e-5312-8dac-2b49a82c6e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26594b52-3e9c-4cde-88df-1f4e9e16676e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26594b52-3e9c-4cde-88df-1f4e9e16676e.jpg?1",
             "name": "Tameshi, Reality Architect",
             "text": "Whenever one or more noncreature permanents are returned to hand, draw a card. This ability triggers only once each turn.\n{X}{W}, Return a land you control to its owner's hand: Return target artifact or enchantment card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "0e2ca9c8-8b26-50fd-8fdc-4cbf8d9f52b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee62e43-6a82-4749-972b-e21802642abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee62e43-6a82-4749-972b-e21802642abf.jpg?1",
             "name": "Tamiyo's Compleation",
             "text": "Flash\nEnchant artifact, creature, or planeswalker\nWhen Tamiyo's Compleation enters the battlefield, tap enchanted permanent. If it's an Equipment, unattach it.\nEnchanted permanent loses all abilities and doesn't untap during its controller's untap step.",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "beddaaaf-a88d-5d44-acef-1a1d052da23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2174d16e-4a78-4d27-b220-1086c40db83e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2174d16e-4a78-4d27-b220-1086c40db83e.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "The first activated ability of an artifact you activate each turn costs {2} less to activate.\n+1: Draw two cards. Then discard two cards unless you discard an artifact card.\n\u22122: Target artifact becomes an artifact creature. If it isn't a Vehicle, it has base power and toughness 4/4.\n\u22126: You get an emblem with \"Whenever an artifact you control becomes tapped, draw a card.\"",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "69e1483d-5c32-5bcd-a270-46121a7542fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b927837-8252-4ea7-b2d0-ab624de65bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b927837-8252-4ea7-b2d0-ab624de65bd7.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "4c4ebd0c-b904-5e97-9d5e-93155ff77d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a698a5-f4ac-4b04-96dc-32e1eeef6ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a698a5-f4ac-4b04-96dc-32e1eeef6ac7.jpg?1",
             "name": "Thousand-Faced Shadow",
             "text": "Ninjutsu {2}{U}{U} ({2}{U}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "bdd250dd-e01d-520d-bab5-ec67403580fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a926c10-029d-4e24-8c3f-1808025e30aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a926c10-029d-4e24-8c3f-1808025e30aa.jpg?1",
             "name": "Assassin's Ink",
             "text": "This spell costs {1} less to cast if you control an artifact and {1} less to cast if you control an enchantment.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3378,7 +3378,7 @@
         },
         {
             "id": "c1b1e927-8e33-5f6a-89d5-9986818eba82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017df51-67ae-4c3d-8210-086f83bc2040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3017df51-67ae-4c3d-8210-086f83bc2040.jpg?1",
             "name": "Biting-Palm Ninja",
             "text": "Ninjutsu {2}{B}\nBiting-Palm Ninja enters the battlefield with a menace counter on it.\nWhenever Biting-Palm Ninja deals combat damage to a player, you may remove a menace counter from it. When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "841679dc-4fad-59e6-a1f6-f736a3be4b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bc3f71-b4ce-4c05-be3c-7a0faad476c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6bc3f71-b4ce-4c05-be3c-7a0faad476c3.jpg?1",
             "name": "Blade of the Oni",
             "text": "Menace\nEquipped creature has base power and toughness 5/5, has menace, and is a black Demon in addition to its other colors and types.\nReconfigure {2}{B}{B} ({2}{B}{B}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "a3f5c445-d600-583e-a7c1-7f36b22aa9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8efe0-2f7b-4ada-a1b9-9c5f9e6a114d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b8efe0-2f7b-4ada-a1b9-9c5f9e6a114d.jpg?1",
             "name": "Chainflail Centipede",
             "text": "Whenever Chainflail Centipede or equipped creature attacks, it gets +2/+0 until end of turn.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "449fd881-d75e-5370-a66e-b60b3fbdf8fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621fce96-5933-4e2b-98ec-2589940e24cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/621fce96-5933-4e2b-98ec-2589940e24cb.jpg?1",
             "name": "Clawing Torment",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets -1/-1 and can't block.\nEnchanted permanent has \"At the beginning of your upkeep, you lose 1 life.\"",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "b2f1e203-47bb-5a24-9f69-45f9005b8ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a7e728-ba01-4e3d-b269-9e2dd85a1d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1a7e728-ba01-4e3d-b269-9e2dd85a1d1b.jpg?1",
             "name": "Debt to the Kami",
             "text": "Choose one \u2014\n\u2022 Target opponent exiles a creature they control.\n\u2022 Target opponent exiles an enchantment they control.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "1bac13ef-9154-5189-a97b-bc27ac59c1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80100c3-c81e-4084-8dfe-f8610637fd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80100c3-c81e-4084-8dfe-f8610637fd91.jpg?1",
             "name": "Dockside Chef",
             "text": "{1}{B}, Sacrifice an artifact or creature: Draw a card.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "68d4f98f-a81f-5e1d-b48f-e72f48e08d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81496a81-c986-4749-a28c-45341764e28f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81496a81-c986-4749-a28c-45341764e28f.jpg?1",
             "name": "Dokuchi Shadow-Walker",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "36431125-3b8c-58bb-82cf-498da586c66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24d5664-e214-466d-bb53-4e8f6f75a009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24d5664-e214-466d-bb53-4e8f6f75a009.jpg?1",
             "name": "Dokuchi Silencer",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Dokuchi Silencer deals combat damage to a player, you may discard a creature card. When you do, destroy target creature or planeswalker that player controls.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "9551daa9-e3ac-543d-8035-7beb7f1a6aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991370bd-a96a-4ed0-bdf9-f03b98191abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991370bd-a96a-4ed0-bdf9-f03b98191abf.jpg?1",
             "name": "Enormous Energy Blade",
             "text": "Equipped creature gets +4/+0.\nWhenever Enormous Energy Blade becomes attached to a creature, tap that creature.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "bf72caf7-8724-598e-a1f3-a463ea64d64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e1ff1e-916b-4455-84cb-4125a79d76de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e1ff1e-916b-4455-84cb-4125a79d76de.jpg?1",
             "name": "Go-Shintai of Hidden Cruelty",
             "text": "Deathtouch\nAt the beginning of your end step, you may pay {1}. When you do, destroy target creature with toughness X or less, where X is the number of Shrines you control.",
             "colours": [
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "2c52acaf-dd4e-5b4f-a23b-4ca77b07db5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c5b14-75cf-4e4c-9b80-2d56a86e2844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c5b14-75cf-4e4c-9b80-2d56a86e2844.jpg?1",
             "name": "Gravelighter",
             "text": "Flying\nWhen Gravelighter enters the battlefield, draw a card if a creature died this turn. Otherwise, each player sacrifices a creature.",
             "colours": [
@@ -3773,7 +3773,7 @@
         },
         {
             "id": "d2d89a9d-ae88-52af-84f1-c0441a9cca03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4142d3-f7ca-4613-a6e5-528cf1f22383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4142d3-f7ca-4613-a6e5-528cf1f22383.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "{B}, Sacrifice a creature: Scry 2.\n{2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.",
             "colours": [
@@ -3818,7 +3818,7 @@
         },
         {
             "id": "b05d8e44-2dec-5b5f-b332-0b2668ae9043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6e447-5f40-4039-8a17-257b4a55382c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb6e447-5f40-4039-8a17-257b4a55382c.jpg?1",
             "name": "Inkrise Infiltrator",
             "text": "Flying\n{3}{B}: Inkrise Infiltrator gets +2/+2 until end of turn.",
             "colours": [
@@ -3855,7 +3855,7 @@
         },
         {
             "id": "c9f820b9-5b00-527f-8f9f-2bf9ad89a8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -3891,7 +3891,7 @@
         },
         {
             "id": "a07096eb-3e0e-5602-823d-d85882721f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9033cf27-d9e6-49b8-8ee1-c1f38c9680b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9033cf27-d9e6-49b8-8ee1-c1f38c9680b9.jpg?1",
             "name": "Junji, the Midnight Sky",
             "text": "Flying, menace\nWhen Junji, the Midnight Sky dies, choose one \u2014\n\u2022 Each opponent discards two cards and loses 2 life.\n\u2022 Put target non-Dragon creature card from a graveyard onto the battlefield under your control. You lose 2 life.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "8b079003-717d-5942-8903-26aacc16282a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd73fa5a-be0f-49a4-a921-afefbc8fa9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd73fa5a-be0f-49a4-a921-afefbc8fa9c5.jpg?1",
             "name": "Kaito's Pursuit",
             "text": "Target player discards two cards. Ninjas and Rogues you control gain menace until end of turn. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "feca572f-e49a-5852-a31e-e32c4dbd9a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3be4a-ab4f-46ef-837c-0f7559a701fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d3be4a-ab4f-46ef-837c-0f7559a701fe.jpg?1",
             "name": "Kami of Restless Shadows",
             "text": "When Kami of Restless Shadows enters the battlefield, choose one \u2014\n\u2022 Return up to one target Ninja or Rogue creature card from your graveyard to your hand.\n\u2022 Put target creature card from your graveyard on top of your library.",
             "colours": [
@@ -3997,7 +3997,7 @@
         },
         {
             "id": "f4fe0808-32d2-5666-8fca-e26192f367af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f15af6-eaf5-41b8-b93d-5a90ca219478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f15af6-eaf5-41b8-b93d-5a90ca219478.jpg?1",
             "name": "Kami of Terrible Secrets",
             "text": "When Kami of Terrible Secrets enters the battlefield, if you control an artifact and an enchantment, you draw a card and you gain 1 life.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "f34e3c90-23e2-5585-8201-d930aa50d69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97986b67-5ae4-492f-a9e0-81f57a829d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97986b67-5ae4-492f-a9e0-81f57a829d86.jpg?1",
             "name": "Leech Gauntlet",
             "text": "Lifelink\nEquipped creature has lifelink.\nReconfigure {4} ({4}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "0f1c9878-1ae5-509d-8f05-63d7d86d9f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8edf8f-c2bd-4fd1-8abf-d3162e068b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8edf8f-c2bd-4fd1-8abf-d3162e068b17.jpg?1",
             "name": "Lethal Exploit",
             "text": "Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn for each modified creature you controlled as you cast this spell. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -4099,7 +4099,7 @@
         },
         {
             "id": "f8aee9ed-0d99-5f25-8dca-5be056591a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg?1",
             "name": "Life of Toshiro Umezawa // Memory of Toshiro",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Choose one \u2014\n\u2022 Target creature gets +2/+2 until end of turn.\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 You gain 2 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "f3158902-81ec-505b-8be4-5b4ad5e3a462",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7f4adf7-b871-417b-8904-7f024ca21486.jpg?1",
             "name": "Life of Toshiro Umezawa // Memory of Toshiro",
             "text": "{T}, Pay 1 life: Add {B}. Spend this mana only to cast an instant or sorcery spell.",
             "colours": [
@@ -4169,7 +4169,7 @@
         },
         {
             "id": "7c96ff8d-1af2-577a-b251-0400cf0c7efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg?1",
             "name": "The Long Reach of Night // Animus of Night's Reach",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent sacrifices a creature unless they discard a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4203,7 +4203,7 @@
         },
         {
             "id": "4b3891a5-d7e9-5111-a7ce-e9f1e40a51a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/e/4ec18bf7-bd80-408d-acc4-ffaaf7ef6b5b.jpg?1",
             "name": "The Long Reach of Night // Animus of Night's Reach",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Animus of Night's Reach attacks, it gets +X/+0 until end of turn, where X is the number of creature cards in defending player's graveyard.",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "684b6d29-31ce-5f86-b4ed-a465a48d90c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e7415f-f014-4ece-81db-d8271444d9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e7415f-f014-4ece-81db-d8271444d9e9.jpg?1",
             "name": "Malicious Malfunction",
             "text": "All creatures get -2/-2 until end of turn. If a creature would die this turn, exile it instead.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "0ac19ec3-ca53-59ac-bc02-0f8904863bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a604e-6146-4e2e-88a5-863ecb3dfa1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050a604e-6146-4e2e-88a5-863ecb3dfa1f.jpg?1",
             "name": "March of Wretched Sorrow",
             "text": "As an additional cost to cast this spell, you may exile any number of black cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nMarch of Wretched Sorrow deals X damage to target creature or planeswalker and you gain X life.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "69c33d92-a202-5405-a557-1b5b722cefb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3293-c1e0-447c-8231-26fa9476a262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3293-c1e0-447c-8231-26fa9476a262.jpg?1",
             "name": "Mukotai Ambusher",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nLifelink",
             "colours": [
@@ -4343,7 +4343,7 @@
         },
         {
             "id": "92d75749-1102-582f-9a34-d941ac855fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166775be-c3b7-4a17-9376-aa4229b147f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166775be-c3b7-4a17-9376-aa4229b147f9.jpg?1",
             "name": "Mukotai Soulripper",
             "text": "Whenever Mukotai Soulripper attacks, you may sacrifice another artifact or creature. If you do, put a +1/+1 counter on Mukotai Soulripper and it gains menace until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "cd7b242e-2d8d-5d2f-b46a-0a58cb312992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893b070-a610-4273-beb2-7609a2da0499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2893b070-a610-4273-beb2-7609a2da0499.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -4421,7 +4421,7 @@
         },
         {
             "id": "69096d29-b8c8-5499-a267-e099d6ef94e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a03d3f5-b32b-4814-b485-25f24e51609c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a03d3f5-b32b-4814-b485-25f24e51609c.jpg?1",
             "name": "Nezumi Bladeblesser",
             "text": "Nezumi Bladeblesser has deathtouch as long as you control an artifact.\nNezumi Bladeblesser has menace as long as you control an enchantment. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "d686b66a-a754-5468-aaaa-7f26d93453f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca911e9a-bd04-4531-a81e-3485e9cbe89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca911e9a-bd04-4531-a81e-3485e9cbe89e.jpg?1",
             "name": "Nezumi Prowler",
             "text": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen Nezumi Prowler enters the battlefield, target creature you control gains deathtouch and lifelink until end of turn.",
             "colours": [
@@ -4496,7 +4496,7 @@
         },
         {
             "id": "fcaab0ce-fae1-5118-a674-b9fd7fe6b15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg?1",
             "name": "Okiba Reckoner Raid // Nezumi Road Captain",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent loses 1 life and you gain 1 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "1f58a3fb-5c60-54b1-ae77-5c7dcb6491fe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/f/4f0582b4-d951-4450-b158-4a34109e48cd.jpg?1",
             "name": "Okiba Reckoner Raid // Nezumi Road Captain",
             "text": "Menace\nVehicles you control have menace. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4566,7 +4566,7 @@
         },
         {
             "id": "f9f29963-21e2-5595-b049-41ff0273165a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e4485d-c208-46b4-9b5d-48e55e2ee182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e4485d-c208-46b4-9b5d-48e55e2ee182.jpg?1",
             "name": "Okiba Salvage",
             "text": "Return target creature or Vehicle card from your graveyard to the battlefield. Then put two +1/+1 counters on that permanent if you control an artifact and an enchantment.",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "c3297f3e-b8e3-5459-9504-2ce51343dd3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf57666f-366b-43bf-95c7-39c1f7f061e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf57666f-366b-43bf-95c7-39c1f7f061e2.jpg?1",
             "name": "Reckoner Shakedown",
             "text": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card. If you don't, put two +1/+1 counters on a creature or Vehicle you control.",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "2f6c16c3-2579-53f5-9f2e-62f3908d275a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6338942d-d650-4571-8ec6-4d658792c53e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6338942d-d650-4571-8ec6-4d658792c53e.jpg?1",
             "name": "Reckoner's Bargain",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nYou gain life equal to the sacrificed permanent's mana value. Draw two cards.",
             "colours": [
@@ -4662,7 +4662,7 @@
         },
         {
             "id": "3109ea0a-5943-5dbf-8e1d-c8051b3d1c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342ec072-e581-490c-b5ae-a625bd35a153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342ec072-e581-490c-b5ae-a625bd35a153.jpg?1",
             "name": "Return to Action",
             "text": "Until end of turn, target creature gets +1/+0 and gains lifelink and \"When this creature dies, return it to the battlefield tapped under its owner's control.\"",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "56d76a8f-a3bd-5c40-b9f9-e46bcff816fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5aba90-c8c7-4f06-b7b3-1b4758d2791a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5aba90-c8c7-4f06-b7b3-1b4758d2791a.jpg?1",
             "name": "Soul Transfer",
             "text": "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both.\n\u2022 Exile target creature or planeswalker.\n\u2022 Return target creature or planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -4729,7 +4729,7 @@
         },
         {
             "id": "884889c3-2fb4-593e-8642-21af6834952f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf42833-43d0-4b05-b499-d13b2c577ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf42833-43d0-4b05-b499-d13b2c577ee8.jpg?1",
             "name": "Tatsunari, Toad Rider",
             "text": "Whenever you cast an enchantment spell, if you don't control a creature named Keimi, create Keimi, a legendary 3/3 black and green Frog creature token with \"Whenever you cast an enchantment spell, each opponent loses 1 life and you gain 1 life.\"\n{1}{GW}: Tatsunari, Toad Rider and target Frog you control can't be blocked this turn except by creatures with flying or reach.",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "11100b42-d6bb-543d-8d14-5a475b14cd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent creates a 1/1 black Rat Rogue creature token.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -4808,7 +4808,7 @@
         },
         {
             "id": "a6c4f572-c1e1-5d39-805f-4bb17c931298",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54613f38-ca91-4764-b1fe-60cd83707fb4.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "Flying, haste\nWhen Echo of Death's Wail enters the battlefield, gain control of all Rat tokens.\nWhenever Echo of Death's Wail attacks, you may sacrifice another creature. If you do, draw a card.",
             "colours": [
@@ -4846,7 +4846,7 @@
         },
         {
             "id": "8b9554a9-b12a-57ed-882a-a250a178d0fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7919a-de62-46df-a937-593647473ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7919a-de62-46df-a937-593647473ef5.jpg?1",
             "name": "Twisted Embrace",
             "text": "Enchant artifact or creature you control\nWhen Twisted Embrace enters the battlefield, destroy target creature or planeswalker an opponent controls.\nAs long as enchanted permanent is a creature, it gets +1/+1.",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "665acf79-d6ef-5a56-961f-40b59756211d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6319b84b-8a3d-4bc8-af48-8b500f124be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6319b84b-8a3d-4bc8-af48-8b500f124be1.jpg?1",
             "name": "Undercity Scrounger",
             "text": "{T}: Create a Treasure token. Activate only if a creature died this turn. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "f33c2238-b3c3-52a9-a333-f5da2b157191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb20c08-a84a-4773-a90c-fb007b94644b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb20c08-a84a-4773-a90c-fb007b94644b.jpg?1",
             "name": "Unforgiving One",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Unforgiving One attacks, return target creature card with mana value X or less from your graveyard to the battlefield, where X is the number of modified creatures you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "213cbf96-9270-5906-9ace-b65561d5a100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488ee202-0d28-4cc0-8a7d-644d9878e952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488ee202-0d28-4cc0-8a7d-644d9878e952.jpg?1",
             "name": "Virus Beetle",
             "text": "When Virus Beetle enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -4985,7 +4985,7 @@
         },
         {
             "id": "8bba91fa-c6ea-590f-ab22-56a93e8aafad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768727ce-4f84-4527-8d69-3c9b7877b748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768727ce-4f84-4527-8d69-3c9b7877b748.jpg?1",
             "name": "You Are Already Dead",
             "text": "Destroy target creature that was dealt damage this turn.\nDraw a card.",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "fd858b35-7fcd-5856-825a-7024033b9e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d83e837-fcd1-4833-9117-e6f1bb53caad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d83e837-fcd1-4833-9117-e6f1bb53caad.jpg?1",
             "name": "Akki Ember-Keeper",
             "text": "Whenever a nontoken modified creature you control dies, create a 1/1 colorless Spirit creature token. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5053,7 +5053,7 @@
         },
         {
             "id": "93ed7aae-6f64-5624-83e7-3a2b545770ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f15754-1ca6-45b0-a7de-2fe507df2a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f15754-1ca6-45b0-a7de-2fe507df2a1a.jpg?1",
             "name": "Akki Ronin",
             "text": "Whenever a Samurai or Warrior you control attacks alone, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "3e831aaf-2264-5fcc-b7d6-32a5f00f2e3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110698e-a343-4eff-ba23-ed7ac5a3f87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f110698e-a343-4eff-ba23-ed7ac5a3f87b.jpg?1",
             "name": "Akki War Paint",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +2/+1.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "01cfe1cc-ac52-5c76-9c79-4e60e0256247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d618d-abad-475b-b938-e111282ea1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00d618d-abad-475b-b938-e111282ea1c3.jpg?1",
             "name": "Ambitious Assault",
             "text": "Creatures you control get +2/+0 until end of turn. If you control a modified creature, draw a card. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "f60ae2f8-5614-5f98-bdac-68cf532dfce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b64c17-8a52-4d9d-a28b-7e0e945be059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b64c17-8a52-4d9d-a28b-7e0e945be059.jpg?1",
             "name": "Atsushi, the Blazing Sky",
             "text": "Flying, trample\nWhen Atsushi, the Blazing Sky dies, choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Create three Treasure tokens.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "0f2638a4-a353-531a-aa4e-5bee99896986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8f5da8-13a8-4b39-8ddc-7661892924af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8f5da8-13a8-4b39-8ddc-7661892924af.jpg?1",
             "name": "Bronzeplate Boar",
             "text": "Trample\nEquipped creature gets +3/+2 and has trample.\nReconfigure {5} ({5}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "d5018e9d-cc32-59c4-8302-2b87a8b02891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f77f987-ebb7-4105-a67c-0987f50fc676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f77f987-ebb7-4105-a67c-0987f50fc676.jpg?1",
             "name": "Crackling Emergence",
             "text": "Enchant land you control\nEnchanted land is a 3/3 red Spirit creature with haste. It's still a land.\nIf enchanted land would be destroyed, instead sacrifice Crackling Emergence and that land gains indestructible until end of turn.",
             "colours": [
@@ -5266,7 +5266,7 @@
         },
         {
             "id": "8432928f-1b52-5107-a63b-36095e559028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf531dd-0a93-43e3-880b-f705fa5f533d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf531dd-0a93-43e3-880b-f705fa5f533d.jpg?1",
             "name": "Dragonspark Reactor",
             "text": "Whenever Dragonspark Reactor or another artifact enters the battlefield under your control, put a charge counter on Dragonspark Reactor.\n{4}, Sacrifice Dragonspark Reactor: It deals damage equal to the number of charge counters on it to target player and that much damage to up to one target creature.",
             "colours": [
@@ -5298,7 +5298,7 @@
         },
         {
             "id": "c82a4e4b-5abf-55fd-a540-3e19faff8a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47931c9-685d-4b83-8299-bc347224b4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c47931c9-685d-4b83-8299-bc347224b4e8.jpg?1",
             "name": "Experimental Synthesizer",
             "text": "When Experimental Synthesizer enters or leaves the battlefield, exile the top card of your library. Until end of turn, you may play that card.\n{2}{R}, Sacrifice Experimental Synthesizer: Create a 2/2 white Samurai creature token with vigilance. Activate only as a sorcery.",
             "colours": [
@@ -5330,7 +5330,7 @@
         },
         {
             "id": "2203b6be-86bf-511c-8459-91329449df73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba639ff-fe82-4ac3-9fb4-eac168bef053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba639ff-fe82-4ac3-9fb4-eac168bef053.jpg?1",
             "name": "Explosive Entry",
             "text": "Destroy up to one target artifact. Put a +1/+1 counter on up to one target creature.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "b0036ff4-5ca7-5132-9cdb-be7a2eef677f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdd822-44a1-4d58-9de4-69fc56eae255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cdd822-44a1-4d58-9de4-69fc56eae255.jpg?1",
             "name": "Explosive Singularity",
             "text": "As an additional cost to cast this spell, you may tap any number of untapped creatures you control. This spell costs {1} less to cast for each creature tapped this way.\nExplosive Singularity deals 10 damage to any target.",
             "colours": [
@@ -5398,7 +5398,7 @@
         },
         {
             "id": "e54871ca-b187-5a71-b8eb-9e9c5322f4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 2/2 red Goblin Shaman creature token with \"Whenever this creature attacks, create a Treasure token.\"\nII \u2014 You may discard up to two cards. If you do, draw that many cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "ff6bdac8-48f6-51e1-a8bc-9db0a5b2dee7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "b2bc4fe0-0b1e-5fe5-acd5-af1ca5f57305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b44534f-d10c-4754-8585-5fe9db5fd4ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b44534f-d10c-4754-8585-5fe9db5fd4ea.jpg?1",
             "name": "Flame Discharge",
             "text": "Flame Discharge deals X damage to target creature or planeswalker. If you controlled a modified creature as you cast this spell, it deals X plus 2 damage instead. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "37ec2f9b-4a90-5234-8ed3-9f97ee61a4c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c33f6d9-be29-4698-96f9-d393a2c8ad68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c33f6d9-be29-4698-96f9-d393a2c8ad68.jpg?1",
             "name": "Gift of Wrath",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +2/+2 and has menace. (It can't be blocked except by two or more creatures.)\nWhen Gift of Wrath leaves the battlefield, create a 2/2 red Spirit creature token with menace.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "925f449b-5578-5809-81ab-84fbba952354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b915e8d-b972-4ae1-a1c3-74d6623963c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b915e8d-b972-4ae1-a1c3-74d6623963c8.jpg?1",
             "name": "Go-Shintai of Ancient Wars",
             "text": "First strike\nAt the beginning of your end step, you may pay {1}. When you do, Go-Shintai of Ancient Wars deals X damage to target player or planeswalker, where X is the number of Shrines you control.",
             "colours": [
@@ -5577,7 +5577,7 @@
         },
         {
             "id": "2ed62ee3-84b6-568b-a09a-1d39904fade0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca736c7-35a9-48c7-b5a9-69b2a6e33ad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca736c7-35a9-48c7-b5a9-69b2a6e33ad0.jpg?1",
             "name": "Goro-Goro, Disciple of Ryusei",
             "text": "{R}: Creatures you control gain haste until end of turn.\n{3}{R}{R}: Create a 5/5 red Dragon Spirit creature token with flying. Activate only if you control an attacking modified creature. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5617,7 +5617,7 @@
         },
         {
             "id": "24785665-d324-5c98-a56a-7e905ad13a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5e61c-d903-410b-9acf-96a917ce05cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea5e61c-d903-410b-9acf-96a917ce05cc.jpg?1",
             "name": "Heiko Yamazaki, the General",
             "text": "Trample\nWhenever a Samurai or Warrior you control attacks alone, you may cast target artifact card from your graveyard this turn.",
             "colours": [
@@ -5656,7 +5656,7 @@
         },
         {
             "id": "6a1a700f-be63-5887-8b58-49f2a48b58f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe666c86-6734-4c47-9244-bcd26b54068d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe666c86-6734-4c47-9244-bcd26b54068d.jpg?1",
             "name": "Invoke Calamity",
             "text": "You may cast up to two instant and/or sorcery spells with total mana value 6 or less from your graveyard and/or hand without paying their mana costs. If those spells would be put into your graveyard, exile them instead. Exile Invoke Calamity.",
             "colours": [
@@ -5691,7 +5691,7 @@
         },
         {
             "id": "43b2c280-be17-5b6a-a8b1-ec5ac1bc1198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abe574-6fb8-4809-9c18-0cf989f986f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73abe574-6fb8-4809-9c18-0cf989f986f5.jpg?1",
             "name": "Ironhoof Boar",
             "text": "Trample, haste\nChannel \u2014 {1}{R}, Discard Ironhoof Boar: Target creature gets +3/+1 and gains trample until end of turn.",
             "colours": [
@@ -5726,7 +5726,7 @@
         },
         {
             "id": "38c1235e-e3ce-566d-a550-25a667f1624e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d00e61-3007-43da-960b-823e9ead2acf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d00e61-3007-43da-960b-823e9ead2acf.jpg?1",
             "name": "Kami of Industry",
             "text": "When Kami of Industry enters the battlefield, return target artifact card with mana value 3 or less from your graveyard to the battlefield. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "e02774a4-9c5c-513d-a789-9dfefa6fd795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef5d58e-b490-4682-9a44-12cd61a94c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bef5d58e-b490-4682-9a44-12cd61a94c0f.jpg?1",
             "name": "Kami's Flare",
             "text": "Kami's Flare deals 3 damage to target creature or planeswalker. Kami's Flare also deals 2 damage to that permanent's controller if you control a modified creature. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "3a9e95d8-dd5a-5bcd-934f-03b6773659be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8bdce-73a3-4266-b3d6-61dbf4534ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c8bdce-73a3-4266-b3d6-61dbf4534ea3.jpg?1",
             "name": "Kindled Fury",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "0a262ce7-7635-51b2-a6e7-8feaccc178ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1",
             "name": "Kumano Faces Kakkazan // Etching of Kumano",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Kumano Faces Kakkazan deals 1 damage to each opponent and each planeswalker they control.\nII \u2014 When you cast your next creature spell this turn, that creature enters the battlefield with an additional +1/+1 counter on it.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "2d410dfb-e1f7-5b32-b013-953eb4ed86ab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1",
             "name": "Kumano Faces Kakkazan // Etching of Kumano",
             "text": "Haste\nIf a creature dealt damage this turn by a source you controlled would die, exile it instead.",
             "colours": [
@@ -5894,7 +5894,7 @@
         },
         {
             "id": "abc87425-bef9-5f5e-948a-15d7c9c3dc3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a747e6cf-c687-4c4f-8e07-d51165d6cb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a747e6cf-c687-4c4f-8e07-d51165d6cb62.jpg?1",
             "name": "Lizard Blades",
             "text": "Double strike\nEquipped creature has double strike.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -5933,7 +5933,7 @@
         },
         {
             "id": "3be796c8-ae44-537f-ad34-1ceba5ed6fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e1bf1-e392-40f2-9e84-764dedc5fcd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780e1bf1-e392-40f2-9e84-764dedc5fcd4.jpg?1",
             "name": "March of Reckless Joy",
             "text": "As an additional cost to cast this spell, you may exile any number of red cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile the top X cards of your library. You may play up to two of those cards until the end of your next turn.",
             "colours": [
@@ -5968,7 +5968,7 @@
         },
         {
             "id": "9d787ee9-e9ad-5538-a4fd-49af08264eb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0d5f7d-4e8a-42ad-8875-610004bd9796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a0d5f7d-4e8a-42ad-8875-610004bd9796.jpg?1",
             "name": "Ogre-Head Helm",
             "text": "Equipped creature gets +2/+2.\nWhenever Ogre-Head Helm or equipped creature deals combat damage to a player, you may sacrifice it. If you do, discard your hand, then draw three cards.\nReconfigure {3} ({3}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -6007,7 +6007,7 @@
         },
         {
             "id": "82c30936-724c-5cd5-a95d-f5a0734e3da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b2176d-8925-4474-9d3e-1c97192715fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b2176d-8925-4474-9d3e-1c97192715fb.jpg?1",
             "name": "Peerless Samurai",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever a Samurai or Warrior you control attacks alone, the next spell you cast this turn costs {1} less to cast.",
             "colours": [
@@ -6044,7 +6044,7 @@
         },
         {
             "id": "0898bec2-807d-54a9-9127-dcda63f86d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d33a5b7-797b-4079-8d62-edd124c0fb5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d33a5b7-797b-4079-8d62-edd124c0fb5a.jpg?1",
             "name": "Rabbit Battery",
             "text": "Haste\nEquipped creature gets +1/+1 and has haste.\nReconfigure {R} ({R}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -6080,7 +6080,7 @@
         },
         {
             "id": "e5abe64e-f408-5af3-a391-4a16b698eb7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a18961-8f0b-4e98-9de4-aba97e91ad9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a18961-8f0b-4e98-9de4-aba97e91ad9a.jpg?1",
             "name": "Reinforced Ronin",
             "text": "Haste\nAt the beginning of your end step, return Reinforced Ronin to its owner's hand.\nChannel \u2014 {1}{R}, Discard Reinforced Ronin: Draw a card.",
             "colours": [
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "ebba66c7-9626-5b0e-b538-8850d84763aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14057067-2325-4229-8580-d9a6397ae343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14057067-2325-4229-8580-d9a6397ae343.jpg?1",
             "name": "Scrap Welder",
             "text": "{T}, Sacrifice an artifact with mana value X: Return target artifact card with mana value less than X from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "28e233b6-d42c-546b-9f7c-f81e4766ec55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5776e576-5562-45ea-a29b-185410317e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5776e576-5562-45ea-a29b-185410317e17.jpg?1",
             "name": "Scrapyard Steelbreaker",
             "text": "{1}, Sacrifice another artifact: Scrapyard Steelbreaker gets +2/+1 until end of turn.",
             "colours": [
@@ -6192,7 +6192,7 @@
         },
         {
             "id": "0ce6e912-7b0b-5dea-b0c2-1f40e9f69678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b8ffb-c2e4-4676-9051-ff6c686cad0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55b8ffb-c2e4-4676-9051-ff6c686cad0b.jpg?1",
             "name": "Seismic Wave",
             "text": "Seismic Wave deals 2 damage to any target and 1 damage to each nonartifact creature target opponent controls.",
             "colours": [
@@ -6224,7 +6224,7 @@
         },
         {
             "id": "66a7c459-985c-55d5-aa84-b74720400cce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg?1",
             "name": "The Shattered States Era // Nameless Conqueror",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Gain control of target creature until end of turn. Untap it. It gains haste until end of turn.\nII \u2014 Creatures you control get +1/+0 until end of turn.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -6258,7 +6258,7 @@
         },
         {
             "id": "6ae71f2e-d666-52c8-8749-f2f30452ce3d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/517392f6-d3fd-4c59-8317-2a3595ab7562.jpg?1",
             "name": "The Shattered States Era // Nameless Conqueror",
             "text": "Trample, haste",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "fd31077b-409a-5295-8644-e9f472697bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a00f95-d563-4d51-a5f2-af139261921a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a00f95-d563-4d51-a5f2-af139261921a.jpg?1",
             "name": "Simian Sling",
             "text": "Equipped creature gets +1/+1.\nWhenever Simian Sling or equipped creature becomes blocked, it deals 1 damage to defending player.\nReconfigure {2} ({2}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -6330,7 +6330,7 @@
         },
         {
             "id": "213c2ff0-9d35-5912-a7d7-6000f36a5448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758724f9-93c9-4178-ae40-3fefc75a010e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758724f9-93c9-4178-ae40-3fefc75a010e.jpg?1",
             "name": "Sokenzan Smelter",
             "text": "At the beginning of combat on your turn, you may pay {1} and sacrifice an artifact. If you do, create a 3/1 red Construct artifact creature token with haste.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "e24e2e15-6faf-5a68-a4c9-53c755f5e479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd0693-6dba-4c0d-8c42-859d7bf38c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd0693-6dba-4c0d-8c42-859d7bf38c40.jpg?1",
             "name": "Tempered in Solitude",
             "text": "Whenever a creature you control attacks alone, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -6397,7 +6397,7 @@
         },
         {
             "id": "b2c633bb-c486-5dd2-95f0-608fec8fc5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1a2920-6d39-4276-921c-65cc16a45f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1a2920-6d39-4276-921c-65cc16a45f17.jpg?1",
             "name": "Thundering Raiju",
             "text": "Haste\nWhenever Thundering Raiju attacks, put a +1/+1 counter on target creature you control. Then Thundering Raiju deals X damage to each opponent, where X is the number of modified creatures you control other than Thundering Raiju. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6434,7 +6434,7 @@
         },
         {
             "id": "cbd992a3-becd-5764-9c22-c47ae1f32ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ff9be1-765f-4001-a0ac-39c8099924eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7ff9be1-765f-4001-a0ac-39c8099924eb.jpg?1",
             "name": "Towashi Songshaper",
             "text": "Whenever another artifact enters the battlefield under your control, Towashi Songshaper gets +1/+0 until end of turn.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "b4c7770f-f788-5217-87d4-dd9d95755838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a86009-4637-4b6c-9d36-367151583668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a86009-4637-4b6c-9d36-367151583668.jpg?1",
             "name": "Twinshot Sniper",
             "text": "Reach\nWhen Twinshot Sniper enters the battlefield, it deals 2 damage to any target.\nChannel \u2014 {1}{R}, Discard Twinshot Sniper: It deals 2 damage to any target.",
             "colours": [
@@ -6506,7 +6506,7 @@
         },
         {
             "id": "93bfb5b2-0f55-5c2c-abe9-3fa3e0272b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719f20d9-2baa-49b3-8c6a-89f21a07d538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719f20d9-2baa-49b3-8c6a-89f21a07d538.jpg?1",
             "name": "Unstoppable Ogre",
             "text": "When Unstoppable Ogre enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -6542,7 +6542,7 @@
         },
         {
             "id": "9e5bda11-4164-56b8-b6c7-d60fd2c2c2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d878c2-a340-4751-adaa-e50b0bb85423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d878c2-a340-4751-adaa-e50b0bb85423.jpg?1",
             "name": "Upriser Renegade",
             "text": "Upriser Renegade gets +2/+0 for each other modified creature you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -6579,7 +6579,7 @@
         },
         {
             "id": "13882ddf-4134-5d8e-9f8e-571f0d2d8b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b7141-45b9-4629-a4e4-b50f93929717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9b7141-45b9-4629-a4e4-b50f93929717.jpg?1",
             "name": "Voltage Surge",
             "text": "As an additional cost to cast this spell, you may sacrifice an artifact.\nVoltage Surge deals 2 damage to target creature or planeswalker. If this spell's additional cost was paid, Voltage Surge deals 4 damage instead.",
             "colours": [
@@ -6611,7 +6611,7 @@
         },
         {
             "id": "34fd3ebf-ae2c-5ad3-abc2-ece387b2d3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg?1",
             "name": "Azusa's Many Journeys // Likeness of the Seeker",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 You may play an additional land this turn.\nII \u2014 You gain 3 life.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -6645,7 +6645,7 @@
         },
         {
             "id": "2649d2cb-b59e-533b-afe5-334e8f310b62",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/8/e8a51d2a-1582-4bad-995c-e7fe9f810149.jpg?1",
             "name": "Azusa's Many Journeys // Likeness of the Seeker",
             "text": "Whenever Likeness of the Seeker becomes blocked, untap up to three lands you control.",
             "colours": [
@@ -6681,7 +6681,7 @@
         },
         {
             "id": "0551a67e-049f-582b-af96-cb2bd4d20ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b43bb9f-1b84-41cc-a4f9-5875ae6d207c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b43bb9f-1b84-41cc-a4f9-5875ae6d207c.jpg?1",
             "name": "Bamboo Grove Archer",
             "text": "Defender, reach\nChannel \u2014 {4}{G}, Discard Bamboo Grove Archer: Destroy target creature with flying.",
             "colours": [
@@ -6717,7 +6717,7 @@
         },
         {
             "id": "3cd4e31a-4336-5362-99d0-34838f4568ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540ba70a-bea8-4512-83ba-92dab6d25b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540ba70a-bea8-4512-83ba-92dab6d25b52.jpg?1",
             "name": "Bearer of Memory",
             "text": "{5}{G}: Put a +1/+1 counter on target enchantment creature. It gains trample until end of turn.",
             "colours": [
@@ -6753,7 +6753,7 @@
         },
         {
             "id": "e7d98862-6983-50fa-bf8d-f0d49326dbd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26abdf2-efd7-40e5-bfc6-d75fcadd26f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26abdf2-efd7-40e5-bfc6-d75fcadd26f8.jpg?1",
             "name": "Blossom Prancer",
             "text": "Reach\nWhen Blossom Prancer enters the battlefield, look at the top five cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, you gain 4 life.",
             "colours": [
@@ -6787,7 +6787,7 @@
         },
         {
             "id": "a2cae6ad-d9df-5e02-aef3-4e349fe42ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06771591-0480-4232-bc67-216b2e0fe738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06771591-0480-4232-bc67-216b2e0fe738.jpg?1",
             "name": "Boon of Boseiju",
             "text": "Target creature gets +X/+X until end of turn, where X is the greatest mana value among permanents you control. Untap it.",
             "colours": [
@@ -6819,7 +6819,7 @@
         },
         {
             "id": "b0d99b95-a0e2-5afd-abcd-4fd24793ca42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg?1",
             "name": "Boseiju Reaches Skyward // Branch of Boseiju",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Search your library for up to two basic Forest cards, reveal them, put them into your hand, then shuffle.\nII \u2014 Put up to one target land card from your graveyard on top of your library.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -6853,7 +6853,7 @@
         },
         {
             "id": "47355285-ab9e-5748-858f-ae3f62af3579",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/1144014b-f13b-4397-97ed-a8de46371a2c.jpg?1",
             "name": "Boseiju Reaches Skyward // Branch of Boseiju",
             "text": "Reach\nBranch of Boseiju gets +1/+1 for each land you control.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "1aaf1c02-71c9-5530-841d-cf7ed6b64d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2ebad5-0a56-4166-80af-7ebd20ae565a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2ebad5-0a56-4166-80af-7ebd20ae565a.jpg?1",
             "name": "Careful Cultivation",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +1/+3 and has reach and \"{T}: Add {G}{G}.\"\nChannel \u2014 {1}{G}, Discard Careful Cultivation: Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"",
             "colours": [
@@ -6922,7 +6922,7 @@
         },
         {
             "id": "550680a6-a484-5949-9381-19f75a03afbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eba24f6-8a9c-4398-b2ab-3924b107c7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eba24f6-8a9c-4398-b2ab-3924b107c7b7.jpg?1",
             "name": "Coiling Stalker",
             "text": "Ninjutsu {1}{G} ({1}{G}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Coiling Stalker deals combat damage to a player, put a +1/+1 counter on target creature you control that doesn't have a +1/+1 counter on it.",
             "colours": [
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "9d2bd07e-4b55-56ff-a7cf-3a3d2d23eb23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ff4dd-bad3-4496-82b3-8253f48af06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35ff4dd-bad3-4496-82b3-8253f48af06d.jpg?1",
             "name": "Commune with Spirits",
             "text": "Look at the top four cards of your library. You may reveal an enchantment or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6991,7 +6991,7 @@
         },
         {
             "id": "1285a01c-6b69-58c9-82e0-bec092465844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 You gain 2 life. Look at the top three cards of your library. Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "81f21804-bf2f-5b0a-bee4-36d1e63cffe9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/2534caaa-a793-415f-977f-1d0fac3642ab.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "Whenever Dragon-Kami's Egg or a Dragon you control dies, you may cast a creature spell from among cards you own in exile with hatching counters on them without paying its mana cost.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "b6e328f0-5d1b-57d6-8cbb-989c50b08c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55174ab7-9f2e-42e5-a61b-57458cfd33f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55174ab7-9f2e-42e5-a61b-57458cfd33f3.jpg?1",
             "name": "Fade into Antiquity",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "0ebf0136-1096-50a9-b65b-035935445fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd0fef1-209f-4de5-a736-8f9bca2faa0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd0fef1-209f-4de5-a736-8f9bca2faa0a.jpg?1",
             "name": "Fang of Shigeki",
             "text": "Deathtouch",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "0c6593d9-2f70-5731-bf0e-252e52526ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013266a-81f4-4441-8dcf-2764d14afceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013266a-81f4-4441-8dcf-2764d14afceb.jpg?1",
             "name": "Favor of Jukai",
             "text": "Enchant artifact or creature\nAs long as enchanted permanent is a creature, it gets +3/+3 and has reach.\nChannel \u2014 {1}{G}, Discard Favor of Jukai: Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -7170,7 +7170,7 @@
         },
         {
             "id": "a9c36462-d45d-5a0c-b76c-c1d1ec87674e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1066ccd-a932-4d05-98da-11ae4675364e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1066ccd-a932-4d05-98da-11ae4675364e.jpg?1",
             "name": "Generous Visitor",
             "text": "Whenever you cast an enchantment spell, put a +1/+1 counter on target creature.",
             "colours": [
@@ -7204,7 +7204,7 @@
         },
         {
             "id": "21116e40-cad1-5365-898d-caa3c2f06039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d7162-39fc-4d99-8c5f-b40a765b883a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559d7162-39fc-4d99-8c5f-b40a765b883a.jpg?1",
             "name": "Geothermal Kami",
             "text": "When Geothermal Kami enters the battlefield, you may return an enchantment you control to its owner's hand. If you do, you gain 3 life.",
             "colours": [
@@ -7238,7 +7238,7 @@
         },
         {
             "id": "49957446-7c02-5c2e-ba1a-11b7be2b98af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691016a1-8630-423c-9a57-061593d170fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691016a1-8630-423c-9a57-061593d170fd.jpg?1",
             "name": "Go-Shintai of Boundless Vigor",
             "text": "Trample\nAt the beginning of your end step, you may pay {1}. When you do, put a +1/+1 counter on target Shrine for each Shrine you control.",
             "colours": [
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "0dab9121-ce6e-5d18-a1e5-9c5fafc6bb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a15010-1b70-4b4f-8b5d-cb2d764a1799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a15010-1b70-4b4f-8b5d-cb2d764a1799.jpg?1",
             "name": "Grafted Growth",
             "text": "Enchant land\nWhen Grafted Growth enters the battlefield, put a +1/+1 counter on target creature or Vehicle you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "b8c064d3-14ef-5068-ab8e-8d4455197a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fbaee3-a10f-4b2d-b07e-d041a96a7e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4fbaee3-a10f-4b2d-b07e-d041a96a7e27.jpg?1",
             "name": "Greater Tanuki",
             "text": "Trample\nChannel \u2014 {2}{G}, Discard Greater Tanuki: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "20c06679-1915-5559-9b8e-bfcd43b8b134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ff968-b436-4313-8375-8a3bb41f9892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92ff968-b436-4313-8375-8a3bb41f9892.jpg?1",
             "name": "Harmonious Emergence",
             "text": "Enchant land you control\nEnchanted land is a 4/5 green Spirit creature with vigilance and haste. It's still a land.\nIf enchanted land would be destroyed, instead sacrifice Harmonious Emergence and that land gains indestructible until end of turn.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "f72f4a23-a50e-5b9f-91c1-694668416db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45daa56-6ad8-4df7-9d81-3193fd32e574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45daa56-6ad8-4df7-9d81-3193fd32e574.jpg?1",
             "name": "Heir of the Ancient Fang",
             "text": "Heir of the Ancient Fang enters the battlefield with a +1/+1 counter on it if you control a modified creature. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "4be47f4f-75b2-55c7-8a10-acfe234c25aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941f91bb-f5a3-4cca-85b5-b610502460bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941f91bb-f5a3-4cca-85b5-b610502460bb.jpg?1",
             "name": "Historian's Wisdom",
             "text": "Enchant artifact or creature\nWhen Historian's Wisdom enters the battlefield, if enchanted permanent is a creature with the greatest power among creatures on the battlefield, draw a card.\nAs long as enchanted permanent is a creature, it gets +2/+1.",
             "colours": [
@@ -7449,7 +7449,7 @@
         },
         {
             "id": "863ec27b-bbd8-5cfd-a571-bc17a39c08c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c02102-3be7-462f-ab9c-ff404255002d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c02102-3be7-462f-ab9c-ff404255002d.jpg?1",
             "name": "Invoke the Ancients",
             "text": "Create two 4/5 green Spirit creature tokens. For each of them, put your choice of a vigilance counter, a reach counter, or a trample counter on it.",
             "colours": [
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "60e2af6f-d9b9-5338-b02c-cc0a3846c6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"\nII \u2014 Put a +1/+1 counter on each of up to two target creatures.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "ce05e474-1979-5f32-b08e-72a832cb4db4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a22b5f27-f9e7-49e1-8e96-dc5d8e7fbe27.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on that creature.\nAs long as you control five or more modified creatures, Remnant of the Rising Star gets +5/+5 and has trample. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -7560,7 +7560,7 @@
         },
         {
             "id": "5ed3eef1-f470-52b3-90d8-a4d56738707e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66120a5-95a3-4d15-873c-cfba221a2299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66120a5-95a3-4d15-873c-cfba221a2299.jpg?1",
             "name": "Jukai Preserver",
             "text": "When Jukai Preserver enters the battlefield, put a +1/+1 counter on target creature you control.\nChannel \u2014 {2}{G}, Discard Jukai Preserver: Put a +1/+1 counter on each of up to two target creatures you control.",
             "colours": [
@@ -7596,7 +7596,7 @@
         },
         {
             "id": "35085fce-178f-5ca7-9f2e-e0a7f098b3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be526cd-1480-4661-a05b-e004d7b4656c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be526cd-1480-4661-a05b-e004d7b4656c.jpg?1",
             "name": "Jukai Trainee",
             "text": "Whenever Jukai Trainee blocks or becomes blocked, it gets +1/+1 until end of turn.",
             "colours": [
@@ -7633,7 +7633,7 @@
         },
         {
             "id": "8ceb44a4-1427-5d26-9ee4-f982d3af8b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d038a59-e589-45f4-b5ef-6d2f9875d560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d038a59-e589-45f4-b5ef-6d2f9875d560.jpg?1",
             "name": "Kami of Transience",
             "text": "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on Kami of Transience.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return Kami of Transience from your graveyard to your hand.",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "3323c0b0-b345-5136-89e3-8d268b93685c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a7bc69-4500-4e7e-94e4-67b85597bd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a7bc69-4500-4e7e-94e4-67b85597bd82.jpg?1",
             "name": "Kappa Tech-Wrecker",
             "text": "Ninjutsu {1}{G}\nKappa Tech-Wrecker enters the battlefield with a deathtouch counter on it.\nWhenever Kappa Tech-Wrecker deals combat damage to a player, you may remove a deathtouch counter from it. When you do, exile target artifact or enchantment that player controls.",
             "colours": [
@@ -7707,7 +7707,7 @@
         },
         {
             "id": "c0bf15e5-3e01-5c3b-85fb-f4712afe0e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e1dff-b559-441d-8df3-b6a418066aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef1e1dff-b559-441d-8df3-b6a418066aca.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "Reach\nModified creatures you control have trample. (Equipment, Auras you control, and counters are modifications.)\nWhenever a modified creature you control deals combat damage to a player, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7747,7 +7747,7 @@
         },
         {
             "id": "b76f513b-00c3-57e9-99ad-889643c994c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b25752-26be-4189-bc8b-828db6f0e612.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b25752-26be-4189-bc8b-828db6f0e612.jpg?1",
             "name": "Kura, the Boundless Sky",
             "text": "Flying, deathtouch\nWhen Kura, the Boundless Sky dies, choose one \u2014\n\u2022 Search your library for up to three land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Create an X/X green Spirit creature token, where X is the number of lands you control.",
             "colours": [
@@ -7787,7 +7787,7 @@
         },
         {
             "id": "749a36c5-2621-59a1-ab94-b6adb63e5588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e223d99-408a-413d-abb1-cb2f11ae521d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e223d99-408a-413d-abb1-cb2f11ae521d.jpg?1",
             "name": "March of Burgeoning Life",
             "text": "As an additional cost to cast this spell, you may exile any number of green cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nChoose target creature with mana value less than X. Search your library for a creature card with the same name as that creature, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "41644b59-168e-54c4-aad8-dbd751a57bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42ca7c-5b36-45a9-b235-4f90e66f4377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d42ca7c-5b36-45a9-b235-4f90e66f4377.jpg?1",
             "name": "Master's Rebuke",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "1b70aeea-46af-5704-bbde-8d6308ae33d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736c3278-6ee2-47f9-aab0-1457e90137b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736c3278-6ee2-47f9-aab0-1457e90137b1.jpg?1",
             "name": "Orochi Merge-Keeper",
             "text": "{T}: Add {G}.\nAs long as Orochi Merge-Keeper is modified, it has \"{T}: Add {G}{G}.\" (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -7889,7 +7889,7 @@
         },
         {
             "id": "72f182d1-cbd0-5e34-9d3d-3bf604d0c50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbdd88e-c532-4fc0-a1fe-8aa0c26d1092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbdd88e-c532-4fc0-a1fe-8aa0c26d1092.jpg?1",
             "name": "Roaring Earth",
             "text": "Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature or Vehicle you control.\nChannel \u2014 {X}{G}{G}, Discard Roaring Earth: Put X +1/+1 counters on target land you control. It becomes a 0/0 green Spirit creature with haste. It's still a land.",
             "colours": [
@@ -7921,7 +7921,7 @@
         },
         {
             "id": "9082406e-8a03-591d-8e6d-32abb28e5534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841f0ec2-94c7-4cec-94bb-b365084ca45f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841f0ec2-94c7-4cec-94bb-b365084ca45f.jpg?1",
             "name": "Season of Renewal",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -7953,7 +7953,7 @@
         },
         {
             "id": "feb59d6e-ee2d-5f4f-9f13-1a5e644551ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a16623-7e6d-405b-95db-bf18aeea3f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a16623-7e6d-405b-95db-bf18aeea3f49.jpg?1",
             "name": "Shigeki, Jukai Visionary",
             "text": "{1}{G}, {T}, Return Shigeki, Jukai Visionary to its owner's hand: Reveal the top four cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest into your graveyard.\nChannel \u2014 {X}{X}{G}{G}, Discard Shigeki: Return X target nonlegendary cards from your graveyard to your hand.",
             "colours": [
@@ -7994,7 +7994,7 @@
         },
         {
             "id": "2b9f3c2a-555e-5229-b672-e3defc3e08e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f36ddd7-82c1-45ef-a966-ae2a34c540e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f36ddd7-82c1-45ef-a966-ae2a34c540e1.jpg?1",
             "name": "Spinning Wheel Kick",
             "text": "Target creature you control deals damage equal to its power to each of X target creatures and/or planeswalkers.",
             "colours": [
@@ -8026,7 +8026,7 @@
         },
         {
             "id": "e8340bce-194d-5bf4-a10c-bc5f15bf1c07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1ba9c-ee62-461f-8422-f791274e2f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b1ba9c-ee62-461f-8422-f791274e2f1c.jpg?1",
             "name": "Spring-Leaf Avenger",
             "text": "Ninjutsu {3}{G} ({3}{G}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Spring-Leaf Avenger deals combat damage to a player, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -8064,7 +8064,7 @@
         },
         {
             "id": "f930708f-e4b2-5263-8301-13609541952a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a77eed-aa03-43b7-b3c8-6aee4c96c648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a77eed-aa03-43b7-b3c8-6aee4c96c648.jpg?1",
             "name": "Storyweave",
             "text": "Choose one \u2014\n\u2022 Put two +1/+1 counters on target creature you control.\n\u2022 Put two lore counters on target Saga you control. The next time one or more enchantment creatures enter the battlefield under your control this turn, each enters with two additional +1/+1 counters on it.",
             "colours": [
@@ -8096,7 +8096,7 @@
         },
         {
             "id": "57b9ab73-4bee-5e41-8b23-4e34fe7d157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg?1",
             "name": "Tales of Master Seshiro // Seshiro's Living Legacy",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Put a +1/+1 counter on target creature or Vehicle you control. It gains vigilance until end of turn.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8130,7 +8130,7 @@
         },
         {
             "id": "a8630b25-30f9-54a8-8c52-b21093d723a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/512bc867-3a86-4da2-93f0-dd76d6a6f30d.jpg?1",
             "name": "Tales of Master Seshiro // Seshiro's Living Legacy",
             "text": "Vigilance, haste",
             "colours": [
@@ -8166,7 +8166,7 @@
         },
         {
             "id": "0650fc5d-0edb-50cb-a547-3f177ac3d24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4b7ee2-de65-4288-872d-486065a4f226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd4b7ee2-de65-4288-872d-486065a4f226.jpg?1",
             "name": "Tamiyo's Safekeeping",
             "text": "Target permanent you control gains hexproof and indestructible until end of turn. You gain 2 life.(A permanent with hexproof and indestructible can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "586dc7fe-bcbc-59ba-b234-085ff74f503a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill three cards. Create a 1/1 colorless Spirit creature token.\nII \u2014 Put a +1/+1 counter on target creature you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "b09459b8-a39f-5c42-b1ea-c83b5b91724e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/c/4c0c6c2a-4352-4c65-b41d-2a722bbef6c5.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "Whenever Kirin-Touched Orochi attacks, choose one \u2014\n\u2022 Exile target creature card from a graveyard. When you do, create a 1/1 colorless Spirit creature token.\n\u2022 Exile target noncreature card from a graveyard. When you do, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8274,7 +8274,7 @@
         },
         {
             "id": "c772def6-a5a7-5549-8f72-d47cdb76961b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1682673-e947-44e2-b9c9-cbcb9a16892b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1682673-e947-44e2-b9c9-cbcb9a16892b.jpg?1",
             "name": "Weaver of Harmony",
             "text": "Other enchantment creatures you control get +1/+1.\n{G}, {T}: Copy target activated or triggered ability you control from an enchantment source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
             "colours": [
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "1894d9f2-e0ae-5dc0-adc6-a63fb24fd3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73cc6a7-0a18-488c-b52a-787da95a2e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e73cc6a7-0a18-488c-b52a-787da95a2e6b.jpg?1",
             "name": "Webspinner Cuff",
             "text": "Reach\nEquipped creature gets +1/+4 and has reach.\nReconfigure {4} ({4}: Attach to target creature you control; or unattach from a creature. Reconfigure only as a sorcery. While attached, this isn't a creature.)",
             "colours": [
@@ -8349,7 +8349,7 @@
         },
         {
             "id": "589fa1d7-d898-50de-9c37-b23aaf1f5e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b4e6a-1812-4399-8fe4-bb1686ba49ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b4e6a-1812-4399-8fe4-bb1686ba49ef.jpg?1",
             "name": "Asari Captain",
             "text": "Haste\nWhenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.",
             "colours": [
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "6bd4eeb4-81e7-5393-b579-34a9dfd923ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40bd797-4d12-4098-a1a8-d7e5b7b82ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40bd797-4d12-4098-a1a8-d7e5b7b82ac9.jpg?1",
             "name": "Colossal Skyturtle",
             "text": "Flying, ward {2}\nChannel \u2014 {2}{G}, Discard Colossal Skyturtle: Return target card from your graveyard to your hand.\nChannel \u2014 {1}{U}, Discard Colossal Skyturtle: Return target creature to its owner's hand.",
             "colours": [
@@ -8425,7 +8425,7 @@
         },
         {
             "id": "39ff65f2-0121-5657-bbfc-a1e4c8df04f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35203138-5237-49aa-a335-7a32829548a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35203138-5237-49aa-a335-7a32829548a1.jpg?1",
             "name": "Eiganjo Uprising",
             "text": "Create X 2/2 white Samurai creature tokens with vigilance. They gain menace and haste until end of turn.\nEach opponent creates X minus one 2/2 white Samurai creature tokens with vigilance.",
             "colours": [
@@ -8462,7 +8462,7 @@
         },
         {
             "id": "68b7d0f3-5389-53a6-8578-3815d100ec9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00521f-1b7d-478d-afe8-6761ea512d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00521f-1b7d-478d-afe8-6761ea512d8d.jpg?1",
             "name": "Enthusiastic Mechanaut",
             "text": "Flying\nArtifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "557d0e90-e2d2-5349-b886-e64aba07cbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b50751-7f65-4321-86da-eef735bf8b67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b50751-7f65-4321-86da-eef735bf8b67.jpg?1",
             "name": "Gloomshrieker",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Gloomshrieker enters the battlefield, return target permanent card from your graveyard to your hand.\nIf Gloomshrieker would die, exile it instead.",
             "colours": [
@@ -8540,7 +8540,7 @@
         },
         {
             "id": "5cff0b8e-ae7e-5489-887a-5f58af8a2c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a0d43b-4d38-40a7-be6c-8324ab3bf773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a0d43b-4d38-40a7-be6c-8324ab3bf773.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "At the beginning of combat on your turn, return target Vehicle card from your graveyard to the battlefield. It gains haste. Return it to its owner's hand at the beginning of your next end step.",
             "colours": [
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "fde7c235-495e-5277-93db-b22522cdcd5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Destroy each nonland permanent with mana value 1 or less.\nII \u2014 Exile all graveyards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8621,7 +8621,7 @@
         },
         {
             "id": "5dccaf2a-e203-5d82-b91c-eb2fdb559eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e910464-329a-4de1-930a-be85b1956676.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "Trample\nWhenever Vessel of the All-Consuming deals damage, put a +1/+1 counter on it.\nWhenever Vessel of the All-Consuming deals damage to a player, if it has dealt 10 or more damage to that player this turn, they lose the game.",
             "colours": [
@@ -8662,7 +8662,7 @@
         },
         {
             "id": "855600e3-71d8-5dc2-89bb-7785dce3c47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25aff90-56fd-4f70-bb3b-cabf2900c391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25aff90-56fd-4f70-bb3b-cabf2900c391.jpg?1",
             "name": "Hinata, Dawn-Crowned",
             "text": "Flying, trample\nSpells you cast cost {1} less to cast for each target.\nSpells your opponents cast cost {1} more to cast for each target.",
             "colours": [
@@ -8706,7 +8706,7 @@
         },
         {
             "id": "0073008c-2bf2-52a3-9093-6a39d3e01f9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a118d1-30b8-42c0-ac42-6fba0778200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a118d1-30b8-42c0-ac42-6fba0778200a.jpg?1",
             "name": "Invigorating Hot Spring",
             "text": "Invigorating Hot Spring enters the battlefield with four +1/+1 counters on it.\nModified creatures you control have haste. (Equipment, Auras you control, and counters are modifications.)\nRemove a +1/+1 counter from Invigorating Hot Spring: Put a +1/+1 counter on target creature you control. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -8740,7 +8740,7 @@
         },
         {
             "id": "6223bd64-f295-50f2-97db-1e17f6ba99b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062a004-984e-4b62-960c-af7288f7a3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a062a004-984e-4b62-960c-af7288f7a3e9.jpg?1",
             "name": "Isshin, Two Heavens as One",
             "text": "If a creature attacking causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "54471ea2-f563-5892-b211-e4f6b912f4de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5366900b-2abf-4e5c-8507-f51aca9c7ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5366900b-2abf-4e5c-8507-f51aca9c7ce8.jpg?1",
             "name": "Jukai Naturalist",
             "text": "Lifelink\nEnchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -8824,7 +8824,7 @@
         },
         {
             "id": "2afa6690-ec57-5501-8659-4b11ce8b35e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d35a710-3008-4e27-8afd-6e83329f9917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d35a710-3008-4e27-8afd-6e83329f9917.jpg?1",
             "name": "Kaito Shizuki",
             "text": "At the beginning of your end step, if Kaito Shizuki entered the battlefield this turn, he phases out.\n+1: Draw a card. Then discard a card unless you attacked this turn.\n\u22122: Create a 1/1 blue Ninja creature token with \"This creature can't be blocked.\"\n\u22127: You get an emblem with \"Whenever a creature you control deals combat damage to a player, search your library for a blue or black creature card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -8866,7 +8866,7 @@
         },
         {
             "id": "5760a74f-8685-58df-9ec5-74a28e17b372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile target nonland permanent an opponent controls.\nII \u2014 Return up to one other target nonland permanent to its owner's hand. Then each opponent discards a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "edcb8ea4-c961-52d4-a188-82abc60481f7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/36052532-5028-43a8-9fc4-56221ec867fd.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "O-Kagachi Made Manifest is all colors.\nFlying, trample\nWhenever O-Kagachi Made Manifest attacks, defending player chooses a nonland card in your graveyard. Return that card to your hand. O-Kagachi Made Manifest gets +X/+0 until end of turn, where X is the mana value of that card.",
             "colours": [
@@ -8958,7 +8958,7 @@
         },
         {
             "id": "1451bc53-9193-580d-b163-0e2b5a59d08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e97b5-cd43-4f5e-acdd-a107208e061c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314e97b5-cd43-4f5e-acdd-a107208e061c.jpg?1",
             "name": "Kotose, the Silent Spider",
             "text": "When Kotose, the Silent Spider enters the battlefield, exile target card other than a basic land card from an opponent's graveyard. Search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles. For as long as you control Kotose, you may play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -9000,7 +9000,7 @@
         },
         {
             "id": "c6146703-5caa-58d3-a181-64d3e657dfc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4400fd66-1a24-47fb-bc94-37e0aae0e610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4400fd66-1a24-47fb-bc94-37e0aae0e610.jpg?1",
             "name": "Naomi, Pillar of Order",
             "text": "Whenever Naomi, Pillar of Order enters the battlefield or attacks, if you control an artifact and an enchantment, create a 2/2 white Samurai creature token with vigilance.",
             "colours": [
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "8b72d531-3261-52dc-843c-e529be89c696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84db1e2-855c-4169-a9cc-a54c73c14e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84db1e2-855c-4169-a9cc-a54c73c14e0c.jpg?1",
             "name": "Oni-Cult Anvil",
             "text": "Whenever one or more artifacts you control leave the battlefield during your turn, create a 1/1 colorless Construct artifact creature token. This ability triggers only once each turn.\n{T}, Sacrifice an artifact: Oni-Cult Anvil deals 1 damage to each opponent. You gain 1 life.",
             "colours": [
@@ -9073,7 +9073,7 @@
         },
         {
             "id": "bae38a34-14ae-52a3-bc39-6b238cbcaf65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be046e0a-6509-450b-b34f-29d5a5e3472e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be046e0a-6509-450b-b34f-29d5a5e3472e.jpg?1",
             "name": "Prodigy's Prototype",
             "text": "Whenever one or more Vehicles you control attack, create a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "7749b2bd-fe9d-54d3-8686-407635b8eba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37748b74-0eda-4b20-a08f-faa418adb9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37748b74-0eda-4b20-a08f-faa418adb9ff.jpg?1",
             "name": "Raiyuu, Storm's Edge",
             "text": "First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "colours": [
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "a78817be-d624-5a64-a119-934d751042af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8f1fa-ca92-4e2e-91e8-195bdad82def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d8f1fa-ca92-4e2e-91e8-195bdad82def.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "Haste\nWhenever Risona, Asari Commander deals combat damage to a player, if it doesn't have an indestructible counter on it, put an indestructible counter on it.\nWhenever combat damage is dealt to you, remove an indestructible counter from Risona.",
             "colours": [
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "a9a1963b-b751-5de7-98b6-47de633f79f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8887f26d-b097-4fbc-9c48-bdc656409a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8887f26d-b097-4fbc-9c48-bdc656409a32.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -9238,7 +9238,7 @@
         },
         {
             "id": "04e88882-2e45-5a21-b836-1d1ff79a1a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0152575b-31b0-4142-9cc2-b87a81bd51a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0152575b-31b0-4142-9cc2-b87a81bd51a8.jpg?1",
             "name": "Satsuki, the Living Lore",
             "text": "{T}: Put a lore counter on each Saga you control. Activate only as a sorcery.\nWhen Satsuki, the Living Lore dies, choose up to one \u2014\n\u2022 Return target Saga or enchantment creature you control to its owner's hand.\n\u2022 Return target Saga card from your graveyard to your hand.",
             "colours": [
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "e472aa7d-bf2c-50ea-bc04-7c44ff7b6c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacc36d9-4c4b-43b2-a8b4-d265deb1e6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cacc36d9-4c4b-43b2-a8b4-d265deb1e6b2.jpg?1",
             "name": "Silver-Fur Master",
             "text": "Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.",
             "colours": [
@@ -9320,7 +9320,7 @@
         },
         {
             "id": "d5e3f668-af8f-5974-a5a6-ac067de534db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f094735f-5843-4f75-bc90-3e248a061a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f094735f-5843-4f75-bc90-3e248a061a43.jpg?1",
             "name": "Spirit-Sister's Call",
             "text": "At the beginning of your end step, choose target permanent card in your graveyard. You may sacrifice a permanent that shares a card type with the chosen card. If you do, return the chosen card from your graveyard to the battlefield and it gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\"",
             "colours": [
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "59c7f473-c87a-5758-90e9-425b454075c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222a736e-d819-452d-aeda-eb848c4b2302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/222a736e-d819-452d-aeda-eb848c4b2302.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "Compleated ({Variable} can be paid with {G}, {U}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Tap up to one target artifact or creature. It doesn't untap during its controller's next untap step.\n\u2212X: Exile target nonland permanent card with mana value X from your graveyard. Create a token that's a copy of that card.\n\u22127: Create Tamiyo's Notebook, a legendary colorless artifact token with \"Spells you cast cost {2} less to cast\" and \"{T}: Draw a card.\"",
             "colours": [
@@ -9399,7 +9399,7 @@
         },
         {
             "id": "0244d788-e8f9-5630-9715-5886fd6745bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c30ffb-b4f5-40b0-87b8-800a42bded2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c30ffb-b4f5-40b0-87b8-800a42bded2b.jpg?1",
             "name": "Automated Artificer",
             "text": "{T}: Add {C}. Spend this mana only to activate an ability or cast an artifact spell.",
             "colours": [],
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "6325be0f-7169-5ca6-a777-0eddbac9d5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fa226c-cc31-4c22-a167-40985706557b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fa226c-cc31-4c22-a167-40985706557b.jpg?1",
             "name": "Bronze Cudgels",
             "text": "{2}: Until end of turn, equipped creature gets +X/+0, where X is the number of times this ability has resolved this turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9460,7 +9460,7 @@
         },
         {
             "id": "a0c910c9-9d64-5381-afcf-5fdb5a7ea452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cb43a-e358-4380-a42f-9b095ca522c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363cb43a-e358-4380-a42f-9b095ca522c6.jpg?1",
             "name": "Brute Suit",
             "text": "Vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9490,7 +9490,7 @@
         },
         {
             "id": "f5b7605d-ef20-50ca-8511-cace967423cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg?1",
             "name": "Circuit Mender",
             "text": "When Circuit Mender enters the battlefield, you gain 2 life.\nWhen Circuit Mender leaves the battlefield, draw a card.",
             "colours": [],
@@ -9521,7 +9521,7 @@
         },
         {
             "id": "48b77764-6400-5d92-8cc0-11ca0aa758fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520e5505-429b-4da0-b25e-14b8d4e81ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520e5505-429b-4da0-b25e-14b8d4e81ce3.jpg?1",
             "name": "Containment Construct",
             "text": "Whenever you discard a card, you may exile that card from your graveyard. If you do, you may play that card this turn.",
             "colours": [],
@@ -9552,7 +9552,7 @@
         },
         {
             "id": "5d5aff94-224a-593d-8ddc-fc79a9f36195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b490e065-b54a-4015-9768-d0e62f0e2e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b490e065-b54a-4015-9768-d0e62f0e2e84.jpg?1",
             "name": "Dramatist's Puppet",
             "text": "When Dramatist's Puppet enters the battlefield, for each kind of counter on target permanent, put another counter of that kind on it or remove one from it.",
             "colours": [],
@@ -9583,7 +9583,7 @@
         },
         {
             "id": "ce32b5eb-7028-569e-bb05-0e1f4a9eb054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d92077-d7b2-4996-848f-fd4917e2fb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d92077-d7b2-4996-848f-fd4917e2fb42.jpg?1",
             "name": "Eater of Virtue",
             "text": "Whenever equipped creature dies, exile it.\nEquipped creature gets +2/+0.\nAs long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.\nEquip {1}",
             "colours": [],
@@ -9618,7 +9618,7 @@
         },
         {
             "id": "b35452ee-5e44-5ba2-8a24-bb49f9914462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d981026-b2df-4d8d-a9b4-296b011d9925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d981026-b2df-4d8d-a9b4-296b011d9925.jpg?1",
             "name": "Ecologist's Terrarium",
             "text": "When Ecologist's Terrarium enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{2}, {T}, Sacrifice Ecologist's Terrarium: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [],
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "28af4320-3185-5893-a9b8-e2872012c5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c619116-1eae-439d-9b1f-639643458a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c619116-1eae-439d-9b1f-639643458a23.jpg?1",
             "name": "High-Speed Hoverbike",
             "text": "Flash\nFlying\nWhen High-Speed Hoverbike enters the battlefield, tap up to one target creature.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -9676,7 +9676,7 @@
         },
         {
             "id": "f6b2d2b8-649a-5692-8bbd-66979aab78c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6d9fc-509b-42db-8ac1-85066eb6e9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6d9fc-509b-42db-8ac1-85066eb6e9c4.jpg?1",
             "name": "Iron Apprentice",
             "text": "Iron Apprentice enters the battlefield with a +1/+1 counter on it.\nWhen Iron Apprentice dies, if it had counters on it, put those counters on target creature you control.",
             "colours": [],
@@ -9707,7 +9707,7 @@
         },
         {
             "id": "6284e544-335d-5c6d-bd65-3b6585e4f19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca286ba9-01a7-4dce-b388-177f5dcb95b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca286ba9-01a7-4dce-b388-177f5dcb95b1.jpg?1",
             "name": "Mechtitan Core",
             "text": "{5}, Exile Mechtitan Core and four other artifact creatures and/or Vehicles you control: Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors. When that token leaves the battlefield, return all cards exiled with Mechtitan Core except Mechtitan Core to the battlefield tapped under their owners' control.\nCrew 2",
             "colours": [],
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "ee311e6d-2cce-543c-835d-cedcdc86442a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d507daa3-3f16-4ab1-81ea-794e5bb488fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d507daa3-3f16-4ab1-81ea-794e5bb488fc.jpg?1",
             "name": "Mirror Box",
             "text": "The \"legend rule\" doesn't apply to permanents you control.\nEach legendary creature you control gets +1/+1.\nEach nontoken creature you control gets +1/+1 for each other creature you control with the same name as that creature.",
             "colours": [],
@@ -9771,7 +9771,7 @@
         },
         {
             "id": "fff966b5-e4fa-5ddb-ab33-501ab3701a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61e596f-97ef-4eb3-af42-ddfe50d07667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61e596f-97ef-4eb3-af42-ddfe50d07667.jpg?1",
             "name": "Network Terminal",
             "text": "{T}: Add one mana of any color.\n{1}, {T}, Tap another untapped artifact you control: Draw a card, then discard a card.",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "b918c3d0-4e46-5500-93d1-4a7985a39d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6ae567-c77a-416a-b609-4df3d0dd2e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6ae567-c77a-416a-b609-4df3d0dd2e18.jpg?1",
             "name": "Ninja's Kunai",
             "text": "Equipped creature has \"{1}, {T}, Sacrifice Ninja's Kunai: Ninja's Kunai deals 3 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9829,7 +9829,7 @@
         },
         {
             "id": "4789bf41-10d8-5c91-bd78-28acd11589d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3453084c-42cc-4241-b244-c79e704f96c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3453084c-42cc-4241-b244-c79e704f96c8.jpg?1",
             "name": "Papercraft Decoy",
             "text": "When Papercraft Decoy leaves the battlefield, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -9860,7 +9860,7 @@
         },
         {
             "id": "8c29e511-490a-5d27-89ab-4fc3759d2d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e1580-dd26-4f4b-ac98-3e6fa7b879d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4e1580-dd26-4f4b-ac98-3e6fa7b879d5.jpg?1",
             "name": "Patchwork Automaton",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhenever you cast an artifact spell, put a +1/+1 counter on Patchwork Automaton.",
             "colours": [],
@@ -9891,7 +9891,7 @@
         },
         {
             "id": "55b5864a-8d81-55b5-bfd6-c927e0c380d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279acd17-6c17-427b-a69d-fc02442ff4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/279acd17-6c17-427b-a69d-fc02442ff4a3.jpg?1",
             "name": "Reckoner Bankbuster",
             "text": "Reckoner Bankbuster enters the battlefield with three charge counters on it.\n{2}, {T}, Remove a charge counter from Reckoner Bankbuster: Draw a card. Then if there are no charge counters on Reckoner Bankbuster, create a Treasure token and a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 3",
             "colours": [],
@@ -9924,7 +9924,7 @@
         },
         {
             "id": "33eb8f7b-c2ed-5803-a748-90cbe2007c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0218923a-b685-4492-8fdd-2d2d22ef532e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0218923a-b685-4492-8fdd-2d2d22ef532e.jpg?1",
             "name": "Reito Sentinel",
             "text": "Defender\nWhen Reito Sentinel enters the battlefield, target player mills three cards. (They put the top three cards of their library into their graveyard.)\n{3}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "fd04376c-52ff-50bd-a9bf-1814e4a74580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eebf6a6-f1fd-40a1-ac27-367deafa6f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eebf6a6-f1fd-40a1-ac27-367deafa6f2a.jpg?1",
             "name": "Runaway Trash-Bot",
             "text": "Trample\nRunaway Trash-Bot gets +1/+0 for each artifact and/or enchantment card in your graveyard.",
             "colours": [],
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "e0d61bc4-1eaf-501c-9729-f580ad9c5865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79b30e-e7aa-490e-b130-de7533e6e13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b79b30e-e7aa-490e-b130-de7533e6e13b.jpg?1",
             "name": "Searchlight Companion",
             "text": "Flying\nWhen Searchlight Companion enters the battlefield, create a 1/1 colorless Spirit creature token.",
             "colours": [],
@@ -10017,7 +10017,7 @@
         },
         {
             "id": "2e4d2a3d-ae3c-59cd-adc5-f61199df48dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e8d71c-3a0b-4042-a0f7-e99e92a79dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75e8d71c-3a0b-4042-a0f7-e99e92a79dc2.jpg?1",
             "name": "Shrine Steward",
             "text": "When Shrine Steward enters the battlefield, you may search your library for an Aura or Shrine card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "20311449-033b-559f-8c30-e2effa40edc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4bf679-01cc-4786-a3bd-89c8ae70fdfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4bf679-01cc-4786-a3bd-89c8ae70fdfa.jpg?1",
             "name": "Surgehacker Mech",
             "text": "Menace\nWhen Surgehacker Mech enters the battlefield, it deals damage equal to twice the number of Vehicles you control to target creature or planeswalker an opponent controls.\nCrew 4",
             "colours": [],
@@ -10081,7 +10081,7 @@
         },
         {
             "id": "8afb204e-c442-54b9-a950-1bfa3d481814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d49f9c-2dd3-4aed-9b78-e1bcad354a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d49f9c-2dd3-4aed-9b78-e1bcad354a35.jpg?1",
             "name": "Thundersteel Colossus",
             "text": "Trample, haste\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -10111,7 +10111,7 @@
         },
         {
             "id": "e4cf0817-f1a1-57ca-9e3c-ccfb05d029ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ccf70-b661-46ea-bea9-4466a3a35562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ccf70-b661-46ea-bea9-4466a3a35562.jpg?1",
             "name": "Towashi Guide-Bot",
             "text": "When Towashi Guide-Bot enters the battlefield, put a +1/+1 counter on target creature you control.\n{4}, {T}: Draw a card. This ability costs {1} less to activate for each modified creature you control. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "734519a1-6376-5e53-af5e-74a74fa3c835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958af4ba-f29e-47ef-995e-3985982c75ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958af4ba-f29e-47ef-995e-3985982c75ad.jpg?1",
             "name": "Walking Skyscraper",
             "text": "This spell costs {1} less to cast for each modified creature you control. (Equipment, Auras you control, and counters are modifications.)\nTrample\nWalking Skyscraper has hexproof as long as it's untapped. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [],
@@ -10173,7 +10173,7 @@
         },
         {
             "id": "5765ecef-a549-5979-bb23-fa08ac10da49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba06fcda-7ab8-48d4-8656-2a911e73dc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba06fcda-7ab8-48d4-8656-2a911e73dc44.jpg?1",
             "name": "Bloodfell Caves",
             "text": "Bloodfell Caves enters the battlefield tapped.\nWhen Bloodfell Caves enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -10204,7 +10204,7 @@
         },
         {
             "id": "562b232a-13a5-562f-b04c-624eab33adc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290ec6b-15a6-49e8-abd2-b8c4d0f556eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290ec6b-15a6-49e8-abd2-b8c4d0f556eb.jpg?1",
             "name": "Blossoming Sands",
             "text": "Blossoming Sands enters the battlefield tapped.\nWhen Blossoming Sands enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "8f6e5033-fdb3-502c-85fc-ee71d77cbbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2135ac5a-187b-4dc9-8f82-34e8d1603416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2135ac5a-187b-4dc9-8f82-34e8d1603416.jpg?1",
             "name": "Boseiju, Who Endures",
             "text": "{T}: Add {G}.\nChannel \u2014 {1}{G}, Discard Boseiju, Who Endures: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "c6c88f02-ee95-57de-bbb6-62fdfc855cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab0660b-81f8-40ca-8098-5f8d51219a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab0660b-81f8-40ca-8098-5f8d51219a40.jpg?1",
             "name": "Dismal Backwater",
             "text": "Dismal Backwater enters the battlefield tapped.\nWhen Dismal Backwater enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -10301,7 +10301,7 @@
         },
         {
             "id": "a3c9ce9d-c5e6-567e-a475-19240c6bff28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375a022-5b57-496d-a802-e4ea8376e9e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c375a022-5b57-496d-a802-e4ea8376e9e4.jpg?1",
             "name": "Eiganjo, Seat of the Empire",
             "text": "{T}: Add {W}.\nChannel \u2014 {2}{W}, Discard Eiganjo, Seat of the Empire: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10336,7 +10336,7 @@
         },
         {
             "id": "6aa5e279-721e-5d86-9c46-9304119e2701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadca61-0be9-4eeb-ba12-bc73a49bae74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deadca61-0be9-4eeb-ba12-bc73a49bae74.jpg?1",
             "name": "Jungle Hollow",
             "text": "Jungle Hollow enters the battlefield tapped.\nWhen Jungle Hollow enters the battlefield, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "2205f8d9-50bc-5dc5-bf0f-ca433862aabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c093984d-38cd-4b49-b179-1e289ab442d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c093984d-38cd-4b49-b179-1e289ab442d1.jpg?1",
             "name": "Mech Hangar",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Pilot or Vehicle spell.\n{3}, {T}: Target Vehicle becomes an artifact creature until end of turn.",
             "colours": [],
@@ -10395,7 +10395,7 @@
         },
         {
             "id": "f25d25fe-48bf-51c9-9b29-bedd6975f4e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486d7edc-d983-41f0-8b78-c99aecd72996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486d7edc-d983-41f0-8b78-c99aecd72996.jpg?1",
             "name": "Otawara, Soaring City",
             "text": "{T}: Add {U}.\nChannel \u2014 {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10430,7 +10430,7 @@
         },
         {
             "id": "a626eb95-5182-5111-8005-6b22aa5819e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8002de90-93fb-48ea-a849-40fdad0aef5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8002de90-93fb-48ea-a849-40fdad0aef5a.jpg?1",
             "name": "Roadside Reliquary",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Roadside Reliquary: Draw a card if you control an artifact. Draw a card if you control an enchantment.",
             "colours": [],
@@ -10458,7 +10458,7 @@
         },
         {
             "id": "e7ff6285-f9f2-559b-b0a7-727cea209b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d511be-60e0-4755-abec-18eebb530605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d511be-60e0-4755-abec-18eebb530605.jpg?1",
             "name": "Rugged Highlands",
             "text": "Rugged Highlands enters the battlefield tapped.\nWhen Rugged Highlands enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -10489,7 +10489,7 @@
         },
         {
             "id": "297590d9-2601-5722-93b5-e2e579e2170b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00538414-90f3-41da-b67e-d81cfa643de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00538414-90f3-41da-b67e-d81cfa643de3.jpg?1",
             "name": "Scoured Barrens",
             "text": "Scoured Barrens enters the battlefield tapped.\nWhen Scoured Barrens enters the battlefield, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10520,7 +10520,7 @@
         },
         {
             "id": "0a6cef69-ab9a-5545-b810-afb8ec9a973b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As Secluded Courtyard enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature or creature card of the chosen type.",
             "colours": [],
@@ -10550,7 +10550,7 @@
         },
         {
             "id": "c4e84811-f488-55b2-9b01-5ae741f9e040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa548dcd-c1dd-492d-a69f-c65dfeef0633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa548dcd-c1dd-492d-a69f-c65dfeef0633.jpg?1",
             "name": "Sokenzan, Crucible of Defiance",
             "text": "{T}: Add {R}.\nChannel \u2014 {3}{R}, Discard Sokenzan, Crucible of Defiance: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10585,7 +10585,7 @@
         },
         {
             "id": "afbc6770-154e-5f40-8a1b-de219d1211e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6c2670-e6fd-40d6-afe0-7d3c4db96a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6c2670-e6fd-40d6-afe0-7d3c4db96a4d.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "Swiftwater Cliffs enters the battlefield tapped.\nWhen Swiftwater Cliffs enters the battlefield, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10616,7 +10616,7 @@
         },
         {
             "id": "62c39db2-afee-518e-ad3c-c2ffb7abba5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499037cc-a577-41cb-8ca2-5e117945634f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499037cc-a577-41cb-8ca2-5e117945634f.jpg?1",
             "name": "Takenuma, Abandoned Mire",
             "text": "{T}: Add {B}.\nChannel \u2014 {3}{B}, Discard Takenuma, Abandoned Mire: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "d897313e-25e5-5e3d-8708-30d4c7257a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5af3569-3e66-4a50-aca0-c17c799dca28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5af3569-3e66-4a50-aca0-c17c799dca28.jpg?1",
             "name": "Thornwood Falls",
             "text": "Thornwood Falls enters the battlefield tapped.\nWhen Thornwood Falls enters the battlefield, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10682,7 +10682,7 @@
         },
         {
             "id": "cbf34a82-8d75-51fe-85f7-53ade371bf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f822b7-efc5-42c8-93ea-7dd17b4c3e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f822b7-efc5-42c8-93ea-7dd17b4c3e7a.jpg?1",
             "name": "Tranquil Cove",
             "text": "Tranquil Cove enters the battlefield tapped.\nWhen Tranquil Cove enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "2707b022-d12f-5e19-87e7-b5c6227e0bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4ad89a-3a00-4bf4-a357-4a8a089d4a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4ad89a-3a00-4bf4-a357-4a8a089d4a82.jpg?1",
             "name": "Uncharted Haven",
             "text": "Uncharted Haven enters the battlefield tapped.\nAs Uncharted Haven enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -10741,7 +10741,7 @@
         },
         {
             "id": "7fa83775-f18c-5349-a396-da973b307805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b1d47-11ef-4f06-94b2-94b6727de3bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b1d47-11ef-4f06-94b2-94b6727de3bd.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "Wind-Scarred Crag enters the battlefield tapped.\nWhen Wind-Scarred Crag enters the battlefield, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10772,7 +10772,7 @@
         },
         {
             "id": "a8902146-7c93-5751-82fa-c6b173148645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc26aa1-58b9-41b5-95b4-7e9bf2309b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc26aa1-58b9-41b5-95b4-7e9bf2309b54.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10810,7 +10810,7 @@
         },
         {
             "id": "684d2321-ac91-5441-a82a-7f5e7a99fcdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db21784-e56b-46bd-97a4-3770f2ef5caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db21784-e56b-46bd-97a4-3770f2ef5caf.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10848,7 +10848,7 @@
         },
         {
             "id": "e067f68b-0df4-5e4b-ba4e-7f4da4832a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66d573-5da4-4b3c-ab06-bb330cff2c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66d573-5da4-4b3c-ab06-bb330cff2c9a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10886,7 +10886,7 @@
         },
         {
             "id": "f79d5937-5ee7-5d23-add6-ac6ed3ea27c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae091d-8bd3-44d0-a083-6b4078303bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae091d-8bd3-44d0-a083-6b4078303bc3.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10924,7 +10924,7 @@
         },
         {
             "id": "a9f90e47-e47c-542e-b018-608beb4174f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f7492c-67f2-4ba3-848b-7a6a8df7e88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f7492c-67f2-4ba3-848b-7a6a8df7e88b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10962,7 +10962,7 @@
         },
         {
             "id": "20ec4bcf-47d1-5cea-b18e-7449b7f090df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfebc79-5d84-4ce5-8bff-d09fe333f4a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfebc79-5d84-4ce5-8bff-d09fe333f4a3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11000,7 +11000,7 @@
         },
         {
             "id": "d3bf1756-9dec-521f-88db-f06fca315045",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe601b0-0398-47f0-9e4f-9f841ad79b9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe601b0-0398-47f0-9e4f-9f841ad79b9b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11038,7 +11038,7 @@
         },
         {
             "id": "182c88fe-257b-57e0-9cfc-e6210569b3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8489c0-b01c-466e-b33b-239406d7ea69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8489c0-b01c-466e-b33b-239406d7ea69.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11076,7 +11076,7 @@
         },
         {
             "id": "8edbcf7d-2715-57e3-b34e-1e64b3fca0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea5c36b-c107-4daf-bedb-507b4cd64724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea5c36b-c107-4daf-bedb-507b4cd64724.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11114,7 +11114,7 @@
         },
         {
             "id": "ce189568-fdd4-5fcc-8c72-9ef3072ed2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17db23-a8ca-416e-b978-1eae852c6690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e17db23-a8ca-416e-b978-1eae852c6690.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11152,7 +11152,7 @@
         },
         {
             "id": "822705d0-4c39-5701-919a-bd0f74d59f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8fb179-7e81-4b20-8b81-ea1aa97afe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8fb179-7e81-4b20-8b81-ea1aa97afe58.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11190,7 +11190,7 @@
         },
         {
             "id": "fa297a82-aff5-51af-b12f-617697a59dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a76d8ee-28fc-49ac-951c-a4d29822f91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a76d8ee-28fc-49ac-951c-a4d29822f91e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11228,7 +11228,7 @@
         },
         {
             "id": "cf74a84a-1f1c-5aac-a49d-530cb05224db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0578f26-1396-4e1d-9986-8fc6c55aeb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0578f26-1396-4e1d-9986-8fc6c55aeb66.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11266,7 +11266,7 @@
         },
         {
             "id": "19a31a18-1d66-585b-b145-e638345ffad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132999f-6e2d-4689-8131-7b12076a348d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132999f-6e2d-4689-8131-7b12076a348d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11304,7 +11304,7 @@
         },
         {
             "id": "1679f14d-7893-50dd-be2e-898cd7cc617d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50b3d79-2361-4858-98b0-64d83c4f7f70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c50b3d79-2361-4858-98b0-64d83c4f7f70.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11342,7 +11342,7 @@
         },
         {
             "id": "3010da25-e2f9-57c5-af01-e92b2b41313d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ef531e-2a8f-4d40-b509-92e3a86b2257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ef531e-2a8f-4d40-b509-92e3a86b2257.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "bf38abc3-a3c0-5ecc-b05a-6752124777ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd5953-37fc-4a8a-89f8-0b5dd8412dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd5953-37fc-4a8a-89f8-0b5dd8412dc9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11418,7 +11418,7 @@
         },
         {
             "id": "1e079185-018b-52de-912d-60ac49412cbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d75969d-c932-4b4e-8135-61968228bc32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d75969d-c932-4b4e-8135-61968228bc32.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11456,7 +11456,7 @@
         },
         {
             "id": "477f3189-5c2e-5a77-985d-538a62b2e616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc778ae-a2d0-493f-963d-e946bd7cacd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc778ae-a2d0-493f-963d-e946bd7cacd9.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11494,7 +11494,7 @@
         },
         {
             "id": "d24e9cf2-c35c-5ad5-b9a1-5ccf9e278205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8179106-e5d7-457a-9250-70df980b38ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8179106-e5d7-457a-9250-70df980b38ce.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "14c66c62-1dae-52f5-9bbf-925bf67249dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71327818-2784-4fde-8e19-ef8677694a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71327818-2784-4fde-8e19-ef8677694a5f.jpg?1",
             "name": "The Wandering Emperor",
             "text": "Flash\nAs long as The Wandering Emperor entered the battlefield this turn, you may activate her loyalty abilities any time you could cast an instant.\n+1: Put a +1/+1 counter on up to one target creature. It gains first strike until end of turn.\n\u22121: Create a 2/2 white Samurai creature token with vigilance.\n\u22122: Exile target tapped creature. You gain 2 life.",
             "colours": [
@@ -11570,7 +11570,7 @@
         },
         {
             "id": "2385db1a-fc37-564b-a4e6-9889da682a3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc079b5-291d-466e-9f1b-baaf1079637b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc079b5-291d-466e-9f1b-baaf1079637b.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "The first activated ability of an artifact you activate each turn costs {2} less to activate.\n+1: Draw two cards. Then discard two cards unless you discard an artifact card.\n\u22122: Target artifact becomes an artifact creature. If it isn't a Vehicle, it has base power and toughness 4/4.\n\u22126: You get an emblem with \"Whenever an artifact you control becomes tapped, draw a card.\"",
             "colours": [
@@ -11610,7 +11610,7 @@
         },
         {
             "id": "4dd59a99-6088-510a-a841-14987a235670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106e4cc-f3fc-41bf-ab1c-4ae7c1a0521c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e106e4cc-f3fc-41bf-ab1c-4ae7c1a0521c.jpg?1",
             "name": "Kaito Shizuki",
             "text": "At the beginning of your end step, if Kaito Shizuki entered the battlefield this turn, he phases out.\n+1: Draw a card. Then discard a card unless you attacked this turn.\n\u22122: Create a 1/1 blue Ninja creature token with \"This creature can't be blocked.\"\n\u22127: You get an emblem with \"Whenever a creature you control deals combat damage to a player, search your library for a blue or black creature card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "e8e365fb-f5f3-5cc6-9b5e-8fae6cc95fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5898a9c4-c983-4807-af06-18111702ab59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5898a9c4-c983-4807-af06-18111702ab59.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "Compleated ({Variable} can be paid with {G}, {U}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Tap up to one target artifact or creature. It doesn't untap during its controller's next untap step.\n\u2212X: Exile target nonland permanent card with mana value X from your graveyard. Create a token that's a copy of that card.\n\u22127: Create Tamiyo's Notebook, a legendary colorless artifact token with \"Spells you cast cost {2} less to cast\" and \"{T}: Draw a card.\"",
             "colours": [
@@ -11694,7 +11694,7 @@
         },
         {
             "id": "be84b7d9-3a07-5680-90b6-c36c262a093c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855ca31-842e-4962-a5f0-163a3f833784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8855ca31-842e-4962-a5f0-163a3f833784.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn. (A copy of a permanent spell becomes a token.)\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -11738,7 +11738,7 @@
         },
         {
             "id": "8f71630d-0a76-5925-9ea2-916d3178cba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16028f-25d0-4817-b20e-8b390b80ef35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16028f-25d0-4817-b20e-8b390b80ef35.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "Compleated ({Variable} can be paid with {G}, {U}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Tap up to one target artifact or creature. It doesn't untap during its controller's next untap step.\n\u2212X: Exile target nonland permanent card with mana value X from your graveyard. Create a token that's a copy of that card.\n\u22127: Create Tamiyo's Notebook, a legendary colorless artifact token with \"Spells you cast cost {2} less to cast\" and \"{T}: Draw a card.\"",
             "colours": [
@@ -11780,7 +11780,7 @@
         },
         {
             "id": "11682101-db7b-508d-8153-16b0d94051ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85917c-60ea-44d3-8483-fa639564e881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c85917c-60ea-44d3-8483-fa639564e881.jpg?1",
             "name": "Eiganjo Exemplar",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.",
             "colours": [
@@ -11818,7 +11818,7 @@
         },
         {
             "id": "a3eb3065-37fc-5d7c-ac7b-60326ff77ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e7420e-55d0-4f4b-84bb-e5b86616cbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e7420e-55d0-4f4b-84bb-e5b86616cbb3.jpg?1",
             "name": "Imperial Subduer",
             "text": "Whenever a Samurai or Warrior you control attacks alone, tap target creature you don't control.",
             "colours": [
@@ -11855,7 +11855,7 @@
         },
         {
             "id": "85eaf070-e4c9-5e28-bf1f-f9e405737920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344df5c2-a963-42e3-b61b-1712f15e1eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344df5c2-a963-42e3-b61b-1712f15e1eb9.jpg?1",
             "name": "Norika Yamazaki, the Poet",
             "text": "Vigilance\nWhenever a Samurai or Warrior you control attacks alone, you may cast target enchantment card from your graveyard this turn.",
             "colours": [
@@ -11894,7 +11894,7 @@
         },
         {
             "id": "4f445e55-50ab-553c-aa14-4e3e0ed1b464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1ade5-06ff-41ab-9a68-bf901959b01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f1ade5-06ff-41ab-9a68-bf901959b01f.jpg?1",
             "name": "Selfless Samurai",
             "text": "Whenever a Samurai or Warrior you control attacks alone, it gains lifelink until end of turn.\nSacrifice Selfless Samurai: Another target creature you control gains indestructible until end of turn.",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "c055b489-9651-5b76-86c6-14d16247b2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267efff1-cbe6-40b0-959e-72b81cbda1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267efff1-cbe6-40b0-959e-72b81cbda1d0.jpg?1",
             "name": "Seven-Tail Mentor",
             "text": "When Seven-Tail Mentor enters the battlefield or dies, put a +1/+1 counter on target creature or Vehicle you control.",
             "colours": [
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "e6fa1ffc-1bb1-5855-accf-46352ae9da7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d6a843-a1b7-4862-a2bf-8f8f66788126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91d6a843-a1b7-4862-a2bf-8f8f66788126.jpg?1",
             "name": "Sky-Blessed Samurai",
             "text": "This spell costs {1} less to cast for each enchantment you control.\nFlying",
             "colours": [
@@ -12006,7 +12006,7 @@
         },
         {
             "id": "43356485-e1a1-5fcd-9cd5-b0082e5db9fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32e2ad3-c5fb-4072-aabf-6cb9538db3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32e2ad3-c5fb-4072-aabf-6cb9538db3ca.jpg?1",
             "name": "Sunblade Samurai",
             "text": "Vigilance\nChannel \u2014 {2}, Discard Sunblade Samurai: Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
             "colours": [
@@ -12044,7 +12044,7 @@
         },
         {
             "id": "038b47e7-ea13-54fc-b0e0-b8472d292c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92aafa5-9a21-4564-8b33-dab414cd5dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92aafa5-9a21-4564-8b33-dab414cd5dca.jpg?1",
             "name": "The Wandering Emperor",
             "text": "Flash\nAs long as The Wandering Emperor entered the battlefield this turn, you may activate her loyalty abilities any time you could cast an instant.\n+1: Put a +1/+1 counter on up to one target creature. It gains first strike until end of turn.\n\u22121: Create a 2/2 white Samurai creature token with vigilance.\n\u22122: Exile target tapped creature. You gain 2 life.",
             "colours": [
@@ -12082,7 +12082,7 @@
         },
         {
             "id": "83ca6f4c-44e5-5fb4-ab1b-75b83ee02fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dbd59e-a2f0-4031-b6c6-1b59fb7cb067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95dbd59e-a2f0-4031-b6c6-1b59fb7cb067.jpg?1",
             "name": "Guardians of Oboro",
             "text": "Defender\nModified creatures you control can attack as though they didn't have defender.",
             "colours": [
@@ -12119,7 +12119,7 @@
         },
         {
             "id": "b326f163-12ba-5fb8-93b8-7aaa833d0251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bdf0d-df7d-4ca2-8131-060ba7cf2602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bdf0d-df7d-4ca2-8131-060ba7cf2602.jpg?1",
             "name": "Nezumi Bladeblesser",
             "text": "Nezumi Bladeblesser has deathtouch as long as you control an artifact.\nNezumi Bladeblesser has menace as long as you control an enchantment.",
             "colours": [
@@ -12156,7 +12156,7 @@
         },
         {
             "id": "31cf0c98-c833-5897-b695-2a8b470b030b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ee8e-d33a-40e9-9956-e345f0511819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa16ee8e-d33a-40e9-9956-e345f0511819.jpg?1",
             "name": "Akki Ronin",
             "text": "Whenever a Samurai or Warrior you control attacks alone, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -12193,7 +12193,7 @@
         },
         {
             "id": "c4ffe8c7-a4d1-50cf-af16-a7088f8a1f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862e9b05-209d-47d6-8692-ec0cb5f19e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862e9b05-209d-47d6-8692-ec0cb5f19e25.jpg?1",
             "name": "Goro-Goro, Disciple of Ryusei",
             "text": "{R}: Creatures you control gain haste until end of turn.\n{3}{R}{R}: Create a 5/5 red Dragon Spirit creature token with flying. Activate only if you control an attacking modified creature.",
             "colours": [
@@ -12233,7 +12233,7 @@
         },
         {
             "id": "051d5105-dd2a-54c7-b2e5-38055ea89396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91040c0-f025-4843-8c0e-3ac1b76c8582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91040c0-f025-4843-8c0e-3ac1b76c8582.jpg?1",
             "name": "Heiko Yamazaki, the General",
             "text": "Trample\nWhenever a Samurai or Warrior you control attacks alone, you may cast target artifact card from your graveyard this turn.",
             "colours": [
@@ -12272,7 +12272,7 @@
         },
         {
             "id": "6aafe7f1-ca84-56bd-ab14-123fe8416de6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247c362c-bf21-4bca-89d4-54eb60806f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247c362c-bf21-4bca-89d4-54eb60806f10.jpg?1",
             "name": "Peerless Samurai",
             "text": "Menace\nWhenever a Samurai or Warrior you control attacks alone, the next spell you cast this turn costs {1} less to cast.",
             "colours": [
@@ -12309,7 +12309,7 @@
         },
         {
             "id": "fa1d971f-ce13-51cf-bbf4-a800d327948a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69eec2f-eec0-491f-944c-ca944d9d320b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69eec2f-eec0-491f-944c-ca944d9d320b.jpg?1",
             "name": "Reinforced Ronin",
             "text": "Haste\nAt the beginning of your end step, return Reinforced Ronin to its owner's hand.\nChannel \u2014 {1}{R}, Discard Reinforced Ronin: Draw a card.",
             "colours": [
@@ -12347,7 +12347,7 @@
         },
         {
             "id": "db4feb75-7c7d-55ff-97fd-17227533476f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52af0f2d-de2e-4554-ae32-c88bc7ba7c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52af0f2d-de2e-4554-ae32-c88bc7ba7c71.jpg?1",
             "name": "Upriser Renegade",
             "text": "Upriser Renegade gets +2/+0 for each other modified creature you control.",
             "colours": [
@@ -12384,7 +12384,7 @@
         },
         {
             "id": "c13652c1-4a35-5bbe-9fcc-20de94ff59bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54509524-92b9-41a3-8aba-a8955a7dfa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54509524-92b9-41a3-8aba-a8955a7dfa1a.jpg?1",
             "name": "Heir of the Ancient Fang",
             "text": "Heir of the Ancient Fang enters the battlefield with a +1/+1 counter on it if you control a modified creature.",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "766448bc-4367-56b1-a1f7-509610e730db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164e663f-6a67-4a10-a737-33ea533a9316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164e663f-6a67-4a10-a737-33ea533a9316.jpg?1",
             "name": "Jukai Trainee",
             "text": "Whenever Jukai Trainee blocks or becomes blocked, it gets +1/+1 until end of turn.",
             "colours": [
@@ -12458,7 +12458,7 @@
         },
         {
             "id": "e48285ef-223f-5c3b-8434-f7ef41548fed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94158fdf-c794-4ce9-a04e-cb6922604d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94158fdf-c794-4ce9-a04e-cb6922604d19.jpg?1",
             "name": "Asari Captain",
             "text": "Haste\nWhenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.",
             "colours": [
@@ -12497,7 +12497,7 @@
         },
         {
             "id": "47c9d122-6fb1-56af-8a16-107b0e422f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf8b008-3a7c-4b6d-8c18-263a576f0d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf8b008-3a7c-4b6d-8c18-263a576f0d64.jpg?1",
             "name": "Isshin, Two Heavens as One",
             "text": "If a creature attacking would cause a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "ada3d938-2061-5d62-8e11-2a79279640fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1026485e-3df5-4ac7-baa1-06bff537a506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1026485e-3df5-4ac7-baa1-06bff537a506.jpg?1",
             "name": "Raiyuu, Storm's Edge",
             "text": "First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "colours": [
@@ -12583,7 +12583,7 @@
         },
         {
             "id": "b8fc2dea-4c58-5658-93d6-ecd2d9a539da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd32b69-5e1e-4990-88ec-85b21056ceae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd32b69-5e1e-4990-88ec-85b21056ceae.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "Haste\nWhenever Risona, Asari Commander deals combat damage to a player, if it doesn't have an indestructible counter on it, put an indestructible counter on it.\nWhenever combat damage is dealt to you, remove an indestructible counter from Risona.",
             "colours": [
@@ -12626,7 +12626,7 @@
         },
         {
             "id": "0dc81de1-dad5-5e29-ae95-5a0f2c1484c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d244d4-c2c4-4032-b249-794556d79429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d244d4-c2c4-4032-b249-794556d79429.jpg?1",
             "name": "Blade-Blizzard Kitsune",
             "text": "Ninjutsu {3}{W}\nDouble strike",
             "colours": [
@@ -12663,7 +12663,7 @@
         },
         {
             "id": "79896d82-8e2a-5b75-aad2-5f5da70b6d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f268152-304a-4db8-a3f9-dd9d0f3319a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f268152-304a-4db8-a3f9-dd9d0f3319a1.jpg?1",
             "name": "Covert Technician",
             "text": "Ninjutsu {1}{U}\nWhenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.",
             "colours": [
@@ -12701,7 +12701,7 @@
         },
         {
             "id": "9ebcbf7a-89a2-5fc4-9a80-c943aa6d1ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bad5c1-5804-4fba-91d9-3a49951f6e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bad5c1-5804-4fba-91d9-3a49951f6e06.jpg?1",
             "name": "Futurist Operative",
             "text": "As long as Futurist Operative is tapped, it's a Human Citizen with base power and toughness 1/1 and can't be blocked.\n{2}{U}: Untap Futurist Operative.",
             "colours": [
@@ -12738,7 +12738,7 @@
         },
         {
             "id": "fafc2bd0-bb19-5717-88da-1edafb366660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c43923-7280-4ccb-810b-e8c38dd8a26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c43923-7280-4ccb-810b-e8c38dd8a26f.jpg?1",
             "name": "Moon-Circuit Hacker",
             "text": "Ninjutsu {U}\nWhenever Moon-Circuit Hacker deals combat damage to a player, you may draw a card. If you do, discard a card unless Moon-Circuit Hacker entered the battlefield this turn.",
             "colours": [
@@ -12776,7 +12776,7 @@
         },
         {
             "id": "0b637440-bc16-50b2-a007-037810f7a68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2fdd4-b953-4e9a-b511-52199a34214e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2fdd4-b953-4e9a-b511-52199a34214e.jpg?1",
             "name": "Moonsnare Specialist",
             "text": "Ninjutsu {2}{U}\nWhen Moonsnare Specialist enters the battlefield, return up to one target creature to its owner's hand.",
             "colours": [
@@ -12813,7 +12813,7 @@
         },
         {
             "id": "191d8139-dfc3-52f1-a4de-c9cdfaa9a9a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e666d9-d2ba-49a6-a2c7-cd2639bf4663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e666d9-d2ba-49a6-a2c7-cd2639bf4663.jpg?1",
             "name": "Prosperous Thief",
             "text": "Ninjutsu {1}{U}\nWhenever one or more Ninja or Rogue creatures you control deal combat damage to a player, create a Treasure token.",
             "colours": [
@@ -12850,7 +12850,7 @@
         },
         {
             "id": "ae4f4699-e4b5-5ad6-908b-12c19be594be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c2751-fd12-42f2-b8c1-eaf78c5e29eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c2751-fd12-42f2-b8c1-eaf78c5e29eb.jpg?1",
             "name": "Thousand-Faced Shadow",
             "text": "Ninjutsu {2}{U}{U}\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.",
             "colours": [
@@ -12888,7 +12888,7 @@
         },
         {
             "id": "2f015f09-43e3-5dc3-9ae7-bd47fb796815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f92eb2-84ef-4343-9a31-41479c61a26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f92eb2-84ef-4343-9a31-41479c61a26d.jpg?1",
             "name": "Biting-Palm Ninja",
             "text": "Ninjutsu {2}{B}\nBiting-Palm Ninja enters the battlefield with a menace counter on it.\nWhenever Biting-Palm Ninja deals combat damage to a player, you may remove a menace counter from it. When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
             "colours": [
@@ -12926,7 +12926,7 @@
         },
         {
             "id": "d7a61d9e-7c77-584f-9a95-f772393a6a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d35bcc7-2280-4061-9a6c-e67038cfb114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d35bcc7-2280-4061-9a6c-e67038cfb114.jpg?1",
             "name": "Dokuchi Shadow-Walker",
             "text": "Ninjutsu {3}{B}",
             "colours": [
@@ -12963,7 +12963,7 @@
         },
         {
             "id": "4cd3ec66-6841-5cfe-b3b6-ba215b0cb937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5103a49-806f-48de-ba44-e252bb6dd035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5103a49-806f-48de-ba44-e252bb6dd035.jpg?1",
             "name": "Dokuchi Silencer",
             "text": "Ninjutsu {1}{B}\nWhenever Dokuchi Silencer deals combat damage to a player, you may discard a creature card. When you do, destroy target creature or planeswalker that player controls.",
             "colours": [
@@ -13000,7 +13000,7 @@
         },
         {
             "id": "e9a4ab51-b3fb-5b6a-b1bb-721fd8476c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66aaba3-4a28-4fcf-926a-34bbbf0dbeb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66aaba3-4a28-4fcf-926a-34bbbf0dbeb4.jpg?1",
             "name": "Inkrise Infiltrator",
             "text": "Flying\n{3}{B}: Inkrise Infiltrator gets +2/+2 until end of turn.",
             "colours": [
@@ -13037,7 +13037,7 @@
         },
         {
             "id": "1b65680b-c4c2-5bc6-9ceb-3fe5578eeb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357594c7-a9a6-468d-b262-e5f7d5e35f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357594c7-a9a6-468d-b262-e5f7d5e35f54.jpg?1",
             "name": "Mukotai Ambusher",
             "text": "Ninjutsu {1}{B}\nLifelink",
             "colours": [
@@ -13075,7 +13075,7 @@
         },
         {
             "id": "bc10c82e-599d-5ce4-ac6a-39d3dd39e131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e4f390-c420-44ec-a703-9a9d3ca6ab2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e4f390-c420-44ec-a703-9a9d3ca6ab2e.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "Ninjutsu {3}{B}\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -13116,7 +13116,7 @@
         },
         {
             "id": "3278b0cd-f402-5f81-96f9-3dbb19d44396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a64789a-748a-4630-949c-e1b045edd225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a64789a-748a-4630-949c-e1b045edd225.jpg?1",
             "name": "Nezumi Prowler",
             "text": "Ninjutsu {1}{B}\nWhen Nezumi Prowler enters the battlefield, target creature you control gains deathtouch and lifelink until end of turn.",
             "colours": [
@@ -13154,7 +13154,7 @@
         },
         {
             "id": "0ef70622-ce54-5799-80f7-35f04670db68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b3345-d09c-46ec-b450-f52fbcac5233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89b3345-d09c-46ec-b450-f52fbcac5233.jpg?1",
             "name": "Tatsunari, Toad Rider",
             "text": "Whenever you cast an enchantment spell, if you don't control a creature named Keimi, create Keimi, a legendary 3/3 black and green Frog creature token with \"Whenever you cast an enchantment spell, each opponent loses 1 life and you gain 1 life.\"\n{1}{GW}: Tatsunari, Toad Rider and target Frog you control can't be blocked this turn except by creatures with flying or reach.",
             "colours": [
@@ -13196,7 +13196,7 @@
         },
         {
             "id": "21afaa23-868b-5429-96a6-162388a6744e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297592c-3036-434a-9dbb-5f0af804dd13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8297592c-3036-434a-9dbb-5f0af804dd13.jpg?1",
             "name": "Coiling Stalker",
             "text": "Ninjutsu {1}{G}\nWhenever Coiling Stalker deals combat damage to a player, put a +1/+1 counter on target creature you control that doesn't have a +1/+1 counter on it.",
             "colours": [
@@ -13233,7 +13233,7 @@
         },
         {
             "id": "69bea426-7e12-5f1a-8126-a8c00399dd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c8e2d5-2706-4137-bfdc-d65f1cd33bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c8e2d5-2706-4137-bfdc-d65f1cd33bda.jpg?1",
             "name": "Fang of Shigeki",
             "text": "Deathtouch",
             "colours": [
@@ -13271,7 +13271,7 @@
         },
         {
             "id": "83c9daca-0e58-59e1-8fc5-e3ca039f70ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9017ff4-d63f-4dd2-9157-c93fe4866bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9017ff4-d63f-4dd2-9157-c93fe4866bef.jpg?1",
             "name": "Kappa Tech-Wrecker",
             "text": "Ninjutsu {1}{G}\nKappa Tech-Wrecker enters the battlefield with a deathtouch counter on it.\nWhenever Kappa Tech-Wrecker deals combat damage to a player, you may remove a deathtouch counter from it. When you do, exile target artifact or enchantment that player controls.",
             "colours": [
@@ -13308,7 +13308,7 @@
         },
         {
             "id": "c9acfa54-bbd0-5187-b112-a9be0efdad4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a144bb-df52-4d55-aecc-8c2ba644a942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a144bb-df52-4d55-aecc-8c2ba644a942.jpg?1",
             "name": "Spring-Leaf Avenger",
             "text": "Ninjutsu {3}{G}\nWhenever Spring-Leaf Avenger deals combat damage to a player, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -13346,7 +13346,7 @@
         },
         {
             "id": "857aa231-2514-52f2-964a-31b8c957c686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6d5319-1cbb-41fb-83ed-97c9344e3073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae6d5319-1cbb-41fb-83ed-97c9344e3073.jpg?1",
             "name": "Kaito Shizuki",
             "text": "At the beginning of your end step, if Kaito Shizuki entered the battlefield this turn, he phases out.\n+1: Draw a card. Then discard a card unless you attacked this turn.\n\u22122: Create a 1/1 blue Ninja creature token with \"This creature can't be blocked.\"\n\u22127: You get an emblem with \"Whenever a creature you control deals combat damage to a player, search your library for a blue or black creature card, put it onto the battlefield, then shuffle.\"",
             "colours": [
@@ -13388,7 +13388,7 @@
         },
         {
             "id": "169d3186-2b47-5e03-b0b0-4522dfe0045f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf89ee78-bcc9-419a-a400-e612b5a90f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf89ee78-bcc9-419a-a400-e612b5a90f07.jpg?1",
             "name": "Kotose, the Silent Spider",
             "text": "When Kotose, the Silent Spider enters the battlefield, exile target card other than a basic land card from an opponent's graveyard. Search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles. For as long as you control Kotose, you may play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -13430,7 +13430,7 @@
         },
         {
             "id": "969b07fb-145f-5190-9e4a-344ea3bb7457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c415762a-5b24-4dbb-9066-6e9be48874a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c415762a-5b24-4dbb-9066-6e9be48874a6.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -13474,7 +13474,7 @@
         },
         {
             "id": "c954711e-cdf1-56f5-b28f-6bb302d9ba66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9a0771-072c-4b0c-afcb-15a6406473c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9a0771-072c-4b0c-afcb-15a6406473c6.jpg?1",
             "name": "Silver-Fur Master",
             "text": "Ninjutsu {U}{B}\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.",
             "colours": [
@@ -13514,7 +13514,7 @@
         },
         {
             "id": "c6779dcb-e7bd-525b-bea2-77587f0b01d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nII \u2014 You may discard a card. When you do, return target permanent card with mana value 2 or less from your graveyard to the battlefield tapped.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13551,7 +13551,7 @@
         },
         {
             "id": "a2af8a6a-e40e-5ecb-bc93-fd5e5b1c20b1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57900858-940f-4d62-8a2c-378e82f4b79c.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "Vigilance\nWhenever Architect of Restoration attacks or blocks, create a 1/1 colorless Spirit creature token.",
             "colours": [
@@ -13590,7 +13590,7 @@
         },
         {
             "id": "28ed206d-6c6a-54c4-8c62-206805e8b7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Return up to one target creature or planeswalker to its owner's hand.\nII \u2014 Return an artifact card from your graveyard to your hand. If you can't, draw a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13627,7 +13627,7 @@
         },
         {
             "id": "0a62b979-3110-5fcd-86b0-c6ad8d34ca24",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f54308-cbfb-484c-bb4d-efc04ef8d9a4.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "Flying\nWhenever you cast a spell, your opponents can't cast spells with the same mana value as that spell until your next turn.",
             "colours": [
@@ -13665,7 +13665,7 @@
         },
         {
             "id": "acfda7f4-9b1e-5cdf-ab35-88f5a6b96fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 Each opponent creates a 1/1 black Rat Rogue creature token.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13702,7 +13702,7 @@
         },
         {
             "id": "46271276-669b-5353-997b-0ae0a8a32072",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d3a26bf-c3e3-40d0-8746-c135b3c4c7d1.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "Flying, haste\nWhen Echo of Death's Wail enters the battlefield, gain control of all Rat tokens.\nWhenever Echo of Death's Wail attacks, you may sacrifice another creature. If you do, draw a card.",
             "colours": [
@@ -13740,7 +13740,7 @@
         },
         {
             "id": "48c2413e-30a2-5fa9-85aa-9f8305d7f4f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 2/2 red Goblin Shaman creature token with \"Whenever this creature attacks, create a Treasure token.\"\nII \u2014 You may discard up to two cards. If you do, draw that many cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13777,7 +13777,7 @@
         },
         {
             "id": "b384f442-c485-587e-954e-f3bc0962daa1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b696cd1-0d72-4df5-bacc-dc77e62f9a13.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -13816,7 +13816,7 @@
         },
         {
             "id": "131e6619-3b54-5c9d-abc1-7e392dec9d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II \u2014 You gain 2 life. Look at the top three cards of your library. Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13853,7 +13853,7 @@
         },
         {
             "id": "ad7a3465-26b8-5a44-9532-834e19b83ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/d/2d77f095-c04e-4b7f-b1b1-2991a06134e8.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "Whenever Dragon-Kami's Egg or a Dragon you control dies, you may cast a creature spell from among cards you own in exile with hatching counters on them without paying its mana cost.",
             "colours": [
@@ -13891,7 +13891,7 @@
         },
         {
             "id": "a937305c-719b-52a5-b600-902d252b91e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"\nII \u2014 Put a +1/+1 counter on each of up to two target creatures.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -13928,7 +13928,7 @@
         },
         {
             "id": "64d23141-1b89-5fd2-b7ad-1c7e389ce56b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/29f05618-3c06-488e-80d8-3957be7f0a71.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on that creature.\nAs long as you control five or more modified creatures, Remnant of the Rising Star gets +5/+5 and has trample.",
             "colours": [
@@ -13967,7 +13967,7 @@
         },
         {
             "id": "71a468ee-2c87-5cea-8009-94a9c663c2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Mill three cards. Create a 1/1 colorless Spirit creature token.\nII \u2014 Put a +1/+1 counter on target creature you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -14004,7 +14004,7 @@
         },
         {
             "id": "941c7d9c-57fb-5575-bea6-a8e733769dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9587550-bb1e-40af-9569-0667f4439452.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "Whenever Kirin-Touched Orochi attacks, choose one \u2014\n\u2022 Exile target creature card from a graveyard. When you do, create a 1/1 colorless Spirit creature token.\n\u2022 Exile target noncreature card from a graveyard. When you do, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -14043,7 +14043,7 @@
         },
         {
             "id": "abf2cbbc-a757-5f91-8cef-2b30c472ecbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Destroy each nonland permanent with mana value 1 or less.\nII \u2014 Exile all graveyards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -14082,7 +14082,7 @@
         },
         {
             "id": "02291ae9-e366-506e-8130-6f94f76c1915",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/887e6d1e-cb53-4964-ba0b-c15dffa5eb32.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "Trample\nWhenever Vessel of the All-Consuming deals damage, put a +1/+1 counter on it.\nWhenever Vessel of the All-Consuming deals damage to a player, if it has dealt 10 or more damage to that player this turn, they lose the game.",
             "colours": [
@@ -14123,7 +14123,7 @@
         },
         {
             "id": "76c7301f-b7d3-52be-aa5d-d027e4274390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "(As this Saga enters and after your draw step, add a lore counter.)\nI \u2014 Exile target nonland permanent an opponent controls.\nII \u2014 Return up to one other target nonland permanent to its owner's hand. Then each opponent discards a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -14168,7 +14168,7 @@
         },
         {
             "id": "031190c2-7a56-583c-b37b-1ce907f0a9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cfcc7dd5-c6ac-4e66-b197-c010dcfdb397.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "O-Kagachi Made Manifest is all colors.\nFlying, trample\nWhenever O-Kagachi Made Manifest attacks, defending player chooses a nonland card in your graveyard. Return that card to your hand. O-Kagachi Made Manifest gets +X/+0 until end of turn, where X is the mana value of that card.",
             "colours": [
@@ -14215,7 +14215,7 @@
         },
         {
             "id": "1edeb946-a0dd-5659-b2ee-f90113def0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820390d7-fabb-4556-8d30-99f0a58b2da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820390d7-fabb-4556-8d30-99f0a58b2da5.jpg?1",
             "name": "Brilliant Restoration",
             "text": "Return all artifact and enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -14250,7 +14250,7 @@
         },
         {
             "id": "e048edc1-629b-5b28-aa07-3b3a40fa6698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ace38c6-2cc8-4f72-8276-eb02aa6773e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ace38c6-2cc8-4f72-8276-eb02aa6773e0.jpg?1",
             "name": "Cloudsteel Kirin",
             "text": "Flying\nEquipped creature has flying and \"You can't lose the game and your opponents can't win the game.\"\nReconfigure {5}",
             "colours": [
@@ -14289,7 +14289,7 @@
         },
         {
             "id": "794297f4-e9c1-5cd9-9195-e17c1249f2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c664bc-9585-47a7-9514-b3e30a4e1b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c664bc-9585-47a7-9514-b3e30a4e1b59.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -14325,7 +14325,7 @@
         },
         {
             "id": "3c0b225a-09b9-57e3-ac67-223245ecdf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c1acbf-5ef0-4677-b097-30db77d87310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c1acbf-5ef0-4677-b097-30db77d87310.jpg?1",
             "name": "Invoke Justice",
             "text": "Return target permanent card from your graveyard to the battlefield, then distribute four +1/+1 counters among any number of creatures and/or Vehicles target player controls.",
             "colours": [
@@ -14360,7 +14360,7 @@
         },
         {
             "id": "e9d3ba82-9f8a-539f-87e0-1ec0bc41f773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614523-e51a-44ff-83ad-5be9e322697a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76614523-e51a-44ff-83ad-5be9e322697a.jpg?1",
             "name": "Light-Paws, Emperor's Voice",
             "text": "Whenever an Aura enters the battlefield under your control, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, Emperor's Voice, then shuffle.",
             "colours": [
@@ -14400,7 +14400,7 @@
         },
         {
             "id": "c34c94b6-547f-59ff-8835-d52a1af412d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c8834-e06e-452a-b82e-cb2b8fe0c304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c8834-e06e-452a-b82e-cb2b8fe0c304.jpg?1",
             "name": "Lion Sash",
             "text": "{W}: Exile target card from a graveyard. If it was a permanent card, put a +1/+1 counter on Lion Sash.\nEquipped creature gets +1/+1 for each +1/+1 counter on Lion Sash.\nReconfigure {2}",
             "colours": [
@@ -14439,7 +14439,7 @@
         },
         {
             "id": "63b796f3-17d2-57ec-87c1-71273e3c3839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a400cd7d-b004-4310-9787-bbec0fe36fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a400cd7d-b004-4310-9787-bbec0fe36fd8.jpg?1",
             "name": "March of Otherworldly Light",
             "text": "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
             "colours": [
@@ -14474,7 +14474,7 @@
         },
         {
             "id": "b23db4e8-ad62-5af8-873b-9e8ee615b4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307380fe-7484-4513-8180-f10411ea7726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307380fe-7484-4513-8180-f10411ea7726.jpg?1",
             "name": "Invoke the Winds",
             "text": "Gain control of target artifact or creature. Untap it.",
             "colours": [
@@ -14509,7 +14509,7 @@
         },
         {
             "id": "4dc289a9-6c82-5420-9152-59992c696d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01985566-275b-4bf0-8667-c81eb95ad70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01985566-275b-4bf0-8667-c81eb95ad70c.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn.\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -14553,7 +14553,7 @@
         },
         {
             "id": "d4fce68e-1740-5681-92ca-3651d0a97e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a8eac-82c7-4e02-bff5-1e1095b781ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633a8eac-82c7-4e02-bff5-1e1095b781ef.jpg?1",
             "name": "March of Swirling Mist",
             "text": "As an additional cost to cast this spell, you may exile any number of blue cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nUp to X target creatures phase out.",
             "colours": [
@@ -14588,7 +14588,7 @@
         },
         {
             "id": "f886b418-f06b-5c47-a0cb-c37c5e69fe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37163f66-393f-4cb7-9f55-307d3d4b5975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37163f66-393f-4cb7-9f55-307d3d4b5975.jpg?1",
             "name": "Mindlink Mech",
             "text": "Flying\nWhenever Mindlink Mech becomes crewed for the first time each turn, until end of turn, Mindlink Mech becomes a copy of target nonlegendary creature that crewed it this turn, except it's 4/3, it's a Vehicle artifact in addition to its other types, and it has flying.\nCrew 1",
             "colours": [
@@ -14625,7 +14625,7 @@
         },
         {
             "id": "029be1ea-eaeb-50bb-b050-cca86d056f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fb5ee3-97af-40c1-a8de-a2a62afd418d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fb5ee3-97af-40c1-a8de-a2a62afd418d.jpg?1",
             "name": "The Reality Chip",
             "text": "You may look at the top card of your library any time.\nAs long as The Reality Chip is attached to a creature, you may play lands and cast spells from the top of your library.\nReconfigure {2}{U}",
             "colours": [
@@ -14666,7 +14666,7 @@
         },
         {
             "id": "a8b4dcff-5ef2-592f-8c98-da55a1ee6d29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0467d-bc7b-4233-8ac1-adb9d88344fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c0467d-bc7b-4233-8ac1-adb9d88344fb.jpg?1",
             "name": "Tameshi, Reality Architect",
             "text": "Whenever one or more noncreature permanents are returned to hand, draw a card. This ability triggers only once each turn.\n{X}{W}, Return a land you control to its owner's hand: Return target artifact or enchantment card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -14707,7 +14707,7 @@
         },
         {
             "id": "ce2b63c9-fa96-5b07-8863-990c72de3e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b71dd5-0bed-4c02-9f92-c52984e2bb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b71dd5-0bed-4c02-9f92-c52984e2bb78.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "The first activated ability of an artifact you activate each turn costs {2} less to activate.\n+1: Draw two cards. Then discard two cards unless you discard an artifact card.\n\u22122: Target artifact becomes an artifact creature. If it isn't a Vehicle, it has base power and toughness 4/4.\n\u22126: You get an emblem with \"Whenever an artifact you control becomes tapped, draw a card.\"",
             "colours": [
@@ -14747,7 +14747,7 @@
         },
         {
             "id": "a319e2b9-8155-5eb2-9f29-c4c6356a9581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f5c2f4-1690-4392-80d6-d99148bc8b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f5c2f4-1690-4392-80d6-d99148bc8b13.jpg?1",
             "name": "Blade of the Oni",
             "text": "Menace\nEquipped creature has base power and toughness 5/5, has menace, and is a black Demon in addition to its other colors and types.\nReconfigure {2}{B}{B}",
             "colours": [
@@ -14787,7 +14787,7 @@
         },
         {
             "id": "114e3066-b29c-5fad-bb4f-d50fdd4c469f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3981fc94-efb5-4256-8adb-4538515a085c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3981fc94-efb5-4256-8adb-4538515a085c.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "{B}, Sacrifice a creature: Scry 2.\n{2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.",
             "colours": [
@@ -14832,7 +14832,7 @@
         },
         {
             "id": "ad48e205-1bc2-56aa-afb1-a2ee72665c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e4edbd-4a7c-435b-b7c0-f9cfdd3dff68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e4edbd-4a7c-435b-b7c0-f9cfdd3dff68.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -14868,7 +14868,7 @@
         },
         {
             "id": "9bc14b09-90ad-5ab0-890a-76ce80db6938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4703bba7-3248-410f-99a8-dffd629bab4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4703bba7-3248-410f-99a8-dffd629bab4c.jpg?1",
             "name": "March of Wretched Sorrow",
             "text": "As an additional cost to cast this spell, you may exile any number of black cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nMarch of Wretched Sorrow deals X damage to target creature or planeswalker and you gain X life.",
             "colours": [
@@ -14903,7 +14903,7 @@
         },
         {
             "id": "d01ed3d6-bddc-5e93-89c1-da239f10dac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d7df77-dc10-4c88-a51e-43d6b86ef10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d7df77-dc10-4c88-a51e-43d6b86ef10e.jpg?1",
             "name": "Mukotai Soulripper",
             "text": "Whenever Mukotai Soulripper attacks, you may sacrifice another artifact or creature. If you do, put a +1/+1 counter on Mukotai Soulripper and it gains menace until end of turn.\nCrew 2",
             "colours": [
@@ -14940,7 +14940,7 @@
         },
         {
             "id": "b1a4261e-13d5-50f4-9177-d9ffd3f650c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12642d-85b5-4b40-b1c0-2c08feae2f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce12642d-85b5-4b40-b1c0-2c08feae2f0a.jpg?1",
             "name": "Soul Transfer",
             "text": "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both.\n\u2022 Exile target creature or planeswalker.\n\u2022 Return target creature or planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -14975,7 +14975,7 @@
         },
         {
             "id": "192b1640-1a8b-58a5-856b-ad674be71401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d47e98-daae-42f7-9581-1269d57bd16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d47e98-daae-42f7-9581-1269d57bd16e.jpg?1",
             "name": "Explosive Singularity",
             "text": "As an additional cost to cast this spell, you may tap any number of untapped creatures you control. This spell costs {1} less to cast for each creature tapped this way.\nExplosive Singularity deals 10 damage to any target.",
             "colours": [
@@ -15011,7 +15011,7 @@
         },
         {
             "id": "ae2307a1-e245-56f5-b8c3-c759cc13f8d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12af2504-ff1c-4361-a428-be9d1d35899f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12af2504-ff1c-4361-a428-be9d1d35899f.jpg?1",
             "name": "Invoke Calamity",
             "text": "You may cast up to two instant and/or sorcery spells with total mana value 6 or less from your graveyard and/or hand without paying their mana costs. If those spells would be put into your graveyard, exile them instead. Exile Invoke Calamity.",
             "colours": [
@@ -15046,7 +15046,7 @@
         },
         {
             "id": "9e91e4fd-e09b-5e0e-a12b-92df66a2f2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cadc1b-3434-4c38-b414-0f5ab4ca52a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cadc1b-3434-4c38-b414-0f5ab4ca52a0.jpg?1",
             "name": "Lizard Blades",
             "text": "Double strike\nEquipped creature has double strike.\nReconfigure {2}",
             "colours": [
@@ -15085,7 +15085,7 @@
         },
         {
             "id": "fe3168f3-7143-5d35-861c-ee1536b12c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbd3545-f98e-404e-a283-0ce2d83e64bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbd3545-f98e-404e-a283-0ce2d83e64bc.jpg?1",
             "name": "March of Reckless Joy",
             "text": "As an additional cost to cast this spell, you may exile any number of red cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile the top X cards of your library. You may play up to two of those cards until the end of your next turn.",
             "colours": [
@@ -15120,7 +15120,7 @@
         },
         {
             "id": "a95e2935-3527-598f-aa21-9905c5931b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f143d-986a-474e-be48-819d1f9f078c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517f143d-986a-474e-be48-819d1f9f078c.jpg?1",
             "name": "Ogre-Head Helm",
             "text": "Equipped creature gets +2/+2.\nWhenever Ogre-Head Helm or equipped creature deals combat damage to a player, you may sacrifice it. If you do, discard your hand, then draw three cards.\nReconfigure {3}",
             "colours": [
@@ -15159,7 +15159,7 @@
         },
         {
             "id": "4eefadca-eb9d-566d-b056-cb09c0c2db3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793c45e2-d0ce-4899-9f7f-5629bd6e01a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/793c45e2-d0ce-4899-9f7f-5629bd6e01a1.jpg?1",
             "name": "Scrap Welder",
             "text": "{T}, Sacrifice an artifact with mana value X: Return target artifact card with mana value less than X from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -15197,7 +15197,7 @@
         },
         {
             "id": "90f032f7-1c3b-5ce3-b6cb-399bba3ad15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6a9bef-6910-4293-87b8-52abcef41566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6a9bef-6910-4293-87b8-52abcef41566.jpg?1",
             "name": "Thundering Raiju",
             "text": "Haste\nWhenever Thundering Raiju attacks, put a +1/+1 counter on target creature you control. Then Thundering Raiju deals X damage to each opponent, where X is the number of modified creatures you control other than Thundering Raiju.",
             "colours": [
@@ -15234,7 +15234,7 @@
         },
         {
             "id": "27ad4eae-e68c-522c-955a-b2f533508ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f89fc5-fe77-490b-ba05-34ec0b362801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f89fc5-fe77-490b-ba05-34ec0b362801.jpg?1",
             "name": "Invoke the Ancients",
             "text": "Create two 4/5 green Spirit creature tokens. For each of them, put your choice of a vigilance counter, a reach counter, or a trample counter on it.",
             "colours": [
@@ -15269,7 +15269,7 @@
         },
         {
             "id": "bacee13b-e91d-5d91-a70a-4726cf604c15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f10049-8fd2-48f4-9319-d747546cf22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f10049-8fd2-48f4-9319-d747546cf22d.jpg?1",
             "name": "Kami of Transience",
             "text": "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on Kami of Transience.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return Kami of Transience from your graveyard to your hand.",
             "colours": [
@@ -15306,7 +15306,7 @@
         },
         {
             "id": "471e5871-2860-5f35-a954-0db6b54cfc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a4aeaa-aff7-4299-8030-36eefd5acaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a4aeaa-aff7-4299-8030-36eefd5acaf3.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "Reach\nModified creatures you control have trample.\nWhenever a modified creature you control deals combat damage to a player, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "22c957c8-ad24-5025-bbe2-34febb807c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed33009e-5686-4de9-9270-d1540ddceb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed33009e-5686-4de9-9270-d1540ddceb8a.jpg?1",
             "name": "March of Burgeoning Life",
             "text": "As an additional cost to cast this spell, you may exile any number of green cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nChoose target creature with mana value less than X. Search your library for a creature card with the same name as that creature, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -15381,7 +15381,7 @@
         },
         {
             "id": "a66fb16b-1c79-5ca3-b021-a617f68734b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c303e5-a0af-4e42-afcc-1d3a81c78e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c303e5-a0af-4e42-afcc-1d3a81c78e8e.jpg?1",
             "name": "Shigeki, Jukai Visionary",
             "text": "{1}{G}, {T}, Return Shigeki, Jukai Visionary to its owner's hand: Reveal the top four cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest into your graveyard.\nChannel \u2014 {X}{X}{G}{G}, Discard Shigeki: Return X target nonlegendary cards from your graveyard to your hand.",
             "colours": [
@@ -15422,7 +15422,7 @@
         },
         {
             "id": "317710f4-1c6c-582c-97e3-33eadd33da8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c4b17-a804-4340-bb7e-5cd3183ecbef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c4b17-a804-4340-bb7e-5cd3183ecbef.jpg?1",
             "name": "Weaver of Harmony",
             "text": "Other enchantment creatures you control get +1/+1.\n{G}, {T}: Copy target activated or triggered ability you control from an enchantment source. You may choose new targets for the copy.",
             "colours": [
@@ -15461,7 +15461,7 @@
         },
         {
             "id": "7f2f0143-9f62-53ab-90cc-eb3299672484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a560ff4-446e-4dd0-87a6-145a27bdcdb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a560ff4-446e-4dd0-87a6-145a27bdcdb9.jpg?1",
             "name": "Eiganjo Uprising",
             "text": "Create X 2/2 white Samurai creature tokens with vigilance. They gain menace and haste until end of turn.\nEach opponent creates X minus one 2/2 white Samurai creature tokens with vigilance.",
             "colours": [
@@ -15498,7 +15498,7 @@
         },
         {
             "id": "bcf9d63a-854e-51e5-8aff-0de49b04a7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9455cb27-89d3-4bb1-8af8-08c7712c2915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9455cb27-89d3-4bb1-8af8-08c7712c2915.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "At the beginning of combat on your turn, return target Vehicle card from your graveyard to the battlefield. It gains haste. Return it to its owner's hand at the beginning of your next end step.",
             "colours": [
@@ -15540,7 +15540,7 @@
         },
         {
             "id": "1fae3320-0a21-5103-9199-b637bab95e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737d299-09ce-4012-b3e9-c93a09035d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4737d299-09ce-4012-b3e9-c93a09035d65.jpg?1",
             "name": "Hinata, Dawn-Crowned",
             "text": "Flying, trample\nSpells you cast cost {1} less to cast for each target.\nSpells your opponents cast cost {1} more to cast for each target.",
             "colours": [
@@ -15584,7 +15584,7 @@
         },
         {
             "id": "8280a696-5e91-53c2-97a7-09a86a676d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dd5813-8c6e-4fa3-b11d-e13f14ce8c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0dd5813-8c6e-4fa3-b11d-e13f14ce8c4e.jpg?1",
             "name": "Satsuki, the Living Lore",
             "text": "{T}: Put a lore counter on each Saga you control. Activate only as a sorcery.\nWhen Satsuki, the Living Lore dies, choose up to one \u2014\n\u2022 Return target Saga or enchantment creature you control to its owner's hand.\n\u2022 Return target Saga card from your graveyard to your hand.",
             "colours": [
@@ -15626,7 +15626,7 @@
         },
         {
             "id": "081132fd-7d1c-525e-af32-2d64ae38f7f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaefe4b-9750-460a-9993-60a138df80a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaefe4b-9750-460a-9993-60a138df80a6.jpg?1",
             "name": "Spirit-Sister's Call",
             "text": "At the beginning of your end step, choose target permanent card in your graveyard. You may sacrifice a permanent that shares a card type with the chosen card. If you do, return the chosen card from your graveyard to the battlefield and it gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\"",
             "colours": [
@@ -15663,7 +15663,7 @@
         },
         {
             "id": "e76fba99-2f57-5dad-a646-2dd91164a9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f103cb00-29f7-41ad-8368-ed2cf1a408ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f103cb00-29f7-41ad-8368-ed2cf1a408ea.jpg?1",
             "name": "Eater of Virtue",
             "text": "Whenever equipped creature dies, exile it.\nEquipped creature gets +2/+0.\nAs long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.\nEquip {1}",
             "colours": [],
@@ -15698,7 +15698,7 @@
         },
         {
             "id": "4de32c0d-eb72-51f6-b477-cc0d1ece6cb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b7411-09e5-4990-88ca-649321dd62b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508b7411-09e5-4990-88ca-649321dd62b5.jpg?1",
             "name": "Mechtitan Core",
             "text": "{5}, Exile Mechtitan Core and four other artifact creatures and/or Vehicles you control: Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors. When that token leaves the battlefield, return all cards exiled with Mechtitan Core except Mechtitan Core to the battlefield tapped under their owners' control.\nCrew 2",
             "colours": [],
@@ -15731,7 +15731,7 @@
         },
         {
             "id": "58ec70dd-4482-589f-a95b-732df0d164d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf676a6-8ccb-4908-9e49-ccb4a319d588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf676a6-8ccb-4908-9e49-ccb4a319d588.jpg?1",
             "name": "Mirror Box",
             "text": "The \"legend rule\" doesn't apply to permanents you control.\nEach legendary creature you control gets +1/+1.\nEach nontoken creature you control gets +1/+1 for each other creature you control with the same name as that creature.",
             "colours": [],
@@ -15762,7 +15762,7 @@
         },
         {
             "id": "4258601e-7151-5b84-93d1-b6ab16671d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bf5955-67fe-4bbf-acd5-164bf087e7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bf5955-67fe-4bbf-acd5-164bf087e7a2.jpg?1",
             "name": "Reckoner Bankbuster",
             "text": "Reckoner Bankbuster enters the battlefield with three charge counters on it.\n{2}, {T}, Remove a charge counter from Reckoner Bankbuster: Draw a card. Then if there are no charge counters on Reckoner Bankbuster, create a Treasure token and a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 3",
             "colours": [],
@@ -15795,7 +15795,7 @@
         },
         {
             "id": "09579f26-be0a-5263-b5ec-0a25f295d5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0332502-bcba-42c0-9dfc-9ab873b1719a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0332502-bcba-42c0-9dfc-9ab873b1719a.jpg?1",
             "name": "Surgehacker Mech",
             "text": "Menace\nWhen Surgehacker Mech enters the battlefield, it deals damage equal to twice the number of Vehicles you control to target creature or planeswalker an opponent controls.\nCrew 4",
             "colours": [],
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "6ecde099-bc5d-5537-8846-8b5a15a4ebf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d1c2d-d3be-4647-a260-15ce85e69eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7d1c2d-d3be-4647-a260-15ce85e69eea.jpg?1",
             "name": "Ao, the Dawn Sky",
             "text": "Flying, vigilance\nWhen Ao, the Dawn Sky dies, choose one \u2014\n\u2022 Look at the top seven cards of your library. Put any number of nonland permanent cards with total mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\n\u2022 Put two +1/+1 counters on each permanent you control that's a creature or Vehicle.",
             "colours": [
@@ -15868,7 +15868,7 @@
         },
         {
             "id": "1b946e7c-8838-5444-8e99-dc0f392a1649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e500c22f-b16a-431b-8562-1508df7db27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e500c22f-b16a-431b-8562-1508df7db27e.jpg?1",
             "name": "Kyodai, Soul of Kamigawa",
             "text": "Flash\nFlying\nWhen Kyodai, Soul of Kamigawa enters the battlefield, another target permanent gains indestructible for as long as you control Kyodai.\n{W}{U}{B}{R}{G}: Kyodai gets +5/+5 until end of turn.",
             "colours": [
@@ -15912,7 +15912,7 @@
         },
         {
             "id": "92063907-3b81-5741-a96d-753c5f6b282a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516dc285-f0f9-4a5c-a7b7-395c1821b42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516dc285-f0f9-4a5c-a7b7-395c1821b42c.jpg?1",
             "name": "Kairi, the Swirling Sky",
             "text": "Flying, ward {3}\nWhen Kairi, the Swirling Sky dies, choose one \u2014\n\u2022 Return any number of target nonland permanents with total mana value 6 or less to their owners' hands.\n\u2022 Mill six cards, then return up to two instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -15952,7 +15952,7 @@
         },
         {
             "id": "b294b576-4d72-57d3-adf3-57665cbfdb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c61476-2105-48f3-8f57-3d0322bdc92e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c61476-2105-48f3-8f57-3d0322bdc92e.jpg?1",
             "name": "Junji, the Midnight Sky",
             "text": "Flying, menace\nWhen Junji, the Midnight Sky dies, choose one \u2014\n\u2022 Each opponent discards two cards and loses 2 life.\n\u2022 Put target non-Dragon creature card from a graveyard onto the battlefield under your control. You lose 2 life.",
             "colours": [
@@ -15992,7 +15992,7 @@
         },
         {
             "id": "1d8dfd46-1ce3-5c2c-bdd4-2c5f59e3506f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed997183-24b2-466f-b740-c414ef485a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed997183-24b2-466f-b740-c414ef485a96.jpg?1",
             "name": "Atsushi, the Blazing Sky",
             "text": "Flying, trample\nWhen Atsushi, the Blazing Sky dies, choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Create three Treasure tokens.",
             "colours": [
@@ -16032,7 +16032,7 @@
         },
         {
             "id": "dd5b8849-af08-523a-afe8-644103903cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0986e1a1-749d-4f34-9cdf-b347f2041c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0986e1a1-749d-4f34-9cdf-b347f2041c5c.jpg?1",
             "name": "Kura, the Boundless Sky",
             "text": "Flying, deathtouch\nWhen Kura, the Boundless Sky dies, choose one \u2014\n\u2022 Search your library for up to three land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Create an X/X green Spirit creature token, where X is the number of lands you control.",
             "colours": [
@@ -16072,7 +16072,7 @@
         },
         {
             "id": "9b4a13c9-99d2-5e55-82ec-6c55b375b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055ea30-20fb-4324-a632-8fed87628f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055ea30-20fb-4324-a632-8fed87628f05.jpg?1",
             "name": "Boseiju, Who Endures",
             "text": "{T}: Add {G}.\nChannel \u2014 {1}{G}, Discard Boseiju, Who Endures: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16107,7 +16107,7 @@
         },
         {
             "id": "b71f6f8d-c3c1-524b-8afa-3884445f6982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c31c48f-6275-4430-8dc9-05d70c332b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c31c48f-6275-4430-8dc9-05d70c332b7a.jpg?1",
             "name": "Eiganjo, Seat of the Empire",
             "text": "{T}: Add {W}.\nChannel \u2014 {2}{W}, Discard Eiganjo, Seat of the Empire: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16142,7 +16142,7 @@
         },
         {
             "id": "3dc881d0-b0e0-5e00-afbe-219f098b2624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e99599e-c594-42c6-b9e3-4dbb8e982f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e99599e-c594-42c6-b9e3-4dbb8e982f88.jpg?1",
             "name": "Otawara, Soaring City",
             "text": "{T}: Add {U}.\nChannel \u2014 {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16177,7 +16177,7 @@
         },
         {
             "id": "a87f4980-b2ec-5ee2-a268-f7df5247f351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327333cc-2cc9-44ba-a0e6-d01329c416a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327333cc-2cc9-44ba-a0e6-d01329c416a3.jpg?1",
             "name": "Sokenzan, Crucible of Defiance",
             "text": "{T}: Add {R}.\nChannel \u2014 {3}{R}, Discard Sokenzan, Crucible of Defiance: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16212,7 +16212,7 @@
         },
         {
             "id": "60469103-5301-5a82-b5b2-72886f64cba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc98705-77c2-47b6-b41c-3e41578700e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc98705-77c2-47b6-b41c-3e41578700e8.jpg?1",
             "name": "Takenuma, Abandoned Mire",
             "text": "{T}: Add {B}.\nChannel \u2014 {3}{B}, Discard Takenuma, Abandoned Mire: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -16247,7 +16247,7 @@
         },
         {
             "id": "a117fe2d-3817-5429-b5e1-b99af81d8cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956b833-0b74-4890-bc67-4aed7df33af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3956b833-0b74-4890-bc67-4aed7df33af4.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -16282,7 +16282,7 @@
         },
         {
             "id": "38faf8e0-756f-500d-bf1d-6c41701fd7b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22edc832-993b-432a-8435-8d8a72799122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22edc832-993b-432a-8435-8d8a72799122.jpg?1",
             "name": "The Wandering Emperor",
             "text": "",
             "colours": [
@@ -16319,7 +16319,7 @@
         },
         {
             "id": "f9e5bf08-bbcd-56db-86bd-db496e3c7067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd7793-5a6d-4b5c-8924-b0aee73e31eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dd7793-5a6d-4b5c-8924-b0aee73e31eb.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh",
             "text": "",
             "colours": [
@@ -16358,7 +16358,7 @@
         },
         {
             "id": "e885d0d4-7a5c-5f81-8621-64115ec6b475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029be79-88d8-4d15-a7d7-f5b8d469ad54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029be79-88d8-4d15-a7d7-f5b8d469ad54.jpg?1",
             "name": "Blade of the Oni",
             "text": "",
             "colours": [
@@ -16397,7 +16397,7 @@
         },
         {
             "id": "bf30b070-13f8-5c35-8dd7-9b8abd52aceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3564486e-e19b-4a11-a587-ad3e040cd914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3564486e-e19b-4a11-a587-ad3e040cd914.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "",
             "colours": [
@@ -16437,7 +16437,7 @@
         },
         {
             "id": "750634d9-3eb8-5bf3-a9cb-9a700d18f52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae9af1-58ea-49ad-8e57-8dcc53d2a959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ae9af1-58ea-49ad-8e57-8dcc53d2a959.jpg?1",
             "name": "Explosive Singularity",
             "text": "",
             "colours": [
@@ -16472,7 +16472,7 @@
         },
         {
             "id": "83eeaeb4-eb1e-5fdb-8d74-816fb741679f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f7bfb-8f0a-435a-b23c-c2f3bea46ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f7bfb-8f0a-435a-b23c-c2f3bea46ed2.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "",
             "colours": [
@@ -16511,7 +16511,7 @@
         },
         {
             "id": "186c8408-50d9-5f5f-8534-0bedb157fec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b189f965-d66d-4b35-b42f-933bdea62562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b189f965-d66d-4b35-b42f-933bdea62562.jpg?1",
             "name": "Kaito Shizuki",
             "text": "",
             "colours": [
@@ -16552,7 +16552,7 @@
         },
         {
             "id": "3bc5eae6-eb01-56b2-9a20-048a3239e143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a3d9fd-4023-4f64-b31c-8dab1eec8566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a3d9fd-4023-4f64-b31c-8dab1eec8566.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "",
             "colours": [
@@ -16594,7 +16594,7 @@
         },
         {
             "id": "1b1a6fa4-fdcc-55ce-ae62-a1ec5cb2cf0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c178c8d-ef57-4a69-a72d-c6c6f1eda617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c178c8d-ef57-4a69-a72d-c6c6f1eda617.jpg?1",
             "name": "Satoru Umezawa",
             "text": "",
             "colours": [
@@ -16637,7 +16637,7 @@
         },
         {
             "id": "89142f06-23ee-54d7-b0ed-505e335be5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa7cbf8-64b2-428e-8991-d8454d724f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa7cbf8-64b2-428e-8991-d8454d724f9f.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "",
             "colours": [
@@ -16680,7 +16680,7 @@
         },
         {
             "id": "6c89aef7-b810-5773-85a2-bec1c98783bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816eacac-a8b2-4d77-af3c-75f620ce3148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816eacac-a8b2-4d77-af3c-75f620ce3148.jpg?1",
             "name": "Tamiyo, Compleated Sage",
             "text": "",
             "colours": [
@@ -16721,7 +16721,7 @@
         },
         {
             "id": "c8e496a3-684c-5c37-a5bb-0475c7fa699c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4826991d-c3c3-45ff-9dfc-4246a84b40e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4826991d-c3c3-45ff-9dfc-4246a84b40e0.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16765,7 +16765,7 @@
         },
         {
             "id": "d274e1a6-af18-5ab6-ad23-1b6f070fdd41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046b0b3-05f0-4468-817f-355e87552faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c046b0b3-05f0-4468-817f-355e87552faf.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16809,7 +16809,7 @@
         },
         {
             "id": "3dac3f82-0eeb-591b-82f1-08d2fff5ac67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92da2c98-afe0-4e7a-9510-5a74cc2cdde4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92da2c98-afe0-4e7a-9510-5a74cc2cdde4.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16853,7 +16853,7 @@
         },
         {
             "id": "ca6df049-edea-5e26-ba38-6c0cb4c1807c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c0b64b-cade-414d-b893-ac1b633c66d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c0b64b-cade-414d-b893-ac1b633c66d0.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "",
             "colours": [
@@ -16897,7 +16897,7 @@
         },
         {
             "id": "5c185426-0557-53dd-bb04-3e1535ef2e0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d726f3f-2920-4de4-b531-5c42006e85af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d726f3f-2920-4de4-b531-5c42006e85af.jpg?1",
             "name": "Ao, the Dawn Sky",
             "text": "Flying, vigilance\nWhen Ao, the Dawn Sky dies, choose one \u2014\n\u2022 Look at the top seven cards of your library. Put any number of nonland permanent cards with total mana value 4 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\n\u2022 Put two +1/+1 counters on each permanent you control that's a creature or Vehicle.",
             "colours": [
@@ -16937,7 +16937,7 @@
         },
         {
             "id": "34351cf0-60d1-506a-b980-7aded950f2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d801eea3-d549-458a-b099-730969bfcba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d801eea3-d549-458a-b099-730969bfcba7.jpg?1",
             "name": "Brilliant Restoration",
             "text": "Return all artifact and enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -16972,7 +16972,7 @@
         },
         {
             "id": "3ec852bd-04bf-57a9-97ab-5f0fc40abaa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea33e1d-fa3b-4179-9f94-74bc35cdf088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea33e1d-fa3b-4179-9f94-74bc35cdf088.jpg?1",
             "name": "Cloudsteel Kirin",
             "text": "Flying\nEquipped creature has flying and \"You can't lose the game and your opponents can't win the game.\"\nReconfigure {5}",
             "colours": [
@@ -17011,7 +17011,7 @@
         },
         {
             "id": "81cd1f23-4d0c-5e71-96ac-69ff0c695ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050b693-7bad-4c0c-baca-0186d153ce2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050b693-7bad-4c0c-baca-0186d153ce2e.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -17047,7 +17047,7 @@
         },
         {
             "id": "95fe1570-ddc0-5a10-bdf2-58f27bf7aa41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a2079f-2a87-428f-aefc-f7c075a35598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a2079f-2a87-428f-aefc-f7c075a35598.jpg?1",
             "name": "Invoke Justice",
             "text": "Return target permanent card from your graveyard to the battlefield, then distribute four +1/+1 counters among any number of creatures and/or Vehicles target player controls.",
             "colours": [
@@ -17082,7 +17082,7 @@
         },
         {
             "id": "d21d8047-8ebe-5b8b-8150-f065be924cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c446e-986a-4345-aeec-28f4cd8c801b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967c446e-986a-4345-aeec-28f4cd8c801b.jpg?1",
             "name": "Kyodai, Soul of Kamigawa",
             "text": "Flash\nFlying\nWhen Kyodai, Soul of Kamigawa enters the battlefield, another target permanent gains indestructible for as long as you control Kyodai.\n{W}{U}{B}{R}{G}: Kyodai gets +5/+5 until end of turn.",
             "colours": [
@@ -17126,7 +17126,7 @@
         },
         {
             "id": "12cd1e92-46d6-5518-bd5a-29c4be14be78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008fe9b-1913-4358-a411-5d3c175c60ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e008fe9b-1913-4358-a411-5d3c175c60ba.jpg?1",
             "name": "Light-Paws, Emperor's Voice",
             "text": "Whenever an Aura enters the battlefield under your control, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, Emperor's Voice, then shuffle.",
             "colours": [
@@ -17166,7 +17166,7 @@
         },
         {
             "id": "5f5b9dc3-7bd1-5ab8-9b10-91dbbdd4ce30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f8ce4c-c6fc-408c-a216-33374bbfb08d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f8ce4c-c6fc-408c-a216-33374bbfb08d.jpg?1",
             "name": "Lion Sash",
             "text": "{W}: Exile target card from a graveyard. If it was a permanent card, put a +1/+1 counter on Lion Sash.\nEquipped creature gets +1/+1 for each +1/+1 counter on Lion Sash.\nReconfigure {2}",
             "colours": [
@@ -17205,7 +17205,7 @@
         },
         {
             "id": "62e61598-aa38-5da4-820d-fd22da7ed924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbf453c-bded-4d39-bebf-fd240ec44287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbf453c-bded-4d39-bebf-fd240ec44287.jpg?1",
             "name": "March of Otherworldly Light",
             "text": "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
             "colours": [
@@ -17240,7 +17240,7 @@
         },
         {
             "id": "c7fedf9d-a3d2-571c-8446-56e49f42c78b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "I \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nII \u2014 You may discard a card. When you do, return target permanent card with mana value 2 or less from your graveyard to the battlefield tapped.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -17277,7 +17277,7 @@
         },
         {
             "id": "faf8f293-b7b8-5d4c-977a-1018952752f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/070d6344-ee01-4e27-a513-467d8775a853.jpg?1",
             "name": "The Restoration of Eiganjo // Architect of Restoration",
             "text": "Vigilance\nWhenever Architect of Restoration attacks or blocks, create a 1/1 colorless Spirit creature token.",
             "colours": [
@@ -17316,7 +17316,7 @@
         },
         {
             "id": "783e4236-19fe-5927-b644-3f15385cbc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "I \u2014 Return up to one target creature or planeswalker to its owner's hand.\nII \u2014 Return an artifact card from your graveyard to your hand. If you can't, draw a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -17353,7 +17353,7 @@
         },
         {
             "id": "12c20efb-f785-5ddc-9366-c0354b7ceb22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3dd148-60d8-4ab3-b71f-b79f2272d78e.jpg?1",
             "name": "Inventive Iteration // Living Breakthrough",
             "text": "Flying\nWhenever you cast a spell, your opponents can't cast spells with the same mana value as that spell until your next turn.",
             "colours": [
@@ -17391,7 +17391,7 @@
         },
         {
             "id": "01dcf3f8-3106-53ea-b94c-c12a1d42120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8832ae-0f84-48f0-a8f2-0bf37c3a6551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8832ae-0f84-48f0-a8f2-0bf37c3a6551.jpg?1",
             "name": "Invoke the Winds",
             "text": "Gain control of target artifact or creature. Untap it.",
             "colours": [
@@ -17426,7 +17426,7 @@
         },
         {
             "id": "291c02f3-dc12-5ba1-89bc-53a44f9f5c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729a8bdc-3246-482b-a0b7-1d071247d218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729a8bdc-3246-482b-a0b7-1d071247d218.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "Whenever you cast an artifact, instant, or sorcery spell, copy that spell. You may choose new targets for the copy. This ability triggers only once each turn. (A copy of a permanent spell becomes a token.)\nWhenever an opponent casts an artifact, instant, or sorcery spell, counter that spell. This ability triggers only once each turn.",
             "colours": [
@@ -17470,7 +17470,7 @@
         },
         {
             "id": "d146ff34-49e5-5227-9fce-9a90bf2c5493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e356fa-eeeb-44a0-a3ba-90f90a855d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e356fa-eeeb-44a0-a3ba-90f90a855d40.jpg?1",
             "name": "Kairi, the Swirling Sky",
             "text": "Flying, ward {3}\nWhen Kairi, the Swirling Sky dies, choose one \u2014\n\u2022 Return any number of target nonland permanents with total mana value 6 or less to their owners' hands.\n\u2022 Mill six cards, then return up to two instant and/or sorcery cards from your graveyard to your hand.",
             "colours": [
@@ -17510,7 +17510,7 @@
         },
         {
             "id": "b02c0659-c22d-5406-aa13-fcc24f6e73bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e72c2-e229-43c9-9e5a-df4754732d19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e72c2-e229-43c9-9e5a-df4754732d19.jpg?1",
             "name": "March of Swirling Mist",
             "text": "As an additional cost to cast this spell, you may exile any number of blue cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nUp to X target creatures phase out.",
             "colours": [
@@ -17545,7 +17545,7 @@
         },
         {
             "id": "13c324ec-7069-5a2d-8d06-c73cea57ba8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1e4d50-8ca7-4dc0-8181-aa51beafb218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1e4d50-8ca7-4dc0-8181-aa51beafb218.jpg?1",
             "name": "Mindlink Mech",
             "text": "Flying\nWhenever Mindlink Mech becomes crewed for the first time each turn, until end of turn, Mindlink Mech becomes a copy of target nonlegendary creature that crewed it this turn, except it's 4/3, it's a Vehicle artifact in addition to its other types, and it has flying.\nCrew 1",
             "colours": [
@@ -17582,7 +17582,7 @@
         },
         {
             "id": "a8f80842-2893-57b4-b7d2-3cc8acb41d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797bb82-24f6-4dd5-8f5d-b3ea45bb65b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797bb82-24f6-4dd5-8f5d-b3ea45bb65b8.jpg?1",
             "name": "The Reality Chip",
             "text": "You may look at the top card of your library any time.\nAs long as The Reality Chip is attached to a creature, you may play lands and cast spells from the top of your library.\nReconfigure {2}{U}",
             "colours": [
@@ -17623,7 +17623,7 @@
         },
         {
             "id": "5135924b-5736-5bac-9155-efa3d7d4f06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28d4c2-279e-4f73-a134-a47b7cc2fa9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea28d4c2-279e-4f73-a134-a47b7cc2fa9b.jpg?1",
             "name": "Tameshi, Reality Architect",
             "text": "Whenever one or more noncreature permanents are returned to hand, draw a card. This ability triggers only once each turn.\n{X}{W}, Return a land you control to its owner's hand: Return target artifact or enchantment card with mana value X or less from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -17664,7 +17664,7 @@
         },
         {
             "id": "8d1dc7e8-bb0d-50e1-9f67-e0dd115936d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00632c03-be00-4722-85b3-2ce31bba5cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00632c03-be00-4722-85b3-2ce31bba5cc6.jpg?1",
             "name": "Thousand-Faced Shadow",
             "text": "Ninjutsu {2}{U}{U}\nFlying\nWhen Thousand-Faced Shadow enters the battlefield from your hand, if it's attacking, create a token that's a copy of another target attacking creature. The token enters the battlefield tapped and attacking.",
             "colours": [
@@ -17702,7 +17702,7 @@
         },
         {
             "id": "ee450cbd-fac3-5177-8d21-5bcbefa2b47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b1cd2e-cea3-41c6-9fd2-1b473d5f61a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b1cd2e-cea3-41c6-9fd2-1b473d5f61a7.jpg?1",
             "name": "Biting-Palm Ninja",
             "text": "Ninjutsu {2}{B}\nBiting-Palm Ninja enters the battlefield with a menace counter on it.\nWhenever Biting-Palm Ninja deals combat damage to a player, you may remove a menace counter from it. When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
             "colours": [
@@ -17740,7 +17740,7 @@
         },
         {
             "id": "520d89cd-8811-5c80-9dbd-d56a0dc0e4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9896df-0d5c-4b02-b584-345f4c7cd127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9896df-0d5c-4b02-b584-345f4c7cd127.jpg?1",
             "name": "Blade of the Oni",
             "text": "Menace\nEquipped creature has base power and toughness 5/5, has menace, and is a black Demon in addition to its other colors and types.\nReconfigure {2}{B}{B}",
             "colours": [
@@ -17780,7 +17780,7 @@
         },
         {
             "id": "07320e66-550d-5e2c-989f-49361a8de0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9655d9c-d4fb-4ced-b841-543eb4d88d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9655d9c-d4fb-4ced-b841-543eb4d88d2f.jpg?1",
             "name": "Hidetsugu, Devouring Chaos",
             "text": "{B}, Sacrifice a creature: Scry 2.\n{2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.",
             "colours": [
@@ -17825,7 +17825,7 @@
         },
         {
             "id": "6bfcba59-d856-5bba-8f20-19ae096df1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359445e8-2f4a-4e73-9201-2c7a11d26666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359445e8-2f4a-4e73-9201-2c7a11d26666.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -17861,7 +17861,7 @@
         },
         {
             "id": "f5a4c003-496c-531b-8695-76c7471723b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f0f499-35d7-4e04-a2fc-d6735f6087d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f0f499-35d7-4e04-a2fc-d6735f6087d4.jpg?1",
             "name": "Junji, the Midnight Sky",
             "text": "Flying, menace\nWhen Junji, the Midnight Sky dies, choose one \u2014\n\u2022 Each opponent discards two cards and loses 2 life.\n\u2022 Put target non-Dragon creature card from a graveyard onto the battlefield under your control. You lose 2 life.",
             "colours": [
@@ -17901,7 +17901,7 @@
         },
         {
             "id": "30f59f31-f0c7-5152-b18b-69f5dd043dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70647c5f-e2ce-43e0-8715-0648e206caf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70647c5f-e2ce-43e0-8715-0648e206caf8.jpg?1",
             "name": "March of Wretched Sorrow",
             "text": "As an additional cost to cast this spell, you may exile any number of black cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nMarch of Wretched Sorrow deals X damage to target creature or planeswalker and you gain X life.",
             "colours": [
@@ -17936,7 +17936,7 @@
         },
         {
             "id": "9c0ce6d4-c635-5bce-9035-e676ecb66092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d99c1-a6ad-4ab8-abb9-4845f7945f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64d99c1-a6ad-4ab8-abb9-4845f7945f08.jpg?1",
             "name": "Mukotai Soulripper",
             "text": "Whenever Mukotai Soulripper attacks, you may sacrifice another artifact or creature. If you do, put a +1/+1 counter on Mukotai Soulripper and it gains menace until end of turn.\nCrew 2",
             "colours": [
@@ -17973,7 +17973,7 @@
         },
         {
             "id": "430951bf-56bb-5da3-9f9e-d6090058369e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a509120-d075-43cc-9422-35b2bf8183aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a509120-d075-43cc-9422-35b2bf8183aa.jpg?1",
             "name": "Nashi, Moon Sage's Scion",
             "text": "Ninjutsu {3}{B}\nWhenever Nashi, Moon Sage's Scion deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
             "colours": [
@@ -18014,7 +18014,7 @@
         },
         {
             "id": "e4aa0fbc-bdca-5974-99ce-647020a9e654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35ce3d2-8e7b-412a-abde-9885ca4e7a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35ce3d2-8e7b-412a-abde-9885ca4e7a64.jpg?1",
             "name": "Soul Transfer",
             "text": "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both.\n\u2022 Exile target creature or planeswalker.\n\u2022 Return target creature or planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -18049,7 +18049,7 @@
         },
         {
             "id": "04a0628c-3b33-528f-a8f5-44ae525804c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b9c95e-6691-4736-bfbd-0932458f03c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b9c95e-6691-4736-bfbd-0932458f03c6.jpg?1",
             "name": "Tatsunari, Toad Rider",
             "text": "Whenever you cast an enchantment spell, if you don't control a creature named Keimi, create Keimi, a legendary 3/3 black and green Frog creature token with \"Whenever you cast an enchantment spell, each opponent loses 1 life and you gain 1 life.\"\n{1}{GW}: Tatsunari, Toad Rider and target Frog you control can't be blocked this turn except by creatures with flying or reach.",
             "colours": [
@@ -18091,7 +18091,7 @@
         },
         {
             "id": "a6b414cf-44d5-5be3-b343-e0a0ae32317f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "I, II \u2014 Each opponent creates a 1/1 black Rat Rogue creature token.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18128,7 +18128,7 @@
         },
         {
             "id": "8a3ad2e6-6b77-5e71-afe0-fbe27a4fe331",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8f1b467-3cfe-4fab-bfd1-b7ac856d608c.jpg?1",
             "name": "Tribute to Horobi // Echo of Death's Wail",
             "text": "Flying, haste\nWhen Echo of Death's Wail enters the battlefield, gain control of all Rat tokens.\nWhenever Echo of Death's Wail attacks, you may sacrifice another creature. If you do, draw a card.",
             "colours": [
@@ -18166,7 +18166,7 @@
         },
         {
             "id": "2aba0181-6727-59dc-96c3-e9958b7c1e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756ccc1d-e43a-44d6-a722-3e209a164dc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756ccc1d-e43a-44d6-a722-3e209a164dc5.jpg?1",
             "name": "Atsushi, the Blazing Sky",
             "text": "Flying, trample\nWhen Atsushi, the Blazing Sky dies, choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Create three Treasure tokens.",
             "colours": [
@@ -18206,7 +18206,7 @@
         },
         {
             "id": "3ad22d7a-f9b0-57e1-bb8e-5a4a7e88cf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74a2f31-01e6-480b-a722-7a9c972e2a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74a2f31-01e6-480b-a722-7a9c972e2a51.jpg?1",
             "name": "Explosive Singularity",
             "text": "As an additional cost to cast this spell, you may tap any number of untapped creatures you control. This spell costs {1} less to cast for each creature tapped this way.\nExplosive Singularity deals 10 damage to any target.",
             "colours": [
@@ -18242,7 +18242,7 @@
         },
         {
             "id": "1e03fdfd-e583-5b65-bec9-091dde849bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "I \u2014 Create a 2/2 red Goblin Shaman creature token with \"Whenever this creature attacks, create a Treasure token.\"\nII \u2014 You may discard up to two cards. If you do, draw that many cards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18279,7 +18279,7 @@
         },
         {
             "id": "f71fe9b3-8915-5c5d-b736-633995e0c5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1",
             "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
             "text": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -18318,7 +18318,7 @@
         },
         {
             "id": "7981ddcc-b58c-575e-8bd5-e1dc3afed8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d398246a-dc65-4096-b4b7-46ddff38372e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d398246a-dc65-4096-b4b7-46ddff38372e.jpg?1",
             "name": "Goro-Goro, Disciple of Ryusei",
             "text": "{R}: Creatures you control gain haste until end of turn.\n{3}{R}{R}: Create a 5/5 red Dragon Spirit creature token with flying. Activate only if you control an attacking modified creature.",
             "colours": [
@@ -18358,7 +18358,7 @@
         },
         {
             "id": "78fae0ce-75e9-5771-8a29-436d0a52c62b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff8eec-5510-4c57-91c1-ec380fdd7f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff8eec-5510-4c57-91c1-ec380fdd7f8e.jpg?1",
             "name": "Invoke Calamity",
             "text": "You may cast up to two instant and/or sorcery spells with total mana value 6 or less from your graveyard and/or hand without paying their mana costs. If those spells would be put into your graveyard, exile them instead. Exile Invoke Calamity.",
             "colours": [
@@ -18393,7 +18393,7 @@
         },
         {
             "id": "9059563d-4fc7-589b-9d12-3dce7689387a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20833a-ebdf-4daa-8220-ea95758d41b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20833a-ebdf-4daa-8220-ea95758d41b5.jpg?1",
             "name": "Lizard Blades",
             "text": "Double strike\nEquipped creature has double strike.\nReconfigure {2}",
             "colours": [
@@ -18432,7 +18432,7 @@
         },
         {
             "id": "f2d3c476-2e18-52a0-be8a-e686a9bddc89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec97d1-3b8c-4441-b6bc-836be5f8a015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec97d1-3b8c-4441-b6bc-836be5f8a015.jpg?1",
             "name": "March of Reckless Joy",
             "text": "As an additional cost to cast this spell, you may exile any number of red cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile the top X cards of your library. You may play up to two of those cards until the end of your next turn.",
             "colours": [
@@ -18467,7 +18467,7 @@
         },
         {
             "id": "d3d8b587-b21a-51d2-bf39-ee0639103b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eecab66-d600-49d5-8b5a-f70872375d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eecab66-d600-49d5-8b5a-f70872375d8b.jpg?1",
             "name": "Ogre-Head Helm",
             "text": "Equipped creature gets +2/+2.\nWhenever Ogre-Head Helm or equipped creature deals combat damage to a player, you may sacrifice it. If you do, discard your hand, then draw three cards.\nReconfigure {3}",
             "colours": [
@@ -18506,7 +18506,7 @@
         },
         {
             "id": "78750ad3-270c-5d5a-ab25-f1a75ca00176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76866cc1-06a4-4d1d-bbec-724109fa6c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76866cc1-06a4-4d1d-bbec-724109fa6c93.jpg?1",
             "name": "Scrap Welder",
             "text": "{T}, Sacrifice an artifact with mana value X: Return target artifact card with mana value less than X from your graveyard to the battlefield. It gains haste until end of turn.",
             "colours": [
@@ -18544,7 +18544,7 @@
         },
         {
             "id": "27d000ad-d60e-5324-8afa-8dbe0e58abc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49d17cf-242b-4f44-8ea0-125d9d18139c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49d17cf-242b-4f44-8ea0-125d9d18139c.jpg?1",
             "name": "Thundering Raiju",
             "text": "Haste\nWhenever Thundering Raiju attacks, put a +1/+1 counter on target creature you control. Then Thundering Raiju deals X damage to each opponent, where X is the number of modified creatures you control other than Thundering Raiju.",
             "colours": [
@@ -18581,7 +18581,7 @@
         },
         {
             "id": "2fab85d9-1aa3-59c6-81c8-1f6bbc3a3656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "I, II \u2014 You gain 2 life. Look at the top three cards of your library. Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18618,7 +18618,7 @@
         },
         {
             "id": "95ef007a-5073-5ae2-abcf-b9e007bc0afb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f57cb819-1d76-4cbc-bbcd-45e52bd89e04.jpg?1",
             "name": "The Dragon-Kami Reborn // Dragon-Kami's Egg",
             "text": "Whenever Dragon-Kami's Egg or a Dragon you control dies, you may cast a creature spell from among cards you own in exile with hatching counters on them without paying its mana cost.",
             "colours": [
@@ -18656,7 +18656,7 @@
         },
         {
             "id": "931723bf-0fba-557b-91ef-1e6b7b1f66fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5564dc16-22f1-428a-8c49-ecc7de13d4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5564dc16-22f1-428a-8c49-ecc7de13d4a6.jpg?1",
             "name": "Invoke the Ancients",
             "text": "Create two 4/5 green Spirit creature tokens. For each of them, put your choice of a vigilance counter, a reach counter, or a trample counter on it.",
             "colours": [
@@ -18691,7 +18691,7 @@
         },
         {
             "id": "8a819086-cd2c-5843-aaf8-70b73ce63384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "I \u2014 Create a 1/1 green Human Monk creature token with \"{T}: Add {G}.\"\nII \u2014 Put a +1/+1 counter on each of up to two target creatures.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -18728,7 +18728,7 @@
         },
         {
             "id": "ca75c486-f313-5770-a870-a7954e899030",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9d59000-11e0-41ca-9626-9eae22627924.jpg?1",
             "name": "Jugan Defends the Temple // Remnant of the Rising Star",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may pay {X}. When you do, put X +1/+1 counters on that creature.\nAs long as you control five or more modified creatures, Remnant of the Rising Star gets +5/+5 and has trample.",
             "colours": [
@@ -18767,7 +18767,7 @@
         },
         {
             "id": "b209b0f8-a31a-5029-b6f9-06d4e5d90b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bfeaf-ed02-4bf3-a36a-58feda05d992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5bfeaf-ed02-4bf3-a36a-58feda05d992.jpg?1",
             "name": "Kami of Transience",
             "text": "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on Kami of Transience.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return Kami of Transience from your graveyard to your hand.",
             "colours": [
@@ -18804,7 +18804,7 @@
         },
         {
             "id": "b1c118e3-1e7a-5087-b2af-13d0e6c7277f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e17d9-fb24-45ef-aba6-292009834dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33e17d9-fb24-45ef-aba6-292009834dc2.jpg?1",
             "name": "Kodama of the West Tree",
             "text": "Reach\nModified creatures you control have trample.\nWhenever a modified creature you control deals combat damage to a player, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -18844,7 +18844,7 @@
         },
         {
             "id": "bf2f0930-8096-5766-a3a5-c761cfed2e49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765ad05-069b-4224-80ed-2f9bdced2dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d765ad05-069b-4224-80ed-2f9bdced2dae.jpg?1",
             "name": "Kura, the Boundless Sky",
             "text": "Flying, deathtouch\nWhen Kura, the Boundless Sky dies, choose one \u2014\n\u2022 Search your library for up to three land cards, reveal them, put them into your hand, then shuffle.\n\u2022 Create an X/X green Spirit creature token, where X is the number of lands you control.",
             "colours": [
@@ -18884,7 +18884,7 @@
         },
         {
             "id": "f980b6ea-df2c-5b41-a5b2-b8a5eff03af6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36efdf01-9e6f-4963-887a-9018df56ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36efdf01-9e6f-4963-887a-9018df56ced4.jpg?1",
             "name": "March of Burgeoning Life",
             "text": "As an additional cost to cast this spell, you may exile any number of green cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nChoose target creature with mana value less than X. Search your library for a creature card with the same name as that creature, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -18919,7 +18919,7 @@
         },
         {
             "id": "5cf1a289-cc35-5614-a251-cff8e3359bfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd634f0-2373-4747-8b16-92dbf279e1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd634f0-2373-4747-8b16-92dbf279e1ff.jpg?1",
             "name": "Shigeki, Jukai Visionary",
             "text": "{1}{G}, {T}, Return Shigeki, Jukai Visionary to its owner's hand: Reveal the top four cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest into your graveyard.\nChannel \u2014 {X}{X}{G}{G}, Discard Shigeki: Return X target nonlegendary cards from your graveyard to your hand.",
             "colours": [
@@ -18960,7 +18960,7 @@
         },
         {
             "id": "261abec2-2c77-5ff2-a1ed-03bd62ae8e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209115ac-06ef-4d3f-9550-5e9eda081079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209115ac-06ef-4d3f-9550-5e9eda081079.jpg?1",
             "name": "Spring-Leaf Avenger",
             "text": "Ninjutsu {3}{G}\nWhenever Spring-Leaf Avenger deals combat damage to a player, return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -18998,7 +18998,7 @@
         },
         {
             "id": "9ab92083-1da7-5cde-b367-897630072278",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "I \u2014 Mill three cards. Create a 1/1 colorless Spirit creature token.\nII \u2014 Put a +1/+1 counter on target creature you control.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -19035,7 +19035,7 @@
         },
         {
             "id": "748bee3d-89d7-5f11-be37-9d34b590ed64",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af77b3e8-298e-4f85-8fc0-93ffa8c0dc6a.jpg?1",
             "name": "Teachings of the Kirin // Kirin-Touched Orochi",
             "text": "Whenever Kirin-Touched Orochi attacks, choose one \u2014\n\u2022 Exile target creature card from a graveyard. When you do, create a 1/1 colorless Spirit creature token.\n\u2022 Exile target noncreature card from a graveyard. When you do, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -19074,7 +19074,7 @@
         },
         {
             "id": "602b47dd-4f4f-56c2-9828-f7ea08a48bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009fad8-40cb-4421-9fa8-fd525c5f7189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009fad8-40cb-4421-9fa8-fd525c5f7189.jpg?1",
             "name": "Weaver of Harmony",
             "text": "Other enchantment creatures you control get +1/+1.\n{G}, {T}: Copy target activated or triggered ability you control from an enchantment source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
             "colours": [
@@ -19113,7 +19113,7 @@
         },
         {
             "id": "dcff09f9-74f5-5c45-8d88-6428b1fb3e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d6851-f110-46aa-a4ed-f657d2d2eceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33d6851-f110-46aa-a4ed-f657d2d2eceb.jpg?1",
             "name": "Eiganjo Uprising",
             "text": "Create X 2/2 white Samurai creature tokens with vigilance. They gain menace and haste until end of turn.\nEach opponent creates X minus one 2/2 white Samurai creature tokens with vigilance.",
             "colours": [
@@ -19150,7 +19150,7 @@
         },
         {
             "id": "09423682-808a-5779-8f5c-5343416f8076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020a4094-e5d8-477b-930f-f7ab98dc9fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/020a4094-e5d8-477b-930f-f7ab98dc9fb1.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "At the beginning of combat on your turn, return target Vehicle card from your graveyard to the battlefield. It gains haste. Return it to its owner's hand at the beginning of your next end step.",
             "colours": [
@@ -19192,7 +19192,7 @@
         },
         {
             "id": "88416c94-7ae8-5c4a-8ddf-277f2b9227bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "I \u2014 Destroy each nonland permanent with mana value 1 or less.\nII \u2014 Exile all graveyards.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -19231,7 +19231,7 @@
         },
         {
             "id": "609e9c73-8507-5e26-9964-74506ad9cee4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6a8ead0-df99-4a55-8f64-99cfc47baa9f.jpg?1",
             "name": "Hidetsugu Consumes All // Vessel of the All-Consuming",
             "text": "Trample\nWhenever Vessel of the All-Consuming deals damage, put a +1/+1 counter on it.\nWhenever Vessel of the All-Consuming deals damage to a player, if it has dealt 10 or more damage to that player this turn, they lose the game.",
             "colours": [
@@ -19272,7 +19272,7 @@
         },
         {
             "id": "edb016ac-f74f-5f4b-8904-fdc3eaea47e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/466f98c4-c5a7-4fad-b183-a3fbd28cb66b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/466f98c4-c5a7-4fad-b183-a3fbd28cb66b.jpg?1",
             "name": "Hinata, Dawn-Crowned",
             "text": "Flying, trample\nSpells you cast cost {1} less to cast for each target.\nSpells your opponents cast cost {1} more to cast for each target.",
             "colours": [
@@ -19316,7 +19316,7 @@
         },
         {
             "id": "87cb62e8-6027-57a6-ae48-93e565f53414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26eeb39-77ab-4e60-8b10-1420e755c372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26eeb39-77ab-4e60-8b10-1420e755c372.jpg?1",
             "name": "Isshin, Two Heavens as One",
             "text": "If a creature attacking would cause a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -19360,7 +19360,7 @@
         },
         {
             "id": "136c4e09-8eeb-5878-a0aa-b67f5a267d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "I \u2014 Exile target nonland permanent an opponent controls.\nII \u2014 Return up to one other target nonland permanent to its owner's hand. Then each opponent discards a card.\nIII \u2014 Exile this Saga, then return it to the battlefield transformed under your control.",
             "colours": [
@@ -19405,7 +19405,7 @@
         },
         {
             "id": "13903bf8-0ee7-5f97-a12a-bcb42e5830fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/68dfd0ee-64bf-425d-a847-c4a72f84d8aa.jpg?1",
             "name": "The Kami War // O-Kagachi Made Manifest",
             "text": "O-Kagachi Made Manifest is all colors.\nFlying, trample\nWhenever O-Kagachi Made Manifest attacks, defending player chooses a nonland card in your graveyard. Return that card to your hand. O-Kagachi Made Manifest gets +X/+0 until end of turn, where X is the mana value of that card.",
             "colours": [
@@ -19452,7 +19452,7 @@
         },
         {
             "id": "5e11809b-9426-53a2-a75c-31195475acdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabc4c53-365e-412e-8ce4-a9e67d12c33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabc4c53-365e-412e-8ce4-a9e67d12c33f.jpg?1",
             "name": "Kotose, the Silent Spider",
             "text": "When Kotose, the Silent Spider enters the battlefield, exile target card other than a basic land card from an opponent's graveyard. Search that player's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles. For as long as you control Kotose, you may play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -19494,7 +19494,7 @@
         },
         {
             "id": "c2b571a3-2f03-5b0e-a5ce-4dc48ae8af85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89f16b7-fcfb-44a9-b05f-a77a157a9865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89f16b7-fcfb-44a9-b05f-a77a157a9865.jpg?1",
             "name": "Raiyuu, Storm's Edge",
             "text": "First strike\nWhenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "colours": [
@@ -19536,7 +19536,7 @@
         },
         {
             "id": "99297d05-6772-5552-83e8-6443add89dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5db6d6-c8b4-4c38-8b94-f455f148cf3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5db6d6-c8b4-4c38-8b94-f455f148cf3f.jpg?1",
             "name": "Risona, Asari Commander",
             "text": "Haste\nWhenever Risona, Asari Commander deals combat damage to a player, if it doesn't have an indestructible counter on it, put an indestructible counter on it.\nWhenever combat damage is dealt to you, remove an indestructible counter from Risona.",
             "colours": [
@@ -19579,7 +19579,7 @@
         },
         {
             "id": "b391ae18-e4fb-5660-8d1d-4ddf65f0f78b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb4d0a-f979-42ed-a4aa-15c180e4f0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fb4d0a-f979-42ed-a4aa-15c180e4f0be.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -19623,7 +19623,7 @@
         },
         {
             "id": "ec9c47d6-697c-54de-b110-7eecc071ca1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80aa5a9e-5152-4dc0-9a98-089a3d4d7dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80aa5a9e-5152-4dc0-9a98-089a3d4d7dda.jpg?1",
             "name": "Satsuki, the Living Lore",
             "text": "{T}: Put a lore counter on each Saga you control. Activate only as a sorcery.\nWhen Satsuki, the Living Lore dies, choose up to one \u2014\n\u2022 Return target Saga or enchantment creature you control to its owner's hand.\n\u2022 Return target Saga card from your graveyard to your hand.",
             "colours": [
@@ -19665,7 +19665,7 @@
         },
         {
             "id": "7a12c7d5-0224-5df9-aeaf-e255f4040458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e7b4ab-bc2c-4dd0-9433-6266c86c1c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e7b4ab-bc2c-4dd0-9433-6266c86c1c84.jpg?1",
             "name": "Spirit-Sister's Call",
             "text": "At the beginning of your end step, choose target permanent card in your graveyard. You may sacrifice a permanent that shares a card type with the chosen card. If you do, return the chosen card from your graveyard to the battlefield and it gains \"If this permanent would leave the battlefield, exile it instead of putting it anywhere else.\"",
             "colours": [
@@ -19702,7 +19702,7 @@
         },
         {
             "id": "1fc634ea-576a-57cf-92f9-c270a70befc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a86f45-ba70-48b4-a2e9-8269ec22b991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a86f45-ba70-48b4-a2e9-8269ec22b991.jpg?1",
             "name": "Eater of Virtue",
             "text": "Whenever equipped creature dies, exile it.\nEquipped creature gets +2/+0.\nAs long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.\nEquip {1}",
             "colours": [],
@@ -19737,7 +19737,7 @@
         },
         {
             "id": "aacbd487-4cf9-5e6a-9994-d622138b5431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9430b849-cee9-4fda-84c1-0777db82fe58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9430b849-cee9-4fda-84c1-0777db82fe58.jpg?1",
             "name": "Mechtitan Core",
             "text": "{5}, Exile Mechtitan Core and four other artifact creatures and/or Vehicles you control: Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors. When that token leaves the battlefield, return all cards exiled with Mechtitan Core except Mechtitan Core to the battlefield tapped under their owners' control.\nCrew 2",
             "colours": [],
@@ -19770,7 +19770,7 @@
         },
         {
             "id": "bccc949c-99a1-5c1e-9281-1eeab0d711be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8354b07-8dac-44bb-871f-3c8f60a20d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8354b07-8dac-44bb-871f-3c8f60a20d1c.jpg?1",
             "name": "Mirror Box",
             "text": "The \"legend rule\" doesn't apply to permanents you control.\nEach legendary creature you control gets +1/+1.\nEach nontoken creature you control gets +1/+1 for each other creature you control with the same name as that creature.",
             "colours": [],
@@ -19801,7 +19801,7 @@
         },
         {
             "id": "d5cc74ab-7262-530e-b626-1023305f91c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5d9a22-0111-40ba-8d9e-a36bd84a39c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5d9a22-0111-40ba-8d9e-a36bd84a39c3.jpg?1",
             "name": "Reckoner Bankbuster",
             "text": "Reckoner Bankbuster enters the battlefield with three charge counters on it.\n{2}, {T}, Remove a charge counter from Reckoner Bankbuster: Draw a card. Then if there are no charge counters on Reckoner Bankbuster, create a Treasure token and a 1/1 colorless Pilot creature token with \"This creature crews Vehicles as though its power were 2 greater.\"\nCrew 3",
             "colours": [],
@@ -19834,7 +19834,7 @@
         },
         {
             "id": "2cbaf6d5-9ae0-5470-8de9-cb6d07697bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ce02c6-0918-41a7-9286-7a0bdc0f166e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ce02c6-0918-41a7-9286-7a0bdc0f166e.jpg?1",
             "name": "Surgehacker Mech",
             "text": "Menace\nWhen Surgehacker Mech enters the battlefield, it deals damage equal to twice the number of Vehicles you control to target creature or planeswalker an opponent controls.\nCrew 4",
             "colours": [],
@@ -19867,7 +19867,7 @@
         },
         {
             "id": "488ed991-4cc1-53d5-89b1-c3bb99fa1d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2488a80b-6882-4b59-8232-f02f800204a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2488a80b-6882-4b59-8232-f02f800204a9.jpg?1",
             "name": "Boseiju, Who Endures",
             "text": "{T}: Add {G}.\nChannel \u2014 {1}{G}, Discard Boseiju, Who Endures: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -19902,7 +19902,7 @@
         },
         {
             "id": "ec3589f5-def0-5b85-91dc-77eeb1ad152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb53f59-d89b-481c-af98-75c11c30ee17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb53f59-d89b-481c-af98-75c11c30ee17.jpg?1",
             "name": "Eiganjo, Seat of the Empire",
             "text": "{T}: Add {W}.\nChannel \u2014 {2}{W}, Discard Eiganjo, Seat of the Empire: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -19937,7 +19937,7 @@
         },
         {
             "id": "38c008cf-1cc7-5e8c-8855-c84570dc0b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdbf15-7578-465e-afa2-f65c01fb4802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdbf15-7578-465e-afa2-f65c01fb4802.jpg?1",
             "name": "Otawara, Soaring City",
             "text": "{T}: Add {U}.\nChannel \u2014 {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -19972,7 +19972,7 @@
         },
         {
             "id": "6d7093e3-3133-5148-ac5f-8e161e0dd1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca9f8ae-838f-4a9c-9341-38e39da68926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca9f8ae-838f-4a9c-9341-38e39da68926.jpg?1",
             "name": "Sokenzan, Crucible of Defiance",
             "text": "{T}: Add {R}.\nChannel \u2014 {3}{R}, Discard Sokenzan, Crucible of Defiance: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -20007,7 +20007,7 @@
         },
         {
             "id": "375e116f-e257-5bf9-92c8-2b69aee150e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13410bd5-acee-4cc9-90e3-dbcf8415bcaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13410bd5-acee-4cc9-90e3-dbcf8415bcaf.jpg?1",
             "name": "Takenuma, Abandoned Mire",
             "text": "{T}: Add {B}.\nChannel \u2014 {3}{B}, Discard Takenuma, Abandoned Mire: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
             "colours": [],
@@ -20042,7 +20042,7 @@
         },
         {
             "id": "8c3a2f60-6cd3-557f-9c29-7694b7b526d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe6d3be-67b9-45be-a5c8-4edf753a7fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbe6d3be-67b9-45be-a5c8-4edf753a7fd0.jpg?1",
             "name": "Invoke Despair",
             "text": "Target opponent sacrifices a creature. If they can't, they lose 2 life and you draw a card. Then repeat this process for an enchantment and a planeswalker.",
             "colours": [
@@ -20078,7 +20078,7 @@
         },
         {
             "id": "8d93fe3c-e3d1-52e0-8cc5-1dd3c8b01c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7112729-908e-430d-8e0e-eb71a9043309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7112729-908e-430d-8e0e-eb71a9043309.jpg?1",
             "name": "Satoru Umezawa",
             "text": "Whenever you activate a ninjutsu ability, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. This ability triggers only once each turn.\nEach creature card in your hand has ninjutsu {2}{U}{B}.",
             "colours": [
@@ -20121,7 +20121,7 @@
         },
         {
             "id": "55f218e3-c32b-59f9-9d56-56267c635fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae5aecd-f1e3-4a1a-92a7-69235437102d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae5aecd-f1e3-4a1a-92a7-69235437102d.jpg?1",
             "name": "Spirited Companion",
             "text": "When Spirited Companion enters the battlefield, draw a card.",
             "colours": [
@@ -20158,7 +20158,7 @@
         },
         {
             "id": "6f07d674-4a76-5968-b321-18dd1aabcf67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a43b94-4425-47ab-9e9f-9287aa9a807e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a43b94-4425-47ab-9e9f-9287aa9a807e.jpg?1",
             "name": "Enthusiastic Mechanaut",
             "text": "Flying\nArtifact spells you cast cost {1} less to cast.",
             "colours": [
@@ -20198,7 +20198,7 @@
         },
         {
             "id": "c8c41aed-78ba-5861-a8d2-a6e7b638a2be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa567185-e0f2-4fe1-82a8-57b7fb277ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa567185-e0f2-4fe1-82a8-57b7fb277ab9.jpg?1",
             "name": "Jukai Naturalist",
             "text": "Lifelink\nEnchantment spells you cast cost {1} less to cast.",
             "colours": [
@@ -20238,7 +20238,7 @@
         },
         {
             "id": "181c8b04-2aea-5b87-b8da-916036993cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1eef728-8f2f-4b18-ae40-f14074ab6791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1eef728-8f2f-4b18-ae40-f14074ab6791.jpg?1",
             "name": "Silver-Fur Master",
             "text": "Ninjutsu {U}{B}\nNinjutsu abilities you activate cost {1} less to activate.\nOther Ninja and Rogue creatures you control get +1/+1.",
             "colours": [
@@ -20278,7 +20278,7 @@
         },
         {
             "id": "56f456ca-cf4a-5e0d-a216-80de38e4e956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb026a80-72ae-4969-b2e7-ed88ecc542a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb026a80-72ae-4969-b2e7-ed88ecc542a1.jpg?1",
             "name": "Secluded Courtyard",
             "text": "As Secluded Courtyard enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature or creature card of the chosen type.",
             "colours": [],
@@ -20308,7 +20308,7 @@
         },
         {
             "id": "46a97d70-e73b-5117-80e7-3c1ca286ca51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c395a69-b60d-4510-b04b-86b59ed2b158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c395a69-b60d-4510-b04b-86b59ed2b158.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "",
             "colours": [
@@ -20352,7 +20352,7 @@
         },
         {
             "id": "10ea1fa3-6c35-57af-862d-9693bca5e728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5ffb0d-1fc3-40da-ac1f-19465aa8412b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5ffb0d-1fc3-40da-ac1f-19465aa8412b.jpg?1",
             "name": "Jin-Gitaxias, Progress Tyrant",
             "text": "",
             "colours": [
@@ -20395,7 +20395,7 @@
         },
         {
             "id": "6c112277-fd0b-5566-a5f5-0f59216e0444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be84f259-2809-48c9-9c70-861437f08c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be84f259-2809-48c9-9c70-861437f08c23.jpg?1",
             "name": "Pilot",
             "text": "",
             "colours": [],
@@ -20425,7 +20425,7 @@
         },
         {
             "id": "af3f43ba-5ccd-5df8-bb7b-5b26307c67b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -20455,7 +20455,7 @@
         },
         {
             "id": "0979b2d0-05a6-5616-b7be-75c1777f6cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg?1",
             "name": "Samurai",
             "text": "",
             "colours": [
@@ -20489,7 +20489,7 @@
         },
         {
             "id": "e279e34e-2bb6-5fc5-9f24-e2d8441c8b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14eb629e-f09f-4deb-b434-7615a3010a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14eb629e-f09f-4deb-b434-7615a3010a4d.jpg?1",
             "name": "Ninja",
             "text": "",
             "colours": [
@@ -20523,7 +20523,7 @@
         },
         {
             "id": "9179b14e-8e42-594c-bb1a-b2ef2b4cadbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f72ea-13e6-40ab-afc7-55657701c82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695f72ea-13e6-40ab-afc7-55657701c82d.jpg?1",
             "name": "Rat Rogue",
             "text": "",
             "colours": [
@@ -20558,7 +20558,7 @@
         },
         {
             "id": "ff7baed0-4359-5fe5-bd9b-abb6234677ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbafdfc0-380a-482b-b5f8-a7a00ecf8da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbafdfc0-380a-482b-b5f8-a7a00ecf8da6.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [
@@ -20593,7 +20593,7 @@
         },
         {
             "id": "90c08b72-09bc-50dd-82c2-00c0d6906d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c06e08-2026-471d-a6d0-bbb0f040420a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c06e08-2026-471d-a6d0-bbb0f040420a.jpg?1",
             "name": "Dragon Spirit",
             "text": "",
             "colours": [
@@ -20628,7 +20628,7 @@
         },
         {
             "id": "54edcc8d-dc97-5a6e-b42b-00d63b81e738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9461c3-f545-4efb-926e-759961db0495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9461c3-f545-4efb-926e-759961db0495.jpg?1",
             "name": "Goblin Shaman",
             "text": "",
             "colours": [
@@ -20663,7 +20663,7 @@
         },
         {
             "id": "3678f749-eef6-5616-a8f0-b019b350f8a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20e427c-efa5-476c-aa33-e3149648d207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20e427c-efa5-476c-aa33-e3149648d207.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20697,7 +20697,7 @@
         },
         {
             "id": "64544fb1-96f2-59f1-a427-0a8ec477a8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dd086e-c757-4a6a-8838-51860f2095f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dd086e-c757-4a6a-8838-51860f2095f8.jpg?1",
             "name": "Human Monk",
             "text": "",
             "colours": [
@@ -20732,7 +20732,7 @@
         },
         {
             "id": "8d87d9c3-08f4-516a-b53d-0c28162ae064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f48aaab-dd6e-4bcc-a8fb-d31dd4a098ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f48aaab-dd6e-4bcc-a8fb-d31dd4a098ba.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20766,7 +20766,7 @@
         },
         {
             "id": "c06ee636-394e-505c-8844-ac3c012e5a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237377d-b79b-4f27-a142-e2c1756e0d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237377d-b79b-4f27-a142-e2c1756e0d94.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -20800,7 +20800,7 @@
         },
         {
             "id": "385c70a5-88a4-5ba7-8a01-51688d3af742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb5b3f9-0012-4deb-b795-c377cdfe546b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbb5b3f9-0012-4deb-b795-c377cdfe546b.jpg?1",
             "name": "Keimi",
             "text": "",
             "colours": [
@@ -20838,7 +20838,7 @@
         },
         {
             "id": "023515e1-6755-56be-a01a-6f75b668a182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0281825d-9d38-4b56-b522-a8d3cf8c77c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0281825d-9d38-4b56-b522-a8d3cf8c77c9.jpg?1",
             "name": "Mechtitan",
             "text": "",
             "colours": [
@@ -20883,7 +20883,7 @@
         },
         {
             "id": "68fddd02-839b-556e-abc3-c1ec59dcf867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2770f887-7e96-44d1-864a-8c0504a39785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2770f887-7e96-44d1-864a-8c0504a39785.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -20914,7 +20914,7 @@
         },
         {
             "id": "e1afd0a4-f8bf-53eb-8c21-034d1240c3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992cb1e0-e846-4710-b49e-a748e4ebffa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992cb1e0-e846-4710-b49e-a748e4ebffa5.jpg?1",
             "name": "Tamiyo's Notebook",
             "text": "",
             "colours": [],
@@ -20944,7 +20944,7 @@
         },
         {
             "id": "fe4dffe8-dc27-5c0d-aaa3-589a15e78f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911181d-573b-41eb-96a4-799c96e008fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6911181d-573b-41eb-96a4-799c96e008fc.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -20974,7 +20974,7 @@
         },
         {
             "id": "274930fe-6153-55a8-8c05-c8e88b7fac19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df296190-e51b-44a7-ae83-279fee3151a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df296190-e51b-44a7-ae83-279fee3151a5.jpg?1",
             "name": "Kaito Shizuki Emblem",
             "text": "",
             "colours": [],
@@ -21001,7 +21001,7 @@
         },
         {
             "id": "7ee89398-0e02-5dc6-837e-c5105a01e4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb4fa32-18dd-4530-a529-5477e45413dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb4fa32-18dd-4530-a529-5477e45413dd.jpg?1",
             "name": "Tezzeret, Betrayer of Flesh Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/NPH.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/NPH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8130be98-f21c-5977-be37-823d59751a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9287151-95df-4f5a-b32a-4b0aea825452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9287151-95df-4f5a-b32a-4b0aea825452.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from his or her hand.\n-3: Exile target permanent.\n-14: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -36,7 +36,7 @@
         },
         {
             "id": "dde65be5-56df-5126-b0b4-29894c7accda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7c3571-925d-486e-80dd-bac47aa48283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7c3571-925d-486e-80dd-bac47aa48283.jpg?1",
             "name": "Apostle's Blessing",
             "text": "({PW} can be paid with either {W} or 2 life.)\nTarget artifact or creature you control gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "6d2fd5b4-5a83-58e7-8a0a-80c93aeb4035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deffb601-6a53-4d88-a6af-686ce97eb4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deffb601-6a53-4d88-a6af-686ce97eb4f0.jpg?1",
             "name": "Auriok Survivors",
             "text": "When Auriok Survivors enters the battlefield, you may return target Equipment card from your graveyard to the battlefield. If you do, you may attach it to Auriok Survivors.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "fd9c8e7a-c050-551a-8e5a-a3e1ee821f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e56a28-713b-4a13-a601-1128cf117539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e56a28-713b-4a13-a601-1128cf117539.jpg?1",
             "name": "Blade Splicer",
             "text": "When Blade Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control have first strike.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "6fb3c0bb-1174-55e8-8cb2-a49fa606a5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07592731-68be-4218-bb2c-c2523c5a27f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07592731-68be-4218-bb2c-c2523c5a27f1.jpg?1",
             "name": "Cathedral Membrane",
             "text": "({PW} can be paid with either {W} or 2 life.)\nDefender\nWhen Cathedral Membrane is put into a graveyard from the battlefield during combat, it deals 6 damage to each creature it blocked this combat.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "8c98e08d-8ffb-5958-a59a-bbb30b70af8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1b482a-badb-4b9a-ab63-2e7944826aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1b482a-badb-4b9a-ab63-2e7944826aa0.jpg?1",
             "name": "Chancellor of the Annex",
             "text": "You may reveal this card from your opening hand. If you do, when each opponent casts his or her first spell of the game, counter that spell unless that player pays {1}.\nFlying\nWhenever an opponent casts a spell, counter it unless that player pays {1}.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "986531ec-1fe2-584f-a220-ef73ddd73c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496634f9-1271-4be7-bad5-364bb87a6962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496634f9-1271-4be7-bad5-364bb87a6962.jpg?1",
             "name": "Dispatch",
             "text": "Tap target creature.\nMetalcraft \u2014 If you control three or more artifacts, exile that creature.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "8064c4c6-6b58-5c9b-8849-64cd42481ded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7159850-964b-4f12-957f-614eb0570544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7159850-964b-4f12-957f-614eb0570544.jpg?1",
             "name": "Due Respect",
             "text": "Permanents enter the battlefield tapped this turn.\nDraw a card.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "eb466fee-cd94-5313-9cd3-4cd2423a6ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66390d6-1649-4bfa-92d3-77664650d552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b66390d6-1649-4bfa-92d3-77664650d552.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "Vigilance\nOther creatures you control get +2/+2.\nCreatures your opponents control get -2/-2.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "e5299b7a-bedf-5208-9223-68d7794357fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3b826a-7349-45ae-89bf-675fea7ce8e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e3b826a-7349-45ae-89bf-675fea7ce8e3.jpg?1",
             "name": "Exclusion Ritual",
             "text": "Imprint \u2014 When Exclusion Ritual enters the battlefield, exile target nonland permanent.\nPlayers can't cast spells with the same name as the exiled card.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "038f4ef3-8f50-51a5-84e7-66dd05c03f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e050701d-4609-470d-85ff-4b7638893c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e050701d-4609-470d-85ff-4b7638893c6a.jpg?1",
             "name": "Forced Worship",
             "text": "Enchant creature\nEnchanted creature can't attack.\n{2}{W}: Return Forced Worship to its owner's hand.",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "57159a07-07a6-5719-b54a-f8a511182c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e241a0-a027-494b-8187-6ecb006d1d33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e241a0-a027-494b-8187-6ecb006d1d33.jpg?1",
             "name": "Inquisitor Exarch",
             "text": "When Inquisitor Exarch enters the battlefield, choose one \u2014 You gain 2 life; or target opponent loses 2 life.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "48a42da3-e6c0-5a3a-b121-d5a98c315eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8209fa5d-2c0e-4827-813b-fff123533f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8209fa5d-2c0e-4827-813b-fff123533f16.jpg?1",
             "name": "Lost Leonin",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "521a6122-7410-5a6a-bad2-854d29ca579e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c050c3-4f50-4bb6-8477-6737887ca10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c050c3-4f50-4bb6-8477-6737887ca10d.jpg?1",
             "name": "Loxodon Convert",
             "text": "",
             "colours": [
@@ -484,7 +484,7 @@
         },
         {
             "id": "2ce98b48-c7c3-53b3-bbae-9ffe85db4689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ca60ee-e54b-4a28-b6a6-7bf3503c35b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ca60ee-e54b-4a28-b6a6-7bf3503c35b4.jpg?1",
             "name": "Marrow Shards",
             "text": "({PW} can be paid with either {W} or 2 life.)\nMarrow Shards deals 1 damage to each attacking creature.",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "82981058-1a50-501d-9cc6-f47a051930e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2b91-63af-4700-8ca5-b1756aa6639b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859d2b91-63af-4700-8ca5-b1756aa6639b.jpg?1",
             "name": "Master Splicer",
             "text": "When Master Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control get +1/+1.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "11f21d9a-4899-5529-8304-48ebdaa0b803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64073f2-99f5-4dc7-9403-e7cb94ce0e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64073f2-99f5-4dc7-9403-e7cb94ce0e60.jpg?1",
             "name": "Norn's Annex",
             "text": "({PW} can be paid with either {W} or 2 life.)\nCreatures can't attack you or a planeswalker you control unless their controller pays {PW} for each of those creatures.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "5f9c3025-5531-5050-aae0-199fff681c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a1e16a-39f0-47ab-aba8-73e82ba9ab18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a1e16a-39f0-47ab-aba8-73e82ba9ab18.jpg?1",
             "name": "Phyrexian Unlife",
             "text": "You don't lose the game for having 0 or less life.\nAs long as you have 0 or less life, all damage is dealt to you as though its source had infect. (Damage is dealt to you in the form of poison counters.)",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "57761de5-5958-5c03-aea8-19dc038977f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616aa0e-8413-4e63-877c-bffd5263f552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616aa0e-8413-4e63-877c-bffd5263f552.jpg?1",
             "name": "Porcelain Legionnaire",
             "text": "({PW} can be paid with either {W} or 2 life.)\nFirst strike",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "1b103515-a22d-50a5-a651-c013a2114362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca100248-fcd6-41ed-8d75-bcb473845edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca100248-fcd6-41ed-8d75-bcb473845edd.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "5a934f4d-e3d0-59d9-970c-794b420cdad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9b8325-2a28-4312-b778-40087f8ea778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9b8325-2a28-4312-b778-40087f8ea778.jpg?1",
             "name": "Remember the Fallen",
             "text": "Choose one or both \u2014 Return target creature card from your graveyard to your hand; and/or return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "d825ab4b-8123-582c-8f0b-44848c0ec925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79076264-d71c-4b30-aac9-702a4d229933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79076264-d71c-4b30-aac9-702a4d229933.jpg?1",
             "name": "Sensor Splicer",
             "text": "When Sensor Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control have vigilance.",
             "colours": [
@@ -754,7 +754,7 @@
         },
         {
             "id": "c1e3c300-295b-5ca6-97b2-432084c40b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f94e9-91cd-48da-873f-2da2b03a4965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012f94e9-91cd-48da-873f-2da2b03a4965.jpg?1",
             "name": "Shattered Angel",
             "text": "Flying\nWhenever a land enters the battlefield under an opponent's control, you may gain 3 life.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "3cfc4510-8ec3-583c-90e6-e89ca819e114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73071a3b-9329-418e-9285-fa4765463d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73071a3b-9329-418e-9285-fa4765463d1f.jpg?1",
             "name": "Shriek Raptor",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "9fe2de06-25b4-5729-ac3d-e5f879cccc35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31432e98-86cd-42ea-ad37-eb4383dc6a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31432e98-86cd-42ea-ad37-eb4383dc6a81.jpg?1",
             "name": "Suture Priest",
             "text": "Whenever another creature enters the battlefield under your control, you may gain 1 life.\nWhenever a creature enters the battlefield under an opponent's control, you may have that player lose 1 life.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "fbe84364-567a-59db-9c95-bfdbbaeef97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d837262-cd5d-4fc9-96dd-39ed04166883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d837262-cd5d-4fc9-96dd-39ed04166883.jpg?1",
             "name": "War Report",
             "text": "You gain life equal to the number of creatures on the battlefield plus the number of artifacts on the battlefield.",
             "colours": [
@@ -891,7 +891,7 @@
         },
         {
             "id": "2a673723-f6cb-5c3f-b70f-918d9ca85a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507fa5fd-2aa5-4721-a059-2c8c3056a4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507fa5fd-2aa5-4721-a059-2c8c3056a4ca.jpg?1",
             "name": "Argent Mutation",
             "text": "Target permanent becomes an artifact in addition to its other types until end of turn.\nDraw a card.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "6a3a2439-6c13-592d-9d11-8272947563bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0878b20-315d-49fa-a4d7-232ba1ed6b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0878b20-315d-49fa-a4d7-232ba1ed6b0d.jpg?1",
             "name": "Arm with Aether",
             "text": "Until end of turn, creatures you control gain \"Whenever this creature deals damage to an opponent, you may return target creature that player controls to its owner's hand.\"",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "8d615557-102a-5b2a-b701-85227e417574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddaebde-a060-4510-8c97-68432d931987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddaebde-a060-4510-8c97-68432d931987.jpg?1",
             "name": "Blighted Agent",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nBlighted Agent is unblockable.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "3081b169-78b6-5072-ab6f-d6175a69685b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7bb447-c2b0-429e-bf82-02d6a966fe73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7bb447-c2b0-429e-bf82-02d6a966fe73.jpg?1",
             "name": "Chained Throatseeker",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nChained Throatseeker can't attack unless defending player is poisoned.",
             "colours": [
@@ -1026,7 +1026,7 @@
         },
         {
             "id": "ed8003ff-8cc7-511b-a2d0-ab8284833d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e06e16-96fa-4611-b4a9-512eeeeddd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e06e16-96fa-4611-b4a9-512eeeeddd3c.jpg?1",
             "name": "Chancellor of the Spires",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, each opponent puts the top seven cards of his or her library into his or her graveyard.\nFlying\nWhen Chancellor of the Spires enters the battlefield, you may cast target instant or sorcery card from an opponent's graveyard without paying its mana cost.",
             "colours": [
@@ -1061,7 +1061,7 @@
         },
         {
             "id": "92a0d797-2615-51cc-83e5-75cdbc9cd347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28432161-023b-4a98-b92a-55dc6d936cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28432161-023b-4a98-b92a-55dc6d936cd1.jpg?1",
             "name": "Corrupted Resolve",
             "text": "Counter target spell if its controller is poisoned.",
             "colours": [
@@ -1093,7 +1093,7 @@
         },
         {
             "id": "b9f1c267-f3ff-5cb4-86d5-c757e7f1f3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f123ad6-fe84-4fed-9c0f-6b41921e9c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f123ad6-fe84-4fed-9c0f-6b41921e9c26.jpg?1",
             "name": "Deceiver Exarch",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Deceiver Exarch enters the battlefield, choose one \u2014 Untap target permanent you control; or tap target permanent an opponent controls.",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "fcb14a82-2e05-55ee-8188-1d64891f2878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0670653-d4fe-4fac-b769-d19ca4698c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0670653-d4fe-4fac-b769-d19ca4698c97.jpg?1",
             "name": "Defensive Stance",
             "text": "Enchant creature\nEnchanted creature gets -1/+1.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "46575881-efb3-5df5-93aa-2ed44b7852da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995486ce-58bb-4753-a812-0ca73ef1a235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995486ce-58bb-4753-a812-0ca73ef1a235.jpg?1",
             "name": "Gitaxian Probe",
             "text": "({PU} can be paid with either {U} or 2 life.)\nLook at target player's hand.\nDraw a card.",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "4a3540e4-a836-5b02-9058-13d49080ffb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e1f8b5-4792-457d-b3de-1d4874ddf72e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e1f8b5-4792-457d-b3de-1d4874ddf72e.jpg?1",
             "name": "Impaler Shrike",
             "text": "Flying\nWhen Impaler Shrike deals combat damage to a player, you may sacrifice it. If you do, draw three cards.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "7e3e1df1-49dc-5586-9de4-74032da6e280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd46fc9f-5b92-44d7-8940-2f39b0962b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd46fc9f-5b92-44d7-8940-2f39b0962b8f.jpg?1",
             "name": "Jin-Gitaxias, Core Augur",
             "text": "Flash\nAt the beginning of your end step, draw seven cards.\nEach opponent's maximum hand size is reduced by seven.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "0f0c9ca6-9687-5454-8d54-2c91c5d49a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e9c6df-1c84-4eab-9076-a4feb6347c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e9c6df-1c84-4eab-9076-a4feb6347c10.jpg?1",
             "name": "Mental Misstep",
             "text": "({PU} can be paid with either {U} or 2 life.)\nCounter target spell with converted mana cost 1.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "56d7dfca-775b-50b1-8633-616f914fee82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faf4372-6fb5-48aa-9b94-b0e77c867116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6faf4372-6fb5-48aa-9b94-b0e77c867116.jpg?1",
             "name": "Mindculling",
             "text": "You draw two cards and target opponent discards two cards.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "de3729ed-f58b-541d-a600-02fcb571b88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f28a0f4-43e1-46df-8b6a-d588c5cceb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f28a0f4-43e1-46df-8b6a-d588c5cceb88.jpg?1",
             "name": "Numbing Dose",
             "text": "Enchant artifact or creature\nEnchanted permanent doesn't untap during its controller's untap step.\nAt the beginning of the upkeep of enchanted permanent's controller, that player loses 1 life.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "8027cc50-ee1e-5559-88b5-2b6a8fce175f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376e9829-23eb-4b43-9ec7-246cb3156e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/376e9829-23eb-4b43-9ec7-246cb3156e95.jpg?1",
             "name": "Phyrexian Ingester",
             "text": "Imprint \u2014 When Phyrexian Ingester enters the battlefield, you may exile target nontoken creature.\nPhyrexian Ingester gets +X/+Y, where X is the exiled creature card's power and Y is its toughness.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "95b2120c-e0a6-523a-8600-001f86cc6ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e27911-87cb-49a0-a34f-6afe4bddd592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e27911-87cb-49a0-a34f-6afe4bddd592.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "({PU} can be paid with either {U} or 2 life.)\nYou may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "7ad337c2-7f17-5229-966b-f425b84345d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cba7d67-5c6c-4738-8907-7cce503e3180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cba7d67-5c6c-4738-8907-7cce503e3180.jpg?1",
             "name": "Psychic Barrier",
             "text": "Counter target creature spell. Its controller loses 1 life.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "f8759670-a9d4-5950-bce7-92384c76eb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea9a6d-d6ca-48cb-adac-958ad0e7440c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ea9a6d-d6ca-48cb-adac-958ad0e7440c.jpg?1",
             "name": "Psychic Surgery",
             "text": "Whenever an opponent shuffles his or her library, you may look at the top two cards of that library. You may exile one of those cards. Then put the rest on top of that library in any order.",
             "colours": [
@@ -1499,7 +1499,7 @@
         },
         {
             "id": "29f3138b-9427-5ad9-a897-81e57570892c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd27f71a-cd22-4b5e-9536-3e160111875a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd27f71a-cd22-4b5e-9536-3e160111875a.jpg?1",
             "name": "Spined Thopter",
             "text": "({PU} can be paid with either {U} or 2 life.)\nFlying",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "62474302-a468-574e-9408-707b883594c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f83aa-264b-4d09-b45f-099597a789d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189f83aa-264b-4d09-b45f-099597a789d4.jpg?1",
             "name": "Spire Monitor",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "f4df5428-2ac5-5255-8e0f-bfb9ab7eb7cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff5a09e-9276-44b8-b374-4b84aebd47cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff5a09e-9276-44b8-b374-4b84aebd47cc.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "({PU} can be paid with either {U} or 2 life.)\nDraw two cards, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "a603a196-d4b8-545d-98d9-61cda056075d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70305148-23bd-41dd-9de5-13cf5ae591ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70305148-23bd-41dd-9de5-13cf5ae591ae.jpg?1",
             "name": "Vapor Snag",
             "text": "Return target creature to its owner's hand. Its controller loses 1 life.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "5148a787-8ed6-5e85-a608-9e3aa74e16f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89b312b-cc90-4f08-ae2e-043a79e51156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89b312b-cc90-4f08-ae2e-043a79e51156.jpg?1",
             "name": "Viral Drake",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{3}{U}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1669,7 +1669,7 @@
         },
         {
             "id": "0e864a45-4590-5948-aed0-ce39de43a359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dbfb1b-092c-44a3-932d-a8b27be0a72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2dbfb1b-092c-44a3-932d-a8b27be0a72b.jpg?1",
             "name": "Wing Splicer",
             "text": "When Wing Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\nGolem creatures you control have flying.",
             "colours": [
@@ -1705,7 +1705,7 @@
         },
         {
             "id": "6d4ead99-3d4d-572f-bbee-afdc559fd8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52f08e1-b234-42e4-8f1f-485a4f6edb3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52f08e1-b234-42e4-8f1f-485a4f6edb3b.jpg?1",
             "name": "Xenograft",
             "text": "As Xenograft enters the battlefield, choose a creature type.\nEach creature you control is the chosen type in addition to its other types.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "a7bf233a-d92d-59f6-a7ab-4fbd1fdda5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd04df1-5131-455d-b497-fcce4f9af552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd04df1-5131-455d-b497-fcce4f9af552.jpg?1",
             "name": "Blind Zealot",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever Blind Zealot deals combat damage to a player, you may sacrifice it. If you do, destroy target creature that player controls.",
             "colours": [
@@ -1773,7 +1773,7 @@
         },
         {
             "id": "719c7c0e-8f58-523e-86dc-5fbac4e57593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef987ad-a3dc-4ef5-90ec-9a8cfa95965b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef987ad-a3dc-4ef5-90ec-9a8cfa95965b.jpg?1",
             "name": "Caress of Phyrexia",
             "text": "Target player draws three cards, loses 3 life, and gets three poison counters.",
             "colours": [
@@ -1805,7 +1805,7 @@
         },
         {
             "id": "5eb2777f-1c7a-515e-b760-962c715f0119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec6d85e-6263-44b4-a91f-d51585c561c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec6d85e-6263-44b4-a91f-d51585c561c2.jpg?1",
             "name": "Chancellor of the Dross",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, each opponent loses 3 life, then you gain life equal to the life lost this way.\nFlying, lifelink",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "4adf4345-fe12-557f-b167-08f61089e9f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ae22c3-2dea-463e-894a-188657849909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ae22c3-2dea-463e-894a-188657849909.jpg?1",
             "name": "Dementia Bat",
             "text": "Flying\n{4}{B}, Sacrifice Dementia Bat: Target player discards two cards.",
             "colours": [
@@ -1875,7 +1875,7 @@
         },
         {
             "id": "28004313-defc-5f8b-afaa-48ec622e65d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bfcd3-9f2b-41f5-93b4-8c1ee6ba4d88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7bfcd3-9f2b-41f5-93b4-8c1ee6ba4d88.jpg?1",
             "name": "Despise",
             "text": "Target opponent reveals his or her hand. You choose a creature or planeswalker card from it. That player discards that card.",
             "colours": [
@@ -1907,7 +1907,7 @@
         },
         {
             "id": "26db94e4-32a5-5f8d-8347-179ac7348575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dfdeb-485f-473e-9fa0-8fdb7638cdc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064dfdeb-485f-473e-9fa0-8fdb7638cdc6.jpg?1",
             "name": "Dismember",
             "text": "({PB} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -1939,7 +1939,7 @@
         },
         {
             "id": "7df7ea69-59a0-574c-a6a5-e91ed2857fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2f5f0-1f37-4f51-9c10-c02e2ef7d4ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c2f5f0-1f37-4f51-9c10-c02e2ef7d4ee.jpg?1",
             "name": "Enslave",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, enchanted creature deals 1 damage to its owner.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "cf7782a4-1932-5985-9fbe-7b9d6de0864e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f58020e-6d4d-474d-8d4b-cfb7d5a5e9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f58020e-6d4d-474d-8d4b-cfb7d5a5e9a8.jpg?1",
             "name": "Entomber Exarch",
             "text": "When Entomber Exarch enters the battlefield, choose one \u2014 Return target creature card from your graveyard to your hand; or target opponent reveals his or her hand, you choose a noncreature card from it, then that player discards that card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "9846b817-95b7-5df4-aeef-a4f1e74d4bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd00bc5-234c-4ded-b0b7-1181bc16cb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd00bc5-234c-4ded-b0b7-1181bc16cb28.jpg?1",
             "name": "Evil Presence",
             "text": "Enchant land\nEnchanted land is a Swamp.",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "efa6cc79-a88f-5478-9db4-12ee9e82f091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20b5a2-8613-49ed-b5cc-7cae9d0e0850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a20b5a2-8613-49ed-b5cc-7cae9d0e0850.jpg?1",
             "name": "Geth's Verdict",
             "text": "Target player sacrifices a creature and loses 1 life.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "1c183bcf-951c-578b-98b5-e76b1aad9110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e99fd-7e48-400d-9817-451089089e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483e99fd-7e48-400d-9817-451089089e0c.jpg?1",
             "name": "Glistening Oil",
             "text": "Enchant creature\nEnchanted creature has infect.\nAt the beginning of your upkeep, put a -1/-1 counter on enchanted creature.\nWhen Glistening Oil is put into a graveyard from the battlefield, return Glistening Oil to its owner's hand.",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "b95418c2-7948-5f84-888e-f8e502e82e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5c8ba8-d9f4-440c-8e0b-93699df6343e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d5c8ba8-d9f4-440c-8e0b-93699df6343e.jpg?1",
             "name": "Grim Affliction",
             "text": "Put a -1/-1 counter on target creature, then proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "46bd4566-da66-55ae-ab1b-3e9c0336e292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b207e2f-4604-43c5-bb35-a877e35ddd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b207e2f-4604-43c5-bb35-a877e35ddd81.jpg?1",
             "name": "Ichor Explosion",
             "text": "As an additional cost to cast Ichor Explosion, sacrifice a creature.\nAll creatures get -X/-X until end of turn, where X is the sacrificed creature's power.",
             "colours": [
@@ -2172,7 +2172,7 @@
         },
         {
             "id": "60ec56c2-4740-5da8-8cc6-530db8268895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd3fbd2-87c7-4f08-baaa-91d61c1114da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd3fbd2-87c7-4f08-baaa-91d61c1114da.jpg?1",
             "name": "Life's Finale",
             "text": "Destroy all creatures, then search target opponent's library for up to three creature cards and put them into his or her graveyard. Then that player shuffles his or her library.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "f863a2d2-46eb-540d-87ec-efbd07395a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cae1f40-0e43-41d8-bc5c-aa9873f7d7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cae1f40-0e43-41d8-bc5c-aa9873f7d7d5.jpg?1",
             "name": "Mortis Dogs",
             "text": "Whenever Mortis Dogs attacks, it gets +2/+0 until end of turn.\nWhen Mortis Dogs is put into a graveyard from the battlefield, target player loses life equal to its power.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "626419a8-6d57-5918-983c-1755d72798eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f1bf3-9f3a-47f0-9761-8b2356328a39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f1bf3-9f3a-47f0-9761-8b2356328a39.jpg?1",
             "name": "Parasitic Implant",
             "text": "Enchant creature\nAt the beginning of your upkeep, enchanted creature's controller sacrifices it and you put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "8cd926fa-b06e-568c-8768-b8ae6e7ff020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c4476d-58f9-420d-9545-f5d580c589de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c4476d-58f9-420d-9545-f5d580c589de.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "372ace98-509f-54e6-a038-bfe2ad1ce730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e960c6-6da0-4679-87eb-55bac890e0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e960c6-6da0-4679-87eb-55bac890e0c6.jpg?1",
             "name": "Pith Driller",
             "text": "({PB} can be paid with either {B} or 2 life.)\nWhen Pith Driller enters the battlefield, put a -1/-1 counter on target creature.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "b12eada7-5a1f-5503-8cac-afcf5d900ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f8b46e-1ad3-4c6e-aa63-376f2d222d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f8b46e-1ad3-4c6e-aa63-376f2d222d46.jpg?1",
             "name": "Postmortem Lunge",
             "text": "({PB} can be paid with either {B} or 2 life.)\nReturn target creature card with converted mana cost X from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "3261649b-2982-5180-b3cd-19bd0f9ee651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9588be49-d9b5-4491-a5a0-10bcadc9f8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9588be49-d9b5-4491-a5a0-10bcadc9f8b3.jpg?1",
             "name": "Praetor's Grasp",
             "text": "Search target opponent's library for a card and exile it face down. Then that player shuffles his or her library. You may look at and play that card for as long as it remains exiled.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "58e9da95-98e9-5da6-8422-acec4b6b3a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300a645-aec6-4cda-8c11-1e8a6af056ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a300a645-aec6-4cda-8c11-1e8a6af056ff.jpg?1",
             "name": "Reaper of Sheoldred",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever a source deals damage to Reaper of Sheoldred, that source's controller gets a poison counter.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "7d18309e-04d9-5ea4-aeac-81b30a94c950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8347b-8663-40b8-bdfb-411236d2efc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bb8347b-8663-40b8-bdfb-411236d2efc8.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "Swampwalk\nAt the beginning of your upkeep, return target creature card from your graveyard to the battlefield.\nAt the beginning of each opponent's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -2480,7 +2480,7 @@
         },
         {
             "id": "faa41ad0-fe62-5866-8b36-6d1d264f54fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca7e072-edb5-4f7e-bdec-a3a393053c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca7e072-edb5-4f7e-bdec-a3a393053c80.jpg?1",
             "name": "Surgical Extraction",
             "text": "({PB} can be paid with either {B} or 2 life.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "96f05ffd-2a1d-56c9-9faf-74a17741c748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5823990c-8d40-4352-8d34-74332934adb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5823990c-8d40-4352-8d34-74332934adb2.jpg?1",
             "name": "Toxic Nim",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{B}: Regenerate Toxic Nim.",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "d76cd63b-bf56-55e4-a520-edd52cfc268f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f254239c-c07a-4c41-98f7-8f4de539c73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f254239c-c07a-4c41-98f7-8f4de539c73e.jpg?1",
             "name": "Vault Skirge",
             "text": "({PB} can be paid with either {B} or 2 life.)\nFlying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2583,7 +2583,7 @@
         },
         {
             "id": "7cd86351-f2bd-556d-a4fe-3d198a3ed634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb1b486-e336-4e88-b635-b6ff18cb4841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb1b486-e336-4e88-b635-b6ff18cb4841.jpg?1",
             "name": "Whispering Specter",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Whispering Specter deals combat damage to a player, you may sacrifice it. If you do, that player discards a card for each poison counter he or she has.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "7069ef31-1382-58b4-af23-8da8d0b5a79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a9f30b-d154-49a4-ad6b-f05601992de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a9f30b-d154-49a4-ad6b-f05601992de3.jpg?1",
             "name": "Act of Aggression",
             "text": "({PR} can be paid with either {R} or 2 life.)\nGain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "5ef6dec9-f676-55df-ba8a-37dd28a2cab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034522ae-f531-44d9-b186-ada046ce0abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034522ae-f531-44d9-b186-ada046ce0abc.jpg?1",
             "name": "Artillerize",
             "text": "As an additional cost to cast Artillerize, sacrifice an artifact or creature.\nArtillerize deals 5 damage to target creature or player.",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "78dd8369-982c-571c-9fca-72fc62a2b532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30fa96d-64d1-423e-a62e-d43453ea838d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30fa96d-64d1-423e-a62e-d43453ea838d.jpg?1",
             "name": "Bludgeon Brawl",
             "text": "Each noncreature, non-Equipment artifact is an Equipment with equip {X} and \"Equipped creature gets +X/+0,\" where X is that artifact's converted mana cost.",
             "colours": [
@@ -2714,7 +2714,7 @@
         },
         {
             "id": "800ced71-dd44-58e2-81b3-e682ec735694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3520a7-a55f-4c00-b4f1-c1c154adfc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3520a7-a55f-4c00-b4f1-c1c154adfc8f.jpg?1",
             "name": "Chancellor of the Forge",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of the first upkeep, put a 1/1 red Goblin creature token with haste onto the battlefield.\nWhen Chancellor of the Forge enters the battlefield, put X 1/1 red Goblin creature tokens with haste onto the battlefield, where X is the number of creatures you control.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "cbd06e67-2941-50b0-a2e2-6d37eb80f8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b200986-f553-4156-8f5e-37678db09687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b200986-f553-4156-8f5e-37678db09687.jpg?1",
             "name": "Fallen Ferromancer",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{1}{R}, {T}: Fallen Ferromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "e58baef3-e2d8-5c15-b022-1536377639ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9601ea62-a609-4bc5-a2f0-f7615b4dd5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9601ea62-a609-4bc5-a2f0-f7615b4dd5fa.jpg?1",
             "name": "Flameborn Viron",
             "text": "",
             "colours": [
@@ -2820,7 +2820,7 @@
         },
         {
             "id": "944b7867-2b11-5c62-a479-5dc600eaa030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97538294-058c-47d4-b7a8-4db3753a6628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97538294-058c-47d4-b7a8-4db3753a6628.jpg?1",
             "name": "Furnace Scamp",
             "text": "Whenever Furnace Scamp deals combat damage to a player, you may sacrifice it. If you do, Furnace Scamp deals 3 damage to that player.",
             "colours": [
@@ -2855,7 +2855,7 @@
         },
         {
             "id": "eaac4455-ac6f-5ffa-a5d2-e5204953d00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b7aa3-bb05-4691-978e-51486435bf05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118b7aa3-bb05-4691-978e-51486435bf05.jpg?1",
             "name": "Geosurge",
             "text": "Add {R}{R}{R}{R}{R}{R}{R} to your mana pool. Spend this mana only to cast artifact or creature spells.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "2332fc69-5248-510f-a319-1da3c2928790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a2a30-b96a-49c7-9151-1f4b0d4a4413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a54a2a30-b96a-49c7-9151-1f4b0d4a4413.jpg?1",
             "name": "Gut Shot",
             "text": "({PR} can be paid with either {R} or 2 life.)\nGut Shot deals 1 damage to target creature or player.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "6b39846e-236c-5246-8068-e6bad81853d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a8c53f-2cb0-41ea-8391-c32667f17c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a8c53f-2cb0-41ea-8391-c32667f17c30.jpg?1",
             "name": "Invader Parasite",
             "text": "Imprint \u2014 When Invader Parasite enters the battlefield, exile target land.\nWhenever a land with the same name as the exiled card enters the battlefield under an opponent's control, Invader Parasite deals 2 damage to that player.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "0e89e63f-b481-5b7d-a21e-5ac17b5cc6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b78018-bfbe-43fa-809f-9b52a155e11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b78018-bfbe-43fa-809f-9b52a155e11c.jpg?1",
             "name": "Moltensteel Dragon",
             "text": "({PR} can be paid with either {R} or 2 life.)\nFlying\n{PR}: Moltensteel Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "3540b031-73ea-5e25-947d-04ec8e17b73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6271c5c1-5f39-4908-b838-0f34c74e912e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6271c5c1-5f39-4908-b838-0f34c74e912e.jpg?1",
             "name": "Ogre Menial",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{R}: Ogre Menial gets +1/+0 until end of turn.",
             "colours": [
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "f04fde7e-c69b-5f25-8889-87bec3a8823b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9f49c-f15c-4b2d-b6a5-8efc3c430d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a9f49c-f15c-4b2d-b6a5-8efc3c430d87.jpg?1",
             "name": "Priest of Urabrask",
             "text": "When Priest of Urabrask enters the battlefield, add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "f46b2c83-6924-5f35-83e0-060bdd159bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8cebc2c-a46b-4459-b62b-7fce1a744b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8cebc2c-a46b-4459-b62b-7fce1a744b11.jpg?1",
             "name": "Rage Extractor",
             "text": "({PR} can be paid with either {R} or 2 life.)\nWhenever you cast a spell with p in its mana cost, Rage Extractor deals damage equal to that spell's converted mana cost to target creature or player.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "41ce6f8d-509a-56b0-a4b5-eb8c8c34e8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb022a3-5f9e-491e-8340-087e33f927d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb022a3-5f9e-491e-8340-087e33f927d6.jpg?1",
             "name": "Razor Swine",
             "text": "First strike\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3128,7 +3128,7 @@
         },
         {
             "id": "9c3a2574-3084-53e2-9cd4-016418437345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2bbff9-af57-4858-9351-d148b8c4bc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc2bbff9-af57-4858-9351-d148b8c4bc3a.jpg?1",
             "name": "Ruthless Invasion",
             "text": "({PR} can be paid with either {R} or 2 life.)\nNonartifact creatures can't block this turn.",
             "colours": [
@@ -3160,7 +3160,7 @@
         },
         {
             "id": "7cd8e402-e7a5-533b-900d-670a926664cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4874eb-635b-47f0-bbee-6bd8b26e2f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a4874eb-635b-47f0-bbee-6bd8b26e2f10.jpg?1",
             "name": "Scrapyard Salvo",
             "text": "Scrapyard Salvo deals damage to target player equal to the number of artifact cards in your graveyard.",
             "colours": [
@@ -3192,7 +3192,7 @@
         },
         {
             "id": "1316ef86-28fa-5dac-976c-0fe1e14018e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d1ee33-e247-4ada-bb01-518611cd7d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d1ee33-e247-4ada-bb01-518611cd7d00.jpg?1",
             "name": "Slag Fiend",
             "text": "Slag Fiend's power and toughness are each equal to the number of artifact cards in all graveyards.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "cdf6cf26-22e7-5d05-ba66-4981b64309ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f510946-34de-4c12-8998-f61887d1a0e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f510946-34de-4c12-8998-f61887d1a0e1.jpg?1",
             "name": "Slash Panther",
             "text": "({PR} can be paid with either {R} or 2 life.)\nHaste",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "e126f893-3c79-59cf-950b-df79ea215dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4886eb6a-0f6a-4ea7-8e85-4a27d1a6f03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4886eb6a-0f6a-4ea7-8e85-4a27d1a6f03b.jpg?1",
             "name": "Tormentor Exarch",
             "text": "When Tormentor Exarch enters the battlefield, choose one \u2014 Target creature gets +2/+0 until end of turn; or target creature gets -0/-2 until end of turn.",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "c25e702c-6200-56bc-901f-f5ba2774a121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06fcab2-891e-4fa3-8583-068ba56c2e27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06fcab2-891e-4fa3-8583-068ba56c2e27.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "Creatures you control have haste.\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "5701e585-dcab-52fa-9fe8-b99305d51ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b81cb30-e9f8-41f3-a10b-26e0ba2503aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b81cb30-e9f8-41f3-a10b-26e0ba2503aa.jpg?1",
             "name": "Victorious Destruction",
             "text": "Destroy target artifact or land. Its controller loses 1 life.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "6cfc3054-bc79-552d-912f-e3d9d2886d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88011c-a19d-4faa-8da6-86b9980cd571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa88011c-a19d-4faa-8da6-86b9980cd571.jpg?1",
             "name": "Volt Charge",
             "text": "Volt Charge deals 3 damage to target creature or player. Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -3399,7 +3399,7 @@
         },
         {
             "id": "d4379a55-b449-5249-ae36-fb4db1a0cc6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1615ec-21b3-4575-8b02-fd2bccb930ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1615ec-21b3-4575-8b02-fd2bccb930ba.jpg?1",
             "name": "Vulshok Refugee",
             "text": "Protection from red",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "e1bc452d-28f2-57a2-b07e-14390dc37220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e6c10-d066-4967-932f-5b6c8d74568b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7e6c10-d066-4967-932f-5b6c8d74568b.jpg?1",
             "name": "Whipflare",
             "text": "Whipflare deals 2 damage to each nonartifact creature.",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "a59e8188-768b-5857-9648-a356808cab68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5b6d19-22e3-4f57-8f4d-a17e982286c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5b6d19-22e3-4f57-8f4d-a17e982286c7.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller puts a 3/3 green Beast creature token onto the battlefield.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "d0bcc0c4-1735-58d6-8645-900bc9ae3a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b768efa2-e56b-4a7e-ace8-d673f10e0714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b768efa2-e56b-4a7e-ace8-d673f10e0714.jpg?1",
             "name": "Birthing Pod",
             "text": "({PG} can be paid with either {G} or 2 life.)\n{1}{PG}, {T}, Sacrifice a creature: Search your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "48b02786-7ffd-5bbf-b779-4082b05f6667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfa4ed-70fb-4e25-875d-df0f973f7294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddfa4ed-70fb-4e25-875d-df0f973f7294.jpg?1",
             "name": "Brutalizer Exarch",
             "text": "When Brutalizer Exarch enters the battlefield, choose one \u2014 Search your library for a creature card, reveal it, then shuffle your library and put that card on top of it; or put target noncreature permanent on the bottom of its owner's library.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "88050ada-9e44-5484-bb7a-ab3abb77bab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129aa8-b637-451e-8123-5221e08cc2cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d129aa8-b637-451e-8123-5221e08cc2cc.jpg?1",
             "name": "Chancellor of the Tangle",
             "text": "You may reveal this card from your opening hand. If you do, at the beginning of your first main phase, add {G} to your mana pool.\nVigilance, reach",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "63e30831-50f8-58e2-882d-d795ec2cc334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a13825-ab9b-4ffd-9b59-6198181891b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a13825-ab9b-4ffd-9b59-6198181891b9.jpg?1",
             "name": "Corrosive Gale",
             "text": "({PG} can be paid with either {G} or 2 life.)\nCorrosive Gale deals X damage to each creature with flying.",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "5635a434-e3bd-59b4-90dd-2e4fb1b9e87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279ac25-8175-44ad-ab7b-dfa17e359a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5279ac25-8175-44ad-ab7b-dfa17e359a10.jpg?1",
             "name": "Death-Hood Cobra",
             "text": "{1}{G}: Death-Hood Cobra gains reach until end of turn. (It can block creatures with flying.)\n{1}{G}: Death-Hood Cobra gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "1e12dc9f-54ca-5127-80ef-3f43eae6df05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000ce65b-5347-4a88-81af-be9053e4d3f3.jpg?1",
             "name": "Fresh Meat",
             "text": "Put a 3/3 green Beast creature token onto the battlefield for each creature put into your graveyard from the battlefield this turn.",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "566524be-4c3d-5bf2-bd65-01ad1f6bbae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11187c1-de35-4e85-87c3-656f978b2d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11187c1-de35-4e85-87c3-656f978b2d7e.jpg?1",
             "name": "Glissa's Scorn",
             "text": "Destroy target artifact. Its controller loses 1 life.",
             "colours": [
@@ -3731,7 +3731,7 @@
         },
         {
             "id": "010e4573-7fdc-5559-82f8-797179e1bfaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94f4c6-b518-43b3-be52-e889d1f3ea38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b94f4c6-b518-43b3-be52-e889d1f3ea38.jpg?1",
             "name": "Glistener Elf",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "80532ed1-47bd-5d98-b4bf-0a22a805a0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370f8ef5-c809-43cc-903a-077fad33cd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370f8ef5-c809-43cc-903a-077fad33cd30.jpg?1",
             "name": "Greenhilt Trainee",
             "text": "{T}: Target creature gets +4/+4 until end of turn. Activate this ability only if Greenhilt Trainee's power is 4 or greater.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "b9ba3811-474a-598a-81da-0f725cf8a4a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3bdbeb-c376-42bd-af2a-251cd7ac704c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c3bdbeb-c376-42bd-af2a-251cd7ac704c.jpg?1",
             "name": "Leeching Bite",
             "text": "Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "33f2bd92-346a-5fd4-a80f-9199a6abd02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c6a6d-5b59-47d7-b290-df3640d9555f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d2c6a6d-5b59-47d7-b290-df3640d9555f.jpg?1",
             "name": "Maul Splicer",
             "text": "When Maul Splicer enters the battlefield, put two 3/3 colorless Golem artifact creature tokens onto the battlefield.\nGolem creatures you control have trample.",
             "colours": [
@@ -3870,7 +3870,7 @@
         },
         {
             "id": "4c141f3c-4e6c-5c49-8913-a7cdce8d88b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83851a1-e4e8-49ec-af5c-4efe86fa51ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83851a1-e4e8-49ec-af5c-4efe86fa51ad.jpg?1",
             "name": "Melira, Sylvok Outcast",
             "text": "You can't get poison counters.\nCreatures you control can't have -1/-1 counters placed on them.\nCreatures your opponents control lose infect.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "6e1a0bc2-eb2b-57b1-9ba8-1b021cd51166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d23da-70a1-49ba-91bf-c110cc4bbedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af2d23da-70a1-49ba-91bf-c110cc4bbedc.jpg?1",
             "name": "Mutagenic Growth",
             "text": "({PG} can be paid with either {G} or 2 life.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "b8cffb54-3bf7-524c-a65b-0d4820ff5c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcd1b8e-9f1f-48a3-b7a1-43a32cc03bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdcd1b8e-9f1f-48a3-b7a1-43a32cc03bb1.jpg?1",
             "name": "Mycosynth Fiend",
             "text": "Mycosynth Fiend gets +1/+1 for each poison counter your opponents have.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "5efc2769-b535-5437-90f6-01c0b854dc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd1243-1d14-496a-9b7a-0c5b34461361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdd1243-1d14-496a-9b7a-0c5b34461361.jpg?1",
             "name": "Noxious Revival",
             "text": "({PG} can be paid with either {G} or 2 life.)\nPut target card from a graveyard on top of its owner's library.",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "65c3b16a-adcd-52ab-8f2c-0166c277908c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a91dea7-9792-4714-82b0-ba2c06cef304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a91dea7-9792-4714-82b0-ba2c06cef304.jpg?1",
             "name": "Phyrexian Swarmlord",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nAt the beginning of your upkeep, put a 1/1 green Insect creature token with infect onto the battlefield for each poison counter your opponents have.",
             "colours": [
@@ -4042,7 +4042,7 @@
         },
         {
             "id": "c27926b6-8c3c-5f8c-beb7-cdd478870dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcae97d-468a-4e16-bfed-d2946f64784c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcae97d-468a-4e16-bfed-d2946f64784c.jpg?1",
             "name": "Rotted Hystrix",
             "text": "",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "17432b9c-90e3-537f-9cb7-d9d45e2958bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc79ac6-ffc6-4506-9dea-e20176f960ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc79ac6-ffc6-4506-9dea-e20176f960ea.jpg?1",
             "name": "Spinebiter",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nYou may have Spinebiter assign its combat damage as though it weren't blocked.",
             "colours": [
@@ -4112,7 +4112,7 @@
         },
         {
             "id": "e88e4c4a-2acf-5dde-84c6-930b4d4fdf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fab443-0f4b-45ea-8a6d-435b93803409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fab443-0f4b-45ea-8a6d-435b93803409.jpg?1",
             "name": "Thundering Tanadon",
             "text": "({PG} can be paid with either {G} or 2 life.)\nTrample",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "f9a07681-0ac3-54f5-aaf7-819301f7714c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16b90ff-d256-4ac6-b687-3430b8c80dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16b90ff-d256-4ac6-b687-3430b8c80dd7.jpg?1",
             "name": "Triumph of the Hordes",
             "text": "Until end of turn, creatures you control get +1/+1 and gain trample and infect. (Creatures with infect deal damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "71f38180-09bf-53ad-a74f-de6e32bf3084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ea52f-4b24-45ff-99e1-4d0e1bd42875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc6ea52f-4b24-45ff-99e1-4d0e1bd42875.jpg?1",
             "name": "Viridian Betrayers",
             "text": "Viridian Betrayers has infect as long as an opponent is poisoned. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "5c800b02-c433-50d9-9b61-1a38aa06b380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666eb9a5-b105-45c1-be3e-7ac5cc650338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666eb9a5-b105-45c1-be3e-7ac5cc650338.jpg?1",
             "name": "Viridian Harvest",
             "text": "Enchant artifact\nWhen enchanted artifact is put into a graveyard, you gain 6 life.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "dce3de3e-dc43-5e6b-b788-7c4857e635c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b982d-bca2-4418-8618-c711d28fc901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/273b982d-bca2-4418-8618-c711d28fc901.jpg?1",
             "name": "Vital Splicer",
             "text": "When Vital Splicer enters the battlefield, put a 3/3 colorless Golem artifact creature token onto the battlefield.\n{1}: Regenerate target Golem you control.",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "0eca3b0c-40f7-5fea-913e-25d17b54d391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0806adab-6a08-411b-b249-e1c58ade354b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0806adab-6a08-411b-b249-e1c58ade354b.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "Trample\nWhenever you tap a land for mana, add one mana to your mana pool of any type that land produced.\nWhenever an opponent taps a land for mana, that land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "590bc71c-f8fc-5895-804a-47e400c4993b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd8d7de-a2e1-4f83-85f9-7057eebf0c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd8d7de-a2e1-4f83-85f9-7057eebf0c37.jpg?1",
             "name": "Jor Kadeen, the Prevailer",
             "text": "First strike\nMetalcraft \u2014 Creatures you control get +3/+0 as long as you control three or more artifacts.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "2e31da60-fc58-513c-bb69-e23e2f95654c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd3350b-89fb-40b4-a942-28e0c8c274aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd3350b-89fb-40b4-a942-28e0c8c274aa.jpg?1",
             "name": "Alloy Myr",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "d0d5adad-202a-5214-abe6-205b04e841b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd114ec3-d286-4c70-a122-3043bc53cc88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd114ec3-d286-4c70-a122-3043bc53cc88.jpg?1",
             "name": "Batterskull",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return Batterskull to its owner's hand.\nEquip {5}",
             "colours": [],
@@ -4423,7 +4423,7 @@
         },
         {
             "id": "2687074b-7975-5efd-b2d5-cabe0f1669de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220e9dd-f1d8-4a69-9df9-1322e4a5cdc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2220e9dd-f1d8-4a69-9df9-1322e4a5cdc7.jpg?1",
             "name": "Blinding Souleater",
             "text": "{PW}, {T}: Tap target creature. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [],
@@ -4457,7 +4457,7 @@
         },
         {
             "id": "cfa07c23-a9bc-5e28-b662-c535fab5067e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506597cc-48f9-4098-a229-2b3b3c0de944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506597cc-48f9-4098-a229-2b3b3c0de944.jpg?1",
             "name": "Caged Sun",
             "text": "As Caged Sun enters the battlefield, choose a color.\nCreatures you control of the chosen color get +1/+1.\nWhenever a land's ability adds one or more mana of the chosen color to your mana pool, add one additional mana of that color to your mana pool.",
             "colours": [],
@@ -4485,7 +4485,7 @@
         },
         {
             "id": "76fd29fb-68ba-5e8e-982d-6d6653130d57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5a8f3-05b6-4bb7-bbe1-e753e22cbb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5a8f3-05b6-4bb7-bbe1-e753e22cbb50.jpg?1",
             "name": "Conversion Chamber",
             "text": "{2}, {T}: Exile target artifact card from a graveyard. Put a charge counter on Conversion Chamber.\n{2}, {T}, Remove a charge counter from Conversion Chamber: Put a 3/3 colorless Golem artifact creature token onto the battlefield.",
             "colours": [],
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "1d82327b-7bdf-5390-b256-ed635fe102d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd8c918-62d9-41be-a3e1-32ddac71b7e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd8c918-62d9-41be-a3e1-32ddac71b7e7.jpg?1",
             "name": "Darksteel Relic",
             "text": "Darksteel Relic is indestructible. (Effects that say \"destroy\" don't destroy it.)",
             "colours": [],
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "e1fe033f-383b-5078-b042-741ae4ea2655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9c4451-dd17-4859-a31d-62ed2430c63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9c4451-dd17-4859-a31d-62ed2430c63c.jpg?1",
             "name": "Etched Monstrosity",
             "text": "Etched Monstrosity enters the battlefield with five -1/-1 counters on it.\n{W}{U}{B}{R}{G}, Remove five -1/-1 counters from Etched Monstrosity: Target player draws three cards.",
             "colours": [],
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "d913d2c5-5e58-5dfd-8467-f3481e358eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccde7ebb-90de-4174-a1c5-75fc9384deaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccde7ebb-90de-4174-a1c5-75fc9384deaa.jpg?1",
             "name": "Gremlin Mine",
             "text": "{1}, {T}, Sacrifice Gremlin Mine: Gremlin Mine deals 4 damage to target artifact creature.\n{1}, {T}, Sacrifice Gremlin Mine: Remove up to four charge counters from target noncreature artifact.",
             "colours": [],
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "b9a02b83-781e-5c55-9411-d53331052466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43502078-5349-4e29-8e7d-277654a9a71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43502078-5349-4e29-8e7d-277654a9a71e.jpg?1",
             "name": "Hex Parasite",
             "text": "{X}{PB}: Remove up to X counters from target permanent. For each counter removed this way, Hex Parasite gets +1/+0 until end of turn. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [],
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "cce3302e-4097-5860-8d82-63e0f019e7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4e445-8333-4cb4-b4fb-80957fae0b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4e445-8333-4cb4-b4fb-80957fae0b97.jpg?1",
             "name": "Hovermyr",
             "text": "Flying, vigilance",
             "colours": [],
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "7306c676-ec7e-5cf0-9146-06eda148c55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbaf916-067d-4834-a55c-b400fe0d8c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbaf916-067d-4834-a55c-b400fe0d8c1f.jpg?1",
             "name": "Immolating Souleater",
             "text": "{PR}: Immolating Souleater gets +1/+0 until end of turn. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [],
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "cc429993-8d7a-5406-b1a4-5f17ceb1c637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171d5213-5bb4-4f5b-9ddd-e2a7ac092ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171d5213-5bb4-4f5b-9ddd-e2a7ac092ec6.jpg?1",
             "name": "Insatiable Souleater",
             "text": "{PG}: Insatiable Souleater gains trample until end of turn. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [],
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "0de228e6-769e-53cb-b171-2cd0dcd91eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e72c64-cb0e-4a04-97d0-3537bb0420cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e72c64-cb0e-4a04-97d0-3537bb0420cd.jpg?1",
             "name": "Isolation Cell",
             "text": "Whenever an opponent casts a creature spell, that player loses 2 life unless he or she pays {2}.",
             "colours": [],
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "30731f96-2262-5cd4-9d5b-4c51fa6f9852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91678632-ebe6-41b6-9250-cd3ffd63663b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91678632-ebe6-41b6-9250-cd3ffd63663b.jpg?1",
             "name": "Kiln Walker",
             "text": "Whenever Kiln Walker attacks, it gets +3/+0 until end of turn.",
             "colours": [],
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "578180d2-5e1f-5ca0-ae10-75a7ad530855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c418159-b5d1-48e9-9a31-707f49d6733b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c418159-b5d1-48e9-9a31-707f49d6733b.jpg?1",
             "name": "Lashwrithe",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +1/+1 for each Swamp you control.\nEquip {PB}{PB} ({PB} can be paid with either {B} or 2 life.)",
             "colours": [],
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "e4e5ed0b-51e0-547a-bb73-3f3f128f2492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a5ae0-d76a-4430-98c1-47a19e615e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13a5ae0-d76a-4430-98c1-47a19e615e2c.jpg?1",
             "name": "Mindcrank",
             "text": "Whenever an opponent loses life, that player puts that many cards from the top of his or her library into his or her graveyard. (Damage dealt by sources without infect causes loss of life.)",
             "colours": [],
@@ -4860,7 +4860,7 @@
         },
         {
             "id": "bc088047-dc01-5d4c-bca9-ae2fdd4f100b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097f7ab8-01fa-4699-943a-32075aecebc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097f7ab8-01fa-4699-943a-32075aecebc2.jpg?1",
             "name": "Mycosynth Wellspring",
             "text": "When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "8d568569-d77c-58d4-b7b5-f67f9d1f6bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290c6036-02a3-43fa-b0d4-af3818794c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290c6036-02a3-43fa-b0d4-af3818794c3c.jpg?1",
             "name": "Myr Superion",
             "text": "Spend only mana produced by creatures to cast Myr Superion.",
             "colours": [],
@@ -4919,7 +4919,7 @@
         },
         {
             "id": "40d24c20-d83c-59a1-81d4-690c013d1580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed51dbc-bbec-4c78-a71e-26322a8d2439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ed51dbc-bbec-4c78-a71e-26322a8d2439.jpg?1",
             "name": "Necropouncer",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +3/+1 and has haste.\nEquip {2}",
             "colours": [],
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "d002fb98-c3ae-5d87-910b-b3664a882b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4e35f-2a82-4d3c-86c5-ae05a5abc4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4e35f-2a82-4d3c-86c5-ae05a5abc4d7.jpg?1",
             "name": "Omen Machine",
             "text": "Players can't draw cards.\nAt the beginning of each player's draw step, that player exiles the top card of his or her library. If it's a land card, the player puts it onto the battlefield. Otherwise, the player casts it without paying its mana cost if able.",
             "colours": [],
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "d6615067-214e-5f38-a3f2-b6bd700dfe84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a069cc07-55eb-4ddb-a548-cbf463d078d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a069cc07-55eb-4ddb-a548-cbf463d078d3.jpg?1",
             "name": "Pestilent Souleater",
             "text": "{PB}: Pestilent Souleater gains infect until end of turn. ({PB} can be paid with either {B} or 2 life. A creature with infect deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -5011,7 +5011,7 @@
         },
         {
             "id": "2370d712-cf23-5f29-b889-1470af911081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687b5a7-7013-409a-ba8d-9cd8b5bb08f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1687b5a7-7013-409a-ba8d-9cd8b5bb08f3.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "85533b0a-2b86-5469-8ada-690a3dd0c525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31d96cf-7276-46c4-ad17-d6a5c85f1315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31d96cf-7276-46c4-ad17-d6a5c85f1315.jpg?1",
             "name": "Pristine Talisman",
             "text": "{T}: Add {1} to your mana pool. You gain 1 life.",
             "colours": [],
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "7e0097fe-e0df-5c24-837e-d4b219d72d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ec7b95-667f-43ed-b310-b657befd55a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ec7b95-667f-43ed-b310-b657befd55a2.jpg?1",
             "name": "Shrine of Boundless Growth",
             "text": "At the beginning of your upkeep or whenever you cast a green spell, put a charge counter on Shrine of Boundless Growth.\n{T}, Sacrifice Shrine of Boundless Growth: Add {1} to your mana pool for each charge counter on Shrine of Boundless Growth.",
             "colours": [],
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "fad7a770-0a63-5675-be11-62f94b9f1a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a8afef-fa50-4aeb-94de-a4d90b1e5631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a8afef-fa50-4aeb-94de-a4d90b1e5631.jpg?1",
             "name": "Shrine of Burning Rage",
             "text": "At the beginning of your upkeep or whenever you cast a red spell, put a charge counter on Shrine of Burning Rage.\n{3}, {T}, Sacrifice Shrine of Burning Rage: Shrine of Burning Rage deals damage equal to the number of charge counters on it to target creature or player.",
             "colours": [],
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "23d96f27-c1f0-5095-8e11-7c87f6bf58d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61873223-f378-4478-9cf3-f1326eb76834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61873223-f378-4478-9cf3-f1326eb76834.jpg?1",
             "name": "Shrine of Limitless Power",
             "text": "At the beginning of your upkeep or whenever you cast a black spell, put a charge counter on Shrine of Limitless Power.\n{4}, {T}, Sacrifice Shrine of Limitless Power: Target player discards a card for each charge counter on Shrine of Limitless Power.",
             "colours": [],
@@ -5155,7 +5155,7 @@
         },
         {
             "id": "c9f29a6f-bafd-5f6a-afb4-6840e5869ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13563c7-abe0-4760-9b4c-841de47dbc46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13563c7-abe0-4760-9b4c-841de47dbc46.jpg?1",
             "name": "Shrine of Loyal Legions",
             "text": "At the beginning of your upkeep or whenever you cast a white spell, put a charge counter on Shrine of Loyal Legions.\n{3}, {T}, Sacrifice Shrine of Loyal Legions: Put a 1/1 colorless Myr artifact creature token onto the battlefield for each charge counter on Shrine of Loyal Legions.",
             "colours": [],
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "a7ab5e65-bac4-5d3a-989a-8e90b1c10e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b150924-f83c-410e-aaab-ff2d06c9d356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b150924-f83c-410e-aaab-ff2d06c9d356.jpg?1",
             "name": "Shrine of Piercing Vision",
             "text": "At the beginning of your upkeep or whenever you cast a blue spell, put a charge counter on Shrine of Piercing Vision.\n{T}, Sacrifice Shrine of Piercing Vision: Look at the top X cards of your library, where X is the number of charge counters on Shrine of Piercing Vision. Put one of those cards into your hand and the rest on the bottom of your library in any order.",
             "colours": [],
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "5e5232a0-16f2-55a2-97ba-36828805f97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44746d5-3d34-4480-b4cd-c66de72f0622.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44746d5-3d34-4480-b4cd-c66de72f0622.jpg?1",
             "name": "Sickleslicer",
             "text": "Living weapon (When this Equipment enters the battlefield, put a 0/0 black Germ creature token onto the battlefield, then attach this to it.)\nEquipped creature gets +2/+2.\nEquip {4}",
             "colours": [],
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "18adf78f-b8de-51c4-9c0f-3aa7676c04e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7e4989-cba7-4e0c-bb9d-140af6c006c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7e4989-cba7-4e0c-bb9d-140af6c006c3.jpg?1",
             "name": "Soul Conduit",
             "text": "{6}, {T}: Two target players exchange life totals.",
             "colours": [],
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "94c6ba0a-4357-5783-b78a-a90fe697ea37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a84bada-ed6a-4e97-8a0c-05b7cb32d66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a84bada-ed6a-4e97-8a0c-05b7cb32d66f.jpg?1",
             "name": "Spellskite",
             "text": "{PU}: Change a target of target spell or ability to Spellskite. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "ef432622-2c22-582f-bf93-65b344da8e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12414fc0-bb24-4244-baf4-adad0125376e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12414fc0-bb24-4244-baf4-adad0125376e.jpg?1",
             "name": "Surge Node",
             "text": "Surge Node enters the battlefield with six charge counters on it.\n{1}, {T}, Remove a charge counter from Surge Node: Put a charge counter on target artifact.",
             "colours": [],
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "1e6c58f8-0510-5553-90f1-33497f1a91ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5bc6c-8943-4078-866a-5d02f9be0eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab5bc6c-8943-4078-866a-5d02f9be0eef.jpg?1",
             "name": "Sword of War and Peace",
             "text": "Equipped creature gets +2/+2 and has protection from red and from white.\nWhenever equipped creature deals combat damage to a player, Sword of War and Peace deals damage to that player equal to the number of cards in his or her hand and you gain 1 life for each card in your hand.\nEquip {2}",
             "colours": [],
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "0c18cee4-144f-56e6-b54d-390354dc79f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953610f6-ea96-4e71-969f-50ecac09c091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953610f6-ea96-4e71-969f-50ecac09c091.jpg?1",
             "name": "Torpor Orb",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [],
@@ -5389,7 +5389,7 @@
         },
         {
             "id": "9d700286-e587-5985-a62b-c32b22892b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5263269-9f64-43de-9e82-408644dbc628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5263269-9f64-43de-9e82-408644dbc628.jpg?1",
             "name": "Trespassing Souleater",
             "text": "{PU}: Trespassing Souleater is unblockable this turn. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [],
@@ -5423,7 +5423,7 @@
         },
         {
             "id": "a2008e00-77bf-5414-8305-5e59cd4e22f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d520b-7560-4ecb-ae62-143eeec5682f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d520b-7560-4ecb-ae62-143eeec5682f.jpg?1",
             "name": "Unwinding Clock",
             "text": "Untap all artifacts you control during each other player's untap step.",
             "colours": [],
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "041203ff-7e3d-514e-8078-1a196c2e8b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db36c8e7-0c13-4f0d-9947-68cb0e9ea239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db36c8e7-0c13-4f0d-9947-68cb0e9ea239.jpg?1",
             "name": "Phyrexia's Core",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice an artifact: You gain 1 life.",
             "colours": [],
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "a61134b2-4ee9-5c6e-8871-230eef5cba00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0c6f01-42be-40a1-becb-085f54750830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0c6f01-42be-40a1-becb-085f54750830.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5515,7 +5515,7 @@
         },
         {
             "id": "5fb5547e-8a9c-5d2f-b1bb-f8a607f16405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9129628e-ee2b-450b-a3d6-fc94e9bf477d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9129628e-ee2b-450b-a3d6-fc94e9bf477d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "960fd8bc-b431-50ac-8ace-f889cf387d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25790-29ac-4fc6-afd8-9c4063f4284d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a25790-29ac-4fc6-afd8-9c4063f4284d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "f39b232b-83a5-5dce-a321-cf421076f624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aba057e-11db-432b-a39c-a2845868bccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aba057e-11db-432b-a39c-a2845868bccd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5623,7 +5623,7 @@
         },
         {
             "id": "ccdd25fd-573f-5814-bf75-5debd6eff5be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267d4321-4411-499c-a476-70c805abf02a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267d4321-4411-499c-a476-70c805abf02a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5659,7 +5659,7 @@
         },
         {
             "id": "8d7af453-7748-565b-801c-8c4dd032e618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f11dc9-cedd-4691-9615-0ed65b5398ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f11dc9-cedd-4691-9615-0ed65b5398ba.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "af017ab5-c317-5012-8bab-1cf372862da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af1a73f-e2ab-4832-b9a0-5bd9643f4fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af1a73f-e2ab-4832-b9a0-5bd9643f4fd3.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5731,7 +5731,7 @@
         },
         {
             "id": "bffbba18-626b-5035-b3d2-bc00d319148d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d68279-a6fd-4cf3-afb3-1ba4e26a78a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d68279-a6fd-4cf3-afb3-1ba4e26a78a3.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5767,7 +5767,7 @@
         },
         {
             "id": "59aa53d0-0b9f-5947-bac6-8e4ea9754094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a8d9ff-291a-4862-b2e8-3db520cc9ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a8d9ff-291a-4862-b2e8-3db520cc9ae4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5803,7 +5803,7 @@
         },
         {
             "id": "da5a70f4-00fc-52fb-8c26-c2a92cd2645c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebd9027-5b48-42c0-9533-afe50bb101e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebd9027-5b48-42c0-9533-afe50bb101e6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5839,7 +5839,7 @@
         },
         {
             "id": "5e492088-8c67-5abf-a3f2-13d0a5871f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b226475-c85c-4b78-9d6a-70cc9545bc31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b226475-c85c-4b78-9d6a-70cc9545bc31.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "37995e58-2bf6-5ce8-be92-1c0e16bead9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeae905-e456-4598-b3de-b339397983bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeae905-e456-4598-b3de-b339397983bf.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -5907,7 +5907,7 @@
         },
         {
             "id": "72154cc7-4afa-5a35-942d-1b4c3b52eaf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "d300dc0e-fe5c-534c-ac74-aaa150bdd12b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -5969,7 +5969,7 @@
         },
         {
             "id": "f1bf3ee3-1f9f-54f0-b789-efd6d7ce4560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470618f6-f67f-44c6-a086-285632508915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470618f6-f67f-44c6-a086-285632508915.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ODY.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ODY.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b115ceba-324e-5b1f-bebc-b7b0b5e21507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561ffdb-f4dd-4b62-a2c2-933498e3a061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9561ffdb-f4dd-4b62-a2c2-933498e3a061.jpg?1",
             "name": "Aegis of Honor",
             "text": "o1: The next time an instant or sorcery spell would deal damage to you this turn, that spell deals that damage to its controller instead.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "2bef54d5-8860-5b95-bcdf-547ec73ce469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f28b2af-7891-49eb-a07f-5552b5fe3d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f28b2af-7891-49eb-a07f-5552b5fe3d15.jpg?1",
             "name": "Ancestral Tribute",
             "text": "You gain 2 life for each card in your graveyard.\nFlashback o9o\nWo\nWo\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "10ad8196-c72e-560a-aa25-9f3e05e14fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7c9675-e663-4ad1-9271-38d5c050a7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7c9675-e663-4ad1-9271-38d5c050a7c7.jpg?1",
             "name": "Angelic Wall",
             "text": "(Walls can't attack.)\nFlying",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "3773af8f-2a85-5dd1-9fa4-451f52149b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3379317-be18-4252-84ad-b7ebb6e557ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3379317-be18-4252-84ad-b7ebb6e557ff.jpg?1",
             "name": "Animal Boneyard",
             "text": "Enchanted land has \"oc\nT, Sacrifice a creature: You gain life equal to that creature's toughness.\"",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "343672a9-33ce-5b9f-a800-7a3dda392b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090dd4cf-5087-4ed8-a944-f3794e5862d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090dd4cf-5087-4ed8-a944-f3794e5862d5.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer comes into play, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "f8c9359c-7d2a-5c1c-ad49-805ba4269943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d174892-c192-4667-94fb-9f8dbcc6c5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d174892-c192-4667-94fb-9f8dbcc6c5eb.jpg?1",
             "name": "Aven Archer",
             "text": "Flying\no2o\nW, oc\nT: Aven Archer deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "3500d96d-4b86-5035-83f2-26b53e797fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08afe190-368e-4259-9959-00beaccee7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08afe190-368e-4259-9959-00beaccee7ba.jpg?1",
             "name": "Aven Cloudchaser",
             "text": "Flying\nWhen Aven Cloudchaser comes into play, destroy target enchantment.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "6fedc331-a462-58af-b12c-51538b944132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29866d0b-f9be-4284-9d21-03598ef6ae4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29866d0b-f9be-4284-9d21-03598ef6ae4f.jpg?1",
             "name": "Aven Flock",
             "text": "Flying\no\nW: Aven Flock gets +0/+1 until end of turn.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "061ca2cf-b6f0-5ddd-b9a4-5b095a5c322a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9890be7f-35af-43b7-b255-25be4ff20dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9890be7f-35af-43b7-b255-25be4ff20dc0.jpg?1",
             "name": "Aven Shrine",
             "text": "Whenever a player plays a spell, that player gains X life, where X is the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -309,7 +309,7 @@
         },
         {
             "id": "0c12a466-3775-5fc0-b843-fc374bfc54a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6cb368-43f7-4d06-9cd5-492df5766567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d6cb368-43f7-4d06-9cd5-492df5766567.jpg?1",
             "name": "Balancing Act",
             "text": "Each player chooses a number of permanents he or she controls equal to the number of permanents controlled by the player who controls the fewest, then sacrifices the rest. Each player discards cards from his or her hand the same way.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "ee55cc08-a8c3-5e68-8ebf-eb91a12cdb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decec62b-7ac4-4097-9215-5db18db2dec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decec62b-7ac4-4097-9215-5db18db2dec6.jpg?1",
             "name": "Beloved Chaplain",
             "text": "Protection from creatures",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "aac72b72-583f-50fe-aee5-48c684c1c621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5654575e-0849-4e7f-98f2-0074ac8e0faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5654575e-0849-4e7f-98f2-0074ac8e0faa.jpg?1",
             "name": "Blessed Orator",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "8cc0dd3e-d975-5166-94eb-70f98dce32f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5243fc3-176b-44a3-9f1a-ab069a08757a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5243fc3-176b-44a3-9f1a-ab069a08757a.jpg?1",
             "name": "Cantivore",
             "text": "Attacking doesn't cause Cantivore to tap.\nCantivore's power and toughness are each equal to the number of enchantment cards in all graveyards.",
             "colours": [
@@ -445,7 +445,7 @@
         },
         {
             "id": "2077c234-4a88-58f3-b241-1b80ef347383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646c998-aee5-497f-bd75-24ced1dabef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1646c998-aee5-497f-bd75-24ced1dabef9.jpg?1",
             "name": "Cease-Fire",
             "text": "Target player can't play creature spells this turn.\nDraw a card.",
             "colours": [
@@ -477,7 +477,7 @@
         },
         {
             "id": "1279963f-83a0-5fe9-9e19-94f83a8ea215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c0bdb-e9e2-435e-aa68-2dbad52c3dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984c0bdb-e9e2-435e-aa68-2dbad52c3dbd.jpg?1",
             "name": "Confessor",
             "text": "Whenever a player discards a card from his or her hand, you may gain 1 life.",
             "colours": [
@@ -512,7 +512,7 @@
         },
         {
             "id": "daee1fd6-5954-5ae4-8dea-06193d0f28a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f95b64-858b-4344-84a2-3afa5c7b9ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f95b64-858b-4344-84a2-3afa5c7b9ee9.jpg?1",
             "name": "Dedicated Martyr",
             "text": "o\nW, Sacrifice Dedicated Martyr: You gain 3 life.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "716e708c-4c27-52d1-9626-5e5df617f90b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8195a-d0e4-4b11-b413-765ed1cae834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e8195a-d0e4-4b11-b413-765ed1cae834.jpg?1",
             "name": "Delaying Shield",
             "text": "If you would be dealt damage, put that many delay counters on Delaying Shield instead.\nAt the beginning of your upkeep, remove all delay counters from Delaying Shield. For each delay counter removed this way, you lose 1 life unless you pay o1o\nW.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "f91f8c59-0d32-5c4d-98a3-b7a387d33b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d400b63-de3e-4805-a51d-c4c0dfbb7033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d400b63-de3e-4805-a51d-c4c0dfbb7033.jpg?1",
             "name": "Devoted Caretaker",
             "text": "o\nW, oc\nT: Target permanent you control gains protection from instant spells and from sorcery spells until end of turn.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "f764d740-1ef6-5fad-b193-a274068d29df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69ecef5-4f1a-4463-8908-7c0ef955b02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69ecef5-4f1a-4463-8908-7c0ef955b02d.jpg?1",
             "name": "Divine Sacrament",
             "text": "White creatures get +1/+1.\nThreshold White creatures get an additional +1/+1. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "ac41b326-f87d-5832-a205-677ea3bb1614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d4337-9b71-429b-b6bc-2d70299a6e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b50d4337-9b71-429b-b6bc-2d70299a6e76.jpg?1",
             "name": "Dogged Hunter",
             "text": "oc\nT: Destroy target creature token.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "90a85158-1568-5d5d-8a3c-2253af9b6b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66392169-5c6f-46bf-b0df-5670e40aecd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66392169-5c6f-46bf-b0df-5670e40aecd9.jpg?1",
             "name": "Earnest Fellowship",
             "text": "Each creature has protection from its colors.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "14848184-54a0-5162-886c-2bd8484c526b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36848fb0-4070-40cf-b24a-2e8f47c5ebc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36848fb0-4070-40cf-b24a-2e8f47c5ebc3.jpg?1",
             "name": "Embolden",
             "text": "Prevent the next 4 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.\nFlashback o1o\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "7377d2f9-f09b-5942-9ecf-d7422ee3351e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7992f83-93ad-4132-b8f2-a9f93bc96b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7992f83-93ad-4132-b8f2-a9f93bc96b4e.jpg?1",
             "name": "Gallantry",
             "text": "Target blocking creature gets +4/+4 until end of turn.\nDraw a card.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "bf3c0238-23c4-5118-9ecd-fcc05f2067f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f0d9d-4e05-48b4-8652-1f8f41d35563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f0d9d-4e05-48b4-8652-1f8f41d35563.jpg?1",
             "name": "Graceful Antelope",
             "text": "Plainswalk\nWhenever Graceful Antelope deals combat damage to a player, you may have target land become a plains until Graceful Antelope leaves play.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "c692ab84-5894-56e9-b45c-c3065c900db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254d5bf0-f985-4919-a142-d4578ae9a38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254d5bf0-f985-4919-a142-d4578ae9a38e.jpg?1",
             "name": "Hallowed Healer",
             "text": "oc\nT: Prevent the next 2 damage that would be dealt to target creature or player this turn.\nThreshold oc\nT: Prevent the next 4 damage that would be dealt to target creature or player this turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "af5f22cb-db2c-55ac-8404-78a26a15c311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ffb8e7-7ae3-4846-b3da-ca6b4598eb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ffb8e7-7ae3-4846-b3da-ca6b4598eb7c.jpg?1",
             "name": "Karmic Justice",
             "text": "Whenever a spell or ability an opponent controls destroys a noncreature permanent you control, you may destroy target permanent that opponent controls.",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "1d286a26-feb1-545f-8beb-1533984ba59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e36fe-ecbe-46aa-9ee8-2ba4daba7d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f1e36fe-ecbe-46aa-9ee8-2ba4daba7d31.jpg?1",
             "name": "Kirtar's Desire",
             "text": "Enchanted creature can't attack.\nThreshold Enchanted creature can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "079bffa1-700e-5452-b2f0-bb59cb9d75f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a0c4e6-d50e-42e8-b062-8f6ef5950ab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a0c4e6-d50e-42e8-b062-8f6ef5950ab7.jpg?1",
             "name": "Kirtar's Wrath",
             "text": "Destroy all creatures. They can't be regenerated.\nThreshold Instead destroy all creatures, then put two 1/1 white Spirit creature tokens with flying into play. Creatures destroyed this way can't be regenerated. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "dc5f6f12-9b44-59f6-8fc6-3e3becd0c30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e518750f-492d-4575-b4ee-c80c1f8e0a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e518750f-492d-4575-b4ee-c80c1f8e0a58.jpg?1",
             "name": "Lieutenant Kirtar",
             "text": "Flying\no1o\nW, Sacrifice Lieutenant Kirtar: Remove target attacking creature from the game.",
             "colours": [
@@ -981,7 +981,7 @@
         },
         {
             "id": "18460453-2820-55af-9cc3-15b29903f999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8eee50-efd2-45fd-b815-051167ef4541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8eee50-efd2-45fd-b815-051167ef4541.jpg?1",
             "name": "Life Burst",
             "text": "Target player gains 4 life, then gains 4 life for each Life Burst card in each graveyard.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "5dcc7297-1da2-51b5-90da-3e5f75e649db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5becc51-4df8-4f67-a029-42a3da598a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5becc51-4df8-4f67-a029-42a3da598a26.jpg?1",
             "name": "Luminous Guardian",
             "text": "o\nW: Luminous Guardian gets +0/+1 until end of turn.\no2: Luminous Guardian may block an additional creature this turn.",
             "colours": [
@@ -1048,7 +1048,7 @@
         },
         {
             "id": "b9a0bb6d-8f4e-5fde-852e-95718e87a4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff6624-ed0e-43d0-9519-112979b165f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff6624-ed0e-43d0-9519-112979b165f5.jpg?1",
             "name": "Master Apothecary",
             "text": "Tap an untapped Cleric you control: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "a714a140-2f97-5805-b1c8-e49ffae0cd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce1baf-8a89-4884-b0f7-19311bfc8c4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ce1baf-8a89-4884-b0f7-19311bfc8c4c.jpg?1",
             "name": "Mystic Crusader",
             "text": "Protection from black and from red\nThreshold Mystic Crusader gets +1/+1 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "e0397687-d3c5-5c22-a3c2-2cdf8366630a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37f08b-019e-4e6b-8b15-b2971a3b5ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb37f08b-019e-4e6b-8b15-b2971a3b5ebb.jpg?1",
             "name": "Mystic Penitent",
             "text": "Attacking doesn't cause Mystic Penitent to tap.\nThreshold Mystic Penitent gets +1/+1 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "4ecbfe6a-7ee8-531f-b3b6-b8ba88f2b28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ed1b3d-0f7e-46ff-ada7-ebbd416ecf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48ed1b3d-0f7e-46ff-ada7-ebbd416ecf5b.jpg?1",
             "name": "Mystic Visionary",
             "text": "Threshold Mystic Visionary has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1191,7 +1191,7 @@
         },
         {
             "id": "d0eafb42-228f-5aff-8e9b-060db88e6963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba21062-5d13-47b9-bea1-ded8530a9aeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba21062-5d13-47b9-bea1-ded8530a9aeb.jpg?1",
             "name": "Mystic Zealot",
             "text": "Threshold Mystic Zealot gets +1/+1 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "b9c96296-d5af-51a7-9fbe-2135e0fd3bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffef7c6-e05b-4bef-84aa-8df10be110af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ffef7c6-e05b-4bef-84aa-8df10be110af.jpg?1",
             "name": "Nomad Decoy",
             "text": "o\nW, oc\nT: Tap target creature.\nThreshold o\nWo\nW, oc\nT: Tap two target creatures. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "9ab506c6-bfe5-531b-9aaa-44d4678b2fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216a539-152b-4a83-98ef-1996182a5714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216a539-152b-4a83-98ef-1996182a5714.jpg?1",
             "name": "Patrol Hound",
             "text": "Discard a card from your hand: Patrol Hound gains first strike until end of turn.",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "f86d25aa-bc5a-536f-88f5-d58956a6dfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812edfa-3a53-48e8-ba35-6922a1f3aa90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0812edfa-3a53-48e8-ba35-6922a1f3aa90.jpg?1",
             "name": "Pianna, Nomad Captain",
             "text": "Whenever Pianna, Nomad Captain attacks, attacking creatures get +1/+1 until end of turn.",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "c7e7f75a-d305-57e5-b409-859904917d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6103a3a7-78ce-4a66-bd82-434e0bd9dea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6103a3a7-78ce-4a66-bd82-434e0bd9dea4.jpg?1",
             "name": "Pilgrim of Justice",
             "text": "Protection from red\no\nW, Sacrifice Pilgrim of Justice: The next time a red source of your choice would deal damage this turn, prevent that damage.",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "7c646e8c-89fb-59ee-b7e6-bb767df635b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be58f0dd-3856-4960-83de-06eed78ed703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be58f0dd-3856-4960-83de-06eed78ed703.jpg?1",
             "name": "Pilgrim of Virtue",
             "text": "Protection from black\no\nW, Sacrifice Pilgrim of Virtue: The next time a black source of your choice would deal damage this turn, prevent that damage.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "3498f9f0-522b-5f9e-bf81-cabb55aee68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9940f593-021f-44cd-9725-0779a2808b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9940f593-021f-44cd-9725-0779a2808b6c.jpg?1",
             "name": "Ray of Distortion",
             "text": "Destroy target artifact or enchantment.\nFlashback o4o\nWo\nW (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "bd691240-464b-5f72-a460-d698336e3dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a61de-ee4e-4097-b342-b5f2c976e16e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5a61de-ee4e-4097-b342-b5f2c976e16e.jpg?1",
             "name": "Resilient Wanderer",
             "text": "First strike\nDiscard a card from your hand: Resilient Wanderer gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -1470,7 +1470,7 @@
         },
         {
             "id": "8336a969-5e2c-5a92-93bf-287928e48863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7f1dd0-ee1b-484a-949d-dde4c3340a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7f1dd0-ee1b-484a-949d-dde4c3340a09.jpg?1",
             "name": "Sacred Rites",
             "text": "Discard any number of cards from your hand. Creatures you control get +0/+1 until end of turn for each card discarded this way.",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "718be822-fd0a-5f48-b199-ca1cf7874468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09586de-4853-4e51-a4ac-70eabb37eef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09586de-4853-4e51-a4ac-70eabb37eef4.jpg?1",
             "name": "Second Thoughts",
             "text": "Remove target attacking creature from the game.\nDraw a card.",
             "colours": [
@@ -1534,7 +1534,7 @@
         },
         {
             "id": "9517992a-e143-53c5-a034-ba593b2b3570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c726ab3-1692-4e14-ab21-664a1679bc53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c726ab3-1692-4e14-ab21-664a1679bc53.jpg?1",
             "name": "Shelter",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -1566,7 +1566,7 @@
         },
         {
             "id": "2679c275-acdc-5845-9513-80873c9f965f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d24d2f-699b-46d8-9353-45e6a67f99d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d24d2f-699b-46d8-9353-45e6a67f99d2.jpg?1",
             "name": "Soulcatcher",
             "text": "Flying\nWhenever a creature with flying is put into a graveyard from play, put a +1/+1 counter on Soulcatcher.",
             "colours": [
@@ -1601,7 +1601,7 @@
         },
         {
             "id": "25ffe3e0-fa75-540d-ae35-2c6b97f6e4ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdcd0de-6466-488c-a882-bad80c86504d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdcd0de-6466-488c-a882-bad80c86504d.jpg?1",
             "name": "Sphere of Duty",
             "text": "If a green source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1633,7 +1633,7 @@
         },
         {
             "id": "1f7756cf-4df0-5f1d-8021-02067b3d0f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b49d82-6d11-4294-a367-0b5b45c05e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5b49d82-6d11-4294-a367-0b5b45c05e44.jpg?1",
             "name": "Sphere of Grace",
             "text": "If a black source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "f3cd9491-f0dd-54e4-a8c1-557fc4e8e488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3451ddf-efec-474b-884c-64288e5552d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3451ddf-efec-474b-884c-64288e5552d2.jpg?1",
             "name": "Sphere of Law",
             "text": "If a red source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1697,7 +1697,7 @@
         },
         {
             "id": "87009baf-f63d-520a-a5fc-f5c60dda4a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ef2016-b3c8-4615-a056-3000bcccb68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ef2016-b3c8-4615-a056-3000bcccb68e.jpg?1",
             "name": "Sphere of Reason",
             "text": "If a blue source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "a5732dba-6f53-5197-87bf-0a3c60c92408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3de9f5-a05c-4341-a2c2-a1a475d400fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3de9f5-a05c-4341-a2c2-a1a475d400fd.jpg?1",
             "name": "Sphere of Truth",
             "text": "If a white source would deal damage to you, prevent 2 of that damage.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "f270f1f6-6f2b-5a91-bda7-eac465d993eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6780ded-86df-419d-b63b-6b67d2960b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6780ded-86df-419d-b63b-6b67d2960b28.jpg?1",
             "name": "Spiritualize",
             "text": "Until end of turn, whenever target creature deals damage, you gain that much life.\nDraw a card.",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "afe9d5a1-86d1-5adf-a20b-26ca633c4289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920480-9b39-47dd-988a-c040067da7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89920480-9b39-47dd-988a-c040067da7fb.jpg?1",
             "name": "Tattoo Ward",
             "text": "Enchanted creature gets +1/+1 and has protection from enchantments. This effect doesn't remove Tattoo Ward.\nSacrifice Tattoo Ward: Destroy target enchantment.",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "978faa25-618b-54d6-bb7e-4cbda17d5ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f399b371-fed0-42b8-8f95-5d76fdbe193d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f399b371-fed0-42b8-8f95-5d76fdbe193d.jpg?1",
             "name": "Testament of Faith",
             "text": "o\nX: Testament of Faith becomes an X/X Wall creature until end of turn. It's still an enchantment. (Walls can't attack.)",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "27dc91f9-d635-5b14-915f-b593e0cbf8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d23e47a-21d5-4d7e-8aa0-3b3064da5967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d23e47a-21d5-4d7e-8aa0-3b3064da5967.jpg?1",
             "name": "Tireless Tribe",
             "text": "Discard a card from your hand: Tireless Tribe gets +0/+4 until end of turn.",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "4a620892-ecb5-58d2-87f4-267707171a5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb726e8-162d-4143-9778-32476c0e1ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb726e8-162d-4143-9778-32476c0e1ab1.jpg?1",
             "name": "Wayward Angel",
             "text": "Flying\nAttacking doesn't cause Wayward Angel to tap.\nThreshold Wayward Angel gets +3/+3, is black, has trample, and has \"At the beginning of your upkeep, sacrifice a creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "5ee5073e-f73d-5841-864d-a1af3d7688ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db4a41-03e8-4f0c-946c-a98fc5c9f7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82db4a41-03e8-4f0c-946c-a98fc5c9f7c8.jpg?1",
             "name": "Aboshan, Cephalid Emperor",
             "text": "Tap an untapped Cephalid you control: Tap target permanent.\no\nUo\nUo\nU: Tap all creatures without flying.",
             "colours": [
@@ -1966,7 +1966,7 @@
         },
         {
             "id": "4f2edfee-374a-5a68-9472-b70b32d3e6ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137b701e-6140-463e-84b5-58d8a728df40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137b701e-6140-463e-84b5-58d8a728df40.jpg?1",
             "name": "Aboshan's Desire",
             "text": "Enchanted creature has flying.\nThreshold Enchanted creature can't be the target of spells or abilities. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "f6727bbd-ffc5-51a0-8e42-e033edcf3f50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09ea4a-0d3a-40b8-be0f-a31693099c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09ea4a-0d3a-40b8-be0f-a31693099c4f.jpg?1",
             "name": "Aether Burst",
             "text": "Return up to X target creatures to their owners' hands, where X is one plus the number of \u00c6ther Burst cards in all graveyards as you play \u00c6ther Burst.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "3b316639-a2fd-5549-aec2-6c4b4265ad6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d73d1e7-79be-4b28-a480-b65b4f34f755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d73d1e7-79be-4b28-a480-b65b4f34f755.jpg?1",
             "name": "Amugaba",
             "text": "Flying\no2o\nU, Discard a card from your hand: Return Amugaba to its owner's hand.",
             "colours": [
@@ -2066,7 +2066,7 @@
         },
         {
             "id": "b671c573-467f-5cbb-9a70-b2d67bc5ef74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7553877-7df2-42f7-98a3-1a07f66a4905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7553877-7df2-42f7-98a3-1a07f66a4905.jpg?1",
             "name": "Aura Graft",
             "text": "Move target enchantment that's enchanting a permanent to another permanent it can enchant. Gain control of that enchantment. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2098,7 +2098,7 @@
         },
         {
             "id": "c8d6108c-1ce4-504b-b64b-6abe5d70c34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b27130d-2296-4076-9829-15ab63081896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b27130d-2296-4076-9829-15ab63081896.jpg?1",
             "name": "Aven Fisher",
             "text": "Flying\nWhen Aven Fisher is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "124d7533-25fb-5c2f-afe2-5aa2ec04dbf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f5d024-f137-4ea8-be02-7de46dee95fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f5d024-f137-4ea8-be02-7de46dee95fd.jpg?1",
             "name": "Aven Smokeweaver",
             "text": "Flying, protection from red",
             "colours": [
@@ -2168,7 +2168,7 @@
         },
         {
             "id": "f432dab2-c070-5f77-a741-bcf415c541c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd2f2cb-a0f1-4844-a692-bcaf1899d41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fd2f2cb-a0f1-4844-a692-bcaf1899d41c.jpg?1",
             "name": "Aven Windreader",
             "text": "Flying\no1o\nU: Target player reveals the top card of his or her library.",
             "colours": [
@@ -2204,7 +2204,7 @@
         },
         {
             "id": "7dd8293e-d88b-540c-abbb-4534fdbd0b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d977da2-4024-4c7b-b557-e89564f8d465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d977da2-4024-4c7b-b557-e89564f8d465.jpg?1",
             "name": "Balshan Beguiler",
             "text": "Whenever Balshan Beguiler deals combat damage to a player, that player reveals the top two cards of his or her library. You choose one of those cards and put it into his or her graveyard.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "de0c2eb9-8d5c-517a-b1d9-614d89b81006",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c5440-e31f-40be-9e66-699d17049fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c5440-e31f-40be-9e66-699d17049fb4.jpg?1",
             "name": "Balshan Griffin",
             "text": "Flying\no1o\nU, Discard a card from your hand: Return Balshan Griffin to its owner's hand.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "183ff917-55a7-5589-94a2-84a8b26e031a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012bb8-17b7-4b50-a796-662ef09bfc29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012bb8-17b7-4b50-a796-662ef09bfc29.jpg?1",
             "name": "Bamboozle",
             "text": "Target player reveals the top four cards of his or her library. You choose two of those cards and put them into his or her graveyard. Put the rest on top of his or her library in any order.",
             "colours": [
@@ -2305,7 +2305,7 @@
         },
         {
             "id": "e54b5360-a13d-5a52-8928-b887d60f4532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f3c75b-0fe0-48e0-b468-bb928565e9dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f3c75b-0fe0-48e0-b468-bb928565e9dd.jpg?1",
             "name": "Battle of Wits",
             "text": "At the beginning of your upkeep, if you have 200 or more cards in your library, you win the game.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "eceafb2a-499f-5cd5-82ce-59a2b9af5fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea15b53-2940-40e7-8d48-8ec11341da83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea15b53-2940-40e7-8d48-8ec11341da83.jpg?1",
             "name": "Careful Study",
             "text": "Draw two cards, then discard two cards from your hand.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "7b05548d-81d0-5ab5-b641-7b661b6a5cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d2cfe5-b905-4d8a-89e4-474619e2796c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d2cfe5-b905-4d8a-89e4-474619e2796c.jpg?1",
             "name": "Cephalid Broker",
             "text": "oc\nT: Target player draws two cards, then discards two cards from his or her hand.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "709374d4-6c5a-5a2d-aa41-f1bf75a5c41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f1c4e-4fbc-4474-8dd2-5846d417b6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6f1c4e-4fbc-4474-8dd2-5846d417b6ab.jpg?1",
             "name": "Cephalid Looter",
             "text": "oc\nT: Target player draws a card, then discards a card from his or her hand.",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "e8dd1a47-1c37-5a94-95ee-ca33354c2b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae87f9d-d6eb-4178-a99d-76a9dffacf28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae87f9d-d6eb-4178-a99d-76a9dffacf28.jpg?1",
             "name": "Cephalid Looter",
             "text": "",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "b10c2f6f-349d-5988-bcc9-f64e54a705ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78480527-cfd6-4065-b702-82de4694f9bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78480527-cfd6-4065-b702-82de4694f9bb.jpg?1",
             "name": "Cephalid Retainer",
             "text": "o\nUo\nU: Tap target creature without flying.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "396d380c-159d-5e6e-bb76-545db2ef34e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efdf190-970d-4751-b214-cd962f7f2ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efdf190-970d-4751-b214-cd962f7f2ca8.jpg?1",
             "name": "Cephalid Scout",
             "text": "Flying\no2o\nU, Sacrifice a land: Draw a card.",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "c275a73a-4599-5bdc-9566-144a902076c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137e0ac1-3bf2-4583-b44f-c9fe8d7e8882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137e0ac1-3bf2-4583-b44f-c9fe8d7e8882.jpg?1",
             "name": "Cephalid Shrine",
             "text": "Whenever a player plays a spell, counter that spell unless that player pays o\nX, where X is the number of cards in all graveyards with the same name as the spell.",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "386cbb19-647c-50ac-9766-155c20c46a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50496069-0f55-4dfe-8b1e-7fc4f649f2f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50496069-0f55-4dfe-8b1e-7fc4f649f2f1.jpg?1",
             "name": "Chamber of Manipulation",
             "text": "Enchanted land has \"oc\nT, Discard a card from your hand: Gain control of target creature until end of turn.\"",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "7d0f2ddb-d347-5ca3-a224-3a899744c47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de76ff6-d065-4db1-b28d-4a4ccb1cc0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de76ff6-d065-4db1-b28d-4a4ccb1cc0fa.jpg?1",
             "name": "Cognivore",
             "text": "Flying\nCognivore's power and toughness are each equal to the number of instant cards in all graveyards.",
             "colours": [
@@ -2647,7 +2647,7 @@
         },
         {
             "id": "9f3ba421-c6ce-5347-86a9-8a154d656742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2878e-1c1c-4dd3-9687-7bb216d557c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f2878e-1c1c-4dd3-9687-7bb216d557c7.jpg?1",
             "name": "Concentrate",
             "text": "Draw three cards.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "5f62e157-3127-562f-9cfc-69c997a3e8a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f38d07-829c-4311-a61b-2785cf2266ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f38d07-829c-4311-a61b-2785cf2266ef.jpg?1",
             "name": "Cultural Exchange",
             "text": "Choose any number of creatures target player controls. Choose the same number of creatures another target player controls. Those players exchange control of those creatures. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "d0a5d989-087f-51b4-a1b6-8c1aa0199cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e64f32-0436-4f07-b2b5-a622e3f59d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e64f32-0436-4f07-b2b5-a622e3f59d65.jpg?1",
             "name": "Deluge",
             "text": "Tap all creatures without flying.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "7c164472-830e-52e5-8c77-1c3767978c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04217c17-7c29-4b02-b9b6-bfa1df50d4bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04217c17-7c29-4b02-b9b6-bfa1df50d4bc.jpg?1",
             "name": "Dematerialize",
             "text": "Return target permanent to its owner's hand.\nFlashback o5o\nUo\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "63bc1141-5498-5dcb-8926-eb34c560438a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6e9f8-a508-451e-8a72-5f9834ba5352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb6e9f8-a508-451e-8a72-5f9834ba5352.jpg?1",
             "name": "Divert",
             "text": "Change the target of target spell with a single target unless that spell's controller pays o2.",
             "colours": [
@@ -2807,7 +2807,7 @@
         },
         {
             "id": "10ac94e8-461a-5e39-88d3-9b8b386c8ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae3a000-478c-4185-a8c0-82f29942497b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ae3a000-478c-4185-a8c0-82f29942497b.jpg?1",
             "name": "Dreamwinder",
             "text": "Dreamwinder can't attack unless defending player controls an island.\no\nU, Sacrifice an island: Target land becomes an island until end of turn.",
             "colours": [
@@ -2841,7 +2841,7 @@
         },
         {
             "id": "01a665bb-a08e-5445-ab2d-a11513d07bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5d0e3f-b8f1-472a-857b-5464174d243b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5d0e3f-b8f1-472a-857b-5464174d243b.jpg?1",
             "name": "Escape Artist",
             "text": "Escape Artist is unblockable.\no\nU, Discard a card from your hand: Return Escape Artist to its owner's hand.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "7f2ccf67-234e-5e45-85b2-94361566ef8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f99a3d-d811-4666-aac8-5957068157dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f99a3d-d811-4666-aac8-5957068157dc.jpg?1",
             "name": "Extract",
             "text": "Search target player's library for a card and remove that card from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2908,7 +2908,7 @@
         },
         {
             "id": "284dbad0-cc2b-5b5b-994a-43e2dc5b57b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed13fdb4-f28a-43c9-a69f-bab227806c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed13fdb4-f28a-43c9-a69f-bab227806c39.jpg?1",
             "name": "Fervent Denial",
             "text": "Counter target spell.\nFlashback o5o\nUo\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2940,7 +2940,7 @@
         },
         {
             "id": "11706f30-f25b-5b9f-9d4f-cfdde57d3015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6e2d96-dd9e-45f6-b412-78562f2ada40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee6e2d96-dd9e-45f6-b412-78562f2ada40.jpg?1",
             "name": "Immobilizing Ink",
             "text": "Enchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"o1, Discard a card from your hand: Untap this creature.\"",
             "colours": [
@@ -2974,7 +2974,7 @@
         },
         {
             "id": "7a2aa93b-1a01-5f23-9db9-59f15368e07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd48c28-bfa3-4eca-8e1a-f72d785b2ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcd48c28-bfa3-4eca-8e1a-f72d785b2ab9.jpg?1",
             "name": "Laquatus's Creativity",
             "text": "Target player draws cards equal to the number of cards in his or her hand, then discards that many cards.",
             "colours": [
@@ -3006,7 +3006,7 @@
         },
         {
             "id": "cea8da24-a339-50c5-883a-ee6d4c7147aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b863b8-7780-4bbe-a7f8-46bfdcb34a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b863b8-7780-4bbe-a7f8-46bfdcb34a2b.jpg?1",
             "name": "Patron Wizard",
             "text": "Tap an untapped Wizard you control: Counter target spell unless its controller pays o1.",
             "colours": [
@@ -3041,7 +3041,7 @@
         },
         {
             "id": "78dfe7ec-8cd1-5632-9b10-34a705d14a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67445332-0b56-4fec-8dcd-bb9a87194db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67445332-0b56-4fec-8dcd-bb9a87194db5.jpg?1",
             "name": "Pedantic Learning",
             "text": "Whenever a land card is put into your graveyard from your library, you may pay o1. If you do, draw a card.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "56032103-4eef-5fa9-a733-05196b9ec717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50843cc-20ac-4746-816e-f2630aa31594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50843cc-20ac-4746-816e-f2630aa31594.jpg?1",
             "name": "Peek",
             "text": "Look at target player's hand.\nDraw a card.",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "428620c9-c943-5ab9-a4df-5a084e758461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5d930-23b4-4726-8f5c-3c690b36f4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db5d930-23b4-4726-8f5c-3c690b36f4a4.jpg?1",
             "name": "Persuasion",
             "text": "You control enchanted creature.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "51f5447a-168f-5f12-b7a1-88639597058b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9216e73b-56ef-48b9-a6a1-b370fb0d97c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9216e73b-56ef-48b9-a6a1-b370fb0d97c1.jpg?1",
             "name": "Phantom Whelp",
             "text": "When Phantom Whelp attacks or blocks, return it to its owner's hand at end of combat.",
             "colours": [
@@ -3174,7 +3174,7 @@
         },
         {
             "id": "cdac857b-036d-50d2-96ca-8b818182425e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dc842c-3250-44ed-906c-38f14bf1f0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dc842c-3250-44ed-906c-38f14bf1f0e2.jpg?1",
             "name": "Predict",
             "text": "Name a card, then put the top card of target player's library into his or her graveyard. If that card is the named card, you draw two cards. Otherwise, you draw a card.",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "cdf07699-558c-507c-910b-9dc75b50e42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fc18f-90d2-430d-aff2-47c1483dee9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fc18f-90d2-430d-aff2-47c1483dee9d.jpg?1",
             "name": "Psionic Gift",
             "text": "Enchanted creature has \"oc\nT: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "5a4b30cd-4b8a-566c-9a24-9d7b09aa9d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3297f28-a15d-43dd-a96e-09701d5f9aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3297f28-a15d-43dd-a96e-09701d5f9aed.jpg?1",
             "name": "Pulsating Illusion",
             "text": "Flying\nDiscard a card from your hand: Pulsating Illusion gets +4/+4 until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "2946de09-dff3-592f-b29d-2cf90ef5a4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d5bd2-02bf-4a22-a656-764425711c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d5bd2-02bf-4a22-a656-764425711c29.jpg?1",
             "name": "Puppeteer",
             "text": "o\nU, oc\nT: Tap or untap target creature.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "5eec6283-86ab-53f9-8a2b-25baafa12446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ea14a6-539a-47eb-9147-a310be7b63fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ea14a6-539a-47eb-9147-a310be7b63fe.jpg?1",
             "name": "Repel",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "eb84e010-5516-55c7-b884-7b54b6670102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa88f595-1b6f-4af0-bc50-bd07c8be431f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa88f595-1b6f-4af0-bc50-bd07c8be431f.jpg?1",
             "name": "Rites of Refusal",
             "text": "Discard any number of cards from your hand. Counter target spell unless its controller pays o3 for each card discarded this way.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "bb8d0a37-5dc4-5e0b-b655-1c792d436c54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f16fb-0829-45f9-a12e-aeb2371dd533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606f16fb-0829-45f9-a12e-aeb2371dd533.jpg?1",
             "name": "Scrivener",
             "text": "When Scrivener comes into play, you may return target instant card from your graveyard to your hand.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "5efbdab7-2ec0-50b6-a04d-4e1ad5ef7d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538ffe1e-c312-4797-99dd-9bf5f896bdc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538ffe1e-c312-4797-99dd-9bf5f896bdc3.jpg?1",
             "name": "Shifty Doppelganger",
             "text": "o3o\nU, Remove Shifty Doppelganger from the game: Put a creature card from your hand into play. That creature gains haste until end of turn. At end of turn, sacrifice that creature. If you do, return Shifty Doppelganger to play.",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "074d1271-6f47-52b3-b1f0-7b22e230a79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede3f6f-e642-4fe4-aa37-0f01cdf4d149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ede3f6f-e642-4fe4-aa37-0f01cdf4d149.jpg?1",
             "name": "Standstill",
             "text": "When a player plays a spell, sacrifice Standstill. If you do, each of that player's opponents draws three cards.",
             "colours": [
@@ -3474,7 +3474,7 @@
         },
         {
             "id": "fc7da356-b141-58cd-a0df-130443327e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7850794-4c85-4844-a461-650cd4eaec93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7850794-4c85-4844-a461-650cd4eaec93.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays o\nX. If that spell is countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "32f6940d-d732-517d-b186-ffa311dda473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c9d34-ea4c-4e89-a7ed-06c4469c1aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c1c9d34-ea4c-4e89-a7ed-06c4469c1aca.jpg?1",
             "name": "Think Tank",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -3538,7 +3538,7 @@
         },
         {
             "id": "a4ceeea9-0fea-551b-927a-d2454f645f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7a96ee-e2d1-4d76-a09e-d6868ddd9282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7a96ee-e2d1-4d76-a09e-d6868ddd9282.jpg?1",
             "name": "Thought Devourer",
             "text": "Flying\nYour maximum hand size is reduced by four.",
             "colours": [
@@ -3572,7 +3572,7 @@
         },
         {
             "id": "8eb420e1-9ac6-57eb-ae56-9e93206d0554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e05f63c-f93d-44b9-98e9-c5e3e3aad6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e05f63c-f93d-44b9-98e9-c5e3e3aad6b9.jpg?1",
             "name": "Thought Eater",
             "text": "Flying\nYour maximum hand size is reduced by three.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "5eb5e069-005a-5e38-a0c3-e359394206ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7284a7fd-cda8-43ac-b119-ad47b33c2ec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7284a7fd-cda8-43ac-b119-ad47b33c2ec4.jpg?1",
             "name": "Thought Nibbler",
             "text": "Flying\nYour maximum hand size is reduced by two.",
             "colours": [
@@ -3640,7 +3640,7 @@
         },
         {
             "id": "8f8322dd-b342-5494-a50d-5f1647f05db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c3d626-880c-422a-ac09-a79a52847477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c3d626-880c-422a-ac09-a79a52847477.jpg?1",
             "name": "Time Stretch",
             "text": "Target player takes two extra turns after this one.",
             "colours": [
@@ -3672,7 +3672,7 @@
         },
         {
             "id": "2249a0e4-05cc-5b16-b622-0b1316ef5ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0c915-92a9-4eb0-a02a-c1571b00761b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5a0c915-92a9-4eb0-a02a-c1571b00761b.jpg?1",
             "name": "Touch of Invisibility",
             "text": "Target creature is unblockable this turn.\nDraw a card.",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "8c7c316c-bddf-5494-bf16-b534ada6bdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cad8762-ff91-4971-84be-f643c7795679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cad8762-ff91-4971-84be-f643c7795679.jpg?1",
             "name": "Traumatize",
             "text": "Target player puts the top half of his or her library, rounded down, into his or her graveyard.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "50aafbce-e387-5573-963e-29483bb717c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b4e02-f81a-490c-8d2e-cfea7917d6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606b4e02-f81a-490c-8d2e-cfea7917d6b7.jpg?1",
             "name": "Treetop Sentinel",
             "text": "Flying, protection from green",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "435c2005-9396-5f8f-82f0-9a9ed8a54392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa4bf82-65e7-4b0c-9f96-dd84a67dcfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa4bf82-65e7-4b0c-9f96-dd84a67dcfb2.jpg?1",
             "name": "Unifying Theory",
             "text": "Whenever a player plays a spell, that player may pay o2. If the player does, he or she draws a card.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "41cd1b42-7209-520f-84d0-ef0d11bd87ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e201229-34a6-48c8-a07c-d8aefcf5f8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e201229-34a6-48c8-a07c-d8aefcf5f8a7.jpg?1",
             "name": "Upheaval",
             "text": "Return all permanents to their owners' hands.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "e4e1100b-3193-5fd1-bc9a-5a740b99350d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0199cfb-5e44-40f0-b9cf-71473155eb94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0199cfb-5e44-40f0-b9cf-71473155eb94.jpg?1",
             "name": "Words of Wisdom",
             "text": "You draw two cards, then each other player draws a card.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "a61ff5ab-413e-5253-b742-3822f9f21570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0012621b-c0e1-48d6-99b9-ecca4763d748.jpg?1",
             "name": "Afflict",
             "text": "Target creature gets -1/-1 until end of turn.\nDraw a card.",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "ae826956-60e6-52e9-ba00-aeb79c40527e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1452ff-cec6-4df3-8bdc-bfb7869553a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1452ff-cec6-4df3-8bdc-bfb7869553a1.jpg?1",
             "name": "Bloodcurdler",
             "text": "Flying\nAt the beginning of your upkeep, put the top card of your library into your graveyard.\nThreshold Bloodcurdler gets +1/+1 and has \"At the end of your turn, remove two cards in your graveyard from the game.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "ea92b680-e0e4-5848-ad34-0ed9e31d7db1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcdcad5-e4fb-480e-984f-1ac5cdc986b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcdcad5-e4fb-480e-984f-1ac5cdc986b9.jpg?1",
             "name": "Braids, Cabal Minion",
             "text": "At the beginning of each player's upkeep, that player sacrifices an artifact, creature, or land.",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "2a36ed0e-e599-5bbd-9931-b9ebd8c2f772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db3697e-a31b-45a5-b742-fdfb00ce3929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db3697e-a31b-45a5-b742-fdfb00ce3929.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards and put them into your graveyard. Then shuffle your library.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "1f8f8880-114b-5bf0-a97e-ec6e2d1556a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0530e09-5206-460e-abd2-e928eca294a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0530e09-5206-460e-abd2-e928eca294a5.jpg?1",
             "name": "Cabal Inquisitor",
             "text": "Threshold o1o\nB, oc\nT, Remove two cards in your graveyard from the game: Target player discards a card from his or her hand. Play this ability only any time you could play a sorcery. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "4d3f0198-0d59-5247-b719-cb67f4b3e133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2f0da3-a13e-4a45-98dc-6227cf952a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2f0da3-a13e-4a45-98dc-6227cf952a5e.jpg?1",
             "name": "Cabal Patriarch",
             "text": "o2o\nB, Sacrifice a creature: Target creature gets -2/-2 until end of turn.\no2o\nB, Remove a creature card in your graveyard from the game: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -4074,7 +4074,7 @@
         },
         {
             "id": "b012919c-46d1-530d-b0ff-8416203fa4bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd376a52-5dfd-49f3-a520-537cd4527439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd376a52-5dfd-49f3-a520-537cd4527439.jpg?1",
             "name": "Cabal Shrine",
             "text": "Whenever a player plays a spell, that player discards X cards from his or her hand, where X is the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "2970231f-3f90-57a1-aefd-850bae883fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a61f-76fe-42e6-be93-0ba319b7b543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3700a61f-76fe-42e6-be93-0ba319b7b543.jpg?1",
             "name": "Caustic Tar",
             "text": "Enchanted land has \"oc\nT: Target player loses 3 life.\"",
             "colours": [
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "c7f99a44-e825-521d-b423-d47ae7141017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c180ea-2d1e-458e-b5d4-e87975eba968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c180ea-2d1e-458e-b5d4-e87975eba968.jpg?1",
             "name": "Childhood Horror",
             "text": "Flying\nThreshold Childhood Horror gets +2/+2 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "15bba7b9-7505-5d77-9e1a-956df21f25dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e06cb-5616-40b4-9d36-89471a795ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/541e06cb-5616-40b4-9d36-89471a795ac8.jpg?1",
             "name": "Coffin Purge",
             "text": "Remove target card in a graveyard from the game.\nFlashback o\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "b846501f-6872-5058-a813-fe5795cac4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7363dc-fc0d-4fe0-a90c-6ce1782be3ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7363dc-fc0d-4fe0-a90c-6ce1782be3ae.jpg?1",
             "name": "Crypt Creeper",
             "text": "Sacrifice Crypt Creeper: Remove target card in a graveyard from the game.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "809df54e-bf75-5511-9103-4c0743e1a53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de97585-3d24-4e8d-8bf9-edd75ee88443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de97585-3d24-4e8d-8bf9-edd75ee88443.jpg?1",
             "name": "Cursed Monstrosity",
             "text": "Flying\nWhenever Cursed Monstrosity becomes the target of a spell or ability, sacrifice it unless you discard a land card from your hand.",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "4dd19d9f-cc17-546b-bb1b-289678106664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bea0ec-52e0-4f45-a445-8805dc6ed596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bea0ec-52e0-4f45-a445-8805dc6ed596.jpg?1",
             "name": "Decaying Soil",
             "text": "At the beginning of your upkeep, remove a card in your graveyard from the game.\nThreshold Whenever a nontoken creature is put into your graveyard from play, you may pay o1. If you do, return that card to your hand. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "2939b646-2a7d-5c20-9efc-6838001548ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916fb8a8-f402-4ef6-8a6b-8fc591e04367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916fb8a8-f402-4ef6-8a6b-8fc591e04367.jpg?1",
             "name": "Decompose",
             "text": "Remove up to three target cards in a single graveyard from the game.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "3226c5e8-9128-5eca-9a3c-56251cde2aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cf7e1b-00ea-46f8-a20a-76c307167854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cf7e1b-00ea-46f8-a20a-76c307167854.jpg?1",
             "name": "Diabolic Tutor",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "364a78e3-e1e2-509c-b213-69847618824d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d15534-310f-4f9d-be0d-59b0ed8a5f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d15534-310f-4f9d-be0d-59b0ed8a5f53.jpg?1",
             "name": "Dirty Wererat",
             "text": "o\nB, Discard a card from your hand: Regenerate Dirty Wererat.\nThreshold Dirty Wererat gets +2/+2 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4406,7 +4406,7 @@
         },
         {
             "id": "d22b288c-2652-51ff-86eb-4d29ac188a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67943c0-304a-4d04-8e26-f45b3ab27a45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67943c0-304a-4d04-8e26-f45b3ab27a45.jpg?1",
             "name": "Dusk Imp",
             "text": "Flying",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "75434c84-1e0a-5dcd-92a4-4f83c259112b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60a2091-fb97-4f04-911b-fce9b6351044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60a2091-fb97-4f04-911b-fce9b6351044.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card and put that card into your graveyard. Then shuffle your library.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "161b3b0a-91da-503b-a583-6748e7c64fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333123bc-fb66-4b5a-bf55-045d2906c8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333123bc-fb66-4b5a-bf55-045d2906c8c3.jpg?1",
             "name": "Execute",
             "text": "Destroy target white creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -4504,7 +4504,7 @@
         },
         {
             "id": "77552a05-3493-563e-91d1-5049ac9176b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17542219-1165-4483-9cef-7abecaebb6a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17542219-1165-4483-9cef-7abecaebb6a2.jpg?1",
             "name": "Face of Fear",
             "text": "o2o\nB, Discard a card from your hand: Face of Fear can't be blocked this turn except by artifact creatures and/or black creatures.",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "d7d8b352-98e6-57bc-8208-d58570217657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e413b65a-700d-44eb-a880-5a0118d2ebac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e413b65a-700d-44eb-a880-5a0118d2ebac.jpg?1",
             "name": "Famished Ghoul",
             "text": "o1o\nB, Sacrifice Famished Ghoul: Remove up to two target cards in a single graveyard from the game.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "0cb66385-2406-5aef-a9e9-9d8f9c234da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634b2b46-b213-4eb0-81d8-0e9dd161b85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634b2b46-b213-4eb0-81d8-0e9dd161b85f.jpg?1",
             "name": "Filthy Cur",
             "text": "Whenever Filthy Cur is dealt damage, you lose that much life.",
             "colours": [
@@ -4606,7 +4606,7 @@
         },
         {
             "id": "49b38bb3-d102-5612-bfa8-01d9dbe7d984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11770ee-dcf0-4dd4-ab43-b98f1133cec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11770ee-dcf0-4dd4-ab43-b98f1133cec7.jpg?1",
             "name": "Fledgling Imp",
             "text": "o\nB, Discard a card from your hand: Fledgling Imp gains flying until end of turn.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "533641e9-8ccb-53b2-977b-677aa4019e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79129e7-6cc4-4060-8b76-3afbd2e0d456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79129e7-6cc4-4060-8b76-3afbd2e0d456.jpg?1",
             "name": "Frightcrawler",
             "text": "Frightcrawler can't be blocked except by artifact creatures and/or black creatures.\nThreshold Frightcrawler gets +2/+2 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "a4b4db82-6417-5e3b-94b1-e518e9a925f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2bfa3-0499-43ea-a76d-b12fddbc104e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d2bfa3-0499-43ea-a76d-b12fddbc104e.jpg?1",
             "name": "Ghastly Demise",
             "text": "Destroy target nonblack creature if its toughness is less than or equal to the number of cards in your graveyard.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "cf652576-7db1-5dec-8c82-8b1228c2a622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92e67ef-d1e9-427f-827b-d07e06126821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92e67ef-d1e9-427f-827b-d07e06126821.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "333968d2-e053-53bd-adc5-10ad6dc833a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e273b71-85ca-49d2-ba96-70cc0ae8d718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e273b71-85ca-49d2-ba96-70cc0ae8d718.jpg?1",
             "name": "Gravestorm",
             "text": "At the beginning of your upkeep, target opponent may remove a card in his or her graveyard from the game. If that player doesn't, you may draw a card.",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "bf9da854-10a7-5258-995f-99e3ce85afb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca4c571-48b8-4150-93f8-4cb5c8e797c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca4c571-48b8-4150-93f8-4cb5c8e797c4.jpg?1",
             "name": "Haunting Echoes",
             "text": "Remove all cards in target player's graveyard other than basic land cards from the game. Search that player's library for all cards with the same name as cards removed this way and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -4804,7 +4804,7 @@
         },
         {
             "id": "43cc8983-aab5-5f4a-b6a7-3621bcfc215b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6abaca0-7ce1-4024-adf6-ef6cc0fbcb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6abaca0-7ce1-4024-adf6-ef6cc0fbcb75.jpg?1",
             "name": "Hint of Insanity",
             "text": "Target player reveals his or her hand. That player discards from it all nonland cards with the same name as another card in his or her hand.",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "5c92763c-0c1e-5623-91c9-f614e399f44c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00615487-3526-4b4c-bb06-8f2af1f101d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00615487-3526-4b4c-bb06-8f2af1f101d0.jpg?1",
             "name": "Infected Vermin",
             "text": "o2o\nB: Infected Vermin deals 1 damage to each creature and each player.\nThreshold o3o\nB: Infected Vermin deals 3 damage to each creature and each player. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "47f4de42-e097-5703-8708-2b81ea975ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26af8f6-df64-4027-880c-f2fae2d8103f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d26af8f6-df64-4027-880c-f2fae2d8103f.jpg?1",
             "name": "Innocent Blood",
             "text": "Each player sacrifices a creature.",
             "colours": [
@@ -4902,7 +4902,7 @@
         },
         {
             "id": "e4ad7330-eab8-5ae6-acb6-5931fa036261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b140a36-6686-4781-a432-cb2ef58afa81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b140a36-6686-4781-a432-cb2ef58afa81.jpg?1",
             "name": "Last Rites",
             "text": "Discard any number of cards from your hand. Target player reveals his or her hand, then you choose a nonland card from it for each card discarded this way. That player discards those cards.",
             "colours": [
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "4f548729-fa5e-5bff-9ff2-a32379bdb89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d94052-aae3-4ced-9309-fc4a0d1f159d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d94052-aae3-4ced-9309-fc4a0d1f159d.jpg?1",
             "name": "Malevolent Awakening",
             "text": "o1o\nBo\nB, Sacrifice a creature: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4966,7 +4966,7 @@
         },
         {
             "id": "2fd7bbaf-9eff-5ac3-b6f9-76880f38e7c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07889a1-1582-4f14-8925-fa21a1a5fd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07889a1-1582-4f14-8925-fa21a1a5fd65.jpg?1",
             "name": "Mind Burst",
             "text": "Target player discards X cards from his or her hand, where X is one plus the number of Mind Burst cards in all graveyards.",
             "colours": [
@@ -4998,7 +4998,7 @@
         },
         {
             "id": "1b3b11f2-f787-5f2d-8993-ffc085c9671e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895b1c9b-b1a1-457b-92cd-3469a38b69a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/895b1c9b-b1a1-457b-92cd-3469a38b69a3.jpg?1",
             "name": "Mindslicer",
             "text": "When Mindslicer is put into a graveyard from play, each player discards his or her hand.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "71a6d6cb-5597-5346-9095-3333623bcf6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a4e7d0-ff09-4e19-8456-f4845f56dc8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a4e7d0-ff09-4e19-8456-f4845f56dc8b.jpg?1",
             "name": "Morbid Hunger",
             "text": "Morbid Hunger deals 3 damage to target creature or player. You gain 3 life.\nFlashback o7o\nBo\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5064,7 +5064,7 @@
         },
         {
             "id": "798edf13-56ff-5929-99b1-bd11500fbd11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937465ca-4cf7-4412-86eb-264efb0fdddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937465ca-4cf7-4412-86eb-264efb0fdddd.jpg?1",
             "name": "Morgue Theft",
             "text": "Return target creature card from your graveyard to your hand.\nFlashback o4o\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5096,7 +5096,7 @@
         },
         {
             "id": "f63da01b-42a7-5504-aeb5-ede2ca34e9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc0d499-4a22-4f33-83c7-4e8cdbc3ebe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc0d499-4a22-4f33-83c7-4e8cdbc3ebe6.jpg?1",
             "name": "Mortivore",
             "text": "Mortivore's power and toughness are each equal to the number of creature cards in all graveyards.\no\nB: Regenerate Mortivore.",
             "colours": [
@@ -5130,7 +5130,7 @@
         },
         {
             "id": "120ab790-fdd5-538c-8504-8150be62702c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90f5a4e-8c3a-4803-bb59-d3d7c23761db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90f5a4e-8c3a-4803-bb59-d3d7c23761db.jpg?1",
             "name": "Nefarious Lich",
             "text": "If you would be dealt damage, remove that many cards in your graveyard from the game instead. If you can't, you lose the game.\nIf you would gain life, draw that many cards instead.\nWhen Nefarious Lich leaves play, you lose the game.",
             "colours": [
@@ -5162,7 +5162,7 @@
         },
         {
             "id": "481e6be2-fc07-52ca-b23b-a03cf983e22c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b886292-5937-44ee-bc2a-f316791c91ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b886292-5937-44ee-bc2a-f316791c91ae.jpg?1",
             "name": "Overeager Apprentice",
             "text": "Discard a card from your hand, Sacrifice Overeager Apprentice: Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -5197,7 +5197,7 @@
         },
         {
             "id": "32d68fa0-539f-5853-9083-7cfde93d43d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f993815-af2f-4fa0-8848-979fc8c72d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f993815-af2f-4fa0-8848-979fc8c72d9a.jpg?1",
             "name": "Painbringer",
             "text": "oc\nT, Remove any number of cards in your graveyard from the game: Target creature gets -X/-X until end of turn, where X is the number of cards removed this way.",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "8ba53fd3-b200-549e-be4b-85080b1651e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309bc2e7-bece-493d-b7ab-0e08a9f40909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309bc2e7-bece-493d-b7ab-0e08a9f40909.jpg?1",
             "name": "Patriarch's Desire",
             "text": "Enchanted creature gets +2/-2.\nThreshold Enchanted creature gets an additional +2/-2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -5266,7 +5266,7 @@
         },
         {
             "id": "15503ac8-d34f-5a56-bd9f-61bf66a21a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbad4-1105-4426-8d4d-a30f6fa95ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1dbad4-1105-4426-8d4d-a30f6fa95ce8.jpg?1",
             "name": "Repentant Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Repentant Vampire this turn is put into a graveyard, put a +1/+1 counter on Repentant Vampire.\nThreshold Repentant Vampire is white and has \"oc\nT: Destroy target black creature.\"",
             "colours": [
@@ -5300,7 +5300,7 @@
         },
         {
             "id": "999a111d-88e0-5433-967d-ed46d027aba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2db4b2-6209-4a49-b868-e5d229ffcbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2db4b2-6209-4a49-b868-e5d229ffcbc1.jpg?1",
             "name": "Rotting Giant",
             "text": "Whenever Rotting Giant attacks or blocks, sacrifice it unless you remove a card in your graveyard from the game.",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "c0345c75-c652-5ebf-8d8f-2ff345401b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a6fba0-e5fc-4fa8-9895-8e4b8272bebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a6fba0-e5fc-4fa8-9895-8e4b8272bebe.jpg?1",
             "name": "Sadistic Hypnotist",
             "text": "Sacrifice a creature: Target player discards two cards from his or her hand. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "f632d64b-f88a-5a6e-b53b-ab21e8ba56dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cc53cf-13eb-4028-944d-a670ad30dbca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cc53cf-13eb-4028-944d-a670ad30dbca.jpg?1",
             "name": "Screams of the Damned",
             "text": "o1o\nB, Remove a card in your graveyard from the game: Screams of the Damned deals 1 damage to each creature and each player.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "d0814f61-a4d1-5a18-b654-aeb53a90b742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee49bae4-b53f-4d62-9ba6-6105b0087bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee49bae4-b53f-4d62-9ba6-6105b0087bcf.jpg?1",
             "name": "Skeletal Scrying",
             "text": "As an additional cost to play Skeletal Scrying, remove X cards in your graveyard from the game.\nYou draw X cards and you lose X life.",
             "colours": [
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "75220e2c-4aac-5e03-9d07-5b422b88e2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e3c013-319f-4a77-a55e-11323468b8ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e3c013-319f-4a77-a55e-11323468b8ea.jpg?1",
             "name": "Skull Fracture",
             "text": "Target player discards a card from his or her hand.\nFlashback o3o\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5466,7 +5466,7 @@
         },
         {
             "id": "5a6174a7-51b8-5f3a-8b8a-ec570d9d7cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16705695-1ba8-4169-974f-d8c683ab2652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16705695-1ba8-4169-974f-d8c683ab2652.jpg?1",
             "name": "Stalking Bloodsucker",
             "text": "Flying\no1o\nB, Discard a card from your hand: Stalking Bloodsucker gets +2/+2 until end of turn.",
             "colours": [
@@ -5500,7 +5500,7 @@
         },
         {
             "id": "11aa2a64-049f-553a-8b19-08e2557f94ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c513f51b-a0db-4c08-8acc-1e91060b93b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c513f51b-a0db-4c08-8acc-1e91060b93b7.jpg?1",
             "name": "Tainted Pact",
             "text": "Remove the top card of your library from the game. You may put that card into your hand unless it has the same name as another card removed this way. Repeat this process until you put a card into your hand or you remove two cards with the same name, whichever comes first.",
             "colours": [
@@ -5532,7 +5532,7 @@
         },
         {
             "id": "22908fa2-d733-562e-9415-7907d7405f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb08a4a7-941b-4b54-a89b-a4145a6fc14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb08a4a7-941b-4b54-a89b-a4145a6fc14e.jpg?1",
             "name": "Tombfire",
             "text": "Target player removes all cards with flashback in his or her graveyard from the game.",
             "colours": [
@@ -5564,7 +5564,7 @@
         },
         {
             "id": "c7f55e06-9ef0-54e7-b07f-0396c0aafbcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b6413d-68d3-4097-9bb3-873df4900e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b6413d-68d3-4097-9bb3-873df4900e4c.jpg?1",
             "name": "Traveling Plague",
             "text": "At the beginning of each player's upkeep, put a plague counter on Traveling Plague.\nEnchanted creature gets -1/-1 for each plague counter on Traveling Plague.\nWhen enchanted creature leaves play, that creature's controller returns Traveling Plague from its owner's graveyard to play.",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "b84fbfb1-3b4c-569f-9fcb-4411f1ab48d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbfdc2a-7bf3-4461-bef7-fa499d29d1b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbfdc2a-7bf3-4461-bef7-fa499d29d1b8.jpg?1",
             "name": "Whispering Shade",
             "text": "Swampwalk\no\nB: Whispering Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "457223f6-3d8c-594d-8979-1b8aec32c53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4649311-1300-42fb-ac10-90490756c7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4649311-1300-42fb-ac10-90490756c7aa.jpg?1",
             "name": "Zombie Assassin",
             "text": "oc\nT, Remove two cards in your graveyard and Zombie Assassin from the game: Destroy target nonblack creature. It can't be regenerated.",
             "colours": [
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "9c430939-d16a-553c-9cb1-2eee2ef77349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe73ea4-caa2-41de-a065-272a4d850362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe73ea4-caa2-41de-a065-272a4d850362.jpg?1",
             "name": "Zombie Cannibal",
             "text": "Whenever Zombie Cannibal deals combat damage to a player, you may remove target card in that player's graveyard from the game.",
             "colours": [
@@ -5701,7 +5701,7 @@
         },
         {
             "id": "752665ed-e4ac-5f9f-9392-65dd15628a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd5f98a-7ab5-44b3-850c-b50963dace66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd5f98a-7ab5-44b3-850c-b50963dace66.jpg?1",
             "name": "Zombie Infestation",
             "text": "Discard two cards from your hand: Put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -5733,7 +5733,7 @@
         },
         {
             "id": "e0e5b3e9-49ef-5980-8ca8-def78fb028cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a2a6f-9ae6-42cb-b75f-6b45fc35f36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513a2a6f-9ae6-42cb-b75f-6b45fc35f36e.jpg?1",
             "name": "Zombify",
             "text": "Return target creature card from your graveyard to play.",
             "colours": [
@@ -5765,7 +5765,7 @@
         },
         {
             "id": "9ce08581-c475-5806-9060-d674620fb244",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9082bfb8-0ab0-4378-976d-a2c9d3c35a5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9082bfb8-0ab0-4378-976d-a2c9d3c35a5e.jpg?1",
             "name": "Acceptable Losses",
             "text": "As an additional cost to play Acceptable Losses, discard a card at random from your hand.\nAcceptable Losses deals 5 damage to target creature.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "141f9a3b-cf0b-5566-a0d5-7329c5520ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5514627a-b24c-48c9-9a5a-5a375adcdf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5514627a-b24c-48c9-9a5a-5a375adcdf62.jpg?1",
             "name": "Anarchist",
             "text": "When Anarchist comes into play, you may return target sorcery card from your graveyard to your hand.",
             "colours": [
@@ -5832,7 +5832,7 @@
         },
         {
             "id": "47407006-536e-5aaa-8b1c-ac9a6c4d242f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaef0bd-8288-49ba-a889-d897a4aae64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaef0bd-8288-49ba-a889-d897a4aae64c.jpg?1",
             "name": "Ashen Firebeast",
             "text": "o1o\nR: Ashen Firebeast deals 1 damage to each creature without flying.",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "7f347609-84f8-598a-9aa1-373a329817a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c899f9b-ebce-4424-9cd9-861a50a5f7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c899f9b-ebce-4424-9cd9-861a50a5f7d2.jpg?1",
             "name": "Barbarian Lunatic",
             "text": "o2o\nR, Sacrifice Barbarian Lunatic: Barbarian Lunatic deals 2 damage to target creature.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "196da1b6-79d9-56a2-94b0-d626fa9627c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694b24de-d7f8-49c6-8ab3-d5fab13b6a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694b24de-d7f8-49c6-8ab3-d5fab13b6a8f.jpg?1",
             "name": "Bash to Bits",
             "text": "Destroy target artifact.\nFlashback o4o\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5934,7 +5934,7 @@
         },
         {
             "id": "da16eb40-c814-5949-95e8-54be3e575d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1be893-1287-40a3-81d6-271df3154b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1be893-1287-40a3-81d6-271df3154b45.jpg?1",
             "name": "Battle Strain",
             "text": "Whenever a creature blocks, Battle Strain deals 1 damage to that creature's controller.",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "536505a4-5713-55a7-94f1-f92eb81e1c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d192ef-a174-4df5-b67f-22918c32cf71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d192ef-a174-4df5-b67f-22918c32cf71.jpg?1",
             "name": "Blazing Salvo",
             "text": "Blazing Salvo deals 3 damage to target creature unless that creature's controller has Blazing Salvo deal 5 damage to him or her.",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "2d235403-9978-5873-a21c-cda45772d8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9535a5-29ea-4085-a36b-4905d85e97ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9535a5-29ea-4085-a36b-4905d85e97ac.jpg?1",
             "name": "Bomb Squad",
             "text": "oc\nT: Put a fuse counter on target creature.\nAt the beginning of your upkeep, put a fuse counter on each creature with a fuse counter on it.\nWhenever a creature has four or more fuse counters on it, remove all fuse counters from it and destroy it. That creature deals 4 damage to its controller.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "3fa9a2f4-5114-500c-bf73-c698a6a7d919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5d5eef-6e3c-4907-a277-a13de2916e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a5d5eef-6e3c-4907-a277-a13de2916e2b.jpg?1",
             "name": "Burning Sands",
             "text": "Whenever a creature is put into a graveyard from play, that creature's controller sacrifices a land.",
             "colours": [
@@ -6064,7 +6064,7 @@
         },
         {
             "id": "8cfa2aae-aa8f-5c0d-b736-85bcd5081500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a5bba-a10f-41f6-88cd-cef1dfe4bfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a5bba-a10f-41f6-88cd-cef1dfe4bfa9.jpg?1",
             "name": "Chainflinger",
             "text": "o1o\nR, oc\nT: Chainflinger deals 1 damage to target creature or player.\nThreshold o2o\nR, oc\nT: Chainflinger deals 2 damage to target creature or player. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -6098,7 +6098,7 @@
         },
         {
             "id": "312c95a8-7c86-54f0-9910-aa675d60efd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57817159-de10-4a68-83e1-971fa9cfee2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57817159-de10-4a68-83e1-971fa9cfee2c.jpg?1",
             "name": "Chance Encounter",
             "text": "Whenever you win a coin flip, put a luck counter on Chance Encounter.\nAt the beginning of your upkeep, if Chance Encounter has ten or more luck counters on it, you win the game.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "5dc9f5e5-cc2e-5045-a5eb-5a91dd5a3bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9162a4df-ca6d-4f07-ae48-d333f1cb74b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9162a4df-ca6d-4f07-ae48-d333f1cb74b9.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "5f91bf83-3dfe-5258-b749-f781f2f8c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2f16f9-4980-45e9-99bf-0e00e3008b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2f16f9-4980-45e9-99bf-0e00e3008b1d.jpg?1",
             "name": "Demoralize",
             "text": "Each creature can't be blocked this turn except by two or more creatures.\nThreshold Creatures can't block this turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "6bf08151-4a70-5337-b827-4cb8ee5dc908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f00d726-4289-48ff-8c14-6a5080a00fda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f00d726-4289-48ff-8c14-6a5080a00fda.jpg?1",
             "name": "Dwarven Grunt",
             "text": "Mountainwalk",
             "colours": [
@@ -6228,7 +6228,7 @@
         },
         {
             "id": "4f73102c-d004-5cba-8472-b1404f4435d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a15d274-85b4-4f3c-b502-f6dfe7db4d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a15d274-85b4-4f3c-b502-f6dfe7db4d37.jpg?1",
             "name": "Dwarven Recruiter",
             "text": "When Dwarven Recruiter comes into play, search your library for any number of Dwarf cards and reveal those cards. Shuffle your library, then put them on top of it in any order.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "d8cee50f-304a-5ecc-a61d-f37e54022ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85197997-5e1a-46ce-8f0d-6da5ce297baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85197997-5e1a-46ce-8f0d-6da5ce297baf.jpg?1",
             "name": "Dwarven Shrine",
             "text": "Whenever a player plays a spell, Dwarven Shrine deals X damage to that player, where X is twice the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "916c723a-ee2e-51f8-b19e-c598c70f5414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bc3d85-5ba1-4f2e-a676-be989bdb04f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bc3d85-5ba1-4f2e-a676-be989bdb04f7.jpg?1",
             "name": "Dwarven Strike Force",
             "text": "Discard a card at random from your hand: Dwarven Strike Force gains first strike and haste until end of turn.",
             "colours": [
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "65235541-9fe5-51a1-8b31-237926ca9e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e10742-77c9-4f91-81b2-37b2ac910f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e10742-77c9-4f91-81b2-37b2ac910f09.jpg?1",
             "name": "Earth Rift",
             "text": "Destroy target land.\nFlashback o5o\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -6361,7 +6361,7 @@
         },
         {
             "id": "d4817371-883b-5be2-a455-6f839ae6fe64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25080720-612f-40c0-8894-cda8e3e8afb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25080720-612f-40c0-8894-cda8e3e8afb8.jpg?1",
             "name": "Ember Beast",
             "text": "Ember Beast can't attack or block alone.",
             "colours": [
@@ -6395,7 +6395,7 @@
         },
         {
             "id": "99a44c94-6c46-562f-b91f-e79dedc8b653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a92ac-0788-4238-a2ed-1ebd3dd0dd88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a92ac-0788-4238-a2ed-1ebd3dd0dd88.jpg?1",
             "name": "Engulfing Flames",
             "text": "Engulfing Flames deals 1 damage to target creature. It can't be regenerated this turn.\nFlashback o3o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -6427,7 +6427,7 @@
         },
         {
             "id": "2725213e-5436-5204-96b0-0472cf5327b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9232ae-9f32-4bbc-a020-554b3f9cbbd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9232ae-9f32-4bbc-a020-554b3f9cbbd3.jpg?1",
             "name": "Epicenter",
             "text": "Target player sacrifices a land.\nThreshold All players sacrifice all lands instead. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -6459,7 +6459,7 @@
         },
         {
             "id": "4c157fa0-47c6-5025-bccb-b0c43b1ffa9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e45005-dd81-4d80-b043-02f719aca929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e45005-dd81-4d80-b043-02f719aca929.jpg?1",
             "name": "Firebolt",
             "text": "Firebolt deals 2 damage to target creature or player.\nFlashback o4o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -6491,7 +6491,7 @@
         },
         {
             "id": "f42cc081-85bd-5be6-b531-605c9c57b1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bbd438-7df2-4d7b-88ad-4531ebaf3931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64bbd438-7df2-4d7b-88ad-4531ebaf3931.jpg?1",
             "name": "Flame Burst",
             "text": "Flame Burst deals X damage to target creature or player, where X is 2 plus the number of Flame Burst cards in all graveyards.",
             "colours": [
@@ -6523,7 +6523,7 @@
         },
         {
             "id": "af2b1baf-34fb-53c0-a9c0-89e7a8688366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc939cc-826a-4208-ba5b-a11e1cd47aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc939cc-826a-4208-ba5b-a11e1cd47aa2.jpg?1",
             "name": "Frenetic Ogre",
             "text": "o\nR, Discard a card at random from your hand: Frenetic Ogre gets +3/+0 until end of turn.",
             "colours": [
@@ -6557,7 +6557,7 @@
         },
         {
             "id": "2a630cd5-7f6e-5c4c-a26e-71e7708d496e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69dfc05-51ba-4798-ac00-1e9b8bbbf280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69dfc05-51ba-4798-ac00-1e9b8bbbf280.jpg?1",
             "name": "Halberdier",
             "text": "First strike",
             "colours": [
@@ -6592,7 +6592,7 @@
         },
         {
             "id": "8ded884f-5a1b-5d4a-9332-228514777263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b404c0-9ce1-4491-82fd-6dba7e6895cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b404c0-9ce1-4491-82fd-6dba7e6895cd.jpg?1",
             "name": "Impulsive Maneuvers",
             "text": "Whenever a creature attacks, flip a coin. If you win the flip, the next time that creature would deal combat damage this turn, it deals double that damage instead. If you lose the flip, the next time that creature would deal combat damage this turn, prevent that damage.",
             "colours": [
@@ -6624,7 +6624,7 @@
         },
         {
             "id": "f091278e-f518-50e3-a739-cf3cad23a04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee88c776-85f1-4beb-a814-f706f5c4f341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee88c776-85f1-4beb-a814-f706f5c4f341.jpg?1",
             "name": "Kamahl, Pit Fighter",
             "text": "Haste\noc\nT: Kamahl, Pit Fighter deals 3 damage to target creature or player.",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "6e3d1127-cf89-5b58-b576-a34e14992675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99e1ded-7440-40a6-846b-7450a9b7d2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99e1ded-7440-40a6-846b-7450a9b7d2a8.jpg?1",
             "name": "Kamahl's Desire",
             "text": "Enchanted creature has first strike.\nThreshold Enchanted creature gets +3/+0. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -6695,7 +6695,7 @@
         },
         {
             "id": "14ffaaa5-7b92-57f3-9a89-1da8fbe62ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e53-2710-4c2a-a8e4-48f25375ebc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0e9e53-2710-4c2a-a8e4-48f25375ebc7.jpg?1",
             "name": "Lava Blister",
             "text": "Destroy target nonbasic land unless its controller has Lava Blister deal 6 damage to him or her.",
             "colours": [
@@ -6727,7 +6727,7 @@
         },
         {
             "id": "c0d2e4d6-ae30-5a3a-9646-1058e0369e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b836d4c-38f3-4661-9dc7-0c9baaa595a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b836d4c-38f3-4661-9dc7-0c9baaa595a5.jpg?1",
             "name": "Liquid Fire",
             "text": "Liquid Fire deals 5 damage divided as you choose between target creature and that creature's controller.",
             "colours": [
@@ -6759,7 +6759,7 @@
         },
         {
             "id": "b1c3bb94-6c09-534f-b688-c95a1eb2de13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be2da24-a0cd-4e90-bc29-4da649fa56bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be2da24-a0cd-4e90-bc29-4da649fa56bf.jpg?1",
             "name": "Mad Dog",
             "text": "At the end of your turn, if Mad Dog didn't attack or come under your control this turn, sacrifice it.",
             "colours": [
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "364ce09c-83fa-5c19-a54d-3b826a46a1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ed2b52-2862-423c-8ce3-6c8232d9d92c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ed2b52-2862-423c-8ce3-6c8232d9d92c.jpg?1",
             "name": "Magma Vein",
             "text": "o\nR, Sacrifice a land: Magma Vein deals 1 damage to each creature without flying.",
             "colours": [
@@ -6825,7 +6825,7 @@
         },
         {
             "id": "0b84d151-a550-5fec-a0bd-0e98c4c5177a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200fa50d-5a54-47eb-a123-29c4fb55ebee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200fa50d-5a54-47eb-a123-29c4fb55ebee.jpg?1",
             "name": "Magnivore",
             "text": "Haste\nMagnivore's power and toughness are each equal to the number of sorcery cards in all graveyards.",
             "colours": [
@@ -6859,7 +6859,7 @@
         },
         {
             "id": "66c421cf-6636-5685-a3a4-7c444791a450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497efda1-5013-45d2-b717-b0296218c42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497efda1-5013-45d2-b717-b0296218c42b.jpg?1",
             "name": "Mine Layer",
             "text": "o1o\nR, oc\nT: Put a mine counter on target land.\nWhenever a land with a mine counter on it becomes tapped, destroy it.\nWhen Mine Layer leaves play, remove all mine counters from all lands.",
             "colours": [
@@ -6893,7 +6893,7 @@
         },
         {
             "id": "a22fb48e-492f-5d97-b35a-a45af078c55c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55725e38-d60a-41a2-93b0-2eefe6d2cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55725e38-d60a-41a2-93b0-2eefe6d2cc59.jpg?1",
             "name": "Minotaur Explorer",
             "text": "When Minotaur Explorer comes into play, sacrifice it unless you discard a card at random from your hand.",
             "colours": [
@@ -6928,7 +6928,7 @@
         },
         {
             "id": "a18ef66f-2fe8-50d1-af48-7a9187ca2072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2b326b-d177-4a03-a0a3-fe2c2d4af272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c2b326b-d177-4a03-a0a3-fe2c2d4af272.jpg?1",
             "name": "Molten Influence",
             "text": "Counter target instant or sorcery spell unless its controller has Molten Influence deal 4 damage to him or her.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "b6dfae53-7f60-5ccb-8728-7ec75d7cede0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d31bc-7355-4dfc-ac4e-ababaa0dc529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993d31bc-7355-4dfc-ac4e-ababaa0dc529.jpg?1",
             "name": "Mudhole",
             "text": "Target player removes all land cards in his or her graveyard from the game.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "f63823fc-166f-5607-8c31-e01101526336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407b02f-66b3-4cfa-a3c4-105f314fd037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8407b02f-66b3-4cfa-a3c4-105f314fd037.jpg?1",
             "name": "Need for Speed",
             "text": "Sacrifice a land: Target creature gains haste until end of turn.",
             "colours": [
@@ -7024,7 +7024,7 @@
         },
         {
             "id": "6f7beea2-5e1a-5b20-be3d-8329fd084fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88468a76-1f64-4189-bbb8-7c333181d57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88468a76-1f64-4189-bbb8-7c333181d57c.jpg?1",
             "name": "Obstinate Familiar",
             "text": "If you would draw a card, you may skip that draw instead.",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "468247f2-12aa-56fb-9144-9a6127ab9120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16858395-c742-4657-88c2-5af20c92718d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16858395-c742-4657-88c2-5af20c92718d.jpg?1",
             "name": "Pardic Firecat",
             "text": "Haste\nIf Pardic Firecat is in a graveyard, Flame Burst's effect counts it as a Flame Burst.",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "4112ce7a-0f5a-5fa2-8022-e462b3a6fbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a734abe-7bfd-4153-be2d-1c289fb60996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a734abe-7bfd-4153-be2d-1c289fb60996.jpg?1",
             "name": "Pardic Miner",
             "text": "Sacrifice Pardic Miner: Target player can't play lands this turn.",
             "colours": [
@@ -7127,7 +7127,7 @@
         },
         {
             "id": "f3f99503-9970-5485-ac53-2561d2b06841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ac622c-db04-41bf-817e-4698843e6346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ac622c-db04-41bf-817e-4698843e6346.jpg?1",
             "name": "Pardic Swordsmith",
             "text": "o\nR, Discard a card at random from your hand: Pardic Swordsmith gets +2/+0 until end of turn.",
             "colours": [
@@ -7161,7 +7161,7 @@
         },
         {
             "id": "7cd3718e-aa6d-5b05-bfb0-5daa32a760c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785ccfe1-04f1-4d2e-9e30-2ae3efe7213a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785ccfe1-04f1-4d2e-9e30-2ae3efe7213a.jpg?1",
             "name": "Price of Glory",
             "text": "Whenever a player taps a land for mana during another player's turn, destroy that land.",
             "colours": [
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "76942ada-7d7c-5f7d-aa3c-6cfe1e7396cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0938e686-345e-4411-b564-cf9324ec6b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0938e686-345e-4411-b564-cf9324ec6b9d.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback o2o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7225,7 +7225,7 @@
         },
         {
             "id": "97d7ef86-8e2d-521b-acef-5f51032eadcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431145f8-64e9-4e7d-998a-21fe55f49e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431145f8-64e9-4e7d-998a-21fe55f49e01.jpg?1",
             "name": "Recoup",
             "text": "Target sorcery card in your graveyard gains flashback until end of turn. Its flashback cost is equal to its mana cost. (Mana cost includes color.)\nFlashback o3o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "922b680c-bc26-534e-84ed-0d190255c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2fc246-2e95-456f-aa4e-97768c4f4bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2fc246-2e95-456f-aa4e-97768c4f4bb4.jpg?1",
             "name": "Rites of Initiation",
             "text": "Discard any number of cards at random from your hand. Creatures you control get +1/+0 until end of turn for each card discarded this way.",
             "colours": [
@@ -7289,7 +7289,7 @@
         },
         {
             "id": "48fcb400-0290-5532-9368-bce0aefcf790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e14dbe-4d33-405c-ab84-2fc6b1e000b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e14dbe-4d33-405c-ab84-2fc6b1e000b8.jpg?1",
             "name": "Savage Firecat",
             "text": "Trample\nSavage Firecat comes into play with seven +1/+1 counters on it.\nWhenever you tap a land for mana, remove a +1/+1 counter from Savage Firecat.",
             "colours": [
@@ -7324,7 +7324,7 @@
         },
         {
             "id": "ec623ebf-5716-56b4-839e-654949f55167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0672960b-4cb5-4ed6-ba3c-6b97290e0330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0672960b-4cb5-4ed6-ba3c-6b97290e0330.jpg?1",
             "name": "Scorching Missile",
             "text": "Scorching Missile deals 4 damage to target player.\nFlashback o9o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7356,7 +7356,7 @@
         },
         {
             "id": "dedee1af-77b4-5bb8-b74d-cc5b1daeef08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d03ec3-2279-4266-a3bd-4cebdcb04d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d03ec3-2279-4266-a3bd-4cebdcb04d70.jpg?1",
             "name": "Seize the Day",
             "text": "Untap target creature. After this phase, there is an additional combat phase followed by an additional main phase.\nFlashback o2o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7388,7 +7388,7 @@
         },
         {
             "id": "632a974f-991d-530a-9aae-893632f48dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e623a8-145e-4649-b2cc-d3bb8a93f0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e623a8-145e-4649-b2cc-d3bb8a93f0f3.jpg?1",
             "name": "Shower of Coals",
             "text": "Shower of Coals deals 2 damage to each of up to three target creatures and/or players.\nThreshold Shower of Coals deals 4 damage to each of those creatures and/or players instead. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "b2ee872c-eb4c-56f3-b212-463797ba7012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5902e-2ca1-43bb-b636-c860b3d0b3f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff5902e-2ca1-43bb-b636-c860b3d0b3f2.jpg?1",
             "name": "Spark Mage",
             "text": "Whenever Spark Mage deals combat damage to a player, you may have Spark Mage deal 1 damage to target creature that player controls.",
             "colours": [
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "47a4d337-2aa8-54f3-90ce-86909393c4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3936053-b2ed-49b8-ab69-fe47a972cfe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3936053-b2ed-49b8-ab69-fe47a972cfe4.jpg?1",
             "name": "Steam Vines",
             "text": "When enchanted land becomes tapped, destroy it and Steam Vines deals 1 damage to that land's controller. That player moves Steam Vines to a land of his or her choice.",
             "colours": [
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "cd6327ff-a1a7-5c21-a71d-7703431abb18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623cc141-0f75-4e67-b852-6c144d98e619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623cc141-0f75-4e67-b852-6c144d98e619.jpg?1",
             "name": "Thermal Blast",
             "text": "Thermal Blast deals 3 damage to target creature.\nThreshold Thermal Blast deals 5 damage to that creature instead. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "4a4fae1a-4cd6-5129-98fa-96b0e5758910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1dc36f-3fdd-42cf-9d3a-695f4bf60c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1dc36f-3fdd-42cf-9d3a-695f4bf60c68.jpg?1",
             "name": "Tremble",
             "text": "Each player sacrifices a land.",
             "colours": [
@@ -7553,7 +7553,7 @@
         },
         {
             "id": "2a8647c7-b5fa-5bb4-b9cf-fa42dbad137c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97daab4b-d934-4a3f-a043-f7c9c1dd32bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97daab4b-d934-4a3f-a043-f7c9c1dd32bf.jpg?1",
             "name": "Volcanic Spray",
             "text": "Volcanic Spray deals 1 damage to each creature without flying and each player.\nFlashback o1o\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "b0414922-1dd7-5884-9094-432be5515c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f663979-a778-4fb2-97c4-67ab82926f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f663979-a778-4fb2-97c4-67ab82926f13.jpg?1",
             "name": "Volley of Boulders",
             "text": "Volley of Boulders deals 6 damage divided as you choose among any number of target creatures and/or players.\nFlashback o\nRo\nRo\nRo\nRo\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7617,7 +7617,7 @@
         },
         {
             "id": "80c54a92-8a68-5520-bb74-13969e509224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d86db25-3ec1-42f3-8b02-2729d50dd201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d86db25-3ec1-42f3-8b02-2729d50dd201.jpg?1",
             "name": "Whipkeeper",
             "text": "oc\nT: Whipkeeper deals damage to target creature equal to the damage already dealt to it this turn.",
             "colours": [
@@ -7651,7 +7651,7 @@
         },
         {
             "id": "ca2428e9-eb3c-5b57-88e0-b1d80c0264bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3284b61a-bd95-4846-ad3f-903cd1158867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3284b61a-bd95-4846-ad3f-903cd1158867.jpg?1",
             "name": "Bearscape",
             "text": "o1o\nG, Remove two cards in your graveyard from the game: Put a 2/2 green Bear creature token into play.",
             "colours": [
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "99b8f924-4cdc-5b63-83f8-98d736187b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5ebe27-2083-400e-8943-b506be470e3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5ebe27-2083-400e-8943-b506be470e3f.jpg?1",
             "name": "Beast Attack",
             "text": "Put a 4/4 green Beast creature token into play.\nFlashback o2o\nGo\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "55a8844a-e8d4-5e0e-be6c-109900735660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429a88cc-53db-4c5e-a061-f0f49a38c675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429a88cc-53db-4c5e-a061-f0f49a38c675.jpg?1",
             "name": "Call of the Herd",
             "text": "Put a 3/3 green Elephant creature token into play.\nFlashback o3o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7747,7 +7747,7 @@
         },
         {
             "id": "ba0ab9e6-f36c-5d35-aa1d-14b4dddb132c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8241680d-6453-44ac-ab0f-3e7ebdd31e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8241680d-6453-44ac-ab0f-3e7ebdd31e89.jpg?1",
             "name": "Cartographer",
             "text": "When Cartographer comes into play, you may return target land card from your graveyard to your hand.",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "571bbd3a-2e8b-5216-81b0-efa4dfd1a7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84273844-7fab-4ff7-afb3-c82153132daf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84273844-7fab-4ff7-afb3-c82153132daf.jpg?1",
             "name": "Chatter of the Squirrel",
             "text": "Put a 1/1 green Squirrel creature token into play.\nFlashback o1o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "9869abbe-a26c-547e-a0d4-7a0786d98657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd0ea3-4134-4f7d-a0c8-01c49bacfcfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4fd0ea3-4134-4f7d-a0c8-01c49bacfcfc.jpg?1",
             "name": "Chlorophant",
             "text": "At the beginning of your upkeep, you may put a +1/+1 counter on Chlorophant.\nThreshold At the beginning of your upkeep, you may put another +1/+1 counter on Chlorophant. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "ce5ff27d-af4d-5369-a326-e29f297f962c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3a32a-bfd2-4c31-a349-3e62a84c20e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f3a32a-bfd2-4c31-a349-3e62a84c20e1.jpg?1",
             "name": "Crashing Centaur",
             "text": "o\nG, Discard a card from your hand: Crashing Centaur gains trample until end of turn.\nThreshold Crashing Centaur gets +2/+2 and can't be the target of spells or abilities. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "a11ef53b-86bb-539b-afef-924979ebbc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148ce683-3911-4b77-9e07-3985766a3777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148ce683-3911-4b77-9e07-3985766a3777.jpg?1",
             "name": "Deep Reconnaissance",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.\nFlashback o4o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "31f3a2ce-b440-56ac-bbc0-aae315886026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb40e09-6855-46d5-9bc9-bc6b2b0d7653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb40e09-6855-46d5-9bc9-bc6b2b0d7653.jpg?1",
             "name": "Diligent Farmhand",
             "text": "o1o\nG, Sacrifice Diligent Farmhand: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.\nIf Diligent Farmhand is in a graveyard, Muscle Burst's effect counts it as a Muscle Burst.",
             "colours": [
@@ -7948,7 +7948,7 @@
         },
         {
             "id": "08fb7c3d-f9a1-56b9-811d-beb2093ab700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9923532-bc4f-44de-b963-d6914321c49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9923532-bc4f-44de-b963-d6914321c49a.jpg?1",
             "name": "Druid Lyrist",
             "text": "o\nG, oc\nT, Sacrifice Druid Lyrist: Destroy target enchantment.",
             "colours": [
@@ -7983,7 +7983,7 @@
         },
         {
             "id": "f31c402a-3197-56f2-af2c-a47e2b2697ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22318a5-80c8-4fa3-ad05-8d3035caf336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22318a5-80c8-4fa3-ad05-8d3035caf336.jpg?1",
             "name": "Druid's Call",
             "text": "Whenever enchanted creature is dealt damage, its controller puts that many 1/1 green Squirrel creature tokens into play.",
             "colours": [
@@ -8017,7 +8017,7 @@
         },
         {
             "id": "055ed5b2-e0b5-5427-bea5-e10a7c07351c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4abdf1c-a0a9-4e1d-b448-58742830f767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4abdf1c-a0a9-4e1d-b448-58742830f767.jpg?1",
             "name": "Elephant Ambush",
             "text": "Put a 3/3 green Elephant creature token into play.\nFlashback o6o\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "b799efe7-c454-5709-86e2-af4ade2f90cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435d9562-8f2b-43fe-ba21-8f5896378280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435d9562-8f2b-43fe-ba21-8f5896378280.jpg?1",
             "name": "Gorilla Titan",
             "text": "Trample\nGorilla Titan gets +4/+4 as long as there are no cards in your graveyard.",
             "colours": [
@@ -8083,7 +8083,7 @@
         },
         {
             "id": "289032ec-6347-5598-856b-841ea6e99a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977383a8-9a31-4aad-ace2-6ed4d0dd1cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977383a8-9a31-4aad-ace2-6ed4d0dd1cbe.jpg?1",
             "name": "Ground Seal",
             "text": "When Ground Seal comes into play, draw a card.\nCards in graveyards can't be the targets of spells or abilities.",
             "colours": [
@@ -8115,7 +8115,7 @@
         },
         {
             "id": "2f8fc613-7a04-5779-ad94-242fec7364ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2134a564-b089-4049-bd9c-a3f10e072263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2134a564-b089-4049-bd9c-a3f10e072263.jpg?1",
             "name": "Holistic Wisdom",
             "text": "o2, Remove a card in your hand from the game: Return target card from your graveyard to your hand if it shares a type with the card removed this way. (The card types are artifact, creature, enchantment, instant, land, and sorcery.)",
             "colours": [
@@ -8147,7 +8147,7 @@
         },
         {
             "id": "f0a739c9-335c-55e5-897c-fd242a39696e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9917cf32-0236-4463-9b1d-e8193754ff97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9917cf32-0236-4463-9b1d-e8193754ff97.jpg?1",
             "name": "Howling Gale",
             "text": "Howling Gale deals 1 damage to each creature with flying and each player.\nFlashback o1o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "6bc84134-5c93-5100-baf8-cdb0108a65be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc441d3a-e917-4dd6-b5f9-f99075ec398f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc441d3a-e917-4dd6-b5f9-f99075ec398f.jpg?1",
             "name": "Ivy Elemental",
             "text": "Ivy Elemental comes into play with X +1/+1 counters on it.",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "a3e69a1f-82ec-5401-81cc-c53cc496534b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188562f-8219-4fb0-ac2c-5618cfb00bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e188562f-8219-4fb0-ac2c-5618cfb00bca.jpg?1",
             "name": "Krosan Archer",
             "text": "Krosan Archer may block as though it had flying.\no\nG, Discard a card from your hand: Krosan Archer gets +0/+2 until end of turn.",
             "colours": [
@@ -8248,7 +8248,7 @@
         },
         {
             "id": "ca92b122-217d-5fcb-8519-7940dfbd68e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afd6911-32b5-410a-afb0-fd3d2996fe59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afd6911-32b5-410a-afb0-fd3d2996fe59.jpg?1",
             "name": "Krosan Avenger",
             "text": "Trample\nThreshold o1o\nG: Regenerate Krosan Avenger. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "c6d72557-d06a-52b9-acee-3710eea67d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af822507-fd4c-454b-ab07-106c81c535bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af822507-fd4c-454b-ab07-106c81c535bf.jpg?1",
             "name": "Krosan Beast",
             "text": "Threshold Krosan Beast gets +7/+7. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8318,7 +8318,7 @@
         },
         {
             "id": "ea88b5fe-af45-5445-99ab-d24be839fe7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebab65c-7d5f-4086-8eb1-7dc445e801e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebab65c-7d5f-4086-8eb1-7dc445e801e9.jpg?1",
             "name": "Leaf Dancer",
             "text": "Forestwalk",
             "colours": [
@@ -8352,7 +8352,7 @@
         },
         {
             "id": "d74c5ae7-38f0-5218-8c58-3f8a831dedc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e020a-ed73-465a-b7eb-a4eeccd096cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47e020a-ed73-465a-b7eb-a4eeccd096cc.jpg?1",
             "name": "Metamorphic Wurm",
             "text": "Threshold Metamorphic Wurm gets +4/+4. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8387,7 +8387,7 @@
         },
         {
             "id": "c94cb550-35ec-5021-a341-cd6e4379cae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ebe935-ccf9-435e-8fe8-53bcbf3526e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ebe935-ccf9-435e-8fe8-53bcbf3526e7.jpg?1",
             "name": "Moment's Peace",
             "text": "Prevent all combat damage that would be dealt this turn.\nFlashback o2o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "2a3e4267-9bc9-5f55-a7a7-18fe68e09581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dada5-7ffc-488b-8062-34c034906ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217dada5-7ffc-488b-8062-34c034906ea9.jpg?1",
             "name": "Muscle Burst",
             "text": "Target creature gets +X/+X until end of turn, where X is 3 plus the number of Muscle Burst cards in all graveyards.",
             "colours": [
@@ -8451,7 +8451,7 @@
         },
         {
             "id": "5d1edc02-e92d-57d1-a700-9ff2277424ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5db5e0-bd95-4c82-a12d-7288dbbbe3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5db5e0-bd95-4c82-a12d-7288dbbbe3ba.jpg?1",
             "name": "Nantuko Disciple",
             "text": "o\nG, oc\nT: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "88decf22-3cd0-52d4-acf3-92628b48e56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0a4e6e-cc4e-43d5-aece-f009e117366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c0a4e6e-cc4e-43d5-aece-f009e117366a.jpg?1",
             "name": "Nantuko Elder",
             "text": "oc\nT: Add o1o\nG to your mana pool.",
             "colours": [
@@ -8521,7 +8521,7 @@
         },
         {
             "id": "4245e4e3-60d4-574a-a8ac-6b0633ead32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb5283-d384-490e-a0a5-2d10c1acc8cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48cb5283-d384-490e-a0a5-2d10c1acc8cc.jpg?1",
             "name": "Nantuko Mentor",
             "text": "o2o\nG, oc\nT: Target creature gets +X/+X until end of turn, where X is that creature's power.",
             "colours": [
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "76c0da19-d841-5821-9ff7-367188241f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66bab3-ee6f-4f74-bbc1-8099c9c4904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b66bab3-ee6f-4f74-bbc1-8099c9c4904b.jpg?1",
             "name": "Nantuko Shrine",
             "text": "Whenever a player plays a spell, that player puts X 1/1 green Squirrel creature tokens into play, where X is the number of cards in all graveyards with the same name as that spell.",
             "colours": [
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "562c33ed-7b3a-579e-b57b-405ed85fbe1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1f6cfa-9576-4bb8-83db-33c2b147206d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1f6cfa-9576-4bb8-83db-33c2b147206d.jpg?1",
             "name": "New Frontiers",
             "text": "Each player may search his or her library for up to X basic land cards and put them into play tapped. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -8620,7 +8620,7 @@
         },
         {
             "id": "90540949-3c8f-5853-b0c2-279bf9f3227a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e5ecf5-a662-4df0-a6ba-9177c62b6503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e5ecf5-a662-4df0-a6ba-9177c62b6503.jpg?1",
             "name": "Nimble Mongoose",
             "text": "Nimble Mongoose can't be the target of spells or abilities.\nThreshold Nimble Mongoose gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8654,7 +8654,7 @@
         },
         {
             "id": "1055e72a-a1b9-5ec9-bd8c-74c89671c135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4eec210-5df0-4fb8-8eb1-e616d9995acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4eec210-5df0-4fb8-8eb1-e616d9995acc.jpg?1",
             "name": "Nut Collector",
             "text": "At the beginning of your upkeep, you may put a 1/1 green Squirrel creature token into play.\nThreshold All Squirrels get +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8689,7 +8689,7 @@
         },
         {
             "id": "0c523e70-5067-57a1-969b-8d505cbd6fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9df13-3bd8-415d-b949-9b39f97fdde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f9df13-3bd8-415d-b949-9b39f97fdde7.jpg?1",
             "name": "Overrun",
             "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "65819b0e-b90b-5b4e-86a4-3d35b9c8d65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642ea1f9-49f0-4e0d-8122-c3a305c149e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642ea1f9-49f0-4e0d-8122-c3a305c149e9.jpg?1",
             "name": "Piper's Melody",
             "text": "Shuffle any number of target creature cards from your graveyard into your library.",
             "colours": [
@@ -8753,7 +8753,7 @@
         },
         {
             "id": "6533632e-c475-5c09-a871-e516752d4b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2d822-09d0-42e5-ad91-67c66e947b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e2d822-09d0-42e5-ad91-67c66e947b3d.jpg?1",
             "name": "Primal Frenzy",
             "text": "Enchanted creature has trample.",
             "colours": [
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "07c366c8-dfa1-58f0-b631-fb6c90ef9bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe394a38-ee44-4342-adcf-8c65d14f4978.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe394a38-ee44-4342-adcf-8c65d14f4978.jpg?1",
             "name": "Rabid Elephant",
             "text": "Whenever Rabid Elephant becomes blocked, it gets +2/+2 until end of turn for each creature blocking it.",
             "colours": [
@@ -8821,7 +8821,7 @@
         },
         {
             "id": "247f60e4-a060-5ebf-945b-a5c0330a3003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0084ba4e-98eb-4eb4-b23e-c5ab4d7d95cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0084ba4e-98eb-4eb4-b23e-c5ab4d7d95cb.jpg?1",
             "name": "Refresh",
             "text": "Regenerate target creature.\nDraw a card.",
             "colours": [
@@ -8853,7 +8853,7 @@
         },
         {
             "id": "c888da26-7b07-5bd8-9b16-7a8dcb1b1414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bddb0ef-fdda-491b-a0cf-48cbdd761918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bddb0ef-fdda-491b-a0cf-48cbdd761918.jpg?1",
             "name": "Rites of Spring",
             "text": "Discard any number of cards from your hand. Search your library for that many basic land cards, reveal those cards, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -8885,7 +8885,7 @@
         },
         {
             "id": "8b5b5f0a-1dd9-5103-b8d8-63fc9f05d5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf54317-4c08-4a66-9fd2-9983384e2374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf54317-4c08-4a66-9fd2-9983384e2374.jpg?1",
             "name": "Roar of the Wurm",
             "text": "Put a 6/6 green Wurm creature token into play.\nFlashback o3o\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8917,7 +8917,7 @@
         },
         {
             "id": "7ba5bac3-2929-5e7a-8535-6539646d3f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641a3bae-9146-4e70-862a-86a56f7c3816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641a3bae-9146-4e70-862a-86a56f7c3816.jpg?1",
             "name": "Seton, Krosan Protector",
             "text": "Tap an untapped Druid you control: Add o\nG to your mana pool.",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "5691768a-929e-54ba-95e7-aea047f45ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d05b6a-5c7e-4e08-88d3-98f2b5b054bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d05b6a-5c7e-4e08-88d3-98f2b5b054bc.jpg?1",
             "name": "Seton's Desire",
             "text": "Enchanted creature gets +2/+2.\nThreshold All creatures able to block enchanted creature do so. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -8988,7 +8988,7 @@
         },
         {
             "id": "6673e904-b3b1-5618-8ac7-74181d34e1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a43fd3e-1e08-400c-b22b-e22da82bcdee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a43fd3e-1e08-400c-b22b-e22da82bcdee.jpg?1",
             "name": "Simplify",
             "text": "Each player sacrifices an enchantment.",
             "colours": [
@@ -9020,7 +9020,7 @@
         },
         {
             "id": "50188273-d9e7-55aa-a1a0-8bbe27ed878f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56f195e-a80c-4447-8d3f-cc1259035d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f56f195e-a80c-4447-8d3f-cc1259035d1b.jpg?1",
             "name": "Skyshooter",
             "text": "Skyshooter may block as though it had flying.\noc\nT, Sacrifice Skyshooter: Destroy target attacking or blocking creature with flying.",
             "colours": [
@@ -9055,7 +9055,7 @@
         },
         {
             "id": "b038c139-e60f-5e4c-99fd-ce0c579ad5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72194a6e-481d-4b07-922b-53f919bfa316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72194a6e-481d-4b07-922b-53f919bfa316.jpg?1",
             "name": "Spellbane Centaur",
             "text": "Creatures you control can't be the targets of blue spells or abilities from blue sources.",
             "colours": [
@@ -9089,7 +9089,7 @@
         },
         {
             "id": "012f4333-6134-54b0-b761-abecb4ec0842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04462629-fb03-40e8-84e6-4a66e4d5392b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04462629-fb03-40e8-84e6-4a66e4d5392b.jpg?1",
             "name": "Springing Tiger",
             "text": "Threshold Springing Tiger gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9123,7 +9123,7 @@
         },
         {
             "id": "f0179755-517a-5efc-9542-d1ac320f953b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181254ce-259a-4b31-8937-728564f2baf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181254ce-259a-4b31-8937-728564f2baf3.jpg?1",
             "name": "Squirrel Mob",
             "text": "Squirrel Mob gets +1/+1 for each other Squirrel in play.",
             "colours": [
@@ -9157,7 +9157,7 @@
         },
         {
             "id": "e20fbce9-da38-50cf-8bbb-0e36188bb723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eccb27-1723-4c5a-96b8-85e6e5739c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22eccb27-1723-4c5a-96b8-85e6e5739c30.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchanted land has \"oc\nT: Put a 1/1 green Squirrel creature token into play.\"",
             "colours": [
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "76d989f7-0487-5304-8195-23b670002ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12be33d7-f25e-4dbf-9706-74403103b127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12be33d7-f25e-4dbf-9706-74403103b127.jpg?1",
             "name": "Still Life",
             "text": "o\nGo\nG: Still Life becomes a 4/3 Centaur creature until end of turn. It's still an enchantment.",
             "colours": [
@@ -9223,7 +9223,7 @@
         },
         {
             "id": "2a382909-9789-586d-9495-160f78d66e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d5157-154c-4300-82d4-0e23d934d436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d5157-154c-4300-82d4-0e23d934d436.jpg?1",
             "name": "Stone-Tongue Basilisk",
             "text": "Whenever Stone-Tongue Basilisk deals combat damage to a creature, destroy that creature at end of combat.\nThreshold All creatures able to block Stone-Tongue Basilisk do so. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9257,7 +9257,7 @@
         },
         {
             "id": "38a45bcb-ee74-5edd-8739-0ff510eeb510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e3ccd-40a3-4ea9-8e76-5e70b2ef9123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576e3ccd-40a3-4ea9-8e76-5e70b2ef9123.jpg?1",
             "name": "Sylvan Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.\nFlashback o2o\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "9f3291a5-8115-5144-b662-41e4e4199441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39c412b-2f21-483a-b744-5d55bc007c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39c412b-2f21-483a-b744-5d55bc007c0d.jpg?1",
             "name": "Terravore",
             "text": "Trample\nTerravore's power and toughness are each equal to the number of land cards in all graveyards.",
             "colours": [
@@ -9323,7 +9323,7 @@
         },
         {
             "id": "535195f7-02cc-5f36-9ab6-6106845f0636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b8ba27-c3bb-48cf-b831-518f5d255c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b8ba27-c3bb-48cf-b831-518f5d255c2e.jpg?1",
             "name": "Twigwalker",
             "text": "o1o\nG, Sacrifice Twigwalker: Two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "5e4cb7d2-e4cf-527b-8fa4-17c7f1f685b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3c78de-0c2a-441e-8912-ff920fc563ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3c78de-0c2a-441e-8912-ff920fc563ef.jpg?1",
             "name": "Verdant Succession",
             "text": "Whenever a green nontoken creature is put into a graveyard from play, that creature's controller may search his or her library for a card with the same name as that creature and put it into play. If that player does, he or she then shuffles his or her library.",
             "colours": [
@@ -9389,7 +9389,7 @@
         },
         {
             "id": "54ec622d-07a2-5d97-ab08-61b86f7d60d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b5e7ed-a0ab-48f6-8f69-56a8bd115007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b5e7ed-a0ab-48f6-8f69-56a8bd115007.jpg?1",
             "name": "Vivify",
             "text": "Target land becomes a 3/3 creature until end of turn. It's still a land.\nDraw a card.",
             "colours": [
@@ -9421,7 +9421,7 @@
         },
         {
             "id": "533fea94-9804-5445-8500-ee62e1e06111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964cf7e3-932d-432f-8ad4-9bd651aada96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/964cf7e3-932d-432f-8ad4-9bd651aada96.jpg?1",
             "name": "Werebear",
             "text": "oc\nT: Add o\nG to your mana pool.\nThreshold Werebear gets +3/+3. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "5fbb4293-b8a9-54eb-a168-74f4f5b47c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb8dd5c-a79a-4afc-80b2-64645bb17a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb8dd5c-a79a-4afc-80b2-64645bb17a34.jpg?1",
             "name": "Wild Mongrel",
             "text": "Discard a card from your hand: Wild Mongrel gets +1/+1 and becomes the color of your choice until end of turn.",
             "colours": [
@@ -9491,7 +9491,7 @@
         },
         {
             "id": "cfb43ded-c561-52cd-a332-96bed8b4fdff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e501e6-38da-44ad-abe2-53ea7f0eb4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e501e6-38da-44ad-abe2-53ea7f0eb4ae.jpg?1",
             "name": "Woodland Druid",
             "text": "",
             "colours": [
@@ -9526,7 +9526,7 @@
         },
         {
             "id": "4ff061a2-43d7-5e52-bf38-1f7ef2a1286f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be645675-d263-42c4-9e71-f98cf4c2aab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be645675-d263-42c4-9e71-f98cf4c2aab5.jpg?1",
             "name": "Zoologist",
             "text": "o3o\nG, oc\nT: Reveal the top card of your library. If it's a creature card, put it into play. Otherwise, put it into your graveyard.",
             "colours": [
@@ -9561,7 +9561,7 @@
         },
         {
             "id": "7173fffd-c862-527a-83c3-85a104902b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3e6eb5-6d0f-4f82-86f9-bbce8d27afbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3e6eb5-6d0f-4f82-86f9-bbce8d27afbb.jpg?1",
             "name": "Atogatog",
             "text": "Sacrifice an Atog: Atogatog gets +X/+X until end of turn, where X is the sacrificed Atog's power.",
             "colours": [
@@ -9605,7 +9605,7 @@
         },
         {
             "id": "c7c09497-42b5-52fe-b633-a244feff325c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912c398a-e49a-4399-ac41-7b1d4328a59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912c398a-e49a-4399-ac41-7b1d4328a59d.jpg?1",
             "name": "Decimate",
             "text": "Destroy target artifact, target creature, target enchantment, and target land.",
             "colours": [
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "dc22c77e-935d-542b-8bbe-7af8662c13b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bce4f8-3a3f-4ec2-9b37-10bb12713afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3bce4f8-3a3f-4ec2-9b37-10bb12713afc.jpg?1",
             "name": "Iridescent Angel",
             "text": "Flying, protection from all colors",
             "colours": [
@@ -9675,7 +9675,7 @@
         },
         {
             "id": "4ec7b667-62dd-5c0f-a312-4e24b4d5afe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69742a8-cc6d-457b-8d99-81d05ab1bf0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c69742a8-cc6d-457b-8d99-81d05ab1bf0b.jpg?1",
             "name": "Lithatog",
             "text": "Sacrifice an artifact: Lithatog gets +1/+1 until end of turn.\nSacrifice a land: Lithatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9711,7 +9711,7 @@
         },
         {
             "id": "98f746f8-3be5-52b0-be7d-7afa9fdbfc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb68983d-fd8c-4844-8ceb-afd3cae7e4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb68983d-fd8c-4844-8ceb-afd3cae7e4df.jpg?1",
             "name": "Mystic Enforcer",
             "text": "Protection from black\nThreshold Mystic Enforcer gets +3/+3 and has flying. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -9749,7 +9749,7 @@
         },
         {
             "id": "24b7f7ee-c7dc-50e6-b07a-632b44da11b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967608d-141d-426f-a129-6f1a6a58273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967608d-141d-426f-a129-6f1a6a58273c.jpg?1",
             "name": "Phantatog",
             "text": "Sacrifice an enchantment: Phantatog gets +1/+1 until end of turn.\nDiscard a card from your hand: Phantatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9785,7 +9785,7 @@
         },
         {
             "id": "5e4d0c59-adee-546b-abed-6a3e42787daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6757bf0e-489f-4be2-9e41-463b59f00dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6757bf0e-489f-4be2-9e41-463b59f00dd1.jpg?1",
             "name": "Psychatog",
             "text": "Discard a card from your hand: Psychatog gets +1/+1 until end of turn.\nRemove two cards in your graveyard from the game: Psychatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "9c9c00da-1f14-56bf-b45b-a88f7d17821d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a329c-e815-49d3-8df1-d052ce19b0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a329c-e815-49d3-8df1-d052ce19b0c6.jpg?1",
             "name": "Sarcatog",
             "text": "Remove two cards in your graveyard from the game: Sarcatog gets +1/+1 until end of turn.\nSacrifice an artifact: Sarcatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9857,7 +9857,7 @@
         },
         {
             "id": "0b25ba97-22ab-59e8-b357-6df465ff634a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932ce702-565f-4d8c-b9fc-2d7c939ef7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/932ce702-565f-4d8c-b9fc-2d7c939ef7d7.jpg?1",
             "name": "Shadowmage Infiltrator",
             "text": "Shadowmage Infiltrator can't be blocked except by artifact creatures and/or black creatures.\nWhenever Shadowmage Infiltrator deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -9894,7 +9894,7 @@
         },
         {
             "id": "971e0be0-faf7-5111-b019-4bddd95bc7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa559342-9587-4fe3-9059-3b3a08d6637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa559342-9587-4fe3-9059-3b3a08d6637a.jpg?1",
             "name": "Thaumatog",
             "text": "Sacrifice a land: Thaumatog gets +1/+1 until end of turn.\nSacrifice an enchantment: Thaumatog gets +1/+1 until end of turn.",
             "colours": [
@@ -9930,7 +9930,7 @@
         },
         {
             "id": "7aa2061f-669e-5a7d-b482-4159ef910c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f21d595-c248-4aae-9fd7-4e5787ab8781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f21d595-c248-4aae-9fd7-4e5787ab8781.jpg?1",
             "name": "Vampiric Dragon",
             "text": "Flying\nWhenever a creature dealt damage by Vampiric Dragon this turn is put into a graveyard, put a +1/+1 counter on Vampiric Dragon.\no1o\nR: Vampiric Dragon deals 1 damage to target creature.",
             "colours": [
@@ -9967,7 +9967,7 @@
         },
         {
             "id": "01517c3a-ddc8-561a-9439-6ea0fdd17c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca85d4-b4c2-4adc-a0f9-26339bacfd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaca85d4-b4c2-4adc-a0f9-26339bacfd92.jpg?1",
             "name": "Catalyst Stone",
             "text": "Flashback costs you pay cost up to o2 less.\nFlashback costs your opponents pay cost o2 more.",
             "colours": [],
@@ -9995,7 +9995,7 @@
         },
         {
             "id": "c67ec222-5601-51b2-a709-a586118fa827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701942dd-7777-436f-8076-194584be8285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701942dd-7777-436f-8076-194584be8285.jpg?1",
             "name": "Charmed Pendant",
             "text": "oc\nT, Put the top card of your library into your graveyard: For each colored mana symbol in that card's mana cost, add one mana of that color to your mana pool. Play this ability only any time you could play an instant. (For example, if the card's mana cost is o3o\nUo\nUo\nB, you add o\nUo\nUo\nB to your mana pool.)",
             "colours": [],
@@ -10023,7 +10023,7 @@
         },
         {
             "id": "098ea01f-87b0-529c-8e95-36f90872175f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb988572-1e1d-4b1d-8dc7-78bda966554e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb988572-1e1d-4b1d-8dc7-78bda966554e.jpg?1",
             "name": "Darkwater Egg",
             "text": "o2, oc\nT, Sacrifice Darkwater Egg: Add o\nUo\nB to your mana pool. Draw a card.",
             "colours": [],
@@ -10054,7 +10054,7 @@
         },
         {
             "id": "da2eb80f-db47-5a52-8fba-8da6ea2732b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9410da0-5693-456f-afa8-cb92ac176847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9410da0-5693-456f-afa8-cb92ac176847.jpg?1",
             "name": "Junk Golem",
             "text": "Junk Golem comes into play with three +1/+1 counters on it.\nAt the beginning of your upkeep, sacrifice Junk Golem unless you remove a +1/+1 counter from it.\no1, Discard a card from your hand: Put a +1/+1 counter on Junk Golem.",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "612d05ca-d77c-56f7-87df-3a6df23d6d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522518c-1846-4e95-b77d-2aadac78684d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522518c-1846-4e95-b77d-2aadac78684d.jpg?1",
             "name": "Limestone Golem",
             "text": "o2, Sacrifice Limestone Golem: Target player draws a card.",
             "colours": [],
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "e7e2408d-6d8a-59d3-808c-0ce1e16c6b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550133b-22cf-4ecd-b89a-8c2f0beeaa22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0550133b-22cf-4ecd-b89a-8c2f0beeaa22.jpg?1",
             "name": "Millikin",
             "text": "oc\nT, Put the top card of your library into your graveyard: Add one colorless mana to your mana pool.",
             "colours": [],
@@ -10147,7 +10147,7 @@
         },
         {
             "id": "ea9c0761-fe9b-5336-a584-efeff32e14c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbaad4f-fb66-4e56-b383-32f55552c8b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbaad4f-fb66-4e56-b383-32f55552c8b2.jpg?1",
             "name": "Mirari",
             "text": "Whenever you play an instant or sorcery spell, you may pay o3. If you do, put a copy of that spell onto the stack. You may choose new targets for that copy.",
             "colours": [],
@@ -10177,7 +10177,7 @@
         },
         {
             "id": "33f05ce8-a101-59d5-b441-c7bdba441e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd66433-b0e9-453d-9a27-ea0efb158dac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd66433-b0e9-453d-9a27-ea0efb158dac.jpg?1",
             "name": "Mossfire Egg",
             "text": "o2, oc\nT, Sacrifice Mossfire Egg: Add o\nRo\nG to your mana pool. Draw a card.",
             "colours": [],
@@ -10208,7 +10208,7 @@
         },
         {
             "id": "4c06e03a-9302-587d-9534-cc73a023bd10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752420dc-d69a-4c9d-b563-f8928a4a0920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752420dc-d69a-4c9d-b563-f8928a4a0920.jpg?1",
             "name": "Otarian Juggernaut",
             "text": "Otarian Juggernaut can't be blocked by Walls.\nThreshold Otarian Juggernaut gets +3/+0 and attacks each turn if able. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10239,7 +10239,7 @@
         },
         {
             "id": "c8ed8e0a-7a27-571e-9eb6-86220b5abd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8958d5-e4a9-42ee-ae82-d184c4b92c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8958d5-e4a9-42ee-ae82-d184c4b92c9d.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Discard a card from your hand: Regenerate Patchwork Gnomes.",
             "colours": [],
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "4626ef6a-bf7d-5604-9384-1f69648c21a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ebc17-b8ae-4ca4-8413-f53501d86244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ebc17-b8ae-4ca4-8413-f53501d86244.jpg?1",
             "name": "Sandstone Deadfall",
             "text": "oc\nT, Sacrifice two lands and Sandstone Deadfall: Destroy target attacking creature.",
             "colours": [],
@@ -10298,7 +10298,7 @@
         },
         {
             "id": "38e803f9-b925-5125-92b1-719ced16760c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044bbf15-e71d-4f47-bac3-bba8021118bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044bbf15-e71d-4f47-bac3-bba8021118bd.jpg?1",
             "name": "Shadowblood Egg",
             "text": "o2, oc\nT, Sacrifice Shadowblood Egg: Add o\nBo\nR to your mana pool. Draw a card.",
             "colours": [],
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "aedf172b-273d-5342-b09d-000aaff0625e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e588cc41-4b86-4e93-94e8-dd765b27ab63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e588cc41-4b86-4e93-94e8-dd765b27ab63.jpg?1",
             "name": "Skycloud Egg",
             "text": "o2, oc\nT, Sacrifice Skycloud Egg: Add o\nWo\nU to your mana pool. Draw a card.",
             "colours": [],
@@ -10360,7 +10360,7 @@
         },
         {
             "id": "dfbd6a51-7ce1-5cf6-8c0e-db58726422ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f84a9bf-ce64-4301-8f2c-20f1b4acd3ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f84a9bf-ce64-4301-8f2c-20f1b4acd3ef.jpg?1",
             "name": "Steamclaw",
             "text": "o3, oc\nT: Remove target card in a graveyard from the game.\no1, Sacrifice Steamclaw: Remove target card in a graveyard from the game.",
             "colours": [],
@@ -10388,7 +10388,7 @@
         },
         {
             "id": "18d6f03c-6510-59ae-b9c8-f2b97c89bffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e888f9-c583-478a-9ef0-2e89db8a8dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e888f9-c583-478a-9ef0-2e89db8a8dbb.jpg?1",
             "name": "Sungrass Egg",
             "text": "o2, oc\nT, Sacrifice Sungrass Egg: Add o\nGo\nW to your mana pool. Draw a card.",
             "colours": [],
@@ -10419,7 +10419,7 @@
         },
         {
             "id": "e30b3771-fba9-5093-a088-b9b849bf47a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4945031e-1158-474c-9e50-1ec817acc767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4945031e-1158-474c-9e50-1ec817acc767.jpg?1",
             "name": "Abandoned Outpost",
             "text": "Abandoned Outpost comes into play tapped.\noc\nT: Add o\nW to your mana pool.\noc\nT, Sacrifice Abandoned Outpost: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10449,7 +10449,7 @@
         },
         {
             "id": "554f90f6-71f7-53df-87fc-6133cbaece7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1809361e-ae1a-4c47-8464-e6496e94d962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1809361e-ae1a-4c47-8464-e6496e94d962.jpg?1",
             "name": "Barbarian Ring",
             "text": "oc\nT: Add o\nR to your mana pool. Barbarian Ring deals 1 damage to you.\nThreshold o\nR, oc\nT, Sacrifice Barbarian Ring: Barbarian Ring deals 2 damage to target creature or player. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10479,7 +10479,7 @@
         },
         {
             "id": "46a96f08-ddb3-5e4f-8d56-ab7e0c324019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189b4925-b34b-43bd-869e-1b1db99450e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189b4925-b34b-43bd-869e-1b1db99450e6.jpg?1",
             "name": "Bog Wreckage",
             "text": "Bog Wreckage comes into play tapped.\noc\nT: Add o\nB to your mana pool.\noc\nT, Sacrifice Bog Wreckage: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10509,7 +10509,7 @@
         },
         {
             "id": "fe6ef7f8-875a-5486-9775-eba61fa75fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848d686a-e2f7-488d-947f-a555099b74b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848d686a-e2f7-488d-947f-a555099b74b1.jpg?1",
             "name": "Cabal Pit",
             "text": "oc\nT: Add o\nB to your mana pool. Cabal Pit deals 1 damage to you.\nThreshold o\nB, oc\nT, Sacrifice Cabal Pit: Target creature gets -2/-2 until end of turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "21dc7e05-5365-58f3-8cdd-6071e9dd2aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca041d5e-c65f-4e7e-ae4f-9c748a069aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca041d5e-c65f-4e7e-ae4f-9c748a069aa3.jpg?1",
             "name": "Centaur Garden",
             "text": "oc\nT: Add o\nG to your mana pool. Centaur Garden deals 1 damage to you.\nThreshold o\nG, oc\nT, Sacrifice Centaur Garden: Target creature gets +3/+3 until end of turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10569,7 +10569,7 @@
         },
         {
             "id": "99f58f00-acb6-5778-bf39-8837d5ea5c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d74112-7244-4c3f-a5eb-b6be671aefe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d74112-7244-4c3f-a5eb-b6be671aefe8.jpg?1",
             "name": "Cephalid Coliseum",
             "text": "oc\nT: Add o\nU to your mana pool. Cephalid Coliseum deals 1 damage to you.\nThreshold o\nU, oc\nT, Sacrifice Cephalid Coliseum: Target player draws three cards, then discards three cards from his or her hand. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10599,7 +10599,7 @@
         },
         {
             "id": "094f7ca6-af94-5d2d-9953-50abe8970a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1012124a-5401-4bd1-a163-4633d934938f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1012124a-5401-4bd1-a163-4633d934938f.jpg?1",
             "name": "Crystal Quarry",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no5, oc\nT: Add o\nWo\nUo\nBo\nRo\nG to your mana pool.",
             "colours": [],
@@ -10633,7 +10633,7 @@
         },
         {
             "id": "0e6ea663-0840-5553-84de-d94c70c451d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2583b941-6156-4c4b-a068-0d0ac75a3dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2583b941-6156-4c4b-a068-0d0ac75a3dd3.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "o1, oc\nT: Add o\nUo\nB to your mana pool.",
             "colours": [],
@@ -10664,7 +10664,7 @@
         },
         {
             "id": "16fd0db1-c8f0-5208-a489-d84a96215c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fa74b2-f9bd-4617-8b65-878781f3a2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fa74b2-f9bd-4617-8b65-878781f3a2fd.jpg?1",
             "name": "Deserted Temple",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1, oc\nT: Untap target land.",
             "colours": [],
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "4abf77f3-009c-5f7a-8047-83d43e8e4670",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6c08ce-d01d-4ae6-81d3-149679e27e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b6c08ce-d01d-4ae6-81d3-149679e27e6a.jpg?1",
             "name": "Mossfire Valley",
             "text": "o1, oc\nT: Add o\nRo\nG to your mana pool.",
             "colours": [],
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "333d5d2a-6631-506d-9a5c-72792f4b81ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64300b71-050f-47a3-83be-f24480bdc01d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64300b71-050f-47a3-83be-f24480bdc01d.jpg?1",
             "name": "Nomad Stadium",
             "text": "oc\nT: Add o\nW to your mana pool. Nomad Stadium deals 1 damage to you.\nThreshold o\nW, oc\nT, Sacrifice Nomad Stadium: You gain 4 life. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [],
@@ -10753,7 +10753,7 @@
         },
         {
             "id": "058a5384-b67f-5016-8a2c-c32925f1e9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeaf9f2-d196-4607-a704-06f2315d8cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaeaf9f2-d196-4607-a704-06f2315d8cc5.jpg?1",
             "name": "Petrified Field",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Petrified Field: Return target land card from your graveyard to your hand.",
             "colours": [],
@@ -10781,7 +10781,7 @@
         },
         {
             "id": "f36b7d82-5534-5c27-83fd-5906cc42999c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb60ffc9-4919-40f2-bdd6-07eee6abf37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb60ffc9-4919-40f2-bdd6-07eee6abf37c.jpg?1",
             "name": "Ravaged Highlands",
             "text": "Ravaged Highlands comes into play tapped.\noc\nT: Add o\nR to your mana pool.\noc\nT, Sacrifice Ravaged Highlands: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10811,7 +10811,7 @@
         },
         {
             "id": "eb4d8ed3-5240-525d-a393-46a83fb16a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e492399-d514-485a-8cdd-a3797a05e47a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e492399-d514-485a-8cdd-a3797a05e47a.jpg?1",
             "name": "Seafloor Debris",
             "text": "Seafloor Debris comes into play tapped.\noc\nT: Add o\nU to your mana pool.\noc\nT, Sacrifice Seafloor Debris: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10843,7 +10843,7 @@
         },
         {
             "id": "adfc7385-b0ae-501f-84ed-467aef5e9cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb5977c-5009-4d97-82c8-c150a0d41bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb5977c-5009-4d97-82c8-c150a0d41bc3.jpg?1",
             "name": "Seafloor Debris",
             "text": "",
             "colours": [],
@@ -10874,7 +10874,7 @@
         },
         {
             "id": "56e30965-7a9d-50e9-ad4e-1ee9ef840166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a5f84a-9e9b-42b6-a973-864409d6e564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69a5f84a-9e9b-42b6-a973-864409d6e564.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "o1, oc\nT: Add o\nBo\nR to your mana pool.",
             "colours": [],
@@ -10905,7 +10905,7 @@
         },
         {
             "id": "64291673-fd96-5f3b-8af7-c177ac9acb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c0da61-59c5-4206-83d9-c4676e169f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8c0da61-59c5-4206-83d9-c4676e169f01.jpg?1",
             "name": "Skycloud Expanse",
             "text": "o1, oc\nT: Add o\nWo\nU to your mana pool.",
             "colours": [],
@@ -10936,7 +10936,7 @@
         },
         {
             "id": "681f7234-2403-5019-9b68-e7449cb25018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfa27ee-553e-4c6e-a79c-9757bd74c057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfa27ee-553e-4c6e-a79c-9757bd74c057.jpg?1",
             "name": "Sungrass Prairie",
             "text": "o1, oc\nT: Add o\nGo\nW to your mana pool.",
             "colours": [],
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "123d82bb-28a4-5a13-a029-441b38ce4797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30375d24-ccfe-47a2-babd-1bda0a6298fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30375d24-ccfe-47a2-babd-1bda0a6298fe.jpg?1",
             "name": "Tarnished Citadel",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add one mana of any color to your mana pool. Tarnished Citadel deals 3 damage to you.",
             "colours": [],
@@ -10995,7 +10995,7 @@
         },
         {
             "id": "3370b874-17ed-5cec-be38-2f34ece17152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e8770-c72b-439c-8f79-3aa24646cdd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2e8770-c72b-439c-8f79-3aa24646cdd5.jpg?1",
             "name": "Timberland Ruins",
             "text": "Timberland Ruins comes into play tapped.\noc\nT: Add o\nG to your mana pool.\noc\nT, Sacrifice Timberland Ruins: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -11025,7 +11025,7 @@
         },
         {
             "id": "fd317690-4a6c-5f37-97c5-fb09f179c633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecfb420-ace3-4627-a2e0-62a701d025c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecfb420-ace3-4627-a2e0-62a701d025c9.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11063,7 +11063,7 @@
         },
         {
             "id": "6a8967bf-84be-5b14-ad31-6a5dc0efb375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014efd6a-5b0c-41d1-b7de-78eab5b62917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014efd6a-5b0c-41d1-b7de-78eab5b62917.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11101,7 +11101,7 @@
         },
         {
             "id": "65b210e3-b8b7-54a4-b7cd-715641e42d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b0dd0f-8ad8-4292-9df6-7b28ab4605e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b0dd0f-8ad8-4292-9df6-7b28ab4605e3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11139,7 +11139,7 @@
         },
         {
             "id": "aa8730c2-7377-5ed3-9853-05fd4c96cbd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee52bef-0586-46b8-a405-f4e0741f0059.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee52bef-0586-46b8-a405-f4e0741f0059.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "d1558fc2-b254-5cbb-a408-7dd5c97acf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527f36a0-80b8-4492-b1c3-20a34953ceb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/527f36a0-80b8-4492-b1c3-20a34953ceb7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11215,7 +11215,7 @@
         },
         {
             "id": "fe2f4ad4-65b3-5084-8f53-162d88c8433c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef57bbe1-8507-4284-8d08-6b10b7894f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef57bbe1-8507-4284-8d08-6b10b7894f96.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "b8ee0208-27dd-54d3-b25f-3d6d351a6d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30bfc3-5aec-480d-a80a-fe71b098b14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30bfc3-5aec-480d-a80a-fe71b098b14b.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11291,7 +11291,7 @@
         },
         {
             "id": "4705c2be-4aac-500a-9a40-83bc96b987a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf964c1b-941f-4a02-895b-0608bddc1ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf964c1b-941f-4a02-895b-0608bddc1ce7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11329,7 +11329,7 @@
         },
         {
             "id": "80cfa786-570f-5474-b7df-e36c03e17016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b18fb-66cb-4dc0-9c67-60cee1502c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b18fb-66cb-4dc0-9c67-60cee1502c7f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11367,7 +11367,7 @@
         },
         {
             "id": "57d2884c-53b0-55fd-8368-f84f02ec50fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907ff242-885f-4948-b95c-61cf033d0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907ff242-885f-4948-b95c-61cf033d0969.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11405,7 +11405,7 @@
         },
         {
             "id": "8d2bbb73-4606-5c32-8382-3a7c2876adc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a9736-da37-4327-b9ee-e9a38fbe8a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4a9736-da37-4327-b9ee-e9a38fbe8a19.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11443,7 +11443,7 @@
         },
         {
             "id": "6b8970fa-2bb9-58f7-ba13-ffc177a914c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f74cd0-cd73-4b08-8544-5f56b6d96f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f74cd0-cd73-4b08-8544-5f56b6d96f78.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11481,7 +11481,7 @@
         },
         {
             "id": "a261ddfd-a8c5-549e-b6de-01e6b369afc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c22765e-a131-4be6-ba48-64b84564ea51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c22765e-a131-4be6-ba48-64b84564ea51.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11519,7 +11519,7 @@
         },
         {
             "id": "9077748b-110a-591e-8eae-39e13611124f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e88b41-7ae5-40fc-8947-5f5aa03388be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e88b41-7ae5-40fc-8947-5f5aa03388be.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11557,7 +11557,7 @@
         },
         {
             "id": "8cc27cb6-5b69-5f8b-83c5-a7251417e67c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025e57e4-d088-4ad9-b872-cba327f63e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/025e57e4-d088-4ad9-b872-cba327f63e9c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11595,7 +11595,7 @@
         },
         {
             "id": "af13132c-589d-5b1d-a9d9-ed862d925efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b396f90-92b1-4cc0-9be8-2f724b39fbc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b396f90-92b1-4cc0-9be8-2f724b39fbc6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "9161b799-9fa2-5501-b856-cf0e20dc6c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73029d4b-f073-4df0-a6cc-8014284a1ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73029d4b-f073-4df0-a6cc-8014284a1ced.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11671,7 +11671,7 @@
         },
         {
             "id": "eb08181a-9298-5851-999f-2b36795705a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9397010b-6116-4612-993a-11ec2a5d3115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9397010b-6116-4612-993a-11ec2a5d3115.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "b8656f2e-3dff-57a0-87a6-8e4d2eefe7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b15ea-80b9-48df-b010-aa1aabcf51ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b15ea-80b9-48df-b010-aa1aabcf51ea.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11747,7 +11747,7 @@
         },
         {
             "id": "c0597e8c-3015-52de-8d3b-af6f4bd41595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e8080f-9e4a-4fad-9ea3-09d5e0e1c816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e8080f-9e4a-4fad-9ea3-09d5e0e1c816.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/OGW.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/OGW.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "1b85404d-d965-5418-92cd-627280d66ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a416d54b-ac84-48ac-92f8-eeb348f26016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a416d54b-ac84-48ac-92f8-eeb348f26016.jpg?1",
             "name": "Deceiver of Form",
             "text": "({C} represents colorless mana.)\nAt the beginning of combat on your turn, reveal the top card of your library. If a creature card is revealed this way, you may have creatures you control other than Deceiver of Form become copies of that card until end of turn. You may put that card on the bottom of your library.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "476df97e-3333-5c64-9ac7-137001914598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a05b1-042d-47e7-9fd7-6e8abe8fc578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a05b1-042d-47e7-9fd7-6e8abe8fc578.jpg?1",
             "name": "Eldrazi Mimic",
             "text": "Whenever another colorless creature enters the battlefield under your control, you may change Eldrazi Mimic's base power and toughness to that creature's power and toughness until end of turn.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "41f5a87f-713a-52e1-8ac3-66e8020fc35c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bba7509-db77-414f-926f-1f28a4117831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bba7509-db77-414f-926f-1f28a4117831.jpg?1",
             "name": "Endbringer",
             "text": "Untap Endbringer during each other player's untap step.\n{T}: Endbringer deals 1 damage to target creature or player.\n{C}, {T}: Target creature can't attack or block this turn.\n{C}{C}, {T}: Draw a card.",
             "colours": [],
@@ -94,7 +94,7 @@
         },
         {
             "id": "bbe86a57-53bf-5430-b7f4-d018d48984ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06fc6e0-b22c-40d3-bb53-d5ec400d921c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06fc6e0-b22c-40d3-bb53-d5ec400d921c.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "When you cast Kozilek, the Great Distortion, if you have fewer than seven cards in hand, draw cards equal to the difference.\nMenace\nDiscard a card with converted mana cost X: Counter target spell with converted mana cost X.",
             "colours": [],
@@ -126,7 +126,7 @@
         },
         {
             "id": "89c962b0-8156-5bba-96b5-707a9a6150f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75585bd-fdd8-44d1-8c7c-b96df5fc473e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75585bd-fdd8-44d1-8c7c-b96df5fc473e.jpg?1",
             "name": "Kozilek's Pathfinder",
             "text": "{C}: Target creature can't block Kozilek's Pathfinder this turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -156,7 +156,7 @@
         },
         {
             "id": "ed297c15-c849-51c8-8fb8-2ec4780e0a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906b61a-3865-4dfd-ae06-a7d2a608851a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906b61a-3865-4dfd-ae06-a7d2a608851a.jpg?1",
             "name": "Matter Reshaper",
             "text": "({C} represents colorless mana.)\nWhen Matter Reshaper dies, reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with converted mana cost 3 or less. Otherwise, put that card into your hand.",
             "colours": [],
@@ -186,7 +186,7 @@
         },
         {
             "id": "43ffa08b-254d-5616-a75e-6836f5f69517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d4b652-a830-4fd4-94bb-c17c227f2928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d4b652-a830-4fd4-94bb-c17c227f2928.jpg?1",
             "name": "Reality Smasher",
             "text": "({C} represents colorless mana.)\nTrample, haste\nWhenever Reality Smasher becomes the target of a spell an opponent controls, counter that spell unless its controller discards a card.",
             "colours": [],
@@ -216,7 +216,7 @@
         },
         {
             "id": "a173dd20-23f2-5732-ba93-f8f97e757b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2acf70-7625-4b77-83c1-0e08436da31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2acf70-7625-4b77-83c1-0e08436da31f.jpg?1",
             "name": "Spatial Contortion",
             "text": "({C} represents colorless mana.)\nTarget creature gets +3/-3 until end of turn.",
             "colours": [],
@@ -244,7 +244,7 @@
         },
         {
             "id": "8c19de75-def2-5330-954a-5e58877ec842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg?1",
             "name": "Thought-Knot Seer",
             "text": "({C} represents colorless mana.)\nWhen Thought-Knot Seer enters the battlefield, target opponent reveals his or her hand. You choose a nonland card from it and exile that card.\nWhen Thought-Knot Seer leaves the battlefield, target opponent draws a card.",
             "colours": [],
@@ -274,7 +274,7 @@
         },
         {
             "id": "46ec5404-767e-5d68-ba27-f038c0eee90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f635ac-ad6d-4a13-a08e-64c8e2b9779c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f635ac-ad6d-4a13-a08e-64c8e2b9779c.jpg?1",
             "name": "Walker of the Wastes",
             "text": "({C} represents colorless mana.)\nTrample\nWalker of the Wastes gets +1/+1 for each land you control named Wastes.",
             "colours": [],
@@ -304,7 +304,7 @@
         },
         {
             "id": "fdca781d-a310-5b58-a486-58127c534c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f517b9-ac10-4710-8ef1-ced1253d5ecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f517b9-ac10-4710-8ef1-ced1253d5ecf.jpg?1",
             "name": "Warden of Geometries",
             "text": "Vigilance\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)",
             "colours": [],
@@ -335,7 +335,7 @@
         },
         {
             "id": "5530f939-0952-5c42-afcd-e5d319e6ebe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ef4db8-b51c-4f52-84f1-6fee31c4a14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ef4db8-b51c-4f52-84f1-6fee31c4a14c.jpg?1",
             "name": "Warping Wail",
             "text": "({C} represents colorless mana.)\nChoose one \u2014\n\u2022 Exile target creature with power or toughness 1 or less.\n\u2022 Counter target sorcery spell.\n\u2022 Put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\"",
             "colours": [],
@@ -363,7 +363,7 @@
         },
         {
             "id": "34e86fb7-c504-5a5f-946b-145b6799bafb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb1a5c-0f59-4951-827f-fe9df968232d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bb1a5c-0f59-4951-827f-fe9df968232d.jpg?1",
             "name": "Eldrazi Displacer",
             "text": "Devoid (This card has no color.)\n{2}{C}: Exile another target creature, then return it to the battlefield tapped under its owner's control. ({C} represents colorless mana.)",
             "colours": [],
@@ -395,7 +395,7 @@
         },
         {
             "id": "3f560736-ae97-569d-8166-16bb7fa74ce7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e54ac79-fbaa-4385-869b-aaf31e33a11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e54ac79-fbaa-4385-869b-aaf31e33a11f.jpg?1",
             "name": "Affa Protector",
             "text": "Vigilance",
             "colours": [
@@ -431,7 +431,7 @@
         },
         {
             "id": "60574abb-95b8-5032-8018-34c02d665212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7d7c93-5622-45ca-9359-110685d9162c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7d7c93-5622-45ca-9359-110685d9162c.jpg?1",
             "name": "Allied Reinforcements",
             "text": "Put two 2/2 white Knight Ally creature tokens onto the battlefield.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "b8fb5227-1d45-5a78-912b-f64a6d38e125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4719ac60-2cff-4abb-b9cc-b677d3ac945c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4719ac60-2cff-4abb-b9cc-b677d3ac945c.jpg?1",
             "name": "Call the Gatewatch",
             "text": "Search your library for a planeswalker card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "93ee2eea-cc93-549d-89cb-eeff59b4a1ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77977e8-25d8-4531-a6fc-8c46e6904670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77977e8-25d8-4531-a6fc-8c46e6904670.jpg?1",
             "name": "Dazzling Reflection",
             "text": "You gain life equal to target creature's power. The next time that creature would deal damage this turn, prevent that damage.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "70b5b4f5-33fd-5566-a96a-bb51a8328a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d11eb-960b-4116-ba09-f03bff88b4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/819d11eb-960b-4116-ba09-f03bff88b4e7.jpg?1",
             "name": "Expedition Raptor",
             "text": "Flying\nWhen Expedition Raptor enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "1d60cd12-194c-5001-a7fe-4003954bdd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e9aa86-1a31-4c0f-928d-923f066286b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e9aa86-1a31-4c0f-928d-923f066286b6.jpg?1",
             "name": "General Tazri",
             "text": "When General Tazri enters the battlefield, you may search your library for an Ally creature card, reveal it, put it into your hand, then shuffle your library.\n{W}{U}{B}{R}{G}: Ally creatures you control get +X/+X until end of turn, where X is the number of colors among those creatures.",
             "colours": [
@@ -602,7 +602,7 @@
         },
         {
             "id": "3b3ec5fc-1d59-5376-918b-749148cd8910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f468338-bb66-4db0-a883-69095566092b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f468338-bb66-4db0-a883-69095566092b.jpg?1",
             "name": "Immolating Glare",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "d626b04b-8cd6-53ae-bcb3-42357ae8f169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30f26f7-5181-4bf1-9084-5563b4996a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30f26f7-5181-4bf1-9084-5563b4996a3c.jpg?1",
             "name": "Iona's Blessing",
             "text": "Enchant creature\nEnchanted creature gets +2/+2, has vigilance, and can block an additional creature.",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "0636d2f5-dc98-528d-a9e3-9ffdc5b2912c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca698e3-1249-4a08-be04-bae3bd944e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ca698e3-1249-4a08-be04-bae3bd944e99.jpg?1",
             "name": "Isolation Zone",
             "text": "When Isolation Zone enters the battlefield, exile target creature or enchantment an opponent controls until Isolation Zone leaves the battlefield. (That permanent returns under its owner's control.)",
             "colours": [
@@ -700,7 +700,7 @@
         },
         {
             "id": "80292929-1645-5795-a592-5dc2665c4ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce587ba-f23a-4548-a5b8-fca54984d4b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce587ba-f23a-4548-a5b8-fca54984d4b4.jpg?1",
             "name": "Kor Scythemaster",
             "text": "Kor Scythemaster has first strike as long as it's attacking.",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "7d7b6d11-e3de-53a9-94ff-3db7cb0fe509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54938334-ebad-4dde-82e6-8c854aef4a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54938334-ebad-4dde-82e6-8c854aef4a91.jpg?1",
             "name": "Kor Sky Climber",
             "text": "{1}{W}: Kor Sky Climber gains flying until end of turn.",
             "colours": [
@@ -772,7 +772,7 @@
         },
         {
             "id": "435ca3a4-9c60-51d9-8948-35fdbb7e6a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0dbb08-d124-46da-bfb1-af7ef4a18179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef0dbb08-d124-46da-bfb1-af7ef4a18179.jpg?1",
             "name": "Linvala, the Preserver",
             "text": "Flying\nWhen Linvala, the Preserver enters the battlefield, if an opponent has more life than you, you gain 5 life.\nWhen Linvala enters the battlefield, if an opponent controls more creatures than you, put a 3/3 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "bdc6165b-5910-5c0f-8276-b289c5653fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cace63-91ca-493c-b67f-740fbbf06370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30cace63-91ca-493c-b67f-740fbbf06370.jpg?1",
             "name": "Make a Stand",
             "text": "Creatures you control get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "52aa1e1b-7cfd-50a5-8681-4b7aae600d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d3113-6cb7-4b74-94a3-8160d9ac1b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35d3113-6cb7-4b74-94a3-8160d9ac1b89.jpg?1",
             "name": "Makindi Aeronaut",
             "text": "Flying",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "eba9c90d-be65-51ff-abc7-7ce7c8e4c33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e25089b-5a5f-4cb5-9261-be6cb6b45b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e25089b-5a5f-4cb5-9261-be6cb6b45b22.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -908,7 +908,7 @@
         },
         {
             "id": "018633d9-9c74-5943-a8b2-52f90e27b926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfb21b1-95a5-446d-afc6-aede81ee5a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dfb21b1-95a5-446d-afc6-aede81ee5a0d.jpg?1",
             "name": "Munda's Vanguard",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "4b287b30-6123-58fd-907c-c8a68b86e640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97976ade-c6ec-4068-be6b-953255b86a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97976ade-c6ec-4068-be6b-953255b86a79.jpg?1",
             "name": "Oath of Gideon",
             "text": "When Oath of Gideon enters the battlefield, put two 1/1 white Kor Ally creature tokens onto the battlefield.\nEach planeswalker you control enters the battlefield with an additional loyalty counter on it.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "91b2a7a2-230b-58a3-b2ae-02561aadefe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b255d34-04fa-4d3b-9fc1-8f980ef1f054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b255d34-04fa-4d3b-9fc1-8f980ef1f054.jpg?1",
             "name": "Ondu War Cleric",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: You gain 2 life.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "07a61ba8-6ecc-5a2e-888d-e08bcea8f209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecacff4-87b9-4cc1-bfbe-019cfda82d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecacff4-87b9-4cc1-bfbe-019cfda82d17.jpg?1",
             "name": "Relief Captain",
             "text": "When Relief Captain enters the battlefield, support 3. (Put a +1/+1 counter on each of up to three other target creatures.)",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "68c0d239-b28d-5182-9fb0-40796d2ebaa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dadfd8-8492-4c55-827c-cd4e6a40ae97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dadfd8-8492-4c55-827c-cd4e6a40ae97.jpg?1",
             "name": "Searing Light",
             "text": "Destroy target attacking or blocking creature with power 2 or less.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "b0393926-caac-5226-8b86-b240a110ec4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d11865-a1ea-4f2e-b7da-31630c6d0272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d11865-a1ea-4f2e-b7da-31630c6d0272.jpg?1",
             "name": "Shoulder to Shoulder",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nDraw a card.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "88763199-e109-5253-ac65-2e032826bc80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677bd49-69eb-41dc-8e64-2df3b7f5c45f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5677bd49-69eb-41dc-8e64-2df3b7f5c45f.jpg?1",
             "name": "Spawnbinder Mage",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Tap target creature.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "4e66160b-98a3-5764-9739-4dcf3d1f5093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539dbdfe-3e32-409d-8e1e-aeb0c56656a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539dbdfe-3e32-409d-8e1e-aeb0c56656a7.jpg?1",
             "name": "Steppe Glider",
             "text": "Flying, vigilance\n{1}{W}: Target creature with a +1/+1 counter on it gains flying and vigilance until end of turn.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "bf6d9619-32ed-594e-830a-2e4ec639ba33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b98e63-f23d-432a-86ae-f88bdad2f648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1b98e63-f23d-432a-86ae-f88bdad2f648.jpg?1",
             "name": "Stone Haven Outfitter",
             "text": "Equipped creatures you control get +1/+1.\nWhenever an equipped creature you control dies, draw a card.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "5284cca3-86da-57f7-9ca0-adec794260ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ec11-48c3-49d8-9dcd-1da5ffaf9184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b1ec11-48c3-49d8-9dcd-1da5ffaf9184.jpg?1",
             "name": "Stoneforge Acolyte",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Look at the top four cards of your library. You may reveal an Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "02354ce8-221a-5ecd-ba04-738488373d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f0dc1-c8cf-4733-a874-5ae57b38258e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f0dc1-c8cf-4733-a874-5ae57b38258e.jpg?1",
             "name": "Wall of Resurgence",
             "text": "Defender\nWhen Wall of Resurgence enters the battlefield, you may put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.",
             "colours": [
@@ -1290,7 +1290,7 @@
         },
         {
             "id": "3f4a026f-0704-51ea-ac9f-c1a3f9596c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249a7be3-311e-4ce6-97dc-97242463ae23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249a7be3-311e-4ce6-97dc-97242463ae23.jpg?1",
             "name": "Abstruse Interference",
             "text": "Devoid (This card has no color.)\nCounter target spell unless its controller pays {1}. You put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "8e76a8e5-faec-5b61-891d-bbee668ecb0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb60957-0811-40c3-a92b-cce3e6a94745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb60957-0811-40c3-a92b-cce3e6a94745.jpg?1",
             "name": "Blinding Drone",
             "text": "Devoid (This card has no color.)\n{C}, {T}: Tap target creature. ({C} represents colorless mana.)",
             "colours": [],
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "7a435393-2564-5e99-8f61-9866ef543344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe4bb6f-bec6-49d2-99d7-e3750a0ea03f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe4bb6f-bec6-49d2-99d7-e3750a0ea03f.jpg?1",
             "name": "Cultivator Drone",
             "text": "Devoid (This card has no color.)\n{T}: Add {C} to your mana pool. Spend this mana only to cast a colorless spell, activate an ability of a colorless permanent, or pay a cost that contains {C}. ({C} represents colorless mana.)",
             "colours": [],
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "1c7e3597-a6bb-5d6b-9112-3f529adce853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a22cc-36dd-4d4d-b887-8c4733a29870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/496a22cc-36dd-4d4d-b887-8c4733a29870.jpg?1",
             "name": "Deepfathom Skulker",
             "text": "Devoid (This card has no color.)\nWhenever a creature you control deals combat damage to a player, you may draw a card.\n{3}{C}: Target creature can't be blocked this turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "f34cfa5d-c0b9-51a1-84b9-cc051b08a945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea28dd5-57b0-4255-a3d9-1c190c446f20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea28dd5-57b0-4255-a3d9-1c190c446f20.jpg?1",
             "name": "Dimensional Infiltrator",
             "text": "Devoid (This card has no color.)\nFlash\nFlying\n{1}{C}: Target opponent exiles the top card of his or her library. If it's a land card, you may return Dimensional Infiltrator to its owner's hand. ({C} represents colorless mana.)",
             "colours": [],
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "19f2ab80-c7d5-5b6f-8a42-b21969e29692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9b63e-6ecc-4d85-9724-87b8176ae6a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9b63e-6ecc-4d85-9724-87b8176ae6a6.jpg?1",
             "name": "Gravity Negator",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever Gravity Negator attacks, you may pay {C}. If you do, another target creature gains flying until end of turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -1483,7 +1483,7 @@
         },
         {
             "id": "c8bc3da4-89c8-526e-87fd-ea8e3c005f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ee2d7e-50ee-4f5a-b787-cf9669a892f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ee2d7e-50ee-4f5a-b787-cf9669a892f3.jpg?1",
             "name": "Prophet of Distortion",
             "text": "Devoid (This card has no color.)\n{3}{C}: Draw a card. ({C} represents colorless mana.)",
             "colours": [],
@@ -1516,7 +1516,7 @@
         },
         {
             "id": "61b31748-9472-5998-a781-8103dbc5289d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dee6dca-9c7e-4347-bea7-7fecc69e5827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dee6dca-9c7e-4347-bea7-7fecc69e5827.jpg?1",
             "name": "Slip Through Space",
             "text": "Devoid (This card has no color.)\nTarget creature can't be blocked this turn.\nDraw a card.",
             "colours": [],
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "1fb6b965-6d0e-536c-8593-63140f3c6e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f9eeb2-22f6-4bdb-bbf8-f53774cc6226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f9eeb2-22f6-4bdb-bbf8-f53774cc6226.jpg?1",
             "name": "Thought Harvester",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever you cast a colorless spell, target opponent exiles the top card of his or her library.",
             "colours": [],
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "14abd99b-f452-56e8-8f6d-7247052fd443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf13c5e-3968-48ad-ba08-99ba58873223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf13c5e-3968-48ad-ba08-99ba58873223.jpg?1",
             "name": "Void Shatter",
             "text": "Devoid (This card has no color.)\nCounter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [],
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "3d0be5c2-4535-5189-b2e6-0ba6395d99c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783794e3-fe0c-4014-ae5a-6c249af23ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783794e3-fe0c-4014-ae5a-6c249af23ddc.jpg?1",
             "name": "Ancient Crab",
             "text": "",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "738dcc95-7c3f-57ce-8987-f2139ebab35e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd83129b-7e8c-4cc5-a7b3-e0ae221d7ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd83129b-7e8c-4cc5-a7b3-e0ae221d7ad4.jpg?1",
             "name": "Comparative Analysis",
             "text": "Surge {2}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nTarget player draws two cards.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "f36936ed-927e-500f-9aef-a107634e5b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd3963-a4d7-4992-b6f8-753996390bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd3963-a4d7-4992-b6f8-753996390bbf.jpg?1",
             "name": "Containment Membrane",
             "text": "Surge {U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nEnchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1709,7 +1709,7 @@
         },
         {
             "id": "c96eea20-9fb4-5bb5-b22f-87a2798db3b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1434e1-a0d6-4028-918b-1e2d17d3a227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1434e1-a0d6-4028-918b-1e2d17d3a227.jpg?1",
             "name": "Crush of Tentacles",
             "text": "Surge {3}{U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nReturn all nonland permanents to their owners' hands. If Crush of Tentacles's surge cost was paid, put an 8/8 blue Octopus creature token onto the battlefield.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "1f42e397-1ca3-5ddf-a29a-e39d170daceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff62270-57ed-4706-bedf-11f60ae2da43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff62270-57ed-4706-bedf-11f60ae2da43.jpg?1",
             "name": "Cyclone Sire",
             "text": "Flying\nWhen Cyclone Sire dies, you may put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.",
             "colours": [
@@ -1775,7 +1775,7 @@
         },
         {
             "id": "5d6c2ddc-bb40-5946-9d4c-9e25b7ee63e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3821122c-c495-42b0-b8f6-3f469967f16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3821122c-c495-42b0-b8f6-3f469967f16d.jpg?1",
             "name": "Gift of Tusks",
             "text": "Until end of turn, target creature loses all abilities and becomes a green Elephant with base power and toughness 3/3.",
             "colours": [
@@ -1807,7 +1807,7 @@
         },
         {
             "id": "facd991f-9a0d-5f23-9161-09c3cbf3e81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf33069-013f-43ab-9a31-e67bb6dc996d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cf33069-013f-43ab-9a31-e67bb6dc996d.jpg?1",
             "name": "Grip of the Roil",
             "text": "Surge {1}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "c4e1202d-ab50-5ab0-9619-9df1c8e48dea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ec511-1b78-46e9-8ec2-fc09abd1b434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3ec511-1b78-46e9-8ec2-fc09abd1b434.jpg?1",
             "name": "Hedron Alignment",
             "text": "Hexproof\nAt the beginning of your upkeep, you may reveal your hand. If you do, you win the game if you own a card named Hedron Alignment in exile, in your hand, in your graveyard, and on the battlefield.\n{1}{U}: Scry 1.",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "38ae7bbc-73d6-5cd2-b2a9-5b13b67709ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b059f-2fa3-474f-9c74-6d4021703add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5b059f-2fa3-474f-9c74-6d4021703add.jpg?1",
             "name": "Jwar Isle Avenger",
             "text": "Surge {2}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFlying",
             "colours": [
@@ -1905,7 +1905,7 @@
         },
         {
             "id": "a0922c23-9456-5550-a002-6e367073e91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026c499d-3d5b-4f65-a824-f78f146b82ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026c499d-3d5b-4f65-a824-f78f146b82ef.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "7dd85c72-ffaa-569d-a572-4f1dbe702c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7b007-a14b-40b2-9de7-38545c50a073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e7b007-a14b-40b2-9de7-38545c50a073.jpg?1",
             "name": "Oath of Jace",
             "text": "When Oath of Jace enters the battlefield, draw three cards, then discard two cards.\nAt the beginning of your upkeep, scry X, where X is the number of planeswalkers you control.",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "ee63c4e2-67b5-5e7d-880f-2f09839ab162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff1000-1a4e-43f6-aa02-1dbe9fac6901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ff1000-1a4e-43f6-aa02-1dbe9fac6901.jpg?1",
             "name": "Overwhelming Denial",
             "text": "Surge {U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nOverwhelming Denial can't be countered by spells or abilities.\nCounter target spell.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "9b203bad-6ea1-51b4-a76e-b3335ff15ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d878c10-de5e-4224-98ce-d49902b5ab8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d878c10-de5e-4224-98ce-d49902b5ab8b.jpg?1",
             "name": "Roiling Waters",
             "text": "Return up to two target creatures your opponents control to their owners' hands. Target player draws two cards.",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "dc16bd4e-4cff-5de2-81a2-2db11185814c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg?1",
             "name": "Sphinx of the Final Word",
             "text": "Sphinx of the Final Word can't be countered.\nFlying, hexproof\nInstant and sorcery spells you control can't be countered by spells or abilities.",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "c5b808b7-f4b7-5a3e-969f-dc3ed5326ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75234f6d-a2da-42dd-a668-8db8f341e7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75234f6d-a2da-42dd-a668-8db8f341e7f0.jpg?1",
             "name": "Sweep Away",
             "text": "Return target creature to its owner's hand. If that creature is attacking, you may put it on top of its owner's library instead.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "44e7e272-cd4d-5a75-abe8-fa5ceb79e080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4ddc45-cd67-4b2c-84d0-4604783fd8e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4ddc45-cd67-4b2c-84d0-4604783fd8e7.jpg?1",
             "name": "Umara Entangler",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "d94cca2b-aeb8-5f90-8312-5895d693bc0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f87292c-0140-44d7-881e-2e8c9ff737a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f87292c-0140-44d7-881e-2e8c9ff737a1.jpg?1",
             "name": "Unity of Purpose",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nUntap each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "01cb51c7-44d2-5667-aa18-95b998418031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50460cce-ee1c-4384-bb0c-d90616e0d2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50460cce-ee1c-4384-bb0c-d90616e0d2e9.jpg?1",
             "name": "Bearer of Silence",
             "text": "Devoid (This card has no color.)\nWhen you cast Bearer of Silence, you may pay {1}{C}. If you do, target opponent sacrifices a creature. ({C} represents colorless mana.)\nFlying\nBearer of Silence can't block.",
             "colours": [],
@@ -2201,7 +2201,7 @@
         },
         {
             "id": "fc6d19ea-7078-5ac7-9e02-88a96cbdbe5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b26769-4705-4b09-94b4-1063e67041d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b26769-4705-4b09-94b4-1063e67041d1.jpg?1",
             "name": "Dread Defiler",
             "text": "Devoid (This card has no color.)\n{3}{C}, Exile a creature card from your graveyard: Target opponent loses life equal to the exiled card's power. ({C} represents colorless mana.)",
             "colours": [],
@@ -2233,7 +2233,7 @@
         },
         {
             "id": "479ab91c-f98d-51b7-850d-e5dcce4a37d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996da623-1c34-4545-a800-648238ea91ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/996da623-1c34-4545-a800-648238ea91ae.jpg?1",
             "name": "Essence Depleter",
             "text": "Devoid (This card has no color.)\n{1}{C}: Target opponent loses 1 life and you gain 1 life. ({C} represents colorless mana.)",
             "colours": [],
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "da2658fc-f04d-5f72-bd36-6f25c2ae472a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77899cb2-4d87-4c2d-99ae-1ae75bc5dc86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77899cb2-4d87-4c2d-99ae-1ae75bc5dc86.jpg?1",
             "name": "Flaying Tendrils",
             "text": "Devoid (This card has no color.)\nAll creatures get -2/-2 until end of turn. If a creature would die this turn, exile it instead.",
             "colours": [],
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "4fa571b5-fb97-56eb-b242-9462862f87f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8585871-24a2-41d7-ae12-29aabfbc9ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8585871-24a2-41d7-ae12-29aabfbc9ccc.jpg?1",
             "name": "Havoc Sower",
             "text": "Devoid (This card has no color.)\n{1}{C}: Havoc Sower gets +2/+1 until end of turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -2329,7 +2329,7 @@
         },
         {
             "id": "6336cde2-1a6f-5bfc-84d6-e8a2cff61dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c9d8c5-333b-4281-b923-b4a060927bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c9d8c5-333b-4281-b923-b4a060927bbc.jpg?1",
             "name": "Inverter of Truth",
             "text": "Devoid (This card has no color.)\nFlying\nWhen Inverter of Truth enters the battlefield, exile all cards from your library face down, then shuffle all cards from your graveyard into your library.",
             "colours": [],
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "513ce397-8737-5c97-b108-3176574c2335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a384cd5b-2c6c-4969-bb62-a017e2fc9794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a384cd5b-2c6c-4969-bb62-a017e2fc9794.jpg?1",
             "name": "Kozilek's Shrieker",
             "text": "Devoid (This card has no color.)\n{C}: Kozilek's Shrieker gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures. {C} represents colorless mana.)",
             "colours": [],
@@ -2394,7 +2394,7 @@
         },
         {
             "id": "1990ea10-2979-5d6a-a0a6-fa8171396f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80665ae-fcb2-48fd-95be-8768293bcef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80665ae-fcb2-48fd-95be-8768293bcef7.jpg?1",
             "name": "Kozilek's Translator",
             "text": "Devoid (This card has no color.)\nPay 1 life: Add {C} to your mana pool. Activate this ability only once each turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -2427,7 +2427,7 @@
         },
         {
             "id": "0ce07a6d-f70b-540b-bcdb-5556103a95bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e30acf-b30f-4bb3-b80e-dc7e9559da51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e30acf-b30f-4bb3-b80e-dc7e9559da51.jpg?1",
             "name": "Oblivion Strike",
             "text": "Devoid (This card has no color.)\nExile target creature.",
             "colours": [],
@@ -2457,7 +2457,7 @@
         },
         {
             "id": "e912a670-5ba5-5633-82eb-011137324722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162f3fb8-75b7-4cd7-9d6c-27dd76197aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162f3fb8-75b7-4cd7-9d6c-27dd76197aa5.jpg?1",
             "name": "Reaver Drone",
             "text": "Devoid (This card has no color.)\nAt the beginning of your upkeep, you lose 1 life unless you control another colorless creature.",
             "colours": [],
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "f918e90c-ef38-5dcd-9eba-54e94b477b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be57a5aa-44f1-483f-9274-aa68f5a2bf1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be57a5aa-44f1-483f-9274-aa68f5a2bf1f.jpg?1",
             "name": "Sifter of Skulls",
             "text": "Devoid (This card has no color.)\nWhenever another nontoken creature you control dies, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "d6df5383-46eb-50b1-b1e0-359776812d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00fa72-bcda-4081-9048-e13752da8d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb00fa72-bcda-4081-9048-e13752da8d46.jpg?1",
             "name": "Sky Scourer",
             "text": "Devoid (This card has no color.)\nFlying\nWhenever you cast a colorless spell, Sky Scourer gets +1/+0 until end of turn.",
             "colours": [],
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "e844291e-2942-5dac-879c-c54f27c83219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b1185-49aa-45ae-8e2d-12aa469a7d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b1185-49aa-45ae-8e2d-12aa469a7d77.jpg?1",
             "name": "Slaughter Drone",
             "text": "Devoid (This card has no color.)\n{C}: Slaughter Drone gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it. {C} represents colorless mana.)",
             "colours": [],
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "e9d3f69e-622b-532b-9bdc-ef1bc9977acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac497133-a44a-4acc-ba7e-8fc1fae7e226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac497133-a44a-4acc-ba7e-8fc1fae7e226.jpg?1",
             "name": "Unnatural Endurance",
             "text": "Devoid (This card has no color.)\nTarget creature gets +2/+0 until end of turn. Regenerate it.",
             "colours": [],
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "9587e7ab-5c86-559f-af9b-a69bec33296f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ed374-54ad-4b81-b071-0b4668feb282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9ed374-54ad-4b81-b071-0b4668feb282.jpg?1",
             "name": "Visions of Brutality",
             "text": "Devoid (This card has no color.)\nEnchant creature\nEnchanted creature can't block.\nWhenever enchanted creature deals damage, its controller loses that much life.",
             "colours": [],
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "708117b0-f116-5975-a198-24422cc153af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c06d8ec-55ab-4be9-a470-77c79d643d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c06d8ec-55ab-4be9-a470-77c79d643d1f.jpg?1",
             "name": "Witness the End",
             "text": "Devoid (This card has no color.)\nTarget opponent exiles two cards from his or her hand and loses 2 life.",
             "colours": [],
@@ -2680,7 +2680,7 @@
         },
         {
             "id": "a954c595-d003-5b42-af45-f4b997805817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7e6054-c6b8-4b29-83c5-a2e4e295bdf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7e6054-c6b8-4b29-83c5-a2e4e295bdf3.jpg?1",
             "name": "Corpse Churn",
             "text": "Put the top three cards of your library into your graveyard, then you may return a creature card from your graveyard to your hand.",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "f853f063-cb65-526f-aff1-cb1e099a10f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189abe2f-5899-438b-9f54-3c98e50f037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189abe2f-5899-438b-9f54-3c98e50f037a.jpg?1",
             "name": "Drana's Chosen",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -2748,7 +2748,7 @@
         },
         {
             "id": "3f731932-6904-54b4-b08a-3ad13a96790a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d692236-92e5-460f-a8fc-8f6c73eba30c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d692236-92e5-460f-a8fc-8f6c73eba30c.jpg?1",
             "name": "Grasp of Darkness",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "968d91e6-eae1-5dd3-8fda-8d57d9c0d6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a278d0-f601-4d57-bc3d-2972f8602a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a278d0-f601-4d57-bc3d-2972f8602a69.jpg?1",
             "name": "Kalitas, Traitor of Ghet",
             "text": "Lifelink\nIf a nontoken creature an opponent controls would die, instead exile that card and put a 2/2 black Zombie creature token onto the battlefield.\n{2}{B}, Sacrifice another Vampire or Zombie: Put two +1/+1 counters on Kalitas, Traitor of Ghet.",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "c87cd087-cd08-5a4d-a752-02ed5635087e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cb3c2c-5d5a-4c9b-a381-ab4dd477d84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cb3c2c-5d5a-4c9b-a381-ab4dd477d84d.jpg?1",
             "name": "Malakir Soothsayer",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: You draw a card and you lose 1 life.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "8577dc94-3acc-5e01-b9f7-6ce9d399ecfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe773b-2987-4001-a0fd-9dca414a9129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe773b-2987-4001-a0fd-9dca414a9129.jpg?1",
             "name": "Null Caller",
             "text": "{3}{B}, Exile a creature card from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -2888,7 +2888,7 @@
         },
         {
             "id": "1614c3a5-c661-5b71-a983-e9d3f4884269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde9379-b335-400f-9748-a7ca3e293ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde9379-b335-400f-9748-a7ca3e293ee0.jpg?1",
             "name": "Remorseless Punishment",
             "text": "Target opponent loses 5 life unless that player discards two cards or sacrifices a creature or planeswalker. Repeat this process once.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "533028ae-7a0c-5afd-b360-9dcec70c3bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee017c-25ae-4668-8cfe-ae3b55e851aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ee017c-25ae-4668-8cfe-ae3b55e851aa.jpg?1",
             "name": "Tar Snare",
             "text": "Target creature gets -3/-2 until end of turn.",
             "colours": [
@@ -2952,7 +2952,7 @@
         },
         {
             "id": "a6b606e6-4b37-5909-8550-234b26ef3128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595deb86-b6cf-4e4f-a6cf-f5ff128b720d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/595deb86-b6cf-4e4f-a6cf-f5ff128b720d.jpg?1",
             "name": "Untamed Hunger",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "e9eb9fba-8330-55ba-b404-c46e633cba9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba8e7aa-9a87-410e-b846-5f5c910585cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3ba8e7aa-9a87-410e-b846-5f5c910585cf.jpg?1",
             "name": "Vampire Envoy",
             "text": "Flying\nWhenever Vampire Envoy becomes tapped, you gain 1 life.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "86d5c9f9-cdfa-5d0c-b1ca-d2113ed11f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92461f3c-21dc-48a8-b532-9c4e2e1e80b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92461f3c-21dc-48a8-b532-9c4e2e1e80b5.jpg?1",
             "name": "Zulaport Chainmage",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Target opponent loses 2 life.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "71aa6c57-9c99-5c3d-8140-ececbc1b28cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a42b28-3d1b-4432-b8c9-2d42e4d0e1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a42b28-3d1b-4432-b8c9-2d42e4d0e1c5.jpg?1",
             "name": "Consuming Sinkhole",
             "text": "Devoid (This card has no color.)\nChoose one \u2014\n\u2022 Exile target land creature.\n\u2022 Consuming Sinkhole deals 4 damage to target player.",
             "colours": [],
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "d2280846-0d70-5a82-a5bd-9866c6ab502f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f3ec85-552d-4e28-939e-ab2c39e3e9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f3ec85-552d-4e28-939e-ab2c39e3e9c5.jpg?1",
             "name": "Eldrazi Aggressor",
             "text": "Devoid (This card has no color.)\nEldrazi Aggressor has haste as long as you control another colorless creature.",
             "colours": [],
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "8a49fac3-7e0c-5532-b03f-428a63251a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaa8b16-7c12-44e2-8ddb-17608d491c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaa8b16-7c12-44e2-8ddb-17608d491c41.jpg?1",
             "name": "Eldrazi Obligator",
             "text": "Devoid (This card has no color.)\nWhen you cast Eldrazi Obligator, you may pay {1}{C}. If you do, gain control of target creature until end of turn, untap that creature, and it gains haste until end of turn. ({C} represents colorless mana.)\nHaste",
             "colours": [],
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "a79ccb68-b43e-58e5-b804-87c724e58680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9c92d-8b1b-4adc-8015-d50e673b6321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d9c92d-8b1b-4adc-8015-d50e673b6321.jpg?1",
             "name": "Immobilizer Eldrazi",
             "text": "Devoid (This card has no color.)\n{2}{C}: Each creature with toughness greater than its power can't block this turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -3186,7 +3186,7 @@
         },
         {
             "id": "cf8a28d7-afc4-5969-99c8-830fbb854bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72765559-0a78-4aa3-827e-cb4612720991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72765559-0a78-4aa3-827e-cb4612720991.jpg?1",
             "name": "Kozilek's Return",
             "text": "Devoid (This card has no color.)\nKozilek's Return deals 2 damage to each creature.\nWhenever you cast an Eldrazi creature spell with converted mana cost 7 or greater, you may exile Kozilek's Return from your graveyard. If you do, Kozilek's Return deals 5 damage to each creature.",
             "colours": [],
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "2653d424-4ba3-5845-8c0d-6d83c8f08a99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48669993-ad68-499e-8f2e-bc5c651b4b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48669993-ad68-499e-8f2e-bc5c651b4b28.jpg?1",
             "name": "Maw of Kozilek",
             "text": "Devoid (This card has no color.)\n{C}: Maw of Kozilek gets +2/-2 until end of turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -3249,7 +3249,7 @@
         },
         {
             "id": "10e36b0e-88a9-5bdd-be4d-3727ffc967de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c044168d-cb08-493d-98c1-b66b6149fe5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c044168d-cb08-493d-98c1-b66b6149fe5a.jpg?1",
             "name": "Reality Hemorrhage",
             "text": "Devoid (This card has no color.)\nReality Hemorrhage deals 2 damage to target creature or player.",
             "colours": [],
@@ -3279,7 +3279,7 @@
         },
         {
             "id": "2b03bd87-1f75-5897-8885-dcbd821a90fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4e1e2-7961-47d2-bb55-9168ea201214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef4e1e2-7961-47d2-bb55-9168ea201214.jpg?1",
             "name": "Akoum Flameseeker",
             "text": "Cohort \u2014 {T}, Tap an untapped Ally you control: Discard a card. If you do, draw a card.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "461cf41a-585c-5b6b-a54f-0b3144f32e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e269989-bb22-4da4-a374-434a572e8e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e269989-bb22-4da4-a374-434a572e8e8f.jpg?1",
             "name": "Boulder Salvo",
             "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nBoulder Salvo deals 4 damage to target creature.",
             "colours": [
@@ -3347,7 +3347,7 @@
         },
         {
             "id": "5edf7a0c-b1e1-5959-afa4-5457e72d323a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec60192a-19b3-447c-b732-bbcb2d275df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec60192a-19b3-447c-b732-bbcb2d275df6.jpg?1",
             "name": "Brute Strength",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.",
             "colours": [
@@ -3379,7 +3379,7 @@
         },
         {
             "id": "d460ffe2-635f-5dc3-b9ba-ccd535bce435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fdd0d3-7140-4c12-a41c-37eedd986d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fdd0d3-7140-4c12-a41c-37eedd986d9e.jpg?1",
             "name": "Chandra, Flamecaller",
             "text": "+1: Put two 3/1 red Elemental creature tokens with haste onto the battlefield. Exile them at the beginning of the next end step.\n0: Discard all the cards in your hand, then draw that many cards plus one.\n\u2212X: Chandra, Flamecaller deals X damage to each creature.",
             "colours": [
@@ -3415,7 +3415,7 @@
         },
         {
             "id": "ba520565-3e5d-590c-ad46-b781bbd31cb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a069118-42e4-40e3-a2ba-593ac89b9064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a069118-42e4-40e3-a2ba-593ac89b9064.jpg?1",
             "name": "Cinder Hellion",
             "text": "Trample\nWhen Cinder Hellion enters the battlefield, it deals 2 damage to target opponent.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "f0261d8c-8a00-5dd6-a679-1e36f4c1e999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432dd78b-9520-4c28-8699-d7ff9c477070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432dd78b-9520-4c28-8699-d7ff9c477070.jpg?1",
             "name": "Devour in Flames",
             "text": "As an additional cost to cast Devour in Flames, return a land you control to its owner's hand.\nDevour in Flames deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "c93120e6-206c-5f20-81c6-5588d7ea1496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f385d1-a6c5-40b7-bc90-6f71b6f815e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f385d1-a6c5-40b7-bc90-6f71b6f815e7.jpg?1",
             "name": "Embodiment of Fury",
             "text": "Trample\nLand creatures you control have trample.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target land you control become a 3/3 Elemental creature with haste until end of turn. It's still a land.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "d6203006-0886-5b89-b300-87117c113659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c65eb7-4353-45ce-9c2e-1791c2804ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c65eb7-4353-45ce-9c2e-1791c2804ccf.jpg?1",
             "name": "Expedite",
             "text": "Target creature gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "692b35f6-29f2-50bc-966b-e3a0e09888c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21da73-0dad-4b2b-8cc6-61861bed9410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21da73-0dad-4b2b-8cc6-61861bed9410.jpg?1",
             "name": "Fall of the Titans",
             "text": "Surge {X}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFall of the Titans deals X damage to each of up to two target creatures and/or players.",
             "colours": [
@@ -3579,7 +3579,7 @@
         },
         {
             "id": "3a83e403-7e44-5ccb-b188-a788c20065da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf91a4e-97f7-4189-823d-b619bb3b3d55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf91a4e-97f7-4189-823d-b619bb3b3d55.jpg?1",
             "name": "Goblin Dark-Dwellers",
             "text": "Menace\nWhen Goblin Dark-Dwellers enters the battlefield, you may cast target instant or sorcery card with converted mana cost 3 or less from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "2215358d-8af0-5d32-804b-f3c3ed90843e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5082e0a1-5c3e-4b8c-ba88-290151564133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5082e0a1-5c3e-4b8c-ba88-290151564133.jpg?1",
             "name": "Goblin Freerunner",
             "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "aec84040-a619-5194-995f-786ecffd58fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6824f48d-6808-4458-a2fd-1ffd0a10d72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6824f48d-6808-4458-a2fd-1ffd0a10d72a.jpg?1",
             "name": "Kazuul's Toll Collector",
             "text": "{0}: Attach target Equipment you control to Kazuul's Toll Collector. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "b50438e0-e180-5dcf-aa3c-58e9549cd74b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f570b0cb-2f38-422d-89d6-22c85e085328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f570b0cb-2f38-422d-89d6-22c85e085328.jpg?1",
             "name": "Oath of Chandra",
             "text": "When Oath of Chandra enters the battlefield, it deals 3 damage to target creature an opponent controls.\nAt the beginning of each end step, if a planeswalker entered the battlefield under your control this turn, Oath of Chandra deals 2 damage to each opponent.",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "c3b1302a-20b3-548e-948b-591e76f9d3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b9eb4b-3ab8-4506-baa4-3a818e7677a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b9eb4b-3ab8-4506-baa4-3a818e7677a3.jpg?1",
             "name": "Press into Service",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3750,7 +3750,7 @@
         },
         {
             "id": "148bf771-be00-5247-abdb-ccab50650579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c8dad1-278c-4ced-8124-5593b140d361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c8dad1-278c-4ced-8124-5593b140d361.jpg?1",
             "name": "Pyromancer's Assault",
             "text": "Whenever you cast your second spell each turn, Pyromancer's Assault deals 2 damage to target creature or player.",
             "colours": [
@@ -3782,7 +3782,7 @@
         },
         {
             "id": "fef5a7dc-3415-52fc-81a3-e9cd1927c1b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0405b1b9-976a-4aaf-bec6-fa006decea74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0405b1b9-976a-4aaf-bec6-fa006decea74.jpg?1",
             "name": "Reckless Bushwhacker",
             "text": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nHaste\nWhen Reckless Bushwhacker enters the battlefield, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -3818,7 +3818,7 @@
         },
         {
             "id": "5d7a09bd-52fc-5e31-a204-fad82cf9547f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736ad6c8-e275-4644-9d1e-d2d380149839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736ad6c8-e275-4644-9d1e-d2d380149839.jpg?1",
             "name": "Sparkmage's Gambit",
             "text": "Sparkmage's Gambit deals 1 damage to each of up to two target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "f22ceac8-501a-5a5b-96c0-997a16ab4195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db858823-ae8b-4da1-be6f-aee541e008ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db858823-ae8b-4da1-be6f-aee541e008ae.jpg?1",
             "name": "Tears of Valakut",
             "text": "Tears of Valakut can't be countered by spells or abilities.\nTears of Valakut deals 5 damage to target creature with flying.",
             "colours": [
@@ -3882,7 +3882,7 @@
         },
         {
             "id": "4284b1e1-99fd-5756-affe-df411cb086d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388be9e-332e-4199-9f30-862d631fa26b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f388be9e-332e-4199-9f30-862d631fa26b.jpg?1",
             "name": "Tyrant of Valakut",
             "text": "Surge {3}{R}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nFlying\nWhen Tyrant of Valakut enters the battlefield, if its surge cost was paid, it deals 3 damage to target creature or player.",
             "colours": [
@@ -3916,7 +3916,7 @@
         },
         {
             "id": "076eb3de-0172-5ce5-8c1a-7a7ec58d8351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ad826d-c7e6-4dfd-991f-15d75b87d504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ad826d-c7e6-4dfd-991f-15d75b87d504.jpg?1",
             "name": "Zada's Commando",
             "text": "First strike\nCohort \u2014 {T}, Tap an untapped Ally you control: Zada's Commando deals 1 damage to target opponent.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "3e87b480-2b47-5e22-92e9-a6c7d533c599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a644e0-96e5-4b73-873f-1132948cb21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a644e0-96e5-4b73-873f-1132948cb21f.jpg?1",
             "name": "Birthing Hulk",
             "text": "Devoid (This card has no color.)\nWhen Birthing Hulk enters the battlefield, put two 1/1 colorless Eldrazi Scion creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)\n{1}{C}: Regenerate Birthing Hulk.",
             "colours": [],
@@ -3985,7 +3985,7 @@
         },
         {
             "id": "aed4c413-eda0-5148-b5f7-b2d9175be57e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0ff591-e4d9-4b62-ac9c-7962fd815226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0ff591-e4d9-4b62-ac9c-7962fd815226.jpg?1",
             "name": "Ruin in Their Wake",
             "text": "Devoid (This card has no color.)\nSearch your library for a basic land card and reveal it. You may put that card onto the battlefield tapped if you control a land named Wastes. Otherwise, put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "b78b63e6-7b7b-573f-81fb-ff0eb1727b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a882e-c4bd-4132-b797-9e1aa2d0bce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826a882e-c4bd-4132-b797-9e1aa2d0bce4.jpg?1",
             "name": "Scion Summoner",
             "text": "Devoid (This card has no color.)\nWhen Scion Summoner enters the battlefield, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield. It has \"Sacrifice this creature: Add {C} to your mana pool.\" ({C} represents colorless mana.)",
             "colours": [],
@@ -4048,7 +4048,7 @@
         },
         {
             "id": "ba3b0819-a6f3-5283-bd4a-935e1026278f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bc5b4c-a809-43f0-8848-38812ce865c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12bc5b4c-a809-43f0-8848-38812ce865c2.jpg?1",
             "name": "Stalking Drone",
             "text": "Devoid (This card has no color.)\n{C}: Stalking Drone gets +1/+2 until end of turn. Activate this ability only once each turn. ({C} represents colorless mana.)",
             "colours": [],
@@ -4081,7 +4081,7 @@
         },
         {
             "id": "e9721010-a8da-5ce3-96d9-15350b07c85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b0613-127a-4338-aea4-ad0b8aa96d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48b0613-127a-4338-aea4-ad0b8aa96d77.jpg?1",
             "name": "Vile Redeemer",
             "text": "Devoid (This card has no color.)\nFlash\nWhen you cast Vile Redeemer, you may pay {C}. If you do, put a 1/1 colorless Eldrazi Scion creature token onto the battlefield for each nontoken creature that died under your control this turn. Those tokens have \"Sacrifice this creature: Add {C} to your mana pool.\"",
             "colours": [],
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "aebb4023-332e-5daf-bbfe-2e629d1433aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1",
             "name": "World Breaker",
             "text": "Devoid (This card has no color.)\nWhen you cast World Breaker, exile target artifact, enchantment, or land.\nReach\n{2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand. ({C} represents colorless mana.)",
             "colours": [],
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "7a5d0f97-be5c-5646-b5fd-481d0895bf00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c87f4-4fa5-4c97-9654-c4acd250f850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f9c87f4-4fa5-4c97-9654-c4acd250f850.jpg?1",
             "name": "Baloth Pup",
             "text": "Baloth Pup has trample as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "e65f7045-6ea6-5bb3-90b1-acb88f2ac09e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff50de00-115f-41ed-892b-aac9bd13b9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff50de00-115f-41ed-892b-aac9bd13b9b9.jpg?1",
             "name": "Bonds of Mortality",
             "text": "When Bonds of Mortality enters the battlefield, draw a card.\n{G}: Creatures your opponents control lose hexproof and indestructible until end of turn.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "e22a403e-0286-5ee7-95d0-398141744fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc8957d-769c-4630-9544-56cea8c847c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc8957d-769c-4630-9544-56cea8c847c2.jpg?1",
             "name": "Canopy Gorger",
             "text": "",
             "colours": [
@@ -4245,7 +4245,7 @@
         },
         {
             "id": "5e2ee7df-bebe-5da3-9468-fec024242f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e194b283-a7d2-4c0a-9ee2-8689a8e911b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e194b283-a7d2-4c0a-9ee2-8689a8e911b9.jpg?1",
             "name": "Elemental Uprising",
             "text": "Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land. It must be blocked this turn if able.",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "26ffa7a4-9e09-5dff-899e-efde248d369f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b034a95d-4f51-4f04-94c2-dad073ea0f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b034a95d-4f51-4f04-94c2-dad073ea0f35.jpg?1",
             "name": "Embodiment of Insight",
             "text": "Vigilance\nLand creatures you control have vigilance.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target land you control become a 3/3 Elemental creature with haste until end of turn. It's still a land.",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "c1cd2e46-4854-5bec-b120-d2a244c2a77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ffd3f4-a034-4cb2-9270-bdb5197f1bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ffd3f4-a034-4cb2-9270-bdb5197f1bef.jpg?1",
             "name": "Gladehart Cavalry",
             "text": "When Gladehart Cavalry enters the battlefield, support 6. (Put a +1/+1 counter on each of up to six other target creatures.)\nWhenever a creature you control with a +1/+1 counter on it dies, you gain 2 life.",
             "colours": [
@@ -4346,7 +4346,7 @@
         },
         {
             "id": "d2e53ba2-2533-5013-b183-dfa26727b5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf92744-0acc-4c7e-819c-51b0696facad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf92744-0acc-4c7e-819c-51b0696facad.jpg?1",
             "name": "Harvester Troll",
             "text": "When Harvester Troll enters the battlefield, you may sacrifice a creature or land. If you do, put two +1/+1 counters on Harvester Troll.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "18e42ebd-8011-532f-a543-90e5aa838741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cdcb985-b0bb-4921-a7e4-3ee6e8f8992b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cdcb985-b0bb-4921-a7e4-3ee6e8f8992b.jpg?1",
             "name": "Lead by Example",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "5cbd65d8-0e1a-56fc-8c82-d81fb1e0c4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affa9314-0021-445e-9496-349254b16bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/affa9314-0021-445e-9496-349254b16bf8.jpg?1",
             "name": "Loam Larva",
             "text": "When Loam Larva enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle your library and put that card on top of it.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "49c56c51-88b8-5794-a1be-c800221bb2f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd4bdd5-1673-4f22-b593-41df8ce95a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd4bdd5-1673-4f22-b593-41df8ce95a97.jpg?1",
             "name": "Natural State",
             "text": "Destroy target artifact or enchantment with converted mana cost 3 or less.",
             "colours": [
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "ea3ef362-09de-5323-8502-1f652540d759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456de8f8-f5dc-44fb-81b1-ca653c32be8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456de8f8-f5dc-44fb-81b1-ca653c32be8e.jpg?1",
             "name": "Netcaster Spider",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Netcaster Spider blocks a creature with flying, Netcaster Spider gets +2/+0 until end of turn.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "ba07abeb-ec3d-5cb4-af04-fc3c35426fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a600b97b-1851-4b1b-a2af-f80e0307c02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a600b97b-1851-4b1b-a2af-f80e0307c02c.jpg?1",
             "name": "Nissa, Voice of Zendikar",
             "text": "+1: Put a 0/1 green Plant creature token onto the battlefield.\n\u22122: Put a +1/+1 counter on each creature you control.\n\u22127: You gain X life and draw X cards, where X is the number of lands you control.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "9a833312-edfc-5c56-a113-064c89c6914d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b263fb-00b5-4050-85e1-cfc4018bb75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b263fb-00b5-4050-85e1-cfc4018bb75d.jpg?1",
             "name": "Nissa's Judgment",
             "text": "Support 2. (Put a +1/+1 counter on each of up to two target creatures.)\nChoose up to one target creature an opponent controls. Each creature you control with a +1/+1 counter on it deals damage equal to its power to that creature.",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "2beb9411-5d69-59b1-bd71-ba806a0d6a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613513ea-55dd-4ae8-93b2-247e468112a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613513ea-55dd-4ae8-93b2-247e468112a6.jpg?1",
             "name": "Oath of Nissa",
             "text": "When Oath of Nissa enters the battlefield, look at the top three cards of your library. You may reveal a creature, land, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nYou may spend mana as though it were mana of any color to cast planeswalker spells.",
             "colours": [
@@ -4614,7 +4614,7 @@
         },
         {
             "id": "ebb0e013-49e1-55f5-ab3c-434604171f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c8057f-b45b-4f67-90cd-c808b5e9cbfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c8057f-b45b-4f67-90cd-c808b5e9cbfa.jpg?1",
             "name": "Pulse of Murasa",
             "text": "Return target creature or land card from a graveyard to its owner's hand. You gain 6 life.",
             "colours": [
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "cd5bffba-e3e9-568d-bb42-e644a94760e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df4803-b32d-43ae-ac68-b72e45e10b0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33df4803-b32d-43ae-ac68-b72e45e10b0c.jpg?1",
             "name": "Saddleback Lagac",
             "text": "When Saddleback Lagac enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "e2090566-f510-5758-8ca3-19f6e03ab1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4736b3-d6ce-4a16-bcb7-67780caeb78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4736b3-d6ce-4a16-bcb7-67780caeb78c.jpg?1",
             "name": "Seed Guardian",
             "text": "Reach\nWhen Seed Guardian dies, put an X/X green Elemental creature token onto the battlefield, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "69d725fd-6e09-587b-b6bd-bcdb425df73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1ff9b-306d-47c3-9334-371e4482370b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad1ff9b-306d-47c3-9334-371e4482370b.jpg?1",
             "name": "Sylvan Advocate",
             "text": "Vigilance\nAs long as you control six or more lands, Sylvan Advocate and land creatures you control get +2/+2.",
             "colours": [
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "601e3ea8-641e-53fe-b2eb-97a039a3572e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073e75b-b432-41a5-a71e-d169fecf774f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073e75b-b432-41a5-a71e-d169fecf774f.jpg?1",
             "name": "Tajuru Pathwarden",
             "text": "Vigilance, trample",
             "colours": [
@@ -4786,7 +4786,7 @@
         },
         {
             "id": "8061e89b-f6e1-5691-9b54-ed5d7be8d490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a1fc4b-ec68-4fd1-af0f-6ccc8c6dee89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a1fc4b-ec68-4fd1-af0f-6ccc8c6dee89.jpg?1",
             "name": "Vines of the Recluse",
             "text": "Target creature gets +1/+2 and gains reach until end of turn. Untap it. (A creature with reach can block creatures with flying.)",
             "colours": [
@@ -4818,7 +4818,7 @@
         },
         {
             "id": "fe343165-b53d-54b0-a97e-4a7ceedd5609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f02bc3-b565-4a38-8313-eb47ff31db8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f02bc3-b565-4a38-8313-eb47ff31db8d.jpg?1",
             "name": "Zendikar Resurgent",
             "text": "Whenever you tap a land for mana, add one mana to your mana pool of any type that land produced. (The types of mana are white, blue, black, red, green, and colorless.)\nWhenever you cast a creature spell, draw a card.",
             "colours": [
@@ -4850,7 +4850,7 @@
         },
         {
             "id": "9c212646-876b-5b14-b23e-04d5983d0e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3931db42-3773-4aae-b6eb-2209e7312f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3931db42-3773-4aae-b6eb-2209e7312f8c.jpg?1",
             "name": "Flayer Drone",
             "text": "Devoid (This card has no color.)\nFirst strike\nWhenever another colorless creature enters the battlefield under your control, target opponent loses 1 life.",
             "colours": [],
@@ -4884,7 +4884,7 @@
         },
         {
             "id": "0812faca-0d90-57c9-bb5f-53223e207038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5bf575-6d09-4cb0-8fe0-8e49d2c39fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5bf575-6d09-4cb0-8fe0-8e49d2c39fd5.jpg?1",
             "name": "Mindmelter",
             "text": "Devoid (This card has no color.)\nMindmelter can't be blocked.\n{3}{C}: Target opponent exiles a card from his or her hand. Activate this ability only any time you could cast a sorcery. ({C} represents colorless mana.)",
             "colours": [],
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "6861bcef-3e68-5cd8-a612-94da5cc99379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e37e2-a4bd-4f90-9191-3125784a3369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2e37e2-a4bd-4f90-9191-3125784a3369.jpg?1",
             "name": "Void Grafter",
             "text": "Devoid (This card has no color.)\nFlash (You may cast this spell any time you could cast an instant.)\nWhen Void Grafter enters the battlefield, another target creature you control gains hexproof until end of turn.",
             "colours": [],
@@ -4952,7 +4952,7 @@
         },
         {
             "id": "77a37e8a-1035-5d19-9fd1-a453f82b734f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b5893d-6df6-4cae-ae70-d02d443d1740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b5893d-6df6-4cae-ae70-d02d443d1740.jpg?1",
             "name": "Ayli, Eternal Pilgrim",
             "text": "Deathtouch\n{1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.\n{1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate this ability only if you have at least 10 life more than your starting life total.",
             "colours": [
@@ -4991,7 +4991,7 @@
         },
         {
             "id": "268d267a-9cd2-5b8b-92bc-cb0e35b868a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8811d210-23e2-4318-9730-7ee3b2021c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8811d210-23e2-4318-9730-7ee3b2021c68.jpg?1",
             "name": "Baloth Null",
             "text": "When Baloth Null enters the battlefield, return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -5028,7 +5028,7 @@
         },
         {
             "id": "77981902-4770-5656-8fdf-582c237dfe74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544247d-1f8f-443f-a4c4-d8461db28a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5544247d-1f8f-443f-a4c4-d8461db28a79.jpg?1",
             "name": "Cliffhaven Vampire",
             "text": "Flying\nWhenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "e45d56d0-f2bc-5f47-98ff-ef9cdd407830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d920b4-81ab-45be-b763-b6114b879357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d920b4-81ab-45be-b763-b6114b879357.jpg?1",
             "name": "Joraga Auxiliary",
             "text": "{4}{G}{W}: Support 2. (Put a +1/+1 counter on each of up to two other target creatures.)",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "98a3a425-9181-5b4e-b854-c8eda0c9c79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900d3af7-a03f-4173-8a8a-bd146dec9c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900d3af7-a03f-4173-8a8a-bd146dec9c0f.jpg?1",
             "name": "Jori En, Ruin Diver",
             "text": "Whenever you cast your second spell each turn, draw a card.",
             "colours": [
@@ -5143,7 +5143,7 @@
         },
         {
             "id": "1c8c07db-4ce5-5831-b9a6-934b1916bc6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27ff523-0ff3-480d-ae95-ff5e04483e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27ff523-0ff3-480d-ae95-ff5e04483e40.jpg?1",
             "name": "Mina and Denn, Wildborn",
             "text": "You may play an additional land on each of your turns.\n{R}{G}, Return a land you control to its owner's hand: Target creature gains trample until end of turn.",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "7971f30c-a3c4-54a3-9834-9fc5274253b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473fe01-83f6-4432-ab01-f7953d2ca904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473fe01-83f6-4432-ab01-f7953d2ca904.jpg?1",
             "name": "Reflector Mage",
             "text": "When Reflector Mage enters the battlefield, return target creature an opponent controls to its owner's hand. That creature's owner can't cast spells with the same name as that creature until your next turn.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "0d752b8a-98a5-5be1-acee-086712880731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a52252-46b6-42e5-8cb5-c4f823cd0bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a52252-46b6-42e5-8cb5-c4f823cd0bf5.jpg?1",
             "name": "Relentless Hunter",
             "text": "{1}{R}{G}: Relentless Hunter gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -5256,7 +5256,7 @@
         },
         {
             "id": "9a3d9f28-9497-5cf4-879d-c74b070f0ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba1b45-d8ae-42fd-b30f-c904640ab173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bba1b45-d8ae-42fd-b30f-c904640ab173.jpg?1",
             "name": "Stormchaser Mage",
             "text": "Flying, haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -5293,7 +5293,7 @@
         },
         {
             "id": "e3bbdb4f-719d-5740-81f7-40e0607e6056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47bcb1-b028-4be8-9710-7c390cb984ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d47bcb1-b028-4be8-9710-7c390cb984ce.jpg?1",
             "name": "Weapons Trainer",
             "text": "Other creatures you control get +1/+0 as long as you control an Equipment.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "df7f1a01-8d94-52ef-b028-17744fd980fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3d19ff-b618-4b07-99a8-ea6e7ee72459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3d19ff-b618-4b07-99a8-ea6e7ee72459.jpg?1",
             "name": "Bone Saw",
             "text": "Equipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "b3442430-cf71-5c56-b072-6ee3045e192c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521ee576-5a51-4353-af38-c461f05d66ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521ee576-5a51-4353-af38-c461f05d66ce.jpg?1",
             "name": "Captain's Claws",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature attacks, put a 1/1 white Kor Ally creature token onto the battlefield tapped and attacking.\nEquip {1}",
             "colours": [],
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "55b003c0-6916-5323-8b6c-ac15e4b8bccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acbc14b-89e6-44ef-ae12-e2049adc06b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acbc14b-89e6-44ef-ae12-e2049adc06b1.jpg?1",
             "name": "Captain's Claws",
             "text": "",
             "colours": [],
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "4766fd45-18f2-5b60-8243-e33b38e76b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e54603-af67-497f-afe0-88cfa4d00095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e54603-af67-497f-afe0-88cfa4d00095.jpg?1",
             "name": "Chitinous Cloak",
             "text": "Equipped creature gets +2/+2 and has menace. (It can't be blocked except by two or more creatures.)\nEquip {3}",
             "colours": [],
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "8623a0ae-1901-5191-a3e7-4c2b22a91ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f827f92-1df6-4fd0-aa61-ec2e53476f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f827f92-1df6-4fd0-aa61-ec2e53476f9c.jpg?1",
             "name": "Hedron Crawler",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)",
             "colours": [],
@@ -5485,7 +5485,7 @@
         },
         {
             "id": "e8082b2b-2708-5251-bf63-3fb41c33afe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6618a854-7d9c-4e57-b959-4c0259cb4d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6618a854-7d9c-4e57-b959-4c0259cb4d97.jpg?1",
             "name": "Seer's Lantern",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{2}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [],
@@ -5513,7 +5513,7 @@
         },
         {
             "id": "799a21a6-139f-5373-b91a-55d3a8e0e8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5b78f5-6a49-4433-a42b-5abf5ea60919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae5b78f5-6a49-4433-a42b-5abf5ea60919.jpg?1",
             "name": "Stoneforge Masterwork",
             "text": "Equipped creature gets +1/+1 for each other creature you control that shares a creature type with it.\nEquip {2}",
             "colours": [],
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "d9a6d0b2-14c4-5afd-8b59-224cee962374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c90f49-d1eb-420e-bfb6-b834a496860d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c90f49-d1eb-420e-bfb6-b834a496860d.jpg?1",
             "name": "Strider Harness",
             "text": "Equipped creature gets +1/+1 and has haste.\nEquip {1}",
             "colours": [],
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "7abe3511-24fa-5dd2-b1f9-ddef75132d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949f41a0-9082-4682-88b8-a29fbcb48d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949f41a0-9082-4682-88b8-a29fbcb48d5d.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "6a1fa2aa-d923-5183-aa8a-a74f7252986c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7043e193-8051-4f1b-9633-9c1f250d3607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7043e193-8051-4f1b-9633-9c1f250d3607.jpg?1",
             "name": "Corrupted Crossroads",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}, Pay 1 life: Add one mana of any color to your mana pool. Spend this mana only to cast a spell with devoid.",
             "colours": [],
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "6a4c5895-45b8-57eb-af4a-a00aac5d47ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d491c13c-43e3-4ca3-b888-4edd34dfe14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d491c13c-43e3-4ca3-b888-4edd34dfe14a.jpg?1",
             "name": "Crumbling Vestige",
             "text": "Crumbling Vestige enters the battlefield tapped.\nWhen Crumbling Vestige enters the battlefield, add one mana of any color to your mana pool.\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)",
             "colours": [],
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "925a248d-8407-589d-b56b-8ca45e039f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef11b54-205a-48e9-92d0-5d416be869ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef11b54-205a-48e9-92d0-5d416be869ef.jpg?1",
             "name": "Hissing Quagmire",
             "text": "Hissing Quagmire enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.\n{1}{B}{G}: Hissing Quagmire becomes a 2/2 black and green Elemental creature with deathtouch until end of turn. It's still a land.",
             "colours": [],
@@ -5691,7 +5691,7 @@
         },
         {
             "id": "711dc524-f104-5a0c-ac6b-de5dc4ca8e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08c317-6f2d-47e3-ab5b-8af73fd3e404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf08c317-6f2d-47e3-ab5b-8af73fd3e404.jpg?1",
             "name": "Holdout Settlement",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5719,7 +5719,7 @@
         },
         {
             "id": "bb39ca73-b1a8-5e0b-9472-bd221a33ede4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5bedf1-92b6-465c-afc2-ce8e150a5e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5bedf1-92b6-465c-afc2-ce8e150a5e57.jpg?1",
             "name": "Meandering River",
             "text": "Meandering River enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "1b26b32d-fc88-5bdd-9914-b14f90fdfac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbea2b5-eed3-464b-9d5c-9591f309f298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbea2b5-eed3-464b-9d5c-9591f309f298.jpg?1",
             "name": "Mirrorpool",
             "text": "Mirrorpool enters the battlefield tapped.\n{T}: Add {C} to your mana pool.\n{2}{C}, {T}, Sacrifice Mirrorpool: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}{C}, {T}, Sacrifice Mirrorpool: Put a token onto the battlefield that's a copy of target creature you control.",
             "colours": [],
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "cde10a13-c29d-5064-8950-9c755bffacf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73700c-fa62-42be-aaca-5f8a50af20db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d73700c-fa62-42be-aaca-5f8a50af20db.jpg?1",
             "name": "Needle Spires",
             "text": "Needle Spires enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.\n{2}{R}{W}: Needle Spires becomes a 2/1 red and white Elemental creature with double strike until end of turn. It's still a land.",
             "colours": [],
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "efa59d83-f63e-504e-92ab-8d6bc8c9cbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed86e5-5631-401b-8820-9685f8296134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fed86e5-5631-401b-8820-9685f8296134.jpg?1",
             "name": "Ruins of Oran-Rief",
             "text": "Ruins of Oran-Rief enters the battlefield tapped.\n{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{T}: Put a +1/+1 counter on target colorless creature that entered the battlefield this turn.",
             "colours": [],
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "5b34a47a-af85-5ebb-9f9a-e253ef389863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd42576b-9de5-4d77-9d30-1ef5b5a4fd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd42576b-9de5-4d77-9d30-1ef5b5a4fd73.jpg?1",
             "name": "Sea Gate Wreckage",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{2}{C}, {T}: Draw a card. Activate this ability only if you have no cards in hand.",
             "colours": [],
@@ -5865,7 +5865,7 @@
         },
         {
             "id": "ce3c4606-269d-5b55-8fa2-bb7eadebe7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479a246-21ac-490a-aefb-6ed72aabdb88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479a246-21ac-490a-aefb-6ed72aabdb88.jpg?1",
             "name": "Submerged Boneyard",
             "text": "Submerged Boneyard enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "82557838-9203-5d7b-9b16-989746c677a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d05ff7-f071-4eb3-b10a-203741abdf10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d05ff7-f071-4eb3-b10a-203741abdf10.jpg?1",
             "name": "Timber Gorge",
             "text": "Timber Gorge enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "3f509c0c-13a5-5f74-8c0e-c0edd94008c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42787d2b-3f9d-4c29-9ece-e65544eb1340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42787d2b-3f9d-4c29-9ece-e65544eb1340.jpg?1",
             "name": "Tranquil Expanse",
             "text": "Tranquil Expanse enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -5958,7 +5958,7 @@
         },
         {
             "id": "43a79012-3276-58d6-8556-a43e5845d54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87db92c1-ac17-4e32-840e-7ccbcef31bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87db92c1-ac17-4e32-840e-7ccbcef31bc6.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {C} to your mana pool. ({C} represents colorless mana.)\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -5986,7 +5986,7 @@
         },
         {
             "id": "8342b862-3a09-5c07-8697-3b4e235566e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0ee251-6c79-499b-8366-c281c989b061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd0ee251-6c79-499b-8366-c281c989b061.jpg?1",
             "name": "Wandering Fumarole",
             "text": "Wandering Fumarole enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.\n{2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with \"{0}: Switch this creature's power and toughness until end of turn.\" It's still a land.",
             "colours": [],
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "b14af286-9338-5c24-9715-c4c9479e8d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7019912c-bd9b-4b96-9388-400794909aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7019912c-bd9b-4b96-9388-400794909aa1.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "8da5d0bf-9f7c-5d8b-89a3-2fa3055cf7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc070d3-4b83-4684-9caf-063e5c473a77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc070d3-4b83-4684-9caf-063e5c473a77.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6084,7 +6084,7 @@
         },
         {
             "id": "7015e402-ad21-5e10-9681-afc52e43a0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b215fe-0d97-4ca1-9490-174220fd454b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b215fe-0d97-4ca1-9490-174220fd454b.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6118,7 +6118,7 @@
         },
         {
             "id": "d2c827be-6188-558c-ae9d-317a50436ab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60682c00-c661-4a9d-8326-f3f014a04e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60682c00-c661-4a9d-8326-f3f014a04e3e.jpg?1",
             "name": "Wastes",
             "text": "C",
             "colours": [],
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "5475891d-3ff7-5af1-9f29-318cd6231bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03edf14-3495-4f61-ad73-f16e9456472c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03edf14-3495-4f61-ad73-f16e9456472c.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "a6be99bf-0852-56eb-a8bf-9064c3303bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88da33f-a944-4cc4-978e-3858c2e17e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88da33f-a944-4cc4-978e-3858c2e17e3a.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6213,7 +6213,7 @@
         },
         {
             "id": "e1fee3c2-87e9-5c7b-bd2e-c038c4a28165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e69ee5-ea72-4f0b-91fe-152b1459e318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e69ee5-ea72-4f0b-91fe-152b1459e318.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "47209d9f-c753-5476-afe1-e7451b5fdf9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2f495f-3b50-4b59-a2aa-d33c1767cf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2f495f-3b50-4b59-a2aa-d33c1767cf7c.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "eeab57a1-7941-5786-b834-0b974f173877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e91066-63ee-40f7-aa69-0603b61ea49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e91066-63ee-40f7-aa69-0603b61ea49e.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "5e22c8ed-9cfc-5244-aaa7-d49109b2b414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b7443e-7eb2-4fcb-8114-23bad3b3bf51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b7443e-7eb2-4fcb-8114-23bad3b3bf51.jpg?1",
             "name": "Eldrazi Scion",
             "text": "",
             "colours": [],
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "bd954ba2-c399-5d83-9c8b-c0503991e723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f407ef-2b08-45e9-a45e-128cf0a63839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f407ef-2b08-45e9-a45e-128cf0a63839.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "4f38d11a-7a5e-54fd-b4ca-04ff6873b36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bde78b-98d1-4864-899b-fc2f945ce06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bde78b-98d1-4864-899b-fc2f945ce06b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "0bfa7d0c-9a5d-58a2-aa93-ffe0f6aa1f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f27f7-0248-4c04-8022-41073966e4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6f27f7-0248-4c04-8022-41073966e4d8.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "9cd481a2-eed9-5d16-a789-6228b9fbc5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db67bc06-b6c9-49a0-beef-4d35842497cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db67bc06-b6c9-49a0-beef-4d35842497cb.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -6473,7 +6473,7 @@
         },
         {
             "id": "5d511409-a4ae-50f9-8cc7-c7fd0ec6fda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8501a910-e181-4f85-ad34-d2a099257148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8501a910-e181-4f85-ad34-d2a099257148.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/ONE.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ONE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7966a171-4458-5fb1-aa99-b8486938798a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd8dd4e-6892-49d7-8fae-97d04f9f6c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd8dd4e-6892-49d7-8fae-97d04f9f6c84.jpg?1",
             "name": "Against All Odds",
             "text": "Choose one or both \u2014\n\u2022 Exile target artifact or creature you control, then return it to the battlefield under its owner's control.\n\u2022 Return target artifact or creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "ec921ff1-d254-5831-bd17-d09f2ca025dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04baad61-1b51-4602-9e33-0de4a9f34793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04baad61-1b51-4602-9e33-0de4a9f34793.jpg?1",
             "name": "Annex Sentry",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Annex Sentry enters the battlefield, exile target artifact or creature an opponent controls with mana value 3 or less until Annex Sentry leaves the battlefield.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "95c002c0-293c-57de-8a07-b96b20ee146e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a973487-5def-4771-bb77-5748cbd2f469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a973487-5def-4771-bb77-5748cbd2f469.jpg?1",
             "name": "Apostle of Invasion",
             "text": "Flying\nCorrupted \u2014 As long as an opponent has three or more poison counters, Apostle of Invasion has double strike.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "4c7e3e56-53ff-5ae8-812c-e685dc7a5a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ef3cfa-63e6-4450-af65-da7f05d13cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ef3cfa-63e6-4450-af65-da7f05d13cf3.jpg?1",
             "name": "Basilica Shepherd",
             "text": "Flying\nWhen Basilica Shepherd enters the battlefield, create two 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by them also get a poison counter.)",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "c6ab8992-3cd8-5aea-a843-bccd39ce53c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd8d2b8-4caf-4349-9538-0dfbebf0ce1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd8d2b8-4caf-4349-9538-0dfbebf0ce1b.jpg?1",
             "name": "Bladed Ambassador",
             "text": "Bladed Ambassador enters the battlefield with an oil counter on it.\n{1}, Remove an oil counter from Bladed Ambassador: Bladed Ambassador gains indestructible until end of turn.",
             "colours": [
@@ -180,7 +180,7 @@
         },
         {
             "id": "2ebe9fe7-32ff-5750-9051-e2e884836399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42060b9d-de58-485e-817a-1e64839943aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42060b9d-de58-485e-817a-1e64839943aa.jpg?1",
             "name": "Charge of the Mites",
             "text": "Choose one \u2014\n\u2022 Charge of the Mites deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Create two 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by them also get a poison counter.)",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "98301b7b-e585-515d-9d05-19b618ee103b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb29a69-3e42-4268-8026-f01072d7b56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb29a69-3e42-4268-8026-f01072d7b56c.jpg?1",
             "name": "Compleat Devotion",
             "text": "Target creature you control gets +2/+2 until end of turn. If that creature has toxic, draw a card.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "64471693-5444-5652-951b-7373c253f66a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aace4c44-7250-414b-aac4-df042a1e2e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aace4c44-7250-414b-aac4-df042a1e2e1d.jpg?1",
             "name": "Crawling Chorus",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Crawling Chorus dies, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "194fcbca-3f8a-512c-9ebc-6c5fe57a8736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444440-a9e6-4583-a289-9f0571a98093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56444440-a9e6-4583-a289-9f0571a98093.jpg?1",
             "name": "Duelist of Deep Faith",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nAs long as it's your turn, Duelist of Deep Faith has first strike.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "0da82b07-e6e4-5679-a50b-fe268459bd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dcab01-1d13-4dfc-ae2f-fbaa3dd35087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dcab01-1d13-4dfc-ae2f-fbaa3dd35087.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "a4b710c3-6a4e-596e-8c92-bcffae689084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905f0dd4-0197-45f8-8e7f-396d6dcef600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905f0dd4-0197-45f8-8e7f-396d6dcef600.jpg?1",
             "name": "The Eternal Wanderer",
             "text": "No more than one creature can attack The Eternal Wanderer each combat.\n+1: Exile up to one target artifact or creature. Return that card to the battlefield under its owner's control at the beginning of that player's next end step.\n0: Create a 2/2 white Samurai creature token with double strike.\n\u22124: For each player, choose a creature that player controls. Each player sacrifices all creatures they control not chosen this way.",
             "colours": [
@@ -398,7 +398,7 @@
         },
         {
             "id": "76088f0c-f5d2-560e-a129-0d1b47b8dce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134aecf0-dc48-4fb3-8c8b-4e5272077856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134aecf0-dc48-4fb3-8c8b-4e5272077856.jpg?1",
             "name": "Flensing Raptor",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Flensing Raptor enters the battlefield, another target creature you control with toxic gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -433,7 +433,7 @@
         },
         {
             "id": "048f38ad-7d42-50ce-b6d5-e43f677f4299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4057210-ef07-4496-94c8-95c3b807c23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4057210-ef07-4496-94c8-95c3b807c23c.jpg?1",
             "name": "Goldwarden's Helm",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +0/+1.\nEquip {1}{W} ({1}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -467,7 +467,7 @@
         },
         {
             "id": "cbbc084c-b6a2-5e55-b5de-78de7ebac743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c498dbf9-c68c-400c-9349-c3c3fc8efcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c498dbf9-c68c-400c-9349-c3c3fc8efcae.jpg?1",
             "name": "Hexgold Hoverwings",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature has flying.\nCreatures you control that are equipped get +1/+0.\nEquip {2}{W}",
             "colours": [
@@ -501,7 +501,7 @@
         },
         {
             "id": "c7bbfb6a-0674-5ba7-b732-004452611005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3cf4c4f-bda6-454c-991d-429c0dca0e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3cf4c4f-bda6-454c-991d-429c0dca0e85.jpg?1",
             "name": "Incisor Glider",
             "text": "Flying\nCorrupted \u2014 Whenever Incisor Glider attacks, if an opponent has three or more poison counters, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -537,7 +537,7 @@
         },
         {
             "id": "4755c4b0-fa5a-5910-b893-4de8428705e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d051bfc7-b402-444d-896e-c3a9562cdb0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d051bfc7-b402-444d-896e-c3a9562cdb0d.jpg?1",
             "name": "Indoctrination Attendant",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Indoctrination Attendant enters the battlefield, you may return another permanent you control to its owner's hand. If you do, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -572,7 +572,7 @@
         },
         {
             "id": "7205a8ce-5119-5095-84aa-46853b1bd9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f03d6bf-cbba-4ad7-8cec-065a47f03dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f03d6bf-cbba-4ad7-8cec-065a47f03dbe.jpg?1",
             "name": "Infested Fleshcutter",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by it also get a poison counter.)\nEquip {2}{W}",
             "colours": [
@@ -606,7 +606,7 @@
         },
         {
             "id": "f1c443b6-a0cd-551f-9e31-cd9d1c1efccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00ea7bb-705b-4669-bb2a-560bed04b14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00ea7bb-705b-4669-bb2a-560bed04b14a.jpg?1",
             "name": "Jawbone Duelist",
             "text": "Double strike\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "2b4c0cce-eda8-5db9-9677-20914c4701b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945d283d-4592-485f-808a-6e5a721f3cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/945d283d-4592-485f-808a-6e5a721f3cf7.jpg?1",
             "name": "Kemba, Kha Enduring",
             "text": "Whenever Kemba, Kha Enduring or another Cat enters the battlefield under your control, attach up to one target Equipment you control to that creature.\nEquipped creatures you control get +1/+1.\n{3}{W}{W}: Create a 2/2 white Cat creature token.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "7164f4af-364f-508f-b066-4a52e4095173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ae13df-670e-49a0-99b0-baf908ac9eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ae13df-670e-49a0-99b0-baf908ac9eb4.jpg?1",
             "name": "Leonin Lightbringer",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAs long as Leonin Lightbringer is equipped, it gets +1/+1.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "ce067242-e0c0-5d99-bc04-044883a6fcec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a707d-4090-4a74-91aa-60fbd8a4ae96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544a707d-4090-4a74-91aa-60fbd8a4ae96.jpg?1",
             "name": "Mandible Justiciar",
             "text": "Lifelink\nWhenever another artifact enters the battlefield under your control, Mandible Justiciar gets +1/+1 until end of turn.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "59e8cbcd-d0cf-5950-bd16-54b89aada7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3006ea5a-5391-41eb-b0c8-092741dca2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3006ea5a-5391-41eb-b0c8-092741dca2eb.jpg?1",
             "name": "Mirran Bardiche",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +2/+1 and has vigilance.\nEquip {3}{W} ({3}{W}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "9082dc4a-b3d5-599d-80e5-0fd052d19e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296a455-21d5-498e-9029-2bdf0da855a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296a455-21d5-498e-9029-2bdf0da855a8.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n{1}{PW}{PW}, Sacrifice two other artifacts and/or creatures: Put an indestructible counter on Mondrak, Glory Dominus. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -827,7 +827,7 @@
         },
         {
             "id": "7d6c732b-3b16-52d4-b2c1-9ab7d00d6e4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeebc0ab-89fb-47d5-a20f-8f1fe5e3c149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeebc0ab-89fb-47d5-a20f-8f1fe5e3c149.jpg?1",
             "name": "Norn's Wellspring",
             "text": "Whenever a creature you control dies, scry 1 and put an oil counter on Norn's Wellspring.\n{1}, {T}, Remove two oil counters from Norn's Wellspring: Draw a card.",
             "colours": [
@@ -861,7 +861,7 @@
         },
         {
             "id": "5c525b35-f1fb-5c4a-be30-bb27cb85a7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c938a0f-531c-4293-a89c-c7440d5acc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c938a0f-531c-4293-a89c-c7440d5acc5d.jpg?1",
             "name": "Orthodoxy Enforcer",
             "text": "Vigilance\nOrthodoxy Enforcer gets +2/+0 as long as you control two or more artifacts.",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "d2712fe8-6850-52ad-b318-6f72140e766f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da03224-c1af-438f-96c2-b0e41e1070b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da03224-c1af-438f-96c2-b0e41e1070b7.jpg?1",
             "name": "Ossification",
             "text": "Enchant basic land you control\nWhen Ossification enters the battlefield, exile target creature or planeswalker an opponent controls until Ossification leaves the battlefield.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "ec217e50-10f3-507d-b2ae-7ef2315b6937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18780ce-add4-4346-8028-4bc3b4099d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18780ce-add4-4346-8028-4bc3b4099d71.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "Flying\nIf damage would be dealt to Phyrexian Vindicator, prevent that damage. When damage is prevented this way, Phyrexian Vindicator deals that much damage to any other target.",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "a38930e1-f11d-5674-8c61-91a2fc1c09eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee69a1f-aeed-4eb4-8987-fa720fc99715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee69a1f-aeed-4eb4-8987-fa720fc99715.jpg?1",
             "name": "Planar Disruption",
             "text": "Enchant artifact, creature, or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1005,7 +1005,7 @@
         },
         {
             "id": "610c9cb6-2b51-5307-8e81-718d4c723d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472a635a-a581-4c00-89d6-464f30887944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472a635a-a581-4c00-89d6-464f30887944.jpg?1",
             "name": "Plated Onslaught",
             "text": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nCreatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "e36f72ed-cf67-54c0-a81f-ab9a9a557d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409bacf-b728-473d-bf9b-41fdf364e783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0409bacf-b728-473d-bf9b-41fdf364e783.jpg?1",
             "name": "Porcelain Zealot",
             "text": "At the beginning of combat on your turn, target creature you control gets +1/+1 until end of turn. If that creature has toxic, instead it gets +2/+2 until end of turn.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "a49edb48-2529-551b-9402-a7ce753b3f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc4b5ca-557e-4465-9725-9e7a15590258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc4b5ca-557e-4465-9725-9e7a15590258.jpg?1",
             "name": "Resistance Reunited",
             "text": "Target creature gets +2/+2 until end of turn.\nEquipped creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -1104,7 +1104,7 @@
         },
         {
             "id": "9d8c43ef-8e60-5c20-8cc4-9407f5995f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebad4fcc-4f78-48dc-b236-c78c22edc1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebad4fcc-4f78-48dc-b236-c78c22edc1e9.jpg?1",
             "name": "Sinew Dancer",
             "text": "{3}{W}, {T}: Tap target creature.\nCorrupted \u2014 {W}, {T}: Tap target creature. Activate only if an opponent has three or more poison counters.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "aed49ca5-02ad-54b0-8c4a-0b20f104e7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b565da-a49b-479c-b0c4-8ff3dd20cc0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b565da-a49b-479c-b0c4-8ff3dd20cc0b.jpg?1",
             "name": "Skrelv, Defector Mite",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nSkrelv, Defector Mite can't block.\n{PW}, {T}: Choose a color. Another target creature you control gains toxic 1 and hexproof from that color until end of turn. It can't be blocked by creatures of that color this turn. ({PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "930b0d2e-10dc-5fd7-a510-feaaeeaa7ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd77ec-fc81-41d5-934f-c3dd844cb053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd77ec-fc81-41d5-934f-c3dd844cb053.jpg?1",
             "name": "Skrelv's Hive",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"\nCorrupted \u2014 As long as an opponent has three or more poison counters, creatures you control with toxic have lifelink.",
             "colours": [
@@ -1217,7 +1217,7 @@
         },
         {
             "id": "465e5154-c390-5e1d-b1ce-34027792b5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c740d-260d-4dfa-b6b3-9a1527538f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b62c740d-260d-4dfa-b6b3-9a1527538f89.jpg?1",
             "name": "Swooping Lookout",
             "text": "Flying, vigilance",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "fdbc75d9-2c3b-5839-a231-8952c8867a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0b3308-9c0b-4461-9094-38deec20e1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0b3308-9c0b-4461-9094-38deec20e1bc.jpg?1",
             "name": "Vanish into Eternity",
             "text": "This spell costs {3} more to cast if it targets a creature.\nExile target nonland permanent.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "00c63beb-6c64-5947-88a6-066e09a11a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d8d87-e32f-4ad9-8d72-d1b88cd14510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f9d8d87-e32f-4ad9-8d72-d1b88cd14510.jpg?1",
             "name": "Veil of Assimilation",
             "text": "Whenever Veil of Assimilation or another artifact enters the battlefield under your control, target creature you control gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -1317,7 +1317,7 @@
         },
         {
             "id": "4426392e-513e-5289-9d7f-174fc159c0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff13d77-8133-4328-b91e-efce229bc331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff13d77-8133-4328-b91e-efce229bc331.jpg?1",
             "name": "White Sun's Twilight",
             "text": "You gain X life. Create X 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" If X is 5 or more, destroy all other creatures. (Players dealt combat damage by a creature with toxic 1 also get a poison counter.)",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "8d1034ad-59ec-574c-99dd-c1acbd7ad483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a419ba1-7bd3-48e3-8f88-d9f833b25d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a419ba1-7bd3-48e3-8f88-d9f833b25d6d.jpg?1",
             "name": "Zealot's Conviction",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nCorrupted \u2014 As long as an opponent has three or more poison counters, enchanted creature gets an additional +1/+0 and has first strike.",
             "colours": [
@@ -1385,7 +1385,7 @@
         },
         {
             "id": "bade33e1-a75b-59ff-86ff-46d937e242f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57551332-e2a4-4e6a-9bd8-e3a9baafcd17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57551332-e2a4-4e6a-9bd8-e3a9baafcd17.jpg?1",
             "name": "Aspirant's Ascent",
             "text": "Until end of turn, target creature gets +1/+3 and gains flying and toxic 1. (Players dealt combat damage by that creature also get a poison counter.)",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "018bcf55-3b74-5331-8167-028b41f9e228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66988ca-29d5-45ea-8d68-c8e0e4c3ffb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66988ca-29d5-45ea-8d68-c8e0e4c3ffb1.jpg?1",
             "name": "Atmosphere Surgeon",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Atmosphere Surgeon.\nRemove an oil counter from Atmosphere Surgeon: Target creature gains flying until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "0523e6fd-35f5-511a-b124-0706f83321f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277aeb73-4c7c-4132-b9f9-55181d57e75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277aeb73-4c7c-4132-b9f9-55181d57e75d.jpg?1",
             "name": "Blade of Shared Souls",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nWhenever Blade of Shared Souls becomes attached to a creature, for as long as Blade of Shared Souls remains attached to it, you may have that creature become a copy of another target creature you control.\nEquip {2}",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "790a4b44-02cc-51a4-b763-a17d83a516cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a836e6b-6854-4f6f-bc78-2da1fd4dd224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a836e6b-6854-4f6f-bc78-2da1fd4dd224.jpg?1",
             "name": "Blue Sun's Twilight",
             "text": "Gain control of target creature with mana value X or less. If X is 5 or more, create a token that's a copy of that creature.",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "f3293a7f-1700-568a-b2c8-73f450f93758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d9d26-0c76-4a09-aa25-b32854e70c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9d9d26-0c76-4a09-aa25-b32854e70c0b.jpg?1",
             "name": "Bring the Ending",
             "text": "Counter target spell unless its controller pays {2}.\nCorrupted \u2014 Counter that spell instead if its controller has three or more poison counters.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "688e19c3-7a61-57dd-999f-e44e38efb17a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94378a2-cbde-4adf-b889-43e90fc6ba28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94378a2-cbde-4adf-b889-43e90fc6ba28.jpg?1",
             "name": "Chrome Prowler",
             "text": "Flash\nWhen Chrome Prowler enters the battlefield, tap target creature an opponent controls.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "86b8af57-606b-53c7-94cb-a035ec9117f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f932ddd3-beb4-4dc8-8c15-e1c9c2276986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f932ddd3-beb4-4dc8-8c15-e1c9c2276986.jpg?1",
             "name": "Distorted Curiosity",
             "text": "Corrupted \u2014 This spell costs {2} less to cast if an opponent has three or more poison counters.\nDraw two cards.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "71d990cd-9777-5b87-9eb4-4fab7d2af9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a2fcc9-2317-48a1-a5eb-234fb3300364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a2fcc9-2317-48a1-a5eb-234fb3300364.jpg?1",
             "name": "Encroaching Mycosynth",
             "text": "Nonland permanents you control are artifacts in addition to their other types. The same is true for permanent spells you control and nonland permanent cards you own that aren't on the battlefield.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "0b382265-73df-5d46-b2b1-b802d97075f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611497d2-83df-4c69-bbeb-6a807c686bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/611497d2-83df-4c69-bbeb-6a807c686bc4.jpg?1",
             "name": "Escaped Experiment",
             "text": "Whenever Escaped Experiment attacks, target creature an opponent controls gets -X/-0 until end of turn, where X is the number of artifacts you control.",
             "colours": [
@@ -1692,7 +1692,7 @@
         },
         {
             "id": "7470cbb7-3734-58d2-a2b5-fdaf47c7a604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e508ae5d-ffb5-4480-be90-a4394954b559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e508ae5d-ffb5-4480-be90-a4394954b559.jpg?1",
             "name": "Experimental Augury",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "2baf2518-4295-5ef4-a2ec-c952548f68ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4246b-ff59-44b2-acff-c0bb6e4cd6ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc4246b-ff59-44b2-acff-c0bb6e4cd6ac.jpg?1",
             "name": "Eye of Malcator",
             "text": "When Eye of Malcator enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\nWhenever another artifact enters the battlefield under your control, Eye of Malcator becomes a 4/4 Phyrexian Eye artifact creature until end of turn.",
             "colours": [
@@ -1758,7 +1758,7 @@
         },
         {
             "id": "cd298f35-d14b-52ba-90da-af4d97c3b2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272c9888-ef13-4d47-a4bc-f5239b357a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272c9888-ef13-4d47-a4bc-f5239b357a1b.jpg?1",
             "name": "Font of Progress",
             "text": "Font of Progress enters the battlefield with two oil counters on it.\n{3}, {T}: Target player mills X cards, where X is the number of oil counters on Font of Progress.",
             "colours": [
@@ -1790,7 +1790,7 @@
         },
         {
             "id": "0ac734f5-d42e-55ad-b38b-9cae1a9d00da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63517062-77da-4b60-aa24-f91553a81bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63517062-77da-4b60-aa24-f91553a81bed.jpg?1",
             "name": "Gitaxian Anatomist",
             "text": "When Gitaxian Anatomist enters the battlefield, you may tap it. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "c5c9e029-f09a-5152-b858-d7eedb2f486d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5e95f8-c04d-405f-bba4-e83a8f6bf463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5e95f8-c04d-405f-bba4-e83a8f6bf463.jpg?1",
             "name": "Gitaxian Raptor",
             "text": "Flying\nGitaxian Raptor enters the battlefield with three oil counters on it.\nRemove an oil counter from Gitaxian Raptor: Gitaxian Raptor gets +1/-1 until end of turn.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "28d82030-1f59-5b11-b377-f2f220845abc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22aaaec-bad5-43e9-8e92-9c4bde95fcfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22aaaec-bad5-43e9-8e92-9c4bde95fcfd.jpg?1",
             "name": "Glistener Seer",
             "text": "Glistener Seer enters the battlefield with three oil counters on it.\n{T}, Remove an oil counter from Glistener Seer: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "8959a8a8-7e7f-528b-9bfa-bb4fb81a0237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f516ee6-8f7b-40b2-82e5-9c4ea3e0a355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f516ee6-8f7b-40b2-82e5-9c4ea3e0a355.jpg?1",
             "name": "Ichor Synthesizer",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Ichor Synthesizer.\nAs long as Ichor Synthesizer has four or more oil counters on it, it gets +2/+0 and can't be blocked.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "42f5939f-4a62-5927-8b8b-c55f762b2fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c093ce0-2561-4847-ab58-f6f1650d743e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c093ce0-2561-4847-ab58-f6f1650d743e.jpg?1",
             "name": "Ichormoon Gauntlet",
             "text": "Planeswalkers you control have \"0: Proliferate\" and \"\u201312: Take an extra turn after this one.\"\nWhenever you cast a noncreature spell, choose a counter on target permanent. Put an additional counter of that kind on that permanent.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "7db75465-cffb-5742-a5b0-075766b2584e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e6a8d1-ae75-45bd-af62-9a622620cb5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e6a8d1-ae75-45bd-af62-9a622620cb5c.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "Compleated ({PU} can be paid with {U} or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Until your next turn, up to one target creature gets -3/-0.\n\u22122: Target player mills three cards. Then if a graveyard has twenty or more cards in it, you draw three cards. Otherwise, you draw a card.\n\u2212X: Target player mills three times X cards.",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "e6edc6de-0e72-5810-81e2-2e823ff06e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a7e5ff-ba81-4b45-933e-0ac747525ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a7e5ff-ba81-4b45-933e-0ac747525ab8.jpg?1",
             "name": "Malcator's Watcher",
             "text": "Flying, vigilance\nWhen Malcator's Watcher dies, draw a card.",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "9f2d52b0-51b8-5e1f-ba60-58c5b6238109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d392b2-1dac-432d-930c-66b238f7512b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0d392b2-1dac-432d-930c-66b238f7512b.jpg?1",
             "name": "Meldweb Curator",
             "text": "When Meldweb Curator enters the battlefield, put up to one target instant or sorcery card from your graveyard on top of your library.",
             "colours": [
@@ -2077,7 +2077,7 @@
         },
         {
             "id": "4bac64f0-c950-5182-b398-94afaea8e192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efd9b5-05e5-440f-b28c-658e461cf644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5efd9b5-05e5-440f-b28c-658e461cf644.jpg?1",
             "name": "Meldweb Strider",
             "text": "Vigilance\nMeldweb Strider enters the battlefield with an oil counter on it.\nRemove an oil counter from Meldweb Strider: It becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2111,7 +2111,7 @@
         },
         {
             "id": "031bcda4-05fc-5ceb-bd2f-11a110455f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf28c75d-1fb3-44cc-b651-5b2830e22add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf28c75d-1fb3-44cc-b651-5b2830e22add.jpg?1",
             "name": "Mercurial Spelldancer",
             "text": "Mercurial Spelldancer can't be blocked.\nWhenever you cast a noncreature spell, put an oil counter on Mercurial Spelldancer.\nWhenever Mercurial Spelldancer deals combat damage to a player, you may remove two oil counters from it. If you do, when you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "7556c708-8c3a-5965-8e82-9f62dede5c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28e27-78aa-48b1-96fa-edca1fbcfb77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac28e27-78aa-48b1-96fa-edca1fbcfb77.jpg?1",
             "name": "Mesmerizing Dose",
             "text": "Enchant creature\nWhen Mesmerizing Dose enters the battlefield, tap enchanted creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "ebe7cdaa-e84e-5a91-9720-d81942ddec11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4ad1cb-4bbb-4485-b322-0b003f06d034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4ad1cb-4bbb-4485-b322-0b003f06d034.jpg?1",
             "name": "Mindsplice Apparatus",
             "text": "Flash\nAt the beginning of your upkeep, put an oil counter on Mindsplice Apparatus.\nInstant and sorcery spells you cast cost {1} less to cast for each oil counter on Mindsplice Apparatus.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "a4134fde-a36b-535d-8072-69e9e58b392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360ca37b-5bbd-4923-a493-7674786a36af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360ca37b-5bbd-4923-a493-7674786a36af.jpg?1",
             "name": "Minor Misstep",
             "text": "Counter target spell with mana value 1 or less.",
             "colours": [
@@ -2248,7 +2248,7 @@
         },
         {
             "id": "867970b6-629d-576b-ad79-2e012ebee781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac625f30-ed91-4b21-ada8-aaa5b2ad79b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac625f30-ed91-4b21-ada8-aaa5b2ad79b8.jpg?1",
             "name": "Prologue to Phyresis",
             "text": "Each opponent gets a poison counter.\nDraw a card.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "0b198323-715c-5062-a9ac-4d996ee5472f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad0e96a-b4cc-4439-aab9-731a1036145d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad0e96a-b4cc-4439-aab9-731a1036145d.jpg?1",
             "name": "Quicksilver Fisher",
             "text": "Flying\nWhen Quicksilver Fisher enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -2318,7 +2318,7 @@
         },
         {
             "id": "b584cd9e-b373-576e-8ede-b8a79a58df7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ce5296-f28f-4105-9c79-b9c63ea720e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ce5296-f28f-4105-9c79-b9c63ea720e7.jpg?1",
             "name": "Reject Imperfection",
             "text": "Counter target spell. If that spell's mana value was 3 or less, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2350,7 +2350,7 @@
         },
         {
             "id": "97d2d04b-7491-5a02-8389-9a0712958e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326bff1-5370-4817-8370-6da87a061058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d326bff1-5370-4817-8370-6da87a061058.jpg?1",
             "name": "Serum Snare",
             "text": "Return target nonland permanent to its owner's hand. If that permanent had mana value 3 or less, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "c25610de-84ad-538a-a0e0-80529aa1616f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa20112-2955-439d-8802-3a228ba0832e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa20112-2955-439d-8802-3a228ba0832e.jpg?1",
             "name": "Tamiyo's Immobilizer",
             "text": "Tamiyo's Immobilizer enters the battlefield with four oil counters on it.\n{T}, Remove an oil counter from Tamiyo's Immobilizer: Tap target artifact or creature.",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "8ae50d88-6d45-5a2d-bb90-790089ccb4b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb2d01-9a94-410c-8ab7-ca1b404ab5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb2d01-9a94-410c-8ab7-ca1b404ab5f0.jpg?1",
             "name": "Tamiyo's Logbook",
             "text": "{5}{U}, {T}: Draw a card. This ability costs {1} less to activate for each other artifact you control.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "35b1c00c-1e44-518d-bf58-0b1b20e12050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4b157-2c77-4355-8c65-78dec9d44c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d4b157-2c77-4355-8c65-78dec9d44c85.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "Flying\nIf you would proliferate, proliferate twice instead.\n{1}{PU}{PU}, Remove three counters from among other artifacts, creatures, and planeswalkers you control: Put an indestructible counter on Tekuthal, Inquiry Dominus. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -2487,7 +2487,7 @@
         },
         {
             "id": "f0064a60-e027-5ed9-9a08-7534f3541505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f0a63e-0866-423e-b917-fc7c71063021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f0a63e-0866-423e-b917-fc7c71063021.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "9b4095c2-24f7-5477-907d-dbd517777c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f912c4ec-08e9-4524-a2ba-98f6dfabdc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f912c4ec-08e9-4524-a2ba-98f6dfabdc18.jpg?1",
             "name": "Transplant Theorist",
             "text": "Whenever Transplant Theorist or another artifact enters the battlefield under your control, you may draw a card. If you do, discard a card.\n{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "35990d2c-954d-5c2a-9b8a-13eef00dc3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442442d-2e5d-4913-82d8-bab2f31541f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f442442d-2e5d-4913-82d8-bab2f31541f8.jpg?1",
             "name": "Trawler Drake",
             "text": "Flying\nTrawler Drake enters the battlefield with an oil counter on it.\nTrawler Drake gets +1/+1 for each oil counter on it.\nWhenever you cast a noncreature spell, put an oil counter on Trawler Drake.",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "2f64a1d6-d332-5154-99e7-881115850df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164b07e6-48ba-4789-bd8f-7cada1fec8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164b07e6-48ba-4789-bd8f-7cada1fec8a9.jpg?1",
             "name": "Unctus, Grand Metatect",
             "text": "Other blue creatures you control have \"Whenever this creature becomes tapped, draw a card, then discard a card.\"\nOther artifact creatures you control get +1/+1.\n{PU}: Until end of turn, target creature you control becomes a blue artifact in addition to its other colors and types. Activate only as a sorcery. ({PU} can be paid with either {U} or 2 life.)",
             "colours": [
@@ -2638,7 +2638,7 @@
         },
         {
             "id": "44ae9f8a-2ae0-5c11-8379-8a866a650a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30225e40-4bde-4e2e-b0f0-48ed16aebafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30225e40-4bde-4e2e-b0f0-48ed16aebafd.jpg?1",
             "name": "Unctus's Retrofitter",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Unctus's Retrofitter enters the battlefield, up to one target artifact you control becomes an artifact creature with base power and toughness 4/4 for as long as Unctus's Retrofitter remains on the battlefield.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "13d10813-b5c1-5091-9eaa-22889c148c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd244359-781e-4e1d-946d-243664f40c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd244359-781e-4e1d-946d-243664f40c7c.jpg?1",
             "name": "Vivisurgeon's Insight",
             "text": "Draw three cards. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "bda63558-1fd6-5dd2-8a1c-befd4822f8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a895f63f-3c59-4249-9346-55ef489944fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a895f63f-3c59-4249-9346-55ef489944fc.jpg?1",
             "name": "Watchful Blisterzoa",
             "text": "Flying\nWatchful Blisterzoa enters the battlefield with an oil counter on it.\nWhen Watchful Blisterzoa dies, draw cards equal to the number of oil counters on it.",
             "colours": [
@@ -2740,7 +2740,7 @@
         },
         {
             "id": "d340266c-7582-587f-a8c0-73e3e2dee903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c9005c-0574-4b75-8dbf-0a6641c3ae33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c9005c-0574-4b75-8dbf-0a6641c3ae33.jpg?1",
             "name": "Ambulatory Edifice",
             "text": "When Ambulatory Edifice enters the battlefield, you may pay 2 life. When you do, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "caef4ff0-c3fb-58d3-afa6-82248ce2a711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5d0b95-ec12-4e8e-99a0-7aca457f9107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be5d0b95-ec12-4e8e-99a0-7aca457f9107.jpg?1",
             "name": "Annihilating Glare",
             "text": "As an additional cost to cast this spell, pay {4} or sacrifice an artifact or creature.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -2808,7 +2808,7 @@
         },
         {
             "id": "1810f7c4-6971-5024-9368-f10a24825192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc55a8-290f-4666-90ce-aa632e87c5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc55a8-290f-4666-90ce-aa632e87c5e7.jpg?1",
             "name": "Anoint with Affliction",
             "text": "Exile target creature if it has mana value 3 or less.\nCorrupted \u2014 Exile that creature instead if its controller has three or more poison counters.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "8dc4c406-8045-5655-a6ed-b803113b02c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b0edaf-8cfd-4508-9554-6f0fddc2dfc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b0edaf-8cfd-4508-9554-6f0fddc2dfc4.jpg?1",
             "name": "Archfiend of the Dross",
             "text": "Flying\nArchfiend of the Dross enters the battlefield with four oil counters on it.\nAt the beginning of your upkeep, remove an oil counter from Archfiend of the Dross. Then if it has no oil counters on it, you lose the game.\nWhenever a creature an opponent controls dies, its controller loses 2 life.",
             "colours": [
@@ -2878,7 +2878,7 @@
         },
         {
             "id": "3106a5eb-b92c-5e02-b2ec-6d7eee84dd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb81cb1-ac56-4803-a962-359854a447df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfb81cb1-ac56-4803-a962-359854a447df.jpg?1",
             "name": "Bilious Skulldweller",
             "text": "Deathtouch\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -2913,7 +2913,7 @@
         },
         {
             "id": "0da0d3d2-613d-5dbb-a003-6657481114c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb4def-c67c-44c2-b3b2-8c53a077432d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb4def-c67c-44c2-b3b2-8c53a077432d.jpg?1",
             "name": "Black Sun's Twilight",
             "text": "Up to one target creature gets -X/-X until end of turn. If X is 5 or more, return a creature card with mana value X or less from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2947,7 +2947,7 @@
         },
         {
             "id": "bb866dca-ee14-51bd-9137-26d650fe6a1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9255cd01-a611-4fec-b9ec-b271687740ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9255cd01-a611-4fec-b9ec-b271687740ba.jpg?1",
             "name": "Blightbelly Rat",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Blightbelly Rat dies, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "08be0746-efaf-5db6-bb8c-9bd18be62f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f4e41-a5f5-4929-9816-06dc1c228474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f4e41-a5f5-4929-9816-06dc1c228474.jpg?1",
             "name": "Bonepicker Skirge",
             "text": "Flying\nCorrupted \u2014 As long as an opponent has three or more poison counters, Bonepicker Skirge has deathtouch and lifelink.",
             "colours": [
@@ -3023,7 +3023,7 @@
         },
         {
             "id": "05a4e403-5d85-5c99-8156-2a90984d3963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0328d43-ae9b-462a-a1e5-8ed408eea1a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0328d43-ae9b-462a-a1e5-8ed408eea1a7.jpg?1",
             "name": "Chittering Skitterling",
             "text": "Corrupted \u2014 Sacrifice an artifact or creature: Draw a card. Activate only if an opponent has three or more poison counters and only once each turn.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "e1dbc387-af3c-5064-9599-f8f0b1c61fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f571b5-ce50-4856-a151-fe6610d27bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f571b5-ce50-4856-a151-fe6610d27bca.jpg?1",
             "name": "Cruel Grimnarch",
             "text": "Deathtouch\nWhen Cruel Grimnarch enters the battlefield, each opponent discards a card. For each opponent who can't, you gain 4 life.",
             "colours": [
@@ -3093,7 +3093,7 @@
         },
         {
             "id": "ef25e595-eaeb-5ddb-a29b-56c2b5e8af1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3890961-d636-4ccc-9c42-2088a8531c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3890961-d636-4ccc-9c42-2088a8531c9b.jpg?1",
             "name": "Cutthroat Centurion",
             "text": "Sacrifice another artifact or creature: Cutthroat Centurion gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "6ccea8a0-86e3-5c3d-9d52-a5008f718720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc26bca-c4d8-4e8b-a96a-9529fc2daed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bc26bca-c4d8-4e8b-a96a-9529fc2daed7.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n{PB}{PB}, Exile three creature cards from your graveyard: Put an indestructible counter on Drivnod, Carnage Dominus. ({PB} can be paid with either {B} or 2 life.)",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "e09166c0-8245-5423-a707-d1a860e56fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf148ef4-0ed7-4fbe-8ab6-01dd3981c8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf148ef4-0ed7-4fbe-8ab6-01dd3981c8d3.jpg?1",
             "name": "Drown in Ichor",
             "text": "Target creature gets -4/-4 until end of turn. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "2e6ced1f-fce7-583b-9c37-41776c679fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557e601-9b71-4ce9-9047-1a8baa72e574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3557e601-9b71-4ce9-9047-1a8baa72e574.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "87aca805-afde-5be3-8ae3-bc44d8d32122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f013a1a-d4b9-4380-9802-c299ee6c4492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f013a1a-d4b9-4380-9802-c299ee6c4492.jpg?1",
             "name": "Feed the Infection",
             "text": "You draw three cards and you lose 3 life.\nCorrupted \u2014 Each opponent who has three or more poison counters loses 3 life.",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "9d1eb74a-badb-5996-9748-f4a5dbe73878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2a32c9-f0ae-4ae4-a5c5-72bea05018fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2a32c9-f0ae-4ae4-a5c5-72bea05018fb.jpg?1",
             "name": "Fleshless Gladiator",
             "text": "Corrupted \u2014 {2}{B}: Return Fleshless Gladiator from your graveyard to the battlefield tapped. You lose 1 life. Activate only if an opponent has three or more poison counters.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "004caf6d-019f-5213-9300-f2029a5c86e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26e18be-81a1-4645-866a-fae5c2fdf7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26e18be-81a1-4645-866a-fae5c2fdf7c9.jpg?1",
             "name": "Geth, Thane of Contracts",
             "text": "Other creatures you control get -1/-1.\n{1}{B}{B}, {T}: Return target creature card from your graveyard to the battlefield. It gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else.\" Activate only as a sorcery.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "3b0604f2-d0dc-55a1-ac09-24e92080d357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f48394-c6aa-4453-954a-68195d9bd6ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f48394-c6aa-4453-954a-68195d9bd6ea.jpg?1",
             "name": "Gulping Scraptrap",
             "text": "When Gulping Scraptrap enters the battlefield or dies, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "d1e388ff-87dc-5dbf-a716-b6b12d96b7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a10f284-b043-4307-bdc7-6dad47cc9221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a10f284-b043-4307-bdc7-6dad47cc9221.jpg?1",
             "name": "Infectious Inquiry",
             "text": "You draw two cards and you lose 2 life. Each opponent gets a poison counter.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "d5a9a880-dd05-5b87-b4c9-8845b9b91fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e282d-8941-46c7-a974-c05b6f73c964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16e282d-8941-46c7-a974-c05b6f73c964.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nOther Rats you control have toxic 1.\nWhen Karumonix enters the battlefield, look at the top five cards of your library. You may reveal any number of Rat cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "b877f126-c183-50cb-8df8-9e012eb4d140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8cd7c-992f-4953-b5bf-42e5a9ff09ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8cd7c-992f-4953-b5bf-42e5a9ff09ad.jpg?1",
             "name": "Necrogen Communion",
             "text": "Enchant creature you control\nEnchanted creature has toxic 2. (Players dealt combat damage by it also get two poison counters.)\nWhen enchanted creature dies, return that card to the battlefield under your control.",
             "colours": [
@@ -3483,7 +3483,7 @@
         },
         {
             "id": "ab9973ee-3e5d-5941-89cc-6e8269e4b066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72af72d2-5995-4cad-82f1-e2d0c465d6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72af72d2-5995-4cad-82f1-e2d0c465d6f1.jpg?1",
             "name": "Necrosquito",
             "text": "Flying\nNecrosquito enters the battlefield with two oil counters on it.\nNecrosquito gets +1/+1 for each oil counter on it.\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Necrosquito.",
             "colours": [
@@ -3518,7 +3518,7 @@
         },
         {
             "id": "89962ac1-e504-5a20-9267-061799bd2a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99fe9a8-d9e7-4286-81a1-adfb753e4741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99fe9a8-d9e7-4286-81a1-adfb753e4741.jpg?1",
             "name": "Nimraiser Paladin",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhen Nimraiser Paladin enters the battlefield, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "bdda9781-0417-55d3-9d6a-6a0cbaba1e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aac10a-6d47-4a6c-8a10-2b7c06f3ff32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aac10a-6d47-4a6c-8a10-2b7c06f3ff32.jpg?1",
             "name": "Offer Immortality",
             "text": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3585,7 +3585,7 @@
         },
         {
             "id": "d9c91082-8138-5bd3-8770-4b0eca317de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a1e44-3485-4e24-a34d-6c318584743c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947a1e44-3485-4e24-a34d-6c318584743c.jpg?1",
             "name": "Pestilent Syphoner",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "b3f15302-6345-526a-bacd-cb6b2f294ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f69d43-de01-46a8-b102-b47e23e0e947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f69d43-de01-46a8-b102-b47e23e0e947.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -3655,7 +3655,7 @@
         },
         {
             "id": "f81713fe-a075-5a46-8b1b-0a04146c47b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a9c38b-6b3a-4056-a87c-fc48446f854f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a9c38b-6b3a-4056-a87c-fc48446f854f.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -3694,7 +3694,7 @@
         },
         {
             "id": "58a52f97-c78e-5d6b-a511-e28371c68813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7e1e9b-ad7f-4f4c-bdb5-2ccb6f147037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7e1e9b-ad7f-4f4c-bdb5-2ccb6f147037.jpg?1",
             "name": "Ravenous Necrotitan",
             "text": "Corrupted \u2014 When Ravenous Necrotitan enters the battlefield, sacrifice a creature unless an opponent has three or more poison counters.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "7b5e31ea-482c-5681-be21-03b64fa4c9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de80f71-82b5-499c-afc0-6bbae6b896ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de80f71-82b5-499c-afc0-6bbae6b896ad.jpg?1",
             "name": "Scheming Aspirant",
             "text": "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "5cb1ec7d-5109-542a-8d54-d26792cce328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9225cc3-90f0-448f-a8d9-7c6c2796d077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9225cc3-90f0-448f-a8d9-7c6c2796d077.jpg?1",
             "name": "Sheoldred's Edict",
             "text": "Choose one \u2014\n\u2022 Each opponent sacrifices a nontoken creature.\n\u2022 Each opponent sacrifices a creature token.\n\u2022 Each opponent sacrifices a planeswalker.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "1d11ac95-a4a1-5460-95f2-28cc9661a076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b818f-6912-4ea1-a35a-c8cd7ee9aead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b818f-6912-4ea1-a35a-c8cd7ee9aead.jpg?1",
             "name": "Sheoldred's Headcleaver",
             "text": "Menace\nToxic 2 (Players dealt combat damage by this creature also get two poison counters.)",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "9c0498ff-1248-5e8c-92a5-6a1f62886ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbbcbe1-5317-455e-8d71-a4e2ad0addfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbbcbe1-5317-455e-8d71-a4e2ad0addfc.jpg?1",
             "name": "Stinging Hivemaster",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Stinging Hivemaster dies, create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -3868,7 +3868,7 @@
         },
         {
             "id": "5603460d-c840-5957-b04c-475c9d794085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5424859-628a-4c19-acd0-0c63c21c8338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5424859-628a-4c19-acd0-0c63c21c8338.jpg?1",
             "name": "Testament Bearer",
             "text": "When Testament Bearer dies, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "036b4a98-f494-5be5-afc1-87463f4472c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2aeaeb-7853-4588-8a5e-cfd997ba8515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2aeaeb-7853-4588-8a5e-cfd997ba8515.jpg?1",
             "name": "Vat Emergence",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "cbe0ade1-dbf8-57a6-ae68-fab988d75ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a961ea-0639-4f5d-8cf4-f909c59a4ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a961ea-0639-4f5d-8cf4-f909c59a4ae1.jpg?1",
             "name": "Vat of Rebirth",
             "text": "Whenever another artifact or creature you control is put into a graveyard from the battlefield, put an oil counter on Vat of Rebirth.\n{2}{B}, {T}, Remove four oil counters from Vat of Rebirth: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "3e3cdcaa-0187-5836-bb38-2f1f0662b3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4a3119-c70a-46ff-8ede-6356f2b7bc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4a3119-c70a-46ff-8ede-6356f2b7bc13.jpg?1",
             "name": "Vraan, Executioner Thane",
             "text": "Whenever one or more other creatures you control die, each opponent loses 2 life and you gain 2 life. This ability triggers only once each turn.",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "cd5308fd-6729-5f7d-9d04-e81270d04480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59f2b07-47ad-4efd-ae8c-1c04b9265024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59f2b07-47ad-4efd-ae8c-1c04b9265024.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "Compleated ({PB} can be paid with {B} or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n0: You draw a card and you lose 1 life. Proliferate.\n\u22122: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\u22129: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.",
             "colours": [
@@ -4049,7 +4049,7 @@
         },
         {
             "id": "002a5e44-81f2-596e-9b3d-bf8a4981df78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0173b7b4-2832-4943-ba45-8ba498d7a056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0173b7b4-2832-4943-ba45-8ba498d7a056.jpg?1",
             "name": "Vraska's Fall",
             "text": "Each opponent sacrifices a creature or planeswalker and gets a poison counter.",
             "colours": [
@@ -4081,7 +4081,7 @@
         },
         {
             "id": "df50b486-2722-509c-8d15-ee52bae7f4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d287e8-5297-415a-97d5-02002470c52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d287e8-5297-415a-97d5-02002470c52b.jpg?1",
             "name": "Whisper of the Dross",
             "text": "Target creature gets -1/-1 until end of turn. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "5523af1e-1d88-53a3-a5ac-8ee78dfc8d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d75e1f4-bd63-428e-8e6e-131594b3ba44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d75e1f4-bd63-428e-8e6e-131594b3ba44.jpg?1",
             "name": "All Will Be One",
             "text": "Whenever you put one or more counters on a permanent or player, All Will Be One deals that much damage to target opponent, creature an opponent controls, or planeswalker an opponent controls.",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "d1f2038f-085f-5098-b079-82365ffb1462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92f866-2522-4f2a-a5ca-7d01ad79b927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b92f866-2522-4f2a-a5ca-7d01ad79b927.jpg?1",
             "name": "Awaken the Sleeper",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. If it's equipped, you may destroy all Equipment attached to that creature.",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "53a1d83b-8d47-5ffe-8fc8-135e6902b966",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b3b785-396e-4240-bfa3-58ab53497686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9b3b785-396e-4240-bfa3-58ab53497686.jpg?1",
             "name": "Axiom Engraver",
             "text": "Axiom Engraver enters the battlefield with two oil counters on it.\n{T}, Remove an oil counter from Axiom Engraver, Discard a card: Draw a card.",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "540ca546-2050-5ca8-b2e9-78dc9c266d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1d02d1-91dc-47d6-bdbe-87602428abfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1d02d1-91dc-47d6-bdbe-87602428abfb.jpg?1",
             "name": "Barbed Batterfist",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +1/-1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "f98569a0-f016-51dc-93bd-2fa30a24baea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6cf933-73fe-4e79-8d0b-29dc0f18b25d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6cf933-73fe-4e79-8d0b-29dc0f18b25d.jpg?1",
             "name": "Bladegraft Aspirant",
             "text": "Menace\nEquipment spells you cast cost {1} less to cast.\nActivated abilities of Equipment you control that target Bladegraft Aspirant cost {1} less to activate.",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "f06d5006-947f-506e-aa49-6c6d7bae2aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfc16a-2871-40a4-b279-636b80491a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bfc16a-2871-40a4-b279-636b80491a06.jpg?1",
             "name": "Blazing Crescendo",
             "text": "Target creature gets +3/+1 until end of turn.\nExile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "ef359b96-9ff2-5ed8-9c32-d4c14e034234",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553dcef-7b99-49d5-b071-06b894696952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3553dcef-7b99-49d5-b071-06b894696952.jpg?1",
             "name": "Cacophony Scamp",
             "text": "Whenever Cacophony Scamp deals combat damage to a player, you may sacrifice it. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nWhen Cacophony Scamp dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "f5024d59-ee03-5943-a71e-89ae8d6bbc99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23afca1a-62a8-497f-994f-ceb479d020ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23afca1a-62a8-497f-994f-ceb479d020ba.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "This spell costs {3} less to cast if you have nine or more cards in your graveyard.\nFlying\nWhen Capricious Hellraiser enters the battlefield, exile three cards at random from your graveyard. Choose a noncreature, nonland card from among them and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -4390,7 +4390,7 @@
         },
         {
             "id": "909a29bd-773a-5bf9-acc3-7b9d687d60eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5668699d-8df8-426b-a04a-99cfe55e570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5668699d-8df8-426b-a04a-99cfe55e570b.jpg?1",
             "name": "Chimney Rabble",
             "text": "Haste\nWhen Chimney Rabble enters the battlefield, create a 1/1 red Phyrexian Goblin creature token.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "e084dfdf-f7a2-5231-b108-5b283dd97263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c117239-8e40-4e7e-ab1b-82f2ddf55cf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c117239-8e40-4e7e-ab1b-82f2ddf55cf4.jpg?1",
             "name": "Churning Reservoir",
             "text": "At the beginning of your upkeep, put an oil counter on another target nontoken artifact or creature you control.\n{2}, {T}: Create a 1/1 red Phyrexian Goblin creature token. Activate only if an oil counter was removed from a permanent you controlled this turn or a permanent with an oil counter on it was put into a graveyard this turn.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "d7f7057a-61b4-5153-bd24-7b77218e0c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5456b036-231e-4a64-b060-0709f5254664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5456b036-231e-4a64-b060-0709f5254664.jpg?1",
             "name": "Dragonwing Glider",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +2/+2 and has flying and haste.\nEquip {3}{R}{R}",
             "colours": [
@@ -4494,7 +4494,7 @@
         },
         {
             "id": "a42734b2-aeb4-52ff-97ca-f2320d2392cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8d7b9-ff5e-48ae-9e38-d2b6a45b119b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e8d7b9-ff5e-48ae-9e38-d2b6a45b119b.jpg?1",
             "name": "Exuberant Fuseling",
             "text": "Trample\nExuberant Fuseling gets +1/+0 for each oil counter on it.\nWhen Exuberant Fuseling enters the battlefield and whenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Exuberant Fuseling.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "8d9fd16a-d102-5679-9985-5c3df3fc1682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c2c914-e9a7-450b-88d9-8885fe0f6643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c2c914-e9a7-450b-88d9-8885fe0f6643.jpg?1",
             "name": "Forgehammer Centurion",
             "text": "Whenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Forgehammer Centurion.\nWhenever Forgehammer Centurion attacks, you may remove two oil counters from it. When you do, target creature can't block this turn.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "3cfaf622-32e0-5414-8f0c-0fa99c5c5b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c83600d-ea4d-4219-8dbb-34c4215a2005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c83600d-ea4d-4219-8dbb-34c4215a2005.jpg?1",
             "name": "Free from Flesh",
             "text": "Target creature gets +2/+2 until end of turn. Put two oil counters on it.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "29a0bcfa-6fb2-564b-8867-4aa9ece4fcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e5fc08-7a04-4bba-81ba-990889cae96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e5fc08-7a04-4bba-81ba-990889cae96a.jpg?1",
             "name": "Furnace Punisher",
             "text": "Menace\nAt the beginning of each player's upkeep, Furnace Punisher deals 2 damage to that player unless they control two or more basic lands.",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "6979b6a6-1377-5358-9c10-359cd276f2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa625ab0-1e79-4497-a5da-98fe1abfd024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa625ab0-1e79-4497-a5da-98fe1abfd024.jpg?1",
             "name": "Furnace Strider",
             "text": "Furnace Strider enters the battlefield with two oil counters on it.\nRemove an oil counter from Furnace Strider: Target creature you control gains haste until end of turn.",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "430c50d3-1247-58d1-ab72-16b64af4aa7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e4efa6-5783-4a51-99c6-116d1a8f01cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e4efa6-5783-4a51-99c6-116d1a8f01cf.jpg?1",
             "name": "Gleeful Demolition",
             "text": "Destroy target artifact. If you controlled that artifact, create three 1/1 red Phyrexian Goblin creature tokens.",
             "colours": [
@@ -4702,7 +4702,7 @@
         },
         {
             "id": "9db7fc73-b602-5ec6-83b9-a8a616404352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380a4c9-a5d3-465f-8584-e546b54f91e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380a4c9-a5d3-465f-8584-e546b54f91e0.jpg?1",
             "name": "Hazardous Blast",
             "text": "Hazardous Blast deals 1 damage to each creature your opponents control. Creatures your opponents control can't block this turn.",
             "colours": [
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "ac68cb3a-ea48-5304-b7f6-4c48c6a18a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22108ec-28f0-44d3-ba6b-3075f5f6bc65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22108ec-28f0-44d3-ba6b-3075f5f6bc65.jpg?1",
             "name": "Hexgold Halberd",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nAs long as it's your turn, equipped creature has first strike and trample.\nEquip {2}{R}",
             "colours": [
@@ -4768,7 +4768,7 @@
         },
         {
             "id": "db100f3f-f7f0-5074-8a9c-8fc6ba0e35b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec44465-68d4-4dca-a313-7f2ab0ce2e63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec44465-68d4-4dca-a313-7f2ab0ce2e63.jpg?1",
             "name": "Hexgold Slash",
             "text": "Hexgold Slash deals 2 damage to target creature. If that creature has toxic, Hexgold Slash deals 4 damage to that creature instead.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "4f4f323d-eff6-54f1-9bd9-ea32ec592052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6528e012-4091-4722-b706-c51772676167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6528e012-4091-4722-b706-c51772676167.jpg?1",
             "name": "Koth, Fire of Resistance",
             "text": "+2: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n\u22123: Koth, Fire of Resistance deals damage to target creature equal to the number of Mountains you control.\n\u22127: You get an emblem with \"Whenever a Mountain enters the battlefield under your control, this emblem deals 4 damage to any target.\"",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "67613efc-963c-54ed-8a41-49ca92f34112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7155c42-a824-4bbe-9f7a-fa01e7625fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7155c42-a824-4bbe-9f7a-fa01e7625fd6.jpg?1",
             "name": "Kuldotha Cackler",
             "text": "Trample\nWhenever Kuldotha Cackler attacks, it gets +X/+0 until end of turn, where X is the number of permanents you control with oil counters on them.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "1958f038-8af7-51a5-b7dc-1b4c8023e6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6af42f-35ec-432f-9879-2a0fb938a9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6af42f-35ec-432f-9879-2a0fb938a9f6.jpg?1",
             "name": "Magmatic Sprinter",
             "text": "Haste\nWhen Magmatic Sprinter enters the battlefield, put two oil counters on target artifact or creature you control.\nAt the beginning of your end step, return Magmatic Sprinter to its owner's hand unless you remove two oil counters from it.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "7dc26f6c-bd5e-55f1-91e7-b9e883f3045e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3291b-de5c-4a10-9915-2cd2d84a815c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e3291b-de5c-4a10-9915-2cd2d84a815c.jpg?1",
             "name": "Molten Rebuke",
             "text": "Choose one or both \u2014\n\u2022 Molten Rebuke deals 5 damage to target creature or planeswalker.\n\u2022 Destroy target Equipment.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "e517109b-449d-514a-8f14-d7c7885d4ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98395039-1353-4fa8-b51d-c4e1cadf9263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98395039-1353-4fa8-b51d-c4e1cadf9263.jpg?1",
             "name": "Nahiri's Sacrifice",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature with mana value X.\nNahiri's Sacrifice deals X damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -4973,7 +4973,7 @@
         },
         {
             "id": "50cd4e78-859c-5d27-bc23-1e4aeaebf5a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7177431e-5cc4-4ecd-8848-f51903289072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7177431e-5cc4-4ecd-8848-f51903289072.jpg?1",
             "name": "Oxidda Finisher",
             "text": "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nTrample",
             "colours": [
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "430b8664-73a5-5268-8b27-4d236f63c857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd37d1b1-70ce-466e-890d-36be82433035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd37d1b1-70ce-466e-890d-36be82433035.jpg?1",
             "name": "Rebel Salvo",
             "text": "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nRebel Salvo deals 5 damage to target creature or planeswalker. That permanent loses indestructible until end of turn.",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "cd866547-0c2e-5695-b59e-4de4893184e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cac1827-69af-469d-b88c-fb9f2f33866a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cac1827-69af-469d-b88c-fb9f2f33866a.jpg?1",
             "name": "Red Sun's Twilight",
             "text": "Destroy up to X target artifacts. If X is 5 or more, for each artifact destroyed this way, create a token that's a copy of it. Those tokens gain haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "7ab9c136-cc86-55ad-bd19-bd3956981931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6249aabe-8f21-4257-9e04-ceffd44d42a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6249aabe-8f21-4257-9e04-ceffd44d42a5.jpg?1",
             "name": "Resistance Skywarden",
             "text": "Menace, reach",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "8f92c873-1835-5701-9ee2-fbbf6fb7b9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c2e5-9100-439a-9aa4-28d388518e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f04c2e5-9100-439a-9aa4-28d388518e4a.jpg?1",
             "name": "Sawblade Scamp",
             "text": "Haste\nWhenever you cast a noncreature spell, put an oil counter on Sawblade Scamp.\n{T}, Remove an oil counter from Sawblade Scamp: It deals 1 damage to each opponent.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "e71e6f05-5688-568c-82a9-58aee00c9112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6147bdc-4e02-48be-9ab9-c212f70d9194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6147bdc-4e02-48be-9ab9-c212f70d9194.jpg?1",
             "name": "Shrapnel Slinger",
             "text": "When Shrapnel Slinger enters the battlefield, you may sacrifice a creature. When you do, destroy target artifact an opponent controls.",
             "colours": [
@@ -5183,7 +5183,7 @@
         },
         {
             "id": "a4e03a81-6b89-5555-b5a9-c660b99253a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7dadf0-7323-403e-b353-33c121bdb0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7dadf0-7323-403e-b353-33c121bdb0db.jpg?1",
             "name": "Slobad, Iron Goblin",
             "text": "{T}, Sacrifice an artifact: Add an amount of {R} equal to the sacrificed artifact's mana value. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "59bfd687-78f5-55fb-b26c-95c65e5a7f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0c7f3-7fb9-43de-a9af-96532c31e5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a0c7f3-7fb9-43de-a9af-96532c31e5ed.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "If a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals double that damage to that player or permanent instead.\n{1}{PR}{PR}, Discard two cards: Put an indestructible counter on Solphim, Mayhem Dominus. ({PR} can be paid with either {R} or 2 life.)",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "7f423ee1-9bfd-5635-ba7a-e122fff93282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efd4ae5-0076-46a0-a113-58cfff53144f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1efd4ae5-0076-46a0-a113-58cfff53144f.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "fc0bc28b-560b-5400-ac4d-076a5123da9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ef034f-37e5-4baa-a7a9-5fd0de792535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ef034f-37e5-4baa-a7a9-5fd0de792535.jpg?1",
             "name": "Urabrask's Anointer",
             "text": "When Urabrask's Anointer enters the battlefield, it deals X damage to any target, where X is the number of permanents you control with oil counters on them.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "784e981f-97f8-5417-893c-41b6c3b730b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f9f9d8-9ea0-4608-a79c-a09a87918186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f9f9d8-9ea0-4608-a79c-a09a87918186.jpg?1",
             "name": "Urabrask's Forge",
             "text": "At the beginning of combat on your turn, put an oil counter on Urabrask's Forge, then create an X/1 red Phyrexian Horror creature token with trample and haste, where X is the number of oil counters on Urabrask's Forge. Sacrifice that token at the beginning of the next end step.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "053d5396-62ae-581f-9478-0f016a1703a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7a16-ff30-4fb9-9fcb-6561eec50caf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7a16-ff30-4fb9-9fcb-6561eec50caf.jpg?1",
             "name": "Vindictive Flamestoker",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Vindictive Flamestoker.\n{6}{R}, Sacrifice Vindictive Flamestoker: Discard your hand, then draw four cards. This ability costs {1} less to activate for each oil counter on Vindictive Flamestoker.",
             "colours": [
@@ -5407,7 +5407,7 @@
         },
         {
             "id": "d52bb3ca-49a0-5945-829b-3cdaae67b0f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d74045-cc9b-4b01-bc5f-0f2eb4b01580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d74045-cc9b-4b01-bc5f-0f2eb4b01580.jpg?1",
             "name": "Volt Charge",
             "text": "Volt Charge deals 3 damage to any target. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "a7ec285f-f436-5100-ae25-d44bdef52402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05078dd-b928-4b3f-9636-f299ebac180b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05078dd-b928-4b3f-9636-f299ebac180b.jpg?1",
             "name": "Vulshok Splitter",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +2/+0.\nEquip {2}{R} ({2}{R}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "b8473eeb-c4f2-5163-9cfe-28b335afdf9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6d202-9c6f-4485-9224-173b23de7054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6d202-9c6f-4485-9224-173b23de7054.jpg?1",
             "name": "Adaptive Sporesinger",
             "text": "Vigilance\nWhen Adaptive Sporesinger enters the battlefield, choose one \u2014\n\u2022 Target creature gets +2/+2 and gains vigilance until end of turn.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "2d1a89e3-dbc7-5370-8333-4cbafd26dcda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e220d0-38c9-4584-940b-8a9e983ecfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e220d0-38c9-4584-940b-8a9e983ecfe7.jpg?1",
             "name": "Armored Scrapgorger",
             "text": "Armored Scrapgorger gets +3/+0 as long as it has three or more oil counters on it.\n{T}: Add one mana of any color.\nWhenever Armored Scrapgorger becomes tapped, exile target card from a graveyard and put an oil counter on Armored Scrapgorger.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "03b60dc5-9023-5a0c-b2ae-fed7b0a84a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411bda96-6c65-475d-9850-0a9b3eefa553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411bda96-6c65-475d-9850-0a9b3eefa553.jpg?1",
             "name": "Bloated Contaminator",
             "text": "Trample\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhenever Bloated Contaminator deals combat damage to a player, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5580,7 +5580,7 @@
         },
         {
             "id": "0c518ca2-8608-57b6-809d-dd71074712c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5290a4c-1f98-4e97-a407-f951e386b8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5290a4c-1f98-4e97-a407-f951e386b8b0.jpg?1",
             "name": "Branchblight Stalker",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "b57e19e2-5e80-501a-8923-bd37f540cea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b39293-6f57-4294-85fc-c718bdbb4d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b39293-6f57-4294-85fc-c718bdbb4d40.jpg?1",
             "name": "Cankerbloom",
             "text": "{1}, Sacrifice Cankerbloom: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "bc9ad3b9-1082-577c-8c25-9ba96c907a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ba43-f7ae-4e00-b797-2360c3ccd839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ba43-f7ae-4e00-b797-2360c3ccd839.jpg?1",
             "name": "Carnivorous Canopy",
             "text": "Destroy target artifact, enchantment, or creature with flying. If that permanent's mana value was 3 or less, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "7910545e-c599-5998-9663-386e261a328d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635146da-d415-4107-a7f9-2c46189e5c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635146da-d415-4107-a7f9-2c46189e5c52.jpg?1",
             "name": "Conduit of Worlds",
             "text": "You may play lands from your graveyard.\n{T}: Choose target nonland permanent card in your graveyard. If you haven't cast a spell this turn, you may cast that card. If you do, you can't cast additional spells this turn. Activate only as a sorcery.",
             "colours": [
@@ -5720,7 +5720,7 @@
         },
         {
             "id": "6d89f777-3976-5029-8fcf-7668b9ab0631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af2c85-e58f-4043-99d3-e90121348aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18af2c85-e58f-4043-99d3-e90121348aca.jpg?1",
             "name": "Contagious Vorrac",
             "text": "When Contagious Vorrac enters the battlefield, look at the top four cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "d29fa315-0d68-5e2b-93a0-3eac7664a5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8855fbf-4f1e-4c44-9653-bbbfc3f2fafd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8855fbf-4f1e-4c44-9653-bbbfc3f2fafd.jpg?1",
             "name": "Copper Longlegs",
             "text": "Reach\n{1}{G}, Sacrifice Copper Longlegs: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "d7dbba15-4e28-5a6c-8d77-f683cdce9638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4bcb42-f5cf-410d-8f20-1006b0f92abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd4bcb42-f5cf-410d-8f20-1006b0f92abe.jpg?1",
             "name": "Evolved Spinoderm",
             "text": "Evolved Spinoderm enters the battlefield with four oil counters on it.\nEvolved Spinoderm has trample as long as it has two or fewer oil counters on it. Otherwise, it has hexproof.\nAt the beginning of your upkeep, remove an oil counter from Evolved Spinoderm. Then if it has no oil counters on it, sacrifice it.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "3223c974-e7de-5fb9-a357-9465b2032b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13366c60-1200-4ad2-bbf4-77596121fcd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13366c60-1200-4ad2-bbf4-77596121fcd2.jpg?1",
             "name": "Evolving Adaptive",
             "text": "Evolving Adaptive enters the battlefield with an oil counter on it.\nEvolving Adaptive gets +1/+1 for each oil counter on it.\nWhenever another creature enters the battlefield under your control, if that creature has greater power or toughness than Evolving Adaptive, put an oil counter on Evolving Adaptive.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "4893f5a8-ce90-55f7-8c06-8be2a3a0ae24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572e174e-99f7-4b5e-8506-1833adddbf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572e174e-99f7-4b5e-8506-1833adddbf07.jpg?1",
             "name": "Expand the Sphere",
             "text": "Look at the top six cards of your library. Put up to two land cards from among them onto the battlefield tapped and the rest on the bottom of your library in a random order. If you put fewer than two lands onto the battlefield this way, proliferate a number of times equal to the difference. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "07e45dea-714c-5a56-bf2c-0ea4034aa4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c985d-cb70-41a7-9f66-3506708b7e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c985d-cb70-41a7-9f66-3506708b7e26.jpg?1",
             "name": "Green Sun's Twilight",
             "text": "Reveal the top X plus one cards of your library. Choose a creature card and/or a land card from among them. Put those cards into your hand and the rest on the bottom of your library in a random order. If X is 5 or more, instead put the chosen cards onto the battlefield or into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5931,7 +5931,7 @@
         },
         {
             "id": "60020c37-97c0-57d5-a500-28261916e8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0955b64f-6721-4fa6-b161-cae404cb5b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0955b64f-6721-4fa6-b161-cae404cb5b9f.jpg?1",
             "name": "Ichorspit Basilisk",
             "text": "Deathtouch\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "a1161542-f856-55c8-8bb6-22ca4982c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b36e23-a414-400c-a3a5-e23883e866d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b36e23-a414-400c-a3a5-e23883e866d3.jpg?1",
             "name": "Incubation Sac",
             "text": "Incubation Sac enters the battlefield with three oil counters on it.\n{4}, {T}, Remove an oil counter from Incubation Sac: Create a 3/3 colorless Phyrexian Golem artifact creature token. Activate only as a sorcery.",
             "colours": [
@@ -5998,7 +5998,7 @@
         },
         {
             "id": "c6897d5b-fad9-5202-a8dc-fc4ab2dbb61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83dfb2a5-cd5c-46c6-9bb8-7c5d00f3e003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83dfb2a5-cd5c-46c6-9bb8-7c5d00f3e003.jpg?1",
             "name": "Infectious Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control. Each opponent gets a poison counter.",
             "colours": [
@@ -6030,7 +6030,7 @@
         },
         {
             "id": "fb3d29f5-a392-5c19-b5f6-b80211709979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7427def-c4b2-475a-8dc9-7e89409d9abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7427def-c4b2-475a-8dc9-7e89409d9abb.jpg?1",
             "name": "Lattice-Blade Mantis",
             "text": "Lattice-Blade Mantis enters the battlefield with two oil counters on it.\nWhenever Lattice-Blade Mantis attacks, you may remove an oil counter from it. If you do, untap it and it gets +1/+1 until end of turn.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "1f054389-514a-565b-a30a-b7c5dc9ea657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc79106b-9aa2-4add-b9ca-e3c7aafd9821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc79106b-9aa2-4add-b9ca-e3c7aafd9821.jpg?1",
             "name": "Maze's Mantle",
             "text": "Flash\nEnchant creature\nWhen Maze's Mantle enters the battlefield, if enchanted creature has toxic, that creature gains hexproof until end of turn.\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "a1023295-7922-5b7d-afd2-eabd05c16b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd64b1d-bcef-476c-bf0b-3ac7df7cbed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd64b1d-bcef-476c-bf0b-3ac7df7cbed3.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "Compleated ({PG} can be paid with {G} or 2 life. For each {PG} paid with life, this planeswalker enters with two fewer loyalty counters.)\n+1: Create an X/X green Phyrexian Horror creature token, where X is Nissa, Ascended Animist's loyalty.\n\u22121: Destroy target artifact or enchantment.\n\u22127: Until end of turn, creatures you control get +1/+1 for each Forest you control and gain trample.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "e1cc3bd9-7514-5c32-89d4-67d7dae2030b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9649de6c-a9f7-4f0a-8bf7-cacaea60ed54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9649de6c-a9f7-4f0a-8bf7-cacaea60ed54.jpg?1",
             "name": "Noxious Assault",
             "text": "Creatures you control get +2/+2 until end of turn. Whenever a creature blocks this turn, its controller gets a poison counter.",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "62d18d80-f5a3-580a-bc0c-db18a697b9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78493579-1fad-4664-96d7-195bf59ceef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78493579-1fad-4664-96d7-195bf59ceef2.jpg?1",
             "name": "Oil-Gorger Troll",
             "text": "When Oil-Gorger Troll enters the battlefield, you gain 3 life. Then if you control a permanent with an oil counter on it, draw a card.",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "ec588a7f-6aad-576d-901c-a17640adb15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758dbe61-6dc7-4b08-bdd6-7262257955fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758dbe61-6dc7-4b08-bdd6-7262257955fc.jpg?1",
             "name": "Paladin of Predation",
             "text": "Toxic 6 (Players dealt combat damage by this creature also get six poison counters.)\nPaladin of Predation can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "79af8678-6ab6-586c-9607-8e3dcb0c9d80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7eef9e-68ae-4743-ad89-64f6fafbe365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7eef9e-68ae-4743-ad89-64f6fafbe365.jpg?1",
             "name": "Plague Nurse",
             "text": "Toxic 2\n{2}{G}: Each other creature you control with toxic gains toxic 1 until end of turn. Activate only once each turn. (A player dealt combat damage by a creature with toxic also gets poison counters equal to that creature's total toxic value.)",
             "colours": [
@@ -6279,7 +6279,7 @@
         },
         {
             "id": "2d9e2dca-3fb6-57b7-b3fb-98afcc38390e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fab07-f921-4eff-91e2-1974ae121077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/419fab07-f921-4eff-91e2-1974ae121077.jpg?1",
             "name": "Predation Steward",
             "text": "Predation Steward enters the battlefield with two oil counters on it.\n{2}{G}, {T}, Remove an oil counter from Predation Steward: Target creature gets +2/+2 until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "c16e5c6b-9952-589a-a3b3-f1a91998c48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b71fd8f-e688-4210-bc5b-a3f19b5b3497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b71fd8f-e688-4210-bc5b-a3f19b5b3497.jpg?1",
             "name": "Rustvine Cultivator",
             "text": "{T}: Put an oil counter on Rustvine Cultivator.\n{T}, Remove an oil counter from Rustvine Cultivator: Untap target land.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "154d5c62-91e6-5cd4-9345-84d883468b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123f0c76-1fde-439e-a76d-eccf96f8d941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123f0c76-1fde-439e-a76d-eccf96f8d941.jpg?1",
             "name": "Ruthless Predation",
             "text": "Target creature you control gets +1/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "1fe6144a-8d1c-5e6c-b043-4e8f98d087d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7898399-3c52-402c-9cd7-baad2cb7f00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7898399-3c52-402c-9cd7-baad2cb7f00e.jpg?1",
             "name": "Skyscythe Engulfer",
             "text": "Reach, trample\nSkyscythe Engulfer can't be blocked by creatures with flying.",
             "colours": [
@@ -6421,7 +6421,7 @@
         },
         {
             "id": "20a7a394-ed82-5305-9376-fa037f688773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c1a1d0-5616-42f8-a59c-42c1ccd48d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c1a1d0-5616-42f8-a59c-42c1ccd48d26.jpg?1",
             "name": "Sylvok Battle-Chair",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has trample.\nEquip {5}{G}{G}",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "0a07b890-8ef8-576b-8d41-93b7a6f3c46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4a340-453b-471a-82ba-48ebf20b271a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4a340-453b-471a-82ba-48ebf20b271a.jpg?1",
             "name": "Thirsting Roots",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6487,7 +6487,7 @@
         },
         {
             "id": "78f2b9c7-c869-554a-8457-f488cffd041e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9f51dd-0393-4b3c-bea5-8f74634ab0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9f51dd-0393-4b3c-bea5-8f74634ab0e5.jpg?1",
             "name": "Thrun, Breaker of Silence",
             "text": "This spell can't be countered.\nTrample\nThrun, Breaker of Silence can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.\nAs long as it's your turn, Thrun has indestructible.",
             "colours": [
@@ -6527,7 +6527,7 @@
         },
         {
             "id": "5a3bd3b1-9f07-5d1c-ad86-595a73ccea49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3583ea03-525f-4c70-9d7e-ccc6002ee9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3583ea03-525f-4c70-9d7e-ccc6002ee9e1.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6559,7 +6559,7 @@
         },
         {
             "id": "fc186b98-10f1-55e1-8c1c-16f559415bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157cf43c-f7f2-4362-bfc8-11682e94b747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/157cf43c-f7f2-4362-bfc8-11682e94b747.jpg?1",
             "name": "Tyrranax Atrocity",
             "text": "Haste\nToxic 3 (Players dealt combat damage by this creature also get three poison counters.)",
             "colours": [
@@ -6594,7 +6594,7 @@
         },
         {
             "id": "0f465d50-ec6b-569d-8d8a-ce65b4baa33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg?1",
             "name": "Tyrranax Rex",
             "text": "This spell can't be countered.\nTrample, ward {4}, haste\nToxic 4 (Players dealt combat damage by this creature also get four poison counters.)",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "8bd34a5d-d614-535b-a7a3-94c5408daddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b362a5-382a-4016-b4f2-aa7b683354c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b362a5-382a-4016-b4f2-aa7b683354c4.jpg?1",
             "name": "Tyvar's Stand",
             "text": "Target creature you control gets +X/+X and gains hexproof and indestructible until end of turn. (A creature with hexproof and indestructible can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -6665,7 +6665,7 @@
         },
         {
             "id": "1561e67e-a9dd-502a-b498-566003ad0d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e6a91-59cc-4f7f-af25-16acabdafb1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4e6a91-59cc-4f7f-af25-16acabdafb1a.jpg?1",
             "name": "Unnatural Restoration",
             "text": "Return target permanent card from your graveyard to your hand. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6697,7 +6697,7 @@
         },
         {
             "id": "409bff6c-b7e2-5836-842a-4e8f8b84468b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b032e3-14e3-48ba-ab8a-d2b4f8d31a7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b032e3-14e3-48ba-ab8a-d2b4f8d31a7d.jpg?1",
             "name": "Venerated Rotpriest",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhenever a creature you control becomes the target of a spell, target opponent gets a poison counter.",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "5bcd4e6d-a9d9-5be4-8183-63be1ba304a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9df44a-a0ab-435f-914c-aa11cd88f4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd9df44a-a0ab-435f-914c-aa11cd88f4ec.jpg?1",
             "name": "Venomous Brutalizer",
             "text": "Toxic 3 (Players dealt combat damage by this creature also get three poison counters.)\nWhen Venomous Brutalizer enters the battlefield, you may pay {1}{G}. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "91befce7-5b8a-55a0-ae2f-3468afdee6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad30a1-3ecc-42ca-afe8-85df5bad9196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85ad30a1-3ecc-42ca-afe8-85df5bad9196.jpg?1",
             "name": "Viral Spawning",
             "text": "Create a 3/3 green Phyrexian Beast creature token with toxic 1. (Players dealt combat damage by it also get a poison counter.)\nCorrupted \u2014 As long as an opponent has three or more poison counters and Viral Spawning is in your graveyard, it has flashback {2}{G}. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "f73401c0-2d8e-5113-8226-736006970735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb419d9d-e06f-48c8-a4f8-a57f9be39e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb419d9d-e06f-48c8-a4f8-a57f9be39e50.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "Reach\nAt the beginning of each combat, double the power and toughness of each creature you control until end of turn.\n{PG}{PG}, Sacrifice two other creatures: Put an indestructible counter on Zopandrel, Hunger Dominus. ({PG} can be paid with either {G} or 2 life.)",
             "colours": [
@@ -6842,7 +6842,7 @@
         },
         {
             "id": "00110d45-bc2b-58af-936c-7eb69899ec7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1f905f-1d55-4d02-9d24-e58070793d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1f905f-1d55-4d02-9d24-e58070793d3f.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "Flying, vigilance, deathtouch, lifelink\nWhen Atraxa, Grand Unifier enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order. (Artifact, battle, creature, enchantment, instant, land, planeswalker, and sorcery are card types.)",
             "colours": [
@@ -6889,7 +6889,7 @@
         },
         {
             "id": "b116f091-5597-5d99-8e53-e897e4254a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e9ba5-e0ec-4fb3-8301-689aa145cc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e9ba5-e0ec-4fb3-8301-689aa145cc19.jpg?1",
             "name": "Bladehold War-Whip",
             "text": "For Mirrodin (When this Equipment enters the battlefield, create a 2/2 red Rebel creature token, then attach this to it.)\nEquip abilities you activate of other Equipment cost {1} less to activate.\nEquipped creature has double strike.\nEquip {3}{R}{W}",
             "colours": [
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "97ab7286-8822-5a73-a214-4df1cc0531a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c22eb9-5056-4c0b-a5d8-41e09161eb40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c22eb9-5056-4c0b-a5d8-41e09161eb40.jpg?1",
             "name": "Cephalopod Sentry",
             "text": "Flying\nCephalopod Sentry's power is equal to the number of artifacts you control.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "ab9472f1-fa45-5992-9d4a-e83b0bafbb56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45db6b46-c4b4-4684-8a49-53a64ffc82f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45db6b46-c4b4-4684-8a49-53a64ffc82f2.jpg?1",
             "name": "Charforger",
             "text": "When Charforger enters the battlefield, create a 1/1 red Phyrexian Goblin creature token.\nWhenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Charforger.\nRemove three oil counters from Charforger: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "58274e59-5ff0-551d-b6a7-241d6535188b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee24300-fff8-4405-9629-9f62b4a839ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee24300-fff8-4405-9629-9f62b4a839ef.jpg?1",
             "name": "Cinderslash Ravager",
             "text": "This spell costs {1} less to cast for each permanent you control with oil counters on it.\nVigilance\nWhen Cinderslash Ravager enters the battlefield, it deals 1 damage to each creature your opponents control.",
             "colours": [
@@ -7039,7 +7039,7 @@
         },
         {
             "id": "b5d0a4cd-aa06-5e4a-9960-a0fea2ec2ddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38961ce-0257-412f-acec-c5c9886061f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38961ce-0257-412f-acec-c5c9886061f8.jpg?1",
             "name": "Ezuri, Stalker of Spheres",
             "text": "When Ezuri, Stalker of Spheres enters the battlefield, you may pay {3}. If you do, proliferate twice.\nWhenever you proliferate, draw a card.",
             "colours": [
@@ -7082,7 +7082,7 @@
         },
         {
             "id": "91040ff4-32d2-5207-8941-158734ba7991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bf633e-0470-4b87-99ed-5ad1683b0954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2bf633e-0470-4b87-99ed-5ad1683b0954.jpg?1",
             "name": "Glissa Sunslayer",
             "text": "First strike, deathtouch\nWhenever Glissa Sunslayer deals combat damage to a player, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Destroy target enchantment.\n\u2022 Remove up to three counters from target permanent.",
             "colours": [
@@ -7125,7 +7125,7 @@
         },
         {
             "id": "9a26a488-ea97-561b-a6f9-29f3d5165a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4d8f7-874d-4b2a-ad23-afab479784ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4d8f7-874d-4b2a-ad23-afab479784ea.jpg?1",
             "name": "Jor Kadeen, First Goldwarden",
             "text": "Trample\nWhenever Jor Kadeen, First Goldwarden attacks, it gets +X/+X until end of turn, where X is the number of equipped creatures you control. Then if Jor Kadeen's power is 4 or greater, draw a card.",
             "colours": [
@@ -7167,7 +7167,7 @@
         },
         {
             "id": "7e3db830-928a-59e9-a587-84e2f733ed79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d97f59a-07b8-47ef-aa88-d94f8c3feae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d97f59a-07b8-47ef-aa88-d94f8c3feae4.jpg?1",
             "name": "Kaito, Dancing Shadow",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may return one of them to its owner's hand. If you do, you may activate loyalty abilities of Kaito twice this turn rather than only once.\n+1: Up to one target creature can't attack or block until your next turn.\n0: Draw a card.\n\u22122: Create a 2/2 colorless Drone artifact creature token with deathtouch and \"When this creature leaves the battlefield, each opponent loses 2 life and you gain 2 life.\"",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "35fc764b-a80b-59e6-a8ff-ac3793a8c6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6865b8c7-b260-48e8-a905-64cbf06b7e57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6865b8c7-b260-48e8-a905-64cbf06b7e57.jpg?1",
             "name": "Kaya, Intangible Slayer",
             "text": "Hexproof\n+2: Each opponent loses 3 life and you gain 3 life.\n0: You draw two cards. Then each opponent may scry 1.\n\u22123: Exile target creature or enchantment. If it wasn't an Aura, create a token that's a copy of it, except it's a 1/1 white Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -7249,7 +7249,7 @@
         },
         {
             "id": "1484ffdc-bdf6-53b6-8852-81947ed34ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152a5a8-e5a1-46b0-8f75-b9ac341da474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4152a5a8-e5a1-46b0-8f75-b9ac341da474.jpg?1",
             "name": "Kethek, Crucible Goliath",
             "text": "At the beginning of your end step, you may sacrifice another creature. If you do, reveal cards from the top of your library until you reveal a nonlegendary creature card with lesser mana value, put it onto the battlefield, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "52b13bc8-697f-5742-ab91-e68796e17493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df77017-c4a7-4b79-a16b-26463bd6a96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df77017-c4a7-4b79-a16b-26463bd6a96a.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "Compleated ({Red Green Mana for Phyrexian} can be paid with {R}, {G}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.\n\u22121: Create a 3/3 green Phyrexian Beast creature token with toxic 1.\n\u22124: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers, where X is the greatest power among creatures you controlled as you activated this ability.",
             "colours": [
@@ -7335,7 +7335,7 @@
         },
         {
             "id": "c497e727-e54c-5522-aa0d-eff604a510cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bda977-e5d1-4813-a5f5-265023965142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bda977-e5d1-4813-a5f5-265023965142.jpg?1",
             "name": "Malcator, Purity Overseer",
             "text": "When Malcator, Purity Overseer enters the battlefield, create a 3/3 colorless Phyrexian Golem artifact creature token.\nAt the beginning of your end step, if three or more artifacts entered the battlefield under your control this turn, create a 3/3 colorless Phyrexian Golem artifact creature token.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "1e5e358e-534d-5e18-9e5b-b37df31133ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1329ad9-5989-4920-b17b-943b9b4a0cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1329ad9-5989-4920-b17b-943b9b4a0cd9.jpg?1",
             "name": "Melira, the Living Cure",
             "text": "If you would get one or more poison counters, instead you get one poison counter and you can't get additional poison counters this turn.\nExile Melira, the Living Cure: Choose another target creature or artifact. When it's put into a graveyard this turn, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -7420,7 +7420,7 @@
         },
         {
             "id": "b72c847f-81f7-508f-bdd8-8580cdd589af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1171899-07d8-4e60-a79b-f162f59dc3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1171899-07d8-4e60-a79b-f162f59dc3ce.jpg?1",
             "name": "Migloz, Maze Crusher",
             "text": "Migloz, Maze Crusher enters the battlefield with five oil counters on it.\n{1}, Remove an oil counter from Migloz: It gains vigilance and menace until end of turn.\n{2}, Remove two oil counters from Migloz: It gets +2/+2 until end of turn.\n{3}, Remove three oil counters from Migloz: Destroy target artifact or enchantment.",
             "colours": [
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "1faa0a14-481c-53d0-9dd5-ccf714d4d0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578e35b9-7252-4767-a1f3-aecd71256515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578e35b9-7252-4767-a1f3-aecd71256515.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "Compleated ({Red White Mana for Phyrexian} can be paid with {R}, {W}, or 2 life. If life was paid, this planeswalker enters with two fewer loyalty counters.)\n+1: Until your next turn, up to one target creature attacks a player each combat if able.\n+1: Discard a card, then draw a card.\n0: Exile target creature or Equipment card with mana value less than Nahiri's loyalty from your graveyard. Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -7506,7 +7506,7 @@
         },
         {
             "id": "bdacc19b-1ba6-54e1-a072-efa0bb4a7857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87519b36-1d95-4020-a61d-6afb75555e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87519b36-1d95-4020-a61d-6afb75555e3e.jpg?1",
             "name": "Necrogen Rotpriest",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.",
             "colours": [
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "e7d0e9e1-1a1e-58fe-a989-2a20982ff527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298cf34-7aa5-4f97-a86c-7f28d2113b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298cf34-7aa5-4f97-a86c-7f28d2113b87.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "Flying\nWard\u2014{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "6f8151d0-1016-5d0c-9ef1-c7ed0d327c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7531ed3-235f-4368-98a8-e4e1947c53fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7531ed3-235f-4368-98a8-e4e1947c53fb.jpg?1",
             "name": "Ria Ivor, Bane of Bladehold",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nAt the beginning of combat on your turn, the next time target creature would deal combat damage to one or more players this combat, prevent that damage. If damage is prevented this way, create that many 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "0164f94a-5768-5f1b-b623-f5699c3cf9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31147651-9a5e-4329-923b-e464f67135e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31147651-9a5e-4329-923b-e464f67135e9.jpg?1",
             "name": "Serum-Core Chimera",
             "text": "Flying\nWhenever you cast a noncreature spell, put an oil counter on Serum-Core Chimera.\nRemove three oil counters from Serum-Core Chimera: Draw a card. Then you may discard a nonland card. When you discard a card this way, Serum-Core Chimera deals 3 damage to target creature or planeswalker. Activate only as a sorcery.",
             "colours": [
@@ -7668,7 +7668,7 @@
         },
         {
             "id": "962f89e1-2bdf-5c33-8f08-21a5f2d196fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a37aa46-bcf3-48a5-9f74-05e4878ad96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a37aa46-bcf3-48a5-9f74-05e4878ad96f.jpg?1",
             "name": "Slaughter Singer",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever another creature you control with toxic attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -7707,7 +7707,7 @@
         },
         {
             "id": "c34584b0-15b9-5f99-abd6-756b9200890a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cba67a-b714-49b0-9797-24aca283f162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cba67a-b714-49b0-9797-24aca283f162.jpg?1",
             "name": "Tainted Observer",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhenever another creature enters the battlefield under your control, you may pay {2}. If you do, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -7744,7 +7744,7 @@
         },
         {
             "id": "b37b5d29-bdeb-5b5a-9017-05abb45f8ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605fe1-9a20-4c95-b53e-1249cedb978b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66605fe1-9a20-4c95-b53e-1249cedb978b.jpg?1",
             "name": "Tyvar, Jubilant Brawler",
             "text": "You may activate abilities of creatures you control as though those creatures had haste.\n+1: Untap up to one target creature.\n\u22122: Mill three cards, then you may return a creature card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -7785,7 +7785,7 @@
         },
         {
             "id": "6453e540-883a-5efb-82f3-da93fd7ae064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5b94b8-0420-40f2-b989-39cb43cff916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5b94b8-0420-40f2-b989-39cb43cff916.jpg?1",
             "name": "Venser, Corpse Puppet",
             "text": "Lifelink, toxic 1\nWhenever you proliferate, choose one \u2014\n\u2022 If you don't control a creature named The Hollow Sentinel, create The Hollow Sentinel, a legendary 3/3 colorless Phyrexian Golem artifact creature token.\n\u2022 Target artifact creature you control gains flying and lifelink until end of turn.",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "c49a8ac8-e978-5f45-b79b-f02d859ad844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c46a3-72b8-4e04-adf2-c9c7aaf94f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626c46a3-72b8-4e04-adf2-c9c7aaf94f04.jpg?1",
             "name": "Vivisection Evangelist",
             "text": "Vigilance\nCorrupted \u2014 When Vivisection Evangelist enters the battlefield, if an opponent has three or more poison counters, destroy target creature or planeswalker an opponent controls.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "17841d45-2c10-54f5-952e-6f9649989031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a48705f-bd8a-43f1-b1fe-14a5c9a83ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a48705f-bd8a-43f1-b1fe-14a5c9a83ccd.jpg?1",
             "name": "Voidwing Hybrid",
             "text": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen you proliferate, return Voidwing Hybrid from your graveyard to your hand.",
             "colours": [
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "dbde4eab-eb45-54be-a42f-e95995d370ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746e3ab-c0a6-46c1-a418-275b419962e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746e3ab-c0a6-46c1-a418-275b419962e4.jpg?1",
             "name": "Argentum Masticore",
             "text": "First strike, protection from multicolored\nAt the beginning of your upkeep, sacrifice Argentum Masticore unless you discard a card. When you discard a card this way, destroy target nonland permanent an opponent controls with mana value less than or equal to the mana value of the discarded card.",
             "colours": [],
@@ -7936,7 +7936,7 @@
         },
         {
             "id": "d97bbf63-2a4f-57a9-aed3-2fcd9e7074ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdedebad-f71e-4434-871e-5bbbd3c07a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdedebad-f71e-4434-871e-5bbbd3c07a12.jpg?1",
             "name": "Atraxa's Skitterfang",
             "text": "Atraxa's Skitterfang enters the battlefield with three oil counters on it.\nAt the beginning of combat on your turn, you may remove an oil counter from Atraxa's Skitterfang. When you do, target creature you control gains your choice of flying, vigilance, deathtouch, or lifelink until end of turn.",
             "colours": [],
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "9d521f23-2078-5df0-b2e5-0e88d238280a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f0ae2-db68-4338-93f9-9d9268cec41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2f0ae2-db68-4338-93f9-9d9268cec41e.jpg?1",
             "name": "Basilica Skullbomb",
             "text": "{1}, Sacrifice Basilica Skullbomb: Draw a card.\n{2}{W}, Sacrifice Basilica Skullbomb: Target creature you control gets +2/+2 and gains flying until end of turn. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -7998,7 +7998,7 @@
         },
         {
             "id": "ed03fd2c-0bf7-5237-b9ce-42ed6287cddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66270dd2-9139-4329-9621-852962836688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66270dd2-9139-4329-9621-852962836688.jpg?1",
             "name": "Dross Skullbomb",
             "text": "{1}, Sacrifice Dross Skullbomb: Draw a card.\n{2}{B}, Sacrifice Dross Skullbomb: Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "8504a0b8-dc1a-512e-929d-5cd519039314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d2c689-af37-433a-a012-e8d384702811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d2c689-af37-433a-a012-e8d384702811.jpg?1",
             "name": "Dune Mover",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen Dune Mover enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -8060,7 +8060,7 @@
         },
         {
             "id": "a293647c-5273-5d38-9987-e929af697213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0958a1-1bac-48be-888d-f7573f409a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0958a1-1bac-48be-888d-f7573f409a9b.jpg?1",
             "name": "The Filigree Sylex",
             "text": "{T}: Put an oil counter on The Filigree Sylex.\n{T}, Sacrifice The Filigree Sylex: Destroy each nonland permanent with mana value equal to the number of oil counters on The Filigree Sylex.\n{T}, Remove ten oil counters from among permanents you control and sacrifice The Filigree Sylex: It deals 10 damage to any target.",
             "colours": [],
@@ -8092,7 +8092,7 @@
         },
         {
             "id": "89a813e2-8b74-5674-a12b-3ea8509b70d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb530f9d-cf35-48a7-8711-f74b3d9a35a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb530f9d-cf35-48a7-8711-f74b3d9a35a7.jpg?1",
             "name": "Furnace Skullbomb",
             "text": "{1}, Sacrifice Furnace Skullbomb: Draw a card.\n{1}{R}, Sacrifice Furnace Skullbomb: Put two oil counters on target artifact or creature you control. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8122,7 +8122,7 @@
         },
         {
             "id": "1281a038-9a04-56db-92c4-6b00c066826f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e73b63-17cc-4dca-abd6-728b74bc37a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e73b63-17cc-4dca-abd6-728b74bc37a8.jpg?1",
             "name": "Graaz, Unstoppable Juggernaut",
             "text": "Juggernauts you control attack each combat if able.\nJuggernauts you control can't be blocked by Walls.\nOther creatures you control have base power and toughness 5/3 and are Juggernauts in addition to their other creature types.",
             "colours": [],
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "3d5f3101-7947-572e-9883-2a05b66ddb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e555abb1-ffd4-4143-9be8-ec8a758f5c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e555abb1-ffd4-4143-9be8-ec8a758f5c2a.jpg?1",
             "name": "Ichorplate Golem",
             "text": "Whenever a creature enters the battlefield under your control, if it has one or more oil counters on it, put an oil counter on it.\nCreatures you control with oil counters on them get +1/+1.",
             "colours": [],
@@ -8190,7 +8190,7 @@
         },
         {
             "id": "cf713e79-43f5-5d0d-a005-abde8c0102ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1073aee2-aea6-473d-97c6-248778d79d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1073aee2-aea6-473d-97c6-248778d79d80.jpg?1",
             "name": "Maze Skullbomb",
             "text": "{1}, Sacrifice Maze Skullbomb: Draw a card.\n{2}{G}, Sacrifice Maze Skullbomb: Target creature you control gets +3/+3 and gains trample until end of turn. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "df89add1-9ab4-5fac-999f-67e1f789d206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76fe2f2-ce2c-49e4-9f00-89c82f2fae8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76fe2f2-ce2c-49e4-9f00-89c82f2fae8d.jpg?1",
             "name": "Mirran Safehouse",
             "text": "As long as Mirran Safehouse is on the battlefield, it has all activated abilities of all land cards in all graveyards.",
             "colours": [],
@@ -8250,7 +8250,7 @@
         },
         {
             "id": "e2a85358-af52-53c1-a4b7-9933a921617c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab892e7b-6797-4ede-ab5d-d9d0fa488c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab892e7b-6797-4ede-ab5d-d9d0fa488c80.jpg?1",
             "name": "Monument to Perfection",
             "text": "{3}, {T}: Search your library for a basic, Sphere, or Locus land card, reveal it, put it into your hand, then shuffle.\n{3}: Monument to Perfection becomes a 9/9 Phyrexian Construct artifact creature, loses all abilities, and gains indestructible and toxic 9. Activate only if there are nine or more lands with different names among the basic, Sphere, and Locus lands you control.",
             "colours": [],
@@ -8280,7 +8280,7 @@
         },
         {
             "id": "2df501c8-8536-58be-aa10-3209c42faa9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg?1",
             "name": "Myr Convert",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\n{T}, Pay 2 life: Add one mana of any color.",
             "colours": [],
@@ -8315,7 +8315,7 @@
         },
         {
             "id": "a68a6509-353f-55a0-b478-a5d2b173ccbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bfdd21-4d46-4ec2-ba25-f16b6993f1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bfdd21-4d46-4ec2-ba25-f16b6993f1a8.jpg?1",
             "name": "Myr Custodian",
             "text": "When Myr Custodian enters the battlefield, scry 2. Then each opponent may scry 1. (To scry X, that player looks at the top X cards of their library, then put any number of them on the bottom and the rest on top in any order.)",
             "colours": [],
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "6914752a-c557-58b5-a9c5-d002997c6856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6046e50a-f4c9-4029-a589-62a19371b734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6046e50a-f4c9-4029-a589-62a19371b734.jpg?1",
             "name": "Myr Kinsmith",
             "text": "When Myr Kinsmith enters the battlefield, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -8377,7 +8377,7 @@
         },
         {
             "id": "cdc59af9-db9e-5cb4-b0be-3d812f6b2d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5adb509-6ad3-4838-925d-1cafa926b83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5adb509-6ad3-4838-925d-1cafa926b83a.jpg?1",
             "name": "Phyrexian Atlas",
             "text": "{T}: Add one mana of any color.\nCorrupted \u2014 Whenever Phyrexian Atlas becomes tapped, each opponent who has three or more poison counters loses 1 life.",
             "colours": [],
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "ff8208f0-ce25-5034-9acd-4baa1d692c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3056ac38-7630-4301-88bb-a012a5b186ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3056ac38-7630-4301-88bb-a012a5b186ed.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8433,7 +8433,7 @@
         },
         {
             "id": "cc4be521-bef6-53df-b9d8-af4cf506e3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a1beec-bafe-4243-b91e-040a88fb0e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a1beec-bafe-4243-b91e-040a88fb0e95.jpg?1",
             "name": "Prosthetic Injector",
             "text": "Equipped creature gets +0/+2 and has toxic 1. (Players dealt combat damage by equipped creature also get a poison counter.)\nEquip {1}",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "c1254c43-4574-5a8a-ad6a-9014e76b6227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec8f984-5ed4-4b34-8b2a-a113cbba001d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec8f984-5ed4-4b34-8b2a-a113cbba001d.jpg?1",
             "name": "Ribskiff",
             "text": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhen Ribskiff enters the battlefield, draw a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8493,7 +8493,7 @@
         },
         {
             "id": "b3d3b304-e427-5502-9075-9bb02fddbe7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9991fd-ea6a-4ed7-b5f1-46a95f8d0634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9991fd-ea6a-4ed7-b5f1-46a95f8d0634.jpg?1",
             "name": "Soulless Jailer",
             "text": "Permanent cards in graveyards can't enter the battlefield.\nPlayers can't cast noncreature spells from graveyards or exile.",
             "colours": [],
@@ -8527,7 +8527,7 @@
         },
         {
             "id": "ec257bb0-a4ac-5d8d-9071-7a50ee6a25cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2934af5-aa4f-4c88-adbd-dcd847ef43a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2934af5-aa4f-4c88-adbd-dcd847ef43a2.jpg?1",
             "name": "Staff of Compleation",
             "text": "{T}, Pay 1 life: Destroy target permanent you own.\n{T}, Pay 2 life: Add one mana of any color.\n{T}, Pay 3 life: Proliferate.\n{T}, Pay 4 life: Draw a card.\n{5}: Untap Staff of Compleation.",
             "colours": [],
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "5ff878e7-33c8-5c9a-8f02-1f2bec9add19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg?1",
             "name": "Surgical Skullbomb",
             "text": "{1}, Sacrifice Surgical Skullbomb: Draw a card.\n{2}{U}, Sacrifice Surgical Skullbomb: Return target creature to its owner's hand. Draw a card. Activate only as a sorcery.",
             "colours": [],
@@ -8587,7 +8587,7 @@
         },
         {
             "id": "41fc2554-ffdb-5897-a0b5-d023a1ce60c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa3621-8a2c-4b4b-87ac-f981192a0567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa3621-8a2c-4b4b-87ac-f981192a0567.jpg?1",
             "name": "Sword of Forge and Frontier",
             "text": "Equipped creature gets +2/+2 and has protection from red and from green.\nWhenever equipped creature deals combat damage to a player, exile the top two cards of your library. You may play those cards this turn. You may play an additional land this turn.\nEquip {2}",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "ac12fd65-4caa-5089-a4e5-70486b0df317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9747e4b0-fcf9-4f1d-b990-2a3e461adfee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9747e4b0-fcf9-4f1d-b990-2a3e461adfee.jpg?1",
             "name": "Tablet of Compleation",
             "text": "{T}: Put an oil counter on Tablet of Compleation.\n{T}: Add {C}. Activate only if Tablet of Compleation has two or more oil counters on it.\n{1}, {T}: Draw a card. Activate only if Tablet of Compleation has five or more oil counters on it.",
             "colours": [],
@@ -8649,7 +8649,7 @@
         },
         {
             "id": "c81a1ccc-ea6f-5cd0-b37e-6769d51afed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431fe83-7dc7-4c40-8d66-6525560e4323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1431fe83-7dc7-4c40-8d66-6525560e4323.jpg?1",
             "name": "Zenith Chronicler",
             "text": "Whenever a player casts their first multicolored spell each turn, each other player draws a card.",
             "colours": [],
@@ -8683,7 +8683,7 @@
         },
         {
             "id": "a32683d9-7e4b-5dde-8b67-290f2995b2f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16f96f5-a2a6-4ac4-bdae-326cee92bf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16f96f5-a2a6-4ac4-bdae-326cee92bf2e.jpg?1",
             "name": "The Autonomous Furnace",
             "text": "The Autonomous Furnace enters the battlefield tapped.\n{T}: Add {R}.\n{1}{R}, {T}, Sacrifice The Autonomous Furnace: Draw a card.",
             "colours": [],
@@ -8715,7 +8715,7 @@
         },
         {
             "id": "140bad0a-64b8-5f64-a73d-1e9d9095b667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1441fba4-fe06-4b5f-a103-aa6cf59a3859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1441fba4-fe06-4b5f-a103-aa6cf59a3859.jpg?1",
             "name": "Blackcleave Cliffs",
             "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8748,7 +8748,7 @@
         },
         {
             "id": "76dca8d1-34e6-5e31-b571-5c6cb9e4bd4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0f36b-7d8c-4e77-adc2-a4dad93a81d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0f36b-7d8c-4e77-adc2-a4dad93a81d5.jpg?1",
             "name": "Copperline Gorge",
             "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8781,7 +8781,7 @@
         },
         {
             "id": "c6092d44-6658-5556-858b-4c7afc31e48e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbda15b-e49a-4445-a0e1-f221aa82c1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbda15b-e49a-4445-a0e1-f221aa82c1e8.jpg?1",
             "name": "Darkslick Shores",
             "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "78d187c6-3baa-5ae8-add9-18e18734216f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d469f1-2219-4466-9f8a-769ee43e28db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d469f1-2219-4466-9f8a-769ee43e28db.jpg?1",
             "name": "The Dross Pits",
             "text": "The Dross Pits enters the battlefield tapped.\n{T}: Add {B}.\n{1}{B}, {T}, Sacrifice The Dross Pits: Draw a card.",
             "colours": [],
@@ -8846,7 +8846,7 @@
         },
         {
             "id": "2caf45dc-59c5-571a-a35a-f1d380cc70b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d6ba55-7bc0-41c6-84be-8cd528e46a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d6ba55-7bc0-41c6-84be-8cd528e46a05.jpg?1",
             "name": "The Fair Basilica",
             "text": "The Fair Basilica enters the battlefield tapped.\n{T}: Add {W}.\n{1}{W}, {T}, Sacrifice The Fair Basilica: Draw a card.",
             "colours": [],
@@ -8878,7 +8878,7 @@
         },
         {
             "id": "bfdbb395-bf75-54cf-9cd1-3d2af2955617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6389c242-2139-4f12-af30-2b080a1c5e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6389c242-2139-4f12-af30-2b080a1c5e83.jpg?1",
             "name": "The Hunter Maze",
             "text": "The Hunter Maze enters the battlefield tapped.\n{T}: Add {G}.\n{1}{G}, {T}, Sacrifice The Hunter Maze: Draw a card.",
             "colours": [],
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "f9ea76b0-2a1e-5277-a24b-b57b9b51053c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a702cd-ca49-4570-b47e-8b090452a3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a702cd-ca49-4570-b47e-8b090452a3c3.jpg?1",
             "name": "Mirrex",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Activate only if Mirrex entered the battlefield this turn.\n{3}, {T}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by it also get a poison counter.)",
             "colours": [],
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "883d83eb-055b-53ae-9318-0f9e1583dbb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6785057-0d06-4f91-b45f-c05f7c4e2b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6785057-0d06-4f91-b45f-c05f7c4e2b19.jpg?1",
             "name": "The Monumental Facade",
             "text": "The Monumental Facade enters the battlefield with two oil counters on it.\n{T}: Add {C}.\n{T}, Remove an oil counter from The Monumental Facade: Put an oil counter on target artifact or creature you control. Activate only as a sorcery.",
             "colours": [],
@@ -8974,7 +8974,7 @@
         },
         {
             "id": "7e44d41f-161b-5b6b-a913-aebb3e292a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a931463-25f6-4e31-95b4-bb4a9388009b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a931463-25f6-4e31-95b4-bb4a9388009b.jpg?1",
             "name": "The Mycosynth Gardens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{X}, {T}: The Mycosynth Gardens becomes a copy of target nontoken artifact you control with mana value X.",
             "colours": [],
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "4a778101-c1d6-5413-a27d-9d0927434d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b26f68-3a25-4c4e-bc76-a199ab479a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b26f68-3a25-4c4e-bc76-a199ab479a50.jpg?1",
             "name": "Razorverge Thicket",
             "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "7d614044-85d6-59db-b32f-0c6faf34f916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed7441f-f624-49c8-8611-d9bba0e441ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed7441f-f624-49c8-8611-d9bba0e441ac.jpg?1",
             "name": "Seachrome Coast",
             "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9072,7 +9072,7 @@
         },
         {
             "id": "0ce4cdcb-5d49-581c-9ab6-0eb57e95249d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c91aad-bf33-448e-b122-65940fb2e33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c91aad-bf33-448e-b122-65940fb2e33b.jpg?1",
             "name": "The Seedcore",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast Phyrexian creature spells.\nCorrupted \u2014 {T}: Target 1/1 creature gets +2/+1 until end of turn. Activate only if an opponent has three or more poison counters.",
             "colours": [],
@@ -9104,7 +9104,7 @@
         },
         {
             "id": "583277bf-d414-52cc-84de-e20080b3eea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49ec35-2c4f-4144-85fe-226f7cb67266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b49ec35-2c4f-4144-85fe-226f7cb67266.jpg?1",
             "name": "The Surgical Bay",
             "text": "The Surgical Bay enters the battlefield tapped.\n{T}: Add {U}.\n{1}{U}, {T}, Sacrifice The Surgical Bay: Draw a card.",
             "colours": [],
@@ -9136,7 +9136,7 @@
         },
         {
             "id": "79bdf24d-3306-528d-a4c5-39920c6f5954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adceb34-78c7-40dd-af31-6fb282d577ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adceb34-78c7-40dd-af31-6fb282d577ca.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9164,7 +9164,7 @@
         },
         {
             "id": "033b1a64-bdc0-59ec-8c1d-7fdbabd65956",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50958c6e-9555-42ad-9bb3-2da9faa5cb52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50958c6e-9555-42ad-9bb3-2da9faa5cb52.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9202,7 +9202,7 @@
         },
         {
             "id": "2a6ab51e-424f-5487-85ec-943339e2dc2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6322d4-52bf-471a-a5b2-8329ef4be39a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c6322d4-52bf-471a-a5b2-8329ef4be39a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9240,7 +9240,7 @@
         },
         {
             "id": "7194b0ea-d862-564d-b459-7c48500cf781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736a0484-e091-4178-92c5-c517b0e92f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736a0484-e091-4178-92c5-c517b0e92f3d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "fee13d2f-7a4c-5b3b-bb4f-2860155c20ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9e44c1-7b51-47cb-b564-608deb46cc44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9e44c1-7b51-47cb-b564-608deb46cc44.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9316,7 +9316,7 @@
         },
         {
             "id": "2fc57869-a899-5d3c-8270-50e7cc317ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fce7045-4572-4e9e-8853-2a5dcfc989ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fce7045-4572-4e9e-8853-2a5dcfc989ac.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9354,7 +9354,7 @@
         },
         {
             "id": "e823b2cd-efe1-55dc-b04f-bcb81dbdaea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ccde39-98bd-4a67-bfcf-a66d9fbd9417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36ccde39-98bd-4a67-bfcf-a66d9fbd9417.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "ed09057a-b976-56a7-a80b-b6fac64c0f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97baa8-5e57-45b6-9c64-cb9ce4806294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97baa8-5e57-45b6-9c64-cb9ce4806294.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "e475bd17-a94e-52d0-921f-e298e4649800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e9fa1-6a50-4697-8645-fea4524e8dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/187e9fa1-6a50-4697-8645-fea4524e8dde.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "6d4ef65f-47de-5e7e-b268-e28362c6d0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c61b29-797f-4fda-acf1-039a807954c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c61b29-797f-4fda-acf1-039a807954c9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9506,7 +9506,7 @@
         },
         {
             "id": "001b516c-09a3-5776-92d3-944fee7c18e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ec4ded-7c8d-416a-9a12-3e5d6c91ac93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ec4ded-7c8d-416a-9a12-3e5d6c91ac93.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "5aeb8a6b-f2dd-5201-a315-fa37f04c3b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db14da86-6721-4e22-9b61-4a5680d4e5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db14da86-6721-4e22-9b61-4a5680d4e5a3.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "479243a5-f674-5b21-ba5e-00ebf23c9cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa641d46-d002-4903-af72-e96971f558bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa641d46-d002-4903-af72-e96971f558bc.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "570f0826-2dea-5ad3-82fd-a03517fca7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485c620-f1fb-4715-b7c5-d2d56588308d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d485c620-f1fb-4715-b7c5-d2d56588308d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9658,7 +9658,7 @@
         },
         {
             "id": "66de1103-e901-5910-a332-e91877915390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd95f833-27ce-447c-b505-02137daaba4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd95f833-27ce-447c-b505-02137daaba4c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9696,7 +9696,7 @@
         },
         {
             "id": "c952ea2f-c71f-5071-b07e-ad840d56bb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e911e-7e12-4d99-806c-5cfba19ea8f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9e911e-7e12-4d99-806c-5cfba19ea8f3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9734,7 +9734,7 @@
         },
         {
             "id": "835fcbd6-c719-5c01-b569-81d71d9094bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1374a1-2795-4477-b800-e8a777391ef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1374a1-2795-4477-b800-e8a777391ef6.jpg?1",
             "name": "Ossification",
             "text": "Enchant basic land you control\nWhen Ossification enters the battlefield, exile target creature or planeswalker an opponent controls until Ossification leaves the battlefield.",
             "colours": [
@@ -9770,7 +9770,7 @@
         },
         {
             "id": "cf6b4bab-4dfe-5617-81e5-d7a36f247d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d056ff-ee47-4718-8587-6f172cdf8b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d056ff-ee47-4718-8587-6f172cdf8b2c.jpg?1",
             "name": "Experimental Augury",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order. Proliferate.",
             "colours": [
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "118e682b-fe9e-5502-9103-bf43650d19f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d6e50e-d339-49b5-ab97-4b38bba7c187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7d6e50e-d339-49b5-ab97-4b38bba7c187.jpg?1",
             "name": "Sheoldred's Edict",
             "text": "Choose one \u2014\n\u2022 Each opponent sacrifices a nontoken creature.\n\u2022 Each opponent sacrifices a creature token.\n\u2022 Each opponent sacrifices a planeswalker.",
             "colours": [
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "86691d07-203e-5cf9-82e5-29ed5f92bc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fd082c-3209-4268-8bf8-01dbbda15f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4fd082c-3209-4268-8bf8-01dbbda15f1d.jpg?1",
             "name": "Bladehold War-Whip",
             "text": "For Mirrodin\nEquip abilities you activate of other Equipment cost {1} less to activate.\nEquipped creature has double strike.\nEquip {3}{R}{W}",
             "colours": [
@@ -9876,7 +9876,7 @@
         },
         {
             "id": "114cc2b1-66b9-5b72-9839-62f23889703b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a802def-efe2-4f65-9dff-a1c0d800b146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a802def-efe2-4f65-9dff-a1c0d800b146.jpg?1",
             "name": "Slaughter Singer",
             "text": "Toxic 2\nWhenever another creature you control with toxic attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -9915,7 +9915,7 @@
         },
         {
             "id": "93749cb0-2d01-5b80-b630-ff97d25e5ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c2d370-982d-4b1b-b9b3-371b08121b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c2d370-982d-4b1b-b9b3-371b08121b1f.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nOther Rats you control have toxic 1.\nWhen Karumonix enters the battlefield, look at the top five cards of your library. You may reveal any number of Rat cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "dab29a67-28a9-5847-a77e-1f0771b55be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b18d219-efde-4cc0-b955-cb71ead88023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b18d219-efde-4cc0-b955-cb71ead88023.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -9989,7 +9989,7 @@
         },
         {
             "id": "ed7712f8-8771-5828-9c5a-2faa0e49d6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c79dbc-0b75-4ffb-bc17-42cfe3cbd7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c79dbc-0b75-4ffb-bc17-42cfe3cbd7e4.jpg?1",
             "name": "Green Sun's Twilight",
             "text": "Reveal the top X plus one cards of your library. Choose a creature card and/or a land card from among them. Put those cards into your hand and the rest on the bottom of your library in a random order. If X is 5 or more, instead put the chosen cards onto the battlefield or into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10023,7 +10023,7 @@
         },
         {
             "id": "349d7608-d871-539d-b768-bfd6523b2697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85465be2-7327-4e1f-8a4b-d24dca4f3ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85465be2-7327-4e1f-8a4b-d24dca4f3ada.jpg?1",
             "name": "Bladed Ambassador",
             "text": "Bladed Ambassador enters the battlefield with an oil counter on it.\n{1}, Remove an oil counter from Bladed Ambassador: Bladed Ambassador gains indestructible until end of turn.",
             "colours": [
@@ -10061,7 +10061,7 @@
         },
         {
             "id": "918ef7db-4500-5365-a46d-e254bc9837be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7836bd5e-9df3-4f24-adce-ca7028fea78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7836bd5e-9df3-4f24-adce-ca7028fea78f.jpg?1",
             "name": "Sinew Dancer",
             "text": "{3}{W}, {T}: Tap target creature.\nCorrupted \u2014 {W}, {T}: Tap target creature. Activate only if an opponent has three or more poison counters.",
             "colours": [
@@ -10099,7 +10099,7 @@
         },
         {
             "id": "41aa8a9b-b8e7-5b2d-b9d3-7bf627c7c400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b394cdd1-a632-4b57-8356-4e2d9c9620f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b394cdd1-a632-4b57-8356-4e2d9c9620f7.jpg?1",
             "name": "Quicksilver Fisher",
             "text": "Flying\nWhen Quicksilver Fisher enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -10137,7 +10137,7 @@
         },
         {
             "id": "ec5bbe93-5a39-5d12-b9d5-2a310fee0d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9dd552-1020-4e82-ba51-f54b3938b920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9dd552-1020-4e82-ba51-f54b3938b920.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate.",
             "colours": [
@@ -10176,7 +10176,7 @@
         },
         {
             "id": "e33edf3e-e3e4-5adb-906f-71d259a1807e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20364e49-0948-411a-b58f-b0d12fedce43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20364e49-0948-411a-b58f-b0d12fedce43.jpg?1",
             "name": "Blightbelly Rat",
             "text": "Toxic 1\nWhen Blightbelly Rat dies, proliferate.",
             "colours": [
@@ -10214,7 +10214,7 @@
         },
         {
             "id": "374b0827-86e2-5bf0-8e3f-a278e646fe48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e1de30-1899-49ef-88ae-6defc69f19b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e1de30-1899-49ef-88ae-6defc69f19b3.jpg?1",
             "name": "Bonepicker Skirge",
             "text": "Flying\nCorrupted \u2014 As long as an opponent has three or more poison counters, Bonepicker Skirge has deathtouch and lifelink.",
             "colours": [
@@ -10252,7 +10252,7 @@
         },
         {
             "id": "77b74dda-4f80-575a-ad5c-fe808e2fc33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66c086-bb19-45d1-8387-17348f2c5c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f66c086-bb19-45d1-8387-17348f2c5c78.jpg?1",
             "name": "Furnace Punisher",
             "text": "Menace\nAt the beginning of each player's upkeep, Furnace Punisher deals 2 damage to that player unless they control two or more basic lands.",
             "colours": [
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "b3add4bb-63b8-52ff-85ab-5849c1d80605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3df8b6-3f31-4d1c-a165-40cb3f2e2233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3df8b6-3f31-4d1c-a165-40cb3f2e2233.jpg?1",
             "name": "Sawblade Scamp",
             "text": "Haste\nWhenever you cast a noncreature spell, put an oil counter on Sawblade Scamp.\n{T}, Remove an oil counter from Sawblade Scamp: It deals 1 damage to each opponent.",
             "colours": [
@@ -10328,7 +10328,7 @@
         },
         {
             "id": "5d13fb08-96f0-5517-8a9f-bcc768635444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d419a3d0-c1ee-4c7a-a88c-a6a8b1f7ab6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d419a3d0-c1ee-4c7a-a88c-a6a8b1f7ab6e.jpg?1",
             "name": "Urabrask's Anointer",
             "text": "When Urabrask's Anointer enters the battlefield, it deals X damage to any target, where X is the number of permanents you control with oil counters on them.",
             "colours": [
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "08fd4e5a-83ab-5688-aaee-3585a8ea05b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02272f89-dd8e-4a07-8bd4-b33ad4e12888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02272f89-dd8e-4a07-8bd4-b33ad4e12888.jpg?1",
             "name": "Cankerbloom",
             "text": "{1}, Sacrifice Cankerbloom: Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Proliferate.",
             "colours": [
@@ -10405,7 +10405,7 @@
         },
         {
             "id": "5f94a228-3093-5cba-8613-ece1bcbe40f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8ef6fc-a81b-4354-aa65-c88590522d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8ef6fc-a81b-4354-aa65-c88590522d30.jpg?1",
             "name": "Rustvine Cultivator",
             "text": "{T}: Put an oil counter on Rustvine Cultivator.\n{T}, Remove an oil counter from Rustvine Cultivator: Untap target land.",
             "colours": [
@@ -10444,7 +10444,7 @@
         },
         {
             "id": "e5d92ef1-e112-57ea-b695-bb8e50a3de2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b4fe48-f9e6-4606-9901-76dd85fd7038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b4fe48-f9e6-4606-9901-76dd85fd7038.jpg?1",
             "name": "Necrogen Rotpriest",
             "text": "Toxic 2\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.",
             "colours": [
@@ -10485,7 +10485,7 @@
         },
         {
             "id": "8f90f581-52ab-551f-a745-38dce55111b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb7150-5157-4471-8874-4f9258c5d396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb7150-5157-4471-8874-4f9258c5d396.jpg?1",
             "name": "Myr Convert",
             "text": "Toxic 1\n{T}, Pay 2 life: Add one mana of any color.",
             "colours": [],
@@ -10520,7 +10520,7 @@
         },
         {
             "id": "e1e6c672-8060-5a49-b4c1-16d9aa3a38ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db44dd2-6bb4-4f0b-8bab-c0d89ba7f2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db44dd2-6bb4-4f0b-8bab-c0d89ba7f2ca.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -10567,7 +10567,7 @@
         },
         {
             "id": "81f3f988-934e-5aa0-8938-9aa7393b52c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c633ffe8-2198-4d62-969c-9a44a7ca132d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c633ffe8-2198-4d62-969c-9a44a7ca132d.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n{1}{PW}{PW}, Sacrifice two other artifacts and/or creatures: Put an indestructible counter on Mondrak, Glory Dominus.",
             "colours": [
@@ -10608,7 +10608,7 @@
         },
         {
             "id": "17a5bd77-30c4-5b0c-a421-b052f68db75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1b0b81-6f78-4c4b-9d0d-28acf0a15940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1b0b81-6f78-4c4b-9d0d-28acf0a15940.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "Flying\nIf damage would be dealt to Phyrexian Vindicator, prevent that damage. When damage is prevented this way, Phyrexian Vindicator deals that much damage to any other target.",
             "colours": [
@@ -10647,7 +10647,7 @@
         },
         {
             "id": "a1b4e9c3-be1c-5403-b371-6e86a5c42cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4862ed-7be8-4fd0-9150-a20e56d1e858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c4862ed-7be8-4fd0-9150-a20e56d1e858.jpg?1",
             "name": "Skrelv, Defector Mite",
             "text": "Toxic 1\nSkrelv, Defector Mite can't block.\n{PW}, {T}: Choose a color. Another target creature you control gains toxic 1 and hexproof from that color until end of turn. It can't be blocked by creatures of that color this turn.",
             "colours": [
@@ -10688,7 +10688,7 @@
         },
         {
             "id": "0cfe8b12-6a8d-5c40-926b-93af05f007fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c17f88-440b-443a-bca7-6f4e8587cffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c17f88-440b-443a-bca7-6f4e8587cffb.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "Flying\nIf you would proliferate, proliferate twice instead.\n{1}{PU}{PU}, Remove three counters from among other artifacts, creatures, and planeswalkers you control: Put an indestructible counter on Tekuthal, Inquiry Dominus.",
             "colours": [
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "29456adc-b67a-520a-a76c-de5229c30445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc001d-b20b-4d6e-b744-f4f19339f0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3bc001d-b20b-4d6e-b744-f4f19339f0cb.jpg?1",
             "name": "Unctus, Grand Metatect",
             "text": "Other blue creatures you control have \"Whenever this creature becomes tapped, draw a card, then discard a card.\"\nOther artifact creatures you control get +1/+1.\n{PU}: Until end of turn, target creature you control becomes a blue artifact in addition to its other colors and types. Activate only as a sorcery.",
             "colours": [
@@ -10770,7 +10770,7 @@
         },
         {
             "id": "94ce7a4c-73e7-5b56-a831-37e606a28252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4aad94-5b0e-4644-b331-39dae2a7e937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a4aad94-5b0e-4644-b331-39dae2a7e937.jpg?1",
             "name": "Archfiend of the Dross",
             "text": "Flying\nArchfiend of the Dross enters the battlefield with four oil counters on it.\nAt the beginning of your upkeep, remove an oil counter from Archfiend of the Dross. Then if it has no oil counters on it, you lose the game.\nWhenever a creature an opponent controls dies, its controller loses 2 life.",
             "colours": [
@@ -10808,7 +10808,7 @@
         },
         {
             "id": "d649fb73-5f39-5f68-a893-58290efbf50f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676cf76-027d-423b-a84c-19179cee9d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676cf76-027d-423b-a84c-19179cee9d08.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n{PB}{PB}, Exile three creature cards from your graveyard: Put an indestructible counter on Drivnod, Carnage Dominus.",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "0f2c845c-d0d8-52d8-b6ef-a9482018f571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0957749-7539-4aa4-b89c-61c0e8ad0c55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0957749-7539-4aa4-b89c-61c0e8ad0c55.jpg?1",
             "name": "Geth, Thane of Contracts",
             "text": "Other creatures you control get -1/-1.\n{1}{B}{B}, {T}: Return target creature card from your graveyard to the battlefield. It gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else.\" Activate only as a sorcery.",
             "colours": [
@@ -10889,7 +10889,7 @@
         },
         {
             "id": "87d43a8a-c8a5-5ae7-a459-2b6a3c1d7646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55e3-71c5-4444-a307-76c8ccc0a02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ea55e3-71c5-4444-a307-76c8ccc0a02b.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "Toxic 1\nOther Rats you control have toxic 1.\nWhen Karumonix enters the battlefield, look at the top five cards of your library. You may reveal any number of Rat cards from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10930,7 +10930,7 @@
         },
         {
             "id": "872a5f71-a168-54b7-ae1e-9d97df26eb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216360c-ce9a-443a-b5c1-0ecd08aed37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a216360c-ce9a-443a-b5c1-0ecd08aed37f.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "Trample\nWhenever a source deals damage to Phyrexian Obliterator, that source's controller sacrifices that many permanents.",
             "colours": [
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "72654f92-fde1-5c58-b7f8-02d614811372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d279e-8350-4baf-9aa8-3c6f7b7ae444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d279e-8350-4baf-9aa8-3c6f7b7ae444.jpg?1",
             "name": "Vraan, Executioner Thane",
             "text": "Whenever one or more other creatures you control die, each opponent loses 2 life and you gain 2 life. This ability triggers only once each turn.",
             "colours": [
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "5609cdbc-a206-5d70-b9b8-a7bc51a6afa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fcddc7-126a-4e2c-898d-dcf488618cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93fcddc7-126a-4e2c-898d-dcf488618cf0.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "This spell costs {3} less to cast if you have nine or more cards in your graveyard.\nFlying\nWhen Capricious Hellraiser enters the battlefield, exile three cards at random from your graveyard. Choose a noncreature, nonland card from among them and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -11048,7 +11048,7 @@
         },
         {
             "id": "365ab43f-ff90-5e26-ae3a-f789dda0482c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0c255c-d42e-413c-8afd-c8f373600cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0c255c-d42e-413c-8afd-c8f373600cbf.jpg?1",
             "name": "Slobad, Iron Goblin",
             "text": "{T}, Sacrifice an artifact: Add an amount of {R} equal to the sacrificed artifact's mana value. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -11089,7 +11089,7 @@
         },
         {
             "id": "2e54c269-1181-597c-af15-c8091e653de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91271b80-cc8c-436f-983e-3f168febeb99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91271b80-cc8c-436f-983e-3f168febeb99.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "If a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, it deals double that damage to that player or permanent instead.\n{1}{PR}{PR}, Discard two cards: Put an indestructible counter on Solphim, Mayhem Dominus.",
             "colours": [
@@ -11130,7 +11130,7 @@
         },
         {
             "id": "89b350fb-95db-5ae4-933a-e0019449924c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dd555e-cd27-4b9e-9ee6-b785242637d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1dd555e-cd27-4b9e-9ee6-b785242637d6.jpg?1",
             "name": "Evolved Spinoderm",
             "text": "Evolved Spinoderm enters the battlefield with four oil counters on it.\nEvolved Spinoderm has trample as long as it has two or fewer oil counters on it. Otherwise, it has hexproof.\nAt the beginning of your upkeep, remove an oil counter from Evolved Spinoderm. Then if it has no oil counters on it, sacrifice it.",
             "colours": [
@@ -11168,7 +11168,7 @@
         },
         {
             "id": "c1d9701f-2738-521a-b7df-b863daf15057",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3697cb-416c-49ca-a80a-c681e15230ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3697cb-416c-49ca-a80a-c681e15230ce.jpg?1",
             "name": "Tyrranax Rex",
             "text": "This spell can't be countered.\nTrample, toxic 4, ward {4}, haste",
             "colours": [
@@ -11207,7 +11207,7 @@
         },
         {
             "id": "fdaeea0f-2407-5b18-8630-42c53071aaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49782a6f-1a14-47c1-a6e6-e5650092684f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49782a6f-1a14-47c1-a6e6-e5650092684f.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "Reach\nAt the beginning of each combat, double the power and toughness of each creature you control until end of turn.\n{PG}{PG}, Sacrifice two other creatures: Put an indestructible counter on Zopandrel, Hunger Dominus.",
             "colours": [
@@ -11248,7 +11248,7 @@
         },
         {
             "id": "73907208-58f7-5afa-bac8-c44e4684120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e5d02-d3d0-45e5-a589-1fe25ff5082b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e51e5d02-d3d0-45e5-a589-1fe25ff5082b.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "Flying, vigilance, deathtouch, lifelink\nWhen Atraxa, Grand Unifier enters the battlefield, reveal the top ten cards of your library. For each card type, you may put a card of that type from among the revealed cards into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11295,7 +11295,7 @@
         },
         {
             "id": "cdddeb2b-ffb6-5930-b890-fcfb68360236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3be4338-2c79-470a-a11f-8f7370d98e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3be4338-2c79-470a-a11f-8f7370d98e85.jpg?1",
             "name": "Ezuri, Stalker of Spheres",
             "text": "When Ezuri, Stalker of Spheres enters the battlefield, you may pay {3}. If you do, proliferate twice.\nWhenever you proliferate, draw a card.",
             "colours": [
@@ -11338,7 +11338,7 @@
         },
         {
             "id": "86fe28e3-19d6-5506-8d2f-2a475b38197b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cecd38-6729-4870-8fad-4dfa4f9fcc3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cecd38-6729-4870-8fad-4dfa4f9fcc3a.jpg?1",
             "name": "Glissa Sunslayer",
             "text": "First strike, deathtouch\nWhenever Glissa Sunslayer deals combat damage to a player, choose one \u2014\n\u2022 You draw a card and you lose 1 life.\n\u2022 Destroy target enchantment.\n\u2022 Remove up to three counters from target permanent.",
             "colours": [
@@ -11381,7 +11381,7 @@
         },
         {
             "id": "32f35b50-83cf-5400-ae06-c832ed1478f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34e3ef-8d6d-4304-bb19-803f8c049205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f34e3ef-8d6d-4304-bb19-803f8c049205.jpg?1",
             "name": "Kethek, Crucible Goliath",
             "text": "At the beginning of your end step, you may sacrifice another creature. If you do, reveal cards from the top of your library until you reveal a nonlegendary creature card with lesser mana value, put it onto the battlefield, then put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11423,7 +11423,7 @@
         },
         {
             "id": "1cb0779f-91cb-5310-a9ac-221685cce123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2960de-b1ee-4ac3-bf34-835e7edb6582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2960de-b1ee-4ac3-bf34-835e7edb6582.jpg?1",
             "name": "Malcator, Purity Overseer",
             "text": "When Malcator, Purity Overseer enters the battlefield, create a 3/3 colorless Phyrexian Golem artifact creature token.\nAt the beginning of your end step, if three or more artifacts entered the battlefield under your control this turn, create a 3/3 colorless Phyrexian Golem artifact creature token.",
             "colours": [
@@ -11466,7 +11466,7 @@
         },
         {
             "id": "86e9a9b5-a5eb-57d6-b8ed-4072b09c2332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f24481-fd89-4d0e-bb64-1f6afe4f17df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f24481-fd89-4d0e-bb64-1f6afe4f17df.jpg?1",
             "name": "Migloz, Maze Crusher",
             "text": "Migloz, Maze Crusher enters the battlefield with five oil counters on it.\n{1}, Remove an oil counter from Migloz: It gains vigilance and menace until end of turn.\n{2}, Remove two oil counters from Migloz: It gets +2/+2 until end of turn.\n{3}, Remove three oil counters from Migloz: Destroy target artifact or enchantment.",
             "colours": [
@@ -11508,7 +11508,7 @@
         },
         {
             "id": "46d3009b-572b-5c35-b220-6e466423e500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52321500-b025-4195-819a-4b895315d0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52321500-b025-4195-819a-4b895315d0ee.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "Flying\nWard\u2014{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
             "colours": [
@@ -11550,7 +11550,7 @@
         },
         {
             "id": "fcc1acdf-59b3-5b6f-b435-12bd4b7ad170",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e4160e-bc91-416e-8ab0-49742fd8ed63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7e4160e-bc91-416e-8ab0-49742fd8ed63.jpg?1",
             "name": "Ria Ivor, Bane of Bladehold",
             "text": "Battle cry\nAt the beginning of combat on your turn, the next time target creature would deal combat damage to one or more players this combat, prevent that damage. If damage is prevented this way, create that many 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -11592,7 +11592,7 @@
         },
         {
             "id": "8b2bfea9-701a-5b76-bbe8-6c9f813f0f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7089903f-25cb-4eda-9ebb-ddad36fc8610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7089903f-25cb-4eda-9ebb-ddad36fc8610.jpg?1",
             "name": "Venser, Corpse Puppet",
             "text": "Lifelink, toxic 1\nWhenever you proliferate, choose one \u2014\n\u2022 If you don't control a creature named The Hollow Sentinel, create The Hollow Sentinel, a legendary 3/3 colorless Phyrexian Golem artifact creature token.\n\u2022 Target artifact creature you control gains flying and lifelink until end of turn.",
             "colours": [
@@ -11635,7 +11635,7 @@
         },
         {
             "id": "b7531f1f-fd7e-5c99-9525-d8b530f11c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b1acf9-9d25-4d80-a364-34eecaa474b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b1acf9-9d25-4d80-a364-34eecaa474b0.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "Compleated\n+1: Until your next turn, up to one target creature gets -3/-0.\n\u22122: Target player mills three cards. Then if a graveyard has twenty or more cards in it, you draw three cards. Otherwise, you draw a card.\n\u2212X: Target player mills three times X cards.",
             "colours": [
@@ -11677,7 +11677,7 @@
         },
         {
             "id": "e6261f1b-248b-5aa4-8bdb-8d9f9a171c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdbadc3-f93d-4ec8-aa56-3fe235b9a85e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdbadc3-f93d-4ec8-aa56-3fe235b9a85e.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "Compleated\n0: You draw a card and you lose 1 life. Proliferate.\n\u22122: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\u22129: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.",
             "colours": [
@@ -11719,7 +11719,7 @@
         },
         {
             "id": "b64afc3d-a8e6-58ca-939e-15b35f95600c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a0ced-c1c9-4a35-b1ce-476506afc030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4a0ced-c1c9-4a35-b1ce-476506afc030.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "Compleated\n+1: Create an X/X green Phyrexian Horror creature token, where X is Nissa, Ascended Animist's loyalty.\n\u22121: Destroy target artifact or enchantment.\n\u22127: Until end of turn, creatures you control get +1/+1 for each Forest you control and gain trample.",
             "colours": [
@@ -11761,7 +11761,7 @@
         },
         {
             "id": "39a68207-0be5-5248-aca9-831155f20a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b70560-5c87-4aa7-9e92-5c80e4cc1115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b70560-5c87-4aa7-9e92-5c80e4cc1115.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "Compleated\n+1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.\n\u22121: Create a 3/3 green Phyrexian Beast creature token with toxic 1.\n\u22124: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers, where X is the greatest power among creatures you controlled as you activated this ability.",
             "colours": [
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "b1889829-459a-50f7-bf4a-36cde8037059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad016ccb-bb4d-427a-a6c2-9fd65924e542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad016ccb-bb4d-427a-a6c2-9fd65924e542.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "Compleated\n+1: Until your next turn, up to one target creature attacks a player each combat if able.\n+1: Discard a card, then draw a card.\n0: Exile target creature or Equipment card with mana value less than Nahiri's loyalty from your graveyard. Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -11849,7 +11849,7 @@
         },
         {
             "id": "3318293c-c846-58a6-b104-f029befc1ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192ccc7f-ffb1-4f78-8cf0-a220df612be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192ccc7f-ffb1-4f78-8cf0-a220df612be7.jpg?1",
             "name": "Kemba, Kha Enduring",
             "text": "Whenever Kemba, Kha Enduring or another Cat enters the battlefield under your control, attach up to one target Equipment you control to that creature.\nEquipped creatures you control get +1/+1.\n{3}{W}{W}: Create a 2/2 white Cat creature token.",
             "colours": [
@@ -11889,7 +11889,7 @@
         },
         {
             "id": "45bcac82-2327-5dec-8d7f-558e4d09b1e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374b5642-8fd2-414b-b634-9a9cba801846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374b5642-8fd2-414b-b634-9a9cba801846.jpg?1",
             "name": "Thrun, Breaker of Silence",
             "text": "This spell can't be countered.\nTrample\nThrun, Breaker of Silence can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.\nAs long as it's your turn, Thrun has indestructible.",
             "colours": [
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "19ae57ae-94fe-55f0-bafe-1f64c2e55f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01502e03-4cd6-40ef-b8fe-93e76e7ed54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01502e03-4cd6-40ef-b8fe-93e76e7ed54b.jpg?1",
             "name": "Jor Kadeen, First Goldwarden",
             "text": "Trample\nWhenever Jor Kadeen, First Goldwarden attacks, it gets +X/+X until end of turn, where X is the number of equipped creatures you control. Then if Jor Kadeen's power is 4 or greater, draw a card.",
             "colours": [
@@ -11971,7 +11971,7 @@
         },
         {
             "id": "c9450738-87c8-512e-900c-c375cb7d66c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54455a6a-5a59-4a2f-b7e9-732a11d49f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54455a6a-5a59-4a2f-b7e9-732a11d49f6d.jpg?1",
             "name": "Melira, the Living Cure",
             "text": "If you would get one or more poison counters, instead you get one poison counter and you can't get additional poison counters this turn.\nExile Melira, the Living Cure: Choose another target creature or artifact. When it's put into a graveyard this turn, return that card to the battlefield under its owner's control.",
             "colours": [
@@ -12013,7 +12013,7 @@
         },
         {
             "id": "cb83ef19-aa6c-554b-9a53-c43839defcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e29a758-d930-4a99-b524-fc72bd125485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e29a758-d930-4a99-b524-fc72bd125485.jpg?1",
             "name": "Graaz, Unstoppable Juggernaut",
             "text": "Juggernauts you control attack each combat if able.\nJuggernauts you control can't be blocked by Walls.\nOther creatures you control have base power and toughness 5/3 and are Juggernauts in addition to their other creature types.",
             "colours": [],
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "a7070278-1396-55fa-ba70-5cd38a7d14af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af4c00-014c-448c-ac48-53a4698cf8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2af4c00-014c-448c-ac48-53a4698cf8d8.jpg?1",
             "name": "The Eternal Wanderer",
             "text": "No more than one creature can attack The Eternal Wanderer each combat.\n+1: Exile up to one target artifact or creature. Return that card to the battlefield under its owner's control at the beginning of that player's next end step.\n0: Create a 2/2 white Samurai creature token with double strike.\n\u22124: For each player, choose a creature that player controls. Each player sacrifices all creatures they control not chosen this way.",
             "colours": [
@@ -12086,7 +12086,7 @@
         },
         {
             "id": "757f6de6-d8cd-58d8-ad8a-5f074283cfcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b48007-37d7-49b9-ad47-1fe0db14c3c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0b48007-37d7-49b9-ad47-1fe0db14c3c4.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "Compleated\n+1: Until your next turn, up to one target creature gets -3/-0.\n\u22122: Target player mills three cards. Then if a graveyard has twenty or more cards in it, you draw three cards. Otherwise, you draw a card.\n\u2212X: Target player mills three times X cards.",
             "colours": [
@@ -12128,7 +12128,7 @@
         },
         {
             "id": "20d4c1da-25f5-5685-abb8-871cb25be961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa015843-2aff-4184-9432-a548e379b1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa015843-2aff-4184-9432-a548e379b1f4.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "Compleated\n0: You draw a card and you lose 1 life. Proliferate.\n\u22122: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\u22129: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.",
             "colours": [
@@ -12170,7 +12170,7 @@
         },
         {
             "id": "1c62caf6-826f-5b9d-85ab-c21284db73df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fc1c96-849e-43a8-9e7f-3c3af6861155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fc1c96-849e-43a8-9e7f-3c3af6861155.jpg?1",
             "name": "Koth, Fire of Resistance",
             "text": "+2: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n\u22123: Koth, Fire of Resistance deals damage to target creature equal to the number of Mountains you control.\n\u22127: You get an emblem with \"Whenever a Mountain enters the battlefield under your control, this emblem deals 4 damage to any target.\"",
             "colours": [
@@ -12209,7 +12209,7 @@
         },
         {
             "id": "37d2bc9d-f0cb-5b96-bcd8-b6e3058e3a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d6d5a-acd4-444d-a670-2fc87e4d53b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d6d5a-acd4-444d-a670-2fc87e4d53b0.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "Compleated\n+1: Create an X/X green Phyrexian Horror creature token, where X is Nissa, Ascended Animist's loyalty.\n\u22121: Destroy target artifact or enchantment.\n\u22127: Until end of turn, creatures you control get +1/+1 for each Forest you control and gain trample.",
             "colours": [
@@ -12251,7 +12251,7 @@
         },
         {
             "id": "84e11d08-2917-5507-81d0-2c98a39b0e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f04ee2-dd29-4ce8-98a6-d8b669c71308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f04ee2-dd29-4ce8-98a6-d8b669c71308.jpg?1",
             "name": "Kaito, Dancing Shadow",
             "text": "Whenever one or more creatures you control deal combat damage to a player, you may return one of them to its owner's hand. If you do, you may activate loyalty abilities of Kaito twice this turn rather than only once.\n+1: Up to one target creature can't attack or block until your next turn.\n0: Draw a card.\n\u22122: Create a 2/2 colorless Drone artifact creature token with deathtouch and \"When this creature leaves the battlefield, each opponent loses 2 life and you gain 2 life.\"",
             "colours": [
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "11acd014-5c18-50d7-8ab5-a3ac0364b942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35830b2-b622-4b95-b36f-37c3de83c694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35830b2-b622-4b95-b36f-37c3de83c694.jpg?1",
             "name": "Kaya, Intangible Slayer",
             "text": "Hexproof\n+2: Each opponent loses 3 life and you gain 3 life.\n0: You draw two cards. Then each opponent may scry 1.\n\u22123: Exile target creature or enchantment. If it wasn't an Aura, create a token that's a copy of it, except it's a 1/1 white Spirit creature with flying in addition to its other types.",
             "colours": [
@@ -12333,7 +12333,7 @@
         },
         {
             "id": "92d8bd84-3de6-576b-a7a7-670087354f23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5e2da-3e4f-4f48-8510-619ff3cc5952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d5e2da-3e4f-4f48-8510-619ff3cc5952.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "Compleated\n+1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.\n\u22121: Create a 3/3 green Phyrexian Beast creature token with toxic 1.\n\u22124: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers, where X is the greatest power among creatures you controlled as you activated this ability.",
             "colours": [
@@ -12377,7 +12377,7 @@
         },
         {
             "id": "42286bd8-c3b2-503a-a1ef-2557e678a41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d97fd-b5d7-4c9d-b1ed-d84e2ba820fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/123d97fd-b5d7-4c9d-b1ed-d84e2ba820fa.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "Compleated\n+1: Until your next turn, up to one target creature attacks a player each combat if able.\n+1: Discard a card, then draw a card.\n0: Exile target creature or Equipment card with mana value less than Nahiri's loyalty from your graveyard. Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -12421,7 +12421,7 @@
         },
         {
             "id": "55da91da-7ce4-5851-8b00-9d822a945e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bddf1b3-e23f-4f05-977d-257881b8babe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bddf1b3-e23f-4f05-977d-257881b8babe.jpg?1",
             "name": "Tyvar, Jubilant Brawler",
             "text": "You may activate abilities of creatures you control as though those creatures had haste.\n+1: Untap up to one target creature.\n\u22122: Mill three cards, then you may return a creature card with mana value 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -12462,7 +12462,7 @@
         },
         {
             "id": "7d437eb9-e2c7-5850-9e5e-c82026f6b4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ceaf6-b22d-4a4f-aa04-41202d72b379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124ceaf6-b22d-4a4f-aa04-41202d72b379.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -12508,7 +12508,7 @@
         },
         {
             "id": "a4cadcaf-f018-52ea-8436-27e36d13ed24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef1b6a8-0151-4e41-a909-3d519dc19f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef1b6a8-0151-4e41-a909-3d519dc19f14.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "",
             "colours": [
@@ -12548,7 +12548,7 @@
         },
         {
             "id": "08d560a9-98e5-5025-aed8-2129bdb7d38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8bb65-07b7-462a-9bbb-0f48cb872b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a8bb65-07b7-462a-9bbb-0f48cb872b43.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "",
             "colours": [
@@ -12586,7 +12586,7 @@
         },
         {
             "id": "18ee7d02-5440-5f52-bfb0-ae75662e1348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac5bc52-dd0d-473e-ad8a-a0f5b546d1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac5bc52-dd0d-473e-ad8a-a0f5b546d1ee.jpg?1",
             "name": "Ichormoon Gauntlet",
             "text": "",
             "colours": [
@@ -12619,7 +12619,7 @@
         },
         {
             "id": "16ac6bdf-4fe4-53e9-8b52-1c186ba0e41e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9b1f69-baf8-4e36-8612-d4fc486a5568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9b1f69-baf8-4e36-8612-d4fc486a5568.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "",
             "colours": [
@@ -12659,7 +12659,7 @@
         },
         {
             "id": "58ad6b04-c057-519a-a3aa-cf6a6b74d92e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682cdf8e-6248-49bc-816d-35e75de64a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682cdf8e-6248-49bc-816d-35e75de64a1f.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "",
             "colours": [
@@ -12699,7 +12699,7 @@
         },
         {
             "id": "28f5ed5f-21b1-55fb-9901-e08f3c16f491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c44e5-dd14-4569-8e2d-466f72eaf287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a01c44e5-dd14-4569-8e2d-466f72eaf287.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "",
             "colours": [
@@ -12737,7 +12737,7 @@
         },
         {
             "id": "73765b7d-f169-57d1-9810-c9a5c46a5eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff67241-4c6a-436d-893b-ef7760825e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4ff67241-4c6a-436d-893b-ef7760825e68.jpg?1",
             "name": "All Will Be One",
             "text": "",
             "colours": [
@@ -12770,7 +12770,7 @@
         },
         {
             "id": "59b0ffc0-8b0d-5db6-9780-6cfc1d882c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7bdd7a-6d85-4d9c-ae21-c0701160b348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7bdd7a-6d85-4d9c-ae21-c0701160b348.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "",
             "colours": [
@@ -12808,7 +12808,7 @@
         },
         {
             "id": "b0c52e89-e2cb-595b-800b-4532d2a61f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8273b43-6702-412e-b0c1-4c715fa24ed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8273b43-6702-412e-b0c1-4c715fa24ed6.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "",
             "colours": [
@@ -12848,7 +12848,7 @@
         },
         {
             "id": "6986b9f3-74bb-5db2-b4f4-8a5f3c3b3fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9989f-6314-4bae-9404-430582af2bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0c9989f-6314-4bae-9404-430582af2bf5.jpg?1",
             "name": "Tyrranax Rex",
             "text": "",
             "colours": [
@@ -12886,7 +12886,7 @@
         },
         {
             "id": "4e017e79-d6d9-5bc3-9640-d2ae8f72adde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4e681-91f2-47ad-942e-b1c1950ff81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e4e681-91f2-47ad-942e-b1c1950ff81d.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "",
             "colours": [
@@ -12926,7 +12926,7 @@
         },
         {
             "id": "253a7431-e232-59b4-955f-ce4e87b68a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b484a071-1e65-4bb3-893b-d34d7d101af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b484a071-1e65-4bb3-893b-d34d7d101af8.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "",
             "colours": [
@@ -12972,7 +12972,7 @@
         },
         {
             "id": "a2e75550-8378-50d0-80e7-a791c80133ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315490d2-4d1f-4065-9d18-4682f1d7d066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315490d2-4d1f-4065-9d18-4682f1d7d066.jpg?1",
             "name": "Staff of Compleation",
             "text": "",
             "colours": [],
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "a0c48f39-a25d-5fef-bee8-c42cdd5343c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d98f3d-046c-4acc-8cd3-51876844613c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d98f3d-046c-4acc-8cd3-51876844613c.jpg?1",
             "name": "Sword of Forge and Frontier",
             "text": "",
             "colours": [],
@@ -13032,7 +13032,7 @@
         },
         {
             "id": "38b4bca4-0dab-549d-b409-d4c86b590efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d00f39-cdc0-4e26-b2c7-0aae50f76e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d00f39-cdc0-4e26-b2c7-0aae50f76e85.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "",
             "colours": [
@@ -13073,7 +13073,7 @@
         },
         {
             "id": "fb262505-2f6f-56f3-9593-69387fdeb47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4d205-8721-46c4-81b9-017c9a5adcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4d205-8721-46c4-81b9-017c9a5adcae.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "",
             "colours": [
@@ -13114,7 +13114,7 @@
         },
         {
             "id": "5d43ef27-f5a5-52e4-ac22-c4df1bc8173a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e4d34-65c1-4d5f-8689-600c68c01931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440e4d34-65c1-4d5f-8689-600c68c01931.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "",
             "colours": [
@@ -13155,7 +13155,7 @@
         },
         {
             "id": "a74d2d5c-b75b-5a48-8287-fb6e23f381a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c1d8c-ddb8-4617-8d59-5427cbde7972.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c1d8c-ddb8-4617-8d59-5427cbde7972.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "",
             "colours": [
@@ -13198,7 +13198,7 @@
         },
         {
             "id": "4d548085-e5e4-56a4-94d6-763616773fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7a6dbb-9dee-4e2b-8372-e74f49fe83d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf7a6dbb-9dee-4e2b-8372-e74f49fe83d1.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "",
             "colours": [
@@ -13241,7 +13241,7 @@
         },
         {
             "id": "8a41f21f-6cea-5957-8ecc-0a10389141d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82b57f-a886-4423-a921-9932055feb68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e82b57f-a886-4423-a921-9932055feb68.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -13278,7 +13278,7 @@
         },
         {
             "id": "1ada23b6-f837-5c93-8be4-256481515379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6f4848-85b9-4770-9820-516e2a295284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a6f4848-85b9-4770-9820-516e2a295284.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13315,7 +13315,7 @@
         },
         {
             "id": "7dcc04ce-1788-5229-abea-56596487a2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af92ec23-a252-4ae2-98d7-0dce19d18e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af92ec23-a252-4ae2-98d7-0dce19d18e35.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13352,7 +13352,7 @@
         },
         {
             "id": "92ae7986-05f3-5df2-99f0-f39f491848fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b4fb7-dbfe-4d9d-b520-4a307c31c876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864b4fb7-dbfe-4d9d-b520-4a307c31c876.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -13389,7 +13389,7 @@
         },
         {
             "id": "d184a3d0-65b1-5f03-84cc-a4a3eaf7d9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d94fa1c-48d1-48bc-b725-5c11a158507b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d94fa1c-48d1-48bc-b725-5c11a158507b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "069f26dc-ea0f-5f69-83db-3122da6f1cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359ab776-e30c-4ccf-8fb8-8597812f131d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359ab776-e30c-4ccf-8fb8-8597812f131d.jpg?1",
             "name": "Blackcleave Cliffs",
             "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -13459,7 +13459,7 @@
         },
         {
             "id": "feefae0a-d8a7-5d1c-a67f-f885abe35192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d316dca-05e6-471e-99ad-dfd9eecedf39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d316dca-05e6-471e-99ad-dfd9eecedf39.jpg?1",
             "name": "Copperline Gorge",
             "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -13492,7 +13492,7 @@
         },
         {
             "id": "8ef8239b-d954-504d-93cf-c5f5be8731fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b95c400-8fa0-489d-b401-5e2ec4241942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b95c400-8fa0-489d-b401-5e2ec4241942.jpg?1",
             "name": "Darkslick Shores",
             "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -13525,7 +13525,7 @@
         },
         {
             "id": "e34148ce-2ce6-5e31-a548-28210a9a674d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedadf47-0e1e-4569-9da6-fac097f32497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedadf47-0e1e-4569-9da6-fac097f32497.jpg?1",
             "name": "Razorverge Thicket",
             "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -13558,7 +13558,7 @@
         },
         {
             "id": "8500abb8-7a5b-5688-bde0-920ba7d759de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f4e8-aa29-4c68-ab89-7a529bae73e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c37f4e8-aa29-4c68-ab89-7a529bae73e9.jpg?1",
             "name": "Seachrome Coast",
             "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -13591,7 +13591,7 @@
         },
         {
             "id": "14a735e6-55d5-50f7-9083-dd130a2da580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf5e4f-c907-4ab4-877d-90fe7623cb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cf5e4f-c907-4ab4-877d-90fe7623cb81.jpg?1",
             "name": "Norn's Wellspring",
             "text": "Whenever a creature you control dies, scry 1 and put an oil counter on Norn's Wellspring.\n{1}, {T}, Remove two oil counters from Norn's Wellspring: Draw a card.",
             "colours": [
@@ -13625,7 +13625,7 @@
         },
         {
             "id": "58a0fea6-7953-529b-ae7d-2643221774f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029caf7-da57-4894-ab27-4718977817c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2029caf7-da57-4894-ab27-4718977817c5.jpg?1",
             "name": "Skrelv's Hive",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"\nCorrupted \u2014 As long as an opponent has three or more poison counters, creatures you control with toxic have lifelink.",
             "colours": [
@@ -13659,7 +13659,7 @@
         },
         {
             "id": "dc7de853-76a7-5121-ab56-36919a1a724b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8d13-45e5-4ead-8617-0b3939bb9123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/920c8d13-45e5-4ead-8617-0b3939bb9123.jpg?1",
             "name": "White Sun's Twilight",
             "text": "You gain X life. Create X 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\" If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -13693,7 +13693,7 @@
         },
         {
             "id": "9e81fc5b-53bc-5ffe-b7d3-514ea3800dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e3aa37-80dc-4c5a-b118-788298ee3fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1e3aa37-80dc-4c5a-b118-788298ee3fd5.jpg?1",
             "name": "Blade of Shared Souls",
             "text": "For Mirrodin\nWhenever Blade of Shared Souls becomes attached to a creature, for as long as Blade of Shared Souls remains attached to it, you may have that creature become a copy of another target creature you control.\nEquip {2}",
             "colours": [
@@ -13729,7 +13729,7 @@
         },
         {
             "id": "ee92fd87-40e6-5131-80a4-3d55beb25783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7a6f3e-4e9f-4e50-ab60-17dc1b494fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7a6f3e-4e9f-4e50-ab60-17dc1b494fa5.jpg?1",
             "name": "Blue Sun's Twilight",
             "text": "Gain control of target creature with mana value X or less. If X is 5 or more, create a token that's a copy of that creature.",
             "colours": [
@@ -13763,7 +13763,7 @@
         },
         {
             "id": "b6eaac7f-6503-5be4-b9b1-a77a94c730d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764475dd-00ee-4e5b-bf17-06b5c534ffe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764475dd-00ee-4e5b-bf17-06b5c534ffe0.jpg?1",
             "name": "Encroaching Mycosynth",
             "text": "Nonland permanents you control are artifacts in addition to their other types. The same is true for permanent spells you control and nonland permanent cards you own that aren't on the battlefield.",
             "colours": [
@@ -13797,7 +13797,7 @@
         },
         {
             "id": "b27bc2ad-c557-5de6-925c-8979c1af3d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b820e40-178d-4dac-b5f9-e4192e6d9161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b820e40-178d-4dac-b5f9-e4192e6d9161.jpg?1",
             "name": "Mercurial Spelldancer",
             "text": "Mercurial Spelldancer can't be blocked.\nWhenever you cast a noncreature spell, put an oil counter on Mercurial Spelldancer.\nWhenever Mercurial Spelldancer deals combat damage to a player, you may remove two oil counters from it. If you do, when you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -13834,7 +13834,7 @@
         },
         {
             "id": "c7a169b0-2ad3-5293-9652-a32671c91782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e92da4c-85ed-4afa-8755-dc9627491b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e92da4c-85ed-4afa-8755-dc9627491b07.jpg?1",
             "name": "Mindsplice Apparatus",
             "text": "Flash\nAt the beginning of your upkeep, put an oil counter on Mindsplice Apparatus.\nInstant and sorcery spells you cast cost {1} less to cast for each oil counter on Mindsplice Apparatus.",
             "colours": [
@@ -13868,7 +13868,7 @@
         },
         {
             "id": "668b9602-035e-542d-a98e-0e0980d02b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646144b6-f644-4a3f-af46-63feb16bd0f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646144b6-f644-4a3f-af46-63feb16bd0f9.jpg?1",
             "name": "Black Sun's Twilight",
             "text": "Up to one target creature gets -X/-X until end of turn. If X is 5 or more, return a creature card with mana value X or less from your graveyard to the battlefield tapped.",
             "colours": [
@@ -13902,7 +13902,7 @@
         },
         {
             "id": "8cb3b628-c30b-5bff-bb12-14966c7f0b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0ecf3a-ac0e-45a6-98ae-8c043c636252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb0ecf3a-ac0e-45a6-98ae-8c043c636252.jpg?1",
             "name": "Phyrexian Arena",
             "text": "At the beginning of your upkeep, you draw a card and you lose 1 life.",
             "colours": [
@@ -13937,7 +13937,7 @@
         },
         {
             "id": "1926cccd-2ea8-56f9-b950-892b09c0ca5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eccd1f0-8e03-48c7-b457-c616c0bd79ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eccd1f0-8e03-48c7-b457-c616c0bd79ae.jpg?1",
             "name": "Dragonwing Glider",
             "text": "For Mirrodin\nEquipped creature gets +2/+2 and has flying and haste.\nEquip {3}{R}{R}",
             "colours": [
@@ -13973,7 +13973,7 @@
         },
         {
             "id": "fc74836a-1902-59d0-87e1-4c3cea64ceef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf27ba9-7d6a-41d1-acec-a55c25e39997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf27ba9-7d6a-41d1-acec-a55c25e39997.jpg?1",
             "name": "Red Sun's Twilight",
             "text": "Destroy up to X target artifacts. If X is 5 or more, for each artifact destroyed this way, create a token that's a copy of it. Those tokens gain haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -14007,7 +14007,7 @@
         },
         {
             "id": "a0ce5988-857e-56c7-a922-d4b9358a9185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd0ae70-db67-43d8-beab-e70c97794d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd0ae70-db67-43d8-beab-e70c97794d7b.jpg?1",
             "name": "Urabrask's Forge",
             "text": "At the beginning of combat on your turn, put an oil counter on Urabrask's Forge, then create an X/1 red Phyrexian Horror creature token with trample and haste, where X is the number of oil counters on Urabrask's Forge. Sacrifice that token at the beginning of the next end step.",
             "colours": [
@@ -14041,7 +14041,7 @@
         },
         {
             "id": "9e9d87cb-6276-5158-8fba-827e043a9fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c266012-6374-4870-917a-532fadf917ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c266012-6374-4870-917a-532fadf917ad.jpg?1",
             "name": "Vindictive Flamestoker",
             "text": "Whenever you cast a noncreature spell, put an oil counter on Vindictive Flamestoker.\n{6}{R}, Sacrifice Vindictive Flamestoker: Discard your hand, then draw four cards. This ability costs {1} less to activate for each oil counter on Vindictive Flamestoker.",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "cc8a2a3f-ee66-5775-a33b-8c84eb207cbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53285ae-3345-4ebf-836f-8eb8ae43c21f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53285ae-3345-4ebf-836f-8eb8ae43c21f.jpg?1",
             "name": "Bloated Contaminator",
             "text": "Trample, toxic 1\nWhenever Bloated Contaminator deals combat damage to a player, proliferate.",
             "colours": [
@@ -14115,7 +14115,7 @@
         },
         {
             "id": "bc0c6360-89f9-5404-9120-0224573ce3ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc653708-e7de-48fb-ba4f-6e52163160e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc653708-e7de-48fb-ba4f-6e52163160e2.jpg?1",
             "name": "Conduit of Worlds",
             "text": "You may play lands from your graveyard.\n{T}: Choose target nonland permanent card in your graveyard. If you haven't cast a spell this turn, you may cast that card. If you do, you can't cast additional spells this turn. Activate only as a sorcery.",
             "colours": [
@@ -14149,7 +14149,7 @@
         },
         {
             "id": "e86979f7-39b7-57e2-8dd2-b895bdb78611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8f1ec-a5d6-4ad5-af27-2604f1fb211a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a8f1ec-a5d6-4ad5-af27-2604f1fb211a.jpg?1",
             "name": "Green Sun's Twilight",
             "text": "Reveal the top X plus one cards of your library. Choose a creature card and/or a land card from among them. Put those cards into your hand and the rest on the bottom of your library in a random order. If X is 5 or more, instead put the chosen cards onto the battlefield or into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14184,7 +14184,7 @@
         },
         {
             "id": "0b2f7c20-9905-5cee-b393-0bce147521fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ea9176-16cf-4064-8c69-071a520a110b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ea9176-16cf-4064-8c69-071a520a110b.jpg?1",
             "name": "Venerated Rotpriest",
             "text": "Toxic 1\nWhenever a creature you control becomes the target of a spell, target opponent gets a poison counter.",
             "colours": [
@@ -14221,7 +14221,7 @@
         },
         {
             "id": "43ba161c-89d5-56d4-a94d-f3e9c0477c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149425d1-e0d3-4b97-b893-b8a5055e0e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/149425d1-e0d3-4b97-b893-b8a5055e0e7d.jpg?1",
             "name": "Argentum Masticore",
             "text": "First strike, protection from multicolored\nAt the beginning of your upkeep, sacrifice Argentum Masticore unless you discard a card. When you discard a card this way, destroy target nonland permanent an opponent controls with mana value less than or equal to the mana value of the discarded card.",
             "colours": [],
@@ -14255,7 +14255,7 @@
         },
         {
             "id": "93a13057-2799-5031-9804-20b4aeabae8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2638457b-276c-4738-acff-a75e9c4ac7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2638457b-276c-4738-acff-a75e9c4ac7c7.jpg?1",
             "name": "The Filigree Sylex",
             "text": "{T}: Put an oil counter on The Filigree Sylex.\n{T}, Sacrifice The Filigree Sylex: Destroy each nonland permanent with mana value equal to the number of oil counters on The Filigree Sylex.\n{T}, Remove ten oil counters from among permanents you control and sacrifice The Filigree Sylex: It deals 10 damage to any target.",
             "colours": [],
@@ -14287,7 +14287,7 @@
         },
         {
             "id": "7e22c845-3356-5733-a2be-10a6ea3f0078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d109ca-5ffa-4854-a18f-b7485fe307cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d109ca-5ffa-4854-a18f-b7485fe307cc.jpg?1",
             "name": "Mirran Safehouse",
             "text": "As long as Mirran Safehouse is on the battlefield, it has all activated abilities of all land cards in all graveyards.",
             "colours": [],
@@ -14317,7 +14317,7 @@
         },
         {
             "id": "d391ab6d-c672-5338-9b2f-8ea973c12138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ccd6b-dab6-4657-97ed-58caead1287f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ccd6b-dab6-4657-97ed-58caead1287f.jpg?1",
             "name": "Monument to Perfection",
             "text": "{3}, {T}: Search your library for a basic, Sphere, or Locus land card, reveal it, put it into your hand, then shuffle.\n{3}: Monument to Perfection becomes a 9/9 Phyrexian Construct artifact creature, loses all abilities, and gains indestructible and toxic 9. Activate only if there are nine or more lands with different names among the basic, Sphere, and Locus lands you control.",
             "colours": [],
@@ -14347,7 +14347,7 @@
         },
         {
             "id": "debe7410-a35d-5d68-8b57-58371ee1231c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45354872-4426-445e-8ef0-2df65afdbc53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45354872-4426-445e-8ef0-2df65afdbc53.jpg?1",
             "name": "Soulless Jailer",
             "text": "Permanent cards in graveyards can't enter the battlefield.\nPlayers can't cast noncreature spells from graveyards or exile.",
             "colours": [],
@@ -14381,7 +14381,7 @@
         },
         {
             "id": "eb18a0d8-b17a-5956-9881-12474d0c8069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91a075f-b8c2-499e-a7e5-4063f0dbafc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91a075f-b8c2-499e-a7e5-4063f0dbafc8.jpg?1",
             "name": "Tablet of Compleation",
             "text": "{T}: Put an oil counter on Tablet of Compleation.\n{T}: Add {C}. Activate only if Tablet of Compleation has two or more oil counters on it.\n{1}, {T}: Draw a card. Activate only if Tablet of Compleation has five or more oil counters on it.",
             "colours": [],
@@ -14411,7 +14411,7 @@
         },
         {
             "id": "5ced9739-b0e9-58e0-94e8-3b7b0705cb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca1010-95ab-48a0-ae69-7948e7dc73df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca1010-95ab-48a0-ae69-7948e7dc73df.jpg?1",
             "name": "Zenith Chronicler",
             "text": "Whenever a player casts their first multicolored spell each turn, each other player draws a card.",
             "colours": [],
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "4b0f00aa-ce14-57f1-8391-edac87bbdf47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7a760f-c9fb-454c-bedd-46a675daf02e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7a760f-c9fb-454c-bedd-46a675daf02e.jpg?1",
             "name": "Mirrex",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Activate only if Mirrex entered the battlefield this turn.\n{3}, {T}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [],
@@ -14477,7 +14477,7 @@
         },
         {
             "id": "88bc7236-7987-5988-ae90-70ee0ab4036b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1469fe76-f7e9-48a2-85de-d4d02856cd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1469fe76-f7e9-48a2-85de-d4d02856cd00.jpg?1",
             "name": "The Monumental Facade",
             "text": "The Monumental Facade enters the battlefield with two oil counters on it.\n{T}: Add {C}.\n{T}, Remove an oil counter from The Monumental Facade: Put an oil counter on target artifact or creature you control. Activate only as a sorcery.",
             "colours": [],
@@ -14509,7 +14509,7 @@
         },
         {
             "id": "277e7f2a-b0e4-5b4a-b683-4b35b76f8467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afcac49-ac80-4561-ba2c-ce9487e9d8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afcac49-ac80-4561-ba2c-ce9487e9d8fe.jpg?1",
             "name": "The Mycosynth Gardens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{X}, {T}: The Mycosynth Gardens becomes a copy of target nontoken artifact you control with mana value X.",
             "colours": [],
@@ -14541,7 +14541,7 @@
         },
         {
             "id": "06c5784e-cc95-5868-a36b-9442768fd031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3e28ca-bd1a-46bf-8ce0-56807cbb41c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3e28ca-bd1a-46bf-8ce0-56807cbb41c6.jpg?1",
             "name": "The Seedcore",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast Phyrexian creature spells.\nCorrupted \u2014 {T}: Target 1/1 creature gets +2/+1 until end of turn. Activate only if an opponent has three or more poison counters.",
             "colours": [],
@@ -14573,7 +14573,7 @@
         },
         {
             "id": "86cd1f91-6ffc-530c-8339-eb1365ee2df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55a5edb-edf3-4f6c-90b8-1780b1e73997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55a5edb-edf3-4f6c-90b8-1780b1e73997.jpg?1",
             "name": "Mite Overseer",
             "text": "First strike\nAs long as it's your turn, creature tokens you control get +1/+0 and have first strike.\n{3}{PW}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\" (Players dealt combat damage by it also get a poison counter. {PW} can be paid with either {W} or 2 life.)",
             "colours": [
@@ -14610,7 +14610,7 @@
         },
         {
             "id": "e845f297-eeaa-5894-9258-089cafd160c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d562aa-8b49-40a3-a5c1-3af8afa98edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d562aa-8b49-40a3-a5c1-3af8afa98edc.jpg?1",
             "name": "Serum Sovereign",
             "text": "Flying\nWhenever you cast a noncreature spell, put an oil counter on Serum Sovereign.\n{U}, Remove an oil counter from Serum Sovereign: Draw a card, then scry 2.",
             "colours": [
@@ -14647,7 +14647,7 @@
         },
         {
             "id": "b1d76fc1-3fe7-5c52-9922-2d8afe783e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28934cf3-c1e0-49c9-93ce-fd60b1881884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28934cf3-c1e0-49c9-93ce-fd60b1881884.jpg?1",
             "name": "Kinzu of the Bleak Coven",
             "text": "Flying\nWhenever another nontoken creature you control dies, you may pay 2 life and exile it. If you do, create a token that's a copy of that creature, except it's 1/1 and has toxic 1. (Players dealt combat damage by it also get a poison counter.)",
             "colours": [
@@ -14686,7 +14686,7 @@
         },
         {
             "id": "6b8f9233-8f78-5016-88f0-334a08100653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c25806-1da6-4789-a17e-d2440184ec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c25806-1da6-4789-a17e-d2440184ec40.jpg?1",
             "name": "Rhuk, Hexgold Nabber",
             "text": "Trample, haste\nWhenever an equipped creature you control other than Rhuk, Hexgold Nabber attacks or dies, you may attach all Equipment attached to that creature to Rhuk.",
             "colours": [
@@ -14725,7 +14725,7 @@
         },
         {
             "id": "43a4ecbe-4561-5ac3-aa69-75cafc750e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1141ca-78c0-46e5-99f8-28069d69f23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1141ca-78c0-46e5-99f8-28069d69f23a.jpg?1",
             "name": "Goliath Hatchery",
             "text": "When Goliath Hatchery enters the battlefield, create two 3/3 green Phyrexian Beast creature tokens with toxic 1. (Players dealt combat damage by them also get a poison counter.)\nCorrupted \u2014 At the beginning of your upkeep, if an opponent has three or more poison counters, choose a creature you control, then draw cards equal to its total toxic value.",
             "colours": [
@@ -14759,7 +14759,7 @@
         },
         {
             "id": "cee3911f-5491-5c14-9e1e-1ad3518372d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83a0027-e82d-46ec-b40b-8bf16eb1f379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83a0027-e82d-46ec-b40b-8bf16eb1f379.jpg?1",
             "name": "Mite Overseer",
             "text": "First strike\nAs long as it's your turn, creature tokens you control get +1/+0 and have first strike.\n{3}{PW}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This creature can't block.\"",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "e9f9dc33-bf53-517f-b866-c286c4068dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ed286-e5ac-4224-8892-363885eb1350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492ed286-e5ac-4224-8892-363885eb1350.jpg?1",
             "name": "Serum Sovereign",
             "text": "Flying\nWhenever you cast a noncreature spell, put an oil counter on Serum Sovereign.\n{U}, Remove an oil counter from Serum Sovereign: Draw a card, then scry 2.",
             "colours": [
@@ -14833,7 +14833,7 @@
         },
         {
             "id": "f38cb3db-51bd-543d-8929-ff9876787094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0359c24-6a70-476f-b26b-cd992d9acecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0359c24-6a70-476f-b26b-cd992d9acecf.jpg?1",
             "name": "Kinzu of the Bleak Coven",
             "text": "Flying\nWhenever another nontoken creature you control dies, you may pay 2 life and exile it. If you do, create a token that's a copy of that creature, except it's 1/1 and has toxic 1.",
             "colours": [
@@ -14872,7 +14872,7 @@
         },
         {
             "id": "fa17bdb4-8b3a-51cc-9bd9-b5545e510773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94655928-1f1c-4993-8139-c705be369134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94655928-1f1c-4993-8139-c705be369134.jpg?1",
             "name": "Rhuk, Hexgold Nabber",
             "text": "Trample, haste\nWhenever an equipped creature you control other than Rhuk, Hexgold Nabber attacks or dies, you may attach all Equipment attached to that creature to Rhuk.",
             "colours": [
@@ -14911,7 +14911,7 @@
         },
         {
             "id": "d4347a5a-06aa-596e-abf2-1854a2fc64fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d55c882-bf32-4d52-8af2-6a59c00bde5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d55c882-bf32-4d52-8af2-6a59c00bde5c.jpg?1",
             "name": "Goliath Hatchery",
             "text": "When Goliath Hatchery enters the battlefield, create two 3/3 green Phyrexian Beast creature tokens with toxic 1.\nCorrupted \u2014 At the beginning of your upkeep, if an opponent has three or more poison counters, choose a creature you control, then draw cards equal to its total toxic value.",
             "colours": [
@@ -14945,7 +14945,7 @@
         },
         {
             "id": "1330d7f5-2ef2-5233-af4d-d59e12e693e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09705595-47c6-4f7c-9351-4004bfa39218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09705595-47c6-4f7c-9351-4004bfa39218.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -14992,7 +14992,7 @@
         },
         {
             "id": "2342718f-3d15-5243-8fd0-4c86b116330d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673ccb2-e960-44a9-917b-c53c91e61a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673ccb2-e960-44a9-917b-c53c91e61a94.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "Vigilance\nIf a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nPermanents entering the battlefield don't cause abilities of permanents your opponents control to trigger.",
             "colours": [
@@ -15039,7 +15039,7 @@
         },
         {
             "id": "2f49292a-f476-5c70-86ac-4fa00d5f7900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649be99a-fa52-469e-85df-11ecc576ea39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649be99a-fa52-469e-85df-11ecc576ea39.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15086,7 +15086,7 @@
         },
         {
             "id": "0cc400ed-2270-5d14-a507-6d725ce175b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71546201-a8a9-4d9d-93b7-46e90fb7b8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71546201-a8a9-4d9d-93b7-46e90fb7b8ae.jpg?1",
             "name": "Bladed Ambassador",
             "text": "",
             "colours": [
@@ -15123,7 +15123,7 @@
         },
         {
             "id": "3824b0d2-7444-5f20-b24b-10dc0190a47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e5db-dad1-4544-a9c5-8a4a29327265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e5db-dad1-4544-a9c5-8a4a29327265.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15169,7 +15169,7 @@
         },
         {
             "id": "e71df342-78a6-5a1c-b430-48738185a820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eca4d1-07e3-4142-85ce-3dca122f7f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eca4d1-07e3-4142-85ce-3dca122f7f2c.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15215,7 +15215,7 @@
         },
         {
             "id": "99925849-2d19-5c18-9a87-00f56b3bdf1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0835e3b2-7836-47b2-905d-5660a718387c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0835e3b2-7836-47b2-905d-5660a718387c.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15261,7 +15261,7 @@
         },
         {
             "id": "0e7ac64a-c882-5ccf-928c-d8344fb8229f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835ba56b-6a8f-4ca7-be05-baedfa3451c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835ba56b-6a8f-4ca7-be05-baedfa3451c0.jpg?1",
             "name": "Elesh Norn, Mother of Machines",
             "text": "",
             "colours": [
@@ -15307,7 +15307,7 @@
         },
         {
             "id": "6b9c19bd-2690-506d-957a-b97f4e1992fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73088dcd-56e0-4421-834b-bfb8edfe8b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73088dcd-56e0-4421-834b-bfb8edfe8b68.jpg?1",
             "name": "The Eternal Wanderer",
             "text": "",
             "colours": [
@@ -15343,7 +15343,7 @@
         },
         {
             "id": "9b64598b-b6e1-58ea-8fdd-39825fc47353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1ae568-c353-4da5-a6bb-3e09f3c403d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1ae568-c353-4da5-a6bb-3e09f3c403d7.jpg?1",
             "name": "Kemba, Kha Enduring",
             "text": "",
             "colours": [
@@ -15382,7 +15382,7 @@
         },
         {
             "id": "42b8427a-d8c2-5faa-b45c-fdc0f66527f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e733259b-ef96-4a60-ab1a-b70dd3ef7681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e733259b-ef96-4a60-ab1a-b70dd3ef7681.jpg?1",
             "name": "Mondrak, Glory Dominus",
             "text": "",
             "colours": [
@@ -15422,7 +15422,7 @@
         },
         {
             "id": "c03af55a-d35b-5dfc-b4be-94baf9045af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad244f-2f1d-4c95-9cd4-519f325b56f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad244f-2f1d-4c95-9cd4-519f325b56f3.jpg?1",
             "name": "Phyrexian Vindicator",
             "text": "",
             "colours": [
@@ -15460,7 +15460,7 @@
         },
         {
             "id": "90681e2c-87ea-5924-83f9-90056bac81ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca49f9-4c0a-4279-86cd-f02c2117b04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaca49f9-4c0a-4279-86cd-f02c2117b04d.jpg?1",
             "name": "Sinew Dancer",
             "text": "",
             "colours": [
@@ -15497,7 +15497,7 @@
         },
         {
             "id": "0654adb3-c64d-58ce-ac41-ba4c66b133a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55ca48-0fe0-44bd-9453-02cda0b7f5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55ca48-0fe0-44bd-9453-02cda0b7f5da.jpg?1",
             "name": "Skrelv, Defector Mite",
             "text": "",
             "colours": [
@@ -15537,7 +15537,7 @@
         },
         {
             "id": "3e5b29b9-650f-5216-ae2c-0bac9cfb4a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f45a6a-6425-45ce-8661-9b511c71bb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9f45a6a-6425-45ce-8661-9b511c71bb5f.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "",
             "colours": [
@@ -15578,7 +15578,7 @@
         },
         {
             "id": "91289491-b300-5859-bfdb-dd0c52cf4d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9f5a2e-1f1e-4ecf-8d5c-dbd952574f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9f5a2e-1f1e-4ecf-8d5c-dbd952574f7e.jpg?1",
             "name": "Jace, the Perfected Mind",
             "text": "",
             "colours": [
@@ -15619,7 +15619,7 @@
         },
         {
             "id": "10c078ea-fce8-5167-9ba2-04f915442dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ae222b-5fe0-4110-8a45-f47a6bff63f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ae222b-5fe0-4110-8a45-f47a6bff63f7.jpg?1",
             "name": "Quicksilver Fisher",
             "text": "",
             "colours": [
@@ -15656,7 +15656,7 @@
         },
         {
             "id": "1de4aca1-15e5-5e2f-951b-d8ce1156a9b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6915aa9f-f8c7-415d-b265-6d40fa7cd0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6915aa9f-f8c7-415d-b265-6d40fa7cd0fe.jpg?1",
             "name": "Tekuthal, Inquiry Dominus",
             "text": "",
             "colours": [
@@ -15696,7 +15696,7 @@
         },
         {
             "id": "d54d0c03-a5ba-531d-97ae-4c065a3bbf11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fff05f-84f3-43ec-9752-86b156ec0c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39fff05f-84f3-43ec-9752-86b156ec0c5b.jpg?1",
             "name": "Thrummingbird",
             "text": "",
             "colours": [
@@ -15734,7 +15734,7 @@
         },
         {
             "id": "db952d8e-d61b-5a22-bc87-6f0fcb9b2d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3992c4c-d241-4dc5-bb68-6db5fb93a356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3992c4c-d241-4dc5-bb68-6db5fb93a356.jpg?1",
             "name": "Unctus, Grand Metatect",
             "text": "",
             "colours": [
@@ -15774,7 +15774,7 @@
         },
         {
             "id": "35b91bbb-79eb-5f14-b0f6-ee980a70909c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d02c56-bf38-4bd8-9e0b-c1e2cc2e5dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d02c56-bf38-4bd8-9e0b-c1e2cc2e5dfe.jpg?1",
             "name": "Archfiend of the Dross",
             "text": "",
             "colours": [
@@ -15811,7 +15811,7 @@
         },
         {
             "id": "770cf186-7dcf-548c-9af0-cc66d7a4de9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bf86e8-df70-4ec0-8fe6-f15191774e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bf86e8-df70-4ec0-8fe6-f15191774e50.jpg?1",
             "name": "Blightbelly Rat",
             "text": "",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "9a0fed4b-798c-5918-b405-13dae01656ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c1b7bb-79ca-44c2-9152-d302ca00eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14c1b7bb-79ca-44c2-9152-d302ca00eb3e.jpg?1",
             "name": "Bonepicker Skirge",
             "text": "",
             "colours": [
@@ -15885,7 +15885,7 @@
         },
         {
             "id": "6602bae5-7943-5315-85df-33b50fa92c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4b6d7-945f-4bce-9591-ec80cab18055.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4b6d7-945f-4bce-9591-ec80cab18055.jpg?1",
             "name": "Drivnod, Carnage Dominus",
             "text": "",
             "colours": [
@@ -15925,7 +15925,7 @@
         },
         {
             "id": "31b19a7e-351b-5287-9a09-89552cdd9791",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5230995-da48-4eea-a2fd-3b303d3df963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5230995-da48-4eea-a2fd-3b303d3df963.jpg?1",
             "name": "Geth, Thane of Contracts",
             "text": "",
             "colours": [
@@ -15964,7 +15964,7 @@
         },
         {
             "id": "1885a4ec-f428-5fad-ac54-7a47e3fd74f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b3202b-fdfb-422b-8abd-5a319cb34341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02b3202b-fdfb-422b-8abd-5a319cb34341.jpg?1",
             "name": "Karumonix, the Rat King",
             "text": "",
             "colours": [
@@ -16004,7 +16004,7 @@
         },
         {
             "id": "19e47847-e39c-54ec-9aee-2d285090f076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f21774-ea98-41ae-b4fa-4402f1876cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f21774-ea98-41ae-b4fa-4402f1876cda.jpg?1",
             "name": "Phyrexian Obliterator",
             "text": "",
             "colours": [
@@ -16042,7 +16042,7 @@
         },
         {
             "id": "0c77eb2a-4a68-56c1-8ae1-31cf03f59cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b41d4e-913c-49fd-a263-b0144fdd8667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b41d4e-913c-49fd-a263-b0144fdd8667.jpg?1",
             "name": "Vraan, Executioner Thane",
             "text": "",
             "colours": [
@@ -16081,7 +16081,7 @@
         },
         {
             "id": "1b7f5de3-e64a-5d5d-97e6-651c77880b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae2dfd8-a10a-4a13-97c0-a0ac7df0aabb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae2dfd8-a10a-4a13-97c0-a0ac7df0aabb.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "",
             "colours": [
@@ -16122,7 +16122,7 @@
         },
         {
             "id": "954bf834-771f-5ea5-9829-b2acae18ceac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af5aaae-c343-4a9e-94a3-6225100e2e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af5aaae-c343-4a9e-94a3-6225100e2e25.jpg?1",
             "name": "Vraska, Betrayal's Sting",
             "text": "",
             "colours": [
@@ -16163,7 +16163,7 @@
         },
         {
             "id": "d7178899-625d-5cfb-8932-51efd7490cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43706591-f0ac-4a03-b745-126fa1d4cfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43706591-f0ac-4a03-b745-126fa1d4cfe6.jpg?1",
             "name": "Capricious Hellraiser",
             "text": "",
             "colours": [
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "4c50740d-f7bf-563c-987b-300a3f82940d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16994ad-6288-4e3a-a02f-0dfce71bf013.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16994ad-6288-4e3a-a02f-0dfce71bf013.jpg?1",
             "name": "Furnace Punisher",
             "text": "",
             "colours": [
@@ -16238,7 +16238,7 @@
         },
         {
             "id": "db1b6c7d-8c25-5246-8aa7-9b09e9951209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8570-0f6d-4a49-b166-38a5d788a3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8570-0f6d-4a49-b166-38a5d788a3f0.jpg?1",
             "name": "Koth, Fire of Resistance",
             "text": "",
             "colours": [
@@ -16276,7 +16276,7 @@
         },
         {
             "id": "8a2b986a-0ecc-5ed6-a0ed-aecfa8c3106f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e5be1-b129-4384-8b51-d076b1459302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976e5be1-b129-4384-8b51-d076b1459302.jpg?1",
             "name": "Sawblade Scamp",
             "text": "",
             "colours": [
@@ -16313,7 +16313,7 @@
         },
         {
             "id": "50ac2ec9-4ccb-5aa6-afb8-7149b2ace513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb7a29-7bca-4402-b47c-e73eaa5e6fef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cb7a29-7bca-4402-b47c-e73eaa5e6fef.jpg?1",
             "name": "Slobad, Iron Goblin",
             "text": "",
             "colours": [
@@ -16353,7 +16353,7 @@
         },
         {
             "id": "d1c5df6a-b1b8-5d63-83b6-6a2171e8ad82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ac6a1-d792-473a-a189-5282ae7559a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b6ac6a1-d792-473a-a189-5282ae7559a7.jpg?1",
             "name": "Solphim, Mayhem Dominus",
             "text": "",
             "colours": [
@@ -16393,7 +16393,7 @@
         },
         {
             "id": "b7fbac61-95f5-58b6-8004-2109cbfe9238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c2c971-aaed-48af-80ae-f5df2b1f17ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c2c971-aaed-48af-80ae-f5df2b1f17ac.jpg?1",
             "name": "Urabrask's Anointer",
             "text": "",
             "colours": [
@@ -16431,7 +16431,7 @@
         },
         {
             "id": "c1506ac2-f92b-51b0-a9f2-38ad8a8c9af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbfb112b-a148-4c28-9ba6-af535ec2d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbfb112b-a148-4c28-9ba6-af535ec2d4fd.jpg?1",
             "name": "Cankerbloom",
             "text": "",
             "colours": [
@@ -16468,7 +16468,7 @@
         },
         {
             "id": "8d338ee2-e09d-5705-848c-eac384ac769e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99546cde-3a05-45d0-b77d-e007243a68e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99546cde-3a05-45d0-b77d-e007243a68e4.jpg?1",
             "name": "Evolved Spinoderm",
             "text": "",
             "colours": [
@@ -16505,7 +16505,7 @@
         },
         {
             "id": "716df6e5-5c72-56f0-bf79-b2874d86b4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff957d-257b-4cfa-94f5-15fd5f0091ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ff957d-257b-4cfa-94f5-15fd5f0091ff.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "",
             "colours": [
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "6f24bb46-5af8-56c9-9d90-93fd20cfc598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570136da-4178-48db-a725-16cd240c9e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570136da-4178-48db-a725-16cd240c9e8a.jpg?1",
             "name": "Nissa, Ascended Animist",
             "text": "",
             "colours": [
@@ -16587,7 +16587,7 @@
         },
         {
             "id": "d57684a4-c772-5ed6-b684-a86d67b1c5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c97359-8355-436d-8d48-833d18793de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c97359-8355-436d-8d48-833d18793de0.jpg?1",
             "name": "Rustvine Cultivator",
             "text": "",
             "colours": [
@@ -16625,7 +16625,7 @@
         },
         {
             "id": "0f9dac93-3081-54c9-9fbc-174067bf195c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e39ca9-0267-47cb-a378-892fbad324e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e39ca9-0267-47cb-a378-892fbad324e4.jpg?1",
             "name": "Thrun, Breaker of Silence",
             "text": "",
             "colours": [
@@ -16664,7 +16664,7 @@
         },
         {
             "id": "e1899d57-5090-59e3-9992-cb76890ff36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc1978e-ba4f-48ed-90e2-9252603f99fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc1978e-ba4f-48ed-90e2-9252603f99fe.jpg?1",
             "name": "Tyrranax Rex",
             "text": "",
             "colours": [
@@ -16702,7 +16702,7 @@
         },
         {
             "id": "4c0d9f52-a677-570d-86c0-88d3d397403e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b31ca5-087a-4359-a570-134eedc7cb3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b31ca5-087a-4359-a570-134eedc7cb3a.jpg?1",
             "name": "Zopandrel, Hunger Dominus",
             "text": "",
             "colours": [
@@ -16742,7 +16742,7 @@
         },
         {
             "id": "d7011b9d-66a8-5a16-bd31-78297e02508d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d5df16-3f65-4616-9d41-b8a9afb1e6bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d5df16-3f65-4616-9d41-b8a9afb1e6bb.jpg?1",
             "name": "Atraxa, Grand Unifier",
             "text": "",
             "colours": [
@@ -16788,7 +16788,7 @@
         },
         {
             "id": "71ebb842-13cd-5cac-9b9a-c3040dc23495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc873b9-1e0e-4787-9447-893a7e16346f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc873b9-1e0e-4787-9447-893a7e16346f.jpg?1",
             "name": "Ezuri, Stalker of Spheres",
             "text": "",
             "colours": [
@@ -16830,7 +16830,7 @@
         },
         {
             "id": "fee78fa4-55ae-579b-b573-31d0e3ce0aea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d347959-a8c8-4a5d-af1f-257dadf42064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d347959-a8c8-4a5d-af1f-257dadf42064.jpg?1",
             "name": "Glissa Sunslayer",
             "text": "",
             "colours": [
@@ -16872,7 +16872,7 @@
         },
         {
             "id": "58c7d4a8-1d5b-5516-8063-d56f6dc4347d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85071fe7-ce69-40e7-95ad-ccf0d5ef5ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85071fe7-ce69-40e7-95ad-ccf0d5ef5ee0.jpg?1",
             "name": "Jor Kadeen, First Goldwarden",
             "text": "",
             "colours": [
@@ -16913,7 +16913,7 @@
         },
         {
             "id": "369e7ee0-7d32-5ae3-976a-2f2b21d3e448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66d6e92-006e-4eb3-91e4-93c2c40f700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66d6e92-006e-4eb3-91e4-93c2c40f700e.jpg?1",
             "name": "Kaito, Dancing Shadow",
             "text": "",
             "colours": [
@@ -16953,7 +16953,7 @@
         },
         {
             "id": "bf27b565-29f7-5a36-9dcf-3ad65fec9747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93770494-21c5-491e-bf4f-3dc7888a93a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93770494-21c5-491e-bf4f-3dc7888a93a5.jpg?1",
             "name": "Kaya, Intangible Slayer",
             "text": "",
             "colours": [
@@ -16993,7 +16993,7 @@
         },
         {
             "id": "3b233f36-933c-5333-9beb-7b52d49d8129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c29f1eb-5e1d-452e-892d-a9e8393af477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c29f1eb-5e1d-452e-892d-a9e8393af477.jpg?1",
             "name": "Kethek, Crucible Goliath",
             "text": "",
             "colours": [
@@ -17034,7 +17034,7 @@
         },
         {
             "id": "7d8e7523-133b-588d-94de-83cee7c70fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508eb4f9-56a1-4e7c-99d5-d5e751c61b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/508eb4f9-56a1-4e7c-99d5-d5e751c61b91.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "",
             "colours": [
@@ -17077,7 +17077,7 @@
         },
         {
             "id": "ccdf2293-496a-5371-b310-8d231397766d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738ed22-fb88-4f19-a67f-b39a33a0c7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738ed22-fb88-4f19-a67f-b39a33a0c7a7.jpg?1",
             "name": "Lukka, Bound to Ruin",
             "text": "",
             "colours": [
@@ -17120,7 +17120,7 @@
         },
         {
             "id": "32f1b81a-ae5c-5005-92ee-c5c90b855861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70919ad2-8045-4354-b3a0-793fa6910d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70919ad2-8045-4354-b3a0-793fa6910d10.jpg?1",
             "name": "Malcator, Purity Overseer",
             "text": "",
             "colours": [
@@ -17162,7 +17162,7 @@
         },
         {
             "id": "cfb7f453-0958-51bd-896a-b9d57505b336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538fcecf-0e1d-4995-960b-c461b92d2f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538fcecf-0e1d-4995-960b-c461b92d2f72.jpg?1",
             "name": "Melira, the Living Cure",
             "text": "",
             "colours": [
@@ -17203,7 +17203,7 @@
         },
         {
             "id": "c62ab924-b3f2-5ea1-83a1-92bc2fc21b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7066cfb-f2a5-4dc0-973c-3ff73c74ba65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7066cfb-f2a5-4dc0-973c-3ff73c74ba65.jpg?1",
             "name": "Migloz, Maze Crusher",
             "text": "",
             "colours": [
@@ -17244,7 +17244,7 @@
         },
         {
             "id": "92240a5c-54d4-5af6-8470-f8b863a92969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ad9ed5-5cbb-4329-936c-32fefd623eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ad9ed5-5cbb-4329-936c-32fefd623eb7.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "",
             "colours": [
@@ -17287,7 +17287,7 @@
         },
         {
             "id": "f41a870b-1262-5f9b-a313-c4314e9e4833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ba17d4-19e0-4d11-a565-52aeb08d954e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83ba17d4-19e0-4d11-a565-52aeb08d954e.jpg?1",
             "name": "Nahiri, the Unforgiving",
             "text": "",
             "colours": [
@@ -17330,7 +17330,7 @@
         },
         {
             "id": "476ce0b1-9d60-5ad0-81b0-c6d819c551bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ffea1-e103-4f06-b652-7b9f37de8754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0ffea1-e103-4f06-b652-7b9f37de8754.jpg?1",
             "name": "Necrogen Rotpriest",
             "text": "",
             "colours": [
@@ -17370,7 +17370,7 @@
         },
         {
             "id": "c53e2d25-f179-55fd-8a73-df7e0e2eee15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f4293-ea6e-4f10-b9e1-1b06c94af32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/780f4293-ea6e-4f10-b9e1-1b06c94af32b.jpg?1",
             "name": "Ovika, Enigma Goliath",
             "text": "",
             "colours": [
@@ -17411,7 +17411,7 @@
         },
         {
             "id": "6c15d9a7-69e1-5242-b607-9e3e6c322bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3809f4-5ee6-40cb-b5eb-b29dda1c038f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3809f4-5ee6-40cb-b5eb-b29dda1c038f.jpg?1",
             "name": "Ria Ivor, Bane of Bladehold",
             "text": "",
             "colours": [
@@ -17452,7 +17452,7 @@
         },
         {
             "id": "94dbb941-79a9-5586-9372-6a69a01a1a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bc261c-fb79-4397-9a47-b9f601a1341b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7bc261c-fb79-4397-9a47-b9f601a1341b.jpg?1",
             "name": "Tyvar, Jubilant Brawler",
             "text": "",
             "colours": [
@@ -17492,7 +17492,7 @@
         },
         {
             "id": "d08f67f7-a052-55ef-942c-d72b1a98daac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc9003-7290-48b0-ba7b-4dc5c98cf2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fc9003-7290-48b0-ba7b-4dc5c98cf2c4.jpg?1",
             "name": "Venser, Corpse Puppet",
             "text": "",
             "colours": [
@@ -17534,7 +17534,7 @@
         },
         {
             "id": "d8fd2200-9354-53fb-9bab-8217d15c566e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7c66b-5453-4237-8dd5-bf6ee69bcab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db7c66b-5453-4237-8dd5-bf6ee69bcab8.jpg?1",
             "name": "Graaz, Unstoppable Juggernaut",
             "text": "",
             "colours": [],
@@ -17569,7 +17569,7 @@
         },
         {
             "id": "82fe9ae0-eddb-542a-b06b-e78c1d1c804a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c7d89a-2b02-4faa-83cf-7dcf7faf6c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c7d89a-2b02-4faa-83cf-7dcf7faf6c4a.jpg?1",
             "name": "Myr Convert",
             "text": "",
             "colours": [],
@@ -17603,7 +17603,7 @@
         },
         {
             "id": "21098256-4763-5eaf-ae0e-9eed26ef6b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11011596-4aa1-48a7-90d8-36cb7b27c711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11011596-4aa1-48a7-90d8-36cb7b27c711.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -17638,7 +17638,7 @@
         },
         {
             "id": "f61410ad-88a7-5e6b-b4db-fcd243ae3ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70750c90-3856-4d6d-923b-2ab91b1d7049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70750c90-3856-4d6d-923b-2ab91b1d7049.jpg?1",
             "name": "Samurai",
             "text": "",
             "colours": [
@@ -17673,7 +17673,7 @@
         },
         {
             "id": "3a49ec7d-50c8-5459-861f-07185c1142e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg?1",
             "name": "Phyrexian Goblin",
             "text": "",
             "colours": [
@@ -17709,7 +17709,7 @@
         },
         {
             "id": "56b09793-68bf-56de-ab32-7ee18e9aa1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da13c90f-9ed2-4262-88e2-17daa294537b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da13c90f-9ed2-4262-88e2-17daa294537b.jpg?1",
             "name": "Phyrexian Horror",
             "text": "",
             "colours": [
@@ -17745,7 +17745,7 @@
         },
         {
             "id": "f78af17a-6b08-5984-b36b-a15b4f1dccd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41eb9df-d8b4-4697-a759-886faf16754d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41eb9df-d8b4-4697-a759-886faf16754d.jpg?1",
             "name": "Rebel",
             "text": "",
             "colours": [
@@ -17780,7 +17780,7 @@
         },
         {
             "id": "1e507a36-d0d4-5fd0-9076-0ebdcc7b3432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919381b0-2d23-4794-b4ff-923c23e18196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919381b0-2d23-4794-b4ff-923c23e18196.jpg?1",
             "name": "Phyrexian Beast",
             "text": "",
             "colours": [
@@ -17816,7 +17816,7 @@
         },
         {
             "id": "22dbcfbd-79aa-5d9e-b5ee-ab3ef77529db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5fc2cb-a172-418a-a0f3-1a63a5f1aa2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f5fc2cb-a172-418a-a0f3-1a63a5f1aa2c.jpg?1",
             "name": "Phyrexian Horror",
             "text": "",
             "colours": [
@@ -17852,7 +17852,7 @@
         },
         {
             "id": "d9327567-d717-52db-aa40-71cc2a6b962b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacac5f-7685-4792-9e4c-166d4b421240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfacac5f-7685-4792-9e4c-166d4b421240.jpg?1",
             "name": "Drone",
             "text": "",
             "colours": [],
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "4de6bb51-46aa-59d7-b603-291babb01771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0cbfa-a7f9-49a6-9bca-4a08f5b8da93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0cbfa-a7f9-49a6-9bca-4a08f5b8da93.jpg?1",
             "name": "The Hollow Sentinel",
             "text": "",
             "colours": [],
@@ -17919,7 +17919,7 @@
         },
         {
             "id": "ca6d8b20-0901-5c81-9dbc-7615c2f21b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ace2fa-8cfb-4641-a05c-d12830378e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ace2fa-8cfb-4641-a05c-d12830378e03.jpg?1",
             "name": "Phyrexian Golem",
             "text": "",
             "colours": [],
@@ -17952,7 +17952,7 @@
         },
         {
             "id": "d4928ecf-ba43-5759-b91c-d230325c6331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ec91a9-659a-455f-98e0-cd30b6c6c2a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ec91a9-659a-455f-98e0-cd30b6c6c2a4.jpg?1",
             "name": "Phyrexian Mite",
             "text": "",
             "colours": [],
@@ -17985,7 +17985,7 @@
         },
         {
             "id": "3ebcf5ed-caad-558d-8ab0-90afa791c054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b4b9cc-b0a4-4383-881b-e843e5d8a8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b4b9cc-b0a4-4383-881b-e843e5d8a8c1.jpg?1",
             "name": "Phyrexian Mite",
             "text": "",
             "colours": [],
@@ -18018,7 +18018,7 @@
         },
         {
             "id": "5fb6fd07-bae2-5d67-92a2-5e1000e4fa12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4746f904-67f3-450d-93f6-172b3fd50057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4746f904-67f3-450d-93f6-172b3fd50057.jpg?1",
             "name": "Koth, Fire of Resistance Emblem",
             "text": "",
             "colours": [],
@@ -18046,7 +18046,7 @@
         },
         {
             "id": "be1f1afc-0d4e-5ce8-9bab-8e65a120ecbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40255bfa-0004-45f1-a31b-17d385f09a95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40255bfa-0004-45f1-a31b-17d385f09a95.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ONS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ONS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b5be618e-ef00-5081-9a3c-1acead38807f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3710c68-3f71-4d76-8bd2-001f0e8036f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3710c68-3f71-4d76-8bd2-001f0e8036f5.jpg?1",
             "name": "Akroma's Blessing",
             "text": "Creatures you control gain protection from the color of your choice until end of turn.\nCycling o\nW (o\nW, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "e32e9f23-d6b1-584d-88af-62fb06405357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33aaf7-7490-4b64-a966-82fbf7ca8686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e33aaf7-7490-4b64-a966-82fbf7ca8686.jpg?1",
             "name": "Akroma's Vengeance",
             "text": "Destroy all artifacts, creatures, and enchantments.\nCycling o3 (o3, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "9c250be9-8f16-5fdc-b4d1-af188d1c6420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdee956e-76b1-4ba7-a387-2fbfb853507d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdee956e-76b1-4ba7-a387-2fbfb853507d.jpg?1",
             "name": "Ancestor's Prophet",
             "text": "Tap five untapped Clerics you control: You gain 10 life.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "8481fb36-5a9a-5d12-831b-06b40e508d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14993b6-ed8d-4b9b-b54c-2837b343a61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14993b6-ed8d-4b9b-b54c-2837b343a61e.jpg?1",
             "name": "Astral Slide",
             "text": "Whenever a player cycles a card, you may remove target creature from the game. If you do, return that creature to play under its owner's control at end of turn.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "b8067d0b-7434-581b-86d3-67b186bef6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d16883-5e98-4dd2-92dd-0ba92f1099cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d16883-5e98-4dd2-92dd-0ba92f1099cb.jpg?1",
             "name": "Aura Extraction",
             "text": "Put target enchantment on top of its owner's library.\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "5f4893b8-904c-5e85-9d02-8621efde5189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d9e9ea-9f88-4206-8960-b5ebe839ee16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d9e9ea-9f88-4206-8960-b5ebe839ee16.jpg?1",
             "name": "Aurification",
             "text": "Whenever a creature deals damage to you, put a gold counter on it.\nEach creature with a gold counter on it is a Wall in addition to its other creature types. (Walls can't attack.)\nWhen Aurification leaves play, remove all gold counters from all creatures.",
             "colours": [
@@ -199,7 +199,7 @@
         },
         {
             "id": "48b053a0-8bea-55c0-bb90-269ae72af258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da24ef56-8d54-4146-97e9-4abded807545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da24ef56-8d54-4146-97e9-4abded807545.jpg?1",
             "name": "Aven Brigadier",
             "text": "Flying\nAll other Birds get +1/+1.\nAll other Soldiers get +1/+1.",
             "colours": [
@@ -234,7 +234,7 @@
         },
         {
             "id": "a6d17844-cb98-51fa-8222-162c3c68bfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5189f152-f075-4090-97dd-b7686d813865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5189f152-f075-4090-97dd-b7686d813865.jpg?1",
             "name": "Aven Soulgazer",
             "text": "Flying\no2o\nW: Look at target face-down creature.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "c67ebba0-4eef-5542-b5c9-1c60cf7adad5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c444503-42a8-4952-819b-bbca89b06abc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c444503-42a8-4952-819b-bbca89b06abc.jpg?1",
             "name": "Battlefield Medic",
             "text": "oc\nT: Prevent the next X damage that would be dealt to target creature this turn, where X is the number of Clerics in play.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "dea9ded2-5212-507e-a878-d1a93f6d6672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d7aa2-c6ff-432d-b671-cef58c6736c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d7aa2-c6ff-432d-b671-cef58c6736c6.jpg?1",
             "name": "Catapult Master",
             "text": "Tap five untapped Soldiers you control: Remove target creature from the game.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "ae88f0f7-1887-5cd2-9e58-cd6b27564291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a71d29-29eb-43c4-b0f3-457435e8f629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a71d29-29eb-43c4-b0f3-457435e8f629.jpg?1",
             "name": "Catapult Squad",
             "text": "Tap two untapped Soldiers you control: Catapult Squad deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "1c82505d-85ca-5055-9f86-8d007bc226a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a60ac8e-11eb-433f-86f9-8e593b38c617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a60ac8e-11eb-433f-86f9-8e593b38c617.jpg?1",
             "name": "Chain of Silence",
             "text": "Prevent all damage target creature would deal this turn. That creature's controller may sacrifice a land. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "7c0a451f-0a07-5074-964d-345bc617f8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f567dc-8a60-40e1-b947-199872d8df08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f567dc-8a60-40e1-b947-199872d8df08.jpg?1",
             "name": "Circle of Solace",
             "text": "As Circle of Solace comes into play, choose a creature type.\no1o\nW: The next time a creature of the chosen type would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "22122b0e-3a18-5ad6-aa01-35416dff20cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f3ad80-d000-496a-b704-d09e07981b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f3ad80-d000-496a-b704-d09e07981b6e.jpg?1",
             "name": "Convalescent Care",
             "text": "At the beginning of your upkeep, if you have 5 life or less, you gain 3 life and draw a card.",
             "colours": [
@@ -470,7 +470,7 @@
         },
         {
             "id": "f76d6a6c-08a0-5570-b6d6-c08ddcc70923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1038436d-aea5-4508-8b37-c2cfa32c2771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1038436d-aea5-4508-8b37-c2cfa32c2771.jpg?1",
             "name": "Crowd Favorites",
             "text": "o3o\nW: Tap target creature.\no3o\nW: Crowd Favorites gets +0/+5 until end of turn.",
             "colours": [
@@ -505,7 +505,7 @@
         },
         {
             "id": "22d32cd8-60c2-5341-83d2-d00f4a8b0148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaea4bc-dcea-4340-a039-ebc97b944673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeaea4bc-dcea-4340-a039-ebc97b944673.jpg?1",
             "name": "Crown of Awe",
             "text": "Enchanted creature has protection from black and from red.\nSacrifice Crown of Awe: Enchanted creature and other creatures that share a creature type with it gain protection from black and from red until end of turn.",
             "colours": [
@@ -539,7 +539,7 @@
         },
         {
             "id": "ece559dc-fce0-5e6b-a360-da9989096fa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d1be2-d6ae-4820-aa01-62f261b0f110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5d1be2-d6ae-4820-aa01-62f261b0f110.jpg?1",
             "name": "Crude Rampart",
             "text": "(Walls can't attack.)\nMorph o4o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "30b5804c-b019-5ef7-8f09-22fda8da6089",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2e9b7e-434e-477f-b3e8-e85ceb913650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb2e9b7e-434e-477f-b3e8-e85ceb913650.jpg?1",
             "name": "Daru Cavalier",
             "text": "First strike\nWhen Daru Cavalier comes into play, you may search your library for a card named Daru Cavalier, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -608,7 +608,7 @@
         },
         {
             "id": "fee1b7a6-27b0-5b04-adce-b7f6078ee5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f3eff-ac99-41e2-9003-9630cdb3ae23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f3eff-ac99-41e2-9003-9630cdb3ae23.jpg?1",
             "name": "Daru Healer",
             "text": "oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\nMorph o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "1175aa79-3587-5941-818c-d31ebf1ccd20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd888ca8-0ebe-46f0-9317-3b193ccc43fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd888ca8-0ebe-46f0-9317-3b193ccc43fb.jpg?1",
             "name": "Daru Lancer",
             "text": "First strike\nMorph o2o\nWo\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "79930b4a-5796-5975-9c5a-0e09f5994fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38737f38-26bd-417c-b6b4-53f26e4e8044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38737f38-26bd-417c-b6b4-53f26e4e8044.jpg?1",
             "name": "Daunting Defender",
             "text": "If a source would deal damage to a Cleric you control, prevent 1 of that damage.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "13fa5c2b-b046-5740-a4ff-24888f7ded6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb25b0-e4c3-4a4e-b722-ea30e695f917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb25b0-e4c3-4a4e-b722-ea30e695f917.jpg?1",
             "name": "Dawning Purist",
             "text": "Whenever Dawning Purist deals combat damage to a player, you may destroy target enchantment that player controls.\nMorph o1o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "f27f78c5-e8e4-562c-91f6-49357f6027cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f9eb25-4140-4ecf-bcaa-1b193d884007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f9eb25-4140-4ecf-bcaa-1b193d884007.jpg?1",
             "name": "Defensive Maneuvers",
             "text": "Creatures of the type of your choice get +0/+4 until end of turn.",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "07ec1be1-a12d-50b0-8d8c-875ffd6ae96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0df839f-dc4c-44b0-82c7-cb2037172ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0df839f-dc4c-44b0-82c7-cb2037172ac5.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "15f85638-89bd-53fa-b7d0-1600fda3b3fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1790cb-34e4-4f23-8a13-1906fd9a956f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1790cb-34e4-4f23-8a13-1906fd9a956f.jpg?1",
             "name": "Disciple of Grace",
             "text": "Protection from black\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "ef9d5f9e-5ec5-572a-beff-626393716a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65162b24-8a3b-4b92-a831-6f23f809c76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65162b24-8a3b-4b92-a831-6f23f809c76f.jpg?1",
             "name": "Dive Bomber",
             "text": "Flying\noc\nT, Sacrifice Dive Bomber: Dive Bomber deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "c6a9a0de-0a49-5dcc-85bc-bb1970e50986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dedef8a-5527-40dc-9ad9-bcee4cf30a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dedef8a-5527-40dc-9ad9-bcee4cf30a76.jpg?1",
             "name": "Doubtless One",
             "text": "Doubtless One's power and toughness are each equal to the number of Clerics in play.\nWhenever Doubtless One deals damage, you gain that much life.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "d12e0d50-d5f3-5f84-9d3f-a44676420197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2213eac-cea4-4dfd-90c4-c1f466967e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2213eac-cea4-4dfd-90c4-c1f466967e2e.jpg?1",
             "name": "Exalted Angel",
             "text": "Flying\nWhenever Exalted Angel deals damage, you gain that much life.\nMorph o2o\nWo\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "8435581e-18f1-548c-a7de-2778c3641547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409adb7b-6dcb-4e7f-a5dd-c0adf12140a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409adb7b-6dcb-4e7f-a5dd-c0adf12140a4.jpg?1",
             "name": "Foothill Guide",
             "text": "Protection from Goblins\nMorph o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "1f43f10a-35f0-5104-a59a-cfc9e31f8f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e505e8e-51aa-4415-81e6-cf022279edb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e505e8e-51aa-4415-81e6-cf022279edb0.jpg?1",
             "name": "Glarecaster",
             "text": "Flying\no5o\nW: The next time damage would be dealt to Glarecaster or you this turn, that damage is dealt to target creature or player instead.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "2e6f3bb4-946e-5e3c-9a02-da9009b6a9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047075e-9fca-484d-bb79-32c0d6821281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9047075e-9fca-484d-bb79-32c0d6821281.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "548a1e75-3af9-5bef-8cd6-2191627c83bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c129f361-8769-4f9a-9745-eb5d0c085b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c129f361-8769-4f9a-9745-eb5d0c085b88.jpg?1",
             "name": "Grassland Crusader",
             "text": "oc\nT: Target Elf or Soldier gets +2/+2 until end of turn.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "63fc0809-3bc7-533b-805e-5556e96cc7f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87551307-6b5f-4f12-aa1f-4beebefad3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87551307-6b5f-4f12-aa1f-4beebefad3b3.jpg?1",
             "name": "Gravel Slinger",
             "text": "oc\nT: Gravel Slinger deals 1 damage to target attacking or blocking creature.\nMorph o1o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1127,7 +1127,7 @@
         },
         {
             "id": "ea949bc9-7d74-55e2-a8d5-c2689c3cc21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ff5c7d-7823-4d1e-8abb-77e2d8126996.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ff5c7d-7823-4d1e-8abb-77e2d8126996.jpg?1",
             "name": "Gustcloak Harrier",
             "text": "Flying\nWhenever Gustcloak Harrier becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "ce7e8595-6cf3-56a2-a93c-092ab09eb730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227f65-9189-41ed-94a0-2aa21cad26f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227f65-9189-41ed-94a0-2aa21cad26f5.jpg?1",
             "name": "Gustcloak Runner",
             "text": "Whenever Gustcloak Runner becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "7eb4cc44-9281-5289-810a-d9fedf7bee39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d6e81-1869-4ab7-8a4e-477d5c4aed6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9d6e81-1869-4ab7-8a4e-477d5c4aed6b.jpg?1",
             "name": "Gustcloak Savior",
             "text": "Flying\nWhenever a creature you control becomes blocked, you may untap that creature and remove it from combat.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "a767f0dc-da7d-53cb-ae7f-9b7cb14cccbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90da5c3-fd8f-445d-809f-e129870d7449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90da5c3-fd8f-445d-809f-e129870d7449.jpg?1",
             "name": "Gustcloak Sentinel",
             "text": "Whenever Gustcloak Sentinel becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "5f65fb59-ea71-568c-b699-d82828040d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbff06c-5f92-4320-8b70-df3c8344f600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbff06c-5f92-4320-8b70-df3c8344f600.jpg?1",
             "name": "Gustcloak Skirmisher",
             "text": "Flying\nWhenever Gustcloak Skirmisher becomes blocked, you may untap it and remove it from combat.",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "2c204bfe-4159-5bdd-a7f5-c0fe3f4dd3eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6473b4d-1f59-4216-ace9-f3e5306266fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6473b4d-1f59-4216-ace9-f3e5306266fb.jpg?1",
             "name": "Harsh Mercy",
             "text": "Each player chooses a creature type. Destroy all creatures that aren't of a type chosen this way. They can't be regenerated.",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "fcfceb0c-7f1b-5257-ba5e-8e35afa940f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7d5d79-73d8-4f1a-9dda-4de5f41539d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7d5d79-73d8-4f1a-9dda-4de5f41539d9.jpg?1",
             "name": "Improvised Armor",
             "text": "Enchanted creature gets +2/+5.\nCycling o3 (o3, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -1368,7 +1368,7 @@
         },
         {
             "id": "3e8e91ce-9b2d-592c-b6de-c7e53fd4ef19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0e300-db79-4328-ba1d-9c3910e47f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0e300-db79-4328-ba1d-9c3910e47f52.jpg?1",
             "name": "Inspirit",
             "text": "Untap target creature. It gets +2/+4 until end of turn.",
             "colours": [
@@ -1400,7 +1400,7 @@
         },
         {
             "id": "16b4cba1-ba18-55a7-8015-ff52dfc3bb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7284e32-de54-4c83-a7de-7b249c47319a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7284e32-de54-4c83-a7de-7b249c47319a.jpg?1",
             "name": "Ironfist Crusher",
             "text": "Ironfist Crusher may block any number of creatures.\nMorph o3o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "6c6136b0-a451-581f-819c-33e6add94c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd1364-ff36-4cb9-ad93-e6fcbcb942cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65dd1364-ff36-4cb9-ad93-e6fcbcb942cf.jpg?1",
             "name": "Jareth, Leonine Titan",
             "text": "Whenever Jareth, Leonine Titan blocks, it gets +7/+7 until end of turn.\no\nW: Jareth gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -1472,7 +1472,7 @@
         },
         {
             "id": "af7e5b52-14cc-57a2-8523-84e46ba50f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653cc07b-0f53-4b5b-9c5f-885b8b4a6e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653cc07b-0f53-4b5b-9c5f-885b8b4a6e5f.jpg?1",
             "name": "Mobilization",
             "text": "Attacking doesn't cause Soldiers to tap.\no2o\nW: Put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -1504,7 +1504,7 @@
         },
         {
             "id": "a71c081e-0d8d-58ef-ab0d-883ed1fa566d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2048d84-b5e6-405c-9091-1997a0c4e1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2048d84-b5e6-405c-9091-1997a0c4e1a5.jpg?1",
             "name": "Nova Cleric",
             "text": "o2o\nW, oc\nT, Sacrifice Nova Cleric: Destroy all enchantments.",
             "colours": [
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "eff02303-d9fd-5c66-a719-053f73bbdf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58561356-4a97-467b-88e5-412e633715fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58561356-4a97-467b-88e5-412e633715fb.jpg?1",
             "name": "Oblation",
             "text": "The owner of target nonland permanent shuffles it into his or her library, then draws two cards.",
             "colours": [
@@ -1571,7 +1571,7 @@
         },
         {
             "id": "30273590-e307-5296-8470-c3423c451203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee262fde-8df1-431f-9e5c-0cafe9212b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee262fde-8df1-431f-9e5c-0cafe9212b49.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature can't attack or block.",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "cf6ad2eb-d0de-59c6-939e-a59f14dbf2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea7219-6ab6-471a-afe7-d7da1df434c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea7219-6ab6-471a-afe7-d7da1df434c7.jpg?1",
             "name": "Pearlspear Courier",
             "text": "You may choose not to untap Pearlspear Courier during your untap step.\no2o\nW, oc\nT: As long as Pearlspear Courier remains tapped, target Soldier gets +2/+2 and has \"Attacking doesn't cause this creature to tap.\"",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "f727ec40-5cb8-52bb-81ba-8f9e13a5980f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2da43-c0e1-4fbf-b309-a75e105c29c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2da43-c0e1-4fbf-b309-a75e105c29c1.jpg?1",
             "name": "Piety Charm",
             "text": "Choose one Destroy target enchant creature; or target Soldier gets +2/+2 until end of turn; or attacking doesn't cause creatures you control to tap this turn.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "01990ecd-f83e-5609-8556-06a56b4bf754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea572b5-ff68-45aa-8200-78ee7f64a0ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea572b5-ff68-45aa-8200-78ee7f64a0ce.jpg?1",
             "name": "Renewed Faith",
             "text": "You gain 6 life.\nCycling o1o\nW (o1o\nW, Discard this card from your hand: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "47c83dd2-6ff0-5f97-a80d-fe35e70801cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83c6245-4b37-430d-af10-2581804fff08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83c6245-4b37-430d-af10-2581804fff08.jpg?1",
             "name": "Righteous Cause",
             "text": "Whenever a creature attacks, you gain 1 life.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "6d4c8b3e-a45f-56e3-b1c2-390ba91cc5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b59844-c9d4-4bc1-86e6-4cc596d9165d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b59844-c9d4-4bc1-86e6-4cc596d9165d.jpg?1",
             "name": "Sandskin",
             "text": "Prevent all combat damage that would be dealt to and dealt by enchanted creature.",
             "colours": [
@@ -1770,7 +1770,7 @@
         },
         {
             "id": "27aad62c-55f0-59aa-83ef-1238d7364d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ebe6-76cf-4345-b59b-9954496c44d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ebe6-76cf-4345-b59b-9954496c44d0.jpg?1",
             "name": "Shared Triumph",
             "text": "As Shared Triumph comes into play, choose a creature type.\nCreatures of the chosen type get +1/+1.",
             "colours": [
@@ -1802,7 +1802,7 @@
         },
         {
             "id": "b4fb4fd4-1ba9-5dd6-af51-1960dc7a7f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2d660-7c93-4087-a6e5-49c2ad21eb5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2d660-7c93-4087-a6e5-49c2ad21eb5a.jpg?1",
             "name": "Shieldmage Elder",
             "text": "Tap two untapped Clerics you control: Prevent all damage target creature would deal this turn.\nTap two untapped Wizards you control: Prevent all damage target spell would deal this turn.",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "ca28357d-c2db-5a3a-be83-2ab712565211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1babca-b285-4b00-8b46-ed946c9a027f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1babca-b285-4b00-8b46-ed946c9a027f.jpg?1",
             "name": "Sigil of the New Dawn",
             "text": "Whenever a creature is put into your graveyard from play, you may pay o1o\nW. If you do, return that card to your hand.",
             "colours": [
@@ -1870,7 +1870,7 @@
         },
         {
             "id": "93bc409f-e57b-5b5a-8953-27a237a2642e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d563ebb-ecd1-406c-9d69-c101acdeced7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d563ebb-ecd1-406c-9d69-c101acdeced7.jpg?1",
             "name": "Sunfire Balm",
             "text": "Prevent the next 4 damage that would be dealt to target creature or player this turn.\nCycling o1o\nW (o1o\nW, Discard this card from your hand: Draw a card.)\nWhen you cycle Sunfire Balm, you may prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1902,7 +1902,7 @@
         },
         {
             "id": "ed8233b5-72f4-50c2-a5a6-68601fc47901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4289bdcb-6eea-458f-a4eb-89e26264673a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4289bdcb-6eea-458f-a4eb-89e26264673a.jpg?1",
             "name": "True Believer",
             "text": "You can't be the target of spells or abilities.",
             "colours": [
@@ -1937,7 +1937,7 @@
         },
         {
             "id": "c244658f-5f79-5dc0-a320-4c9126e73e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29906eca-0823-4cd6-890f-e5b93cc50a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29906eca-0823-4cd6-890f-e5b93cc50a11.jpg?1",
             "name": "Unified Strike",
             "text": "Remove target attacking creature from the game if its power is less than or equal to the number of Soldiers in play.",
             "colours": [
@@ -1969,7 +1969,7 @@
         },
         {
             "id": "7c39156a-1908-5c43-830a-cedebb78794a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601ab1-3862-4aff-82be-be15493fe4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6601ab1-3862-4aff-82be-be15493fe4b0.jpg?1",
             "name": "Weathered Wayfarer",
             "text": "o\nW, oc\nT: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library. Play this ability only if an opponent controls more lands than you.",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "0a58b648-0b77-520c-bee0-eed8e2cd4603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf6987e-a6e4-4a88-af0b-cf3b2d2b80c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf6987e-a6e4-4a88-af0b-cf3b2d2b80c7.jpg?1",
             "name": "Whipcorder",
             "text": "o\nW, oc\nT: Tap target creature.\nMorph o\nW (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "b9375010-6acd-5001-a68f-81ba233fe3ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea5c6e0-8361-4214-997b-32a66b19fae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea5c6e0-8361-4214-997b-32a66b19fae9.jpg?1",
             "name": "Words of Worship",
             "text": "o1: The next time you would draw a card this turn, you gain 5 life instead.",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "7a0cce7b-5e97-5c6c-a832-b25d2163b460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa43b0-601f-4b99-a328-541b04d5696d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aaa43b0-601f-4b99-a328-541b04d5696d.jpg?1",
             "name": "Airborne Aid",
             "text": "Draw a card for each Bird in play.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "2ee98c33-b75b-57b4-8c1a-e549ae95b2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95d5cb7-3121-430b-80c3-84c75e5f869e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c95d5cb7-3121-430b-80c3-84c75e5f869e.jpg?1",
             "name": "Annex",
             "text": "You control enchanted land.",
             "colours": [
@@ -2139,7 +2139,7 @@
         },
         {
             "id": "9306d242-8a71-53fa-8de6-9e4340f126c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd2628f-63c4-4e19-83ea-26041650faab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd2628f-63c4-4e19-83ea-26041650faab.jpg?1",
             "name": "Aphetto Alchemist",
             "text": "oc\nT: Untap target artifact or creature.\nMorph o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "dd8418ad-47c6-5f2e-bb6a-57af366fd6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a7bf3-1b0c-415d-9c57-73ac55b1f915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7a7bf3-1b0c-415d-9c57-73ac55b1f915.jpg?1",
             "name": "Aphetto Grifter",
             "text": "Tap two untapped Wizards you control: Tap target permanent.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "ae53d7f5-9e4b-5f94-af1c-214dcb3c1b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90865f52-c062-4505-a204-b4d7d4b3fc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90865f52-c062-4505-a204-b4d7d4b3fc4c.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "oc\nT: Draw three cards.\no2o\nUo\nU: Return Arcanis the Omnipotent to its owner's hand.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "5c048d5f-d1bf-5fea-a3cf-56743193b2d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46894d1-2503-43fa-938e-7bbf19101d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46894d1-2503-43fa-938e-7bbf19101d13.jpg?1",
             "name": "Artificial Evolution",
             "text": "Change the text of target spell or permanent by replacing all instances of one creature type with another. The new creature type can't be Legend or Wall. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "0d6f904b-6cc3-502e-bfff-e27b106df9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b17df-615c-4cc1-af1a-2fc35a985af9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b17df-615c-4cc1-af1a-2fc35a985af9.jpg?1",
             "name": "Ascending Aven",
             "text": "Flying\nAscending Aven may block only creatures with flying.\nMorph o2o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "666e8cf7-fc62-5af9-b617-1122a4a599ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4b41c4-0d14-4b9c-8e0c-a626ba6b104d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4b41c4-0d14-4b9c-8e0c-a626ba6b104d.jpg?1",
             "name": "Aven Fateshaper",
             "text": "Flying\nWhen Aven Fateshaper comes into play, look at the top four cards of your library, then put them back in any order.\no4o\nU: Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "d99fd63e-ebb8-5bc8-ad3b-af6c180c5354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c40269-80a5-454f-83dd-dae1c11500c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c40269-80a5-454f-83dd-dae1c11500c0.jpg?1",
             "name": "Backslide",
             "text": "Turn target creature with morph face down.\nCycling o\nU (o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "b9d5d150-c6a1-542a-a267-d477fc0b48f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8284476c-a7c8-4a6c-8021-ee997e9270ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8284476c-a7c8-4a6c-8021-ee997e9270ce.jpg?1",
             "name": "Blatant Thievery",
             "text": "For each opponent, gain control of target permanent that player controls. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "7e1e3177-46c7-5365-b7a4-7f244a371acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd3ce7-e0e3-4412-9983-ff933584f59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dd3ce7-e0e3-4412-9983-ff933584f59b.jpg?1",
             "name": "Callous Oppressor",
             "text": "You may choose not to untap Callous Oppressor during your untap step.\nAs Callous Oppressor comes into play, an opponent chooses a creature type.\noc\nT: Gain control of target creature that isn't of the chosen type as long as Callous Oppressor remains tapped.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "3bc37ffb-0aa3-578d-9e37-4a37b5108373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6b4a2-5780-46e9-b239-459d2cf37743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f6b4a2-5780-46e9-b239-459d2cf37743.jpg?1",
             "name": "Chain of Vapor",
             "text": "Return target nonland permanent to its owner's hand. Then that permanent's controller may sacrifice a land. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "f543e64d-72ad-5203-aa54-baca67d1df61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4de14d1-441f-4d65-bd12-df0506530015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4de14d1-441f-4d65-bd12-df0506530015.jpg?1",
             "name": "Choking Tethers",
             "text": "Tap up to four target creatures.\nCycling o1o\nU (o1o\nU, Discard this card from your hand: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
             "colours": [
@@ -2509,7 +2509,7 @@
         },
         {
             "id": "81691298-49ff-51d6-aacc-4ab98eb10771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d513dde-7c5f-46f1-b871-5290595bdbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d513dde-7c5f-46f1-b871-5290595bdbbe.jpg?1",
             "name": "Clone",
             "text": "As Clone comes into play, you may choose a creature in play. If you do, Clone comes into play as a copy of that creature.",
             "colours": [
@@ -2543,7 +2543,7 @@
         },
         {
             "id": "7f6737c6-b3d5-53b7-884c-23ed3c16ce36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f69670-e494-42b8-9148-fe105ec61aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f69670-e494-42b8-9148-fe105ec61aa0.jpg?1",
             "name": "Complicate",
             "text": "Counter target spell unless its controller pays o3.\nCycling o2o\nU (o2o\nU, Discard this card from your hand: Draw a card.)\nWhen you cycle Complicate, you may counter target spell unless its controller pays o1.",
             "colours": [
@@ -2575,7 +2575,7 @@
         },
         {
             "id": "15d28ef5-50c2-5a40-8a3f-a929803089e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d91378-f831-40ef-a79b-b044af1470e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d91378-f831-40ef-a79b-b044af1470e0.jpg?1",
             "name": "Crafty Pathmage",
             "text": "oc\nT: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "5d824a36-bc77-5e5a-be9c-488db21f74c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe86733-7851-4c2a-8d94-dba6f071b94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe86733-7851-4c2a-8d94-dba6f071b94d.jpg?1",
             "name": "Crown of Ascension",
             "text": "Enchanted creature has flying.\nSacrifice Crown of Ascension: Enchanted creature and other creatures that share a creature type with it gain flying until end of turn.",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "4ff58604-467a-57dd-8cae-1d66a09e9835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef584c5-6e2d-419b-9c11-a1b6c9c9ab2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef584c5-6e2d-419b-9c11-a1b6c9c9ab2a.jpg?1",
             "name": "Discombobulate",
             "text": "Counter target spell. Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2676,7 +2676,7 @@
         },
         {
             "id": "c8585246-8e7a-5be4-82b4-2fc9756242fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69db0298-f6d5-450f-add3-a28c0a43f33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69db0298-f6d5-450f-add3-a28c0a43f33f.jpg?1",
             "name": "Dispersing Orb",
             "text": "o3o\nU, Sacrifice a permanent: Return target permanent to its owner's hand.",
             "colours": [
@@ -2708,7 +2708,7 @@
         },
         {
             "id": "35b13727-7bd7-5e8e-9e52-4ae980ccb85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d9c2f-356c-4f27-8560-8ffceadac31c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0d9c2f-356c-4f27-8560-8ffceadac31c.jpg?1",
             "name": "Disruptive Pitmage",
             "text": "oc\nT: Counter target spell unless its controller pays o1.\nMorph o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "5e92dc52-bcd3-59d5-a834-bad741d0d91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0b6c7a-0891-492d-8e07-6a198bf2ccc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0b6c7a-0891-492d-8e07-6a198bf2ccc4.jpg?1",
             "name": "Essence Fracture",
             "text": "Return two target creatures to their owners' hands.\nCycling o2o\nU (o2o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "ae49538e-acff-5c1e-9034-0ab6afcaedf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a2758-0096-43b9-8193-d6ae5b41b6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a2758-0096-43b9-8193-d6ae5b41b6e6.jpg?1",
             "name": "Fleeting Aven",
             "text": "Flying\nWhenever a player cycles a card, return Fleeting Aven to its owner's hand.",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "99a9f5cc-cd06-56b8-ad9b-54bb7eba38fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd665-4948-4961-aec5-f17782257f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688bd665-4948-4961-aec5-f17782257f9b.jpg?1",
             "name": "Future Sight",
             "text": "Play with the top card of your library revealed.\nYou may play the top card of your library as though it were in your hand.",
             "colours": [
@@ -2842,7 +2842,7 @@
         },
         {
             "id": "4275595d-3e30-5a77-9e81-3271aea91c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cc30a-9ed4-4f36-95cb-6f0a2b8dce02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd6cc30a-9ed4-4f36-95cb-6f0a2b8dce02.jpg?1",
             "name": "Ghosthelm Courier",
             "text": "You may choose not to untap Ghosthelm Courier during your untap step.\no2o\nU, oc\nT: As long as Ghosthelm Courier remains tapped, target Wizard gets +2/+2 and can't be the target of spells or abilities.",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "3d384fad-647a-5b03-987a-1acdd3416c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c16e565-0b7f-46b1-a091-64c47c923a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c16e565-0b7f-46b1-a091-64c47c923a9f.jpg?1",
             "name": "Graxiplon",
             "text": "Graxiplon is unblockable unless defending player controls three or more creatures that share a creature type.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "3812f9f5-b4c9-57ee-8ba7-6d832f6a5e15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6441-8a45-43e4-8d12-a886dcaadbd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be6441-8a45-43e4-8d12-a886dcaadbd3.jpg?1",
             "name": "Imagecrafter",
             "text": "oc\nT: Choose a creature type other than Legend or Wall. Target creature's type becomes that type until end of turn.",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "2f1eaa32-fbc5-5bdf-ad92-eee1d82b9760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ac59c-654d-44de-b266-532d44b34137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ac59c-654d-44de-b266-532d44b34137.jpg?1",
             "name": "Information Dealer",
             "text": "oc\nT: Look at the top X cards of your library, where X is the number of Wizards in play, then put them back in any order.",
             "colours": [
@@ -2981,7 +2981,7 @@
         },
         {
             "id": "321aefb8-4f6c-51dd-98b7-4846adb1ad52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d5e89-55f7-42b4-af19-d4d0f499a265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314d5e89-55f7-42b4-af19-d4d0f499a265.jpg?1",
             "name": "Ixidor, Reality Sculptor",
             "text": "Face-down creatures get +1/+1.\no2o\nU: Turn target face-down creature face up.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "5852aef0-d60b-5fb3-a444-d4c714f62ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b713448-853a-41ee-a302-963e9c1c1c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b713448-853a-41ee-a302-963e9c1c1c65.jpg?1",
             "name": "Ixidor's Will",
             "text": "Counter target spell unless its controller pays o2 for each Wizard in play.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "10ec581d-456f-5172-90e5-fb42c4642b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301cb538-a931-4916-927b-4986046b1158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301cb538-a931-4916-927b-4986046b1158.jpg?1",
             "name": "Mage's Guile",
             "text": "Target creature can't be the target of spells or abilities this turn.\nCycling o\nU (o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3082,7 +3082,7 @@
         },
         {
             "id": "b6a40151-876f-5418-8b5c-585137c9ef30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685edfe8-9770-47c6-95fb-0816f3126f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685edfe8-9770-47c6-95fb-0816f3126f04.jpg?1",
             "name": "Meddle",
             "text": "If target spell has only one target and that target is a creature, change that spell's target to another creature.",
             "colours": [
@@ -3114,7 +3114,7 @@
         },
         {
             "id": "a33ec260-6d6b-59b1-99a3-2c415712c237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff34e303-c94a-4f5f-b9f6-8d48e6aac383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff34e303-c94a-4f5f-b9f6-8d48e6aac383.jpg?1",
             "name": "Mistform Dreamer",
             "text": "Flying\no1: Mistform Dreamer's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "a9f1f476-f217-565b-8abf-f67065806eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbb075-5795-425f-9e33-70cb922eea16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbbb075-5795-425f-9e33-70cb922eea16.jpg?1",
             "name": "Mistform Mask",
             "text": "o1: Enchanted creature's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "95ea7de6-1d57-5c63-9cfe-26f1e10fcf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25b2697-5d7f-490a-8474-c775096e681e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a25b2697-5d7f-490a-8474-c775096e681e.jpg?1",
             "name": "Mistform Mutant",
             "text": "o1o\nU: Choose a creature type other than Legend or Wall. Target creature's type becomes that type until end of turn.",
             "colours": [
@@ -3217,7 +3217,7 @@
         },
         {
             "id": "662bba54-af59-5c1b-88b1-80f600316b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1082eea2-5e83-48d4-b02b-a22e7cbe2054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1082eea2-5e83-48d4-b02b-a22e7cbe2054.jpg?1",
             "name": "Mistform Shrieker",
             "text": "Flying\no1: Mistform Shrieker's type becomes the creature type of your choice until end of turn.\nMorph o3o\nUo\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "762de601-3f11-5d45-a70c-57a5708004aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e394e096-ea70-4813-9039-e4bd065d0a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e394e096-ea70-4813-9039-e4bd065d0a17.jpg?1",
             "name": "Mistform Skyreaver",
             "text": "Flying\no1: Mistform Skyreaver's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "132ebcc0-0ab0-5c8a-9b46-d650b35458cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80d109-b73f-4b5d-b9e4-534e8d69633f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e80d109-b73f-4b5d-b9e4-534e8d69633f.jpg?1",
             "name": "Mistform Stalker",
             "text": "o1: Mistform Stalker's type becomes the creature type of your choice until end of turn.\no2o\nUo\nU: Mistform Stalker gets +2/+2 and gains flying until end of turn.",
             "colours": [
@@ -3319,7 +3319,7 @@
         },
         {
             "id": "672e0ce5-ab1d-5b4d-bd6b-e74268130d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaa7a26-8516-4d71-a524-77b2d3f030d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebaa7a26-8516-4d71-a524-77b2d3f030d5.jpg?1",
             "name": "Mistform Wall",
             "text": "(Walls can't attack.)\no1: Mistform Wall's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "9e01e03e-4148-50bc-9df7-aabefa7b2424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cf3535-3f80-4b76-aad3-dd851e6885a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cf3535-3f80-4b76-aad3-dd851e6885a6.jpg?1",
             "name": "Nameless One",
             "text": "Nameless One's power and toughness are each equal to the number of Wizards in play.\nMorph o2o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "217ec249-b205-5372-8a2f-17f87af2fc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0110ba-49e4-4729-8a84-4d408b20df53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0110ba-49e4-4729-8a84-4d408b20df53.jpg?1",
             "name": "Peer Pressure",
             "text": "Choose a creature type. If you control more creatures of that type than any other player, you gain control of all creatures of that type. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -3421,7 +3421,7 @@
         },
         {
             "id": "c0ebfc62-9188-57ed-8493-3181879b240e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e55695-16cc-4373-8078-959f1ded4c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e55695-16cc-4373-8078-959f1ded4c6d.jpg?1",
             "name": "Psychic Trance",
             "text": "Until end of turn, Wizards you control gain \"oc\nT: Counter target spell.\"",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "5e15baf5-3e63-5be4-a990-0ffd9900a886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93577bd-2711-443c-aa88-a235345d7800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93577bd-2711-443c-aa88-a235345d7800.jpg?1",
             "name": "Quicksilver Dragon",
             "text": "Flying\no\nU: If target spell has only one target and that target is Quicksilver Dragon, change that spell's target to another creature.\nMorph o4o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "f09f7132-2845-54d5-ae59-726fd43daaea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc148c21-cbe6-4cea-899b-e62501b59a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc148c21-cbe6-4cea-899b-e62501b59a00.jpg?1",
             "name": "Read the Runes",
             "text": "Draw X cards. For each card drawn this way, discard a card from your hand unless you sacrifice a permanent.",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "ab12fa71-3947-508e-96a3-0bdfe72e67ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f246e3-2193-4820-9c59-07b480300fbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f246e3-2193-4820-9c59-07b480300fbe.jpg?1",
             "name": "Reminisce",
             "text": "Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -3551,7 +3551,7 @@
         },
         {
             "id": "6ad26f2d-ab6f-5425-b306-5df798a6d828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d399b71-c365-492c-976e-2c79d97d08bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d399b71-c365-492c-976e-2c79d97d08bc.jpg?1",
             "name": "Riptide Biologist",
             "text": "Protection from Beasts\nMorph o2o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "fc249eb0-2778-55c6-8e75-299ba71c38a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3767f568-36b1-4064-835e-4dd7576b7b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3767f568-36b1-4064-835e-4dd7576b7b8b.jpg?1",
             "name": "Riptide Chronologist",
             "text": "o\nU, Sacrifice Riptide Chronologist: Untap all creatures of the type of your choice.",
             "colours": [
@@ -3621,7 +3621,7 @@
         },
         {
             "id": "189bf95e-7dbc-5240-996a-0693d05eac4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd9abc9-f289-4294-bc0f-4addc8b92a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd9abc9-f289-4294-bc0f-4addc8b92a4e.jpg?1",
             "name": "Riptide Entrancer",
             "text": "Whenever Riptide Entrancer deals combat damage to a player, you may sacrifice it. If you do, gain control of target creature that player controls. (This effect doesn't end at end of turn.)\nMorph o\nUo\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3656,7 +3656,7 @@
         },
         {
             "id": "7c051edf-ad88-5093-893f-cf3021d05bde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85be34ac-7bc2-4da2-8d9c-2412b9946073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85be34ac-7bc2-4da2-8d9c-2412b9946073.jpg?1",
             "name": "Riptide Shapeshifter",
             "text": "o2o\nUo\nU, Sacrifice Riptide Shapeshifter: Choose a creature type. Reveal cards from the top of your library until you reveal a creature card of that type. Put that card into play and shuffle the rest into your library.",
             "colours": [
@@ -3690,7 +3690,7 @@
         },
         {
             "id": "9a25de58-bf33-5155-b5c5-d42d8f6e2e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad96e158-bf2b-4f3e-9692-0f79efdd94f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad96e158-bf2b-4f3e-9692-0f79efdd94f5.jpg?1",
             "name": "Rummaging Wizard",
             "text": "o2o\nU: Look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -3725,7 +3725,7 @@
         },
         {
             "id": "d2cf6aac-e13a-5c12-8df6-12d20b2b47c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c03afc5-7ca3-4ac6-a06e-091e2cce13a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c03afc5-7ca3-4ac6-a06e-091e2cce13a0.jpg?1",
             "name": "Sage Aven",
             "text": "Flying\nWhen Sage Aven comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -3760,7 +3760,7 @@
         },
         {
             "id": "38c505ff-2a4b-5df6-b526-05d05c3fe63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5856ac-e710-44ee-8516-6070f4f31ce5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5856ac-e710-44ee-8516-6070f4f31ce5.jpg?1",
             "name": "Screaming Seahawk",
             "text": "Flying\nWhen Screaming Seahawk comes into play, you may search your library for a card named Screaming Seahawk, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "cf5909f0-a4bd-542c-ad38-9dd2f179db34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb652a5c-464e-4ba4-a4ab-1181be70cf7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb652a5c-464e-4ba4-a4ab-1181be70cf7a.jpg?1",
             "name": "Sea's Claim",
             "text": "Enchanted land is an island.",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "140ec755-b635-5d61-8392-2bfcc8addd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d06a1f-00b7-440d-849d-efc466d73f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d06a1f-00b7-440d-849d-efc466d73f29.jpg?1",
             "name": "Slipstream Eel",
             "text": "Slipstream Eel can't attack unless defending player controls an island.\nCycling o1o\nU (o1o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "b730df06-b7bc-55dd-b477-a43c978dd11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4bed3f-845c-4822-b8af-8b511dce6fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4bed3f-845c-4822-b8af-8b511dce6fe2.jpg?1",
             "name": "Spy Network",
             "text": "Look at target player's hand, the top card of that player's library, and any face-down creatures he or she controls. Look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -3895,7 +3895,7 @@
         },
         {
             "id": "ea8c90f9-e421-549f-b519-3cd42d70cc26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c79e64-91bf-4e87-a4fd-3136ea67c5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c79e64-91bf-4e87-a4fd-3136ea67c5bb.jpg?1",
             "name": "Standardize",
             "text": "Choose a creature type other than Legend or Wall. Each creature's type becomes that type until end of turn.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "0cbc6ab8-629a-5669-96aa-7bdff36c7bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867de3d2-2178-4931-823e-ff439e1a45ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867de3d2-2178-4931-823e-ff439e1a45ea.jpg?1",
             "name": "Supreme Inquisitor",
             "text": "Tap five untapped Wizards you control: Search target player's library for up to five cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "f6ba8b97-6dc0-5883-9239-e927a876ac75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92e197e-ef7e-46bb-9533-5f9819d545b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92e197e-ef7e-46bb-9533-5f9819d545b2.jpg?1",
             "name": "Trade Secrets",
             "text": "Target opponent draws two cards, then you draw up to four cards. That opponent may repeat this process as many times as he or she chooses.",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "ca174f0e-24fc-5cca-96d4-5ef4765f08e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a2ee45-7f1d-40a8-82b4-ab3b705417ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a2ee45-7f1d-40a8-82b4-ab3b705417ea.jpg?1",
             "name": "Trickery Charm",
             "text": "Choose one Target creature gains flying until end of turn; or target creature's type becomes the creature type of your choice until end of turn; or look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -4026,7 +4026,7 @@
         },
         {
             "id": "8e14be91-4a8d-5822-8903-199dc2e2d19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7441e7f9-a326-4f61-b7b1-e0dbed06046f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7441e7f9-a326-4f61-b7b1-e0dbed06046f.jpg?1",
             "name": "Voidmage Prodigy",
             "text": "o\nUo\nU, Sacrifice a Wizard: Counter target spell.\nMorph o\nU (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4061,7 +4061,7 @@
         },
         {
             "id": "1628559b-3ec3-5f5e-b5b4-97b2d8c7fa47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f50a1a-f3d0-4fcf-bd32-0e173b0d3247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f50a1a-f3d0-4fcf-bd32-0e173b0d3247.jpg?1",
             "name": "Wheel and Deal",
             "text": "Any number of target opponents each discards his or her hand and draws seven cards.\nDraw a card.",
             "colours": [
@@ -4093,7 +4093,7 @@
         },
         {
             "id": "454f5658-5f95-5ef7-80a3-05e0be13c7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5595a57a-a76c-467b-afaf-5affffc24f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5595a57a-a76c-467b-afaf-5affffc24f35.jpg?1",
             "name": "Words of Wind",
             "text": "o1: The next time you would draw a card this turn, each player returns a permanent he or she controls to its owner's hand instead.",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "c2e2bd85-74e3-5b60-9768-684c0bbf046a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894556d8-6d5c-431b-a45d-26cd37c5f456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/894556d8-6d5c-431b-a45d-26cd37c5f456.jpg?1",
             "name": "Accursed Centaur",
             "text": "When Accursed Centaur comes into play, sacrifice a creature.",
             "colours": [
@@ -4160,7 +4160,7 @@
         },
         {
             "id": "98602e96-acee-5632-a429-882eae5511b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e43d62c-488a-4c8d-b193-bacbf8037761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e43d62c-488a-4c8d-b193-bacbf8037761.jpg?1",
             "name": "Anurid Murkdiver",
             "text": "Swampwalk",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "10065749-efa1-5d46-ac68-e9c4b036c7b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e7fadf-40f1-45ff-97ef-5830381accc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e7fadf-40f1-45ff-97ef-5830381accc9.jpg?1",
             "name": "Aphetto Dredging",
             "text": "Return up to three target creature cards of the creature type of your choice from your graveyard to your hand.",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "239a6a04-31c3-529c-90b9-dce5271cd53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492b9-03a8-4d53-a0cf-4814ffbec409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492b9-03a8-4d53-a0cf-4814ffbec409.jpg?1",
             "name": "Aphetto Vulture",
             "text": "Flying\nWhen Aphetto Vulture is put into a graveyard from play, you may put target Zombie card from your graveyard on top of your library.",
             "colours": [
@@ -4263,7 +4263,7 @@
         },
         {
             "id": "bf3b4737-8948-50aa-80e6-f2bc5c311b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b40f6eb-e2a4-46d2-8822-b0f3dc508b73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b40f6eb-e2a4-46d2-8822-b0f3dc508b73.jpg?1",
             "name": "Blackmail",
             "text": "Target player reveals three cards from his or her hand and you choose one of them. That player discards that card.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "6acebbcd-2d45-5e03-b539-b93a291d27fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d58030-a95a-4221-93bc-30a59344e30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9d58030-a95a-4221-93bc-30a59344e30b.jpg?1",
             "name": "Boneknitter",
             "text": "o1o\nB: Regenerate target Zombie.\nMorph o2o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4330,7 +4330,7 @@
         },
         {
             "id": "f4963900-a6d8-5baf-85a9-e6de4359ec2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdf6e2a-1bf5-4d63-a58b-883cfb1ea0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdf6e2a-1bf5-4d63-a58b-883cfb1ea0fa.jpg?1",
             "name": "Cabal Archon",
             "text": "o\nB, Sacrifice a Cleric: Target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "a813d5a4-94c6-5ed0-bd73-c8751a74626e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7727a7-0cdf-4fd5-82b4-e6587c10ca80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7727a7-0cdf-4fd5-82b4-e6587c10ca80.jpg?1",
             "name": "Cabal Executioner",
             "text": "Whenever Cabal Executioner deals combat damage to a player, that player sacrifices a creature.\nMorph o3o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4400,7 +4400,7 @@
         },
         {
             "id": "aa410d84-5c6a-5963-b16a-1d7d6320df1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c04fd3-021a-4011-be9b-0d268557aa06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c04fd3-021a-4011-be9b-0d268557aa06.jpg?1",
             "name": "Cabal Slaver",
             "text": "Whenever a Goblin deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "beada537-108a-5d82-be87-422ebf562aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfe64f9-8b03-41f6-a47b-fade397ad9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bfe64f9-8b03-41f6-a47b-fade397ad9d1.jpg?1",
             "name": "Chain of Smog",
             "text": "Target player discards two cards from his or her hand. That player may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "e6d8e894-b461-5f65-9a65-96d574ab9155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6d7d88-d82b-40f4-bf57-ec5d7c480689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6d7d88-d82b-40f4-bf57-ec5d7c480689.jpg?1",
             "name": "Cover of Darkness",
             "text": "As Cover of Darkness comes into play, choose a creature type.\nCreatures of the chosen type have fear. (They can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "2654df6a-5ce0-5f97-8468-b2c2bd9ea364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8953e11b-cc3a-4c8d-9d7e-04bf90c77027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8953e11b-cc3a-4c8d-9d7e-04bf90c77027.jpg?1",
             "name": "Crown of Suspicion",
             "text": "Enchanted creature gets +2/-1.\nSacrifice Crown of Suspicion: Enchanted creature and other creatures that share a creature type with it get +2/-1 until end of turn.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "0ebbd262-917e-5c1e-aa1e-fe48d770e1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245aba23-2abb-4084-b4cb-d06e46de2108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245aba23-2abb-4084-b4cb-d06e46de2108.jpg?1",
             "name": "Cruel Revival",
             "text": "Destroy target non-Zombie creature. It can't be regenerated. Return up to one target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "603231f0-6184-58d9-970f-a03e7b1181e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9057-267a-4c78-b72a-4f8018b627a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e9057-267a-4c78-b72a-4f8018b627a8.jpg?1",
             "name": "Death Match",
             "text": "Whenever a creature comes into play, that creature's controller may have target creature of his or her choice get -3/-3 until end of turn.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "6584f9e0-a7be-5db0-80ee-4d74735fab41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fd470-e535-47ea-98a0-6187e429dfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/524fd470-e535-47ea-98a0-6187e429dfe1.jpg?1",
             "name": "Death Pulse",
             "text": "Target creature gets -4/-4 until end of turn.\nCycling o1o\nBo\nB (o1o\nBo\nB, Discard this card from your hand: Draw a card.)\nWhen you cycle Death Pulse, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "420a60d7-03af-5786-82da-58c46e6c38d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8496e9c2-4c13-4307-bda7-b88512a21a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8496e9c2-4c13-4307-bda7-b88512a21a6a.jpg?1",
             "name": "Dirge of Dread",
             "text": "All creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)\nCycling o1o\nB (o1o\nB, Discard this card from your hand: Draw a card.)\nWhen you cycle Dirge of Dread, you may have target creature gain fear until end of turn.",
             "colours": [
@@ -4661,7 +4661,7 @@
         },
         {
             "id": "89743b98-7ec9-51cc-a77a-dc46619a56a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cc7ab0-a5db-4ae9-af9a-89fd5aaaab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74cc7ab0-a5db-4ae9-af9a-89fd5aaaab57.jpg?1",
             "name": "Disciple of Malice",
             "text": "Protection from white\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -4696,7 +4696,7 @@
         },
         {
             "id": "092f93ad-628f-5c55-bb8d-2b9274e23289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca3e348-47cc-41d6-999a-60d1206aaf06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca3e348-47cc-41d6-999a-60d1206aaf06.jpg?1",
             "name": "Doomed Necromancer",
             "text": "o\nB, oc\nT, Sacrifice Doomed Necromancer: Return target creature card from your graveyard to play.",
             "colours": [
@@ -4732,7 +4732,7 @@
         },
         {
             "id": "8ee5569f-b0dc-59c2-982c-6afe7d5c137f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebef2c-8bb2-4816-a628-0062f95e512e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ebef2c-8bb2-4816-a628-0062f95e512e.jpg?1",
             "name": "Ebonblade Reaper",
             "text": "Whenever Ebonblade Reaper attacks, you lose half your life, rounded up.\nWhenever Ebonblade Reaper deals combat damage to a player, that player loses half his or her life, rounded up.\nMorph o3o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "2f3b284e-5fc4-59bc-a143-aac6a6bc9b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15326971-a53b-45f2-8f1d-1b82935286e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15326971-a53b-45f2-8f1d-1b82935286e1.jpg?1",
             "name": "Endemic Plague",
             "text": "As an additional cost to play Endemic Plague, sacrifice a creature.\nDestroy all creatures that share a creature type with the sacrificed creature. They can't be regenerated.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "b527d563-7482-549d-902a-d23c9c50eef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab92-3e1f-49dc-afd0-8c84d0d952c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdddab92-3e1f-49dc-afd0-8c84d0d952c2.jpg?1",
             "name": "Entrails Feaster",
             "text": "At the beginning of your upkeep, you may remove a creature card in a graveyard from the game. If you do, put a +1/+1 counter on Entrails Feaster. If you don't, tap Entrails Feaster.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "628fffbd-8558-5703-8660-b96e36a7de4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34afa-0183-49aa-aa5f-03e070020136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b34afa-0183-49aa-aa5f-03e070020136.jpg?1",
             "name": "Fade from Memory",
             "text": "Remove target card in a graveyard from the game.\nCycling o\nB (o\nB, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "97d7e4de-2eed-5d86-95bb-d2728ce88275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7652dc61-9170-4895-a0bf-c32a1ee0350e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7652dc61-9170-4895-a0bf-c32a1ee0350e.jpg?1",
             "name": "Fallen Cleric",
             "text": "Protection from Clerics\nMorph o4o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "9f62d05b-2cd1-5f58-8dfd-698c070ebf36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef397db1-2d99-4cb0-a6e9-6f72d615ebad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef397db1-2d99-4cb0-a6e9-6f72d615ebad.jpg?1",
             "name": "False Cure",
             "text": "Until end of turn, whenever a player gains life, that player loses 2 life for each 1 life he or she gained.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "3eb16b6f-29e0-5467-a096-bf2b94150f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d74c30-ebca-4684-ad84-3ca19193ad88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d74c30-ebca-4684-ad84-3ca19193ad88.jpg?1",
             "name": "Feeding Frenzy",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of Zombies in play.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "66143d4c-030e-5c1c-b241-50260c941dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7209cc8-b519-4f27-87d8-b12e239a121f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7209cc8-b519-4f27-87d8-b12e239a121f.jpg?1",
             "name": "Festering Goblin",
             "text": "When Festering Goblin is put into a graveyard from play, target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "3ed447f2-b6b2-5541-a6ee-0d097b8d88e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0fa75a-a82b-44cd-965f-07e0fe7a111a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a0fa75a-a82b-44cd-965f-07e0fe7a111a.jpg?1",
             "name": "Frightshroud Courier",
             "text": "You may choose not to untap Frightshroud Courier during your untap step.\no2o\nB, oc\nT: As long as Frightshroud Courier remains tapped, target Zombie gets +2/+2 and has fear. (It can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -5034,7 +5034,7 @@
         },
         {
             "id": "73c931d0-d2e4-5c94-a47b-0d64cb5827d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b58b6b-24cd-4440-b99c-d88d44b3c41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b58b6b-24cd-4440-b99c-d88d44b3c41c.jpg?1",
             "name": "Gangrenous Goliath",
             "text": "Tap three untapped Clerics you control: Return Gangrenous Goliath from your graveyard to your hand.",
             "colours": [
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "2e7724c5-bcc3-5368-828c-560a74754777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db909e95-7979-41f0-b17a-874c4137fcc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db909e95-7979-41f0-b17a-874c4137fcc1.jpg?1",
             "name": "Gluttonous Zombie",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -5103,7 +5103,7 @@
         },
         {
             "id": "c43a2f6d-3e31-5832-b7b1-24dfc30a08b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18dc249-a343-4198-bef9-e8092a2bac15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18dc249-a343-4198-bef9-e8092a2bac15.jpg?1",
             "name": "Gravespawn Sovereign",
             "text": "Tap five untapped Zombies you control: Put target creature card from a graveyard into play under your control.",
             "colours": [
@@ -5137,7 +5137,7 @@
         },
         {
             "id": "e3a2dfbb-848a-529c-9ff4-68364ddfba91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de2f66-0b86-4c21-b4c8-c2d97e3fd095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de2f66-0b86-4c21-b4c8-c2d97e3fd095.jpg?1",
             "name": "Grinning Demon",
             "text": "At the beginning of your upkeep, you lose 2 life.\nMorph o2o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "c4659c15-a416-5a7c-b4fe-7de6c64dd1aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a164420c-3619-4f5e-81cf-2aa5a4553bc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a164420c-3619-4f5e-81cf-2aa5a4553bc3.jpg?1",
             "name": "Haunted Cadaver",
             "text": "Whenever Haunted Cadaver deals combat damage to a player, you may sacrifice it. If you do, that player discards three cards from his or her hand.\nMorph o1o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "80a3b164-5676-5b46-8bbe-2b86a5df2f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecc098-aa2b-4bae-80d5-4d02128ef837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ecc098-aa2b-4bae-80d5-4d02128ef837.jpg?1",
             "name": "Head Games",
             "text": "Target opponent puts the cards from his or her hand on top of his or her library. Search that player's library for that many cards. The player puts those cards into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -5237,7 +5237,7 @@
         },
         {
             "id": "ffcc5119-2fa1-592b-aa4e-39ee3e91b290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbd82d5-d64f-4833-b1a9-9652fcfa1578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbd82d5-d64f-4833-b1a9-9652fcfa1578.jpg?1",
             "name": "Headhunter",
             "text": "Whenever Headhunter deals combat damage to a player, that player discards a card from his or her hand.\nMorph o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "8224f491-8020-5e05-aea3-91f6ce920903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7890ba2-aa42-4c8d-bbc1-94fb1d4150fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7890ba2-aa42-4c8d-bbc1-94fb1d4150fc.jpg?1",
             "name": "Infest",
             "text": "All creatures get -2/-2 until end of turn.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "0989d38c-46b1-59aa-b0dd-c873185a5085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be66eaf-222b-4c40-a9fa-aad56b9218e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be66eaf-222b-4c40-a9fa-aad56b9218e0.jpg?1",
             "name": "Misery Charm",
             "text": "Choose one Destroy target Cleric; or return target Cleric card from your graveyard to your hand; or target player loses 2 life.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "7f77133e-da57-556e-944d-cc06fcb36cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff31ece-f132-4107-9415-fcf30e251167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff31ece-f132-4107-9415-fcf30e251167.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -5371,7 +5371,7 @@
         },
         {
             "id": "321f3080-f740-5df9-a0d5-db99d355b56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbfd715-0772-4516-8cd8-89495dbccf4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bbfd715-0772-4516-8cd8-89495dbccf4a.jpg?1",
             "name": "Oversold Cemetery",
             "text": "At the beginning of your upkeep, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "005cae9d-52f2-5f53-b212-4b7d1dad344b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2deba175-8c02-492d-b404-5d842910c095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2deba175-8c02-492d-b404-5d842910c095.jpg?1",
             "name": "Patriarch's Bidding",
             "text": "Each player chooses a creature type. Each player returns all creature cards of a type chosen this way from his or her graveyard to play.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "659b48c4-da4a-538f-a1d6-f6e4ffdf0669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8320ef-af97-4cf6-9aaf-17818174d842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8320ef-af97-4cf6-9aaf-17818174d842.jpg?1",
             "name": "Profane Prayers",
             "text": "Profane Prayers deals X damage to target creature or player and you gain X life, where X is the number of Clerics in play.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "599bea52-f75c-58ad-8c04-c724b7b3aa42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f037e99-75fb-4a2a-b4c6-448ef21b16a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f037e99-75fb-4a2a-b4c6-448ef21b16a3.jpg?1",
             "name": "Prowling Pangolin",
             "text": "When Prowling Pangolin comes into play, any player may sacrifice two creatures. If a player does, sacrifice Prowling Pangolin.",
             "colours": [
@@ -5502,7 +5502,7 @@
         },
         {
             "id": "00426069-829e-5bdd-a94b-82b98dc59ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b29d1e-9c06-4ad1-8178-b3eaa212f6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87b29d1e-9c06-4ad1-8178-b3eaa212f6f1.jpg?1",
             "name": "Rotlung Reanimator",
             "text": "Whenever Rotlung Reanimator or another Cleric is put into a graveyard from play, put a 2/2 black Zombie creature token into play.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "fa5b1951-551a-5f00-a058-988f83f05a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4b887a-d928-4f6c-aa37-a0b09e87b91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4b887a-d928-4f6c-aa37-a0b09e87b91e.jpg?1",
             "name": "Screeching Buzzard",
             "text": "Flying\nWhen Screeching Buzzard is put into a graveyard from play, each opponent discards a card from his or her hand.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "ee3b2c53-b9db-5552-8a0b-461e76fde688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe12afd-da41-436e-af84-fa3b36a58030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe12afd-da41-436e-af84-fa3b36a58030.jpg?1",
             "name": "Severed Legion",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
             "colours": [
@@ -5605,7 +5605,7 @@
         },
         {
             "id": "1753a371-fc73-5e85-bba4-b1431d8a4dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37be9a8-ef69-4c62-8455-e129e62fe69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37be9a8-ef69-4c62-8455-e129e62fe69a.jpg?1",
             "name": "Shade's Breath",
             "text": "Until end of turn, each creature you control becomes black, its creature type becomes Shade, and it gains \"o\nB: This creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -5637,7 +5637,7 @@
         },
         {
             "id": "2698ec69-6a3b-557f-9e54-e621d76c7432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952c021f-74c9-455f-9cd9-f0d354e8bea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952c021f-74c9-455f-9cd9-f0d354e8bea8.jpg?1",
             "name": "Shepherd of Rot",
             "text": "oc\nT: Each player loses 1 life for each Zombie in play.",
             "colours": [
@@ -5672,7 +5672,7 @@
         },
         {
             "id": "a0e22422-af02-525d-b1e2-6a87a2e2feb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd891ba-cf6a-4b83-a421-3a7c346ada31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd891ba-cf6a-4b83-a421-3a7c346ada31.jpg?1",
             "name": "Silent Specter",
             "text": "Flying\nWhenever Silent Specter deals combat damage to a player, that player discards two cards from his or her hand.\nMorph o3o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5706,7 +5706,7 @@
         },
         {
             "id": "f82e9a9b-f041-5ab0-8adf-e4217859a522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8321af-d667-44e7-8c03-3957286604b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8321af-d667-44e7-8c03-3957286604b9.jpg?1",
             "name": "Smother",
             "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "5c917f2d-3b95-58d7-8ade-905f9cdbfa99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c826d786-0d96-4f77-94ae-6907fbce51e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c826d786-0d96-4f77-94ae-6907fbce51e0.jpg?1",
             "name": "Soulless One",
             "text": "Soulless One's power and toughness are each equal to the number of Zombies in play plus the number of Zombie cards in all graveyards.",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "c5d92066-cc07-5214-b3ac-8f2da4d496d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0d666a-8e31-466c-937f-54df910f664e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0d666a-8e31-466c-937f-54df910f664e.jpg?1",
             "name": "Spined Basher",
             "text": "Morph o2o\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5808,7 +5808,7 @@
         },
         {
             "id": "ed3d8434-cf8f-5d44-b0be-e221a565a240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcf434-5c67-440a-8b67-2df7307e92bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcf434-5c67-440a-8b67-2df7307e92bd.jpg?1",
             "name": "Strongarm Tactics",
             "text": "Each player discards a card from his or her hand. Then each player who didn't discard a creature card this way loses 4 life.",
             "colours": [
@@ -5840,7 +5840,7 @@
         },
         {
             "id": "66484280-edfc-5325-82a7-f845dcee90eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a260-6c50-401d-a0ff-bf49a973e1a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3a260-6c50-401d-a0ff-bf49a973e1a1.jpg?1",
             "name": "Swat",
             "text": "Destroy target creature with power 2 or less.\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "bd8b0004-435c-5bd6-b03c-1942cd7a98a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg?1",
             "name": "Syphon Mind",
             "text": "Each other player discards a card from his or her hand. You draw a card for each card discarded this way.",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "9c015664-e6e8-53a4-ad48-276138b18098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaef0f-9965-463b-902d-72ec24b2db7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdaef0f-9965-463b-902d-72ec24b2db7b.jpg?1",
             "name": "Syphon Soul",
             "text": "Syphon Soul deals 2 damage to each other player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "516d81b8-62c0-5116-a129-becdb64df549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da84de0e-a4cd-4dff-8ee3-87c9debf0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da84de0e-a4cd-4dff-8ee3-87c9debf0969.jpg?1",
             "name": "Thrashing Mudspawn",
             "text": "Whenever Thrashing Mudspawn is dealt damage, you lose that much life.\nMorph o1o\nBo\nB (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "8590e97b-2039-5feb-9ee2-0f67f36ecb1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc779d9-3200-4369-9289-1a8e90e243b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc779d9-3200-4369-9289-1a8e90e243b9.jpg?1",
             "name": "Undead Gladiator",
             "text": "o1o\nB, Discard a card from your hand: Return Undead Gladiator from your graveyard to your hand. Play this ability only during your upkeep.\nCycling o1o\nB (o1o\nB, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -6005,7 +6005,7 @@
         },
         {
             "id": "7353d5a5-8b3d-59d5-a6ed-c04c8ad33911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6adcfe-b0f7-4a96-bab2-f76c84ef5ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce6adcfe-b0f7-4a96-bab2-f76c84ef5ca6.jpg?1",
             "name": "Visara the Dreadful",
             "text": "Flying\noc\nT: Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -6041,7 +6041,7 @@
         },
         {
             "id": "ae1b5ab3-6fa6-5b5a-b58f-8c8e79a1e9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f3e91-571a-4990-b1e8-db2a5bac34af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f3e91-571a-4990-b1e8-db2a5bac34af.jpg?1",
             "name": "Walking Desecration",
             "text": "o\nB, oc\nT: Creatures of the type of your choice attack this turn if able.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "c2c42dbb-c402-5581-97c5-7b03aa227cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce4be1e-97dd-45ec-89e5-2fb56145c098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce4be1e-97dd-45ec-89e5-2fb56145c098.jpg?1",
             "name": "Withering Hex",
             "text": "Whenever a player cycles a card, put a plague counter on Withering Hex.\nEnchanted creature gets -1/-1 for each plague counter on Withering Hex.",
             "colours": [
@@ -6109,7 +6109,7 @@
         },
         {
             "id": "3ab4cf8b-1490-591a-a513-b4ec037bfda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2dcb8ed-23e7-4cee-9f43-042232c6035a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2dcb8ed-23e7-4cee-9f43-042232c6035a.jpg?1",
             "name": "Words of Waste",
             "text": "o1: The next time you would draw a card this turn, each opponent discards a card from his or her hand instead.",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "1ce513d8-9219-5753-96cf-19a9e499521c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab525ad-1f62-4d9c-9b74-c7b0048da452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab525ad-1f62-4d9c-9b74-c7b0048da452.jpg?1",
             "name": "Wretched Anurid",
             "text": "Whenever another creature comes into play, you lose 1 life.",
             "colours": [
@@ -6177,7 +6177,7 @@
         },
         {
             "id": "a76cc031-816c-5673-aa49-5ffe61cdb5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df2792-4971-49e8-a8f2-17700e247500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df2792-4971-49e8-a8f2-17700e247500.jpg?1",
             "name": "Aether Charge",
             "text": "Whenever a Beast comes into play under your control, you may have it deal 4 damage to target opponent.",
             "colours": [
@@ -6209,7 +6209,7 @@
         },
         {
             "id": "dd550ac2-ca82-5011-abf8-6d6af9c3ee25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c5707-d5f2-4675-bfca-e801e6b0f627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c5707-d5f2-4675-bfca-e801e6b0f627.jpg?1",
             "name": "Aggravated Assault",
             "text": "o3o\nRo\nR: Untap all creatures you control. After this phase, there is an additional combat phase followed by an additional main phase. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -6241,7 +6241,7 @@
         },
         {
             "id": "b1e13027-a000-5dcd-a87f-f56e67a0d29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9796ac-11e2-4295-bf00-f684d0111970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9796ac-11e2-4295-bf00-f684d0111970.jpg?1",
             "name": "Airdrop Condor",
             "text": "Flying\no1o\nR, Sacrifice a Goblin: Airdrop Condor deals damage equal to the sacrificed Goblin's power to target creature or player.",
             "colours": [
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "6d5b7a0f-4740-5e89-b23a-5e7a10e22aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76705f-ec95-48b0-9e26-84ce40c9514b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae76705f-ec95-48b0-9e26-84ce40c9514b.jpg?1",
             "name": "Avarax",
             "text": "Haste\nWhen Avarax comes into play, you may search your library for a card named Avarax, reveal it, and put it into your hand. If you do, shuffle your library.\no1o\nR: Avarax gets +1/+0 until end of turn.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "99eb75bb-f759-5dfd-b7cd-b071eb8a2428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef71f42-87e5-4b1d-aac1-3752b81cee7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef71f42-87e5-4b1d-aac1-3752b81cee7c.jpg?1",
             "name": "Battering Craghorn",
             "text": "First strike\nMorph o1o\nRo\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6344,7 +6344,7 @@
         },
         {
             "id": "274eaea1-f129-598f-bba3-640f029ac6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ddcf4a-1943-49dd-a02c-75804ce4bc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ddcf4a-1943-49dd-a02c-75804ce4bc3e.jpg?1",
             "name": "Blistering Firecat",
             "text": "Trample, haste\nAt end of turn, sacrifice Blistering Firecat.\nMorph o\nRo\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "54e189ba-3c6d-5968-bf39-8b664ac9ca4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ae8050-b644-41db-b1e9-d9bad2173485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ae8050-b644-41db-b1e9-d9bad2173485.jpg?1",
             "name": "Break Open",
             "text": "Turn target face-down creature an opponent controls face up.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "b96981ad-1bd1-585b-97cc-254b40343852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b08b0a6-c94e-4407-8a24-c8202497b5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b08b0a6-c94e-4407-8a24-c8202497b5f2.jpg?1",
             "name": "Brightstone Ritual",
             "text": "Add o\nR to your mana pool for each Goblin in play.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "b4fe6e2c-b0a1-59ba-8757-14d998b4ce22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a29cf-4b2e-44c0-af73-512d6fed0dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2a29cf-4b2e-44c0-af73-512d6fed0dae.jpg?1",
             "name": "Butcher Orgg",
             "text": "You may divide Butcher Orgg's combat damage as you choose among defending player and/or any number of creatures he or she controls.",
             "colours": [
@@ -6477,7 +6477,7 @@
         },
         {
             "id": "04178205-0b20-5641-95a2-1c0a6800d122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94aa774-9036-4016-8880-4bde2710cb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94aa774-9036-4016-8880-4bde2710cb90.jpg?1",
             "name": "Chain of Plasma",
             "text": "Chain of Plasma deals 3 damage to target creature or player. Then that player or that creature's controller may discard a card from his or her hand. If the player does, he or she may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -6509,7 +6509,7 @@
         },
         {
             "id": "02885f14-3b09-5b29-a40d-ce75008505e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cfff37-655f-4107-abf3-e6f63d0e4de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cfff37-655f-4107-abf3-e6f63d0e4de2.jpg?1",
             "name": "Charging Slateback",
             "text": "Charging Slateback can't block.\nMorph o4o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6543,7 +6543,7 @@
         },
         {
             "id": "4f51d410-6c77-526c-9114-705c9c956a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb237330-ac2e-411d-836c-6628f96f3262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb237330-ac2e-411d-836c-6628f96f3262.jpg?1",
             "name": "Commando Raid",
             "text": "Until end of turn, target creature you control gains \"When this creature deals combat damage to a player, you may have it deal damage equal to its power to target creature that player controls.\"",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "7175746b-3173-5581-9a93-f2fb4fa5c364",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caae974-f531-469d-8c6a-2077c4f3294a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6caae974-f531-469d-8c6a-2077c4f3294a.jpg?1",
             "name": "Crown of Fury",
             "text": "Enchanted creature gets +1/+0 and has first strike.\nSacrifice Crown of Fury: Enchanted creature and other creatures that share a creature type with it get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -6609,7 +6609,7 @@
         },
         {
             "id": "3282eaf9-847c-5d0c-b6a2-448e884b3379",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72257f5-0cf9-45ca-8dc7-a1a93bd7dd1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72257f5-0cf9-45ca-8dc7-a1a93bd7dd1e.jpg?1",
             "name": "Custody Battle",
             "text": "Enchanted creature has \"At the beginning of your upkeep, target opponent gains control of this creature unless you sacrifice a land.\"",
             "colours": [
@@ -6643,7 +6643,7 @@
         },
         {
             "id": "ab5cbeb2-4210-55e1-ab43-e1a33e274320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4f28b-c7a7-4450-b477-73e4559f0276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e4f28b-c7a7-4450-b477-73e4559f0276.jpg?1",
             "name": "Dragon Roost",
             "text": "o5o\nRo\nR: Put a 5/5 red Dragon creature token with flying into play.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "71f768fe-021f-5248-8bc9-e9400f65e4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970831a-738b-476f-9d46-39f10a1f91e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2970831a-738b-476f-9d46-39f10a1f91e7.jpg?1",
             "name": "Dwarven Blastminer",
             "text": "o2o\nR, oc\nT: Destroy target nonbasic land.\nMorph o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -6709,7 +6709,7 @@
         },
         {
             "id": "bc61e812-95e5-56ef-8676-2dda68131844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50f60a8-e99a-4891-b474-a21abee38970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50f60a8-e99a-4891-b474-a21abee38970.jpg?1",
             "name": "Embermage Goblin",
             "text": "When Embermage Goblin comes into play, you may search your library for a card named Embermage Goblin, reveal it, and put it into your hand. If you do, shuffle your library.\noc\nT: Embermage Goblin deals 1 damage to target creature or player.",
             "colours": [
@@ -6745,7 +6745,7 @@
         },
         {
             "id": "27d7a71e-07d6-52bb-9664-4e2e3db2ffd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee5aa80-32cc-486e-bbb2-5386eadaf4ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee5aa80-32cc-486e-bbb2-5386eadaf4ca.jpg?1",
             "name": "Embermage Goblin",
             "text": "",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "c3c8ac79-758e-5063-a5ce-94e1c1e99f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f608a7e-5555-4554-a6e7-fe00e0bbe753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f608a7e-5555-4554-a6e7-fe00e0bbe753.jpg?1",
             "name": "Erratic Explosion",
             "text": "Choose target creature or player. Reveal cards from the top of your library until you reveal a nonland card. Erratic Explosion deals damage equal to that card's converted mana cost to that creature or player. Put the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -6813,7 +6813,7 @@
         },
         {
             "id": "dc4da6d3-88ae-5b59-8760-2114518b4f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d1980-f460-4be2-9379-c3f74c8318f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d1980-f460-4be2-9379-c3f74c8318f3.jpg?1",
             "name": "Fever Charm",
             "text": "Choose one Target creature gains haste until end of turn; or target creature gets +2/+0 until end of turn; or Fever Charm deals 3 damage to target Wizard.",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "2ba5e8ff-bb3f-5ce1-94a8-26422a4ecbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e822161d-0434-4578-aecd-c9ef0b84bd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e822161d-0434-4578-aecd-c9ef0b84bd4e.jpg?1",
             "name": "Flamestick Courier",
             "text": "You may choose not to untap Flamestick Courier during your untap step.\no2o\nR, oc\nT: As long as Flamestick Courier remains tapped, target Goblin gets +2/+2 and has haste.",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "a06fcfc2-7c39-53a6-ab67-3ccad21289e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5874e312-1010-43f2-b330-82bc9fcc9f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5874e312-1010-43f2-b330-82bc9fcc9f53.jpg?1",
             "name": "Goblin Machinist",
             "text": "o2o\nR: Reveal cards from the top of your library until you reveal a nonland card. Goblin Machinist gets +X/+0 until end of turn, where X is that card's converted mana cost. Put the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -6913,7 +6913,7 @@
         },
         {
             "id": "d838b33a-07fe-56ef-a46e-e9dfd51dea7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c4df1f-f148-42ec-8e22-e7114216927d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c4df1f-f148-42ec-8e22-e7114216927d.jpg?1",
             "name": "Goblin Piledriver",
             "text": "Protection from blue\nWhenever Goblin Piledriver attacks, it gets +2/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "a479bf53-8e01-5ad8-851a-a43fe15bba0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4815b7-fc20-44a4-ad1c-66d92993557f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4815b7-fc20-44a4-ad1c-66d92993557f.jpg?1",
             "name": "Goblin Pyromancer",
             "text": "When Goblin Pyromancer comes into play, all Goblins get +3/+0 until end of turn.\nAt end of turn, destroy all Goblins.",
             "colours": [
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "4d78e400-9ffe-5e8b-b1ad-0aeeaced1517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e689df7-b85d-4346-bee8-5e978b5cbbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e689df7-b85d-4346-bee8-5e978b5cbbbc.jpg?1",
             "name": "Goblin Sharpshooter",
             "text": "Goblin Sharpshooter doesn't untap during your untap step.\nWhenever a creature is put into a graveyard from play, untap Goblin Sharpshooter.\noc\nT: Goblin Sharpshooter deals 1 damage to target creature or player.",
             "colours": [
@@ -7017,7 +7017,7 @@
         },
         {
             "id": "6547649c-ac39-5e32-abe9-e7ef339decf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738cbf9b-e3d3-4568-93ce-7915b248e5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738cbf9b-e3d3-4568-93ce-7915b248e5b3.jpg?1",
             "name": "Goblin Sky Raider",
             "text": "Flying",
             "colours": [
@@ -7052,7 +7052,7 @@
         },
         {
             "id": "a659d3af-ca3e-57d7-8218-2f5af2d01e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9a1ecf-29f6-474e-bbcf-3455d388aa94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a9a1ecf-29f6-474e-bbcf-3455d388aa94.jpg?1",
             "name": "Goblin Sledder",
             "text": "Sacrifice a Goblin: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7086,7 +7086,7 @@
         },
         {
             "id": "7ea52a0c-f150-554c-b77e-be254bcd0f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feff65ca-aedf-4434-b701-590d600d1a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feff65ca-aedf-4434-b701-590d600d1a0b.jpg?1",
             "name": "Goblin Taskmaster",
             "text": "o1o\nR: Target Goblin gets +1/+0 until end of turn.\nMorph o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7120,7 +7120,7 @@
         },
         {
             "id": "2b4ab389-545e-526c-b16d-4c21271db96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0d3142-4224-4b51-885d-33c8938418c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0d3142-4224-4b51-885d-33c8938418c1.jpg?1",
             "name": "Grand Melee",
             "text": "All creatures attack each turn if able.\nAll creatures block each turn if able.",
             "colours": [
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "558acb5c-9ea3-5e58-a20e-86c9b2aa64cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c5d14-4fab-4034-a2d3-0d851ef67cbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c5d14-4fab-4034-a2d3-0d851ef67cbd.jpg?1",
             "name": "Gratuitous Violence",
             "text": "If a creature you control would deal damage to a creature or player, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "f4312ca1-722b-5c2a-83f7-b4e639606cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998bad32-1927-4e12-9527-efa55b86cae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998bad32-1927-4e12-9527-efa55b86cae0.jpg?1",
             "name": "Insurrection",
             "text": "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn.",
             "colours": [
@@ -7216,7 +7216,7 @@
         },
         {
             "id": "ec6e4530-3356-52a9-8ab4-0b033f149dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e81e5fc-0e18-4dd8-a505-aa7dba8521a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e81e5fc-0e18-4dd8-a505-aa7dba8521a8.jpg?1",
             "name": "Kaboom!",
             "text": "Choose any number of target players. For each of those players, reveal cards from the top of your library until you reveal a nonland card. Kaboom deals damage equal to that card's converted mana cost to that player, then you put the revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "121371bc-da15-5ea5-83d2-c4756ba1827c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4dd156-a2c1-4fab-b9f4-3302a4e8835a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4dd156-a2c1-4fab-b9f4-3302a4e8835a.jpg?1",
             "name": "Lavamancer's Skill",
             "text": "Enchanted creature has \"oc\nT: This creature deals 1 damage to target creature.\"\nIf enchanted creature is a Wizard, it has \"oc\nT: This creature deals 2 damage to target creature.\"",
             "colours": [
@@ -7282,7 +7282,7 @@
         },
         {
             "id": "e0d82e91-0d55-5d22-bd6a-0736dd05fc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22061b5e-81d3-4c7f-ab39-7ee719c13cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22061b5e-81d3-4c7f-ab39-7ee719c13cef.jpg?1",
             "name": "Lay Waste",
             "text": "Destroy target land.\nCycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "29468782-66b3-5c57-a556-bcd4dfad17a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d775d729-0ad9-4b14-9d44-6282f6936e07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d775d729-0ad9-4b14-9d44-6282f6936e07.jpg?1",
             "name": "Lightning Rift",
             "text": "Whenever a player cycles a card, you may pay o1. If you do, Lightning Rift deals 2 damage to target creature or player.",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "28ee6bb1-072a-556b-bc48-97f2ec8b4534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b15d04c-62cb-4704-8cc7-9842cef27a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b15d04c-62cb-4704-8cc7-9842cef27a1b.jpg?1",
             "name": "Mana Echoes",
             "text": "Whenever a creature comes into play, you may add o1 to your mana pool for each creature you control that shares a creature type with it.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "e6bf2e99-20db-59e2-9e7c-bc37b3084aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360a871-6932-45b2-bc94-1bd414e38906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5360a871-6932-45b2-bc94-1bd414e38906.jpg?1",
             "name": "Menacing Ogre",
             "text": "Trample, haste\nWhen Menacing Ogre comes into play, each player secretly chooses a number. Then those numbers are revealed. Each player with the highest number loses that much life. If you are one of those players, put two +1/+1 counters on Menacing Ogre.",
             "colours": [
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "a7ce8c1f-039e-51f4-aebc-0a00c26e5d1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea023e-e66d-4049-b7bc-5e660804f088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea023e-e66d-4049-b7bc-5e660804f088.jpg?1",
             "name": "Nosy Goblin",
             "text": "oc\nT, Sacrifice Nosy Goblin: Destroy target face-down creature.",
             "colours": [
@@ -7446,7 +7446,7 @@
         },
         {
             "id": "5ed77a43-dd16-53d5-ab80-38ec0f1c7cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cf8876-4c7d-4779-9363-d0a58bb7d851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cf8876-4c7d-4779-9363-d0a58bb7d851.jpg?1",
             "name": "Pinpoint Avalanche",
             "text": "Pinpoint Avalanche deals 4 damage to target creature. The damage can't be prevented.",
             "colours": [
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "d4e68eb6-24ba-5b3f-a797-92dcfe354b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37775f40-10de-4f5d-abb2-c49e682039de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37775f40-10de-4f5d-abb2-c49e682039de.jpg?1",
             "name": "Reckless One",
             "text": "Haste\nReckless One's power and toughness are each equal to the number of Goblins in play.",
             "colours": [
@@ -7513,7 +7513,7 @@
         },
         {
             "id": "d45ae925-a2f4-5286-b6e3-64de9d32f341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09315c-d6ff-4fdb-8774-c6402b45e959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09315c-d6ff-4fdb-8774-c6402b45e959.jpg?1",
             "name": "Risky Move",
             "text": "At the beginning of each player's upkeep, that player gains control of Risky Move.\nWhen you gain control of Risky Move from another player, choose a creature you control and an opponent. Flip a coin. If you lose the flip, that opponent gains control of that creature.",
             "colours": [
@@ -7545,7 +7545,7 @@
         },
         {
             "id": "0f6282f2-80e8-5b74-96e6-d4bd3af696a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2caba5-9f30-4b5e-833e-68c85a47ef7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f2caba5-9f30-4b5e-833e-68c85a47ef7c.jpg?1",
             "name": "Rorix Bladewing",
             "text": "Flying, haste",
             "colours": [
@@ -7581,7 +7581,7 @@
         },
         {
             "id": "9162dc72-5f7f-55a2-ab8e-18c83d75d05d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83db110-42e7-4823-a686-b83205faf503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83db110-42e7-4823-a686-b83205faf503.jpg?1",
             "name": "Searing Flesh",
             "text": "Searing Flesh deals 7 damage to target opponent.",
             "colours": [
@@ -7613,7 +7613,7 @@
         },
         {
             "id": "ea581b74-c2b7-5cc7-9caa-27f5f8e5c669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2de8a4-0d84-4f7c-bbe4-3a31172186ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc2de8a4-0d84-4f7c-bbe4-3a31172186ab.jpg?1",
             "name": "Shaleskin Bruiser",
             "text": "Trample\nWhenever Shaleskin Bruiser attacks, it gets +3/+0 until end of turn for each other attacking Beast.",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "cd5a1479-2969-5f5a-bbb8-093b31fee07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c92b5d-103c-4719-a850-690a7010291a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c92b5d-103c-4719-a850-690a7010291a.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -7679,7 +7679,7 @@
         },
         {
             "id": "4f1fbfa9-edf3-530f-a141-4502ada32ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c870a66-4cd5-4a8d-9948-feffa7d4ff11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c870a66-4cd5-4a8d-9948-feffa7d4ff11.jpg?1",
             "name": "Skirk Commando",
             "text": "Whenever Skirk Commando deals combat damage to a player, you may have it deal 2 damage to target creature that player controls.\nMorph o2o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7713,7 +7713,7 @@
         },
         {
             "id": "12aeaf71-2c0f-586d-909f-b4b58eea2f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71117d0-5cf7-4041-b568-00bd8a975dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71117d0-5cf7-4041-b568-00bd8a975dd8.jpg?1",
             "name": "Skirk Fire Marshal",
             "text": "Protection from red\nTap five untapped Goblins you control: Skirk Fire Marshal deals 10 damage to each creature and each player.",
             "colours": [
@@ -7747,7 +7747,7 @@
         },
         {
             "id": "2b2213df-2e26-505d-9862-de7dc5a550f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb545dcd-3a7a-46a7-9c35-d28faebc6d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb545dcd-3a7a-46a7-9c35-d28faebc6d17.jpg?1",
             "name": "Skirk Prospector",
             "text": "Sacrifice a Goblin: Add o\nR to your mana pool.",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "2fbfee7f-cc68-5187-8764-e9bf2c9216c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc8a6e6-ed62-4784-ba9a-b1f703fc6119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc8a6e6-ed62-4784-ba9a-b1f703fc6119.jpg?1",
             "name": "Skittish Valesk",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, turn Skittish Valesk face down.\nMorph o5o\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7815,7 +7815,7 @@
         },
         {
             "id": "f3a08fd9-1c7c-589f-8752-78f9eac6d547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59262684-86e3-4485-9e35-202771c3eaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59262684-86e3-4485-9e35-202771c3eaa6.jpg?1",
             "name": "Slice and Dice",
             "text": "Slice and Dice deals 4 damage to each creature.\nCycling o2o\nR (o2o\nR, Discard this card from your hand: Draw a card.)\nWhen you cycle Slice and Dice, you may have it deal 1 damage to each creature.",
             "colours": [
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "0ec33b70-19b6-5fe0-b424-96a62f5b7371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a47d41-b893-46b9-90c9-ccd8f9f78855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a47d41-b893-46b9-90c9-ccd8f9f78855.jpg?1",
             "name": "Snapping Thragg",
             "text": "Whenever Snapping Thragg deals combat damage to a player, you may have it deal 3 damage to target creature that player controls.\nMorph o4o\nRo\nR (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -7881,7 +7881,7 @@
         },
         {
             "id": "a661cc07-1000-53b0-8a6c-ffe01f9d8292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fc40c-6a68-4192-91d9-2031c7d32e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36fc40c-6a68-4192-91d9-2031c7d32e05.jpg?1",
             "name": "Solar Blast",
             "text": "Solar Blast deals 3 damage to target creature or player.\nCycling o1o\nRo\nR (o1o\nRo\nR, Discard this card from your hand: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "6389ef66-09ea-5781-adc4-32c6331c9b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a4460d-3fe8-4b1f-9990-0a19c3345367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a4460d-3fe8-4b1f-9990-0a19c3345367.jpg?1",
             "name": "Sparksmith",
             "text": "oc\nT: Sparksmith deals X damage to target creature and X damage to you, where X is the number of Goblins in play.",
             "colours": [
@@ -7947,7 +7947,7 @@
         },
         {
             "id": "42e82155-92ec-5ac7-86ab-683c350ad32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe72820-952f-4c53-9ee7-ea7ea54fc848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe72820-952f-4c53-9ee7-ea7ea54fc848.jpg?1",
             "name": "Spitfire Handler",
             "text": "Spitfire Handler can't block creatures with power greater than Spitfire Handler's power.\no\nR: Spitfire Handler gets +1/+0 until end of turn.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "b9f97286-a560-5db3-8c5e-08597337cf30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d7aaea-226b-4820-8db2-89dcdcbcc557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d7aaea-226b-4820-8db2-89dcdcbcc557.jpg?1",
             "name": "Spurred Wolverine",
             "text": "Tap two untapped Beasts you control: Target creature gains first strike until end of turn.",
             "colours": [
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "465e8c53-4843-57d3-88ff-dcb959e43aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54d72ba-05ce-4299-a7c3-a9e9f126fffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54d72ba-05ce-4299-a7c3-a9e9f126fffb.jpg?1",
             "name": "Starstorm",
             "text": "Starstorm deals X damage to each creature.\nCycling o3 (o3, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -8048,7 +8048,7 @@
         },
         {
             "id": "fa26da38-0ccc-58f4-87ce-4902304b569f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b65eba-140b-4c1d-b796-8134b7c1ede8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b65eba-140b-4c1d-b796-8134b7c1ede8.jpg?1",
             "name": "Tephraderm",
             "text": "Whenever a creature deals damage to Tephraderm, Tephraderm deals that much damage to that creature.\nWhenever a spell deals damage to Tephraderm, Tephraderm deals that much damage to that spell's controller.",
             "colours": [
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "e08562d2-b593-526a-844f-40ce3ac0a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89156b5-8bdb-41d1-a7aa-63f770a9b070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89156b5-8bdb-41d1-a7aa-63f770a9b070.jpg?1",
             "name": "Thoughtbound Primoc",
             "text": "Flying\nAt the beginning of your upkeep, if a player controls more Wizards than any other player, he or she gains control of Thoughtbound Primoc.",
             "colours": [
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "8a511385-9a2f-5c28-baaa-694c85ae3d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9676b6-6812-44e5-ad70-f498fbad0e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9676b6-6812-44e5-ad70-f498fbad0e18.jpg?1",
             "name": "Threaten",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "40282069-ee68-586e-b1cb-40f2d3a37488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4f796a-6831-4d83-824d-88fd2148b4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4f796a-6831-4d83-824d-88fd2148b4c1.jpg?1",
             "name": "Thunder of Hooves",
             "text": "Thunder of Hooves deals X damage to each creature without flying and each player, where X is the number of Beasts in play.",
             "colours": [
@@ -8181,7 +8181,7 @@
         },
         {
             "id": "ad83b32e-c777-5ed3-8f68-dba107280577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c88b942-06d5-45d8-a4d8-6ca864f65516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c88b942-06d5-45d8-a4d8-6ca864f65516.jpg?1",
             "name": "Wave of Indifference",
             "text": "X target creatures can't block this turn.",
             "colours": [
@@ -8213,7 +8213,7 @@
         },
         {
             "id": "c692d1d4-498c-57c2-ba86-614122b3eed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2593a6a6-dc21-4742-acb8-f7092931b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2593a6a6-dc21-4742-acb8-f7092931b1ce.jpg?1",
             "name": "Words of War",
             "text": "o1: The next time you would draw a card this turn, Words of War deals 2 damage to target creature or player instead.",
             "colours": [
@@ -8245,7 +8245,7 @@
         },
         {
             "id": "c2e9eb4d-ad07-577f-a11d-d679fd370674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33db646-b30d-4a15-9f8a-63bda74e2d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33db646-b30d-4a15-9f8a-63bda74e2d81.jpg?1",
             "name": "Animal Magnetism",
             "text": "Reveal the top five cards of your library. An opponent chooses a creature card from among them. Put that card into play and the rest into your graveyard.",
             "colours": [
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "6ebb301b-635a-577d-a223-b36e7cd21f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9196ce7-3ff4-4dda-a628-559ada11c9ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9196ce7-3ff4-4dda-a628-559ada11c9ba.jpg?1",
             "name": "Barkhide Mauler",
             "text": "Cycling o2 (o2, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -8311,7 +8311,7 @@
         },
         {
             "id": "50542c89-2839-5638-bacf-ddb22212aa22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02d6d5-27be-4301-a467-5b49491d0d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a02d6d5-27be-4301-a467-5b49491d0d4f.jpg?1",
             "name": "Biorhythm",
             "text": "Each player's life total becomes the number of creatures he or she controls.",
             "colours": [
@@ -8343,7 +8343,7 @@
         },
         {
             "id": "3df4f458-06b1-5950-b8f4-fec55e5aa1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce3a3a1-3569-4909-a604-f78d4888781e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce3a3a1-3569-4909-a604-f78d4888781e.jpg?1",
             "name": "Birchlore Rangers",
             "text": "Tap two untapped Elves you control: Add one mana of any color to your mana pool.\nMorph o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "8d9ad366-f16c-5452-93be-b7c686ecfdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc473-8477-4c04-a4e7-ecac1b0a5716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdfc473-8477-4c04-a4e7-ecac1b0a5716.jpg?1",
             "name": "Bloodline Shaman",
             "text": "oc\nT: Choose a creature type. Reveal the top card of your library. If that card is a creature card of the chosen type, put it into your hand. Otherwise, put it into your graveyard.",
             "colours": [
@@ -8415,7 +8415,7 @@
         },
         {
             "id": "5c73b821-075a-5afc-b8d8-8919732c80f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38315ba3-57a0-4aa0-b1bc-4b1fcdd763d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38315ba3-57a0-4aa0-b1bc-4b1fcdd763d4.jpg?1",
             "name": "Broodhatch Nantuko",
             "text": "Whenever Broodhatch Nantuko is dealt damage, you may put that many 1/1 green Insect creature tokens into play.\nMorph o2o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "23f0e917-5807-5c17-8b91-09ea9feb5ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c75f9c8-9640-4f64-b32a-916436e461fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c75f9c8-9640-4f64-b32a-916436e461fc.jpg?1",
             "name": "Centaur Glade",
             "text": "o2o\nGo\nG: Put a 3/3 green Centaur creature token into play.",
             "colours": [
@@ -8482,7 +8482,7 @@
         },
         {
             "id": "5ac026bf-e12f-50d5-a316-89e5a0c1adb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d47ddca-a363-4ab7-b7f2-d0e0043c9916.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d47ddca-a363-4ab7-b7f2-d0e0043c9916.jpg?1",
             "name": "Chain of Acid",
             "text": "Destroy target noncreature permanent. Then that permanent's controller may copy this spell and may choose a new target for that copy.",
             "colours": [
@@ -8514,7 +8514,7 @@
         },
         {
             "id": "896ccc3d-f606-59a1-a47a-5478ef7dc6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e320a6-88e2-4be1-97e2-30e0f3c2e450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e320a6-88e2-4be1-97e2-30e0f3c2e450.jpg?1",
             "name": "Crown of Vigor",
             "text": "Enchanted creature gets +1/+1.\nSacrifice Crown of Vigor: Enchanted creature and other creatures that share a creature type with it get +1/+1 until end of turn.",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "144dac9c-fef6-560b-b316-a9c28a5aad26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c1aa30-0271-48d9-b9d0-3b1da26d98bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c1aa30-0271-48d9-b9d0-3b1da26d98bf.jpg?1",
             "name": "Elven Riders",
             "text": "Elven Riders can't be blocked except by creatures with flying and/or Walls.",
             "colours": [
@@ -8582,7 +8582,7 @@
         },
         {
             "id": "c8c0be55-537d-5e62-8bbc-e08999445b7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698c46b-2628-4482-88f9-e37a01ade274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698c46b-2628-4482-88f9-e37a01ade274.jpg?1",
             "name": "Elvish Guidance",
             "text": "Whenever enchanted land is tapped for mana, its controller adds o\nG to his or her mana pool for each Elf in play.",
             "colours": [
@@ -8616,7 +8616,7 @@
         },
         {
             "id": "4dc4eba7-8209-5d0b-b25b-c5c466dba863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d810b8-1a15-46cc-9d9d-871ac43b7036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d810b8-1a15-46cc-9d9d-871ac43b7036.jpg?1",
             "name": "Elvish Pathcutter",
             "text": "o2o\nG: Target Elf gains forestwalk until end of turn.",
             "colours": [
@@ -8651,7 +8651,7 @@
         },
         {
             "id": "323ff0fc-be66-5018-9146-a1ae9bca33ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e71fc2d-643b-4fad-89a8-624d330895d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e71fc2d-643b-4fad-89a8-624d330895d6.jpg?1",
             "name": "Elvish Pioneer",
             "text": "When Elvish Pioneer comes into play, you may put a basic land card from your hand into play tapped.",
             "colours": [
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "0a70ba58-5539-5694-99c6-0ce5e746163d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae85fafb-114b-4fd8-ac4c-5ada57054705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae85fafb-114b-4fd8-ac4c-5ada57054705.jpg?1",
             "name": "Elvish Scrapper",
             "text": "o\nG, oc\nT, Sacrifice Elvish Scrapper: Destroy target artifact.",
             "colours": [
@@ -8720,7 +8720,7 @@
         },
         {
             "id": "195f810f-2bbd-5676-9559-1c5a31589db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455c6923-8d0e-4a7f-a5c0-add8db519ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455c6923-8d0e-4a7f-a5c0-add8db519ee3.jpg?1",
             "name": "Elvish Vanguard",
             "text": "Whenever another Elf comes into play, put a +1/+1 counter on Elvish Vanguard.",
             "colours": [
@@ -8755,7 +8755,7 @@
         },
         {
             "id": "20d5a703-3a71-5abd-ae95-56c76994a08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6b767b-49e5-4845-9b3f-29540e5fa330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6b767b-49e5-4845-9b3f-29540e5fa330.jpg?1",
             "name": "Elvish Warrior",
             "text": "",
             "colours": [
@@ -8790,7 +8790,7 @@
         },
         {
             "id": "82f4b549-0c22-5bc9-a517-bd73765ee350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75def198-99d6-4b0a-8878-5151f44bc0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75def198-99d6-4b0a-8878-5151f44bc0a4.jpg?1",
             "name": "Enchantress's Presence",
             "text": "Whenever you play an enchantment spell, draw a card.",
             "colours": [
@@ -8822,7 +8822,7 @@
         },
         {
             "id": "a9b95b0c-b89d-5dfe-b85a-c16c0f3716ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bf5786-e41a-4839-b8a0-5c7a413b23d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bf5786-e41a-4839-b8a0-5c7a413b23d0.jpg?1",
             "name": "Everglove Courier",
             "text": "You may choose not to untap Everglove Courier during your untap step.\no2o\nG, oc\nT: As long as Everglove Courier remains tapped, target Elf gets +2/+2 and has trample.",
             "colours": [
@@ -8856,7 +8856,7 @@
         },
         {
             "id": "0905d6cc-9009-55ea-86f9-5e8b5b01c376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6efd31-ab5e-46ff-80d2-9382438e302c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6efd31-ab5e-46ff-80d2-9382438e302c.jpg?1",
             "name": "Explosive Vegetation",
             "text": "Search your library for up to two basic land cards and put them into play tapped. Then shuffle your library.",
             "colours": [
@@ -8888,7 +8888,7 @@
         },
         {
             "id": "0d0bf7bc-d458-5fff-ae1d-188eaa708fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a96a608-9237-41c1-824c-89d5fad939ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a96a608-9237-41c1-824c-89d5fad939ad.jpg?1",
             "name": "Gigapede",
             "text": "Gigapede can't be the target of spells or abilities.\nAt the beginning of your upkeep, if Gigapede is in your graveyard, you may discard a card from your hand. If you do, return Gigapede to your hand.",
             "colours": [
@@ -8922,7 +8922,7 @@
         },
         {
             "id": "fe7a040d-d053-5e2e-838a-d1166c5d5fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea338499-26a0-44e5-8999-f264644184d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea338499-26a0-44e5-8999-f264644184d1.jpg?1",
             "name": "Heedless One",
             "text": "Trample\nHeedless One's power and toughness are each equal to the number of Elves in play.",
             "colours": [
@@ -8957,7 +8957,7 @@
         },
         {
             "id": "6ed31a8d-a89c-5f5a-809d-0b98eaac4d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c964473-7c54-4c2d-a3eb-dba01c842103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c964473-7c54-4c2d-a3eb-dba01c842103.jpg?1",
             "name": "Hystrodon",
             "text": "Trample\nWhenever Hystrodon deals combat damage to a player, you may draw a card.\nMorph o1o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -8991,7 +8991,7 @@
         },
         {
             "id": "571bc0e9-428c-5fd4-85fa-494df9aeabb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f324b-63c6-4fb5-a80a-e9da51c3eb77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f324b-63c6-4fb5-a80a-e9da51c3eb77.jpg?1",
             "name": "Invigorating Boon",
             "text": "Whenever a player cycles a card, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -9023,7 +9023,7 @@
         },
         {
             "id": "a8316609-0500-573e-9b83-08f0c8806f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150d5229-b1a5-42cf-bf6a-04d246f1124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150d5229-b1a5-42cf-bf6a-04d246f1124f.jpg?1",
             "name": "Kamahl, Fist of Krosa",
             "text": "o\nG: Target land becomes a 1/1 creature until end of turn. It's still a land.\no2o\nGo\nGo\nG: Creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -9060,7 +9060,7 @@
         },
         {
             "id": "f5175ec9-9e14-5b58-8e99-cecf793b9974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edc37c6-b6a8-424f-95dd-928d03c28542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edc37c6-b6a8-424f-95dd-928d03c28542.jpg?1",
             "name": "Kamahl's Summons",
             "text": "Each player may reveal any number of creature cards from his or her hand. Then each player puts a 2/2 green Bear creature token into play for each card he or she revealed this way.",
             "colours": [
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "d3516447-7d75-5c0a-ab1f-37b8b3087afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804f3c0-5ebf-43ca-b200-09f7c1bbe902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a804f3c0-5ebf-43ca-b200-09f7c1bbe902.jpg?1",
             "name": "Krosan Colossus",
             "text": "Morph o6o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9126,7 +9126,7 @@
         },
         {
             "id": "9402f02f-11dc-55ec-8287-b01b0282079d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82105090-5f71-4690-9ade-187354311ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82105090-5f71-4690-9ade-187354311ae3.jpg?1",
             "name": "Krosan Groundshaker",
             "text": "o\nG: Target Beast gains trample until end of turn.",
             "colours": [
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "70720d48-6adb-5628-b7f3-632e3f733c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b872f85-60c5-44c4-956d-a8aa8132908b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b872f85-60c5-44c4-956d-a8aa8132908b.jpg?1",
             "name": "Krosan Tusker",
             "text": "Cycling o2o\nG (o2o\nG, Discard this card from your hand: Draw a card.)\nWhen you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -9195,7 +9195,7 @@
         },
         {
             "id": "fe484e83-cd9e-54e5-82bd-ee8569d57999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56125660-2307-4270-a947-f1f4ad63841c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56125660-2307-4270-a947-f1f4ad63841c.jpg?1",
             "name": "Leery Fogbeast",
             "text": "Whenever Leery Fogbeast becomes blocked, prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "ea510d6e-494c-5af9-8c74-96f9b6c523ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829069cf-7e63-4443-b679-65ad15d6ca5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/829069cf-7e63-4443-b679-65ad15d6ca5e.jpg?1",
             "name": "Mythic Proportions",
             "text": "Enchanted creature gets +8/+8 and has trample.",
             "colours": [
@@ -9263,7 +9263,7 @@
         },
         {
             "id": "11320490-55cf-52a4-8a85-746492907f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0acc41f-b55b-47cb-8803-d39d72788799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0acc41f-b55b-47cb-8803-d39d72788799.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -9295,7 +9295,7 @@
         },
         {
             "id": "0bd48913-1497-5673-90c4-a5abce224ca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9e3793-7ddc-45c5-b25d-acd5cb96026f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9e3793-7ddc-45c5-b25d-acd5cb96026f.jpg?1",
             "name": "Overwhelming Instinct",
             "text": "Whenever you attack with three or more creatures, draw a card.",
             "colours": [
@@ -9327,7 +9327,7 @@
         },
         {
             "id": "c799edb4-3a32-5976-be07-db94bc285cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b91a5a-9328-4fc6-a2f6-a7879281e145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b91a5a-9328-4fc6-a2f6-a7879281e145.jpg?1",
             "name": "Primal Boost",
             "text": "Target creature gets +4/+4 until end of turn.\nCycling o2o\nG (o2o\nG, Discard this card from your hand: Draw a card.)\nWhen you cycle Primal Boost, you may have target creature get +1/+1 until end of turn.",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "88e23599-0578-54b3-81ec-358d2c051406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98182d6-5b25-4493-9286-f29633e1bec4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98182d6-5b25-4493-9286-f29633e1bec4.jpg?1",
             "name": "Ravenous Baloth",
             "text": "Sacrifice a Beast: You gain 4 life.",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "37013baa-7288-5639-9052-5d2dd29fdaac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a7354-162c-489d-955d-4df17b930e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939a7354-162c-489d-955d-4df17b930e1c.jpg?1",
             "name": "Run Wild",
             "text": "Until end of turn, target creature gains trample and \"o\nG: Regenerate this creature.\"",
             "colours": [
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "80459a80-f908-5b58-a3b2-c79ff4081031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052a5af-20b2-4817-8c94-78d488ee220f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052a5af-20b2-4817-8c94-78d488ee220f.jpg?1",
             "name": "Serpentine Basilisk",
             "text": "Whenever Serpentine Basilisk deals combat damage to a creature, destroy that creature at end of combat.\nMorph o1o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "38b423ba-f34d-532c-82f0-03e49ad38c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41680e2-6689-4263-a5a3-9fb2e4280d52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41680e2-6689-4263-a5a3-9fb2e4280d52.jpg?1",
             "name": "Silklash Spider",
             "text": "Silklash Spider may block as though it had flying.\no\nXo\nGo\nG: Silklash Spider deals X damage to each creature with flying.",
             "colours": [
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "5ac2d3ad-dfda-57a4-a0bb-e43c1cbe867d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e48715c-6ff7-4b0c-aa7e-a2c901215426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e48715c-6ff7-4b0c-aa7e-a2c901215426.jpg?1",
             "name": "Silvos, Rogue Elemental",
             "text": "Trample\no\nG: Regenerate Silvos, Rogue Elemental.",
             "colours": [
@@ -9529,7 +9529,7 @@
         },
         {
             "id": "ae5b80b6-ee61-530a-bc5f-a252a2d3316a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05788d63-6210-44f2-9ae4-e55e9507a3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05788d63-6210-44f2-9ae4-e55e9507a3a9.jpg?1",
             "name": "Snarling Undorak",
             "text": "o2o\nG: Target Beast gets +1/+1 until end of turn.\nMorph o1o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "87f40376-161b-50ca-9ed1-fa51b4f5531a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746b98bf-5398-4a00-b4fe-a990ea9cfd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746b98bf-5398-4a00-b4fe-a990ea9cfd77.jpg?1",
             "name": "Spitting Gourna",
             "text": "Spitting Gourna may block as though it had flying.\nMorph o4o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "ee5ed1e1-359d-57e6-beb7-7e20dca181e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc64b9-f5b9-42d3-9921-564c4c9f2c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc64b9-f5b9-42d3-9921-564c4c9f2c77.jpg?1",
             "name": "Stag Beetle",
             "text": "Stag Beetle comes into play with X +1/+1 counters on it, where X is the number of other creatures in play.",
             "colours": [
@@ -9631,7 +9631,7 @@
         },
         {
             "id": "faa04b17-9bde-5c58-a9d2-823c5b6a07c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88c530a-abc3-4cc4-8a48-5b76e1504a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88c530a-abc3-4cc4-8a48-5b76e1504a3c.jpg?1",
             "name": "Steely Resolve",
             "text": "As Steely Resolve comes into play, choose a creature type.\nCreatures of the chosen type can't be the targets of spells or abilities.",
             "colours": [
@@ -9663,7 +9663,7 @@
         },
         {
             "id": "935cf33f-5709-532d-ab91-c7fe52d2a986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb61443d-e47a-4fe1-b777-67a3670a5a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb61443d-e47a-4fe1-b777-67a3670a5a56.jpg?1",
             "name": "Symbiotic Beast",
             "text": "When Symbiotic Beast is put into a graveyard from play, put four 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -9698,7 +9698,7 @@
         },
         {
             "id": "5a9c1a91-c911-5e94-b8ca-d5f7fd1bec62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af35c6-7802-4366-ad20-1e330b4957ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af35c6-7802-4366-ad20-1e330b4957ef.jpg?1",
             "name": "Symbiotic Elf",
             "text": "When Symbiotic Elf is put into a graveyard from play, put two 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "515dca0e-a44a-536b-bd53-10f7b25a2fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60313ca-10cc-4c33-a557-1401c5721e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60313ca-10cc-4c33-a557-1401c5721e3b.jpg?1",
             "name": "Symbiotic Wurm",
             "text": "When Symbiotic Wurm is put into a graveyard from play, put seven 1/1 green Insect creature tokens into play.",
             "colours": [
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "82103017-0b8d-5d45-8eac-413c62c4424d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b24af94-9632-47da-9bf3-e81bb743cd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b24af94-9632-47da-9bf3-e81bb743cd43.jpg?1",
             "name": "Taunting Elf",
             "text": "All creatures able to block Taunting Elf do so.",
             "colours": [
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "7527d37f-2fa6-5460-b1d9-f412ca366d72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857c2b6c-cfdf-4c88-a334-2937cb7db603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857c2b6c-cfdf-4c88-a334-2937cb7db603.jpg?1",
             "name": "Tempting Wurm",
             "text": "When Tempting Wurm comes into play, each opponent may put any number of artifact, creature, enchantment, and/or land cards from his or her hand into play.",
             "colours": [
@@ -9834,7 +9834,7 @@
         },
         {
             "id": "7aedd758-9204-53d8-b328-f5a341fd0de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8cc948-28ff-4bbe-b8c9-71de37478023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8cc948-28ff-4bbe-b8c9-71de37478023.jpg?1",
             "name": "Towering Baloth",
             "text": "Morph o6o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9868,7 +9868,7 @@
         },
         {
             "id": "20305cf5-f09b-58c3-9ca5-c4ac66fbc895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d7ce-37d3-4989-beb4-173447cb5294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f525d7ce-37d3-4989-beb4-173447cb5294.jpg?1",
             "name": "Treespring Lorian",
             "text": "Morph o5o\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9902,7 +9902,7 @@
         },
         {
             "id": "55e6b67f-85cf-530d-95ff-43aa7363ba31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7b5ddf-d5a6-42bf-a196-7e834dbdb3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7b5ddf-d5a6-42bf-a196-7e834dbdb3dc.jpg?1",
             "name": "Tribal Unity",
             "text": "Creatures of the type of your choice get +X/+X until end of turn.",
             "colours": [
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "f11d67ec-dcea-5180-82ad-bc6e8b7e4d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774771c-5373-4636-9174-d06e7d635183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774771c-5373-4636-9174-d06e7d635183.jpg?1",
             "name": "Venomspout Brackus",
             "text": "o1o\nG, oc\nT: Venomspout Brackus deals 5 damage to target attacking or blocking creature with flying.\nMorph o3o\nGo\nG (You may play this face down as a 2/2 creature for o3. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -9968,7 +9968,7 @@
         },
         {
             "id": "3e29868d-9ca1-5129-9969-0bbde2df3cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1abae21-ed8f-4e21-b227-f721b840c11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1abae21-ed8f-4e21-b227-f721b840c11f.jpg?1",
             "name": "Vitality Charm",
             "text": "Choose one Put a 1/1 green Insect creature token into play; or target creature gets +1/+1 and gains trample until end of turn; or regenerate target Beast.",
             "colours": [
@@ -10000,7 +10000,7 @@
         },
         {
             "id": "1d5af82a-8b16-5b11-860d-00c399a3b0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb4668-eebf-4b7e-ae29-75fff5963868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebb4668-eebf-4b7e-ae29-75fff5963868.jpg?1",
             "name": "Voice of the Woods",
             "text": "Tap five untapped Elves you control: Put a 7/7 green Elemental creature token with trample into play.",
             "colours": [
@@ -10034,7 +10034,7 @@
         },
         {
             "id": "24c2c1ca-fdb8-5a3a-aafb-6a4d6751bfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b4448-50f0-4996-94a1-db9ce356d925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3b4448-50f0-4996-94a1-db9ce356d925.jpg?1",
             "name": "Wall of Mulch",
             "text": "(Walls can't attack.)\no\nG, Sacrifice a Wall: Draw a card.",
             "colours": [
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "e30c7730-7419-59e0-845b-3335bfa61021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdfa8b3-393b-4bb6-9265-faa4ab7126d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdfa8b3-393b-4bb6-9265-faa4ab7126d2.jpg?1",
             "name": "Weird Harvest",
             "text": "Each player may search his or her library for up to X creature cards, reveal those cards, and put them into his or her hand. Then each player who searched his or her library this way shuffles it.",
             "colours": [
@@ -10100,7 +10100,7 @@
         },
         {
             "id": "87a1378d-5c76-5b16-90e2-696630503bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95ab7c-0e77-4293-aa48-ee54902a363f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95ab7c-0e77-4293-aa48-ee54902a363f.jpg?1",
             "name": "Wellwisher",
             "text": "oc\nT: You gain 1 life for each Elf in play.",
             "colours": [
@@ -10134,7 +10134,7 @@
         },
         {
             "id": "b952da86-cd26-5c04-8815-83ee646f595c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a34e31-97f1-40e8-9d91-a8139af7f096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a34e31-97f1-40e8-9d91-a8139af7f096.jpg?1",
             "name": "Wirewood Elf",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [
@@ -10169,7 +10169,7 @@
         },
         {
             "id": "5a187388-1980-5641-b5ca-30ba6b591445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35724e9f-efa6-47e7-ab4d-7defe38ba576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35724e9f-efa6-47e7-ab4d-7defe38ba576.jpg?1",
             "name": "Wirewood Herald",
             "text": "When Wirewood Herald is put into a graveyard from play, you may search your library for an Elf card. If you do, reveal that card and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -10203,7 +10203,7 @@
         },
         {
             "id": "3695eedb-481f-5700-8888-299422cb4dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559e844-06c9-4953-bc2c-a58e4170fe47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a559e844-06c9-4953-bc2c-a58e4170fe47.jpg?1",
             "name": "Wirewood Pride",
             "text": "Target creature gets +X/+X until end of turn, where X is the number of Elves in play.",
             "colours": [
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "4cf6e561-76f4-5689-87a7-ce2657397cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99982622-98bc-45ae-8642-41cd543f32a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99982622-98bc-45ae-8642-41cd543f32a8.jpg?1",
             "name": "Wirewood Savage",
             "text": "Whenever a Beast comes into play, you may draw a card.",
             "colours": [
@@ -10269,7 +10269,7 @@
         },
         {
             "id": "f014aecb-b501-5e7b-8e48-4bea9f4aeb8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb9565f-5b09-4127-b169-3146079dab84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb9565f-5b09-4127-b169-3146079dab84.jpg?1",
             "name": "Words of Wilding",
             "text": "o1: The next time you would draw a card this turn, put a 2/2 green Bear creature token into play instead.",
             "colours": [
@@ -10301,7 +10301,7 @@
         },
         {
             "id": "c531e709-b300-5fe4-8ac1-2b343a5fd3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f379966-6a0a-434c-8682-1cf528a9a4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f379966-6a0a-434c-8682-1cf528a9a4a1.jpg?1",
             "name": "Cryptic Gateway",
             "text": "Tap two untapped creatures you control: You may put a creature card from your hand into play that shares a creature type with each creature tapped this way.",
             "colours": [],
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "7da23043-7120-5fa5-bf44-147fa24b19b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abde0d7-266b-41bd-ade1-c4d93507eb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abde0d7-266b-41bd-ade1-c4d93507eb16.jpg?1",
             "name": "Doom Cannon",
             "text": "As Doom Cannon comes into play, choose a creature type.\no3, oc\nT, Sacrifice a creature of the chosen type: Doom Cannon deals 3 damage to target creature or player.",
             "colours": [],
@@ -10357,7 +10357,7 @@
         },
         {
             "id": "0ef73265-2e2b-565c-b736-b9d1e65c7af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89610e9-f1d3-4332-901a-2598bf01d61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e89610e9-f1d3-4332-901a-2598bf01d61d.jpg?1",
             "name": "Dream Chisel",
             "text": "Face-down creature spells you play cost o1 less to play.",
             "colours": [],
@@ -10385,7 +10385,7 @@
         },
         {
             "id": "79cac9bb-9660-56ac-8e66-26fb012e1082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bb314f-237a-43fc-95c8-b26188dc4476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bb314f-237a-43fc-95c8-b26188dc4476.jpg?1",
             "name": "Riptide Replicator",
             "text": "As Riptide Replicator comes into play, choose a color and a creature type.\nRiptide Replicator comes into play with X charge counters on it.\no4, oc\nT: Put an X/X creature token of the chosen color and type into play, where X is the number of charge counters on Riptide Replicator.",
             "colours": [],
@@ -10413,7 +10413,7 @@
         },
         {
             "id": "ade07f4f-1bba-5ef6-9b1c-972563448569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae596e8c-04f5-48b0-b5e2-683c74912e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae596e8c-04f5-48b0-b5e2-683c74912e85.jpg?1",
             "name": "Slate of Ancestry",
             "text": "o4, oc\nT, Discard your hand: Draw a card for each creature you control.",
             "colours": [],
@@ -10441,7 +10441,7 @@
         },
         {
             "id": "2898ad79-f7ed-5187-a2eb-040c12b5b73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e208be1-8b24-4048-90b2-6389f08043d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e208be1-8b24-4048-90b2-6389f08043d1.jpg?1",
             "name": "Tribal Golem",
             "text": "Tribal Golem has trample as long as you control a Beast, haste as long as you control a Goblin, first strike as long as you control a Soldier, flying as long as you control a Wizard, and \"o\nB: Regenerate Tribal Golem\" as long as you control a Zombie.",
             "colours": [],
@@ -10474,7 +10474,7 @@
         },
         {
             "id": "022b44a7-227e-5e5f-affa-c39582562f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45be3811-a223-4c45-9b24-0317f2d53c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45be3811-a223-4c45-9b24-0317f2d53c60.jpg?1",
             "name": "Barren Moor",
             "text": "Barren Moor comes into play tapped.\noc\nT: Add o\nB to your mana pool.\nCycling o\nB (o\nB, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10504,7 +10504,7 @@
         },
         {
             "id": "9f120b75-5834-57a7-80e2-dfff9bacc0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c72226-6f52-4322-8b14-18737293dfa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c72226-6f52-4322-8b14-18737293dfa0.jpg?1",
             "name": "Bloodstained Mire",
             "text": "oc\nT, Pay 1 life, Sacrifice Bloodstained Mire: Search your library for a swamp or mountain card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10532,7 +10532,7 @@
         },
         {
             "id": "72d26b04-31d4-52f1-b2ce-67568dd29284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6363ea-3814-4014-ad9e-1066c72d907c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6363ea-3814-4014-ad9e-1066c72d907c.jpg?1",
             "name": "Contested Cliffs",
             "text": "oc\nT: Add o1 to your mana pool.\no\nRo\nG, oc\nT: Choose target Beast you control and target creature an opponent controls. Each creature deals damage equal to its power to the other.",
             "colours": [],
@@ -10563,7 +10563,7 @@
         },
         {
             "id": "888d88b5-0e3c-57d0-94f3-405c340bb659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5869f08-fac8-44b6-8142-7d7ecccab414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5869f08-fac8-44b6-8142-7d7ecccab414.jpg?1",
             "name": "Daru Encampment",
             "text": "oc\nT: Add o1 to your mana pool.\no\nW, oc\nT: Target Soldier gets +1/+1 until end of turn.",
             "colours": [],
@@ -10593,7 +10593,7 @@
         },
         {
             "id": "78851d72-de34-5893-a18a-859150b8c636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e3d844-d3b4-41d8-921d-c1cb3af343f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e3d844-d3b4-41d8-921d-c1cb3af343f8.jpg?1",
             "name": "Flooded Strand",
             "text": "oc\nT, Pay 1 life, Sacrifice Flooded Strand: Search your library for a plains or island card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "a19f2077-61f8-5962-bbd1-55dd70624f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5202668-a32c-4473-b272-e86264992576.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5202668-a32c-4473-b272-e86264992576.jpg?1",
             "name": "Forgotten Cave",
             "text": "Forgotten Cave comes into play tapped.\noc\nT: Add o\nR to your mana pool.\nCycling o\nR (o\nR, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "9d2565de-7c68-5dbc-8f0c-cf67fba9619a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5064cd2-8762-4e08-8c3c-be6f31e9ab61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5064cd2-8762-4e08-8c3c-be6f31e9ab61.jpg?1",
             "name": "Goblin Burrows",
             "text": "oc\nT: Add o1 to your mana pool.\no1o\nR, oc\nT: Target Goblin gets +2/+0 until end of turn.",
             "colours": [],
@@ -10681,7 +10681,7 @@
         },
         {
             "id": "7f1cc940-cb96-531d-993f-e9b75c024990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dc8061-a855-4a81-9eb7-350b355a9b3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2dc8061-a855-4a81-9eb7-350b355a9b3f.jpg?1",
             "name": "Grand Coliseum",
             "text": "Grand Coliseum comes into play tapped.\noc\nT: Add o1 to your mana pool.\noc\nT: Add one mana of any color to your mana pool. Grand Coliseum deals 1 damage to you.",
             "colours": [],
@@ -10709,7 +10709,7 @@
         },
         {
             "id": "06ab039c-0d3a-5852-b6b5-e31e65d87d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddab06-aff7-4c40-bcaa-10cbfe899dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddab06-aff7-4c40-bcaa-10cbfe899dd9.jpg?1",
             "name": "Lonely Sandbar",
             "text": "Lonely Sandbar comes into play tapped.\noc\nT: Add o\nU to your mana pool.\nCycling o\nU (o\nU, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10739,7 +10739,7 @@
         },
         {
             "id": "204f6277-6785-58e8-a35c-28ed4963ddb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7585c8-9e21-4eef-afc1-2852de23db2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7585c8-9e21-4eef-afc1-2852de23db2f.jpg?1",
             "name": "Polluted Delta",
             "text": "oc\nT, Pay 1 life, Sacrifice Polluted Delta: Search your library for an island or swamp card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "fca0ba14-93b6-5961-824c-922dc94ef4c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d993c973-2eb6-423c-8ee9-10749a751524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d993c973-2eb6-423c-8ee9-10749a751524.jpg?1",
             "name": "Riptide Laboratory",
             "text": "oc\nT: Add o1 to your mana pool.\no1o\nU, oc\nT: Return target Wizard you control to its owner's hand.",
             "colours": [],
@@ -10797,7 +10797,7 @@
         },
         {
             "id": "8c1a21f0-cac3-5bc9-bf78-efcb6459aded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c940a6b-3c5e-4ce2-92b6-63e2cb575c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c940a6b-3c5e-4ce2-92b6-63e2cb575c15.jpg?1",
             "name": "Seaside Haven",
             "text": "oc\nT: Add o1 to your mana pool.\no\nWo\nU, oc\nT, Sacrifice a Bird: Draw a card.",
             "colours": [],
@@ -10828,7 +10828,7 @@
         },
         {
             "id": "a73a2671-b8be-53eb-95a1-0aa4320588a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea454280-f7f4-4315-bb46-b56050c02c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea454280-f7f4-4315-bb46-b56050c02c97.jpg?1",
             "name": "Secluded Steppe",
             "text": "Secluded Steppe comes into play tapped.\noc\nT: Add o\nW to your mana pool.\nCycling o\nW (o\nW, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10858,7 +10858,7 @@
         },
         {
             "id": "a1a54582-e511-5a81-bf0d-1bd358fab7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace5e601-2583-4d9c-8bdf-aa33666c717c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace5e601-2583-4d9c-8bdf-aa33666c717c.jpg?1",
             "name": "Starlit Sanctum",
             "text": "oc\nT: Add o1 to your mana pool.\no\nW, oc\nT, Sacrifice a Cleric: You gain life equal to that Cleric's toughness.\no\nB, oc\nT, Sacrifice a Cleric: Target player loses life equal to that Cleric's power.",
             "colours": [],
@@ -10889,7 +10889,7 @@
         },
         {
             "id": "7ec55299-c645-5a0a-9908-025e0baa7c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7cef-8aeb-4c84-88e9-6df17768e292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7cef-8aeb-4c84-88e9-6df17768e292.jpg?1",
             "name": "Tranquil Thicket",
             "text": "Tranquil Thicket comes into play tapped.\noc\nT: Add o\nG to your mana pool.\nCycling o\nG (o\nG, Discard this card from your hand: Draw a card.)",
             "colours": [],
@@ -10919,7 +10919,7 @@
         },
         {
             "id": "cdc4e0ff-325c-5026-bae2-dfd88306e825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f464a9-586c-4cf3-894b-b407c9f4dcb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52f464a9-586c-4cf3-894b-b407c9f4dcb8.jpg?1",
             "name": "Unholy Grotto",
             "text": "oc\nT: Add o1 to your mana pool.\no\nB, oc\nT: Put target Zombie card from your graveyard on top of your library.",
             "colours": [],
@@ -10949,7 +10949,7 @@
         },
         {
             "id": "057ab958-8e75-5640-89b0-48fdd53e2240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c5941-9c8a-4a40-9efb-a84f05c58e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7c5941-9c8a-4a40-9efb-a84f05c58e53.jpg?1",
             "name": "Windswept Heath",
             "text": "oc\nT, Pay 1 life, Sacrifice Windswept Heath: Search your library for a forest or plains card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -10977,7 +10977,7 @@
         },
         {
             "id": "f735c763-eb7a-5823-91fd-5e0d198ae68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d251490-41bb-4ad3-bfd0-a5e66ee42598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d251490-41bb-4ad3-bfd0-a5e66ee42598.jpg?1",
             "name": "Wirewood Lodge",
             "text": "oc\nT: Add o1 to your mana pool.\no\nG, oc\nT: Untap target Elf.",
             "colours": [],
@@ -11007,7 +11007,7 @@
         },
         {
             "id": "1e2d949e-4371-5e11-a189-bac74f753780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad38f7-9dfa-4f1b-9fac-41ab2b253f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdad38f7-9dfa-4f1b-9fac-41ab2b253f53.jpg?1",
             "name": "Wooded Foothills",
             "text": "oc\nT, Pay 1 life, Sacrifice Wooded Foothills: Search your library for a mountain or forest card and put it into play. Then shuffle your library.",
             "colours": [],
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "afa23e8b-4cfa-599e-80b3-9865c2df3a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf7d68a-dbd0-45f3-acbb-59ee38e6057e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf7d68a-dbd0-45f3-acbb-59ee38e6057e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11073,7 +11073,7 @@
         },
         {
             "id": "1a7a501c-3882-5f4a-b021-a70b593f0f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52ed647-bd30-40a5-b648-0b98d1a3fd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52ed647-bd30-40a5-b648-0b98d1a3fd4a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11111,7 +11111,7 @@
         },
         {
             "id": "18e3eb70-964c-56c7-b6b8-12c9816ab701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854a255e-fd89-4c5d-b97b-416a9ac70960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854a255e-fd89-4c5d-b97b-416a9ac70960.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11149,7 +11149,7 @@
         },
         {
             "id": "93bd04bd-75b9-5841-9f97-e49fdaddb697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7babbe-f8c1-4e7c-8de2-2224dd357de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7babbe-f8c1-4e7c-8de2-2224dd357de4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -11187,7 +11187,7 @@
         },
         {
             "id": "e7aeaeaa-59ab-588c-b2ff-63ddd86e5273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e062ec-df51-40c0-ad8a-2ee1cb8f8f17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e062ec-df51-40c0-ad8a-2ee1cb8f8f17.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11225,7 +11225,7 @@
         },
         {
             "id": "46549032-d4c1-58fe-ac05-d54722cf1715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8c0e52-8482-4c33-bc5d-26eaad922e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8c0e52-8482-4c33-bc5d-26eaad922e72.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11263,7 +11263,7 @@
         },
         {
             "id": "9a755292-6fe4-5a68-b28b-a379be207eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dac3bfe-884b-4875-bc7d-df564eb014cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dac3bfe-884b-4875-bc7d-df564eb014cd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11301,7 +11301,7 @@
         },
         {
             "id": "009dbba5-ccab-5e07-aae2-5fc32185b21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a09b8-46d2-4ef6-b7cc-9e510d1ea0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189a09b8-46d2-4ef6-b7cc-9e510d1ea0b8.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -11339,7 +11339,7 @@
         },
         {
             "id": "3aa44df6-87f7-5bed-b01d-93a73ad26b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0356ae45-e5ca-46b9-8ebc-42bf4776e89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0356ae45-e5ca-46b9-8ebc-42bf4776e89c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11377,7 +11377,7 @@
         },
         {
             "id": "2bf47f3c-5a4b-5ef1-8531-5a8d997fae51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6285f63-a5d8-4b8b-a6dd-51ce7968fbaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6285f63-a5d8-4b8b-a6dd-51ce7968fbaf.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11415,7 +11415,7 @@
         },
         {
             "id": "5a2f8f98-c87f-52aa-b617-551be38b4567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa97b25-1ea0-4351-ab9f-f06c8bb4d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa97b25-1ea0-4351-ab9f-f06c8bb4d044.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11453,7 +11453,7 @@
         },
         {
             "id": "5626d132-7176-58eb-9f9b-075e101a4e4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e10b125-eaa6-4630-a6fe-6b1805921f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e10b125-eaa6-4630-a6fe-6b1805921f07.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11491,7 +11491,7 @@
         },
         {
             "id": "43b1455f-0f45-5de9-80f6-746b893b53a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f9bdca-0d54-46c7-b803-9083dfc9ee24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f9bdca-0d54-46c7-b803-9083dfc9ee24.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11529,7 +11529,7 @@
         },
         {
             "id": "f40895cd-ca24-5dd9-af7f-1c34d091cd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d39f35-c7b2-43b2-aee3-4ff2cd3e37e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6d39f35-c7b2-43b2-aee3-4ff2cd3e37e7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11567,7 +11567,7 @@
         },
         {
             "id": "5f3e7e6a-0848-5715-9694-62681f450744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8aade2d-5cf5-44f6-9095-aa3756b1c1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8aade2d-5cf5-44f6-9095-aa3756b1c1dd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11605,7 +11605,7 @@
         },
         {
             "id": "c601a84e-2a40-551a-ad9d-efe94dc04708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd194fb1-0d3a-4eff-a446-240d18dad43c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd194fb1-0d3a-4eff-a446-240d18dad43c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11643,7 +11643,7 @@
         },
         {
             "id": "6de6537b-81c7-56e8-9496-8ad2b1831781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b361b42d-401f-440a-bae9-35338b5dde0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b361b42d-401f-440a-bae9-35338b5dde0e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11681,7 +11681,7 @@
         },
         {
             "id": "ec5b9c11-ce3f-5c66-8f7b-3a72c09549d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8edfee-7837-450a-bcf3-a7bb25670056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d8edfee-7837-450a-bcf3-a7bb25670056.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11719,7 +11719,7 @@
         },
         {
             "id": "5cd274e0-746b-5aa6-af83-248db158a903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0af992-80e0-4ac6-a828-5eaac47eaff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0af992-80e0-4ac6-a828-5eaac47eaff6.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "49013084-8d20-5a77-bcc7-af4cd1dc052c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835a4eed-a308-428d-ac85-e385b5d47d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/835a4eed-a308-428d-ac85-e385b5d47d8e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ORI.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ORI.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "d4066ede-a0fc-5f22-94d8-d1daec6723b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg?1",
             "name": "Akroan Jailer",
             "text": "{2}{W}, {T}: Tap target creature.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "8db77bc6-b969-5fbe-85e0-74b8855066c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg?1",
             "name": "Ampryn Tactician",
             "text": "When Ampryn Tactician enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "82345c0b-3dce-5a4d-8e82-5128303c367d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg?1",
             "name": "Anointer of Champions",
             "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "c0da2f7b-dd82-562d-b3f5-0da81cf86c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af50bf1-c51e-4592-86bf-4197ec85a45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af50bf1-c51e-4592-86bf-4197ec85a45d.jpg?1",
             "name": "Archangel of Tithes",
             "text": "Flying\nAs long as Archangel of Tithes is untapped, creatures can't attack you or a planeswalker you control unless their controller pays {1} for each of those creatures.\nAs long as Archangel of Tithes is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "a19b5d8d-e7cb-52ac-8ff5-b59beb2fafa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598ebb91-57d6-4800-8931-4d0016e9fec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/598ebb91-57d6-4800-8931-4d0016e9fec1.jpg?1",
             "name": "Auramancer",
             "text": "When Auramancer enters the battlefield, you may return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "52446988-15f5-57a4-b62a-6d5c39bab309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg?1",
             "name": "Aven Battle Priest",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aven Battle Priest enters the battlefield, you gain 3 life.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "8147c810-3f73-508c-ba59-511e58648029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150dd602-5f61-4f1e-a422-e64c079de141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150dd602-5f61-4f1e-a422-e64c079de141.jpg?1",
             "name": "Blessed Spirits",
             "text": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on Blessed Spirits.",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "d6431884-e599-5e96-96d1-b4044c764c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bb3b06-b33b-4897-882e-75b75790ea02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bb3b06-b33b-4897-882e-75b75790ea02.jpg?1",
             "name": "Celestial Flare",
             "text": "Target player sacrifices an attacking or blocking creature.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "3a1f2a0a-f146-5815-97d9-4d86a7b6ecb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86bd259-bc2f-402c-9e7a-030f9a3781e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d86bd259-bc2f-402c-9e7a-030f9a3781e2.jpg?1",
             "name": "Charging Griffin",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever Charging Griffin attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -313,7 +313,7 @@
         },
         {
             "id": "bf729219-262a-5e2a-9128-aa859241a63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcea783-e9f0-4d44-ac74-5aee9a07aa69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcea783-e9f0-4d44-ac74-5aee9a07aa69.jpg?1",
             "name": "Cleric of the Forward Order",
             "text": "When Cleric of the Forward Order enters the battlefield, you gain 2 life for each creature you control named Cleric of the Forward Order.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "d85a2e44-dd4f-5a1d-a199-9a440bcbc63f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a1b68-2890-4702-a90e-bad8d309c40d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301a1b68-2890-4702-a90e-bad8d309c40d.jpg?1",
             "name": "Consul's Lieutenant",
             "text": "First strike\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhenever Consul's Lieutenant attacks, if it's renowned, other attacking creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "03e67300-5fff-52c0-afca-414a7f5b1d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg?1",
             "name": "Enlightened Ascetic",
             "text": "When Enlightened Ascetic enters the battlefield, you may destroy target enchantment.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "f46ef550-f5b5-56cc-9cfa-79832439e8e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059bd3e-451c-445a-b299-544c82fc0eb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059bd3e-451c-445a-b299-544c82fc0eb9.jpg?1",
             "name": "Enshrouding Mist",
             "text": "Target creature gets +1/+1 until end of turn. Prevent all damage that would be dealt to it this turn. If it's renowned, untap it.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "3caf9ad0-e24f-587a-93fa-221dfd1f14a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30142729-de9a-4a0b-b060-8f68e1ef234d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30142729-de9a-4a0b-b060-8f68e1ef234d.jpg?1",
             "name": "Gideon's Phalanx",
             "text": "Put four 2/2 white Knight creature tokens with vigilance onto the battlefield.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, creatures you control gain indestructible until end of turn.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "cbb7d6f8-80c4-5c22-b1d5-2a03d2c02121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8740d2-7fcf-4bdf-afea-0c28c025370c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8740d2-7fcf-4bdf-afea-0c28c025370c.jpg?1",
             "name": "Grasp of the Hieromancer",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature attacks, tap target creature defending player controls.\"",
             "colours": [
@@ -516,7 +516,7 @@
         },
         {
             "id": "e7f84d27-e3c4-51aa-be69-d3e069cb8f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fd0c0f-4a6a-47cf-9f50-df0bbf19aae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94fd0c0f-4a6a-47cf-9f50-df0bbf19aae4.jpg?1",
             "name": "Hallowed Moonlight",
             "text": "Until end of turn, if a creature would enter the battlefield and it wasn't cast, exile it instead.\nDraw a card.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "38640ca7-d113-5363-8810-92451a23e090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26559c-0ac5-42a7-b6ac-b39938c31026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26559c-0ac5-42a7-b6ac-b39938c31026.jpg?1",
             "name": "Healing Hands",
             "text": "Target player gains 4 life.\nDraw a card.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "fb29b33f-ee5c-5f12-9c30-6529d05d2dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg?1",
             "name": "Heavy Infantry",
             "text": "When Heavy Infantry enters the battlefield, tap target creature an opponent controls.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "6f67ad7c-b19d-5169-9302-d9de89e5e0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c21a35-4b70-4de4-93ff-c0ccabdc39e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c21a35-4b70-4de4-93ff-c0ccabdc39e0.jpg?1",
             "name": "Hixus, Prison Warden",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever a creature deals combat damage to you, if Hixus, Prison Warden entered the battlefield this turn, exile that creature until Hixus leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "4866b8c8-0765-593f-a968-4b74603830d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg?1",
             "name": "Knight of the Pilgrim's Road",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "f7b53ad2-0328-52b6-9d0e-56409f24f63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a601d-de5c-412c-87a2-69500c08809a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a601d-de5c-412c-87a2-69500c08809a.jpg?1",
             "name": "Knight of the White Orchid",
             "text": "First strike\nWhen Knight of the White Orchid enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "5128c866-cf5c-5d4d-ae6b-c82c82eb7804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20930fab-eb4f-4179-94a7-84dc7055710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20930fab-eb4f-4179-94a7-84dc7055710a.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, put a 2/2 white Knight creature token with vigilance onto the battlefield. (Attacking doesn't cause it to tap.)\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -756,7 +756,7 @@
         },
         {
             "id": "afb65926-e03d-53dc-ba00-2370bfe260a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg?1",
             "name": "Kytheon, Hero of Akros // Gideon, Battle-Forged",
             "text": "At end of combat, if Kytheon, Hero of Akros and at least two other creatures attacked this combat, exile Kytheon, then return him to the battlefield transformed under his owner's control.{2}{W}: Kytheon gains indestructible until end of turn.",
             "colours": [
@@ -793,7 +793,7 @@
         },
         {
             "id": "e0152afe-6828-586e-a1cc-a0b75079708c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c39df6-b237-40d1-bdcb-2fe5d05392a9.jpg?1",
             "name": "Kytheon, Hero of Akros // Gideon, Battle-Forged",
             "text": "+2: Up to one target creature an opponent controls attacks Gideon, Battle-Forged during its controller's next turn if able.+1: Until your next turn, target creature gains indestructible. Untap that creature.0: Until end of turn, Gideon, Battle-Forged becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -829,7 +829,7 @@
         },
         {
             "id": "e9fba55e-0ec8-5e8c-ae1c-3270295bbf41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg?1",
             "name": "Kytheon's Irregulars",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.){W}{W}: Tap target creature.",
             "colours": [
@@ -864,7 +864,7 @@
         },
         {
             "id": "859ca126-274b-50b7-8838-bd103a9a45ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0521669-206e-4909-be6f-a74603203a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0521669-206e-4909-be6f-a74603203a70.jpg?1",
             "name": "Kytheon's Tactics",
             "text": "Creatures you control get +2/+1 until end of turn.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, those creatures also gain vigilance until end of turn. (Attacking doesn't cause them to tap.)",
             "colours": [
@@ -896,7 +896,7 @@
         },
         {
             "id": "4da36866-b693-57cd-b0d7-6ae7dd1e62b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dad608-5f8d-49a8-a1f1-c80aae207945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06dad608-5f8d-49a8-a1f1-c80aae207945.jpg?1",
             "name": "Mighty Leap",
             "text": "Target creature gets +2/+2 and gains flying until end of turn. (It can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -928,7 +928,7 @@
         },
         {
             "id": "78bd5118-032e-5585-976c-4ce21750b284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8d6f7-ed22-4e01-9aeb-c6bc0065c89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d8d6f7-ed22-4e01-9aeb-c6bc0065c89c.jpg?1",
             "name": "Murder Investigation",
             "text": "Enchant creature you control\nWhen enchanted creature dies, put X 1/1 white Soldier creature tokens onto the battlefield, where X is its power.",
             "colours": [
@@ -962,7 +962,7 @@
         },
         {
             "id": "ec315a32-8848-54b9-b71d-4411abda8558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5c0526-ac1f-40ca-a597-bf004f2e2377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b5c0526-ac1f-40ca-a597-bf004f2e2377.jpg?1",
             "name": "Patron of the Valiant",
             "text": "Flying\nWhen Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "969f5f14-96a3-5b0f-9856-c7ef4b4ad2ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a4b00c-5bd5-4931-be05-121f09a3fae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60a4b00c-5bd5-4931-be05-121f09a3fae4.jpg?1",
             "name": "Relic Seeker",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhen Relic Seeker becomes renowned, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "ed2b5923-b6f4-55fc-8dd1-145db14978bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7b01ce-2729-4b70-ae0a-b9a1007be78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7b01ce-2729-4b70-ae0a-b9a1007be78f.jpg?1",
             "name": "Sentinel of the Eternal Watch",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nAt the beginning of combat on each opponent's turn, tap target creature that player controls.",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "362e7b63-b083-57ff-aebb-ca9debd2458c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386f050c-0233-490f-94ab-92a7b5dc65cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386f050c-0233-490f-94ab-92a7b5dc65cf.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, put a 4/4 white Angel creature token with flying onto the battlefield.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "ffe1bd4c-4008-5d04-b3c2-2f71cb0f8c60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg?1",
             "name": "Stalwart Aven",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1133,7 +1133,7 @@
         },
         {
             "id": "31260b56-aa6d-5715-84d0-6a1e5b095f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861dc1a5-4e84-47bc-83a2-f289804086d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861dc1a5-4e84-47bc-83a2-f289804086d8.jpg?1",
             "name": "Starfield of Nyx",
             "text": "At the beginning of your upkeep, you may return target enchantment card from your graveyard to the battlefield.\nAs long as you control five or more enchantments, each other non-Aura enchantment you control is a creature in addition to its other types and has base power and base toughness each equal to its converted mana cost.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "2da90fb6-e808-5c2b-b780-28f9835a5944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34c717b-224b-4289-826d-f5b1f7c3dbfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34c717b-224b-4289-826d-f5b1f7c3dbfb.jpg?1",
             "name": "Suppression Bonds",
             "text": "Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "edeb9610-6438-5ff7-b1f3-3944b5b68c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904cb2f5-eb62-4416-8236-d2fbeadf1dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904cb2f5-eb62-4416-8236-d2fbeadf1dc4.jpg?1",
             "name": "Swift Reckoning",
             "text": "Spell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may cast Swift Reckoning as though it had flash. (You may cast it any time you could cast an instant.)\nDestroy target tapped creature.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "830afd2b-e08f-5274-a516-567757271c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg?1",
             "name": "Topan Freeblade",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "02f40065-9163-51a5-8026-a83475cc580a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589346d3-b32b-40f2-8513-741ceb88bf7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589346d3-b32b-40f2-8513-741ceb88bf7b.jpg?1",
             "name": "Totem-Guide Hartebeest",
             "text": "When Totem-Guide Hartebeest enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "fa751be7-80bd-57ad-b38d-2f60b6981cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16acf619-0f45-4985-a8ec-074a4ec33fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16acf619-0f45-4985-a8ec-074a4ec33fa7.jpg?1",
             "name": "Tragic Arrogance",
             "text": "For each player, you choose from among the permanents that player controls an artifact, a creature, an enchantment, and a planeswalker. Then each player sacrifices all other nonland permanents he or she controls.",
             "colours": [
@@ -1332,7 +1332,7 @@
         },
         {
             "id": "dcfa530a-722a-5304-af41-0596a4403269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fa0acd-84c3-492e-adf7-e7438db47e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fa0acd-84c3-492e-adf7-e7438db47e0a.jpg?1",
             "name": "Valor in Akros",
             "text": "Whenever a creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "0c96b7da-967a-581e-8ed3-5833a338a93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg?1",
             "name": "Vryn Wingmare",
             "text": "Flying\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "d707e356-2db1-58bd-95f5-eab5a86dc327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg?1",
             "name": "War Oracle",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "f0a63ac4-cd33-5aa6-9b89-6f2efba41b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431069f2-3eba-42f3-b42d-05a7d066b665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431069f2-3eba-42f3-b42d-05a7d066b665.jpg?1",
             "name": "Yoked Ox",
             "text": "",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "4dee4663-2ccd-5e6c-8d09-74b726528901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4200b101-19d3-4442-bddd-3eb77d5f99a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4200b101-19d3-4442-bddd-3eb77d5f99a9.jpg?1",
             "name": "Alhammarret, High Arbiter",
             "text": "Flying\nAs Alhammarret, High Arbiter enters the battlefield, each opponent reveals his or her hand. You choose the name of a nonland card revealed this way.\nYour opponents can't cast spells with the chosen name (as long as this creature is on the battlefield).",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "775f431b-c477-56c3-9b01-43ffc476cbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15058f91-d266-4804-96af-fc050b6c8436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15058f91-d266-4804-96af-fc050b6c8436.jpg?1",
             "name": "Anchor to the Aether",
             "text": "Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "19dff3aa-7a25-5153-8459-8739b6a106f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c847774-c76d-44bd-acf6-bc1bc865ac77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c847774-c76d-44bd-acf6-bc1bc865ac77.jpg?1",
             "name": "Artificer's Epiphany",
             "text": "Draw two cards. If you control no artifacts, discard a card.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "dccca95d-a8f3-53d1-917d-16ac57c44520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae6c87f-003b-44b7-96fd-ab8fca9af6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae6c87f-003b-44b7-96fd-ab8fca9af6f1.jpg?1",
             "name": "Aspiring Aeronaut",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aspiring Aeronaut enters the battlefield, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield.",
             "colours": [
@@ -1602,7 +1602,7 @@
         },
         {
             "id": "20d17316-2b25-5c2c-98f0-c36c878aebc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7a29e0-02a8-4d04-8b80-831a7bed58f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7a29e0-02a8-4d04-8b80-831a7bed58f7.jpg?1",
             "name": "Bone to Ash",
             "text": "Counter target creature spell.\nDraw a card.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "696723b9-a62d-5020-a08a-c774095472b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c42ab35-6050-42b2-9c3c-3252f2e69442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c42ab35-6050-42b2-9c3c-3252f2e69442.jpg?1",
             "name": "Calculated Dismissal",
             "text": "Counter target spell unless its controller pays {3}.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, scry 2. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1666,7 +1666,7 @@
         },
         {
             "id": "b49c6bea-8706-5968-a1fd-c1c2b42fc978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665ee42f-8d76-4f8b-9dd3-7455a90f0da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/665ee42f-8d76-4f8b-9dd3-7455a90f0da7.jpg?1",
             "name": "Clash of Wills",
             "text": "Counter target spell unless its controller pays {X}.",
             "colours": [
@@ -1698,7 +1698,7 @@
         },
         {
             "id": "8a939c7a-f99b-5589-b2b2-002436540e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d249de3-4a84-4e98-9557-06e23e78de15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d249de3-4a84-4e98-9557-06e23e78de15.jpg?1",
             "name": "Claustrophobia",
             "text": "Enchant creature\nWhen Claustrophobia enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "8433e8d8-b7b9-568e-902e-e5fe34bb068f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a11287a-8002-4679-9f69-a7360e7f4d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a11287a-8002-4679-9f69-a7360e7f4d3c.jpg?1",
             "name": "Day's Undoing",
             "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. If it's your turn, end the turn. (Exile all spells and abilities on the stack, including this card. Discard down to your maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
             "colours": [
@@ -1764,7 +1764,7 @@
         },
         {
             "id": "1a09fb8c-c370-5890-810f-609c38f76ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007b526c-5387-4ed4-a320-b826d507e014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007b526c-5387-4ed4-a320-b826d507e014.jpg?1",
             "name": "Deep-Sea Terror",
             "text": "Deep-Sea Terror can't attack unless there are seven or more cards in your graveyard.",
             "colours": [
@@ -1798,7 +1798,7 @@
         },
         {
             "id": "1029dc8c-1d8f-50ed-b355-b685b8fb718f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d344f86-a02d-4de3-82c1-2586dd9ddbfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d344f86-a02d-4de3-82c1-2586dd9ddbfe.jpg?1",
             "name": "Disciple of the Ring",
             "text": "{1}, Exile an instant or sorcery card from your graveyard: Choose one \u2014\u2022 Counter target noncreature spell unless its controller pays {2}.\u2022 Disciple of the Ring gets +1/+1 until end of turn.\u2022 Tap target creature.\u2022 Untap target creature.",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "b6ae0b93-b1a9-5029-93cc-f6b2e6cee1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f790b0b5-ed67-40f8-b23b-10cf0a71f285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f790b0b5-ed67-40f8-b23b-10cf0a71f285.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1865,7 +1865,7 @@
         },
         {
             "id": "e29fbc87-b6ae-5ef2-8527-0caec7a31fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6fef1f-6cc9-4e24-a1be-fc313774f28d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6fef1f-6cc9-4e24-a1be-fc313774f28d.jpg?1",
             "name": "Displacement Wave",
             "text": "Return all nonland permanents with converted mana cost X or less to their owners' hands.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "68f7c59a-d0bd-5e8a-a3fb-09252202d818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1434a-4832-4008-a091-e0703dedd0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c1434a-4832-4008-a091-e0703dedd0a2.jpg?1",
             "name": "Dreadwaters",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of lands you control.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "e870df24-a875-51b0-b307-35d87917f135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c487f1a-a51d-449c-827d-c7b9381acb34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c487f1a-a51d-449c-827d-c7b9381acb34.jpg?1",
             "name": "Faerie Miscreant",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Faerie Miscreant enters the battlefield, if you control another creature named Faerie Miscreant, draw a card.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "0576b965-72c0-500a-bd54-ee08d200bc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca53de-cffb-4740-b318-a4ebfb3a31af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca53de-cffb-4740-b318-a4ebfb3a31af.jpg?1",
             "name": "Harbinger of the Tides",
             "text": "You may cast Harbinger of the Tides as though it had flash if you pay {2} more to cast it. (You may cast it any time you could cast an instant.)\nWhen Harbinger of the Tides enters the battlefield, you may return target tapped creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "406bbed4-aafa-5cbe-b2be-f505666d38de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaaa583-bdd3-448a-921e-527df5f7f548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeaaa583-bdd3-448a-921e-527df5f7f548.jpg?1",
             "name": "Hydrolash",
             "text": "Attacking creatures get -2/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2031,7 +2031,7 @@
         },
         {
             "id": "d3c62c41-549f-50f1-bc7c-7613df49367c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg?1",
             "name": "Jace, Vryn's Prodigy // Jace, Telepath Unbound",
             "text": "{T}: Draw a card, then discard a card. If there are five or more cards in your graveyard, exile Jace, Vryn's Prodigy, then return him to the battlefield transformed under his owner's control.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "683653a5-c730-5764-ab7e-8d9ee1dbed51",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02d6d693-f1f3-4317-bcc0-c21fa8490d38.jpg?1",
             "name": "Jace, Vryn's Prodigy // Jace, Telepath Unbound",
             "text": "+1: Up to one target creature gets -2/-0 until your next turn.\u22123: You may cast target instant or sorcery card from your graveyard this turn. If that card would be put into a graveyard this turn, exile it instead.\u22129: You get an emblem with \"Whenever you cast a spell, target opponent puts the top five cards of his or her library into his or her graveyard.\"",
             "colours": [
@@ -2104,7 +2104,7 @@
         },
         {
             "id": "a20dcbbe-28bc-5983-bb71-10b7407b39bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3fe038-a982-4cbf-a158-c45fdc3d727e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3fe038-a982-4cbf-a158-c45fdc3d727e.jpg?1",
             "name": "Jace's Sanctum",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "cfcc9aa1-5923-5176-be95-919954812d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg?1",
             "name": "Jhessian Thief",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Jhessian Thief deals combat damage to a player, draw a card.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "44aa02eb-c5ae-5a2b-9a1e-c72bde2feafc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008ff1b-7fb0-4570-b23e-9fda14b97640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008ff1b-7fb0-4570-b23e-9fda14b97640.jpg?1",
             "name": "Maritime Guard",
             "text": "",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "3457416f-7f85-5be5-ab70-36196d48f0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d568d-a2d6-449b-85c2-a92755efe4c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762d568d-a2d6-449b-85c2-a92755efe4c3.jpg?1",
             "name": "Mizzium Meddler",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Mizzium Meddler enters the battlefield, you may change a target of target spell or ability to Mizzium Meddler.",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "0ce14e2a-5d9c-59be-a9e1-604d1c44ceb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e848b632-e08a-4341-a99c-d8207f9ffe48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e848b632-e08a-4341-a99c-d8207f9ffe48.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "74b0066f-59a0-505c-85c0-c2763beee3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg?1",
             "name": "Nivix Barrier",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nDefender (This creature can't attack.)\nWhen Nivix Barrier enters the battlefield, target attacking creature gets -4/-0 until end of turn.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "c0d269c7-b9de-5c40-ae5f-7f7951d6492e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a105f8-0c01-4c09-a3bf-8c912b6dc741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a105f8-0c01-4c09-a3bf-8c912b6dc741.jpg?1",
             "name": "Psychic Rebuttal",
             "text": "Counter target instant or sorcery spell that targets you.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may copy the spell countered this way. You may choose new targets for the copy.",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "14eb1b5b-6b72-54ca-aabb-64bdd4c02f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg?1",
             "name": "Ringwarden Owl",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "67ad89d2-39dd-5bfe-a97b-8427bf2bda92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a1b7fc-6b0e-4228-b320-b1274e5ed14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a1b7fc-6b0e-4228-b320-b1274e5ed14b.jpg?1",
             "name": "Scrapskin Drake",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)Scrapskin Drake can block only creatures with flying.",
             "colours": [
@@ -2409,7 +2409,7 @@
         },
         {
             "id": "9cd2ed38-0232-5a4a-8e32-987079323eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f65037-d382-4a95-8cde-15f5d9f41297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f65037-d382-4a95-8cde-15f5d9f41297.jpg?1",
             "name": "Screeching Skaab",
             "text": "When Screeching Skaab enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2443,7 +2443,7 @@
         },
         {
             "id": "05823bca-9013-5808-811b-be2499548504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa34d648-da0a-4615-8dd8-d2c8b1a1a574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa34d648-da0a-4615-8dd8-d2c8b1a1a574.jpg?1",
             "name": "Send to Sleep",
             "text": "Tap up to two target creatures.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, those creatures don't untap during their controllers' next untap steps.",
             "colours": [
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "7d2bf4f6-f57a-541f-9796-f86ca3720a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg?1",
             "name": "Separatist Voidmage",
             "text": "When Separatist Voidmage enters the battlefield, you may return target creature to its owner's hand.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "f6d8ebfc-40af-53c2-91cb-2bba23913e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5849fa3-6296-4ca9-b2ac-519cf90f6b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5849fa3-6296-4ca9-b2ac-519cf90f6b62.jpg?1",
             "name": "Sigiled Starfish",
             "text": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "2b6411d4-c0f1-5221-a5d3-6836e0d49e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3682b3d3-cb3d-4c2c-a419-f08e3a370cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3682b3d3-cb3d-4c2c-a419-f08e3a370cd1.jpg?1",
             "name": "Skaab Goliath",
             "text": "As an additional cost to cast Skaab Goliath, exile two creature cards from your graveyard.\nTrample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "e77f3310-3fdc-55cc-9203-511c089b58d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg?1",
             "name": "Soulblade Djinn",
             "text": "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "0b79069b-4e12-5e7a-8b06-0dbe83880d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d90c3b0-f958-4a15-94a1-9bf1b0a9ac2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d90c3b0-f958-4a15-94a1-9bf1b0a9ac2a.jpg?1",
             "name": "Sphinx's Tutelage",
             "text": "Whenever you draw a card, target opponent puts the top two cards of his or her library into his or her graveyard. If they're both nonland cards that share a color, repeat this process.{5}{U}: Draw a card, then discard a card.",
             "colours": [
@@ -2645,7 +2645,7 @@
         },
         {
             "id": "18825764-5b07-5c04-98ef-8dffda264975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947bb8f3-51f5-4fbe-9098-7e48f9fe1452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947bb8f3-51f5-4fbe-9098-7e48f9fe1452.jpg?1",
             "name": "Stratus Walk",
             "text": "Enchant creature\nWhen Stratus Walk enters the battlefield, draw a card.\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\nEnchanted creature can block only creatures with flying.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "1f14f879-0c93-5705-b44c-5a03fe7841e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da13a1-8be2-4312-a660-f3e102c552b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da13a1-8be2-4312-a660-f3e102c552b6.jpg?1",
             "name": "Talent of the Telepath",
             "text": "Target opponent reveals the top seven cards of his or her library. You may cast an instant or sorcery card from among them without paying its mana cost. Then that player puts the rest into his or her graveyard.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two revealed instant and/or sorcery cards instead of one.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "a8068e23-31c1-57be-b276-6bd82b5571b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516d86e-539a-4ba8-8d25-1a3b27b1267a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516d86e-539a-4ba8-8d25-1a3b27b1267a.jpg?1",
             "name": "Thopter Spy Network",
             "text": "At the beginning of your upkeep, if you control an artifact, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield.\nWhenever one or more artifact creatures you control deal combat damage to a player, draw a card.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "c7ea63b0-0b7c-5c46-af23-82b88dcc72d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62815ee-d1d6-4c96-8ab0-4c0a8250ae86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62815ee-d1d6-4c96-8ab0-4c0a8250ae86.jpg?1",
             "name": "Tower Geist",
             "text": "Flying\nWhen Tower Geist enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2777,7 +2777,7 @@
         },
         {
             "id": "3053fe6a-f3d3-57e2-ae1c-4b0afb302e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13c604f-b2a7-4370-b7e4-698d8e8647bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13c604f-b2a7-4370-b7e4-698d8e8647bb.jpg?1",
             "name": "Turn to Frog",
             "text": "Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "a184400d-772d-51ae-b1d8-4dbf8359913f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b12e87-ccd6-4c84-80b2-9ac7d099be89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b12e87-ccd6-4c84-80b2-9ac7d099be89.jpg?1",
             "name": "Watercourser",
             "text": "{U}: Watercourser gets +1/-1 until end of turn.",
             "colours": [
@@ -2843,7 +2843,7 @@
         },
         {
             "id": "fb67d0cd-b37d-5d4f-9f6a-7b085b99ed2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feb66d2-c50f-4296-af2f-b374c57443b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feb66d2-c50f-4296-af2f-b374c57443b0.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, put two 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "d0057667-7c5d-53bb-8c5f-f6f5708cec94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2465eafc-453c-4e4f-b369-0951b8a4b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2465eafc-453c-4e4f-b369-0951b8a4b7bf.jpg?1",
             "name": "Willbreaker",
             "text": "Whenever a creature an opponent controls becomes the target of a spell or ability you control, gain control of that creature for as long as you control Willbreaker.",
             "colours": [
@@ -2914,7 +2914,7 @@
         },
         {
             "id": "1c895172-51a5-5cc5-8dac-126168cb5917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8986163-6362-4c70-8ece-22ae22da5031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8986163-6362-4c70-8ece-22ae22da5031.jpg?1",
             "name": "Blightcaster",
             "text": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn.",
             "colours": [
@@ -2949,7 +2949,7 @@
         },
         {
             "id": "82081030-a86d-5b33-8876-40a4daa3da06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30d6df7-6199-4b06-9d45-785ee1e2ed3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30d6df7-6199-4b06-9d45-785ee1e2ed3b.jpg?1",
             "name": "Catacomb Slug",
             "text": "",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "e5837076-7f89-5213-883e-9b2a1779d001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d896df9-f897-4786-b1a1-d2375e81c9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d896df9-f897-4786-b1a1-d2375e81c9ef.jpg?1",
             "name": "Consecrated by Blood",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying and \"Sacrifice two other creatures: Regenerate this creature.\" (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "6cbdf8d9-6bef-5387-a6a4-e4fd171fc3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a863ae27-a99a-4a60-ab07-25c1bacec64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a863ae27-a99a-4a60-ab07-25c1bacec64d.jpg?1",
             "name": "Cruel Revival",
             "text": "Destroy target non-Zombie creature. It can't be regenerated. Return up to one target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "9a64b9a0-9585-5370-a88e-151c603a0c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5a047-2315-41a5-a78d-6a690622c457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5a047-2315-41a5-a78d-6a690622c457.jpg?1",
             "name": "Dark Dabbling",
             "text": "Regenerate target creature. Draw a card. (The next time the creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, also regenerate each other creature you control.",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "dd4ea09a-2531-567c-b7ad-bd8b346d23ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9df9c5e-7087-42b2-9001-c89d40a66c68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9df9c5e-7087-42b2-9001-c89d40a66c68.jpg?1",
             "name": "Dark Petition",
             "text": "Search your library for a card and put that card into your hand. Then shuffle your library.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, add {B}{B}{B} to your mana pool.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "94b72494-9e50-5d4f-a5ba-8d1528374511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b62a4c2-e66d-4fc3-8703-a90b84f567bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b62a4c2-e66d-4fc3-8703-a90b84f567bf.jpg?1",
             "name": "Deadbridge Shaman",
             "text": "When Deadbridge Shaman dies, target opponent discards a card.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "d3566abe-1d30-5703-9941-66a56ef87501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c04014-91f9-4197-b4b4-f62c4739a5c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c04014-91f9-4197-b4b4-f62c4739a5c2.jpg?1",
             "name": "Demonic Pact",
             "text": "At the beginning of your upkeep, choose one that hasn't been chosen \u2014\u2022 Demonic Pact deals 4 damage to target creature or player and you gain 4 life.\u2022 Target opponent discards two cards.\u2022 Draw two cards.\u2022 You lose the game.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "f67a9f47-604f-5950-92e4-cbd47754c15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a09fe4-d7a0-4065-968d-0837c3eafda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a09fe4-d7a0-4065-968d-0837c3eafda0.jpg?1",
             "name": "Despoiler of Souls",
             "text": "Despoiler of Souls can't block.{B}{B}, Exile two other creature cards from your graveyard: Return Despoiler of Souls from your graveyard to the battlefield.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "11122e7e-51e3-594e-ae3b-9f541fe3c993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5972911-2d41-4a0c-8a8f-b3d35a6594d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5972911-2d41-4a0c-8a8f-b3d35a6594d8.jpg?1",
             "name": "Erebos's Titan",
             "text": "As long as your opponents control no creatures, Erebos's Titan has indestructible. (Damage and effects that say \"destroy\" don't destroy it.)\nWhenever a creature card leaves an opponent's graveyard, you may discard a card. If you do, return Erebos's Titan from your graveyard to your hand.",
             "colours": [
@@ -3248,7 +3248,7 @@
         },
         {
             "id": "5f535a11-56c7-56ff-ae40-eaf16405b0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8aaaf1-6b21-465d-8450-0718beb9106b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f8aaaf1-6b21-465d-8450-0718beb9106b.jpg?1",
             "name": "Eyeblight Assassin",
             "text": "When Eyeblight Assassin enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3283,7 +3283,7 @@
         },
         {
             "id": "67928909-bfeb-5243-a80b-466a8f6b2835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73484db-5fd0-4a01-83fd-54748cc21a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73484db-5fd0-4a01-83fd-54748cc21a0f.jpg?1",
             "name": "Eyeblight Massacre",
             "text": "Non-Elf creatures get -2/-2 until end of turn.",
             "colours": [
@@ -3315,7 +3315,7 @@
         },
         {
             "id": "50fac2bf-fc6f-51e2-ba56-a984a07afc38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891718e9-bef3-470a-80c5-514f7f43abe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891718e9-bef3-470a-80c5-514f7f43abe8.jpg?1",
             "name": "Fetid Imp",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.){B}: Fetid Imp gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3349,7 +3349,7 @@
         },
         {
             "id": "9dc1d836-a343-586c-aab9-5e324c325d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb8ea7b-dfac-47bf-b608-efd54e4fe0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb8ea7b-dfac-47bf-b608-efd54e4fe0f1.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -3384,7 +3384,7 @@
         },
         {
             "id": "7e7c901c-8560-5c56-bdd0-b5d9eb8f346c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9667cae-6801-434b-9d91-ea1f2bd2449e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9667cae-6801-434b-9d91-ea1f2bd2449e.jpg?1",
             "name": "Gilt-Leaf Winnower",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Gilt-Leaf Winnower enters the battlefield, you may destroy target non-Elf creature whose power and toughness aren't equal.",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "bc78b5b7-10c4-55dd-8c46-fd9ea4ccb312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05572ba-3a26-41f5-96c1-960ec9367178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05572ba-3a26-41f5-96c1-960ec9367178.jpg?1",
             "name": "Gnarlroot Trapper",
             "text": "{T}, Pay 1 life: Add {G} to your mana pool. Spend this mana only to cast an Elf creature spell.{T}: Target attacking Elf you control gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
             "colours": [
@@ -3455,7 +3455,7 @@
         },
         {
             "id": "eedead06-f982-5fe6-a4cd-558cf9304b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85880be1-65b2-432f-8788-79716e4c8066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85880be1-65b2-432f-8788-79716e4c8066.jpg?1",
             "name": "Graveblade Marauder",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever Graveblade Marauder deals combat damage to a player, that player loses life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -3490,7 +3490,7 @@
         },
         {
             "id": "65faf7a6-78c6-5450-990c-65224a23afad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead8cc-5b7d-4a6d-a56f-95da91a958d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead8cc-5b7d-4a6d-a56f-95da91a958d2.jpg?1",
             "name": "Infernal Scarring",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "8612efa5-dfbe-5179-8308-f788cb47414e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f6a0-3670-4b72-8c8e-668f47252fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a6f6a0-3670-4b72-8c8e-668f47252fa0.jpg?1",
             "name": "Infinite Obliteration",
             "text": "Name a creature card. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "b91b94e5-ca87-5137-8e50-b40782695b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036e696a-b2aa-40ba-9ed6-3a859c4288a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/036e696a-b2aa-40ba-9ed6-3a859c4288a0.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "Flying\nWhenever a permanent owned by another player is put into a graveyard from the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "94c9a868-a47d-5db4-adb8-9d68bda2db90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3593efa-0a05-4061-9f6e-edd0a5ca9a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3593efa-0a05-4061-9f6e-edd0a5ca9a1f.jpg?1",
             "name": "Languish",
             "text": "All creatures get -4/-4 until end of turn.",
             "colours": [
@@ -3624,7 +3624,7 @@
         },
         {
             "id": "63ea84ce-bca0-5eb0-861d-b82e2aaf92de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg?1",
             "name": "Liliana, Heretical Healer // Liliana, Defiant Necromancer",
             "text": "Lifelink\nWhenever another nontoken creature you control dies, exile Liliana, Heretical Healer, then return her to the battlefield transformed under her owner's control. If you do, put a 2/2 black Zombie creature token onto the battlefield.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "2bd840b5-e790-56fe-9f21-32ff880c49c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f25e1cf-eeb4-458d-8fb2-b3a2f86bdd54.jpg?1",
             "name": "Liliana, Heretical Healer // Liliana, Defiant Necromancer",
             "text": "+2: Each player discards a card.\u2212X: Return target nonlegendary creature card with converted mana cost X from your graveyard to the battlefield.\u22128: You get an emblem with \"Whenever a creature dies, return it to the battlefield under your control at the beginning of the next end step.\"",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "2bf75b07-7e2d-5358-9d6c-c83b19a8f306",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958e5da-ca77-4f22-972f-5d6e2777509a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b958e5da-ca77-4f22-972f-5d6e2777509a.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "1a2ccd99-b19b-5b50-857a-49dabbe7158b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70861692-1eb2-4cb1-8d7f-b881386c37d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70861692-1eb2-4cb1-8d7f-b881386c37d1.jpg?1",
             "name": "Malakir Cullblade",
             "text": "Whenever a creature an opponent controls dies, put a +1/+1 counter on Malakir Cullblade.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "c664695f-a1d7-5a34-aa9a-3943aed0e2a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3915c0be-7e9c-45bc-9c83-80beba469a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3915c0be-7e9c-45bc-9c83-80beba469a81.jpg?1",
             "name": "Nantuko Husk",
             "text": "Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "15fdfdf8-7a9d-53c0-9384-b0057db425cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe7891-09d5-470e-aa41-71d89249875b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe7891-09d5-470e-aa41-71d89249875b.jpg?1",
             "name": "Necromantic Summons",
             "text": "Put target creature card from a graveyard onto the battlefield under your control.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, that creature enters the battlefield with two additional +1/+1 counters on it.",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "9bb5e196-5c58-5465-8e6d-421778bebf4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391a1023-69e7-425c-ac54-987ba366f8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391a1023-69e7-425c-ac54-987ba366f8f4.jpg?1",
             "name": "Nightsnare",
             "text": "Target opponent reveals his or her hand. You may choose a nonland card from it. If you do, that player discards that card. If you don't, that player discards two cards.",
             "colours": [
@@ -3863,7 +3863,7 @@
         },
         {
             "id": "9eb900ed-abe3-5c5f-9f0c-9c99fc05263e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118ba6f2-a2f0-4554-ad87-a932c951cdd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118ba6f2-a2f0-4554-ad87-a932c951cdd4.jpg?1",
             "name": "Priest of the Blood Rite",
             "text": "When Priest of the Blood Rite enters the battlefield, put a 5/5 black Demon creature token with flying onto the battlefield.\nAt the beginning of your upkeep, you lose 2 life.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "fc32bdd3-1cf4-5dbf-a022-7e0fd508b1d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335da62-3b59-4c73-a19e-b1733393ed88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335da62-3b59-4c73-a19e-b1733393ed88.jpg?1",
             "name": "Rabid Bloodsucker",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Rabid Bloodsucker enters the battlefield, each player loses 2 life.",
             "colours": [
@@ -3932,7 +3932,7 @@
         },
         {
             "id": "4fc3ff3c-094f-5fa6-a650-272589db59c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc51b90-7f1e-4e20-bc36-e3a198bc71bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc51b90-7f1e-4e20-bc36-e3a198bc71bf.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3964,7 +3964,7 @@
         },
         {
             "id": "f5a732c1-fe19-59f6-bb07-85806690a67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3d5e9d-07e8-43e1-aaf0-1f9e4ed2834a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3d5e9d-07e8-43e1-aaf0-1f9e4ed2834a.jpg?1",
             "name": "Reave Soul",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "b3fc4548-d9c1-58f5-9825-8796993985b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103b369c-da58-40e7-98aa-5a5471434bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103b369c-da58-40e7-98aa-5a5471434bca.jpg?1",
             "name": "Returned Centaur",
             "text": "When Returned Centaur enters the battlefield, target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "2c13f197-22a3-52bf-a03f-0225f5ec301b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c6dbe5-3375-42c2-88f5-8ead0dc2b094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7c6dbe5-3375-42c2-88f5-8ead0dc2b094.jpg?1",
             "name": "Revenant",
             "text": "FlyingRevenant's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -4065,7 +4065,7 @@
         },
         {
             "id": "ae1a8f2b-d99c-5d56-9ef9-81558ce658e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02962013-fc5a-46be-9021-8fd40ab3027c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02962013-fc5a-46be-9021-8fd40ab3027c.jpg?1",
             "name": "Shadows of the Past",
             "text": "Whenever a creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.){4}{B}: Each opponent loses 2 life and you gain 2 life. Activate this ability only if there are four or more creature cards in your graveyard.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "66c5dd14-2b40-5be6-b1fb-efdcb3383d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8061d2-84ce-4e4a-9911-ffc9833749da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8061d2-84ce-4e4a-9911-ffc9833749da.jpg?1",
             "name": "Shambling Ghoul",
             "text": "Shambling Ghoul enters the battlefield tapped.",
             "colours": [
@@ -4131,7 +4131,7 @@
         },
         {
             "id": "a132ad5d-7cd8-52d3-84ba-e75841874802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb8edd0-4573-4b52-a3ea-83ed19dbf58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb8edd0-4573-4b52-a3ea-83ed19dbf58d.jpg?1",
             "name": "Tainted Remedy",
             "text": "If an opponent would gain life, that player loses that much life instead.",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "02d98836-6aa3-56af-a75e-71f213f3ad2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290c60a-f9a0-464d-a15e-8473a6d50d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290c60a-f9a0-464d-a15e-8473a6d50d96.jpg?1",
             "name": "Thornbow Archer",
             "text": "Whenever Thornbow Archer attacks, each opponent who doesn't control an Elf loses 1 life.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "8155547f-1b96-5090-9f66-4f747772345d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be2be08-5bad-4813-b6f3-45b564e10b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be2be08-5bad-4813-b6f3-45b564e10b2f.jpg?1",
             "name": "Tormented Thoughts",
             "text": "As an additional cost to cast Tormented Thoughts, sacrifice a creature.\nTarget player discards a number of cards equal to the sacrificed creature's power.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "b6662ba3-4559-5b17-8cf9-0f6925b14e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf659f2f-983c-4a62-a969-4176e5fbe193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf659f2f-983c-4a62-a969-4176e5fbe193.jpg?1",
             "name": "Touch of Moonglove",
             "text": "Target creature you control gets +1/+0 and gains deathtouch until end of turn. Whenever a creature dealt damage by that creature dies this turn, its controller loses 2 life. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "5340f2c6-e5d4-5610-b7b7-cfb77f6008cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36afdfd4-8db7-45b6-9b6d-b9293fe6c26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36afdfd4-8db7-45b6-9b6d-b9293fe6c26d.jpg?1",
             "name": "Undead Servant",
             "text": "When Undead Servant enters the battlefield, put a 2/2 black Zombie creature token onto the battlefield for each card named Undead Servant in your graveyard.",
             "colours": [
@@ -4296,7 +4296,7 @@
         },
         {
             "id": "264ee6f2-ac8b-5c17-90c1-57db8a8256fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994b7b0-3bca-480b-b265-ed269f15c17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5994b7b0-3bca-480b-b265-ed269f15c17e.jpg?1",
             "name": "Unholy Hunger",
             "text": "Destroy target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you gain 2 life.",
             "colours": [
@@ -4328,7 +4328,7 @@
         },
         {
             "id": "7ffd744f-d841-5382-b811-043d78809fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f31943-e26c-4bd2-bdbd-d980836f99b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f31943-e26c-4bd2-bdbd-d980836f99b9.jpg?1",
             "name": "Weight of the Underworld",
             "text": "Enchant creature\nEnchanted creature gets -3/-2.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "df0e1ede-b627-5b95-8eed-0ce7d08a897b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg?1",
             "name": "Abbot of Keral Keep",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Abbot of Keral Keep enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "a25b5d66-c9c4-56da-9b80-5aa2d3cf8231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186581c7-81a6-4c27-b8a9-ff7f7a4b1d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186581c7-81a6-4c27-b8a9-ff7f7a4b1d40.jpg?1",
             "name": "Acolyte of the Inferno",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhenever Acolyte of the Inferno becomes blocked by a creature, it deals 2 damage to that creature.",
             "colours": [
@@ -4432,7 +4432,7 @@
         },
         {
             "id": "993e910a-f713-5c28-8018-1ba232d0831f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a71ba3-e5f0-4f36-bafa-db96611681dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a71ba3-e5f0-4f36-bafa-db96611681dd.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4464,7 +4464,7 @@
         },
         {
             "id": "322f699a-4fa1-5574-bb20-643e19cc6059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg?1",
             "name": "Akroan Sergeant",
             "text": "First strike (This creature deals combat damage before creatures without first strike.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "1418e1a4-1729-575c-a283-281be85ae219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354255d7-dc29-403b-aa90-9044cde669d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354255d7-dc29-403b-aa90-9044cde669d0.jpg?1",
             "name": "Avaricious Dragon",
             "text": "Flying\nAt the beginning of your draw step, draw an additional card.\nAt the beginning of your end step, discard your hand.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "d84ef24d-9306-5a60-9503-bb93adeccfe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d2e99-13f1-4ce8-9a54-139de193c1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285d2e99-13f1-4ce8-9a54-139de193c1b3.jpg?1",
             "name": "Bellows Lizard",
             "text": "{1}{R}: Bellows Lizard gets +1/+0 until end of turn.",
             "colours": [
@@ -4567,7 +4567,7 @@
         },
         {
             "id": "28974db4-fe40-5262-91ad-cf98981100b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d735ebf-61a4-4507-9399-6d32c8903ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d735ebf-61a4-4507-9399-6d32c8903ded.jpg?1",
             "name": "Boggart Brute",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4602,7 +4602,7 @@
         },
         {
             "id": "54c1c056-d92f-5550-afa6-c99f01d9f647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369d837a-a19b-457c-8146-cc1766a63ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369d837a-a19b-457c-8146-cc1766a63ec1.jpg?1",
             "name": "Call of the Full Moon",
             "text": "Enchant creature\nEnchanted creature gets +3/+2 and has trample. (It can deal excess combat damage to defending player or planeswalker while attacking.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, sacrifice Call of the Full Moon.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "86f3ab5a-ab07-57c5-9388-f04eabdfdaf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg?1",
             "name": "Chandra, Fire of Kaladesh // Chandra, Roaring Flame",
             "text": "Whenever you cast a red spell, untap Chandra, Fire of Kaladesh.{T}: Chandra, Fire of Kaladesh deals 1 damage to target player. If Chandra has dealt 3 or more damage this turn, exile her, then return her to the battlefield transformed under her owner's control.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "eb02a93c-ff6e-5746-a9d1-e597c5716b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0d6caf0-4fa8-4ec5-b7f4-1307474d1b13.jpg?1",
             "name": "Chandra, Fire of Kaladesh // Chandra, Roaring Flame",
             "text": "+1: Chandra, Roaring Flame deals 2 damage to target player.\u22122: Chandra, Roaring Flame deals 2 damage to target creature.\u22127: Chandra, Roaring Flame deals 6 damage to each opponent. Each player dealt damage this way gets an emblem with \"At the beginning of your upkeep, this emblem deals 3 damage to you.\"",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "f72b3360-d2e2-5563-b5b7-8f386637922e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b85237-98a8-4b52-9cc6-6fd14849b069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b85237-98a8-4b52-9cc6-6fd14849b069.jpg?1",
             "name": "Chandra's Fury",
             "text": "Chandra's Fury deals 4 damage to target player and 1 damage to each creature that player controls.",
             "colours": [
@@ -4741,7 +4741,7 @@
         },
         {
             "id": "23cc35ec-57ec-5b67-a7ac-bc08761ca56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4c90de-49aa-43ed-a18a-f7f96268e5eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4c90de-49aa-43ed-a18a-f7f96268e5eb.jpg?1",
             "name": "Chandra's Ignition",
             "text": "Target creature you control deals damage equal to its power to each other creature and each opponent.",
             "colours": [
@@ -4773,7 +4773,7 @@
         },
         {
             "id": "630e0ecc-7cc8-553f-827e-aa39c52d40f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa87a70-c9fb-4ab3-ac16-367888aa775b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffa87a70-c9fb-4ab3-ac16-367888aa775b.jpg?1",
             "name": "Cobblebrute",
             "text": "",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "fceaa313-26e4-50a7-9aba-c0dad3b7f146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c95da-458d-4914-9e7c-2c5fc1aa626b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7c95da-458d-4914-9e7c-2c5fc1aa626b.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4839,7 +4839,7 @@
         },
         {
             "id": "88c6b2e7-5033-5e27-835e-4d1e237b5bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19fc806-f1b7-4f82-be0e-b960699f9a36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19fc806-f1b7-4f82-be0e-b960699f9a36.jpg?1",
             "name": "Dragon Fodder",
             "text": "Put two 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "ebde715b-13f8-5101-ad6c-660328cfec6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664f60a8-e80a-4fe0-b76c-2d76c728329e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664f60a8-e80a-4fe0-b76c-2d76c728329e.jpg?1",
             "name": "Embermaw Hellion",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nIf another red source you control would deal damage to a permanent or player, it deals that much damage plus 1 to that permanent or player instead.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "24065f2e-2436-51d4-a273-580c75ce96f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607d63b-82ab-44f0-aef5-d9063e17c76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3607d63b-82ab-44f0-aef5-d9063e17c76f.jpg?1",
             "name": "Enthralling Victor",
             "text": "When Enthralling Victor enters the battlefield, gain control of target creature an opponent controls with power 2 or less until end of turn. Untap that creature. It gains haste until end of turn. (It can attack and {T} this turn.)",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "839e567a-ee93-5cec-9c34-a4354b09f3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eca98e-a164-4f70-a0b0-7a604863f30b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eca98e-a164-4f70-a0b0-7a604863f30b.jpg?1",
             "name": "Exquisite Firecraft",
             "text": "Exquisite Firecraft deals 4 damage to target creature or player.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Exquisite Firecraft can't be countered by spells or abilities.",
             "colours": [
@@ -4972,7 +4972,7 @@
         },
         {
             "id": "8bc2c5f7-e279-58af-b77a-6e27fccb59d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104365ec-7452-4542-b409-b7eb5d314735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104365ec-7452-4542-b409-b7eb5d314735.jpg?1",
             "name": "Fiery Conclusion",
             "text": "As an additional cost to cast Fiery Conclusion, sacrifice a creature.Fiery Conclusion deals 5 damage to target creature.",
             "colours": [
@@ -5004,7 +5004,7 @@
         },
         {
             "id": "89ceffe7-c65f-5e5d-80ea-4754dd8984da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b81a589-44bf-4441-9079-1ae66d067519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b81a589-44bf-4441-9079-1ae66d067519.jpg?1",
             "name": "Fiery Impulse",
             "text": "Fiery Impulse deals 2 damage to target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Fiery Impulse deals 3 damage to that creature instead.",
             "colours": [
@@ -5036,7 +5036,7 @@
         },
         {
             "id": "f30c907e-eba9-5337-8e98-dfbcdaa1037b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg?1",
             "name": "Firefiend Elemental",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "179de610-1b31-5fd4-8023-99b0a5f1f293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b473ee0c-b037-4968-9dda-82c2288e54f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b473ee0c-b037-4968-9dda-82c2288e54f7.jpg?1",
             "name": "Flameshadow Conjuring",
             "text": "Whenever a nontoken creature enters the battlefield under your control, you may pay {R}. If you do, put a token onto the battlefield that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [
@@ -5102,7 +5102,7 @@
         },
         {
             "id": "2782664f-5eca-5358-ae37-cce8fa1cfcca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg?1",
             "name": "Ghirapur Aether Grid",
             "text": "Tap two untapped artifacts you control: Ghirapur \u00c6ther Grid deals 1 damage to target creature or player.",
             "colours": [
@@ -5134,7 +5134,7 @@
         },
         {
             "id": "bd3c622a-56ea-5bab-9ee0-2b8ddb19d7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05cafb6-8812-42bb-ad14-3dde4bcb7034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05cafb6-8812-42bb-ad14-3dde4bcb7034.jpg?1",
             "name": "Ghirapur Gearcrafter",
             "text": "When Ghirapur Gearcrafter enters the battlefield, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield. (A creature with flying can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "6dafe209-ef79-51e7-880b-3b97a1fa32d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2779415-9e0e-4c61-b590-e15ac089cf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2779415-9e0e-4c61-b590-e15ac089cf30.jpg?1",
             "name": "Goblin Glory Chaser",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nAs long as Goblin Glory Chaser is renowned, it has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5204,7 +5204,7 @@
         },
         {
             "id": "bd486c89-e9eb-542a-bad4-774246baffa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b332e3d-dcf4-4f62-8130-124ec5d23b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b332e3d-dcf4-4f62-8130-124ec5d23b90.jpg?1",
             "name": "Goblin Piledriver",
             "text": "Protection from blue (This creature can't be blocked, targeted, dealt damage, or enchanted by anything blue.)\nWhenever Goblin Piledriver attacks, it gets +2/+0 until end of turn for each other attacking Goblin.",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "0c5151a9-2f0f-5fa9-8480-fb6f64e44015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44df88-45a4-46ef-a8bd-f7fb7b9542b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44df88-45a4-46ef-a8bd-f7fb7b9542b8.jpg?1",
             "name": "Infectious Bloodlust",
             "text": "Enchant creature\nEnchanted creature gets +2/+1, has haste, and attacks each turn if able.\nWhen enchanted creature dies, you may search your library for a card named Infectious Bloodlust, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "c714c03e-f357-5c52-b1c7-b69531d103ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg?1",
             "name": "Lightning Javelin",
             "text": "Lightning Javelin deals 3 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5305,7 +5305,7 @@
         },
         {
             "id": "8bfd95bc-217a-544b-a847-e22342d33fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a129f22-dd7e-4b2c-a514-a2ac55bb5661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a129f22-dd7e-4b2c-a514-a2ac55bb5661.jpg?1",
             "name": "Mage-Ring Bully",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)Mage-Ring Bully attacks each turn if able.",
             "colours": [
@@ -5340,7 +5340,7 @@
         },
         {
             "id": "0ae855e3-af98-535e-9e03-80525ca97950",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg?1",
             "name": "Magmatic Insight",
             "text": "As an additional cost to cast Magmatic Insight, discard a land card.\nDraw two cards.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "2e32afe8-ecfa-56a4-80e0-d3df604a50c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg?1",
             "name": "Molten Vortex",
             "text": "{R}, Discard a land card: Molten Vortex deals 2 damage to target creature or player.",
             "colours": [
@@ -5404,7 +5404,7 @@
         },
         {
             "id": "ce7d685b-f94e-5b45-901d-d8597e9813d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcafa9e-3637-42ca-bdb2-45a2b5da7294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcafa9e-3637-42ca-bdb2-45a2b5da7294.jpg?1",
             "name": "Pia and Kiran Nalaar",
             "text": "When Pia and Kiran Nalaar enters the battlefield, put two 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.{2}{R}, Sacrifice an artifact: Pia and Kiran Nalaar deals 2 damage to target creature or player.",
             "colours": [
@@ -5441,7 +5441,7 @@
         },
         {
             "id": "bacfb7d9-b212-540f-b419-9922436b72b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191a8fd-2c54-4e47-9d5a-692bb38c811f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3191a8fd-2c54-4e47-9d5a-692bb38c811f.jpg?1",
             "name": "Prickleboar",
             "text": "As long as it's your turn, Prickleboar gets +2/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "4b9fe7c2-f4de-5bad-9f79-4ff1723fe4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9404b2-f0ea-4a31-bc7b-6748574c57d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9404b2-f0ea-4a31-bc7b-6748574c57d3.jpg?1",
             "name": "Ravaging Blaze",
             "text": "Ravaging Blaze deals X damage to target creature. Spell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, Ravaging Blaze also deals X damage to that creature's controller.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "9fc238d6-157e-5997-b841-e45868b823e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d600b0-8649-424a-acad-879f3067b55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d600b0-8649-424a-acad-879f3067b55e.jpg?1",
             "name": "Scab-Clan Berserker",
             "text": "Haste\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nWhenever an opponent casts a noncreature spell, if Scab-Clan Berserker is renowned, Scab-Clan Berserker deals 2 damage to that player.",
             "colours": [
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "71f7f447-a10d-5eed-8e91-4d927114d3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60d957b-f71a-403e-82fe-30ea87d1e142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a60d957b-f71a-403e-82fe-30ea87d1e142.jpg?1",
             "name": "Seismic Elemental",
             "text": "When Seismic Elemental enters the battlefield, creatures without flying can't block this turn.",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "62a0daf8-10e8-544c-a074-8d0e3da273c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f0d87a-8f37-4598-9106-c3545dadf6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f0d87a-8f37-4598-9106-c3545dadf6fd.jpg?1",
             "name": "Skyraker Giant",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "23cfd2e6-5c47-506b-9004-82d7ad5bf712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c489f-bffb-45a4-8e7c-2d1a35220197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655c489f-bffb-45a4-8e7c-2d1a35220197.jpg?1",
             "name": "Smash to Smithereens",
             "text": "Destroy target artifact. Smash to Smithereens deals 3 damage to that artifact's controller.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "37661921-d370-5b70-997e-a326180d2766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9289dd-f1a3-4be5-8ed1-4b4dd4e97743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9289dd-f1a3-4be5-8ed1-4b4dd4e97743.jpg?1",
             "name": "Subterranean Scout",
             "text": "When Subterranean Scout enters the battlefield, target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -5677,7 +5677,7 @@
         },
         {
             "id": "45e2632b-55ad-5455-8b6c-358735ce1b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6c48a-29d0-40ae-aac6-df7319873f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e6c48a-29d0-40ae-aac6-df7319873f50.jpg?1",
             "name": "Thopter Engineer",
             "text": "When Thopter Engineer enters the battlefield, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield.\nArtifact creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "42edb9dd-fca5-5dfc-9dd2-c879d3799e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e48f309-8e56-4741-a9ff-e899dafb333a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e48f309-8e56-4741-a9ff-e899dafb333a.jpg?1",
             "name": "Titan's Strength",
             "text": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "d7b2ff04-82e1-5517-b5b6-d12b7e1257aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg?1",
             "name": "Volcanic Rambler",
             "text": "{2}{R}: Volcanic Rambler deals 1 damage to target player.",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "e0b38df4-8796-5c29-9307-5bfe425ff622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg?1",
             "name": "Aerial Volley",
             "text": "Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.",
             "colours": [
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "d38aba85-9e64-5b8e-bcdb-f840c825dfc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b62616-c1a3-45f7-a329-f1305c462eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b62616-c1a3-45f7-a329-f1305c462eaf.jpg?1",
             "name": "Animist's Awakening",
             "text": "Reveal the top X cards of your library. Put all land cards from among them onto the battlefield tapped and the rest on the bottom of your library in a random order.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, untap those lands.",
             "colours": [
@@ -5842,7 +5842,7 @@
         },
         {
             "id": "e5ba2934-4802-56e1-b3e7-60f86decde93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d4e0d-bddd-4835-91b8-11c2f15e54c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03d4e0d-bddd-4835-91b8-11c2f15e54c3.jpg?1",
             "name": "Caustic Caterpillar",
             "text": "{1}{G}, Sacrifice Caustic Caterpillar: Destroy target artifact or enchantment.",
             "colours": [
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "352a94a3-2fe7-5bd9-a670-37c7dd30caf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg?1",
             "name": "Conclave Naturalists",
             "text": "When Conclave Naturalists enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -5910,7 +5910,7 @@
         },
         {
             "id": "13dcfb8b-ff31-5b4a-b395-2653b3fc2637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c143a9-c642-425a-a469-a9d158e43c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91c143a9-c642-425a-a469-a9d158e43c21.jpg?1",
             "name": "Dwynen, Gilt-Leaf Daen",
             "text": "Reach\nOther Elf creatures you control get +1/+1.\nWhenever Dwynen, Gilt-Leaf Daen attacks, you gain 1 life for each attacking Elf you control.",
             "colours": [
@@ -5947,7 +5947,7 @@
         },
         {
             "id": "abf48426-be1d-5729-8dbd-9485851c08fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c203722b-3f16-4b6c-9b2e-18169d3f80c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c203722b-3f16-4b6c-9b2e-18169d3f80c9.jpg?1",
             "name": "Dwynen's Elite",
             "text": "When Dwynen's Elite enters the battlefield, if you control another Elf, put a 1/1 green Elf Warrior creature token onto the battlefield.",
             "colours": [
@@ -5982,7 +5982,7 @@
         },
         {
             "id": "d4590b70-6141-5bc2-a419-1d44e64ee51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg?1",
             "name": "Elemental Bond",
             "text": "Whenever a creature with power 3 or greater enters the battlefield under your control, draw a card.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "0bd63037-e339-5907-9d7c-09e6a8986352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ef35a-528b-407c-8b8d-679109662bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367ef35a-528b-407c-8b8d-679109662bae.jpg?1",
             "name": "Elvish Visionary",
             "text": "When Elvish Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "256616af-eb43-563a-97ab-92ce8dab624d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27f3193-3083-409e-99d8-10f5b1afe9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27f3193-3083-409e-99d8-10f5b1afe9f1.jpg?1",
             "name": "Evolutionary Leap",
             "text": "{G}, Sacrifice a creature: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "f10c1aa8-24cc-5983-a644-718f2a60a108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fad73f-c6eb-46d7-8971-9be4d7d7b75f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fad73f-c6eb-46d7-8971-9be4d7d7b75f.jpg?1",
             "name": "Gaea's Revenge",
             "text": "Gaea's Revenge can't be countered.\nHasteGaea's Revenge can't be the target of nongreen spells or abilities from nongreen sources.",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "ad3819fe-8afe-5c83-abfe-d946419a6010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f5b00-ac50-485f-a38a-b9f409307d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4f5b00-ac50-485f-a38a-b9f409307d5c.jpg?1",
             "name": "Gather the Pack",
             "text": "Reveal the top five cards of your library. You may put a creature card from among them into your hand. Put the rest into your graveyard.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, put up to two creature cards from among the revealed cards into your hand instead of one.",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "0c0b2eff-ed06-5cd3-b1d5-f73d455059bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0eb3b-00b9-42ca-9f7d-5543bffc3480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0eb3b-00b9-42ca-9f7d-5543bffc3480.jpg?1",
             "name": "The Great Aurora",
             "text": "Each player shuffles all cards from his or her hand and all permanents he or she owns into his or her library, then draws that many cards. Each player may put any number of land cards from his or her hand onto the battlefield. Exile The Great Aurora.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "713ce581-49ad-5cc7-a315-6681746d5ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg?1",
             "name": "Herald of the Pantheon",
             "text": "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "2e8ea325-74c1-52b6-a681-53bcd3a1ee9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf335eac-e57b-44ec-afe2-8aed567469e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf335eac-e57b-44ec-afe2-8aed567469e7.jpg?1",
             "name": "Hitchclaw Recluse",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "78261d23-f74e-58e9-b39b-96d7260545f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769d0447-2c8f-41ef-a950-3a3022161c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769d0447-2c8f-41ef-a950-3a3022161c7f.jpg?1",
             "name": "Honored Hierarch",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\nAs long as Honored Hierarch is renowned, it has vigilance and \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "c5b226fb-7eb6-5691-9cd8-381466977b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c89431-0881-4aa6-ac15-d4c13b075273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65c89431-0881-4aa6-ac15-d4c13b075273.jpg?1",
             "name": "Joraga Invocation",
             "text": "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -6315,7 +6315,7 @@
         },
         {
             "id": "ce42e124-8713-5edc-bac7-ab1fd4ddf1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f0c9b4-9b79-4e61-8386-a36b26d9963c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f0c9b4-9b79-4e61-8386-a36b26d9963c.jpg?1",
             "name": "Leaf Gilder",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "898b4190-97b9-5299-8a32-e5c9c3dca4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bdc8e-7c12-4838-9017-0d5abfc94463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363bdc8e-7c12-4838-9017-0d5abfc94463.jpg?1",
             "name": "Llanowar Empath",
             "text": "When Llanowar Empath enters the battlefield, scry 2, then reveal the top card of your library. If it's a creature card, put it into your hand. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -6385,7 +6385,7 @@
         },
         {
             "id": "14c12033-7fb3-5871-b5a6-09c747dbfe12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg?1",
             "name": "Managorger Hydra",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nWhenever a player casts a spell, put a +1/+1 counter on Managorger Hydra.",
             "colours": [
@@ -6419,7 +6419,7 @@
         },
         {
             "id": "d81bf509-417c-5983-bf92-0bb3ff929c1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg?1",
             "name": "Mantle of Webs",
             "text": "Enchant creature\nEnchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)",
             "colours": [
@@ -6453,7 +6453,7 @@
         },
         {
             "id": "619f3e80-acc9-5783-ab2f-f879be0d3bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b53cc0-ef96-40da-b9b8-d93fdae40cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b53cc0-ef96-40da-b9b8-d93fdae40cb8.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -6485,7 +6485,7 @@
         },
         {
             "id": "cc3b7e29-d14d-59dc-92ea-33f825d407cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg?1",
             "name": "Nissa, Vastwood Seer // Nissa, Sage Animist",
             "text": "When Nissa, Vastwood Seer enters the battlefield, you may search your library for a basic Forest card, reveal it, put it into your hand, then shuffle your library.\nWhenever a land enters the battlefield under your control, if you control seven or more lands, exile Nissa, then return her to the battlefield transformed under her owner's control.",
             "colours": [
@@ -6522,7 +6522,7 @@
         },
         {
             "id": "a25b5d47-1b78-50de-9c1a-11cf6453a203",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff0063da-ab6b-499d-8e87-8b34d46f0372.jpg?1",
             "name": "Nissa, Vastwood Seer // Nissa, Sage Animist",
             "text": "+1: Reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand.\u22122: Put a legendary 4/4 green Elemental creature token named Ashaya, the Awoken World onto the battlefield.\u22127: Untap up to six target lands. They become 6/6 Elemental creatures. They're still lands.",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "62af22e8-fbd2-5954-b2f7-7d6a4a3b04f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800cef89-e90c-4f84-a7a0-3cd203532169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/800cef89-e90c-4f84-a7a0-3cd203532169.jpg?1",
             "name": "Nissa's Pilgrimage",
             "text": "Search your library for up to two basic Forest cards, reveal those cards, and put one onto the battlefield tapped and the rest into your hand. Then shuffle your library.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, search your library for up to three basic Forest cards instead of two.",
             "colours": [
@@ -6590,7 +6590,7 @@
         },
         {
             "id": "f16762d2-1075-5928-959f-622ed690b3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71143665-012f-4723-a58b-d5cfdbe82e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71143665-012f-4723-a58b-d5cfdbe82e8f.jpg?1",
             "name": "Nissa's Revelation",
             "text": "Scry 5, then reveal the top card of your library. If it's a creature card, you draw cards equal to its power and you gain life equal to its toughness.",
             "colours": [
@@ -6622,7 +6622,7 @@
         },
         {
             "id": "cf8ceabd-0e29-5180-a28e-5d7a2e06b311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3077a-0446-4cf4-9a32-366b4c4085a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd3077a-0446-4cf4-9a32-366b4c4085a3.jpg?1",
             "name": "Orchard Spirit",
             "text": "Orchard Spirit can't be blocked except by creatures with flying or reach.",
             "colours": [
@@ -6656,7 +6656,7 @@
         },
         {
             "id": "54b15d50-e746-5989-af56-177905b96cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg?1",
             "name": "Outland Colossus",
             "text": "Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)Outland Colossus can't be blocked by more than one creature.",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "0e53d342-06c8-5672-9479-a12629e9436b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg?1",
             "name": "Pharika's Disciple",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
             "colours": [
@@ -6725,7 +6725,7 @@
         },
         {
             "id": "18993483-3076-5ac2-8e57-daacadd77c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f3c600-66f1-4a5e-ba4f-61e9f7f7a1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f3c600-66f1-4a5e-ba4f-61e9f7f7a1d9.jpg?1",
             "name": "Reclaim",
             "text": "Put target card from your graveyard on top of your library.",
             "colours": [
@@ -6757,7 +6757,7 @@
         },
         {
             "id": "dafaef84-dfa8-5e41-bfe6-c943bcc87302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg?1",
             "name": "Rhox Maulers",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
             "colours": [
@@ -6792,7 +6792,7 @@
         },
         {
             "id": "7d1e404d-79c0-527d-9ba7-a36faf6cb7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg?1",
             "name": "Skysnare Spider",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "6c7ad929-2b1f-5248-ae00-e30d30209401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg?1",
             "name": "Somberwald Alpha",
             "text": "Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.{1}{G}: Target creature you control gains trample until end of turn. (It can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "dd5320b4-d08d-5299-81b8-0df03f0bc61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e0550c-d3ad-4bd4-a259-d597991079b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e0550c-d3ad-4bd4-a259-d597991079b1.jpg?1",
             "name": "Sylvan Messenger",
             "text": "Trample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)\nWhen Sylvan Messenger enters the battlefield, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "52cd3e9e-c8ae-5e86-a3b3-d26d2ff7d7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b12b-cf16-4a71-b4b6-4842c1402726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f326b12b-cf16-4a71-b4b6-4842c1402726.jpg?1",
             "name": "Timberpack Wolf",
             "text": "Timberpack Wolf gets +1/+1 for each other creature you control named Timberpack Wolf.",
             "colours": [
@@ -6928,7 +6928,7 @@
         },
         {
             "id": "89b27e18-dada-5a17-80c7-5ff58249c468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f80ad0-2420-4de4-886c-1168166c7dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f80ad0-2420-4de4-886c-1168166c7dae.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "e50f8529-cdae-5c2c-bd0b-1bf68a6d704e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg?1",
             "name": "Undercity Troll",
             "text": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.){2}{G}: Regenerate Undercity Troll. (The next time this creature would be destroyed this turn, it isn't. Instead tap it, remove all damage from it, and remove it from combat.)",
             "colours": [
@@ -6994,7 +6994,7 @@
         },
         {
             "id": "7d8c5867-5448-59ef-b49f-41c069630edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693a7e7-d95e-4cd8-9524-ca5fc517189a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e693a7e7-d95e-4cd8-9524-ca5fc517189a.jpg?1",
             "name": "Valeron Wardens",
             "text": "Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)\nWhenever a creature you control becomes renowned, draw a card.",
             "colours": [
@@ -7029,7 +7029,7 @@
         },
         {
             "id": "960ac0ea-6169-595b-8790-5cb7bfbfcaf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f53dc9-5397-49e1-97d4-3b0b6858f2b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f53dc9-5397-49e1-97d4-3b0b6858f2b2.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -7063,7 +7063,7 @@
         },
         {
             "id": "af5f06e2-d19f-5dc9-a3be-40ac909914f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg?1",
             "name": "Vine Snare",
             "text": "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "5dbbb497-0185-58ef-a298-adb21d8ebec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fafd9d-777f-4d88-ad93-63af6d7ef274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fafd9d-777f-4d88-ad93-63af6d7ef274.jpg?1",
             "name": "Wild Instincts",
             "text": "Target creature you control gets +2/+2 until end of turn. It fights target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7127,7 +7127,7 @@
         },
         {
             "id": "e495cb36-cab8-511a-b3b5-4337f04e4ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706d4bb-0b44-4e43-b340-7de799c086b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a706d4bb-0b44-4e43-b340-7de799c086b8.jpg?1",
             "name": "Woodland Bellower",
             "text": "When Woodland Bellower enters the battlefield, you may search your library for a nonlegendary green creature card with converted mana cost 3 or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -7161,7 +7161,7 @@
         },
         {
             "id": "e229c8a7-f4b0-5313-a047-40dfa2636273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1.jpg?1",
             "name": "Yeva's Forcemage",
             "text": "When Yeva's Forcemage enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -7196,7 +7196,7 @@
         },
         {
             "id": "b885b319-453b-555d-a2c5-219043b42c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c0783-936d-4fa2-bdcb-01dae7a67fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f75c0783-936d-4fa2-bdcb-01dae7a67fdb.jpg?1",
             "name": "Zendikar's Roil",
             "text": "Whenever a land enters the battlefield under your control, put a 2/2 green Elemental creature token onto the battlefield.",
             "colours": [
@@ -7228,7 +7228,7 @@
         },
         {
             "id": "37e232d2-fd81-5093-9a52-afbd4e2bfef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg?1",
             "name": "Blazing Hellhound",
             "text": "{1}, Sacrifice another creature: Blazing Hellhound deals 1 damage to target creature or player.",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "cd757d20-a928-528c-bbf0-100d89bfbe4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg?1",
             "name": "Blood-Cursed Knight",
             "text": "As long as you control an enchantment, Blood-Cursed Knight gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -7302,7 +7302,7 @@
         },
         {
             "id": "f3522835-c4a9-55c6-aa2d-490f5ff3d300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660befe5-9c98-4aa3-9ca7-e643eaf91490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660befe5-9c98-4aa3-9ca7-e643eaf91490.jpg?1",
             "name": "Bounding Krasis",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Bounding Krasis enters the battlefield, you may tap or untap target creature.",
             "colours": [
@@ -7339,7 +7339,7 @@
         },
         {
             "id": "3c71396f-2f0a-5b93-864a-58986a00b52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg?1",
             "name": "Citadel Castellan",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
             "colours": [
@@ -7376,7 +7376,7 @@
         },
         {
             "id": "9b8c01cf-b82d-5b35-8fd8-baa7b234a299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg?1",
             "name": "Iroas's Champion",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "8bea1385-44f4-585a-b417-c3c0b60ac07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc94e5-a595-43ab-929b-426009190669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc94e5-a595-43ab-929b-426009190669.jpg?1",
             "name": "Possessed Skaab",
             "text": "When Possessed Skaab enters the battlefield, return target instant, sorcery, or creature card from your graveyard to your hand.\nIf Possessed Skaab would die, exile it instead.",
             "colours": [
@@ -7449,7 +7449,7 @@
         },
         {
             "id": "516cc289-6351-5313-8197-070a449a4de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5299a549-06cf-47e8-b6cd-7e44d9f1efb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5299a549-06cf-47e8-b6cd-7e44d9f1efb8.jpg?1",
             "name": "Reclusive Artificer",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen Reclusive Artificer enters the battlefield, you may have it deal damage to target creature equal to the number of artifacts you control.",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "c65de806-30e3-528a-9ce9-dd81506baab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304687b1-2294-4144-b2bd-7e36f9aaac34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304687b1-2294-4144-b2bd-7e36f9aaac34.jpg?1",
             "name": "Shaman of the Pack",
             "text": "When Shaman of the Pack enters the battlefield, target opponent loses life equal to the number of Elves you control.",
             "colours": [
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "585716d5-a233-5292-8369-7b46c940d6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg?1",
             "name": "Thunderclap Wyvern",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nOther creatures you control with flying get +1/+1.",
             "colours": [
@@ -7559,7 +7559,7 @@
         },
         {
             "id": "7ffea63a-ee80-543b-af23-b7db4433f83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg?1",
             "name": "Zendikar Incarnate",
             "text": "Zendikar Incarnate's power is equal to the number of lands you control.",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "622a597d-f15c-57cc-8d32-ffaef1a84ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg?1",
             "name": "Alchemist's Vial",
             "text": "When Alchemist's Vial enters the battlefield, draw a card.{1}, {T}, Sacrifice Alchemist's Vial: Target creature can't attack or block this turn.",
             "colours": [],
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "d8232fe3-7881-5dd2-be24-d35b38d7ec76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afb856-6697-411b-b1aa-e9290a0bfd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afb856-6697-411b-b1aa-e9290a0bfd68.jpg?1",
             "name": "Alhammarret's Archive",
             "text": "If you would gain life, you gain twice that much life instead.\nIf you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.",
             "colours": [],
@@ -7653,7 +7653,7 @@
         },
         {
             "id": "b5e65756-b39b-5f5b-a332-7267015d7042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffaa737-ce46-4f35-aa8c-bd9bb77ed9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffaa737-ce46-4f35-aa8c-bd9bb77ed9f6.jpg?1",
             "name": "Angel's Tomb",
             "text": "Whenever a creature enters the battlefield under your control, you may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn.",
             "colours": [],
@@ -7681,7 +7681,7 @@
         },
         {
             "id": "aff4bf14-1bd5-56b0-a7bc-68b9248a8dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43361897-f853-4cab-a132-5af48dad3b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43361897-f853-4cab-a132-5af48dad3b54.jpg?1",
             "name": "Bonded Construct",
             "text": "Bonded Construct can't attack alone.",
             "colours": [],
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "5ed64a00-95e8-50f1-b005-4caf5c2a7977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0a017e-eb8e-4f92-91f7-7d980461e284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0a017e-eb8e-4f92-91f7-7d980461e284.jpg?1",
             "name": "Brawler's Plate",
             "text": "Equipped creature gets +2/+2 and has trample. (It can deal excess combat damage to defending player or planeswalker while attacking.)\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7742,7 +7742,7 @@
         },
         {
             "id": "8e9894a8-9ad4-5e76-a3ee-c16cb2c80794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c65947-bc1d-4f47-b60b-2f76ab5ebde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c65947-bc1d-4f47-b60b-2f76ab5ebde9.jpg?1",
             "name": "Chief of the Foundry",
             "text": "Other artifact creatures you control get +1/+1.",
             "colours": [],
@@ -7773,7 +7773,7 @@
         },
         {
             "id": "f3cde50b-c13d-513e-b327-faed7cf5cc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdf08b-b812-4ad9-a4ca-3a9b7000b749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9fdf08b-b812-4ad9-a4ca-3a9b7000b749.jpg?1",
             "name": "Gold-Forged Sentinel",
             "text": "Flying",
             "colours": [],
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "0036ecd2-b835-5d1d-959e-22d84187c3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg?1",
             "name": "Guardian Automaton",
             "text": "When Guardian Automaton dies, you gain 3 life.",
             "colours": [],
@@ -7835,7 +7835,7 @@
         },
         {
             "id": "dbd0ffa5-da1b-5435-88cc-694a7719c452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff39de2-d071-4568-baac-25b505a2da56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff39de2-d071-4568-baac-25b505a2da56.jpg?1",
             "name": "Guardians of Meletis",
             "text": "Defender (This creature can't attack.)",
             "colours": [],
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "19c0c367-7b80-5a9b-824a-ef0033c2bfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c21fb-fc78-4106-9a42-abc73f41ab8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c21fb-fc78-4106-9a42-abc73f41ab8b.jpg?1",
             "name": "Hangarback Walker",
             "text": "Hangarback Walker enters the battlefield with X +1/+1 counters on it.\nWhen Hangarback Walker dies, put a 1/1 colorless Thopter artifact creature token with flying onto the battlefield for each +1/+1 counter on Hangarback Walker.{1}, {T}: Put a +1/+1 counter on Hangarback Walker.",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "a07e27bb-cacf-5e9b-b0d3-248eac66e035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba006c8-0ffc-4e68-9a55-c7b842d3add9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba006c8-0ffc-4e68-9a55-c7b842d3add9.jpg?1",
             "name": "Helm of the Gods",
             "text": "Equipped creature gets +1/+1 for each enchantment you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "6d78d1ba-03fe-5bb0-be76-516b9300ab6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518af905-f518-4269-89b4-781085be8dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/518af905-f518-4269-89b4-781085be8dd2.jpg?1",
             "name": "Jayemdae Tome",
             "text": "{4}, {T}: Draw a card.",
             "colours": [],
@@ -7955,7 +7955,7 @@
         },
         {
             "id": "0d94ffc2-490a-5e34-a121-f715537afecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c60473d-5065-4e63-bfc2-a041a8ca48ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c60473d-5065-4e63-bfc2-a041a8ca48ed.jpg?1",
             "name": "Mage-Ring Responder",
             "text": "Mage-Ring Responder doesn't untap during your untap step.{7}: Untap Mage-Ring Responder.\nWhenever Mage-Ring Responder attacks, it deals 7 damage to target creature defending player controls.",
             "colours": [],
@@ -7986,7 +7986,7 @@
         },
         {
             "id": "841f8cdd-af8d-5713-94d7-df029f4fed89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a8969f-d7a6-479a-9277-1270ee533c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a8969f-d7a6-479a-9277-1270ee533c4a.jpg?1",
             "name": "Meteorite",
             "text": "When Meteorite enters the battlefield, it deals 2 damage to target creature or player.{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8014,7 +8014,7 @@
         },
         {
             "id": "81553bbd-7ba9-5a23-9708-91c2f17ebe5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33ba4e5-217f-47e3-a6ce-f935a70c7566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33ba4e5-217f-47e3-a6ce-f935a70c7566.jpg?1",
             "name": "Orbs of Warding",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\nIf a creature would deal damage to you, prevent 1 of that damage.",
             "colours": [],
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "f6e01231-03ba-5059-b8e4-6e4d0ebea7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f99de-493a-4f0f-81e4-fcd29d6e9340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403f99de-493a-4f0f-81e4-fcd29d6e9340.jpg?1",
             "name": "Prism Ring",
             "text": "As Prism Ring enters the battlefield, choose a color.\nWhenever you cast a spell of the chosen color, you gain 1 life.",
             "colours": [],
@@ -8070,7 +8070,7 @@
         },
         {
             "id": "8657e487-4850-5d8b-8f25-c348ad658063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163ce9f-cf22-422e-a4b5-0240b88e2816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1163ce9f-cf22-422e-a4b5-0240b88e2816.jpg?1",
             "name": "Pyromancer's Goggles",
             "text": "{T}: Add {R} to your mana pool. When that mana is spent to cast a red instant or sorcery spell, copy that spell and you may choose new targets for the copy.",
             "colours": [],
@@ -8102,7 +8102,7 @@
         },
         {
             "id": "cbfc0e81-66ee-561d-a06c-a7ae378bcc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7ba4d-26bb-4631-a135-f27d94f376d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f7ba4d-26bb-4631-a135-f27d94f376d1.jpg?1",
             "name": "Ramroller",
             "text": "Ramroller attacks each turn if able.Ramroller gets +2/+0 as long as you control another artifact.",
             "colours": [],
@@ -8133,7 +8133,7 @@
         },
         {
             "id": "31902de1-7988-5279-981d-5984e198f4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0616483f-3169-41ac-b7a8-6a543d483b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0616483f-3169-41ac-b7a8-6a543d483b87.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor dies, each player draws a card.",
             "colours": [],
@@ -8164,7 +8164,7 @@
         },
         {
             "id": "c142f1c1-4319-59d0-b44e-295fe583ff1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f134f242-cbb5-4a3d-bfd4-46e8b8669b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f134f242-cbb5-4a3d-bfd4-46e8b8669b4b.jpg?1",
             "name": "Sigil of Valor",
             "text": "Whenever equipped creature attacks alone, it gets +1/+1 until end of turn for each other creature you control.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "2a05eb2c-1a17-5c35-bbf9-477d6d32169f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3687c36-c0ae-4dba-9379-b420236bf529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3687c36-c0ae-4dba-9379-b420236bf529.jpg?1",
             "name": "Sword of the Animist",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\nEquip {2}",
             "colours": [],
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "b409fd7f-663b-52ce-ab5e-b732118f8c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfce9be-67a2-4e8a-a71f-e88f64067691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dfce9be-67a2-4e8a-a71f-e88f64067691.jpg?1",
             "name": "Throwing Knife",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, you may sacrifice Throwing Knife. If you do, Throwing Knife deals 2 damage to target creature or player.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8256,7 +8256,7 @@
         },
         {
             "id": "3fb2ba78-9b83-55f8-ae1e-ff328145bd5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg?1",
             "name": "Veteran's Sidearm",
             "text": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8286,7 +8286,7 @@
         },
         {
             "id": "24605c70-624f-534f-ba0d-b3ff4964e7e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg?1",
             "name": "War Horn",
             "text": "Attacking creatures you control get +1/+0.",
             "colours": [],
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "75b25e10-cbb1-5e5c-9e69-8c6e57d8f1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034c5944-aad3-4bf2-b79d-8da61ab1bd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034c5944-aad3-4bf2-b79d-8da61ab1bd52.jpg?1",
             "name": "Battlefield Forge",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {R} or {W} to your mana pool. Battlefield Forge deals 1 damage to you.",
             "colours": [],
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "a50ccbe9-137f-53bb-b64a-32f31ced77bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca145c1c-537a-459e-9241-0b95368aaf3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca145c1c-537a-459e-9241-0b95368aaf3a.jpg?1",
             "name": "Caves of Koilos",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {W} or {B} to your mana pool. Caves of Koilos deals 1 damage to you.",
             "colours": [],
@@ -8376,7 +8376,7 @@
         },
         {
             "id": "bc477f1c-abe0-5962-a3b7-278f607164e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a3dd4-27bd-4825-a525-2d6cc2201046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14a3dd4-27bd-4825-a525-2d6cc2201046.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -8404,7 +8404,7 @@
         },
         {
             "id": "cbf38d8c-024c-59c0-8cd0-a23f8c0d4a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f29e03-0a71-46cd-992e-7baa61f16ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f29e03-0a71-46cd-992e-7baa61f16ac5.jpg?1",
             "name": "Foundry of the Consuls",
             "text": "{T}: Add {1} to your mana pool.{5}, {T}, Sacrifice Foundry of the Consuls: Put two 1/1 colorless Thopter artifact creature tokens with flying onto the battlefield.",
             "colours": [],
@@ -8432,7 +8432,7 @@
         },
         {
             "id": "be2cc16d-579f-534e-b919-48da91b7ff28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924d4025-a6f7-4ab0-8f0d-f4ba9ed0a232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924d4025-a6f7-4ab0-8f0d-f4ba9ed0a232.jpg?1",
             "name": "Llanowar Wastes",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {B} or {G} to your mana pool. Llanowar Wastes deals 1 damage to you.",
             "colours": [],
@@ -8463,7 +8463,7 @@
         },
         {
             "id": "53371bce-f282-505b-9c2d-20a42fe22f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988180b-a374-43fd-b299-fb61c781df2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4988180b-a374-43fd-b299-fb61c781df2e.jpg?1",
             "name": "Mage-Ring Network",
             "text": "{T}: Add {1} to your mana pool.{1}, {T}: Put a storage counter on Mage-Ring Network.{T}, Remove X storage counters from Mage-Ring Network: Add {X} to your mana pool.",
             "colours": [],
@@ -8491,7 +8491,7 @@
         },
         {
             "id": "67ef7866-693a-5913-9b44-aeae3a2791c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9851abd-ec17-4b97-9e5f-c335985a5f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9851abd-ec17-4b97-9e5f-c335985a5f29.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {1} to your mana pool.{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -8519,7 +8519,7 @@
         },
         {
             "id": "f9eb4a44-74c8-5d35-a618-e6ca763779da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d33afd-6f2a-43c8-ae5d-17a0674fcdd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1d33afd-6f2a-43c8-ae5d-17a0674fcdd3.jpg?1",
             "name": "Shivan Reef",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {U} or {R} to your mana pool. Shivan Reef deals 1 damage to you.",
             "colours": [],
@@ -8550,7 +8550,7 @@
         },
         {
             "id": "4568e2dc-a15c-5f7c-a766-bcab34ae70ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae3d45b-a40c-4003-960a-2d1d0847e750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae3d45b-a40c-4003-960a-2d1d0847e750.jpg?1",
             "name": "Yavimaya Coast",
             "text": "{T}: Add {1} to your mana pool.{T}: Add {G} or {U} to your mana pool. Yavimaya Coast deals 1 damage to you.",
             "colours": [],
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "0b6d0c20-bb81-528d-a19c-9fe2672cc249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f96591-4f22-451e-bfb5-32561cc4640d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f96591-4f22-451e-bfb5-32561cc4640d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "e0278a30-75a6-589c-bb78-d54cb52f043c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763c1eaa-fe29-4b24-8e41-96b94e5a75a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763c1eaa-fe29-4b24-8e41-96b94e5a75a4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8657,7 +8657,7 @@
         },
         {
             "id": "d98ead89-230a-5058-aea8-9175e1d76f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e683531-4a59-4461-b589-5ebcbc51a600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e683531-4a59-4461-b589-5ebcbc51a600.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "9dee799d-6c82-59ab-b6f8-5e35a39fb602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f7329-9c72-4369-8b66-2a89423e957d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4f7329-9c72-4369-8b66-2a89423e957d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8733,7 +8733,7 @@
         },
         {
             "id": "cefe7d87-cc29-5b59-8420-f0e6af1c551c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a9df3b-b542-4915-96ac-0c9027f6870a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a9df3b-b542-4915-96ac-0c9027f6870a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8771,7 +8771,7 @@
         },
         {
             "id": "19fb6263-1d04-583e-9472-8e11f26bf10a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d88f06-276b-41d4-a4c3-d904f93ea403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d88f06-276b-41d4-a4c3-d904f93ea403.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8809,7 +8809,7 @@
         },
         {
             "id": "3358b305-f87f-518f-ae94-4ec54d8244b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880b12e-948b-4f3a-bb0b-604e3dd66f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7880b12e-948b-4f3a-bb0b-604e3dd66f78.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8847,7 +8847,7 @@
         },
         {
             "id": "b67c5fba-a11b-5865-9939-2b7803ad0f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f845b1-3b8a-4387-aae3-fd497acf193c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f845b1-3b8a-4387-aae3-fd497acf193c.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8885,7 +8885,7 @@
         },
         {
             "id": "68d5c991-4820-536e-8522-a5b5839d8e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae0b13-c9f6-4659-ba85-a87a81f6e730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1ae0b13-c9f6-4659-ba85-a87a81f6e730.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8923,7 +8923,7 @@
         },
         {
             "id": "4943314f-2154-5656-b8b1-acdf7c012374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d4e89-93aa-4b1e-84f6-8addef529a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56d4e89-93aa-4b1e-84f6-8addef529a3f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8961,7 +8961,7 @@
         },
         {
             "id": "85b6f29e-5a24-599d-af67-32cd17c6b962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63b7238-ebdc-4dd8-b799-1ca33c14163b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a63b7238-ebdc-4dd8-b799-1ca33c14163b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "1dcd2b80-bab1-5ae4-b5cf-5b56995d193f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c617c618-8320-4f76-80a6-83581470dc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c617c618-8320-4f76-80a6-83581470dc13.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9037,7 +9037,7 @@
         },
         {
             "id": "76f3c87f-bdf1-52ac-bf29-3cb0cbf0d060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b95522-a9de-4ec1-8158-c66813919e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b95522-a9de-4ec1-8158-c66813919e62.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9075,7 +9075,7 @@
         },
         {
             "id": "a7329794-9209-539d-9d40-40e213cd0e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a0ca9e-c72b-4c99-8e6b-b6dbebf894e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a0ca9e-c72b-4c99-8e6b-b6dbebf894e9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "19069324-7937-5996-9f92-d66b4a26525a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7fe3c3-9cf7-4b73-b2bd-301667a2cd4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7fe3c3-9cf7-4b73-b2bd-301667a2cd4d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "00c38ae0-a771-5f13-9bbb-6cb6e2dbeaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ddd6e0-dbdc-4ce0-bc26-f94c951f90ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ddd6e0-dbdc-4ce0-bc26-f94c951f90ad.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "c847d5c3-927e-58d7-811d-4d2b622984f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ee8330-f1bf-460b-9345-00d08665e9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ee8330-f1bf-460b-9345-00d08665e9cf.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9227,7 +9227,7 @@
         },
         {
             "id": "748ef682-9f98-57dd-8571-8ab37b691d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcdbcd-2c5e-4733-a4c4-c5a345e9206a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dcdbcd-2c5e-4733-a4c4-c5a345e9206a.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9265,7 +9265,7 @@
         },
         {
             "id": "ea30cff7-8542-59e4-a2a3-37ae6f3f45ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b101184-71b2-4400-a5dc-4113df5a4f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b101184-71b2-4400-a5dc-4113df5a4f12.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9303,7 +9303,7 @@
         },
         {
             "id": "69c7d3e1-5aaa-5d28-9953-c392887d1c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1afc-eb3d-46ba-a645-ab2f33264f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9be1afc-eb3d-46ba-a645-ab2f33264f36.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "278ab11d-bcfe-518c-a961-5d386300ca74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29edd82c-8d47-4417-85fb-c38a02d7e0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29edd82c-8d47-4417-85fb-c38a02d7e0fa.jpg?1",
             "name": "Aegis Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen Aegis Angel enters the battlefield, another target permanent gains indestructible for as long as you control Aegis Angel. (Effects that say \"destroy\" don't destroy it. A creature with indestructible can't be destroyed by damage.)",
             "colours": [
@@ -9374,7 +9374,7 @@
         },
         {
             "id": "3592be14-8f09-5092-a4ff-b74ee801f681",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1a7b-149d-42ba-aaea-345ccae7227c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/562f1a7b-149d-42ba-aaea-345ccae7227c.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "4edca554-d51e-5936-9834-ba2a9c9aaec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af7956d-f811-49d3-bef7-07f294dcea3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af7956d-f811-49d3-bef7-07f294dcea3c.jpg?1",
             "name": "Eagle of the Watch",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9438,7 +9438,7 @@
         },
         {
             "id": "e9bcbdb3-02f0-571c-a20e-b8394cd972b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740a59f-0a46-4ad2-90a7-ac8c4d753a38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d740a59f-0a46-4ad2-90a7-ac8c4d753a38.jpg?1",
             "name": "Serra Angel",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9471,7 +9471,7 @@
         },
         {
             "id": "1b1a27a4-6b83-5de7-884d-599c3dd22267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236fbb72-3aea-4737-bf90-bd4d4e80b527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236fbb72-3aea-4737-bf90-bd4d4e80b527.jpg?1",
             "name": "Into the Void",
             "text": "Return up to two target creatures to their owners' hands.",
             "colours": [
@@ -9502,7 +9502,7 @@
         },
         {
             "id": "87757498-7852-50a9-97a6-1ba26f86c474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1035c7d3-2a5b-4404-93cf-e46abd716a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1035c7d3-2a5b-4404-93cf-e46abd716a10.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
             "colours": [
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "65784727-82d7-5651-a0f5-a638acb71e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e57fc1-1633-447f-ae32-ad7da25a4177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e57fc1-1633-447f-ae32-ad7da25a4177.jpg?1",
             "name": "Weave Fate",
             "text": "Draw two cards.",
             "colours": [
@@ -9566,7 +9566,7 @@
         },
         {
             "id": "b260478c-cfcf-5c06-9147-1cdf79e3418c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4b0f6-fc67-48aa-9f17-21a79bd0c3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4b0f6-fc67-48aa-9f17-21a79bd0c3d3.jpg?1",
             "name": "Flesh to Dust",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -9597,7 +9597,7 @@
         },
         {
             "id": "0e7ac756-5951-5209-ac1a-f7fe79f09765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df7f95a-0629-4568-9f0a-9074daa0d743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df7f95a-0629-4568-9f0a-9074daa0d743.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -9628,7 +9628,7 @@
         },
         {
             "id": "0a99f6a8-8915-53e4-9f8b-1050aee8991b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bb40a-3ecd-41eb-acee-819f3138875a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192bb40a-3ecd-41eb-acee-819f3138875a.jpg?1",
             "name": "Nightmare",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nNightmare's power and toughness are each equal to the number of Swamps you control.",
             "colours": [
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "a0449452-91d6-5913-bac2-3554044c84d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8926224e-aeae-4e5d-b33f-5bfd5d3766c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8926224e-aeae-4e5d-b33f-5bfd5d3766c1.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever a creature dealt damage by Sengir Vampire this turn dies, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -9695,7 +9695,7 @@
         },
         {
             "id": "67952215-a454-533b-a48c-5f9d0466da70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980efa5-bd21-4980-91a7-5e66528b1011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8980efa5-bd21-4980-91a7-5e66528b1011.jpg?1",
             "name": "Fiery Hellhound",
             "text": "{R}: Fiery Hellhound gets +1/+0 until end of turn.",
             "colours": [
@@ -9729,7 +9729,7 @@
         },
         {
             "id": "f9d28c81-8229-5bf0-8c15-290ec427dfb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fd9b74-8e5b-4c57-bb4f-4a7222183c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6fd9b74-8e5b-4c57-bb4f-4a7222183c44.jpg?1",
             "name": "Shivan Dragon",
             "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{R}: Shivan Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -9762,7 +9762,7 @@
         },
         {
             "id": "f484fa29-3ab9-5989-b28c-db65fb44bf8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8bee44-410b-46a9-be40-03f000cad9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8bee44-410b-46a9-be40-03f000cad9a9.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -9793,7 +9793,7 @@
         },
         {
             "id": "c07737ba-96b0-5723-89d5-549a3982162b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500c1ede-8f4a-4009-8057-c65411550487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500c1ede-8f4a-4009-8057-c65411550487.jpg?1",
             "name": "Prized Unicorn",
             "text": "All creatures able to block Prized Unicorn do so.",
             "colours": [
@@ -9826,7 +9826,7 @@
         },
         {
             "id": "515aa243-9a30-5afb-a253-ce3cc6fb7149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652db782-cf79-4626-9eb2-ad214cb39c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652db782-cf79-4626-9eb2-ad214cb39c86.jpg?1",
             "name": "Terra Stomper",
             "text": "Terra Stomper can't be countered.\nTrample (This creature can deal excess combat damage to defending player or planeswalker while attacking.)",
             "colours": [
@@ -9859,7 +9859,7 @@
         },
         {
             "id": "95e2556c-0b31-5ef9-9640-686913315dae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcc7b5-c911-44c9-be5a-087298ddb492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcc7b5-c911-44c9-be5a-087298ddb492.jpg?1",
             "name": "Magic Origins Checklist",
             "text": "",
             "colours": [],
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "a6c0c426-17b4-5e19-b8a1-b5267a1cb3dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ce74d5-ec65-44e8-b6c2-3f70b9fc3dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ce74d5-ec65-44e8-b6c2-3f70b9fc3dbb.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9920,7 +9920,7 @@
         },
         {
             "id": "686ad1d7-d846-5ef3-89f4-c46dc7279e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2969b-2176-4471-b316-9c80443866dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc2969b-2176-4471-b316-9c80443866dd.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9954,7 +9954,7 @@
         },
         {
             "id": "d9c6c80e-a415-5150-8b2d-a8c4fbc513ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33426f5-59bf-456c-8fff-0ca27eacdef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33426f5-59bf-456c-8fff-0ca27eacdef9.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9988,7 +9988,7 @@
         },
         {
             "id": "3f69c9c3-3b9e-5beb-b792-4edb428294d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14259948-5427-401f-b510-f5b705445e50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14259948-5427-401f-b510-f5b705445e50.jpg?1",
             "name": "Demon",
             "text": "",
             "colours": [
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "3b49dcde-f310-5692-a8b0-530e880f9769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ccae95-95c2-4d11-aa68-5c80ecf90fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ccae95-95c2-4d11-aa68-5c80ecf90fd2.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -10056,7 +10056,7 @@
         },
         {
             "id": "bbd9e6d6-1bdd-590a-8d07-e373496fd030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21498f5-9098-4e50-b1d3-bd64cba1372a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21498f5-9098-4e50-b1d3-bd64cba1372a.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -10090,7 +10090,7 @@
         },
         {
             "id": "525e7f62-6d27-5a6c-bc83-389625308040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affd414-f774-48d1-af9e-bff74e58e1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affd414-f774-48d1-af9e-bff74e58e1ca.jpg?1",
             "name": "Ashaya, the Awoken World",
             "text": "",
             "colours": [
@@ -10126,7 +10126,7 @@
         },
         {
             "id": "b7d2f111-d79c-5faf-9aa4-99e4ecd723f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7047838-ac9f-4ca1-9827-73d87098124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7047838-ac9f-4ca1-9827-73d87098124f.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10160,7 +10160,7 @@
         },
         {
             "id": "777d0755-3363-520a-91c2-831baaa42bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb75376-3b3c-4957-bf87-952f8cfc1da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb75376-3b3c-4957-bf87-952f8cfc1da7.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -10195,7 +10195,7 @@
         },
         {
             "id": "f2b2fd0e-d051-5d7f-b806-31df0bd1d0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa5fab-1076-443b-ba27-46d10770883d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fa5fab-1076-443b-ba27-46d10770883d.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -10226,7 +10226,7 @@
         },
         {
             "id": "53316f3a-2854-52da-826e-8e37dcb53d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa49655-6ce7-404b-ad12-33ec1cd7c0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa49655-6ce7-404b-ad12-33ec1cd7c0d3.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -10257,7 +10257,7 @@
         },
         {
             "id": "2e1d3bd1-27c1-54c5-b479-d914b4693c1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458e37b1-a849-41ae-b63c-3e09ffd814e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458e37b1-a849-41ae-b63c-3e09ffd814e4.jpg?1",
             "name": "Jace, Telepath Unbound Emblem",
             "text": "",
             "colours": [],
@@ -10286,7 +10286,7 @@
         },
         {
             "id": "b6b767d0-52a6-598c-997b-6876a92a5a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f984f-2e11-4f52-b3b0-dd9d94a2dd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75f984f-2e11-4f52-b3b0-dd9d94a2dd74.jpg?1",
             "name": "Liliana, Defiant Necromancer Emblem",
             "text": "",
             "colours": [],
@@ -10315,7 +10315,7 @@
         },
         {
             "id": "741922f7-81d6-5ee9-b850-6d83d447552e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8123a6-7e7b-49fb-9ebc-19d8150852e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8123a6-7e7b-49fb-9ebc-19d8150852e8.jpg?1",
             "name": "Chandra, Roaring Flame Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/OTJ.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/OTJ.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c37140a4-32c2-569c-91ca-34fb56a1b6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg?1",
             "name": "Another Round",
             "text": "Exile any number of creatures you control, then return them to the battlefield under their owner's control. Then repeat this process X more times.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "a2ad35c4-afd8-5849-98ba-5b080743f4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853d04c-864b-491c-8c6f-72d2d4874d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c853d04c-864b-491c-8c6f-72d2d4874d2f.jpg?1",
             "name": "Archangel of Tithes",
             "text": "Flying\nAs long as Archangel of Tithes is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.\nAs long as Archangel of Tithes is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "6a1018f9-ca3b-5c28-a357-de3e8c3d07da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263232df-69b8-4205-93ad-c724fe57ec11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/263232df-69b8-4205-93ad-c724fe57ec11.jpg?1",
             "name": "Armored Armadillo",
             "text": "Ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n{3}{W}: Armored Armadillo gets +X/+0 until end of turn, where X is its toughness.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "c522e3b4-1d64-5570-9d86-4acb9a9c0866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg?1",
             "name": "Aven Interrupter",
             "text": "Flash\nFlying\nWhen Aven Interrupter enters the battlefield, exile target spell. It becomes plotted. (Its owner may cast it as a sorcery on a later turn without paying its mana cost.)\nSpells your opponents cast from graveyards or from exile cost {2} more to cast.",
             "colours": [
@@ -145,7 +145,7 @@
         },
         {
             "id": "1497f3ae-0a46-5f74-b9e0-f491d103c086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8925279f-c16a-43b4-b791-ce450157275b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8925279f-c16a-43b4-b791-ce450157275b.jpg?1",
             "name": "Bounding Felidar",
             "text": "Whenever Bounding Felidar attacks while saddled, put a +1/+1 counter on each other creature you control. You gain 1 life for each of those creatures.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "aa2b8e61-71ee-546b-945f-47ea47b27ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c36742-456f-4618-99bc-793ef20b31b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c36742-456f-4618-99bc-793ef20b31b0.jpg?1",
             "name": "Bovine Intervention",
             "text": "Destroy target artifact or creature. Its controller creates a 2/2 white Ox creature token.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "343c765c-ea51-57d3-ba6b-76e8ac386f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7bf089-fa9b-4ffc-bf84-45cd51c76463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7bf089-fa9b-4ffc-bf84-45cd51c76463.jpg?1",
             "name": "Bridled Bighorn",
             "text": "Vigilance\nWhenever Bridled Bighorn attacks while saddled, create a 1/1 white Sheep creature token.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -248,7 +248,7 @@
         },
         {
             "id": "e8fcc9db-12df-5e88-9e2f-806e11f888fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654ade6b-0369-4b90-a744-2f57a45b04f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654ade6b-0369-4b90-a744-2f57a45b04f4.jpg?1",
             "name": "Claim Jumper",
             "text": "Vigilance\nWhen Claim Jumper enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls more lands than you, repeat this process once. If you search your library this way, shuffle.",
             "colours": [
@@ -285,7 +285,7 @@
         },
         {
             "id": "b693aa86-708c-5c1a-9b40-1b01e58a8178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70719e7b-6f02-4c1a-9f11-79b2b0d9846a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70719e7b-6f02-4c1a-9f11-79b2b0d9846a.jpg?1",
             "name": "Dust Animus",
             "text": "Flying\nIf you control five or more untapped lands, Dust Animus enters the battlefield with two +1/+1 counters and a lifelink counter on it.\nPlot {1}{W} (You may pay {1}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "96ece353-a301-52f8-a264-4da37b591579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c18b6-40e2-4f7f-a3bb-49bc695b68ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184c18b6-40e2-4f7f-a3bb-49bc695b68ec.jpg?1",
             "name": "Eriette's Lullaby",
             "text": "Destroy target tapped creature. You gain 2 life.",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "0810f0e6-58d5-5640-a689-8f2f546cb571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg?1",
             "name": "Final Showdown",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 All creatures lose all abilities until end of turn.\n+ {1} \u2014 Choose a creature you control. It gains indestructible until end of turn.\n+ {3}{W}{W} \u2014 Destroy all creatures.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "d462cafd-04a2-5c14-aeb5-544af545425e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg?1",
             "name": "Fortune, Loyal Steed",
             "text": "When Fortune, Loyal Steed enters the battlefield, scry 2.\nWhenever Fortune attacks while saddled, at end of combat, exile it and up to one creature that saddled it this turn, then return those cards to the battlefield under their owner's control.\nSaddle 1",
             "colours": [
@@ -426,7 +426,7 @@
         },
         {
             "id": "ce9cc7ab-70f6-570a-a7cf-744641a6f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9368cc76-bee5-4b46-a309-981106c3addf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9368cc76-bee5-4b46-a309-981106c3addf.jpg?1",
             "name": "Frontier Seeker",
             "text": "When Frontier Seeker enters the battlefield, look at the top five cards of your library. You may reveal a Mount creature card or a Plains card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "77d1f4b3-c0e2-545a-a17a-0ff90a17c7a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69689049-a704-4f16-84ee-4d5d915028ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69689049-a704-4f16-84ee-4d5d915028ec.jpg?1",
             "name": "Getaway Glamer",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step.\n+ {2} \u2014 Destroy target creature if no other creature has greater power.",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "70a4df7f-b92d-54a2-807e-e16cc956cedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9995e0e6-7c9c-4fef-8fd2-8fb1622e6ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9995e0e6-7c9c-4fef-8fd2-8fb1622e6ec8.jpg?1",
             "name": "High Noon",
             "text": "Each player can't cast more than one spell each turn.\n{4}{R}, Sacrifice High Noon: It deals 5 damage to any target.",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "ed997377-d359-5d9e-95f4-56909e4ca8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90de84c9-941b-4056-8501-ce8a948b9643.jpg?1",
             "name": "Holy Cow",
             "text": "Flash\nFlying\nWhen Holy Cow enters the battlefield, you gain 2 life and scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -565,7 +565,7 @@
         },
         {
             "id": "884f5b9d-b40b-5efa-b14e-d63492096294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b36bb3-dacc-44f6-adcd-2c2d65513d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b36bb3-dacc-44f6-adcd-2c2d65513d8c.jpg?1",
             "name": "Inventive Wingsmith",
             "text": "At the beginning of your end step, if you haven't cast a spell from your hand this turn and Inventive Wingsmith doesn't have a flying counter on it, put a flying counter on it.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "177d4611-57b1-533c-970b-bec08f510d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea96eeac-c316-4247-a81f-0ddf52675ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea96eeac-c316-4247-a81f-0ddf52675ebf.jpg?1",
             "name": "Lassoed by the Law",
             "text": "When Lassoed by the Law enters the battlefield, exile target nonland permanent an opponent controls until Lassoed by the Law leaves the battlefield.\nWhen Lassoed by the Law enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "7c056732-d0e6-5a79-aa19-260a60090352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18344498-952e-489c-8b03-bd1bef4c26ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18344498-952e-489c-8b03-bd1bef4c26ca.jpg?1",
             "name": "Mystical Tether",
             "text": "You may cast Mystical Tether as though it had flash if you pay {2} more to cast it.\nWhen Mystical Tether enters the battlefield, exile target artifact or creature an opponent controls until Mystical Tether leaves the battlefield.",
             "colours": [
@@ -664,7 +664,7 @@
         },
         {
             "id": "41e9d6c6-0f9f-570d-a222-81c567e97ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe155f6-888b-41a0-a9a0-be7bea998718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe155f6-888b-41a0-a9a0-be7bea998718.jpg?1",
             "name": "Nurturing Pixie",
             "text": "Flying\nWhen Nurturing Pixie enters the battlefield, return up to one target non-Faerie, nonland permanent you control to its owner's hand. If a permanent was returned this way, put a +1/+1 counter on Nurturing Pixie.",
             "colours": [
@@ -699,7 +699,7 @@
         },
         {
             "id": "712e70bc-a5ce-52e5-99b5-f0e53c6cf62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecd8b6f-b9aa-466a-909c-3209beef8244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecd8b6f-b9aa-466a-909c-3209beef8244.jpg?1",
             "name": "Omenport Vigilante",
             "text": "Omenport Vigilante has double strike as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "a51a4ab1-4656-58e1-ad6c-15b2380788af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg?1",
             "name": "One Last Job",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Return target creature card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Mount or Vehicle card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Aura or Equipment card from your graveyard to the battlefield attached to a creature you control.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "69494ef0-0b2b-5b5b-b790-cf553e917a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feaa51e-47fb-4849-b420-ee7278f3489a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feaa51e-47fb-4849-b420-ee7278f3489a.jpg?1",
             "name": "Outlaw Medic",
             "text": "Lifelink\nWhen Outlaw Medic dies, draw a card.",
             "colours": [
@@ -803,7 +803,7 @@
         },
         {
             "id": "a7b2612b-16d8-5953-9648-88b7d8594b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37302b5d-e528-4baa-947a-c859e4ddcff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37302b5d-e528-4baa-947a-c859e4ddcff9.jpg?1",
             "name": "Prairie Dog",
             "text": "Lifelink\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, put a +1/+1 counter on Prairie Dog.\n{4}{W}: Until end of turn, if you would put one or more +1/+1 counters on a creature you control, put that many plus one +1/+1 counters on it instead.",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "67338a36-2500-5d2a-a7e6-0a4c2d494aca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87824f3-aa9f-4d3d-99f7-0fbca43d8a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87824f3-aa9f-4d3d-99f7-0fbca43d8a51.jpg?1",
             "name": "Prosperity Tycoon",
             "text": "When Prosperity Tycoon enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{2}, Sacrifice a token: Prosperity Tycoon gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -872,7 +872,7 @@
         },
         {
             "id": "20badb60-8b2c-5bf3-8d86-673e2e952bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154e9ba9-0d0e-4b0e-acf2-f66a993cf3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/154e9ba9-0d0e-4b0e-acf2-f66a993cf3a2.jpg?1",
             "name": "Requisition Raid",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Destroy target artifact.\n+ {1} \u2014 Destroy target enchantment.\n+ {1} \u2014 Put a +1/+1 counter on each creature target player controls.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "a43cb582-b10c-5181-9176-995ea2b924eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ed7ca3-894b-45f4-a15f-51b6bcd3f474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ed7ca3-894b-45f4-a15f-51b6bcd3f474.jpg?1",
             "name": "Rustler Rampage",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Untap all creatures target player controls.\n+ {1} \u2014 Target creature gains double strike until end of turn.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "1e0fb01e-8d9c-5fdb-828c-2bd9f3a46c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2245f36-2138-4f01-9b70-151137a5ac59.jpg?1",
             "name": "Shepherd of the Clouds",
             "text": "Flying, vigilance\nWhen Shepherd of the Clouds enters the battlefield, return target permanent card with mana value 3 or less from your graveyard to your hand. Return that card to the battlefield instead if you control a Mount.",
             "colours": [
@@ -970,7 +970,7 @@
         },
         {
             "id": "d92cc6c8-1bee-5dc7-8cef-599643a15827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38a845d-f25d-45ab-9154-3fa5291b0ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38a845d-f25d-45ab-9154-3fa5291b0ba0.jpg?1",
             "name": "Sheriff of Safe Passage",
             "text": "Sheriff of Safe Passage enters the battlefield with a +1/+1 counter on it plus an additional +1/+1 counter on it for each other creature you control.\nPlot {1}{W} (You may pay {1}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1005,7 +1005,7 @@
         },
         {
             "id": "0f8534c3-19d7-59b6-9d73-3751b88663b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21301998-b3e6-4f3d-89f4-5e17aeb79a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21301998-b3e6-4f3d-89f4-5e17aeb79a1e.jpg?1",
             "name": "Stagecoach Security",
             "text": "When Stagecoach Security enters the battlefield, creatures you control get +1/+1 and gain vigilance until end of turn.\nPlot {3}{W} (You may pay {3}{W} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1040,7 +1040,7 @@
         },
         {
             "id": "684ed2ab-db17-5552-a511-d97f6c85aaee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523a4d6e-122b-49b4-bf3d-17d29c0007fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523a4d6e-122b-49b4-bf3d-17d29c0007fb.jpg?1",
             "name": "Steer Clear",
             "text": "Steer Clear deals 2 damage to target attacking or blocking creature. Steer Clear deals 4 damage to that creature instead if you controlled a Mount as you cast this spell.",
             "colours": [
@@ -1072,7 +1072,7 @@
         },
         {
             "id": "ec54a1af-e697-5576-82af-7e04eb05dfaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019d539f-04c2-43f1-8677-6d6fbb0e94f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019d539f-04c2-43f1-8677-6d6fbb0e94f7.jpg?1",
             "name": "Sterling Keykeeper",
             "text": "{2}, {T}: Tap target non-Mount creature.",
             "colours": [
@@ -1107,7 +1107,7 @@
         },
         {
             "id": "f3d4abb5-dfbe-5ec4-826a-9361ccd8a89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6000be7-67db-440e-87ba-276df20b803e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6000be7-67db-440e-87ba-276df20b803e.jpg?1",
             "name": "Sterling Supplier",
             "text": "Flying\nWhen Sterling Supplier enters the battlefield, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -1142,7 +1142,7 @@
         },
         {
             "id": "b237017b-86a9-5768-835c-4881316f4811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a31968-ba6d-4c01-838f-4cb8c64e73fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a31968-ba6d-4c01-838f-4cb8c64e73fb.jpg?1",
             "name": "Take Up the Shield",
             "text": "Put a +1/+1 counter on target creature. It gains lifelink and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "ef992121-be11-5db4-b6e5-106435f9b04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dff5fc-2adf-447a-b35f-e7883e0fd821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73dff5fc-2adf-447a-b35f-e7883e0fd821.jpg?1",
             "name": "Thunder Lasso",
             "text": "When Thunder Lasso enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1.\nWhenever equipped creature attacks, tap target creature defending player controls.\nEquip {2}",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "c2cf8d16-6fd8-5ddd-b08e-d3d17edca972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32a5f8-f69d-47dc-a800-4f0ddf4eada5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef32a5f8-f69d-47dc-a800-4f0ddf4eada5.jpg?1",
             "name": "Trained Arynx",
             "text": "Whenever Trained Arynx attacks while saddled, it gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -1244,7 +1244,7 @@
         },
         {
             "id": "92e61160-4ee0-5e8b-9b83-68f3c2adde3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df404af-571a-4867-83f5-bb4163b433ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df404af-571a-4867-83f5-bb4163b433ff.jpg?1",
             "name": "Vengeful Townsfolk",
             "text": "Whenever one or more other creatures you control die, put a +1/+1 counter on Vengeful Townsfolk.",
             "colours": [
@@ -1279,7 +1279,7 @@
         },
         {
             "id": "739d4ca3-a391-5869-bc0a-4702a4fe358f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624a176b-fe24-4441-8877-464cf172ccff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624a176b-fe24-4441-8877-464cf172ccff.jpg?1",
             "name": "Wanted Griffin",
             "text": "Flying\nWhen Wanted Griffin dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "11aae4e1-7d47-5aca-b22f-932cec3adf44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a440bbd6-8e51-4db1-90d9-7fa9fc327ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a440bbd6-8e51-4db1-90d9-7fa9fc327ad5.jpg?1",
             "name": "Archmage's Newt",
             "text": "Whenever Archmage's Newt deals combat damage to a player, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. That card gains flashback {0} until end of turn instead if Archmage's Newt is saddled. (You may cast that card from your graveyard for its flashback cost. Then exile it.)\nSaddle 3",
             "colours": [
@@ -1350,7 +1350,7 @@
         },
         {
             "id": "19d12f17-0efa-5c41-bc7b-2c1c7257b086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b740a8a8-e1d3-4642-a214-03731c9b5553.jpg?1",
             "name": "Canyon Crab",
             "text": "{1}{U}: Canyon Crab gets +2/-2 until end of turn.\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card, then discard a card.",
             "colours": [
@@ -1384,7 +1384,7 @@
         },
         {
             "id": "59d841f7-75b9-5978-979e-1712e3f778ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a2bf7-248c-4f8b-92ec-3010d276cb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a2bf7-248c-4f8b-92ec-3010d276cb59.jpg?1",
             "name": "Daring Thunder-Thief",
             "text": "Flash\nDaring Thunder-Thief enters the battlefield tapped.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "0e540a3e-e26c-5370-a8ce-108ca1f91d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ee726-7465-40f8-a954-19b19e636c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ee726-7465-40f8-a954-19b19e636c12.jpg?1",
             "name": "Deepmuck Desperado",
             "text": "Whenever you commit a crime, each opponent mills three cards. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "b3ed033c-9928-5a73-8da0-ff232311af60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc6af-c651-485e-a1cc-f9d00aeaf812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfc6af-c651-485e-a1cc-f9d00aeaf812.jpg?1",
             "name": "Djinn of Fool's Fall",
             "text": "Flying\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "7c2f8f1d-085e-5cb9-8bc6-018d3ca8c5b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg?1",
             "name": "Double Down",
             "text": "Whenever you cast an outlaw spell, copy that spell. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. Copies of permanent spells become tokens.)",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "9496592b-8f9d-523b-b919-a007857fe0aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg?1",
             "name": "Duelist of the Mind",
             "text": "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "9812317a-6d92-5a4d-86cc-8dadf4c8c317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623053a8-7abe-45ec-9f26-97e1c037120b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623053a8-7abe-45ec-9f26-97e1c037120b.jpg?1",
             "name": "Emergent Haunting",
             "text": "At the beginning of your end step, if you haven't cast a spell from your hand this turn and Emergent Haunting isn't a creature, it becomes a 3/3 Spirit creature with flying in addition to its other types.\n{2}{U}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "d97b7a59-0a74-57ea-906a-58d6c390f60f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62bbe11b-e959-4080-98ac-09bd57519c00.jpg?1",
             "name": "Failed Fording",
             "text": "Return target nonland permanent to its owner's hand. If you control a Desert, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "75c7b05a-b151-576a-93a9-58af72d42fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg?1",
             "name": "Fblthp, Lost on the Range",
             "text": "Ward {2}\nYou may look at the top card of your library any time.\nThe top card of your library has plot. The plot cost is equal to its mana cost.\nYou may plot nonland cards from the top of your library.",
             "colours": [
@@ -1661,7 +1661,7 @@
         },
         {
             "id": "ff356e23-8293-5f6c-9ebd-82d20539e907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8c931e-219f-4032-b55b-b5975fbea1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8c931e-219f-4032-b55b-b5975fbea1e7.jpg?1",
             "name": "Fleeting Reflection",
             "text": "Target creature you control gains hexproof until end of turn. Untap that creature. Until end of turn, it becomes a copy of up to one other target creature.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "53a66eef-e857-53da-b23c-93a9926f8a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg?1",
             "name": "Geralf, the Fleshwright",
             "text": "Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2 blue and black Zombie Rogue creature token.\nWhenever a Zombie enters the battlefield under your control, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your control this turn.",
             "colours": [
@@ -1732,7 +1732,7 @@
         },
         {
             "id": "2ddc7d43-db65-5610-a537-2240aea77c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b270377b-33eb-4e5e-9d14-0da2876da74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b270377b-33eb-4e5e-9d14-0da2876da74f.jpg?1",
             "name": "Geyser Drake",
             "text": "Flying\nAs long as it's not your turn, spells you cast cost {1} less to cast.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "5fa1d449-c345-5af9-8749-2e28a7d442e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ca61a9-8938-41bf-bd14-5759f4de6521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ca61a9-8938-41bf-bd14-5759f4de6521.jpg?1",
             "name": "Harrier Strix",
             "text": "Flying\nWhen Harrier Strix enters the battlefield, tap target permanent.\n{2}{U}: Draw a card, then discard a card.",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "d3f0212b-2016-5058-a8cd-35242ab5a24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be8e47-9006-4770-8d99-68a684064a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be8e47-9006-4770-8d99-68a684064a43.jpg?1",
             "name": "Jailbreak Scheme",
             "text": "Spree (Choose one or more additional costs.)\n+ {3} \u2014 Put a +1/+1 counter on target creature. It can't be blocked this turn.\n+ {2} \u2014 Target artifact or creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -1832,7 +1832,7 @@
         },
         {
             "id": "72538605-4fd1-5cbf-9899-b4477bb6fbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg?1",
             "name": "The Key to the Vault",
             "text": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "6ca92037-a70d-5450-9ee9-3e418158aa0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f12760-ff07-4c9f-a7a9-1e64bd3a9adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f12760-ff07-4c9f-a7a9-1e64bd3a9adf.jpg?1",
             "name": "Loan Shark",
             "text": "When Loan Shark enters the battlefield, if you've cast two or more spells this turn, draw a card.\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "076c1160-ecd7-545a-a891-d26259f06c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34071884-c5b6-42c0-9eb3-9f32910c29d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34071884-c5b6-42c0-9eb3-9f32910c29d8.jpg?1",
             "name": "Marauding Sphinx",
             "text": "Flying, vigilance, ward {2}\nWhenever you commit a crime, surveil 2. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "3d1ed782-01d7-5395-8e5e-ab08064a111a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd38d922-cfc1-43a8-82d8-5de441c71076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd38d922-cfc1-43a8-82d8-5de441c71076.jpg?1",
             "name": "Metamorphic Blast",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Until end of turn, target creature becomes a white Rabbit with base power and toughness 0/1.\n+ {3} \u2014 Target player draws two cards.",
             "colours": [
@@ -1973,7 +1973,7 @@
         },
         {
             "id": "7924ac83-5dff-5071-adac-41b3aea9d0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c74d48-362d-4c3b-9ff7-39bdd19657a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c74d48-362d-4c3b-9ff7-39bdd19657a6.jpg?1",
             "name": "Nimble Brigand",
             "text": "Nimble Brigand can't be blocked if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nWhenever Nimble Brigand deals combat damage to a player, draw a card.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "81bfed24-7596-57f1-838d-bd46e239b2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9584f0-55b8-448d-99a7-041934053f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9584f0-55b8-448d-99a7-041934053f42.jpg?1",
             "name": "Outlaw Stitcher",
             "text": "When Outlaw Stitcher enters the battlefield, create a 2/2 blue and black Zombie Rogue creature token, then put two +1/+1 counters on that token for each spell you've cast this turn other than the first.\nPlot {4}{U} (You may pay {4}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "2d4bf343-b85c-5199-9f10-d0df2b9bbd67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae044509-2f31-4506-a124-0e445b7181a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae044509-2f31-4506-a124-0e445b7181a2.jpg?1",
             "name": "Peerless Ropemaster",
             "text": "When Peerless Ropemaster enters the battlefield, return up to one target tapped creature to its owner's hand.",
             "colours": [
@@ -2078,7 +2078,7 @@
         },
         {
             "id": "69fbc8aa-dfed-5977-bc6f-63d79201fdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf4dd1-5468-4594-9c7b-0737610f19d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00bf4dd1-5468-4594-9c7b-0737610f19d4.jpg?1",
             "name": "Phantom Interference",
             "text": "Spree (Choose one or more additional costs.)\n+ {3} \u2014 Create a 2/2 white Spirit creature token with flying.\n+ {1} \u2014 Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "8dc553c4-5d72-58dc-8d38-9eb0163769fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8c3a0e-d61c-457f-ac85-577d0bb94b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8c3a0e-d61c-457f-ac85-577d0bb94b96.jpg?1",
             "name": "Plan the Heist",
             "text": "Surveil 3 if you have no cards in hand. Then draw three cards. (To surveil 3, look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nPlot {3}{U} (You may pay {3}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2142,7 +2142,7 @@
         },
         {
             "id": "9a706878-cb5c-5293-9833-12c50cdfe27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d08008-9272-405e-82ef-566e6d42bb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7d08008-9272-405e-82ef-566e6d42bb17.jpg?1",
             "name": "Razzle-Dazzler",
             "text": "Whenever you cast your second spell each turn, put a +1/+1 counter on Razzle-Dazzler. It can't be blocked this turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "f9d66b75-5107-5540-939c-a7d493bf973f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdbdfa8-aa28-4b3d-95e7-3d0e7e37f982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bdbdfa8-aa28-4b3d-95e7-3d0e7e37f982.jpg?1",
             "name": "Seize the Secrets",
             "text": "This spell costs {1} less to cast if you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nDraw two cards.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "536e7995-ca2b-5808-bffa-6334793c5848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe383-e483-47e7-99d1-991a06b089bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cfe383-e483-47e7-99d1-991a06b089bc.jpg?1",
             "name": "Shackle Slinger",
             "text": "Whenever you cast your second spell each turn, choose target creature an opponent controls. If it's tapped, put a stun counter on it. Otherwise, tap it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "01fd50d7-744c-5eea-a475-eacd1c2bcdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b8313b-a680-4dca-959a-1a7fa5cb4b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b8313b-a680-4dca-959a-1a7fa5cb4b1b.jpg?1",
             "name": "Shifting Grift",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Exchange control of two target creatures.\n+ {1} \u2014 Exchange control of two target artifacts.\n+ {1} \u2014 Exchange control of two target enchantments.",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "924de6ba-0114-59b0-adb8-0378398b1ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a9464-ce30-4747-874e-3bbf75913081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a9464-ce30-4747-874e-3bbf75913081.jpg?1",
             "name": "Slickshot Lockpicker",
             "text": "When Slickshot Lockpicker enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)\nPlot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "9bfa736a-e982-54d6-99b6-27fbe4f2dd4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592ccc36-3d10-4a12-8743-9b300b80cb4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592ccc36-3d10-4a12-8743-9b300b80cb4d.jpg?1",
             "name": "Slickshot Vault-Buster",
             "text": "Vigilance\nSlickshot Vault-Buster gets +2/+0 as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -2346,7 +2346,7 @@
         },
         {
             "id": "964a9642-5928-5e13-8ddf-c1652fb50b84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6822d12-1a25-42e7-94cc-71bd29daed93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6822d12-1a25-42e7-94cc-71bd29daed93.jpg?1",
             "name": "Spring Splasher",
             "text": "Whenever Spring Splasher attacks, target creature defending player controls gets -3/-0 until end of turn.",
             "colours": [
@@ -2381,7 +2381,7 @@
         },
         {
             "id": "b1544a73-705c-535d-b6e1-bddb2491bfd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea2054-3d22-42ce-ab50-501ef09c2128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ea2054-3d22-42ce-ab50-501ef09c2128.jpg?1",
             "name": "Step Between Worlds",
             "text": "Each player may shuffle their hand and graveyard into their library. Each player who does draws seven cards. Exile Step Between Worlds.\nPlot {4}{U}{U} (You may pay {4}{U}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2415,7 +2415,7 @@
         },
         {
             "id": "fb0d2b4f-9ce4-5967-9ebf-f7b5348c9adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg?1",
             "name": "Stoic Sphinx",
             "text": "Flash\nFlying\nStoic Sphinx has hexproof as long as you haven't cast a spell this turn.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "299c403c-703c-5b8c-93e3-61f17be36427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9c158-0080-427c-8cf9-0289011ea63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9c158-0080-427c-8cf9-0289011ea63e.jpg?1",
             "name": "Stop Cold",
             "text": "Flash\nEnchant artifact or creature\nWhen Stop Cold enters the battlefield, tap enchanted permanent.\nEnchanted permanent loses all abilities and doesn't untap during its controller's untap step.",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "8bf8eb09-86b0-5454-b86d-1898d587565a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fea80c4-923c-40a1-9363-bfa4c267a024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fea80c4-923c-40a1-9363-bfa4c267a024.jpg?1",
             "name": "Take the Fall",
             "text": "Target creature gets -1/-0 until end of turn. It gets -4/-0 until end of turn instead if you control an outlaw. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nDraw a card.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "aae9ae3c-e1a3-5d1e-8b2e-53127ec8c0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg?1",
             "name": "This Town Ain't Big Enough",
             "text": "This spell costs {3} less to cast if it targets a permanent you control.\nReturn up to two target nonland permanents to their owners' hands.",
             "colours": [
@@ -2549,7 +2549,7 @@
         },
         {
             "id": "820ea9bb-3e1d-5ca4-82b4-9f1460c9ad21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg?1",
             "name": "Three Steps Ahead",
             "text": "Spree (Choose one or more additional costs.)\n+ {1}{U} \u2014 Counter target spell.\n+ {3} \u2014 Create a token that's a copy of target artifact or creature you control.\n+ {2} \u2014 Draw two cards, then discard a card.",
             "colours": [
@@ -2583,7 +2583,7 @@
         },
         {
             "id": "ef412910-e80c-5f33-bfb7-27e5301cf510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ec4c6-3332-498f-8b56-d7ad8fc5230c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685ec4c6-3332-498f-8b56-d7ad8fc5230c.jpg?1",
             "name": "Visage Bandit",
             "text": "You may have Visage Bandit enter the battlefield as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.\nPlot {2}{U} (You may pay {2}{U} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "c36d8ad8-c8fa-5f35-a857-e0da039575b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b17d09-974a-4e33-b14d-5fe4230ab241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b17d09-974a-4e33-b14d-5fe4230ab241.jpg?1",
             "name": "Ambush Gigapede",
             "text": "Flash\nWhen Ambush Gigapede enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "28044daa-0445-5f47-99df-d4407f07b09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c26b9-981f-47cf-b0f4-769e788d9537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c26b9-981f-47cf-b0f4-769e788d9537.jpg?1",
             "name": "Binding Negotiation",
             "text": "Target opponent reveals their hand. You may choose a nonland card from it. If you do, they discard it. Otherwise, you may put a face-up exiled card they own into their graveyard.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "cd21e7cd-d035-56b7-8355-61f564cafdb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef10b2ad-9b9b-4c5d-a2c7-3ce742224b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef10b2ad-9b9b-4c5d-a2c7-3ce742224b50.jpg?1",
             "name": "Blacksnag Buzzard",
             "text": "Flying\nBlacksnag Buzzard enters the battlefield with a +1/+1 counter on it if a creature died this turn.\nPlot {1}{B} (You may pay {1}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "458072f4-af39-5ac9-a6a2-36be801e3593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016a750-2a18-4443-a600-957eb4026d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016a750-2a18-4443-a600-957eb4026d3a.jpg?1",
             "name": "Blood Hustler",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Blood Hustler. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n{3}{B}: Target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "cf47982e-0cac-5e9f-97d4-f82d34dd7f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43981b1-60c8-4896-8885-b07e73b99b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43981b1-60c8-4896-8885-b07e73b99b30.jpg?1",
             "name": "Boneyard Desecrator",
             "text": "Menace\n{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Boneyard Desecrator. If an outlaw was sacrificed this way, create a Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "f4409d13-2bcf-5d83-80e0-abdb796c070f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a268ba-c442-4fe4-90b4-2810c8474f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a268ba-c442-4fe4-90b4-2810c8474f4e.jpg?1",
             "name": "Caustic Bronco",
             "text": "Whenever Caustic Bronco attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if Caustic Bronco isn't saddled. Otherwise, each opponent loses that much life.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "602d5db0-db76-5c56-9f36-1eff1c00ad66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f96be9-60fc-4e2f-9172-4cc53c9a095a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f96be9-60fc-4e2f-9172-4cc53c9a095a.jpg?1",
             "name": "Consuming Ashes",
             "text": "Exile target creature. If it had mana value 3 or less, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2858,7 +2858,7 @@
         },
         {
             "id": "6b66e36d-3f74-596a-807e-0c9a4b95cb31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8046f892-3317-4ef7-9cf7-97b9060540c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8046f892-3317-4ef7-9cf7-97b9060540c8.jpg?1",
             "name": "Corrupted Conviction",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "58942fdd-7fa7-56a9-9a14-202bea768fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e899e4-e2de-44cf-b6f4-cace8d3770cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e899e4-e2de-44cf-b6f4-cace8d3770cb.jpg?1",
             "name": "Desert's Due",
             "text": "Target creature gets -2/-2 until end of turn. It gets an additional -1/-1 until end of turn for each Desert you control.",
             "colours": [
@@ -2922,7 +2922,7 @@
         },
         {
             "id": "3201e863-3773-54fd-a132-0f4bcfa2793a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59da027-b5dd-4920-b3a1-9da05fcb1977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59da027-b5dd-4920-b3a1-9da05fcb1977.jpg?1",
             "name": "Desperate Bloodseeker",
             "text": "Lifelink\nWhen Desperate Bloodseeker enters the battlefield, target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "9903673d-aed5-5497-9099-2e233efed4b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a17ab9-13c9-41d4-a143-82d8caacfd8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a17ab9-13c9-41d4-a143-82d8caacfd8b.jpg?1",
             "name": "Fake Your Own Death",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control and you create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "14db4347-7490-512e-acd9-c1799fb8338a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1679f74d-00f8-436c-9f8c-aa3f843a546c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1679f74d-00f8-436c-9f8c-aa3f843a546c.jpg?1",
             "name": "Forsaken Miner",
             "text": "Forsaken Miner can't block.\nWhenever you commit a crime, you may pay {B}. If you do, return Forsaken Miner from your graveyard to the battlefield. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3023,7 +3023,7 @@
         },
         {
             "id": "da46f56f-f4a8-58de-8a30-f6bd1de92add",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg?1",
             "name": "Gisa, the Hellraiser",
             "text": "Ward\u2014{2}, Pay 2 life.\nSkeletons and Zombies you control get +1/+1 and have menace.\nWhenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3062,7 +3062,7 @@
         },
         {
             "id": "eafef7bc-5a53-5844-92db-a6135d745217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2913d5-57c7-4f9b-bc96-8a46beef2563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2913d5-57c7-4f9b-bc96-8a46beef2563.jpg?1",
             "name": "Hollow Marauder",
             "text": "This spell costs {1} less to cast for each creature card in your graveyard.\nFlying\nWhen Hollow Marauder enters the battlefield, any number of target opponents each discard a card. For each of those opponents who didn't discard a card with mana value 4 or greater, draw a card.",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "19a0e48f-977e-5d00-9ff1-248205c82d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a108b0e4-1b43-4659-9e91-facb0bd57ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a108b0e4-1b43-4659-9e91-facb0bd57ebb.jpg?1",
             "name": "Insatiable Avarice",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Search your library for a card, then shuffle and put that card on top.\n+ {B}{B} \u2014 Target player draws three cards and loses 3 life.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "dd1288f4-e995-5448-b1c2-6ce723204fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3affc1-be42-48c7-89ff-b59550ff278c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3affc1-be42-48c7-89ff-b59550ff278c.jpg?1",
             "name": "Kaervek, the Punisher",
             "text": "Whenever you commit a crime, exile up to one target black card from your graveyard and copy it. You may cast the copy. If you do, you lose 2 life. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime. Copies of permanent spells become tokens.)",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "0c0b4521-119f-53e4-a771-25da52d0d891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35a0d3-12f7-46f3-a6b3-02a490d45ca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35a0d3-12f7-46f3-a6b3-02a490d45ca0.jpg?1",
             "name": "Lively Dirge",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Search your library for a card, put it into your graveyard, then shuffle.\n+ {2} \u2014 Return up to two creature cards with total mana value 4 or less from your graveyard to the battlefield.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "b5f09746-5bdb-5c26-b0e2-f8e3777a9d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg?1",
             "name": "Mourner's Surprise",
             "text": "Return up to one target creature card from your graveyard to your hand. Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "74ae85d2-2a95-5285-a5e9-26900c8a890f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f1a481-598e-4e05-8471-eedb12a39022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f1a481-598e-4e05-8471-eedb12a39022.jpg?1",
             "name": "Neutralize the Guards",
             "text": "Creatures target opponent controls get -1/-1 until end of turn. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -3266,7 +3266,7 @@
         },
         {
             "id": "20b47c0b-56ca-5d0e-8da6-cea2cdbb3c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0095b-6136-4368-94cb-4c82621aaf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dd0095b-6136-4368-94cb-4c82621aaf37.jpg?1",
             "name": "Nezumi Linkbreaker",
             "text": "When Nezumi Linkbreaker dies, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "79215d9e-0266-5105-8492-a1f19d0158a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce57d977-e9c5-4ed1-915f-cdc90a54f8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce57d977-e9c5-4ed1-915f-cdc90a54f8f8.jpg?1",
             "name": "Overzealous Muscle",
             "text": "Whenever you commit a crime during your turn, Overzealous Muscle gains indestructible until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime. Damage and effects that say \"destroy\" don't destroy a creature with indestructible.)",
             "colours": [
@@ -3336,7 +3336,7 @@
         },
         {
             "id": "d5cf3da4-2a91-51be-a065-6b22934b5240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa76fc45-a106-4dc9-9d44-a005eaa2784d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa76fc45-a106-4dc9-9d44-a005eaa2784d.jpg?1",
             "name": "Pitiless Carnage",
             "text": "Sacrifice any number of permanents you control, then draw that many cards.\nPlot {1}{B}{B} (You may pay {1}{B}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3370,7 +3370,7 @@
         },
         {
             "id": "b12f0d60-c321-5524-b4db-d0ba82d663b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f64358-58db-40ab-90e8-6137c3bd0a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f64358-58db-40ab-90e8-6137c3bd0a29.jpg?1",
             "name": "Rakish Crew",
             "text": "When Rakish Crew enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nWhenever an outlaw you control dies, each opponent loses 1 life and you gain 1 life. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "19f4e294-f519-5be6-8e60-5ef70c9a7dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a88e233-f09c-49e7-b1e3-386fba851fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a88e233-f09c-49e7-b1e3-386fba851fdf.jpg?1",
             "name": "Rattleback Apothecary",
             "text": "Deathtouch\nWhenever you commit a crime, target creature you control gains your choice of menace or lifelink until end of turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "22fa3f91-71da-579b-801b-d028f1ce2df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2df3cb4-1658-450a-912a-df336706acdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2df3cb4-1658-450a-912a-df336706acdc.jpg?1",
             "name": "Raven of Fell Omens",
             "text": "Flying\nWhenever you commit a crime, each opponent loses 1 life and you gain 1 life. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "2ca6b276-df48-572a-8f6e-cfae9c3dc73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252def94-2d89-48f7-8ff7-9c8682ca3ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252def94-2d89-48f7-8ff7-9c8682ca3ec6.jpg?1",
             "name": "Rictus Robber",
             "text": "When Rictus Robber enters the battlefield, if a creature died this turn, create a 2/2 blue and black Zombie Rogue creature token.\nPlot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "904eda09-24b3-56e2-85cb-fca8b48f491f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e4311a-8583-4cf0-8126-508dbfbcddb6.jpg?1",
             "name": "Rooftop Assassin",
             "text": "Flash\nFlying, lifelink\nWhen Rooftop Assassin enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "959a2a52-24b5-5a91-8858-82a58184ef7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg?1",
             "name": "Rush of Dread",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Target opponent sacrifices half the creatures they control, rounded up.\n+ {2} \u2014 Target opponent discards half the cards in their hand, rounded up.\n+ {2} \u2014 Target opponent loses half their life, rounded up.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "c11a289f-a96f-55e6-bf26-fb622328b963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c98650-b195-4071-8e02-4df35fddddc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c98650-b195-4071-8e02-4df35fddddc7.jpg?1",
             "name": "Servant of the Stinger",
             "text": "Deathtouch\nWhenever Servant of the Stinger deals combat damage to a player, if you've committed a crime this turn, you may sacrifice Servant of the Stinger. If you do, search your library for a card, put it into your hand, then shuffle. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -3610,7 +3610,7 @@
         },
         {
             "id": "a958174b-65c3-58f1-9f57-74f56db630de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d6528-c524-4bb8-8a72-b3775cd2c177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180d6528-c524-4bb8-8a72-b3775cd2c177.jpg?1",
             "name": "Shoot the Sheriff",
             "text": "Destroy target non-outlaw creature. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. Everyone else is fair game.)",
             "colours": [
@@ -3642,7 +3642,7 @@
         },
         {
             "id": "fa250655-a455-527e-903a-9e2616ed8b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03709166-164a-4075-ad0d-ea3b516ab771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03709166-164a-4075-ad0d-ea3b516ab771.jpg?1",
             "name": "Skulduggery",
             "text": "Until end of turn, target creature you control gets +1/+1 and target creature an opponent controls gets -1/-1.",
             "colours": [
@@ -3674,7 +3674,7 @@
         },
         {
             "id": "243d9946-dd04-5abc-bc6f-8b3bcc1d173e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5724a15f-0ba0-421a-9cd4-a2b701e6141f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5724a15f-0ba0-421a-9cd4-a2b701e6141f.jpg?1",
             "name": "Tinybones Joins Up",
             "text": "When Tinybones Joins Up enters the battlefield, any number of target players each discard a card.\nWhenever a legendary creature enters the battlefield under your control, any number of target players each mill a card and lose 1 life.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "d9ddb794-3cb2-5a53-97d2-20375d1c607d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg?1",
             "name": "Tinybones, the Pickpocket",
             "text": "Deathtouch\nWhenever Tinybones, the Pickpocket deals combat damage to a player, you may cast target nonland permanent card from that player's graveyard, and mana of any type can be spent to cast that spell.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "2c99a4f4-38f5-5cd2-8ca2-d37e3d156987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88df498-147c-4609-8a94-d8d10a87e37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c88df498-147c-4609-8a94-d8d10a87e37c.jpg?1",
             "name": "Treasure Dredger",
             "text": "{1}, {T}, Pay 1 life: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3784,7 +3784,7 @@
         },
         {
             "id": "4226ccf9-eba2-5f5f-a3e9-43ed1dc31903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5a25d9-926e-4004-8830-2b2bf7bc0775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5a25d9-926e-4004-8830-2b2bf7bc0775.jpg?1",
             "name": "Unfortunate Accident",
             "text": "Spree (Choose one or more additional costs.)\n+ {2}{B} \u2014 Destroy target creature.\n+ {1} \u2014 Create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -3816,7 +3816,7 @@
         },
         {
             "id": "e6b1f987-c445-5b6b-a3a6-d1875c277e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e56a8df-db04-4a88-a5ab-6954d3449976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e56a8df-db04-4a88-a5ab-6954d3449976.jpg?1",
             "name": "Unscrupulous Contractor",
             "text": "When Unscrupulous Contractor enters the battlefield, you may sacrifice a creature. When you do, target player draws two cards and loses 2 life.\nPlot {2}{B} (You may pay {2}{B} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "a992f77b-6dbf-5d0d-a328-87491eb2318b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg?1",
             "name": "Vadmir, New Blood",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Vadmir, New Blood. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nAs long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink.",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "7ee68dd0-6334-53a8-81e6-7c606df64c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6bf35c-8763-47cc-ab2d-5dbabeb28072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6bf35c-8763-47cc-ab2d-5dbabeb28072.jpg?1",
             "name": "Vault Plunderer",
             "text": "When Vault Plunderer enters the battlefield, target player draws a card and loses 1 life.",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "8b244098-b156-5bd8-ae32-a19541db894f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd13011e-a4fc-4107-988f-60cfc851ecd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd13011e-a4fc-4107-988f-60cfc851ecd3.jpg?1",
             "name": "Brimstone Roundup",
             "text": "Whenever you cast your second spell each turn, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "b0975e45-5440-59ea-bb91-0e655e67b973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a70f5a-2056-4c26-b6ea-9f751b5d0d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a70f5a-2056-4c26-b6ea-9f751b5d0d8c.jpg?1",
             "name": "Calamity, Galloping Inferno",
             "text": "Haste\nWhenever Calamity, Galloping Inferno attacks while saddled, choose a nonlegendary creature that saddled it this turn and create a tapped and attacking token that's a copy of it. Sacrifice that token at the beginning of the next end step. Repeat this process once.\nSaddle 1",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "94c21e52-cec6-59ba-a2be-a8554161bcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd0c4-509e-49c2-ad57-f772efcbc207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fd0c4-509e-49c2-ad57-f772efcbc207.jpg?1",
             "name": "Caught in the Crossfire",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Caught in the Crossfire deals 2 damage to each outlaw creature. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\n+ {1} \u2014 Caught in the Crossfire deals 2 damage to each non-outlaw creature.",
             "colours": [
@@ -4028,7 +4028,7 @@
         },
         {
             "id": "9d88191c-9797-57e0-bfbc-bdb4f46618c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ac6ea-c67b-4f90-be4f-aa25882f5794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b4ac6ea-c67b-4f90-be4f-aa25882f5794.jpg?1",
             "name": "Cunning Coyote",
             "text": "Haste\nWhen Cunning Coyote enters the battlefield, another target creature you control gets +1/+1 and gains haste until end of turn.\nPlot {1}{R} (You may pay {1}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4062,7 +4062,7 @@
         },
         {
             "id": "bf4c3a0a-8921-5efc-911d-fde99e6e07c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a50b7a-8741-4520-8d45-8e6b128c2628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a50b7a-8741-4520-8d45-8e6b128c2628.jpg?1",
             "name": "Deadeye Duelist",
             "text": "Reach\n{1}, {T}: Deadeye Duelist deals 1 damage to target opponent.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "e96e8787-776d-55d9-9ee1-9422a02656eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b491d11-d00a-4541-8389-2785a455eeee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b491d11-d00a-4541-8389-2785a455eeee.jpg?1",
             "name": "Demonic Ruckus",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has menace and trample.\nWhen Demonic Ruckus is put into a graveyard from the battlefield, draw a card.\nPlot {R} (You may pay {R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4131,7 +4131,7 @@
         },
         {
             "id": "be96c593-34aa-5712-a02a-a05508f0efa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b359bf-afd8-439d-a4d2-985db1ad368c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b359bf-afd8-439d-a4d2-985db1ad368c.jpg?1",
             "name": "Discerning Peddler",
             "text": "When Discerning Peddler enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "0fb87202-3591-59e3-951b-41d1ab9e0359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3df9c-0a86-4e6f-a3c7-84a883328a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e3df9c-0a86-4e6f-a3c7-84a883328a3d.jpg?1",
             "name": "Explosive Derailment",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Explosive Derailment deals 4 damage to target creature.\n+ {2} \u2014 Destroy target artifact.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "89a27db3-ed47-5fb9-839e-ffa800155ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db4260-6fc8-4500-afd7-2c845ac0d53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db4260-6fc8-4500-afd7-2c845ac0d53b.jpg?1",
             "name": "Ferocification",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Target creature you control gets +2/+0 until end of turn.\n\u2022 Target creature you control gains menace and haste until end of turn.",
             "colours": [
@@ -4230,7 +4230,7 @@
         },
         {
             "id": "d2680cfd-aa73-5141-b542-d83a1a8af9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f568803d-65c0-48d7-916f-671267a9e00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f568803d-65c0-48d7-916f-671267a9e00e.jpg?1",
             "name": "Gila Courser",
             "text": "Whenever Gila Courser attacks while saddled, exile the top card of your library. Until the end of your next turn, you may play that card.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "42bd71ea-2aeb-507c-ad1e-6f910a8a9214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg?1",
             "name": "Great Train Heist",
             "text": "Spree (Choose one or more additional costs.)\n+ {2}{R} \u2014 Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.\n+ {2} \u2014 Creatures you control get +1/+0 and gain first strike until end of turn.\n+ {R} \u2014 Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
             "colours": [
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "0cb24618-20b3-58f2-a371-5f64181efdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ad8ed7-1429-432e-8217-a4db3b97675c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ad8ed7-1429-432e-8217-a4db3b97675c.jpg?1",
             "name": "Hell to Pay",
             "text": "Hell to Pay deals X damage to target creature. Create a number of tapped Treasure tokens equal to the amount of excess damage dealt to that creature this way.",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "d55389b5-2b38-5ae8-8759-751020b80d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b99db5b-cd13-4e69-98b7-753e72c781f8.jpg?1",
             "name": "Hellspur Brute",
             "text": "Affinity for outlaws (This spell costs {1} less to cast for each Assassin, Mercenary, Pirate, Rogue, and/or Warlock you control.)\nTrample",
             "colours": [
@@ -4368,7 +4368,7 @@
         },
         {
             "id": "4d1bf2c3-2c2d-51ee-a554-296ace176e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg?1",
             "name": "Hellspur Posse Boss",
             "text": "Other outlaws you control have haste. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhen Hellspur Posse Boss enters the battlefield, create two 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "dee70ef4-0b0c-5955-a9fd-22449c872654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a88429-9204-4a23-a7a8-babbd6bab79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a88429-9204-4a23-a7a8-babbd6bab79f.jpg?1",
             "name": "Highway Robbery",
             "text": "You may discard a card or sacrifice a land. If you do, draw two cards.\nPlot {1}{R} (You may pay {1}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "0d0a0017-bc07-5bc7-9680-4a27d92fc786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c0af5-7cdf-4c71-84cc-6349f10e0d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324c0af5-7cdf-4c71-84cc-6349f10e0d66.jpg?1",
             "name": "Irascible Wolverine",
             "text": "When Irascible Wolverine enters the battlefield, exile the top card of your library. Until end of turn, you may play that card.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "d2c8c94a-bdf6-55fc-bb78-c02fe11489b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg?1",
             "name": "Iron-Fist Pulverizer",
             "text": "Reach\nWhenever you cast your second spell each turn, Iron-Fist Pulverizer deals 2 damage to target opponent. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "388232c7-9abc-5883-8461-0a2a48480345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398d9a16-d72c-42e2-a0ea-d9da642ee046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398d9a16-d72c-42e2-a0ea-d9da642ee046.jpg?1",
             "name": "Longhorn Sharpshooter",
             "text": "Reach\nWhen Longhorn Sharpshooter becomes plotted, it deals 2 damage to any target.\nPlot {3}{R} (You may pay {3}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "62c7bde6-8890-5a3d-ba91-71a3376b6a3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg?1",
             "name": "Magda, the Hoardmaster",
             "text": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
             "colours": [
@@ -4581,7 +4581,7 @@
         },
         {
             "id": "256c420d-bdc5-5545-a080-fcc028457570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e12566-375f-4f31-aa91-1b13a96d9ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e12566-375f-4f31-aa91-1b13a96d9ece.jpg?1",
             "name": "Magebane Lizard",
             "text": "Whenever a player casts a noncreature spell, Magebane Lizard deals damage to that player equal to the number of noncreature spells they've cast this turn.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "5c86e367-0ceb-510c-ba3a-0e9ff384ca1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cfacff-e884-4954-aa6b-ed56ca942bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19cfacff-e884-4954-aa6b-ed56ca942bf2.jpg?1",
             "name": "Mine Raider",
             "text": "Trample\nWhen Mine Raider enters the battlefield, if you control another outlaw, create a Treasure token. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. A Treasure token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "c30baed6-3dfe-5973-bcdf-571d5d9eefdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7502b9c-b759-499a-8e94-22f87f5eb142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7502b9c-b759-499a-8e94-22f87f5eb142.jpg?1",
             "name": "Outlaws' Fury",
             "text": "Creatures you control get +2/+0 until end of turn. If you control an outlaw, exile the top card of your library. Until the end of your next turn, you may play that card. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "150a939e-c2f4-52f8-9836-35c3cea52a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70f2278-8857-46e4-aa2b-fff5589b750f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70f2278-8857-46e4-aa2b-fff5589b750f.jpg?1",
             "name": "Prickly Pair",
             "text": "When Prickly Pair enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "fb2a8220-32ba-51f2-8252-6b01d57e8866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56399cd0-1214-42b6-be38-f2cbd770915f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56399cd0-1214-42b6-be38-f2cbd770915f.jpg?1",
             "name": "Quick Draw",
             "text": "Target creature you control gets +1/+1 and gains first strike until end of turn. Creatures target opponent controls lose first strike and double strike until end of turn.",
             "colours": [
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "e4f1971d-444e-5f6f-a265-30f4642f28f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e326c4-39f1-41ee-9e47-ebe468c51718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e326c4-39f1-41ee-9e47-ebe468c51718.jpg?1",
             "name": "Quilled Charger",
             "text": "Whenever Quilled Charger attacks while saddled, it gets +1/+2 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -4784,7 +4784,7 @@
         },
         {
             "id": "ad518202-cd35-53ab-863d-a86bbe76cac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912fcd14-5e81-418c-997b-771f2f38f63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912fcd14-5e81-418c-997b-771f2f38f63d.jpg?1",
             "name": "Reckless Lackey",
             "text": "First strike, haste\n{2}{R}, Sacrifice Reckless Lackey: Draw a card and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4819,7 +4819,7 @@
         },
         {
             "id": "48150d54-e1f8-5d55-9400-15da6c1c3b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07d3ee9-d3c4-4f07-839e-ec81c2587ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07d3ee9-d3c4-4f07-839e-ec81c2587ae0.jpg?1",
             "name": "Resilient Roadrunner",
             "text": "Haste, protection from Coyotes\n{3}: Resilient Roadrunner can't be blocked this turn except by creatures with haste.",
             "colours": [
@@ -4853,7 +4853,7 @@
         },
         {
             "id": "3c810e8f-418b-5a55-87d1-2a870db401d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc02d1-799d-42aa-9bc2-4c05452b63b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cc02d1-799d-42aa-9bc2-4c05452b63b4.jpg?1",
             "name": "Return the Favor",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Copy target instant spell, sorcery spell, activated ability, or triggered ability. You may choose new targets for the copy.\n+ {1} \u2014 Change the target of target spell or ability with a single target.",
             "colours": [
@@ -4885,7 +4885,7 @@
         },
         {
             "id": "7c25120e-86aa-50bb-bb5c-eef189e2b96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df877a29-06e1-474d-8600-410bbec674ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df877a29-06e1-474d-8600-410bbec674ae.jpg?1",
             "name": "Rodeo Pyromancers",
             "text": "Whenever you cast your first spell each turn, add {R}{R}.",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "df6315ca-23a5-5738-aa05-c37c21a08c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d603c00f-048a-4a05-9df9-52844819d523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d603c00f-048a-4a05-9df9-52844819d523.jpg?1",
             "name": "Scalestorm Summoner",
             "text": "Whenever Scalestorm Summoner attacks, create a 3/1 red Dinosaur creature token if you control a creature with power 4 or greater.",
             "colours": [
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "f759dba3-5b11-5765-bce1-36996cd4e1ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d8357-83bd-4157-a389-68e4aa4985c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f93d8357-83bd-4157-a389-68e4aa4985c8.jpg?1",
             "name": "Scorching Shot",
             "text": "Scorching Shot deals 5 damage to target creature.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "4e5c20d3-bcfd-5b04-95c5-d3f203dd1261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054012b-4f9d-44a0-aaf9-7fd3bddc7b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7054012b-4f9d-44a0-aaf9-7fd3bddc7b2d.jpg?1",
             "name": "Slickshot Show-Off",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, Slickshot Show-Off gets +2/+0 until end of turn.\nPlot {1}{R} (You may pay {1}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "8fe466c5-73cf-5801-8025-beee6a65370b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg?1",
             "name": "Stingerback Terror",
             "text": "Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R} (You may pay {2}{R} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5063,7 +5063,7 @@
         },
         {
             "id": "f66d7854-f546-5640-beb3-d6b86bcc5afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e2ff9c-0e98-46f9-a33c-739388c5f3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e2ff9c-0e98-46f9-a33c-739388c5f3d0.jpg?1",
             "name": "Take for a Ride",
             "text": "Take for a Ride has flash as long as you've committed a crime this turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "1b5a18af-6f45-5e20-8e22-90f48d389774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ff94a-4db4-44a6-8593-89c32905b3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ff94a-4db4-44a6-8593-89c32905b3fc.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -5131,7 +5131,7 @@
         },
         {
             "id": "579da7ae-33cb-53f9-af34-fef8cb82a9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bf0ea9-0929-4d33-815a-6df29c399e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bf0ea9-0929-4d33-815a-6df29c399e7e.jpg?1",
             "name": "Thunder Salvo",
             "text": "Thunder Salvo deals X damage to target creature, where X is 2 plus the number of other spells you've cast this turn.",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "0577fa46-115e-5605-8710-4d5da5ea2ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3c2d02-67ca-4858-9b7a-3cfe8a08356c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3c2d02-67ca-4858-9b7a-3cfe8a08356c.jpg?1",
             "name": "Trick Shot",
             "text": "Trick Shot deals 6 damage to target creature and 2 damage to up to one other target creature token.",
             "colours": [
@@ -5195,7 +5195,7 @@
         },
         {
             "id": "5f9dbd63-183e-5ebe-9cfb-dcd09825be23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f2f632-b6cc-4092-acd5-a6b152e90488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f2f632-b6cc-4092-acd5-a6b152e90488.jpg?1",
             "name": "Aloe Alchemist",
             "text": "Trample\nWhen Aloe Alchemist becomes plotted, target creature gets +3/+2 and gains trample until end of turn.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "506621c5-5e9c-576f-8868-b9b0dea3cacd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424972d6-3b2c-449b-b786-749a77020fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424972d6-3b2c-449b-b786-749a77020fa1.jpg?1",
             "name": "Ankle Biter",
             "text": "Deathtouch",
             "colours": [
@@ -5264,7 +5264,7 @@
         },
         {
             "id": "8869ee04-278a-5126-aea3-56ebdfa535c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073b9ae8-8ac3-4824-aec4-84a80531aa23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/073b9ae8-8ac3-4824-aec4-84a80531aa23.jpg?1",
             "name": "Beastbond Outcaster",
             "text": "When Beastbond Outcaster enters the battlefield, if you control a creature with power 4 or greater, draw a card.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "44a33d09-096e-5c53-993c-b67b71f29679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c494820f-607d-4ed2-8a86-a916ae390272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c494820f-607d-4ed2-8a86-a916ae390272.jpg?1",
             "name": "Betrayal at the Vault",
             "text": "Target creature you control deals damage equal to its power to each of two other target creatures.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "8a6aaa2d-cd1a-5fee-9d16-2b58fae1ce51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aea6702-16a8-4073-9c83-fbea20a5fd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aea6702-16a8-4073-9c83-fbea20a5fd32.jpg?1",
             "name": "Bristlepack Sentry",
             "text": "Defender\nAs long as you control a creature with power 4 or greater, Bristlepack Sentry can attack as though it didn't have defender.",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "07c179ee-cccc-5809-a585-ec77cfced29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg?1",
             "name": "Bristly Bill, Spine Sower",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature.\n{3}{G}{G}: Double the number of +1/+1 counters on each creature you control.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "49f804f2-54ad-5a1a-890c-9279be7b7fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0e27f9-dc2c-4366-b810-3e8d0bdff8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e0e27f9-dc2c-4366-b810-3e8d0bdff8c3.jpg?1",
             "name": "Cactarantula",
             "text": "This spell costs {1} less to cast if you control a Desert.\nReach\nWhenever Cactarantula becomes the target of a spell or ability an opponent controls, you may draw a card.",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "36b94fee-df97-5220-8c47-fc457e47fa1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a104d3-e4ac-44a0-9c6a-39965b1b9751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a104d3-e4ac-44a0-9c6a-39965b1b9751.jpg?1",
             "name": "Colossal Rattlewurm",
             "text": "Colossal Rattlewurm has flash as long as you control a Desert.\nTrample\n{1}{G}, Exile Colossal Rattlewurm from your graveyard: Search your library for a Desert card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -5476,7 +5476,7 @@
         },
         {
             "id": "e4d8a4d3-7563-5edb-af70-7ced3411d419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf0e715-befb-4904-82e6-d3f8c7fbd454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf0e715-befb-4904-82e6-d3f8c7fbd454.jpg?1",
             "name": "Dance of the Tumbleweeds",
             "text": "Spree (Choose one or more additional costs.)\n+ {1} \u2014 Search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle.\n+ {3} \u2014 Create an X/X green Elemental creature token, where X is the number of lands you control.",
             "colours": [
@@ -5508,7 +5508,7 @@
         },
         {
             "id": "8b988ca8-0f5b-56c9-b025-3048141e798c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560062cd-34f8-4d30-9e25-099b03961724.jpg?1",
             "name": "Drover Grizzly",
             "text": "Whenever Drover Grizzly attacks while saddled, creatures you control gain trample until end of turn.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "dea1e717-4486-5f00-a209-393b50a2ef63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92762169-095e-46e2-82f6-5b2ff2232240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92762169-095e-46e2-82f6-5b2ff2232240.jpg?1",
             "name": "Freestrider Commando",
             "text": "Freestrider Commando enters the battlefield with two +1/+1 counters on it if it wasn't cast or no mana was spent to cast it.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "a5b0270e-8e2c-5772-a16b-4edf0791ee9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32370f05-52a2-405f-b2bb-1b8a9b0b69f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32370f05-52a2-405f-b2bb-1b8a9b0b69f8.jpg?1",
             "name": "Freestrider Lookout",
             "text": "Reach\nWhenever you commit a crime, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -5615,7 +5615,7 @@
         },
         {
             "id": "6265f979-8f66-5fb0-8b36-3e86e0321f70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084748d8-7169-4e86-a69c-631c6d7d3a1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084748d8-7169-4e86-a69c-631c6d7d3a1e.jpg?1",
             "name": "Full Steam Ahead",
             "text": "Until end of turn, each creature you control gets +2/+2 and gains trample and \"This creature can't be blocked by more than one creature.\"",
             "colours": [
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "5da250e3-57fe-52e7-a3a5-ff2c4fb3c7f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/919826a9-c427-42c6-8885-a87f0b6d2192.jpg?1",
             "name": "Giant Beaver",
             "text": "Vigilance\nWhenever Giant Beaver attacks while saddled, put a +1/+1 counter on target creature that saddled it this turn.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "940ca68c-b30a-52e3-a12f-af9e2e7e4407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15845be1-919d-4450-9de6-3552c52e8623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15845be1-919d-4450-9de6-3552c52e8623.jpg?1",
             "name": "Gold Rush",
             "text": "Create a Treasure token. Until end of turn, up to one target creature gets +2/+2 for each Treasure you control.",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "9afba958-eb26-5d06-af49-0cd814519c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0e01e4-e143-47fd-8565-7b48219bb546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0e01e4-e143-47fd-8565-7b48219bb546.jpg?1",
             "name": "Goldvein Hydra",
             "text": "Vigilance, trample, haste\nGoldvein Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Goldvein Hydra dies, create a number of tapped Treasure tokens equal to its power.",
             "colours": [
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "2ccd127c-f8c0-5772-8c5e-3be57163de3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe544fb-93b7-4640-b886-cb0b3e437357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe544fb-93b7-4640-b886-cb0b3e437357.jpg?1",
             "name": "Hardbristle Bandit",
             "text": "{T}: Add one mana of any color.\nWhenever you commit a crime, untap Hardbristle Bandit. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "cde225f0-bb16-535c-8362-2c8e1b38bbe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cdf2a-026a-41ba-87d9-8fcd8a67f06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6cdf2a-026a-41ba-87d9-8fcd8a67f06e.jpg?1",
             "name": "Intrepid Stablemaster",
             "text": "Reach\n{T}: Add {G}.\n{T}: Add two mana of any one color. Spend this mana only to cast Mount or Vehicle spells.",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "11b0c798-f40b-57bf-97be-40b191741428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165f4428-e1a1-477d-bd90-138189e88163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165f4428-e1a1-477d-bd90-138189e88163.jpg?1",
             "name": "Map the Frontier",
             "text": "Search your library for up to two basic land cards and/or Desert cards, put them onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "7e8cc9df-0abe-5bc7-b4c4-ef443f842aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020c31b-002a-4121-bc61-2c2c16e9afc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0020c31b-002a-4121-bc61-2c2c16e9afc8.jpg?1",
             "name": "Ornery Tumblewagg",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature.\nWhenever Ornery Tumblewagg attacks while saddled, double the number of +1/+1 counters on target creature.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "155b13f5-3924-5b18-876f-32d8aadcc27b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9458f0f-5593-4ac9-934c-e215ef8093a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9458f0f-5593-4ac9-934c-e215ef8093a7.jpg?1",
             "name": "Outcaster Greenblade",
             "text": "When Outcaster Greenblade enters the battlefield, search your library for a basic land card or a Desert card, reveal it, put it into your hand, then shuffle.\nOutcaster Greenblade gets +1/+1 for each Desert you control.",
             "colours": [
@@ -5924,7 +5924,7 @@
         },
         {
             "id": "e2312b37-e75b-5d7e-8176-c469f3b69381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b9cd6c-d75c-4905-aa38-ff03a9c4b398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b9cd6c-d75c-4905-aa38-ff03a9c4b398.jpg?1",
             "name": "Outcaster Trailblazer",
             "text": "When Outcaster Trailblazer enters the battlefield, add one mana of any color.\nWhenever another creature with power 4 or greater enters the battlefield under your control, draw a card.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -5961,7 +5961,7 @@
         },
         {
             "id": "7f11140c-02fd-5819-8c37-0e60be9b0dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd17cea-9e8c-4dba-b6ab-a6b9de87a306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd17cea-9e8c-4dba-b6ab-a6b9de87a306.jpg?1",
             "name": "Patient Naturalist",
             "text": "When Patient Naturalist enters the battlefield, mill three cards. Put a land card from among the milled cards into your hand. If you can't, create a Treasure token. (To mill three cards, put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -5996,7 +5996,7 @@
         },
         {
             "id": "15ad0296-af37-5345-b1fe-98eb73c0bd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec1f76f-f21d-4f06-8c02-be6745183348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec1f76f-f21d-4f06-8c02-be6745183348.jpg?1",
             "name": "Railway Brawler",
             "text": "Reach, trample\nWhenever another creature enters the battlefield under your control, put X +1/+1 counters on it, where X is its power.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "f7aab77f-5824-5f00-a0b1-5f267c753446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1e75f-0fee-4e07-9420-df771b696e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d1e75f-0fee-4e07-9420-df771b696e85.jpg?1",
             "name": "Rambling Possum",
             "text": "Whenever Rambling Possum attacks while saddled, it gets +1/+2 until end of turn. Then you may return any number of creatures that saddled it this turn to their owner's hand.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6068,7 +6068,7 @@
         },
         {
             "id": "2aed3065-a688-557e-a5c3-64bd7097c392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3cbfe-410f-40e3-8021-647a2efb50bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc3cbfe-410f-40e3-8021-647a2efb50bf.jpg?1",
             "name": "Raucous Entertainer",
             "text": "{1}, {T}: Put a +1/+1 counter on each creature you control that entered the battlefield this turn.",
             "colours": [
@@ -6103,7 +6103,7 @@
         },
         {
             "id": "249524a9-8b7b-5556-b425-9b6f11206f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb871985-a11b-4dfe-b0e3-898888c86277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb871985-a11b-4dfe-b0e3-898888c86277.jpg?1",
             "name": "Reach for the Sky",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +3/+2 and has reach.\nWhen Reach for the Sky is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -6137,7 +6137,7 @@
         },
         {
             "id": "b5cd0a40-fa2d-565e-8698-78bc40d1c6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e879d8-a058-48e8-9733-f58b1e0da4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e879d8-a058-48e8-9733-f58b1e0da4b9.jpg?1",
             "name": "Rise of the Varmints",
             "text": "Create X 2/1 green Varmint creature tokens, where X is the number of creature cards in your graveyard.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "039dba5d-26b1-509c-bd08-01ad3d64db58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg?1",
             "name": "Smuggler's Surprise",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Mill four cards. You may put up to two creature and/or land cards from among the milled cards into your hand.\n+ {4}{G} \u2014 You may put up to two creature cards from your hand onto the battlefield.\n+ {1} \u2014 Creatures you control with power 4 or greater gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -6203,7 +6203,7 @@
         },
         {
             "id": "b6ce5910-fae4-5e8d-b7e6-c0ab6277a4b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133fbdec-0d00-433f-9015-5eb091126e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/133fbdec-0d00-433f-9015-5eb091126e3a.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "8ca7c170-b5f2-5967-a408-bc63df024500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d63e7-a8c6-4750-91c9-c575a4d0561b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f79d63e7-a8c6-4750-91c9-c575a4d0561b.jpg?1",
             "name": "Spinewoods Armadillo",
             "text": "Reach\nWard {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\n{1}{G}, Discard Spinewoods Armadillo: Search your library for a basic land card or a Desert card, reveal it, put it into your hand, then shuffle. You gain 3 life.",
             "colours": [
@@ -6269,7 +6269,7 @@
         },
         {
             "id": "473e698b-c2df-5d69-beda-7c26e32d1ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b432d-9e73-4ab2-a098-546d406df6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b432d-9e73-4ab2-a098-546d406df6c0.jpg?1",
             "name": "Spinewoods Paladin",
             "text": "Trample\nWhen Spinewoods Paladin enters the battlefield, you gain 3 life.\nPlot {3}{G} (You may pay {3}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6304,7 +6304,7 @@
         },
         {
             "id": "25e0b514-dbb5-5857-87fd-752498323ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963eb4-d20b-4d3f-bf5d-c75f7bcb9670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d963eb4-d20b-4d3f-bf5d-c75f7bcb9670.jpg?1",
             "name": "Stubborn Burrowfiend",
             "text": "Whenever Stubborn Burrowfiend becomes saddled for the first time each turn, mill two cards, then Stubborn Burrowfiend gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.\nSaddle 2 (Tap any number of other creatures you control with total power 2 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "9fbf48da-0efd-57ae-980f-abbcf1fa42e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775874cc-4b78-4904-9c97-431c2e400c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/775874cc-4b78-4904-9c97-431c2e400c64.jpg?1",
             "name": "Throw from the Saddle",
             "text": "Target creature you control gets +1/+1 until end of turn. Put a +1/+1 counter on it instead if it's a Mount. Then it deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -6372,7 +6372,7 @@
         },
         {
             "id": "72335408-bae7-572b-b9f0-a6cc2629e8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda59f99-1d6d-4051-ac89-b7cbfa19262e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda59f99-1d6d-4051-ac89-b7cbfa19262e.jpg?1",
             "name": "Trash the Town",
             "text": "Spree (Choose one or more additional costs.)\n+ {2} \u2014 Put two +1/+1 counters on target creature.\n+ {1} \u2014 Target creature gains trample until end of turn.\n+ {1} \u2014 Until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, draw two cards.\"",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "9eba0ad1-70e0-5785-a1e9-bd51e880af5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d2d2a-ef85-48c9-919d-bc62cdad8a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275d2d2a-ef85-48c9-919d-bc62cdad8a10.jpg?1",
             "name": "Tumbleweed Rising",
             "text": "Create an X/X green Elemental creature token, where X is the greatest power among creatures you control.\nPlot {2}{G} (You may pay {2}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -6436,7 +6436,7 @@
         },
         {
             "id": "67a0624b-7ec6-5e0f-9f67-5a439d5cd0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b74fa3-c1d7-4780-977d-f2d6663a529a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b74fa3-c1d7-4780-977d-f2d6663a529a.jpg?1",
             "name": "Voracious Varmint",
             "text": "Vigilance\n{1}, Sacrifice Voracious Varmint: Destroy target artifact or enchantment.",
             "colours": [
@@ -6470,7 +6470,7 @@
         },
         {
             "id": "2a1e3689-8b05-5fda-8d3a-64e5c51f7267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fd8548-50db-4243-9154-377f32408d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fd8548-50db-4243-9154-377f32408d58.jpg?1",
             "name": "Akul the Unrepentant",
             "text": "Flying, trample\nSacrifice three other creatures: You may put a creature card from your hand onto the battlefield. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "63c69341-9c62-550f-994e-8ec0ab0c0c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4af7c3-a70d-4f71-b27d-b268c4a0f81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4af7c3-a70d-4f71-b27d-b268c4a0f81e.jpg?1",
             "name": "Annie Flash, the Veteran",
             "text": "Flash\nWhen Annie Flash, the Veteran enters the battlefield, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\nWhenever Annie Flash becomes tapped, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -6555,7 +6555,7 @@
         },
         {
             "id": "9aef13e5-8840-53e9-aafa-c5e5e6c76d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1624a5f4-f5bc-47c9-85de-c5520ee234ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1624a5f4-f5bc-47c9-85de-c5520ee234ce.jpg?1",
             "name": "Annie Joins Up",
             "text": "When Annie Joins Up enters the battlefield, it deals 5 damage to target creature or planeswalker an opponent controls.\nIf a triggered ability of a legendary creature you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -6595,7 +6595,7 @@
         },
         {
             "id": "ecc33a9b-f28e-55d3-85f5-02db00939ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bf3c6-e46f-48f8-902f-82deeba260b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014bf3c6-e46f-48f8-902f-82deeba260b2.jpg?1",
             "name": "Assimilation Aegis",
             "text": "When Assimilation Aegis enters the battlefield, exile up to one target creature until Assimilation Aegis leaves the battlefield.\nWhenever Assimilation Aegis becomes attached to a creature, for as long as Assimilation Aegis remains attached to it, that creature becomes a copy of a creature card exiled with Assimilation Aegis.\nEquip {2}",
             "colours": [
@@ -6633,7 +6633,7 @@
         },
         {
             "id": "47f2095a-8fe2-5cda-84a2-8ed93b497f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897d594d-b5b0-43dc-b877-b483942416ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897d594d-b5b0-43dc-b877-b483942416ce.jpg?1",
             "name": "At Knifepoint",
             "text": "As long as it's your turn, outlaws you control have first strike. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)\nWhenever you commit a crime, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\" This ability triggers only once each turn.",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "d7db4361-843d-5179-b214-a1dc8d4edfaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ef971-cdd4-410c-97c3-df98e4f02ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3ef971-cdd4-410c-97c3-df98e4f02ab2.jpg?1",
             "name": "Badlands Revival",
             "text": "Return up to one target creature card from your graveyard to the battlefield. Return up to one target permanent card from your graveyard to your hand.",
             "colours": [
@@ -6701,7 +6701,7 @@
         },
         {
             "id": "bc227a25-bed3-574d-b50f-862b0a396830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9da18b4-1efc-44b7-8001-a2cfd44c69bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9da18b4-1efc-44b7-8001-a2cfd44c69bf.jpg?1",
             "name": "Baron Bertram Graywater",
             "text": "Whenever one or more tokens enter the battlefield under your control, create a 1/1 black Vampire Rogue creature token with lifelink. This ability triggers only once each turn.\n{1}{B}, Sacrifice another creature or artifact: Draw a card.",
             "colours": [
@@ -6740,7 +6740,7 @@
         },
         {
             "id": "414229fc-4402-5f91-b6aa-4bbc2d43cf68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383ae7c-58ea-4354-93e4-677ad185c3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383ae7c-58ea-4354-93e4-677ad185c3bb.jpg?1",
             "name": "Bonny Pall, Clearcutter",
             "text": "Reach\nWhen Bonny Pall, Clearcutter enters the battlefield, create Beau, a legendary blue Ox creature token with \"This creature's power and toughness are each equal to the number of lands you control.\"\nWhenever you attack, draw a card, then you may put a land card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "3b568273-ccce-57b3-b080-4966a1884063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3bda9e-42af-4f99-a504-c96c25c2794b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf3bda9e-42af-4f99-a504-c96c25c2794b.jpg?1",
             "name": "Breeches, the Blastmaker",
             "text": "Menace\nWhenever you cast your second spell each turn, you may sacrifice an artifact. If you do, flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy. When you lose the flip, Breeches, the Blastmaker deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -6822,7 +6822,7 @@
         },
         {
             "id": "42586fcf-de1a-5e18-aeea-f04c5c83f8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286c55c2-dcc1-4e87-a83f-9981d28ab62d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/286c55c2-dcc1-4e87-a83f-9981d28ab62d.jpg?1",
             "name": "Bruse Tarl, Roving Rancher",
             "text": "Oxen you control have double strike.\nWhenever Bruse Tarl, Roving Rancher enters the battlefield or attacks, exile the top card of your library. If it's a land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the end of your next turn.",
             "colours": [
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "d599451d-baeb-558e-ae28-e9c028853235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b8c5d-9fb0-488f-9b32-c2e29d1f1dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318b8c5d-9fb0-488f-9b32-c2e29d1f1dbb.jpg?1",
             "name": "Cactusfolk Sureshot",
             "text": "Reach\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of combat on your turn, other creatures you control with power 4 or greater gain trample and haste until end of turn.",
             "colours": [
@@ -6900,7 +6900,7 @@
         },
         {
             "id": "a2affdb1-5cff-545c-a0c8-130f650eb7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef4907a-2fc1-42c5-bffc-3b3f93601fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef4907a-2fc1-42c5-bffc-3b3f93601fb9.jpg?1",
             "name": "Congregation Gryff",
             "text": "Flying, lifelink\nWhenever Congregation Gryff attacks while saddled, it gets +X/+X until end of turn, where X is the number of Mounts you control.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -6937,7 +6937,7 @@
         },
         {
             "id": "1a832995-af20-54e2-a5a6-232da74b1fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc27b30-8c8e-434c-a72c-e1d409efc1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc27b30-8c8e-434c-a72c-e1d409efc1ae.jpg?1",
             "name": "Doc Aurlock, Grizzled Genius",
             "text": "Spells you cast from your graveyard or from exile cost {2} less to cast.\nPlotting cards from your hand costs {2} less.",
             "colours": [
@@ -6976,7 +6976,7 @@
         },
         {
             "id": "e65d431e-8163-5977-852a-fb22ed6e59d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46c133a-7ae4-431b-88f2-ec606a7baf69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46c133a-7ae4-431b-88f2-ec606a7baf69.jpg?1",
             "name": "Eriette, the Beguiler",
             "text": "Lifelink\nWhenever an Aura you control becomes attached to a nonland permanent an opponent controls with mana value less than or equal to that Aura's mana value, gain control of that permanent for as long as that Aura is attached to it.",
             "colours": [
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "c10612eb-65e3-5e31-aa3d-ab9353787d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e81be6-6447-4f1e-be00-6fcdb2ab35af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e81be6-6447-4f1e-be00-6fcdb2ab35af.jpg?1",
             "name": "Ertha Jo, Frontier Mentor",
             "text": "When Ertha Jo, Frontier Mentor enters the battlefield, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\nWhenever you activate an ability that targets a creature or player, copy that ability. You may choose new targets for the copy.",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "cf0f74ea-455c-5472-a87a-588cd8456f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee1387-c24e-4a66-8ad6-9afa9c0abcbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee1387-c24e-4a66-8ad6-9afa9c0abcbb.jpg?1",
             "name": "Form a Posse",
             "text": "Create X 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "7801e062-e505-5840-bf11-84555d5d8879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e3d71-4fb8-4ab1-8c8f-b65ae3ad4cc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e3d71-4fb8-4ab1-8c8f-b65ae3ad4cc4.jpg?1",
             "name": "Ghired, Mirror of the Wilds",
             "text": "Haste\nNontoken creatures you control have \"{T}: Create a token that's a copy of target token you control that entered the battlefield this turn.\"",
             "colours": [
@@ -7135,7 +7135,7 @@
         },
         {
             "id": "77b1a414-68da-5ff7-a7ec-fe26d2ffd979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82512813-8618-483b-a7f0-e6a611d9d487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82512813-8618-483b-a7f0-e6a611d9d487.jpg?1",
             "name": "The Gitrog, Ravenous Ride",
             "text": "Trample, haste\nWhenever The Gitrog, Ravenous Ride deals combat damage to a player, you may sacrifice a creature that saddled it this turn. If you do, draw X cards, then put up to X land cards from your hand onto the battlefield tapped, where X is the sacrificed creature's power.\nSaddle 1",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "505b089d-cd9c-5392-a4eb-cc7c3b8a3202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ddf66-76af-4857-83c3-c812327a6e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259ddf66-76af-4857-83c3-c812327a6e23.jpg?1",
             "name": "Honest Rutstein",
             "text": "When Honest Rutstein enters the battlefield, return target creature card from your graveyard to your hand.\nCreature spells you cast cost {1} less to cast.",
             "colours": [
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "53a0b44a-ffeb-5d17-bebc-170630b2e387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596fb7a2-bb79-44b7-ad84-414c8139ec13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596fb7a2-bb79-44b7-ad84-414c8139ec13.jpg?1",
             "name": "Intimidation Campaign",
             "text": "When Intimidation Campaign enters the battlefield, each opponent loses 1 life, you gain 1 life, and you draw a card.\nWhenever you commit a crime, you may return Intimidation Campaign to its owner's hand. (It returns only from the battlefield. Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -7252,7 +7252,7 @@
         },
         {
             "id": "03a6d69c-0a5c-5421-9458-8e03348e0b35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe6dc-662a-4abc-ad60-a1959b2be006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24fe6dc-662a-4abc-ad60-a1959b2be006.jpg?1",
             "name": "Jem Lightfoote, Sky Explorer",
             "text": "Flying, vigilance\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, draw a card.",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "161475f1-44d1-5321-aeea-fcd7fce6dceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe30b5c8-4889-4350-bb1d-3e2a67d9dfb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe30b5c8-4889-4350-bb1d-3e2a67d9dfb2.jpg?1",
             "name": "Jolene, Plundering Pugilist",
             "text": "Whenever you attack with one or more creatures with power 4 or greater, create a Treasure token.\n{1}{R}, Sacrifice a Treasure: Jolene, Plundering Pugilist deals 1 damage to any target.",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "b3b8a077-0d38-59e7-a1ca-b3d1fa9256a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a775d-5898-41a8-b404-9b7d4721c6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a775d-5898-41a8-b404-9b7d4721c6ba.jpg?1",
             "name": "Kambal, Profiteering Mayor",
             "text": "Whenever one or more tokens enter the battlefield under your opponents' control, for each of them, create a tapped token that's a copy of it. This ability triggers only once each turn.\nWhenever one or more tokens enter the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7371,7 +7371,7 @@
         },
         {
             "id": "6117548b-f0fa-5563-ae6f-24927818fcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f95d5-b279-4469-9c89-1e02630d61e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7f95d5-b279-4469-9c89-1e02630d61e6.jpg?1",
             "name": "Kellan Joins Up",
             "text": "When Kellan Joins Up enters the battlefield, you may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted. (You may cast it as a sorcery on a later turn without paying its mana cost.)\nWhenever a legendary creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -7411,7 +7411,7 @@
         },
         {
             "id": "83d76712-309f-532d-bbd6-d92a3b0870d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfbc4c-ab21-45db-bbd9-b9d245d60015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfbc4c-ab21-45db-bbd9-b9d245d60015.jpg?1",
             "name": "Kellan, the Kid",
             "text": "Flying, lifelink\nWhenever you cast a spell from anywhere other than your hand, you may cast a permanent spell with equal or lesser mana value from your hand without paying its mana cost. If you don't, you may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "c47f19d2-13ed-52ec-8140-ca3db5ce6c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a3e6b-7e20-40ea-8b2c-7c728934b5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958a3e6b-7e20-40ea-8b2c-7c728934b5e5.jpg?1",
             "name": "Kraum, Violent Cacophony",
             "text": "Flying\nWhenever you cast your second spell each turn, put a +1/+1 counter on Kraum, Violent Cacophony and draw a card.",
             "colours": [
@@ -7494,7 +7494,7 @@
         },
         {
             "id": "7d3a9a2d-ce43-5846-a922-4fc69d2a5c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0b3a41-ba99-41e8-bcfb-5796500c17c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af0b3a41-ba99-41e8-bcfb-5796500c17c7.jpg?1",
             "name": "Laughing Jasper Flint",
             "text": "Creatures you control but don't own are Mercenaries in addition to their other types.\nAt the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "53743464-3b9a-5286-9c1b-d9e5a93cd875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00293326-3eb2-492c-b565-7abafa037d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00293326-3eb2-492c-b565-7abafa037d8c.jpg?1",
             "name": "Lazav, Familiar Stranger",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Lazav, Familiar Stranger. Then you may exile a card from a graveyard. If a creature card was exiled this way, you may have Lazav become a copy of that card until end of turn. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "4516f6eb-d3da-597e-bb9c-948406e53c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f90ea-5934-4757-8515-38ef116afac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21f90ea-5934-4757-8515-38ef116afac1.jpg?1",
             "name": "Lilah, Undefeated Slickshot",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a multicolored instant or sorcery spell from your hand, exile that spell instead of putting it into your graveyard as it resolves. If you do, it becomes plotted. (You may cast it as a sorcery on a later turn without paying its mana cost.)",
             "colours": [
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "81fdbf09-082d-51a0-881f-ced09710aecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0557b0a3-2b48-408f-a508-9f4da2ab1cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0557b0a3-2b48-408f-a508-9f4da2ab1cd1.jpg?1",
             "name": "Make Your Own Luck",
             "text": "Look at the top three cards of your library. You may exile a nonland card from among them. If you do, it becomes plotted. Put the rest into your hand. (You may cast it as a sorcery on a later turn without paying its mana cost.)",
             "colours": [
@@ -7650,7 +7650,7 @@
         },
         {
             "id": "d6788c4f-63fa-5749-aace-bd5cb8f4a60e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521dffaa-813b-41e4-b7c2-a8c407167875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521dffaa-813b-41e4-b7c2-a8c407167875.jpg?1",
             "name": "Malcolm, the Eyes",
             "text": "Flying, haste\nWhenever you cast your second spell each turn, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7691,7 +7691,7 @@
         },
         {
             "id": "d3dadd18-1576-5f7f-8b1e-d263e56b1f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29b59c-d57c-4a03-bae7-e9dfa57d6bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29b59c-d57c-4a03-bae7-e9dfa57d6bb1.jpg?1",
             "name": "Marchesa, Dealer of Death",
             "text": "Whenever you commit a crime, you may pay {1}. If you do, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
             "colours": [
@@ -7734,7 +7734,7 @@
         },
         {
             "id": "55cf8d51-fc20-5731-adfb-05cf55748e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa7750a-7c32-4413-b762-62e24d992c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa7750a-7c32-4413-b762-62e24d992c6b.jpg?1",
             "name": "Miriam, Herd Whisperer",
             "text": "As long as it's your turn, Mounts and Vehicles you control have hexproof.\nWhenever a Mount or Vehicle you control attacks, put a +1/+1 counter on it.",
             "colours": [
@@ -7773,7 +7773,7 @@
         },
         {
             "id": "e98d734c-0e80-5486-b91f-fea9b0c0e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03415c42-086e-4a2e-9be8-5cdcde83f134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03415c42-086e-4a2e-9be8-5cdcde83f134.jpg?1",
             "name": "Obeka, Splitter of Seconds",
             "text": "Menace\nWhenever Obeka, Splitter of Seconds deals combat damage to a player, you get that many additional upkeep steps after this phase.",
             "colours": [
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "43bde815-4d50-5aa0-b03f-537f637ed158",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396df8d6-e85d-4486-8116-68841b7e1e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396df8d6-e85d-4486-8116-68841b7e1e2e.jpg?1",
             "name": "Oko, the Ringleader",
             "text": "At the beginning of combat on your turn, Oko, the Ringleader becomes a copy of up to one target creature you control until end of turn, except he has hexproof.\n+1: Draw two cards. If you've committed a crime this turn, discard a card. Otherwise, discard two cards.\n\u22121: Create a 3/3 green Elk creature token.\n\u22125: For each other nonland permanent you control, create a token that's a copy of that permanent.",
             "colours": [
@@ -7857,7 +7857,7 @@
         },
         {
             "id": "52fb4bff-218d-57ea-b6d8-f1487edd55ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b415f-7901-4ab4-84fe-60b90d40ac90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3b415f-7901-4ab4-84fe-60b90d40ac90.jpg?1",
             "name": "Pillage the Bog",
             "text": "Look at the top X cards of your library, where X is twice the number of lands you control. Put one of them into your hand and the rest on the bottom of your library in a random order.\nPlot {1}{B}{G} (You may pay {1}{B}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
             "colours": [
@@ -7893,7 +7893,7 @@
         },
         {
             "id": "1f112cdf-6eb5-5092-85bd-154c855e9eec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7154dca-7e10-4c34-aa56-9f200c6277d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7154dca-7e10-4c34-aa56-9f200c6277d1.jpg?1",
             "name": "Rakdos Joins Up",
             "text": "When Rakdos Joins Up enters the battlefield, return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it.\nWhenever a legendary creature you control dies, Rakdos Joins Up deals damage equal to that creature's power to target opponent.",
             "colours": [
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "2d69fb61-7549-5cde-8cce-c2b3e05d70d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb34babd-1b85-4a7d-a066-a8337805056e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb34babd-1b85-4a7d-a066-a8337805056e.jpg?1",
             "name": "Rakdos, the Muscle",
             "text": "Flying, trample\nWhenever you sacrifice another creature, exile cards equal to its mana value from the top of target player's library. Until your next end step, you may play those cards, and mana of any type can be spent to cast those spells.\nSacrifice another creature: Rakdos, the Muscle gains indestructible until end of turn. Tap it. Activate only once each turn.",
             "colours": [
@@ -7972,7 +7972,7 @@
         },
         {
             "id": "901775e5-e3cf-524c-93d8-0ec0550876fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b63544-4c31-4f38-9907-0407719a60b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b63544-4c31-4f38-9907-0407719a60b1.jpg?1",
             "name": "Riku of Many Paths",
             "text": "Whenever you cast a modal spell, choose up to X, where X is the number of times you chose a mode for that spell \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play it.\n\u2022 Put a +1/+1 counter on Riku of Many Paths. It gains trample until end of turn.\n\u2022 Create a 1/1 blue Bird creature token with flying.",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "44052fb9-2122-547b-bab9-dfe6c33ed965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbe52f-febd-49fc-8391-28d3efe9c3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11fbe52f-febd-49fc-8391-28d3efe9c3eb.jpg?1",
             "name": "Roxanne, Starfall Savant",
             "text": "Whenever Roxanne, Starfall Savant enters the battlefield or attacks, create a tapped colorless artifact token named Meteorite with \"When Meteorite enters the battlefield, it deals 2 damage to any target\" and \"{T}: Add one mana of any color.\"\nWhenever you tap an artifact token for mana, add one mana of any type that artifact token produced.",
             "colours": [
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "17d238bd-d4cd-53fd-a907-70248c201c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927b5498-23f1-47c0-b441-7daaeb54f9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927b5498-23f1-47c0-b441-7daaeb54f9b8.jpg?1",
             "name": "Ruthless Lawbringer",
             "text": "When Ruthless Lawbringer enters the battlefield, you may sacrifice another creature. When you do, destroy target nonland permanent.",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "f4b24a37-9628-5c04-9bad-94862992ef90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9a5cc-2b3c-4c2f-8176-4a2d86265cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc9a5cc-2b3c-4c2f-8176-4a2d86265cc5.jpg?1",
             "name": "Satoru, the Infiltrator",
             "text": "Menace\nWhenever Satoru, the Infiltrator and/or one or more other nontoken creatures enter the battlefield under your control, if none of them were cast or no mana was spent to cast them, draw a card.",
             "colours": [
@@ -8137,7 +8137,7 @@
         },
         {
             "id": "f193c0f0-b9d8-5ab1-bd1a-953085e099dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2e167f-7cb2-4f15-a1db-7ee56b7ba523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2e167f-7cb2-4f15-a1db-7ee56b7ba523.jpg?1",
             "name": "Selvala, Eager Trailblazer",
             "text": "Vigilance\nWhenever you cast a creature spell, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{T}: Choose a color. Add one mana of that color for each different power among creatures you control.",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "8198d164-d5b1-57c3-8bc3-b296196384e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ada7ab4-0dee-4ff3-9817-1e61ca3f2ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ada7ab4-0dee-4ff3-9817-1e61ca3f2ccf.jpg?1",
             "name": "Seraphic Steed",
             "text": "First strike, lifelink\nWhenever Seraphic Steed attacks while saddled, create a 3/3 white Angel creature token with flying.\nSaddle 4 (Tap any number of other creatures you control with total power 4 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
             "colours": [
@@ -8217,7 +8217,7 @@
         },
         {
             "id": "cf710bb7-5f65-5e52-9560-955bd96c36a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb1c974-0d35-4e9f-a310-44eb2af64494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beb1c974-0d35-4e9f-a310-44eb2af64494.jpg?1",
             "name": "Slick Sequence",
             "text": "Slick Sequence deals 2 damage to any target. If you've cast another spell this turn, draw a card.",
             "colours": [
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "5581b583-952c-5d2f-b68f-e58bbd279980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1643af0b-fcbf-4636-8c50-77ec77eaa34d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1643af0b-fcbf-4636-8c50-77ec77eaa34d.jpg?1",
             "name": "Taii Wakeen, Perfect Shot",
             "text": "Whenever a source you control deals noncombat damage to a creature equal to that creature's toughness, draw a card.\n{X}, {T}: If a source you control would deal noncombat damage to a permanent or player this turn, it deals that much damage plus X instead.",
             "colours": [
@@ -8292,7 +8292,7 @@
         },
         {
             "id": "ac80a80a-0f02-5e49-9c23-644f5a87f5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afce4e6-ac59-4fba-b63a-8fed96bbdc4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afce4e6-ac59-4fba-b63a-8fed96bbdc4a.jpg?1",
             "name": "Vial Smasher, Gleeful Grenadier",
             "text": "Whenever another outlaw enters the battlefield under your control, Vial Smasher, Gleeful Grenadier deals 1 damage to target opponent. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws.)",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "617d238b-be5a-5ab3-8e30-fa121d56a988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e546c2-737e-4b17-bf60-3069b1ccdf31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e546c2-737e-4b17-bf60-3069b1ccdf31.jpg?1",
             "name": "Vraska Joins Up",
             "text": "When Vraska Joins Up enters the battlefield, put a deathtouch counter on each creature you control.\nWhenever a legendary creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -8369,7 +8369,7 @@
         },
         {
             "id": "9f774fd5-aef8-5f4b-b9cb-f4bb280864ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b042abf2-c40b-4235-a4fa-2e4901c375c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b042abf2-c40b-4235-a4fa-2e4901c375c3.jpg?1",
             "name": "Vraska, the Silencer",
             "text": "Deathtouch\nWhenever a nontoken creature an opponent controls dies, you may pay {1}. If you do, return that card to the battlefield tapped under your control. It's a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other card types.",
             "colours": [
@@ -8410,7 +8410,7 @@
         },
         {
             "id": "cf4cec8f-c124-5255-bf66-799d6fd3fe93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d163dd-67dc-4aab-afb9-d043352d109c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d163dd-67dc-4aab-afb9-d043352d109c.jpg?1",
             "name": "Wrangler of the Damned",
             "text": "Flash\nAt the beginning of your end step, if you haven't cast a spell from your hand this turn, create a 2/2 white Spirit creature token with flying.",
             "colours": [
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "698e6144-a907-577d-babc-9511c405e2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc97ffcf-4f51-44cd-8daa-a7dae4592ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc97ffcf-4f51-44cd-8daa-a7dae4592ee5.jpg?1",
             "name": "Wylie Duke, Atiin Hero",
             "text": "Vigilance\nWhenever Wylie Duke, Atiin Hero becomes tapped, you gain 1 life and draw a card.",
             "colours": [
@@ -8488,7 +8488,7 @@
         },
         {
             "id": "ed6a1c96-5c4e-5cb7-9473-b5b3b49a43e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b2e74b-933b-4285-963b-dda3a986a914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b2e74b-933b-4285-963b-dda3a986a914.jpg?1",
             "name": "Bandit's Haul",
             "text": "Whenever you commit a crime, put a loot counter on Bandit's Haul. This ability triggers only once each turn. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)\n{T}: Add one mana of any color.\n{2}, {T}, Remove two loot counters from Bandit's Haul: Draw a card.",
             "colours": [],
@@ -8516,7 +8516,7 @@
         },
         {
             "id": "37c0e4d8-6d8c-51b9-8b16-776cb599bc97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61d964-6d73-422e-9e08-360ac66f237a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea61d964-6d73-422e-9e08-360ac66f237a.jpg?1",
             "name": "Boom Box",
             "text": "{6}, {T}, Sacrifice Boom Box: Destroy up to one target artifact, up to one target creature, and up to one target land.",
             "colours": [],
@@ -8544,7 +8544,7 @@
         },
         {
             "id": "e370b834-21ca-5fdf-9a01-0bef8a706765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098aae-3d9b-453b-a37e-e102f81a8311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098aae-3d9b-453b-a37e-e102f81a8311.jpg?1",
             "name": "Gold Pan",
             "text": "When Gold Pan enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "c80f2a52-32ca-5203-a3c3-7fcc6856c2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50709de-e6ef-4dbc-af1e-290fed279f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50709de-e6ef-4dbc-af1e-290fed279f34.jpg?1",
             "name": "Lavaspur Boots",
             "text": "Equipped creature gets +1/+0 and has haste and ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nEquip {1}",
             "colours": [],
@@ -8604,7 +8604,7 @@
         },
         {
             "id": "9d7785d3-9b33-5a02-8645-1a3ab485f2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc598338-eeba-4815-a0a6-ff2dc09790d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc598338-eeba-4815-a0a6-ff2dc09790d2.jpg?1",
             "name": "Luxurious Locomotive",
             "text": "Whenever Luxurious Locomotive attacks, create a Treasure token for each creature that crewed it this turn. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nCrew 1. Activate only once each turn. (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8634,7 +8634,7 @@
         },
         {
             "id": "49e5eaf9-9a3f-5561-9982-58db55a14f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg?1",
             "name": "Mobile Homestead",
             "text": "Mobile Homestead has haste as long as you control a Mount.\nWhenever Mobile Homestead attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8664,7 +8664,7 @@
         },
         {
             "id": "4db39578-34df-5b4d-9c70-df997b68a764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0dc663-4bfb-46d4-af79-d0143c799487.jpg?1",
             "name": "Oasis Gardener",
             "text": "When Oasis Gardener enters the battlefield, you gain 2 life.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8695,7 +8695,7 @@
         },
         {
             "id": "e87829ae-9eeb-5e8c-9069-8d70b1c267f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb98381-8418-4dfd-b7d1-4353570e611b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb98381-8418-4dfd-b7d1-4353570e611b.jpg?1",
             "name": "Redrock Sentinel",
             "text": "Defender\n{2}, {T}, Sacrifice a land: Draw a card and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -8726,7 +8726,7 @@
         },
         {
             "id": "1bf65224-db5d-591f-8e11-9db9436853ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d2c11d-1eb8-4768-bc61-fa8f20a69462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d2c11d-1eb8-4768-bc61-fa8f20a69462.jpg?1",
             "name": "Silver Deputy",
             "text": "When Silver Deputy enters the battlefield, you may search your library for a basic land card or a Desert card, reveal it, then shuffle and put it on top.\n{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -8757,7 +8757,7 @@
         },
         {
             "id": "31c9f2f8-06d3-5ea1-a3c5-524bb730e6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5bfcf5-6e5c-47fe-af6c-6b18938261c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5bfcf5-6e5c-47fe-af6c-6b18938261c6.jpg?1",
             "name": "Sterling Hound",
             "text": "When Sterling Hound enters the battlefield, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [],
@@ -8788,7 +8788,7 @@
         },
         {
             "id": "e3ba7f66-f444-50fe-bc99-3d4bafaf2587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e61cb8-219a-4fe6-a2e6-307665ffa38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e61cb8-219a-4fe6-a2e6-307665ffa38f.jpg?1",
             "name": "Tomb Trawler",
             "text": "{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -8819,7 +8819,7 @@
         },
         {
             "id": "f5d34872-c33b-578d-b82f-3667c0838cd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e96521-b4ce-4a36-a887-200e05ccc804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e96521-b4ce-4a36-a887-200e05ccc804.jpg?1",
             "name": "Abraded Bluffs",
             "text": "Abraded Bluffs enters the battlefield tapped.\nWhen Abraded Bluffs enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "78e6b942-1709-5c08-a8df-9e460fd8bb16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c8fa2-12ab-4f6a-9f7a-2bc69e9ba024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c8fa2-12ab-4f6a-9f7a-2bc69e9ba024.jpg?1",
             "name": "Arid Archway",
             "text": "Arid Archway enters the battlefield tapped.\nWhen Arid Archway enters the battlefield, return a land you control to its owner's hand. If another Desert was returned this way, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}{C}.",
             "colours": [],
@@ -8882,7 +8882,7 @@
         },
         {
             "id": "43c64c60-0fe2-5f1d-b767-d3685e0fd005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61dfeb7-7f6b-4601-8396-2cbb98165489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d61dfeb7-7f6b-4601-8396-2cbb98165489.jpg?1",
             "name": "Bristling Backwoods",
             "text": "Bristling Backwoods enters the battlefield tapped.\nWhen Bristling Backwoods enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8915,7 +8915,7 @@
         },
         {
             "id": "dc6f3ed2-209a-5dbc-8935-6938e6778aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffa48cc-b991-4d47-b7ec-cf678915c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffa48cc-b991-4d47-b7ec-cf678915c758.jpg?1",
             "name": "Conduit Pylons",
             "text": "When Conduit Pylons enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "e8c6f29c-ed4e-574b-ba61-c6564ad84b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5523dac-7aa0-4486-89c8-3b22a1411f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5523dac-7aa0-4486-89c8-3b22a1411f26.jpg?1",
             "name": "Creosote Heath",
             "text": "Creosote Heath enters the battlefield tapped.\nWhen Creosote Heath enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "4a3d1de1-f596-5a7e-986e-84ff4c3069f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9d080f-28d7-41d6-a4e0-5b3e3a5ed770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c9d080f-28d7-41d6-a4e0-5b3e3a5ed770.jpg?1",
             "name": "Eroded Canyon",
             "text": "Eroded Canyon enters the battlefield tapped.\nWhen Eroded Canyon enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "43490fe7-f568-5327-bde7-da9b70ccb16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad841eb-da0d-43d4-8b60-efe30922990b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad841eb-da0d-43d4-8b60-efe30922990b.jpg?1",
             "name": "Festering Gulch",
             "text": "Festering Gulch enters the battlefield tapped.\nWhen Festering Gulch enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9044,7 +9044,7 @@
         },
         {
             "id": "d454d997-68f3-52f2-aeae-e8050b0877fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963c100e-4e12-438f-b5ae-14391406dff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963c100e-4e12-438f-b5ae-14391406dff6.jpg?1",
             "name": "Forlorn Flats",
             "text": "Forlorn Flats enters the battlefield tapped.\nWhen Forlorn Flats enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9077,7 +9077,7 @@
         },
         {
             "id": "e2a0d6ad-b3c9-5bac-83d4-581d3e2cbc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d809f5b-d965-4cb1-a9f8-2048f8534373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d809f5b-d965-4cb1-a9f8-2048f8534373.jpg?1",
             "name": "Jagged Barrens",
             "text": "Jagged Barrens enters the battlefield tapped.\nWhen Jagged Barrens enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9110,7 +9110,7 @@
         },
         {
             "id": "90b9c858-bdb1-5d7e-845d-d9073a8336e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b778b63-e5fc-4d63-a93b-4372f32cade2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b778b63-e5fc-4d63-a93b-4372f32cade2.jpg?1",
             "name": "Lonely Arroyo",
             "text": "Lonely Arroyo enters the battlefield tapped.\nWhen Lonely Arroyo enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9143,7 +9143,7 @@
         },
         {
             "id": "42a842eb-6203-58db-8cb3-d42d6f1dfb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988e44c5-4632-4ebb-b6ae-c3886e49d637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988e44c5-4632-4ebb-b6ae-c3886e49d637.jpg?1",
             "name": "Lush Oasis",
             "text": "Lush Oasis enters the battlefield tapped.\nWhen Lush Oasis enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9176,7 +9176,7 @@
         },
         {
             "id": "6fdcd268-61ab-54e5-a651-c8ee8ddccd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e816-c06d-4c5d-98fe-c350d8cfab27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d2e816-c06d-4c5d-98fe-c350d8cfab27.jpg?1",
             "name": "Mirage Mesa",
             "text": "Mirage Mesa enters the battlefield tapped. As it enters, choose a color.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9206,7 +9206,7 @@
         },
         {
             "id": "d83846f8-5065-54e1-aa0c-1b9cf69fa84a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab4e0a4-2faf-456b-99e3-ee06c008538c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab4e0a4-2faf-456b-99e3-ee06c008538c.jpg?1",
             "name": "Sandstorm Verge",
             "text": "{T}: Add {C}.\n{3}, {T}: Target creature can't block this turn. Activate only as a sorcery.",
             "colours": [],
@@ -9236,7 +9236,7 @@
         },
         {
             "id": "0e5f7df0-c992-5920-9cd5-7f3cd314f935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67daa31c-d9c4-4c22-b29c-1b8a17d577e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67daa31c-d9c4-4c22-b29c-1b8a17d577e5.jpg?1",
             "name": "Soured Springs",
             "text": "Soured Springs enters the battlefield tapped.\nWhen Soured Springs enters the battlefield, it deals 1 damage to target opponent.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9269,7 +9269,7 @@
         },
         {
             "id": "cba28f49-69fd-51f3-bc68-13ea8670f1f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4f6b81-53d0-49fb-b404-c2ad67de7493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4f6b81-53d0-49fb-b404-c2ad67de7493.jpg?1",
             "name": "Bucolic Ranch",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Mount spell.\n{3}, {T}: Look at the top card of your library. If it's a Mount card, you may reveal it and put it into your hand. If you don't put it into your hand, you may put it on the bottom of your library.",
             "colours": [],
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "aa874e11-05b4-52b7-b0f4-b0d32198f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861caabb-0573-4e94-8b03-342f90465064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861caabb-0573-4e94-8b03-342f90465064.jpg?1",
             "name": "Blooming Marsh",
             "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9332,7 +9332,7 @@
         },
         {
             "id": "b658c176-f603-520e-9dab-e9e9291a307d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18d5f4-a56a-4f7d-9f56-ccc92cbfb7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18d5f4-a56a-4f7d-9f56-ccc92cbfb7f7.jpg?1",
             "name": "Botanical Sanctum",
             "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9365,7 +9365,7 @@
         },
         {
             "id": "96347282-5292-5103-933e-656c01504222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75df1f0-0513-40e4-a449-454f75de6434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75df1f0-0513-40e4-a449-454f75de6434.jpg?1",
             "name": "Concealed Courtyard",
             "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9398,7 +9398,7 @@
         },
         {
             "id": "f533b932-307a-5f00-af97-2ed21e0fde89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85df6b6a-2dcf-4828-a4a8-e07d52e1fddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85df6b6a-2dcf-4828-a4a8-e07d52e1fddd.jpg?1",
             "name": "Inspiring Vantage",
             "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "4320d7b6-7541-5a1f-a85c-7d7da40a992c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a04e16-a767-4112-ab01-6ca1b09c286c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a04e16-a767-4112-ab01-6ca1b09c286c.jpg?1",
             "name": "Spirebluff Canal",
             "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "53f194d8-9b63-5614-a869-b3a7c59f05dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg?1",
             "name": "Jace Reawakened",
             "text": "You can't cast this spell during your first, second, or third turns of the game.\n+1: Draw a card, then discard a card.\n+1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\n\u22126: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -9502,7 +9502,7 @@
         },
         {
             "id": "2439cad8-5b11-52c9-96f1-fbf451ca082a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe51d97-66f6-4ac3-b926-01ab7e4c5686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe51d97-66f6-4ac3-b926-01ab7e4c5686.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "95b06628-80db-5dc8-8b24-8b689994c1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624d656-207d-4e73-b615-59e7cf64ad64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624d656-207d-4e73-b615-59e7cf64ad64.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9576,7 +9576,7 @@
         },
         {
             "id": "4a1a324d-b930-5afb-845c-2410c98d4b28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b383b16-8128-4d9e-a0d0-9b8ccc9ad6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b383b16-8128-4d9e-a0d0-9b8ccc9ad6df.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "053ded5c-2cea-5a75-a55e-daf37e2ea91e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dbfd2-cda7-4fc9-9677-e442fb5f5f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7dbfd2-cda7-4fc9-9677-e442fb5f5f6f.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "452d4eaf-d736-5dbf-9fc2-cb35022ee7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf8a774-65f3-431e-b084-328ff1000895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf8a774-65f3-431e-b084-328ff1000895.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9687,7 +9687,7 @@
         },
         {
             "id": "de196252-02f1-54ab-97ac-fa59d75c7eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f501773-1b39-4a4c-9b45-a950385c9e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f501773-1b39-4a4c-9b45-a950385c9e82.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9724,7 +9724,7 @@
         },
         {
             "id": "6932a15f-4028-5ffb-8a25-9cf7a3a78df3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe60da77-084c-49e8-9948-9ac4b6a6382f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe60da77-084c-49e8-9948-9ac4b6a6382f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9761,7 +9761,7 @@
         },
         {
             "id": "3d2e9367-5afd-560b-869a-c7c612d0db53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd6be3f-745c-41ad-95c9-1db66ba56be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd6be3f-745c-41ad-95c9-1db66ba56be2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9798,7 +9798,7 @@
         },
         {
             "id": "f40527c4-8a3b-5cc8-99c3-f81fd94757bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be4db0-7cb3-4202-939b-cb7a26e90019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91be4db0-7cb3-4202-939b-cb7a26e90019.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9835,7 +9835,7 @@
         },
         {
             "id": "d625c38f-3b9c-59b7-85eb-e4bdfda3a8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7dc259-9949-4673-a8f1-874396948392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7dc259-9949-4673-a8f1-874396948392.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9872,7 +9872,7 @@
         },
         {
             "id": "75cf6103-13f2-530b-b598-3c92163d7445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c9dc0-7f3a-4f3a-ba08-5c2f87e252bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2c9dc0-7f3a-4f3a-ba08-5c2f87e252bc.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9909,7 +9909,7 @@
         },
         {
             "id": "b7a2c32e-944c-5d49-9223-d8d515d44ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9137b4aa-2289-4a4d-b1f5-ae75a0928278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9137b4aa-2289-4a4d-b1f5-ae75a0928278.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9946,7 +9946,7 @@
         },
         {
             "id": "12bf8065-8c2b-541e-a55d-7aeb19cd578b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2237ee9b-fff6-472c-903c-11faf9bb116d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2237ee9b-fff6-472c-903c-11faf9bb116d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "a7fda38b-455a-50b3-8408-eeddeaeb19f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20a07e-5f92-49c2-9c97-d5eda536d3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20a07e-5f92-49c2-9c97-d5eda536d3f6.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "b24333e9-249c-5f4b-9503-a77069beaf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9ac507-7c8f-431f-8d1a-220ceeacf871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e9ac507-7c8f-431f-8d1a-220ceeacf871.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10057,7 +10057,7 @@
         },
         {
             "id": "ca826bbc-9dc5-5c7d-babb-41e5f441b845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef3f55e-b8e6-4ef1-85e4-2aef5afc15ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef3f55e-b8e6-4ef1-85e4-2aef5afc15ab.jpg?1",
             "name": "Geralf, the Fleshwright",
             "text": "Whenever you cast a spell during your turn other than your first spell that turn, create a 2/2 blue and black Zombie Rogue creature token.\nWhenever a Zombie enters the battlefield under your control, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your control this turn.",
             "colours": [
@@ -10096,7 +10096,7 @@
         },
         {
             "id": "bba1619d-f59f-58a1-a4f4-171116f784af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c1ad56-cf6e-4717-a56e-feeb7339b8c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c1ad56-cf6e-4717-a56e-feeb7339b8c3.jpg?1",
             "name": "Gisa, the Hellraiser",
             "text": "Ward\u2014{2}, Pay 2 life.\nSkeletons and Zombies you control get +1/+1 and have menace.\nWhenever you commit a crime, create two tapped 2/2 blue and black Zombie Rogue creature tokens. This ability triggers only once each turn.",
             "colours": [
@@ -10135,7 +10135,7 @@
         },
         {
             "id": "6e4d9a40-74e3-519f-84f9-3e1cfa7cc4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e759e4-bda5-4d01-a9a8-3986df1d4428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e759e4-bda5-4d01-a9a8-3986df1d4428.jpg?1",
             "name": "Kaervek, the Punisher",
             "text": "Whenever you commit a crime, exile up to one target black card from your graveyard and copy it. You may cast the copy. If you do, you lose 2 life.",
             "colours": [
@@ -10174,7 +10174,7 @@
         },
         {
             "id": "56e1af38-efd3-5cba-ab1c-a88990627786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2a3962-315d-48df-9af5-7cb4dd2040de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2a3962-315d-48df-9af5-7cb4dd2040de.jpg?1",
             "name": "Tinybones, the Pickpocket",
             "text": "Deathtouch\nWhenever Tinybones, the Pickpocket deals combat damage to a player, you may cast target nonland permanent card from that player's graveyard, and mana of any type can be spent to cast that spell.",
             "colours": [
@@ -10213,7 +10213,7 @@
         },
         {
             "id": "1fefbd25-61cd-5d47-9a22-08155896b3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8d21f-a003-4711-ad5c-0bde87e1edc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8d21f-a003-4711-ad5c-0bde87e1edc6.jpg?1",
             "name": "Annie Flash, the Veteran",
             "text": "Flash\nWhen Annie Flash, the Veteran enters the battlefield, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\nWhenever Annie Flash becomes tapped, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -10256,7 +10256,7 @@
         },
         {
             "id": "235f9028-a23b-530c-a210-e1b9ef8d4280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcde5cd5-4ce6-4b94-8d97-534a647dbfc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcde5cd5-4ce6-4b94-8d97-534a647dbfc1.jpg?1",
             "name": "Breeches, the Blastmaker",
             "text": "Menace\nWhenever you cast your second spell each turn, you may sacrifice an artifact. If you do, flip a coin. When you win the flip, copy that spell. You may choose new targets for the copy. When you lose the flip, Breeches, the Blastmaker deals damage equal to that spell's mana value to any target.",
             "colours": [
@@ -10297,7 +10297,7 @@
         },
         {
             "id": "1ef727a5-1d56-54a5-abd6-2d1c961b80a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b5791-a405-4578-acba-959cc181e9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f69b5791-a405-4578-acba-959cc181e9ad.jpg?1",
             "name": "Eriette, the Beguiler",
             "text": "Lifelink\nWhenever an Aura you control becomes attached to a nonland permanent an opponent controls with mana value less than or equal to that Aura's mana value, gain control of that permanent for as long as that Aura is attached to it.",
             "colours": [
@@ -10340,7 +10340,7 @@
         },
         {
             "id": "851ed524-2f77-5ef9-b3f4-1c1613a1e427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789659f6-af39-4357-985f-a006f192893c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/789659f6-af39-4357-985f-a006f192893c.jpg?1",
             "name": "Kellan, the Kid",
             "text": "Flying, lifelink\nWhenever you cast a spell from anywhere other than your hand, you may cast a permanent spell with equal or lesser mana value from your hand without paying its mana cost. If you don't, you may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -10384,7 +10384,7 @@
         },
         {
             "id": "3e263f5f-2a2b-591f-9d2b-334b27c2e57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480de469-3fac-4a2b-8dec-7899ce00551e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480de469-3fac-4a2b-8dec-7899ce00551e.jpg?1",
             "name": "Malcolm, the Eyes",
             "text": "Flying, haste\nWhenever you cast your second spell each turn, investigate.",
             "colours": [
@@ -10425,7 +10425,7 @@
         },
         {
             "id": "ef245052-cde1-5a43-89cb-e05ab1a7ff6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c025072-0d0a-4ca7-a386-f1ed7c97638b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c025072-0d0a-4ca7-a386-f1ed7c97638b.jpg?1",
             "name": "Oko, the Ringleader",
             "text": "At the beginning of combat on your turn, Oko, the Ringleader becomes a copy of up to one target creature you control until end of turn, except he has hexproof.\n+1: Draw two cards. If you've committed a crime this turn, discard a card. Otherwise, discard two cards.\n\u22121: Create a 3/3 green Elk creature token.\n\u22125: For each other nonland permanent you control, create a token that's a copy of that permanent.",
             "colours": [
@@ -10466,7 +10466,7 @@
         },
         {
             "id": "606b7abc-9013-586d-bc0f-12b0b279cac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85635e0-fb5b-42ea-8a30-d67922cbca95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85635e0-fb5b-42ea-8a30-d67922cbca95.jpg?1",
             "name": "Rakdos, the Muscle",
             "text": "Flying, trample\nWhenever you sacrifice another creature, exile cards equal to its mana value from the top of target player's library. Until your next end step, you may play those cards, and mana of any type can be spent to cast those spells.\nSacrifice another creature: Rakdos, the Muscle gains indestructible until end of turn. Tap it. Activate only once each turn.",
             "colours": [
@@ -10507,7 +10507,7 @@
         },
         {
             "id": "8f6a0bde-9ab4-56e0-b768-d07fc6bea691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a76f0-b697-4c1d-9b60-c66f7fc4316e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a76f0-b697-4c1d-9b60-c66f7fc4316e.jpg?1",
             "name": "Satoru, the Infiltrator",
             "text": "Menace\nWhenever Satoru, the Infiltrator and/or one or more other nontoken creatures enter the battlefield under your control, if none of them were cast or no mana was spent to cast them, draw a card.",
             "colours": [
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "46a3eef0-a80d-54d5-b2d7-27e75fe86534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6cc9ab-a1d8-47de-8ac5-112e5fee00f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a6cc9ab-a1d8-47de-8ac5-112e5fee00f9.jpg?1",
             "name": "Vraska, the Silencer",
             "text": "Deathtouch\nWhenever a nontoken creature an opponent controls dies, you may pay {1}. If you do, return that card to the battlefield tapped under your control. It's a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other card types.",
             "colours": [
@@ -10590,7 +10590,7 @@
         },
         {
             "id": "e021b9da-4728-5c75-8961-a3ac87380862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb4a80-3319-41ad-9d97-a9a53c9f84fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cfb4a80-3319-41ad-9d97-a9a53c9f84fb.jpg?1",
             "name": "Blooming Marsh",
             "text": "Blooming Marsh enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10623,7 +10623,7 @@
         },
         {
             "id": "ded56fea-2d14-5b81-9226-68a30706b171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82670072-9851-48c7-a8f5-7842bff6c252.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82670072-9851-48c7-a8f5-7842bff6c252.jpg?1",
             "name": "Botanical Sanctum",
             "text": "Botanical Sanctum enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10656,7 +10656,7 @@
         },
         {
             "id": "c55a9e81-67a9-563c-a718-8382be4a353a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e85ace-7e2c-46f6-adb9-07f33f8e1750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e85ace-7e2c-46f6-adb9-07f33f8e1750.jpg?1",
             "name": "Concealed Courtyard",
             "text": "Concealed Courtyard enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "4c31cf96-5daf-58d4-8d4f-f630b28278ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551e216d-a82f-49a1-a3fd-8165715a05c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551e216d-a82f-49a1-a3fd-8165715a05c4.jpg?1",
             "name": "Inspiring Vantage",
             "text": "Inspiring Vantage enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10722,7 +10722,7 @@
         },
         {
             "id": "4355eee5-dc0e-5890-a8a9-a2a029b15b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83bdb3-1f04-4b99-a36b-312da0cbed50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d83bdb3-1f04-4b99-a36b-312da0cbed50.jpg?1",
             "name": "Spirebluff Canal",
             "text": "Spirebluff Canal enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10755,7 +10755,7 @@
         },
         {
             "id": "aebc46ed-7fb4-57dc-8073-59552fff2ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfbb249-f2cc-4295-b6e3-4fd7e1eac183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfbb249-f2cc-4295-b6e3-4fd7e1eac183.jpg?1",
             "name": "Oko, the Ringleader",
             "text": "At the beginning of combat on your turn, Oko, the Ringleader becomes a copy of up to one target creature you control until end of turn, except he has hexproof.\n+1: Draw two cards. If you've committed a crime this turn, discard a card. Otherwise, discard two cards.\n\u22121: Create a 3/3 green Elk creature token.\n\u22125: For each other nonland permanent you control, create a token that's a copy of that permanent.",
             "colours": [
@@ -10796,7 +10796,7 @@
         },
         {
             "id": "399a16ee-1ee2-5d91-a75f-8e438d383b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73bdf79-6c18-46bc-a8bb-97e07dd23aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d73bdf79-6c18-46bc-a8bb-97e07dd23aff.jpg?1",
             "name": "Jace Reawakened",
             "text": "You can't cast this spell during your first, second, or third turns of the game.\n+1: Draw a card, then discard a card.\n+1: You may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\n\u22126: Until end of turn, whenever you cast a spell, copy it. You may choose new targets for the copy.",
             "colours": [
@@ -10834,7 +10834,7 @@
         },
         {
             "id": "79c76c90-f2f9-5ff5-9108-ea583f09ac5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddec615b-537a-4fef-a2a7-9bdf74c0192a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddec615b-537a-4fef-a2a7-9bdf74c0192a.jpg?1",
             "name": "Another Round",
             "text": "Exile any number of creatures you control, then return them to the battlefield under their owner's control. Then repeat this process X more times.",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "b9735a22-0932-56c2-8372-b0e5e19a3eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34f043c-d01e-4462-b381-39748d7fa31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d34f043c-d01e-4462-b381-39748d7fa31b.jpg?1",
             "name": "Archangel of Tithes",
             "text": "Flying\nAs long as Archangel of Tithes is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.\nAs long as Archangel of Tithes is attacking, creatures can't block unless their controller pays {1} for each of those creatures.",
             "colours": [
@@ -10904,7 +10904,7 @@
         },
         {
             "id": "bf501161-ea5a-54bc-b740-650533c7e227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75143fdb-5651-4289-86df-76c9655a0599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75143fdb-5651-4289-86df-76c9655a0599.jpg?1",
             "name": "Aven Interrupter",
             "text": "Flash\nFlying\nWhen Aven Interrupter enters the battlefield, exile target spell. It becomes plotted.\nSpells your opponents cast from graveyards or from exile cost {2} more to cast.",
             "colours": [
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "c5ad4928-ad44-587f-a017-ca38211eecf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfad3c84-4264-4757-8e83-25dbbed67070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfad3c84-4264-4757-8e83-25dbbed67070.jpg?1",
             "name": "Claim Jumper",
             "text": "Vigilance\nWhen Claim Jumper enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card and put it onto the battlefield tapped. Then if an opponent controls more lands than you, repeat this process once. If you search your library this way, shuffle.",
             "colours": [
@@ -10978,7 +10978,7 @@
         },
         {
             "id": "9a02af6c-4cc3-5950-a3ef-4748256ba020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d9d4f0-48ec-43e6-bb93-a9589790417b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d9d4f0-48ec-43e6-bb93-a9589790417b.jpg?1",
             "name": "Dust Animus",
             "text": "Flying\nIf you control five or more untapped lands, Dust Animus enters the battlefield with two +1/+1 counters and a lifelink counter on it.\nPlot {1}{W}",
             "colours": [
@@ -11014,7 +11014,7 @@
         },
         {
             "id": "a93030f1-74bb-5a9a-ae05-fe7eae585965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94397320-b814-487f-aca2-537517ff9eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94397320-b814-487f-aca2-537517ff9eff.jpg?1",
             "name": "Final Showdown",
             "text": "Spree\n+ {1} \u2014 All creatures lose all abilities until end of turn.\n+ {1} \u2014 Choose a creature you control. It gains indestructible until end of turn.\n+ {3}{W}{W} \u2014 Destroy all creatures.",
             "colours": [
@@ -11048,7 +11048,7 @@
         },
         {
             "id": "d1574781-f743-578d-b680-31f5d4647875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ffb299-a327-43c1-868e-1c5225204956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ffb299-a327-43c1-868e-1c5225204956.jpg?1",
             "name": "Fortune, Loyal Steed",
             "text": "When Fortune, Loyal Steed enters the battlefield, scry 2.\nWhenever Fortune attacks while saddled, at end of combat, exile it and up to one creature that saddled it this turn, then return those cards to the battlefield under their owner's control.\nSaddle 1",
             "colours": [
@@ -11087,7 +11087,7 @@
         },
         {
             "id": "49d17971-00b4-5cb4-a972-d3b15ac39bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d69fce2-3307-4518-a196-e0b8155dca73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d69fce2-3307-4518-a196-e0b8155dca73.jpg?1",
             "name": "High Noon",
             "text": "Each player can't cast more than one spell each turn.\n{4}{R}, Sacrifice High Noon: It deals 5 damage to any target.",
             "colours": [
@@ -11122,7 +11122,7 @@
         },
         {
             "id": "4f1059d2-79df-5dc9-a996-1de60f5229d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6db7ba-3150-4ae8-84e3-11661bf1d1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6db7ba-3150-4ae8-84e3-11661bf1d1c4.jpg?1",
             "name": "One Last Job",
             "text": "Spree\n+ {2} \u2014 Return target creature card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Mount or Vehicle card from your graveyard to the battlefield.\n+ {1} \u2014 Return target Aura or Equipment card from your graveyard to the battlefield attached to a creature you control.",
             "colours": [
@@ -11156,7 +11156,7 @@
         },
         {
             "id": "2f914156-00c1-5b57-85bb-cd3493c114ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25563be1-71f1-4f70-8527-02c5855a0b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25563be1-71f1-4f70-8527-02c5855a0b9d.jpg?1",
             "name": "Archmage's Newt",
             "text": "Whenever Archmage's Newt deals combat damage to a player, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. That card gains flashback {0} until end of turn instead if Archmage's Newt is saddled.\nSaddle 3",
             "colours": [
@@ -11193,7 +11193,7 @@
         },
         {
             "id": "ec12499e-4675-5cc7-aa18-c98f143542dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f24b8b-f9ed-4c77-8cb0-2a94848ee69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f24b8b-f9ed-4c77-8cb0-2a94848ee69b.jpg?1",
             "name": "Double Down",
             "text": "Whenever you cast an outlaw spell, copy that spell.",
             "colours": [
@@ -11227,7 +11227,7 @@
         },
         {
             "id": "7f32d840-982c-566d-853b-a20e00450c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126ae45-00b3-419c-8f07-d1286ac6b121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4126ae45-00b3-419c-8f07-d1286ac6b121.jpg?1",
             "name": "Duelist of the Mind",
             "text": "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn.",
             "colours": [
@@ -11264,7 +11264,7 @@
         },
         {
             "id": "118fb102-9475-519f-8278-5ed3a9d97951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bbf861-448b-455b-8922-38515ba65c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bbf861-448b-455b-8922-38515ba65c40.jpg?1",
             "name": "Fblthp, Lost on the Range",
             "text": "Ward {2}\nYou may look at the top card of your library any time.\nThe top card of your library has plot. The plot cost is equal to its mana cost.\nYou may plot nonland cards from the top of your library.",
             "colours": [
@@ -11302,7 +11302,7 @@
         },
         {
             "id": "2908d282-832f-5e99-86b6-a50cbc4db9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70388ee-2f97-4282-ba74-af95462ac0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70388ee-2f97-4282-ba74-af95462ac0aa.jpg?1",
             "name": "The Key to the Vault",
             "text": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
             "colours": [
@@ -11341,7 +11341,7 @@
         },
         {
             "id": "d35efa44-6de2-5f4c-a43e-1b6330a3d04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e532e5b-6d84-4669-8788-f471b1498c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e532e5b-6d84-4669-8788-f471b1498c7b.jpg?1",
             "name": "Step Between Worlds",
             "text": "Each player may shuffle their hand and graveyard into their library. Each player who does draws seven cards. Exile Step Between Worlds.\nPlot {4}{U}{U}",
             "colours": [
@@ -11375,7 +11375,7 @@
         },
         {
             "id": "7cb9c4fa-8c04-5f3a-9edf-d0d9db4f018d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e346fab1-48db-4cd2-836d-dad5e8437308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e346fab1-48db-4cd2-836d-dad5e8437308.jpg?1",
             "name": "Stoic Sphinx",
             "text": "Flash\nFlying\nStoic Sphinx has hexproof as long as you haven't cast a spell this turn.",
             "colours": [
@@ -11411,7 +11411,7 @@
         },
         {
             "id": "0d3cb81d-a43d-5488-8894-8075d5ff80c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be980c3b-b4ab-4ed7-9f61-d8db54c226d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be980c3b-b4ab-4ed7-9f61-d8db54c226d9.jpg?1",
             "name": "Three Steps Ahead",
             "text": "Spree\n+ {1}{U} \u2014 Counter target spell.\n+ {3} \u2014 Create a token that's a copy of target artifact or creature you control.\n+ {2} \u2014 Draw two cards, then discard a card.",
             "colours": [
@@ -11445,7 +11445,7 @@
         },
         {
             "id": "974bef44-a58c-59ee-80fc-d3c79cfd2c26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517505a0-0d05-4e81-8582-999b88040f48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517505a0-0d05-4e81-8582-999b88040f48.jpg?1",
             "name": "Caustic Bronco",
             "text": "Whenever Caustic Bronco attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if Caustic Bronco isn't saddled. Otherwise, each opponent loses that much life.\nSaddle 3",
             "colours": [
@@ -11483,7 +11483,7 @@
         },
         {
             "id": "9ac142d3-2ca1-582b-b6c2-9ed5c34cb317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae03d91-8269-4124-ba50-a6c65f47718b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae03d91-8269-4124-ba50-a6c65f47718b.jpg?1",
             "name": "Insatiable Avarice",
             "text": "Spree\n+ {2} \u2014 Search your library for a card, then shuffle and put that card on top.\n+ {B}{B} \u2014 Target player draws three cards and loses 3 life.",
             "colours": [
@@ -11517,7 +11517,7 @@
         },
         {
             "id": "6c5792dd-4e47-5abe-be3d-82a5511ad21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea6391-e70d-4f36-86b7-fd08440b4976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bea6391-e70d-4f36-86b7-fd08440b4976.jpg?1",
             "name": "Pitiless Carnage",
             "text": "Sacrifice any number of permanents you control, then draw that many cards.\nPlot {1}{B}{B}",
             "colours": [
@@ -11551,7 +11551,7 @@
         },
         {
             "id": "827d17bd-c634-5a1e-ae65-3a2b569eb028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ca7ac5-5552-487f-9ac9-1092fe6cd165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ca7ac5-5552-487f-9ac9-1092fe6cd165.jpg?1",
             "name": "Rush of Dread",
             "text": "Spree\n+ {1} \u2014 Target opponent sacrifices half the creatures they control, rounded up.\n+ {2} \u2014 Target opponent discards half the cards in their hand, rounded up.\n+ {2} \u2014 Target opponent loses half their life, rounded up.",
             "colours": [
@@ -11585,7 +11585,7 @@
         },
         {
             "id": "76306f73-8a1b-538c-945b-739f1e47e7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3afc0c2-95e7-4b9f-94c5-144cce17c7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3afc0c2-95e7-4b9f-94c5-144cce17c7ed.jpg?1",
             "name": "Tinybones Joins Up",
             "text": "When Tinybones Joins Up enters the battlefield, any number of target players each discard a card.\nWhenever a legendary creature enters the battlefield under your control, any number of target players each mill a card and lose 1 life.",
             "colours": [
@@ -11621,7 +11621,7 @@
         },
         {
             "id": "d86fc688-fca9-5537-9ec5-942fda698dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d876a888-e119-494d-857a-e780a277c817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d876a888-e119-494d-857a-e780a277c817.jpg?1",
             "name": "Vadmir, New Blood",
             "text": "Whenever you commit a crime, put a +1/+1 counter on Vadmir, New Blood. This ability triggers only once each turn.\nAs long as Vadmir has four or more +1/+1 counters on it, it has menace and lifelink.",
             "colours": [
@@ -11660,7 +11660,7 @@
         },
         {
             "id": "61bfa14c-8bbe-591a-b4fc-61a7275f1d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295e63c2-b533-4dbf-8c8a-c6493de31457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295e63c2-b533-4dbf-8c8a-c6493de31457.jpg?1",
             "name": "Calamity, Galloping Inferno",
             "text": "Haste\nWhenever Calamity, Galloping Inferno attacks while saddled, choose a nonlegendary creature that saddled it this turn and create a tapped and attacking token that's a copy of it. Sacrifice that token at the beginning of the next end step. Repeat this process once.\nSaddle 1",
             "colours": [
@@ -11699,7 +11699,7 @@
         },
         {
             "id": "1c9a18ed-acac-5a7c-b4bb-2e8904189ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b570d9c5-3348-482f-a211-ed8c9777a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b570d9c5-3348-482f-a211-ed8c9777a9fa.jpg?1",
             "name": "Great Train Heist",
             "text": "Spree\n+ {2}{R} \u2014 Untap all creatures you control. If it's your combat phase, there is an additional combat phase after this phase.\n+ {2} \u2014 Creatures you control get +1/+0 and gain first strike until end of turn.\n+ {R} \u2014 Choose target opponent. Whenever a creature you control deals combat damage to that player this turn, create a tapped Treasure token.",
             "colours": [
@@ -11733,7 +11733,7 @@
         },
         {
             "id": "d581a156-4e5a-5533-b94e-3b7da9a9f6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c522c232-0f86-49ad-969f-a2b086432a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c522c232-0f86-49ad-969f-a2b086432a97.jpg?1",
             "name": "Hell to Pay",
             "text": "Hell to Pay deals X damage to target creature. Create a number of tapped Treasure tokens equal to the amount of excess damage dealt to that creature this way.",
             "colours": [
@@ -11767,7 +11767,7 @@
         },
         {
             "id": "2909adc6-4c24-53b5-93a6-a599e5e18aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259262b9-f74b-4e71-9c4e-cf18ba2dc3c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259262b9-f74b-4e71-9c4e-cf18ba2dc3c2.jpg?1",
             "name": "Hellspur Posse Boss",
             "text": "Other outlaws you control have haste.\nWhen Hellspur Posse Boss enters the battlefield, create two 1/1 red Mercenary creature tokens with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"",
             "colours": [
@@ -11804,7 +11804,7 @@
         },
         {
             "id": "65ee59c5-5b60-5ae2-b944-f762e5281ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf42a57-02f0-4a3f-8677-d68ffe3090c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf42a57-02f0-4a3f-8677-d68ffe3090c0.jpg?1",
             "name": "Magda, the Hoardmaster",
             "text": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn.\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
             "colours": [
@@ -11844,7 +11844,7 @@
         },
         {
             "id": "3c45d8e4-28e3-50b9-90c8-260486b19194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304523e7-f332-4c1d-9590-ff9a70daff26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/304523e7-f332-4c1d-9590-ff9a70daff26.jpg?1",
             "name": "Slickshot Show-Off",
             "text": "Flying, haste\nWhenever you cast a noncreature spell, Slickshot Show-Off gets +2/+0 until end of turn.\nPlot {1}{R}",
             "colours": [
@@ -11881,7 +11881,7 @@
         },
         {
             "id": "4956ba04-da57-581c-a99a-849033335c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa00b-bc34-4be8-a21f-11ae695f166d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9fa00b-bc34-4be8-a21f-11ae695f166d.jpg?1",
             "name": "Stingerback Terror",
             "text": "Flying, trample\nStingerback Terror gets -1/-1 for each card in your hand.\nPlot {2}{R}",
             "colours": [
@@ -11918,7 +11918,7 @@
         },
         {
             "id": "a9aa0f6a-b20a-563b-bcc7-51e00a14ef5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd20aae9-9de0-498b-8325-f8e8290d56e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd20aae9-9de0-498b-8325-f8e8290d56e3.jpg?1",
             "name": "Terror of the Peaks",
             "text": "Flying\nSpells your opponents cast that target Terror of the Peaks cost an additional 3 life to cast.\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
             "colours": [
@@ -11954,7 +11954,7 @@
         },
         {
             "id": "052da6e7-e1e8-525a-9dd4-768ab121e9d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f921e711-168d-4836-bca2-f9bb43992708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f921e711-168d-4836-bca2-f9bb43992708.jpg?1",
             "name": "Bristly Bill, Spine Sower",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on target creature.\n{3}{G}{G}: Double the number of +1/+1 counters on each creature you control.",
             "colours": [
@@ -11993,7 +11993,7 @@
         },
         {
             "id": "78b82d7d-06fc-5796-8f8d-b2afb5a847d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fbb0c7-29ac-4394-87e1-6e8227602aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fbb0c7-29ac-4394-87e1-6e8227602aac.jpg?1",
             "name": "Colossal Rattlewurm",
             "text": "Colossal Rattlewurm has flash as long as you control a Desert.\nTrample\n{1}{G}, Exile Colossal Rattlewurm from your graveyard: Search your library for a Desert card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -12029,7 +12029,7 @@
         },
         {
             "id": "c8cb0431-3e84-53ba-a791-0a2e70574f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81289833-ebdb-4fe7-ad17-6e39eb399e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81289833-ebdb-4fe7-ad17-6e39eb399e69.jpg?1",
             "name": "Freestrider Lookout",
             "text": "Reach\nWhenever you commit a crime, look at the top five cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
             "colours": [
@@ -12066,7 +12066,7 @@
         },
         {
             "id": "3388a871-eb2b-5496-a56f-7aff2f53dc67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700b3a6-327b-4dc0-aa8d-434ca971a7b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8700b3a6-327b-4dc0-aa8d-434ca971a7b9.jpg?1",
             "name": "Goldvein Hydra",
             "text": "Vigilance, trample, haste\nGoldvein Hydra enters the battlefield with X +1/+1 counters on it.\nWhen Goldvein Hydra dies, create a number of tapped Treasure tokens equal to its power.",
             "colours": [
@@ -12102,7 +12102,7 @@
         },
         {
             "id": "b3457978-935d-5a42-9462-4eabf84f577e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1729d3-8e27-4db0-a7c6-e629a8faf946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1729d3-8e27-4db0-a7c6-e629a8faf946.jpg?1",
             "name": "Ornery Tumblewagg",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature.\nWhenever Ornery Tumblewagg attacks while saddled, double the number of +1/+1 counters on target creature.\nSaddle 2",
             "colours": [
@@ -12139,7 +12139,7 @@
         },
         {
             "id": "da1cabbe-023a-5cf2-9c87-a63bab5b24b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf1fe32-eac2-4d50-b403-25c3666f6d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf1fe32-eac2-4d50-b403-25c3666f6d80.jpg?1",
             "name": "Outcaster Trailblazer",
             "text": "When Outcaster Trailblazer enters the battlefield, add one mana of any color.\nWhenever another creature with power 4 or greater enters the battlefield under your control, draw a card.\nPlot {2}{G}",
             "colours": [
@@ -12176,7 +12176,7 @@
         },
         {
             "id": "89862c93-72fd-5aa8-97b1-1f3d57365a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db8c96-e6b8-4d4a-9935-29f12385a151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78db8c96-e6b8-4d4a-9935-29f12385a151.jpg?1",
             "name": "Railway Brawler",
             "text": "Reach, trample\nWhenever another creature enters the battlefield under your control, put X +1/+1 counters on it, where X is its power.\nPlot {3}{G}",
             "colours": [
@@ -12213,7 +12213,7 @@
         },
         {
             "id": "72a6cf79-fe73-5017-a06c-077439871f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b76d0d-da55-44ec-add8-61696ee40d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b76d0d-da55-44ec-add8-61696ee40d21.jpg?1",
             "name": "Smuggler's Surprise",
             "text": "Spree\n+ {2} \u2014 Mill four cards. You may put up to two creature and/or land cards from among the milled cards into your hand.\n+ {4}{G} \u2014 You may put up to two creature cards from your hand onto the battlefield.\n+ {1} \u2014 Creatures you control with power 4 or greater gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -12247,7 +12247,7 @@
         },
         {
             "id": "383449f6-c81e-5316-9754-9749e424953d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6534bdb1-9436-4919-8a8b-5401bc070fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6534bdb1-9436-4919-8a8b-5401bc070fc2.jpg?1",
             "name": "Akul the Unrepentant",
             "text": "Flying, trample\nSacrifice three other creatures: You may put a creature card from your hand onto the battlefield. Activate only as a sorcery and only once each turn.",
             "colours": [
@@ -12289,7 +12289,7 @@
         },
         {
             "id": "280ad7c3-321b-5970-a7dc-cced454a992e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce19341-e652-448f-8f14-0439bd8fa385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce19341-e652-448f-8f14-0439bd8fa385.jpg?1",
             "name": "Annie Joins Up",
             "text": "When Annie Joins Up enters the battlefield, it deals 5 damage to target creature or planeswalker an opponent controls.\nIf a triggered ability of a legendary creature you control triggers, that ability triggers an additional time.",
             "colours": [
@@ -12329,7 +12329,7 @@
         },
         {
             "id": "4cb47089-5249-547f-8d3b-ec9b5468e7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8e4f7b-bdf6-44d3-9b2b-4420bab84864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8e4f7b-bdf6-44d3-9b2b-4420bab84864.jpg?1",
             "name": "Assimilation Aegis",
             "text": "When Assimilation Aegis enters the battlefield, exile up to one target creature until Assimilation Aegis leaves the battlefield.\nWhenever Assimilation Aegis becomes attached to a creature, for as long as Assimilation Aegis remains attached to it, that creature becomes a copy of a creature card exiled with Assimilation Aegis.\nEquip {2}",
             "colours": [
@@ -12367,7 +12367,7 @@
         },
         {
             "id": "e62cef32-7cce-5ae4-b3aa-138f6cc24f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29f20b-27cd-433a-8874-41f500720109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee29f20b-27cd-433a-8874-41f500720109.jpg?1",
             "name": "Bonny Pall, Clearcutter",
             "text": "Reach\nWhen Bonny Pall, Clearcutter enters the battlefield, create Beau, a legendary blue Ox creature token with \"This creature's power and toughness are each equal to the number of lands you control.\"\nWhenever you attack, draw a card, then you may put a land card from your hand or graveyard onto the battlefield.",
             "colours": [
@@ -12408,7 +12408,7 @@
         },
         {
             "id": "e845ce1d-3428-5497-b596-cc0f1697d098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026257bf-f4e7-45f8-9c93-7248f201c583.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026257bf-f4e7-45f8-9c93-7248f201c583.jpg?1",
             "name": "Bruse Tarl, Roving Rancher",
             "text": "Oxen you control have double strike.\nWhenever Bruse Tarl, Roving Rancher enters the battlefield or attacks, exile the top card of your library. If it's a land card, create a 2/2 white Ox creature token. Otherwise, you may cast it until the end of your next turn.",
             "colours": [
@@ -12449,7 +12449,7 @@
         },
         {
             "id": "d2ab9ab0-c7e4-5627-ac00-6f4b1ae234e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203c84a3-5f1a-440f-93e7-bb65d1e07886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203c84a3-5f1a-440f-93e7-bb65d1e07886.jpg?1",
             "name": "Ghired, Mirror of the Wilds",
             "text": "Haste\nNontoken creatures you control have \"{T}: Create a token that's a copy of target token you control that entered the battlefield this turn.\"",
             "colours": [
@@ -12492,7 +12492,7 @@
         },
         {
             "id": "34856c65-0267-5cb7-89ec-52cab29bce95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a634b934-710b-4c83-b769-d8a034e297b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a634b934-710b-4c83-b769-d8a034e297b8.jpg?1",
             "name": "The Gitrog, Ravenous Ride",
             "text": "Trample, haste\nWhenever The Gitrog, Ravenous Ride deals combat damage to a player, you may sacrifice a creature that saddled it this turn. If you do, draw X cards, then put up to X land cards from your hand onto the battlefield tapped, where X is the sacrificed creature's power.\nSaddle 1",
             "colours": [
@@ -12534,7 +12534,7 @@
         },
         {
             "id": "efe1837f-7933-5064-b3e7-ece8c4536ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd5a0f-8859-4272-a08f-13b788422f4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd5a0f-8859-4272-a08f-13b788422f4c.jpg?1",
             "name": "Kambal, Profiteering Mayor",
             "text": "Whenever one or more tokens enter the battlefield under your opponents' control, for each of them, create a tapped token that's a copy of it. This ability triggers only once each turn.\nWhenever one or more tokens enter the battlefield under your control, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -12575,7 +12575,7 @@
         },
         {
             "id": "86de96a2-fae2-5bf9-a028-7e2b808a47aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d927dc7-77b7-473d-b50b-e81c52d66b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d927dc7-77b7-473d-b50b-e81c52d66b55.jpg?1",
             "name": "Kellan Joins Up",
             "text": "When Kellan Joins Up enters the battlefield, you may exile a nonland card with mana value 3 or less from your hand. If you do, it becomes plotted.\nWhenever a legendary creature enters the battlefield under your control, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -12615,7 +12615,7 @@
         },
         {
             "id": "1d0ccfc7-d9b7-5e4a-9121-0749a29e1501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7fadd-33ea-4bf4-9122-362821ef96dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7fadd-33ea-4bf4-9122-362821ef96dc.jpg?1",
             "name": "Laughing Jasper Flint",
             "text": "Creatures you control but don't own are Mercenaries in addition to their other types.\nAt the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells.",
             "colours": [
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "a2ed0519-24e7-5b4e-b3a7-241f8a9e28c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95efd401-579e-448b-9655-31311c0ae41e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95efd401-579e-448b-9655-31311c0ae41e.jpg?1",
             "name": "Lilah, Undefeated Slickshot",
             "text": "Prowess\nWhenever you cast a multicolored instant or sorcery spell from your hand, exile that spell instead of putting it into your graveyard as it resolves. If you do, it becomes plotted.",
             "colours": [
@@ -12697,7 +12697,7 @@
         },
         {
             "id": "6453614a-d397-52d4-8f15-c62c7d7cb4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724309cd-fb05-4632-a7be-33a9ba024e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724309cd-fb05-4632-a7be-33a9ba024e4a.jpg?1",
             "name": "Marchesa, Dealer of Death",
             "text": "Whenever you commit a crime, you may pay {1}. If you do, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -12740,7 +12740,7 @@
         },
         {
             "id": "91a2ed57-2e9b-55f8-88a0-8ee34f9d1c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183b8c06-62ab-41e8-82c1-f23066d832ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/183b8c06-62ab-41e8-82c1-f23066d832ee.jpg?1",
             "name": "Obeka, Splitter of Seconds",
             "text": "Menace\nWhenever Obeka, Splitter of Seconds deals combat damage to a player, you get that many additional upkeep steps after this phase.",
             "colours": [
@@ -12783,7 +12783,7 @@
         },
         {
             "id": "9d18996b-ad03-5239-aa32-bcbe2ff69c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05939b7-1877-4464-98fe-d3b9ae754fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05939b7-1877-4464-98fe-d3b9ae754fb9.jpg?1",
             "name": "Pillage the Bog",
             "text": "Look at the top X cards of your library, where X is twice the number of lands you control. Put one of them into your hand and the rest on the bottom of your library in a random order.\nPlot {1}{B}{G}",
             "colours": [
@@ -12819,7 +12819,7 @@
         },
         {
             "id": "3feb0232-b85f-5f27-aa68-71159cad4dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a743a-6358-4e08-a6b7-6eaaf7ab9ddc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761a743a-6358-4e08-a6b7-6eaaf7ab9ddc.jpg?1",
             "name": "Rakdos Joins Up",
             "text": "When Rakdos Joins Up enters the battlefield, return target creature card from your graveyard to the battlefield with two additional +1/+1 counters on it.\nWhenever a legendary creature you control dies, Rakdos Joins Up deals damage equal to that creature's power to target opponent.",
             "colours": [
@@ -12857,7 +12857,7 @@
         },
         {
             "id": "661e5cfc-5c70-546d-ac47-1dcde9de2e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215b4632-adce-4357-bfcf-b6014ed2a24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215b4632-adce-4357-bfcf-b6014ed2a24b.jpg?1",
             "name": "Riku of Many Paths",
             "text": "Whenever you cast a modal spell, choose up to X, where X is the number of times you chose a mode for that spell \u2014\n\u2022 Exile the top card of your library. Until the end of your next turn, you may play it.\n\u2022 Put a +1/+1 counter on Riku of Many Paths. It gains trample until end of turn.\n\u2022 Create a 1/1 blue Bird creature token with flying.",
             "colours": [
@@ -12900,7 +12900,7 @@
         },
         {
             "id": "a21a90ad-0c4f-5479-81f7-b17abcb512b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8aea8d-452a-4b23-bc78-8c7db54610d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8aea8d-452a-4b23-bc78-8c7db54610d3.jpg?1",
             "name": "Roxanne, Starfall Savant",
             "text": "Whenever Roxanne, Starfall Savant enters the battlefield or attacks, create a tapped colorless artifact token named Meteorite with \"When Meteorite enters the battlefield, it deals 2 damage to any target\" and \"{T}: Add one mana of any color.\"\nWhenever you tap an artifact token for mana, add one mana of any type that artifact token produced.",
             "colours": [
@@ -12941,7 +12941,7 @@
         },
         {
             "id": "b1545762-3a9d-54ee-b630-0e46d97cab41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e523de28-b2d5-4be9-be78-883cef2499e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e523de28-b2d5-4be9-be78-883cef2499e9.jpg?1",
             "name": "Selvala, Eager Trailblazer",
             "text": "Vigilance\nWhenever you cast a creature spell, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"\n{T}: Choose a color. Add one mana of that color for each different power among creatures you control.",
             "colours": [
@@ -12982,7 +12982,7 @@
         },
         {
             "id": "ef08d011-52d2-5edd-87b2-a342d4bdd8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9df2d7-6738-496c-8164-8bdf7d011df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9df2d7-6738-496c-8164-8bdf7d011df3.jpg?1",
             "name": "Seraphic Steed",
             "text": "First strike, lifelink\nWhenever Seraphic Steed attacks while saddled, create a 3/3 white Angel creature token with flying.\nSaddle 4",
             "colours": [
@@ -13021,7 +13021,7 @@
         },
         {
             "id": "80808eb9-68bc-5932-9df7-25bc6852a15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c558349-87bc-4e0f-96c2-b075f7da97d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c558349-87bc-4e0f-96c2-b075f7da97d5.jpg?1",
             "name": "Taii Wakeen, Perfect Shot",
             "text": "Whenever a source you control deals noncombat damage to a creature equal to that creature's toughness, draw a card.\n{X}, {T}: If a source you control would deal noncombat damage to a permanent or player this turn, it deals that much damage plus X instead.",
             "colours": [
@@ -13062,7 +13062,7 @@
         },
         {
             "id": "994a8029-791f-558b-8906-6e219012e24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43579701-c89a-4455-8f6a-0589af0c6bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43579701-c89a-4455-8f6a-0589af0c6bd3.jpg?1",
             "name": "Vraska Joins Up",
             "text": "When Vraska Joins Up enters the battlefield, put a deathtouch counter on each creature you control.\nWhenever a legendary creature you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "4f150a06-c180-5cc2-84dc-ea350846becf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17955d83-89ea-4151-950c-d72acf1a852a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17955d83-89ea-4151-950c-d72acf1a852a.jpg?1",
             "name": "Wylie Duke, Atiin Hero",
             "text": "Vigilance\nWhenever Wylie Duke, Atiin Hero becomes tapped, you gain 1 life and draw a card.",
             "colours": [
@@ -13141,7 +13141,7 @@
         },
         {
             "id": "512e2281-b1fa-5682-a850-4dd65e7645de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd49911-9ddb-4bef-8cd0-89f558ccd5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd49911-9ddb-4bef-8cd0-89f558ccd5cc.jpg?1",
             "name": "Frontier Seeker",
             "text": "When Frontier Seeker enters the battlefield, look at the top five cards of your library. You may reveal a Mount creature card or a Plains card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "a6b95033-5491-5e88-9b9c-09aaa117b91d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188694af-b856-4439-8ce0-8306b38caacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/188694af-b856-4439-8ce0-8306b38caacb.jpg?1",
             "name": "Scorching Shot",
             "text": "Scorching Shot deals 5 damage to target creature.",
             "colours": [
@@ -13211,7 +13211,7 @@
         },
         {
             "id": "44cf63d1-cfff-5726-92d0-53d5e50f057f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8df8b87-3ea1-44eb-9218-9e7e06dfd0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8df8b87-3ea1-44eb-9218-9e7e06dfd0db.jpg?1",
             "name": "Honest Rutstein",
             "text": "When Honest Rutstein enters the battlefield, return target creature card from your graveyard to your hand.\nCreature spells you cast cost {1} less to cast.",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "88f01215-1e3e-557f-9fa6-8d838b5e8a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9073963-5866-4132-a059-a46f96cd2a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9073963-5866-4132-a059-a46f96cd2a8d.jpg?1",
             "name": "Make Your Own Luck",
             "text": "Look at the top three cards of your library. You may exile a nonland card from among them. If you do, it becomes plotted. Put the rest into your hand.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "bcb3cea4-a348-5546-a82a-6991a2822d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19e6995-4926-4513-b8c1-f35a22aafbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19e6995-4926-4513-b8c1-f35a22aafbe5.jpg?1",
             "name": "Ruthless Lawbringer",
             "text": "When Ruthless Lawbringer enters the battlefield, you may sacrifice another creature. When you do, destroy target nonland permanent.",
             "colours": [
@@ -13325,7 +13325,7 @@
         },
         {
             "id": "6facc0db-c630-5624-bf58-b03350b84a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695db51-f9d5-4eef-84d9-62f7602792b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695db51-f9d5-4eef-84d9-62f7602792b4.jpg?1",
             "name": "The Key to the Vault",
             "text": "Whenever equipped creature deals combat damage to a player, look at that many cards from the top of your library. You may exile a nonland card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost.\nEquip {2}{U}",
             "colours": [
@@ -13363,7 +13363,7 @@
         },
         {
             "id": "b5b5322f-0ea1-5652-99a4-cf3a14fcfb2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834e84e-e932-4052-9dad-2e1c8e76fbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834e84e-e932-4052-9dad-2e1c8e76fbbc.jpg?1",
             "name": "Magda, the Hoardmaster",
             "text": "Whenever you commit a crime, create a tapped Treasure token. This ability triggers only once each turn.\nSacrifice three Treasures: Create a 4/4 red Scorpion Dragon creature token with flying and haste. Activate only as a sorcery.",
             "colours": [
@@ -13402,7 +13402,7 @@
         },
         {
             "id": "4d2ba458-569a-5a74-b079-cd2b89ec3f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f57c5-923a-4824-969e-53feddd78c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85f57c5-923a-4824-969e-53feddd78c3b.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -13430,7 +13430,7 @@
         },
         {
             "id": "125181f9-7b89-595f-9fa7-fb0b325b664b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d8c502-e053-425f-ba40-27a627ca12a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d8c502-e053-425f-ba40-27a627ca12a0.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -13465,7 +13465,7 @@
         },
         {
             "id": "0c6204e4-e3fc-51cd-9496-4b2da24e3783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee3ecef-4566-4164-af39-89cb0bbbffeb.jpg?1",
             "name": "Ox",
             "text": "",
             "colours": [
@@ -13500,7 +13500,7 @@
         },
         {
             "id": "644d3865-e392-5252-afa5-16f1574c96d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccb30d0-b491-43be-8aa0-2ee7da86343e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccb30d0-b491-43be-8aa0-2ee7da86343e.jpg?1",
             "name": "Sheep",
             "text": "",
             "colours": [
@@ -13535,7 +13535,7 @@
         },
         {
             "id": "2aeeec8f-4a21-58bf-a104-6ef6ea36077b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c15b18b-1ab1-44e9-b96f-c36d52f11ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c15b18b-1ab1-44e9-b96f-c36d52f11ea0.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -13570,7 +13570,7 @@
         },
         {
             "id": "d9de4442-bfad-519b-8851-a5957e5de797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1751016-9461-4250-ac07-afe4f5b41095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1751016-9461-4250-ac07-afe4f5b41095.jpg?1",
             "name": "Beau",
             "text": "",
             "colours": [
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "4121ca98-6b4d-582a-915e-7e7bb7b4ba15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d9280-a79a-4f9f-822c-7aaecbff3337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000d9280-a79a-4f9f-822c-7aaecbff3337.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -13642,7 +13642,7 @@
         },
         {
             "id": "f0ef8d6a-4b64-5c73-8233-800aee022a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a35e07-9d80-4f2b-a000-5638b72a9808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a35e07-9d80-4f2b-a000-5638b72a9808.jpg?1",
             "name": "Vampire Rogue",
             "text": "",
             "colours": [
@@ -13678,7 +13678,7 @@
         },
         {
             "id": "13ae534a-28a8-5a1d-9e3c-d3cc3cb539f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c01ea-427d-4401-b5b0-166e87c4585e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75c01ea-427d-4401-b5b0-166e87c4585e.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -13713,7 +13713,7 @@
         },
         {
             "id": "0b3c8513-324d-5347-af39-b6da4161a67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04607f-eed2-462e-897f-82e41e5f7049.jpg?1",
             "name": "Mercenary",
             "text": "",
             "colours": [
@@ -13748,7 +13748,7 @@
         },
         {
             "id": "693ffc98-ec95-55c5-8d26-0cadc4663721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334178bb-970b-4f5a-af9b-1729eab65808.jpg?1",
             "name": "Scorpion Dragon",
             "text": "",
             "colours": [
@@ -13784,7 +13784,7 @@
         },
         {
             "id": "d07787f4-9cc9-532c-8917-b4afb42e49b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008695e6-6d6f-4c16-bf05-377e8cc5f5ff.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -13819,7 +13819,7 @@
         },
         {
             "id": "550650bd-3ac5-55ee-b739-173af89ff794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1632f3fa-4615-46ee-9768-22bbd9d142d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1632f3fa-4615-46ee-9768-22bbd9d142d6.jpg?1",
             "name": "Elk",
             "text": "",
             "colours": [
@@ -13854,7 +13854,7 @@
         },
         {
             "id": "a48209c0-04de-5b70-a252-d5c3462dc3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcefb329-b93d-41a1-88d3-8058afebeca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcefb329-b93d-41a1-88d3-8058afebeca8.jpg?1",
             "name": "Varmint",
             "text": "",
             "colours": [
@@ -13889,7 +13889,7 @@
         },
         {
             "id": "9c4d4329-1a29-544f-b569-59312b54fd19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c7a0bd-6011-495a-b56c-8fa707dd7f12.jpg?1",
             "name": "Zombie Rogue",
             "text": "",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "fc4a3b47-a7a6-5fa9-8eb5-e99527c79be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a906c-8b27-4ffa-bdc3-7825c6919d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/764a906c-8b27-4ffa-bdc3-7825c6919d3e.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -13958,7 +13958,7 @@
         },
         {
             "id": "f605e1eb-231e-5e9f-89dd-93523bee6512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b41ca9-0bf0-41fc-af65-854e602ee007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b41ca9-0bf0-41fc-af65-854e602ee007.jpg?1",
             "name": "Meteorite",
             "text": "",
             "colours": [],
@@ -13987,7 +13987,7 @@
         },
         {
             "id": "3a2e0ac9-54bb-5b35-a4c9-6bad348f7144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec6f053-96f7-4e57-b2eb-4e7699a40a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ec6f053-96f7-4e57-b2eb-4e7699a40a4f.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -14018,7 +14018,7 @@
         },
         {
             "id": "d0056891-3072-5040-b870-2c88c9110497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07677af-88a4-4ff5-b591-e1e3ac05235d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07677af-88a4-4ff5-b591-e1e3ac05235d.jpg?1",
             "name": "Plot",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/P02.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/P02.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4b3884d1-6b49-5c17-b07b-a9a06e2d8eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e865658-67c8-43b2-8d3a-909fb1c17e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e865658-67c8-43b2-8d3a-909fb1c17e8a.jpg?1",
             "name": "Alaborn Cavalier",
             "text": "If Alaborn Cavalier attacks, you may choose to tap any one creature. (Tapped creatures can't block.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "05063d02-db75-5a6f-b09b-361a7a70b6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153b7197-57a7-4e38-bd4a-4550b9d22dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153b7197-57a7-4e38-bd4a-4550b9d22dd8.jpg?1",
             "name": "Alaborn Grenadier",
             "text": "Attacking doesn't cause Alaborn Grenadier to tap.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "20adc065-0a79-5b52-ba02-315b613047d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4776a9ed-dbc6-44d2-9761-b2d09ff34008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4776a9ed-dbc6-44d2-9761-b2d09ff34008.jpg?1",
             "name": "Alaborn Musketeer",
             "text": "Alaborn Musketeer can block creatures with flying.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "fd1cdc87-8e3d-506a-849b-4103294ae429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg?1",
             "name": "Alaborn Trooper",
             "text": "",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "171ef4d1-e523-5b21-8133-520521182c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg?1",
             "name": "Alaborn Veteran",
             "text": "On your turn, before you attack, you may tap Alaborn Veteran to give any one creature +2/+2 until the end of the turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "0ab9317a-6ff8-5e7f-a7f7-c505884104ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5eba273-0b83-42a7-b8b0-9e0cd6a7aa6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5eba273-0b83-42a7-b8b0-9e0cd6a7aa6f.jpg?1",
             "name": "Alaborn Zealot",
             "text": "If Alaborn Zealot blocks, destroy both Alaborn Zealot and the creature it blocks. (Destroy both creatures before you deal damage.)",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "d579766b-8d09-5c6f-9866-da6f4847e7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2461bf0b-53e4-4103-8485-88a940ad66fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2461bf0b-53e4-4103-8485-88a940ad66fd.jpg?1",
             "name": "Angel of Fury",
             "text": "Flying\nIf Angel of Fury is put into your graveyard from play, you may choose to shuffle Angel of Fury into your library.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "3af0b117-d8af-50b4-9c78-7afd04196daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac5c913-4eb5-4cfb-9c24-223f14f07064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac5c913-4eb5-4cfb-9c24-223f14f07064.jpg?1",
             "name": "Angel of Mercy",
             "text": "Flying\nWhen Angel of Mercy comes into play from your hand, you gain 3 life.",
             "colours": [
@@ -274,7 +274,7 @@
         },
         {
             "id": "0483ce25-fc41-508d-9f20-30eb61015f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d409ef-9635-4ebe-944f-03e371bc40f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d409ef-9635-4ebe-944f-03e371bc40f0.jpg?1",
             "name": "Angelic Blessing",
             "text": "Any one creature gets +3/+3 and gains flying until the end of the turn.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "7ddca86a-2e7f-523f-89e4-0c3c1e136b4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bb39fb-29fc-4e69-9918-47277b8af0d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bb39fb-29fc-4e69-9918-47277b8af0d3.jpg?1",
             "name": "Angelic Wall",
             "text": "Flying\nWalls can't attack.",
             "colours": [
@@ -338,7 +338,7 @@
         },
         {
             "id": "e1d2266c-766d-5674-9f97-3d792e12bf1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73364e-d833-410f-b460-c36fe14c52ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73364e-d833-410f-b460-c36fe14c52ca.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking doesn't cause Archangel to tap.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "91c17e31-bed6-5572-8d96-d5a0d2c22b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f2ab-e09c-48d5-9c87-d27368e60750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591f2ab-e09c-48d5-9c87-d27368e60750.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands. (This includes your lands.)",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "b9680460-9d43-5cf0-8f0a-0ae3629b6964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54866603-c80c-4dc8-9655-eaf54ed2c5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54866603-c80c-4dc8-9655-eaf54ed2c5ab.jpg?1",
             "name": "Armored Griffin",
             "text": "Flying\nAttacking doesn't cause Armored Griffin to tap.",
             "colours": [
@@ -435,7 +435,7 @@
         },
         {
             "id": "acb236ef-c2bc-5ef8-9820-19755172f21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7f3064-a378-4ca4-99f5-b46518ddc43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7f3064-a378-4ca4-99f5-b46518ddc43d.jpg?1",
             "name": "Bargain",
             "text": "Your opponent draws a card.\nYou gain 7 life.",
             "colours": [
@@ -466,7 +466,7 @@
         },
         {
             "id": "dd85a42c-fc6b-5ae6-920d-21b4de59b019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10f24f7-f82e-413e-824f-384607c7d858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10f24f7-f82e-413e-824f-384607c7d858.jpg?1",
             "name": "Breath of Life",
             "text": "Take any one creature card from your graveyard and put that creature into play. Treat it as though you just played it from your hand.",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "e59a2c2e-afea-56cd-aecf-f813ddafd80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bd783b-d4cd-4a53-8fec-a5ead7c14738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bd783b-d4cd-4a53-8fec-a5ead7c14738.jpg?1",
             "name": "Festival of Trokin",
             "text": "For each creature you have in play, you gain 2 life.",
             "colours": [
@@ -528,7 +528,7 @@
         },
         {
             "id": "46a26109-7a27-56e8-818b-83dc6524cdb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg?1",
             "name": "Just Fate",
             "text": "Play Just Fate only after you're attacked, before you declare blockers.\nDestroy any one attacking creature.",
             "colours": [
@@ -559,7 +559,7 @@
         },
         {
             "id": "62ecf410-4a0c-5c81-8daa-84cfc2efe9c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb14d3f4-09f3-4113-bdc3-0fd753137f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb14d3f4-09f3-4113-bdc3-0fd753137f7c.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy any one creature. That creature's owner gains 4 life.",
             "colours": [
@@ -590,7 +590,7 @@
         },
         {
             "id": "0800ceaa-23e1-50da-a073-d12b176e59d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d92577-c3e2-4129-8974-89eb896cdc2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d92577-c3e2-4129-8974-89eb896cdc2d.jpg?1",
             "name": "Rally the Troops",
             "text": "Play Rally the Troops only after you're attacked, before you declare blockers.\nUntap all your creatures.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "84d32c03-2f69-57e4-a4ca-4bb26f52e45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7bd958-20c7-4394-8beb-06b32db90d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7bd958-20c7-4394-8beb-06b32db90d32.jpg?1",
             "name": "Righteous Charge",
             "text": "All your creatures get +2/+2 until the end of the turn.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "a753d196-28bb-5e29-a888-b56191ddf1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c408f43e-9092-440d-a15f-bef4ad58bcc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c408f43e-9092-440d-a15f-bef4ad58bcc6.jpg?1",
             "name": "Righteous Fury",
             "text": "Destroy all tapped creatures. For each creature destroyed this way, you gain 2 life. (This includes your creatures.)",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "465ba5c5-ce53-57bf-a5d0-af89c2eb50d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbf23ff-e095-4c5c-afe6-76badfc422c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbf23ff-e095-4c5c-afe6-76badfc422c5.jpg?1",
             "name": "Steam Catapult",
             "text": "On your turn, before you attack, you may tap Steam Catapult to destroy any one tapped creature.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "724dfe39-01f7-5db8-a143-dbe14b697ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be7cba2-5673-4bef-aa3d-cbfad8932610.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be7cba2-5673-4bef-aa3d-cbfad8932610.jpg?1",
             "name": "Temple Acolyte",
             "text": "When Temple Acolyte comes into play from your hand, you gain 3 life.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "f95be15a-ab0a-540f-ad0d-f09395d35f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4d4b14-d774-430c-a483-be04a238718d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4d4b14-d774-430c-a483-be04a238718d.jpg?1",
             "name": "Temple Elder",
             "text": "On your turn, before you attack, you may tap Temple Elder to gain 1 life.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "72962fc6-224e-5bf8-a4bc-95160869cf74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e9db36-0592-4e59-951a-d9d6c1522b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e9db36-0592-4e59-951a-d9d6c1522b99.jpg?1",
             "name": "Town Sentry",
             "text": "If Town Sentry blocks, it gets +0/+2 until the end of the turn.",
             "colours": [
@@ -819,7 +819,7 @@
         },
         {
             "id": "13b39a81-9d65-5fbc-9b4f-578a0eb7be78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2b9302-fca6-43ca-a01c-03aec51acd0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2b9302-fca6-43ca-a01c-03aec51acd0d.jpg?1",
             "name": "Trokin High Guard",
             "text": "",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "350f6e61-59d9-530f-8d78-e789f66abb7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3209ee48-4485-44fc-b71d-cd6241674e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3209ee48-4485-44fc-b71d-cd6241674e64.jpg?1",
             "name": "Vengeance",
             "text": "Destroy any one tapped creature.",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "110013f9-92fe-514c-93b7-b35688d16310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg?1",
             "name": "Volunteer Militia",
             "text": "",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "74313962-3c55-5849-950a-82df41d58fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a24f00c-7e2e-4609-b956-ca3d5fb365b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a24f00c-7e2e-4609-b956-ca3d5fb365b2.jpg?1",
             "name": "Warrior's Stand",
             "text": "Play Warrior's Stand only after you're attacked, before you declare blockers.\nAll your creatures get +2/+2 until the end of the turn.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "ff37c3b6-fcb9-5376-9a68-504edefff8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b6541a-cda3-4c8a-a5b0-1845169b9b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b6541a-cda3-4c8a-a5b0-1845169b9b71.jpg?1",
             "name": "Wild Griffin",
             "text": "Flying",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "1507acc3-d4d3-5f7b-a86b-9a23adfbb6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd01ed7d-45d5-420c-836c-aec52250f161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd01ed7d-45d5-420c-836c-aec52250f161.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "8cdea777-148b-57de-990d-afce048a556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd317-5500-40e8-ad79-323832815f81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd317-5500-40e8-ad79-323832815f81.jpg?1",
             "name": "Apprentice Sorcerer",
             "text": "On your turn, before you attack, you may tap Apprentice Sorcerer to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -1049,7 +1049,7 @@
         },
         {
             "id": "e1e71ca9-c264-50d2-9c7b-b33762fb694f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b2978-2da5-41cf-85d4-128e9dae75c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b2978-2da5-41cf-85d4-128e9dae75c0.jpg?1",
             "name": "Armored Galleon",
             "text": "Armored Galleon can't attack unless the defending player has an island in play.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "8d7f7c47-ef31-5368-9375-3cb9700bf922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8c7377-1404-44a4-9689-1fc6cdc286c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8c7377-1404-44a4-9689-1fc6cdc286c8.jpg?1",
             "name": "Coastal Wizard",
             "text": "On your turn, before you attack, you may tap Coastal Wizard to return it and any one other creature to their owners' hands.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "8c5dc4a4-26d4-50c6-a244-6dc4315b5e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620478b8-47b7-48c5-ac22-1ba4d234c794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620478b8-47b7-48c5-ac22-1ba4d234c794.jpg?1",
             "name": "Denizen of the Deep",
             "text": "When Denizen of the Deep comes into play from your hand, return all your other creatures from play to your hand.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "19fdf0c3-9b8e-5402-a15a-c540801ebce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade6a71a-e8ec-4d41-8a39-3eacf0097c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade6a71a-e8ec-4d41-8a39-3eacf0097c8b.jpg?1",
             "name": "D\u00e9j\u00e0 Vu",
             "text": "Return any one sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1181,7 +1181,7 @@
         },
         {
             "id": "316eb72b-74b5-53ec-a434-132481adcd5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc103a6-7888-4e35-b35b-a796a48caf70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc103a6-7888-4e35-b35b-a796a48caf70.jpg?1",
             "name": "Exhaustion",
             "text": "At the beginning of your opponent's next turn, he or she skips untapping creatures and lands.",
             "colours": [
@@ -1212,7 +1212,7 @@
         },
         {
             "id": "8893a4c8-eb91-5a67-b93a-9c619f392a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641f4e66-b46b-4da3-a053-f3763400d4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641f4e66-b46b-4da3-a053-f3763400d4f5.jpg?1",
             "name": "Extinguish",
             "text": "Play Extinguish only in response to another player playing a sorcery. That sorcery has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1243,7 +1243,7 @@
         },
         {
             "id": "a43e6feb-1a79-5829-a53e-7243d7fdb42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee109b81-96ef-494a-9d6d-0ea4a49b76a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee109b81-96ef-494a-9d6d-0ea4a49b76a0.jpg?1",
             "name": "Eye Spy",
             "text": "Look at the top card of any player's library. You may choose to put that card back on top of that library or into that player's graveyard.",
             "colours": [
@@ -1274,7 +1274,7 @@
         },
         {
             "id": "0043f4a7-aa18-59f1-b105-33d0c481665a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7d30a8-bc7a-42bc-8d1b-600cbf78ab98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7d30a8-bc7a-42bc-8d1b-600cbf78ab98.jpg?1",
             "name": "False Summoning",
             "text": "Play False Summoning only in response to another player playing a creature. That creature card has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "8aa736aa-0632-50f5-8f65-0cbee1894fea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bb424f-f3d6-4616-a368-df12af3ad024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bb424f-f3d6-4616-a368-df12af3ad024.jpg?1",
             "name": "Mystic Denial",
             "text": "Play Mystic Denial only in response to another player playing a creature or a sorcery. That card has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "9db14610-4ab3-53d9-9c0b-27cd78790739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daeab88f-2bfc-4f40-8eed-ee44a9e90bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daeab88f-2bfc-4f40-8eed-ee44a9e90bd7.jpg?1",
             "name": "Piracy",
             "text": "This turn, you may tap your opponent's lands to help pay for your spells.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "04759a7b-46dc-512e-8b66-09a3d706aea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb08549-8ff8-410f-b817-0255abaf8b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb08549-8ff8-410f-b817-0255abaf8b1e.jpg?1",
             "name": "Remove",
             "text": "Play Remove only after you're attacked, before you declare blockers.\nReturn any one attacking creature to its owner's hand.",
             "colours": [
@@ -1398,7 +1398,7 @@
         },
         {
             "id": "ded7a8ef-0d84-59b1-9472-0ef2e695c9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c16faac-b093-425b-b1e9-f71602d2f6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c16faac-b093-425b-b1e9-f71602d2f6dd.jpg?1",
             "name": "Screeching Drake",
             "text": "Flying\nWhen Screeching Drake comes into play from your hand, draw a card, then choose and discard a card from your hand.",
             "colours": [
@@ -1431,7 +1431,7 @@
         },
         {
             "id": "63dde068-db76-5981-9523-57975ca1c666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87a40cb-b30d-41ce-8e11-5fe3136fdadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87a40cb-b30d-41ce-8e11-5fe3136fdadd.jpg?1",
             "name": "Sea Drake",
             "text": "Flying\nWhen Sea Drake comes into play from your hand, return any two of your lands from play to your hand.",
             "colours": [
@@ -1464,7 +1464,7 @@
         },
         {
             "id": "cf9edb85-1751-5ba5-adef-bad2ef7f6986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405184-dcda-4bb6-ade6-c2a87bc3296d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3405184-dcda-4bb6-ade6-c2a87bc3296d.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "8aa2dbd3-e900-51e3-879e-5ec275208b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3193cb-2c00-4ef8-bf2e-d3b1e3b875a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3193cb-2c00-4ef8-bf2e-d3b1e3b875a3.jpg?1",
             "name": "Steam Frigate",
             "text": "Steam Frigate can't attack unless the defending player has an island in play.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "70bd28c6-a9c5-572e-b6b0-1b8d7fc0fa99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bc3159-f585-45cd-8578-f3bf2fa9b2d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bc3159-f585-45cd-8578-f3bf2fa9b2d1.jpg?1",
             "name": "Talas Air Ship",
             "text": "Flying",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "f76df1e2-be5f-5592-a574-5001bea3a05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f184c9-a716-4ba8-8efa-495358660de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f184c9-a716-4ba8-8efa-495358660de5.jpg?1",
             "name": "Talas Explorer",
             "text": "Flying\nWhen Talas Explorer comes into play from your hand, look at your opponent's hand.",
             "colours": [
@@ -1598,7 +1598,7 @@
         },
         {
             "id": "0eb7db17-9d5e-5d7c-ba08-4159877ba814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f779d7e-6e37-49bc-b76d-3bb490ff142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f779d7e-6e37-49bc-b76d-3bb490ff142b.jpg?1",
             "name": "Talas Merchant",
             "text": "",
             "colours": [
@@ -1632,7 +1632,7 @@
         },
         {
             "id": "0ce6d425-2333-5622-9087-48616ba9b8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg?1",
             "name": "Talas Researcher",
             "text": "On your turn, before you attack, you may tap Talas Researcher to draw a card.",
             "colours": [
@@ -1667,7 +1667,7 @@
         },
         {
             "id": "81fd67e1-cf2d-54a5-b551-93d4d1bc1b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e12f17-855e-47e0-b7e3-df5c388b01bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e12f17-855e-47e0-b7e3-df5c388b01bb.jpg?1",
             "name": "Talas Scout",
             "text": "Flying",
             "colours": [
@@ -1702,7 +1702,7 @@
         },
         {
             "id": "974226c9-6859-5de9-80f8-eb106296a8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg?1",
             "name": "Talas Warrior",
             "text": "Talas Warrior can't be blocked.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "f081f76c-3aa0-5889-a5a7-f63aea5ca57e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3964160-79d6-4cdd-8b43-7a8f5dde9da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3964160-79d6-4cdd-8b43-7a8f5dde9da7.jpg?1",
             "name": "Temporal Manipulation",
             "text": "You take another turn after this one.",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "1f6b87d2-3663-532e-b011-6b95f8ddc236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a826f84c-24c4-41f9-88a9-a18dc860b9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a826f84c-24c4-41f9-88a9-a18dc860b9a1.jpg?1",
             "name": "Theft of Dreams",
             "text": "For each tapped creature your opponent has in play, you draw a card.",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "b7a2a843-26e0-5948-b66e-3212e30ddf01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9ecba0-3d9d-4383-a45c-103300442799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9ecba0-3d9d-4383-a45c-103300442799.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap any one, two, or three creatures without flying. (Tapped creatures can't block.)",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "491786cf-991c-5c20-a11b-958972e016bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea285582-2279-4393-885d-e471d00681e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea285582-2279-4393-885d-e471d00681e9.jpg?1",
             "name": "Time Ebb",
             "text": "Return any one creature from play to the top of its owner's library.",
             "colours": [
@@ -1861,7 +1861,7 @@
         },
         {
             "id": "70a2c64e-f671-5d40-9d2e-9bdd40f3e766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277d38ee-09e5-4266-a077-d737f6c8b8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277d38ee-09e5-4266-a077-d737f6c8b8d3.jpg?1",
             "name": "Touch of Brilliance",
             "text": "Draw two cards.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "8050fe2a-9f5a-5300-beac-15250be4edf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca55da2-33e1-44b5-88b2-ac159d842b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca55da2-33e1-44b5-88b2-ac159d842b1f.jpg?1",
             "name": "Undo",
             "text": "Return any two creatures from play to their owner's hand. (You can't play Undo unless you can choose two creatures to return.)",
             "colours": [
@@ -1923,7 +1923,7 @@
         },
         {
             "id": "4c7a7830-5f7f-5be4-ba41-0b52cea64699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ef39fd-96d0-4a02-97d5-580d121b92a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ef39fd-96d0-4a02-97d5-580d121b92a3.jpg?1",
             "name": "Wind Sail",
             "text": "Any one or two creatures gain flying until the end of the turn.",
             "colours": [
@@ -1954,7 +1954,7 @@
         },
         {
             "id": "dac8f009-9bc3-5bdf-8d2e-edabee93f412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b688039-7441-490b-ad06-8a72086c4023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b688039-7441-490b-ad06-8a72086c4023.jpg?1",
             "name": "Abyssal Nightstalker",
             "text": "If Abyssal Nightstalker attacks and isn't blocked, your opponent chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "516fa67d-a565-5342-95bb-531186f068b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee59a7-0f41-4d5d-b049-71ca1ba335b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ee59a7-0f41-4d5d-b049-71ca1ba335b1.jpg?1",
             "name": "Ancient Craving",
             "text": "Draw 3 cards. You lose 3 life.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "575c60ba-1c3f-5bf1-93f0-6f7a1fd96e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb0ec62-6d6f-4d10-bc2d-37f25495f884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb0ec62-6d6f-4d10-bc2d-37f25495f884.jpg?1",
             "name": "Bloodcurdling Scream",
             "text": "Any one creature gets +X/+0 until the end of the turn.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "0612e7c2-a81e-5402-8381-57526adb3543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b471102b-a66e-4cdc-b20f-7ae1f9bd0e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b471102b-a66e-4cdc-b20f-7ae1f9bd0e8a.jpg?1",
             "name": "Brutal Nightstalker",
             "text": "When Brutal Nightstalker comes into play from your hand, you may force your opponent to choose and discard a card from his or her hand.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "2b9a4d6e-3d64-5ba9-af7c-09a2ecbd61d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0289ddb3-b35c-4edf-92bb-06f84a3475d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0289ddb3-b35c-4edf-92bb-06f84a3475d9.jpg?1",
             "name": "Chorus of Woe",
             "text": "All your creatures get +1/+0 until the end of the turn.",
             "colours": [
@@ -2113,7 +2113,7 @@
         },
         {
             "id": "ff67662b-8b9c-5b8f-8dbe-7c04305ad2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ff6af-22f4-46fb-97d3-6f8f20f8b16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6ff6af-22f4-46fb-97d3-6f8f20f8b16c.jpg?1",
             "name": "Coercion",
             "text": "Look at your opponent's hand and choose a card. Your opponent discards that card.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "b4699ee1-f9e7-5fa0-8573-2386057450ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018d90-cfcc-4fb1-8ecd-4e0f1c71550d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6018d90-cfcc-4fb1-8ecd-4e0f1c71550d.jpg?1",
             "name": "Cruel Edict",
             "text": "Your opponent chooses one of his or her creatures. Destroy that creature.",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "ca4821fb-c959-5896-92ee-00f4097de468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45994db-776d-420e-9241-99bf3b71fa59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45994db-776d-420e-9241-99bf3b71fa59.jpg?1",
             "name": "Dakmor Bat",
             "text": "Flying",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "93b020c6-073e-5833-b0ab-f4559a0a9f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b38ef1-5839-4292-91d6-e45698c69a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b38ef1-5839-4292-91d6-e45698c69a75.jpg?1",
             "name": "Dakmor Plague",
             "text": "Dakmor Plague deals 3 damage to each creature and player. (This includes your creatures and you.)",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "5c3c5884-bda4-517e-99b7-d46842c1dad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d860dee-93a9-48e5-ba7a-80ad8cdc84e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d860dee-93a9-48e5-ba7a-80ad8cdc84e4.jpg?1",
             "name": "Dakmor Scorpion",
             "text": "",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "4aa4a590-1596-5ee0-9d58-f229d47b8e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985ef9ad-b842-40b7-8d56-98143ecef0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985ef9ad-b842-40b7-8d56-98143ecef0dc.jpg?1",
             "name": "Dakmor Sorceress",
             "text": "Dakmor Sorceress has power equal to the number of swamp cards you have in play. (This includes both tapped and untapped swamp cards.)",
             "colours": [
@@ -2306,7 +2306,7 @@
         },
         {
             "id": "a0e742fa-fe52-5041-a6cc-2e3aebc18022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0cef9-6de4-4a71-b76a-eb0198387294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0cef9-6de4-4a71-b76a-eb0198387294.jpg?1",
             "name": "Dark Offering",
             "text": "Destroy any one creature that isn't black. You gain 3 life.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "0c077160-e0a7-5de4-a27b-e7ff0a4c98ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b63e5f-b2cf-42c2-8111-1ebb9ed5ca33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b63e5f-b2cf-42c2-8111-1ebb9ed5ca33.jpg?1",
             "name": "Foul Spirit",
             "text": "Flying\nWhen Foul Spirit comes into play from your hand, destroy one of your lands.",
             "colours": [
@@ -2370,7 +2370,7 @@
         },
         {
             "id": "8de745fa-581d-5a3b-9c32-ca0ff9f87d13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9761136-9e1c-4d86-98ce-7abe1d8e6a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9761136-9e1c-4d86-98ce-7abe1d8e6a8d.jpg?1",
             "name": "Hand of Death",
             "text": "Destroy any one creature that isn't black.",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "f4b65e49-910a-5dfc-a808-9bb2424190d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64243f71-0941-47d5-816b-4548986726b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64243f71-0941-47d5-816b-4548986726b4.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play from your hand, choose and discard a creature card from your hand or destroy Hidden Horror.",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "94e668ca-1b53-5028-b559-fff08f43356a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6832c1-a0a9-49ec-a787-879e510aee08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6832c1-a0a9-49ec-a787-879e510aee08.jpg?1",
             "name": "Kiss of Death",
             "text": "Kiss of Death deals 4 damage to your opponent. You gain 4 life.",
             "colours": [
@@ -2465,7 +2465,7 @@
         },
         {
             "id": "4dcb0f98-0a83-5365-9a1e-937e5f109401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg?1",
             "name": "Lurking Nightstalker",
             "text": "If Lurking Nightstalker attacks, it gets +2/+0 until the end of the turn.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "8112531e-c241-5fcb-92d1-2c3c0f709204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7553a2bf-2038-42f7-a311-bdc889dd773d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7553a2bf-2038-42f7-a311-bdc889dd773d.jpg?1",
             "name": "Mind Rot",
             "text": "Your opponent chooses and discards two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "62b1755a-e270-5b46-8cbf-4049c6c6e196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd99210-5201-4ecc-b86a-aee9dafe2657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd99210-5201-4ecc-b86a-aee9dafe2657.jpg?1",
             "name": "Moaning Spirit",
             "text": "Flying",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "37831dcf-45b7-5f5f-9213-4fc8c7af251d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded268ef-f1a3-4d53-82f6-9562fe51c3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded268ef-f1a3-4d53-82f6-9562fe51c3e4.jpg?1",
             "name": "Muck Rats",
             "text": "",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "0e102aad-8772-5e22-a5fb-a3318a7792bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg?1",
             "name": "Nightstalker Engine",
             "text": "Nightstalker Engine has power equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "e7f5da17-ad50-50e4-b248-e8b8e824c104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4c782-bd7f-495e-8a4d-ea7c9ac1f58b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd4c782-bd7f-495e-8a4d-ea7c9ac1f58b.jpg?1",
             "name": "Predatory Nightstalker",
             "text": "When Predatory Nightstalker comes into play from your hand, you may force your opponent to destroy any one of his or her creatures. (Your opponent chooses the creature.)",
             "colours": [
@@ -2661,7 +2661,7 @@
         },
         {
             "id": "9195d9bb-5103-5e27-ae00-822e3e57e59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749e3992-693b-4b4f-b410-b5f2faac0040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749e3992-693b-4b4f-b410-b5f2faac0040.jpg?1",
             "name": "Prowling Nightstalker",
             "text": "Prowling Nightstalker can't be blocked except by other black creatures.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "2b570781-3bc3-5d77-bc6b-5a00a87058ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df2887c-e70b-4ff3-a437-450c0037fb07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df2887c-e70b-4ff3-a437-450c0037fb07.jpg?1",
             "name": "Raiding Nightstalker",
             "text": "Swampwalk (If defending player has any swamps in play, Raiding Nightstalker can't be blocked.)",
             "colours": [
@@ -2727,7 +2727,7 @@
         },
         {
             "id": "64c5f63d-5196-5a37-be41-c85f7f94bba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb09a5bb-9730-43cd-8dea-3842634c9983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb09a5bb-9730-43cd-8dea-3842634c9983.jpg?1",
             "name": "Rain of Daggers",
             "text": "Destroy all your opponent's creatures. For each creature destroyed this way, you lose 2 life.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "a4d5a511-dc6d-58d2-b0e6-5b04bd4ac77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4a57-003e-40fd-9998-ed10b38eeed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ec4a57-003e-40fd-9998-ed10b38eeed7.jpg?1",
             "name": "Raise Dead",
             "text": "Return any one creature from your graveyard to your hand.",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "dbfbdbde-31df-55a9-a33c-2c8b81c244bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8899244b-737a-43a9-9241-15a650b47bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8899244b-737a-43a9-9241-15a650b47bed.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play from your hand, your opponent chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "6cd4312c-0bc2-5b2d-9227-dba980357c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85d85c2-9f34-4375-adcd-a1c5b487cacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e85d85c2-9f34-4375-adcd-a1c5b487cacc.jpg?1",
             "name": "Return of the Nightstalkers",
             "text": "Return all the Nightstalker cards from your graveyard to play. Then destroy all your swamps. (Treat these Nightstalkers as though they just came into play from your hand.)",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "fd337cda-1afa-5f52-80e4-42910a7afb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f154e89e-bb64-4579-9ff5-f3fc1c480105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f154e89e-bb64-4579-9ff5-f3fc1c480105.jpg?1",
             "name": "Swarm of Rats",
             "text": "Swarm of Rats has power equal to the number of Rat cards you have in play. (This includes both tapped and untapped Rat cards.)",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "fe2d6487-6a2e-5608-bb2a-ae3682cee148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f636e46a-9d35-47b8-8df0-6dcb18105d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f636e46a-9d35-47b8-8df0-6dcb18105d30.jpg?1",
             "name": "Vampiric Spirit",
             "text": "Flying\nWhen Vampiric Spirit comes into play from your hand, you lose 4 life. (The person who plays Vampiric Spirit loses the life.)",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "6519b9e0-bd98-56d1-b6b2-29965aea4952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3940d0ca-0ca2-4446-9330-a554c3e89824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3940d0ca-0ca2-4446-9330-a554c3e89824.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "5afa368e-cb51-50bd-beda-d846a6d33c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c72f51-2e8c-4a2f-9b61-80f36f8af521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c72f51-2e8c-4a2f-9b61-80f36f8af521.jpg?1",
             "name": "Brimstone Dragon",
             "text": "Flying\nBrimstone Dragon is unaffected by summoning sickness.",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "82530037-d893-59cd-abee-99027f67dc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa284a7-3aac-4e88-becb-548a28c77401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aa284a7-3aac-4e88-becb-548a28c77401.jpg?1",
             "name": "Cunning Giant",
             "text": "If Cunning Giant attacks and isn't blocked, you may choose to have it deal its damage to any one of your opponent's creatures instead of to him or her.",
             "colours": [
@@ -3016,7 +3016,7 @@
         },
         {
             "id": "92f67327-2f22-561b-a7b5-f5238dbc9d04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05126438-e806-43e6-bd81-233b629b4a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05126438-e806-43e6-bd81-233b629b4a1b.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each player and each creature without flying. (This includes you and your creatures without flying.)",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "8ee0c16d-e5b0-5720-a00b-60615a2b314e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg?1",
             "name": "Goblin Cavaliers",
             "text": "",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "277baec0-d7a7-509c-9eed-b84cf8b5588a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ee21ef-26c0-4def-9046-5d6fcfa3bfeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84ee21ef-26c0-4def-9046-5d6fcfa3bfeb.jpg?1",
             "name": "Goblin Firestarter",
             "text": "On your turn, before you attack, you may destroy Goblin Firestarter to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "759d1485-38de-5afa-abf1-13a5d20e7d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg?1",
             "name": "Goblin General",
             "text": "When Goblin General attacks, all your Goblins get +1/+1 until the end of the turn.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "c111fa97-2ee7-5e19-bd82-6ccb3a7d75e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29491b-dec1-429d-9950-062582f8164f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c29491b-dec1-429d-9950-062582f8164f.jpg?1",
             "name": "Goblin Glider",
             "text": "Flying\nGoblin Glider can't block.",
             "colours": [
@@ -3180,7 +3180,7 @@
         },
         {
             "id": "d8f69b28-e416-595c-bfee-c53b0705fce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26f34db-732c-43d4-a6ef-e170538c0235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26f34db-732c-43d4-a6ef-e170538c0235.jpg?1",
             "name": "Goblin Lore",
             "text": "Draw four cards and put them into your hand. Then discard three cards at random from your hand.",
             "colours": [
@@ -3211,7 +3211,7 @@
         },
         {
             "id": "ae5ed59e-eeb9-566b-b34e-eaac16ebdf96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc21c-8600-49bf-b0a3-c981f7ec7ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc21c-8600-49bf-b0a3-c981f7ec7ac3.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron comes into play from your hand, search your library for a Goblin card and put that card into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "74f91826-a15a-5308-9eef-688acee31858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f841fe25-237f-4303-b75e-392b82767eea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f841fe25-237f-4303-b75e-392b82767eea.jpg?1",
             "name": "Goblin Mountaineer",
             "text": "Mountainwalk (If defending player has any mountains in play, Goblin Mountaineer can't be blocked.)",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "ca6a9cc9-e6fd-5144-87ad-eba35e119df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2786834d-dbda-40ce-82a4-e518cd554312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2786834d-dbda-40ce-82a4-e518cd554312.jpg?1",
             "name": "Goblin Piker",
             "text": "",
             "colours": [
@@ -3312,7 +3312,7 @@
         },
         {
             "id": "2a71900e-1705-5213-860a-f6a402fc96db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fe9691-d788-42cb-8d13-005724939b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fe9691-d788-42cb-8d13-005724939b62.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider can't block.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "c1c90f29-a704-5eb2-9cae-cd28cc160595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3822880c-a559-409c-8390-6d57eacc3a7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3822880c-a559-409c-8390-6d57eacc3a7c.jpg?1",
             "name": "Goblin War Cry",
             "text": "Your opponent chooses one of his or her creatures. Only that creature can block this turn.",
             "colours": [
@@ -3377,7 +3377,7 @@
         },
         {
             "id": "f618fa47-ebc9-5c44-b7f7-7742d7392228",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738fecfd-1119-4dcb-acd6-ec9715d9c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738fecfd-1119-4dcb-acd6-ec9715d9c074.jpg?1",
             "name": "Goblin War Strike",
             "text": "Goblin War Strike deals to your opponent damage equal to the number of Goblin cards you have in play. (This includes both tapped and untapped Goblin cards.)",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "77982381-6622-56be-9afd-ae45ed09a60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148e6704-9cf0-45cf-9bab-db318c016593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148e6704-9cf0-45cf-9bab-db318c016593.jpg?1",
             "name": "Jagged Lightning",
             "text": "Choose any two creatures. Jagged Lightning deals 3 damage to each of them. (You can't play Jagged Lightning unless you can choose two creatures to damage.)",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "12fc06d7-c686-536c-869e-69d87b31be0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6cff90-ecec-4610-82ea-0f2a109959cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6cff90-ecec-4610-82ea-0f2a109959cf.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to your opponent.",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "41cf5fdb-78ba-5279-94e3-8b9089402777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bec2e0-a016-42bd-85d9-fbb262998110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bec2e0-a016-42bd-85d9-fbb262998110.jpg?1",
             "name": "Magma Giant",
             "text": "When Magma Giant comes into play from your hand, it deals 2 damage to each creature and player. (This includes you and your creatures, including Magma Giant.)",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "222bb560-d849-5fb8-96bf-70298bbee34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg?1",
             "name": "Obsidian Giant",
             "text": "",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "c4a44fc9-3f2d-5557-9cec-723391aebc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e28b2-9d25-4873-8db2-1f0853ab0c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b67e28b2-9d25-4873-8db2-1f0853ab0c47.jpg?1",
             "name": "Ogre Arsonist",
             "text": "When Ogre Arsonist comes into play from your hand, destroy any one land. (If you're the only one with lands, destroy one of them.)",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "d8e88429-350d-5355-a097-0693652b0913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6969d4d-c311-4663-bcd6-77a4d6458335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6969d4d-c311-4663-bcd6-77a4d6458335.jpg?1",
             "name": "Ogre Berserker",
             "text": "Ogre Berserker is unaffected by summoning sickness.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "ba13cfbd-9459-5d04-9ae6-078284b463ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d674a92e-b268-48f7-b082-f8ca2e63d43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d674a92e-b268-48f7-b082-f8ca2e63d43b.jpg?1",
             "name": "Ogre Taskmaster",
             "text": "Ogre Taskmaster can't block.",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "53e688a6-9ee1-557b-9b2f-7d2a8b1eae8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e72970-df1f-4ded-a686-036008555a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e72970-df1f-4ded-a686-036008555a76.jpg?1",
             "name": "Ogre Warrior",
             "text": "",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "3410676e-e924-5c61-87e4-10942865af61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6df5a36-7bd4-4456-a462-54f65089826c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6df5a36-7bd4-4456-a462-54f65089826c.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness.",
             "colours": [
@@ -3704,7 +3704,7 @@
         },
         {
             "id": "e1e44532-0531-52b8-868e-82ddcbe41908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c641c3d6-0364-4209-b908-1717e5e612ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c641c3d6-0364-4209-b908-1717e5e612ad.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all your creatures that attacked this turn. You may declare an additional attack this turn.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "eb25e792-fbdc-5ebf-885f-a5da2b26ae0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f868b8b0-2be2-4833-8e9a-43a08c6d9c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f868b8b0-2be2-4833-8e9a-43a08c6d9c96.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to any one creature damage equal to the number of mountains you have in play. (This includes both tapped and untapped mountains.)",
             "colours": [
@@ -3766,7 +3766,7 @@
         },
         {
             "id": "818e2d5c-52ca-5ce4-ad3f-fa5486afbed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0b04bc-54ba-48a8-9181-233e08774a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0b04bc-54ba-48a8-9181-233e08774a8b.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy any one land.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "cc01cb0e-d765-5cc6-9089-8596ad8b3022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2509285-a88e-4f5c-86c1-c0386da0f0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2509285-a88e-4f5c-86c1-c0386da0f0c5.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying. (This includes your creatures without flying.)",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "00287b3c-8c5b-530c-9b98-75ea54409c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c0489d-b073-4ad4-b044-447fcc865b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c0489d-b073-4ad4-b044-447fcc865b6c.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to any one creature or player.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "1d1fb2d8-002f-598e-b4f0-0af5dc66c996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cfcb0-db68-4494-a3e1-7c2ca279fcf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b69cfcb0-db68-4494-a3e1-7c2ca279fcf5.jpg?1",
             "name": "Wildfire",
             "text": "You destroy four of your lands and your opponent destroys four of his or her lands. Then Wildfire deals 4 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -3890,7 +3890,7 @@
         },
         {
             "id": "c6f49ef1-b130-54d8-8e3b-2fc40595e120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d66645-a5e5-4d29-9dc0-a058f7a3f24b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65d66645-a5e5-4d29-9dc0-a058f7a3f24b.jpg?1",
             "name": "Alluring Scent",
             "text": "Choose any one creature. This turn, all creatures able to block it do so.",
             "colours": [
@@ -3921,7 +3921,7 @@
         },
         {
             "id": "b4526a4d-ca64-555d-a0f6-93f3d8068c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f627db9-c63e-4353-94f4-3e28db7b222a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f627db9-c63e-4353-94f4-3e28db7b222a.jpg?1",
             "name": "Barbtooth Wurm",
             "text": "",
             "colours": [
@@ -3954,7 +3954,7 @@
         },
         {
             "id": "f7817572-0f68-597f-9246-b5de379c61b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71abb70-bee5-4823-83dc-db0707023b37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71abb70-bee5-4823-83dc-db0707023b37.jpg?1",
             "name": "Bear Cub",
             "text": "",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "7fa6bd82-88cf-5a02-9e08-2f0cbe18f23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dc1f90-8227-47ad-8551-a4e7e565738d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74dc1f90-8227-47ad-8551-a4e7e565738d.jpg?1",
             "name": "Bee Sting",
             "text": "Bee Sting deals 2 damage to any one creature or player.",
             "colours": [
@@ -4018,7 +4018,7 @@
         },
         {
             "id": "639b2933-80ef-538d-a9fc-3cfe844a92f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17e3b5-d609-4289-9b74-5ac96ab4ccfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c17e3b5-d609-4289-9b74-5ac96ab4ccfa.jpg?1",
             "name": "Deathcoil Wurm",
             "text": "If Deathcoil Wurm attacks and is blocked, you may choose to have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -4051,7 +4051,7 @@
         },
         {
             "id": "d029cb1a-bdc6-5702-bd54-a529becdd990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04db1-bf4a-4824-9dc9-f5c510ba62bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04db1-bf4a-4824-9dc9-f5c510ba62bc.jpg?1",
             "name": "Deep Wood",
             "text": "Play Deep Wood only after you're attacked, before you declare blockers.\nThis turn, all damage dealt to you by attacking creatures is reduced to 0.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "83afde0d-048d-5eef-a7de-97e1f8a80e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dfc789-7ea0-4eb8-8c3b-2c50fd52cbab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dfc789-7ea0-4eb8-8c3b-2c50fd52cbab.jpg?1",
             "name": "Golden Bear",
             "text": "",
             "colours": [
@@ -4115,7 +4115,7 @@
         },
         {
             "id": "bff1dee7-1680-5081-9898-3e0380335416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fa08d9-d41b-4696-b81a-42c8eebdeb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fa08d9-d41b-4696-b81a-42c8eebdeb49.jpg?1",
             "name": "Harmony of Nature",
             "text": "Tap any number of your creatures. You gain 4 life for each creature tapped this way. (Tapped creatures can't block.)",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "653f4e16-c6e6-5de1-97fb-d2394ea09eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4dd722-4729-444a-9d81-e2e93317fbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4dd722-4729-444a-9d81-e2e93317fbd5.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each player and each creature with flying. (This includes you and your creatures with flying.)",
             "colours": [
@@ -4177,7 +4177,7 @@
         },
         {
             "id": "9c531396-f661-5654-a8e0-d828ba3e0c99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2528c2-6405-4db9-9137-623946a4de2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2528c2-6405-4db9-9137-623946a4de2f.jpg?1",
             "name": "Ironhoof Ox",
             "text": "Ironhoof Ox can't be blocked by more than one creature.",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "ff21dc4c-e3c5-5c9d-9899-2071b63c48fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4d831-7388-4321-a636-79cf7bde25bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4d831-7388-4321-a636-79cf7bde25bb.jpg?1",
             "name": "Lone Wolf",
             "text": "If Lone Wolf attacks and is blocked, you may choose to have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "0a7ed31c-316e-5b29-b58b-3081e52bb8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8648e1-bc40-4eff-ad7b-ab0b62a47570.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8648e1-bc40-4eff-ad7b-ab0b62a47570.jpg?1",
             "name": "Lynx",
             "text": "Forestwalk (If defending player has any forests in play, Lynx can't be blocked.)",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "9de6e3c6-aacf-5978-8c31-1c44a334f65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3816da20-4434-4bf7-a9dd-3eb3bb735f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3816da20-4434-4bf7-a9dd-3eb3bb735f08.jpg?1",
             "name": "Monstrous Growth",
             "text": "Any one creature gets +4/+4 until the end of the turn.",
             "colours": [
@@ -4307,7 +4307,7 @@
         },
         {
             "id": "1910bd38-a3a9-5c7a-a9b7-56ff7b4b46fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d73903-182d-4fc8-a1e4-8a1738e7a67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d73903-182d-4fc8-a1e4-8a1738e7a67b.jpg?1",
             "name": "Natural Spring",
             "text": "You gain 8 life.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "0e7336bf-c1f7-5876-b9a5-3946315e94d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fb749-5672-4a5c-ac89-e443195b95bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43fb749-5672-4a5c-ac89-e443195b95bc.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your library for a forest card and put that forest into play. Shuffle your library afterwards.",
             "colours": [
@@ -4369,7 +4369,7 @@
         },
         {
             "id": "49b360ce-bd7a-56a5-a8a2-bd414fd162a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c545fa63-d0dd-422b-8d3b-88b444f13fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c545fa63-d0dd-422b-8d3b-88b444f13fce.jpg?1",
             "name": "Norwood Archers",
             "text": "Norwood Archers can block creatures with flying.",
             "colours": [
@@ -4403,7 +4403,7 @@
         },
         {
             "id": "493d9f3b-9e70-58e9-abe7-4dd5f92c68bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afd472f-1ede-4e78-b44c-3298ee4c8694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afd472f-1ede-4e78-b44c-3298ee4c8694.jpg?1",
             "name": "Norwood Priestess",
             "text": "On your turn, before you attack, you may tap Norwood Priestess to put any green creature from your hand into play without paying for it.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "3abd68ff-b3bf-5961-b63f-e3de124b38b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557c0c2-eb0f-4a9d-9192-577a684b3426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c557c0c2-eb0f-4a9d-9192-577a684b3426.jpg?1",
             "name": "Norwood Ranger",
             "text": "",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "4b94e6b5-c3b6-54d9-9cc5-bb7c006e0c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ba8db-853e-4f51-acfe-83e472524380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/904ba8db-853e-4f51-acfe-83e472524380.jpg?1",
             "name": "Norwood Riders",
             "text": "Norwood Riders can't be blocked by more than one creature.",
             "colours": [
@@ -4505,7 +4505,7 @@
         },
         {
             "id": "43cc936c-0de2-58b0-b570-caa56986feca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7ddf0a-1081-4ae0-ab91-b052153bab4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7ddf0a-1081-4ae0-ab91-b052153bab4c.jpg?1",
             "name": "Norwood Warrior",
             "text": "If Norwood Warrior attacks and is blocked, it gets +1/+1 until the end of the turn.",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "492fc440-2749-51f1-963f-f360b8761908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51f8724-8f26-4a9d-b586-4223354ae7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51f8724-8f26-4a9d-b586-4223354ae7fc.jpg?1",
             "name": "Plated Wurm",
             "text": "",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "4cd6af72-e7de-5e24-85b8-0c7c061c884a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg?1",
             "name": "Razorclaw Bear",
             "text": "If Razorclaw Bear attacks and is blocked, it gets +2/+2 until the end of the turn.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "8885ca05-257b-5dc6-b9ea-7a9c43955882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ec869-f933-4b27-9f0b-b583e71a1110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b63ec869-f933-4b27-9f0b-b583e71a1110.jpg?1",
             "name": "Renewing Touch",
             "text": "Choose any number of creature cards in your graveyard and shuffle them into your library.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "429b2a8e-b345-51cd-b21c-824386a1ed6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8508e3b-a934-4795-a2df-07e792f2685f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8508e3b-a934-4795-a2df-07e792f2685f.jpg?1",
             "name": "River Bear",
             "text": "Islandwalk (If defending player has any islands in play, River Bear can't be blocked.)",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "dcf7f3c0-9049-528b-bc94-5e6dffcfbcad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3012e10-566b-447c-bb0a-dfc38c8e0fdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3012e10-566b-447c-bb0a-dfc38c8e0fdf.jpg?1",
             "name": "Salvage",
             "text": "Take any one card from your graveyard and put that card on the top of your library.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "18cb7887-1a98-5e29-8438-ba0ccbce449d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09886-a733-4797-a489-46150cecfc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c09886-a733-4797-a489-46150cecfc13.jpg?1",
             "name": "Sylvan Basilisk",
             "text": "If Sylvan Basilisk attacks and is blocked, destroy all creatures blocking it. (Destroy the creatures before they deal damage. The Basilisk doesn't damage your opponent.)",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "9101ccc5-ed7a-535d-9f72-c6de22480e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8686e2-1e14-4b4a-b45b-cab4d5c57fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8686e2-1e14-4b4a-b45b-cab4d5c57fce.jpg?1",
             "name": "Sylvan Yeti",
             "text": "Sylvan Yeti has power equal to the number of cards you have in your hand.",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "b90050b3-17f9-58b0-8361-a6267516e349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60bbbf7-a005-4b4b-b8e4-e95bbb67f529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60bbbf7-a005-4b4b-b8e4-e95bbb67f529.jpg?1",
             "name": "Tree Monkey",
             "text": "Tree Monkey can block creatures with flying.",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "ad5222c8-3147-5a2f-8444-82c2f2111a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6890024-246c-42ba-8ccc-ffabb5867530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6890024-246c-42ba-8ccc-ffabb5867530.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your library for a plains, island, swamp, mountain, or forest card and put that land into play. Shuffle your library afterwards.",
             "colours": [
@@ -4830,7 +4830,7 @@
         },
         {
             "id": "7aea16f9-0a0a-50f8-bd05-77fda49b799b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7890-86dc-4fb8-a47b-99331bbe7c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c5a7890-86dc-4fb8-a47b-99331bbe7c29.jpg?1",
             "name": "Wild Ox",
             "text": "Swampwalk (If defending player has any swamps in play, Wild Ox can't be blocked.)",
             "colours": [
@@ -4863,7 +4863,7 @@
         },
         {
             "id": "0d6b107e-68c6-5e28-97ce-6d1932eb4595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ecf285-c48f-4ac3-9b75-0ee0ff052767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ecf285-c48f-4ac3-9b75-0ee0ff052767.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "5d46745e-85e1-5ae9-a4b1-960b9c1db9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a136975-e513-4c50-9d4a-855d03630470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a136975-e513-4c50-9d4a-855d03630470.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4935,7 +4935,7 @@
         },
         {
             "id": "ff7fb962-8fb2-5aec-8998-710212d0d154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67f2ecd-d5fb-406b-b14d-34eb087eb08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67f2ecd-d5fb-406b-b14d-34eb087eb08b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "5cb3137c-a011-58a3-8a8e-ca1dcc8a267c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a83b1a-a734-4726-9d14-c75ef04798d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a83b1a-a734-4726-9d14-c75ef04798d1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "709de056-1e70-5816-b2a8-dde675948a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b165ada0-7f52-4047-8596-c54247d13704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b165ada0-7f52-4047-8596-c54247d13704.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "a78566cd-eff9-5a23-b09b-891d43799bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8ecec-8925-470b-994d-79694d056834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf8ecec-8925-470b-994d-79694d056834.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "14a0f5d1-1100-55e8-9f6f-15c4806d053b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c0bd18-fdee-4cb2-8a7e-dd86bb8a6bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c0bd18-fdee-4cb2-8a7e-dd86bb8a6bbe.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "279ae081-dc2f-5357-8966-e428caddf916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb62dd9-266b-4de9-8a11-3228b5f1e03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adb62dd9-266b-4de9-8a11-3228b5f1e03a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "fb4ad4a5-93e1-5c98-ab65-96ebf4d46047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103ed69-b73b-4789-a28d-1fd071bc9029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c103ed69-b73b-4789-a28d-1fd071bc9029.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5187,7 +5187,7 @@
         },
         {
             "id": "d8246b61-33b9-5592-b8ea-4a96e0d7cd81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfbb15a-d7f4-470a-9d36-78c710a6d397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfbb15a-d7f4-470a-9d36-78c710a6d397.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "30e49f46-dbd1-5ed3-a7ce-394c539444e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4453a5c0-76f2-422d-8cbc-4b21c17cdf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4453a5c0-76f2-422d-8cbc-4b21c17cdf1e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5259,7 +5259,7 @@
         },
         {
             "id": "3e4002a2-b656-51d7-b566-26542676d5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9006aa97-884f-404a-9ead-af8437ea9596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9006aa97-884f-404a-9ead-af8437ea9596.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "5e6307c8-c4a6-5a27-9a77-b7ffac92271e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f4fcbb-86a8-475f-a547-d59014bb7a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f4fcbb-86a8-475f-a547-d59014bb7a98.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "c46f8daa-1bdb-5821-8a13-d5808d2c5030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa863815-1dcc-43d8-8076-a35037688b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa863815-1dcc-43d8-8076-a35037688b20.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5367,7 +5367,7 @@
         },
         {
             "id": "cdc41ceb-9350-52b8-bd36-3d54bdf5d1d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abebee47-5205-4855-ae72-475b58a02240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abebee47-5205-4855-ae72-475b58a02240.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/PCY.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/PCY.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "01b64921-dba7-5ddc-aa4a-4dd9e670345d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c81ae90-5abd-4c79-b14a-d5f3a1daff38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c81ae90-5abd-4c79-b14a-d5f3a1daff38.jpg?1",
             "name": "Abolish",
             "text": "You may discard a plains from your hand instead of paying Abolish's mana cost.\nDestroy target artifact or enchantment.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "db67c6ad-9b6c-5387-ae08-f36a06ca744e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8d3e36-977f-4169-8f2a-a4057b912ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8d3e36-977f-4169-8f2a-a4057b912ccb.jpg?1",
             "name": "Aura Fracture",
             "text": "Sacrifice a land: Destroy target enchantment.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "b9c59577-adfb-56f9-ac68-97d21dce08d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eec03a2-c62b-4e55-ae9d-edc30a9ad5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eec03a2-c62b-4e55-ae9d-edc30a9ad5f4.jpg?1",
             "name": "Avatar of Hope",
             "text": "Flying\nIf you have 3 life or less, Avatar of Hope costs o6 less to play.\nAvatar of Hope may block any number of creatures.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "7da10cc2-cbb2-5fb1-bd2e-c391185c191f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb624d6-9aec-498c-8df9-6fd025c74487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb624d6-9aec-498c-8df9-6fd025c74487.jpg?1",
             "name": "Blessed Wind",
             "text": "Target player's life total becomes 20.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "cf02dd64-8c1e-5c3b-b0e3-fa33b76fcc42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e5c9ca-b453-488b-8702-fc74907a8335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e5c9ca-b453-488b-8702-fc74907a8335.jpg?1",
             "name": "Celestial Convergence",
             "text": "Celestial Convergence comes into play with seven omen counters on it.\nAt the beginning of your upkeep, remove an omen counter from Celestial Convergence. If there are no omen counters on Celestial Convergence, the player with the highest life total wins the game. If two or more players are tied for highest life total, the game is a draw.",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "14246ce5-a4a8-50be-b6ea-525de2e61e98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f72b2-e3d0-4b24-9a73-b95d54695fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f72b2-e3d0-4b24-9a73-b95d54695fa4.jpg?1",
             "name": "Diving Griffin",
             "text": "Flying\nAttacking doesn't cause Diving Griffin to tap.",
             "colours": [
@@ -200,7 +200,7 @@
         },
         {
             "id": "000db0e0-047e-59e2-b7aa-265e656ea91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc20785-4512-4ef6-8f62-928482cb585f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc20785-4512-4ef6-8f62-928482cb585f.jpg?1",
             "name": "Entangler",
             "text": "Enchanted creature may block any number of creatures.",
             "colours": [
@@ -234,7 +234,7 @@
         },
         {
             "id": "3b68af8d-b4d7-5723-8a72-f918b9e37d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f97dd-434b-4156-8e9d-253a943784e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f97dd-434b-4156-8e9d-253a943784e3.jpg?1",
             "name": "Excise",
             "text": "Remove target attacking creature from the game unless its controller pays o\nX.",
             "colours": [
@@ -266,7 +266,7 @@
         },
         {
             "id": "b7c5493e-6e08-5c04-8776-71ed4cf41eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c241fd76-f52d-48fc-864c-57caffa700f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c241fd76-f52d-48fc-864c-57caffa700f6.jpg?1",
             "name": "Flowering Field",
             "text": "Enchanted land has \"oc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.\"",
             "colours": [
@@ -300,7 +300,7 @@
         },
         {
             "id": "ff9f390a-05dc-5652-b8c2-e89d5c6ad37f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4be296-33a6-46b1-9748-5b0d335f40ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4be296-33a6-46b1-9748-5b0d335f40ee.jpg?1",
             "name": "Glittering Lion",
             "text": "Prevent all damage that would be dealt to Glittering Lion.\no3: Until end of turn, Glittering Lion loses \"Prevent all damage that would be dealt to Glittering Lion.\" Any player may play this ability.",
             "colours": [
@@ -334,7 +334,7 @@
         },
         {
             "id": "fb7bd218-c8fe-5781-bc5a-551dcbbf4b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f26c7e-c525-4191-a542-b81343ae95bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f26c7e-c525-4191-a542-b81343ae95bb.jpg?1",
             "name": "Glittering Lynx",
             "text": "Prevent all damage that would be dealt to Glittering Lynx.\no2: Until end of turn, Glittering Lynx loses \"Prevent all damage that would be dealt to Glittering Lynx.\" Any player may play this ability.",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "8bfb3644-ff48-5077-8616-b880821d64e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3e681-bd4b-41e9-8db4-083172f3caad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d3e681-bd4b-41e9-8db4-083172f3caad.jpg?1",
             "name": "Jeweled Spirit",
             "text": "Flying\nSacrifice two lands: Jeweled Spirit gains protection from artifacts or from the color of your choice until end of turn.",
             "colours": [
@@ -402,7 +402,7 @@
         },
         {
             "id": "198d9a4f-8256-5ac1-ba05-49b4e115d85c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5861dffc-5afa-44a3-a3fa-9fd440093377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5861dffc-5afa-44a3-a3fa-9fd440093377.jpg?1",
             "name": "Mageta the Lion",
             "text": "o2o\nWo\nW, oc\nT, Discard two cards from your hand: Destroy all creatures except for Mageta the Lion. Those creatures can't be regenerated.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "8106611f-4f4a-534c-a003-1c9048e04c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22db8a3b-413d-4f4d-b103-f50fc0415e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22db8a3b-413d-4f4d-b103-f50fc0415e9b.jpg?1",
             "name": "Mageta's Boon",
             "text": "You may play Mageta's Boon any time you could play an instant.\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "942a2876-52ec-5342-bd33-129bd6102c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee3f50-09d7-4960-8214-680a7299fa20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ee3f50-09d7-4960-8214-680a7299fa20.jpg?1",
             "name": "Mercenary Informer",
             "text": "Mercenary Informer can't be the target of black spells or abilities.\no2oo\nW Put target Mercenary card on the bottom of its owner's library.",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "9e5658ee-4b68-5d39-8264-a1ff8462fef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8151510-2445-4244-b851-ab332b908170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8151510-2445-4244-b851-ab332b908170.jpg?1",
             "name": "Mine Bearer",
             "text": "oc\nT, Sacrifice Mine Bearer: Destroy target attacking creature.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "6b5a5ead-c8f7-5792-981b-df501506f1bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148fbe36-b22d-44e6-9341-7f707baca49d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148fbe36-b22d-44e6-9341-7f707baca49d.jpg?1",
             "name": "Mirror Strike",
             "text": "Target unblocked creature deals combat damage to its controller instead of to you this turn.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "c67c6e5f-ca35-58cb-83c2-71965ecfedf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6385bb-18f9-461b-b541-3c2a5e59189b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6385bb-18f9-461b-b541-3c2a5e59189b.jpg?1",
             "name": "Reveille Squad",
             "text": "Whenever you're attacked, if Reveille Squad is untapped, you may untap all creatures you control.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "7d723ae4-f0a4-5043-8c75-a7c6777211e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76711e-b508-4bb7-a87c-911a11905af3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a76711e-b508-4bb7-a87c-911a11905af3.jpg?1",
             "name": "Rhystic Circle",
             "text": "o1: Any player may pay o1. If no one does, the next time a source of your choice would deal damage to you this turn, prevent that damage.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "da170a78-1238-5866-9c0a-5084c6038b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49af7b3f-f56a-4102-b398-5c215dd4fa11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49af7b3f-f56a-4102-b398-5c215dd4fa11.jpg?1",
             "name": "Rhystic Shield",
             "text": "Creatures you control get +0/+1 until end of turn. They get an additional +0/+2 until end of turn unless any player pays o2.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "a8db841a-76a3-5983-8a89-ae941b0ef5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ebeba-b61a-497a-a698-e75b130c468c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022ebeba-b61a-497a-a698-e75b130c468c.jpg?1",
             "name": "Samite Sanctuary",
             "text": "o2: Prevent the next 1 damage that would be dealt to target creature this turn. Any player may play this ability.",
             "colours": [
@@ -707,7 +707,7 @@
         },
         {
             "id": "46996945-20da-5fb6-a3d6-db460af3d2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30803e6-7f0e-4832-b121-b18480c6465c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30803e6-7f0e-4832-b121-b18480c6465c.jpg?1",
             "name": "Sheltering Prayers",
             "text": "Basic lands each player controls can't be the targets of spells or abilities as long as that player controls three or fewer lands.",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "5407aafa-c8c2-5121-843e-ff2c4564fbb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d885360-1ce1-4b80-8928-29437731993f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d885360-1ce1-4b80-8928-29437731993f.jpg?1",
             "name": "Shield Dancer",
             "text": "o2oo\nW The next time target attacking creature would deal combat damage to Shield Dancer this turn, that creature deals that damage to itself instead.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "5a6ede04-3a2b-511e-b4b3-4b73735a7c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1656bd2a-e7ce-48b1-8fa1-5f470fe6058e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1656bd2a-e7ce-48b1-8fa1-5f470fe6058e.jpg?1",
             "name": "Soul Charmer",
             "text": "Whenever Soul Charmer deals combat damage to a creature, you gain 2 life unless that creature's controller pays o2.",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "a2acb991-93c2-526f-9551-cc6e908873a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06f00e8-3e58-4ba7-9542-ce6b17fd4005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06f00e8-3e58-4ba7-9542-ce6b17fd4005.jpg?1",
             "name": "Sword Dancer",
             "text": "o\nWoo\nW Target attacking creature gets -1/-0 until end of turn.",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "9c0b8eed-51ec-5654-b6e1-f767b799837c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a359837-2e41-4ddc-9299-89a783d62014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a359837-2e41-4ddc-9299-89a783d62014.jpg?1",
             "name": "Trenching Steed",
             "text": "Sacrifice a land: Trenching Steed gets +0/+3 until end of turn.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "1756a098-dc54-5ca9-8e10-9591c236a0e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54407ba7-6671-42a9-acbe-8a1104c7166c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54407ba7-6671-42a9-acbe-8a1104c7166c.jpg?1",
             "name": "Troubled Healer",
             "text": "Sacrifice a land: Prevent the next 2 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -914,7 +914,7 @@
         },
         {
             "id": "21be870a-edd1-52c3-ae9d-00073341244e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8fc0b0-4a23-47ed-b61b-a4505fcfc5d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f8fc0b0-4a23-47ed-b61b-a4505fcfc5d2.jpg?1",
             "name": "Alexi, Zephyr Mage",
             "text": "o\nXo\nU, oc\nT, Discard two cards from your hand: Return X target creatures to their owners' hands.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "ef453da7-2bb3-55ab-97cb-9b91b452a386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457a5613-d1d4-4112-8484-f40120079b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457a5613-d1d4-4112-8484-f40120079b7b.jpg?1",
             "name": "Alexi's Cloak",
             "text": "You may play Alexi's Cloak any time you could play an instant.\nEnchanted creature can't be the target of spells or abilities.",
             "colours": [
@@ -985,7 +985,7 @@
         },
         {
             "id": "4930bede-d5d5-5341-8feb-315edc9a7208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf65efc7-6ab5-4116-b003-1f028af80939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf65efc7-6ab5-4116-b003-1f028af80939.jpg?1",
             "name": "Avatar of Will",
             "text": "Flying\nIf an opponent has no cards in hand, Avatar of Will costs o6 less to play.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "00fb62e4-8a9f-54b6-ba2d-af4993b25649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b91ddc-8630-4214-8dce-215f28ccc685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b91ddc-8630-4214-8dce-215f28ccc685.jpg?1",
             "name": "Coastal Hornclaw",
             "text": "Sacrifice a land: Coastal Hornclaw gains flying until end of turn.",
             "colours": [
@@ -1053,7 +1053,7 @@
         },
         {
             "id": "021935a7-af9b-589a-bffe-62ea07bcc056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f236ce-41ad-4a49-a6f9-7853a2395a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f236ce-41ad-4a49-a6f9-7853a2395a84.jpg?1",
             "name": "Denying Wind",
             "text": "Search target player's library for up to seven cards and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1085,7 +1085,7 @@
         },
         {
             "id": "193e7d92-e738-5a30-bde5-38981213f6cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b87ff-42a9-4ea0-a79e-1208ca35ffb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4b87ff-42a9-4ea0-a79e-1208ca35ffb2.jpg?1",
             "name": "Excavation",
             "text": "o1, Sacrifice a land: Draw a card. Any player may play this ability.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "c3af2dfb-f6d5-582f-8c74-a33d83637f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870fb793-3107-4cb2-ba78-34fbf5c9da2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/870fb793-3107-4cb2-ba78-34fbf5c9da2f.jpg?1",
             "name": "Foil",
             "text": "You may discard an island and another card from your hand instead of paying Foil's mana cost.\nCounter target spell.",
             "colours": [
@@ -1149,7 +1149,7 @@
         },
         {
             "id": "8b6d009c-af82-580b-84b0-76bcef43daa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf424982-a0ab-4db9-8889-f3cef10966c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf424982-a0ab-4db9-8889-f3cef10966c6.jpg?1",
             "name": "Gulf Squid",
             "text": "When Gulf Squid comes into play, tap all lands target player controls.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "43f9b3db-d2c6-562b-a6cd-9ffc6502ca18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87489f2-82b7-4be6-80ae-3d5955d5ed92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87489f2-82b7-4be6-80ae-3d5955d5ed92.jpg?1",
             "name": "Hazy Homunculus",
             "text": "Hazy Homunculus is unblockable as long as defending player controls an untapped land.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "d5094309-95ac-54ca-ac6f-69d3638e7ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2765be4f-23bf-49c1-9546-11a7916156be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2765be4f-23bf-49c1-9546-11a7916156be.jpg?1",
             "name": "Heightened Awareness",
             "text": "As Heightened Awareness comes into play, discard your hand.\nAt the beginning of your draw step, draw a card.",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "d3e45edd-5d5e-5b0a-9af0-3947fd1e81c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6dfe49-9fd6-4fa0-b73e-e6470d8e7ca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b6dfe49-9fd6-4fa0-b73e-e6470d8e7ca7.jpg?1",
             "name": "Mana Vapors",
             "text": "Lands target player controls don't untap during his or her next untap step.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "f9856dba-03e4-5ceb-965f-024e6f96bd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6cf6b6-b4c1-4742-9be4-b3b15fbb0202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6cf6b6-b4c1-4742-9be4-b3b15fbb0202.jpg?1",
             "name": "Overburden",
             "text": "Whenever a player puts a creature card into play, that player returns a land he or she controls to its owner's hand.",
             "colours": [
@@ -1315,7 +1315,7 @@
         },
         {
             "id": "5eb63154-11b8-5ccf-b0b1-19598b9b4bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f86c92-c19e-4f2c-96d3-d3b05623cb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f86c92-c19e-4f2c-96d3-d3b05623cb00.jpg?1",
             "name": "Psychic Theft",
             "text": "Look at target player's hand, choose an instant or sorcery card from it, and remove that card from the game. You may play the card as though it were in your hand as long as the card remains removed from the game. At end of turn, if you haven't played the card, return it to its owner's hand.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "9131c8d6-2b39-500a-b703-c989c996b42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a680aeaf-8c6e-45b5-8814-7fd04e963220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a680aeaf-8c6e-45b5-8814-7fd04e963220.jpg?1",
             "name": "Quicksilver Wall",
             "text": "(Walls can't attack.)\no4: Return Quicksilver Wall to its owner's hand. Any player may play this ability.",
             "colours": [
@@ -1381,7 +1381,7 @@
         },
         {
             "id": "e460f26f-4e88-5654-9b1a-f92ae9fc790a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ae03f-22f3-4ecc-a875-5226d8dec384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915ae03f-22f3-4ecc-a875-5226d8dec384.jpg?1",
             "name": "Rethink",
             "text": "Counter target spell unless its controller pays o\nX, where X is its converted mana cost.",
             "colours": [
@@ -1413,7 +1413,7 @@
         },
         {
             "id": "14e02779-f514-510b-a8b8-b8004e031cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dd540-7f54-46fe-b1e8-7b07f57e71d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3dd540-7f54-46fe-b1e8-7b07f57e71d0.jpg?1",
             "name": "Rhystic Deluge",
             "text": "oo\nU Tap target creature unless its controller pays o1.",
             "colours": [
@@ -1445,7 +1445,7 @@
         },
         {
             "id": "5e884ebb-a7c6-5665-9ae3-64a020bbcd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a59737-f06f-49b7-a490-3dc1115b47b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a59737-f06f-49b7-a490-3dc1115b47b7.jpg?1",
             "name": "Rhystic Scrying",
             "text": "Draw three cards. Then, if any player pays o2, discard three cards from your hand.",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "7691887a-48cf-523b-bd19-c94a756392a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394cefd-a3c6-4917-8f46-234e441ecfb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394cefd-a3c6-4917-8f46-234e441ecfb6.jpg?1",
             "name": "Rhystic Study",
             "text": "Whenever an opponent plays a spell, you may draw a card unless that player pays o1.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "17f9a9bc-fee1-5110-8677-04f4a1fdc20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5135dc-4fc1-48a1-8405-44b2f93a3c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5135dc-4fc1-48a1-8405-44b2f93a3c21.jpg?1",
             "name": "Ribbon Snake",
             "text": "Flying\no2: Ribbon Snake loses flying until end of turn. Any player may play this ability.",
             "colours": [
@@ -1543,7 +1543,7 @@
         },
         {
             "id": "bab87fe0-2d7a-5b26-b7ea-f7d230203756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d9035b-b6ec-479f-b697-3e5c3110ef10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3d9035b-b6ec-479f-b697-3e5c3110ef10.jpg?1",
             "name": "Shrouded Serpent",
             "text": "Whenever Shrouded Serpent attacks, defending player may pay o4. If he or she doesn't, Shrouded Serpent is unblockable this turn.",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "1d3bf258-4f4f-5e89-b165-5c19b11bff33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db398ca-6b0b-4225-baaa-c4b1c243b2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db398ca-6b0b-4225-baaa-c4b1c243b2bd.jpg?1",
             "name": "Spiketail Drake",
             "text": "Flying\nSacrifice Spiketail Drake: Counter target spell unless its controller pays o3.",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "2dd559a6-ca10-58ff-9b36-6d0efb239bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9988f0fe-a7d4-44f9-b37c-fa30014ea215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9988f0fe-a7d4-44f9-b37c-fa30014ea215.jpg?1",
             "name": "Spiketail Hatchling",
             "text": "Flying\nSacrifice Spiketail Hatchling: Counter target spell unless its controller pays o1.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "88160909-d8ac-56e0-8bed-cbff6ceaa863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c3bb62-63b4-4b53-9e4d-edfc7487494b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c3bb62-63b4-4b53-9e4d-edfc7487494b.jpg?1",
             "name": "Stormwatch Eagle",
             "text": "Flying\nSacrifice a land: Return Stormwatch Eagle to its owner's hand.",
             "colours": [
@@ -1679,7 +1679,7 @@
         },
         {
             "id": "33292320-b027-5907-83e8-287e70ac9c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211ee02-e854-4414-92b1-65a7af29f0b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211ee02-e854-4414-92b1-65a7af29f0b9.jpg?1",
             "name": "Sunken Field",
             "text": "Enchanted land has \"oc\nT: Counter target spell unless its controller pays o1.\"",
             "colours": [
@@ -1713,7 +1713,7 @@
         },
         {
             "id": "b714fcac-0100-5bcb-9bd5-0221a3b6f796",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d7e856-6852-4b97-ae0e-a4becdfc8166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d7e856-6852-4b97-ae0e-a4becdfc8166.jpg?1",
             "name": "Troublesome Spirit",
             "text": "Flying\nAt the end of your turn, tap all lands you control.",
             "colours": [
@@ -1747,7 +1747,7 @@
         },
         {
             "id": "40606d6b-f239-567f-96b5-5b4ae7c94f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb70925a-4bef-4067-a1d7-79114aff5847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb70925a-4bef-4067-a1d7-79114aff5847.jpg?1",
             "name": "Windscouter",
             "text": "Flying\nWhenever Windscouter attacks or blocks, return it to its owner's hand at end of combat.",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "01f91513-95a1-5a33-a1fc-4eed13e8e4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a3a52f-0ccd-4935-b3ca-9c69cba283cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a3a52f-0ccd-4935-b3ca-9c69cba283cc.jpg?1",
             "name": "Withdraw",
             "text": "Return target creature to its owner's hand. Then return another target creature to its owner's hand unless its controller pays o1.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "9d5fad89-1025-52ea-b355-b3c425f6eb37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8316804-6f8b-423e-a2c3-fa476c095544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8316804-6f8b-423e-a2c3-fa476c095544.jpg?1",
             "name": "Agent of Shauku",
             "text": "o1o\nB, Sacrifice a land: Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -1849,7 +1849,7 @@
         },
         {
             "id": "5b80c2cc-14fa-57ca-b974-86423192db90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f695405-7238-48fb-9ea2-1b1613a0afda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f695405-7238-48fb-9ea2-1b1613a0afda.jpg?1",
             "name": "Avatar of Woe",
             "text": "If there are ten or more creature cards total in all graveyards, Avatar of Woe costs o6 less to play.\nAvatar of Woe can't be blocked except by artifact creatures and/or black creatures.\noc\nT: Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -1883,7 +1883,7 @@
         },
         {
             "id": "966a4f56-3c47-5c09-b673-cbb87b60e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75191915-352e-4de7-b216-63f0ff588ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75191915-352e-4de7-b216-63f0ff588ba5.jpg?1",
             "name": "Bog Elemental",
             "text": "Protection from white\nAt the beginning of your upkeep, sacrifice Bog Elemental unless you sacrifice a land.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "6d18d1f5-bde4-5324-8a70-eb82a589384a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086a5620-704b-47a9-9a5d-73e28631d6f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086a5620-704b-47a9-9a5d-73e28631d6f8.jpg?1",
             "name": "Bog Glider",
             "text": "Flying\noc\nT, Sacrifice a land: Search your library for a Mercenary card with converted mana cost 2 or less and put that card into play. Then shuffle your library.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "e8d30ba9-254c-5491-978b-902cf38dac37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20edb71-aa1d-437b-bcfb-953efbe45150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20edb71-aa1d-437b-bcfb-953efbe45150.jpg?1",
             "name": "Chilling Apparition",
             "text": "oo\nB Regenerate Chilling Apparition.\nWhenever Chilling Apparition deals combat damage to a player, that player discards a card from his or her hand.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "766ba887-5246-57d2-b376-657c528113b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcda8e4-d3dc-44f8-b277-b61fa261666b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcda8e4-d3dc-44f8-b277-b61fa261666b.jpg?1",
             "name": "Coffin Puppets",
             "text": "Sacrifice two lands: Return Coffin Puppets to play. Play this ability only during your upkeep, only if Coffin Puppets is in your graveyard, and only if you control a swamp.",
             "colours": [
@@ -2022,7 +2022,7 @@
         },
         {
             "id": "63d02cb3-f375-5052-bb68-06d5f261dfba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34019cb-5d87-4451-a102-b751ea3a97f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34019cb-5d87-4451-a102-b751ea3a97f8.jpg?1",
             "name": "Coffin Puppets",
             "text": "",
             "colours": [
@@ -2058,7 +2058,7 @@
         },
         {
             "id": "f13379de-5ab4-501e-9bc4-4d5688554e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58a303a-9f7a-43e7-bcba-c58b378a53ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e58a303a-9f7a-43e7-bcba-c58b378a53ce.jpg?1",
             "name": "Death Charmer",
             "text": "Whenever Death Charmer deals combat damage to a creature, that creature's controller loses 2 life unless he or she pays o2.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "9f498048-1a99-575b-a46d-ae59b37336a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb6ff7-2cd6-430e-a618-0b83d9c1d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb6ff7-2cd6-430e-a618-0b83d9c1d044.jpg?1",
             "name": "Despoil",
             "text": "Destroy target land. Its controller loses 2 life.",
             "colours": [
@@ -2125,7 +2125,7 @@
         },
         {
             "id": "483bcee9-e9a1-5370-949c-0964aca85b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76843b0-0e71-473b-8c9b-6a8bc30255da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76843b0-0e71-473b-8c9b-6a8bc30255da.jpg?1",
             "name": "Endbringer's Revel",
             "text": "o4: Return target creature card from a graveyard to its owner's hand. Any player may play this ability but only any time he or she could play a sorcery.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "bac1b5e5-1aa5-52cb-8379-0defda5c8455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7d1125-7eb0-4065-bc2c-764689380fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7d1125-7eb0-4065-bc2c-764689380fa8.jpg?1",
             "name": "Fen Stalker",
             "text": "Fen Stalker can't be blocked except by artifact creatures and/or black creatures as long as you control no untapped lands.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "cd49daa6-fd33-566b-b2b5-24d884d5818c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fe155f-bfb2-49d8-83f0-ab1047a961d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fe155f-bfb2-49d8-83f0-ab1047a961d1.jpg?1",
             "name": "Flay",
             "text": "Target player discards a card at random from his or her hand. Then that player discards another card at random from his or her hand unless he or she pays o1.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "6c3be56e-71ca-53d2-abe9-d06e82422642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d1f317-efd1-4595-92e2-44815a2b8147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d1f317-efd1-4595-92e2-44815a2b8147.jpg?1",
             "name": "Greel, Mind Raker",
             "text": "o\nXo\nB, oc\nT, Discard two cards from your hand: Target player discards X cards at random from his or her hand.",
             "colours": [
@@ -2260,7 +2260,7 @@
         },
         {
             "id": "db0255d3-4b50-5a3f-a087-c9bc05089282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b25ce3f-fab3-40f8-8a16-fe580f3d97a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b25ce3f-fab3-40f8-8a16-fe580f3d97a5.jpg?1",
             "name": "Greel's Caress",
             "text": "You may play Greel's Caress any time you could play an instant.\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -2294,7 +2294,7 @@
         },
         {
             "id": "a841e224-0f93-53e4-a0a0-06996eaae392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a63d16e-319d-46f4-a28c-895b36605ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a63d16e-319d-46f4-a28c-895b36605ee6.jpg?1",
             "name": "Infernal Genesis",
             "text": "At the beginning of each player's upkeep, that player puts the top card of his or her library into his or her graveyard. He or she then puts X 1/1 black Minion creature tokens into play, where X is that card's converted mana cost.",
             "colours": [
@@ -2326,7 +2326,7 @@
         },
         {
             "id": "9804f78e-ed0b-526f-8bf2-0ac48daffa93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefd9315-9b7c-4c6b-8a15-a6af873dab6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefd9315-9b7c-4c6b-8a15-a6af873dab6f.jpg?1",
             "name": "Nakaya Shade",
             "text": "oo\nB Nakaya Shade gets +1/+1 until end of turn unless any player pays o2.",
             "colours": [
@@ -2360,7 +2360,7 @@
         },
         {
             "id": "b29c452c-c4d3-5713-a553-fea330b93ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c84d09-555c-472b-b445-5dd5a44cd555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c84d09-555c-472b-b445-5dd5a44cd555.jpg?1",
             "name": "Noxious Field",
             "text": "Enchanted land has \"oc\nT: This land deals 1 damage to each creature and each player.\"",
             "colours": [
@@ -2394,7 +2394,7 @@
         },
         {
             "id": "a6602618-6346-5af3-bd57-fea292279f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43c30d9-23a5-4872-925d-3427f5f57995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43c30d9-23a5-4872-925d-3427f5f57995.jpg?1",
             "name": "Outbreak",
             "text": "You may discard a swamp from your hand instead of paying Outbreak's mana cost.\nChoose a creature type. All creatures of that type get -1/-1 until end of turn.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "a35b2dfd-8825-56c9-9e6b-c1d7a0437a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37cd150-1064-43b7-919b-8922d8a18f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37cd150-1064-43b7-919b-8922d8a18f21.jpg?1",
             "name": "Pit Raptor",
             "text": "Flying, first strike\nAt the beginning of your upkeep, sacrifice Pit Raptor unless you pay o2o\nBo\nB.",
             "colours": [
@@ -2461,7 +2461,7 @@
         },
         {
             "id": "ce246379-e5f2-5f7b-92f3-c9cf1de55abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f077f5-c0b0-4e94-8599-e2122bc87238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f077f5-c0b0-4e94-8599-e2122bc87238.jpg?1",
             "name": "Plague Fiend",
             "text": "Whenever Plague Fiend deals combat damage to a creature, destroy that creature unless its controller pays o2.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "4eb5a9a9-f6e9-5e1a-b768-e594e760d51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4bd20-7422-45ed-aa76-3ef055c556e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4bd20-7422-45ed-aa76-3ef055c556e7.jpg?1",
             "name": "Plague Wind",
             "text": "Destroy all creatures you don't control. They can't be regenerated.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "a9aba568-91c3-5031-bbb5-fe66f7428011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98a71a8-291f-4d94-ada0-5f50f354cca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c98a71a8-291f-4d94-ada0-5f50f354cca7.jpg?1",
             "name": "Rebel Informer",
             "text": "Rebel Informer can't be the target of white spells or abilities.\no3: Put target Rebel card on the bottom of its owner's library.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "8ec47a3d-f588-5166-9c13-566e9abd6cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c5df2-e299-4bf3-8018-725893702314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/750c5df2-e299-4bf3-8018-725893702314.jpg?1",
             "name": "Rhystic Syphon",
             "text": "Unless target player pays o3, he or she loses 5 life and you gain 5 life.",
             "colours": [
@@ -2595,7 +2595,7 @@
         },
         {
             "id": "b82da2d5-3271-5658-aa97-b05e8f8a1132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c1609-9cac-460f-8504-a84e28c340c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c1609-9cac-460f-8504-a84e28c340c1.jpg?1",
             "name": "Rhystic Tutor",
             "text": "Unless any player pays o2, search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "74093bc9-e08d-5aba-9d8f-ceb4ad8cfea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f9d1b-a89a-439f-8aa9-b96a1bf892eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34f9d1b-a89a-439f-8aa9-b96a1bf892eb.jpg?1",
             "name": "Soul Strings",
             "text": "Return two target creature cards from your graveyard to your hand unless any player pays o\nX.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "d1363d84-b47a-5029-9579-f0a998230aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470b3bb-5061-4beb-9f44-b56c3b2fd816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5470b3bb-5061-4beb-9f44-b56c3b2fd816.jpg?1",
             "name": "Steal Strength",
             "text": "Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "6c115226-b2b0-517f-be60-c8228e5b507c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00042443-4d4e-4087-b4e5-5e781e7cc5fa.jpg?1",
             "name": "Wall of Vipers",
             "text": "(Walls can't attack.)\no3: Destroy Wall of Vipers and target creature it's blocking. Any player may play this ability.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "72534716-6fb6-5609-a75d-00af189294e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd00b0b-2ac1-4926-a735-215f402ba1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd00b0b-2ac1-4926-a735-215f402ba1c4.jpg?1",
             "name": "Whipstitched Zombie",
             "text": "At the beginning of your upkeep, sacrifice Whipstitched Zombie unless you pay o\nB.",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "b24bd8c5-88d2-54da-8499-91befc6009d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528293b4-ce3b-4623-8ced-496701d7265b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528293b4-ce3b-4623-8ced-496701d7265b.jpg?1",
             "name": "Avatar of Fury",
             "text": "Flying\nIf an opponent controls seven or more lands, Avatar of Fury costs o6 less to play.\noo\nR Avatar of Fury gets +1/+0 until end of turn.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "b894bbbe-d874-5b1d-a7a4-e593ec16b4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c76db48-6f05-49c3-a49c-587c0a8a3613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c76db48-6f05-49c3-a49c-587c0a8a3613.jpg?1",
             "name": "Barbed Field",
             "text": "Enchanted land has \"oc\nT: This land deals 1 damage to target creature or player.\"",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "5abdb7bb-fa0d-51e1-830f-2bb794c6e260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a48065-fbf1-4f2a-993e-7061057a4c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a48065-fbf1-4f2a-993e-7061057a4c45.jpg?1",
             "name": "Branded Brawlers",
             "text": "Branded Brawlers can't attack if defending player controls an untapped land.\nBranded Brawlers can't block if you control an untapped land.",
             "colours": [
@@ -2863,7 +2863,7 @@
         },
         {
             "id": "0fabbddd-75c0-5e62-9ef9-5ea35dc782a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b3725b-924d-4137-9078-1a28f06c84fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b3725b-924d-4137-9078-1a28f06c84fa.jpg?1",
             "name": "Brutal Suppression",
             "text": "Activated abilities on Rebel cards cost an additional \"Sacrifice a land\" to play.",
             "colours": [
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "ab5c2852-b0df-5a6b-afee-ad395837a9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66585109-77cb-42f1-9c14-3dac1d493b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66585109-77cb-42f1-9c14-3dac1d493b71.jpg?1",
             "name": "Citadel of Pain",
             "text": "At the end of each player's turn, Citadel of Pain deals X damage to that player, where X is the number of untapped lands he or she controls.",
             "colours": [
@@ -2927,7 +2927,7 @@
         },
         {
             "id": "380eff64-9dc7-5eb3-ac0f-f9f6a7c43f1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7c990-a34b-475e-a612-447c22f998d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe7c990-a34b-475e-a612-447c22f998d3.jpg?1",
             "name": "Devastate",
             "text": "Destroy target land. Devastate deals 1 damage to each creature and each player.",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "25af13e3-873c-5ac8-aa7f-1fc63d03f7ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d3579-3fc1-434e-8f26-d5dbd6344429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9d3579-3fc1-434e-8f26-d5dbd6344429.jpg?1",
             "name": "Fault Riders",
             "text": "Sacrifice a land: Fault Riders gets +2/+0 and gains first strike until end of turn. Play this ability only once each turn.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "874b7259-e3cf-59d3-b2a5-55abb9096e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6d047a-f3dc-4c34-9679-fb76037e4044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6d047a-f3dc-4c34-9679-fb76037e4044.jpg?1",
             "name": "Fickle Efreet",
             "text": "Whenever Fickle Efreet attacks or blocks, flip a coin at end of combat. If you lose the flip, an opponent gains control of Fickle Efreet.",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "7b7797e9-7763-5d1f-b4b7-75da2281f230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7b61a8-a1ff-4e2a-bc24-8990c61a5e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7b61a8-a1ff-4e2a-bc24-8990c61a5e5b.jpg?1",
             "name": "Flameshot",
             "text": "You may discard a mountain from your hand instead of paying Flameshot's mana cost.\nFlameshot deals 3 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "4619f7ad-5321-5817-9885-3ad20a8c3ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7bc4c0-9bfd-444b-b22c-f1b7e1426807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7bc4c0-9bfd-444b-b22c-f1b7e1426807.jpg?1",
             "name": "Inflame",
             "text": "Inflame deals 2 damage to each creature dealt damage this turn.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "3190c4fd-bb85-540e-ba12-53d06c19e4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f58b1-d8d7-4544-8363-e2b96e9d2623.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f58b1-d8d7-4544-8363-e2b96e9d2623.jpg?1",
             "name": "Keldon Arsonist",
             "text": "o1, Sacrifice two lands: Destroy target land.",
             "colours": [
@@ -3127,7 +3127,7 @@
         },
         {
             "id": "066b7401-0bec-5bc3-a989-3400668fae0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa3f9c0-66ff-4b94-b0c3-e1c65d2040b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa3f9c0-66ff-4b94-b0c3-e1c65d2040b9.jpg?1",
             "name": "Keldon Berserker",
             "text": "Whenever Keldon Berserker attacks, if you control no untapped lands, it gets +3/+0 until end of turn.",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "d3e4e1f4-1b1f-50d7-9e0f-a6ea881d5a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc78b5-c259-4c67-810c-99655e72c2da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc78b5-c259-4c67-810c-99655e72c2da.jpg?1",
             "name": "Keldon Firebombers",
             "text": "When Keldon Firebombers comes into play, each player sacrifices all lands he or she controls except for three.",
             "colours": [
@@ -3198,7 +3198,7 @@
         },
         {
             "id": "9ea1e7a0-cafa-5c93-b0be-c9d26c9b8f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3c7b0c-98bd-4c63-bbb0-80484a5ab26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd3c7b0c-98bd-4c63-bbb0-80484a5ab26f.jpg?1",
             "name": "Latulla, Keldon Overseer",
             "text": "o\nXo\nR, oc\nT, Discard two cards from your hand: Latulla, Keldon Overseer deals X damage to target creature or player.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "9bf560bb-0cde-5a16-bb0a-179f7682a639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56cd728-5c3c-4fd6-bb01-0bf0875508c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56cd728-5c3c-4fd6-bb01-0bf0875508c7.jpg?1",
             "name": "Latulla's Orders",
             "text": "You may play Latulla's Orders any time you could play an instant.\nWhenever enchanted creature deals combat damage to defending player, you may have it destroy target artifact that player controls.",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "642e7c6d-40d7-59ed-b3ba-deb8a9d48d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ed7aec-a513-418e-9cef-e0c51203055b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ed7aec-a513-418e-9cef-e0c51203055b.jpg?1",
             "name": "Lesser Gargadon",
             "text": "Whenever Lesser Gargadon attacks or blocks, sacrifice a land.",
             "colours": [
@@ -3303,7 +3303,7 @@
         },
         {
             "id": "4a132604-de61-5b78-bfa6-6d7dfb42eef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ec751c-08b5-4afb-bc08-8b2735b24f59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ec751c-08b5-4afb-bc08-8b2735b24f59.jpg?1",
             "name": "Panic Attack",
             "text": "Up to three target creatures can't block this turn.",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "ef55a20e-8aab-55a3-882c-5854f387328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ce365e-3002-42e9-aeb5-1b845408271e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ce365e-3002-42e9-aeb5-1b845408271e.jpg?1",
             "name": "Rhystic Lightning",
             "text": "Rhystic Lightning deals 4 damage to target creature or player unless that creature's controller or that player pays o2. If he or she does, Rhystic Lightning deals 2 damage to the creature or player.",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "2e10f471-3546-52a1-9dae-61faaa1fe2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f663a4a-592a-4a3b-bbaf-e9c5c3049021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f663a4a-592a-4a3b-bbaf-e9c5c3049021.jpg?1",
             "name": "Ridgeline Rager",
             "text": "oo\nR Ridgeline Rager gets +1/+0 until end of turn.",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "cd515f39-2f0e-5806-ba0e-a96660a58151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274f791-c9f1-49a1-9002-10e94caee96e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7274f791-c9f1-49a1-9002-10e94caee96e.jpg?1",
             "name": "Scoria Cat",
             "text": "Scoria Cat gets +3/+3 as long as you control no untapped lands.",
             "colours": [
@@ -3435,7 +3435,7 @@
         },
         {
             "id": "222cc5e0-afa0-5d35-9ba2-99f05bc63e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f19a1b5-48ba-44a9-b91f-2f628b223ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f19a1b5-48ba-44a9-b91f-2f628b223ffb.jpg?1",
             "name": "Search for Survivors",
             "text": "Shuffle your graveyard. An opponent chooses a card from it at random. If that card is a creature card, put it into play. Otherwise, remove it from the game.",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "0547a36a-2d26-5859-8107-af56f251d010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b761f97-3690-497a-b6ab-c71f61b8e841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b761f97-3690-497a-b6ab-c71f61b8e841.jpg?1",
             "name": "Searing Wind",
             "text": "Searing Wind deals 10 damage to target creature or player.",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "530fe78d-b7bb-52f0-8732-42d6e815caa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf91a7-4d04-437c-a290-6adb52f25312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf91a7-4d04-437c-a290-6adb52f25312.jpg?1",
             "name": "Spur Grappler",
             "text": "Spur Grappler gets +2/+1 as long as you control no untapped lands.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "f1e4a400-20d5-55f2-a2e4-01fd1274862e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258a9cdd-c626-404e-b82d-01091f11f107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258a9cdd-c626-404e-b82d-01091f11f107.jpg?1",
             "name": "Task Mage Assembly",
             "text": "When there are no creatures in play, sacrifice Task Mage Assembly.\no2: Task Mage Assembly deals 1 damage to target creature. Any player may play this ability but only any time he or she could play a sorcery.",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "93910065-2c74-573b-8289-6d1a6e3bc2d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d3acb-68be-409d-beb7-92a7cbc0402f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4d3acb-68be-409d-beb7-92a7cbc0402f.jpg?1",
             "name": "Veteran Brawlers",
             "text": "Veteran Brawlers can't attack if defending player controls an untapped land.\nVeteran Brawlers can't block if you control an untapped land.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "735d7e25-8fc7-54d7-b0c2-cd6c83ae4976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6b3f38-87c9-4cea-b9e5-b8fb42e64794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6b3f38-87c9-4cea-b9e5-b8fb42e64794.jpg?1",
             "name": "Whip Sergeant",
             "text": "oo\nR Target creature gains haste until end of turn. (It may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "f861a59a-d0ff-5712-a38b-02cc88827df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a8e1ce-e394-48d6-938a-aa76c0273abe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a8e1ce-e394-48d6-938a-aa76c0273abe.jpg?1",
             "name": "Zerapa Minotaur",
             "text": "First strike\no2: Zerapa Minotaur loses first strike until end of turn. Any player may play this ability.",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "d0e58dba-d889-5eeb-b45c-b5b1121d6519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97614db-167e-4ede-96bd-77ed90b57d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c97614db-167e-4ede-96bd-77ed90b57d4e.jpg?1",
             "name": "Avatar of Might",
             "text": "Trample\nIf an opponent controls at least four more creatures than you, Avatar of Might costs o6 less to play.",
             "colours": [
@@ -3703,7 +3703,7 @@
         },
         {
             "id": "ef584f9b-d6fb-5b43-9c0e-a1e2c9fb1f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec38c856-dc21-450d-9aa6-da16c91a489a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec38c856-dc21-450d-9aa6-da16c91a489a.jpg?1",
             "name": "Calming Verse",
             "text": "Destroy all enchantments you don't control. Then, if you control an untapped land, destroy all enchantments you control.",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "023df0f7-38d8-5ee2-a54e-6f7ea2633a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82636dc-4b3e-44a8-bc72-dab1275dfb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82636dc-4b3e-44a8-bc72-dab1275dfb6d.jpg?1",
             "name": "Darba",
             "text": "At the beginning of your upkeep, sacrifice Darba unless you pay o\nGo\nG.",
             "colours": [
@@ -3770,7 +3770,7 @@
         },
         {
             "id": "2c0a26ff-6a0d-5078-a145-ad4c39309224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890e414-d7e1-4320-924c-083e65a2ae72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6890e414-d7e1-4320-924c-083e65a2ae72.jpg?1",
             "name": "Dual Nature",
             "text": "Whenever a creature card comes into play, its controller puts a creature token into play that's a copy of that creature.\nWhenever a creature card leaves play, remove all tokens with the same name as that creature from the game.\nWhen Dual Nature leaves play, remove all tokens created with it from the game.",
             "colours": [
@@ -3802,7 +3802,7 @@
         },
         {
             "id": "8847947d-eefb-51ef-9ae9-644978188e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22147f72-7ff8-40c4-9bdd-df41dce17dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22147f72-7ff8-40c4-9bdd-df41dce17dad.jpg?1",
             "name": "Elephant Resurgence",
             "text": "Each player puts a green Elephant creature token into play. Those creatures have \"This creature's power and toughness are each equal to the number of creature cards in its controller's graveyard.\"",
             "colours": [
@@ -3834,7 +3834,7 @@
         },
         {
             "id": "24179bb5-1e61-5479-b95f-2e6ac80badd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fefbace-03cb-43db-a221-0be2b8784357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fefbace-03cb-43db-a221-0be2b8784357.jpg?1",
             "name": "Forgotten Harvest",
             "text": "At the beginning of your upkeep, you may remove a land card in your graveyard from the game. If you do, put a +1/+1 counter on target creature.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "cc06a866-a99b-5fed-a721-6bb24b8be7f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ea1c3-e920-467b-a3c8-a6b1097c3e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0ea1c3-e920-467b-a3c8-a6b1097c3e8d.jpg?1",
             "name": "Jolrael, Empress of Beasts",
             "text": "o2o\nG, oc\nT, Discard two cards from your hand: Until end of turn, all lands target player controls are 3/3 creatures that are still lands.",
             "colours": [
@@ -3903,7 +3903,7 @@
         },
         {
             "id": "afca6947-a88d-5e82-9a37-e203bffe550b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8275ecd7-f119-4cca-bef1-626a3272dd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8275ecd7-f119-4cca-bef1-626a3272dd2c.jpg?1",
             "name": "Jolrael's Favor",
             "text": "You may play Jolrael's Favor any time you could play an instant.\no1oo\nG Regenerate enchanted creature.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "2b6c23d0-d3b0-5e4f-9696-8f375839530e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64558128-7990-470c-88c9-d47d622e44db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64558128-7990-470c-88c9-d47d622e44db.jpg?1",
             "name": "Living Terrain",
             "text": "Enchanted land is a 5/6 green Treefolk creature that's still a land.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "a85fbd67-5ad5-5c98-ac68-c87a19ffa461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c99bb6-a483-4beb-b98c-eb641fe3d50a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c99bb6-a483-4beb-b98c-eb641fe3d50a.jpg?1",
             "name": "Marsh Boa",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a swamp.)",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "aeac099c-2b12-5379-bb8a-fb59c4f1592b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addc915-2997-4b81-a026-97d4421cf17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6addc915-2997-4b81-a026-97d4421cf17d.jpg?1",
             "name": "Mungha Wurm",
             "text": "You can't untap more than one land during your untap step.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "196eee60-8e8f-58a9-b9b6-491d49e4dd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad9744f-797a-4dd3-8617-192773be995c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad9744f-797a-4dd3-8617-192773be995c.jpg?1",
             "name": "Pygmy Razorback",
             "text": "Trample",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "96b33813-f4d9-5bed-83d9-08aff0ebd162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71bebea-1634-4d9a-b3ad-2e01ecacad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71bebea-1634-4d9a-b3ad-2e01ecacad7e.jpg?1",
             "name": "Rib Cage Spider",
             "text": "Rib Cage Spider may block as though it had flying.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "19bfb21e-1c0c-5fff-a771-ccd7569e7ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db109497-7674-4067-a12b-dfb5c317a358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db109497-7674-4067-a12b-dfb5c317a358.jpg?1",
             "name": "Root Cage",
             "text": "Mercenaries don't untap during their controllers' untap steps.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "80fbefb6-97b7-5073-980a-77afb7ef80f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f334e864-4e62-4bc3-9470-661be3d879e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f334e864-4e62-4bc3-9470-661be3d879e2.jpg?1",
             "name": "Silt Crawler",
             "text": "When Silt Crawler comes into play, tap all lands you control.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "f3137977-e091-5474-96b6-65070a0331a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7401df8b-23e7-4485-9ed4-70118a66feed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7401df8b-23e7-4485-9ed4-70118a66feed.jpg?1",
             "name": "Snag",
             "text": "You may discard a forest from your hand instead of paying Snag's mana cost.\nPrevent all combat damage that would be dealt by unblocked creatures this turn.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "ef2d38ba-d250-553e-8432-ee8bda483ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220fada-5cbb-4266-bca3-a44d51773d63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f220fada-5cbb-4266-bca3-a44d51773d63.jpg?1",
             "name": "Spitting Spider",
             "text": "Spitting Spider may block as though it had flying.\nSacrifice a land: Spitting Spider deals 1 damage to each creature with flying.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "b2ff5fa4-a337-57d8-809f-c4cc90bc3344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f752339-003d-4ded-b2bf-e4200fc8d5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f752339-003d-4ded-b2bf-e4200fc8d5d6.jpg?1",
             "name": "Spore Frog",
             "text": "Sacrifice Spore Frog: Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -4273,7 +4273,7 @@
         },
         {
             "id": "b47a56dd-a307-5ffa-883b-1b15e349528f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7094be2a-454e-4e4d-a540-c5c80e37468a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7094be2a-454e-4e4d-a540-c5c80e37468a.jpg?1",
             "name": "Squirrel Wrangler",
             "text": "o1o\nG, Sacrifice a land: Put two 1/1 green Squirrel creature tokens into play.\no1o\nG, Sacrifice a land: All Squirrels get +1/+1 until end of turn.",
             "colours": [
@@ -4308,7 +4308,7 @@
         },
         {
             "id": "302b107e-278e-5769-8a59-b52664fdb376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57996732-c9e4-4271-9d5f-2a8c77f8d177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57996732-c9e4-4271-9d5f-2a8c77f8d177.jpg?1",
             "name": "Thresher Beast",
             "text": "Whenever Thresher Beast becomes blocked, defending player sacrifices a land.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "2a4965ba-beff-55b8-9968-5ec13b9bd666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb20099-fc53-4fdf-86f4-d7d8155c2af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb20099-fc53-4fdf-86f4-d7d8155c2af1.jpg?1",
             "name": "Thrive",
             "text": "Put a +1/+1 counter on each of X target creatures.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "ebd8516b-0262-5d23-b7fe-d964bcd74182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d123da53-9fd3-492b-beb7-76d1c0f5e4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d123da53-9fd3-492b-beb7-76d1c0f5e4f6.jpg?1",
             "name": "Verdant Field",
             "text": "Enchanted land has \"oc\nT: Target creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "1e9177ce-0395-5a6b-85b1-a39a61aed2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f7aef-7398-4e10-9f4e-68e7c294c101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f7aef-7398-4e10-9f4e-68e7c294c101.jpg?1",
             "name": "Vintara Elephant",
             "text": "Trample\no3: Vintara Elephant loses trample until end of turn. Any player may play this ability.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "f89332a5-66c6-50c6-9bef-3c100843d483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897edf01-fc6f-4835-b025-c137d921ce09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/897edf01-fc6f-4835-b025-c137d921ce09.jpg?1",
             "name": "Vintara Snapper",
             "text": "Vintara Snapper can't be the target of spells or abilities as long as you control no untapped lands.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "9e8cff26-3462-54ea-b80c-87e9a6dfb927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbd7c20-d527-4d97-9630-896d5e7bf1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbd7c20-d527-4d97-9630-896d5e7bf1de.jpg?1",
             "name": "Vitalizing Wind",
             "text": "Creatures you control get +7/+7 until end of turn.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "3ce6999a-df4b-5673-b4a4-f15f809e1974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8c0be2-ba90-4e7a-b1a6-c68be550e33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a8c0be2-ba90-4e7a-b1a6-c68be550e33d.jpg?1",
             "name": "Wild Might",
             "text": "Target creature gets +1/+1 until end of turn. That creature gets an additional +4/+4 until end of turn unless any player pays o2.",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "76a5511d-1370-5f0e-91b0-20c17e35e1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e66be1-f18a-433f-8504-aa1e85e22023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e66be1-f18a-433f-8504-aa1e85e22023.jpg?1",
             "name": "Wing Storm",
             "text": "Wing Storm deals X damage to each player, where X is twice the number of creatures with flying that player controls.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "ae0be565-65fb-5d6e-93f5-485bcbea35ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0fb30e-e4d0-4271-a712-db40fa7650c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0fb30e-e4d0-4271-a712-db40fa7650c3.jpg?1",
             "name": "Chimeric Idol",
             "text": "o0: Tap all lands you control. Chimeric Idol becomes a 3/3 artifact creature until end of turn.",
             "colours": [],
@@ -4600,7 +4600,7 @@
         },
         {
             "id": "2d6262b3-ee74-5d56-a202-3f51e7daf795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be413dd-d6e0-4bd3-8c14-4dbe44e8ee41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be413dd-d6e0-4bd3-8c14-4dbe44e8ee41.jpg?1",
             "name": "Copper-Leaf Angel",
             "text": "Flying\noc\nT, Sacrifice X lands: Put X +1/+1 counters on Copper-Leaf Angel.",
             "colours": [],
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "812fb027-a52e-526e-a72e-4ab1848ba9ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163add05-9ee9-4a8f-8838-3c4143ddc2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163add05-9ee9-4a8f-8838-3c4143ddc2f5.jpg?1",
             "name": "Hollow Warrior",
             "text": "Hollow Warrior can't attack or block unless you tap an untapped creature you control. (This cost is paid as attackers or blockers are declared.)",
             "colours": [],
@@ -4663,7 +4663,7 @@
         },
         {
             "id": "c5e504ed-1b7f-54c7-841a-4d7c3c6358c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c810aa1-e367-4102-a5bd-6dc02d3023e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c810aa1-e367-4102-a5bd-6dc02d3023e8.jpg?1",
             "name": "Keldon Battlewagon",
             "text": "Trample\nKeldon Battlewagon can't block.\nWhen Keldon Battlewagon attacks, sacrifice it at end of combat.\nTap an untapped creature you control: Keldon Battlewagon gets +X/+0 until end of turn, where X is the tapped creature's power.",
             "colours": [],
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "91f9f641-40f1-518c-a3ae-1e3369ae1dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82331a8a-c0f1-4d89-87f8-1b1d0fccabb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82331a8a-c0f1-4d89-87f8-1b1d0fccabb8.jpg?1",
             "name": "Well of Discovery",
             "text": "At the end of your turn, if you control no untapped lands, draw a card.",
             "colours": [],
@@ -4722,7 +4722,7 @@
         },
         {
             "id": "8c84dabb-7715-5932-b54f-e7534049c23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3f4fc3-3819-470d-92d9-98cb390f89b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3f4fc3-3819-470d-92d9-98cb390f89b9.jpg?1",
             "name": "Well of Life",
             "text": "At the end of your turn, if you control no untapped lands, you gain 2 life.",
             "colours": [],
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "f2f8f712-be4f-50a5-9ac3-c6ea44b5340b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae74463-4426-4ad4-b7a2-324694854245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae74463-4426-4ad4-b7a2-324694854245.jpg?1",
             "name": "Rhystic Cave",
             "text": "oc\nT: Add one mana of any color to your mana pool unless any player pays o1.",
             "colours": [],
@@ -4778,7 +4778,7 @@
         },
         {
             "id": "fcc0baca-e632-58db-a68e-ed432fa8db43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07144a6-6e47-4315-8353-f8958f014f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07144a6-6e47-4315-8353-f8958f014f41.jpg?1",
             "name": "Wintermoon Mesa",
             "text": "Wintermoon Mesa comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\no2, oc\nT, Sacrifice Wintermoon Mesa: Tap two target lands.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/PIP.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/PIP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "759ca3de-1758-59a2-bad8-d65070984712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a7176-98bc-4f54-aa61-38747420f178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246a7176-98bc-4f54-aa61-38747420f178.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "Whenever you attack, you may sacrifice another creature. When you do, choose two \u2014\n\u2022 Create two 1/1 red and white Soldier creature tokens with haste that are tapped and attacking.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Caesar, Legion's Emperor deals damage equal to the number of creature tokens you control to target opponent.",
             "colours": [
@@ -49,7 +49,7 @@
         },
         {
             "id": "0ec1782b-4274-5d6e-9b22-4fb3fb53d6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b45e3e-8460-4678-87d1-d74479936c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b45e3e-8460-4678-87d1-d74479936c83.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "When Dogmeat enters the battlefield, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\nWhenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -93,7 +93,7 @@
         },
         {
             "id": "d7bf6ff2-0a77-5640-a8ce-c649c8a2b8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95af426d-a8af-4314-9ad0-ac61935e8e8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95af426d-a8af-4314-9ad0-ac61935e8e8e.jpg?1",
             "name": "Dr. Madison Li",
             "text": "Whenever you cast an artifact spell, you get {E} (an energy counter).\n{T}, Pay {E}: Target creature gets +1/+0 and gains trample and haste until end of turn.\n{T}, Pay {E}{E}{E}: Draw a card.\n{T}, Pay {E}{E}{E}{E}{E}: Return target artifact card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "c9e712fb-2e1c-572e-be7a-815bf9582581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d6944-a364-41c2-b824-7a1bf6ad0d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6d6944-a364-41c2-b824-7a1bf6ad0d1e.jpg?1",
             "name": "The Wise Mothman",
             "text": "Flying\nWhenever The Wise Mothman enters the battlefield or attacks, each player gets a rad counter.\nWhenever one or more nonland cards are milled, put a +1/+1 counter on each of up to X target creatures, where X is the number of nonland cards milled this way.",
             "colours": [
@@ -183,7 +183,7 @@
         },
         {
             "id": "250b2f63-66cb-5a13-b9e4-8bc7535e3c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da11337-ceb2-4744-9696-c06fec2f2daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2da11337-ceb2-4744-9696-c06fec2f2daa.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "Vigilance, trample, haste\nWhenever Liberty Prime, Recharged attacks or blocks, sacrifice it unless you pay {E}{E} (two energy counters).\n{2}, {T}, Sacrifice an artifact: You get {E}{E} and draw a card.",
             "colours": [
@@ -227,7 +227,7 @@
         },
         {
             "id": "166ea6d0-1dd0-585b-a95a-40a0ac796302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0497da-670a-405c-a39c-97cae7942836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0497da-670a-405c-a39c-97cae7942836.jpg?1",
             "name": "The Master, Transcendent",
             "text": "When The Master, Transcendent enters the battlefield, target player gets two rad counters.\n{T}: Put target creature card in a graveyard that was milled this turn onto the battlefield under your control. It's a green Mutant with base power and toughness 3/3. (It loses its other colors and creature types.)",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "2a214374-0a31-5564-80f8-b30249201277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb3cf7-c90d-4bfa-b125-4fbcb5614468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23eb3cf7-c90d-4bfa-b125-4fbcb5614468.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "Whenever you roll a 4 or higher, create a 3/3 colorless Robot artifact creature token. If you rolled 6 or higher, instead create that token and a Treasure token.\n{4}, {T}: Roll a six-sided die plus an additional six-sided die for each mana from Treasures spent to activate this ability.",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "ba075f2f-9db0-52e1-bc3f-e62533ca58e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b60168-1e7b-4c80-bb93-6841c1e961bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b60168-1e7b-4c80-bb93-6841c1e961bb.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "At the beginning of combat on your turn, create a green Aura enchantment token named Settlement attached to up to one target land you control. It has enchant land and \"Enchanted land has \u2018{T}: Add one mana of any color.'\"\nWhenever Preston Garvey, Minuteman attacks, untap each enchanted permanent you control.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "9745cf29-661a-597d-be64-0a969e0f91ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701dae4-348e-40f6-9db4-d6f0039be831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6701dae4-348e-40f6-9db4-d6f0039be831.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "Enlist (As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.)\nWhenever a creature you control attacks, if it enlisted a creature this combat, the creature that attacked gains double strike until end of turn. If that creature's power is 4 or greater, draw a card.",
             "colours": [
@@ -400,7 +400,7 @@
         },
         {
             "id": "0b4b626a-1455-540e-921e-3be2c3215a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e2a76-1324-4b8e-b23c-10c04aca1870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9e2a76-1324-4b8e-b23c-10c04aca1870.jpg?1",
             "name": "Automated Assembly Line",
             "text": "Whenever one or more artifact creatures you control deal combat damage to a player, you get {E} (an energy counter).\nPay {E}{E}{E}: Create a tapped 3/3 colorless Robot artifact creature token.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "75184ad8-1878-5f6b-ac7b-9de1db7ebc2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c0f13a-4e83-4e0b-a790-1f78b5ee6a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c0f13a-4e83-4e0b-a790-1f78b5ee6a64.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "As Battle of Hoover Dam enters the battlefield, choose NCR or Legion.\n\u2022 NCR \u2014 At the beginning of your end step, return target creature card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.\n\u2022 Legion \u2014 Whenever a creature you control dies, put two +1/+1 counters on target creature you control.",
             "colours": [
@@ -472,7 +472,7 @@
         },
         {
             "id": "95af5175-75ff-5dc6-a708-e1824f2e6a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e96e656-7146-420d-aaae-3aedd773eea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e96e656-7146-420d-aaae-3aedd773eea2.jpg?1",
             "name": "Brotherhood Outcast",
             "text": "When Brotherhood Outcast enters the battlefield, choose one \u2014\n\u2022 Return target Aura or Equipment card with mana value 3 or less from your graveyard to the battlefield.\n\u2022 Put a shield counter on target creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "c7e3d2fd-2479-5e3c-8b4c-c56a727ab5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751250e-ebf2-42b1-9a45-779b39974ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b751250e-ebf2-42b1-9a45-779b39974ba7.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "Metalcraft \u2014 {T}: You get {E} (an energy counter). Activate only if you control three or more artifacts.\nWhenever you get one or more {E} during your turn, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "78b0724d-9bf5-5b1c-a5a0-3dd362c54775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdfbd21-61b1-4ebd-8d37-bce2a391a7e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbdfbd21-61b1-4ebd-8d37-bce2a391a7e9.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "Commanders you control have ward {2}.\n{T}: Add {W}{W}. Spend this mana only to cast Aura and/or Equipment spells.\n{T}: Attach target Aura or Equipment you control to target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "70ddf5ea-2ddc-503b-ba47-72130e232129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712697a4-69b4-4237-9340-96f0e5a32229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712697a4-69b4-4237-9340-96f0e5a32229.jpg?1",
             "name": "Commander Sofia Daguerre",
             "text": "Flash\nCrash Landing \u2014 When Commander Sofia Daguerre enters the battlefield, destroy up to one target legendary permanent. That permanent's controller creates a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -628,7 +628,7 @@
         },
         {
             "id": "5a8786c8-b970-5efb-9192-bbdf02d64bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45346ac-54a9-4fda-bde7-92ff75ac34f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45346ac-54a9-4fda-bde7-92ff75ac34f7.jpg?1",
             "name": "Gary Clone",
             "text": "Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhenever Gary Clone attacks, each creature you control named Gary Clone gets +1/+0 until end of turn.",
             "colours": [
@@ -665,7 +665,7 @@
         },
         {
             "id": "fda4d637-0640-5dea-8642-c930ea2768a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687133cb-3754-475c-9e21-b6a33aa58bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687133cb-3754-475c-9e21-b6a33aa58bb0.jpg?1",
             "name": "Idolized",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks alone, it gets +X/+X until end of turn, where X is the number of nonland permanents you control.\"",
             "colours": [
@@ -703,7 +703,7 @@
         },
         {
             "id": "512264bb-3cf4-5fb8-9b27-9b6be0442222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47058eaa-348d-4bbb-8df5-b931eba067f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47058eaa-348d-4bbb-8df5-b931eba067f3.jpg?1",
             "name": "Overencumbered",
             "text": "Enchant opponent\nWhen Overencumbered enters the battlefield, enchanted opponent creates a Clue token, a Food token, and a Junk token.\nAt the beginning of combat on enchanted opponent's turn, that player may pay {1} for each artifact they control. If they don't, creatures can't attack this combat.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "57c28f22-e294-5996-b0a7-8d2d507a092e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35848917-d658-4c3b-b675-4f0185f76dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35848917-d658-4c3b-b675-4f0185f76dc4.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "First Contact \u2014 Whenever Overseer of Vault 76 or another creature with power 3 or less enters the battlefield under your control, put a quest counter on Overseer of Vault 76.\nAt the beginning of combat on your turn, you may remove three quest counters from among permanents you control. When you do, put a +1/+1 counter on each creature you control and they gain vigilance until end of turn.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "6b49e9d0-f0f8-55b8-8dce-4945fcdb39b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7ee3a-18f1-4771-86d6-db1e0b2aa542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7ee3a-18f1-4771-86d6-db1e0b2aa542.jpg?1",
             "name": "Paladin Danse, Steel Maverick",
             "text": "Vigilance, lifelink\nExile Paladin Danse, Steel Maverick: Each creature you control that's an artifact or Human gains indestructible until end of turn.",
             "colours": [
@@ -822,7 +822,7 @@
         },
         {
             "id": "074945d6-064c-5112-ada8-84c5d85375d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19018f23-b63b-45af-8419-8959f41472d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19018f23-b63b-45af-8419-8959f41472d4.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "When Pre-War Formalwear enters the battlefield, return target creature card with mana value 3 or less from your graveyard to the battlefield and attach Pre-War Formalwear to it.\nEquipped creature gets +2/+2 and has vigilance.\nEquip {3}",
             "colours": [
@@ -860,7 +860,7 @@
         },
         {
             "id": "70399eac-df1f-5d73-91e5-8ca37a107bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a8eda-bfeb-4fd9-9e41-12fce02883d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0a8eda-bfeb-4fd9-9e41-12fce02883d8.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "Flying\nWhenever another nontoken artifact enters the battlefield under your control, create a 2/2 white Human Knight creature token with \"This creature gets +2/+2 as long as an artifact entered the battlefield under your control this turn.\"\nCrew 2",
             "colours": [
@@ -900,7 +900,7 @@
         },
         {
             "id": "75b965e8-1404-5728-99ae-2ffa5254a1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b689a206-aec3-4a31-95cf-3d4b840db04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b689a206-aec3-4a31-95cf-3d4b840db04c.jpg?1",
             "name": "Securitron Squadron",
             "text": "Squad {3} (As an additional cost to cast this spell, you may pay {3} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nVigilance\nWhenever a creature token enters the battlefield under your control, put a +1/+1 counter on it.",
             "colours": [
@@ -939,7 +939,7 @@
         },
         {
             "id": "01308706-8daf-50c1-ab0d-308c139e1c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b0143-3511-4f79-bdb1-1ff7af55f051.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b0143-3511-4f79-bdb1-1ff7af55f051.jpg?1",
             "name": "Sentry Bot",
             "text": "Flash\nThis spell costs {1} less to cast for each creature attacking you.\nWhen Sentry Bot enters the battlefield, you get {E} for each creature attacking you.\nAt the beginning of combat on your turn, you may pay {E}{E}{E}. If you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "207a0ca1-2604-5796-800b-6688c51cd1bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641dd97c-6577-4cab-8672-56f870477961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641dd97c-6577-4cab-8672-56f870477961.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "The Nuka-Cola Challenge \u2014 Whenever one or more creatures you control deal combat damage to a player, put a quest counter on Sierra, Nuka's Biggest Fan and create a Food token.\nWhenever you sacrifice a Food, target creature you control gets +X/+X until end of turn, where X is the number of quest counters on Sierra.",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "33834b89-6229-54bc-b722-4f29112d65cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22ad436-215a-4da1-b12e-1faac474f948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22ad436-215a-4da1-b12e-1faac474f948.jpg?1",
             "name": "Vault 13: Dweller's Journey",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 For each player, exile up to one other target enchantment or creature that player controls until Vault 13 leaves the battlefield.\nII \u2014 You gain 2 life and scry 2.\nIII \u2014 Return two cards exiled with Vault 13 to the battlefield under their owners' control and put the rest on the bottom of their owners' libraries.",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "1b516a9e-5944-51c3-81a3-91d50097530a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992e262-0491-4379-b74b-13cc8b63065e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992e262-0491-4379-b74b-13cc8b63065e.jpg?1",
             "name": "Vault 75: Middle School",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile all creatures with power 4 or greater.\nII, III \u2014 Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "ba74e6ea-b228-593a-bed9-a6d0dfbe5700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc513659-ea88-4d04-82bd-5bb2e740d957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc513659-ea88-4d04-82bd-5bb2e740d957.jpg?1",
             "name": "Vault 101: Birthday Party",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human Soldier creature token and a Food token. (A Food token is an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nII, III \u2014 You may put an Aura or Equipment card from your hand or graveyard onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control.",
             "colours": [
@@ -1127,7 +1127,7 @@
         },
         {
             "id": "67b5139c-47d1-521e-b6ed-50253202a790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fac8c-a574-4414-ac68-632fc822ddbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2fac8c-a574-4414-ac68-632fc822ddbb.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "{T}: Target opponent gains control of Yes Man, Personal Securitron. When they do, you draw two cards and put a quest counter on Yes Man. Activate only during your turn.\nWild Card \u2014 When Yes Man leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "e9990c25-0f2f-5943-b722-a5805d9a4f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54870f19-96f3-4cde-ae44-a9c5bbb0dbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54870f19-96f3-4cde-ae44-a9c5bbb0dbc1.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.\n{1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has \"Whenever this creature deals combat damage to a player, draw cards equal to its base power.\"",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "a3a240da-ef0d-5ce3-8ef8-08da21b7e172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "{T}: Add {C}{C}. Spend this mana only to activate abilities.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "c121c742-fbbf-5a66-bc7b-288b04e07fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "Investigate X times. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "6e0c58c1-b068-5a63-ae3f-aa769e0d834f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48313997-fd94-486a-bf30-e9143a155814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48313997-fd94-486a-bf30-e9143a155814.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "Whenever a Zombie or Mutant you control dies, if its power was different from its base power, draw a card.\nCome Fly With Me \u2014 {2}, Sacrifice a creature: Put a +1/+1 counter on target creature you control. It gains flying until end of turn.",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "2a3ed239-3aa4-570a-afff-fededdf5c95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d1843-9e05-4cdd-ad4e-15d7913d87f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6d1843-9e05-4cdd-ad4e-15d7913d87f7.jpg?1",
             "name": "Mirelurk Queen",
             "text": "Vigilance\nWhen Mirelurk Queen enters the battlefield, target player gets two rad counters.\nWhenever one or more nonland cards are milled, draw a card, then put a +1/+1 counter on Mirelurk Queen. This ability triggers only once each turn.",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "04c97542-3476-5e8c-8516-6f581a72a12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9857669-5fad-458a-8eda-c1790298add7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9857669-5fad-458a-8eda-c1790298add7.jpg?1",
             "name": "Nerd Rage",
             "text": "Enchant creature\nWhen Nerd Rage enters the battlefield, draw two cards.\nEnchanted creature has \"You have no maximum hand size\" and \"Whenever this creature attacks, if you have ten or more cards in hand, it gets +10/+10 until end of turn.\"",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "522f18ed-58fe-5c0d-ba2f-15b1d612069d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9553-d4a8-4d51-8e8a-8a0ffbdf1715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7c9553-d4a8-4d51-8e8a-8a0ffbdf1715.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "Nick Valentine, Private Eye can't be blocked except by artifact creatures.\nWhenever Nick Valentine or another artifact creature you control dies, you may investigate. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "79df93fd-5d37-5252-8d40-fd82cc3adb8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916bf331-455a-4694-93d3-15dcf6971072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/916bf331-455a-4694-93d3-15dcf6971072.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "Whenever Piper Wright deals combat damage to a player, investigate that many times. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "45c2434b-7cd6-521c-b242-c7ec8cd8ba94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d778cdec-8fc7-4174-bae1-4c8e8ccdfab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d778cdec-8fc7-4174-bae1-4c8e8ccdfab3.jpg?1",
             "name": "Radstorm",
             "text": "Storm (When you cast this spell, copy it for each spell cast before it this turn.)\nProliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "3edd8ce2-f9f5-5089-adce-4cbff6ca05dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c0791d-f0c5-4673-a0c5-40540c1e6d8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c0791d-f0c5-4673-a0c5-40540c1e6d8c.jpg?1",
             "name": "Robobrain War Mind",
             "text": "Robobrain War Mind's power is equal to the number of cards in your hand.\nWhen Robobrain War Mind enters the battlefield, you get an amount of {E} (energy counters) equal to the number of artifact creatures you control.\nWhenever Robobrain War Mind attacks, you may pay {E}{E}{E}. If you do, draw a card.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "4a15b789-cdba-53b0-b986-849ceda2a8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c60155-9337-4ea2-b9a2-5b72d96743ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c60155-9337-4ea2-b9a2-5b72d96743ff.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "As Struggle for Project Purity enters the battlefield, choose Brotherhood or Enclave.\n\u2022 Brotherhood \u2014 At the beginning of your upkeep, each opponent draws a card. You draw a card for each card drawn this way.\n\u2022 Enclave \u2014 Whenever a player attacks you with one or more creatures, that player gets twice that many rad counters.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "f899e0bb-8e38-57b4-ad29-294da20a2c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe16bc4-8457-4c5f-902a-0746112e80a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe16bc4-8457-4c5f-902a-0746112e80a4.jpg?1",
             "name": "Synth Infiltrator",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nYou may have Synth Infiltrator enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.",
             "colours": [
@@ -1636,7 +1636,7 @@
         },
         {
             "id": "12f4fa4f-d70c-5473-a823-0f3cd33ae69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91580910-fe0e-4cd9-9e73-821af23abfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91580910-fe0e-4cd9-9e73-821af23abfe7.jpg?1",
             "name": "Vexing Radgull",
             "text": "Flying\nWhenever Vexing Radgull deals combat damage to a player, that player gets two rad counters if they don't have any rad counters. Otherwise, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "9d0e3637-de45-55b0-8189-19c702ae734d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d90b839-0808-435d-bcf3-aa7af414c44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d90b839-0808-435d-bcf3-aa7af414c44b.jpg?1",
             "name": "Bloatfly Swarm",
             "text": "Flying\nBloatfly Swarm enters the battlefield with five +1/+1 counters on it.\nIf damage would be dealt to Bloatfly Swarm while it has a +1/+1 counter on it, prevent that damage, remove that many +1/+1 counters from it, then give each player a rad counter for each +1/+1 counter removed this way.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "452d0964-24b2-5f30-bdaf-a5bcd76ab925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed508c-ff2c-444c-8149-34b29e2fbebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed508c-ff2c-444c-8149-34b29e2fbebe.jpg?1",
             "name": "Butch DeLoria, Tunnel Snake",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nTunnel Snakes Rule \u2014 Whenever Butch DeLoria, Tunnel Snake attacks, it gets +1/+1 until end of turn for each other Rogue and/or Snake you control.\n{1}{B}: Put a menace counter on another target creature. It becomes a Rogue in addition to its other types.",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "573a6625-4cd4-5745-b573-444ae4380356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdef99d-6ce9-495d-a55b-e6ba799d3da7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdef99d-6ce9-495d-a55b-e6ba799d3da7.jpg?1",
             "name": "Feral Ghoul",
             "text": "Menace\nWhenever another creature you control dies, put a +1/+1 counter on Feral Ghoul.\nWhen Feral Ghoul dies, each opponent gets a number of rad counters equal to its power.",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "3134aec0-d496-55b4-bbed-06ef8835f294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bda1b4-3f02-4cbc-9573-f5b6e6c991d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bda1b4-3f02-4cbc-9573-f5b6e6c991d5.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "Each other creature you control that's a Zombie or Mutant gets +X/+X, where X is the number of counters on Hancock, Ghoulish Mayor.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "1c27aa6e-5a31-53f4-8493-65d234d8f9c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b51b691-e226-44c9-b7cb-26f19c060597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b51b691-e226-44c9-b7cb-26f19c060597.jpg?1",
             "name": "Infesting Radroach",
             "text": "Flying\nInfesting Radroach can't block.\nWhenever Infesting Radroach deals combat damage to a player, they get that many rad counters.\nWhenever an opponent mills a nonland card, if Infesting Radroach is in your graveyard, you may return it to your hand.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "2a390efe-a256-551d-8d55-8125b2fa79c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e717e4b0-a8c1-4411-b18a-1d17e7225503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e717e4b0-a8c1-4411-b18a-1d17e7225503.jpg?1",
             "name": "Nuclear Fallout",
             "text": "Each creature gets twice -X/-X until end of turn. Each player gets X rad counters.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "551ef638-dc57-55c2-92ba-3ca46d681503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4542e34-2905-41ce-9182-a432c8f2c451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4542e34-2905-41ce-9182-a432c8f2c451.jpg?1",
             "name": "Ruthless Radrat",
             "text": "Squad\u2014\nExile four cards from your graveyard. (As an additional cost to cast this spell, you may pay its squad cost any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -1940,7 +1940,7 @@
         },
         {
             "id": "636e4e5b-60f2-55f0-86d6-554ca6aa3d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967dbb24-3073-4c33-bfdf-b3eb9e8fe443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967dbb24-3073-4c33-bfdf-b3eb9e8fe443.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "Flying, menace\nWhenever Screeching Scorchbeast attacks, each player gets two rad counters.\nWhenever one or more nonland cards are milled, you may create that many 2/2 black Zombie Mutant creature tokens. Do this only once each turn.",
             "colours": [
@@ -1979,7 +1979,7 @@
         },
         {
             "id": "56e3801a-1098-5d32-9595-805652907f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512df222-0db0-4b24-9372-d0c01b181b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512df222-0db0-4b24-9372-d0c01b181b91.jpg?1",
             "name": "V.A.T.S.",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose any number of target creatures with equal toughness. Destroy the chosen creatures.",
             "colours": [
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "6849290f-b5fc-5310-a972-987fcc5ac52a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cd9eb-9b15-40ce-8a48-919e72dbaa67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144cd9eb-9b15-40ce-8a48-919e72dbaa67.jpg?1",
             "name": "Vault 12: The Necropolis",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player gets three rad counters.\nII \u2014 Create X 2/2 black Zombie Mutant creature tokens, where X is the total number of rad counters among players.\nIII \u2014 Put two +1/+1 counters on each creature you control that's a Zombie or Mutant.",
             "colours": [
@@ -2051,7 +2051,7 @@
         },
         {
             "id": "2c8f762c-3b55-5f9c-8170-dbae9d6eb019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae2596-013a-4e9b-982b-e0fc8d1e78bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eae2596-013a-4e9b-982b-e0fc8d1e78bf.jpg?1",
             "name": "Wasteland Raider",
             "text": "Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhen Wasteland Raider enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -2090,7 +2090,7 @@
         },
         {
             "id": "75802892-0df5-5eb0-ab50-104f8b4633cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19586946-a6a6-4154-a544-15a052483f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19586946-a6a6-4154-a544-15a052483f96.jpg?1",
             "name": "Acquired Mutation",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and is goaded. (It attacks each combat if able and attacks a player other than you if able.)\nWhenever enchanted creature attacks, defending player gets two rad counters.",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "f13310f9-d26b-511d-9e4e-40daa725b4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112fadb-da03-441a-beeb-1dc90425e3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112fadb-da03-441a-beeb-1dc90425e3f3.jpg?1",
             "name": "Assaultron Dominator",
             "text": "When Assaultron Dominator enters the battlefield, you get {E}{E} (two energy counters).\nWhenever an artifact creature you control attacks, you may pay {E}. If you do, put your choice of a +1/+1, first strike, or trample counter on that creature.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "a1012542-96cf-5485-ab9e-573b05f16bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdceec0-0950-4d52-86fc-d0f04e8487ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdceec0-0950-4d52-86fc-d0f04e8487ce.jpg?1",
             "name": "Bottle-Cap Blast",
             "text": "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nBottle-Cap Blast deals 5 damage to any target. If excess damage was dealt to a permanent this way, create that many tapped Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "421bd8e3-82cc-5abc-b4cb-a13b37648935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc522b-6297-455e-8bb5-6187061496d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3acc522b-6297-455e-8bb5-6187061496d0.jpg?1",
             "name": "Crimson Caravaneer",
             "text": "Double strike, trample\nWhenever Crimson Caravaneer deals combat damage to a player, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "a01791c9-2cde-55ed-9ff6-b07e44a3c54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0a17f-787b-41ac-8375-d9532dce1f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c0a17f-787b-41ac-8375-d9532dce1f4f.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "Hunters for Hire \u2014 Whenever a creature you control deals combat damage to a player, put a quest counter on it.\n{1}, Remove a quest counter from a permanent you control: Create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "048a829d-e16a-5575-a04f-4aa8f853a8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e76286-9e06-42de-b322-eb8aa2cdca3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e76286-9e06-42de-b322-eb8aa2cdca3a.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "Morbid \u2014 This spell costs {3} less to cast if a creature died this turn.\nEnchant creature\nWhen Grim Reaper's Sprint enters the battlefield, untap each creature you control. If it's your main phase, there is an additional combat phase after this phase.\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "2eccbe20-3abb-5038-bbb1-06acb4827beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd46b6a-eb20-4ffa-94e0-47d1d2d46087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd46b6a-eb20-4ffa-94e0-47d1d2d46087.jpg?1",
             "name": "Ian the Reckless",
             "text": "Whenever Ian the Reckless attacks, if it's modified, you may have it deal damage equal to its power to you and any target. (Equipment, Auras you control, and counters are modifications.)",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "a6a8ba26-0bf2-5ba1-97ba-3c73548ba4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2397c9b8-3974-48b8-94bd-f05f2e20750c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2397c9b8-3974-48b8-94bd-f05f2e20750c.jpg?1",
             "name": "Junk Jet",
             "text": "When Junk Jet enters the battlefield, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\n{3}, Sacrifice another artifact: Double equipped creature's power until end of turn.\nEquip {1}",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "55ed5682-c877-5903-9b89-df14b6e2da45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8492127-888d-4da0-b49f-fba6a356b0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8492127-888d-4da0-b49f-fba6a356b0a9.jpg?1",
             "name": "Megaton's Fate",
             "text": "Choose one \u2014\n\u2022 Disarm \u2014 Destroy target artifact. Create four Treasure tokens.\n\u2022 Detonate \u2014 Megaton's Fate deals 8 damage to each creature. Each player gets four rad counters.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "89b4b639-3401-5a97-beea-6680efcf1123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9df394-522c-4458-bc36-cf24ad763718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9df394-522c-4458-bc36-cf24ad763718.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "When The Motherlode, Excavator enters the battlefield, choose target opponent. You get an amount of {E} (energy counters) equal to the number of nonbasic lands that player controls.\nWhenever The Motherlode attacks, you may pay {E}{E}{E}{E}. When you do, destroy target nonbasic land defending player controls, and creatures that player controls without flying can't block this turn.",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "6d698c1d-aa47-50a8-af6c-a95c12d93a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063ca0fa-1947-48da-86f9-76dd00dfb550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/063ca0fa-1947-48da-86f9-76dd00dfb550.jpg?1",
             "name": "Mysterious Stranger",
             "text": "Flash\nWhen Mysterious Stranger enters the battlefield, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -2508,7 +2508,7 @@
         },
         {
             "id": "87dfcd2c-c94c-5d91-8a3a-1ab7dd1d32c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1654256-25ea-4467-812d-25f32fe65cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1654256-25ea-4467-812d-25f32fe65cdd.jpg?1",
             "name": "Plasma Caster",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you get {E}{E} (two energy counters).\nPay {E}{E}: Choose target creature that's blocking equipped creature. Flip a coin. If you win the flip, exile the chosen creature. Otherwise, Plasma Caster deals 1 damage to it.\nEquip {2}",
             "colours": [
@@ -2546,7 +2546,7 @@
         },
         {
             "id": "e3268dbd-2f46-5b4b-8f87-661a5e65ae76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb57c73-a454-450d-9db9-67501bf4559d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb57c73-a454-450d-9db9-67501bf4559d.jpg?1",
             "name": "Powder Ganger",
             "text": "Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhen Powder Ganger enters the battlefield, destroy up to one target artifact.",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "537a1667-b282-5182-aac2-bddaa8d753cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803a510-99fe-467a-be3b-9301497ec7ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803a510-99fe-467a-be3b-9301497ec7ec.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "First strike\nRaid \u2014 At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\nWhenever you sacrifice a Junk, add {R}.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "3b6c15fd-ec44-57ed-9fc9-33ce68add3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc7b54-26e5-4b0d-b2bb-be8f977f752b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc7b54-26e5-4b0d-b2bb-be8f977f752b.jpg?1",
             "name": "Synth Eradicator",
             "text": "Haste\nWhenever Synth Eradicator attacks, exile the top card of your library. You may get {E}{E} (two energy counters). If you don't, you may play that card this turn.\n{T}, Pay {E}{E}{E}: Synth Eradicator deals 3 damage to any target.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "ce4a0f22-38e3-542d-b12f-0213a826b147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5628e781-9f12-49ed-a575-6b467d39510b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5628e781-9f12-49ed-a575-6b467d39510b.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "Squad\u2014{1}, Discard a card. (As an additional cost to cast this spell, you may pay its squad cost any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)\nWhen Thrill-Kill Disciple dies, create a Junk token.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "d0869ab7-aca0-5353-8a75-27f02095b0d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40972644-a284-4c7c-a451-d70eff7488ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40972644-a284-4c7c-a451-d70eff7488ab.jpg?1",
             "name": "Vault 21: House Gambit",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Discard a card, then draw a card.\nIII \u2014 Reveal up to five nonland cards from your hand. For each of those cards that has the same mana value as another card revealed this way, create a Treasure token.",
             "colours": [
@@ -2741,7 +2741,7 @@
         },
         {
             "id": "aa1b01e6-c52a-521d-9bc1-04fb3dbce329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2325aa29-7050-42a5-a0b4-c162db2192c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2325aa29-7050-42a5-a0b4-c162db2192c9.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "Menace\nWhenever Veronica, Dissident Scribe attacks, you may discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards for the first time each turn, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2783,7 +2783,7 @@
         },
         {
             "id": "8289800b-851f-5f5b-8011-1526deb8dbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1024d6-c5f1-48f5-9081-fb90d0c46fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1024d6-c5f1-48f5-9081-fb90d0c46fdb.jpg?1",
             "name": "Wild Wasteland",
             "text": "Skip your draw step.\nAt the beginning of your upkeep, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "d57b8147-6657-57d7-b6c5-5d3c4f9cbb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af31a045-0387-44ff-b735-54e19b04d925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af31a045-0387-44ff-b735-54e19b04d925.jpg?1",
             "name": "Animal Friend",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 1/1 green Squirrel creature token. Put a +1/+1 counter on that token for each Aura and Equipment attached to this creature other than Animal Friend.\"",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "bf53d960-529c-51c6-814f-24a853d0a83e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861361bc-b357-4ff8-931b-a48d08817191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/861361bc-b357-4ff8-931b-a48d08817191.jpg?1",
             "name": "Bighorner Rancher",
             "text": "Vigilance\n{T}: Add an amount of {G} equal to the greatest power among creatures you control.\nSacrifice Bighorner Rancher: You gain life equal to the greatest toughness among other creatures you control.",
             "colours": [
@@ -2894,7 +2894,7 @@
         },
         {
             "id": "e96d1d4c-684c-59fa-b9e8-a78bd8953345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389f9d7-b8ae-4c51-90f9-b6385517914a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3389f9d7-b8ae-4c51-90f9-b6385517914a.jpg?1",
             "name": "Break Down",
             "text": "Destroy target artifact or enchantment. Create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "6357859e-205f-5de3-841e-5853575d7f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84118221-20a3-46a9-9e6e-a928b46a8633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84118221-20a3-46a9-9e6e-a928b46a8633.jpg?1",
             "name": "Cathedral Acolyte",
             "text": "Each creature you control with a counter on it has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\n{T}: Put a +1/+1 counter on target creature that entered the battlefield this turn.",
             "colours": [
@@ -2965,7 +2965,7 @@
         },
         {
             "id": "9c9ff706-e9a9-53cb-8cb6-565a3c1a392c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e36b92-aa88-4536-aebc-7e84a10d73fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e36b92-aa88-4536-aebc-7e84a10d73fe.jpg?1",
             "name": "Glowing One",
             "text": "Deathtouch\nWhenever Glowing One deals combat damage to a player, they get four rad counters.\nWhenever a player mills a nonland card, you gain 1 life.",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "95f876c4-73ef-54a6-9f5e-6bdacbd2a5ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6d444f-9ffb-4dc2-b668-738d45aec2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f6d444f-9ffb-4dc2-b668-738d45aec2c3.jpg?1",
             "name": "Gunner Conscript",
             "text": "Trample\nGunner Conscript gets +1/+1 for each Aura and Equipment attached to it.\nWhen Gunner Conscript dies, if it was enchanted, create a Junk token.\nWhen Gunner Conscript dies, if it was equipped, create a Junk token.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "30ac44df-ca1d-5dbd-8110-b9a34105e479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730ac69-20ec-4ef3-85ee-a5fd24e5f277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d730ac69-20ec-4ef3-85ee-a5fd24e5f277.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "Vigilance, reach\nWhen Harold and Bob, First Numens dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add three mana of any one color. You get two rad counters.'\" Harold and Bob loses all other abilities.",
             "colours": [
@@ -3080,7 +3080,7 @@
         },
         {
             "id": "22fdfb42-6454-5e17-b3ce-0922074d9976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052dc548-d356-43fe-9484-665db7e1f505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052dc548-d356-43fe-9484-665db7e1f505.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "Vigilance\nLily Bowen, Raging Grandma enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Lily Bowen if its power is 16 or less. Otherwise, remove all but one +1/+1 counter from it, then you gain 1 life for each +1/+1 counter removed this way.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "5c1cc132-eec1-5705-a900-d48f3bdc81ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b92e8a-fadf-4568-8b30-2df68e6ff7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b92e8a-fadf-4568-8b30-2df68e6ff7cf.jpg?1",
             "name": "Lumbering Megasloth",
             "text": "This spell costs {1} less to cast for each counter among players and permanents.\nTrample\nLumbering Megasloth enters the battlefield tapped.",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "a00fea9e-353c-5200-94fb-ae249d967d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8f7fbc-bf2a-43c1-a88d-807c1e7dab69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8f7fbc-bf2a-43c1-a88d-807c1e7dab69.jpg?1",
             "name": "Power Fist",
             "text": "Equipped creature has trample and \"Whenever this creature deals combat damage to a player, put that many +1/+1 counters on it.\"\nEquip {2}",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "e8f48213-2b88-524d-b167-34ee95e67ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63619236-a27a-4fdd-add6-7a295901f906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63619236-a27a-4fdd-add6-7a295901f906.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "Vigilance, trample\nRampaging Yao Guai enters the battlefield with X +1/+1 counters on it.\nWhen Rampaging Yao Guai enters the battlefield, destroy any number of target artifacts and/or enchantments with total mana value X or less.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "9a933adc-e43e-5d20-aac0-fba48f347351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65afa5-e4f7-49c2-97f9-47ad5dbcacfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f65afa5-e4f7-49c2-97f9-47ad5dbcacfa.jpg?1",
             "name": "Strong Back",
             "text": "Enchant creature\nEquip abilities you activate that target enchanted creature cost {3} less to activate.\nAura spells you cast that target enchanted creature cost {3} less to cast.\nEnchanted creature gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "01a9dfa4-d955-58fd-8910-ffad27b336aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc79ed6-057b-439f-b2cd-58d5bcd8b551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc79ed6-057b-439f-b2cd-58d5bcd8b551.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "Ward {2}\nEnrage \u2014 Whenever Strong is dealt damage, you get three rad counters and put three +1/+1 counters on Strong.\nYou gain life rather than lose life from radiation.",
             "colours": [
@@ -3314,7 +3314,7 @@
         },
         {
             "id": "199a9498-e8dc-5183-a841-1356c41c34be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f48a99-eaf7-42ec-bab3-9ebbc735a82a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f48a99-eaf7-42ec-bab3-9ebbc735a82a.jpg?1",
             "name": "Super Mutant Scavenger",
             "text": "Trample\nWhen Super Mutant Scavenger enters the battlefield or dies, return up to one target Aura or Equipment card from your graveyard to your hand.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "25e7ab7b-3df7-5d4a-8054-ea4f264c415e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bade4-7232-4808-af5c-2dbed4d5bf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bade4-7232-4808-af5c-2dbed4d5bf07.jpg?1",
             "name": "Tato Farmer",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may get two rad counters.\n{T}: Put target land card in a graveyard that was milled this turn onto the battlefield under your control tapped.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "ed193d68-1433-585a-bcf4-b23bfee83858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4151d4-4d35-48d2-9e72-c87014f79137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4151d4-4d35-48d2-9e72-c87014f79137.jpg?1",
             "name": "Watchful Radstag",
             "text": "Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.)\nWhenever Watchful Radstag evolves, create a token that's a copy of it.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "42df1d90-0ba4-5c51-9359-cdf5a3e0c56b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed640359-01e2-4a96-a4ab-aca053a2498d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed640359-01e2-4a96-a4ab-aca053a2498d.jpg?1",
             "name": "Well Rested",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature becomes untapped, put two +1/+1 counters on it, then you gain 2 life and draw a card. This ability triggers only once each turn.\"",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "ecfef169-295a-5ab3-8691-f54ed70af086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91193a0b-9087-404f-b397-815e29d0fe12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91193a0b-9087-404f-b397-815e29d0fe12.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "Trample\nAgent Frank Horrigan has indestructible as long as it attacked this turn.\nWhenever Agent Frank Horrigan enters the battlefield or attacks, proliferate twice. (To proliferate, choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "d2bcdb2c-b165-5f9c-982b-6f6e6e71d1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a9bff-969f-49c1-be02-40cb45858f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a9bff-969f-49c1-be02-40cb45858f19.jpg?1",
             "name": "Almost Perfect",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 9/10 and has indestructible.",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "3bcdc99e-6e89-55dc-862e-f9efe4d71fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4c8b04-66af-4cb3-8003-9088d8344b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4c8b04-66af-4cb3-8003-9088d8344b20.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "Menace, trample\nWhen Alpha Deathclaw enters the battlefield or becomes monstrous, destroy target permanent.\n{5}{B}{G}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -3590,7 +3590,7 @@
         },
         {
             "id": "82bdaa14-8585-5719-a41f-8589e2632799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36356522-15fc-41e2-bf14-a745e5a96a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36356522-15fc-41e2-bf14-a745e5a96a50.jpg?1",
             "name": "Arcade Gannon",
             "text": "{T}: Draw a card, then discard a card. Put a quest counter on Arcade Gannon.\nFor Auld Lang Syne \u2014 Once during each of your turns, you may cast an artifact or Human spell from your graveyard with mana value less than or equal to the number of quest counters on Arcade Gannon.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "1c75def1-6b9a-58b7-99b5-ffae5da40a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ffa95-5c5f-449b-820a-7d5bc1688d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5ffa95-5c5f-449b-820a-7d5bc1688d29.jpg?1",
             "name": "Armory Paladin",
             "text": "Trample\nWhenever you cast an Aura or Equipment spell, exile the top card of your library. You may play that card until the end of your next turn.",
             "colours": [
@@ -3674,7 +3674,7 @@
         },
         {
             "id": "4810de94-0351-509d-afd6-c8b070aed883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592cbafc-ab4e-461f-b64f-0bf9d83aaff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592cbafc-ab4e-461f-b64f-0bf9d83aaff3.jpg?1",
             "name": "Atomize",
             "text": "Destroy target nonland permanent. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -3712,7 +3712,7 @@
         },
         {
             "id": "9b1e9596-2f2b-5c19-9014-e610dab58aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d0316-9b94-4ccb-9103-509e6a0963a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193d0316-9b94-4ccb-9103-509e6a0963a1.jpg?1",
             "name": "Boomer Scrapper",
             "text": "Whenever Boomer Scrapper enters the battlefield or attacks, you lose 1 life and create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\nWhenever a token you control leaves the battlefield, put a +1/+1 counter on Boomer Scrapper.",
             "colours": [
@@ -3753,7 +3753,7 @@
         },
         {
             "id": "098d34ae-bbb3-57b8-bf50-578b7035f5ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca61d02-2819-483f-9d30-862f0650ab0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca61d02-2819-483f-9d30-862f0650ab0a.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "As long as it's your turn, Cait, Cage Brawler has indestructible.\nWhenever Cait attacks, you and defending player each draw a card, then discard a card. Put two +1/+1 counters on Cait if you discarded the card with the highest mana value among those cards or tied for highest.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "099ddf6b-01cd-5490-91b3-02cad5feb72a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6d7fa6-4de6-4bc8-b250-2ed6eb559618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6d7fa6-4de6-4bc8-b250-2ed6eb559618.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "Vigilance\nWhenever Cass or another creature you control dies, if it was enchanted or equipped, return any number of Aura cards that were attached to it from your graveyard to the battlefield attached to target creature, then attach any number of Equipment  that were attached to it to that creature.",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "d81d105a-9ef9-52cc-9ecd-d4b45b25a977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c3e5a-64f3-40b5-8080-1c53be45aa40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c3e5a-64f3-40b5-8080-1c53be45aa40.jpg?1",
             "name": "Colonel Autumn",
             "text": "Lifelink\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nOther legendary creatures you control have exploit.\nWhenever a creature you control exploits a creature, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -3882,7 +3882,7 @@
         },
         {
             "id": "93250333-e4fa-5bbc-ae34-05e09e8926fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde9eb15-544a-462a-8ab8-86067840c083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bde9eb15-544a-462a-8ab8-86067840c083.jpg?1",
             "name": "Contaminated Drink",
             "text": "Draw X cards, then you get half X rad counters, rounded up.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "c44308cb-3703-5d7b-ad36-08fdaf92f3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d83dad-21c3-4777-84b0-3c775585b5fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d83dad-21c3-4777-84b0-3c775585b5fd.jpg?1",
             "name": "Craig Boone, Novac Guard",
             "text": "Reach, lifelink\nOne for My Baby \u2014 Whenever you attack with two or more creatures, put two quest counters on Craig Boone, Novac Guard. When you do, Craig Boone deals damage equal to the number of quest counters on it to up to one target creature unless that creature's controller has Craig Boone deal that much damage to them.",
             "colours": [
@@ -3959,7 +3959,7 @@
         },
         {
             "id": "2eebb8d0-85ea-5544-a634-4eb9b5858005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38d445-1752-4921-bb83-5afcdf655015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38d445-1752-4921-bb83-5afcdf655015.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "Vigilance\nWhenever Desdemona, Freedom's Edge attacks, target creature card in your graveyard that's an artifact or that has mana value 3 or less gains escape until end of turn. The escape cost is equal to its mana cost plus exile two other cards from your graveyard. (You may cast it from your graveyard for its escape cost this turn.)",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "13b11a52-aace-58bf-8d41-2d90a912aece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049771b0-69ad-4f2d-8567-47e8a87b4496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049771b0-69ad-4f2d-8567-47e8a87b4496.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "Creature tokens you control have training. (Whenever a creature token you control attacks with another creature with greater power, put a +1/+1 counter on that token.)\nBlind Betrayal \u2014 Sacrifice another creature: Elder Arthur Maxson gains indestructible until end of turn.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "a8daf465-ed63-5a7d-a940-2b113fe4896e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d923c845-59e0-403e-b57b-955fec528f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d923c845-59e0-403e-b57b-955fec528f1e.jpg?1",
             "name": "Elder Owyn Lyons",
             "text": "Artifacts you control have ward {1}. (Whenever an artifact you control becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)\nWhen Elder Owyn Lyons enters the battlefield or dies, return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -4086,7 +4086,7 @@
         },
         {
             "id": "f3fc3b8b-4de6-5b6d-b106-0aa72a4874d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8377fce8-edc8-4926-bf75-57162ff6df9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8377fce8-edc8-4926-bf75-57162ff6df9f.jpg?1",
             "name": "Electrosiphon",
             "text": "Counter target spell. You get an amount of {E} (energy counters) equal to its mana value.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "ae749cb8-48d9-51b7-b383-422e84cb4bd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1acb59-a679-4c6d-8458-8fe5556b9d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1acb59-a679-4c6d-8458-8fe5556b9d4d.jpg?1",
             "name": "Inventory Management",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nFor each Aura and Equipment you control, you may attach it to a creature you control.",
             "colours": [
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "311715ff-3b70-5c40-9ded-d861e3384ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b22b32-be24-48e3-aa81-9256190df02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2b22b32-be24-48e3-aa81-9256190df02c.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "First strike, haste\nWhenever Kellogg, Dangerous Mind attacks, create a Treasure token.\nSacrifice five Treasures: Gain control of target creature for as long as you control Kellogg. Activate only as a sorcery.",
             "colours": [
@@ -4205,7 +4205,7 @@
         },
         {
             "id": "c934c9a1-71b8-555b-9ba4-5f2422d5f48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14eb369-b8e3-4abf-9e77-79d1fe5b426f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f14eb369-b8e3-4abf-9e77-79d1fe5b426f.jpg?1",
             "name": "Legate Lanius, Caesar's Ace",
             "text": "Decimate \u2014 When Legate Lanius enters the battlefield, each opponent sacrifices a tenth of the creatures they control, rounded up.\nWhenever an opponent sacrifices a creature, put a +1/+1 counter on Legate Lanius.",
             "colours": [
@@ -4246,7 +4246,7 @@
         },
         {
             "id": "ef83c492-995b-5e62-9616-2924afa5556b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2251ce-2d5b-4d0d-8dc9-44f6b40aa7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2251ce-2d5b-4d0d-8dc9-44f6b40aa7cf.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "Whenever a creature you control with power 2 or less attacks, it gains skulk until end of turn. (It can't be blocked by creatures with greater power.)\nWhenever a creature with power 4 or greater attacks you, its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "c4326539-9a13-5816-89e9-0241995a17de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15db5769-af10-4369-ab4c-db25adb22223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15db5769-af10-4369-ab4c-db25adb22223.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "Vigilance, trample\nWhenever a creature you control deals combat damage to a player, draw a card if that creature has a +1/+1 counter on it. If it doesn't, put a +1/+1 counter on it.",
             "colours": [
@@ -4332,7 +4332,7 @@
         },
         {
             "id": "84a17e53-29ce-5219-b87e-365daea13a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418ce6f6-b483-4695-aaf5-e4f7eeb9eb16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418ce6f6-b483-4695-aaf5-e4f7eeb9eb16.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "When Moira Brown, Guide Author enters the battlefield, create a colorless Equipment artifact token named Wasteland Survival Guide with \"Equipped creature gets +1/+1 for each quest counter among permanents you control\" and equip {1}.\nWhenever you attack, put a quest counter on target nonland permanent you control.",
             "colours": [
@@ -4375,7 +4375,7 @@
         },
         {
             "id": "c5120471-694d-5cf1-af64-9e59a606d1c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff92f1-9dc7-48e6-9e7c-9ef4a88518cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ff92f1-9dc7-48e6-9e7c-9ef4a88518cb.jpg?1",
             "name": "Mutational Advantage",
             "text": "Permanents you control with counters on them gain hexproof and indestructible until end of turn. Prevent all damage that would be dealt to those permanents this turn. Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -4413,7 +4413,7 @@
         },
         {
             "id": "9f0e210e-f6af-5e6a-8e8b-2b2e0ff15138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7cfcb2-83fb-41ad-ae31-9c32c942506c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7cfcb2-83fb-41ad-ae31-9c32c942506c.jpg?1",
             "name": "Nightkin Ambusher",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Nightkin Ambusher enters the battlefield, target player gets four rad counters.\nNightkin Ambusher can't be blocked as long as defending player has a rad counter.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "a33ffb15-ab07-58b7-9a82-2e5ecedee0ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0abd847-1c9d-45cd-a6d1-3a0cda3687cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0abd847-1c9d-45cd-a6d1-3a0cda3687cb.jpg?1",
             "name": "The Nipton Lottery",
             "text": "Choose a creature at random. You gain control of that creature until end of turn. Untap it. It gains haste until end of turn. Then destroy all other creatures.",
             "colours": [
@@ -4490,7 +4490,7 @@
         },
         {
             "id": "502b42ab-7796-5b6c-a929-52bf8aa51a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24fd14b-cfd1-43db-b155-3187a1063d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24fd14b-cfd1-43db-b155-3187a1063d92.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "Battalion \u2014 Whenever Paladin Elizabeth Taggerdy and at least two other creatures attack, draw a card, then you may put a creature card with mana value X or less from your hand onto the battlefield tapped and attacking, where X is Paladin Elizabeth Taggerdy's power.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "08bd0415-c9e9-5a1f-9eb7-a7095c35d9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73a314-b197-4954-a242-7d9096a406c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73a314-b197-4954-a242-7d9096a406c1.jpg?1",
             "name": "Raul, Trouble Shooter",
             "text": "Once during each of your turns, you may cast a spell from among cards in your graveyard that were milled this turn.\n{T}: Each player mills a card. (They each put the top card of their library into their graveyard.)",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "ac551d1f-cfdd-51a3-af42-ec0c85ba07b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf616fa-b9a0-4f7a-b7ee-32ce3a08d466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf616fa-b9a0-4f7a-b7ee-32ce3a08d466.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "Alluring Eyes \u2014 {T}: Goad target creature an opponent controls. That player draws a card. You add {R}. (Until your next turn, that creature attacks each combat if able and attacks a player other than you if able.)",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "bc21b656-3031-505b-8e4d-96c179e5eabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae95822-d4a9-4698-bd11-c504414fc160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae95822-d4a9-4698-bd11-c504414fc160.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "Whenever Rex, Cyber-Hound deals combat damage to a player, they mill two cards and you get {E}{E} (two energy counters).\nPay {E}{E}: Choose target creature card in a graveyard. Exile it with a brain counter on it. Activate only as a sorcery.\nRex has all activated abilities of all cards in exile with brain counters on them.",
             "colours": [
@@ -4662,7 +4662,7 @@
         },
         {
             "id": "0a6bbaf0-ce9b-5346-9556-c4c06880306c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b76965-528c-48f9-9ee6-332b09cae664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b76965-528c-48f9-9ee6-332b09cae664.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "Haste\nAs long as an artifact entered the battlefield under your control this turn, creatures you control get +2/+2.\nBattalion \u2014 Whenever Sentinel Sarah Lyons and at least two other creatures attack, Sentinel Sarah Lyons deals damage equal to the number of artifacts you control to target player.",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "f1accae0-74fd-5e3e-9c66-aaf64d13ea49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68af449f-3c30-43ea-be60-d85061d7adbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68af449f-3c30-43ea-be60-d85061d7adbd.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "Whenever you attack, you may create a tapped and attacking token that's a copy of target attacking legendary creature you control other than Shaun, except it's not legendary and it's a Synth artifact creature in addition to its other types.\nWhen Shaun leaves the battlefield, exile all Synth tokens you control.",
             "colours": [
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "02a2319c-6224-51e8-bb37-fb1075ac116a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab34e869-be7a-4632-95b3-5f200b4edcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab34e869-be7a-4632-95b3-5f200b4edcca.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "Whenever you attack, you may pay {2} and sacrifice an Aura attached to Three Dog, Galaxy News DJ. When you sacrifice an Aura this way, for each other attacking creature you control, create a token that's a copy of that Aura attached to that creature.",
             "colours": [
@@ -4791,7 +4791,7 @@
         },
         {
             "id": "3d4d90ea-94c8-5fb7-a298-be815229fa0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafcd4e-5693-4c23-be79-75653fcd214c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bafcd4e-5693-4c23-be79-75653fcd214c.jpg?1",
             "name": "Vault 11: Voter's Dilemma",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 For each opponent, you create a 1/1 white Human Soldier creature token.\nII, III \u2014 Each player secretly votes for up to one creature, then those votes are revealed. If no creature got votes, each player draws a card. Otherwise, destroy each creature with the most votes or tied for most votes.",
             "colours": [
@@ -4829,7 +4829,7 @@
         },
         {
             "id": "aa281683-cfb6-5a2d-ae47-46f0e0c004ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf267b-f41c-447a-aa35-0c01aad8a489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33bf267b-f41c-447a-aa35-0c01aad8a489.jpg?1",
             "name": "Vault 87: Forced Evolution",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Gain control of target non-Mutant creature for as long as you control Vault 87.\nII \u2014 Put a +1/+1 counter on target creature you control. It becomes a Mutant in addition to its other types.\nIII \u2014 Draw cards equal to the greatest power among Mutants you control.",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "2098e00d-bcc1-580b-b1bb-f4645b815785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0acee2-f6dc-4e92-937b-01e2c07adc55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a0acee2-f6dc-4e92-937b-01e2c07adc55.jpg?1",
             "name": "Vault 112: Sadistic Simulation",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Tap up to one target creature and put a stun counter on it. You get {E}{E} (two energy counters).\nIII \u2014 Pay any amount of {E}. If you paid one or more {E} this way, shuffle your library, then exile that many cards from the top. You may play one of those cards without paying its mana cost.",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "57644998-c287-5684-8ac4-1c73b7b155c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bf1f6c-4653-4734-9bd7-af689a1b679d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bf1f6c-4653-4734-9bd7-af689a1b679d.jpg?1",
             "name": "White Glove Gourmand",
             "text": "When White Glove Gourmand enters the battlefield, create two 1/1 white Human Soldier creature tokens.\nAt the beginning of your end step, if another Human died under your control this turn, create a Food token.",
             "colours": [
@@ -4944,7 +4944,7 @@
         },
         {
             "id": "67d377d9-ec5f-5938-9d7e-e6bd500c904f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d5e6bd-de46-4bc2-854b-cc6cae713f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d5e6bd-de46-4bc2-854b-cc6cae713f98.jpg?1",
             "name": "Young Deathclaws",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nEach creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "a3d06ee3-3ec3-58b7-8688-258d89a8df68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8b0c5-5457-432a-8c27-f193c9922aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8b0c5-5457-432a-8c27-f193c9922aec.jpg?1",
             "name": "Agility Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Up to X target creatures you control each gain haste until end of turn and can't be blocked this turn except by creatures with haste, where X is the number of Bobbleheads you control as you activate this ability.",
             "colours": [],
@@ -5016,7 +5016,7 @@
         },
         {
             "id": "01906695-e676-50ea-afc5-947b1a6198bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d6e5b-a94e-460c-ab2f-21fd842c3d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d6e5b-a94e-460c-ab2f-21fd842c3d9a.jpg?1",
             "name": "Behemoth of Vault 0",
             "text": "Trample\nWhen Behemoth of Vault 0 enters the battlefield, you get {E}{E}{E}{E} (four energy counters).\nWhen Behemoth of Vault 0 dies, you may pay an amount of {E} equal to target nonland permanent's mana value. When you do, destroy that permanent.",
             "colours": [],
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "88f1992a-7e9f-576b-984d-7b2f0e86a0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c207c76d-5f10-4fd9-9826-cf0611bfa2d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c207c76d-5f10-4fd9-9826-cf0611bfa2d0.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "Flying\nBrotherhood Vertibird's power is equal to the number of artifacts you control.\nCrew 2 (Tap any number of creatures you control with total power 2 or greater: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -5083,7 +5083,7 @@
         },
         {
             "id": "e55af085-668d-51b5-a578-e542508a949f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034d4543-2c53-4cda-acfd-7f26b8dd17fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034d4543-2c53-4cda-acfd-7f26b8dd17fb.jpg?1",
             "name": "C.A.M.P.",
             "text": "Whenever fortified land is tapped for mana, put a +1/+1 counter on target creature you control. If that creature shares a color with the mana that land produced, create a Junk token. (It's an artifact with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")\nFortify {3} ({3}: Attach to target land you control. Fortify only as a sorcery.)",
             "colours": [],
@@ -5115,7 +5115,7 @@
         },
         {
             "id": "9c9b3e86-0475-5345-b59d-1b095ad8cb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f61330-869f-448c-8374-1cbac7c23454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f61330-869f-448c-8374-1cbac7c23454.jpg?1",
             "name": "Charisma Bobblehead",
             "text": "{T}: Add one mana of any color.\n{4}, {T}: Create X 1/1 white Soldier creature tokens, where X is the number of Bobbleheads you control. Activate only as a sorcery.",
             "colours": [],
@@ -5148,7 +5148,7 @@
         },
         {
             "id": "149e881d-6a23-5da4-82cd-49e4f3f3c89d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b319f0e1-6f18-4fea-9f72-a21da5513aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b319f0e1-6f18-4fea-9f72-a21da5513aa4.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "Flying\nED-E My Love \u2014 Whenever you attack, if the number of attacking creatures is greater than the number of quest counters on ED-E, Lonesome Eyebot, put a quest counter on it.\n{2}, Sacrifice ED-E: Draw a card, then draw an additional card for each quest counter on ED-E.",
             "colours": [],
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "dfb34474-6e41-5c58-9c8a-014aaf87d8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8768789b-c414-4e35-bff3-d06a69dccff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8768789b-c414-4e35-bff3-d06a69dccff6.jpg?1",
             "name": "Endurance Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Up to X target creatures you control get +1/+0 and gain indestructible until end of turn, where X is the number of Bobbleheads you control as you activate this ability. Activate only as a sorcery.",
             "colours": [],
@@ -5218,7 +5218,7 @@
         },
         {
             "id": "4532fd68-c34b-5ebf-b393-ca8ae30c41fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f4bdc-8b6a-4e87-92fd-8368537a6ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f4bdc-8b6a-4e87-92fd-8368537a6ced.jpg?1",
             "name": "Expert-Level Safe",
             "text": "When Expert-Level Safe enters the battlefield, exile the top two cards of your library face down.\n{1}, {T}: You and target opponent each secretly choose 1, 2, or 3. Then those choices are revealed. If they match, sacrifice Expert-Level Safe and put all cards exiled with it into their owners' hands. Otherwise, exile the top card of your library face down.",
             "colours": [],
@@ -5248,7 +5248,7 @@
         },
         {
             "id": "0f0bfc52-8c8c-58d8-ac74-41951bdda3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6546c0d-6be2-4ced-9d7c-4269df8dea76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6546c0d-6be2-4ced-9d7c-4269df8dea76.jpg?1",
             "name": "Intelligence Bobblehead",
             "text": "{T}: Add one mana of any color.\n{5}, {T}: Draw X cards, where X is the number of Bobbleheads you control.",
             "colours": [],
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "54ac4de7-11eb-5225-b3c5-9d7ad43544cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13281945-47ff-464d-96ef-9b26ef6783fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13281945-47ff-464d-96ef-9b26ef6783fa.jpg?1",
             "name": "Luck Bobblehead",
             "text": "{T}: Add one mana of any color.\n{1}, {T}: Roll X six-sided dice, where X is the number of Bobbleheads you control. Create a tapped Treasure token for each even result. If you rolled 6 exactly seven times, you win the game.",
             "colours": [],
@@ -5314,7 +5314,7 @@
         },
         {
             "id": "a680d38e-1dec-5615-9140-a01904859d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09166a-78de-4136-8a3c-034e1ef73ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f09166a-78de-4136-8a3c-034e1ef73ede.jpg?1",
             "name": "Mister Gutsy",
             "text": "Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on Mister Gutsy.\nWhen Mister Gutsy dies, create X Junk tokens, where X is the number of +1/+1 counters on it. (They're artifacts with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [],
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "d49dfa6a-1461-5060-a841-3c2ae5da0fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405df7c7-0e37-499e-9826-6bf9f5db7a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405df7c7-0e37-499e-9826-6bf9f5db7a40.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "{1}, {T}: Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever you sacrifice a Food, create a tapped Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -5382,7 +5382,7 @@
         },
         {
             "id": "276cb8d0-6d9c-557c-a94d-b4d05b7d0139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d5835b-c206-4884-bdcf-38c7cdc703f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d5835b-c206-4884-bdcf-38c7cdc703f4.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "Equipped creature gets +3/+0 and has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever equipped creature attacks, until the end of defending player's next turn, that player gets two rad counters whenever they cast a spell.\nEquip {3}",
             "colours": [],
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "0056d472-f526-5728-8104-67e1c6915666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a8c89c-2cd1-4f68-9758-449177be2880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a8c89c-2cd1-4f68-9758-449177be2880.jpg?1",
             "name": "Perception Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Look at the top X cards of your library, where X is the number of Bobbleheads you control. You may cast a spell with mana value 3 or less from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -5449,7 +5449,7 @@
         },
         {
             "id": "8b025a00-b58b-5a43-84f9-d12a627a3a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2248694-aab0-47a8-ae8b-8d5283075e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2248694-aab0-47a8-ae8b-8d5283075e10.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Sort Inventory \u2014 Draw a card, then discard a card.\n\u2022 Pick a Perk \u2014 Put a +1/+1 counter on that creature.\n\u2022 Check Map \u2014 Untap up to two target lands.\nEquip {2}",
             "colours": [],
@@ -5483,7 +5483,7 @@
         },
         {
             "id": "e0dbf03a-d60f-528f-86d8-2304766764b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21aa59d3-e786-4ba0-9802-01b57597cda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21aa59d3-e786-4ba0-9802-01b57597cda2.jpg?1",
             "name": "Recon Craft Theta",
             "text": "Flying\nWhen Recon Craft Theta enters the battlefield, create a 0/0 blue Alien creature token. Put a +1/+1 counter on it.\nWhenever Recon Craft Theta attacks, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nCrew 2",
             "colours": [],
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "fa5948ec-3228-5e08-99ce-c4950fbf93d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21fba59-330b-4daf-bf77-6dd817327a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21fba59-330b-4daf-bf77-6dd817327a64.jpg?1",
             "name": "Silver Shroud Costume",
             "text": "Flash\nWhen Silver Shroud Costume enters the battlefield, attach it to target creature you control. That creature gains shroud until end of turn. (It can't be the target of spells or abilities.)\nEquipped creature can't be blocked.\nEquip {3}",
             "colours": [],
@@ -5549,7 +5549,7 @@
         },
         {
             "id": "8247e2b0-a9d8-5caf-924a-f08ed9df570d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af73ad-625a-4260-8917-6a837f9fdf88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af73ad-625a-4260-8917-6a837f9fdf88.jpg?1",
             "name": "Strength Bobblehead",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: Put X +1/+1 counters on target creature, where X is the number of Bobbleheads you control. Activate only as a sorcery.",
             "colours": [],
@@ -5582,7 +5582,7 @@
         },
         {
             "id": "73c868fe-dd85-5e8e-bf02-fda7c91ab0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f30a39-aad3-45da-8f03-50b1d1806b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f30a39-aad3-45da-8f03-50b1d1806b00.jpg?1",
             "name": "Survivor's Med Kit",
             "text": "{1}, {T}: Choose one that hasn't been chosen \u2014\n\u2022 Stimpak \u2014 Draw a card.\n\u2022 Fancy Lads Snack Cakes \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n\u2022 Rad\nAway \u2014 Target player loses all rad counters. Sacrifice Survivor's Med Kit.",
             "colours": [],
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "21f14793-5663-5d04-9fb4-e13a46704162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203b1cb3-5eae-469a-8a5a-2e56dc859f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/203b1cb3-5eae-469a-8a5a-2e56dc859f78.jpg?1",
             "name": "T-45 Power Armor",
             "text": "When T-45 Power Armor enters the battlefield, you get {E}{E} (two energy counters).\nEquipped creature gets +3/+3 and doesn't untap during its controller's untap step.\nAt the beginning of your upkeep, you may pay {E}. If you do, untap equipped creature, then put your choice of a menace, trample, or lifelink counter on it.\nEquip {3}",
             "colours": [],
@@ -5646,7 +5646,7 @@
         },
         {
             "id": "9946ca93-e695-5a20-869e-587cb8bd9b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f38637-8cdc-42bb-b164-85596b6b14b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05f38637-8cdc-42bb-b164-85596b6b14b9.jpg?1",
             "name": "Desolate Mire",
             "text": "{1}, {T}: Add {W}{B}.",
             "colours": [],
@@ -5681,7 +5681,7 @@
         },
         {
             "id": "5da92361-3d00-5aac-958b-d5214e7fc940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9bd49a-e9f1-4543-b04a-777a9e5a55ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9bd49a-e9f1-4543-b04a-777a9e5a55ec.jpg?1",
             "name": "Diamond City",
             "text": "Diamond City enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\n{T}: Add {C}.\n{T}: Move a shield counter from Diamond City onto target creature. Activate only if two or more creatures entered the battlefield under your control this turn.",
             "colours": [],
@@ -5713,7 +5713,7 @@
         },
         {
             "id": "1f0a69f8-d3c8-5fad-bdd7-c8b5fa34a79d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0406ff96-419b-44bc-b836-a39eaa55ae78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0406ff96-419b-44bc-b836-a39eaa55ae78.jpg?1",
             "name": "Ferrous Lake",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "2a8c6c22-82fd-5c55-80f1-840cb0975184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4102d28e-437b-440b-bf9b-8b4f6fb85a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4102d28e-437b-440b-bf9b-8b4f6fb85a6c.jpg?1",
             "name": "HELIOS One",
             "text": "{T}: Add {C}.\n{1}, {T}: You get {E} (an energy counter).\n{3}, {T}, Pay X {E}, Sacrifice HELIOS One: Destroy target nonland permanent with mana value X. Activate only as a sorcery.",
             "colours": [],
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "9a4ee213-29f4-5334-a600-0f227d802d77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e24c687-f070-469d-a09d-acf4ac6ed374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e24c687-f070-469d-a09d-acf4ac6ed374.jpg?1",
             "name": "Junktown",
             "text": "{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Junktown: Create three Junk tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")",
             "colours": [],
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "3b9d9edd-004f-5a41-ba3d-9afa0a8a19f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7be9d4-f9fa-44a3-9902-7e9e226ccf56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7be9d4-f9fa-44a3-9902-7e9e226ccf56.jpg?1",
             "name": "Mariposa Military Base",
             "text": "You may have Mariposa Military Base enter the battlefield tapped. If you do, you get two rad counters.\n{T}: Add {C}.\n{5}, {T}: Draw a card. This ability costs {1} less to activate for each rad counter you have.",
             "colours": [],
@@ -5846,7 +5846,7 @@
         },
         {
             "id": "63988af9-caec-5870-9fce-9990b59efcfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75372ba1-85fb-4923-a62f-4050761c1471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75372ba1-85fb-4923-a62f-4050761c1471.jpg?1",
             "name": "Overflowing Basin",
             "text": "{1}, {T}: Add {G}{U}.",
             "colours": [],
@@ -5881,7 +5881,7 @@
         },
         {
             "id": "a94808e3-ebb6-5d53-ad74-08a2f823beaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84a8f54-9ede-40ee-a783-e58a7e4f2e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84a8f54-9ede-40ee-a783-e58a7e4f2e94.jpg?1",
             "name": "Sunscorched Divide",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -5916,7 +5916,7 @@
         },
         {
             "id": "2eccf9fa-dc4a-5e96-9e4c-e27ca74d0f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4ce16b-39bb-4580-9c38-a7c6b9a33609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea4ce16b-39bb-4580-9c38-a7c6b9a33609.jpg?1",
             "name": "Viridescent Bog",
             "text": "{1}, {T}: Add {B}{G}.",
             "colours": [],
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "2ede928a-b2c7-5589-8c9e-0c92fa36b339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d9fb74-9f2d-40f1-88b8-514a460a4f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d9fb74-9f2d-40f1-88b8-514a460a4f86.jpg?1",
             "name": "All That Glitters",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each artifact and/or enchantment you control.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "9c889b86-969b-5d57-8710-6c5f17c9cf6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5215c18d-90cd-45df-ac14-99909c97c69e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5215c18d-90cd-45df-ac14-99909c97c69e.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with mana value 3 or less.\n\u2022 Destroy all creatures with mana value 4 or greater.",
             "colours": [
@@ -6023,7 +6023,7 @@
         },
         {
             "id": "b5aca8e6-c176-537a-9e9c-0d89fb200d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936e77d4-ab74-4123-9225-879493e5ad79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/936e77d4-ab74-4123-9225-879493e5ad79.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -6062,7 +6062,7 @@
         },
         {
             "id": "e081dd73-10bf-5d9d-9814-200823aa6ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0941279-8695-4b71-b27a-5477a1858525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0941279-8695-4b71-b27a-5477a1858525.jpg?1",
             "name": "Crush Contraband",
             "text": "Choose one or both \u2014\n\u2022 Exile target artifact.\n\u2022 Exile target enchantment.",
             "colours": [
@@ -6096,7 +6096,7 @@
         },
         {
             "id": "aeb65042-e28f-5e11-ae1c-a02bcafef03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfcc2a8-ab59-47b5-88a9-0692e6091334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfcc2a8-ab59-47b5-88a9-0692e6091334.jpg?1",
             "name": "Dispatch",
             "text": "Tap target creature.\nMetalcraft \u2014 If you control three or more artifacts, exile that creature.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "7aad5b77-4d0a-5b88-951c-2b97d2436dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2707cc0c-20ea-4241-b0b0-7000a713fb63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2707cc0c-20ea-4241-b0b0-7000a713fb63.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "Target player sacrifices an attacking creature. You create X 1/1 white Soldier creature tokens, where X is that creature's toughness.",
             "colours": [
@@ -6166,7 +6166,7 @@
         },
         {
             "id": "f644bc79-bce4-563c-8d8e-9d9ed67e6b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca614808-4e09-4839-ae80-7c3ea6cf61fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca614808-4e09-4839-ae80-7c3ea6cf61fd.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "fdf70f4e-ab95-5bf0-999d-7497d6b1d539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574c3028-c942-4257-a825-c25318915593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574c3028-c942-4257-a825-c25318915593.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -6239,7 +6239,7 @@
         },
         {
             "id": "97d414b7-9035-5427-9763-ed73a1fab258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805c99f1-ab4d-4072-a8b7-7e2818adbc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805c99f1-ab4d-4072-a8b7-7e2818adbc97.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -6273,7 +6273,7 @@
         },
         {
             "id": "8dbc7f3a-50ba-5210-96ea-3825c74339b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dad7f-774a-47c2-892b-b3952dbed683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367dad7f-774a-47c2-892b-b3952dbed683.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6312,7 +6312,7 @@
         },
         {
             "id": "61917242-1f0a-50b9-9e8b-2bee6c631883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ec4350-05fa-4452-ade3-3cf2c319eb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ec4350-05fa-4452-ade3-3cf2c319eb0b.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "Enchant creature you control\nWhen Mantle of the Ancients enters the battlefield, return any number of target Aura and/or Equipment cards that could be attached to enchanted creature from your graveyard to the battlefield attached to enchanted creature.\nEnchanted creature gets +1/+1 for each Aura and Equipment attached to it.",
             "colours": [
@@ -6350,7 +6350,7 @@
         },
         {
             "id": "3601a92b-e344-59ef-85b0-c702d89466e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cea75f-f2b0-47f3-a40b-ee43a6132ead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cea75f-f2b0-47f3-a40b-ee43a6132ead.jpg?1",
             "name": "Marshal's Anthem",
             "text": "Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nCreatures you control get +1/+1.\nWhen Marshal's Anthem enters the battlefield, return up to X target creature cards from your graveyard to the battlefield, where X is the number of times Marshal's Anthem was kicked.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "55ad74c4-bd39-540e-8da7-3b36b5f2e75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f7f71-625a-46ec-bce8-6bd934f2a275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3f7f71-625a-46ec-bce8-6bd934f2a275.jpg?1",
             "name": "Martial Coup",
             "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "4f530702-97d7-5aa6-85d2-9f4a53f8cba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd2e9d0-3691-40a4-a0e8-42ca29bfcc10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd2e9d0-3691-40a4-a0e8-42ca29bfcc10.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control. (Auras with nothing to enchant remain in graveyards.)",
             "colours": [
@@ -6458,7 +6458,7 @@
         },
         {
             "id": "69c7acfd-ca45-54de-9c6e-be8d70e00115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437e42e1-a8b5-49db-885b-e7e1a06db59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437e42e1-a8b5-49db-885b-e7e1a06db59d.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -6492,7 +6492,7 @@
         },
         {
             "id": "6f5091a7-7af6-5b6b-9be1-094df5d0bc2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e496f4-ec53-4e3c-a27d-5c1b5a54a642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e496f4-ec53-4e3c-a27d-5c1b5a54a642.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "0d195986-166c-51db-a270-710bb96d0f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97649f03-262c-485d-8cb4-75cc4f65ec53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97649f03-262c-485d-8cb4-75cc4f65ec53.jpg?1",
             "name": "Secure the Wastes",
             "text": "Create X 1/1 white Warrior creature tokens.",
             "colours": [
@@ -6567,7 +6567,7 @@
         },
         {
             "id": "be88ed98-8da5-5210-8ac3-dd3cc263b936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea2469c-f719-40e6-bec1-0457fa93c541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea2469c-f719-40e6-bec1-0457fa93c541.jpg?1",
             "name": "Single Combat",
             "text": "Each player chooses a creature or planeswalker they control, then sacrifices the rest. Players can't cast creature or planeswalker spells until the end of your next turn.",
             "colours": [
@@ -6603,7 +6603,7 @@
         },
         {
             "id": "e6120841-e4f8-5321-aeb0-44eba948637e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed55827d-1d72-4884-8a4f-fe7acbedab2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed55827d-1d72-4884-8a4f-fe7acbedab2c.jpg?1",
             "name": "Swords to Plowshares",
             "text": "Exile target creature. Its controller gains life equal to its power.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "579b5bf8-f670-5b90-b66b-d43fce85a561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11545710-6917-4e44-856f-4c9063a1313c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11545710-6917-4e44-856f-4c9063a1313c.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn.\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "4d430395-c83d-5f69-830d-2ec71f55dfc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dbffda-f7cf-454f-b449-0fa7c6895add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dbffda-f7cf-454f-b449-0fa7c6895add.jpg?1",
             "name": "Fraying Sanity",
             "text": "Enchant player\nAt the beginning of each end step, enchanted player mills X cards, where X is the number of cards put into their graveyard from anywhere this turn.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "4540a85b-3baf-5f70-a719-a0b78cf0ad05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d84305-2143-470a-bf1f-12fb6d4d63b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d84305-2143-470a-bf1f-12fb6d4d63b9.jpg?1",
             "name": "Glimmer of Genius",
             "text": "Scry 2, then draw two cards. You get {E}{E} (two energy counters).",
             "colours": [
@@ -6744,7 +6744,7 @@
         },
         {
             "id": "cc5536da-8292-5a5c-9386-ce01978681cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e857a2-389d-43f4-96aa-721e4ad1f3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e857a2-389d-43f4-96aa-721e4ad1f3f1.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "54d94b5e-09b5-5830-a9b7-3110888d96c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dca7cb-4724-48d6-a0e0-2cbb5a7fa4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40dca7cb-4724-48d6-a0e0-2cbb5a7fa4f7.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "9a6c2d74-2c82-5e16-9fb5-b4218c64e442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f555efc-4314-4111-8c61-9548c5bae2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f555efc-4314-4111-8c61-9548c5bae2e0.jpg?1",
             "name": "One with the Machine",
             "text": "Draw cards equal to the highest mana value among artifacts you control.",
             "colours": [
@@ -6854,7 +6854,7 @@
         },
         {
             "id": "c0b793df-b1fa-515a-8f8a-94132f7e7fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d4cc8d6-b366-4da8-a2d2-ff3be9092789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d4cc8d6-b366-4da8-a2d2-ff3be9092789.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "Draw three cards. Then discard two cards unless you discard an artifact card.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "f15ad3f8-10df-5ec5-abeb-1159078f5bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91323e0e-5384-4571-a7c0-0e2c2ed45f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91323e0e-5384-4571-a7c0-0e2c2ed45f02.jpg?1",
             "name": "Whirler Rogue",
             "text": "When Whirler Rogue enters the battlefield, create two 1/1 colorless Thopter artifact creature tokens with flying.\nTap two untapped artifacts you control: Target creature can't be blocked this turn.",
             "colours": [
@@ -6926,7 +6926,7 @@
         },
         {
             "id": "78751e32-1426-5ccb-8b28-fcefea0067b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e2c839-4f55-482c-baaa-aa8f7c8e9b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e2c839-4f55-482c-baaa-aa8f7c8e9b7d.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "When Bastion of Remembrance enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "a95602bb-61a5-51d9-839b-77fcbf1406a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b4c56-e17e-49ec-8946-0e95a4bfa1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275b4c56-e17e-49ec-8946-0e95a4bfa1ae.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "aaef1995-9056-5b33-937f-3f455219a81b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ee1e37-bde7-4208-8851-718f2ae1c540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ee1e37-bde7-4208-8851-718f2ae1c540.jpg?1",
             "name": "Deadly Dispute",
             "text": "As an additional cost to cast this spell, sacrifice an artifact or creature.\nDraw two cards and create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7030,7 +7030,7 @@
         },
         {
             "id": "a8277d91-1fb4-5147-84e5-06a38a8acba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2c44f7-7b54-4cdf-8f53-ab78c515795b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2c44f7-7b54-4cdf-8f53-ab78c515795b.jpg?1",
             "name": "Lethal Scheme",
             "text": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature or planeswalker. Each creature that convoked Lethal Scheme connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "85e19e16-e228-5928-a068-294f636a4f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7357386d-7ede-449f-bd30-b19a08921d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7357386d-7ede-449f-bd30-b19a08921d86.jpg?1",
             "name": "Morbid Opportunist",
             "text": "Whenever one or more other creatures die, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -7103,7 +7103,7 @@
         },
         {
             "id": "45964035-1c64-5501-928e-9c68a259bb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47255b76-2c77-4e94-938d-b9d3497798ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47255b76-2c77-4e94-938d-b9d3497798ec.jpg?1",
             "name": "Pitiless Plunderer",
             "text": "Whenever another creature you control dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "f0efa478-70c9-5769-abfc-9dad5d5aacab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c16b7-63c2-4071-9117-184cb1a04f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c16b7-63c2-4071-9117-184cb1a04f14.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "ff2c563d-2356-5eab-bea8-411ae760b3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4d0e40-d771-458e-b705-1d2bef8c200e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4d0e40-d771-458e-b705-1d2bef8c200e.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -7212,7 +7212,7 @@
         },
         {
             "id": "30cff0e7-7ea0-578c-901e-7e2215e7b5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cd0e82-d2aa-4614-93a2-b84828866742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5cd0e82-d2aa-4614-93a2-b84828866742.jpg?1",
             "name": "Loyal Apprentice",
             "text": "Haste\nLieutenant \u2014 At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.",
             "colours": [
@@ -7249,7 +7249,7 @@
         },
         {
             "id": "4e40e2dd-92af-5dbc-b2eb-90b89a4417d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f748393d-5845-45d7-96e9-bbdbb701151f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f748393d-5845-45d7-96e9-bbdbb701151f.jpg?1",
             "name": "Sticky Fingers",
             "text": "Enchant creature\nEnchanted creature has menace and \"Whenever this creature deals combat damage to a player, create a Treasure token.\" (It can't be blocked except by two or more creatures. The token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhen enchanted creature dies, draw a card.",
             "colours": [
@@ -7285,7 +7285,7 @@
         },
         {
             "id": "167e9f77-213e-5156-92e4-a530e65f048f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0adad-207a-4504-9636-75f7ccb5b60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0adad-207a-4504-9636-75f7ccb5b60c.jpg?1",
             "name": "Stolen Strategy",
             "text": "At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -7321,7 +7321,7 @@
         },
         {
             "id": "7aa4a157-669d-5cb3-8a7e-58e1a14b3113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5261d46-bf8c-4c29-8683-9a4fe4b23b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5261d46-bf8c-4c29-8683-9a4fe4b23b8d.jpg?1",
             "name": "Unexpected Windfall",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7355,7 +7355,7 @@
         },
         {
             "id": "963c63c9-1e8b-57e9-bf89-cef9e9c31f7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120b71f5-3c4d-4e00-9a3d-6872416a4373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120b71f5-3c4d-4e00-9a3d-6872416a4373.jpg?1",
             "name": "Abundant Growth",
             "text": "Enchant land\nWhen Abundant Growth enters the battlefield, draw a card.\nEnchanted land has \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -7391,7 +7391,7 @@
         },
         {
             "id": "5c403025-b600-5994-9330-c08d3cd03b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b2c132-0e57-4273-aa30-e78870647dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4b2c132-0e57-4273-aa30-e78870647dc7.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -7427,7 +7427,7 @@
         },
         {
             "id": "11bb4068-4ced-5698-934d-fd5502451cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b149d9f6-c337-43cd-8f9e-1f864d039d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b149d9f6-c337-43cd-8f9e-1f864d039d9c.jpg?1",
             "name": "Cultivate",
             "text": "Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.",
             "colours": [
@@ -7461,7 +7461,7 @@
         },
         {
             "id": "83ace907-6006-545f-8760-8e86a3d71172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd4d32-8cb8-4699-8e96-22746cf5ea57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2dd4d32-8cb8-4699-8e96-22746cf5ea57.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7495,7 +7495,7 @@
         },
         {
             "id": "9849fe97-73f3-5610-87df-570b1b6db864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d3b2bb-2be0-4de9-9de0-1a07da693e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88d3b2bb-2be0-4de9-9de0-1a07da693e4f.jpg?1",
             "name": "Fertile Ground",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
             "colours": [
@@ -7531,7 +7531,7 @@
         },
         {
             "id": "e6924a58-de70-5f6e-b57a-93044760f15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1b0ed2-dc94-471d-9ea4-1a17f3cbb81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1b0ed2-dc94-471d-9ea4-1a17f3cbb81a.jpg?1",
             "name": "Guardian Project",
             "text": "Whenever a nontoken creature enters the battlefield under your control, if it doesn't have the same name as another creature you control or a creature card in your graveyard, draw a card.",
             "colours": [
@@ -7567,7 +7567,7 @@
         },
         {
             "id": "a89c6e5f-0970-57c0-9a46-f436934b1a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecefd95-4eff-4403-83c1-c0c29a2f2a76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecefd95-4eff-4403-83c1-c0c29a2f2a76.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -7603,7 +7603,7 @@
         },
         {
             "id": "3f3b80d2-39a2-5aec-b31f-f2b755cdc0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd260f0-2bce-469a-9c40-7978db5776e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd260f0-2bce-469a-9c40-7978db5776e9.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -7637,7 +7637,7 @@
         },
         {
             "id": "23d094b5-9bbc-5b5b-ad86-8e7a5c38ffcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdaecd3-fc71-4c86-a65e-27681e1ba41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bdaecd3-fc71-4c86-a65e-27681e1ba41f.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -7673,7 +7673,7 @@
         },
         {
             "id": "4b9789d5-2f17-5ac4-a331-aa4deef1ce1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7760a-16d9-4fe2-98f3-212cc2cf6d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7760a-16d9-4fe2-98f3-212cc2cf6d83.jpg?1",
             "name": "Inspiring Call",
             "text": "Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn.",
             "colours": [
@@ -7707,7 +7707,7 @@
         },
         {
             "id": "59c037dc-0cb2-59e4-aff8-aa7dd78137f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fad7e1-b57f-4652-879e-d97466948829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fad7e1-b57f-4652-879e-d97466948829.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -7741,7 +7741,7 @@
         },
         {
             "id": "56019e8e-2f72-561b-8980-fcfab3a92863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073ecc9-5d3a-452f-b708-0572fa27a6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073ecc9-5d3a-452f-b708-0572fa27a6f0.jpg?1",
             "name": "Rancor",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and has trample.\nWhen Rancor is put into a graveyard from the battlefield, return Rancor to its owner's hand.",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "b9b5dbf7-aab4-5fa2-b436-27803155f2f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52b4496-b60d-4c72-bf86-0f0e54515821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52b4496-b60d-4c72-bf86-0f0e54515821.jpg?1",
             "name": "Squirrel Nest",
             "text": "Enchant land\nEnchanted land has \"{T}: Create a 1/1 green Squirrel creature token.\"",
             "colours": [
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "e71c774d-0aac-53a9-afd2-c2dd5775a56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b1bc46-e8be-4437-a50a-96b6f1ec4a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b1bc46-e8be-4437-a50a-96b6f1ec4a08.jpg?1",
             "name": "Tireless Tracker",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.",
             "colours": [
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "909b3356-4cb1-5b90-a619-1b90ead0212f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fdfa77-424a-4f83-bb48-1c43b6c84b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fdfa77-424a-4f83-bb48-1c43b6c84b17.jpg?1",
             "name": "Wild Growth",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.",
             "colours": [
@@ -7888,7 +7888,7 @@
         },
         {
             "id": "b0b79137-9e71-5f94-9428-ef1744f18393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e0f42-a881-4ee2-94a5-2c740863aa74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272e0f42-a881-4ee2-94a5-2c740863aa74.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "499779f0-ba34-5a14-86fc-c181fca6f813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c04498-91cf-42d2-a349-44df4d022746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c04498-91cf-42d2-a349-44df4d022746.jpg?1",
             "name": "Assemble the Legion",
             "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then create a 1/1 red and white Soldier creature token with haste for each muster counter on Assemble the Legion.",
             "colours": [
@@ -7964,7 +7964,7 @@
         },
         {
             "id": "60eb1656-534c-56d4-9235-bf17e93b03b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053d366-fc35-443b-a8dd-4ab0c3362c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053d366-fc35-443b-a8dd-4ab0c3362c81.jpg?1",
             "name": "Behemoth Sledge",
             "text": "Equipped creature gets +2/+2 and has trample and lifelink.\nEquip {3}",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "7f6d5a31-f57c-5b3c-a49e-4d2521e2ebfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3f731a-03d7-4dc9-a922-cc2250cee6ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a3f731a-03d7-4dc9-a922-cc2250cee6ef.jpg?1",
             "name": "Biomass Mutation",
             "text": "Creatures you control have base power and toughness X/X until end of turn.",
             "colours": [
@@ -8040,7 +8040,7 @@
         },
         {
             "id": "08316c03-c35d-52df-a681-3089c1da0f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea2451e-ad6e-4f76-ac76-0b8f4fabd0a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ea2451e-ad6e-4f76-ac76-0b8f4fabd0a9.jpg?1",
             "name": "Casualties of War",
             "text": "Choose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature.\n\u2022 Destroy target enchantment.\n\u2022 Destroy target land.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -8078,7 +8078,7 @@
         },
         {
             "id": "014016de-9f65-59b6-a864-82ff2f834c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb08ac43-f138-47b6-9bff-6248c315b0ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb08ac43-f138-47b6-9bff-6248c315b0ca.jpg?1",
             "name": "Corpsejack Menace",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on it instead.",
             "colours": [
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "928f12bb-9a5e-5ecf-9723-ec2d316f3a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2a0286-a16d-4e48-a295-da8232ddc9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2a0286-a16d-4e48-a295-da8232ddc9c7.jpg?1",
             "name": "Fervent Charge",
             "text": "Whenever a creature you control attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -8156,7 +8156,7 @@
         },
         {
             "id": "768c10e3-d10f-50cc-8247-27568d4d7495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg?1",
             "name": "Find // Finality",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "fe6bb1fc-9c37-5efa-9e0d-c4f6eb3ab3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cbd4c04c-81b5-4026-a82a-4ae94ad50c01.jpg?1",
             "name": "Find // Finality",
             "text": "You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.",
             "colours": [
@@ -8228,7 +8228,7 @@
         },
         {
             "id": "0cc50a05-572f-59f9-bc1a-bc1293ec3847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682373ca-d358-4a21-8cbe-4a41d8636b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682373ca-d358-4a21-8cbe-4a41d8636b42.jpg?1",
             "name": "General's Enforcer",
             "text": "Legendary Humans you control have indestructible.\n{2}{W}{B}: Exile target card from a graveyard. If it was a creature card, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -8267,7 +8267,7 @@
         },
         {
             "id": "72ed92dc-8f69-55d3-913e-c40230c0ad58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a87f7-208d-4312-ba37-7a844b9c89ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912a87f7-208d-4312-ba37-7a844b9c89ab.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "Create two 1/1 white Soldier creature tokens. Until end of turn, creatures you control get +1/+1 and gain haste.",
             "colours": [
@@ -8303,7 +8303,7 @@
         },
         {
             "id": "7e46ad05-06c6-50f7-af1a-358b5978a9a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf308540-dd6d-4437-abe7-373a2c129455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf308540-dd6d-4437-abe7-373a2c129455.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -8339,7 +8339,7 @@
         },
         {
             "id": "f65b03fc-90b0-5c3a-a28b-f65d839fb3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3d5d4-7fa3-47ba-9963-23814bce063d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe3d5d4-7fa3-47ba-9963-23814bce063d.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "Destroy all nonland permanents your opponents control.",
             "colours": [
@@ -8379,7 +8379,7 @@
         },
         {
             "id": "9673da82-ef59-555d-9a2e-c4a60a4a3561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4548087a-9e65-4d57-988c-2b42c2801197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4548087a-9e65-4d57-988c-2b42c2801197.jpg?1",
             "name": "Wake the Past",
             "text": "Return all artifact cards from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "48ca770f-b3e7-59f8-a24f-9988f429838b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target artifact.\n\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -8452,7 +8452,7 @@
         },
         {
             "id": "a8d95e2f-e850-5c39-a371-b4130bb69a89",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/427d7eab-24e3-41de-8444-d9a2c96f526f.jpg?1",
             "name": "Wear // Tear",
             "text": "Destroy target enchantment.\n\nFuse (You may cast one or both halves of this card from your hand.)",
             "colours": [
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "ee5514cd-7b03-5a54-9522-a72f06ad134e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238c728e-5e5d-4fb2-9e97-59b5b0e721c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/238c728e-5e5d-4fb2-9e97-59b5b0e721c8.jpg?1",
             "name": "Winding Constrictor",
             "text": "If one or more counters would be put on an artifact or creature you control, that many plus one of each of those kinds of counters are put on that permanent instead.\nIf you would get one or more counters, you get that many plus one of each of those kinds of counters instead.",
             "colours": [
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "1d0364df-9152-59b0-9c28-1e6402b5192a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafeaa8-5e77-4303-b30a-23fd137b7c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bafeaa8-5e77-4303-b30a-23fd137b7c35.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "f493f2eb-7e34-5113-b99d-010141e0a7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b8ca7-81cb-40d8-904e-88872bd3797e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b8ca7-81cb-40d8-904e-88872bd3797e.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "eae52b98-9aab-5bbc-b882-197a1e118cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78289e0-3675-4587-8a33-54640e58a1f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78289e0-3675-4587-8a33-54640e58a1f7.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -8625,7 +8625,7 @@
         },
         {
             "id": "7ac3bbc4-47f6-5813-92c3-5562a790279c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3fcf94-c206-46ac-9356-7561cc0cd711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3fcf94-c206-46ac-9356-7561cc0cd711.jpg?1",
             "name": "Brass Knuckles",
             "text": "When you cast this spell, copy it. (The copy becomes a token.)\nEquipped creature has double strike as long as two or more Equipment are attached to it.\nEquip {1}",
             "colours": [],
@@ -8657,7 +8657,7 @@
         },
         {
             "id": "573dfce1-8919-50f7-8ab4-b748bd805c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f5d866-4ee9-4054-8d48-82da0a2d1170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f5d866-4ee9-4054-8d48-82da0a2d1170.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof. (It can't be the target of spells or abilities your opponents control.)\nEquip {1}",
             "colours": [],
@@ -8691,7 +8691,7 @@
         },
         {
             "id": "04415470-32ba-5286-b0b7-fd7e64647b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5bd288-0488-4354-a201-717bdaa10d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5bd288-0488-4354-a201-717bdaa10d44.jpg?1",
             "name": "Contagion Clasp",
             "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "4ea16af8-76da-5973-8ea1-993156f8e19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6be33e-1a5b-482c-a444-3e8ab98d591d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6be33e-1a5b-482c-a444-3e8ab98d591d.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -8751,7 +8751,7 @@
         },
         {
             "id": "836b422f-2910-50b4-bdb5-ce2b7cab01fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66cbdcb-c42c-4f30-871f-f1bc11f475df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66cbdcb-c42c-4f30-871f-f1bc11f475df.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "03e4764c-ba40-5e7d-a47d-a74f667ff8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cda06f-b935-4a40-aae5-9fcf7966e68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cda06f-b935-4a40-aae5-9fcf7966e68c.jpg?1",
             "name": "Fireshrieker",
             "text": "Equipped creature has double strike.\nEquip {2}",
             "colours": [],
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "bb368b09-4e3a-5c18-a38c-fb106a632da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec824ef-fd09-4f7e-a350-ac80005c261f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec824ef-fd09-4f7e-a350-ac80005c261f.jpg?1",
             "name": "Lightning Greaves",
             "text": "Equipped creature has haste and shroud. (It can't be the target of spells or abilities.)\nEquip {0}",
             "colours": [],
@@ -8847,7 +8847,7 @@
         },
         {
             "id": "a106e261-ff76-5f80-b131-51093b6b2fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea75905-326f-48a9-9144-3ac147b9c2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ea75905-326f-48a9-9144-3ac147b9c2bf.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "You may have Masterwork of Ingenuity enter the battlefield as a copy of any Equipment on the battlefield.",
             "colours": [],
@@ -8881,7 +8881,7 @@
         },
         {
             "id": "7f23cbac-ae7c-5e57-b711-582b9a4757ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88baf29-a556-4e89-8471-9ba9bc8efe2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88baf29-a556-4e89-8471-9ba9bc8efe2c.jpg?1",
             "name": "Mind Stone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "8f2a6d23-bc98-5416-928f-e00b6d47abed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a6275-331e-4696-85ea-6f7a0a0f865e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109a6275-331e-4696-85ea-6f7a0a0f865e.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast artifact spells and colorless spells from the top of your library.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -8943,7 +8943,7 @@
         },
         {
             "id": "deff04bf-e86a-5d5d-9044-dd59530db3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d92b7dd-1f63-4f34-87ca-01a0eaa7b3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d92b7dd-1f63-4f34-87ca-01a0eaa7b3a1.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "32d9eb4a-a622-5a8f-ba5c-5ad2290f75af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160f5f0-8ab8-4ec1-a84c-cfe49cb43b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7160f5f0-8ab8-4ec1-a84c-cfe49cb43b8d.jpg?1",
             "name": "Skullclamp",
             "text": "Equipped creature gets +1/-1.\nWhenever equipped creature dies, draw two cards.\nEquip {1}",
             "colours": [],
@@ -9007,7 +9007,7 @@
         },
         {
             "id": "7bc6511d-3529-55d0-ac3e-de29767f49fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e675f7e2-5c9f-4912-8fdd-daaeda284a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e675f7e2-5c9f-4912-8fdd-daaeda284a3d.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "16d4381e-c306-51de-acf8-dcd48ddd4e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc91d8b8-ed18-45bf-a9e0-2f6afe6dd23c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc91d8b8-ed18-45bf-a9e0-2f6afe6dd23c.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "3a8245db-206a-5e5a-a47c-6d13e0751047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca078f45-b4eb-4b5b-87cb-80b6c0ba5f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca078f45-b4eb-4b5b-87cb-80b6c0ba5f31.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "0266e48a-0618-5713-ba14-22e12e1fb15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d405a1-f951-4043-97bf-887e4fa388ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d405a1-f951-4043-97bf-887e4fa388ad.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "Equipped creature has hexproof and haste. (It can't be the target of spells or abilities your opponents control.)\nEquip {1}",
             "colours": [],
@@ -9141,7 +9141,7 @@
         },
         {
             "id": "9ee90e8c-9cd2-57be-800a-69561432b601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec517e7-bc4d-4986-ba3c-89866a29991d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec517e7-bc4d-4986-ba3c-89866a29991d.jpg?1",
             "name": "Talisman of Conviction",
             "text": "{T}: Add {C}.\n{T}: Add {R} or {W}. Talisman of Conviction deals 1 damage to you.",
             "colours": [],
@@ -9174,7 +9174,7 @@
         },
         {
             "id": "66514c40-d49c-5708-bd18-255ad25b1d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d318b7-5c82-40a7-a63e-d8e72938624f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d318b7-5c82-40a7-a63e-d8e72938624f.jpg?1",
             "name": "Talisman of Creativity",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {R}. Talisman of Creativity deals 1 damage to you.",
             "colours": [],
@@ -9207,7 +9207,7 @@
         },
         {
             "id": "5e601cdf-3503-5b83-b27f-d47ec08ba29b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9544d0d1-f9bb-43a5-9c39-db187a6efe3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9544d0d1-f9bb-43a5-9c39-db187a6efe3b.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "{T}: Add {C}.\n{T}: Add {G} or {U}. Talisman of Curiosity deals 1 damage to you.",
             "colours": [],
@@ -9240,7 +9240,7 @@
         },
         {
             "id": "32019809-c6aa-5dc6-a036-377c7fde2f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f294565-2bbc-49c6-9777-42160c0afe3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f294565-2bbc-49c6-9777-42160c0afe3e.jpg?1",
             "name": "Talisman of Dominance",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Talisman of Dominance deals 1 damage to you.",
             "colours": [],
@@ -9273,7 +9273,7 @@
         },
         {
             "id": "7718e3e9-f68a-5543-b370-73e6a9a6d4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b55b6cb-820c-4782-9f63-e04fe46e02d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b55b6cb-820c-4782-9f63-e04fe46e02d2.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Talisman of Hierarchy deals 1 damage to you.",
             "colours": [],
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "0840cdfc-1686-55da-943a-6169c78e0ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113410ff-d25e-4f25-a6c2-236bcf4c8486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113410ff-d25e-4f25-a6c2-236bcf4c8486.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Talisman of Indulgence deals 1 damage to you.",
             "colours": [],
@@ -9339,7 +9339,7 @@
         },
         {
             "id": "052d810d-ddba-5aa0-90bc-99a58df23530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290b095-7f4f-452d-b54d-b4290d182c8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3290b095-7f4f-452d-b54d-b4290d182c8d.jpg?1",
             "name": "Talisman of Progress",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {U}. Talisman of Progress deals 1 damage to you.",
             "colours": [],
@@ -9372,7 +9372,7 @@
         },
         {
             "id": "ace8bd8f-21fd-5593-bb15-321aa2d10d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf1082-624c-4b9d-a57f-672ccbef4987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ebf1082-624c-4b9d-a57f-672ccbef4987.jpg?1",
             "name": "Talisman of Resilience",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Talisman of Resilience deals 1 damage to you.",
             "colours": [],
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "5946dc25-5e73-5f9c-9932-1fae30dbfc37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68c8703-3029-443b-95f5-5310e8b48a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68c8703-3029-443b-95f5-5310e8b48a2b.jpg?1",
             "name": "Thought Vessel",
             "text": "You have no maximum hand size.\n{T}: Add {C}.",
             "colours": [],
@@ -9435,7 +9435,7 @@
         },
         {
             "id": "9acaa63d-f7b1-5fc9-b5ec-252a703cb3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7503-d05b-4eac-bb6f-ef3bf696437d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084b7503-d05b-4eac-bb6f-ef3bf696437d.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "{2}, {T}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9465,7 +9465,7 @@
         },
         {
             "id": "96a097bf-d036-5f5b-9626-75b113a863f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a90148-5ed9-42db-a64f-4735676d82e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a90148-5ed9-42db-a64f-4735676d82e3.jpg?1",
             "name": "Ash Barrens",
             "text": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
             "colours": [],
@@ -9495,7 +9495,7 @@
         },
         {
             "id": "18ff8254-369f-5d0e-af17-b1e0b3f3d97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3ebfce-47cd-4ebe-bfeb-2cb22a1bd9ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3ebfce-47cd-4ebe-bfeb-2cb22a1bd9ec.jpg?1",
             "name": "Buried Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Buried Ruin: Return target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -9525,7 +9525,7 @@
         },
         {
             "id": "63a8016f-af83-5059-8ed8-fa2890a77a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3076b36b-292a-4b14-8284-28e623c20e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3076b36b-292a-4b14-8284-28e623c20e30.jpg?1",
             "name": "Canopy Vista",
             "text": "({T}: Add {G} or {W}.)\nCanopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "bda2a641-4fd0-5f58-a5ea-1de4124c521f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c66f9-64af-48aa-b24b-3ef76596378a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e8c66f9-64af-48aa-b24b-3ef76596378a.jpg?1",
             "name": "Canyon Slough",
             "text": "({T}: Add {B} or {R}.)\nCanyon Slough enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "96bbec60-278b-5d64-bdb1-f1f48b76132b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4959e5-bdc8-4f60-a1d2-77dc17a493a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4959e5-bdc8-4f60-a1d2-77dc17a493a0.jpg?1",
             "name": "Cinder Glade",
             "text": "({T}: Add {R} or {G}.)\nCinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "96bca4ca-a3d4-5100-8412-13b61df8da2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6454d4c-5820-4cb8-b625-3d9a09778513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6454d4c-5820-4cb8-b625-3d9a09778513.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "620533da-9b3d-5344-a2f3-dc83ac8095f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb8cb-633c-468f-8ef5-54ff91ddfb22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952cb8cb-633c-468f-8ef5-54ff91ddfb22.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -9706,7 +9706,7 @@
         },
         {
             "id": "1559d073-1a23-532b-8a51-e9bda20de922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3d4b7-972f-447f-a512-f40ceeba5d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3d4b7-972f-447f-a512-f40ceeba5d9c.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -9741,7 +9741,7 @@
         },
         {
             "id": "3a86e38b-3f78-5f79-9b39-2523d422f5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed078f-74b4-4ae8-9b2f-6b7b629fff1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09ed078f-74b4-4ae8-9b2f-6b7b629fff1f.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9776,7 +9776,7 @@
         },
         {
             "id": "4a7fe09a-a28f-5b73-8781-03f154efe348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e033971a-3460-43a1-abf6-6dab433a9c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e033971a-3460-43a1-abf6-6dab433a9c3f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "adeda323-57d7-53d1-91e8-0b9b7435bcb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912837ca-054a-49a8-a5c5-5e65631b0575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912837ca-054a-49a8-a5c5-5e65631b0575.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "5d80394a-e7b5-5573-9419-3a8e4e613d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f07a84-2788-4f5b-bd76-701bab10f01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f07a84-2788-4f5b-bd76-701bab10f01b.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "70aa6ce1-145e-563b-9fa2-d5981d65962b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae00e88-0dfc-477a-a982-0187efe753f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ae00e88-0dfc-477a-a982-0187efe753f2.jpg?1",
             "name": "Fetid Pools",
             "text": "({T}: Add {U} or {B}.)\nFetid Pools enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "91b74b41-6264-5d0d-81b3-ee4c1eaf52ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f303a30-e3d9-4b31-aa67-608a627fc6ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f303a30-e3d9-4b31-aa67-608a627fc6ff.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -9946,7 +9946,7 @@
         },
         {
             "id": "5714a283-c512-52c5-b529-9c4599d8941c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fdcf1-09b4-4eba-a5f1-242d68ba1aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758fdcf1-09b4-4eba-a5f1-242d68ba1aea.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9981,7 +9981,7 @@
         },
         {
             "id": "23627813-bab5-5a2b-aa04-f1bdd62635e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd325f-2762-4ef0-a0f1-b56bb63da0d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1cd325f-2762-4ef0-a0f1-b56bb63da0d1.jpg?1",
             "name": "Irrigated Farmland",
             "text": "({T}: Add {W} or {U}.)\nIrrigated Farmland enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "ff11c164-1643-51ae-80f1-6d6f6e733419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377487dd-d72a-4169-bfe1-29e36c3e3d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377487dd-d72a-4169-bfe1-29e36c3e3d1f.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10054,7 +10054,7 @@
         },
         {
             "id": "3afaa3fd-0f52-5e06-8599-7870f392c407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374c9b90-9179-4866-b479-ffd303767f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374c9b90-9179-4866-b479-ffd303767f97.jpg?1",
             "name": "Jungle Shrine",
             "text": "Jungle Shrine enters the battlefield tapped.\n{T}: Add {R}, {G}, or {W}.",
             "colours": [],
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "77303229-fabd-5e4b-a095-67fcf2e305b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3cc476-3d5b-42d3-afe2-54c639770181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3cc476-3d5b-42d3-afe2-54c639770181.jpg?1",
             "name": "Memorial to Glory",
             "text": "Memorial to Glory enters the battlefield tapped.\n{T}: Add {W}.\n{3}{W}, {T}, Sacrifice Memorial to Glory: Create two 1/1 white Soldier creature tokens.",
             "colours": [],
@@ -10120,7 +10120,7 @@
         },
         {
             "id": "608e52e8-4a74-592e-832e-eae6111181ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b7472f-48f5-4ab5-8896-3eee29d13d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b7472f-48f5-4ab5-8896-3eee29d13d59.jpg?1",
             "name": "Mortuary Mire",
             "text": "Mortuary Mire enters the battlefield tapped.\nWhen Mortuary Mire enters the battlefield, you may put target creature card from your graveyard on top of your library.\n{T}: Add {B}.",
             "colours": [],
@@ -10152,7 +10152,7 @@
         },
         {
             "id": "9183284c-e428-5622-bb67-81a33c2a357a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b31a08a-8fb5-48ef-b923-a1c6378a95f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b31a08a-8fb5-48ef-b923-a1c6378a95f4.jpg?1",
             "name": "Mossfire Valley",
             "text": "{1}, {T}: Add {R}{G}.",
             "colours": [],
@@ -10187,7 +10187,7 @@
         },
         {
             "id": "442b5c03-5495-594c-81e4-f9098df68afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe6542-9f4b-4afa-8568-272916125b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afe6542-9f4b-4afa-8568-272916125b4a.jpg?1",
             "name": "Myriad Landscape",
             "text": "Myriad Landscape enters the battlefield tapped.\n{T}: Add {C}.\n{2}, {T}, Sacrifice Myriad Landscape: Search your library for up to two basic land cards that share a land type, put them onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10217,7 +10217,7 @@
         },
         {
             "id": "8ae05575-4543-5827-a363-922fa33016a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91902a-a524-4207-8864-4d7085a0e09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91902a-a524-4207-8864-4d7085a0e09f.jpg?1",
             "name": "Mystic Monastery",
             "text": "Mystic Monastery enters the battlefield tapped.\n{T}: Add {U}, {R}, or {W}.",
             "colours": [],
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "9919da04-44e0-5ee2-86f9-2a12be18371a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1cf348-7434-4b43-907a-87a86eac735f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1cf348-7434-4b43-907a-87a86eac735f.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -10283,7 +10283,7 @@
         },
         {
             "id": "c5fca2ae-95ca-5ca3-b233-2048b7bd3efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17aa04-dbd8-4d49-898c-bf0a64cdb827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad17aa04-dbd8-4d49-898c-bf0a64cdb827.jpg?1",
             "name": "Nomad Outpost",
             "text": "Nomad Outpost enters the battlefield tapped.\n{T}: Add {R}, {W}, or {B}.",
             "colours": [],
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "6a074ffc-32cf-5e54-acdf-2b80e03573a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba66391-8ff8-423a-893f-72cc022f4714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba66391-8ff8-423a-893f-72cc022f4714.jpg?1",
             "name": "Opulent Palace",
             "text": "Opulent Palace enters the battlefield tapped.\n{T}: Add {B}, {G}, or {U}.",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "3707cc3e-7890-5987-b576-067561ec616a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6415d9-14fb-4a58-aa86-bf2063037684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff6415d9-14fb-4a58-aa86-bf2063037684.jpg?1",
             "name": "Path of Ancestry",
             "text": "Path of Ancestry enters the battlefield tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "acf13b01-8fdc-5723-bc0a-42d5cbfb46d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69dd983-757e-4de8-9824-a5123b906c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d69dd983-757e-4de8-9824-a5123b906c62.jpg?1",
             "name": "Prairie Stream",
             "text": "({T}: Add {W} or {U}.)\nPrairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -10419,7 +10419,7 @@
         },
         {
             "id": "8852f6a2-ec0f-5fbd-9e78-245f2a60f54c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697d872f-111f-4810-baf2-d4c6f2f48dd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697d872f-111f-4810-baf2-d4c6f2f48dd5.jpg?1",
             "name": "Razortide Bridge",
             "text": "Razortide Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -10453,7 +10453,7 @@
         },
         {
             "id": "07248361-25e2-5a56-9a4a-947fda603fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deca57c8-ac90-4fce-83b5-74adf45622e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deca57c8-ac90-4fce-83b5-74adf45622e5.jpg?1",
             "name": "Roadside Reliquary",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Roadside Reliquary: Draw a card if you control an artifact. Draw a card if you control an enchantment.",
             "colours": [],
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "405f56a8-ab54-5133-9581-1ae1e030ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0d5ed6-baa9-42b7-87e2-372e4513b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0d5ed6-baa9-42b7-87e2-372e4513b771.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -10513,7 +10513,7 @@
         },
         {
             "id": "c714b86c-82e6-5dc9-a18a-af5fd72c8026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8ba5e7-5867-47dc-88f5-412b490306a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b8ba5e7-5867-47dc-88f5-412b490306a6.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -10548,7 +10548,7 @@
         },
         {
             "id": "5f104bfd-63a9-594d-8af4-0f5cd7799937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dd5b22-c7f8-4c00-a27b-437da0136177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45dd5b22-c7f8-4c00-a27b-437da0136177.jpg?1",
             "name": "Rustvale Bridge",
             "text": "Rustvale Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10582,7 +10582,7 @@
         },
         {
             "id": "ad172cff-9de1-598b-a463-05b25d563912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc924137-6f0d-41bd-bb94-b7a6e1a13be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc924137-6f0d-41bd-bb94-b7a6e1a13be1.jpg?1",
             "name": "Scattered Groves",
             "text": "({T}: Add {G} or {W}.)\nScattered Groves enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10620,7 +10620,7 @@
         },
         {
             "id": "4c722df7-2695-5267-beef-352d614636a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8fa97c-f796-4fb7-bd4d-f55b5f66c36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8fa97c-f796-4fb7-bd4d-f55b5f66c36e.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all graveyards.",
             "colours": [],
@@ -10654,7 +10654,7 @@
         },
         {
             "id": "7fb6e6e5-7891-5f97-b0b7-8449124b4a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02d5d2-2f71-4b93-a0c5-5964ec08524f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff02d5d2-2f71-4b93-a0c5-5964ec08524f.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "{1}, {T}: Add {B}{R}.",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "e89c8a0f-b25f-5814-a358-7c6469a670b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923d2489-54c6-47df-8bce-285f42c33c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923d2489-54c6-47df-8bce-285f42c33c20.jpg?1",
             "name": "Sheltered Thicket",
             "text": "({T}: Add {R} or {G}.)\nSheltered Thicket enters the battlefield tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10727,7 +10727,7 @@
         },
         {
             "id": "62d0b809-819c-5d10-8bbc-3792a244394c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820485ab-0a31-4278-9316-ec5b909f4d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820485ab-0a31-4278-9316-ec5b909f4d11.jpg?1",
             "name": "Silverbluff Bridge",
             "text": "Silverbluff Bridge enters the battlefield tapped.\nIndestructible\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10761,7 +10761,7 @@
         },
         {
             "id": "ddd40ba6-5dbe-50c3-88ce-799eab6260d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b8f769-57c8-45e7-b451-7b4fe7e80bf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b8f769-57c8-45e7-b451-7b4fe7e80bf8.jpg?1",
             "name": "Skycloud Expanse",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -10796,7 +10796,7 @@
         },
         {
             "id": "8575d4d5-b61a-5482-b193-3eb132ba0d31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567e219b-2961-4f02-9be0-7776210b62b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567e219b-2961-4f02-9be0-7776210b62b0.jpg?1",
             "name": "Smoldering Marsh",
             "text": "({T}: Add {B} or {R}.)\nSmoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -10834,7 +10834,7 @@
         },
         {
             "id": "409cfbfa-45af-584c-8de5-82313e9a179c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdda2ce8-23d1-4814-8e81-d6cf40f75a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdda2ce8-23d1-4814-8e81-d6cf40f75a13.jpg?1",
             "name": "Spire of Industry",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Activate only if you control an artifact.",
             "colours": [],
@@ -10866,7 +10866,7 @@
         },
         {
             "id": "2d25c939-ad14-575b-9684-7613d8434859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6821409-3793-4a7c-962b-7d501fa50fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6821409-3793-4a7c-962b-7d501fa50fe5.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10901,7 +10901,7 @@
         },
         {
             "id": "8fdd9e24-b056-5206-9863-d850b7e886ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61db976-f33e-4904-829c-b9ec11a7eeb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c61db976-f33e-4904-829c-b9ec11a7eeb0.jpg?1",
             "name": "Sungrass Prairie",
             "text": "{1}, {T}: Add {G}{W}.",
             "colours": [],
@@ -10936,7 +10936,7 @@
         },
         {
             "id": "93c0e170-7c43-5f81-9063-7e4defc33166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4d725-cb54-4617-bbfd-45e2f2d3dec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4d725-cb54-4617-bbfd-45e2f2d3dec8.jpg?1",
             "name": "Sunken Hollow",
             "text": "({T}: Add {U} or {B}.)\nSunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -10974,7 +10974,7 @@
         },
         {
             "id": "1a2bac4e-d7b6-5de7-9357-0f2c948c345f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bd068-32f4-4055-930d-afd2015fb41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/011bd068-32f4-4055-930d-afd2015fb41a.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "f13c0409-3838-5306-9f52-f1be2cdb697d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46db1a-7066-47bd-a033-cc55f9b4004e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c46db1a-7066-47bd-a033-cc55f9b4004e.jpg?1",
             "name": "Tainted Field",
             "text": "{T}: Add {C}.\n{T}: Add {W} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "4eb0a1e0-0e30-588b-8cb7-b84bb5a6b649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc20d1-c3be-4630-b860-49b9fdb6f6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cc20d1-c3be-4630-b860-49b9fdb6f6c4.jpg?1",
             "name": "Tainted Isle",
             "text": "{T}: Add {C}.\n{T}: Add {U} or {B}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11075,7 +11075,7 @@
         },
         {
             "id": "cea3fabc-6718-5fd0-8930-1bbbff0689f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1374839-bdef-4e55-a7bc-906340439605.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1374839-bdef-4e55-a7bc-906340439605.jpg?1",
             "name": "Tainted Peak",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {R}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11108,7 +11108,7 @@
         },
         {
             "id": "a7331689-74cc-50a5-b072-8014887b94d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aed044e-d9c8-429f-b618-62446fa688cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aed044e-d9c8-429f-b618-62446fa688cc.jpg?1",
             "name": "Tainted Wood",
             "text": "{T}: Add {C}.\n{T}: Add {B} or {G}. Activate only if you control a Swamp.",
             "colours": [],
@@ -11141,7 +11141,7 @@
         },
         {
             "id": "d42e8f54-d1b0-5dcc-b9be-57ebc8de011f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83e083-bdaf-4f11-9be2-7d148428f479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83e083-bdaf-4f11-9be2-7d148428f479.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -11176,7 +11176,7 @@
         },
         {
             "id": "ad72cdec-d999-59cc-b087-e834b4257a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5460711e-dd15-476c-922f-3f1cd582d3f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5460711e-dd15-476c-922f-3f1cd582d3f6.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -11211,7 +11211,7 @@
         },
         {
             "id": "2859ccf2-a659-5f6c-a52e-3882619ad43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658fec13-a62d-4701-ad8b-9cb08d960253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658fec13-a62d-4701-ad8b-9cb08d960253.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -11246,7 +11246,7 @@
         },
         {
             "id": "c5f03cac-a280-5069-bc94-16045ba4d56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d6842-0ba6-494d-b10c-9ac47f78c757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311d6842-0ba6-494d-b10c-9ac47f78c757.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -11281,7 +11281,7 @@
         },
         {
             "id": "d3d131ce-8df7-5daa-a5f1-22b38c217935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a280c4-9cc6-4b48-9124-0ddb7fd05626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a280c4-9cc6-4b48-9124-0ddb7fd05626.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11316,7 +11316,7 @@
         },
         {
             "id": "05572ac0-79d6-54c5-9389-f907e5396abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ccf18ae-ca47-46b0-85c2-235e75d5b42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ccf18ae-ca47-46b0-85c2-235e75d5b42b.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -11351,7 +11351,7 @@
         },
         {
             "id": "c6ec319d-3d5c-5c5f-8237-4dd3b2502dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ba1f6-a35b-4b24-9d33-6a9658441ec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ba1f6-a35b-4b24-9d33-6a9658441ec7.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -11386,7 +11386,7 @@
         },
         {
             "id": "7f6055a4-a152-503c-a9fa-d6ae79f92328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694d6658-4126-4aea-a2ab-0cffa168e101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694d6658-4126-4aea-a2ab-0cffa168e101.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -11421,7 +11421,7 @@
         },
         {
             "id": "6022a5ac-65ec-57f9-bfed-3817f991822f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e014eb8-e325-40f7-9ac8-d53508c88925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e014eb8-e325-40f7-9ac8-d53508c88925.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -11456,7 +11456,7 @@
         },
         {
             "id": "5b8aabf9-a1ad-5f3a-a03d-3c5797c0f08e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22223010-1864-483d-b0af-50ca40bc3d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22223010-1864-483d-b0af-50ca40bc3d0d.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {C}{C}. Activate only if you control five or more lands.",
             "colours": [],
@@ -11486,7 +11486,7 @@
         },
         {
             "id": "74a91da7-f70e-5a8c-ba84-9c22597a3fbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76721cda-494e-4c77-8b0f-43238a35c040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76721cda-494e-4c77-8b0f-43238a35c040.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11521,7 +11521,7 @@
         },
         {
             "id": "fb84280e-2322-5101-bd37-0af0a7627a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548805de-3e2e-4f1f-aafc-d89fddf8288a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548805de-3e2e-4f1f-aafc-d89fddf8288a.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11551,7 +11551,7 @@
         },
         {
             "id": "59442308-9107-58a2-afc6-659e41624992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8a9a88-d4b5-4c2a-86fa-22475ce919ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8a9a88-d4b5-4c2a-86fa-22475ce919ca.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -11584,7 +11584,7 @@
         },
         {
             "id": "7c418531-58b4-5354-9518-e216bda2e1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b7b9f1-8428-4c04-a918-7c0e1d3906ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b7b9f1-8428-4c04-a918-7c0e1d3906ed.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway 4 (When this land enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWindbrisk Heights enters the battlefield tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -11618,7 +11618,7 @@
         },
         {
             "id": "b73984c8-eaea-56c8-b3b1-0a17a6a429d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98edea5-a974-4475-b518-e79a91fe4371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98edea5-a974-4475-b518-e79a91fe4371.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11653,7 +11653,7 @@
         },
         {
             "id": "02e7cd22-5653-570e-84ff-adfc76b7b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f33598-1344-4365-9067-17a7379de894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f33598-1344-4365-9067-17a7379de894.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11691,7 +11691,7 @@
         },
         {
             "id": "2a1490f1-06d6-586f-9ae1-e7d7e92df415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6be912-4d77-45d2-b653-7fbbee6a881a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6be912-4d77-45d2-b653-7fbbee6a881a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "353c1c91-0d66-5d8c-9893-b2acff066b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0a88d-7049-4206-8085-4a68ab0bfd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b0a88d-7049-4206-8085-4a68ab0bfd81.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11767,7 +11767,7 @@
         },
         {
             "id": "9961b60c-b41d-536a-8d8a-1cb45fa6f2cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040ed422-663a-4b6c-bdcd-09092f1c9004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/040ed422-663a-4b6c-bdcd-09092f1c9004.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11805,7 +11805,7 @@
         },
         {
             "id": "f1198b81-4fb5-57d4-9d98-e864853a8446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237204ad-ab8a-496f-a093-48d00417350b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/237204ad-ab8a-496f-a093-48d00417350b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11843,7 +11843,7 @@
         },
         {
             "id": "f6ccbaf0-aab4-552a-8186-e239bb5fac6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09af769d-a051-40d4-b203-7ec818c367ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09af769d-a051-40d4-b203-7ec818c367ca.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11881,7 +11881,7 @@
         },
         {
             "id": "b06486ee-21b3-559e-ba56-6e5201f55ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f5bbab-7bf0-48d4-8138-d64f84f4d769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f5bbab-7bf0-48d4-8138-d64f84f4d769.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11919,7 +11919,7 @@
         },
         {
             "id": "674e682b-a3a0-510c-a0b2-b8210df24a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5691d3-751a-41dd-b2a3-c766c8973bfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5691d3-751a-41dd-b2a3-c766c8973bfe.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11957,7 +11957,7 @@
         },
         {
             "id": "433a3ec6-229b-530d-a183-b0caa7cb1ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13351c-ca20-410c-8959-bbaa59816002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be13351c-ca20-410c-8959-bbaa59816002.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11995,7 +11995,7 @@
         },
         {
             "id": "1cd560bc-0ce6-5d84-8f06-55007f734f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1e5ef3-790d-4f45-a264-157448bab2e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a1e5ef3-790d-4f45-a264-157448bab2e8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12033,7 +12033,7 @@
         },
         {
             "id": "4757d023-5938-5453-95b3-30f172f4192f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9eebec-e93d-4b23-b28a-534d00ae0765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9eebec-e93d-4b23-b28a-534d00ae0765.jpg?1",
             "name": "Idolized",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks alone, it gets +X/+X until end of turn, where X is the number of nonland permanents you control.\"",
             "colours": [
@@ -12071,7 +12071,7 @@
         },
         {
             "id": "047c28a2-9b28-5163-8535-84329debada7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f361e79-91eb-42d6-a967-cc01c7528595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f361e79-91eb-42d6-a967-cc01c7528595.jpg?1",
             "name": "Securitron Squadron",
             "text": "Squad {3}\nVigilance\nWhenever a creature token enters the battlefield under your control, put a +1/+1 counter on it.",
             "colours": [
@@ -12110,7 +12110,7 @@
         },
         {
             "id": "9b28cbea-f8c9-57f8-807a-597672b1142a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed00d6f-dfcd-4a60-bb8f-8e95944548fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed00d6f-dfcd-4a60-bb8f-8e95944548fa.jpg?1",
             "name": "Radstorm",
             "text": "Storm\nProliferate.",
             "colours": [
@@ -12146,7 +12146,7 @@
         },
         {
             "id": "fd4bdc2f-2d8b-5589-a7e1-1fdc309c3002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ef27-1467-489d-b451-5d0c18b871c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3ef27-1467-489d-b451-5d0c18b871c6.jpg?1",
             "name": "Synth Infiltrator",
             "text": "Improvise\nYou may have Synth Infiltrator enter the battlefield as a copy of any creature on the battlefield, except it's a Synth artifact creature in addition to its other types.",
             "colours": [
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "3d192edd-8e49-550d-be86-a7b3dfc0dbb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1039a7de-bd49-4412-8d51-01041a463ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1039a7de-bd49-4412-8d51-01041a463ab4.jpg?1",
             "name": "Nuclear Fallout",
             "text": "Each creature gets twice -X/-X until end of turn. Each player gets X rad counters.",
             "colours": [
@@ -12221,7 +12221,7 @@
         },
         {
             "id": "4563732c-a538-5b62-9d30-ed1ad578dcfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd2d88-3354-4e8d-8db9-86cfd46b8444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24dd2d88-3354-4e8d-8db9-86cfd46b8444.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "Flying, menace\nWhenever Screeching Scorchbeast attacks, each player gets two rad counters.\nWhenever one or more nonland cards are milled, you may create that many 2/2 black Zombie Mutant creature tokens. Do this only once each turn.",
             "colours": [
@@ -12260,7 +12260,7 @@
         },
         {
             "id": "b38e5af3-6f41-59e6-b1c5-b66f280a4bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35303f4b-4114-443e-ab9c-74813becdf63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35303f4b-4114-443e-ab9c-74813becdf63.jpg?1",
             "name": "V.A.T.S.",
             "text": "Split second\nChoose any number of target creatures with equal toughness. Destroy the chosen creatures.",
             "colours": [
@@ -12296,7 +12296,7 @@
         },
         {
             "id": "f16d72c7-bf4d-5f28-bdf7-3bfc2daa4985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82d22c8-e3a0-4aa3-b721-e19f80db592f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82d22c8-e3a0-4aa3-b721-e19f80db592f.jpg?1",
             "name": "Mysterious Stranger",
             "text": "Flash\nWhen Mysterious Stranger enters the battlefield, for each graveyard with an instant or sorcery card in it, exile target instant or sorcery card from that graveyard. If two or more cards are exiled this way, choose one of them at random and copy it. You may cast the copy without paying its mana cost.",
             "colours": [
@@ -12335,7 +12335,7 @@
         },
         {
             "id": "fa868e33-9bc8-572f-8c80-1f60b28b16d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1033bdf3-eca0-4767-a4e9-a9c812a32145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1033bdf3-eca0-4767-a4e9-a9c812a32145.jpg?1",
             "name": "Watchful Radstag",
             "text": "Evolve\nWhenever Watchful Radstag evolves, create a token that's a copy of it.",
             "colours": [
@@ -12374,7 +12374,7 @@
         },
         {
             "id": "aa3fcc52-3433-5bff-91ad-6848748a4b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2dc5b0-ac26-4829-9716-f213eda5df30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e2dc5b0-ac26-4829-9716-f213eda5df30.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "Menace, trample\nWhen Alpha Deathclaw enters the battlefield or becomes monstrous, destroy target permanent.\n{5}{B}{G}: Monstrosity 4.",
             "colours": [
@@ -12415,7 +12415,7 @@
         },
         {
             "id": "5647d913-6e76-57d2-9c04-31b421801d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb785d-2294-481b-a82d-e7da357767ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69bb785d-2294-481b-a82d-e7da357767ed.jpg?1",
             "name": "Armory Paladin",
             "text": "Trample\nWhenever you cast an Aura or Equipment spell, exile the top card of your library. You may play that card until the end of your next turn.",
             "colours": [
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "cbecfed8-a419-54d4-ace7-beecc0d37398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb065c-6edd-4ef4-a5ee-cd65e5c65573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2ddb065c-6edd-4ef4-a5ee-cd65e5c65573.jpg?1",
             "name": "Atomize",
             "text": "Destroy target nonland permanent. Proliferate.",
             "colours": [
@@ -12494,7 +12494,7 @@
         },
         {
             "id": "b98b1781-8806-5c13-a60b-12ae5c72fb3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db77f53a-3960-4015-a809-b387a906be35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db77f53a-3960-4015-a809-b387a906be35.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "Whenever you attack, you may sacrifice another creature. When you do, choose two \u2014\n\u2022 Create two 1/1 red and white Soldier creature tokens with haste that are tapped and attacking.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Caesar, Legion's Emperor deals damage equal to the number of creature tokens you control to target opponent.",
             "colours": [
@@ -12540,7 +12540,7 @@
         },
         {
             "id": "c42515bc-42e8-573c-a751-869ee3e69750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda442d-cee3-4c92-b84b-bc6851d2c046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecda442d-cee3-4c92-b84b-bc6851d2c046.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "When Dogmeat enters the battlefield, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\nWhenever a creature you control that's enchanted or equipped attacks, create a Junk token.",
             "colours": [
@@ -12585,7 +12585,7 @@
         },
         {
             "id": "8e18ea23-64ff-5858-9729-8aada6e08ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e356527-66a6-4d71-bc59-0c3bdde3d14c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e356527-66a6-4d71-bc59-0c3bdde3d14c.jpg?1",
             "name": "Dr. Madison Li",
             "text": "Whenever you cast an artifact spell, you get {E}.\n{T}, Pay {E}: Target creature gets +1/+0 and gains trample and haste until end of turn.\n{T}, Pay {E}{E}{E}: Draw a card.\n{T}, Pay {E}{E}{E}{E}{E}: Return target artifact card from your graveyard to the battlefield tapped.",
             "colours": [
@@ -12631,7 +12631,7 @@
         },
         {
             "id": "96600cfa-2dce-5adb-b9c4-2f362c7b5cc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db40c0c-773a-4b8f-9ed7-bfe24317c5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4db40c0c-773a-4b8f-9ed7-bfe24317c5fe.jpg?1",
             "name": "Inventory Management",
             "text": "Split second\nFor each Aura and Equipment you control, you may attach it to a creature you control.",
             "colours": [
@@ -12669,7 +12669,7 @@
         },
         {
             "id": "da614a4f-12c9-5130-a2b1-79ac4a68abd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44f6097-a513-44a5-aaa4-92ac2fa800c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44f6097-a513-44a5-aaa4-92ac2fa800c0.jpg?1",
             "name": "The Wise Mothman",
             "text": "Flying\nWhenever The Wise Mothman enters the battlefield or attacks, each player gets a rad counter.\nWhenever one or more nonland cards are milled, put a +1/+1 counter on each of up to X target creatures, where X is the number of nonland cards milled this way.",
             "colours": [
@@ -12715,7 +12715,7 @@
         },
         {
             "id": "5f3a079c-4a97-52a1-bd9b-7d7b16cfd574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c19303a-89eb-4d05-bc0a-13a7e283d408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c19303a-89eb-4d05-bc0a-13a7e283d408.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -12752,7 +12752,7 @@
         },
         {
             "id": "1b58d897-5f1c-5c8c-bb89-8d188ee3cccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7774935-41f4-438a-a1a8-790f9b85efc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7774935-41f4-438a-a1a8-790f9b85efc0.jpg?1",
             "name": "Lord of the Undead",
             "text": "Other Zombie creatures get +1/+1.\n{1}{B}, {T}: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -12788,7 +12788,7 @@
         },
         {
             "id": "8b1dce57-e096-5ea8-ada7-0ce0707ce84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942178d-6e44-4801-8692-8a4007b4d060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942178d-6e44-4801-8692-8a4007b4d060.jpg?1",
             "name": "Grave Titan",
             "text": "Deathtouch\nWhenever West Tek Tyrant enters the battlefield or attacks, create two 2/2 black Zombie creature tokens.",
             "colours": [
@@ -12824,7 +12824,7 @@
         },
         {
             "id": "9d9688bc-1774-59bf-a09f-118203b05734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1b41d-f0bf-403c-a12d-1a1f5fc6bfb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d1b41d-f0bf-403c-a12d-1a1f5fc6bfb9.jpg?1",
             "name": "Vigor",
             "text": "Trample\nIf damage would be dealt to another creature you control, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way.\nWhen Fog Crawler is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -12861,7 +12861,7 @@
         },
         {
             "id": "66b5e0cd-87dd-5403-a865-2a47c8c548b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af1ee9-525f-4db8-a07b-8a097a321afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af1ee9-525f-4db8-a07b-8a097a321afb.jpg?1",
             "name": "Ayula, Queen Among Bears",
             "text": "Whenever another Bear enters the battlefield under your control, choose one \u2014\n\u2022 Put two +1/+1 counters on target Bear.\n\u2022 Target Bear you control fights target creature you don't control.",
             "colours": [
@@ -12899,7 +12899,7 @@
         },
         {
             "id": "7517728a-d03a-5aef-ab36-3e4c6d43142e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d514db4-cf57-4442-a7c9-7373a2a42c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d514db4-cf57-4442-a7c9-7373a2a42c0d.jpg?1",
             "name": "Tarmogoyf",
             "text": "Scrounging Deathclaw's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -12935,7 +12935,7 @@
         },
         {
             "id": "b473055a-bbc2-56bc-8000-a6eec3d2bbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64e9259-3d47-4bfd-b781-504eaf7adc66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64e9259-3d47-4bfd-b781-504eaf7adc66.jpg?1",
             "name": "Hornet Queen",
             "text": "Flying\nDeathtouch\nWhen Specimen 73 enters the battlefield, create four 1/1 green Insect creature tokens with flying and deathtouch.",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "758eeebe-4376-5a65-9e3c-4c188ee722d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89a613-2a48-4953-8e45-9afaebdf84bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c89a613-2a48-4953-8e45-9afaebdf84bc.jpg?1",
             "name": "Gemrazer",
             "text": "Mutate {1}{G}{G}\nReach, trample\nWhenever this creature mutates, destroy target artifact or enchantment an opponent controls.",
             "colours": [
@@ -13007,7 +13007,7 @@
         },
         {
             "id": "b717cefd-3ff8-5f60-a490-4bac5c44f3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e66e6b-2501-4e87-bbc0-c823d39121f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e66e6b-2501-4e87-bbc0-c823d39121f8.jpg?1",
             "name": "Walking Ballista",
             "text": "Assaultron Invader enters the battlefield with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on Assaultron Invader.\nRemove a +1/+1 counter from Assaultron Invader: It deals 1 damage to any target.",
             "colours": [],
@@ -13040,7 +13040,7 @@
         },
         {
             "id": "bf71c349-d0d0-55d3-8883-196a1f3d948e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd945-e362-4aea-ba29-326b1b6a2004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634dd945-e362-4aea-ba29-326b1b6a2004.jpg?1",
             "name": "Farewell",
             "text": "Choose one or more \u2014\n\u2022 Exile all artifacts.\n\u2022 Exile all creatures.\n\u2022 Exile all enchantments.\n\u2022 Exile all graveyards.",
             "colours": [
@@ -13074,7 +13074,7 @@
         },
         {
             "id": "b0813ca1-798b-54d6-a16a-3e8ef30e20b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341292df-b9bd-4796-a12d-10fb67c91040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341292df-b9bd-4796-a12d-10fb67c91040.jpg?1",
             "name": "Ravages of War",
             "text": "Destroy all lands.",
             "colours": [
@@ -13108,7 +13108,7 @@
         },
         {
             "id": "255f0f9a-ad84-58a4-b2cb-a471342c3580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3ed08-7a10-4f49-b5d5-d3ae75b0caa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d3ed08-7a10-4f49-b5d5-d3ae75b0caa9.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R}",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "5915d66c-3274-5874-bd20-a2e2e3c25263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a30b502-569b-49fc-9a9e-96fdeaab6ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a30b502-569b-49fc-9a9e-96fdeaab6ad6.jpg?1",
             "name": "Arcane Signet",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13174,7 +13174,7 @@
         },
         {
             "id": "6f718953-05e8-55e1-bef4-af8118e40026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f314ca8-19fa-4cc9-9d23-c280de3b79bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f314ca8-19fa-4cc9-9d23-c280de3b79bc.jpg?1",
             "name": "Crucible of Worlds",
             "text": "You may play lands from your graveyard.",
             "colours": [],
@@ -13204,7 +13204,7 @@
         },
         {
             "id": "3fedcb5d-34d7-59e6-bc5b-bb3217eedd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794663d5-b397-4775-9921-30184bc36aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794663d5-b397-4775-9921-30184bc36aa9.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "{1}, {T}: Create a Food token.\nWhenever you sacrifice a Food, create a tapped Treasure token.",
             "colours": [],
@@ -13236,7 +13236,7 @@
         },
         {
             "id": "ce3fd22d-f477-568d-907a-49d470f9f331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af88e4e8-b694-4ec0-8885-701ea30bf84c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af88e4e8-b694-4ec0-8885-701ea30bf84c.jpg?1",
             "name": "Sol Ring",
             "text": "{T}: Add {C}{C}.",
             "colours": [],
@@ -13268,7 +13268,7 @@
         },
         {
             "id": "ee62cb16-20a1-578a-83de-235e169d24ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f460bca4-dfe0-4645-8feb-0b715ed3bd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f460bca4-dfe0-4645-8feb-0b715ed3bd0e.jpg?1",
             "name": "Command Tower",
             "text": "{T}: Add one mana of any color in your commander's color identity.",
             "colours": [],
@@ -13300,7 +13300,7 @@
         },
         {
             "id": "97b5234f-a550-5cda-b06d-0ceb8c0a711f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d51c18-4b7d-4948-96bc-12c8ab3d0bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d51c18-4b7d-4948-96bc-12c8ab3d0bd0.jpg?1",
             "name": "Wasteland",
             "text": "{T}: Add {C}.\n{T}, Sacrifice Wasteland: Destroy target nonbasic land.",
             "colours": [],
@@ -13330,7 +13330,7 @@
         },
         {
             "id": "b9b0a4c7-8633-5011-8a99-08490e81475e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76832a0-8690-4843-8be4-1eba89ada995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b76832a0-8690-4843-8be4-1eba89ada995.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "Enlist\nWhenever a creature you control attacks, if it enlisted a creature this combat, the creature that attacked gains double strike until end of turn. If that creature's power is 4 or greater, draw a card.",
             "colours": [
@@ -13371,7 +13371,7 @@
         },
         {
             "id": "034759e6-4822-5de3-ba10-c297729c5395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ac69e-c2a0-4106-951a-3ca3a33c30ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ac69e-c2a0-4106-951a-3ca3a33c30ed.jpg?1",
             "name": "Automated Assembly Line",
             "text": "Whenever one or more artifact creatures you control deal combat damage to a player, you get {E}.\nPay {E}{E}{E}: Create a tapped 3/3 colorless Robot artifact creature token.",
             "colours": [
@@ -13407,7 +13407,7 @@
         },
         {
             "id": "29682f33-25cc-587f-8414-0240c3e1b5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad4f5e-ac74-4549-bfc7-bbfdb1eb185e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad4f5e-ac74-4549-bfc7-bbfdb1eb185e.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "As Battle of Hoover Dam enters the battlefield, choose NCR or Legion.\n\u2022 NCR \u2014 At the beginning of your end step, return target creature card with mana value 3 or less from your graveyard to the battlefield with a finality counter on it.\n\u2022 Legion \u2014 Whenever a creature you control dies, put two +1/+1 counters on target creature you control.",
             "colours": [
@@ -13443,7 +13443,7 @@
         },
         {
             "id": "0f3293c6-3052-5b7b-83b5-83e5e3d29d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d9b1a8-36c1-48c6-bcfb-d2cc161da584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d9b1a8-36c1-48c6-bcfb-d2cc161da584.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "Metalcraft \u2014 {T}: You get {E}. Activate only if you control three or more artifacts.\nWhenever you get one or more {E} during your turn, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -13482,7 +13482,7 @@
         },
         {
             "id": "64351f3c-4b02-5cd8-89b3-f902c8694658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e8f8c9-7e59-43a3-b8e7-c8515fd4b3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e8f8c9-7e59-43a3-b8e7-c8515fd4b3eb.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "Commanders you control have ward {2}.\n{T}: Add {W}{W}. Spend this mana only to cast Aura and/or Equipment spells.\n{T}: Attach target Aura or Equipment you control to target creature you control. Activate only as a sorcery.",
             "colours": [
@@ -13523,7 +13523,7 @@
         },
         {
             "id": "6257b292-d614-51dd-b9a5-978e84331f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ab676-2437-4927-8f30-dd234298f190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6ab676-2437-4927-8f30-dd234298f190.jpg?1",
             "name": "Overencumbered",
             "text": "Enchant opponent\nWhen Overencumbered enters the battlefield, enchanted opponent creates a Clue token, a Food token, and a Junk token.\nAt the beginning of combat on enchanted opponent's turn, that player may pay {1} for each artifact they control. If they don't, creatures can't attack this combat.",
             "colours": [
@@ -13561,7 +13561,7 @@
         },
         {
             "id": "fa797126-7421-5a1b-ac11-fcf75e9d083b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515c4b3-a0af-4c60-aad1-627216f0bdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515c4b3-a0af-4c60-aad1-627216f0bdf7.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "First Contact \u2014 Whenever Overseer of Vault 76 or another creature with power 3 or less enters the battlefield under your control, put a quest counter on Overseer of Vault 76.\nAt the beginning of combat on your turn, you may remove three quest counters from among permanents you control. When you do, put a +1/+1 counter on each creature you control and they gain vigilance until end of turn.",
             "colours": [
@@ -13602,7 +13602,7 @@
         },
         {
             "id": "3b312c13-5373-590c-b30b-f3072a1d30f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f58eb-3cd7-44fa-abf7-6110d3e12407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31f58eb-3cd7-44fa-abf7-6110d3e12407.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "When Pre-War Formalwear enters the battlefield, return target creature card with mana value 3 or less from your graveyard to the battlefield and attach Pre-War Formalwear to it.\nEquipped creature gets +2/+2 and has vigilance.\nEquip {3}",
             "colours": [
@@ -13640,7 +13640,7 @@
         },
         {
             "id": "b7e30236-e5e0-5c3f-9785-7b5d06817844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd7f68-4dab-49b3-a151-dec47f5c30b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd7f68-4dab-49b3-a151-dec47f5c30b1.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "Flying\nWhenever another nontoken artifact enters the battlefield under your control, create a 2/2 white Human Knight creature token with \"This creature gets +2/+2 as long as an artifact entered the battlefield under your control this turn.\"\nCrew 2",
             "colours": [
@@ -13680,7 +13680,7 @@
         },
         {
             "id": "8ec4f571-3261-5ce7-9a36-5266fae90ae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f5b4d8-1beb-4b74-8279-6bf0eddb6857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f5b4d8-1beb-4b74-8279-6bf0eddb6857.jpg?1",
             "name": "Sentry Bot",
             "text": "Flash\nThis spell costs {1} less to cast for each creature attacking you.\nWhen Sentry Bot enters the battlefield, you get {E} for each creature attacking you.\nAt the beginning of combat on your turn, you may pay {E}{E}{E}. If you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -13719,7 +13719,7 @@
         },
         {
             "id": "7737f69b-3552-5fe7-b856-ddbc98f5e44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9163197-bbe9-44d7-a942-04b88f7c9120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9163197-bbe9-44d7-a942-04b88f7c9120.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "The Nuka-Cola Challenge \u2014 Whenever one or more creatures you control deal combat damage to a player, put a quest counter on Sierra, Nuka's Biggest Fan and create a Food token.\nWhenever you sacrifice a Food, target creature you control gets +X/+X until end of turn, where X is the number of quest counters on Sierra.",
             "colours": [
@@ -13760,7 +13760,7 @@
         },
         {
             "id": "006f095e-96c1-58fb-b745-7990694cadfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac476507-f947-4faf-839e-fe01109c2c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac476507-f947-4faf-839e-fe01109c2c6c.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "{T}: Target opponent gains control of Yes Man, Personal Securitron. When they do, you draw two cards and put a quest counter on Yes Man. Activate only during your turn.\nWild Card \u2014 When Yes Man leaves the battlefield, its owner creates a tapped 1/1 white Soldier creature token for each quest counter on it.",
             "colours": [
@@ -13801,7 +13801,7 @@
         },
         {
             "id": "7eff1d33-0c8e-525e-bbfd-ae147d9286bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126e9146-440b-442b-8981-1fcffeef441d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126e9146-440b-442b-8981-1fcffeef441d.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.\n{1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has \"Whenever this creature deals combat damage to a player, draw cards equal to its base power.\"",
             "colours": [
@@ -13842,7 +13842,7 @@
         },
         {
             "id": "a69f917c-cfab-5a30-9982-f8282288efa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "{T}: Add {C}{C}. Spend this mana only to activate abilities.",
             "colours": [
@@ -13883,7 +13883,7 @@
         },
         {
             "id": "c46cd4f9-0972-538f-afa5-b002115cf9dd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/6687197c-db19-4557-b58c-bc111dfb84c4.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "Investigate X times.",
             "colours": [
@@ -13921,7 +13921,7 @@
         },
         {
             "id": "e7fb51e1-4480-5d60-b79f-680af643e063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4089a153-fdf8-481a-b13d-02aaf6ca1815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4089a153-fdf8-481a-b13d-02aaf6ca1815.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "Whenever a Zombie or Mutant you control dies, if its power was different from its base power, draw a card.\nCome Fly With Me \u2014 {2}, Sacrifice a creature: Put a +1/+1 counter on target creature you control. It gains flying until end of turn.",
             "colours": [
@@ -13963,7 +13963,7 @@
         },
         {
             "id": "e2256950-d91d-5ed6-92fe-dda94abcaa88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54b0f74-f0f5-4753-9f2f-a376b1b0da2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54b0f74-f0f5-4753-9f2f-a376b1b0da2f.jpg?1",
             "name": "Mirelurk Queen",
             "text": "Vigilance\nWhen Mirelurk Queen enters the battlefield, target player gets two rad counters.\nWhenever one or more nonland cards are milled, draw a card, then put a +1/+1 counter on Mirelurk Queen. This ability triggers only once each turn.",
             "colours": [
@@ -14002,7 +14002,7 @@
         },
         {
             "id": "b9aac35f-f907-50a4-99f1-99fa5702e7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd230a2-cbbc-49e1-a57d-7f189ef8d10f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd230a2-cbbc-49e1-a57d-7f189ef8d10f.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "Nick Valentine, Private Eye can't be blocked except by artifact creatures.\nWhenever Nick Valentine or another artifact creature you control dies, you may investigate.",
             "colours": [
@@ -14044,7 +14044,7 @@
         },
         {
             "id": "3ca47f48-76a8-5f49-9e7c-d09584f5837f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f00cff-9999-4d81-ac3d-2a74f4ae19e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f00cff-9999-4d81-ac3d-2a74f4ae19e1.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "Whenever Piper Wright deals combat damage to a player, investigate that many times.\nWhenever you sacrifice a Clue, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -14085,7 +14085,7 @@
         },
         {
             "id": "ad69a3d5-cd42-5ebc-b94a-d71c66c23299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae6487-3f00-4dbb-b6ec-4b6b2d090c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dae6487-3f00-4dbb-b6ec-4b6b2d090c35.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "As Struggle for Project Purity enters the battlefield, choose Brotherhood or Enclave.\n\u2022 Brotherhood \u2014 At the beginning of your upkeep, each opponent draws a card. You draw a card for each card drawn this way.\n\u2022 Enclave \u2014 Whenever a player attacks you with one or more creatures, that player gets twice that many rad counters.",
             "colours": [
@@ -14121,7 +14121,7 @@
         },
         {
             "id": "46534c1e-6d20-55a9-9bf6-4a4fe7162296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3431ac9-006d-4f19-b933-fcd1dc375ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3431ac9-006d-4f19-b933-fcd1dc375ede.jpg?1",
             "name": "Feral Ghoul",
             "text": "Menace\nWhenever another creature you control dies, put a +1/+1 counter on Feral Ghoul.\nWhen Feral Ghoul dies, each opponent gets a number of rad counters equal to its power.",
             "colours": [
@@ -14160,7 +14160,7 @@
         },
         {
             "id": "6e3db293-aa49-5a4c-acdf-f26302a66a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24419ecc-c740-4972-8510-8fd15a65dd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24419ecc-c740-4972-8510-8fd15a65dd4e.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "Each other creature you control that's a Zombie or Mutant gets +X/+X, where X is the number of counters on Hancock, Ghoulish Mayor.\nUndying",
             "colours": [
@@ -14202,7 +14202,7 @@
         },
         {
             "id": "39bf31d6-f14b-5a98-a4e4-52d5826bb8ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498b0c25-5de1-493d-a328-ccfa4cb1b32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498b0c25-5de1-493d-a328-ccfa4cb1b32f.jpg?1",
             "name": "Wasteland Raider",
             "text": "Squad {2}\nWhen Wasteland Raider enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -14241,7 +14241,7 @@
         },
         {
             "id": "344bc53c-0d8d-5a3e-8f5d-33e1bdf8f2c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4ba2a5-102c-49b9-8c1d-e078a7c0d4c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4ba2a5-102c-49b9-8c1d-e078a7c0d4c0.jpg?1",
             "name": "Assaultron Dominator",
             "text": "When Assaultron Dominator enters the battlefield, you get {E}{E}.\nWhenever an artifact creature you control attacks, you may pay {E}. If you do, put your choice of a +1/+1, first strike, or trample counter on that creature.",
             "colours": [
@@ -14280,7 +14280,7 @@
         },
         {
             "id": "4aaf3830-dc67-51a1-92bf-71d4f9c2f896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845ee858-bcb9-4a46-aa1a-18e99081a48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845ee858-bcb9-4a46-aa1a-18e99081a48d.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "Hunters for Hire \u2014 Whenever a creature you control deals combat damage to a player, put a quest counter on it.\n{1}, Remove a quest counter from a permanent you control: Create a Junk token.",
             "colours": [
@@ -14321,7 +14321,7 @@
         },
         {
             "id": "d728fbf1-9b29-5726-af44-eb0352c5e558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c775f4f-90a5-413a-9838-c7328f5752dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c775f4f-90a5-413a-9838-c7328f5752dd.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "Morbid \u2014 This spell costs {3} less to cast if a creature died this turn.\nEnchant creature\nWhen Grim Reaper's Sprint enters the battlefield, untap each creature you control. If it's your main phase, there is an additional combat phase after this phase.\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -14359,7 +14359,7 @@
         },
         {
             "id": "e4e7caea-c2c6-57a5-a86a-bbc8af05bbc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e74c30-fcd8-4ee2-87b1-e8b7f3a846d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e74c30-fcd8-4ee2-87b1-e8b7f3a846d0.jpg?1",
             "name": "Junk Jet",
             "text": "When Junk Jet enters the battlefield, create a Junk token.\n{3}, Sacrifice another artifact: Double equipped creature's power until end of turn.\nEquip {1}",
             "colours": [
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "f19802df-eab5-5738-bdff-4ac5e0b9cc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c93a1-3553-4de7-8441-396aa50b26bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c93a1-3553-4de7-8441-396aa50b26bb.jpg?1",
             "name": "Megaton's Fate",
             "text": "Choose one \u2014\n\u2022 Disarm \u2014 Destroy target artifact. Create four Treasure tokens.\n\u2022 Detonate \u2014 Megaton's Fate deals 8 damage to each creature. Each player gets four rad counters.",
             "colours": [
@@ -14433,7 +14433,7 @@
         },
         {
             "id": "22177724-f146-5371-bed0-28fa6fa7cfae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a82f32-24aa-4575-8cae-0301f649d87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a82f32-24aa-4575-8cae-0301f649d87f.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "When The Motherlode, Excavator enters the battlefield, choose target opponent. You get an amount of {E} equal to the number of nonbasic lands that player controls.\nWhenever The Motherlode attacks, you may pay {E}{E}{E}{E}. When you do, destroy target nonbasic land defending player controls, and creatures that player controls without flying can't block this turn.",
             "colours": [
@@ -14474,7 +14474,7 @@
         },
         {
             "id": "679baef9-22d3-5710-b4d1-f5bf1ba89a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b74f6f-be1f-47ef-ae3f-1c7b0138b6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b74f6f-be1f-47ef-ae3f-1c7b0138b6c0.jpg?1",
             "name": "Plasma Caster",
             "text": "Equipped creature gets +1/+1.\nWhenever equipped creature attacks, you get {E}{E}.\nPay {E}{E}: Choose target creature that's blocking equipped creature. Flip a coin. If you win the flip, exile the chosen creature. Otherwise, Plasma Caster deals 1 damage to it.\nEquip {2}",
             "colours": [
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "ccaa04d0-0d3d-5e48-82eb-87c671ee45e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdf49f1-4a49-4ab7-b0fe-d16a846e0a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fdf49f1-4a49-4ab7-b0fe-d16a846e0a59.jpg?1",
             "name": "Powder Ganger",
             "text": "Squad {2}\nWhen Powder Ganger enters the battlefield, destroy up to one target artifact.",
             "colours": [
@@ -14551,7 +14551,7 @@
         },
         {
             "id": "d1532472-e81f-572e-9470-fefedc657bfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c7391a-77ad-48db-adf1-59d91c0bacac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c7391a-77ad-48db-adf1-59d91c0bacac.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "First strike\nRaid \u2014 At end of combat on your turn, if you attacked this turn, create a Junk token for each opponent you attacked.\nWhenever you sacrifice a Junk, add {R}.",
             "colours": [
@@ -14592,7 +14592,7 @@
         },
         {
             "id": "2b585fad-e201-50ef-824b-0d7655e0ed38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ca870a-ebb5-41cb-bd90-39268d6a401f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ca870a-ebb5-41cb-bd90-39268d6a401f.jpg?1",
             "name": "Synth Eradicator",
             "text": "Haste\nWhenever Synth Eradicator attacks, exile the top card of your library. You may get {E}{E}. If you don't, you may play that card this turn.\n{T}, Pay {E}{E}{E}: Synth Eradicator deals 3 damage to any target.",
             "colours": [
@@ -14632,7 +14632,7 @@
         },
         {
             "id": "8e77af0b-e429-5a48-8589-193ad4c26c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8e6169-b36d-44c0-8491-69affc360d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8e6169-b36d-44c0-8491-69affc360d9a.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "Squad\u2014{1}, Discard a card.\nWhen Thrill-Kill Disciple dies, create a Junk token.",
             "colours": [
@@ -14671,7 +14671,7 @@
         },
         {
             "id": "eb99fa97-f622-5933-9874-dfd929820022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21edcd68-dd1e-4705-badb-16ae76945ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21edcd68-dd1e-4705-badb-16ae76945ac9.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "Menace\nWhenever Veronica, Dissident Scribe attacks, you may discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards for the first time each turn, create a Junk token.",
             "colours": [
@@ -14713,7 +14713,7 @@
         },
         {
             "id": "a6782cff-3649-572e-bb8b-1d315a2fff72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f04427-e286-4196-b471-dd368f40d14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f04427-e286-4196-b471-dd368f40d14b.jpg?1",
             "name": "Wild Wasteland",
             "text": "Skip your draw step.\nAt the beginning of your upkeep, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -14749,7 +14749,7 @@
         },
         {
             "id": "ac8ccb70-bd16-54d6-b682-998314cde14e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66faa677-14d5-4a4e-8587-c777f5b55869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66faa677-14d5-4a4e-8587-c777f5b55869.jpg?1",
             "name": "Animal Friend",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 1/1 green Squirrel creature token. Put a +1/+1 counter on that token for each Aura and Equipment attached to this creature other than Animal Friend.\"",
             "colours": [
@@ -14787,7 +14787,7 @@
         },
         {
             "id": "84c769eb-f31b-5e5a-9dea-80d54ff92f56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7dc266-d38e-479c-a978-0c4bfd6e7370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b7dc266-d38e-479c-a978-0c4bfd6e7370.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "Vigilance, reach\nWhen Harold and Bob, First Numens dies, if it was a creature, return it to the battlefield. It's an Aura enchantment with enchant Forest you control and \"Enchanted Forest has \u2018{T}: Add three mana of any one color. You get two rad counters.'\" Harold and Bob loses all other abilities.",
             "colours": [
@@ -14828,7 +14828,7 @@
         },
         {
             "id": "26a348cb-2206-5351-9ec3-eeb06a3f2ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27fe33-8675-4a36-8c24-873eb5d8bbf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27fe33-8675-4a36-8c24-873eb5d8bbf7.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "Vigilance\nLily Bowen, Raging Grandma enters the battlefield with two +1/+1 counters on it.\nAt the beginning of your upkeep, double the number of +1/+1 counters on Lily Bowen if its power is 16 or less. Otherwise, remove all but one +1/+1 counter from it, then you gain 1 life for each +1/+1 counter removed this way.",
             "colours": [
@@ -14869,7 +14869,7 @@
         },
         {
             "id": "8db42aac-fe7f-5bc1-b1d4-abc7d6abab11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05c5af9-67ad-4c20-9d5f-91bda19d5809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e05c5af9-67ad-4c20-9d5f-91bda19d5809.jpg?1",
             "name": "Power Fist",
             "text": "Equipped creature has trample and \"Whenever this creature deals combat damage to a player, put that many +1/+1 counters on it.\"\nEquip {2}",
             "colours": [
@@ -14907,7 +14907,7 @@
         },
         {
             "id": "2baf1218-0cc1-53aa-bf8f-98a3ea73248b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f7072a-5627-44e1-99b7-8a7aa228a029.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f7072a-5627-44e1-99b7-8a7aa228a029.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "Vigilance, trample\nRampaging Yao Guai enters the battlefield with X +1/+1 counters on it.\nWhen Rampaging Yao Guai enters the battlefield, destroy any number of target artifacts and/or enchantments with total mana value X or less.",
             "colours": [
@@ -14946,7 +14946,7 @@
         },
         {
             "id": "2385a71c-0e94-5ef1-926b-d42576d85a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06833c3e-8447-4900-9196-8a953dab3827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06833c3e-8447-4900-9196-8a953dab3827.jpg?1",
             "name": "Strong Back",
             "text": "Enchant creature\nEquip abilities you activate that target enchanted creature cost {3} less to activate.\nAura spells you cast that target enchanted creature cost {3} less to cast.\nEnchanted creature gets +2/+2 for each Aura and Equipment attached to it.",
             "colours": [
@@ -14984,7 +14984,7 @@
         },
         {
             "id": "f3e1cff3-8f8b-55ef-9e3f-092b547db112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba8a965-7f74-4d78-97a4-1781ebbcb52d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba8a965-7f74-4d78-97a4-1781ebbcb52d.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "Ward {2}\nEnrage \u2014 Whenever Strong is dealt damage, you get three rad counters and put three +1/+1 counters on Strong.\nYou gain life rather than lose life from radiation.",
             "colours": [
@@ -15025,7 +15025,7 @@
         },
         {
             "id": "c8de614e-3146-5f6c-89d4-f254568d1085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aef208-dcd2-4b66-bab2-882e38752ab5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aef208-dcd2-4b66-bab2-882e38752ab5.jpg?1",
             "name": "Tato Farmer",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may get two rad counters.\n{T}: Put target land card in a graveyard that was milled this turn onto the battlefield under your control tapped.",
             "colours": [
@@ -15065,7 +15065,7 @@
         },
         {
             "id": "8bb9a85c-22c0-50e4-b9e6-81522bb0c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1e4b1-5ebf-47b6-a60b-252f245877a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e1e4b1-5ebf-47b6-a60b-252f245877a6.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "Trample\nAgent Frank Horrigan has indestructible as long as it attacked this turn.\nWhenever Agent Frank Horrigan enters the battlefield or attacks, proliferate twice.",
             "colours": [
@@ -15108,7 +15108,7 @@
         },
         {
             "id": "bb145d1f-7e49-5955-bf55-2adbcbe50fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a21ea5c-2e3a-42db-b688-f02f20ff2e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a21ea5c-2e3a-42db-b688-f02f20ff2e02.jpg?1",
             "name": "Almost Perfect",
             "text": "Enchant creature\nEnchanted creature has base power and toughness 9/10 and has indestructible.",
             "colours": [
@@ -15148,7 +15148,7 @@
         },
         {
             "id": "b2cbde15-8aec-59af-9f99-f10959f96114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987fd451-7276-4cde-a820-a6e55a59b010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987fd451-7276-4cde-a820-a6e55a59b010.jpg?1",
             "name": "Arcade Gannon",
             "text": "{T}: Draw a card, then discard a card. Put a quest counter on Arcade Gannon.\nFor Auld Lang Syne \u2014 Once during each of your turns, you may cast an artifact or Human spell from your graveyard with mana value less than or equal to the number of quest counters on Arcade Gannon.",
             "colours": [
@@ -15191,7 +15191,7 @@
         },
         {
             "id": "3df38d08-c951-5b77-a101-88c8813e1d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e84784-3baf-47da-adcd-4f00b379b278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e84784-3baf-47da-adcd-4f00b379b278.jpg?1",
             "name": "Boomer Scrapper",
             "text": "Whenever Boomer Scrapper enters the battlefield or attacks, you lose 1 life and create a Junk token.\nWhenever a token you control leaves the battlefield, put a +1/+1 counter on Boomer Scrapper.",
             "colours": [
@@ -15232,7 +15232,7 @@
         },
         {
             "id": "9bbd9398-b20b-5ba9-97a3-22a70e807c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a55e3-d231-4c2b-9035-d7835a62e649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499a55e3-d231-4c2b-9035-d7835a62e649.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "As long as it's your turn, Cait, Cage Brawler has indestructible.\nWhenever Cait attacks, you and defending player each draw a card, then discard a card. Put two +1/+1 counters on Cait if you discarded the card with the highest mana value among those cards or tied for highest.",
             "colours": [
@@ -15275,7 +15275,7 @@
         },
         {
             "id": "e7f25b52-6dc6-5c30-8b27-7ebe3118a040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6143ede-4613-4f87-b792-e9aa6c19a274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6143ede-4613-4f87-b792-e9aa6c19a274.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "Vigilance\nWhenever Cass or another creature you control dies, if it was enchanted or equipped, return any number of Aura cards that were attached to it from your graveyard to the battlefield attached to target creature, then attach any number of Equipment  that were attached to it to that creature.",
             "colours": [
@@ -15318,7 +15318,7 @@
         },
         {
             "id": "7103f6fd-4712-535a-a60c-218b10b2781f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8333aa-d516-4b5a-bc74-ba81b2826dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8333aa-d516-4b5a-bc74-ba81b2826dfc.jpg?1",
             "name": "Colonel Autumn",
             "text": "Lifelink, exploit\nOther legendary creatures you control have exploit.\nWhenever a creature you control exploits a creature, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -15361,7 +15361,7 @@
         },
         {
             "id": "08be50fc-2649-5b78-ae04-b9db9e4a068c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae8bcf-4c03-477b-aa6c-f94d99676627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae8bcf-4c03-477b-aa6c-f94d99676627.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "Vigilance\nWhenever Desdemona, Freedom's Edge attacks, target creature card in your graveyard that's an artifact or that has mana value 3 or less gains escape until end of turn. The escape cost is equal to its mana cost plus exile two other cards from your graveyard.",
             "colours": [
@@ -15404,7 +15404,7 @@
         },
         {
             "id": "d68370ad-883a-52a3-b3e0-cc6133e87d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0534b7-ed5c-4bed-947e-9ec5ac7e37a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0534b7-ed5c-4bed-947e-9ec5ac7e37a9.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "Creature tokens you control have training.\nBlind Betrayal \u2014 Sacrifice another creature: Elder Arthur Maxson gains indestructible until end of turn.",
             "colours": [
@@ -15447,7 +15447,7 @@
         },
         {
             "id": "22868179-c565-5299-92b4-b6ba62bd0a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af3801-d036-4395-8c39-1f46e7de9b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7af3801-d036-4395-8c39-1f46e7de9b7a.jpg?1",
             "name": "Electrosiphon",
             "text": "Counter target spell. You get an amount of {E} equal to its mana value.",
             "colours": [
@@ -15485,7 +15485,7 @@
         },
         {
             "id": "a1ac9e34-68aa-5c25-9267-25ed28236ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8912d8ca-bd08-47e0-aa21-bc9e16c954bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8912d8ca-bd08-47e0-aa21-bc9e16c954bb.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "First strike, haste\nWhenever Kellogg, Dangerous Mind attacks, create a Treasure token.\nSacrifice five Treasures: Gain control of target creature for as long as you control Kellogg. Activate only as a sorcery.",
             "colours": [
@@ -15528,7 +15528,7 @@
         },
         {
             "id": "9f12a3fd-171a-5bd6-89ff-d4b66ba7fe0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ddb442-7006-4e50-a4f5-88e2b8ec2285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ddb442-7006-4e50-a4f5-88e2b8ec2285.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "Vigilance, trample, haste\nWhenever Liberty Prime, Recharged attacks or blocks, sacrifice it unless you pay {E}{E}.\n{2}, {T}, Sacrifice an artifact: You get {E}{E} and draw a card.",
             "colours": [
@@ -15573,7 +15573,7 @@
         },
         {
             "id": "61d404be-7441-5340-ae46-2c90de9aa5b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d4a3f9-c73f-4f1e-a9e2-ef4eb7cb1e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d4a3f9-c73f-4f1e-a9e2-ef4eb7cb1e1e.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "Whenever a creature you control with power 2 or less attacks, it gains skulk until end of turn.\nWhenever a creature with power 4 or greater attacks you, its controller loses 2 life and you gain 2 life.",
             "colours": [
@@ -15616,7 +15616,7 @@
         },
         {
             "id": "fef718ee-07aa-5e48-8726-beb0539998b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122cbe69-1ea2-4448-94d9-db5119339563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122cbe69-1ea2-4448-94d9-db5119339563.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "Vigilance, trample\nWhenever a creature you control deals combat damage to a player, draw a card if that creature has a +1/+1 counter on it. If it doesn't, put a +1/+1 counter on it.",
             "colours": [
@@ -15659,7 +15659,7 @@
         },
         {
             "id": "9b67a938-eaa5-5886-b301-544fbe12f0ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811876c4-ca77-4fc0-9c05-690da35949ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811876c4-ca77-4fc0-9c05-690da35949ac.jpg?1",
             "name": "The Master, Transcendent",
             "text": "When The Master, Transcendent enters the battlefield, target player gets two rad counters.\n{T}: Put target creature card in a graveyard that was milled this turn onto the battlefield under your control. It's a green Mutant with base power and toughness 3/3.",
             "colours": [
@@ -15704,7 +15704,7 @@
         },
         {
             "id": "68b7fec4-e622-5923-af70-324d0a756ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb999a58-8380-470f-8e0f-2575d089c979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb999a58-8380-470f-8e0f-2575d089c979.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "When Moira Brown, Guide Author enters the battlefield, create a colorless Equipment artifact token named Wasteland Survival Guide with \"Equipped creature gets +1/+1 for each quest counter among permanents you control\" and equip {1}.\nWhenever you attack, put a quest counter on target nonland permanent you control.",
             "colours": [
@@ -15747,7 +15747,7 @@
         },
         {
             "id": "ce321129-9215-54ff-a632-b48dae3d8291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac318a61-40c5-4772-b8a6-6843dfb62ef4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac318a61-40c5-4772-b8a6-6843dfb62ef4.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "Whenever you roll a 4 or higher, create a 3/3 colorless Robot artifact creature token. If you rolled 6 or higher, instead create that token and a Treasure token.\n{4}, {T}: Roll a six-sided die plus an additional six-sided die for each mana from Treasures spent to activate this ability.",
             "colours": [
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "603bdf15-0fd9-52db-9896-30f8d1528bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c2e0-4881-4651-8550-339a15e7566e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d60c2e0-4881-4651-8550-339a15e7566e.jpg?1",
             "name": "Mutational Advantage",
             "text": "Permanents you control with counters on them gain hexproof and indestructible until end of turn. Prevent all damage that would be dealt to those permanents this turn. Proliferate.",
             "colours": [
@@ -15830,7 +15830,7 @@
         },
         {
             "id": "de717fb4-3c53-52fe-8e8e-a448c8b59787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5db3b38-9ea2-416f-9d15-47a2b0adf9c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5db3b38-9ea2-416f-9d15-47a2b0adf9c3.jpg?1",
             "name": "The Nipton Lottery",
             "text": "Choose a creature at random. You gain control of that creature until end of turn. Untap it. It gains haste until end of turn. Then destroy all other creatures.",
             "colours": [
@@ -15868,7 +15868,7 @@
         },
         {
             "id": "db84ff4b-234e-5b70-95c8-f7d78289e0fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7532db9-d064-4406-9e15-40e4f06bafc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7532db9-d064-4406-9e15-40e4f06bafc3.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "Battalion \u2014 Whenever Paladin Elizabeth Taggerdy and at least two other creatures attack, draw a card, then you may put a creature card with mana value X or less from your hand onto the battlefield tapped and attacking, where X is Paladin Elizabeth Taggerdy's power.",
             "colours": [
@@ -15911,7 +15911,7 @@
         },
         {
             "id": "665b02e8-2f82-5d14-a749-43efe8b10faa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc4f47f-5847-4edb-8348-cce0b0e00f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc4f47f-5847-4edb-8348-cce0b0e00f09.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "At the beginning of combat on your turn, create a green Aura enchantment token named Settlement attached to up to one target land you control. It has enchant land and \"Enchanted land has \u2018{T}: Add one mana of any color.'\"\nWhenever Preston Garvey, Minuteman attacks, untap each enchanted permanent you control.",
             "colours": [
@@ -15956,7 +15956,7 @@
         },
         {
             "id": "eefaace5-3f12-5742-9775-c1461a71084b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f555f5b-da14-4e81-9afc-60c1ed337062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f555f5b-da14-4e81-9afc-60c1ed337062.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "Alluring Eyes \u2014 {T}: Goad target creature an opponent controls. That player draws a card. You add {R}.",
             "colours": [
@@ -15999,7 +15999,7 @@
         },
         {
             "id": "9a43e74a-5735-5a87-88ae-efd7e4e3655a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4068c6-b95e-4959-9f3c-d43a7f048f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a4068c6-b95e-4959-9f3c-d43a7f048f85.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "Whenever Rex, Cyber-Hound deals combat damage to a player, they mill two cards and you get {E}{E}.\nPay {E}{E}: Choose target creature card in a graveyard. Exile it with a brain counter on it. Activate only as a sorcery.\nRex has all activated abilities of all cards in exile with brain counters on them.",
             "colours": [
@@ -16043,7 +16043,7 @@
         },
         {
             "id": "fa67cc91-58c4-59f4-aa65-dc9439eeb448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a54f0-caad-4c9f-8cfa-84702a326017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a54f0-caad-4c9f-8cfa-84702a326017.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "Haste\nAs long as an artifact entered the battlefield under your control this turn, creatures you control get +2/+2.\nBattalion \u2014 Whenever Sentinel Sarah Lyons and at least two other creatures attack, Sentinel Sarah Lyons deals damage equal to the number of artifacts you control to target player.",
             "colours": [
@@ -16086,7 +16086,7 @@
         },
         {
             "id": "1220e39f-aacc-59ce-9132-007a8e095d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a23ad1-e1ce-4aaa-b670-118b351dd970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a23ad1-e1ce-4aaa-b670-118b351dd970.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "Whenever you attack, you may create a tapped and attacking token that's a copy of target attacking legendary creature you control other than Shaun, except it's not legendary and it's a Synth artifact creature in addition to its other types.\nWhen Shaun leaves the battlefield, exile all Synth tokens you control.",
             "colours": [
@@ -16129,7 +16129,7 @@
         },
         {
             "id": "1db58b05-75ee-536e-921d-3b114c6ca610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5a41f-0139-4c9b-94ea-c9d0d5fd6079.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a5a41f-0139-4c9b-94ea-c9d0d5fd6079.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "Whenever you attack, you may pay {2} and sacrifice an Aura attached to Three Dog, Galaxy News DJ. When you sacrifice an Aura this way, for each other attacking creature you control, create a token that's a copy of that Aura attached to that creature.",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "a2384dbf-d3a6-531d-883d-6df7396a3803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900da9ff-01d5-429e-b11a-48e0dca5df69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900da9ff-01d5-429e-b11a-48e0dca5df69.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "Flying\nBrotherhood Vertibird's power is equal to the number of artifacts you control.\nCrew 2",
             "colours": [],
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "5cf9cbd1-35b7-51d1-805c-7dc487f13b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b643d9-056b-42c2-a9aa-62f584d2e414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b643d9-056b-42c2-a9aa-62f584d2e414.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "Flying\nED-E My Love \u2014 Whenever you attack, if the number of attacking creatures is greater than the number of quest counters on ED-E, Lonesome Eyebot, put a quest counter on it.\n{2}, Sacrifice ED-E: Draw a card, then draw an additional card for each quest counter on ED-E.",
             "colours": [],
@@ -16243,7 +16243,7 @@
         },
         {
             "id": "ef3493d0-9d9b-5747-8252-d1b61e630651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e1ad95-4587-49b0-ac26-ba788b55a847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e1ad95-4587-49b0-ac26-ba788b55a847.jpg?1",
             "name": "Mister Gutsy",
             "text": "Whenever you cast an Aura or Equipment spell, put a +1/+1 counter on Mister Gutsy.\nWhen Mister Gutsy dies, create X Junk tokens, where X is the number of +1/+1 counters on it.",
             "colours": [],
@@ -16279,7 +16279,7 @@
         },
         {
             "id": "0baa2f21-8c33-5cf7-8f25-df9aa66c7c77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d699efaa-4984-4712-8704-c7970cf157af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d699efaa-4984-4712-8704-c7970cf157af.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "Equipped creature gets +3/+0 and has intimidate.\nWhenever equipped creature attacks, until the end of defending player's next turn, that player gets two rad counters whenever they cast a spell.\nEquip {3}",
             "colours": [],
@@ -16313,7 +16313,7 @@
         },
         {
             "id": "87b81481-d965-5462-88ec-3e1532f93f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c1d9b-cb3b-40d7-ba6c-e05ff9762e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c1d9b-cb3b-40d7-ba6c-e05ff9762e2d.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "Whenever equipped creature attacks, choose one \u2014\n\u2022 Sort Inventory \u2014 Draw a card, then discard a card.\n\u2022 Pick a Perk \u2014 Put a +1/+1 counter on that creature.\n\u2022 Check Map \u2014 Untap up to two target lands.\nEquip {2}",
             "colours": [],
@@ -16347,7 +16347,7 @@
         },
         {
             "id": "a3ec0eb1-6750-5571-b98f-a32eafed2d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a553d-400b-44c2-bc28-a690765e32c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743a553d-400b-44c2-bc28-a690765e32c6.jpg?1",
             "name": "Recon Craft Theta",
             "text": "Flying\nWhen Recon Craft Theta enters the battlefield, create a 0/0 blue Alien creature token. Put a +1/+1 counter on it.\nWhenever Recon Craft Theta attacks, proliferate.\nCrew 2",
             "colours": [],
@@ -16381,7 +16381,7 @@
         },
         {
             "id": "b384d4f4-f1ae-521d-98a3-0fb2cade33fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa426a5-0621-44aa-b053-800c2a33ec19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa426a5-0621-44aa-b053-800c2a33ec19.jpg?1",
             "name": "T-45 Power Armor",
             "text": "When T-45 Power Armor enters the battlefield, you get {E}{E}.\nEquipped creature gets +3/+3 and doesn't untap during its controller's untap step.\nAt the beginning of your upkeep, you may pay {E}. If you do, untap equipped creature, then put your choice of a menace, trample, or lifelink counter on it.\nEquip {3}",
             "colours": [],
@@ -16415,7 +16415,7 @@
         },
         {
             "id": "17936985-4af6-505b-9be9-6875acf3a43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174fb330-e13b-46c1-b9b2-d1cbbe979526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174fb330-e13b-46c1-b9b2-d1cbbe979526.jpg?1",
             "name": "Desolate Mire",
             "text": "{1}, {T}: Add {W}{B}.",
             "colours": [],
@@ -16450,7 +16450,7 @@
         },
         {
             "id": "681db0c5-8d51-5935-9d57-9b9587297c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b04a178-f8bf-4804-a676-8b8f7c569ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b04a178-f8bf-4804-a676-8b8f7c569ab6.jpg?1",
             "name": "Diamond City",
             "text": "Diamond City enters the battlefield with a shield counter on it.\n{T}: Add {C}.\n{T}: Move a shield counter from Diamond City onto target creature. Activate only if two or more creatures entered the battlefield under your control this turn.",
             "colours": [],
@@ -16482,7 +16482,7 @@
         },
         {
             "id": "4a5d19dc-a211-5bf7-b433-4e0aa2582350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac13eb-cff7-4461-b648-4e7ded990994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eac13eb-cff7-4461-b648-4e7ded990994.jpg?1",
             "name": "Ferrous Lake",
             "text": "{1}, {T}: Add {U}{R}.",
             "colours": [],
@@ -16517,7 +16517,7 @@
         },
         {
             "id": "1a4e1a4e-84e1-5972-9a56-7c32d3a6c0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b31d55a-44f3-4745-bc40-1399532d558e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b31d55a-44f3-4745-bc40-1399532d558e.jpg?1",
             "name": "HELIOS One",
             "text": "{T}: Add {C}.\n{1}, {T}: You get {E}.\n{3}, {T}, Pay X {E}, Sacrifice HELIOS One: Destroy target nonland permanent with mana value X. Activate only as a sorcery.",
             "colours": [],
@@ -16549,7 +16549,7 @@
         },
         {
             "id": "0e62c492-4715-582e-b88e-2ff23dc7a184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecd671f-da9e-4f96-8c6f-42382d949dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ecd671f-da9e-4f96-8c6f-42382d949dcb.jpg?1",
             "name": "Junktown",
             "text": "{T}: Add {C}.\n{4}{R}, {T}, Sacrifice Junktown: Create three Junk tokens.",
             "colours": [],
@@ -16583,7 +16583,7 @@
         },
         {
             "id": "650ae422-bfa2-5ece-a020-d932d4857c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d50288e-4e68-4d0a-ba5f-efaa48f6e42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d50288e-4e68-4d0a-ba5f-efaa48f6e42c.jpg?1",
             "name": "Mariposa Military Base",
             "text": "You may have Mariposa Military Base enter the battlefield tapped. If you do, you get two rad counters.\n{T}: Add {C}.\n{5}, {T}: Draw a card. This ability costs {1} less to activate for each rad counter you have.",
             "colours": [],
@@ -16615,7 +16615,7 @@
         },
         {
             "id": "3cdb6261-5bf7-594f-921b-707c975fedb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec743e0-f2b6-4f38-a00b-3e6fa01e37ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec743e0-f2b6-4f38-a00b-3e6fa01e37ea.jpg?1",
             "name": "Overflowing Basin",
             "text": "{1}, {T}: Add {G}{U}.",
             "colours": [],
@@ -16650,7 +16650,7 @@
         },
         {
             "id": "31b84978-da52-537c-86da-b379a415ab37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4e4af7-ce45-4f69-9269-e5dac980f0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4e4af7-ce45-4f69-9269-e5dac980f0de.jpg?1",
             "name": "Sunscorched Divide",
             "text": "{1}, {T}: Add {R}{W}.",
             "colours": [],
@@ -16685,7 +16685,7 @@
         },
         {
             "id": "d97cd595-5c76-5051-9d6d-67c285572381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119f64d-1944-449d-a523-75f083f81940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8119f64d-1944-449d-a523-75f083f81940.jpg?1",
             "name": "Viridescent Bog",
             "text": "{1}, {T}: Add {B}{G}.",
             "colours": [],
@@ -16720,7 +16720,7 @@
         },
         {
             "id": "f9d83c02-8bb2-5030-a80d-566b138f419d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df8b22f-f408-49cd-87f8-9614a6ddaaa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df8b22f-f408-49cd-87f8-9614a6ddaaa6.jpg?1",
             "name": "Austere Command",
             "text": "Choose two \u2014\n\u2022 Destroy all artifacts.\n\u2022 Destroy all enchantments.\n\u2022 Destroy all creatures with mana value 3 or less.\n\u2022 Destroy all creatures with mana value 4 or greater.",
             "colours": [
@@ -16756,7 +16756,7 @@
         },
         {
             "id": "e6768a4f-1c51-5e7e-9825-41aa95c0f58e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c224e24c-1eb7-4ebc-b2aa-7ae491acc4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c224e24c-1eb7-4ebc-b2aa-7ae491acc4ef.jpg?1",
             "name": "Captain of the Watch",
             "text": "Vigilance\nOther Soldier creatures you control get +1/+1 and have vigilance.\nWhen Captain of the Watch enters the battlefield, create three 1/1 white Soldier creature tokens.",
             "colours": [
@@ -16795,7 +16795,7 @@
         },
         {
             "id": "2f5b1403-fc79-5bf2-881b-9a52d2a01f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bde02c-bb78-492e-be37-90a69f054dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bde02c-bb78-492e-be37-90a69f054dcb.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "Target player sacrifices an attacking creature. You create X 1/1 white Soldier creature tokens, where X is that creature's toughness.",
             "colours": [
@@ -16831,7 +16831,7 @@
         },
         {
             "id": "d3f1fcd9-d9f0-5132-b280-5a896a94a05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7647150-24a7-4497-9870-7f0ee6435213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7647150-24a7-4497-9870-7f0ee6435213.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke\nDestroy all nontoken creatures.",
             "colours": [
@@ -16867,7 +16867,7 @@
         },
         {
             "id": "4ba93982-f2d7-5c34-9600-54667b5688ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abfdea-b367-4e96-a435-4a03f6c98c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2abfdea-b367-4e96-a435-4a03f6c98c9f.jpg?1",
             "name": "Keeper of the Accord",
             "text": "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -16906,7 +16906,7 @@
         },
         {
             "id": "30eacdad-03ba-5279-a2c5-1facbfd303ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba58d6cf-ed9c-4a6c-a6f2-4ddeec1ccd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba58d6cf-ed9c-4a6c-a6f2-4ddeec1ccd1a.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "Enchant creature you control\nWhen Mantle of the Ancients enters the battlefield, return any number of target Aura and/or Equipment cards that could be attached to enchanted creature from your graveyard to the battlefield attached to enchanted creature.\nEnchanted creature gets +1/+1 for each Aura and Equipment attached to it.",
             "colours": [
@@ -16944,7 +16944,7 @@
         },
         {
             "id": "5d4ab65d-de45-59b2-b2f9-82a488ea1f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1452097-e584-44d6-bafd-a95265bdbc1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1452097-e584-44d6-bafd-a95265bdbc1a.jpg?1",
             "name": "Marshal's Anthem",
             "text": "Multikicker {1}{W}\nCreatures you control get +1/+1.\nWhen Marshal's Anthem enters the battlefield, return up to X target creature cards from your graveyard to the battlefield, where X is the number of times Marshal's Anthem was kicked.",
             "colours": [
@@ -16980,7 +16980,7 @@
         },
         {
             "id": "12fce191-0c6a-57e4-a497-704c33ce8897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2eb4f30-bb11-487c-95b0-24077569fc37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2eb4f30-bb11-487c-95b0-24077569fc37.jpg?1",
             "name": "Martial Coup",
             "text": "Create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures.",
             "colours": [
@@ -17016,7 +17016,7 @@
         },
         {
             "id": "4499b2f8-5024-5cb8-ada2-c5d60b7529b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dc9868-af65-44f3-872f-4157cded5ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3dc9868-af65-44f3-872f-4157cded5ac9.jpg?1",
             "name": "Open the Vaults",
             "text": "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control.",
             "colours": [
@@ -17052,7 +17052,7 @@
         },
         {
             "id": "75a43812-893a-5da7-8c67-fbe7bd6e2bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b5529-b70f-4d61-b98f-e7936683d3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6b5529-b70f-4d61-b98f-e7936683d3ad.jpg?1",
             "name": "Puresteel Paladin",
             "text": "Whenever an Equipment enters the battlefield under your control, you may draw a card.\nMetalcraft \u2014 Equipment you control have equip {0} as long as you control three or more artifacts.",
             "colours": [
@@ -17091,7 +17091,7 @@
         },
         {
             "id": "6c25c33a-65d2-58d2-9b6f-64771e5fd5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fb73c4-be61-4e9b-995f-05e02d6c69d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68fb73c4-be61-4e9b-995f-05e02d6c69d0.jpg?1",
             "name": "Secure the Wastes",
             "text": "Create X 1/1 white Warrior creature tokens.",
             "colours": [
@@ -17127,7 +17127,7 @@
         },
         {
             "id": "682b8071-9c75-5dd6-b408-914a2155e4af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bd5046-39ed-46df-851f-622e07302c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bd5046-39ed-46df-851f-622e07302c5c.jpg?1",
             "name": "Single Combat",
             "text": "Each player chooses a creature or planeswalker they control, then sacrifices the rest. Players can't cast creature or planeswalker spells until the end of your next turn.",
             "colours": [
@@ -17163,7 +17163,7 @@
         },
         {
             "id": "3c0ca2a8-26e8-5e8d-ab29-06efb72382e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0756c6-7db8-4333-b828-4df4c0298b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0756c6-7db8-4333-b828-4df4c0298b5c.jpg?1",
             "name": "Fraying Sanity",
             "text": "Enchant player\nAt the beginning of each end step, enchanted player mills X cards, where X is the number of cards put into their graveyard from anywhere this turn.",
             "colours": [
@@ -17202,7 +17202,7 @@
         },
         {
             "id": "76906a87-58b9-501e-9491-7bcd48ae9b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0436cf2-a48d-46e1-bf60-537c199be370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0436cf2-a48d-46e1-bf60-537c199be370.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate.",
             "colours": [
@@ -17238,7 +17238,7 @@
         },
         {
             "id": "adecb634-3b60-5eba-a5c2-a0604538a410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c37cc19-11f0-4deb-91b4-c61d95f85ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c37cc19-11f0-4deb-91b4-c61d95f85ed8.jpg?1",
             "name": "Mechanized Production",
             "text": "Enchant artifact you control\nAt the beginning of your upkeep, create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game.",
             "colours": [
@@ -17276,7 +17276,7 @@
         },
         {
             "id": "1efd0991-6e8f-50d6-999f-63d10b1e2d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd47a-a2f8-4618-a326-bee7f8260343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd47a-a2f8-4618-a326-bee7f8260343.jpg?1",
             "name": "One with the Machine",
             "text": "Draw cards equal to the highest mana value among artifacts you control.",
             "colours": [
@@ -17312,7 +17312,7 @@
         },
         {
             "id": "45044e06-bd47-51cb-94c7-26dea9b08e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec25793-fb7e-4f94-a5fb-08f683602c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec25793-fb7e-4f94-a5fb-08f683602c0b.jpg?1",
             "name": "Black Market",
             "text": "Whenever a creature dies, put a charge counter on Black Market.\nAt the beginning of your precombat main phase, add {B} for each charge counter on Black Market.",
             "colours": [
@@ -17348,7 +17348,7 @@
         },
         {
             "id": "90c5d827-8064-5a77-b243-85893696ff1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7c7321-9d14-4940-8d59-4ffc7abdab07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7c7321-9d14-4940-8d59-4ffc7abdab07.jpg?1",
             "name": "Lethal Scheme",
             "text": "Convoke\nDestroy target creature or planeswalker. Each creature that convoked Lethal Scheme connives.",
             "colours": [
@@ -17384,7 +17384,7 @@
         },
         {
             "id": "cf23e202-df82-58eb-9ce5-731e92c2b614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dab546-6392-40cd-bcdd-14952b458e5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1dab546-6392-40cd-bcdd-14952b458e5e.jpg?1",
             "name": "Blasphemous Act",
             "text": "This spell costs {1} less to cast for each creature on the battlefield.\nBlasphemous Act deals 13 damage to each creature.",
             "colours": [
@@ -17420,7 +17420,7 @@
         },
         {
             "id": "98f53db1-2ece-5ddf-b4c0-716d9c13cc40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ea9180-2a4a-4c69-848e-002cf2ccf921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ea9180-2a4a-4c69-848e-002cf2ccf921.jpg?1",
             "name": "Chaos Warp",
             "text": "The owner of target permanent shuffles it into their library, then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield.",
             "colours": [
@@ -17456,7 +17456,7 @@
         },
         {
             "id": "ac509f3a-0f18-5534-9634-19d3ae614bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3676db-0f8f-41ee-b178-058930c962bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3676db-0f8f-41ee-b178-058930c962bf.jpg?1",
             "name": "Stolen Strategy",
             "text": "At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells.",
             "colours": [
@@ -17492,7 +17492,7 @@
         },
         {
             "id": "6cc26ae5-f658-5e53-beec-5381ae773a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3544398-02fc-4fc1-ba72-65a00f14aeb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3544398-02fc-4fc1-ba72-65a00f14aeb9.jpg?1",
             "name": "Branching Evolution",
             "text": "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.",
             "colours": [
@@ -17528,7 +17528,7 @@
         },
         {
             "id": "3b9f03f0-23e8-5a85-b52d-125cf32264ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaed17fa-09ed-47d9-a310-94c4a894b992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaed17fa-09ed-47d9-a310-94c4a894b992.jpg?1",
             "name": "Guardian Project",
             "text": "Whenever a nontoken creature enters the battlefield under your control, if it doesn't have the same name as another creature you control or a creature card in your graveyard, draw a card.",
             "colours": [
@@ -17564,7 +17564,7 @@
         },
         {
             "id": "5b0f010f-0bd3-5f91-a932-fc21c7da4373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ae7868-0cb3-427c-93c4-16bf35ac0a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ae7868-0cb3-427c-93c4-16bf35ac0a6f.jpg?1",
             "name": "Hardened Scales",
             "text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -17600,7 +17600,7 @@
         },
         {
             "id": "3472f668-307f-5de7-bfd7-c41c6db01b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f9fb7-e881-4f54-bcb0-833fd11bcae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f9fb7-e881-4f54-bcb0-833fd11bcae2.jpg?1",
             "name": "Heroic Intervention",
             "text": "Permanents you control gain hexproof and indestructible until end of turn.",
             "colours": [
@@ -17636,7 +17636,7 @@
         },
         {
             "id": "c03ef367-eeba-55bf-b3c4-f48098beead8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ba9f4-4aca-46a6-89f7-9b7d8299c68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439ba9f4-4aca-46a6-89f7-9b7d8299c68e.jpg?1",
             "name": "Tireless Tracker",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, investigate.\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.",
             "colours": [
@@ -17675,7 +17675,7 @@
         },
         {
             "id": "e224ece2-35ad-5ed7-bdfb-078912fd472e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0ac04a-54c6-48cd-b449-38c1f0d752f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc0ac04a-54c6-48cd-b449-38c1f0d752f0.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -17713,7 +17713,7 @@
         },
         {
             "id": "f7a8a822-1c90-567f-9c76-c11e64bd25b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea53937-7fe9-46bd-8956-5238788bbbe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea53937-7fe9-46bd-8956-5238788bbbe9.jpg?1",
             "name": "Assemble the Legion",
             "text": "At the beginning of your upkeep, put a muster counter on Assemble the Legion. Then create a 1/1 red and white Soldier creature token with haste for each muster counter on Assemble the Legion.",
             "colours": [
@@ -17751,7 +17751,7 @@
         },
         {
             "id": "e6c5b0bf-3766-5a95-aa4a-7e89f6e16a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697ec02-5056-41ce-b35e-36e3ce2caa06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697ec02-5056-41ce-b35e-36e3ce2caa06.jpg?1",
             "name": "Biomass Mutation",
             "text": "Creatures you control have base power and toughness X/X until end of turn.",
             "colours": [
@@ -17789,7 +17789,7 @@
         },
         {
             "id": "667c3b7f-2e4d-5968-93bb-c3bc339133ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d5d867-8c79-4226-bf97-2b185b3b056e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d5d867-8c79-4226-bf97-2b185b3b056e.jpg?1",
             "name": "Casualties of War",
             "text": "Choose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature.\n\u2022 Destroy target enchantment.\n\u2022 Destroy target land.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -17827,7 +17827,7 @@
         },
         {
             "id": "0c6a56e5-427f-5bbf-8320-ff62c3e994e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64cd0a6-401b-4281-a7e0-ed7059e5596c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64cd0a6-401b-4281-a7e0-ed7059e5596c.jpg?1",
             "name": "Fervent Charge",
             "text": "Whenever a creature you control attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -17867,7 +17867,7 @@
         },
         {
             "id": "ad3afc55-5d5d-5622-9731-f74608e1d424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3dbc470-4580-4672-910b-9ef96910d7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3dbc470-4580-4672-910b-9ef96910d7ae.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "Destroy all nonland permanents your opponents control.",
             "colours": [
@@ -17907,7 +17907,7 @@
         },
         {
             "id": "b6136e0f-1aa5-5e21-bc35-487848d70678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72281f40-7f62-496d-b4b7-3ba1bcbe820e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72281f40-7f62-496d-b4b7-3ba1bcbe820e.jpg?1",
             "name": "Wake the Past",
             "text": "Return all artifact cards from your graveyard to the battlefield. They gain haste until end of turn.",
             "colours": [
@@ -17945,7 +17945,7 @@
         },
         {
             "id": "04bb2238-8722-58f9-a8ae-b31d609c2807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e2248-a9cf-4d8e-bfb9-04b6fc067387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e2248-a9cf-4d8e-bfb9-04b6fc067387.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -17979,7 +17979,7 @@
         },
         {
             "id": "63c51a7a-2ddb-573e-80d7-db1165c74b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75efaf-34d9-4ea1-979d-afa95f4cdcb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75efaf-34d9-4ea1-979d-afa95f4cdcb8.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, create a token that's a copy of Bloodforged Battle-Axe.\nEquip {2}",
             "colours": [],
@@ -18013,7 +18013,7 @@
         },
         {
             "id": "4469d38b-6edd-51bf-b014-a080ca435038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509384-6db1-4dca-8ddf-b2a03a56c310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0509384-6db1-4dca-8ddf-b2a03a56c310.jpg?1",
             "name": "Champion's Helm",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature is legendary, it has hexproof.\nEquip {1}",
             "colours": [],
@@ -18047,7 +18047,7 @@
         },
         {
             "id": "02260682-48d6-5d3b-aad8-ee42633eeb1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176fc61-cb23-41c4-8f9b-84ff10b9b4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6176fc61-cb23-41c4-8f9b-84ff10b9b4e0.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "You may have Masterwork of Ingenuity enter the battlefield as a copy of any Equipment on the battlefield.",
             "colours": [],
@@ -18081,7 +18081,7 @@
         },
         {
             "id": "dfa72bf8-0bb2-5ae2-ac2f-53a42106dcf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f596ee-b551-411f-a460-bfffa89e358e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f596ee-b551-411f-a460-bfffa89e358e.jpg?1",
             "name": "Mystic Forge",
             "text": "You may look at the top card of your library any time.\nYou may cast artifact spells and colorless spells from the top of your library.\n{T}, Pay 1 life: Exile the top card of your library.",
             "colours": [],
@@ -18113,7 +18113,7 @@
         },
         {
             "id": "ea5ad61e-cdfb-55f2-9ed1-6d0408a4fa4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8eff48e-6a3d-4c30-ba14-c6ccbc765ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8eff48e-6a3d-4c30-ba14-c6ccbc765ce0.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -18145,7 +18145,7 @@
         },
         {
             "id": "4c42eb7d-940d-5d29-909e-55f713a6371d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1c2df-05dd-4a25-9126-1aa952864fb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d1c2df-05dd-4a25-9126-1aa952864fb9.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -18180,7 +18180,7 @@
         },
         {
             "id": "4b365d30-f0d6-5817-ab2e-06f082bbe107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cace8d-3618-4c10-b59e-dbb51fb46ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cace8d-3618-4c10-b59e-dbb51fb46ad5.jpg?1",
             "name": "Steel Overseer",
             "text": "{T}: Put a +1/+1 counter on each artifact creature you control.",
             "colours": [],
@@ -18215,7 +18215,7 @@
         },
         {
             "id": "150a00e4-01a0-5c1a-b083-ce4db3a65611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8510d85-e078-471e-a3dc-2720eb4f3bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8510d85-e078-471e-a3dc-2720eb4f3bab.jpg?1",
             "name": "Canopy Vista",
             "text": "Canopy Vista enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -18253,7 +18253,7 @@
         },
         {
             "id": "c6f8ab6e-d516-5611-8f5c-ac9a4e376883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a42f03-b1da-459a-9444-cf6935276841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a42f03-b1da-459a-9444-cf6935276841.jpg?1",
             "name": "Canyon Slough",
             "text": "Canyon Slough enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18291,7 +18291,7 @@
         },
         {
             "id": "ba97b1cd-b596-5dfe-9446-e378b74e8660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d03315-1eaf-41fe-beaf-3269167a89ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d03315-1eaf-41fe-beaf-3269167a89ad.jpg?1",
             "name": "Cinder Glade",
             "text": "Cinder Glade enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -18329,7 +18329,7 @@
         },
         {
             "id": "f688546e-70a5-5ff5-a776-1c6e43d76204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90316ec8-9e36-4abd-bf89-47227e58953a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90316ec8-9e36-4abd-bf89-47227e58953a.jpg?1",
             "name": "Clifftop Retreat",
             "text": "Clifftop Retreat enters the battlefield tapped unless you control a Mountain or a Plains.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -18364,7 +18364,7 @@
         },
         {
             "id": "b98cd7f2-dd9d-565d-82b9-475e1cfc16da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c4a65-9fe1-4f08-89a8-942c55da4929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/459c4a65-9fe1-4f08-89a8-942c55da4929.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "{1}, {T}: Add {U}{B}.",
             "colours": [],
@@ -18399,7 +18399,7 @@
         },
         {
             "id": "c8743336-a507-500a-957f-6a3fc747b7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119b5bb5-6de4-4a66-ba22-14e19d02942f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119b5bb5-6de4-4a66-ba22-14e19d02942f.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -18434,7 +18434,7 @@
         },
         {
             "id": "0819a244-6a88-56cb-b1d7-9d34a1a068e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301ab57-e06e-4965-8182-a048fc98a01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0301ab57-e06e-4965-8182-a048fc98a01e.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -18469,7 +18469,7 @@
         },
         {
             "id": "c3fd4b9a-7d7d-5153-8d73-71f7ad8df4a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536e502-30c1-4107-aaec-1690cfa78ce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536e502-30c1-4107-aaec-1690cfa78ce8.jpg?1",
             "name": "Exotic Orchard",
             "text": "{T}: Add one mana of any color that a land an opponent controls could produce.",
             "colours": [],
@@ -18501,7 +18501,7 @@
         },
         {
             "id": "45dedc3c-538d-518f-833f-47984bc0d46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d5841a-52b4-4a29-a929-2b0e7a1395c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d5841a-52b4-4a29-a929-2b0e7a1395c0.jpg?1",
             "name": "Fetid Pools",
             "text": "Fetid Pools enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18539,7 +18539,7 @@
         },
         {
             "id": "e19f7de1-b523-55dd-bef9-649bd9b32ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73ef22-e219-4b4c-8ff3-c0cfce8e6fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b73ef22-e219-4b4c-8ff3-c0cfce8e6fd9.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -18574,7 +18574,7 @@
         },
         {
             "id": "17814f1e-0368-59fc-90ca-e63662ea8573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99085218-b635-47b3-9f0d-211feb70faa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99085218-b635-47b3-9f0d-211feb70faa1.jpg?1",
             "name": "Hinterland Harbor",
             "text": "Hinterland Harbor enters the battlefield tapped unless you control a Forest or an Island.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -18609,7 +18609,7 @@
         },
         {
             "id": "f9caea59-7e29-5c17-ba3b-ffa5612e3c74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff76774-678f-41ac-9601-d5d8c4096234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff76774-678f-41ac-9601-d5d8c4096234.jpg?1",
             "name": "Irrigated Farmland",
             "text": "Irrigated Farmland enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18647,7 +18647,7 @@
         },
         {
             "id": "94362b63-0150-5ca6-9602-46670a90d82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f947e35-b994-4eb3-886e-f767f9542298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f947e35-b994-4eb3-886e-f767f9542298.jpg?1",
             "name": "Isolated Chapel",
             "text": "Isolated Chapel enters the battlefield tapped unless you control a Plains or a Swamp.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -18682,7 +18682,7 @@
         },
         {
             "id": "51649504-bdfc-507e-b8c1-adbc9f7d50ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090cecfe-bf79-4547-965b-3567783e7d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090cecfe-bf79-4547-965b-3567783e7d11.jpg?1",
             "name": "Mossfire Valley",
             "text": "{1}, {T}: Add {R}{G}.",
             "colours": [],
@@ -18717,7 +18717,7 @@
         },
         {
             "id": "98062036-5a92-5e07-9c0c-5476d7f41734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39f4c02-0879-4793-b1cf-95165d2f73bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39f4c02-0879-4793-b1cf-95165d2f73bf.jpg?1",
             "name": "Nesting Grounds",
             "text": "{T}: Add {C}.\n{1}, {T}: Move a counter from target permanent you control onto another target permanent. Activate only as a sorcery.",
             "colours": [],
@@ -18749,7 +18749,7 @@
         },
         {
             "id": "ad520adc-83b3-53e3-b059-6d2f75a0628d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a75617-f7d6-44fd-a294-74efd9e0d219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a75617-f7d6-44fd-a294-74efd9e0d219.jpg?1",
             "name": "Prairie Stream",
             "text": "Prairie Stream enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -18787,7 +18787,7 @@
         },
         {
             "id": "8b900a81-907e-5651-8874-f41fa1d3be02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e3078-eb36-4125-9511-1f542a2af740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e3078-eb36-4125-9511-1f542a2af740.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -18822,7 +18822,7 @@
         },
         {
             "id": "9d03c347-9910-5f87-8760-ef4088e20556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab57258f-60c3-46f8-af50-64a7165974e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab57258f-60c3-46f8-af50-64a7165974e6.jpg?1",
             "name": "Scattered Groves",
             "text": "Scattered Groves enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18860,7 +18860,7 @@
         },
         {
             "id": "bb12bfeb-b85f-58d8-8f16-07ad07a2db22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4759d1a6-2cb3-4bab-b001-6798be2c589b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4759d1a6-2cb3-4bab-b001-6798be2c589b.jpg?1",
             "name": "Scavenger Grounds",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all graveyards.",
             "colours": [],
@@ -18894,7 +18894,7 @@
         },
         {
             "id": "3d80ea1a-133b-5e46-9a1f-bf3b8313fd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533d161c-a0a1-460f-b658-87bc268a713a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533d161c-a0a1-460f-b658-87bc268a713a.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "{1}, {T}: Add {B}{R}.",
             "colours": [],
@@ -18929,7 +18929,7 @@
         },
         {
             "id": "4d2d35eb-a1d8-519b-9893-c95be7c72fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684058fa-ceef-41e7-abb5-23571ea07cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684058fa-ceef-41e7-abb5-23571ea07cc7.jpg?1",
             "name": "Sheltered Thicket",
             "text": "Sheltered Thicket enters the battlefield tapped.\nCycling {2}",
             "colours": [],
@@ -18967,7 +18967,7 @@
         },
         {
             "id": "f2e90245-8815-57e1-883c-ee7bee16a1c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261c9330-1d31-450b-b4c0-16e2581b8c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261c9330-1d31-450b-b4c0-16e2581b8c9b.jpg?1",
             "name": "Skycloud Expanse",
             "text": "{1}, {T}: Add {W}{U}.",
             "colours": [],
@@ -19002,7 +19002,7 @@
         },
         {
             "id": "fda711a3-0e4a-59b6-9451-e655fb612799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b6f3d8-59c6-45dd-bc50-9ae4982e1ef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b6f3d8-59c6-45dd-bc50-9ae4982e1ef9.jpg?1",
             "name": "Smoldering Marsh",
             "text": "Smoldering Marsh enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -19040,7 +19040,7 @@
         },
         {
             "id": "89fc7bc3-c6f4-5fab-a5de-02137553cac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e62a9d-67db-4ffa-ab08-3305e52f9362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e62a9d-67db-4ffa-ab08-3305e52f9362.jpg?1",
             "name": "Spire of Industry",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Activate only if you control an artifact.",
             "colours": [],
@@ -19072,7 +19072,7 @@
         },
         {
             "id": "dce22fd6-50c1-55a7-8529-ff5d25d933a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe65f24-3621-4139-b1cd-3343ae2d0119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe65f24-3621-4139-b1cd-3343ae2d0119.jpg?1",
             "name": "Sulfur Falls",
             "text": "Sulfur Falls enters the battlefield tapped unless you control an Island or a Mountain.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -19107,7 +19107,7 @@
         },
         {
             "id": "9f4911bb-2986-507b-947f-cb6b09be3f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3e41ad-c901-412c-9e05-1b43d062ed66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a3e41ad-c901-412c-9e05-1b43d062ed66.jpg?1",
             "name": "Sungrass Prairie",
             "text": "{1}, {T}: Add {G}{W}.",
             "colours": [],
@@ -19142,7 +19142,7 @@
         },
         {
             "id": "4385211a-99fe-50cf-82cb-df6381c4a563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c64bef5-67c2-4f8c-bc6d-0528650c5b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c64bef5-67c2-4f8c-bc6d-0528650c5b3a.jpg?1",
             "name": "Sunken Hollow",
             "text": "Sunken Hollow enters the battlefield tapped unless you control two or more basic lands.",
             "colours": [],
@@ -19180,7 +19180,7 @@
         },
         {
             "id": "6baa1f01-7d47-5d5b-b65e-d372f20c1779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8065c0-5286-4448-8fd5-07f2719c5218.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8065c0-5286-4448-8fd5-07f2719c5218.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -19215,7 +19215,7 @@
         },
         {
             "id": "ea77531f-dd52-56d0-b7bf-243008186064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef9db60-85d6-4008-9224-37caa5efb63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef9db60-85d6-4008-9224-37caa5efb63d.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -19250,7 +19250,7 @@
         },
         {
             "id": "a1d11de4-46b1-583d-b3f4-3b570fe2ebc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69598022-4ff6-42bc-a9b5-530803c841cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69598022-4ff6-42bc-a9b5-530803c841cc.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -19285,7 +19285,7 @@
         },
         {
             "id": "16233a61-35be-53c7-83ba-007f4abf5eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931f17f4-3fd4-45c4-b6e1-c9dee7e8f4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/931f17f4-3fd4-45c4-b6e1-c9dee7e8f4b1.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -19320,7 +19320,7 @@
         },
         {
             "id": "cf857115-9181-5631-bb9a-5f7224486a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b523ff-386a-42a9-a8b5-f18e5f4cca53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b523ff-386a-42a9-a8b5-f18e5f4cca53.jpg?1",
             "name": "Temple of Epiphany",
             "text": "Temple of Epiphany enters the battlefield tapped.\nWhen Temple of Epiphany enters the battlefield, scry 1.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -19355,7 +19355,7 @@
         },
         {
             "id": "28ea9906-fad0-5539-9fd2-51fb1207edfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e0586-d48e-4d0a-ac3b-870d605b8934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e0586-d48e-4d0a-ac3b-870d605b8934.jpg?1",
             "name": "Temple of Malady",
             "text": "Temple of Malady enters the battlefield tapped.\nWhen Temple of Malady enters the battlefield, scry 1.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -19390,7 +19390,7 @@
         },
         {
             "id": "7ef12029-84f1-54d0-a368-b0b21b9180de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d8a4eb-794c-49d1-bdd8-efc23932c6fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d8a4eb-794c-49d1-bdd8-efc23932c6fa.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -19425,7 +19425,7 @@
         },
         {
             "id": "9a7e5c29-2852-5a17-a4c9-431312fa67bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c038eb3-5b72-4120-a60a-5c43020934ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c038eb3-5b72-4120-a60a-5c43020934ac.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -19460,7 +19460,7 @@
         },
         {
             "id": "806141ed-3625-5b49-997b-e5c388c87408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd2f0f6-9e7b-4401-a760-0285b999365c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdd2f0f6-9e7b-4401-a760-0285b999365c.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -19495,7 +19495,7 @@
         },
         {
             "id": "99e5f23b-0259-5d0a-bec7-35d72b59c157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e505c0cc-eab3-4ee8-a659-73d6ccf075e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e505c0cc-eab3-4ee8-a659-73d6ccf075e7.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -19530,7 +19530,7 @@
         },
         {
             "id": "ddc497c1-4bb8-5cec-87ae-afa4fee97e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36d0f53-faee-40ba-8f91-8e96549af4ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36d0f53-faee-40ba-8f91-8e96549af4ad.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -19565,7 +19565,7 @@
         },
         {
             "id": "b36998fd-a9cb-5322-9b13-0301b6141074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb08369-1e4d-4182-9978-808cc9b79a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb08369-1e4d-4182-9978-808cc9b79a40.jpg?1",
             "name": "Treasure Vault",
             "text": "{T}: Add {C}.\n{X}{X}, {T}, Sacrifice Treasure Vault: Create X Treasure tokens.",
             "colours": [],
@@ -19598,7 +19598,7 @@
         },
         {
             "id": "586e6593-5662-5d38-b8f4-349a1592f07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b46df-c3ff-432f-9960-30451d5f60fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b5b46df-c3ff-432f-9960-30451d5f60fa.jpg?1",
             "name": "Windbrisk Heights",
             "text": "Hideaway 4\nWindbrisk Heights enters the battlefield tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
             "colours": [],
@@ -19632,7 +19632,7 @@
         },
         {
             "id": "20dd0b5d-07e2-5661-a9bb-6d978afe42ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e193aa3b-5db3-4c71-bc38-8834e62f5a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e193aa3b-5db3-4c71-bc38-8834e62f5a05.jpg?1",
             "name": "Woodland Cemetery",
             "text": "Woodland Cemetery enters the battlefield tapped unless you control a Swamp or a Forest.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -19667,7 +19667,7 @@
         },
         {
             "id": "c0513aec-ae17-5bca-825a-816ba32ed2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca55a2-2824-41b7-8ce7-596ae028a5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aca55a2-2824-41b7-8ce7-596ae028a5b2.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "",
             "colours": [
@@ -19712,7 +19712,7 @@
         },
         {
             "id": "6f585a57-fc5a-567e-8a5e-5f1b35ff4188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dae1fc-804c-499f-b3cd-1a5f3f25c1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dae1fc-804c-499f-b3cd-1a5f3f25c1ce.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "",
             "colours": [
@@ -19756,7 +19756,7 @@
         },
         {
             "id": "06ffa86a-1497-5f85-981c-a59bd0fd4ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b582ba-5216-48d7-9306-5c717e81c9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b582ba-5216-48d7-9306-5c717e81c9b8.jpg?1",
             "name": "Dr. Madison Li",
             "text": "",
             "colours": [
@@ -19801,7 +19801,7 @@
         },
         {
             "id": "185aef00-a64d-52e8-b9a2-6798f7e778e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a1d611-6f5f-40af-8ca3-b9dc619111eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a1d611-6f5f-40af-8ca3-b9dc619111eb.jpg?1",
             "name": "The Wise Mothman",
             "text": "",
             "colours": [
@@ -19846,7 +19846,7 @@
         },
         {
             "id": "ae250338-ea02-5492-b23a-2a6f8fefd994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7f0363-bf56-48fb-9cf9-68b7e8888ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7f0363-bf56-48fb-9cf9-68b7e8888ce3.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "",
             "colours": [
@@ -19890,7 +19890,7 @@
         },
         {
             "id": "230153d7-f9bb-5b3e-8fde-3858e4d6244c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21707502-8edf-4c0c-9df3-55f843d45256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21707502-8edf-4c0c-9df3-55f843d45256.jpg?1",
             "name": "The Master, Transcendent",
             "text": "",
             "colours": [
@@ -19934,7 +19934,7 @@
         },
         {
             "id": "d26b27c4-3706-59d0-a1ca-ae8a2b9a26d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000f379-bfd6-4d6c-bd8c-82bc0e13caa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d000f379-bfd6-4d6c-bd8c-82bc0e13caa6.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "",
             "colours": [
@@ -19978,7 +19978,7 @@
         },
         {
             "id": "0a637d38-417c-5e0d-868e-1b15966b1c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc78029-39a6-489d-9571-5ae8d90893e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc78029-39a6-489d-9571-5ae8d90893e3.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "",
             "colours": [
@@ -20022,7 +20022,7 @@
         },
         {
             "id": "05c27681-ad35-5d5c-9509-365a296b70be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c569396f-99cf-44c5-bb64-f59a4891efd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c569396f-99cf-44c5-bb64-f59a4891efd1.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "",
             "colours": [
@@ -20062,7 +20062,7 @@
         },
         {
             "id": "00fc9193-af3c-523d-95de-85dd8d94094e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f9180-9cb5-4b0c-8e51-b7080c4d1184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7f9180-9cb5-4b0c-8e51-b7080c4d1184.jpg?1",
             "name": "Automated Assembly Line",
             "text": "",
             "colours": [
@@ -20097,7 +20097,7 @@
         },
         {
             "id": "e7004cda-fb4b-5296-bf6e-92ef9af7d4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883efc5f-be03-4cca-8a26-8223d22f33f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883efc5f-be03-4cca-8a26-8223d22f33f3.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "",
             "colours": [
@@ -20132,7 +20132,7 @@
         },
         {
             "id": "8af35dcd-1e67-54b0-853b-f88d26f400ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0949fcab-5aa2-4277-bf4d-f5855a863cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0949fcab-5aa2-4277-bf4d-f5855a863cb6.jpg?1",
             "name": "Brotherhood Outcast",
             "text": "",
             "colours": [
@@ -20168,7 +20168,7 @@
         },
         {
             "id": "5f03b20a-89d1-5842-a934-354a39d6bc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147ba707-c8ef-45ef-ba9e-dff954f6fe98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147ba707-c8ef-45ef-ba9e-dff954f6fe98.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "",
             "colours": [
@@ -20206,7 +20206,7 @@
         },
         {
             "id": "23a6937b-18b8-5e71-8a2a-0ed9849e3b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a56b5c-1aea-4f05-80eb-891249bec62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a56b5c-1aea-4f05-80eb-891249bec62a.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "",
             "colours": [
@@ -20246,7 +20246,7 @@
         },
         {
             "id": "a1571cf5-e1d4-5def-ab03-910f66ff9f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63259e39-7267-465e-8600-9104c34bfcba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63259e39-7267-465e-8600-9104c34bfcba.jpg?1",
             "name": "Commander Sofia Daguerre",
             "text": "",
             "colours": [
@@ -20284,7 +20284,7 @@
         },
         {
             "id": "4f63bc96-a9fa-5eb1-a48d-b23ccc8af850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d130be-bda5-4ceb-b434-73d1aae9dcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d130be-bda5-4ceb-b434-73d1aae9dcb0.jpg?1",
             "name": "Gary Clone",
             "text": "",
             "colours": [
@@ -20320,7 +20320,7 @@
         },
         {
             "id": "90f232a5-4ae1-5d17-9849-73394574c958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427cdbb-887c-492f-8bab-6002351d1e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427cdbb-887c-492f-8bab-6002351d1e68.jpg?1",
             "name": "Idolized",
             "text": "",
             "colours": [
@@ -20357,7 +20357,7 @@
         },
         {
             "id": "3e43ab20-60bb-52f1-9029-4faed266eb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a36e45-3da1-4330-a0a2-b68be3a42478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a36e45-3da1-4330-a0a2-b68be3a42478.jpg?1",
             "name": "Overencumbered",
             "text": "",
             "colours": [
@@ -20394,7 +20394,7 @@
         },
         {
             "id": "bca6ecf7-f608-5239-9aeb-0a6dee8347d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf809b-b6e2-4513-9865-228679b9de43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf809b-b6e2-4513-9865-228679b9de43.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "",
             "colours": [
@@ -20434,7 +20434,7 @@
         },
         {
             "id": "0de78894-e014-55ed-a9bc-448ede4d0964",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05d535-e457-40f1-8496-9a38e7023ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba05d535-e457-40f1-8496-9a38e7023ce4.jpg?1",
             "name": "Paladin Danse, Steel Maverick",
             "text": "",
             "colours": [
@@ -20473,7 +20473,7 @@
         },
         {
             "id": "4bd14744-9a19-53f3-8236-8ece2dcb436e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461e2ddb-1d1f-4ac3-ae06-dc2f613e8564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/461e2ddb-1d1f-4ac3-ae06-dc2f613e8564.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "",
             "colours": [
@@ -20510,7 +20510,7 @@
         },
         {
             "id": "70c71b7e-9cf0-56d0-80b1-18aab47f82db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a4d4fb-d55f-4a75-94bc-e5e27cc443a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a4d4fb-d55f-4a75-94bc-e5e27cc443a6.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "",
             "colours": [
@@ -20549,7 +20549,7 @@
         },
         {
             "id": "3a10d1b5-50cc-53ac-b43f-00edf28d6c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eee88d-9866-4fc3-8d7e-5f9f364af482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3eee88d-9866-4fc3-8d7e-5f9f364af482.jpg?1",
             "name": "Securitron Squadron",
             "text": "",
             "colours": [
@@ -20587,7 +20587,7 @@
         },
         {
             "id": "205872d4-fe96-5530-82ec-5683180910af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2cac9-e3b7-4cdf-9d61-3970bef64a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a2cac9-e3b7-4cdf-9d61-3970bef64a08.jpg?1",
             "name": "Sentry Bot",
             "text": "",
             "colours": [
@@ -20625,7 +20625,7 @@
         },
         {
             "id": "73a256e7-c75e-55e8-b095-31233f5126b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b28085-0274-457b-955f-a853f8c6ccba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b28085-0274-457b-955f-a853f8c6ccba.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "",
             "colours": [
@@ -20665,7 +20665,7 @@
         },
         {
             "id": "404128a3-313d-5d26-a7f9-0e21f6fb9a04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e537f1ab-8c76-436a-8928-8acccf8d00e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e537f1ab-8c76-436a-8928-8acccf8d00e6.jpg?1",
             "name": "Vault 13: Dweller's Journey",
             "text": "",
             "colours": [
@@ -20700,7 +20700,7 @@
         },
         {
             "id": "0dc16263-717d-5fa4-9d03-446c2e46024d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77cb40e-1feb-49e5-ac56-d0f9df321480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77cb40e-1feb-49e5-ac56-d0f9df321480.jpg?1",
             "name": "Vault 75: Middle School",
             "text": "",
             "colours": [
@@ -20735,7 +20735,7 @@
         },
         {
             "id": "c34e9ccc-3ff3-536e-8323-85efdc5cf924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741caee0-03c7-4b72-8f71-234e66eb6609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741caee0-03c7-4b72-8f71-234e66eb6609.jpg?1",
             "name": "Vault 101: Birthday Party",
             "text": "",
             "colours": [
@@ -20770,7 +20770,7 @@
         },
         {
             "id": "b410135e-43bc-5da2-9adf-04e7184e5940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882551c2-c891-4a66-aac7-08612c9fc416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882551c2-c891-4a66-aac7-08612c9fc416.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "",
             "colours": [
@@ -20810,7 +20810,7 @@
         },
         {
             "id": "b6e87977-fd7e-5de0-a29d-c596f967ffaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7fce3a-1432-4b96-8bf0-34cbe3cea39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7fce3a-1432-4b96-8bf0-34cbe3cea39b.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "",
             "colours": [
@@ -20850,7 +20850,7 @@
         },
         {
             "id": "17fef03f-7628-5eb1-bc23-d8f3a7a9423a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -20890,7 +20890,7 @@
         },
         {
             "id": "1843601c-b046-522a-8e32-b971c0a1ccc6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/d/6d0679d4-42ce-4793-a63d-3d797abdcdbb.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -20927,7 +20927,7 @@
         },
         {
             "id": "4112d4eb-9a15-5339-82ba-8b44fcdbdf47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b8573d-1e31-4af8-846f-ea895f039a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b8573d-1e31-4af8-846f-ea895f039a42.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "",
             "colours": [
@@ -20968,7 +20968,7 @@
         },
         {
             "id": "d6bc4368-40c3-54b1-81ba-7a950efa2834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46aadeb3-25cb-434f-826c-5b3ea406a7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46aadeb3-25cb-434f-826c-5b3ea406a7cf.jpg?1",
             "name": "Mirelurk Queen",
             "text": "",
             "colours": [
@@ -21006,7 +21006,7 @@
         },
         {
             "id": "c22fb7e9-771f-5e36-8544-7de640d37878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea947462-b8d0-4279-99d9-8a1fa1b31269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea947462-b8d0-4279-99d9-8a1fa1b31269.jpg?1",
             "name": "Nerd Rage",
             "text": "",
             "colours": [
@@ -21041,7 +21041,7 @@
         },
         {
             "id": "44c1c780-6cd1-5dd1-ac1d-69cde0c28714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930e5715-d704-4489-b3dc-a2e44c9beeb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930e5715-d704-4489-b3dc-a2e44c9beeb1.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "",
             "colours": [
@@ -21082,7 +21082,7 @@
         },
         {
             "id": "e8ae80e6-efad-54d5-ad10-646fbffd956d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c836d5df-9a1a-43ce-90db-067b32e1f4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c836d5df-9a1a-43ce-90db-067b32e1f4d4.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "",
             "colours": [
@@ -21122,7 +21122,7 @@
         },
         {
             "id": "66636f10-dbea-52d6-ac81-cbac92131d16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796f354-5836-438c-a6c3-b688028e5016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5796f354-5836-438c-a6c3-b688028e5016.jpg?1",
             "name": "Radstorm",
             "text": "",
             "colours": [
@@ -21157,7 +21157,7 @@
         },
         {
             "id": "6d8085ea-661c-557c-937e-99951972e945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69865b14-d016-47a7-a0c9-f61319ae92d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69865b14-d016-47a7-a0c9-f61319ae92d2.jpg?1",
             "name": "Robobrain War Mind",
             "text": "",
             "colours": [
@@ -21193,7 +21193,7 @@
         },
         {
             "id": "21db2675-7c24-5969-abc4-a71a22db8ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2af4139-6990-413d-b9fe-cb4ad33579d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2af4139-6990-413d-b9fe-cb4ad33579d3.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "",
             "colours": [
@@ -21228,7 +21228,7 @@
         },
         {
             "id": "afb74439-ff23-5341-88b9-2821f8e79381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ab62f4-fc9c-4f81-b363-45fc41227d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ab62f4-fc9c-4f81-b363-45fc41227d20.jpg?1",
             "name": "Synth Infiltrator",
             "text": "",
             "colours": [
@@ -21266,7 +21266,7 @@
         },
         {
             "id": "3edf2563-e630-5eb5-a335-25b6eec18922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7cad10-1e0e-4b01-9fa7-94f048034a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7cad10-1e0e-4b01-9fa7-94f048034a10.jpg?1",
             "name": "Vexing Radgull",
             "text": "",
             "colours": [
@@ -21302,7 +21302,7 @@
         },
         {
             "id": "0976ffad-ee2b-572f-b900-8f09ea905a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89cd297-f44c-4d17-b714-327b7e382dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89cd297-f44c-4d17-b714-327b7e382dd3.jpg?1",
             "name": "Bloatfly Swarm",
             "text": "",
             "colours": [
@@ -21338,7 +21338,7 @@
         },
         {
             "id": "f16368f9-4f2b-5280-b941-2bcf8d7b99c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edf6c39-6519-4b3e-afed-5e9ab6c4c572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8edf6c39-6519-4b3e-afed-5e9ab6c4c572.jpg?1",
             "name": "Butch DeLoria, Tunnel Snake",
             "text": "",
             "colours": [
@@ -21376,7 +21376,7 @@
         },
         {
             "id": "adc1ed42-a83a-5970-b90d-d2be9b0818c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2addaa0e-6476-405b-b4be-9040b47f246b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2addaa0e-6476-405b-b4be-9040b47f246b.jpg?1",
             "name": "Feral Ghoul",
             "text": "",
             "colours": [
@@ -21414,7 +21414,7 @@
         },
         {
             "id": "9b8d93eb-820a-5180-a5d2-ff48286ed933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72fd70-211c-4350-8bd1-33929079383c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72fd70-211c-4350-8bd1-33929079383c.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "",
             "colours": [
@@ -21455,7 +21455,7 @@
         },
         {
             "id": "82f421d2-0acc-569e-a64a-e11e3362b3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a4355-5645-4af3-a16a-7fe49d0d5aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18a4355-5645-4af3-a16a-7fe49d0d5aab.jpg?1",
             "name": "Infesting Radroach",
             "text": "",
             "colours": [
@@ -21491,7 +21491,7 @@
         },
         {
             "id": "3c0a73a1-1181-5919-9faa-cb04011d550e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528897b3-4a26-447a-896c-5cf4041f299c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/528897b3-4a26-447a-896c-5cf4041f299c.jpg?1",
             "name": "Nuclear Fallout",
             "text": "",
             "colours": [
@@ -21526,7 +21526,7 @@
         },
         {
             "id": "05602db4-a8fb-5f4d-ad78-563051e95f73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d866e7-fc21-4c96-9c3f-0cef8e7b09ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d866e7-fc21-4c96-9c3f-0cef8e7b09ed.jpg?1",
             "name": "Ruthless Radrat",
             "text": "",
             "colours": [
@@ -21562,7 +21562,7 @@
         },
         {
             "id": "4ff22f75-2c2b-5ab9-9cb7-2af68348b155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e5e6b-ebde-4133-9379-a4c882304651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e5e6b-ebde-4133-9379-a4c882304651.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "",
             "colours": [
@@ -21600,7 +21600,7 @@
         },
         {
             "id": "5a5a3bc2-49c7-5f2a-bba7-c2f171c4f7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89d6cd-0f61-4aee-b4a5-5ff6cfac037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce89d6cd-0f61-4aee-b4a5-5ff6cfac037a.jpg?1",
             "name": "V.A.T.S.",
             "text": "",
             "colours": [
@@ -21635,7 +21635,7 @@
         },
         {
             "id": "e1d2ccbe-f011-57c6-8948-407bbb1b649f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961d090c-9548-42e1-abd2-34ba225a46c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961d090c-9548-42e1-abd2-34ba225a46c2.jpg?1",
             "name": "Vault 12: The Necropolis",
             "text": "",
             "colours": [
@@ -21670,7 +21670,7 @@
         },
         {
             "id": "3375865c-72cf-5a60-bb46-d868557cfc8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cb1ec-de98-4a82-b872-9e62ee0198d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/071cb1ec-de98-4a82-b872-9e62ee0198d7.jpg?1",
             "name": "Wasteland Raider",
             "text": "",
             "colours": [
@@ -21708,7 +21708,7 @@
         },
         {
             "id": "86ec37d2-4ee6-5143-87ca-5b743626263b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd34f1bc-1386-45a5-a229-a948bbe373c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd34f1bc-1386-45a5-a229-a948bbe373c5.jpg?1",
             "name": "Acquired Mutation",
             "text": "",
             "colours": [
@@ -21743,7 +21743,7 @@
         },
         {
             "id": "335c4795-c8a9-5249-9d4d-dd947e76730c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d663f6-c76c-42ee-b5aa-db8aa1aaf4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d663f6-c76c-42ee-b5aa-db8aa1aaf4c4.jpg?1",
             "name": "Assaultron Dominator",
             "text": "",
             "colours": [
@@ -21781,7 +21781,7 @@
         },
         {
             "id": "2efcdf4c-350e-56a0-b877-764cac04a7b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d8bfb-aaf0-41f3-a000-1df6363fb25c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4d8bfb-aaf0-41f3-a000-1df6363fb25c.jpg?1",
             "name": "Bottle-Cap Blast",
             "text": "",
             "colours": [
@@ -21814,7 +21814,7 @@
         },
         {
             "id": "81b29916-bf01-5941-8917-8ceec90382ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f12abc-34e9-486a-a160-1a99e3632403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f12abc-34e9-486a-a160-1a99e3632403.jpg?1",
             "name": "Crimson Caravaneer",
             "text": "",
             "colours": [
@@ -21850,7 +21850,7 @@
         },
         {
             "id": "3729b4e9-372a-5eb6-bc9f-b760d4fb4fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ee8d5a-8f8d-44fe-a129-5208d14d1212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8ee8d5a-8f8d-44fe-a129-5208d14d1212.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "",
             "colours": [
@@ -21890,7 +21890,7 @@
         },
         {
             "id": "2a3b2818-590b-524c-8c32-114a8cf3df77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93d5766-5cd6-45a8-8fa0-03391e274908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93d5766-5cd6-45a8-8fa0-03391e274908.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "",
             "colours": [
@@ -21927,7 +21927,7 @@
         },
         {
             "id": "1efe7a99-e68e-5317-b5bb-0a6079da7a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be12244-5e1f-4e5e-bd4b-ac0bcd74724b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be12244-5e1f-4e5e-bd4b-ac0bcd74724b.jpg?1",
             "name": "Ian the Reckless",
             "text": "",
             "colours": [
@@ -21965,7 +21965,7 @@
         },
         {
             "id": "221bcdac-8d58-5380-bf3c-52818b3cbd01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b718ad-4b42-414f-ad9a-5dffad959469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b718ad-4b42-414f-ad9a-5dffad959469.jpg?1",
             "name": "Junk Jet",
             "text": "",
             "colours": [
@@ -22002,7 +22002,7 @@
         },
         {
             "id": "e9e746f1-fef3-5c50-afc6-38a0faae0640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c90a103-e42f-4d12-848b-cf00f94ba83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c90a103-e42f-4d12-848b-cf00f94ba83c.jpg?1",
             "name": "Megaton's Fate",
             "text": "",
             "colours": [
@@ -22037,7 +22037,7 @@
         },
         {
             "id": "ffc452a6-182e-543c-a188-9ff947a7f725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ce5d9-8aaa-4982-85d7-36242d4805d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4ce5d9-8aaa-4982-85d7-36242d4805d2.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "",
             "colours": [
@@ -22077,7 +22077,7 @@
         },
         {
             "id": "e66ec9d6-01bc-5f5b-899b-1b65f9487fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798c9e70-c30c-4c69-99e5-f8e90e787e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798c9e70-c30c-4c69-99e5-f8e90e787e6a.jpg?1",
             "name": "Mysterious Stranger",
             "text": "",
             "colours": [
@@ -22115,7 +22115,7 @@
         },
         {
             "id": "64a794df-15d5-5c37-96f5-b7a6e84a9a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12194b-b9c4-47ba-853f-60a1bcf2c279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12194b-b9c4-47ba-853f-60a1bcf2c279.jpg?1",
             "name": "Plasma Caster",
             "text": "",
             "colours": [
@@ -22152,7 +22152,7 @@
         },
         {
             "id": "03f01a80-e070-53dc-a815-9039ed85d49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ff636a-f681-4164-acb5-61aa91014645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ff636a-f681-4164-acb5-61aa91014645.jpg?1",
             "name": "Powder Ganger",
             "text": "",
             "colours": [
@@ -22190,7 +22190,7 @@
         },
         {
             "id": "7d824125-2e22-59ff-9b14-8af85767da79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5163087f-163d-4e5e-ae6b-aca192b4358b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5163087f-163d-4e5e-ae6b-aca192b4358b.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "",
             "colours": [
@@ -22230,7 +22230,7 @@
         },
         {
             "id": "38dc2f8a-9e3f-5edb-a1b7-e652ba637096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d641b-7740-471f-bf93-671858ea720f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084d641b-7740-471f-bf93-671858ea720f.jpg?1",
             "name": "Synth Eradicator",
             "text": "",
             "colours": [
@@ -22269,7 +22269,7 @@
         },
         {
             "id": "d3143d7d-9a81-512e-9fde-3deaa76159f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747df6bf-9605-47fa-b2a0-9457d0e4db19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747df6bf-9605-47fa-b2a0-9457d0e4db19.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "",
             "colours": [
@@ -22307,7 +22307,7 @@
         },
         {
             "id": "4e41c958-349c-5bca-a320-46a99f464392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e60ea-4192-4388-8ad0-e5b3339eb872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4e60ea-4192-4388-8ad0-e5b3339eb872.jpg?1",
             "name": "Vault 21: House Gambit",
             "text": "",
             "colours": [
@@ -22342,7 +22342,7 @@
         },
         {
             "id": "9638ac7c-c3b5-5738-b240-0b6c5b158a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951f76d2-2ad2-4b9a-b47a-0cdc7567092c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/951f76d2-2ad2-4b9a-b47a-0cdc7567092c.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "",
             "colours": [
@@ -22383,7 +22383,7 @@
         },
         {
             "id": "d545eae2-04f3-54ab-abba-54c848335e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b15caa8-4d33-4f1e-bf4e-8cc749c3cb19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b15caa8-4d33-4f1e-bf4e-8cc749c3cb19.jpg?1",
             "name": "Wild Wasteland",
             "text": "",
             "colours": [
@@ -22418,7 +22418,7 @@
         },
         {
             "id": "90bc37a9-aff5-50b9-abb5-d44e7df68143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a34ff7-4e2e-4773-a0c4-10526e7369eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a34ff7-4e2e-4773-a0c4-10526e7369eb.jpg?1",
             "name": "Animal Friend",
             "text": "",
             "colours": [
@@ -22455,7 +22455,7 @@
         },
         {
             "id": "9bbf2662-77a1-54a6-a158-ed8af13383e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e27f186-4ae0-4ee2-9a3c-7fb62072c56b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e27f186-4ae0-4ee2-9a3c-7fb62072c56b.jpg?1",
             "name": "Bighorner Rancher",
             "text": "",
             "colours": [
@@ -22491,7 +22491,7 @@
         },
         {
             "id": "10c6cc8b-6df3-5adb-9e69-555c134a9654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2245de3-4438-433d-8a61-b16acc4e25ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2245de3-4438-433d-8a61-b16acc4e25ac.jpg?1",
             "name": "Break Down",
             "text": "",
             "colours": [
@@ -22524,7 +22524,7 @@
         },
         {
             "id": "ed466699-4b8f-5b68-ad35-f92b88d1ebac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4879129a-33db-479f-a24a-bfe92b3541a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4879129a-33db-479f-a24a-bfe92b3541a0.jpg?1",
             "name": "Cathedral Acolyte",
             "text": "",
             "colours": [
@@ -22560,7 +22560,7 @@
         },
         {
             "id": "00d72f75-c46a-5301-82ce-2e48900c8317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b3537a-e44a-47ff-9687-c2172738aeed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b3537a-e44a-47ff-9687-c2172738aeed.jpg?1",
             "name": "Glowing One",
             "text": "",
             "colours": [
@@ -22596,7 +22596,7 @@
         },
         {
             "id": "acc6b906-7149-552e-8ce9-6103e1c055de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c5337-31b2-4f1e-8b33-448c879367fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2c5337-31b2-4f1e-8b33-448c879367fd.jpg?1",
             "name": "Gunner Conscript",
             "text": "",
             "colours": [
@@ -22632,7 +22632,7 @@
         },
         {
             "id": "c05bee58-c7ff-51ff-890f-d573db8d0f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5f93d2-2edc-4a97-9a51-b276d1706e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5f93d2-2edc-4a97-9a51-b276d1706e7d.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "",
             "colours": [
@@ -22672,7 +22672,7 @@
         },
         {
             "id": "bf71f629-905c-5df9-b751-c02e323bf4b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438066d-32df-42bb-91e7-f7be9ad3b86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438066d-32df-42bb-91e7-f7be9ad3b86a.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "",
             "colours": [
@@ -22712,7 +22712,7 @@
         },
         {
             "id": "4c8d0825-0c59-50fb-8822-37ecb365668f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cad35-c10a-4b7e-bfd4-0295c6032736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802cad35-c10a-4b7e-bfd4-0295c6032736.jpg?1",
             "name": "Lumbering Megasloth",
             "text": "",
             "colours": [
@@ -22748,7 +22748,7 @@
         },
         {
             "id": "8d57c5ec-d3e5-565f-ac96-ff9d6d30b2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171b2a6-0052-4329-9c9f-5c4d7f2c2eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171b2a6-0052-4329-9c9f-5c4d7f2c2eba.jpg?1",
             "name": "Power Fist",
             "text": "",
             "colours": [
@@ -22785,7 +22785,7 @@
         },
         {
             "id": "367f9568-a7a2-52d7-9676-f196f2cbe20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ab3da0-96b5-4b8a-bcc1-69824945d043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ab3da0-96b5-4b8a-bcc1-69824945d043.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "",
             "colours": [
@@ -22823,7 +22823,7 @@
         },
         {
             "id": "c3a9ecc9-91df-5c0d-8684-410237e73a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad5795c-a7be-4267-a196-f57d5537081c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad5795c-a7be-4267-a196-f57d5537081c.jpg?1",
             "name": "Strong Back",
             "text": "",
             "colours": [
@@ -22860,7 +22860,7 @@
         },
         {
             "id": "73066f99-c0bc-5f71-b56e-46f011f2229d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3623d4a1-7364-4177-b431-2a4dc70dec3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3623d4a1-7364-4177-b431-2a4dc70dec3d.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "",
             "colours": [
@@ -22900,7 +22900,7 @@
         },
         {
             "id": "07d52daa-cfe5-5eab-925b-68db1382e0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d05043f-9cbb-40e2-86b8-ad28247879e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d05043f-9cbb-40e2-86b8-ad28247879e2.jpg?1",
             "name": "Super Mutant Scavenger",
             "text": "",
             "colours": [
@@ -22936,7 +22936,7 @@
         },
         {
             "id": "5bf1dbcb-81c6-5ac0-9a6c-b62e93ce91b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86a7a14-6e24-4b98-a757-d0ea05055946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86a7a14-6e24-4b98-a757-d0ea05055946.jpg?1",
             "name": "Tato Farmer",
             "text": "",
             "colours": [
@@ -22975,7 +22975,7 @@
         },
         {
             "id": "8050524e-cb22-5a61-b68b-0b63cafe222d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04f9dde-d9ea-4a6e-9fe5-8f019437db01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04f9dde-d9ea-4a6e-9fe5-8f019437db01.jpg?1",
             "name": "Watchful Radstag",
             "text": "",
             "colours": [
@@ -23013,7 +23013,7 @@
         },
         {
             "id": "311f5775-7656-585a-ae4a-69354b9fcc96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831a905-55c2-4d88-b7ec-463df05e4d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9831a905-55c2-4d88-b7ec-463df05e4d7a.jpg?1",
             "name": "Well Rested",
             "text": "",
             "colours": [
@@ -23048,7 +23048,7 @@
         },
         {
             "id": "2575382d-7c27-59f9-ba69-a7eb1f487433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2f624e-3d61-4582-9582-6c6cf558936e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2f624e-3d61-4582-9582-6c6cf558936e.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "",
             "colours": [
@@ -23090,7 +23090,7 @@
         },
         {
             "id": "9594226b-497b-5ff5-80cf-a3ecb08aa51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b645f84-4213-41ba-8860-332971606f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b645f84-4213-41ba-8860-332971606f26.jpg?1",
             "name": "Almost Perfect",
             "text": "",
             "colours": [
@@ -23129,7 +23129,7 @@
         },
         {
             "id": "af1e5f49-d6b4-5ac3-ad04-06c0ad43b363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00650b7-eaeb-4da1-948a-48cc97e58a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00650b7-eaeb-4da1-948a-48cc97e58a31.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "",
             "colours": [
@@ -23169,7 +23169,7 @@
         },
         {
             "id": "94c7967a-5305-5493-901e-ea356b8c0157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f49b-87ca-4ee3-a957-89cfe9716e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb14f49b-87ca-4ee3-a957-89cfe9716e31.jpg?1",
             "name": "Arcade Gannon",
             "text": "",
             "colours": [
@@ -23211,7 +23211,7 @@
         },
         {
             "id": "6166b610-4448-529d-ab32-807bb13a0abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67a3942-25ad-4008-8913-682704f7c501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c67a3942-25ad-4008-8913-682704f7c501.jpg?1",
             "name": "Armory Paladin",
             "text": "",
             "colours": [
@@ -23251,7 +23251,7 @@
         },
         {
             "id": "f35a6ce4-99f2-5be1-a4af-7fb5cfd9b369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238b4e8-72a6-4424-9165-d9e7275b9778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238b4e8-72a6-4424-9165-d9e7275b9778.jpg?1",
             "name": "Atomize",
             "text": "",
             "colours": [
@@ -23288,7 +23288,7 @@
         },
         {
             "id": "a4bfda31-f71b-554b-a066-96a2bdf94ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c37047-bf08-4ac1-92e7-609ab8ff6f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c37047-bf08-4ac1-92e7-609ab8ff6f43.jpg?1",
             "name": "Boomer Scrapper",
             "text": "",
             "colours": [
@@ -23328,7 +23328,7 @@
         },
         {
             "id": "44e45b95-9f58-580b-b5df-388602a4831b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcabc69-fe20-40ee-987e-afe1d42d78cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcabc69-fe20-40ee-987e-afe1d42d78cb.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "",
             "colours": [
@@ -23370,7 +23370,7 @@
         },
         {
             "id": "ea2ee85f-4c6a-5e4a-afec-306508476aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacd28e-4b44-4b5e-a58c-9cccae7a04c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccacd28e-4b44-4b5e-a58c-9cccae7a04c1.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "",
             "colours": [
@@ -23412,7 +23412,7 @@
         },
         {
             "id": "6550d1d1-455f-5867-95a8-72f796bf2962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a100e650-8a34-43af-b4a0-6595cfcd4a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a100e650-8a34-43af-b4a0-6595cfcd4a1b.jpg?1",
             "name": "Colonel Autumn",
             "text": "",
             "colours": [
@@ -23454,7 +23454,7 @@
         },
         {
             "id": "5c54017f-7f92-5596-9727-ec25a384e83a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd30bb4-790a-4c02-b7cb-fec60467dd89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd30bb4-790a-4c02-b7cb-fec60467dd89.jpg?1",
             "name": "Contaminated Drink",
             "text": "",
             "colours": [
@@ -23489,7 +23489,7 @@
         },
         {
             "id": "475d7a52-2359-5f7e-abaf-71d94e9fa26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc98779-5ee4-4169-8a98-02e0f63a599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc98779-5ee4-4169-8a98-02e0f63a599a.jpg?1",
             "name": "Craig Boone, Novac Guard",
             "text": "",
             "colours": [
@@ -23529,7 +23529,7 @@
         },
         {
             "id": "abd3f7ce-1d91-55f5-b647-11116abaa82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23145616-8f99-4269-8875-9bb7e24ace04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23145616-8f99-4269-8875-9bb7e24ace04.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "",
             "colours": [
@@ -23571,7 +23571,7 @@
         },
         {
             "id": "e2cdb646-f4f8-5a49-a12c-d1a34db442dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850d0a27-e6e4-4e11-bcd9-9c8253444624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/850d0a27-e6e4-4e11-bcd9-9c8253444624.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "",
             "colours": [
@@ -23613,7 +23613,7 @@
         },
         {
             "id": "c3c700eb-89a2-5bca-a7a7-aae9399061b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc8fe5-736c-4baf-bd0f-a0c95721225e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bc8fe5-736c-4baf-bd0f-a0c95721225e.jpg?1",
             "name": "Elder Owyn Lyons",
             "text": "",
             "colours": [
@@ -23653,7 +23653,7 @@
         },
         {
             "id": "32623bf9-3f08-59a0-938a-80b3b994efb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17762d3-b7d2-43c9-9983-046b9ec1d5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17762d3-b7d2-43c9-9983-046b9ec1d5df.jpg?1",
             "name": "Electrosiphon",
             "text": "",
             "colours": [
@@ -23690,7 +23690,7 @@
         },
         {
             "id": "44d69e1b-0290-5f6d-ae37-654dd2a66419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a392364-6045-4d1f-8ca9-61bbf5a277a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a392364-6045-4d1f-8ca9-61bbf5a277a3.jpg?1",
             "name": "Inventory Management",
             "text": "",
             "colours": [
@@ -23727,7 +23727,7 @@
         },
         {
             "id": "ddbcc9de-6bc2-5db7-939f-097e00f63db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d13d78-6094-40af-8c47-a4baacd5185f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d13d78-6094-40af-8c47-a4baacd5185f.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "",
             "colours": [
@@ -23769,7 +23769,7 @@
         },
         {
             "id": "8d4db5e1-00d7-5ccd-972f-b8b56f6a36fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522f45b-060b-4a77-9910-3c40e3b2de78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b522f45b-060b-4a77-9910-3c40e3b2de78.jpg?1",
             "name": "Legate Lanius, Caesar's Ace",
             "text": "",
             "colours": [
@@ -23809,7 +23809,7 @@
         },
         {
             "id": "581dd7ef-4e43-5b4d-8610-feb67ba39838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeccc970-6762-404f-a4d9-31c1aef80d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeccc970-6762-404f-a4d9-31c1aef80d22.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "",
             "colours": [
@@ -23851,7 +23851,7 @@
         },
         {
             "id": "dd4cc344-4196-5408-b8f3-a1cff0ae6d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79d6167-fdf3-4d3c-b90e-f1511ad75113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79d6167-fdf3-4d3c-b90e-f1511ad75113.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "",
             "colours": [
@@ -23893,7 +23893,7 @@
         },
         {
             "id": "434e5d6b-7c25-5185-98d7-1724af2f9c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55baad5-d0cb-44bc-aa8d-5dcd22a0605f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55baad5-d0cb-44bc-aa8d-5dcd22a0605f.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "",
             "colours": [
@@ -23935,7 +23935,7 @@
         },
         {
             "id": "4803cdf4-806c-5829-9bdc-5e49d0bd4876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e14f3b-e3fd-4975-94b7-654f14150d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e14f3b-e3fd-4975-94b7-654f14150d96.jpg?1",
             "name": "Mutational Advantage",
             "text": "",
             "colours": [
@@ -23972,7 +23972,7 @@
         },
         {
             "id": "abc6c0c1-7033-5495-bf6a-533d3443795d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323747a-1d2e-4f08-a788-afa4dda56c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2323747a-1d2e-4f08-a788-afa4dda56c13.jpg?1",
             "name": "Nightkin Ambusher",
             "text": "",
             "colours": [
@@ -24010,7 +24010,7 @@
         },
         {
             "id": "4b14d963-98f6-5ed3-9789-cfa605eaf00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c59808-ae7a-40c4-b4b5-970264fdd32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c59808-ae7a-40c4-b4b5-970264fdd32d.jpg?1",
             "name": "The Nipton Lottery",
             "text": "",
             "colours": [
@@ -24047,7 +24047,7 @@
         },
         {
             "id": "d1918f44-b018-540e-b3fd-15040f3f7d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f1540f-293c-401a-a8cc-d147334176de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21f1540f-293c-401a-a8cc-d147334176de.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "",
             "colours": [
@@ -24089,7 +24089,7 @@
         },
         {
             "id": "371927a6-d8bf-52b0-b576-d6f013b0a599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e240f7-b8e5-48c4-83fe-0efd559c9c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e240f7-b8e5-48c4-83fe-0efd559c9c9f.jpg?1",
             "name": "Raul, Trouble Shooter",
             "text": "",
             "colours": [
@@ -24130,7 +24130,7 @@
         },
         {
             "id": "746a7333-c274-5b53-894b-7a1fe09f1d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9956f3c2-992d-43c8-9c5a-ccb491bd0b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9956f3c2-992d-43c8-9c5a-ccb491bd0b5d.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "",
             "colours": [
@@ -24172,7 +24172,7 @@
         },
         {
             "id": "5aea6ade-18ed-5f04-833f-dae73ce5015f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e56e5a9-e1de-4879-9287-37d1c16d46dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e56e5a9-e1de-4879-9287-37d1c16d46dd.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "",
             "colours": [
@@ -24215,7 +24215,7 @@
         },
         {
             "id": "eb19655b-4867-58d5-a967-61348711c490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b296fe9-73ad-41b1-b8dc-5a34c7de9065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b296fe9-73ad-41b1-b8dc-5a34c7de9065.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "",
             "colours": [
@@ -24257,7 +24257,7 @@
         },
         {
             "id": "6ebe213f-fc61-5eef-b916-957ad4955fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1414e2-a43b-46b9-ba77-de9a9c50b0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1414e2-a43b-46b9-ba77-de9a9c50b0cf.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "",
             "colours": [
@@ -24299,7 +24299,7 @@
         },
         {
             "id": "1824e348-7e52-500b-9878-dffe18d61fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075f346e-4e2a-4424-b974-fdcf83b3ebfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075f346e-4e2a-4424-b974-fdcf83b3ebfc.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "",
             "colours": [
@@ -24341,7 +24341,7 @@
         },
         {
             "id": "e8ddac42-ef7f-5d1d-ae19-87c2ae48e89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375a3fb0-386d-40ba-97c0-534a6c289078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375a3fb0-386d-40ba-97c0-534a6c289078.jpg?1",
             "name": "Vault 11: Voter's Dilemma",
             "text": "",
             "colours": [
@@ -24378,7 +24378,7 @@
         },
         {
             "id": "4ccbeffa-2451-5736-a0d9-9a2ac4190175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383eb67-0b54-4c3d-b830-9340b457d5ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4383eb67-0b54-4c3d-b830-9340b457d5ae.jpg?1",
             "name": "Vault 87: Forced Evolution",
             "text": "",
             "colours": [
@@ -24415,7 +24415,7 @@
         },
         {
             "id": "1ce3c99e-ae12-5421-81a6-a64fb26b8909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93922262-f4db-4cdb-b6e5-bd05a1f9172c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93922262-f4db-4cdb-b6e5-bd05a1f9172c.jpg?1",
             "name": "Vault 112: Sadistic Simulation",
             "text": "",
             "colours": [
@@ -24452,7 +24452,7 @@
         },
         {
             "id": "d3f72c3e-c4da-5803-9716-ba7c40c04595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a015ab6-4eb3-42e3-bb19-a0668e9f7ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a015ab6-4eb3-42e3-bb19-a0668e9f7ff0.jpg?1",
             "name": "White Glove Gourmand",
             "text": "",
             "colours": [
@@ -24490,7 +24490,7 @@
         },
         {
             "id": "4ad006cc-05f2-5982-b215-c0d5bd6bb69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d94ede9-5125-48d9-a707-d7cf2f1b51af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d94ede9-5125-48d9-a707-d7cf2f1b51af.jpg?1",
             "name": "Young Deathclaws",
             "text": "",
             "colours": [
@@ -24528,7 +24528,7 @@
         },
         {
             "id": "0876bb17-c589-5cab-a151-547ce573a868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371ff49d-a382-4ff0-8849-aac6bc674248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371ff49d-a382-4ff0-8849-aac6bc674248.jpg?1",
             "name": "Agility Bobblehead",
             "text": "",
             "colours": [],
@@ -24560,7 +24560,7 @@
         },
         {
             "id": "0d7d6c1a-5e45-50f9-a8fc-10c8d5454f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ed63-2328-4a0f-8c36-3cdef967dc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d4ed63-2328-4a0f-8c36-3cdef967dc81.jpg?1",
             "name": "Behemoth of Vault 0",
             "text": "",
             "colours": [],
@@ -24592,7 +24592,7 @@
         },
         {
             "id": "3481116c-bf96-5441-8ddf-c94c0082c5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f19f53-dabd-4bbb-ba85-ba19d3ada1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f19f53-dabd-4bbb-ba85-ba19d3ada1e8.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "",
             "colours": [],
@@ -24625,7 +24625,7 @@
         },
         {
             "id": "79db72e4-2417-56ad-b509-b8605cc1ea53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6f12b-284d-4e81-8c8a-f481268422c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de6f12b-284d-4e81-8c8a-f481268422c2.jpg?1",
             "name": "C.A.M.P.",
             "text": "",
             "colours": [],
@@ -24656,7 +24656,7 @@
         },
         {
             "id": "c3c66a19-7f86-59a9-82a7-c76ef2640f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def088be-c2fe-46e4-8e3d-cccdabb4b8e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def088be-c2fe-46e4-8e3d-cccdabb4b8e6.jpg?1",
             "name": "Charisma Bobblehead",
             "text": "",
             "colours": [],
@@ -24688,7 +24688,7 @@
         },
         {
             "id": "725f1130-6c13-5d5f-a584-beba240aaba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726c514-1a82-4281-82bc-e543233e084d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726c514-1a82-4281-82bc-e543233e084d.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "",
             "colours": [],
@@ -24724,7 +24724,7 @@
         },
         {
             "id": "a2ac0f16-11a8-5835-9c4f-a27c171a8d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5dad34-a8c5-42de-b5b5-7537a681f126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5dad34-a8c5-42de-b5b5-7537a681f126.jpg?1",
             "name": "Endurance Bobblehead",
             "text": "",
             "colours": [],
@@ -24756,7 +24756,7 @@
         },
         {
             "id": "7ccf1cce-1835-57bc-bc5f-61abaf43c0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3000197-dfe4-48d6-be21-0f408fee143a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3000197-dfe4-48d6-be21-0f408fee143a.jpg?1",
             "name": "Expert-Level Safe",
             "text": "",
             "colours": [],
@@ -24785,7 +24785,7 @@
         },
         {
             "id": "a0ea4fe7-80b3-5990-ba4d-5c7991ddd2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dd4d0-f6c8-4a04-919a-2c9b6842b361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236dd4d0-f6c8-4a04-919a-2c9b6842b361.jpg?1",
             "name": "Intelligence Bobblehead",
             "text": "",
             "colours": [],
@@ -24817,7 +24817,7 @@
         },
         {
             "id": "45027947-4338-54a1-aeb8-2003068734c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c0520-8008-412d-83f5-6608cfb7372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1c0520-8008-412d-83f5-6608cfb7372c.jpg?1",
             "name": "Luck Bobblehead",
             "text": "",
             "colours": [],
@@ -24849,7 +24849,7 @@
         },
         {
             "id": "28952fbe-2413-5c61-91b5-92c482c59835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb3bec7-40bb-4b5a-9a7b-cdecf974e044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb3bec7-40bb-4b5a-9a7b-cdecf974e044.jpg?1",
             "name": "Mister Gutsy",
             "text": "",
             "colours": [],
@@ -24884,7 +24884,7 @@
         },
         {
             "id": "eaf6197c-a038-5b59-8aa3-3510e0e379b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda4cbd3-e030-4349-9643-9f7bdebf80c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda4cbd3-e030-4349-9643-9f7bdebf80c1.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "",
             "colours": [],
@@ -24915,7 +24915,7 @@
         },
         {
             "id": "67523770-d318-5adf-9a6d-16c27613162b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be9d675-c284-4da6-81b5-0ceed836f9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be9d675-c284-4da6-81b5-0ceed836f9cc.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "",
             "colours": [],
@@ -24948,7 +24948,7 @@
         },
         {
             "id": "731beb74-b489-532a-98ee-4870820d58b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc935e71-8be8-4420-ba4f-3720f7eba941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc935e71-8be8-4420-ba4f-3720f7eba941.jpg?1",
             "name": "Perception Bobblehead",
             "text": "",
             "colours": [],
@@ -24980,7 +24980,7 @@
         },
         {
             "id": "1f3022f2-5b33-50d1-acbb-945079c9be62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6f71d-aea0-4711-9177-06a8c3917d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a6f71d-aea0-4711-9177-06a8c3917d6d.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "",
             "colours": [],
@@ -25013,7 +25013,7 @@
         },
         {
             "id": "ab5d9df6-2199-5a11-bda4-c1e63289fb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906c5c0-135d-4372-bcdb-a366341d1f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906c5c0-135d-4372-bcdb-a366341d1f65.jpg?1",
             "name": "Recon Craft Theta",
             "text": "",
             "colours": [],
@@ -25046,7 +25046,7 @@
         },
         {
             "id": "94fd4d29-3a77-5c60-80da-e2d57d826a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04fc3fa-119f-4dbf-a1b3-6f92812cd07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04fc3fa-119f-4dbf-a1b3-6f92812cd07d.jpg?1",
             "name": "Silver Shroud Costume",
             "text": "",
             "colours": [],
@@ -25077,7 +25077,7 @@
         },
         {
             "id": "9cb47c03-9462-50b6-a863-01019c04e8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271424ac-1f2b-4419-baca-bc9f0a862221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271424ac-1f2b-4419-baca-bc9f0a862221.jpg?1",
             "name": "Strength Bobblehead",
             "text": "",
             "colours": [],
@@ -25109,7 +25109,7 @@
         },
         {
             "id": "83dae9de-94c1-57db-8327-fa16b94ad602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda5e513-775c-4c5e-b9dc-cb836ca8cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda5e513-775c-4c5e-b9dc-cb836ca8cb8c.jpg?1",
             "name": "Survivor's Med Kit",
             "text": "",
             "colours": [],
@@ -25138,7 +25138,7 @@
         },
         {
             "id": "410e8735-9e31-5e79-9bae-87e96b211ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34a21a-3026-44d1-96d9-92112b0df7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c34a21a-3026-44d1-96d9-92112b0df7f6.jpg?1",
             "name": "T-45 Power Armor",
             "text": "",
             "colours": [],
@@ -25171,7 +25171,7 @@
         },
         {
             "id": "b12cc1ff-756c-52fb-959a-f90fb26ddc58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc62e13-19c0-421b-b5b1-8bff5a6db6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc62e13-19c0-421b-b5b1-8bff5a6db6cb.jpg?1",
             "name": "Desolate Mire",
             "text": "",
             "colours": [],
@@ -25205,7 +25205,7 @@
         },
         {
             "id": "23827f37-05fe-5e6b-a292-e40cc2e5f90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259e77f-0a15-43e2-bb94-41e8c585d927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2259e77f-0a15-43e2-bb94-41e8c585d927.jpg?1",
             "name": "Diamond City",
             "text": "",
             "colours": [],
@@ -25236,7 +25236,7 @@
         },
         {
             "id": "b46e5fd0-2446-56d1-baaf-e76270e1ebc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277ced12-77eb-426f-a661-bb5edd2d48e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277ced12-77eb-426f-a661-bb5edd2d48e7.jpg?1",
             "name": "Ferrous Lake",
             "text": "",
             "colours": [],
@@ -25270,7 +25270,7 @@
         },
         {
             "id": "96b03fbe-3d39-51c2-9057-c2ac250350de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83173a2-3d81-4617-a41d-51fc803cd774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d83173a2-3d81-4617-a41d-51fc803cd774.jpg?1",
             "name": "HELIOS One",
             "text": "",
             "colours": [],
@@ -25301,7 +25301,7 @@
         },
         {
             "id": "7eac7f6d-f43d-51cd-ba25-d679f1fae2ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d23ba-2e8f-46ef-805e-b00405417760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b7d23ba-2e8f-46ef-805e-b00405417760.jpg?1",
             "name": "Junktown",
             "text": "",
             "colours": [],
@@ -25334,7 +25334,7 @@
         },
         {
             "id": "a533a3b4-c9cf-59e7-9ebf-55adb7bf9e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b43792-6a34-4f36-b82a-793b846d5cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b43792-6a34-4f36-b82a-793b846d5cf5.jpg?1",
             "name": "Mariposa Military Base",
             "text": "",
             "colours": [],
@@ -25365,7 +25365,7 @@
         },
         {
             "id": "f235b8cc-35f2-5e28-bea3-7af6f877aac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04c2f3c-7114-4e8d-9c2f-e6611b4b3917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04c2f3c-7114-4e8d-9c2f-e6611b4b3917.jpg?1",
             "name": "Overflowing Basin",
             "text": "",
             "colours": [],
@@ -25399,7 +25399,7 @@
         },
         {
             "id": "8ecf985e-c805-50bd-9ae6-d0007bf496d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a916758c-9db2-48ff-b3b7-177e8d28284e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a916758c-9db2-48ff-b3b7-177e8d28284e.jpg?1",
             "name": "Sunscorched Divide",
             "text": "",
             "colours": [],
@@ -25433,7 +25433,7 @@
         },
         {
             "id": "3a7c0451-f750-5589-9ac8-c1d6960ae21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c555b4c5-08cc-4cd0-9b08-be29ce821fce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c555b4c5-08cc-4cd0-9b08-be29ce821fce.jpg?1",
             "name": "Viridescent Bog",
             "text": "",
             "colours": [],
@@ -25467,7 +25467,7 @@
         },
         {
             "id": "1f1c4733-c01b-5484-bd42-7b9eb1ed256e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56300ae6-d374-412e-b7f7-23e057666596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56300ae6-d374-412e-b7f7-23e057666596.jpg?1",
             "name": "All That Glitters",
             "text": "",
             "colours": [
@@ -25502,7 +25502,7 @@
         },
         {
             "id": "21d94162-a81a-55e0-be51-c5714d25420a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b675653-2689-4d02-b64e-8ac2204fe816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b675653-2689-4d02-b64e-8ac2204fe816.jpg?1",
             "name": "Austere Command",
             "text": "",
             "colours": [
@@ -25537,7 +25537,7 @@
         },
         {
             "id": "d93485fa-2f99-50f0-ad0d-16319260ada2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72641763-ac1d-42af-896b-985fd8980413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72641763-ac1d-42af-896b-985fd8980413.jpg?1",
             "name": "Captain of the Watch",
             "text": "",
             "colours": [
@@ -25575,7 +25575,7 @@
         },
         {
             "id": "df0b5eac-22dd-565b-856d-7424122e086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec886ab3-0cc2-4b17-879d-73ae10247a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec886ab3-0cc2-4b17-879d-73ae10247a8b.jpg?1",
             "name": "Crush Contraband",
             "text": "",
             "colours": [
@@ -25608,7 +25608,7 @@
         },
         {
             "id": "ba69db05-6153-5bb8-90d8-294341244e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da39a64-e8d9-4dc3-85f1-ac633b33330c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da39a64-e8d9-4dc3-85f1-ac633b33330c.jpg?1",
             "name": "Dispatch",
             "text": "",
             "colours": [
@@ -25641,7 +25641,7 @@
         },
         {
             "id": "28c6aea6-9475-5a04-acf4-3c5b4a615e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7c22b-f1f8-4d71-b5af-aae97fd6ebf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f7c22b-f1f8-4d71-b5af-aae97fd6ebf0.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "",
             "colours": [
@@ -25676,7 +25676,7 @@
         },
         {
             "id": "7a842192-2cec-5f2b-a20e-92fd66689c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b73c1cb-0e96-41d7-91c1-912aedd263a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b73c1cb-0e96-41d7-91c1-912aedd263a7.jpg?1",
             "name": "Hour of Reckoning",
             "text": "",
             "colours": [
@@ -25711,7 +25711,7 @@
         },
         {
             "id": "4a2c761d-1791-5e42-981a-87ba2accce02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8cf32-3283-46f8-bde1-5f02b71ed553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d8cf32-3283-46f8-bde1-5f02b71ed553.jpg?1",
             "name": "Impassioned Orator",
             "text": "",
             "colours": [
@@ -25747,7 +25747,7 @@
         },
         {
             "id": "b3bcbf89-859f-5407-b386-adc6eedf2bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9394fad6-af1b-4006-93f4-d154eb3435dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9394fad6-af1b-4006-93f4-d154eb3435dd.jpg?1",
             "name": "Intangible Virtue",
             "text": "",
             "colours": [
@@ -25780,7 +25780,7 @@
         },
         {
             "id": "d26b7e9e-0fee-5517-84d3-e2d97f68d7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee310ee-850f-44f0-82af-58bf766ea737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee310ee-850f-44f0-82af-58bf766ea737.jpg?1",
             "name": "Keeper of the Accord",
             "text": "",
             "colours": [
@@ -25818,7 +25818,7 @@
         },
         {
             "id": "4d081266-37c2-5b1f-a280-0a2eb6a7a494",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb587e8-b83a-491e-9b8c-736c115d4146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb587e8-b83a-491e-9b8c-736c115d4146.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "",
             "colours": [
@@ -25855,7 +25855,7 @@
         },
         {
             "id": "7ab7a83f-2620-5e0e-b6d7-c131421ad208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f893f1-47f6-4e1d-8cc5-4ee66c855d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f893f1-47f6-4e1d-8cc5-4ee66c855d77.jpg?1",
             "name": "Marshal's Anthem",
             "text": "",
             "colours": [
@@ -25890,7 +25890,7 @@
         },
         {
             "id": "ca6ddaec-eed9-549e-9194-97ba07d63b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a14e82-31fc-4c56-a8cc-acc3f7ef91a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a14e82-31fc-4c56-a8cc-acc3f7ef91a3.jpg?1",
             "name": "Martial Coup",
             "text": "",
             "colours": [
@@ -25925,7 +25925,7 @@
         },
         {
             "id": "172aa2cc-58fb-5542-9d6e-bf88d74ef345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e54f2-38cf-41dc-b8b3-0c123db66b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e54f2-38cf-41dc-b8b3-0c123db66b3c.jpg?1",
             "name": "Open the Vaults",
             "text": "",
             "colours": [
@@ -25960,7 +25960,7 @@
         },
         {
             "id": "b8b5d93c-92cd-57fa-bbc1-aa80d0a0a536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4919c263-a9d9-4ff2-979b-2ca8ff138200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4919c263-a9d9-4ff2-979b-2ca8ff138200.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -25993,7 +25993,7 @@
         },
         {
             "id": "8dbf3112-f2b4-50e8-8636-a924da13cf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9196b9-24b9-4398-b712-3fc0ee34717e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9196b9-24b9-4398-b712-3fc0ee34717e.jpg?1",
             "name": "Puresteel Paladin",
             "text": "",
             "colours": [
@@ -26031,7 +26031,7 @@
         },
         {
             "id": "410141b5-a666-55d8-b7ca-78443d064733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4ca60c-259e-4dfd-8b70-294bc551030f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4ca60c-259e-4dfd-8b70-294bc551030f.jpg?1",
             "name": "Secure the Wastes",
             "text": "",
             "colours": [
@@ -26066,7 +26066,7 @@
         },
         {
             "id": "e7354d78-02d6-5a50-a26b-ecd5044c232f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a92d8-18b6-4b60-8650-6f0c915211a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a92d8-18b6-4b60-8650-6f0c915211a6.jpg?1",
             "name": "Single Combat",
             "text": "",
             "colours": [
@@ -26101,7 +26101,7 @@
         },
         {
             "id": "c3cf378c-7bf6-5c87-b446-01e8db41737a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809cc7e4-215b-4b39-a5f3-e60240f1723f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/809cc7e4-215b-4b39-a5f3-e60240f1723f.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -26134,7 +26134,7 @@
         },
         {
             "id": "8547c27b-9754-5eac-a2ec-b444675218ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bc488a-957a-43d5-bff5-587ced5dadb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bc488a-957a-43d5-bff5-587ced5dadb3.jpg?1",
             "name": "Valorous Stance",
             "text": "",
             "colours": [
@@ -26167,7 +26167,7 @@
         },
         {
             "id": "cdc16b28-06b7-50f1-9885-d5f6cf5bf57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e2ab1-71dc-4151-ab5e-7e1e26e193b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e2ab1-71dc-4151-ab5e-7e1e26e193b5.jpg?1",
             "name": "Fraying Sanity",
             "text": "",
             "colours": [
@@ -26205,7 +26205,7 @@
         },
         {
             "id": "6fe2e34f-4b65-5c44-a56f-bbf82884e1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0d649-8a4d-43e0-a923-bc5af1ca796b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c0d649-8a4d-43e0-a923-bc5af1ca796b.jpg?1",
             "name": "Glimmer of Genius",
             "text": "",
             "colours": [
@@ -26238,7 +26238,7 @@
         },
         {
             "id": "ae2c299e-adae-56aa-862a-73b2b1cadc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b898e8c-43bd-4be2-9f7b-3937cd3549ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b898e8c-43bd-4be2-9f7b-3937cd3549ea.jpg?1",
             "name": "Inexorable Tide",
             "text": "",
             "colours": [
@@ -26273,7 +26273,7 @@
         },
         {
             "id": "00904105-1037-59c5-8207-eed4daab6815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e5d9eb-a9e8-4d9e-946f-8549f4f9c616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e5d9eb-a9e8-4d9e-946f-8549f4f9c616.jpg?1",
             "name": "Mechanized Production",
             "text": "",
             "colours": [
@@ -26310,7 +26310,7 @@
         },
         {
             "id": "0dbc40a5-ce84-5d8f-b882-b1971a0c3f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4145ffe0-8824-4a30-8b99-6d52184985b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4145ffe0-8824-4a30-8b99-6d52184985b4.jpg?1",
             "name": "One with the Machine",
             "text": "",
             "colours": [
@@ -26345,7 +26345,7 @@
         },
         {
             "id": "f15905f2-6a41-5084-8b28-40089ff94c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c89abbe-6391-438e-8ff9-e91484aa8139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c89abbe-6391-438e-8ff9-e91484aa8139.jpg?1",
             "name": "Thirst for Knowledge",
             "text": "",
             "colours": [
@@ -26378,7 +26378,7 @@
         },
         {
             "id": "3afd1436-bea6-5a73-bb71-07ee5d0ee858",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd71d34-3fd5-4029-b29f-b23e63ec2031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd71d34-3fd5-4029-b29f-b23e63ec2031.jpg?1",
             "name": "Whirler Rogue",
             "text": "",
             "colours": [
@@ -26415,7 +26415,7 @@
         },
         {
             "id": "df70ac3c-fe1b-59fd-bed6-886a2e8fce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d257c-3255-46f2-876f-9ecdcccfd133.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1d257c-3255-46f2-876f-9ecdcccfd133.jpg?1",
             "name": "Bastion of Remembrance",
             "text": "",
             "colours": [
@@ -26448,7 +26448,7 @@
         },
         {
             "id": "6dca74fb-3abd-515e-8c6b-885745d1f403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e572d0-f2d0-4b92-ade3-d3ffafb75aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e572d0-f2d0-4b92-ade3-d3ffafb75aa0.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -26483,7 +26483,7 @@
         },
         {
             "id": "092ed834-553e-5162-afba-fb5f76c2090b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088d768f-5523-48ed-a038-6ef70961f674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088d768f-5523-48ed-a038-6ef70961f674.jpg?1",
             "name": "Deadly Dispute",
             "text": "",
             "colours": [
@@ -26516,7 +26516,7 @@
         },
         {
             "id": "b35ca6da-e32a-5deb-83a0-766948a87d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e765f41c-54b7-447e-853a-8453b44747b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e765f41c-54b7-447e-853a-8453b44747b2.jpg?1",
             "name": "Lethal Scheme",
             "text": "",
             "colours": [
@@ -26551,7 +26551,7 @@
         },
         {
             "id": "5a3e78e6-ef83-5ba6-ae4b-e867752ad9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9fa939-2891-41da-a50c-cd1c5ff5e15f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b9fa939-2891-41da-a50c-cd1c5ff5e15f.jpg?1",
             "name": "Morbid Opportunist",
             "text": "",
             "colours": [
@@ -26587,7 +26587,7 @@
         },
         {
             "id": "5d23ec4c-6109-5e8d-9711-4f84b22c6553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4869d-fadd-41ec-862e-eb391996145f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4869d-fadd-41ec-862e-eb391996145f.jpg?1",
             "name": "Pitiless Plunderer",
             "text": "",
             "colours": [
@@ -26623,7 +26623,7 @@
         },
         {
             "id": "9c9630fb-019d-5cd8-863e-958fe3ac90e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e821a9f-6e5a-4314-82e7-8009d9aef1be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e821a9f-6e5a-4314-82e7-8009d9aef1be.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -26658,7 +26658,7 @@
         },
         {
             "id": "d16181d1-3a41-5ba4-8f1e-a5ec665d2ed7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c613d707-6f76-42f9-81f0-80954a7e77fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c613d707-6f76-42f9-81f0-80954a7e77fd.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -26693,7 +26693,7 @@
         },
         {
             "id": "1df09454-56f3-5477-b75f-0a40c646b50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bcd6c2-3112-42e3-80c6-2408622c3955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52bcd6c2-3112-42e3-80c6-2408622c3955.jpg?1",
             "name": "Loyal Apprentice",
             "text": "",
             "colours": [
@@ -26729,7 +26729,7 @@
         },
         {
             "id": "52a52f52-3652-5fa5-b69c-fae4d8b7cffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46d567-495d-4b55-877f-87a1cef5d01a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc46d567-495d-4b55-877f-87a1cef5d01a.jpg?1",
             "name": "Sticky Fingers",
             "text": "",
             "colours": [
@@ -26764,7 +26764,7 @@
         },
         {
             "id": "aa8a5f47-94b7-5196-b088-dbcf5b7e44bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dbfed-4134-466f-8591-9fe70078f97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dbfed-4134-466f-8591-9fe70078f97a.jpg?1",
             "name": "Stolen Strategy",
             "text": "",
             "colours": [
@@ -26799,7 +26799,7 @@
         },
         {
             "id": "b463f1da-a5ec-5ad5-8ab3-98f5a023a6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae31c29-280f-4459-9a11-6706cfa1fe2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae31c29-280f-4459-9a11-6706cfa1fe2c.jpg?1",
             "name": "Unexpected Windfall",
             "text": "",
             "colours": [
@@ -26832,7 +26832,7 @@
         },
         {
             "id": "e5e74cf1-1517-596b-b2d4-467fb6ebfcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ae59fe-6764-4374-84cd-86fa27818f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ae59fe-6764-4374-84cd-86fa27818f54.jpg?1",
             "name": "Abundant Growth",
             "text": "",
             "colours": [
@@ -26867,7 +26867,7 @@
         },
         {
             "id": "97430ca0-527f-5940-b748-ba164a65b725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3e8e9-58a3-4e88-a46d-498974ea6284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3e8e9-58a3-4e88-a46d-498974ea6284.jpg?1",
             "name": "Branching Evolution",
             "text": "",
             "colours": [
@@ -26902,7 +26902,7 @@
         },
         {
             "id": "01f3ebc7-6057-5b49-82e4-432d1dee9b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c97fe96-f30a-41ef-9d80-dd83207d14a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c97fe96-f30a-41ef-9d80-dd83207d14a4.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -26935,7 +26935,7 @@
         },
         {
             "id": "0047a173-7db7-53cd-b12f-39c66ef9dc3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114862d6-96b4-444e-95c0-67c6e1d8b9c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114862d6-96b4-444e-95c0-67c6e1d8b9c7.jpg?1",
             "name": "Farseek",
             "text": "",
             "colours": [
@@ -26968,7 +26968,7 @@
         },
         {
             "id": "2dc40b62-f812-5d48-a4bf-8c4d7e8177a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd7e29-db55-472b-878e-02cbb46afe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cd7e29-db55-472b-878e-02cbb46afe9e.jpg?1",
             "name": "Fertile Ground",
             "text": "",
             "colours": [
@@ -27003,7 +27003,7 @@
         },
         {
             "id": "25215a03-05ba-5e97-8e53-939748d09be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82cd903c-48de-46d0-a511-663f0f4f63fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82cd903c-48de-46d0-a511-663f0f4f63fe.jpg?1",
             "name": "Guardian Project",
             "text": "",
             "colours": [
@@ -27038,7 +27038,7 @@
         },
         {
             "id": "80f55a4d-8af1-594e-838c-8f2ae4d8ad8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a8288-05b2-4ec9-9712-17aa7f35332a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67a8288-05b2-4ec9-9712-17aa7f35332a.jpg?1",
             "name": "Hardened Scales",
             "text": "",
             "colours": [
@@ -27073,7 +27073,7 @@
         },
         {
             "id": "571ccf95-c84e-514e-9d7d-be19c65c7709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3211a14-207a-4f95-ab2e-d64329a75bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3211a14-207a-4f95-ab2e-d64329a75bc5.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -27106,7 +27106,7 @@
         },
         {
             "id": "0d734746-9e47-5ab2-bbe5-3db52ece8052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94545a-407c-4e5f-950a-e052fd6bda46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94545a-407c-4e5f-950a-e052fd6bda46.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -27141,7 +27141,7 @@
         },
         {
             "id": "cebcb129-1b65-5ea3-bc9b-145442a6caac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c701031a-11d1-4aeb-993b-37775ade51d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c701031a-11d1-4aeb-993b-37775ade51d6.jpg?1",
             "name": "Inspiring Call",
             "text": "",
             "colours": [
@@ -27174,7 +27174,7 @@
         },
         {
             "id": "d0903ef6-340c-51d0-9e1c-dab2e10d2917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b134dc-b58f-43ca-9d7b-f5bead3a4e2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b134dc-b58f-43ca-9d7b-f5bead3a4e2c.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -27207,7 +27207,7 @@
         },
         {
             "id": "5525aec6-1511-5af0-b0e7-c2b56c3e036b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d86ea97-0d7a-42ee-9d46-1c0dd10474c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d86ea97-0d7a-42ee-9d46-1c0dd10474c7.jpg?1",
             "name": "Rancor",
             "text": "",
             "colours": [
@@ -27242,7 +27242,7 @@
         },
         {
             "id": "9cbf050d-e6e8-57b1-b48c-c3ee4e5eab44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc59e1a-f0f5-4054-bedf-1908fc8646ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc59e1a-f0f5-4054-bedf-1908fc8646ec.jpg?1",
             "name": "Squirrel Nest",
             "text": "",
             "colours": [
@@ -27277,7 +27277,7 @@
         },
         {
             "id": "c1c82c6a-cd8b-5601-b5dc-ee0e5797d615",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856cfb5a-6e85-4ac2-9964-19b6dc68e149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856cfb5a-6e85-4ac2-9964-19b6dc68e149.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -27315,7 +27315,7 @@
         },
         {
             "id": "3ef11719-4b4d-58ed-9a1f-b22f450ba5f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6714a-a83f-417c-87a2-54b5d0c3cabc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6714a-a83f-417c-87a2-54b5d0c3cabc.jpg?1",
             "name": "Wild Growth",
             "text": "",
             "colours": [
@@ -27350,7 +27350,7 @@
         },
         {
             "id": "3fa5c3d6-7034-5717-b6be-22601b646cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b230483-dcdd-4731-b98c-cbb8c221de6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b230483-dcdd-4731-b98c-cbb8c221de6b.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -27387,7 +27387,7 @@
         },
         {
             "id": "d5c9658f-1fc1-5e85-888e-90c26db720de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515422b-5bdd-413b-a414-ad3510dd62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5515422b-5bdd-413b-a414-ad3510dd62cc.jpg?1",
             "name": "Assemble the Legion",
             "text": "",
             "colours": [
@@ -27424,7 +27424,7 @@
         },
         {
             "id": "b8951125-7fe9-5bd4-8c9e-d906b4f0a4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d1950-2405-442a-841d-fced89280036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d1950-2405-442a-841d-fced89280036.jpg?1",
             "name": "Behemoth Sledge",
             "text": "",
             "colours": [
@@ -27461,7 +27461,7 @@
         },
         {
             "id": "534ef5f2-cbd0-5ce5-bb60-f90c08d1cb4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79bf08b-973a-45bc-ae96-43e93092f0c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d79bf08b-973a-45bc-ae96-43e93092f0c0.jpg?1",
             "name": "Biomass Mutation",
             "text": "",
             "colours": [
@@ -27498,7 +27498,7 @@
         },
         {
             "id": "2205b11d-c961-51ee-bbac-63722370a392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f8961-ddf0-4057-b434-b220d88b3e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f4f8961-ddf0-4057-b434-b220d88b3e2d.jpg?1",
             "name": "Casualties of War",
             "text": "",
             "colours": [
@@ -27535,7 +27535,7 @@
         },
         {
             "id": "d97a29ba-27e5-5ba7-b430-cffeea28e143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a7300-b2ce-4889-94a2-0b6ea823b575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049a7300-b2ce-4889-94a2-0b6ea823b575.jpg?1",
             "name": "Corpsejack Menace",
             "text": "",
             "colours": [
@@ -27572,7 +27572,7 @@
         },
         {
             "id": "2c7c556d-31b4-5203-a6f0-fa6fb347a6c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b2b8a4-3174-4188-959c-f456f9fcd563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b2b8a4-3174-4188-959c-f456f9fcd563.jpg?1",
             "name": "Fervent Charge",
             "text": "",
             "colours": [
@@ -27611,7 +27611,7 @@
         },
         {
             "id": "cb901e2c-8e64-5c78-9216-3867285eecc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg?1",
             "name": "Find // Finality",
             "text": "",
             "colours": [
@@ -27646,7 +27646,7 @@
         },
         {
             "id": "cc7fa634-6481-5ddb-bfd0-a98daa51ff07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad3a885d-de06-49e3-9f68-217c5a8035b4.jpg?1",
             "name": "Find // Finality",
             "text": "",
             "colours": [
@@ -27681,7 +27681,7 @@
         },
         {
             "id": "419f4dea-3312-5888-a8a7-b4c9a594a776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc140950-d7d0-46d3-98a0-8d1453f4b0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc140950-d7d0-46d3-98a0-8d1453f4b0cf.jpg?1",
             "name": "General's Enforcer",
             "text": "",
             "colours": [
@@ -27719,7 +27719,7 @@
         },
         {
             "id": "56ba5c0c-ca3a-5b05-a9d9-f369a30b4a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7092139a-f0ad-42fd-83f2-058650c01553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7092139a-f0ad-42fd-83f2-058650c01553.jpg?1",
             "name": "Heroic Reinforcements",
             "text": "",
             "colours": [
@@ -27754,7 +27754,7 @@
         },
         {
             "id": "29a86617-6ddb-51c6-87c1-bd99dd7a5387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2e8b73-f4bc-4cd9-b442-eb1832399958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2e8b73-f4bc-4cd9-b442-eb1832399958.jpg?1",
             "name": "Putrefy",
             "text": "",
             "colours": [
@@ -27789,7 +27789,7 @@
         },
         {
             "id": "377f7221-1716-56d6-8dd9-639ef17983f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726cc21b-953e-41d3-b073-d2c6afdb0fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726cc21b-953e-41d3-b073-d2c6afdb0fbd.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "",
             "colours": [
@@ -27828,7 +27828,7 @@
         },
         {
             "id": "5fb996b5-f447-5719-9b20-ac7b6ef72038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc783338-4792-43a7-ab40-7151ba0e06a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc783338-4792-43a7-ab40-7151ba0e06a3.jpg?1",
             "name": "Wake the Past",
             "text": "",
             "colours": [
@@ -27865,7 +27865,7 @@
         },
         {
             "id": "9d67c08b-d2a3-5c70-bc93-b8c76f45333b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg?1",
             "name": "Wear // Tear",
             "text": "",
             "colours": [
@@ -27899,7 +27899,7 @@
         },
         {
             "id": "663ad389-c435-5d45-9ff0-a6acb6ff3705",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ac6703-85f0-48df-bcca-983f49df63fa.jpg?1",
             "name": "Wear // Tear",
             "text": "",
             "colours": [
@@ -27933,7 +27933,7 @@
         },
         {
             "id": "d417f0f7-b139-5fce-8ce1-1257b25880b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da1507-9ec6-40a9-a848-5110583bebfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24da1507-9ec6-40a9-a848-5110583bebfe.jpg?1",
             "name": "Winding Constrictor",
             "text": "",
             "colours": [
@@ -27970,7 +27970,7 @@
         },
         {
             "id": "7cd0d6af-a365-5a59-8839-1f2e11e9f1c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6e91b-5ea2-4e0e-8dcf-1f99ecaa7bc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6e91b-5ea2-4e0e-8dcf-1f99ecaa7bc6.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -28001,7 +28001,7 @@
         },
         {
             "id": "de0e04a1-be48-5552-83db-20ecbea772e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab107ee4-5775-4376-9992-d380360f546c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab107ee4-5775-4376-9992-d380360f546c.jpg?1",
             "name": "Basilisk Collar",
             "text": "",
             "colours": [],
@@ -28034,7 +28034,7 @@
         },
         {
             "id": "0702f949-35bb-5eed-81e5-b1d29ca8a58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabd38d7-0170-4c78-940f-7dba9ffe1c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aabd38d7-0170-4c78-940f-7dba9ffe1c46.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "",
             "colours": [],
@@ -28067,7 +28067,7 @@
         },
         {
             "id": "594fdd48-027f-5ed1-a25e-3bda1ba02ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6010f966-c931-4032-a59b-feeb428e0c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6010f966-c931-4032-a59b-feeb428e0c16.jpg?1",
             "name": "Brass Knuckles",
             "text": "",
             "colours": [],
@@ -28098,7 +28098,7 @@
         },
         {
             "id": "ae5c948c-815e-5fb6-8148-3a19a7c28787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aa98c5-0f8a-45b2-904d-29afeeb491bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77aa98c5-0f8a-45b2-904d-29afeeb491bc.jpg?1",
             "name": "Champion's Helm",
             "text": "",
             "colours": [],
@@ -28131,7 +28131,7 @@
         },
         {
             "id": "69968591-eb37-5eb4-b114-9a34a665209f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6f54ff-507d-4f78-9293-7c5eac04bbcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6f54ff-507d-4f78-9293-7c5eac04bbcf.jpg?1",
             "name": "Contagion Clasp",
             "text": "",
             "colours": [],
@@ -28160,7 +28160,7 @@
         },
         {
             "id": "3f5852a8-ea6e-5eef-9eea-83153a25ec26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f1ca9-453c-49b6-a913-20e461b9ea1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f1ca9-453c-49b6-a913-20e461b9ea1b.jpg?1",
             "name": "Everflowing Chalice",
             "text": "",
             "colours": [],
@@ -28189,7 +28189,7 @@
         },
         {
             "id": "a015d57a-fa99-5979-932e-57e86f6fb4dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68412b0-dd83-4346-9ed0-3cb8a4a0856f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68412b0-dd83-4346-9ed0-3cb8a4a0856f.jpg?1",
             "name": "Explorer's Scope",
             "text": "",
             "colours": [],
@@ -28220,7 +28220,7 @@
         },
         {
             "id": "0bbb3654-7a93-5c06-90c6-46ced32cfee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12fc244-ca30-4da6-8350-340975a79708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12fc244-ca30-4da6-8350-340975a79708.jpg?1",
             "name": "Fireshrieker",
             "text": "",
             "colours": [],
@@ -28251,7 +28251,7 @@
         },
         {
             "id": "f4b963da-aa5a-5ae6-a871-1a1bd7178553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db25753d-59e6-4866-92fe-2b38b0f72967.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db25753d-59e6-4866-92fe-2b38b0f72967.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -28282,7 +28282,7 @@
         },
         {
             "id": "db589310-1951-5110-a453-ea99ffc1d943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b132024-7835-46ef-ac08-e2f88b5c6a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b132024-7835-46ef-ac08-e2f88b5c6a33.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "",
             "colours": [],
@@ -28315,7 +28315,7 @@
         },
         {
             "id": "48fc81a6-6fa9-5674-89ec-1c53926a0f85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad9914-4a18-4679-8d41-1e338fc23fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ad9914-4a18-4679-8d41-1e338fc23fe5.jpg?1",
             "name": "Mind Stone",
             "text": "",
             "colours": [],
@@ -28344,7 +28344,7 @@
         },
         {
             "id": "4ac6e15f-8e09-5326-97c6-99ba94975b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26614a2-b6ce-4161-89ee-d9596a97a146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26614a2-b6ce-4161-89ee-d9596a97a146.jpg?1",
             "name": "Mystic Forge",
             "text": "",
             "colours": [],
@@ -28375,7 +28375,7 @@
         },
         {
             "id": "357b02df-8d0b-5184-af4c-99a67821aabb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7721abe9-79a1-4831-87f4-95184e9223c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7721abe9-79a1-4831-87f4-95184e9223c8.jpg?1",
             "name": "Panharmonicon",
             "text": "",
             "colours": [],
@@ -28406,7 +28406,7 @@
         },
         {
             "id": "6f1524d5-5ffe-5b0d-992e-dd5a47b34d54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb146d9a-f66a-460d-a230-942d04a9658e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb146d9a-f66a-460d-a230-942d04a9658e.jpg?1",
             "name": "Skullclamp",
             "text": "",
             "colours": [],
@@ -28437,7 +28437,7 @@
         },
         {
             "id": "890fe5f5-9851-583e-9331-f31d9c85ec35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8260eef-5ff2-4058-8aa5-469b402eaf65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8260eef-5ff2-4058-8aa5-469b402eaf65.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -28468,7 +28468,7 @@
         },
         {
             "id": "7b872052-35a7-5691-a6a9-b5f52c40ff6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd833ea2-6bef-4abc-8111-d7903ae4130a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd833ea2-6bef-4abc-8111-d7903ae4130a.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -28502,7 +28502,7 @@
         },
         {
             "id": "d4a11d8f-b0b9-5ec4-bbd5-8e58a44be74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f194b1-463b-4e82-961a-61be31fae8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f194b1-463b-4e82-961a-61be31fae8ab.jpg?1",
             "name": "Steel Overseer",
             "text": "",
             "colours": [],
@@ -28536,7 +28536,7 @@
         },
         {
             "id": "1182227f-82a4-5cfd-822f-8d662294ad25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae6364-fd70-403a-8ffd-9a584e992e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceae6364-fd70-403a-8ffd-9a584e992e4a.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "",
             "colours": [],
@@ -28567,7 +28567,7 @@
         },
         {
             "id": "b2358196-f6b1-560a-a285-22f73e5ce409",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b6a71d-83f3-4aaa-8bbc-d1dabaaade08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b6a71d-83f3-4aaa-8bbc-d1dabaaade08.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -28599,7 +28599,7 @@
         },
         {
             "id": "28e30e81-3b22-5b1d-81e8-46bfb001b454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bf263b-a568-4901-a9c7-205aabf2b631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bf263b-a568-4901-a9c7-205aabf2b631.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -28631,7 +28631,7 @@
         },
         {
             "id": "fc2c7103-02ff-58b2-9047-c87b351cea51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c74a36-5d0f-49fe-b1ec-330f40c9abca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c74a36-5d0f-49fe-b1ec-330f40c9abca.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -28663,7 +28663,7 @@
         },
         {
             "id": "9f2f875f-3d77-5fc0-931b-117f38e34132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd2d-89cb-464d-bba5-e7da37776454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637ebd2d-89cb-464d-bba5-e7da37776454.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -28695,7 +28695,7 @@
         },
         {
             "id": "74a48df5-e214-56a9-8520-1437e93e0d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e890d8-6542-4d8e-9782-94fb5a74e244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e890d8-6542-4d8e-9782-94fb5a74e244.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "",
             "colours": [],
@@ -28727,7 +28727,7 @@
         },
         {
             "id": "3013ea62-de93-56b6-a1e8-d4c4f096f980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8190e77f-05ff-4b24-9b09-60bc8d6a6577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8190e77f-05ff-4b24-9b09-60bc8d6a6577.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -28759,7 +28759,7 @@
         },
         {
             "id": "8251f745-be05-5292-88f0-91c5b8b5be7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132b71a-032e-488d-ac63-ffbc4b18a745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7132b71a-032e-488d-ac63-ffbc4b18a745.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -28791,7 +28791,7 @@
         },
         {
             "id": "73a54f11-b110-5010-b405-5c5fa52bfeca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b403f3-8570-4a60-9e03-49cd85f66f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b403f3-8570-4a60-9e03-49cd85f66f69.jpg?1",
             "name": "Talisman of Resilience",
             "text": "",
             "colours": [],
@@ -28823,7 +28823,7 @@
         },
         {
             "id": "03e1fc42-be68-522d-a4cb-1629ebdf7085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f626574-9eb2-4d17-be70-24216f1a7cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f626574-9eb2-4d17-be70-24216f1a7cb9.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -28852,7 +28852,7 @@
         },
         {
             "id": "6f27be9c-0d1d-56d3-9bee-40e7364e2d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a633b4-2c18-46f0-a902-4699a4021c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a633b4-2c18-46f0-a902-4699a4021c4d.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "",
             "colours": [],
@@ -28881,7 +28881,7 @@
         },
         {
             "id": "896fc7b5-fae4-5765-8efe-d2ee8f34e5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f448c0c-c9d2-4e3c-91b1-d8cf6b9072e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f448c0c-c9d2-4e3c-91b1-d8cf6b9072e1.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -28910,7 +28910,7 @@
         },
         {
             "id": "dd28c478-40a1-598a-ae5b-33987f67709f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67a003-7a1e-410b-9758-d8f005e84028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a67a003-7a1e-410b-9758-d8f005e84028.jpg?1",
             "name": "Buried Ruin",
             "text": "",
             "colours": [],
@@ -28939,7 +28939,7 @@
         },
         {
             "id": "3e6b845e-8004-50a3-8047-7f3f73ce1497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b0a2f-53ef-43d4-99a8-9967db05e39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9b0a2f-53ef-43d4-99a8-9967db05e39e.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -28976,7 +28976,7 @@
         },
         {
             "id": "e2890903-09ef-5575-9338-c7d67d7994f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad503ae-45f1-406b-b1c6-06fcb9d2f2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad503ae-45f1-406b-b1c6-06fcb9d2f2b1.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -29013,7 +29013,7 @@
         },
         {
             "id": "a143ef65-6d82-5387-8fd1-84b410ed814f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7bab64-177f-411c-bdf5-6a41dd4bb89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7bab64-177f-411c-bdf5-6a41dd4bb89a.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -29050,7 +29050,7 @@
         },
         {
             "id": "96839880-fbf4-532e-82f5-87008a06fe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20c3bf2-15f6-4692-b0d8-69a80adc55c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20c3bf2-15f6-4692-b0d8-69a80adc55c4.jpg?1",
             "name": "Clifftop Retreat",
             "text": "",
             "colours": [],
@@ -29084,7 +29084,7 @@
         },
         {
             "id": "34447e9f-3b26-5c28-b78e-dbe6c817e611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1bb7b31-9da7-4146-be80-0d5d1245ca48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1bb7b31-9da7-4146-be80-0d5d1245ca48.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -29115,7 +29115,7 @@
         },
         {
             "id": "4cac4ae6-ffde-5612-a711-a6b511eb3f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c3285-a1d8-4f7e-8fe7-1ba0d96dca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c3285-a1d8-4f7e-8fe7-1ba0d96dca51.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -29149,7 +29149,7 @@
         },
         {
             "id": "40d4ef21-57d3-55b2-b622-92bafb06aad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83f390-66cd-46a7-8b4c-752a3782fc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b83f390-66cd-46a7-8b4c-752a3782fc7c.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -29183,7 +29183,7 @@
         },
         {
             "id": "8ec130d8-3046-5049-b191-a7408549660d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e37b17-de7c-4acf-b16a-404036525c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e37b17-de7c-4acf-b16a-404036525c2f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -29217,7 +29217,7 @@
         },
         {
             "id": "36fde2ae-bf1c-5544-bf0d-52bc1b131b54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a3a97-f17a-4626-b6a5-94bc2be62f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/164a3a97-f17a-4626-b6a5-94bc2be62f03.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -29246,7 +29246,7 @@
         },
         {
             "id": "6a57d0fe-63aa-5173-802f-003cc31fde27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c052fe03-d300-41e2-89ff-054d32c4280b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c052fe03-d300-41e2-89ff-054d32c4280b.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -29277,7 +29277,7 @@
         },
         {
             "id": "d39c6ceb-adbb-5b90-b048-6a7b6aae87b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8abd26-fdba-4c08-9fa3-cab805e1908c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8abd26-fdba-4c08-9fa3-cab805e1908c.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -29314,7 +29314,7 @@
         },
         {
             "id": "dc078767-6fe1-5f58-a330-bd5e9b8e401c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ed4714-ed3d-45b6-a427-f0dcbf7e48c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ed4714-ed3d-45b6-a427-f0dcbf7e48c9.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -29348,7 +29348,7 @@
         },
         {
             "id": "77fe7d72-8996-5b3d-9dbc-d1adabda5b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7558a926-9b97-4981-89ac-6a2890cf6d21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7558a926-9b97-4981-89ac-6a2890cf6d21.jpg?1",
             "name": "Hinterland Harbor",
             "text": "",
             "colours": [],
@@ -29382,7 +29382,7 @@
         },
         {
             "id": "a94a492b-2faa-555f-89de-6408062490b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddf5f7-cc9c-433a-b2db-fb8dbe3b7248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddf5f7-cc9c-433a-b2db-fb8dbe3b7248.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -29419,7 +29419,7 @@
         },
         {
             "id": "1f5116ab-9327-522e-bd2f-1dfddb7935dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe452473-c99f-4ca2-a9a4-b69fe93e521f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe452473-c99f-4ca2-a9a4-b69fe93e521f.jpg?1",
             "name": "Isolated Chapel",
             "text": "",
             "colours": [],
@@ -29453,7 +29453,7 @@
         },
         {
             "id": "6173d627-a923-5f68-842f-a125db1c1336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8f174c-c16b-4b60-aa02-3d1f3a3f7989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8f174c-c16b-4b60-aa02-3d1f3a3f7989.jpg?1",
             "name": "Jungle Shrine",
             "text": "",
             "colours": [],
@@ -29486,7 +29486,7 @@
         },
         {
             "id": "e4b6baeb-478a-5f3b-b366-9c5af792fc97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd62678-4c82-4bb1-b1c7-9dc701cde473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd62678-4c82-4bb1-b1c7-9dc701cde473.jpg?1",
             "name": "Memorial to Glory",
             "text": "",
             "colours": [],
@@ -29517,7 +29517,7 @@
         },
         {
             "id": "c4ab4644-2e42-52eb-897c-fae32cf40e44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872b085d-f633-4bb4-91ab-956e0f8f3dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872b085d-f633-4bb4-91ab-956e0f8f3dc8.jpg?1",
             "name": "Mortuary Mire",
             "text": "",
             "colours": [],
@@ -29548,7 +29548,7 @@
         },
         {
             "id": "62ecde0f-cff2-5873-b618-5db197ef2bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80804054-1d2d-4f41-8399-3931e80a1e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80804054-1d2d-4f41-8399-3931e80a1e92.jpg?1",
             "name": "Mossfire Valley",
             "text": "",
             "colours": [],
@@ -29582,7 +29582,7 @@
         },
         {
             "id": "c2a7b3c2-d885-55de-b1a4-61bce82b1de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369fe1f-35b5-4b0f-be65-e6761c6852cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3369fe1f-35b5-4b0f-be65-e6761c6852cf.jpg?1",
             "name": "Myriad Landscape",
             "text": "",
             "colours": [],
@@ -29611,7 +29611,7 @@
         },
         {
             "id": "6b368877-4d77-5bd4-ba0f-3a333545894f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0a61d8-9a11-413b-b836-a7d57f3de1d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a0a61d8-9a11-413b-b836-a7d57f3de1d9.jpg?1",
             "name": "Mystic Monastery",
             "text": "",
             "colours": [],
@@ -29644,7 +29644,7 @@
         },
         {
             "id": "d3255f48-b214-5c77-a6cd-ea0020e227e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb45f3c2-6c64-429a-abb2-0ba9424b58bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb45f3c2-6c64-429a-abb2-0ba9424b58bb.jpg?1",
             "name": "Nesting Grounds",
             "text": "",
             "colours": [],
@@ -29675,7 +29675,7 @@
         },
         {
             "id": "be338c31-dedd-5c6c-a167-4cc115195208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a172fb-883d-4499-97e5-4de0d10e3e19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a172fb-883d-4499-97e5-4de0d10e3e19.jpg?1",
             "name": "Nomad Outpost",
             "text": "",
             "colours": [],
@@ -29708,7 +29708,7 @@
         },
         {
             "id": "04b665a9-7413-587d-acc2-08dfb8a92d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3647db5-e95b-46e5-b2a2-969cf1f2a492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3647db5-e95b-46e5-b2a2-969cf1f2a492.jpg?1",
             "name": "Opulent Palace",
             "text": "",
             "colours": [],
@@ -29741,7 +29741,7 @@
         },
         {
             "id": "b68e5a76-61fd-5dd4-b9a8-cdf3940a96da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da838121-732e-4cf2-9456-487306129a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da838121-732e-4cf2-9456-487306129a73.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -29770,7 +29770,7 @@
         },
         {
             "id": "bac55529-5719-5a9d-b4d9-f2263651d785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ac603e-d8c9-4917-855a-23cece560068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ac603e-d8c9-4917-855a-23cece560068.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -29807,7 +29807,7 @@
         },
         {
             "id": "43cc3994-c9be-5822-b342-515874a6da5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4d3468-ee25-4b02-bcb9-8860c5b5ce4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4d3468-ee25-4b02-bcb9-8860c5b5ce4b.jpg?1",
             "name": "Razortide Bridge",
             "text": "",
             "colours": [],
@@ -29840,7 +29840,7 @@
         },
         {
             "id": "9e6fe040-e0d3-52ae-8e8d-64dacf57a9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6624d46-4a49-4125-b536-9300527975b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6624d46-4a49-4125-b536-9300527975b9.jpg?1",
             "name": "Roadside Reliquary",
             "text": "",
             "colours": [],
@@ -29869,7 +29869,7 @@
         },
         {
             "id": "2c33c0a6-1255-5ce5-b9b3-1211fb0321db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dae074c-d52c-482e-851a-48c89ee50802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dae074c-d52c-482e-851a-48c89ee50802.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -29898,7 +29898,7 @@
         },
         {
             "id": "3729cba0-1ac9-5290-83fe-a7bcf85f3c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7b74-97b8-4a2b-a317-de0bb7aed6f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5b7b74-97b8-4a2b-a317-de0bb7aed6f9.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -29932,7 +29932,7 @@
         },
         {
             "id": "7d25d125-dd35-5aef-a9ee-fe05cf6c23b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fac8e5-d471-4a30-84e9-72b3dce529c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fac8e5-d471-4a30-84e9-72b3dce529c3.jpg?1",
             "name": "Rustvale Bridge",
             "text": "",
             "colours": [],
@@ -29965,7 +29965,7 @@
         },
         {
             "id": "0e6f3256-067e-5bd6-809b-c2a2669a0600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82dc7d0-e2da-4d59-9c24-b631048c9ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82dc7d0-e2da-4d59-9c24-b631048c9ebe.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -30002,7 +30002,7 @@
         },
         {
             "id": "578d17ad-365b-50b7-8fdd-62ab32aca34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125bebe-71f9-429f-a50d-3b7eb11fe5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125bebe-71f9-429f-a50d-3b7eb11fe5ac.jpg?1",
             "name": "Scavenger Grounds",
             "text": "",
             "colours": [],
@@ -30035,7 +30035,7 @@
         },
         {
             "id": "23235e99-9d68-5e24-a45a-ace3c397c8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad2ea22-64ca-443c-9530-1f36fa58a0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ad2ea22-64ca-443c-9530-1f36fa58a0d8.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -30069,7 +30069,7 @@
         },
         {
             "id": "7c731eca-32f6-5c02-86b0-1a69475bd65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bff6bd-7a60-4824-9b2b-70b9a48610ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bff6bd-7a60-4824-9b2b-70b9a48610ba.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -30106,7 +30106,7 @@
         },
         {
             "id": "97d8c6d9-3254-599c-95e7-796a9215442a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b943a5c6-01c9-4ff1-9e52-37899ee885ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b943a5c6-01c9-4ff1-9e52-37899ee885ea.jpg?1",
             "name": "Silverbluff Bridge",
             "text": "",
             "colours": [],
@@ -30139,7 +30139,7 @@
         },
         {
             "id": "555e45a9-90a6-5d8a-bb40-84d800d2a851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1a1c2-1b00-4eb3-a537-33402a471308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1a1c2-1b00-4eb3-a537-33402a471308.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -30173,7 +30173,7 @@
         },
         {
             "id": "1d34e956-287b-5c1e-8bf7-46be79093a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77861dbb-86d6-4c3e-9680-e1155015b936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77861dbb-86d6-4c3e-9680-e1155015b936.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -30210,7 +30210,7 @@
         },
         {
             "id": "d825dd73-e740-58ac-aa7d-270ceda921d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e60a0b4-357b-4221-baff-afcda079422c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e60a0b4-357b-4221-baff-afcda079422c.jpg?1",
             "name": "Spire of Industry",
             "text": "",
             "colours": [],
@@ -30241,7 +30241,7 @@
         },
         {
             "id": "a9a10f92-a0ee-59ad-b96d-20001a1139e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceed6d6f-bec8-46c8-a59c-5fc3f1f4d8c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceed6d6f-bec8-46c8-a59c-5fc3f1f4d8c0.jpg?1",
             "name": "Sulfur Falls",
             "text": "",
             "colours": [],
@@ -30275,7 +30275,7 @@
         },
         {
             "id": "4f3858e9-0e59-5de3-b8a8-24070b4255d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a992ab-dbf6-4585-bdaf-f44de250d9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a992ab-dbf6-4585-bdaf-f44de250d9a7.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -30309,7 +30309,7 @@
         },
         {
             "id": "c5f90716-80d4-5b9a-951b-ae96bc5b077c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719122c5-eeca-4424-8be7-c66baf5083ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/719122c5-eeca-4424-8be7-c66baf5083ab.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -30346,7 +30346,7 @@
         },
         {
             "id": "1b7be27a-43f8-5ba2-adf0-dec0df30886d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984ac231-5488-4312-bdc7-b425d2e7061f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984ac231-5488-4312-bdc7-b425d2e7061f.jpg?1",
             "name": "Sunpetal Grove",
             "text": "",
             "colours": [],
@@ -30380,7 +30380,7 @@
         },
         {
             "id": "6b57df2a-d8f5-5f6d-9426-99253f43bad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5d15cd-e6d9-4146-8bdc-b0c65b469dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5d15cd-e6d9-4146-8bdc-b0c65b469dbe.jpg?1",
             "name": "Tainted Field",
             "text": "",
             "colours": [],
@@ -30412,7 +30412,7 @@
         },
         {
             "id": "ba1bae6b-377e-56af-bb81-3b05773fc072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94ddd6-e957-4eb2-96e3-56db87aba066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f94ddd6-e957-4eb2-96e3-56db87aba066.jpg?1",
             "name": "Tainted Isle",
             "text": "",
             "colours": [],
@@ -30444,7 +30444,7 @@
         },
         {
             "id": "44ef23f2-256f-5d96-93a0-e08d470ed06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887b00e-cf23-4b01-80de-20ff037aaea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887b00e-cf23-4b01-80de-20ff037aaea9.jpg?1",
             "name": "Tainted Peak",
             "text": "",
             "colours": [],
@@ -30476,7 +30476,7 @@
         },
         {
             "id": "02743741-8882-5d9c-9941-4ef24e69f041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efd18dc-ccb4-46a0-b080-50fdec45d745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efd18dc-ccb4-46a0-b080-50fdec45d745.jpg?1",
             "name": "Tainted Wood",
             "text": "",
             "colours": [],
@@ -30508,7 +30508,7 @@
         },
         {
             "id": "611992a2-a0d8-5e93-9897-3545e709c7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e4b28-8800-48cf-ace8-1669cfd5f67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/917e4b28-8800-48cf-ace8-1669cfd5f67c.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -30542,7 +30542,7 @@
         },
         {
             "id": "240dffd9-fb53-55dc-8de6-9cd03d5cb17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d322d8-cbce-4be3-9b7d-d4876031f92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d322d8-cbce-4be3-9b7d-d4876031f92f.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -30576,7 +30576,7 @@
         },
         {
             "id": "7ae0c7a5-bda7-588f-b2aa-ad5943531102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be15d793-4706-4c68-9938-a1f8bfeb5674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be15d793-4706-4c68-9938-a1f8bfeb5674.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -30610,7 +30610,7 @@
         },
         {
             "id": "6f58825c-5879-5e99-bc00-1a657fe33d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b49d5-25cb-451c-a68a-e5b7de8e1f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93b49d5-25cb-451c-a68a-e5b7de8e1f00.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -30644,7 +30644,7 @@
         },
         {
             "id": "1224e929-416d-5f23-b787-4dd0f0642156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2689b828-85de-4493-bd5e-81858513fa3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2689b828-85de-4493-bd5e-81858513fa3c.jpg?1",
             "name": "Temple of Malady",
             "text": "",
             "colours": [],
@@ -30678,7 +30678,7 @@
         },
         {
             "id": "52e4dc8f-642c-534e-8f76-43d6c5ad7960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3c5245-f328-4fdf-9193-75dfb6de03ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3c5245-f328-4fdf-9193-75dfb6de03ad.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -30712,7 +30712,7 @@
         },
         {
             "id": "973390aa-348f-5992-ae2c-bfaa0e784178",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9120c4-1a4d-4bd8-a03b-9070781677a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9120c4-1a4d-4bd8-a03b-9070781677a5.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -30746,7 +30746,7 @@
         },
         {
             "id": "61efae05-eecc-5cb8-b69b-5546078554c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a67571c-f89b-4cb2-8c62-9bfc35acab1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a67571c-f89b-4cb2-8c62-9bfc35acab1d.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -30780,7 +30780,7 @@
         },
         {
             "id": "73a1dc27-3e35-553d-93bd-9a4d1d2d6510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e0c9e5-9432-47ae-891f-dadf2558736b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e0c9e5-9432-47ae-891f-dadf2558736b.jpg?1",
             "name": "Temple of Silence",
             "text": "",
             "colours": [],
@@ -30814,7 +30814,7 @@
         },
         {
             "id": "9669c7a4-f547-51ca-9e70-93724095cc65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0778f4-2717-4e77-84cf-d01d359004ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0778f4-2717-4e77-84cf-d01d359004ed.jpg?1",
             "name": "Temple of the False God",
             "text": "",
             "colours": [],
@@ -30843,7 +30843,7 @@
         },
         {
             "id": "4c835bf1-a3af-5c83-b142-cb5acb363b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ec3ada-496e-4bee-ab87-55ae3734cc03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ec3ada-496e-4bee-ab87-55ae3734cc03.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -30877,7 +30877,7 @@
         },
         {
             "id": "b0bd46af-53ea-5369-8032-2247391912a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b79a1a-b627-42ec-8ddb-c43d9765cf85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b79a1a-b627-42ec-8ddb-c43d9765cf85.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -30906,7 +30906,7 @@
         },
         {
             "id": "901cc318-7821-5185-a8e8-6e144c2a3939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb659e8d-c7e9-4035-82b1-d2427da081a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb659e8d-c7e9-4035-82b1-d2427da081a6.jpg?1",
             "name": "Treasure Vault",
             "text": "",
             "colours": [],
@@ -30938,7 +30938,7 @@
         },
         {
             "id": "18394ad1-50a1-5755-a341-faedb1a857bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a2ef6-4316-4dbf-9725-7da20f38218d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a2ef6-4316-4dbf-9725-7da20f38218d.jpg?1",
             "name": "Windbrisk Heights",
             "text": "",
             "colours": [],
@@ -30971,7 +30971,7 @@
         },
         {
             "id": "f60d7f3e-6bc0-52d0-9ace-c6692af6e01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613e0e75-9b61-4c16-bb83-53546dc9f502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613e0e75-9b61-4c16-bb83-53546dc9f502.jpg?1",
             "name": "Woodland Cemetery",
             "text": "",
             "colours": [],
@@ -31005,7 +31005,7 @@
         },
         {
             "id": "36f2217c-e576-502c-9f53-66659ed7fc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c15c48-8425-48f5-80f7-c8f74ad773e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c15c48-8425-48f5-80f7-c8f74ad773e1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -31042,7 +31042,7 @@
         },
         {
             "id": "56c03c7d-74c6-5fef-98b7-5e230d49e534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783eeb62-ab10-437d-a6cd-c3f99401b818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783eeb62-ab10-437d-a6cd-c3f99401b818.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -31079,7 +31079,7 @@
         },
         {
             "id": "8c79a832-3809-52c0-9f9c-69e5a0e9f955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6317711a-83fc-4f6e-87d2-a147b34275ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6317711a-83fc-4f6e-87d2-a147b34275ec.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -31116,7 +31116,7 @@
         },
         {
             "id": "53815ef0-7bdf-5582-9eb1-66ec07ee6407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0480b669-e72b-4b21-b0f3-09d78abe421c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0480b669-e72b-4b21-b0f3-09d78abe421c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -31153,7 +31153,7 @@
         },
         {
             "id": "801ceeaa-a2e5-5fc0-8506-ca2548959873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37f8bb9-1d63-4f28-b15d-06f423785599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a37f8bb9-1d63-4f28-b15d-06f423785599.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -31190,7 +31190,7 @@
         },
         {
             "id": "0fe24ba3-3454-5c17-9bbf-d4c7e4a7dc96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c16759-117f-4f17-baea-88b18d391c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c16759-117f-4f17-baea-88b18d391c38.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -31227,7 +31227,7 @@
         },
         {
             "id": "792c949a-cd53-5b66-8a2d-997ea2514bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0e93c3-48e3-4ae5-a33f-4ef83f67ee37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0e93c3-48e3-4ae5-a33f-4ef83f67ee37.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -31264,7 +31264,7 @@
         },
         {
             "id": "9c056223-0361-52b9-9f43-4e07641c2f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84298c7a-8bae-4e62-bd0a-bcce2156fdf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84298c7a-8bae-4e62-bd0a-bcce2156fdf1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -31301,7 +31301,7 @@
         },
         {
             "id": "1806d26c-f48b-542a-be8a-9e4de194fa9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35801ab-e484-44cb-b9ec-80723cb25bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35801ab-e484-44cb-b9ec-80723cb25bc7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -31338,7 +31338,7 @@
         },
         {
             "id": "52bc880b-c907-52d6-8eb6-931fe4e2d356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9305b9c-63af-49a3-97c2-0b3597555cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9305b9c-63af-49a3-97c2-0b3597555cc2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -31375,7 +31375,7 @@
         },
         {
             "id": "a077cbb1-43ac-5ba5-b5bb-deabf3d78574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682f0d75-0c08-4a4f-990c-2cc14761b616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/682f0d75-0c08-4a4f-990c-2cc14761b616.jpg?1",
             "name": "Idolized",
             "text": "",
             "colours": [
@@ -31412,7 +31412,7 @@
         },
         {
             "id": "e5dc9bf6-0d04-5d65-94d8-9625c53034d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7951636-0969-4157-a9a5-96f86f61524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7951636-0969-4157-a9a5-96f86f61524c.jpg?1",
             "name": "Securitron Squadron",
             "text": "",
             "colours": [
@@ -31450,7 +31450,7 @@
         },
         {
             "id": "9915c1df-c151-5e79-9936-f4ecad7b17b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0ba541-930a-404f-bd38-f1aa8bd52ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d0ba541-930a-404f-bd38-f1aa8bd52ed5.jpg?1",
             "name": "Radstorm",
             "text": "",
             "colours": [
@@ -31485,7 +31485,7 @@
         },
         {
             "id": "8936e594-33f8-54e0-822a-c379bf8c1373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ebaef-f153-4e5f-86d4-03750c80416a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ebaef-f153-4e5f-86d4-03750c80416a.jpg?1",
             "name": "Synth Infiltrator",
             "text": "",
             "colours": [
@@ -31523,7 +31523,7 @@
         },
         {
             "id": "c7d6f045-fdf4-5ce2-a716-ee98e7ea313e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf96a60-ab61-410e-9faf-1aba5fb81bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf96a60-ab61-410e-9faf-1aba5fb81bfb.jpg?1",
             "name": "Nuclear Fallout",
             "text": "",
             "colours": [
@@ -31558,7 +31558,7 @@
         },
         {
             "id": "6f0d9e88-d1e9-5135-8843-10b2a35aad6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bcd152-b1ba-4c49-8ad9-c71f31218ba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bcd152-b1ba-4c49-8ad9-c71f31218ba8.jpg?1",
             "name": "Screeching Scorchbeast",
             "text": "",
             "colours": [
@@ -31596,7 +31596,7 @@
         },
         {
             "id": "84bb2aeb-52f6-5c38-84d7-02513c174ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa9106-9ea8-4497-98a8-a005f5437a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa9106-9ea8-4497-98a8-a005f5437a30.jpg?1",
             "name": "V.A.T.S.",
             "text": "",
             "colours": [
@@ -31631,7 +31631,7 @@
         },
         {
             "id": "5b057419-8c77-5417-bf15-9c69c3c65db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad3fb9e-ec2e-4ac5-ba77-7052ebc3a2ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad3fb9e-ec2e-4ac5-ba77-7052ebc3a2ab.jpg?1",
             "name": "Mysterious Stranger",
             "text": "",
             "colours": [
@@ -31669,7 +31669,7 @@
         },
         {
             "id": "d8e2c85a-bc7e-53a3-9231-96c49a0a4f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29442821-cb24-4e55-b65a-88742cd793ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29442821-cb24-4e55-b65a-88742cd793ef.jpg?1",
             "name": "Watchful Radstag",
             "text": "",
             "colours": [
@@ -31707,7 +31707,7 @@
         },
         {
             "id": "bec120ae-6e85-53d5-986a-9ab2f363275d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a85ee1e-554e-42cf-88da-2de42a43c293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a85ee1e-554e-42cf-88da-2de42a43c293.jpg?1",
             "name": "Alpha Deathclaw",
             "text": "",
             "colours": [
@@ -31747,7 +31747,7 @@
         },
         {
             "id": "fcb5130d-0974-5b56-ab32-0d51a34cf19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a1c494-b569-4cf4-9af2-d462c38f1792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a1c494-b569-4cf4-9af2-d462c38f1792.jpg?1",
             "name": "Armory Paladin",
             "text": "",
             "colours": [
@@ -31787,7 +31787,7 @@
         },
         {
             "id": "6693e602-b3a1-533c-881e-ea0e816455f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da41054-7f89-4c74-8c58-092f9d6ed144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da41054-7f89-4c74-8c58-092f9d6ed144.jpg?1",
             "name": "Atomize",
             "text": "",
             "colours": [
@@ -31824,7 +31824,7 @@
         },
         {
             "id": "e962df5e-6e2c-535d-9a75-98ba63d9cb72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87eec46e-dc81-45aa-9026-c010663e0756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87eec46e-dc81-45aa-9026-c010663e0756.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "",
             "colours": [
@@ -31869,7 +31869,7 @@
         },
         {
             "id": "4ef39d13-b1e3-580a-9903-c5251abcdfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985d780d-e049-4638-8f5a-9611efcfe09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985d780d-e049-4638-8f5a-9611efcfe09f.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "",
             "colours": [
@@ -31913,7 +31913,7 @@
         },
         {
             "id": "cd434f3b-4abe-53cb-9079-fe781d655544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b35ceb-1927-4a87-a489-7b2bc9b9ceaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6b35ceb-1927-4a87-a489-7b2bc9b9ceaa.jpg?1",
             "name": "Dr. Madison Li",
             "text": "",
             "colours": [
@@ -31958,7 +31958,7 @@
         },
         {
             "id": "03729953-cf82-5e40-b048-5908d9d35663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b81d84-cc20-4123-9aab-56abdadb3516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b81d84-cc20-4123-9aab-56abdadb3516.jpg?1",
             "name": "Inventory Management",
             "text": "",
             "colours": [
@@ -31995,7 +31995,7 @@
         },
         {
             "id": "fff584d9-2778-52d3-9cb0-a561f284970d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a769dd6-3018-412f-b8ea-2434c5074945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a769dd6-3018-412f-b8ea-2434c5074945.jpg?1",
             "name": "The Wise Mothman",
             "text": "",
             "colours": [
@@ -32040,7 +32040,7 @@
         },
         {
             "id": "f89dec07-fa46-54e5-bc88-e9dc440b1cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82e6a6-2ed6-4e97-a637-586d65af7aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f82e6a6-2ed6-4e97-a637-586d65af7aaf.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "",
             "colours": [
@@ -32076,7 +32076,7 @@
         },
         {
             "id": "2c3e8298-1b05-5fd1-ae2b-0b055d0f65f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342240d-cbcc-41a0-9b7d-514ca2273b80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9342240d-cbcc-41a0-9b7d-514ca2273b80.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -32111,7 +32111,7 @@
         },
         {
             "id": "38ecdfce-08c8-5ede-9762-38939023407a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664c7357-93c3-4148-baf4-d7c88aa69ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664c7357-93c3-4148-baf4-d7c88aa69ac9.jpg?1",
             "name": "Grave Titan",
             "text": "",
             "colours": [
@@ -32146,7 +32146,7 @@
         },
         {
             "id": "dd53937f-0766-55b2-b44f-41f9838f1b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d78449-9e80-42e5-b525-068a3985e069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d78449-9e80-42e5-b525-068a3985e069.jpg?1",
             "name": "Vigor",
             "text": "",
             "colours": [
@@ -32182,7 +32182,7 @@
         },
         {
             "id": "19b6f43a-e99e-58a0-b8cd-b461be39cdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b20cbf0-0cfe-4adb-bbf5-31ff98cd8382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b20cbf0-0cfe-4adb-bbf5-31ff98cd8382.jpg?1",
             "name": "Ayula, Queen Among Bears",
             "text": "",
             "colours": [
@@ -32219,7 +32219,7 @@
         },
         {
             "id": "16261784-995c-567c-80a0-a617974a9d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb6278-9b1d-4bac-bebd-e084e713d54a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8eb6278-9b1d-4bac-bebd-e084e713d54a.jpg?1",
             "name": "Tarmogoyf",
             "text": "",
             "colours": [
@@ -32254,7 +32254,7 @@
         },
         {
             "id": "615fac4e-e777-56d1-a081-5d76072e8b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35408cdb-5123-455b-9944-a871d5303510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35408cdb-5123-455b-9944-a871d5303510.jpg?1",
             "name": "Hornet Queen",
             "text": "",
             "colours": [
@@ -32289,7 +32289,7 @@
         },
         {
             "id": "f9e27f19-d758-5785-a36c-69e70a3ffd6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e524a4b-ce4d-43cc-a04f-4f4432746ede.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e524a4b-ce4d-43cc-a04f-4f4432746ede.jpg?1",
             "name": "Gemrazer",
             "text": "",
             "colours": [
@@ -32324,7 +32324,7 @@
         },
         {
             "id": "d8d7fd94-eea3-5a82-a31a-bea222538380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81111fb0-93fe-4cac-9ce2-bdf2466d7341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81111fb0-93fe-4cac-9ce2-bdf2466d7341.jpg?1",
             "name": "Walking Ballista",
             "text": "",
             "colours": [],
@@ -32356,7 +32356,7 @@
         },
         {
             "id": "ede7bd8e-ab87-563a-b8ab-e95a529eca8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a66c7bb-ef8a-4cb2-aebf-36a31883f1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a66c7bb-ef8a-4cb2-aebf-36a31883f1bf.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -32389,7 +32389,7 @@
         },
         {
             "id": "e2332d16-ff5e-5d7c-a090-7be0bf78c46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe116d16-8c6e-47c2-a2bd-01529caae440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe116d16-8c6e-47c2-a2bd-01529caae440.jpg?1",
             "name": "Ravages of War",
             "text": "",
             "colours": [
@@ -32422,7 +32422,7 @@
         },
         {
             "id": "e7e8f5d7-bbe8-5162-8180-69d3818ac6bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d96f945-cf40-456d-b53b-95ef1524777c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d96f945-cf40-456d-b53b-95ef1524777c.jpg?1",
             "name": "Vandalblast",
             "text": "",
             "colours": [
@@ -32455,7 +32455,7 @@
         },
         {
             "id": "f274ef5f-0964-5cf5-9ee8-976035f18b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847c19ee-c4f9-49e7-842f-a07033bc604b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847c19ee-c4f9-49e7-842f-a07033bc604b.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -32486,7 +32486,7 @@
         },
         {
             "id": "9e5bb90c-6c22-5c3a-b973-2f84e94a516c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef970bfc-462d-4998-9366-eed160ab57da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef970bfc-462d-4998-9366-eed160ab57da.jpg?1",
             "name": "Crucible of Worlds",
             "text": "",
             "colours": [],
@@ -32515,7 +32515,7 @@
         },
         {
             "id": "8f96bf72-71b4-5dca-8df6-25810e8b3159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237fd51-5a49-4ada-8bea-236be78412ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a237fd51-5a49-4ada-8bea-236be78412ac.jpg?1",
             "name": "Nuka-Cola Vending Machine",
             "text": "",
             "colours": [],
@@ -32546,7 +32546,7 @@
         },
         {
             "id": "34c18918-d03e-52a3-985e-b7af3c6ea2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cd916c-7464-4391-814b-09eac0d8d204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cd916c-7464-4391-814b-09eac0d8d204.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -32577,7 +32577,7 @@
         },
         {
             "id": "7d9df13d-45ba-5f72-8111-9b4e33fbde3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186ca552-40bd-4ca0-9c2a-e899c443643b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186ca552-40bd-4ca0-9c2a-e899c443643b.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32608,7 +32608,7 @@
         },
         {
             "id": "3f114aed-300f-5b3a-a209-d0116a4e4fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfc63d-fc27-40dd-8e03-f1e24df6b911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bfc63d-fc27-40dd-8e03-f1e24df6b911.jpg?1",
             "name": "Wasteland",
             "text": "",
             "colours": [],
@@ -32637,7 +32637,7 @@
         },
         {
             "id": "29e58061-8da7-51c9-9e97-00111d8a13c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382f11f-c32f-46cb-a578-d82e545691c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3382f11f-c32f-46cb-a578-d82e545691c3.jpg?1",
             "name": "Aradesh, the Founder",
             "text": "",
             "colours": [
@@ -32677,7 +32677,7 @@
         },
         {
             "id": "eb79e497-fffc-579b-8c40-a245fe90d0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf60b162-3e56-4ae6-a27f-7fa09491f839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf60b162-3e56-4ae6-a27f-7fa09491f839.jpg?1",
             "name": "Automated Assembly Line",
             "text": "",
             "colours": [
@@ -32712,7 +32712,7 @@
         },
         {
             "id": "8f73d8bb-9d96-5906-99ef-e17bcb42ef2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58508e3-144b-4876-9e25-c9b78eba0b0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58508e3-144b-4876-9e25-c9b78eba0b0a.jpg?1",
             "name": "Battle of Hoover Dam",
             "text": "",
             "colours": [
@@ -32747,7 +32747,7 @@
         },
         {
             "id": "348af9fa-91f0-53cc-b63a-813f5e99fd89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8853734f-5538-43b5-a634-e210f80b5546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8853734f-5538-43b5-a634-e210f80b5546.jpg?1",
             "name": "Brotherhood Scribe",
             "text": "",
             "colours": [
@@ -32785,7 +32785,7 @@
         },
         {
             "id": "586be17f-1ff4-5785-bd70-b8884935fb68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6327f10-a2d3-4e2f-8d43-5a9d3f667e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6327f10-a2d3-4e2f-8d43-5a9d3f667e89.jpg?1",
             "name": "Codsworth, Handy Helper",
             "text": "",
             "colours": [
@@ -32825,7 +32825,7 @@
         },
         {
             "id": "487fa8a7-e51f-54db-9797-ddd9b0044da6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ce2c9-b2aa-47c9-ae6e-480c9733e5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ce2c9-b2aa-47c9-ae6e-480c9733e5bb.jpg?1",
             "name": "Overencumbered",
             "text": "",
             "colours": [
@@ -32862,7 +32862,7 @@
         },
         {
             "id": "d9a3756c-d0a3-52fb-ac54-0ef3f98ff976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9db6bb-a6c8-4118-aa63-e29fd999cf3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9db6bb-a6c8-4118-aa63-e29fd999cf3f.jpg?1",
             "name": "Overseer of Vault 76",
             "text": "",
             "colours": [
@@ -32902,7 +32902,7 @@
         },
         {
             "id": "0c5f7aca-8696-50ed-8f87-9c264546d67f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295ef96f-512a-4277-89f0-8131a30faa59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295ef96f-512a-4277-89f0-8131a30faa59.jpg?1",
             "name": "Pre-War Formalwear",
             "text": "",
             "colours": [
@@ -32939,7 +32939,7 @@
         },
         {
             "id": "ce5cd244-ac2f-53ea-bed3-d6513ba7d84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18c8974-61d6-4076-a612-9f5df80ac076.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18c8974-61d6-4076-a612-9f5df80ac076.jpg?1",
             "name": "The Prydwen, Steel Flagship",
             "text": "",
             "colours": [
@@ -32978,7 +32978,7 @@
         },
         {
             "id": "82f57cda-72e4-5655-ab13-13af02617efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12bd82f-a201-4faa-818a-ef335c72d7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12bd82f-a201-4faa-818a-ef335c72d7bf.jpg?1",
             "name": "Sentry Bot",
             "text": "",
             "colours": [
@@ -33016,7 +33016,7 @@
         },
         {
             "id": "a3688476-03bc-5e8c-991a-2fb0e6b9f73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd827857-3971-48ec-9aec-fe7d4c49882a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd827857-3971-48ec-9aec-fe7d4c49882a.jpg?1",
             "name": "Sierra, Nuka's Biggest Fan",
             "text": "",
             "colours": [
@@ -33056,7 +33056,7 @@
         },
         {
             "id": "3f6a2a10-cc81-54e2-94a5-218801e9f144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f266eb4-1de6-41c2-9b8c-eb62e9093980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f266eb4-1de6-41c2-9b8c-eb62e9093980.jpg?1",
             "name": "Yes Man, Personal Securitron",
             "text": "",
             "colours": [
@@ -33096,7 +33096,7 @@
         },
         {
             "id": "685619ea-c8f1-5f41-97db-60ba542c84b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522b0987-9a79-40dd-9205-38274ac2bb1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522b0987-9a79-40dd-9205-38274ac2bb1d.jpg?1",
             "name": "Curie, Emergent Intelligence",
             "text": "",
             "colours": [
@@ -33136,7 +33136,7 @@
         },
         {
             "id": "384b0fdb-0213-5799-ac92-4ad6e478844f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -33176,7 +33176,7 @@
         },
         {
             "id": "ae5da402-f07b-5787-95cd-dc8b1f5d9849",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/4/7450fcd7-e373-4122-aff5-73d9e8879c6f.jpg?1",
             "name": "James, Wandering Dad // Follow Him",
             "text": "",
             "colours": [
@@ -33213,7 +33213,7 @@
         },
         {
             "id": "5ef45cc5-f930-53db-ba68-1387e54fcd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492f15f9-8026-4ef7-82b3-389894906297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492f15f9-8026-4ef7-82b3-389894906297.jpg?1",
             "name": "Jason Bright, Glowing Prophet",
             "text": "",
             "colours": [
@@ -33254,7 +33254,7 @@
         },
         {
             "id": "5445c145-c6d3-53f6-aea0-5bd8f1bb3433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07b1d4-9823-4797-acd6-22f1a0e31735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d07b1d4-9823-4797-acd6-22f1a0e31735.jpg?1",
             "name": "Mirelurk Queen",
             "text": "",
             "colours": [
@@ -33292,7 +33292,7 @@
         },
         {
             "id": "fc1983d9-c1d4-52bc-8966-c89a79c22ca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9aba4b8-e830-4a75-8b1f-b0059773dd78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9aba4b8-e830-4a75-8b1f-b0059773dd78.jpg?1",
             "name": "Nick Valentine, Private Eye",
             "text": "",
             "colours": [
@@ -33333,7 +33333,7 @@
         },
         {
             "id": "2a04f7fd-c320-5153-b3f6-93f93034b923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f313db51-fa28-4a66-b96f-f7f2bb4eae9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f313db51-fa28-4a66-b96f-f7f2bb4eae9f.jpg?1",
             "name": "Piper Wright, Publick Reporter",
             "text": "",
             "colours": [
@@ -33373,7 +33373,7 @@
         },
         {
             "id": "94e1f88a-545a-5004-a6a8-17629bc703f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c04bb6-108f-40d5-bc0f-b33ad749cf26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c04bb6-108f-40d5-bc0f-b33ad749cf26.jpg?1",
             "name": "Struggle for Project Purity",
             "text": "",
             "colours": [
@@ -33408,7 +33408,7 @@
         },
         {
             "id": "32edc037-b226-5a42-9447-bbe128a3b780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d9eb00-5d34-4a2f-963c-017e3229dd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d9eb00-5d34-4a2f-963c-017e3229dd5a.jpg?1",
             "name": "Feral Ghoul",
             "text": "",
             "colours": [
@@ -33446,7 +33446,7 @@
         },
         {
             "id": "fdfaf1df-92cb-5ab0-b838-d2e66c2739fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a594b6-6fda-49f8-a2d5-95bccec830dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a594b6-6fda-49f8-a2d5-95bccec830dd.jpg?1",
             "name": "Hancock, Ghoulish Mayor",
             "text": "",
             "colours": [
@@ -33487,7 +33487,7 @@
         },
         {
             "id": "39ab9da7-8ada-5a77-abb6-b263d413adc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75af4c9-7d5b-4846-a20c-3f1c40d1a5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75af4c9-7d5b-4846-a20c-3f1c40d1a5c3.jpg?1",
             "name": "Wasteland Raider",
             "text": "",
             "colours": [
@@ -33525,7 +33525,7 @@
         },
         {
             "id": "e3cf2aa3-1a7b-59a8-8833-c6bc0636e0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd3a6bb-5578-449f-864c-9923ba10c4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd3a6bb-5578-449f-864c-9923ba10c4e8.jpg?1",
             "name": "Assaultron Dominator",
             "text": "",
             "colours": [
@@ -33563,7 +33563,7 @@
         },
         {
             "id": "e676c81e-73ff-5262-a681-2c6885ef6074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c339fe-47cf-4a93-93b8-2fa00b6dfacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c339fe-47cf-4a93-93b8-2fa00b6dfacc.jpg?1",
             "name": "Duchess, Wayward Tavernkeep",
             "text": "",
             "colours": [
@@ -33603,7 +33603,7 @@
         },
         {
             "id": "02711ffa-0148-5c89-a7a4-78aaf81ce34d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6100a41b-ecc2-4489-9109-de9bd1cac6aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6100a41b-ecc2-4489-9109-de9bd1cac6aa.jpg?1",
             "name": "Grim Reaper's Sprint",
             "text": "",
             "colours": [
@@ -33640,7 +33640,7 @@
         },
         {
             "id": "52a03151-ee94-5a7e-ace3-34cb4cbcb2e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92550d-7cc9-43f4-80b4-4a49bd8806b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92550d-7cc9-43f4-80b4-4a49bd8806b1.jpg?1",
             "name": "Junk Jet",
             "text": "",
             "colours": [
@@ -33677,7 +33677,7 @@
         },
         {
             "id": "5db0c852-e0b6-5935-a130-73bcd3734480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89241e80-3637-4ea0-afb4-14e5a22aa393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89241e80-3637-4ea0-afb4-14e5a22aa393.jpg?1",
             "name": "Megaton's Fate",
             "text": "",
             "colours": [
@@ -33712,7 +33712,7 @@
         },
         {
             "id": "73c13388-ce92-5266-836f-f929383b6712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f643e-985b-4965-862d-8ba8a2733514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6f643e-985b-4965-862d-8ba8a2733514.jpg?1",
             "name": "The Motherlode, Excavator",
             "text": "",
             "colours": [
@@ -33752,7 +33752,7 @@
         },
         {
             "id": "ac3299a4-0269-53aa-bd33-56d393e0fd54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934217-04c4-4047-b5e2-183431123825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934217-04c4-4047-b5e2-183431123825.jpg?1",
             "name": "Plasma Caster",
             "text": "",
             "colours": [
@@ -33789,7 +33789,7 @@
         },
         {
             "id": "c21298fd-308f-5d25-8cb3-040d04c06f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa2906-f364-4681-8cf8-1510c7ba749e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa2906-f364-4681-8cf8-1510c7ba749e.jpg?1",
             "name": "Powder Ganger",
             "text": "",
             "colours": [
@@ -33827,7 +33827,7 @@
         },
         {
             "id": "19f48b0e-07c8-52e7-951c-db41a560deb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caae2dad-2e81-46b3-8e2d-cf1980aeba3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caae2dad-2e81-46b3-8e2d-cf1980aeba3c.jpg?1",
             "name": "Rose, Cutthroat Raider",
             "text": "",
             "colours": [
@@ -33867,7 +33867,7 @@
         },
         {
             "id": "b0700bed-1e1f-57e5-b335-2dcea053e2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d4ad5e-0201-4d8c-be94-ba7052e5c019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d4ad5e-0201-4d8c-be94-ba7052e5c019.jpg?1",
             "name": "Synth Eradicator",
             "text": "",
             "colours": [
@@ -33906,7 +33906,7 @@
         },
         {
             "id": "01354dad-ba34-5e7e-89db-7870eefc7ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf633e4-8d57-4357-b1c6-e4cf91ebecb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf633e4-8d57-4357-b1c6-e4cf91ebecb3.jpg?1",
             "name": "Thrill-Kill Disciple",
             "text": "",
             "colours": [
@@ -33944,7 +33944,7 @@
         },
         {
             "id": "1c1f96dd-dba6-59c9-b835-a76db49f78e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299640b7-1924-4788-a425-bb30f6d619a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299640b7-1924-4788-a425-bb30f6d619a1.jpg?1",
             "name": "Veronica, Dissident Scribe",
             "text": "",
             "colours": [
@@ -33985,7 +33985,7 @@
         },
         {
             "id": "73b9e8ae-42ce-559d-aa99-3e0cacd8b6e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2140ef84-a738-4b85-b67e-ea2d4c03b5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2140ef84-a738-4b85-b67e-ea2d4c03b5e8.jpg?1",
             "name": "Wild Wasteland",
             "text": "",
             "colours": [
@@ -34020,7 +34020,7 @@
         },
         {
             "id": "b15ee0c6-1a75-5c76-a8a1-5cd74f9618f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d965b1cf-44f4-40d4-b06e-deca3c132dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d965b1cf-44f4-40d4-b06e-deca3c132dbc.jpg?1",
             "name": "Animal Friend",
             "text": "",
             "colours": [
@@ -34057,7 +34057,7 @@
         },
         {
             "id": "557cba90-e267-5246-83bc-14910a130f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e0d4d40-9fd6-4550-a7c8-45aaf5a7e17f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e0d4d40-9fd6-4550-a7c8-45aaf5a7e17f.jpg?1",
             "name": "Harold and Bob, First Numens",
             "text": "",
             "colours": [
@@ -34097,7 +34097,7 @@
         },
         {
             "id": "eb84f19e-1a25-5691-9cfc-3ecc38208ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f5a89-1b83-40d3-81b2-0b54e80ee9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7f5a89-1b83-40d3-81b2-0b54e80ee9f9.jpg?1",
             "name": "Lily Bowen, Raging Grandma",
             "text": "",
             "colours": [
@@ -34137,7 +34137,7 @@
         },
         {
             "id": "fedc107c-cc3a-533c-ada3-5a914b92b509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee6b263-c15a-47a3-9546-fc36dbda74b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee6b263-c15a-47a3-9546-fc36dbda74b6.jpg?1",
             "name": "Power Fist",
             "text": "",
             "colours": [
@@ -34174,7 +34174,7 @@
         },
         {
             "id": "4b125f9b-a9ce-556b-bda5-6edaf78d8901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a02723-3f78-48bf-baa2-ebed73403688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a02723-3f78-48bf-baa2-ebed73403688.jpg?1",
             "name": "Rampaging Yao Guai",
             "text": "",
             "colours": [
@@ -34212,7 +34212,7 @@
         },
         {
             "id": "f14dbd07-658c-58c2-9554-242e0a1486b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0374c25-1de7-451b-9b9f-e81429f3ea30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0374c25-1de7-451b-9b9f-e81429f3ea30.jpg?1",
             "name": "Strong Back",
             "text": "",
             "colours": [
@@ -34249,7 +34249,7 @@
         },
         {
             "id": "17f33f3e-c2e8-5501-9bf1-930a77231986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe374-7594-437c-aaab-37a4ce5c7751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84fbe374-7594-437c-aaab-37a4ce5c7751.jpg?1",
             "name": "Strong, the Brutish Thespian",
             "text": "",
             "colours": [
@@ -34289,7 +34289,7 @@
         },
         {
             "id": "db18cb32-a9c9-5a10-ac81-8f120af0fe8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ce341f-1e23-44dc-8577-f5ad77962f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ce341f-1e23-44dc-8577-f5ad77962f1b.jpg?1",
             "name": "Tato Farmer",
             "text": "",
             "colours": [
@@ -34328,7 +34328,7 @@
         },
         {
             "id": "998e06da-f0fa-5be6-8c4d-1f26735422ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68fb1eb-6dc1-4feb-b5ad-44805ecc6da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68fb1eb-6dc1-4feb-b5ad-44805ecc6da6.jpg?1",
             "name": "Agent Frank Horrigan",
             "text": "",
             "colours": [
@@ -34370,7 +34370,7 @@
         },
         {
             "id": "84ca4d27-1c25-5513-82e5-7866a746975e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717522d7-09b4-4659-b88f-58aaacd1aa8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717522d7-09b4-4659-b88f-58aaacd1aa8d.jpg?1",
             "name": "Almost Perfect",
             "text": "",
             "colours": [
@@ -34409,7 +34409,7 @@
         },
         {
             "id": "f669c7e6-67a0-5fdd-9b48-6142bdd6fbb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61569b1a-2942-4426-a9d5-3130f725f3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61569b1a-2942-4426-a9d5-3130f725f3d6.jpg?1",
             "name": "Arcade Gannon",
             "text": "",
             "colours": [
@@ -34451,7 +34451,7 @@
         },
         {
             "id": "25aa037d-d8c6-5fcc-b53e-059320398627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf59a3b-f837-42b5-a680-a519d64d2aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf59a3b-f837-42b5-a680-a519d64d2aa9.jpg?1",
             "name": "Boomer Scrapper",
             "text": "",
             "colours": [
@@ -34491,7 +34491,7 @@
         },
         {
             "id": "d8ce2145-872c-55d7-8f41-765211737c94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e492470-dff3-4005-b0ee-0810b73601de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e492470-dff3-4005-b0ee-0810b73601de.jpg?1",
             "name": "Cait, Cage Brawler",
             "text": "",
             "colours": [
@@ -34533,7 +34533,7 @@
         },
         {
             "id": "668a2d1b-a14d-5cd9-8e13-9dad0315731b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c1d18d-a575-4d8d-a16e-fae0bdc43380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c1d18d-a575-4d8d-a16e-fae0bdc43380.jpg?1",
             "name": "Cass, Hand of Vengeance",
             "text": "",
             "colours": [
@@ -34575,7 +34575,7 @@
         },
         {
             "id": "e72d0f8b-d9f4-5a91-89f9-d6794125e2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cc1769-e09f-43c0-9c03-979cb0a764a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14cc1769-e09f-43c0-9c03-979cb0a764a2.jpg?1",
             "name": "Colonel Autumn",
             "text": "",
             "colours": [
@@ -34617,7 +34617,7 @@
         },
         {
             "id": "c6398647-8f92-52c5-b24c-531359b44bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f84c2-0a96-4f50-9b68-f2968044c202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7f84c2-0a96-4f50-9b68-f2968044c202.jpg?1",
             "name": "Desdemona, Freedom's Edge",
             "text": "",
             "colours": [
@@ -34659,7 +34659,7 @@
         },
         {
             "id": "0a8f5080-6dc9-5729-b15f-ffc21c1be39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51434898-d4ac-4448-8223-f570204a6cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51434898-d4ac-4448-8223-f570204a6cba.jpg?1",
             "name": "Elder Arthur Maxson",
             "text": "",
             "colours": [
@@ -34701,7 +34701,7 @@
         },
         {
             "id": "4d66877a-f392-5da9-9bd0-4c78c079a082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f388077-d7a5-41a2-a9e9-4c3a5f7c6b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f388077-d7a5-41a2-a9e9-4c3a5f7c6b48.jpg?1",
             "name": "Electrosiphon",
             "text": "",
             "colours": [
@@ -34738,7 +34738,7 @@
         },
         {
             "id": "e45746c9-c3c7-5a37-acde-28869d3d0a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff1f97-01e8-4825-aff9-3c6bab10aaab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cff1f97-01e8-4825-aff9-3c6bab10aaab.jpg?1",
             "name": "Kellogg, Dangerous Mind",
             "text": "",
             "colours": [
@@ -34780,7 +34780,7 @@
         },
         {
             "id": "294dea5f-9d15-56a3-838e-e0bf8ced6c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7aa89-f7c0-471b-ab16-c0664f535942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7aa89-f7c0-471b-ab16-c0664f535942.jpg?1",
             "name": "Liberty Prime, Recharged",
             "text": "",
             "colours": [
@@ -34824,7 +34824,7 @@
         },
         {
             "id": "17757faf-eb2a-5d91-ab64-559fd7a5937d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bb617b-34e9-4126-9d45-7561640896db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bb617b-34e9-4126-9d45-7561640896db.jpg?1",
             "name": "MacCready, Lamplight Mayor",
             "text": "",
             "colours": [
@@ -34866,7 +34866,7 @@
         },
         {
             "id": "ac7a386c-c28c-5238-9610-91d8f3cbb72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724cbef5-7f32-4341-9455-f2b8027ff715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724cbef5-7f32-4341-9455-f2b8027ff715.jpg?1",
             "name": "Marcus, Mutant Mayor",
             "text": "",
             "colours": [
@@ -34908,7 +34908,7 @@
         },
         {
             "id": "a3a1d39a-58b2-5bf9-9a2b-a77f8962dc7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d4b2e0-1e57-461d-9c5e-fea4b9ebe897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d4b2e0-1e57-461d-9c5e-fea4b9ebe897.jpg?1",
             "name": "The Master, Transcendent",
             "text": "",
             "colours": [
@@ -34952,7 +34952,7 @@
         },
         {
             "id": "a38c3016-f3be-543d-beb8-5f5ef1a3a0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1062b4a3-c6f0-413a-b6f0-182c0d69b114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1062b4a3-c6f0-413a-b6f0-182c0d69b114.jpg?1",
             "name": "Moira Brown, Guide Author",
             "text": "",
             "colours": [
@@ -34994,7 +34994,7 @@
         },
         {
             "id": "94cc7a27-33e5-50cd-a697-8a5d7af74401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fa1d0-ec56-4be8-973b-384ae0e66b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fa1d0-ec56-4be8-973b-384ae0e66b6c.jpg?1",
             "name": "Mr. House, President and CEO",
             "text": "",
             "colours": [
@@ -35038,7 +35038,7 @@
         },
         {
             "id": "6888f602-6092-5f9a-995e-362f79f18b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa8edfc-6a80-4982-a009-70d3d4259fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa8edfc-6a80-4982-a009-70d3d4259fd1.jpg?1",
             "name": "Mutational Advantage",
             "text": "",
             "colours": [
@@ -35075,7 +35075,7 @@
         },
         {
             "id": "88fea92a-4f1d-5833-9bda-7ba6b5613b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099d5706-6595-4129-83d7-ca4ae1c8e363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099d5706-6595-4129-83d7-ca4ae1c8e363.jpg?1",
             "name": "The Nipton Lottery",
             "text": "",
             "colours": [
@@ -35112,7 +35112,7 @@
         },
         {
             "id": "11023831-7b90-569d-898f-a45f1bd4dd44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9972f7e4-a5d1-48ca-95a4-4b7f3f49563e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9972f7e4-a5d1-48ca-95a4-4b7f3f49563e.jpg?1",
             "name": "Paladin Elizabeth Taggerdy",
             "text": "",
             "colours": [
@@ -35154,7 +35154,7 @@
         },
         {
             "id": "adc4acf0-7075-5749-96a9-a8a5166f472c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834c8bf-1278-4cdb-a8e1-30fb2e2c66eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2834c8bf-1278-4cdb-a8e1-30fb2e2c66eb.jpg?1",
             "name": "Preston Garvey, Minuteman",
             "text": "",
             "colours": [
@@ -35198,7 +35198,7 @@
         },
         {
             "id": "31aae57e-4b75-5ac5-b481-c40a4876646a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2172a39d-7481-4a4a-861b-b4a1204d28ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2172a39d-7481-4a4a-861b-b4a1204d28ef.jpg?1",
             "name": "Red Death, Shipwrecker",
             "text": "",
             "colours": [
@@ -35240,7 +35240,7 @@
         },
         {
             "id": "8953c852-d796-570e-a136-74af300d3d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539a969b-18ae-4958-b4bc-32b2ac3d4295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539a969b-18ae-4958-b4bc-32b2ac3d4295.jpg?1",
             "name": "Rex, Cyber-Hound",
             "text": "",
             "colours": [
@@ -35283,7 +35283,7 @@
         },
         {
             "id": "95aecdd9-5b47-5d27-b65a-ab0c614d9474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a321f651-1016-4fce-bc9e-be11d90cea30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a321f651-1016-4fce-bc9e-be11d90cea30.jpg?1",
             "name": "Sentinel Sarah Lyons",
             "text": "",
             "colours": [
@@ -35325,7 +35325,7 @@
         },
         {
             "id": "3fc8e574-2841-58c4-9347-5f019dde460a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead06c9-4175-42a3-be4c-0b685c6cf8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bead06c9-4175-42a3-be4c-0b685c6cf8b7.jpg?1",
             "name": "Shaun, Father of Synths",
             "text": "",
             "colours": [
@@ -35367,7 +35367,7 @@
         },
         {
             "id": "e647c25a-aaa0-5e2a-82c3-897663001e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ef2bb3-ecb7-43c6-b4ed-982983c3060d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ef2bb3-ecb7-43c6-b4ed-982983c3060d.jpg?1",
             "name": "Three Dog, Galaxy News DJ",
             "text": "",
             "colours": [
@@ -35409,7 +35409,7 @@
         },
         {
             "id": "5be3efdf-efc1-5457-b0be-1808619a7a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49c217d-b476-421c-9b17-aba9f3bb5454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49c217d-b476-421c-9b17-aba9f3bb5454.jpg?1",
             "name": "Brotherhood Vertibird",
             "text": "",
             "colours": [],
@@ -35442,7 +35442,7 @@
         },
         {
             "id": "ad11c0a3-5d5b-53e2-ba34-b3bcd9f3a3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc1e676-2e9e-406a-b01d-b3b4893ffbae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc1e676-2e9e-406a-b01d-b3b4893ffbae.jpg?1",
             "name": "ED-E, Lonesome Eyebot",
             "text": "",
             "colours": [],
@@ -35478,7 +35478,7 @@
         },
         {
             "id": "b3cf5a0c-6140-5c70-9185-24ee0689b473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b0b820-338d-4045-bbc6-bf605785c7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b0b820-338d-4045-bbc6-bf605785c7d5.jpg?1",
             "name": "Mister Gutsy",
             "text": "",
             "colours": [],
@@ -35513,7 +35513,7 @@
         },
         {
             "id": "34f93cb5-7a08-5ec9-91b9-5eff56658c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8176a675-cf7f-44cf-af3f-c77371a3165f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8176a675-cf7f-44cf-af3f-c77371a3165f.jpg?1",
             "name": "Nuka-Nuke Launcher",
             "text": "",
             "colours": [],
@@ -35546,7 +35546,7 @@
         },
         {
             "id": "2e2cedca-3c26-5287-ae94-d7d37ebd49e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf7bd2-be3f-4cae-82a1-3232b2dc2815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00cf7bd2-be3f-4cae-82a1-3232b2dc2815.jpg?1",
             "name": "Pip-Boy 3000",
             "text": "",
             "colours": [],
@@ -35579,7 +35579,7 @@
         },
         {
             "id": "3c53d6af-ea0b-53a0-828b-db16c3bdc88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15442abc-8a9a-4eeb-9166-8c0f502b11aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15442abc-8a9a-4eeb-9166-8c0f502b11aa.jpg?1",
             "name": "Recon Craft Theta",
             "text": "",
             "colours": [],
@@ -35612,7 +35612,7 @@
         },
         {
             "id": "ce55e074-3044-5c54-8281-ea8a2a04b426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5079fc-6381-4705-b3bd-9b29dbe62bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b5079fc-6381-4705-b3bd-9b29dbe62bfa.jpg?1",
             "name": "T-45 Power Armor",
             "text": "",
             "colours": [],
@@ -35645,7 +35645,7 @@
         },
         {
             "id": "b4e3aa06-310e-5c43-9fbc-3687dd028785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e282d9-33fb-4107-8a8c-add7bebcedd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e282d9-33fb-4107-8a8c-add7bebcedd1.jpg?1",
             "name": "Desolate Mire",
             "text": "",
             "colours": [],
@@ -35679,7 +35679,7 @@
         },
         {
             "id": "2669a7bf-1121-5098-a7c8-59be43c175b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eddac3-aa5c-4163-b223-b57da25ee4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38eddac3-aa5c-4163-b223-b57da25ee4a2.jpg?1",
             "name": "Diamond City",
             "text": "",
             "colours": [],
@@ -35710,7 +35710,7 @@
         },
         {
             "id": "d6ecd15b-de9c-528b-b7d2-9b72a6ca65f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a752279-4973-4824-bb79-8dac890c548e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a752279-4973-4824-bb79-8dac890c548e.jpg?1",
             "name": "Ferrous Lake",
             "text": "",
             "colours": [],
@@ -35744,7 +35744,7 @@
         },
         {
             "id": "61f76d39-3ce7-5554-916b-a5c643401190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcdab6a-2656-4515-baaa-47373253b6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcdab6a-2656-4515-baaa-47373253b6c8.jpg?1",
             "name": "HELIOS One",
             "text": "",
             "colours": [],
@@ -35775,7 +35775,7 @@
         },
         {
             "id": "4e597f57-69e0-572d-b93d-8a0aeb4894f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe44c048-7b6b-442f-a389-f633d752d08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe44c048-7b6b-442f-a389-f633d752d08e.jpg?1",
             "name": "Junktown",
             "text": "",
             "colours": [],
@@ -35808,7 +35808,7 @@
         },
         {
             "id": "1ab0dad8-e215-576c-99cd-14c58b49269f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2724c630-5638-4b6a-8f1e-0f764b11c8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2724c630-5638-4b6a-8f1e-0f764b11c8d8.jpg?1",
             "name": "Mariposa Military Base",
             "text": "",
             "colours": [],
@@ -35839,7 +35839,7 @@
         },
         {
             "id": "92860f56-b821-5e00-9d9d-9e6d60f6da9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068dc34e-976e-428f-8b83-e31466589310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068dc34e-976e-428f-8b83-e31466589310.jpg?1",
             "name": "Overflowing Basin",
             "text": "",
             "colours": [],
@@ -35873,7 +35873,7 @@
         },
         {
             "id": "e1ef2f28-f63b-5525-9f7b-05e3246d1c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2595012-a6ce-49d1-a1b6-27d06ae1fc64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2595012-a6ce-49d1-a1b6-27d06ae1fc64.jpg?1",
             "name": "Sunscorched Divide",
             "text": "",
             "colours": [],
@@ -35907,7 +35907,7 @@
         },
         {
             "id": "95bc038d-4207-5c48-9a59-56ed1814047f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d192615-0aaa-488f-b535-93b6a5a2d8bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d192615-0aaa-488f-b535-93b6a5a2d8bd.jpg?1",
             "name": "Viridescent Bog",
             "text": "",
             "colours": [],
@@ -35941,7 +35941,7 @@
         },
         {
             "id": "dadcbbf2-33d4-54fa-bc4e-8615a1008bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed103241-84e9-4a62-a76c-0cdf9a0c51b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed103241-84e9-4a62-a76c-0cdf9a0c51b4.jpg?1",
             "name": "Austere Command",
             "text": "",
             "colours": [
@@ -35976,7 +35976,7 @@
         },
         {
             "id": "4152fb5b-3eda-50f7-86ed-52bca3e2d547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ce501c-ae18-468e-922a-078c4eb130bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ce501c-ae18-468e-922a-078c4eb130bd.jpg?1",
             "name": "Captain of the Watch",
             "text": "",
             "colours": [
@@ -36014,7 +36014,7 @@
         },
         {
             "id": "2cd088af-d493-5ee7-a3cb-78483f138050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32abf12c-edda-479b-b844-aaa0b3061c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32abf12c-edda-479b-b844-aaa0b3061c0a.jpg?1",
             "name": "Entrapment Maneuver",
             "text": "",
             "colours": [
@@ -36049,7 +36049,7 @@
         },
         {
             "id": "9b63c585-6f30-51b2-b028-6364a10b8044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b324eff-e709-4dc2-b5fb-0922d90ec848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b324eff-e709-4dc2-b5fb-0922d90ec848.jpg?1",
             "name": "Hour of Reckoning",
             "text": "",
             "colours": [
@@ -36084,7 +36084,7 @@
         },
         {
             "id": "df278d61-9348-56db-a847-8ff9004ce66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4575fce3-872a-4a97-a291-822988cb2745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4575fce3-872a-4a97-a291-822988cb2745.jpg?1",
             "name": "Keeper of the Accord",
             "text": "",
             "colours": [
@@ -36122,7 +36122,7 @@
         },
         {
             "id": "66c9e5c8-09f6-5f47-97b6-6750b5150a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b32d84-2d56-4ffe-a433-3d033f16045c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b32d84-2d56-4ffe-a433-3d033f16045c.jpg?1",
             "name": "Mantle of the Ancients",
             "text": "",
             "colours": [
@@ -36159,7 +36159,7 @@
         },
         {
             "id": "f3b4d7a7-639c-54d8-8119-347d0280b4a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55620d51-6e27-4f38-a141-c39bf3d6d5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55620d51-6e27-4f38-a141-c39bf3d6d5d6.jpg?1",
             "name": "Marshal's Anthem",
             "text": "",
             "colours": [
@@ -36194,7 +36194,7 @@
         },
         {
             "id": "cb8b16a7-e8e8-54b5-8b39-d894ce0942a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30206bee-c895-4ab7-9535-68a6afb2c686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30206bee-c895-4ab7-9535-68a6afb2c686.jpg?1",
             "name": "Martial Coup",
             "text": "",
             "colours": [
@@ -36229,7 +36229,7 @@
         },
         {
             "id": "79abf21d-21bb-5023-8e75-cca0519cfb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1727b15d-2918-489f-a5b8-8ac3ca86d670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1727b15d-2918-489f-a5b8-8ac3ca86d670.jpg?1",
             "name": "Open the Vaults",
             "text": "",
             "colours": [
@@ -36264,7 +36264,7 @@
         },
         {
             "id": "2a874f95-d584-5dc3-8a02-242f6575d016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69d118-fc58-40b7-bb38-f1c3da04d950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a69d118-fc58-40b7-bb38-f1c3da04d950.jpg?1",
             "name": "Puresteel Paladin",
             "text": "",
             "colours": [
@@ -36302,7 +36302,7 @@
         },
         {
             "id": "82aa3d79-2491-5f32-8081-8a079ef669d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ddf912-5bd5-430c-bb42-4a76e609466c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ddf912-5bd5-430c-bb42-4a76e609466c.jpg?1",
             "name": "Secure the Wastes",
             "text": "",
             "colours": [
@@ -36337,7 +36337,7 @@
         },
         {
             "id": "4d16e7a8-f4b2-5ad9-86ac-fdfebcda6051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b88918-d819-4dc9-ac6c-48c3b1f67092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b88918-d819-4dc9-ac6c-48c3b1f67092.jpg?1",
             "name": "Single Combat",
             "text": "",
             "colours": [
@@ -36372,7 +36372,7 @@
         },
         {
             "id": "fb7ddd8c-fd2b-5c2e-ab3c-58b2d0261995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a3d786-2ac1-48c8-aafe-64b72ecde383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a3d786-2ac1-48c8-aafe-64b72ecde383.jpg?1",
             "name": "Fraying Sanity",
             "text": "",
             "colours": [
@@ -36410,7 +36410,7 @@
         },
         {
             "id": "64ca1a63-184c-5a20-91d3-152fb50befd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd7775-da74-4312-9b2d-c4721ee179cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27fd7775-da74-4312-9b2d-c4721ee179cb.jpg?1",
             "name": "Inexorable Tide",
             "text": "",
             "colours": [
@@ -36445,7 +36445,7 @@
         },
         {
             "id": "4ee6d56e-69ef-503d-ad2f-ec4d9f5f9b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47199-65d9-472b-ae8e-0c6580420b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deb47199-65d9-472b-ae8e-0c6580420b8f.jpg?1",
             "name": "Mechanized Production",
             "text": "",
             "colours": [
@@ -36482,7 +36482,7 @@
         },
         {
             "id": "371b1887-6ab1-5717-8ea5-87016fa86492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f5512b-e7c4-43cd-9bfd-e95681a5b050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f5512b-e7c4-43cd-9bfd-e95681a5b050.jpg?1",
             "name": "One with the Machine",
             "text": "",
             "colours": [
@@ -36517,7 +36517,7 @@
         },
         {
             "id": "f7a0451b-7bb2-5ba7-b70e-2f26dc75165f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957651eb-9adb-4105-aece-d55991dc1e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957651eb-9adb-4105-aece-d55991dc1e02.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -36552,7 +36552,7 @@
         },
         {
             "id": "b94f1a6f-c85e-52ca-896e-c5a307dc1768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31e4679-e594-4907-8bef-acff38b856a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31e4679-e594-4907-8bef-acff38b856a3.jpg?1",
             "name": "Lethal Scheme",
             "text": "",
             "colours": [
@@ -36587,7 +36587,7 @@
         },
         {
             "id": "2074e840-3109-5722-a126-2fd277505abf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889a828d-8915-4c2b-8650-f368172890e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889a828d-8915-4c2b-8650-f368172890e8.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -36622,7 +36622,7 @@
         },
         {
             "id": "c4cf89e6-749a-5f08-9c65-43f268e9ac1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5bc9c-490b-4873-8be1-bd39ab10ed86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e5bc9c-490b-4873-8be1-bd39ab10ed86.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -36657,7 +36657,7 @@
         },
         {
             "id": "88d484cc-c74e-5c78-ad68-450d94e032f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5bdc07-7221-4681-a84c-f4fe3e85d120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d5bdc07-7221-4681-a84c-f4fe3e85d120.jpg?1",
             "name": "Stolen Strategy",
             "text": "",
             "colours": [
@@ -36692,7 +36692,7 @@
         },
         {
             "id": "a4567c0e-ce51-54d6-9463-fa3dfc35c14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aee54b7-698a-4f19-8682-70b5f36a7e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aee54b7-698a-4f19-8682-70b5f36a7e30.jpg?1",
             "name": "Branching Evolution",
             "text": "",
             "colours": [
@@ -36727,7 +36727,7 @@
         },
         {
             "id": "6ace7c0b-39a8-559c-9bc8-913bf0bda100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e3d320-c63e-49b4-b6dc-441298db1329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e3d320-c63e-49b4-b6dc-441298db1329.jpg?1",
             "name": "Guardian Project",
             "text": "",
             "colours": [
@@ -36762,7 +36762,7 @@
         },
         {
             "id": "82f33430-8070-52c6-9cf7-76f8a37f8d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e897027e-b8fc-44a7-ba82-19e765f757c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e897027e-b8fc-44a7-ba82-19e765f757c4.jpg?1",
             "name": "Hardened Scales",
             "text": "",
             "colours": [
@@ -36797,7 +36797,7 @@
         },
         {
             "id": "82b41324-dd1c-5e2e-9127-2f69e2e40c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad0069-25a4-4e1d-8ef5-a5223e57d699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad0069-25a4-4e1d-8ef5-a5223e57d699.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -36832,7 +36832,7 @@
         },
         {
             "id": "e4ed896a-1ed7-5035-8cf8-9fb83953dea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b262574e-6eb0-46d5-b05c-ac66ac8f7f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b262574e-6eb0-46d5-b05c-ac66ac8f7f07.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -36870,7 +36870,7 @@
         },
         {
             "id": "473cce5e-0b2a-5a23-979d-dbfb6023ecc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275c0f2c-6454-45b8-8e4d-bcf3e66ed1b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275c0f2c-6454-45b8-8e4d-bcf3e66ed1b7.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -36907,7 +36907,7 @@
         },
         {
             "id": "f16cbf1d-612a-591f-a240-76eb2d26974a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca637814-9afb-46a1-ad90-4403f7ff62d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca637814-9afb-46a1-ad90-4403f7ff62d3.jpg?1",
             "name": "Assemble the Legion",
             "text": "",
             "colours": [
@@ -36944,7 +36944,7 @@
         },
         {
             "id": "1907ce87-c733-5f72-ac0e-77bc1b777cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c1692c-d95e-480f-9f6c-da9ce099b75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c1692c-d95e-480f-9f6c-da9ce099b75d.jpg?1",
             "name": "Biomass Mutation",
             "text": "",
             "colours": [
@@ -36981,7 +36981,7 @@
         },
         {
             "id": "81aeafb2-9f9f-578b-acdc-abd8b6e156f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6918ab-ef4f-4cd4-92d9-2da6622a4cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6918ab-ef4f-4cd4-92d9-2da6622a4cb7.jpg?1",
             "name": "Casualties of War",
             "text": "",
             "colours": [
@@ -37018,7 +37018,7 @@
         },
         {
             "id": "27c355cf-c7f5-5838-af91-8cea129a99f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca785ef8-f893-4c48-83c1-6886b0dc43c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca785ef8-f893-4c48-83c1-6886b0dc43c4.jpg?1",
             "name": "Fervent Charge",
             "text": "",
             "colours": [
@@ -37057,7 +37057,7 @@
         },
         {
             "id": "24b6eac7-dc1e-5a19-887a-63a37365d8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39e94a-07b0-4a87-bd03-0cc369790c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b39e94a-07b0-4a87-bd03-0cc369790c01.jpg?1",
             "name": "Ruinous Ultimatum",
             "text": "",
             "colours": [
@@ -37096,7 +37096,7 @@
         },
         {
             "id": "fd73fff4-da2d-5897-9ac2-f544a720c4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45691343-4ae4-4cdb-845a-52006b1d2566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45691343-4ae4-4cdb-845a-52006b1d2566.jpg?1",
             "name": "Wake the Past",
             "text": "",
             "colours": [
@@ -37133,7 +37133,7 @@
         },
         {
             "id": "a5f23b8e-3a38-546b-a7fd-5574f9ddcd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6e34fb-d3d0-409a-a3ad-612177b98baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d6e34fb-d3d0-409a-a3ad-612177b98baa.jpg?1",
             "name": "Basilisk Collar",
             "text": "",
             "colours": [],
@@ -37166,7 +37166,7 @@
         },
         {
             "id": "e1ced1a6-b370-5fb4-942e-410ad616d1f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decf8d08-a4e4-4a5d-91d7-102596b30cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/decf8d08-a4e4-4a5d-91d7-102596b30cb5.jpg?1",
             "name": "Bloodforged Battle-Axe",
             "text": "",
             "colours": [],
@@ -37199,7 +37199,7 @@
         },
         {
             "id": "46081fca-ad8c-5711-bebe-a792f691028e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062fe8d7-c0d4-4460-9613-27c6c0555a14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062fe8d7-c0d4-4460-9613-27c6c0555a14.jpg?1",
             "name": "Champion's Helm",
             "text": "",
             "colours": [],
@@ -37232,7 +37232,7 @@
         },
         {
             "id": "5fc42952-768f-592b-a21d-36ed54166a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f10fe0-4810-4894-9805-4280175a7fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8f10fe0-4810-4894-9805-4280175a7fa6.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "",
             "colours": [],
@@ -37265,7 +37265,7 @@
         },
         {
             "id": "e365f6d8-a121-5dc9-980a-96deb0c8e20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fd1f7f-4946-4f28-a759-3f73c0473536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74fd1f7f-4946-4f28-a759-3f73c0473536.jpg?1",
             "name": "Mystic Forge",
             "text": "",
             "colours": [],
@@ -37296,7 +37296,7 @@
         },
         {
             "id": "065cc1b6-9af7-54c1-adc7-e7dd05539162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ea3ea-4ede-436d-a899-3e4a52dd56cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ea3ea-4ede-436d-a899-3e4a52dd56cd.jpg?1",
             "name": "Panharmonicon",
             "text": "",
             "colours": [],
@@ -37327,7 +37327,7 @@
         },
         {
             "id": "6cec8771-9570-587e-8816-d241b9d8af76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f14e3f-7de4-4c1a-a1e2-a3e21afee14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f14e3f-7de4-4c1a-a1e2-a3e21afee14f.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -37361,7 +37361,7 @@
         },
         {
             "id": "b11a3841-8e30-5d14-b60b-e18a82c210e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1752cc62-abf9-406b-a5ac-f4c8b12a92ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1752cc62-abf9-406b-a5ac-f4c8b12a92ef.jpg?1",
             "name": "Steel Overseer",
             "text": "",
             "colours": [],
@@ -37395,7 +37395,7 @@
         },
         {
             "id": "c54eb32e-bbbc-52d6-bfb0-3a4aa5cc3a68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b861c7b1-976d-4d0b-8f53-59bac360432c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b861c7b1-976d-4d0b-8f53-59bac360432c.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -37432,7 +37432,7 @@
         },
         {
             "id": "2ee8d12b-9cf2-5b57-8e7c-43210dc854df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062526c8-29c1-4e0d-86ae-fb3aac9b0d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/062526c8-29c1-4e0d-86ae-fb3aac9b0d95.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -37469,7 +37469,7 @@
         },
         {
             "id": "b93344ff-e660-545b-b177-d77ac7c5cd42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7547eaf7-ddc1-4881-9045-b6be302354de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7547eaf7-ddc1-4881-9045-b6be302354de.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -37506,7 +37506,7 @@
         },
         {
             "id": "38e47c61-cdda-5e63-bb57-2b3cff251feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3246847-83f0-46c3-8e7f-867734448a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3246847-83f0-46c3-8e7f-867734448a62.jpg?1",
             "name": "Clifftop Retreat",
             "text": "",
             "colours": [],
@@ -37540,7 +37540,7 @@
         },
         {
             "id": "9b912ad7-9e82-57e4-bf4b-4d1ade940596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceac46f-e4e6-4a76-87c9-d8c7c6b47256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceac46f-e4e6-4a76-87c9-d8c7c6b47256.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -37574,7 +37574,7 @@
         },
         {
             "id": "da6fc880-0ff5-5e56-96f0-2db4a41e3fff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76dbcd3-e280-4c71-b8bd-715001340697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76dbcd3-e280-4c71-b8bd-715001340697.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -37608,7 +37608,7 @@
         },
         {
             "id": "c792bb08-1ff1-586a-af43-7476fd13b61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a47f879-962b-44a0-9448-7217e35ea4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a47f879-962b-44a0-9448-7217e35ea4d0.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -37642,7 +37642,7 @@
         },
         {
             "id": "0a90c233-32bf-594b-9667-530c13a423e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0651aa-b804-4517-af87-41fe1d5e1699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0651aa-b804-4517-af87-41fe1d5e1699.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -37673,7 +37673,7 @@
         },
         {
             "id": "946a67b3-8700-5227-bee1-7af044efe36a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f799-be3a-4d9c-9050-85cb0b0774d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d0f799-be3a-4d9c-9050-85cb0b0774d7.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -37710,7 +37710,7 @@
         },
         {
             "id": "8b7ab9a4-9478-5f75-8a60-6bf93a4182c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205cd322-db6c-455a-b2ab-f196a64e08c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205cd322-db6c-455a-b2ab-f196a64e08c9.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -37744,7 +37744,7 @@
         },
         {
             "id": "57f0fc89-6ec9-508f-b3bc-c71c408b56e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd36ff-2228-4bfd-bb98-76243defbb78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cd36ff-2228-4bfd-bb98-76243defbb78.jpg?1",
             "name": "Hinterland Harbor",
             "text": "",
             "colours": [],
@@ -37778,7 +37778,7 @@
         },
         {
             "id": "f6149376-1c3b-511d-9ab2-de19bd036a4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb11d4ab-0095-4021-8ec6-79d5d3e6bbd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb11d4ab-0095-4021-8ec6-79d5d3e6bbd0.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -37815,7 +37815,7 @@
         },
         {
             "id": "1e9d77da-2d4e-50b2-92e5-7157c02d8b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d96ac45-2484-4d14-b1f5-b46f2a6ac5ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d96ac45-2484-4d14-b1f5-b46f2a6ac5ee.jpg?1",
             "name": "Isolated Chapel",
             "text": "",
             "colours": [],
@@ -37849,7 +37849,7 @@
         },
         {
             "id": "43b8a834-e221-5505-9f58-0522ebd02039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896c4424-a5b9-4e2a-80a5-cda8a7612f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896c4424-a5b9-4e2a-80a5-cda8a7612f51.jpg?1",
             "name": "Mossfire Valley",
             "text": "",
             "colours": [],
@@ -37883,7 +37883,7 @@
         },
         {
             "id": "c94bf7b7-b03c-5bee-96cd-bebd6aa3db62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c7e99-7b74-46a5-8622-fca661b3f889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/481c7e99-7b74-46a5-8622-fca661b3f889.jpg?1",
             "name": "Nesting Grounds",
             "text": "",
             "colours": [],
@@ -37914,7 +37914,7 @@
         },
         {
             "id": "d9855421-7655-5392-a4d3-73c7c42b8470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9479bc09-7db2-46b3-8c1e-dbee5508e26a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9479bc09-7db2-46b3-8c1e-dbee5508e26a.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -37951,7 +37951,7 @@
         },
         {
             "id": "3d97e8d6-73b0-5c2c-9b3a-4ea247a52d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941113c4-9a14-4f92-8a5b-e351dcd210a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941113c4-9a14-4f92-8a5b-e351dcd210a4.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -37985,7 +37985,7 @@
         },
         {
             "id": "e2de0f53-e055-543e-9473-88452bbcf009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab3e653-e27f-4c64-8339-59849cdd9939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab3e653-e27f-4c64-8339-59849cdd9939.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -38022,7 +38022,7 @@
         },
         {
             "id": "f1c78c59-6bcf-5aa1-8c67-c058cf803fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c2062-b105-4e87-8cbc-be6e274f393a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5c2062-b105-4e87-8cbc-be6e274f393a.jpg?1",
             "name": "Scavenger Grounds",
             "text": "",
             "colours": [],
@@ -38055,7 +38055,7 @@
         },
         {
             "id": "5db0d890-6dbb-583c-afad-ecbfb2af3054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87115cd5-542e-4964-9e0b-d911c8fdc335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87115cd5-542e-4964-9e0b-d911c8fdc335.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -38089,7 +38089,7 @@
         },
         {
             "id": "3c66b258-36e7-579f-8b4c-4d15dfa10c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec1158-3699-44be-8cd7-a15a1dd26311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec1158-3699-44be-8cd7-a15a1dd26311.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -38126,7 +38126,7 @@
         },
         {
             "id": "edd367c0-2f49-5f9f-bc41-3266e2b089a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216ce04-a93d-430f-ba24-fcc797076cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e216ce04-a93d-430f-ba24-fcc797076cd1.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -38160,7 +38160,7 @@
         },
         {
             "id": "53c8b0c7-d3f8-5432-9f73-7935347334ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc6ca28-2df7-4cbd-b847-62c1f4576f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc6ca28-2df7-4cbd-b847-62c1f4576f3b.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -38197,7 +38197,7 @@
         },
         {
             "id": "8ec2e2a1-452d-5413-b571-7ef5736cdc19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cab6984-8d22-4bed-a42e-0f4604798787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cab6984-8d22-4bed-a42e-0f4604798787.jpg?1",
             "name": "Spire of Industry",
             "text": "",
             "colours": [],
@@ -38228,7 +38228,7 @@
         },
         {
             "id": "03b7999e-09f9-5081-9379-0a1d2bd4b935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e172658-3ba7-4d50-9c9d-bb26368f381f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e172658-3ba7-4d50-9c9d-bb26368f381f.jpg?1",
             "name": "Sulfur Falls",
             "text": "",
             "colours": [],
@@ -38262,7 +38262,7 @@
         },
         {
             "id": "72497c0b-ecfa-593f-9648-fe91e66d35b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a56626-fc86-4c3e-bc9b-75b89e0d9e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a56626-fc86-4c3e-bc9b-75b89e0d9e88.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -38296,7 +38296,7 @@
         },
         {
             "id": "96dc9565-7a0d-5fc8-94ab-218ee69d2a77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fba5c8e-a364-458c-95fb-3a3999704b43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fba5c8e-a364-458c-95fb-3a3999704b43.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -38333,7 +38333,7 @@
         },
         {
             "id": "a177874b-3416-52d8-80a7-6d11321b9f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80afdcb5-8ef1-442a-9f8b-233443efdc41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80afdcb5-8ef1-442a-9f8b-233443efdc41.jpg?1",
             "name": "Sunpetal Grove",
             "text": "",
             "colours": [],
@@ -38367,7 +38367,7 @@
         },
         {
             "id": "032602d3-4941-5547-aa37-bcd1d7679162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e073d623-551c-489c-8f66-082c3c2a84fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e073d623-551c-489c-8f66-082c3c2a84fa.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -38401,7 +38401,7 @@
         },
         {
             "id": "fb7c3b97-fe3d-51bf-8723-8da5e5065cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2caf68-7d2e-4896-bf3a-bbbc0583f09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2caf68-7d2e-4896-bf3a-bbbc0583f09f.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -38435,7 +38435,7 @@
         },
         {
             "id": "00e41fe2-e0ac-5310-934a-ebc35c7ecf81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30da3c97-e9ef-4344-b814-adf7471a3d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30da3c97-e9ef-4344-b814-adf7471a3d78.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -38469,7 +38469,7 @@
         },
         {
             "id": "66300644-9cfe-5e77-b5f0-26cee09f403a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad07467-d467-40cf-8706-3a4b0c59ac42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad07467-d467-40cf-8706-3a4b0c59ac42.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -38503,7 +38503,7 @@
         },
         {
             "id": "92019dd3-98c0-56d5-937d-c1e92d5de438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2673417-67fa-4c32-ab9f-155d8a18d304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2673417-67fa-4c32-ab9f-155d8a18d304.jpg?1",
             "name": "Temple of Malady",
             "text": "",
             "colours": [],
@@ -38537,7 +38537,7 @@
         },
         {
             "id": "45a08e84-bc90-543d-9005-86f35b34a708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b15ef1-d79c-4164-af18-900c8aab8f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b15ef1-d79c-4164-af18-900c8aab8f1f.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -38571,7 +38571,7 @@
         },
         {
             "id": "177072f6-3188-5c18-8404-dddc0311332a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1c98e1-0181-40b3-8276-81ba79ac6741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1c98e1-0181-40b3-8276-81ba79ac6741.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -38605,7 +38605,7 @@
         },
         {
             "id": "354bca26-49ac-5894-998c-99bcd07f8d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b7a74-aa53-47f0-86ee-edad1b188200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b7a74-aa53-47f0-86ee-edad1b188200.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -38639,7 +38639,7 @@
         },
         {
             "id": "3d87e6f7-c5fd-59ef-8b49-f6093795dac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163c033-1a95-4bfb-a3c0-692a12e99e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c163c033-1a95-4bfb-a3c0-692a12e99e1d.jpg?1",
             "name": "Temple of Silence",
             "text": "",
             "colours": [],
@@ -38673,7 +38673,7 @@
         },
         {
             "id": "59624696-2df6-57ca-a36a-569a39caa7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d60c97-cc03-4a3f-b521-8b9eb40af06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d60c97-cc03-4a3f-b521-8b9eb40af06d.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -38707,7 +38707,7 @@
         },
         {
             "id": "77a8b4dd-15ae-5125-83e4-e56256fa7bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbba0d-8884-4e24-a180-749a408b27d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1cbba0d-8884-4e24-a180-749a408b27d2.jpg?1",
             "name": "Treasure Vault",
             "text": "",
             "colours": [],
@@ -38739,7 +38739,7 @@
         },
         {
             "id": "fd674479-710a-5a5e-a840-769679d994f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70d498-1fe2-4136-94bc-18fc163cbc7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70d498-1fe2-4136-94bc-18fc163cbc7b.jpg?1",
             "name": "Windbrisk Heights",
             "text": "",
             "colours": [],
@@ -38772,7 +38772,7 @@
         },
         {
             "id": "207a231d-d836-58ee-b3fc-c1e626f805e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dfbf7-317e-45d6-9cca-29d14125e025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566dfbf7-317e-45d6-9cca-29d14125e025.jpg?1",
             "name": "Woodland Cemetery",
             "text": "",
             "colours": [],
@@ -38806,7 +38806,7 @@
         },
         {
             "id": "4affd004-d432-5788-84eb-f5f3e57ac811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697418b-9823-4b9c-b8d4-b38ce818a2a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697418b-9823-4b9c-b8d4-b38ce818a2a0.jpg?1",
             "name": "Strength Bobblehead",
             "text": "",
             "colours": [],
@@ -38838,7 +38838,7 @@
         },
         {
             "id": "2f800ed0-ac69-5e69-ad7d-466517a8c3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2925410a-7c44-4bf4-83cd-3e75dbe82b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2925410a-7c44-4bf4-83cd-3e75dbe82b23.jpg?1",
             "name": "Perception Bobblehead",
             "text": "",
             "colours": [],
@@ -38870,7 +38870,7 @@
         },
         {
             "id": "a8444e02-5a49-5022-a319-204a8cfc0eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb36a80-ddef-4be9-a6b3-ebe8143bc1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb36a80-ddef-4be9-a6b3-ebe8143bc1ca.jpg?1",
             "name": "Endurance Bobblehead",
             "text": "",
             "colours": [],
@@ -38902,7 +38902,7 @@
         },
         {
             "id": "061e783e-e245-5047-bf08-0a105924849e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1630054-b9f8-474c-8383-3d6058c0e555.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1630054-b9f8-474c-8383-3d6058c0e555.jpg?1",
             "name": "Charisma Bobblehead",
             "text": "",
             "colours": [],
@@ -38934,7 +38934,7 @@
         },
         {
             "id": "98a1922f-a650-58d9-852f-0f87beb3f397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114600bd-4bf5-4eeb-bb9d-25bfb8a54adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114600bd-4bf5-4eeb-bb9d-25bfb8a54adc.jpg?1",
             "name": "Intelligence Bobblehead",
             "text": "",
             "colours": [],
@@ -38966,7 +38966,7 @@
         },
         {
             "id": "551a9909-3a46-586f-8e7f-60c260a357f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16414b32-2e70-4da6-9556-fcac07528e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16414b32-2e70-4da6-9556-fcac07528e5f.jpg?1",
             "name": "Agility Bobblehead",
             "text": "",
             "colours": [],
@@ -38998,7 +38998,7 @@
         },
         {
             "id": "0f1b5809-8d95-5ee3-a61b-2f04dfc8c639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e26cce-e872-47f4-90b2-0739fa98e97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e26cce-e872-47f4-90b2-0739fa98e97c.jpg?1",
             "name": "Luck Bobblehead",
             "text": "",
             "colours": [],
@@ -39030,7 +39030,7 @@
         },
         {
             "id": "4dc9b590-6b41-54a0-bab4-a7b8d06b6a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faac5cd1-ce93-4b98-97ad-8bdce2862b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faac5cd1-ce93-4b98-97ad-8bdce2862b3b.jpg?1",
             "name": "Caesar, Legion's Emperor",
             "text": "",
             "colours": [
@@ -39075,7 +39075,7 @@
         },
         {
             "id": "a622f7ec-a10d-593c-80a8-023d03dde43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12956bf2-cea1-40b9-8229-2746fc952755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12956bf2-cea1-40b9-8229-2746fc952755.jpg?1",
             "name": "Dogmeat, Ever Loyal",
             "text": "",
             "colours": [
@@ -39119,7 +39119,7 @@
         },
         {
             "id": "460c8d72-6265-57dc-a82d-2522a19f302e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833fe154-fe11-4bef-8194-812cccacd4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833fe154-fe11-4bef-8194-812cccacd4fb.jpg?1",
             "name": "Dr. Madison Li",
             "text": "",
             "colours": [
@@ -39164,7 +39164,7 @@
         },
         {
             "id": "8386643b-e09f-5b9c-a06e-6ff60db6a0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28686dda-64b0-4ffe-b71a-58e7f901c4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28686dda-64b0-4ffe-b71a-58e7f901c4eb.jpg?1",
             "name": "The Wise Mothman",
             "text": "",
             "colours": [
@@ -39209,7 +39209,7 @@
         },
         {
             "id": "b99511ee-2aaf-5277-9715-18959b0636d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6535fc5-fc35-425a-a8da-2e443b4ac8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6535fc5-fc35-425a-a8da-2e443b4ac8d2.jpg?1",
             "name": "War Room",
             "text": "{T}: Add {C}.\n{3}, {T}, Pay life equal to the number of colors in your commanders' color identity: Draw a card.",
             "colours": [],
@@ -39237,7 +39237,7 @@
         },
         {
             "id": "79c46733-682f-5be1-b347-386901478499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c43047-87f6-4382-874e-02e9628647bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78c43047-87f6-4382-874e-02e9628647bd.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -39265,7 +39265,7 @@
         },
         {
             "id": "5a89935e-2167-5ee7-8e6c-b0ed7c340979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546bda77-e3a8-4f2a-ba9c-94fb0b9ff183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546bda77-e3a8-4f2a-ba9c-94fb0b9ff183.jpg?1",
             "name": "Human Knight",
             "text": "",
             "colours": [
@@ -39301,7 +39301,7 @@
         },
         {
             "id": "930d0b44-6e57-5fc8-a310-01c9380940b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737741e7-b2b2-4c41-ab7c-4eeaf9f37b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737741e7-b2b2-4c41-ab7c-4eeaf9f37b71.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -39337,7 +39337,7 @@
         },
         {
             "id": "d69959d9-f0f9-51cd-8b0d-c560cff6e53d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af191656-5e62-440f-b63a-705cfed314e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af191656-5e62-440f-b63a-705cfed314e7.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -39372,7 +39372,7 @@
         },
         {
             "id": "4db45815-c663-5c72-94dd-32f109c9d522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263a442-8ca6-4c69-a841-4a590ff2e729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a263a442-8ca6-4c69-a841-4a590ff2e729.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -39407,7 +39407,7 @@
         },
         {
             "id": "110f3dd8-f598-57bd-a219-d29e29bcb414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66f10d-6fc4-4510-818c-96d29b425052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66f10d-6fc4-4510-818c-96d29b425052.jpg?1",
             "name": "Alien",
             "text": "",
             "colours": [
@@ -39442,7 +39442,7 @@
         },
         {
             "id": "e4ed1737-026f-59c0-9d76-b7bfd9649659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba45bc9c-8257-43f8-9ba1-116b9fea90f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba45bc9c-8257-43f8-9ba1-116b9fea90f4.jpg?1",
             "name": "Zombie Mutant",
             "text": "",
             "colours": [
@@ -39478,7 +39478,7 @@
         },
         {
             "id": "f265a084-6b20-50a4-8e99-d8b412da85d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02789d01-f939-4515-a6e4-db6aff36f893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02789d01-f939-4515-a6e4-db6aff36f893.jpg?1",
             "name": "Settlement",
             "text": "",
             "colours": [
@@ -39513,7 +39513,7 @@
         },
         {
             "id": "15d70ab7-e396-5476-85cc-840a9f4885c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90bb066-79fd-48cd-ab5a-eaed71139b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f90bb066-79fd-48cd-ab5a-eaed71139b4e.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -39548,7 +39548,7 @@
         },
         {
             "id": "a4fa2d1c-1462-501e-b492-d6926a131c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae7bdfe-fe14-4a18-b2b0-16e9175a0441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae7bdfe-fe14-4a18-b2b0-16e9175a0441.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -39585,7 +39585,7 @@
         },
         {
             "id": "e4dce79e-c9ce-520b-9401-d635e4e4c654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff5544-bdf8-43a3-a74d-4a2b7d79245a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ff5544-bdf8-43a3-a74d-4a2b7d79245a.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -39616,7 +39616,7 @@
         },
         {
             "id": "53fff3d8-02af-5b55-ac8f-6166b29f1ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2a0ab-7f64-4f82-b6db-d84194b5d417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2a0ab-7f64-4f82-b6db-d84194b5d417.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -39647,7 +39647,7 @@
         },
         {
             "id": "fae89cdd-11c5-504e-9299-67377131033d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a004f0-b216-41cc-904f-91eea562d485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a004f0-b216-41cc-904f-91eea562d485.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -39678,7 +39678,7 @@
         },
         {
             "id": "89ecc35b-cd4a-5edf-a5e6-b41fbcb9bee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d0801a-9565-419f-bb0b-23547c9dd59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d0801a-9565-419f-bb0b-23547c9dd59d.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -39709,7 +39709,7 @@
         },
         {
             "id": "de557c08-4418-5956-8a9c-1a485cde1194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c4a6f6-6425-4c0c-b35a-880fcab42aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c4a6f6-6425-4c0c-b35a-880fcab42aad.jpg?1",
             "name": "Junk",
             "text": "",
             "colours": [],
@@ -39740,7 +39740,7 @@
         },
         {
             "id": "ddc8ad4e-de72-556a-926b-994d7831d498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde21f-2f01-4560-972b-7ecd6740d6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cde21f-2f01-4560-972b-7ecd6740d6de.jpg?1",
             "name": "Robot",
             "text": "",
             "colours": [],
@@ -39772,7 +39772,7 @@
         },
         {
             "id": "88e4b3a4-d00d-5bf8-8360-35069add6912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaadec8-5bf7-4b53-b83e-33d17dc0ed74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efaadec8-5bf7-4b53-b83e-33d17dc0ed74.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -39804,7 +39804,7 @@
         },
         {
             "id": "168d1610-a4cc-54e6-bd3b-cc3fa6b11b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0d0741-028f-481b-8982-55f36304c343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0d0741-028f-481b-8982-55f36304c343.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -39835,7 +39835,7 @@
         },
         {
             "id": "04632524-9fd9-5f3d-89ba-1b31400561f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d74d012-66ca-4a0c-9e90-e31e96730d4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d74d012-66ca-4a0c-9e90-e31e96730d4d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -39866,7 +39866,7 @@
         },
         {
             "id": "20e22465-c63e-5637-abbf-0bdd2c14eee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad073c87-42f2-45f0-9613-2cdbd0abf719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad073c87-42f2-45f0-9613-2cdbd0abf719.jpg?1",
             "name": "Wasteland Survival Guide",
             "text": "",
             "colours": [],
@@ -39897,7 +39897,7 @@
         },
         {
             "id": "ab6d8380-aba9-5462-a2dc-e47698f6298b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a794202-875f-4397-a8de-9722c8d78448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a794202-875f-4397-a8de-9722c8d78448.jpg?1",
             "name": "Energy Reserve",
             "text": "",
             "colours": [],
@@ -39925,7 +39925,7 @@
         },
         {
             "id": "4ce0f951-01fd-5279-ac2c-8219768baf53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0886657d-afb0-4f1f-9af7-960724793077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0886657d-afb0-4f1f-9af7-960724793077.jpg?1",
             "name": "Radiation",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/PLC.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/PLC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "54a02219-51cc-5401-b7b6-d4b255a1bb8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4394a-9ce2-4876-8a04-38e3775123af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a4394a-9ce2-4876-8a04-38e3775123af.jpg?1",
             "name": "Aven Riftwatcher",
             "text": "Flying\nVanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher comes into play or leaves play, you gain 2 life.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "6c0086e2-8542-5619-b549-76d0b606a1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814da0-3bc8-423d-9b22-3fea123048fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44814da0-3bc8-423d-9b22-3fea123048fa.jpg?1",
             "name": "Benalish Commander",
             "text": "Benalish Commander's power and toughness are each equal to the number of Soldiers you control.\nSuspend X\u2014{X}{W}{W}. X can't be 0.\nWhenever a time counter is removed from Benalish Commander while it's removed from the game, put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "41a31003-0e13-5e34-a8db-7ffec3b2fe6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63049fe4-de25-4606-a271-4ccb1b8298f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63049fe4-de25-4606-a271-4ccb1b8298f1.jpg?1",
             "name": "Crovax, Ascendant Hero",
             "text": "Other white creatures get +1/+1.\nNonwhite creatures get -1/-1.\nPay 2 life: Return Crovax, Ascendant Hero to its owner's hand.",
             "colours": [
@@ -112,7 +112,7 @@
         },
         {
             "id": "953e1605-049a-59cd-a6f1-db21ecfc3c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9667b-1d94-42eb-ae8e-1ae4755e200a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c9667b-1d94-42eb-ae8e-1ae4755e200a.jpg?1",
             "name": "Dawn Charm",
             "text": "Choose one Prevent all combat damage that would be dealt this turn; or regenerate target creature; or counter target spell that targets you.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "2b0a1071-2e17-5d6d-97f6-bfc577122c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144e9391-f417-464b-8c04-c952193997c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144e9391-f417-464b-8c04-c952193997c7.jpg?1",
             "name": "Dust Elemental",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying, fear\nWhen Dust Elemental comes into play, return three creatures you control to their owner's hand.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "da405808-346d-5236-948f-72244c886833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ab366c-085b-4b13-b5ad-918965c34d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ab366c-085b-4b13-b5ad-918965c34d22.jpg?1",
             "name": "Ghost Tactician",
             "text": "{W}, {T}, Discard a card: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -213,7 +213,7 @@
         },
         {
             "id": "8028b34c-f720-5551-bf7b-15b2cafa13c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9902b260-82cf-4b10-a353-321231824a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9902b260-82cf-4b10-a353-321231824a3b.jpg?1",
             "name": "Heroes Remembered",
             "text": "You gain 20 life.\nSuspend 10\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with ten time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "b850f2ec-afa5-5ecf-9fbe-5fd5a4382011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd520f8c-93fb-4cf3-8dd5-d05abbd86c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd520f8c-93fb-4cf3-8dd5-d05abbd86c74.jpg?1",
             "name": "Magus of the Tabernacle",
             "text": "All creatures have \"At the beginning of your upkeep, sacrifice this creature unless you pay {1}.\"",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "70e7b2fc-5880-56cd-bc67-06b35a2384be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef5d122-cf18-42c3-be24-cfd92bd18be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ef5d122-cf18-42c3-be24-cfd92bd18be9.jpg?1",
             "name": "Mantle of Leadership",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nWhenever a creature comes into play, enchanted creature gets +2/+2 until end of turn.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "f68a2a90-a01e-5e23-a49e-1fe02ed92b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a11b639-a5a3-424d-80c6-42d7252472a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a11b639-a5a3-424d-80c6-42d7252472a1.jpg?1",
             "name": "Pallid Mycoderm",
             "text": "At the beginning of your upkeep, put a spore counter on Pallid Mycoderm.\nRemove three spore counters from Pallid Mycoderm: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Each Fungus and each Saproling you control gets +1/+1 until end of turn.",
             "colours": [
@@ -348,7 +348,7 @@
         },
         {
             "id": "a2b9f53b-4f60-5928-86ce-1adad0e18429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3441ae0-4c20-487b-99b8-d6934dfb66ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3441ae0-4c20-487b-99b8-d6934dfb66ff.jpg?1",
             "name": "Poultice Sliver",
             "text": "All Slivers have \"{2}, {T}: Regenerate target Sliver.\"",
             "colours": [
@@ -382,7 +382,7 @@
         },
         {
             "id": "4c5c3b41-6e7d-58e5-a366-2b56fa2bbf48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47fcce-d4c4-40a2-8853-6d7569d50926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa47fcce-d4c4-40a2-8853-6d7569d50926.jpg?1",
             "name": "Rebuff the Wicked",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "4a0268eb-b606-5eba-bd92-4ba1ace04d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faa005e-c753-4484-bf64-349350d59094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faa005e-c753-4484-bf64-349350d59094.jpg?1",
             "name": "Retether",
             "text": "Return each Aura card from your graveyard to play. Only creatures can be enchanted this way. (Aura cards that can't enchant a creature in play remain in your graveyard.)",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "52b602b6-95ae-5955-8fe0-af7094783c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d503b565-a3c8-4b57-9e30-fb97d2a49afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d503b565-a3c8-4b57-9e30-fb97d2a49afa.jpg?1",
             "name": "Riftmarked Knight",
             "text": "Flanking, protection from black\nSuspend 3\u2014{1}{W}{W}\nWhen the last time counter is removed from Riftmarked Knight while it's removed from the game, put a 2/2 black Knight creature token with flanking, protection from white, and haste into play.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "112152b2-3b36-58ef-b7d7-2a1e1b6cf959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd1833d-64b0-4c9b-8f6b-1cf15c29d473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edd1833d-64b0-4c9b-8f6b-1cf15c29d473.jpg?1",
             "name": "Saltblast",
             "text": "Destroy target nonwhite permanent.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "b1fef00a-466b-5b0c-9ff7-a5284a2837cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffed4e4-0f54-4ab1-8563-ac4be7ae8309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ffed4e4-0f54-4ab1-8563-ac4be7ae8309.jpg?1",
             "name": "Saltfield Recluse",
             "text": "{T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "ccfd9880-c820-57d2-8801-75b5cd198b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b869a77-dd1c-46bb-9360-5a0c69a193c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b869a77-dd1c-46bb-9360-5a0c69a193c0.jpg?1",
             "name": "Serra's Boon",
             "text": "Enchant creature\nEnchanted creature gets +1/+2 as long as it's white. Otherwise, it gets -2/-1.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "77312ff8-1a87-5fa7-b7ff-113ebdf1e7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90d62c-5b3e-4830-bdc9-c3e342fc8389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90d62c-5b3e-4830-bdc9-c3e342fc8389.jpg?1",
             "name": "Shade of Trokair",
             "text": "{W}: Shade of Trokair gets +1/+1 until end of turn.\nSuspend 3\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "629fa7da-e90e-5cf5-8685-bff93ceff1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b11cec-de85-4289-a7b4-e8bfdf655130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b11cec-de85-4289-a7b4-e8bfdf655130.jpg?1",
             "name": "Stonecloaker",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Stonecloaker comes into play, return a creature you control to its owner's hand.\nWhen Stonecloaker comes into play, remove target card in a graveyard from the game.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "f317027b-a99e-535f-9938-322b9895df64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5e892e-d321-436f-81a6-73975e65b45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de5e892e-d321-436f-81a6-73975e65b45c.jpg?1",
             "name": "Stormfront Riders",
             "text": "Flying\nWhen Stormfront Riders comes into play, return two creatures you control to their owner's hand.\nWhenever Stormfront Riders or another creature is returned to your hand from play, put a 1/1 white Soldier creature token into play.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "be6e66ae-2b03-549b-b4a2-4e3032f8df6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583741a1-0faf-4fb3-8536-b9b1cc8a3b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583741a1-0faf-4fb3-8536-b9b1cc8a3b6f.jpg?1",
             "name": "Voidstone Gargoyle",
             "text": "Flying\nAs Voidstone Gargoyle comes into play, name a nonland card.\nThe named card can't be played.\nActivated abilities of permanents with that name can't be played.\nActivated abilities of cards with that name that aren't in play can't be played.",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "b433d58b-6cbc-57b3-9fef-c711093e5622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1214ff-e959-43ca-8415-79a98d398490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb1214ff-e959-43ca-8415-79a98d398490.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Whitemane Lion comes into play, return a creature you control to its owner's hand.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "fc3fb615-5623-56a1-8aa9-d8175f4b3efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0159719-ccf4-4798-a394-b01f5e422a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0159719-ccf4-4798-a394-b01f5e422a27.jpg?1",
             "name": "Calciderm",
             "text": "Vanishing 4 (This permanent comes into play with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nCalciderm can't be the target of spells or abilities.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "51ef8916-29ba-524d-b142-524e7b4edd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5df373-5dad-4e33-9e2b-351f1f4bdde4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f5df373-5dad-4e33-9e2b-351f1f4bdde4.jpg?1",
             "name": "Malach of the Dawn",
             "text": "Flying\n{W}{W}{W}: Regenerate Malach of the Dawn.",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "a88e9aa7-ae80-5b8c-b909-62b418054399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d48d622-f397-4f31-b1a5-0c23f60aa71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d48d622-f397-4f31-b1a5-0c23f60aa71c.jpg?1",
             "name": "Mana Tithe",
             "text": "Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "b6569548-b506-5510-bb4c-c6bc5c31b16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037d6de-f30b-483c-83a8-9a4e2978f7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4037d6de-f30b-483c-83a8-9a4e2978f7fc.jpg?1",
             "name": "Mesa Enchantress",
             "text": "Whenever you play an enchantment spell, you may draw a card.",
             "colours": [
@@ -890,7 +890,7 @@
         },
         {
             "id": "79f2f68b-c6eb-596e-a2cd-9c6ae67d105f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d8e9fa-e241-4a11-99b8-ffced81eb38b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d8e9fa-e241-4a11-99b8-ffced81eb38b.jpg?1",
             "name": "Mycologist",
             "text": "At the beginning of your upkeep, put a spore counter on Mycologist.\nRemove three spore counters from Mycologist: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: You gain 2 life.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "7c60a790-cd17-593f-a025-d3d20722a7b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8f0e5-8fec-45b2-a6a0-59d7b493a259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a8f0e5-8fec-45b2-a6a0-59d7b493a259.jpg?1",
             "name": "Porphyry Nodes",
             "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures in play, sacrifice Porphyry Nodes.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "8e5fa3bb-d3b2-5017-aa3f-108c84875566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a78d5c-27f8-4061-be89-0246fb69e752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a78d5c-27f8-4061-be89-0246fb69e752.jpg?1",
             "name": "Revered Dead",
             "text": "{W}: Regenerate Revered Dead.",
             "colours": [
@@ -992,7 +992,7 @@
         },
         {
             "id": "fc4efdf9-68e0-5e5d-af7d-6522aec8a570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd2ed50-cd9a-45d9-a59a-6279be1ab308.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd2ed50-cd9a-45d9-a59a-6279be1ab308.jpg?1",
             "name": "Sinew Sliver",
             "text": "All Slivers get +1/+1.",
             "colours": [
@@ -1026,7 +1026,7 @@
         },
         {
             "id": "3229bd6d-1607-532b-99e9-eb10ed26e94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46144ca5-aa81-4314-a1e5-1716f8565d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46144ca5-aa81-4314-a1e5-1716f8565d70.jpg?1",
             "name": "Sunlance",
             "text": "Sunlance deals 3 damage to target nonwhite creature.",
             "colours": [
@@ -1058,7 +1058,7 @@
         },
         {
             "id": "fecd5269-360a-5fd0-ad3d-f3c6e22f100f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbc2dd2-976b-4239-bef9-ea0f06be79ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbc2dd2-976b-4239-bef9-ea0f06be79ba.jpg?1",
             "name": "Aeon Chronicler",
             "text": "Aeon Chronicler's power and toughness are each equal to the number of cards in your hand.\nSuspend X\u2014{X}{3}{U}. X can't be 0.\nWhenever a time counter is removed from Aeon Chronicler while it's removed from the game, draw a card.",
             "colours": [
@@ -1092,7 +1092,7 @@
         },
         {
             "id": "4bc38d45-5fda-5761-836c-b622925b04d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9781ab73-5c79-41f3-b319-c9299b03353a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9781ab73-5c79-41f3-b319-c9299b03353a.jpg?1",
             "name": "Aquamorph Entity",
             "text": "As Aquamorph Entity comes into play or is turned face up, it becomes your choice of 5/1 or 1/5.\nMorph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "89f7cb2b-024f-5f90-bc62-a235e308cbab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c787368d-d208-4aac-936d-b0c189d1cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c787368d-d208-4aac-936d-b0c189d1cd90.jpg?1",
             "name": "Auramancer's Guise",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 for each Aura attached to it and has vigilance.",
             "colours": [
@@ -1160,7 +1160,7 @@
         },
         {
             "id": "edfa383f-723b-5dc9-a85b-5927fdfa3246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66895b2-07f9-46b1-80e6-2d573e532fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66895b2-07f9-46b1-80e6-2d573e532fc5.jpg?1",
             "name": "Body Double",
             "text": "As Body Double comes into play, you may choose a creature card in a graveyard. If you do, Body Double comes into play as a copy of that card.",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "8653afbb-6348-519f-bac2-b7a9d6660b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f16252d-0692-43f6-b980-ed9a6d937637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f16252d-0692-43f6-b980-ed9a6d937637.jpg?1",
             "name": "Braids, Conjurer Adept",
             "text": "At the beginning of each player's upkeep, that player may put an artifact, creature, or land card from his or her hand into play.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "4daba2a1-8b47-59c7-896e-6eb900490d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77c1ac0-5548-42b0-aa46-d532b3518632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77c1ac0-5548-42b0-aa46-d532b3518632.jpg?1",
             "name": "Chronozoa",
             "text": "Flying\nVanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Chronozoa is put into a graveyard from play, if it had no time counters on it, put two tokens into play that are copies of it.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "558d00a3-c02d-5bbd-a24f-e1d5fb984c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61583ead-bccc-44d9-bd1d-2a13511990b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61583ead-bccc-44d9-bd1d-2a13511990b5.jpg?1",
             "name": "Dichotomancy",
             "text": "For each tapped nonland permanent target opponent controls, search that player's library for a card with the same name as that permanent and put it into play under your control. Then that player shuffles his or her library.\nSuspend 3\u2014{1}{U}{U}",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "83ecdb65-c6c8-57ba-b535-38d3c53a2911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35786a7a-faa6-457d-9b92-da560b93a43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35786a7a-faa6-457d-9b92-da560b93a43a.jpg?1",
             "name": "Dismal Failure",
             "text": "Counter target spell. Its controller discards a card.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "419dd637-19db-51ac-8430-2daea900012a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479d22f-1a97-4bc8-a1e1-c3de87429c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6479d22f-1a97-4bc8-a1e1-c3de87429c22.jpg?1",
             "name": "Dreamscape Artist",
             "text": "{2}{U}, {T}, Discard a card, Sacrifice a land: Search your library for up to two basic land cards and put them into play. Then shuffle your library.",
             "colours": [
@@ -1364,7 +1364,7 @@
         },
         {
             "id": "10dcb6c5-2bd1-57a5-b9ec-e2795d641a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d3fb1-abfa-4724-a4e7-f65de88521f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06d3fb1-abfa-4724-a4e7-f65de88521f8.jpg?1",
             "name": "Erratic Mutation",
             "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -1396,7 +1396,7 @@
         },
         {
             "id": "976e61e5-245f-5426-8a30-de4eab1b7e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c92ae75-a209-4cc4-8817-06ff18f3ac02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c92ae75-a209-4cc4-8817-06ff18f3ac02.jpg?1",
             "name": "Jodah's Avenger",
             "text": "{0}: Until end of turn, Jodah's Avenger gets -1/-1 and gains your choice of double strike, protection from red, vigilance, or shadow. (A creature with shadow can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "903ec183-9622-52cc-8f21-6ea0b1cf57a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89762f8-70e0-414b-a788-532710129733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a89762f8-70e0-414b-a788-532710129733.jpg?1",
             "name": "Magus of the Bazaar",
             "text": "{T}: Draw two cards, then discard three cards.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "760402ad-b067-5756-b80b-1eca315e8ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce74a84-4441-4f2e-89d8-df0b096790ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce74a84-4441-4f2e-89d8-df0b096790ed.jpg?1",
             "name": "Pongify",
             "text": "Destroy target creature. It can't be regenerated. That creature's controller puts a 3/3 green Ape creature token into play.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "b172df9d-997c-527f-89ba-8fae23581de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6ad9c3-b5dd-46a9-8494-8b395e21aedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6ad9c3-b5dd-46a9-8494-8b395e21aedf.jpg?1",
             "name": "Reality Acid",
             "text": "Enchant permanent\nVanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves play, enchanted permanent's controller sacrifices it.",
             "colours": [
@@ -1531,7 +1531,7 @@
         },
         {
             "id": "70911afd-9723-578c-bf08-598a50472d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88afc02-522b-4c51-9509-aff54bbb41c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88afc02-522b-4c51-9509-aff54bbb41c8.jpg?1",
             "name": "Shaper Parasite",
             "text": "Morph {2}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Shaper Parasite is turned face up, target creature gets +2/-2 or -2/+2 until end of turn.",
             "colours": [
@@ -1565,7 +1565,7 @@
         },
         {
             "id": "86275a73-0af6-5a1e-8692-37692eb21a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c897a6-5835-42ac-8cc7-e8d9fc1e7c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c897a6-5835-42ac-8cc7-e8d9fc1e7c77.jpg?1",
             "name": "Spellshift",
             "text": "Counter target instant or sorcery spell. Its controller reveals cards from the top of his or her library until he or she reveals an instant or sorcery card. That player may play that card without paying its mana cost. Then he or she shuffles his or her library.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "7b6b098f-ad04-53fd-8b25-7c834a498ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02fa57b-4b7f-46e1-b2b5-6b1a9e9d1643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02fa57b-4b7f-46e1-b2b5-6b1a9e9d1643.jpg?1",
             "name": "Synchronous Sliver",
             "text": "All Slivers have vigilance.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "2c1b4254-3648-522f-b1dc-e76504c6c23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464c2aa-8f12-4654-89c5-3323d7e7ab73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9464c2aa-8f12-4654-89c5-3323d7e7ab73.jpg?1",
             "name": "Tidewalker",
             "text": "Tidewalker comes into play with a time counter on it for each Island you control.\nVanishing (At the beginning of your upkeep, remove a time counter from this permanent. When the last is removed, sacrifice it.)\nTidewalker's power and toughness are each equal to the number of time counters on it.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "947e57dd-5620-5a77-8abd-45c6bd4bc775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fdf8bd-a069-41ca-9cbb-deb7f53cbcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fdf8bd-a069-41ca-9cbb-deb7f53cbcbe.jpg?1",
             "name": "Timebender",
             "text": "Morph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Timebender is turned face up, choose one Remove two time counters from target permanent or suspended card; or put two time counters on target permanent with a time counter on it or suspended card.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "2a272847-4e9d-5b41-b764-d3119a2cf0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7fd5f3-e5af-4591-9db8-5d85dfe0170f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7fd5f3-e5af-4591-9db8-5d85dfe0170f.jpg?1",
             "name": "Veiling Oddity",
             "text": "Suspend 4\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)\nWhen the last time counter is removed from Veiling Oddity while it's removed from the game, creatures are unblockable this turn.",
             "colours": [
@@ -1734,7 +1734,7 @@
         },
         {
             "id": "af592cc0-baac-5e5a-a703-3542c554db67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfab012-f57a-4018-bfe3-8eac073f6ee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfab012-f57a-4018-bfe3-8eac073f6ee8.jpg?1",
             "name": "Venarian Glimmer",
             "text": "Target player reveals his or her hand. Choose a nonland card with converted mana cost X or less from it. That player discards that card.",
             "colours": [
@@ -1766,7 +1766,7 @@
         },
         {
             "id": "9fd159cd-0731-51da-8d37-6f83ac319175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5031831-49ee-4c54-9200-448b8953f915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5031831-49ee-4c54-9200-448b8953f915.jpg?1",
             "name": "Wistful Thinking",
             "text": "Target player draws two cards, then discards four cards.",
             "colours": [
@@ -1798,7 +1798,7 @@
         },
         {
             "id": "e5fb32bc-9d38-5a75-9fac-31e49c8c5b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e727bb9e-3510-4c8e-ac49-6d7217667a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e727bb9e-3510-4c8e-ac49-6d7217667a18.jpg?1",
             "name": "Frozen Aether",
             "text": "Artifacts, creatures, and lands your opponents control come into play tapped.",
             "colours": [
@@ -1830,7 +1830,7 @@
         },
         {
             "id": "1913882b-1a2c-5981-b85d-f9366e75170f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d53c7-ef63-464f-b5f0-90220ee2b575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307d53c7-ef63-464f-b5f0-90220ee2b575.jpg?1",
             "name": "Gossamer Phantasm",
             "text": "Flying\nWhen Gossamer Phantasm becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "05481b64-3de4-518b-8f19-83cc31e6561b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa3d335-f39f-4291-85e0-7430561e953b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa3d335-f39f-4291-85e0-7430561e953b.jpg?1",
             "name": "Merfolk Thaumaturgist",
             "text": "{T}: Switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -1899,7 +1899,7 @@
         },
         {
             "id": "c6a82611-58c6-5096-97c2-1c966c22711c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a985cfb0-6bae-4b1c-902e-d9d7a1aeec61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a985cfb0-6bae-4b1c-902e-d9d7a1aeec61.jpg?1",
             "name": "Ovinize",
             "text": "Target creature loses all abilities and becomes 0/1 until end of turn.",
             "colours": [
@@ -1931,7 +1931,7 @@
         },
         {
             "id": "9246ce26-4f33-5a54-834c-954bb69d9812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586a1d9f-59ae-41a7-8de7-d6c4553ea79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/586a1d9f-59ae-41a7-8de7-d6c4553ea79e.jpg?1",
             "name": "Piracy Charm",
             "text": "Choose one Target creature gains islandwalk until end of turn; or target creature gets +2/-1 until end of turn; or target player discards a card.",
             "colours": [
@@ -1963,7 +1963,7 @@
         },
         {
             "id": "4b96f2b7-6175-5c04-b06a-3522ec53ad4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbdd96b-e740-43d0-a1b6-7b9b92cc7993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bbdd96b-e740-43d0-a1b6-7b9b92cc7993.jpg?1",
             "name": "Primal Plasma",
             "text": "As Primal Plasma comes into play, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.",
             "colours": [
@@ -1998,7 +1998,7 @@
         },
         {
             "id": "5802f345-6b28-579f-a901-bb26913fb6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcc3c1a-edb5-4534-aafa-5e078d503e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcc3c1a-edb5-4534-aafa-5e078d503e64.jpg?1",
             "name": "Riptide Pilferer",
             "text": "Whenever Riptide Pilferer deals combat damage to a player, that player discards a card.\nMorph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "ea86febe-7934-5f5e-9556-6bfe99a6581a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfd6aa-2fc9-4628-aa17-3ff0c30dc804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfd6aa-2fc9-4628-aa17-3ff0c30dc804.jpg?1",
             "name": "Serendib Sorcerer",
             "text": "{T}: Target creature other than Serendib Sorcerer becomes 0/2 until end of turn.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "a23731ce-bffc-5f36-b13d-e31db73dc99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a4d7ac-082b-4f66-9b7f-4d1d0fda78c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a4d7ac-082b-4f66-9b7f-4d1d0fda78c7.jpg?1",
             "name": "Serra Sphinx",
             "text": "Flying, vigilance",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "48fbd948-cd44-5be1-8aa1-b3ff22d26359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61f38a9-6f15-4186-a602-78cdb00f2d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a61f38a9-6f15-4186-a602-78cdb00f2d75.jpg?1",
             "name": "Big Game Hunter",
             "text": "When Big Game Hunter comes into play, destroy target creature with power 4 or greater. It can't be regenerated.\nMadness {B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "17ea8a5b-1045-5f7b-81b4-c75aeb2cd868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae24bc0-1217-4db9-a745-8860f23b6d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ae24bc0-1217-4db9-a745-8860f23b6d57.jpg?1",
             "name": "Blightspeaker",
             "text": "{T}: Target player loses 1 life.\n{4}, {T}: Search your library for a Rebel card with converted mana cost 3 or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "84be87e8-594e-5717-8699-2bc0c84e063e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02161f4-505c-4c01-ae33-5c61598c71d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b02161f4-505c-4c01-ae33-5c61598c71d7.jpg?1",
             "name": "Brain Gorgers",
             "text": "When you play Brain Gorgers, any player may sacrifice a creature. If a player does, counter Brain Gorgers.\nMadness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "8be11234-57b0-54f9-a7cf-4adc4ec89124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f059cd0-7924-495e-bac4-021f0e46bb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f059cd0-7924-495e-bac4-021f0e46bb87.jpg?1",
             "name": "Circle of Affliction",
             "text": "As Circle of Affliction comes into play, choose a color.\nWhenever a source of the chosen color deals damage to you, you may pay {1}. If you do, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "734b7f46-3d3e-5cc1-b7a7-1d8a6502a395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec275cf-bb4e-4de0-9184-4d53dd87dad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec275cf-bb4e-4de0-9184-4d53dd87dad3.jpg?1",
             "name": "Cradle to Grave",
             "text": "Destroy target nonblack creature that came into play this turn.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "e18986be-47ce-5650-9763-32cbe01ffd81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814bcfc0-7539-4ed9-8b51-27e6a3ab9d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814bcfc0-7539-4ed9-8b51-27e6a3ab9d9a.jpg?1",
             "name": "Dash Hopes",
             "text": "When you play Dash Hopes, any player may pay 5 life. If a player does, counter Dash Hopes.\nCounter target spell.",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "78a4ab0e-2ae7-5578-b95a-037a8fd9fb29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde915a3-9c85-4365-bab9-87d446f85794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cde915a3-9c85-4365-bab9-87d446f85794.jpg?1",
             "name": "Deadly Grub",
             "text": "Vanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadly Grub is put into a graveyard from play, if it had no time counters on it, put a 6/1 green Insect creature token into play with \"This creature can't be the target of spells or abilities.\"",
             "colours": [
@@ -2338,7 +2338,7 @@
         },
         {
             "id": "f7734b94-bcc2-51f5-8a4f-ca034eff85a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6283e1-e4f1-4ff6-be01-b66ab623e0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6283e1-e4f1-4ff6-be01-b66ab623e0ac.jpg?1",
             "name": "Enslave",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, enchanted creature deals 1 damage to its owner.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "31641497-b074-56cb-bb88-03404fce839c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2608b5fc-3b58-4b02-aef1-35d885b16b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2608b5fc-3b58-4b02-aef1-35d885b16b01.jpg?1",
             "name": "Extirpate",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land. Search its owner's graveyard, hand, and library for all cards with the same name as that card and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "9b7f511e-f115-5e4d-9e78-340e0b2cb280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ec70a6-40b7-41da-a6c0-c140cadf5509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ec70a6-40b7-41da-a6c0-c140cadf5509.jpg?1",
             "name": "Imp's Mischief",
             "text": "Change the target of target spell with a single target. You lose life equal to that spell's converted mana cost.",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "54ac3b12-1e17-5ff8-90ef-965a98f6e471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6b93ea-8ada-404c-9920-7976690c3e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6b93ea-8ada-404c-9920-7976690c3e8c.jpg?1",
             "name": "Magus of the Coffers",
             "text": "{2}, {T}: Add {B} to your mana pool for each Swamp you control.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "032623a5-2f61-5855-b142-ab52318082ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f51f18-41af-4a2c-a353-48bebd697599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f51f18-41af-4a2c-a353-48bebd697599.jpg?1",
             "name": "Midnight Charm",
             "text": "Choose one Midnight Charm deals 1 damage to target creature and you gain 1 life; or target creature gains first strike until end of turn; or tap target creature.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "438016fc-733d-5692-b94b-f62483f786e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09233-952f-4784-995e-0d85d8b56637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da09233-952f-4784-995e-0d85d8b56637.jpg?1",
             "name": "Mirri the Cursed",
             "text": "Flying, first strike, haste\nWhenever Mirri the Cursed deals combat damage to a creature, put a +1/+1 counter on Mirri the Cursed.",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "6b99aa60-5df8-59db-b4ba-261ad45750bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bda3fc-89e8-44c2-bcfb-d17064bbc391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bda3fc-89e8-44c2-bcfb-d17064bbc391.jpg?1",
             "name": "Muck Drubb",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Muck Drubb comes into play, change the target of target spell that targets only a single creature to Muck Drubb.\nMadness {2}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -2574,7 +2574,7 @@
         },
         {
             "id": "bf995934-db27-57ab-8a15-49766260d4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bcd780-70a6-4c25-8611-8b750a50aa3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bcd780-70a6-4c25-8611-8b750a50aa3d.jpg?1",
             "name": "Phantasmagorian",
             "text": "When you play Phantasmagorian, any player may discard three cards. If a player does, counter Phantasmagorian.\nDiscard three cards: Return Phantasmagorian from your graveyard to your hand.",
             "colours": [
@@ -2608,7 +2608,7 @@
         },
         {
             "id": "78ff8a83-7c99-5c0d-95c6-6e35178a25e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b27919-6b36-49f2-a6df-d63e5db6de0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b27919-6b36-49f2-a6df-d63e5db6de0b.jpg?1",
             "name": "Ridged Kusite",
             "text": "{1}{B}, {T}, Discard a card: Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -2643,7 +2643,7 @@
         },
         {
             "id": "71bf23ea-9a1f-545b-9a42-5f8b30767261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83006a5-c42b-4083-a246-f46b25412150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83006a5-c42b-4083-a246-f46b25412150.jpg?1",
             "name": "Roiling Horror",
             "text": "Roiling Horror's power and toughness are each equal to your life total minus the life total of an opponent with the most life.\nSuspend X\u2014{X}{B}{B}{B}. X can't be 0.\nWhenever a time counter is removed from Roiling Horror while it's removed from the game, target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "efe09eae-321c-5f02-a37f-e31f4a754bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd07649e-c7fc-44f7-ab23-0fb935aff8c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd07649e-c7fc-44f7-ab23-0fb935aff8c7.jpg?1",
             "name": "Spitting Sliver",
             "text": "All Slivers have first strike.",
             "colours": [
@@ -2711,7 +2711,7 @@
         },
         {
             "id": "2cc8aa2a-af00-59bf-93bc-2f196b461d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a1afb-423d-4f12-93e1-75cc336553b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a1afb-423d-4f12-93e1-75cc336553b8.jpg?1",
             "name": "Temporal Extortion",
             "text": "When you play Temporal Extortion, any player may pay half his or her life, rounded up. If a player does, counter Temporal Extortion.\nTake an extra turn after this one.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "2861447e-8fc1-5b19-b092-a6df19430446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22563bcd-1f29-4544-ba43-173ead61e62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22563bcd-1f29-4544-ba43-173ead61e62a.jpg?1",
             "name": "Treacherous Urge",
             "text": "Target opponent reveals his or her hand. You may put a creature card from it into play under your control. That creature has haste. Sacrifice it at end of turn.",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "9c87b39f-158a-5989-8052-f202cda8cc16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20b0048-f93a-4349-b5d1-201ab0a38d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b20b0048-f93a-4349-b5d1-201ab0a38d1b.jpg?1",
             "name": "Waning Wurm",
             "text": "Vanishing 2 (This permanent comes into play with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -2810,7 +2810,7 @@
         },
         {
             "id": "0ad6a629-61b1-5361-b31e-fcdff2e34bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958de76-a5ec-4e14-a025-4fe0e84c8b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2958de76-a5ec-4e14-a025-4fe0e84c8b4b.jpg?1",
             "name": "Bog Serpent",
             "text": "Bog Serpent can't attack unless defending player controls a Swamp.\nWhen you control no Swamps, sacrifice Bog Serpent.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "280111ea-c53a-552f-9078-41148322ee96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c68473-70ca-40ba-b5c6-71ec30f88a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c68473-70ca-40ba-b5c6-71ec30f88a2c.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -2876,7 +2876,7 @@
         },
         {
             "id": "46a9336f-bda4-53f8-86a3-4b426cd55960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965d9f9-0a7b-48bc-a6ab-d8b73c4550a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965d9f9-0a7b-48bc-a6ab-d8b73c4550a8.jpg?1",
             "name": "Dunerider Outlaw",
             "text": "Protection from green\nAt end of turn, if Dunerider Outlaw dealt damage to an opponent this turn, put a +1/+1 counter on it.",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "41b99c3d-34aa-53a4-b9c8-e91e60479fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e1ec29-508f-4e5e-b601-79e27743bcea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e1ec29-508f-4e5e-b601-79e27743bcea.jpg?1",
             "name": "Kor Dirge",
             "text": "All damage that would be dealt this turn to target creature you control by a source of your choice is dealt to another target creature instead.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "409f464e-7dd6-52fa-9714-4334b19aa316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa6fe9a-27ba-480f-84ce-b8d3306f0339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faa6fe9a-27ba-480f-84ce-b8d3306f0339.jpg?1",
             "name": "Melancholy",
             "text": "Enchant creature\nWhen Melancholy comes into play, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nAt the beginning of your upkeep, sacrifice Melancholy unless you pay {B}.",
             "colours": [
@@ -2978,7 +2978,7 @@
         },
         {
             "id": "8184e466-8426-50cc-a234-27aca4fab4a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c996792c-0846-4b78-bce5-1c6ad29640f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c996792c-0846-4b78-bce5-1c6ad29640f6.jpg?1",
             "name": "Null Profusion",
             "text": "Skip your draw step.\nWhenever you play a card, draw a card.\nYour maximum hand size is two.",
             "colours": [
@@ -3010,7 +3010,7 @@
         },
         {
             "id": "fe14902d-0080-546f-8353-ff7cbcb03bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2968e01-2d04-4591-98de-24688bb087df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2968e01-2d04-4591-98de-24688bb087df.jpg?1",
             "name": "Rathi Trapper",
             "text": "{B}, {T}: Tap target creature.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "d6e129c5-2188-5c55-9a54-fa3e5659bc4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf956-90eb-4221-a8e0-c8414d819072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf956-90eb-4221-a8e0-c8414d819072.jpg?1",
             "name": "Shrouded Lore",
             "text": "Target opponent chooses a card in your graveyard. You may pay {B}. If you do, repeat this process except that opponent can't choose a card already chosen for Shrouded Lore. Then put the last chosen card into your hand.",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "816b1e25-5a79-5cc2-8529-d3b3f4c19542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9be1058-0668-4938-8801-e9a98464651c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9be1058-0668-4938-8801-e9a98464651c.jpg?1",
             "name": "Vampiric Link",
             "text": "Enchant creature\nWhenever enchanted creature deals damage, you gain that much life.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "bc4284b8-715d-5046-a3dd-15a94d29e1e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7767264f-926f-48eb-a5a1-c56b027e645f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7767264f-926f-48eb-a5a1-c56b027e645f.jpg?1",
             "name": "Aether Membrane",
             "text": "Defender\n\u00c6ther Membrane can block as though it had flying.\nWhenever \u00c6ther Membrane blocks a creature, return that creature to its owner's hand at end of combat.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "2d01ef6f-8d80-5aa4-86a2-a99fa7ad8cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815de82-5ba9-4fb6-9259-d5e50e046890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3815de82-5ba9-4fb6-9259-d5e50e046890.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "Akroma, Angel of Fury can't be countered.\nFlying, trample, protection from white, protection from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3182,7 +3182,7 @@
         },
         {
             "id": "1abb31d2-2375-5bf2-9e0b-ba6fb7c4fab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc86d6-aa3e-46c6-9405-86f1e1ee7844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dc86d6-aa3e-46c6-9405-86f1e1ee7844.jpg?1",
             "name": "Battering Sliver",
             "text": "All Slivers have trample.",
             "colours": [
@@ -3216,7 +3216,7 @@
         },
         {
             "id": "06dc97fe-4999-5c45-8d36-80725da9daf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec01f4b-b3df-4e2b-ae93-2f2d0cc279bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec01f4b-b3df-4e2b-ae93-2f2d0cc279bd.jpg?1",
             "name": "Detritivore",
             "text": "Detritivore's power and toughness are each equal to the number of nonbasic land cards in your opponents' graveyards.\nSuspend X\u2014{X}{3}{R}. X can't be 0.\nWhenever a time counter is removed from Detritivore while it's removed from the game, destroy target nonbasic land.",
             "colours": [
@@ -3250,7 +3250,7 @@
         },
         {
             "id": "5d8a4bef-4ddd-5e5c-bed2-bf1ce753648f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb554768-d908-474d-832d-d4e36d293712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb554768-d908-474d-832d-d4e36d293712.jpg?1",
             "name": "Dust Corona",
             "text": "Enchant creature\nEnchanted creature gets +2/+0 and can't be blocked by creatures with flying.",
             "colours": [
@@ -3284,7 +3284,7 @@
         },
         {
             "id": "1d0da11c-7de3-58b0-9ae3-3b25633139dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe87d-e886-4e30-8ff2-3886199f0461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe87d-e886-4e30-8ff2-3886199f0461.jpg?1",
             "name": "Fatal Frenzy",
             "text": "Until end of turn, target creature you control gains trample and gets +X/+0, where X is its power. Sacrifice it at end of turn.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "c557148c-f271-5c99-817d-b7a9c7573793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e1f374-d5fc-4f39-ad2a-2c9dad74efd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e1f374-d5fc-4f39-ad2a-2c9dad74efd3.jpg?1",
             "name": "Firefright Mage",
             "text": "{1}{R}, {T}, Discard a card: Target creature can't be blocked this turn except by artifact creatures and/or red creatures.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "942d9b2b-a263-5325-b696-d81482b023cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e891f1-79fa-43dc-817b-c7838cd03d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e891f1-79fa-43dc-817b-c7838cd03d5f.jpg?1",
             "name": "Fury Charm",
             "text": "Choose one Destroy target artifact; or target creature gets +1/+1 and gains trample until end of turn; or remove two time counters from target permanent or suspended card.",
             "colours": [
@@ -3383,7 +3383,7 @@
         },
         {
             "id": "7fcb3a85-5f2e-5a05-8dbf-b716a0bbe64e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791cb45a-66f0-4609-8da8-56112e31cef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791cb45a-66f0-4609-8da8-56112e31cef0.jpg?1",
             "name": "Hammerheim Deadeye",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Hammerheim Deadeye comes into play, destroy target creature with flying.",
             "colours": [
@@ -3418,7 +3418,7 @@
         },
         {
             "id": "c88735ce-0fa0-523e-927a-2a6313c89590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c28db-34d2-4325-99d1-9b689753802f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677c28db-34d2-4325-99d1-9b689753802f.jpg?1",
             "name": "Keldon Marauders",
             "text": "Vanishing 2 (This permanent comes into play with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Keldon Marauders comes into play or leaves play, it deals 1 damage to target player.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "4d549d62-2427-594d-95f5-28d3fa6b8799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2f4de-fc41-4e68-8655-577616b10c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b2f4de-fc41-4e68-8655-577616b10c7e.jpg?1",
             "name": "Lavacore Elemental",
             "text": "Vanishing 1 (This permanent comes into play with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever a creature you control deals combat damage to a player, put a time counter on Lavacore Elemental.",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "32b9ffc5-77e8-5cde-9477-51e483ab191b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28af8d4-98e8-48aa-9697-49c94dfabedb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28af8d4-98e8-48aa-9697-49c94dfabedb.jpg?1",
             "name": "Magus of the Arena",
             "text": "{3}, {T}: Tap target creature you control and target creature of an opponent's choice he or she controls. Each of those creatures deals damage equal to its power to the other.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "faddbd86-a153-56c4-8cd0-86d2d22cbc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4307e3-3138-4ccb-8aa3-2ffcfeb2948f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a4307e3-3138-4ccb-8aa3-2ffcfeb2948f.jpg?1",
             "name": "Needlepeak Spider",
             "text": "Needlepeak Spider can block as though it had flying.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "0dd37042-6143-5ba2-ad7a-0d0623f4be3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108599c3-f641-48f1-af68-8e9a66c6afbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/108599c3-f641-48f1-af68-8e9a66c6afbc.jpg?1",
             "name": "Shivan Meteor",
             "text": "Shivan Meteor deals 13 damage to target creature.\nSuspend 2\u2014{1}{R}{R} (Rather than play this card from your hand, you may pay {1}{R}{R} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost.)",
             "colours": [
@@ -3588,7 +3588,7 @@
         },
         {
             "id": "9ca17080-c65c-5287-a55f-80e216911793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b10d6b3-2cd9-4628-a079-6ac803b6f3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b10d6b3-2cd9-4628-a079-6ac803b6f3c3.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger comes into play, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -3623,7 +3623,7 @@
         },
         {
             "id": "8e234f28-934b-597a-832f-67ff6040291d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cba6fd-2474-400d-8568-33fe447abc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49cba6fd-2474-400d-8568-33fe447abc7c.jpg?1",
             "name": "Sulfur Elemental",
             "text": "Flash (You may play this spell any time you could play an instant.)\nSplit second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nWhite creatures get +1/-1.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "5010385d-b09c-5424-979a-44ee607a9843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6da5ef-7e5b-4536-ad28-6fe66f3e0438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6da5ef-7e5b-4536-ad28-6fe66f3e0438.jpg?1",
             "name": "Timecrafting",
             "text": "Choose one Remove X time counters from target permanent or suspended card; or put X time counters on target permanent with a time counter on it or suspended card.",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "01677f47-0e71-5e1e-9cec-7870988ee149",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9bee9f-701b-433e-b0c3-9bf00f598aa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9bee9f-701b-433e-b0c3-9bf00f598aa9.jpg?1",
             "name": "Torchling",
             "text": "{R}: Untap Torchling.\n{R}: Target creature blocks Torchling this turn if able.\n{R}: Change the target of target spell that targets only Torchling.\n{1}: Torchling gets +1/-1 until end of turn.\n{1}: Torchling gets -1/+1 until end of turn.",
             "colours": [
@@ -3723,7 +3723,7 @@
         },
         {
             "id": "ba614973-7b60-526a-928d-bb1b6735187d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026b1a54-ab62-431d-a23e-5890d3932c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026b1a54-ab62-431d-a23e-5890d3932c7e.jpg?1",
             "name": "Volcano Hellion",
             "text": "Volcano Hellion has echo {X}, where X is your life total.\nWhen Volcano Hellion comes into play, it deals an amount of damage of your choice to you and target creature. The damage can't be prevented.",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "7104f01e-0ca6-53e6-873f-ee246015174a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy target land you control and target land you don't control.",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "94a1683f-deed-5731-bc0a-894075b3fdb2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7ce986a4-5f82-4e7e-bef5-b49f05bf96a6.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy all lands.",
             "colours": [
@@ -3821,7 +3821,7 @@
         },
         {
             "id": "bea0e066-b932-546f-ae6d-7c311e395bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg?1",
             "name": "Dead // Gone",
             "text": "Dead deals 2 damage to target creature.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "38face9b-00dc-555b-b88b-f62d19f5eab9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96fd8d8e-8f2a-4240-bcb7-18f73fd47bd5.jpg?1",
             "name": "Dead // Gone",
             "text": "Return target creature you don't control to its owner's hand.",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "f62813a2-f422-5f6f-b07e-97a9a47efaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg?1",
             "name": "Rough // Tumble",
             "text": "Rough deals 2 damage to each creature without flying.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "0e6a7d39-5a2b-5ced-892a-3517592f5919",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0c93c9a0-53eb-44cc-bd79-8103774bfd4c.jpg?1",
             "name": "Rough // Tumble",
             "text": "Tumble deals 6 damage to each creature with flying.",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "a8eff59b-676c-5edb-827d-c57c2050b763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2133c0-8561-4264-8802-1b2933abf186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2133c0-8561-4264-8802-1b2933abf186.jpg?1",
             "name": "Blood Knight",
             "text": "First strike, protection from white",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "92713de9-9da7-5294-aa55-2b0b540b9dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d43220-1e4e-4b61-9844-51c8bb5dde35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d43220-1e4e-4b61-9844-51c8bb5dde35.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "d41f7374-5c3a-5eb4-b2c8-fb3e8ef44183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddda66c-2df4-452e-8eca-7e100213fd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddda66c-2df4-452e-8eca-7e100213fd98.jpg?1",
             "name": "Molten Firebird",
             "text": "Flying\nWhen Molten Firebird is put into a graveyard from play, return it to play under its owner's control at end of turn and you skip your next draw step.\n{4}{R}: Remove Molten Firebird from the game.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "b2515423-4abe-5be3-bb54-e04040b32225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97787109-408e-42d3-acc5-300f5f5bf2ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97787109-408e-42d3-acc5-300f5f5bf2ff.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to target creature or player.",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "8189ad5f-0cc3-5b8e-9349-a6a3dcfa76b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b778d44-60a9-4230-8090-73c38e7c9697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b778d44-60a9-4230-8090-73c38e7c9697.jpg?1",
             "name": "Pyrohemia",
             "text": "At end of turn, if no creatures are in play, sacrifice Pyrohemia.\n{R}: Pyrohemia deals 1 damage to each creature and each player.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "8f7c49f9-9426-5ec4-b436-5bca1eaec959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d4fd92-33d1-4f14-a4f4-7c7feaa18f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d4fd92-33d1-4f14-a4f4-7c7feaa18f93.jpg?1",
             "name": "Reckless Wurm",
             "text": "Trample\nMadness {2}{R} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "9b8abaf9-f0f9-5f5f-b8b6-e3194c2076e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7958a1e5-b671-4ecb-95de-240ffaf5021e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7958a1e5-b671-4ecb-95de-240ffaf5021e.jpg?1",
             "name": "Shivan Wumpus",
             "text": "Trample\nWhen Shivan Wumpus comes into play, any player may sacrifice a land. If a player does, put Shivan Wumpus on top of its owner's library.",
             "colours": [
@@ -4185,7 +4185,7 @@
         },
         {
             "id": "00845562-0b07-5c79-b903-9d2febceddd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7f701c-dcdc-4067-8d00-b4b7aadee9ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7f701c-dcdc-4067-8d00-b4b7aadee9ba.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "Remove Simian Spirit Guide in your hand from the game: Add {R} to your mana pool.",
             "colours": [
@@ -4220,7 +4220,7 @@
         },
         {
             "id": "b8a82844-b4bd-5332-a11c-55cacb0a7c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47307d3f-14e8-42bd-acf4-1383e5790e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47307d3f-14e8-42bd-acf4-1383e5790e6f.jpg?1",
             "name": "Skirk Shaman",
             "text": "Skirk Shaman can't be blocked except by artifact creatures and/or red creatures.",
             "colours": [
@@ -4255,7 +4255,7 @@
         },
         {
             "id": "cea7ac50-171a-5791-9c4c-b33340563c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafbeae0-17e3-4a29-bd02-9f45b549b990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafbeae0-17e3-4a29-bd02-9f45b549b990.jpg?1",
             "name": "Ana Battlemage",
             "text": "Kicker {2}{U} and/or {1}{B}\nWhen Ana Battlemage comes into play, if the {2}{U} kicker cost was paid, target player discards three cards.\nWhen Ana Battlemage comes into play, if the {1}{B} kicker cost was paid, tap target untapped creature and that creature deals damage equal to its power to its controller.",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "bfde935e-48c9-597b-a0ee-a8852dde251b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14556a-1bf4-4024-ba5b-2a4753fc236b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc14556a-1bf4-4024-ba5b-2a4753fc236b.jpg?1",
             "name": "Citanul Woodreaders",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you play this spell.)\nWhen Citanul Woodreaders comes into play, if the kicker cost was paid, draw two cards.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "e3eca687-756d-534a-ae19-c4f275052c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e69c12-41f3-489c-ba30-2836b978f9dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e69c12-41f3-489c-ba30-2836b978f9dc.jpg?1",
             "name": "Deadwood Treefolk",
             "text": "Vanishing 3 (This permanent comes into play with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk comes into play or leaves play, return another target creature card from your graveyard to your hand.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "7351c2f4-ee2f-5892-be9e-ecfea31f34ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4546059-71fe-43c1-9272-3b054e668e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4546059-71fe-43c1-9272-3b054e668e3c.jpg?1",
             "name": "Evolution Charm",
             "text": "Choose one Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library; or return target creature card from your graveyard to your hand; or target creature gains flying until end of turn.",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "5311a316-9409-534d-995c-1ff672c4bae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c1910b-9475-4551-b9a0-4b24511a6f98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c1910b-9475-4551-b9a0-4b24511a6f98.jpg?1",
             "name": "Fungal Behemoth",
             "text": "Fungal Behemoth's power and toughness are each equal to the number of +1/+1 counters on creatures you control.\nSuspend X\u2014{X}{G}{G}. X can't be 0.\nWhenever a time counter is removed from Fungal Behemoth while it's removed from the game, you may put a +1/+1 counter on target creature.",
             "colours": [
@@ -4427,7 +4427,7 @@
         },
         {
             "id": "d226cec2-b83d-544e-968e-bd3a1d52f7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6938b-89e6-4cf2-8372-17f1682124ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d6938b-89e6-4cf2-8372-17f1682124ec.jpg?1",
             "name": "Giant Dustwasp",
             "text": "Flying\nSuspend 4\u2014{1}{G} (Rather than play this card from your hand, you may pay {1}{G} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "83bd0c82-d369-54d4-98c6-81c2ba136ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112e0d7-5451-4e3b-8c73-2d2024f45cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4112e0d7-5451-4e3b-8c73-2d2024f45cd8.jpg?1",
             "name": "Hunting Wilds",
             "text": "Kicker {3}{G} (You may pay an additional {3}{G} as you play this spell.)\nSearch your library for up to two Forest cards and put them into play tapped. Then shuffle your library.\nIf the kicker cost was paid, untap all Forests put into play this way. They become 3/3 green creatures with haste that are still lands.",
             "colours": [
@@ -4493,7 +4493,7 @@
         },
         {
             "id": "54dc14c7-ddfd-5b9c-a1bf-97e7e06302e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1685676c-19be-4220-993f-494c53f60499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1685676c-19be-4220-993f-494c53f60499.jpg?1",
             "name": "Jedit Ojanen of Efrava",
             "text": "Forestwalk\nWhenever Jedit Ojanen of Efrava attacks or blocks, put a 2/2 green Cat Warrior creature token with forestwalk into play.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "043563fd-5411-5a0d-a93a-7f23a3f1484e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965048e6-a693-4858-a244-3b9ee10bfb56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965048e6-a693-4858-a244-3b9ee10bfb56.jpg?1",
             "name": "Kavu Predator",
             "text": "Trample\nWhenever an opponent gains life, put that many +1/+1 counters on Kavu Predator.",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "3b6fe62d-8ae7-538a-af7e-fe4b2c9a69a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe9e8e-7fb3-4a6d-be3d-7965d2ffb0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0efe9e8e-7fb3-4a6d-be3d-7965d2ffb0a3.jpg?1",
             "name": "Life and Limb",
             "text": "All Forests and all Saprolings are 1/1 green Saproling creatures and Forest lands in addition to their other types.",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "da8326dc-41d5-587b-8c73-142d4cdd0b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899db99b-df27-4848-a23d-5c645deae450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899db99b-df27-4848-a23d-5c645deae450.jpg?1",
             "name": "Magus of the Library",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Draw a card. Play this ability only if you have exactly seven cards in hand.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "c72a782f-a12f-5f42-bb90-4554b2bb6201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190dffdc-9d85-430d-9aea-b75084104840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190dffdc-9d85-430d-9aea-b75084104840.jpg?1",
             "name": "Mire Boa",
             "text": "Swampwalk\n{G}: Regenerate Mire Boa.",
             "colours": [
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "d90f9000-5662-506e-8460-41b457d7a6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e48a2f3-9c30-4187-868e-33dbf5e279fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e48a2f3-9c30-4187-868e-33dbf5e279fc.jpg?1",
             "name": "Pouncing Wurm",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you play this spell.)\nIf the kicker cost was paid, Pouncing Wurm comes into play with three +1/+1 counters on it and with haste.",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "87814e7f-7008-52b4-9d6c-27c9f55131b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2803fdc-2ae1-438c-b5b1-559817e85fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2803fdc-2ae1-438c-b5b1-559817e85fdb.jpg?1",
             "name": "Psychotrope Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Psychotrope Thallid.\nRemove three spore counters from Psychotrope Thallid: Put a 1/1 green Saproling creature token into play.\n{1}, Sacrifice a Saproling: Draw a card.",
             "colours": [
@@ -4733,7 +4733,7 @@
         },
         {
             "id": "1abff1a5-d66e-5968-bbcd-634d3db7664e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017d37d-f47d-405e-95d8-78a8eec8addc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9017d37d-f47d-405e-95d8-78a8eec8addc.jpg?1",
             "name": "Reflex Sliver",
             "text": "All Slivers have haste.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "3d054a4f-08e8-5d11-b1ec-b60f2815e1c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582cefca-6c11-4df3-8b54-46309dafff4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582cefca-6c11-4df3-8b54-46309dafff4a.jpg?1",
             "name": "Sophic Centaur",
             "text": "{2}{G}{G}, {T}, Discard a card: You gain 2 life for each card in your hand.",
             "colours": [
@@ -4802,7 +4802,7 @@
         },
         {
             "id": "9cd81cb2-d722-52c9-879e-35280ebcad56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d604bac-58b7-4479-8ab8-2e0680746e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d604bac-58b7-4479-8ab8-2e0680746e0e.jpg?1",
             "name": "Timbermare",
             "text": "Haste\nEcho {5}{G} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Timbermare comes into play, tap all other creatures.",
             "colours": [
@@ -4837,7 +4837,7 @@
         },
         {
             "id": "bd67655c-009b-5b6c-a5c1-27da0d1646cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3fcd5-0e84-4332-ac84-19b75265ab52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3fcd5-0e84-4332-ac84-19b75265ab52.jpg?1",
             "name": "Uktabi Drake",
             "text": "Flying, haste\nEcho {1}{G}{G} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -4871,7 +4871,7 @@
         },
         {
             "id": "1ab2b951-ca1a-5c87-a856-393ab601360f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f2ddb-3111-45a2-8334-a526bc885415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97f2ddb-3111-45a2-8334-a526bc885415.jpg?1",
             "name": "Utopia Vow",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -4905,7 +4905,7 @@
         },
         {
             "id": "34f0e239-1d65-5373-b9de-f8ed8975cad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad14bc9-b90e-48e0-9e72-173874dab6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad14bc9-b90e-48e0-9e72-173874dab6bc.jpg?1",
             "name": "Vitaspore Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Vitaspore Thallid.\nRemove three spore counters from Vitaspore Thallid: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Target creature gains haste until end of turn.",
             "colours": [
@@ -4939,7 +4939,7 @@
         },
         {
             "id": "4882c72a-15b8-5abf-9eea-1a08f07ace36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38385d7a-fff2-4fe4-90ae-b9c58ad3b1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38385d7a-fff2-4fe4-90ae-b9c58ad3b1f5.jpg?1",
             "name": "Wild Pair",
             "text": "Whenever a creature comes into play, if you played it from your hand, you may search your library for a creature card with the same total power and toughness and put it into play. If you do, shuffle your library.",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "5951324c-cfcf-57f8-b55e-578d5e474104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a65d6-0887-4fe8-a6e6-909208fddd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a65d6-0887-4fe8-a6e6-909208fddd90.jpg?1",
             "name": "Essence Warden",
             "text": "Whenever another creature comes into play, you gain 1 life.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "881e874a-c0cb-5930-9334-40e206183d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9985e8-535d-4815-8a58-a98c3edb68d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9985e8-535d-4815-8a58-a98c3edb68d4.jpg?1",
             "name": "Fa'adiyah Seer",
             "text": "{T}: Draw a card and reveal it. If it isn't a land card, discard it.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "f921b9e6-d10e-5890-af62-2eea6b4e6c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9e0de1-2299-4ff9-b49a-88535a96bda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea9e0de1-2299-4ff9-b49a-88535a96bda0.jpg?1",
             "name": "Gaea's Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "7c33bda6-7eb0-5cf7-8054-0c7d00d25b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f467cdea-6166-4289-918b-18f5038c94ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f467cdea-6166-4289-918b-18f5038c94ed.jpg?1",
             "name": "Groundbreaker",
             "text": "Trample, haste\nAt end of turn, sacrifice Groundbreaker.",
             "colours": [
@@ -5107,7 +5107,7 @@
         },
         {
             "id": "f869a2c8-d738-5935-b11f-205ae9bbff7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b90dbd0-4672-4c0b-92eb-262ddd11cd32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b90dbd0-4672-4c0b-92eb-262ddd11cd32.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "56c95a2f-0aba-595d-84c4-98379d0c9400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f58258-a1bd-4364-954e-c39938f7dab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f58258-a1bd-4364-954e-c39938f7dab2.jpg?1",
             "name": "Healing Leaves",
             "text": "Choose one Target player gains 3 life; or prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "1f9d53c3-d0ec-50e8-8105-10430fa64ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2e6027-598d-4ba0-93ae-f76d031de8af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b2e6027-598d-4ba0-93ae-f76d031de8af.jpg?1",
             "name": "Hedge Troll",
             "text": "Hedge Troll gets +1/+1 as long as you control a Plains.\n{W}: Regenerate Hedge Troll.",
             "colours": [
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "2ebc922c-0b8b-536f-a7ef-8fc42033a885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4197d992-f868-44dd-85f7-598b22e208f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4197d992-f868-44dd-85f7-598b22e208f3.jpg?1",
             "name": "Keen Sense",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "cff9b6b5-3347-58ef-be89-6c57900dd42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba91ee-1f8e-47db-bb2d-bbb62039db17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2ba91ee-1f8e-47db-bb2d-bbb62039db17.jpg?1",
             "name": "Seal of Primordium",
             "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
             "colours": [
@@ -5273,7 +5273,7 @@
         },
         {
             "id": "7903d26f-43ae-508e-9029-5ff202719029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91da31d4-6616-4d61-82b7-52954162fe4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91da31d4-6616-4d61-82b7-52954162fe4d.jpg?1",
             "name": "Cautery Sliver",
             "text": "All Slivers have \"{1}, Sacrifice this creature: This creature deals 1 damage to target creature or player.\"\nAll Slivers have \"{1}, Sacrifice this creature: Prevent the next 1 damage that would be dealt to target Sliver or player this turn.\"",
             "colours": [
@@ -5309,7 +5309,7 @@
         },
         {
             "id": "3934308c-936d-5afd-8201-881c4ab94319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541ff31-0043-49a9-abac-77369f95b942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541ff31-0043-49a9-abac-77369f95b942.jpg?1",
             "name": "Darkheart Sliver",
             "text": "All Slivers have \"Sacrifice this creature: You gain 3 life.\"",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "234dee1a-6e68-5298-9dc8-1019c5c979f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b549e959-aa43-4ccc-8c45-ea357c25fb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b549e959-aa43-4ccc-8c45-ea357c25fb8c.jpg?1",
             "name": "Dormant Sliver",
             "text": "All Slivers have defender and \"When this creature comes into play, draw a card.\"",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "6b9fbb4e-7f19-5015-a833-1aa8d9f6e9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b1d87-ff9d-4511-a196-b8ae8b5b5e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/424b1d87-ff9d-4511-a196-b8ae8b5b5e1d.jpg?1",
             "name": "Frenetic Sliver",
             "text": "All Slivers have \"{0}: If this creature is in play, flip a coin. If you win the flip, remove this creature from the game and return it to play under its owner's control at end of turn. If you lose the flip, sacrifice it.\"",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "7c03c2f8-c869-578a-b651-518dbc8b5cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394e4fe9-2bb0-4a5c-bf10-b72b519d5226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394e4fe9-2bb0-4a5c-bf10-b72b519d5226.jpg?1",
             "name": "Intet, the Dreamer",
             "text": "Flying\nWhenever Intet, the Dreamer deals combat damage to a player, you may pay {2}{U}. If you do, remove the top card of your library from the game face down. You may look at that card as long as it remains removed from the game. You may play that card without paying its mana cost as long as Intet remains in play.",
             "colours": [
@@ -5457,7 +5457,7 @@
         },
         {
             "id": "9223603e-0bfa-5885-a2d4-05bd537e68e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e18843-06b4-480c-9291-c502542f72b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e18843-06b4-480c-9291-c502542f72b1.jpg?1",
             "name": "Necrotic Sliver",
             "text": "All Slivers have \"{3}, Sacrifice this creature: Destroy target permanent.\"",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "bc2e9b64-68a3-5d9a-8703-49623bbe708e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bf777a-a232-4504-afbb-13d2f79b4355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1bf777a-a232-4504-afbb-13d2f79b4355.jpg?1",
             "name": "Numot, the Devastator",
             "text": "Flying\nWhenever Numot, the Devastator deals combat damage to a player, you may pay {2}{R}. If you do, destroy up to two target lands.",
             "colours": [
@@ -5533,7 +5533,7 @@
         },
         {
             "id": "ce65a12a-e121-50a6-81d9-450b6777736e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2790685-f6ae-4106-ae4d-fe97954bcb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2790685-f6ae-4106-ae4d-fe97954bcb82.jpg?1",
             "name": "Oros, the Avenger",
             "text": "Flying\nWhenever Oros, the Avenger deals combat damage to a player, you may pay {2}{W}. If you do, Oros deals 3 damage to each nonwhite creature.",
             "colours": [
@@ -5573,7 +5573,7 @@
         },
         {
             "id": "d3fcb530-c8ca-5775-b4a5-c44de5eba360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc23b2e-9124-4f88-b93e-8bfe90e6eb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc23b2e-9124-4f88-b93e-8bfe90e6eb41.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R} to your mana pool.\n{T}: Add {G} to your mana pool.",
             "colours": [
@@ -5612,7 +5612,7 @@
         },
         {
             "id": "a9046c00-7af7-5022-8059-e3ba072fa4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c1b26c-97f0-4e7e-8744-8497a83a11ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c1b26c-97f0-4e7e-8744-8497a83a11ab.jpg?1",
             "name": "Teneb, the Harvester",
             "text": "Flying\nWhenever Teneb, the Harvester deals combat damage to a player, you may pay {2}{B}. If you do, put target creature card in a graveyard into play under your control.",
             "colours": [
@@ -5652,7 +5652,7 @@
         },
         {
             "id": "009231ae-6d65-5eb3-b786-25ee2dad051c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4438fe-b11b-4adb-b8dd-b44e12ef6124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4438fe-b11b-4adb-b8dd-b44e12ef6124.jpg?1",
             "name": "Vorosh, the Hunter",
             "text": "Flying\nWhenever Vorosh, the Hunter deals combat damage to a player, you may pay {2}{G}. If you do, put six +1/+1 counters on Vorosh.",
             "colours": [
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "c4390b5b-13ff-55a0-bb62-898d7c758d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e1224f-82cb-4f41-8739-f880cba61bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e1224f-82cb-4f41-8739-f880cba61bbb.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/PLS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/PLS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "8ce57c19-2905-5bf7-827b-53fe450ff2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f5ad6-e10e-49b3-8643-51a4e792517c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f5ad6-e10e-49b3-8643-51a4e792517c.jpg?1",
             "name": "Aura Blast",
             "text": "Destroy target enchantment.\nDraw a card.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "9e4f4460-ff0a-581a-8570-639b89fd6896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6c695-1944-4bb0-a701-0daf47cdbcb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfd6c695-1944-4bb0-a701-0daf47cdbcb4.jpg?1",
             "name": "Aurora Griffin",
             "text": "Flying\no\nW: Target permanent becomes white until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "e9cb3842-250d-500f-af38-97e21e28b822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e268fe16-070b-4b78-9793-59755edb2fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e268fe16-070b-4b78-9793-59755edb2fd5.jpg?1",
             "name": "Disciple of Kangee",
             "text": "o\nU, oc\nT: Target creature gains flying and becomes blue until end of turn.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "0959cb88-17ca-5937-8ffa-e043c0226c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9703d090-b415-48e2-8158-dd8fc57ecc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9703d090-b415-48e2-8158-dd8fc57ecc50.jpg?1",
             "name": "Dominaria's Judgment",
             "text": "Until end of turn, creatures you control gain protection from white if you control a plains, from blue if you control an island, from black if you control a swamp, from red if you control a mountain, and from green if you control a forest.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "87e89326-a262-587b-9b70-6be118e8583c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32eee7-10ba-4f0b-8a87-c3ecfa22ae41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32eee7-10ba-4f0b-8a87-c3ecfa22ae41.jpg?1",
             "name": "Guard Dogs",
             "text": "o2o\nW, oc\nT: Choose a permanent you control. Prevent all combat damage target creature would deal this turn if it shares a color with that permanent.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "d98c1260-dc4f-5379-b0ff-4100f5cf5521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc1aa36-5d3b-4d25-9d54-937cdabf72a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc1aa36-5d3b-4d25-9d54-937cdabf72a4.jpg?1",
             "name": "Heroic Defiance",
             "text": "Enchanted creature gets +3/+3 unless it shares a color with the most common color among all permanents or a color tied for most common.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "a6838491-11c1-5915-a77d-37701d7ec8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c76a22-f9e3-408b-a5bd-403add57e31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c76a22-f9e3-408b-a5bd-403add57e31a.jpg?1",
             "name": "Hobble",
             "text": "When Hobble comes into play, draw a card.\nEnchanted creature can't attack.\nEnchanted creature can't block if it's black.",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "af68d99d-ad07-55d4-8ba6-0637f2b736f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd311758-0352-4b7d-a24f-7f3f2b5d7b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd311758-0352-4b7d-a24f-7f3f2b5d7b0f.jpg?1",
             "name": "Honorable Scout",
             "text": "When Honorable Scout comes into play, you gain 2 life for each black and/or red creature target opponent controls.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "85b61b06-68c8-53a2-ac4d-6daa8ccafc51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2485c10d-de02-4be9-8119-afb2296e3317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2485c10d-de02-4be9-8119-afb2296e3317.jpg?1",
             "name": "Lashknife Barrier",
             "text": "When Lashknife Barrier comes into play, draw a card.\nIf a source would deal damage to a creature you control, it deals that much damage minus 1 to that creature instead.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "be92b3c7-774b-5d77-9498-c83e183accd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07dd0f1-b80b-4af0-ae76-907ec55ec7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07dd0f1-b80b-4af0-ae76-907ec55ec7d5.jpg?1",
             "name": "March of Souls",
             "text": "Destroy all creatures. They can't be regenerated. For each creature destroyed this way, its controller puts a 1/1 white Spirit creature token with flying into play.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "6e9b8491-7120-5d14-bb9f-3094b57512b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055afa78-b969-498f-a3ad-c792426e5ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/055afa78-b969-498f-a3ad-c792426e5ee6.jpg?1",
             "name": "Orim's Chant",
             "text": "Kicker o\nW (You may pay an additional o\nW as you play this spell.)\nTarget player can't play spells this turn.\nIf you paid the kicker cost, creatures can't attack this turn.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "0c904aec-dd4d-52ca-83e9-0cd24f2da68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0205d094-c846-4aa0-ade8-2a52c57b11da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0205d094-c846-4aa0-ade8-2a52c57b11da.jpg?1",
             "name": "Planeswalker's Mirth",
             "text": "o3o\nW: Target opponent reveals a card at random from his or her hand. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "3b6f5982-ef4a-545b-9cd6-9258d7d5d0d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c813-0cda-44ad-ae41-330e9bde9cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9797c813-0cda-44ad-ae41-330e9bde9cb9.jpg?1",
             "name": "Pollen Remedy",
             "text": "Kicker\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs as you play this spell.)\nPrevent the next 3 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose. If you paid the kicker cost, prevent the next 6 damage this way instead.",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "e957e5e0-af17-50ac-80a7-7e111b48cd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c5dccc-2a48-4dcc-a796-fa6fdc11a14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c5dccc-2a48-4dcc-a796-fa6fdc11a14e.jpg?1",
             "name": "Samite Elder",
             "text": "oc\nT: Creatures you control gain protection from the color(s) of target permanent you control until end of turn.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "0b58190d-e889-5005-8b62-5d324531ac29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12529e4-f4b1-45be-8252-28783badbec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12529e4-f4b1-45be-8252-28783badbec5.jpg?1",
             "name": "Samite Pilgrim",
             "text": "oc\nT: Prevent the next X damage that would be dealt to target creature this turn, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "7945e1a8-b60e-5e86-833d-c9a0cc025fbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e590f-0a4a-4ad0-b8ef-d3a18edadc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85e590f-0a4a-4ad0-b8ef-d3a18edadc05.jpg?1",
             "name": "Sunscape Battlemage",
             "text": "Kicker o1o\nG and/or o2o\nU\nWhen Sunscape Battlemage comes into play, if you paid the o1o\nG kicker cost, destroy target creature with flying.\nWhen Sunscape Battlemage comes into play, if you paid the o2o\nU kicker cost, draw two cards.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "4314b8d5-c006-5a68-b5b1-55f5875c0135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621f341-bf85-4b77-bf19-2fb013b4c955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9621f341-bf85-4b77-bf19-2fb013b4c955.jpg?1",
             "name": "Sunscape Familiar",
             "text": "(Walls can't attack.)\nGreen spells and blue spells you play cost o1 less to play.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "6c8009e7-3cde-5d0e-a3b9-e37f8887b030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26148b-b981-4af5-995b-52b1426737e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a26148b-b981-4af5-995b-52b1426737e3.jpg?1",
             "name": "Surprise Deployment",
             "text": "Play Surprise Deployment only during combat.\nPut a nonwhite creature card from your hand into play. At end of turn, return that creature to your hand. (Return it only if it's in play.)",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "1f811e0c-5a19-50f6-bb16-69818397d944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f37536-db3d-4726-9e45-b9108247d0e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f37536-db3d-4726-9e45-b9108247d0e6.jpg?1",
             "name": "Voice of All",
             "text": "Flying\nAs Voice of All comes into play, choose a color.\nVoice of All has protection from the chosen color.",
             "colours": [
@@ -643,7 +643,7 @@
         },
         {
             "id": "3baab717-273c-5a1b-ae27-9dd1daecbe0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4f211-10e8-486d-b982-287ab0c060c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d4f211-10e8-486d-b982-287ab0c060c9.jpg?1",
             "name": "Allied Strategies",
             "text": "Target player draws a card for each basic land type among lands he or she controls.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "30e73f2c-fd65-50c6-a32e-39b7339f53e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86369fe5-d86d-4f4c-8f3d-dedc174f2032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86369fe5-d86d-4f4c-8f3d-dedc174f2032.jpg?1",
             "name": "Arctic Merfolk",
             "text": "Kicker\u2014\nReturn a creature you control to its owner's hand. (You may return a creature you control to its owner's hand in addition to any other costs as you play this spell.)\nIf you paid the kicker cost, Arctic Merfolk comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -709,7 +709,7 @@
         },
         {
             "id": "3f49a8e7-6f04-5559-9931-959e069223f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b7d39-ce98-48e2-b2bf-0d55b4d3102b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3b7d39-ce98-48e2-b2bf-0d55b4d3102b.jpg?1",
             "name": "Confound",
             "text": "Counter target spell that targets one or more creatures.\nDraw a card.",
             "colours": [
@@ -741,7 +741,7 @@
         },
         {
             "id": "973fc21e-18b7-5827-94b4-1d41ba814823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f4daf-7b54-4425-a93a-19532dfb83ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f4daf-7b54-4425-a93a-19532dfb83ca.jpg?1",
             "name": "Dralnu's Pet",
             "text": "Kicker\u2014o2o\nB, Discard a creature card from your hand. (You may pay o2o\nB and discard a creature card from your hand in addition to any other costs as you play this spell.)\nIf you paid the kicker cost, Dralnu's Pet has flying and comes into play with X +1/+1 counters on it, where X is the discarded card's converted mana cost.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "0973d41e-72d5-5a4a-b967-7d18852ebaeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544e3575-9fb6-41f7-a4e6-f8460dfae344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544e3575-9fb6-41f7-a4e6-f8460dfae344.jpg?1",
             "name": "Ertai's Trickery",
             "text": "Counter target spell if a kicker cost was paid for it.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "9455e0b3-015f-5e77-9ab8-67302037ca02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc9062e-ddd9-41ac-a88a-33f5a7b22103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc9062e-ddd9-41ac-a88a-33f5a7b22103.jpg?1",
             "name": "Escape Routes",
             "text": "o2o\nU: Return target white or black creature you control to its owner's hand.",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "6dc19cc5-2c4f-5d64-a16d-18813d2bb5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70a2092-5048-49c0-9351-a3f882c2f56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70a2092-5048-49c0-9351-a3f882c2f56e.jpg?1",
             "name": "Gainsay",
             "text": "Counter target blue spell.",
             "colours": [
@@ -872,7 +872,7 @@
         },
         {
             "id": "8d0ad1ba-5cdd-53a6-b79d-4b82e9553169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0293a9-48fe-4018-bd25-3e02c227a3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0293a9-48fe-4018-bd25-3e02c227a3dd.jpg?1",
             "name": "Hunting Drake",
             "text": "Flying\nWhen Hunting Drake comes into play, put target red or green creature on top of its owner's library.",
             "colours": [
@@ -906,7 +906,7 @@
         },
         {
             "id": "942a7fc4-2d8f-58b0-b83f-8de1c50f051d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1315fef0-234e-44f5-a7a3-bf3db78943c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1315fef0-234e-44f5-a7a3-bf3db78943c3.jpg?1",
             "name": "Planar Overlay",
             "text": "Each player chooses a land he or she controls of each basic land type. Return those lands to their owners' hands.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "60707b67-c552-5e51-a569-7e64a04761ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa232c-3f16-4c68-99dc-09a7aeef477b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79aa232c-3f16-4c68-99dc-09a7aeef477b.jpg?1",
             "name": "Planeswalker's Mischief",
             "text": "o3o\nU: Target opponent reveals a card at random from his or her hand. If it's an instant or sorcery card, remove it from the game. As long as it remains removed from the game, you may play it as though it were in your hand without paying its mana cost. If it has X in its mana cost, X is 0. At end of turn, if you haven't played it, return it to its owner's hand. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -970,7 +970,7 @@
         },
         {
             "id": "1d433d60-e483-5b00-ac00-5edb4a686621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ddf7bf-de9c-4657-8d5b-79869d36fa63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ddf7bf-de9c-4657-8d5b-79869d36fa63.jpg?1",
             "name": "Rushing River",
             "text": "Kicker\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs as you play this spell.)\nReturn target nonland permanent to its owner's hand. If you paid the kicker cost, return another target nonland permanent to its owner's hand.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "afbd07ea-0623-54e6-84fc-3236e80a027d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11015e-200b-488c-8bf5-662dcc03cd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11015e-200b-488c-8bf5-662dcc03cd2d.jpg?1",
             "name": "Sea Snidd",
             "text": "oc\nT: Target land's type becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "cc2388d2-3a96-5720-9b78-9996749d902d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071726d-48f0-46d6-802b-dd9589489580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1071726d-48f0-46d6-802b-dd9589489580.jpg?1",
             "name": "Shifting Sky",
             "text": "As Shifting Sky comes into play, choose a color.\nAll nonland permanents are the chosen color.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "10e92b09-ebc4-5d20-a7bf-0477cfc5dbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe20cc1-621a-4813-9bbb-ace006e173ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe20cc1-621a-4813-9bbb-ace006e173ff.jpg?1",
             "name": "Sisay's Ingenuity",
             "text": "When Sisay's Ingenuity comes into play, draw a card.\nEnchanted creature has \"o2o\nU: Target creature becomes the color of your choice until end of turn.\"",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "080a47d1-e3c6-5bd8-888a-cf4762deb6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f79f4b2-71cd-4f78-a161-d75b162c745e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f79f4b2-71cd-4f78-a161-d75b162c745e.jpg?1",
             "name": "Sleeping Potion",
             "text": "When Sleeping Potion comes into play, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhen enchanted creature becomes the target of a spell or ability, sacrifice Sleeping Potion.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "beeb6bcf-223b-5d41-aa42-b0cfe20503bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46a39d-c6f4-4281-b31f-f0a0c9fba887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46a39d-c6f4-4281-b31f-f0a0c9fba887.jpg?1",
             "name": "Stormscape Battlemage",
             "text": "Kicker o\nW and/or o2o\nB\nWhen Stormscape Battlemage comes into play, if you paid the o\nW kicker cost, you gain 3 life.\nWhen Stormscape Battlemage comes into play, if you paid the o2o\nB kicker cost, destroy target nonblack creature. That creature can't be regenerated.",
             "colours": [
@@ -1173,7 +1173,7 @@
         },
         {
             "id": "4d783b25-5b95-53f9-b11f-459536142400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c831c42-77a0-4f4f-9628-ad630541cf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c831c42-77a0-4f4f-9628-ad630541cf66.jpg?1",
             "name": "Stormscape Familiar",
             "text": "Flying\nWhite spells and black spells you play cost {1} less to play.",
             "colours": [
@@ -1207,7 +1207,7 @@
         },
         {
             "id": "75dc6a8b-7726-5d43-9516-f35da01ae75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12ac0c-cfe6-4f08-b6df-20be4ce83e8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f12ac0c-cfe6-4f08-b6df-20be4ce83e8c.jpg?1",
             "name": "Sunken Hope",
             "text": "At the beginning of each player's upkeep, that player returns a creature he or she controls to its owner's hand.",
             "colours": [
@@ -1239,7 +1239,7 @@
         },
         {
             "id": "0d2d7d77-1c66-5684-80ed-4fc867c77930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425156e6-8eee-4bff-8f2f-86edd9a4f73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425156e6-8eee-4bff-8f2f-86edd9a4f73b.jpg?1",
             "name": "Waterspout Elemental",
             "text": "Kicker o\nU (You may pay an additional o\nU as you play this spell.)\nFlying\nWhen Waterspout Elemental comes into play, if you paid the kicker cost, return all other creatures to their owners' hands and you skip your next turn.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "87515dd9-3574-555b-8707-cec4b845ab4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8752a605-38f8-4d75-b122-063a788dff6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8752a605-38f8-4d75-b122-063a788dff6e.jpg?1",
             "name": "Bog Down",
             "text": "Kicker\u2014\nSacrifice two lands. (You may sacrifice two lands in addition to any other costs as you play this spell.)\nTarget player discards two cards from his or her hand. If you paid the kicker cost, that player discards three cards from his or her hand instead.",
             "colours": [
@@ -1305,7 +1305,7 @@
         },
         {
             "id": "65dfc8a7-27bd-58fc-93cb-c95209d2aaf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518e2fd-7767-43d7-92e3-62a4a465154c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d518e2fd-7767-43d7-92e3-62a4a465154c.jpg?1",
             "name": "Dark Suspicions",
             "text": "At the beginning of each opponent's upkeep, that player loses 1 life for each card in his or her hand more than you have in your hand.",
             "colours": [
@@ -1337,7 +1337,7 @@
         },
         {
             "id": "c5681401-b898-5287-808d-2d451e245c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a84715-c5dc-4a19-af6a-796c6ee912c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a84715-c5dc-4a19-af6a-796c6ee912c2.jpg?1",
             "name": "Death Bomb",
             "text": "As an additional cost to play Death Bomb, sacrifice a creature.\nDestroy target nonblack creature. It can't be regenerated. Its controller loses 2 life.",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "dbc1f65a-6a48-5f9f-a63d-9af50294a31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d1b5c5-cc47-465f-8549-4fd1ca4280df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d1b5c5-cc47-465f-8549-4fd1ca4280df.jpg?1",
             "name": "Diabolic Intent",
             "text": "As an additional cost to play Diabolic Intent, sacrifice a creature.\nSearch your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "56ef52f1-cc45-55ec-83d5-3fc41db0ed25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9624e5-79a2-41de-997b-12d871d4be66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9624e5-79a2-41de-997b-12d871d4be66.jpg?1",
             "name": "Exotic Disease",
             "text": "Target player loses X life and you gain X life, where X is the number of basic land types among lands you control.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "6e76db16-0bc2-527d-b0a9-98b94fa43c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7f50f4-37a0-476e-8655-edba228aafd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7f50f4-37a0-476e-8655-edba228aafd6.jpg?1",
             "name": "Lord of the Undead",
             "text": "All Zombies get +1/+1.\no1o\nB, oc\nT: Return target Zombie card from your graveyard to your hand.",
             "colours": [
@@ -1467,7 +1467,7 @@
         },
         {
             "id": "5b1d5e02-6af1-5ccb-8163-c9ab9b32c0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2c3dc4-bb49-4ec3-a6c8-4256d1939326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2c3dc4-bb49-4ec3-a6c8-4256d1939326.jpg?1",
             "name": "Maggot Carrier",
             "text": "When Maggot Carrier comes into play, each player loses 1 life.",
             "colours": [
@@ -1501,7 +1501,7 @@
         },
         {
             "id": "bc259785-df34-5342-acd5-bebe2d1d78d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8ae73-70d1-4082-8581-5f74c1aaa63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d8ae73-70d1-4082-8581-5f74c1aaa63b.jpg?1",
             "name": "Morgue Toad",
             "text": "Sacrifice Morgue Toad: Add o\nUo\nR to your mana pool.",
             "colours": [
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "cdba7571-bb85-5a42-a76d-d70a93d96a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5389643-4cc0-4a17-bc2d-7f9b76d30f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5389643-4cc0-4a17-bc2d-7f9b76d30f9f.jpg?1",
             "name": "Nightscape Battlemage",
             "text": "Kicker o2o\nU and/or o2o\nR\nWhen Nightscape Battlemage comes into play, if you paid the o2o\nU kicker cost, return up to two target nonblack creatures to their owners' hands.\nWhen Nightscape Battlemage comes into play, if you paid the o2o\nR kicker cost, destroy target land.",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "27900460-ae79-5b11-bdff-9926cfbbb643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fa6853-09b0-4c9f-a138-9dd005780255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24fa6853-09b0-4c9f-a138-9dd005780255.jpg?1",
             "name": "Nightscape Familiar",
             "text": "Blue spells and red spells you play cost o1 less to play.\no1o\nB: Regenerate Nightscape Familiar.",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "088278b7-b10e-5234-86fa-1931f223b671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9326-6e1c-4a05-abea-16d6b6cb2a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9326-6e1c-4a05-abea-16d6b6cb2a6d.jpg?1",
             "name": "Noxious Vapors",
             "text": "Each player reveals his or her hand and chooses one card of each color from it, then discards all other nonland cards from it.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "d841c9c2-1279-516e-96d2-00e542dd9795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e1a67-af94-48e8-bb37-4999d1fb4c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e1a67-af94-48e8-bb37-4999d1fb4c66.jpg?1",
             "name": "Phyrexian Bloodstock",
             "text": "When Phyrexian Bloodstock leaves play, destroy target white creature. It can't be regenerated.",
             "colours": [
@@ -1675,7 +1675,7 @@
         },
         {
             "id": "b2bde8b6-9509-5a37-8bd1-f306d24acbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb57e656-c94e-4cc2-ae8d-9300f51f941f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb57e656-c94e-4cc2-ae8d-9300f51f941f.jpg?1",
             "name": "Phyrexian Scuta",
             "text": "Kicker\u2014\nPay 3 life. (You may pay 3 life in addition to any other costs as you play this spell.)\nIf you paid the kicker cost, Phyrexian Scuta comes into play with two +1/+1 counters on it.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "3e86b5c5-6ce7-5032-8bfa-c083c3c71f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed08376-836f-4313-83d0-481895ead9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed08376-836f-4313-83d0-481895ead9da.jpg?1",
             "name": "Planeswalker's Scorn",
             "text": "o3o\nB: Target opponent reveals a card at random from his or her hand. Target creature gets -X/-X until end of turn, where X is the revealed card's converted mana cost. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "097a4ad2-5210-5ed8-8063-499925351573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a7fb3b-8e81-4763-b2a1-7c2108a00afe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a7fb3b-8e81-4763-b2a1-7c2108a00afe.jpg?1",
             "name": "Shriek of Dread",
             "text": "Target creature can't be blocked this turn except by artifact creatures and/or black creatures.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "0c54c78a-dfc3-50b7-b4e9-3458e43c1d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe487b8-c1ae-483d-bcd5-62c62b66a22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe487b8-c1ae-483d-bcd5-62c62b66a22e.jpg?1",
             "name": "Sinister Strength",
             "text": "Enchanted creature gets +3/+1 and is black.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "139f4f43-a39b-5d3a-b76b-b4c9b5f8e094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccda747-2680-4793-8a13-35e49b4de12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eccda747-2680-4793-8a13-35e49b4de12f.jpg?1",
             "name": "Slay",
             "text": "Destroy target green creature. It can't be regenerated.\nDraw a card.",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "fa25ffd2-6dbe-5803-afb4-491765d39805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8281cc6-2132-4f76-841e-d1ade9cafb84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8281cc6-2132-4f76-841e-d1ade9cafb84.jpg?1",
             "name": "Volcano Imp",
             "text": "Flying\no1o\nR: Volcano Imp gains first strike until end of turn.",
             "colours": [
@@ -1875,7 +1875,7 @@
         },
         {
             "id": "95561d09-fa4a-552b-a52e-3a95ccba6923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bce620f-799a-4ad8-9edb-6fb3d9ea1cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bce620f-799a-4ad8-9edb-6fb3d9ea1cc6.jpg?1",
             "name": "Warped Devotion",
             "text": "Whenever a permanent is returned to a player's hand, that player discards a card from his or her hand.",
             "colours": [
@@ -1907,7 +1907,7 @@
         },
         {
             "id": "97c7174f-9fa0-5cdd-9c21-824b4f1c7bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcad32aa-2ce1-402d-a9d8-ad5c81fe4c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcad32aa-2ce1-402d-a9d8-ad5c81fe4c5b.jpg?1",
             "name": "Caldera Kavu",
             "text": "o1o\nB: Caldera Kavu gets +1/+1 until end of turn.\no\nG: Caldera Kavu becomes the color of your choice until end of turn.",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "816a6f1e-c6f5-582e-858d-8217df08063b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc93b3d-bde4-422f-9edc-e337719be7b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc93b3d-bde4-422f-9edc-e337719be7b4.jpg?1",
             "name": "Deadapult",
             "text": "o\nR, Sacrifice a Zombie: Deadapult deals 2 damage to target creature or player.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "c506bf42-ac04-5b39-a8b8-3b1bfaca00f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5056bca-bd90-4b50-8630-105558f8ef92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5056bca-bd90-4b50-8630-105558f8ef92.jpg?1",
             "name": "Flametongue Kavu",
             "text": "When Flametongue Kavu comes into play, it deals 4 damage to target creature.",
             "colours": [
@@ -2009,7 +2009,7 @@
         },
         {
             "id": "6cdf8e34-ae2a-53b3-8692-b3f19cfba2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe6e7e5-ffea-4c6c-8a42-28e695029f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe6e7e5-ffea-4c6c-8a42-28e695029f24.jpg?1",
             "name": "Goblin Game",
             "text": "Each player hides at least one object, then all players reveal them simultaneously. Each player loses life equal to the number of objects he or she revealed. The player who revealed the fewest objects then loses half his or her life, rounded up. If two or more players are tied for fewest, each loses half his or her life, rounded up.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "eefd3b77-e95f-5f6f-8a63-fe6d38bc3292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ee318-8126-4ebf-884d-8369ae8726ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ee318-8126-4ebf-884d-8369ae8726ac.jpg?1",
             "name": "Implode",
             "text": "Destroy target land.\nDraw a card.",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "a0136e48-0c39-54e6-b647-bb84eccc68e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8009a37-f966-4a71-9a2a-469127758dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8009a37-f966-4a71-9a2a-469127758dc6.jpg?1",
             "name": "Insolence",
             "text": "Whenever enchanted creature becomes tapped, Insolence deals 2 damage to that creature's controller.",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "f50aa24c-7659-5f01-b8c4-cafe3d1ef17c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f04ac02-3eff-4a66-8320-ee7b4357522f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f04ac02-3eff-4a66-8320-ee7b4357522f.jpg?1",
             "name": "Kavu Recluse",
             "text": "oc\nT: Target land becomes a forest until end of turn.",
             "colours": [
@@ -2141,7 +2141,7 @@
         },
         {
             "id": "0c7395e8-38b2-5c6d-a5ef-bf0ba485811e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bb73df-f488-468c-a9ad-72f52c8da3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bb73df-f488-468c-a9ad-72f52c8da3dc.jpg?1",
             "name": "Keldon Mantle",
             "text": "o\nB: Regenerate enchanted creature.\no\nR: Enchanted creature gets +1/+0 until end of turn.\no\nG: Enchanted creature gains trample until end of turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "f5ce237d-54ce-5fc6-a800-4a216fc1d66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9752bc3-0bdf-4657-8750-73c8cbc8e83f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9752bc3-0bdf-4657-8750-73c8cbc8e83f.jpg?1",
             "name": "Magma Burst",
             "text": "Kicker\u2014\nSacrifice two lands. (You may sacrifice two lands in addition to any other costs as you play this spell.)\nMagma Burst deals 3 damage to target creature or player. If you paid the kicker cost, Magma Burst deals 3 damage to another target creature or player.",
             "colours": [
@@ -2209,7 +2209,7 @@
         },
         {
             "id": "0010f07c-a2e4-5ca5-b91a-fbc5f0380d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd0086-eb27-48b3-91cb-a113aa1de102.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdd0086-eb27-48b3-91cb-a113aa1de102.jpg?1",
             "name": "Mire Kavu",
             "text": "Mire Kavu gets +1/+1 as long as you control a swamp.",
             "colours": [
@@ -2243,7 +2243,7 @@
         },
         {
             "id": "e57027a5-68e8-5596-b8fc-57f04ba91dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52513235-0e6c-40ea-8ead-a050e6da676e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52513235-0e6c-40ea-8ead-a050e6da676e.jpg?1",
             "name": "Mogg Jailer",
             "text": "Mogg Jailer can't attack if defending player controls an untapped creature with power 2 or less.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "05b0a4a4-e65a-5edc-a22d-a4ad3b631912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536ec54-cebd-4d44-8e52-42344a3e6daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/8536ec54-cebd-4d44-8e52-42344a3e6daa.jpg?1",
             "name": "Mogg Sentry",
             "text": "Whenever an opponent plays a spell, Mogg Sentry gets +2/+2 until end of turn.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "b9edaf0c-2727-5ad1-b820-4f3861c2388e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa09e3a-bc7e-4292-aa5d-ce97c1b1f79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa09e3a-bc7e-4292-aa5d-ce97c1b1f79f.jpg?1",
             "name": "Planeswalker's Fury",
             "text": "o3o\nR: Target opponent reveals a card at random from his or her hand. Planeswalker's Fury deals damage equal to that card's converted mana cost to that player. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "a75db63b-3c0a-55b9-9bd2-93cc03113ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32323277-db9a-48a7-b9a4-8e6914386e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32323277-db9a-48a7-b9a4-8e6914386e26.jpg?1",
             "name": "Singe",
             "text": "Singe deals 1 damage to target creature. That creature becomes black until end of turn.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "eeb43bcf-421b-528b-bf41-936d8de53ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81825aef-bef7-46b7-bf52-29e32c1836b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81825aef-bef7-46b7-bf52-29e32c1836b0.jpg?1",
             "name": "Slingshot Goblin",
             "text": "o\nR, oc\nT: Slingshot Goblin deals 2 damage to target blue creature.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "eef8286d-a535-53fb-bfde-8dc49d6b8815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b77cf-9c1e-4c8f-b452-295cc1570d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec8b77cf-9c1e-4c8f-b452-295cc1570d0e.jpg?1",
             "name": "Strafe",
             "text": "Strafe deals 3 damage to target nonred creature.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "f6f5fae0-0fc2-5289-be7e-9093215892db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1778f37-af01-4f8c-ab9d-a4c60abf7e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1778f37-af01-4f8c-ab9d-a4c60abf7e78.jpg?1",
             "name": "Tahngarth, Talruum Hero",
             "text": "Attacking doesn't cause Tahngarth, Talruum Hero to tap.\no1o\nR, oc\nT: Tahngarth deals damage equal to its power to target creature. That creature deals damage equal to its power to Tahngarth.",
             "colours": [
@@ -2481,7 +2481,7 @@
         },
         {
             "id": "2e8d1ebb-db0b-5976-a936-f83fba5cd95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdab0f9-7208-4555-b509-e61773ebc1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cdab0f9-7208-4555-b509-e61773ebc1f9.jpg?1",
             "name": "Tahngarth, Talruum Hero",
             "text": "Attacking doesn't cause Tahngarth, Talruum Hero to tap.\no1o\nR, oc\nT: Tahngarth deals damage equal to its power to target creature. That creature deals damage equal to its power to Tahngarth.",
             "colours": [
@@ -2519,7 +2519,7 @@
         },
         {
             "id": "19b02e4d-3584-563e-8e28-1abc74f86a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707243e-7f11-44bc-b8b8-af635ab1dc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707243e-7f11-44bc-b8b8-af635ab1dc87.jpg?1",
             "name": "Thunderscape Battlemage",
             "text": "Kicker o1o\nB and/or o\nG\nWhen Thunderscape Battlemage comes into play, if you paid the o1o\nB kicker cost, target player discards two cards from his or her hand.\nWhen Thunderscape Battlemage comes into play, if you paid the o\nG kicker cost, destroy target enchantment.",
             "colours": [
@@ -2556,7 +2556,7 @@
         },
         {
             "id": "06e9a08c-f135-5f53-bdc3-e427f855db24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c9c0aa-9412-4320-aaee-e05369b8bc7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c9c0aa-9412-4320-aaee-e05369b8bc7b.jpg?1",
             "name": "Thunderscape Familiar",
             "text": "First strike\nBlack spells and green spells you play cost o1 less to play.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "b61822ce-c549-553c-9207-f2955c302606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545ed916-59fc-4c60-9260-8c2dc88e67a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/545ed916-59fc-4c60-9260-8c2dc88e67a1.jpg?1",
             "name": "Alpha Kavu",
             "text": "o1o\nG: Target Kavu gets -1/+1 until end of turn.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "9bb04c0f-43cb-5cd3-97be-b8525aeb4016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d94fb2-958c-487e-9f64-52d2771c6ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d94fb2-958c-487e-9f64-52d2771c6ea4.jpg?1",
             "name": "Amphibious Kavu",
             "text": "Whenever Amphibious Kavu blocks or becomes blocked by one or more blue and/or black creatures, Amphibious Kavu gets +3/+3 until end of turn.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "2f5e6386-32d8-5ee7-b6a5-00eb2daffd28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e54c84d-ccc9-4c52-b02c-e0392e8fe447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e54c84d-ccc9-4c52-b02c-e0392e8fe447.jpg?1",
             "name": "Falling Timber",
             "text": "Kicker\u2014\nSacrifice a land. (You may sacrifice a land in addition to any other costs as you play this spell.)\nPrevent all combat damage target creature would deal this turn. If you paid the kicker cost, prevent all combat damage another target creature would deal this turn.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "3e02adbb-5c6c-54c7-8540-bf81809ce9b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa52bc97-109a-4de5-b287-bce21dad6a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa52bc97-109a-4de5-b287-bce21dad6a9c.jpg?1",
             "name": "Gaea's Herald",
             "text": "Creature spells can't be countered by spells or abilities.",
             "colours": [
@@ -2724,7 +2724,7 @@
         },
         {
             "id": "d53c5091-657e-50d2-a78d-aa78867e9c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e5adce-7735-4fa5-aa14-8dce012e9fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e5adce-7735-4fa5-aa14-8dce012e9fcc.jpg?1",
             "name": "Gaea's Might",
             "text": "Target creature gets +1/+1 until end of turn for each basic land type among lands you control.",
             "colours": [
@@ -2756,7 +2756,7 @@
         },
         {
             "id": "de543f98-d170-55a7-a73a-01a38a90fdaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2869b-43cf-4d5e-8a54-9ae200f5bff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2869b-43cf-4d5e-8a54-9ae200f5bff9.jpg?1",
             "name": "Magnigoth Treefolk",
             "text": "For each basic land type among lands you control, Magnigoth Treefolk has landwalk of that type. (It's unblockable as long as defending player controls a land of that type.)",
             "colours": [
@@ -2790,7 +2790,7 @@
         },
         {
             "id": "ba9ac79f-53a3-5361-90e9-d71efdf21492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9a1c94-2b7f-4df7-8517-a122616d9ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba9a1c94-2b7f-4df7-8517-a122616d9ae4.jpg?1",
             "name": "Mirrorwood Treefolk",
             "text": "o2o\nRo\nW: The next time damage would be dealt to Mirrorwood Treefolk this turn, that damage is dealt to target creature or player instead.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "a4d1629c-8f0f-5bfd-a143-df60b51fb653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76352ea-e3d2-4221-8ebe-e953301c35ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76352ea-e3d2-4221-8ebe-e953301c35ab.jpg?1",
             "name": "Multani's Harmony",
             "text": "Enchanted creature has \"oc\nT: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "7c78533a-ce63-5dbd-a495-71d47ec384ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2.jpg?1",
             "name": "Nemata, Grove Guardian",
             "text": "o2o\nG: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: All Saprolings get +1/+1 until end of turn.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "81eac25f-c260-59e6-abc0-2ad001c00df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3387540-93bf-451e-8e7a-fc78caab42b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3387540-93bf-451e-8e7a-fc78caab42b0.jpg?1",
             "name": "Planeswalker's Favor",
             "text": "o3o\nG: Target opponent reveals a card at random from his or her hand. Target creature gets +X/+X until end of turn, where X is the revealed card's converted mana cost.",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "9da93f26-1af3-5eed-97fa-2b3e373c2ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4a3c83-faaa-4dd9-9349-abcaf09cc7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4a3c83-faaa-4dd9-9349-abcaf09cc7a8.jpg?1",
             "name": "Primal Growth",
             "text": "Kicker\u2014\nSacrifice a creature. (You may sacrifice a creature in addition to any other costs as you play this spell.)\nSearch your library for a basic land card, put that card into play, then shuffle your library. If you paid the kicker cost, instead search your library for two basic land cards, put them into play, then shuffle your library.",
             "colours": [
@@ -2960,7 +2960,7 @@
         },
         {
             "id": "e470925c-ac42-5eba-8833-e21b7aa3410d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31c69ec-feb5-430a-a3e9-3a6f3fb8ee1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31c69ec-feb5-430a-a3e9-3a6f3fb8ee1c.jpg?1",
             "name": "Pygmy Kavu",
             "text": "When Pygmy Kavu comes into play, draw a card for each black creature your opponents control.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "58a9d6b3-ed82-571b-a02f-cb1c66b81983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6841ae6-b15f-488e-9cae-2cc5ec668278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6841ae6-b15f-488e-9cae-2cc5ec668278.jpg?1",
             "name": "Quirion Dryad",
             "text": "Whenever you play a white, blue, black, or red spell, put a +1/+1 counter on Quirion Dryad.",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "3cb0b2a5-58b4-5ea2-a97c-6a6a22f6fecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a031d-f899-497b-adf7-4af142078085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a031d-f899-497b-adf7-4af142078085.jpg?1",
             "name": "Quirion Explorer",
             "text": "oc\nT: Add to your mana pool one mana of any color that a land an opponent controls could produce.",
             "colours": [
@@ -3064,7 +3064,7 @@
         },
         {
             "id": "70984f12-b185-5b7a-919c-197769fedb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306e3429-b3b4-4186-935b-18cfc308d22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306e3429-b3b4-4186-935b-18cfc308d22c.jpg?1",
             "name": "Root Greevil",
             "text": "o2o\nG, oc\nT, Sacrifice Root Greevil: Destroy all enchantments of the color of your choice.",
             "colours": [
@@ -3098,7 +3098,7 @@
         },
         {
             "id": "ed85869b-361a-5bbd-a3db-ebb44b6e0860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c10b16-97b1-4a36-b2b4-f0c28ead3eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c10b16-97b1-4a36-b2b4-f0c28ead3eb4.jpg?1",
             "name": "Skyshroud Blessing",
             "text": "Lands can't be the targets of spells or abilities this turn.\nDraw a card.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "eb5959c2-ed7d-517b-8758-1ad48fa7530f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a1cdca-d48c-4936-ad6a-4610aeb991ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a1cdca-d48c-4936-ad6a-4610aeb991ce.jpg?1",
             "name": "Stone Kavu",
             "text": "o\nR: Stone Kavu gets +1/+0 until end of turn.\no\nW: Stone Kavu gets +0/+1 until end of turn.",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "3d331144-0a97-5f20-a513-0f3a29eb5fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f24f89-3996-4740-a6c9-d26b8869554b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f24f89-3996-4740-a6c9-d26b8869554b.jpg?1",
             "name": "Thornscape Battlemage",
             "text": "Kicker o\nR and/or o\nW\nWhen Thornscape Battlemage comes into play, if you paid the o\nR kicker cost, Thornscape Battlemage deals 2 damage to target creature or player.\nWhen Thornscape Battlemage comes into play, if you paid the o\nW kicker cost, destroy target artifact.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "d08321fd-143d-5a39-86f6-bbbe497ae75a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c6e426-6165-4f8e-8766-de768ae13452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c6e426-6165-4f8e-8766-de768ae13452.jpg?1",
             "name": "Thornscape Familiar",
             "text": "Red spells and white spells you play cost o1 less to play.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "6d7b8ab2-376e-52e8-9101-19288b43c0e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca99de-57e7-47c4-b40a-6e41e3b18069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ca99de-57e7-47c4-b40a-6e41e3b18069.jpg?1",
             "name": "Ancient Spider",
             "text": "First strike\nAncient Spider may block as though it had flying.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "adcba755-a00e-51f5-a707-54efa08f7bd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfb0804-50d6-4bca-8733-72e01030a543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfb0804-50d6-4bca-8733-72e01030a543.jpg?1",
             "name": "Cavern Harpy",
             "text": "Flying\nWhen Cavern Harpy comes into play, return a blue or black creature you control to its owner's hand.\nPay 1 life: Return Cavern Harpy to its owner's hand.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "4622450a-601f-5426-8354-e55853b22382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943b3886-5556-474f-8dc1-18219e25abc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943b3886-5556-474f-8dc1-18219e25abc3.jpg?1",
             "name": "Cloud Cover",
             "text": "Whenever another permanent you control becomes the target of a spell or ability an opponent controls, you may return that permanent to its owner's hand.",
             "colours": [
@@ -3344,7 +3344,7 @@
         },
         {
             "id": "6b8c22a9-7af4-54d8-af73-81e8b15f7977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59a9e75-9988-4040-a718-b1655fc20d11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b59a9e75-9988-4040-a718-b1655fc20d11.jpg?1",
             "name": "Crosis's Charm",
             "text": "Choose one Return target permanent to its owner's hand; or destroy target nonblack creature, and it can't be regenerated; or destroy target artifact.",
             "colours": [
@@ -3380,7 +3380,7 @@
         },
         {
             "id": "d26a98f8-8b31-5668-9500-934e9ba6c413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c9d6a-86eb-45be-9405-473eb263b94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4c9d6a-86eb-45be-9405-473eb263b94c.jpg?1",
             "name": "Darigaaz's Charm",
             "text": "Choose one Return target creature card from your graveyard to your hand; or Darigaaz's Charm deals 3 damage to target creature or player; or target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3416,7 +3416,7 @@
         },
         {
             "id": "003dfe5d-0406-59c5-9d8b-f2493ccfe74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ec6c4b-2de0-4759-a25d-007706cb18cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ec6c4b-2de0-4759-a25d-007706cb18cc.jpg?1",
             "name": "Daring Leap",
             "text": "Target creature gets +1/+1 and gains flying and first strike until end of turn.",
             "colours": [
@@ -3450,7 +3450,7 @@
         },
         {
             "id": "17302f09-7ffc-553f-83bb-8bf3a7aade72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db86e34-c3ec-4a29-8779-81350a985644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db86e34-c3ec-4a29-8779-81350a985644.jpg?1",
             "name": "Destructive Flow",
             "text": "At the beginning of each player's upkeep, that player sacrifices a nonbasic land.",
             "colours": [
@@ -3486,7 +3486,7 @@
         },
         {
             "id": "f1af98bb-3409-56a7-a268-c3fdad8c58b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85206cc1-5484-40c6-b11d-b8d6fad4fc5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85206cc1-5484-40c6-b11d-b8d6fad4fc5c.jpg?1",
             "name": "Doomsday Specter",
             "text": "Flying\nWhen Doomsday Specter comes into play, return a blue or black creature you control to its owner's hand.\nWhenever Doomsday Specter deals combat damage to a player, look at that player's hand and choose a card from it. The player discards that card.",
             "colours": [
@@ -3522,7 +3522,7 @@
         },
         {
             "id": "da2e8a09-acb4-5797-9cbb-056c6d098f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a35d227-4489-4a0b-8f81-eb8e5949e1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a35d227-4489-4a0b-8f81-eb8e5949e1fc.jpg?1",
             "name": "Dralnu's Crusade",
             "text": "All Goblins get +1/+1, are black, and are Zombies in addition to their creature types.",
             "colours": [
@@ -3556,7 +3556,7 @@
         },
         {
             "id": "a47bca32-5f88-57fd-9d25-1496167a26e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a1894c-af4e-4530-960f-2225916be8cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a1894c-af4e-4530-960f-2225916be8cb.jpg?1",
             "name": "Dromar's Charm",
             "text": "Choose one You gain 5 life; or counter target spell; or target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "654325fc-a312-5e4c-9233-6bb8bc317b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb79f39-5ef3-4ad6-9a43-04beb27d8480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb79f39-5ef3-4ad6-9a43-04beb27d8480.jpg?1",
             "name": "Eladamri's Call",
             "text": "Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "64f532aa-9a4a-51c0-97d3-2af8619d9c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b950d9-8fef-4deb-b51b-26edb90abc56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b950d9-8fef-4deb-b51b-26edb90abc56.jpg?1",
             "name": "Ertai, the Corrupted",
             "text": "o\nU, oc\nT, Sacrifice a creature or enchantment: Counter target spell.",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "d22484cb-0c49-5e45-80fe-4b626d67624d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbfeb32-1654-4bf6-9a38-891f1a03e02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbfeb32-1654-4bf6-9a38-891f1a03e02b.jpg?1",
             "name": "Ertai, the Corrupted",
             "text": "o\nU, oc\nT, Sacrifice a creature or enchantment: Counter target spell.",
             "colours": [
@@ -3713,7 +3713,7 @@
         },
         {
             "id": "8d68411a-1daa-51c2-bd1a-2319a21cbe47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70220d8-f81b-44a4-b92e-d66de8c1b4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b70220d8-f81b-44a4-b92e-d66de8c1b4ce.jpg?1",
             "name": "Fleetfoot Panther",
             "text": "You may play Fleetfoot Panther any time you could play an instant.\nWhen Fleetfoot Panther comes into play, return a green or white creature you control to its owner's hand.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "66e11c6c-c433-5137-a492-c559ba1e01aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fda263-b6a7-43e3-998a-72a9d84c4572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fda263-b6a7-43e3-998a-72a9d84c4572.jpg?1",
             "name": "Gerrard's Command",
             "text": "Untap target creature. It gets +3/+3 until end of turn.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "05ca4249-6011-5085-a81f-3d268033b9e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd79fbf-626d-4549-917b-435f16b973d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd79fbf-626d-4549-917b-435f16b973d9.jpg?1",
             "name": "Horned Kavu",
             "text": "When Horned Kavu comes into play, return a red or green creature you control to its owner's hand.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "a0d09e84-8d24-59bf-bf13-aaad1b5e3175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6907fa19-29ed-4319-8835-68f424c92831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6907fa19-29ed-4319-8835-68f424c92831.jpg?1",
             "name": "Hull Breach",
             "text": "Choose one Destroy target artifact; or destroy target enchantment; or destroy target artifact and target enchantment.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "a955c77a-86f1-57ba-b15a-567bafd5b1df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e071665e-bb72-42e0-a42d-0d0ff02abd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e071665e-bb72-42e0-a42d-0d0ff02abd2b.jpg?1",
             "name": "Keldon Twilight",
             "text": "At the end of each player's turn, if no creatures attacked that turn, that player sacrifices a creature he or she controlled since the beginning of the turn.",
             "colours": [
@@ -3887,7 +3887,7 @@
         },
         {
             "id": "15899809-bc96-56a8-ba0a-fadf9f4b7eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd87185b-1242-4fb3-abee-44bc267ee5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd87185b-1242-4fb3-abee-44bc267ee5fb.jpg?1",
             "name": "Lava Zombie",
             "text": "When Lava Zombie comes into play, return a black or red creature you control to its owner's hand.\no2: Lava Zombie gets +1/+0 until end of turn.",
             "colours": [
@@ -3923,7 +3923,7 @@
         },
         {
             "id": "488c4a55-1124-5ffc-855f-988016a5718e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1547c2-ae9f-4871-a675-4026bf20e7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1547c2-ae9f-4871-a675-4026bf20e7e1.jpg?1",
             "name": "Malicious Advice",
             "text": "Tap X target artifacts, creatures, and/or lands. You lose X life.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "5243207f-65be-5420-bd31-46c76ca42d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813279d1-d7bd-4d49-bd9d-fc9a6595dd39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813279d1-d7bd-4d49-bd9d-fc9a6595dd39.jpg?1",
             "name": "Marsh Crocodile",
             "text": "When Marsh Crocodile comes into play, return a blue or black creature you control to its owner's hand.\nWhen Marsh Crocodile comes into play, each player discards a card from his or her hand.",
             "colours": [
@@ -3993,7 +3993,7 @@
         },
         {
             "id": "d85ee5f6-7334-57fc-b5af-2df8a3b12836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176f84c6-aa5e-449c-bd2b-cc91a898f0c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176f84c6-aa5e-449c-bd2b-cc91a898f0c7.jpg?1",
             "name": "Meddling Mage",
             "text": "As Meddling Mage comes into play, name a nonland card.\nThe named card can't be played.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "d491394a-d569-52b4-bd35-bce831812913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb4857-7c66-42e4-913c-97a0306366d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb4857-7c66-42e4-913c-97a0306366d5.jpg?1",
             "name": "Natural Emergence",
             "text": "When Natural Emergence comes into play, return a red or green enchantment you control to its owner's hand.\nLands you control are 2/2 creatures with first strike. They're still lands.",
             "colours": [
@@ -4064,7 +4064,7 @@
         },
         {
             "id": "c1cc879d-887e-5d77-b63a-7e8990111c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8440ca8-73ca-462b-a735-f6fb3d0de603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8440ca8-73ca-462b-a735-f6fb3d0de603.jpg?1",
             "name": "Phyrexian Tyranny",
             "text": "Whenever a player draws a card, that player loses 2 life unless he or she pays o2.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "295c896e-4c00-5f78-8c37-53e599bf1602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea4cfef-6736-42a5-9f3e-10de8d0cd8d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea4cfef-6736-42a5-9f3e-10de8d0cd8d3.jpg?1",
             "name": "Questing Phelddagrif",
             "text": "o\nG: Questing Phelddagrif gets +1/+1 until end of turn. Target opponent puts a 1/1 green Hippo creature token into play.\no\nW: Questing Phelddagrif gains protection from black and from red until end of turn. Target opponent gains 2 life.\no\nU: Questing Phelddagrif gains flying until end of turn. Target opponent may draw a card.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "8375fab2-d00a-5259-8056-d50bdcdaf448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153077a8-38c0-44aa-9b84-cdd9ade50ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153077a8-38c0-44aa-9b84-cdd9ade50ad6.jpg?1",
             "name": "Radiant Kavu",
             "text": "o\nRo\nGo\nW: Prevent all combat damage blue creatures and black creatures would deal this turn.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "776ea205-4cbb-5330-88b0-c1b89b1966b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2090b80-2ce2-4c9a-87fe-d221f3c677b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2090b80-2ce2-4c9a-87fe-d221f3c677b4.jpg?1",
             "name": "Razing Snidd",
             "text": "When Razing Snidd comes into play, return a black or red creature you control to its owner's hand.\nWhen Razing Snidd comes into play, each player sacrifices a land.",
             "colours": [
@@ -4212,7 +4212,7 @@
         },
         {
             "id": "2347a4b0-0210-56f7-ae9b-578f1284db1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd30f389-bac8-4b82-a8a7-6948d43a9f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd30f389-bac8-4b82-a8a7-6948d43a9f60.jpg?1",
             "name": "Rith's Charm",
             "text": "Choose one Destroy target nonbasic land; or put three 1/1 green Saproling creature tokens into play; or prevent all damage a source of your choice would deal this turn.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "4e283726-d57b-50c4-9656-865b0c54dc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0a87f-e946-4ef1-b30d-fe32c19a0f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b0a87f-e946-4ef1-b30d-fe32c19a0f52.jpg?1",
             "name": "Sawtooth Loon",
             "text": "Flying\nWhen Sawtooth Loon comes into play, return a white or blue creature you control to its owner's hand.\nWhen Sawtooth Loon comes into play, draw two cards, then put two cards from your hand on the bottom of your library.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "e74cb19d-fe18-5dd0-891e-4a1415e5d5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc72997-78b0-47aa-a029-bf55f77c3e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc72997-78b0-47aa-a029-bf55f77c3e73.jpg?1",
             "name": "Shivan Wurm",
             "text": "Trample\nWhen Shivan Wurm comes into play, return a red or green creature you control to its owner's hand.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "ec4ff6f5-c8ea-5764-b7c1-8d1baaf28e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ee86-96b2-47aa-a1ba-2988737f11ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac35ee86-96b2-47aa-a1ba-2988737f11ee.jpg?1",
             "name": "Silver Drake",
             "text": "Flying\nWhen Silver Drake comes into play, return a white or blue creature you control to its owner's hand.",
             "colours": [
@@ -4356,7 +4356,7 @@
         },
         {
             "id": "b06211d3-ac38-5326-a692-eaa56f63b5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf442b3-fa39-4f6a-90a0-22dcd9df649c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf442b3-fa39-4f6a-90a0-22dcd9df649c.jpg?1",
             "name": "Sparkcaster",
             "text": "When Sparkcaster comes into play, return a red or green creature you control to its owner's hand.\nWhen Sparkcaster comes into play, it deals 1 damage to target player.",
             "colours": [
@@ -4392,7 +4392,7 @@
         },
         {
             "id": "8dc49c9c-c85c-506c-9934-5db57a9cdae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e8697f-fdf3-4a1a-a84d-dd29b17336c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e8697f-fdf3-4a1a-a84d-dd29b17336c2.jpg?1",
             "name": "Steel Leaf Paladin",
             "text": "First strike\nWhen Steel Leaf Paladin comes into play, return a green or white creature you control to its owner's hand.",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "907ada8a-00c0-59eb-93ca-6dfcfb09fcb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ca502-672d-4cc0-b6e0-b9de517058d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ca502-672d-4cc0-b6e0-b9de517058d0.jpg?1",
             "name": "Terminate",
             "text": "Destroy target creature. It can't be regenerated.",
             "colours": [
@@ -4463,7 +4463,7 @@
         },
         {
             "id": "68cd0fc0-44e2-53e4-9c0d-dbe21b9893eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72acb67d-01cb-4fde-8b0b-199e8d1e396a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72acb67d-01cb-4fde-8b0b-199e8d1e396a.jpg?1",
             "name": "Treva's Charm",
             "text": "Choose one Destroy target enchantment; or remove target attacking creature from the game; or draw a card, then discard a card from your hand.",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "c6d992e9-0b9f-5ac4-a5b4-036c4ae2070a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d429233e-1cf9-4f87-b191-894a73e7a876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d429233e-1cf9-4f87-b191-894a73e7a876.jpg?1",
             "name": "Urza's Guilt",
             "text": "Each player draws two cards, then discards three cards from his or her hand, then loses 4 life.",
             "colours": [
@@ -4533,7 +4533,7 @@
         },
         {
             "id": "7ff52aaf-39e7-56c3-b591-694348f29d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e3edb-62f1-4680-884f-70323547f8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212e3edb-62f1-4680-884f-70323547f8ad.jpg?1",
             "name": "Draco",
             "text": "Draco costs o2 less to play for each basic land type among lands you control.\nFlying\nAt the beginning of your upkeep, sacrifice Draco unless you pay o10. This cost is reduced by o2 for each basic land type among lands you control.",
             "colours": [],
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "54c44056-8115-5af4-9178-add3c1d3b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f95767-afda-4d74-bbd4-1b702eeae54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f95767-afda-4d74-bbd4-1b702eeae54b.jpg?1",
             "name": "Mana Cylix",
             "text": "o1, oc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "a05c82be-c929-5720-a509-7b9f51156db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f5498b-bb12-48ec-811b-b52e45ffddaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f5498b-bb12-48ec-811b-b52e45ffddaf.jpg?1",
             "name": "Skyship Weatherlight",
             "text": "When Skyship Weatherlight comes into play, search your library for any number of artifact and/or creature cards and remove them from the game. Then shuffle your library.\no4, oc\nT: Choose a card at random that was removed from the game with Skyship Weatherlight. Put that card into your hand.",
             "colours": [],
@@ -4624,7 +4624,7 @@
         },
         {
             "id": "dcc4ee11-6a61-55f0-966a-d19732010ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99791ef7-ff51-4982-b0ef-55560f9577ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99791ef7-ff51-4982-b0ef-55560f9577ff.jpg?1",
             "name": "Skyship Weatherlight",
             "text": "When Skyship Weatherlight comes into play, search your library for any number of artifact and/or creature cards and remove them from the game. Then shuffle your library.\no4, oc\nT: Choose a card at random that was removed from the game with Skyship Weatherlight. Put that card into your hand.",
             "colours": [],
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "208bc9d2-3c62-53ee-aade-bd057cf4abb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0beb4-c3dd-4bb1-b49b-a48b2d4ad38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d0beb4-c3dd-4bb1-b49b-a48b2d4ad38d.jpg?1",
             "name": "Star Compass",
             "text": "Star Compass comes into play tapped.\noc\nT: Add to your mana pool one mana of any color a basic land you control could produce.",
             "colours": [],
@@ -4683,7 +4683,7 @@
         },
         {
             "id": "5bdedf8d-6f37-51b7-bdc2-258e6573222a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324bc757-9942-4862-b691-5af42e07f682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324bc757-9942-4862-b691-5af42e07f682.jpg?1",
             "name": "Stratadon",
             "text": "Stratadon costs o1 less to play for each basic land type among lands you control.\nTrample",
             "colours": [],
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "8425ddef-69df-509f-b870-558db4dacc72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caad74f-c0d0-4eca-94be-b89a2c9a3980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caad74f-c0d0-4eca-94be-b89a2c9a3980.jpg?1",
             "name": "Crosis's Catacombs",
             "text": "Crosis's Catacombs is a Lair in addition to its land type.\nWhen Crosis's Catacombs comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nU, o\nB, or o\nR to your mana pool.",
             "colours": [],
@@ -4748,7 +4748,7 @@
         },
         {
             "id": "bc710e9e-0b80-5979-bb9d-0f370276df98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f6f0c-af30-4937-b4a7-48f493e007a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f6f0c-af30-4937-b4a7-48f493e007a0.jpg?1",
             "name": "Darigaaz's Caldera",
             "text": "Darigaaz's Caldera is a Lair in addition to its land type.\nWhen Darigaaz's Caldera comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nB, o\nR, or o\nG to your mana pool.",
             "colours": [],
@@ -4782,7 +4782,7 @@
         },
         {
             "id": "6bacfb09-ac19-55bf-a214-bba1b060f4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f10cee-6a63-438e-a9df-6b902dd025b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f10cee-6a63-438e-a9df-6b902dd025b8.jpg?1",
             "name": "Dromar's Cavern",
             "text": "Dromar's Cavern is a Lair in addition to its land type.\nWhen Dromar's Cavern comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nW, o\nU, or o\nB to your mana pool.",
             "colours": [],
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "bf573d7c-63cd-5bd2-96f0-0db504f0243e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676703fe-bd80-413c-8704-1da5d3248b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676703fe-bd80-413c-8704-1da5d3248b7e.jpg?1",
             "name": "Forsaken City",
             "text": "Forsaken City doesn't untap during your untap step.\nAt the beginning of your upkeep, you may remove a card in your hand from the game. If you do, untap Forsaken City.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "734e5e9a-2672-542b-a20c-0c69bcb5a326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043a2299-1cfc-4732-a10a-58c773b9992c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043a2299-1cfc-4732-a10a-58c773b9992c.jpg?1",
             "name": "Meteor Crater",
             "text": "oc\nT: Choose a color of a permanent you control. Add one mana of that color to your mana pool.",
             "colours": [],
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "de5793cc-64f3-56ae-baef-738f8cf6006b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740fa25d-9c1f-44eb-9eb4-0dd514cb315a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740fa25d-9c1f-44eb-9eb4-0dd514cb315a.jpg?1",
             "name": "Rith's Grove",
             "text": "Rith's Grove is a Lair in addition to its land type.\nWhen Rith's Grove comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nR, o\nG, or o\nW to your mana pool.",
             "colours": [],
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "06385292-2d0c-5279-92d2-0dc07ecf48d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353a8ea8-3f1f-4f77-95bc-b09b96996285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/353a8ea8-3f1f-4f77-95bc-b09b96996285.jpg?1",
             "name": "Terminal Moraine",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT, Sacrifice Terminal Moraine: Search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [],
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "90f44f37-ef3b-57ef-9a9c-29a80d35bd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae2458-b54f-426a-ad40-13529a73c423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae2458-b54f-426a-ad40-13529a73c423.jpg?1",
             "name": "Treva's Ruins",
             "text": "Treva's Ruins is a Lair in addition to its land type.\nWhen Treva's Ruins comes into play, sacrifice it unless you return a non-Lair land you control to its owner's hand.\noc\nT: Add o\nG, o\nW, or o\nU to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/POR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/POR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "90710375-0dc2-5682-92f5-f6ce171ff472",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc6ec1-3b34-45e0-8573-39eba1d10efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc6ec1-3b34-45e0-8573-39eba1d10efa.jpg?1",
             "name": "Alabaster Dragon",
             "text": "Flying\nIf Alabaster Dragon is put into your discard pile from play, shuffle Alabaster Dragon back into your deck.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "0da19281-7435-570b-a98e-3eb88ddaf7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dda640-2a00-437e-855f-173c487e7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dda640-2a00-437e-855f-173c487e7395.jpg?1",
             "name": "Angelic Blessing",
             "text": "Any one creature gets +3/+3 and gains flying until the end of the turn.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "20cdb535-5b57-522e-9cf6-c30036b525cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387b9236-1241-44b7-9436-1fbc9970b692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387b9236-1241-44b7-9436-1fbc9970b692.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking doesn't cause Archangel to tap.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "d99d4140-3d3f-55aa-85b7-ca86b0c91156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543f8c6a-bcf1-4400-82e5-83d36cb60464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543f8c6a-bcf1-4400-82e5-83d36cb60464.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking doesn't cause Ardent Militia to tap.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "d6ee2968-f939-5158-88fc-6a28c8264fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2073ca8b-2bca-4539-94d7-989da157e4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2073ca8b-2bca-4539-94d7-989da157e4b8.jpg?1",
             "name": "Armageddon",
             "text": "Destroy all lands. (This includes your lands.)",
             "colours": [
@@ -166,7 +166,7 @@
         },
         {
             "id": "7fecb362-e6b5-5692-a202-538e39ebeebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81b61af-cdb7-468f-9ff0-db82aa084023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81b61af-cdb7-468f-9ff0-db82aa084023.jpg?1",
             "name": "Armored Pegasus",
             "text": "Flying",
             "colours": [
@@ -201,7 +201,7 @@
         },
         {
             "id": "f40ecd98-872f-51b7-8909-b37b0e1e9954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f021a79-a182-4914-9ff4-d6fcba7c1d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f021a79-a182-4914-9ff4-d6fcba7c1d22.jpg?1",
             "name": "Armored Pegasus",
             "text": "",
             "colours": [
@@ -236,7 +236,7 @@
         },
         {
             "id": "4e7e8175-828a-5c1f-b184-7a1a33623db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecc19-8106-4e5a-bb25-aaea9684ba0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecc19-8106-4e5a-bb25-aaea9684ba0e.jpg?1",
             "name": "Blessed Reversal",
             "text": "Play Blessed Reversal only after you're attacked, before you declare interceptors.\nFor each attacking creature, you gain 3 life.",
             "colours": [
@@ -267,7 +267,7 @@
         },
         {
             "id": "3618f64c-02c3-52de-ad26-bd596b23acea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea283d2-8f00-4836-81b4-c041b0469dcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea283d2-8f00-4836-81b4-c041b0469dcb.jpg?1",
             "name": "Blinding Light",
             "text": "Tap all creatures except for white creatures. (This includes your creatures.)",
             "colours": [
@@ -298,7 +298,7 @@
         },
         {
             "id": "7a83750b-22a6-57c5-908b-0ee0ad0c82d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985af775-2036-459d-83c6-31ac84a0ffb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985af775-2036-459d-83c6-31ac84a0ffb1.jpg?1",
             "name": "Border Guard",
             "text": "",
             "colours": [
@@ -332,7 +332,7 @@
         },
         {
             "id": "c62d3aaf-5cad-52ea-a994-4cfc3bbafdae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcea5e09-6385-41df-970b-ac26c9b46127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcea5e09-6385-41df-970b-ac26c9b46127.jpg?1",
             "name": "Breath of Life",
             "text": "Take any one summon creature from your discard pile and put that card into play. Treat it as though you just played it from your hand.",
             "colours": [
@@ -363,7 +363,7 @@
         },
         {
             "id": "60bf84c2-b584-5d6f-bcd0-d89f3d060800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db1bbf-a6cf-460c-bec8-dbd682157af4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29db1bbf-a6cf-460c-bec8-dbd682157af4.jpg?1",
             "name": "Charging Paladin",
             "text": "If Charging Paladin attacks, it gets +0/+3 until the end of the turn.",
             "colours": [
@@ -397,7 +397,7 @@
         },
         {
             "id": "cfab17cf-c6ff-593a-a06d-19242476cd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc37fd2-5c34-4522-8113-e6dd2181550b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc37fd2-5c34-4522-8113-e6dd2181550b.jpg?1",
             "name": "Defiant Stand",
             "text": "Play Defiant Stand only after you're attacked, before you declare interceptors.\nAny one creature gets +1/+3 until the end of the turn. If that creature is tapped, untap it.",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "a2643431-ab68-59ad-bcf6-b8c93f0a7d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4bf8-51b6-44a8-92ac-e5aec4e4f2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89fb4bf8-51b6-44a8-92ac-e5aec4e4f2bc.jpg?1",
             "name": "Devoted Hero",
             "text": "",
             "colours": [
@@ -462,7 +462,7 @@
         },
         {
             "id": "0f9a7ae4-9953-5e8f-b240-9cfd3178d29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4234262-56c6-4bd1-b425-12db931829d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4234262-56c6-4bd1-b425-12db931829d5.jpg?1",
             "name": "False Peace",
             "text": "Choose any one player. That player can't attack on his or her next turn.",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "3cbe4dc6-5efe-50e4-a63c-a0e99bc37694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd972d-1cc1-4fb1-9b4e-a88ea115cf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cd972d-1cc1-4fb1-9b4e-a88ea115cf7f.jpg?1",
             "name": "Fleet-Footed Monk",
             "text": "Fleet-Footed Monk can't be intercepted by any creature with offense 2 or greater.",
             "colours": [
@@ -527,7 +527,7 @@
         },
         {
             "id": "2e51d8b3-7e12-505c-9f98-4c18d3f71e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ddb33-66c4-4753-b1eb-8937ab812a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458ddb33-66c4-4753-b1eb-8937ab812a81.jpg?1",
             "name": "Foot Soldiers",
             "text": "",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "76c22e9a-2764-5158-acef-4ab126bdf882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342b5afe-544f-4fa1-a833-4e0590b41eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342b5afe-544f-4fa1-a833-4e0590b41eed.jpg?1",
             "name": "Gift of Estates",
             "text": "If your opponent has more lands in play than you do, search your deck for up to three plains and put them into your hand. Shuffle your deck afterwards.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "6c128d3a-08f7-58c6-a72b-d478d0ac73d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3657001a-7f79-4d3f-9d35-462ecf684fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3657001a-7f79-4d3f-9d35-462ecf684fa8.jpg?1",
             "name": "Harsh Justice",
             "text": "Play Harsh Justice only after you're attacked, before you declare interceptors.\nThis turn, each attacking creature that damages you also deals equal damage to the attacking player.",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "79ba84d7-d35d-5aba-9d62-7d8320fe1a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594de429-58ed-4a0c-9631-464cde7a48c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594de429-58ed-4a0c-9631-464cde7a48c3.jpg?1",
             "name": "Keen-Eyed Archers",
             "text": "Keen-Eyed Archers can intercept as though it had flying.",
             "colours": [
@@ -657,7 +657,7 @@
         },
         {
             "id": "03a1d676-30e3-5dc4-a57e-ca7027d41797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c31b4b4-18fc-4a6e-8d74-fd5340964320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c31b4b4-18fc-4a6e-8d74-fd5340964320.jpg?1",
             "name": "Knight Errant",
             "text": "",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "2d9c3a7d-35a1-5959-95ee-1ad0757fe4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f3e1c9-bfad-49a1-b171-6fa344ef2eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f3e1c9-bfad-49a1-b171-6fa344ef2eef.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy any one creature. That creature's owner gains 4 life.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "7ed5d802-6ee7-53ae-8943-3eb360821d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1fb8c-12fa-4e9c-979f-55e89356acaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa1fb8c-12fa-4e9c-979f-55e89356acaf.jpg?1",
             "name": "Regal Unicorn",
             "text": "",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "a13d491c-aa21-511f-84e5-9d34cdfb6787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56300cb-6b44-47fe-9508-c33ad5670b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56300cb-6b44-47fe-9508-c33ad5670b4b.jpg?1",
             "name": "Renewing Dawn",
             "text": "For each mountain your opponent has in play, you gain 2 life.",
             "colours": [
@@ -786,7 +786,7 @@
         },
         {
             "id": "69930d1a-8ac2-55d2-973e-16d835a83999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b19990-c4a2-433d-a9ce-005216e9e4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b19990-c4a2-433d-a9ce-005216e9e4ac.jpg?1",
             "name": "Sacred Knight",
             "text": "Sacred Knight can't be intercepted by black or red creatures.",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "cd4fbfa3-df4f-5fa2-b860-f6f9f1332a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484d1b31-5363-49ef-9b13-2005568636c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484d1b31-5363-49ef-9b13-2005568636c1.jpg?1",
             "name": "Sacred Nectar",
             "text": "You gain 4 life.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "445a10b9-2d68-500b-8326-ed3b7b411ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db0060-3667-4c8c-ae9b-d62dceac64e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17db0060-3667-4c8c-ae9b-d62dceac64e3.jpg?1",
             "name": "Seasoned Marshal",
             "text": "If Seasoned Marshal attacks, you may choose to tap any one creature. (Tapped creatures can't intercept.)",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "b939f6e2-2cb1-5ed3-9c1d-b1749e4a322d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbea02f-9124-4e1a-8693-d988a0a3adae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbea02f-9124-4e1a-8693-d988a0a3adae.jpg?1",
             "name": "Spiritual Guardian",
             "text": "When Spiritual Guardian comes into play from your hand, you gain 4 life.",
             "colours": [
@@ -918,7 +918,7 @@
         },
         {
             "id": "d18eb139-b680-5bce-95df-a88644b16b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b708b-368f-48d2-8eca-40f2ae6d5178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b708b-368f-48d2-8eca-40f2ae6d5178.jpg?1",
             "name": "Spotted Griffin",
             "text": "Flying",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "0c83dc67-4c88-519c-aeb4-5be4537298c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6992524-6921-473b-8301-cb63fe502600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6992524-6921-473b-8301-cb63fe502600.jpg?1",
             "name": "Starlight",
             "text": "For each black creature your opponent has in play, you gain 3 life.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "6e577811-9d4d-586c-ac9b-0056e3a36f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36691cd0-c709-4452-a61a-d6e2049fdfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36691cd0-c709-4452-a61a-d6e2049fdfcf.jpg?1",
             "name": "Starlit Angel",
             "text": "Flying",
             "colours": [
@@ -1017,7 +1017,7 @@
         },
         {
             "id": "dc831bbf-3ce8-5a53-86a8-4d0e1dd5e73a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d76e2d-6720-4f0e-a5b1-71a59d47a3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d76e2d-6720-4f0e-a5b1-71a59d47a3fb.jpg?1",
             "name": "Starlit Angel",
             "text": "",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "851c9595-ff76-5d4f-98cb-236a13a51e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4693b3-d5d7-4401-aee3-119d3eb276a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4693b3-d5d7-4401-aee3-119d3eb276a2.jpg?1",
             "name": "Steadfastness",
             "text": "All your creatures get +0/+3 until the end of the turn.",
             "colours": [
@@ -1083,7 +1083,7 @@
         },
         {
             "id": "50583b4e-af62-56af-aeb5-074ad7dea0fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fbfbc0-c55b-4e56-a3d2-5d09571c36c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18fbfbc0-c55b-4e56-a3d2-5d09571c36c8.jpg?1",
             "name": "Stern Marshal",
             "text": "On your turn, before you attack, you may tap Stern Marshal to give any one creature +2/+2 until the end of the turn.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "1d21a238-18e7-59ba-9ea4-ff8e307f1e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6ee294-7dbb-4872-81d1-c69c7337cf9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6ee294-7dbb-4872-81d1-c69c7337cf9f.jpg?1",
             "name": "Temporary Truce",
             "text": "Each player may draw up to two cards. For each card less than two any player draws, that player gains 2 life. (You choose whether to draw first.)",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "622e1dc2-ade7-541b-8a1c-f40f800a5120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f61bdf-cbcd-4a63-8866-eb13ec9b351c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f61bdf-cbcd-4a63-8866-eb13ec9b351c.jpg?1",
             "name": "Valorous Charge",
             "text": "All white creatures get +2/+0 until the end of the turn. (This includes other players' white creatures.)",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "33b63bae-4541-5960-a0f0-e0ba08cee326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72322032-c287-4a9e-9d61-a452f6c45bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72322032-c287-4a9e-9d61-a452f6c45bfb.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play from your hand, you gain 2 life.",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "628309e3-d015-5c46-a3cb-130319405a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c249b-157c-4f1d-8171-29d1e75b1c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c249b-157c-4f1d-8171-29d1e75b1c9f.jpg?1",
             "name": "Vengeance",
             "text": "Destroy any one tapped creature.",
             "colours": [
@@ -1245,7 +1245,7 @@
         },
         {
             "id": "773f9e18-d017-54da-878d-d3de9284fa0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8d55a3-0d7f-4fba-9879-9a8264110e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8d55a3-0d7f-4fba-9879-9a8264110e78.jpg?1",
             "name": "Wall of Swords",
             "text": "Flying\nWall of Swords can't attack.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "8ac10fee-4aed-5683-b5a1-d3a9b70a40ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8668e4af-ae89-4fab-8015-8dc643c6cd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8668e4af-ae89-4fab-8015-8dc643c6cd36.jpg?1",
             "name": "Warrior's Charge",
             "text": "All your creatures get +1/+1 until the end of the turn.",
             "colours": [
@@ -1311,7 +1311,7 @@
         },
         {
             "id": "d49220e5-4eee-5825-85b3-e6f68fdbb03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9279d545-28b7-41c5-bb88-6dc4bbbcd71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9279d545-28b7-41c5-bb88-6dc4bbbcd71f.jpg?1",
             "name": "Warrior's Charge",
             "text": "All your creatures get +1/+1 until the end of the turn. (For example, a 1/2 creature would become 2/3.)",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "de2fe9e8-57f7-5800-8a61-ec080736f776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75d8204-6f9d-4a7a-bb8b-d51ac65a30fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75d8204-6f9d-4a7a-bb8b-d51ac65a30fa.jpg?1",
             "name": "Wrath of God",
             "text": "Put all creatures into their owners' discard piles. (This includes your creatures.)",
             "colours": [
@@ -1375,7 +1375,7 @@
         },
         {
             "id": "cfad670c-545a-517a-9fa9-e9d8e09a8614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b613c-61bf-4c2d-9c90-2949e442aea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b613c-61bf-4c2d-9c90-2949e442aea5.jpg?1",
             "name": "Ancestral Memories",
             "text": "Look at the top seven cards of your deck. Put two of them into your hand and the rest into your discard pile.",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "2b8d5ea9-ddb0-5848-95eb-65d1a26f69ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875e753-117a-40b6-9cd2-dd5dfd11a38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3875e753-117a-40b6-9cd2-dd5dfd11a38d.jpg?1",
             "name": "Balance of Power",
             "text": "If you have fewer cards in your hand than your opponent does, draw until you have the same number. (When you play Balance of Power, it doesn't count as in your hand.)",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "6bc7d046-97bc-5ecb-8aeb-e8064c602d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb46c8-30ae-4457-a726-6fe1ddd183d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49fb46c8-30ae-4457-a726-6fe1ddd183d5.jpg?1",
             "name": "Baleful Stare",
             "text": "Look at your opponent's hand. For each mountain and red card there, you draw a card. (You draw from your deck.)",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "9873ed7d-857f-5b20-a762-41645777a043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d5eec0-0afe-4af9-ba1b-70282df8cd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d5eec0-0afe-4af9-ba1b-70282df8cd0a.jpg?1",
             "name": "Capricious Sorcerer",
             "text": "On your turn, before you attack, you may tap Capricious Sorcerer to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "2f16fcb2-3055-500d-8b27-98a61ebe57d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746790c-a426-4135-8c9d-afb82a0c26b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746790c-a426-4135-8c9d-afb82a0c26b8.jpg?1",
             "name": "Cloak of Feathers",
             "text": "Any one creature gains flying until the end of the turn. You draw a card.",
             "colours": [
@@ -1533,7 +1533,7 @@
         },
         {
             "id": "402d9afa-f7bf-5536-9c10-e76c54a8598b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb7fb59-65c0-4af6-9d3a-79cd6602d004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb7fb59-65c0-4af6-9d3a-79cd6602d004.jpg?1",
             "name": "Cloud Dragon",
             "text": "Flying\nCloud Dragon can intercept only creatures with flying.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "04dd5497-5d48-5e62-b02c-1a4d5219bce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7386c6-d17a-4c7d-884d-2471b87d8b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7386c6-d17a-4c7d-884d-2471b87d8b8e.jpg?1",
             "name": "Cloud Pirates",
             "text": "Flying\nCloud Pirates can intercept only creatures with flying.",
             "colours": [
@@ -1603,7 +1603,7 @@
         },
         {
             "id": "399a36ae-aba7-5c74-9d57-74e6d4c66ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88425a48-7b03-4ecf-88cd-d72ef98ca814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88425a48-7b03-4ecf-88cd-d72ef98ca814.jpg?1",
             "name": "Cloud Pirates",
             "text": "",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "33745b3f-a5d3-5c27-a627-ca216ef1f49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7547aa-fcf7-4b6e-955d-cc5ebc40cd7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7547aa-fcf7-4b6e-955d-cc5ebc40cd7d.jpg?1",
             "name": "Cloud Spirit",
             "text": "Flying\nCloud Spirit can intercept only creatures with flying.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "dc4a1259-b2bb-5373-b77b-5597f1bd5d6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b97fc-fa42-40a6-918e-e06383bfcae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b97fc-fa42-40a6-918e-e06383bfcae3.jpg?1",
             "name": "Command of Unsummoning",
             "text": "Play Command of Unsummoning only after you're attacked, before you declare interceptors.\nReturn any one or two attacking creatures to their owner's hand.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "75f7edd2-7cbd-59f8-80d2-e2bc18eb5e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bbb10f-c118-4905-8329-3963af415178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35bbb10f-c118-4905-8329-3963af415178.jpg?1",
             "name": "Coral Eel",
             "text": "",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "63be29ad-9428-5830-93d8-c403d6bee4b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bea0d4-946e-4cb8-b6f1-50231d52bfbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bea0d4-946e-4cb8-b6f1-50231d52bfbe.jpg?1",
             "name": "Cruel Fate",
             "text": "Look at the top five cards of your opponent's deck. Put one of them into your opponent's discard pile and the rest on top of his or her deck in any order.",
             "colours": [
@@ -1767,7 +1767,7 @@
         },
         {
             "id": "12ca2ddc-1edf-544a-a8f5-d25af6eb83ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d7f8d8-30fb-47c7-8927-646c41f0b9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d7f8d8-30fb-47c7-8927-646c41f0b9bc.jpg?1",
             "name": "Deep-Sea Serpent",
             "text": "Deep-Sea Serpent can attack only if the defending player has an island in play.",
             "colours": [
@@ -1800,7 +1800,7 @@
         },
         {
             "id": "17d5b6c9-b1b1-566b-8e64-a246b24e7649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e7b52-2663-4140-9758-f24b8b947876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5e7b52-2663-4140-9758-f24b8b947876.jpg?1",
             "name": "Djinn of the Lamp",
             "text": "Flying",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "ac42975d-0a00-53e3-9bee-aece5ea29b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c93d4e9-7fd6-4814-b86b-89b92d1dad3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c93d4e9-7fd6-4814-b86b-89b92d1dad3b.jpg?1",
             "name": "D\u00e9j\u00e0 Vu",
             "text": "Return any one sorcery card from your discard pile to your hand.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "0c1d82e4-0bf4-54f3-9965-8c26a30d38c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6a5c33-cf74-4cec-a4f4-1aac9e7b8f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6a5c33-cf74-4cec-a4f4-1aac9e7b8f79.jpg?1",
             "name": "Exhaustion",
             "text": "At the beginning of your opponent's next turn, he or she skips untapping his or her creatures and lands.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "e0566418-0763-5152-8be1-cff2ef472bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26bf66-8fa8-4f69-9556-c9fcc56a7f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26bf66-8fa8-4f69-9556-c9fcc56a7f33.jpg?1",
             "name": "Flux",
             "text": "Each player chooses and discards from his or her hand any number of cards and then draws that many cards. You then draw a card. (You choose first.)",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "b7c426ae-5015-5644-9273-40be2f0c202a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4528edca-cc36-4f63-9615-24ca315d672c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4528edca-cc36-4f63-9615-24ca315d672c.jpg?1",
             "name": "Giant Octopus",
             "text": "",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "9a5144aa-6457-5bb7-b412-8db200f5ad64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d25497-36b4-48b9-ba01-f24f6222d6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d25497-36b4-48b9-ba01-f24f6222d6be.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "452a6156-e6a4-5d15-be25-377a4b023c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5e413-85ea-4528-97b9-e1db5117ec2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5e413-85ea-4528-97b9-e1db5117ec2a.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -2029,7 +2029,7 @@
         },
         {
             "id": "a4042a4c-72a2-507f-9b00-93f6905637b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be341805-b4de-456e-8b46-4ee5fdbca7e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be341805-b4de-456e-8b46-4ee5fdbca7e0.jpg?1",
             "name": "Ingenious Thief",
             "text": "Flying\nWhen Ingenious Thief comes into play from your hand, look at your opponent's hand.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "4adc83da-a535-5bd4-9ebb-eef411276c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e835b618-83c1-46e2-b8bd-aec56f58ccfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e835b618-83c1-46e2-b8bd-aec56f58ccfc.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War comes into play from your hand, return any one creature to its owner's hand. (If you're the only one with creatures, return one of them to your hand.)",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "236fd88c-a04f-5d8a-96d8-868b66777e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126fec7a-4f36-49e5-a2d7-96deb7af856f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/126fec7a-4f36-49e5-a2d7-96deb7af856f.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "04376b80-edff-5093-b36a-f9caa79a12a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d60f29-6da0-4ce6-9c92-96f313007271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d60f29-6da0-4ce6-9c92-96f313007271.jpg?1",
             "name": "Mystic Denial",
             "text": "Play Mystic Denial only in response to another player playing a summon creature or a sorcery. That card has no effect, and that player puts it into his or her discard pile.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "bde51bef-cd14-5180-994e-e0e2e94e698f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be1956e-c43e-4a6c-950a-5be6e6ca013f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be1956e-c43e-4a6c-950a-5be6e6ca013f.jpg?1",
             "name": "Omen",
             "text": "Look at the top three cards of your deck and return them in any order. You may choose to shuffle your deck. Then draw a card.",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "297062f9-5481-57c9-b0bf-ad162323e713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587bcb-0ece-4b36-85dc-76899e403b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9587bcb-0ece-4b36-85dc-76899e403b08.jpg?1",
             "name": "Owl Familiar",
             "text": "Flying\nWhen Owl Familiar comes into play from your hand, draw a card, then choose and discard a card from your hand.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "fce3cbbf-78e9-5029-b586-dca894b2287d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc3917-fded-4773-8f8d-62bd861c1131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1edc3917-fded-4773-8f8d-62bd861c1131.jpg?1",
             "name": "Personal Tutor",
             "text": "Search your deck for a sorcery and reveal that card to all players. Shuffle your deck and put the revealed card on top of it.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "63d6290b-5c46-5460-985e-2197622673c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbcb0df-d1cc-4718-ba1e-b590852cce20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dbcb0df-d1cc-4718-ba1e-b590852cce20.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior can't be intercepted.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "04333668-23fb-59d8-b682-45e02fb63114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269bb4fc-9d8f-42cc-8f71-6a658e41533c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269bb4fc-9d8f-42cc-8f71-6a658e41533c.jpg?1",
             "name": "Prosperity",
             "text": "Each player draws X cards.",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "6581eebc-bbf2-5d44-b325-d97e371bb59f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd755a7-914a-4547-8d38-34d8cc3b9a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd755a7-914a-4547-8d38-34d8cc3b9a7f.jpg?1",
             "name": "Prosperity",
             "text": "",
             "colours": [
@@ -2355,7 +2355,7 @@
         },
         {
             "id": "e5735040-dfc6-5f31-b313-99b521cc0a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b49dd4c-ead6-4d94-9acb-0518d1f6426e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b49dd4c-ead6-4d94-9acb-0518d1f6426e.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "e2898af1-3e83-5775-a5e4-3618cc961075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fadc0d-d6de-4634-9c15-d9c9732cdc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fadc0d-d6de-4634-9c15-d9c9732cdc87.jpg?1",
             "name": "Snapping Drake",
             "text": "",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "021e7810-9aa6-5d44-956a-2de1dd9b19bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfd43dc-e5fd-43bc-babb-fe7ecb6ccd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfd43dc-e5fd-43bc-babb-fe7ecb6ccd00.jpg?1",
             "name": "Sorcerous Sight",
             "text": "Look at your opponent's hand. You draw a card. (Draw the card from your deck.)",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "f48b65ad-b88c-5204-b83a-f3e5007ac0c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe87b59-b456-4532-a695-0dea3110d878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe87b59-b456-4532-a695-0dea3110d878.jpg?1",
             "name": "Storm Crow",
             "text": "Flying",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "6763a230-d521-512c-9671-9fc7f74fda59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb2fa5-8f88-4d08-badb-3e52358d21d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb2fa5-8f88-4d08-badb-3e52358d21d6.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "e5eb9aa4-3039-503e-aa33-011b1a247492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55811106-9f30-4e34-924e-2c9401b49574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55811106-9f30-4e34-924e-2c9401b49574.jpg?1",
             "name": "Symbol of Unsummoning",
             "text": "Return any one creature to its owner's hand. You draw a card.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "24297d27-2fea-56ec-bccd-76af529e969a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d87322-aba4-4187-9655-1da1f18615f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d87322-aba4-4187-9655-1da1f18615f8.jpg?1",
             "name": "Taunt",
             "text": "Choose any one player. On that player's next turn, all his or her creatures that can attack you must do so.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "915ca991-1d1b-557b-bb42-fe0d5afb9b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ce2daa-8d47-4417-a5bb-3354a7c24bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ce2daa-8d47-4417-a5bb-3354a7c24bab.jpg?1",
             "name": "Taunt",
             "text": "",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "07f6937f-4905-5857-aa3b-ddb57b3d91e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29019e28-4ef8-4732-9972-0a47305fe303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29019e28-4ef8-4732-9972-0a47305fe303.jpg?1",
             "name": "Theft of Dreams",
             "text": "For each tapped creature your opponent has in play, you draw a card.",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "27b43196-c569-5ba6-b6a2-6ac349b88394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9682-7f3a-4857-9ecf-01f3530659fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9682-7f3a-4857-9ecf-01f3530659fc.jpg?1",
             "name": "Thing from the Deep",
             "text": "If Thing from the Deep attacks, destroy one of your islands or destroy Thing from the Deep.",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "da77969d-1307-567c-acaf-a491ea7a62cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027c31d-c662-4ce1-a0d1-a32e62f6a724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a027c31d-c662-4ce1-a0d1-a32e62f6a724.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap any one, two, or three creatures without flying. (Tapped creatures can't intercept.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "a49696ed-2136-5ea2-9b59-e49cbb19aff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd26ca-dc7d-453d-8653-7f967e8f6dc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fd26ca-dc7d-453d-8653-7f967e8f6dc7.jpg?1",
             "name": "Time Ebb",
             "text": "Return any one creature to the top of its owner's deck.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "3c65134c-f60d-57a8-81ef-f78d1fa1088c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196474ce-e28e-48f0-b407-dc5535adf1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196474ce-e28e-48f0-b407-dc5535adf1b6.jpg?1",
             "name": "Touch of Brilliance",
             "text": "Draw two cards.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "15acfd8c-02ac-525b-b20a-0d59d18ab084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5486d2dc-9a5d-4f58-a5ec-d94de54b852f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5486d2dc-9a5d-4f58-a5ec-d94de54b852f.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -2813,7 +2813,7 @@
         },
         {
             "id": "20a5c82b-b8ba-58d0-a16f-a93385597593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952a48-9e60-4fce-8423-7f0bafd29bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e952a48-9e60-4fce-8423-7f0bafd29bb1.jpg?1",
             "name": "Withering Gaze",
             "text": "Look at your opponent's hand. For each forest and green card there, you draw a card. (You draw from your deck.)",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "17ae61d5-5195-5775-ac7d-686cb3897b7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7342875-d49b-4fa7-a2fb-8dfc5e3d6e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7342875-d49b-4fa7-a2fb-8dfc5e3d6e4f.jpg?1",
             "name": "Arrogant Vampire",
             "text": "Flying",
             "colours": [
@@ -2877,7 +2877,7 @@
         },
         {
             "id": "9c6f7fe2-544c-5d92-b5c7-777a5c944561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80e8fe0-eccb-4268-a6ce-1365c68e6b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b80e8fe0-eccb-4268-a6ce-1365c68e6b13.jpg?1",
             "name": "Assassin's Blade",
             "text": "Play Assassin's Blade only after you're attacked, before you declare interceptors.\nDestroy any one attacking creature that isn't black.",
             "colours": [
@@ -2910,7 +2910,7 @@
         },
         {
             "id": "f22e8485-7401-5486-83a5-a980edf79cf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235f25bf-e079-4957-bbb1-0f90716275ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235f25bf-e079-4957-bbb1-0f90716275ad.jpg?1",
             "name": "Assassin's Blade",
             "text": "",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "81b5897f-f36f-595f-943a-a510063a5fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8681b3fd-33e5-4a45-8650-a4a142405096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8681b3fd-33e5-4a45-8650-a4a142405096.jpg?1",
             "name": "Bog Imp",
             "text": "Flying",
             "colours": [
@@ -2976,7 +2976,7 @@
         },
         {
             "id": "f89ca1fd-8fa7-5599-979b-75bf793f309d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bbb7a-b59a-4a01-b1cb-66eef881ffcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bbb7a-b59a-4a01-b1cb-66eef881ffcd.jpg?1",
             "name": "Bog Raiders",
             "text": "Swampwalk (If defending player has any swamps in play, Bog Raiders can't be intercepted.)",
             "colours": [
@@ -3009,7 +3009,7 @@
         },
         {
             "id": "e900c794-43d9-587c-916a-643ef4f70d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4487d7d0-d5a5-4b0c-bf30-e0ec511e9aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4487d7d0-d5a5-4b0c-bf30-e0ec511e9aa4.jpg?1",
             "name": "Bog Wraith",
             "text": "Swampwalk (If defending player has any swamps in play, Bog Wraith can't be intercepted.)",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "180a08f1-c565-54b1-9ff0-da71be102396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1721ee11-c7ee-4878-b2ab-4f090e0c5def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1721ee11-c7ee-4878-b2ab-4f090e0c5def.jpg?1",
             "name": "Charging Bandits",
             "text": "If Charging Bandits attacks, it gets +2/+0 until the end of the turn.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "36df5a31-b3bf-56d1-ade3-9627b7589b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cbae27-4a1a-4e16-8876-9a2925c45302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4cbae27-4a1a-4e16-8876-9a2925c45302.jpg?1",
             "name": "Craven Knight",
             "text": "Craven Knight can't intercept.",
             "colours": [
@@ -3110,7 +3110,7 @@
         },
         {
             "id": "0af2ef33-847e-5fda-8b06-8cbea8cdea82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96837a9e-dd68-4ce8-b760-0e1c22837164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96837a9e-dd68-4ce8-b760-0e1c22837164.jpg?1",
             "name": "Cruel Bargain",
             "text": "Draw four cards. You lose half your life, rounded up. (For example, if you have 11 life, you lose 6 life.)",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "982e153c-d084-588f-8769-080e41bc6e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05bfb5-dd36-44c5-a60d-43f7f8c68a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c05bfb5-dd36-44c5-a60d-43f7f8c68a6b.jpg?1",
             "name": "Cruel Tutor",
             "text": "Search your deck for any card. Shuffle your deck and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "771f8c40-388e-5714-8ebe-9c9467207c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ca934-6989-415b-8816-7c66d22b4707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0ca934-6989-415b-8816-7c66d22b4707.jpg?1",
             "name": "Dread Charge",
             "text": "This turn, your black creatures can be intercepted only by other black creatures.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "475a0af5-e7b9-5d53-b53b-629699370adc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb25d674-11f3-42d2-ba2f-e9a5d55a7852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb25d674-11f3-42d2-ba2f-e9a5d55a7852.jpg?1",
             "name": "Dread Reaper",
             "text": "Flying\nWhen Dread Reaper comes into play from your hand, you lose 5 life. (The person who plays Dread Reaper loses the life.)",
             "colours": [
@@ -3236,7 +3236,7 @@
         },
         {
             "id": "1f6599fd-f44e-50ba-87e1-9e1d1f629692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a142f369-8fdd-4dc8-b5d9-3493455cc588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a142f369-8fdd-4dc8-b5d9-3493455cc588.jpg?1",
             "name": "Dry Spell",
             "text": "Dry Spell deals 1 damage to each creature and player. (This includes your creatures and you.)",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "710705e6-7e03-5036-b439-235f166b48ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f10cf69-d3dc-43a4-9595-0f7d245c5efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f10cf69-d3dc-43a4-9595-0f7d245c5efa.jpg?1",
             "name": "Ebon Dragon",
             "text": "Flying\nWhen Ebon Dragon comes into play from your hand, you may force your opponent to choose and discard a card from his or her hand.",
             "colours": [
@@ -3300,7 +3300,7 @@
         },
         {
             "id": "0a9fc296-a750-546d-996b-eaa86d41d87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3d18b9-ad59-435b-934b-703e10287e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3d18b9-ad59-435b-934b-703e10287e32.jpg?1",
             "name": "Endless Cockroaches",
             "text": "If Endless Cockroaches is put into your discard pile from play, return Endless Cockroaches to your hand.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "6daea72e-ed16-541a-913c-c724c050ea20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f4c00-6bf8-440b-9761-b17a0e36c27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46f4c00-6bf8-440b-9761-b17a0e36c27e.jpg?1",
             "name": "Feral Shadow",
             "text": "Flying",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "0b9699f6-adc7-5212-a9a5-0f56a4847936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200365f5-05a1-461e-904e-daf99f4b92bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200365f5-05a1-461e-904e-daf99f4b92bb.jpg?1",
             "name": "Feral Shadow",
             "text": "",
             "colours": [
@@ -3403,7 +3403,7 @@
         },
         {
             "id": "0491d03f-e4e4-5bd3-b5b5-55394caa8e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdfcb03-2f77-4f54-af62-3012cd3efd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecdfcb03-2f77-4f54-af62-3012cd3efd4f.jpg?1",
             "name": "Final Strike",
             "text": "Choose one of your creatures. Final Strike deals to your opponent damage equal to that creature's offense. Then, put the creature in your discard pile.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "058bbaab-64ee-5153-95e4-67486c645852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979d70e-d514-420f-886c-f60e2bb1861f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979d70e-d514-420f-886c-f60e2bb1861f.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play from your hand, you may choose to return a summon creature from your discard pile to your hand.",
             "colours": [
@@ -3467,7 +3467,7 @@
         },
         {
             "id": "a97e1cae-adf2-539e-95c5-3ac5957ff208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f136b8-52be-49b9-919b-2b9785254350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f136b8-52be-49b9-919b-2b9785254350.jpg?1",
             "name": "Hand of Death",
             "text": "Destroy any one creature that isn't black. (A creature is black if it has o\nB in its cost.)",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "ea3ed272-c08f-5537-b152-4d4e7cbec7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64afd70a-cde2-4980-9ec9-275e6198b40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64afd70a-cde2-4980-9ec9-275e6198b40f.jpg?1",
             "name": "Hand of Death",
             "text": "Destroy any one creature that isn't black.",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "f51a448b-fef0-50c1-9814-8d0b5cd92260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a7c61-8696-4bab-9c96-05028db3a9f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49a7c61-8696-4bab-9c96-05028db3a9f9.jpg?1",
             "name": "Howling Fury",
             "text": "Any one creature gets +4/+0 until the end of the turn.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "7c48b22e-a7f8-5c96-8f4a-289ae1da2cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a3149-54fb-4fd2-bc66-3ee9bcc3519d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670a3149-54fb-4fd2-bc66-3ee9bcc3519d.jpg?1",
             "name": "King's Assassin",
             "text": "On your turn, before you attack, you may tap King's Assassin to destroy any one tapped creature.",
             "colours": [
@@ -3598,7 +3598,7 @@
         },
         {
             "id": "f8e2bd41-4eaa-531a-98d9-09cdfc7150e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f97a2-b04e-418b-89c7-1c019288f27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f97a2-b04e-418b-89c7-1c019288f27a.jpg?1",
             "name": "Mercenary Knight",
             "text": "When Mercenary Knight comes into play from your hand, choose and discard a summon creature from your hand or destroy Mercenary Knight.",
             "colours": [
@@ -3633,7 +3633,7 @@
         },
         {
             "id": "705ce6ac-ae24-540a-a684-4a7ca3fe3549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17e23a6-6313-416d-b826-5df5833371dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17e23a6-6313-416d-b826-5df5833371dc.jpg?1",
             "name": "Mind Knives",
             "text": "Your opponent discards a card at random from his or her hand.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "924737f2-81db-5730-b580-a27271b53dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91d355d-8409-4f0b-87ce-7590a8b9ebc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b91d355d-8409-4f0b-87ce-7590a8b9ebc0.jpg?1",
             "name": "Mind Rot",
             "text": "Your opponent chooses and discards two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "da583dd0-cdb6-5a6d-8868-1c4a02da0070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4041226-7ce2-46d1-8844-20fa50b6568a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4041226-7ce2-46d1-8844-20fa50b6568a.jpg?1",
             "name": "Muck Rats",
             "text": "",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "f6ee2168-6587-5e37-9eff-fbca593a05ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5950f52a-493e-432e-9175-0272c0edb232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5950f52a-493e-432e-9175-0272c0edb232.jpg?1",
             "name": "Nature's Ruin",
             "text": "Destroy all green creatures. (This includes your green creatures.)",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "0bc4846a-53ce-5088-b0cc-5aabc4a17e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec75ba-bae2-4ccc-b18b-ad4639cfb548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5ec75ba-bae2-4ccc-b18b-ad4639cfb548.jpg?1",
             "name": "Noxious Toad",
             "text": "If Noxious Toad is put into your discard pile from play, your opponent chooses and discards a card from his or her hand.",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "71bce205-f0a5-5949-8dca-e911bc3266ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c552a1-6245-4caf-8249-765ce7ea80d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82c552a1-6245-4caf-8249-765ce7ea80d2.jpg?1",
             "name": "Python",
             "text": "",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "1ca45e63-1613-5b16-b3e9-8aed1c14f70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803ba4ef-24ed-4f45-aed8-f9442322e31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803ba4ef-24ed-4f45-aed8-f9442322e31e.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy any one land.",
             "colours": [
@@ -3856,7 +3856,7 @@
         },
         {
             "id": "7e553249-7790-5013-b99d-b150824371d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0584553-a25e-4030-ab39-53550cba3f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0584553-a25e-4030-ab39-53550cba3f0b.jpg?1",
             "name": "Raise Dead",
             "text": "Return any one summon creature from your discard pile to your hand.",
             "colours": [
@@ -3889,7 +3889,7 @@
         },
         {
             "id": "2b1d34a4-040b-51ea-8b35-d19e56791350",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c06d6-d20d-4aa6-85f8-ed6b75007330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/045c06d6-d20d-4aa6-85f8-ed6b75007330.jpg?1",
             "name": "Raise Dead",
             "text": "",
             "colours": [
@@ -3922,7 +3922,7 @@
         },
         {
             "id": "fc9d7052-3055-519f-8cee-dd3ed2fe9340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018f6ff-5eaa-4fe1-ba20-544df799f5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1018f6ff-5eaa-4fe1-ba20-544df799f5b2.jpg?1",
             "name": "Serpent Assassin",
             "text": "When Serpent Assassin comes into play from your hand, you may choose to destroy any one creature that isn't black.",
             "colours": [
@@ -3956,7 +3956,7 @@
         },
         {
             "id": "e89e626b-34a4-5560-93e8-25f3af514a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c364fd06-64c5-45f6-8ed5-64f44a1e8bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c364fd06-64c5-45f6-8ed5-64f44a1e8bda.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play from your hand, you lose 3 life. (The person who plays Serpent Warrior loses the life.)",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "0a07c5ad-ee69-54aa-91a2-5d9bc77a9567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcbbd6f-2915-4b4c-85d3-1d9b55d36c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcbbd6f-2915-4b4c-85d3-1d9b55d36c11.jpg?1",
             "name": "Skeletal Crocodile",
             "text": "",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "f2aca4ce-dfa6-57e8-aa78-f8bef39d4c61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bd4896-4191-4479-be57-070753f8725c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42bd4896-4191-4479-be57-070753f8725c.jpg?1",
             "name": "Skeletal Snake",
             "text": "",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "cd6f476c-f435-516c-9521-55645fbe33c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990902d2-9594-4963-807c-48a90324d487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/990902d2-9594-4963-807c-48a90324d487.jpg?1",
             "name": "Soul Shred",
             "text": "Soul Shred deals 3 damage to any one creature that isn't black. You gain 3 life.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "06904be9-38a5-5247-a3fe-22dec94e6aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c95c752-3add-4830-8159-036b8689f40a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c95c752-3add-4830-8159-036b8689f40a.jpg?1",
             "name": "Undying Beast",
             "text": "If Undying Beast is put into your discard pile from play, put Undying Beast on top of your deck.",
             "colours": [
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "a4e612c4-b7f5-5e3d-9234-633ec5dcc82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19500ffb-bfad-46d6-8a6e-d134405959c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19500ffb-bfad-46d6-8a6e-d134405959c0.jpg?1",
             "name": "Vampiric Feast",
             "text": "Vampiric Feast deals 4 damage to any one creature or player. You gain 4 life.",
             "colours": [
@@ -4155,7 +4155,7 @@
         },
         {
             "id": "8d0d24eb-21c6-564c-9d55-3b8b1cf1cb3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfc875c-e79e-435a-906f-fb7e88550f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfc875c-e79e-435a-906f-fb7e88550f01.jpg?1",
             "name": "Vampiric Feast",
             "text": "",
             "colours": [
@@ -4188,7 +4188,7 @@
         },
         {
             "id": "33ae2400-0016-5acb-b1ce-5a5704d49f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231f7598-8c47-4828-8240-e2a545a7ac5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231f7598-8c47-4828-8240-e2a545a7ac5b.jpg?1",
             "name": "Vampiric Touch",
             "text": "Vampiric Touch deals 2 damage to your opponent. You gain 2 life.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "3c528b1d-dc79-555a-adb8-7e793adc91b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7854928a-d467-4616-b96b-de7e5fe7303e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7854928a-d467-4616-b96b-de7e5fe7303e.jpg?1",
             "name": "Virtue's Ruin",
             "text": "Destroy all white creatures. (This includes your white creatures.)",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "71cb32cb-1dc2-573b-95f9-ed4c0bd85412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d7c251-cb65-4ffc-8bf0-5e9692004a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d7c251-cb65-4ffc-8bf0-5e9692004a87.jpg?1",
             "name": "Wicked Pact",
             "text": "Destroy any two creatures that aren't black. You lose 5 life. (You can't play Wicked Pact unless you can choose two creatures to destroy.)",
             "colours": [
@@ -4283,7 +4283,7 @@
         },
         {
             "id": "507fa887-3dae-59f1-9915-b160a143c7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc849bf-9c29-41a7-8fc0-ad0137c5724e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdc849bf-9c29-41a7-8fc0-ad0137c5724e.jpg?1",
             "name": "Wicked Pact",
             "text": "",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "744f9c1e-8bad-5501-97cb-57cb8c3ce808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175c959-3b5d-46a3-9194-fad2359bbff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f175c959-3b5d-46a3-9194-fad2359bbff9.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "926d19d0-8292-5983-a90f-32e84be8d257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8d48-539e-4eb4-9ac1-025722aae459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0d8d48-539e-4eb4-9ac1-025722aae459.jpg?1",
             "name": "Blaze",
             "text": "",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "73b7e8ec-6b0c-5c35-92ca-dc0cd1156456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab9da23-624e-4c33-ab5d-82a30015b0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab9da23-624e-4c33-ab5d-82a30015b0e7.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player. (For example, if you tap a mountain plus four other lands when you play Blaze, it deals 4 damage.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "5bdcf2f7-f8a0-52e0-9690-be68f0a6c2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1523c1b-2ba1-4581-8502-47544d450d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1523c1b-2ba1-4581-8502-47544d450d8e.jpg?1",
             "name": "Boiling Seas",
             "text": "Destroy all islands. (This includes your islands.)",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "bfdd2f5e-9ddb-5eda-8927-894c50b4e326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b8f443-dba5-45a5-bb2e-f57b4fdd1d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b8f443-dba5-45a5-bb2e-f57b4fdd1d01.jpg?1",
             "name": "Burning Cloak",
             "text": "Any one creature gets +2/+0 until the end of the turn.\nBurning Cloak deals 2 damage to that creature.",
             "colours": [
@@ -4480,7 +4480,7 @@
         },
         {
             "id": "930af056-7db9-530c-aff0-bfa899e847f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e1c12-f848-43b4-9505-851c66a509f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e1c12-f848-43b4-9505-851c66a509f1.jpg?1",
             "name": "Craven Giant",
             "text": "Craven Giant can't intercept.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "0d46fc50-7b80-5b94-b60e-15c94f25f4fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24673b35-aed2-40c0-a4ae-93bc4d392562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24673b35-aed2-40c0-a4ae-93bc4d392562.jpg?1",
             "name": "Desert Drake",
             "text": "Flying",
             "colours": [
@@ -4546,7 +4546,7 @@
         },
         {
             "id": "dff99c94-f218-5b27-a788-35c53f1fc197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cce019-162c-4969-89ac-1cf94148a032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71cce019-162c-4969-89ac-1cf94148a032.jpg?1",
             "name": "Devastation",
             "text": "Destroy all creatures and lands. (This includes your creatures and lands.)",
             "colours": [
@@ -4577,7 +4577,7 @@
         },
         {
             "id": "29a217c1-496a-52d9-a48e-2331b38b2075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272f65a3-3c0c-417d-b5b6-276a643d643e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/272f65a3-3c0c-417d-b5b6-276a643d643e.jpg?1",
             "name": "Earthquake",
             "text": "Earthquake deals X damage to each player and each creature without flying. (This includes you and your creatures without flying.)",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "f1a29989-a38d-5c4e-b99e-f6c162c7cf6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1f26d1-4381-470a-bfbf-ef226f980597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1f26d1-4381-470a-bfbf-ef226f980597.jpg?1",
             "name": "Fire Dragon",
             "text": "Flying\nWhen Fire Dragon comes into play from your hand, it deals to any one creature damage equal to the number of mountains you have in play.",
             "colours": [
@@ -4641,7 +4641,7 @@
         },
         {
             "id": "45c75de8-e504-5ad6-8d7c-75a2c772ab32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edaf3-7941-4085-bdbc-e5c9832b6444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7edaf3-7941-4085-bdbc-e5c9832b6444.jpg?1",
             "name": "Fire Imp",
             "text": "When Fire Imp comes into play from your hand, it deals 2 damage to any one creature. (If you're the only player with creatures, Fire Imp deals 2 damage to one of your creatures.)",
             "colours": [
@@ -4674,7 +4674,7 @@
         },
         {
             "id": "70cb9bd2-65c4-5083-b98c-6eb16b6db6de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c36e32-59e8-4e3d-903e-a264211f2a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c36e32-59e8-4e3d-903e-a264211f2a82.jpg?1",
             "name": "Fire Snake",
             "text": "If Fire Snake is put into your discard pile from play, destroy any one land.",
             "colours": [
@@ -4707,7 +4707,7 @@
         },
         {
             "id": "c68f8555-55fb-5ec7-a47c-04265dcd0892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92334ebe-3d7a-46de-8b91-931e5d56a5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92334ebe-3d7a-46de-8b91-931e5d56a5a5.jpg?1",
             "name": "Fire Tempest",
             "text": "Fire Tempest deals 6 damage to each creature and player. (This includes your creatures and you. If all players drop to 0 life or less, the game is a draw.)",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "6c96bd5a-bf5f-5fd2-afef-9c88610ac906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e88867-6acb-43f8-806b-21480aaa1afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e88867-6acb-43f8-806b-21480aaa1afc.jpg?1",
             "name": "Flashfires",
             "text": "Destroy all plains. (This includes your plains.)",
             "colours": [
@@ -4769,7 +4769,7 @@
         },
         {
             "id": "4986aeaf-1f4f-51e7-8875-41f9ffe1dcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85883197-fd55-4e82-862f-87be4f789493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85883197-fd55-4e82-862f-87be4f789493.jpg?1",
             "name": "Forked Lightning",
             "text": "Forked Lightning deals 4 damage divided any way you choose among any one, two, or three creatures.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "df8f44b9-d545-59a8-a0ce-015cdbeb34d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2094f2f6-8b38-47d6-973d-271986b5d982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2094f2f6-8b38-47d6-973d-271986b5d982.jpg?1",
             "name": "Goblin Bully",
             "text": "",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "1229e660-133d-56cc-9846-e04aa11d032b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f49716-1522-4f36-92c9-63ef2059c4ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f49716-1522-4f36-92c9-63ef2059c4ef.jpg?1",
             "name": "Highland Giant",
             "text": "",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "27f2aaa4-7a4b-552c-b266-b7e0dc814f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd36579-c108-40c0-bce4-38ab837a8c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd36579-c108-40c0-bce4-38ab837a8c65.jpg?1",
             "name": "Hill Giant",
             "text": "",
             "colours": [
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "b57805f1-d9fb-54e4-be0f-9b4f7117b511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ae982-8a70-4dd3-8254-0d447954f580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ae982-8a70-4dd3-8254-0d447954f580.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops can't intercept.",
             "colours": [
@@ -4934,7 +4934,7 @@
         },
         {
             "id": "d96d9173-7e82-501a-9f51-ef87cc61d929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca7851-1267-4dcc-ab5d-0ab205624562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ca7851-1267-4dcc-ab5d-0ab205624562.jpg?1",
             "name": "Hulking Cyclops",
             "text": "",
             "colours": [
@@ -4969,7 +4969,7 @@
         },
         {
             "id": "32b2204d-1250-52d3-9958-454e1bc9e386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3eead8-7e07-4463-9e67-c396d2d7931e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3eead8-7e07-4463-9e67-c396d2d7931e.jpg?1",
             "name": "Hulking Goblin",
             "text": "Hulking Goblin can't intercept.",
             "colours": [
@@ -5002,7 +5002,7 @@
         },
         {
             "id": "9f2dd65b-f09a-5d7f-97a9-974c3c1ab5b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f2c423-1694-466e-9a7d-4ec99e53578d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f2c423-1694-466e-9a7d-4ec99e53578d.jpg?1",
             "name": "Last Chance",
             "text": "Take another turn after this one. You lose the game at the end of that turn. (You don't lose if you've already won.)",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "8e383a51-4d11-5f2d-9258-34bd61248e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bebbad-76aa-4388-891a-583e8af9509d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bebbad-76aa-4388-891a-583e8af9509d.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to your opponent.",
             "colours": [
@@ -5064,7 +5064,7 @@
         },
         {
             "id": "f7099840-f20f-5e69-87e3-6ff7a0c769e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e825e4-98be-49f0-bc5e-c8988118dcef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e825e4-98be-49f0-bc5e-c8988118dcef.jpg?1",
             "name": "Lava Flow",
             "text": "Destroy any one creature or land.",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "b5c9e9fa-10f3-5747-a471-6d823de92a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053cd970-5b79-410b-8420-82d9a490b897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053cd970-5b79-410b-8420-82d9a490b897.jpg?1",
             "name": "Lizard Warrior",
             "text": "",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "bb156d73-ba18-58ab-82d1-bf30de5e6625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694f5db-a4ad-4abd-acff-d6b340d2387c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c694f5db-a4ad-4abd-acff-d6b340d2387c.jpg?1",
             "name": "Minotaur Warrior",
             "text": "",
             "colours": [
@@ -5163,7 +5163,7 @@
         },
         {
             "id": "dce40ade-1ac0-58b3-8554-995a2b3e92e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325100f1-d424-4db0-bfa9-24877156c0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325100f1-d424-4db0-bfa9-24877156c0ba.jpg?1",
             "name": "Mountain Goat",
             "text": "Mountainwalk (If defending player has any mountains in play, Mountain Goat can't be intercepted.)",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "fab4d2d4-336c-51c9-8a92-56662dc67723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daad744-e6b2-4bd8-83df-2e97e9e60d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daad744-e6b2-4bd8-83df-2e97e9e60d16.jpg?1",
             "name": "Pillaging Horde",
             "text": "When Pillaging Horde comes into play from your hand, discard a card at random from your hand or destroy Pillaging Horde.",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "2abd5445-eb9a-564d-afef-0d8ca4c7e02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de214247-e5e3-4d8f-935a-797218416be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de214247-e5e3-4d8f-935a-797218416be1.jpg?1",
             "name": "Pyroclasm",
             "text": "Pyroclasm deals 2 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "7222da2c-ae5a-58e6-a1dc-3acc85cce18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d126a-9db9-4adc-9cf6-11408c63201d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d126a-9db9-4adc-9cf6-11408c63201d.jpg?1",
             "name": "Raging Cougar",
             "text": "Raging Cougar is unaffected by summoning sickness.",
             "colours": [
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "7fb39bce-19e7-5def-91cd-265fe6be19f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed57a17-7847-4e60-bc40-4452880f12a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed57a17-7847-4e60-bc40-4452880f12a3.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness.",
             "colours": [
@@ -5330,7 +5330,7 @@
         },
         {
             "id": "e410cea1-ca02-5fce-b4e9-ad8b6dfb6a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0fa444-5534-4476-8bfa-78b2364f2dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0fa444-5534-4476-8bfa-78b2364f2dd3.jpg?1",
             "name": "Raging Goblin",
             "text": "Raging Goblin is unaffected by summoning sickness. (It can attack the turn you play it, unless another card prevents this.)",
             "colours": [
@@ -5366,7 +5366,7 @@
         },
         {
             "id": "a6e9d24f-26a9-55be-816f-4b2db03fa2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea4be95-8147-431c-8bb8-8fe7e5a2ad53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea4be95-8147-431c-8bb8-8fe7e5a2ad53.jpg?1",
             "name": "Raging Minotaur",
             "text": "Raging Minotaur is unaffected by summoning sickness.",
             "colours": [
@@ -5400,7 +5400,7 @@
         },
         {
             "id": "b4937a8b-6d56-5956-ab52-bb619dda2e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661ffab2-9cf5-492d-874f-de73d7a13e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/661ffab2-9cf5-492d-874f-de73d7a13e2b.jpg?1",
             "name": "Rain of Salt",
             "text": "Destroy any two lands.",
             "colours": [
@@ -5431,7 +5431,7 @@
         },
         {
             "id": "152db94d-231f-51b0-846c-25a35c7ccdc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4817bd-68e8-4a85-983a-ee6dda2bbf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e4817bd-68e8-4a85-983a-ee6dda2bbf33.jpg?1",
             "name": "Scorching Spear",
             "text": "Scorching Spear deals 1 damage to any one creature or player.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "c3b9d48d-ddd1-5866-8e7c-28d770e48fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec371e-d4ba-439f-b1b8-2aac3f5b36bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fec371e-d4ba-439f-b1b8-2aac3f5b36bf.jpg?1",
             "name": "Scorching Winds",
             "text": "Play Scorching Winds only after you're attacked, before you declare interceptors.\nScorching Winds deals 1 damage to each attacking creature.",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "34171bda-9d1f-5f12-ad9f-2db02c2d398f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb16998c-cfa4-49cc-8e37-2dfc33fa2f1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb16998c-cfa4-49cc-8e37-2dfc33fa2f1e.jpg?1",
             "name": "Spitting Earth",
             "text": "Spitting Earth deals to any one creature damage equal to the number of mountains you have in play. (This includes both tapped and untapped mountains.)",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "61148866-6288-5369-9922-cfc0f7b2769a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f84a13-d7dc-491b-a77c-1b99b6797d7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f84a13-d7dc-491b-a77c-1b99b6797d7e.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy any one land.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "d26bd36a-1417-58dd-8376-65d3738e9c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a9f3f5-c80f-47a4-bf84-b7262437017f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a9f3f5-c80f-47a4-bf84-b7262437017f.jpg?1",
             "name": "Thundermare",
             "text": "Thundermare is unaffected by summoning sickness.\nWhen Thundermare comes into play from your hand, tap all other creatures. (This includes your creatures.)",
             "colours": [
@@ -5589,7 +5589,7 @@
         },
         {
             "id": "2549d446-7e97-5255-9489-61990dbb4ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99c5c70-7568-42d3-939c-b6ee1ed94b9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99c5c70-7568-42d3-939c-b6ee1ed94b9f.jpg?1",
             "name": "Volcanic Dragon",
             "text": "Flying\nVolcanic Dragon is unaffected by summoning sickness.",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "3f2fd372-c7d9-5878-9c42-9f0e2ab13321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9563d7c1-4ed1-4919-b0b8-ea1ec9d4bbf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9563d7c1-4ed1-4919-b0b8-ea1ec9d4bbf6.jpg?1",
             "name": "Volcanic Hammer",
             "text": "Volcanic Hammer deals 3 damage to any one creature or player.",
             "colours": [
@@ -5653,7 +5653,7 @@
         },
         {
             "id": "ccc16e04-6cd9-5e2c-9ba0-6e306c5f85c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c5ac71-bf45-4b99-8184-36ce88dd728a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c5ac71-bf45-4b99-8184-36ce88dd728a.jpg?1",
             "name": "Wall of Granite",
             "text": "Wall of Granite can't attack.",
             "colours": [
@@ -5686,7 +5686,7 @@
         },
         {
             "id": "754a66ac-e376-54a5-a734-1923dee297f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b8aec-62d4-46db-9a68-a6c69cb6fd98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/735b8aec-62d4-46db-9a68-a6c69cb6fd98.jpg?1",
             "name": "Winds of Change",
             "text": "Each player counts the cards in his or her hand, shuffles those cards into his or her deck, and then draws that many cards. (When you play Winds of Change, it doesn't count as a card in your hand.)",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "bbcb1ca9-df3b-5441-abc8-92a39a0d7d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726242e-bfd8-4ed5-a016-ac0c82e4762b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8726242e-bfd8-4ed5-a016-ac0c82e4762b.jpg?1",
             "name": "Alluring Scent",
             "text": "Choose any one creature. This turn, all creatures able to intercept that creature do so.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "263836cf-f2fe-54d1-9a78-3fb7c2006a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2012ad-6425-4935-83af-fc7309ec2ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2012ad-6425-4935-83af-fc7309ec2ece.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (If defending player has any swamps in play, Anaconda can't be intercepted.)",
             "colours": [
@@ -5783,7 +5783,7 @@
         },
         {
             "id": "c8b7c22f-1a06-5b51-8e4c-37a97fa8f47f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffba7a5-8845-46f4-bb86-4722d6cbd4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ffba7a5-8845-46f4-bb86-4722d6cbd4c1.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (If defending player has any swamps in play, Anaconda can't be intercepted. Swamps are in play regardless of whether they're tapped or untapped.)",
             "colours": [
@@ -5818,7 +5818,7 @@
         },
         {
             "id": "9175f689-027c-5cde-aeb8-e1d17c8fe91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcf64a-ae3d-4abb-acc7-81bba237f37b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcf64a-ae3d-4abb-acc7-81bba237f37b.jpg?1",
             "name": "Bee Sting",
             "text": "Bee Sting deals 2 damage to any one creature or player.",
             "colours": [
@@ -5849,7 +5849,7 @@
         },
         {
             "id": "83bf932d-33c7-5089-993d-d3dc12fcccf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dd236b-94fc-4c56-aeae-215c71a009ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dd236b-94fc-4c56-aeae-215c71a009ea.jpg?1",
             "name": "Bull Hippo",
             "text": "Islandwalk (If defending player has any islands in play, Bull Hippo can't be intercepted.)",
             "colours": [
@@ -5884,7 +5884,7 @@
         },
         {
             "id": "d37b7dff-e00e-5785-9671-4bcf97dfe240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbe115b-ded7-4749-95e2-b69bff26fc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbe115b-ded7-4749-95e2-b69bff26fc74.jpg?1",
             "name": "Bull Hippo",
             "text": "",
             "colours": [
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "1ae26179-d8d3-5ed0-9bf9-fb9dc4684636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e47248-051c-4ee6-aad2-352ebd1f38ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e47248-051c-4ee6-aad2-352ebd1f38ca.jpg?1",
             "name": "Charging Rhino",
             "text": "Charging Rhino can't be intercepted by more than one creature.",
             "colours": [
@@ -5952,7 +5952,7 @@
         },
         {
             "id": "e0a94f62-a38c-5587-9257-94ea290d1b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216c5aa-9df0-4e7c-b3e9-a3f712b17ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4216c5aa-9df0-4e7c-b3e9-a3f712b17ce7.jpg?1",
             "name": "Deep Wood",
             "text": "Play Deep Wood only after you're attacked, before you declare interceptors.\nThis turn, all damage dealt to you by attacking creatures is reduced to 0.",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "189dd8e1-7412-53b5-b8a0-56443c5e8349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7396c4e9-b0d8-4b8f-8c17-6f913a967b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7396c4e9-b0d8-4b8f-8c17-6f913a967b17.jpg?1",
             "name": "Elite Cat Warrior",
             "text": "Forestwalk (If defending player has any forests in play, Elite Cat Warrior can't be intercepted.)",
             "colours": [
@@ -6019,7 +6019,7 @@
         },
         {
             "id": "844d01a4-2cb5-5c52-b132-7221d3a84c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4d16b-5bfc-4e35-8a8e-16cf84f54586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a4d16b-5bfc-4e35-8a8e-16cf84f54586.jpg?1",
             "name": "Elite Cat Warrior",
             "text": "Forestwalk (If defending player has any forests in play, Elite Cat Warrior can't be intercepted. Forests are in play regardless of whether they're tapped or untapped.)",
             "colours": [
@@ -6055,7 +6055,7 @@
         },
         {
             "id": "fc006f54-6a8f-52d0-a0db-41305cac4d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68939020-eb6a-4d77-a850-4df96cf01918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68939020-eb6a-4d77-a850-4df96cf01918.jpg?1",
             "name": "Elven Cache",
             "text": "Return any one card from your discard pile to your hand.",
             "colours": [
@@ -6088,7 +6088,7 @@
         },
         {
             "id": "e019addd-eaf5-5aa7-865c-3c2c9a76f6e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0b0afb-75c0-4613-be3b-f4b739fa7954.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0b0afb-75c0-4613-be3b-f4b739fa7954.jpg?1",
             "name": "Elven Cache",
             "text": "",
             "colours": [
@@ -6121,7 +6121,7 @@
         },
         {
             "id": "d46fcdcb-62b0-53f4-9f4c-c5f442e88591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26caff65-3a96-46f2-8f0b-e5091b632a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26caff65-3a96-46f2-8f0b-e5091b632a2e.jpg?1",
             "name": "Elvish Ranger",
             "text": "",
             "colours": [
@@ -6155,7 +6155,7 @@
         },
         {
             "id": "fad5903a-b3e9-5cad-ad46-10f6f58d15e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147082a3-1408-44f9-ab39-f069cee5c710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147082a3-1408-44f9-ab39-f069cee5c710.jpg?1",
             "name": "Fruition",
             "text": "For each forest you and your opponent have in play, you gain 1 life.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "d4c53a0d-da42-5a31-b2dc-734776b1a80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695fcf4-1eef-4671-a11e-da6b1ff8d466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e695fcf4-1eef-4671-a11e-da6b1ff8d466.jpg?1",
             "name": "Fruition",
             "text": "",
             "colours": [
@@ -6221,7 +6221,7 @@
         },
         {
             "id": "756a24f4-3498-5662-8aaa-d441014bbf07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995530c-16bd-4dcb-99c2-008bba00052c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2995530c-16bd-4dcb-99c2-008bba00052c.jpg?1",
             "name": "Giant Spider",
             "text": "Giant Spider can intercept as though it had flying.",
             "colours": [
@@ -6254,7 +6254,7 @@
         },
         {
             "id": "d24e95e9-948e-5ad4-82ab-c974f4a7645a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f9c3f3-0d4d-4eec-bd14-9be3233178dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f9c3f3-0d4d-4eec-bd14-9be3233178dc.jpg?1",
             "name": "Gorilla Warrior",
             "text": "",
             "colours": [
@@ -6288,7 +6288,7 @@
         },
         {
             "id": "c5f10306-f840-51c6-b438-fb194724527d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1b99c-97d0-48f2-bfdf-faa65bc0b608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1b99c-97d0-48f2-bfdf-faa65bc0b608.jpg?1",
             "name": "Grizzly Bears",
             "text": "",
             "colours": [
@@ -6321,7 +6321,7 @@
         },
         {
             "id": "542ec783-c856-54d8-a809-07ff57e9b9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b97904e-80ba-4d65-808a-a528200430f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b97904e-80ba-4d65-808a-a528200430f8.jpg?1",
             "name": "Hurricane",
             "text": "Hurricane deals X damage to each player and each creature with flying. (This includes you and your creatures with flying.)",
             "colours": [
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "0151cfd9-168f-5eef-a7f7-2b1c1dcc0ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ceee3-92c7-46f1-8267-d6229ab15df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613ceee3-92c7-46f1-8267-d6229ab15df5.jpg?1",
             "name": "Jungle Lion",
             "text": "Jungle Lion can't intercept.",
             "colours": [
@@ -6385,7 +6385,7 @@
         },
         {
             "id": "b9ceee94-3af8-563d-ba50-1f587e9b5585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9712ecaa-4059-44ba-98b7-07bfe7411b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9712ecaa-4059-44ba-98b7-07bfe7411b5b.jpg?1",
             "name": "Mobilize",
             "text": "Untap all your creatures.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "40f6a94d-3a35-5f1f-ad92-aa12138f73d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2edb9-0b53-432e-bb3b-171d2a85439d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd2edb9-0b53-432e-bb3b-171d2a85439d.jpg?1",
             "name": "Monstrous Growth",
             "text": "Any one creature gets +4/+4 until the end of the turn.",
             "colours": [
@@ -6449,7 +6449,7 @@
         },
         {
             "id": "0740eb1a-ad8b-5850-a227-b95968995eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523c816-dddf-4b63-8db8-5e41dc673e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523c816-dddf-4b63-8db8-5e41dc673e5f.jpg?1",
             "name": "Monstrous Growth",
             "text": "Any one creature gets +4/+4 until the end of the turn. (For example, a 6/3 creature would become 10/7.)",
             "colours": [
@@ -6482,7 +6482,7 @@
         },
         {
             "id": "25b6ed49-af73-5908-be25-a23d773ec577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0944759-ee9f-4ae0-9d1b-2533ff6791a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0944759-ee9f-4ae0-9d1b-2533ff6791a2.jpg?1",
             "name": "Moon Sprite",
             "text": "Flying",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "ddb98d47-b0d1-575c-8b99-fb21386074f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecb34f8-6961-4c27-9368-26d156714d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecb34f8-6961-4c27-9368-26d156714d7b.jpg?1",
             "name": "Natural Order",
             "text": "Search your deck for a green summon creature and put that card into play. Treat it as though you just played it from your hand. Then put one of your green creatures into your discard pile. Shuffle your deck afterwards.",
             "colours": [
@@ -6546,7 +6546,7 @@
         },
         {
             "id": "2e8407af-68cd-576a-9625-0aadcce9c46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfc1cc-5c13-443c-a0ae-0bcc931923e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfc1cc-5c13-443c-a0ae-0bcc931923e7.jpg?1",
             "name": "Natural Spring",
             "text": "You gain 8 life.",
             "colours": [
@@ -6577,7 +6577,7 @@
         },
         {
             "id": "ca805058-bd33-5a83-9347-8d27644a2fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfaba58-d0ab-4d1d-91dd-48543c862165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfaba58-d0ab-4d1d-91dd-48543c862165.jpg?1",
             "name": "Nature's Cloak",
             "text": "All your green creatures gain forestwalk until the end of the turn. (If defending player has any forests in play, none of your green creatures can be intercepted.)",
             "colours": [
@@ -6608,7 +6608,7 @@
         },
         {
             "id": "57ac8211-7439-5210-b744-19dedc8d52ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5242227-d033-4e03-b1e6-b334b17bb158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5242227-d033-4e03-b1e6-b334b17bb158.jpg?1",
             "name": "Nature's Lore",
             "text": "Search your deck for a forest and put that card into play. Shuffle your deck afterwards.",
             "colours": [
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "4df18683-a323-57a4-912e-c4e9414d28de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a44e44-94b1-4bd2-8e00-6bd2ec07ee4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a44e44-94b1-4bd2-8e00-6bd2ec07ee4c.jpg?1",
             "name": "Needle Storm",
             "text": "Needle Storm deals 4 damage to each creature with flying. (This includes your creatures with flying.)",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "734551ab-9679-5c08-bfe6-f0a73303070b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be610ce-5b84-416e-b427-98887642ff01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be610ce-5b84-416e-b427-98887642ff01.jpg?1",
             "name": "Panther Warriors",
             "text": "",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "cdfccea6-5623-5e30-b014-b9954608f09a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892594db-1d66-4c45-bd54-608a9972ca77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892594db-1d66-4c45-bd54-608a9972ca77.jpg?1",
             "name": "Plant Elemental",
             "text": "When Plant Elemental comes into play from your hand, destroy one of your forests or destroy Plant Elemental.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "3d4c007b-765d-5974-ae66-ba7995ce5e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce7fc51-0ed8-49d9-bdba-ba5a89e1e852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce7fc51-0ed8-49d9-bdba-ba5a89e1e852.jpg?1",
             "name": "Primeval Force",
             "text": "When Primeval Force comes into play from your hand, destroy three of your forests or destroy Primeval Force.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "717df58c-4080-54b0-a272-b53953eb579b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9399667-ae2a-4b64-84dd-8f97f3e5fe79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9399667-ae2a-4b64-84dd-8f97f3e5fe79.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "34c97a31-117b-52a9-84cb-a5ddcee5b66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852a0956-8558-4754-ab57-6f1cc4de740e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852a0956-8558-4754-ab57-6f1cc4de740e.jpg?1",
             "name": "Rowan Treefolk",
             "text": "",
             "colours": [
@@ -6837,7 +6837,7 @@
         },
         {
             "id": "de7f95f6-d179-5fee-91e1-826b8ff02e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053bd00-90fd-48c2-8f79-952d5d1e3e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0053bd00-90fd-48c2-8f79-952d5d1e3e74.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "cba02608-3101-5476-8854-ef8746d5e042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc78337-2d1a-4a1d-8630-fcf7a7f6abce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc78337-2d1a-4a1d-8630-fcf7a7f6abce.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be intercepted by more than one creature.",
             "colours": [
@@ -6903,7 +6903,7 @@
         },
         {
             "id": "aa046c0b-61a0-5696-8c2d-3f4c8b79bdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e86abcc-272e-4959-90ee-343b9f546ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e86abcc-272e-4959-90ee-343b9f546ea7.jpg?1",
             "name": "Summer Bloom",
             "text": "Take up to three lands from your hand and put them into play.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "bc221a10-d2fd-5a04-aaae-8ff18e0a4df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ba07e-6434-4850-940f-454fcab3f535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287ba07e-6434-4850-940f-454fcab3f535.jpg?1",
             "name": "Sylvan Tutor",
             "text": "Search your deck for a summon creature and reveal that card to all players. Then shuffle your deck and put the revealed card on top of it.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "6cf38661-461f-5233-b7d1-15019ace784e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0ba623-d17f-4f0e-b914-da139a3971df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0ba623-d17f-4f0e-b914-da139a3971df.jpg?1",
             "name": "Thundering Wurm",
             "text": "When Thundering Wurm comes into play from your hand, discard a land from your hand or destroy Thundering Wurm.",
             "colours": [
@@ -6998,7 +6998,7 @@
         },
         {
             "id": "c3d9ed7a-2502-5d2a-a5c9-a1025748aa91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e134b3-e8af-41e9-928d-c217ea7b2b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e134b3-e8af-41e9-928d-c217ea7b2b13.jpg?1",
             "name": "Treetop Defense",
             "text": "Play Treetop Defense only after you're attacked, before you declare interceptors.\nThis turn, all your creatures can intercept as though they had flying.",
             "colours": [
@@ -7029,7 +7029,7 @@
         },
         {
             "id": "8468bfbb-abab-5327-be42-21cdbe3ab606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fd77e-ee43-4de7-9ee8-1075ff70b5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4fd77e-ee43-4de7-9ee8-1075ff70b5e7.jpg?1",
             "name": "Untamed Wilds",
             "text": "Search your deck for a plains, island, swamp, mountain, or forest and put that card into play. Shuffle your deck afterwards.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "1c27d83f-f8d9-538e-9c3a-2b7912e36668",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e76072-e76d-485e-b94c-c29849bc8a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1e76072-e76d-485e-b94c-c29849bc8a6f.jpg?1",
             "name": "Whiptail Wurm",
             "text": "",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "a410f62a-6f9a-5d43-9428-defecc14df2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def835b-aabb-4a9d-8fb9-460452de0d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1def835b-aabb-4a9d-8fb9-460452de0d79.jpg?1",
             "name": "Willow Dryad",
             "text": "Forestwalk (If defending player has any forests in play, Willow Dryad can't be intercepted.)",
             "colours": [
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "67f5318b-f0a8-5ebd-8118-a4ba15ef1a16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2215de4-da49-4270-aec7-5e16a938bae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2215de4-da49-4270-aec7-5e16a938bae4.jpg?1",
             "name": "Winter's Grasp",
             "text": "Destroy any one land.",
             "colours": [
@@ -7157,7 +7157,7 @@
         },
         {
             "id": "6617d060-cc87-5f01-8928-34e80881fc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f1fb90-5c85-46a5-802d-248cc0250921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f1fb90-5c85-46a5-802d-248cc0250921.jpg?1",
             "name": "Wood Elves",
             "text": "When Wood Elves comes into play from your hand, search your deck for a forest and put that card into play. Shuffle your deck afterwards.",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "117f2f69-8556-5431-bb32-d04deaa94828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d35453-7fe3-4053-aad9-a124ecc7dcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d35453-7fe3-4053-aad9-a124ecc7dcf0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7232,7 +7232,7 @@
         },
         {
             "id": "0e63764d-1f5c-53ab-b3cc-f9743cce8a3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b90ae-6f52-412f-88fa-1a5585f486bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02b90ae-6f52-412f-88fa-1a5585f486bd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "0cabcd45-81cb-5d8b-9428-b7a983223e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1de52fb-796c-4146-b592-00ce0cc5a187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1de52fb-796c-4146-b592-00ce0cc5a187.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7314,7 +7314,7 @@
         },
         {
             "id": "8b5af06c-8757-5270-9ebd-ba50d6414f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc84a2-8892-437e-bbb3-991dbbfe5cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafc84a2-8892-437e-bbb3-991dbbfe5cdd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7355,7 +7355,7 @@
         },
         {
             "id": "45aafbd5-4480-5f38-806a-17f763d39ac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a48c07b-ddbe-4251-b9e7-38ea60d66e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a48c07b-ddbe-4251-b9e7-38ea60d66e72.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7396,7 +7396,7 @@
         },
         {
             "id": "408a8109-81e1-5d8d-b418-4ff558d77b61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee9d25-0f3f-4a50-802a-23122bc4c6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ee9d25-0f3f-4a50-802a-23122bc4c6b2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7437,7 +7437,7 @@
         },
         {
             "id": "bc3e104e-9553-5852-a163-0e22aafe9d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e511581-2739-445e-b486-c2b2d15c9be4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e511581-2739-445e-b486-c2b2d15c9be4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "4c4079bd-7987-5cce-92f3-712ea9aeb983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db83947-3441-4e1d-bd47-dd015ae55d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db83947-3441-4e1d-bd47-dd015ae55d15.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7519,7 +7519,7 @@
         },
         {
             "id": "9423c529-6e6c-5af6-a2d3-d6b7932ee69b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d1e6f-5902-4e67-91a6-30eb5c3ce4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98d1e6f-5902-4e67-91a6-30eb5c3ce4a1.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7560,7 +7560,7 @@
         },
         {
             "id": "f1e2ecf8-c67f-56fe-85ba-6c2591a2a3bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f049121-5daf-4bc6-9431-3ab665a3dc8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f049121-5daf-4bc6-9431-3ab665a3dc8a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7601,7 +7601,7 @@
         },
         {
             "id": "8eaf556c-f058-50e5-abf4-a45cee829b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fcc1eb-8689-4b0f-9e56-cfeb4c8c1edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7fcc1eb-8689-4b0f-9e56-cfeb4c8c1edb.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7642,7 +7642,7 @@
         },
         {
             "id": "cbf897b5-5621-51bb-98e4-222e1c442889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d494cfbe-8017-41a6-84df-f8f16fb40016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d494cfbe-8017-41a6-84df-f8f16fb40016.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "c4993564-d770-511c-a183-ea6220b8bf63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36da118a-d54d-489d-85da-5cbcd0d80519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36da118a-d54d-489d-85da-5cbcd0d80519.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "5b4c98f2-d5d9-5fcf-95e1-4c586334412f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29b600a-3a8e-4ae2-a186-b6d5cdcbd496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29b600a-3a8e-4ae2-a186-b6d5cdcbd496.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7765,7 +7765,7 @@
         },
         {
             "id": "96e916dd-8a96-5052-8510-2014c7eac8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591c9c1-ce72-4b68-b32f-4d048dcfa495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591c9c1-ce72-4b68-b32f-4d048dcfa495.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7806,7 +7806,7 @@
         },
         {
             "id": "19fb2e61-3218-5311-adb4-3f0431a4b3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ca67a8-2922-4c12-a888-d89981e28f0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ca67a8-2922-4c12-a888-d89981e28f0e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7847,7 +7847,7 @@
         },
         {
             "id": "41304c50-b867-519b-b563-d3f3233e7c8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0da69e-4ab6-4ef1-a7ae-4d6c47172c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0da69e-4ab6-4ef1-a7ae-4d6c47172c81.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7884,7 +7884,7 @@
         },
         {
             "id": "5970dc96-d6a5-52e9-b111-43fb9a65925d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6c1c8d-dd83-4dbe-b022-495edd1a909f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6c1c8d-dd83-4dbe-b022-495edd1a909f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7921,7 +7921,7 @@
         },
         {
             "id": "6d5add97-7ecf-5b5d-a447-8b35b297ab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c5cf6-f91d-45eb-a5c1-5aacec9cda69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c5cf6-f91d-45eb-a5c1-5aacec9cda69.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7958,7 +7958,7 @@
         },
         {
             "id": "f18e9001-e542-5933-b683-2cf2aedaf857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd26e01-cbd2-4787-bc01-aff58c13840f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd26e01-cbd2-4787-bc01-aff58c13840f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7995,7 +7995,7 @@
         },
         {
             "id": "770f5dec-542c-5dab-adda-91f182474058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17cf7ce4-d5d7-49f2-a7e4-021d1a2d58c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17cf7ce4-d5d7-49f2-a7e4-021d1a2d58c5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "2ebe4799-b0d6-5e10-b2aa-41bfb3764c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c40d24d-a81d-46b9-87ef-d5304d438c0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c40d24d-a81d-46b9-87ef-d5304d438c0e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8077,7 +8077,7 @@
         },
         {
             "id": "3209acb7-d63a-5c2c-a49c-05a4cd702eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86914cf-0808-4c7c-b364-1539087688bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86914cf-0808-4c7c-b364-1539087688bc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "4653cd0d-56c3-5b93-93bc-28078bcd35fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163c2b6b-d8cd-4a46-b4da-81cbd42e0511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/163c2b6b-d8cd-4a46-b4da-81cbd42e0511.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8159,7 +8159,7 @@
         },
         {
             "id": "fffdd333-3789-5104-a8be-37be199a2cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16a4aa-7476-4999-ad1f-5d8bc27bf418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce16a4aa-7476-4999-ad1f-5d8bc27bf418.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8200,7 +8200,7 @@
         },
         {
             "id": "dfabc7e4-ce65-5bf0-9a22-e41d0ea8a6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4641987d-e69e-4399-9b20-f85765ecf5f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4641987d-e69e-4399-9b20-f85765ecf5f3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8241,7 +8241,7 @@
         },
         {
             "id": "9cf11aa2-12f9-5b2b-81ca-f64d0642a35c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5f3d2-6728-47b9-8178-a640e23ba30a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c5f3d2-6728-47b9-8178-a640e23ba30a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8282,7 +8282,7 @@
         },
         {
             "id": "a49db359-5a8d-5c72-9b8f-d86e19322003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd723ea-66fe-439e-84f7-2b4625fcc22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dd723ea-66fe-439e-84f7-2b4625fcc22a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "c6c1e6ca-decd-5f9d-aed5-ec21d7686619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40146f61-d3f0-45e7-82b5-788ff7b0e520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40146f61-d3f0-45e7-82b5-788ff7b0e520.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "097984fb-70df-59f2-9924-7183d68e9f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2db57-be7f-4963-aef3-aa57fe6c0cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba2db57-be7f-4963-aef3-aa57fe6c0cdf.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "75e2ce34-36e2-599c-b3ba-f02c1fd7727c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f15f2-abfa-4176-856f-be815152b620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/448f15f2-abfa-4176-856f-be815152b620.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8446,7 +8446,7 @@
         },
         {
             "id": "fd3d7dbb-1353-507a-880b-bc755ce27cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b36fbc-c2c2-4e17-962b-cd018493ff6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b36fbc-c2c2-4e17-962b-cd018493ff6f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8487,7 +8487,7 @@
         },
         {
             "id": "aa80ba2f-8a0d-5c91-865d-fc7d2a26fc89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37ea002-f81e-4fa6-ac24-bba1cb6d7edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37ea002-f81e-4fa6-ac24-bba1cb6d7edf.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "c615f748-729d-54ca-a8eb-2a7953311ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776e2ad-5bf8-4b2a-89bd-4f7e7ee723a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776e2ad-5bf8-4b2a-89bd-4f7e7ee723a7.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8569,7 +8569,7 @@
         },
         {
             "id": "a67d2c87-9a4f-5854-ac14-24758af648ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a98ba-d999-41b7-a5c6-f3efa6056800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b44a98ba-d999-41b7-a5c6-f3efa6056800.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "5b1dca0f-5271-53cf-9d32-e6c91812aad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620b6d41-562f-4225-bbfc-59655141c4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/620b6d41-562f-4225-bbfc-59655141c4d0.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/PTK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/PTK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c70cc38d-339d-5315-98c7-5353394d1033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a92a9-060e-42d3-a8d1-49425defc08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a92a9-060e-42d3-a8d1-49425defc08a.jpg?1",
             "name": "Alert Shu Infantry",
             "text": "Attacking doesn't cause Alert Shu Infantry to tap.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "781a8d6f-6d04-5cb5-9f84-6124db814269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg?1",
             "name": "Eightfold Maze",
             "text": "Play Eightfold Maze only after you're attacked, before you declare blockers.\nDestroy any one attacking creature.",
             "colours": [
@@ -69,7 +69,7 @@
         },
         {
             "id": "6a1c3727-7ffb-5c3f-aae7-40f6adb62056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d37c84c-80e5-453d-bd2e-4f77ff864c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d37c84c-80e5-453d-bd2e-4f77ff864c89.jpg?1",
             "name": "Empty City Ruse",
             "text": "Your opponent can't attack on his or her next turn.",
             "colours": [
@@ -100,7 +100,7 @@
         },
         {
             "id": "2f4ea5a2-3dee-5b33-97c1-d3cea9422a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca71ce3-8633-428a-8d9e-9b807b77a8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca71ce3-8633-428a-8d9e-9b807b77a8e2.jpg?1",
             "name": "False Defeat",
             "text": "Take any one creature card from your graveyard and put that creature into play.",
             "colours": [
@@ -131,7 +131,7 @@
         },
         {
             "id": "2d4d4812-eca7-51f2-a83c-df4078a0bd21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a219a031-2466-4850-b646-79a09e30cf18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a219a031-2466-4850-b646-79a09e30cf18.jpg?1",
             "name": "Flanking Troops",
             "text": "When Flanking Troops attacks, you may tap any one creature. (Tapped creatures can't block.)",
             "colours": [
@@ -165,7 +165,7 @@
         },
         {
             "id": "17e974ff-129e-5d7f-a901-0f2ac91c90b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1575fadf-cd5c-4b4f-8965-c006e571334b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1575fadf-cd5c-4b4f-8965-c006e571334b.jpg?1",
             "name": "Guan Yu, Sainted Warrior",
             "text": "Horsemanship\nWhen Guan Yu is put into your graveyard from play, you may shuffle Guan Yu into your library.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "519cf3ab-5b48-59bb-a6e2-23c96a85eb12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7526a-7a4e-4b3d-b96e-91f2bbf1c7bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fa7526a-7a4e-4b3d-b96e-91f2bbf1c7bd.jpg?1",
             "name": "Guan Yu's 1,000-Li March",
             "text": "Destroy all tapped creatures. (This includes your tapped creatures.)",
             "colours": [
@@ -233,7 +233,7 @@
         },
         {
             "id": "b8c02fd0-84d8-5229-9bf5-f07233f9d67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg?1",
             "name": "Huang Zhong, Shu General",
             "text": "Huang Zhong can't be blocked by more than one creature each turn.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "5be0c76f-f539-5dfa-a024-c3f171e9e15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ae0a05-1870-4f4a-b8a2-bfb5381acacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ae0a05-1870-4f4a-b8a2-bfb5381acacb.jpg?1",
             "name": "Kongming, \"Sleeping Dragon\"",
             "text": "All your other creatures get +1/+1 as long as Kongming is in play.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "aa0f8d33-5a92-599e-8dee-6008afe83d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6729eb0b-5655-4191-af14-4f7e4a8dded7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6729eb0b-5655-4191-af14-4f7e4a8dded7.jpg?1",
             "name": "Kongming's Contraptions",
             "text": "After you're attacked, before you declare blockers, you may tap Kongming's Contraptions to have it deal 2 damage to any one attacking creature.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "ce8229dd-d7f2-54ec-8744-2c370001ff90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804c879-fe23-4d7f-9e7d-1da41b5c0973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804c879-fe23-4d7f-9e7d-1da41b5c0973.jpg?1",
             "name": "Liu Bei, Lord of Shu",
             "text": "Horsemanship\nAs long as you have Guan Yu and/or Zhang Fei in play, Liu Bei gets +2/+2.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "f6169dc5-4b7a-5a05-9a50-ce77ea7c15c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c37964-1c0d-40e6-9947-8be04fe14427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c37964-1c0d-40e6-9947-8be04fe14427.jpg?1",
             "name": "Loyal Retainers",
             "text": "On your turn, before you attack you may put Loyal Retainers in your graveyard to take any one Legend card from your graveyard and put that creature into play.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "7383a382-84fc-548f-8587-3e4fc4b77b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80abd7c1-8f7a-4279-b76f-251a02624345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80abd7c1-8f7a-4279-b76f-251a02624345.jpg?1",
             "name": "Misfortune's Gain",
             "text": "Destroy any one creature. That creature's owner gains 4 life.",
             "colours": [
@@ -440,7 +440,7 @@
         },
         {
             "id": "5217a4fc-541a-559e-93ae-72c0f11295de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg?1",
             "name": "Pang Tong, \"Young Phoenix\"",
             "text": "On your turn, before you attack, you may tap Pang Tong to give any one creature +0/+2 until the end of the turn.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "0f56b784-08cf-53e4-8ed2-93f0a3ce37d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bfd51a-0aca-4686-a9c5-11288f409a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bfd51a-0aca-4686-a9c5-11288f409a22.jpg?1",
             "name": "Peach Garden Oath",
             "text": "For each creature you have in play, you gain 2 life.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "d6e1beee-f942-51ce-9144-86a6fe14123a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ee74d6-bd06-48e5-89de-f926e0c9413f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ee74d6-bd06-48e5-89de-f926e0c9413f.jpg?1",
             "name": "Rally the Troops",
             "text": "Play Rally the Troops only after you're attacked, before you declare blockers.\nUntap all your creatures.",
             "colours": [
@@ -538,7 +538,7 @@
         },
         {
             "id": "fd003cc1-79ea-5cf4-86cb-b22a76dee0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11dca9ba-b27f-4af8-9962-3794e743886f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11dca9ba-b27f-4af8-9962-3794e743886f.jpg?1",
             "name": "Ravages of War",
             "text": "Destroy all lands. (This includes your lands.)",
             "colours": [
@@ -569,7 +569,7 @@
         },
         {
             "id": "0c3ac77d-340d-5cf7-bab9-11d36642f8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0504a24-4b92-471a-8da4-02ec57eb43be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0504a24-4b92-471a-8da4-02ec57eb43be.jpg?1",
             "name": "Riding Red Hare",
             "text": "Any one creature gets +3/+3 and gains horsemanship until the end of the turn.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "dcf287f6-078a-5e9d-8d17-1d25c2ae29db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0433bee7-406d-4dd3-8d1b-dfd6cb64d038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0433bee7-406d-4dd3-8d1b-dfd6cb64d038.jpg?1",
             "name": "Shu Cavalry",
             "text": "Horsemanship",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "28e5e88c-ed16-5e37-9c1a-dd70ab4bebc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee57a9ab-c385-4a51-aff7-6a654f5d7611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee57a9ab-c385-4a51-aff7-6a654f5d7611.jpg?1",
             "name": "Shu Defender",
             "text": "When Shu Defender blocks, it gets +0/+2 until the end of the turn.",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "a428f582-0b2d-5577-ba2f-5e652c9217aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ac63f6-cd61-4334-902a-777410311b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ac63f6-cd61-4334-902a-777410311b2d.jpg?1",
             "name": "Shu Elite Companions",
             "text": "Horsemanship",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "b688038f-6a89-503a-a695-b1493f6ce25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg?1",
             "name": "Shu Elite Infantry",
             "text": "",
             "colours": [
@@ -736,7 +736,7 @@
         },
         {
             "id": "c43d2a8f-6f88-5c71-b593-8d481d74071e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6524-d8bd-4eb9-9222-747443492b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6524-d8bd-4eb9-9222-747443492b8c.jpg?1",
             "name": "Shu Farmer",
             "text": "On your turn, before you attack, you may tap Shu Farmer to gain 1 life.",
             "colours": [
@@ -769,7 +769,7 @@
         },
         {
             "id": "b41f4194-a321-5445-9c1f-54c4a229cedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4268d5-f27b-44a5-91f6-6c90521825fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4268d5-f27b-44a5-91f6-6c90521825fd.jpg?1",
             "name": "Shu Foot Soldiers",
             "text": "",
             "colours": [
@@ -803,7 +803,7 @@
         },
         {
             "id": "c3f59565-b4e5-5d80-907c-5020bd87ca33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c3be7a-82a8-411c-bfe2-16749ada1244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c3be7a-82a8-411c-bfe2-16749ada1244.jpg?1",
             "name": "Shu General",
             "text": "Horsemanship\nAttacking doesn't cause Shu General to tap.",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "8496a9f5-f7a7-594d-8d2b-efec5cdd642d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf26eb7-8a31-4022-87bb-67394653f06a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf26eb7-8a31-4022-87bb-67394653f06a.jpg?1",
             "name": "Shu Grain Caravan",
             "text": "When Shu Grain Caravan comes into play, you gain 2 life.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "84c2e875-0343-5be0-8c40-06c3d928ef8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb576e9-98ba-4bd1-9d1e-e316acf2e7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb576e9-98ba-4bd1-9d1e-e316acf2e7f5.jpg?1",
             "name": "Shu Soldier-Farmers",
             "text": "When Shu Soldier-Farmers comes into play, you gain 4 life.",
             "colours": [
@@ -905,7 +905,7 @@
         },
         {
             "id": "429d8f59-4f0e-52f6-8316-6c029f9aaa5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a882fbcc-b2b9-44f3-b5cc-56759879f473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a882fbcc-b2b9-44f3-b5cc-56759879f473.jpg?1",
             "name": "Vengeance",
             "text": "Destroy any one tapped creature.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "030d9c02-073b-52bb-9f8c-f2d3038f5e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad4c79-a85d-4fc6-95ab-5a6d6d667579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ad4c79-a85d-4fc6-95ab-5a6d6d667579.jpg?1",
             "name": "Virtuous Charge",
             "text": "All your creatures get +1/+1 until the end of the turn.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "5bdf7276-6c45-5787-87de-d06b34f59a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af243f6-ef28-49d1-afeb-ac03d568ed6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af243f6-ef28-49d1-afeb-ac03d568ed6a.jpg?1",
             "name": "Volunteer Militia",
             "text": "",
             "colours": [
@@ -1001,7 +1001,7 @@
         },
         {
             "id": "4b3a5d52-3cf8-5ef6-8b6d-ea629518268b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bffc2e-67b6-4eb0-9742-e2a5918cc8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bffc2e-67b6-4eb0-9742-e2a5918cc8d8.jpg?1",
             "name": "Warrior's Stand",
             "text": "Play Warrior's Stand only after you're attacked, before you declare blockers.\nAll your creatures get +2/+2 until the end of the turn.",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "c1449798-f08d-5d27-a073-af4ec827c855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg?1",
             "name": "Zhang Fei, Fierce Warrior",
             "text": "Horsemanship\nAttacking doesn't cause Zhang Fei to tap.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "91946740-2846-5b8b-b8b7-f112bad19290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg?1",
             "name": "Zhao Zilong, Tiger General",
             "text": "Horsemanship\nWhen Zhao Zilong blocks, it gets +1/+1 until the end of the turn.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "24fbd51f-0f3c-53ea-aac9-6ac502c7baff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae27edb4-424b-4a2f-a588-d3b60c8d78e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae27edb4-424b-4a2f-a588-d3b60c8d78e5.jpg?1",
             "name": "Balance of Power",
             "text": "If you have fewer cards in your hand than your opponent does, you draw until you have the same number. (When you play Balance of Power it doesn't count as in your hand.)",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "3c6ac177-8efe-5efb-92c3-1ce1b25e215b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b5362a-bbca-4dc3-a320-3664609fe169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96b5362a-bbca-4dc3-a320-3664609fe169.jpg?1",
             "name": "Borrowing 100,000 Arrows",
             "text": "For each tapped creature your opponent has in play, you draw a card.",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "30314223-eb68-5db4-9a37-48850e83a464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg?1",
             "name": "Brilliant Plan",
             "text": "Draw three cards.",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "5e7682c0-42e8-5749-ba08-5046715825ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b8b1-f1dc-46a3-8f4a-c6181e8a049f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f7b8b1-f1dc-46a3-8f4a-c6181e8a049f.jpg?1",
             "name": "Broken Dam",
             "text": "Tap any one or two creatures without horsemanship. (Tapped creatures can't block.)",
             "colours": [
@@ -1230,7 +1230,7 @@
         },
         {
             "id": "79af494f-06c2-520c-97cd-0e54c10ed3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2df84f2-08e8-43e4-825f-dccfe096d92b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2df84f2-08e8-43e4-825f-dccfe096d92b.jpg?1",
             "name": "Capture of Jingzhou",
             "text": "You take another turn after this one.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "85ed4573-25f5-50bb-9c06-5c5c0a390a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451ef657-8590-497a-9d98-a732d4de6165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451ef657-8590-497a-9d98-a732d4de6165.jpg?1",
             "name": "Champion's Victory",
             "text": "Play Champion's Victory only after you're attacked, before you declare blockers.\nReturn any one attacking creature to its owner's hand.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "1c5f4d7b-5834-5eba-b171-b1db2a5735a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59f45b-46fa-4494-9b25-cf9d3e462539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59f45b-46fa-4494-9b25-cf9d3e462539.jpg?1",
             "name": "Council of Advisors",
             "text": "When Council of Advisors comes into play, draw a card.",
             "colours": [
@@ -1326,7 +1326,7 @@
         },
         {
             "id": "85056678-6c67-5d26-b177-e74f2fec75a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbeafb-ef84-4a8d-9ca8-ca305b1feeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eafbeafb-ef84-4a8d-9ca8-ca305b1feeea.jpg?1",
             "name": "Counterintelligence",
             "text": "Return any one or two creatures to their owner's hand.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "fd6b2bbc-dace-52d8-98fe-c8b4b984245f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad34ed-c811-432d-b9c7-bff7c024cd4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad34ed-c811-432d-b9c7-bff7c024cd4f.jpg?1",
             "name": "Exhaustion",
             "text": "At the beginning of your opponent's next turn, he or she skips untapping creatures and lands.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "df74fa32-b524-52a4-8d5b-b07846af46c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21140417-09f5-4d05-b94c-355fde9b4719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21140417-09f5-4d05-b94c-355fde9b4719.jpg?1",
             "name": "Extinguish",
             "text": "Play Extinguish only in response to another player playing a sorcery.\nThat sorcery has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "56cc2b80-f49e-521b-ad50-270d8a6291fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9753d211-3436-4a9b-86d9-54a541770ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9753d211-3436-4a9b-86d9-54a541770ec2.jpg?1",
             "name": "Forced Retreat",
             "text": "Return any one creature from play to the top of its owner's library.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "6bded0a1-5a83-5f68-b252-681e5de7ce1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f45e837-7b98-46ef-b21b-e3508ce999e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f45e837-7b98-46ef-b21b-e3508ce999e5.jpg?1",
             "name": "Lady Sun",
             "text": "On your turn, before you attack, you may tap Lady Sun to return it and any one other creature to their owners' hands.",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "c12e8ed9-4118-5e5e-b499-5ee8e94de24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg?1",
             "name": "Lu Meng, Wu General",
             "text": "Horsemanship",
             "colours": [
@@ -1522,7 +1522,7 @@
         },
         {
             "id": "cefa3821-0268-5936-a558-cf4b2ff943b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg?1",
             "name": "Lu Su, Wu Advisor",
             "text": "On your turn, before you attack, you may tap Lu Su to draw a card.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "b5d585f3-32a2-5703-bebd-440e3be91780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0882d4c8-32f1-4d86-b5c5-75a16697004c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0882d4c8-32f1-4d86-b5c5-75a16697004c.jpg?1",
             "name": "Lu Xun, Scholar General",
             "text": "Horsemanship\nWhen Lu Xun successfully damages your opponent, you may draw a card.",
             "colours": [
@@ -1594,7 +1594,7 @@
         },
         {
             "id": "c5ba9f9e-2725-533e-9100-4b52b4c448da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1296ddc4-300d-44f6-95d8-1b392613d379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1296ddc4-300d-44f6-95d8-1b392613d379.jpg?1",
             "name": "Mystic Denial",
             "text": "Play Mystic Denial only in response to another player playing a creature or a sorcery. That card has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "eb5e99c0-6bee-5b59-a8d2-66ccc09668f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2314bf1-b22d-48c2-860f-e1081f56296b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2314bf1-b22d-48c2-860f-e1081f56296b.jpg?1",
             "name": "Preemptive Strike",
             "text": "Play Preemptive Strike only in response to another player playing a creature card.\nThat creature has no effect, and that player puts it into his or her graveyard.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "cd5009f9-87c4-559c-a8b5-571794780ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fe0f33-35c7-439b-bece-4a9461b92352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fe0f33-35c7-439b-bece-4a9461b92352.jpg?1",
             "name": "Red Cliffs Armada",
             "text": "Red Cliffs Armada can't attack unless the defending player has an island in play.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "f029413b-2d2a-5e6b-a7c9-95643d1c7683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156d7c70-6c6d-4052-9d44-029ba1bb66e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/156d7c70-6c6d-4052-9d44-029ba1bb66e4.jpg?1",
             "name": "Sage's Knowledge",
             "text": "Return any one sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "938d621f-db7a-5e1c-9b48-f69c4e9aeb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7727e7b5-39a3-46ba-935b-ee093c694c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7727e7b5-39a3-46ba-935b-ee093c694c38.jpg?1",
             "name": "Strategic Planning",
             "text": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -1752,7 +1752,7 @@
         },
         {
             "id": "75a802e3-7538-5e65-bd8a-4a09692bdb0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae5ba21-eb8e-4663-bfd8-3e19a0c10774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae5ba21-eb8e-4663-bfd8-3e19a0c10774.jpg?1",
             "name": "Straw Soldiers",
             "text": "",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "c3f11ece-154b-5598-a446-d03409b073df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg?1",
             "name": "Sun Ce, Young Conquerer",
             "text": "Horsemanship\nWhen Sun Ce comes into play, you may return any one creature from play to its owner's hand.",
             "colours": [
@@ -1822,7 +1822,7 @@
         },
         {
             "id": "a71cb10d-6d11-58b7-934f-448156036f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def4492-3f67-4cdb-8a25-c3ddebd125c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6def4492-3f67-4cdb-8a25-c3ddebd125c7.jpg?1",
             "name": "Sun Quan, Lord of Wu",
             "text": "All your creatures gain horsemanship as long as Sun Quan is in play. (This includes Sun Quan.)",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "f0eb8d93-0391-513e-83ad-4f3ee4cf5909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ae191-80ac-42bf-b49d-db343803bd56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499ae191-80ac-42bf-b49d-db343803bd56.jpg?1",
             "name": "Wu Admiral",
             "text": "As long as your opponent has an island in play, Wu Admiral gets +1/+1.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "6a9280b6-2956-5642-8e81-c02879ce5272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf562e2-be8e-4514-b2c8-3268dc1ab0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf562e2-be8e-4514-b2c8-3268dc1ab0db.jpg?1",
             "name": "Wu Elite Cavalry",
             "text": "Horsemanship",
             "colours": [
@@ -1926,7 +1926,7 @@
         },
         {
             "id": "484abf49-9192-5a71-b9c0-d0ba12157110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe4115e-7ca3-4996-a390-133c2e6d09b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe4115e-7ca3-4996-a390-133c2e6d09b7.jpg?1",
             "name": "Wu Infantry",
             "text": "",
             "colours": [
@@ -1960,7 +1960,7 @@
         },
         {
             "id": "2a1a09e2-bf18-553f-879f-2afe33f645e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e55b25-fde2-4b57-b5db-65b75262ff3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e55b25-fde2-4b57-b5db-65b75262ff3d.jpg?1",
             "name": "Wu Light Cavalry",
             "text": "Horsemanship",
             "colours": [
@@ -1994,7 +1994,7 @@
         },
         {
             "id": "93ed7a23-82f7-5eba-98a2-fc044f36930e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e68635-b0ed-4a56-8b18-679f95db12b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e68635-b0ed-4a56-8b18-679f95db12b6.jpg?1",
             "name": "Wu Longbowman",
             "text": "On your turn, before you attack, you may tap Wu Longbowman to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -2029,7 +2029,7 @@
         },
         {
             "id": "d5b3293d-cd53-57d6-82a7-a4b6ce115ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d13330f-6e07-451f-b17a-4e1606a74c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d13330f-6e07-451f-b17a-4e1606a74c3f.jpg?1",
             "name": "Wu Scout",
             "text": "Horsemanship\nWhen Wu Scout comes into play, look at your opponent's hand.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "8dd467ed-b1e5-57c6-8e52-540726b1bf3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77b8e34-e7e9-4ac6-bc21-0ef52c6696c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77b8e34-e7e9-4ac6-bc21-0ef52c6696c7.jpg?1",
             "name": "Wu Spy",
             "text": "When Wu Spy comes into play, look at the top two cards of any player's library. Put one of them on the top of that player's library and the other in his or her graveyard.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "01972011-ea46-544c-a6d4-33877acb697e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e211d47-dab4-429a-a90b-5b8489441886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e211d47-dab4-429a-a90b-5b8489441886.jpg?1",
             "name": "Wu Warship",
             "text": "Wu Warship can't attack unless the defending player has an island in play.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "8535386f-520e-5c5d-b4b3-8007f2b34e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg?1",
             "name": "Zhou Yu, Chief Commander",
             "text": "Zhou Yu can't attack unless your opponent has an island in play.",
             "colours": [
@@ -2169,7 +2169,7 @@
         },
         {
             "id": "803a0851-06da-57ac-98fb-dde59f138a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg?1",
             "name": "Zhuge Jin, Wu Strategist",
             "text": "On your turn, before you attack, you may tap Zhuge Jin to make any one creature unblockable this turn.",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "28549153-dc56-5d84-9ea0-103c356f9561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0b1613-e879-4c28-b27e-f3997b9ebccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0b1613-e879-4c28-b27e-f3997b9ebccd.jpg?1",
             "name": "Ambition's Cost",
             "text": "Draw three cards. You lose 3 life.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "0176a59d-b4ba-5d13-9edb-24e95f5283d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e5a530-c954-4696-85ce-6afaf7de1808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e5a530-c954-4696-85ce-6afaf7de1808.jpg?1",
             "name": "Cao Cao, Lord of Wei",
             "text": "On your turn, before you attack, you may tap Cao Cao to force your opponent to choose and discard two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "0bafd599-9c98-5457-87f0-b55bd00163f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg?1",
             "name": "Cao Ren, Wei Commander",
             "text": "Horsemanship\nWhen Cao Ren comes into play, you lose 3 life.",
             "colours": [
@@ -2309,7 +2309,7 @@
         },
         {
             "id": "fa9e4f50-37ba-524d-b9fd-696689a9b112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a193b33-0db2-411d-8f91-2247cb2d924a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a193b33-0db2-411d-8f91-2247cb2d924a.jpg?1",
             "name": "Coercion",
             "text": "Look at your opponent's hand and choose a card from it. Your opponent discards that card.",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "880cf404-f7ca-5661-9f4d-8fcba7abc28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3ba2e3-e680-47cd-81c5-555deea7d00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3ba2e3-e680-47cd-81c5-555deea7d00f.jpg?1",
             "name": "Corrupt Court Official",
             "text": "When Corrupt Official comes into play, your opponent chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "76c93178-d55a-5f0e-b25c-e95361f0eb3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e31ede4-b0bb-4f63-b8df-1330152611a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e31ede4-b0bb-4f63-b8df-1330152611a4.jpg?1",
             "name": "Cunning Advisor",
             "text": "On your turn, before you attack, you may tap Cunning Advisor to force your opponent to choose and discard a card from his or her hand.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "7d4e58f6-faf8-55e3-a805-090fc9188dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63768-2d8a-4a74-a312-b981dd462cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb63768-2d8a-4a74-a312-b981dd462cdc.jpg?1",
             "name": "Deception",
             "text": "Your opponent chooses and discards two cards from his or her hand. (If your opponent has only one card, he or she discards it.)",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "d0affbb9-9c42-519a-8c5c-538f994bf260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5587089-b17e-4187-97aa-1c3eec070a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5587089-b17e-4187-97aa-1c3eec070a0b.jpg?1",
             "name": "Desperate Charge",
             "text": "All your creatures get +2/+0 until the end of the turn.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "1195f32a-a1c4-594e-9154-2aa3d8fb56fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6c10ca-f6d6-4322-aa17-7e874cb10bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6c10ca-f6d6-4322-aa17-7e874cb10bb1.jpg?1",
             "name": "Famine",
             "text": "Famine deals 3 damage to each creature and player. (This includes your creatures and you.)",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "e351f4d2-fe0a-5e34-9746-771e1f4388cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6938a-229a-4521-b5d5-7999ce5fb372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f6938a-229a-4521-b5d5-7999ce5fb372.jpg?1",
             "name": "Ghostly Visit",
             "text": "Destroy any one creature that isn't black.",
             "colours": [
@@ -2532,7 +2532,7 @@
         },
         {
             "id": "a96fdd10-7aee-5ea3-ba87-ba99be1b549b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a7f91d-b4ee-45c1-a229-bb23daf68e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a7f91d-b4ee-45c1-a229-bb23daf68e6b.jpg?1",
             "name": "Imperial Edict",
             "text": "Your opponent chooses one of his or her creatures. Destroy that creature.",
             "colours": [
@@ -2563,7 +2563,7 @@
         },
         {
             "id": "79d1f5fb-ee62-5bc8-b6ea-52400714263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e30db-40c5-4099-868b-185ad9b7c7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822e30db-40c5-4099-868b-185ad9b7c7dc.jpg?1",
             "name": "Imperial Seal",
             "text": "Search your library for any one card. Shuffle your library and put that card on top of it. You lose 2 life.",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "02588e8d-8e3a-5ace-ba23-a51b6d09ad31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56c7fb4-8b7b-40fc-879c-76cfb5d417b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56c7fb4-8b7b-40fc-879c-76cfb5d417b8.jpg?1",
             "name": "Overwhelming Forces",
             "text": "Destroy all your opponent's creatures. you draw a card for each creature destroyed in this way.",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "d87a62c6-fb48-502c-9101-ff1a624e6bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7b5f34-c250-484e-9bae-94789b2a87fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b7b5f34-c250-484e-9bae-94789b2a87fb.jpg?1",
             "name": "Poison Arrow",
             "text": "Destroy any one creature that isn't black. You gain 3 life.",
             "colours": [
@@ -2656,7 +2656,7 @@
         },
         {
             "id": "33ebc68a-b941-52f7-ba79-85288272551a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1841e615-fdcd-4187-bd69-d07abde0e1ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1841e615-fdcd-4187-bd69-d07abde0e1ae.jpg?1",
             "name": "Return to Battle",
             "text": "Return any one creature card from your graveyard to your hand.",
             "colours": [
@@ -2687,7 +2687,7 @@
         },
         {
             "id": "f8116aa3-0d13-5473-8127-37995143d5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg?1",
             "name": "Sima Yi, Wei Field Marshal",
             "text": "Sima Yi has power equal to the number of swamp cards you have in play. (This includes both tapped and untapped swamp cards.)",
             "colours": [
@@ -2723,7 +2723,7 @@
         },
         {
             "id": "b7f5a3c1-d008-5ddc-8c79-4e4dbe780d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f08862-5107-46a0-8c14-a961a5c4b135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f08862-5107-46a0-8c14-a961a5c4b135.jpg?1",
             "name": "Stolen Grain",
             "text": "Stolen Grain deals 5 damage to your opponent. You gain 5 life.",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "ea114b43-7070-5252-a2c3-ef9e93503d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60303bfe-9158-4e25-a905-6522883ab671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60303bfe-9158-4e25-a905-6522883ab671.jpg?1",
             "name": "Stone Catapult",
             "text": "On your turn, before you attack, you may tap Stone Catapult to destroy any one tapped creature that isn't black.",
             "colours": [
@@ -2788,7 +2788,7 @@
         },
         {
             "id": "3209612e-055d-50fc-8706-30efec9ac184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b241ba4-cff5-48ce-83bd-d70fb5e20ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b241ba4-cff5-48ce-83bd-d70fb5e20ff4.jpg?1",
             "name": "Wei Ambush Force",
             "text": "When Wei Ambush Force attacks, it gets +2/+0 until the end of the turn.",
             "colours": [
@@ -2822,7 +2822,7 @@
         },
         {
             "id": "547b3eea-b531-55a9-a3bc-db3300adaf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b448c08-140f-41d6-aed5-ce9b68efafa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b448c08-140f-41d6-aed5-ce9b68efafa9.jpg?1",
             "name": "Wei Assassins",
             "text": "When Wei Assassins comes into play, your opponent chooses one of his or her creatures. Destroy that creature. (Ignore this effect if your opponent has no creatures in play.)",
             "colours": [
@@ -2857,7 +2857,7 @@
         },
         {
             "id": "52708cdf-2e84-5f41-9ae7-886998333a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843cbf18-60ac-4d97-b156-874735db61c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/843cbf18-60ac-4d97-b156-874735db61c6.jpg?1",
             "name": "Wei Elite Companions",
             "text": "Horsemanship",
             "colours": [
@@ -2891,7 +2891,7 @@
         },
         {
             "id": "64568a6f-0708-5b54-9f0a-8cfc6745e8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6465f-3144-4faf-b248-a9fb941dc002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c6465f-3144-4faf-b248-a9fb941dc002.jpg?1",
             "name": "Wei Infantry",
             "text": "",
             "colours": [
@@ -2925,7 +2925,7 @@
         },
         {
             "id": "58c7ceaa-2c45-5a8b-9e09-74d1a4dbcfe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a0292e-ecf4-42df-8abf-f4479f8ad6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a0292e-ecf4-42df-8abf-f4479f8ad6cb.jpg?1",
             "name": "Wei Night Raiders",
             "text": "Horsemanship\nWhen Wei Night Raiders successfully damages your opponent, he or she chooses and discards a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -2959,7 +2959,7 @@
         },
         {
             "id": "bdaba705-26fa-5428-a14f-1686aebc5744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d58fb-fb70-4e8f-8f64-232ad2c1f59b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11d58fb-fb70-4e8f-8f64-232ad2c1f59b.jpg?1",
             "name": "Wei Scout",
             "text": "Horsemanship",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "8cf06c52-5132-5102-9954-5e78c64c8111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eae8ce1-b21f-4d64-91ff-e98bf6a4548a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eae8ce1-b21f-4d64-91ff-e98bf6a4548a.jpg?1",
             "name": "Wei Strike Force",
             "text": "Horsemanship",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "3163a015-f521-563d-8d9d-506df92b41de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bed8a9-ede6-4fdc-966e-d1e4261c68e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bed8a9-ede6-4fdc-966e-d1e4261c68e4.jpg?1",
             "name": "Xiahou Dun, the One-Eyed",
             "text": "Horsemanship\nOn your turn, before you attack, you may put Xiahou Dun into your graveyard to return a black card from your graveyard to your hand.",
             "colours": [
@@ -3064,7 +3064,7 @@
         },
         {
             "id": "af810a66-5ff3-5615-866b-d2ea429a5232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg?1",
             "name": "Xun Yu, Wei Advisor",
             "text": "On your turn, before you attack, you may tap Xun Yu to give one of your creatures +2/+0 until the end of the turn.",
             "colours": [
@@ -3100,7 +3100,7 @@
         },
         {
             "id": "cddb37c7-0a48-5b9d-94d1-321b6bd13be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11431c4c-b0bb-4747-a34a-4a90238ec9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11431c4c-b0bb-4747-a34a-4a90238ec9c6.jpg?1",
             "name": "Young Wei Recruits",
             "text": "Young Wei Recruits can't block.",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "437ba741-5494-5077-8c6a-95b9395caf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e4bf1-fee9-47cc-9bbc-093f21c77297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e4bf1-fee9-47cc-9bbc-093f21c77297.jpg?1",
             "name": "Zhang He, Wei General",
             "text": "Horsemanship\nWhen Zhang He attacks, all your other creatures get +1/+0 until the end of the turn.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "77dfcd44-6ebb-5312-8818-d9b1cf3efd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42a953-3073-4e74-9bb8-c8c5a45d1dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f42a953-3073-4e74-9bb8-c8c5a45d1dfa.jpg?1",
             "name": "Zhang Liao, Hero of Hefei",
             "text": "When Zhang Liao successfully damages your opponent, he or she chooses and discard a card from his or her hand. (Ignore this effect if your opponent doesn't have any cards.)",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "e7567865-e5fb-5256-99fd-327a1e005ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e364b5-55ca-4df5-8755-6643218b0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e364b5-55ca-4df5-8755-6643218b0969.jpg?1",
             "name": "Zodiac Pig",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Pig can't be blocked.)",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "a83be79b-0a90-570b-bff4-46b95d38fe53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6e5814-e1b5-48d2-9c4f-62b5727f333f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6e5814-e1b5-48d2-9c4f-62b5727f333f.jpg?1",
             "name": "Zodiac Rat",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Rat can't be blocked.)",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "276e2354-304b-523f-9a6d-bc67c6bd0c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d30d6f0-ca4c-4442-a47f-ecdf52088ecc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d30d6f0-ca4c-4442-a47f-ecdf52088ecc.jpg?1",
             "name": "Zodiac Snake",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Snake can't be blocked.)",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "33758738-ca23-5aa2-9c07-a48fd63939d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060da652-03c7-45e3-ad83-f0a9fa9d1049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/060da652-03c7-45e3-ad83-f0a9fa9d1049.jpg?1",
             "name": "Barbarian General",
             "text": "Horsemanship",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "719b88f2-fdc1-5ca2-aa15-e3b436a30776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f930c2-e828-4566-b2df-3b054f311be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f930c2-e828-4566-b2df-3b054f311be5.jpg?1",
             "name": "Barbarian Horde",
             "text": "",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "38b02df8-69bf-5742-b881-72afeffed172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b6cfd3-4fb1-40a7-a090-de6f8b283cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b6cfd3-4fb1-40a7-a090-de6f8b283cb3.jpg?1",
             "name": "Blaze",
             "text": "Blaze deals X damage to any one creature or player.",
             "colours": [
@@ -3406,7 +3406,7 @@
         },
         {
             "id": "90cb37b6-c1d8-5903-86a5-c4e4de40fc7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee12f01-581e-4a3c-a8b5-41bef2516781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee12f01-581e-4a3c-a8b5-41bef2516781.jpg?1",
             "name": "Burning Fields",
             "text": "Burning Fields deals 5 damage to your opponent.",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "68501ed1-94c5-5cb0-ad14-36356707001c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a1fe45-52d2-4c50-bedc-eee156ab69c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a1fe45-52d2-4c50-bedc-eee156ab69c8.jpg?1",
             "name": "Burning of Xinye",
             "text": "You destroy four of your lands and your opponent destroys four of his or her lands. Then Burning of Xinye deals 4 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -3468,7 +3468,7 @@
         },
         {
             "id": "63b912d9-30e0-5860-9db2-90592396a13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4f0005-4f19-4352-9cd2-3993ae6db879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e4f0005-4f19-4352-9cd2-3993ae6db879.jpg?1",
             "name": "Control of the Court",
             "text": "Draw four cards and put them into your hand. Then discard three cards at random from your hand.",
             "colours": [
@@ -3499,7 +3499,7 @@
         },
         {
             "id": "e1a70b79-2441-55ce-bdd5-ad9a93f7e587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e084664-2faf-4f7a-9068-d58d3f4b8456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e084664-2faf-4f7a-9068-d58d3f4b8456.jpg?1",
             "name": "Corrupt Eunuchs",
             "text": "When Corrupt Eunuchs comes into play, it deals 2 damage to any one creature. (If you're the only one with creatures, deal the damage to one of them.)",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "8b350151-a93d-5c9b-a807-2931edb120fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588ad2bf-405d-4c36-b485-e415c22f2703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588ad2bf-405d-4c36-b485-e415c22f2703.jpg?1",
             "name": "Desert Sandstorm",
             "text": "Desert Sandstorm deals 1 damage to each creature. (This includes your creatures.)",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "d9fb3856-addd-5ca1-9a27-9c6a09426d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6180c476-dadf-4c03-ab1e-639386bd4319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6180c476-dadf-4c03-ab1e-639386bd4319.jpg?1",
             "name": "Diaochan, Artful Beauty",
             "text": "On your turn, before you attack, you may tap Diaochan to destroy any one creature. Then, your opponent destroys any one creature of his or her choice.",
             "colours": [
@@ -3600,7 +3600,7 @@
         },
         {
             "id": "8ed16cc7-6668-5da9-9154-f4b60773ae97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ccdca0-2c29-4b5c-ba5a-364cc6945801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ccdca0-2c29-4b5c-ba5a-364cc6945801.jpg?1",
             "name": "Dong Zhou, the Tyrant",
             "text": "When Dong Zhou comes into play, choose one of your opponent's creatures. That creature deals damage to him or her equal to its power. (Ignore this effect if your opponent doesn't have any creatures in play.)",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "e6bfaaa2-dc10-5496-a8fe-e4d117e112f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7ca92f-770d-4147-8eaf-f1fa69340dc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e7ca92f-770d-4147-8eaf-f1fa69340dc9.jpg?1",
             "name": "Eunuchs' Intrigues",
             "text": "Your opponent chooses one of his or her creatures. Only that creature can block this turn.",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "c8efc191-84ff-55dd-a07e-675461207ca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8bdbd-99c9-4fa7-936a-acc7f4238507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd8bdbd-99c9-4fa7-936a-acc7f4238507.jpg?1",
             "name": "Fire Ambush",
             "text": "Fire Ambush deals 3 damage to any one creature or player.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "03338dd9-fffb-51e5-8a32-9274dd7673e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acc721-e9ae-4ba4-b435-754e41fb541e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18acc721-e9ae-4ba4-b435-754e41fb541e.jpg?1",
             "name": "Fire Bowman",
             "text": "On your turn, before you attack, you may destroy Fire Bowman to have it deal 1 damage to any one creature or player.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "8e71a983-531a-5b54-b697-47ec0aabe503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c473253-3992-4cc1-8b46-5d1da308c537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c473253-3992-4cc1-8b46-5d1da308c537.jpg?1",
             "name": "Imperial Recruiter",
             "text": "When Imperial Recruiter comes into play, search your library for a creature card with power no greater than 2, reveal that card, and put it into your hand. Shuffle your library afterward.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "f56b0bda-3f05-55bc-b6ae-a1bc3ad36437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7a4769-7a64-4016-8db0-b56c6b98aff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff7a4769-7a64-4016-8db0-b56c6b98aff3.jpg?1",
             "name": "Independent Troops",
             "text": "",
             "colours": [
@@ -3801,7 +3801,7 @@
         },
         {
             "id": "06b30f55-2632-5a19-a87d-1d6f501030f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d60c27-8625-48eb-a3f0-1e26d6930ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d60c27-8625-48eb-a3f0-1e26d6930ae7.jpg?1",
             "name": "Lu Bu, Master-at-Arms",
             "text": "Horsemanship\nLu Bu is unaffected by summoning sickness.",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "32cb68b3-fa51-5838-be53-56cbb2bec115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf7f-8c40-40e9-8118-e8626c3c6433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b8cf7f-8c40-40e9-8118-e8626c3c6433.jpg?1",
             "name": "Ma Chao, Western Warrior",
             "text": "Horsemanship\nWhenever Ma Chao attacks and no other creatures do, Ma Chao can't be blocked.",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "3df53f2c-a86d-52a7-961e-116518c8d8e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd541d-9956-4595-9527-a83db4c5f74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fd541d-9956-4595-9527-a83db4c5f74f.jpg?1",
             "name": "Mountain Bandit",
             "text": "Mountain Bandit is unaffected by summoning sickness.",
             "colours": [
@@ -3910,7 +3910,7 @@
         },
         {
             "id": "15cc12b2-3eda-5fd9-8d10-2e14d2485185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6278d679-fc54-4527-ab16-90735574ab9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6278d679-fc54-4527-ab16-90735574ab9b.jpg?1",
             "name": "Ravaging Horde",
             "text": "When Ravaging Horde comes into play, destroy any one land.",
             "colours": [
@@ -3944,7 +3944,7 @@
         },
         {
             "id": "7d09ec3e-7d39-5038-8f26-7f43d1cea638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f23cc3-da79-4e08-964f-b52815c40990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f23cc3-da79-4e08-964f-b52815c40990.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You may declare an additional attack this turn.",
             "colours": [
@@ -3975,7 +3975,7 @@
         },
         {
             "id": "2bbec8b2-0de8-52e9-a243-69920f869c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75095f4-a77f-4237-ae25-2e6f2f8788c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75095f4-a77f-4237-ae25-2e6f2f8788c1.jpg?1",
             "name": "Renegade Troops",
             "text": "Renegade Troops is unaffected by summoning sickness.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "9c5bdad2-85d7-5557-b08a-190c6557af14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5faf1-25c9-46c0-88f2-c59e7b9c08c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e5faf1-25c9-46c0-88f2-c59e7b9c08c5.jpg?1",
             "name": "Rockslide Ambush",
             "text": "Rockslide Ambush deals to any one creature damage equal to the number of mountain cards you have in play. (This includes both tapped and untapped mountain cards.)",
             "colours": [
@@ -4040,7 +4040,7 @@
         },
         {
             "id": "3791cca6-ed91-5dac-a6f9-acb56e61b4bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1bf210-ecdb-4b49-8504-51360c269e66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1bf210-ecdb-4b49-8504-51360c269e66.jpg?1",
             "name": "Rolling Earthquake",
             "text": "Rolling Earthquake deals X damage to each player and each creature without horsemanship. (This includes you and your creatures without horsemanship.)",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "bad3fdc3-326f-5a01-90b4-6357d6a464a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67738ab8-75cf-4ea1-aa1d-b840d94b2601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67738ab8-75cf-4ea1-aa1d-b840d94b2601.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy any one land.",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "cce8b731-6dd3-5811-9a4f-4ed41670047f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d582861a-ca6e-4b74-adf0-3eb588ea5ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d582861a-ca6e-4b74-adf0-3eb588ea5ed2.jpg?1",
             "name": "Warrior's Oath",
             "text": "Take another turn after this one. At the end of that turn, you lose the game. (You don't lose if you've already won.)",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "b263322b-b6fb-5976-ac4a-7592bf95f2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84460666-4f6b-422c-b20e-dc1651c66e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84460666-4f6b-422c-b20e-dc1651c66e15.jpg?1",
             "name": "Yellow Scarves Cavalry",
             "text": "Horsemanship\nYellow Scarves Cavalry can't block.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "bddd1c3e-e3e4-5d4c-829b-88fb10b8025f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg?1",
             "name": "Yellow Scarves General",
             "text": "Horsemanship\nYellow Scarves General can't block.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "54438a3b-2052-5c3b-b566-39d1192bd48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca36a8d-ca44-485e-a219-85814f160c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca36a8d-ca44-485e-a219-85814f160c4d.jpg?1",
             "name": "Yellow Scarves Troops",
             "text": "Yellow Scarves Troops can't block.",
             "colours": [
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "89c90fc6-b343-5dc2-8036-38a58e633dfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9b3794-d0f0-4d28-85cb-22492e195ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9b3794-d0f0-4d28-85cb-22492e195ae1.jpg?1",
             "name": "Yuan Shao, the Indecisive",
             "text": "Horsemanship\nEach of your creatures can't be blocked by more than one creature each turn as long as Yuan Shao is in play.",
             "colours": [
@@ -4271,7 +4271,7 @@
         },
         {
             "id": "d0b7faaa-9940-5af2-a71e-e63acf3248f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2623481-cee3-4a9d-933b-235fcde9a27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2623481-cee3-4a9d-933b-235fcde9a27b.jpg?1",
             "name": "Yuan Shao's Infantry",
             "text": "Whenever Yuan Shao's Infantry attacks and no other creatures do, Yuan Shao's Infantry can't be blocked.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "3879e971-4e75-5664-a431-b244dcaa2dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61aa62-25ee-40a4-9b6e-d6277316b464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc61aa62-25ee-40a4-9b6e-d6277316b464.jpg?1",
             "name": "Zodiac Dog",
             "text": "Mountainwalk (If defending player has a mountain in play, Zodiac Dog can't be blocked.)",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "45515ae3-e32e-5f20-ad76-573125398107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46652ae3-6572-4296-939b-0789923180d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46652ae3-6572-4296-939b-0789923180d5.jpg?1",
             "name": "Zodiac Dragon",
             "text": "If Zodiac Dragon is put into your graveyard, you may return Zodiac Dragon to your hand.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "f6cfe841-abc3-5eee-a4ab-ffe84b201689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510462-2802-4e16-87d4-da376ee2e3be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52510462-2802-4e16-87d4-da376ee2e3be.jpg?1",
             "name": "Zodiac Goat",
             "text": "Mountainwalk (If defending player has a mountain in play, Zodiac Goat can't be blocked.)",
             "colours": [
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "0f0a4ff2-f9fd-54fb-8af3-cb9fc9dcca7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg?1",
             "name": "Borrowing the East Wind",
             "text": "Borrowing the East Wind deals X damage to each player and each creature with horsemanship. (This includes you and your creatures with horsemanship.)",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "3bb416e9-79e3-5bd4-9a5a-76f96dae5c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bdfefb-f2e2-409c-b5e1-66d24ab3ee5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bdfefb-f2e2-409c-b5e1-66d24ab3ee5d.jpg?1",
             "name": "False Mourning",
             "text": "Take any one card from your graveyard and put that card on the top of your library.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "15a8f0ec-7112-5009-bf9f-163a736d2ba5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae9abc7-ecd3-4042-a5b0-5f2b24491fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae9abc7-ecd3-4042-a5b0-5f2b24491fa6.jpg?1",
             "name": "Forest Bear",
             "text": "",
             "colours": [
@@ -4499,7 +4499,7 @@
         },
         {
             "id": "3b4639d6-1c9a-5648-8f7c-f53624a7886b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499fee7b-1942-4eb9-b1d0-806a1f6c0cd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499fee7b-1942-4eb9-b1d0-806a1f6c0cd8.jpg?1",
             "name": "Heavy Fog",
             "text": "Play Heavy Fog only after you're attacked, before you declare blockers.\nThis turn, all damage dealt to you by attacking creatures is reduced to 0.",
             "colours": [
@@ -4530,7 +4530,7 @@
         },
         {
             "id": "3f1cf845-98f4-5abf-a517-ca8528cfe9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9c02e-f569-43b5-929a-ec04f661f644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee9c02e-f569-43b5-929a-ec04f661f644.jpg?1",
             "name": "Hua Tuo, Honored Physician",
             "text": "On your turn, before you attack, you may tap Hua Tuo to put any one creature card from your graveyard on the top of your library.",
             "colours": [
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "13d51e3f-b660-53b8-8184-c0673514be6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a63628-17e6-4845-96b4-c82c3e7e8fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a63628-17e6-4845-96b4-c82c3e7e8fb5.jpg?1",
             "name": "Hunting Cheetah",
             "text": "When Hunting Cheetah successfully damages your opponent, you may search your library for a forest card, reveal that card, and put it into your hand. Shuffle your library afterward.",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "eb3ae076-241e-52e6-9ef5-a186633a08e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg?1",
             "name": "Lady Zhurong, Warrior Queen",
             "text": "Horsemanship",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "2fbda095-87a1-5ee4-a87b-3a9c3d16d465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d085684-aabf-4b63-a0b3-3deb4679909b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d085684-aabf-4b63-a0b3-3deb4679909b.jpg?1",
             "name": "Lone Wolf",
             "text": "When Lone Wolf attacks and is blocked, you may have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "35808f6c-d5ec-532a-a7c6-89736d1517a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e4df87-7908-4274-a07f-81d42be89f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e4df87-7908-4274-a07f-81d42be89f18.jpg?1",
             "name": "Marshaling the Troops",
             "text": "Tap any number of your creatures. You gain 4 life for each creature tapped this way. (Tapped creatures can't block.)",
             "colours": [
@@ -4699,7 +4699,7 @@
         },
         {
             "id": "1c2008ae-6f0a-5396-9eee-3b4378192128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340647c-fb6d-45a6-9f42-235390b40337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340647c-fb6d-45a6-9f42-235390b40337.jpg?1",
             "name": "Meng Huo, Barbarian King",
             "text": "All your other green creatures get +1/+1 as long as Meng Huo is in play.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "343fad84-43a5-51d0-88be-efe149f4d2eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1642802-055e-44d2-a261-c2a45ad515e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1642802-055e-44d2-a261-c2a45ad515e8.jpg?1",
             "name": "Meng Huo's Horde",
             "text": "",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "ed4e9a4a-3e45-5e66-9f09-8ea39f8de36b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fea93-7f39-4fc7-89ab-bb3ea3f15951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fea93-7f39-4fc7-89ab-bb3ea3f15951.jpg?1",
             "name": "Riding the Dilu Horse",
             "text": "Any one creature gets +2/+2 and gains horsemanship.",
             "colours": [
@@ -4801,7 +4801,7 @@
         },
         {
             "id": "1f37cc04-01db-57aa-96ff-1728f9207f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg?1",
             "name": "Slashing Tiger",
             "text": "When Slashing Tiger attacks and is blocked, it gets +2/+2 until the end of the turn.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "5682cb75-ef16-5a53-bb7b-b36843ebfb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e138c7-1166-4e20-b039-e94c1319ad42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e138c7-1166-4e20-b039-e94c1319ad42.jpg?1",
             "name": "Southern Elephant",
             "text": "",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "11eee547-45f2-55d8-a7d3-7227e3ca0440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ed2d85-0e28-40d1-bd44-d36caa0d4e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ed2d85-0e28-40d1-bd44-d36caa0d4e31.jpg?1",
             "name": "Spoils of Victory",
             "text": "Search your library for a plains, island, swamp, mountain, or forest card and put that land into play. Shuffle your library afterward.",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "8830dfe3-371b-5763-ab14-cbedab2b4735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6862d7a-04ee-48ac-a5b3-46a4e8694d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6862d7a-04ee-48ac-a5b3-46a4e8694d5b.jpg?1",
             "name": "Spring of Eternal Peace",
             "text": "You gain 8 life.",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "ae04be01-827e-5ed1-86eb-af0c3bbbd464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d39e5c-40c7-4f1a-8576-c8b4d12a4bbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d39e5c-40c7-4f1a-8576-c8b4d12a4bbc.jpg?1",
             "name": "Stalking Tiger",
             "text": "Stalking Tiger can't be blocked by more than one creature each turn.",
             "colours": [
@@ -4962,7 +4962,7 @@
         },
         {
             "id": "d982995b-6daa-5758-a89f-eeb615c8112f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d818c231-8d66-4024-91de-fe29f8622902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d818c231-8d66-4024-91de-fe29f8622902.jpg?1",
             "name": "Taoist Hermit",
             "text": "Whenever your opponent chooses a creature in play, he or she can't choose Taoist Hermit.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "a5f9db41-3fd4-5cce-aba0-603e7958f642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg?1",
             "name": "Taoist Mystic",
             "text": "Taoist Mystic can't be blocked by creatures with horsemanship.",
             "colours": [
@@ -5030,7 +5030,7 @@
         },
         {
             "id": "db08ba19-fae8-59ba-95f1-abcbcee328fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg?1",
             "name": "Taunting Challenge",
             "text": "Choose any one creature. This turn, all creatures able to block it do so.",
             "colours": [
@@ -5061,7 +5061,7 @@
         },
         {
             "id": "cec6666d-6ebf-5b90-9e89-bfad2388de08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306d22ae-657e-4b52-8cd9-6fc3df9e8376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/306d22ae-657e-4b52-8cd9-6fc3df9e8376.jpg?1",
             "name": "Three Visits",
             "text": "Search your library for a forest card and put that forest into play. Shuffle your library afterward.",
             "colours": [
@@ -5092,7 +5092,7 @@
         },
         {
             "id": "e42b2dd5-284d-566c-bb64-75ae7c11a90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab242eab-5cab-41a0-bcf8-93a6919e4558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab242eab-5cab-41a0-bcf8-93a6919e4558.jpg?1",
             "name": "Trained Cheetah",
             "text": "When Trained Cheetah attacks and is blocked, it gets +1/+1 until the end of the turn.",
             "colours": [
@@ -5125,7 +5125,7 @@
         },
         {
             "id": "3d8259ff-3ed9-5daa-885a-5f1656e7328f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01deb3cc-91e8-4ef3-964f-f36c6a21207c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01deb3cc-91e8-4ef3-964f-f36c6a21207c.jpg?1",
             "name": "Trained Jackal",
             "text": "",
             "colours": [
@@ -5158,7 +5158,7 @@
         },
         {
             "id": "1e08d1c4-d4b6-5d44-8e93-69dd7ec565ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb1e16f-002e-4a81-ba41-cfe41f3a9071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb1e16f-002e-4a81-ba41-cfe41f3a9071.jpg?1",
             "name": "Trip Wire",
             "text": "Destroy any one creature with horsemanship.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "c2daffe0-8be9-5e88-9011-8c2be34f0a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b138167-8129-4109-a58b-af26c95577e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b138167-8129-4109-a58b-af26c95577e4.jpg?1",
             "name": "Wielding the Green Dragon",
             "text": "Any one creature gets +4/+4 until the end of the turn.",
             "colours": [
@@ -5220,7 +5220,7 @@
         },
         {
             "id": "20a5de2a-5f50-54cd-b8ac-cab2bdb17309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f395d-0827-4f62-b117-4766d4ab5dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290f395d-0827-4f62-b117-4766d4ab5dca.jpg?1",
             "name": "Wolf Pack",
             "text": "When Wolf Pack attacks and is blocked, you may have it deal its damage to the defending player instead of to the creatures blocking it.",
             "colours": [
@@ -5253,7 +5253,7 @@
         },
         {
             "id": "4b2f29a9-172a-5433-ad32-034c963f46fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24cb19-3409-45f7-b0e0-7c652064d2dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb24cb19-3409-45f7-b0e0-7c652064d2dd.jpg?1",
             "name": "Zodiac Horse",
             "text": "Islandwalk (If defending player has an island in play, Zodiac Horse can't be blocked.)",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "9a1828e6-e633-5b65-bbe0-fdb05e0de545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e98eb0b-c3b5-4561-b8a2-f22bd0fe1115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e98eb0b-c3b5-4561-b8a2-f22bd0fe1115.jpg?1",
             "name": "Zodiac Monkey",
             "text": "Forestwalk (If defending player has a forest in play, Zodaic Monkey can't be blocked.)",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "6ddca5f3-8985-52c4-b225-63830103161c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a731b3a-0065-448d-841c-28700d78a4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a731b3a-0065-448d-841c-28700d78a4fd.jpg?1",
             "name": "Zodiac Ox",
             "text": "Swampwalk (If defending player has a swamp in play, Zodiac Ox can't be blocked.)",
             "colours": [
@@ -5352,7 +5352,7 @@
         },
         {
             "id": "e6febf2d-f151-5652-9007-f8eb598e89a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4211d0-deef-4113-84e0-47ce0df7a5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4211d0-deef-4113-84e0-47ce0df7a5c6.jpg?1",
             "name": "Zodiac Rabbit",
             "text": "Forestwalk (If defending player has a forest in play, Zodiac Hare can't be blocked.)",
             "colours": [
@@ -5385,7 +5385,7 @@
         },
         {
             "id": "bfab250a-ca54-51c4-b298-9cc15b529109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dd362e-42f6-4eeb-9fe7-0d9cbeb4f21e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81dd362e-42f6-4eeb-9fe7-0d9cbeb4f21e.jpg?1",
             "name": "Zodiac Rooster",
             "text": "Plainswalk (If defending player has a plain in play, Zodiac Rooster can't be blocked.)",
             "colours": [
@@ -5418,7 +5418,7 @@
         },
         {
             "id": "e7451974-fc76-5228-86d0-59b6d78d80c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd78d5-df9f-46a3-a634-ebf7634a6358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafd78d5-df9f-46a3-a634-ebf7634a6358.jpg?1",
             "name": "Zodiac Tiger",
             "text": "Forestwalk (If defending player has a forest in play, Zodiac Tiger can't be blocked.)",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "cc18dc70-3fce-54cf-9f7d-303e1ff3121c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg?1",
             "name": "Zuo Ci, the Mocking Sage",
             "text": "Zuo Ci can't be blocked by creatures with horsemanship.\nWhenever your opponent chooses a creature in play, he or she can't choose Zuo Ci.",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "026eba13-6231-5299-a9bb-338f2d9eeeaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82f466-ee1c-4942-9b4d-a8bffd548b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82f466-ee1c-4942-9b4d-a8bffd548b30.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "38d2c545-c12e-51d6-905c-72c6dfeb8d35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe3d8c0-1640-42bb-bb15-0b82c553976f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe3d8c0-1640-42bb-bb15-0b82c553976f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "cbcdf426-581c-51d2-a423-ecd26644e0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4801e24d-7c45-4d23-9461-0c7771eddd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4801e24d-7c45-4d23-9461-0c7771eddd91.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -5595,7 +5595,7 @@
         },
         {
             "id": "0570e88d-b393-55f5-98fa-7d6d59d27c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76033c90-1e06-473b-ba44-a94e16ac5348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76033c90-1e06-473b-ba44-a94e16ac5348.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5631,7 +5631,7 @@
         },
         {
             "id": "79fe06b6-215c-5f9c-9da2-64d71a164403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899cfba6-9131-43ef-9e8d-803a0e64d0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899cfba6-9131-43ef-9e8d-803a0e64d0b0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "b9ed627f-4897-51ab-a058-1a50d29ba2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74b6430-0ddb-4433-b3bc-6f0ab42560e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e74b6430-0ddb-4433-b3bc-6f0ab42560e6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -5703,7 +5703,7 @@
         },
         {
             "id": "f9355027-2bfe-566b-b3b0-278dc216e9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b4a8a4-caa8-472d-bf90-ee70250bc0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b4a8a4-caa8-472d-bf90-ee70250bc0ab.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5739,7 +5739,7 @@
         },
         {
             "id": "8321c0e2-fedc-507a-a63f-02d297ae095a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc74272-8dc7-4a07-85e3-e7a13573345e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc74272-8dc7-4a07-85e3-e7a13573345e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5775,7 +5775,7 @@
         },
         {
             "id": "2ba89636-f5fa-5e3f-b69b-162a90e916ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6447bb-fffc-41c8-91cb-e526ed727b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6447bb-fffc-41c8-91cb-e526ed727b3e.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -5811,7 +5811,7 @@
         },
         {
             "id": "11ace9a8-8f8d-518b-9c97-eebefddc8fc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95046649-bc6d-46f5-8dbc-85d3fa5097c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95046649-bc6d-46f5-8dbc-85d3fa5097c4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "7de09b0b-da1d-5b38-b050-f601819430d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a6f28b-6910-416e-86e1-bd428360bb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a6f28b-6910-416e-86e1-bd428360bb27.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "c837ad88-ca1a-515d-91b0-67a01ad8b44a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f0ab3f-86c5-49f6-948b-ace35bc03889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00f0ab3f-86c5-49f6-948b-ace35bc03889.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "8b50c63b-8c84-5a66-947a-fbf7f87c3e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6677baa6-a38f-48f2-9ff2-2e3321b22959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6677baa6-a38f-48f2-9ff2-2e3321b22959.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "04db31b4-d70e-578d-a044-4a695b8c8611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c94d6c-ed6d-4544-8565-35f1ea8bfc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c94d6c-ed6d-4544-8565-35f1ea8bfc26.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "1d587a7b-e261-580b-b93c-e910cba1761f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84722185-dffb-498e-8ce7-f50236b716f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84722185-dffb-498e-8ce7-f50236b716f5.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/RAV.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/RAV.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c5bea520-b7bb-57e2-ab7f-0f0ac0af7f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d6414-11e1-4822-9c5d-e4f96846a85f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d6414-11e1-4822-9c5d-e4f96846a85f.jpg?1",
             "name": "Auratouched Mage",
             "text": "When Auratouched Mage comes into play, search your library for an Aura card that could enchant it. If Auratouched Mage is still in play, attach that Aura to it. Otherwise, reveal the Aura card and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "2156ca78-8bd5-5dfd-80c9-4b84045c7b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bd976e-56c7-482e-8d2f-073b0b589274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bd976e-56c7-482e-8d2f-073b0b589274.jpg?1",
             "name": "Bathe in Light",
             "text": "Radiance Choose a color. Target creature and each other creature that shares a color with it gain protection from the chosen color until end of turn.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "6c573dc0-d686-50ae-809a-f081bd7e6e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23110b5-0dd4-49a2-8991-bc673aed53c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23110b5-0dd4-49a2-8991-bc673aed53c9.jpg?1",
             "name": "Benevolent Ancestor",
             "text": "Defender (This creature can't attack.)\n{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "19138380-cdbe-5415-b52f-4540d14c5603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0bc05b-ec48-41fd-a97a-ffb0d5a2dee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0bc05b-ec48-41fd-a97a-ffb0d5a2dee0.jpg?1",
             "name": "Blazing Archon",
             "text": "Flying\nCreatures can't attack you.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "88cbea86-d91d-58f0-829a-bdfaa0175d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b2f5c-3c7a-4421-9d6f-81197e93d8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46b2f5c-3c7a-4421-9d6f-81197e93d8d0.jpg?1",
             "name": "Boros Fury-Shield",
             "text": "Prevent all combat damage that would be dealt by target attacking or blocking creature this turn. If {R} was spent to play Boros Fury-Shield, it deals damage to that creature's controller equal to the creature's power.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "16173684-12c4-5395-92ec-944c02955526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c33d3fe-cdd3-4829-8f10-6611f063983b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c33d3fe-cdd3-4829-8f10-6611f063983b.jpg?1",
             "name": "Caregiver",
             "text": "{W}, Sacrifice a creature: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "173e1b87-7df8-5b15-b0a2-bfac3855a5e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c22d01-1d14-4f73-a2db-a77f96a9a0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c22d01-1d14-4f73-a2db-a77f96a9a0e3.jpg?1",
             "name": "Chant of Vitu-Ghazi",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nPrevent all damage that would be dealt by creatures this turn. You gain 1 life for each damage prevented this way.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "23ca41e9-ae22-5408-b650-c38624fa1e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afa3367-eb7e-4c92-96a1-2b6865b24f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afa3367-eb7e-4c92-96a1-2b6865b24f52.jpg?1",
             "name": "Concerted Effort",
             "text": "At the beginning of each player's upkeep, all creatures you control gain flying until end of turn if a creature you control has flying. The same is true for fear, first strike, double strike, landwalk, protection, trample, and vigilance.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "f5a29620-e87e-5e61-a5b7-8ffd3ac95b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd663560-915a-4762-a3a6-0b9f6d7a9c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd663560-915a-4762-a3a6-0b9f6d7a9c64.jpg?1",
             "name": "Conclave Equenaut",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nFlying",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "13e191cd-92ff-5fdb-b83d-82e9cc3363a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83854443-736b-4650-8a7e-e123ee6e0b8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83854443-736b-4650-8a7e-e123ee6e0b8b.jpg?1",
             "name": "Conclave Phalanx",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nWhen Conclave Phalanx comes into play, you gain 1 life for each creature you control.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "37e10ac8-9eec-5fc5-9879-491b490e44b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86235d9f-ba69-417d-9203-812ab428b374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86235d9f-ba69-417d-9203-812ab428b374.jpg?1",
             "name": "Conclave's Blessing",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nEnchant creature\nEnchanted creature gets +0/+2 for each other creature you control.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "dbc5ab55-8883-536b-a6a5-9269e05bee1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2fb5-248d-4d2d-aa06-f325d786e949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d06a2fb5-248d-4d2d-aa06-f325d786e949.jpg?1",
             "name": "Courier Hawk",
             "text": "Flying, vigilance",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "100c6b84-514e-5349-9db4-f16c85f6d6e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fcc46c-682c-4482-8422-811b951d96cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fcc46c-682c-4482-8422-811b951d96cf.jpg?1",
             "name": "Devouring Light",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nRemove target attacking or blocking creature from the game.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "fa313ba3-3dd7-5a2e-a5e2-74d343897dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa5a010-6253-4dfb-952e-df05ff08eb9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa5a010-6253-4dfb-952e-df05ff08eb9e.jpg?1",
             "name": "Divebomber Griffin",
             "text": "Flying\n{T}, Sacrifice Divebomber Griffin: Divebomber Griffin deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -475,7 +475,7 @@
         },
         {
             "id": "2365fe4f-8581-50fd-8c89-c8b1133fe787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0106caf1-2201-4661-96a5-56af02963fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0106caf1-2201-4661-96a5-56af02963fa6.jpg?1",
             "name": "Dromad Purebred",
             "text": "Whenever Dromad Purebred is dealt damage, you gain 1 life.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "4df80668-7f59-57ab-b6ec-dea5acb261da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ffba3-44a9-41ce-a5a1-37413346db2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8ffba3-44a9-41ce-a5a1-37413346db2f.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters comes into play, you gain 4 life.\nEnchanted permanent's activated abilities can't be played unless they're mana abilities. If enchanted permanent is a creature, it can't attack or block.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "86de92d9-2b2a-5537-b274-dca7316b2823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fc49c-07a9-4e55-a977-24f7b7c2df1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15fc49c-07a9-4e55-a977-24f7b7c2df1a.jpg?1",
             "name": "Festival of the Guildpact",
             "text": "Prevent the next X damage that would be dealt to you this turn.\nDraw a card.",
             "colours": [
@@ -576,7 +576,7 @@
         },
         {
             "id": "857e7193-7d32-5a88-9cd7-255eec459a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165de5d-57f0-419b-95a1-02bd53e5a0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6165de5d-57f0-419b-95a1-02bd53e5a0c5.jpg?1",
             "name": "Flickerform",
             "text": "Enchant creature\n{2}{W}{W}: Remove enchanted creature and all Auras attached to it from the game. At end of turn, return that card to play under its owner's control. If you do, return those Auras to play under their owners' control enchanting that creature.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "881710f4-7857-5ac4-9913-3270ddd2ab51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06732c6f-c3b5-4c68-82a0-655cffff79db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06732c6f-c3b5-4c68-82a0-655cffff79db.jpg?1",
             "name": "Gate Hound",
             "text": "Creatures you control have vigilance as long as Gate Hound is enchanted.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "b3b8d0c1-14e6-55de-8e23-4065d18246f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg?1",
             "name": "Ghosts of the Innocent",
             "text": "If a source would deal damage to a creature or player, it deals half that damage, rounded down, to that creature or player instead.",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "b9e6f15f-3822-505a-beb9-25d7e22ffe55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec7a987-1ef2-40aa-a744-92d90b246df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec7a987-1ef2-40aa-a744-92d90b246df4.jpg?1",
             "name": "Hour of Reckoning",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nDestroy all nontoken creatures.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "5cadf5f4-29fb-5321-ab4f-b892d23373e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84de052-65e5-4723-a746-5c554fa1612d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84de052-65e5-4723-a746-5c554fa1612d.jpg?1",
             "name": "Hunted Lammasu",
             "text": "Flying\nWhen Hunted Lammasu comes into play, put a 4/4 black Horror creature token into play under target opponent's control.",
             "colours": [
@@ -744,7 +744,7 @@
         },
         {
             "id": "5e6a3099-2597-5755-8a6f-67f1569a3b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58466d46-7225-42ff-8471-6d489be32cf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58466d46-7225-42ff-8471-6d489be32cf3.jpg?1",
             "name": "Leave No Trace",
             "text": "Radiance Destroy target enchantment and each other enchantment that shares a color with it.",
             "colours": [
@@ -776,7 +776,7 @@
         },
         {
             "id": "81e0350d-bc10-5fb7-9376-b888f126eea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg?1",
             "name": "Light of Sanction",
             "text": "Prevent all damage that would be dealt to creatures you control by sources you control.",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "a545fbce-71ef-5cd5-9fc9-6b2ecf518f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg?1",
             "name": "Loxodon Gatekeeper",
             "text": "Artifacts, creatures, and lands your opponents control come into play tapped.",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "a77a2998-aab7-589e-852d-321eff5439e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20377fbf-70c0-441b-b2e3-62ed26aaab4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20377fbf-70c0-441b-b2e3-62ed26aaab4a.jpg?1",
             "name": "Nightguard Patrol",
             "text": "First strike, vigilance",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "a7b117de-9a95-5e69-a702-fb738b49bc0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c342b0f-a8a5-4991-a0a2-fd75b54e1de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c342b0f-a8a5-4991-a0a2-fd75b54e1de2.jpg?1",
             "name": "Oathsworn Giant",
             "text": "Vigilance\nOther creatures you control get +0/+2 and have vigilance.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "d933a9d3-ef7a-5803-94e5-34d877a98449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43472fbe-d4f6-41b5-9928-965336d44a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43472fbe-d4f6-41b5-9928-965336d44a8f.jpg?1",
             "name": "Sandsower",
             "text": "Tap three untapped creatures you control: Tap target creature.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "67120c42-2f52-5dff-8713-e52da8587155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2fa710-4615-42de-8716-41b009b56d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2fa710-4615-42de-8716-41b009b56d32.jpg?1",
             "name": "Screeching Griffin",
             "text": "Flying\n{R}: Target creature can't block Screeching Griffin this turn.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "f94b63d5-f264-58a1-96b7-963c57ed8ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af31cf-d730-4f54-a0be-3229cdccf60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33af31cf-d730-4f54-a0be-3229cdccf60c.jpg?1",
             "name": "Seed Spark",
             "text": "Destroy target artifact or enchantment. If {G} was spent to play Seed Spark, put two 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "0c35953b-6a1d-5017-aa41-31092d1bd7b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df7883b-f744-4410-a682-7391bd697afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0df7883b-f744-4410-a682-7391bd697afb.jpg?1",
             "name": "Suppression Field",
             "text": "Activated abilities cost {2} more to play unless they're mana abilities.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "351ed5ba-4a3f-5e88-bb80-ef6de001d4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb144b8-f2ee-4d35-814d-ceb728b2ab75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb144b8-f2ee-4d35-814d-ceb728b2ab75.jpg?1",
             "name": "Three Dreams",
             "text": "Search your library for up to three Aura cards with different names, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -1079,7 +1079,7 @@
         },
         {
             "id": "df8ca654-2a54-579b-b8dc-e667fbd13cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc33bb6-d71c-45f9-9030-bdef3d40a08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc33bb6-d71c-45f9-9030-bdef3d40a08a.jpg?1",
             "name": "Twilight Drover",
             "text": "Whenever a creature token leaves play, put a +1/+1 counter on Twilight Drover.\n{2}{W}, Remove a +1/+1 counter from Twilight Drover: Put two 1/1 white Spirit creature tokens with flying into play.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "191c3f5d-a2fa-52aa-9424-a66f58fab9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151a455f-c364-4600-a5f8-98da86aabc48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151a455f-c364-4600-a5f8-98da86aabc48.jpg?1",
             "name": "Veteran Armorer",
             "text": "Other creatures you control get +0/+1.",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "f911f60e-5fb0-5d36-8747-773b990270ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6f929-5a19-421b-ae88-9bbb7e64756c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6f929-5a19-421b-ae88-9bbb7e64756c.jpg?1",
             "name": "Votary of the Conclave",
             "text": "{2}{G}: Regenerate Votary of the Conclave.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "285ab785-2527-5c1e-9d55-6e370d4d5d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef74fea5-2345-4ffd-8951-f420e17259e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef74fea5-2345-4ffd-8951-f420e17259e6.jpg?1",
             "name": "Wojek Apothecary",
             "text": "Radiance {T}: Prevent the next 1 damage that would be dealt to target creature and each other creature that shares a color with it this turn.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "1435efe1-ab58-56c4-9cf5-c9247b0a9ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c0d7d-2325-4d7e-b449-c8fdcf988ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55c0d7d-2325-4d7e-b449-c8fdcf988ec0.jpg?1",
             "name": "Wojek Siren",
             "text": "Radiance Target creature and each other creature that shares a color with it get +1/+1 until end of turn.",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "bb03093f-7960-5f0e-b72e-549a738a90e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452a23a0-62de-4561-b361-9c0de9151129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452a23a0-62de-4561-b361-9c0de9151129.jpg?1",
             "name": "Belltower Sphinx",
             "text": "Flying\nWhenever a source deals damage to Belltower Sphinx, that source's controller puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "6c2e0539-1113-57b5-a79c-7172f5e8ef43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg?1",
             "name": "Cerulean Sphinx",
             "text": "Flying\n{U}: Cerulean Sphinx's owner shuffles it into his or her library.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "ab0cb01c-9603-50ae-bf0c-90dd781793a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b9c057-b80a-4e4e-a0d7-34b7ff3a69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b9c057-b80a-4e4e-a0d7-34b7ff3a69f4.jpg?1",
             "name": "Compulsive Research",
             "text": "Target player draws three cards. Then that player discards two cards unless he or she discards a land card.",
             "colours": [
@@ -1351,7 +1351,7 @@
         },
         {
             "id": "e0212035-bc31-5a56-8d30-2abe471aae83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac88052-96a3-4a4d-95a2-c5a652fcb275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac88052-96a3-4a4d-95a2-c5a652fcb275.jpg?1",
             "name": "Convolute",
             "text": "Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "e3bfe874-e441-5f3c-b749-6b08fccddde8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac22117d-bd58-439f-b199-da72bc7160b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac22117d-bd58-439f-b199-da72bc7160b2.jpg?1",
             "name": "Copy Enchantment",
             "text": "As Copy Enchantment comes into play, you may choose an enchantment in play. If you do, Copy Enchantment comes into play as a copy of that enchantment.",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "b05f27ce-7be0-50dd-87c8-de0d56179ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0db10d-fb6d-44df-9ff2-6f1e0e8f8209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e0db10d-fb6d-44df-9ff2-6f1e0e8f8209.jpg?1",
             "name": "Dizzy Spell",
             "text": "Target creature gets -3/-0 until end of turn.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "5abbc7a5-c183-5e36-bba8-5f5036e7720b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4583623-e367-48cc-8e86-e6c5e35f1a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4583623-e367-48cc-8e86-e6c5e35f1a9c.jpg?1",
             "name": "Drake Familiar",
             "text": "Flying\nWhen Drake Familiar comes into play, sacrifice it unless you return an enchantment in play to its owner's hand.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "478a3585-847e-5301-8b64-c9740dc5fd46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de4fa3d-a144-4918-b032-7495ab2e1c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de4fa3d-a144-4918-b032-7495ab2e1c8c.jpg?1",
             "name": "Dream Leash",
             "text": "Enchant permanent\nYou may play Dream Leash only on a tapped permanent.\nYou control enchanted permanent.",
             "colours": [
@@ -1515,7 +1515,7 @@
         },
         {
             "id": "871f57cd-c548-5ab0-bf6d-7123de40a5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1096ce5-f776-4028-b231-e6eaee35014b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1096ce5-f776-4028-b231-e6eaee35014b.jpg?1",
             "name": "Drift of Phantasms",
             "text": "Defender (This creature can't attack.)\nFlying\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -1549,7 +1549,7 @@
         },
         {
             "id": "e9362913-95e1-5d45-9900-fd938573f929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908901b7-fb40-4358-bca5-5e71bdafcbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908901b7-fb40-4358-bca5-5e71bdafcbe7.jpg?1",
             "name": "Ethereal Usher",
             "text": "{U}, {T}: Target creature is unblockable this turn.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -1583,7 +1583,7 @@
         },
         {
             "id": "3d70cd8d-dd52-5ff5-9ede-42571789b7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49967eb9-5020-4f0a-8775-5114f6d96d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49967eb9-5020-4f0a-8775-5114f6d96d75.jpg?1",
             "name": "Eye of the Storm",
             "text": "Whenever a player plays an instant or sorcery card, remove it from the game. Then that player copies each instant or sorcery card removed from the game with Eye of the Storm. For each copy, the player may play the copy without paying its mana cost.",
             "colours": [
@@ -1615,7 +1615,7 @@
         },
         {
             "id": "676c2fc8-f58b-5500-b762-21b7073191fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ad201-ce70-45bf-9ac3-51f5ccfa8df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8ad201-ce70-45bf-9ac3-51f5ccfa8df9.jpg?1",
             "name": "Flight of Fancy",
             "text": "Enchant creature\nWhen Flight of Fancy comes into play, draw two cards.\nEnchanted creature has flying.",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "f91f1231-19b0-54cd-829f-4f9353bb2a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27203b79-b383-4698-8b81-b6198c51c2f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27203b79-b383-4698-8b81-b6198c51c2f6.jpg?1",
             "name": "Flow of Ideas",
             "text": "Draw a card for each Island you control.",
             "colours": [
@@ -1681,7 +1681,7 @@
         },
         {
             "id": "38be89d2-4140-5cad-afaa-9e16d4565849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e2fcc-0fa2-451e-8c69-7a24ba533e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00e2fcc-0fa2-451e-8c69-7a24ba533e0b.jpg?1",
             "name": "Followed Footsteps",
             "text": "Enchant creature\nAt the beginning of your upkeep, put a creature token into play that's a copy of enchanted creature.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "318b2200-e965-5d48-b519-c6be20667b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2c94a-31df-4789-a309-4cdfe7f6a719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c2c94a-31df-4789-a309-4cdfe7f6a719.jpg?1",
             "name": "Grayscaled Gharial",
             "text": "Islandwalk",
             "colours": [
@@ -1749,7 +1749,7 @@
         },
         {
             "id": "f1dbb8e7-2518-5693-b525-4a94f18fd489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg?1",
             "name": "Grozoth",
             "text": "Defender (This creature can't attack.)\nWhen Grozoth comes into play, you may search your library for any number of cards that have converted mana cost 9, reveal them, and put them into your hand. If you do, shuffle your library.\n{4}: Grozoth loses defender until end of turn.\nTransmute {1}{U}{U}",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "05f9cecd-c595-56fb-9310-b61bc7e8c666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafd3018-1cfe-4c41-a08c-5c2ba3528c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fafd3018-1cfe-4c41-a08c-5c2ba3528c7e.jpg?1",
             "name": "Halcyon Glaze",
             "text": "Whenever you play a creature spell, Halcyon Glaze becomes a 4/4 Illusion creature with flying until end of turn. It's still an enchantment.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "b89b4abb-8074-5a3c-80d6-b125bddfb1d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg?1",
             "name": "Hunted Phantasm",
             "text": "Hunted Phantasm is unblockable.\nWhen Hunted Phantasm comes into play, put five 1/1 red Goblin creature tokens into play under target opponent's control.",
             "colours": [
@@ -1849,7 +1849,7 @@
         },
         {
             "id": "0c3b8a14-c705-5c63-a6d2-c3eb9b24b5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc462b75-8b08-47a3-be22-d7b5c062ec5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc462b75-8b08-47a3-be22-d7b5c062ec5b.jpg?1",
             "name": "Induce Paranoia",
             "text": "Counter target spell. If {B} was spent to play Induce Paranoia, that spell's controller puts the top X cards of his or her library into his or her graveyard, where X is the spell's converted mana cost.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "7b047b4b-9226-502b-9688-9dbc1a0c419f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7935b2b-aebe-44b3-b91b-52978bb4ded5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7935b2b-aebe-44b3-b91b-52978bb4ded5.jpg?1",
             "name": "Lore Broker",
             "text": "{T}: Each player draws a card, then discards a card.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "dd6f05b7-199e-524c-be86-fbffb54ee312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae826236-e591-4afb-817b-0017a11010ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae826236-e591-4afb-817b-0017a11010ad.jpg?1",
             "name": "Mark of Eviction",
             "text": "Enchant creature\nAt the beginning of your upkeep, return enchanted creature and all Auras attached to that creature to their owners' hands.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "22c24c12-734d-5ecc-a397-e2aa1e5075ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200edda9-7ad9-47fc-837e-37ec9e5b4b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200edda9-7ad9-47fc-837e-37ec9e5b4b51.jpg?1",
             "name": "Mnemonic Nexus",
             "text": "Each player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "041fc2a9-ffc5-5f90-bca4-27d1d2890c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc785b0-0a77-4b02-b0b4-2bda2fc621cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc785b0-0a77-4b02-b0b4-2bda2fc621cc.jpg?1",
             "name": "Muddle the Mixture",
             "text": "Counter target instant or sorcery spell.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2015,7 +2015,7 @@
         },
         {
             "id": "b2245378-cd00-595a-a6a4-b8acd91315db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6ca71-ba17-4a16-a331-b787363874e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4e6ca71-ba17-4a16-a331-b787363874e2.jpg?1",
             "name": "Peel from Reality",
             "text": "Return target creature you control and target creature you don't control to their owners' hands.",
             "colours": [
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "89010831-054c-5a2a-b4f4-6566eb673465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f90c1a1-679d-45c5-a1d4-53dad05e45fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f90c1a1-679d-45c5-a1d4-53dad05e45fa.jpg?1",
             "name": "Quickchange",
             "text": "Target creature's color becomes the color or colors of your choice until end of turn.\nDraw a card.",
             "colours": [
@@ -2079,7 +2079,7 @@
         },
         {
             "id": "eb0dcd1a-2f31-55d3-b206-29defc6f2abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581f3780-c480-48c6-b15c-1618f2feccb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581f3780-c480-48c6-b15c-1618f2feccb9.jpg?1",
             "name": "Remand",
             "text": "Counter target spell. If you do, return that spell card to its owner's hand.\nDraw a card.",
             "colours": [
@@ -2111,7 +2111,7 @@
         },
         {
             "id": "6fc476ea-e7bb-5d74-8bbe-aa0ef9fb1596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1e21fa-4d85-464b-9e64-3ba284769df9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1e21fa-4d85-464b-9e64-3ba284769df9.jpg?1",
             "name": "Snapping Drake",
             "text": "Flying",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "fec8c1e3-0b02-5198-a6f6-2513d90ef588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg?1",
             "name": "Spawnbroker",
             "text": "When Spawnbroker comes into play, you may exchange control of target creature you control and target creature with power less than or equal to that creature's power an opponent controls.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "d554c083-f57a-5629-ab7d-97031c2af219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75611d2-6e87-4032-a71c-b46806798a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75611d2-6e87-4032-a71c-b46806798a29.jpg?1",
             "name": "Stasis Cell",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\n{3}{U}: Attach Stasis Cell to target creature.",
             "colours": [
@@ -2214,7 +2214,7 @@
         },
         {
             "id": "d0e1e2d3-8536-50b7-9042-a82d78bc6d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec114de-bee9-4a4a-826c-82a836b4bda1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec114de-bee9-4a4a-826c-82a836b4bda1.jpg?1",
             "name": "Surveilling Sprite",
             "text": "Flying\nWhen Surveilling Sprite is put into a graveyard from play, you may draw a card.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "fc8d5861-efb7-50af-9c93-ad12c5c240a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28cbc8-4dbb-465b-813d-52b2b2f73b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d28cbc8-4dbb-465b-813d-52b2b2f73b14.jpg?1",
             "name": "Tattered Drake",
             "text": "Flying\n{B}: Regenerate Tattered Drake.",
             "colours": [
@@ -2285,7 +2285,7 @@
         },
         {
             "id": "f86ce5ad-d28b-5295-a14f-442ea4954567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e6cf4-e86f-4538-85a1-3abbc83b303d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/563e6cf4-e86f-4538-85a1-3abbc83b303d.jpg?1",
             "name": "Telling Time",
             "text": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
             "colours": [
@@ -2317,7 +2317,7 @@
         },
         {
             "id": "fa0018d6-932f-5b56-a7b1-d7828897bf4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b9d4f3-4570-4fe0-857f-97f5bd6ead44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b9d4f3-4570-4fe0-857f-97f5bd6ead44.jpg?1",
             "name": "Terraformer",
             "text": "{1}: Choose a basic land type. The land type of each land you control becomes that type until end of turn.",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "4697eb5c-8044-5a26-84df-ae164b2ad4d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffa68f-cc21-41c8-ad3d-d6b60a4ccd36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ffa68f-cc21-41c8-ad3d-d6b60a4ccd36.jpg?1",
             "name": "Tidewater Minion",
             "text": "Defender (This creature can't attack.)\n{4}: Tidewater Minion loses defender until end of turn.\n{T}: Untap target permanent.",
             "colours": [
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "fd66388e-cb05-5ecb-8230-30eee32b4561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eba31-02eb-449a-8a36-899ada5664bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3eba31-02eb-449a-8a36-899ada5664bc.jpg?1",
             "name": "Tunnel Vision",
             "text": "Name a card. Target player reveals cards from the top of his or her library until the named card is revealed. If it is, that player puts the rest of the revealed cards into his or her graveyard and puts the named card on top of his or her library. Otherwise, the player shuffles his or her library.",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "2b08db37-d14a-587d-9497-063e6090a801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0656f4eb-40c5-4a21-b994-4ab07bc63981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0656f4eb-40c5-4a21-b994-4ab07bc63981.jpg?1",
             "name": "Vedalken Dismisser",
             "text": "When Vedalken Dismisser comes into play, put target creature on top of its owner's library.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "23256ba2-3e0f-5151-81bb-f081d9ab179b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf5e4b8-3bb9-4a4c-b8fa-2cae5372ba24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf5e4b8-3bb9-4a4c-b8fa-2cae5372ba24.jpg?1",
             "name": "Vedalken Entrancer",
             "text": "{U}, {T}: Target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "6f44a088-9ac9-5b0d-9bc2-6404ea7c5488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35807a-a003-4a99-a883-03b8e097f1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf35807a-a003-4a99-a883-03b8e097f1b2.jpg?1",
             "name": "Wizened Snitches",
             "text": "Flying\nPlayers play with the top card of their libraries revealed.",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "4702eda5-f2e0-545a-b988-3f9327e00aeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cbe78f-4325-416b-bf23-282efed5b407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cbe78f-4325-416b-bf23-282efed5b407.jpg?1",
             "name": "Zephyr Spirit",
             "text": "When Zephyr Spirit blocks, return it to its owner's hand.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "4def6314-05fc-56d0-8120-e55598fad4be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg?1",
             "name": "Blood Funnel",
             "text": "Noncreature spells you play cost {2} less to play.\nWhenever you play a noncreature spell, counter that spell unless you sacrifice a creature.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "f71c872e-c0a6-5856-b71b-c11b4bbdcdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34fa44f-274e-4914-bbd5-71193f8d2f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34fa44f-274e-4914-bbd5-71193f8d2f96.jpg?1",
             "name": "Brainspoil",
             "text": "Destroy target creature that isn't enchanted. It can't be regenerated.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "e07c7d91-6ed3-5c3b-b6c6-a22d153cdfb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff031f4-df27-40de-8615-f3ea225f9830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff031f4-df27-40de-8615-f3ea225f9830.jpg?1",
             "name": "Carrion Howler",
             "text": "Pay 1 life: Carrion Howler gets +2/-1 until end of turn.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "b2cf2eb4-3d30-5c98-a717-a7a934b29195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a939a4e-5a9e-454f-8716-cee7470f05e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a939a4e-5a9e-454f-8716-cee7470f05e2.jpg?1",
             "name": "Clinging Darkness",
             "text": "Enchant creature\nEnchanted creature gets -4/-1.",
             "colours": [
@@ -2691,7 +2691,7 @@
         },
         {
             "id": "4732deef-6d46-54c3-86be-fd081d780893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7a441-bf2d-46fb-a7b6-9bd6137f86d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f7a441-bf2d-46fb-a7b6-9bd6137f86d9.jpg?1",
             "name": "Dark Confidant",
             "text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "6d7a2057-ac91-5351-939a-8118012c2250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcaba91-06d3-4492-9e07-36a1b858ca47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcaba91-06d3-4492-9e07-36a1b858ca47.jpg?1",
             "name": "Darkblast",
             "text": "Target creature gets -1/-1 until end of turn.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "2071323d-38f3-583d-a736-6b930e0c950a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a021caf-d9e7-470b-85be-3af42a3adfd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a021caf-d9e7-470b-85be-3af42a3adfd3.jpg?1",
             "name": "Dimir House Guard",
             "text": "Fear\nSacrifice a creature: Regenerate Dimir House Guard.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "40abda02-95db-557c-9a53-26f5a0ba252e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bfd72a-78c1-4167-89bf-ea1fccccd5b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14bfd72a-78c1-4167-89bf-ea1fccccd5b1.jpg?1",
             "name": "Dimir Machinations",
             "text": "Look at the top three cards of target player's library. Remove any number of those cards from the game, then put the rest back in any order.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "a3687f8a-033e-5ffb-87e8-42b94bc8d10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1edb79d-0031-4dc6-8881-f6d1fe4acba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1edb79d-0031-4dc6-8881-f6d1fe4acba2.jpg?1",
             "name": "Disembowel",
             "text": "Destroy target creature with converted mana cost X.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "796a788f-854f-5391-9b06-de20911008aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg?1",
             "name": "Empty the Catacombs",
             "text": "Each player returns all creature cards from his or her graveyard to his or her hand.",
             "colours": [
@@ -2888,7 +2888,7 @@
         },
         {
             "id": "7df087df-c692-5e19-aff5-6351d5e71b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c39e21-3e2f-4cbf-9f99-69e977924a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c39e21-3e2f-4cbf-9f99-69e977924a73.jpg?1",
             "name": "Golgari Thug",
             "text": "When Golgari Thug is put into a graveyard from play, put target creature card in your graveyard on top of your library.\nDredge 4 (If you would draw a card, instead you may put exactly four cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -2923,7 +2923,7 @@
         },
         {
             "id": "beb83d7c-3be4-5865-b31e-42a4fdc07181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5be07-166c-4b51-9ca5-655e21c32370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff5be07-166c-4b51-9ca5-655e21c32370.jpg?1",
             "name": "Helldozer",
             "text": "{B}{B}{B}, {T}: Destroy target land. If that land is nonbasic, untap Helldozer.",
             "colours": [
@@ -2958,7 +2958,7 @@
         },
         {
             "id": "af9a1faa-9e0f-5830-864f-dc7f75c55aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6af730f-a86d-4b0f-a120-fb56f065351b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6af730f-a86d-4b0f-a120-fb56f065351b.jpg?1",
             "name": "Hex",
             "text": "Destroy six target creatures.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "6d48ee04-8395-5242-8bfe-09cd66a461aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca680e3-2d10-4a32-8b0c-8b0c6be96540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca680e3-2d10-4a32-8b0c-8b0c6be96540.jpg?1",
             "name": "Hunted Horror",
             "text": "Trample\nWhen Hunted Horror comes into play, put two 3/3 green Centaur creature tokens with protection from black into play under target opponent's control.",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "e2c145ba-ba0e-520c-879c-36b2b427ea6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11858b4f-3a90-4990-9984-d888c000ec73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11858b4f-3a90-4990-9984-d888c000ec73.jpg?1",
             "name": "Infectious Host",
             "text": "When Infectious Host is put into a graveyard from play, target player loses 2 life.",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "b33f22d5-f922-582c-ac8d-f9f788a8723e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0866b383-dced-459e-9510-38248a29dd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0866b383-dced-459e-9510-38248a29dd14.jpg?1",
             "name": "Keening Banshee",
             "text": "Flying\nWhen Keening Banshee comes into play, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -3092,7 +3092,7 @@
         },
         {
             "id": "da980357-f250-534a-86ad-2f07487f3255",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e035b3-bd83-43a4-8f31-d2393d29cd94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e035b3-bd83-43a4-8f31-d2393d29cd94.jpg?1",
             "name": "Last Gasp",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -3124,7 +3124,7 @@
         },
         {
             "id": "c46fae5b-6852-51ba-a525-8f38e7ef2b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b6dc7d-fc8a-4842-bf30-3dc9fec708c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b6dc7d-fc8a-4842-bf30-3dc9fec708c4.jpg?1",
             "name": "Mausoleum Turnkey",
             "text": "When Mausoleum Turnkey comes into play, return target creature card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "10a7cb5a-652e-51f3-92eb-a8de0aa38747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7957c37f-96da-4b7e-9581-afdf73a85edd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7957c37f-96da-4b7e-9581-afdf73a85edd.jpg?1",
             "name": "Moonlight Bargain",
             "text": "Look at the top five cards of your library. For each card, put that card into your graveyard unless you pay 2 life. Then put the rest into your hand.",
             "colours": [
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "0cd54ad4-6fb8-527c-be8b-fd36503982be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a8ae6e-51b1-4985-9d09-f9c3818df911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a8ae6e-51b1-4985-9d09-f9c3818df911.jpg?1",
             "name": "Mortipede",
             "text": "{2}{G}: All creatures able to block Mortipede this turn do so.",
             "colours": [
@@ -3226,7 +3226,7 @@
         },
         {
             "id": "526500ae-1dc5-507c-b80c-7a09655d4a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a46880c-a9f4-452d-8b91-51d8aa97cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a46880c-a9f4-452d-8b91-51d8aa97cbd2.jpg?1",
             "name": "Necromantic Thirst",
             "text": "Enchant creature\nWhenever enchanted creature deals combat damage to a player, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "4b3e61aa-0999-543a-9695-b0e79df6d497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372424cf-85b3-4a78-bcf2-0543b0b88c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/372424cf-85b3-4a78-bcf2-0543b0b88c0b.jpg?1",
             "name": "Necroplasm",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on Necroplasm.\nAt the end of your turn, destroy each creature with converted mana cost equal to the number of +1/+1 counters on Necroplasm.\nDredge 2",
             "colours": [
@@ -3294,7 +3294,7 @@
         },
         {
             "id": "b5bfaf79-f600-5b8a-b4c0-6f685876b127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665e905-cb06-48b7-9f50-5916277e237d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b665e905-cb06-48b7-9f50-5916277e237d.jpg?1",
             "name": "Netherborn Phalanx",
             "text": "When Netherborn Phalanx comes into play, each opponent loses 1 life for each creature he or she controls.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -3328,7 +3328,7 @@
         },
         {
             "id": "23947bd1-9a9f-5ae5-89b9-5808e0807286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892299e9-8ee9-4a81-b4aa-b03ad2565eb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/892299e9-8ee9-4a81-b4aa-b03ad2565eb4.jpg?1",
             "name": "Nightmare Void",
             "text": "Target player reveals his or her hand. Choose a card from it. That player discards that card.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3360,7 +3360,7 @@
         },
         {
             "id": "681cd4d5-740e-5443-99bd-588413c12dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a2e910-5a61-4ca0-8d69-0a6d4ea12ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a2e910-5a61-4ca0-8d69-0a6d4ea12ed7.jpg?1",
             "name": "Ribbons of Night",
             "text": "Ribbons of Night deals 4 damage to target creature and you gain 4 life. If {U} was spent to play Ribbons of Night, draw a card.",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "07a41c27-dfb7-52ca-8831-238c090b2945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43fb78-497b-4a05-84cd-d2aca4b2db1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43fb78-497b-4a05-84cd-d2aca4b2db1b.jpg?1",
             "name": "Roofstalker Wight",
             "text": "{1}{U}: Roofstalker Wight gains flying until end of turn.",
             "colours": [
@@ -3428,7 +3428,7 @@
         },
         {
             "id": "ee42531d-6a3d-5903-b4be-b8044b6b0471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40283989-c2cc-4f17-a817-2c548d2ce71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40283989-c2cc-4f17-a817-2c548d2ce71f.jpg?1",
             "name": "Sadistic Augermage",
             "text": "When Sadistic Augermage is put into a graveyard from play, each player puts a card from his or her hand on top of his or her library.",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "dc69fac7-8112-5714-a0df-ebb05b3efa19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b216ad4e-29b4-4e03-8c16-5796277bd05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b216ad4e-29b4-4e03-8c16-5796277bd05f.jpg?1",
             "name": "Sewerdreg",
             "text": "Swampwalk\nSacrifice Sewerdreg: Remove target card in a graveyard from the game.",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "bacf9bd8-e17c-588f-9ca1-21c297766f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38192e5-814f-4269-bae8-13867a73e7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38192e5-814f-4269-bae8-13867a73e7fa.jpg?1",
             "name": "Shred Memory",
             "text": "Remove up to four target cards in a single graveyard from the game.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -3529,7 +3529,7 @@
         },
         {
             "id": "f38eebd1-1b23-504a-8ec2-7bb90a647b72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c518792-a50f-40b1-b6fb-674432093b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c518792-a50f-40b1-b6fb-674432093b6a.jpg?1",
             "name": "Sins of the Past",
             "text": "Until end of turn, you may play target instant or sorcery card in your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, remove it from the game instead. Remove Sins of the Past from the game.",
             "colours": [
@@ -3561,7 +3561,7 @@
         },
         {
             "id": "0e27a1f7-56f1-527e-a5e3-75ed597029f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628903a0-6695-4643-80f3-9a6efc4d6a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628903a0-6695-4643-80f3-9a6efc4d6a27.jpg?1",
             "name": "Stinkweed Imp",
             "text": "Flying\nWhenever Stinkweed Imp deals combat damage to a creature, destroy that creature.\nDredge 5 (If you would draw a card, instead you may put exactly five cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "eb814d11-b4b0-5d88-ae20-1bc27cba06ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ced365-f445-4a4a-b33f-986279404fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ced365-f445-4a4a-b33f-986279404fde.jpg?1",
             "name": "Strands of Undeath",
             "text": "Enchant creature\nWhen Strands of Undeath comes into play, target player discards two cards.\n{B}: Regenerate enchanted creature.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "966a2934-b693-57d4-aaa5-aed86516aedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8df33-a955-403c-aafc-85e5589c5041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f8df33-a955-403c-aafc-85e5589c5041.jpg?1",
             "name": "Thoughtpicker Witch",
             "text": "{1}, Sacrifice a creature: Look at the top two cards of target opponent's library, then remove one of them from the game.",
             "colours": [
@@ -3664,7 +3664,7 @@
         },
         {
             "id": "ec3680b9-b116-570a-be1b-dec1825cb496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6609aa2e-6832-4c20-beda-e5f2506bf9b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6609aa2e-6832-4c20-beda-e5f2506bf9b2.jpg?1",
             "name": "Undercity Shade",
             "text": "Fear\n{B}: Undercity Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "8b3b91cd-ff6f-5939-a0bf-2d9676d2f9cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe06560-bb3f-4f0b-ad3c-7257419eb8ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe06560-bb3f-4f0b-ad3c-7257419eb8ef.jpg?1",
             "name": "Vigor Mortis",
             "text": "Return target creature card from your graveyard to play. If {G} was spent to play Vigor Mortis, that creature comes into play with a +1/+1 counter on it.",
             "colours": [
@@ -3731,7 +3731,7 @@
         },
         {
             "id": "0bdc99d8-3bab-5b41-a950-a883532f869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5c72c-982c-4cfd-b576-089200b4cc04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5c72c-982c-4cfd-b576-089200b4cc04.jpg?1",
             "name": "Vindictive Mob",
             "text": "When Vindictive Mob comes into play, sacrifice a creature.\nVindictive Mob can't be blocked by Saprolings.",
             "colours": [
@@ -3766,7 +3766,7 @@
         },
         {
             "id": "d1e92fe0-056a-531f-a487-5aef0f94e601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg?1",
             "name": "Woebringer Demon",
             "text": "Flying\nAt the beginning of each player's upkeep, that player sacrifices a creature. If the player can't, sacrifice Woebringer Demon.",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "8ce2e7b2-f706-58af-b4fb-17f6c452327d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f4cfa-4f03-404d-a6f7-24c27505906f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152f4cfa-4f03-404d-a6f7-24c27505906f.jpg?1",
             "name": "Barbarian Riftcutter",
             "text": "{R}, Sacrifice Barbarian Riftcutter: Destroy target land.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "dc601e4e-3199-518d-a65f-e4ff6a7389ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a28b9d-1bd2-4ca4-a1e1-4138891d6739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00a28b9d-1bd2-4ca4-a1e1-4138891d6739.jpg?1",
             "name": "Blockbuster",
             "text": "{1}{R}, Sacrifice Blockbuster: Blockbuster deals 3 damage to each tapped creature and each player.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "2e5a7cb9-4f63-567c-a543-9376cc68039b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbef6f4a-f9a0-4a4c-b8a2-6c3a8fb7e14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbef6f4a-f9a0-4a4c-b8a2-6c3a8fb7e14a.jpg?1",
             "name": "Breath of Fury",
             "text": "Enchant creature you control\nWhen enchanted creature deals combat damage to a player, sacrifice it and attach Breath of Fury to a creature you control. If you do, untap all creatures you control and after this phase, there is an additional combat phase.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "e4ffc6c2-a498-5bdb-8f26-3179fe3eeac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg?1",
             "name": "Char",
             "text": "Char deals 4 damage to target creature or player and 2 damage to you.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "bdfbd727-7a68-54e4-8bfe-fed6492d4369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cbaab6-db0d-40bb-bdf4-aee6543d9f27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cbaab6-db0d-40bb-bdf4-aee6543d9f27.jpg?1",
             "name": "Cleansing Beam",
             "text": "Radiance Cleansing Beam deals 2 damage to target creature and each other creature that shares a color with it.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "c3b26b0c-2533-5896-a29f-6d8968746925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc001cef-3afd-4128-989f-ac99dc76b243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc001cef-3afd-4128-989f-ac99dc76b243.jpg?1",
             "name": "Coalhauler Swine",
             "text": "Whenever Coalhauler Swine is dealt damage, it deals that much damage to each player.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "f151a61c-f8b1-5bdd-942d-906796d8ea9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26316b00-22db-4546-8366-8a624f10c1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26316b00-22db-4546-8366-8a624f10c1ba.jpg?1",
             "name": "Dogpile",
             "text": "Dogpile deals damage to target creature or player equal to the number of attacking creatures you control.",
             "colours": [
@@ -4032,7 +4032,7 @@
         },
         {
             "id": "621370fc-4675-5734-a022-453d08a3df0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg?1",
             "name": "Excruciator",
             "text": "Damage that would be dealt by Excruciator can't be prevented.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "c85f4b2d-ef90-5786-b0ee-c1bd06894128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9a92c-9fde-4313-ac4c-9791604d7f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa9a92c-9fde-4313-ac4c-9791604d7f4f.jpg?1",
             "name": "Fiery Conclusion",
             "text": "As an additional cost to play Fiery Conclusion, sacrifice a creature.\nFiery Conclusion deals 5 damage to target creature.",
             "colours": [
@@ -4098,7 +4098,7 @@
         },
         {
             "id": "03167eac-d546-57da-9855-9c4dc0bfb704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg?1",
             "name": "Flame Fusillade",
             "text": "Until end of turn, permanents you control gain \"{T}: This permanent deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "f51e3962-0417-5ab3-9875-b1a7d240f7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52361237-a653-4470-9ed5-c531c040c686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52361237-a653-4470-9ed5-c531c040c686.jpg?1",
             "name": "Flash Conscription",
             "text": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. If {W} was spent to play Flash Conscription, the creature gains \"Whenever this creature deals combat damage, you gain that much life\" until end of turn.",
             "colours": [
@@ -4163,7 +4163,7 @@
         },
         {
             "id": "0d2667a4-6fcb-50bb-aa16-bde72dcf279d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d307d8c7-b9b5-4f8f-933d-f1c64cbbf92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d307d8c7-b9b5-4f8f-933d-f1c64cbbf92f.jpg?1",
             "name": "Frenzied Goblin",
             "text": "Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "532bab05-2992-5a6f-ac23-d6428a1959b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d816df-51e5-46f8-ad9a-68f3f656dbcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d816df-51e5-46f8-ad9a-68f3f656dbcd.jpg?1",
             "name": "Galvanic Arc",
             "text": "Enchant creature\nWhen Galvanic Arc comes into play, it deals 3 damage to target creature or player.\nEnchanted creature has first strike.",
             "colours": [
@@ -4232,7 +4232,7 @@
         },
         {
             "id": "9aa9b58a-a5a0-52cb-a273-6bce4b9d8cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d3b2d2-4ec2-495d-833d-7476cbfc80f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d3b2d2-4ec2-495d-833d-7476cbfc80f6.jpg?1",
             "name": "Goblin Fire Fiend",
             "text": "Haste\nDefending player blocks Goblin Fire Fiend if able.\n{R}: Goblin Fire Fiend gets +1/+0 until end of turn.",
             "colours": [
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "20485139-3683-5987-a27b-deeca3146092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3889c5-3321-486c-b03c-8607f2393a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3889c5-3321-486c-b03c-8607f2393a75.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "Mountainwalk",
             "colours": [
@@ -4302,7 +4302,7 @@
         },
         {
             "id": "70daa522-b753-56d2-a755-c2585b3870ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8ad11-4ffa-4878-9354-737be6f9e90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef8ad11-4ffa-4878-9354-737be6f9e90c.jpg?1",
             "name": "Greater Forgeling",
             "text": "{1}{R}: Greater Forgeling gets +3/-3 until end of turn.",
             "colours": [
@@ -4336,7 +4336,7 @@
         },
         {
             "id": "148911b5-8f68-5dfb-ad4b-a0097b1613c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f946d-9715-466e-b322-905995d28107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f946d-9715-466e-b322-905995d28107.jpg?1",
             "name": "Hammerfist Giant",
             "text": "{T}: Hammerfist Giant deals 4 damage to each creature without flying and each player.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "c079d6b9-58d8-51b4-88b8-0194ceeba38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b9cc6e-47db-47d5-84c9-975e4b618261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b9cc6e-47db-47d5-84c9-975e4b618261.jpg?1",
             "name": "Hunted Dragon",
             "text": "Flying, haste\nWhen Hunted Dragon comes into play, put three 2/2 white Knight creature tokens with first strike into play under target opponent's control.",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "e47860fd-5892-5b39-a07b-e55179ff9c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f5060-df9e-4665-bf60-a8e33da55c84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f5060-df9e-4665-bf60-a8e33da55c84.jpg?1",
             "name": "Incite Hysteria",
             "text": "Radiance Creatures that share a color with target creature can't block this turn.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "2c1d7914-b9f1-51fb-b589-787bc8baf273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e976c-3c0b-4ba5-b614-e1b576b57e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6e976c-3c0b-4ba5-b614-e1b576b57e86.jpg?1",
             "name": "Indentured Oaf",
             "text": "Prevent all damage that Indentured Oaf would deal to red creatures.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "f8d155b6-5cf2-5ec6-b8d3-13a0a429b463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6164762-c02d-4553-9064-2b99ff6352c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6164762-c02d-4553-9064-2b99ff6352c9.jpg?1",
             "name": "Instill Furor",
             "text": "Enchant creature\nEnchanted creature has \"At the end of your turn, sacrifice this creature unless it attacked this turn.\"",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "42482800-d2cf-5e1c-9310-4f75593a962a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg?1",
             "name": "Mindmoil",
             "text": "Whenever you play a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "99c00f38-d62c-5adb-84c0-5eda08055032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg?1",
             "name": "Molten Sentry",
             "text": "As Molten Sentry comes into play, flip a coin. If the coin comes up heads, Molten Sentry comes into play as a 5/2 creature with haste. If it comes up tails, Molten Sentry comes into play as a 2/5 creature with defender.",
             "colours": [
@@ -4572,7 +4572,7 @@
         },
         {
             "id": "65e21696-54ab-596f-9f0b-64aab27211f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa726c0e-3a7e-4299-8842-4ce1f9f26567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa726c0e-3a7e-4299-8842-4ce1f9f26567.jpg?1",
             "name": "Ordruun Commando",
             "text": "{W}: Prevent the next 1 damage that would be dealt to Ordruun Commando this turn.",
             "colours": [
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "0f868b90-c4bf-576b-93bb-4954c1f2b4fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5391a9-6c30-4f9b-b746-a4427a3e63fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5391a9-6c30-4f9b-b746-a4427a3e63fc.jpg?1",
             "name": "Rain of Embers",
             "text": "Rain of Embers deals 1 damage to each creature and each player.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "fa529bbe-f35b-5b72-8612-cb69beab386b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42794e10-ddcd-4d2d-ab0c-a6b99b6d4662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42794e10-ddcd-4d2d-ab0c-a6b99b6d4662.jpg?1",
             "name": "Reroute",
             "text": "Change the target of target activated ability with a single target.\nDraw a card.",
             "colours": [
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "bacdba65-7b9a-5d60-a603-3b60b9ce6354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec817c-c414-4a56-b455-748c6e5cac0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec817c-c414-4a56-b455-748c6e5cac0d.jpg?1",
             "name": "Sabertooth Alley Cat",
             "text": "Sabertooth Alley Cat attacks each turn if able.\n{1}{R}: Creatures without defender can't block Sabertooth Alley Cat this turn.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "52347240-0e93-5d8f-a830-493a22421c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9caddbe-1329-4ac2-9071-6fc5059d4dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9caddbe-1329-4ac2-9071-6fc5059d4dec.jpg?1",
             "name": "Seismic Spike",
             "text": "Destroy target land. Add {R}{R} to your mana pool.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "4eeb942c-45ca-534c-b855-373aa6ff9f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db513835-af5a-4ff3-8cf8-31936732a4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db513835-af5a-4ff3-8cf8-31936732a4db.jpg?1",
             "name": "Sell-Sword Brute",
             "text": "When Sell-Sword Brute is put into a graveyard from play, it deals 2 damage to you.",
             "colours": [
@@ -4773,7 +4773,7 @@
         },
         {
             "id": "f5f4af58-5bb2-59e7-b58a-d54ef013f432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692b1487-7752-4c40-ba91-09ef67016032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/692b1487-7752-4c40-ba91-09ef67016032.jpg?1",
             "name": "Smash",
             "text": "Destroy target artifact.\nDraw a card.",
             "colours": [
@@ -4805,7 +4805,7 @@
         },
         {
             "id": "2bcf0804-87e7-5e32-83bf-d243d4f0da53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca91f7f-4b17-469e-8650-4c18e1521ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca91f7f-4b17-469e-8650-4c18e1521ea9.jpg?1",
             "name": "Sparkmage Apprentice",
             "text": "When Sparkmage Apprentice comes into play, it deals 1 damage to target creature or player.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "01eef3f8-f30d-5ce8-8378-f9668da1257d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a0edb0-697a-4e0b-872b-f3c15c19cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17a0edb0-697a-4e0b-872b-f3c15c19cbda.jpg?1",
             "name": "Stoneshaker Shaman",
             "text": "At the end of each player's turn, that player sacrifices an untapped land.",
             "colours": [
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "8c12bfa3-5df9-528e-b364-2fe1be0be3d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c07fa6-b575-46f9-ab39-fb777d4b8acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c07fa6-b575-46f9-ab39-fb777d4b8acd.jpg?1",
             "name": "Surge of Zeal",
             "text": "Radiance Target creature and each other creature that shares a color with it gain haste until end of turn.",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "de85c263-3371-5d41-b473-8db3563e1675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900ff91-0e47-4903-a680-9031f4a23cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7900ff91-0e47-4903-a680-9031f4a23cb4.jpg?1",
             "name": "Torpid Moloch",
             "text": "Defender (This creature can't attack.)\nSacrifice three lands: Torpid Moloch loses defender until end of turn.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "b741bc5e-040d-5dcb-87ba-1de123d88af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616dac9-bbcf-453a-9205-8e433a1c62aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2616dac9-bbcf-453a-9205-8e433a1c62aa.jpg?1",
             "name": "Viashino Fangtail",
             "text": "{T}: Viashino Fangtail deals 1 damage to target creature or player.",
             "colours": [
@@ -4976,7 +4976,7 @@
         },
         {
             "id": "1875f3ca-2630-5024-a316-02d61bf95034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa18f23-c995-4fcc-8e95-bbf76426e703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa18f23-c995-4fcc-8e95-bbf76426e703.jpg?1",
             "name": "Viashino Slasher",
             "text": "{R}: Viashino Slasher gets +1/-1 until end of turn.",
             "colours": [
@@ -5011,7 +5011,7 @@
         },
         {
             "id": "5be4d719-cb8c-56ef-8cc4-e354a3006fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbf743a-6e28-47c4-acfe-1c5d42f80eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdbf743a-6e28-47c4-acfe-1c5d42f80eee.jpg?1",
             "name": "Warp World",
             "text": "Each player shuffles all permanents he or she owns into his or her library, then reveals that many cards from the top of his or her library. Each player puts all artifact, creature, and land cards revealed this way into play, then puts all enchantment cards revealed this way into play, then puts the rest on the bottom of his or her library in any order.",
             "colours": [
@@ -5043,7 +5043,7 @@
         },
         {
             "id": "20c738fe-f52f-592a-8e74-8f74772f73bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259469b3-1212-4030-97ae-a84f132798d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/259469b3-1212-4030-97ae-a84f132798d4.jpg?1",
             "name": "War-Torch Goblin",
             "text": "{R}, Sacrifice War-Torch Goblin: War-Torch Goblin deals 2 damage to target blocking creature.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "1df8ad3a-43c2-52bc-acf5-691c2139765f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1614866-fb0b-47bd-ab26-5c20ff175d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1614866-fb0b-47bd-ab26-5c20ff175d10.jpg?1",
             "name": "Wojek Embermage",
             "text": "Radiance {T}: Wojek Embermage deals 1 damage to target creature and each other creature that shares a color with it.",
             "colours": [
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "f362c4ef-1ae3-59b1-8502-2812c85794d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a4396a-0f22-482b-ad1d-4d9b68a1ed96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90a4396a-0f22-482b-ad1d-4d9b68a1ed96.jpg?1",
             "name": "Birds of Paradise",
             "text": "Flying\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "dc2ea262-20bb-508a-94a7-0cfb13e6ab8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470665e5-fa48-4772-ba71-5d4008d042f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470665e5-fa48-4772-ba71-5d4008d042f3.jpg?1",
             "name": "Bramble Elemental",
             "text": "Whenever an Aura becomes attached to Bramble Elemental, put two 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -5181,7 +5181,7 @@
         },
         {
             "id": "3e047da3-603c-57b9-8e2e-b39e9afceb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba52a417-0950-4ddf-9bd5-3557f659fdf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba52a417-0950-4ddf-9bd5-3557f659fdf5.jpg?1",
             "name": "Carven Caryatid",
             "text": "Defender (This creature can't attack.)\nWhen Carven Caryatid comes into play, draw a card.",
             "colours": [
@@ -5215,7 +5215,7 @@
         },
         {
             "id": "c8c7504a-28d0-54a2-9e14-f89c64ae3da4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e064174b-8f07-4fea-9eef-c3b5d0220b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e064174b-8f07-4fea-9eef-c3b5d0220b1a.jpg?1",
             "name": "Chord of Calling",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nSearch your library for a creature card with converted mana cost X or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "9606c306-0ba7-5dd6-bcf9-a8ff80374a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654eacc9-5f80-44ea-8d7b-71cd8227fa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/654eacc9-5f80-44ea-8d7b-71cd8227fa38.jpg?1",
             "name": "Civic Wayfinder",
             "text": "When Civic Wayfinder comes into play, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -5283,7 +5283,7 @@
         },
         {
             "id": "ba3c07bc-9856-59e2-ba17-7329df4b456a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e71299-98f6-494e-b187-8d22ce5f50af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e71299-98f6-494e-b187-8d22ce5f50af.jpg?1",
             "name": "Doubling Season",
             "text": "If an effect would put one or more tokens into play under your control, it puts twice that many into play instead.\nIf an effect would place one or more counters on a permanent you control, it places twice that many on that permanent instead.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "a3a26725-807e-5f50-a495-942a29fa170e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34ac5bd-2d2f-4c44-8f2d-aaa8fa18e81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34ac5bd-2d2f-4c44-8f2d-aaa8fa18e81a.jpg?1",
             "name": "Dowsing Shaman",
             "text": "{2}{G}, {T}: Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "6c14653e-de15-5546-8604-12d49360d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf707f2-1a62-458e-bcc8-8b1cd081f225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf707f2-1a62-458e-bcc8-8b1cd081f225.jpg?1",
             "name": "Dryad's Caress",
             "text": "You gain 1 life for each creature in play. If {W} was spent to play Dryad's Caress, untap all creatures you control.",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "19f52df8-e5f7-5d3c-ad95-2f2dfe5f337d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bea6dea-d767-4092-a285-305d9997357a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bea6dea-d767-4092-a285-305d9997357a.jpg?1",
             "name": "Elves of Deep Shadow",
             "text": "{T}: Add {B} to your mana pool. Elves of Deep Shadow deals 1 damage to you.",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "2093aee8-7a31-5d05-86a5-d1583dc4bfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80b91e8-c498-4178-8310-3cd3b039a3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80b91e8-c498-4178-8310-3cd3b039a3dc.jpg?1",
             "name": "Elvish Skysweeper",
             "text": "{4}{G}, Sacrifice a creature: Destroy target creature with flying.",
             "colours": [
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "141896a7-bf04-560f-8775-846bd9b30768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8180abec-9459-4b81-987e-b1794e45d543.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8180abec-9459-4b81-987e-b1794e45d543.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card and put it into play tapped. Then shuffle your library.",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "76cc2925-7584-5677-bed8-d8db041ab74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7193c00f-0398-485c-974d-346ee59cd4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7193c00f-0398-485c-974d-346ee59cd4c7.jpg?1",
             "name": "Fists of Ironwood",
             "text": "Enchant creature\nWhen Fists of Ironwood comes into play, put two 1/1 green Saproling creature tokens into play.\nEnchanted creature has trample.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "cc68c560-3af9-592e-b912-55fcc8d29da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93311f80-0d0e-4005-ba43-5dbfe438d127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93311f80-0d0e-4005-ba43-5dbfe438d127.jpg?1",
             "name": "Gather Courage",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5552,7 +5552,7 @@
         },
         {
             "id": "00910c78-dd97-5feb-a2d4-e04e987dfabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690cfc79-da41-4ac0-b0cc-719aa650b207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/690cfc79-da41-4ac0-b0cc-719aa650b207.jpg?1",
             "name": "Golgari Brownscale",
             "text": "When Golgari Brownscale is put into your hand from your graveyard, you gain 2 life.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "11bc8f66-b5b3-54a7-b76c-f6291c194e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b50e6-2166-435d-bf48-c4a0cff9999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b50e6-2166-435d-bf48-c4a0cff9999c.jpg?1",
             "name": "Golgari Grave-Troll",
             "text": "Golgari Grave-Troll comes into play with a +1/+1 counter on it for each creature card in your graveyard.\n{1}, Remove a +1/+1 counter from Golgari Grave-Troll: Regenerate Golgari Grave-Troll.\nDredge 6",
             "colours": [
@@ -5621,7 +5621,7 @@
         },
         {
             "id": "593baf77-dc3e-5051-8c84-f4756922a60d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecc53b1-942e-4b44-bf93-dd2d8cc92d6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cecc53b1-942e-4b44-bf93-dd2d8cc92d6d.jpg?1",
             "name": "Goliath Spider",
             "text": "Goliath Spider can block as though it had flying.",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "90b5c97e-63c5-5e98-b8c6-78e95e23ef68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f75b44-01a3-47f6-96c9-9ce327111e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f75b44-01a3-47f6-96c9-9ce327111e64.jpg?1",
             "name": "Greater Mossdog",
             "text": "Dredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "4403a43c-d8ab-55da-8132-13b078821a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d891e-ae8c-485a-b999-d1e08fffd164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9d891e-ae8c-485a-b999-d1e08fffd164.jpg?1",
             "name": "Hunted Troll",
             "text": "When Hunted Troll comes into play, put four 1/1 blue Faerie creature tokens with flying into play under target opponent's control.\n{G}: Regenerate Hunted Troll.",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "92d05c9c-7ed9-5bdf-b1b9-ac5fe1b9554f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73597c90-a527-4338-9668-126c6cf15927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73597c90-a527-4338-9668-126c6cf15927.jpg?1",
             "name": "Ivy Dancer",
             "text": "{T}: Target creature gains forestwalk until end of turn.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "ce783790-bdb1-54ea-8433-c35e797e8aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac16d09-8bc7-407c-a757-666f4707bc90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac16d09-8bc7-407c-a757-666f4707bc90.jpg?1",
             "name": "Life from the Loam",
             "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5792,7 +5792,7 @@
         },
         {
             "id": "5b4cbdfb-9659-5c54-8f39-24ac175904a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c3f80-aaa7-485f-b519-57363f5905dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c3f80-aaa7-485f-b519-57363f5905dd.jpg?1",
             "name": "Moldervine Cloak",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "9bbf9c3a-8077-5b86-aec4-f59bd0a89c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f2a6de-1598-4dd9-81a0-9a4f3dd4de0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f2a6de-1598-4dd9-81a0-9a4f3dd4de0b.jpg?1",
             "name": "Nullmage Shepherd",
             "text": "Tap four untapped creatures you control: Destroy target artifact or enchantment.",
             "colours": [
@@ -5861,7 +5861,7 @@
         },
         {
             "id": "9cf1da14-c2e1-5c47-9119-66c0c9039f21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f6cc6-52ed-417f-b816-5733a71566e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f6cc6-52ed-417f-b816-5733a71566e8.jpg?1",
             "name": "Overwhelm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nCreatures you control get +3/+3 until end of turn.",
             "colours": [
@@ -5893,7 +5893,7 @@
         },
         {
             "id": "be3901f3-b843-5080-8cb9-162d11b96926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210a148-d16c-42de-b0d6-83c05c553dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4210a148-d16c-42de-b0d6-83c05c553dd4.jpg?1",
             "name": "Perilous Forays",
             "text": "{1}, Sacrifice a creature: Search your library for a land card with a basic land type and put it into play tapped. Then shuffle your library.",
             "colours": [
@@ -5925,7 +5925,7 @@
         },
         {
             "id": "4294ccb7-7d57-5f82-804f-67bdc4425951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e11e6d8-d375-4278-8cb0-94deeecaeeca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e11e6d8-d375-4278-8cb0-94deeecaeeca.jpg?1",
             "name": "Primordial Sage",
             "text": "Whenever you play a creature spell, you may draw a card.",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "c6407cc8-db5e-50c2-8cfb-91898200f7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa7f09-a2cc-4bef-857a-32bcccb7366a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa7f09-a2cc-4bef-857a-32bcccb7366a.jpg?1",
             "name": "Recollect",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "84a77197-1c1a-575e-b682-e72da9d7e209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c5546f-2429-4099-a9bd-eda3f52779b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c5546f-2429-4099-a9bd-eda3f52779b7.jpg?1",
             "name": "Rolling Spoil",
             "text": "Destroy target land. If {B} was spent to play Rolling Spoil, all creatures get -1/-1 until end of turn.",
             "colours": [
@@ -6024,7 +6024,7 @@
         },
         {
             "id": "2a35aa39-5ff6-5f70-9dd0-7a6fa2d0ba8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e469162b-c8c9-4746-80f3-d2c2acd89e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e469162b-c8c9-4746-80f3-d2c2acd89e0f.jpg?1",
             "name": "Root-Kin Ally",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTap two untapped creatures you control: Root-Kin Ally gets +2/+2 until end of turn.",
             "colours": [
@@ -6059,7 +6059,7 @@
         },
         {
             "id": "5f51c98c-dd84-5b95-8d3f-744bf8968df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4415070-4304-482b-b8e5-2bf689af0843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4415070-4304-482b-b8e5-2bf689af0843.jpg?1",
             "name": "Scatter the Seeds",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nPut three 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -6091,7 +6091,7 @@
         },
         {
             "id": "f2035de2-ab53-5d76-908a-31c909c5ea1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb05072-c619-4024-8ed8-440b01f73113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb05072-c619-4024-8ed8-440b01f73113.jpg?1",
             "name": "Scion of the Wild",
             "text": "Scion of the Wild's power and toughness are each equal to the number of creatures you control.",
             "colours": [
@@ -6125,7 +6125,7 @@
         },
         {
             "id": "12d36672-1455-5c7a-a7a7-47ea8757134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae199825-563e-4837-a6d2-7b009b93cd4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae199825-563e-4837-a6d2-7b009b93cd4d.jpg?1",
             "name": "Siege Wurm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTrample",
             "colours": [
@@ -6159,7 +6159,7 @@
         },
         {
             "id": "a4237af4-952f-546f-a1c7-a49eb690403e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e1b9f9-e58c-4474-9a31-8e5d9f96492e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e1b9f9-e58c-4474-9a31-8e5d9f96492e.jpg?1",
             "name": "Stone-Seeder Hierophant",
             "text": "Whenever a land comes into play under your control, untap Stone-Seeder Hierophant.\n{T}: Untap target land.",
             "colours": [
@@ -6194,7 +6194,7 @@
         },
         {
             "id": "febb466a-a484-5a03-b1d2-8bb518b79cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab15b40-c5c8-4d77-a4c0-982b6bf94267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab15b40-c5c8-4d77-a4c0-982b6bf94267.jpg?1",
             "name": "Sundering Vitae",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "bf18d50d-461f-568c-ae19-c068c0cf7343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ce4ef-38bd-4360-895f-457587164197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318ce4ef-38bd-4360-895f-457587164197.jpg?1",
             "name": "Transluminant",
             "text": "{W}, Sacrifice Transluminant: Put a 1/1 white Spirit creature token with flying into play at end of turn.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "f8ff0acb-cc0c-59f1-8c5b-903107bc2ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d1047-9010-437c-94ab-7a8ad3a0250f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d1047-9010-437c-94ab-7a8ad3a0250f.jpg?1",
             "name": "Trophy Hunter",
             "text": "{1}{G}: Trophy Hunter deals 1 damage to target creature with flying.\nWhenever a creature with flying dealt damage by Trophy Hunter this turn is put into a graveyard, put a +1/+1 counter on Trophy Hunter.",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "cf82230f-aba8-5f6f-977b-b0cf27056efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba547810-c82a-498b-81eb-e81a8dcbbd42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba547810-c82a-498b-81eb-e81a8dcbbd42.jpg?1",
             "name": "Ursapine",
             "text": "{G}: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -6331,7 +6331,7 @@
         },
         {
             "id": "2b004b9e-40e1-52b4-83b2-11ec74543700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34955f52-521f-466c-9025-c117f6162e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34955f52-521f-466c-9025-c117f6162e97.jpg?1",
             "name": "Vinelasher Kudzu",
             "text": "Whenever a land comes into play under your control, put a +1/+1 counter on Vinelasher Kudzu.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "f082e76d-1746-5635-8e10-53e917d1de45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2521942-0ecd-45a9-bac6-04267a2c29ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2521942-0ecd-45a9-bac6-04267a2c29ed.jpg?1",
             "name": "Agrus Kos, Wojek Veteran",
             "text": "Whenever Agrus Kos, Wojek Veteran attacks, attacking red creatures get +2/+0 and attacking white creatures get +0/+2 until end of turn.",
             "colours": [
@@ -6404,7 +6404,7 @@
         },
         {
             "id": "8b40b5e3-4405-558f-aab3-7f338ff98dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7002a87b-a55f-42ec-b247-119a3229129f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7002a87b-a55f-42ec-b247-119a3229129f.jpg?1",
             "name": "Autochthon Wurm",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nTrample",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "58cf0961-f32d-59b8-8518-89ee1f3929e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb977f5b-2202-43c1-a8c0-7fba8c093fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb977f5b-2202-43c1-a8c0-7fba8c093fa2.jpg?1",
             "name": "Bloodbond March",
             "text": "Whenever a creature spell is played, each player returns all cards with the same name as that spell from his or her graveyard to play.",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "2bbd9b32-af50-55f9-bccd-cdb3c3db1b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf25cd63-3304-4eea-841b-1f058010c627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf25cd63-3304-4eea-841b-1f058010c627.jpg?1",
             "name": "Boros Swiftblade",
             "text": "Double strike",
             "colours": [
@@ -6511,7 +6511,7 @@
         },
         {
             "id": "d031d813-2876-56d6-a4f8-2b01220c95ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3acf27-5d07-48e6-8e19-a2e6d4cd49d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a3acf27-5d07-48e6-8e19-a2e6d4cd49d1.jpg?1",
             "name": "Brightflame",
             "text": "Radiance Brightflame deals X damage to target creature and each other creature that shares a color with it. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -6545,7 +6545,7 @@
         },
         {
             "id": "13579ae3-2808-51a3-a3f3-cab709a30dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2792033-19e1-4629-8155-85c6c2d89106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2792033-19e1-4629-8155-85c6c2d89106.jpg?1",
             "name": "Chorus of the Conclave",
             "text": "Forestwalk\nAs an additional cost to play creature spells, you may pay any amount of mana. If you do, that creature comes into play with that many additional +1/+1 counters on it.",
             "colours": [
@@ -6583,7 +6583,7 @@
         },
         {
             "id": "453557f6-8c03-50cb-92c5-dac1bca10dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b19c0f3-68a5-4544-985a-677aa2c2b50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b19c0f3-68a5-4544-985a-677aa2c2b50b.jpg?1",
             "name": "Circu, Dimir Lobotomist",
             "text": "Whenever you play a blue spell, remove the top card of target library from the game.\nWhenever you play a black spell, remove the top card of target library from the game.\nYour opponents can't play nonland cards with the same name as a card removed from the game with Circu, Dimir Lobotomist.",
             "colours": [
@@ -6622,7 +6622,7 @@
         },
         {
             "id": "2f63a51d-f3b2-56b5-a8dd-cd8bc605121c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24437641-85a1-4fcd-93dc-bd19a7abf969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24437641-85a1-4fcd-93dc-bd19a7abf969.jpg?1",
             "name": "Clutch of the Undercity",
             "text": "Return target permanent to its owner's hand. Its controller loses 3 life.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -6656,7 +6656,7 @@
         },
         {
             "id": "fa4ba4b4-d3ea-5c35-a0bd-103584e2442c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b950a-b2fe-4afc-bb79-c9f4c272ea36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1b950a-b2fe-4afc-bb79-c9f4c272ea36.jpg?1",
             "name": "Congregation at Dawn",
             "text": "Search your library for up to three creature cards and reveal them. Shuffle your library, then put those cards on top of it in any order.",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "5b2c7849-7049-50d7-9642-5a0aef702353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f51484b-3bad-4332-87f8-61924e153799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f51484b-3bad-4332-87f8-61924e153799.jpg?1",
             "name": "Consult the Necrosages",
             "text": "Choose one Target player draws two cards; or target player discards two cards.",
             "colours": [
@@ -6724,7 +6724,7 @@
         },
         {
             "id": "cdb47081-cb5e-51d1-90c2-373fa4442ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa3ae99-a770-4487-8de6-68a347ee64bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa3ae99-a770-4487-8de6-68a347ee64bb.jpg?1",
             "name": "Dark Heart of the Wood",
             "text": "Sacrifice a Forest: You gain 3 life.",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "fc519b02-d387-58ef-9c50-4c32685e920c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2b0b24-83bf-479b-baa4-3244a114852d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2b0b24-83bf-479b-baa4-3244a114852d.jpg?1",
             "name": "Dimir Cutpurse",
             "text": "Whenever Dimir Cutpurse deals combat damage to a player, that player discards a card and you draw a card.",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "395cbbdd-35bc-5e53-8cfb-c3e829055d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48be841-d35c-4d99-aebc-3684b36760ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48be841-d35c-4d99-aebc-3684b36760ac.jpg?1",
             "name": "Dimir Doppelganger",
             "text": "{1}{U}{B}: Remove target creature card in a graveyard from the game. Dimir Doppelganger becomes a copy of that card and gains this ability.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "f530fa6e-3693-506d-90e1-c50fced85654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db9204c-dde8-4241-aac2-1f090566f604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db9204c-dde8-4241-aac2-1f090566f604.jpg?1",
             "name": "Dimir Infiltrator",
             "text": "Dimir Infiltrator is unblockable.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -6866,7 +6866,7 @@
         },
         {
             "id": "ccd23eca-52a3-5898-aac1-c4b58afe9f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de33c222-0d74-4eb5-8794-39f3601eb8f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de33c222-0d74-4eb5-8794-39f3601eb8f4.jpg?1",
             "name": "Drooling Groodion",
             "text": "{2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "183d005e-9f6f-5252-9df3-f50bf7ab8db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493730ab-c30d-4830-a188-0462426fc5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493730ab-c30d-4830-a188-0462426fc5bf.jpg?1",
             "name": "Firemane Angel",
             "text": "Flying, first strike\nAt the beginning of your upkeep, if Firemane Angel is in your graveyard or in play, you may gain 1 life.\n{6}{R}{R}{W}{W}: Return Firemane Angel from your graveyard to play. Play this ability only during your upkeep.",
             "colours": [
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "5d2cc56e-38c8-5681-bdb4-29f69938fcd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec53f16-5bf7-4ef5-b83e-9e36463d1640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec53f16-5bf7-4ef5-b83e-9e36463d1640.jpg?1",
             "name": "Flame-Kin Zealot",
             "text": "When Flame-Kin Zealot comes into play, creatures you control get +1/+1 and gain haste until end of turn.",
             "colours": [
@@ -6975,7 +6975,7 @@
         },
         {
             "id": "53b8c3a5-8d06-53f4-915e-e2556baddc63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6166c1-3c2e-47af-873e-d3b39f42bd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6166c1-3c2e-47af-873e-d3b39f42bd27.jpg?1",
             "name": "Glare of Subdual",
             "text": "Tap an untapped creature you control: Tap target artifact or creature.",
             "colours": [
@@ -7009,7 +7009,7 @@
         },
         {
             "id": "5b1744f0-fe62-5d3b-9d6d-3afc718e37fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48058253-54b8-403b-8d95-94d8da986e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48058253-54b8-403b-8d95-94d8da986e69.jpg?1",
             "name": "Glimpse the Unthinkable",
             "text": "Target player puts the top ten cards of his or her library into his or her graveyard.",
             "colours": [
@@ -7043,7 +7043,7 @@
         },
         {
             "id": "995420bb-d38b-5ac1-b037-dd553acfc9f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a1db16-d936-4f92-9611-327a988ce04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a1db16-d936-4f92-9611-327a988ce04c.jpg?1",
             "name": "Golgari Germination",
             "text": "Whenever a nontoken creature you control is put into a graveyard from play, put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7077,7 +7077,7 @@
         },
         {
             "id": "3d3e337a-c4fe-553f-a3f7-a1f8836c3b70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc97674-f60a-4854-a807-60dbcf90637e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc97674-f60a-4854-a807-60dbcf90637e.jpg?1",
             "name": "Golgari Rotwurm",
             "text": "{B}, Sacrifice a creature: Target player loses 1 life.",
             "colours": [
@@ -7114,7 +7114,7 @@
         },
         {
             "id": "2b87f5e4-7a9a-5f2b-901e-4a9f90fc178a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f7c7d0-a48b-4153-8386-a9ab71e01dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f7c7d0-a48b-4153-8386-a9ab71e01dbe.jpg?1",
             "name": "Grave-Shell Scarab",
             "text": "{1}, Sacrifice Grave-Shell Scarab: Draw a card.\nDredge 1 (If you would draw a card, instead you may put exactly one card from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -7150,7 +7150,7 @@
         },
         {
             "id": "00a9a91f-5e03-55dd-8056-fa9a1487e2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c293144-df82-481d-8d24-2bdc164a355f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c293144-df82-481d-8d24-2bdc164a355f.jpg?1",
             "name": "Guardian of Vitu-Ghazi",
             "text": "Convoke (Each creature you tap while playing this spell reduces its cost by {1} or by one mana of that creature's color.)\nVigilance",
             "colours": [
@@ -7186,7 +7186,7 @@
         },
         {
             "id": "e61fd0ed-2584-5418-8eda-895e195a01ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ecf55-c1cc-4b28-b7ce-e1b25305155e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2ecf55-c1cc-4b28-b7ce-e1b25305155e.jpg?1",
             "name": "Lightning Helix",
             "text": "Lightning Helix deals 3 damage to target creature or player and you gain 3 life.",
             "colours": [
@@ -7220,7 +7220,7 @@
         },
         {
             "id": "4bbdd0b5-fa9b-5c01-9bcb-7f3d00219ec7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d3ccca-8040-4a5f-9f2b-6fdb1a033234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d3ccca-8040-4a5f-9f2b-6fdb1a033234.jpg?1",
             "name": "Loxodon Hierarch",
             "text": "When Loxodon Hierarch comes into play, you gain 4 life.\n{G}{W}, Sacrifice Loxodon Hierarch: Regenerate each creature you control.",
             "colours": [
@@ -7257,7 +7257,7 @@
         },
         {
             "id": "48f883d8-4058-56bd-8faa-96ba0664835f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd1ace7-d4fe-4f96-9434-7ab1442bf36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd1ace7-d4fe-4f96-9434-7ab1442bf36f.jpg?1",
             "name": "Mindleech Mass",
             "text": "Trample\nWhenever Mindleech Mass deals combat damage to a player, you may look at that player's hand. If you do, you may play a nonland card in it without paying that card's mana cost.",
             "colours": [
@@ -7293,7 +7293,7 @@
         },
         {
             "id": "c1b576c5-065d-5087-885c-6fcedf90ec60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ce70-67d1-4007-94ed-4545867e90c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ce70-67d1-4007-94ed-4545867e90c8.jpg?1",
             "name": "Moroii",
             "text": "Flying\nAt the beginning of your upkeep, you lose 1 life.",
             "colours": [
@@ -7329,7 +7329,7 @@
         },
         {
             "id": "fae008d9-5c98-514e-a421-19ee462b615c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db57459-29f0-4ef6-b256-56955036c0ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db57459-29f0-4ef6-b256-56955036c0ef.jpg?1",
             "name": "Perplex",
             "text": "Counter target spell unless its controller discards his or her hand.\nTransmute {1}{U}{B} ({1}{U}{B}, Discard this card: Search your library for a card with the same converted mana cost as this card, reveal it, and put it into your hand. Then shuffle your library. Play only as a sorcery.)",
             "colours": [
@@ -7363,7 +7363,7 @@
         },
         {
             "id": "7a996930-adb2-5ddf-b461-dc260ff1299e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c336d2-cc14-4b74-a6f9-aab7a084d0de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c336d2-cc14-4b74-a6f9-aab7a084d0de.jpg?1",
             "name": "Phytohydra",
             "text": "If damage would be dealt to Phytohydra, put that many +1/+1 counters on it instead.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "bf6b7f41-54c7-57c6-a191-104752a1ffb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4f3b9-c952-4fd3-a586-3e063b62b23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca4f3b9-c952-4fd3-a586-3e063b62b23d.jpg?1",
             "name": "Pollenbright Wings",
             "text": "Enchant creature\nEnchanted creature has flying.\nWhenever enchanted creature deals combat damage to a player, put that many 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "b08979df-d3d0-5233-892f-3e5b0d41c96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fd2d8-76ce-4334-b772-a5dc64fc2989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00fd2d8-76ce-4334-b772-a5dc64fc2989.jpg?1",
             "name": "Psychic Drain",
             "text": "Target player puts the top X cards of his or her library into his or her graveyard and you gain X life.",
             "colours": [
@@ -7470,7 +7470,7 @@
         },
         {
             "id": "053430c0-71b0-581d-bd3d-a71245169850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a16086c-5a74-45d0-8b38-e832cfbc80f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a16086c-5a74-45d0-8b38-e832cfbc80f7.jpg?1",
             "name": "Putrefy",
             "text": "Destroy target artifact or creature. It can't be regenerated.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "9d6d70be-5377-508c-a46c-1b6ad93b678a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da51b6c-2e27-4b41-8fb0-bd9f6ad47b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da51b6c-2e27-4b41-8fb0-bd9f6ad47b19.jpg?1",
             "name": "Rally the Righteous",
             "text": "Radiance Untap target creature and each other creature that shares a color with it. Those creatures get +2/+0 until end of turn.",
             "colours": [
@@ -7538,7 +7538,7 @@
         },
         {
             "id": "a0e6342a-749e-51c9-8724-0307c6b76b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4580cc4-ee26-41d9-a81c-91505c9e2a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4580cc4-ee26-41d9-a81c-91505c9e2a99.jpg?1",
             "name": "Razia, Boros Archangel",
             "text": "Flying, vigilance, haste\n{T}: The next 3 damage that would be dealt to target creature you control this turn is dealt to another target creature instead.",
             "colours": [
@@ -7576,7 +7576,7 @@
         },
         {
             "id": "76134657-9512-53e5-a6fc-612936fe5430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bfefd3-bddd-47bb-92f3-9356a7bca637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bfefd3-bddd-47bb-92f3-9356a7bca637.jpg?1",
             "name": "Razia's Purification",
             "text": "Each player chooses three permanents he or she controls, then sacrifices the rest.",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "41ced48b-e899-595b-b597-c1713a9b23d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15accf35-a174-4ba5-a633-cc46da848dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15accf35-a174-4ba5-a633-cc46da848dbe.jpg?1",
             "name": "Savra, Queen of the Golgari",
             "text": "Whenever you sacrifice a black creature, you may pay 2 life. If you do, each other player sacrifices a creature.\nWhenever you sacrifice a green creature, you may gain 2 life.",
             "colours": [
@@ -7649,7 +7649,7 @@
         },
         {
             "id": "093f3647-e200-5d25-91a4-c2203c1a8e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c1fbdd-884d-467a-956e-7c28881002ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c1fbdd-884d-467a-956e-7c28881002ab.jpg?1",
             "name": "Searing Meditation",
             "text": "Whenever you gain life, you may pay {2}. If you do, Searing Meditation deals 2 damage to target creature or player.",
             "colours": [
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "b35aa8d3-6a4c-5e15-af92-3e31e01a605b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1ac13-adbd-439a-90b2-9c506aec0836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa1ac13-adbd-439a-90b2-9c506aec0836.jpg?1",
             "name": "Seeds of Strength",
             "text": "Target creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7717,7 +7717,7 @@
         },
         {
             "id": "81a24c93-3e7b-588d-89fd-35986a869c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc93c1-f236-4d1b-bb54-5041b3cae5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18bc93c1-f236-4d1b-bb54-5041b3cae5a6.jpg?1",
             "name": "Selesnya Evangel",
             "text": "{1}, {T}, Tap an untapped creature you control: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "397533b3-b323-55d0-8b45-c886a135431e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72e933-d977-4be9-985f-8b8cf1267f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a72e933-d977-4be9-985f-8b8cf1267f8c.jpg?1",
             "name": "Selesnya Sagittars",
             "text": "Selesnya Sagittars can block as though it had flying.\nSelesnya Sagittars can block an additional creature.",
             "colours": [
@@ -7791,7 +7791,7 @@
         },
         {
             "id": "91999a15-77f6-52de-8cc3-ece4533870ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c93baa2-a23e-4e18-b4cd-779c992d2042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c93baa2-a23e-4e18-b4cd-779c992d2042.jpg?1",
             "name": "Shambling Shell",
             "text": "Sacrifice Shambling Shell: Put a +1/+1 counter on target creature.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -7828,7 +7828,7 @@
         },
         {
             "id": "83ac4bbb-3524-5919-b694-948835fcaa47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d214d25b-96c3-4479-88f0-3996805d6e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d214d25b-96c3-4479-88f0-3996805d6e6f.jpg?1",
             "name": "Sisters of Stone Death",
             "text": "{G}: Target creature blocks Sisters of Stone Death this turn if able.\n{B}{G}: Remove from the game target creature blocking or blocked by Sisters of Stone Death.\n{2}{B}: Put a creature card removed from the game with Sisters of Stone Death into play under your control.",
             "colours": [
@@ -7866,7 +7866,7 @@
         },
         {
             "id": "0d1accb6-0750-5106-86fa-e2d306957ee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d697ef7f-0e51-4bf1-b0f5-742325706d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d697ef7f-0e51-4bf1-b0f5-742325706d2a.jpg?1",
             "name": "Skyknight Legionnaire",
             "text": "Flying, haste",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "c4c283d1-38e1-54c1-8f78-9fb2cdd3c9c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d5a88e-fc8f-4dd6-a1db-8e44b74ee0a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d5a88e-fc8f-4dd6-a1db-8e44b74ee0a1.jpg?1",
             "name": "Sunhome Enforcer",
             "text": "Whenever Sunhome Enforcer deals combat damage, you gain that much life.\n{1}{R}: Sunhome Enforcer gets +1/+0 until end of turn.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "5b121bea-6ded-5381-ac80-356798db0f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2882793e-5d7d-47f0-9308-652a5e036c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2882793e-5d7d-47f0-9308-652a5e036c2c.jpg?1",
             "name": "Szadek, Lord of Secrets",
             "text": "Flying\nIf Szadek, Lord of Secrets would deal combat damage to a player, instead put that many +1/+1 counters on Szadek and that player puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -7978,7 +7978,7 @@
         },
         {
             "id": "05953b58-a7c9-5e3d-8453-fd2864ec9a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7410c546-745c-469f-b3b8-eafb69391600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7410c546-745c-469f-b3b8-eafb69391600.jpg?1",
             "name": "Thundersong Trumpeter",
             "text": "{T}: Target creature can't attack or block this turn.",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "2d44bf3a-1e70-51b0-8916-ca2d1637e093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069ac859-e0ef-4685-bad3-5c741102b5b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069ac859-e0ef-4685-bad3-5c741102b5b9.jpg?1",
             "name": "Tolsimir Wolfblood",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\n{T}: Put a legendary 2/2 green and white Wolf creature token named Voja into play.",
             "colours": [
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "56830f0b-574b-542e-b359-1e1f96d00945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8efa02d-c301-47e1-8cdf-26ff9e97a243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8efa02d-c301-47e1-8cdf-26ff9e97a243.jpg?1",
             "name": "Twisted Justice",
             "text": "Target player sacrifices a creature. You draw cards equal to that creature's power.",
             "colours": [
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "d78b4876-e7c1-57c4-8add-1e03c1641619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0fb8e7-14aa-4f2d-aa05-c98b2c9c463c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0fb8e7-14aa-4f2d-aa05-c98b2c9c463c.jpg?1",
             "name": "Vulturous Zombie",
             "text": "Flying\nWhenever a card is put into an opponent's graveyard from anywhere, put a +1/+1 counter on Vulturous Zombie.",
             "colours": [
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "4105410d-0c37-5789-bd00-5ab797869010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e5828a-3e54-4b9c-9e84-21880930f2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e5828a-3e54-4b9c-9e84-21880930f2d5.jpg?1",
             "name": "Watchwolf",
             "text": "",
             "colours": [
@@ -8161,7 +8161,7 @@
         },
         {
             "id": "74a0677a-51e1-5aad-96f9-82b551cf6d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ee1ceb-61dd-4c98-bc48-a0763315a14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ee1ceb-61dd-4c98-bc48-a0763315a14f.jpg?1",
             "name": "Woodwraith Corrupter",
             "text": "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.",
             "colours": [
@@ -8198,7 +8198,7 @@
         },
         {
             "id": "4702b4cc-8657-5a1b-9fd2-4fe243a435d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be72ff91-f810-46c3-884f-6e65827824bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be72ff91-f810-46c3-884f-6e65827824bc.jpg?1",
             "name": "Woodwraith Strangler",
             "text": "Remove a creature card in your graveyard from the game: Regenerate Woodwraith Strangler.",
             "colours": [
@@ -8235,7 +8235,7 @@
         },
         {
             "id": "58ff5d21-c09e-5db2-8c2f-a7dec1044c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072a1ff1-9c50-426a-a83c-817bde5beab7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072a1ff1-9c50-426a-a83c-817bde5beab7.jpg?1",
             "name": "Boros Guildmage",
             "text": "({GU} can be paid with either {R} or {W}.)\n{1}{R}: Target creature gains haste until end of turn.\n{1}{W}: Target creature gains first strike until end of turn.",
             "colours": [
@@ -8272,7 +8272,7 @@
         },
         {
             "id": "e7281adb-90f4-5846-84fc-b37d9fffd0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af01330-05c2-4c5b-9830-2886711b2b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af01330-05c2-4c5b-9830-2886711b2b5d.jpg?1",
             "name": "Boros Recruit",
             "text": "({GU} can be paid with either {R} or {W}.)\nFirst strike",
             "colours": [
@@ -8309,7 +8309,7 @@
         },
         {
             "id": "e6907eca-7ab7-50b7-8643-54e3ef59dfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d3e06-93e6-4948-a3ec-6a00bdfc0f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647d3e06-93e6-4948-a3ec-6a00bdfc0f99.jpg?1",
             "name": "Centaur Safeguard",
             "text": "({RW} can be paid with either {G} or {W}.)\nWhen Centaur Safeguard is put into a graveyard from play, you may gain 3 life.",
             "colours": [
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "5e253a9c-ac94-5adb-a43b-977bbeddb0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b822aa-4144-400a-b993-f146cbeed54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b822aa-4144-400a-b993-f146cbeed54f.jpg?1",
             "name": "Dimir Guildmage",
             "text": "({UB} can be paid with either {U} or {B}.)\n{3}{U}: Target player draws a card. Play this ability only any time you could play a sorcery.\n{3}{B}: Target player discards a card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "6f8dd65f-541e-5648-a5e6-46ac14dab8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c9e772-5213-4c28-9b6c-1cfa6675ee8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c9e772-5213-4c28-9b6c-1cfa6675ee8f.jpg?1",
             "name": "Gaze of the Gorgon",
             "text": "({BG} can be paid with either {B} or {G}.)\nRegenerate target creature. At end of combat, destroy all creatures that blocked or were blocked by that creature this turn.",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "c6fe3337-c030-5027-bd04-8a3efc82c974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ebb44b-bf3e-4b9e-b568-c20970bb969d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ebb44b-bf3e-4b9e-b568-c20970bb969d.jpg?1",
             "name": "Gleancrawler",
             "text": "({BG} can be paid with either {B} or {G}.)\nTrample\nAt the end of your turn, return to your hand all creature cards in your graveyard that were put into your graveyard from play this turn.",
             "colours": [
@@ -8454,7 +8454,7 @@
         },
         {
             "id": "09a6caee-5d4c-5ecb-94cb-3a87f7f716f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91b994b-3cf2-43f7-8af6-7925e882208f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d91b994b-3cf2-43f7-8af6-7925e882208f.jpg?1",
             "name": "Golgari Guildmage",
             "text": "({BG} can be paid with either {B} or {G}.)\n{4}{B}, Sacrifice a creature: Return target creature card from your graveyard to your hand.\n{4}{G}: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -8491,7 +8491,7 @@
         },
         {
             "id": "09f94154-ca76-516b-935d-ea73506ce16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012a7f5d-f798-4030-86e3-05956487a383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012a7f5d-f798-4030-86e3-05956487a383.jpg?1",
             "name": "Lurking Informant",
             "text": "({UB} can be paid with either {U} or {B}.)\n{2}, {T}: Look at the top card of target player's library. You may put that card into that player's graveyard.",
             "colours": [
@@ -8528,7 +8528,7 @@
         },
         {
             "id": "183f0174-15d9-5f8a-893d-b6c1b8d1ab88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d111510-ca7f-4127-b540-48265aa36311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d111510-ca7f-4127-b540-48265aa36311.jpg?1",
             "name": "Master Warcraft",
             "text": "({GU} can be paid with either {R} or {W}.)\nPlay Master Warcraft only before attackers are declared.\nYou choose which creatures attack this turn. You choose how each creature blocks this turn.",
             "colours": [
@@ -8562,7 +8562,7 @@
         },
         {
             "id": "990b4608-845a-5e46-a7ce-5841036d5792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fa7566-6f7d-4c01-a442-ff7b38684de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fa7566-6f7d-4c01-a442-ff7b38684de5.jpg?1",
             "name": "Privileged Position",
             "text": "({RW} can be paid with either {G} or {W}.)\nOther permanents you control can't be the targets of spells or abilities your opponents control.",
             "colours": [
@@ -8596,7 +8596,7 @@
         },
         {
             "id": "5e01676c-e569-5361-a283-a955985a1c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061ce3-d098-4057-b341-c5db6ee1b6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21061ce3-d098-4057-b341-c5db6ee1b6d4.jpg?1",
             "name": "Selesnya Guildmage",
             "text": "({RW} can be paid with either {G} or {W}.)\n{3}{G}: Put a 1/1 green Saproling creature token into play.\n{3}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -8633,7 +8633,7 @@
         },
         {
             "id": "81752769-5fae-5f84-8ef3-b0a54ae4a07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd0e3c-b26d-4080-b7cf-1c64fce09668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dbd0e3c-b26d-4080-b7cf-1c64fce09668.jpg?1",
             "name": "Shadow of Doubt",
             "text": "({UB} can be paid with either {U} or {B}.)\nPlayers can't search libraries this turn.\nDraw a card.",
             "colours": [
@@ -8667,7 +8667,7 @@
         },
         {
             "id": "efeafb7b-1469-57d2-ad0b-ce14fb1a4d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fbdf87-2424-4fc2-904e-b1e5fef2a335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8fbdf87-2424-4fc2-904e-b1e5fef2a335.jpg?1",
             "name": "Bloodletter Quill",
             "text": "{2}, {T}, Put a blood counter on Bloodletter Quill: Draw a card, then lose 1 life for each blood counter on Bloodletter Quill.\n{U}{B}: Remove a blood counter from Bloodletter Quill.",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "9c2d81ca-5226-5e4b-86e8-25f7db1b55e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bae1f86-4639-4424-b47b-fdc826bf6e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bae1f86-4639-4424-b47b-fdc826bf6e97.jpg?1",
             "name": "Boros Signet",
             "text": "{1}, {T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -8729,7 +8729,7 @@
         },
         {
             "id": "4b3fd16f-651c-5a95-ac77-d531f3404215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf42acc-d2d3-4165-b257-6885df2d1ba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf42acc-d2d3-4165-b257-6885df2d1ba4.jpg?1",
             "name": "Bottled Cloister",
             "text": "At the beginning of each opponent's upkeep, remove your hand from the game face down.\nAt the beginning of your upkeep, return all cards removed from the game with Bottled Cloister to your hand, then draw a card.",
             "colours": [],
@@ -8757,7 +8757,7 @@
         },
         {
             "id": "3e762ce1-a71e-5628-96fe-16f023b26692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cbda17-d368-4dc3-b41c-95b146468b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cbda17-d368-4dc3-b41c-95b146468b44.jpg?1",
             "name": "Cloudstone Curio",
             "text": "Whenever a nonartifact permanent comes into play under your control, you may return another permanent you control that shares a permanent type with it to its owner's hand.",
             "colours": [],
@@ -8785,7 +8785,7 @@
         },
         {
             "id": "2af36b8a-b78e-59c6-a39a-389c9130e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9f8c8-2927-4746-a540-dd3853b9a00e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b9f8c8-2927-4746-a540-dd3853b9a00e.jpg?1",
             "name": "Crown of Convergence",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is a creature card, creatures you control that share a color with that card get +1/+1.\n{G}{W}: Put the top card of your library on the bottom of your library.",
             "colours": [],
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "9c789793-c943-5610-9932-df7f18bac118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ba776a-c959-4d15-aa36-9fba1fcb512d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22ba776a-c959-4d15-aa36-9fba1fcb512d.jpg?1",
             "name": "Cyclopean Snare",
             "text": "{3}, {T}: Tap target creature, then return Cyclopean Snare to its owner's hand.",
             "colours": [],
@@ -8844,7 +8844,7 @@
         },
         {
             "id": "ce7fef66-cc4b-51eb-a04a-a80a07c39b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a1df5-a4e8-49a4-aebe-ca93894ccfcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9a1df5-a4e8-49a4-aebe-ca93894ccfcf.jpg?1",
             "name": "Dimir Signet",
             "text": "{1}, {T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "e50d20e1-d4be-5ebc-b894-ae035d53f1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87dc27-3cea-4101-aec5-ca0b96978476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b87dc27-3cea-4101-aec5-ca0b96978476.jpg?1",
             "name": "Glass Golem",
             "text": "",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "322cac64-5434-522e-9e63-eac1789cb457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be03b002-1a3e-4b21-bc23-7f5a9cedb74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be03b002-1a3e-4b21-bc23-7f5a9cedb74f.jpg?1",
             "name": "Golgari Signet",
             "text": "{1}, {T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -8937,7 +8937,7 @@
         },
         {
             "id": "f7ccd7a2-5491-5a75-96d3-03ea414aba9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c411784-fe96-42c0-baaa-36616d2be0b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c411784-fe96-42c0-baaa-36616d2be0b3.jpg?1",
             "name": "Grifter's Blade",
             "text": "You may play Grifter's Blade any time you could play an instant.\nGrifter's Blade comes into play equipping a creature of your choice you control.\nEquipped creature gets +1/+1.\nEquip {1}",
             "colours": [],
@@ -8967,7 +8967,7 @@
         },
         {
             "id": "076aecd2-ee13-5312-b855-c0c22b611d0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2c5f0a-755f-4d4f-b5f8-a938562797f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e2c5f0a-755f-4d4f-b5f8-a938562797f9.jpg?1",
             "name": "Junktroller",
             "text": "Defender (This creature can't attack.)\n{T}: Put target card in a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -8998,7 +8998,7 @@
         },
         {
             "id": "ed229ac6-bf5d-5c62-b7f3-4f3a19f93e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132551d3-ef8e-4ed0-a363-53db4f0621f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132551d3-ef8e-4ed0-a363-53db4f0621f0.jpg?1",
             "name": "Leashling",
             "text": "Put a card in your hand on top of your library: Return Leashling to its owner's hand.",
             "colours": [],
@@ -9029,7 +9029,7 @@
         },
         {
             "id": "f5962af1-362b-51fd-85e4-ce61b9e2616f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3aa88-2555-4862-a771-e9d5b9eab3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dc3aa88-2555-4862-a771-e9d5b9eab3ad.jpg?1",
             "name": "Nullstone Gargoyle",
             "text": "Flying\nWhenever the first noncreature spell each turn is played, counter that spell.",
             "colours": [],
@@ -9060,7 +9060,7 @@
         },
         {
             "id": "695aff1d-4e37-5ea8-84f2-7801224ddf14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc316f1e-84ce-4013-a150-d537f964a604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc316f1e-84ce-4013-a150-d537f964a604.jpg?1",
             "name": "Pariah's Shield",
             "text": "All damage that would be dealt to you is dealt to equipped creature instead.\nEquip {3}",
             "colours": [],
@@ -9090,7 +9090,7 @@
         },
         {
             "id": "fcfb1c77-470a-5621-9b88-eaf258cd2648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9196f43e-f905-4e83-8e47-9d8fd53a4c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9196f43e-f905-4e83-8e47-9d8fd53a4c9f.jpg?1",
             "name": "Peregrine Mask",
             "text": "Equipped creature has defender, flying, and first strike.\nEquip {2}",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "3df6d500-7ad3-52da-8ae6-a43bbfb16436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889bab2c-d383-4a04-9f93-d507ba1973d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889bab2c-d383-4a04-9f93-d507ba1973d9.jpg?1",
             "name": "Plague Boiler",
             "text": "At the beginning of your upkeep, put a plague counter on Plague Boiler.\n{1}{B}{G}: Put a plague counter on Plague Boiler or remove a plague counter from it.\nWhen Plague Boiler has three or more plague counters on it, sacrifice it. If you do, destroy all nonland permanents.",
             "colours": [],
@@ -9151,7 +9151,7 @@
         },
         {
             "id": "273fbe25-2b2e-5985-9275-a80faf21cf28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296d86a-2c79-43c8-8a1c-1d4bb600bc6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8296d86a-2c79-43c8-8a1c-1d4bb600bc6b.jpg?1",
             "name": "Selesnya Signet",
             "text": "{1}, {T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -9182,7 +9182,7 @@
         },
         {
             "id": "243d65bb-1327-5675-ab41-9fa124bd65e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7209e2-8e62-40aa-ad84-16c6ad52fd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7209e2-8e62-40aa-ad84-16c6ad52fd69.jpg?1",
             "name": "Spectral Searchlight",
             "text": "{T}: Choose a player. That player adds one mana of any color he or she chooses to his or her mana pool.",
             "colours": [],
@@ -9210,7 +9210,7 @@
         },
         {
             "id": "9c306e3a-2110-50ae-b597-e16b1c7b2cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d5e027-aa74-444b-a945-1bafa9bdec4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d5e027-aa74-444b-a945-1bafa9bdec4c.jpg?1",
             "name": "Sunforger",
             "text": "Equipped creature gets +4/+0.\n{R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and play that card without paying its mana cost. Then shuffle your library.\nEquip {3}",
             "colours": [],
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "a789a1ae-4b80-5eae-b2c7-22c793b2f092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4b07f-c6ed-4a92-aab3-54ee6adfb793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c4b07f-c6ed-4a92-aab3-54ee6adfb793.jpg?1",
             "name": "Terrarion",
             "text": "Terrarion comes into play tapped.\n{2}, {T}, Sacrifice Terrarion: Add two mana of any combination of colors to your mana pool.\nWhen Terrarion is put into a graveyard from play, draw a card.",
             "colours": [],
@@ -9271,7 +9271,7 @@
         },
         {
             "id": "976bf8cd-e60a-5276-bd19-7f3a0335c773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76554c65-edea-48b0-b3a5-483dfe80eaac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76554c65-edea-48b0-b3a5-483dfe80eaac.jpg?1",
             "name": "Voyager Staff",
             "text": "{2}, Sacrifice Voyager Staff: Remove target creature from the game. Return that creature to play under its owner's control at end of turn.",
             "colours": [],
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "2127bd81-012a-54c2-95f3-1103658dd954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfe3f03-078f-44fb-89cd-efa3ebfaf637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfe3f03-078f-44fb-89cd-efa3ebfaf637.jpg?1",
             "name": "Boros Garrison",
             "text": "Boros Garrison comes into play tapped.\nWhen Boros Garrison comes into play, return a land you control to its owner's hand.\n{T}: Add {R}{W} to your mana pool.",
             "colours": [],
@@ -9330,7 +9330,7 @@
         },
         {
             "id": "2ecd3ce5-e0d7-56e4-8d87-df9b678d7208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3c3d56-8291-407e-87a1-94b7d12811fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df3c3d56-8291-407e-87a1-94b7d12811fd.jpg?1",
             "name": "Dimir Aqueduct",
             "text": "Dimir Aqueduct comes into play tapped.\nWhen Dimir Aqueduct comes into play, return a land you control to its owner's hand.\n{T}: Add {U}{B} to your mana pool.",
             "colours": [],
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "32d6d03c-eef1-529f-9553-01ff8e8b9424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c85e2-58a5-4469-85ea-7e89268f310c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d3c85e2-58a5-4469-85ea-7e89268f310c.jpg?1",
             "name": "Duskmantle, House of Shadow",
             "text": "{T}: Add {1} to your mana pool.\n{U}{B}, {T}: Target player puts the top card of his or her library into his or her graveyard.",
             "colours": [],
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "911117a2-7e08-56c3-b461-71d3f6efa207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104364d5-ede8-4ac5-900f-19947f51bbc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/104364d5-ede8-4ac5-900f-19947f51bbc1.jpg?1",
             "name": "Golgari Rot Farm",
             "text": "Golgari Rot Farm comes into play tapped.\nWhen Golgari Rot Farm comes into play, return a land you control to its owner's hand.\n{T}: Add {B}{G} to your mana pool.",
             "colours": [],
@@ -9423,7 +9423,7 @@
         },
         {
             "id": "2e023e3e-dc65-5aac-905e-6c139346e1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce07335-cc78-4683-b2f0-9c98a06ea1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fce07335-cc78-4683-b2f0-9c98a06ea1d8.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G} to your mana pool.)\nAs Overgrown Tomb comes into play, you may pay 2 life. If you don't, Overgrown Tomb comes into play tapped instead.",
             "colours": [],
@@ -9457,7 +9457,7 @@
         },
         {
             "id": "3b30c16d-eb6d-59fa-9729-bc868450a204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168ef687-5797-4b45-b75b-393d8117cebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168ef687-5797-4b45-b75b-393d8117cebd.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W} to your mana pool.)\nAs Sacred Foundry comes into play, you may pay 2 life. If you don't, Sacred Foundry comes into play tapped instead.",
             "colours": [],
@@ -9491,7 +9491,7 @@
         },
         {
             "id": "9da98b27-6527-5f23-8814-11a4404474f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e51787-f9c9-4926-9df1-a384a3092676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e51787-f9c9-4926-9df1-a384a3092676.jpg?1",
             "name": "Selesnya Sanctuary",
             "text": "Selesnya Sanctuary comes into play tapped.\nWhen Selesnya Sanctuary comes into play, return a land you control to its owner's hand.\n{T}: Add {G}{W} to your mana pool.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "39ea48df-0fce-566b-b832-0e44f4ced3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a69f7b-be68-43f7-b1ed-df528bde74e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a69f7b-be68-43f7-b1ed-df528bde74e5.jpg?1",
             "name": "Sunhome, Fortress of the Legion",
             "text": "{T}: Add {1} to your mana pool.\n{2}{R}{W}, {T}: Target creature gains double strike until end of turn.",
             "colours": [],
@@ -9553,7 +9553,7 @@
         },
         {
             "id": "3f6aa6a9-4174-5a58-8695-b8acb9e1a4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3ba87-93a0-44db-83d9-92e23a677a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cf3ba87-93a0-44db-83d9-92e23a677a62.jpg?1",
             "name": "Svogthos, the Restless Tomb",
             "text": "{T}: Add {1} to your mana pool.\n{3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land.",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "e43df04f-3552-5dc1-844e-6c13fe84b8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794a2b79-8c55-4423-8843-7e6e96f84071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794a2b79-8c55-4423-8843-7e6e96f84071.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W} to your mana pool.)\nAs Temple Garden comes into play, you may pay 2 life. If you don't, Temple Garden comes into play tapped instead.",
             "colours": [],
@@ -9618,7 +9618,7 @@
         },
         {
             "id": "558bbbc5-0820-559c-a66f-64559033c5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc35026-a29e-4fb0-931f-5e90faf41802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc35026-a29e-4fb0-931f-5e90faf41802.jpg?1",
             "name": "Vitu-Ghazi, the City-Tree",
             "text": "{T}: Add {1} to your mana pool.\n{2}{G}{W}, {T}: Put a 1/1 green Saproling creature token into play.",
             "colours": [],
@@ -9649,7 +9649,7 @@
         },
         {
             "id": "428d14f6-a8a5-566a-8a7e-6d1d14024ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b90cd-8272-457a-be32-1298145345be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139b90cd-8272-457a-be32-1298145345be.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B} to your mana pool.)\nAs Watery Grave comes into play, you may pay 2 life. If you don't, Watery Grave comes into play tapped instead.",
             "colours": [],
@@ -9683,7 +9683,7 @@
         },
         {
             "id": "7270b504-f20f-5c8a-9e9e-50c3fa469f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8d3cd4-0f5f-4424-82ee-d8ba81da47fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d8d3cd4-0f5f-4424-82ee-d8ba81da47fd.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9721,7 +9721,7 @@
         },
         {
             "id": "c6838738-e772-547a-b134-c068ff344e49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b7beb9-0805-47b9-8e62-ff110e9e086a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b7beb9-0805-47b9-8e62-ff110e9e086a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9759,7 +9759,7 @@
         },
         {
             "id": "37f35b53-f822-55f6-87e6-3455af0a577d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3d0fe-6af6-4d02-b41d-0b88b510be4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab3d0fe-6af6-4d02-b41d-0b88b510be4f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9797,7 +9797,7 @@
         },
         {
             "id": "8c858455-36e8-594f-8e98-980047513237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2839fa-33eb-47fb-9541-77c68612aa02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c2839fa-33eb-47fb-9541-77c68612aa02.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9835,7 +9835,7 @@
         },
         {
             "id": "0f096e5b-5527-5de3-9a2d-eb0901488344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c8056-f155-434c-a4cb-a532a4707245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c8056-f155-434c-a4cb-a532a4707245.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "4c4f7a66-0c6a-548f-9242-3b730fceccd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d603978-3877-454e-8910-53a4cc95431d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d603978-3877-454e-8910-53a4cc95431d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9911,7 +9911,7 @@
         },
         {
             "id": "b0a3ed8a-7fdb-5e71-a6f1-5164dee9c1bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a272ca-98a7-4887-b6b7-903a1adc33e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a272ca-98a7-4887-b6b7-903a1adc33e0.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9949,7 +9949,7 @@
         },
         {
             "id": "7b3d7000-0a6b-585b-aee0-671b2a95d93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cba2b8-d865-46e8-81f1-752598a0d729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9cba2b8-d865-46e8-81f1-752598a0d729.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9987,7 +9987,7 @@
         },
         {
             "id": "565ec80b-b7b0-5752-b9ec-e18d666414ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2755f9f7-95f9-4907-8ec9-21853eb376f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2755f9f7-95f9-4907-8ec9-21853eb376f4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10025,7 +10025,7 @@
         },
         {
             "id": "b0b09dc7-fed0-586e-a2c8-55d5e8f67416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18dd43d-0d9e-4d61-90f9-63822cf0cb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18dd43d-0d9e-4d61-90f9-63822cf0cb2d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10063,7 +10063,7 @@
         },
         {
             "id": "96d4e248-f789-5b85-9cc2-bf011b67ea84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd659b0-1f79-4e3b-bc20-8f384aa43670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd659b0-1f79-4e3b-bc20-8f384aa43670.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10101,7 +10101,7 @@
         },
         {
             "id": "e99b0d0a-3cdb-5c08-b474-6643a348780e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a1df0-e6dc-4815-bb73-9d100ee6e0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a1df0-e6dc-4815-bb73-9d100ee6e0b2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10139,7 +10139,7 @@
         },
         {
             "id": "ba5758ab-f72b-5434-bd60-8dc1f236c3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad3662a-f7b4-45d5-a35e-fc6c38474692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad3662a-f7b4-45d5-a35e-fc6c38474692.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10177,7 +10177,7 @@
         },
         {
             "id": "16a09531-820b-55fa-969e-fef72eab9fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477ebad-e1e5-4508-aa20-39b47e39a5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6477ebad-e1e5-4508-aa20-39b47e39a5c6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10215,7 +10215,7 @@
         },
         {
             "id": "25b204d8-06b5-5004-9062-d103e5fae03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312d7b-f505-45c3-bb87-650259e5db50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f312d7b-f505-45c3-bb87-650259e5db50.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10253,7 +10253,7 @@
         },
         {
             "id": "c53bf60b-d201-51c8-9429-d372a8d0dc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e135c9f9-5099-4029-bc19-dd9a0760d86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e135c9f9-5099-4029-bc19-dd9a0760d86f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "bee0fa2a-7b02-5317-bc94-5adbe57cd4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706be1bd-720d-4e74-b71f-568081afcab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706be1bd-720d-4e74-b71f-568081afcab1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10329,7 +10329,7 @@
         },
         {
             "id": "80ac629e-1bd1-523d-b68e-db8f998e1dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839f63ad-476a-4344-b6c3-911c1075c2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839f63ad-476a-4344-b6c3-911c1075c2b8.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10367,7 +10367,7 @@
         },
         {
             "id": "2f5d8dd0-d45b-5e21-b18f-1e8c2d57b3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2e6db4-94a4-4fa9-be52-1ec235d2b137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe2e6db4-94a4-4fa9-be52-1ec235d2b137.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10405,7 +10405,7 @@
         },
         {
             "id": "6201acf1-9e78-551e-b0a2-f6afc9a26c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade29c12-43f6-473d-bcc8-1e3f2cf4ee8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade29c12-43f6-473d-bcc8-1e3f2cf4ee8f.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/RIX.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/RIX.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "7cc3f061-5568-55ff-810c-6a0fa247959e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208c6f51-3c00-4fc6-8579-8f57444d0e97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/208c6f51-3c00-4fc6-8579-8f57444d0e97.jpg?1",
             "name": "Baffling End",
             "text": "When Baffling End enters the battlefield, exile target creature an opponent controls with converted mana cost 3 or less.\nWhen Baffling End leaves the battlefield, target opponent creates a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "3156f0ba-53f3-579d-ba2d-829741f552c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaadceb3-8a57-45de-b3f1-aca94f20de18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaadceb3-8a57-45de-b3f1-aca94f20de18.jpg?1",
             "name": "Bishop of Binding",
             "text": "When Bishop of Binding enters the battlefield, exile target creature an opponent controls until Bishop of Binding leaves the battlefield.\nWhenever Bishop of Binding attacks, target Vampire gets +X/+X until end of turn, where X is the power of the exiled card.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "99d6fc09-bab7-5ca4-8244-51811fc772e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6beac36-e12f-408d-a37b-a70e0e6c52d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6beac36-e12f-408d-a37b-a70e0e6c52d8.jpg?1",
             "name": "Blazing Hope",
             "text": "Exile target creature with power greater than or equal to your life total.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d47fc463-2114-5c1a-a92c-45fbfca77760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf94184-e745-469a-9d55-af0ddacbb9cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf94184-e745-469a-9d55-af0ddacbb9cf.jpg?1",
             "name": "Cleansing Ray",
             "text": "Choose one \u2014\n\u2022 Destroy target Vampire.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -135,7 +135,7 @@
         },
         {
             "id": "c09aee38-0a29-5a0f-a3eb-88e8541206a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed07b708-7232-4b87-b5d9-edaa20a69293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed07b708-7232-4b87-b5d9-edaa20a69293.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "f6fee20f-95be-5d58-9a1a-9b63c7452432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a74fa9-1338-40ea-95d9-0f4e78b85f60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a74fa9-1338-40ea-95d9-0f4e78b85f60.jpg?1",
             "name": "Everdawn Champion",
             "text": "Prevent all combat damage that would be dealt to Everdawn Champion.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "d85ca0b2-54e2-5a3a-bb78-4b6ae306f914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffe7b2b-22c3-4e6a-9b1b-c6d7b29b9f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fffe7b2b-22c3-4e6a-9b1b-c6d7b29b9f86.jpg?1",
             "name": "Exultant Skymarcher",
             "text": "Flying",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "7601b75a-c4ba-5ca6-847f-c8c5167be5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e3bc9-7b67-4eab-916a-6d83da06f20a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e3bc9-7b67-4eab-916a-6d83da06f20a.jpg?1",
             "name": "Famished Paladin",
             "text": "Famished Paladin doesn't untap during your untap step.\nWhenever you gain life, untap Famished Paladin.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "64a89f6c-59d6-5112-98f2-d7a15bbc7790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10718d37-63d4-44b7-9450-5d49cffce944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10718d37-63d4-44b7-9450-5d49cffce944.jpg?1",
             "name": "Forerunner of the Legion",
             "text": "When Forerunner of the Legion enters the battlefield, you may search your library for a Vampire card, reveal it, then shuffle your library and put that card on top of it.\nWhenever another Vampire enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "749e4fdb-7fda-5107-876d-ee4eab6213e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5030e80-58c4-4ce3-877e-8395b653f6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5030e80-58c4-4ce3-877e-8395b653f6e8.jpg?1",
             "name": "Imperial Ceratops",
             "text": "Enrage \u2014 Whenever Imperial Ceratops is dealt damage, you gain 2 life.",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "571baaef-97f6-56b1-832c-b6115346bdf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba197b31-97b8-447e-b8fd-3eefd5ccdc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba197b31-97b8-447e-b8fd-3eefd5ccdc72.jpg?1",
             "name": "Legion Conquistador",
             "text": "When Legion Conquistador enters the battlefield, you may search your library for any number of cards named Legion Conquistador, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "845b5f40-974a-515b-a5b8-2cc7050c3a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca3a547-ef22-4b87-b90f-e8ffb42f73ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca3a547-ef22-4b87-b90f-e8ffb42f73ac.jpg?1",
             "name": "Luminous Bonds",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "8cf30ca9-3b4d-5216-b811-1e47dc394e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a012af0-c54e-4658-8a3b-b81cc8835e1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a012af0-c54e-4658-8a3b-b81cc8835e1b.jpg?1",
             "name": "Majestic Heliopterus",
             "text": "Flying\nWhenever Majestic Heliopterus attacks, another target Dinosaur you control gains flying until end of turn.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "cbe44955-3cbe-5d4a-9e59-ebe7e55ee0b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04134be2-5e40-4732-832c-f616009eceff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04134be2-5e40-4732-832c-f616009eceff.jpg?1",
             "name": "Martyr of Dusk",
             "text": "When Martyr of Dusk dies, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "a786a8c0-da1c-5099-9875-13d967a311ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be8c18-eca3-4960-b174-e4a78579ed63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08be8c18-eca3-4960-b174-e4a78579ed63.jpg?1",
             "name": "Moment of Triumph",
             "text": "Target creature gets +2/+2 until end of turn. You gain 2 life.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "b88257cf-72b5-55c4-a7ba-8db3e55be5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad263e-7ff0-459b-b04b-1d03b09c48aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ad263e-7ff0-459b-b04b-1d03b09c48aa.jpg?1",
             "name": "Paladin of Atonement",
             "text": "At the beginning of each upkeep, if you lost life last turn, put a +1/+1 counter on Paladin of Atonement.\nWhen Paladin of Atonement dies, you gain life equal to its toughness.",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "72848888-20cb-5a1d-b34a-aead3c3c7159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a769c-6602-4f6f-a388-f5aa15fb3c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0a769c-6602-4f6f-a388-f5aa15fb3c90.jpg?1",
             "name": "Pride of Conquerors",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nCreatures you control get +1/+1 until end of turn. If you have the city's blessing, those creatures get +2/+2 until end of turn instead.",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "265eefca-faff-53f1-a69d-03aed2ab3a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44584d-e501-40aa-b3f2-a6155e2ee6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d44584d-e501-40aa-b3f2-a6155e2ee6e7.jpg?1",
             "name": "Radiant Destiny",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAs Radiant Destiny enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1. As long as you have the city's blessing, they also have vigilance.",
             "colours": [
@@ -610,7 +610,7 @@
         },
         {
             "id": "94d19ceb-a343-580c-b3fb-1626b944f8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f2ffb-2780-47d2-bcdf-9cef82716b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f2ffb-2780-47d2-bcdf-9cef82716b20.jpg?1",
             "name": "Raptor Companion",
             "text": "",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "3089f919-a547-59bc-8077-0c6784cddbb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12993e53-8790-4d6f-9da1-a259f67aa5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12993e53-8790-4d6f-9da1-a259f67aa5bf.jpg?1",
             "name": "Sanguine Glorifier",
             "text": "When Sanguine Glorifier enters the battlefield, put a +1/+1 counter on another target Vampire you control.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "71207f09-164c-5aad-aeb3-7a06dc5833e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473190f-5e96-4cf7-a0fa-a77d916acc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473190f-5e96-4cf7-a0fa-a77d916acc2e.jpg?1",
             "name": "Skymarcher Aspirant",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nSkymarcher Aspirant has flying as long as you have the city's blessing.",
             "colours": [
@@ -714,7 +714,7 @@
         },
         {
             "id": "aaa442e3-f5a9-5737-9659-5841c217a030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4217ab21-181e-4c32-97c3-d8bd441287e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4217ab21-181e-4c32-97c3-d8bd441287e0.jpg?1",
             "name": "Slaughter the Strong",
             "text": "Each player chooses any number of creatures he or she controls with total power 4 or less, then sacrifices all other creatures he or she controls.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "c2f77a4b-9c4f-5a3b-b001-2dc8b14bd6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee111e7-5309-46d5-b3ea-a049b3962c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee111e7-5309-46d5-b3ea-a049b3962c23.jpg?1",
             "name": "Snubhorn Sentry",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nSnubhorn Sentry gets +3/+0 as long as you have the city's blessing.",
             "colours": [
@@ -780,7 +780,7 @@
         },
         {
             "id": "92c4276c-530e-57d0-99a9-f8ddd1b1b12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5058a729-9739-4548-b420-deebbc0950b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5058a729-9739-4548-b420-deebbc0950b7.jpg?1",
             "name": "Sphinx's Decree",
             "text": "Each opponent can't cast instant or sorcery spells during that player's next turn.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "6fdb1b70-ffc6-5ccd-aec7-badd4b01c6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91de07da-564d-42f3-987d-a2321c3216bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91de07da-564d-42f3-987d-a2321c3216bc.jpg?1",
             "name": "Squire's Devotion",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has lifelink.\nWhen Squire's Devotion enters the battlefield, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "977b5947-86bf-553a-b2de-385ba3ebaf26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867fd5a-3bbe-416d-96a6-1db0b341260e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6867fd5a-3bbe-416d-96a6-1db0b341260e.jpg?1",
             "name": "Sun Sentinel",
             "text": "Vigilance",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "5c1b905d-d6fc-5efd-b3bb-79e7bf0d8a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c298b51f-b725-4a51-a91e-4c66cf6dfe9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c298b51f-b725-4a51-a91e-4c66cf6dfe9d.jpg?1",
             "name": "Sun-Crested Pterodon",
             "text": "Flying\nSun-Crested Pterodon has vigilance as long as you control another Dinosaur.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "3ba6a1b1-a472-514c-90a6-906342bfac68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8f8d61-51d6-479b-a812-6cbacc7ea1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8f8d61-51d6-479b-a812-6cbacc7ea1fc.jpg?1",
             "name": "Temple Altisaur",
             "text": "If a source would deal damage to another Dinosaur you control, prevent all but 1 of that damage.",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "23a6192f-d543-5351-b47a-4c69f1e2c461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c280c8-3471-4ae1-be96-0f392b095ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2c280c8-3471-4ae1-be96-0f392b095ce2.jpg?1",
             "name": "Trapjaw Tyrant",
             "text": "Enrage \u2014 Whenever Trapjaw Tyrant is dealt damage, exile target creature an opponent controls until Trapjaw Tyrant leaves the battlefield.",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "a3dec5d1-f5b7-5e45-afd3-811ea8775c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10560f-199d-4d04-b573-90024f8aecc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d10560f-199d-4d04-b573-90024f8aecc4.jpg?1",
             "name": "Zetalpa, Primal Dawn",
             "text": "Flying, double strike, vigilance, trample, indestructible",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "e0b3b9ae-7441-5663-8bf2-86e7cc9d3b27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dc0310-afd9-49b4-b58f-a0e91120c38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dc0310-afd9-49b4-b58f-a0e91120c38c.jpg?1",
             "name": "Admiral's Order",
             "text": "Raid \u2014 If you attacked with a creature this turn, you may pay {U} rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "daab4fdd-b79f-5fe6-99a1-a155e372e1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cb8fa2-337b-4596-9c31-01f0c0b171b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cb8fa2-337b-4596-9c31-01f0c0b171b7.jpg?1",
             "name": "Aquatic Incursion",
             "text": "When Aquatic Incursion enters the battlefield, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)\n{3}{U}: Target Merfolk can't be blocked this turn.",
             "colours": [
@@ -1084,7 +1084,7 @@
         },
         {
             "id": "a33e369b-77da-5539-a7c0-fc5904b0a19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6afc4c-3c41-44e8-ad8c-186c277267a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac6afc4c-3c41-44e8-ad8c-186c277267a1.jpg?1",
             "name": "Crafty Cutpurse",
             "text": "Flash\nWhen Crafty Cutpurse enters the battlefield, each token that would be created under an opponent's control this turn is created under your control instead.",
             "colours": [
@@ -1119,7 +1119,7 @@
         },
         {
             "id": "eebc4ecf-5de1-5a58-8c7e-5c9b45eb139b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312980a-7b3c-43f8-81cf-53ff818cea30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e312980a-7b3c-43f8-81cf-53ff818cea30.jpg?1",
             "name": "Crashing Tide",
             "text": "Crashing Tide has flash as long as you control a Merfolk.\nReturn target creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1151,7 +1151,7 @@
         },
         {
             "id": "2013b972-5ae4-5ee9-9e1b-34ed8a6dbf83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f998c62-30c9-4fc3-a045-5becc04f9e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f998c62-30c9-4fc3-a045-5becc04f9e3e.jpg?1",
             "name": "Curious Obsession",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, you may draw a card.\"\nAt the beginning of your end step, if you didn't attack with a creature this turn, sacrifice Curious Obsession.",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "4b588b45-7ccc-5ccf-9e4e-5bdfb5d19b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db310d8f-0db7-44c9-9f2d-9a0773b565b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db310d8f-0db7-44c9-9f2d-9a0773b565b0.jpg?1",
             "name": "Deadeye Rig-Hauler",
             "text": "Raid \u2014 When Deadeye Rig-Hauler enters the battlefield, if you attacked with a creature this turn, you may return target creature to its owner's hand.",
             "colours": [
@@ -1220,7 +1220,7 @@
         },
         {
             "id": "2cce85d1-f6df-5baf-a587-9477a8efe2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f5119f-3921-48a5-a8fb-0cb1bbabde30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f5119f-3921-48a5-a8fb-0cb1bbabde30.jpg?1",
             "name": "Expel from Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nReturn target nonland permanent to its owner's hand. If you have the city's blessing, you may put that permanent on top of its owner's library instead.",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "7681078a-73cb-5659-844d-dad87dadcb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a353c1-a640-4b01-9754-3fb6011c8211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a353c1-a640-4b01-9754-3fb6011c8211.jpg?1",
             "name": "Flood of Recollection",
             "text": "Return target instant or sorcery card from your graveyard to your hand. Exile Flood of Recollection.",
             "colours": [
@@ -1284,7 +1284,7 @@
         },
         {
             "id": "d3c20eee-bc3f-5d0a-b294-f27d4db24071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10b8f15-b323-44d8-85a7-ed662a40889d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10b8f15-b323-44d8-85a7-ed662a40889d.jpg?1",
             "name": "Hornswoggle",
             "text": "Counter target creature spell. You create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -1316,7 +1316,7 @@
         },
         {
             "id": "56d5d9db-e138-5d6f-b367-1f77d0cde8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ee56f1-9f08-459f-8517-0fe7bc645fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ee56f1-9f08-459f-8517-0fe7bc645fa3.jpg?1",
             "name": "Induced Amnesia",
             "text": "When Induced Amnesia enters the battlefield, target player exiles all cards from his or her hand face down, then draws that many cards.\nWhen Induced Amnesia is put into a graveyard from the battlefield, return the exiled cards to their owner's hand.",
             "colours": [
@@ -1348,7 +1348,7 @@
         },
         {
             "id": "d487d82b-4d7a-5e6b-b943-b4958bdbbf42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8d0e8d-c2d4-4682-8095-827ffd79539b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b8d0e8d-c2d4-4682-8095-827ffd79539b.jpg?1",
             "name": "Kitesail Corsair",
             "text": "Kitesail Corsair has flying as long as it's attacking.",
             "colours": [
@@ -1383,7 +1383,7 @@
         },
         {
             "id": "05d0d71c-a2d8-5267-b0c0-920cc95d38f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86f499-a2d4-47f1-9fc1-b543e5ad5c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a86f499-a2d4-47f1-9fc1-b543e5ad5c82.jpg?1",
             "name": "Kumena's Awakening",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, each player draws a card. If you have the city's blessing, instead only you draw a card.",
             "colours": [
@@ -1415,7 +1415,7 @@
         },
         {
             "id": "79a0f0d1-af9b-558a-852d-37c0fcaf1455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c1368e-114b-4618-922b-1d824ba0d1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c1368e-114b-4618-922b-1d824ba0d1d5.jpg?1",
             "name": "Mist-Cloaked Herald",
             "text": "Mist-Cloaked Herald can't be blocked.",
             "colours": [
@@ -1450,7 +1450,7 @@
         },
         {
             "id": "d6b934a2-b92d-5040-b79d-29fbaa5c3db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31534f45-43e6-4103-bf58-ad8fa688e4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31534f45-43e6-4103-bf58-ad8fa688e4b0.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "a83581bb-dbf4-5f5c-8d1e-be61a6d70bc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eba418-94ab-46a3-958c-4d5058fc2bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48eba418-94ab-46a3-958c-4d5058fc2bcd.jpg?1",
             "name": "Nezahal, Primal Tide",
             "text": "Nezahal, Primal Tide can't be countered.\nYou have no maximum hand size.\nWhenever an opponent casts a noncreature spell, draw a card.\nDiscard three cards: Exile Nezahal. Return it to the battlefield tapped under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "edf14f5c-0144-51bb-bb1e-317848a54a2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4f72ef-3939-467c-8fe4-fd1c215f2b1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4f72ef-3939-467c-8fe4-fd1c215f2b1e.jpg?1",
             "name": "Release to the Wind",
             "text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may cast it without paying its mana cost.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "85d2c10c-bc02-5cd2-80d3-c1c214d0cb09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d766eb87-19ef-460b-982f-e55ae5890e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d766eb87-19ef-460b-982f-e55ae5890e6a.jpg?1",
             "name": "River Darter",
             "text": "River Darter can't be blocked by Dinosaurs.",
             "colours": [
@@ -1586,7 +1586,7 @@
         },
         {
             "id": "8cc14ebd-01f2-5a9e-b815-9a57b08ba3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea5ac8f-f83d-47ca-a20e-3d129afb34d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea5ac8f-f83d-47ca-a20e-3d129afb34d2.jpg?1",
             "name": "Riverwise Augur",
             "text": "When Riverwise Augur enters the battlefield, draw three cards, then put two cards from your hand on top of your library in any order.",
             "colours": [
@@ -1621,7 +1621,7 @@
         },
         {
             "id": "d273b78c-1188-5547-8fbc-a83f8d47a9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963425c-4694-42f4-a969-8f30e13276d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e963425c-4694-42f4-a969-8f30e13276d3.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "3c27add8-ff8e-594e-bb41-dee05b616475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae48b747-b9ea-4af1-84c5-3f5835d1ba1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae48b747-b9ea-4af1-84c5-3f5835d1ba1f.jpg?1",
             "name": "Sea Legs",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +0/+2 as long as it's a Pirate. Otherwise, it gets -2/-0.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "5c3774d3-6de1-52ae-9e7b-c075c0a6d2e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4316eacf-4b78-4b99-833c-53ecf49a0ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4316eacf-4b78-4b99-833c-53ecf49a0ae5.jpg?1",
             "name": "Seafloor Oracle",
             "text": "Whenever a Merfolk you control deals combat damage to a player, draw a card.",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "ccbf3896-c94e-5099-8de9-2411226420e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecd7a-bfd6-42a4-8cb2-18bac40b4401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ecd7a-bfd6-42a4-8cb2-18bac40b4401.jpg?1",
             "name": "Secrets of the Golden City",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nDraw two cards. If you have the city's blessing, draw three cards instead.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "79d168e7-df1d-5e81-a8e9-8039639e2902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ea8ca1-612d-4984-8572-06710d38bfa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ea8ca1-612d-4984-8572-06710d38bfa6.jpg?1",
             "name": "Silvergill Adept",
             "text": "As an additional cost to cast Silvergill Adept, reveal a Merfolk card from your hand or pay {3}.\nWhen Silvergill Adept enters the battlefield, draw a card.",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "eb695018-56b9-53ba-b113-cd214d9df259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5827a7-8ee3-4a89-b936-00a3283ddad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5827a7-8ee3-4a89-b936-00a3283ddad3.jpg?1",
             "name": "Siren Reaver",
             "text": "Raid \u2014 Siren Reaver costs {1} less to cast if you attacked with a creature this turn.\nFlying",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "be317768-3acc-5477-a51b-c1ef754499d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262f3c10-f29a-494f-88c6-0d44b2cbdc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262f3c10-f29a-494f-88c6-0d44b2cbdc82.jpg?1",
             "name": "Slippery Scoundrel",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAs long as you have the city's blessing, Slippery Scoundrel has hexproof and can't be blocked.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "ba2c7169-f34d-5da3-818e-3b90b7ca16ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1aed7d-4236-4d44-9366-ee03e15469bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1aed7d-4236-4d44-9366-ee03e15469bc.jpg?1",
             "name": "Soul of the Rapids",
             "text": "Flying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1896,7 +1896,7 @@
         },
         {
             "id": "6e1b7fdd-2d8f-5bd7-89b7-2223f5173580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca438d7-1134-4fee-9fad-85c3b1abe8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca438d7-1134-4fee-9fad-85c3b1abe8ed.jpg?1",
             "name": "Spire Winder",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nSpire Winder gets +1/+1 as long as you have the city's blessing.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "10ef515f-7232-5516-b145-dc4e5642fcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6452ba94-6bb0-409c-99f7-71e6457c3f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6452ba94-6bb0-409c-99f7-71e6457c3f2a.jpg?1",
             "name": "Sworn Guardian",
             "text": "",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "1b2fb9f1-1e79-57dc-90f7-1b08e553371f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14770537-209a-4260-88a4-30f4e2b5ede0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14770537-209a-4260-88a4-30f4e2b5ede0.jpg?1",
             "name": "Timestream Navigator",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{2}{U}{U}, {T}, Put Timestream Navigator on the bottom of its owner's library: Take an extra turn after this one. Activate this ability only if you have the city's blessing.",
             "colours": [
@@ -2001,7 +2001,7 @@
         },
         {
             "id": "62f28b0f-1416-5a0f-a10a-cf673be58b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ff9cf-f739-40cb-8974-77f6850150eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ff9cf-f739-40cb-8974-77f6850150eb.jpg?1",
             "name": "Warkite Marauder",
             "text": "Flying\nWhenever Warkite Marauder attacks, target creature defending player controls loses all abilities and has base power and toughness 0/1 until end of turn.",
             "colours": [
@@ -2036,7 +2036,7 @@
         },
         {
             "id": "16ed8ce0-df99-5dff-9095-fb1b44093a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4579ee-76c4-4ed6-9208-55d2b598d3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4579ee-76c4-4ed6-9208-55d2b598d3b5.jpg?1",
             "name": "Waterknot",
             "text": "Enchant creature\nWhen Waterknot enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "7d91f7cf-9aa3-5c11-930f-4afcbdea84a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c41212-9f16-48e0-8c4b-985ce331164b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c41212-9f16-48e0-8c4b-985ce331164b.jpg?1",
             "name": "Arterial Flow",
             "text": "Each opponent discards two cards. If you control a Vampire, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "338a81cf-45c8-5d37-934d-0794350cca2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78226edc-87dd-4c38-987c-52aefe0f9531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78226edc-87dd-4c38-987c-52aefe0f9531.jpg?1",
             "name": "Canal Monitor",
             "text": "",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "913522e7-467d-52b3-93a0-3ef13fd1ece7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507a4fb1-d27b-4393-9eed-48fe05b367d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/507a4fb1-d27b-4393-9eed-48fe05b367d8.jpg?1",
             "name": "Champion of Dusk",
             "text": "When Champion of Dusk enters the battlefield, you draw X cards and you lose X life, where X is the number of Vampires you control.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "ef67aad2-e01e-5981-9daa-f2b57778acef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eaa634-0add-4e3d-9eee-5712598dda3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42eaa634-0add-4e3d-9eee-5712598dda3f.jpg?1",
             "name": "Dark Inquiry",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "8d69d6c6-47ac-5123-bb00-eb4f1a948ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ac1d9-b0df-4dec-b133-057cc5902071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76ac1d9-b0df-4dec-b133-057cc5902071.jpg?1",
             "name": "Dead Man's Chest",
             "text": "Enchant creature an opponent controls\nWhen enchanted creature dies, exile cards equal to its power from the top of its owner's library. You may cast nonland cards from among them for as long as they remain exiled, and you may spend mana as though it were mana of any type to cast those spells.",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "9eae30fc-2d1b-58c0-adc2-3052e91795b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ff5a4e-9ec5-4b52-90f5-b8b6753c958d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ff5a4e-9ec5-4b52-90f5-b8b6753c958d.jpg?1",
             "name": "Dinosaur Hunter",
             "text": "Whenever Dinosaur Hunter deals damage to a Dinosaur, destroy that creature.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "b3fd718b-5782-54ed-b175-0c1e8e7abc8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88273b1e-b33b-44d3-8777-4e78a04eed65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88273b1e-b33b-44d3-8777-4e78a04eed65.jpg?1",
             "name": "Dire Fleet Poisoner",
             "text": "Flash\nDeathtouch\nWhen Dire Fleet Poisoner enters the battlefield, target attacking Pirate you control gets +1/+1 and gains deathtouch until end of turn.",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "e50e0698-eaac-5ca3-9cc6-5e6e5bc08c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce54a3-f3eb-48a0-bfa2-5f4b90e413f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce54a3-f3eb-48a0-bfa2-5f4b90e413f0.jpg?1",
             "name": "Dusk Charger",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nDusk Charger gets +2/+2 as long as you have the city's blessing.",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "4914f55f-df2d-5f85-8659-a197117ff69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3190cea3-fbea-464f-999b-4b4473be745e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3190cea3-fbea-464f-999b-4b4473be745e.jpg?1",
             "name": "Dusk Legion Zealot",
             "text": "When Dusk Legion Zealot enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "abeb3431-0346-5115-a634-d87e65ce3ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f447eb83-c805-4ba8-b9f2-0add092f6795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f447eb83-c805-4ba8-b9f2-0add092f6795.jpg?1",
             "name": "Fathom Fleet Boarder",
             "text": "When Fathom Fleet Boarder enters the battlefield, you lose 2 life unless you control another Pirate.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "dab2bb72-e065-590e-b3d0-88d7456044ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b499fc26-26b0-4b0f-9c62-5ed599baf41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b499fc26-26b0-4b0f-9c62-5ed599baf41d.jpg?1",
             "name": "Forerunner of the Coalition",
             "text": "When Forerunner of the Coalition enters the battlefield, you may search your library for a Pirate card, reveal it, then shuffle your library and put that card on top of it.\nWhenever another Pirate enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "d5c7348c-80d9-52c6-8796-004d5ae3a12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bb420a-8bf1-4504-b1b5-2d929be978be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bb420a-8bf1-4504-b1b5-2d929be978be.jpg?1",
             "name": "Golden Demise",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAll creatures get -2/-2 until end of turn. If you have the city's blessing, instead only creatures your opponents control get -2/-2 until end of turn.",
             "colours": [
@@ -2478,7 +2478,7 @@
         },
         {
             "id": "64129b7a-ded5-5baa-9323-d7e4cdf677f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6da2e7-4cf0-49ae-b0ba-3b994ff21587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6da2e7-4cf0-49ae-b0ba-3b994ff21587.jpg?1",
             "name": "Grasping Scoundrel",
             "text": "Grasping Scoundrel gets +1/+0 as long as it's attacking.",
             "colours": [
@@ -2513,7 +2513,7 @@
         },
         {
             "id": "42002605-c387-5008-83a8-70d2eaec584a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea07116-afe7-4d88-a530-54424e791b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ea07116-afe7-4d88-a530-54424e791b74.jpg?1",
             "name": "Gruesome Fate",
             "text": "Each opponent loses 1 life for each creature you control.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "0b5db650-d052-5ced-8c78-aa4204b29204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa0c4f7-3497-467d-9453-104fb4b5a0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfa0c4f7-3497-467d-9453-104fb4b5a0f3.jpg?1",
             "name": "Impale",
             "text": "Destroy target creature.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "c92976c6-d234-52ff-ae5f-1cb5a52d4b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00f09b-a113-460e-ac2f-d3988a83179e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f00f09b-a113-460e-ac2f-d3988a83179e.jpg?1",
             "name": "Mastermind's Acquisition",
             "text": "Choose one \u2014\n\u2022 Search your library for a card, put it into your hand, then shuffle your library.\n\u2022 Choose a card you own from outside the game and put it into your hand.",
             "colours": [
@@ -2609,7 +2609,7 @@
         },
         {
             "id": "df56747e-b7e3-53c4-bf8d-5179f7992254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b40f3c-d75e-483f-b978-8b3bf30cc7ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b40f3c-d75e-483f-b978-8b3bf30cc7ce.jpg?1",
             "name": "Mausoleum Harpy",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever another creature you control dies, if you have the city's blessing, put a +1/+1 counter on Mausoleum Harpy.",
             "colours": [
@@ -2643,7 +2643,7 @@
         },
         {
             "id": "0574d7a9-c811-5710-b8bd-e4685fbe438c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e3ea55-162d-4466-ba4e-b938a0845fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e3ea55-162d-4466-ba4e-b938a0845fb5.jpg?1",
             "name": "Moment of Craving",
             "text": "Target creature gets -2/-2 until end of turn. You gain 2 life.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "8db97b18-02e6-57e1-af5c-89eaebff0388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405f82d6-2991-4958-a563-572f0d298346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/405f82d6-2991-4958-a563-572f0d298346.jpg?1",
             "name": "Oathsworn Vampire",
             "text": "Oathsworn Vampire enters the battlefield tapped.\nYou may cast Oathsworn Vampire from your graveyard if you gained life this turn.",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "63e72c36-6219-5d77-89d3-84d4e32dbc23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87ebffe-5907-427b-9f9b-7c36a12b4a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c87ebffe-5907-427b-9f9b-7c36a12b4a03.jpg?1",
             "name": "Pitiless Plunderer",
             "text": "Whenever another creature you control dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2745,7 +2745,7 @@
         },
         {
             "id": "937d36d0-40e0-5be3-9d61-2218011bfe1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551196-ecea-472f-9547-3c9658d0489e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02551196-ecea-472f-9547-3c9658d0489e.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.",
             "colours": [
@@ -2780,7 +2780,7 @@
         },
         {
             "id": "776dc1b4-5406-5041-b375-68751b08743e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaac2f-b26c-4da9-bf4f-c7672394dd7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceaac2f-b26c-4da9-bf4f-c7672394dd7f.jpg?1",
             "name": "Reaver Ambush",
             "text": "Exile target creature with power 3 or less.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "c343c911-af2f-534e-80b6-60461370a90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f4e0a8-7af7-4422-a964-c19503692ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f4e0a8-7af7-4422-a964-c19503692ba6.jpg?1",
             "name": "Recover",
             "text": "Return target creature card from your graveyard to your hand.\nDraw a card.",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "77050f7e-2d28-5f9f-9030-4b0ebd688a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1334ee90-c798-42ec-b2be-68dac766a7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1334ee90-c798-42ec-b2be-68dac766a7eb.jpg?1",
             "name": "Sadistic Skymarcher",
             "text": "As an additional cost to cast Sadistic Skymarcher, reveal a Vampire card from your hand or pay {1}.\nFlying, lifelink",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "819b4448-aeea-50a1-ba0d-c7f97dacd779",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a0b40e-7a43-4722-b787-a5d7ec6453ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a0b40e-7a43-4722-b787-a5d7ec6453ac.jpg?1",
             "name": "Tetzimoc, Primal Death",
             "text": "Deathtouch\n{B}, Reveal Tetzimoc, Primal Death from your hand: Put a prey counter on target creature. Activate this ability only during your turn.\nWhen Tetzimoc enters the battlefield, destroy each creature your opponents control with a prey counter on it.",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "c83db6a1-b03a-5426-8bdf-a1caf1a9809a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68132a28-b33b-48cb-acf8-42245312934e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68132a28-b33b-48cb-acf8-42245312934e.jpg?1",
             "name": "Tomb Robber",
             "text": "Menace\n{1}, Discard a card: Tomb Robber explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -2951,7 +2951,7 @@
         },
         {
             "id": "fb2e5522-233a-547f-b600-b81701a2a29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6974f-6753-48ac-98cd-86412cc93726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da6974f-6753-48ac-98cd-86412cc93726.jpg?1",
             "name": "Twilight Prophet",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of your upkeep, if you have the city's blessing, reveal the top card of your library and put it into your hand. Each opponent loses X life and you gain X life, where X is that card's converted mana cost.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "8b2db8d5-fdd2-5cd0-97cf-0bf34cab8e1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3a6c6-33b8-4530-9d80-c488898afd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3a6c6-33b8-4530-9d80-c488898afd6e.jpg?1",
             "name": "Vampire Revenant",
             "text": "Flying",
             "colours": [
@@ -3021,7 +3021,7 @@
         },
         {
             "id": "25d88c53-0422-53fc-bcc2-c6ebc0e9fa89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab958d5-9c1f-420f-b358-ec0325f22f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab958d5-9c1f-420f-b358-ec0325f22f84.jpg?1",
             "name": "Vona's Hunger",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nEach opponent sacrifices a creature. If you have the city's blessing, instead each opponent sacrifices half the creatures he or she controls, rounded up.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "f963e456-3974-5b3a-a4b8-7ace25a08013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66a9f1b-31c8-4557-888b-a927922d37af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66a9f1b-31c8-4557-888b-a927922d37af.jpg?1",
             "name": "Voracious Vampire",
             "text": "Menace\nWhen Voracious Vampire enters the battlefield, target Vampire you control gets +1/+1 and gains menace until end of turn.",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "d35c83d3-edd6-5aab-9439-d31af3f36967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875832f4-e541-4c87-8479-731e0eab2cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875832f4-e541-4c87-8479-731e0eab2cc6.jpg?1",
             "name": "Blood Sun",
             "text": "When Blood Sun enters the battlefield, draw a card.\nAll lands lose all abilities except mana abilities.",
             "colours": [
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "222ab458-ff55-54d2-97c3-098abbdea8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a605abc-78e8-47ba-9022-0fad9006fd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a605abc-78e8-47ba-9022-0fad9006fd05.jpg?1",
             "name": "Bombard",
             "text": "Bombard deals 4 damage to target creature.",
             "colours": [
@@ -3152,7 +3152,7 @@
         },
         {
             "id": "3d710017-f4fc-5bdc-b06b-88d8dc4f7aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505866-6ce9-4d11-b3f3-fc2f09839b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13505866-6ce9-4d11-b3f3-fc2f09839b71.jpg?1",
             "name": "Brass's Bounty",
             "text": "For each land you control, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "3bcfc59b-dc26-5f06-9c6b-5875f769de5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3d3b6-6805-4476-aea1-a95c31bd21d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeb3d3b6-6805-4476-aea1-a95c31bd21d7.jpg?1",
             "name": "Brazen Freebooter",
             "text": "When Brazen Freebooter enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "99af8a0a-745f-5a04-852b-b86b193efc6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82c583f-3d2b-4c7f-a6f4-97da150423b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82c583f-3d2b-4c7f-a6f4-97da150423b4.jpg?1",
             "name": "Buccaneer's Bravado",
             "text": "Choose one \u2014\n\u2022 Target creature gets +1/+1 and gains first strike until end of turn.\n\u2022 Target Pirate gets +1/+1 and gains double strike until end of turn.",
             "colours": [
@@ -3251,7 +3251,7 @@
         },
         {
             "id": "fe5274fb-c694-523a-8bd7-5e8abe1b6836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e49960d-4b45-4d3b-9c6e-e7b717b4feaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e49960d-4b45-4d3b-9c6e-e7b717b4feaa.jpg?1",
             "name": "Charging Tuskodon",
             "text": "Trample\nIf Charging Tuskodon would deal combat damage to a player, it deals double that damage to that player instead.",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "edcfbec6-3518-5f3c-9ae5-38163d4432e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d413b88-8f5d-415f-bd07-169f6c175e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d413b88-8f5d-415f-bd07-169f6c175e6b.jpg?1",
             "name": "Daring Buccaneer",
             "text": "As an additional cost to cast Daring Buccaneer, reveal a Pirate card from your hand or pay {2}.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "30a726f0-ee3c-514b-9213-f4d11c084e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e3c0c5-7451-4da9-acc0-d6e4e1f2655e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13e3c0c5-7451-4da9-acc0-d6e4e1f2655e.jpg?1",
             "name": "Dire Fleet Daredevil",
             "text": "First strike\nWhen Dire Fleet Daredevil enters the battlefield, exile target instant or sorcery card from an opponent's graveyard. You may cast that card this turn, and you may spend mana as though it were mana of any type to cast that spell. If that card would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -3355,7 +3355,7 @@
         },
         {
             "id": "ee67bb54-1048-52df-90da-1bc939eef340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d8bb4-0430-45bb-930d-5d6db6521945.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d3d8bb4-0430-45bb-930d-5d6db6521945.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of nonland cards exiled this way without paying their mana costs.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "6b74e330-691d-54cf-8cd8-77e0f07d5085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5565de-028c-4799-a9f6-4dcd685639eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5565de-028c-4799-a9f6-4dcd685639eb.jpg?1",
             "name": "Fanatical Firebrand",
             "text": "Haste\n{T}, Sacrifice Fanatical Firebrand: It deals 1 damage to target creature or player.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "e7ea1b86-3aab-5d4c-8b73-bdb4d49229f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947644ab-02b3-4ebe-b62a-c087ab205ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947644ab-02b3-4ebe-b62a-c087ab205ab0.jpg?1",
             "name": "Forerunner of the Empire",
             "text": "When Forerunner of the Empire enters the battlefield, you may search your library for a Dinosaur card, reveal it, then shuffle your library and put that card on top of it.\nWhenever a Dinosaur enters the battlefield under your control, you may have Forerunner of the Empire deal 1 damage to each creature.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "f173d647-5e2b-5310-b13b-de8af6ff27cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e4fe86-281d-4174-bb72-ac5bb9560b7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e4fe86-281d-4174-bb72-ac5bb9560b7e.jpg?1",
             "name": "Form of the Dinosaur",
             "text": "When Form of the Dinosaur enters the battlefield, your life total becomes 15.\nAt the beginning of your upkeep, Form of the Dinosaur deals 15 damage to target creature an opponent controls and that creature deals damage equal to its power to you.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "d66e04bb-40d8-5558-9e22-15f312912b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3825798-f673-4d8a-9997-ccb73681cbf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3825798-f673-4d8a-9997-ccb73681cbf2.jpg?1",
             "name": "Frilled Deathspitter",
             "text": "Enrage \u2014 Whenever Frilled Deathspitter is dealt damage, it deals 2 damage to target opponent.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "3ea142de-d40c-50c1-980e-8fb27a8f097f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b2d16-bdf5-4249-9dc1-bb51498aa33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b2d16-bdf5-4249-9dc1-bb51498aa33b.jpg?1",
             "name": "Goblin Trailblazer",
             "text": "Menace",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "0c48e17e-8435-50a2-9919-df4e4f0f9135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010711a0-5e95-4a8c-816f-e314f2a909ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010711a0-5e95-4a8c-816f-e314f2a909ef.jpg?1",
             "name": "Mutiny",
             "text": "Target creature an opponent controls deals damage equal to its power to another target creature that player controls.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "01803680-5dab-5060-ad04-64ba34e83598",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a90b68-d5f4-4f3c-bd4b-af59dd868919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a90b68-d5f4-4f3c-bd4b-af59dd868919.jpg?1",
             "name": "Needletooth Raptor",
             "text": "Enrage \u2014 Whenever Needletooth Raptor is dealt damage, it deals 5 damage to target creature an opponent controls.",
             "colours": [
@@ -3629,7 +3629,7 @@
         },
         {
             "id": "45135e6c-c7bc-5cd0-934d-f908cbe7e2a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7080f86-0a9f-4471-a52b-0d44d19e6e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7080f86-0a9f-4471-a52b-0d44d19e6e59.jpg?1",
             "name": "Orazca Raptor",
             "text": "",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "f761a081-3f2f-54f3-9d2f-705682b5e268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c812f-89b1-4741-a50d-8634e003a7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99c812f-89b1-4741-a50d-8634e003a7c0.jpg?1",
             "name": "Pirate's Pillage",
             "text": "As an additional cost to cast Pirate's Pillage, discard a card.\nDraw two cards and create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "18d320b3-3b97-5cfc-959c-66e22911627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4b97a3-8f6f-461e-aa55-ab752752f539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4b97a3-8f6f-461e-aa55-ab752752f539.jpg?1",
             "name": "Reckless Rage",
             "text": "Reckless Rage deals 4 damage to target creature you don't control and 2 damage to target creature you control.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "93797c70-fc1e-536d-94c5-ea6f89efd56e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daccec32-84c6-4de4-9b00-c497a6ba5de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daccec32-84c6-4de4-9b00-c497a6ba5de8.jpg?1",
             "name": "Rekindling Phoenix",
             "text": "Flying\nWhen Rekindling Phoenix dies, create a 0/1 red Elemental creature token with \"At the beginning of your upkeep, sacrifice this creature and return target card named Rekindling Phoenix from your graveyard to the battlefield. It gains haste until end of turn.\"",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "3171448a-6b1e-5d72-a2e3-1d8d7913198d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686cbaf-1de8-4f30-8027-c6c8a85dde7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4686cbaf-1de8-4f30-8027-c6c8a85dde7a.jpg?1",
             "name": "See Red",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has first strike.\nAt the beginning of your end step, if you didn't attack with a creature this turn, sacrifice See Red.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "399928ff-a13d-59c2-b451-5ed8ada59ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd4bdd-3a2a-40d9-9f86-fefe0a462cd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bd4bdd-3a2a-40d9-9f86-fefe0a462cd2.jpg?1",
             "name": "Shake the Foundations",
             "text": "Shake the Foundations deals 1 damage to each creature without flying.\nDraw a card.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "4346a32a-2274-5d16-8f4d-b97e2634642a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929a41f7-f52d-4190-a80c-5ceb3e368a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/929a41f7-f52d-4190-a80c-5ceb3e368a31.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "ebd6b24e-5a71-5036-9a79-9d5793afd627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0d0c8d-c057-4a44-bd1e-38e1dd175778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f0d0c8d-c057-4a44-bd1e-38e1dd175778.jpg?1",
             "name": "Silverclad Ferocidons",
             "text": "Enrage \u2014 Whenever Silverclad Ferocidons is dealt damage, each opponent sacrifices a permanent.",
             "colours": [
@@ -3893,7 +3893,7 @@
         },
         {
             "id": "7e71a186-3bdb-5ae7-a075-7873c6cef9a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d4bb3-583c-4c3b-b6b7-342a78bbaec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d4bb3-583c-4c3b-b6b7-342a78bbaec6.jpg?1",
             "name": "Stampeding Horncrest",
             "text": "Stampeding Horncrest has haste as long as you control another Dinosaur.",
             "colours": [
@@ -3927,7 +3927,7 @@
         },
         {
             "id": "2e305d44-3256-5b5b-b7b6-f7f85afb04a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7093bd0e-3b98-4f46-9717-202ddd277bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7093bd0e-3b98-4f46-9717-202ddd277bf5.jpg?1",
             "name": "Storm Fleet Swashbuckler",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nStorm Fleet Swashbuckler has double strike as long as you have the city's blessing.",
             "colours": [
@@ -3962,7 +3962,7 @@
         },
         {
             "id": "e37a41e1-49db-521f-bbf2-42f3c2e97bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fbd1bc-3e57-43d5-ad54-443ca740fcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62fbd1bc-3e57-43d5-ad54-443ca740fcc4.jpg?1",
             "name": "Sun-Collared Raptor",
             "text": "Trample\n{2}{R}: Sun-Collared Raptor gets +3/+0 until end of turn.",
             "colours": [
@@ -3996,7 +3996,7 @@
         },
         {
             "id": "3da35b7f-6125-5efa-972f-68c901ec8563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22da9f6a-9598-4cfe-b465-719266b65dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22da9f6a-9598-4cfe-b465-719266b65dee.jpg?1",
             "name": "Swaggering Corsair",
             "text": "Raid \u2014 Swaggering Corsair enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "b708f580-9823-5b59-8dd7-ccabfb051db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e941a7-c2c1-4855-b79a-c0dfebb28854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e941a7-c2c1-4855-b79a-c0dfebb28854.jpg?1",
             "name": "Tilonalli's Crown",
             "text": "Enchant creature\nWhen Tilonalli's Crown enters the battlefield, it deals 1 damage to enchanted creature.\nEnchanted creature gets +3/+0 and has trample.",
             "colours": [
@@ -4065,7 +4065,7 @@
         },
         {
             "id": "0dedf3ea-c2e1-58c8-bcd7-b82fdd05083b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b107726-3a44-4b0f-86ef-4dbbf4473e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b107726-3a44-4b0f-86ef-4dbbf4473e7e.jpg?1",
             "name": "Tilonalli's Summoner",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever Tilonalli's Summoner attacks, you may pay {X}{R}. If you do, create X 1/1 red Elemental creature tokens that are tapped and attacking. At the beginning of the next end step, exile those tokens unless you have the city's blessing.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "7b3a1afc-6200-5868-88ff-6b0df8b165d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38252c3-fcc1-4bb7-8dd7-ba0e54ade6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e38252c3-fcc1-4bb7-8dd7-ba0e54ade6b7.jpg?1",
             "name": "Aggressive Urge",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card.",
             "colours": [
@@ -4132,7 +4132,7 @@
         },
         {
             "id": "e3e31c01-dbe8-5473-b89a-c32aee9e5cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351b213e-b23e-4287-947a-6bd81f1cf751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351b213e-b23e-4287-947a-6bd81f1cf751.jpg?1",
             "name": "Cacophodon",
             "text": "Enrage \u2014 Whenever Cacophodon is dealt damage, untap target permanent.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "4125530b-29ef-5f5e-a4e0-f237bb804e20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14fe6c-b272-415b-974d-c60d016ab786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14fe6c-b272-415b-974d-c60d016ab786.jpg?1",
             "name": "Cherished Hatchling",
             "text": "When Cherished Hatchling dies, you may cast Dinosaur spells this turn as though they had flash, and whenever you cast a Dinosaur spell this turn, it gains \"When this creature enters the battlefield, you may have it fight another target creature.\"",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "fd3db5e3-54e5-55fd-998e-4e5905363bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "ced52be1-d9b8-578d-b73b-c57ee411c0b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bccca0-6425-4676-a98a-e0721a6beff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80bccca0-6425-4676-a98a-e0721a6beff7.jpg?1",
             "name": "Crested Herdcaller",
             "text": "Trample\nWhen Crested Herdcaller enters the battlefield, create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -4268,7 +4268,7 @@
         },
         {
             "id": "0bdc85fb-5b13-55fb-bc62-28013a27a2af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b738ce-a609-448f-97ea-bbf90ba833d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b738ce-a609-448f-97ea-bbf90ba833d7.jpg?1",
             "name": "Deeproot Elite",
             "text": "Whenever another Merfolk enters the battlefield under your control, put a +1/+1 counter on target Merfolk you control.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "2fa066de-0813-507c-be47-958667ac5c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96acf94b-75bb-4f0e-92be-978ce5920710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96acf94b-75bb-4f0e-92be-978ce5920710.jpg?1",
             "name": "Enter the Unknown",
             "text": "Target creature you control explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)\nYou may play an additional land this turn.",
             "colours": [
@@ -4335,7 +4335,7 @@
         },
         {
             "id": "dbf1e48b-2aa0-5a42-aa84-e439e456c0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bc2bd2-adfc-490e-998a-303598e6a942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30bc2bd2-adfc-490e-998a-303598e6a942.jpg?1",
             "name": "Forerunner of the Heralds",
             "text": "When Forerunner of the Heralds enters the battlefield, you may search your library for a Merfolk card, reveal it, then shuffle your library and put that card on top of it.\nWhenever another Merfolk enters the battlefield under your control, put a +1/+1 counter on Forerunner of the Heralds.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "81581621-27dd-50b5-83f4-7ad5248b5c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b5b3-9376-4ad7-9a77-3e564e9c42e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0104b5b3-9376-4ad7-9a77-3e564e9c42e6.jpg?1",
             "name": "Ghalta, Primal Hunger",
             "text": "Ghalta, Primal Hunger costs {X} less to cast, where X is the total power of creatures you control.\nTrample",
             "colours": [
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "f03cdaa6-0c11-55f3-ba16-0db14c80cb1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47963f87-d5c2-4e5b-8dff-b25735182841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47963f87-d5c2-4e5b-8dff-b25735182841.jpg?1",
             "name": "Giltgrove Stalker",
             "text": "Giltgrove Stalker can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -4442,7 +4442,7 @@
         },
         {
             "id": "6162336c-2a08-5b38-9b83-a59d158b9e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f2755f-276f-4260-a201-f02af88b5708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62f2755f-276f-4260-a201-f02af88b5708.jpg?1",
             "name": "Hardy Veteran",
             "text": "As long as it's your turn, Hardy Veteran gets +0/+2.",
             "colours": [
@@ -4477,7 +4477,7 @@
         },
         {
             "id": "3e86ab8e-4238-50d0-9149-d9bd37fd68f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6cab6-b0f9-4631-a4bd-5ff1d6d53880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d6cab6-b0f9-4631-a4bd-5ff1d6d53880.jpg?1",
             "name": "Hunt the Weak",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "c7e6a529-ad40-5ad7-8e5d-b9c2392f430f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696bb954-353e-488b-a1e8-0df75da6339b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696bb954-353e-488b-a1e8-0df75da6339b.jpg?1",
             "name": "Jade Bearer",
             "text": "When Jade Bearer enters the battlefield, put a +1/+1 counter on another target Merfolk you control.",
             "colours": [
@@ -4544,7 +4544,7 @@
         },
         {
             "id": "ee9428c9-443e-5ac3-bed5-5a22308b16d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b745934-c1fe-49f5-bda4-b0eafa1408e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b745934-c1fe-49f5-bda4-b0eafa1408e1.jpg?1",
             "name": "Jadecraft Artisan",
             "text": "When Jadecraft Artisan enters the battlefield, target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "cbfeb7da-e30d-5b9e-9b8f-b59d93321401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe5c719-f20d-4469-9750-fb689d5f3fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe5c719-f20d-4469-9750-fb689d5f3fc8.jpg?1",
             "name": "Jadelight Ranger",
             "text": "When Jadelight Ranger enters the battlefield, it explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard. Then repeat this process.)",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "b67ec0c9-af29-5b71-87f0-3d6cff7e601a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f01ae0d-db1e-4912-b8ad-3069f6938e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f01ae0d-db1e-4912-b8ad-3069f6938e04.jpg?1",
             "name": "Jungleborn Pioneer",
             "text": "When Jungleborn Pioneer enters the battlefield, create a 1/1 blue Merfolk creature token with hexproof. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "ffa78954-1122-5221-af63-31b9c5bc5d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81565a4-cbbe-4820-8473-15ceda42d553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81565a4-cbbe-4820-8473-15ceda42d553.jpg?1",
             "name": "Knight of the Stampede",
             "text": "Dinosaur spells you cast cost {2} less to cast.",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "0926e139-730e-541d-9e76-a3cc20245f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c187d05-0df4-48b6-8e75-690e725b8bcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c187d05-0df4-48b6-8e75-690e725b8bcf.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "016b5ac0-f8e3-593b-ac32-602f4658ce31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c81160-192c-4077-8ed1-3643919a2025.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c81160-192c-4077-8ed1-3643919a2025.jpg?1",
             "name": "Orazca Frillback",
             "text": "",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "deac24ff-bf96-5f63-982a-72716deb1adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6558db-6332-42ac-8a61-4524c200b62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6558db-6332-42ac-8a61-4524c200b62f.jpg?1",
             "name": "Overgrown Armasaur",
             "text": "Enrage \u2014 Whenever Overgrown Armasaur is dealt damage, create a 1/1 green Saproling creature token.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "c7a04b22-6096-5099-936b-71d0a5a93467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9d5518-34ea-418d-b34d-74d773db8bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9d5518-34ea-418d-b34d-74d773db8bcb.jpg?1",
             "name": "Path of Discovery",
             "text": "Whenever a creature enters the battlefield under your control, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "01db9ec9-12e4-5770-8bd0-ba11a95b5209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a0afaa-f99f-4c7a-9fa1-c6a46dfb2a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a0afaa-f99f-4c7a-9fa1-c6a46dfb2a29.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "275430fa-1ed2-5a06-80ad-b0ab6dab81d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8965a3a-93fe-4021-a665-b6013bdc86f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8965a3a-93fe-4021-a665-b6013bdc86f7.jpg?1",
             "name": "Polyraptor",
             "text": "Enrage \u2014 Whenever Polyraptor is dealt damage, create a token that's a copy of Polyraptor.",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "ce2dfafe-0cde-54bd-b7b7-284a313a3e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dd7d94-e2bd-4320-8452-9e0deb1be351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dd7d94-e2bd-4320-8452-9e0deb1be351.jpg?1",
             "name": "Strength of the Pack",
             "text": "Put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -4915,7 +4915,7 @@
         },
         {
             "id": "5242c5c3-f26a-5ad7-bfcf-67a2891b2001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531cb47-b0ff-4d66-acf2-ef5bb5f690fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531cb47-b0ff-4d66-acf2-ef5bb5f690fc.jpg?1",
             "name": "Swift Warden",
             "text": "Flash\nWhen Swift Warden enters the battlefield, target Merfolk you control gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "d1e5524f-526b-5596-963b-b5bbf0be5037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a159830a-698f-423c-9da0-a734b210ecab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a159830a-698f-423c-9da0-a734b210ecab.jpg?1",
             "name": "Tendershoot Dryad",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nAt the beginning of each upkeep, create a 1/1 green Saproling creature token.\nSaprolings you control get +2/+2 as long as you have the city's blessing.",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "9794bb4e-cc43-5416-9ebd-90d0ac9da127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9264ff-9f7c-46f3-862a-fee7ad213250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9264ff-9f7c-46f3-862a-fee7ad213250.jpg?1",
             "name": "Thrashing Brontodon",
             "text": "{1}, Sacrifice Thrashing Brontodon: Destroy target artifact or enchantment.",
             "colours": [
@@ -5018,7 +5018,7 @@
         },
         {
             "id": "612c1c3a-5c9e-5ca4-bd94-7229eb4b7c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56de4a3-f5ab-469e-ab66-b8187c8c04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56de4a3-f5ab-469e-ab66-b8187c8c04a0.jpg?1",
             "name": "Thunderherd Migration",
             "text": "As an additional cost to cast Thunderherd Migration, reveal a Dinosaur card from your hand or pay {1}.\nSearch your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5050,7 +5050,7 @@
         },
         {
             "id": "19f97ee8-9e55-530f-b86d-ca7525625700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351e8b1b-4e4e-4ffc-a134-3cf0e2a1dd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351e8b1b-4e4e-4ffc-a134-3cf0e2a1dd6d.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nYou may play an additional land on each of your turns.\nWayward Swordtooth can't attack or block unless you have the city's blessing.",
             "colours": [
@@ -5084,7 +5084,7 @@
         },
         {
             "id": "ecc4ad08-01f3-5a24-947d-19e9b93adf9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59c87f5-95ab-4385-abbe-99a3149bdbcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59c87f5-95ab-4385-abbe-99a3149bdbcf.jpg?1",
             "name": "World Shaper",
             "text": "Whenever World Shaper attacks, you may put the top three cards of your library into your graveyard.\nWhen World Shaper dies, put all land cards from your graveyard onto the battlefield tapped.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "92ebbe6a-d5fb-5c96-9a83-cc607673bdd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d76d03-4fcf-42f8-8c2e-ad6b03d58677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d76d03-4fcf-42f8-8c2e-ad6b03d58677.jpg?1",
             "name": "Angrath, the Flame-Chained",
             "text": "+1: Each opponent discards a card and loses 2 life.\n\u22123: Gain control of target creature until end of turn. Untap it. It gains haste until end of turn. Sacrifice it at the beginning of the next end step if it has converted mana cost 3 or less.\n\u22128: Each opponent loses life equal to the number of cards in his or her graveyard.",
             "colours": [
@@ -5157,7 +5157,7 @@
         },
         {
             "id": "a549806d-f763-550a-8c12-6258166e6075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe84b3c0-bca2-42d3-a82c-540644e59625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe84b3c0-bca2-42d3-a82c-540644e59625.jpg?1",
             "name": "Atzocan Seer",
             "text": "{T}: Add one mana of any color to your mana pool.\nSacrifice Atzocan Seer: Return target Dinosaur card from your graveyard to your hand.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "6f13efa3-e0ee-5628-85b8-95932e3cc6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc237e-b28a-4b65-9790-6b434828bf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc237e-b28a-4b65-9790-6b434828bf2e.jpg?1",
             "name": "Azor, the Lawbringer",
             "text": "Flying\nWhen Azor, the Lawbringer enters the battlefield, each opponent can't cast instant or sorcery spells during that player's next turn.\nWhenever Azor attacks, you may pay {X}{W}{U}{U}. If you do, you gain X life and draw X cards.",
             "colours": [
@@ -5232,7 +5232,7 @@
         },
         {
             "id": "024c9e4d-bed7-5ecf-8cef-babb5c79e923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb1ab66-f2ce-4094-b2dd-1fc63d78eea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb1ab66-f2ce-4094-b2dd-1fc63d78eea2.jpg?1",
             "name": "Deadeye Brawler",
             "text": "Deathtouch\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever Deadeye Brawler deals combat damage to a player, if you have the city's blessing, draw a card.",
             "colours": [
@@ -5269,7 +5269,7 @@
         },
         {
             "id": "0a79cb65-ff26-5bf5-b4c5-220e84835371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5146dd15-f696-42c3-b0e5-6a1b1d7be6b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5146dd15-f696-42c3-b0e5-6a1b1d7be6b4.jpg?1",
             "name": "Dire Fleet Neckbreaker",
             "text": "Attacking Pirates you control get +2/+0.",
             "colours": [
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "618c125d-bc56-5b10-8afd-bc3294592d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52af49b-cfeb-47a8-9ce5-5d35bfa9eb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a52af49b-cfeb-47a8-9ce5-5d35bfa9eb75.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "Lifelink\nWhenever another creature dies, put a +1/+1 counter on Elenda, the Dusk Rose.\nWhen Elenda dies, create X 1/1 white Vampire creature tokens with lifelink, where X is Elenda's power.",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "d5b69801-24de-5dcc-ad79-6a21cd2b12dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg?1",
             "name": "Hadana's Climb // Winged Temple of Orazca",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if that creature has three or more +1/+1 counters on it, transform Hadana's Climb.",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "6e299ca2-d620-5fe6-9fc4-35d1305d318a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e7554bc-8583-4059-8895-c3845bc27ae3.jpg?1",
             "name": "Hadana's Climb // Winged Temple of Orazca",
             "text": "(Transforms from Hadana's Climb.)\n{T}: Add one mana of any color to your mana pool.\n{1}{G}{U}, {T}: Target creature you control gains flying and gets +X/+X until end of turn, where X is its power.",
             "colours": [],
@@ -5414,7 +5414,7 @@
         },
         {
             "id": "80f0d8bf-6ca9-5768-8bee-29051616f3c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bcc48a-efdb-443f-93b8-bc0b54aa0eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bcc48a-efdb-443f-93b8-bc0b54aa0eb8.jpg?1",
             "name": "Huatli, Radiant Champion",
             "text": "+1: Put a loyalty counter on Huatli, Radiant Champion for each creature you control.\n\u22121: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.\n\u22128: You get an emblem with \"Whenever a creature enters the battlefield under your control, you may draw a card.\"",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "88400e25-72b6-54b9-8e0d-40851b42bcdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg?1",
             "name": "Journey to Eternity // Atzal, Cave of Eternity",
             "text": "Enchant creature you control\nWhen enchanted creature dies, return it to the battlefield under your control, then return Journey to Eternity to the battlefield transformed under your control.",
             "colours": [
@@ -5490,7 +5490,7 @@
         },
         {
             "id": "7664ab16-0936-560c-97ad-38da8f083349",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d81c4b3f-81c2-403b-8a5d-c9415f73a1f9.jpg?1",
             "name": "Journey to Eternity // Atzal, Cave of Eternity",
             "text": "(Transforms from Journey to Eternity.)\n{T}: Add one mana of any color to your mana pool.\n{3}{B}{G}, {T}: Return target creature card from your graveyard to the battlefield.",
             "colours": [],
@@ -5523,7 +5523,7 @@
         },
         {
             "id": "0b03d1e9-4c22-5d0a-b45f-548ec32c0dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71282d-021c-4028-9ab7-f10e43e92c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71282d-021c-4028-9ab7-f10e43e92c80.jpg?1",
             "name": "Jungle Creeper",
             "text": "{3}{B}{G}: Return Jungle Creeper from your graveyard to your hand.",
             "colours": [
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "50dd34dc-b85f-5668-bb1e-583e9dff2721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aef818-c896-46e6-aaff-56aee52a066c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3aef818-c896-46e6-aaff-56aee52a066c.jpg?1",
             "name": "Kumena, Tyrant of Orazca",
             "text": "Tap another untapped Merfolk you control: Kumena, Tyrant of Orazca can't be blocked this turn.\nTap three untapped Merfolk you control: Draw a card.\nTap five untapped Merfolk you control: Put a +1/+1 counter on each Merfolk you control.",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "748c9b9d-fd0e-5c14-87db-501661fb334f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7ff99-65d6-4e97-bdfa-b6e6eac0588f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f7ff99-65d6-4e97-bdfa-b6e6eac0588f.jpg?1",
             "name": "Legion Lieutenant",
             "text": "Other Vampires you control get +1/+1.",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "5b841a0b-80b8-5f61-bba1-4c6f1ff5dd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2935b829-23fb-415e-90f2-2e0016b5cde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2935b829-23fb-415e-90f2-2e0016b5cde9.jpg?1",
             "name": "Merfolk Mistbinder",
             "text": "Other Merfolk you control get +1/+1.",
             "colours": [
@@ -5672,7 +5672,7 @@
         },
         {
             "id": "7030cce5-cda0-52f4-a90b-7389387a3062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1",
             "name": "Path of Mettle // Metzali, Tower of Triumph",
             "text": "When Path of Mettle enters the battlefield, it deals 1 damage to each creature that doesn't have first strike, double strike, vigilance, or haste.\nWhenever you attack with at least two creatures that have first strike, double strike, vigilance, and/or haste, transform Path of Mettle.",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "a632754f-2552-5c91-90d2-063175557774",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1",
             "name": "Path of Mettle // Metzali, Tower of Triumph",
             "text": "(Transforms from Path of Mettle.)\n{T}: Add one mana of any color to your mana pool.\n{1}{R}, {T}: Metzali, Tower of Triumph deals 2 damage to each opponent.\n{2}{W}, {T}: Choose a creature at random that attacked this turn. Destroy that creature.",
             "colours": [],
@@ -5741,7 +5741,7 @@
         },
         {
             "id": "92584313-4011-514e-bc54-13723aada3a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg?1",
             "name": "Profane Procession // Tomb of the Dusk Rose",
             "text": "{3}{W}{B}: Exile target creature. Then if there are three or more cards exiled with Profane Procession, transform it.",
             "colours": [
@@ -5777,7 +5777,7 @@
         },
         {
             "id": "0f7191ec-1143-5483-b44b-7ad31989968d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d94ff37-f04e-48ee-8253-d62ab07f0632.jpg?1",
             "name": "Profane Procession // Tomb of the Dusk Rose",
             "text": "(Transforms from Profane Procession.)\n{T}: Add one mana of any color to your mana pool.\n{2}{W}{B}, {T}: Put a creature card exiled with this permanent onto the battlefield under your control.",
             "colours": [],
@@ -5810,7 +5810,7 @@
         },
         {
             "id": "b578b9a0-f980-5d4f-b1a2-a597268e2456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ed9247-16c0-4ca4-9b46-d3da5a375e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ed9247-16c0-4ca4-9b46-d3da5a375e4c.jpg?1",
             "name": "Protean Raider",
             "text": "Raid \u2014 If you attacked with a creature this turn, you may have Protean Raider enter the battlefield as a copy of any creature on the battlefield.",
             "colours": [
@@ -5847,7 +5847,7 @@
         },
         {
             "id": "72f0e60a-b3b0-56ee-8c7c-a0f90ef569ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6c43a7-e9c5-4b1c-9a6d-0d8798303045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad6c43a7-e9c5-4b1c-9a6d-0d8798303045.jpg?1",
             "name": "Raging Regisaur",
             "text": "Whenever Raging Regisaur attacks, it deals 1 damage to target creature or player.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "cbba7335-c833-5313-b9dc-a2790d3c8fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0727ba-4180-4908-93be-a8abf29a8958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0727ba-4180-4908-93be-a8abf29a8958.jpg?1",
             "name": "Relentless Raptor",
             "text": "Vigilance\nRelentless Raptor attacks or blocks each combat if able.",
             "colours": [
@@ -5919,7 +5919,7 @@
         },
         {
             "id": "96ff7ee4-097f-58c6-80d8-a3dee32464c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915f2ad9-fd39-465c-8261-bfa34116cbcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915f2ad9-fd39-465c-8261-bfa34116cbcc.jpg?1",
             "name": "Resplendent Griffin",
             "text": "Flying\nAscend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\nWhenever Resplendent Griffin attacks, if you have the city's blessing, put a +1/+1 counter on it.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "44de3305-1657-5e19-b10b-7a4091287d42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9c4c63-402e-489e-ab0d-1c98309b010a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9c4c63-402e-489e-ab0d-1c98309b010a.jpg?1",
             "name": "Siegehorn Ceratops",
             "text": "Enrage \u2014 Whenever Siegehorn Ceratops is dealt damage, put two +1/+1 counters on it. (It must survive the damage to get the counters.)",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "81bb9071-b002-5cfa-b057-eac428e0f1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad8525-7618-4c2b-8037-46f53dd42ee0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ad8525-7618-4c2b-8037-46f53dd42ee0.jpg?1",
             "name": "Storm Fleet Sprinter",
             "text": "Haste\nStorm Fleet Sprinter can't be blocked.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "334707ec-651b-5c1d-bf11-330cf58e3282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg?1",
             "name": "Storm the Vault // Vault of Catlacan",
             "text": "Whenever one or more creatures you control deal combat damage to a player, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nAt the beginning of your end step, if you control five or more artifacts, transform Storm the Vault.",
             "colours": [
@@ -6064,7 +6064,7 @@
         },
         {
             "id": "ae385080-8c4b-5dfd-9c1b-fda792310c20",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c16ba84e-a0cc-4c6c-9b80-713247b8fef9.jpg?1",
             "name": "Storm the Vault // Vault of Catlacan",
             "text": "(Transforms from Storm the Vault.)\n{T}: Add one mana of any color to your mana pool.\n{T}: Add {U} to your mana pool for each artifact you control.",
             "colours": [],
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "ba3f6ea7-2699-552f-b11c-2041a03ce5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa75f2b-53c5-47c5-96d2-ab796358a96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa75f2b-53c5-47c5-96d2-ab796358a96f.jpg?1",
             "name": "Zacama, Primal Calamity",
             "text": "Vigilance, reach, trample\nWhen Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.\n{2}{R}: Zacama deals 3 damage to target creature.\n{2}{G}: Destroy target artifact or enchantment.\n{2}{W}: You gain 3 life.",
             "colours": [
@@ -6138,7 +6138,7 @@
         },
         {
             "id": "c0cec6af-73e2-5677-a339-d778a13c4d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b14ea-04f0-4d4b-970e-efc65d64945e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24b14ea-04f0-4d4b-970e-efc65d64945e.jpg?1",
             "name": "Awakened Amalgam",
             "text": "Awakened Amalgam's power and toughness are each equal to the number of differently named lands you control.",
             "colours": [],
@@ -6169,7 +6169,7 @@
         },
         {
             "id": "84cabf87-ea4e-53e6-9f48-2bfe3d2f4216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg?1",
             "name": "Azor's Gateway // Sanctum of the Sun",
             "text": "{1}, {T}: Draw a card, then exile a card from your hand. If cards with five or more different converted mana costs are exiled with Azor's Gateway, you gain 5 life, untap Azor's Gateway, and transform it.",
             "colours": [],
@@ -6199,7 +6199,7 @@
         },
         {
             "id": "d0b0fece-d4bd-5013-b718-df9d2db81d05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/303d51ab-b9c4-4647-950f-291daabe7b81.jpg?1",
             "name": "Azor's Gateway // Sanctum of the Sun",
             "text": "(Transforms from Azor's Gateway.)\n{T}: Add X mana of any one color to your mana pool, where X is your life total.",
             "colours": [],
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "28dcfe92-70f7-559a-af25-9fd83d2e5ec0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3f777-b33a-454a-8d5d-993260ddda03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd3f777-b33a-454a-8d5d-993260ddda03.jpg?1",
             "name": "Captain's Hook",
             "text": "Equipped creature gets +2/+0, has menace, and is a Pirate in addition to its other creature types.\nWhenever Captain's Hook becomes unattached from a permanent, destroy that permanent.\nEquip {1}",
             "colours": [],
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "507c36c2-9c37-58de-9ebf-445125b4f2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62447a76-4aa7-4823-941e-84bc18eb672a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62447a76-4aa7-4823-941e-84bc18eb672a.jpg?1",
             "name": "Gleaming Barrier",
             "text": "Defender\nWhen Gleaming Barrier dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [],
@@ -6290,7 +6290,7 @@
         },
         {
             "id": "b9d63a33-71cc-5824-a614-b511480cf3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg?1",
             "name": "Golden Guardian // Gold-Forge Garrison",
             "text": "Defender\n{2}: Golden Guardian fights another target creature you control. When Golden Guardian dies this turn, return it to the battlefield transformed under your control.",
             "colours": [],
@@ -6321,7 +6321,7 @@
         },
         {
             "id": "7cc06729-21e7-5cb0-822f-c88156a98eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ba02d-f347-46f7-b028-dd4ba55faa2f.jpg?1",
             "name": "Golden Guardian // Gold-Forge Garrison",
             "text": "(Transforms from Golden Guardian.)\n{T}: Add two mana of any one color to your mana pool.\n{4}, {T}: Create a 4/4 colorless Golem artifact creature token.",
             "colours": [],
@@ -6349,7 +6349,7 @@
         },
         {
             "id": "ad1528f9-a4b4-58ea-955d-0f4cad3f3398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeccd88-8dc0-4cc1-943f-27d540d248bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adeccd88-8dc0-4cc1-943f-27d540d248bb.jpg?1",
             "name": "The Immortal Sun",
             "text": "Players can't activate planeswalkers' loyalty abilities.\nAt the beginning of your draw step, draw an additional card.\nSpells you cast cost {1} less to cast.\nCreatures you control get +1/+1.",
             "colours": [],
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "fd962248-4199-565b-8dce-9a4b2b011348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed70bc5-8ea9-404e-a8cd-04322c8bc689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed70bc5-8ea9-404e-a8cd-04322c8bc689.jpg?1",
             "name": "Orazca Relic",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C} to your mana pool.\n{T}, Sacrifice Orazca Relic: You gain 3 life and draw a card. Activate this ability only if you have the city's blessing.",
             "colours": [],
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "6906c333-1051-5710-8aee-f8b97f544938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff60f685-a17e-4be6-bbb6-d14a053533ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff60f685-a17e-4be6-bbb6-d14a053533ef.jpg?1",
             "name": "Silent Gravestone",
             "text": "Cards in graveyards can't be the targets of spells or abilities.\n{4}, {T}: Exile Silent Gravestone and all cards from all graveyards. Draw a card.",
             "colours": [],
@@ -6435,7 +6435,7 @@
         },
         {
             "id": "5b67b730-8892-529d-98d2-a2e059b8825e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94daa9-5b9b-4fd2-829e-081eed22c18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e94daa9-5b9b-4fd2-829e-081eed22c18f.jpg?1",
             "name": "Strider Harness",
             "text": "Equipped creature gets +1/+1 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6465,7 +6465,7 @@
         },
         {
             "id": "2ce650b2-8b3a-59aa-abe1-7205ea7fba29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e2aa2-110e-4824-a9c9-5a76cb2bec23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393e2aa2-110e-4824-a9c9-5a76cb2bec23.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "0b10bbf7-5ce1-5913-838c-67660bd87a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d47162-749b-47d5-9589-8f1dbf60b9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d47162-749b-47d5-9589-8f1dbf60b9f3.jpg?1",
             "name": "Arch of Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C} to your mana pool.\n{5}, {T}: Draw a card. Activate this ability only if you have the city's blessing.",
             "colours": [],
@@ -6521,7 +6521,7 @@
         },
         {
             "id": "c13c66ee-1db9-5674-876b-11cc0fdb47ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62df0466-3bb4-423c-aae8-412205fb9f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62df0466-3bb4-423c-aae8-412205fb9f14.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "9719235d-3592-549d-a96b-30dddba8acf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e5daf3-6a55-4c2f-92d1-33e0755ee280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e5daf3-6a55-4c2f-92d1-33e0755ee280.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -6580,7 +6580,7 @@
         },
         {
             "id": "b06c36fe-a25b-593c-b776-f2b74ff9eb49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66f9017-e04b-4f13-aae0-28a903f2fac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66f9017-e04b-4f13-aae0-28a903f2fac2.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -6611,7 +6611,7 @@
         },
         {
             "id": "28f8f87d-ecb7-5bee-b444-6bb02d3fcc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344f5678-d25b-40af-aa91-b0eed90fd037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/344f5678-d25b-40af-aa91-b0eed90fd037.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -6642,7 +6642,7 @@
         },
         {
             "id": "2411512a-1770-5702-91b3-ed1ee0885a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e782c-2159-4e8d-b2d7-9f96b7609db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315e782c-2159-4e8d-b2d7-9f96b7609db4.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -6673,7 +6673,7 @@
         },
         {
             "id": "5cf45853-425e-5511-970e-9cdffe2d57b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f14b4d-b90e-4ce4-aa32-13c9969aa46a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f14b4d-b90e-4ce4-aa32-13c9969aa46a.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "42d0ea18-a81d-591a-ac58-7923d0beb500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92342f45-ccfe-4d94-82ba-2fd55128326f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92342f45-ccfe-4d94-82ba-2fd55128326f.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "a446efdc-27fc-5e7a-9c68-d8326396586e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22fb908-e616-48ce-a388-46eabe26221a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22fb908-e616-48ce-a388-46eabe26221a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "a6f143e5-b88a-5f3e-9259-68fc97ea0a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674de0e1-be2d-4fda-8519-8775802a7b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674de0e1-be2d-4fda-8519-8775802a7b36.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -6806,7 +6806,7 @@
         },
         {
             "id": "fcc6374e-1f2e-5363-a0d9-797bb037bb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd9acc5-0088-4621-8f48-e997da5f27c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd9acc5-0088-4621-8f48-e997da5f27c5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "5a894232-5b7b-5d7c-a803-5cadd21c52e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c9e16d-525b-4ba9-890d-fa2719206ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92c9e16d-525b-4ba9-890d-fa2719206ba0.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "aefe8769-bc31-51e4-89e7-dece664724f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91685732-c118-4f52-ac77-f96866a687a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91685732-c118-4f52-ac77-f96866a687a3.jpg?1",
             "name": "Vraska, Scheming Gorgon",
             "text": "+2: Creatures you control get +1/+0 until end of turn.\n\u22123: Destroy target creature.\n\u221210: Until end of turn, creatures you control gain deathtouch and \"Whenever this creature deals damage to an opponent, that player loses the game.\"",
             "colours": [
@@ -6909,7 +6909,7 @@
         },
         {
             "id": "7e5bef08-30ce-55a6-8a13-853f0309caf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47f91ff-c916-4938-8e01-2c684004dd9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47f91ff-c916-4938-8e01-2c684004dd9a.jpg?1",
             "name": "Vampire Champion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6943,7 +6943,7 @@
         },
         {
             "id": "fad9f64b-d800-5982-9a31-87c2c80c6aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d890a17-ffd4-4bda-bef3-2c116f7bf66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d890a17-ffd4-4bda-bef3-2c116f7bf66f.jpg?1",
             "name": "Vraska's Conquistador",
             "text": "Whenever Vraska's Conquistador attacks or blocks, if you control a Vraska planeswalker, target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -6977,7 +6977,7 @@
         },
         {
             "id": "194d8db7-67aa-5bc3-9695-fde4701a6cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569ff807-365d-4f25-9fad-86617ed1c8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569ff807-365d-4f25-9fad-86617ed1c8f2.jpg?1",
             "name": "Vraska's Scorn",
             "text": "Target opponent loses 4 life. You may search your library and/or graveyard for a card named Vraska, Scheming Gorgon, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "8c5ddefb-ae09-50f0-883f-9a9ea7962fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17103dd-f31b-4f6e-b2ea-4ea91815bdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17103dd-f31b-4f6e-b2ea-4ea91815bdd6.jpg?1",
             "name": "Angrath, Minotaur Pirate",
             "text": "+2: Angrath, Minotaur Pirate deals 1 damage to target opponent and each creature that player controls.\n\u22123: Return target Pirate card from your graveyard to the battlefield.\n\u221211: Destroy all creatures target opponent controls. Angrath, Minotaur Pirate deals damage to that player equal to their total power.",
             "colours": [
@@ -7045,7 +7045,7 @@
         },
         {
             "id": "e3daa823-204d-5ac3-84c3-70f7ea7bdc74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48181263-11fd-444e-9fef-02ccfe016c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48181263-11fd-444e-9fef-02ccfe016c8c.jpg?1",
             "name": "Angrath's Ambusher",
             "text": "Angrath's Ambusher gets +2/+0 as long as you control an Angrath planeswalker.",
             "colours": [
@@ -7079,7 +7079,7 @@
         },
         {
             "id": "3b09bc67-eb02-5be2-b9bc-20000072995d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0403b8e5-29c5-4a4a-b9e7-1e79a7452f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0403b8e5-29c5-4a4a-b9e7-1e79a7452f14.jpg?1",
             "name": "Swab Goblin",
             "text": "",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "a6b382c7-4539-57c8-85df-0559c052d9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708006ba-d494-4093-b108-8249b110831e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/708006ba-d494-4093-b108-8249b110831e.jpg?1",
             "name": "Angrath's Fury",
             "text": "Destroy target creature. Angrath's Fury deals 3 damage to target player. You may search your library and/or graveyard for a card named Angrath, Minotaur Pirate, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "34f9410d-1167-5e7a-ad3b-3151909383cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6bd6b-92fb-4b4f-89c2-762cc2c465f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f6bd6b-92fb-4b4f-89c2-762cc2c465f3.jpg?1",
             "name": "Cinder Barrens",
             "text": "Cinder Barrens enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "ffe14eda-bdfb-5982-9749-71ceb4fad071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf1d7-2e66-41fd-ae9a-ea86b939e7c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0bf1d7-2e66-41fd-ae9a-ea86b939e7c9.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -7210,7 +7210,7 @@
         },
         {
             "id": "1a5ed6ee-d893-5407-9e68-78b5ccb46175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236ab9c-7730-46d9-a543-84ff7b245ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236ab9c-7730-46d9-a543-84ff7b245ece.jpg?1",
             "name": "Rivals of Ixalan Checklist",
             "text": "",
             "colours": [],
@@ -7237,7 +7237,7 @@
         },
         {
             "id": "199f5634-c706-5103-84c8-9d3100ee5edc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577a3396-e974-47fb-91bd-01751cae83bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577a3396-e974-47fb-91bd-01751cae83bf.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -7271,7 +7271,7 @@
         },
         {
             "id": "001779ab-ab90-512e-9e9f-cd5bf1a39d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925715e5-bb94-406b-82b1-93b4d51f0cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925715e5-bb94-406b-82b1-93b4d51f0cc2.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -7305,7 +7305,7 @@
         },
         {
             "id": "dbcdc2ad-8a30-56df-840b-e8db8edf53cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7820eb9-6d7f-4bc4-b421-4e4420642fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7820eb9-6d7f-4bc4-b421-4e4420642fb7.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -7336,7 +7336,7 @@
         },
         {
             "id": "69216e15-1df0-5748-a037-172be13eeb25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859f645b-24e0-4c34-ae82-ba0ae9854377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859f645b-24e0-4c34-ae82-ba0ae9854377.jpg?1",
             "name": "Huatli, Radiant Champion Emblem",
             "text": "",
             "colours": [],
@@ -7365,7 +7365,7 @@
         },
         {
             "id": "ef50f1ce-9ec6-5f7c-a5b5-3bdc1097e5c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64ed3e-93c5-406f-a38d-65cc68472122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba64ed3e-93c5-406f-a38d-65cc68472122.jpg?1",
             "name": "City's Blessing",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/RNA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/RNA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b659bb15-30b1-5fb8-b57c-2addaaccbe69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80164e61-3e94-4e10-9bd1-518b8dc7fc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80164e61-3e94-4e10-9bd1-518b8dc7fc4c.jpg?1",
             "name": "Angel of Grace",
             "text": "Flash\nFlying\nWhen Angel of Grace enters the battlefield, until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.\n{4}{W}{W}, Exile Angel of Grace from your graveyard: Your life total becomes 10.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "d995c603-e44a-5fe1-a7e1-4a8451326968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7b5ae5-0f6b-4f45-8597-4e6212d2ad0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7b5ae5-0f6b-4f45-8597-4e6212d2ad0e.jpg?1",
             "name": "Angelic Exaltation",
             "text": "Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "d27b0d0d-f775-534b-bd39-deb6d15ab4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b209d219-b946-4226-a8b4-65a5f3837fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b209d219-b946-4226-a8b4-65a5f3837fac.jpg?1",
             "name": "Archway Angel",
             "text": "Flying\nWhen Archway Angel enters the battlefield, you gain 2 life for each Gate you control.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "7f937f1a-6c12-5de9-950e-8a6285d6b832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b075a6f2-5196-45e9-b062-f131f7b1a347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b075a6f2-5196-45e9-b062-f131f7b1a347.jpg?1",
             "name": "Arrester's Zeal",
             "text": "Target creature gets +2/+2 until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, that creature gains flying until end of turn.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "d9b1484c-cadd-501c-bd6f-35a2f69d8478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d566fc-0936-4035-96fd-f8b0c4eadbf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d566fc-0936-4035-96fd-f8b0c4eadbf5.jpg?1",
             "name": "Bring to Trial",
             "text": "Exile target creature with power 4 or greater.",
             "colours": [
@@ -168,7 +168,7 @@
         },
         {
             "id": "94b5308d-2717-58c9-80de-1dde77a16d67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa981489-4301-43f6-b1d7-2aa42e00cf75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa981489-4301-43f6-b1d7-2aa42e00cf75.jpg?1",
             "name": "Civic Stalwart",
             "text": "When Civic Stalwart enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "c1b58101-a228-584d-bd76-1ad73f8021c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7fdf7b-022c-4900-9344-9b13d41c1604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7fdf7b-022c-4900-9344-9b13d41c1604.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying",
             "colours": [
@@ -237,7 +237,7 @@
         },
         {
             "id": "6e318808-aa42-5397-a883-fe630f804ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c2ac3-040f-41fe-9a37-c037d90baec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094c2ac3-040f-41fe-9a37-c037d90baec0.jpg?1",
             "name": "Expose to Daylight",
             "text": "Destroy target artifact or enchantment. Scry 1.",
             "colours": [
@@ -269,7 +269,7 @@
         },
         {
             "id": "49e5508d-9d8c-5e25-af21-90ff15698fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17056e7-95c6-4bed-a747-3b40dcda275a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17056e7-95c6-4bed-a747-3b40dcda275a.jpg?1",
             "name": "Forbidding Spirit",
             "text": "When Forbidding Spirit enters the battlefield, until your next turn, creatures can't attack you or a planeswalker you control unless their controller pays {2} for each of those creatures.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "c6f8a3a0-df8a-51cb-a7b8-85a228734679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba5f096-c6ea-4db6-966b-617e3454813f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba5f096-c6ea-4db6-966b-617e3454813f.jpg?1",
             "name": "Haazda Officer",
             "text": "When Haazda Officer enters the battlefield, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "bea6fb15-9ca5-5dfb-8e58-53a59cc18307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87732718-1067-4e5f-a76d-409539c9ef3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87732718-1067-4e5f-a76d-409539c9ef3f.jpg?1",
             "name": "Hero of Precinct One",
             "text": "Whenever you cast a multicolored spell, create a 1/1 white Human creature token.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "d3be5dc8-0909-569b-a53b-012171e85a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd746e3-8934-4c86-894e-2cb1738b1d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd746e3-8934-4c86-894e-2cb1738b1d58.jpg?1",
             "name": "Impassioned Orator",
             "text": "Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -409,7 +409,7 @@
         },
         {
             "id": "8ce91e86-b3b7-510e-a40a-1ae177123d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df611df-3490-4b07-8034-6da9a0122a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df611df-3490-4b07-8034-6da9a0122a81.jpg?1",
             "name": "Justiciar's Portal",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. It gains first strike until end of turn.",
             "colours": [
@@ -441,7 +441,7 @@
         },
         {
             "id": "e349d3d5-f71a-553b-8b1f-7d3c7f963ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce239e9-9b35-4dde-8a44-6c7ce4eb2d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce239e9-9b35-4dde-8a44-6c7ce4eb2d1a.jpg?1",
             "name": "Knight of Sorrows",
             "text": "Knight of Sorrows can block an additional creature each combat.\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "2dbf5c4b-aeb1-57bf-b25b-a0a69fbdf92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2469bc93-57ca-4077-bda2-160b4160adad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2469bc93-57ca-4077-bda2-160b4160adad.jpg?1",
             "name": "Lumbering Battlement",
             "text": "Vigilance\nWhen Lumbering Battlement enters the battlefield, exile any number of other nontoken creatures you control until it leaves the battlefield.\nLumbering Battlement gets +2/+2 for each card exiled with it.",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "88658929-152b-5ae7-9be8-9be49c0efd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2a093a-25f0-4247-94dc-550865d86317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2a093a-25f0-4247-94dc-550865d86317.jpg?1",
             "name": "Ministrant of Obligation",
             "text": "Afterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "3d199dc5-f9e4-5d3e-8ee8-dc297e02c900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5382fc4-3384-449e-a83f-43a59158d55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5382fc4-3384-449e-a83f-43a59158d55b.jpg?1",
             "name": "Prowling Caracal",
             "text": "",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "9bfea731-d787-5a7f-8680-5939f1586c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0798546-1ef4-485e-b094-cba12a12c67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0798546-1ef4-485e-b094-cba12a12c67c.jpg?1",
             "name": "Rally to Battle",
             "text": "Creatures you control get +1/+3 until end of turn. Untap them.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "c2f125ec-847c-501a-8974-59edd31b696d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d86909-b7f3-4a46-9904-e173853b79f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d86909-b7f3-4a46-9904-e173853b79f1.jpg?1",
             "name": "Resolute Watchdog",
             "text": "Defender\n{1}, Sacrifice Resolute Watchdog: Target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "cef6d8f1-2085-5dc6-98be-8f1eb6faaee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f4f661-ee4b-4fa5-99c4-106731d117ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f4f661-ee4b-4fa5-99c4-106731d117ce.jpg?1",
             "name": "Sentinel's Mark",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+2 and has vigilance.\nAddendum \u2014 When Sentinel's Mark enters the battlefield, if you cast it during your main phase, enchanted creature gains lifelink until end of turn.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "a72ba1f4-b5fc-51a9-81ad-8d9c2bdb98b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c47be3-0228-46de-b4b5-911fb86d4596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c47be3-0228-46de-b4b5-911fb86d4596.jpg?1",
             "name": "Sky Tether",
             "text": "Enchant creature\nEnchanted creature has defender and loses flying.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "fdccaf49-4190-5740-bf6c-2fc9139489f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af082fa-86a3-4f7b-966d-2be1f1d0c0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af082fa-86a3-4f7b-966d-2be1f1d0c0bc.jpg?1",
             "name": "Smothering Tithe",
             "text": "Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color.\"",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "01f2c604-0473-57df-a39e-e6d47759636c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd11910-58e2-4233-a18c-e97413126597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd11910-58e2-4233-a18c-e97413126597.jpg?1",
             "name": "Spirit of the Spires",
             "text": "Flying\nOther creatures you control with flying get +0/+1.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "5f499cfe-240d-514e-8480-b86d1b1d2ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b20fec-8373-4c6c-b3c1-ee7cff64dd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b20fec-8373-4c6c-b3c1-ee7cff64dd37.jpg?1",
             "name": "Summary Judgment",
             "text": "Summary Judgment deals 3 damage to target tapped creature.\nAddendum \u2014 If you cast this spell during your main phase, it deals 5 damage to that creature instead.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "9daddc47-6090-5fd8-8cce-2460d8731c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10273046-4c74-42d8-afaa-6cfbe0bd4e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10273046-4c74-42d8-afaa-6cfbe0bd4e8f.jpg?1",
             "name": "Syndicate Messenger",
             "text": "Flying\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "9a2878ae-c247-51df-a3e7-e347f17bbbfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef573e92-3106-4b42-90e8-0e165de0659f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef573e92-3106-4b42-90e8-0e165de0659f.jpg?1",
             "name": "Tenth District Veteran",
             "text": "Vigilance\nWhenever Tenth District Veteran attacks, untap another target creature you control.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "be77ca12-561c-5153-8952-0259d365d96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26b7b1-992d-4b8c-bc33-51aab5abdf98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26b7b1-992d-4b8c-bc33-51aab5abdf98.jpg?1",
             "name": "Tithe Taker",
             "text": "During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities.\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "0712bc53-5228-54cd-92f3-5bce00b429a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb149cc-74ca-4bc3-8efc-10ce872b59fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb149cc-74ca-4bc3-8efc-10ce872b59fb.jpg?1",
             "name": "Twilight Panther",
             "text": "{B}: Twilight Panther gains deathtouch until end of turn.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "50289b0b-7c1a-5c8d-99b1-de02a10118c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cc8574-7b8c-492c-8a36-75cb0192f853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cc8574-7b8c-492c-8a36-75cb0192f853.jpg?1",
             "name": "Unbreakable Formation",
             "text": "Creatures you control gain indestructible until end of turn.\nAddendum \u2014 If you cast this spell during your main phase, put a +1/+1 counter on each of those creatures and they gain vigilance until end of turn.",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "263b5478-6d78-5fed-abc1-3e48f2d2ac65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a38f24-1eb3-4914-be1f-0b5f6d4b09d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a38f24-1eb3-4914-be1f-0b5f6d4b09d5.jpg?1",
             "name": "Watchful Giant",
             "text": "When Watchful Giant enters the battlefield, create a 1/1 white Human creature token.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "6e5a5a2c-d78e-5646-a06f-cacb53969a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c2d6a-e6b8-4dc5-81aa-da1b7384e006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637c2d6a-e6b8-4dc5-81aa-da1b7384e006.jpg?1",
             "name": "Arrester's Admonition",
             "text": "Return target creature to its owner's hand.\nAddendum \u2014 If you cast this spell during your main phase, draw a card.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "0070f147-8697-5fb9-8da7-1981aec68dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0cb4d6-350b-4e66-b035-dac7b3ba77cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0cb4d6-350b-4e66-b035-dac7b3ba77cc.jpg?1",
             "name": "Benthic Biomancer",
             "text": "{1}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Benthic Biomancer, draw a card, then discard a card.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "fd6776d7-69c4-5333-92b4-23c008348940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158547fa-7313-4e77-949f-afc68ebfb022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/158547fa-7313-4e77-949f-afc68ebfb022.jpg?1",
             "name": "Chillbringer",
             "text": "Flying\nWhen Chillbringer enters the battlefield, tap target creature an opponent controls. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1120,7 +1120,7 @@
         },
         {
             "id": "62525794-0d8b-5788-a238-b49f0aec9366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da6982-9e57-41d2-a052-f2a3bb646436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da6982-9e57-41d2-a052-f2a3bb646436.jpg?1",
             "name": "Clear the Mind",
             "text": "Target player shuffles their graveyard into their library.\nDraw a card.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "0a3ba2fb-0acb-570f-8bcc-0e288cf21861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258aeef1-565a-4f19-b12c-d46d54ba231d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/258aeef1-565a-4f19-b12c-d46d54ba231d.jpg?1",
             "name": "Code of Constraint",
             "text": "Target creature gets -4/-0 until end of turn.\nDraw a card.\nAddendum \u2014 If you cast this spell during your main phase, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "fb2d4fb4-e82e-5307-a8b2-afaf0948d7c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg?1",
             "name": "Coral Commando",
             "text": "",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "7a6ef288-74cb-5cbf-9521-b3be3f23daee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce137910-0f0e-4f94-9b95-6e0eeeba164e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce137910-0f0e-4f94-9b95-6e0eeeba164e.jpg?1",
             "name": "Essence Capture",
             "text": "Counter target creature spell. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "ab0962f8-f4b0-5791-b55e-1fd42d314579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdbf073-3ee6-402b-bd40-4781f40a6cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdbf073-3ee6-402b-bd40-4781f40a6cae.jpg?1",
             "name": "Eyes Everywhere",
             "text": "At the beginning of your upkeep, scry 1.\n{5}{U}: Exchange control of Eyes Everywhere and target nonland permanent. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1283,7 +1283,7 @@
         },
         {
             "id": "88c317e3-0a38-5991-99e1-b028890e4c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da9c9b-aeef-4f48-bc8f-39425841cc8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7da9c9b-aeef-4f48-bc8f-39425841cc8c.jpg?1",
             "name": "Faerie Duelist",
             "text": "Flash\nFlying\nWhen Faerie Duelist enters the battlefield, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1318,7 +1318,7 @@
         },
         {
             "id": "fd8c9492-f8d9-5688-af02-db9c27ac8063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc0229d-05e6-41b7-b7a9-2a8b2b258add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc0229d-05e6-41b7-b7a9-2a8b2b258add.jpg?1",
             "name": "Gateway Sneak",
             "text": "Whenever a Gate enters the battlefield under your control, Gateway Sneak can't be blocked this turn.\nWhenever Gateway Sneak deals combat damage to a player, draw a card.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "4e86ea22-e47c-55bc-8108-b6e34126a9d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21982dc7-4f79-4251-8382-95cd1f627e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21982dc7-4f79-4251-8382-95cd1f627e0f.jpg?1",
             "name": "Humongulus",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1387,7 +1387,7 @@
         },
         {
             "id": "08a26304-d0cd-58fb-a001-23f7963e09b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782760d7-59cc-4d40-a885-6a7980094fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782760d7-59cc-4d40-a885-6a7980094fee.jpg?1",
             "name": "Mass Manipulation",
             "text": "Gain control of X target creatures and/or planeswalkers.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "675d9fac-40b4-515e-8323-53b64ead6402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bed7c69-1302-4c1a-b410-b4e6c4ef4c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bed7c69-1302-4c1a-b410-b4e6c4ef4c0c.jpg?1",
             "name": "Mesmerizing Benthid",
             "text": "When Mesmerizing Benthid enters the battlefield, create two 0/2 blue Illusion creature tokens with \"Whenever this creature blocks a creature, that creature doesn't untap during its controller's next untap step.\"\nMesmerizing Benthid has hexproof as long as you control an Illusion.",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "b58ff632-8260-542a-b66b-61b0fbbccddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93f0c57-eb80-4dde-bdb0-326970491621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93f0c57-eb80-4dde-bdb0-326970491621.jpg?1",
             "name": "Persistent Petitioners",
             "text": "{1}, {T}: Target player puts the top card of their library into their graveyard.\nTap four untapped Advisors you control: Target player puts the top twelve cards of their library into their graveyard.\nA deck can have any number of cards named Persistent Petitioners.",
             "colours": [
@@ -1488,7 +1488,7 @@
         },
         {
             "id": "5804d99c-b7d0-5389-8794-5d50038ab4bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724fd1ea-05ad-497c-9989-825ada48e684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724fd1ea-05ad-497c-9989-825ada48e684.jpg?1",
             "name": "Precognitive Perception",
             "text": "Draw three cards.\nAddendum \u2014 If you cast this spell during your main phase, instead scry 3, then draw three cards.",
             "colours": [
@@ -1520,7 +1520,7 @@
         },
         {
             "id": "6477f2b3-0b86-515e-b9cc-d13cca19fdf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ee2c64-68f1-434b-8092-ae80d6575666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11ee2c64-68f1-434b-8092-ae80d6575666.jpg?1",
             "name": "Prying Eyes",
             "text": "Draw four cards, then discard two cards.",
             "colours": [
@@ -1552,7 +1552,7 @@
         },
         {
             "id": "4d22da4b-79b2-5d5f-b250-39e12273375d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280f2a85-1900-460b-a768-164fc2dea636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280f2a85-1900-460b-a768-164fc2dea636.jpg?1",
             "name": "Pteramander",
             "text": "Flying\n{7}{U}: Adapt 4. This ability costs {1} less to activate for each instant and sorcery card in your graveyard. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)",
             "colours": [
@@ -1587,7 +1587,7 @@
         },
         {
             "id": "9261f315-9202-589f-9d33-8ccae165b4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ba01b-de96-4f8f-9405-ff3ad288afac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0ba01b-de96-4f8f-9405-ff3ad288afac.jpg?1",
             "name": "Quench",
             "text": "Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -1619,7 +1619,7 @@
         },
         {
             "id": "5bee2743-65fc-5364-9869-314cbb7e1e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg?1",
             "name": "Sage's Row Savant",
             "text": "When Sage's Row Savant enters the battlefield, scry 2.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "d68676bf-52ce-52e5-b5c4-d3e4cfbb313d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8dc5c8-4eb7-4e41-8431-b41251f7814e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da8dc5c8-4eb7-4e41-8431-b41251f7814e.jpg?1",
             "name": "Senate Courier",
             "text": "Flying\n{1}{W}: Senate Courier gains vigilance until end of turn.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "2b33686d-8d6c-5282-8950-9356dd1e763c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e3092d-2422-438c-b5dd-bf8eca33a76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e3092d-2422-438c-b5dd-bf8eca33a76e.jpg?1",
             "name": "Shimmer of Possibility",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "39cb70b4-33cd-56cc-bdc1-7fa63329662f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4a517c-515b-4adc-8ea6-fb86820f22ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4a517c-515b-4adc-8ea6-fb86820f22ed.jpg?1",
             "name": "Skatewing Spy",
             "text": "{5}{U}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nEach creature you control with a +1/+1 counter on it has flying.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "00aa8ab6-2c28-5cfd-8af6-d6a30f9ee8ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328f03-7dae-445b-8e71-99dd88f26a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328f03-7dae-445b-8e71-99dd88f26a9e.jpg?1",
             "name": "Skitter Eel",
             "text": "{2}{U}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)",
             "colours": [
@@ -1792,7 +1792,7 @@
         },
         {
             "id": "aa58db2f-a869-5cf0-89bb-37ed029d5e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6263410-20c5-43b4-8183-3c02c10d07fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6263410-20c5-43b4-8183-3c02c10d07fb.jpg?1",
             "name": "Slimebind",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -4/-0.",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "ad67e5ce-06a6-5f12-9a57-e84abfdb1110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2386fd-edc0-4731-8f4e-7a7c45548bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2386fd-edc0-4731-8f4e-7a7c45548bf3.jpg?1",
             "name": "Sphinx of Foresight",
             "text": "You may reveal this card from your opening hand. If you do, scry 3 at the beginning of your first upkeep.\nFlying\nAt the beginning of your upkeep, scry 1.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "4e788d84-1799-53b1-b2d7-7bb9d104dff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb3d2f-4ee4-46e2-98aa-4aa388bd5375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb3d2f-4ee4-46e2-98aa-4aa388bd5375.jpg?1",
             "name": "Swirling Torrent",
             "text": "Choose one or both \u2014\n\u2022 Put target creature on top of its owner's library.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -1892,7 +1892,7 @@
         },
         {
             "id": "d59efcc4-1a29-56b7-92a9-d1d3b42f9519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b569b-6341-418b-99b5-f79dfb3fe8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948b569b-6341-418b-99b5-f79dfb3fe8dd.jpg?1",
             "name": "Thought Collapse",
             "text": "Counter target spell. Its controller puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -1924,7 +1924,7 @@
         },
         {
             "id": "8d710981-34d1-5305-9d66-a0d7ddc1c3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d866d26-b630-46d3-bcc2-b810c844cc89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d866d26-b630-46d3-bcc2-b810c844cc89.jpg?1",
             "name": "Verity Circle",
             "text": "Whenever a creature an opponent controls becomes tapped, if it isn't being declared as an attacker, you may draw a card.\n{4}{U}: Tap target creature without flying.",
             "colours": [
@@ -1956,7 +1956,7 @@
         },
         {
             "id": "0569f9d3-c22a-550d-9523-9b594a0b60df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a0a627-ea7a-48bb-bf30-60b2677dd8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a0a627-ea7a-48bb-bf30-60b2677dd8ae.jpg?1",
             "name": "Wall of Lost Thoughts",
             "text": "Defender\nWhen Wall of Lost Thoughts enters the battlefield, target player puts the top four cards of their library into their graveyard.",
             "colours": [
@@ -1990,7 +1990,7 @@
         },
         {
             "id": "7cb9cd80-3ebe-5fb7-b2c7-3e319b5ac4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120aa3b3-d358-4df3-be39-9b7ce926673a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120aa3b3-d358-4df3-be39-9b7ce926673a.jpg?1",
             "name": "Windstorm Drake",
             "text": "Flying\nOther creatures you control with flying get +1/+0.",
             "colours": [
@@ -2024,7 +2024,7 @@
         },
         {
             "id": "266da262-9891-5741-8817-efccb42d6a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea166114-2f9b-4ca6-b573-1f49f7485580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea166114-2f9b-4ca6-b573-1f49f7485580.jpg?1",
             "name": "Awaken the Erstwhile",
             "text": "Each player discards all the cards in their hand, then creates that many 2/2 black Zombie creature tokens.",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "43a662a7-d2a9-5416-abb5-68b7c5fd527b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635c433-0398-442a-856e-1869f6bf2cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635c433-0398-442a-856e-1869f6bf2cfd.jpg?1",
             "name": "Bankrupt in Blood",
             "text": "As an additional cost to cast this spell, sacrifice two creatures.\nDraw three cards.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "183065ff-7e3a-5598-acbb-31170983a839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099bc474-e656-4167-b105-3a3a36c0b23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/099bc474-e656-4167-b105-3a3a36c0b23e.jpg?1",
             "name": "Blade Juggler",
             "text": "Spectacle {2}{B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nWhen Blade Juggler enters the battlefield, it deals 1 damage to you and you draw a card.",
             "colours": [
@@ -2123,7 +2123,7 @@
         },
         {
             "id": "e6919189-513a-58a8-ab9d-cd382456f94c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f738545d-5483-45ec-bb31-d62b0fae9ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f738545d-5483-45ec-bb31-d62b0fae9ea7.jpg?1",
             "name": "Bladebrand",
             "text": "Target creature gains deathtouch until end of turn.\nDraw a card.",
             "colours": [
@@ -2155,7 +2155,7 @@
         },
         {
             "id": "60ca4fc3-0a43-578c-800d-a1c46c1de0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909489a9-2678-4b6f-9d5e-2c04bb4cbd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909489a9-2678-4b6f-9d5e-2c04bb4cbd66.jpg?1",
             "name": "Bloodmist Infiltrator",
             "text": "Whenever Bloodmist Infiltrator attacks, you may sacrifice another creature. If you do, Bloodmist Infiltrator can't be blocked this turn.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "3ac029bd-1e61-5a95-aed3-5f0b3cba3f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958caf1d-b159-4c27-8248-00c345f880be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958caf1d-b159-4c27-8248-00c345f880be.jpg?1",
             "name": "Carrion Imp",
             "text": "Flying\nWhen Carrion Imp enters the battlefield, you may exile target creature card from a graveyard. If you do, you gain 2 life.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "5bf11981-a6f8-5347-afb7-d5ed8a403932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c53f0-7922-4e14-802d-d7a22f8fed85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c53f0-7922-4e14-802d-d7a22f8fed85.jpg?1",
             "name": "Catacomb Crocodile",
             "text": "",
             "colours": [
@@ -2257,7 +2257,7 @@
         },
         {
             "id": "ce00e9ad-ec71-58cb-9952-ab0315af833a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65975-6ff5-4863-b7b7-d7dbea213b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac65975-6ff5-4863-b7b7-d7dbea213b50.jpg?1",
             "name": "Clear the Stage",
             "text": "Target creature gets -3/-3 until end of turn. If you control a creature with power 4 or greater, you may return up to one target creature card from your graveyard to your hand.",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "c46c1906-96d7-5213-a20d-c05658e7f3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09991fad-4282-4a17-bfb1-03eaa13502df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09991fad-4282-4a17-bfb1-03eaa13502df.jpg?1",
             "name": "Consign to the Pit",
             "text": "Destroy target creature. Consign to the Pit deals 2 damage to that creature's controller.",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "d02ddc80-40be-588a-ab0e-4fb95f55445d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715a14a3-046e-45ca-b943-dd630e5202b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715a14a3-046e-45ca-b943-dd630e5202b7.jpg?1",
             "name": "Cry of the Carnarium",
             "text": "All creatures get -2/-2 until end of turn. Exile all creature cards in all graveyards that were put there from the battlefield this turn. If a creature would die this turn, exile it instead.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "468648b9-7e18-578d-93aa-bb641abf9af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2c21a-419d-4896-82e3-1b5cb32b158e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b2c21a-419d-4896-82e3-1b5cb32b158e.jpg?1",
             "name": "Dead Revels",
             "text": "Spectacle {1}{B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nReturn up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "fce95457-eadb-5d2c-bc07-b98c045b13d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03b99-d62e-428a-9e0d-097f1227a4da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd03b99-d62e-428a-9e0d-097f1227a4da.jpg?1",
             "name": "Debtors' Transport",
             "text": "Afterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "9d694d26-1cd5-533e-97d4-d8b07b99d798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8710c-9c5e-4d11-b45f-0728c54bd631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f8710c-9c5e-4d11-b45f-0728c54bd631.jpg?1",
             "name": "Drill Bit",
             "text": "Spectacle {B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nTarget player reveals their hand. You choose a nonland card from it. That player discards that card.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "15e0f9ed-d09f-5286-9950-2ae06f6e7122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c02aec-4a89-4ccc-8525-6f979c10d799.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7c02aec-4a89-4ccc-8525-6f979c10d799.jpg?1",
             "name": "Font of Agonies",
             "text": "Whenever you pay life, put that many blood counters on Font of Agonies.\n{1}{B}, Remove four blood counters from Font of Agonies: Destroy target creature.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "7b430b0a-2a5e-58ba-b654-63d36676818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b698c5e1-3816-4f35-8e39-65dc68f5c64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b698c5e1-3816-4f35-8e39-65dc68f5c64f.jpg?1",
             "name": "Grotesque Demise",
             "text": "Exile target creature with power 3 or less.",
             "colours": [
@@ -2515,7 +2515,7 @@
         },
         {
             "id": "21c1a3b4-9561-547d-8b1f-49b81985e5b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1c710b-bd67-4174-ab02-6ae98a7575ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a1c710b-bd67-4174-ab02-6ae98a7575ac.jpg?1",
             "name": "Gutterbones",
             "text": "Gutterbones enters the battlefield tapped.\n{1}{B}: Return Gutterbones from your graveyard to your hand. Activate this ability only during your turn and only if an opponent lost life this turn.",
             "colours": [
@@ -2550,7 +2550,7 @@
         },
         {
             "id": "9274ff14-981b-567b-8cb9-aab693b36420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d44b342-f611-4836-a9d5-83b00a24318f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d44b342-f611-4836-a9d5-83b00a24318f.jpg?1",
             "name": "Ill-Gotten Inheritance",
             "text": "At the beginning of your upkeep, Ill-Gotten Inheritance deals 1 damage to each opponent and you gain 1 life.\n{5}{B}, Sacrifice Ill-Gotten Inheritance: It deals 4 damage to target opponent and you gain 4 life.",
             "colours": [
@@ -2582,7 +2582,7 @@
         },
         {
             "id": "21d9c49e-8332-5cb8-a6cf-d82d4e40c096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb3d78-1a60-4e9b-b387-afeb58677536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb3d78-1a60-4e9b-b387-afeb58677536.jpg?1",
             "name": "Noxious Groodion",
             "text": "Deathtouch",
             "colours": [
@@ -2616,7 +2616,7 @@
         },
         {
             "id": "26ca8bf8-5caf-5807-bd55-972a3d6145a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72b49e-be14-485b-a467-31cbac9aa1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a72b49e-be14-485b-a467-31cbac9aa1c5.jpg?1",
             "name": "Orzhov Enforcer",
             "text": "Deathtouch\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "a9dcb67c-497b-5d34-8e7c-f82906233577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b89f68-72ba-493d-95c4-eb37751fbd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b89f68-72ba-493d-95c4-eb37751fbd3d.jpg?1",
             "name": "Orzhov Racketeers",
             "text": "Whenever Orzhov Racketeers deals combat damage to a player, that player discards a card.\nAfterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "1712dfad-c570-53ff-b806-f5d8dba401df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9a0387-5116-484b-bb2b-064bd42e7fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9a0387-5116-484b-bb2b-064bd42e7fff.jpg?1",
             "name": "Pestilent Spirit",
             "text": "Menace, deathtouch\nInstant and sorcery spells you control have deathtouch. (Any amount of damage they deal to a creature is enough to destroy it.)",
             "colours": [
@@ -2720,7 +2720,7 @@
         },
         {
             "id": "1dcaa9bf-915b-5da5-8f8a-d7845690d51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d354f-f2ad-4b47-8666-0ed64543b676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962d354f-f2ad-4b47-8666-0ed64543b676.jpg?1",
             "name": "Plague Wight",
             "text": "Whenever Plague Wight becomes blocked, each creature blocking it gets -1/-1 until end of turn.",
             "colours": [
@@ -2754,7 +2754,7 @@
         },
         {
             "id": "5f97ff82-01c0-574d-a397-9c48981a16ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3378fe8-3355-48aa-90d4-9cb739200160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3378fe8-3355-48aa-90d4-9cb739200160.jpg?1",
             "name": "Priest of Forgotten Gods",
             "text": "{T}, Sacrifice two other creatures: Any number of target players each lose 2 life and sacrifice a creature. You add {B}{B} and draw a card.",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "01cae04a-5a52-50c7-a536-fef6cf204761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2822aff3-9985-424b-9f19-b49e987c25e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2822aff3-9985-424b-9f19-b49e987c25e4.jpg?1",
             "name": "Rakdos Trumpeter",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{3}{R}: Rakdos Trumpeter gets +2/+0 until end of turn.",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "060fbad4-7652-57ed-979c-71a1d4f0c2d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be01b8d-e0ef-44d1-ac97-39bb5a0e76be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be01b8d-e0ef-44d1-ac97-39bb5a0e76be.jpg?1",
             "name": "Spawn of Mayhem",
             "text": "Spectacle {1}{B}{B} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nFlying, trample\nAt the beginning of your upkeep, Spawn of Mayhem deals 1 damage to each player. Then if you have 10 or less life, put a +1/+1 counter on Spawn of Mayhem.",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "556c0ae7-a569-5400-bda7-a9c2dc31e280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce548d-764a-4397-bae3-d348dca78421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ce548d-764a-4397-bae3-d348dca78421.jpg?1",
             "name": "Spire Mangler",
             "text": "Flash\nFlying\nWhen Spire Mangler enters the battlefield, target creature with flying you control gets +2/+0 until end of turn.",
             "colours": [
@@ -2893,7 +2893,7 @@
         },
         {
             "id": "e5f63891-1a27-58e7-8345-58b431817202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a920c2e6-4a1f-487c-ad3f-b772443f0633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a920c2e6-4a1f-487c-ad3f-b772443f0633.jpg?1",
             "name": "Thirsting Shade",
             "text": "Lifelink\n{2}{B}: Thirsting Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -2927,7 +2927,7 @@
         },
         {
             "id": "69c39a38-eaad-5e44-94b0-05b1cece3bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7e297-4602-44f8-b919-07015813fd7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7e297-4602-44f8-b919-07015813fd7e.jpg?1",
             "name": "Undercity Scavenger",
             "text": "When Undercity Scavenger enters the battlefield, you may sacrifice another creature. If you do, put two +1/+1 counters on Undercity Scavenger, then scry 2.",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "3eca8050-3e3f-5832-981a-3ce8321acab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb9805-eca0-476c-9480-0c958acdb50f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcb9805-eca0-476c-9480-0c958acdb50f.jpg?1",
             "name": "Undercity's Embrace",
             "text": "Target opponent sacrifices a creature. If you control a creature with power 4 or greater, you gain 4 life.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "3bf56d70-7be2-5f10-ad7e-f749224c126b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0bfb47-c753-42fa-969b-7b10b87b0462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c0bfb47-c753-42fa-969b-7b10b87b0462.jpg?1",
             "name": "Vindictive Vampire",
             "text": "Whenever another creature you control dies, Vindictive Vampire deals 1 damage to each opponent and you gain 1 life.",
             "colours": [
@@ -3028,7 +3028,7 @@
         },
         {
             "id": "87a47456-1237-54ea-a8d6-53d708d63e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2328c4-7344-48bf-b515-977499bcfd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2328c4-7344-48bf-b515-977499bcfd1c.jpg?1",
             "name": "Act of Treason",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "4e2ecd9f-45ad-50c2-88d3-de4debdb43a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58c77f-7c15-44f4-8011-6046482a2d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a58c77f-7c15-44f4-8011-6046482a2d08.jpg?1",
             "name": "Amplifire",
             "text": "At the beginning of your upkeep, reveal cards from the top of your library until you reveal a creature card. Until your next turn, Amplifire's base power becomes twice that card's power and its base toughness becomes twice that card's toughness. Put the revealed cards on the bottom of your library in a random order.",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "3834e130-a5cf-580c-bb9a-97021ca47a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8574ffd-3e72-41de-90bf-69363189f047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8574ffd-3e72-41de-90bf-69363189f047.jpg?1",
             "name": "Burn Bright",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -3126,7 +3126,7 @@
         },
         {
             "id": "fb6f99b5-c2ea-5cdf-9458-5fea270ed6b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5674753-17e4-4e35-a12c-13e1e077ec70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5674753-17e4-4e35-a12c-13e1e077ec70.jpg?1",
             "name": "Burning-Tree Vandal",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhenever Burning-Tree Vandal attacks, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "98cfa0cb-81bb-59a2-98d3-5044de0f2632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a81e889-490b-4aeb-8e84-ea9a390bb8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a81e889-490b-4aeb-8e84-ea9a390bb8fe.jpg?1",
             "name": "Cavalcade of Calamity",
             "text": "Whenever a creature you control with power 1 or less attacks, Cavalcade of Calamity deals 1 damage to the player or planeswalker that creature is attacking.",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "4cedd9e4-169f-5456-abbe-7ddb327ff421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f073d7-f60a-44c1-aec9-cf42bbdb3153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3f073d7-f60a-44c1-aec9-cf42bbdb3153.jpg?1",
             "name": "Clamor Shaman",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhenever Clamor Shaman attacks, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "534027d7-35f9-5e02-a990-4ed49749c047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a7ac34-ec4a-4571-abb1-bff1fb67c78f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a7ac34-ec4a-4571-abb1-bff1fb67c78f.jpg?1",
             "name": "Dagger Caster",
             "text": "When Dagger Caster enters the battlefield, it deals 1 damage to each opponent and 1 damage to each creature your opponents control.",
             "colours": [
@@ -3263,7 +3263,7 @@
         },
         {
             "id": "f207cf11-e470-51ea-9712-a7c11c3c1ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43df9f41-944e-4cf3-ac80-524eadac221d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43df9f41-944e-4cf3-ac80-524eadac221d.jpg?1",
             "name": "Deface",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature with defender.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "2755ca61-b8bd-50cf-ae64-04445c823543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c63877b-cdab-4ce4-a1c0-c088eb62a57a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c63877b-cdab-4ce4-a1c0-c088eb62a57a.jpg?1",
             "name": "Electrodominance",
             "text": "Electrodominance deals X damage to any target. You may cast a card with converted mana cost X or less from your hand without paying its mana cost.",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "f4e7a65c-903b-51c2-9582-936617fe05d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c969aa0-b0e5-42cd-abba-0a3c7266142c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c969aa0-b0e5-42cd-abba-0a3c7266142c.jpg?1",
             "name": "Feral Maaka",
             "text": "",
             "colours": [
@@ -3361,7 +3361,7 @@
         },
         {
             "id": "bb4346fb-c395-51fa-8158-9fede4168161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16957271-12bb-4031-b476-f7678b753ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16957271-12bb-4031-b476-f7678b753ae3.jpg?1",
             "name": "Flames of the Raze-Boar",
             "text": "Flames of the Raze-Boar deals 4 damage to target creature an opponent controls. Then Flames of the Raze-Boar deals 2 damage to each other creature that player controls if you control a creature with power 4 or greater.",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "df7c7bd6-a42a-5cec-9226-8f845cd2cad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b574b44-01e1-4197-99bd-57e54aebc5ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b574b44-01e1-4197-99bd-57e54aebc5ff.jpg?1",
             "name": "Gates Ablaze",
             "text": "Gates Ablaze deals X damage to each creature, where X is the number of Gates you control.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "d4454ca5-bca7-5c6c-8c04-3c1f04bc51c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3969c-1979-4eee-828a-4a7189121eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da3969c-1979-4eee-828a-4a7189121eba.jpg?1",
             "name": "Ghor-Clan Wrecker",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3460,7 +3460,7 @@
         },
         {
             "id": "35bcb407-36c9-5f2f-8f90-fbd969c2b691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147bef05-4497-44d5-9dd6-fb5dc08e78f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/147bef05-4497-44d5-9dd6-fb5dc08e78f7.jpg?1",
             "name": "Goblin Gathering",
             "text": "Create a number of 1/1 red Goblin creature tokens equal to two plus the number of cards named Goblin Gathering in your graveyard.",
             "colours": [
@@ -3492,7 +3492,7 @@
         },
         {
             "id": "7862b280-31b5-5b64-bfe9-ff953d9345c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4942068c-ffde-4a6b-849e-8acf05e1d2e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4942068c-ffde-4a6b-849e-8acf05e1d2e1.jpg?1",
             "name": "Gravel-Hide Goblin",
             "text": "{3}{G}: Gravel-Hide Goblin gets +2/+2 until end of turn.",
             "colours": [
@@ -3528,7 +3528,7 @@
         },
         {
             "id": "817890c6-61cb-59df-9f99-98033755d97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e668e5-ef50-43eb-852e-b111370459c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45e668e5-ef50-43eb-852e-b111370459c8.jpg?1",
             "name": "Immolation Shaman",
             "text": "Whenever an opponent activates an ability of an artifact, creature, or land that isn't a mana ability, Immolation Shaman deals 1 damage to that player.\n{3}{R}{R}: Immolation Shaman gets +3/+3 and gains menace until end of turn.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "38aa0617-9a4e-5cab-aee8-4c2b2275db87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9287b848-2aeb-4c70-ac4a-acafb871b7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9287b848-2aeb-4c70-ac4a-acafb871b7a4.jpg?1",
             "name": "Light Up the Stage",
             "text": "Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nExile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "6ebafe7f-35f2-5f4b-b0f3-bc2054504241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a27943-f08c-4cbd-affb-8e59411b3d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50a27943-f08c-4cbd-affb-8e59411b3d4f.jpg?1",
             "name": "Mirror March",
             "text": "Whenever a nontoken creature enters the battlefield under your control, flip a coin until you lose a flip. For each flip you won, create a token that's a copy of that creature. Those tokens gain haste. Exile them at the beginning of the next end step.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "b1292f71-65ac-5832-a390-65dcb9b252c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40396da-18e2-42ca-a78c-4838a38f68b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40396da-18e2-42ca-a78c-4838a38f68b8.jpg?1",
             "name": "Rix Maadi Reveler",
             "text": "Spectacle {2}{B}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nWhen Rix Maadi Reveler enters the battlefield, discard a card, then draw a card. If Rix Maadi Reveler's spectacle cost was paid, instead discard your hand, then draw three cards.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "394b853a-49fd-5806-905f-bbf535e9e40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ace095a-3ea9-4121-8ffb-5b3612b96985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ace095a-3ea9-4121-8ffb-5b3612b96985.jpg?1",
             "name": "Rubble Reading",
             "text": "Destroy target land. Scry 2.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "8edcf759-c1b7-552c-b465-10411447b00a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faac11b-4ece-4537-aa55-c2d0afa41786.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2faac11b-4ece-4537-aa55-c2d0afa41786.jpg?1",
             "name": "Rubblebelt Recluse",
             "text": "Rubblebelt Recluse attacks each combat if able.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "4c03605e-e6f2-5cd5-838e-54188103037c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fe7057-de70-456d-8f33-f64652447bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fe7057-de70-456d-8f33-f64652447bdd.jpg?1",
             "name": "Rumbling Ruin",
             "text": "When Rumbling Ruin enters the battlefield, count the number of +1/+1 counters on creatures you control. Creatures your opponents control with power less than or equal to that number can't block this turn.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "fc3ce67a-23ed-5120-8f5a-f330e66f19f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a14834f-78ae-4ca5-9ce0-5b928ad3d76c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a14834f-78ae-4ca5-9ce0-5b928ad3d76c.jpg?1",
             "name": "Scorchmark",
             "text": "Scorchmark deals 2 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "5631a047-f3ec-57ef-a483-ef01ab0d4ea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be941a2e-4eb0-45b3-9da0-834053907a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be941a2e-4eb0-45b3-9da0-834053907a65.jpg?1",
             "name": "Skarrgan Hellkite",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nFlying\n{3}{R}: Skarrgan Hellkite deals 2 damage divided as you choose among one or two targets. Activate this ability only if Skarrgan Hellkite has a +1/+1 counter on it.",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "cdd3640a-0501-5d20-9f7d-b40529144f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97295660-6bea-46ae-9a3b-0fc6abba407f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97295660-6bea-46ae-9a3b-0fc6abba407f.jpg?1",
             "name": "Skewer the Critics",
             "text": "Spectacle {R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nSkewer the Critics deals 3 damage to any target.",
             "colours": [
@@ -3862,7 +3862,7 @@
         },
         {
             "id": "1746683d-8474-555d-9379-c24ce0456001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24b2b6-b994-455f-b8e6-aa73e1be81b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f24b2b6-b994-455f-b8e6-aa73e1be81b4.jpg?1",
             "name": "Smelt-Ward Ignus",
             "text": "{2}{R}, Sacrifice Smelt-Ward Ignus: Gain control of target creature with power 3 or less until end of turn. Untap that creature. It gains haste until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "dd07dfc2-c270-5ccd-95de-0f0b66f9b2c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbee1daa-b4ba-49ee-bed1-e70fa09942a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbee1daa-b4ba-49ee-bed1-e70fa09942a2.jpg?1",
             "name": "Spear Spewer",
             "text": "Defender\n{T}: Spear Spewer deals 1 damage to each player.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "28c697fc-f9bb-5c0d-a876-e21a474e5454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f70b8a-62ec-4ae6-97d2-3c6ae86a3602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f70b8a-62ec-4ae6-97d2-3c6ae86a3602.jpg?1",
             "name": "Spikewheel Acrobat",
             "text": "Spectacle {2}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "d6f90bec-aa08-53bb-b867-bcd005a05852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de24cba-545a-438b-9516-1c19a50ca78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de24cba-545a-438b-9516-1c19a50ca78c.jpg?1",
             "name": "Storm Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -3998,7 +3998,7 @@
         },
         {
             "id": "4dbf6293-d035-5a14-9fb8-f1f9de5b1165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3815ab6-87cd-4310-8068-ec721ee10a24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3815ab6-87cd-4310-8068-ec721ee10a24.jpg?1",
             "name": "Tin Street Dodger",
             "text": "Haste\n{R}: Tin Street Dodger can't be blocked this turn except by creatures with defender.",
             "colours": [
@@ -4033,7 +4033,7 @@
         },
         {
             "id": "03b0eb04-7ebd-5583-b034-4ab85e3166fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f420b35-1f73-41c8-a15f-1aee4af0999c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f420b35-1f73-41c8-a15f-1aee4af0999c.jpg?1",
             "name": "Axebane Beast",
             "text": "",
             "colours": [
@@ -4067,7 +4067,7 @@
         },
         {
             "id": "a28e7e23-363d-58f5-a823-71115bad6b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11029a-b24d-4248-834f-b852b56857f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f11029a-b24d-4248-834f-b852b56857f6.jpg?1",
             "name": "Biogenic Ooze",
             "text": "When Biogenic Ooze enters the battlefield, create a 2/2 green Ooze creature token.\nAt the beginning of your end step, put a +1/+1 counter on each Ooze you control.\n{1}{G}{G}{G}: Create a 2/2 green Ooze creature token.",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "10fcb2c8-5daf-5e60-8184-830d22ee5e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd73fb2-453f-40b9-8beb-dfa99e6a706e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd73fb2-453f-40b9-8beb-dfa99e6a706e.jpg?1",
             "name": "Biogenic Upgrade",
             "text": "Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "203ccb31-5060-54ff-8d5b-35ca006b1fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50d79fe-6d37-42f3-b7b0-0c3018282fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50d79fe-6d37-42f3-b7b0-0c3018282fa2.jpg?1",
             "name": "End-Raze Forerunners",
             "text": "Vigilance, trample, haste\nWhen End-Raze Forerunners enters the battlefield, other creatures you control get +2/+2 and gain vigilance and trample until end of turn.",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "f9d4e9b2-1968-51fd-a30c-7b74cbf82751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44fc50f-8958-422f-933f-fd043d642c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c44fc50f-8958-422f-933f-fd043d642c97.jpg?1",
             "name": "Enraged Ceratok",
             "text": "Enraged Ceratok can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "5ac609a4-f4b1-5600-bcc1-e62eeca7db47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef592d1-e5e1-4252-8741-402c32d65dfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef592d1-e5e1-4252-8741-402c32d65dfd.jpg?1",
             "name": "Gatebreaker Ram",
             "text": "Gatebreaker Ram gets +1/+1 for each Gate you control.\nAs long as you control two or more Gates, Gatebreaker Ram has vigilance and trample.",
             "colours": [
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "f636dd63-e033-5086-990e-93569501243d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb363b1d-0b80-453c-98ca-e9f873bb7add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb363b1d-0b80-453c-98ca-e9f873bb7add.jpg?1",
             "name": "Gift of Strength",
             "text": "Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "68b1f7de-507f-5a1f-aa0c-b3f6613bbd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f97cdf4-231d-4bd0-af5e-bcb64ce1556c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f97cdf4-231d-4bd0-af5e-bcb64ce1556c.jpg?1",
             "name": "Growth-Chamber Guardian",
             "text": "{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nWhenever one or more +1/+1 counters are put on Growth-Chamber Guardian, you may search your library for a card named Growth-Chamber Guardian, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4303,7 +4303,7 @@
         },
         {
             "id": "5dd6be38-ceab-5a84-ba6f-b78e87d59fc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0aaded-515f-4ac9-a72f-6948b4d4df51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b0aaded-515f-4ac9-a72f-6948b4d4df51.jpg?1",
             "name": "Gruul Beastmaster",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhenever Gruul Beastmaster attacks, another target creature you control gets +X/+0 until end of turn, where X is Gruul Beastmaster's power.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "b2e31d4d-a7db-58ec-99f7-5e25fa1fea63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad6ce0-ddf0-458d-bdae-3d7805fdc775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccad6ce0-ddf0-458d-bdae-3d7805fdc775.jpg?1",
             "name": "Guardian Project",
             "text": "Whenever a nontoken creature enters the battlefield under your control, if it doesn't have the same name as another creature you control or a creature card in your graveyard, draw a card.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "8dbaa0f7-789b-547d-94b0-b6747b46068a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bbe5d-d0f3-4be3-a3a6-072d5d3d614c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bbe5d-d0f3-4be3-a3a6-072d5d3d614c.jpg?1",
             "name": "Incubation Druid",
             "text": "{T}: Add one mana of any type that a land you control could produce. If Incubation Druid has a +1/+1 counter on it, add three mana of that type instead.\n{3}{G}{G}: Adapt 3. (If this creature has no +1/+1 counters on it, put three +1/+1 counters on it.)",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "022fda96-964b-5b97-b311-3b0b0bcd0254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a684871-ff6e-4474-82da-30757c324c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a684871-ff6e-4474-82da-30757c324c73.jpg?1",
             "name": "Mammoth Spider",
             "text": "Reach",
             "colours": [
@@ -4439,7 +4439,7 @@
         },
         {
             "id": "b6842dd6-0b53-5c4a-bfc6-ee33e1219729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff326c57-accb-4b75-9bc9-b5ef1a85f38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff326c57-accb-4b75-9bc9-b5ef1a85f38d.jpg?1",
             "name": "Open the Gates",
             "text": "Search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "b0c7809d-bbcc-547f-bb78-2c979b773536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebab7d-d03d-4473-aa9b-485aebb66433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ebab7d-d03d-4473-aa9b-485aebb66433.jpg?1",
             "name": "Rampage of the Clans",
             "text": "Destroy all artifacts and enchantments. For each permanent destroyed this way, its controller creates a 3/3 green Centaur creature token.",
             "colours": [
@@ -4503,7 +4503,7 @@
         },
         {
             "id": "d0e63b33-28bb-549a-90e0-98c37bec313b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b820-0f06-41f6-804f-5c98f60c1529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c1b820-0f06-41f6-804f-5c98f60c1529.jpg?1",
             "name": "Rampaging Rendhorn",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "31c9eded-82a4-5199-8d50-f2e9496b295d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a362c1-af92-4094-a7c2-f09952767606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a362c1-af92-4094-a7c2-f09952767606.jpg?1",
             "name": "Regenesis",
             "text": "Return up to two target permanent cards from your graveyard to your hand.",
             "colours": [
@@ -4569,7 +4569,7 @@
         },
         {
             "id": "7710120c-393e-5e4e-86d6-ff81e1835dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f38b1a2-3f85-4dcd-b90d-bb049651b8b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f38b1a2-3f85-4dcd-b90d-bb049651b8b7.jpg?1",
             "name": "Root Snare",
             "text": "Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -4601,7 +4601,7 @@
         },
         {
             "id": "7b08f6dc-0260-58c7-8c3c-a634c7a937ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3104cad-e684-4bd7-b26b-5aa862f7a2b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3104cad-e684-4bd7-b26b-5aa862f7a2b3.jpg?1",
             "name": "Sagittars' Volley",
             "text": "Destroy target creature with flying. Sagittars' Volley deals 1 damage to each creature with flying your opponents control.",
             "colours": [
@@ -4633,7 +4633,7 @@
         },
         {
             "id": "2230ced2-cee6-5583-a2bd-ed7e936b9d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3358cb-714c-49bf-b7e9-a69d02d7799e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3358cb-714c-49bf-b7e9-a69d02d7799e.jpg?1",
             "name": "Saruli Caretaker",
             "text": "Defender\n{T}, Tap an untapped creature you control: Add one mana of any color.",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "5f340c1c-450f-5b0d-9ea2-9699194a0e84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7ecad5-8bb5-416f-b8ef-a04aba4dc4b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7ecad5-8bb5-416f-b8ef-a04aba4dc4b5.jpg?1",
             "name": "Sauroform Hybrid",
             "text": "{4}{G}{G}: Adapt 4. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "d8d27350-5129-5c9d-afbf-49be71c3c1a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6cd6a5-da6c-483c-a9f7-49e666ac0b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6cd6a5-da6c-483c-a9f7-49e666ac0b6c.jpg?1",
             "name": "Silhana Wayfinder",
             "text": "When Silhana Wayfinder enters the battlefield, look at the top four cards of your library. You may reveal a creature or land card from among them and put it on top of your library. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4738,7 +4738,7 @@
         },
         {
             "id": "75122993-1d45-51a1-93d8-dcb486a70c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afafb4-3fc0-4ccf-a942-e4bd2f146d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4afafb4-3fc0-4ccf-a942-e4bd2f146d89.jpg?1",
             "name": "Steeple Creeper",
             "text": "{3}{U}: Steeple Creeper gains flying until end of turn.",
             "colours": [
@@ -4774,7 +4774,7 @@
         },
         {
             "id": "0ab2ecba-d2cf-5084-abfa-8e02a2d0e0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbab274-69dd-44a9-9310-a15779c35cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbab274-69dd-44a9-9310-a15779c35cad.jpg?1",
             "name": "Stony Strength",
             "text": "Put a +1/+1 counter on target creature you control. Untap that creature.",
             "colours": [
@@ -4806,7 +4806,7 @@
         },
         {
             "id": "d35038c6-16dd-5844-bd5b-ef02531b9032",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc288a3-ea56-450a-96fd-c2123121f663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc288a3-ea56-450a-96fd-c2123121f663.jpg?1",
             "name": "Sylvan Brushstrider",
             "text": "When Sylvan Brushstrider enters the battlefield, you gain 2 life.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "6d9dbbf7-a896-5250-b469-8112c90bd369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ddae7-7e7c-46c7-ad7d-9a686c256b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ddae7-7e7c-46c7-ad7d-9a686c256b9d.jpg?1",
             "name": "Territorial Boar",
             "text": "Whenever a creature with power 4 or greater enters the battlefield under your control, Territorial Boar gets +1/+1 and gains vigilance until end of turn.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "66e38fbb-22b4-59b2-a5d6-8b74b4e04024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf9b57a-a759-4488-965a-651070cd2156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf9b57a-a759-4488-965a-651070cd2156.jpg?1",
             "name": "Titanic Brawl",
             "text": "This spell costs {1} less to cast if it targets a creature you control with a +1/+1 counter on it.\nTarget creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "7dfc89b9-2ca0-540c-8fce-d174ebe36fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195e94a4-a698-4c66-9428-5cc8a40d42c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/195e94a4-a698-4c66-9428-5cc8a40d42c6.jpg?1",
             "name": "Tower Defense",
             "text": "Creatures you control get +0/+5 and gain reach until end of turn.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "84f303cb-9a07-5f4e-82cd-fe072018aa63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e51f6-7091-4cf3-86a3-b8c5946f3796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e51f6-7091-4cf3-86a3-b8c5946f3796.jpg?1",
             "name": "Trollbred Guardian",
             "text": "{2}{G}: Adapt 2. (If this creature has no +1/+1 counters on it, put two +1/+1 counters on it.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "221c667a-7e2c-5c29-bfcb-b6371e292b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af08f7-9c6c-464e-b2f7-2b5803f36481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54af08f7-9c6c-464e-b2f7-2b5803f36481.jpg?1",
             "name": "Wilderness Reclamation",
             "text": "At the beginning of your end step, untap all lands you control.",
             "colours": [
@@ -5006,7 +5006,7 @@
         },
         {
             "id": "e1335217-0d38-5625-a903-d0b0b90e2568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e6f7be-4493-4081-ac67-d782ab2b3723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e6f7be-4493-4081-ac67-d782ab2b3723.jpg?1",
             "name": "Wrecking Beast",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nTrample",
             "colours": [
@@ -5040,7 +5040,7 @@
         },
         {
             "id": "7d6637d8-1d04-5977-a925-f4187ac3fd1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8a43c1-42d1-45ef-8a63-4b87775a6e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e8a43c1-42d1-45ef-8a63-4b87775a6e88.jpg?1",
             "name": "Absorb",
             "text": "Counter target spell. You gain 3 life.",
             "colours": [
@@ -5074,7 +5074,7 @@
         },
         {
             "id": "4ab1d468-b666-50cc-b255-359b6d7bc6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671c94c1-df52-4985-ad78-3e1c9c78df18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671c94c1-df52-4985-ad78-3e1c9c78df18.jpg?1",
             "name": "Aeromunculus",
             "text": "Flying\n{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "aef7a3ed-b927-5321-a8ca-5b1492dedee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91ed618-7b0b-4a70-95ad-d9ed46e28692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f91ed618-7b0b-4a70-95ad-d9ed46e28692.jpg?1",
             "name": "Applied Biomancy",
             "text": "Choose one or both \u2014\n\u2022 Target creature gets +1/+1 until end of turn.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "6101883a-fb23-5ea8-9b23-ead08153f112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60befc28-2ab8-4b59-a33f-0328c5d2f995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60befc28-2ab8-4b59-a33f-0328c5d2f995.jpg?1",
             "name": "Azorius Knight-Arbiter",
             "text": "Vigilance\nAzorius Knight-Arbiter can't be blocked.",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "fadd66d8-9fed-5c6d-aa27-8c5cf4ebad19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fddecd-e660-43de-bccc-52f60a089052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fddecd-e660-43de-bccc-52f60a089052.jpg?1",
             "name": "Azorius Skyguard",
             "text": "Flying, first strike\nCreatures your opponents control get -1/-0.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "bbb88fa6-3b6f-547c-9731-ff677e68309f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f4329-db6f-4284-b63e-55f22a0a0f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72f4329-db6f-4284-b63e-55f22a0a0f6e.jpg?1",
             "name": "Basilica Bell-Haunt",
             "text": "When Basilica Bell-Haunt enters the battlefield, each opponent discards a card and you gain 3 life.",
             "colours": [
@@ -5255,7 +5255,7 @@
         },
         {
             "id": "0cdc27a1-3a6d-5bca-a930-b10aa9eb269d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e2b96b-ecf2-4dd9-bc9d-3c46ee8c59e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e2b96b-ecf2-4dd9-bc9d-3c46ee8c59e6.jpg?1",
             "name": "Bedevil",
             "text": "Destroy target artifact, creature, or planeswalker.",
             "colours": [
@@ -5289,7 +5289,7 @@
         },
         {
             "id": "a4d7c303-aecb-5414-9e4a-f4e3b41c62a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38c9891-36d1-4565-9c4a-1cd9dbf8c048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38c9891-36d1-4565-9c4a-1cd9dbf8c048.jpg?1",
             "name": "Biomancer's Familiar",
             "text": "Activated abilities of creatures you control cost {2} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.\n{T}: The next time target creature adapts this turn, it adapts as though it had no +1/+1 counters on it.",
             "colours": [
@@ -5325,7 +5325,7 @@
         },
         {
             "id": "c62abeb8-34ae-56ea-a459-1f53fe7aa5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5080975e-693a-44f5-a718-9ee947dada6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5080975e-693a-44f5-a718-9ee947dada6d.jpg?1",
             "name": "Bolrac-Clan Crusher",
             "text": "{T}, Remove a +1/+1 counter from a creature you control: Bolrac-Clan Crusher deals 2 damage to any target.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "ef0304f9-653b-58bf-a831-cfa94f60b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065f63b2-472e-4148-8294-88ed38a5685f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065f63b2-472e-4148-8294-88ed38a5685f.jpg?1",
             "name": "Captive Audience",
             "text": "Captive Audience enters the battlefield under the control of an opponent of your choice.\nAt the beginning of your upkeep, choose one that hasn't been chosen \u2014\n\u2022 Your life total becomes 4.\n\u2022 Discard your hand.\n\u2022 Each opponent creates five 2/2 black Zombie creature tokens.",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "3b19c0b7-b71a-5738-b573-7b0edf56302f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f970f79-3051-4ba1-badb-697ef321cbb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f970f79-3051-4ba1-badb-697ef321cbb3.jpg?1",
             "name": "Cindervines",
             "text": "Whenever an opponent casts a noncreature spell, Cindervines deals 1 damage to that player.\n{1}, Sacrifice Cindervines: Destroy target artifact or enchantment. Cindervines deals 2 damage to that permanent's controller.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "896cbb9a-ad01-589e-a2a3-ba983ee7c06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a18415-015c-4d3f-8042-b156a673e125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a18415-015c-4d3f-8042-b156a673e125.jpg?1",
             "name": "Clan Guildmage",
             "text": "{1}{R}, {T}: Target creature can't block this turn.\n{2}{G}, {T}: Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land.",
             "colours": [
@@ -5467,7 +5467,7 @@
         },
         {
             "id": "d8eca791-88cb-5e58-807b-561457b52889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e2816-d50b-41a5-b503-faa58dc7c94a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6e2816-d50b-41a5-b503-faa58dc7c94a.jpg?1",
             "name": "Combine Guildmage",
             "text": "{1}{G}, {T}: This turn, each creature you control enters the battlefield with an additional +1/+1 counter on it.\n{1}{U}, {T}: Move a +1/+1 counter from target creature you control onto another target creature you control.",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "fee4cfe3-2c7b-5d4d-9daf-301f78b4293b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0536c2fa-7402-49a1-9016-dcf5633ca9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0536c2fa-7402-49a1-9016-dcf5633ca9ef.jpg?1",
             "name": "Cult Guildmage",
             "text": "{3}{B}, {T}: Target player discards a card. Activate this ability only any time you could cast a sorcery.\n{R}, {T}: Cult Guildmage deals 1 damage to target opponent or planeswalker.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "1c568923-fb51-5ec8-a9cf-b961165b1aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e362055-78a1-48fa-a4ef-6cf7e0b21b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e362055-78a1-48fa-a4ef-6cf7e0b21b14.jpg?1",
             "name": "Deputy of Detention",
             "text": "When Deputy of Detention enters the battlefield, exile target nonland permanent an opponent controls and all other nonland permanents that player controls with the same name as that permanent until Deputy of Detention leaves the battlefield.",
             "colours": [
@@ -5578,7 +5578,7 @@
         },
         {
             "id": "68e69f37-48d2-57c9-ada5-677f8775da2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f56bbf3-3884-495a-b9cd-6585d86f76f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f56bbf3-3884-495a-b9cd-6585d86f76f1.jpg?1",
             "name": "Domri, Chaos Bringer",
             "text": "+1: Add {R} or {G}. If that mana is spent on a creature spell, it gains riot.\n\u22123: Look at the top four cards of your library. You may reveal up to two creature cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.\n\u22128: You get an emblem with \"At the beginning of each end step, create a 4/4 red and green Beast creature token with trample.\"",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "6e3e8558-0ed1-5579-9d7d-76eb2575417c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6784910-0204-4a39-bb38-50daa03e94c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6784910-0204-4a39-bb38-50daa03e94c2.jpg?1",
             "name": "Dovin, Grand Arbiter",
             "text": "+1: Until end of turn, whenever a creature you control deals combat damage to a player, put a loyalty counter on Dovin, Grand Arbiter.\n\u22121: Create a 1/1 colorless Thopter artifact creature token with flying. You gain 1 life.\n\u22127: Look at the top ten cards of your library. Put three of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5654,7 +5654,7 @@
         },
         {
             "id": "5e30587e-00b9-597c-aea3-150adca20318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b191592-7221-422a-8b5a-65f7b1caec1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b191592-7221-422a-8b5a-65f7b1caec1a.jpg?1",
             "name": "Dovin's Acuity",
             "text": "When Dovin's Acuity enters the battlefield, you gain 2 life and draw a card.\nWhenever you cast an instant spell during your main phase, you may return Dovin's Acuity to its owner's hand.",
             "colours": [
@@ -5688,7 +5688,7 @@
         },
         {
             "id": "a04f3c61-7d3b-5073-aa13-4afa1396187a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6473a93f-879f-4f44-8650-ee05a647c763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6473a93f-879f-4f44-8650-ee05a647c763.jpg?1",
             "name": "Emergency Powers",
             "text": "Each player shuffles their hand and graveyard into their library, then draws seven cards. Exile Emergency Powers.\nAddendum \u2014 If you cast this spell during your main phase, you may put a permanent card with converted mana cost 7 or less from your hand onto the battlefield.",
             "colours": [
@@ -5722,7 +5722,7 @@
         },
         {
             "id": "0b13e229-b305-5042-8f7c-f1d290e5195a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0872d0ff-1060-44cc-9ed0-a6aa496440c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0872d0ff-1060-44cc-9ed0-a6aa496440c8.jpg?1",
             "name": "Ethereal Absolution",
             "text": "Creatures you control get +1/+1.\nCreatures your opponents control get -1/-1.\n{2}{W}{B}: Exile target card from an opponent's graveyard. If it was a creature card, you create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "9488e9af-2dee-5ad6-b650-473155749c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a21a8f-9c7b-4ae8-8635-f2ee2151c8de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a21a8f-9c7b-4ae8-8635-f2ee2151c8de.jpg?1",
             "name": "Final Payment",
             "text": "As an additional cost to cast this spell, pay 5 life or sacrifice a creature or enchantment.\nDestroy target creature.",
             "colours": [
@@ -5790,7 +5790,7 @@
         },
         {
             "id": "8d6a363a-f219-5a2f-b5ae-0f6ec5e1404e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1161f-bd2c-45a7-a86b-3b2e5210f148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e1161f-bd2c-45a7-a86b-3b2e5210f148.jpg?1",
             "name": "Fireblade Artist",
             "text": "Haste\nAt the beginning of your upkeep, you may sacrifice a creature. When you do, Fireblade Artist deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -5827,7 +5827,7 @@
         },
         {
             "id": "bb6cfc91-337d-5666-998a-87c6a8986206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2eef7-03a4-415f-8bb7-a29d50ce1b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce2eef7-03a4-415f-8bb7-a29d50ce1b0f.jpg?1",
             "name": "Frenzied Arynx",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nTrample\n{4}{R}{G}: Frenzied Arynx gets +3/+0 until end of turn.",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "0c1337fc-e8c0-5373-a2bc-311389088fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50595d02-edad-48a6-b10c-6fa859cc88bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50595d02-edad-48a6-b10c-6fa859cc88bb.jpg?1",
             "name": "Frilled Mystic",
             "text": "Flash\nWhen Frilled Mystic enters the battlefield, you may counter target spell.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "b970f9e8-9851-521e-9579-1e46bdea913d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2b7cfe-4696-4448-93d2-33be596e32d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2b7cfe-4696-4448-93d2-33be596e32d9.jpg?1",
             "name": "Galloping Lizrog",
             "text": "Trample\nWhen Galloping Lizrog enters the battlefield, you may remove any number of +1/+1 counters from among creatures you control. If you do, put twice that many +1/+1 counters on Galloping Lizrog.",
             "colours": [
@@ -5939,7 +5939,7 @@
         },
         {
             "id": "dff5ffb4-f509-5652-86b5-52adbf20542c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821c4ab5-eb75-445a-bbec-e50af54dba7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821c4ab5-eb75-445a-bbec-e50af54dba7a.jpg?1",
             "name": "Get the Point",
             "text": "Destroy target creature. Scry 1.",
             "colours": [
@@ -5973,7 +5973,7 @@
         },
         {
             "id": "d941457e-c88d-52fe-a096-f81c51d663b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f82d97-ce50-490c-ad7f-46d70a73e454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f82d97-ce50-490c-ad7f-46d70a73e454.jpg?1",
             "name": "Grasping Thrull",
             "text": "Flying\nWhen Grasping Thrull enters the battlefield, it deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "ce5c7d0c-324a-58af-a74c-dcacd99af21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c77a6b1-ef06-4da5-8e86-a5204216cb77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c77a6b1-ef06-4da5-8e86-a5204216cb77.jpg?1",
             "name": "Growth Spiral",
             "text": "Draw a card. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "85903b81-e520-51cf-9a8e-810f7bccb7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326679a2-782d-45a0-9a06-b147ceff3979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/326679a2-782d-45a0-9a06-b147ceff3979.jpg?1",
             "name": "Gruul Spellbreaker",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nTrample\nAs long as it's your turn, you and Gruul Spellbreaker have hexproof.",
             "colours": [
@@ -6080,7 +6080,7 @@
         },
         {
             "id": "c5bf7592-d426-56cf-a8f4-4565ba01fa74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dd6a1d-4dcb-4392-9856-c0e4140efbd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26dd6a1d-4dcb-4392-9856-c0e4140efbd7.jpg?1",
             "name": "Gyre Engineer",
             "text": "{T}: Add {G}{U}.",
             "colours": [
@@ -6117,7 +6117,7 @@
         },
         {
             "id": "d3633ea3-64ad-536c-ac01-524a9666b111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41335c2-3d11-4f95-8d9f-66b04398c10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41335c2-3d11-4f95-8d9f-66b04398c10b.jpg?1",
             "name": "Hackrobat",
             "text": "Spectacle {B}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\n{B}: Hackrobat gains deathtouch until end of turn.\n{R}: Hackrobat gets +2/-2 until end of turn.",
             "colours": [
@@ -6154,7 +6154,7 @@
         },
         {
             "id": "e8b1f616-9d82-5f85-9ac1-5adfdaa9b207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce124f6e-ef0c-4d01-a876-e34d3e445108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce124f6e-ef0c-4d01-a876-e34d3e445108.jpg?1",
             "name": "High Alert",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\nCreatures you control can attack as though they didn't have defender.\n{2}{W}{U}: Untap target creature.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "7dfa9036-98ef-50ad-bf74-f18e1ba20951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801dd9c6-b159-4e1c-af2c-214c1f573633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801dd9c6-b159-4e1c-af2c-214c1f573633.jpg?1",
             "name": "Hydroid Krasis",
             "text": "When you cast this spell, you gain half X life and draw half X cards. Round down each time.\nFlying, trample\nHydroid Krasis enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "bd0d0b32-5705-57be-88a2-e66c284d730e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd27ba9e-5b9c-468f-9a44-bf2e89138e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd27ba9e-5b9c-468f-9a44-bf2e89138e72.jpg?1",
             "name": "Imperious Oligarch",
             "text": "Vigilance\nAfterlife 1 (When this creature dies, create a 1/1 white and black Spirit creature token with flying.)",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "1528bace-73e5-5cfb-ad31-a940fa42e882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742125-730d-4082-bfd8-5feb7733def4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742125-730d-4082-bfd8-5feb7733def4.jpg?1",
             "name": "Judith, the Scourge Diva",
             "text": "Other creatures you control get +1/+0.\nWhenever a nontoken creature you control dies, Judith, the Scourge Diva deals 1 damage to any target.",
             "colours": [
@@ -6302,7 +6302,7 @@
         },
         {
             "id": "9f721028-eed0-534d-8e30-cc5df513c852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb4b2ef-5196-4f7f-88ff-64b2cdb36c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdb4b2ef-5196-4f7f-88ff-64b2cdb36c6b.jpg?1",
             "name": "Kaya, Orzhov Usurper",
             "text": "+1: Exile up to two target cards from a single graveyard. You gain 2 life if at least one creature card was exiled this way.\n\u22121: Exile target nonland permanent with converted mana cost 1 or less.\n\u22125: Kaya, Orzhov Usurper deals damage to target player equal to the number of cards that player owns in exile and you gain that much life.",
             "colours": [
@@ -6340,7 +6340,7 @@
         },
         {
             "id": "732b93cc-72ed-54ba-bf71-0d227d8e943d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed140c1-752b-4539-88f2-1fa354049b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed140c1-752b-4539-88f2-1fa354049b17.jpg?1",
             "name": "Kaya's Wrath",
             "text": "Destroy all creatures. You gain life equal to the number of creatures you controlled that were destroyed this way.",
             "colours": [
@@ -6374,7 +6374,7 @@
         },
         {
             "id": "402c4fa9-85e0-5c7c-af79-c0ffd45dfe9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fccf60-2df5-4c14-893f-41d3f86c545f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fccf60-2df5-4c14-893f-41d3f86c545f.jpg?1",
             "name": "Knight of the Last Breath",
             "text": "{3}, Sacrifice another nontoken creature: Create a 1/1 white and black Spirit creature token with flying.\nAfterlife 3 (When this creature dies, create three 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "5a7d18d9-7625-5f2d-a932-909741023ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c497d496-1232-4614-93b0-9864fa93c29f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c497d496-1232-4614-93b0-9864fa93c29f.jpg?1",
             "name": "Lavinia, Azorius Renegade",
             "text": "Each opponent can't cast noncreature spells with converted mana cost greater than the number of lands that player controls.\nWhenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.",
             "colours": [
@@ -6450,7 +6450,7 @@
         },
         {
             "id": "4caa256a-1aee-5db0-9822-8ef23ab9e8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a7be1f-3fba-4ff2-a4f1-aebd3d20da8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a7be1f-3fba-4ff2-a4f1-aebd3d20da8f.jpg?1",
             "name": "Lawmage's Binding",
             "text": "Flash\nEnchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "d1bd7c3d-d9ee-5431-9c08-a4045246d450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1aee37-dcee-4e58-be9b-81ca57cedb53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1aee37-dcee-4e58-be9b-81ca57cedb53.jpg?1",
             "name": "Macabre Mockery",
             "text": "Put target creature card from an opponent's graveyard onto the battlefield under your control. It gets +2/+0 and gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -6520,7 +6520,7 @@
         },
         {
             "id": "fe0411b4-7b85-57ff-8a5e-1266df630e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6c0dc-5c7b-4170-99bc-2637ea44e716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6c0dc-5c7b-4170-99bc-2637ea44e716.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -6554,7 +6554,7 @@
         },
         {
             "id": "5069f2d0-4af1-5df5-be3a-9292b167fcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdad71-323e-41e0-a1b3-9fd5b753e71c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcdad71-323e-41e0-a1b3-9fd5b753e71c.jpg?1",
             "name": "Nikya of the Old Ways",
             "text": "You can't cast noncreature spells.\nWhenever you tap a land for mana, add one mana of any type that land produced.",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "9470d134-acce-58d1-94b4-4c5c167e4b8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f66c03-cf79-4de0-be55-b921cbdc5038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f66c03-cf79-4de0-be55-b921cbdc5038.jpg?1",
             "name": "Pitiless Pontiff",
             "text": "{1}, Sacrifice another creature: Pitiless Pontiff gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "9dab4d0a-75a4-50b1-a4cc-a307b7d054a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84abfc59-10a7-4cb5-9cdd-81797116c810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84abfc59-10a7-4cb5-9cdd-81797116c810.jpg?1",
             "name": "Prime Speaker Vannifar",
             "text": "{T}, Sacrifice another creature: Search your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield, then shuffle your library. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "33d27a6f-6d6a-5249-8184-cc31b43ccd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8dad4d-bc4f-46fb-892c-dbf6481cdc46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf8dad4d-bc4f-46fb-892c-dbf6481cdc46.jpg?1",
             "name": "Rafter Demon",
             "text": "Spectacle {3}{B}{R} (You may cast this spell for its spectacle cost rather than its mana cost if an opponent lost life this turn.)\nWhen Rafter Demon enters the battlefield, if its spectacle cost was paid, each opponent discards a card.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "7dc13d61-a1b8-59a2-8061-a43265b0895e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d819a944-0b3e-4e26-87da-2417081928e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d819a944-0b3e-4e26-87da-2417081928e7.jpg?1",
             "name": "Rakdos Firewheeler",
             "text": "When Rakdos Firewheeler enters the battlefield, it deals 2 damage to target opponent and 2 damage to up to one target creature or planeswalker.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "37be5c37-cecf-52ea-880f-5ad6488e9243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed534af-e16a-4d1d-8884-938fc7e13ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed534af-e16a-4d1d-8884-938fc7e13ca8.jpg?1",
             "name": "Rakdos Roustabout",
             "text": "Whenever Rakdos Roustabout becomes blocked, it deals 1 damage to the player or planeswalker it's attacking.",
             "colours": [
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "18fb37b1-8616-5c0d-88bc-40591c2c8164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3c30c7-c52e-41a0-b7c2-21d39c05160b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e3c30c7-c52e-41a0-b7c2-21d39c05160b.jpg?1",
             "name": "Rakdos, the Showstopper",
             "text": "Flying, trample\nWhen Rakdos, the Showstopper enters the battlefield, flip a coin for each creature that isn't a Demon, Devil, or Imp. Destroy each creature whose coin comes up tails.",
             "colours": [
@@ -6818,7 +6818,7 @@
         },
         {
             "id": "caa919c0-d50b-57a6-bd48-1f4ae534b795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5a6085-bb5d-412e-8831-757996bbc8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d5a6085-bb5d-412e-8831-757996bbc8fb.jpg?1",
             "name": "Ravager Wurm",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)\nWhen Ravager Wurm enters the battlefield, choose up to one \u2014\n\u2022 Ravager Wurm fights target creature you don't control.\n\u2022 Destroy target land with an activated ability that isn't a mana ability.",
             "colours": [
@@ -6854,7 +6854,7 @@
         },
         {
             "id": "a930efbf-1397-5665-863d-50a674b4f934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84062ce2-fea2-4e06-b83b-7cc597fb2a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84062ce2-fea2-4e06-b83b-7cc597fb2a1b.jpg?1",
             "name": "Rhythm of the Wild",
             "text": "Creature spells you control can't be countered.\nNontoken creatures you control have riot. (They enter the battlefield with your choice of a +1/+1 counter or haste.)",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "47f4ec18-0623-5ac3-875f-c24a5168056d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cc4e02-949f-4879-9f32-7c33490d0b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78cc4e02-949f-4879-9f32-7c33490d0b45.jpg?1",
             "name": "Rubblebelt Runner",
             "text": "Rubblebelt Runner can't be blocked by creature tokens.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "dac81423-041b-5406-a5c3-195f2c25e1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca942d7-a3a3-429f-a159-fc2363d9bca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca942d7-a3a3-429f-a159-fc2363d9bca6.jpg?1",
             "name": "Savage Smash",
             "text": "Target creature you control gets +2/+2 until end of turn. It fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "ad419cf2-5e14-5275-800a-ff2a2a98bd87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b3a2a-e3fd-4095-ab2a-5e356ea179df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b3a2a-e3fd-4095-ab2a-5e356ea179df.jpg?1",
             "name": "Senate Guildmage",
             "text": "{W}, {T}: You gain 2 life.\n{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "41010ff9-be8b-5ab9-92c6-ab9d04aad88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d602e9e6-31ed-4d17-b39c-457b3b182943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d602e9e6-31ed-4d17-b39c-457b3b182943.jpg?1",
             "name": "Seraph of the Scales",
             "text": "Flying\n{W}: Seraph of the Scales gains vigilance until end of turn.\n{B}: Seraph of the Scales gains deathtouch until end of turn.\nAfterlife 2 (When this creature dies, create two 1/1 white and black Spirit creature tokens with flying.)",
             "colours": [
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "4e1175fc-eaed-5b7c-b625-c64d3588eab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f31228-0c47-4c51-932d-50fdec965f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f31228-0c47-4c51-932d-50fdec965f15.jpg?1",
             "name": "Sharktocrab",
             "text": "{2}{G}{U}: Adapt 1. (If this creature has no +1/+1 counters on it, put a +1/+1 counter on it.)\nWhenever one or more +1/+1 counters are put on Sharktocrab, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -7070,7 +7070,7 @@
         },
         {
             "id": "df8e477b-7ba4-5e7b-82da-4ed214d8654b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff824392-fb5c-496c-be2f-6dfa6e04e3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff824392-fb5c-496c-be2f-6dfa6e04e3a2.jpg?1",
             "name": "Simic Ascendancy",
             "text": "{1}{G}{U}: Put a +1/+1 counter on target creature you control.\nWhenever one or more +1/+1 counters are put on a creature you control, put that many growth counters on Simic Ascendancy.\nAt the beginning of your upkeep, if Simic Ascendancy has twenty or more growth counters on it, you win the game.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "281478bf-61fa-56db-92f0-43fda9fa4bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9aec56e-50a3-491f-89c6-32907ea3161a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9aec56e-50a3-491f-89c6-32907ea3161a.jpg?1",
             "name": "Sphinx of New Prahv",
             "text": "Flying, vigilance\nSpells your opponents cast that target Sphinx of New Prahv cost {2} more to cast.",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "5f2f9d22-f27d-5aa4-9632-4143c2207557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71c2435-0312-4279-a9e1-fab7432756b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71c2435-0312-4279-a9e1-fab7432756b7.jpg?1",
             "name": "Sphinx's Insight",
             "text": "Draw two cards.\nAddendum \u2014 If you cast this spell during your main phase, you gain 2 life.",
             "colours": [
@@ -7174,7 +7174,7 @@
         },
         {
             "id": "41d06cf5-32a1-50f9-bdc2-591329fd6520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6a8bb-9eec-4f9b-a5a8-604631e4b823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb6a8bb-9eec-4f9b-a5a8-604631e4b823.jpg?1",
             "name": "Sunder Shaman",
             "text": "Sunder Shaman can't be blocked by more than one creature.\nWhenever Sunder Shaman deals combat damage to a player, destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -7211,7 +7211,7 @@
         },
         {
             "id": "2b50de06-d5f2-5cf1-8573-6ce601ed6a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82d3c8d-849a-445b-bc7c-365514d1511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82d3c8d-849a-445b-bc7c-365514d1511f.jpg?1",
             "name": "Syndicate Guildmage",
             "text": "{1}{W}, {T}: Tap target creature with power 4 or greater.\n{4}{B}, {T}: Syndicate Guildmage deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "4e54e567-962d-58cc-aeb3-b9448fe82d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaa19e-995e-447d-a0a2-46e5d117d5ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfaa19e-995e-447d-a0a2-46e5d117d5ec.jpg?1",
             "name": "Teysa Karlov",
             "text": "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\nCreature tokens you control have vigilance and lifelink.",
             "colours": [
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "343fb908-188c-5d9c-be3b-5aa0bad45baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42efd5-79c8-44f9-b3d6-d9058e0cb0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad42efd5-79c8-44f9-b3d6-d9058e0cb0f6.jpg?1",
             "name": "Theater of Horrors",
             "text": "At the beginning of your upkeep, exile the top card of your library.\nDuring your turn, if an opponent lost life this turn, you may play cards exiled with Theater of Horrors.\n{3}{R}: Theater of Horrors deals 1 damage to target opponent or planeswalker.",
             "colours": [
@@ -7321,7 +7321,7 @@
         },
         {
             "id": "ccdabe5f-edcb-561c-b2c8-95ff1bba5c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd199a48-5ac8-4ab9-a33c-bbce6f7c9d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd199a48-5ac8-4ab9-a33c-bbce6f7c9d1b.jpg?1",
             "name": "Zegana, Utopian Speaker",
             "text": "When Zegana, Utopian Speaker enters the battlefield, if you control another creature with a +1/+1 counter on it, draw a card.\n{4}{G}{U}: Adapt 4. (If this creature has no +1/+1 counters on it, put four +1/+1 counters on it.)\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -7360,7 +7360,7 @@
         },
         {
             "id": "1eda886f-d307-5b4f-93ed-6a43e7358e59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13070db2-cf89-4552-8b6c-76426274321a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13070db2-cf89-4552-8b6c-76426274321a.jpg?1",
             "name": "Zhur-Taa Goblin",
             "text": "Riot (This creature enters the battlefield with your choice of a +1/+1 counter or haste.)",
             "colours": [
@@ -7397,7 +7397,7 @@
         },
         {
             "id": "0994914c-2d8c-50eb-9b6b-4ad69bbcb847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c604697-5c81-4329-9b16-f19bd90ba08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c604697-5c81-4329-9b16-f19bd90ba08c.jpg?1",
             "name": "Footlight Fiend",
             "text": "When Footlight Fiend dies, it deals 1 damage to any target.",
             "colours": [
@@ -7433,7 +7433,7 @@
         },
         {
             "id": "27c78013-9fc8-54da-b1f3-4c229d329932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f006255f-b18d-4d52-b97a-17909b67decc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f006255f-b18d-4d52-b97a-17909b67decc.jpg?1",
             "name": "Rubble Slinger",
             "text": "Reach",
             "colours": [
@@ -7470,7 +7470,7 @@
         },
         {
             "id": "3d37d14c-5a3d-5f54-b2a5-9e913617b4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886fd9a-7800-41f1-b692-32a439b045da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d886fd9a-7800-41f1-b692-32a439b045da.jpg?1",
             "name": "Scuttlegator",
             "text": "Defender\n{6}{GW}{GW}: Adapt 3. (If this creature has no +1/+1 counters on it, put three +1/+1 counters on it.)\nAs long as Scuttlegator has a +1/+1 counter on it, it can attack as though it didn't have defender.",
             "colours": [
@@ -7508,7 +7508,7 @@
         },
         {
             "id": "f8cd94dc-8662-5320-b114-be6d1cb7ea36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465adbb4-4c64-44eb-8323-61d23282c6b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465adbb4-4c64-44eb-8323-61d23282c6b8.jpg?1",
             "name": "Senate Griffin",
             "text": "Flying\nWhen Senate Griffin enters the battlefield, scry 1.",
             "colours": [
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "b58bcaf1-1489-5ca9-9025-eadd2d800444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61245466-694f-4a80-b556-4e7f876aedca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61245466-694f-4a80-b556-4e7f876aedca.jpg?1",
             "name": "Vizkopa Vampire",
             "text": "Lifelink",
             "colours": [
@@ -7580,7 +7580,7 @@
         },
         {
             "id": "ef3c9a4e-ee5f-56f1-b1aa-d942c50f98ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg?1",
             "name": "Bedeck // Bedazzle",
             "text": "Target creature gets +3/-3 until end of turn.",
             "colours": [
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "8b1435d3-64a8-562d-8e1b-3c64c51492b6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5873efa-d573-4435-81ad-48df2ca5c7f2.jpg?1",
             "name": "Bedeck // Bedazzle",
             "text": "Destroy target nonbasic land. Bedazzle deals 2 damage to target opponent or planeswalker.",
             "colours": [
@@ -7648,7 +7648,7 @@
         },
         {
             "id": "48e54abe-a208-5578-aa03-036d8142e4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg?1",
             "name": "Carnival // Carnage",
             "text": "Carnival deals 1 damage to target creature or planeswalker and 1 damage to that permanent's controller.",
             "colours": [
@@ -7682,7 +7682,7 @@
         },
         {
             "id": "f7201a85-2421-55e8-b9bf-003da8abc29f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/1/d1dbc559-c78c-4675-9582-9c28f8151bc7.jpg?1",
             "name": "Carnival // Carnage",
             "text": "Carnage deals 3 damage to target opponent. That player discards two cards.",
             "colours": [
@@ -7716,7 +7716,7 @@
         },
         {
             "id": "d96649dd-4281-5e05-aa80-f59b8ce2c671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg?1",
             "name": "Collision // Colossus",
             "text": "Collision deals 6 damage to target creature with flying.",
             "colours": [
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "3b2890b8-fd78-5f97-8dab-8de86fc5c66f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9bd15da6-2b86-4dba-951d-318c7d9a5dde.jpg?1",
             "name": "Collision // Colossus",
             "text": "Target creature gets +4/+2 and gains trample until end of turn.",
             "colours": [
@@ -7784,7 +7784,7 @@
         },
         {
             "id": "0edb8bf4-3578-5140-b05f-8e66b282f254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1",
             "name": "Consecrate // Consume",
             "text": "Exile target card from a graveyard.\nDraw a card.",
             "colours": [
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "14e343b7-c684-57b8-bdec-633828e6ae60",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/00320106-ce51-46a9-b0f9-79b3baf4e505.jpg?1",
             "name": "Consecrate // Consume",
             "text": "Target player sacrifices a creature with the greatest power among creatures they control. You gain life equal to its power.",
             "colours": [
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "d58a6df4-6066-5049-b705-10c1dd865084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg?1",
             "name": "Depose // Deploy",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -7886,7 +7886,7 @@
         },
         {
             "id": "3a0dd57f-a855-570e-8cc3-a4a72c3d50f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab0ba4ef-9e82-4177-a80f-8fa6f6a5bd60.jpg?1",
             "name": "Depose // Deploy",
             "text": "Create two 1/1 colorless Thopter artifact creature tokens with flying, then you gain 1 life for each creature you control.",
             "colours": [
@@ -7920,7 +7920,7 @@
         },
         {
             "id": "b0506af8-075d-5629-85f4-c3860c02573c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg?1",
             "name": "Incubation // Incongruity",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "0c08602c-0d20-5ede-85d7-1e0f8458ba72",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd3a4d6e-34ae-4047-a9c7-11e28b0a276d.jpg?1",
             "name": "Incubation // Incongruity",
             "text": "Exile target creature. That creature's controller creates a 3/3 green Frog Lizard creature token.",
             "colours": [
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "654f4f6a-158d-5721-a9e7-d8cd807b2fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg?1",
             "name": "Repudiate // Replicate",
             "text": "Counter target activated or triggered ability. (Mana abilities can't be targeted.)",
             "colours": [
@@ -8022,7 +8022,7 @@
         },
         {
             "id": "1f9a0bbd-341f-5153-b7a8-73ffccf0eb40",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6200937-3146-4972-ab83-051ade3b7a52.jpg?1",
             "name": "Repudiate // Replicate",
             "text": "Create a token that's a copy of target creature you control.",
             "colours": [
@@ -8056,7 +8056,7 @@
         },
         {
             "id": "ac399fe8-535f-530a-bab8-62b882477efe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg?1",
             "name": "Revival // Revenge",
             "text": "Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -8090,7 +8090,7 @@
         },
         {
             "id": "cbec6fc3-8b6e-5ec9-a3db-f95b935bff9c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ae0831-f3ba-4535-bfb6-feefbbc15275.jpg?1",
             "name": "Revival // Revenge",
             "text": "Double your life total. Target opponent loses half their life, rounded up.",
             "colours": [
@@ -8124,7 +8124,7 @@
         },
         {
             "id": "da8df4d6-425c-5e3f-9d7f-182ff8b5aa26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg?1",
             "name": "Thrash // Threat",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "7d01cd4c-a6f8-5d88-acc3-d6ab76e8e884",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/e/2eefd8c1-96ce-4d7a-8aaf-29c35d634dda.jpg?1",
             "name": "Thrash // Threat",
             "text": "Create a 4/4 red and green Beast creature token with trample.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "3d5ceb46-ca7b-52b7-a0aa-0e1a5876b1e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg?1",
             "name": "Warrant // Warden",
             "text": "Put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "b5046154-a12d-56f1-8698-405c153932eb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0070651d-79aa-4ea6-b703-6ecd3528b548.jpg?1",
             "name": "Warrant // Warden",
             "text": "Create a 4/4 white and blue Sphinx creature token with flying and vigilance.",
             "colours": [
@@ -8260,7 +8260,7 @@
         },
         {
             "id": "f8fcc657-60a6-5194-92a0-84b97560a85f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13aed078-9e29-48e7-b145-5252362031a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13aed078-9e29-48e7-b145-5252362031a0.jpg?1",
             "name": "Azorius Locket",
             "text": "{T}: Add {W} or {U}.\n{WU}{WU}{WU}{WU}, {T}, Sacrifice Azorius Locket: Draw two cards.",
             "colours": [],
@@ -8291,7 +8291,7 @@
         },
         {
             "id": "c262806c-6190-50d8-98d3-5dca4a24d9b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99767e2f-a558-4d63-b9b6-923d15b433e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99767e2f-a558-4d63-b9b6-923d15b433e1.jpg?1",
             "name": "Gate Colossus",
             "text": "This spell costs {1} less to cast for each Gate you control.\nGate Colossus can't be blocked by creatures with power 2 or less.\nWhenever a Gate enters the battlefield under your control, you may put Gate Colossus from your graveyard on top of your library.",
             "colours": [],
@@ -8322,7 +8322,7 @@
         },
         {
             "id": "6e285cad-4126-5f15-b0cd-0c14e0310a84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1022d41-c1d0-42bf-b3e5-d6fb02d47119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1022d41-c1d0-42bf-b3e5-d6fb02d47119.jpg?1",
             "name": "Glass of the Guildpact",
             "text": "Multicolored creatures you control get +1/+1.",
             "colours": [],
@@ -8350,7 +8350,7 @@
         },
         {
             "id": "7d5c303c-8912-5faa-821c-39c62c258f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec78880-a8ec-4c87-bc3f-e2a79d154884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec78880-a8ec-4c87-bc3f-e2a79d154884.jpg?1",
             "name": "Gruul Locket",
             "text": "{T}: Add {R} or {G}.\n{RG}{RG}{RG}{RG}, {T}, Sacrifice Gruul Locket: Draw two cards.",
             "colours": [],
@@ -8381,7 +8381,7 @@
         },
         {
             "id": "b3f56f87-5fc5-501d-a90e-2cd2f99b626f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd8ee5-0a2a-4c68-9b09-01945c7189ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fd8ee5-0a2a-4c68-9b09-01945c7189ab.jpg?1",
             "name": "Junktroller",
             "text": "Defender\n{T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -8412,7 +8412,7 @@
         },
         {
             "id": "f6640841-ffeb-5c57-a689-bcdd5eb0f394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761e7188-bad1-4775-84a2-15da9a42a57c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761e7188-bad1-4775-84a2-15da9a42a57c.jpg?1",
             "name": "Orzhov Locket",
             "text": "{T}: Add {W} or {B}.\n{WB}{WB}{WB}{WB}, {T}, Sacrifice Orzhov Locket: Draw two cards.",
             "colours": [],
@@ -8443,7 +8443,7 @@
         },
         {
             "id": "6a5cf777-c480-55ea-ba14-ae8cd3a774b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd60d9b-2282-4b32-9bff-efb2bcf87d22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd60d9b-2282-4b32-9bff-efb2bcf87d22.jpg?1",
             "name": "Rakdos Locket",
             "text": "{T}: Add {B} or {R}.\n{BR}{BR}{BR}{BR}, {T}, Sacrifice Rakdos Locket: Draw two cards.",
             "colours": [],
@@ -8474,7 +8474,7 @@
         },
         {
             "id": "adcf663c-70e6-5299-a64f-ba4cfc9c1c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b06cb5-5e74-456f-81b1-fced1346cc47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b06cb5-5e74-456f-81b1-fced1346cc47.jpg?1",
             "name": "Scrabbling Claws",
             "text": "{T}: Target player exiles a card from their graveyard.\n{1}, Sacrifice Scrabbling Claws: Exile target card from a graveyard. Draw a card.",
             "colours": [],
@@ -8502,7 +8502,7 @@
         },
         {
             "id": "d31643a7-3585-50a3-a845-5d9900570fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb42a80-0442-4850-b0e7-41182d5633ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb42a80-0442-4850-b0e7-41182d5633ff.jpg?1",
             "name": "Screaming Shield",
             "text": "Equipped creature gets +0/+3 and has \"{2}, {T}: Target player puts the top three cards of their library into their graveyard.\"\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8532,7 +8532,7 @@
         },
         {
             "id": "2675ce8f-c940-59f5-9c2a-2adf969ad2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c65978-e5b0-428e-aace-f99768ca6106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c65978-e5b0-428e-aace-f99768ca6106.jpg?1",
             "name": "Simic Locket",
             "text": "{T}: Add {G} or {U}.\n{GW}{GW}{GW}{GW}, {T}, Sacrifice Simic Locket: Draw two cards.",
             "colours": [],
@@ -8563,7 +8563,7 @@
         },
         {
             "id": "a6a50123-9636-522d-a77b-05a8176efadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d30399e-2ecb-4de2-b830-673a3f059197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d30399e-2ecb-4de2-b830-673a3f059197.jpg?1",
             "name": "Sphinx of the Guildpact",
             "text": "Sphinx of the Guildpact is all colors.\nFlying\nHexproof from monocolored (This creature can't be the target of monocolored spells or abilities your opponents control.)",
             "colours": [
@@ -8606,7 +8606,7 @@
         },
         {
             "id": "8ff15b8b-19eb-57c7-926d-a3e62bcf5e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e307d4-7e5f-4f00-869e-da0e7abbf27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e307d4-7e5f-4f00-869e-da0e7abbf27f.jpg?1",
             "name": "Tome of the Guildpact",
             "text": "Whenever you cast a multicolored spell, draw a card.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8634,7 +8634,7 @@
         },
         {
             "id": "3beb486e-c2ca-5a87-be8d-baf99e3ac809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5412-c711-41b4-ab3b-7788a0a22228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cf5412-c711-41b4-ab3b-7788a0a22228.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "6bac2c36-a718-5730-b9c3-d55255388936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52013ba-9b17-497b-a844-1e7eb5607019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52013ba-9b17-497b-a844-1e7eb5607019.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8704,7 +8704,7 @@
         },
         {
             "id": "bf3e3575-8eb1-520f-be3a-b26b778ea003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5faba6c8-3463-47c1-ba01-09eb87fcb2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5faba6c8-3463-47c1-ba01-09eb87fcb2d5.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R}.)\nAs Blood Crypt enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8738,7 +8738,7 @@
         },
         {
             "id": "2c89affc-1e48-5e11-9d6d-d1435d1f59ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb54233c-0844-4965-9cde-e8a4ef3e11b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb54233c-0844-4965-9cde-e8a4ef3e11b8.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U}.)\nAs Breeding Pool enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8772,7 +8772,7 @@
         },
         {
             "id": "7eff0d87-e24e-5e4c-96ac-5578933bcea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3433a2c2-d252-4cd8-97e8-389875b2cda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3433a2c2-d252-4cd8-97e8-389875b2cda0.jpg?1",
             "name": "Gateway Plaza",
             "text": "Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -8802,7 +8802,7 @@
         },
         {
             "id": "19c54a73-e7d5-525f-89b0-d48faacfeab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4c824-2dfc-42ae-84e6-09f8e3f51b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced4c824-2dfc-42ae-84e6-09f8e3f51b5b.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B}.)\nAs Godless Shrine enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8836,7 +8836,7 @@
         },
         {
             "id": "8ac9cfdf-8334-505a-9b14-bf2589e3519b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d10573-1695-4a73-b92d-d478572b85ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d10573-1695-4a73-b92d-d478572b85ec.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "7005a1e1-bda9-5c06-9959-4c11b388fbd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd445-de4f-45de-95b9-6e0855926a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fffd445-de4f-45de-95b9-6e0855926a6a.jpg?1",
             "name": "Gruul Guildgate",
             "text": "Gruul Guildgate enters the battlefield tapped.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "0fdc024f-665d-5098-8b0f-af684a39a4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97a6d34-03ab-49f1-b02e-405b733f8843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f97a6d34-03ab-49f1-b02e-405b733f8843.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U}.)\nAs Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -8940,7 +8940,7 @@
         },
         {
             "id": "fef05c98-a52a-5a41-b309-68ce3c1e84c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fb67-e161-4e89-be3e-c8021122ff19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba5fb67-e161-4e89-be3e-c8021122ff19.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -8975,7 +8975,7 @@
         },
         {
             "id": "259cc2a3-6031-5a97-94f1-4ddc64b4e63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7046b5e-622f-4ae8-9ddd-709ccd61000e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7046b5e-622f-4ae8-9ddd-709ccd61000e.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9010,7 +9010,7 @@
         },
         {
             "id": "554c74b1-91c2-581b-a7b8-799e91bf47e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f2ae00-206d-4984-84eb-d10ab75d3791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07f2ae00-206d-4984-84eb-d10ab75d3791.jpg?1",
             "name": "Plaza of Harmony",
             "text": "When Plaza of Harmony enters the battlefield, if you control two or more Gates, you gain 3 life.\n{T}: Add {C}.\n{T}: Add one mana of any type that a Gate you control could produce.",
             "colours": [],
@@ -9038,7 +9038,7 @@
         },
         {
             "id": "08f88182-c117-59cc-8e76-be9aba5b5ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7e55d-d4c9-4755-ab87-a592ba3fb64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f7e55d-d4c9-4755-ab87-a592ba3fb64f.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9073,7 +9073,7 @@
         },
         {
             "id": "4c1020e7-9b19-5e0e-83f8-b025236efcba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88b90fa-a7f1-4739-a507-d22dede9384f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88b90fa-a7f1-4739-a507-d22dede9384f.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "0a32f328-fb8a-5178-84fb-3c93a5b73436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e73e082-b16a-45d5-bc4a-24c694b0b9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e73e082-b16a-45d5-bc4a-24c694b0b9af.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9143,7 +9143,7 @@
         },
         {
             "id": "263a0ce7-237d-5f51-a2bf-c2c49cc146aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62537433-3c49-417d-89ef-c12d5288bb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62537433-3c49-417d-89ef-c12d5288bb6f.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9178,7 +9178,7 @@
         },
         {
             "id": "c9bd32eb-a01b-55b6-b3b5-5399bba48f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaa1ff6-304e-4660-9df3-36de8e89592e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcaa1ff6-304e-4660-9df3-36de8e89592e.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G}.)\nAs Stomping Ground enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -9212,7 +9212,7 @@
         },
         {
             "id": "0479b61d-cd43-577e-aa02-145c73977f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9433619d-5bd1-41e9-ab7a-364c98347b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9433619d-5bd1-41e9-ab7a-364c98347b1d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9246,7 +9246,7 @@
         },
         {
             "id": "3ef716ae-3c49-5067-b752-d2dab5216495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5bd0-5ab3-4bf4-b20e-1389c0e9527a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197f5bd0-5ab3-4bf4-b20e-1389c0e9527a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9280,7 +9280,7 @@
         },
         {
             "id": "0e7fc903-869c-5581-9c21-f4a72211b814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308809ad-c150-49b1-83e3-b78494156d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308809ad-c150-49b1-83e3-b78494156d7a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "1e16c2cc-400c-56f0-bc4f-c4f65945b076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a773e3-93f0-4bf8-ab6a-8cee939d743a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a773e3-93f0-4bf8-ab6a-8cee939d743a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9348,7 +9348,7 @@
         },
         {
             "id": "6944bec7-7702-5f77-b0e6-6942f90b2f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48764854-d268-462d-a016-27329c8f062d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48764854-d268-462d-a016-27329c8f062d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9382,7 +9382,7 @@
         },
         {
             "id": "2f378ee8-5661-5be5-8856-53f5bbfdf4ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7cffe-8751-4da7-8c1c-59f472ef3735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c7cffe-8751-4da7-8c1c-59f472ef3735.jpg?1",
             "name": "Dovin, Architect of Law",
             "text": "+1: You gain 2 life and draw a card.\n\u22121: Tap target creature. It doesn't untap during its controller's next untap step.\n\u22129: Tap all permanents target opponent controls. That player skips their next untap step.",
             "colours": [
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "cecf0914-d9f6-5b8b-9946-d0113d9b59c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070f0a21-8e06-46ec-9d84-c65067b23893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070f0a21-8e06-46ec-9d84-c65067b23893.jpg?1",
             "name": "Elite Arrester",
             "text": "{1}{U}, {T}: Tap target creature.",
             "colours": [
@@ -9454,7 +9454,7 @@
         },
         {
             "id": "6976c560-32cb-53b8-ae70-aaff9e18b43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6328e6b5-9dfb-4fd4-99ee-a1ffc2c707da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6328e6b5-9dfb-4fd4-99ee-a1ffc2c707da.jpg?1",
             "name": "Dovin's Dismissal",
             "text": "Put up to one target tapped creature on top of its owner's library. You may search your library and/or graveyard for a card named Dovin, Architect of Law, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "facb2935-8a79-5ca9-97a6-ee94f01b0621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a962509-2e77-4655-b397-9625b2f3407a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a962509-2e77-4655-b397-9625b2f3407a.jpg?1",
             "name": "Dovin's Automaton",
             "text": "As long as you control a Dovin planeswalker, Dovin's Automaton gets +2/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "885f98a7-3163-5720-8063-f0cd901ea3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe16cdb-90df-4670-a084-55c505791d85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe16cdb-90df-4670-a084-55c505791d85.jpg?1",
             "name": "Domri, City Smasher",
             "text": "+2: Creatures you control get +1/+1 and gain haste until end of turn.\n\u22123: Domri, City Smasher deals 3 damage to any target.\n\u22128: Put three +1/+1 counters on each creature you control. Those creatures gain trample until end of turn.",
             "colours": [
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "bbefba15-4dda-53ba-a4d8-3a26db00d484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13420d-d295-4000-9c38-fa5d10e06ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb13420d-d295-4000-9c38-fa5d10e06ece.jpg?1",
             "name": "Ragefire",
             "text": "Ragefire deals 3 damage to target creature.",
             "colours": [
@@ -9585,7 +9585,7 @@
         },
         {
             "id": "dbf30816-d953-54e0-afe7-d6dbf98b2181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cef5a4-e8fd-4ebd-b121-67059308c772.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cef5a4-e8fd-4ebd-b121-67059308c772.jpg?1",
             "name": "Charging War Boar",
             "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAs long as you control a Domri planeswalker, Charging War Boar gets +1/+1 and has trample. (It can deal excess damage to the player or planeswalker it's attacking.)",
             "colours": [
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "464169d8-253b-5243-8705-4491434fb58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe58d8-67d1-4719-8e84-27747dea3506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1abe58d8-67d1-4719-8e84-27747dea3506.jpg?1",
             "name": "Domri's Nodorog",
             "text": "Trample\nWhen Domri's Nodorog enters the battlefield, you may search your library and/or graveyard for a card named Domri, City Smasher, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9655,7 +9655,7 @@
         },
         {
             "id": "70119b58-5449-581a-b5bd-2ce6f7a752b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a908e8-6952-46c0-94ec-3962b7a4caef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a908e8-6952-46c0-94ec-3962b7a4caef.jpg?1",
             "name": "The Haunt of Hightower",
             "text": "Flying, lifelink\nWhenever The Haunt of Hightower attacks, defending player discards a card.\nWhenever a card is put into an opponent's graveyard from anywhere, put a +1/+1 counter on The Haunt of Hightower.",
             "colours": [
@@ -9690,7 +9690,7 @@
         },
         {
             "id": "95f964bc-416c-5241-8e2d-8d8378d91016",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a2483-d21f-4c31-9a36-ed7c5672894b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f2a2483-d21f-4c31-9a36-ed7c5672894b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -9724,7 +9724,7 @@
         },
         {
             "id": "f021ed7e-996c-5af2-94a2-9d707a276482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3d8da-9005-44d9-bb10-18cdac7a32f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccc3d8da-9005-44d9-bb10-18cdac7a32f5.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -9758,7 +9758,7 @@
         },
         {
             "id": "31a18be7-bf42-5723-b1fb-880471a2597c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b69e52-f394-4863-943b-239e96b5cc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b69e52-f394-4863-943b-239e96b5cc95.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -9792,7 +9792,7 @@
         },
         {
             "id": "d450ce97-dd62-59ff-921f-f73a276817fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993613a6-09a9-45a5-b35f-5a5fdb6d14ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993613a6-09a9-45a5-b35f-5a5fdb6d14ec.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9826,7 +9826,7 @@
         },
         {
             "id": "6f6d519d-0848-54a0-96d0-81cd8a5d4c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc993a7-a1ce-4403-a0a0-2afc9f9eca42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc993a7-a1ce-4403-a0a0-2afc9f9eca42.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -9860,7 +9860,7 @@
         },
         {
             "id": "3ede2133-21e1-5a02-9e74-7921242a84a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d3391-6311-418e-b55a-10c0af751026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/495d3391-6311-418e-b55a-10c0af751026.jpg?1",
             "name": "Frog Lizard",
             "text": "",
             "colours": [
@@ -9895,7 +9895,7 @@
         },
         {
             "id": "aa0ad8d3-c95b-56b0-ae31-6b7e8dfc424b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0260e0ae-bf09-430a-a449-c16219d84b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0260e0ae-bf09-430a-a449-c16219d84b63.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9929,7 +9929,7 @@
         },
         {
             "id": "888e284a-6bfa-5d0c-b01f-410a813bddf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec9ade-1e06-43c9-97df-55465cabdf32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ec9ade-1e06-43c9-97df-55465cabdf32.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9965,7 +9965,7 @@
         },
         {
             "id": "2b2ad031-308d-5b77-a25c-3ca2d2cce68e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82ba894-7b10-45ae-9322-60ef85a2869d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82ba894-7b10-45ae-9322-60ef85a2869d.jpg?1",
             "name": "Sphinx",
             "text": "",
             "colours": [
@@ -10001,7 +10001,7 @@
         },
         {
             "id": "ecb4f782-2e1d-599e-b215-50205578124c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3bdd7-b093-4bfd-8a9a-965e72bfefb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3bdd7-b093-4bfd-8a9a-965e72bfefb3.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -10037,7 +10037,7 @@
         },
         {
             "id": "66373335-28d6-53e4-abd9-d2f69976ac62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd768c3-f278-41f8-b329-8403391d6326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd768c3-f278-41f8-b329-8403391d6326.jpg?1",
             "name": "Thopter",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "689f3fc1-adb2-5cbe-9f22-65d4b99d5dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559f9f3-eff0-465d-93c1-e875a8afe87f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559f9f3-eff0-465d-93c1-e875a8afe87f.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10098,7 +10098,7 @@
         },
         {
             "id": "9d6edd76-8452-5786-b276-7b93f3795897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44717d19-d8c2-45ba-9904-00c0c79ee0c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44717d19-d8c2-45ba-9904-00c0c79ee0c3.jpg?1",
             "name": "Domri, Chaos Bringer Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ROE.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ROE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ceeeaa92-ff8e-5943-8842-3bb7efa6b673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dba377-7446-4517-a504-ee04568fd6cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dba377-7446-4517-a504-ee04568fd6cf.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all colored permanents he or she controls.",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "6f2e877f-e72b-5254-b016-d178324e6a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac80eb8-321d-476a-87e7-d25bdac6a91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac80eb8-321d-476a-87e7-d25bdac6a91c.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast Artisan of Kozilek, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "f0700782-7ba6-5ed1-858a-e04100a000b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f26fb7-43cc-4a3b-8ba3-b90101c8ee3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f26fb7-43cc-4a3b-8ba3-b90101c8ee3a.jpg?1",
             "name": "Eldrazi Conscription",
             "text": "Enchant creature\nEnchanted creature gets +10/+10 and has trample and annihilator 2. (Whenever it attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "644a5c05-371f-507d-83a3-aa54c76f8436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67600383-bbb8-411c-b8e6-2296650bc747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67600383-bbb8-411c-b8e6-2296650bc747.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "Emrakul, the Aeons Torn can't be countered.\nWhen you cast Emrakul, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -129,7 +129,7 @@
         },
         {
             "id": "29f4faa8-a65e-5e61-8ef3-43707d1c72c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d602f4-5876-416a-95e5-821a285358bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d602f4-5876-416a-95e5-821a285358bf.jpg?1",
             "name": "Hand of Emrakul",
             "text": "You may sacrifice four Eldrazi Spawn rather than pay Hand of Emrakul's mana cost.\nAnnihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)",
             "colours": [],
@@ -159,7 +159,7 @@
         },
         {
             "id": "5af77709-cb2e-5494-baf9-89ac2d6e95da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fac91-2483-4678-b86a-2c54a3a480cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/067fac91-2483-4678-b86a-2c54a3a480cf.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast Kozilek, Butcher of Truth, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -191,7 +191,7 @@
         },
         {
             "id": "b5d65681-69ee-5068-b0fa-f34ffa85ad88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d790ad-3559-4c32-9057-e2e326740bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d790ad-3559-4c32-9057-e2e326740bdc.jpg?1",
             "name": "It That Betrays",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nWhenever an opponent sacrifices a nontoken permanent, put that card onto the battlefield under your control.",
             "colours": [],
@@ -221,7 +221,7 @@
         },
         {
             "id": "1c047837-e79f-52bc-8d48-3938e4ddacaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569e2c39-7a49-4a3b-afe5-1862a7da8026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569e2c39-7a49-4a3b-afe5-1862a7da8026.jpg?1",
             "name": "Not of This World",
             "text": "Counter target spell or ability that targets a permanent you control.\nNot of This World costs {7} less to cast if it targets a spell or ability that targets a creature you control with power 7 or greater.",
             "colours": [],
@@ -252,7 +252,7 @@
         },
         {
             "id": "0858b6af-64a4-548c-a6c3-2c6164f68562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd84b5-fd93-483e-a131-028d04d9dea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fdd84b5-fd93-483e-a131-028d04d9dea7.jpg?1",
             "name": "Pathrazer of Ulamog",
             "text": "Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents.)\nPathrazer of Ulamog can't be blocked except by three or more creatures.",
             "colours": [],
@@ -282,7 +282,7 @@
         },
         {
             "id": "c499f072-6654-50a2-89e1-5549266f11bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270f0e5b-2c46-4816-a195-cfce16570bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270f0e5b-2c46-4816-a195-cfce16570bde.jpg?1",
             "name": "Skittering Invasion",
             "text": "Put five 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [],
@@ -313,7 +313,7 @@
         },
         {
             "id": "841e58c4-8cc7-5f4c-a6b0-0177e3d48b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff46819-bfb3-4448-ab4f-f22ff9e2b2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff46819-bfb3-4448-ab4f-f22ff9e2b2b4.jpg?1",
             "name": "Spawnsire of Ulamog",
             "text": "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\n{4}: Put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"\n{2}0: Cast any number of Eldrazi cards you own from outside the game without paying their mana costs.",
             "colours": [],
@@ -343,7 +343,7 @@
         },
         {
             "id": "02c5da97-edd3-56a7-8686-e5a92e51672e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225e3cc6-34d0-4f81-9f49-162d97e2ea59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225e3cc6-34d0-4f81-9f49-162d97e2ea59.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast Ulamog, the Infinite Gyre, destroy target permanent.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nUlamog is indestructible.\nWhen Ulamog is put into a graveyard from anywhere, its owner shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -375,7 +375,7 @@
         },
         {
             "id": "e6d66504-1737-5eb1-9264-d12a9e8bea9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bacedb-9fa8-4a21-b0eb-e7ead64360b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bacedb-9fa8-4a21-b0eb-e7ead64360b4.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each turn if able.",
             "colours": [],
@@ -405,7 +405,7 @@
         },
         {
             "id": "eaa2e6b5-33f1-5afb-8af0-b378160f6c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85623f54-1c18-4b1e-a8da-df66de3832a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85623f54-1c18-4b1e-a8da-df66de3832a6.jpg?1",
             "name": "Affa Guard Hound",
             "text": "Flash\nWhen Affa Guard Hound enters the battlefield, target creature gets +0/+3 until end of turn.",
             "colours": [
@@ -439,7 +439,7 @@
         },
         {
             "id": "04adfada-5fa1-504b-afe4-ae9e2f1881a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8452b0b7-8157-4a3f-8bef-a34e322b9463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8452b0b7-8157-4a3f-8bef-a34e322b9463.jpg?1",
             "name": "Caravan Escort",
             "text": "Level up {2} ({2}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n2/2\n\nLEVEL 5+\n5/5\nFirst strike",
             "colours": [
@@ -474,7 +474,7 @@
         },
         {
             "id": "1c1f989e-7669-5c7d-ae6f-888c2f042daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e255235f-9e0c-44c0-b903-47af24d87d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e255235f-9e0c-44c0-b903-47af24d87d1f.jpg?1",
             "name": "Dawnglare Invoker",
             "text": "Flying\n{8}: Tap all creatures target player controls.",
             "colours": [
@@ -509,7 +509,7 @@
         },
         {
             "id": "9aa90a10-16f4-5564-adbd-5fb0fd2e37f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg?1",
             "name": "Deathless Angel",
             "text": "Flying\n{W}{W}: Target creature is indestructible this turn.",
             "colours": [
@@ -543,7 +543,7 @@
         },
         {
             "id": "3de93dce-a2b5-5a85-8880-d6f81e2cc707",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e109007a-9d4a-4a6d-bf97-edadb9a1c745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e109007a-9d4a-4a6d-bf97-edadb9a1c745.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "20230f94-a434-599c-85d5-0554d8fb79d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a2ec16-bee4-4dfd-81cb-cb81b017170c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a2ec16-bee4-4dfd-81cb-cb81b017170c.jpg?1",
             "name": "Eland Umbra",
             "text": "Enchant creature\nEnchanted creature gets +0/+4.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "826cbf1f-0bc2-5fbd-922e-d0af8f9f5687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23013b-4202-45c1-a756-b9a8c5a9dc05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c23013b-4202-45c1-a756-b9a8c5a9dc05.jpg?1",
             "name": "Emerge Unscathed",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -641,7 +641,7 @@
         },
         {
             "id": "f40f60aa-45b4-57e4-b2ae-b75496012d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0440668-1b0e-437c-9e42-7166dd14dfe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0440668-1b0e-437c-9e42-7166dd14dfe5.jpg?1",
             "name": "Gideon Jura",
             "text": "+2: During target opponent's next turn, creatures that player controls attack Gideon Jura if able.\n-2: Destroy target tapped creature.\n0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "a0677cf6-118d-55a2-bf42-265f3c3694a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5a3110-0081-4dee-b7b1-597dfd568eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5a3110-0081-4dee-b7b1-597dfd568eed.jpg?1",
             "name": "Glory Seeker",
             "text": "",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "efe76751-4a89-5834-92c1-8685b1b19b94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77efd36-f9e7-4c34-a6ee-9e1c9b273fb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77efd36-f9e7-4c34-a6ee-9e1c9b273fb7.jpg?1",
             "name": "Guard Duty",
             "text": "Enchant creature\nEnchanted creature has defender.",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "7108201e-8661-5f2f-a7e4-f407c048d395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77fef2c-227e-474e-896e-c0ebe227f494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77fef2c-227e-474e-896e-c0ebe227f494.jpg?1",
             "name": "Harmless Assault",
             "text": "Prevent all combat damage that would be dealt this turn by attacking creatures.",
             "colours": [
@@ -778,7 +778,7 @@
         },
         {
             "id": "080da8f4-975c-5298-aba8-ae17babfd401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48e9f90-4b13-4281-943c-126be4ff1ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48e9f90-4b13-4281-943c-126be4ff1ce0.jpg?1",
             "name": "Hedron-Field Purists",
             "text": "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n1/4\nIf a source would deal damage to you or a creature you control, prevent 1 of that damage.\nLEVEL 5+\n2/5\nIf a source would deal damage to you or a creature you control, prevent 2 of that damage.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "888e0ae2-e190-51c2-8e0f-e87eb0309320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1461e2f-fb1d-4092-9935-4cee092f27e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1461e2f-fb1d-4092-9935-4cee092f27e7.jpg?1",
             "name": "Hyena Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has first strike.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "8826dccd-4188-50f5-b4be-2b1dd5c46bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1532b1-6f3b-48d3-ada9-ec395e842b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e1532b1-6f3b-48d3-ada9-ec395e842b96.jpg?1",
             "name": "Ikiral Outrider",
             "text": "Level up {4} ({4}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n2/6\nVigilance\nLEVEL 4+\n3/10\nVigilance",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "bf232a80-2961-5780-bc5a-faa82b1205c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31551a-ab7a-4e49-b545-77afb3be72d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d31551a-ab7a-4e49-b545-77afb3be72d3.jpg?1",
             "name": "Kabira Vindicator",
             "text": "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-4\n3/6\nOther creatures you control get +1/+1.\nLEVEL 5+\n4/8\nOther creatures you control get +2/+2.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "e19e3d0f-bb66-5ac0-8609-f26ebb6d445f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8332e9-7b02-4d58-b081-11004e690524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8332e9-7b02-4d58-b081-11004e690524.jpg?1",
             "name": "Knight of Cliffhaven",
             "text": "Level up {3} ({3}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n2/3\nFlying\nLEVEL 4+\n4/4\nFlying, vigilance",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "cd7d0aaa-4f23-5b25-aeae-f9c77be2f6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068943d2-c456-42a3-8088-3e4923bf6d74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068943d2-c456-42a3-8088-3e4923bf6d74.jpg?1",
             "name": "Kor Line-Slinger",
             "text": "{T}: Tap target creature with power 3 or less.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "5d9d3bd2-7aa7-579e-94d0-e86a4332e2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03066fa1-ea16-4a87-9218-120efa976909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03066fa1-ea16-4a87-9218-120efa976909.jpg?1",
             "name": "Kor Spiritdancer",
             "text": "Kor Spiritdancer gets +2/+2 for each Aura attached to it.\nWhenever you cast an Aura spell, you may draw a card.",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "4c3ba2f9-8dd9-5fc0-a100-990a18659292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602b52a-5904-4780-9192-72990d07c975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5602b52a-5904-4780-9192-72990d07c975.jpg?1",
             "name": "Lightmine Field",
             "text": "Whenever one or more creatures attack, Lightmine Field deals damage to each of those creatures equal to the number of attacking creatures.",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "2048b59f-351c-5fd3-a8f1-63ff60637f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b80a09-7e75-4091-a60e-04aff79339a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b80a09-7e75-4091-a60e-04aff79339a3.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "Flying\nActivated abilities of creatures your opponents control can't be activated.",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "0d25af92-1bd9-5bd3-ab95-821c0e6a809a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc00f4b-ca9a-468a-91e1-c81fe6585765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdc00f4b-ca9a-468a-91e1-c81fe6585765.jpg?1",
             "name": "Lone Missionary",
             "text": "When Lone Missionary enters the battlefield, you gain 4 life.",
             "colours": [
@@ -1125,7 +1125,7 @@
         },
         {
             "id": "90e79abf-7e35-54a5-9b7e-106a03638ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d5a36-cc29-47fc-bdf7-b753f3bc5197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d5a36-cc29-47fc-bdf7-b753f3bc5197.jpg?1",
             "name": "Luminous Wake",
             "text": "Enchant creature\nWhenever enchanted creature attacks or blocks, you gain 4 life.",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "a63fbfdb-1e98-5fe7-a4bb-f7ff27378064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f839a5e-3cbb-4179-9267-02f40645bdbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f839a5e-3cbb-4179-9267-02f40645bdbc.jpg?1",
             "name": "Makindi Griffin",
             "text": "Flying",
             "colours": [
@@ -1193,7 +1193,7 @@
         },
         {
             "id": "dc40e345-1fb2-51de-856e-499d480528fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f1abef-385d-4202-8a45-835c37c4e242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f1abef-385d-4202-8a45-835c37c4e242.jpg?1",
             "name": "Mammoth Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has vigilance.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1227,7 +1227,7 @@
         },
         {
             "id": "1f5508d2-e8bd-538d-8e78-a7fe635266ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d61706-f9c1-4590-8057-7aa7fa199e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d61706-f9c1-4590-8057-7aa7fa199e6d.jpg?1",
             "name": "Near-Death Experience",
             "text": "At the beginning of your upkeep, if you have exactly 1 life, you win the game.",
             "colours": [
@@ -1259,7 +1259,7 @@
         },
         {
             "id": "e4163f8c-6b86-54d0-804b-95225e58a98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52f249-14bd-4489-aaba-03e50fe42c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd52f249-14bd-4489-aaba-03e50fe42c2e.jpg?1",
             "name": "Nomads' Assembly",
             "text": "Put a 1/1 white Kor Soldier creature token onto the battlefield for each creature you control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1291,7 +1291,7 @@
         },
         {
             "id": "b0ba5a24-8ef1-588c-a552-2732634750cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07313dd3-d0dc-40ca-98a3-fa4d39e5bcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07313dd3-d0dc-40ca-98a3-fa4d39e5bcae.jpg?1",
             "name": "Oust",
             "text": "Put target creature into its owner's library second from the top. Its controller gains 3 life.",
             "colours": [
@@ -1323,7 +1323,7 @@
         },
         {
             "id": "ab689654-26a9-5c8e-9d6f-9a960e2cb0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d260a-e1ca-4228-855e-2e104b86fd6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52d260a-e1ca-4228-855e-2e104b86fd6c.jpg?1",
             "name": "Puncturing Light",
             "text": "Destroy target attacking or blocking creature with power 3 or less.",
             "colours": [
@@ -1355,7 +1355,7 @@
         },
         {
             "id": "5d44176f-6306-5f80-b796-e91d92167b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fa47c3-3209-4e01-920a-aed2184520c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fa47c3-3209-4e01-920a-aed2184520c2.jpg?1",
             "name": "Repel the Darkness",
             "text": "Tap up to two target creatures.\nDraw a card.",
             "colours": [
@@ -1387,7 +1387,7 @@
         },
         {
             "id": "3029b331-18fd-511c-8863-706f324f6b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2698f01a-8574-4ae8-9441-a4361b1c29c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2698f01a-8574-4ae8-9441-a4361b1c29c6.jpg?1",
             "name": "Smite",
             "text": "Destroy target blocked creature.",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "6f016fc1-21ac-5382-a060-5996397df1a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3223c0ac-cc22-4886-8919-11273b477cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3223c0ac-cc22-4886-8919-11273b477cc7.jpg?1",
             "name": "Soul's Attendant",
             "text": "Whenever another creature enters the battlefield, you may gain 1 life.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "118942c9-6602-5c1e-ab9e-f97dc0e2c9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e8128f-9858-4c48-ab43-1beca3db70e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e8128f-9858-4c48-ab43-1beca3db70e5.jpg?1",
             "name": "Soulbound Guardians",
             "text": "Defender, flying",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "c85b7ce2-3ba6-5d32-8b2e-5bbc2c3ecc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868256bb-d4e2-42eb-a43a-360148aec06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/868256bb-d4e2-42eb-a43a-360148aec06f.jpg?1",
             "name": "Stalwart Shield-Bearers",
             "text": "Defender\nOther creatures you control with defender get +0/+2.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "67367dca-2d31-5d5e-8f38-2bcfa3e47caf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4df9be-324b-458a-9379-ab4aa437a6d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4df9be-324b-458a-9379-ab4aa437a6d2.jpg?1",
             "name": "Student of Warfare",
             "text": "Level up {W} ({W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-6\n3/3\nFirst strike\nLEVEL 7+\n4/4\nDouble strike",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "d5475175-b171-5cef-8d2b-11b57352e28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4333f864-6b1c-4720-b2d6-490d5c7b31a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4333f864-6b1c-4720-b2d6-490d5c7b31a1.jpg?1",
             "name": "Survival Cache",
             "text": "You gain 2 life. Then if you have more life than an opponent, draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "559717cd-72b9-585d-8943-ff4512b37c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f70224d-e723-436d-8493-dcec5049f1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f70224d-e723-436d-8493-dcec5049f1a0.jpg?1",
             "name": "Time of Heroes",
             "text": "Each creature you control with a level counter on it gets +2/+2.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "ef98060a-60ed-50de-ae22-950fdf21152f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1364a830-36b7-48b9-bf69-6fd35eed9399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1364a830-36b7-48b9-bf69-6fd35eed9399.jpg?1",
             "name": "Totem-Guide Hartebeest",
             "text": "When Totem-Guide Hartebeest enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "5199914a-6c45-5263-82b9-fa811584b15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b007f42-9ec2-466b-8d6b-1d55c516080b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b007f42-9ec2-466b-8d6b-1d55c516080b.jpg?1",
             "name": "Transcendent Master",
             "text": "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 6-11\n6/6\nLifelink\nLEVEL 12+\n9/9\nLifelink\nTranscendent Master is indestructible.",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "c27aa762-f53c-5fd5-b5ea-db33f5f8d31a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55705d3-8640-478e-ace4-f4f900d617c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55705d3-8640-478e-ace4-f4f900d617c5.jpg?1",
             "name": "Umbra Mystic",
             "text": "Auras attached to permanents you control have totem armor. (If an enchanted permanent you control would be destroyed, instead remove all damage from it and destroy an Aura attached to it.)",
             "colours": [
@@ -1728,7 +1728,7 @@
         },
         {
             "id": "1d24cdaa-6da9-519b-b818-252af3935e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3510f5-e450-400b-98ea-341dbf212054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e3510f5-e450-400b-98ea-341dbf212054.jpg?1",
             "name": "Wall of Omens",
             "text": "Defender\nWhen Wall of Omens enters the battlefield, draw a card.",
             "colours": [
@@ -1762,7 +1762,7 @@
         },
         {
             "id": "8db3d175-201e-5ec7-b91a-3e0ce14a4820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e398a02-1456-4fae-be75-4231c968bf47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e398a02-1456-4fae-be75-4231c968bf47.jpg?1",
             "name": "Aura Finesse",
             "text": "Attach target Aura you control to target creature.\nDraw a card.",
             "colours": [
@@ -1794,7 +1794,7 @@
         },
         {
             "id": "5e31c03a-7c6b-58ec-8354-4d063621f464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9850489-c056-4b17-8743-a5b514d8edf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9850489-c056-4b17-8743-a5b514d8edf4.jpg?1",
             "name": "Cast Through Time",
             "text": "Instant and sorcery spells you control have rebound. (Exile the spell as it resolves if you cast it from your hand. At the beginning of your next upkeep, you may cast that card from exile without paying its mana cost.)",
             "colours": [
@@ -1826,7 +1826,7 @@
         },
         {
             "id": "ffbd1c75-65cc-5175-9130-7bcec50b0f67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7585316f-ba3d-4472-9a7e-7db6f6dd9d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7585316f-ba3d-4472-9a7e-7db6f6dd9d15.jpg?1",
             "name": "Champion's Drake",
             "text": "Flying\nChampion's Drake gets +3/+3 as long as you control a creature with three or more level counters on it.",
             "colours": [
@@ -1860,7 +1860,7 @@
         },
         {
             "id": "24fd524e-c6ca-560c-a94b-82ea273fb72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d1bea-58cd-4483-a70a-0330ad5ab4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8d1bea-58cd-4483-a70a-0330ad5ab4a1.jpg?1",
             "name": "Coralhelm Commander",
             "text": "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n3/3\nFlying\nLEVEL 4+\n4/4\nFlying\nOther Merfolk creatures you control get +1/+1.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "85b0ef54-77e7-5fb5-bf98-d9d8062a7a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe6e1ce-bc46-4f86-9504-f8cc062ed3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fe6e1ce-bc46-4f86-9504-f8cc062ed3c6.jpg?1",
             "name": "Crab Umbra",
             "text": "Enchant creature\n{2}{U}: Untap enchanted creature.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "27400ded-49ba-5290-a2fa-e886f2baa23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efecdd9-bd3a-4b79-92da-6485589d5bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efecdd9-bd3a-4b79-92da-6485589d5bde.jpg?1",
             "name": "Deprive",
             "text": "As an additional cost to cast Deprive, return a land you control to its owner's hand.\nCounter target spell.",
             "colours": [
@@ -1961,7 +1961,7 @@
         },
         {
             "id": "2bd345d7-6fa7-56f8-9861-fc14eb3c1229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315f1cf8-7bde-4592-a14e-ef9e2e3e7ac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315f1cf8-7bde-4592-a14e-ef9e2e3e7ac0.jpg?1",
             "name": "Distortion Strike",
             "text": "Target creature gets +1/+0 until end of turn and is unblockable this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -1993,7 +1993,7 @@
         },
         {
             "id": "b50cb42e-16c6-5c11-b0a6-154b658e03d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f15831-8dfd-4232-875c-efa6744c9a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f15831-8dfd-4232-875c-efa6744c9a12.jpg?1",
             "name": "Domestication",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your end step, if enchanted creature's power is 4 or greater, sacrifice Domestication.",
             "colours": [
@@ -2027,7 +2027,7 @@
         },
         {
             "id": "7ea99336-7f00-5b1b-953a-05ba55a8c6fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131d2925-d87c-415f-aa84-97f14030624e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131d2925-d87c-415f-aa84-97f14030624e.jpg?1",
             "name": "Dormant Gomazoa",
             "text": "Flying\nDormant Gomazoa enters the battlefield tapped.\nDormant Gomazoa doesn't untap during your untap step.\nWhenever you become the target of a spell, you may untap Dormant Gomazoa.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "468cc1ae-4264-571e-ade8-ca359f459ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f7334-658d-44da-a81c-26b258e44c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1f7334-658d-44da-a81c-26b258e44c26.jpg?1",
             "name": "Drake Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has flying.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "4898f809-5f39-50bc-8474-35fbbec7e167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb327b4-01b0-468c-9916-129c7c64341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb327b4-01b0-468c-9916-129c7c64341d.jpg?1",
             "name": "Echo Mage",
             "text": "Level up {1}{U} ({1}{U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n2/4\n{U}{U}, {T}: Copy target instant or sorcery spell. You may choose new targets for the copy.\nLEVEL 4+\n2/5\n{U}{U}, {T}: Copy target instant or sorcery spell twice. You may choose new targets for the copies.",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "b3336c47-c42f-5c14-994e-705bfff35868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca550605-a0fc-4392-b8b6-a4f06868d9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca550605-a0fc-4392-b8b6-a4f06868d9f2.jpg?1",
             "name": "Eel Umbra",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +1/+1.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -2164,7 +2164,7 @@
         },
         {
             "id": "ffe14e5f-5e65-5fd3-9f29-fa291ce7d390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d3b541-40aa-469e-be97-20496a7632d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d3b541-40aa-469e-be97-20496a7632d4.jpg?1",
             "name": "Enclave Cryptologist",
             "text": "Level up {1}{U} ({1}{U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n0/1\n{T}: Draw a card, then discard a card.\nLEVEL 3+\n0/1\n{T}: Draw a card.",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "b95cd3ac-9e14-51dc-9930-8480464e64b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed843c4d-28b5-4a4c-8bae-8f03f329bf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed843c4d-28b5-4a4c-8bae-8f03f329bf2b.jpg?1",
             "name": "Fleeting Distraction",
             "text": "Target creature gets -1/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -2231,7 +2231,7 @@
         },
         {
             "id": "f6d3228c-ad04-56fb-861d-2577720b8ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ec9a28-3b36-4b6a-b420-7b4266b64f69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ec9a28-3b36-4b6a-b420-7b4266b64f69.jpg?1",
             "name": "Frostwind Invoker",
             "text": "Flying\n{8}: Creatures you control gain flying until end of turn.",
             "colours": [
@@ -2266,7 +2266,7 @@
         },
         {
             "id": "6c15804c-0d94-5f93-b37c-2440c10486b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg?1",
             "name": "Gravitational Shift",
             "text": "Creatures with flying get +2/+0.\nCreatures without flying get -2/-0.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "f58e406c-b010-5d2a-a00a-313b5122fcaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523e59a-91f7-4893-a4fe-8814a745b422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0523e59a-91f7-4893-a4fe-8814a745b422.jpg?1",
             "name": "Guard Gomazoa",
             "text": "Defender, flying\nPrevent all combat damage that would be dealt to Guard Gomazoa.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "f05c33b1-f344-5ea4-936a-1b85e82f3b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb6af-1727-4fa9-938f-13962efadd74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb6af-1727-4fa9-938f-13962efadd74.jpg?1",
             "name": "Hada Spy Patrol",
             "text": "Level up {2}{U} ({2}{U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n2/2\nHada Spy Patrol is unblockable.\nLEVEL 3+\n3/3\nShroud\nHada Spy Patrol is unblockable.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "dd1dbf66-b43b-5d0b-a485-9a8a73f62027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff68d2f-6758-45ee-8109-4e8909f49de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff68d2f-6758-45ee-8109-4e8909f49de8.jpg?1",
             "name": "Halimar Wavewatch",
             "text": "Level up {2} ({2}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n0/6\n\nLEVEL 5+\n6/6\nIslandwalk",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "1f6d50b3-7cfd-518f-ad6b-46e4914b3c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04129038-3b02-418a-862a-229e9dde339b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04129038-3b02-418a-862a-229e9dde339b.jpg?1",
             "name": "Jwari Scuttler",
             "text": "",
             "colours": [
@@ -2436,7 +2436,7 @@
         },
         {
             "id": "8a222f2f-906e-597a-aa28-8d8ee47b069e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0454c2a8-b17d-4cdf-8562-9a28bc6cf0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0454c2a8-b17d-4cdf-8562-9a28bc6cf0be.jpg?1",
             "name": "Lay Bare",
             "text": "Counter target spell. Look at its controller's hand.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "d54a7f1c-9bd9-51fa-ba81-bc947048c4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3087f7e7-9163-45b5-907d-7667c1075a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3087f7e7-9163-45b5-907d-7667c1075a74.jpg?1",
             "name": "Lighthouse Chronologist",
             "text": "Level up {U} ({U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 4-6\n2/4\n\nLEVEL 7+\n3/5\nAt the beginning of each end step, if it's not your turn, take an extra turn after this one.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "4f51809c-9f24-5342-a3fe-4e833b680092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fa8c72-320b-4a7e-9181-bad7ec0c865c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16fa8c72-320b-4a7e-9181-bad7ec0c865c.jpg?1",
             "name": "Merfolk Observer",
             "text": "When Merfolk Observer enters the battlefield, look at the top card of target player's library.",
             "colours": [
@@ -2538,7 +2538,7 @@
         },
         {
             "id": "bf998952-3358-5352-ade7-8754c34d2c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce213c7-7835-4b81-a983-059dd97b0214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce213c7-7835-4b81-a983-059dd97b0214.jpg?1",
             "name": "Merfolk Skyscout",
             "text": "Flying\nWhenever Merfolk Skyscout attacks or blocks, untap target permanent.",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "0a513dae-62ec-52e5-b486-5fd84abec5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaebb4a-cb9b-4ac8-b661-3e63d9d984f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaebb4a-cb9b-4ac8-b661-3e63d9d984f4.jpg?1",
             "name": "Mnemonic Wall",
             "text": "Defender\nWhen Mnemonic Wall enters the battlefield, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2607,7 +2607,7 @@
         },
         {
             "id": "477e0ae4-6441-5bf4-8ef8-bc5a6fb60751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88e502e-2421-46fb-b880-a9000930e6d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88e502e-2421-46fb-b880-a9000930e6d9.jpg?1",
             "name": "Narcolepsy",
             "text": "Enchant creature\nAt the beginning of each upkeep, if enchanted creature is untapped, tap it.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "21d4b1f0-0658-562c-8e09-68227fa24233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d9c83f-ddd2-4929-887f-9df6155c4b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d9c83f-ddd2-4929-887f-9df6155c4b82.jpg?1",
             "name": "Phantasmal Abomination",
             "text": "Defender\nWhen Phantasmal Abomination becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "3bfcf047-e615-5c2d-9472-29347e998291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec85a97d-4f02-4d0d-ab9a-e172e327da0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec85a97d-4f02-4d0d-ab9a-e172e327da0e.jpg?1",
             "name": "Reality Spasm",
             "text": "Choose one \u2014 Tap X target permanents; or untap X target permanents.",
             "colours": [
@@ -2707,7 +2707,7 @@
         },
         {
             "id": "d1254d85-f424-57a7-81b4-d2f1b2f469a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db92d00c-e5eb-4e69-9ebc-fec6d9c0f71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db92d00c-e5eb-4e69-9ebc-fec6d9c0f71e.jpg?1",
             "name": "Recurring Insight",
             "text": "Draw cards equal to the number of cards in target opponent's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -2739,7 +2739,7 @@
         },
         {
             "id": "b396c136-3377-50e5-a7ae-9edf1beec64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7aba8e0-34e7-43ec-bce5-b6b472daa841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7aba8e0-34e7-43ec-bce5-b6b472daa841.jpg?1",
             "name": "Regress",
             "text": "Return target permanent to its owner's hand.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "db15c2c2-9635-5c96-8768-c41657aec271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6453040-38a3-4d3a-8e4b-51b72aa80186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6453040-38a3-4d3a-8e4b-51b72aa80186.jpg?1",
             "name": "Renegade Doppelganger",
             "text": "Whenever another creature enters the battlefield under your control, you may have Renegade Doppelganger become a copy of that creature until end of turn. (If it does, it loses this ability for the rest of the turn.)",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "43482d97-1431-5c9b-80ab-4e6edf905ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd056c91-5026-41ea-bc9e-68078d78ca82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd056c91-5026-41ea-bc9e-68078d78ca82.jpg?1",
             "name": "Sea Gate Oracle",
             "text": "When Sea Gate Oracle enters the battlefield, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "39f6d895-4f39-54d9-bc6b-5602f5af900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7242e6e-b2e6-42f5-b611-3e8e0dfc0b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7242e6e-b2e6-42f5-b611-3e8e0dfc0b6b.jpg?1",
             "name": "See Beyond",
             "text": "Draw two cards, then shuffle a card from your hand into your library.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "bea58510-a620-50d1-87ec-97c9f28c7103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0b99f1-d706-4332-a1c2-86d789919069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0b99f1-d706-4332-a1c2-86d789919069.jpg?1",
             "name": "Shared Discovery",
             "text": "As an additional cost to cast Shared Discovery, tap four untapped creatures you control.\nDraw three cards.",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "c684724c-48ff-52b1-89ba-ee8272997d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be61e893-4bf5-4550-83f4-42ebe7f1e3b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be61e893-4bf5-4550-83f4-42ebe7f1e3b0.jpg?1",
             "name": "Skywatcher Adept",
             "text": "Level up {3} ({3}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n2/2\nFlying\nLEVEL 3+\n4/2\nFlying",
             "colours": [
@@ -2939,7 +2939,7 @@
         },
         {
             "id": "83212856-03ac-53d7-ad21-a9f77c141b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff88609-f55e-45c5-be10-087d88789a83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff88609-f55e-45c5-be10-087d88789a83.jpg?1",
             "name": "Sphinx of Magosi",
             "text": "Flying\n{2}{U}: Draw a card, then put a +1/+1 counter on Sphinx of Magosi.",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "9192d5cd-abb3-5f0a-9263-7a78bfd813bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4199be-e1ec-4f0e-a31f-29a7007128a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4199be-e1ec-4f0e-a31f-29a7007128a5.jpg?1",
             "name": "Surrakar Spellblade",
             "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Surrakar Spellblade.\nWhenever Surrakar Spellblade deals combat damage to a player, you may draw X cards, where X is the number of charge counters on it.",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "49e82b1f-b3d1-5440-b1ee-cd05e3f74318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cf16f8-6e69-46b3-8453-1d1a2a5670e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cf16f8-6e69-46b3-8453-1d1a2a5670e2.jpg?1",
             "name": "Training Grounds",
             "text": "Activated abilities of creatures you control cost up to {2} less to activate. This effect can't reduce the amount of mana an ability costs to activate to less than one mana.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "ac67c7fd-c8bd-517e-8d9f-836b2e6b95aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb50db7-f1d4-4f9d-ac60-564398af79ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cb50db7-f1d4-4f9d-ac60-564398af79ea.jpg?1",
             "name": "Unified Will",
             "text": "Counter target spell if you control more creatures than that spell's controller.",
             "colours": [
@@ -3071,7 +3071,7 @@
         },
         {
             "id": "84c25a3c-051a-5309-805f-7634208f2359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec4d902-8841-4f37-9b07-9e8d0f671071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec4d902-8841-4f37-9b07-9e8d0f671071.jpg?1",
             "name": "Venerated Teacher",
             "text": "When Venerated Teacher enters the battlefield, put two level counters on each creature you control with level up.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "4c6487c2-24c4-514c-927f-9dbe205e8385",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed08a7f-6682-46a4-89df-b9b418df3f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed08a7f-6682-46a4-89df-b9b418df3f1a.jpg?1",
             "name": "Arrogant Bloodlord",
             "text": "Whenever Arrogant Bloodlord blocks or becomes blocked by a creature with power 1 or less, destroy Arrogant Bloodlord at end of combat.",
             "colours": [
@@ -3141,7 +3141,7 @@
         },
         {
             "id": "54c47d6d-fc4c-5f6d-87b9-ed8936778565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acb66bd-6abd-46dd-a272-09bea66e2917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acb66bd-6abd-46dd-a272-09bea66e2917.jpg?1",
             "name": "Bala Ged Scorpion",
             "text": "When Bala Ged Scorpion enters the battlefield, you may destroy target creature with power 1 or less.",
             "colours": [
@@ -3175,7 +3175,7 @@
         },
         {
             "id": "bfc318a1-0396-5e27-acc0-6af7fe460fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff6e03-b6af-4f54-b365-9a6db2dbb595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bff6e03-b6af-4f54-b365-9a6db2dbb595.jpg?1",
             "name": "Baneful Omen",
             "text": "At the beginning of your end step, you may reveal the top card of your library. If you do, each opponent loses life equal to that card's converted mana cost.",
             "colours": [
@@ -3207,7 +3207,7 @@
         },
         {
             "id": "b1026154-2251-59f4-966b-ab1d0b967f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc36f94-2499-4d94-a506-27d42b9da667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dc36f94-2499-4d94-a506-27d42b9da667.jpg?1",
             "name": "Bloodrite Invoker",
             "text": "{8}: Target player loses 3 life and you gain 3 life.",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "674b0da5-4ac6-5548-8bd9-dc95311a383f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bf0233-1d2e-40cb-9a69-8eeeeb2959ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bf0233-1d2e-40cb-9a69-8eeeeb2959ca.jpg?1",
             "name": "Bloodthrone Vampire",
             "text": "Sacrifice a creature: Bloodthrone Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "6aebd0ee-f1bc-5d84-9cea-66c81d315ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f83d5-9269-4297-b507-558c2bdec32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2f83d5-9269-4297-b507-558c2bdec32b.jpg?1",
             "name": "Cadaver Imp",
             "text": "Flying\nWhen Cadaver Imp enters the battlefield, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "0bd7b3d1-e596-5d31-8ffd-46c930e48a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921ebea0-48bf-4338-9e84-2cd06ffe6f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/921ebea0-48bf-4338-9e84-2cd06ffe6f4b.jpg?1",
             "name": "Consume the Meek",
             "text": "Destroy each creature with converted mana cost 3 or less. They can't be regenerated.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "38c5da70-bde2-54cb-8539-fb237a728a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008de17e-aa79-4d4c-ab66-d516eca49e42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008de17e-aa79-4d4c-ab66-d516eca49e42.jpg?1",
             "name": "Consuming Vapors",
             "text": "Target player sacrifices a creature. You gain life equal to that creature's toughness.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "5ac95cfb-0700-512a-9087-136121d3dc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2ba8f3-58f5-43e5-9201-974ba58f56f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2ba8f3-58f5-43e5-9201-974ba58f56f8.jpg?1",
             "name": "Contaminated Ground",
             "text": "Enchant land\nEnchanted land is a Swamp.\nWhenever enchanted land becomes tapped, its controller loses 2 life.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "359c0f47-5d73-5cf1-a8b8-ef8db1cddf76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c152d-1829-438c-b571-74361e09df62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91c152d-1829-438c-b571-74361e09df62.jpg?1",
             "name": "Corpsehatch",
             "text": "Destroy target nonblack creature. Put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "a14d259f-0865-50f0-a603-af653a5617b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162535ea-87be-4ea7-a006-b63ae981f453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162535ea-87be-4ea7-a006-b63ae981f453.jpg?1",
             "name": "Curse of Wizardry",
             "text": "As Curse of Wizardry enters the battlefield, choose a color.\nWhenever a player casts a spell of the chosen color, that player loses 1 life.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "88b8fbaf-2a26-54ca-9296-6cc5552b2200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a2fe3-45ab-4bac-aca7-a6418e28d0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0a2fe3-45ab-4bac-aca7-a6418e28d0be.jpg?1",
             "name": "Death Cultist",
             "text": "Sacrifice Death Cultist: Target player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3507,7 +3507,7 @@
         },
         {
             "id": "9be799c9-85e9-544a-9930-1260cc409613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca51786a-d58c-455f-910d-01efa5ef8470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca51786a-d58c-455f-910d-01efa5ef8470.jpg?1",
             "name": "Demonic Appetite",
             "text": "Enchant creature you control\nEnchanted creature gets +3/+3.\nAt the beginning of your upkeep, sacrifice a creature.",
             "colours": [
@@ -3541,7 +3541,7 @@
         },
         {
             "id": "e118bda5-c585-5ce6-993f-b87c56d665f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca8d295-e8e9-4213-bc9b-f1acf57fb520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca8d295-e8e9-4213-bc9b-f1acf57fb520.jpg?1",
             "name": "Drana, Kalastria Bloodchief",
             "text": "Flying\n{X}{B}{B}: Target creature gets -0/-X until end of turn and Drana, Kalastria Bloodchief gets +X/+0 until end of turn.",
             "colours": [
@@ -3578,7 +3578,7 @@
         },
         {
             "id": "3bfa8c34-70fe-5ee2-9db5-7ea3b35c4b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d65339-e419-40b9-814a-374874f5585f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d65339-e419-40b9-814a-374874f5585f.jpg?1",
             "name": "Dread Drone",
             "text": "When Dread Drone enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "b4a2290b-8ab5-5114-84c4-fbd4b8d9fdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364dbe9-ee9a-4dcc-b058-4e669c75f060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7364dbe9-ee9a-4dcc-b058-4e669c75f060.jpg?1",
             "name": "Escaped Null",
             "text": "Lifelink\nWhenever Escaped Null blocks or becomes blocked, it gets +5/+0 until end of turn.",
             "colours": [
@@ -3648,7 +3648,7 @@
         },
         {
             "id": "9098564a-1082-5cd2-8b73-d088fa874843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf2116-7ae5-4b6a-830a-919a55235690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9cf2116-7ae5-4b6a-830a-919a55235690.jpg?1",
             "name": "Essence Feed",
             "text": "Target player loses 3 life. You gain 3 life and put three 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -3680,7 +3680,7 @@
         },
         {
             "id": "b84af5b4-acb4-5389-865b-8dc602d638cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db4317-9850-44c1-884b-d8d3abe1afeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98db4317-9850-44c1-884b-d8d3abe1afeb.jpg?1",
             "name": "Gloomhunter",
             "text": "Flying",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "3a89c619-691a-5926-807d-3c538aa2409b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de01ef-cdf2-44ad-bf2f-a927d82a4f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72de01ef-cdf2-44ad-bf2f-a927d82a4f72.jpg?1",
             "name": "Guul Draz Assassin",
             "text": "Level up {1}{B} ({1}{B}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n2/2\n{B}, {T}: Target creature gets -2/-2 until end of turn.\nLEVEL 4+\n4/4\n{B}, {T}: Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "afd18131-6d0a-55da-ba45-c88c7534562c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984a037b-63c0-497d-b3b1-15726ef11a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984a037b-63c0-497d-b3b1-15726ef11a60.jpg?1",
             "name": "Hellcarver Demon",
             "text": "Flying\nWhenever Hellcarver Demon deals combat damage to a player, sacrifice all other permanents you control and discard your hand. Exile the top six cards of your library. You may cast any number of nonland cards exiled this way without paying their mana costs.",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "03fd8773-3984-599d-bc1f-b53da722ce06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0c6980-a371-4cb5-b684-3ebddd4890f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0c6980-a371-4cb5-b684-3ebddd4890f8.jpg?1",
             "name": "Induce Despair",
             "text": "As an additional cost to cast Induce Despair, reveal a creature card from your hand.\nTarget creature gets -X/-X until end of turn, where X is the revealed card's converted mana cost.",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "a14f1e62-e4b9-517b-89a9-9bcc0fa65610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3ff5c3-0fdb-4d54-b4e5-ce7bad9953f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a3ff5c3-0fdb-4d54-b4e5-ce7bad9953f0.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "Target player reveals his or her hand. You choose a nonland card from it with converted mana cost 3 or less. That player discards that card.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "d40a907b-2cbd-5483-89fb-418e44757d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f480f-8f68-4060-b964-f67515930549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/348f480f-8f68-4060-b964-f67515930549.jpg?1",
             "name": "Last Kiss",
             "text": "Last Kiss deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "11d7ae93-b9c5-5e81-890a-5f6fc8884d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19ee3e4-5f76-4c28-bee6-f1c063ec0cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19ee3e4-5f76-4c28-bee6-f1c063ec0cb3.jpg?1",
             "name": "Mortician Beetle",
             "text": "Whenever a player sacrifices a creature, you may put a +1/+1 counter on Mortician Beetle.",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "47e901f1-026f-5ca9-9403-49770c56eb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290b215b-13cb-493a-83f9-f89edfa6b314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290b215b-13cb-493a-83f9-f89edfa6b314.jpg?1",
             "name": "Nighthaze",
             "text": "Target creature gains swampwalk until end of turn.\nDraw a card.",
             "colours": [
@@ -3945,7 +3945,7 @@
         },
         {
             "id": "bbd586c3-9668-56a8-8cee-9a9ebe483b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341f4ea1-8101-4e2e-b824-4b0e88ea71f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341f4ea1-8101-4e2e-b824-4b0e88ea71f1.jpg?1",
             "name": "Nirkana Cutthroat",
             "text": "Level up {2}{B} ({2}{B}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n4/3\nDeathtouch\nLEVEL 3+\n5/4\nFirst strike, deathtouch",
             "colours": [
@@ -3980,7 +3980,7 @@
         },
         {
             "id": "aea6cdba-3769-5f27-8f50-dde173af054a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7c53cf-d314-4f60-bb5b-cf5068ed9915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7c53cf-d314-4f60-bb5b-cf5068ed9915.jpg?1",
             "name": "Nirkana Revenant",
             "text": "Whenever you tap a Swamp for mana, add {B} to your mana pool (in addition to the mana the land produces).\n{B}: Nirkana Revenant gets +1/+1 until end of turn.",
             "colours": [
@@ -4015,7 +4015,7 @@
         },
         {
             "id": "1a098c93-4d08-5215-acba-b7ef0245c43d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf39e84-a554-49e3-8f65-e304e1720818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bf39e84-a554-49e3-8f65-e304e1720818.jpg?1",
             "name": "Null Champion",
             "text": "Level up {3} ({3}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n4/2\n\nLEVEL 4+\n7/3\n{B}: Regenerate Null Champion.",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "1471a0dd-b18d-5c1b-a848-3671e43e8082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4d77d-e0de-48fe-899b-5718cee779e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4d77d-e0de-48fe-899b-5718cee779e2.jpg?1",
             "name": "Pawn of Ulamog",
             "text": "Whenever Pawn of Ulamog or another nontoken creature you control is put into a graveyard from the battlefield, you may put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -4085,7 +4085,7 @@
         },
         {
             "id": "a8dbf36c-4609-5d79-9161-139bebdb97ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1dd413-6e5a-4e36-b1b0-eca39e132e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e1dd413-6e5a-4e36-b1b0-eca39e132e38.jpg?1",
             "name": "Perish the Thought",
             "text": "Target opponent reveals his or her hand. You choose a card from it. That player shuffles that card into his or her library.",
             "colours": [
@@ -4117,7 +4117,7 @@
         },
         {
             "id": "1ed83589-59d7-525a-9564-e8cddafb5aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6931673-20e0-410e-bc2a-d14efa2b488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6931673-20e0-410e-bc2a-d14efa2b488a.jpg?1",
             "name": "Pestilence Demon",
             "text": "Flying\n{B}: Pestilence Demon deals 1 damage to each creature and each player.",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "85066470-fc57-5bf4-8855-abd41df42110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d1db4c-1e79-410a-92ab-c9d58c5e58a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d1db4c-1e79-410a-92ab-c9d58c5e58a6.jpg?1",
             "name": "Repay in Kind",
             "text": "Each player's life total becomes the lowest life total among all players.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "85e5776c-8e33-5874-b70f-85e8a4b02321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c80a1-5818-45fd-9a37-a2ee3396626e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c80a1-5818-45fd-9a37-a2ee3396626e.jpg?1",
             "name": "Shrivel",
             "text": "All creatures get -1/-1 until end of turn.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "66095e06-f2c4-5fa4-9d70-b1d05595ae08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feedcf2-c443-4363-80cf-a90579a64342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2feedcf2-c443-4363-80cf-a90579a64342.jpg?1",
             "name": "Skeletal Wurm",
             "text": "{B}: Regenerate Skeletal Wurm.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "eed220a5-98a1-5df7-835c-0fc56a571543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e959ec-7ba2-429d-a5b9-b5e4d97dfd4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e959ec-7ba2-429d-a5b9-b5e4d97dfd4e.jpg?1",
             "name": "Suffer the Past",
             "text": "Exile X target cards from target player's graveyard. For each card exiled this way, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "2293ffd6-376b-57be-a6eb-7226d56661eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b6b512-6252-4899-bb9c-5c304f37d10a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b6b512-6252-4899-bb9c-5c304f37d10a.jpg?1",
             "name": "Thought Gorger",
             "text": "Trample\nWhen Thought Gorger enters the battlefield, put a +1/+1 counter on it for each card in your hand. If you do, discard your hand.\nWhen Thought Gorger leaves the battlefield, draw a card for each +1/+1 counter on it.",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "ef3f0e10-1d09-5ef1-9f6a-40f643a818bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039fc76d-3b7e-4329-a997-07c25509e421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039fc76d-3b7e-4329-a997-07c25509e421.jpg?1",
             "name": "Vendetta",
             "text": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "6adf4227-85dc-5774-bb38-cfe4b0f53008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61d7f4b-e3c3-49f1-a600-6e6ac71a5515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61d7f4b-e3c3-49f1-a600-6e6ac71a5515.jpg?1",
             "name": "Virulent Swipe",
             "text": "Target creature gets +2/+0 and gains deathtouch until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "925ad53b-623e-5b90-9c72-263011db74ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46976d4-7266-4359-bf7a-7e81983ae6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46976d4-7266-4359-bf7a-7e81983ae6e3.jpg?1",
             "name": "Zof Shade",
             "text": "{2}{B}: Zof Shade gets +2/+2 until end of turn.",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "7baba623-85cf-5357-bf9d-991f2582b87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975d18a-df3f-4c1f-8fde-d11dabbc4adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1975d18a-df3f-4c1f-8fde-d11dabbc4adc.jpg?1",
             "name": "Zulaport Enforcer",
             "text": "Level up {4} ({4}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n3/3\n\nLEVEL 3+\n5/5\nZulaport Enforcer can't be blocked except by black creatures.",
             "colours": [
@@ -4449,7 +4449,7 @@
         },
         {
             "id": "cb384cf2-4571-5696-8531-32b99247d458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e8f7b6-1214-447b-8665-ff3c85845564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e8f7b6-1214-447b-8665-ff3c85845564.jpg?1",
             "name": "Akoum Boulderfoot",
             "text": "When Akoum Boulderfoot enters the battlefield, it deals 1 damage to target creature or player.",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "694cc0ef-7fcc-5214-98a5-fd192cb31c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223ec005-e089-4dd4-85dc-2998bff56b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/223ec005-e089-4dd4-85dc-2998bff56b75.jpg?1",
             "name": "Battle Rampart",
             "text": "Defender\n{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "0c78e3e2-b4f0-5510-bcd2-918fe4e16132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1df08a-ccef-44cf-936a-838e238c27c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1df08a-ccef-44cf-936a-838e238c27c1.jpg?1",
             "name": "Battle-Rattle Shaman",
             "text": "At the beginning of combat on your turn, you may have target creature get +2/+0 until end of turn.",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "ce3d381c-bf67-58f0-bcc4-8062e4e769f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f65ebef-e159-4698-8852-650b7b6a08d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f65ebef-e159-4698-8852-650b7b6a08d3.jpg?1",
             "name": "Brimstone Mage",
             "text": "Level up {3}{R} ({3}{R}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-2\n2/3\n{T}: Brimstone Mage deals 1 damage to target creature or player.\nLEVEL 3+\n2/4\n{T}: Brimstone Mage deals 3 damage to target creature or player.",
             "colours": [
@@ -4588,7 +4588,7 @@
         },
         {
             "id": "ffcb0745-08fd-50a7-b29e-892bda2e7253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e44f7ff-1cfa-4bc4-a0f7-9d71ba48a97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e44f7ff-1cfa-4bc4-a0f7-9d71ba48a97a.jpg?1",
             "name": "Brood Birthing",
             "text": "If you control an Eldrazi Spawn, put three 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\" Otherwise, put one of those tokens onto the battlefield.",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "92f87f72-df7c-525c-96ed-59927a6b8624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1dc898-bf60-406f-922a-aa50cbffe5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf1dc898-bf60-406f-922a-aa50cbffe5b0.jpg?1",
             "name": "Conquering Manticore",
             "text": "Flying\nWhen Conquering Manticore enters the battlefield, gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -4654,7 +4654,7 @@
         },
         {
             "id": "717535ee-be5b-501c-97c6-3dc78ff693e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b09784-8e89-4013-975d-57e4d26cc926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b09784-8e89-4013-975d-57e4d26cc926.jpg?1",
             "name": "Devastating Summons",
             "text": "As an additional cost to cast Devastating Summons, sacrifice X lands.\nPut two X/X red Elemental creature tokens onto the battlefield.",
             "colours": [
@@ -4686,7 +4686,7 @@
         },
         {
             "id": "24d92dd0-2aa8-58c7-98b5-ffe9e1654225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9318ae4a-1084-49d9-b5de-dbe4d80836cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9318ae4a-1084-49d9-b5de-dbe4d80836cb.jpg?1",
             "name": "Disaster Radius",
             "text": "As an additional cost to cast Disaster Radius, reveal a creature card from your hand.\nDisaster Radius deals X damage to each creature your opponents control, where X is the revealed card's converted mana cost.",
             "colours": [
@@ -4718,7 +4718,7 @@
         },
         {
             "id": "b14b47fd-667f-52b3-ab40-64eb8f9c23ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a901c3f-313d-495e-96a0-29f1a33b8225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a901c3f-313d-495e-96a0-29f1a33b8225.jpg?1",
             "name": "Emrakul's Hatcher",
             "text": "When Emrakul's Hatcher enters the battlefield, put three 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -4753,7 +4753,7 @@
         },
         {
             "id": "b55ca80c-b582-5626-ba98-f0af7ad209b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a38cd0-2cd3-436d-bb44-79778d5808ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a38cd0-2cd3-436d-bb44-79778d5808ad.jpg?1",
             "name": "Explosive Revelation",
             "text": "Choose target creature or player. Reveal cards from the top of your library until you reveal a nonland card. Explosive Revelation deals damage equal to that card's converted mana cost to that creature or player. Put the nonland card into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "9e94cd68-e02b-5728-905a-eebac88ecad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4f813-f04c-4309-a007-b0549c00d6ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15f4f813-f04c-4309-a007-b0549c00d6ab.jpg?1",
             "name": "Fissure Vent",
             "text": "Choose one or both \u2014 Destroy target artifact; and/or destroy target nonbasic land.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "c6a40375-dd7c-5086-916b-73f3e22ead81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d2bf1-20f7-4b09-8d98-8233d91682bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006d2bf1-20f7-4b09-8d98-8233d91682bd.jpg?1",
             "name": "Flame Slash",
             "text": "Flame Slash deals 4 damage to target creature.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "c1f03e3a-78ef-53ac-8a94-dea9eb867052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127297-fdaa-45bf-a82e-4fc61315e0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06127297-fdaa-45bf-a82e-4fc61315e0e2.jpg?1",
             "name": "Forked Bolt",
             "text": "Forked Bolt deals 2 damage divided as you choose among one or two target creatures and/or players.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "7bc403bc-663c-5d47-9243-d32989241f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707d396d-950b-4ab8-9db2-f40c8f7db062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/707d396d-950b-4ab8-9db2-f40c8f7db062.jpg?1",
             "name": "Goblin Arsonist",
             "text": "When Goblin Arsonist is put into a graveyard from the battlefield, you may have it deal 1 damage to target creature or player.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "c8c23c66-0ef5-59ba-a0f6-858903912b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e4a34-6255-4f89-a62d-941996c573e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b2e4a34-6255-4f89-a62d-941996c573e1.jpg?1",
             "name": "Goblin Tunneler",
             "text": "{T}: Target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -4951,7 +4951,7 @@
         },
         {
             "id": "2db71ef4-cfe4-570b-8389-1815974f9bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c1a241-38ad-453e-b6c2-a79006031e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c1a241-38ad-453e-b6c2-a79006031e2d.jpg?1",
             "name": "Grotag Siege-Runner",
             "text": "{R}, Sacrifice Grotag Siege-Runner: Destroy target creature with defender. Grotag Siege-Runner deals 2 damage to that creature's controller.",
             "colours": [
@@ -4986,7 +4986,7 @@
         },
         {
             "id": "ec52b5ce-4134-551b-b100-2b9fa23be33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82227287-1774-448b-8c3a-573ddd58cc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82227287-1774-448b-8c3a-573ddd58cc80.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -5018,7 +5018,7 @@
         },
         {
             "id": "155421d6-f41f-5035-93e3-891835f73dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6529c92e-c79b-4953-8bd0-50ceae2ce261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6529c92e-c79b-4953-8bd0-50ceae2ce261.jpg?1",
             "name": "Hellion Eruption",
             "text": "Sacrifice all creatures you control, then put that many 4/4 red Hellion creature tokens onto the battlefield.",
             "colours": [
@@ -5050,7 +5050,7 @@
         },
         {
             "id": "7f0d677d-0547-5beb-918a-6c25bae3ccb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669d2d9-649b-4941-9a76-9833bdf77ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b669d2d9-649b-4941-9a76-9833bdf77ca4.jpg?1",
             "name": "Kargan Dragonlord",
             "text": "Level up {R} ({R}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 4-7\n4/4\nFlying\nLEVEL 8+\n8/8\nFlying, trample\n{R}: Kargan Dragonlord gets +1/+0 until end of turn.",
             "colours": [
@@ -5085,7 +5085,7 @@
         },
         {
             "id": "60141b8d-150a-5dea-8c3a-7b2311823b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c584268-67c3-411b-a26c-aee3adf23872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c584268-67c3-411b-a26c-aee3adf23872.jpg?1",
             "name": "Kiln Fiend",
             "text": "Whenever you cast an instant or sorcery spell, Kiln Fiend gets +3/+0 until end of turn.",
             "colours": [
@@ -5120,7 +5120,7 @@
         },
         {
             "id": "41b7937a-3296-5d34-bf79-5479121ec8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e9cfa-5547-4ef3-9e36-8d0f36dfa59a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47e9cfa-5547-4ef3-9e36-8d0f36dfa59a.jpg?1",
             "name": "Lagac Lizard",
             "text": "",
             "colours": [
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "c96c863f-1672-568b-bb25-e60e0daac949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e773b3f-37ef-4e37-8b1e-99b7b6314877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e773b3f-37ef-4e37-8b1e-99b7b6314877.jpg?1",
             "name": "Lavafume Invoker",
             "text": "{8}: Creatures you control get +3/+0 until end of turn.",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "f7d566c4-6822-51da-a2de-52a2485b429b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2159a7d-e37a-4c43-a7b9-1e7179a7e43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2159a7d-e37a-4c43-a7b9-1e7179a7e43b.jpg?1",
             "name": "Lord of Shatterskull Pass",
             "text": "Level up {1}{R} ({1}{R}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-5\n6/6\n\nLEVEL 6+\n6/6\nWhenever Lord of Shatterskull Pass attacks, it deals 6 damage to each creature defending player controls.",
             "colours": [
@@ -5224,7 +5224,7 @@
         },
         {
             "id": "127384f1-9821-57f2-a565-9510a7e145fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fa150-383d-448c-8e14-f24f65e13770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8fa150-383d-448c-8e14-f24f65e13770.jpg?1",
             "name": "Lust for War",
             "text": "Enchant creature\nWhenever enchanted creature becomes tapped, Lust for War deals 3 damage to that creature's controller.\nEnchanted creature attacks each turn if able.",
             "colours": [
@@ -5258,7 +5258,7 @@
         },
         {
             "id": "d2eb59d0-6c26-50e0-bd90-796b873baf86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015de202-e796-4194-a06b-d74230759f38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015de202-e796-4194-a06b-d74230759f38.jpg?1",
             "name": "Magmaw",
             "text": "{1}, Sacrifice a nonland permanent: Magmaw deals 1 damage to target creature or player.",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "f88cf00f-705e-52c9-941a-dd5a80191723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71db75c-c896-4887-ba18-92416fa6cbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71db75c-c896-4887-ba18-92416fa6cbd5.jpg?1",
             "name": "Ogre Sentry",
             "text": "Defender",
             "colours": [
@@ -5327,7 +5327,7 @@
         },
         {
             "id": "7cf64a3d-b004-551c-bd4b-fdf0dcea495c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c213b45-d86b-4ced-9ab9-44cd84ad94a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c213b45-d86b-4ced-9ab9-44cd84ad94a4.jpg?1",
             "name": "Rage Nimbus",
             "text": "Defender, flying\n{1}{R}: Target creature attacks this turn if able.",
             "colours": [
@@ -5361,7 +5361,7 @@
         },
         {
             "id": "d6a525ae-38ff-5616-9f56-ed68f1a5e242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2d1a48-efde-4134-95f0-b23f6cf85259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c2d1a48-efde-4134-95f0-b23f6cf85259.jpg?1",
             "name": "Raid Bombardment",
             "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to defending player.",
             "colours": [
@@ -5393,7 +5393,7 @@
         },
         {
             "id": "792a202b-6051-5af9-abd9-6c801fb75c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3befaa0-55a3-4e34-8051-1ab19eabd7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3befaa0-55a3-4e34-8051-1ab19eabd7d2.jpg?1",
             "name": "Rapacious One",
             "text": "Trample\nWhenever Rapacious One deals combat damage to a player, put that many 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5428,7 +5428,7 @@
         },
         {
             "id": "2003ba06-2bbc-5ab9-9efb-d63bf80480d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dcb81b-dcdb-44ca-9ef5-0b45d276c0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dcb81b-dcdb-44ca-9ef5-0b45d276c0dd.jpg?1",
             "name": "Soulsurge Elemental",
             "text": "First strike\nSoulsurge Elemental's power is equal to the number of creatures you control.",
             "colours": [
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "f0cd56d0-4b3f-5716-b186-13cb2d2e1c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ec1540-e8cb-4edc-a3b3-f71423cb46fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ec1540-e8cb-4edc-a3b3-f71423cb46fc.jpg?1",
             "name": "Spawning Breath",
             "text": "Spawning Breath deals 1 damage to target creature or player. Put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5494,7 +5494,7 @@
         },
         {
             "id": "82526226-c84f-5167-8fd2-0c559b214e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8f22fb-7291-4517-9b15-e98501f2856b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8f22fb-7291-4517-9b15-e98501f2856b.jpg?1",
             "name": "Splinter Twin",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put a token that's a copy of this creature onto the battlefield. That token has haste. Exile it at the beginning of the next end step.\"",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "ce859abe-90f7-5b33-9dc5-7fd1c56523f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75624ab3-ddbd-4fe8-8a07-7d1f78ec8a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75624ab3-ddbd-4fe8-8a07-7d1f78ec8a84.jpg?1",
             "name": "Staggershock",
             "text": "Staggershock deals 2 damage to target creature or player.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -5560,7 +5560,7 @@
         },
         {
             "id": "11c0f120-33dc-5b22-9a6b-e27c78ce603c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9108d6-d103-47f5-98ed-0d0d7564d328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9108d6-d103-47f5-98ed-0d0d7564d328.jpg?1",
             "name": "Surreal Memoir",
             "text": "Return an instant card at random from your graveyard to your hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -5592,7 +5592,7 @@
         },
         {
             "id": "c177efbe-173b-5ea0-b9d1-f4ea68a0a7af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b63ea-e3c3-465d-8cd9-7251cda9cc63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65b63ea-e3c3-465d-8cd9-7251cda9cc63.jpg?1",
             "name": "Traitorous Instinct",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "6efa287c-a208-5870-9827-886bfa7fb84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd23ab54-1eec-4bb4-81ce-b5cbe83fa940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd23ab54-1eec-4bb4-81ce-b5cbe83fa940.jpg?1",
             "name": "Tuktuk the Explorer",
             "text": "Haste\nWhen Tuktuk the Explorer is put into a graveyard from the battlefield, put a legendary 5/5 colorless Goblin Golem artifact creature token named Tuktuk the Returned onto the battlefield.",
             "colours": [
@@ -5660,7 +5660,7 @@
         },
         {
             "id": "adf94f4d-38a1-55fa-a321-66a7e7c66c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5718b282-d3e9-4c68-8623-9ea8a3c937d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5718b282-d3e9-4c68-8623-9ea8a3c937d0.jpg?1",
             "name": "Valakut Fireboar",
             "text": "Whenever Valakut Fireboar attacks, switch its power and toughness until end of turn.",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "3761729b-0620-5f1b-8bbc-8e59b7bd6c50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07989612-d3c4-44f7-b1ee-1ddf2d93a7da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07989612-d3c4-44f7-b1ee-1ddf2d93a7da.jpg?1",
             "name": "Vent Sentinel",
             "text": "Defender\n{1}{R}, {T}: Vent Sentinel deals damage to target player equal to the number of creatures with defender you control.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "549b9c8b-093c-588c-8552-c8f27cb59ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47a05ad-fe86-481e-b770-e1760be4f852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47a05ad-fe86-481e-b770-e1760be4f852.jpg?1",
             "name": "World at War",
             "text": "After the first postcombat main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "252a5eb5-685b-5146-8812-8cd8e03bd4c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babdaf80-f9a3-42cb-9df6-10878301f335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babdaf80-f9a3-42cb-9df6-10878301f335.jpg?1",
             "name": "Wrap in Flames",
             "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -5793,7 +5793,7 @@
         },
         {
             "id": "cc7325d7-3b21-55c2-a3f1-55b8306d348a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ac2766-a597-4949-882d-c5e61e6dd268.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ac2766-a597-4949-882d-c5e61e6dd268.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order. (Cards with no colored mana in their mana costs are colorless. Lands are also colorless.)",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "4b841832-1d52-5262-afb3-fb2c3bc0b558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8dbb4f-4b01-4666-b62f-a2323dac7a19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f8dbb4f-4b01-4666-b62f-a2323dac7a19.jpg?1",
             "name": "Aura Gnarlid",
             "text": "Creatures with power less than Aura Gnarlid's power can't block it.\nAura Gnarlid gets +1/+1 for each Aura on the battlefield.",
             "colours": [
@@ -5859,7 +5859,7 @@
         },
         {
             "id": "d449c934-e2fe-519c-bd06-08c1fc1a5671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080dbd69-95a8-4fed-bbaf-875a8a34a2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/080dbd69-95a8-4fed-bbaf-875a8a34a2c9.jpg?1",
             "name": "Awakening Zone",
             "text": "At the beginning of your upkeep, you may put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "4a4558e9-5718-5e4b-99fc-9deecdc66400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a953b-3205-41bf-a5b2-5b852e889c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a953b-3205-41bf-a5b2-5b852e889c5a.jpg?1",
             "name": "Bear Umbra",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"Whenever this creature attacks, untap all lands you control.\"\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5925,7 +5925,7 @@
         },
         {
             "id": "90b78804-b91b-5f4a-8b47-e0931716c5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24c2406-ba46-428b-9d5c-38954818edc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24c2406-ba46-428b-9d5c-38954818edc0.jpg?1",
             "name": "Beastbreaker of Bala Ged",
             "text": "Level up {2}{G} ({2}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-3\n4/4\n\nLEVEL 4+\n6/6\nTrample",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "260d9c28-ce51-5e2b-bf02-57f44171288d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfdec4f-e66a-48f8-ba6d-13459e80b52c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dfdec4f-e66a-48f8-ba6d-13459e80b52c.jpg?1",
             "name": "Boar Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "d6efba25-b256-5444-8f96-468669670125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcddd71f-bb8d-4153-854f-af87189babe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcddd71f-bb8d-4153-854f-af87189babe7.jpg?1",
             "name": "Bramblesnap",
             "text": "Trample\nTap an untapped creature you control: Bramblesnap gets +1/+1 until end of turn.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "b3403270-5f2c-5db1-84f5-5c18cf937720",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a1ca42-0fb1-4962-8663-39fc07443aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a1ca42-0fb1-4962-8663-39fc07443aef.jpg?1",
             "name": "Broodwarden",
             "text": "Eldrazi Spawn creatures you control get +2/+1.",
             "colours": [
@@ -6063,7 +6063,7 @@
         },
         {
             "id": "29ee7782-955f-5e0a-8739-029b18b90e73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4343cb0-6490-496c-9d58-ac1f7d3a91c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4343cb0-6490-496c-9d58-ac1f7d3a91c6.jpg?1",
             "name": "Daggerback Basilisk",
             "text": "Deathtouch",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "f0b8a2ba-d0ac-55fc-9019-e4a046e73ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea40dc5-de1b-4d2b-ae0e-df8e52876647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea40dc5-de1b-4d2b-ae0e-df8e52876647.jpg?1",
             "name": "Gelatinous Genesis",
             "text": "Put X X/X green Ooze creature tokens onto the battlefield.",
             "colours": [
@@ -6129,7 +6129,7 @@
         },
         {
             "id": "d352ed1c-9e16-5b15-bdfa-b3af97e1fa03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af25e35c-d1a4-4c10-8574-82babaaac4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af25e35c-d1a4-4c10-8574-82babaaac4fd.jpg?1",
             "name": "Gigantomancer",
             "text": "{1}: Target creature you control becomes 7/7 until end of turn.",
             "colours": [
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "f45c1802-099f-5b1f-9f72-7bb452aa8f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb13d0-1a62-4acd-9267-3b2df4b6a199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb13d0-1a62-4acd-9267-3b2df4b6a199.jpg?1",
             "name": "Gravity Well",
             "text": "Whenever a creature with flying attacks, it loses flying until end of turn.",
             "colours": [
@@ -6196,7 +6196,7 @@
         },
         {
             "id": "f076404a-1be2-5f0e-83d2-85e7b126b0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6a649-ae48-4cf1-b0e3-ba627b4ac1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d6a649-ae48-4cf1-b0e3-ba627b4ac1e1.jpg?1",
             "name": "Growth Spasm",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -6228,7 +6228,7 @@
         },
         {
             "id": "40bbb7e0-ac56-50a3-9fb6-ec2f4ab7cfcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8e000-5b4c-4340-ab85-7522107ab589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8e000-5b4c-4340-ab85-7522107ab589.jpg?1",
             "name": "Haze Frog",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Haze Frog enters the battlefield, prevent all combat damage that other creatures would deal this turn.",
             "colours": [
@@ -6262,7 +6262,7 @@
         },
         {
             "id": "bf026018-e684-5bc8-a431-75f466adda57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1511d4d-3e70-4688-ab88-37e26cb1a46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1511d4d-3e70-4688-ab88-37e26cb1a46f.jpg?1",
             "name": "Irresistible Prey",
             "text": "Target creature must be blocked this turn if able.\nDraw a card.",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "f8113c31-297f-5158-9487-512efaf35813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22144b6f-e8a8-4fcb-ac2b-83693481ffba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22144b6f-e8a8-4fcb-ac2b-83693481ffba.jpg?1",
             "name": "Jaddi Lifestrider",
             "text": "When Jaddi Lifestrider enters the battlefield, you may tap any number of untapped creatures you control. You gain 2 life for each creature tapped this way.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "5989bc5b-2c14-5977-ab5b-4a25cf624339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1132218d-56cd-441e-9006-df3c50344491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1132218d-56cd-441e-9006-df3c50344491.jpg?1",
             "name": "Joraga Treespeaker",
             "text": "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n1/2\n{T}: Add {G}{G} to your mana pool.\nLEVEL 5+\n1/4\nElves you control have \"{T}: Add {G}{G} to your mana pool.\"",
             "colours": [
@@ -6363,7 +6363,7 @@
         },
         {
             "id": "3c413416-e9b1-5397-a673-8fb159b17bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54908d58-c7b4-46e1-9cad-3a7ea0bc7a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54908d58-c7b4-46e1-9cad-3a7ea0bc7a6b.jpg?1",
             "name": "Kazandu Tuskcaller",
             "text": "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-5\n1/1\n{T}: Put a 3/3 green Elephant creature token onto the battlefield.\nLEVEL 6+\n1/1\n{T}: Put two 3/3 green Elephant creature tokens onto the battlefield.",
             "colours": [
@@ -6398,7 +6398,7 @@
         },
         {
             "id": "b277e6cf-7316-5625-bb6e-b4480717dbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d27a00e-4402-4410-bab7-ccb34a0de72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d27a00e-4402-4410-bab7-ccb34a0de72f.jpg?1",
             "name": "Khalni Hydra",
             "text": "Khalni Hydra costs {G} less to cast for each green creature you control.\nTrample",
             "colours": [
@@ -6432,7 +6432,7 @@
         },
         {
             "id": "11625c17-8191-5f61-a3bf-3cfec7a1a15a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab37d0e-5542-4ae0-a48e-d0a4e6bf48e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab37d0e-5542-4ae0-a48e-d0a4e6bf48e7.jpg?1",
             "name": "Kozilek's Predator",
             "text": "When Kozilek's Predator enters the battlefield, put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -6467,7 +6467,7 @@
         },
         {
             "id": "73a64c46-a6eb-5e16-ab03-90da5eb889a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d531ba4-df99-41e4-9dd3-a27a420ad63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d531ba4-df99-41e4-9dd3-a27a420ad63c.jpg?1",
             "name": "Leaf Arrow",
             "text": "Leaf Arrow deals 3 damage to target creature with flying.",
             "colours": [
@@ -6499,7 +6499,7 @@
         },
         {
             "id": "e51fbc2d-a650-579f-84b8-81470aaf2560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361399a4-04f3-4eef-8090-2caec7d1bb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361399a4-04f3-4eef-8090-2caec7d1bb66.jpg?1",
             "name": "Living Destiny",
             "text": "As an additional cost to cast Living Destiny, reveal a creature card from your hand.\nYou gain life equal to the revealed card's converted mana cost.",
             "colours": [
@@ -6531,7 +6531,7 @@
         },
         {
             "id": "4cf09b2c-d34e-5a5a-8c80-97ef96cd9597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10465f4f-f4ff-45d8-bc97-3ec85e5eea70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10465f4f-f4ff-45d8-bc97-3ec85e5eea70.jpg?1",
             "name": "Might of the Masses",
             "text": "Target creature gets +1/+1 until end of turn for each creature you control.",
             "colours": [
@@ -6563,7 +6563,7 @@
         },
         {
             "id": "3e3681ac-35a2-5de8-b706-12784247c377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0271550a-0610-4e21-849a-f29547a77bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0271550a-0610-4e21-849a-f29547a77bdc.jpg?1",
             "name": "Momentous Fall",
             "text": "As an additional cost to cast Momentous Fall, sacrifice a creature.\nYou draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness.",
             "colours": [
@@ -6595,7 +6595,7 @@
         },
         {
             "id": "d09c7994-6784-5286-b22e-562a300d25c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d362c3b-f9e1-476b-b5fd-d1292bbc257c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d362c3b-f9e1-476b-b5fd-d1292bbc257c.jpg?1",
             "name": "Mul Daya Channelers",
             "text": "Play with the top card of your library revealed.\nAs long as the top card of your library is a creature card, Mul Daya Channelers gets +3/+3.\nAs long as the top card of your library is a land card, Mul Daya Channelers has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -6631,7 +6631,7 @@
         },
         {
             "id": "4261ba57-e778-5d8c-94d1-297ed8cf9be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02618f5-ae78-47a9-855a-65a3408fcba4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c02618f5-ae78-47a9-855a-65a3408fcba4.jpg?1",
             "name": "Naturalize",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -6663,7 +6663,7 @@
         },
         {
             "id": "5d95329e-e4c7-51aa-a31d-e2b015e199ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477e081-949f-4cf0-b0d2-b9bdff6c760d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a477e081-949f-4cf0-b0d2-b9bdff6c760d.jpg?1",
             "name": "Nema Siltlurker",
             "text": "",
             "colours": [
@@ -6697,7 +6697,7 @@
         },
         {
             "id": "29e16d30-174e-52a5-9509-82b4857c0d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24517d9c-6cde-41e8-9e82-ee73f069379a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24517d9c-6cde-41e8-9e82-ee73f069379a.jpg?1",
             "name": "Nest Invader",
             "text": "When Nest Invader enters the battlefield, put a 0/1 colorless Eldrazi Spawn creature token onto the battlefield. It has \"Sacrifice this creature: Add {1} to your mana pool.\"",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "e3a5f2e1-7ac1-5e3e-83b4-7497c64233d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8b1e5-418f-4e64-a2ac-0e03b387ed33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf8b1e5-418f-4e64-a2ac-0e03b387ed33.jpg?1",
             "name": "Ondu Giant",
             "text": "When Ondu Giant enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "293e889f-0378-5ed2-a233-48930112f2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e3d197-e978-4ec6-ab69-3c5fd8ac3fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e3d197-e978-4ec6-ab69-3c5fd8ac3fc1.jpg?1",
             "name": "Overgrown Battlement",
             "text": "Defender\n{T}: Add {G} to your mana pool for each creature with defender you control.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "bb0e2320-83b6-5a56-9d54-e1f03a556797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e732593-0bdc-4dd4-9b07-9aa1a780e6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e732593-0bdc-4dd4-9b07-9aa1a780e6e8.jpg?1",
             "name": "Pelakka Wurm",
             "text": "Trample\nWhen Pelakka Wurm enters the battlefield, you gain 7 life.\nWhen Pelakka Wurm is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -6835,7 +6835,7 @@
         },
         {
             "id": "4e59eba0-4f0e-5b6a-91bd-9e854997aad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd0d15f-8200-46a4-a9e9-e7f0ee2aa0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd0d15f-8200-46a4-a9e9-e7f0ee2aa0e4.jpg?1",
             "name": "Prey's Vengeance",
             "text": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "78ec72a6-b643-5bb2-9b97-73ca7e2efccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8967ceff-9e25-46da-926b-e05f4ee98325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8967ceff-9e25-46da-926b-e05f4ee98325.jpg?1",
             "name": "Realms Uncharted",
             "text": "Search your library for four land cards with different names and reveal them. An opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest into your hand. Then shuffle your library.",
             "colours": [
@@ -6899,7 +6899,7 @@
         },
         {
             "id": "a7497c68-7ee6-565f-8b2c-78c390ec888d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a011820-80c6-484f-84be-f07f0e45f1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a011820-80c6-484f-84be-f07f0e45f1a8.jpg?1",
             "name": "Snake Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals damage to an opponent, you may draw a card.\"\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6933,7 +6933,7 @@
         },
         {
             "id": "afe206ff-cf0e-50f1-8832-9b0a441a1a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e593a5b-0de6-4df2-bbda-54195400dc69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e593a5b-0de6-4df2-bbda-54195400dc69.jpg?1",
             "name": "Spider Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has reach. (It can block creatures with flying.)\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6967,7 +6967,7 @@
         },
         {
             "id": "c094f21c-35d5-53ea-a963-c83533e93357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb1d18f-7a94-4a2f-a60c-0af852d44501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb1d18f-7a94-4a2f-a60c-0af852d44501.jpg?1",
             "name": "Sporecap Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "5c8adfef-dd8b-5daa-8422-d622a116d608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89be64a8-dd78-48c3-bb47-4f2a5ad9ec10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89be64a8-dd78-48c3-bb47-4f2a5ad9ec10.jpg?1",
             "name": "Stomper Cub",
             "text": "Trample",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "7d6ff481-216c-5e99-a54d-4a5747ea0924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d03346-0802-4058-b89e-1b6076963c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d03346-0802-4058-b89e-1b6076963c8e.jpg?1",
             "name": "Tajuru Preserver",
             "text": "Spells and abilities your opponents control can't cause you to sacrifice permanents.",
             "colours": [
@@ -7070,7 +7070,7 @@
         },
         {
             "id": "236cbb40-c946-55a3-8d01-5ea24c556c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb9f05-9d5a-4196-9329-626ce4793c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb9f05-9d5a-4196-9329-626ce4793c42.jpg?1",
             "name": "Vengevine",
             "text": "Haste\nWhenever you cast a spell, if it's the second creature spell you cast this turn, you may return Vengevine from your graveyard to the battlefield.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "5ba157f7-dd80-58da-a5c5-38927a67f049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8315bf-03af-4f19-92c7-556e486cb099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8315bf-03af-4f19-92c7-556e486cb099.jpg?1",
             "name": "Wildheart Invoker",
             "text": "{8}: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -7139,7 +7139,7 @@
         },
         {
             "id": "8fc6ecd8-9901-519b-9565-f6ff548b03dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c1ba92-556e-4da9-8e3a-a4a82612cb29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26c1ba92-556e-4da9-8e3a-a4a82612cb29.jpg?1",
             "name": "Sarkhan the Mad",
             "text": "0: Reveal the top card of your library and put it into your hand. Sarkhan the Mad deals damage to himself equal to that card's converted mana cost.\n-2: Target creature's controller sacrifices it, then that player puts a 5/5 red Dragon creature token with flying onto the battlefield.\n-4: Each Dragon creature you control deals damage equal to its power to target player.",
             "colours": [
@@ -7177,7 +7177,7 @@
         },
         {
             "id": "6e19885e-a466-5c76-bf49-ee333cafcfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1fe7a-eb30-4252-bada-ce3f8096e091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf1fe7a-eb30-4252-bada-ce3f8096e091.jpg?1",
             "name": "Angelheart Vial",
             "text": "Whenever you're dealt damage, you may put that many charge counters on Angelheart Vial.\n{2}, {T}, Remove four charge counters from Angelheart Vial: You gain 2 life and draw a card.",
             "colours": [],
@@ -7205,7 +7205,7 @@
         },
         {
             "id": "cddf42c0-8b90-5f7f-bd7b-6109d9972f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79090d66-19ab-456e-96c0-023c84f4e521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79090d66-19ab-456e-96c0-023c84f4e521.jpg?1",
             "name": "Dreamstone Hedron",
             "text": "{T}: Add {3} to your mana pool.\n{3}, {T}, Sacrifice Dreamstone Hedron: Draw three cards.",
             "colours": [],
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "ab8027cc-6f14-5d6c-9894-faabfd03e56d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b2e63d-61c6-46e4-9a6f-56653c49b2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b2e63d-61c6-46e4-9a6f-56653c49b2ea.jpg?1",
             "name": "Enatu Golem",
             "text": "When Enatu Golem is put into a graveyard from the battlefield, you gain 4 life.",
             "colours": [],
@@ -7264,7 +7264,7 @@
         },
         {
             "id": "b86309ee-8922-567b-b84f-bb179e96d8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26a7d8-3bc5-4666-a0dc-c5fbd68f9441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f26a7d8-3bc5-4666-a0dc-c5fbd68f9441.jpg?1",
             "name": "Hedron Matrix",
             "text": "Equipped creature gets +X/+X, where X is its converted mana cost.\nEquip {4}",
             "colours": [],
@@ -7294,7 +7294,7 @@
         },
         {
             "id": "3dcd4b30-e38a-5cbe-a58c-13eb582a107a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f9355b-3a3e-417c-9fbc-afddb4d8f9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f9355b-3a3e-417c-9fbc-afddb4d8f9af.jpg?1",
             "name": "Keening Stone",
             "text": "{5}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of cards in that player's graveyard.",
             "colours": [],
@@ -7322,7 +7322,7 @@
         },
         {
             "id": "cd1a31e1-0f9c-597b-8f15-248e8c2a80c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec319380-bede-49e8-9d0c-473688033601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec319380-bede-49e8-9d0c-473688033601.jpg?1",
             "name": "Ogre's Cleaver",
             "text": "Equipped creature gets +5/+0.\nEquip {5}",
             "colours": [],
@@ -7352,7 +7352,7 @@
         },
         {
             "id": "8f5d27a5-2a29-5b67-a28f-752fcc9e7e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a64a1b-4816-4d8f-a8ba-ba39c92c61ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a64a1b-4816-4d8f-a8ba-ba39c92c61ec.jpg?1",
             "name": "Pennon Blade",
             "text": "Equipped creature gets +1/+1 for each creature you control.\nEquip {4}",
             "colours": [],
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "0d36f401-a08b-5e07-bdbf-b9ac51d115c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb90d44-8cb1-4b83-b2f2-92c19d6304fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb90d44-8cb1-4b83-b2f2-92c19d6304fb.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7410,7 +7410,7 @@
         },
         {
             "id": "573efbcb-e5ad-5820-bcec-94651b5066df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437a91e7-f98e-4ed8-9ab7-f4db62979f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/437a91e7-f98e-4ed8-9ab7-f4db62979f5b.jpg?1",
             "name": "Reinforced Bulwark",
             "text": "Defender\n{T}: Prevent the next 1 damage that would be dealt to you this turn.",
             "colours": [],
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "74aafdcd-1379-52a9-a987-8540dd828054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbbbbf6-e3ed-4a36-bedf-11c3514ff965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbbbbf6-e3ed-4a36-bedf-11c3514ff965.jpg?1",
             "name": "Runed Servitor",
             "text": "When Runed Servitor is put into a graveyard from the battlefield, each player draws a card.",
             "colours": [],
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "27f52867-06e3-50d0-8043-3a4a5deef695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da189e-f692-4b91-a452-3c628c3c2b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7da189e-f692-4b91-a452-3c628c3c2b1c.jpg?1",
             "name": "Sphinx-Bone Wand",
             "text": "Whenever you cast an instant or sorcery spell, you may put a charge counter on Sphinx-Bone Wand. If you do, Sphinx-Bone Wand deals damage equal to the number of charge counters on it to target creature or player.",
             "colours": [],
@@ -7500,7 +7500,7 @@
         },
         {
             "id": "12458f3e-2b0a-5724-9c40-d3cfd18a5e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44da7915-98bd-4f4e-9bcc-801eb10c8a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44da7915-98bd-4f4e-9bcc-801eb10c8a18.jpg?1",
             "name": "Warmonger's Chariot",
             "text": "Equipped creature gets +2/+2.\nAs long as equipped creature has defender, it can attack as though it didn't have defender.\nEquip {3}",
             "colours": [],
@@ -7530,7 +7530,7 @@
         },
         {
             "id": "9999b1ed-df21-5699-9a73-6367d6273c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315924c9-77e3-405b-9bbf-852ed563c6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315924c9-77e3-405b-9bbf-852ed563c6e3.jpg?1",
             "name": "Eldrazi Temple",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Add {2} to your mana pool. Spend this mana only to cast colorless Eldrazi spells or activate abilities of colorless Eldrazi.",
             "colours": [],
@@ -7558,7 +7558,7 @@
         },
         {
             "id": "25231603-90bb-5a91-8f6e-e05389c26438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7e0407-fea1-43ef-8580-82271e440bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7e0407-fea1-43ef-8580-82271e440bb3.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "f6b063a0-815a-5105-9ddb-4f1acbb9e52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3345553-8f04-4a83-9b6b-95ca0654921d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3345553-8f04-4a83-9b6b-95ca0654921d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7624,7 +7624,7 @@
         },
         {
             "id": "414a8436-d86f-5b80-ba3d-0f9cbea4f21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dc47f2-a92d-446b-b788-8287b5d609c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70dc47f2-a92d-446b-b788-8287b5d609c4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "fa3851f7-56af-5ebf-9ffb-9fc5fd3d2345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf39f344-1204-4c90-93b5-c04a24f0f1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf39f344-1204-4c90-93b5-c04a24f0f1f5.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "13e78170-7ba8-5be1-b1f1-76c780aa68a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45031d49-c82b-47a4-a652-f8904cd9bb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45031d49-c82b-47a4-a652-f8904cd9bb66.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "35639b2e-3779-54c1-a887-c3b77e1dc51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c799192-43bb-4c25-ab4f-b1d4ef0df660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c799192-43bb-4c25-ab4f-b1d4ef0df660.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7776,7 +7776,7 @@
         },
         {
             "id": "33f49aad-9755-5d7e-b005-6d3ff3d25452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15973a22-cf86-447d-94ef-d62ac824aa49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15973a22-cf86-447d-94ef-d62ac824aa49.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7814,7 +7814,7 @@
         },
         {
             "id": "7f87cfb5-46a6-56d0-ad52-2c2268a01bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32a5e25-8e85-474e-ab32-ab28898ac87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32a5e25-8e85-474e-ab32-ab28898ac87a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7852,7 +7852,7 @@
         },
         {
             "id": "6e095630-c7b4-5690-becb-c5b8db09212e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcc2609-59ba-4eca-8b90-993cab90364a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddcc2609-59ba-4eca-8b90-993cab90364a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "b3ad9125-7358-5cac-b8cf-fdf9e9b2bd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75f4aa-cede-452b-80c1-bd3b8221dbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f75f4aa-cede-452b-80c1-bd3b8221dbcb.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "d4a8435a-c0f4-56c5-990e-b42dea233fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d7edb2-3bb4-4a0f-ad66-eef31cc8ed6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30d7edb2-3bb4-4a0f-ad66-eef31cc8ed6b.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7966,7 +7966,7 @@
         },
         {
             "id": "fe9de957-e587-5bea-952c-049e2902dcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bdea83-efb5-4371-8d25-5703c6efee65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bdea83-efb5-4371-8d25-5703c6efee65.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8004,7 +8004,7 @@
         },
         {
             "id": "ec7ae475-5c55-50fd-a224-76bce8668a3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1660f317-d337-4c24-8523-613dc3072ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1660f317-d337-4c24-8523-613dc3072ca9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "5b9b39bc-22b0-5757-83bb-ab54fe2add7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf940cc3-282e-4b6b-877d-5ce71ee797bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf940cc3-282e-4b6b-877d-5ce71ee797bc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8080,7 +8080,7 @@
         },
         {
             "id": "ba0b5086-fdb3-50f2-945c-15de60074be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acc9266-3a8e-4a5b-9c00-bbc30e3bf5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9acc9266-3a8e-4a5b-9c00-bbc30e3bf5e7.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "9d98a217-174a-57c5-9931-0130b6cf061a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352288b-ff7b-43c7-a5ae-3f6577d11708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352288b-ff7b-43c7-a5ae-3f6577d11708.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8156,7 +8156,7 @@
         },
         {
             "id": "5e834126-996b-5757-9ea9-ee22f2c5626e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56424d3-ceda-4cd3-988f-48ced72d17b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56424d3-ceda-4cd3-988f-48ced72d17b8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "f65a752f-3712-57d5-a754-7b97f42675c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e2588b-7781-418c-abc8-08601fbb2336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e2588b-7781-418c-abc8-08601fbb2336.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8232,7 +8232,7 @@
         },
         {
             "id": "74422852-01dd-59f0-9264-1984810e00a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af153b-5cc6-4130-8694-dcdb1fd45cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92af153b-5cc6-4130-8694-dcdb1fd45cdc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8270,7 +8270,7 @@
         },
         {
             "id": "34a6cf7f-c1cc-55ce-93c0-189f95ec183f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776470f5-3a47-475b-a599-cb5fee156593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/776470f5-3a47-475b-a599-cb5fee156593.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8308,7 +8308,7 @@
         },
         {
             "id": "51f2710a-8cd9-5b82-917a-b7b46f861047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dd7a8a-a560-481a-a16e-dc60cdb440bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4dd7a8a-a560-481a-a16e-dc60cdb440bb.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8346,7 +8346,7 @@
         },
         {
             "id": "946a7482-bf4a-5eab-8c8f-3b06b9ba413b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3826c-3c85-4910-bd6c-04894ea328d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e3826c-3c85-4910-bd6c-04894ea328d0.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8377,7 +8377,7 @@
         },
         {
             "id": "2858a0da-25df-526d-b946-74c309c4bc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb1a3d-3f1a-45ba-a643-1dca435c77de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb1a3d-3f1a-45ba-a643-1dca435c77de.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8408,7 +8408,7 @@
         },
         {
             "id": "72736a8e-7059-58e0-83df-1a88d355766b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0da4f8d-cce9-4d08-8d11-792e0b2af7d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0da4f8d-cce9-4d08-8d11-792e0b2af7d0.jpg?1",
             "name": "Eldrazi Spawn",
             "text": "",
             "colours": [],
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "f9482da1-1da5-5ed9-a322-f3b5031d8904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c9fb3-5f4c-47f9-a9b3-369d4936de60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0c9fb3-5f4c-47f9-a9b3-369d4936de60.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8473,7 +8473,7 @@
         },
         {
             "id": "c2d9fa31-b2b6-5c1e-bbd9-65206fbb04aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acabc3ce-a3c1-4c6c-8022-9a96ffba59c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acabc3ce-a3c1-4c6c-8022-9a96ffba59c6.jpg?1",
             "name": "Hellion",
             "text": "",
             "colours": [
@@ -8507,7 +8507,7 @@
         },
         {
             "id": "6e7758ec-e4bb-59fc-a314-6a52cc158724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e91df-0647-4c9f-9c3e-fb8c77c4886c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e91df-0647-4c9f-9c3e-fb8c77c4886c.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "8a2b5077-33e8-52c8-af65-28159fe2bc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f55fa2-bb6f-4609-85ec-72703638fbd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f55fa2-bb6f-4609-85ec-72703638fbd9.jpg?1",
             "name": "Tuktuk the Returned",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/RTR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/RTR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "923d8c9a-79e6-52de-82c3-b04646c10141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d82f7-7759-457e-a9bb-f9a5bd968f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d82f7-7759-457e-a9bb-f9a5bd968f82.jpg?1",
             "name": "Angel of Serenity",
             "text": "Flying\nWhen Angel of Serenity enters the battlefield, you may exile up to three other target creatures from the battlefield and/or creature cards from graveyards.\nWhen Angel of Serenity leaves the battlefield, return the exiled cards to their owners' hands.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "d4b10a8e-f7ee-5ad5-8c11-80a521aaf560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03498c1-b7f7-41fb-8e2a-1c087d4e9990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03498c1-b7f7-41fb-8e2a-1c087d4e9990.jpg?1",
             "name": "Armory Guard",
             "text": "Armory Guard has vigilance as long as you control a Gate.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "c6fc40d9-8bf5-51b3-9def-44347e649f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498f74a2-7e5e-4082-97e7-b938d703f869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498f74a2-7e5e-4082-97e7-b938d703f869.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "09b0b6ed-d1ce-5006-a150-3094bfcc6dc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696678ff-44dc-4fe4-bf17-024e86cd0220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696678ff-44dc-4fe4-bf17-024e86cd0220.jpg?1",
             "name": "Avenging Arrow",
             "text": "Destroy target creature that dealt damage this turn.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "85b45749-eb8c-5cea-8a64-f627510075d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199f7563-563e-483c-8317-5380a83db955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199f7563-563e-483c-8317-5380a83db955.jpg?1",
             "name": "Azorius Arrester",
             "text": "When Azorius Arrester enters the battlefield, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "8f6448ec-8748-5bdc-adb7-4c701e5be6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f56272e-c05e-446b-8871-e3783dd29a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f56272e-c05e-446b-8871-e3783dd29a8b.jpg?1",
             "name": "Azorius Justiciar",
             "text": "When Azorius Justiciar enters the battlefield, detain up to two target creatures your opponents control. (Until your next turn, those creatures can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "2cf4daa9-029b-532f-add2-0cb2a98d85ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07bb2fe-3a9b-47d0-864b-99a662d9544b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07bb2fe-3a9b-47d0-864b-99a662d9544b.jpg?1",
             "name": "Bazaar Krovod",
             "text": "Whenever Bazaar Krovod attacks, another target attacking creature gets +0/+2 until end of turn. Untap that creature.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "98f7bca4-7d9f-583a-baee-81049a09feac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0333d0b-ae42-48aa-83d8-a4f2c7483a46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0333d0b-ae42-48aa-83d8-a4f2c7483a46.jpg?1",
             "name": "Concordia Pegasus",
             "text": "Flying",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "ae1abfc0-ad32-55c2-81b6-8df85b5ddba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76960e65-e5c7-4414-b9a5-37d7b2ded4a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76960e65-e5c7-4414-b9a5-37d7b2ded4a0.jpg?1",
             "name": "Ethereal Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each enchantment you control and has first strike.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "85d04b65-f196-5c53-bf52-bfa9778b2537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befef095-3429-4dd7-aa01-2f7f619675d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befef095-3429-4dd7-aa01-2f7f619675d4.jpg?1",
             "name": "Eyes in the Skies",
             "text": "Put a 1/1 white Bird creature token with flying onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "6125dc0e-1b9d-50a4-8658-5412e45358b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42d3066-f4ec-4d28-83ab-e48141206c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42d3066-f4ec-4d28-83ab-e48141206c72.jpg?1",
             "name": "Fencing Ace",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "cbbe0ac3-2d99-5f3d-91f5-b539f77d77fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657b242c-46cb-44d1-86fd-fb2485144a5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657b242c-46cb-44d1-86fd-fb2485144a5b.jpg?1",
             "name": "Keening Apparition",
             "text": "Sacrifice Keening Apparition: Destroy target enchantment.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "9c3244e8-be90-52af-939e-355621d1ecf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d821f-c8dd-4a3c-a6d7-b42fe5491f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122d821f-c8dd-4a3c-a6d7-b42fe5491f02.jpg?1",
             "name": "Knightly Valor",
             "text": "Enchant creature\nWhen Knightly Valor enters the battlefield, put a 2/2 white Knight creature token with vigilance onto the battlefield.\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "a6b3eef6-c010-5084-9db9-d9aab87f4645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21078b6f-a39d-4ec8-879e-ad10d97c3ff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21078b6f-a39d-4ec8-879e-ad10d97c3ff6.jpg?1",
             "name": "Martial Law",
             "text": "At the beginning of your upkeep, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "8bc748ac-8c22-509a-9299-670e2fa1c77d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfd37ca-e4c9-4674-a75f-15d8ebcce72b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfd37ca-e4c9-4674-a75f-15d8ebcce72b.jpg?1",
             "name": "Palisade Giant",
             "text": "All damage that would be dealt to you or another permanent you control is dealt to Palisade Giant instead.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "247e592d-051e-551d-9f39-0fb20b4551c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f42791-070a-4e3a-91c8-b801980abb76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f42791-070a-4e3a-91c8-b801980abb76.jpg?1",
             "name": "Phantom General",
             "text": "Creature tokens you control get +1/+1.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "81e26755-b763-5ddb-b158-580254fec1d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1f6178-4071-401f-bd0d-cac0c5967661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1f6178-4071-401f-bd0d-cac0c5967661.jpg?1",
             "name": "Precinct Captain",
             "text": "First strike\nWhenever Precinct Captain deals combat damage to a player, put a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "058b3b18-e305-57b2-a47b-1624691d08aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b1d1-faa0-40fd-82f4-216604ce7635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b1d1-faa0-40fd-82f4-216604ce7635.jpg?1",
             "name": "Rest in Peace",
             "text": "When Rest in Peace enters the battlefield, exile all cards from all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "1f030a24-e4e3-583c-b7f5-d74be97e6b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deccfa48-b8df-4dcc-ba1b-920f8352def7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deccfa48-b8df-4dcc-ba1b-920f8352def7.jpg?1",
             "name": "Rootborn Defenses",
             "text": "Populate. Creatures you control are indestructible this turn. (To populate, put a token onto the battlefield that's a copy of a creature token you control. Damage and effects that say \"destroy\" don't destroy indestructible creatures.)",
             "colours": [
@@ -647,7 +647,7 @@
         },
         {
             "id": "b3a0f22b-f7dc-5280-972c-b0bc736a0d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6250b31-8592-48b2-a877-3637c9ee7d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6250b31-8592-48b2-a877-3637c9ee7d49.jpg?1",
             "name": "Security Blockade",
             "text": "Enchant land\nWhen Security Blockade enters the battlefield, put a 2/2 white Knight creature token with vigilance onto the battlefield.\nEnchanted land has \"{T}: Prevent the next 1 damage that would be dealt to you this turn.\"",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "e0f2e287-df8e-530b-9f70-aa974945c593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c34c1f5-d509-4c66-ba41-c7958ef5ee44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c34c1f5-d509-4c66-ba41-c7958ef5ee44.jpg?1",
             "name": "Selesnya Sentry",
             "text": "{5}{G}: Regenerate Selesnya Sentry.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "bb1257e9-854f-54d6-89d6-490645b5b6bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41edbe-4c5a-4535-a082-235dc3ffe60a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a41edbe-4c5a-4535-a082-235dc3ffe60a.jpg?1",
             "name": "Seller of Songbirds",
             "text": "When Seller of Songbirds enters the battlefield, put a 1/1 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "e9fb19be-142f-5cd5-b7d2-e9f7f8560328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e546ce-f498-4136-9015-bb262c301716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e546ce-f498-4136-9015-bb262c301716.jpg?1",
             "name": "Soul Tithe",
             "text": "Enchant nonland permanent\nAt the beginning of the upkeep of enchanted permanent's controller, that player sacrifices it unless he or she pays {X}, where X is its converted mana cost.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "d9652ea5-7f5b-517a-afcc-b9d70d69a74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3bd0d8-7e44-4cf2-9012-8ff0bc39417f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3bd0d8-7e44-4cf2-9012-8ff0bc39417f.jpg?1",
             "name": "Sphere of Safety",
             "text": "Creatures can't attack you or a planeswalker you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "231c0c47-791d-586d-9c97-1ba482dcbfe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1388ce6e-8199-46c1-8ee3-71266b0929bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1388ce6e-8199-46c1-8ee3-71266b0929bf.jpg?1",
             "name": "Sunspire Griffin",
             "text": "Flying",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "265f137e-6345-5523-af49-7a3c7f48ef43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94801ba-0295-4611-abda-4c6508d69cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94801ba-0295-4611-abda-4c6508d69cc3.jpg?1",
             "name": "Swift Justice",
             "text": "Until end of turn, target creature gets +1/+0 and gains first strike and lifelink.",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "ea5773c1-d8f7-50be-9656-67b5b3c0bd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e45d1-d17d-40c0-bfdf-ec533784e676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797e45d1-d17d-40c0-bfdf-ec533784e676.jpg?1",
             "name": "Trained Caracal",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "072810c9-d48f-5f30-b37c-bcfa9e3a2e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707bdb1-1f8c-4cc0-be01-496f3f03b878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d707bdb1-1f8c-4cc0-be01-496f3f03b878.jpg?1",
             "name": "Trostani's Judgment",
             "text": "Exile target creature, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "b272de9f-3986-5cdb-b03f-11fa17e00b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af643949-7a9b-4195-8ab8-d43b1928b85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af643949-7a9b-4195-8ab8-d43b1928b85a.jpg?1",
             "name": "Aquus Steed",
             "text": "{2}{U}, {T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "d5f0d7b3-a97d-576e-8788-19f47e6ab996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998847b-323d-406a-b08e-0da66edcc7b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d998847b-323d-406a-b08e-0da66edcc7b3.jpg?1",
             "name": "Blustersquall",
             "text": "Tap target creature you don't control.\nOverload {3}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1015,7 +1015,7 @@
         },
         {
             "id": "ee08823a-35d8-532f-aef8-eee8a3ef682f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd994a26-65ff-43be-8d52-476e887d3ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd994a26-65ff-43be-8d52-476e887d3ed2.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "b874549d-15a0-5968-8e20-ac23e4c9720a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a757425-3cf2-4aca-b415-5ec2d5f753fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a757425-3cf2-4aca-b415-5ec2d5f753fe.jpg?1",
             "name": "Chronic Flooding",
             "text": "Enchant land\nWhenever enchanted land becomes tapped, its controller puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "eef71db2-265c-585e-8841-7b09ec652ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c2ea6e-7d29-4526-b135-9bbb1eed9d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c2ea6e-7d29-4526-b135-9bbb1eed9d4a.jpg?1",
             "name": "Conjured Currency",
             "text": "At the beginning of your upkeep, you may exchange control of Conjured Currency and target permanent you neither own nor control.",
             "colours": [
@@ -1113,7 +1113,7 @@
         },
         {
             "id": "53e8cccd-fc00-5b81-bbae-c181d66d727e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8875a3-9f56-4947-9655-aa5d95f06de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8875a3-9f56-4947-9655-aa5d95f06de0.jpg?1",
             "name": "Crosstown Courier",
             "text": "Whenever Crosstown Courier deals combat damage to a player, that player puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "edd213b6-1f31-5895-a139-771c4036ed06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c4689-8b02-4d40-9274-3c1fcafa8b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205c4689-8b02-4d40-9274-3c1fcafa8b82.jpg?1",
             "name": "Cyclonic Rift",
             "text": "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1179,7 +1179,7 @@
         },
         {
             "id": "31df7d20-cbe6-5367-8daf-9a3b1f974a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d4a8d7-c136-472f-8146-a1100701ca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d4a8d7-c136-472f-8146-a1100701ca4f.jpg?1",
             "name": "Dispel",
             "text": "Counter target instant spell.",
             "colours": [
@@ -1211,7 +1211,7 @@
         },
         {
             "id": "c81b2c8e-ba1f-561e-801e-f458414ace5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c31221f-3753-4d5c-905a-6b558ab648ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c31221f-3753-4d5c-905a-6b558ab648ae.jpg?1",
             "name": "Doorkeeper",
             "text": "Defender\n{2}{U}, {T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of creatures with defender you control.",
             "colours": [
@@ -1245,7 +1245,7 @@
         },
         {
             "id": "0d9bff05-eb55-5caa-b267-3f8c3d7e90c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8408a52-d34a-4e03-9312-700dec75d844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8408a52-d34a-4e03-9312-700dec75d844.jpg?1",
             "name": "Downsize",
             "text": "Target creature you don't control gets -4/-0 until end of turn.\nOverload {2}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1277,7 +1277,7 @@
         },
         {
             "id": "a53d8d00-74c9-5088-b434-498d855d92d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfddc9d-85f6-4b37-9973-14c69f6818ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dfddc9d-85f6-4b37-9973-14c69f6818ec.jpg?1",
             "name": "Faerie Impostor",
             "text": "Flying\nWhen Faerie Impostor enters the battlefield, sacrifice it unless you return another creature you control to its owner's hand.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "6683bc9b-e0b3-56db-8d98-ad3fd32e37f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884afdb3-0d5f-45a1-b57e-6c3760aa0031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884afdb3-0d5f-45a1-b57e-6c3760aa0031.jpg?1",
             "name": "Hover Barrier",
             "text": "Defender, flying",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "85b3e1ad-d09e-5c91-b5c7-c515ee8bf6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5342ec3c-9d26-474a-9df5-c21ac90bb233.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5342ec3c-9d26-474a-9df5-c21ac90bb233.jpg?1",
             "name": "Inaction Injunction",
             "text": "Detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)\nDraw a card.",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "e01eee9a-f0a7-5574-b618-a0d5a4193d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9dc0-0a12-459c-88e2-97ed94653058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cf9dc0-0a12-459c-88e2-97ed94653058.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "c6531295-fb79-5acd-9c86-5bef027b9fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba84d-d236-45c5-a8ad-75def7736d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba84d-d236-45c5-a8ad-75def7736d0c.jpg?1",
             "name": "Isperia's Skywatch",
             "text": "Flying\nWhen Isperia's Skywatch enters the battlefield, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -1446,7 +1446,7 @@
         },
         {
             "id": "41162bba-7a2b-57d3-8c70-a2377a308bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df3a38-678e-42dc-a3fd-d1d399368f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4df3a38-678e-42dc-a3fd-d1d399368f07.jpg?1",
             "name": "Jace, Architect of Thought",
             "text": "+1: Until your next turn, whenever a creature an opponent controls attacks, it gets -1/-0 until end of turn.\n-2: Reveal the top three cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other on the bottom of your library in any order.\n-8: For each player, search that player's library for a nonland card and exile it, then that player shuffles his or her library. You may cast those cards without paying their mana costs.",
             "colours": [
@@ -1482,7 +1482,7 @@
         },
         {
             "id": "a1956347-0326-50fb-9c4f-7074091efcea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9859344-4efc-4b87-a3fb-147e496cee68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9859344-4efc-4b87-a3fb-147e496cee68.jpg?1",
             "name": "Mizzium Skin",
             "text": "Target creature you control gets +0/+1 and gains hexproof until end of turn.\nOverload {1}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "e01bee1f-0e7a-56af-ba75-0d164cffe00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd97b3-d83e-406f-af45-40eec6347462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfd97b3-d83e-406f-af45-40eec6347462.jpg?1",
             "name": "Paralyzing Grasp",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1548,7 +1548,7 @@
         },
         {
             "id": "528e8a90-b17e-57f0-9f26-456051838cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b09c16-f611-4c90-a990-e22bf46bd0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b09c16-f611-4c90-a990-e22bf46bd0e2.jpg?1",
             "name": "Psychic Spiral",
             "text": "Shuffle all cards from your graveyard into your library. Target player puts that many cards from the top of his or her library into his or her graveyard.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "7aa59b59-6f9e-5d61-a0f8-bdd8b59ce0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749961e6-b135-4629-ae9d-124de0d70db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749961e6-b135-4629-ae9d-124de0d70db9.jpg?1",
             "name": "Runewing",
             "text": "Flying\nWhen Runewing dies, draw a card.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "48bcd8cf-bb4a-5155-a0d4-39ad14c18dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd77575-fedc-45b1-a53b-dfed0f34c875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd77575-fedc-45b1-a53b-dfed0f34c875.jpg?1",
             "name": "Search the City",
             "text": "When Search the City enters the battlefield, exile the top five cards of your library.\nWhenever you play a card with the same name as one of the exiled cards, you may put one of those cards with that name into its owner's hand. Then if there are no cards exiled with Search the City, sacrifice it. If you do, take an extra turn after this one.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "9a985fc1-3c41-521a-9461-1aa3a22505a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839556c-6635-44c4-96ed-666e4466b929.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839556c-6635-44c4-96ed-666e4466b929.jpg?1",
             "name": "Skyline Predator",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "cc906bd8-c861-5e8c-bb4f-ecdad723697d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32602ed9-c0a7-4498-a333-235eaae628df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32602ed9-c0a7-4498-a333-235eaae628df.jpg?1",
             "name": "Soulsworn Spirit",
             "text": "Soulsworn Spirit is unblockable.\nWhen Soulsworn Spirit enters the battlefield, detain target creature an opponent controls. (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "143ee4ec-71d5-54c0-a1e8-e0d93edcbc79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a0cae5-925f-4d00-a4da-1db8bae5511b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a0cae5-925f-4d00-a4da-1db8bae5511b.jpg?1",
             "name": "Sphinx of the Chimes",
             "text": "Flying\nDiscard two nonland cards with the same name: Draw four cards.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "d4edf62b-643d-5935-be7f-3ebb62b453ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ae7001-4d0f-4160-b41c-2fcb83fdb60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30ae7001-4d0f-4160-b41c-2fcb83fdb60b.jpg?1",
             "name": "Stealer of Secrets",
             "text": "Whenever Stealer of Secrets deals combat damage to a player, draw a card.",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "9f6cb568-a4dd-5840-9046-c0df4dcc882a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f218f-83b0-4b68-a00f-0327cd79f32a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6f218f-83b0-4b68-a00f-0327cd79f32a.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays {X}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1815,7 +1815,7 @@
         },
         {
             "id": "1b7e86d5-81ec-541f-ba59-097f084a3635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d759d6f-daf0-47f4-8a35-81c9d6437495.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d759d6f-daf0-47f4-8a35-81c9d6437495.jpg?1",
             "name": "Tower Drake",
             "text": "Flying\n{W}: Tower Drake gets +0/+1 until end of turn.",
             "colours": [
@@ -1850,7 +1850,7 @@
         },
         {
             "id": "b1200a6a-4808-549e-9ff7-234e57a7b34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23723bc7-a68e-4810-bc87-60df916cbb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23723bc7-a68e-4810-bc87-60df916cbb8a.jpg?1",
             "name": "Voidwielder",
             "text": "When Voidwielder enters the battlefield, you may return target creature to its owner's hand.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "e9640ade-9c2d-501c-94c8-d4159e1189ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f796e320-9898-45d4-9d7a-6d35de53c9ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f796e320-9898-45d4-9d7a-6d35de53c9ab.jpg?1",
             "name": "Assassin's Strike",
             "text": "Destroy target creature. Its controller discards a card.",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "8c223cb8-e9cc-54c4-9d9a-c9ff29103b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b36fba-6a0e-4f03-8bee-03919062537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b36fba-6a0e-4f03-8bee-03919062537f.jpg?1",
             "name": "Catacomb Slug",
             "text": "",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "64054348-27a8-53d5-a61c-ea3263ec7cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d5260-f906-4f6a-97ed-725197743b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013d5260-f906-4f6a-97ed-725197743b60.jpg?1",
             "name": "Cremate",
             "text": "Exile target card from a graveyard.\nDraw a card.",
             "colours": [
@@ -1983,7 +1983,7 @@
         },
         {
             "id": "84255e6d-df65-53cc-b53c-87b89778a4e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70639887-bdba-4879-a3f8-c716f97fc325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70639887-bdba-4879-a3f8-c716f97fc325.jpg?1",
             "name": "Daggerdrome Imp",
             "text": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -2017,7 +2017,7 @@
         },
         {
             "id": "19f419d9-d172-5efd-a9ba-1ff0240bca11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167cc6d-ddb5-4f13-8905-a0c5123b852a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167cc6d-ddb5-4f13-8905-a0c5123b852a.jpg?1",
             "name": "Dark Revenant",
             "text": "Flying\nWhen Dark Revenant dies, put it on top of its owner's library.",
             "colours": [
@@ -2051,7 +2051,7 @@
         },
         {
             "id": "426f2ff4-207b-5ed6-a019-cc1fe8393084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a0a38-2c22-4b49-8938-1a8162c077e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/909a0a38-2c22-4b49-8938-1a8162c077e6.jpg?1",
             "name": "Dead Reveler",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2085,7 +2085,7 @@
         },
         {
             "id": "4f6a7de7-3a17-58d1-862f-ee07b3053a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8242fade-754c-4404-b3fb-f3cccf84b3b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8242fade-754c-4404-b3fb-f3cccf84b3b6.jpg?1",
             "name": "Desecration Demon",
             "text": "Flying\nAt the beginning of each combat, any opponent may sacrifice a creature. If a player does, tap Desecration Demon and put a +1/+1 counter on it.",
             "colours": [
@@ -2119,7 +2119,7 @@
         },
         {
             "id": "f52d2840-3c97-54d6-9c86-bf84aae433d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca53097-108d-457e-831c-e3d6cb499a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca53097-108d-457e-831c-e3d6cb499a41.jpg?1",
             "name": "Destroy the Evidence",
             "text": "Destroy target land. Its controller reveals cards from the top of his or her library until he or she reveals a land card, then puts those cards into his or her graveyard.",
             "colours": [
@@ -2151,7 +2151,7 @@
         },
         {
             "id": "f5cb29d6-eb53-5d73-abdf-dbdc5a9a6745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150896e-8745-42ac-894b-8f42a92bd7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150896e-8745-42ac-894b-8f42a92bd7a7.jpg?1",
             "name": "Deviant Glee",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has \"{R}: This creature gains trample until end of turn.\"",
             "colours": [
@@ -2186,7 +2186,7 @@
         },
         {
             "id": "24d562ca-b8e4-534b-a6ee-ac6f464940d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7251f3-df66-4611-a84c-1897f74431f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7251f3-df66-4611-a84c-1897f74431f7.jpg?1",
             "name": "Drainpipe Vermin",
             "text": "When Drainpipe Vermin dies, you may pay {B}. If you do, target player discards a card.",
             "colours": [
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "ab2e7086-04c8-53f6-8ba6-1b85a4fef606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b38c68-8e72-4afc-bb5e-0b40880fdda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b38c68-8e72-4afc-bb5e-0b40880fdda9.jpg?1",
             "name": "Grave Betrayal",
             "text": "Whenever a creature you don't control dies, return it to the battlefield under your control with an additional +1/+1 counter on it at the beginning of the next end step. That creature is a black Zombie in addition to its other colors and types.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "c66721e7-d8e5-51e5-bcc1-7f892bfe06ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5ae3f5-5466-4058-a2cd-1a036cb38a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a5ae3f5-5466-4058-a2cd-1a036cb38a8e.jpg?1",
             "name": "Grim Roustabout",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\n{1}{B}: Regenerate Grim Roustabout.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "a0e81854-3b73-55da-b708-cfc310a94099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f29821-902e-41bc-97a2-6fc7a710cbdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f29821-902e-41bc-97a2-6fc7a710cbdb.jpg?1",
             "name": "Launch Party",
             "text": "As an additional cost to cast Launch Party, sacrifice a creature.\nDestroy target creature. Its controller loses 2 life.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "fb261cd7-14cc-5029-8d16-88ea883222c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5261ab4b-dfe7-4761-a71c-44a893fc4a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5261ab4b-dfe7-4761-a71c-44a893fc4a69.jpg?1",
             "name": "Mind Rot",
             "text": "Target player discards two cards.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "2d921eb3-2ed1-5c65-80bf-dc8fbab1c5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b421dcc9-0299-416d-86bc-c70ef49bcf98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b421dcc9-0299-416d-86bc-c70ef49bcf98.jpg?1",
             "name": "Necropolis Regent",
             "text": "Flying\nWhenever a creature you control deals combat damage to a player, put that many +1/+1 counters on it.",
             "colours": [
@@ -2385,7 +2385,7 @@
         },
         {
             "id": "0a55694e-2e6b-5463-b10f-04cfa2aa9b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a96c83d-96d9-4f8f-8020-77990130ad81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a96c83d-96d9-4f8f-8020-77990130ad81.jpg?1",
             "name": "Ogre Jailbreaker",
             "text": "Defender\nOgre Jailbreaker can attack as though it didn't have defender as long as you control a Gate.",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "9f208978-8567-5188-a3ee-b30fad0a0ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170693f5-13db-4191-99b1-e527ffb5b88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/170693f5-13db-4191-99b1-e527ffb5b88e.jpg?1",
             "name": "Pack Rat",
             "text": "Pack Rat's power and toughness are each equal to the number of Rats you control.\n{2}{B}, Discard a card: Put a token onto the battlefield that's a copy of Pack Rat.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "758b9b10-7a81-5e02-8c3c-e1f97824c599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c101171-a988-4c1d-9954-634e2f1c6f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c101171-a988-4c1d-9954-634e2f1c6f01.jpg?1",
             "name": "Perilous Shadow",
             "text": "{1}{B}: Perilous Shadow gets +2/+2 until end of turn.",
             "colours": [
@@ -2489,7 +2489,7 @@
         },
         {
             "id": "a4381290-926d-57bb-abdd-2d91f5247cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7ba14-c901-4266-ae31-812e001916d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae7ba14-c901-4266-ae31-812e001916d3.jpg?1",
             "name": "Sewer Shambler",
             "text": "Swampwalk (This creature is unblockable as long as defending player controls a Swamp.)\nScavenge {2}{B} ({2}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "ebaaac19-e2f1-5d66-9de1-5499df8bad51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd08894-2534-4114-9365-40809ba95eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd08894-2534-4114-9365-40809ba95eb2.jpg?1",
             "name": "Shrieking Affliction",
             "text": "At the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, he or she loses 3 life.",
             "colours": [
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "04dca176-da8b-54f9-9171-785764829113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0fea13-63cf-4574-8752-3c357eee4524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f0fea13-63cf-4574-8752-3c357eee4524.jpg?1",
             "name": "Slum Reaper",
             "text": "When Slum Reaper enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "fad7dda1-2e5e-5785-a5d5-ae28bd47c9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b562269-e6ec-4f8d-844e-26b272248d9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b562269-e6ec-4f8d-844e-26b272248d9d.jpg?1",
             "name": "Stab Wound",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.\nAt the beginning of the upkeep of enchanted creature's controller, that player loses 2 life.",
             "colours": [
@@ -2623,7 +2623,7 @@
         },
         {
             "id": "bae292a3-7418-55a6-991c-518088119ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47240ed3-f256-45fb-ab38-7b07e672d2ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47240ed3-f256-45fb-ab38-7b07e672d2ed.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "ad5cab67-211c-59e0-830d-700012fb0a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1998135c-7b7f-402b-a8a5-4f4af131b1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1998135c-7b7f-402b-a8a5-4f4af131b1bc.jpg?1",
             "name": "Terrus Wurm",
             "text": "Scavenge {6}{B} ({6}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "4e822d23-9bc1-5a66-b182-1818404f5841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f32204-eda7-4184-92e5-9da8b15b2359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f32204-eda7-4184-92e5-9da8b15b2359.jpg?1",
             "name": "Thrill-Kill Assassin",
             "text": "Deathtouch\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "741491a6-daa6-5480-b0a0-f57e4baf77fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b4912a-83a2-4870-8fac-81fa79da2830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b4912a-83a2-4870-8fac-81fa79da2830.jpg?1",
             "name": "Ultimate Price",
             "text": "Destroy target monocolored creature.",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "65617e56-4d64-561c-a6b2-3024737a0b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c52e3b-b3b8-4243-96fe-fa4c8eea7c59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c52e3b-b3b8-4243-96fe-fa4c8eea7c59.jpg?1",
             "name": "Underworld Connections",
             "text": "Enchant land\nEnchanted land has \"{T}, Pay 1 life: Draw a card.\"",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "8f14290c-36e5-5a90-a1dd-bf976db4bb0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbd7ee-8958-46fe-abb0-e899e7d2e654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbd7ee-8958-46fe-abb0-e899e7d2e654.jpg?1",
             "name": "Zanikev Locust",
             "text": "Flying\nScavenge {2}{B}{B} ({2}{B}{B}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "82cb0a64-dc06-54fc-9fe7-0f43299d94a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae12fd10-c13e-4777-a233-96204ec75ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae12fd10-c13e-4777-a233-96204ec75ac1.jpg?1",
             "name": "Annihilating Fire",
             "text": "Annihilating Fire deals 3 damage to target creature or player. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "c506205f-c45d-5b80-8184-9cc2f80e2b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f61b1a3-4b3b-4490-a9dc-17aac258cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f61b1a3-4b3b-4490-a9dc-17aac258cbda.jpg?1",
             "name": "Ash Zealot",
             "text": "First strike, haste\nWhenever a player casts a spell from a graveyard, Ash Zealot deals 3 damage to that player.",
             "colours": [
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "aaeca27d-bdc0-54cf-aa3a-78e5643e7b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b40f74-893f-4bfc-87b2-7f8df4c912d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b40f74-893f-4bfc-87b2-7f8df4c912d8.jpg?1",
             "name": "Batterhorn",
             "text": "When Batterhorn enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -2929,7 +2929,7 @@
         },
         {
             "id": "6935f64a-b7c9-5f89-b184-8c43b3359f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg?1",
             "name": "Bellows Lizard",
             "text": "{1}{R}: Bellows Lizard gets +1/+0 until end of turn.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "4b385cc5-8546-561c-9735-71b8b4b1c9e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c468cd-1255-4257-9a69-c6b40a27c427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8c468cd-1255-4257-9a69-c6b40a27c427.jpg?1",
             "name": "Bloodfray Giant",
             "text": "Trample\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -2997,7 +2997,7 @@
         },
         {
             "id": "0322876d-22b3-541d-a651-ed23815044b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a702a-c9be-4bee-9087-22b5905f783a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70a702a-c9be-4bee-9087-22b5905f783a.jpg?1",
             "name": "Chaos Imps",
             "text": "Flying\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\nChaos Imps has trample as long as it has a +1/+1 counter on it.",
             "colours": [
@@ -3031,7 +3031,7 @@
         },
         {
             "id": "990d84c3-3e63-5cf1-9d7e-924163bdd48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e038376-801f-454e-a635-0e2d58ccbf7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e038376-801f-454e-a635-0e2d58ccbf7c.jpg?1",
             "name": "Cobblebrute",
             "text": "",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "d6be1a9f-734f-5b2a-8fee-2d7b3af5c977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e612a032-39be-44cd-a78c-29f89dc384b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e612a032-39be-44cd-a78c-29f89dc384b0.jpg?1",
             "name": "Dynacharge",
             "text": "Target creature you control gets +2/+0 until end of turn.\nOverload {2}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3097,7 +3097,7 @@
         },
         {
             "id": "ee1fcc47-974e-5863-a0cb-7caafefba6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed81ee8-d5e4-4127-876e-9bff81f9c726.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed81ee8-d5e4-4127-876e-9bff81f9c726.jpg?1",
             "name": "Electrickery",
             "text": "Electrickery deals 1 damage to target creature you don't control.\nOverload {1}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "a1ba0c6d-47ad-588e-b6a2-9a6a89a0eef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3e2b45-b086-4ffd-aa1a-1d03046e0d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3e2b45-b086-4ffd-aa1a-1d03046e0d61.jpg?1",
             "name": "Explosive Impact",
             "text": "Explosive Impact deals 5 damage to target creature or player.",
             "colours": [
@@ -3161,7 +3161,7 @@
         },
         {
             "id": "cf11a456-e11a-533b-92cf-0fd7b6ff97cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec8ada-09a6-449a-ac4a-7d3acbd08014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ec8ada-09a6-449a-ac4a-7d3acbd08014.jpg?1",
             "name": "Goblin Rally",
             "text": "Put four 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -3193,7 +3193,7 @@
         },
         {
             "id": "aedc7efa-d2bd-5135-bade-a0db62bdbe04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ba132f-95fc-4b99-a1dc-ebe6f622bb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ba132f-95fc-4b99-a1dc-ebe6f622bb41.jpg?1",
             "name": "Gore-House Chainwalker",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "d0bcc932-d1f2-509c-90de-42512b6fef75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e622878-0aea-4401-873e-d34bf05ee98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e622878-0aea-4401-873e-d34bf05ee98d.jpg?1",
             "name": "Guild Feud",
             "text": "At the beginning of your upkeep, target opponent reveals the top three cards of his or her library, may put a creature card from among them onto the battlefield, then puts the rest into his or her graveyard. You do the same with the top three cards of your library. If two creatures are put onto the battlefield this way, those creatures fight each other.",
             "colours": [
@@ -3260,7 +3260,7 @@
         },
         {
             "id": "b688633e-b2a8-5c6a-9f6c-0030383c9552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8590ea-512c-4e09-97cc-7f07d0706f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8590ea-512c-4e09-97cc-7f07d0706f2b.jpg?1",
             "name": "Guttersnipe",
             "text": "Whenever you cast an instant or sorcery spell, Guttersnipe deals 2 damage to each opponent.",
             "colours": [
@@ -3295,7 +3295,7 @@
         },
         {
             "id": "4e8c4a4d-a426-5d0f-8cdd-2fdf4ec5ffdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4aa15-a3c2-42a3-a87a-443e7dd20c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d4aa15-a3c2-42a3-a87a-443e7dd20c04.jpg?1",
             "name": "Lobber Crew",
             "text": "Defender\n{T}: Lobber Crew deals 1 damage to each opponent.\nWhenever you cast a multicolored spell, untap Lobber Crew.",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "7f09067c-b1c0-57bb-8db3-93cbf0c38413",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22959dc-8759-454e-80b9-623a799af354.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e22959dc-8759-454e-80b9-623a799af354.jpg?1",
             "name": "Minotaur Aggressor",
             "text": "First strike, haste",
             "colours": [
@@ -3365,7 +3365,7 @@
         },
         {
             "id": "a53b4afe-d825-58e2-917f-3c536c2809c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ded88d-2688-4f5e-a8b2-16216cf9c792.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ded88d-2688-4f5e-a8b2-16216cf9c792.jpg?1",
             "name": "Mizzium Mortars",
             "text": "Mizzium Mortars deals 4 damage to target creature you don't control.\nOverload {3}{R}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3397,7 +3397,7 @@
         },
         {
             "id": "6d854ef9-35ad-5581-a369-a2e65fd6cd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a6290c-a0a8-4032-972b-84a7eef04dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a6290c-a0a8-4032-972b-84a7eef04dae.jpg?1",
             "name": "Pursuit of Flight",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{U}: This creature gains flying until end of turn.\"",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "da166780-223b-55ff-a254-11f4684cd5db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff95b7-79eb-4796-9a01-31ff355681ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cff95b7-79eb-4796-9a01-31ff355681ab.jpg?1",
             "name": "Pyroconvergence",
             "text": "Whenever you cast a multicolored spell, Pyroconvergence deals 2 damage to target creature or player.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "1979e9a2-ab9e-57cf-b259-acb8fc2a0a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d13d35-b5f7-4d3d-a1fa-84178b28acae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d13d35-b5f7-4d3d-a1fa-84178b28acae.jpg?1",
             "name": "Racecourse Fury",
             "text": "Enchant land\nEnchanted land has \"{T}: Target creature gains haste until end of turn.\"",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "37e00c39-f9e7-5fc1-acd5-e7a83f931d1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c511805-3392-4033-8679-811711a0aaca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c511805-3392-4033-8679-811711a0aaca.jpg?1",
             "name": "Splatter Thug",
             "text": "First strike\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -3533,7 +3533,7 @@
         },
         {
             "id": "35ab4fa1-c10c-5606-9918-4692e4b193df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a19d3b8-80d0-480f-8900-47be527d0e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a19d3b8-80d0-480f-8900-47be527d0e53.jpg?1",
             "name": "Street Spasm",
             "text": "Street Spasm deals X damage to target creature without flying you don't control.\nOverload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3565,7 +3565,7 @@
         },
         {
             "id": "3eb39c04-fa37-5341-a14b-70e926c96da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e750f9-ad86-4d60-98a3-78d11cd52cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6e750f9-ad86-4d60-98a3-78d11cd52cd1.jpg?1",
             "name": "Survey the Wreckage",
             "text": "Destroy target land. Put a 1/1 red Goblin creature token onto the battlefield.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "8e8d801e-aa10-53dd-8da6-92698821da63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af9170-bd99-4fde-b673-62d988312b2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af9170-bd99-4fde-b673-62d988312b2d.jpg?1",
             "name": "Tenement Crasher",
             "text": "Haste",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "1b3ad3df-34c9-59d0-9290-879fb1456d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4456951-844a-4847-b933-c32cfafbfef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4456951-844a-4847-b933-c32cfafbfef0.jpg?1",
             "name": "Traitorous Instinct",
             "text": "Gain control of target creature until end of turn. Untap that creature. Until end of turn, it gets +2/+0 and gains haste.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "3d4164df-ea3a-59fa-8841-214a7698cdb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c6478-dd80-4854-9560-bfc5ef597872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f17c6478-dd80-4854-9560-bfc5ef597872.jpg?1",
             "name": "Utvara Hellkite",
             "text": "Flying\nWhenever a Dragon you control attacks, put a 6/6 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "44f04176-a1ff-5f22-8407-f765f5ef53f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5925c559-3e3c-481b-ba95-20a405cbffce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5925c559-3e3c-481b-ba95-20a405cbffce.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "a74a95ae-4fa5-5309-863c-b3232b14cd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4c2d22-9c36-42cc-854d-f96410bb5cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4c2d22-9c36-42cc-854d-f96410bb5cf1.jpg?1",
             "name": "Viashino Racketeer",
             "text": "When Viashino Racketeer enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "0df57484-69dd-5e5a-9a49-2c019d1c3590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3c023c-037e-495a-b7df-32be42a75f36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3c023c-037e-495a-b7df-32be42a75f36.jpg?1",
             "name": "Aerial Predation",
             "text": "Destroy target creature with flying. You gain 2 life.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "9a1025f8-82fa-5ca9-bf63-05f98b8353f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc8ff-932c-4d56-9253-99ce9e145306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99dc8ff-932c-4d56-9253-99ce9e145306.jpg?1",
             "name": "Archweaver",
             "text": "Reach, trample",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "be3665a5-1190-5a2a-b998-77c5383adedb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/725584fe-9e97-4020-89b1-5e5b45a5beb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/725584fe-9e97-4020-89b1-5e5b45a5beb2.jpg?1",
             "name": "Axebane Guardian",
             "text": "Defender\n{T}: Add X mana in any combination of colors to your mana pool, where X is the number of creatures with defender you control.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "12b932bc-bad5-5c4c-bcab-081e9cdd2b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfce7c02-ccc3-44cd-8087-627eaa6a072e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfce7c02-ccc3-44cd-8087-627eaa6a072e.jpg?1",
             "name": "Axebane Stag",
             "text": "",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "80b5b104-02a6-5b14-befa-a672aad9ae7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bd1534-52d1-4946-b430-d26f039a9067.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59bd1534-52d1-4946-b430-d26f039a9067.jpg?1",
             "name": "Brushstrider",
             "text": "Vigilance",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "9d8b71ef-83cc-527a-8f3b-56cb4f40fda2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08598b2b-6fd2-4a1d-8d74-7ca6d93ad382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08598b2b-6fd2-4a1d-8d74-7ca6d93ad382.jpg?1",
             "name": "Centaur's Herald",
             "text": "{2}{G}, Sacrifice Centaur's Herald: Put a 3/3 green Centaur creature token onto the battlefield.",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "00e4745d-cedf-5173-856f-c73edee25cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214dc9c1-154d-4c35-845d-dd2928f1e142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214dc9c1-154d-4c35-845d-dd2928f1e142.jpg?1",
             "name": "Chorus of Might",
             "text": "Until end of turn, target creature gets +1/+1 for each creature you control and gains trample.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "03db94d3-2c73-50c6-81fb-14e497990dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad03e99-25d3-4a09-819b-9192dfd8c9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad03e99-25d3-4a09-819b-9192dfd8c9d2.jpg?1",
             "name": "Deadbridge Goliath",
             "text": "Scavenge {4}{G}{G} ({4}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4034,7 +4034,7 @@
         },
         {
             "id": "ae6fd184-c286-5b53-a50f-d0b01b9025a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa82c57d-4bb9-407c-b973-7abc793b6f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa82c57d-4bb9-407c-b973-7abc793b6f47.jpg?1",
             "name": "Death's Presence",
             "text": "Whenever a creature you control dies, put X +1/+1 counters on target creature you control, where X is the power of the creature that died.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "bfac6c0b-94c9-5356-b827-e2f225aea6a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4812e81-beca-4afc-b2f2-24d5ab27abff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4812e81-beca-4afc-b2f2-24d5ab27abff.jpg?1",
             "name": "Drudge Beetle",
             "text": "Scavenge {5}{G} ({5}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "6690d7a1-714a-50a0-9684-c7b78df7b237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b35961-f4d5-4e14-a793-335147110627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b35961-f4d5-4e14-a793-335147110627.jpg?1",
             "name": "Druid's Deliverance",
             "text": "Prevent all combat damage that would be dealt to you this turn. Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -4132,7 +4132,7 @@
         },
         {
             "id": "be87d656-d71f-587e-af69-6ea3fa6a4e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabcc2f-7536-44e3-a495-bbfc526fdc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dabcc2f-7536-44e3-a495-bbfc526fdc5d.jpg?1",
             "name": "Gatecreeper Vine",
             "text": "Defender\nWhen Gatecreeper Vine enters the battlefield, you may search your library for a basic land card or a Gate card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -4166,7 +4166,7 @@
         },
         {
             "id": "495ac685-41cc-5658-8854-6d095e77a02d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1f6503-e4b2-4085-92cd-e9c522b4b10d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b1f6503-e4b2-4085-92cd-e9c522b4b10d.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -4198,7 +4198,7 @@
         },
         {
             "id": "58ad4f24-d439-5afc-ba4c-81e21b786bae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8a63-0ced-4aec-be34-2098b72c8af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/465d8a63-0ced-4aec-be34-2098b72c8af6.jpg?1",
             "name": "Gobbling Ooze",
             "text": "{G}, Sacrifice another creature: Put a +1/+1 counter on Gobbling Ooze.",
             "colours": [
@@ -4232,7 +4232,7 @@
         },
         {
             "id": "9d4e2346-db5f-5d97-ab1c-7bd3156ee761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511a42a8-71ce-476f-98fa-fc0dc822edcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/511a42a8-71ce-476f-98fa-fc0dc822edcf.jpg?1",
             "name": "Golgari Decoy",
             "text": "All creatures able to block Golgari Decoy do so.\nScavenge {3}{G}{G} ({3}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "92c0ae74-e970-5124-870c-c17f45c101ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8d33ed-9ca2-41d1-ba35-fdeb5b88ad44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b8d33ed-9ca2-41d1-ba35-fdeb5b88ad44.jpg?1",
             "name": "Horncaller's Chant",
             "text": "Put a 4/4 green Rhino creature token with trample onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "f18a3687-0be5-5fbd-8da2-9f26dc4802b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f319d57-7a54-4b10-86d4-58d7b3994844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f319d57-7a54-4b10-86d4-58d7b3994844.jpg?1",
             "name": "Korozda Monitor",
             "text": "Trample\nScavenge {5}{G}{G} ({5}{G}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -4333,7 +4333,7 @@
         },
         {
             "id": "1c9c846a-9e28-5570-bd35-7cd321a11d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7592d88-64e8-4a31-b00a-f65d4b1867fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7592d88-64e8-4a31-b00a-f65d4b1867fc.jpg?1",
             "name": "Mana Bloom",
             "text": "Mana Bloom enters the battlefield with X charge counters on it.\nRemove a charge counter from Mana Bloom: Add one mana of any color to your mana pool. Activate this ability only once each turn.\nAt the beginning of your upkeep, if Mana Bloom has no charge counters on it, return it to its owner's hand.",
             "colours": [
@@ -4365,7 +4365,7 @@
         },
         {
             "id": "3b7bb5b6-a397-5d6a-b28e-19659eba65e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08274d1b-52b7-46c1-8f93-7631d2e21def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08274d1b-52b7-46c1-8f93-7631d2e21def.jpg?1",
             "name": "Oak Street Innkeeper",
             "text": "As long as it's not your turn, tapped creatures you control have hexproof.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "e7aff0b6-ca88-5e74-ba87-2a0bd464af82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51daaf9b-d8a8-49a6-94e1-0c8be2c6188b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51daaf9b-d8a8-49a6-94e1-0c8be2c6188b.jpg?1",
             "name": "Rubbleback Rhino",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -4433,7 +4433,7 @@
         },
         {
             "id": "0daaac60-9627-5ade-b0de-644109b1ad25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa74aae-e857-410c-8836-953c8623d0b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa74aae-e857-410c-8836-953c8623d0b0.jpg?1",
             "name": "Savage Surge",
             "text": "Target creature gets +2/+2 until end of turn. Untap that creature.",
             "colours": [
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "62071fce-5cb6-58a4-982e-cf70f216fa2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f52ac7-933f-4b31-8576-338f5dcf4285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f52ac7-933f-4b31-8576-338f5dcf4285.jpg?1",
             "name": "Seek the Horizon",
             "text": "Search your library for up to three basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -4497,7 +4497,7 @@
         },
         {
             "id": "7c74fa2a-0972-5f1b-a69c-a0ee197df30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a439e8-d586-4995-abfc-3dee5c860968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44a439e8-d586-4995-abfc-3dee5c860968.jpg?1",
             "name": "Slime Molding",
             "text": "Put an X/X green Ooze creature token onto the battlefield.",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "ffd3b061-b52f-521e-b9f9-a3cd10aff163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2517d74-0589-49dc-88f1-1fc02b27bc9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2517d74-0589-49dc-88f1-1fc02b27bc9d.jpg?1",
             "name": "Stonefare Crocodile",
             "text": "{2}{B}: Stonefare Crocodile gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "4f9c21bd-3be1-5ead-b62f-c2c1dbc651ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6049e92-6c52-44be-a3c7-aa8e8bf9c10a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6049e92-6c52-44be-a3c7-aa8e8bf9c10a.jpg?1",
             "name": "Towering Indrik",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -4598,7 +4598,7 @@
         },
         {
             "id": "d7594213-b078-5fe3-91a5-0e3f4561af3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393c230f-5bc3-4b71-b5ac-81d5ce227df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393c230f-5bc3-4b71-b5ac-81d5ce227df5.jpg?1",
             "name": "Urban Burgeoning",
             "text": "Enchant land\nEnchanted land has \"Untap this land during each other player's untap step.\"",
             "colours": [
@@ -4632,7 +4632,7 @@
         },
         {
             "id": "a7df1656-dff2-532a-89ab-a53fa444ede6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d4ef98-949b-49db-b4f9-a070f8b4ff47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d4ef98-949b-49db-b4f9-a070f8b4ff47.jpg?1",
             "name": "Wild Beastmaster",
             "text": "Whenever Wild Beastmaster attacks, each other creature you control gets +X/+X until end of turn, where X is Wild Beastmaster's power.",
             "colours": [
@@ -4667,7 +4667,7 @@
         },
         {
             "id": "bd46f5f7-4382-52e5-b6b9-a3d9a84cb4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d55cb-3a6b-4620-af25-10ae74ed32c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543d55cb-3a6b-4620-af25-10ae74ed32c4.jpg?1",
             "name": "Worldspine Wurm",
             "text": "Trample\nWhen Worldspine Wurm dies, put three 5/5 green Wurm creature tokens with trample onto the battlefield.\nWhen Worldspine Wurm is put into a graveyard from anywhere, shuffle it into its owner's library.",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "62f644b3-742d-5aaf-a3a0-3e574fe96beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1e92b4-6e53-4dba-a572-c67e01965ac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b1e92b4-6e53-4dba-a572-c67e01965ac5.jpg?1",
             "name": "Abrupt Decay",
             "text": "Abrupt Decay can't be countered by spells or abilities.\nDestroy target nonland permanent with converted mana cost 3 or less.",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "9e882b7f-eca9-5c65-a1ae-22e63d8b3c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf91d847-4a87-4a65-8d6d-e20d538c5cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf91d847-4a87-4a65-8d6d-e20d538c5cec.jpg?1",
             "name": "Archon of the Triumvirate",
             "text": "Flying\nWhenever Archon of the Triumvirate attacks, detain up to two target nonland permanents your opponents control. (Until your next turn, those permanents can't attack or block and their activated abilities can't be activated.)",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "afaf189b-c45b-5aa4-a43c-dfd69f974901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cb4bf3-70d1-4acc-a1fb-49f4ea74ca16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cb4bf3-70d1-4acc-a1fb-49f4ea74ca16.jpg?1",
             "name": "Armada Wurm",
             "text": "Trample\nWhen Armada Wurm enters the battlefield, put a 5/5 green Wurm creature token with trample onto the battlefield.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "25d99b40-9fa1-5366-a49a-17c432d74341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9580a40b-b413-4f0d-9b38-13903a9d367d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9580a40b-b413-4f0d-9b38-13903a9d367d.jpg?1",
             "name": "Auger Spree",
             "text": "Target creature gets +4/-4 until end of turn.",
             "colours": [
@@ -4841,7 +4841,7 @@
         },
         {
             "id": "7263c6e6-efe0-5d5a-aae1-ee7fff299792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26adc211-d089-4102-91e5-225bbeb5f382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26adc211-d089-4102-91e5-225bbeb5f382.jpg?1",
             "name": "Azorius Charm",
             "text": "Choose one \u2014 Creatures you control gain lifelink until end of turn; or draw a card; or put target attacking or blocking creature on top of its owner's library.",
             "colours": [
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "6f261cee-b479-5dc5-8547-6069f218fc5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6df8f4d-a07a-4664-878d-efec8b2affb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6df8f4d-a07a-4664-878d-efec8b2affb9.jpg?1",
             "name": "Call of the Conclave",
             "text": "Put a 3/3 green Centaur creature token onto the battlefield.",
             "colours": [
@@ -4909,7 +4909,7 @@
         },
         {
             "id": "62c2c962-3471-51d0-a126-442baac64fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ada7ce-c693-48f0-a6e3-766f61d93370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ada7ce-c693-48f0-a6e3-766f61d93370.jpg?1",
             "name": "Carnival Hellsteed",
             "text": "First strike, haste\nUnleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -4946,7 +4946,7 @@
         },
         {
             "id": "a8b5bc7d-8820-55fc-a5c5-69cbbcd4868d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833835d1-9beb-4ad8-b675-7adebdbd7d82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833835d1-9beb-4ad8-b675-7adebdbd7d82.jpg?1",
             "name": "Centaur Healer",
             "text": "When Centaur Healer enters the battlefield, you gain 3 life.",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "e1f795ea-b79d-5a2c-bdcb-b7481c9b2dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfc2748-351f-4b5d-8a7e-bc51851578bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfc2748-351f-4b5d-8a7e-bc51851578bb.jpg?1",
             "name": "Chemister's Trick",
             "text": "Target creature you don't control gets -2/-0 until end of turn and attacks this turn if able.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "1ef0800a-f196-5a5e-a889-ba7936c18b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c84c4d-e6d6-4eac-9d14-5b6cba914c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c84c4d-e6d6-4eac-9d14-5b6cba914c3d.jpg?1",
             "name": "Collective Blessing",
             "text": "Creatures you control get +3/+3.",
             "colours": [
@@ -5051,7 +5051,7 @@
         },
         {
             "id": "fcb4a480-82d5-5ade-a437-181b5a08d0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59965953-1522-4103-9a6c-5534205d34d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59965953-1522-4103-9a6c-5534205d34d9.jpg?1",
             "name": "Common Bond",
             "text": "Put a +1/+1 counter on target creature.\nPut a +1/+1 counter on target creature.",
             "colours": [
@@ -5085,7 +5085,7 @@
         },
         {
             "id": "4ba8d403-aca7-597b-a448-98fe891dfe0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35a8efe-2a3e-4060-9134-d4150e4bdf28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b35a8efe-2a3e-4060-9134-d4150e4bdf28.jpg?1",
             "name": "Corpsejack Menace",
             "text": "If one or more +1/+1 counters would be placed on a creature you control, twice that many +1/+1 counters are placed on it instead.",
             "colours": [
@@ -5121,7 +5121,7 @@
         },
         {
             "id": "d52b7a2b-ba21-5b51-8d2c-d7fee6550dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4b773-40a4-4272-85dd-f728ada22748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e4b773-40a4-4272-85dd-f728ada22748.jpg?1",
             "name": "Counterflux",
             "text": "Counterflux can't be countered by spells or abilities.\nCounter target spell you don't control.\nOverload {1}{U}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -5155,7 +5155,7 @@
         },
         {
             "id": "aae50f78-3afe-517f-9337-e9e7e3a11b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f027ceb0-5d2b-4cf6-87ad-e6b9b1e20634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f027ceb0-5d2b-4cf6-87ad-e6b9b1e20634.jpg?1",
             "name": "Coursers' Accord",
             "text": "Put a 3/3 green Centaur creature token onto the battlefield, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -5189,7 +5189,7 @@
         },
         {
             "id": "fbe1c72e-a3dd-5561-87f5-f5cb786cdbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee5464-83b7-4d7a-b407-9ee7de21535b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee5464-83b7-4d7a-b407-9ee7de21535b.jpg?1",
             "name": "Detention Sphere",
             "text": "When Detention Sphere enters the battlefield, you may exile target nonland permanent not named Detention Sphere and all other permanents with the same name as that permanent.\nWhen Detention Sphere leaves the battlefield, return the exiled cards to the battlefield under their owner's control.",
             "colours": [
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "c36f4a97-8f85-58ac-bc4c-8027d92ebaf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041afd23-1ecc-4cca-9244-fe42203ad689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/041afd23-1ecc-4cca-9244-fe42203ad689.jpg?1",
             "name": "Dramatic Rescue",
             "text": "Return target creature to its owner's hand. You gain 2 life.",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "0799ee5c-7fee-5730-a0dc-1db9f9bdd192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83945c6-4dc6-4d9a-9bc2-2d4a264e5422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83945c6-4dc6-4d9a-9bc2-2d4a264e5422.jpg?1",
             "name": "Dreadbore",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -5291,7 +5291,7 @@
         },
         {
             "id": "ad0cd4da-3122-5b50-a625-e0b1c1678cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d42d6a-e9a0-449e-9b31-436c09b7c1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d42d6a-e9a0-449e-9b31-436c09b7c1ba.jpg?1",
             "name": "Dreg Mangler",
             "text": "Haste\nScavenge {3}{B}{G} ({3}{B}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -5328,7 +5328,7 @@
         },
         {
             "id": "267545e0-b280-59bd-85b8-cfbe57b56095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f0b68a-de4b-4c0c-98ac-a812017f88a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f0b68a-de4b-4c0c-98ac-a812017f88a7.jpg?1",
             "name": "Epic Experiment",
             "text": "Exile the top X cards of your library. For each instant and sorcery card with converted mana cost X or less among them, you may cast that card without paying its mana cost. Then put all cards exiled this way that weren't cast into your graveyard.",
             "colours": [
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "da71d3d1-73ff-5d5d-9d74-050d552fcd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98609dc-ea90-4c7e-a191-5e5d0ba16847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98609dc-ea90-4c7e-a191-5e5d0ba16847.jpg?1",
             "name": "Essence Backlash",
             "text": "Counter target creature spell. Essence Backlash deals damage equal to that spell's power to its controller.",
             "colours": [
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "2899b11b-3f1e-5848-ba90-c7eb9319251a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f42848-963b-4b16-aeec-66d0f349758b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f42848-963b-4b16-aeec-66d0f349758b.jpg?1",
             "name": "Fall of the Gavel",
             "text": "Counter target spell. You gain 5 life.",
             "colours": [
@@ -5430,7 +5430,7 @@
         },
         {
             "id": "b1970773-3e98-51c5-8349-9b66e75221b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5cb63-e7ec-4fc3-a389-4d8b5a4b96b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb5cb63-e7ec-4fc3-a389-4d8b5a4b96b9.jpg?1",
             "name": "Firemind's Foresight",
             "text": "Search your library for an instant card with converted mana cost 3, reveal it, and put it into your hand. Then repeat this process for instant cards with converted mana costs 2 and 1. Then shuffle your library.",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "c80c5386-f13a-539e-b343-704b02829a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb620f-4057-4f60-94b9-56ab855be974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79fb620f-4057-4f60-94b9-56ab855be974.jpg?1",
             "name": "Goblin Electromancer",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -5501,7 +5501,7 @@
         },
         {
             "id": "295c7e0b-9513-5745-9016-ae1a11ae52bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fce388-eefc-4234-8dd9-1260c1ba97eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48fce388-eefc-4234-8dd9-1260c1ba97eb.jpg?1",
             "name": "Golgari Charm",
             "text": "Choose one \u2014 All creatures get -1/-1 until end of turn; or destroy target enchantment; or regenerate each creature you control.",
             "colours": [
@@ -5535,7 +5535,7 @@
         },
         {
             "id": "9d3a4196-3813-5c64-832c-601ecd58db60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb5eb2a-ae7a-4416-970c-6e9306689c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb5eb2a-ae7a-4416-970c-6e9306689c88.jpg?1",
             "name": "Grisly Salvage",
             "text": "Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5569,7 +5569,7 @@
         },
         {
             "id": "a1c5f597-a919-5cdc-9bc4-627439fb572a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04560623-c768-4273-a40d-7e3f39e832cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04560623-c768-4273-a40d-7e3f39e832cf.jpg?1",
             "name": "Havoc Festival",
             "text": "Players can't gain life.\nAt the beginning of each player's upkeep, that player loses half his or her life, rounded up.",
             "colours": [
@@ -5603,7 +5603,7 @@
         },
         {
             "id": "ad58f109-4aec-5587-a5bc-750d5e1989db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4984a089-84af-4387-9a0d-819b119b5565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4984a089-84af-4387-9a0d-819b119b5565.jpg?1",
             "name": "Hellhole Flailer",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\n{2}{B}{R}, Sacrifice Hellhole Flailer: Hellhole Flailer deals damage equal to its power to target player.",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "f5973c53-2f01-5600-be88-f96152fdb6c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b56515-f688-495c-b721-2b9abc6628c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b56515-f688-495c-b721-2b9abc6628c2.jpg?1",
             "name": "Heroes' Reunion",
             "text": "Target player gains 7 life.",
             "colours": [
@@ -5674,7 +5674,7 @@
         },
         {
             "id": "d80c3626-c912-52fc-9f87-05ec436bd549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd775231-e1e0-41e2-ad9a-0726624f57f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd775231-e1e0-41e2-ad9a-0726624f57f9.jpg?1",
             "name": "Hussar Patrol",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nVigilance",
             "colours": [
@@ -5711,7 +5711,7 @@
         },
         {
             "id": "29819eaf-27c4-5561-9e93-e16d61ea1269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f024b19a-923a-4313-be06-e743d3fbab46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f024b19a-923a-4313-be06-e743d3fbab46.jpg?1",
             "name": "Hypersonic Dragon",
             "text": "Flying, haste\nYou may cast sorcery spells as though they had flash. (You may cast them any time you could cast an instant.)",
             "colours": [
@@ -5747,7 +5747,7 @@
         },
         {
             "id": "87428154-aad4-5739-a437-40930250f7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cce2d4-3944-4ff0-98e8-80f19697f108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cce2d4-3944-4ff0-98e8-80f19697f108.jpg?1",
             "name": "Isperia, Supreme Judge",
             "text": "Flying\nWhenever a creature attacks you or a planeswalker you control, you may draw a card.",
             "colours": [
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "da1add41-63d0-50e6-a4d0-074d93ec6589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5af6-5423-442b-a207-364e97a871d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5af6-5423-442b-a207-364e97a871d8.jpg?1",
             "name": "Izzet Charm",
             "text": "Choose one \u2014 Counter target noncreature spell unless its controller pays {2}; or Izzet Charm deals 2 damage to target creature; or draw two cards, then discard two cards.",
             "colours": [
@@ -5819,7 +5819,7 @@
         },
         {
             "id": "a039e0d1-b6b1-5ca0-b266-ea742fa3c251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ac2fe-532d-4d7e-9d74-07ae6850aac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190ac2fe-532d-4d7e-9d74-07ae6850aac8.jpg?1",
             "name": "Izzet Staticaster",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nHaste\n{T}: Izzet Staticaster deals 1 damage to target creature and each other creature with the same name as that creature.",
             "colours": [
@@ -5856,7 +5856,7 @@
         },
         {
             "id": "8700a1ac-6c89-57b1-b0fd-ac27c8c446c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef18d1-fd05-4dbc-9fa7-a383799b34e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02ef18d1-fd05-4dbc-9fa7-a383799b34e9.jpg?1",
             "name": "Jarad, Golgari Lich Lord",
             "text": "Jarad, Golgari Lich Lord gets +1/+1 for each creature card in your graveyard.\n{1}{B}{G}, Sacrifice another creature: Each opponent loses life equal to the sacrificed creature's power.\nSacrifice a Swamp and a Forest: Return Jarad from your graveyard to your hand.",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "8f111c1b-ae7f-574d-b8a1-710ec873b78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59171ce-7dc6-4dd9-a124-3c2c3028d93d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59171ce-7dc6-4dd9-a124-3c2c3028d93d.jpg?1",
             "name": "Jarad's Orders",
             "text": "Search your library for up to two creature cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle your library.",
             "colours": [
@@ -5929,7 +5929,7 @@
         },
         {
             "id": "26db2038-94f2-5275-a76f-858d0a5f8cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761c16aa-d4a7-492d-9275-98d0e07de45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761c16aa-d4a7-492d-9275-98d0e07de45a.jpg?1",
             "name": "Korozda Guildmage",
             "text": "{1}{B}{G}: Target creature gets +1/+1 and gains intimidate until end of turn.\n{2}{B}{G}, Sacrifice a nontoken creature: Put X 1/1 green Saproling creature tokens onto the battlefield, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -5966,7 +5966,7 @@
         },
         {
             "id": "42b4f76e-fef7-5a62-81ed-c0530eafc2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b628197-f26c-457a-b9a4-c1f1d3e02f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b628197-f26c-457a-b9a4-c1f1d3e02f3d.jpg?1",
             "name": "Lotleth Troll",
             "text": "Trample\nDiscard a creature card: Put a +1/+1 counter on Lotleth Troll.\n{B}: Regenerate Lotleth Troll.",
             "colours": [
@@ -6003,7 +6003,7 @@
         },
         {
             "id": "98e14bfd-45e0-565d-b314-3b362f298fc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69247168-2bfb-4cce-a2a6-61459a0fbce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69247168-2bfb-4cce-a2a6-61459a0fbce4.jpg?1",
             "name": "Loxodon Smiter",
             "text": "Loxodon Smiter can't be countered.\nIf a spell or ability an opponent controls causes you to discard Loxodon Smiter, put it onto the battlefield instead of putting it into your graveyard.",
             "colours": [
@@ -6040,7 +6040,7 @@
         },
         {
             "id": "74f86a46-9a4b-51e7-aecc-ea47968e6b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbeb3b-1579-4318-a024-4a2c06896eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11cbeb3b-1579-4318-a024-4a2c06896eaf.jpg?1",
             "name": "Lyev Skyknight",
             "text": "Flying\nWhen Lyev Skyknight enters the battlefield, detain target nonland permanent an opponent controls. (Until your next turn, that permanent can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -6077,7 +6077,7 @@
         },
         {
             "id": "b2779a0e-bc02-586d-8f41-b877e0bb345f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881728ce-4b18-410e-9cdb-4d439ce0b21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881728ce-4b18-410e-9cdb-4d439ce0b21d.jpg?1",
             "name": "Mercurial Chemister",
             "text": "{U}, {T}: Draw two cards.\n{R}, {T}, Discard a card: Mercurial Chemister deals damage to target creature equal to the discarded card's converted mana cost.",
             "colours": [
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "7e41f87f-f008-5bf3-8c0e-f8275bb3d33d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b47d1-c72e-4dc3-b28b-7421e0163f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698b47d1-c72e-4dc3-b28b-7421e0163f22.jpg?1",
             "name": "New Prahv Guildmage",
             "text": "{W}{U}: Target creature gains flying until end of turn.\n{3}{W}{U}: Detain target nonland permanent an opponent controls. (Until your next turn, that permanent can't attack or block and its activated abilities can't be activated.)",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "1b81600d-c722-52ea-a9c3-6657b6603ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fde47-8d9e-4a84-b8a5-dcfe0c1d443c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3fde47-8d9e-4a84-b8a5-dcfe0c1d443c.jpg?1",
             "name": "Nivix Guildmage",
             "text": "{1}{U}{R}: Draw a card, then discard a card.\n{2}{U}{R}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -6188,7 +6188,7 @@
         },
         {
             "id": "d08934de-8b16-5cdc-bfe1-de8aa6d5494b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345e475-8095-41b5-90b4-771fcf80b939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345e475-8095-41b5-90b4-771fcf80b939.jpg?1",
             "name": "Niv-Mizzet, Dracogenius",
             "text": "Flying\nWhenever Niv-Mizzet, Dracogenius deals damage to a player, you may draw a card.\n{U}{R}: Niv-Mizzet, Dracogenius deals 1 damage to target creature or player.",
             "colours": [
@@ -6227,7 +6227,7 @@
         },
         {
             "id": "d27352ef-8c8e-56d9-9b5f-15d039bd09f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd4394-d22d-4eec-ad73-ffaf10ad60de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd4394-d22d-4eec-ad73-ffaf10ad60de.jpg?1",
             "name": "Rakdos Charm",
             "text": "Choose one \u2014 Exile all cards from target player's graveyard; or destroy target artifact; or each creature deals 1 damage to its controller.",
             "colours": [
@@ -6261,7 +6261,7 @@
         },
         {
             "id": "7dc2a217-deb6-54cb-af9e-1e3753349604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb36840a-3f85-4fca-87ab-379dfce8e542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb36840a-3f85-4fca-87ab-379dfce8e542.jpg?1",
             "name": "Rakdos Ragemutt",
             "text": "Lifelink, haste",
             "colours": [
@@ -6298,7 +6298,7 @@
         },
         {
             "id": "faba4d3d-8baa-5016-b079-e382c08e3641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b54fbe8-324a-4066-bed1-dda1dca319fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b54fbe8-324a-4066-bed1-dda1dca319fc.jpg?1",
             "name": "Rakdos Ringleader",
             "text": "First strike\nWhenever Rakdos Ringleader deals combat damage to a player, that player discards a card at random.\n{B}: Regenerate Rakdos Ringleader.",
             "colours": [
@@ -6335,7 +6335,7 @@
         },
         {
             "id": "cc1f6453-9998-5adb-ae53-1c1ac30ee807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f3db71-802f-488c-b40d-ac90df2d660a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f3db71-802f-488c-b40d-ac90df2d660a.jpg?1",
             "name": "Rakdos, Lord of Riots",
             "text": "You can't cast Rakdos, Lord of Riots unless an opponent lost life this turn.\nFlying, trample\nCreature spells you cast cost {1} less to cast for each 1 life your opponents have lost this turn.",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "7482cf30-2829-54a1-b377-09387bffc406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72981c0-1632-4d64-9341-2a76047d9b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72981c0-1632-4d64-9341-2a76047d9b36.jpg?1",
             "name": "Rakdos's Return",
             "text": "Rakdos's Return deals X damage to target opponent. That player discards X cards.",
             "colours": [
@@ -6407,7 +6407,7 @@
         },
         {
             "id": "e26d82dd-fb07-5e1b-ba57-3732ef09c299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6695e5bb-56a9-49ab-8940-72336e845875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6695e5bb-56a9-49ab-8940-72336e845875.jpg?1",
             "name": "Righteous Authority",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each card in its controller's hand.\nAt the beginning of the draw step of enchanted creature's controller, that player draws an additional card.",
             "colours": [
@@ -6443,7 +6443,7 @@
         },
         {
             "id": "261d27d7-0744-541f-9f11-d21a0dc37f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6c136-2bbe-48c1-ac53-2a8221b96936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6c136-2bbe-48c1-ac53-2a8221b96936.jpg?1",
             "name": "Risen Sanctuary",
             "text": "Vigilance",
             "colours": [
@@ -6479,7 +6479,7 @@
         },
         {
             "id": "a32a9c14-b4ce-5169-bdc1-d4340a7ca2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115d504f-3aec-4374-8cd8-732d56c448f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115d504f-3aec-4374-8cd8-732d56c448f2.jpg?1",
             "name": "Rites of Reaping",
             "text": "Target creature gets +3/+3 until end of turn. Another target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -6513,7 +6513,7 @@
         },
         {
             "id": "a90b8ea5-cf4d-5258-9702-1ab18c97200a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb737465-5de8-4015-befe-2bf386da2a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb737465-5de8-4015-befe-2bf386da2a89.jpg?1",
             "name": "Rix Maadi Guildmage",
             "text": "{B}{R}: Target blocking creature gets -1/-1 until end of turn.\n{B}{R}: Target player who lost life this turn loses 1 life.",
             "colours": [
@@ -6550,7 +6550,7 @@
         },
         {
             "id": "4a740a27-923f-5629-9f93-0dc4ab5e298f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f625a-6e9e-40ba-ae46-cf6bafc0a41b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55f625a-6e9e-40ba-ae46-cf6bafc0a41b.jpg?1",
             "name": "Search Warrant",
             "text": "Target player reveals his or her hand. You gain life equal to the number of cards in that player's hand.",
             "colours": [
@@ -6584,7 +6584,7 @@
         },
         {
             "id": "38e76f56-4271-56c7-95cb-92cf22d183d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9848eab-1d3a-4ab0-adf6-c20858aa3afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9848eab-1d3a-4ab0-adf6-c20858aa3afb.jpg?1",
             "name": "Selesnya Charm",
             "text": "Choose one \u2014 Target creature gets +2/+2 and gains trample until end of turn; or exile target creature with power 5 or greater; or put a 2/2 white Knight creature token with vigilance onto the battlefield.",
             "colours": [
@@ -6618,7 +6618,7 @@
         },
         {
             "id": "86ce8b1e-75b5-59e8-84e1-850d3bdd7a1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8efb23-bac0-41d2-b4ee-27a6b1fe3134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8efb23-bac0-41d2-b4ee-27a6b1fe3134.jpg?1",
             "name": "Skull Rend",
             "text": "Skull Rend deals 2 damage to each opponent. Those players each discard two cards at random.",
             "colours": [
@@ -6652,7 +6652,7 @@
         },
         {
             "id": "da00e288-5639-5e95-8809-5a52ab09c11d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60601296-2229-4c48-94cc-1903926750ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60601296-2229-4c48-94cc-1903926750ce.jpg?1",
             "name": "Skymark Roc",
             "text": "Flying\nWhenever Skymark Roc attacks, you may return target creature defending player controls with toughness 2 or less to its owner's hand.",
             "colours": [
@@ -6688,7 +6688,7 @@
         },
         {
             "id": "d2655e7a-1075-5cf2-b733-f7fdc9e50b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf37391d-db35-40a7-908a-abb53895793c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf37391d-db35-40a7-908a-abb53895793c.jpg?1",
             "name": "Slaughter Games",
             "text": "Slaughter Games can't be countered by spells or abilities.\nName a nonland card. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -6722,7 +6722,7 @@
         },
         {
             "id": "25a0576e-ee90-5fb7-aabe-8c62c01593f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6dbadf-a6f7-4876-9c3f-44e4a33b2bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b6dbadf-a6f7-4876-9c3f-44e4a33b2bee.jpg?1",
             "name": "Sluiceway Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nScavenge {1}{B}{G} ({1}{B}{G}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "7dbc20b9-c41c-5b2e-a338-35c4374ffbba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6196e702-7f76-49db-8ee4-bd343359d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6196e702-7f76-49db-8ee4-bd343359d498.jpg?1",
             "name": "Spawn of Rix Maadi",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -6794,7 +6794,7 @@
         },
         {
             "id": "42af1e4f-ccd3-5a1c-890e-c5074c217cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404d9413-ef57-4b6e-8584-48a1dc7fe6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404d9413-ef57-4b6e-8584-48a1dc7fe6f1.jpg?1",
             "name": "Sphinx's Revelation",
             "text": "You gain X life and draw X cards.",
             "colours": [
@@ -6828,7 +6828,7 @@
         },
         {
             "id": "9f3eb978-cf16-5f9f-85ca-bbabecb160c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9648f9-7a67-4717-bca1-861d1f7fed43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9648f9-7a67-4717-bca1-861d1f7fed43.jpg?1",
             "name": "Supreme Verdict",
             "text": "Supreme Verdict can't be countered.\nDestroy all creatures.",
             "colours": [
@@ -6862,7 +6862,7 @@
         },
         {
             "id": "75474a07-64de-52c2-ba8c-27e26d74d565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438c718-ac18-45d5-824e-5b697c5f0692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e438c718-ac18-45d5-824e-5b697c5f0692.jpg?1",
             "name": "Teleportal",
             "text": "Target creature you control gets +1/+0 until end of turn and is unblockable this turn.\nOverload {3}{U}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -6896,7 +6896,7 @@
         },
         {
             "id": "80953f98-2522-5e04-96c5-3a6e258fbb63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90514aa-e356-4502-9e0e-76ab7644a07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90514aa-e356-4502-9e0e-76ab7644a07a.jpg?1",
             "name": "Thoughtflare",
             "text": "Draw four cards, then discard two cards.",
             "colours": [
@@ -6930,7 +6930,7 @@
         },
         {
             "id": "91c7d237-7aee-5e22-a790-6e5d7a4ec652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c0e00b-2290-493f-a3fc-3b9bff2830cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c0e00b-2290-493f-a3fc-3b9bff2830cc.jpg?1",
             "name": "Treasured Find",
             "text": "Return target card from your graveyard to your hand. Exile Treasured Find.",
             "colours": [
@@ -6964,7 +6964,7 @@
         },
         {
             "id": "3e0da6f3-6cc2-56ab-990f-e5348cd51e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d224279-83f3-4a29-9fd9-86b72407b87a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d224279-83f3-4a29-9fd9-86b72407b87a.jpg?1",
             "name": "Trestle Troll",
             "text": "Defender\nReach (This creature can block creatures with flying.)\n{1}{B}{G}: Regenerate Trestle Troll.",
             "colours": [
@@ -7000,7 +7000,7 @@
         },
         {
             "id": "3dfc134d-58d9-506d-8f99-9ade811624ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d9d86-5666-4e59-9766-137657b4e040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1d9d86-5666-4e59-9766-137657b4e040.jpg?1",
             "name": "Trostani, Selesnya's Voice",
             "text": "Whenever another creature enters the battlefield under your control, you gain life equal to that creature's toughness.\n{1}{G}{W}, {T}: Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7038,7 +7038,7 @@
         },
         {
             "id": "beebbebd-a4b6-566e-b208-015157af6ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54f8e61-550f-4493-b8ba-65f81b2457d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54f8e61-550f-4493-b8ba-65f81b2457d3.jpg?1",
             "name": "Vitu-Ghazi Guildmage",
             "text": "{4}{G}{W}: Put a 3/3 green Centaur creature token onto the battlefield.\n{2}{G}{W}: Populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7075,7 +7075,7 @@
         },
         {
             "id": "48e634f1-32cd-5773-a6ed-93cd70e05f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8971938c-cd26-4b83-96d7-1408cd0b0de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8971938c-cd26-4b83-96d7-1408cd0b0de6.jpg?1",
             "name": "Vraska the Unseen",
             "text": "+1: Until your next turn, whenever a creature deals combat damage to Vraska the Unseen, destroy that creature.\n-3: Destroy target nonland permanent.\n-7: Put three 1/1 black Assassin creature tokens onto the battlefield with \"Whenever this creature deals combat damage to a player, that player loses the game.\"",
             "colours": [
@@ -7113,7 +7113,7 @@
         },
         {
             "id": "7bfb1a19-dcfd-51c6-9c1a-20f79be810ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125e6aa-f916-4dfa-a9fe-82bb546012af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2125e6aa-f916-4dfa-a9fe-82bb546012af.jpg?1",
             "name": "Wayfaring Temple",
             "text": "Wayfaring Temple's power and toughness are each equal to the number of creatures you control.\nWhenever Wayfaring Temple deals combat damage to a player, populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "a1d0f719-4825-5938-8a0f-503a1effae99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e82934-546b-4734-a715-b22ace4c5a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61e82934-546b-4734-a715-b22ace4c5a9b.jpg?1",
             "name": "Azor's Elocutors",
             "text": "At the beginning of your upkeep, put a filibuster counter on Azor's Elocutors. Then if Azor's Elocutors has five or more filibuster counters on it, you win the game.\nWhenever a source deals damage to you, remove a filibuster counter from Azor's Elocutors.",
             "colours": [
@@ -7186,7 +7186,7 @@
         },
         {
             "id": "c25092b0-f825-5c25-bef8-21d70492393c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a8e716-ea33-4ae2-9ff8-5e78b0e50459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a8e716-ea33-4ae2-9ff8-5e78b0e50459.jpg?1",
             "name": "Blistercoil Weird",
             "text": "Whenever you cast an instant or sorcery spell, Blistercoil Weird gets +1/+1 until end of turn. Untap it.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "99327fe0-7d94-565a-805e-97a57bfb9683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffd77d7-3fe6-4493-96eb-f62183c0358d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffd77d7-3fe6-4493-96eb-f62183c0358d.jpg?1",
             "name": "Cryptborn Horror",
             "text": "Trample\nCryptborn Horror enters the battlefield with X +1/+1 counters on it, where X is the total life lost by your opponents this turn.",
             "colours": [
@@ -7258,7 +7258,7 @@
         },
         {
             "id": "407ac6a4-cb3c-54f9-beb0-08e7e5d81c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70496f16-c4c0-4c03-beef-454eb4824cd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70496f16-c4c0-4c03-beef-454eb4824cd1.jpg?1",
             "name": "Deathrite Shaman",
             "text": "{T}: Exile target land card from a graveyard. Add one mana of any color to your mana pool.\n{B}, {T}: Exile target instant or sorcery card from a graveyard. Each opponent loses 2 life.\n{G}, {T}: Exile target creature card from a graveyard. You gain 2 life.",
             "colours": [
@@ -7295,7 +7295,7 @@
         },
         {
             "id": "ba4f0d83-c19a-529f-9983-6d2845970883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb8cb8c-0d03-4cbf-b7f2-a97324817698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb8cb8c-0d03-4cbf-b7f2-a97324817698.jpg?1",
             "name": "Dryad Militant",
             "text": "If an instant or sorcery card would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -7332,7 +7332,7 @@
         },
         {
             "id": "fe23238c-357b-5cbb-98a4-1ebd8ec5743e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5a68d3-6bc9-4de8-bc06-e1106cf9b3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5a68d3-6bc9-4de8-bc06-e1106cf9b3d4.jpg?1",
             "name": "Frostburn Weird",
             "text": "{UR}: Frostburn Weird gets +1/-1 until end of turn.",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "51d539bb-b34f-530e-9c12-9b865503ceef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44058ba-3419-4777-8d59-05dea5e864e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44058ba-3419-4777-8d59-05dea5e864e1.jpg?1",
             "name": "Golgari Longlegs",
             "text": "",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "8c0afb1c-fb48-51a9-a6e6-92ec52e3debc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f31616-1249-4964-b81a-4435405a2449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f31616-1249-4964-b81a-4435405a2449.jpg?1",
             "name": "Growing Ranks",
             "text": "At the beginning of your upkeep, populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "ded40915-eb69-56ed-82de-ed0e454cb51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc51899-3970-416b-b7de-fadbc9678955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc51899-3970-416b-b7de-fadbc9678955.jpg?1",
             "name": "Judge's Familiar",
             "text": "Flying\nSacrifice Judge's Familiar: Counter target instant or sorcery spell unless its controller pays {1}.",
             "colours": [
@@ -7474,7 +7474,7 @@
         },
         {
             "id": "3f5440f7-cd72-523d-9526-f455ba084e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1892003-2e4c-43bd-8a37-3a97a76f113a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1892003-2e4c-43bd-8a37-3a97a76f113a.jpg?1",
             "name": "Nivmagus Elemental",
             "text": "Exile an instant or sorcery spell you control: Put two +1/+1 counters on Nivmagus Elemental. (That spell won't resolve.)",
             "colours": [
@@ -7510,7 +7510,7 @@
         },
         {
             "id": "8a798a57-5261-5d35-9b30-1eb10e871cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f873c0b-e779-4f09-8e9c-94a1765eb5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f873c0b-e779-4f09-8e9c-94a1765eb5da.jpg?1",
             "name": "Rakdos Cackler",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)",
             "colours": [
@@ -7546,7 +7546,7 @@
         },
         {
             "id": "0b2f5e44-6d29-5f58-9c56-e3e723153f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06899549-5534-4d11-86c1-afd1796e18b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06899549-5534-4d11-86c1-afd1796e18b1.jpg?1",
             "name": "Rakdos Shred-Freak",
             "text": "Haste",
             "colours": [
@@ -7583,7 +7583,7 @@
         },
         {
             "id": "3c1d4f62-a592-5ded-ac9e-f876097e6ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9327905-a254-4885-8310-69fc153ec52f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9327905-a254-4885-8310-69fc153ec52f.jpg?1",
             "name": "Slitherhead",
             "text": "Scavenge {0} ({0}, Exile this card from your graveyard: Put a number of +1/+1 counters equal to this card's power on target creature. Scavenge only as a sorcery.)",
             "colours": [
@@ -7620,7 +7620,7 @@
         },
         {
             "id": "25aa872b-5d06-5769-81c5-b280d432311c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5048e-cb76-48c4-8a95-70dcc14775f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14d5048e-cb76-48c4-8a95-70dcc14775f6.jpg?1",
             "name": "Sundering Growth",
             "text": "Destroy target artifact or enchantment, then populate. (Put a token onto the battlefield that's a copy of a creature token you control.)",
             "colours": [
@@ -7654,7 +7654,7 @@
         },
         {
             "id": "6a677ade-135e-5763-a464-53e14b87de26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc61748-029f-4bae-a7ec-e08b7059226d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfc61748-029f-4bae-a7ec-e08b7059226d.jpg?1",
             "name": "Vassal Soul",
             "text": "Flying",
             "colours": [
@@ -7690,7 +7690,7 @@
         },
         {
             "id": "fe109cd6-5c42-516b-ae92-8d5ccfefde45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a05db7-dcae-4180-8ad1-60ba6fb30816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a05db7-dcae-4180-8ad1-60ba6fb30816.jpg?1",
             "name": "Azorius Keyrune",
             "text": "{T}: Add {W} or {U} to your mana pool.\n{W}{U}: Azorius Keyrune becomes a 2/2 white and blue Bird artifact creature with flying until end of turn.",
             "colours": [],
@@ -7721,7 +7721,7 @@
         },
         {
             "id": "94e92c02-a660-50b9-9fd0-601bcc547837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f4e0f0-13d1-43ed-8d95-13cff94a26e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f4e0f0-13d1-43ed-8d95-13cff94a26e7.jpg?1",
             "name": "Chromatic Lantern",
             "text": "Lands you control have \"{T}: Add one mana of any color to your mana pool.\"\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "f7489abf-d449-5475-b35c-5056d8bd1ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c9247e-05f4-44bb-86e3-90a60e880374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c9247e-05f4-44bb-86e3-90a60e880374.jpg?1",
             "name": "Civic Saber",
             "text": "Equipped creature gets +1/+0 for each of its colors.\nEquip {1}",
             "colours": [],
@@ -7779,7 +7779,7 @@
         },
         {
             "id": "e9f14529-25ce-56cd-bdee-22e3eca7c9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b632b-ee20-4082-8376-1dae53f91b70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f7b632b-ee20-4082-8376-1dae53f91b70.jpg?1",
             "name": "Codex Shredder",
             "text": "{T}: Target player puts the top card of his or her library into his or her graveyard.\n{5}, {T}, Sacrifice Codex Shredder: Return target card from your graveyard to your hand.",
             "colours": [],
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "1acf866f-bbcb-531f-94fc-fd07165b1bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b803f-ba82-4660-86be-49677d1e32c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/913b803f-ba82-4660-86be-49677d1e32c9.jpg?1",
             "name": "Golgari Keyrune",
             "text": "{T}: Add {B} or {G} to your mana pool.\n{B}{G}: Golgari Keyrune becomes a 2/2 black and green Insect artifact creature with deathtouch until end of turn.",
             "colours": [],
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "a7ac23c6-1586-5731-81ad-8802c65e0d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e4e83b-cbb8-4efd-b6c4-4459a29177ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e4e83b-cbb8-4efd-b6c4-4459a29177ac.jpg?1",
             "name": "Izzet Keyrune",
             "text": "{T}: Add {U} or {R} to your mana pool.\n{U}{R}: Until end of turn, Izzet Keyrune becomes a 2/1 blue and red Elemental artifact creature.\nWhenever Izzet Keyrune deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [],
@@ -7869,7 +7869,7 @@
         },
         {
             "id": "0c090097-dc52-5593-bad4-f0397994e1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c1e91-9d75-46a3-9e0d-56d29fcb01a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786c1e91-9d75-46a3-9e0d-56d29fcb01a7.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle enters the battlefield, name a card.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "b51d3bd3-090a-58dd-ac2d-e3e559550f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6124b4c-49a1-42e3-a6ff-62de231c7823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6124b4c-49a1-42e3-a6ff-62de231c7823.jpg?1",
             "name": "Rakdos Keyrune",
             "text": "{T}: Add {B} or {R} to your mana pool.\n{B}{R}: Rakdos Keyrune becomes a 3/1 black and red Devil artifact creature with first strike until end of turn.",
             "colours": [],
@@ -7928,7 +7928,7 @@
         },
         {
             "id": "744899b4-461b-5e2a-b50d-e705a554a109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1645eafd-cd17-463a-9d7e-42f5f7b5196f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1645eafd-cd17-463a-9d7e-42f5f7b5196f.jpg?1",
             "name": "Selesnya Keyrune",
             "text": "{T}: Add {G} or {W} to your mana pool.\n{G}{W}: Selesnya Keyrune becomes a 3/3 green and white Wolf artifact creature until end of turn.",
             "colours": [],
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "f1817e1d-df5a-57ef-b4c2-3cd78261a7cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a62827a-183f-4bef-b6ce-20a4577f6d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a62827a-183f-4bef-b6ce-20a4577f6d30.jpg?1",
             "name": "Street Sweeper",
             "text": "Whenever Street Sweeper attacks, destroy all Auras attached to target land.",
             "colours": [],
@@ -7990,7 +7990,7 @@
         },
         {
             "id": "104dfd9f-21b2-5e94-9739-48aa5d35fc02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b006384-6fb6-4129-b1d2-7674d1141f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b006384-6fb6-4129-b1d2-7674d1141f8f.jpg?1",
             "name": "Tablet of the Guilds",
             "text": "As Tablet of the Guilds enters the battlefield, choose two colors.\nWhenever you cast a spell, if it's at least one of the chosen colors, you gain 1 life for each of the chosen colors it is.",
             "colours": [],
@@ -8018,7 +8018,7 @@
         },
         {
             "id": "f0d80ec2-2f6e-57e0-bbb1-232624482086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5055ed18-b234-4702-92eb-4d483431ff47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5055ed18-b234-4702-92eb-4d483431ff47.jpg?1",
             "name": "Volatile Rig",
             "text": "Trample\nVolatile Rig attacks each turn if able.\nWhenever Volatile Rig is dealt damage, flip a coin. If you lose the flip, sacrifice Volatile Rig.\nWhen Volatile Rig dies, flip a coin. If you lose the flip, it deals 4 damage to each creature and each player.",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "5a32f8d8-aeac-5393-a41a-ba40cad7af39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984e37df-0734-493a-a958-f519a0c98580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/984e37df-0734-493a-a958-f519a0c98580.jpg?1",
             "name": "Azorius Guildgate",
             "text": "Azorius Guildgate enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "a8e77a71-0ddb-5d2c-bc96-4f1a6e9f5274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd5828b-8dcd-4ce6-b834-ebe9cbaa12d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bd5828b-8dcd-4ce6-b834-ebe9cbaa12d1.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R} to your mana pool.)\nAs Blood Crypt enters the battlefield, you may pay 2 life. If you don't, Blood Crypt enters the battlefield tapped.",
             "colours": [],
@@ -8116,7 +8116,7 @@
         },
         {
             "id": "a6110455-8f32-5819-9c2c-4f934d80b38c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe2fd1a-f7d3-48b4-bad8-be5ee45d6121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fe2fd1a-f7d3-48b4-bad8-be5ee45d6121.jpg?1",
             "name": "Golgari Guildgate",
             "text": "Golgari Guildgate enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "aceaeff5-6070-5f26-b825-34da90891163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf60ca0-e01f-499c-8d04-d59050f38c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf60ca0-e01f-499c-8d04-d59050f38c33.jpg?1",
             "name": "Grove of the Guardian",
             "text": "{T}: Add {1} to your mana pool.\n{3}{G}{W}, {T}, Tap two untapped creatures you control, Sacrifice Grove of the Guardian: Put an 8/8 green and white Elemental creature token with vigilance onto the battlefield.",
             "colours": [],
@@ -8180,7 +8180,7 @@
         },
         {
             "id": "a48a7df6-1a09-5c2f-8879-8134249a7555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7091c9-5f98-4078-a42b-c9e057346d9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7091c9-5f98-4078-a42b-c9e057346d9b.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U} to your mana pool.)\nAs Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, Hallowed Fountain enters the battlefield tapped.",
             "colours": [],
@@ -8214,7 +8214,7 @@
         },
         {
             "id": "7cb7f243-78d3-5622-bd52-c8461b3d1822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6951d84f-2d3c-4203-8d31-e08f4bc707f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6951d84f-2d3c-4203-8d31-e08f4bc707f0.jpg?1",
             "name": "Izzet Guildgate",
             "text": "Izzet Guildgate enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -8247,7 +8247,7 @@
         },
         {
             "id": "05e270c9-fac0-5bd8-8654-3ff9e1ddd957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7d50d6-b63a-4d8c-88fa-1d78ae693a45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c7d50d6-b63a-4d8c-88fa-1d78ae693a45.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G} to your mana pool.)\nAs Overgrown Tomb enters the battlefield, you may pay 2 life. If you don't, Overgrown Tomb enters the battlefield tapped.",
             "colours": [],
@@ -8281,7 +8281,7 @@
         },
         {
             "id": "cbf17453-adf0-597e-996d-99e484418919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207048f5-268b-4cdb-b4e7-c8282cac1b28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207048f5-268b-4cdb-b4e7-c8282cac1b28.jpg?1",
             "name": "Rakdos Guildgate",
             "text": "Rakdos Guildgate enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -8314,7 +8314,7 @@
         },
         {
             "id": "85699155-7a97-5a3d-8fb3-817e1fcf34b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f416e36a-15cb-43c8-b27f-82f65a95ddef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f416e36a-15cb-43c8-b27f-82f65a95ddef.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {1} to your mana pool.\n{4}, {T}: Target creature is unblockable this turn.",
             "colours": [],
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "6bd7acda-c26d-5558-917a-fa7233494954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff61d4e4-3c8c-48f7-a994-ec2317bbd9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff61d4e4-3c8c-48f7-a994-ec2317bbd9a0.jpg?1",
             "name": "Selesnya Guildgate",
             "text": "Selesnya Guildgate enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "e471d793-14da-551b-a4e7-fbf0a1bfc3f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de911c88-f5c8-4955-9fa5-1f28a9b17236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de911c88-f5c8-4955-9fa5-1f28a9b17236.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R} to your mana pool.)\nAs Steam Vents enters the battlefield, you may pay 2 life. If you don't, Steam Vents enters the battlefield tapped.",
             "colours": [],
@@ -8409,7 +8409,7 @@
         },
         {
             "id": "a740fc1f-cab9-5a5e-9d82-c480c5adcfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b821e604-f9fd-47a4-b5ff-bfb5022834c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b821e604-f9fd-47a4-b5ff-bfb5022834c2.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W} to your mana pool.)\nAs Temple Garden enters the battlefield, you may pay 2 life. If you don't, Temple Garden enters the battlefield tapped.",
             "colours": [],
@@ -8443,7 +8443,7 @@
         },
         {
             "id": "40f96673-3900-592d-bffd-d15665a25898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ce8115-41fe-44c2-8719-741ba87bcb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ce8115-41fe-44c2-8719-741ba87bcb17.jpg?1",
             "name": "Transguild Promenade",
             "text": "Transguild Promenade enters the battlefield tapped.\nWhen Transguild Promenade enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "bdfd114d-cad4-5b1c-a4a0-c9d5266758a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac754820-343e-4c01-bcfa-89fa5c8c7e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac754820-343e-4c01-bcfa-89fa5c8c7e1d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8510,7 +8510,7 @@
         },
         {
             "id": "cfde8495-0254-582c-a40f-ebd0686eb737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34044cf5-79ed-479c-abdc-3718ec193dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34044cf5-79ed-479c-abdc-3718ec193dd3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8549,7 +8549,7 @@
         },
         {
             "id": "7ac30db4-5f2e-593b-93be-ede877251f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9bcca-b41a-4a6a-b380-36bfea9f0715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9bcca-b41a-4a6a-b380-36bfea9f0715.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "68779ab2-469a-5969-8495-319aca24958a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d293ea0f-8b87-4d8a-ad8f-650131c83c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d293ea0f-8b87-4d8a-ad8f-650131c83c20.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8627,7 +8627,7 @@
         },
         {
             "id": "22a77a78-9b38-5ec2-a07a-9511d8c5f034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0334fe-3de3-4779-a31d-d021db50b62b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0334fe-3de3-4779-a31d-d021db50b62b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8666,7 +8666,7 @@
         },
         {
             "id": "77977e3a-9366-5a59-bf56-ff863278ec45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f35064-c662-48ff-a2a9-d26f594500f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f35064-c662-48ff-a2a9-d26f594500f5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8705,7 +8705,7 @@
         },
         {
             "id": "d2cae570-18ad-5b8f-82ba-7180464316c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc5e0d9-1c8f-4d38-9915-40469988983d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dc5e0d9-1c8f-4d38-9915-40469988983d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8744,7 +8744,7 @@
         },
         {
             "id": "15612963-4a63-5c3f-bcad-82d9ea4a3000",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10e5b17-6099-445d-9a7b-484eeff7cea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10e5b17-6099-445d-9a7b-484eeff7cea8.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "1c1c7e9f-d959-532e-a2ff-253366d7e0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7869f14e-d1d5-4a99-bc2c-f3a0d63077a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7869f14e-d1d5-4a99-bc2c-f3a0d63077a5.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8822,7 +8822,7 @@
         },
         {
             "id": "5bac5f92-3821-5c1d-8bea-929222fe3d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070e97c-142a-4d5d-ae89-c0c6d85a97ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e070e97c-142a-4d5d-ae89-c0c6d85a97ac.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8861,7 +8861,7 @@
         },
         {
             "id": "c84fb37b-2ebf-5eba-8485-8bd9aa847f02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8c3f29-121e-42d1-be21-29f403f97708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8c3f29-121e-42d1-be21-29f403f97708.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "58df248d-fc92-5bb4-9dbe-8d97a76f6af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73b50e-8230-41e5-8492-db8f749d00a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be73b50e-8230-41e5-8492-db8f749d00a4.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8939,7 +8939,7 @@
         },
         {
             "id": "ca7d5bf1-3358-5fab-93a2-cc5b6353cabc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46908606-f572-4b2d-9562-ed9c6f50f1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46908606-f572-4b2d-9562-ed9c6f50f1ad.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "4e18e9da-11e4-54c6-bd08-30a9d979cef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cd375e-f41c-42b1-bbd4-36032d4fb92d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cd375e-f41c-42b1-bbd4-36032d4fb92d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9017,7 +9017,7 @@
         },
         {
             "id": "5974900b-fc2a-599c-854f-7b1bff284bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745b1731-af31-44d2-ad50-b3e43b620913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/745b1731-af31-44d2-ad50-b3e43b620913.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9056,7 +9056,7 @@
         },
         {
             "id": "8ed8d3d1-47da-5acb-a7f7-c5354992559e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4a196f-de7e-4100-ad65-56cf8b0a8b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b4a196f-de7e-4100-ad65-56cf8b0a8b23.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9095,7 +9095,7 @@
         },
         {
             "id": "a82cd940-f0e4-5d30-b157-288ea7a10cfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b2d0ed-0b47-459a-8f5c-554dd816c03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b2d0ed-0b47-459a-8f5c-554dd816c03a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9134,7 +9134,7 @@
         },
         {
             "id": "818ad8df-ec4c-57cd-bafc-f3552f848744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5353e8b2-3280-48ec-9bc2-8c8e7a15b460.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5353e8b2-3280-48ec-9bc2-8c8e7a15b460.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "7b1f34d0-ebd9-5cf2-aaba-8311ac58d11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b61852-860e-4f89-a1b2-6429168f0c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b61852-860e-4f89-a1b2-6429168f0c02.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9212,7 +9212,7 @@
         },
         {
             "id": "1d4bb587-5cce-593a-a64c-a26232c53a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96614dc1-9386-4861-b792-b83bcc6c5811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96614dc1-9386-4861-b792-b83bcc6c5811.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9251,7 +9251,7 @@
         },
         {
             "id": "9255569f-4eba-5d9a-b6ed-9f5517a93974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00849dd-c1ba-4171-a503-603fe77c0a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00849dd-c1ba-4171-a503-603fe77c0a43.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9290,7 +9290,7 @@
         },
         {
             "id": "9303cb30-5ff4-5086-ad35-8bd3fdce39f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1428575c-f18e-41a0-b58a-259d2feafd06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1428575c-f18e-41a0-b58a-259d2feafd06.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9329,7 +9329,7 @@
         },
         {
             "id": "59cfbbcd-9195-575e-9a1d-83f3fbe37441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6850740-6219-4f82-a705-2e7b20ede751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6850740-6219-4f82-a705-2e7b20ede751.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9368,7 +9368,7 @@
         },
         {
             "id": "db7bf927-d540-53fe-89ad-f84e0091983a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc50993-1fd4-4dba-9d2f-ae7a18559829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc50993-1fd4-4dba-9d2f-ae7a18559829.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9407,7 +9407,7 @@
         },
         {
             "id": "d54ead09-b0a2-590c-a817-e37ca4278208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfcde62-1b20-48ce-8ba0-7929edcd26fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfcde62-1b20-48ce-8ba0-7929edcd26fc.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9446,7 +9446,7 @@
         },
         {
             "id": "eef39312-4e8d-5768-93e0-2a29cd65a030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4dbe1-12ac-404f-a1fe-96e0b620533e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b4dbe1-12ac-404f-a1fe-96e0b620533e.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -9480,7 +9480,7 @@
         },
         {
             "id": "9c8242c0-385f-5376-b45c-c4059d30cb04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d3d039-248a-4eb8-be5c-12959b458fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67d3d039-248a-4eb8-be5c-12959b458fea.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "c9ab1a15-5d57-567b-ade2-47532db5b778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944a40e8-5469-4d8b-b044-67ff3382ec92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/944a40e8-5469-4d8b-b044-67ff3382ec92.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -9548,7 +9548,7 @@
         },
         {
             "id": "343e8a60-15d6-5115-b490-64e639348116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89eb9f92-d189-4438-b6fe-cb253055d63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89eb9f92-d189-4438-b6fe-cb253055d63e.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "2fcc3061-95f2-59ee-88eb-beb5f3eb18b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84310f84-3e5f-4db8-bff1-16bef64de1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84310f84-3e5f-4db8-bff1-16bef64de1a0.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -9616,7 +9616,7 @@
         },
         {
             "id": "f9ad44ed-4d40-5eb7-b192-d444a13bab27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577c2e32-deb6-40d9-a050-c2acb5bfc05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/577c2e32-deb6-40d9-a050-c2acb5bfc05f.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9650,7 +9650,7 @@
         },
         {
             "id": "fa42ee21-15bf-591e-93c7-0f78f10e338f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880d5dc1-ceec-4c5f-93c2-c88b7dbfcac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880d5dc1-ceec-4c5f-93c2-c88b7dbfcac2.jpg?1",
             "name": "Centaur",
             "text": "",
             "colours": [
@@ -9684,7 +9684,7 @@
         },
         {
             "id": "89047637-7bd8-5e84-9360-5f00bae47f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a686e51d-e8c3-4ed6-8357-c3d38d56dd09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a686e51d-e8c3-4ed6-8357-c3d38d56dd09.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9718,7 +9718,7 @@
         },
         {
             "id": "8919ba50-388c-5db4-8e92-eda31e897401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1331008a-ae86-4640-b823-a73be766ac16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1331008a-ae86-4640-b823-a73be766ac16.jpg?1",
             "name": "Rhino",
             "text": "",
             "colours": [
@@ -9752,7 +9752,7 @@
         },
         {
             "id": "ec48d786-606c-5cdb-9ff7-9dda3252239c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6544989-91b4-4db7-ad44-f1355f1d6e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6544989-91b4-4db7-ad44-f1355f1d6e6b.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -9786,7 +9786,7 @@
         },
         {
             "id": "50d906a7-4408-5cfd-9dc9-e0546a2963b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ee3f6c-5df6-4271-b2f9-86b9afffab7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ee3f6c-5df6-4271-b2f9-86b9afffab7b.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "8fda9b74-0f10-5f90-8500-a5fa3024c84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64c5f80-4676-4860-be0e-20bcf2227405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64c5f80-4676-4860-be0e-20bcf2227405.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/SCG.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SCG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "43d45f84-f88b-5b40-a959-57638302e41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa4a19-8eba-4c43-8a9a-636e234df751.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaa4a19-8eba-4c43-8a9a-636e234df751.jpg?1",
             "name": "Ageless Sentinels",
             "text": "(Walls can't attack.)\nFlying\nWhen Ageless Sentinels blocks, its creature type becomes Giant Bird. (It's no longer a Wall. This effect doesn't end at end of turn.)",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "9af7a130-c5e7-52dc-b3bd-4694ce5cfc65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f836d3-52c8-4628-b18a-8c8fb67969c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64f836d3-52c8-4628-b18a-8c8fb67969c9.jpg?1",
             "name": "Astral Steel",
             "text": "Target creature gets +1/+2 until end of turn.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "e2490c2b-368e-5fe3-8d46-be5815aa1367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47854e89-4d22-4eb6-a77d-6f04407bd2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47854e89-4d22-4eb6-a77d-6f04407bd2e5.jpg?1",
             "name": "Aven Farseer",
             "text": "Flying\nWhenever a creature is turned face up, put a +1/+1 counter on Aven Farseer.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "e74e8390-80ca-5f3b-b4c2-973e31ed2434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2804006-2a60-400c-be0b-8aa042469372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2804006-2a60-400c-be0b-8aa042469372.jpg?1",
             "name": "Aven Liberator",
             "text": "Flying\nMorph {3}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Aven Liberator is turned face up, target creature you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "a4ce8241-679e-59af-b7f8-ec7e17a11bd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f26b88-cffc-47ed-a70a-7d704a32c8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f26b88-cffc-47ed-a70a-7d704a32c8bb.jpg?1",
             "name": "Daru Spiritualist",
             "text": "Whenever a Cleric you control becomes the target of a spell or ability, it gets +0/+2 until end of turn.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "399f714a-8c06-5fe4-b5e5-1e698e6a3446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2630d3b5-8f3a-4aad-a45e-22a7979429f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2630d3b5-8f3a-4aad-a45e-22a7979429f3.jpg?1",
             "name": "Daru Warchief",
             "text": "Soldier spells you play cost {1} less to play.\nSoldiers you control get +1/+2.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "7441ab94-d4ba-5f4c-bd82-7a9c52f2e8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90a303-25fb-460b-bd55-6249f61c361c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd90a303-25fb-460b-bd55-6249f61c361c.jpg?1",
             "name": "Dawn Elemental",
             "text": "Flying\nPrevent all damage that would be dealt to Dawn Elemental.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "6f1977e3-15a4-5d3c-b3f3-5342e90d1506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8a7e5c-f252-4de8-94d7-e7327210bf26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e8a7e5c-f252-4de8-94d7-e7327210bf26.jpg?1",
             "name": "Decree of Justice",
             "text": "Put X 4/4 white Angel creature tokens with flying into play.\nCycling {2}{W}\nWhen you cycle Decree of Justice, you may pay {X}. If you do, put X 1/1 white Soldier creature tokens into play.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "e4702bbe-937a-51e5-a09d-70a937bf122e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2832-07c5-47be-8966-b250fb997f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2832-07c5-47be-8966-b250fb997f78.jpg?1",
             "name": "Dimensional Breach",
             "text": "Remove all permanents from the game. As long as any of those cards remain removed from the game, at the beginning of each player's upkeep, that player returns one of the removed cards he or she owns to play.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "09257f29-80d3-5535-a6ae-5db5919ff22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e78b364-015d-4074-ad9e-55c973ce2f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e78b364-015d-4074-ad9e-55c973ce2f4b.jpg?1",
             "name": "Dragon Scales",
             "text": "Enchanted creature gets +1/+2 and attacking doesn't cause it to tap.\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Scales from your graveyard to play enchanting that creature.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "5bd404f8-b3e5-5f0e-b7fd-981ba0bb4e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58017ff1-74d2-4be2-976a-8dff53e16150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58017ff1-74d2-4be2-976a-8dff53e16150.jpg?1",
             "name": "Dragonstalker",
             "text": "Flying, protection from Dragons",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "6b2cb786-eff3-50e1-b474-1f3559f46ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0596928c-2b20-4dbb-aa78-3ab6c3ce0d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0596928c-2b20-4dbb-aa78-3ab6c3ce0d72.jpg?1",
             "name": "Eternal Dragon",
             "text": "Flying\n{3}{W}{W}: Return Eternal Dragon from your graveyard to your hand. Play this ability only during your upkeep.\nPlainscycling {2} ({2}, Discard this card from your hand: Search your library for a plains card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "67849427-5dbc-541a-bfda-be44ccbd968f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aaf095-143a-43fc-a858-b1e82a4b906e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74aaf095-143a-43fc-a858-b1e82a4b906e.jpg?1",
             "name": "Exiled Doomsayer",
             "text": "All morph costs cost {2} more. (This doesn't affect the cost to play creatures face down.)",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "517df31b-6ff3-5c42-b578-c11e143e3ec6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742ac116-86ed-4ce6-9805-76f47a41c4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742ac116-86ed-4ce6-9805-76f47a41c4c4.jpg?1",
             "name": "Force Bubble",
             "text": "If damage would be dealt to you, put that many depletion counters on Force Bubble instead.\nWhen there are four or more depletion counters on Force Bubble, sacrifice it.\nAt end of turn, remove all depletion counters from Force Bubble.",
             "colours": [
@@ -479,7 +479,7 @@
         },
         {
             "id": "12c63c1d-7950-5c85-a6e5-c30b7f96e24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c43fac2-62fb-4924-848d-a8d739773d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c43fac2-62fb-4924-848d-a8d739773d6e.jpg?1",
             "name": "Frontline Strategist",
             "text": "Morph {W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Frontline Strategist is turned face up, prevent all combat damage non-Soldiers would deal this turn.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "a548ddea-6a92-5758-b319-f6417c617f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b92597-cb1e-4b8f-9ee9-07b48cf1a5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b92597-cb1e-4b8f-9ee9-07b48cf1a5c6.jpg?1",
             "name": "Gilded Light",
             "text": "You can't be the target of spells or abilities this turn.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -546,7 +546,7 @@
         },
         {
             "id": "d47059e6-c124-5d2e-9d3f-cc800dd3ec47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b8701c-0f03-4ad0-9097-3caf885abd59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67b8701c-0f03-4ad0-9097-3caf885abd59.jpg?1",
             "name": "Guilty Conscience",
             "text": "Whenever enchanted creature deals damage, Guilty Conscience deals that much damage to enchanted creature.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "63d88e58-fd41-527b-a200-e29e6af02b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914a1200-b77c-4a2c-96c6-7cc624ee9a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914a1200-b77c-4a2c-96c6-7cc624ee9a6a.jpg?1",
             "name": "Karona's Zealot",
             "text": "Morph {3}{W}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Karona's Zealot is turned face up, all damage that would be dealt to it this turn is dealt to target creature instead.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "027d67ed-65ee-5ef2-ad4e-b721ae135c76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ede92-e64f-44a5-afb6-c7495077fb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a9ede92-e64f-44a5-afb6-c7495077fb0b.jpg?1",
             "name": "Noble Templar",
             "text": "Attacking doesn't cause Noble Templar to tap.\nPlainscycling {2} ({2}, Discard this card from your hand: Search your library for a plains card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "e4961221-87a4-56c5-9aac-ea15becb9152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418476cd-94da-47a5-ba77-6bb4771e9c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418476cd-94da-47a5-ba77-6bb4771e9c89.jpg?1",
             "name": "Rain of Blades",
             "text": "Rain of Blades deals 1 damage to each attacking creature.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "c6fb2f97-27e5-5e9b-8abd-5d2847759ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5945397-0906-48dd-80d1-c65bfa2b31a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5945397-0906-48dd-80d1-c65bfa2b31a6.jpg?1",
             "name": "Recuperate",
             "text": "Choose one You gain 6 life; or prevent the next 6 damage that would be dealt to target creature this turn.",
             "colours": [
@@ -715,7 +715,7 @@
         },
         {
             "id": "ceede19d-f4a8-5504-8768-b91f20532c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6e8844-3736-4fb1-bedb-6a6bfa6ccdc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6e8844-3736-4fb1-bedb-6a6bfa6ccdc8.jpg?1",
             "name": "Reward the Faithful",
             "text": "Any number of target players each gains life equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "9052d841-ceb6-506b-9fc2-92dc8a873c2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f559da-08ad-402d-8c6b-3050bce5867b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f559da-08ad-402d-8c6b-3050bce5867b.jpg?1",
             "name": "Silver Knight",
             "text": "First strike, protection from red",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "0e48be1e-1df9-5a88-ac0b-31ce1f829f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cd76bf-db08-45f8-b3ae-501bcca6df3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05cd76bf-db08-45f8-b3ae-501bcca6df3c.jpg?1",
             "name": "Trap Digger",
             "text": "{2}{W}, {T}: Put a trap counter on target land you control.\nSacrifice a land with a trap counter on it: Trap Digger deals 3 damage to target attacking creature without flying.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "bf3e54c1-ee22-5b26-ba4b-e1ecc2bc8034",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65efa443-666a-45c1-8784-e98c510854b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65efa443-666a-45c1-8784-e98c510854b5.jpg?1",
             "name": "Wing Shards",
             "text": "Target player sacrifices an attacking creature.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "9cccb55c-22dd-5ac0-9c3f-13d60d142b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7c14c9-cb5a-49f0-be2c-eb3166f02510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7c14c9-cb5a-49f0-be2c-eb3166f02510.jpg?1",
             "name": "Wipe Clean",
             "text": "Remove target enchantment from the game.\nCycling {3} ({3}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "12679b57-cbd4-5e8d-9bf1-fb9c6105b202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb821b6-4e73-4970-b1ac-b67c93990ec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb821b6-4e73-4970-b1ac-b67c93990ec0.jpg?1",
             "name": "Zealous Inquisitor",
             "text": "{1}{W}: The next 1 damage that would be dealt to Zealous Inquisitor this turn is dealt to target creature instead.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "278a0d76-cef1-5361-b8c9-20576d2adbee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5de028-91ce-48d8-8557-ae12542adea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5de028-91ce-48d8-8557-ae12542adea2.jpg?1",
             "name": "Aphetto Runecaster",
             "text": "Whenever a creature is turned face up, you may draw a card.",
             "colours": [
@@ -951,7 +951,7 @@
         },
         {
             "id": "130d664e-a4e0-52cc-95ce-3b6898df53e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a43ef5-08f0-44fc-802d-b6cfd56b7d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59a43ef5-08f0-44fc-802d-b6cfd56b7d1f.jpg?1",
             "name": "Brain Freeze",
             "text": "Target player puts the top three cards of his or her library into his or her graveyard.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -983,7 +983,7 @@
         },
         {
             "id": "ca4b5f54-4c84-502b-88fb-2230f2548156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbbc67d-99d0-4277-a8f2-64509e59ec00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbbc67d-99d0-4277-a8f2-64509e59ec00.jpg?1",
             "name": "Coast Watcher",
             "text": "Flying, protection from green",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "eb192481-dcb7-5a3c-b9d6-d2ab01a280d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366a934c-eb01-48c6-8393-c2fe0708ff91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366a934c-eb01-48c6-8393-c2fe0708ff91.jpg?1",
             "name": "Day of the Dragons",
             "text": "When Day of the Dragons comes into play, remove all creatures you control from the game. Then put that many 5/5 red Dragon creature tokens with flying into play.\nWhen Day of the Dragons leaves play, sacrifice all Dragons you control. Then return the removed cards to play under your control.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "253cfe94-24d3-592b-84f2-a625a59046c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fc46e2-5e19-4999-a4cd-1e84697066c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fc46e2-5e19-4999-a4cd-1e84697066c1.jpg?1",
             "name": "Decree of Silence",
             "text": "Whenever an opponent plays a spell, counter that spell and put a depletion counter on Decree of Silence. If there are three or more depletion counters on Decree of Silence, sacrifice it.\nCycling {4}{U}{U}\nWhen you cycle Decree of Silence, you may counter target spell.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "02074273-34d1-5677-ae91-7c8c29ef4ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c257df6-f275-40db-bfe3-a9291356cdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c257df6-f275-40db-bfe3-a9291356cdf7.jpg?1",
             "name": "Dispersal Shield",
             "text": "Counter target spell if its converted mana cost is less than or equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -1114,7 +1114,7 @@
         },
         {
             "id": "2df53bea-4a1d-5d58-b531-d354cd735ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7674ab4d-9bc0-45c3-88e1-3fd2c947cfaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7674ab4d-9bc0-45c3-88e1-3fd2c947cfaa.jpg?1",
             "name": "Dragon Wings",
             "text": "Enchanted creature has flying.\nCycling {1}{U} ({1}{U}, Discard this card from your hand: Draw a card.)\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Wings from your graveyard to play enchanting that creature.",
             "colours": [
@@ -1148,7 +1148,7 @@
         },
         {
             "id": "c06479c3-bfac-5e01-ab75-941bd0ba1d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6dc35b-eb26-498f-ae35-0e860871446e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6dc35b-eb26-498f-ae35-0e860871446e.jpg?1",
             "name": "Faces of the Past",
             "text": "Whenever a creature is put into a graveyard from play, tap or untap all creatures that share a creature type with it.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "7b5ac839-3ffb-531b-a10f-71544eec787e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b98d-0245-4b64-b835-d101ce2bd3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b98d-0245-4b64-b835-d101ce2bd3fa.jpg?1",
             "name": "Frozen Solid",
             "text": "Enchanted creature doesn't untap during its controller's untap step.\nWhen damage is dealt to enchanted creature, destroy it.",
             "colours": [
@@ -1214,7 +1214,7 @@
         },
         {
             "id": "773946d4-0de2-53ea-9a33-6858b3eb8c22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9735d9-4aac-4175-8ec8-fc9bfd8f2c5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9735d9-4aac-4175-8ec8-fc9bfd8f2c5c.jpg?1",
             "name": "Hindering Touch",
             "text": "Counter target spell unless its controller pays {2}.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1246,7 +1246,7 @@
         },
         {
             "id": "ffd6d5f3-fa27-571e-ae02-05ca2b26ab06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0422d9-9694-45b6-9c2b-2ca31198cebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0422d9-9694-45b6-9c2b-2ca31198cebf.jpg?1",
             "name": "Long-Term Plans",
             "text": "Search your library for a card, shuffle your library, then put that card third from the top.",
             "colours": [
@@ -1278,7 +1278,7 @@
         },
         {
             "id": "e9a025b7-da4a-5133-80fb-72fbc35eb36a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bc8655-ae27-40be-8d61-e80a5924e955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bc8655-ae27-40be-8d61-e80a5924e955.jpg?1",
             "name": "Mercurial Kite",
             "text": "Flying\nWhenever Mercurial Kite deals combat damage to a creature, tap that creature. It doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "39202306-5005-54c9-aeb2-9fa44762d8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0c20c-184e-4d27-ae8b-933abb6fee0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0f0c20c-184e-4d27-ae8b-933abb6fee0c.jpg?1",
             "name": "Metamorphose",
             "text": "Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from his or her hand into play.",
             "colours": [
@@ -1344,7 +1344,7 @@
         },
         {
             "id": "ab6730a4-f31b-555b-8c7f-9f561a93c2bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7474e1-cfae-4867-a11a-d5cf9ff7ea5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7474e1-cfae-4867-a11a-d5cf9ff7ea5f.jpg?1",
             "name": "Mind's Desire",
             "text": "Shuffle your library. Then remove the top card of your library from the game. Until end of turn, you may play it as though it were in your hand without paying its mana cost. (If it has X in its mana cost, X is 0.)\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "9aa3d1aa-c52e-54fb-9873-9de14c84a5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc48c2db-f5b4-4c24-a5fa-00750b7ff56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc48c2db-f5b4-4c24-a5fa-00750b7ff56f.jpg?1",
             "name": "Mischievous Quanar",
             "text": "{3}{U}{U}: Turn Mischievous Quanar face down.\nMorph {1}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Mischievous Quanar is turned face up, copy target instant or sorcery spell. You may choose new targets for that copy.",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "b65144db-04b9-5b05-b2f1-8517c5010788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a633d85b-4be1-44a2-8fd8-1ccec4a95ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a633d85b-4be1-44a2-8fd8-1ccec4a95ecb.jpg?1",
             "name": "Mistform Warchief",
             "text": "Creature spells you play that share a creature type with Mistform Warchief cost {1} less to play.\n{T}: Mistform Warchief's type becomes the creature type of your choice until end of turn.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "6e41075d-21c4-52c6-96f3-35cce7f10605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913c541-a8fb-4383-bbab-988be3e0f5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d913c541-a8fb-4383-bbab-988be3e0f5d5.jpg?1",
             "name": "Parallel Thoughts",
             "text": "When Parallel Thoughts comes into play, search your library for seven cards, remove them from the game in a face-down pile, and shuffle that pile. Then shuffle your library.\nIf you would draw a card, you may instead put the top card of the pile you removed into your hand.",
             "colours": [
@@ -1476,7 +1476,7 @@
         },
         {
             "id": "dc1d8d6d-5f15-589a-be8d-0814f928bf09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb3e38b-086e-4fbc-b7b1-8564c18276d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb3e38b-086e-4fbc-b7b1-8564c18276d7.jpg?1",
             "name": "Pemmin's Aura",
             "text": "{U}: Untap enchanted creature.\n{U}: Enchanted creature gains flying until end of turn.\n{U}: Enchanted creature can't be the target of spells or abilities this turn.\n{1}: Enchanted creature gets +1/-1 or -1/+1 until end of turn.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "260d6d6d-87d0-5d21-ba10-ab578e132058",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e11f70-06c3-4dc5-aafe-82d65080085e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e11f70-06c3-4dc5-aafe-82d65080085e.jpg?1",
             "name": "Raven Guild Initiate",
             "text": "Morph\u2014\nReturn a Bird you control to its owner's hand. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "df3a0d04-a358-5da0-aad5-60516bc590f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9843f847-6a8f-4042-86b6-f7fe5a47cc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9843f847-6a8f-4042-86b6-f7fe5a47cc57.jpg?1",
             "name": "Raven Guild Master",
             "text": "Whenever Raven Guild Master deals combat damage to a player, that player removes the top ten cards of his or her library from the game.\nMorph {2}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1581,7 +1581,7 @@
         },
         {
             "id": "cb7e65bf-0fa3-5def-af9d-396872c58eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7515187f-4821-400d-b78f-cec173df6b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7515187f-4821-400d-b78f-cec173df6b84.jpg?1",
             "name": "Riptide Survivor",
             "text": "Morph {1}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Riptide Survivor is turned face up, discard two cards from your hand, then draw three cards.",
             "colours": [
@@ -1616,7 +1616,7 @@
         },
         {
             "id": "55316be7-0aea-5ea7-9ea0-b7174a534619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b03b40-671f-4973-8d75-c3fa878ef603.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b03b40-671f-4973-8d75-c3fa878ef603.jpg?1",
             "name": "Rush of Knowledge",
             "text": "Draw cards equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "530eb7a3-abb8-5aed-9981-62361205fb38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec6b189-97e7-4627-9785-a9ce2f1ad89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fec6b189-97e7-4627-9785-a9ce2f1ad89f.jpg?1",
             "name": "Scornful Egotist",
             "text": "Morph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "cac6f843-75c2-5065-897c-82b962e2cdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed813c4-fff0-43f1-bc62-cbc3a126d600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed813c4-fff0-43f1-bc62-cbc3a126d600.jpg?1",
             "name": "Shoreline Ranger",
             "text": "Flying\nIslandcycling {2} ({2}, Discard this card from your hand: Search your library for an island card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "d3e9de63-2b01-51c1-864c-c62a7e90236a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7643c0-b2db-478f-944e-b27b77bad3eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7643c0-b2db-478f-944e-b27b77bad3eb.jpg?1",
             "name": "Stifle",
             "text": "Counter target activated or triggered ability. (Mana abilities can't be countered.)",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "ce1a12da-d30f-5d77-969b-273343fdd3bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97949c53-aef7-4c0c-b846-8d4003193ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97949c53-aef7-4c0c-b846-8d4003193ced.jpg?1",
             "name": "Temporal Fissure",
             "text": "Return target permanent to its owner's hand.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -1783,7 +1783,7 @@
         },
         {
             "id": "1edce411-939b-57b7-ad24-c0c2bfdefa6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597aea42-43e0-41ed-bfe7-fc92b6b8e680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597aea42-43e0-41ed-bfe7-fc92b6b8e680.jpg?1",
             "name": "Thundercloud Elemental",
             "text": "Flying\n{3}{U}: Tap all creatures with toughness 2 or less.\n{3}{U}: All other creatures lose flying until end of turn.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "f3e2bbca-c062-583c-b891-d42b783b0f1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07e0d28-6383-4846-89d3-72910a7bbdcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07e0d28-6383-4846-89d3-72910a7bbdcd.jpg?1",
             "name": "Bladewing's Thrall",
             "text": "Bladewing's Thrall has flying as long as you control a Dragon.\nWhen a Dragon comes into play, you may return Bladewing's Thrall from your graveyard to play.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "7431985d-c197-5e28-86a4-d6eb37d03b6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81c6e6-fded-4cd3-a6fa-486419a5408a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb81c6e6-fded-4cd3-a6fa-486419a5408a.jpg?1",
             "name": "Cabal Conditioning",
             "text": "Any number of target players each discards cards from his or her hand equal to the highest converted mana cost among permanents you control.",
             "colours": [
@@ -1883,7 +1883,7 @@
         },
         {
             "id": "a49c636b-99f3-5968-b68a-60dcb9b810be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a7a37-6f47-47a3-b149-5692aee8b34a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/256a7a37-6f47-47a3-b149-5692aee8b34a.jpg?1",
             "name": "Cabal Interrogator",
             "text": "{X}{B}, {T}: Target player reveals X cards from his or her hand and you choose one of them. That player discards that card. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -1918,7 +1918,7 @@
         },
         {
             "id": "0221d078-4da1-5993-a63a-792d4ec602f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a346b4a-ac8a-4f99-9ed7-dd41102e56ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a346b4a-ac8a-4f99-9ed7-dd41102e56ce.jpg?1",
             "name": "Call to the Grave",
             "text": "At the beginning of each player's upkeep, that player sacrifices a non-Zombie creature.\nAt end of turn, if no creatures are in play, sacrifice Call to the Grave.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "9a0e0cc7-f5ac-5d2d-8b77-bbc931d02ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88042031-64af-4f84-85d5-95992b43aa6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88042031-64af-4f84-85d5-95992b43aa6c.jpg?1",
             "name": "Carrion Feeder",
             "text": "Carrion Feeder can't block.\nSacrifice a creature: Put a +1/+1 counter on Carrion Feeder.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "af34fa91-b98e-5f28-9a86-c6dc77a0de38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91035d03-2bf8-4e6b-945b-4dfbed0873ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91035d03-2bf8-4e6b-945b-4dfbed0873ec.jpg?1",
             "name": "Chill Haunting",
             "text": "As an additional cost to play Chill Haunting, remove X creature cards in your graveyard from the game.\nTarget creature gets -X/-X until end of turn.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "715d4c07-797d-5fd4-945f-6bd01619c38e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7301fdec-ca17-47ae-9a0a-84ea8665ece1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7301fdec-ca17-47ae-9a0a-84ea8665ece1.jpg?1",
             "name": "Clutch of Undeath",
             "text": "Enchanted creature gets +3/+3 as long as it's a Zombie. Otherwise, it gets -3/-3.",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "63b195b2-cb12-599d-9311-960e7dfa66b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0f549f-6607-483a-9d89-2019ca9ef571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0f549f-6607-483a-9d89-2019ca9ef571.jpg?1",
             "name": "Consumptive Goo",
             "text": "{2}{B}{B}: Target creature gets -1/-1 until end of turn. Put a +1/+1 counter on Consumptive Goo.",
             "colours": [
@@ -2084,7 +2084,7 @@
         },
         {
             "id": "c68caf19-3a22-5917-ad7a-17988cf47518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8d4fd9-1f9e-41f0-9114-d1a698506ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8d4fd9-1f9e-41f0-9114-d1a698506ad9.jpg?1",
             "name": "Death's-Head Buzzard",
             "text": "Flying\nWhen Death's-Head Buzzard is put into a graveyard from play, all creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2118,7 +2118,7 @@
         },
         {
             "id": "c66e98f0-a2d6-5cd2-b3b5-10227e306c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1958a07-fc75-41cd-ac45-d92d49587754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1958a07-fc75-41cd-ac45-d92d49587754.jpg?1",
             "name": "Decree of Pain",
             "text": "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way.\nCycling {3}{B}{B}\nWhen you cycle Decree of Pain, all creatures get -2/-2 until end of turn.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "9c54b402-8bd6-506e-925a-9517d69e6ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec35e03-022b-417c-9987-7379cf3956f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec35e03-022b-417c-9987-7379cf3956f9.jpg?1",
             "name": "Dragon Shadow",
             "text": "Enchanted creature gets +1/+0 and has fear. (It can't be blocked except by artifact creatures and/or black creatures.)\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Shadow from your graveyard to play enchanting that creature.",
             "colours": [
@@ -2184,7 +2184,7 @@
         },
         {
             "id": "4bce565e-3808-5484-bc5a-27431452d7fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cf9f50-8858-44a6-8bd5-0ce1e281a584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cf9f50-8858-44a6-8bd5-0ce1e281a584.jpg?1",
             "name": "Fatal Mutation",
             "text": "When enchanted creature is turned face up, destroy it. It can't be regenerated.",
             "colours": [
@@ -2218,7 +2218,7 @@
         },
         {
             "id": "a869c403-e18d-596e-8026-d8e0c97ce4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097dbfae-1a18-4c10-8d1f-b2c20971c75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/097dbfae-1a18-4c10-8d1f-b2c20971c75e.jpg?1",
             "name": "Final Punishment",
             "text": "Target player loses life equal to the damage already dealt to him or her this turn.",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "6b5e4823-8697-53e7-a93b-7e15ccd3615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96acfea-009a-4ac9-8746-64f65199024f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96acfea-009a-4ac9-8746-64f65199024f.jpg?1",
             "name": "Lethal Vapors",
             "text": "Whenever a creature comes into play, destroy it.\n{0}: Destroy Lethal Vapors. You skip your next turn. Any player may play this ability.",
             "colours": [
@@ -2282,7 +2282,7 @@
         },
         {
             "id": "987ecec9-1867-5834-a95e-869012503daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f174fd76-f28d-4272-8cb0-7f66cd60579e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f174fd76-f28d-4272-8cb0-7f66cd60579e.jpg?1",
             "name": "Lingering Death",
             "text": "The controller of enchanted creature sacrifices it at the end of his or her turn.",
             "colours": [
@@ -2316,7 +2316,7 @@
         },
         {
             "id": "eeb85ea9-da4b-591f-b701-fafdb3af70c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7046acc2-e2fd-43e6-9d46-a729d48ba562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7046acc2-e2fd-43e6-9d46-a729d48ba562.jpg?1",
             "name": "Nefashu",
             "text": "Whenever Nefashu attacks, up to five target creatures each get -1/-1 until end of turn.",
             "colours": [
@@ -2351,7 +2351,7 @@
         },
         {
             "id": "07ae9bc1-7caf-5c63-b8f1-8d89a184ce19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9127942b-d73d-42a9-9f97-6a39fa798a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9127942b-d73d-42a9-9f97-6a39fa798a8b.jpg?1",
             "name": "Putrid Raptor",
             "text": "Morph\u2014\nDiscard a Zombie card from your hand. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2387,7 +2387,7 @@
         },
         {
             "id": "c2fb28d6-30ea-5fab-ae97-d0c1e2f592dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a66bd-2821-4710-8f02-3c30772dd884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760a66bd-2821-4710-8f02-3c30772dd884.jpg?1",
             "name": "Reaping the Graves",
             "text": "Return target creature card from your graveyard to your hand.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -2419,7 +2419,7 @@
         },
         {
             "id": "7d94b2fb-6707-5c28-980c-56792a3fa876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a90779-008e-401f-9877-be0a935d2ccd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a90779-008e-401f-9877-be0a935d2ccd.jpg?1",
             "name": "Skulltap",
             "text": "As an additional cost to play Skulltap, sacrifice a creature.\nDraw two cards.",
             "colours": [
@@ -2451,7 +2451,7 @@
         },
         {
             "id": "de6ec24f-2f2d-550c-871f-3e7858e589f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec78c0e8-a354-46d2-95ad-012f120c3df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec78c0e8-a354-46d2-95ad-012f120c3df8.jpg?1",
             "name": "Soul Collector",
             "text": "Flying\nWhenever a creature dealt damage by Soul Collector this turn is put into a graveyard, return that card to play under your control.\nMorph {B}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2485,7 +2485,7 @@
         },
         {
             "id": "e2a6d92f-c154-52b6-9b8b-ded783b6933a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559352e-95c1-403b-bd8f-d0679717cfa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0559352e-95c1-403b-bd8f-d0679717cfa2.jpg?1",
             "name": "Tendrils of Agony",
             "text": "Target player loses 2 life and you gain 2 life.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "8671df71-046e-5b01-9c55-09aa02016c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e672f-87aa-4308-98bb-d00548c5bcef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446e672f-87aa-4308-98bb-d00548c5bcef.jpg?1",
             "name": "Twisted Abomination",
             "text": "{B}: Regenerate Twisted Abomination.\nSwampcycling {2} ({2}, Discard this card from your hand: Search your library for a swamp card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "bba0106b-2881-5fac-9b4a-47f6dfa333c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fc0e0-4ee5-40eb-a9f0-9b1fff2adefc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5fc0e0-4ee5-40eb-a9f0-9b1fff2adefc.jpg?1",
             "name": "Unburden",
             "text": "Target player discards two cards.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -2584,7 +2584,7 @@
         },
         {
             "id": "360ad77f-bfd7-5cef-9714-ad06ca3a186c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3bcfe-be82-458b-ba59-ecb84436d747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b3bcfe-be82-458b-ba59-ecb84436d747.jpg?1",
             "name": "Undead Warchief",
             "text": "Zombie spells you play cost {1} less to play.\nZombies you control get +2/+1.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "4d73aa99-eebe-53f0-86f5-96bb2463147a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc4601b-5f34-4733-8c32-9779de4c502c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc4601b-5f34-4733-8c32-9779de4c502c.jpg?1",
             "name": "Unspeakable Symbol",
             "text": "Pay 3 life: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "bed7e944-a917-5fc8-9915-05c115033d9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11c11d-9809-4031-8cbc-21aef07d7f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c11c11d-9809-4031-8cbc-21aef07d7f1f.jpg?1",
             "name": "Vengeful Dead",
             "text": "Whenever Vengeful Dead or another Zombie is put into a graveyard from play, each opponent loses 1 life.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "26ed4f5f-f613-5876-93ee-6c3347878f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe491cba-6ec7-4c44-ad1e-832d936986a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe491cba-6ec7-4c44-ad1e-832d936986a0.jpg?1",
             "name": "Zombie Cutthroat",
             "text": "Morph\u2014\nPay 5 life. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "8c571023-ab8b-5747-bc5e-b2d1fdd4b340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d7326-ad03-464d-97e2-443042d48f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297d7326-ad03-464d-97e2-443042d48f92.jpg?1",
             "name": "Bonethorn Valesk",
             "text": "Whenever a creature is turned face up, Bonethorn Valesk deals 1 damage to target creature or player.",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "c6cb48b6-2f3b-55a8-b510-0971805d7443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f565fa1-a1a0-4dd0-b7f4-df65a807d156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f565fa1-a1a0-4dd0-b7f4-df65a807d156.jpg?1",
             "name": "Carbonize",
             "text": "Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would be put into a graveyard this turn, remove it from the game instead.",
             "colours": [
@@ -2784,7 +2784,7 @@
         },
         {
             "id": "cac6db53-40f2-5eeb-927a-90788b505c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c9c07-c3db-46ca-a204-b710c3a34ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2c9c07-c3db-46ca-a204-b710c3a34ae9.jpg?1",
             "name": "Chartooth Cougar",
             "text": "{R}: Chartooth Cougar gets +1/+0 until end of turn.\nMountaincycling {2} ({2}, Discard this card from your hand: Search your library for a mountain card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -2819,7 +2819,7 @@
         },
         {
             "id": "24bab718-4e6c-5ea7-900c-443d923f206f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73744717-518c-478e-9da9-201c49124f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73744717-518c-478e-9da9-201c49124f37.jpg?1",
             "name": "Decree of Annihilation",
             "text": "Remove all artifacts, creatures, lands, graveyards, and hands from the game.\nCycling {5}{R}{R}\nWhen you cycle Decree of Annihilation, destroy all lands.",
             "colours": [
@@ -2851,7 +2851,7 @@
         },
         {
             "id": "83269e21-7e8e-5f4e-a718-5dca8ce105e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1832aaed-e164-4f78-9bc9-ec6c015835f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1832aaed-e164-4f78-9bc9-ec6c015835f5.jpg?1",
             "name": "Dragon Breath",
             "text": "Enchanted creature has haste.\noo\nR Enchanted creature gets +1/+0 until end of turn.\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Breath from your graveyard to play enchanting that creature.",
             "colours": [
@@ -2885,7 +2885,7 @@
         },
         {
             "id": "840c5f81-fdb7-575c-a756-95fa328313bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7687a201-0ecc-4739-86e3-3b4090d345a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7687a201-0ecc-4739-86e3-3b4090d345a8.jpg?1",
             "name": "Dragon Mage",
             "text": "Flying\nWhenever Dragon Mage deals combat damage to a player, each player discards his or her hand and draws seven cards.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "61b572f2-d1b3-5b9e-a36c-11c811a3167c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1a29b-af80-4f9a-881b-ef7374ecbce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d1a29b-af80-4f9a-881b-ef7374ecbce1.jpg?1",
             "name": "Dragon Tyrant",
             "text": "Flying, trample\nDouble strike (This creature deals both first-strike and regular combat damage.)\nAt the beginning of your upkeep, sacrifice Dragon Tyrant unless you pay {R}{R}{R}{R}.\n{R}: Dragon Tyrant gets +1/+0 until end of turn.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "4589adfe-ad64-5301-ad21-10f88076ec52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f5fa96-dcfb-4d29-bea9-7dd99e8c43d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f5fa96-dcfb-4d29-bea9-7dd99e8c43d8.jpg?1",
             "name": "Dragonspeaker Shaman",
             "text": "Dragon spells you play cost {2} less to play.",
             "colours": [
@@ -2990,7 +2990,7 @@
         },
         {
             "id": "d096e9e7-eede-52b5-81a0-319c5911d994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9aa594-39e6-4824-aed9-75d1a301ac51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9aa594-39e6-4824-aed9-75d1a301ac51.jpg?1",
             "name": "Dragonstorm",
             "text": "Search your library for a Dragon card and put it into play. Then shuffle your library.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "96f4741d-fd1f-55f9-9ba5-126dd56ff6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed7866-9eef-49c3-9b9e-4247b6e71a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ed7866-9eef-49c3-9b9e-4247b6e71a6c.jpg?1",
             "name": "Enrage",
             "text": "Target creature gets +X/+0 until end of turn.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "aaf83980-42a7-5ee4-8102-91ece333a219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28efa11c-6aeb-4c22-bbb3-b41f26d65c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28efa11c-6aeb-4c22-bbb3-b41f26d65c65.jpg?1",
             "name": "Extra Arms",
             "text": "Whenever enchanted creature attacks, it deals 2 damage to target creature or player.",
             "colours": [
@@ -3088,7 +3088,7 @@
         },
         {
             "id": "81639bc8-0b41-58c7-b601-cf56160f7a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058bcb4-50ac-4323-ab49-3b80a5891894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2058bcb4-50ac-4323-ab49-3b80a5891894.jpg?1",
             "name": "Form of the Dragon",
             "text": "At the beginning of your upkeep, Form of the Dragon deals 5 damage to target creature or player.\nAt the end of each turn, your life total becomes 5.\nCreatures without flying can't attack you.",
             "colours": [
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "ebf78c72-8f48-5918-a8fb-7699627458b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b024afe-7a28-4e3b-afbd-b42f1c45f338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b024afe-7a28-4e3b-afbd-b42f1c45f338.jpg?1",
             "name": "Goblin Brigand",
             "text": "Goblin Brigand attacks each turn if able.",
             "colours": [
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "d15a19ee-7a3b-50b9-9caf-f18788b7e95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52287036-00f1-4b6d-8cd8-b8cbc70c5135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52287036-00f1-4b6d-8cd8-b8cbc70c5135.jpg?1",
             "name": "Goblin Psychopath",
             "text": "Whenever Goblin Psychopath attacks or blocks, flip a coin. If you lose the flip, the next time it would deal combat damage this turn, it deals that damage to you instead.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "d7c13930-f4d4-5563-bc42-104aeb988907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce59945-37a2-4f09-8831-9d44b4a59ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce59945-37a2-4f09-8831-9d44b4a59ea7.jpg?1",
             "name": "Goblin War Strike",
             "text": "Goblin War Strike deals damage equal to the number of Goblins you control to target player.",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "fa9d9c8c-30b0-5f62-a6c9-83bab74ebc69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66864a4b-8924-40ef-a337-15b12413a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66864a4b-8924-40ef-a337-15b12413a158.jpg?1",
             "name": "Goblin Warchief",
             "text": "Goblin spells you play cost {1} less to play.\nGoblins you control have haste.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "1837a89f-c66e-5622-8ef0-1d51a7d95e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defbbd3a-0e7d-4af2-b25f-9003ddad0bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/defbbd3a-0e7d-4af2-b25f-9003ddad0bf5.jpg?1",
             "name": "Grip of Chaos",
             "text": "Whenever a spell or ability is put onto the stack, reselect its target at random if it has a single target. (Select from among all legal targets.)",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "3f8bf6b4-37cb-57e2-9840-121cb437279f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b5e00a-fef0-4711-9112-2fd067321890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b5e00a-fef0-4711-9112-2fd067321890.jpg?1",
             "name": "Misguided Rage",
             "text": "Target player sacrifices a permanent.",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "ecfca0db-5dc3-5ddb-a2e5-b184360b1027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5973cd53-f6cd-4edc-b952-f6d3eef97988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5973cd53-f6cd-4edc-b952-f6d3eef97988.jpg?1",
             "name": "Pyrostatic Pillar",
             "text": "Whenever a player plays a spell with converted mana cost 3 or less, Pyrostatic Pillar deals 2 damage to that player.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "7f816a77-ed0c-5f98-9702-b16754fb982a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f836e90-3255-48bd-a174-6a127528551e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f836e90-3255-48bd-a174-6a127528551e.jpg?1",
             "name": "Rock Jockey",
             "text": "You can't play Rock Jockey if you played a land this turn.\nYou can't play lands if you played Rock Jockey this turn.",
             "colours": [
@@ -3387,7 +3387,7 @@
         },
         {
             "id": "12e035a3-0ec7-5a1a-b390-55b977b44196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf22f3e7-1626-4bab-9f62-7d4774704395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf22f3e7-1626-4bab-9f62-7d4774704395.jpg?1",
             "name": "Scattershot",
             "text": "Scattershot deals 1 damage to target creature.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -3419,7 +3419,7 @@
         },
         {
             "id": "18211630-f9fa-5a42-a046-dec36d9bf135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e78cec-aaf9-4fe8-887b-b7e356d63315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e78cec-aaf9-4fe8-887b-b7e356d63315.jpg?1",
             "name": "Siege-Gang Commander",
             "text": "When Siege-Gang Commander comes into play, put three 1/1 red Goblin creature tokens into play.\n{1}{R}, Sacrifice a Goblin: Siege-Gang Commander deals 2 damage to target creature or player.",
             "colours": [
@@ -3453,7 +3453,7 @@
         },
         {
             "id": "33119ea1-75b9-53a6-9e21-cda786c986d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdfb7e3-e077-400a-868d-3f3811e7a35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdfb7e3-e077-400a-868d-3f3811e7a35c.jpg?1",
             "name": "Skirk Volcanist",
             "text": "Morph\u2014\nSacrifice two mountains. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Skirk Volcanist is turned face up, it deals 3 damage divided as you choose among any number of target creatures.",
             "colours": [
@@ -3487,7 +3487,7 @@
         },
         {
             "id": "77e62bcc-fd91-5f52-a48e-72fb809b4e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60d8716-4297-484c-8e02-c30ce2773a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60d8716-4297-484c-8e02-c30ce2773a65.jpg?1",
             "name": "Spark Spray",
             "text": "Spark Spray deals 1 damage to target creature or player.\nCycling {R} ({R}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "71aab515-d674-5dcb-9b7b-830a3aad578a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79955e27-eef7-43bd-9895-e9209ed1537f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79955e27-eef7-43bd-9895-e9209ed1537f.jpg?1",
             "name": "Sulfuric Vortex",
             "text": "At the beginning of each player's upkeep, Sulfuric Vortex deals 2 damage to that player.\nIf a player would gain life, that player gains no life instead.",
             "colours": [
@@ -3551,7 +3551,7 @@
         },
         {
             "id": "2f6f2c14-79b5-52ca-8252-1211782b7e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeee859-f64a-4cd8-be0b-ad60cff8812e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeee859-f64a-4cd8-be0b-ad60cff8812e.jpg?1",
             "name": "Torrent of Fire",
             "text": "Torrent of Fire deals damage equal to the highest converted mana cost among permanents you control to target creature or player.",
             "colours": [
@@ -3583,7 +3583,7 @@
         },
         {
             "id": "43b39301-6ee4-53b4-84bb-1c5c7b7f9cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ead6c3-a4e9-43e0-ae2a-6eb73033bc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ead6c3-a4e9-43e0-ae2a-6eb73033bc49.jpg?1",
             "name": "Uncontrolled Infestation",
             "text": "Uncontrolled Infestation can enchant only a nonbasic land.\nWhen enchanted land becomes tapped, destroy it.",
             "colours": [
@@ -3617,7 +3617,7 @@
         },
         {
             "id": "f8a98973-7dcf-51e8-ae20-1a287cf1c678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f808c-0b58-4b98-aeda-f606a10d1a4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282f808c-0b58-4b98-aeda-f606a10d1a4b.jpg?1",
             "name": "Accelerated Mutation",
             "text": "Target creature gets +X/+X until end of turn, where X is the highest converted mana cost among permanents you control.",
             "colours": [
@@ -3649,7 +3649,7 @@
         },
         {
             "id": "db31216c-c491-54c9-93d0-7c7027f724b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd210c45-57f3-4d7d-93ba-81fe4298ade3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd210c45-57f3-4d7d-93ba-81fe4298ade3.jpg?1",
             "name": "Alpha Status",
             "text": "Enchanted creature gets +2/+2 for each other creature in play that shares a creature type with it.",
             "colours": [
@@ -3683,7 +3683,7 @@
         },
         {
             "id": "33757323-c327-5779-af26-b63f8f772fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7485da91-a051-4680-8a25-c81fdaa77130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7485da91-a051-4680-8a25-c81fdaa77130.jpg?1",
             "name": "Ambush Commander",
             "text": "Forests you control are 1/1 green Elf creatures that are still lands.\n{1}{G}, Sacrifice an Elf: Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3717,7 +3717,7 @@
         },
         {
             "id": "8f695933-0388-5e31-8a1f-a14705eda727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b57b41c-f99c-4525-8541-f025b7e31974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b57b41c-f99c-4525-8541-f025b7e31974.jpg?1",
             "name": "Ancient Ooze",
             "text": "Ancient Ooze's power and toughness are each equal to the total converted mana cost of other creatures you control.",
             "colours": [
@@ -3751,7 +3751,7 @@
         },
         {
             "id": "926b7851-fefc-58ae-8223-add40f15ace2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb989895-a5c7-4151-8620-ab277d826303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb989895-a5c7-4151-8620-ab277d826303.jpg?1",
             "name": "Break Asunder",
             "text": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3783,7 +3783,7 @@
         },
         {
             "id": "ff7b52ca-c0e8-5688-b511-22257efa27c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94cd33f-40b6-4b11-97a4-8676ef27631e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b94cd33f-40b6-4b11-97a4-8676ef27631e.jpg?1",
             "name": "Claws of Wirewood",
             "text": "Claws of Wirewood deals 3 damage to each creature with flying and each player.\nCycling {2} ({2}, Discard this card from your hand: Draw a card.)",
             "colours": [
@@ -3815,7 +3815,7 @@
         },
         {
             "id": "6432c2d0-6bdc-58a2-85d9-ca998e61cd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e643fbf1-74d5-412b-beba-ab3c712edb3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e643fbf1-74d5-412b-beba-ab3c712edb3b.jpg?1",
             "name": "Decree of Savagery",
             "text": "Put four +1/+1 counters on each creature you control.\nCycling {4}{G}{G}\nWhen you cycle Decree of Savagery, you may put four +1/+1 counters on target creature.",
             "colours": [
@@ -3847,7 +3847,7 @@
         },
         {
             "id": "ad3220fe-8c5c-57b6-b15e-84e6605ec6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e609448-7868-4e28-b399-3750556a693c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e609448-7868-4e28-b399-3750556a693c.jpg?1",
             "name": "Divergent Growth",
             "text": "Until end of turn, lands you control gain \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3879,7 +3879,7 @@
         },
         {
             "id": "13c0f7f1-743a-52f0-a4a1-f10d57fb0524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9754f52f-8937-4402-8956-2c18b520898a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9754f52f-8937-4402-8956-2c18b520898a.jpg?1",
             "name": "Dragon Fangs",
             "text": "Enchanted creature gets +1/+1 and has trample.\nWhen a creature with converted mana cost 6 or more comes into play, you may return Dragon Fangs from your graveyard to play enchanting that creature.",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "0d964329-dba8-5089-9adc-208faf66a76c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137d326f-83e1-449a-b934-71c7986c64e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/137d326f-83e1-449a-b934-71c7986c64e7.jpg?1",
             "name": "Elvish Aberration",
             "text": "{T}: Add {G}{G}{G} to your mana pool.\nForestcycling {2} ({2}, Discard this card from your hand: Search your library for a forest card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "fbcfafba-3f42-567d-b2ce-476457ad395d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237e169-f152-4ddf-a5a1-32ca46cfa16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d237e169-f152-4ddf-a5a1-32ca46cfa16d.jpg?1",
             "name": "Fierce Empath",
             "text": "When Fierce Empath comes into play, you may search your library for a creature card with converted mana cost 6 or more, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -3982,7 +3982,7 @@
         },
         {
             "id": "f7b4d4d5-23ed-53d9-8430-8470cf16b6a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d3b91d-2e4f-4574-89f8-7b804f1d21bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49d3b91d-2e4f-4574-89f8-7b804f1d21bf.jpg?1",
             "name": "Forgotten Ancient",
             "text": "Whenever a player plays a spell, you may put a +1/+1 counter on Forgotten Ancient.\nAt the beginning of your upkeep, you may move any number of +1/+1 counters from Forgotten Ancient onto other creatures.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "83ac18fb-5af3-5cff-8782-d1a21f246e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0f5d29-5342-4591-bdc9-c2bc9289ed41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0f5d29-5342-4591-bdc9-c2bc9289ed41.jpg?1",
             "name": "Hunting Pack",
             "text": "Put a 4/4 green Beast creature token into play.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -4048,7 +4048,7 @@
         },
         {
             "id": "7202f230-9b8a-5450-a92e-29ae5d984b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92a7141-119f-4bf8-a82d-eb7c0c37185c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92a7141-119f-4bf8-a82d-eb7c0c37185c.jpg?1",
             "name": "Krosan Drover",
             "text": "Creature spells you play with converted mana cost 6 or more cost {2} less to play.",
             "colours": [
@@ -4082,7 +4082,7 @@
         },
         {
             "id": "8dd583cb-d635-5fca-a28f-e9880bfbb5d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b700b-2072-47c0-9725-ad04414d2474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435b700b-2072-47c0-9725-ad04414d2474.jpg?1",
             "name": "Krosan Warchief",
             "text": "Beast spells you play cost {1} less to play.\n{1}{G}: Regenerate target Beast.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "ddcb152b-15e3-5449-a214-fee641ef03f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1758c-849a-4de3-b674-857c3c9bf399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a1758c-849a-4de3-b674-857c3c9bf399.jpg?1",
             "name": "Kurgadon",
             "text": "Whenever you play a creature spell with converted mana cost 6 or more, put three +1/+1 counters on Kurgadon.",
             "colours": [
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "76380ab9-1007-5911-bd8e-73ef46d24447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2321b01c-7eef-48cc-a86b-4074dfa5b86b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2321b01c-7eef-48cc-a86b-4074dfa5b86b.jpg?1",
             "name": "One with Nature",
             "text": "Whenever enchanted creature deals combat damage to a player, you may search your library for a basic land card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "2650025a-9355-51f9-8a9f-40c89c903b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae26b8d-c3af-42d1-94f4-56950ceac1c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae26b8d-c3af-42d1-94f4-56950ceac1c7.jpg?1",
             "name": "Primitive Etchings",
             "text": "Reveal the first card you draw each turn. Whenever you reveal a creature card this way, draw a card.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "a0a9aa67-ce89-55a3-8d97-2e6d294e17e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5161968e-b757-45b8-826f-98415291024d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5161968e-b757-45b8-826f-98415291024d.jpg?1",
             "name": "Root Elemental",
             "text": "Morph {5}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Root Elemental is turned face up, you may put a creature card from your hand into play.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "cb59fd1f-1a21-528d-9f06-31e3b715eafa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3246a6-b604-4f9f-adb9-3692e0fa8638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3246a6-b604-4f9f-adb9-3692e0fa8638.jpg?1",
             "name": "Sprouting Vines",
             "text": "Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "b1f90826-a9cc-5fed-969c-4724f3022d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f42c4d7-b555-449c-a539-119c1ae62232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f42c4d7-b555-449c-a539-119c1ae62232.jpg?1",
             "name": "Titanic Bulvox",
             "text": "Trample\nMorph {4}{G}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "e1637652-b3c4-5672-b05e-174687c62398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa39646-a609-4b37-b8de-97893ae43c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa39646-a609-4b37-b8de-97893ae43c49.jpg?1",
             "name": "Treetop Scout",
             "text": "Treetop Scout can't be blocked except by creatures with flying.",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "d5e4a562-7d22-592f-9aca-9f8c109a1afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab4600-1f71-48fa-a291-f5c5628c7395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ab4600-1f71-48fa-a291-f5c5628c7395.jpg?1",
             "name": "Upwelling",
             "text": "Mana pools don't empty at the end of phases or turns. (This effect stops mana burn.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "a56e3a7d-abba-5700-b37d-85229a4b3914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8676b1f-e37c-4ae1-9dbe-d000369fa422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8676b1f-e37c-4ae1-9dbe-d000369fa422.jpg?1",
             "name": "Wirewood Guardian",
             "text": "Forestcycling {2} ({2}, Discard this card from your hand: Search your library for a forest card, reveal it, and put it into your hand. Then shuffle your library.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "2f890777-47f2-5989-9a6f-c868bd8750ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49488b76-abaf-4dba-b01f-7b418e4ff295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49488b76-abaf-4dba-b01f-7b418e4ff295.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "Return an Elf you control to its owner's hand: Untap target creature. Play this ability only once each turn.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "ec2f397f-dd39-5d35-b2ed-828876f16f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa85e09-a1cd-473d-98cd-c6a7c7aff949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa85e09-a1cd-473d-98cd-c6a7c7aff949.jpg?1",
             "name": "Woodcloaker",
             "text": "Morph {2}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Woodcloaker is turned face up, target creature gains trample until end of turn.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "f4b3e36e-f2a1-54ab-b7cc-8fb2d0ee5647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a87911a-3931-46aa-9348-2728c4b73b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a87911a-3931-46aa-9348-2728c4b73b96.jpg?1",
             "name": "Xantid Swarm",
             "text": "Flying\nWhenever Xantid Swarm attacks, defending player can't play spells this turn.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "219cdfe0-ed89-53e1-9fcc-7702b82f74d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3e13d-53f8-42bf-aa83-09a9ca94a9f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bd3e13d-53f8-42bf-aa83-09a9ca94a9f0.jpg?1",
             "name": "Bladewing the Risen",
             "text": "Flying\nWhen Bladewing the Risen comes into play, you may return target Dragon card from your graveyard to play.\n{B}{R}: All Dragons get +1/+1 until end of turn.",
             "colours": [
@@ -4559,7 +4559,7 @@
         },
         {
             "id": "c22926e3-a4e3-5d39-b5db-33c7777c8923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b477c2-2cd5-41f2-8754-d4d5000df58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b477c2-2cd5-41f2-8754-d4d5000df58d.jpg?1",
             "name": "Edgewalker",
             "text": "Cleric spells you play cost {W}{B} less to play. This effect reduces only the amount of colored mana you pay. (For example, if you play a Cleric with mana cost {1}{W}, it costs {1} to play.)",
             "colours": [
@@ -4596,7 +4596,7 @@
         },
         {
             "id": "d4809483-04f4-5ac9-8cd1-d980405306e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53d083-251e-42a4-9e2e-c2978c80615b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de53d083-251e-42a4-9e2e-c2978c80615b.jpg?1",
             "name": "Karona, False God",
             "text": "Haste\nAt the beginning of each player's upkeep, that player untaps Karona, False God and gains control of it.\nWhenever Karona attacks, creatures of the type of your choice get +3/+3 until end of turn.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "d68863a5-3d85-56ca-9a34-cdd34ef95a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c16915b-c50d-4fb5-830f-9ca4597a9c0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c16915b-c50d-4fb5-830f-9ca4597a9c0f.jpg?1",
             "name": "Sliver Overlord",
             "text": "{3}: Search your library for a Sliver card, reveal that card, and put it into your hand. Then shuffle your library.\n{3}: Gain control of target Sliver. (This effect doesn't end at end of turn.)",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "f09faaa1-e873-58c9-ac7f-35dbd93926ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b09956-cc34-4472-8b9f-ae355522bd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b09956-cc34-4472-8b9f-ae355522bd5a.jpg?1",
             "name": "Ark of Blight",
             "text": "{3}, {T}, Sacrifice Ark of Blight: Destroy target land.",
             "colours": [],
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "0092018c-5fb5-5c6c-9aef-797a881f6c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c8cff1-b289-41a4-9fa3-cc5e7ba70802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c8cff1-b289-41a4-9fa3-cc5e7ba70802.jpg?1",
             "name": "Proteus Machine",
             "text": "Morph {0} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Proteus Machine is turned face up, its type becomes the creature type of your choice. (This effect doesn't end at end of turn.)",
             "colours": [],
@@ -4744,7 +4744,7 @@
         },
         {
             "id": "550c4e06-f550-50c0-9e8d-e9fe79671eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72dbe81-96d0-4b0d-97a7-c59345f081e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72dbe81-96d0-4b0d-97a7-c59345f081e8.jpg?1",
             "name": "Stabilizer",
             "text": "Players can't cycle cards.",
             "colours": [],
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "cdc5e093-58ca-5e5c-9988-fb9c0422199b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7036f51-10a6-4036-8650-9bc12d2a55cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7036f51-10a6-4036-8650-9bc12d2a55cb.jpg?1",
             "name": "Temple of the False God",
             "text": "{T}: Add {2} to your mana pool. Play this ability only if you control five or more lands.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/SHM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SHM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "46b19147-5715-5059-a455-c5f62e88d98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6ae637-bdb7-4117-8539-e424159bad6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6ae637-bdb7-4117-8539-e424159bad6f.jpg?1",
             "name": "Apothecary Initiate",
             "text": "Whenever a player plays a white spell, you may pay {1}. If you do, you gain 1 life.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "bee80027-536b-59e7-a2e0-8cbbdda497a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66dc28a-3d52-49cf-b1b3-0a1d335d0f5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f66dc28a-3d52-49cf-b1b3-0a1d335d0f5c.jpg?1",
             "name": "Armored Ascension",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each Plains you control and has flying.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "73825ec0-56bd-50ac-8529-8686bf8dd507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c54ec5-2917-4acf-b56f-8273781477f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c54ec5-2917-4acf-b56f-8273781477f6.jpg?1",
             "name": "Ballynock Cohort",
             "text": "First strike\nBallynock Cohort gets +1/+1 as long as you control another white creature.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "5a1d1095-2d0e-5327-aa9c-ded736bfb65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8888e0aa-3682-4800-9c50-fff5d5c9547d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8888e0aa-3682-4800-9c50-fff5d5c9547d.jpg?1",
             "name": "Barrenton Medic",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\nPut a -1/-1 counter on Barrenton Medic: Untap Barrenton Medic.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "198b02bb-3e9f-590d-ac80-0834dbff4387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a27ba4d-53af-427d-9e51-be04db077fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a27ba4d-53af-427d-9e51-be04db077fac.jpg?1",
             "name": "Boon Reflection",
             "text": "If you would gain life, you gain twice that much life instead.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "d7065945-7043-5fc4-83f1-0427ff36d194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12030927-7af2-448f-bc6b-c2035e0b799d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12030927-7af2-448f-bc6b-c2035e0b799d.jpg?1",
             "name": "Goldenglow Moth",
             "text": "Flying\nWhenever Goldenglow Moth blocks, you may gain 4 life.",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "210f1dd7-483f-558a-a7ad-4501d03199ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177787f-bf1e-438b-9615-97d03b04128c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1177787f-bf1e-438b-9615-97d03b04128c.jpg?1",
             "name": "Greater Auramancy",
             "text": "Other enchantments you control have shroud.\nEnchanted creatures you control have shroud.",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "8be2b693-e20b-5f39-ba44-4faaeb15cdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c607ec00-2d44-485e-ad85-24c0c7a284f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c607ec00-2d44-485e-ad85-24c0c7a284f9.jpg?1",
             "name": "Inquisitor's Snare",
             "text": "Prevent all damage target attacking or blocking creature would deal this turn. If that creature is black or red, destroy it.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "450809b6-b536-56b6-9134-19c739cb014b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a0afa-50e6-4bce-b261-4559fd31295e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a0afa-50e6-4bce-b261-4559fd31295e.jpg?1",
             "name": "Kithkin Rabble",
             "text": "Vigilance\nKithkin Rabble's power and toughness are each equal to the number of white permanents you control.",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "47b96acc-bec6-5a09-bb28-57b8d588242f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5102a7-2147-4e22-b683-c08b4a725617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e5102a7-2147-4e22-b683-c08b4a725617.jpg?1",
             "name": "Kithkin Shielddare",
             "text": "{W}, {T}: Target blocking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "65147038-bb26-593c-94e1-adfafdb10a37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225447a5-41e1-4e57-ab6a-bff74d4523b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225447a5-41e1-4e57-ab6a-bff74d4523b3.jpg?1",
             "name": "Last Breath",
             "text": "Remove target creature with power 2 or less from the game. Its controller gains 4 life.",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "898c74e0-238b-5563-8f2d-b8cda087362b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24be94-9922-43bb-83c8-98090adc3f32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24be94-9922-43bb-83c8-98090adc3f32.jpg?1",
             "name": "Mass Calcify",
             "text": "Destroy all nonwhite creatures.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "2e163eec-3032-5b93-b317-1c45fceb1440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9dce2-3d2c-4ac4-a61e-3e352b6d4557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee9dce2-3d2c-4ac4-a61e-3e352b6d4557.jpg?1",
             "name": "Mine Excavation",
             "text": "Return target artifact or enchantment card in a graveyard to its owner's hand.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -438,7 +438,7 @@
         },
         {
             "id": "2c1b0e97-9df8-5d28-b8ee-87f9ecaf3271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18ff12f-3b0e-404a-8e35-3f7d05d0c0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18ff12f-3b0e-404a-8e35-3f7d05d0c0a7.jpg?1",
             "name": "Mistmeadow Skulk",
             "text": "Lifelink, protection from converted mana cost 3 or greater",
             "colours": [
@@ -473,7 +473,7 @@
         },
         {
             "id": "b3e16055-293f-5008-a121-8797ba66e1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea1e2c4-1671-4322-b8ba-e4e1a879cf37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea1e2c4-1671-4322-b8ba-e4e1a879cf37.jpg?1",
             "name": "Niveous Wisps",
             "text": "Target creature becomes white until end of turn. Tap that creature.\nDraw a card.",
             "colours": [
@@ -505,7 +505,7 @@
         },
         {
             "id": "34fa1899-4052-5d35-92ca-69a195ff881d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eb5f06-7f9c-4240-bbbb-6c59a49a5f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06eb5f06-7f9c-4240-bbbb-6c59a49a5f0c.jpg?1",
             "name": "Order of Whiteclay",
             "text": "{1}{W}{W}, {Q}: Return target creature card with converted mana cost 3 or less from your graveyard to play. ({Q} is the untap symbol.)",
             "colours": [
@@ -540,7 +540,7 @@
         },
         {
             "id": "46e23fae-aec6-5662-b09a-e95dde4ac5e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f852508e-7087-42e1-ad9b-c84708e92de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f852508e-7087-42e1-ad9b-c84708e92de7.jpg?1",
             "name": "Pale Wayfarer",
             "text": "{2}{W}{W}, {Q}: Target creature gains protection from the color of its controller's choice until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -575,7 +575,7 @@
         },
         {
             "id": "953cb857-1309-5aa8-9eb3-263bacdc0d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ceb21d-6b51-4634-a2cf-13ef8f559287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ceb21d-6b51-4634-a2cf-13ef8f559287.jpg?1",
             "name": "Prison Term",
             "text": "Enchant creature\nEnchanted creature can't attack or block and its activated abilities can't be played.\nWhenever a creature comes into play under an opponent's control, you may attach Prison Term to that creature.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "e4019922-95b4-5e13-b05e-894d8840ce15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87e59d-422c-4dd7-8867-423e784830a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87e59d-422c-4dd7-8867-423e784830a2.jpg?1",
             "name": "Resplendent Mentor",
             "text": "White creatures you control have \"{T}: You gain 1 life.\"",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "5d917fb6-dd0e-5f0f-99ad-e175a7218bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9574f6-40b3-4fe2-950c-234bc358ecf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d9574f6-40b3-4fe2-950c-234bc358ecf6.jpg?1",
             "name": "Rune-Cervin Rider",
             "text": "Flying\n{RW}{RW}: Rune-Cervin Rider gets +1/+1 until end of turn.",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "cb1af308-50fb-5801-8158-1afef49af3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b45f79-f23e-4eef-8cac-91780dc2a044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b45f79-f23e-4eef-8cac-91780dc2a044.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo comes into play, name a card.\nYou have protection from the chosen name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "28aa77b1-24ca-56bf-a3a1-28f674bb88e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa8bd74-9897-4515-b1a0-50d5f1bda673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa8bd74-9897-4515-b1a0-50d5f1bda673.jpg?1",
             "name": "Safehold Sentry",
             "text": "{2}{W}, {Q}: Safehold Sentry gets +0/+2 until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "7b52c62e-c70f-5694-b715-de76956e9879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e26bd0c-5ec7-4653-8e63-747157c20af1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e26bd0c-5ec7-4653-8e63-747157c20af1.jpg?1",
             "name": "Spectral Procession",
             "text": "({2\nW} can be paid with any two mana or with {W}. This card's converted mana cost is 6.)\nPut three 1/1 white Spirit creature tokens with flying into play.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "bbd4c6a8-c1db-5821-89df-8ca802d5a65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51173fa1-7cd4-4093-982a-db0d46564a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51173fa1-7cd4-4093-982a-db0d46564a8a.jpg?1",
             "name": "Strip Bare",
             "text": "Destroy all Auras and Equipment attached to target creature.",
             "colours": [
@@ -811,7 +811,7 @@
         },
         {
             "id": "4fec6221-386e-5451-a65e-0dc063328e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c24ba-4d1d-48ca-bc1c-ea0ed087de80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119c24ba-4d1d-48ca-bc1c-ea0ed087de80.jpg?1",
             "name": "Twilight Shepherd",
             "text": "Flying, vigilance\nWhen Twilight Shepherd comes into play, return to your hand all cards in your graveyard put there from play this turn.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -845,7 +845,7 @@
         },
         {
             "id": "88a55b3b-3842-5203-8a48-4a27da874400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg?1",
             "name": "Windbrisk Raptor",
             "text": "Flying\nAttacking creatures you control have lifelink.",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "9d232ce2-3c60-53bf-96be-0f018a60bd80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05c7868-e589-478e-af0c-512d0fe4f253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05c7868-e589-478e-af0c-512d0fe4f253.jpg?1",
             "name": "Woeleecher",
             "text": "{W}, {T}: Remove a -1/-1 counter from target creature. If you do, you gain 2 life.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "3d71f5be-3b0b-5e0e-b343-638c8f4c5b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d874f345-e623-4317-9aa7-66d14a011303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d874f345-e623-4317-9aa7-66d14a011303.jpg?1",
             "name": "Advice from the Fae",
             "text": "({2\nU} can be paid with any two mana or with {U}. This card's converted mana cost is 6.)\nLook at the top five cards of your library. If you control more creatures than any other player, put two of those cards into your hand. Otherwise, put one of them into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "d4289a8e-e3a5-5f37-8cab-21d3ce8c7bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ed9c9f-37d1-4f33-b62f-11ed2c208763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ed9c9f-37d1-4f33-b62f-11ed2c208763.jpg?1",
             "name": "Biting Tether",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -979,7 +979,7 @@
         },
         {
             "id": "7c781fb6-4633-5168-94f2-fc6d8734497d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9d87a-533c-4641-9738-e7b98d92b015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf9d87a-533c-4641-9738-e7b98d92b015.jpg?1",
             "name": "Briarberry Cohort",
             "text": "Flying\nBriarberry Cohort gets +1/+1 as long as you control another blue creature.",
             "colours": [
@@ -1014,7 +1014,7 @@
         },
         {
             "id": "bf2a0e81-a033-5961-995a-f58b758376a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dca4f46-0aad-484f-b4ea-ed61a4fc1a89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dca4f46-0aad-484f-b4ea-ed61a4fc1a89.jpg?1",
             "name": "Cerulean Wisps",
             "text": "Target creature becomes blue until end of turn. Untap that creature.\nDraw a card.",
             "colours": [
@@ -1046,7 +1046,7 @@
         },
         {
             "id": "d50bb1d7-08a2-52e6-bd13-9f5345c8a67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e866d86-5bfa-473d-be17-d8f4aea70ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e866d86-5bfa-473d-be17-d8f4aea70ddb.jpg?1",
             "name": "Consign to Dream",
             "text": "Return target permanent to its owner's hand. If that permanent is red or green, put it on top of its owner's library instead.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "18225efd-713d-589f-bc8e-1eb8551ccca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4228b80-d87d-4ebe-ae92-04e4a7d0dc43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4228b80-d87d-4ebe-ae92-04e4a7d0dc43.jpg?1",
             "name": "Counterbore",
             "text": "Counter target spell. Search its controller's graveyard, hand, and library for all cards with the same name as that spell and remove them from the game. Then that player shuffles his or her library.",
             "colours": [
@@ -1110,7 +1110,7 @@
         },
         {
             "id": "8d608f98-5a99-5013-933f-71277f745cc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f2bfa5-bc30-46a4-b114-9d8c5b62e197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f2bfa5-bc30-46a4-b114-9d8c5b62e197.jpg?1",
             "name": "Cursecatcher",
             "text": "Sacrifice Cursecatcher: Counter target instant or sorcery spell unless its controller pays {1}.",
             "colours": [
@@ -1145,7 +1145,7 @@
         },
         {
             "id": "44188572-8618-581d-a70c-78e57de3640f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae429d-c09d-4818-8eb8-7e1c97e4b0c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae429d-c09d-4818-8eb8-7e1c97e4b0c9.jpg?1",
             "name": "Deepchannel Mentor",
             "text": "Blue creatures you control are unblockable.",
             "colours": [
@@ -1180,7 +1180,7 @@
         },
         {
             "id": "142783e8-97db-55ad-8a12-7dad756cf9cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28accc5f-63a5-47d0-b0e6-747aa0aa43e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28accc5f-63a5-47d0-b0e6-747aa0aa43e5.jpg?1",
             "name": "Drowner Initiate",
             "text": "Whenever a player plays a blue spell, you may pay {1}. If you do, target player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1215,7 +1215,7 @@
         },
         {
             "id": "cbf01a25-3b64-5906-8fbd-fda39e0c5b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90598bb2-d96c-4f74-864b-1947b7d39e58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90598bb2-d96c-4f74-864b-1947b7d39e58.jpg?1",
             "name": "Faerie Swarm",
             "text": "Flying\nFaerie Swarm's power and toughness are each equal to the number of blue permanents you control.",
             "colours": [
@@ -1249,7 +1249,7 @@
         },
         {
             "id": "b69e40ae-766b-53b3-afda-3a264dc0ee38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194d88d-6f2c-47ed-ad9c-d55bb1858e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3194d88d-6f2c-47ed-ad9c-d55bb1858e79.jpg?1",
             "name": "Flow of Ideas",
             "text": "Draw a card for each Island you control.",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "aa1ca3f0-d2d0-57fc-b394-328aebde6198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbd510a-d71f-4b0c-bc6c-e403f632cbdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbd510a-d71f-4b0c-bc6c-e403f632cbdb.jpg?1",
             "name": "Ghastly Discovery",
             "text": "Draw two cards, then discard a card.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
             "colours": [
@@ -1313,7 +1313,7 @@
         },
         {
             "id": "5dfdcdee-57bb-5606-9e52-202cfc00be2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e769b1b2-c2a9-4db1-bf1f-01863aa2cd0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e769b1b2-c2a9-4db1-bf1f-01863aa2cd0b.jpg?1",
             "name": "Isleback Spawn",
             "text": "Shroud\nIsleback Spawn gets +4/+8 as long as a library has twenty or fewer cards in it.",
             "colours": [
@@ -1347,7 +1347,7 @@
         },
         {
             "id": "e257eace-4dfd-57a8-af7e-7e41936bb9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfde34-f76b-47ab-b83e-1c188d61a613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfde34-f76b-47ab-b83e-1c188d61a613.jpg?1",
             "name": "Kinscaer Harpoonist",
             "text": "Flying\nWhenever Kinscaer Harpoonist attacks, you may have target creature lose flying until end of turn.",
             "colours": [
@@ -1382,7 +1382,7 @@
         },
         {
             "id": "4292cda5-a229-57da-9714-879a759cd2b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22353590-f248-460e-a1a5-0b7431a4c82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22353590-f248-460e-a1a5-0b7431a4c82d.jpg?1",
             "name": "Knacksaw Clique",
             "text": "Flying\n{1}{U}, {Q}: Target opponent removes the top card of his or her library from the game. Until end of turn, you may play that card. ({Q} is the untap symbol.)",
             "colours": [
@@ -1417,7 +1417,7 @@
         },
         {
             "id": "a33259d6-fc9d-577c-9f63-8789ee894690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86562c6-91bd-4866-a2a9-0062ffdf07ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a86562c6-91bd-4866-a2a9-0062ffdf07ce.jpg?1",
             "name": "Leech Bonder",
             "text": "Leech Bonder comes into play with two -1/-1 counters on it.\n{U}, {Q}: Move a counter from target creature onto another target creature. ({Q} is the untap symbol.)",
             "colours": [
@@ -1452,7 +1452,7 @@
         },
         {
             "id": "32d2a2e8-6a84-560e-bb57-356b8da657ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919382e-3dcd-4f83-8135-be71345e57c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9919382e-3dcd-4f83-8135-be71345e57c0.jpg?1",
             "name": "Merrow Wavebreakers",
             "text": "{1}{U}, {Q}: Merrow Wavebreakers gains flying until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "97ea1e23-908f-555e-8527-61cc0ce7b7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f9987-87d8-4cd3-98c4-b6976c70739e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499f9987-87d8-4cd3-98c4-b6976c70739e.jpg?1",
             "name": "Parapet Watchers",
             "text": "{WU}: Parapet Watchers gets +0/+1 until end of turn.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "6c9605c4-89fd-5d2c-b6fe-6a6d56523b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7ac836-07c9-469d-9ed0-4a0aab457e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7ac836-07c9-469d-9ed0-4a0aab457e31.jpg?1",
             "name": "Prismwake Merrow",
             "text": "Flash\nWhen Prismwake Merrow comes into play, target permanent becomes the color or colors of your choice until end of turn.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "dd5887fe-2e33-5a6c-ad59-7b0ed37b399a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380bd90-35f2-4936-995b-af6427f61752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8380bd90-35f2-4936-995b-af6427f61752.jpg?1",
             "name": "Puca's Mischief",
             "text": "At the beginning of your upkeep, you may exchange control of target nonland permanent you control and target nonland permanent an opponent controls with an equal or lesser converted mana cost.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "32ab3d2a-12bf-52aa-8d6a-8a295d2cae50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17dff9e-23f7-4b12-95e7-aa1c00ab3d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c17dff9e-23f7-4b12-95e7-aa1c00ab3d18.jpg?1",
             "name": "Put Away",
             "text": "Counter target spell. You may shuffle up to one target card from your graveyard into your library.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "0b61b9d8-518b-5ca8-baa2-c695cac930d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970adaaf-1534-4529-8da4-c4dcf7c08b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970adaaf-1534-4529-8da4-c4dcf7c08b7b.jpg?1",
             "name": "River Kelpie",
             "text": "Whenever River Kelpie or another permanent is put into play from a graveyard, draw a card.\nWhenever a spell is played from a graveyard, draw a card.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "b6bd6b55-34b7-5d24-a014-70c85099d760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0d9ad-31bf-4561-a5b2-f44a12a2c2c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0d9ad-31bf-4561-a5b2-f44a12a2c2c2.jpg?1",
             "name": "Savor the Moment",
             "text": "Take an extra turn after this one. Skip the untap step of that turn.",
             "colours": [
@@ -1688,7 +1688,7 @@
         },
         {
             "id": "3c90d662-7ba7-5c6d-8428-4f3b530f9f11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aac9a8a-7594-4270-a8b6-57b4f8f2a390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aac9a8a-7594-4270-a8b6-57b4f8f2a390.jpg?1",
             "name": "Sinking Feeling",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"{1}, Put a -1/-1 counter on this creature: Untap this creature.\"",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "34a85898-5d6a-5492-85c2-bfbd8ef6906a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883113c-e52b-4633-b4a4-016093327b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883113c-e52b-4633-b4a4-016093327b6a.jpg?1",
             "name": "Spell Syphon",
             "text": "Counter target spell unless its controller pays {1} for each blue permanent you control.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "7de2179c-05a4-5f24-b79b-9b133733d19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3090b11-3df3-40bc-bd3c-27218c2e19e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3090b11-3df3-40bc-bd3c-27218c2e19e2.jpg?1",
             "name": "Thought Reflection",
             "text": "If you would draw a card, draw two cards instead.",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "948a4eeb-43cd-5d78-b8cb-63c6a37d6b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e1d8b-edae-4b5e-b897-2c0a307e650c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b10e1d8b-edae-4b5e-b897-2c0a307e650c.jpg?1",
             "name": "Whimwader",
             "text": "Whimwader can't attack unless defending player controls a blue permanent.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "1f41da58-f8b2-5800-bb0b-1eb5c4908287",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd47e7-02c5-4f91-bb3b-697c4c53232a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fd47e7-02c5-4f91-bb3b-697c4c53232a.jpg?1",
             "name": "Aphotic Wisps",
             "text": "Target creature becomes black and gains fear until end of turn.\nDraw a card.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "eeb5d45c-a1ff-5f21-8c0a-eeabecbcd8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdef552-17d0-4b48-868e-058af02101be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebdef552-17d0-4b48-868e-058af02101be.jpg?1",
             "name": "Ashenmoor Cohort",
             "text": "Ashenmoor Cohort gets +1/+1 as long as you control another black creature.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "7f89d4bb-04a5-5f4a-b8a1-a40138c82cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee0a93-0f6d-42be-bdca-1de5422d8d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ee0a93-0f6d-42be-bdca-1de5422d8d54.jpg?1",
             "name": "Beseech the Queen",
             "text": "({2\nB} can be paid with any two mana or with {B}. This card's converted mana cost is 6.)\nSearch your library for a card with converted mana cost less than or equal to the number of lands you control, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "5947f81e-9349-54a8-bedd-a36edb93fea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae027b38-a6cc-41f7-8f0d-9d1402b46517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae027b38-a6cc-41f7-8f0d-9d1402b46517.jpg?1",
             "name": "Blowfly Infestation",
             "text": "Whenever a creature is put into a graveyard from play, if it had a -1/-1 counter on it, put a -1/-1 counter on target creature.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "96cb98f4-12e0-5d0b-b6e9-2fa05b814788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dcf40c-62fb-4205-807e-71655066a61b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22dcf40c-62fb-4205-807e-71655066a61b.jpg?1",
             "name": "Cinderbones",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{1}{B}: Regenerate Cinderbones.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "6905f0b7-43a9-5d34-8f13-4925081e2fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644319c2-f122-4369-b1f8-56ad7d8ce861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/644319c2-f122-4369-b1f8-56ad7d8ce861.jpg?1",
             "name": "Cinderhaze Wretch",
             "text": "{T}: Target player discards a card. Play this ability only during your turn.\nPut a -1/-1 counter on Cinderhaze Wretch: Untap Cinderhaze Wretch.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "aa24a1f9-0cb1-5f9e-975c-fdb8542df283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140457ff-ee7d-48ec-8b91-ef5c2cc1ed74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/140457ff-ee7d-48ec-8b91-ef5c2cc1ed74.jpg?1",
             "name": "Corrosive Mentor",
             "text": "Black creatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -2056,7 +2056,7 @@
         },
         {
             "id": "cf79b6bc-5167-5e9d-a850-22cbf9efdbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3504249-d226-4a9a-8855-69723cefaeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3504249-d226-4a9a-8855-69723cefaeff.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals damage equal to the number of Swamps you control to target creature or player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -2088,7 +2088,7 @@
         },
         {
             "id": "13f726d0-1e5f-54b3-b148-20ab08390820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd88305-d57b-4e77-aec9-f0a3ace42c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd88305-d57b-4e77-aec9-f0a3ace42c37.jpg?1",
             "name": "Crowd of Cinders",
             "text": "Fear\nCrowd of Cinders's power and toughness are each equal to the number of black permanents you control.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "0c8876cb-2821-549e-a9a6-c61f177806a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7796925-fe69-4019-82ab-7cb75760b045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7796925-fe69-4019-82ab-7cb75760b045.jpg?1",
             "name": "Disturbing Plot",
             "text": "Return target creature card in a graveyard to its owner's hand.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "26f92dca-7d7b-5918-8a0e-3a27871725f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adce41c5-3a43-4fe0-b84e-8baaad1a0777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adce41c5-3a43-4fe0-b84e-8baaad1a0777.jpg?1",
             "name": "Dusk Urchins",
             "text": "Whenever Dusk Urchins attacks or blocks, put a -1/-1 counter on it.\nWhen Dusk Urchins is put into a graveyard from play, draw a card for each -1/-1 counter on it.",
             "colours": [
@@ -2188,7 +2188,7 @@
         },
         {
             "id": "07be9f95-dc09-5638-8867-8006a19ce035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8befa-27dd-4ec4-b317-1c231407e0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead8befa-27dd-4ec4-b317-1c231407e0ac.jpg?1",
             "name": "Faerie Macabre",
             "text": "Flying\nDiscard Faerie Macabre: Remove up to two target cards in graveyards from the game.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "2b0a22ce-178a-5f92-a01b-75a366224fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b45bfb2-7c48-4da5-a0fd-29d353221814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b45bfb2-7c48-4da5-a0fd-29d353221814.jpg?1",
             "name": "Gloomlance",
             "text": "Destroy target creature. If that creature was green or white, its controller discards a card.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "10fba05f-1f7b-5e34-b797-18aedd1bd74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544fba3c-0db4-4ac3-ac70-ae9a5468ab5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544fba3c-0db4-4ac3-ac70-ae9a5468ab5d.jpg?1",
             "name": "Hollowborn Barghest",
             "text": "At the beginning of your upkeep, if you have no cards in hand, each opponent loses 2 life.\nAt the beginning of each opponent's upkeep, if that player has no cards in hand, he or she loses 2 life.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "1567f628-c3f1-5893-a0f9-8e7dd7a624c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6618713-0573-44f6-82d9-dfc16dfef052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6618713-0573-44f6-82d9-dfc16dfef052.jpg?1",
             "name": "Hollowsage",
             "text": "Whenever Hollowsage becomes untapped, you may have target player discard a card.",
             "colours": [
@@ -2325,7 +2325,7 @@
         },
         {
             "id": "21bf4eb8-efc8-5f48-94c0-880ea0a75ada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2633f1c-0563-4b3d-bab0-415757bc5ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2633f1c-0563-4b3d-bab0-415757bc5ecd.jpg?1",
             "name": "Incremental Blight",
             "text": "Put a -1/-1 counter on target creature, two -1/-1 counters on another target creature, and three -1/-1 counters on a third target creature.",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "e167e82a-79a2-5ac7-b79e-5f1572736513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964b501-5b7f-4225-9dd3-e7519bf34048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964b501-5b7f-4225-9dd3-e7519bf34048.jpg?1",
             "name": "Loch Korrigan",
             "text": "{UB}: Loch Korrigan gets +1/+1 until end of turn.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "034f1fc5-d5c1-5506-a77f-a369caf3612a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0ff253-001a-45bc-98ab-4713a813fb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df0ff253-001a-45bc-98ab-4713a813fb11.jpg?1",
             "name": "Midnight Banshee",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nAt the beginning of your upkeep, put a -1/-1 counter on each nonblack creature.",
             "colours": [
@@ -2426,7 +2426,7 @@
         },
         {
             "id": "b6ae85a4-544a-5a79-b1da-91637b5c15e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231613d6-d3b8-4b41-bc93-4d5da3fec5d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/231613d6-d3b8-4b41-bc93-4d5da3fec5d0.jpg?1",
             "name": "Plague of Vermin",
             "text": "Starting with you, each player may pay any amount of life. Repeat this process until no one pays life. Each player puts a 1/1 black Rat creature token into play for each 1 life he or she paid this way.",
             "colours": [
@@ -2458,7 +2458,7 @@
         },
         {
             "id": "13e8e109-d9f5-5904-8ec7-cd4032f434b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6439222-de30-44cd-a53f-a7de0cb00b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6439222-de30-44cd-a53f-a7de0cb00b8f.jpg?1",
             "name": "Polluted Bonds",
             "text": "Whenever a land comes into play under an opponent's control, that player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2490,7 +2490,7 @@
         },
         {
             "id": "348c4621-66ef-5493-abbe-2cd7202dc96d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff839e1-6f76-4a24-a87c-d4589b1abf66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6ff839e1-6f76-4a24-a87c-d4589b1abf66.jpg?1",
             "name": "Puppeteer Clique",
             "text": "Flying\nWhen Puppeteer Clique comes into play, put target creature card in an opponent's graveyard into play under your control. It has haste. At the end of your turn, remove it from the game.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "e2e30e7b-a62f-5d87-af60-9ba5f48ddd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62d999c-c81e-4bea-aefd-0d12251dcdd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62d999c-c81e-4bea-aefd-0d12251dcdd1.jpg?1",
             "name": "Rite of Consumption",
             "text": "As an additional cost to play Rite of Consumption, sacrifice a creature.\nRite of Consumption deals damage equal to the sacrificed creature's power to target player. You gain life equal to the damage dealt this way.",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "ec96ffa4-97be-54bd-97fd-8bdd15809c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c4e5f-5de7-45ec-b502-0e6d7c5c359d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e07c4e5f-5de7-45ec-b502-0e6d7c5c359d.jpg?1",
             "name": "Sickle Ripper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "87955378-3d18-5f56-ba0c-321a66bef355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ecbed3-3a41-4823-8cd2-498daaaa0d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ecbed3-3a41-4823-8cd2-498daaaa0d4f.jpg?1",
             "name": "Smolder Initiate",
             "text": "Whenever a player plays a black spell, you may pay {1}. If you do, target player loses 1 life.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "f8d88b13-c79b-51df-8714-b63522ad4611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168d790f-9163-498c-b96d-fdeb2070bda0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168d790f-9163-498c-b96d-fdeb2070bda0.jpg?1",
             "name": "Splitting Headache",
             "text": "Choose one Target player discards two cards; or target player reveals his or her hand, you choose a card from it, then that player discards that card.",
             "colours": [
@@ -2659,7 +2659,7 @@
         },
         {
             "id": "bd1fc581-5f62-5a9c-bba2-285ab9e3c4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fed16d-c800-4c0f-be88-9fddde2c018e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1fed16d-c800-4c0f-be88-9fddde2c018e.jpg?1",
             "name": "Torture",
             "text": "Enchant creature\n{1}{B}: Put a -1/-1 counter on enchanted creature.",
             "colours": [
@@ -2693,7 +2693,7 @@
         },
         {
             "id": "0cc21525-2e70-5260-b828-f96e249fb300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cf8332-0ff2-40c5-980a-6f6be690fad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cf8332-0ff2-40c5-980a-6f6be690fad0.jpg?1",
             "name": "Wound Reflection",
             "text": "At the end of each turn, each opponent loses life equal to the life he or she lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -2725,7 +2725,7 @@
         },
         {
             "id": "f46e71c5-016f-5953-bcab-e34028bb9c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5720a5b2-60ca-49f9-83e8-b801471c92ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5720a5b2-60ca-49f9-83e8-b801471c92ea.jpg?1",
             "name": "Blistering Dieflyn",
             "text": "Flying\n{BR}: Blistering Dieflyn gets +1/+0 until end of turn.",
             "colours": [
@@ -2760,7 +2760,7 @@
         },
         {
             "id": "5caef7a6-bfde-5f8e-a633-c2b5131628fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322a389-44cc-4a3d-bd39-93c156640f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322a389-44cc-4a3d-bd39-93c156640f8e.jpg?1",
             "name": "Bloodmark Mentor",
             "text": "Red creatures you control have first strike.",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "f7deb67d-b240-5bce-bddf-f94a5918a23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b92320-6f83-4731-93c8-7eb9fd90ee83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b92320-6f83-4731-93c8-7eb9fd90ee83.jpg?1",
             "name": "Bloodshed Fever",
             "text": "Enchant creature\nEnchanted creature attacks each turn if able.",
             "colours": [
@@ -2829,7 +2829,7 @@
         },
         {
             "id": "84037f69-a0bf-541e-a889-11400ee419f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a837b6-c8b0-4971-ae95-0b49d38bc830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a837b6-c8b0-4971-ae95-0b49d38bc830.jpg?1",
             "name": "Boggart Arsonists",
             "text": "Plainswalk\n{2}{R}, Sacrifice Boggart Arsonists: Destroy target Scarecrow or Plains.",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "e6d01741-e4c8-5147-b944-a06b62753af7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01f9a0-f1d0-4241-a270-df4ed673d1fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01f9a0-f1d0-4241-a270-df4ed673d1fd.jpg?1",
             "name": "Burn Trail",
             "text": "Burn Trail deals 3 damage to target creature or player.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "aebb787a-ab84-5f23-90b7-ea24539ab132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9297506-8656-483d-892e-217ecd8bab0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9297506-8656-483d-892e-217ecd8bab0c.jpg?1",
             "name": "Cragganwick Cremator",
             "text": "When Cragganwick Cremator comes into play, discard a card at random. If you discard a creature card this way, Cragganwick Cremator deals damage equal to that card's power to target player.",
             "colours": [
@@ -2931,7 +2931,7 @@
         },
         {
             "id": "4f531821-36ee-5f16-baea-26c9067bc348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65c81ff-fc5d-4191-93fb-52eb806457b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a65c81ff-fc5d-4191-93fb-52eb806457b7.jpg?1",
             "name": "Crimson Wisps",
             "text": "Target creature becomes red and gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "7b3d71b4-2167-570b-bc6b-61334ca9ac1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg?1",
             "name": "Deep-Slumber Titan",
             "text": "Deep-Slumber Titan comes into play tapped.\nDeep-Slumber Titan doesn't untap during your untap step.\nWhenever Deep-Slumber Titan is dealt damage, untap it.",
             "colours": [
@@ -2998,7 +2998,7 @@
         },
         {
             "id": "9cfd09a8-563d-52bd-ab23-2767ba01a49c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91705d63-8aae-47c2-a880-1b07c6d33bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91705d63-8aae-47c2-a880-1b07c6d33bde.jpg?1",
             "name": "Elemental Mastery",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put X 1/1 red Elemental creature tokens with haste into play, where X is this creature's power. Remove them from the game at end of turn.\"",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "5ef0a25d-554a-5d44-96f9-89ab34f59715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cafc-ca14-4c1a-8237-565515a81dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf0cafc-ca14-4c1a-8237-565515a81dec.jpg?1",
             "name": "Ember Gale",
             "text": "Creatures target player controls can't block this turn. Ember Gale deals 1 damage to each white and/or blue creature that player controls.",
             "colours": [
@@ -3064,7 +3064,7 @@
         },
         {
             "id": "ada11962-b845-5809-9ab8-5c0bebf8c04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a567b570-81e4-4068-929c-9ce406fe7474.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a567b570-81e4-4068-929c-9ce406fe7474.jpg?1",
             "name": "Flame Javelin",
             "text": "({2\nR} can be paid with any two mana or with {R}. This card's converted mana cost is 6.)\nFlame Javelin deals 4 damage to target creature or player.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "663083ae-f041-5a3a-bc76-425437b16e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b102dc6-d7ef-48dd-8b77-2ce43955f7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b102dc6-d7ef-48dd-8b77-2ce43955f7fa.jpg?1",
             "name": "Furystoke Giant",
             "text": "When Furystoke Giant comes into play, other creatures you control gain \"{T}: This creature deals 2 damage to target creature or player\" until end of turn.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "736c37e0-2924-5099-b96f-3ba9f70735a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023562bf-da7d-486d-93fc-60353f55b8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023562bf-da7d-486d-93fc-60353f55b8a7.jpg?1",
             "name": "Horde of Boggarts",
             "text": "Horde of Boggarts's power and toughness are each equal to the number of red permanents you control.\nHorde of Boggarts can't be blocked except by two or more creatures.",
             "colours": [
@@ -3165,7 +3165,7 @@
         },
         {
             "id": "e5ffb25b-0be4-5995-a88e-bc03c7361895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4a1d42-eaf8-424a-9649-5f3b4602bf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4a1d42-eaf8-424a-9649-5f3b4602bf0d.jpg?1",
             "name": "Inescapable Brute",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nInescapable Brute must be blocked if able.",
             "colours": [
@@ -3200,7 +3200,7 @@
         },
         {
             "id": "e302363b-7e08-55d3-8f04-d196035fb6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19dd557-dd49-450d-8446-71ce351d4f52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c19dd557-dd49-450d-8446-71ce351d4f52.jpg?1",
             "name": "Intimidator Initiate",
             "text": "Whenever a player plays a red spell, you may pay {1}. If you do, target creature can't block this turn.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "531c570e-3b7a-5221-bb97-47edefc8976a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75021156-61af-4a85-8ac5-15cf18482140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75021156-61af-4a85-8ac5-15cf18482140.jpg?1",
             "name": "Jaws of Stone",
             "text": "Jaws of Stone deals X damage divided as you choose among any number of target creatures and/or players, where X is the number of Mountains you control as you play Jaws of Stone.",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "bc024a0c-b7e0-5b7e-88c6-8853bc2f524d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcfec58-bfe4-4b04-80e3-ee11c44e91a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfcfec58-bfe4-4b04-80e3-ee11c44e91a7.jpg?1",
             "name": "Knollspine Dragon",
             "text": "Flying\nWhen Knollspine Dragon comes into play, you may discard your hand and draw cards equal to the damage dealt to target opponent this turn.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "09d5d53b-4569-5e88-862e-0a1e1ae35201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8157aade-9dfc-402d-8e1f-468bf2bccb9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8157aade-9dfc-402d-8e1f-468bf2bccb9c.jpg?1",
             "name": "Knollspine Invocation",
             "text": "{X}, Discard a card with converted mana cost X: Knollspine Invocation deals X damage to target creature or player.",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "43518675-12a4-57f9-8bcd-4c96ce292ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcb1f26-9a2a-40bd-b291-4ef8ce375cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fcb1f26-9a2a-40bd-b291-4ef8ce375cdf.jpg?1",
             "name": "Mudbrawler Cohort",
             "text": "Haste\nMudbrawler Cohort gets +1/+1 as long as you control another red creature.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "008d434b-e1df-59a5-a324-5b288fa6be7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02d053-0885-4720-bf74-b65b3f87cfd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02d053-0885-4720-bf74-b65b3f87cfd9.jpg?1",
             "name": "Power of Fire",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "ca7adbb0-c8fb-5119-aff0-1edddae79d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a0bc1-ab01-4381-8f54-7381a2213cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a0bc1-ab01-4381-8f54-7381a2213cdf.jpg?1",
             "name": "Puncture Bolt",
             "text": "Puncture Bolt deals 1 damage to target creature. Put a -1/-1 counter on that creature.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "f418c932-de21-5508-9472-8b251302b4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de320e0d-c1e9-4b5e-84a0-057f3f162bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de320e0d-c1e9-4b5e-84a0-057f3f162bbf.jpg?1",
             "name": "Pyre Charger",
             "text": "Haste\n{R}: Pyre Charger gets +1/+0 until end of turn.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "280e8dbe-a227-547c-84e4-1f90d15ec20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275e118d-1d50-47ee-a2c9-76169ce372cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/275e118d-1d50-47ee-a2c9-76169ce372cf.jpg?1",
             "name": "Rage Reflection",
             "text": "Creatures you control have double strike.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "4807f2a2-8951-533a-b969-38e41ae0487c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa0dd3e-51d1-4d75-b0f4-835992f420d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa0dd3e-51d1-4d75-b0f4-835992f420d6.jpg?1",
             "name": "Rustrazor Butcher",
             "text": "First strike\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "2f4be608-fe53-57f0-8fed-1fdf41855204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259c6cd-43c8-415e-baca-b31e2374631f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b259c6cd-43c8-415e-baca-b31e2374631f.jpg?1",
             "name": "Slinking Giant",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhenever Slinking Giant blocks or becomes blocked, it gets -3/-0 until end of turn.",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "885888ad-ea6e-54d9-b42c-386a856c2628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eda1524-44dd-4f70-ac21-bac51578860e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eda1524-44dd-4f70-ac21-bac51578860e.jpg?1",
             "name": "Smash to Smithereens",
             "text": "Destroy target artifact. Smash to Smithereens deals 3 damage to that artifact's controller.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "1a0aeccf-29a5-5c2d-a48e-8570e27c006c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320ade77-30be-4930-80ca-86028c010b1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/320ade77-30be-4930-80ca-86028c010b1b.jpg?1",
             "name": "Wild Swing",
             "text": "Choose three target nonenchantment permanents. Destroy one of them at random.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "b423e36a-78cf-5595-8bdc-fcac367f3380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c17b102-a25d-4fff-8718-3bdd53092552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c17b102-a25d-4fff-8718-3bdd53092552.jpg?1",
             "name": "Crabapple Cohort",
             "text": "Crabapple Cohort gets +1/+1 as long as you control another green creature.",
             "colours": [
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "4c3aac53-af3c-5f99-8082-3e0106ecc737",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820e2f07-f637-4144-b45a-0e1430dcf55e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820e2f07-f637-4144-b45a-0e1430dcf55e.jpg?1",
             "name": "Devoted Druid",
             "text": "{T}: Add {G} to your mana pool.\nPut a -1/-1 counter on Devoted Druid: Untap Devoted Druid.",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "f4f129ab-0610-5fc5-a50b-d0e49dfd6453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4562a300-8777-4a47-8650-8a2bc2678def.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4562a300-8777-4a47-8650-8a2bc2678def.jpg?1",
             "name": "Dramatic Entrance",
             "text": "You may put a green creature card from your hand into play.",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "620a451c-6ff3-59f0-a1c0-e552e5c3186f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b657ad23-e84b-4b53-a6b6-80f359624ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b657ad23-e84b-4b53-a6b6-80f359624ab8.jpg?1",
             "name": "Drove of Elves",
             "text": "Drove of Elves's power and toughness are each equal to the number of green permanents you control.\nDrove of Elves can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "357889f7-b134-5d46-9acc-7ea83af0911b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ff79-779f-4fb1-a842-56ba38e80fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d7ff79-779f-4fb1-a842-56ba38e80fdd.jpg?1",
             "name": "Farhaven Elf",
             "text": "When Farhaven Elf comes into play, you may search your library for a basic land card and put it into play tapped. If you do, shuffle your library.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "3ba7aff3-82f1-5758-a81c-a74493d2daf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223f5d6-83f1-454e-9cd5-aba157850430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6223f5d6-83f1-454e-9cd5-aba157850430.jpg?1",
             "name": "Flourishing Defenses",
             "text": "Whenever a -1/-1 counter is placed on a creature, you may put a 1/1 green Elf Warrior creature token into play.",
             "colours": [
@@ -3838,7 +3838,7 @@
         },
         {
             "id": "c1d4cb37-2a04-5b6f-9727-03777d4b1591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e23eae-7630-40db-b265-2fa00715878e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e23eae-7630-40db-b265-2fa00715878e.jpg?1",
             "name": "Foxfire Oak",
             "text": "{RG}{RG}{RG}: Foxfire Oak gets +3/+0 until end of turn.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "0dc2ad9a-a5a6-50ff-897c-91910e72b078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7d043-5f52-4df6-8dcf-5174a5b0c9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7d043-5f52-4df6-8dcf-5174a5b0c9cc.jpg?1",
             "name": "Gleeful Sabotage",
             "text": "Destroy target artifact or enchantment.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "a5e1336f-b67c-5c3b-85d7-f8beb93fed30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bda306-1e37-4359-a649-fcd8a5a7e2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bda306-1e37-4359-a649-fcd8a5a7e2fc.jpg?1",
             "name": "Gloomwidow",
             "text": "Reach\nGloomwidow can't block creatures without flying.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "7c968d41-9f54-55d7-815a-7dea88c2a8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b989b4-692c-4ccb-a290-0ff00abacba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b989b4-692c-4ccb-a290-0ff00abacba9.jpg?1",
             "name": "Gloomwidow's Feast",
             "text": "Destroy target creature with flying. If that creature was blue or black, put a 1/2 green Spider creature token with reach into play. (It can block creatures with flying.)",
             "colours": [
@@ -3972,7 +3972,7 @@
         },
         {
             "id": "6d89e293-7ed2-5f7e-8206-ddb182c6dcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293f7768-6279-4f26-979f-ea4e48095ae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293f7768-6279-4f26-979f-ea4e48095ae5.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "Put a 2/2 green Wolf creature token into play for each Forest you control.",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "4ca8a768-4ea1-5c33-900d-019c7fcd9da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be81b15-eb12-452b-8fdd-bde64807f422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be81b15-eb12-452b-8fdd-bde64807f422.jpg?1",
             "name": "Hungry Spriggan",
             "text": "Trample\nWhenever Hungry Spriggan attacks, it gets +3/+3 until end of turn.",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "184a57bb-c023-5246-ac65-16da7d27dacf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f323d5-f26c-46e9-9d6a-be5c254fe8b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f323d5-f26c-46e9-9d6a-be5c254fe8b6.jpg?1",
             "name": "Juvenile Gloomwidow",
             "text": "Reach (This can block creatures with flying.)\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "7b60ef04-e3c0-5509-9f6a-7e29e59d8e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcf02eb-2aaa-4c22-a3b3-f57019664118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fcf02eb-2aaa-4c22-a3b3-f57019664118.jpg?1",
             "name": "Mana Reflection",
             "text": "If you tap a permanent for mana, it produces twice as much of that mana instead.",
             "colours": [
@@ -4105,7 +4105,7 @@
         },
         {
             "id": "6aad08f7-af15-5216-a7c7-2d603bb31b88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537c39cc-44d3-4869-9e76-dd9c2c68ee90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537c39cc-44d3-4869-9e76-dd9c2c68ee90.jpg?1",
             "name": "Mossbridge Troll",
             "text": "If Mossbridge Troll would be destroyed, regenerate it.\nTap any number of untapped creatures you control other than Mossbridge Troll with total power 10 or greater: Mossbridge Troll gets +20/+20 until end of turn.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "69cc6caf-ddea-57b0-9553-94bd3036ce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2330c78d-1655-4074-a650-27740be4cee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2330c78d-1655-4074-a650-27740be4cee1.jpg?1",
             "name": "Nurturer Initiate",
             "text": "Whenever a player plays a green spell, you may pay {1}. If you do, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "e2405fae-10d1-5a1e-8764-98f2abc5fa0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546c647d-8d0a-4b88-804e-ce0348eb772a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/546c647d-8d0a-4b88-804e-ce0348eb772a.jpg?1",
             "name": "Presence of Gond",
             "text": "Enchant creature\nEnchanted creature has \"{T}: Put a 1/1 green Elf Warrior creature token into play.\"",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "3e8b888a-f5d3-5c45-a7c3-f78050e11ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75594cc-de47-49f2-9a8b-ba76c576368e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75594cc-de47-49f2-9a8b-ba76c576368e.jpg?1",
             "name": "Prismatic Omen",
             "text": "Lands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -4240,7 +4240,7 @@
         },
         {
             "id": "d4e1ea72-3f2b-5816-b43c-2c27ee034c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df529b30-9ac6-4944-9d21-ecf6d64a8845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df529b30-9ac6-4944-9d21-ecf6d64a8845.jpg?1",
             "name": "Raking Canopy",
             "text": "Whenever a creature with flying attacks you, Raking Canopy deals 4 damage to it.",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "960ad773-03cf-52a6-991f-a576e733a209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe77862-516f-4eb2-9a41-0c6401d02843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe77862-516f-4eb2-9a41-0c6401d02843.jpg?1",
             "name": "Roughshod Mentor",
             "text": "Green creatures you control have trample.",
             "colours": [
@@ -4307,7 +4307,7 @@
         },
         {
             "id": "f6d5d416-77c8-5f04-9e7f-0fe10bf1afef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8724b3-c956-476b-9885-95542eee5742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8724b3-c956-476b-9885-95542eee5742.jpg?1",
             "name": "Spawnwrithe",
             "text": "Trample\nWhenever Spawnwrithe deals combat damage to a player, put a token into play that's a copy of Spawnwrithe.",
             "colours": [
@@ -4341,7 +4341,7 @@
         },
         {
             "id": "c9fd9c7d-750b-5666-8813-0b928631c3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fd436-35eb-4207-9439-de652234dd50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54fd436-35eb-4207-9439-de652234dd50.jpg?1",
             "name": "Toil to Renown",
             "text": "You gain 1 life for each tapped artifact, creature, and land you control.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "b63b112c-045e-5986-b14c-521102733889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc1e47-3786-4ba9-b837-bf5b43323135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50cc1e47-3786-4ba9-b837-bf5b43323135.jpg?1",
             "name": "Tower Above",
             "text": "({2\nG} can be paid with any two mana or with {G}. This card's converted mana cost is 6.)\nUntil end of turn, target creature gets +4/+4 and gains trample, wither, and \"When this creature attacks, target creature blocks it this turn if able.\" (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "a8190a03-c67b-5048-b2fa-c278bf003981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c33871f-0e6a-4616-b484-e79b1945255f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c33871f-0e6a-4616-b484-e79b1945255f.jpg?1",
             "name": "Viridescent Wisps",
             "text": "Target creature becomes green and gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "f896817b-0eac-5388-b6cd-33687e6ccf65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323467c-132f-469a-90fc-9d3b0fb004aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3323467c-132f-469a-90fc-9d3b0fb004aa.jpg?1",
             "name": "Wildslayer Elves",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "98a23d96-5333-5cae-8330-acf6bde53e46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5187fc71-e4d3-4071-9ea1-d4513f30c529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5187fc71-e4d3-4071-9ea1-d4513f30c529.jpg?1",
             "name": "Witherscale Wurm",
             "text": "Whenever Witherscale Wurm blocks or becomes blocked by a creature, that creature gains wither until end of turn. (It deals damage to creatures in the form of -1/-1 counters.)\nWhenever Witherscale Wurm deals damage to an opponent, remove all -1/-1 counters from it.",
             "colours": [
@@ -4506,7 +4506,7 @@
         },
         {
             "id": "948b94de-cc26-5dec-a201-a922e1055eca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43aa7e35-55ee-4e02-a8aa-ea2b267055d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43aa7e35-55ee-4e02-a8aa-ea2b267055d1.jpg?1",
             "name": "Woodfall Primus",
             "text": "Trample\nWhen Woodfall Primus comes into play, destroy target noncreature permanent.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "ddd968b7-591b-5906-a724-3fc9976f3313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a656e7-9c1c-40b6-91fe-0098f72d8384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a656e7-9c1c-40b6-91fe-0098f72d8384.jpg?1",
             "name": "Aethertow",
             "text": "Put target attacking or blocking creature on top of its owner's library.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -4575,7 +4575,7 @@
         },
         {
             "id": "b63a6563-1707-503d-8485-6e9c7b66c6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba392e1-f310-4496-9d29-99a8783cc0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba392e1-f310-4496-9d29-99a8783cc0f3.jpg?1",
             "name": "Augury Adept",
             "text": "Whenever Augury Adept deals combat damage to a player, reveal the top card of your library and put that card into your hand. You gain life equal to its converted mana cost.",
             "colours": [
@@ -4612,7 +4612,7 @@
         },
         {
             "id": "627daf32-8fe4-543a-9675-fd1ecfcaf11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361dab9e-22f0-45e4-a793-aa6c97a96781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361dab9e-22f0-45e4-a793-aa6c97a96781.jpg?1",
             "name": "Barrenton Cragtreads",
             "text": "Barrenton Cragtreads can't be blocked by red creatures.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "0ea48ce2-c9f0-5d3b-b3ba-7962d2cd98c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db21bcb-60e8-4d15-8ea7-7298c2b1607c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5db21bcb-60e8-4d15-8ea7-7298c2b1607c.jpg?1",
             "name": "Curse of Chains",
             "text": "Enchant creature\nAt the beginning of each upkeep, tap enchanted creature.",
             "colours": [
@@ -4685,7 +4685,7 @@
         },
         {
             "id": "4daf2e40-5009-5cb0-a4f3-37db5a92d2c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033a7b0-39b0-4c49-b332-7ea62d85455d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5033a7b0-39b0-4c49-b332-7ea62d85455d.jpg?1",
             "name": "Enchanted Evening",
             "text": "All permanents are enchantments in addition to their other types.",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "f7efe90f-79da-5532-a670-ec397331b642",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc402e-8e84-4d47-9638-e94b12f3f667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc402e-8e84-4d47-9638-e94b12f3f667.jpg?1",
             "name": "Glamer Spinners",
             "text": "Flash\nFlying\nWhen Glamer Spinners comes into play, attach all Auras enchanting target permanent to another permanent with the same controller.",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "f38a1222-c8fb-5522-825e-b201d14a37a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e34d294-c0ec-4e3c-a731-31b7a29c59b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e34d294-c0ec-4e3c-a731-31b7a29c59b4.jpg?1",
             "name": "Godhead of Awe",
             "text": "Flying\nOther creatures are 1/1.",
             "colours": [
@@ -4793,7 +4793,7 @@
         },
         {
             "id": "5f211557-5ea7-5c33-ba5d-9a60ddf1a8a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea002c6-d15f-4536-9349-92c77ae5021a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea002c6-d15f-4536-9349-92c77ae5021a.jpg?1",
             "name": "Mirrorweave",
             "text": "Each other creature becomes a copy of target nonlegendary creature until end of turn.",
             "colours": [
@@ -4827,7 +4827,7 @@
         },
         {
             "id": "92e11249-c314-54d9-85e5-8789a34fd0a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e776fe0-6574-4fca-91bd-eb6e7383e5be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e776fe0-6574-4fca-91bd-eb6e7383e5be.jpg?1",
             "name": "Mistmeadow Witch",
             "text": "{2}{W}{U}: Remove target creature from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -4864,7 +4864,7 @@
         },
         {
             "id": "4998dc75-46de-515c-96cf-3baede060256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8b0449-3ae5-4fee-b870-af12be5e5a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e8b0449-3ae5-4fee-b870-af12be5e5a64.jpg?1",
             "name": "Plumeveil",
             "text": "Flash\nFlying, defender",
             "colours": [
@@ -4900,7 +4900,7 @@
         },
         {
             "id": "40676037-46d6-54c8-b9ee-c0ba31ade198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f25680-d1b3-4bf6-83e2-2eea0b5419ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77f25680-d1b3-4bf6-83e2-2eea0b5419ad.jpg?1",
             "name": "Puresight Merrow",
             "text": "{WU}, {Q}: Look at the top card of your library. You may remove that card from the game. ({Q} is the untap symbol.)",
             "colours": [
@@ -4937,7 +4937,7 @@
         },
         {
             "id": "d602f602-1e7a-5890-8296-5fec785972cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e64b09-1a58-4669-b7f2-baa3ccc85f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e64b09-1a58-4669-b7f2-baa3ccc85f2d.jpg?1",
             "name": "Repel Intruders",
             "text": "Put two 1/1 white Kithkin Soldier creature tokens into play if {W} was spent to play Repel Intruders. Counter up to one target creature spell if {U} was spent to play Repel Intruders. (Do both if {W}{U} was spent.)",
             "colours": [
@@ -4971,7 +4971,7 @@
         },
         {
             "id": "d4585183-1e13-5208-9f5e-6e166bb67f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d06328-a124-40e4-a9d8-2342a881970e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12d06328-a124-40e4-a9d8-2342a881970e.jpg?1",
             "name": "Silkbind Faerie",
             "text": "Flying\n{1}{WU}, {Q}: Tap target creature. ({Q} is the untap symbol.)",
             "colours": [
@@ -5008,7 +5008,7 @@
         },
         {
             "id": "7c33d1c4-6bae-5458-a093-a687a45d2c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf51122-fd7c-40b5-b759-65e21c28e3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaf51122-fd7c-40b5-b759-65e21c28e3d6.jpg?1",
             "name": "Somnomancer",
             "text": "When Somnomancer comes into play, you may tap target creature.",
             "colours": [
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "9a6caa66-6054-52a0-8843-0b8951fed53f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf8181-68c7-4f5a-b999-70f985b1f2ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4adf8181-68c7-4f5a-b999-70f985b1f2ac.jpg?1",
             "name": "Steel of the Godhead",
             "text": "Enchant creature\nAs long as enchanted creature is white, it gets +1/+1 and has lifelink. (Whenever it deals damage, its controller gains that much life.)\nAs long as enchanted creature is blue, it gets +1/+1 and is unblockable.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "6c4ba486-edbe-5dbe-a4e2-bfcd16d51ec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdf78b7-3c32-422a-a73f-d198e6f06290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cdf78b7-3c32-422a-a73f-d198e6f06290.jpg?1",
             "name": "Swans of Bryn Argoll",
             "text": "Flying\nIf a source would deal damage to Swans of Bryn Argoll, prevent that damage. The source's controller draws cards equal to the damage prevented this way.",
             "colours": [
@@ -5118,7 +5118,7 @@
         },
         {
             "id": "ce0d7bf5-ed25-5faa-901d-f203771ecd57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57ba0ce-0390-42fd-9473-2436fac53631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57ba0ce-0390-42fd-9473-2436fac53631.jpg?1",
             "name": "Thistledown Duo",
             "text": "Whenever you play a white spell, Thistledown Duo gets +1/+1 until end of turn.\nWhenever you play a blue spell, Thistledown Duo gains flying until end of turn.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "b59c311b-6932-52a2-a84f-bf76120f669f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e34233-0972-4aa7-a5ab-eabed2235148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20e34233-0972-4aa7-a5ab-eabed2235148.jpg?1",
             "name": "Thistledown Liege",
             "text": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
             "colours": [
@@ -5193,7 +5193,7 @@
         },
         {
             "id": "0f3cda9b-4cf3-51a6-98bb-98e0ffe89407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7990b23-d460-46e2-bb05-396e2a653429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7990b23-d460-46e2-bb05-396e2a653429.jpg?1",
             "name": "Thoughtweft Gambit",
             "text": "Tap all creatures your opponents control and untap all creatures you control.",
             "colours": [
@@ -5227,7 +5227,7 @@
         },
         {
             "id": "f3f08dcd-89ac-5b53-be4a-21aa1e3551f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a62b31-986c-4722-97da-d984272f0f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a62b31-986c-4722-97da-d984272f0f05.jpg?1",
             "name": "Turn to Mist",
             "text": "Remove target creature from the game. Return that card to play under its owner's control at end of turn.",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "ae1d2346-eb44-5bd6-ad1e-f3d48802b07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f70fdb-264f-4545-97fa-3702168a66d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f70fdb-264f-4545-97fa-3702168a66d4.jpg?1",
             "name": "Worldpurge",
             "text": "Return all permanents to their owners' hands. Each player chooses up to seven cards in his or her hand, then shuffles the rest into his or her library. Empty all mana pools.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "0edb9ef4-2009-57d2-9230-336d923cfca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951214b-43a9-4c51-bbb4-05bac81b9866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951214b-43a9-4c51-bbb4-05bac81b9866.jpg?1",
             "name": "Zealous Guardian",
             "text": "Flash",
             "colours": [
@@ -5332,7 +5332,7 @@
         },
         {
             "id": "1e400076-578c-545e-810d-1a342552c429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec3b06b-d8c5-459c-aae5-3e51059cfdf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec3b06b-d8c5-459c-aae5-3e51059cfdf1.jpg?1",
             "name": "Cemetery Puca",
             "text": "Whenever a creature is put into a graveyard from play, you may pay {1}. If you do, Cemetery Puca becomes a copy of that creature and gains this ability.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "4ba5aba7-ac73-591f-aa01-842bb52292f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6fb3b2-eef2-4699-ab5e-ff7d8de2a1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6fb3b2-eef2-4699-ab5e-ff7d8de2a1de.jpg?1",
             "name": "Dire Undercurrents",
             "text": "Whenever a blue creature comes into play under your control, you may have target player draw a card.\nWhenever a black creature comes into play under your control, you may have target player discard a card.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "e603fd00-6605-546c-b849-59b77698e55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac999cc-c5c0-4309-a255-3eb7399af340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac999cc-c5c0-4309-a255-3eb7399af340.jpg?1",
             "name": "Dream Salvage",
             "text": "Draw cards equal to the number of cards target opponent discarded this turn.",
             "colours": [
@@ -5436,7 +5436,7 @@
         },
         {
             "id": "4801ef0b-0311-57b4-a691-094c34cab124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e052cde-985a-401f-828a-2d98511bbcd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e052cde-985a-401f-828a-2d98511bbcd5.jpg?1",
             "name": "Fate Transfer",
             "text": "Move all counters from target creature onto another target creature.",
             "colours": [
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "e89eb08b-08cc-5d2c-9758-54f839bf17d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b118200-55e0-4d06-9e7e-ecde2814d24e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b118200-55e0-4d06-9e7e-ecde2814d24e.jpg?1",
             "name": "Ghastlord of Fugue",
             "text": "Ghastlord of Fugue is unblockable.\nWhenever Ghastlord of Fugue deals combat damage to a player, that player reveals his or her hand. Choose a card from it. That player removes that card from the game.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "45d5384f-2820-5d0d-8a22-0d42fe996ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cc72b7-b593-438f-a07a-35f2452e1c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94cc72b7-b593-438f-a07a-35f2452e1c48.jpg?1",
             "name": "Glen Elendra Liege",
             "text": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
             "colours": [
@@ -5544,7 +5544,7 @@
         },
         {
             "id": "9d517048-6d92-51b7-b2ed-a45649d06303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efc174a-f710-4602-aace-c2165473f6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efc174a-f710-4602-aace-c2165473f6c2.jpg?1",
             "name": "Gravelgill Axeshark",
             "text": "Persist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "0470473c-7572-5d90-93b6-13b63ba924c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fd4959-bfff-46dc-b568-b6d69ef8eac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2fd4959-bfff-46dc-b568-b6d69ef8eac9.jpg?1",
             "name": "Gravelgill Duo",
             "text": "Whenever you play a blue spell, Gravelgill Duo gets +1/+1 until end of turn.\nWhenever you play a black spell, Gravelgill Duo gains fear until end of turn.",
             "colours": [
@@ -5619,7 +5619,7 @@
         },
         {
             "id": "116ace74-9a3e-51a3-9503-5d4a33620d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653dd5b7-1ad3-4df1-bd2a-4e6ae362a8a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653dd5b7-1ad3-4df1-bd2a-4e6ae362a8a2.jpg?1",
             "name": "Helm of the Ghastlord",
             "text": "Enchant creature\nAs long as enchanted creature is blue, it gets +1/+1 and has \"Whenever this creature deals damage to an opponent, draw a card.\"\nAs long as enchanted creature is black, it gets +1/+1 and has \"Whenever this creature deals damage to an opponent, that player discards a card.\"",
             "colours": [
@@ -5655,7 +5655,7 @@
         },
         {
             "id": "7b3780e9-75ea-5e4e-a6d1-ca0ee0c5497b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28854f0f-48d3-4a54-8811-c6329ad2e88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28854f0f-48d3-4a54-8811-c6329ad2e88e.jpg?1",
             "name": "Inkfathom Infiltrator",
             "text": "Inkfathom Infiltrator can't block and is unblockable.",
             "colours": [
@@ -5692,7 +5692,7 @@
         },
         {
             "id": "2adac44d-8956-5f99-a7fc-425a67ed5f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a48062c-faac-4183-830f-919ab255b907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a48062c-faac-4183-830f-919ab255b907.jpg?1",
             "name": "Inkfathom Witch",
             "text": "Fear\n{2}{U}{B}: Each unblocked creature becomes 4/1 until end of turn.",
             "colours": [
@@ -5729,7 +5729,7 @@
         },
         {
             "id": "b0988821-6294-5cdb-8724-5176913ceb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6808a-1816-4ac7-bbb2-c7a5a47428d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca6808a-1816-4ac7-bbb2-c7a5a47428d6.jpg?1",
             "name": "Memory Plunder",
             "text": "You may play target instant or sorcery card in an opponent's graveyard without paying its mana cost.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "156ffa61-48ea-5d11-ac97-9e352dae47a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd93980-55f6-43a0-87db-5fa1203aa7b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd93980-55f6-43a0-87db-5fa1203aa7b6.jpg?1",
             "name": "Memory Sluice",
             "text": "Target player puts the top four cards of his or her library into his or her graveyard.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "68205de9-ca1c-5709-a25d-be8baaaef24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b839c9d0-ef08-4661-8009-3bcb256bf508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b839c9d0-ef08-4661-8009-3bcb256bf508.jpg?1",
             "name": "Merrow Grimeblotter",
             "text": "{1}{UB}, {Q}: Target creature gets -2/-0 until end of turn. ({Q} is the untap symbol.)",
             "colours": [
@@ -5834,7 +5834,7 @@
         },
         {
             "id": "e710a967-6778-5f5f-a922-1d2d35135e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ae75f6-fb74-422c-93f6-a0be7f919e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ae75f6-fb74-422c-93f6-a0be7f919e47.jpg?1",
             "name": "Oona, Queen of the Fae",
             "text": "Flying\n{X}{UB}: Choose a color. Target opponent removes the top X cards of his or her library from the game. For each card of the chosen color removed this way, put a 1/1 blue and black Faerie Rogue creature token with flying into play.",
             "colours": [
@@ -5873,7 +5873,7 @@
         },
         {
             "id": "617521c1-23ac-5173-8f72-b3194ba226a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972bb6e4-300c-49f5-8305-459a3ba67baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/972bb6e4-300c-49f5-8305-459a3ba67baa.jpg?1",
             "name": "Oona's Gatewarden",
             "text": "Flying, defender\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -5910,7 +5910,7 @@
         },
         {
             "id": "bf7b99df-bd27-52e5-b078-8f67ad3104fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1209bb9d-8aeb-4d7c-85bb-d9e9a24e36ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1209bb9d-8aeb-4d7c-85bb-d9e9a24e36ac.jpg?1",
             "name": "River's Grasp",
             "text": "If {U} was spent to play River's Grasp, return up to one target creature to its owner's hand. If {B} was spent to play River's Grasp, target player reveals his or her hand, you choose a nonland card from it, then that player discards that card. (Do both if {U}{B} was spent.)",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "94a3d029-489e-537d-b6bd-fe23f2b2bdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d3f64a-ffb9-4f66-91c0-463b5d2d381b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d3f64a-ffb9-4f66-91c0-463b5d2d381b.jpg?1",
             "name": "Scarscale Ritual",
             "text": "As an additional cost to play Scarscale Ritual, put a -1/-1 counter on a creature you control.\nDraw two cards.",
             "colours": [
@@ -5978,7 +5978,7 @@
         },
         {
             "id": "8a45b4b4-890d-5f47-b357-244b5bb66766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3926f037-aaec-416e-a486-b59aae6faf44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3926f037-aaec-416e-a486-b59aae6faf44.jpg?1",
             "name": "Sygg, River Cutthroat",
             "text": "At end of turn, if an opponent lost 3 or more life this turn, you may draw a card. (Damage causes loss of life.)",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "0edef408-ece3-59d8-b1a7-860ddb490c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8840551f-d43a-487f-a960-9b220dec5df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8840551f-d43a-487f-a960-9b220dec5df4.jpg?1",
             "name": "Torpor Dust",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -3/-0.",
             "colours": [
@@ -6053,7 +6053,7 @@
         },
         {
             "id": "de0eaa9c-2c4e-5c8f-a49e-b40256f5a865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab739d64-cdcd-4f07-9854-e067c37c4f41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab739d64-cdcd-4f07-9854-e067c37c4f41.jpg?1",
             "name": "Wanderbrine Rootcutters",
             "text": "Wanderbrine Rootcutters can't be blocked by green creatures.",
             "colours": [
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "514cea50-1266-58b3-bf28-74fc13ee7256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac48a4ff-433b-4fd0-b0d1-43b188ee81b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac48a4ff-433b-4fd0-b0d1-43b188ee81b6.jpg?1",
             "name": "Wasp Lancer",
             "text": "Flying",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "2cc05e9e-5389-556d-9547-4a7f275776e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c7931f-e979-4f43-81dd-c34166526f87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c7931f-e979-4f43-81dd-c34166526f87.jpg?1",
             "name": "Ashenmoor Gouger",
             "text": "Ashenmoor Gouger can't block.",
             "colours": [
@@ -6164,7 +6164,7 @@
         },
         {
             "id": "5b02eae9-1251-5ff0-8f52-1cfb654dddb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40793a-f5d1-4a1b-a7ab-0cb7513a00ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40793a-f5d1-4a1b-a7ab-0cb7513a00ca.jpg?1",
             "name": "Ashenmoor Liege",
             "text": "Other black creatures you control get +1/+1.\nOther red creatures you control get +1/+1.\nWhenever Ashenmoor Liege becomes the target of a spell or ability an opponent controls, that player loses 4 life.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "5f2963fe-ee99-5ee1-9e94-055ac1b9e7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b80a10-a9a9-445e-8040-6cc0155271d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b80a10-a9a9-445e-8040-6cc0155271d8.jpg?1",
             "name": "Cultbrand Cinder",
             "text": "When Cultbrand Cinder comes into play, put a -1/-1 counter on target creature.",
             "colours": [
@@ -6238,7 +6238,7 @@
         },
         {
             "id": "e3730089-436c-5905-819a-a1a4e539e0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe235a9-9ecb-49a9-b91c-18e9725550cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe235a9-9ecb-49a9-b91c-18e9725550cd.jpg?1",
             "name": "Demigod of Revenge",
             "text": "Flying, haste\nWhen you play Demigod of Revenge, return all cards named Demigod of Revenge from your graveyard to play.",
             "colours": [
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "c30c2a5b-7b87-50ea-a088-4f5c86274245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde655f-9f49-42f8-a168-9cbca0592bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bde655f-9f49-42f8-a168-9cbca0592bb8.jpg?1",
             "name": "Din of the Fireherd",
             "text": "Put a 5/5 black and red Elemental creature token into play. Target opponent sacrifices a creature for each black creature you control, then sacrifices a land for each red creature you control.",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "17907887-6bb7-5ac5-8c8a-9947b40d6209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccd4374-5339-4529-99f3-f7dcc939e874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccd4374-5339-4529-99f3-f7dcc939e874.jpg?1",
             "name": "Emberstrike Duo",
             "text": "Whenever you play a black spell, Emberstrike Duo gets +1/+1 until end of turn.\nWhenever you play a red spell, Emberstrike Duo gains first strike until end of turn.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "b1c558ca-f2f1-5695-b5e3-90880ebfe1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa67c32-aeca-473d-994f-58ffc3a6a310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa67c32-aeca-473d-994f-58ffc3a6a310.jpg?1",
             "name": "Everlasting Torment",
             "text": "Players can't gain life.\nDamage can't be prevented.\nAll damage is dealt as though its source had wither. (A source with wither deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -6381,7 +6381,7 @@
         },
         {
             "id": "9c6a4698-4979-5e96-ac8d-4b5153a79a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b28e501-fbb1-443b-a296-420716e49ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b28e501-fbb1-443b-a296-420716e49ab0.jpg?1",
             "name": "Fists of the Demigod",
             "text": "Enchant creature\nAs long as enchanted creature is black, it gets +1/+1 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)\nAs long as enchanted creature is red, it gets +1/+1 and has first strike.",
             "colours": [
@@ -6417,7 +6417,7 @@
         },
         {
             "id": "15af6279-34dc-55b2-b86d-437e1aad172e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1df367-8e85-4fd8-aa6f-f02a478fecb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1df367-8e85-4fd8-aa6f-f02a478fecb3.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -6454,7 +6454,7 @@
         },
         {
             "id": "6302ad0e-f44d-5cba-8f9e-6f1b96d04802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971a3b39-5b4b-41a4-9f67-1f24c48ba621.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971a3b39-5b4b-41a4-9f67-1f24c48ba621.jpg?1",
             "name": "Grief Tyrant",
             "text": "Grief Tyrant comes into play with four -1/-1 counters on it.\nWhen Grief Tyrant is put into a graveyard from play, put a -1/-1 counter on target creature for each -1/-1 counter on Grief Tyrant.",
             "colours": [
@@ -6490,7 +6490,7 @@
         },
         {
             "id": "43c02d92-50cb-56c0-ab6b-529666c61b87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b0bb-37d6-48a3-b140-c826de74c3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2408b0bb-37d6-48a3-b140-c826de74c3a0.jpg?1",
             "name": "Kulrath Knight",
             "text": "Flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)\nCreatures your opponents control with counters on them can't attack or block.",
             "colours": [
@@ -6527,7 +6527,7 @@
         },
         {
             "id": "079b5dae-54b8-54d1-8460-fc465ceb81f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4eb6-06bb-4bc9-83da-0141f7ee4730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4eb6-06bb-4bc9-83da-0141f7ee4730.jpg?1",
             "name": "Manaforge Cinder",
             "text": "{1}: Add {B} or {R} to your mana pool. Play this ability no more than three times each turn.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "bc2782e4-5f24-5e4f-b978-6e45bf4f20c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7171f0-7d42-47c9-ab46-93c2bb42c914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7171f0-7d42-47c9-ab46-93c2bb42c914.jpg?1",
             "name": "Murderous Redcap",
             "text": "When Murderous Redcap comes into play, it deals damage equal to its power to target creature or player.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "a1c909bb-99d3-59da-b0b9-9c58983b69d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb86eeec-d50f-4823-86bd-35437926a6e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb86eeec-d50f-4823-86bd-35437926a6e4.jpg?1",
             "name": "Poison the Well",
             "text": "Destroy target land. Poison the Well deals 2 damage to that land's controller.",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "402e7827-5794-5d85-8b80-bd177505533c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34e3f7c-468a-456c-8ed0-0cb88f6d86fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34e3f7c-468a-456c-8ed0-0cb88f6d86fc.jpg?1",
             "name": "Scar",
             "text": "Put a -1/-1 counter on target creature.",
             "colours": [
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "7127ac03-fef4-5db3-98fb-79134ce51355",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2260b4-c069-4f59-9bd9-35745c98c518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2260b4-c069-4f59-9bd9-35745c98c518.jpg?1",
             "name": "Sootstoke Kindler",
             "text": "Haste\n{T}: Target black or red creature gains haste until end of turn.",
             "colours": [
@@ -6706,7 +6706,7 @@
         },
         {
             "id": "ea247551-5a27-5b54-8616-c73e92734392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36c7932-cc1e-4b1f-ae39-2f04b84bcddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36c7932-cc1e-4b1f-ae39-2f04b84bcddb.jpg?1",
             "name": "Sootwalkers",
             "text": "Sootwalkers can't be blocked by white creatures.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "6bd4dcbd-ca5e-5b6a-8601-20faac284b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d1a332-f950-4f56-9b1e-37c0954e72f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d1a332-f950-4f56-9b1e-37c0954e72f6.jpg?1",
             "name": "Spiteflame Witch",
             "text": "{B}{R}: Each player loses 1 life.",
             "colours": [
@@ -6780,7 +6780,7 @@
         },
         {
             "id": "29215741-aab3-5057-bb8f-ae45c8e4d1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19039ac4-1aaa-4aca-ba09-f7fc400b9ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19039ac4-1aaa-4aca-ba09-f7fc400b9ada.jpg?1",
             "name": "Spiteful Visions",
             "text": "At the beginning of each player's draw step, that player draws a card.\nWhenever a player draws a card, Spiteful Visions deals 1 damage to that player.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "9b15050b-9fab-5fd4-8c59-0357940d2a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1e3eff-d6b2-4758-ac50-91f79cd21b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1e3eff-d6b2-4758-ac50-91f79cd21b93.jpg?1",
             "name": "Torrent of Souls",
             "text": "Return up to one target creature card from your graveyard to play if {B} was spent to play Torrent of Souls. Creatures target player controls get +2/+0 and gain haste until end of turn if {R} was spent to play Torrent of Souls. (Do both if {B}{R} was spent.)",
             "colours": [
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "450500e2-0917-530b-b8b4-0ef9d46dadaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e2700-6425-45b8-b026-8c78098f08b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/751e2700-6425-45b8-b026-8c78098f08b2.jpg?1",
             "name": "Traitor's Roar",
             "text": "Tap target untapped creature. It deals damage equal to its power to its controller.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -6882,7 +6882,7 @@
         },
         {
             "id": "e5fbc917-c922-5f73-a9e5-ca266b341e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7428b-8fff-4839-8b59-b268af0699c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69b7428b-8fff-4839-8b59-b268af0699c2.jpg?1",
             "name": "Tyrannize",
             "text": "Target player discards his or her hand unless he or she pays 7 life.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "1fd14a88-0346-5a50-a6a8-04929f1fe551",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318338f8-f52b-4b9a-8d38-08291bcc2e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318338f8-f52b-4b9a-8d38-08291bcc2e98.jpg?1",
             "name": "Boartusk Liege",
             "text": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
             "colours": [
@@ -6953,7 +6953,7 @@
         },
         {
             "id": "1db97a52-161e-5922-bd27-2310ab3f4cee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25b70-fa21-4663-aabd-34b7e0b75c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25b70-fa21-4663-aabd-34b7e0b75c34.jpg?1",
             "name": "Boggart Ram-Gang",
             "text": "Haste\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "f75d5eea-b50a-5584-9bff-51b8d218d87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eaac2e-51ff-45cb-a554-fdb724ddbb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eaac2e-51ff-45cb-a554-fdb724ddbb91.jpg?1",
             "name": "Deus of Calamity",
             "text": "Trample\nWhenever Deus of Calamity deals 6 or more damage to an opponent, destroy target land that player controls.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "4c928541-bf3d-5027-8542-cf3a31ce94f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13454f69-1458-4c03-ab02-bd697a32eb17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13454f69-1458-4c03-ab02-bd697a32eb17.jpg?1",
             "name": "Firespout",
             "text": "Firespout deals 3 damage to each creature without flying if {R} was spent to play Firespout and 3 damage to each creature with flying if {G} was spent to play it. (Do both if {R}{G} was spent.)",
             "colours": [
@@ -7061,7 +7061,7 @@
         },
         {
             "id": "4cfc697b-7ba9-57f9-ba04-7f6cb09ae691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff61d34-f38f-440b-a234-7bb7251eb5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff61d34-f38f-440b-a234-7bb7251eb5b8.jpg?1",
             "name": "Fossil Find",
             "text": "Return a card at random from your graveyard to your hand, then reorder your graveyard as you choose.",
             "colours": [
@@ -7095,7 +7095,7 @@
         },
         {
             "id": "5d8b526d-bbca-5d69-a30c-9a6d88ec1dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3dd33-7240-4b32-b5ee-a67f24b42e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3dd33-7240-4b32-b5ee-a67f24b42e4d.jpg?1",
             "name": "Giantbaiting",
             "text": "Put a 4/4 red and green Giant Warrior creature token with haste into play. Remove it from the game at end of turn.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "21c7d749-00e0-5621-9214-b592af287ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0662ab6-b475-4b8d-ae77-a9b654e611da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0662ab6-b475-4b8d-ae77-a9b654e611da.jpg?1",
             "name": "Guttural Response",
             "text": "Counter target blue instant spell.",
             "colours": [
@@ -7163,7 +7163,7 @@
         },
         {
             "id": "9eddab7e-4b7c-53e2-9adb-8fa5fdeca19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2171e1c-fd36-43a6-ade3-c3aba8915139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2171e1c-fd36-43a6-ade3-c3aba8915139.jpg?1",
             "name": "Impromptu Raid",
             "text": "{2}{RG}: Reveal the top card of your library. If it isn't a creature card, put it into your graveyard. Otherwise, put that card into play. That creature has haste. Sacrifice it at end of turn.",
             "colours": [
@@ -7197,7 +7197,7 @@
         },
         {
             "id": "cf6b6b6b-fc13-5101-b022-340c5c9640ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a27bbe4-5341-4b2b-9ae8-eb56585a9c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a27bbe4-5341-4b2b-9ae8-eb56585a9c3a.jpg?1",
             "name": "Loamdragger Giant",
             "text": "",
             "colours": [
@@ -7234,7 +7234,7 @@
         },
         {
             "id": "a7e8ecbf-f5bd-5129-8209-1f925664eefe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50283122-b8c4-4fb3-8eba-6252b72222f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50283122-b8c4-4fb3-8eba-6252b72222f4.jpg?1",
             "name": "Manamorphose",
             "text": "Add two mana in any combination of colors to your mana pool.\nDraw a card.",
             "colours": [
@@ -7268,7 +7268,7 @@
         },
         {
             "id": "cca855b3-5084-55bb-9968-1a42c35e33a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589f477e-fd69-4410-b9ba-1d45b25fec31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589f477e-fd69-4410-b9ba-1d45b25fec31.jpg?1",
             "name": "Morselhoarder",
             "text": "Morselhoarder comes into play with two -1/-1 counters on it.\nRemove a -1/-1 counter from Morselhoarder: Add one mana of any color to your mana pool.",
             "colours": [
@@ -7304,7 +7304,7 @@
         },
         {
             "id": "98d2f37b-9daf-5b6a-97cc-c3ee048d6f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe4af47-d913-4c19-a027-501e2c78758c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbe4af47-d913-4c19-a027-501e2c78758c.jpg?1",
             "name": "Mudbrawler Raiders",
             "text": "Mudbrawler Raiders can't be blocked by blue creatures.",
             "colours": [
@@ -7341,7 +7341,7 @@
         },
         {
             "id": "1de02933-1507-550a-9055-96e50d714dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3424135d-70f3-4a67-8477-cbf7ced7e611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3424135d-70f3-4a67-8477-cbf7ced7e611.jpg?1",
             "name": "Rosheen Meanderer",
             "text": "{T}: Add {4} to your mana pool. Spend this mana only on costs that contain {X}.",
             "colours": [
@@ -7380,7 +7380,7 @@
         },
         {
             "id": "a745a03c-5645-5b8c-81f5-e2c76cf27b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a84c7-c27f-49a2-8ae8-cb8e34ce0766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5a84c7-c27f-49a2-8ae8-cb8e34ce0766.jpg?1",
             "name": "Runes of the Deus",
             "text": "Enchant creature\nAs long as enchanted creature is red, it gets +1/+1 and has double strike. (It deals both first-strike and regular combat damage.)\nAs long as enchanted creature is green, it gets +1/+1 and has trample.",
             "colours": [
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "f4234411-6d9c-5825-984d-7725f7cfb5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738d2b7-2773-4146-8f95-8d95b8402266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6738d2b7-2773-4146-8f95-8d95b8402266.jpg?1",
             "name": "Scuzzback Marauders",
             "text": "Trample\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7453,7 +7453,7 @@
         },
         {
             "id": "4efd28b7-c005-5000-95e4-27082b1f3b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ed66f-75bd-43d8-90c4-cb0a5827b2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ed66f-75bd-43d8-90c4-cb0a5827b2f0.jpg?1",
             "name": "Scuzzback Scrapper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [
@@ -7490,7 +7490,7 @@
         },
         {
             "id": "54cac059-68b7-586e-a992-2a8e6ee3d81e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac93faba-8b40-48f4-b4eb-7c8677ed07e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac93faba-8b40-48f4-b4eb-7c8677ed07e2.jpg?1",
             "name": "Tattermunge Duo",
             "text": "Whenever you play a red spell, Tattermunge Duo gets +1/+1 until end of turn.\nWhenever you play a green spell, Tattermunge Duo gains forestwalk until end of turn.",
             "colours": [
@@ -7528,7 +7528,7 @@
         },
         {
             "id": "0d8f70b7-8145-5a01-ae94-831e10c2171f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f80d05-0bc9-4f35-afc4-8e2ae81b94df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f80d05-0bc9-4f35-afc4-8e2ae81b94df.jpg?1",
             "name": "Tattermunge Maniac",
             "text": "Tattermunge Maniac attacks each turn if able.",
             "colours": [
@@ -7565,7 +7565,7 @@
         },
         {
             "id": "4321dd8c-8a66-5094-bd4c-f3fe16b22942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee564d-d663-4ed7-afbd-713e90ba5c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ee564d-d663-4ed7-afbd-713e90ba5c50.jpg?1",
             "name": "Tattermunge Witch",
             "text": "{R}{G}: Each blocked creature gets +1/+0 and gains trample until end of turn.",
             "colours": [
@@ -7602,7 +7602,7 @@
         },
         {
             "id": "b3ba48c5-d5fc-54a4-a761-203467a55335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4fa59-8315-4a66-b5fb-f78daa92aca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b4fa59-8315-4a66-b5fb-f78daa92aca7.jpg?1",
             "name": "Valleymaker",
             "text": "{T}, Sacrifice a Mountain: Valleymaker deals 3 damage to target creature.\n{T}, Sacrifice a Forest: Choose a player. That player adds {G}{G}{G} to his or her mana pool.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "4e120d12-b1ee-5ce9-8a0c-62b60f2ee5a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae04d776-c9e3-4ff7-998d-d264754d61db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae04d776-c9e3-4ff7-998d-d264754d61db.jpg?1",
             "name": "Vexing Shusher",
             "text": "Vexing Shusher can't be countered.\n{RG}: Target spell can't be countered by spells or abilities.",
             "colours": [
@@ -7676,7 +7676,7 @@
         },
         {
             "id": "c6306a2a-5399-535a-bdfe-679f84013388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535189ec-572f-44ed-9741-09b9f575fc40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535189ec-572f-44ed-9741-09b9f575fc40.jpg?1",
             "name": "Wort, the Raidmother",
             "text": "When Wort, the Raidmother comes into play, put two 1/1 red and green Goblin Warrior creature tokens into play.\nEach red or green instant or sorcery spell you play has conspire. (As you play the spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose new targets for the copy.)",
             "colours": [
@@ -7715,7 +7715,7 @@
         },
         {
             "id": "611a60f9-1fef-58bd-9872-8a9ae5cdc856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd273ef2-4aed-4c7e-8c97-fe8b1af9ce69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd273ef2-4aed-4c7e-8c97-fe8b1af9ce69.jpg?1",
             "name": "Barkshell Blessing",
             "text": "Target creature gets +2/+2 until end of turn.\nConspire (As you play this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "c5b723b0-e7a3-52b1-808c-fb56d3730d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038bec82-24a0-4764-a1a0-671f597ebc35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038bec82-24a0-4764-a1a0-671f597ebc35.jpg?1",
             "name": "Dawnglow Infusion",
             "text": "You gain X life if {G} was spent to play Dawnglow Infusion and X life if {W} was spent to play it. (Do both if {G}{W} was spent.)",
             "colours": [
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "f46b6045-16c7-52f6-b3bc-09e9dd970ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7f4d7-278b-45fc-98aa-b7c8b9162bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b7f4d7-278b-45fc-98aa-b7c8b9162bcd.jpg?1",
             "name": "Elvish Hexhunter",
             "text": "{RW}, {T}, Sacrifice Elvish Hexhunter: Destroy target enchantment.",
             "colours": [
@@ -7820,7 +7820,7 @@
         },
         {
             "id": "f2b271b6-c293-5b3a-bfb5-2b38e8343421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd726ce-85f8-4570-96e8-e0cfbd05045a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd726ce-85f8-4570-96e8-e0cfbd05045a.jpg?1",
             "name": "Fracturing Gust",
             "text": "Destroy all artifacts and enchantments. You gain 2 life for each permanent destroyed this way.",
             "colours": [
@@ -7854,7 +7854,7 @@
         },
         {
             "id": "732367fc-243e-50aa-bbfe-6d0fa2359738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c1070-cb58-4948-99c9-febef7fef0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b8c1070-cb58-4948-99c9-febef7fef0d5.jpg?1",
             "name": "Heartmender",
             "text": "At the beginning of your upkeep, remove a -1/-1 counter from each creature you control.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "c8d0adf1-df31-52bd-81d4-4c4d0213d0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d203208-8a21-4c68-afa2-4efd8726f026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d203208-8a21-4c68-afa2-4efd8726f026.jpg?1",
             "name": "Kitchen Finks",
             "text": "When Kitchen Finks comes into play, you gain 2 life.\nPersist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "dc74ca8c-e4d8-5288-8871-09355e110895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97638795-0771-4862-9afc-dbbbfd39515c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97638795-0771-4862-9afc-dbbbfd39515c.jpg?1",
             "name": "Medicine Runner",
             "text": "When Medicine Runner comes into play, you may remove a counter from target permanent.",
             "colours": [
@@ -7963,7 +7963,7 @@
         },
         {
             "id": "0f898385-0be0-522a-9e39-a03ba3aad2dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f55536d-8573-42c2-9e8a-5a2ce24d1878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f55536d-8573-42c2-9e8a-5a2ce24d1878.jpg?1",
             "name": "Mercy Killing",
             "text": "Target creature's controller sacrifices it, then puts X 1/1 green and white Elf Warrior creature tokens into play, where X is that creature's power.",
             "colours": [
@@ -7997,7 +7997,7 @@
         },
         {
             "id": "403865ab-0ddc-5cf4-b6c8-417182e8dd39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5ab941-89cc-4fdd-a916-3a54651f6478.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5ab941-89cc-4fdd-a916-3a54651f6478.jpg?1",
             "name": "Old Ghastbark",
             "text": "",
             "colours": [
@@ -8034,7 +8034,7 @@
         },
         {
             "id": "c71ef292-1922-5730-b083-a9ead79406a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6bb004-b8ef-45a0-b9bf-5a3d513689b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f6bb004-b8ef-45a0-b9bf-5a3d513689b9.jpg?1",
             "name": "Oracle of Nectars",
             "text": "{X}, {T}: You gain X life.",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "e0894416-4d93-5b3b-a605-c8584db52f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893842f-aa3f-45f6-8139-ca775d33792b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8893842f-aa3f-45f6-8139-ca775d33792b.jpg?1",
             "name": "Oversoul of Dusk",
             "text": "Protection from blue, from black, and from red",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "c74a61a4-210c-519a-a481-2687894682bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b868da85-9d19-4407-a0c3-fc3b2b237cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b868da85-9d19-4407-a0c3-fc3b2b237cda.jpg?1",
             "name": "Raven's Run Dragoon",
             "text": "Raven's Run Dragoon can't be blocked by black creatures.",
             "colours": [
@@ -8145,7 +8145,7 @@
         },
         {
             "id": "c458f3b3-c545-55ca-8dc1-6e5b2cfc13c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bde9be-0ad8-4f42-a9a9-838bc476c7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bde9be-0ad8-4f42-a9a9-838bc476c7a6.jpg?1",
             "name": "Reknit",
             "text": "Regenerate target permanent.",
             "colours": [
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "f9430958-c1da-5189-ba18-cd011bf0fae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59327a58-cd41-479c-81c7-31c9d3b29508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59327a58-cd41-479c-81c7-31c9d3b29508.jpg?1",
             "name": "Rhys the Redeemed",
             "text": "{2}{RW}, {T}: Put a 1/1 green and white Elf Warrior creature token into play.\n{4}{RW}{RW}, {T}: For each creature token you control, put a token into play that's a copy of that creature.",
             "colours": [
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "2db6e502-4e9a-5cc7-bf40-7f3eae8675d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b70339-9918-4f7e-9cd0-d4ce36b65997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b70339-9918-4f7e-9cd0-d4ce36b65997.jpg?1",
             "name": "Safehold Duo",
             "text": "Whenever you play a green spell, Safehold Duo gets +1/+1 until end of turn.\nWhenever you play a white spell, Safehold Duo gains vigilance until end of turn.",
             "colours": [
@@ -8256,7 +8256,7 @@
         },
         {
             "id": "64b3993c-b507-5a58-ba57-fdd31c6d4d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dee5be-94fd-4b5d-9265-edd1b58c8026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14dee5be-94fd-4b5d-9265-edd1b58c8026.jpg?1",
             "name": "Safehold Elite",
             "text": "Persist (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "85f74958-e66c-5633-9a6d-d7035378a922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61edb39b-ff82-4568-971f-baf22e209c88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61edb39b-ff82-4568-971f-baf22e209c88.jpg?1",
             "name": "Safewright Quest",
             "text": "Search your library for a Forest or Plains card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "e4dc4e5f-54c8-5cc0-a09e-d11884824d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae8525-ce10-40bd-8980-a05fb81a0fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ae8525-ce10-40bd-8980-a05fb81a0fac.jpg?1",
             "name": "Seedcradle Witch",
             "text": "{2}{G}{W}: Target creature gets +3/+3 until end of turn. Untap that creature.",
             "colours": [
@@ -8364,7 +8364,7 @@
         },
         {
             "id": "a5a7c2f1-946d-579e-9682-4ab0fa2cc876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54040bc6-dd7c-4933-bfac-d0d6d2c78157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54040bc6-dd7c-4933-bfac-d0d6d2c78157.jpg?1",
             "name": "Shield of the Oversoul",
             "text": "Enchant creature\nAs long as enchanted creature is green, it gets +1/+1 and is indestructible. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)\nAs long as enchanted creature is white, it gets +1/+1 and has flying.",
             "colours": [
@@ -8400,7 +8400,7 @@
         },
         {
             "id": "86ec08d3-aaa9-5e1b-8a28-86d90e61dae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55976e4b-718f-44b2-b93d-de5f75dc3bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55976e4b-718f-44b2-b93d-de5f75dc3bbe.jpg?1",
             "name": "Wheel of Sun and Moon",
             "text": "Enchant player\nIf a card would be put into enchanted player's graveyard from anywhere, instead that card is revealed and put on the bottom of that player's library.",
             "colours": [
@@ -8436,7 +8436,7 @@
         },
         {
             "id": "af1acfb3-79c3-58ba-8780-59b769a36507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ffe320-c88a-4eb7-a091-e128e6c1f37c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ffe320-c88a-4eb7-a091-e128e6c1f37c.jpg?1",
             "name": "Wilt-Leaf Cavaliers",
             "text": "Vigilance",
             "colours": [
@@ -8473,7 +8473,7 @@
         },
         {
             "id": "f962cc66-9255-5ecd-98e5-eac9293078f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a2881f-e771-47d7-a39e-692054ee727f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a2881f-e771-47d7-a39e-692054ee727f.jpg?1",
             "name": "Wilt-Leaf Liege",
             "text": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\nIf a spell or ability an opponent controls causes you to discard Wilt-Leaf Liege, put it into play instead of putting it into your graveyard.",
             "colours": [
@@ -8510,7 +8510,7 @@
         },
         {
             "id": "ab7dc39a-8384-5b82-b02f-fb1594634709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44793043-82b4-415b-a9ab-d564fdbcd314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44793043-82b4-415b-a9ab-d564fdbcd314.jpg?1",
             "name": "Blazethorn Scarecrow",
             "text": "Blazethorn Scarecrow has haste as long as you control a red creature.\nBlazethorn Scarecrow has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)",
             "colours": [],
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "07be0caf-8aeb-5cf6-bd33-cc0be6efcb06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f828c7-aedc-462b-8455-46e8a90feb85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f828c7-aedc-462b-8455-46e8a90feb85.jpg?1",
             "name": "Blight Sickle",
             "text": "Equipped creature gets +1/+0 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)\nEquip {2}",
             "colours": [],
@@ -8571,7 +8571,7 @@
         },
         {
             "id": "4a54ba2c-447c-50f0-beac-caa1523888e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7546996-aa71-45f2-93df-3e1f61b252a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7546996-aa71-45f2-93df-3e1f61b252a9.jpg?1",
             "name": "Cauldron of Souls",
             "text": "{T}: Choose any number of target creatures. Each of those creatures gains persist until end of turn. (When it's put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -8599,7 +8599,7 @@
         },
         {
             "id": "0949698c-b3b0-53a4-9d22-988f0e7d0ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094b023e-d5a3-4a57-adf0-898f3dcc8de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/094b023e-d5a3-4a57-adf0-898f3dcc8de2.jpg?1",
             "name": "Chainbreaker",
             "text": "Chainbreaker comes into play with two -1/-1 counters on it.\n{3}, {T}: Remove a -1/-1 counter from target creature.",
             "colours": [],
@@ -8630,7 +8630,7 @@
         },
         {
             "id": "d42bc75a-e11a-5a67-b39d-010d41d0a669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273a17d-114b-4d54-a2a5-1047df8caa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9273a17d-114b-4d54-a2a5-1047df8caa9d.jpg?1",
             "name": "Elsewhere Flask",
             "text": "When Elsewhere Flask comes into play, draw a card.\nSacrifice Elsewhere Flask: Choose a basic land type. Each land you control becomes that type until end of turn.",
             "colours": [],
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "a1c95c0e-3b3f-5b7e-93a5-451418b0bcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6aee954-2a04-425d-8d05-09dad58af656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6aee954-2a04-425d-8d05-09dad58af656.jpg?1",
             "name": "Gnarled Effigy",
             "text": "{4}, {T}: Put a -1/-1 counter on target creature.",
             "colours": [],
@@ -8686,7 +8686,7 @@
         },
         {
             "id": "53f5dc57-ac0b-52c6-be20-491b1b5ce757",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac9d9c-6685-465b-8933-dd6164569f4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bac9d9c-6685-465b-8933-dd6164569f4d.jpg?1",
             "name": "Grim Poppet",
             "text": "Grim Poppet comes into play with three -1/-1 counters on it.\nRemove a -1/-1 counter from Grim Poppet: Put a -1/-1 counter on another target creature.",
             "colours": [],
@@ -8717,7 +8717,7 @@
         },
         {
             "id": "78ccb419-d2b9-5bcc-ade5-4f00c0682ca6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d726e1-a363-4d77-97d4-e8c94f93fd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d726e1-a363-4d77-97d4-e8c94f93fd51.jpg?1",
             "name": "Heap Doll",
             "text": "Sacrifice Heap Doll: Remove target card in a graveyard from the game.",
             "colours": [],
@@ -8748,7 +8748,7 @@
         },
         {
             "id": "c492c576-7eb4-5721-8b57-f622f60e0dd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d473d9-f52e-4357-b25a-e8bdcc833f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d473d9-f52e-4357-b25a-e8bdcc833f09.jpg?1",
             "name": "Illuminated Folio",
             "text": "{1}, {T}, Reveal two cards from your hand that share a color: Draw a card.",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "c8b2ccd6-3951-5da7-80b4-0a60d721ae9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae1cc40-12c0-4300-b6fa-7af32167a158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fae1cc40-12c0-4300-b6fa-7af32167a158.jpg?1",
             "name": "Lockjaw Snapper",
             "text": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\nWhen Lockjaw Snapper is put into a graveyard from play, put a -1/-1 counter on each creature with a -1/-1 counter on it.",
             "colours": [],
@@ -8807,7 +8807,7 @@
         },
         {
             "id": "4921306b-7e7c-5030-8d73-829e9aac87a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89503bf6-d720-4fd5-b2cf-fc1197bf0f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89503bf6-d720-4fd5-b2cf-fc1197bf0f16.jpg?1",
             "name": "Lurebound Scarecrow",
             "text": "As Lurebound Scarecrow comes into play, choose a color.\nWhen you control no permanents of the chosen color, sacrifice Lurebound Scarecrow.",
             "colours": [],
@@ -8838,7 +8838,7 @@
         },
         {
             "id": "e8a0b28b-01e3-5e11-b57c-27f761cde41b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be407a81-b25a-4e5d-845e-be0cc0d18db8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be407a81-b25a-4e5d-845e-be0cc0d18db8.jpg?1",
             "name": "Painter's Servant",
             "text": "As Painter's Servant comes into play, choose a color.\nAll cards that aren't in play, spells, and permanents are the chosen color in addition to their other colors.",
             "colours": [],
@@ -8869,7 +8869,7 @@
         },
         {
             "id": "a1f99065-aa57-5d50-95f9-a59752ca5f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4892c152-1f4a-4616-8e7f-0ca4911e621a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4892c152-1f4a-4616-8e7f-0ca4911e621a.jpg?1",
             "name": "Pili-Pala",
             "text": "Flying\n{2}, {Q}: Add one mana of any color to your mana pool. ({Q} is the untap symbol.)",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "f3e4fd4e-3b9b-5d54-b0f1-0d15a1e47797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b46425f-516c-42f5-8df1-79af17d02a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b46425f-516c-42f5-8df1-79af17d02a4a.jpg?1",
             "name": "Rattleblaze Scarecrow",
             "text": "Rattleblaze Scarecrow has persist as long as you control a black creature. (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)\nRattleblaze Scarecrow has haste as long as you control a red creature.",
             "colours": [],
@@ -8931,7 +8931,7 @@
         },
         {
             "id": "9b3ab708-22bb-5be9-a2da-99211d331693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502740bf-0bff-4358-8996-1a27e5f0343f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502740bf-0bff-4358-8996-1a27e5f0343f.jpg?1",
             "name": "Reaper King",
             "text": "({2\nW} can be paid with any two mana or with {W}. This card's converted mana cost is 10.)\nOther Scarecrow creatures you control get +1/+1.\nWhenever another Scarecrow comes into play under your control, destroy target permanent.",
             "colours": [
@@ -8976,7 +8976,7 @@
         },
         {
             "id": "ef10c3b5-3be5-59f3-be01-35364c93a635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a4801c-fa69-47a0-bdfa-f5f110fd0976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a4801c-fa69-47a0-bdfa-f5f110fd0976.jpg?1",
             "name": "Revelsong Horn",
             "text": "{1}, {T}, Tap an untapped creature you control: Target creature gets +1/+1 until end of turn.",
             "colours": [],
@@ -9004,7 +9004,7 @@
         },
         {
             "id": "48625863-b03c-5e8b-9420-1f0e5442e7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7f0a6d-4127-4ea4-be16-2ed6b263a3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7f0a6d-4127-4ea4-be16-2ed6b263a3f3.jpg?1",
             "name": "Scrapbasket",
             "text": "{1}: Scrapbasket becomes all colors until end of turn.",
             "colours": [],
@@ -9035,7 +9035,7 @@
         },
         {
             "id": "b59bb969-da9c-5a56-a777-a6b509833b7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb3ab2-6d34-4cbf-ad46-070516a7cc54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07cb3ab2-6d34-4cbf-ad46-070516a7cc54.jpg?1",
             "name": "Scuttlemutt",
             "text": "{T}: Add one mana of any color to your mana pool.\n{T}: Target creature becomes the color or colors of your choice until end of turn.",
             "colours": [],
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "48d6092f-428b-5534-a2e5-ef957f89f04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf852c-b8a9-44d4-b2cd-3f1e071a8be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf852c-b8a9-44d4-b2cd-3f1e071a8be9.jpg?1",
             "name": "Tatterkite",
             "text": "Flying\nTatterkite can't have counters placed on it.",
             "colours": [],
@@ -9097,7 +9097,7 @@
         },
         {
             "id": "515e2ddd-255f-5ba8-b4bb-7efb26ed8646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489ac0a-cbdb-43d5-be73-6cb65ae54a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3489ac0a-cbdb-43d5-be73-6cb65ae54a20.jpg?1",
             "name": "Thornwatch Scarecrow",
             "text": "Thornwatch Scarecrow has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)\nThornwatch Scarecrow has vigilance as long as you control a white creature.",
             "colours": [],
@@ -9128,7 +9128,7 @@
         },
         {
             "id": "38708338-be42-5bee-a863-c947e62c38ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b3dd8-cedb-4577-8897-967952dd3c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b2b3dd8-cedb-4577-8897-967952dd3c13.jpg?1",
             "name": "Trip Noose",
             "text": "{2}, {T}: Tap target creature.",
             "colours": [],
@@ -9156,7 +9156,7 @@
         },
         {
             "id": "3038faf1-3dfc-5b22-9e12-a56adb39f88e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e35711-aec9-4024-a2a6-9efff8c71df2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e35711-aec9-4024-a2a6-9efff8c71df2.jpg?1",
             "name": "Umbral Mantle",
             "text": "Equipped creature has \"{3}, {Q}: This creature gets +2/+2 until end of turn.\" ({Q} is the untap symbol.)\nEquip {0}",
             "colours": [],
@@ -9186,7 +9186,7 @@
         },
         {
             "id": "9bf3d037-64ae-5264-ac06-d6114e439c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7774fd-3460-46e3-9c9c-7aa70f2ff6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c7774fd-3460-46e3-9c9c-7aa70f2ff6d8.jpg?1",
             "name": "Watchwing Scarecrow",
             "text": "Watchwing Scarecrow has vigilance as long as you control a white creature.\nWatchwing Scarecrow has flying as long as you control a blue creature.",
             "colours": [],
@@ -9217,7 +9217,7 @@
         },
         {
             "id": "addd4f16-13a8-5fbb-9bd5-10f86385ef5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488e7c73-62bc-4d51-bcb6-8126ec559b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488e7c73-62bc-4d51-bcb6-8126ec559b41.jpg?1",
             "name": "Wicker Warcrawler",
             "text": "Whenever Wicker Warcrawler attacks or blocks, put a -1/-1 counter on it at end of combat.",
             "colours": [],
@@ -9248,7 +9248,7 @@
         },
         {
             "id": "e824e5f0-f74a-5269-8d74-679c3961cd7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c5d86e-1ce1-4386-b70f-73b24351d6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c5d86e-1ce1-4386-b70f-73b24351d6ae.jpg?1",
             "name": "Wingrattle Scarecrow",
             "text": "Wingrattle Scarecrow has flying as long as you control a blue creature.\nWingrattle Scarecrow has persist as long as you control a black creature. (When this creature is put into a graveyard from play, if it had no -1/-1 counters on it, return it to play under its owner's control with a -1/-1 counter on it.)",
             "colours": [],
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "0b6c2c00-9330-5a59-9e47-e67d1ae02ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab9d6ad-f819-4a1e-b4ff-8dc00791f0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab9d6ad-f819-4a1e-b4ff-8dc00791f0fd.jpg?1",
             "name": "Fire-Lit Thicket",
             "text": "{T}: Add {1} to your mana pool.\n{RG}, {T}: Add {R}{R}, {R}{G}, or {G}{G} to your mana pool.",
             "colours": [],
@@ -9310,7 +9310,7 @@
         },
         {
             "id": "7215963c-5de6-5902-95cc-6041a7c8e7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c355bf63-f456-43ad-a6df-6c2a17511f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c355bf63-f456-43ad-a6df-6c2a17511f43.jpg?1",
             "name": "Graven Cairns",
             "text": "{T}: Add {1} to your mana pool.\n{BR}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
             "colours": [],
@@ -9341,7 +9341,7 @@
         },
         {
             "id": "38ba0339-fd21-5d9a-aede-b060b7513baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa47202-5824-4f6a-b306-465976d4d422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afa47202-5824-4f6a-b306-465976d4d422.jpg?1",
             "name": "Leechridden Swamp",
             "text": "({T}: Add {B} to your mana pool.)\nLeechridden Swamp comes into play tapped.\n{B}, {T}: Each opponent loses 1 life. Play this ability only if you control two or more black permanents.",
             "colours": [],
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "0af4af93-a89b-5161-92cd-6065aaa74c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513adae2-6436-4284-9f23-87ef627e81b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513adae2-6436-4284-9f23-87ef627e81b7.jpg?1",
             "name": "Madblind Mountain",
             "text": "({T}: Add {R} to your mana pool.)\nMadblind Mountain comes into play tapped.\n{R}, {T}: Shuffle your library. Play this ability only if you control two or more red permanents.",
             "colours": [],
@@ -9405,7 +9405,7 @@
         },
         {
             "id": "6a7ff952-47ac-5e3c-905d-6065a2482766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af06f923-0c89-42ae-a4a8-618be7f39cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af06f923-0c89-42ae-a4a8-618be7f39cce.jpg?1",
             "name": "Mistveil Plains",
             "text": "({T}: Add {W} to your mana pool.)\nMistveil Plains comes into play tapped.\n{W}, {T}: Put target card in your graveyard on the bottom of your library. Play this ability only if you control two or more white permanents.",
             "colours": [],
@@ -9437,7 +9437,7 @@
         },
         {
             "id": "16528283-6022-5766-8d0d-f5b31b8de8e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b36993-666c-40d0-b61a-1d162bd06dcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b36993-666c-40d0-b61a-1d162bd06dcc.jpg?1",
             "name": "Moonring Island",
             "text": "({T}: Add {U} to your mana pool.)\nMoonring Island comes into play tapped.\n{U}, {T}: Look at the top card of target player's library. Play this ability only if you control two or more blue permanents.",
             "colours": [],
@@ -9469,7 +9469,7 @@
         },
         {
             "id": "f4138035-5ee7-58a8-aff8-f177d9c8be28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfa866b-93e2-4365-91b0-f12d1f7c5395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfa866b-93e2-4365-91b0-f12d1f7c5395.jpg?1",
             "name": "Mystic Gate",
             "text": "{T}: Add {1} to your mana pool.\n{WU}, {T}: Add {W}{W}, {W}{U}, or {U}{U} to your mana pool.",
             "colours": [],
@@ -9500,7 +9500,7 @@
         },
         {
             "id": "0940a360-14f1-5b9e-910c-580dcc86e628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d03dc37-03fb-47b2-aa25-60a85d0d94dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d03dc37-03fb-47b2-aa25-60a85d0d94dd.jpg?1",
             "name": "Reflecting Pool",
             "text": "{T}: Add to your mana pool one mana of any type that a land you control could produce.",
             "colours": [],
@@ -9529,7 +9529,7 @@
         },
         {
             "id": "9e017907-efd8-50fb-81fd-27d3d2ae33e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d7eed-38ee-42de-904d-56c837186198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265d7eed-38ee-42de-904d-56c837186198.jpg?1",
             "name": "Reflecting Pool",
             "text": "",
             "colours": [],
@@ -9558,7 +9558,7 @@
         },
         {
             "id": "1b88cac5-4e64-50c3-ad36-fb44e2c98c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e29d9f-6aa9-49ef-8484-54af216aa509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1e29d9f-6aa9-49ef-8484-54af216aa509.jpg?1",
             "name": "Sapseep Forest",
             "text": "({T}: Add {G} to your mana pool.)\nSapseep Forest comes into play tapped.\n{G}, {T}: You gain 1 life. Play this ability only if you control two or more green permanents.",
             "colours": [],
@@ -9590,7 +9590,7 @@
         },
         {
             "id": "6ce6d845-440e-5e8c-a1de-02b127ad788c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d91a31c-b70a-45bd-a8dd-48d49b277f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d91a31c-b70a-45bd-a8dd-48d49b277f24.jpg?1",
             "name": "Sunken Ruins",
             "text": "{T}: Add {1} to your mana pool.\n{UB}, {T}: Add {U}{U}, {U}{B}, or {B}{B} to your mana pool.",
             "colours": [],
@@ -9621,7 +9621,7 @@
         },
         {
             "id": "9d1ff277-46f7-50e6-bbab-15b654cf0a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e088fe6-e47a-4e27-b07e-ec35db045359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e088fe6-e47a-4e27-b07e-ec35db045359.jpg?1",
             "name": "Wooded Bastion",
             "text": "{T}: Add {1} to your mana pool.\n{RW}, {T}: Add {G}{G}, {G}{W}, or {W}{W} to your mana pool.",
             "colours": [],
@@ -9652,7 +9652,7 @@
         },
         {
             "id": "3955ae53-6c4f-5853-945e-3a0786b0f5c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf67e21-3306-4c4e-a021-9b997cc8c48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf67e21-3306-4c4e-a021-9b997cc8c48c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9690,7 +9690,7 @@
         },
         {
             "id": "eb220c98-931b-5cbd-96a7-3a4f69894952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a646c9-8347-4b62-829e-6af6b275346a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a646c9-8347-4b62-829e-6af6b275346a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9728,7 +9728,7 @@
         },
         {
             "id": "c4ffdd69-b2b5-59a6-8556-49c222f739e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b104eb8-7095-4aba-a155-d8e147639692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b104eb8-7095-4aba-a155-d8e147639692.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "2fc2bc4a-0281-5926-b6fb-d76bd8694723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ba7ff5-7f2a-4268-9bdd-96061ce5e86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19ba7ff5-7f2a-4268-9bdd-96061ce5e86a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9804,7 +9804,7 @@
         },
         {
             "id": "efdc1040-db63-5d33-b878-4ff82b8d4d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d84005-faac-4e02-9fea-40757b43cf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d84005-faac-4e02-9fea-40757b43cf03.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9842,7 +9842,7 @@
         },
         {
             "id": "176de16a-3b5f-5559-b3d3-5612978f485d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae96b4b-7568-4463-b26c-a567e4a418d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae96b4b-7568-4463-b26c-a567e4a418d7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9880,7 +9880,7 @@
         },
         {
             "id": "9ca4daaa-7bab-5631-bef0-7ada4a26b05c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196a004a-ec08-4e1b-8eeb-2ad766fccd25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/196a004a-ec08-4e1b-8eeb-2ad766fccd25.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9918,7 +9918,7 @@
         },
         {
             "id": "cec78f77-64e1-5001-848e-cbd3bddccdf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28da317c-8512-4342-9be5-d14b87a509c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28da317c-8512-4342-9be5-d14b87a509c7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9956,7 +9956,7 @@
         },
         {
             "id": "90d1e326-f8bb-5f02-b8c6-21f94a1a54c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4324380c-68b8-4955-ad92-76f921e6ffc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4324380c-68b8-4955-ad92-76f921e6ffc1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "059f9534-b743-5667-a8e4-b8b30abe3c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a310639-99ca-4a7e-9f65-731779f3ea46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a310639-99ca-4a7e-9f65-731779f3ea46.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10032,7 +10032,7 @@
         },
         {
             "id": "a4a2e2d5-7ab6-5acc-8f29-19315be112fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0be63-ec99-4291-b504-e17061c15a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee0be63-ec99-4291-b504-e17061c15a67.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10070,7 +10070,7 @@
         },
         {
             "id": "7a5264c2-5997-5e38-8eb5-2ff081ef51f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d2dedf-d0d8-42c5-a498-31e172a1b503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d2dedf-d0d8-42c5-a498-31e172a1b503.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "f4c2862d-ad19-5c40-80f4-51deed075436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497551e-eb90-48db-90e9-0f917da41d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0497551e-eb90-48db-90e9-0f917da41d9e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10146,7 +10146,7 @@
         },
         {
             "id": "955c98b4-4acd-5238-89ab-df9e4e1abb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc8e7e-3d78-456a-b4ef-c9f2eaa6ec7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc8e7e-3d78-456a-b4ef-c9f2eaa6ec7c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10184,7 +10184,7 @@
         },
         {
             "id": "1d82e430-6358-5564-9822-0dd5b23c4efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d671616-f58c-4ee9-9ed7-78ebc385948a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d671616-f58c-4ee9-9ed7-78ebc385948a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "0318e5af-2a5b-53ab-b4a8-4902ff24e01f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a63f1a-8224-4c66-9a3a-6c04c656c73b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a63f1a-8224-4c66-9a3a-6c04c656c73b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10260,7 +10260,7 @@
         },
         {
             "id": "9e4508f1-f524-571b-befc-a8b55fbe4d00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b763764f-efb0-48c6-b353-1831164c2db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b763764f-efb0-48c6-b353-1831164c2db5.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10298,7 +10298,7 @@
         },
         {
             "id": "412c0d25-ea50-5937-ba5d-3f456cff6c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa690e4-dbc8-4490-8958-6eb323a05daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa690e4-dbc8-4490-8958-6eb323a05daa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10336,7 +10336,7 @@
         },
         {
             "id": "953c3d7c-5066-52d4-939b-13a96f4029e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6424d21-d852-4af5-96d7-cda2ba0e5912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6424d21-d852-4af5-96d7-cda2ba0e5912.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10374,7 +10374,7 @@
         },
         {
             "id": "6bd614f1-f1ef-55eb-b88c-6689032da7e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62131862-1256-4082-a83d-a0048714acb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62131862-1256-4082-a83d-a0048714acb1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10412,7 +10412,7 @@
         },
         {
             "id": "cd4f88a7-c6c0-597f-b4fa-0f6600fb51a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061cb705-695a-4f65-adbf-869ebb4eb946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061cb705-695a-4f65-adbf-869ebb4eb946.jpg?1",
             "name": "Kithkin Soldier",
             "text": "",
             "colours": [
@@ -10447,7 +10447,7 @@
         },
         {
             "id": "c94a7b9a-270f-5e20-9830-d60600df3c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba50f25-ad8c-4244-8dc1-f8656f4c8c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba50f25-ad8c-4244-8dc1-f8656f4c8c0b.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -10481,7 +10481,7 @@
         },
         {
             "id": "1e926fdb-3ca5-5a7a-b04f-483060004a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a85fe9d-ef18-46c4-88b0-cf2e222e30e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a85fe9d-ef18-46c4-88b0-cf2e222e30e4.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -10515,7 +10515,7 @@
         },
         {
             "id": "fd68571c-fcb2-5ccc-b7f7-7a035e1023eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c14f3d-1578-426b-b64b-07c7e88ab572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c14f3d-1578-426b-b64b-07c7e88ab572.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10549,7 +10549,7 @@
         },
         {
             "id": "51c43f03-a499-5fda-8281-38eb06faf3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7663358-c85c-4ba4-ac9b-6be6105363a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7663358-c85c-4ba4-ac9b-6be6105363a9.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [
@@ -10584,7 +10584,7 @@
         },
         {
             "id": "e00466d1-307b-5117-bb06-69ed13d6f2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df0de51-8d05-475a-832e-de8a0f60849e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df0de51-8d05-475a-832e-de8a0f60849e.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -10618,7 +10618,7 @@
         },
         {
             "id": "501a119f-9fba-5ba6-aad7-880575207506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c138bf9-8be6-4f1a-a82c-a84938ab84f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c138bf9-8be6-4f1a-a82c-a84938ab84f5.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -10652,7 +10652,7 @@
         },
         {
             "id": "503bc871-2fc6-57e4-82c9-f1d546c24756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b4786-1592-42c7-9d3e-d0d66abaed99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07b4786-1592-42c7-9d3e-d0d66abaed99.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "0d54973b-0600-5ea7-bb7c-28ee330c448b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5afb0a-a158-4995-881e-eae0f20805a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5afb0a-a158-4995-881e-eae0f20805a6.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "4ec1e6d8-04cd-57cc-b8fd-ece3c48152eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f84b406-112d-4b01-8500-60391692a17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f84b406-112d-4b01-8500-60391692a17e.jpg?1",
             "name": "Giant Warrior",
             "text": "",
             "colours": [
@@ -10762,7 +10762,7 @@
         },
         {
             "id": "afe81bef-8851-5a9e-882c-66c59e09994e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36334f1-afe3-497c-82d9-aaf149934b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36334f1-afe3-497c-82d9-aaf149934b54.jpg?1",
             "name": "Goblin Warrior",
             "text": "",
             "colours": [
@@ -10799,7 +10799,7 @@
         },
         {
             "id": "1ee3ec14-2249-5992-b6bb-a0cc3c598164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49180301-f72f-48ca-8be1-df295e89cdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49180301-f72f-48ca-8be1-df295e89cdd7.jpg?1",
             "name": "Elf Warrior",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/SLD.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SLD.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a78f0947-fc4e-5831-89af-d7ff3e5a1e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3066cc8b-7a5a-4822-a202-dd560a4fda85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3066cc8b-7a5a-4822-a202-dd560a4fda85.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -42,7 +42,7 @@
         },
         {
             "id": "778193e7-59cb-57d9-8837-9a7543c022b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7c3929-cd56-448d-9752-6d5f9d1fd778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d7c3929-cd56-448d-9752-6d5f9d1fd778.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -80,7 +80,7 @@
         },
         {
             "id": "c9f3cc8a-52a5-5743-819a-a83a20a20e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dce8b37-50da-4f21-9664-e4d6ce6c4e3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dce8b37-50da-4f21-9664-e4d6ce6c4e3c.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -118,7 +118,7 @@
         },
         {
             "id": "3775114c-c464-5a2d-b0c8-454e7f4e2389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a9d6d-497b-44a1-963f-501d61ea7f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685a9d6d-497b-44a1-963f-501d61ea7f66.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -156,7 +156,7 @@
         },
         {
             "id": "ba437894-c60c-558a-a8ed-436118d794e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92195708-cc07-44bf-85d8-6c5d6f0d789e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92195708-cc07-44bf-85d8-6c5d6f0d789e.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -194,7 +194,7 @@
         },
         {
             "id": "e86b79ae-e7b5-5218-9ec4-fc34756ebdf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87089d28-46a7-4247-a784-c34b9f822172.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87089d28-46a7-4247-a784-c34b9f822172.jpg?1",
             "name": "Bloodghast",
             "text": "",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "7f5fe3c6-13f3-587d-9366-79a2cfbe9dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddee704-5315-4b35-9f77-0c12def26ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddee704-5315-4b35-9f77-0c12def26ce1.jpg?1",
             "name": "Golgari Thug",
             "text": "",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "0b01460f-a11a-5403-9c6a-34aad284e22e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ed197-e434-4f01-a71f-053ae3820d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899ed197-e434-4f01-a71f-053ae3820d6c.jpg?1",
             "name": "Life from the Loam",
             "text": "",
             "colours": [
@@ -293,7 +293,7 @@
         },
         {
             "id": "8c73c87b-959a-5c6d-8272-5aa87d039439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3463a8-79f6-4fec-afd6-ad8c412d648c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3463a8-79f6-4fec-afd6-ad8c412d648c.jpg?1",
             "name": "Reaper King",
             "text": "",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "c3eb2450-4ad2-51ec-94fe-51d6be98ad17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fad8ca2-032d-40ee-b3d6-29ab2b59ba86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fad8ca2-032d-40ee-b3d6-29ab2b59ba86.jpg?1",
             "name": "Sliver Overlord",
             "text": "",
             "colours": [
@@ -381,7 +381,7 @@
         },
         {
             "id": "2c334c2c-6664-5bb8-8052-d7e88ed4b835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea949741-af94-47ae-a577-2953c69ab71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea949741-af94-47ae-a577-2953c69ab71d.jpg?1",
             "name": "The Ur-Dragon",
             "text": "",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "3993a2c3-a626-526b-b2b7-7d58c2651b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f88df1-4e1a-4557-bb7a-1ac86641043e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f88df1-4e1a-4557-bb7a-1ac86641043e.jpg?1",
             "name": "Bitterblossom",
             "text": "",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "7484825f-cf0f-5721-91af-9f388b812410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450c7d6-4c09-4264-a711-b956f62f4d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7450c7d6-4c09-4264-a711-b956f62f4d0e.jpg?1",
             "name": "Goblin Bushwhacker",
             "text": "",
             "colours": [
@@ -493,7 +493,7 @@
         },
         {
             "id": "c54d07d1-0947-5a6b-98a1-a41f1d972c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad66330e-166c-4613-b788-e5c2f052cd9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad66330e-166c-4613-b788-e5c2f052cd9d.jpg?1",
             "name": "Goblin Sharpshooter",
             "text": "",
             "colours": [
@@ -526,7 +526,7 @@
         },
         {
             "id": "03518f51-fcd0-5891-b365-99f74c0672ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455dff34-0ab2-4798-84a9-66dcf37f1789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455dff34-0ab2-4798-84a9-66dcf37f1789.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -561,7 +561,7 @@
         },
         {
             "id": "64857a21-7825-57ac-8c15-4c03c8d5b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd57c7f3-4ca5-45e7-9be2-c5c1c3d6ad31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd57c7f3-4ca5-45e7-9be2-c5c1c3d6ad31.jpg?1",
             "name": "Goblin Lackey",
             "text": "",
             "colours": [
@@ -597,7 +597,7 @@
         },
         {
             "id": "cf7e1b75-1301-56ea-9529-a425830f8b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b920dbc-0a61-43b2-9571-dc9d726842eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b920dbc-0a61-43b2-9571-dc9d726842eb.jpg?1",
             "name": "Goblin Piledriver",
             "text": "",
             "colours": [
@@ -631,7 +631,7 @@
         },
         {
             "id": "f2fb2522-184c-5c62-afb3-cd70b1002125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9793cbf-9338-450f-8ef0-8033e7aae49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9793cbf-9338-450f-8ef0-8033e7aae49a.jpg?1",
             "name": "Leonin Warleader",
             "text": "",
             "colours": [
@@ -665,7 +665,7 @@
         },
         {
             "id": "a4302153-bc7b-5860-972c-20656a7f8708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05783c-fd85-4fb2-bddc-2eef72513cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc05783c-fd85-4fb2-bddc-2eef72513cf0.jpg?1",
             "name": "Regal Caracal",
             "text": "",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "6e94e581-8563-561b-92f8-c68739fbd039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8ce2aa-cb2b-4e5f-98b9-1f3cac5cab1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8ce2aa-cb2b-4e5f-98b9-1f3cac5cab1c.jpg?1",
             "name": "Qasali Slingers",
             "text": "",
             "colours": [
@@ -732,7 +732,7 @@
         },
         {
             "id": "b97ec876-4b14-5ee4-bdd6-39a7524509b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda28572-654e-4d43-b88c-cf8c8b0f5eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda28572-654e-4d43-b88c-cf8c8b0f5eb5.jpg?1",
             "name": "Arahbo, Roar of the World",
             "text": "",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "89445970-2a9b-5156-a92c-9ab4eea26c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e856be87-6f2b-4846-87f1-53e2c1c71a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e856be87-6f2b-4846-87f1-53e2c1c71a16.jpg?1",
             "name": "Mirri, Weatherlight Duelist",
             "text": "",
             "colours": [
@@ -808,7 +808,7 @@
         },
         {
             "id": "9e9ab6d0-fcd8-523c-a8e9-8773b0443dd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca3457c-4924-4824-8f32-7f4a12d2e2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca3457c-4924-4824-8f32-7f4a12d2e2ea.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -843,7 +843,7 @@
         },
         {
             "id": "fb3bdc21-d1c3-5fa2-8ea6-3ff48b11a5bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac65dd-31d2-4f59-bf89-537d870bd6a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ac65dd-31d2-4f59-bf89-537d870bd6a9.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -878,7 +878,7 @@
         },
         {
             "id": "ef228daa-505c-5fbf-83c4-110eba5b5946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5444140b-9acf-4d28-bf41-2218f1c12831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5444140b-9acf-4d28-bf41-2218f1c12831.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "f93fa4d1-068d-5126-bbba-3863884b39c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4077e3d5-e0b6-4d2f-8c94-e1f78433c05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4077e3d5-e0b6-4d2f-8c94-e1f78433c05c.jpg?1",
             "name": "Serum Visions",
             "text": "",
             "colours": [
@@ -948,7 +948,7 @@
         },
         {
             "id": "938acf65-6f5e-514a-8913-f89d79ab9d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a11a1a-ebdf-495d-9511-33ee22c07521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a11a1a-ebdf-495d-9511-33ee22c07521.jpg?1",
             "name": "Ink-Eyes, Servant of Oni",
             "text": "",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "88339ccb-b4f2-53df-97a9-0d8b2e8bca9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0ce55-bf61-491e-9136-6f62b5aa5795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce0ce55-bf61-491e-9136-6f62b5aa5795.jpg?1",
             "name": "Marrow-Gnawer",
             "text": "",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "8b3eaf0e-8a2a-5e1d-8ae9-0e34b05183aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3864bc8-f86e-4c41-b454-e19d1939147b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3864bc8-f86e-4c41-b454-e19d1939147b.jpg?1",
             "name": "Pack Rat",
             "text": "",
             "colours": [
@@ -1055,7 +1055,7 @@
         },
         {
             "id": "c8dc8db7-6a76-5f7d-b9ec-d95f6246cdb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4227afa-780b-4755-9b61-46255717c6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4227afa-780b-4755-9b61-46255717c6be.jpg?1",
             "name": "Rat Colony",
             "text": "",
             "colours": [
@@ -1088,7 +1088,7 @@
         },
         {
             "id": "7cba949d-88c9-516f-bfc9-b68a6f43004f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05031dc-f99c-49d3-9a20-3453587d8dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b05031dc-f99c-49d3-9a20-3453587d8dea.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "696679ff-91c6-53a4-bd90-f51eba23237f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbde9d9-1723-4f26-8700-63c459ac80cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bbde9d9-1723-4f26-8700-63c459ac80cb.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "2322a15f-3028-52f2-a962-33d3b7e11284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717de388-0c07-4346-9c7e-7b06b14f1cc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717de388-0c07-4346-9c7e-7b06b14f1cc1.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "5af9d664-4932-5e96-8d0a-9863ed9b4d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67a5aac-dbda-4e5d-ae4a-eb78dec6765b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d67a5aac-dbda-4e5d-ae4a-eb78dec6765b.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "",
             "colours": [
@@ -1248,7 +1248,7 @@
         },
         {
             "id": "2dfdcffa-746b-5273-8991-017bf506c418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f8b11a-6b21-4532-96c9-bdb2cad603e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f8b11a-6b21-4532-96c9-bdb2cad603e8.jpg?1",
             "name": "Spell Pierce",
             "text": "",
             "colours": [
@@ -1279,7 +1279,7 @@
         },
         {
             "id": "e3b61ca3-b574-5b51-97ad-72dc4a11e67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5b65ed-250c-42a6-84c0-ac06662ca5ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5b65ed-250c-42a6-84c0-ac06662ca5ed.jpg?1",
             "name": "Blood Artist",
             "text": "",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "13d2f88e-05a1-5f41-9786-89972b4b3505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bb37b7-3474-42af-abf0-0b713bf34174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bb37b7-3474-42af-abf0-0b713bf34174.jpg?1",
             "name": "Eternal Witness",
             "text": "",
             "colours": [
@@ -1349,7 +1349,7 @@
         },
         {
             "id": "c4417193-b9c4-5df7-b3ea-bdd749ff6832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e503b59c-df3e-4f52-9a59-195f02a6cb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e503b59c-df3e-4f52-9a59-195f02a6cb18.jpg?1",
             "name": "Pithing Needle",
             "text": "",
             "colours": [],
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "9a7d9a2b-14d3-5c0f-bb62-a1c28493610f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c41b06-407e-497a-adb9-a19687fad1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c41b06-407e-497a-adb9-a19687fad1e8.jpg?1",
             "name": "Inkmoth Nexus",
             "text": "",
             "colours": [],
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "b1877893-452e-5444-a216-b1219b03647f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282908d5-29e8-4a55-915e-64883ec3b714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/282908d5-29e8-4a55-915e-64883ec3b714.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "c31101e6-7238-55e9-a305-4d95108cd812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4d5c0-7ad2-446d-b49e-5ee446bb23cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4d5c0-7ad2-446d-b49e-5ee446bb23cd.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -1539,7 +1539,7 @@
         },
         {
             "id": "b919003a-1e07-5c7b-870f-c2e6c9f0ff32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c5c795-5463-425b-9720-627004925e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c5c795-5463-425b-9720-627004925e20.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -1603,7 +1603,7 @@
         },
         {
             "id": "b4f35ef2-aa7a-507b-9a01-be001e2c92c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e820a082-f876-4cfc-95a2-34be5b994d80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e820a082-f876-4cfc-95a2-34be5b994d80.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "d8e4f596-2c78-5c1d-bf1a-ca9860625719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc8f49-6b8f-4466-908c-c6ff3e5c8c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2bc8f49-6b8f-4466-908c-c6ff3e5c8c32.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "3f80c076-6102-5273-9710-b5a83c61dfc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d22ed-7b85-4669-b49c-b1872a448611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44d22ed-7b85-4669-b49c-b1872a448611.jpg?1",
             "name": "Captain Sisay",
             "text": "",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "897a3d5e-ec9c-52b5-967c-914d90aeb10c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91190972-7c9d-4a16-b7b8-0fcf3dbcebd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91190972-7c9d-4a16-b7b8-0fcf3dbcebd5.jpg?1",
             "name": "Meren of Clan Nel Toth",
             "text": "",
             "colours": [
@@ -1818,7 +1818,7 @@
         },
         {
             "id": "7a317099-ea5e-5392-a595-1aa81334270b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c187ac-6b33-4cf6-b407-1dfa265780e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c187ac-6b33-4cf6-b407-1dfa265780e6.jpg?1",
             "name": "Narset, Enlightened Master",
             "text": "",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "abc61539-34ee-5b31-a88d-c9b8841d776a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83ad5fa-b9b8-4c3f-bc42-3ff6282eb941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83ad5fa-b9b8-4c3f-bc42-3ff6282eb941.jpg?1",
             "name": "Oona, Queen of the Fae",
             "text": "",
             "colours": [
@@ -1896,7 +1896,7 @@
         },
         {
             "id": "cf265ce3-a76a-562d-a9f0-7720f22b0590",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd2c01-fb77-4079-b5cf-bcde816386c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcd2c01-fb77-4079-b5cf-bcde816386c9.jpg?1",
             "name": "Saskia the Unyielding",
             "text": "",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "a7d45e03-a1aa-527f-a5ab-5fd806111ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a898fbf-5c73-4a50-8bf5-126051747659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a898fbf-5c73-4a50-8bf5-126051747659.jpg?1",
             "name": "Arcbound Ravager",
             "text": "",
             "colours": [],
@@ -1968,7 +1968,7 @@
         },
         {
             "id": "08585c69-7aa0-540e-8474-c975207abd3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012fb2-9dbc-408a-b84b-1302b442f699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44012fb2-9dbc-408a-b84b-1302b442f699.jpg?1",
             "name": "Darksteel Colossus",
             "text": "",
             "colours": [],
@@ -1998,7 +1998,7 @@
         },
         {
             "id": "f9e17610-a7f2-5943-bd29-626453de5ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60107410-7076-4fcc-b1f7-123dd3b442b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60107410-7076-4fcc-b1f7-123dd3b442b0.jpg?1",
             "name": "Walking Ballista",
             "text": "",
             "colours": [],
@@ -2030,7 +2030,7 @@
         },
         {
             "id": "020c47a2-f45c-58ee-a8c0-722f8b9fb067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4391e8-8d3e-42d2-ab01-08fe68771ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4391e8-8d3e-42d2-ab01-08fe68771ed1.jpg?1",
             "name": "Squire",
             "text": "",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "a2bcb6ae-f8df-5fa5-9126-2434a5f475a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7aa8e1-ada6-491a-b96f-43e89dae7834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7aa8e1-ada6-491a-b96f-43e89dae7834.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -2097,7 +2097,7 @@
         },
         {
             "id": "348445c7-44e0-5231-a64f-37d6cd335bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9e8d45-a7e7-4131-9985-eaf693c1b55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9e8d45-a7e7-4131-9985-eaf693c1b55b.jpg?1",
             "name": "Goblin Snowman",
             "text": "",
             "colours": [
@@ -2130,7 +2130,7 @@
         },
         {
             "id": "c26de73e-8b35-53c9-aa17-c8f295185ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f2e82-4970-4298-a3a7-c42cb1780eb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f11f2e82-4970-4298-a3a7-c42cb1780eb5.jpg?1",
             "name": "Mudhole",
             "text": "",
             "colours": [
@@ -2161,7 +2161,7 @@
         },
         {
             "id": "f916309d-fabb-549a-a216-d5b788439fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4bf87b-1e31-4c09-b685-86592eb32be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4bf87b-1e31-4c09-b685-86592eb32be9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "aa42098a-51ee-5368-96e7-e61f82bce5a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f05fa-30e4-4b2c-9641-8a5847b59d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6f05fa-30e4-4b2c-9641-8a5847b59d65.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "76a81fd3-8410-581b-8c08-b796210d8126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed633b-6452-4a0c-b308-ac28ad438933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ed633b-6452-4a0c-b308-ac28ad438933.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "d599d800-2e6c-5833-a885-71253b320d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05712bcb-eb67-4e84-a640-7e507675756a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05712bcb-eb67-4e84-a640-7e507675756a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -2429,7 +2429,7 @@
         },
         {
             "id": "4cd1bf17-bd7d-58e3-ac4e-f03b8cd06e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed189e2b-a4e5-493b-9085-a5aae892e5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed189e2b-a4e5-493b-9085-a5aae892e5a8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -2493,7 +2493,7 @@
         },
         {
             "id": "b5fb8ec2-d763-53f2-9f39-8b54120bca1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6365e12-c470-40a2-95b0-827ec4404c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6365e12-c470-40a2-95b0-827ec4404c38.jpg?1",
             "name": "Heliod, God of the Sun",
             "text": "",
             "colours": [
@@ -2529,7 +2529,7 @@
         },
         {
             "id": "15fffe16-8007-5eba-ad0d-dccfab8ff28b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe0295f-c731-4e13-9edd-f0e9a9d81769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe0295f-c731-4e13-9edd-f0e9a9d81769.jpg?1",
             "name": "Karametra, God of Harvests",
             "text": "",
             "colours": [
@@ -2567,7 +2567,7 @@
         },
         {
             "id": "c5f9b56c-eada-5c69-981b-6d32ac432f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc3e4ba-726d-4ec5-be73-c68bc186fb2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc3e4ba-726d-4ec5-be73-c68bc186fb2f.jpg?1",
             "name": "Iroas, God of Victory",
             "text": "",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "6de61478-4cad-5f8b-98f1-9ddd23f5b823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bcfb09-ca60-405b-9603-eb3e4b2a8bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84bcfb09-ca60-405b-9603-eb3e4b2a8bd0.jpg?1",
             "name": "Thassa, God of the Sea",
             "text": "",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "1639b187-476f-5d5a-bf22-7e7d9a324a9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549057e-fb55-4752-903c-41355f9a0589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549057e-fb55-4752-903c-41355f9a0589.jpg?1",
             "name": "Ephara, God of the Polis",
             "text": "",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "dd196bd8-2a99-5335-9935-d0a4976540aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf153db-742a-42c0-bc8c-5093c1d6e734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf153db-742a-42c0-bc8c-5093c1d6e734.jpg?1",
             "name": "Kruphix, God of Horizons",
             "text": "",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "641dfec5-2976-5e62-9cc0-b4c8bda9f359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8bdb4c-2d68-4cb4-904f-1649427751dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8bdb4c-2d68-4cb4-904f-1649427751dc.jpg?1",
             "name": "Erebos, God of the Dead",
             "text": "",
             "colours": [
@@ -2753,7 +2753,7 @@
         },
         {
             "id": "8ae84b1a-0e5d-5b96-802a-529f558102d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f9e502-23a3-4f1c-af10-e6c48a5262b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f9e502-23a3-4f1c-af10-e6c48a5262b2.jpg?1",
             "name": "Phenax, God of Deception",
             "text": "",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "b17abbf5-8b0d-5723-9f9e-fb69d518ee12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380a687-c96b-4e1a-bfd9-3849d085b803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3380a687-c96b-4e1a-bfd9-3849d085b803.jpg?1",
             "name": "Athreos, God of Passage",
             "text": "",
             "colours": [
@@ -2829,7 +2829,7 @@
         },
         {
             "id": "67c99f0e-7735-5b1b-b99d-eef24d845dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2698e2d-16d8-4b76-923f-e18775104de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2698e2d-16d8-4b76-923f-e18775104de0.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "",
             "colours": [
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "43a82ca6-338d-5ef9-ae82-1ed44ebb6c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8df131-c29d-4181-8dc4-815a581b0209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8df131-c29d-4181-8dc4-815a581b0209.jpg?1",
             "name": "Mogis, God of Slaughter",
             "text": "",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "1890023b-f3ed-58bf-add9-a95760d1bbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c13445-60e3-43a0-a56a-de91c6442367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c13445-60e3-43a0-a56a-de91c6442367.jpg?1",
             "name": "Keranos, God of Storms",
             "text": "",
             "colours": [
@@ -2943,7 +2943,7 @@
         },
         {
             "id": "4b519479-1493-5758-9211-df4c7d3940b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ce5e5d-2be2-4cf1-8011-a3c79bf8a573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ce5e5d-2be2-4cf1-8011-a3c79bf8a573.jpg?1",
             "name": "Nylea, God of the Hunt",
             "text": "",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "184745b0-6ba3-5fc0-9304-8f6acd7c386f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e144aa4d-3ea7-44fb-b1cb-ad51cf84bba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e144aa4d-3ea7-44fb-b1cb-ad51cf84bba2.jpg?1",
             "name": "Xenagos, God of Revels",
             "text": "",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "276ea161-aa92-55e8-a716-f7299174eb62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109bfa3d-02e0-4395-bd6e-edaad77f25f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109bfa3d-02e0-4395-bd6e-edaad77f25f7.jpg?1",
             "name": "Pharika, God of Affliction",
             "text": "",
             "colours": [
@@ -3055,7 +3055,7 @@
         },
         {
             "id": "26bb9b31-fc82-54b3-b13e-56dd1dba312a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45184cd7-b037-4a85-a063-e622ca928d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45184cd7-b037-4a85-a063-e622ca928d17.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "fa340683-e523-511d-8c98-ea498d69da0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb94c1b-8002-4d79-add0-c4dfef9019ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb94c1b-8002-4d79-add0-c4dfef9019ee.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "20446d8e-c01e-5d05-93c1-488efb00087c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab06973-6440-4b12-8947-8c412500fa41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab06973-6440-4b12-8947-8c412500fa41.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "6787846a-9e3d-52cb-a190-24f29331c62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb3895-b64c-46ab-b704-3c46963920ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3eb3895-b64c-46ab-b704-3c46963920ba.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "1571957b-0497-5eb4-98ea-fa1a8773299b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370e6f6f-67a7-4eea-9a33-efbb64783e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/370e6f6f-67a7-4eea-9a33-efbb64783e4a.jpg?1",
             "name": "Ajani Steadfast",
             "text": "",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "e419bf41-b88c-5dba-9c8a-1d4cb1d073f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e724c648-0585-451f-afcd-7efff2521151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e724c648-0585-451f-afcd-7efff2521151.jpg?1",
             "name": "Domri Rade",
             "text": "",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "4d9c6f9c-67bb-5d10-a39c-b77234623cf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8320f71-e958-4e40-9304-bd115f29d67c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8320f71-e958-4e40-9304-bd115f29d67c.jpg?1",
             "name": "Tamiyo, Field Researcher",
             "text": "",
             "colours": [
@@ -3330,7 +3330,7 @@
         },
         {
             "id": "33721f15-5b41-5b3a-b430-89adada99a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d004e922-1f2b-4325-93f1-04a336192c06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d004e922-1f2b-4325-93f1-04a336192c06.jpg?1",
             "name": "Vraska, Golgari Queen",
             "text": "",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "af9a0ba0-d941-56c7-b479-da3c92994cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fc6412-df1c-4bfa-842b-8c3a6f14e19d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40fc6412-df1c-4bfa-842b-8c3a6f14e19d.jpg?1",
             "name": "Swan Song",
             "text": "",
             "colours": [
@@ -3400,7 +3400,7 @@
         },
         {
             "id": "1ef8afc8-77f4-58e7-9ba0-d78a7cb73a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfeeb64-0f86-45e9-97e3-dcec72683164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdfeeb64-0f86-45e9-97e3-dcec72683164.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "07992efb-4ddd-561a-a30c-1fa8a89e31c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb08b642-aff6-4c37-a952-f8ddcfc4767e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb08b642-aff6-4c37-a952-f8ddcfc4767e.jpg?1",
             "name": "Gilded Goose",
             "text": "",
             "colours": [
@@ -3470,7 +3470,7 @@
         },
         {
             "id": "d946e317-7f8d-5397-9a3a-963101b5c430",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7c9b54-0b40-4007-8d24-bc3945be319f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7c9b54-0b40-4007-8d24-bc3945be319f.jpg?1",
             "name": "Baleful Strix",
             "text": "",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "d1907fec-42d8-5100-a4b5-cb6e01d6a0fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebc97bd-508f-4af5-a308-46cb1f256534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ebc97bd-508f-4af5-a308-46cb1f256534.jpg?1",
             "name": "Dovescape",
             "text": "",
             "colours": [
@@ -3539,7 +3539,7 @@
         },
         {
             "id": "91addac9-2096-57a4-be4d-52c365c4fa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9008f826-9e24-4ba1-b17e-1638b7cdd78d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9008f826-9e24-4ba1-b17e-1638b7cdd78d.jpg?1",
             "name": "Rest in Peace",
             "text": "",
             "colours": [
@@ -3571,7 +3571,7 @@
         },
         {
             "id": "f288db5b-f80b-5d7b-bfaa-ed45910e6056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06025c01-1d70-4e8d-b030-60a773631b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06025c01-1d70-4e8d-b030-60a773631b54.jpg?1",
             "name": "Dig Through Time",
             "text": "",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "4f86556f-d146-5c8f-8101-88d3d155335b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8adb0c-a322-4447-bf2e-7a74e3b735c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d8adb0c-a322-4447-bf2e-7a74e3b735c4.jpg?1",
             "name": "Ancient Grudge",
             "text": "",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "cae4d1fa-6b49-5d7e-be34-f09268a0a787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19080c3f-67fa-4f98-9b5a-ede8579823d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19080c3f-67fa-4f98-9b5a-ede8579823d6.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -3670,7 +3670,7 @@
         },
         {
             "id": "f8aea3de-9ff7-5367-b45c-f538b99a25bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20726fa-d99b-4e3d-8054-b7d313ceb02f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20726fa-d99b-4e3d-8054-b7d313ceb02f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3739,7 +3739,7 @@
         },
         {
             "id": "942decbf-a723-5cd6-837e-318c0c4c62ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ebf9dd-2f3d-440c-9935-bb3903ca7452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32ebf9dd-2f3d-440c-9935-bb3903ca7452.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "20e9d603-6d6b-5967-9539-846658aed8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d433685-601d-4da2-9e4c-796646003ffe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d433685-601d-4da2-9e4c-796646003ffe.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "ca1bd514-26d2-578a-b3c5-65e9b5ea3108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0298749b-089e-49b9-8c89-02431a3d6457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0298749b-089e-49b9-8c89-02431a3d6457.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "223a63df-114e-5586-bdbe-4330491709ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8e7cd9-354d-4b2e-9823-79d6e8eed7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de8e7cd9-354d-4b2e-9823-79d6e8eed7e4.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "ddabe805-5f2f-529e-83f1-8b3a76ec57ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f4fbb8-c91a-4193-b6ef-0a3d4436caad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f4fbb8-c91a-4193-b6ef-0a3d4436caad.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "12e03067-275d-51c1-a3a0-19ca96a3840e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03683fbb-9843-4c14-bb95-387150e97c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03683fbb-9843-4c14-bb95-387150e97c90.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -4140,7 +4140,7 @@
         },
         {
             "id": "fb6d7f6f-e157-5693-b494-308c443bc6e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d52300-3fb9-49a6-8fe9-bd32adcbdb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d52300-3fb9-49a6-8fe9-bd32adcbdb4b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "0eddaaaf-3786-5eda-af80-c9a96e337e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e38987-e257-4da0-b270-bc48404947cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e38987-e257-4da0-b270-bc48404947cd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "113a66d3-5780-5a78-818e-e6d4af2dc568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c96a89-32e3-4412-9e79-51411362b9d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c96a89-32e3-4412-9e79-51411362b9d5.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "1f8ea226-550c-59df-ac54-ae49b84716dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ef813e-2bec-431f-b010-995791285d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ef813e-2bec-431f-b010-995791285d0a.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "6391a5e5-d41b-5a8f-85b2-746d411dac67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bb062-eb03-4d9a-b028-91c089442187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b5bb062-eb03-4d9a-b028-91c089442187.jpg?1",
             "name": "Opt",
             "text": "",
             "colours": [
@@ -4414,7 +4414,7 @@
         },
         {
             "id": "7dc1a803-e2b2-55d6-bb1c-3a9f1de6bd71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5427d8a6-ac9e-4e50-bd39-81713b2ade25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5427d8a6-ac9e-4e50-bd39-81713b2ade25.jpg?1",
             "name": "Fatal Push",
             "text": "",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "4a445e1e-95fb-52b1-a26d-b64592693a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec898bc9-9ab8-4394-8c4c-8d652f313919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec898bc9-9ab8-4394-8c4c-8d652f313919.jpg?1",
             "name": "Anger of the Gods",
             "text": "",
             "colours": [
@@ -4480,7 +4480,7 @@
         },
         {
             "id": "1625e47e-39eb-50b1-bcf8-1a19cc9b7c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098e528a-bd6c-41f3-a246-cba986c54776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098e528a-bd6c-41f3-a246-cba986c54776.jpg?1",
             "name": "Explore",
             "text": "",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "d4b7bdbd-8ff0-5054-b278-e022598a20db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9c1419-aa54-4dd3-8d7d-4e2f60e7f581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9c1419-aa54-4dd3-8d7d-4e2f60e7f581.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "",
             "colours": [
@@ -4546,7 +4546,7 @@
         },
         {
             "id": "e9764bed-301d-57dd-b894-7747d337971d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8acace-57fb-4759-b15e-f4a8be1d13eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8acace-57fb-4759-b15e-f4a8be1d13eb.jpg?1",
             "name": "Mistbind Clique",
             "text": "",
             "colours": [
@@ -4580,7 +4580,7 @@
         },
         {
             "id": "1f0edaff-6efb-506c-9033-5ad8705392ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650221f7-d935-498b-a9a1-ec23c89fc5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650221f7-d935-498b-a9a1-ec23c89fc5f8.jpg?1",
             "name": "Spellstutter Sprite",
             "text": "",
             "colours": [
@@ -4614,7 +4614,7 @@
         },
         {
             "id": "0d093ec1-249b-5c36-b575-4baa1a70e5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebe58d-0f94-47f7-b17b-0d9492b931d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebe58d-0f94-47f7-b17b-0d9492b931d5.jpg?1",
             "name": "Vendilion Clique",
             "text": "",
             "colours": [
@@ -4650,7 +4650,7 @@
         },
         {
             "id": "b65d2b26-bfda-5a14-bb4b-281d5b60ae96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50205489-2960-462c-a6cb-35a491dc54d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50205489-2960-462c-a6cb-35a491dc54d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -4714,7 +4714,7 @@
         },
         {
             "id": "8873b958-99d5-5059-b3f4-51479abf9dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830158d4-1105-4d4c-ae0a-b4cec5f9266b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830158d4-1105-4d4c-ae0a-b4cec5f9266b.jpg?1",
             "name": "Sower of Temptation",
             "text": "",
             "colours": [
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "9fa47a00-0798-5399-a029-cae37352fd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc1d7db-11a3-4ff9-8d27-1fe401053080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fc1d7db-11a3-4ff9-8d27-1fe401053080.jpg?1",
             "name": "Damnation",
             "text": "",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "87aacaac-e07e-59c7-b1cc-26cf2c511271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca3c93-ac49-4976-aa77-ee308b1c59bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ca3c93-ac49-4976-aa77-ee308b1c59bd.jpg?1",
             "name": "Enchanted Evening",
             "text": "",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "2866fcb3-bbf1-51f1-9f29-37b317b547b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321aa38-7aaf-48fd-b516-18e702fbddef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321aa38-7aaf-48fd-b516-18e702fbddef.jpg?1",
             "name": "Hallowed Fountain",
             "text": "",
             "colours": [],
@@ -4848,7 +4848,7 @@
         },
         {
             "id": "35588b8c-73da-5f08-9c34-a59951479df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef01b3-93f7-41e8-834d-9f6768e3b16c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ef01b3-93f7-41e8-834d-9f6768e3b16c.jpg?1",
             "name": "Watery Grave",
             "text": "",
             "colours": [],
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "fe8ba661-8169-5d62-902a-86c3ee206b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1716b4dd-9045-462b-b053-72de450a8cde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1716b4dd-9045-462b-b053-72de450a8cde.jpg?1",
             "name": "Blood Crypt",
             "text": "",
             "colours": [],
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "5d903efa-c338-5459-819f-01deb46e0039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acf970d-d2d7-413d-aba7-587ee53d8d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acf970d-d2d7-413d-aba7-587ee53d8d5c.jpg?1",
             "name": "Stomping Ground",
             "text": "",
             "colours": [],
@@ -4947,7 +4947,7 @@
         },
         {
             "id": "bb3bf815-6e8b-5cff-ac38-bef89ec3f35a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a3039d-46cd-4a51-b726-6eb0b485c9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a3039d-46cd-4a51-b726-6eb0b485c9c5.jpg?1",
             "name": "Temple Garden",
             "text": "",
             "colours": [],
@@ -4980,7 +4980,7 @@
         },
         {
             "id": "1a74f3aa-ba73-5f54-8814-cd1072b073d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c39866-98c2-4c60-98e1-eaf8e40b2d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c39866-98c2-4c60-98e1-eaf8e40b2d29.jpg?1",
             "name": "Godless Shrine",
             "text": "",
             "colours": [],
@@ -5013,7 +5013,7 @@
         },
         {
             "id": "b2231b85-4504-56f9-a829-21972e69d0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516b248-c0be-4c49-83ab-393354c33563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d516b248-c0be-4c49-83ab-393354c33563.jpg?1",
             "name": "Steam Vents",
             "text": "",
             "colours": [],
@@ -5046,7 +5046,7 @@
         },
         {
             "id": "3c36da14-f58f-5fb9-8033-0f37fcd90bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc75949-0bd1-4cd9-9e66-6624dcd41872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc75949-0bd1-4cd9-9e66-6624dcd41872.jpg?1",
             "name": "Overgrown Tomb",
             "text": "",
             "colours": [],
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "369893f8-85e4-5a1c-8d7e-6cfc0741670c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e55b85-92c1-4b83-9a9d-4afb8e938e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e55b85-92c1-4b83-9a9d-4afb8e938e4f.jpg?1",
             "name": "Sacred Foundry",
             "text": "",
             "colours": [],
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "e8b6f485-ed96-5d8d-9e31-38f74a725a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19477aca-b8db-4061-9a78-ebb189a9df22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19477aca-b8db-4061-9a78-ebb189a9df22.jpg?1",
             "name": "Breeding Pool",
             "text": "",
             "colours": [],
@@ -5145,7 +5145,7 @@
         },
         {
             "id": "473b3896-44de-5ddf-88fb-afec760c379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cbcf51-3824-4ab3-89e3-cdcc1a0c7267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cbcf51-3824-4ab3-89e3-cdcc1a0c7267.jpg?1",
             "name": "Necrotic Ooze",
             "text": "",
             "colours": [
@@ -5178,7 +5178,7 @@
         },
         {
             "id": "4f83eed0-9565-5f56-9354-67f69fc9877d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6bd3fa-0d07-4519-b67f-67867ad13c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6bd3fa-0d07-4519-b67f-67867ad13c89.jpg?1",
             "name": "Acidic Slime",
             "text": "",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "1d697a84-f961-5999-99af-75ba182309ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae57dc27-539b-45f2-a18a-ca1f699f645d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae57dc27-539b-45f2-a18a-ca1f699f645d.jpg?1",
             "name": "Scavenging Ooze",
             "text": "",
             "colours": [
@@ -5244,7 +5244,7 @@
         },
         {
             "id": "81e80eb8-bbc0-5727-a0b0-d0d4245fb72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142076ee-870e-4962-8471-be4ae2e6e07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142076ee-870e-4962-8471-be4ae2e6e07c.jpg?1",
             "name": "The Mimeoplasm",
             "text": "",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "8a11fe5f-2a95-5ee0-92d4-21be912dcb24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e640664f-5cc7-4970-b966-6e6e5ae09c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e640664f-5cc7-4970-b966-6e6e5ae09c5a.jpg?1",
             "name": "Voidslime",
             "text": "",
             "colours": [
@@ -5318,7 +5318,7 @@
         },
         {
             "id": "a129a845-b1c4-5640-9eef-3032ef4b3780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd79be1-3e84-41a3-89ae-b1132cb31ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd79be1-3e84-41a3-89ae-b1132cb31ed9.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -5353,7 +5353,7 @@
         },
         {
             "id": "b33c751e-6971-5c4f-a983-99edbcb9b506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00efb55-a859-408c-b727-6914584c06d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00efb55-a859-408c-b727-6914584c06d2.jpg?1",
             "name": "Assassin's Trophy",
             "text": "",
             "colours": [
@@ -5386,7 +5386,7 @@
         },
         {
             "id": "909b95a4-635e-5cb3-af25-fa29d4b7edf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d00d0f-8838-4fd0-b058-7039301af338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d00d0f-8838-4fd0-b058-7039301af338.jpg?1",
             "name": "Decimate",
             "text": "",
             "colours": [
@@ -5419,7 +5419,7 @@
         },
         {
             "id": "3394fced-9fef-52e3-966d-45b3dc9d18be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf26b-d9cd-4aa6-a832-793b8631d681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15bf26b-d9cd-4aa6-a832-793b8631d681.jpg?1",
             "name": "Dreadbore",
             "text": "",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "e579e030-1eb4-55c2-a441-54f9fa5212f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048c829a-3f14-493d-b961-c7fb9cd23613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048c829a-3f14-493d-b961-c7fb9cd23613.jpg?1",
             "name": "Thraximundar",
             "text": "",
             "colours": [
@@ -5492,7 +5492,7 @@
         },
         {
             "id": "b2fdd701-c62f-5c47-a88b-70ecc3324907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8e78b3-3232-4d48-9d6c-540951a0330e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8e78b3-3232-4d48-9d6c-540951a0330e.jpg?1",
             "name": "Greymond, Avacyn's Stalwart",
             "text": "",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "321f9489-2946-56bf-a06c-9218337e52a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bffb892-e5dc-413d-924e-b9bda7bf7100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bffb892-e5dc-413d-924e-b9bda7bf7100.jpg?1",
             "name": "Hansk, Slayer Zealot",
             "text": "",
             "colours": [
@@ -5566,7 +5566,7 @@
         },
         {
             "id": "555fbe91-5eea-5c5b-8e53-4dc25cc844dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5df29a-af3b-4acc-8312-f2024ab039e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5df29a-af3b-4acc-8312-f2024ab039e0.jpg?1",
             "name": "Gregor, Shrewd Magistrate",
             "text": "",
             "colours": [
@@ -5604,7 +5604,7 @@
         },
         {
             "id": "ece715c0-9621-5048-8973-7df0a1b85386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c68c630-c0e1-4e94-8352-b65631cc2caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c68c630-c0e1-4e94-8352-b65631cc2caa.jpg?1",
             "name": "Enkira, Hostile Scavenger",
             "text": "",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "cb04c4bc-0a19-5261-9456-686b30f0ffe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d03f86-5219-4456-8136-802699ff26d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d03f86-5219-4456-8136-802699ff26d3.jpg?1",
             "name": "Malik, Grim Manipulator",
             "text": "",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "15280321-c2d7-5ccc-b182-9045301d555f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4800ebc2-d5a7-4c26-a2f7-943a540ae47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4800ebc2-d5a7-4c26-a2f7-943a540ae47e.jpg?1",
             "name": "Admonition Angel",
             "text": "",
             "colours": [
@@ -5716,7 +5716,7 @@
         },
         {
             "id": "4de2c651-9c41-5c2b-9426-106f5b280c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61514906-0041-49b7-8990-0643dd3431f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61514906-0041-49b7-8990-0643dd3431f0.jpg?1",
             "name": "Roil Elemental",
             "text": "",
             "colours": [
@@ -5750,7 +5750,7 @@
         },
         {
             "id": "00c7b274-c16e-5cad-93a2-619585cb1afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db5cf4-e023-4bd8-9f51-4dc42957007e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27db5cf4-e023-4bd8-9f51-4dc42957007e.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "9216c4a1-67bd-5dfd-9ac0-7fc7066fbc13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abab3d4-d525-41bf-85ee-fba7f999001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3abab3d4-d525-41bf-85ee-fba7f999001f.jpg?1",
             "name": "Warren Instigator",
             "text": "",
             "colours": [
@@ -5821,7 +5821,7 @@
         },
         {
             "id": "4c9bb394-0501-59fb-a0e0-c5a069593d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43add9-f948-41fe-b40c-e1d357db5f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c43add9-f948-41fe-b40c-e1d357db5f05.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "",
             "colours": [
@@ -5855,7 +5855,7 @@
         },
         {
             "id": "09be9392-39b1-5901-bcc5-0bdfd73f3fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27197660-8489-419b-9ad6-29a8713e4673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27197660-8489-419b-9ad6-29a8713e4673.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "",
             "colours": [
@@ -5894,7 +5894,7 @@
         },
         {
             "id": "e771d473-2b2e-54c9-824e-1e309cdf42ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58cb4d-2091-40c8-b97c-09bf9c022a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d58cb4d-2091-40c8-b97c-09bf9c022a8b.jpg?1",
             "name": "Demonlord Belzenlok",
             "text": "",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "77d661e7-b0e0-50b5-ba7f-5c2f28a27052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624eff1-9347-4a99-8986-a2312258791c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a624eff1-9347-4a99-8986-a2312258791c.jpg?1",
             "name": "Griselbrand",
             "text": "",
             "colours": [
@@ -5971,7 +5971,7 @@
         },
         {
             "id": "eeeea359-07bc-5a6e-937a-c581e6097d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c506f57a-e8b9-410f-9b7e-086900e26e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c506f57a-e8b9-410f-9b7e-086900e26e46.jpg?1",
             "name": "Griselbrand",
             "text": "",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "4a7a7ea9-ed6f-5412-89bf-97ad09184ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57c5ab1-3a36-47eb-8cf9-66b0c59d3e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57c5ab1-3a36-47eb-8cf9-66b0c59d3e03.jpg?1",
             "name": "Liliana's Contract",
             "text": "",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "5d79457e-d198-57cc-b079-347e4fa8b00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e5c89f-e181-4a77-8127-6afad5354004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60e5c89f-e181-4a77-8127-6afad5354004.jpg?1",
             "name": "Liliana's Contract",
             "text": "",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "2e5cc393-c33a-5baa-b229-35f04f363338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615a6845-f58a-4ee5-aa83-a5747b890140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/615a6845-f58a-4ee5-aa83-a5747b890140.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "",
             "colours": [
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "2108ded8-5fa6-5b26-a53c-d4317d6b37e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37f93d4-166a-41cd-86b2-0eeeae33ff9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37f93d4-166a-41cd-86b2-0eeeae33ff9d.jpg?1",
             "name": "Kothophed, Soul Hoarder",
             "text": "",
             "colours": [
@@ -6151,7 +6151,7 @@
         },
         {
             "id": "49dff80a-61b3-5550-af95-8d3cce7686e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb98f5c-9ef2-4549-9603-814726f1ffcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb98f5c-9ef2-4549-9603-814726f1ffcc.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "",
             "colours": [
@@ -6189,7 +6189,7 @@
         },
         {
             "id": "3f70b4a7-2f84-5610-a256-6c6bbb5796c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bc7380-e417-4f30-a4aa-356d782b5e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0bc7380-e417-4f30-a4aa-356d782b5e4d.jpg?1",
             "name": "Razaketh, the Foulblooded",
             "text": "",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "f5016e90-917e-5a9a-9740-60e4775e811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f4627-58ab-45c8-b31b-eaa52dad33fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59f4627-58ab-45c8-b31b-eaa52dad33fc.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "ffda0b30-2c36-57bc-a0b3-951a9c178e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09084e38-195a-45d6-a245-1c6d3e86500f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09084e38-195a-45d6-a245-1c6d3e86500f.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "",
             "colours": [
@@ -6294,7 +6294,7 @@
         },
         {
             "id": "b91834a6-59ff-5774-bc56-25c3b0e2c050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba6a508-3286-4938-b0a5-94b794ab6456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba6a508-3286-4938-b0a5-94b794ab6456.jpg?1",
             "name": "Collected Company",
             "text": "",
             "colours": [
@@ -6325,7 +6325,7 @@
         },
         {
             "id": "15d2153c-840b-54b3-a740-faa289453e81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311af3f7-463b-4fe0-aefc-5cd26a5fbd3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311af3f7-463b-4fe0-aefc-5cd26a5fbd3d.jpg?1",
             "name": "Amulet of Vigor",
             "text": "",
             "colours": [],
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "afddf66d-0d75-5ab4-8bab-1026877a5fa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8619034-173c-4950-a0b4-1ae1dcfd0bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8619034-173c-4950-a0b4-1ae1dcfd0bc5.jpg?1",
             "name": "Balance",
             "text": "",
             "colours": [
@@ -6384,7 +6384,7 @@
         },
         {
             "id": "85041861-3d64-544b-8aa2-97619186a8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0da5b-0916-4dd6-99a2-a58e9d83bb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0da5b-0916-4dd6-99a2-a58e9d83bb26.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "b2860b41-ceb3-5ea8-b9ca-17b49b167c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5932f2dc-3bb6-4f5e-8e8d-c62e7413ac0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5932f2dc-3bb6-4f5e-8e8d-c62e7413ac0a.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "67e1f03c-37c4-5752-9ee2-ac5049cb0a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0003aa31-d42e-4972-9fb9-086aefe29a2c.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "ca32c6fd-5119-5d34-b8b0-b0e7d23cb6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a509149-9864-4622-8122-21a723defaa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a509149-9864-4622-8122-21a723defaa8.jpg?1",
             "name": "Howling Mine",
             "text": "",
             "colours": [],
@@ -6521,7 +6521,7 @@
         },
         {
             "id": "da44e28c-7ea3-5ae5-89ad-3235f0504071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53f7e3-f76a-440b-8c84-994d378bda97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53f7e3-f76a-440b-8c84-994d378bda97.jpg?1",
             "name": "Wasteland",
             "text": "",
             "colours": [],
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "4472fc52-ef97-5691-9a96-348c28a0c8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caff117f-844b-4d11-a104-930d7f238114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caff117f-844b-4d11-a104-930d7f238114.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "0131c33e-6cb8-53f7-911e-a2c82b8fc8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382c608-b3db-4112-b0c3-0e12199c4898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382c608-b3db-4112-b0c3-0e12199c4898.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -6615,7 +6615,7 @@
         },
         {
             "id": "a170ec3d-a5a9-5431-86db-41423cb63de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ad5bcb-7bdc-44ec-be67-f4dd49a17450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56ad5bcb-7bdc-44ec-be67-f4dd49a17450.jpg?1",
             "name": "Decree of Pain",
             "text": "",
             "colours": [
@@ -6646,7 +6646,7 @@
         },
         {
             "id": "3365882c-9c59-5e46-915b-739790c21527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e57561-17d4-48db-8e40-f41019010bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e57561-17d4-48db-8e40-f41019010bc9.jpg?1",
             "name": "Gamble",
             "text": "",
             "colours": [
@@ -6677,7 +6677,7 @@
         },
         {
             "id": "646643b3-eece-5c2d-93cc-c66f0283cf37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9f5e0c-8bf4-46ab-ad79-332ceeaed3d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9f5e0c-8bf4-46ab-ad79-332ceeaed3d5.jpg?1",
             "name": "Nature's Lore",
             "text": "",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "ad022f20-e0cd-58b1-8cf2-2bd7f82cfcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58d181-500f-4698-a2ba-e378e5335676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58d181-500f-4698-a2ba-e378e5335676.jpg?1",
             "name": "Soul-Scar Mage",
             "text": "",
             "colours": [
@@ -6745,7 +6745,7 @@
         },
         {
             "id": "c6f713d7-3cda-5dba-b2e0-21d7912bba6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e22287-21c5-4733-a527-b176fbf3725d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e22287-21c5-4733-a527-b176fbf3725d.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "",
             "colours": [
@@ -6781,7 +6781,7 @@
         },
         {
             "id": "a4049112-c629-5d16-ac75-f524c43b25fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b064748-515a-4234-ad00-8a735d7aa385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b064748-515a-4234-ad00-8a735d7aa385.jpg?1",
             "name": "Sakura-Tribe Elder",
             "text": "",
             "colours": [
@@ -6816,7 +6816,7 @@
         },
         {
             "id": "7c8a6f00-961f-57ed-ba02-2531276c5d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1320b1-3eac-4c5a-9f75-6fdff3cc2639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1320b1-3eac-4c5a-9f75-6fdff3cc2639.jpg?1",
             "name": "Spell Queller",
             "text": "",
             "colours": [
@@ -6852,7 +6852,7 @@
         },
         {
             "id": "3ab4b358-19c1-5a6f-bfb6-3ee53a8be282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23caa9ce-057a-40f6-a9fe-073c60b69fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23caa9ce-057a-40f6-a9fe-073c60b69fc2.jpg?1",
             "name": "Metallic Mimic",
             "text": "",
             "colours": [],
@@ -6883,7 +6883,7 @@
         },
         {
             "id": "94b7fa3c-7ff2-5fd6-9fe1-a3fd0bf63804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320d7e7-aa1e-4c00-9b45-525352393e00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a320d7e7-aa1e-4c00-9b45-525352393e00.jpg?1",
             "name": "Chatter of the Squirrel",
             "text": "",
             "colours": [
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "80e83a50-39e3-58d6-9b74-bdec1525a7e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ea2f2d-14ca-4b57-b973-5ce7db35bebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ea2f2d-14ca-4b57-b973-5ce7db35bebf.jpg?1",
             "name": "Krosan Beast",
             "text": "",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "4a5eb51d-dfda-56a8-bde0-357f89081e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff276249-e7ca-4264-9039-d32b38cc4a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff276249-e7ca-4264-9039-d32b38cc4a7e.jpg?1",
             "name": "Squirrel Mob",
             "text": "",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "d7b68e45-69c2-5514-be55-487befc5281a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881ed685-bf7c-4ba3-8401-2ead8c24ca0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/881ed685-bf7c-4ba3-8401-2ead8c24ca0f.jpg?1",
             "name": "Squirrel Wrangler",
             "text": "",
             "colours": [
@@ -7015,7 +7015,7 @@
         },
         {
             "id": "0e112855-529f-5fd8-8c7c-8792d8acf69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db231a23-c556-4667-bf83-9216f13b9618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db231a23-c556-4667-bf83-9216f13b9618.jpg?1",
             "name": "Swarmyard",
             "text": "",
             "colours": [],
@@ -7042,7 +7042,7 @@
         },
         {
             "id": "2d5fc9f9-b5a2-5d13-afbd-60fef514a001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c385447a-f56d-4b65-a090-bae48b0313c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c385447a-f56d-4b65-a090-bae48b0313c0.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -7079,7 +7079,7 @@
         },
         {
             "id": "bee111e0-5d94-505f-8e29-80841d9a4b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97594249-704b-4ef2-a86a-d1442d0fe689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97594249-704b-4ef2-a86a-d1442d0fe689.jpg?1",
             "name": "Chromatic Lantern",
             "text": "",
             "colours": [],
@@ -7107,7 +7107,7 @@
         },
         {
             "id": "e5db05b7-1076-55b0-9099-f3808f7204ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4e5a4-dcd0-4565-afcb-42a089f1559a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4e5a4-dcd0-4565-afcb-42a089f1559a.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -7137,7 +7137,7 @@
         },
         {
             "id": "7f1be45c-5838-5e49-a0d6-9e8ba5387444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dddc050-56ed-43b4-a34d-fea76f3e8a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dddc050-56ed-43b4-a34d-fea76f3e8a55.jpg?1",
             "name": "Darksteel Ingot",
             "text": "",
             "colours": [],
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "c1a02626-6975-5976-aab8-c7d0a1bc5895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed78861-4877-4f27-b900-981af79c2450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed78861-4877-4f27-b900-981af79c2450.jpg?1",
             "name": "Gilded Lotus",
             "text": "",
             "colours": [],
@@ -7193,7 +7193,7 @@
         },
         {
             "id": "3cf62271-58d7-554d-a94b-31ff0c580799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dad59-27a4-4dbb-bec8-f0683d6e2a67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83dad59-27a4-4dbb-bec8-f0683d6e2a67.jpg?1",
             "name": "Exquisite Blood",
             "text": "",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "2fcf8f72-6010-57ab-a620-21b358e34dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f415a76e-6b35-442e-a2e1-9e368f550566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f415a76e-6b35-442e-a2e1-9e368f550566.jpg?1",
             "name": "Night's Whisper",
             "text": "",
             "colours": [
@@ -7259,7 +7259,7 @@
         },
         {
             "id": "df33fdfa-bd34-5864-9645-798f19f85dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097b876-ffb4-4388-beb1-d25d887593b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3097b876-ffb4-4388-beb1-d25d887593b9.jpg?1",
             "name": "Phyrexian Tower",
             "text": "",
             "colours": [],
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "4e42db45-2263-575e-a9f7-bd331e81ca05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436e594-ec27-465d-a570-7645ddbbc2f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b436e594-ec27-465d-a570-7645ddbbc2f7.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "dc360824-ea98-57f1-a332-f2c14e0ee5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5341194-90c3-4554-8c45-f4442ad2eef0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5341194-90c3-4554-8c45-f4442ad2eef0.jpg?1",
             "name": "Jin-Gitaxias, Core Augur",
             "text": "",
             "colours": [
@@ -7367,7 +7367,7 @@
         },
         {
             "id": "5b3b1901-c208-5d90-8831-2575ab911d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18206ae6-08e2-4ad2-bc0a-6626a89b9516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18206ae6-08e2-4ad2-bc0a-6626a89b9516.jpg?1",
             "name": "Sheoldred, Whispering One",
             "text": "",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "f694951f-53c0-5683-bdef-0b37839ef305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60f6330-f1ce-4a39-ab58-49bb5fa96081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60f6330-f1ce-4a39-ab58-49bb5fa96081.jpg?1",
             "name": "Urabrask the Hidden",
             "text": "",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "08d693b7-26e7-50c8-a7f7-e4827e99ace3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603a7305-c036-47ef-8926-25b66a7905df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603a7305-c036-47ef-8926-25b66a7905df.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "",
             "colours": [
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "f581df2b-2693-504e-a9ce-92fe4c47aba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aae46bb-15d3-4049-9eae-86c6c5b5dcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aae46bb-15d3-4049-9eae-86c6c5b5dcff.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "",
             "colours": [
@@ -7517,7 +7517,7 @@
         },
         {
             "id": "eef6958f-5124-5b44-b55c-e8c2113c2b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab03d01-ec92-473d-b983-18cf5f06ff39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab03d01-ec92-473d-b983-18cf5f06ff39.jpg?1",
             "name": "Goblin Rabblemaster",
             "text": "",
             "colours": [
@@ -7552,7 +7552,7 @@
         },
         {
             "id": "7a9411b2-a6f4-5277-91e6-e4a5ad7e32e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef14b6-e604-40c3-bf7e-587a192a68bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ef14b6-e604-40c3-bf7e-587a192a68bc.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "",
             "colours": [
@@ -7587,7 +7587,7 @@
         },
         {
             "id": "38fde9cc-e511-511e-8379-0201f289fcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8cd7a1-3f79-405b-8930-2206f32c2035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8cd7a1-3f79-405b-8930-2206f32c2035.jpg?1",
             "name": "Boros Charm",
             "text": "",
             "colours": [
@@ -7623,7 +7623,7 @@
         },
         {
             "id": "c220d9d3-1586-58c9-b500-09ce1a977f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2178-8e1f-4d64-9711-5b7264632200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2178-8e1f-4d64-9711-5b7264632200.jpg?1",
             "name": "Gisela, Blade of Goldnight",
             "text": "",
             "colours": [
@@ -7661,7 +7661,7 @@
         },
         {
             "id": "fd129eaf-9100-5cb5-a16e-5b70cb049343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8073af-bd3d-48f1-99d4-d216e3f1ff60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8073af-bd3d-48f1-99d4-d216e3f1ff60.jpg?1",
             "name": "Frost Titan",
             "text": "",
             "colours": [
@@ -7695,7 +7695,7 @@
         },
         {
             "id": "93c87e31-3c6a-5630-b6bf-e90d5b5245ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3377096-d89c-408f-ab0b-6f96f1b240f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3377096-d89c-408f-ab0b-6f96f1b240f6.jpg?1",
             "name": "Primeval Titan",
             "text": "",
             "colours": [
@@ -7731,7 +7731,7 @@
         },
         {
             "id": "5dbed221-602d-51d7-aeca-e73e6002bfa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b4542-bf78-4450-a4e0-bf757445c3c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f3b4542-bf78-4450-a4e0-bf757445c3c3.jpg?1",
             "name": "Uro, Titan of Nature's Wrath",
             "text": "",
             "colours": [
@@ -7770,7 +7770,7 @@
         },
         {
             "id": "50157c38-6e9a-5cfb-9dd0-3d39031614f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1a018f-ce08-428b-9be2-937204dd25c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1a018f-ce08-428b-9be2-937204dd25c2.jpg?1",
             "name": "Grave Titan",
             "text": "",
             "colours": [
@@ -7804,7 +7804,7 @@
         },
         {
             "id": "d533b30f-e91c-5369-82ee-130022630cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be293048-1df6-4df4-869c-b3b19534b35b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be293048-1df6-4df4-869c-b3b19534b35b.jpg?1",
             "name": "Inferno Titan",
             "text": "",
             "colours": [
@@ -7838,7 +7838,7 @@
         },
         {
             "id": "ec988c5c-7f1c-5661-a479-8ac49058b75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6186ca35-4d28-4176-aaff-5b384a688aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6186ca35-4d28-4176-aaff-5b384a688aa6.jpg?1",
             "name": "Kroxa, Titan of Death's Hunger",
             "text": "",
             "colours": [
@@ -7877,7 +7877,7 @@
         },
         {
             "id": "bcd70cb6-cc76-5b20-8448-a5f96783dba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe951-4820-4555-8cee-621c66ed8620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fe951-4820-4555-8cee-621c66ed8620.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -7911,7 +7911,7 @@
         },
         {
             "id": "29a577ee-1af6-5b8d-a08d-6ec810fa7fdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7d9a4-c36e-4989-b448-fa56705a4aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7d9a4-c36e-4989-b448-fa56705a4aa6.jpg?1",
             "name": "Well of Lost Dreams",
             "text": "",
             "colours": [],
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "2bb3c4b8-2677-5713-96da-2358e6575c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2e5b6e-ca2e-4149-bad6-784f40afa9fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2e5b6e-ca2e-4149-bad6-784f40afa9fb.jpg?1",
             "name": "Frantic Search",
             "text": "",
             "colours": [
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "5e80dc18-f61b-5d43-99bb-cb327a3e9573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50093179-2369-49db-a66d-ce3225363f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50093179-2369-49db-a66d-ce3225363f5d.jpg?1",
             "name": "Intruder Alarm",
             "text": "",
             "colours": [
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "7411bb46-acbd-59e3-861e-9f4cf8514caa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e093eb73-3780-4735-9e6b-fb4f621978e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e093eb73-3780-4735-9e6b-fb4f621978e9.jpg?1",
             "name": "Shelldock Isle",
             "text": "",
             "colours": [],
@@ -8037,7 +8037,7 @@
         },
         {
             "id": "40a5c908-c467-54cf-90cb-4ebf4d8a679d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e62436-8e4a-48d0-bcb2-fa650b1aafbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e62436-8e4a-48d0-bcb2-fa650b1aafbb.jpg?1",
             "name": "Gravecrawler",
             "text": "",
             "colours": [
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "431e3aa8-3ae3-50ed-b888-f6996e304a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fe57c2-68c6-44c9-ac2b-9d531c0d000c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7fe57c2-68c6-44c9-ac2b-9d531c0d000c.jpg?1",
             "name": "Liliana, Death's Majesty",
             "text": "",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "66b39666-bf65-5040-b9e7-8c4fdb1c8dcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ed0f96-7dc2-47c0-9cac-d24dab264e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4ed0f96-7dc2-47c0-9cac-d24dab264e05.jpg?1",
             "name": "Rise of the Dark Realms",
             "text": "",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "91e8dcc3-d0d2-5f91-aa3a-adabc4df9112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -8174,7 +8174,7 @@
         },
         {
             "id": "bcedbe0a-3778-57f2-a56f-acca400eb720",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/6/06251176-d20f-4960-ac73-135e44b77c83.jpg?1",
             "name": "Brazen Borrower // Petty Theft",
             "text": "",
             "colours": [
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "d27a5b13-44e6-5b48-a6d5-055f20a1a237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3189e68-623f-4da4-baa7-a2912db145e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3189e68-623f-4da4-baa7-a2912db145e1.jpg?1",
             "name": "Vindictive Lich",
             "text": "",
             "colours": [
@@ -8243,7 +8243,7 @@
         },
         {
             "id": "916bc664-8aa5-52c8-b438-d50003e7537c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf037a6-9004-49a3-b4a2-2c814fc63d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf037a6-9004-49a3-b4a2-2c814fc63d1c.jpg?1",
             "name": "Meandering Towershell",
             "text": "",
             "colours": [
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "a6c5dba0-94f7-5c09-91d2-b345bebf13b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9b8337-5e55-4f6b-a5c5-ecbd112408eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9b8337-5e55-4f6b-a5c5-ecbd112408eb.jpg?1",
             "name": "Ohran Frostfang",
             "text": "",
             "colours": [
@@ -8313,7 +8313,7 @@
         },
         {
             "id": "9bfa8e5e-988e-5d3f-8088-d95f88437f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1e3f3-a9b8-4185-9be9-798fe3cddd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e1e3f3-a9b8-4185-9be9-798fe3cddd5c.jpg?1",
             "name": "Thragtusk",
             "text": "",
             "colours": [
@@ -8347,7 +8347,7 @@
         },
         {
             "id": "56b7949c-b860-5112-876c-62e41a03829e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fe1359-c78c-41fb-95d9-fcc7c46f0bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34fe1359-c78c-41fb-95d9-fcc7c46f0bb1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "4eeb9934-5d5e-58da-98d5-6393743e23b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaf2e2-b4af-4a84-ab27-d8a6b40c9552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbaf2e2-b4af-4a84-ab27-d8a6b40c9552.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -8481,7 +8481,7 @@
         },
         {
             "id": "e5dcf29e-36b2-55f0-bdd5-bcf51a0310bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b53b7-4a20-48eb-a0bd-4ddf40aae740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b53b7-4a20-48eb-a0bd-4ddf40aae740.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -8545,7 +8545,7 @@
         },
         {
             "id": "44db6c8e-d75e-50e2-b2e8-d3e2532cd8a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277af45a-1f91-4fd4-804d-5b34241386b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/277af45a-1f91-4fd4-804d-5b34241386b8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8619,7 +8619,7 @@
         },
         {
             "id": "572efbfb-efcf-50ce-b0ba-177e9a667a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6cdc-f92f-497c-8cd9-b69586098512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9e6cdc-f92f-497c-8cd9-b69586098512.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8684,7 +8684,7 @@
         },
         {
             "id": "659121fe-9953-5360-8826-62905675d5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882d3475-4fb9-49ad-bc19-e6331428701b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/882d3475-4fb9-49ad-bc19-e6331428701b.jpg?1",
             "name": "Shalai, Voice of Plenty",
             "text": "",
             "colours": [
@@ -8721,7 +8721,7 @@
         },
         {
             "id": "b589541a-9fb6-51f3-a146-790fbe5ede7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d02bf4-eefd-4916-ab5a-cc16b3e6a186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d02bf4-eefd-4916-ab5a-cc16b3e6a186.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -8755,7 +8755,7 @@
         },
         {
             "id": "48c9c472-8d88-5f46-93ac-07b33985d26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a4b1e-f6c0-489b-878b-533dd46cdd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9a4b1e-f6c0-489b-878b-533dd46cdd1a.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "cc21ecef-9558-59db-aa51-963f2e850e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67851439-26d6-422d-9bce-8c9c25ffc0c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67851439-26d6-422d-9bce-8c9c25ffc0c2.jpg?1",
             "name": "Kaya, Ghost Assassin",
             "text": "",
             "colours": [
@@ -8825,7 +8825,7 @@
         },
         {
             "id": "24213593-cac5-54f2-a146-dc539d051b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6721431-418e-4c92-818a-50417066c229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6721431-418e-4c92-818a-50417066c229.jpg?1",
             "name": "Teferi, Hero of Dominaria",
             "text": "",
             "colours": [
@@ -8863,7 +8863,7 @@
         },
         {
             "id": "34b8fdb8-5d8d-5d67-ba31-de9528757c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf22be9-bf1a-48ec-a825-d19504f9dfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf22be9-bf1a-48ec-a825-d19504f9dfcc.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "b4f357f8-fec9-5687-90ff-c1373fcfa123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35425069-0d8d-4a02-ba7c-50e7abfecb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35425069-0d8d-4a02-ba7c-50e7abfecb4c.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -8928,7 +8928,7 @@
         },
         {
             "id": "f1dfb3fc-ec30-5194-9169-ab9a77186466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3fa12-531b-41a1-a71b-a1a2670cf2db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa3fa12-531b-41a1-a71b-a1a2670cf2db.jpg?1",
             "name": "Dack Fayden",
             "text": "",
             "colours": [
@@ -8967,7 +8967,7 @@
         },
         {
             "id": "ac2baf81-9f79-5bba-a293-95ac780e535e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066cee3d-1bc9-43bb-a1e5-70256875eb9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066cee3d-1bc9-43bb-a1e5-70256875eb9b.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -9006,7 +9006,7 @@
         },
         {
             "id": "33a31e70-8084-5a9d-bd51-3a0fcd733862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefa41f-2970-4312-b0ec-5596fcc49f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefa41f-2970-4312-b0ec-5596fcc49f02.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "c6098fb4-015e-5b43-b79b-85a3abeb213f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a19fcc-f465-43ac-8d08-ba0d2345b66d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a19fcc-f465-43ac-8d08-ba0d2345b66d.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "8062bdc1-f68f-57fb-a67f-82cbc58c731f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd07b50a-0bd7-49fa-9ada-96a8f96a62cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd07b50a-0bd7-49fa-9ada-96a8f96a62cc.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9173,7 +9173,7 @@
         },
         {
             "id": "200ce942-11de-50d5-8c65-b88765f521ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdc3f2-0e3e-45b4-a141-2eb029275e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdc3f2-0e3e-45b4-a141-2eb029275e9a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9237,7 +9237,7 @@
         },
         {
             "id": "724005e6-4cb8-5865-bba1-0adfe0c2cf50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4072f8-4833-4219-b620-3092a9f08874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4072f8-4833-4219-b620-3092a9f08874.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9311,7 +9311,7 @@
         },
         {
             "id": "024784f5-f04c-52b6-95cf-3ada79698b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37620d-4fa4-4d2f-a668-7b1e556b3b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37620d-4fa4-4d2f-a668-7b1e556b3b04.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9376,7 +9376,7 @@
         },
         {
             "id": "2fe8251a-d24b-5ee0-bf53-0e415a7257f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf546a-83ac-470f-a5c7-2b214d18f5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bf546a-83ac-470f-a5c7-2b214d18f5c1.jpg?1",
             "name": "Michiko Konda, Truth Seeker",
             "text": "",
             "colours": [
@@ -9413,7 +9413,7 @@
         },
         {
             "id": "07ea17e2-d4c2-59c9-8ee7-1fded8e0403c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326979d-3620-4f7b-999c-b827ff725b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a326979d-3620-4f7b-999c-b827ff725b16.jpg?1",
             "name": "Kami of the Crescent Moon",
             "text": "",
             "colours": [
@@ -9449,7 +9449,7 @@
         },
         {
             "id": "8ac79ce6-c997-5a42-94ff-5662cb8d9961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8da57c-88ff-4fea-b19e-856a4c89cb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8da57c-88ff-4fea-b19e-856a4c89cb8e.jpg?1",
             "name": "Toshiro Umezawa",
             "text": "",
             "colours": [
@@ -9486,7 +9486,7 @@
         },
         {
             "id": "1ff56bcf-a9ab-5ee6-a30a-7bdfae459666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fe9de5-3b0d-47ed-9302-ef58972592b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85fe9de5-3b0d-47ed-9302-ef58972592b7.jpg?1",
             "name": "Heartless Hidetsugu",
             "text": "",
             "colours": [
@@ -9523,7 +9523,7 @@
         },
         {
             "id": "1b5c4647-7e23-5d3f-94dd-5985697f7bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fac46f-cf4e-47df-8f20-e1710744630b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fac46f-cf4e-47df-8f20-e1710744630b.jpg?1",
             "name": "Reki, the History of Kamigawa",
             "text": "",
             "colours": [
@@ -9560,7 +9560,7 @@
         },
         {
             "id": "ac85400f-4c72-5633-8e48-bc6ac15a9ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc7280c-8136-4ac3-b2d6-6679e13b0470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bc7280c-8136-4ac3-b2d6-6679e13b0470.jpg?1",
             "name": "All Is Dust",
             "text": "",
             "colours": [],
@@ -9591,7 +9591,7 @@
         },
         {
             "id": "c2b0cf3a-8695-5054-8870-21018961edd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f5de3e-f3ca-439f-8b7c-f0b1807f34b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f5de3e-f3ca-439f-8b7c-f0b1807f34b4.jpg?1",
             "name": "Artifact Mutation",
             "text": "",
             "colours": [
@@ -9625,7 +9625,7 @@
         },
         {
             "id": "f3002d9f-f90e-57d2-8f51-de128f49a52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acd1c1-86b2-4423-9ba7-5b9725c0514f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01acd1c1-86b2-4423-9ba7-5b9725c0514f.jpg?1",
             "name": "Drown in the Loch",
             "text": "",
             "colours": [
@@ -9661,7 +9661,7 @@
         },
         {
             "id": "3e26f1fd-48f0-5cde-bc9a-dbdb915a3b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf2da97-3331-4614-b4ff-f03d061500a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf2da97-3331-4614-b4ff-f03d061500a7.jpg?1",
             "name": "Fire Covenant",
             "text": "",
             "colours": [
@@ -9697,7 +9697,7 @@
         },
         {
             "id": "2a8ee0c1-5c6c-5888-93bc-c3f1d738db62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db735ea-f9cf-4e3c-9200-4f180df55baa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8db735ea-f9cf-4e3c-9200-4f180df55baa.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -9731,7 +9731,7 @@
         },
         {
             "id": "d8e131d3-8405-502e-8f63-9910ab1a9f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7f3579-452d-4531-a00a-ee74c67a79e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7f3579-452d-4531-a00a-ee74c67a79e3.jpg?1",
             "name": "Fracturing Gust",
             "text": "",
             "colours": [
@@ -9765,7 +9765,7 @@
         },
         {
             "id": "3bb5f33e-cb2a-51ac-a809-876b99f7d8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2221e-60c9-4880-9513-f7223772bb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e2221e-60c9-4880-9513-f7223772bb0b.jpg?1",
             "name": "Ob Nixilis Reignited",
             "text": "",
             "colours": [
@@ -9801,7 +9801,7 @@
         },
         {
             "id": "26fa0e01-9f8a-5acf-9107-851f556fe3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba1fa6-b96b-48e8-b0d2-e58de7fbc71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba1fa6-b96b-48e8-b0d2-e58de7fbc71d.jpg?1",
             "name": "Sire of Insanity",
             "text": "",
             "colours": [
@@ -9837,7 +9837,7 @@
         },
         {
             "id": "75009016-5fb7-5ab4-bbe8-869e6c44c294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b117d-f2bf-4bf0-b70c-d45e252e1456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1b117d-f2bf-4bf0-b70c-d45e252e1456.jpg?1",
             "name": "Sliver Hivelord",
             "text": "",
             "colours": [
@@ -9881,7 +9881,7 @@
         },
         {
             "id": "c115cd9c-2af7-502c-9996-a685fa044641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9151465-4d98-419e-8cd0-b18ef5716507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9151465-4d98-419e-8cd0-b18ef5716507.jpg?1",
             "name": "Spellskite",
             "text": "",
             "colours": [],
@@ -9917,7 +9917,7 @@
         },
         {
             "id": "ebfe8443-acf1-5318-aac1-de1a4ded0a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba7c2-7ae5-47cc-8fbe-c053628c72e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475ba7c2-7ae5-47cc-8fbe-c053628c72e1.jpg?1",
             "name": "Sanctum Prelate",
             "text": "",
             "colours": [
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "9849ad98-9e6c-57e0-b5bb-f8fc2b3d0e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c3499-d2c0-4e21-be7b-925e23a1d4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20c3499-d2c0-4e21-be7b-925e23a1d4df.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "ff23e0e7-2c80-56c9-8573-370c4f14155e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c378b614-ad53-40cd-86fa-6b6c7b82b824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c378b614-ad53-40cd-86fa-6b6c7b82b824.jpg?1",
             "name": "Sphere of Safety",
             "text": "",
             "colours": [
@@ -10018,7 +10018,7 @@
         },
         {
             "id": "78b1b4ff-a5d0-5731-bb44-8335d28b8a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15090117-5fef-454d-8972-8f31e9fd870f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15090117-5fef-454d-8972-8f31e9fd870f.jpg?1",
             "name": "Karmic Guide",
             "text": "",
             "colours": [
@@ -10053,7 +10053,7 @@
         },
         {
             "id": "0fb11ef2-7d80-54ce-952a-ce84bc0c2438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5335eb-e81f-46c5-a9e8-011f0c962b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd5335eb-e81f-46c5-a9e8-011f0c962b41.jpg?1",
             "name": "Mesa Enchantress",
             "text": "",
             "colours": [
@@ -10088,7 +10088,7 @@
         },
         {
             "id": "855787fd-bfd5-5337-bc2a-0bac75149fb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb59c-085f-4caf-8430-ba6e2888ea6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/552bb59c-085f-4caf-8430-ba6e2888ea6d.jpg?1",
             "name": "Archaeomancer",
             "text": "",
             "colours": [
@@ -10123,7 +10123,7 @@
         },
         {
             "id": "57f5196f-8c07-5f2c-9489-15297377bc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35dbe45e-16df-4ebb-a76a-df24124de23b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35dbe45e-16df-4ebb-a76a-df24124de23b.jpg?1",
             "name": "Bloom Tender",
             "text": "",
             "colours": [
@@ -10158,7 +10158,7 @@
         },
         {
             "id": "e559acf1-18e6-5db5-873f-26c913df93e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4565ed0-36a1-4d36-987e-cae10e36830f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4565ed0-36a1-4d36-987e-cae10e36830f.jpg?1",
             "name": "Meteor Golem",
             "text": "",
             "colours": [],
@@ -10191,7 +10191,7 @@
         },
         {
             "id": "efa86084-f45f-5a62-91e0-446b2c522275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4da73-2faa-4992-8f61-e668ce82ba17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e4da73-2faa-4992-8f61-e668ce82ba17.jpg?1",
             "name": "Azorius Signet",
             "text": "",
             "colours": [],
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "ab000450-357f-5296-883e-6157708a6247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35148573-7788-4023-a63c-4a09f48273c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35148573-7788-4023-a63c-4a09f48273c1.jpg?1",
             "name": "Dimir Signet",
             "text": "",
             "colours": [],
@@ -10253,7 +10253,7 @@
         },
         {
             "id": "cf7f1584-fc48-5088-95f8-6ad0504021e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0310bb0e-bd22-470e-8711-4e15aec86578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0310bb0e-bd22-470e-8711-4e15aec86578.jpg?1",
             "name": "Gruul Signet",
             "text": "",
             "colours": [],
@@ -10284,7 +10284,7 @@
         },
         {
             "id": "6570cd48-0249-54f9-9b05-af48776a3a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f1ee3-d83b-410b-b51f-ad4be841ac59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086f1ee3-d83b-410b-b51f-ad4be841ac59.jpg?1",
             "name": "Rakdos Signet",
             "text": "",
             "colours": [],
@@ -10315,7 +10315,7 @@
         },
         {
             "id": "fb6699a3-0931-5485-8bea-7bd69a35d6f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcfd873-da1f-4f0b-a41d-54f383ec1724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcfd873-da1f-4f0b-a41d-54f383ec1724.jpg?1",
             "name": "Selesnya Signet",
             "text": "",
             "colours": [],
@@ -10346,7 +10346,7 @@
         },
         {
             "id": "5c8df2de-5f69-5b7a-8d46-c2fb3c7d18f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d4532d-f948-4eb3-b855-592080e171e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d4532d-f948-4eb3-b855-592080e171e5.jpg?1",
             "name": "Boros Signet",
             "text": "",
             "colours": [],
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "b5e48ca3-fb55-5913-8bc5-bd5277672fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c0ba5-a83a-40a9-919a-0bda0fef3b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f04c0ba5-a83a-40a9-919a-0bda0fef3b4f.jpg?1",
             "name": "Golgari Signet",
             "text": "",
             "colours": [],
@@ -10408,7 +10408,7 @@
         },
         {
             "id": "1d4999ee-6141-5384-9897-89ab66c30613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab29ff99-b246-49e8-bb77-c7906b502232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab29ff99-b246-49e8-bb77-c7906b502232.jpg?1",
             "name": "Izzet Signet",
             "text": "",
             "colours": [],
@@ -10439,7 +10439,7 @@
         },
         {
             "id": "990827a4-d289-508c-95f4-ace9e7c199cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072b7b7-7ca1-4106-a9b2-49cde7c47faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7072b7b7-7ca1-4106-a9b2-49cde7c47faa.jpg?1",
             "name": "Orzhov Signet",
             "text": "",
             "colours": [],
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "9593ce8a-ceca-5903-b694-78f8a3df27cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58e931a-d4dd-4705-ae31-89c0aecbf192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58e931a-d4dd-4705-ae31-89c0aecbf192.jpg?1",
             "name": "Simic Signet",
             "text": "",
             "colours": [],
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "ff3ed33a-3cb5-5f12-89c9-7d69b5c07de9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb0349-a759-473e-a192-7ca85ef8e515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bdb0349-a759-473e-a192-7ca85ef8e515.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10541,7 +10541,7 @@
         },
         {
             "id": "92c2dc61-6103-5460-9990-6c9c93d460f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527010e-d382-4bd5-8de6-0e3898b80deb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527010e-d382-4bd5-8de6-0e3898b80deb.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "0ca42d7c-53e4-5ac2-af58-bb492d52f26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a96d0b-5c8f-4563-92a0-a2c9e595100b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a96d0b-5c8f-4563-92a0-a2c9e595100b.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10621,7 +10621,7 @@
         },
         {
             "id": "ad7ba83f-e51e-5788-a4b3-341edd135b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69db7d6-80fd-4832-b9f4-47eb4aab54e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e69db7d6-80fd-4832-b9f4-47eb4aab54e6.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -10661,7 +10661,7 @@
         },
         {
             "id": "6d8dde8f-6971-52e5-aa9c-98981d112697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f4c301-6015-456a-8989-e0055402809e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f4c301-6015-456a-8989-e0055402809e.jpg?1",
             "name": "Ancient Den",
             "text": "",
             "colours": [],
@@ -10692,7 +10692,7 @@
         },
         {
             "id": "040bfcf1-dd45-545e-8a4c-2f5078a8b0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea58393a-7d69-4f99-90b7-ef6f31e4c80b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea58393a-7d69-4f99-90b7-ef6f31e4c80b.jpg?1",
             "name": "Seat of the Synod",
             "text": "",
             "colours": [],
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "a8a96968-0bd5-5da6-af3c-80b5b0c40ea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2320e6f4-ff1f-4c07-86b7-ee0e7904a573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2320e6f4-ff1f-4c07-86b7-ee0e7904a573.jpg?1",
             "name": "Vault of Whispers",
             "text": "",
             "colours": [],
@@ -10754,7 +10754,7 @@
         },
         {
             "id": "4e66bc54-668f-5990-91ee-a4749cc3f2d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49411808-630f-4bb4-af52-137932adcd7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49411808-630f-4bb4-af52-137932adcd7c.jpg?1",
             "name": "Great Furnace",
             "text": "",
             "colours": [],
@@ -10785,7 +10785,7 @@
         },
         {
             "id": "ca59dc28-2f05-5823-a176-6d5e3e3c365f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da48f6c-df82-4290-a476-6e4358fac4ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da48f6c-df82-4290-a476-6e4358fac4ff.jpg?1",
             "name": "Tree of Tales",
             "text": "",
             "colours": [],
@@ -10816,7 +10816,7 @@
         },
         {
             "id": "c3f7a479-17ad-5572-a37a-9d83b3982217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2af348-e768-44ca-b847-d541a0b0e6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e2af348-e768-44ca-b847-d541a0b0e6e0.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "",
             "colours": [
@@ -10853,7 +10853,7 @@
         },
         {
             "id": "a0fab005-b156-59aa-bcf7-160224984bda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11944685-56b1-42e4-b9b8-fc468c81e9a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11944685-56b1-42e4-b9b8-fc468c81e9a6.jpg?1",
             "name": "Managorger Hydra",
             "text": "",
             "colours": [
@@ -10887,7 +10887,7 @@
         },
         {
             "id": "10bf674b-15af-5caf-a0d9-21210306cd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd9868-f0c5-452c-9619-a8f3bbf5ea69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9dd9868-f0c5-452c-9619-a8f3bbf5ea69.jpg?1",
             "name": "Pathbreaker Ibex",
             "text": "",
             "colours": [
@@ -10921,7 +10921,7 @@
         },
         {
             "id": "9aca87f9-ef27-5b03-ae55-37383b1e50d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1a7802-92bd-401d-a1a6-705c398359bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1a7802-92bd-401d-a1a6-705c398359bb.jpg?1",
             "name": "Temur Sabertooth",
             "text": "",
             "colours": [
@@ -10955,7 +10955,7 @@
         },
         {
             "id": "08cd6f82-d502-5380-b06b-642d0bbdd471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f94220-9565-429b-af8b-1d4348ae7a1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f94220-9565-429b-af8b-1d4348ae7a1a.jpg?1",
             "name": "Winding Constrictor",
             "text": "",
             "colours": [
@@ -10991,7 +10991,7 @@
         },
         {
             "id": "2909deb9-8389-516a-9cb9-9b0339a29883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07af73d7-5d8e-4c64-91f0-1ecc35b57024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07af73d7-5d8e-4c64-91f0-1ecc35b57024.jpg?1",
             "name": "Unbreakable Formation",
             "text": "",
             "colours": [
@@ -11023,7 +11023,7 @@
         },
         {
             "id": "3ebd4cf4-f0ef-53ab-ab1f-6d1ddb5ad842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460aebc5-6150-4927-8d92-72bad788be42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460aebc5-6150-4927-8d92-72bad788be42.jpg?1",
             "name": "Whir of Invention",
             "text": "",
             "colours": [
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "ddc6e0d4-1f13-5599-ae9f-f1c156c4d4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed96b05d-b2ca-4c8f-969b-cac9b4562fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed96b05d-b2ca-4c8f-969b-cac9b4562fab.jpg?1",
             "name": "Hero's Downfall",
             "text": "",
             "colours": [
@@ -11087,7 +11087,7 @@
         },
         {
             "id": "11f18985-2a4d-5a26-9a7b-ca1fd603ab16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1ebfa2-7e23-48a3-a9bc-59a24a2c1ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1ebfa2-7e23-48a3-a9bc-59a24a2c1ed7.jpg?1",
             "name": "Impact Tremors",
             "text": "",
             "colours": [
@@ -11119,7 +11119,7 @@
         },
         {
             "id": "72b0ed72-dd5e-5c99-bbe3-c73dd3403bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1611b15e-3d33-4fc5-89c7-5bfd6b380cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1611b15e-3d33-4fc5-89c7-5bfd6b380cef.jpg?1",
             "name": "Primal Vigor",
             "text": "",
             "colours": [
@@ -11153,7 +11153,7 @@
         },
         {
             "id": "d21e003d-f4b2-5cdb-add7-bf68a523f3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad783ed-69b9-48b5-9610-4fa4d8f9a6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad783ed-69b9-48b5-9610-4fa4d8f9a6e6.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -11183,7 +11183,7 @@
         },
         {
             "id": "eb149e90-52c6-55f4-867d-d2676444a538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd334816-f058-4296-b1c3-924f22e91820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd334816-f058-4296-b1c3-924f22e91820.jpg?1",
             "name": "Fleet Swallower",
             "text": "",
             "colours": [
@@ -11217,7 +11217,7 @@
         },
         {
             "id": "07f05df5-c7aa-50e4-9843-a6b8690f5ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05441a9-9603-4a35-90cc-85e24eef09b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05441a9-9603-4a35-90cc-85e24eef09b8.jpg?1",
             "name": "Goblin Trashmaster",
             "text": "",
             "colours": [
@@ -11252,7 +11252,7 @@
         },
         {
             "id": "9c5da468-e611-5dc3-a4fd-8c3e13681004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3af587-d08d-4ae0-9599-390ade85c735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad3af587-d08d-4ae0-9599-390ade85c735.jpg?1",
             "name": "Ilharg, the Raze-Boar",
             "text": "",
             "colours": [
@@ -11289,7 +11289,7 @@
         },
         {
             "id": "8eacd2f7-8f4e-5a91-b8b2-5b096a4771d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88269739-8a38-4f75-a53e-4b4ce70f2aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88269739-8a38-4f75-a53e-4b4ce70f2aef.jpg?1",
             "name": "Protean Hulk",
             "text": "",
             "colours": [
@@ -11323,7 +11323,7 @@
         },
         {
             "id": "1532e682-9597-5a1b-87ec-0671d4e453b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c7f7-8022-4457-9a8a-6b87ff3348b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6674c7f7-8022-4457-9a8a-6b87ff3348b0.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "",
             "colours": [
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "efe33cfc-84e7-5229-a54a-4ef5f28e57e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03da66e3-a369-4433-a2b8-8625403d34b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03da66e3-a369-4433-a2b8-8625403d34b0.jpg?1",
             "name": "Dismember",
             "text": "",
             "colours": [
@@ -11398,7 +11398,7 @@
         },
         {
             "id": "5d5b41b0-aa8b-5d2c-a698-b62149bbb3b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a184a4a-2c8c-4a10-9b26-a174859fa1e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a184a4a-2c8c-4a10-9b26-a174859fa1e8.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -11430,7 +11430,7 @@
         },
         {
             "id": "f3d01750-3ff4-5741-ab04-80c751d78c2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23446e7-8573-4e8e-8698-e4ca62424416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23446e7-8573-4e8e-8698-e4ca62424416.jpg?1",
             "name": "Beast Within",
             "text": "",
             "colours": [
@@ -11462,7 +11462,7 @@
         },
         {
             "id": "939390c3-307a-5fbe-bcf0-ebe8ae2aeaff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b5c132-c4d0-42df-bc5b-e7fe0a31a9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b5c132-c4d0-42df-bc5b-e7fe0a31a9e7.jpg?1",
             "name": "Grafdigger's Cage",
             "text": "",
             "colours": [],
@@ -11490,7 +11490,7 @@
         },
         {
             "id": "33a40f1c-b396-5e2b-8d96-ad20db458479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ed0c75-0ec3-4f06-8c37-750fefb8136d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0ed0c75-0ec3-4f06-8c37-750fefb8136d.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -11530,7 +11530,7 @@
         },
         {
             "id": "52040343-74a0-577e-87c4-59194a9cc312",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af8122a-2943-4507-a93a-564fe63a035b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af8122a-2943-4507-a93a-564fe63a035b.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -11570,7 +11570,7 @@
         },
         {
             "id": "3f21f389-bb00-5e91-99e5-4fd269802b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d95c5-278f-4ad5-99ea-9fcf85520de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f19d95c5-278f-4ad5-99ea-9fcf85520de2.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -11610,7 +11610,7 @@
         },
         {
             "id": "8dee5491-eee5-514e-8120-412c9986fb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23fb3767-544d-4ae7-b7c4-af0944a0281b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23fb3767-544d-4ae7-b7c4-af0944a0281b.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -11650,7 +11650,7 @@
         },
         {
             "id": "c61de754-15e7-59ac-8a6b-1dd9c69e5dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9a891d-a2c6-418d-a6bd-be2353b3e980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9a891d-a2c6-418d-a6bd-be2353b3e980.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -11690,7 +11690,7 @@
         },
         {
             "id": "6c7ee803-90f7-5781-818b-1127a1dd11b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1aa91-ec97-4fe8-b4b1-a213f050f956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc1aa91-ec97-4fe8-b4b1-a213f050f956.jpg?1",
             "name": "Aether Gust",
             "text": "",
             "colours": [
@@ -11722,7 +11722,7 @@
         },
         {
             "id": "cdb44c69-b167-50ec-8837-9838960001bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35ec9da-f38b-4b7f-9eb5-090ca7755668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f35ec9da-f38b-4b7f-9eb5-090ca7755668.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "28a9407e-89db-5d7c-a108-5150a56ec95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc6b89-c428-4b7a-ab9c-58323b2d0aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc6b89-c428-4b7a-ab9c-58323b2d0aac.jpg?1",
             "name": "Fabricate",
             "text": "",
             "colours": [
@@ -11791,7 +11791,7 @@
         },
         {
             "id": "3b54bba0-25fa-523e-beeb-d28d6b5b73c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0983f89c-d6ae-479e-aa2f-b2a0c2997608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0983f89c-d6ae-479e-aa2f-b2a0c2997608.jpg?1",
             "name": "Fact or Fiction",
             "text": "",
             "colours": [
@@ -11823,7 +11823,7 @@
         },
         {
             "id": "5ec27fa6-d1f8-5095-88db-c5ffa2c9cb9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0095386-6e4d-432f-a5ac-7407ffaf7938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0095386-6e4d-432f-a5ac-7407ffaf7938.jpg?1",
             "name": "Mystical Tutor",
             "text": "",
             "colours": [
@@ -11855,7 +11855,7 @@
         },
         {
             "id": "d465de12-cc8b-58a8-aa5f-3b9d2b13adca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbaa2f0-9ad0-4ce2-8ce6-359d01bd524c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fbaa2f0-9ad0-4ce2-8ce6-359d01bd524c.jpg?1",
             "name": "Arvinox, the Mind Flail",
             "text": "",
             "colours": [
@@ -11892,7 +11892,7 @@
         },
         {
             "id": "8ce60f81-4d78-5fb5-95fb-d0381484fd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49414b93-55c5-4eea-8699-01bad0b9a7ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49414b93-55c5-4eea-8699-01bad0b9a7ac.jpg?1",
             "name": "Sophina, Spearsage Deserter",
             "text": "",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "2c53909f-3730-5fef-abeb-60475028ffa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f1182-8ab2-4ae6-a38c-13cdbdb1fe43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281f1182-8ab2-4ae6-a38c-13cdbdb1fe43.jpg?1",
             "name": "Hargilde, Kindly Runechanter",
             "text": "",
             "colours": [
@@ -11969,7 +11969,7 @@
         },
         {
             "id": "35422858-fe8b-574c-8149-c0f44968fa53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1e8fc-77b4-409d-9fc4-7bc6f6ae3e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e1e8fc-77b4-409d-9fc4-7bc6f6ae3e26.jpg?1",
             "name": "Cecily, Haunted Mage",
             "text": "",
             "colours": [
@@ -12010,7 +12010,7 @@
         },
         {
             "id": "aef74d80-a1d8-5e80-97ca-65be6322c3f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09edfe-5bef-430e-853d-a6b4b612805a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b09edfe-5bef-430e-853d-a6b4b612805a.jpg?1",
             "name": "Bjorna, Nightfall Alchemist",
             "text": "",
             "colours": [
@@ -12048,7 +12048,7 @@
         },
         {
             "id": "a72058aa-a7f3-56db-9397-41f0a8c0742a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb04ab1-2a74-432f-b3d3-d4f5b2534066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb04ab1-2a74-432f-b3d3-d4f5b2534066.jpg?1",
             "name": "Elmar, Ulvenwald Informant",
             "text": "",
             "colours": [
@@ -12086,7 +12086,7 @@
         },
         {
             "id": "08d9e716-2384-5fb9-8122-0d42ad869bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142edc65-232b-492e-805a-6905f13e9e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142edc65-232b-492e-805a-6905f13e9e6d.jpg?1",
             "name": "Othelm, Sigardian Outcast",
             "text": "",
             "colours": [
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "361e3a5d-681f-5d5a-bfcd-8b4ef6eb52c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a4af68-6e5e-4b44-9c1c-25ecdbd555b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a4af68-6e5e-4b44-9c1c-25ecdbd555b5.jpg?1",
             "name": "Wernog, Rider's Chaplain",
             "text": "",
             "colours": [
@@ -12162,7 +12162,7 @@
         },
         {
             "id": "4aa7f721-c282-5e8a-bcb7-747efbfc8781",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d6b87f-c750-4ed1-8da6-261bb955d3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d6b87f-c750-4ed1-8da6-261bb955d3b9.jpg?1",
             "name": "Moorland Haunt",
             "text": "",
             "colours": [],
@@ -12193,7 +12193,7 @@
         },
         {
             "id": "2e2292e6-d0cc-5a1f-8b24-bb264dcbf6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0c1d5d-767d-4d64-81b0-0d0fb09d6b31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d0c1d5d-767d-4d64-81b0-0d0fb09d6b31.jpg?1",
             "name": "Vault of the Archangel",
             "text": "",
             "colours": [],
@@ -12224,7 +12224,7 @@
         },
         {
             "id": "5719a2e1-990f-531c-b465-ba12f87d37b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7819a326-1d07-4194-a1eb-01d4081ed192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7819a326-1d07-4194-a1eb-01d4081ed192.jpg?1",
             "name": "Nephalia Drownyard",
             "text": "",
             "colours": [],
@@ -12255,7 +12255,7 @@
         },
         {
             "id": "d6f309d2-ea33-5250-b2e0-9baf7c2ab1aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034ad345-96f6-40aa-b610-1eaab258fb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/034ad345-96f6-40aa-b610-1eaab258fb38.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -12286,7 +12286,7 @@
         },
         {
             "id": "64b7b938-8cdf-5940-a31d-ce98a9094fe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf002ecb-9afb-41b4-a6b8-327558ac947c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf002ecb-9afb-41b4-a6b8-327558ac947c.jpg?1",
             "name": "Stensia Bloodhall",
             "text": "",
             "colours": [],
@@ -12317,7 +12317,7 @@
         },
         {
             "id": "69eff3fe-1933-5dfb-adf6-dcb20fb83c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f6d2-a339-4598-af5f-b526fbe276a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f6d2-a339-4598-af5f-b526fbe276a2.jpg?1",
             "name": "Grim Backwoods",
             "text": "",
             "colours": [],
@@ -12348,7 +12348,7 @@
         },
         {
             "id": "ff729c4e-844a-5320-a917-11505c06e512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4e64b-e978-49ba-8e3e-4792f975fb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb4e64b-e978-49ba-8e3e-4792f975fb61.jpg?1",
             "name": "Kessig Wolf Run",
             "text": "",
             "colours": [],
@@ -12379,7 +12379,7 @@
         },
         {
             "id": "18c9fd90-69a0-5a93-a66b-e8fb7f0d3250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed9a072-fd0b-45f2-8962-9d601840c7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aed9a072-fd0b-45f2-8962-9d601840c7c3.jpg?1",
             "name": "Slayers' Stronghold",
             "text": "",
             "colours": [],
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "ba813a06-9d53-5ad4-b8f9-ac448a7a9b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd782cf-414c-4340-9431-4b7809c8c04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd782cf-414c-4340-9431-4b7809c8c04e.jpg?1",
             "name": "Gavony Township",
             "text": "",
             "colours": [],
@@ -12441,7 +12441,7 @@
         },
         {
             "id": "928d334b-927c-59c1-ba87-161b9f320229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6cf714-29b9-4c06-9412-d958a5ffbd66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6cf714-29b9-4c06-9412-d958a5ffbd66.jpg?1",
             "name": "Alchemist's Refuge",
             "text": "",
             "colours": [],
@@ -12472,7 +12472,7 @@
         },
         {
             "id": "77387e7a-bd4b-5b7f-ae21-401b8a9509f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673e184-2b58-44ef-bb68-bd3d139ed0ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8673e184-2b58-44ef-bb68-bd3d139ed0ba.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12541,7 +12541,7 @@
         },
         {
             "id": "0841d85c-386c-58ec-8103-f3a084391f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f64a6-ba1b-4cd9-8cf9-15f394f9524b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8f64a6-ba1b-4cd9-8cf9-15f394f9524b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12606,7 +12606,7 @@
         },
         {
             "id": "19f57223-55bb-5077-a63e-f6d2f3d4baf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f5c55d-09e5-49dd-906c-0f48a79b4c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53f5c55d-09e5-49dd-906c-0f48a79b4c15.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12670,7 +12670,7 @@
         },
         {
             "id": "2778e3b9-6dd9-573c-94a3-c011677cb654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96549393-9607-43c8-91de-905462cbcb19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96549393-9607-43c8-91de-905462cbcb19.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12744,7 +12744,7 @@
         },
         {
             "id": "42d0c6e8-9c33-59a8-ac6f-ac2d78e6ed17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f57347-7206-4a2f-a41b-0612d456cd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f57347-7206-4a2f-a41b-0612d456cd30.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12809,7 +12809,7 @@
         },
         {
             "id": "562d772a-96c5-5217-b70f-fe1adb24fa32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68357502-cf23-4bf6-ab4e-371428e540d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68357502-cf23-4bf6-ab4e-371428e540d0.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -12846,7 +12846,7 @@
         },
         {
             "id": "bc4b85ab-5143-530f-a59c-ffad337dac77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be03def-6e43-4420-8380-8f4e5cf39500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be03def-6e43-4420-8380-8f4e5cf39500.jpg?1",
             "name": "Grim Tutor",
             "text": "",
             "colours": [
@@ -12879,7 +12879,7 @@
         },
         {
             "id": "16a23e53-07cd-516c-8efc-6d0b00466151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaa4c77-0a5c-4b2f-aa22-bfce9cce99f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaa4c77-0a5c-4b2f-aa22-bfce9cce99f9.jpg?1",
             "name": "Blood Moon",
             "text": "",
             "colours": [
@@ -12910,7 +12910,7 @@
         },
         {
             "id": "c19342af-7bfb-5f6b-9b03-f84c3ff2ca4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg?1",
             "name": "Cut // Ribbons",
             "text": "",
             "colours": [
@@ -12942,7 +12942,7 @@
         },
         {
             "id": "ee40c8c1-5b59-5d82-ba67-a1125fae470b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94f09def-15df-4f74-9727-e5d3138bf19e.jpg?1",
             "name": "Cut // Ribbons",
             "text": "",
             "colours": [
@@ -12974,7 +12974,7 @@
         },
         {
             "id": "c11a1f79-9ec8-5bb1-a25a-602979e52f5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb88b2-5dc6-43de-8a38-1f8982ed395a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb88b2-5dc6-43de-8a38-1f8982ed395a.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "",
             "colours": [],
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "f5dfdfe2-543d-5eda-bf60-52d493baa285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d4e224-e630-4696-85ef-cf42f9d03ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d4e224-e630-4696-85ef-cf42f9d03ca5.jpg?1",
             "name": "Generous Gift",
             "text": "",
             "colours": [
@@ -13033,7 +13033,7 @@
         },
         {
             "id": "5cddefd7-aeca-5ef8-a454-899e882a3ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb7fe8e-e348-4bf9-aa71-65f0675147e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb7fe8e-e348-4bf9-aa71-65f0675147e4.jpg?1",
             "name": "Chain Lightning",
             "text": "",
             "colours": [
@@ -13065,7 +13065,7 @@
         },
         {
             "id": "6bb38ab9-44b2-56f0-a0e0-382d7c744005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18381713-3f20-4d5d-8cd4-f3d1fdfad4f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18381713-3f20-4d5d-8cd4-f3d1fdfad4f4.jpg?1",
             "name": "Kodama's Reach",
             "text": "",
             "colours": [
@@ -13099,7 +13099,7 @@
         },
         {
             "id": "affbbba1-36b4-56a8-b6fa-4a41117dcb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01b0d7f-5184-4651-a83d-14c27c8bb1bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01b0d7f-5184-4651-a83d-14c27c8bb1bc.jpg?1",
             "name": "Heirloom Blade",
             "text": "",
             "colours": [],
@@ -13129,7 +13129,7 @@
         },
         {
             "id": "16501944-cdc8-59b0-986a-b9b159b4b317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad7ebb-4994-49f1-a211-90bdccb6a91b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ad7ebb-4994-49f1-a211-90bdccb6a91b.jpg?1",
             "name": "Mulldrifter",
             "text": "",
             "colours": [
@@ -13165,7 +13165,7 @@
         },
         {
             "id": "751cf6f9-6f2c-5c89-b0ac-94d542131245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcae2f-fcf3-4dfd-8818-606d16a03beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdcae2f-fcf3-4dfd-8818-606d16a03beb.jpg?1",
             "name": "Mulldrifter",
             "text": "",
             "colours": [
@@ -13201,7 +13201,7 @@
         },
         {
             "id": "b2bc2b80-c5bd-5c26-9e3c-0937576bdc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2750bee4-7dfa-4128-989c-5f81af1b322a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2750bee4-7dfa-4128-989c-5f81af1b322a.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "",
             "colours": [
@@ -13237,7 +13237,7 @@
         },
         {
             "id": "af53aaf0-b345-59dd-8e1b-cd2556b3c109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640be32d-dcc8-408a-b8a6-077472f1e70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640be32d-dcc8-408a-b8a6-077472f1e70b.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "",
             "colours": [
@@ -13273,7 +13273,7 @@
         },
         {
             "id": "787a7c9f-8531-56f4-86f7-3cb5e4616211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482c454-425e-4d83-a8db-9b1c2d50403c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d482c454-425e-4d83-a8db-9b1c2d50403c.jpg?1",
             "name": "Metalwork Colossus",
             "text": "",
             "colours": [],
@@ -13306,7 +13306,7 @@
         },
         {
             "id": "cfd0a8bb-3663-55bf-9592-7ad8c283d5cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91a198-49f9-4685-b03f-6f9513bddfd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db91a198-49f9-4685-b03f-6f9513bddfd7.jpg?1",
             "name": "Metalwork Colossus",
             "text": "",
             "colours": [],
@@ -13339,7 +13339,7 @@
         },
         {
             "id": "9f9c49af-02d5-5219-8827-98b857cfae3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "c765d1e2-2e30-50fb-af77-a6b128061a05",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5dfd236-b1da-4552-b94f-ebf6bb9dafdf.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13415,7 +13415,7 @@
         },
         {
             "id": "2ef3715f-fcb9-5385-a161-962c83ae5bab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13453,7 +13453,7 @@
         },
         {
             "id": "2f7b07c3-fc95-5e5e-a63e-393d685b15ac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg?1",
             "name": "Zndrsplt, Eye of Wisdom // Zndrsplt, Eye of Wisdom",
             "text": "",
             "colours": [
@@ -13491,7 +13491,7 @@
         },
         {
             "id": "dd0c9dde-abc3-5a05-a7b7-71c210b33a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13530,7 +13530,7 @@
         },
         {
             "id": "3b069438-1548-5596-81bb-d187284bf9df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94eea6e3-20bc-4dab-90ba-3113c120fb90.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13569,7 +13569,7 @@
         },
         {
             "id": "24c022f9-c60c-5d61-828b-aa21771073c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13608,7 +13608,7 @@
         },
         {
             "id": "ab00064b-f3a1-54aa-8311-a561d83ab29e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg?1",
             "name": "Okaun, Eye of Chaos // Okaun, Eye of Chaos",
             "text": "",
             "colours": [
@@ -13647,7 +13647,7 @@
         },
         {
             "id": "4df6612d-7a84-54a5-8fc0-00438fb3e1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1",
             "name": "Propaganda // Propaganda",
             "text": "",
             "colours": [
@@ -13678,7 +13678,7 @@
         },
         {
             "id": "4116e76a-bf4c-5dba-8c08-c0daa02f961c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/e/3e3f0bcd-0796-494d-bf51-94b33c1671e9.jpg?1",
             "name": "Propaganda // Propaganda",
             "text": "",
             "colours": [
@@ -13709,7 +13709,7 @@
         },
         {
             "id": "5e0c6939-8a95-5410-a164-bce4abf08fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg?1",
             "name": "Stitch in Time // Stitch in Time",
             "text": "",
             "colours": [
@@ -13742,7 +13742,7 @@
         },
         {
             "id": "1ca6407c-0152-5291-95e6-ec7e71ae7510",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/087c3a0d-c710-4451-989e-596b55352184.jpg?1",
             "name": "Stitch in Time // Stitch in Time",
             "text": "",
             "colours": [
@@ -13775,7 +13775,7 @@
         },
         {
             "id": "3a6203a3-4a97-50a1-8662-8788443b68d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg?1",
             "name": "Krark's Thumb // Krark's Thumb",
             "text": "",
             "colours": [],
@@ -13804,7 +13804,7 @@
         },
         {
             "id": "f2cc62d6-6d1d-52e3-b34f-35996052abe7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/f/9f63277b-e139-46c8-b9e3-0cfb647f44cc.jpg?1",
             "name": "Krark's Thumb // Krark's Thumb",
             "text": "",
             "colours": [],
@@ -13833,7 +13833,7 @@
         },
         {
             "id": "25e983e0-835a-584a-bf31-687ea6a382d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6079aea9-145a-445d-a00f-1c0f4018a529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6079aea9-145a-445d-a00f-1c0f4018a529.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -13897,7 +13897,7 @@
         },
         {
             "id": "4620a669-fd13-5326-9b14-2dfdee0d19e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e306586a-427f-45b7-9e3b-cd9157cec07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e306586a-427f-45b7-9e3b-cd9157cec07f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -13962,7 +13962,7 @@
         },
         {
             "id": "aa01eb1a-a9fe-5e48-94fe-980eccbefb96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4555e99-7f95-4c76-914f-0a42d49975cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4555e99-7f95-4c76-914f-0a42d49975cd.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "f7d14913-c5f4-5140-87f4-3ec6f4445421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa08a961-cd6a-403e-a098-1e7f716262bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa08a961-cd6a-403e-a098-1e7f716262bb.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14101,7 +14101,7 @@
         },
         {
             "id": "553966c4-8794-5d81-b973-84a6b8242ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249104ba-65fc-42d6-ad8b-d97640545d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/249104ba-65fc-42d6-ad8b-d97640545d89.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14166,7 +14166,7 @@
         },
         {
             "id": "f0a54aac-613e-57a8-b0e7-98aa3f0ac3e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4abaf5-3bc0-464c-b31d-d579d0a9128d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb4abaf5-3bc0-464c-b31d-d579d0a9128d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14240,7 +14240,7 @@
         },
         {
             "id": "d5f1d387-0f81-5f43-a7c6-27bdeb2397f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb59eef-385b-4a9d-b70c-952387b30310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb59eef-385b-4a9d-b70c-952387b30310.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14309,7 +14309,7 @@
         },
         {
             "id": "e48be9d7-a9b5-5f46-8c58-da5100a9c282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771294b5-c1a1-4456-8399-1391bc5ba40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/771294b5-c1a1-4456-8399-1391bc5ba40e.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14378,7 +14378,7 @@
         },
         {
             "id": "5a28c76c-14de-5f99-a9c0-cdd223845235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3352b213-4ebc-4b4c-ae75-f256fbb33d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3352b213-4ebc-4b4c-ae75-f256fbb33d95.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14443,7 +14443,7 @@
         },
         {
             "id": "a1dbd57b-3a73-5ec5-9e2d-d9bc0efeb2b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825f809d-fb64-4101-a985-c3533f26a345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825f809d-fb64-4101-a985-c3533f26a345.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14512,7 +14512,7 @@
         },
         {
             "id": "d0e442c7-718e-5a12-b48f-8a64c382734c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c331d-56c6-47d9-bd52-30a92b6415b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c331d-56c6-47d9-bd52-30a92b6415b3.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14576,7 +14576,7 @@
         },
         {
             "id": "d37f80d8-ceca-5252-aa91-02d8e0b54fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c5d09-6f93-44f5-894d-4c7be40bb006.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c5d09-6f93-44f5-894d-4c7be40bb006.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14641,7 +14641,7 @@
         },
         {
             "id": "19654c6d-50af-5700-a3da-30555eeddf18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284b87f-d249-43c2-a198-dd03e961bedb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284b87f-d249-43c2-a198-dd03e961bedb.jpg?1",
             "name": "Tamiyo, the Moon Sage",
             "text": "",
             "colours": [
@@ -14677,7 +14677,7 @@
         },
         {
             "id": "ecf324eb-c500-557e-a0dd-f14eb4e610f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbfc1b2-2407-4079-a847-6bb6b9a2c9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbfc1b2-2407-4079-a847-6bb6b9a2c9de.jpg?1",
             "name": "Ajani, Mentor of Heroes",
             "text": "",
             "colours": [
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "ccc4f2e0-68ae-5f0e-bc32-62d79d5cf74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba48c787-a444-4e15-bab7-39994a6e23e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba48c787-a444-4e15-bab7-39994a6e23e7.jpg?1",
             "name": "Angrath, the Flame-Chained",
             "text": "",
             "colours": [
@@ -14753,7 +14753,7 @@
         },
         {
             "id": "cedab658-2a9c-57d7-952d-fe0bf9f3e6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f76d4-a2b3-40e5-b6a7-b27c42caf615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f76d4-a2b3-40e5-b6a7-b27c42caf615.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "",
             "colours": [
@@ -14793,7 +14793,7 @@
         },
         {
             "id": "62da8de4-31c6-5c2d-af7e-3fd3330800f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25c3609-a200-4532-9df8-8e92c24544bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25c3609-a200-4532-9df8-8e92c24544bc.jpg?1",
             "name": "Sorin, Grim Nemesis",
             "text": "",
             "colours": [
@@ -14831,7 +14831,7 @@
         },
         {
             "id": "db91c9d5-7c82-5ddf-8d7e-d652c030aa6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252e55c-03ee-44f7-ae07-067ace8e49ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f252e55c-03ee-44f7-ae07-067ace8e49ed.jpg?1",
             "name": "Peek",
             "text": "",
             "colours": [
@@ -14862,7 +14862,7 @@
         },
         {
             "id": "672a75e6-0457-5769-80cd-f4d56f03412e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ee3699-7fbb-4662-ba36-a1a7e19d161d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ee3699-7fbb-4662-ba36-a1a7e19d161d.jpg?1",
             "name": "Greed",
             "text": "",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "b4fe3da6-e621-510e-a601-fef6f1776bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2433b8e1-749b-4086-8819-e45e65e9df7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2433b8e1-749b-4086-8819-e45e65e9df7c.jpg?1",
             "name": "Curiosity",
             "text": "",
             "colours": [
@@ -14926,7 +14926,7 @@
         },
         {
             "id": "2a2fbe2d-2fef-5664-9f51-77b8c605deb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00576634-29da-4f9d-bcbb-07a2f80ceba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00576634-29da-4f9d-bcbb-07a2f80ceba5.jpg?1",
             "name": "Vandalblast",
             "text": "",
             "colours": [
@@ -14957,7 +14957,7 @@
         },
         {
             "id": "8d5a1027-5b4a-5ad6-a1ed-e26cd72a56f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e2a53d-eb33-42b3-a5fd-60fb232e99c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e2a53d-eb33-42b3-a5fd-60fb232e99c7.jpg?1",
             "name": "Last Chance",
             "text": "",
             "colours": [
@@ -14988,7 +14988,7 @@
         },
         {
             "id": "6823b456-723d-5391-b904-abc4b5fc4ed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf76c6a4-d6e8-4d50-b65f-020252f7b659.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf76c6a4-d6e8-4d50-b65f-020252f7b659.jpg?1",
             "name": "Mystic Remora",
             "text": "",
             "colours": [
@@ -15020,7 +15020,7 @@
         },
         {
             "id": "e3dc1ab1-1520-543e-b54f-d567ac68f90b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d268b09-acc7-474d-86be-537d6449755c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d268b09-acc7-474d-86be-537d6449755c.jpg?1",
             "name": "Retreat to Coralhelm",
             "text": "",
             "colours": [
@@ -15052,7 +15052,7 @@
         },
         {
             "id": "5de5d492-17e5-5c9e-bbb9-0fe601b52361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30641539-de35-46c7-99ab-e4478afe064c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30641539-de35-46c7-99ab-e4478afe064c.jpg?1",
             "name": "Burgeoning",
             "text": "",
             "colours": [
@@ -15084,7 +15084,7 @@
         },
         {
             "id": "b11bde20-3888-597e-99d4-96d566a7ad52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04c8a2-dcdd-4e87-85d3-9841561cdcdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f04c8a2-dcdd-4e87-85d3-9841561cdcdf.jpg?1",
             "name": "Utopia Sprawl",
             "text": "",
             "colours": [
@@ -15118,7 +15118,7 @@
         },
         {
             "id": "6155bd41-fed4-56b5-b02f-bb4131804766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33ff8fc-b2b7-4cd9-8724-b926459b519d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d33ff8fc-b2b7-4cd9-8724-b926459b519d.jpg?1",
             "name": "Brain Freeze",
             "text": "",
             "colours": [
@@ -15150,7 +15150,7 @@
         },
         {
             "id": "d35c69d1-1b1f-5b8f-badf-6597596d223b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0cb4bc-c2de-4d4a-8daa-df68350239a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0cb4bc-c2de-4d4a-8daa-df68350239a9.jpg?1",
             "name": "Bribery",
             "text": "",
             "colours": [
@@ -15184,7 +15184,7 @@
         },
         {
             "id": "8a7c4ff8-d2d5-5cdb-b42b-37d3d6a197d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d53b6d-edce-47eb-84a9-528cd60f18e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d53b6d-edce-47eb-84a9-528cd60f18e2.jpg?1",
             "name": "Snap",
             "text": "",
             "colours": [
@@ -15216,7 +15216,7 @@
         },
         {
             "id": "5be2c85f-cdf8-5c34-afd5-1e6f764f5145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a28148-7f9a-4a96-a878-fc15476c5820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a28148-7f9a-4a96-a878-fc15476c5820.jpg?1",
             "name": "Unmask",
             "text": "",
             "colours": [
@@ -15248,7 +15248,7 @@
         },
         {
             "id": "b20569cb-2fc1-5bdc-b0b7-0109e4eb4130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10be9a82-4008-45ae-a739-fdee95e39619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10be9a82-4008-45ae-a739-fdee95e39619.jpg?1",
             "name": "Shadow of Doubt",
             "text": "",
             "colours": [
@@ -15282,7 +15282,7 @@
         },
         {
             "id": "563874e8-6788-5630-9880-dc55fe95dffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71446bd-08f2-41fe-ae44-db44814c8afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c71446bd-08f2-41fe-ae44-db44814c8afb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15351,7 +15351,7 @@
         },
         {
             "id": "532d0d30-ff55-580b-bac1-270c192480f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd081bbf-8e82-405c-a522-f826fa0a6e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd081bbf-8e82-405c-a522-f826fa0a6e1d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15416,7 +15416,7 @@
         },
         {
             "id": "939e2ffe-f4ff-5be9-88fd-a3132b5dbea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085b4641-62fb-4820-aded-ccc9403d319e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085b4641-62fb-4820-aded-ccc9403d319e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15480,7 +15480,7 @@
         },
         {
             "id": "de2b8c55-a7c5-58c3-9e0a-24f4b853f21e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8611ec-6db3-4d29-8d3b-01e87bb38a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd8611ec-6db3-4d29-8d3b-01e87bb38a55.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15554,7 +15554,7 @@
         },
         {
             "id": "db011a97-ad8a-5d78-9941-2460a8842622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5dbb-8d5e-4471-94f6-e0944cf60ed2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fca5dbb-8d5e-4471-94f6-e0944cf60ed2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15619,7 +15619,7 @@
         },
         {
             "id": "a9055e67-7638-5f60-82bc-aa6c363cd3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2c8052-f995-4a8a-b63c-dbe2e8a22498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2c8052-f995-4a8a-b63c-dbe2e8a22498.jpg?1",
             "name": "Hokori, Dust Drinker",
             "text": "",
             "colours": [
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "f526a50b-21b8-5075-b37f-97d98a215339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e26f6c-44e9-4d6f-8eb1-efdef8d04ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0e26f6c-44e9-4d6f-8eb1-efdef8d04ff5.jpg?1",
             "name": "Kira, Great Glass-Spinner",
             "text": "",
             "colours": [
@@ -15691,7 +15691,7 @@
         },
         {
             "id": "b0538a4e-d57f-5b27-937a-e64b37786284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4ab9d-91af-4cb9-90dc-b6bd6897b1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded4ab9d-91af-4cb9-90dc-b6bd6897b1ed.jpg?1",
             "name": "Eidolon of the Great Revel",
             "text": "",
             "colours": [
@@ -15726,7 +15726,7 @@
         },
         {
             "id": "97ebd186-0ad6-56b1-a3f3-8894ddb7f74b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024110ee-5520-49f8-afab-54dcce87c650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/024110ee-5520-49f8-afab-54dcce87c650.jpg?1",
             "name": "Elvish Spirit Guide",
             "text": "",
             "colours": [
@@ -15761,7 +15761,7 @@
         },
         {
             "id": "69184d37-e76c-5146-a967-ff1d74befabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a43d9e8-3320-4873-b322-b323c792ce5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a43d9e8-3320-4873-b322-b323c792ce5e.jpg?1",
             "name": "Ghostly Prison",
             "text": "",
             "colours": [
@@ -15792,7 +15792,7 @@
         },
         {
             "id": "5f5a545e-9766-5ddd-bfc4-9c99e8018bcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db826546-6a96-4272-b72f-d1d2be78b318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db826546-6a96-4272-b72f-d1d2be78b318.jpg?1",
             "name": "Freed from the Real",
             "text": "",
             "colours": [
@@ -15825,7 +15825,7 @@
         },
         {
             "id": "e8bb34fe-3112-5b25-ab4e-685bfb302ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca68ea1-5aad-4d08-b460-768f5a91f1fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ca68ea1-5aad-4d08-b460-768f5a91f1fa.jpg?1",
             "name": "Boseiju, Who Shelters All",
             "text": "",
             "colours": [],
@@ -15854,7 +15854,7 @@
         },
         {
             "id": "1eda3486-4635-5465-969a-655e7c6f5134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d75ad-82a9-4145-ba3c-df4a86bd91d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d75ad-82a9-4145-ba3c-df4a86bd91d7.jpg?1",
             "name": "Hall of the Bandit Lord",
             "text": "",
             "colours": [],
@@ -15883,7 +15883,7 @@
         },
         {
             "id": "6d9098c8-aaa6-52ec-a801-cec430fb770f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecf013-130d-4cf3-b47e-54b5fb718878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecf013-130d-4cf3-b47e-54b5fb718878.jpg?1",
             "name": "Baldin, Century Herdmaster",
             "text": "",
             "colours": [
@@ -15920,7 +15920,7 @@
         },
         {
             "id": "563a9671-4a63-58bd-9be5-a79d33c350c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65a3a8b-ebf8-4e51-8b57-5b14e5cb7abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65a3a8b-ebf8-4e51-8b57-5b14e5cb7abb.jpg?1",
             "name": "Vikya, Scorching Stalwart",
             "text": "",
             "colours": [
@@ -15958,7 +15958,7 @@
         },
         {
             "id": "ae0c3106-c58e-5b72-b5fd-a9a091b44c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f54a1-caf1-499e-aa71-e081a4dd916d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f54a1-caf1-499e-aa71-e081a4dd916d.jpg?1",
             "name": "Aisha of Sparks and Smoke",
             "text": "",
             "colours": [
@@ -15996,7 +15996,7 @@
         },
         {
             "id": "55af0bdb-fac7-5db6-9f62-ef91fe568f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fecfd4-40c1-4ed3-bf58-22c7b98699a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26fecfd4-40c1-4ed3-bf58-22c7b98699a9.jpg?1",
             "name": "The Howling Abomination",
             "text": "",
             "colours": [
@@ -16036,7 +16036,7 @@
         },
         {
             "id": "03b1d07b-70c4-511d-a77e-810d893b40d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ee4a5-c74b-46eb-b709-808ebc803757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ee4a5-c74b-46eb-b709-808ebc803757.jpg?1",
             "name": "Zethi, Arcane Blademaster",
             "text": "",
             "colours": [
@@ -16075,7 +16075,7 @@
         },
         {
             "id": "c9f07a16-4037-5894-a911-f4d2a5f581df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f32937-ca7e-407c-aa23-117b1eae9798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f32937-ca7e-407c-aa23-117b1eae9798.jpg?1",
             "name": "Tadeas, Juniper Ascendant",
             "text": "",
             "colours": [
@@ -16114,7 +16114,7 @@
         },
         {
             "id": "58ac95b5-8813-56fd-bb24-db083c0b363b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fca7f9-ed46-440f-9ea3-225440fc5be5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2fca7f9-ed46-440f-9ea3-225440fc5be5.jpg?1",
             "name": "Immard, the Stormcleaver",
             "text": "",
             "colours": [
@@ -16155,7 +16155,7 @@
         },
         {
             "id": "5145500a-6b46-549f-8922-6d137eb39d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9976eb70-0d39-4882-8041-a4d29527c292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9976eb70-0d39-4882-8041-a4d29527c292.jpg?1",
             "name": "Maarika, Brutal Gladiator",
             "text": "",
             "colours": [
@@ -16196,7 +16196,7 @@
         },
         {
             "id": "1a3ea672-6b59-5366-a117-1a67ee9cc050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b431fd-7a4b-4cba-b5cb-554d7813b1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b431fd-7a4b-4cba-b5cb-554d7813b1f5.jpg?1",
             "name": "Windbrisk Heights",
             "text": "",
             "colours": [],
@@ -16226,7 +16226,7 @@
         },
         {
             "id": "e47164b5-62b8-55ef-94ac-ad95c4c9b88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8a4de-02ea-4efd-873d-8d936d5b6893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce8a4de-02ea-4efd-873d-8d936d5b6893.jpg?1",
             "name": "Shelldock Isle",
             "text": "",
             "colours": [],
@@ -16258,7 +16258,7 @@
         },
         {
             "id": "7013ac0b-f73b-5f67-a854-38dba4d4d394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dc73d6-a2b1-4e19-92a5-fe03d1fb3bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0dc73d6-a2b1-4e19-92a5-fe03d1fb3bd2.jpg?1",
             "name": "Howltooth Hollow",
             "text": "",
             "colours": [],
@@ -16288,7 +16288,7 @@
         },
         {
             "id": "286b91b5-d000-5a04-9270-919bee430558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776ebdf-6d32-4e8b-ab7f-ea16adf352bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776ebdf-6d32-4e8b-ab7f-ea16adf352bf.jpg?1",
             "name": "Spinerock Knoll",
             "text": "",
             "colours": [],
@@ -16318,7 +16318,7 @@
         },
         {
             "id": "fb418090-eb5c-5d6f-b062-a9a6139927ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851a7251-7af5-4137-8422-159314f7351a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/851a7251-7af5-4137-8422-159314f7351a.jpg?1",
             "name": "Mosswort Bridge",
             "text": "",
             "colours": [],
@@ -16348,7 +16348,7 @@
         },
         {
             "id": "980d6920-aba8-54a9-9176-08a99b12009c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3831-93d9-4995-b8c8-0d8c03fee872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0adf3831-93d9-4995-b8c8-0d8c03fee872.jpg?1",
             "name": "Wrath of God",
             "text": "",
             "colours": [
@@ -16382,7 +16382,7 @@
         },
         {
             "id": "7e531bc8-d80e-5ec2-807d-1a57c2a73168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556f7cc0-0fcb-4022-8a2d-9aebe889c891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556f7cc0-0fcb-4022-8a2d-9aebe889c891.jpg?1",
             "name": "Dance of Many",
             "text": "",
             "colours": [
@@ -16414,7 +16414,7 @@
         },
         {
             "id": "3c0841f8-d88f-5db1-9930-c49994fad202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f9bbf2-aa52-4daf-937e-29aef8810d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f9bbf2-aa52-4daf-937e-29aef8810d35.jpg?1",
             "name": "Etherium Sculptor",
             "text": "",
             "colours": [
@@ -16450,7 +16450,7 @@
         },
         {
             "id": "bf0d421a-de15-5d3f-88a8-0285291a5ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8eb787-02e9-47d1-a0d2-bac3f7eb8ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f8eb787-02e9-47d1-a0d2-bac3f7eb8ce0.jpg?1",
             "name": "Grim Tutor",
             "text": "",
             "colours": [
@@ -16484,7 +16484,7 @@
         },
         {
             "id": "742cde9b-52f0-5276-b0a2-d29365ae86d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5bf2-6032-4016-8ede-91e65c87e1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5bf2-6032-4016-8ede-91e65c87e1c2.jpg?1",
             "name": "Triumph of the Hordes",
             "text": "",
             "colours": [
@@ -16516,7 +16516,7 @@
         },
         {
             "id": "56c15695-3786-568b-a136-a5fdedf78111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daf0244-ffb9-42f3-8301-34cee7b9ae1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1daf0244-ffb9-42f3-8301-34cee7b9ae1b.jpg?1",
             "name": "Smuggler's Copter",
             "text": "",
             "colours": [],
@@ -16546,7 +16546,7 @@
         },
         {
             "id": "1c1ce283-686e-5ad0-9302-d985b02173f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593cbbd0-6ec3-4506-be0c-a229f070ce6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/593cbbd0-6ec3-4506-be0c-a229f070ce6d.jpg?1",
             "name": "Planar Bridge",
             "text": "",
             "colours": [],
@@ -16576,7 +16576,7 @@
         },
         {
             "id": "30ee6225-fcf2-5632-ba9c-277415654e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715b89c9-2820-41ec-8a87-b2657ca0c7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715b89c9-2820-41ec-8a87-b2657ca0c7fe.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -16645,7 +16645,7 @@
         },
         {
             "id": "6a7a647a-3e66-5337-a3a7-43c2ac4cde01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c81707-adf0-48fd-8720-25db4d21b0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c81707-adf0-48fd-8720-25db4d21b0b2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -16710,7 +16710,7 @@
         },
         {
             "id": "f7df56ba-1197-5f9c-919a-ae113a2cf30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0520813a-fe20-4bde-8dc9-9a7add51c722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0520813a-fe20-4bde-8dc9-9a7add51c722.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -16774,7 +16774,7 @@
         },
         {
             "id": "8496effd-cd3a-59de-bbb4-274080a8be3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52248fe8-0f1b-4e3d-9024-842c921b6071.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52248fe8-0f1b-4e3d-9024-842c921b6071.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -16848,7 +16848,7 @@
         },
         {
             "id": "5ee92c69-36a6-5434-9249-b965500829bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940a241-4efd-42f7-a670-2c4fed4755bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a940a241-4efd-42f7-a670-2c4fed4755bb.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -16913,7 +16913,7 @@
         },
         {
             "id": "378eda7c-bc89-5df9-89cb-83772d671b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc19f85-7ef6-4fd2-83e5-0dbae1d80f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc19f85-7ef6-4fd2-83e5-0dbae1d80f2b.jpg?1",
             "name": "Atraxa, Praetors' Voice",
             "text": "",
             "colours": [
@@ -16956,7 +16956,7 @@
         },
         {
             "id": "b2dd308c-14ff-532d-a8e7-5bd00f0f9453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581591f0-b3c7-4fca-b4b9-1d1d098ca7fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581591f0-b3c7-4fca-b4b9-1d1d098ca7fb.jpg?1",
             "name": "Breya, Etherium Shaper",
             "text": "",
             "colours": [
@@ -16998,7 +16998,7 @@
         },
         {
             "id": "9dcb465c-b70f-5602-a05a-30f8382a3fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd008c4-884a-4c98-8842-8f4b35fbdf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcd008c4-884a-4c98-8842-8f4b35fbdf81.jpg?1",
             "name": "Yidris, Maelstrom Wielder",
             "text": "",
             "colours": [
@@ -17040,7 +17040,7 @@
         },
         {
             "id": "63d0b867-d88f-5d66-a425-7b88ff582318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff751c7-34c9-498a-bd9f-c6b0c8a194f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff751c7-34c9-498a-bd9f-c6b0c8a194f4.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -17071,7 +17071,7 @@
         },
         {
             "id": "69f00130-e3d5-5039-803f-6dcf8247b2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afd57f-d4cb-4219-a2c7-28ed9b1abe0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70afd57f-d4cb-4219-a2c7-28ed9b1abe0f.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -17102,7 +17102,7 @@
         },
         {
             "id": "73351878-a198-5524-9729-4aa2f87f76f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ecd9bf-757b-4eeb-bef3-0b9ad2e86fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ecd9bf-757b-4eeb-bef3-0b9ad2e86fca.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -17133,7 +17133,7 @@
         },
         {
             "id": "8b7b55b9-2a84-56d6-baf1-b0e62908cf74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0481ee-a028-436d-a4f8-a43720d1e542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0481ee-a028-436d-a4f8-a43720d1e542.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -17164,7 +17164,7 @@
         },
         {
             "id": "4cf6c6c8-54a9-5f9d-9344-2e96ca864412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe0942-a5c9-4821-9992-19467e3a1176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6fe0942-a5c9-4821-9992-19467e3a1176.jpg?1",
             "name": "Sunpetal Grove",
             "text": "",
             "colours": [],
@@ -17195,7 +17195,7 @@
         },
         {
             "id": "45b88c0e-5ae5-567e-9ed5-f746ff20df7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbfddff-bf1b-49c3-a169-f45e53150a6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbfddff-bf1b-49c3-a169-f45e53150a6c.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "",
             "colours": [
@@ -17232,7 +17232,7 @@
         },
         {
             "id": "122c4f95-af05-5bb5-aad9-c18ab8294c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06379f71-2125-4d9b-b0d2-b7b80451076c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06379f71-2125-4d9b-b0d2-b7b80451076c.jpg?1",
             "name": "Balthor the Defiled",
             "text": "",
             "colours": [
@@ -17269,7 +17269,7 @@
         },
         {
             "id": "66bd9fcc-2b7c-57e7-a21a-b188c22fe9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a767f185-bf9c-450a-b699-9a20bb3686c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a767f185-bf9c-450a-b699-9a20bb3686c6.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "",
             "colours": [
@@ -17308,7 +17308,7 @@
         },
         {
             "id": "398d6058-0252-5178-8743-c1ea568918ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27b8285-69f7-441e-91b0-7519f306b512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27b8285-69f7-441e-91b0-7519f306b512.jpg?1",
             "name": "Depala, Pilot Exemplar",
             "text": "",
             "colours": [
@@ -17347,7 +17347,7 @@
         },
         {
             "id": "22e6bfe2-fa7f-508a-ab9a-dea60c70f519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d354e2c-b83d-47f2-a8c4-0234ea9ef5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d354e2c-b83d-47f2-a8c4-0234ea9ef5bf.jpg?1",
             "name": "Nomad Outpost",
             "text": "",
             "colours": [],
@@ -17379,7 +17379,7 @@
         },
         {
             "id": "2231ab92-6cfb-5eca-90f9-dc2af6f9c611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c23ffd3-dcee-4b29-99f0-4502c19f0947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c23ffd3-dcee-4b29-99f0-4502c19f0947.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17444,7 +17444,7 @@
         },
         {
             "id": "832c7718-fb81-5815-8abe-a558f341c59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23df4919-1a2f-489a-ad21-e8df0e2847ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23df4919-1a2f-489a-ad21-e8df0e2847ee.jpg?1",
             "name": "Concordant Crossroads",
             "text": "",
             "colours": [
@@ -17478,7 +17478,7 @@
         },
         {
             "id": "077a153d-4c5c-5357-8a19-4dc042ff47bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b58a5d-1eed-41ca-a2ea-d17763e7e22d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b58a5d-1eed-41ca-a2ea-d17763e7e22d.jpg?1",
             "name": "Ghost Quarter",
             "text": "",
             "colours": [],
@@ -17508,7 +17508,7 @@
         },
         {
             "id": "72a92fa5-7e15-5d54-8e50-c12793d9fac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a28aa07-8b36-4048-9b71-dcb34b96068a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a28aa07-8b36-4048-9b71-dcb34b96068a.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -17535,7 +17535,7 @@
         },
         {
             "id": "4dc0dd58-53d9-5f57-82c8-aeeb5b99eda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ed19f-65c4-4459-9bb9-65156a62e84d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ed19f-65c4-4459-9bb9-65156a62e84d.jpg?1",
             "name": "Command Beacon",
             "text": "",
             "colours": [],
@@ -17565,7 +17565,7 @@
         },
         {
             "id": "288775f3-ac12-5fda-85de-440a9bf81ff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5227dec4-5015-462b-94e9-a1dda8b9de49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5227dec4-5015-462b-94e9-a1dda8b9de49.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -17596,7 +17596,7 @@
         },
         {
             "id": "0d0fc053-5833-5624-937b-38bd68b674fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570ecdd3-ad07-4445-9172-81a185a0d838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570ecdd3-ad07-4445-9172-81a185a0d838.jpg?1",
             "name": "Strip Mine",
             "text": "",
             "colours": [],
@@ -17623,7 +17623,7 @@
         },
         {
             "id": "ce7a496d-b006-53b7-8b69-d8262c3de1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a292b47-95b2-4e10-a31f-a619ed046b8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a292b47-95b2-4e10-a31f-a619ed046b8e.jpg?1",
             "name": "Mother of Runes",
             "text": "",
             "colours": [
@@ -17663,7 +17663,7 @@
         },
         {
             "id": "54aa7009-2467-5a59-ac8a-610667dc7520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776cb6c-548f-45a9-b605-b386c5468885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f776cb6c-548f-45a9-b605-b386c5468885.jpg?1",
             "name": "Death's Shadow",
             "text": "",
             "colours": [
@@ -17697,7 +17697,7 @@
         },
         {
             "id": "80a3cdbc-6d0e-5d52-8170-d348a0e36c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9da45b-54ae-49c1-af50-8b88912c5bcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a9da45b-54ae-49c1-af50-8b88912c5bcd.jpg?1",
             "name": "Elvish Mystic",
             "text": "",
             "colours": [
@@ -17734,7 +17734,7 @@
         },
         {
             "id": "5e969568-0cd3-5773-b714-338ab7f87f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5a81e-1efc-46f3-b169-0422cbc8cd5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d5a81e-1efc-46f3-b169-0422cbc8cd5e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17799,7 +17799,7 @@
         },
         {
             "id": "4db1b7ed-7ebc-5c79-94f1-e4bd961f0268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75192ef-5087-43ed-88bc-2dcd17793483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75192ef-5087-43ed-88bc-2dcd17793483.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -17833,7 +17833,7 @@
         },
         {
             "id": "1df90f3c-8ca1-5ffd-ba84-43e73ec44660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85474-e0e5-40cf-b0a3-a2b7da7f7000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a85474-e0e5-40cf-b0a3-a2b7da7f7000.jpg?1",
             "name": "Rhystic Study",
             "text": "",
             "colours": [
@@ -17865,7 +17865,7 @@
         },
         {
             "id": "685364a7-05e3-5001-8bc8-113eeaa03705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948bd881-f926-413f-99cf-013b5761c851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948bd881-f926-413f-99cf-013b5761c851.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -17897,7 +17897,7 @@
         },
         {
             "id": "1ecdcf0d-0a2f-5cf6-b4fc-08ca628814d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20006931-eaef-4a86-8082-cf487156ef71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20006931-eaef-4a86-8082-cf487156ef71.jpg?1",
             "name": "Seize the Day",
             "text": "",
             "colours": [
@@ -17931,7 +17931,7 @@
         },
         {
             "id": "9eabc885-ed84-5e7c-97f2-11addeabd2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b631f-7b03-441a-b551-59236d79804c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b631f-7b03-441a-b551-59236d79804c.jpg?1",
             "name": "Krosan Grip",
             "text": "",
             "colours": [
@@ -17963,7 +17963,7 @@
         },
         {
             "id": "81e823e1-f931-5b53-90f8-22a1d93d0a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864fd80-baee-468e-9dc3-e650cc203b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e864fd80-baee-468e-9dc3-e650cc203b23.jpg?1",
             "name": "Counterflux",
             "text": "",
             "colours": [
@@ -17997,7 +17997,7 @@
         },
         {
             "id": "89a6f0a2-4fd6-539c-9f85-f0fcb4b70513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186a57f5-5806-4373-90a6-0da950a11054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186a57f5-5806-4373-90a6-0da950a11054.jpg?1",
             "name": "Thran Dynamo",
             "text": "",
             "colours": [],
@@ -18025,7 +18025,7 @@
         },
         {
             "id": "c89dbb21-eb43-58d7-8e21-0675a676d103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37dd1c-27f6-409d-932e-56520a65791a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef37dd1c-27f6-409d-932e-56520a65791a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -18094,7 +18094,7 @@
         },
         {
             "id": "9375a92c-10e1-5833-ae66-b490cd7bb926",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31915934-1e12-49ad-a745-30e1106b4eff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31915934-1e12-49ad-a745-30e1106b4eff.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -18159,7 +18159,7 @@
         },
         {
             "id": "731a07a7-c749-58a7-972c-9a628d490977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa4980a-dcd8-48e0-aca8-ef1590f51c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa4980a-dcd8-48e0-aca8-ef1590f51c10.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -18223,7 +18223,7 @@
         },
         {
             "id": "ce8cbf0c-2694-5ada-87b3-d11c591506b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5687c7d1-4794-4132-9ca2-b039905882a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5687c7d1-4794-4132-9ca2-b039905882a3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -18297,7 +18297,7 @@
         },
         {
             "id": "b3e076dc-319b-57f6-bc44-7b5de877d5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9fe02-124c-4d5c-8526-a763272e05f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9ff9fe02-124c-4d5c-8526-a763272e05f4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -18362,7 +18362,7 @@
         },
         {
             "id": "8c49521d-944f-5456-a54b-8e0b61854e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf75f895-3481-4c21-a85f-c819613bccc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf75f895-3481-4c21-a85f-c819613bccc3.jpg?1",
             "name": "Akroma, Angel of Wrath",
             "text": "",
             "colours": [
@@ -18398,7 +18398,7 @@
         },
         {
             "id": "179954f3-675b-5575-bbcd-c70a09400695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39059423-c4f6-4371-b530-48cdc36e513f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39059423-c4f6-4371-b530-48cdc36e513f.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "",
             "colours": [
@@ -18435,7 +18435,7 @@
         },
         {
             "id": "db15cb3f-5362-543b-9c15-5a166202eea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba320b49-5f1a-4487-8d75-504c534cf522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba320b49-5f1a-4487-8d75-504c534cf522.jpg?1",
             "name": "Glissa Sunseeker",
             "text": "",
             "colours": [
@@ -18472,7 +18472,7 @@
         },
         {
             "id": "7d2f6b02-ead9-51c1-9b1d-b03ad9f6f8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f860fcf-eda1-4a83-9be7-80b7c34fff94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f860fcf-eda1-4a83-9be7-80b7c34fff94.jpg?1",
             "name": "Olivia, Mobilized for War",
             "text": "",
             "colours": [
@@ -18513,7 +18513,7 @@
         },
         {
             "id": "b67b5795-19dc-5240-bde6-4d3a98a7a13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9fe41f-c81d-439c-ae40-72312036678a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9fe41f-c81d-439c-ae40-72312036678a.jpg?1",
             "name": "Kozilek, the Great Distortion",
             "text": "",
             "colours": [],
@@ -18545,7 +18545,7 @@
         },
         {
             "id": "3a97762e-8bf8-5dc3-8e13-cefdae2657a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66bda12-18da-43e2-a5e2-16d2c5e4d070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66bda12-18da-43e2-a5e2-16d2c5e4d070.jpg?1",
             "name": "Primeval Titan",
             "text": "",
             "colours": [
@@ -18581,7 +18581,7 @@
         },
         {
             "id": "b943872d-f3b8-59e0-9fa1-a6df31399225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -18620,7 +18620,7 @@
         },
         {
             "id": "d85fd1dd-7593-51d9-a5bf-5ec39782408a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72216dfe-f14c-45ef-84f7-71fc1204e4cf.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -18658,7 +18658,7 @@
         },
         {
             "id": "91e5908a-97d9-5ee0-83e2-4dc68c973313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94765871-5785-429b-8980-e2b1667278a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94765871-5785-429b-8980-e2b1667278a5.jpg?1",
             "name": "Platinum Angel",
             "text": "",
             "colours": [],
@@ -18689,7 +18689,7 @@
         },
         {
             "id": "15a9821e-3d6d-5d74-8952-6926d2038146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e475d2-a813-43d0-aa6b-4a16e92d7375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e475d2-a813-43d0-aa6b-4a16e92d7375.jpg?1",
             "name": "Brimaz, King of Oreskos",
             "text": "",
             "colours": [
@@ -18726,7 +18726,7 @@
         },
         {
             "id": "783e15bc-1fa7-5d82-b803-5bb39cc6604a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ff3bdd-bfd0-4cea-9493-85632b126cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ff3bdd-bfd0-4cea-9493-85632b126cf1.jpg?1",
             "name": "Arcanis the Omnipotent",
             "text": "",
             "colours": [
@@ -18762,7 +18762,7 @@
         },
         {
             "id": "232b3ca7-6b40-589f-ac8e-d3197e83947b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15bebe2-ae6a-48b4-b203-5ab78996b86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15bebe2-ae6a-48b4-b203-5ab78996b86f.jpg?1",
             "name": "Queen Marchesa",
             "text": "",
             "colours": [
@@ -18805,7 +18805,7 @@
         },
         {
             "id": "47812b57-599e-5f4c-85dc-8a27a6b503ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df93b357-f1be-423a-96c3-a4ceecdeb441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df93b357-f1be-423a-96c3-a4ceecdeb441.jpg?1",
             "name": "Savra, Queen of the Golgari",
             "text": "",
             "colours": [
@@ -18844,7 +18844,7 @@
         },
         {
             "id": "8cad1462-e198-5146-bbb2-97c43f1f55bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c0968c-1377-447b-bede-5a2482d4cd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c0968c-1377-447b-bede-5a2482d4cd2b.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "",
             "colours": [],
@@ -18877,7 +18877,7 @@
         },
         {
             "id": "05336fdd-de97-5283-8a23-864d1eba50be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86395749-e85a-460a-b14d-7228030bde59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86395749-e85a-460a-b14d-7228030bde59.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "",
             "colours": [],
@@ -18910,7 +18910,7 @@
         },
         {
             "id": "baf25a2d-bccb-5498-89d5-b479217f29b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d82cf3e-b29f-4eb1-a58f-dadddc6d7ec2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d82cf3e-b29f-4eb1-a58f-dadddc6d7ec2.jpg?1",
             "name": "Gideon Blackblade",
             "text": "",
             "colours": [
@@ -18945,7 +18945,7 @@
         },
         {
             "id": "20b0881f-3359-53ec-864f-cd0b1469fc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8ca73-388c-429f-8c75-afb5839cfb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8ca73-388c-429f-8c75-afb5839cfb42.jpg?1",
             "name": "Teyo, the Shieldmage",
             "text": "",
             "colours": [
@@ -18980,7 +18980,7 @@
         },
         {
             "id": "6453be0d-20ab-5acf-bef2-36feafc3b932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c428225-e17f-46b8-96d4-933ad0023d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c428225-e17f-46b8-96d4-933ad0023d2a.jpg?1",
             "name": "The Wanderer",
             "text": "",
             "colours": [
@@ -19013,7 +19013,7 @@
         },
         {
             "id": "cb8780b3-7dc0-5b88-a5d9-e24ad0360098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802d126d-f56c-4990-ba85-9ecbe41f5c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802d126d-f56c-4990-ba85-9ecbe41f5c9a.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -19051,7 +19051,7 @@
         },
         {
             "id": "fef3dba0-5182-5b2c-9037-f079fd0ef4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a25476-a256-457f-a5b8-82c6919ac13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a25476-a256-457f-a5b8-82c6919ac13a.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "",
             "colours": [
@@ -19086,7 +19086,7 @@
         },
         {
             "id": "364581d5-2179-51f4-92db-e8fd6694d069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6710a1e4-299c-4ce1-afda-265d27097061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6710a1e4-299c-4ce1-afda-265d27097061.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -19124,7 +19124,7 @@
         },
         {
             "id": "3ca4fa1e-06a9-59ac-813e-b4e7a35aa58d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba61ea6-67b5-49f4-bd1d-9674337f9004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba61ea6-67b5-49f4-bd1d-9674337f9004.jpg?1",
             "name": "Davriel, Rogue Shadowmage",
             "text": "",
             "colours": [
@@ -19159,7 +19159,7 @@
         },
         {
             "id": "a060260c-3686-5a1d-9f2c-fac8fc5f6589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcf9ac-f0f7-405b-960b-ebf15b2640a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bcf9ac-f0f7-405b-960b-ebf15b2640a7.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "",
             "colours": [
@@ -19194,7 +19194,7 @@
         },
         {
             "id": "e05ba1f6-9930-52d0-94b3-fa45f4c41087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9ac88-d6d4-4c20-8a3e-269d22884ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d9ac88-d6d4-4c20-8a3e-269d22884ca5.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "",
             "colours": [
@@ -19229,7 +19229,7 @@
         },
         {
             "id": "fe2101a6-d415-51b3-b6a1-52fda7d4ded3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c5033c-3f25-4b31-8f4b-784d8aaf6150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c5033c-3f25-4b31-8f4b-784d8aaf6150.jpg?1",
             "name": "Chandra, Fire Artisan",
             "text": "",
             "colours": [
@@ -19264,7 +19264,7 @@
         },
         {
             "id": "1f40664a-37ae-5f9c-8592-1da87f0bf272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6c3050-965a-466c-b7a2-d190cee42bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6c3050-965a-466c-b7a2-d190cee42bdf.jpg?1",
             "name": "Jaya, Venerated Firemage",
             "text": "",
             "colours": [
@@ -19299,7 +19299,7 @@
         },
         {
             "id": "413a5fec-a916-56da-85cf-dcb7769a1ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c6d2-270e-401d-8039-328adf280389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c6d2-270e-401d-8039-328adf280389.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "",
             "colours": [
@@ -19334,7 +19334,7 @@
         },
         {
             "id": "82ecc191-7b07-566e-9ac9-3052a4a2b8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd6cc0-91b5-47ca-8f3d-c25cf26b81d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd6cc0-91b5-47ca-8f3d-c25cf26b81d7.jpg?1",
             "name": "Tibalt, Rakish Instigator",
             "text": "",
             "colours": [
@@ -19369,7 +19369,7 @@
         },
         {
             "id": "2b04625c-8f93-547d-81bd-673930c71e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792a7e8-1afd-4fe9-9a20-4131954f1983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b792a7e8-1afd-4fe9-9a20-4131954f1983.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "",
             "colours": [
@@ -19404,7 +19404,7 @@
         },
         {
             "id": "76fdee6a-5612-5160-9c1c-9bb80770ad29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d78dcd4-c64c-4d10-91e2-432d24e801d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d78dcd4-c64c-4d10-91e2-432d24e801d4.jpg?1",
             "name": "Jiang Yanggu, Wildcrafter",
             "text": "",
             "colours": [
@@ -19439,7 +19439,7 @@
         },
         {
             "id": "ff52648a-1ed8-59ed-a803-5af75f4fa303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966bb2-1634-400e-9dd0-b8befda81f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb966bb2-1634-400e-9dd0-b8befda81f6a.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "",
             "colours": [
@@ -19476,7 +19476,7 @@
         },
         {
             "id": "fc3bf4c5-da81-5b1f-9e1f-016fcfb8814f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9967520f-3c8e-42a2-b9dd-887714477c2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9967520f-3c8e-42a2-b9dd-887714477c2d.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "",
             "colours": [
@@ -19511,7 +19511,7 @@
         },
         {
             "id": "14b61553-65c4-5d37-9621-1d9f60039ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b33e71-ef08-4aeb-bca2-a2a4a43c2e0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b33e71-ef08-4aeb-bca2-a2a4a43c2e0d.jpg?1",
             "name": "Ajani, the Greathearted",
             "text": "",
             "colours": [
@@ -19548,7 +19548,7 @@
         },
         {
             "id": "9ac26cdc-1b5e-5bf0-b1f6-0e82564f5622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd69ed9-4c33-4bb5-89a3-fd042d1daa1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cd69ed9-4c33-4bb5-89a3-fd042d1daa1f.jpg?1",
             "name": "Domri, Anarch of Bolas",
             "text": "",
             "colours": [
@@ -19585,7 +19585,7 @@
         },
         {
             "id": "ce5bbfc6-7e82-58b5-a001-e5aa574f1528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830e76d-7d38-4f6e-8ab7-abd9ac3fb0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6830e76d-7d38-4f6e-8ab7-abd9ac3fb0d9.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "",
             "colours": [
@@ -19626,7 +19626,7 @@
         },
         {
             "id": "1072c9aa-f4bd-53a5-bf91-70a8434693b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828289fa-6335-43c3-9d42-1c0199b9af67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/828289fa-6335-43c3-9d42-1c0199b9af67.jpg?1",
             "name": "Ral, Storm Conduit",
             "text": "",
             "colours": [
@@ -19663,7 +19663,7 @@
         },
         {
             "id": "f5f5e528-1470-5281-89ec-621de9d17896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48b7f2a-2195-4b1a-a5f2-3d9e99aa1b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c48b7f2a-2195-4b1a-a5f2-3d9e99aa1b5a.jpg?1",
             "name": "Sorin, Vengeful Bloodlord",
             "text": "",
             "colours": [
@@ -19700,7 +19700,7 @@
         },
         {
             "id": "38a3fb90-1e62-5aa0-ba67-d6e1571c6d06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b45d79-4526-490d-9771-9445e45307a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b45d79-4526-490d-9771-9445e45307a7.jpg?1",
             "name": "Tamiyo, Collector of Tales",
             "text": "",
             "colours": [
@@ -19737,7 +19737,7 @@
         },
         {
             "id": "2584786d-7f06-5a9e-ae9a-9115302af3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b2e55-21a3-4f71-a14b-d3d1b137d18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b2e55-21a3-4f71-a14b-d3d1b137d18c.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -19776,7 +19776,7 @@
         },
         {
             "id": "e414f7b7-9bdc-5c1b-8693-c134d3263101",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129851e1-8dca-4a90-8615-5ea642b61e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129851e1-8dca-4a90-8615-5ea642b61e71.jpg?1",
             "name": "Angrath, Captain of Chaos",
             "text": "",
             "colours": [
@@ -19813,7 +19813,7 @@
         },
         {
             "id": "c62fe142-8eb3-5409-a575-1cc38ca86de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c48e42-5c82-4212-ace5-348177dc04b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c48e42-5c82-4212-ace5-348177dc04b2.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "",
             "colours": [
@@ -19852,7 +19852,7 @@
         },
         {
             "id": "1d0f782e-1a38-50d3-9bbd-61537f5d39d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f906233-7223-4e59-a6dd-2fb2db2d8e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f906233-7223-4e59-a6dd-2fb2db2d8e40.jpg?1",
             "name": "Dovin, Hand of Control",
             "text": "",
             "colours": [
@@ -19889,7 +19889,7 @@
         },
         {
             "id": "bb75cecf-fd39-511d-8752-6b39fbb5fed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d05299-27bd-4826-bbdb-f24ac9a5005b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d05299-27bd-4826-bbdb-f24ac9a5005b.jpg?1",
             "name": "Huatli, the Sun's Heart",
             "text": "",
             "colours": [
@@ -19926,7 +19926,7 @@
         },
         {
             "id": "f9747b6a-4e4d-599c-a92c-995e9b1fefd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ef2d-d94a-4970-b7dd-47f335f33dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3de9ef2d-d94a-4970-b7dd-47f335f33dfc.jpg?1",
             "name": "Kaya, Bane of the Dead",
             "text": "",
             "colours": [
@@ -19963,7 +19963,7 @@
         },
         {
             "id": "ab09b581-bb4d-5349-93fd-4fb701aad879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cf8664-a29d-4d64-af14-7c2002488ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4cf8664-a29d-4d64-af14-7c2002488ba2.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "",
             "colours": [
@@ -20002,7 +20002,7 @@
         },
         {
             "id": "f3a2fe37-1c53-53d0-b4f6-ec6f0d52419b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c664a0f7-f1df-4c34-8755-a53afea7ddba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c664a0f7-f1df-4c34-8755-a53afea7ddba.jpg?1",
             "name": "Nahiri, Storm of Stone",
             "text": "",
             "colours": [
@@ -20039,7 +20039,7 @@
         },
         {
             "id": "709ff9c9-890f-5e52-a7c8-c05cbcd946f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bbc692-8d2e-4487-bd19-1a5c78fd3d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8bbc692-8d2e-4487-bd19-1a5c78fd3d53.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "",
             "colours": [
@@ -20078,7 +20078,7 @@
         },
         {
             "id": "6d6e9894-af90-5731-84fb-3f79a8065414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cdce67-67c0-4b1e-8f86-6e7d6b9fc6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cdce67-67c0-4b1e-8f86-6e7d6b9fc6c2.jpg?1",
             "name": "Samut, Tyrant Smasher",
             "text": "",
             "colours": [
@@ -20115,7 +20115,7 @@
         },
         {
             "id": "1ceb0101-f995-5d4b-8738-9f948055c3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a1df85-9dc9-470b-a0d8-956b63440a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a1df85-9dc9-470b-a0d8-956b63440a20.jpg?1",
             "name": "Vraska, Swarm's Eminence",
             "text": "",
             "colours": [
@@ -20152,7 +20152,7 @@
         },
         {
             "id": "7b013c74-2c7a-5500-86a9-f6b1cc6f5763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da28f3-2b23-47ad-975a-6b7b204efecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3da28f3-2b23-47ad-975a-6b7b204efecb.jpg?1",
             "name": "Tibalt, the Fiend-Blooded",
             "text": "",
             "colours": [
@@ -20187,7 +20187,7 @@
         },
         {
             "id": "871e70ac-ab31-53e6-85fc-dfcf472776dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3df6-da4e-48bd-92d5-349bc60d7150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/478c3df6-da4e-48bd-92d5-349bc60d7150.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -20217,7 +20217,7 @@
         },
         {
             "id": "d8d3610f-e848-51d4-9614-70734390dc68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8f29a-5771-4407-8a2b-cfeeeff04611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f8f29a-5771-4407-8a2b-cfeeeff04611.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -20281,7 +20281,7 @@
         },
         {
             "id": "e38ec94c-070a-5590-94e4-86d62dbd64d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3733ca13-1398-4f8f-a885-4b0b2c498d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3733ca13-1398-4f8f-a885-4b0b2c498d2b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20349,7 +20349,7 @@
         },
         {
             "id": "fc3601c3-aa97-5d3e-8ba3-4e0878194c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796f129d-912f-400b-8077-7b2873ec2040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796f129d-912f-400b-8077-7b2873ec2040.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20417,7 +20417,7 @@
         },
         {
             "id": "f360db77-eb35-577a-aec9-eac9263155ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4323e4e0-399e-495e-b090-7f3783fc4e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4323e4e0-399e-495e-b090-7f3783fc4e4c.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20485,7 +20485,7 @@
         },
         {
             "id": "f2bace3e-1288-5d5e-9ea2-a0a432702826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceb6a79-6d36-4780-b9c0-557fc3676c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fceb6a79-6d36-4780-b9c0-557fc3676c19.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20553,7 +20553,7 @@
         },
         {
             "id": "4c547692-5209-5c0b-bd4b-1534a248e64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d21476a-6112-4f2a-b87e-e4aea514dcc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d21476a-6112-4f2a-b87e-e4aea514dcc7.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20621,7 +20621,7 @@
         },
         {
             "id": "930530ee-d546-5b14-b7de-edeea8102f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43da6f6-fe15-41d3-932d-4ec3d16cc0b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43da6f6-fe15-41d3-932d-4ec3d16cc0b2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20689,7 +20689,7 @@
         },
         {
             "id": "c7ed00f8-7186-51af-9cd7-bba7a3453da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959d473-10aa-482a-b5aa-ff7bb15cc128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3959d473-10aa-482a-b5aa-ff7bb15cc128.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20757,7 +20757,7 @@
         },
         {
             "id": "8eadb3f9-97d5-5dae-9e81-184bad08e6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ec1f39-08e0-45ce-b4ec-c25d64bd3461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ec1f39-08e0-45ce-b4ec-c25d64bd3461.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -20825,7 +20825,7 @@
         },
         {
             "id": "0c2b38c5-f60e-5eb5-96ae-316407a40a1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0563dcbc-59da-468a-97ed-37cd5e36d14a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0563dcbc-59da-468a-97ed-37cd5e36d14a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -20889,7 +20889,7 @@
         },
         {
             "id": "b8cae71f-699c-5c9c-ab64-76ce9dc94930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41829a8c-5ab2-4c44-bf6a-09bad991ab78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41829a8c-5ab2-4c44-bf6a-09bad991ab78.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -20953,7 +20953,7 @@
         },
         {
             "id": "2dfdd05b-d953-5792-b10d-73364635bafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fa28f3-0a91-48c5-9433-4da6e223011c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fa28f3-0a91-48c5-9433-4da6e223011c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21017,7 +21017,7 @@
         },
         {
             "id": "c536a9f4-bdc0-5bf1-828e-7cfd8e2c93af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b62f53-0fde-488b-bdac-986a870ff6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b62f53-0fde-488b-bdac-986a870ff6cb.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21081,7 +21081,7 @@
         },
         {
             "id": "d755a7ea-d9ad-520e-bfb5-4293ffeb6a58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b487e4c0-1135-46f4-807d-cab3f1743132.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b487e4c0-1135-46f4-807d-cab3f1743132.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21145,7 +21145,7 @@
         },
         {
             "id": "5b4b42a4-f4dd-5640-a23c-2dc3a59a3b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5df5731-c9ce-417a-ae07-0359f4e1a989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5df5731-c9ce-417a-ae07-0359f4e1a989.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21209,7 +21209,7 @@
         },
         {
             "id": "eb9295cc-ca63-5551-90f3-1660f14b14ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f83a756-e520-4f72-932c-73fa6ee10500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f83a756-e520-4f72-932c-73fa6ee10500.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21273,7 +21273,7 @@
         },
         {
             "id": "51650413-c00b-5967-8492-b030dd124370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff1e8ef-4856-46c0-a72c-83a8b4d34238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff1e8ef-4856-46c0-a72c-83a8b4d34238.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21337,7 +21337,7 @@
         },
         {
             "id": "e1a10fcb-a6e6-5fad-b877-528244b141d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8ea25-dfed-4453-9e63-57339f948cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8ea25-dfed-4453-9e63-57339f948cac.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21400,7 +21400,7 @@
         },
         {
             "id": "edf14f47-98ea-562c-be74-4851411f98e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551eeb34-09d7-4d08-a0fa-dc313c946279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551eeb34-09d7-4d08-a0fa-dc313c946279.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21463,7 +21463,7 @@
         },
         {
             "id": "7587099e-0e27-592e-b5c1-6d94ec0275b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453aa0d9-b535-4bd9-951c-4304773399b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453aa0d9-b535-4bd9-951c-4304773399b1.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21526,7 +21526,7 @@
         },
         {
             "id": "c9be36b7-cc99-5d5a-ace9-bfface591e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d6c388-5da9-4c7a-907f-dfa7237e71aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d6c388-5da9-4c7a-907f-dfa7237e71aa.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21589,7 +21589,7 @@
         },
         {
             "id": "23f890d0-6800-5e0e-9cde-eb4c1103f01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084efea7-2a22-4cca-a1f9-b47aad2ebcac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/084efea7-2a22-4cca-a1f9-b47aad2ebcac.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21652,7 +21652,7 @@
         },
         {
             "id": "6d7456db-b6a0-5e2f-96db-0452224da8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf253ee5-378b-4396-b826-4c0f2fae38a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf253ee5-378b-4396-b826-4c0f2fae38a0.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21715,7 +21715,7 @@
         },
         {
             "id": "1e48e4be-022d-5284-8ede-9c6da9ba0224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13964bf9-c391-438a-a28c-2a0716375e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13964bf9-c391-438a-a28c-2a0716375e0c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21778,7 +21778,7 @@
         },
         {
             "id": "6bdbc284-b15b-503e-a6ae-af63740bace3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65422b02-47ee-4c68-ac27-81fa6368864e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65422b02-47ee-4c68-ac27-81fa6368864e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21841,7 +21841,7 @@
         },
         {
             "id": "a8e59b37-79a0-510d-9540-6b595307acf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d25ead-70d6-4abd-b611-6c94ce042c89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d25ead-70d6-4abd-b611-6c94ce042c89.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21914,7 +21914,7 @@
         },
         {
             "id": "f36c5de3-7e73-5d11-88a6-63b3b2ff7271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b46e72-6ed0-47c1-ad42-38a893620fa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b46e72-6ed0-47c1-ad42-38a893620fa1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21987,7 +21987,7 @@
         },
         {
             "id": "3cf3ef03-f0e2-5014-b215-7f8514f97cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a2aea9-8b3a-4be3-aaa0-4c4a19f63d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a2aea9-8b3a-4be3-aaa0-4c4a19f63d02.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22060,7 +22060,7 @@
         },
         {
             "id": "b8cbc454-7fb8-5560-b53a-7e0c58e2fced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9894ec2c-e5c2-42a5-b44a-76ec02684171.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9894ec2c-e5c2-42a5-b44a-76ec02684171.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22133,7 +22133,7 @@
         },
         {
             "id": "5d95b204-f001-5c06-9059-5ac56188bd8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340b671-7daf-4f84-80a9-2ca4278aa33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340b671-7daf-4f84-80a9-2ca4278aa33b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22206,7 +22206,7 @@
         },
         {
             "id": "ac68899a-afdd-548d-b053-04c39856efe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831f40f9-2642-4313-99ec-a4a7afe2839d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831f40f9-2642-4313-99ec-a4a7afe2839d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22279,7 +22279,7 @@
         },
         {
             "id": "4b209caf-f91e-53f5-9d8f-f872606534ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eda14c-5e33-41cc-8651-109f5ef97bb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97eda14c-5e33-41cc-8651-109f5ef97bb0.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22352,7 +22352,7 @@
         },
         {
             "id": "098401e9-632b-581c-8197-31bbdc6eb21f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9252dd84-ba93-440a-bc2f-36fb703fb57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9252dd84-ba93-440a-bc2f-36fb703fb57d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -22425,7 +22425,7 @@
         },
         {
             "id": "5f280509-aabb-5891-a0c6-d4f6528645b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0560b5ed-821a-479f-91fb-98ade4a8d470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0560b5ed-821a-479f-91fb-98ade4a8d470.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22489,7 +22489,7 @@
         },
         {
             "id": "ace78bd8-8b1d-5e82-affb-109874796cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3093b-4f83-41fb-9290-757a3b2fa468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3093b-4f83-41fb-9290-757a3b2fa468.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22553,7 +22553,7 @@
         },
         {
             "id": "997355f9-60e2-5418-9312-33d76d5aa23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345293f-e71e-4754-bf88-b3c8b9824ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1345293f-e71e-4754-bf88-b3c8b9824ab3.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22617,7 +22617,7 @@
         },
         {
             "id": "da62f480-a4a3-5050-9243-cea5ae234fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81b803f-e065-4f79-b5e4-e45fb1815443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81b803f-e065-4f79-b5e4-e45fb1815443.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22681,7 +22681,7 @@
         },
         {
             "id": "636c69ab-6a4f-5703-8908-ce42c5823f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016e556-5597-440d-b737-b419acb4e44e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4016e556-5597-440d-b737-b419acb4e44e.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22745,7 +22745,7 @@
         },
         {
             "id": "0e46181c-d563-5f77-b3e2-d3558ac7573e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f774cc-ac13-4bc6-967c-af09358a8da4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f774cc-ac13-4bc6-967c-af09358a8da4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22809,7 +22809,7 @@
         },
         {
             "id": "d40dd836-c202-5743-b044-d8a94f2d6f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc1b2e-945c-4d44-b973-3a299325e756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cc1b2e-945c-4d44-b973-3a299325e756.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22873,7 +22873,7 @@
         },
         {
             "id": "5cb1a341-f791-584c-b53d-10dbd437554a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849969bd-60ec-4e91-9d14-3a50b0346ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849969bd-60ec-4e91-9d14-3a50b0346ca9.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -22937,7 +22937,7 @@
         },
         {
             "id": "5ed427ac-a783-5a2c-9c96-a9cfba688e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f06af-47bd-4ede-a174-21be69387c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92f06af-47bd-4ede-a174-21be69387c1b.jpg?1",
             "name": "Gisa's Favorite Shovel",
             "text": "",
             "colours": [
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "81804f37-fb5c-5679-80fb-28fbc8820140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04872b4a-8231-494e-8a6e-596c66797011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04872b4a-8231-494e-8a6e-596c66797011.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -23007,7 +23007,7 @@
         },
         {
             "id": "fd684563-5118-5eb2-b766-f74959e5308a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b168b85-323c-4d95-80a5-851988522606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b168b85-323c-4d95-80a5-851988522606.jpg?1",
             "name": "Fblthp, the Lost",
             "text": "",
             "colours": [
@@ -23043,7 +23043,7 @@
         },
         {
             "id": "bb935e2e-2860-50b1-8654-c6e5e1bd25b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f621e8-4787-42ce-828d-72cec68acc6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f621e8-4787-42ce-828d-72cec68acc6c.jpg?1",
             "name": "Wrexial, the Risen Deep",
             "text": "",
             "colours": [
@@ -23080,7 +23080,7 @@
         },
         {
             "id": "891264cf-3526-5384-b43e-d0065e05daaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2fad3e-dbcd-4aa6-a2f5-8be673fd01ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2fad3e-dbcd-4aa6-a2f5-8be673fd01ba.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -23107,7 +23107,7 @@
         },
         {
             "id": "632e35a3-81c9-5bed-aa6b-f1a77e5e1cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc7c56d-1a28-477b-b1d1-854b127e1afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc7c56d-1a28-477b-b1d1-854b127e1afc.jpg?1",
             "name": "Spellskite",
             "text": "",
             "colours": [],
@@ -23143,7 +23143,7 @@
         },
         {
             "id": "971bf69a-c271-5d7e-b32c-6efcbf6de5a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62388bb9-db71-4687-b6e7-772e90828759.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62388bb9-db71-4687-b6e7-772e90828759.jpg?1",
             "name": "Sphere of Safety",
             "text": "",
             "colours": [
@@ -23176,7 +23176,7 @@
         },
         {
             "id": "21046320-dffb-5487-a481-6ed322d0ac93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac9fdee-ad50-486a-9fde-4aba6848a6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ac9fdee-ad50-486a-9fde-4aba6848a6c6.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -23214,7 +23214,7 @@
         },
         {
             "id": "fb7fcf6c-e9b4-5ac2-be9f-4e55b126f4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9b42b-1f5d-4aae-8b91-6fb1b302aff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e9b42b-1f5d-4aae-8b91-6fb1b302aff6.jpg?1",
             "name": "Lurking Crocodile",
             "text": "",
             "colours": [
@@ -23248,7 +23248,7 @@
         },
         {
             "id": "4d176f23-67af-5282-b9a1-0a219b11f25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13556e56-24bf-4149-a61f-80850cfc0523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13556e56-24bf-4149-a61f-80850cfc0523.jpg?1",
             "name": "Crash Through",
             "text": "",
             "colours": [
@@ -23280,7 +23280,7 @@
         },
         {
             "id": "14e0447f-ef62-5553-b0d6-a3b4bc71a3e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdfdb25-cfde-404f-b2f6-74283c8daa03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bdfdb25-cfde-404f-b2f6-74283c8daa03.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23322,7 +23322,7 @@
         },
         {
             "id": "52b46022-2925-5fd0-94db-1cc1ccdc7d14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174eafc5-1489-45dd-9555-123647f2268f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174eafc5-1489-45dd-9555-123647f2268f.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23364,7 +23364,7 @@
         },
         {
             "id": "59b0504c-5e91-55bb-ab44-ca5392ff5e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251d8c4a-a40c-4f89-9738-4928a7d4a97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251d8c4a-a40c-4f89-9738-4928a7d4a97c.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23406,7 +23406,7 @@
         },
         {
             "id": "a9460baa-5a40-5fa3-bdce-ac0f3be900b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dae6b1-0407-4ac0-94fe-9711e978258a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28dae6b1-0407-4ac0-94fe-9711e978258a.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23448,7 +23448,7 @@
         },
         {
             "id": "f3001c69-54c8-5ed8-8549-1b8dd7847ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05fbd5a-1114-4887-9dad-5ba398c59f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05fbd5a-1114-4887-9dad-5ba398c59f13.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23490,7 +23490,7 @@
         },
         {
             "id": "cc5c64ac-a386-598c-8157-ce0a52a7c3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd502a-2c3e-4f4f-a206-4bccf175ca11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdd502a-2c3e-4f4f-a206-4bccf175ca11.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23532,7 +23532,7 @@
         },
         {
             "id": "6d44837d-3c16-5b98-809f-c792adbfc92b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115e864c-a47f-48f6-a0e1-739e1427cb37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115e864c-a47f-48f6-a0e1-739e1427cb37.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23574,7 +23574,7 @@
         },
         {
             "id": "5f022bd5-c908-5c66-af7c-0b80e0203970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d419927-f5c0-42fd-a780-b91911909f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d419927-f5c0-42fd-a780-b91911909f2e.jpg?1",
             "name": "Persistent Petitioners",
             "text": "",
             "colours": [
@@ -23616,7 +23616,7 @@
         },
         {
             "id": "446a6877-b893-51bc-86b7-e378ffea56ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a63ff8-97ae-4ba2-a62b-4be10892a7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a63ff8-97ae-4ba2-a62b-4be10892a7a2.jpg?1",
             "name": "Eldrazi Monument",
             "text": "",
             "colours": [],
@@ -23643,7 +23643,7 @@
         },
         {
             "id": "4719ecce-a6a2-56e5-a4cc-6a98b60fd1b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd789709-6613-4688-9272-6d5624140053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd789709-6613-4688-9272-6d5624140053.jpg?1",
             "name": "Ornithopter",
             "text": "",
             "colours": [],
@@ -23673,7 +23673,7 @@
         },
         {
             "id": "f132bdee-5981-50c0-b36b-c170e7baa43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41465e-b702-4b69-8969-ca1da2ef07fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41465e-b702-4b69-8969-ca1da2ef07fa.jpg?1",
             "name": "Panharmonicon",
             "text": "",
             "colours": [],
@@ -23700,7 +23700,7 @@
         },
         {
             "id": "efb5736b-93be-574e-b848-d57b58ea02f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47803242-f744-445b-b645-e6e72b741589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47803242-f744-445b-b645-e6e72b741589.jpg?1",
             "name": "Swiftfoot Boots",
             "text": "",
             "colours": [],
@@ -23729,7 +23729,7 @@
         },
         {
             "id": "fe012952-70fd-5dcb-9a56-112b7b1eae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c63f09-c9ab-4926-85de-6199856fff86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c63f09-c9ab-4926-85de-6199856fff86.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -23756,7 +23756,7 @@
         },
         {
             "id": "45502bd2-e585-59b5-9df5-252bcfb7a8e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfafa38-e7db-4a42-99b8-fc65ab41c572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfafa38-e7db-4a42-99b8-fc65ab41c572.jpg?1",
             "name": "Darksteel Citadel",
             "text": "",
             "colours": [],
@@ -23785,7 +23785,7 @@
         },
         {
             "id": "16015cde-4407-5b6a-b12b-62808c71be8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg?1",
             "name": "Havengul Laboratory // Havengul Mystery",
             "text": "",
             "colours": [],
@@ -23817,7 +23817,7 @@
         },
         {
             "id": "f21ea2f3-8ef4-55fc-b7fb-5d68ad005a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/3/83a86763-c3fe-4cff-8b65-22cb329d112c.jpg?1",
             "name": "Havengul Laboratory // Havengul Mystery",
             "text": "",
             "colours": [],
@@ -23849,7 +23849,7 @@
         },
         {
             "id": "c6ae1a7f-3660-5f0a-99da-bca806b7aceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e367827c-e0b5-44d0-bccf-65ffc6d5318a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e367827c-e0b5-44d0-bccf-65ffc6d5318a.jpg?1",
             "name": "Bonescythe Sliver",
             "text": "",
             "colours": [
@@ -23882,7 +23882,7 @@
         },
         {
             "id": "7c0fdb8d-8592-511f-8a54-d77bb3107a0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348837a-7d77-4419-b329-137f1dd0aff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0348837a-7d77-4419-b329-137f1dd0aff4.jpg?1",
             "name": "Constricting Sliver",
             "text": "",
             "colours": [
@@ -23915,7 +23915,7 @@
         },
         {
             "id": "86b7ba3b-123e-539c-9d52-06aefc2f0fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738bba27-b9cf-4fac-ae70-384799da04df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738bba27-b9cf-4fac-ae70-384799da04df.jpg?1",
             "name": "Essence Sliver",
             "text": "",
             "colours": [
@@ -23948,7 +23948,7 @@
         },
         {
             "id": "1e0c1bce-065a-5898-b795-469a65acafb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7879f2-fb02-45f6-a8b5-a371b704bdf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b7879f2-fb02-45f6-a8b5-a371b704bdf1.jpg?1",
             "name": "Pulmonic Sliver",
             "text": "",
             "colours": [
@@ -23981,7 +23981,7 @@
         },
         {
             "id": "bc6b7293-d614-510a-b78c-8b9294b74ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84505a4e-5715-4731-9831-0107ff79ae05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84505a4e-5715-4731-9831-0107ff79ae05.jpg?1",
             "name": "Sidewinder Sliver",
             "text": "",
             "colours": [
@@ -24014,7 +24014,7 @@
         },
         {
             "id": "cef9b3a3-f2c7-57da-ac7d-99da79b2e041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79337a-cb6d-44cd-a1c9-c2c4cd698011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79337a-cb6d-44cd-a1c9-c2c4cd698011.jpg?1",
             "name": "Ward Sliver",
             "text": "",
             "colours": [
@@ -24047,7 +24047,7 @@
         },
         {
             "id": "86ccb355-b895-5c73-8542-ac465cfe85c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810076dc-e8e8-4fa4-aa2c-07ab4f9a9a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/810076dc-e8e8-4fa4-aa2c-07ab4f9a9a11.jpg?1",
             "name": "Diffusion Sliver",
             "text": "",
             "colours": [
@@ -24080,7 +24080,7 @@
         },
         {
             "id": "dc074643-4d9e-5c17-9852-b0ca75d23333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a768f0cb-031f-4a7a-bb4a-4c6b672a7f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a768f0cb-031f-4a7a-bb4a-4c6b672a7f34.jpg?1",
             "name": "Galerider Sliver",
             "text": "",
             "colours": [
@@ -24113,7 +24113,7 @@
         },
         {
             "id": "d0af25f9-2e48-5240-b19d-6bd0d7a717f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99182657-e5b5-4594-92d8-f9228e9c4c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99182657-e5b5-4594-92d8-f9228e9c4c3a.jpg?1",
             "name": "Mesmeric Sliver",
             "text": "",
             "colours": [
@@ -24146,7 +24146,7 @@
         },
         {
             "id": "82b67f61-0c5b-53e7-82b1-b6ec8c78b111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b2ad56-6d4f-4cc5-8ecd-8d2e2824dfb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9b2ad56-6d4f-4cc5-8ecd-8d2e2824dfb5.jpg?1",
             "name": "Psionic Sliver",
             "text": "",
             "colours": [
@@ -24179,7 +24179,7 @@
         },
         {
             "id": "2dcfdcb9-299f-5c4e-bcd1-f3a4a189e8e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf10ad8-5f62-44be-bba8-2dfbf72a4ac9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf10ad8-5f62-44be-bba8-2dfbf72a4ac9.jpg?1",
             "name": "Screeching Sliver",
             "text": "",
             "colours": [
@@ -24212,7 +24212,7 @@
         },
         {
             "id": "8042b07f-4c66-5ca5-b39b-4e9e18bf521f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0d1e8-fc95-4698-9df7-a09f790c490c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0d1e8-fc95-4698-9df7-a09f790c490c.jpg?1",
             "name": "Scuttling Sliver",
             "text": "",
             "colours": [
@@ -24246,7 +24246,7 @@
         },
         {
             "id": "807651a3-cbe8-5b19-b8a3-c4ed22abcedd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a757de-b218-4334-9056-e75898316adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a757de-b218-4334-9056-e75898316adf.jpg?1",
             "name": "Shadow Sliver",
             "text": "",
             "colours": [
@@ -24279,7 +24279,7 @@
         },
         {
             "id": "70c5dac2-0022-5a79-8aff-c59eed744746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de510e3-a688-4133-980a-5cbd6b2dbed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2de510e3-a688-4133-980a-5cbd6b2dbed7.jpg?1",
             "name": "Synapse Sliver",
             "text": "",
             "colours": [
@@ -24312,7 +24312,7 @@
         },
         {
             "id": "11670e89-3082-53e2-b281-94afab950134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b69f65-8494-49ff-ae8c-b85b82abe808.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b69f65-8494-49ff-ae8c-b85b82abe808.jpg?1",
             "name": "Telekinetic Sliver",
             "text": "",
             "colours": [
@@ -24345,7 +24345,7 @@
         },
         {
             "id": "af24a6ee-9f83-5949-9736-cdb8842e7663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d7fdf9-bbf6-4298-acca-88aa81b6b848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74d7fdf9-bbf6-4298-acca-88aa81b6b848.jpg?1",
             "name": "Winged Sliver",
             "text": "",
             "colours": [
@@ -24378,7 +24378,7 @@
         },
         {
             "id": "a116509a-fa37-5d13-b8d1-c78cf3fe06df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e5856-26f9-4c0f-a753-cce3a45a0d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997e5856-26f9-4c0f-a753-cce3a45a0d17.jpg?1",
             "name": "Basal Sliver",
             "text": "",
             "colours": [
@@ -24411,7 +24411,7 @@
         },
         {
             "id": "213480f8-16a6-5b5d-a2e7-faf822dd9b3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf8c12ff-036e-4eeb-95fb-7564ae728936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf8c12ff-036e-4eeb-95fb-7564ae728936.jpg?1",
             "name": "Dregscape Sliver",
             "text": "",
             "colours": [
@@ -24444,7 +24444,7 @@
         },
         {
             "id": "38d1f975-1b3b-5047-8328-61f5ca71ddba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f81ce-8731-4ff7-9bd8-8d108217fad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971f81ce-8731-4ff7-9bd8-8d108217fad2.jpg?1",
             "name": "Leeching Sliver",
             "text": "",
             "colours": [
@@ -24477,7 +24477,7 @@
         },
         {
             "id": "e3f480e1-2b69-5c0c-8999-9ffcfb023da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a1e50a-cf65-487c-a6e0-e19dcd535046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a1e50a-cf65-487c-a6e0-e19dcd535046.jpg?1",
             "name": "Plague Sliver",
             "text": "",
             "colours": [
@@ -24512,7 +24512,7 @@
         },
         {
             "id": "2723d888-5a01-59fe-bd37-029822be1a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae3bfc8-1c89-494a-ba03-4b53b7c71fe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae3bfc8-1c89-494a-ba03-4b53b7c71fe6.jpg?1",
             "name": "Plague Sliver",
             "text": "",
             "colours": [
@@ -24547,7 +24547,7 @@
         },
         {
             "id": "196c8038-c208-515b-a8be-bcb96496cfe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a991e21-5a1e-4c7e-b5bf-65f7f0882d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a991e21-5a1e-4c7e-b5bf-65f7f0882d8f.jpg?1",
             "name": "Syphon Sliver",
             "text": "",
             "colours": [
@@ -24580,7 +24580,7 @@
         },
         {
             "id": "c0bf904c-5bb8-58e0-bf76-b0f202b206c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966596a0-cddd-4056-bdd7-dff9154d12b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/966596a0-cddd-4056-bdd7-dff9154d12b2.jpg?1",
             "name": "Toxin Sliver",
             "text": "",
             "colours": [
@@ -24615,7 +24615,7 @@
         },
         {
             "id": "62124746-eb93-5cb7-9c0f-14113c16133e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec479019-1581-4f8b-9e34-f9ccded05337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec479019-1581-4f8b-9e34-f9ccded05337.jpg?1",
             "name": "Toxin Sliver",
             "text": "",
             "colours": [
@@ -24650,7 +24650,7 @@
         },
         {
             "id": "533b217a-00df-54c2-b28d-43cc2af595ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fcb1c5-7fad-43df-901f-6389ee886340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03fcb1c5-7fad-43df-901f-6389ee886340.jpg?1",
             "name": "Belligerent Sliver",
             "text": "",
             "colours": [
@@ -24683,7 +24683,7 @@
         },
         {
             "id": "68db1001-019c-560f-a6f2-378a13b40851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cdca59-6f98-437a-b3fd-a48264dd276f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90cdca59-6f98-437a-b3fd-a48264dd276f.jpg?1",
             "name": "Blur Sliver",
             "text": "",
             "colours": [
@@ -24716,7 +24716,7 @@
         },
         {
             "id": "39524f3e-1ca5-5794-a3d1-c7a5c7e1380b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ba1e44-0beb-45ae-8880-3423c3f98015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ba1e44-0beb-45ae-8880-3423c3f98015.jpg?1",
             "name": "Fury Sliver",
             "text": "",
             "colours": [
@@ -24749,7 +24749,7 @@
         },
         {
             "id": "7444299f-f8ff-5f86-bc3b-4e2d5105e32e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc92a34-a623-49eb-8ea5-6d04d8688567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc92a34-a623-49eb-8ea5-6d04d8688567.jpg?1",
             "name": "Homing Sliver",
             "text": "",
             "colours": [
@@ -24782,7 +24782,7 @@
         },
         {
             "id": "da131a1a-753b-5cc2-b322-c15e2d8a039b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e467e-7dec-451f-b5c7-b15a357553ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516e467e-7dec-451f-b5c7-b15a357553ae.jpg?1",
             "name": "Magma Sliver",
             "text": "",
             "colours": [
@@ -24815,7 +24815,7 @@
         },
         {
             "id": "a6782b6f-f021-5241-b885-97126f09a1ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e08306-5028-41d6-b19c-a8ce96b70279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e08306-5028-41d6-b19c-a8ce96b70279.jpg?1",
             "name": "Sedge Sliver",
             "text": "",
             "colours": [
@@ -24849,7 +24849,7 @@
         },
         {
             "id": "5621a042-b969-5f94-99b6-b92e16c088f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9d170-ad06-4bc6-bb4d-350136bb93fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c9d170-ad06-4bc6-bb4d-350136bb93fd.jpg?1",
             "name": "Spiteful Sliver",
             "text": "",
             "colours": [
@@ -24882,7 +24882,7 @@
         },
         {
             "id": "79bbbb9a-e8ec-58c7-a66e-7e0366c086ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b99739-f4b1-4ad1-bc99-d125d4a7fd28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b99739-f4b1-4ad1-bc99-d125d4a7fd28.jpg?1",
             "name": "Striking Sliver",
             "text": "",
             "colours": [
@@ -24915,7 +24915,7 @@
         },
         {
             "id": "7db92f7f-8c8a-5419-9075-1b0aa88d3e0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95409fb-e5ef-45b8-81b4-89fdfd581413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95409fb-e5ef-45b8-81b4-89fdfd581413.jpg?1",
             "name": "Thorncaster Sliver",
             "text": "",
             "colours": [
@@ -24948,7 +24948,7 @@
         },
         {
             "id": "0efaedb3-b512-515c-a19f-fc2f96555677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d127e747-fc45-4271-9ab1-cda4043bd43d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d127e747-fc45-4271-9ab1-cda4043bd43d.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "",
             "colours": [
@@ -24981,7 +24981,7 @@
         },
         {
             "id": "1f2fedcb-1b4a-5b1f-bf5a-6f93d33d529c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bffc93-1162-49e5-a38b-8a7271915d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5bffc93-1162-49e5-a38b-8a7271915d0c.jpg?1",
             "name": "Brood Sliver",
             "text": "",
             "colours": [
@@ -25014,7 +25014,7 @@
         },
         {
             "id": "2d9009a7-23f2-5d54-b69d-9f495aca0784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf38fc5-4f64-4c0c-9679-edf901fc416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf38fc5-4f64-4c0c-9679-edf901fc416c.jpg?1",
             "name": "Gemhide Sliver",
             "text": "",
             "colours": [
@@ -25047,7 +25047,7 @@
         },
         {
             "id": "09f5dc78-884d-5b54-9f04-495a6180e36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f28575-b1a8-4ed0-9bb2-d72c56b9fee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f28575-b1a8-4ed0-9bb2-d72c56b9fee1.jpg?1",
             "name": "Horned Sliver",
             "text": "",
             "colours": [
@@ -25080,7 +25080,7 @@
         },
         {
             "id": "8c9f7922-771a-53ba-bdd9-ce4ef2bcb919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9612d2-0379-4f33-88d2-e4098bfd53ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f9612d2-0379-4f33-88d2-e4098bfd53ac.jpg?1",
             "name": "Manaweft Sliver",
             "text": "",
             "colours": [
@@ -25113,7 +25113,7 @@
         },
         {
             "id": "fe712318-e16b-5912-8300-605fc2434406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a2390f-6d5b-4f65-bc7f-e6e75e85d721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a2390f-6d5b-4f65-bc7f-e6e75e85d721.jpg?1",
             "name": "Megantic Sliver",
             "text": "",
             "colours": [
@@ -25146,7 +25146,7 @@
         },
         {
             "id": "d0dee3f1-0df5-50af-be37-82117fa714c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a397f-448e-4e6a-9b8a-b8034a5ac33c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5a397f-448e-4e6a-9b8a-b8034a5ac33c.jpg?1",
             "name": "Might Sliver",
             "text": "",
             "colours": [
@@ -25179,7 +25179,7 @@
         },
         {
             "id": "63ae1f43-f0ef-51a9-a1e7-2c5a9900ce29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96fa876-5474-4374-bc51-fa5df9278042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96fa876-5474-4374-bc51-fa5df9278042.jpg?1",
             "name": "Muscle Sliver",
             "text": "",
             "colours": [
@@ -25212,7 +25212,7 @@
         },
         {
             "id": "89a1da55-7b34-567b-b966-7b8e8904ef43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06206a5b-ea4b-4b15-b61f-e0543077d4fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06206a5b-ea4b-4b15-b61f-e0543077d4fb.jpg?1",
             "name": "Predatory Sliver",
             "text": "",
             "colours": [
@@ -25245,7 +25245,7 @@
         },
         {
             "id": "06619745-e841-5099-a239-ccfc727b76ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702896b-7bd7-48fa-9bbb-69d50a31178e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4702896b-7bd7-48fa-9bbb-69d50a31178e.jpg?1",
             "name": "Quick Sliver",
             "text": "",
             "colours": [
@@ -25278,7 +25278,7 @@
         },
         {
             "id": "1f7224b3-7027-5e3d-a02d-75038d6f81b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb818ad-fba5-4012-a951-f6bcd72d6812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb818ad-fba5-4012-a951-f6bcd72d6812.jpg?1",
             "name": "Root Sliver",
             "text": "",
             "colours": [
@@ -25311,7 +25311,7 @@
         },
         {
             "id": "01e1e172-f45b-541f-8a6e-dee48d197712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b074f3-13fc-44df-84e1-e557b045fb4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b074f3-13fc-44df-84e1-e557b045fb4f.jpg?1",
             "name": "Tempered Sliver",
             "text": "",
             "colours": [
@@ -25344,7 +25344,7 @@
         },
         {
             "id": "ed676606-0254-5973-b3a9-9651931cac10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27047e1-0f6a-4f78-a3ed-02fc417dde29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27047e1-0f6a-4f78-a3ed-02fc417dde29.jpg?1",
             "name": "Virulent Sliver",
             "text": "",
             "colours": [
@@ -25379,7 +25379,7 @@
         },
         {
             "id": "7f054dc5-611f-5cf9-8211-7106a158f84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c145b06b-45b0-4133-b88d-9cb130aeeeb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c145b06b-45b0-4133-b88d-9cb130aeeeb5.jpg?1",
             "name": "Virulent Sliver",
             "text": "",
             "colours": [
@@ -25414,7 +25414,7 @@
         },
         {
             "id": "b16b4de7-6fab-540e-b0a8-8b43b450a699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e1f39d-b1e4-416d-98a4-3d9755706335.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e1f39d-b1e4-416d-98a4-3d9755706335.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "",
             "colours": [
@@ -25449,7 +25449,7 @@
         },
         {
             "id": "0e571a77-27cf-59d7-bcf8-18ba2e002788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a1b96a-ff75-4b4c-aea7-b41d9f9ac710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a1b96a-ff75-4b4c-aea7-b41d9f9ac710.jpg?1",
             "name": "Crystalline Sliver",
             "text": "",
             "colours": [
@@ -25484,7 +25484,7 @@
         },
         {
             "id": "13f283ac-7470-560a-9539-6a38e86f3568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4190231-8f16-4c1c-82cb-6432e106f0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4190231-8f16-4c1c-82cb-6432e106f0e5.jpg?1",
             "name": "Frenetic Sliver",
             "text": "",
             "colours": [
@@ -25519,7 +25519,7 @@
         },
         {
             "id": "b1c1aeb2-69e6-5174-a51e-b6e6f85c8aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba161cb4-e2b7-440b-a981-4a052af3f034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba161cb4-e2b7-440b-a981-4a052af3f034.jpg?1",
             "name": "Harmonic Sliver",
             "text": "",
             "colours": [
@@ -25554,7 +25554,7 @@
         },
         {
             "id": "5a825b36-2e68-514b-bfbe-8f5c7455e621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b6edd1-f617-45e3-9680-6da6942fdd45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b6edd1-f617-45e3-9680-6da6942fdd45.jpg?1",
             "name": "Hibernation Sliver",
             "text": "",
             "colours": [
@@ -25589,7 +25589,7 @@
         },
         {
             "id": "f93e0834-293e-5f8d-9963-7198b0ea9072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d000551-f457-4050-a36b-4df7d8dcd9e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d000551-f457-4050-a36b-4df7d8dcd9e4.jpg?1",
             "name": "Lavabelly Sliver",
             "text": "",
             "colours": [
@@ -25624,7 +25624,7 @@
         },
         {
             "id": "eb0f044c-3a23-580f-8532-babde9fdbf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699dc42d-3ceb-46dc-bc91-6a93c0d7ddc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699dc42d-3ceb-46dc-bc91-6a93c0d7ddc3.jpg?1",
             "name": "Necrotic Sliver",
             "text": "",
             "colours": [
@@ -25659,7 +25659,7 @@
         },
         {
             "id": "3bf31ea6-26e7-5420-b6d5-765bfa6bb105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df20594-5483-4050-80ed-dc8096295b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df20594-5483-4050-80ed-dc8096295b66.jpg?1",
             "name": "Opaline Sliver",
             "text": "",
             "colours": [
@@ -25694,7 +25694,7 @@
         },
         {
             "id": "61f37adc-e59e-5100-914f-eb1f4352205e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04541650-6ee7-4825-984e-4794b306c274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04541650-6ee7-4825-984e-4794b306c274.jpg?1",
             "name": "Sliver Hive",
             "text": "",
             "colours": [],
@@ -25721,7 +25721,7 @@
         },
         {
             "id": "5476c579-9498-559f-8ce9-1cea7d3c79de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb35ff06-c5bf-460e-8a79-422bda257cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb35ff06-c5bf-460e-8a79-422bda257cfe.jpg?1",
             "name": "Battlefield Forge",
             "text": "",
             "colours": [],
@@ -25751,7 +25751,7 @@
         },
         {
             "id": "21a3ecdb-e282-5f28-a464-3cf7bb5e900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb949a6-9261-4175-bcf1-5519d82f9dc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feb949a6-9261-4175-bcf1-5519d82f9dc3.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -25819,7 +25819,7 @@
         },
         {
             "id": "b32faab5-0e9c-5bc3-9669-a2e1e201be6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afa7ab5-feac-4cc5-ba2d-2b60a4f3308a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afa7ab5-feac-4cc5-ba2d-2b60a4f3308a.jpg?1",
             "name": "Questing Phelddagrif",
             "text": "",
             "colours": [
@@ -25859,7 +25859,7 @@
         },
         {
             "id": "708deab2-ae0e-5ce6-b333-c5f3c0c82ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97f18f-84f7-4ef5-b99e-267d6e7981e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97f18f-84f7-4ef5-b99e-267d6e7981e8.jpg?1",
             "name": "Questing Phelddagrif",
             "text": "",
             "colours": [
@@ -25899,7 +25899,7 @@
         },
         {
             "id": "08f8ffae-101b-568e-8377-d412605437a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6d4527-a88e-4001-b8a7-53db87784c8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6d4527-a88e-4001-b8a7-53db87784c8f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -25963,7 +25963,7 @@
         },
         {
             "id": "57d63daf-91e4-5ce4-ac39-1467562a5c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8993e4d0-d306-4993-b5a7-dbba754d479e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8993e4d0-d306-4993-b5a7-dbba754d479e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -26036,7 +26036,7 @@
         },
         {
             "id": "28774c48-654f-5fdc-9547-42a187ff57c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27740ea5-79c8-420f-bc49-6d5eac58dac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27740ea5-79c8-420f-bc49-6d5eac58dac5.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -26078,7 +26078,7 @@
         },
         {
             "id": "b126253c-304c-522e-a75a-b05b3866083b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac01b7b-7f0c-44ce-a183-28b52dd09833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac01b7b-7f0c-44ce-a183-28b52dd09833.jpg?1",
             "name": "Pyrite Spellbomb",
             "text": "",
             "colours": [],
@@ -26108,7 +26108,7 @@
         },
         {
             "id": "b15e263f-6952-5472-9a60-1a4e006e9c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e97d936-c3dc-42ae-a028-4a183d13ccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e97d936-c3dc-42ae-a028-4a183d13ccc8.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -26147,7 +26147,7 @@
         },
         {
             "id": "1c802eab-0fb9-5e5d-8d39-940fc5f3da00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4438562b-d5af-473d-a6c9-1bc0076341f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4438562b-d5af-473d-a6c9-1bc0076341f7.jpg?1",
             "name": "Torbran, Thane of Red Fell",
             "text": "",
             "colours": [
@@ -26186,7 +26186,7 @@
         },
         {
             "id": "79a9faa4-1a36-5578-871c-c70901126319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842bc7d-a37b-44ae-96e5-3ab42c95c4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3842bc7d-a37b-44ae-96e5-3ab42c95c4be.jpg?1",
             "name": "Ghost Quarter",
             "text": "",
             "colours": [],
@@ -26216,7 +26216,7 @@
         },
         {
             "id": "e9fa2b68-5699-5736-aa65-633db309d088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebc3424-456c-4b84-8e14-60c20828db0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebc3424-456c-4b84-8e14-60c20828db0d.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26260,7 +26260,7 @@
         },
         {
             "id": "f3ea40cd-c702-560d-a7a6-6dbe3a5b7751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5ed779-b400-489f-a419-4208de15efad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5ed779-b400-489f-a419-4208de15efad.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26304,7 +26304,7 @@
         },
         {
             "id": "2c28317d-3a8b-56ce-9467-e52270a234ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92d596-679f-4340-990d-29ae7900b5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92d596-679f-4340-990d-29ae7900b5c8.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26348,7 +26348,7 @@
         },
         {
             "id": "ccc9d450-0702-5d4a-8ede-fc746f3cb831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0b2ddc-eb21-4518-973c-4841b1f2ef52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0b2ddc-eb21-4518-973c-4841b1f2ef52.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26392,7 +26392,7 @@
         },
         {
             "id": "30518e3e-a847-5b56-a86d-136f9b23b3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29c6d37-785b-4d3a-9e7d-7963710538b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29c6d37-785b-4d3a-9e7d-7963710538b1.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26436,7 +26436,7 @@
         },
         {
             "id": "707bce4a-160f-5df3-8075-32837931a7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78bc53e-7106-489f-8818-adef7200e2f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78bc53e-7106-489f-8818-adef7200e2f8.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26480,7 +26480,7 @@
         },
         {
             "id": "40fc750a-c595-5d4a-9088-617b30b054f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3544806-daf9-438f-aec5-087abb40d2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3544806-daf9-438f-aec5-087abb40d2e6.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26524,7 +26524,7 @@
         },
         {
             "id": "5d0baf88-f632-5ee1-8bdf-e7789fa2aaab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c609eef-7ccc-4687-bd06-9b206d9d5b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c609eef-7ccc-4687-bd06-9b206d9d5b11.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26568,7 +26568,7 @@
         },
         {
             "id": "1c89406f-49d4-5b6d-aef9-e7bcd92df49e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f1740-1a79-42c5-bc0b-33a79a00621e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f1740-1a79-42c5-bc0b-33a79a00621e.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26612,7 +26612,7 @@
         },
         {
             "id": "3f0167d1-83a1-5cdb-8f4f-b44a41f94196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25ba4c-42f2-4d23-9299-b5343a7bad2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f25ba4c-42f2-4d23-9299-b5343a7bad2e.jpg?1",
             "name": "Shadowborn Apostle",
             "text": "",
             "colours": [
@@ -26656,7 +26656,7 @@
         },
         {
             "id": "f70df975-a65f-522a-a02e-f986a9c8cdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f7c03-647f-4e5a-98b1-1faa3d330e7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65f7c03-647f-4e5a-98b1-1faa3d330e7b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -26721,7 +26721,7 @@
         },
         {
             "id": "1634d8b4-db10-57c0-b85e-033d34b1bf5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797bd0ea-5c4d-477e-9d92-199a99d6c2cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797bd0ea-5c4d-477e-9d92-199a99d6c2cf.jpg?1",
             "name": "Hedron Archive",
             "text": "",
             "colours": [],
@@ -26748,7 +26748,7 @@
         },
         {
             "id": "7a1ad599-5f44-5f19-bdf2-9fc226777b0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438767ea-4f77-426e-bc01-eab18d5c6b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/438767ea-4f77-426e-bc01-eab18d5c6b17.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "",
             "colours": [],
@@ -26778,7 +26778,7 @@
         },
         {
             "id": "dc61f0f4-61e2-5c5f-a919-0172cd666eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924c4849-ede1-4aee-aa08-16b99282e6c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924c4849-ede1-4aee-aa08-16b99282e6c1.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "",
             "colours": [],
@@ -26805,7 +26805,7 @@
         },
         {
             "id": "32e27f1a-9877-58b4-8459-22433313d9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baec9c6-6f10-4e16-b3a0-910a9e1bf09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3baec9c6-6f10-4e16-b3a0-910a9e1bf09e.jpg?1",
             "name": "Tangle Wire",
             "text": "",
             "colours": [],
@@ -26832,7 +26832,7 @@
         },
         {
             "id": "b8aa4163-1d3e-5e99-89c0-f9e5bf313937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb1ddf8-7a58-4440-9b60-ba77e12e7a0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb1ddf8-7a58-4440-9b60-ba77e12e7a0e.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -26862,7 +26862,7 @@
         },
         {
             "id": "7b8abbab-1a9d-515d-9832-b50d5198c692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0d52a9-8694-46b4-aa0e-7b42b45b11db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a0d52a9-8694-46b4-aa0e-7b42b45b11db.jpg?1",
             "name": "Spore Frog",
             "text": "",
             "colours": [
@@ -26896,7 +26896,7 @@
         },
         {
             "id": "a45a4e2c-1437-51dd-837a-5e62520c3e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e863861-eb0d-4f86-9770-bd32b8227d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e863861-eb0d-4f86-9770-bd32b8227d07.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -26935,7 +26935,7 @@
         },
         {
             "id": "98d0d6d9-9cdb-525c-a7be-adc9d5cd4ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeb8c31-cf87-4058-bc14-991310a9e1d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aeb8c31-cf87-4058-bc14-991310a9e1d5.jpg?1",
             "name": "Dakkon Blackblade",
             "text": "",
             "colours": [
@@ -26976,7 +26976,7 @@
         },
         {
             "id": "1a0a8b4f-e4d0-5a56-8e2f-627fe73942e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890887b-38ed-4794-99d1-f1a574428d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a890887b-38ed-4794-99d1-f1a574428d2b.jpg?1",
             "name": "Olivia, Mobilized for War",
             "text": "",
             "colours": [
@@ -27017,7 +27017,7 @@
         },
         {
             "id": "8f762042-59f4-533e-99dd-aff86478d2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -27056,7 +27056,7 @@
         },
         {
             "id": "c3c4b6be-1cb5-5280-be35-b50ed288f7e2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3e861d2-d0a6-4a00-a4e1-4e10f038309a.jpg?1",
             "name": "Huntmaster of the Fells // Ravager of the Fells",
             "text": "",
             "colours": [
@@ -27094,7 +27094,7 @@
         },
         {
             "id": "9c74d4c6-8604-5f99-a673-531d51a8c13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f40636-6899-4ea8-adda-9b60bcde18a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f40636-6899-4ea8-adda-9b60bcde18a0.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "",
             "colours": [
@@ -27132,7 +27132,7 @@
         },
         {
             "id": "5f3885de-116f-5b8a-87f0-0cb478541458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f93e8ad-8ef6-4cf1-a664-d1477f1ebae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f93e8ad-8ef6-4cf1-a664-d1477f1ebae4.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -27166,7 +27166,7 @@
         },
         {
             "id": "108ddd7e-8b2d-50e8-a2d2-fd3e5c697f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b38015-985f-4718-a6f8-fe19de225801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b38015-985f-4718-a6f8-fe19de225801.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -27200,7 +27200,7 @@
         },
         {
             "id": "55e7c072-0648-5864-ae09-d2bec3c11144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0040569-c4b1-46ad-8115-1fdb82ba3710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0040569-c4b1-46ad-8115-1fdb82ba3710.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -27234,7 +27234,7 @@
         },
         {
             "id": "c00dcbb2-b13f-593e-b8d5-b701961be340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23361f62-c24f-42a6-9720-89a84069ce33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23361f62-c24f-42a6-9720-89a84069ce33.jpg?1",
             "name": "Knight Exemplar",
             "text": "",
             "colours": [
@@ -27271,7 +27271,7 @@
         },
         {
             "id": "3a298291-86d1-50ff-9b68-5ebed28e25ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228933f3-3bca-4417-ab8a-5ccd19829c69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228933f3-3bca-4417-ab8a-5ccd19829c69.jpg?1",
             "name": "Fellwar Stone",
             "text": "",
             "colours": [],
@@ -27301,7 +27301,7 @@
         },
         {
             "id": "0ae54900-2e2a-5cdb-8926-f20306569d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f29c3b1-58b9-4a7b-8874-3db705cc96f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f29c3b1-58b9-4a7b-8874-3db705cc96f5.jpg?1",
             "name": "Dragon's Hoard",
             "text": "",
             "colours": [],
@@ -27328,7 +27328,7 @@
         },
         {
             "id": "e93f698b-5d46-54cc-ad04-6ba93a3bca57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a380bca-e64d-4582-9f55-02f91a1f3c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a380bca-e64d-4582-9f55-02f91a1f3c2f.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -27367,7 +27367,7 @@
         },
         {
             "id": "e487538a-0c76-51b8-8b9d-8d9214918cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c024f-db49-4b98-ad80-b46ee1be32fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7c024f-db49-4b98-ad80-b46ee1be32fe.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -27404,7 +27404,7 @@
         },
         {
             "id": "0ba51819-42ff-5cd3-9242-2ec04dd7f0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6597c9-8271-49c7-b4f6-9265f5d95f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6597c9-8271-49c7-b4f6-9265f5d95f99.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -27441,7 +27441,7 @@
         },
         {
             "id": "e1dba0a1-c241-5211-a353-efaf84b521b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff7380-ac9c-46c4-9544-da6554cb0819.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff7380-ac9c-46c4-9544-da6554cb0819.jpg?1",
             "name": "Merfolk of the Pearl Trident",
             "text": "",
             "colours": [
@@ -27474,7 +27474,7 @@
         },
         {
             "id": "739c92c3-6c33-50d5-84ff-5624f00d4f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fefff7-2ff5-4abf-a9ec-0e2e737ee225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fefff7-2ff5-4abf-a9ec-0e2e737ee225.jpg?1",
             "name": "Lord of the Pit",
             "text": "",
             "colours": [
@@ -27507,7 +27507,7 @@
         },
         {
             "id": "40508241-7da4-5240-bf3b-277d4763379b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a04baf-5301-4e47-ac8f-243d2a73f18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a04baf-5301-4e47-ac8f-243d2a73f18e.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -27542,7 +27542,7 @@
         },
         {
             "id": "478443e8-3f28-5be0-87c2-e1952c281841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a168b8-285b-4725-a982-671557d4f0bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a168b8-285b-4725-a982-671557d4f0bc.jpg?1",
             "name": "Giant Growth",
             "text": "",
             "colours": [
@@ -27573,7 +27573,7 @@
         },
         {
             "id": "d833b558-9825-5c35-8cea-a8c02044303a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f677da5a-cd08-4b5f-8862-51ba239f3329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f677da5a-cd08-4b5f-8862-51ba239f3329.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -27608,7 +27608,7 @@
         },
         {
             "id": "a8e4fdd9-dffd-5ad3-aaed-6be1c560a714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11528f4f-35b7-457d-8b83-1954bd3289c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11528f4f-35b7-457d-8b83-1954bd3289c3.jpg?1",
             "name": "Maro",
             "text": "",
             "colours": [
@@ -27643,7 +27643,7 @@
         },
         {
             "id": "b7dc73a6-8368-5044-bffb-78645b2186da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f586a8ef-2a22-47d9-a45d-eb27def385ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f586a8ef-2a22-47d9-a45d-eb27def385ca.jpg?1",
             "name": "Thought-Knot Seer",
             "text": "",
             "colours": [],
@@ -27675,7 +27675,7 @@
         },
         {
             "id": "0d2350e5-a7e7-5b6e-a8e4-d2b31bfbad3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6150f2-cc6c-405d-9812-bbbc524ce450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6150f2-cc6c-405d-9812-bbbc524ce450.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -27708,7 +27708,7 @@
         },
         {
             "id": "72a1f10e-54cc-54ab-bf05-f51fed52c302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "",
             "colours": [
@@ -27742,7 +27742,7 @@
         },
         {
             "id": "095d1f2f-b86a-5d6f-a278-b00a065b6562",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/8/888fbfaf-dbf9-4045-a79e-d436ef75b3cf.jpg?1",
             "name": "Delver of Secrets // Insectile Aberration",
             "text": "",
             "colours": [
@@ -27776,7 +27776,7 @@
         },
         {
             "id": "b45bc70f-7b32-5d0d-8a9a-bb0c9cfe4d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f947de-fc90-49f1-aad9-d6166a23ee9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f947de-fc90-49f1-aad9-d6166a23ee9e.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -27812,7 +27812,7 @@
         },
         {
             "id": "d2474a78-46af-52c0-90a8-f573df52d855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee11ea-213d-4f71-b3bf-a136b8de700d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afee11ea-213d-4f71-b3bf-a136b8de700d.jpg?1",
             "name": "Lightning Strike",
             "text": "",
             "colours": [
@@ -27844,7 +27844,7 @@
         },
         {
             "id": "18b7640e-bd5b-5d1e-a26a-802f2df285ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f597a-94d0-4117-af92-58e23fdf2c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/948f597a-94d0-4117-af92-58e23fdf2c6c.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "",
             "colours": [
@@ -27881,7 +27881,7 @@
         },
         {
             "id": "255caab7-f7ea-555f-919a-11948c0d7c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5468fd0-822b-40f2-bf23-c5ca11c9e1ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5468fd0-822b-40f2-bf23-c5ca11c9e1ba.jpg?1",
             "name": "Zur the Enchanter",
             "text": "",
             "colours": [
@@ -27921,7 +27921,7 @@
         },
         {
             "id": "919a42fb-c9a5-5e2c-9789-3a7a554e483c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ee3d9-055d-4223-96f9-506ecf4ce0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/023ee3d9-055d-4223-96f9-506ecf4ce0f5.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -27952,7 +27952,7 @@
         },
         {
             "id": "9d826d71-e2fe-52c3-925b-9a46c937935c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce332e85-a842-4afc-a5c5-b5064c5c4569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce332e85-a842-4afc-a5c5-b5064c5c4569.jpg?1",
             "name": "Themberchaud",
             "text": "",
             "colours": [
@@ -27988,7 +27988,7 @@
         },
         {
             "id": "9e069df0-9e09-5d3f-b576-d9d85b12e420",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84468eb-c971-4e5c-92ab-338b4aaa48c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84468eb-c971-4e5c-92ab-338b4aaa48c6.jpg?1",
             "name": "Braid of Fire",
             "text": "",
             "colours": [
@@ -28021,7 +28021,7 @@
         },
         {
             "id": "933ba936-8280-5d41-9437-d62e6e3f1e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84590fb7-a79e-4708-bce4-bb16b1b0dd7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84590fb7-a79e-4708-bce4-bb16b1b0dd7e.jpg?1",
             "name": "Cleansing Nova",
             "text": "",
             "colours": [
@@ -28055,7 +28055,7 @@
         },
         {
             "id": "02ac098f-0b44-51a3-b15a-06c29080b5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1ff426-31d8-4336-a952-3074e9f40f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1ff426-31d8-4336-a952-3074e9f40f3f.jpg?1",
             "name": "Sigarda's Aid",
             "text": "",
             "colours": [
@@ -28088,7 +28088,7 @@
         },
         {
             "id": "5041546d-cfdb-52b3-a04d-1f2e549eb603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b4316-e5f2-40a4-8d7a-a7d7059ebfad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276b4316-e5f2-40a4-8d7a-a7d7059ebfad.jpg?1",
             "name": "Selfless Savior",
             "text": "",
             "colours": [
@@ -28124,7 +28124,7 @@
         },
         {
             "id": "32cafc37-e0bf-58ef-b091-ae38d6d10924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff491659-0756-4450-acc5-0a1cd792f0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff491659-0756-4450-acc5-0a1cd792f0f0.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "",
             "colours": [],
@@ -28155,7 +28155,7 @@
         },
         {
             "id": "3aae9350-6a5e-5fdb-8527-35a2238959fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2731d3c-48be-46d1-8fb3-13a99ac380b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2731d3c-48be-46d1-8fb3-13a99ac380b4.jpg?1",
             "name": "Gr\u00edma Wormtongue",
             "text": "",
             "colours": [
@@ -28192,7 +28192,7 @@
         },
         {
             "id": "96455386-038e-5c1d-bfec-9fca93917636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb93d27-ca54-4d56-a55e-19cec740cd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb93d27-ca54-4d56-a55e-19cec740cd69.jpg?1",
             "name": "Gaea's Blessing",
             "text": "",
             "colours": [
@@ -28226,7 +28226,7 @@
         },
         {
             "id": "236a6b4b-ecfc-5ef5-bfcc-acf00a5ff575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8879c10-6b89-459f-a8f7-0251fca58498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8879c10-6b89-459f-a8f7-0251fca58498.jpg?1",
             "name": "Colossus Hammer",
             "text": "",
             "colours": [],
@@ -28256,7 +28256,7 @@
         },
         {
             "id": "e76b293b-4d9c-5ec5-bfba-17b11eced398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd3c43f-c5ff-42ee-a220-82aa7aef88e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dd3c43f-c5ff-42ee-a220-82aa7aef88e7.jpg?1",
             "name": "Mountain Goat",
             "text": "",
             "colours": [
@@ -28290,7 +28290,7 @@
         },
         {
             "id": "cb00a69c-d443-5a7e-8d37-4b73825c8d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b62c98-8ca3-4768-addf-e255ca98c63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5b62c98-8ca3-4768-addf-e255ca98c63c.jpg?1",
             "name": "Woodland Cemetery",
             "text": "",
             "colours": [],
@@ -28321,7 +28321,7 @@
         },
         {
             "id": "eb4bd950-f1fd-5c62-a2b7-dfc153f6feae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e286b0-b4c4-4b42-ba11-2eec962fee8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e286b0-b4c4-4b42-ba11-2eec962fee8c.jpg?1",
             "name": "Isolated Chapel",
             "text": "",
             "colours": [],
@@ -28352,7 +28352,7 @@
         },
         {
             "id": "8fd76051-34cb-5fb7-a9b3-8c398338cee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4fd0a3-c596-4a88-809b-6f16caf35adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4fd0a3-c596-4a88-809b-6f16caf35adb.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "",
             "colours": [
@@ -28387,7 +28387,7 @@
         },
         {
             "id": "7db7d1f7-8558-53cf-9e99-fa1abb098b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a0e3e-6e0f-412f-8bc7-1a1211c30e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55a0e3e-6e0f-412f-8bc7-1a1211c30e1e.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "",
             "colours": [
@@ -28422,7 +28422,7 @@
         },
         {
             "id": "71ae9b6e-689a-5af9-a18a-1f51093aeadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917b8f0-f35c-44ec-8a59-e09b179a4328.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1917b8f0-f35c-44ec-8a59-e09b179a4328.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -28456,7 +28456,7 @@
         },
         {
             "id": "06239993-414b-5bad-9217-85933e4c75a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3e700f-71ec-4cb7-a795-7b7265fda71b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3e700f-71ec-4cb7-a795-7b7265fda71b.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -28490,7 +28490,7 @@
         },
         {
             "id": "42a48bb1-1f32-517f-91b1-a921621430be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347a7b0f-1239-4113-827c-aa67a6e0552e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347a7b0f-1239-4113-827c-aa67a6e0552e.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -28529,7 +28529,7 @@
         },
         {
             "id": "e8d1911d-3b62-5e34-8bbb-cf2802a1abf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -28567,7 +28567,7 @@
         },
         {
             "id": "c8e14900-b85b-5249-85e1-c71d1fcc9164",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cd6a16f-1eff-4624-8f7f-4d9e70a694bb.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -28605,7 +28605,7 @@
         },
         {
             "id": "abb57760-b05b-55ce-b261-7ddfdfce1954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -28643,7 +28643,7 @@
         },
         {
             "id": "52b84e65-99e2-5f1c-a8c3-3384c53da6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/4696f5de-fe5b-40df-a194-1a73b4c5150f.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -28681,7 +28681,7 @@
         },
         {
             "id": "4a811142-c4a3-5b83-aa48-feaac9be3be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -28719,7 +28719,7 @@
         },
         {
             "id": "57eeee15-5a76-5413-bb2d-243b6c7419c8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94594d48-b728-4be6-9d7a-c67088df8acd.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -28757,7 +28757,7 @@
         },
         {
             "id": "79416179-0526-5d8d-bf2a-ae4ba3632761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -28795,7 +28795,7 @@
         },
         {
             "id": "70835df7-9d50-5756-a438-dd91f6476e24",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8ae0caed-940d-45bc-9877-7cc014b2700e.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -28833,7 +28833,7 @@
         },
         {
             "id": "9c52adbe-7776-5ee1-aab8-ba13fcfbfbc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -28871,7 +28871,7 @@
         },
         {
             "id": "c9bfa288-66d2-51f6-97db-3dcab3a7b600",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05c6c38-d204-458c-af17-4cf5efd2c7fc.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -28909,7 +28909,7 @@
         },
         {
             "id": "bf1c5fa5-8ee8-5b4f-8237-9540d7bad0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg?1",
             "name": "Terror // Terror",
             "text": "",
             "colours": [
@@ -28941,7 +28941,7 @@
         },
         {
             "id": "a8ee4f4d-55cd-55fd-a1a4-434fb2487a54",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60c92f1b-0c78-4809-9365-e1ffa515cb4b.jpg?1",
             "name": "Terror // Terror",
             "text": "",
             "colours": [
@@ -28973,7 +28973,7 @@
         },
         {
             "id": "c5f1bc0e-f65e-52fa-b0d8-fedb2f948183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d306864-1eeb-422a-a014-cb683faba096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d306864-1eeb-422a-a014-cb683faba096.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29011,7 +29011,7 @@
         },
         {
             "id": "8f519576-169e-58d7-97ff-dfe65c7c4a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939e67-17f0-4cd0-9ad1-be3dcb9fb299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1939e67-17f0-4cd0-9ad1-be3dcb9fb299.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29049,7 +29049,7 @@
         },
         {
             "id": "2e766432-2ab3-5bd6-a6a8-bac7705e7200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd52f2e-5d07-4a10-8d1b-a456eaca977c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dd52f2e-5d07-4a10-8d1b-a456eaca977c.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29087,7 +29087,7 @@
         },
         {
             "id": "3ade7809-fe3b-56f0-8271-3e4e3da06f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d296b765-c650-44d5-a4b6-1b58074c0007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d296b765-c650-44d5-a4b6-1b58074c0007.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29125,7 +29125,7 @@
         },
         {
             "id": "441273ec-dbe6-5713-8837-ddb5a492384d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4543516e-890f-44e8-acaa-da4e941e31dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4543516e-890f-44e8-acaa-da4e941e31dd.jpg?1",
             "name": "Relentless Rats",
             "text": "",
             "colours": [
@@ -29163,7 +29163,7 @@
         },
         {
             "id": "17b2e338-989d-5e8d-b4c6-c3a28a08e5cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbf73e9-91ff-4c25-b618-62d652e75587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbf73e9-91ff-4c25-b618-62d652e75587.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -29202,7 +29202,7 @@
         },
         {
             "id": "d3a08696-fdf9-5ba8-b486-8d6dc386fc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40b82-ed28-451f-b191-b9eca2770ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb40b82-ed28-451f-b191-b9eca2770ca5.jpg?1",
             "name": "Skemfar Shadowsage",
             "text": "",
             "colours": [
@@ -29236,7 +29236,7 @@
         },
         {
             "id": "e255b81c-f688-58ae-9082-67a5e7474a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb1b3d7-a48f-49c8-bb00-046ab5f61b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb1b3d7-a48f-49c8-bb00-046ab5f61b49.jpg?1",
             "name": "Elvish Vanguard",
             "text": "",
             "colours": [
@@ -29270,7 +29270,7 @@
         },
         {
             "id": "c9393ecb-c883-54e5-a09a-6ae90b2c613b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef03e37-e5eb-4f46-885a-4c27044262da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef03e37-e5eb-4f46-885a-4c27044262da.jpg?1",
             "name": "Elvish Visionary",
             "text": "",
             "colours": [
@@ -29304,7 +29304,7 @@
         },
         {
             "id": "b306e9c1-5697-5a17-ab22-29a26d6adeb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4232b0-43e4-4352-948b-10cdc9660ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4232b0-43e4-4352-948b-10cdc9660ac2.jpg?1",
             "name": "Evolution Sage",
             "text": "",
             "colours": [
@@ -29338,7 +29338,7 @@
         },
         {
             "id": "b364964a-bb02-5906-88b0-f0e1fe9ee3ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbbb398-9784-4a65-9caf-1d49b98cef20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbbb398-9784-4a65-9caf-1d49b98cef20.jpg?1",
             "name": "Farhaven Elf",
             "text": "",
             "colours": [
@@ -29372,7 +29372,7 @@
         },
         {
             "id": "ab22784c-0fe5-5c5e-8de9-146e195b276d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68581571-cd66-40b9-8a08-c54adf3515d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68581571-cd66-40b9-8a08-c54adf3515d1.jpg?1",
             "name": "Fierce Empath",
             "text": "",
             "colours": [
@@ -29405,7 +29405,7 @@
         },
         {
             "id": "ab89c5a1-c3e8-55f2-b2f5-6d8e5658188b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4596f46-d59d-4bff-afc4-a8235612da23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4596f46-d59d-4bff-afc4-a8235612da23.jpg?1",
             "name": "Generous Patron",
             "text": "",
             "colours": [
@@ -29439,7 +29439,7 @@
         },
         {
             "id": "79b4329d-7316-55fd-9407-c6b6630b840c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e810d32d-c073-4bc5-9ff5-7946c54e045d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e810d32d-c073-4bc5-9ff5-7946c54e045d.jpg?1",
             "name": "Ivy Lane Denizen",
             "text": "",
             "colours": [
@@ -29473,7 +29473,7 @@
         },
         {
             "id": "9f3d23d3-c678-5f6a-a15e-b8200263433a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9853c-8335-45e1-87a3-03cc2d35988c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a9853c-8335-45e1-87a3-03cc2d35988c.jpg?1",
             "name": "Jaspera Sentinel",
             "text": "",
             "colours": [
@@ -29507,7 +29507,7 @@
         },
         {
             "id": "fb8d440b-d9ee-5c04-8c4b-858a098764d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168b0af2-aa4f-421d-bb0a-54f5ac3f72fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168b0af2-aa4f-421d-bb0a-54f5ac3f72fc.jpg?1",
             "name": "Llanowar Visionary",
             "text": "",
             "colours": [
@@ -29541,7 +29541,7 @@
         },
         {
             "id": "6195a00f-3111-53a6-8407-6ea83f3efa70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fc9e54-8fc4-4de4-be74-e925a85187b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5fc9e54-8fc4-4de4-be74-e925a85187b4.jpg?1",
             "name": "Lys Alana Huntmaster",
             "text": "",
             "colours": [
@@ -29575,7 +29575,7 @@
         },
         {
             "id": "c6b81f75-e166-5814-aeba-5c80734e1340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a03a37-08b7-403a-a5d6-efa1dd4cb8d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a03a37-08b7-403a-a5d6-efa1dd4cb8d0.jpg?1",
             "name": "Nettle Sentinel",
             "text": "",
             "colours": [
@@ -29609,7 +29609,7 @@
         },
         {
             "id": "0be1caba-db21-5c84-8088-3a885a083328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9277591c-cf20-4f82-b308-84e69c51113a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9277591c-cf20-4f82-b308-84e69c51113a.jpg?1",
             "name": "Nullmage Shepherd",
             "text": "",
             "colours": [
@@ -29643,7 +29643,7 @@
         },
         {
             "id": "9eb8fc6c-c7c9-53e7-850a-d3e0a6345727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07425bc6-eb70-4b2b-a9e1-e56b098a0f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07425bc6-eb70-4b2b-a9e1-e56b098a0f22.jpg?1",
             "name": "Paradise Druid",
             "text": "",
             "colours": [
@@ -29677,7 +29677,7 @@
         },
         {
             "id": "dffe6d42-0d11-5b53-906f-0bd0c6ee98ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422e29a7-caf4-4d78-813d-10b6d83802d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422e29a7-caf4-4d78-813d-10b6d83802d3.jpg?1",
             "name": "Pollenbright Druid",
             "text": "",
             "colours": [
@@ -29711,7 +29711,7 @@
         },
         {
             "id": "e5b2c240-0e83-52fe-8b63-404b7e9b57ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3636c97-d21d-441d-baa8-7b1795b1548d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3636c97-d21d-441d-baa8-7b1795b1548d.jpg?1",
             "name": "Reclamation Sage",
             "text": "",
             "colours": [
@@ -29745,7 +29745,7 @@
         },
         {
             "id": "f6822898-27a9-5d0c-970d-9c7cf2be3ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70664ccf-07c6-470b-bfcf-e95442e86aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70664ccf-07c6-470b-bfcf-e95442e86aa5.jpg?1",
             "name": "Sylvan Ranger",
             "text": "",
             "colours": [
@@ -29780,7 +29780,7 @@
         },
         {
             "id": "38162fd1-21c2-5ef4-9f29-db701f019604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a513bd7e-b843-4bec-a50f-9f014cc86503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a513bd7e-b843-4bec-a50f-9f014cc86503.jpg?1",
             "name": "Timberwatch Elf",
             "text": "",
             "colours": [
@@ -29813,7 +29813,7 @@
         },
         {
             "id": "6d7987f0-3956-5760-af8d-4670dfa82652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2053d78-ec36-4159-8b5d-5b4757122e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2053d78-ec36-4159-8b5d-5b4757122e06.jpg?1",
             "name": "Viridian Shaman",
             "text": "",
             "colours": [
@@ -29847,7 +29847,7 @@
         },
         {
             "id": "cf561813-36d7-5b83-ab0a-bba602e5dc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cda011d-da71-4836-9795-f12a23041aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cda011d-da71-4836-9795-f12a23041aad.jpg?1",
             "name": "Wellwisher",
             "text": "",
             "colours": [
@@ -29880,7 +29880,7 @@
         },
         {
             "id": "08f7010f-5a47-5fdf-b10c-d3d1149f4a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a6012a-8bb5-436e-9ec2-54a0f06c9d4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a6012a-8bb5-436e-9ec2-54a0f06c9d4e.jpg?1",
             "name": "Wirewood Symbiote",
             "text": "",
             "colours": [
@@ -29913,7 +29913,7 @@
         },
         {
             "id": "1b1f3b2a-2775-533d-a276-cc57297edbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbcd517-12cf-4cec-b13a-7590b8874c5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdbcd517-12cf-4cec-b13a-7590b8874c5b.jpg?1",
             "name": "Frilled Mystic",
             "text": "",
             "colours": [
@@ -29950,7 +29950,7 @@
         },
         {
             "id": "0e5179c4-48ca-5dc5-9d1d-41c657e8f478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4241fbb-9874-4c6b-baa7-62527bc24991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4241fbb-9874-4c6b-baa7-62527bc24991.jpg?1",
             "name": "Poison-Tip Archer",
             "text": "",
             "colours": [
@@ -29986,7 +29986,7 @@
         },
         {
             "id": "0c6d861e-cd42-5abb-b6da-0ec0b126f5dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfda3de9-2eea-44f6-ba1b-d001ede8f7bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfda3de9-2eea-44f6-ba1b-d001ede8f7bb.jpg?1",
             "name": "Shaman of the Pack",
             "text": "",
             "colours": [
@@ -30022,7 +30022,7 @@
         },
         {
             "id": "366812fd-ef58-58e9-8f51-31400e63f0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa3fc7c-c340-454f-b89c-2d059d376cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa3fc7c-c340-454f-b89c-2d059d376cb1.jpg?1",
             "name": "Codex Shredder",
             "text": "",
             "colours": [],
@@ -30049,7 +30049,7 @@
         },
         {
             "id": "859a91b0-74f5-54a1-8dc3-e82560b61106",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bd6b4a-4470-4e4d-9f7b-9b6f1d1dcde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0bd6b4a-4470-4e4d-9f7b-9b6f1d1dcde7.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -30082,7 +30082,7 @@
         },
         {
             "id": "62ebd730-69fc-53b2-a8f3-e7937bd60cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1218c13-3b70-419f-bf95-84b04f2479f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1218c13-3b70-419f-bf95-84b04f2479f5.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -30115,7 +30115,7 @@
         },
         {
             "id": "2972b089-a5a7-5f98-a565-9266e960fc2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57f710-7af0-44f0-9070-47e1b7c3560e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57f710-7af0-44f0-9070-47e1b7c3560e.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -30153,7 +30153,7 @@
         },
         {
             "id": "78b52e1c-0a24-563d-8fa6-6ce885a61cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1733387-4b5b-43b2-aa44-668330cb9922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1733387-4b5b-43b2-aa44-668330cb9922.jpg?1",
             "name": "Nine Lives",
             "text": "",
             "colours": [
@@ -30184,7 +30184,7 @@
         },
         {
             "id": "06146e6c-e4db-5a30-bd32-bb7889115f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c8803-f33a-4530-9882-bff1bf810c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c8803-f33a-4530-9882-bff1bf810c19.jpg?1",
             "name": "Yoshimaru, Ever Faithful",
             "text": "",
             "colours": [
@@ -30219,7 +30219,7 @@
         },
         {
             "id": "1bb2861a-ccf3-51a3-a2e3-f490d98d5b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837edd3f-5380-4c1c-8323-0e61dac385e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837edd3f-5380-4c1c-8323-0e61dac385e5.jpg?1",
             "name": "Wastes",
             "text": "",
             "colours": [],
@@ -30252,7 +30252,7 @@
         },
         {
             "id": "d6e8ce9f-1d5b-5f8a-b440-532f59e57e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20b3a5b-c07e-4314-ab3e-097212ff5e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20b3a5b-c07e-4314-ab3e-097212ff5e6e.jpg?1",
             "name": "Mana Vault",
             "text": "",
             "colours": [],
@@ -30279,7 +30279,7 @@
         },
         {
             "id": "58afab62-ac14-5955-811e-43461da52ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff49618-4612-4a44-a0b7-9d710a7cd60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff49618-4612-4a44-a0b7-9d710a7cd60b.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "",
             "colours": [],
@@ -30309,7 +30309,7 @@
         },
         {
             "id": "22c509d2-3024-56fe-9664-3d35a65f1929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474c0f1-08c7-4183-b024-297a11594a96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c474c0f1-08c7-4183-b024-297a11594a96.jpg?1",
             "name": "Discord, Lord of Disharmony",
             "text": "",
             "colours": [
@@ -30347,7 +30347,7 @@
         },
         {
             "id": "66e7b77f-7f6d-58b3-adff-63f398e4c372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7726e1-f121-4283-9c54-66509f332f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7726e1-f121-4283-9c54-66509f332f39.jpg?1",
             "name": "Coveted Jewel",
             "text": "",
             "colours": [],
@@ -30375,7 +30375,7 @@
         },
         {
             "id": "c7872b2e-6097-5936-89fe-8e8eb628e867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9f1f7e-2e6a-4af3-8272-68cee14b6156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a9f1f7e-2e6a-4af3-8272-68cee14b6156.jpg?1",
             "name": "Spiteful Prankster",
             "text": "",
             "colours": [
@@ -30409,7 +30409,7 @@
         },
         {
             "id": "eab30384-8280-5474-9367-5dc93a64f0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a70aa6-ac7d-4592-94b0-9ce862d71d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a70aa6-ac7d-4592-94b0-9ce862d71d50.jpg?1",
             "name": "Haystack",
             "text": "",
             "colours": [
@@ -30441,7 +30441,7 @@
         },
         {
             "id": "e4d688bd-6850-55ec-b508-f8c4bed4c644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3b2b9f-623f-4993-ad45-099ec3b570c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3b2b9f-623f-4993-ad45-099ec3b570c6.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30469,7 +30469,7 @@
         },
         {
             "id": "3d7e29ad-c87d-5a17-91a8-2262be528028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe8763-1373-49f8-b4a6-dd5984b1d25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acbe8763-1373-49f8-b4a6-dd5984b1d25f.jpg?1",
             "name": "Elvish Mystic",
             "text": "",
             "colours": [
@@ -30506,7 +30506,7 @@
         },
         {
             "id": "adf27287-c24b-5c50-95a2-1bdb4c998b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe98f7c-e6c0-4632-96da-a4c2e1a1c094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fe98f7c-e6c0-4632-96da-a4c2e1a1c094.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -30545,7 +30545,7 @@
         },
         {
             "id": "a49f173e-c6df-5e16-9ac8-728f1e0661ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b4416-61da-4cd5-b3f1-79238a8e2503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77b4416-61da-4cd5-b3f1-79238a8e2503.jpg?1",
             "name": "Chandra, Flamecaller",
             "text": "",
             "colours": [
@@ -30581,7 +30581,7 @@
         },
         {
             "id": "482fced3-4e5c-5315-88c8-9ce471e732d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcec142-ba44-4d66-a1cc-9f98870a69d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcec142-ba44-4d66-a1cc-9f98870a69d5.jpg?1",
             "name": "Snapcaster Mage",
             "text": "",
             "colours": [
@@ -30616,7 +30616,7 @@
         },
         {
             "id": "97933f1e-0675-5650-8754-3280470734fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637216e9-ff5f-4dd5-ac08-a26a334431fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/637216e9-ff5f-4dd5-ac08-a26a334431fb.jpg?1",
             "name": "Immerwolf",
             "text": "",
             "colours": [
@@ -30652,7 +30652,7 @@
         },
         {
             "id": "93f31c45-0c82-50bc-822d-fdbc9a47f377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3776ea-c599-4e39-8259-41d33fdfbb7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3776ea-c599-4e39-8259-41d33fdfbb7e.jpg?1",
             "name": "Thrun, the Last Troll",
             "text": "",
             "colours": [
@@ -30689,7 +30689,7 @@
         },
         {
             "id": "819979c0-2d0b-5284-b99f-05e8adcb6cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c000fe-726f-4236-9317-c9dfeba4fb66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c000fe-726f-4236-9317-c9dfeba4fb66.jpg?1",
             "name": "Elesh Norn, Grand Cenobite",
             "text": "",
             "colours": [
@@ -30727,7 +30727,7 @@
         },
         {
             "id": "d0b1e043-d5e4-5feb-8066-b271adfe8d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6002d99a-c7b4-4845-aca9-b55dabb62d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6002d99a-c7b4-4845-aca9-b55dabb62d9f.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -30763,7 +30763,7 @@
         },
         {
             "id": "f4d4bb37-348c-5ef4-be48-c7a5943a7ea1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3722c7e8-bba3-4db0-a157-577cf37f53b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3722c7e8-bba3-4db0-a157-577cf37f53b4.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -30799,7 +30799,7 @@
         },
         {
             "id": "7fdf74ff-d4cd-59ad-8143-64d86835676f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2a3a29-b629-45f8-bd20-68a8d5018504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2a3a29-b629-45f8-bd20-68a8d5018504.jpg?1",
             "name": "Echo of Eons",
             "text": "",
             "colours": [
@@ -30830,7 +30830,7 @@
         },
         {
             "id": "f5fbfde9-bc18-5125-8e72-e53dbf2eedcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bff89a1-f7e7-4da9-9020-8618afdffda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bff89a1-f7e7-4da9-9020-8618afdffda2.jpg?1",
             "name": "Hive Mind",
             "text": "",
             "colours": [
@@ -30861,7 +30861,7 @@
         },
         {
             "id": "563203b8-dcfc-58dd-8124-acc69335f589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10adb81c-d6c1-4335-83d8-10561bbed490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10adb81c-d6c1-4335-83d8-10561bbed490.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -30895,7 +30895,7 @@
         },
         {
             "id": "249c2f83-0956-5389-8e69-e35fb3afbcf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd37785-bbef-4628-b88a-4ff28b0a7034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbd37785-bbef-4628-b88a-4ff28b0a7034.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -30924,7 +30924,7 @@
         },
         {
             "id": "e725c841-7efb-524e-94ee-8d8090a19898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1f94b-ab3e-4adb-b72a-89f3ea9f5859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1f94b-ab3e-4adb-b72a-89f3ea9f5859.jpg?1",
             "name": "Goblin Bombardment",
             "text": "",
             "colours": [
@@ -30956,7 +30956,7 @@
         },
         {
             "id": "ae47d3c0-94db-53a0-8d49-5d7b44323835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c51a722-633c-4325-ab50-633cebbb5cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c51a722-633c-4325-ab50-633cebbb5cd9.jpg?1",
             "name": "Kezzerdrix",
             "text": "",
             "colours": [
@@ -30991,7 +30991,7 @@
         },
         {
             "id": "781657aa-cfa7-5d2e-9bed-76bee77572b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg?1",
             "name": "Norin the Wary // Norin the Wary",
             "text": "",
             "colours": [
@@ -31028,7 +31028,7 @@
         },
         {
             "id": "2ea5cc89-736d-53a2-ba81-7b0f4f0410b7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/d/3d89c9be-2489-47e4-8e53-f980c82442b4.jpg?1",
             "name": "Norin the Wary // Norin the Wary",
             "text": "",
             "colours": [
@@ -31065,7 +31065,7 @@
         },
         {
             "id": "12d6bd30-bbf2-552d-bb2d-b14e28d75c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0491d-1aea-4d16-83c3-2f58e8bbda5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0491d-1aea-4d16-83c3-2f58e8bbda5a.jpg?1",
             "name": "Keen Duelist",
             "text": "",
             "colours": [
@@ -31100,7 +31100,7 @@
         },
         {
             "id": "28c61000-afb0-5e0a-960c-d85cc2759f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d974ae0-5d39-4b2d-8ca0-2ebed2657e25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d974ae0-5d39-4b2d-8ca0-2ebed2657e25.jpg?1",
             "name": "Masterwork of Ingenuity",
             "text": "",
             "colours": [],
@@ -31130,7 +31130,7 @@
         },
         {
             "id": "083dd03d-c680-5f20-bc6f-50e351ea2732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f824b34-f783-48b3-b5d5-579935101148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f824b34-f783-48b3-b5d5-579935101148.jpg?1",
             "name": "Sculpting Steel",
             "text": "",
             "colours": [],
@@ -31158,7 +31158,7 @@
         },
         {
             "id": "eff20120-c2d2-5e76-b4fc-0821cb327261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a86d3-83ed-4df3-923f-3117296b7224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53a86d3-83ed-4df3-923f-3117296b7224.jpg?1",
             "name": "Unnatural Growth",
             "text": "",
             "colours": [
@@ -31190,7 +31190,7 @@
         },
         {
             "id": "ebd3b847-b5df-52d5-acd5-297dd1330c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851ceb9-0efa-42a6-9fd6-434817a43815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1851ceb9-0efa-42a6-9fd6-434817a43815.jpg?1",
             "name": "Regrowth",
             "text": "",
             "colours": [
@@ -31222,7 +31222,7 @@
         },
         {
             "id": "ba09d4b0-afda-577b-87a8-4be611b0f517",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bec40e-d97b-4d13-a77f-128baf4cca14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5bec40e-d97b-4d13-a77f-128baf4cca14.jpg?1",
             "name": "Nature's Lore",
             "text": "",
             "colours": [
@@ -31256,7 +31256,7 @@
         },
         {
             "id": "3c98b54f-b584-5460-a223-4d2976488ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200d01f-7cb6-47e0-8dd8-0b5f901fb66f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200d01f-7cb6-47e0-8dd8-0b5f901fb66f.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "",
             "colours": [],
@@ -31284,7 +31284,7 @@
         },
         {
             "id": "5bea591e-3738-5a6f-8296-3a99a8fda1dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f519bd-b396-4e45-881e-707f6822c402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f519bd-b396-4e45-881e-707f6822c402.jpg?1",
             "name": "Yargle and Multani",
             "text": "",
             "colours": [
@@ -31324,7 +31324,7 @@
         },
         {
             "id": "14e4ba07-790b-51c0-bcdb-137d0fec36f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e234227-d91e-4049-ad4a-3beca6b89023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e234227-d91e-4049-ad4a-3beca6b89023.jpg?1",
             "name": "Dark Deal",
             "text": "",
             "colours": [
@@ -31356,7 +31356,7 @@
         },
         {
             "id": "4e35ac21-63a4-5885-922e-289c48fe88ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5100d6c-ca6e-40e5-8c55-50e74237ced4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5100d6c-ca6e-40e5-8c55-50e74237ced4.jpg?1",
             "name": "Archivist of Oghma",
             "text": "",
             "colours": [
@@ -31390,7 +31390,7 @@
         },
         {
             "id": "7fb59749-390f-517e-8a59-ba55ebb22e1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3c8050-6acb-4d53-ba46-646ca88d4eb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3c8050-6acb-4d53-ba46-646ca88d4eb6.jpg?1",
             "name": "Battle Angels of Tyr",
             "text": "",
             "colours": [
@@ -31424,7 +31424,7 @@
         },
         {
             "id": "fa4f835d-4d7c-53f8-9b09-119ddfc9f1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d09b91-d4da-4e8f-a6ef-09482e09842d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38d09b91-d4da-4e8f-a6ef-09482e09842d.jpg?1",
             "name": "Xorn",
             "text": "",
             "colours": [
@@ -31457,7 +31457,7 @@
         },
         {
             "id": "1713be40-f07d-5ed3-a1a9-7d52b532a038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1aa886-dc3b-44f7-880c-52370242e81f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a1aa886-dc3b-44f7-880c-52370242e81f.jpg?1",
             "name": "Druid of Purification",
             "text": "",
             "colours": [
@@ -31491,7 +31491,7 @@
         },
         {
             "id": "ae60423b-7dce-5529-b7fa-500e5a058c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab26569-5e7a-410c-86d3-a7ab989f7a31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab26569-5e7a-410c-86d3-a7ab989f7a31.jpg?1",
             "name": "Prosperous Innkeeper",
             "text": "",
             "colours": [
@@ -31525,7 +31525,7 @@
         },
         {
             "id": "e68dbaf2-8a86-53c8-a336-7f08f29c047a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149b45d-b7d4-46bf-ba3a-5137e93ea607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0149b45d-b7d4-46bf-ba3a-5137e93ea607.jpg?1",
             "name": "Minsc & Boo, Timeless Heroes",
             "text": "",
             "colours": [
@@ -31562,7 +31562,7 @@
         },
         {
             "id": "9bd879ca-c5b7-54c2-8ee5-92178ba6c29c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b5e4e-e68f-4b7d-a9c3-af01aa92c4e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b5e4e-e68f-4b7d-a9c3-af01aa92c4e8.jpg?1",
             "name": "Stuffy Doll",
             "text": "",
             "colours": [],
@@ -31593,7 +31593,7 @@
         },
         {
             "id": "35e83c6e-3669-5a42-bc1a-9e437348f2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c547c39-9ef8-4e8c-a6fd-6d9b6a8345a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c547c39-9ef8-4e8c-a6fd-6d9b6a8345a5.jpg?1",
             "name": "Solve the Equation",
             "text": "",
             "colours": [
@@ -31627,7 +31627,7 @@
         },
         {
             "id": "38dc92e1-2c72-54d4-b40e-95b68b976803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2025bd7b-ddef-40cf-9ffd-80591a67b508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2025bd7b-ddef-40cf-9ffd-80591a67b508.jpg?1",
             "name": "The Scarab God",
             "text": "",
             "colours": [
@@ -31664,7 +31664,7 @@
         },
         {
             "id": "19afaf76-fd5c-5a14-bbc7-c1a8fb31de32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c0b1-da97-49c1-a539-7fbaa1f77419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0277c0b1-da97-49c1-a539-7fbaa1f77419.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -31705,7 +31705,7 @@
         },
         {
             "id": "ad89ae78-b8b9-57e0-b58e-04a4d3dc03a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdf04a4-ba1e-4e0d-8c50-d7cea15fd0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdf04a4-ba1e-4e0d-8c50-d7cea15fd0a2.jpg?1",
             "name": "The Locust God",
             "text": "",
             "colours": [
@@ -31742,7 +31742,7 @@
         },
         {
             "id": "96a8bdb7-09c2-5c2d-b3bc-0687f362c808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb52dfd-f603-4fdf-bd9f-20c84c2c28c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb52dfd-f603-4fdf-bd9f-20c84c2c28c4.jpg?1",
             "name": "The Scorpion God",
             "text": "",
             "colours": [
@@ -31779,7 +31779,7 @@
         },
         {
             "id": "bdac9f73-e7c5-5caf-a071-29bede21016a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99beb62-7c89-41e7-9ac2-c1722f679a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99beb62-7c89-41e7-9ac2-c1722f679a2c.jpg?1",
             "name": "Ignoble Hierarch",
             "text": "",
             "colours": [
@@ -31815,7 +31815,7 @@
         },
         {
             "id": "4b08fdab-b445-54b9-b6de-963b61ca12e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b00b40e-338a-48d0-b95a-c1d5815370a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b00b40e-338a-48d0-b95a-c1d5815370a0.jpg?1",
             "name": "Seedborn Muse",
             "text": "",
             "colours": [
@@ -31848,7 +31848,7 @@
         },
         {
             "id": "b097a7b6-0700-5073-8fca-9572cddac774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ed44c-7b95-4153-afde-cfa2fef4e146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4ed44c-7b95-4153-afde-cfa2fef4e146.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -31884,7 +31884,7 @@
         },
         {
             "id": "608517b6-5dc0-5c20-b90a-9642ffd4aa25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cfc62a-2bd0-4292-968e-64c77f427f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25cfc62a-2bd0-4292-968e-64c77f427f78.jpg?1",
             "name": "Elspeth, Knight-Errant",
             "text": "",
             "colours": [
@@ -31922,7 +31922,7 @@
         },
         {
             "id": "2a1857df-95fb-5af0-94fb-1bb6a589f772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c327b8-0b21-425b-87d8-3d04397becfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c327b8-0b21-425b-87d8-3d04397becfe.jpg?1",
             "name": "Patron Wizard",
             "text": "",
             "colours": [
@@ -31957,7 +31957,7 @@
         },
         {
             "id": "1e10289a-c9a9-54d9-a7e6-699208ed6738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ec6360-d69d-41b8-bfca-2c1a3aea2272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ec6360-d69d-41b8-bfca-2c1a3aea2272.jpg?1",
             "name": "Berserk",
             "text": "",
             "colours": [
@@ -31991,7 +31991,7 @@
         },
         {
             "id": "ad536aa2-655b-5ac0-b13e-6b1438169639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526138f9-5003-4597-9ea6-0d83fee5035a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526138f9-5003-4597-9ea6-0d83fee5035a.jpg?1",
             "name": "Verduran Enchantress",
             "text": "",
             "colours": [
@@ -32026,7 +32026,7 @@
         },
         {
             "id": "935f9538-607c-55ec-b43c-c7bf5cb99a00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b822c67-77af-4778-ad1a-374fd780991d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b822c67-77af-4778-ad1a-374fd780991d.jpg?1",
             "name": "Triumphant Reckoning",
             "text": "",
             "colours": [
@@ -32058,7 +32058,7 @@
         },
         {
             "id": "9c1a08b1-8317-5a1a-ad0f-99accfc689c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8280fe-aea3-4796-af6e-6226c6085b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8280fe-aea3-4796-af6e-6226c6085b99.jpg?1",
             "name": "Savor the Moment",
             "text": "",
             "colours": [
@@ -32090,7 +32090,7 @@
         },
         {
             "id": "ecf85371-fbf3-5ac3-a934-712b47080329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e38facb-f520-4950-aa73-bebd2011565c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e38facb-f520-4950-aa73-bebd2011565c.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "",
             "colours": [
@@ -32129,7 +32129,7 @@
         },
         {
             "id": "424ef30a-d0c8-5e41-b433-dace84a422c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8855d65-98fc-4b5f-bd68-95d2fda6345f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8855d65-98fc-4b5f-bd68-95d2fda6345f.jpg?1",
             "name": "Bearscape",
             "text": "",
             "colours": [
@@ -32161,7 +32161,7 @@
         },
         {
             "id": "83713cae-fbfa-5321-967d-ff1405f7d42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54c9dfe-685a-4400-aa7c-0a944c33577b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c54c9dfe-685a-4400-aa7c-0a944c33577b.jpg?1",
             "name": "Collective Voyage",
             "text": "",
             "colours": [
@@ -32193,7 +32193,7 @@
         },
         {
             "id": "ee93cd55-1bb5-5ebc-85ac-5f3989d329d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2714874e-ad9c-4b9a-a91d-16865d29b183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2714874e-ad9c-4b9a-a91d-16865d29b183.jpg?1",
             "name": "Heartbeat of Spring",
             "text": "",
             "colours": [
@@ -32225,7 +32225,7 @@
         },
         {
             "id": "006bd15a-3949-51a7-9c11-06142f3bcc41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b2235b-6c18-436e-9d80-4a82ce0cac14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b2235b-6c18-436e-9d80-4a82ce0cac14.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -32262,7 +32262,7 @@
         },
         {
             "id": "9e53baaf-2db0-5bc2-b81e-ef11d225c6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4b80b1-fc8d-4da6-964a-3b85451c3049.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa4b80b1-fc8d-4da6-964a-3b85451c3049.jpg?1",
             "name": "Mana Confluence",
             "text": "",
             "colours": [],
@@ -32290,7 +32290,7 @@
         },
         {
             "id": "8759ce91-1023-5340-95f1-055717ae0630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebbdc78-4317-4595-a3c7-f265026c11d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ebbdc78-4317-4595-a3c7-f265026c11d1.jpg?1",
             "name": "Icingdeath, Frost Tyrant",
             "text": "",
             "colours": [
@@ -32325,7 +32325,7 @@
         },
         {
             "id": "b0513660-82f2-5158-ab44-ec9244e37aa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b381c1a-63e7-4f35-947a-f2b76c49c1ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b381c1a-63e7-4f35-947a-f2b76c49c1ec.jpg?1",
             "name": "Iymrith, Desert Doom",
             "text": "",
             "colours": [
@@ -32360,7 +32360,7 @@
         },
         {
             "id": "202d407a-2364-58d0-bc06-85ed0d4997d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea750e6-cdb8-4119-b26d-86abdbc14fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea750e6-cdb8-4119-b26d-86abdbc14fb2.jpg?1",
             "name": "Ebondeath, Dracolich",
             "text": "",
             "colours": [
@@ -32396,7 +32396,7 @@
         },
         {
             "id": "a96c02e5-788e-5c9d-99f5-5426a7a53722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830baa09-6098-4530-ae1f-8c94e60e733d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830baa09-6098-4530-ae1f-8c94e60e733d.jpg?1",
             "name": "Inferno of the Star Mounts",
             "text": "",
             "colours": [
@@ -32431,7 +32431,7 @@
         },
         {
             "id": "0ceadb69-5e40-589a-a257-b08bd52f6e03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0737-e1a5-4112-afde-34a3375e23f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0737-e1a5-4112-afde-34a3375e23f7.jpg?1",
             "name": "Old Gnawbone",
             "text": "",
             "colours": [
@@ -32466,7 +32466,7 @@
         },
         {
             "id": "453ddf17-aee4-509d-8d4b-6e0151e27aa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ed714e-28df-4bf3-9752-112a6e9e3609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ed714e-28df-4bf3-9752-112a6e9e3609.jpg?1",
             "name": "Tiamat",
             "text": "",
             "colours": [
@@ -32510,7 +32510,7 @@
         },
         {
             "id": "0b920de3-eee6-54d3-b1b3-7176d8e47ad1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ccb445-53dc-40d7-abea-d6d8dff60ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ccb445-53dc-40d7-abea-d6d8dff60ce4.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -32545,7 +32545,7 @@
         },
         {
             "id": "1f56bb70-91d3-591c-95d7-6d7103dd7f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004dc79-3857-4663-930c-59b2240e84bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a004dc79-3857-4663-930c-59b2240e84bc.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -32583,7 +32583,7 @@
         },
         {
             "id": "5151c92a-cdb6-544e-ad06-4f22d0a4329d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e8c1c1-1917-4858-afd1-ea4412d02375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e8c1c1-1917-4858-afd1-ea4412d02375.jpg?1",
             "name": "Solve the Equation",
             "text": "",
             "colours": [
@@ -32617,7 +32617,7 @@
         },
         {
             "id": "63d376a1-dcf3-5efa-b250-1eb25ad1ca84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e9151-d8b7-43f6-ac21-a8760cc04c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c4e9151-d8b7-43f6-ac21-a8760cc04c7a.jpg?1",
             "name": "Praetor's Grasp",
             "text": "",
             "colours": [
@@ -32649,7 +32649,7 @@
         },
         {
             "id": "9f5509f4-de0c-5088-941a-0b52fe07ee16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d727c345-4c96-4087-bfe3-f54b47b01da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d727c345-4c96-4087-bfe3-f54b47b01da6.jpg?1",
             "name": "Veil of Summer",
             "text": "",
             "colours": [
@@ -32681,7 +32681,7 @@
         },
         {
             "id": "035798e9-575e-5cd2-acdd-1fd2b238b7d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d054f9-ef77-4552-aa49-e9dfd840d8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d054f9-ef77-4552-aa49-e9dfd840d8f6.jpg?1",
             "name": "Merciless Executioner",
             "text": "",
             "colours": [
@@ -32716,7 +32716,7 @@
         },
         {
             "id": "5d2d2a06-526d-5345-be2c-56262f9be32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcfc82b-3e8a-4785-a87e-e96b5bfca90f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bcfc82b-3e8a-4785-a87e-e96b5bfca90f.jpg?1",
             "name": "Aggravated Assault",
             "text": "",
             "colours": [
@@ -32748,7 +32748,7 @@
         },
         {
             "id": "e3fdb723-5441-5602-83d5-8ca5c9917077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a762a954-1166-4c6c-bf87-0f68a5a24f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a762a954-1166-4c6c-bf87-0f68a5a24f3e.jpg?1",
             "name": "Krenko, Tin Street Kingpin",
             "text": "",
             "colours": [
@@ -32784,7 +32784,7 @@
         },
         {
             "id": "04ed9d32-b51b-57ed-9b7d-efdceca5dcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd4c537-e2ef-4c6f-93d0-f427a40c1cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd4c537-e2ef-4c6f-93d0-f427a40c1cf5.jpg?1",
             "name": "Zurgo Helmsmasher",
             "text": "",
             "colours": [
@@ -32825,7 +32825,7 @@
         },
         {
             "id": "ad7d1a7f-995e-58da-9795-6cde98637a9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9438e910-2974-49f8-825d-9835e72cee2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9438e910-2974-49f8-825d-9835e72cee2a.jpg?1",
             "name": "Skysovereign, Consul Flagship",
             "text": "",
             "colours": [],
@@ -32857,7 +32857,7 @@
         },
         {
             "id": "f7d71764-f0cd-560f-8ee8-1d6c036ebe51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b387332-5725-40c2-abf5-2562038e85a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b387332-5725-40c2-abf5-2562038e85a3.jpg?1",
             "name": "Blind Obedience",
             "text": "",
             "colours": [
@@ -32889,7 +32889,7 @@
         },
         {
             "id": "78e6306f-518f-5096-b189-afa28bc1a9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf204f62-999b-4a2c-95de-a733d9c54f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf204f62-999b-4a2c-95de-a733d9c54f1a.jpg?1",
             "name": "Danitha Capashen, Paragon",
             "text": "",
             "colours": [
@@ -32926,7 +32926,7 @@
         },
         {
             "id": "ccc07905-0c56-5946-b6fd-3134fa2b31b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84d0c3c-7382-46f9-a826-44100ac7cb41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84d0c3c-7382-46f9-a826-44100ac7cb41.jpg?1",
             "name": "Najeela, the Blade-Blossom",
             "text": "",
             "colours": [
@@ -32969,7 +32969,7 @@
         },
         {
             "id": "37b1cdf4-992c-5906-9434-8591274b6e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4c7818-4523-44e9-baa4-013695d57bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4c7818-4523-44e9-baa4-013695d57bc4.jpg?1",
             "name": "Scourge of the Throne",
             "text": "",
             "colours": [
@@ -33003,7 +33003,7 @@
         },
         {
             "id": "5bb27b48-44ba-5423-a948-0edb1d2e8753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e2117e-fc5f-4783-87e8-8d733c836b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e2117e-fc5f-4783-87e8-8d733c836b0f.jpg?1",
             "name": "Loxodon Warhammer",
             "text": "",
             "colours": [],
@@ -33033,7 +33033,7 @@
         },
         {
             "id": "eb93124f-5f07-5b0d-b93d-390532b81bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd2850b-8b86-4af0-a6f0-5dddfed6e811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd2850b-8b86-4af0-a6f0-5dddfed6e811.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -33065,7 +33065,7 @@
         },
         {
             "id": "34b19e1a-6f92-5554-aa2a-f297e2eab75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f2538a-9446-45bd-8d28-7a03f812170e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f2538a-9446-45bd-8d28-7a03f812170e.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -33099,7 +33099,7 @@
         },
         {
             "id": "43158c6b-27b8-5a98-88a8-b2d952e4babe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a35bb96-89de-4a0a-a53e-aa97f800e92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a35bb96-89de-4a0a-a53e-aa97f800e92f.jpg?1",
             "name": "Bone Splinters",
             "text": "",
             "colours": [
@@ -33131,7 +33131,7 @@
         },
         {
             "id": "6f44b9d1-a831-5393-bd2f-2bb56e5e0246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7121b5b3-7f05-4914-9af8-5d2bcde9b28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7121b5b3-7f05-4914-9af8-5d2bcde9b28a.jpg?1",
             "name": "Fling",
             "text": "",
             "colours": [
@@ -33165,7 +33165,7 @@
         },
         {
             "id": "1176a559-acc9-5e33-b631-3873de0311e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0c008-e0d9-43b3-9781-d4abbb410413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b0c008-e0d9-43b3-9781-d4abbb410413.jpg?1",
             "name": "Defense of the Heart",
             "text": "",
             "colours": [
@@ -33197,7 +33197,7 @@
         },
         {
             "id": "a0c48483-1f11-5732-b4fb-9e8573fcc473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cd70c4-17e9-4bbe-a8f8-2a29450835a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cd70c4-17e9-4bbe-a8f8-2a29450835a9.jpg?1",
             "name": "Fellwar Stone",
             "text": "",
             "colours": [],
@@ -33227,7 +33227,7 @@
         },
         {
             "id": "6ab06fa1-b53f-5dec-a1b5-a52b2ed29339",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5e5f25-41c8-4626-bb14-a121167a9d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5e5f25-41c8-4626-bb14-a121167a9d79.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -33266,7 +33266,7 @@
         },
         {
             "id": "b4f4e3c5-6df5-5387-95e7-91fa005696e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a31fb1-a323-47e1-b455-489623889794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a31fb1-a323-47e1-b455-489623889794.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "",
             "colours": [
@@ -33304,7 +33304,7 @@
         },
         {
             "id": "2d156d05-2b8b-5005-82f3-6b8be88ad304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0b540a-3f90-4730-a3a1-034992363b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0b540a-3f90-4730-a3a1-034992363b53.jpg?1",
             "name": "Tezzeret, Agent of Bolas",
             "text": "",
             "colours": [
@@ -33342,7 +33342,7 @@
         },
         {
             "id": "576fd091-b2e5-5605-9c32-207c51362cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fac637-9440-4994-b15a-a65364c51089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fac637-9440-4994-b15a-a65364c51089.jpg?1",
             "name": "Knight Exemplar",
             "text": "",
             "colours": [
@@ -33379,7 +33379,7 @@
         },
         {
             "id": "94d9092a-01b3-5970-8470-dd7509fc19dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc8ddc-140a-4e1d-a89a-93ba4756cf5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77dc8ddc-140a-4e1d-a89a-93ba4756cf5a.jpg?1",
             "name": "Knight of the White Orchid",
             "text": "",
             "colours": [
@@ -33414,7 +33414,7 @@
         },
         {
             "id": "4df40b20-df8a-565c-84f2-7bab4568106b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9249230d-6cd4-4f2e-8f8b-c046824a1c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9249230d-6cd4-4f2e-8f8b-c046824a1c72.jpg?1",
             "name": "Lord of the Undead",
             "text": "",
             "colours": [
@@ -33448,7 +33448,7 @@
         },
         {
             "id": "3d0a2362-5626-51ed-9418-e4e1f2137b7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf89e72-1448-48c0-b2b4-ebac0262efdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf89e72-1448-48c0-b2b4-ebac0262efdb.jpg?1",
             "name": "Compost",
             "text": "",
             "colours": [
@@ -33480,7 +33480,7 @@
         },
         {
             "id": "9e171985-ac1b-5d1b-9d60-2c28521d8ef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff105f-58bd-4c4c-ba18-dedbe7aab75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92ff105f-58bd-4c4c-ba18-dedbe7aab75e.jpg?1",
             "name": "Matter Reshaper",
             "text": "",
             "colours": [],
@@ -33510,7 +33510,7 @@
         },
         {
             "id": "cb2e7b83-8745-530b-ba89-8662bc194a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182556f-3a01-41b5-a469-50ce5363c863.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4182556f-3a01-41b5-a469-50ce5363c863.jpg?1",
             "name": "Toothy, Imaginary Friend",
             "text": "",
             "colours": [
@@ -33546,7 +33546,7 @@
         },
         {
             "id": "c8170053-4d6e-5f87-8342-aa0a17e2e913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e84108-c54f-4074-b38c-91dc8abc2f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70e84108-c54f-4074-b38c-91dc8abc2f64.jpg?1",
             "name": "Pir, Imaginative Rascal",
             "text": "",
             "colours": [
@@ -33582,7 +33582,7 @@
         },
         {
             "id": "b021111e-4fb2-58aa-abf7-e8b8b6ece830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f569425-465f-42a8-ae4e-7e98d70cc2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f569425-465f-42a8-ae4e-7e98d70cc2af.jpg?1",
             "name": "The Gitrog Monster",
             "text": "",
             "colours": [
@@ -33621,7 +33621,7 @@
         },
         {
             "id": "3cb6b3cc-5e5d-50f0-a3b7-7369806f9b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7333e089-dc31-4c2f-9230-c2033d95c7e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7333e089-dc31-4c2f-9230-c2033d95c7e6.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -33652,7 +33652,7 @@
         },
         {
             "id": "363f6b00-6a05-58e2-973b-37a2008a6655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5713b7-f2a6-41c5-a485-058b7393570b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5713b7-f2a6-41c5-a485-058b7393570b.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -33683,7 +33683,7 @@
         },
         {
             "id": "1ffcd397-6268-52e0-aa5e-e98f8e7f7f93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85dab-5887-47bb-b5f2-fd11ff77ef91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e85dab-5887-47bb-b5f2-fd11ff77ef91.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -33714,7 +33714,7 @@
         },
         {
             "id": "32743d64-e7e4-5d4d-b2a3-2fd6ce5e450c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb35429-30ee-4e2f-80ad-083faf53e264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fb35429-30ee-4e2f-80ad-083faf53e264.jpg?1",
             "name": "Talisman of Impulse",
             "text": "",
             "colours": [],
@@ -33745,7 +33745,7 @@
         },
         {
             "id": "760de224-66ec-5d0b-b026-588a5bb8a15d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b6bdac-02d4-4661-b022-103f19232985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b6bdac-02d4-4661-b022-103f19232985.jpg?1",
             "name": "Talisman of Unity",
             "text": "",
             "colours": [],
@@ -33776,7 +33776,7 @@
         },
         {
             "id": "22caa1e2-3059-51d4-a896-4143da0377c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36168640-0708-4d51-bc8e-d32e24ae095a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36168640-0708-4d51-bc8e-d32e24ae095a.jpg?1",
             "name": "Talisman of Hierarchy",
             "text": "",
             "colours": [],
@@ -33807,7 +33807,7 @@
         },
         {
             "id": "48d71efe-fa4d-550b-85bb-de85c88cc651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc0a11c-99f0-439d-a372-4fd77e007df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cc0a11c-99f0-439d-a372-4fd77e007df4.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -33838,7 +33838,7 @@
         },
         {
             "id": "0ad03e94-eac8-5aaa-9bdd-807303af390b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a259eb-c6a2-4890-810a-239df5461e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7a259eb-c6a2-4890-810a-239df5461e2f.jpg?1",
             "name": "Talisman of Resilience",
             "text": "",
             "colours": [],
@@ -33869,7 +33869,7 @@
         },
         {
             "id": "951501c3-b786-5631-879a-2f52eb0f1721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832cfe00-bc3e-46bb-b4bd-43f758290a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832cfe00-bc3e-46bb-b4bd-43f758290a41.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -33900,7 +33900,7 @@
         },
         {
             "id": "e6e4d49e-fe75-58b3-9e20-f285dc4db156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc83e0-7de2-4680-9d68-15a6018095fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc83e0-7de2-4680-9d68-15a6018095fe.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -33931,7 +33931,7 @@
         },
         {
             "id": "b7109b64-9964-53aa-abe6-770b77ba0d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699a5f43-2433-401c-be13-7ef15882983f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699a5f43-2433-401c-be13-7ef15882983f.jpg?1",
             "name": "Jaya Ballard",
             "text": "",
             "colours": [
@@ -33967,7 +33967,7 @@
         },
         {
             "id": "4644b4b9-ad7f-50ce-844b-79144804e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41277c6-95f8-4f0e-ad4a-43b8bb7cdb19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41277c6-95f8-4f0e-ad4a-43b8bb7cdb19.jpg?1",
             "name": "Jaya's Immolating Inferno",
             "text": "",
             "colours": [
@@ -34001,7 +34001,7 @@
         },
         {
             "id": "17588444-b1ad-51dc-820f-98def84f4fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb425ed1-d428-495a-a56f-07b81e97dcd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb425ed1-d428-495a-a56f-07b81e97dcd3.jpg?1",
             "name": "Pyretic Ritual",
             "text": "",
             "colours": [
@@ -34033,7 +34033,7 @@
         },
         {
             "id": "10f13dc5-a9a8-52ee-afaf-c0fd70d8fa04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da327c8-730b-4fab-827f-64e7f5b60e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da327c8-730b-4fab-827f-64e7f5b60e1d.jpg?1",
             "name": "Repercussion",
             "text": "",
             "colours": [
@@ -34065,7 +34065,7 @@
         },
         {
             "id": "7461f0b7-6b34-571b-b37e-5bc8635523a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b25bd-6a0f-4521-a6ff-deee9c2ada98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c75b25bd-6a0f-4521-a6ff-deee9c2ada98.jpg?1",
             "name": "Pyromancer's Goggles",
             "text": "",
             "colours": [],
@@ -34097,7 +34097,7 @@
         },
         {
             "id": "bd22d556-019c-5851-bc8d-c0dc28953421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b99807-cbb9-4d77-b36e-0bc9ccea27a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b99807-cbb9-4d77-b36e-0bc9ccea27a6.jpg?1",
             "name": "Arcades Sabboth",
             "text": "",
             "colours": [
@@ -34137,7 +34137,7 @@
         },
         {
             "id": "f6a68c60-65de-5a53-b6d7-60a0cf37c288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488a3ee9-a8c4-4a39-ad07-857560bff200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488a3ee9-a8c4-4a39-ad07-857560bff200.jpg?1",
             "name": "Chromium",
             "text": "",
             "colours": [
@@ -34177,7 +34177,7 @@
         },
         {
             "id": "e3829365-ea26-5ff6-9ad2-6580e2ce9f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f4e969-242f-41a9-9d5f-90c7f95cf472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f4e969-242f-41a9-9d5f-90c7f95cf472.jpg?1",
             "name": "Nicol Bolas",
             "text": "",
             "colours": [
@@ -34217,7 +34217,7 @@
         },
         {
             "id": "8b8a58fb-2ce9-5708-ba10-edb71857ebc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd3abf1-7641-4f5f-99d3-0c9ae65ba5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd3abf1-7641-4f5f-99d3-0c9ae65ba5fe.jpg?1",
             "name": "Vaevictis Asmadi",
             "text": "",
             "colours": [
@@ -34257,7 +34257,7 @@
         },
         {
             "id": "49b219fc-8f51-51b8-8930-192d0f304003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455fe817-0921-4497-a041-04030b0aac55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455fe817-0921-4497-a041-04030b0aac55.jpg?1",
             "name": "Palladia-Mors",
             "text": "",
             "colours": [
@@ -34297,7 +34297,7 @@
         },
         {
             "id": "94880280-4b33-5832-be36-dfa4bc94be22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2dbb1a-4b83-47b6-92ca-145fa5c9c16b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a2dbb1a-4b83-47b6-92ca-145fa5c9c16b.jpg?1",
             "name": "Mox Opal",
             "text": "",
             "colours": [],
@@ -34326,7 +34326,7 @@
         },
         {
             "id": "8d96c02b-8203-51d7-8dd3-f00528765cab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4845994-1d56-4f69-9895-c6142acf3cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4845994-1d56-4f69-9895-c6142acf3cb4.jpg?1",
             "name": "Mox Tantalite",
             "text": "",
             "colours": [],
@@ -34353,7 +34353,7 @@
         },
         {
             "id": "3f54dbed-8fc2-536b-9778-0d2b395170c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ea0aa3-30c0-4eb4-b262-ce70781277ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ea0aa3-30c0-4eb4-b262-ce70781277ce.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -34389,7 +34389,7 @@
         },
         {
             "id": "2650fc8d-893c-5eaa-aba3-9554fd39b1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ef9cd-ee4d-4cbe-a07d-89f9322e5362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5ef9cd-ee4d-4cbe-a07d-89f9322e5362.jpg?1",
             "name": "Void Winnower",
             "text": "",
             "colours": [],
@@ -34419,7 +34419,7 @@
         },
         {
             "id": "bf70459d-b1f2-562c-a22f-3cbd316b9bc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d75604-4941-4faf-8f1a-7fc529e64962.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d75604-4941-4faf-8f1a-7fc529e64962.jpg?1",
             "name": "Goblin Settler",
             "text": "",
             "colours": [
@@ -34453,7 +34453,7 @@
         },
         {
             "id": "33afeae3-79ed-5335-b036-429dc2042de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6550a-b01e-45b0-807c-5593ed419bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebf6550a-b01e-45b0-807c-5593ed419bac.jpg?1",
             "name": "Collector Ouphe",
             "text": "",
             "colours": [
@@ -34487,7 +34487,7 @@
         },
         {
             "id": "796621e2-e789-5c75-96e9-77a2a3b76dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7bb5f3-3488-442f-a0e6-92d93f9e7231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db7bb5f3-3488-442f-a0e6-92d93f9e7231.jpg?1",
             "name": "Vengevine",
             "text": "",
             "colours": [
@@ -34521,7 +34521,7 @@
         },
         {
             "id": "7beb2d19-5f06-5d83-a9bb-312627934e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg?1",
             "name": "Blightsteel Colossus // Blightsteel Colossus",
             "text": "",
             "colours": [],
@@ -34553,7 +34553,7 @@
         },
         {
             "id": "3bac1725-5087-5b5e-bd9f-cb6b5e27d190",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4d227cd3-ebfe-4dd3-929a-4f8ff7c8981e.jpg?1",
             "name": "Blightsteel Colossus // Blightsteel Colossus",
             "text": "",
             "colours": [],
@@ -34585,7 +34585,7 @@
         },
         {
             "id": "6a3c769c-af38-5fcc-adb7-126dad4f7f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg?1",
             "name": "Doubling Cube // Doubling Cube",
             "text": "",
             "colours": [],
@@ -34613,7 +34613,7 @@
         },
         {
             "id": "334a4e94-9f80-579b-8553-343b9801ec2b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/9052f5c7-ee3b-457d-97ca-ac6b4518997c.jpg?1",
             "name": "Doubling Cube // Doubling Cube",
             "text": "",
             "colours": [],
@@ -34641,7 +34641,7 @@
         },
         {
             "id": "ff9fd322-ceac-5456-8012-f927248a3ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg?1",
             "name": "Darksteel Colossus // Darksteel Colossus",
             "text": "",
             "colours": [],
@@ -34672,7 +34672,7 @@
         },
         {
             "id": "2096ddd1-b8e9-5237-83b7-896582de5c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b5341ab-85a6-44b2-b738-1110e699c02b.jpg?1",
             "name": "Darksteel Colossus // Darksteel Colossus",
             "text": "",
             "colours": [],
@@ -34703,7 +34703,7 @@
         },
         {
             "id": "e51c97d8-21a2-53c4-b78b-b3ee771a5450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879adda-c2a7-4e5e-99db-31024e75b585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1879adda-c2a7-4e5e-99db-31024e75b585.jpg?1",
             "name": "True Conviction",
             "text": "",
             "colours": [
@@ -34735,7 +34735,7 @@
         },
         {
             "id": "d41a8e54-79bc-53ca-973a-65572d30a7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e99bb96-dc40-4623-b133-b5def847477d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e99bb96-dc40-4623-b133-b5def847477d.jpg?1",
             "name": "Dramatic Reversal",
             "text": "",
             "colours": [
@@ -34767,7 +34767,7 @@
         },
         {
             "id": "538a12e4-b65f-56e5-8a32-6c1767a81788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f19307-5b4e-4b1d-91b5-2adef6a12e0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f19307-5b4e-4b1d-91b5-2adef6a12e0c.jpg?1",
             "name": "Fabricate",
             "text": "",
             "colours": [
@@ -34801,7 +34801,7 @@
         },
         {
             "id": "7d22eb37-db60-543f-a6c9-e2c0fba68f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a01e89-f109-49d9-a33e-03afef650636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a01e89-f109-49d9-a33e-03afef650636.jpg?1",
             "name": "Collective Brutality",
             "text": "",
             "colours": [
@@ -34833,7 +34833,7 @@
         },
         {
             "id": "0db533e5-14dd-5884-b1bf-afb4105aa252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa8c556-2d3e-4f29-8457-e2162def7353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa8c556-2d3e-4f29-8457-e2162def7353.jpg?1",
             "name": "By Force",
             "text": "",
             "colours": [
@@ -34865,7 +34865,7 @@
         },
         {
             "id": "d19dea28-2ded-5705-adda-4e8db66935ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf97573c-65e3-4eec-92af-c364c1cbceea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf97573c-65e3-4eec-92af-c364c1cbceea.jpg?1",
             "name": "Greater Good",
             "text": "",
             "colours": [
@@ -34899,7 +34899,7 @@
         },
         {
             "id": "cbc75981-362b-5ebf-8f34-6e15c6299e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026777d1-e3a7-45a3-8967-527c0b4236e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026777d1-e3a7-45a3-8967-527c0b4236e2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -34968,7 +34968,7 @@
         },
         {
             "id": "7dedbb51-46d7-508b-b398-d1c54b00e5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a2259b-9ee8-42d7-92c0-d9421dd196e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a2259b-9ee8-42d7-92c0-d9421dd196e5.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -35033,7 +35033,7 @@
         },
         {
             "id": "c59d4cb5-828c-5c06-9c86-0ba9e495c6f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d825e-0a51-43e8-9b5a-43a376b58d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f49d825e-0a51-43e8-9b5a-43a376b58d6f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -35097,7 +35097,7 @@
         },
         {
             "id": "fdde36e4-3e6b-50a6-911a-2693534ba1ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40698-620e-4032-b2e3-0d513a4a4250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf40698-620e-4032-b2e3-0d513a4a4250.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -35171,7 +35171,7 @@
         },
         {
             "id": "4e595d9c-a6f1-5e94-a6b2-9333ceec6150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f694e1-f9c9-428e-a85c-d09b3474c79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f694e1-f9c9-428e-a85c-d09b3474c79b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -35236,7 +35236,7 @@
         },
         {
             "id": "bf400a96-ac6d-5606-8740-9fcc9bfd4aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04ddd06-0082-44aa-8782-7bd5631f2e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d04ddd06-0082-44aa-8782-7bd5631f2e77.jpg?1",
             "name": "Deepglow Skate",
             "text": "",
             "colours": [
@@ -35270,7 +35270,7 @@
         },
         {
             "id": "5f20732b-2ce1-5e23-a94b-dd1ab3d6da08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12eb1d-1027-436a-86a3-455128cc0641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d12eb1d-1027-436a-86a3-455128cc0641.jpg?1",
             "name": "Tireless Tracker",
             "text": "",
             "colours": [
@@ -35307,7 +35307,7 @@
         },
         {
             "id": "e3343aa0-6cb4-504f-9ba1-010a00655335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acd847d-7474-4d6a-8281-aa59991a1b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6acd847d-7474-4d6a-8281-aa59991a1b87.jpg?1",
             "name": "Contagion Engine",
             "text": "",
             "colours": [],
@@ -35335,7 +35335,7 @@
         },
         {
             "id": "8982c4ae-4ea4-50c2-90c7-c9305b36d99d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a14a7-0e77-4445-8d72-be8adcff2f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a14a7-0e77-4445-8d72-be8adcff2f3e.jpg?1",
             "name": "Sword of Truth and Justice",
             "text": "",
             "colours": [],
@@ -35365,7 +35365,7 @@
         },
         {
             "id": "8aa7c8c4-2708-5e23-b9ab-68f6581a9863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15bd831-aa75-42c1-905c-6e8cc644c7fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15bd831-aa75-42c1-905c-6e8cc644c7fc.jpg?1",
             "name": "Laboratory Maniac",
             "text": "",
             "colours": [
@@ -35403,7 +35403,7 @@
         },
         {
             "id": "f6f51d35-520d-5228-9b5d-e9df4aa7508c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28c7fe5-bc61-4fc2-acb9-810f2e4ec682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28c7fe5-bc61-4fc2-acb9-810f2e4ec682.jpg?1",
             "name": "Stitcher's Supplier",
             "text": "",
             "colours": [
@@ -35437,7 +35437,7 @@
         },
         {
             "id": "b603099b-7901-5f49-887a-8e72ed8b9ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c818547c-a6f6-4c69-9e4d-33741e605093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c818547c-a6f6-4c69-9e4d-33741e605093.jpg?1",
             "name": "Beast Whisperer",
             "text": "",
             "colours": [
@@ -35472,7 +35472,7 @@
         },
         {
             "id": "5cfc928b-27e4-5669-ad7b-79bc4c191751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1965955-57fc-4447-8b60-de1d81617204.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1965955-57fc-4447-8b60-de1d81617204.jpg?1",
             "name": "Vizier of the Menagerie",
             "text": "",
             "colours": [
@@ -35507,7 +35507,7 @@
         },
         {
             "id": "5bd227f3-a24a-51fd-ab67-b8ff392181c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b536948f-9a29-4811-a3b2-9d3f73117965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b536948f-9a29-4811-a3b2-9d3f73117965.jpg?1",
             "name": "Wood Elves",
             "text": "",
             "colours": [
@@ -35542,7 +35542,7 @@
         },
         {
             "id": "35f1ab83-8e50-5e41-9f3c-97bc68bc6a34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75a663c-f12f-49d6-b84f-3f941049872e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75a663c-f12f-49d6-b84f-3f941049872e.jpg?1",
             "name": "Imprisoned in the Moon",
             "text": "",
             "colours": [
@@ -35576,7 +35576,7 @@
         },
         {
             "id": "b3c42841-d655-5397-8ac8-751f01b58c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201c6c9-c7c2-405c-b61d-77e7f3a9a1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8201c6c9-c7c2-405c-b61d-77e7f3a9a1ca.jpg?1",
             "name": "Stasis",
             "text": "",
             "colours": [
@@ -35608,7 +35608,7 @@
         },
         {
             "id": "6468c008-2043-5ce1-8d25-0ef0d4decef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6989d1d-00ca-4d5d-acdc-0b7c6a522e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6989d1d-00ca-4d5d-acdc-0b7c6a522e30.jpg?1",
             "name": "Prismatic Omen",
             "text": "",
             "colours": [
@@ -35640,7 +35640,7 @@
         },
         {
             "id": "db4207f1-6180-5311-8451-73a42fbe3f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d6d636-51f1-4f98-94af-5307c3399dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d6d636-51f1-4f98-94af-5307c3399dae.jpg?1",
             "name": "Wheel of Sun and Moon",
             "text": "",
             "colours": [
@@ -35676,7 +35676,7 @@
         },
         {
             "id": "89265655-e0bb-57f0-9a47-cdc003725f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d974a337-3139-43ff-a368-6f3d10f53646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d974a337-3139-43ff-a368-6f3d10f53646.jpg?1",
             "name": "Azami, Lady of Scrolls",
             "text": "",
             "colours": [
@@ -35713,7 +35713,7 @@
         },
         {
             "id": "43a47dc3-a49c-5d35-9cbd-d55687a50849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8751d-0eb6-46fd-88a6-7dd5255a1077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc8751d-0eb6-46fd-88a6-7dd5255a1077.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "",
             "colours": [
@@ -35751,7 +35751,7 @@
         },
         {
             "id": "f68088e8-c488-59fe-b322-285b134050a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85397a1d-1fd1-4ca1-a1fc-f32e3a063c81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85397a1d-1fd1-4ca1-a1fc-f32e3a063c81.jpg?1",
             "name": "Reflector Mage",
             "text": "",
             "colours": [
@@ -35788,7 +35788,7 @@
         },
         {
             "id": "70e9603d-ce4d-566c-a352-00e10717b32f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f038672-d03c-4349-9261-1b76ae4594c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f038672-d03c-4349-9261-1b76ae4594c6.jpg?1",
             "name": "Adaptive Automaton",
             "text": "",
             "colours": [],
@@ -35819,7 +35819,7 @@
         },
         {
             "id": "217a093a-8dbe-53e9-b6a1-67c4df48b5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7501a66-76f8-4f1d-8b4c-2a82b5f930c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7501a66-76f8-4f1d-8b4c-2a82b5f930c4.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "",
             "colours": [
@@ -35857,7 +35857,7 @@
         },
         {
             "id": "3c82ac09-fefb-58dd-bcff-597a9e359137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62835e03-49c8-42b8-91ba-3aa4beb5df66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62835e03-49c8-42b8-91ba-3aa4beb5df66.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "",
             "colours": [
@@ -35895,7 +35895,7 @@
         },
         {
             "id": "0f4899b6-2178-5d39-ac52-b5d342a30b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3668996e-659d-413b-84e6-9f3099518d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3668996e-659d-413b-84e6-9f3099518d7f.jpg?1",
             "name": "Skullclamp",
             "text": "",
             "colours": [],
@@ -35927,7 +35927,7 @@
         },
         {
             "id": "92cdc45a-4135-5e7c-a177-a381f9b99e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b2e5-a34c-48a0-a054-6a459ebe60c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b89b2e5-a34c-48a0-a054-6a459ebe60c9.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -35961,7 +35961,7 @@
         },
         {
             "id": "147afe00-7883-5ee1-8cdf-3630c0d3c21a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e175cb-ffea-473f-8422-53273f263016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e175cb-ffea-473f-8422-53273f263016.jpg?1",
             "name": "Carrion Feeder",
             "text": "",
             "colours": [
@@ -35995,7 +35995,7 @@
         },
         {
             "id": "3c56729d-64d8-566c-9ad2-b21389594924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cb8aec-21cf-49c1-8407-e45afe377f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60cb8aec-21cf-49c1-8407-e45afe377f4f.jpg?1",
             "name": "Doomsday",
             "text": "",
             "colours": [
@@ -36027,7 +36027,7 @@
         },
         {
             "id": "7d7cf901-d465-5c34-8c89-0c7937f56607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a10efc-4b8d-4e32-90fb-50ab73810b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a10efc-4b8d-4e32-90fb-50ab73810b59.jpg?1",
             "name": "Plaguecrafter",
             "text": "",
             "colours": [
@@ -36062,7 +36062,7 @@
         },
         {
             "id": "d0191a06-6d20-5b90-8922-c887fb69fbcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc64b6-6f2c-4b20-aa80-54cc47382606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ecc64b6-6f2c-4b20-aa80-54cc47382606.jpg?1",
             "name": "Thoughtseize",
             "text": "",
             "colours": [
@@ -36094,7 +36094,7 @@
         },
         {
             "id": "a42e3d15-43b3-590e-b9ce-84008f3c18c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger // Ulamog, the Ceaseless Hunger",
             "text": "",
             "colours": [],
@@ -36126,7 +36126,7 @@
         },
         {
             "id": "ecd5b8fa-4d1e-5947-877c-a1e541e6a268",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/82fa24fb-aecc-4c33-9e79-c29651ddafbe.jpg?1",
             "name": "Ulamog, the Ceaseless Hunger // Ulamog, the Ceaseless Hunger",
             "text": "",
             "colours": [],
@@ -36158,7 +36158,7 @@
         },
         {
             "id": "77778260-be35-5d20-b69a-d04325b5ccc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg?1",
             "name": "Etali, Primal Storm // Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -36195,7 +36195,7 @@
         },
         {
             "id": "3bd2dedb-041b-59a7-a94e-388de22d977c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b96d6ea4-a3a4-4e33-be97-b3767f2bb63a.jpg?1",
             "name": "Etali, Primal Storm // Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -36232,7 +36232,7 @@
         },
         {
             "id": "8ccf2256-e912-53cd-96ed-6d45c80f9144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg?1",
             "name": "Ghalta, Primal Hunger // Ghalta, Primal Hunger",
             "text": "",
             "colours": [
@@ -36269,7 +36269,7 @@
         },
         {
             "id": "d29ad67b-392f-51fe-8116-211da7ff2368",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/0489be0d-2117-46a8-97ab-31fe480685e2.jpg?1",
             "name": "Ghalta, Primal Hunger // Ghalta, Primal Hunger",
             "text": "",
             "colours": [
@@ -36306,7 +36306,7 @@
         },
         {
             "id": "a5e09cb3-bd6d-5246-91c9-4895c9481d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddf66f9-a98a-4edf-831d-68b68065d75d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dddf66f9-a98a-4edf-831d-68b68065d75d.jpg?1",
             "name": "Serra Ascendant",
             "text": "",
             "colours": [
@@ -36341,7 +36341,7 @@
         },
         {
             "id": "0c31ba98-60e4-52c8-938a-baceb925f3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423ed9cd-94d9-49a1-a167-69899b630f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423ed9cd-94d9-49a1-a167-69899b630f95.jpg?1",
             "name": "Rapid Hybridization",
             "text": "",
             "colours": [
@@ -36373,7 +36373,7 @@
         },
         {
             "id": "00f7677f-2110-590b-b350-9ed567872336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bdfd40-dbc7-42a8-a122-5834193b8f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91bdfd40-dbc7-42a8-a122-5834193b8f5e.jpg?1",
             "name": "Demonic Consultation",
             "text": "",
             "colours": [
@@ -36405,7 +36405,7 @@
         },
         {
             "id": "7c05a485-59b5-58d5-b1a0-6d536779dd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f954a-8cd4-4cf4-8f30-d4396d44bc5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f954a-8cd4-4cf4-8f30-d4396d44bc5e.jpg?1",
             "name": "Winds of Change",
             "text": "",
             "colours": [
@@ -36437,7 +36437,7 @@
         },
         {
             "id": "5066f628-d50c-5ef0-a405-840efb9ca6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be44d1-da6b-4427-955b-d7f32ebf1813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4be44d1-da6b-4427-955b-d7f32ebf1813.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -36472,7 +36472,7 @@
         },
         {
             "id": "6c0930ea-de5a-52bc-a492-33d6580c9130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912e30e7-9b8b-4c27-af3a-ffdcfe8b6feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/912e30e7-9b8b-4c27-af3a-ffdcfe8b6feb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -36541,7 +36541,7 @@
         },
         {
             "id": "df0d8f4a-7f62-5983-9fcc-76f2a44e2f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cb4d9d-4f2b-4f60-b48f-749747aa7c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96cb4d9d-4f2b-4f60-b48f-749747aa7c15.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -36606,7 +36606,7 @@
         },
         {
             "id": "2658f988-0d25-55cd-867e-c6b3e1efaca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a6e87-a9fb-4bd8-a09d-b160aa302a2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f32a6e87-a9fb-4bd8-a09d-b160aa302a2b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -36670,7 +36670,7 @@
         },
         {
             "id": "ea5858a0-ed46-569a-9885-f8584d468bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b5f331-3d6f-4e0f-b5a4-61040ed61d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b5f331-3d6f-4e0f-b5a4-61040ed61d39.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -36744,7 +36744,7 @@
         },
         {
             "id": "b43253f0-41c0-5380-ab65-c2bd9af0f490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a13a86b-c4c5-4a7a-9e01-8669e9ed6557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a13a86b-c4c5-4a7a-9e01-8669e9ed6557.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -36809,7 +36809,7 @@
         },
         {
             "id": "acd87101-5a2a-5cac-a1f2-02742468c635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b77346-d6e4-4d2f-b054-19fdea686d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b77346-d6e4-4d2f-b054-19fdea686d40.jpg?1",
             "name": "Abundant Growth",
             "text": "",
             "colours": [
@@ -36843,7 +36843,7 @@
         },
         {
             "id": "1cbddd35-ceb1-5d40-bbca-d9c8bdfc27f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798748d5-cb17-4f9a-85d4-1bc518222bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798748d5-cb17-4f9a-85d4-1bc518222bb8.jpg?1",
             "name": "Mycoloth",
             "text": "",
             "colours": [
@@ -36877,7 +36877,7 @@
         },
         {
             "id": "5e657300-bb30-5813-ab72-22c86a45aa71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817f782f-7e62-44b3-9bb2-3a57d34dfe67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817f782f-7e62-44b3-9bb2-3a57d34dfe67.jpg?1",
             "name": "Ghave, Guru of Spores",
             "text": "",
             "colours": [
@@ -36918,7 +36918,7 @@
         },
         {
             "id": "f0cd836c-f2cb-53d6-a47a-7a3b6e876c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16055a39-484e-490d-9ae8-398cd36f80a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16055a39-484e-490d-9ae8-398cd36f80a9.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "",
             "colours": [
@@ -36956,7 +36956,7 @@
         },
         {
             "id": "b5f376f5-ee25-5890-b6a6-6b059ae3f46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f8d1ca-bc82-453a-b237-ef75ce027b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f8d1ca-bc82-453a-b237-ef75ce027b8f.jpg?1",
             "name": "Elspeth, Sun's Champion",
             "text": "",
             "colours": [
@@ -36992,7 +36992,7 @@
         },
         {
             "id": "90f4022b-3cd0-58dd-aaaa-cedb1ac9f02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000db964-719d-4532-9225-35658565b35d.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -37031,7 +37031,7 @@
         },
         {
             "id": "0e7c42dd-89b9-511c-a64c-c772680cfdc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbd5627-2f55-4101-981b-49f5f45db578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbd5627-2f55-4101-981b-49f5f45db578.jpg?1",
             "name": "Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -37067,7 +37067,7 @@
         },
         {
             "id": "571a41a7-fd9f-5591-8336-499d0a9767b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5662d0a5-3222-4ab9-9e15-f06477730b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5662d0a5-3222-4ab9-9e15-f06477730b75.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "",
             "colours": [
@@ -37107,7 +37107,7 @@
         },
         {
             "id": "df1eaa35-859a-5fa2-afbd-e2a516c9bfdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df8d25e-e519-4197-aa8e-ec596cb2a2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1df8d25e-e519-4197-aa8e-ec596cb2a2d8.jpg?1",
             "name": "Sarkhan Vol",
             "text": "",
             "colours": [
@@ -37145,7 +37145,7 @@
         },
         {
             "id": "2423b127-7a0e-5226-a534-5fb21b569d70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0cdff4-c81e-4e53-8721-748eb71d9e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f0cdff4-c81e-4e53-8721-748eb71d9e81.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "",
             "colours": [
@@ -37183,7 +37183,7 @@
         },
         {
             "id": "58a40753-56c9-5a2d-9081-6cc338288b40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29da3c7f-f886-4be0-bce5-d2707c5fc926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29da3c7f-f886-4be0-bce5-d2707c5fc926.jpg?1",
             "name": "Lathliss, Dragon Queen",
             "text": "",
             "colours": [
@@ -37221,7 +37221,7 @@
         },
         {
             "id": "2e1e251a-310b-5348-8dbb-3b4904bdd027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d8bf03-42f3-4200-96a7-03e822b102e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d8bf03-42f3-4200-96a7-03e822b102e9.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -37259,7 +37259,7 @@
         },
         {
             "id": "1130bd10-6b25-5120-9bfd-f1c7b87cbeff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a931b6-607c-4cbb-ad1e-14e2cad14947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33a931b6-607c-4cbb-ad1e-14e2cad14947.jpg?1",
             "name": "Birds of Paradise",
             "text": "",
             "colours": [
@@ -37297,7 +37297,7 @@
         },
         {
             "id": "4da09baa-ae37-5a66-8026-9eb1f0692532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a229f0-3cca-4c2a-8cb5-064040eece72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a229f0-3cca-4c2a-8cb5-064040eece72.jpg?1",
             "name": "Sliver Legion",
             "text": "",
             "colours": [
@@ -37343,7 +37343,7 @@
         },
         {
             "id": "cdcfc495-1c88-5dc5-af96-4e5bd107ce79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feef6ea3-67f3-42d8-bf19-02ba9151c2a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feef6ea3-67f3-42d8-bf19-02ba9151c2a3.jpg?1",
             "name": "Sliver Legion",
             "text": "",
             "colours": [
@@ -37389,7 +37389,7 @@
         },
         {
             "id": "558822e7-4406-5fbc-a05e-ce2387f9c57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396dc9ce-bf25-4f51-9b07-baea8bfa1718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396dc9ce-bf25-4f51-9b07-baea8bfa1718.jpg?1",
             "name": "Thought-Knot Seer",
             "text": "",
             "colours": [],
@@ -37421,7 +37421,7 @@
         },
         {
             "id": "60c71c5a-64c7-5b36-9219-e453b027d6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9f9fb7-c79a-4991-914f-c3500a488bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f9f9fb7-c79a-4991-914f-c3500a488bf1.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "",
             "colours": [
@@ -37453,7 +37453,7 @@
         },
         {
             "id": "0bc6709f-62d2-5ba4-8dd4-8ee4c550c2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00449fad-6b06-40b1-8179-cbc86acec907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00449fad-6b06-40b1-8179-cbc86acec907.jpg?1",
             "name": "Reality Smasher",
             "text": "",
             "colours": [],
@@ -37483,7 +37483,7 @@
         },
         {
             "id": "0d600fd0-7c52-58d9-b526-0b52476a95e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00372c7a-2e83-4a26-9642-0d092dfcf861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00372c7a-2e83-4a26-9642-0d092dfcf861.jpg?1",
             "name": "Eldrazi Temple",
             "text": "",
             "colours": [],
@@ -37511,7 +37511,7 @@
         },
         {
             "id": "2fc3021d-c5e9-50aa-80f0-869929d9c34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -37552,7 +37552,7 @@
         },
         {
             "id": "a66bc29f-804d-54ac-84a8-ceb07140df77",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/46d43696-3c63-4c55-bc61-e1560c8b8201.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -37595,7 +37595,7 @@
         },
         {
             "id": "554a2c4d-7701-5dbd-bc7d-5900e01351fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -37633,7 +37633,7 @@
         },
         {
             "id": "73f57d4f-8bbb-5f05-9a71-c4ae57b07e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/485211cd-6c9f-4fb6-99da-f876c55531b4.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -37671,7 +37671,7 @@
         },
         {
             "id": "61b8865c-4e98-53dd-a92f-c610aa3a25a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -37706,7 +37706,7 @@
         },
         {
             "id": "8e223007-324a-5c85-9f78-6f61e992468b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/3847d9b6-dc35-43b4-a352-662f92a4e7d7.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -37741,7 +37741,7 @@
         },
         {
             "id": "30a2715d-2a38-5762-9e1a-f3c1a683bdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -37783,7 +37783,7 @@
         },
         {
             "id": "09686798-9901-5a01-bbc1-c610ace5e8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/c/cc36eb6d-ec33-47c0-a1c7-d02af1800a3a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -37824,7 +37824,7 @@
         },
         {
             "id": "10beaa6b-a4a1-5ca5-905e-bb734188eb7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [],
@@ -37855,7 +37855,7 @@
         },
         {
             "id": "63b6b0a7-6696-524b-ab0b-79b5d9e8f531",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/3/d3182b40-a731-4957-9d6e-a1f69c3aeb5e.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [
@@ -37892,7 +37892,7 @@
         },
         {
             "id": "54b700ba-9026-5919-8eb3-fbda19eb7229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eec0470-82bf-4a07-a7d9-e5d40a518041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eec0470-82bf-4a07-a7d9-e5d40a518041.jpg?1",
             "name": "Emrakul, the Promised End",
             "text": "",
             "colours": [],
@@ -37924,7 +37924,7 @@
         },
         {
             "id": "fd30a3f6-af03-59c7-b83f-acb8e4cd5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad4c850-097e-4909-87ec-a33ef8f2ba34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad4c850-097e-4909-87ec-a33ef8f2ba34.jpg?1",
             "name": "Serra Angel",
             "text": "",
             "colours": [
@@ -37958,7 +37958,7 @@
         },
         {
             "id": "52894677-7541-55da-acd3-76ced43c680b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3fb533-84a8-4414-ba1f-56bebe04b061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3fb533-84a8-4414-ba1f-56bebe04b061.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -37994,7 +37994,7 @@
         },
         {
             "id": "ba88b6fb-380b-57ca-87b7-f4841d4afbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae63d70a-9ecc-4912-aeb7-7d41c91b3b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae63d70a-9ecc-4912-aeb7-7d41c91b3b9d.jpg?1",
             "name": "Progenitus",
             "text": "",
             "colours": [
@@ -38039,7 +38039,7 @@
         },
         {
             "id": "f64a9383-4056-5cb9-8e4e-ec4978c1701c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38315a5-820e-4f31-b359-5c367bdf2cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38315a5-820e-4f31-b359-5c367bdf2cfc.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "",
             "colours": [
@@ -38078,7 +38078,7 @@
         },
         {
             "id": "c09287b1-8787-5488-a46c-ece1468fce00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea53e1ee-fc87-4aaf-b876-a0b5622414f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea53e1ee-fc87-4aaf-b876-a0b5622414f7.jpg?1",
             "name": "Spellseeker",
             "text": "",
             "colours": [
@@ -38113,7 +38113,7 @@
         },
         {
             "id": "0d35b45b-6136-522d-941d-9acf72b34e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb06c55-186b-45e2-ad0b-3790ed83e1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb06c55-186b-45e2-ad0b-3790ed83e1de.jpg?1",
             "name": "Magus of the Wheel",
             "text": "",
             "colours": [
@@ -38148,7 +38148,7 @@
         },
         {
             "id": "9593699f-8426-57f1-9671-517063fad3b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a795db-6b70-4534-b6e9-240895875d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a795db-6b70-4534-b6e9-240895875d12.jpg?1",
             "name": "Kess, Dissident Mage",
             "text": "",
             "colours": [
@@ -38189,7 +38189,7 @@
         },
         {
             "id": "7bf58d10-c862-5768-ac45-2055305c5c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81e16f-8e5c-42e2-9d4e-220eb3b4aa38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81e16f-8e5c-42e2-9d4e-220eb3b4aa38.jpg?1",
             "name": "Field Marshal",
             "text": "",
             "colours": [
@@ -38224,7 +38224,7 @@
         },
         {
             "id": "40e3c7a4-4a06-5c72-a297-1aa39ea17ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0016ea50-4f77-4814-a505-8067ecb177cc.jpg?1",
             "name": "Temporal Manipulation",
             "text": "",
             "colours": [
@@ -38256,7 +38256,7 @@
         },
         {
             "id": "5fd26b71-4358-505f-a020-ae1dba0044cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e169f68-d336-429d-bdd0-f034a53391a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e169f68-d336-429d-bdd0-f034a53391a3.jpg?1",
             "name": "Dark Ritual",
             "text": "",
             "colours": [
@@ -38288,7 +38288,7 @@
         },
         {
             "id": "27a5ad8a-3930-526a-8787-532a45f5cbc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040c95-8233-4f7f-807d-7c9e33388d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88040c95-8233-4f7f-807d-7c9e33388d49.jpg?1",
             "name": "Midnight Reaper",
             "text": "",
             "colours": [
@@ -38323,7 +38323,7 @@
         },
         {
             "id": "cca9a4fa-c50a-558b-8c0d-370ea4646c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f582e8-148f-432f-a6ba-f12a35750781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65f582e8-148f-432f-a6ba-f12a35750781.jpg?1",
             "name": "Seize the Day",
             "text": "",
             "colours": [
@@ -38357,7 +38357,7 @@
         },
         {
             "id": "8370ef49-a736-5028-a95d-a80abf43b7bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc472a09-7634-429e-a594-94491aabed5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc472a09-7634-429e-a594-94491aabed5c.jpg?1",
             "name": "Faeburrow Elder",
             "text": "",
             "colours": [
@@ -38394,7 +38394,7 @@
         },
         {
             "id": "b0b73522-d703-5b70-a30e-0fa4bbca7214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300e11b6-12df-4d28-95d7-d6514f8eeb6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/300e11b6-12df-4d28-95d7-d6514f8eeb6b.jpg?1",
             "name": "Carnage Tyrant",
             "text": "",
             "colours": [
@@ -38428,7 +38428,7 @@
         },
         {
             "id": "c9f3cefb-9929-51b1-a035-ae1d630a15a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d49ad9-3600-4f64-b284-4f096ed90b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15d49ad9-3600-4f64-b284-4f096ed90b4d.jpg?1",
             "name": "Fleshbag Marauder",
             "text": "",
             "colours": [
@@ -38465,7 +38465,7 @@
         },
         {
             "id": "90fef68d-cc40-5bfc-a9c1-bf1ce76bd867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bc0682-f21a-4c35-bdb2-deb10a6cd8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75bc0682-f21a-4c35-bdb2-deb10a6cd8b8.jpg?1",
             "name": "It That Betrays",
             "text": "",
             "colours": [],
@@ -38495,7 +38495,7 @@
         },
         {
             "id": "3249d50b-de63-58c3-b913-50584b46b38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ccf45b-dee2-4d92-bd45-05d77840d0c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ccf45b-dee2-4d92-bd45-05d77840d0c6.jpg?1",
             "name": "Forced Fruition",
             "text": "",
             "colours": [
@@ -38527,7 +38527,7 @@
         },
         {
             "id": "5001002d-e7ad-5fed-bb01-a5a23d170855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82117419-4d97-4ac6-abb9-316fc6460ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82117419-4d97-4ac6-abb9-316fc6460ddf.jpg?1",
             "name": "Future Sight",
             "text": "",
             "colours": [
@@ -38559,7 +38559,7 @@
         },
         {
             "id": "c2b80cb2-e06e-5214-b929-8d2569cb7496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1efaa-b92f-495d-8c6f-eb6c7481afd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f1efaa-b92f-495d-8c6f-eb6c7481afd0.jpg?1",
             "name": "Mental Misstep",
             "text": "",
             "colours": [
@@ -38591,7 +38591,7 @@
         },
         {
             "id": "96f17f8f-14b1-5c9b-8e13-25f15a6e4beb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e611d3c6-ede9-43ca-a4fc-aacd43b7c1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e611d3c6-ede9-43ca-a4fc-aacd43b7c1fc.jpg?1",
             "name": "Mind's Dilation",
             "text": "",
             "colours": [
@@ -38623,7 +38623,7 @@
         },
         {
             "id": "839eba73-99b6-55d8-9977-8e2464eb7fbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da828d8e-69a2-4900-a87a-111445220e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da828d8e-69a2-4900-a87a-111445220e1c.jpg?1",
             "name": "Well of Lost Dreams",
             "text": "",
             "colours": [],
@@ -38653,7 +38653,7 @@
         },
         {
             "id": "469ea989-0951-5cfb-a4c8-d8c928996d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7138e87-9a3c-4031-8c87-d3630c89e88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7138e87-9a3c-4031-8c87-d3630c89e88c.jpg?1",
             "name": "Felidar Sovereign",
             "text": "",
             "colours": [
@@ -38687,7 +38687,7 @@
         },
         {
             "id": "d5b095df-82c8-5127-8bf4-7e99bcde041d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97797cf-1e4a-4e76-91a4-cac557a17416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97797cf-1e4a-4e76-91a4-cac557a17416.jpg?1",
             "name": "Descendants' Path",
             "text": "",
             "colours": [
@@ -38718,7 +38718,7 @@
         },
         {
             "id": "6bb1a6f9-6569-591d-bf4e-36b5091fe265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da180aa8-7490-4165-bcc9-86b3ca697225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da180aa8-7490-4165-bcc9-86b3ca697225.jpg?1",
             "name": "Lord Windgrace",
             "text": "",
             "colours": [
@@ -38757,7 +38757,7 @@
         },
         {
             "id": "72bae57c-765f-5afa-a919-2d4734afa1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed589f-8635-44a5-9978-d68c2bd1071b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed589f-8635-44a5-9978-d68c2bd1071b.jpg?1",
             "name": "Violent Outburst",
             "text": "",
             "colours": [
@@ -38790,7 +38790,7 @@
         },
         {
             "id": "80776dad-cb79-5614-9bd5-46edb58a3931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995fd27-b4c9-4620-b759-4755101e1534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a995fd27-b4c9-4620-b759-4755101e1534.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "",
             "colours": [
@@ -38830,7 +38830,7 @@
         },
         {
             "id": "8e4005a6-ad95-5c1e-aa00-bf35a477b684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7572bb1d-0578-4ebb-9180-dbb709ec9a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7572bb1d-0578-4ebb-9180-dbb709ec9a5c.jpg?1",
             "name": "Bolas's Citadel",
             "text": "",
             "colours": [
@@ -38864,7 +38864,7 @@
         },
         {
             "id": "19550fcc-fbc1-55bf-b4e0-6b9255e1fa88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3672010d-7293-4906-b76d-759112c89c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3672010d-7293-4906-b76d-759112c89c51.jpg?1",
             "name": "Leshrac's Sigil",
             "text": "",
             "colours": [
@@ -38896,7 +38896,7 @@
         },
         {
             "id": "a8d0a1c6-d95e-5abb-a69c-87fba0137354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521bad8e-46b3-4cd8-bd1a-884ebfa1accd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/521bad8e-46b3-4cd8-bd1a-884ebfa1accd.jpg?1",
             "name": "Jet Medallion",
             "text": "",
             "colours": [],
@@ -38924,7 +38924,7 @@
         },
         {
             "id": "9ec18572-c229-575d-8210-ab0b9e68abf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bc1f3-4e6b-4be9-8d3e-2a268a1eae60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/425bc1f3-4e6b-4be9-8d3e-2a268a1eae60.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -38993,7 +38993,7 @@
         },
         {
             "id": "a3fcd526-942f-5eab-9073-3d929dfb4b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0a1a30-8bef-4297-b566-d5f6b4d277a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f0a1a30-8bef-4297-b566-d5f6b4d277a1.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -39058,7 +39058,7 @@
         },
         {
             "id": "bfe2e3bd-fa5a-59f6-946f-5b7a7e148061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e701b-4a03-4c3d-9574-ca2f035a7a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4e701b-4a03-4c3d-9574-ca2f035a7a5c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -39122,7 +39122,7 @@
         },
         {
             "id": "100ccd50-7553-557e-acd3-aea91d46b367",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3eb87a-8f77-4859-95fd-10988f03da7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3eb87a-8f77-4859-95fd-10988f03da7b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -39196,7 +39196,7 @@
         },
         {
             "id": "cf4934c0-2bde-564a-a786-64c0cf1d6816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fafd821-5bb3-4083-bf3b-ecc4cf6c7468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fafd821-5bb3-4083-bf3b-ecc4cf6c7468.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -39261,7 +39261,7 @@
         },
         {
             "id": "5b4ab551-989b-55ed-ba74-b8f69fa5bc12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e39cb1-0b57-4d70-afa6-67b307068273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41e39cb1-0b57-4d70-afa6-67b307068273.jpg?1",
             "name": "Phage the Untouchable",
             "text": "",
             "colours": [
@@ -39297,7 +39297,7 @@
         },
         {
             "id": "9337ee55-2963-5e0c-9069-77875b3c11f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc5127-b6d1-45e4-b434-0841eb46e4e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dc5127-b6d1-45e4-b434-0841eb46e4e9.jpg?1",
             "name": "Yisan, the Wanderer Bard",
             "text": "",
             "colours": [
@@ -39334,7 +39334,7 @@
         },
         {
             "id": "e8f998df-6957-59c1-91c7-dfee120f35ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad257a3-aacc-4981-b6f3-53fdbf56e834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ad257a3-aacc-4981-b6f3-53fdbf56e834.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "",
             "colours": [
@@ -39377,7 +39377,7 @@
         },
         {
             "id": "0b2b53fa-b1e9-5a2b-9f91-b7b7e2815a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7f7eb-4e29-40d1-acc7-a6819f64771c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf7f7eb-4e29-40d1-acc7-a6819f64771c.jpg?1",
             "name": "Sen Triplets",
             "text": "",
             "colours": [
@@ -39418,7 +39418,7 @@
         },
         {
             "id": "ca946f86-9096-5094-9f41-58ecf23f374a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affc8ed-9ba1-47fe-aa81-8fde61345bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0affc8ed-9ba1-47fe-aa81-8fde61345bfc.jpg?1",
             "name": "Tevesh Szat, Doom of Fools",
             "text": "",
             "colours": [
@@ -39454,7 +39454,7 @@
         },
         {
             "id": "ef22f649-2f96-53b6-aecd-e075c0da0f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0424f97c-b8ba-4c19-9238-cf2d7eed150f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0424f97c-b8ba-4c19-9238-cf2d7eed150f.jpg?1",
             "name": "Godo, Bandit Warlord",
             "text": "",
             "colours": [
@@ -39491,7 +39491,7 @@
         },
         {
             "id": "e0579d7e-7e78-5a38-9c04-6341ac6235fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d028f-b57f-4f68-9694-c5a2bd7295b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864d028f-b57f-4f68-9694-c5a2bd7295b9.jpg?1",
             "name": "Jeska, Thrice Reborn",
             "text": "",
             "colours": [
@@ -39527,7 +39527,7 @@
         },
         {
             "id": "663b1f77-4248-5b08-9c31-c68bfd88138d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e439cd0-5ba1-45af-a868-f408e0a50465.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e439cd0-5ba1-45af-a868-f408e0a50465.jpg?1",
             "name": "Vial Smasher the Fierce",
             "text": "",
             "colours": [
@@ -39566,7 +39566,7 @@
         },
         {
             "id": "da49e51e-50f7-5f3a-ac43-260433929bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01842079-5c70-4e87-a1c5-c814a44ba0f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01842079-5c70-4e87-a1c5-c814a44ba0f5.jpg?1",
             "name": "Blighted Agent",
             "text": "",
             "colours": [
@@ -39602,7 +39602,7 @@
         },
         {
             "id": "4e4cbf9d-aaed-5798-926c-d39dd84fb9c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068d2a94-e4f5-4789-9228-30d72684e3b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/068d2a94-e4f5-4789-9228-30d72684e3b9.jpg?1",
             "name": "K'rrik, Son of Yawgmoth",
             "text": "",
             "colours": [
@@ -39642,7 +39642,7 @@
         },
         {
             "id": "e8825aa3-e822-53e0-a5bf-d0e608163ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97685645-43ab-4dd3-926a-f7439d7a31e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97685645-43ab-4dd3-926a-f7439d7a31e6.jpg?1",
             "name": "Glistener Elf",
             "text": "",
             "colours": [
@@ -39678,7 +39678,7 @@
         },
         {
             "id": "dc9671fa-9cf1-5074-9bf1-84baa82ffafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5358745-44d8-4452-9cee-06ec6006214b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5358745-44d8-4452-9cee-06ec6006214b.jpg?1",
             "name": "Batterskull",
             "text": "",
             "colours": [],
@@ -39708,7 +39708,7 @@
         },
         {
             "id": "b3135abf-5790-5fe6-a794-4d1dcd8b0859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928d19f-a88e-4558-878e-af49c50c70ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f928d19f-a88e-4558-878e-af49c50c70ee.jpg?1",
             "name": "Inkmoth Nexus",
             "text": "",
             "colours": [],
@@ -39738,7 +39738,7 @@
         },
         {
             "id": "ab071747-f34e-54c4-9632-b5881107ff75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -39779,7 +39779,7 @@
         },
         {
             "id": "b7a89717-0fba-55a6-afed-0367bf99bd58",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/86f54b82-0168-421e-bcde-d13d48b7d9ff.jpg?1",
             "name": "Esika, God of the Tree // The Prismatic Bridge",
             "text": "",
             "colours": [
@@ -39822,7 +39822,7 @@
         },
         {
             "id": "b1a39a29-54dd-5c8b-95f9-e309ddbd0600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -39860,7 +39860,7 @@
         },
         {
             "id": "a56f89e1-cca7-588b-8e3b-5f294f9c42fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ee427c2-4445-44ed-8170-d1d02170e873.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "",
             "colours": [
@@ -39898,7 +39898,7 @@
         },
         {
             "id": "ba2da389-0890-5b86-a4b0-7c32aa437f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -39933,7 +39933,7 @@
         },
         {
             "id": "d6b76063-6762-5de2-940d-0e0ee2254479",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e71df56a-c27f-4983-a2c7-c2412a0345b0.jpg?1",
             "name": "Bloodline Keeper // Lord of Lineage",
             "text": "",
             "colours": [
@@ -39968,7 +39968,7 @@
         },
         {
             "id": "8cf87357-5705-5217-a157-61dd8529cfc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -40010,7 +40010,7 @@
         },
         {
             "id": "c516d697-6a79-5a15-9061-be56ba4ddf8e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/3374707f-c203-4a96-aa0d-eef3eca7c17a.jpg?1",
             "name": "Nicol Bolas, the Ravager // Nicol Bolas, the Arisen",
             "text": "",
             "colours": [
@@ -40051,7 +40051,7 @@
         },
         {
             "id": "035d1eda-c67a-5558-a293-ea2430494150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [],
@@ -40082,7 +40082,7 @@
         },
         {
             "id": "15de3999-3a97-5ab3-b375-2cb6738753a0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9ec6cbb4-7182-48fe-87fe-9ce9f3a51032.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "",
             "colours": [
@@ -40119,7 +40119,7 @@
         },
         {
             "id": "db0fa823-83a7-5b38-85ba-5d69a42f0263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c274214-9cef-4b0c-971d-43f0f17d73ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c274214-9cef-4b0c-971d-43f0f17d73ed.jpg?1",
             "name": "Phyrexian Unlife",
             "text": "",
             "colours": [
@@ -40150,7 +40150,7 @@
         },
         {
             "id": "960ab9ae-076b-5130-971f-373682a8f470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35494d-411f-46b4-903d-773d37992e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c35494d-411f-46b4-903d-773d37992e9e.jpg?1",
             "name": "Phyrexian Crusader",
             "text": "",
             "colours": [
@@ -40185,7 +40185,7 @@
         },
         {
             "id": "a70771b7-5992-5a27-b343-e1ca380d0023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58751c9-6b6b-4650-80b3-a72be558ad26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58751c9-6b6b-4650-80b3-a72be558ad26.jpg?1",
             "name": "Plague Engineer",
             "text": "",
             "colours": [
@@ -40219,7 +40219,7 @@
         },
         {
             "id": "753e6ecd-88f9-5091-a887-b610f2709894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3476e706-f71a-4f7a-b026-cd8cb0665c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3476e706-f71a-4f7a-b026-cd8cb0665c39.jpg?1",
             "name": "Ertai, the Corrupted",
             "text": "",
             "colours": [
@@ -40260,7 +40260,7 @@
         },
         {
             "id": "9715aad9-3476-5652-bcd9-5fe097cd08c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d62d95-26af-4a63-91fd-feeb85362299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d62d95-26af-4a63-91fd-feeb85362299.jpg?1",
             "name": "Glissa, the Traitor",
             "text": "",
             "colours": [
@@ -40299,7 +40299,7 @@
         },
         {
             "id": "0c71032d-3f75-50e7-8a93-8993f2093f0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53740e51-ee3f-4158-93f4-395d168820aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53740e51-ee3f-4158-93f4-395d168820aa.jpg?1",
             "name": "Eldrazi Conscription",
             "text": "",
             "colours": [],
@@ -40331,7 +40331,7 @@
         },
         {
             "id": "4e9389ae-48eb-57c2-9e45-ed3661608449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e44ae7-3363-45e9-970e-5789e7721305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e44ae7-3363-45e9-970e-5789e7721305.jpg?1",
             "name": "Deafening Silence",
             "text": "",
             "colours": [
@@ -40363,7 +40363,7 @@
         },
         {
             "id": "5fdd638f-4521-5698-bb0e-b5e41db50975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c46071-b94c-460e-ab3a-9f9633eee833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c46071-b94c-460e-ab3a-9f9633eee833.jpg?1",
             "name": "Counterbalance",
             "text": "",
             "colours": [
@@ -40395,7 +40395,7 @@
         },
         {
             "id": "b6fc80f8-df47-5c83-9036-e76847298264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e376a75-77ea-40f0-a61e-afcdea2c763a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e376a75-77ea-40f0-a61e-afcdea2c763a.jpg?1",
             "name": "Bruna, Light of Alabaster",
             "text": "",
             "colours": [
@@ -40433,7 +40433,7 @@
         },
         {
             "id": "00a1f936-ee43-55a3-aaa2-03adeb7d8f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c2044-328a-4e29-8b3a-0eeb75fee2bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71c2044-328a-4e29-8b3a-0eeb75fee2bf.jpg?1",
             "name": "Hexdrinker",
             "text": "",
             "colours": [
@@ -40467,7 +40467,7 @@
         },
         {
             "id": "e2362853-d8c2-5929-b531-40e60ce1c714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9bf59f-6879-4343-9158-207ddd170bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9bf59f-6879-4343-9158-207ddd170bfb.jpg?1",
             "name": "Lotus Cobra",
             "text": "",
             "colours": [
@@ -40501,7 +40501,7 @@
         },
         {
             "id": "909c97ed-80cb-5e2b-8a94-209311b46502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f966-c081-49eb-8114-1690d1fd19b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4230f966-c081-49eb-8114-1690d1fd19b2.jpg?1",
             "name": "Seshiro the Anointed",
             "text": "",
             "colours": [
@@ -40538,7 +40538,7 @@
         },
         {
             "id": "272f5d31-6aa8-56cc-88b9-67a724dbe18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1950aed0-f34b-4dc6-a01e-31313fa442bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1950aed0-f34b-4dc6-a01e-31313fa442bc.jpg?1",
             "name": "Ice-Fang Coatl",
             "text": "",
             "colours": [
@@ -40576,7 +40576,7 @@
         },
         {
             "id": "64de767b-b9e5-50ca-8bda-86188e2ce1b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f7b125-46ab-4034-b96a-8cc0e6cc5103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f7b125-46ab-4034-b96a-8cc0e6cc5103.jpg?1",
             "name": "Stonecoil Serpent",
             "text": "",
             "colours": [],
@@ -40607,7 +40607,7 @@
         },
         {
             "id": "cd5dba55-46cc-51ea-947a-62f4160b33f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da88239e-1155-4657-9685-ab3f323672ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da88239e-1155-4657-9685-ab3f323672ea.jpg?1",
             "name": "Alms Collector",
             "text": "",
             "colours": [
@@ -40642,7 +40642,7 @@
         },
         {
             "id": "cf48278b-aa11-5671-8ae7-71b9d8a6b6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f101-0df2-4b33-b818-90c77c69ef23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b17f101-0df2-4b33-b818-90c77c69ef23.jpg?1",
             "name": "Crested Sunmare",
             "text": "",
             "colours": [
@@ -40676,7 +40676,7 @@
         },
         {
             "id": "9b6a41f2-30e2-559d-bad7-bc692bdde9d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410bf6b3-885a-41cf-97f7-2e942922a4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/410bf6b3-885a-41cf-97f7-2e942922a4ec.jpg?1",
             "name": "Goreclaw, Terror of Qal Sisma",
             "text": "",
             "colours": [
@@ -40712,7 +40712,7 @@
         },
         {
             "id": "9fb6ea2e-0508-59b7-bea9-4ce8640ea24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c7202-ca36-46a3-ae04-c7da41ecc67d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c7202-ca36-46a3-ae04-c7da41ecc67d.jpg?1",
             "name": "Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -40753,7 +40753,7 @@
         },
         {
             "id": "b287c5b4-4f48-501c-a521-040add7682e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07baf1d-a399-478e-9ae1-0a9e6cfe4933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07baf1d-a399-478e-9ae1-0a9e6cfe4933.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -40781,7 +40781,7 @@
         },
         {
             "id": "264d793e-8dd2-5bc1-b6e2-47356603d7fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7815c90b-f7f7-46ac-9dc1-fc3d8cfdbac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7815c90b-f7f7-46ac-9dc1-fc3d8cfdbac5.jpg?1",
             "name": "Sakashima the Impostor",
             "text": "",
             "colours": [
@@ -40818,7 +40818,7 @@
         },
         {
             "id": "6934b23c-05bb-5aa6-8f6a-e28f344fb8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca1926-6809-4924-a80c-f322266ac38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebca1926-6809-4924-a80c-f322266ac38e.jpg?1",
             "name": "Massacre Girl",
             "text": "",
             "colours": [
@@ -40855,7 +40855,7 @@
         },
         {
             "id": "64a6047a-de6a-5c48-b86a-9dacbafce482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fa88e-1ba5-4166-a7c3-cead597c65b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fa88e-1ba5-4166-a7c3-cead597c65b8.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "",
             "colours": [
@@ -40895,7 +40895,7 @@
         },
         {
             "id": "bbdc03c9-a94a-5f7a-91ba-1d0b3fb909f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a80fbb2-4b3a-46fc-b105-09e512bc414a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a80fbb2-4b3a-46fc-b105-09e512bc414a.jpg?1",
             "name": "Teysa Karlov",
             "text": "",
             "colours": [
@@ -40934,7 +40934,7 @@
         },
         {
             "id": "609f0a19-b50c-5765-ad5d-87eadefcd31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaf50b-5491-474b-8501-8814e2629fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaf50b-5491-474b-8501-8814e2629fe4.jpg?1",
             "name": "Paradise Mantle",
             "text": "",
             "colours": [],
@@ -40964,7 +40964,7 @@
         },
         {
             "id": "84b7b10f-beec-5d2d-9446-ef2a0de2bd17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150240c-10c7-439c-a076-740bd0f2cc0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c150240c-10c7-439c-a076-740bd0f2cc0a.jpg?1",
             "name": "Xenk, Paladin Unbroken",
             "text": "",
             "colours": [
@@ -41001,7 +41001,7 @@
         },
         {
             "id": "da5605bc-5e20-5ba3-a10d-2cda13c7874a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9a9cf1-f480-48e8-a9b8-75d7f1640d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9a9cf1-f480-48e8-a9b8-75d7f1640d1a.jpg?1",
             "name": "Simon, Wild Magic Sorcerer",
             "text": "",
             "colours": [
@@ -41039,7 +41039,7 @@
         },
         {
             "id": "4fcdb7f5-1a1f-5e6f-83d2-1bc53ceeaa09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2091e863-30f3-475e-9a61-e76fc4cf1ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2091e863-30f3-475e-9a61-e76fc4cf1ce2.jpg?1",
             "name": "Forge, Neverwinter Charlatan",
             "text": "",
             "colours": [
@@ -41076,7 +41076,7 @@
         },
         {
             "id": "820aefe1-1d39-53b1-a2b5-689515f96d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab07547-a6b8-487a-9688-8f93aaa71f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab07547-a6b8-487a-9688-8f93aaa71f5b.jpg?1",
             "name": "Holga, Relentless Rager",
             "text": "",
             "colours": [
@@ -41113,7 +41113,7 @@
         },
         {
             "id": "22c9ed5d-6030-5cec-afea-01cd68bac036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg?1",
             "name": "Doric, Nature's Warden // Doric, Owlbear Avenger",
             "text": "",
             "colours": [
@@ -41150,7 +41150,7 @@
         },
         {
             "id": "901b90d1-44db-5c82-a5ed-61976b3ab0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb348aec-ab4e-4940-9235-43f2ef581195.jpg?1",
             "name": "Doric, Nature's Warden // Doric, Owlbear Avenger",
             "text": "",
             "colours": [
@@ -41187,7 +41187,7 @@
         },
         {
             "id": "9d2e0398-91cd-5a5f-87de-ef2d1dcd45cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80c7702-3226-4ec6-bb75-26621a146a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c80c7702-3226-4ec6-bb75-26621a146a7e.jpg?1",
             "name": "Edgin, Larcenous Lutenist",
             "text": "",
             "colours": [
@@ -41226,7 +41226,7 @@
         },
         {
             "id": "433f1681-b1e0-5f05-9597-74312e3b1d19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99285945-0d97-4e29-9be2-2d2cfd9bac4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99285945-0d97-4e29-9be2-2d2cfd9bac4e.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "",
             "colours": [],
@@ -41259,7 +41259,7 @@
         },
         {
             "id": "3abf28aa-de3c-534b-b9b5-c4481969326f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655722c3-e361-48cb-95f8-d5627de56a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655722c3-e361-48cb-95f8-d5627de56a1b.jpg?1",
             "name": "Sorin, Imperious Bloodlord",
             "text": "",
             "colours": [
@@ -41294,7 +41294,7 @@
         },
         {
             "id": "7835cd29-9d71-580c-8803-9a1621f84a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbd6f05-bbd5-4491-a979-ffb3db1d6a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbd6f05-bbd5-4491-a979-ffb3db1d6a64.jpg?1",
             "name": "Sarkhan, Dragonsoul",
             "text": "",
             "colours": [
@@ -41329,7 +41329,7 @@
         },
         {
             "id": "39a2b2cf-26f4-55fe-be54-fc2c00e6b9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee1dee4-651a-4038-ba96-d265bd53c9a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eee1dee4-651a-4038-ba96-d265bd53c9a0.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "",
             "colours": [
@@ -41370,7 +41370,7 @@
         },
         {
             "id": "a35ada4f-67fc-50a3-a3f4-31e8ebd4e01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b8f805-9a02-4704-a5b6-6becdf030804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b8f805-9a02-4704-a5b6-6becdf030804.jpg?1",
             "name": "Braid of Fire",
             "text": "",
             "colours": [
@@ -41404,7 +41404,7 @@
         },
         {
             "id": "be86fcc2-f4c3-5489-82c1-7ab3b32d4baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74af08d9-76ef-48aa-86c5-b92ea6e10c9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74af08d9-76ef-48aa-86c5-b92ea6e10c9f.jpg?1",
             "name": "Koth of the Hammer",
             "text": "",
             "colours": [
@@ -41440,7 +41440,7 @@
         },
         {
             "id": "6058f8fa-1bcd-5957-896e-c95eaaa197f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4dcc14-0f3b-46b0-a37e-31d0c3e70732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4dcc14-0f3b-46b0-a37e-31d0c3e70732.jpg?1",
             "name": "Master of the Wild Hunt",
             "text": "",
             "colours": [
@@ -41475,7 +41475,7 @@
         },
         {
             "id": "2b6ef13f-7689-558a-98ec-03ce5591c2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c248ce-d101-4a26-a8ed-7f98b39b357e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c248ce-d101-4a26-a8ed-7f98b39b357e.jpg?1",
             "name": "Karrthus, Tyrant of Jund",
             "text": "",
             "colours": [
@@ -41515,7 +41515,7 @@
         },
         {
             "id": "f23df117-6437-513a-b78e-82261bd18b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4310db6-9757-469a-a20a-496331d6ff53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4310db6-9757-469a-a20a-496331d6ff53.jpg?1",
             "name": "Cleansing Nova",
             "text": "",
             "colours": [
@@ -41549,7 +41549,7 @@
         },
         {
             "id": "126bcfde-60c5-51f4-94cb-7d7b72dee61a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6748788-496c-42b4-9f68-e0bd5692b511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6748788-496c-42b4-9f68-e0bd5692b511.jpg?1",
             "name": "Serra the Benevolent",
             "text": "",
             "colours": [
@@ -41585,7 +41585,7 @@
         },
         {
             "id": "a5835d71-9605-56e6-99d5-1c366bbba6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb220c6c-8dda-45f4-87fa-f754e94fac42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb220c6c-8dda-45f4-87fa-f754e94fac42.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "",
             "colours": [
@@ -41620,7 +41620,7 @@
         },
         {
             "id": "10165410-d7d2-58db-be98-dc7dd46666d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c28fcb-09e8-4b58-bda2-339afb68fc9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3c28fcb-09e8-4b58-bda2-339afb68fc9a.jpg?1",
             "name": "Muddle the Mixture",
             "text": "",
             "colours": [
@@ -41652,7 +41652,7 @@
         },
         {
             "id": "89aa378c-89bc-5271-8fff-14f4192b9d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0420119f-a25b-44c7-b82f-51d05dfd94c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0420119f-a25b-44c7-b82f-51d05dfd94c5.jpg?1",
             "name": "Flamekin Harbinger",
             "text": "",
             "colours": [
@@ -41687,7 +41687,7 @@
         },
         {
             "id": "b5dbe80c-3b12-5697-9560-47e298fd37e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b75fc9-7045-4a87-b459-8d32f6c5402c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b75fc9-7045-4a87-b459-8d32f6c5402c.jpg?1",
             "name": "Omnath, Locus of Rage",
             "text": "",
             "colours": [
@@ -41725,7 +41725,7 @@
         },
         {
             "id": "828b903e-424b-5db4-9f45-51be3c4bf52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88f895-b5d6-47ea-a69c-eb4e5d65e401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88f895-b5d6-47ea-a69c-eb4e5d65e401.jpg?1",
             "name": "Risen Reef",
             "text": "",
             "colours": [
@@ -41761,7 +41761,7 @@
         },
         {
             "id": "fc36cbcc-d16a-596c-a8fc-18ee80844b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dacda4-ed81-4daf-8718-cc59bffd95fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1dacda4-ed81-4daf-8718-cc59bffd95fc.jpg?1",
             "name": "Voice of Resurgence",
             "text": "",
             "colours": [
@@ -41797,7 +41797,7 @@
         },
         {
             "id": "dcfa2844-4ada-5c5b-8f77-5b856f0e326f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ba709f-e9eb-4cf0-ab68-d1aa88eeaf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ba709f-e9eb-4cf0-ab68-d1aa88eeaf07.jpg?1",
             "name": "Wheel and Deal",
             "text": "",
             "colours": [
@@ -41828,7 +41828,7 @@
         },
         {
             "id": "adc38dff-855b-536e-b1a4-9cef5e947177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c717a-ede7-4f6d-b9a9-da6cf0fd3d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1c717a-ede7-4f6d-b9a9-da6cf0fd3d5d.jpg?1",
             "name": "Questing Beast",
             "text": "",
             "colours": [
@@ -41863,7 +41863,7 @@
         },
         {
             "id": "0a9586e5-d86b-58c1-9326-b4634a3e922e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c5b9d-71f2-45e4-a177-494c231c79fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9c5b9d-71f2-45e4-a177-494c231c79fd.jpg?1",
             "name": "Olivia Voldaren",
             "text": "",
             "colours": [
@@ -41900,7 +41900,7 @@
         },
         {
             "id": "e71364dd-0c57-5dbd-aa07-e754b0192884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a696f69-ba08-4b0b-86e9-37e3671674ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a696f69-ba08-4b0b-86e9-37e3671674ec.jpg?1",
             "name": "Walking Ballista",
             "text": "",
             "colours": [],
@@ -41932,7 +41932,7 @@
         },
         {
             "id": "1e59abcf-73a7-56eb-bbdc-31d69865ed91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb15155-9bd8-4062-aa81-de275748faf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb15155-9bd8-4062-aa81-de275748faf2.jpg?1",
             "name": "The World Tree",
             "text": "",
             "colours": [],
@@ -41965,7 +41965,7 @@
         },
         {
             "id": "8931ddae-f433-53fa-b33c-0ac92016e8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b17ebb8-23e1-4c76-9184-52faa49be274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b17ebb8-23e1-4c76-9184-52faa49be274.jpg?1",
             "name": "Higure, the Still Wind",
             "text": "",
             "colours": [
@@ -42001,7 +42001,7 @@
         },
         {
             "id": "a7467f24-dfbc-5e41-a8d3-cfe8d3c53137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346701fc-f2ca-44dc-8d58-19b40cf83a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/346701fc-f2ca-44dc-8d58-19b40cf83a8c.jpg?1",
             "name": "Nezahal, Primal Tide",
             "text": "",
             "colours": [
@@ -42037,7 +42037,7 @@
         },
         {
             "id": "bf0d143b-c89d-56d3-9305-0fb4a760f476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169b04a-d799-4693-999e-114dd085b378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e169b04a-d799-4693-999e-114dd085b378.jpg?1",
             "name": "Dragonlord Kolaghan",
             "text": "",
             "colours": [
@@ -42075,7 +42075,7 @@
         },
         {
             "id": "dd126808-a793-50ac-8a4d-2323a5995f43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a377b68-9d70-427a-8829-be370e3a0600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a377b68-9d70-427a-8829-be370e3a0600.jpg?1",
             "name": "Mina and Denn, Wildborn",
             "text": "",
             "colours": [
@@ -42113,7 +42113,7 @@
         },
         {
             "id": "59e52ccb-1ae4-5fbe-8603-5f9ef39ff8ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4772947-acf2-44ed-86da-48a623ce4f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4772947-acf2-44ed-86da-48a623ce4f97.jpg?1",
             "name": "Xantcha, Sleeper Agent",
             "text": "",
             "colours": [
@@ -42151,7 +42151,7 @@
         },
         {
             "id": "a6ce5a0b-4271-596b-9581-a6c3c25d9df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fe1eff-e475-4949-9914-c49cb15ec433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13fe1eff-e475-4949-9914-c49cb15ec433.jpg?1",
             "name": "Misdirection",
             "text": "",
             "colours": [
@@ -42182,7 +42182,7 @@
         },
         {
             "id": "81dda362-5f87-5b74-b4ee-ec0db97b38b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61243a31-6608-451f-9ba1-4f8ecc5aaad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61243a31-6608-451f-9ba1-4f8ecc5aaad1.jpg?1",
             "name": "Utvara Hellkite",
             "text": "",
             "colours": [
@@ -42215,7 +42215,7 @@
         },
         {
             "id": "c8f8fa2c-9316-5dcb-861b-f175cbca8b1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b05ce09-b752-46f0-b0a7-508838a41a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b05ce09-b752-46f0-b0a7-508838a41a94.jpg?1",
             "name": "Kogla, the Titan Ape",
             "text": "",
             "colours": [
@@ -42250,7 +42250,7 @@
         },
         {
             "id": "668fd789-ba3c-5e1b-90ae-41ce326a6f55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9929e-95bc-4d97-8579-d85c6f4e2dc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c9929e-95bc-4d97-8579-d85c6f4e2dc8.jpg?1",
             "name": "Nyxbloom Ancient",
             "text": "",
             "colours": [
@@ -42284,7 +42284,7 @@
         },
         {
             "id": "049fbac0-87a5-54ae-8f06-b4435ca0963b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c275f66-32dd-4f40-9b6e-f4423c8e7ec1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c275f66-32dd-4f40-9b6e-f4423c8e7ec1.jpg?1",
             "name": "Jhoira, Weatherlight Captain",
             "text": "",
             "colours": [
@@ -42322,7 +42322,7 @@
         },
         {
             "id": "a4b7a9ab-c2a6-5f28-b077-03da0913a0c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc29468-66bb-4136-a233-283004800d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc29468-66bb-4136-a233-283004800d35.jpg?1",
             "name": "Llawan, Cephalid Empress",
             "text": "",
             "colours": [
@@ -42359,7 +42359,7 @@
         },
         {
             "id": "df6ae14b-3f5d-5f64-bb03-dbd52d73cc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cca3f7c-f0b1-4a0e-a2b9-ffb4a00e2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cca3f7c-f0b1-4a0e-a2b9-ffb4a00e2ac6.jpg?1",
             "name": "Master of Waves",
             "text": "",
             "colours": [
@@ -42394,7 +42394,7 @@
         },
         {
             "id": "221b3159-1dce-5ff3-ba55-f5b77bcbbb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffb0ecd-1326-43d8-9a68-39bc238e5d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffb0ecd-1326-43d8-9a68-39bc238e5d3c.jpg?1",
             "name": "Thassa, Deep-Dwelling",
             "text": "",
             "colours": [
@@ -42431,7 +42431,7 @@
         },
         {
             "id": "dac06452-0759-5ca3-a664-b18ea347b2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9de4-0d31-431f-b060-69a33e9d9c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3b9de4-0d31-431f-b060-69a33e9d9c85.jpg?1",
             "name": "Thassa's Oracle",
             "text": "",
             "colours": [
@@ -42466,7 +42466,7 @@
         },
         {
             "id": "b1cc3020-4f53-5a05-817a-8008c8f48536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d71b38-c770-4d06-aa03-73d5e8381b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76d71b38-c770-4d06-aa03-73d5e8381b9d.jpg?1",
             "name": "Joraga Treespeaker",
             "text": "",
             "colours": [
@@ -42501,7 +42501,7 @@
         },
         {
             "id": "40c8c3f2-74db-5dda-a4c8-c57b3989a541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0bb4a-11e0-442f-b4fe-e54a16b52dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f0bb4a-11e0-442f-b4fe-e54a16b52dad.jpg?1",
             "name": "Nature's Will",
             "text": "",
             "colours": [
@@ -42533,7 +42533,7 @@
         },
         {
             "id": "a58d4fa0-ae35-5ec1-a0dd-0b9aad132b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf611cc-6a54-40bb-8fc3-b66d942254db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf611cc-6a54-40bb-8fc3-b66d942254db.jpg?1",
             "name": "Ulvenwald Tracker",
             "text": "",
             "colours": [
@@ -42568,7 +42568,7 @@
         },
         {
             "id": "2fe82a0b-b982-5812-8a07-a662c83b33d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c45f04-b844-4219-b7c5-5fd42edacc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13c45f04-b844-4219-b7c5-5fd42edacc78.jpg?1",
             "name": "Yeva, Nature's Herald",
             "text": "",
             "colours": [
@@ -42605,7 +42605,7 @@
         },
         {
             "id": "06b8620a-d829-57e0-aa2e-f84685b3ef65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120139f9-3dc5-482f-a70c-7c6a4f264c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/120139f9-3dc5-482f-a70c-7c6a4f264c19.jpg?1",
             "name": "Grand Abolisher",
             "text": "",
             "colours": [
@@ -42640,7 +42640,7 @@
         },
         {
             "id": "b60d482f-40a5-5297-9c4a-c9c9fbafb3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee658648-7bfc-4311-ba4a-395dec49f207.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee658648-7bfc-4311-ba4a-395dec49f207.jpg?1",
             "name": "Selfless Savior",
             "text": "",
             "colours": [
@@ -42676,7 +42676,7 @@
         },
         {
             "id": "72694983-2e64-5d0d-babd-a5fe4e5f7643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635ca686-c04e-47df-b1b5-687bb7c69d4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/635ca686-c04e-47df-b1b5-687bb7c69d4c.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "",
             "colours": [
@@ -42712,7 +42712,7 @@
         },
         {
             "id": "b3755d49-6c88-5d53-af96-94c627dcf454",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94756cbe-022d-4fdf-a3b8-ad368174c90d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94756cbe-022d-4fdf-a3b8-ad368174c90d.jpg?1",
             "name": "Umezawa's Jitte",
             "text": "",
             "colours": [],
@@ -42744,7 +42744,7 @@
         },
         {
             "id": "55626bac-10f6-5c99-884b-942bf1a107ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8cf4ef-0545-4876-b089-bfc723b521ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8cf4ef-0545-4876-b089-bfc723b521ed.jpg?1",
             "name": "Linvala, Keeper of Silence",
             "text": "",
             "colours": [
@@ -42780,7 +42780,7 @@
         },
         {
             "id": "ccc989e1-6378-57db-ac93-282af03dcac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99aad0c2-1df3-4043-8aba-e9cbb9bd5c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99aad0c2-1df3-4043-8aba-e9cbb9bd5c85.jpg?1",
             "name": "Sunblast Angel",
             "text": "",
             "colours": [
@@ -42814,7 +42814,7 @@
         },
         {
             "id": "8622475a-a29a-5a79-9afe-e9b50b25c486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ecba0-a9dd-4adf-ad9d-0c068bf526fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720ecba0-a9dd-4adf-ad9d-0c068bf526fa.jpg?1",
             "name": "Emeria, the Sky Ruin",
             "text": "",
             "colours": [],
@@ -42844,7 +42844,7 @@
         },
         {
             "id": "2df0d23e-f7a6-5c81-9008-66688c69152d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec09c30-b1bb-4380-9c4a-f57c25c67a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec09c30-b1bb-4380-9c4a-f57c25c67a2e.jpg?1",
             "name": "Seraph Sanctuary",
             "text": "",
             "colours": [],
@@ -42875,7 +42875,7 @@
         },
         {
             "id": "e1257085-e57c-5529-9ff4-f8c6555c2fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4eccc6-26a3-48d3-bb15-522ba51327e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d4eccc6-26a3-48d3-bb15-522ba51327e0.jpg?1",
             "name": "Slip On the Ring",
             "text": "",
             "colours": [
@@ -42907,7 +42907,7 @@
         },
         {
             "id": "2f52013b-f080-5ae6-accc-e54c5dc85456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745f592-8d4d-46f4-b631-c014da1ab3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d745f592-8d4d-46f4-b631-c014da1ab3a9.jpg?1",
             "name": "Gandalf, Friend of the Shire",
             "text": "",
             "colours": [
@@ -42944,7 +42944,7 @@
         },
         {
             "id": "9b4d30d9-b1b0-56ac-a209-f1c94e3e5d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d04970-12c7-460f-a7bc-beb97b161246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d04970-12c7-460f-a7bc-beb97b161246.jpg?1",
             "name": "Mirror of Galadriel",
             "text": "",
             "colours": [],
@@ -42974,7 +42974,7 @@
         },
         {
             "id": "62099e8e-5c0c-5732-8d60-473ff26429a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233144a-9e88-44a2-9ea9-88ecc116bcd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5233144a-9e88-44a2-9ea9-88ecc116bcd6.jpg?1",
             "name": "Shire Terrace",
             "text": "",
             "colours": [],
@@ -43002,7 +43002,7 @@
         },
         {
             "id": "c887befb-934a-50d6-b540-7350b0b4742a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b49030-55fe-4bf4-a2b9-c78f36e2d425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b49030-55fe-4bf4-a2b9-c78f36e2d425.jpg?1",
             "name": "Syr Konrad, the Grim",
             "text": "",
             "colours": [
@@ -43039,7 +43039,7 @@
         },
         {
             "id": "3da47f93-fdea-5a18-b906-e2a8b05b9b2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549b913-556a-4aeb-899e-438ff6874f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549b913-556a-4aeb-899e-438ff6874f56.jpg?1",
             "name": "Underworld Dreams",
             "text": "",
             "colours": [
@@ -43071,7 +43071,7 @@
         },
         {
             "id": "0203c3ad-ae84-5d3f-a8f3-64a9a669dcd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fc8e83-471a-4d75-9703-d8f3998a705a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fc8e83-471a-4d75-9703-d8f3998a705a.jpg?1",
             "name": "Waste Not",
             "text": "",
             "colours": [
@@ -43103,7 +43103,7 @@
         },
         {
             "id": "6bdfd75a-23dc-599b-a5c5-f86973f8ddfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9d0f64-2bc2-42da-a2f3-f56235c2bf54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff9d0f64-2bc2-42da-a2f3-f56235c2bf54.jpg?1",
             "name": "Wheel of Misfortune",
             "text": "",
             "colours": [
@@ -43135,7 +43135,7 @@
         },
         {
             "id": "027d8827-486b-5074-9a8e-016ec0ca5df6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e1b0f-c2e5-4b75-817d-19ab5f734139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e1b0f-c2e5-4b75-817d-19ab5f734139.jpg?1",
             "name": "Nekusar, the Mindrazer",
             "text": "",
             "colours": [
@@ -43176,7 +43176,7 @@
         },
         {
             "id": "6ee65967-e6f7-5d01-9d9a-7bfa488a5816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26affcc7-e64a-4dc0-8f01-432288161f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26affcc7-e64a-4dc0-8f01-432288161f9d.jpg?1",
             "name": "Nemesis of Reason",
             "text": "",
             "colours": [
@@ -43213,7 +43213,7 @@
         },
         {
             "id": "288c58fb-65b8-5305-9e9c-3a19e6d80930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df786-c2ed-49c5-a5f2-73f5daf34ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16df786-c2ed-49c5-a5f2-73f5daf34ca9.jpg?1",
             "name": "Gaea's Blessing",
             "text": "",
             "colours": [
@@ -43247,7 +43247,7 @@
         },
         {
             "id": "88868471-2fb5-5def-976c-c230de6ecdcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ec13cf-e164-4222-90b1-af3e92e03b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ec13cf-e164-4222-90b1-af3e92e03b2e.jpg?1",
             "name": "Twilight Prophet",
             "text": "",
             "colours": [
@@ -43282,7 +43282,7 @@
         },
         {
             "id": "7d7676dc-d04f-5426-a3ce-738ec4522010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada90827-f11b-495b-8962-66dd6345b454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada90827-f11b-495b-8962-66dd6345b454.jpg?1",
             "name": "Worldspine Wurm",
             "text": "",
             "colours": [
@@ -43316,7 +43316,7 @@
         },
         {
             "id": "dcebbfa7-cad3-5211-bf52-b310c26dc404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd79f1-88dd-40a0-b348-6eb6757e3b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16cd79f1-88dd-40a0-b348-6eb6757e3b13.jpg?1",
             "name": "Goblin Lackey",
             "text": "",
             "colours": [
@@ -43352,7 +43352,7 @@
         },
         {
             "id": "db868ae3-197c-5aac-8ff6-ace16ba81fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8b2dd7-fabd-4b2a-a9e7-5a02bba89e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a8b2dd7-fabd-4b2a-a9e7-5a02bba89e10.jpg?1",
             "name": "Goblin Lackey",
             "text": "",
             "colours": [
@@ -43388,7 +43388,7 @@
         },
         {
             "id": "c694a639-b62a-5ea2-8e2f-2cbb649b3fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f56067-4b86-4788-8fd7-648c9041dbd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f56067-4b86-4788-8fd7-648c9041dbd4.jpg?1",
             "name": "Goblin Matron",
             "text": "",
             "colours": [
@@ -43423,7 +43423,7 @@
         },
         {
             "id": "ea633847-dd70-565a-bad1-dd778d9b8797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a040d62-d9eb-42a1-ac22-690d497d4de8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a040d62-d9eb-42a1-ac22-690d497d4de8.jpg?1",
             "name": "Goblin Matron",
             "text": "",
             "colours": [
@@ -43458,7 +43458,7 @@
         },
         {
             "id": "a17db5f1-6299-58f6-a7e4-d42d9d0565de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb3b4c-ac12-406c-8517-9fccefdd1544.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6efb3b4c-ac12-406c-8517-9fccefdd1544.jpg?1",
             "name": "Goblin Recruiter",
             "text": "",
             "colours": [
@@ -43493,7 +43493,7 @@
         },
         {
             "id": "bdb98213-fa96-53dc-a3ec-8fbd09f2aaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df52e94a-9836-4afd-b7cc-fd77cdd31eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df52e94a-9836-4afd-b7cc-fd77cdd31eb2.jpg?1",
             "name": "Goblin Recruiter",
             "text": "",
             "colours": [
@@ -43528,7 +43528,7 @@
         },
         {
             "id": "32367441-7d9e-535f-a19f-ce66eb89b6a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f8035b-c776-4213-a5e2-e6c7c3f5961f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f8035b-c776-4213-a5e2-e6c7c3f5961f.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "",
             "colours": [
@@ -43566,7 +43566,7 @@
         },
         {
             "id": "7dd7272f-13a9-51d4-9e25-d035747e0508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea8f92fb-9ecc-4a41-aabc-7261acb4e8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea8f92fb-9ecc-4a41-aabc-7261acb4e8fc.jpg?1",
             "name": "Muxus, Goblin Grandee",
             "text": "",
             "colours": [
@@ -43604,7 +43604,7 @@
         },
         {
             "id": "f32e01cc-5930-5319-a6c0-72628a1f571a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f909489-4567-4886-9191-05119b338cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f909489-4567-4886-9191-05119b338cfd.jpg?1",
             "name": "Shattergang Brothers",
             "text": "",
             "colours": [
@@ -43646,7 +43646,7 @@
         },
         {
             "id": "61158e3c-73ed-5fdc-80b4-67ce53f7d249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e84d2-2685-4b41-a06b-9d54e9d3d725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517e84d2-2685-4b41-a06b-9d54e9d3d725.jpg?1",
             "name": "Shattergang Brothers",
             "text": "",
             "colours": [
@@ -43688,7 +43688,7 @@
         },
         {
             "id": "0606aa2b-a7f4-5c38-987f-59b61cdc2bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ab62b-7f22-49e4-b8af-9062eb782ef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53ab62b-7f22-49e4-b8af-9062eb782ef7.jpg?1",
             "name": "Nirkana Revenant",
             "text": "",
             "colours": [
@@ -43723,7 +43723,7 @@
         },
         {
             "id": "af056c7c-c2bd-54cb-a9f3-75f654406d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bce60-78f6-4f42-9fcd-383f66f85de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d81bce60-78f6-4f42-9fcd-383f66f85de5.jpg?1",
             "name": "Arbor Elf",
             "text": "",
             "colours": [
@@ -43758,7 +43758,7 @@
         },
         {
             "id": "7dba9454-ff2d-590e-ac38-5a074b417531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48783dc1-0976-4955-b7e3-afa311160d68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48783dc1-0976-4955-b7e3-afa311160d68.jpg?1",
             "name": "Terastodon",
             "text": "",
             "colours": [
@@ -43792,7 +43792,7 @@
         },
         {
             "id": "aa2f837a-a703-5890-92a9-3293c31a1183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c835f-2a60-46bb-9046-106ce8fba676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76c835f-2a60-46bb-9046-106ce8fba676.jpg?1",
             "name": "Maelstrom Wanderer",
             "text": "",
             "colours": [
@@ -43832,7 +43832,7 @@
         },
         {
             "id": "5cea7287-022e-54b9-8b97-4b21260fa210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574057d5-d4a3-4d51-9f53-830d533426b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574057d5-d4a3-4d51-9f53-830d533426b2.jpg?1",
             "name": "Gargos, Vicious Watcher",
             "text": "",
             "colours": [
@@ -43867,7 +43867,7 @@
         },
         {
             "id": "4fb3c1b9-19b8-5645-831d-00b0da5cc474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe14302-26be-4e65-8863-d711d33454cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe14302-26be-4e65-8863-d711d33454cd.jpg?1",
             "name": "Primordial Hydra",
             "text": "",
             "colours": [
@@ -43900,7 +43900,7 @@
         },
         {
             "id": "7053c058-ff2b-5425-95e7-62ad6f75119f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e8a326-4438-45f5-8695-a9d85a2858fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e8a326-4438-45f5-8695-a9d85a2858fe.jpg?1",
             "name": "Unbound Flourishing",
             "text": "",
             "colours": [
@@ -43931,7 +43931,7 @@
         },
         {
             "id": "7dbee963-22b1-5475-89e7-87d1d842dc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab115f5d-e182-4d78-bbe9-327e5b612f39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab115f5d-e182-4d78-bbe9-327e5b612f39.jpg?1",
             "name": "Hydroid Krasis",
             "text": "",
             "colours": [
@@ -43968,7 +43968,7 @@
         },
         {
             "id": "71b71daf-9419-5b4e-a594-54349765570e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44043b50-9837-40d2-ad08-d515faed216c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44043b50-9837-40d2-ad08-d515faed216c.jpg?1",
             "name": "Zaxara, the Exemplary",
             "text": "",
             "colours": [
@@ -44008,7 +44008,7 @@
         },
         {
             "id": "014e335e-840a-57ad-ba6a-d570ee41e93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc318-9c3e-471f-90eb-dc76454da957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cfc318-9c3e-471f-90eb-dc76454da957.jpg?1",
             "name": "Gisela, the Broken Blade // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -44046,7 +44046,7 @@
         },
         {
             "id": "ebd91441-1663-50c8-b5ca-23d7f5d062e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a0347e-8ec6-463e-aef5-33f7d62899e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a0347e-8ec6-463e-aef5-33f7d62899e2.jpg?1",
             "name": "Bruna, the Fading Light // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -44084,7 +44084,7 @@
         },
         {
             "id": "c1f975cc-cb83-5d58-86d3-ff70a4fe3900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd83c0e-8e37-40bf-87a5-5b4c009248fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd83c0e-8e37-40bf-87a5-5b4c009248fb.jpg?1",
             "name": "Brisela, Voice of Nightmares",
             "text": "",
             "colours": [],
@@ -44120,7 +44120,7 @@
         },
         {
             "id": "767e6c07-6a10-5405-addb-b42225229a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929b98-e81c-48b9-87d8-11c8830974ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929b98-e81c-48b9-87d8-11c8830974ce.jpg?1",
             "name": "Archangel of Thune",
             "text": "",
             "colours": [
@@ -44153,7 +44153,7 @@
         },
         {
             "id": "7de26f64-6e5f-5ff0-ab10-901dfec3eb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098d5b-0cdb-422f-8bd2-7afd81a7b7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc098d5b-0cdb-422f-8bd2-7afd81a7b7c3.jpg?1",
             "name": "Court of Grace",
             "text": "",
             "colours": [
@@ -44184,7 +44184,7 @@
         },
         {
             "id": "688bf216-ebe2-5383-b800-51ed39998c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a14f93-6896-4b8e-a0b2-e081dfea5958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a14f93-6896-4b8e-a0b2-e081dfea5958.jpg?1",
             "name": "Commander's Plate",
             "text": "",
             "colours": [],
@@ -44215,7 +44215,7 @@
         },
         {
             "id": "7410a574-586c-5234-86e3-2e1073516c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634950f2-3149-41b5-a93d-81f9f1957801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634950f2-3149-41b5-a93d-81f9f1957801.jpg?1",
             "name": "Angel of Finality",
             "text": "",
             "colours": [
@@ -44248,7 +44248,7 @@
         },
         {
             "id": "de38eca4-0829-5e71-b79a-14b64339f928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc1e38-a44e-4127-946e-eac0c8db2b2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87fc1e38-a44e-4127-946e-eac0c8db2b2f.jpg?1",
             "name": "Angel of the Ruins",
             "text": "",
             "colours": [
@@ -44284,7 +44284,7 @@
         },
         {
             "id": "042a355f-2fbe-5952-9ac2-0c9f0b6b4d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb42fb7-1ac5-4923-bec8-2aa2d4dbefd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb42fb7-1ac5-4923-bec8-2aa2d4dbefd5.jpg?1",
             "name": "Arden Angel",
             "text": "",
             "colours": [
@@ -44317,7 +44317,7 @@
         },
         {
             "id": "0fa8b187-cdb5-541e-a6ae-e1ea31fc99f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270c252d-1248-450b-bbc3-3af475a94834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270c252d-1248-450b-bbc3-3af475a94834.jpg?1",
             "name": "Breathkeeper Seraph",
             "text": "",
             "colours": [
@@ -44350,7 +44350,7 @@
         },
         {
             "id": "8f36161e-44be-5d48-b0f1-fc2cba2167a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c48a5-c80f-43e6-ab4e-fa7bd7b5c3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9c48a5-c80f-43e6-ab4e-fa7bd7b5c3a0.jpg?1",
             "name": "Dawnbreak Reclaimer",
             "text": "",
             "colours": [
@@ -44383,7 +44383,7 @@
         },
         {
             "id": "d4ea6152-ecf8-5e78-a4e7-bb983ffa1898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79ecdf5-2167-4590-a964-e9d7eb32dfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79ecdf5-2167-4590-a964-e9d7eb32dfe6.jpg?1",
             "name": "Valkyrie Harbinger",
             "text": "",
             "colours": [
@@ -44417,7 +44417,7 @@
         },
         {
             "id": "ebf52f9c-bd76-5b4d-a46b-ff175a7fc62a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5173aa-1eca-46ae-81ea-0b1dfe5e12de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5173aa-1eca-46ae-81ea-0b1dfe5e12de.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44485,7 +44485,7 @@
         },
         {
             "id": "f3600030-e743-5089-87d6-5c56c5fbf564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77924e4-0f15-48a3-b494-89b544ee9d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77924e4-0f15-48a3-b494-89b544ee9d37.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44553,7 +44553,7 @@
         },
         {
             "id": "e7ee8833-ff69-5335-9da3-58133e6c73f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9deeda0b-81f7-484d-a99d-0e7d2449d157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9deeda0b-81f7-484d-a99d-0e7d2449d157.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44621,7 +44621,7 @@
         },
         {
             "id": "ea5d01c0-c28e-5ac6-a742-23c3fd12e944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63607a09-b00c-4c0e-b8ad-d1bb5a45517b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63607a09-b00c-4c0e-b8ad-d1bb5a45517b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44689,7 +44689,7 @@
         },
         {
             "id": "9a254b50-9412-5661-9ad3-2154e6fbdc1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890e6cd-f5af-4651-a55a-8526617152bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5890e6cd-f5af-4651-a55a-8526617152bb.jpg?1",
             "name": "Puresteel Paladin",
             "text": "",
             "colours": [
@@ -44724,7 +44724,7 @@
         },
         {
             "id": "a4beb479-16f3-50da-ad29-fc3d302c1245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1215c98-e372-4261-b3bf-8b64ac0fb470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1215c98-e372-4261-b3bf-8b64ac0fb470.jpg?1",
             "name": "Vanquish the Horde",
             "text": "",
             "colours": [
@@ -44756,7 +44756,7 @@
         },
         {
             "id": "c5379ecb-8ef1-5810-a496-6288162d0aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d19ea1f-8b39-4a7d-8aaa-e87fc09b15f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d19ea1f-8b39-4a7d-8aaa-e87fc09b15f2.jpg?1",
             "name": "Zombie Apocalypse",
             "text": "",
             "colours": [
@@ -44788,7 +44788,7 @@
         },
         {
             "id": "5665e1a5-73a0-59e0-93c8-1af0cd1d5c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e72a97-4739-41ca-8e79-1978a7baf54d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e72a97-4739-41ca-8e79-1978a7baf54d.jpg?1",
             "name": "Varina, Lich Queen",
             "text": "",
             "colours": [
@@ -44829,7 +44829,7 @@
         },
         {
             "id": "fab0d7b9-51c2-549a-8ec4-4777b6695155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7acd81-1fcb-4758-95f4-e64cb696c9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7acd81-1fcb-4758-95f4-e64cb696c9d2.jpg?1",
             "name": "Field of the Dead",
             "text": "",
             "colours": [],
@@ -44857,7 +44857,7 @@
         },
         {
             "id": "97e85c59-007c-54a9-826a-d309e987735c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b373adfa-ebc2-4060-8ff3-d1f0eca03c02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b373adfa-ebc2-4060-8ff3-d1f0eca03c02.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -44931,7 +44931,7 @@
         },
         {
             "id": "a2b373b5-657d-5aa1-bb71-66f2a2982221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f6a52-67d6-4215-9f3f-3b0a17dd8889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e16f6a52-67d6-4215-9f3f-3b0a17dd8889.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45005,7 +45005,7 @@
         },
         {
             "id": "9017486f-97e9-5024-a034-0ad2b2086b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34410953-113a-45ae-89d4-2ce39f75c3c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34410953-113a-45ae-89d4-2ce39f75c3c6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45079,7 +45079,7 @@
         },
         {
             "id": "dcc5ea4c-a271-5af9-8539-e870e27c6dad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6651e0fd-50ca-449e-84f1-ebb07fb305f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6651e0fd-50ca-449e-84f1-ebb07fb305f5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45153,7 +45153,7 @@
         },
         {
             "id": "eb6efaa6-283c-5376-ab35-f3d8c706bd18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54278194-fc8b-4208-a3ca-e655fddca2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54278194-fc8b-4208-a3ca-e655fddca2df.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45227,7 +45227,7 @@
         },
         {
             "id": "7fd3c247-a13d-59e9-a8ad-2516cfcaee51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0627111-1390-43cb-84e7-d6c0e46c02ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0627111-1390-43cb-84e7-d6c0e46c02ea.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45301,7 +45301,7 @@
         },
         {
             "id": "ea7c578e-040e-5225-af30-012f48b5868a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd0396-2e7b-4b87-9504-953bd35e4fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbd0396-2e7b-4b87-9504-953bd35e4fea.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45375,7 +45375,7 @@
         },
         {
             "id": "96add785-f216-554e-84c8-62fd745de237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b150a6d-a33d-456a-a2b0-286e43bc636e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b150a6d-a33d-456a-a2b0-286e43bc636e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45449,7 +45449,7 @@
         },
         {
             "id": "a8467d6d-6213-5267-89a2-8e447f60fc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88d76e-d71f-43ea-a272-5dc8b5928c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba88d76e-d71f-43ea-a272-5dc8b5928c6b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45523,7 +45523,7 @@
         },
         {
             "id": "17305186-a617-570c-ae7a-a036158d3e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad38f6-ca2a-41a4-96cf-f41a41d54a37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46ad38f6-ca2a-41a4-96cf-f41a41d54a37.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -45597,7 +45597,7 @@
         },
         {
             "id": "f4761df1-1fc4-58ef-b9a5-a859453820de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374cd0e-d06a-4976-9483-202015c845ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374cd0e-d06a-4976-9483-202015c845ff.jpg?1",
             "name": "Rewind",
             "text": "",
             "colours": [
@@ -45631,7 +45631,7 @@
         },
         {
             "id": "82068a26-40b3-56df-83e8-de728bf54e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df323b67-e5f9-4958-90de-1af722c482dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df323b67-e5f9-4958-90de-1af722c482dd.jpg?1",
             "name": "Food Chain",
             "text": "",
             "colours": [
@@ -45663,7 +45663,7 @@
         },
         {
             "id": "bf146a81-aa15-573d-aaba-6058f263d6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5558bc8-31b8-4a83-8bd2-362f4e7be69d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5558bc8-31b8-4a83-8bd2-362f4e7be69d.jpg?1",
             "name": "Rampant Growth",
             "text": "",
             "colours": [
@@ -45695,7 +45695,7 @@
         },
         {
             "id": "82e731a4-4bdf-51d3-86dc-f05e3923ce07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecdb244-aeb5-42ef-b1ce-e586580c6b6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ecdb244-aeb5-42ef-b1ce-e586580c6b6c.jpg?1",
             "name": "The First Sliver",
             "text": "",
             "colours": [
@@ -45739,7 +45739,7 @@
         },
         {
             "id": "ba39c6b9-50d2-598d-92d9-374642538925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23146653-3573-4582-ae28-9764cd99f1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23146653-3573-4582-ae28-9764cd99f1d6.jpg?1",
             "name": "Concealed Courtyard",
             "text": "",
             "colours": [],
@@ -45770,7 +45770,7 @@
         },
         {
             "id": "658ee528-986f-5133-9e35-3a0fa9a29b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd8310d-6a91-46f6-aa85-f73ea37a66a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdd8310d-6a91-46f6-aa85-f73ea37a66a2.jpg?1",
             "name": "Spirebluff Canal",
             "text": "",
             "colours": [],
@@ -45801,7 +45801,7 @@
         },
         {
             "id": "acce8a6b-88c4-5088-9e6f-e526d4e6d6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056f1559-cca9-4aae-810b-a7db56c214e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056f1559-cca9-4aae-810b-a7db56c214e9.jpg?1",
             "name": "Blooming Marsh",
             "text": "",
             "colours": [],
@@ -45832,7 +45832,7 @@
         },
         {
             "id": "a7925fb7-384b-54c9-a0fe-fa5e0e9af2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b1139d-e87c-415d-be20-d4d31480ebdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00b1139d-e87c-415d-be20-d4d31480ebdc.jpg?1",
             "name": "Inspiring Vantage",
             "text": "",
             "colours": [],
@@ -45866,7 +45866,7 @@
         },
         {
             "id": "52da59be-f508-5ae3-99d2-f6f262a57a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c257d-ad28-4029-bb45-324bf262d1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/416c257d-ad28-4029-bb45-324bf262d1e5.jpg?1",
             "name": "Botanical Sanctum",
             "text": "",
             "colours": [],
@@ -45897,7 +45897,7 @@
         },
         {
             "id": "a749d964-de6e-5ec3-b37c-214ab92dbe16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17c9df-7d78-4228-a4ca-2f39b69f2ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd17c9df-7d78-4228-a4ca-2f39b69f2ace.jpg?1",
             "name": "Angel of Serenity",
             "text": "",
             "colours": [
@@ -45931,7 +45931,7 @@
         },
         {
             "id": "771b2378-d55b-59a9-a041-0818f8226b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e33e540-538c-4c39-9f52-df26bdcac3fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e33e540-538c-4c39-9f52-df26bdcac3fc.jpg?1",
             "name": "Angel of the Ruins",
             "text": "",
             "colours": [
@@ -45968,7 +45968,7 @@
         },
         {
             "id": "12fd738b-04fd-5ff0-aefc-079a6502af0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8599310-6b83-46a8-a38b-c48775d9c92f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8599310-6b83-46a8-a38b-c48775d9c92f.jpg?1",
             "name": "Blinding Angel",
             "text": "",
             "colours": [
@@ -46002,7 +46002,7 @@
         },
         {
             "id": "954777cc-b498-5805-a677-2ba1ac2969d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb225a1-d005-4e4d-98b2-7ebe2e9141df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cb225a1-d005-4e4d-98b2-7ebe2e9141df.jpg?1",
             "name": "Restoration Angel",
             "text": "",
             "colours": [
@@ -46036,7 +46036,7 @@
         },
         {
             "id": "449927bc-a041-5a8b-b3b3-d9fff6df2d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac93d2-80dd-4e2a-93b6-3e85526c7372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ac93d2-80dd-4e2a-93b6-3e85526c7372.jpg?1",
             "name": "Sublime Archangel",
             "text": "",
             "colours": [
@@ -46070,7 +46070,7 @@
         },
         {
             "id": "a329f6ce-91f3-504a-b613-a43e65f9a6ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7147b73-a7fa-4ecf-b9a1-a3f4851a5bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7147b73-a7fa-4ecf-b9a1-a3f4851a5bef.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -46139,7 +46139,7 @@
         },
         {
             "id": "ce2ceb5e-6273-52b9-afc1-585e926feab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca2b9b7-9c12-488d-8f8b-540249d0d350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca2b9b7-9c12-488d-8f8b-540249d0d350.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -46204,7 +46204,7 @@
         },
         {
             "id": "02be70bb-528b-5500-80fc-4d4307f2ba65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387ec72f-dd6b-4769-be3a-981d580715be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/387ec72f-dd6b-4769-be3a-981d580715be.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -46268,7 +46268,7 @@
         },
         {
             "id": "c8efff9c-3d4a-596c-8936-9ed3f79f8fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70099566-ba66-4d66-aafa-8232aa664a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70099566-ba66-4d66-aafa-8232aa664a6d.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -46342,7 +46342,7 @@
         },
         {
             "id": "beb211b4-e110-5c3e-bcf3-6cc9c60d5d11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56afe767-c967-4094-8d60-165bc7d11ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56afe767-c967-4094-8d60-165bc7d11ab1.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -46407,7 +46407,7 @@
         },
         {
             "id": "223a202f-83e5-57cd-9212-0297790a36ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128e73b3-19a0-4740-b32b-5882d3937a79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/128e73b3-19a0-4740-b32b-5882d3937a79.jpg?1",
             "name": "Gisela, the Broken Blade // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -46445,7 +46445,7 @@
         },
         {
             "id": "4e72e006-c6cf-5c36-b5a3-59ead838241b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2e842-d953-4e97-b95a-2b1af51173a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd2e842-d953-4e97-b95a-2b1af51173a9.jpg?1",
             "name": "Bruna, the Fading Light // Brisela, Voice of Nightmares",
             "text": "",
             "colours": [
@@ -46483,7 +46483,7 @@
         },
         {
             "id": "8fa74b32-ad1f-5d2b-98f1-b252c4ec3fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcd6747-f763-4e74-bb24-e93afe23cb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcd6747-f763-4e74-bb24-e93afe23cb32.jpg?1",
             "name": "Brisela, Voice of Nightmares",
             "text": "",
             "colours": [],
@@ -46519,7 +46519,7 @@
         },
         {
             "id": "4a3e102a-c030-5ee6-9b9e-dea76e298983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ed5f8-8bfa-483c-beeb-b4a7e7affd65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ed5f8-8bfa-483c-beeb-b4a7e7affd65.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -46557,7 +46557,7 @@
         },
         {
             "id": "77e4fce8-4b12-5617-b10c-a450768ab0b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37614b03-332b-4aa9-8a9a-340b552c7c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37614b03-332b-4aa9-8a9a-340b552c7c12.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "",
             "colours": [
@@ -46595,7 +46595,7 @@
         },
         {
             "id": "9e059267-0a7f-57b1-8e7f-70c966eecd17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201a805-9d9c-4433-8a32-0edac93db271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a201a805-9d9c-4433-8a32-0edac93db271.jpg?1",
             "name": "Rampaging Ferocidon",
             "text": "",
             "colours": [
@@ -46630,7 +46630,7 @@
         },
         {
             "id": "86bf5a75-aa0e-506e-96e9-c1e3a7136690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed9782f-6789-41b6-a04e-03d8f0e8d5cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed9782f-6789-41b6-a04e-03d8f0e8d5cf.jpg?1",
             "name": "Rampaging Ferocidon",
             "text": "",
             "colours": [
@@ -46665,7 +46665,7 @@
         },
         {
             "id": "78a6e140-24ce-5e28-ad97-1248ae4c8c4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8973d1-171b-4d30-abab-9b8e9ace8912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8973d1-171b-4d30-abab-9b8e9ace8912.jpg?1",
             "name": "Polyraptor",
             "text": "",
             "colours": [
@@ -46700,7 +46700,7 @@
         },
         {
             "id": "51dc65ea-c2da-5a11-b279-4461b2fb542c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366303b8-13ce-4f9f-a0db-3b2eff0c1e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366303b8-13ce-4f9f-a0db-3b2eff0c1e8a.jpg?1",
             "name": "Polyraptor",
             "text": "",
             "colours": [
@@ -46735,7 +46735,7 @@
         },
         {
             "id": "0089833b-2bd9-596c-a752-518387022b95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccfc3b7-235c-4680-aabf-4cb2e8d9a2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccfc3b7-235c-4680-aabf-4cb2e8d9a2fe.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "",
             "colours": [
@@ -46770,7 +46770,7 @@
         },
         {
             "id": "082647e2-79d8-5c12-adce-1c430df4a6e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076c5abd-6ae5-4c59-b1f4-f18eeb9159d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076c5abd-6ae5-4c59-b1f4-f18eeb9159d9.jpg?1",
             "name": "Wayward Swordtooth",
             "text": "",
             "colours": [
@@ -46805,7 +46805,7 @@
         },
         {
             "id": "45c2f14c-fcab-5653-894f-a0eb7010c1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a51e82-cbfc-4487-9a81-6e793e93f545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a51e82-cbfc-4487-9a81-6e793e93f545.jpg?1",
             "name": "Regisaur Alpha",
             "text": "",
             "colours": [
@@ -46842,7 +46842,7 @@
         },
         {
             "id": "c8ffadea-f14f-557a-879f-7c767d5a700a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22585cf-f84e-4c3d-a219-bd493d1122b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d22585cf-f84e-4c3d-a219-bd493d1122b3.jpg?1",
             "name": "Regisaur Alpha",
             "text": "",
             "colours": [
@@ -46879,7 +46879,7 @@
         },
         {
             "id": "c0b36e3a-f74a-5547-b012-fbee743fe970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e13cf-4cb4-41f3-88e0-6836a16e905b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e13cf-4cb4-41f3-88e0-6836a16e905b.jpg?1",
             "name": "Laboratory Maniac",
             "text": "",
             "colours": [
@@ -46916,7 +46916,7 @@
         },
         {
             "id": "2cf7af0a-7112-5fcb-8656-9eeda9da02a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1c7054-d6a7-4962-804d-c470bb8e39d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e1c7054-d6a7-4962-804d-c470bb8e39d3.jpg?1",
             "name": "Laboratory Maniac",
             "text": "",
             "colours": [
@@ -46953,7 +46953,7 @@
         },
         {
             "id": "6685fffd-056b-5fc6-9af4-16e68e332a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209bac6-fc0c-4a05-a459-7f0951a918e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7209bac6-fc0c-4a05-a459-7f0951a918e8.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "",
             "colours": [
@@ -46986,7 +46986,7 @@
         },
         {
             "id": "55731677-e7d5-5f04-a8a4-cef10b66b48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45543f2b-abf9-42eb-88d6-6a6a104ee632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45543f2b-abf9-42eb-88d6-6a6a104ee632.jpg?1",
             "name": "Tasha's Hideous Laughter",
             "text": "",
             "colours": [
@@ -47019,7 +47019,7 @@
         },
         {
             "id": "b006aa26-f3ff-5f9d-beb0-140018c5c274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1683cb7f-9623-4ab8-8f88-f8255dac352c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1683cb7f-9623-4ab8-8f88-f8255dac352c.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "",
             "colours": [
@@ -47059,7 +47059,7 @@
         },
         {
             "id": "4995b264-f00b-565e-8029-6b8b37c861fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf11f3-2755-4f0a-bdb7-bb68ac498e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf11f3-2755-4f0a-bdb7-bb68ac498e41.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "",
             "colours": [
@@ -47099,7 +47099,7 @@
         },
         {
             "id": "574cef2c-b466-5b2e-b314-2fc4e2a44214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c872b04-e80d-4c02-ac26-8f5cbb82e99f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c872b04-e80d-4c02-ac26-8f5cbb82e99f.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "",
             "colours": [
@@ -47141,7 +47141,7 @@
         },
         {
             "id": "8e901343-551e-5eab-a015-ccdbd5c80f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2559933-958b-4dfd-a037-3778b914f319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2559933-958b-4dfd-a037-3778b914f319.jpg?1",
             "name": "Atla Palani, Nest Tender",
             "text": "",
             "colours": [
@@ -47183,7 +47183,7 @@
         },
         {
             "id": "35b5dc5a-eb6d-50e0-a901-5ef9c19a84fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefbe595-93a9-4a5d-b5a5-4f517cec7bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefbe595-93a9-4a5d-b5a5-4f517cec7bdd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -47252,7 +47252,7 @@
         },
         {
             "id": "2a953fd4-a132-5d0a-ae67-e095a0447a4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5eda4-6339-4303-97ef-c5a467585949.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a5eda4-6339-4303-97ef-c5a467585949.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -47317,7 +47317,7 @@
         },
         {
             "id": "0949b3fb-9dd8-5347-a262-921e16ca5105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22f49c5-1dcd-453c-b169-0b2519c44d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a22f49c5-1dcd-453c-b169-0b2519c44d0c.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -47381,7 +47381,7 @@
         },
         {
             "id": "39df34be-3930-59a7-91a4-3678e7d875f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3740beb-7fa5-4b83-be7d-039750b126c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3740beb-7fa5-4b83-be7d-039750b126c5.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -47455,7 +47455,7 @@
         },
         {
             "id": "3d6bce5f-d264-54e9-b0e1-9704a70ea1f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715c6de3-5f4a-483f-9b73-ddb23207c0f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715c6de3-5f4a-483f-9b73-ddb23207c0f4.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -47520,7 +47520,7 @@
         },
         {
             "id": "03bdcac7-3f93-54f7-ab54-4a0c854a0280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd9517-a063-4c42-8e1c-c298b314b798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fd9517-a063-4c42-8e1c-c298b314b798.jpg?1",
             "name": "Bottomless Pit",
             "text": "",
             "colours": [
@@ -47552,7 +47552,7 @@
         },
         {
             "id": "0a545e63-eed6-5032-a8da-2e6febdb30ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14309ac9-5e75-4ac8-9f17-a256decd52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14309ac9-5e75-4ac8-9f17-a256decd52e9.jpg?1",
             "name": "Necrogen Mists",
             "text": "",
             "colours": [
@@ -47584,7 +47584,7 @@
         },
         {
             "id": "f151a071-ba13-56f9-acec-c50fc7d1da3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea44c06-900d-41b8-88fa-c1bede6ce757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea44c06-900d-41b8-88fa-c1bede6ce757.jpg?1",
             "name": "Reassembling Skeleton",
             "text": "",
             "colours": [
@@ -47619,7 +47619,7 @@
         },
         {
             "id": "fdfbd70d-1cc7-5187-bdb9-a6d4dd1c420a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3edb27c-4faa-464a-9bb1-fbe17013c022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3edb27c-4faa-464a-9bb1-fbe17013c022.jpg?1",
             "name": "Tinybones, Trinket Thief",
             "text": "",
             "colours": [
@@ -47656,7 +47656,7 @@
         },
         {
             "id": "e3f7f3a3-3e9e-56f2-b8f6-29f081b631b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d80ec47-0e47-49e3-9c43-1c126d8523e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d80ec47-0e47-49e3-9c43-1c126d8523e1.jpg?1",
             "name": "Geier Reach Sanitarium",
             "text": "",
             "colours": [],
@@ -47686,7 +47686,7 @@
         },
         {
             "id": "3a886daa-ef87-5012-8d9f-26bd9e20a525",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f67a2a1-2700-408e-b58c-34f3d2d75a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f67a2a1-2700-408e-b58c-34f3d2d75a98.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "",
             "colours": [
@@ -47724,7 +47724,7 @@
         },
         {
             "id": "7c774606-9ace-5498-bd74-2002429d5939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38944d0-710f-47d1-a117-ee4ede103b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38944d0-710f-47d1-a117-ee4ede103b30.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "",
             "colours": [
@@ -47762,7 +47762,7 @@
         },
         {
             "id": "e062f86c-c40b-5802-a21e-982ee71d2b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13e2b43-bf51-47e1-bc4e-fa80fa50f607.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b13e2b43-bf51-47e1-bc4e-fa80fa50f607.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "",
             "colours": [
@@ -47805,7 +47805,7 @@
         },
         {
             "id": "c598baa4-a658-5d5b-84cf-43a996113825",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3ec2c5-9fe3-4b2a-b649-14e9bd31d0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a3ec2c5-9fe3-4b2a-b649-14e9bd31d0e2.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "",
             "colours": [
@@ -47848,7 +47848,7 @@
         },
         {
             "id": "4dc14a8d-f5fc-5575-8451-674e3574af2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c42be7-84fe-4d9d-bf5c-e75e4d5635fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41c42be7-84fe-4d9d-bf5c-e75e4d5635fa.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "",
             "colours": [
@@ -47888,7 +47888,7 @@
         },
         {
             "id": "11c81e79-66a4-549d-b3bd-6517136011df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec098fee-4f80-4336-af87-d1586c9ea1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec098fee-4f80-4336-af87-d1586c9ea1e9.jpg?1",
             "name": "Elenda, the Dusk Rose",
             "text": "",
             "colours": [
@@ -47928,7 +47928,7 @@
         },
         {
             "id": "26b4ed59-4eaf-5489-a94d-6819ce420f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ae71-29de-45d6-97bb-f60e6f821d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd6ae71-29de-45d6-97bb-f60e6f821d6e.jpg?1",
             "name": "Kumena, Tyrant of Orazca",
             "text": "",
             "colours": [
@@ -47968,7 +47968,7 @@
         },
         {
             "id": "6d56f7a1-8795-54dc-b524-50ba08eb191c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae2f932-9723-4ddc-aa59-1c61e182714a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae2f932-9723-4ddc-aa59-1c61e182714a.jpg?1",
             "name": "Kumena, Tyrant of Orazca",
             "text": "",
             "colours": [
@@ -48008,7 +48008,7 @@
         },
         {
             "id": "64af2737-61c6-590a-8ac3-0c5c838a1bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1033640-5676-4f19-acea-2a69a549c8b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1033640-5676-4f19-acea-2a69a549c8b3.jpg?1",
             "name": "Vona, Butcher of Magan",
             "text": "",
             "colours": [
@@ -48048,7 +48048,7 @@
         },
         {
             "id": "6ac78f5b-5783-52f8-a830-ff3036b390c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6502f54-4045-40f5-98a0-d9eeca61dc87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6502f54-4045-40f5-98a0-d9eeca61dc87.jpg?1",
             "name": "Vona, Butcher of Magan",
             "text": "",
             "colours": [
@@ -48088,7 +48088,7 @@
         },
         {
             "id": "b75f6b36-379c-5e95-9eb7-feb302f5da57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57906b54-9fea-4608-87ce-43a16b95df9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57906b54-9fea-4608-87ce-43a16b95df9a.jpg?1",
             "name": "Eldritch Evolution",
             "text": "",
             "colours": [
@@ -48120,7 +48120,7 @@
         },
         {
             "id": "4498447f-5f3b-5250-849d-2b9b06356cff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca93d7d-869d-4437-829f-9cd0a3b9192b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca93d7d-869d-4437-829f-9cd0a3b9192b.jpg?1",
             "name": "Giant Adephage",
             "text": "",
             "colours": [
@@ -48154,7 +48154,7 @@
         },
         {
             "id": "b36fe590-6b2f-5486-b446-b6f30b6ea695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab584c-1f27-4452-89b4-3b93a2486d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ab584c-1f27-4452-89b4-3b93a2486d61.jpg?1",
             "name": "Noxious Revival",
             "text": "",
             "colours": [
@@ -48186,7 +48186,7 @@
         },
         {
             "id": "76751876-c491-5bcf-a4a1-fbcc4aa23515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10b0238-fe30-4543-ae8a-ed834a0930b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10b0238-fe30-4543-ae8a-ed834a0930b1.jpg?1",
             "name": "Grist, the Hunger Tide",
             "text": "",
             "colours": [
@@ -48224,7 +48224,7 @@
         },
         {
             "id": "28c8218d-4976-50fd-98d4-b7463017203f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13175ed2-c306-4a0a-a50d-b50879e2add6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13175ed2-c306-4a0a-a50d-b50879e2add6.jpg?1",
             "name": "Mazirek, Kraul Death Priest",
             "text": "",
             "colours": [
@@ -48265,7 +48265,7 @@
         },
         {
             "id": "3bdf314f-00a9-5fdd-ad3a-520af9008435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e3de28-d6e9-4f27-a544-0434fb4b55bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e3de28-d6e9-4f27-a544-0434fb4b55bb.jpg?1",
             "name": "Karn, Scion of Urza",
             "text": "",
             "colours": [],
@@ -48298,7 +48298,7 @@
         },
         {
             "id": "c3d7f1ef-f479-5e54-b0d3-0c57efc2092c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c7572e-4547-4ab5-b335-7d31de657cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c7572e-4547-4ab5-b335-7d31de657cc6.jpg?1",
             "name": "Karn, Scion of Urza",
             "text": "",
             "colours": [],
@@ -48331,7 +48331,7 @@
         },
         {
             "id": "6c5c8a7b-008c-5fe7-8723-af1c11021f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7427e78c-4881-42bd-930c-39aae324fc58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7427e78c-4881-42bd-930c-39aae324fc58.jpg?1",
             "name": "Chandra, Flame's Catalyst",
             "text": "",
             "colours": [
@@ -48368,7 +48368,7 @@
         },
         {
             "id": "4eaf59de-58a6-5230-b035-8b61c080f3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f98e65-60bd-44db-acfa-5df98cb60321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69f98e65-60bd-44db-acfa-5df98cb60321.jpg?1",
             "name": "Chandra, Flame's Catalyst",
             "text": "",
             "colours": [
@@ -48405,7 +48405,7 @@
         },
         {
             "id": "6cd878a4-dbf7-5bd5-887e-320515691fb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe22cd8-31e6-491b-bce2-db257668eb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe22cd8-31e6-491b-bce2-db257668eb92.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "",
             "colours": [
@@ -48446,7 +48446,7 @@
         },
         {
             "id": "61da8ef4-8ffd-5e72-a6cb-98ca1be4fcc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3748cbe2-ae41-49fd-823a-40c52496b65b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3748cbe2-ae41-49fd-823a-40c52496b65b.jpg?1",
             "name": "Aminatou, the Fateshifter",
             "text": "",
             "colours": [
@@ -48487,7 +48487,7 @@
         },
         {
             "id": "dd0595ce-f289-59a7-b603-5ede61fdc163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b3f79-74d0-4756-b7e7-1cd17685bbb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d05b3f79-74d0-4756-b7e7-1cd17685bbb7.jpg?1",
             "name": "Daretti, Ingenious Iconoclast",
             "text": "",
             "colours": [
@@ -48526,7 +48526,7 @@
         },
         {
             "id": "52dc8098-33bc-57a1-9692-b6229c9687f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e3a7c2-12fb-4f23-a0d1-a79df048201b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e3a7c2-12fb-4f23-a0d1-a79df048201b.jpg?1",
             "name": "Daretti, Ingenious Iconoclast",
             "text": "",
             "colours": [
@@ -48565,7 +48565,7 @@
         },
         {
             "id": "931f3fad-8c2b-50cf-a979-894761f27175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2813cb-c73c-4a50-b278-2f13deb71773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a2813cb-c73c-4a50-b278-2f13deb71773.jpg?1",
             "name": "Venser, the Sojourner",
             "text": "",
             "colours": [
@@ -48604,7 +48604,7 @@
         },
         {
             "id": "2af87d83-3c40-539e-a0f1-8b2064b10bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc2c6f-90bf-45c3-a836-3fe92a0b98cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bcc2c6f-90bf-45c3-a836-3fe92a0b98cf.jpg?1",
             "name": "Venser, the Sojourner",
             "text": "",
             "colours": [
@@ -48643,7 +48643,7 @@
         },
         {
             "id": "13575d4a-5dbb-5361-a13c-dd14daafe567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148685c3-5c92-4439-aedd-55d451444e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/148685c3-5c92-4439-aedd-55d451444e74.jpg?1",
             "name": "Oppression",
             "text": "",
             "colours": [
@@ -48675,7 +48675,7 @@
         },
         {
             "id": "ebf98cd4-6830-52da-a410-ecfe108d8f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f501f5-2bf4-40a5-8ac5-bff8a64b6762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f501f5-2bf4-40a5-8ac5-bff8a64b6762.jpg?1",
             "name": "Abrade",
             "text": "",
             "colours": [
@@ -48707,7 +48707,7 @@
         },
         {
             "id": "a98f8f84-0ec2-55c4-9aee-3b41e87e7624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d938eab-76f9-4168-8de2-ec11a38d789f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d938eab-76f9-4168-8de2-ec11a38d789f.jpg?1",
             "name": "Mass Hysteria",
             "text": "",
             "colours": [
@@ -48739,7 +48739,7 @@
         },
         {
             "id": "c7c628a2-2994-5c59-a120-6e81945874ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eec665f-9bcc-476b-a8c6-0ea2e03a8b7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eec665f-9bcc-476b-a8c6-0ea2e03a8b7a.jpg?1",
             "name": "Terminate",
             "text": "",
             "colours": [
@@ -48773,7 +48773,7 @@
         },
         {
             "id": "b6bd61f7-02e3-52bd-a56a-49c0c22f141f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c35da2-7dc0-4901-ac44-5ed197e5ea43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c35da2-7dc0-4901-ac44-5ed197e5ea43.jpg?1",
             "name": "Mycosynth Golem",
             "text": "",
             "colours": [],
@@ -48805,7 +48805,7 @@
         },
         {
             "id": "ef8153f6-4db5-5e5b-951b-83324a67e3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e9fe7-ff64-4741-87e8-e2c2904839f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625e9fe7-ff64-4741-87e8-e2c2904839f7.jpg?1",
             "name": "Mycosynth Golem",
             "text": "",
             "colours": [],
@@ -48837,7 +48837,7 @@
         },
         {
             "id": "7e01508e-d53f-5acf-b984-a41ab98a7342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9904ef62-3328-4474-a3b4-21428fb9d911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9904ef62-3328-4474-a3b4-21428fb9d911.jpg?1",
             "name": "Mycosynth Lattice",
             "text": "",
             "colours": [],
@@ -48866,7 +48866,7 @@
         },
         {
             "id": "bcd37c7e-1141-59c6-b91d-b62e77cac0b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede96b86-55b0-4303-a875-a972b47fd372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ede96b86-55b0-4303-a875-a972b47fd372.jpg?1",
             "name": "Mycosynth Lattice",
             "text": "",
             "colours": [],
@@ -48895,7 +48895,7 @@
         },
         {
             "id": "c6ba0c66-7644-5c0b-8630-19f042914ae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d951e0f-3f20-4c1c-ba5a-8cd17dfe5f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d951e0f-3f20-4c1c-ba5a-8cd17dfe5f0b.jpg?1",
             "name": "Mycosynth Wellspring",
             "text": "",
             "colours": [],
@@ -48924,7 +48924,7 @@
         },
         {
             "id": "0f3e69d5-b3e2-5fc9-a809-f8eb857dbffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23aa711-d88c-4b57-a980-2fc0de7e89c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23aa711-d88c-4b57-a980-2fc0de7e89c7.jpg?1",
             "name": "Mycosynth Wellspring",
             "text": "",
             "colours": [],
@@ -48953,7 +48953,7 @@
         },
         {
             "id": "4e4e5aa7-3d01-5f47-a3fa-418b47af9fcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54e310c-060c-40a9-a0e3-d35de672ef13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54e310c-060c-40a9-a0e3-d35de672ef13.jpg?1",
             "name": "Sisay, Weatherlight Captain",
             "text": "",
             "colours": [
@@ -48996,7 +48996,7 @@
         },
         {
             "id": "9bfc4624-741d-5a6d-902d-d3327f0ffad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c66de-a153-4317-9589-2db861bb9640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88c66de-a153-4317-9589-2db861bb9640.jpg?1",
             "name": "Silence",
             "text": "",
             "colours": [
@@ -49028,7 +49028,7 @@
         },
         {
             "id": "3c18188a-0234-5932-bd89-35fa0fcf70ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36c4f5-5eff-4b46-9671-9a038d4d1788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b36c4f5-5eff-4b46-9671-9a038d4d1788.jpg?1",
             "name": "Battle of Wits",
             "text": "",
             "colours": [
@@ -49060,7 +49060,7 @@
         },
         {
             "id": "aedb7d51-c724-5914-a581-2b696db84660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67793e8e-0b7f-4dac-b37d-697149276856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67793e8e-0b7f-4dac-b37d-697149276856.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "",
             "colours": [
@@ -49099,7 +49099,7 @@
         },
         {
             "id": "a76d1718-d771-5ffd-a55e-ce49d4ad4c0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb161c-ff04-4bf2-8320-48302dfb085c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33fb161c-ff04-4bf2-8320-48302dfb085c.jpg?1",
             "name": "Pack Rat",
             "text": "",
             "colours": [
@@ -49135,7 +49135,7 @@
         },
         {
             "id": "bee6ef5d-3541-5968-8ecb-460c4136593a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb05d34-05cb-4536-b7e6-2d526dc30a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fb05d34-05cb-4536-b7e6-2d526dc30a9f.jpg?1",
             "name": "Fynn, the Fangbearer",
             "text": "",
             "colours": [
@@ -49172,7 +49172,7 @@
         },
         {
             "id": "4a817d90-bd38-502f-b0c4-c569087f986c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cf891b-efa0-465f-8029-245f09b6b1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10cf891b-efa0-465f-8029-245f09b6b1b2.jpg?1",
             "name": "Brion Stoutarm",
             "text": "",
             "colours": [
@@ -49211,7 +49211,7 @@
         },
         {
             "id": "375022e4-822c-50d3-970a-e769b7089a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ea1c6-30b2-4612-8911-03fde5ecbb2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7ea1c6-30b2-4612-8911-03fde5ecbb2a.jpg?1",
             "name": "Samut, Voice of Dissent",
             "text": "",
             "colours": [
@@ -49251,7 +49251,7 @@
         },
         {
             "id": "09a4d082-704f-560d-86a9-01d0db95efa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f3f243-927d-4b84-87cd-43c48f6c371a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f3f243-927d-4b84-87cd-43c48f6c371a.jpg?1",
             "name": "Marchesa, the Black Rose",
             "text": "",
             "colours": [
@@ -49292,7 +49292,7 @@
         },
         {
             "id": "33d1b3c9-c27c-5512-a71c-248aa3adaaf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -49331,7 +49331,7 @@
         },
         {
             "id": "6c5824e9-d695-52b7-8b6f-2a0d3de369dd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/acdb72e2-c000-4b92-b5ea-73115969020f.jpg?1",
             "name": "Ajani Goldmane // Ajani Goldmane",
             "text": "",
             "colours": [
@@ -49370,7 +49370,7 @@
         },
         {
             "id": "bb1ae076-3c81-568b-b34b-d6bc9cd29eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -49409,7 +49409,7 @@
         },
         {
             "id": "5e2eba73-44fc-5bb4-8e62-65af34c8a02f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3cb0824c-57cc-46bf-bd43-425d58b8a762.jpg?1",
             "name": "Jace Beleren // Jace Beleren",
             "text": "",
             "colours": [
@@ -49448,7 +49448,7 @@
         },
         {
             "id": "6573e1f6-1c03-52bf-b493-811d89043b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -49487,7 +49487,7 @@
         },
         {
             "id": "76947e90-3eb4-5a22-8d91-d8291cb5b5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5f7a626-7b6b-41ba-a0f5-3aefe511b267.jpg?1",
             "name": "Liliana Vess // Liliana Vess",
             "text": "",
             "colours": [
@@ -49526,7 +49526,7 @@
         },
         {
             "id": "92bbc67c-3e44-52f2-a4fa-182f95155a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -49565,7 +49565,7 @@
         },
         {
             "id": "971fd38a-b1f8-5886-865f-a1eb3e4811a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5ab0412a-2b2f-430f-8830-002a42125148.jpg?1",
             "name": "Chandra Nalaar // Chandra Nalaar",
             "text": "",
             "colours": [
@@ -49604,7 +49604,7 @@
         },
         {
             "id": "1d6d8b1a-be16-5d1a-9b49-d0fb7e9178fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -49643,7 +49643,7 @@
         },
         {
             "id": "868f04b2-2e04-57c9-96fb-0bf0f63543e4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/caf8d01d-07aa-43da-a26e-4a2ba3a76f2d.jpg?1",
             "name": "Garruk Wildspeaker // Garruk Wildspeaker",
             "text": "",
             "colours": [
@@ -49682,7 +49682,7 @@
         },
         {
             "id": "6f93f356-dbe7-597f-9b06-362872b8aa45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg?1",
             "name": "Death Baron // Death Baron",
             "text": "",
             "colours": [
@@ -49717,7 +49717,7 @@
         },
         {
             "id": "4f04b2a7-3a97-59d2-a3cc-0ce88a63f30c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4e7b3a4-a346-4177-9cfe-0142b40ef4a6.jpg?1",
             "name": "Death Baron // Death Baron",
             "text": "",
             "colours": [
@@ -49752,7 +49752,7 @@
         },
         {
             "id": "4be1397f-aad2-5d12-9f0c-c92a84b5d209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg?1",
             "name": "Noxious Ghoul // Noxious Ghoul",
             "text": "",
             "colours": [
@@ -49786,7 +49786,7 @@
         },
         {
             "id": "0aa37a8a-f7eb-5ce9-91c8-7db34c4bafb9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e69f9e0-4981-4fc0-955f-7ebe04264fca.jpg?1",
             "name": "Noxious Ghoul // Noxious Ghoul",
             "text": "",
             "colours": [
@@ -49820,7 +49820,7 @@
         },
         {
             "id": "ce665ebb-3003-543a-bae6-a70957ff0a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg?1",
             "name": "Zombie Master // Zombie Master",
             "text": "",
             "colours": [
@@ -49854,7 +49854,7 @@
         },
         {
             "id": "19047b90-bde7-5649-aeec-1178f2edbb94",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcf942f-5afd-414e-a50d-00d884fe59da.jpg?1",
             "name": "Zombie Master // Zombie Master",
             "text": "",
             "colours": [
@@ -49888,7 +49888,7 @@
         },
         {
             "id": "664d25e1-5888-5786-a83d-51f26fde2de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg?1",
             "name": "Grimgrin, Corpse-Born // Grimgrin, Corpse-Born",
             "text": "",
             "colours": [
@@ -49927,7 +49927,7 @@
         },
         {
             "id": "edb065e2-b45d-55db-9a69-89b6db7892e7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe388da5-9197-4d07-be7f-c49fcdf56dfa.jpg?1",
             "name": "Grimgrin, Corpse-Born // Grimgrin, Corpse-Born",
             "text": "",
             "colours": [
@@ -49966,7 +49966,7 @@
         },
         {
             "id": "436000c1-96d5-5cd1-8b94-2f6879aa21e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg?1",
             "name": "Unholy Grotto // Unholy Grotto",
             "text": "",
             "colours": [],
@@ -49996,7 +49996,7 @@
         },
         {
             "id": "3e304def-f802-5b43-a8a7-675fde5dbf70",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c69ecd2-cb36-4628-802b-fd5ff7405f22.jpg?1",
             "name": "Unholy Grotto // Unholy Grotto",
             "text": "",
             "colours": [],
@@ -50026,7 +50026,7 @@
         },
         {
             "id": "45bf7508-7db9-5130-a083-1905eaa85af3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b56d67-a3f1-4f66-820e-4b354453b091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b56d67-a3f1-4f66-820e-4b354453b091.jpg?1",
             "name": "Giver of Runes",
             "text": "",
             "colours": [
@@ -50062,7 +50062,7 @@
         },
         {
             "id": "9e3b4542-e6ed-5b0d-97af-94f2d3bdd16c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b85f9-0e15-4409-b96a-1f50d6aedf60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b85f9-0e15-4409-b96a-1f50d6aedf60.jpg?1",
             "name": "Giver of Runes",
             "text": "",
             "colours": [
@@ -50098,7 +50098,7 @@
         },
         {
             "id": "cf5acac6-fdd9-549d-b915-da09480040ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf6f926-8dde-45ce-8aa6-966fbcf79a7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf6f926-8dde-45ce-8aa6-966fbcf79a7f.jpg?1",
             "name": "Distant Melody",
             "text": "",
             "colours": [
@@ -50131,7 +50131,7 @@
         },
         {
             "id": "fe3a390b-ca06-5b2c-af57-b9f1c7eb2862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c293461-ca8d-4be3-a8ec-4f76e8b6aff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c293461-ca8d-4be3-a8ec-4f76e8b6aff5.jpg?1",
             "name": "Distant Melody",
             "text": "",
             "colours": [
@@ -50164,7 +50164,7 @@
         },
         {
             "id": "7031ebe0-73d2-5e8f-af91-d6953c357131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70abfaeb-1253-4217-9194-67f40b5ee4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70abfaeb-1253-4217-9194-67f40b5ee4b1.jpg?1",
             "name": "Cathartic Reunion",
             "text": "",
             "colours": [
@@ -50197,7 +50197,7 @@
         },
         {
             "id": "3ffdbcaa-c04f-5c0d-83a1-43903a2eb2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f252720-11b7-43a6-83bc-0d670a54ae31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f252720-11b7-43a6-83bc-0d670a54ae31.jpg?1",
             "name": "Cathartic Reunion",
             "text": "",
             "colours": [
@@ -50230,7 +50230,7 @@
         },
         {
             "id": "d4485e18-3cee-58bd-8066-409ab3ba506d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b05002-0039-4e51-8493-37e64405e342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b05002-0039-4e51-8493-37e64405e342.jpg?1",
             "name": "Moment's Peace",
             "text": "",
             "colours": [
@@ -50263,7 +50263,7 @@
         },
         {
             "id": "caf17d51-bfe0-5c4d-af0f-6b1bd054c521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4531802-d9e1-4374-b9fd-5e5ad52b8d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4531802-d9e1-4374-b9fd-5e5ad52b8d50.jpg?1",
             "name": "Moment's Peace",
             "text": "",
             "colours": [
@@ -50296,7 +50296,7 @@
         },
         {
             "id": "58747277-a82d-5ef8-856e-6669302d4371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0449831a-a07e-4dc0-991f-7406629291b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0449831a-a07e-4dc0-991f-7406629291b6.jpg?1",
             "name": "Homeward Path",
             "text": "",
             "colours": [],
@@ -50325,7 +50325,7 @@
         },
         {
             "id": "71789ccc-f917-5a2d-ae38-7d089eefa436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b522dcf-fc81-4b91-9649-f080016f4339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b522dcf-fc81-4b91-9649-f080016f4339.jpg?1",
             "name": "Homeward Path",
             "text": "",
             "colours": [],
@@ -50354,7 +50354,7 @@
         },
         {
             "id": "970b4acb-af6f-59b6-87a5-a30a8ab4a5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7432b894-e7a9-4de7-9470-846e65cd4d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7432b894-e7a9-4de7-9470-846e65cd4d0c.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -50423,7 +50423,7 @@
         },
         {
             "id": "08608728-5605-5a66-a261-cd751a894bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839e97b5-c04d-4088-af4e-fa64f4575e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839e97b5-c04d-4088-af4e-fa64f4575e51.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -50488,7 +50488,7 @@
         },
         {
             "id": "ac332504-6463-527f-8e9c-269541febc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c0baf-9b5c-44ff-86eb-ca0f24ab0fe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db3c0baf-9b5c-44ff-86eb-ca0f24ab0fe1.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -50552,7 +50552,7 @@
         },
         {
             "id": "1609e468-b06a-596e-a057-a208f18782ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01550676-3659-47d7-9a47-67c31438ec09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01550676-3659-47d7-9a47-67c31438ec09.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -50626,7 +50626,7 @@
         },
         {
             "id": "4b0661b3-9ae7-599f-a527-c4ad85a64c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadcd72e-90ca-4cfc-a181-742e35c4a8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadcd72e-90ca-4cfc-a181-742e35c4a8ed.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -50691,7 +50691,7 @@
         },
         {
             "id": "c93278a9-0764-5574-ba68-edab3ada8438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc0bbe-a901-4565-940b-9f763cf006a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ecc0bbe-a901-4565-940b-9f763cf006a4.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -50729,7 +50729,7 @@
         },
         {
             "id": "dca77707-0e76-562a-b52a-32e0644bdbb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e5104-02b1-48db-a70e-d267066d2561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513e5104-02b1-48db-a70e-d267066d2561.jpg?1",
             "name": "Snow-Covered Plains",
             "text": "",
             "colours": [],
@@ -50767,7 +50767,7 @@
         },
         {
             "id": "70c42767-6f41-54ed-bc8d-be92358ca6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7e936-bd27-4955-a5ea-c1e88a9ab646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef7e936-bd27-4955-a5ea-c1e88a9ab646.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -50805,7 +50805,7 @@
         },
         {
             "id": "55186109-3d6e-53f2-9cd3-8995f03b52f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328fc009-d9c1-472d-8e07-778f60947642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328fc009-d9c1-472d-8e07-778f60947642.jpg?1",
             "name": "Snow-Covered Island",
             "text": "",
             "colours": [],
@@ -50843,7 +50843,7 @@
         },
         {
             "id": "79fe0703-7288-5e18-8ab6-4b38c5b3e99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de8c3b-410e-4fc6-abfb-7315010e05d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97de8c3b-410e-4fc6-abfb-7315010e05d5.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -50881,7 +50881,7 @@
         },
         {
             "id": "c4363bab-65a5-537c-80bf-ebd09bb3c7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a04eb28-cba8-4619-972c-4e6ebff73f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a04eb28-cba8-4619-972c-4e6ebff73f34.jpg?1",
             "name": "Snow-Covered Swamp",
             "text": "",
             "colours": [],
@@ -50919,7 +50919,7 @@
         },
         {
             "id": "78bb7978-4f31-5c14-a0ef-37990816c3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee2b472-8cb0-4722-a1b7-b700ac42a6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee2b472-8cb0-4722-a1b7-b700ac42a6c0.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -50957,7 +50957,7 @@
         },
         {
             "id": "4cfd2a9a-7d85-5dff-9374-b65166833233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4fab9d-7753-489e-a63c-c107e7d27668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4fab9d-7753-489e-a63c-c107e7d27668.jpg?1",
             "name": "Snow-Covered Mountain",
             "text": "",
             "colours": [],
@@ -50995,7 +50995,7 @@
         },
         {
             "id": "4c64c5a4-43e7-5dea-89e7-da9f4671cfae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3995734f-5fa2-4039-af64-0bca88741089.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3995734f-5fa2-4039-af64-0bca88741089.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -51033,7 +51033,7 @@
         },
         {
             "id": "57a0151b-1ac6-5a39-a15b-dbfc9aabe11a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d1476-7778-4743-804a-e3f497d38d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d1476-7778-4743-804a-e3f497d38d77.jpg?1",
             "name": "Snow-Covered Forest",
             "text": "",
             "colours": [],
@@ -51071,7 +51071,7 @@
         },
         {
             "id": "cc305309-8dea-548e-a75a-9140dea5c2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bde779-b9aa-409f-bd8b-94d7cfde8346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bde779-b9aa-409f-bd8b-94d7cfde8346.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "",
             "colours": [
@@ -51111,7 +51111,7 @@
         },
         {
             "id": "a7f983f0-6e1c-5a7d-a4f6-675414245c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ce8ee-8abe-4973-ae6e-a97e20836d05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a49ce8ee-8abe-4973-ae6e-a97e20836d05.jpg?1",
             "name": "Grand Arbiter Augustin IV",
             "text": "",
             "colours": [
@@ -51151,7 +51151,7 @@
         },
         {
             "id": "eb6f4524-69c7-5d50-8a81-df079c494ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7afa73-2f60-4ccc-8f5b-d7e6487c0b2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7afa73-2f60-4ccc-8f5b-d7e6487c0b2b.jpg?1",
             "name": "Sphere of Resistance",
             "text": "",
             "colours": [],
@@ -51180,7 +51180,7 @@
         },
         {
             "id": "bd5d3fe0-c888-513f-a7d1-8b3fe741fc8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d1908-487a-4264-8cab-49adc23d2802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d4d1908-487a-4264-8cab-49adc23d2802.jpg?1",
             "name": "Sphere of Resistance",
             "text": "",
             "colours": [],
@@ -51209,7 +51209,7 @@
         },
         {
             "id": "1d171c09-66cd-5ba7-9643-9db8c818c4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea8286-225b-4990-981a-6b8c49748794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ea8286-225b-4990-981a-6b8c49748794.jpg?1",
             "name": "Trinisphere",
             "text": "",
             "colours": [],
@@ -51238,7 +51238,7 @@
         },
         {
             "id": "c48dc430-5eaf-5c78-932a-0da7e5301c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2689f7-b075-4e64-b2a6-d7b26f1be908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2689f7-b075-4e64-b2a6-d7b26f1be908.jpg?1",
             "name": "Trinisphere",
             "text": "",
             "colours": [],
@@ -51267,7 +51267,7 @@
         },
         {
             "id": "ac9283b1-5e13-569c-8f68-a471bbaa6108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146a0ab1-683e-43e4-a07b-1faa1eb4c7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146a0ab1-683e-43e4-a07b-1faa1eb4c7c6.jpg?1",
             "name": "Winter Orb",
             "text": "",
             "colours": [],
@@ -51296,7 +51296,7 @@
         },
         {
             "id": "e9a6fed7-6b05-549e-b728-54a4c63d3682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9076a877-d2c3-43f8-8f27-29434a06816f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9076a877-d2c3-43f8-8f27-29434a06816f.jpg?1",
             "name": "Winter Orb",
             "text": "",
             "colours": [],
@@ -51325,7 +51325,7 @@
         },
         {
             "id": "a642a7d7-6836-5cc8-87ce-5beb53f9414a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b464549-a84d-44bf-a684-d59db5babc6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b464549-a84d-44bf-a684-d59db5babc6d.jpg?1",
             "name": "Felidar Guardian",
             "text": "",
             "colours": [
@@ -51361,7 +51361,7 @@
         },
         {
             "id": "9803542d-38d2-56bb-9b9d-f7bcbd2ce92e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e19dd-53f9-484c-9ece-1401e2a219a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867e19dd-53f9-484c-9ece-1401e2a219a6.jpg?1",
             "name": "Felidar Guardian",
             "text": "",
             "colours": [
@@ -51397,7 +51397,7 @@
         },
         {
             "id": "7bd3a7fd-8309-5df2-aeac-c3ea7c6cddf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0915174-102d-4d86-b386-8647aa231f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0915174-102d-4d86-b386-8647aa231f95.jpg?1",
             "name": "Peregrine Drake",
             "text": "",
             "colours": [
@@ -51432,7 +51432,7 @@
         },
         {
             "id": "95aca11c-946b-5908-acfc-0c4a00d302d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a971066-5e32-4582-b392-880919d11388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a971066-5e32-4582-b392-880919d11388.jpg?1",
             "name": "Peregrine Drake",
             "text": "",
             "colours": [
@@ -51467,7 +51467,7 @@
         },
         {
             "id": "7bd327f3-ac0b-58eb-ae1f-9b82447e4857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad89f6d0-e965-49b8-adeb-ad07e40f00f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad89f6d0-e965-49b8-adeb-ad07e40f00f0.jpg?1",
             "name": "Serpent of Yawning Depths",
             "text": "",
             "colours": [
@@ -51503,7 +51503,7 @@
         },
         {
             "id": "31509c9a-233b-5039-8126-3b80bd70b39f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a83655-646e-4ccb-b015-13a2092f1444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a83655-646e-4ccb-b015-13a2092f1444.jpg?1",
             "name": "Serpent of Yawning Depths",
             "text": "",
             "colours": [
@@ -51539,7 +51539,7 @@
         },
         {
             "id": "0f826745-a622-5cf1-8f58-48a34176a470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebab854f-f041-49d8-bd7c-3d1cdca72cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebab854f-f041-49d8-bd7c-3d1cdca72cc6.jpg?1",
             "name": "Scourge of Valkas",
             "text": "",
             "colours": [
@@ -51574,7 +51574,7 @@
         },
         {
             "id": "3bf093e7-c167-5252-bbd8-677d8780477c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61a5022-1590-44d7-9def-73173c0dec04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61a5022-1590-44d7-9def-73173c0dec04.jpg?1",
             "name": "Scourge of Valkas",
             "text": "",
             "colours": [
@@ -51609,7 +51609,7 @@
         },
         {
             "id": "44deef76-30ef-5ba4-8a24-d0333ce7abf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd58870d-8625-4d35-a51b-e191970cadf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd58870d-8625-4d35-a51b-e191970cadf3.jpg?1",
             "name": "Voracious Hydra",
             "text": "",
             "colours": [
@@ -51644,7 +51644,7 @@
         },
         {
             "id": "3d856879-a19f-5fb1-85a0-207c465ece4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76648b3-a893-4f06-8055-12b87ab7ba32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76648b3-a893-4f06-8055-12b87ab7ba32.jpg?1",
             "name": "Voracious Hydra",
             "text": "",
             "colours": [
@@ -51679,7 +51679,7 @@
         },
         {
             "id": "255cc92a-37a5-5f2c-b02b-340237cb9433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6b109-4657-4e9e-82f3-53ddd56aef1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc6b109-4657-4e9e-82f3-53ddd56aef1c.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -51715,7 +51715,7 @@
         },
         {
             "id": "44c12349-04fb-5938-a157-a1b6a455f79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf977357-e13d-4c67-ae53-397adf55131e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf977357-e13d-4c67-ae53-397adf55131e.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -51751,7 +51751,7 @@
         },
         {
             "id": "c84e8bea-8c65-57c8-9d08-222787bde76f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfac7625-4c7b-4417-930e-f0de536a34f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfac7625-4c7b-4417-930e-f0de536a34f0.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -51784,7 +51784,7 @@
         },
         {
             "id": "11a30ea2-b647-5636-8185-e5564e0b2b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b840da3-2818-4fed-8cff-19754ab1efdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b840da3-2818-4fed-8cff-19754ab1efdc.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -51817,7 +51817,7 @@
         },
         {
             "id": "b3cf7e34-f1e3-5c1f-94fe-f4430f309ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858e0b83-7927-4e34-ae25-6ad7a787ad97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858e0b83-7927-4e34-ae25-6ad7a787ad97.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -51853,7 +51853,7 @@
         },
         {
             "id": "981a1715-e8a2-5564-ab75-d9fa04b1591b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21365def-bec7-4ec0-a1e9-34c85bf6c274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21365def-bec7-4ec0-a1e9-34c85bf6c274.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -51889,7 +51889,7 @@
         },
         {
             "id": "65e4ed20-ae1a-5161-84f7-040897c13d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584b7e75-6523-4d6f-ada1-f8a8459a0b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584b7e75-6523-4d6f-ada1-f8a8459a0b50.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -51919,7 +51919,7 @@
         },
         {
             "id": "fa191134-bef3-54f1-87c3-2fb2afc48345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd71be2d-5ffc-418e-92d0-a36cf10ac5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd71be2d-5ffc-418e-92d0-a36cf10ac5d6.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -51949,7 +51949,7 @@
         },
         {
             "id": "a274cb0b-7f3c-5793-9e21-f9f38e297cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea9aa06-d0ad-4dae-a36f-f84278a45c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea9aa06-d0ad-4dae-a36f-f84278a45c3a.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -51987,7 +51987,7 @@
         },
         {
             "id": "104c46d9-014c-54b6-8e4c-6823f208ed27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c36efb0-1a5b-4576-b5d9-c9b966716f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c36efb0-1a5b-4576-b5d9-c9b966716f65.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -52025,7 +52025,7 @@
         },
         {
             "id": "500c5d5d-00ad-503e-b127-3492d1e2f59e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd002b2-acc3-421a-ad2e-22117d347b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd002b2-acc3-421a-ad2e-22117d347b29.jpg?1",
             "name": "Beacon of Tomorrows",
             "text": "",
             "colours": [
@@ -52058,7 +52058,7 @@
         },
         {
             "id": "2f93b419-96e5-5b2f-b49b-f080c39b21d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519e3161-5048-47c6-b803-fb46ff5a4e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519e3161-5048-47c6-b803-fb46ff5a4e4b.jpg?1",
             "name": "Beacon of Tomorrows",
             "text": "",
             "colours": [
@@ -52091,7 +52091,7 @@
         },
         {
             "id": "68afb741-aba9-51b7-bff2-614f834ad93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87648fda-7359-4554-aec8-bc98f5ba4f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87648fda-7359-4554-aec8-bc98f5ba4f1c.jpg?1",
             "name": "Nexus of Fate",
             "text": "",
             "colours": [
@@ -52124,7 +52124,7 @@
         },
         {
             "id": "7b18c8fc-59f5-5fbd-9ce6-11b92182cc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7369f643-3f80-4d76-816c-0193a03cd6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7369f643-3f80-4d76-816c-0193a03cd6e6.jpg?1",
             "name": "Nexus of Fate",
             "text": "",
             "colours": [
@@ -52157,7 +52157,7 @@
         },
         {
             "id": "0b78c168-7d5d-594c-b905-9b5619e85ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97deaec0-09a7-4f73-86d2-6f6759afb778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97deaec0-09a7-4f73-86d2-6f6759afb778.jpg?1",
             "name": "Time Reversal",
             "text": "",
             "colours": [
@@ -52190,7 +52190,7 @@
         },
         {
             "id": "3d3a4a1e-dc91-5072-95fd-b2413c45322f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a884bda9-a7e2-419f-a729-9244ba39fa1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a884bda9-a7e2-419f-a729-9244ba39fa1a.jpg?1",
             "name": "Time Reversal",
             "text": "",
             "colours": [
@@ -52223,7 +52223,7 @@
         },
         {
             "id": "879cffe6-73ca-5012-a7cf-9948d7c9fb53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3ed349-c9f2-412d-9e60-01362680d373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f3ed349-c9f2-412d-9e60-01362680d373.jpg?1",
             "name": "Time Stop",
             "text": "",
             "colours": [
@@ -52256,7 +52256,7 @@
         },
         {
             "id": "9de13896-4b01-5dbd-80f3-35f403dee0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4791c4-acde-4325-82d9-8b410ef5c1a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d4791c4-acde-4325-82d9-8b410ef5c1a0.jpg?1",
             "name": "Time Stop",
             "text": "",
             "colours": [
@@ -52289,7 +52289,7 @@
         },
         {
             "id": "5000c005-b6ec-5a12-bac8-4ab137b66279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c976b-6096-4ac7-8d52-2f219ae21d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098c976b-6096-4ac7-8d52-2f219ae21d1f.jpg?1",
             "name": "Lara Croft, Tomb Raider",
             "text": "",
             "colours": [
@@ -52330,7 +52330,7 @@
         },
         {
             "id": "07998e8f-01fa-59f7-8b0b-5ccf1bfa1b07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "",
             "colours": [
@@ -52364,7 +52364,7 @@
         },
         {
             "id": "2062e220-6701-5642-a49d-096f429eb360",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168edd9-0e1b-4ff9-b1c4-18d56866858a.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "",
             "colours": [],
@@ -52396,7 +52396,7 @@
         },
         {
             "id": "6ef69beb-e4d6-5aa9-9056-0d1ecc168369",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1665ec-7617-4754-b604-656411f7476a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1665ec-7617-4754-b604-656411f7476a.jpg?1",
             "name": "Anger of the Gods",
             "text": "",
             "colours": [
@@ -52430,7 +52430,7 @@
         },
         {
             "id": "e7c54417-0e17-52df-9e41-3a4a9f95b2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfd2d0-bdd4-485d-a8a3-d3c3ad31014b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04dfd2d0-bdd4-485d-a8a3-d3c3ad31014b.jpg?1",
             "name": "Bow of Nylea",
             "text": "",
             "colours": [
@@ -52465,7 +52465,7 @@
         },
         {
             "id": "412d3d95-c97e-548c-b660-d4727ea78bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da507391-4dbd-4fff-8c81-db64bfa4162f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da507391-4dbd-4fff-8c81-db64bfa4162f.jpg?1",
             "name": "Shadowspear",
             "text": "",
             "colours": [],
@@ -52497,7 +52497,7 @@
         },
         {
             "id": "a834aae5-4e27-56cc-8e80-3ee6ec74cc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b2979-a887-4ad8-b123-4aea916de36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b2979-a887-4ad8-b123-4aea916de36a.jpg?1",
             "name": "Academy Ruins",
             "text": "",
             "colours": [],
@@ -52529,7 +52529,7 @@
         },
         {
             "id": "11bb434a-fbe0-55f9-8515-7c13c9030d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -52572,7 +52572,7 @@
         },
         {
             "id": "bb0d0e57-b790-50ad-8b00-7cccb9ae8e9c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a129558c-45a1-441c-97f0-b70b4e9d8a56.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -52615,7 +52615,7 @@
         },
         {
             "id": "9ed5924a-3b03-5c34-bc5b-b8c5ff1cbd0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -52658,7 +52658,7 @@
         },
         {
             "id": "10c8e4d8-d935-56d9-8b50-fa565e01e1c5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/399bf36a-5901-437f-b5d3-32283cedbbcb.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -52701,7 +52701,7 @@
         },
         {
             "id": "60c0a4ce-663e-5477-ab82-b8fe8e8db821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -52744,7 +52744,7 @@
         },
         {
             "id": "216505a2-ed88-59ed-ba05-43d9a740ec9b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6fb38a7-f453-44e4-b876-6d542d6c2a85.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -52787,7 +52787,7 @@
         },
         {
             "id": "bbe04204-3f5c-5e6f-b462-845a75d99d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg?1",
             "name": "Anointed Procession // Anointed Procession",
             "text": "",
             "colours": [
@@ -52818,7 +52818,7 @@
         },
         {
             "id": "7f608cc4-c02c-5910-b7ce-c5ca57714b85",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/236e9bcf-ced2-4bee-8188-41dd94df02da.jpg?1",
             "name": "Anointed Procession // Anointed Procession",
             "text": "",
             "colours": [
@@ -52849,7 +52849,7 @@
         },
         {
             "id": "2204fa4d-32e6-50b0-9339-55f668732d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg?1",
             "name": "Sol Ring // Sol Ring",
             "text": "",
             "colours": [],
@@ -52876,7 +52876,7 @@
         },
         {
             "id": "f687278c-44b6-5605-a251-1066cabc1807",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d74a72a2-d46a-41c2-a400-70571197b020.jpg?1",
             "name": "Sol Ring // Sol Ring",
             "text": "",
             "colours": [],
@@ -52903,7 +52903,7 @@
         },
         {
             "id": "b6ee6ed4-4ae9-5638-8ca6-7ff2d06e9834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b86eac-3cd5-48ef-9fda-b4beff540c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b86eac-3cd5-48ef-9fda-b4beff540c94.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -52971,7 +52971,7 @@
         },
         {
             "id": "841ec073-5326-51c5-8443-74e7b49a0fc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76d6ecc-a774-44d5-8c16-e2ba4bf7d283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f76d6ecc-a774-44d5-8c16-e2ba4bf7d283.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -53044,7 +53044,7 @@
         },
         {
             "id": "d8007f07-7d57-59c0-975f-3ba54a3e3d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79053ce4-62d4-416c-b001-93740521fd07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79053ce4-62d4-416c-b001-93740521fd07.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -53108,7 +53108,7 @@
         },
         {
             "id": "3617d042-b435-5945-ba25-e55ca25d4eb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f4d580-0a3c-4f4f-9700-4a2afed4ded0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f4d580-0a3c-4f4f-9700-4a2afed4ded0.jpg?1",
             "name": "Wall of Omens",
             "text": "",
             "colours": [
@@ -53143,7 +53143,7 @@
         },
         {
             "id": "04ab46ac-b266-5bf1-b7ff-c43784fe4a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de38a06-7b5d-4358-99da-3266186c0144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de38a06-7b5d-4358-99da-3266186c0144.jpg?1",
             "name": "Wall of Omens",
             "text": "",
             "colours": [
@@ -53178,7 +53178,7 @@
         },
         {
             "id": "b86d0873-a723-5b10-ab1e-ec68823b01f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0392db52-c77c-4310-be26-7daccc661d07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0392db52-c77c-4310-be26-7daccc661d07.jpg?1",
             "name": "Circular Logic",
             "text": "",
             "colours": [
@@ -53211,7 +53211,7 @@
         },
         {
             "id": "77205f20-da9d-5010-8a3c-cf299dec8da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93201f-d2d0-46ff-8024-3b92cc0878a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a93201f-d2d0-46ff-8024-3b92cc0878a5.jpg?1",
             "name": "Circular Logic",
             "text": "",
             "colours": [
@@ -53244,7 +53244,7 @@
         },
         {
             "id": "ebdf0ea0-e98e-5113-a7b7-7cc40356cbaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef7e2af-c7f6-4634-87d8-0d580d20f9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef7e2af-c7f6-4634-87d8-0d580d20f9d9.jpg?1",
             "name": "Scheming Symmetry",
             "text": "",
             "colours": [
@@ -53277,7 +53277,7 @@
         },
         {
             "id": "df6d5d9c-0369-5f7e-8b4f-3cbd5e9a081f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e641ae-f138-4861-a115-4bc9e29689e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e641ae-f138-4861-a115-4bc9e29689e9.jpg?1",
             "name": "Scheming Symmetry",
             "text": "",
             "colours": [
@@ -53310,7 +53310,7 @@
         },
         {
             "id": "9462d472-5ea5-5f2c-996f-a4d66a044405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e3fd0-c6a9-493c-83b2-9386245c4cbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90e3fd0-c6a9-493c-83b2-9386245c4cbe.jpg?1",
             "name": "Price of Progress",
             "text": "",
             "colours": [
@@ -53343,7 +53343,7 @@
         },
         {
             "id": "6469d02d-4d93-549c-872d-75ce32d12ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f22283-6a46-46c0-b6ba-8155392ccbc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f22283-6a46-46c0-b6ba-8155392ccbc7.jpg?1",
             "name": "Price of Progress",
             "text": "",
             "colours": [
@@ -53376,7 +53376,7 @@
         },
         {
             "id": "594ae525-aaef-5158-b3c3-1f786dfdaf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362b72b5-4f63-43e2-bd09-4398b6aef5f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362b72b5-4f63-43e2-bd09-4398b6aef5f3.jpg?1",
             "name": "Eternal Witness",
             "text": "",
             "colours": [
@@ -53413,7 +53413,7 @@
         },
         {
             "id": "e39aa890-6476-5af0-8980-fa2af4f4490a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f615-e2db-428b-9459-50190ee614ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e29f615-e2db-428b-9459-50190ee614ea.jpg?1",
             "name": "Eternal Witness",
             "text": "",
             "colours": [
@@ -53450,7 +53450,7 @@
         },
         {
             "id": "965ce4f7-ce35-564e-ae9b-9546cdbad69c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b136d-34ad-4bf4-bb1b-1523df01f441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5b136d-34ad-4bf4-bb1b-1523df01f441.jpg?1",
             "name": "Inspiring Overseer",
             "text": "",
             "colours": [
@@ -53484,7 +53484,7 @@
         },
         {
             "id": "d9a231ff-aa8b-5233-85ea-657e661cc8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80f726b-471c-4bc1-8fd7-66db5207e4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80f726b-471c-4bc1-8fd7-66db5207e4ce.jpg?1",
             "name": "Consider",
             "text": "",
             "colours": [
@@ -53515,7 +53515,7 @@
         },
         {
             "id": "0ae7c0e3-6279-538b-9b84-79be112ae033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a084e1-b181-49cc-acb0-8b074ba36fde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a084e1-b181-49cc-acb0-8b074ba36fde.jpg?1",
             "name": "Price of Glory",
             "text": "",
             "colours": [
@@ -53546,7 +53546,7 @@
         },
         {
             "id": "8ad57761-408c-512d-b967-3dfc7d700a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfaf199-af57-4889-924f-9ac2257983ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfaf199-af57-4889-924f-9ac2257983ac.jpg?1",
             "name": "Reckless Fireweaver",
             "text": "",
             "colours": [
@@ -53580,7 +53580,7 @@
         },
         {
             "id": "4d435242-d5e5-560c-b7b1-6165afa8f325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e8ddc-2e8f-4a6c-a20d-a37f2c24fd97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d49e8ddc-2e8f-4a6c-a20d-a37f2c24fd97.jpg?1",
             "name": "Akroma's Memorial",
             "text": "",
             "colours": [],
@@ -53609,7 +53609,7 @@
         },
         {
             "id": "fe3a1560-dc82-53c9-960e-f8a4933f21bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f730eba-fef1-4d2c-bcaf-9fe51f6bf270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f730eba-fef1-4d2c-bcaf-9fe51f6bf270.jpg?1",
             "name": "Bojuka Bog",
             "text": "",
             "colours": [],
@@ -53640,7 +53640,7 @@
         },
         {
             "id": "5ded1ac9-50a6-5115-8357-7b77d8beceae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80ead0d-00ee-46eb-9399-f21027fe3d6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80ead0d-00ee-46eb-9399-f21027fe3d6f.jpg?1",
             "name": "Bojuka Bog",
             "text": "",
             "colours": [],
@@ -53671,7 +53671,7 @@
         },
         {
             "id": "cbe3b8b3-316f-5408-8a81-ee7d614e9975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d40c3-d6dd-4af8-b6f2-dc7dc609d77a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac8d40c3-d6dd-4af8-b6f2-dc7dc609d77a.jpg?1",
             "name": "Command Beacon",
             "text": "",
             "colours": [],
@@ -53701,7 +53701,7 @@
         },
         {
             "id": "870abcb1-62cd-5d56-a1b0-883a2ed0d277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e272810-0142-4957-a543-d71b6f1ac3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e272810-0142-4957-a543-d71b6f1ac3ee.jpg?1",
             "name": "Command Beacon",
             "text": "",
             "colours": [],
@@ -53731,7 +53731,7 @@
         },
         {
             "id": "d46fd2c3-ac42-576b-bcfb-43a21550d1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d65e45-1a3b-4f1b-a148-e498953f966d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d65e45-1a3b-4f1b-a148-e498953f966d.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -53762,7 +53762,7 @@
         },
         {
             "id": "e3300b02-0ff9-578f-a6d3-82b13b906733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfc846e-1326-4055-bce6-68366b08f17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfc846e-1326-4055-bce6-68366b08f17c.jpg?1",
             "name": "Fabled Passage",
             "text": "",
             "colours": [],
@@ -53793,7 +53793,7 @@
         },
         {
             "id": "96f77a98-a789-537c-9ccb-0cdf1566536e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26abf89e-45c9-4c1d-89c5-749eb3c4d301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26abf89e-45c9-4c1d-89c5-749eb3c4d301.jpg?1",
             "name": "Reflecting Pool",
             "text": "",
             "colours": [],
@@ -53822,7 +53822,7 @@
         },
         {
             "id": "2d4236c4-3da5-5247-8952-b07b732764f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90028340-b9e8-476a-9cf0-b1ed06b1489b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90028340-b9e8-476a-9cf0-b1ed06b1489b.jpg?1",
             "name": "Reflecting Pool",
             "text": "",
             "colours": [],
@@ -53851,7 +53851,7 @@
         },
         {
             "id": "04e86f8e-b385-5027-b13a-55eed8fd14df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7bbf6e-28a9-4ead-9b82-ff6ed4ff89fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae7bbf6e-28a9-4ead-9b82-ff6ed4ff89fb.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -53881,7 +53881,7 @@
         },
         {
             "id": "fa7d7182-1ed5-5a63-b185-0c207ba8ca18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac58084-6404-46bd-bf4e-b99fdacebc19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac58084-6404-46bd-bf4e-b99fdacebc19.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -53911,7 +53911,7 @@
         },
         {
             "id": "c60237f6-6ab7-555a-8389-1f45a7000fd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f02241-b268-43c8-b69e-bf10c8a9b9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f02241-b268-43c8-b69e-bf10c8a9b9ca.jpg?1",
             "name": "Applejack",
             "text": "",
             "colours": [
@@ -53949,7 +53949,7 @@
         },
         {
             "id": "a83c2ac8-710e-59b8-84de-9e29d19aa88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9c0698-aaa3-4aef-b1a6-0963e10cd94b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad9c0698-aaa3-4aef-b1a6-0963e10cd94b.jpg?1",
             "name": "Fluttershy",
             "text": "",
             "colours": [
@@ -53987,7 +53987,7 @@
         },
         {
             "id": "d5180354-0090-5941-a63c-170172277f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790770c-110d-4eb2-b9ae-3aa2bc745a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790770c-110d-4eb2-b9ae-3aa2bc745a9d.jpg?1",
             "name": "Pinkie Pie",
             "text": "",
             "colours": [
@@ -54025,7 +54025,7 @@
         },
         {
             "id": "14e5c636-2934-5ba5-a401-f44d7e284dca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab2cbaa-58c5-4612-8d99-10f5ee5041ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab2cbaa-58c5-4612-8d99-10f5ee5041ee.jpg?1",
             "name": "Rainbow Dash",
             "text": "",
             "colours": [
@@ -54066,7 +54066,7 @@
         },
         {
             "id": "48b8e7c9-1ebe-5a78-a208-f36151158084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg?1",
             "name": "Sakashima of a Thousand Faces // Sakashima of a Thousand Faces",
             "text": "",
             "colours": [
@@ -54103,7 +54103,7 @@
         },
         {
             "id": "04372b77-6c57-5b77-a681-36a0909fba02",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/9/f973a1f3-6dcb-470d-89d2-6ddbf2426999.jpg?1",
             "name": "Sakashima of a Thousand Faces // Sakashima of a Thousand Faces",
             "text": "",
             "colours": [
@@ -54140,7 +54140,7 @@
         },
         {
             "id": "a8c7213a-045d-5d9a-8455-1b412aa3f052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg?1",
             "name": "Yargle, Glutton of Urborg // Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -54177,7 +54177,7 @@
         },
         {
             "id": "3f61bbf9-ff9b-5a76-a9de-503a2148f094",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d002b29b-c3a6-4c91-86e1-96a50ce29966.jpg?1",
             "name": "Yargle, Glutton of Urborg // Yargle, Glutton of Urborg",
             "text": "",
             "colours": [
@@ -54214,7 +54214,7 @@
         },
         {
             "id": "23b7f441-fd4b-57fb-88e1-96d71dba33e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg?1",
             "name": "Krark, the Thumbless // Krark, the Thumbless",
             "text": "",
             "colours": [
@@ -54251,7 +54251,7 @@
         },
         {
             "id": "a051c040-14bc-5de4-95dc-51e0b686168e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67574bb4-c443-40fa-b7e6-05e9965c98b8.jpg?1",
             "name": "Krark, the Thumbless // Krark, the Thumbless",
             "text": "",
             "colours": [
@@ -54288,7 +54288,7 @@
         },
         {
             "id": "369280c8-f34e-5272-8988-2a7cdea40018",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg?1",
             "name": "Adrix and Nev, Twincasters // Adrix and Nev, Twincasters",
             "text": "",
             "colours": [
@@ -54327,7 +54327,7 @@
         },
         {
             "id": "f472b16d-3667-526d-96fc-5d8642ec6ddb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6adadbc9-4a08-4c1d-adf7-edee73799d9e.jpg?1",
             "name": "Adrix and Nev, Twincasters // Adrix and Nev, Twincasters",
             "text": "",
             "colours": [
@@ -54366,7 +54366,7 @@
         },
         {
             "id": "88ad53a0-ca1f-5b90-b46b-151ae5109c1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1535dc66-763b-4b14-bd2e-684a2fc7cdfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1535dc66-763b-4b14-bd2e-684a2fc7cdfb.jpg?1",
             "name": "Arcane Denial",
             "text": "",
             "colours": [
@@ -54399,7 +54399,7 @@
         },
         {
             "id": "c7cc1274-0cd9-52de-b3cb-8116eed6248d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b6268-6253-4b46-a7da-2225e27c9fd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee2b6268-6253-4b46-a7da-2225e27c9fd7.jpg?1",
             "name": "Arcane Denial",
             "text": "",
             "colours": [
@@ -54432,7 +54432,7 @@
         },
         {
             "id": "ab7471b0-1d04-530c-a2a2-8584b84c8bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf313ba7-d031-4dd3-aee0-36f2c4533da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf313ba7-d031-4dd3-aee0-36f2c4533da5.jpg?1",
             "name": "Nightscape Familiar",
             "text": "",
             "colours": [
@@ -54467,7 +54467,7 @@
         },
         {
             "id": "cd601610-6a3e-5958-bbf1-909e36d12e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17558592-2e66-48d3-b38a-3738e5a2a01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17558592-2e66-48d3-b38a-3738e5a2a01f.jpg?1",
             "name": "Nightscape Familiar",
             "text": "",
             "colours": [
@@ -54502,7 +54502,7 @@
         },
         {
             "id": "99a4a94f-768b-50ae-8e64-903a71523a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd39e21d-89cf-4211-8b03-c53e7c48311b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd39e21d-89cf-4211-8b03-c53e7c48311b.jpg?1",
             "name": "Rain of Filth",
             "text": "",
             "colours": [
@@ -54535,7 +54535,7 @@
         },
         {
             "id": "2e0374bf-8167-501b-969f-4458de2dbd47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6143f4dc-3a32-4158-bb74-101810d1528d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6143f4dc-3a32-4158-bb74-101810d1528d.jpg?1",
             "name": "Rain of Filth",
             "text": "",
             "colours": [
@@ -54568,7 +54568,7 @@
         },
         {
             "id": "4262d037-dffa-53a6-9062-9bcf5ac4d84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234b53a3-cf34-46dd-a556-653e2348c5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234b53a3-cf34-46dd-a556-653e2348c5da.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "",
             "colours": [
@@ -54604,7 +54604,7 @@
         },
         {
             "id": "dd65373d-0f4e-591d-86a0-29e9c56fa24a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac2428-87a3-4aea-8c91-a02c0b401469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac2428-87a3-4aea-8c91-a02c0b401469.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "",
             "colours": [
@@ -54640,7 +54640,7 @@
         },
         {
             "id": "5d11e7dc-4ce2-5fea-810d-4ee8d2940a4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c7da42-cd73-443e-9f0e-d6aefe08523a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56c7da42-cd73-443e-9f0e-d6aefe08523a.jpg?1",
             "name": "Prince of Thralls",
             "text": "",
             "colours": [
@@ -54679,7 +54679,7 @@
         },
         {
             "id": "284931c6-27a3-56dc-b123-201a2644fadf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689fbfbc-1eea-4cc0-801b-72305160bf8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/689fbfbc-1eea-4cc0-801b-72305160bf8e.jpg?1",
             "name": "Prince of Thralls",
             "text": "",
             "colours": [
@@ -54718,7 +54718,7 @@
         },
         {
             "id": "c4942bed-2823-537e-8f5f-be3129d08291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -54761,7 +54761,7 @@
         },
         {
             "id": "95142a8f-f792-509a-9692-16e27eaef713",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4a2dd5b-6143-4b8d-ae71-e148cf19b66c.jpg?1",
             "name": "Rin and Seri, Inseparable // Rin and Seri, Inseparable",
             "text": "",
             "colours": [
@@ -54804,7 +54804,7 @@
         },
         {
             "id": "669a3767-8ded-545f-aad6-1bc94c599829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -54847,7 +54847,7 @@
         },
         {
             "id": "944935e8-a39b-587a-97fe-1dc9c7e6022c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/eff6a02b-04ff-48da-b940-d3344134b45d.jpg?1",
             "name": "Jetmir, Nexus of Revels // Jetmir, Nexus of Revels",
             "text": "",
             "colours": [
@@ -54890,7 +54890,7 @@
         },
         {
             "id": "52718cc6-73de-538b-9f29-6dca5e30b36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -54933,7 +54933,7 @@
         },
         {
             "id": "c765b079-5dee-5d7d-930d-37122012aff6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/018830b2-dff9-45f3-9cc2-dc5b2eec0e54.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second // Jinnie Fay, Jetmir's Second",
             "text": "",
             "colours": [
@@ -54976,7 +54976,7 @@
         },
         {
             "id": "d093ee37-6706-57e6-a482-cd1e1a1bce46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bd474-fb4b-4c19-b583-ac2fa2e18475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bd474-fb4b-4c19-b583-ac2fa2e18475.jpg?1",
             "name": "Najeela, the Blade-Blossom",
             "text": "",
             "colours": [
@@ -55019,7 +55019,7 @@
         },
         {
             "id": "205d0b1b-d677-590d-b543-9a4ce117a053",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec569-111d-4c0c-a146-4d043ad27c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbec569-111d-4c0c-a146-4d043ad27c8e.jpg?1",
             "name": "Kelsien, the Plague",
             "text": "",
             "colours": [
@@ -55060,7 +55060,7 @@
         },
         {
             "id": "b00094d8-7e5c-5fea-ba2a-641c39e18a81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b04456-c692-47e1-90d7-53bba320bbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b04456-c692-47e1-90d7-53bba320bbda.jpg?1",
             "name": "Queen Marchesa",
             "text": "",
             "colours": [
@@ -55103,7 +55103,7 @@
         },
         {
             "id": "3ec6e904-e9d8-512a-8307-2c82493eb303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0d2967-b11a-498d-b7be-bef1b6160d9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b0d2967-b11a-498d-b7be-bef1b6160d9a.jpg?1",
             "name": "Ramses, Assassin Lord",
             "text": "",
             "colours": [
@@ -55142,7 +55142,7 @@
         },
         {
             "id": "185a8e42-3a6e-5418-b700-8e99aaf44991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d69040-2065-4975-88d3-60bd32731771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d69040-2065-4975-88d3-60bd32731771.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "",
             "colours": [
@@ -55186,7 +55186,7 @@
         },
         {
             "id": "f5ed76ea-3d67-5cb8-9764-379208fd7309",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d741a56f-c490-4e7f-b1d9-f12f37efdfdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d741a56f-c490-4e7f-b1d9-f12f37efdfdd.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "",
             "colours": [
@@ -55224,7 +55224,7 @@
         },
         {
             "id": "efe14ed4-0f74-5f83-9bb6-963a4385f665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060ed17-779a-49bc-a3b0-bcda89edc4b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b060ed17-779a-49bc-a3b0-bcda89edc4b0.jpg?1",
             "name": "Gonti, Lord of Luxury",
             "text": "",
             "colours": [
@@ -55262,7 +55262,7 @@
         },
         {
             "id": "aa9f0c08-6fe8-5bb7-af5d-07f397a65cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c30638e-d094-4e50-8656-f6980b102781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c30638e-d094-4e50-8656-f6980b102781.jpg?1",
             "name": "Vilis, Broker of Blood",
             "text": "",
             "colours": [
@@ -55299,7 +55299,7 @@
         },
         {
             "id": "08e30b06-d44e-5317-a44e-1ed421bb7afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da866-c6b7-4a12-b442-30e3105b45a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/677da866-c6b7-4a12-b442-30e3105b45a8.jpg?1",
             "name": "Vilis, Broker of Blood",
             "text": "",
             "colours": [
@@ -55336,7 +55336,7 @@
         },
         {
             "id": "6598c204-cc74-5d57-90d0-c9c41ffaf708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41026-4988-44f0-9281-93b3d4905be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b41026-4988-44f0-9281-93b3d4905be9.jpg?1",
             "name": "Anowon, the Ruin Thief",
             "text": "",
             "colours": [
@@ -55376,7 +55376,7 @@
         },
         {
             "id": "58f715e2-9a42-5b51-a479-2b89ddacd872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e39a5ae-de10-4412-8939-97dc40fa24d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e39a5ae-de10-4412-8939-97dc40fa24d4.jpg?1",
             "name": "Anowon, the Ruin Thief",
             "text": "",
             "colours": [
@@ -55416,7 +55416,7 @@
         },
         {
             "id": "029e1904-8130-5b0c-907e-e2659999eb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f09945-6098-4bc5-a9e7-03eb56b18030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43f09945-6098-4bc5-a9e7-03eb56b18030.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "",
             "colours": [
@@ -55456,7 +55456,7 @@
         },
         {
             "id": "72ecab64-2beb-5501-9e0b-ba6cc3992f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d07abd2-e7a2-484a-8c84-931cb85e36a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d07abd2-e7a2-484a-8c84-931cb85e36a0.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "",
             "colours": [
@@ -55496,7 +55496,7 @@
         },
         {
             "id": "60b28963-7722-5ad2-b540-64441d7a6e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f6fec8-2932-456c-91c1-c12d7dd0c31c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94f6fec8-2932-456c-91c1-c12d7dd0c31c.jpg?1",
             "name": "Blade of Selves",
             "text": "",
             "colours": [],
@@ -55526,7 +55526,7 @@
         },
         {
             "id": "a4cca700-47e4-5627-b164-67426d348df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7c2428-a3a9-4498-a743-2cb35fd99403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7c2428-a3a9-4498-a743-2cb35fd99403.jpg?1",
             "name": "Conqueror's Flail",
             "text": "",
             "colours": [],
@@ -55556,7 +55556,7 @@
         },
         {
             "id": "7ae26b49-33e9-539f-8bba-282cff813aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876fb8d6-1ac5-4b3d-a300-2a954000b1cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/876fb8d6-1ac5-4b3d-a300-2a954000b1cb.jpg?1",
             "name": "Darksteel Plate",
             "text": "",
             "colours": [],
@@ -55586,7 +55586,7 @@
         },
         {
             "id": "2d67d858-ae4d-53a6-96fe-030800ca7808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07de695f-aac5-4367-9fdc-3b11740c7f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07de695f-aac5-4367-9fdc-3b11740c7f97.jpg?1",
             "name": "Deathrender",
             "text": "",
             "colours": [],
@@ -55616,7 +55616,7 @@
         },
         {
             "id": "a4cdc839-a7df-50d0-9080-a74870ff3a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a90bb-5ff0-48ec-b578-63ebcf7f1e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a90bb-5ff0-48ec-b578-63ebcf7f1e70.jpg?1",
             "name": "Whispersilk Cloak",
             "text": "",
             "colours": [],
@@ -55646,7 +55646,7 @@
         },
         {
             "id": "ba7b3a9d-2555-576e-bee0-634937d4f9e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214828eb-434c-47ed-b4af-faaa6c784fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214828eb-434c-47ed-b4af-faaa6c784fb4.jpg?1",
             "name": "Reconnaissance",
             "text": "",
             "colours": [
@@ -55679,7 +55679,7 @@
         },
         {
             "id": "41baafcc-8abd-56d7-ba8d-fd8efa8c052f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e15b958-237d-4705-a515-02ab2698d3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e15b958-237d-4705-a515-02ab2698d3bb.jpg?1",
             "name": "Reconnaissance",
             "text": "",
             "colours": [
@@ -55712,7 +55712,7 @@
         },
         {
             "id": "f8543a17-e314-56c7-95d5-27b02a77b568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b2d33b-2689-4d03-b297-a196b376804d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b2d33b-2689-4d03-b297-a196b376804d.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -55750,7 +55750,7 @@
         },
         {
             "id": "ce23be65-ac1b-5b53-97d5-534ad41bc37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f13face-aa33-4f57-ad06-5313b4834e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f13face-aa33-4f57-ad06-5313b4834e02.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -55788,7 +55788,7 @@
         },
         {
             "id": "99716b52-c81a-514e-8385-e52d18964e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9817714-70b2-4e36-ae56-14052a9c12a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9817714-70b2-4e36-ae56-14052a9c12a1.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -55821,7 +55821,7 @@
         },
         {
             "id": "34ae078f-e8a4-5cbd-94ce-90a48df0093c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43937afe-6ec4-4d9c-acf9-0fe0df8ca7b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43937afe-6ec4-4d9c-acf9-0fe0df8ca7b5.jpg?1",
             "name": "Black Market",
             "text": "",
             "colours": [
@@ -55854,7 +55854,7 @@
         },
         {
             "id": "604848f4-6c3f-59ca-af72-01ec99bc0ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfa3947-3c50-4bd2-89cc-e4634858244b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfa3947-3c50-4bd2-89cc-e4634858244b.jpg?1",
             "name": "Dire Undercurrents",
             "text": "",
             "colours": [
@@ -55889,7 +55889,7 @@
         },
         {
             "id": "18bf702f-65e1-51e7-b451-217f52ce4094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0e63c-778e-4749-9a96-a192699904c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c0e63c-778e-4749-9a96-a192699904c5.jpg?1",
             "name": "Dire Undercurrents",
             "text": "",
             "colours": [
@@ -55924,7 +55924,7 @@
         },
         {
             "id": "c162e052-7484-5411-894f-60a038fa027e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4ee119-8d1e-4630-93cc-11339d1f5e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4ee119-8d1e-4630-93cc-11339d1f5e95.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "",
             "colours": [
@@ -55966,7 +55966,7 @@
         },
         {
             "id": "d21e4d29-ac69-59c5-a2d8-abe854a34426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc54001-db2f-4d64-ac7b-99bc5ccea52b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc54001-db2f-4d64-ac7b-99bc5ccea52b.jpg?1",
             "name": "Obeka, Brute Chronologist",
             "text": "",
             "colours": [
@@ -56008,7 +56008,7 @@
         },
         {
             "id": "3beaab38-1eef-57e0-adb4-d69892a3ffb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39edd98a-2ee9-4799-9194-5b5a3efb6255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39edd98a-2ee9-4799-9194-5b5a3efb6255.jpg?1",
             "name": "Rose Noble",
             "text": "",
             "colours": [
@@ -56044,7 +56044,7 @@
         },
         {
             "id": "7f132a3d-e335-5b2f-991f-9112a01c10ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c4cdb-c6f2-4ee8-b5fb-acb59a9931bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366c4cdb-c6f2-4ee8-b5fb-acb59a9931bf.jpg?1",
             "name": "The Meep",
             "text": "",
             "colours": [
@@ -56080,7 +56080,7 @@
         },
         {
             "id": "64f80ee0-c68e-5d7c-a56a-0161d307e577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c9e915-9cee-45c3-96aa-9dfd5a600d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c9e915-9cee-45c3-96aa-9dfd5a600d0a.jpg?1",
             "name": "The Celestial Toymaker",
             "text": "",
             "colours": [
@@ -56121,7 +56121,7 @@
         },
         {
             "id": "03a073d6-b062-536d-af5a-9562980f0861",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a78cf-ee6c-4852-9651-eeaa634daaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a78cf-ee6c-4852-9651-eeaa634daaa1.jpg?1",
             "name": "The Fourteenth Doctor",
             "text": "",
             "colours": [
@@ -56164,7 +56164,7 @@
         },
         {
             "id": "856410e7-026b-5591-9c9a-f13deeca1c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530a26f1-cf7a-4e56-886b-6799b057c739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530a26f1-cf7a-4e56-886b-6799b057c739.jpg?1",
             "name": "The Fifteenth Doctor",
             "text": "",
             "colours": [
@@ -56203,7 +56203,7 @@
         },
         {
             "id": "9ee63fab-29f4-5291-a1de-e42b23a36dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d3a061-03b4-4004-8a6c-4374513de17a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d3a061-03b4-4004-8a6c-4374513de17a.jpg?1",
             "name": "Elspeth Tirel",
             "text": "",
             "colours": [
@@ -56239,7 +56239,7 @@
         },
         {
             "id": "1a8c34cd-8745-57fb-bb94-ccf08573d63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbf4c7-ea2c-413b-8226-6aaa46a44661.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dccbf4c7-ea2c-413b-8226-6aaa46a44661.jpg?1",
             "name": "Shelter",
             "text": "",
             "colours": [
@@ -56272,7 +56272,7 @@
         },
         {
             "id": "60764127-dd30-5e7d-b34a-3767d7093009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c7161a-6168-436a-93de-3010841d5a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c7161a-6168-436a-93de-3010841d5a27.jpg?1",
             "name": "Shelter",
             "text": "",
             "colours": [
@@ -56305,7 +56305,7 @@
         },
         {
             "id": "7bd01195-558e-5af8-906f-382d08d28338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d595f6-7b51-4a4a-acb5-08e12bac6ea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d595f6-7b51-4a4a-acb5-08e12bac6ea7.jpg?1",
             "name": "Jace, Unraveler of Secrets",
             "text": "",
             "colours": [
@@ -56341,7 +56341,7 @@
         },
         {
             "id": "31f4a318-9199-5b73-a8fb-b1b4c0b5f87d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6ba63e-0168-45e4-abf3-f7a5b87a4b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df6ba63e-0168-45e4-abf3-f7a5b87a4b85.jpg?1",
             "name": "Diabolic Tutor",
             "text": "",
             "colours": [
@@ -56375,7 +56375,7 @@
         },
         {
             "id": "840b1c8c-9cd2-5b87-ad3e-6874fab726b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb89c6b9-991a-453f-a787-7fb4c1642737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb89c6b9-991a-453f-a787-7fb4c1642737.jpg?1",
             "name": "Liliana of the Dark Realms",
             "text": "",
             "colours": [
@@ -56413,7 +56413,7 @@
         },
         {
             "id": "4802e51c-287b-5301-b38c-edacaf787aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243b872-c90f-4d25-9d8c-dbbcc8004a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9243b872-c90f-4d25-9d8c-dbbcc8004a48.jpg?1",
             "name": "Chandra's Ignition",
             "text": "",
             "colours": [
@@ -56446,7 +56446,7 @@
         },
         {
             "id": "dfd7bab4-3417-5f1a-bf75-812785cae999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec9ffa6-3f61-448a-a5ab-68eeef29ff45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ec9ffa6-3f61-448a-a5ab-68eeef29ff45.jpg?1",
             "name": "Chandra's Ignition",
             "text": "",
             "colours": [
@@ -56479,7 +56479,7 @@
         },
         {
             "id": "8f1c43c8-cdda-5c84-bc48-84f57f92b128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f009d4a-3b50-40ae-b52e-0b9535049265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f009d4a-3b50-40ae-b52e-0b9535049265.jpg?1",
             "name": "Chord of Calling",
             "text": "",
             "colours": [
@@ -56511,7 +56511,7 @@
         },
         {
             "id": "f395c060-dfc3-5ead-a36f-ce8cfcab6fd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40064484-3ed0-4724-ba51-6bf3b66cc0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40064484-3ed0-4724-ba51-6bf3b66cc0ae.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -56544,7 +56544,7 @@
         },
         {
             "id": "bd8b641a-83d5-5192-873a-375d8386b377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02ef5ff-353f-4874-ab0d-ee3a8a5f9bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02ef5ff-353f-4874-ab0d-ee3a8a5f9bf1.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -56577,7 +56577,7 @@
         },
         {
             "id": "5d2aa40c-fafc-5aff-b7fa-e57b663693bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b25568-46e9-4f4e-a4b5-7f371314e49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b25568-46e9-4f4e-a4b5-7f371314e49e.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "",
             "colours": [
@@ -56616,7 +56616,7 @@
         },
         {
             "id": "2b67ab0a-1879-5093-ba1c-54eb1681c503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f3807-9258-452c-80cc-ad8ef6b6863f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844f3807-9258-452c-80cc-ad8ef6b6863f.jpg?1",
             "name": "Azusa, Lost but Seeking",
             "text": "",
             "colours": [
@@ -56655,7 +56655,7 @@
         },
         {
             "id": "6b8c133b-2357-5dff-a96a-3089ef6b614e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a4035e-e8ec-4be0-8009-666bc7a5dd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a4035e-e8ec-4be0-8009-666bc7a5dd69.jpg?1",
             "name": "Freyalise, Llanowar's Fury",
             "text": "",
             "colours": [
@@ -56691,7 +56691,7 @@
         },
         {
             "id": "4ea48c8d-cfbc-50cd-8b74-9e839e8f0d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906482a9-4b9d-4fc3-a3e5-ac135ed076d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/906482a9-4b9d-4fc3-a3e5-ac135ed076d3.jpg?1",
             "name": "Child of Alara",
             "text": "",
             "colours": [
@@ -56735,7 +56735,7 @@
         },
         {
             "id": "93aaa928-e5a0-5e10-a7f4-49acf686f5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ecf1fd-f963-4bc0-8c01-ef781c14e463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ecf1fd-f963-4bc0-8c01-ef781c14e463.jpg?1",
             "name": "The Royal Scions",
             "text": "",
             "colours": [
@@ -56774,7 +56774,7 @@
         },
         {
             "id": "f138a8b5-fc91-58ec-a7d5-b306d942ff63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97162e95-5cc6-4c83-996c-622bc25e7d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97162e95-5cc6-4c83-996c-622bc25e7d0f.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "",
             "colours": [
@@ -56813,7 +56813,7 @@
         },
         {
             "id": "df7392d0-cf60-5ae2-843e-97323712daa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563fe38-f690-40e9-96a6-6ce333b2cfcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3563fe38-f690-40e9-96a6-6ce333b2cfcc.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "",
             "colours": [
@@ -56852,7 +56852,7 @@
         },
         {
             "id": "607307d3-d622-566f-a084-af71ca892a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd4d0c-1aef-4b76-92e7-ceb7ab9bc5e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76dd4d0c-1aef-4b76-92e7-ceb7ab9bc5e7.jpg?1",
             "name": "Song of Creation",
             "text": "",
             "colours": [
@@ -56888,7 +56888,7 @@
         },
         {
             "id": "0ce7faa6-c766-5d07-bb8f-b32db5216e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b145dd-8529-4bff-b381-b4be53f24b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b145dd-8529-4bff-b381-b4be53f24b54.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -56925,7 +56925,7 @@
         },
         {
             "id": "5143b8a4-00f2-50ca-b098-a9577ecfd9b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d1eb-4d45-4c39-b361-48fcf61d8a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d1eb-4d45-4c39-b361-48fcf61d8a26.jpg?1",
             "name": "Inspiring Vantage",
             "text": "",
             "colours": [],
@@ -56958,7 +56958,7 @@
         },
         {
             "id": "61591b18-3b28-5d03-affb-cb1ca05b616d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71132c-306a-4e37-a34a-777f1028e4a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b71132c-306a-4e37-a34a-777f1028e4a1.jpg?1",
             "name": "Inspiring Vantage",
             "text": "",
             "colours": [],
@@ -56991,7 +56991,7 @@
         },
         {
             "id": "2a56ce98-5979-524a-8ae3-c50d7d2a3115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d618c6b2-6ca2-4584-9926-b1d184c144bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d618c6b2-6ca2-4584-9926-b1d184c144bd.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -57019,7 +57019,7 @@
         },
         {
             "id": "c2e8d3fb-c386-514f-bf38-1cec06143a6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "",
             "colours": [
@@ -57054,7 +57054,7 @@
         },
         {
             "id": "764f6ce3-147a-58cc-9a43-65f4d3bceaac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da5ecf95-b360-4bc6-8706-de350736b7e3.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "",
             "colours": [
@@ -57088,7 +57088,7 @@
         },
         {
             "id": "1931c189-bce5-5c5b-90ed-a3b3da33fc9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d087fc-2fd5-4ce7-bece-b12dea3d300a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d087fc-2fd5-4ce7-bece-b12dea3d300a.jpg?1",
             "name": "Beastmaster Ascension",
             "text": "",
             "colours": [
@@ -57120,7 +57120,7 @@
         },
         {
             "id": "a3071287-8544-5ee1-bd22-ac78ab3af6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f60ebd-4f6b-4562-8dec-d4b4e124cb73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f60ebd-4f6b-4562-8dec-d4b4e124cb73.jpg?1",
             "name": "Howl of the Night Pack",
             "text": "",
             "colours": [
@@ -57152,7 +57152,7 @@
         },
         {
             "id": "a53c2276-715a-57b6-aae6-557e4df917b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7def-59e3-4eef-a571-b97db54ce641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a7def-59e3-4eef-a571-b97db54ce641.jpg?1",
             "name": "Second Harvest",
             "text": "",
             "colours": [
@@ -57184,7 +57184,7 @@
         },
         {
             "id": "74df2ade-09c3-529b-90c0-7be2bba81421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -57223,7 +57223,7 @@
         },
         {
             "id": "cd032078-67e7-5778-92ee-09c9e552284a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54c92a0d-ab6e-45b2-b7a8-e13a5dd4e74e.jpg?1",
             "name": "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge",
             "text": "",
             "colours": [
@@ -57261,7 +57261,7 @@
         },
         {
             "id": "35937fc6-930f-5f67-8bd1-a4a78f2330f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6fd16-a7cd-49cb-bb70-806f8eb622dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d6fd16-a7cd-49cb-bb70-806f8eb622dd.jpg?1",
             "name": "Brash Taunter",
             "text": "",
             "colours": [
@@ -57295,7 +57295,7 @@
         },
         {
             "id": "df6e801b-4a2f-52e6-8f6c-c3583e63bfe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c6c448-13c6-4453-965e-6576035aa738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c6c448-13c6-4453-965e-6576035aa738.jpg?1",
             "name": "Goblin Chieftain",
             "text": "",
             "colours": [
@@ -57329,7 +57329,7 @@
         },
         {
             "id": "de3a8370-785f-5e2c-a1b8-79dc7742f441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba83c0d-f72b-442c-ae30-6cf557bd157d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fba83c0d-f72b-442c-ae30-6cf557bd157d.jpg?1",
             "name": "Goblin Ringleader",
             "text": "",
             "colours": [
@@ -57363,7 +57363,7 @@
         },
         {
             "id": "b6b3df14-fce3-5f7f-bd69-d362b42aedea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427b231-3419-407c-803f-d6bcc37efb1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c427b231-3419-407c-803f-d6bcc37efb1d.jpg?1",
             "name": "Goblin Welder",
             "text": "",
             "colours": [
@@ -57398,7 +57398,7 @@
         },
         {
             "id": "186de077-c8b1-5f29-83e8-9bfa5e5a0d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd170aa1-18be-470e-aa36-bfb11e9f92c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd170aa1-18be-470e-aa36-bfb11e9f92c1.jpg?1",
             "name": "Mogg War Marshal",
             "text": "",
             "colours": [
@@ -57433,7 +57433,7 @@
         },
         {
             "id": "8f75232b-f217-57fa-8c10-465ba182066b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b3d65d-3485-4d82-ba2e-9e2071f284b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b3d65d-3485-4d82-ba2e-9e2071f284b5.jpg?1",
             "name": "Tezzeret the Seeker",
             "text": "",
             "colours": [
@@ -57471,7 +57471,7 @@
         },
         {
             "id": "9bdc6045-4e35-5204-a034-9fdf2dbd6936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61805d7f-382c-46ff-8380-d995fc0b9d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61805d7f-382c-46ff-8380-d995fc0b9d25.jpg?1",
             "name": "Griselbrand",
             "text": "",
             "colours": [
@@ -57510,7 +57510,7 @@
         },
         {
             "id": "eb6848cf-118f-5fb4-af6f-9e0251f8b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6f7f0e-7a0a-42ae-8bc9-c20f62dd3264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6f7f0e-7a0a-42ae-8bc9-c20f62dd3264.jpg?1",
             "name": "Grenzo, Havoc Raiser",
             "text": "",
             "colours": [
@@ -57547,7 +57547,7 @@
         },
         {
             "id": "9c8fba2e-4a09-56d7-ae4a-01705ed8e027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab6843-6bdd-439a-b81c-0be83b8d4c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab6843-6bdd-439a-b81c-0be83b8d4c52.jpg?1",
             "name": "Nicol Bolas, Planeswalker",
             "text": "",
             "colours": [
@@ -57587,7 +57587,7 @@
         },
         {
             "id": "0a13e567-d0cd-5b8a-9e85-7e85133f4e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182dc47c-897e-4922-ba9d-80204bed7b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182dc47c-897e-4922-ba9d-80204bed7b5a.jpg?1",
             "name": "Vorinclex, Voice of Hunger",
             "text": "",
             "colours": [
@@ -57626,7 +57626,7 @@
         },
         {
             "id": "4b1d6253-120d-5d52-b3b7-56b128da213d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03988a88-090d-4daf-bb0a-ca0dabee917f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03988a88-090d-4daf-bb0a-ca0dabee917f.jpg?1",
             "name": "Karona, False God",
             "text": "",
             "colours": [
@@ -57670,7 +57670,7 @@
         },
         {
             "id": "85199f42-dad2-5bd8-913a-e8733f99afae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e2c910-6ada-41f6-b5ea-2dc25167666c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e2c910-6ada-41f6-b5ea-2dc25167666c.jpg?1",
             "name": "Korvold, Fae-Cursed King",
             "text": "",
             "colours": [
@@ -57711,7 +57711,7 @@
         },
         {
             "id": "73aaf059-59ab-554f-9d59-fd5882d8b75f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246b1de7-0b50-4edd-b1a7-fd6856351b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246b1de7-0b50-4edd-b1a7-fd6856351b76.jpg?1",
             "name": "Memnarch",
             "text": "",
             "colours": [],
@@ -57746,7 +57746,7 @@
         },
         {
             "id": "d92ce913-2122-5181-b276-e4e6dd31b9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae26b5-bb60-4138-ab08-740e45455373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae26b5-bb60-4138-ab08-740e45455373.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -57783,7 +57783,7 @@
         },
         {
             "id": "c4100878-b071-5d59-a5eb-cb98428e6611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ace56-18ec-47d8-bfeb-5680912b2ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/802ace56-18ec-47d8-bfeb-5680912b2ec5.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -57820,7 +57820,7 @@
         },
         {
             "id": "9b4ee2a3-2d8d-520f-871a-ed43458f0dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8f7a42-b41e-4065-878a-1f350fd0766a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8f7a42-b41e-4065-878a-1f350fd0766a.jpg?1",
             "name": "Faerie Artisans",
             "text": "",
             "colours": [
@@ -57856,7 +57856,7 @@
         },
         {
             "id": "92a62126-f2cf-52a2-9005-a13e84eaf3e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8cefaa-d005-4b9c-a2b0-90ed97f3157f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8cefaa-d005-4b9c-a2b0-90ed97f3157f.jpg?1",
             "name": "Faerie Artisans",
             "text": "",
             "colours": [
@@ -57892,7 +57892,7 @@
         },
         {
             "id": "5399cf82-bd4e-5ddf-8a6a-c881e081a276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697fcd59-1ad7-439f-8307-abe92c457b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697fcd59-1ad7-439f-8307-abe92c457b05.jpg?1",
             "name": "Dockside Chef",
             "text": "",
             "colours": [
@@ -57929,7 +57929,7 @@
         },
         {
             "id": "9be52081-f89a-55fe-84ec-9104685addae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9692d4-8543-4f76-b9ec-e08240091c50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f9692d4-8543-4f76-b9ec-e08240091c50.jpg?1",
             "name": "Dockside Chef",
             "text": "",
             "colours": [
@@ -57966,7 +57966,7 @@
         },
         {
             "id": "0945c5f2-92da-501c-bbec-da1647b67c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f7528-5162-4454-afa8-9ecb912d7ec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40f7528-5162-4454-afa8-9ecb912d7ec7.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "",
             "colours": [
@@ -58009,7 +58009,7 @@
         },
         {
             "id": "54c96c25-5ef2-5395-a9a7-b17ef4ebff93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a94f62-2060-494b-924a-792b728dcf99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a94f62-2060-494b-924a-792b728dcf99.jpg?1",
             "name": "Alela, Artful Provocateur",
             "text": "",
             "colours": [
@@ -58052,7 +58052,7 @@
         },
         {
             "id": "e1bcf9d2-7f73-56f0-83cd-21fa97207815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d102a60-383c-45f1-ab1b-be0ab9b87332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d102a60-383c-45f1-ab1b-be0ab9b87332.jpg?1",
             "name": "Door of Destinies",
             "text": "",
             "colours": [],
@@ -58081,7 +58081,7 @@
         },
         {
             "id": "09e830c3-6be2-5b98-9746-79e6d83a7ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e714d-cd70-4ba2-b125-1affa6b5d4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323e714d-cd70-4ba2-b125-1affa6b5d4f7.jpg?1",
             "name": "Door of Destinies",
             "text": "",
             "colours": [],
@@ -58110,7 +58110,7 @@
         },
         {
             "id": "f88641dd-eb7c-569f-b3de-b0055fa03e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602f394-2bfa-4383-b1aa-2715cc36683d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a602f394-2bfa-4383-b1aa-2715cc36683d.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "",
             "colours": [
@@ -58143,7 +58143,7 @@
         },
         {
             "id": "5c25289e-a862-5328-b5ec-d5e5badde349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7444fb-1a01-4917-80af-d0be4e9e721e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7444fb-1a01-4917-80af-d0be4e9e721e.jpg?1",
             "name": "Steelshaper's Gift",
             "text": "",
             "colours": [
@@ -58176,7 +58176,7 @@
         },
         {
             "id": "127a6212-24eb-5acf-9d42-ba26c46b7de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8aa419-dc96-4cd7-9e6a-c2d071df98d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8aa419-dc96-4cd7-9e6a-c2d071df98d1.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -58209,7 +58209,7 @@
         },
         {
             "id": "fa9161bb-b485-5b98-a476-9ba010fac3d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040aaf3-1331-4960-8220-22bb2c2591da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e040aaf3-1331-4960-8220-22bb2c2591da.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -58242,7 +58242,7 @@
         },
         {
             "id": "8ce31439-54c2-5e58-aa39-abfec1bc6d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82f79da-7284-444b-9dd2-ee7085b3c589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82f79da-7284-444b-9dd2-ee7085b3c589.jpg?1",
             "name": "Elixir of Immortality",
             "text": "",
             "colours": [],
@@ -58271,7 +58271,7 @@
         },
         {
             "id": "46ae4864-e4ac-5852-b0b1-67e1abc5d1dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efb5f-b8ca-4800-87d8-df3d4270d17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6efb5f-b8ca-4800-87d8-df3d4270d17d.jpg?1",
             "name": "Elixir of Immortality",
             "text": "",
             "colours": [],
@@ -58300,7 +58300,7 @@
         },
         {
             "id": "6498edb2-cbfe-5629-8be8-82a865abaf7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf102ad-f44b-401b-9ba2-c514961b0b91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf102ad-f44b-401b-9ba2-c514961b0b91.jpg?1",
             "name": "Council's Judgment",
             "text": "",
             "colours": [
@@ -58333,7 +58333,7 @@
         },
         {
             "id": "d0425e6b-b592-5341-ad52-0cf49b1b09c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90290ee-2967-4d22-85f3-83b9dcb52ac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90290ee-2967-4d22-85f3-83b9dcb52ac8.jpg?1",
             "name": "Council's Judgment",
             "text": "",
             "colours": [
@@ -58366,7 +58366,7 @@
         },
         {
             "id": "8db9486f-7ca8-595c-b472-05e041b0c3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89855f5-d1de-4bb5-94bf-506fba24f438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d89855f5-d1de-4bb5-94bf-506fba24f438.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -58400,7 +58400,7 @@
         },
         {
             "id": "a71b5be3-5676-513e-af98-d3805af7ea04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359573eb-be80-4c6e-98a0-fd6e6f5f1477.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359573eb-be80-4c6e-98a0-fd6e6f5f1477.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -58434,7 +58434,7 @@
         },
         {
             "id": "438f9189-491e-521d-98da-2f608bccc3e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c8447-40bf-4ec0-8a93-0810ade9ec88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c8447-40bf-4ec0-8a93-0810ade9ec88.jpg?1",
             "name": "Anger",
             "text": "",
             "colours": [
@@ -58469,7 +58469,7 @@
         },
         {
             "id": "d0fed492-3c1c-5037-980b-d2a17c3a7787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0fb1-58c0-45f6-84ae-a413bd029b74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0fb1-58c0-45f6-84ae-a413bd029b74.jpg?1",
             "name": "Anger",
             "text": "",
             "colours": [
@@ -58504,7 +58504,7 @@
         },
         {
             "id": "94a799db-acfa-5331-a678-5ce13a0c8499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43c378-9e6a-4ece-9c24-5dc08c977746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f43c378-9e6a-4ece-9c24-5dc08c977746.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -58545,7 +58545,7 @@
         },
         {
             "id": "19765667-ab55-5eb2-8453-ab52a6c4b8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54199d7c-02f8-4ff0-9e43-e7bf66ef9715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54199d7c-02f8-4ff0-9e43-e7bf66ef9715.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -58586,7 +58586,7 @@
         },
         {
             "id": "9e47a88d-2bc0-5c20-bb38-505f425ae91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887d320-2c65-4295-bd6e-9e49eb1bc2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5887d320-2c65-4295-bd6e-9e49eb1bc2e6.jpg?1",
             "name": "Inalla, Archmage Ritualist",
             "text": "",
             "colours": [
@@ -58628,7 +58628,7 @@
         },
         {
             "id": "5d0ac569-0ab0-5f6b-b72c-27159a140b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e28fbc7-b74b-4828-a0e9-08e98cdb5a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e28fbc7-b74b-4828-a0e9-08e98cdb5a92.jpg?1",
             "name": "Inalla, Archmage Ritualist",
             "text": "",
             "colours": [
@@ -58670,7 +58670,7 @@
         },
         {
             "id": "0167f5e6-af71-5d5b-9a8c-c9f92812ab01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6151f39-966e-4af6-a20a-d761781abed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6151f39-966e-4af6-a20a-d761781abed9.jpg?1",
             "name": "Aether Vial",
             "text": "",
             "colours": [],
@@ -58699,7 +58699,7 @@
         },
         {
             "id": "2313830e-9020-5c9f-9d8a-5d36f81401e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641c238d-e14a-41cc-bb5c-ad3993406d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/641c238d-e14a-41cc-bb5c-ad3993406d4b.jpg?1",
             "name": "Aether Vial",
             "text": "",
             "colours": [],
@@ -58728,7 +58728,7 @@
         },
         {
             "id": "5f713c7d-0d41-5e1a-a1a9-6d612c4f2f6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed972e99-c563-4da7-a60a-895949d5f032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed972e99-c563-4da7-a60a-895949d5f032.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -58764,7 +58764,7 @@
         },
         {
             "id": "2c8618da-8fec-5de7-b92d-76821edfb3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36333600-7c9c-4dc2-ba5a-dacd039716ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36333600-7c9c-4dc2-ba5a-dacd039716ea.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -58800,7 +58800,7 @@
         },
         {
             "id": "b0472839-79c7-52ad-b89a-f203e8c295ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285e4f85-c54b-4dda-9b59-fca7a2626671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285e4f85-c54b-4dda-9b59-fca7a2626671.jpg?1",
             "name": "Sword of the Animist",
             "text": "",
             "colours": [],
@@ -58833,7 +58833,7 @@
         },
         {
             "id": "8c63f5e0-858a-5465-abcc-7a81314d4a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20bca1-1f4b-47d6-8e37-b71c98d3e539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20bca1-1f4b-47d6-8e37-b71c98d3e539.jpg?1",
             "name": "Sword of the Animist",
             "text": "",
             "colours": [],
@@ -58866,7 +58866,7 @@
         },
         {
             "id": "531309e0-1d7c-5db1-8ab1-3f32105f1489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814dd29f-439b-4e0b-94a8-b57a1f9ef251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/814dd29f-439b-4e0b-94a8-b57a1f9ef251.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "",
             "colours": [
@@ -58903,7 +58903,7 @@
         },
         {
             "id": "f348a73a-fc31-5b87-a70b-034b47f60c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ba5374-5d70-4300-9f4f-bedac5150cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ba5374-5d70-4300-9f4f-bedac5150cd7.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "",
             "colours": [
@@ -58940,7 +58940,7 @@
         },
         {
             "id": "aefe0456-f29b-5279-b1fb-2829b1be1424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a956ab72-6abd-48f5-863d-7f8b39caf8fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a956ab72-6abd-48f5-863d-7f8b39caf8fd.jpg?1",
             "name": "Aura Shards",
             "text": "",
             "colours": [
@@ -58975,7 +58975,7 @@
         },
         {
             "id": "3a0afa52-87a2-5fef-9e97-d30efc8073dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e737c6c5-7fdc-44fa-9fa6-27b1e34fea7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e737c6c5-7fdc-44fa-9fa6-27b1e34fea7a.jpg?1",
             "name": "Aura Shards",
             "text": "",
             "colours": [
@@ -59010,7 +59010,7 @@
         },
         {
             "id": "8f3f9987-7752-5288-b7d1-98dd5462ef47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681a8036-7eea-4408-887b-a4efcee46124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681a8036-7eea-4408-887b-a4efcee46124.jpg?1",
             "name": "Fiend Artisan",
             "text": "",
             "colours": [
@@ -59047,7 +59047,7 @@
         },
         {
             "id": "1aae9cbf-40be-5fa3-8bed-440a9522b6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25efaa39-fd86-4aef-9309-60b9a864042f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25efaa39-fd86-4aef-9309-60b9a864042f.jpg?1",
             "name": "Fiend Artisan",
             "text": "",
             "colours": [
@@ -59084,7 +59084,7 @@
         },
         {
             "id": "5b196ef0-1fa5-5b0a-887f-04d5fa656fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c718f2-b7a2-4d3d-b5de-629347e6a45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c718f2-b7a2-4d3d-b5de-629347e6a45b.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "",
             "colours": [
@@ -59126,7 +59126,7 @@
         },
         {
             "id": "9c9fe773-e821-5689-8da0-1aa03e878131",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9317408a-374e-4b9c-b438-01618ded2cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9317408a-374e-4b9c-b438-01618ded2cbc.jpg?1",
             "name": "Karador, Ghost Chieftain",
             "text": "",
             "colours": [
@@ -59168,7 +59168,7 @@
         },
         {
             "id": "562c1bae-50be-53d2-b581-46c52ae34af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bccd95-0703-4755-8f31-bd8ab615bd04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5bccd95-0703-4755-8f31-bd8ab615bd04.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -59237,7 +59237,7 @@
         },
         {
             "id": "b5f49c02-32eb-58c9-899f-29595861afa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b7f1bb-b47d-4096-b17a-db0587f566c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3b7f1bb-b47d-4096-b17a-db0587f566c6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -59302,7 +59302,7 @@
         },
         {
             "id": "9959d5e9-b8db-5402-9692-a8e40b408d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c70db5a-3d7f-4534-9e5a-01d510b8d62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c70db5a-3d7f-4534-9e5a-01d510b8d62a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -59366,7 +59366,7 @@
         },
         {
             "id": "53227708-e57e-5c2b-8356-273725be1bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603114eb-c0eb-4734-87e6-7fc94beda3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603114eb-c0eb-4734-87e6-7fc94beda3c7.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -59440,7 +59440,7 @@
         },
         {
             "id": "80de5aa3-f175-59f4-9961-a10ef0d3362c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da462ed3-c8f5-409e-bdc8-53e36a4961dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da462ed3-c8f5-409e-bdc8-53e36a4961dd.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -59505,7 +59505,7 @@
         },
         {
             "id": "2ce0dea0-d732-54d5-945d-779492ac8923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81973f-c7a8-4855-affe-6a65b7f88406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd81973f-c7a8-4855-affe-6a65b7f88406.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -59574,7 +59574,7 @@
         },
         {
             "id": "89ee6746-e0dc-5434-9ecf-106d8ee345c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d03913-c905-439c-a603-7d7fae6b9cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d03913-c905-439c-a603-7d7fae6b9cd9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -59639,7 +59639,7 @@
         },
         {
             "id": "ca94aaf6-5448-5371-9722-3dc83db1f81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4187a894-1a26-43ec-8e38-5422ae7e6b9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4187a894-1a26-43ec-8e38-5422ae7e6b9b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -59703,7 +59703,7 @@
         },
         {
             "id": "5ef6526f-5767-5947-b7f5-929d0976bc7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf928c4-c8ee-479c-88df-d6bb35e0778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf928c4-c8ee-479c-88df-d6bb35e0778a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -59777,7 +59777,7 @@
         },
         {
             "id": "71cd86a2-5866-522b-90c4-620a565cf3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaa22a-d679-48ef-805a-d09d6f1091aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbaa22a-d679-48ef-805a-d09d6f1091aa.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -59842,7 +59842,7 @@
         },
         {
             "id": "d369368b-3929-5d8a-94b7-1b9e82d26783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb064da-aba8-445c-bde7-e0f2172b3176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb064da-aba8-445c-bde7-e0f2172b3176.jpg?1",
             "name": "Consecrated Sphinx",
             "text": "",
             "colours": [
@@ -59878,7 +59878,7 @@
         },
         {
             "id": "d52abb54-dab2-5015-8da9-4df8619c707e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a209ed7c-132c-47ac-9210-d951d2f9e0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a209ed7c-132c-47ac-9210-d951d2f9e0a3.jpg?1",
             "name": "Chaotic Goo",
             "text": "",
             "colours": [
@@ -59912,7 +59912,7 @@
         },
         {
             "id": "b460b4a1-1576-5529-87a9-70bd8dece0e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4694a-ac36-497c-a3f4-09d3f69939fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec4694a-ac36-497c-a3f4-09d3f69939fe.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "",
             "colours": [
@@ -59949,7 +59949,7 @@
         },
         {
             "id": "9801f73f-747f-5c21-b386-b5c62085b0f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32758999-b0f1-4acc-b59a-ead3dce27724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32758999-b0f1-4acc-b59a-ead3dce27724.jpg?1",
             "name": "Meteor Golem",
             "text": "",
             "colours": [],
@@ -59982,7 +59982,7 @@
         },
         {
             "id": "78dd3226-9dc8-57c0-beb7-8620b9958b63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc01aa1-55f3-4557-a5b0-734f3b9ed050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc01aa1-55f3-4557-a5b0-734f3b9ed050.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "",
             "colours": [],
@@ -60014,7 +60014,7 @@
         },
         {
             "id": "a74e76a4-8384-542d-b940-68525579fc81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202a98ec-3ce9-47c6-8f8e-cd421e71631d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202a98ec-3ce9-47c6-8f8e-cd421e71631d.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -60048,7 +60048,7 @@
         },
         {
             "id": "f4e8eb53-2212-5f67-9b24-c44c25a5a2d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc351e-2711-48f1-8301-183d70b046d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc351e-2711-48f1-8301-183d70b046d1.jpg?1",
             "name": "Skullclamp",
             "text": "",
             "colours": [],
@@ -60080,7 +60080,7 @@
         },
         {
             "id": "ceafab64-4789-5a39-93b8-f53a4f631d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fe249-9bda-462b-922c-f01c904c233a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b9fe249-9bda-462b-922c-f01c904c233a.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -60117,7 +60117,7 @@
         },
         {
             "id": "5b294965-b7e0-569b-9ec5-16e2e0dff789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f49a899-e549-48c1-85c5-766fda0ecf03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f49a899-e549-48c1-85c5-766fda0ecf03.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -60148,7 +60148,7 @@
         },
         {
             "id": "96cba9e7-8106-5308-a0bd-96544d991078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec750874-33fb-44d6-915e-ba0ece9bef74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec750874-33fb-44d6-915e-ba0ece9bef74.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -60187,7 +60187,7 @@
         },
         {
             "id": "b1d7bb98-49be-507a-a027-e104974de924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7993b049-09d8-4c1a-9455-bb092249e0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7993b049-09d8-4c1a-9455-bb092249e0b6.jpg?1",
             "name": "Aetherize",
             "text": "",
             "colours": [
@@ -60219,7 +60219,7 @@
         },
         {
             "id": "611e0130-8270-5d99-94ed-f9857e41ae50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c5562d-a3d2-4241-92f0-8d021106819a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c5562d-a3d2-4241-92f0-8d021106819a.jpg?1",
             "name": "Drown in Dreams",
             "text": "",
             "colours": [
@@ -60251,7 +60251,7 @@
         },
         {
             "id": "e4cda4c7-ad4b-5340-ba01-beeaad76f02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac21208-eeab-49db-bd55-d2f2fad40c2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac21208-eeab-49db-bd55-d2f2fad40c2a.jpg?1",
             "name": "Psychic Corrosion",
             "text": "",
             "colours": [
@@ -60283,7 +60283,7 @@
         },
         {
             "id": "6f56ae96-0f5c-5fd0-8d53-b6be1b5fe104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75829dd7-b694-4818-8f93-f66f4b1a81c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75829dd7-b694-4818-8f93-f66f4b1a81c4.jpg?1",
             "name": "Visions of Beyond",
             "text": "",
             "colours": [
@@ -60315,7 +60315,7 @@
         },
         {
             "id": "b7ff5c77-596a-56ca-b380-51a61d538cb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384a1033-bf43-44d7-8d82-d61fc6c2d65a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384a1033-bf43-44d7-8d82-d61fc6c2d65a.jpg?1",
             "name": "Time Sieve",
             "text": "",
             "colours": [
@@ -60349,7 +60349,7 @@
         },
         {
             "id": "8c78297c-00b2-5413-b5bc-bbeff7610f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bce5aeb-0087-4ac6-96d2-6b3df55e4266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bce5aeb-0087-4ac6-96d2-6b3df55e4266.jpg?1",
             "name": "Prodigal Sorcerer",
             "text": "",
             "colours": [
@@ -60384,7 +60384,7 @@
         },
         {
             "id": "d95eb35e-84e7-5982-ae58-8d1a807131bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06ef600-51a0-48e7-b19b-0b15b3e6fc69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06ef600-51a0-48e7-b19b-0b15b3e6fc69.jpg?1",
             "name": "Buried Alive",
             "text": "",
             "colours": [
@@ -60416,7 +60416,7 @@
         },
         {
             "id": "cf205fec-95fc-5a8a-8b8b-e3e0d9808780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1aff-9d0d-4003-84e9-3b63bd4e4fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317f1aff-9d0d-4003-84e9-3b63bd4e4fae.jpg?1",
             "name": "Dismember",
             "text": "",
             "colours": [
@@ -60450,7 +60450,7 @@
         },
         {
             "id": "7e4065c7-6741-521b-968f-8c0ed4322e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg?1",
             "name": "Birds of Paradise // Birds of Paradise",
             "text": "",
             "colours": [
@@ -60484,7 +60484,7 @@
         },
         {
             "id": "8254af3f-befb-5d82-b8d4-ad95bc0ff52f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/dae8751c-4c72-4034-a192-a1e166f20246.jpg?1",
             "name": "Birds of Paradise // Birds of Paradise",
             "text": "",
             "colours": [
@@ -60518,7 +60518,7 @@
         },
         {
             "id": "e4125f56-30c0-56f5-b333-0cdf53baac73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e40ddc-0483-4a2e-a776-807b37bada7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e40ddc-0483-4a2e-a776-807b37bada7f.jpg?1",
             "name": "Three Visits",
             "text": "",
             "colours": [
@@ -60550,7 +60550,7 @@
         },
         {
             "id": "6c719ea0-8b87-5286-a25b-187a192682d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b688b165-5783-47e3-94d6-56d4690171bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b688b165-5783-47e3-94d6-56d4690171bd.jpg?1",
             "name": "Door to Nothingness",
             "text": "",
             "colours": [],
@@ -60584,7 +60584,7 @@
         },
         {
             "id": "fd795a6a-a4bb-5a08-a811-a4e7c03c91a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe96fe60-f251-403c-acd1-d658a1d0c930.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe96fe60-f251-403c-acd1-d658a1d0c930.jpg?1",
             "name": "Ashnod's Altar",
             "text": "",
             "colours": [],
@@ -60612,7 +60612,7 @@
         },
         {
             "id": "eb863054-26d0-5930-acab-5450362fc1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea979ce3-5ac3-4ca1-a28c-aa6071c32616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea979ce3-5ac3-4ca1-a28c-aa6071c32616.jpg?1",
             "name": "Dark Depths",
             "text": "",
             "colours": [],
@@ -60643,7 +60643,7 @@
         },
         {
             "id": "d893a284-4617-5d96-8bca-956667b619d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b899c29e-d1b5-4fba-8a48-073d5c303c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b899c29e-d1b5-4fba-8a48-073d5c303c27.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "",
             "colours": [
@@ -60678,7 +60678,7 @@
         },
         {
             "id": "f001ea09-7814-53a9-84ed-20601347af67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfdc564-51cc-4523-9d84-9d07907f41fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bfdc564-51cc-4523-9d84-9d07907f41fe.jpg?1",
             "name": "Orvar, the All-Form",
             "text": "",
             "colours": [
@@ -60713,7 +60713,7 @@
         },
         {
             "id": "fb084450-6df0-5f6a-9ece-b68481a028c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99645cf7-fd27-487b-949a-cf9f86d43947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99645cf7-fd27-487b-949a-cf9f86d43947.jpg?1",
             "name": "Drana, the Last Bloodchief",
             "text": "",
             "colours": [
@@ -60749,7 +60749,7 @@
         },
         {
             "id": "21c52894-c200-51f9-b099-33b810a5ed07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96ef600-a96c-4563-bc4e-157ea62d14d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96ef600-a96c-4563-bc4e-157ea62d14d4.jpg?1",
             "name": "Lavinia, Azorius Renegade",
             "text": "",
             "colours": [
@@ -60787,7 +60787,7 @@
         },
         {
             "id": "67d2dfd2-cbe3-585a-a3b2-ccbdc3820809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ad6aa-61c2-440c-a911-2c1bd7a63bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20ad6aa-61c2-440c-a911-2c1bd7a63bc1.jpg?1",
             "name": "Omnath, Locus of Creation",
             "text": "",
             "colours": [
@@ -60828,7 +60828,7 @@
         },
         {
             "id": "b794c687-800a-5131-9bd0-41124078c725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89dbc5d-1299-4dad-bb3c-c3160cdf8a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89dbc5d-1299-4dad-bb3c-c3160cdf8a0c.jpg?1",
             "name": "Kalitas, Traitor of Ghet",
             "text": "",
             "colours": [
@@ -60865,7 +60865,7 @@
         },
         {
             "id": "4c4db020-d85e-5426-bd61-a15af5d456f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f229b2-5246-4399-8468-eb030842a17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f229b2-5246-4399-8468-eb030842a17b.jpg?1",
             "name": "Magda, Brazen Outlaw",
             "text": "",
             "colours": [
@@ -60902,7 +60902,7 @@
         },
         {
             "id": "1d266bb8-7951-5ecc-ba30-c018845921a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b14e33d-2c01-49be-b03b-d08aea900f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b14e33d-2c01-49be-b03b-d08aea900f50.jpg?1",
             "name": "Dack Fayden",
             "text": "",
             "colours": [
@@ -60942,7 +60942,7 @@
         },
         {
             "id": "de74047c-81e6-5840-8e12-93f561a74033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c717062-7a4e-4231-9fb3-2c04a750a685.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c717062-7a4e-4231-9fb3-2c04a750a685.jpg?1",
             "name": "Greasefang, Okiba Boss",
             "text": "",
             "colours": [
@@ -60981,7 +60981,7 @@
         },
         {
             "id": "5919800a-fb63-5178-9c6c-9d12d5b9fc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7210c3a-bbd3-4f3a-933b-a5618a4f7a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7210c3a-bbd3-4f3a-933b-a5618a4f7a52.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -61015,7 +61015,7 @@
         },
         {
             "id": "05d725d6-74ab-5b23-8785-5c455323dcd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f999f30-df29-4b60-9415-ef7c4fbd5d77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f999f30-df29-4b60-9415-ef7c4fbd5d77.jpg?1",
             "name": "Eladamri's Vineyard",
             "text": "",
             "colours": [
@@ -61047,7 +61047,7 @@
         },
         {
             "id": "ec0ba6a3-526a-53a3-8883-45201041e51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935e21d-f20c-4f73-92b6-e2e2ea8841af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f935e21d-f20c-4f73-92b6-e2e2ea8841af.jpg?1",
             "name": "Greater Good",
             "text": "",
             "colours": [
@@ -61081,7 +61081,7 @@
         },
         {
             "id": "0e12c1e2-fd02-5f70-8476-9d1bbf934a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c442af6a-8f9c-466f-815c-f7890caff0d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c442af6a-8f9c-466f-815c-f7890caff0d0.jpg?1",
             "name": "Inkshield",
             "text": "",
             "colours": [
@@ -61115,7 +61115,7 @@
         },
         {
             "id": "bdef6cb7-8e46-5e31-83e4-2274aee4b8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebe58a3-ba3f-451e-b834-30e71f071861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ebe58a3-ba3f-451e-b834-30e71f071861.jpg?1",
             "name": "Ruhan of the Fomori",
             "text": "",
             "colours": [
@@ -61156,7 +61156,7 @@
         },
         {
             "id": "cd84cfd2-c24c-5cb3-a6cd-21c86694e1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d698bdd-b485-409d-b03e-c7c7d3fe9a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d698bdd-b485-409d-b03e-c7c7d3fe9a92.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -61193,7 +61193,7 @@
         },
         {
             "id": "8dcdfb83-896c-541d-8d12-846a6c67c7ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37309cf-8b80-402b-9d29-fe5de56ced38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37309cf-8b80-402b-9d29-fe5de56ced38.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -61232,7 +61232,7 @@
         },
         {
             "id": "7be26781-b801-5807-af36-fb7634336e9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f502f4-0295-40de-8ffe-48f23d72006c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f502f4-0295-40de-8ffe-48f23d72006c.jpg?1",
             "name": "Sorin Markov",
             "text": "",
             "colours": [
@@ -61268,7 +61268,7 @@
         },
         {
             "id": "ae39ee35-41bb-5310-8822-b6ceb67e2667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e9d584-2a61-4966-b2c1-f22e0dd94de6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e9d584-2a61-4966-b2c1-f22e0dd94de6.jpg?1",
             "name": "Huatli, Radiant Champion",
             "text": "",
             "colours": [
@@ -61306,7 +61306,7 @@
         },
         {
             "id": "0ab0352d-29ef-5b23-9dcb-336313281663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe59ce-b4f3-44ff-9972-44c0549cb9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ffe59ce-b4f3-44ff-9972-44c0549cb9eb.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "",
             "colours": [
@@ -61346,7 +61346,7 @@
         },
         {
             "id": "804dd017-10fe-5a86-8873-edb026ed466f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf29f1d-b30e-4c5b-a581-a0386d75ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf29f1d-b30e-4c5b-a581-a0386d75ebe1.jpg?1",
             "name": "Tezzeret, Master of the Bridge",
             "text": "",
             "colours": [
@@ -61384,7 +61384,7 @@
         },
         {
             "id": "a629afff-ac05-5ccd-b451-313a85c5722c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d8d96-5d5c-4549-87df-458fc43e4444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35d8d96-5d5c-4549-87df-458fc43e4444.jpg?1",
             "name": "Vraska, Golgari Queen",
             "text": "",
             "colours": [
@@ -61424,7 +61424,7 @@
         },
         {
             "id": "aa0980e2-7e8e-5cb6-a3c4-4e078e04ac6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41e21ba-0165-41a7-acbf-9bcaf3095e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41e21ba-0165-41a7-acbf-9bcaf3095e03.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "",
             "colours": [
@@ -61461,7 +61461,7 @@
         },
         {
             "id": "a86fc080-e5cb-5398-ba09-dbe5fd7b01fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697cba66-1d06-4c8b-bb82-0adc4a73d295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/697cba66-1d06-4c8b-bb82-0adc4a73d295.jpg?1",
             "name": "Coffin Queen",
             "text": "",
             "colours": [
@@ -61496,7 +61496,7 @@
         },
         {
             "id": "d89debde-dec9-5078-8a38-a63031fa9fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac38d90-1269-4884-a301-4664d69f1e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac38d90-1269-4884-a301-4664d69f1e8f.jpg?1",
             "name": "Goblin King",
             "text": "",
             "colours": [
@@ -61532,7 +61532,7 @@
         },
         {
             "id": "88d899c6-72fa-5c67-a6c4-e292178a2209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7c8626-3c82-43f1-98a7-db165b30cf3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7c8626-3c82-43f1-98a7-db165b30cf3b.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "",
             "colours": [
@@ -61567,7 +61567,7 @@
         },
         {
             "id": "c8b5ee29-a83a-53db-8146-6c563147ef5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97776800-5647-4d24-9870-72aeb355926a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97776800-5647-4d24-9870-72aeb355926a.jpg?1",
             "name": "Rankle, Master of Pranks",
             "text": "",
             "colours": [
@@ -61604,7 +61604,7 @@
         },
         {
             "id": "44a6a706-8216-5cfc-8787-6de72e9e7090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e883f62-57de-4005-a937-27d0809ca04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e883f62-57de-4005-a937-27d0809ca04a.jpg?1",
             "name": "Soul Warden",
             "text": "",
             "colours": [
@@ -61639,7 +61639,7 @@
         },
         {
             "id": "5ba4e056-c34a-5a46-ad8a-9c726b9ce675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda24b2-a9ab-4aca-8bbf-1bfb0990f68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bda24b2-a9ab-4aca-8bbf-1bfb0990f68f.jpg?1",
             "name": "Shivan Dragon",
             "text": "",
             "colours": [
@@ -61675,7 +61675,7 @@
         },
         {
             "id": "fff5a9bb-378b-5946-b906-e0623403d488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90438697-02be-4bb4-8ef3-8536c4fb0446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90438697-02be-4bb4-8ef3-8536c4fb0446.jpg?1",
             "name": "Elves of Deep Shadow",
             "text": "",
             "colours": [
@@ -61711,7 +61711,7 @@
         },
         {
             "id": "6828e5e8-55ae-5e4b-a4cb-44d4189e800a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a633f22-eae1-4fba-b81f-d79125ac88ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a633f22-eae1-4fba-b81f-d79125ac88ca.jpg?1",
             "name": "Good-Fortune Unicorn",
             "text": "",
             "colours": [
@@ -61747,7 +61747,7 @@
         },
         {
             "id": "a3a4da9a-b7a7-545e-8886-9abc4f874e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0359f9-b9da-46fe-a1bb-2fa8319792d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0359f9-b9da-46fe-a1bb-2fa8319792d0.jpg?1",
             "name": "Coat of Arms",
             "text": "",
             "colours": [],
@@ -61775,7 +61775,7 @@
         },
         {
             "id": "77be5ca7-3f0b-50fd-af1d-b8ec425cada4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93789500-bcc5-40b0-991d-84d17cef95a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93789500-bcc5-40b0-991d-84d17cef95a6.jpg?1",
             "name": "Dictate of Erebos",
             "text": "",
             "colours": [
@@ -61807,7 +61807,7 @@
         },
         {
             "id": "e1e1b702-9d64-5272-8fa2-f89fa5cf4402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c402380-2de7-4a47-993e-c365dc104dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c402380-2de7-4a47-993e-c365dc104dad.jpg?1",
             "name": "Fecundity",
             "text": "",
             "colours": [
@@ -61839,7 +61839,7 @@
         },
         {
             "id": "8d4e4b2d-8674-542a-83d8-e36fff2d480d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e5c8cb-ef19-499e-b428-00dfb5e75b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92e5c8cb-ef19-499e-b428-00dfb5e75b4f.jpg?1",
             "name": "Mayhem Devil",
             "text": "",
             "colours": [
@@ -61875,7 +61875,7 @@
         },
         {
             "id": "5ad955be-ca35-5965-80d8-663d91fc9884",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68dd98c-8b89-4b5d-88fb-498c13d6a191.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c68dd98c-8b89-4b5d-88fb-498c13d6a191.jpg?1",
             "name": "Moldervine Reclamation",
             "text": "",
             "colours": [
@@ -61909,7 +61909,7 @@
         },
         {
             "id": "c50994c1-15fa-5b01-a3a3-749084e862cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd0ab9-ac1b-48bd-8304-2c15bdbd7bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebd0ab9-ac1b-48bd-8304-2c15bdbd7bf5.jpg?1",
             "name": "Prossh, Skyraider of Kher",
             "text": "",
             "colours": [
@@ -61949,7 +61949,7 @@
         },
         {
             "id": "5a149b7c-9906-5af6-a890-434df3550f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0dbb1c-ae8e-4f40-b7b4-016fea692da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de0dbb1c-ae8e-4f40-b7b4-016fea692da9.jpg?1",
             "name": "Back to Basics",
             "text": "",
             "colours": [
@@ -61981,7 +61981,7 @@
         },
         {
             "id": "3f2bb7c9-47d8-5f9e-9448-b04bda4fa17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a125806c-a837-4220-bd05-083e00b1638d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a125806c-a837-4220-bd05-083e00b1638d.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -62015,7 +62015,7 @@
         },
         {
             "id": "4f61f4d6-d5a2-5095-ab48-ebc361d5fdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0ca3bd-da1d-46ce-843a-cc583b3ecda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0ca3bd-da1d-46ce-843a-cc583b3ecda9.jpg?1",
             "name": "Sphinx of the Second Sun",
             "text": "",
             "colours": [
@@ -62049,7 +62049,7 @@
         },
         {
             "id": "c6d3824c-9fee-5a6a-8535-9a1c27cbefda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db5492c-dc2d-4a06-ae97-f03669b88fb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0db5492c-dc2d-4a06-ae97-f03669b88fb0.jpg?1",
             "name": "Teferi's Ageless Insight",
             "text": "",
             "colours": [
@@ -62083,7 +62083,7 @@
         },
         {
             "id": "b7d04774-7205-5730-9447-28fe16ba318f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba7e9c8-c24c-4bd3-b398-fe42b1fcfb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba7e9c8-c24c-4bd3-b398-fe42b1fcfb5d.jpg?1",
             "name": "Captain America, First Avenger",
             "text": "",
             "colours": [
@@ -62125,7 +62125,7 @@
         },
         {
             "id": "28c0eb7e-efed-5fbc-ad82-feece83bb3b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e6040-84a1-42fe-8537-a000b4cb902f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e6040-84a1-42fe-8537-a000b4cb902f.jpg?1",
             "name": "Sigarda's Aid",
             "text": "",
             "colours": [
@@ -62159,7 +62159,7 @@
         },
         {
             "id": "4cfcc2a8-74a6-5dfc-94f5-c549dac53738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becd6a66-51b5-4ef1-a8a4-f65343bda3f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/becd6a66-51b5-4ef1-a8a4-f65343bda3f8.jpg?1",
             "name": "Flawless Maneuver",
             "text": "",
             "colours": [
@@ -62191,7 +62191,7 @@
         },
         {
             "id": "7b715e9e-8876-5d90-8f81-6c81690eece6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee77da5-3e96-42fc-84ce-7ec9bc28595f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee77da5-3e96-42fc-84ce-7ec9bc28595f.jpg?1",
             "name": "In the Trenches",
             "text": "",
             "colours": [
@@ -62223,7 +62223,7 @@
         },
         {
             "id": "9aef52ef-eff5-5ca2-a1ba-a2a2860b3c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429e4523-5b11-40dc-83cb-2c8cc26a675f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/429e4523-5b11-40dc-83cb-2c8cc26a675f.jpg?1",
             "name": "Sword of War and Peace",
             "text": "",
             "colours": [],
@@ -62253,7 +62253,7 @@
         },
         {
             "id": "959bb6b3-3374-52b4-be77-bb41ec5f44f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7542b1d1-e34d-46dc-af24-1b718034c0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7542b1d1-e34d-46dc-af24-1b718034c0e4.jpg?1",
             "name": "Iron Man, Titan of Innovation",
             "text": "",
             "colours": [
@@ -62293,7 +62293,7 @@
         },
         {
             "id": "8437c844-0d9f-52d2-9ad8-be8c688ffbe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b739607d-0d29-4d29-a926-f8dcb661738c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b739607d-0d29-4d29-a926-f8dcb661738c.jpg?1",
             "name": "Galvanic Blast",
             "text": "",
             "colours": [
@@ -62325,7 +62325,7 @@
         },
         {
             "id": "12279d27-94ee-57cc-a1ca-fd9b912352b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228abefc-9f64-4d64-ad58-41b0201eb82e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228abefc-9f64-4d64-ad58-41b0201eb82e.jpg?1",
             "name": "Commander's Plate",
             "text": "",
             "colours": [],
@@ -62357,7 +62357,7 @@
         },
         {
             "id": "b1ec8286-13b2-5b02-9f25-bb8ba5c13f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2824f3fb-82e6-43bd-babf-da6777a5b075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2824f3fb-82e6-43bd-babf-da6777a5b075.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -62394,7 +62394,7 @@
         },
         {
             "id": "535bd266-0ad0-5184-9574-84180233b037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39000966-42f7-45ef-b25b-eb4b442f9c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39000966-42f7-45ef-b25b-eb4b442f9c8b.jpg?1",
             "name": "Inventors' Fair",
             "text": "",
             "colours": [],
@@ -62424,7 +62424,7 @@
         },
         {
             "id": "d6596ee4-d827-5ba4-b9f9-66ed4f361a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe83332-195e-4ac1-878f-f52eef62ce6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe83332-195e-4ac1-878f-f52eef62ce6a.jpg?1",
             "name": "Wolverine, Best There Is",
             "text": "",
             "colours": [
@@ -62464,7 +62464,7 @@
         },
         {
             "id": "6118d23d-02ff-579f-965c-11d4f128ded7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9866e64e-308b-4920-a76b-ddea0c6bc830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9866e64e-308b-4920-a76b-ddea0c6bc830.jpg?1",
             "name": "Berserk",
             "text": "",
             "colours": [
@@ -62498,7 +62498,7 @@
         },
         {
             "id": "9e3f955d-baeb-5be7-8576-5bddc2fee08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498508dd-fefb-463e-ad13-4cbf9e006b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498508dd-fefb-463e-ad13-4cbf9e006b34.jpg?1",
             "name": "Rite of Passage",
             "text": "",
             "colours": [
@@ -62530,7 +62530,7 @@
         },
         {
             "id": "894e6e38-a1b7-55ed-8b26-c6f794dd19cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32202c0-2572-42f2-b54c-7654914e5729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32202c0-2572-42f2-b54c-7654914e5729.jpg?1",
             "name": "Rhythm of the Wild",
             "text": "",
             "colours": [
@@ -62564,7 +62564,7 @@
         },
         {
             "id": "1a5f3d2c-46aa-50ec-94cb-575917d77168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aaee13-bfeb-47fd-93cb-2ccdd5d44e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0aaee13-bfeb-47fd-93cb-2ccdd5d44e75.jpg?1",
             "name": "The Ozolith",
             "text": "",
             "colours": [],
@@ -62594,7 +62594,7 @@
         },
         {
             "id": "37a9b4a1-e14a-599c-bbae-b74f93d7bad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af7766e-7438-4128-a1f2-8b3b3ba3c650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af7766e-7438-4128-a1f2-8b3b3ba3c650.jpg?1",
             "name": "Storm, Force of Nature",
             "text": "",
             "colours": [
@@ -62635,7 +62635,7 @@
         },
         {
             "id": "0a31c1e5-968f-5e6f-bbef-3e1f2317d088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24484578-7885-4125-b95f-e677d970a5a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24484578-7885-4125-b95f-e677d970a5a1.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -62677,7 +62677,7 @@
         },
         {
             "id": "a85e7ae5-4aef-56ba-bb23-67bf4801f657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f2e39f-bf39-4b27-b211-e46b6045039d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f2e39f-bf39-4b27-b211-e46b6045039d.jpg?1",
             "name": "Jeska's Will",
             "text": "",
             "colours": [
@@ -62709,7 +62709,7 @@
         },
         {
             "id": "8b3356b4-82fe-5f18-a70c-fa8f082947f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801185a5-78e0-4a5d-8aee-9a99f32ffbdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801185a5-78e0-4a5d-8aee-9a99f32ffbdc.jpg?1",
             "name": "Ice Storm",
             "text": "",
             "colours": [
@@ -62741,7 +62741,7 @@
         },
         {
             "id": "199a6410-6063-5e26-9bf3-41269514e1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96ce5e6-70a0-47d7-ac1c-2019a8c77b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96ce5e6-70a0-47d7-ac1c-2019a8c77b45.jpg?1",
             "name": "Manamorphose",
             "text": "",
             "colours": [
@@ -62775,7 +62775,7 @@
         },
         {
             "id": "dc2f9d16-72b8-5d6f-8885-f0807ecd3b1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93a12d-6913-4d9e-8e9c-8067147e37f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a93a12d-6913-4d9e-8e9c-8067147e37f2.jpg?1",
             "name": "Black Panther, Wakandan King",
             "text": "",
             "colours": [
@@ -62815,7 +62815,7 @@
         },
         {
             "id": "4f3084bb-0d81-5c84-bb14-911d3687269f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0da2e-3513-4891-bea2-27dd138064b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f0da2e-3513-4891-bea2-27dd138064b3.jpg?1",
             "name": "Secure the Wastes",
             "text": "",
             "colours": [
@@ -62847,7 +62847,7 @@
         },
         {
             "id": "ea0dcc36-1c25-52e7-a285-dcd33408ef09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359a4ef6-14e9-410a-bb9b-bc5b66b3e47c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359a4ef6-14e9-410a-bb9b-bc5b66b3e47c.jpg?1",
             "name": "Primal Vigor",
             "text": "",
             "colours": [
@@ -62881,7 +62881,7 @@
         },
         {
             "id": "8190b37d-6fbe-570f-80cd-a550615fba9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7ffb0-ad48-4f2c-af43-a86a9546a1b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f7ffb0-ad48-4f2c-af43-a86a9546a1b2.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -62913,7 +62913,7 @@
         },
         {
             "id": "612bf3d0-d4c3-5229-8d3a-4a5bc4c9b253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d247eb-0482-481e-824f-996ae1b20177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69d247eb-0482-481e-824f-996ae1b20177.jpg?1",
             "name": "Karn's Bastion",
             "text": "",
             "colours": [],
@@ -62941,7 +62941,7 @@
         },
         {
             "id": "708b1777-d363-5c03-8909-be870c22086d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7169ecb8-20be-4c40-8dcb-a93265281538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7169ecb8-20be-4c40-8dcb-a93265281538.jpg?1",
             "name": "Phyrexian Metamorph",
             "text": "",
             "colours": [
@@ -62979,7 +62979,7 @@
         },
         {
             "id": "6eba8b50-8137-52bf-8183-c0281cb6d5ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38afc2f2-29d2-413d-abee-d8ad9fa85dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38afc2f2-29d2-413d-abee-d8ad9fa85dec.jpg?1",
             "name": "Cauldron Familiar",
             "text": "",
             "colours": [
@@ -63013,7 +63013,7 @@
         },
         {
             "id": "5e1dd046-7840-5940-90e5-3b5a1cdc5b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e853d-05bd-49b2-b7da-c968e24a2400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e853d-05bd-49b2-b7da-c968e24a2400.jpg?1",
             "name": "Dauthi Voidwalker",
             "text": "",
             "colours": [
@@ -63048,7 +63048,7 @@
         },
         {
             "id": "032cf0c4-2fb4-5718-b7f7-544773ce1922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f5cfdd-9c48-405d-bfd7-1e20558bbd5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f5cfdd-9c48-405d-bfd7-1e20558bbd5a.jpg?1",
             "name": "Magus of the Moon",
             "text": "",
             "colours": [
@@ -63083,7 +63083,7 @@
         },
         {
             "id": "a5ba0303-12aa-55ea-8485-9f564f316d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1546013b-89d7-46b8-bfcb-9d150a50499f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1546013b-89d7-46b8-bfcb-9d150a50499f.jpg?1",
             "name": "Witch's Oven",
             "text": "",
             "colours": [],
@@ -63111,7 +63111,7 @@
         },
         {
             "id": "30c70a6e-f7bc-5df9-a29f-2fe140c69f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1a8780-726b-47f2-904b-a840cfc69d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1a8780-726b-47f2-904b-a840cfc69d76.jpg?1",
             "name": "Doom Whisperer",
             "text": "",
             "colours": [
@@ -63146,7 +63146,7 @@
         },
         {
             "id": "8eacdefe-6d99-5ebf-8675-a29e7bb46674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a7f2f0-3c12-4dba-975e-26d01f3f9c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9a7f2f0-3c12-4dba-975e-26d01f3f9c0d.jpg?1",
             "name": "Ravenous Chupacabra",
             "text": "",
             "colours": [
@@ -63183,7 +63183,7 @@
         },
         {
             "id": "90f296fa-be75-5c28-9953-0de96a4f6a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac5042c-758a-4bd7-b5cc-370425a067a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac5042c-758a-4bd7-b5cc-370425a067a0.jpg?1",
             "name": "Koma, Cosmos Serpent",
             "text": "",
             "colours": [
@@ -63221,7 +63221,7 @@
         },
         {
             "id": "a0acd9ef-5c03-5ff8-85ab-e084bea036a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce045260-7811-45f7-8cbe-902b1cbc6177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce045260-7811-45f7-8cbe-902b1cbc6177.jpg?1",
             "name": "Mazirek, Kraul Death Priest",
             "text": "",
             "colours": [
@@ -63262,7 +63262,7 @@
         },
         {
             "id": "e1c924fe-4192-5953-b1a8-300c7cdbc31b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e4d5f-48bc-4bd3-bedb-4fad8f843a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d1e4d5f-48bc-4bd3-bedb-4fad8f843a2e.jpg?1",
             "name": "Uril, the Miststalker",
             "text": "",
             "colours": [
@@ -63302,7 +63302,7 @@
         },
         {
             "id": "5d2e2873-ee7e-5807-b379-3225f46742ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feefb72-f6fa-4897-b2cf-6f14a3e5d466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0feefb72-f6fa-4897-b2cf-6f14a3e5d466.jpg?1",
             "name": "Careful Study",
             "text": "",
             "colours": [
@@ -63334,7 +63334,7 @@
         },
         {
             "id": "f3146759-a62e-5cc2-b1c1-0e9d2f610181",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e7fd7-a21e-42ae-bad3-b35e4fab62f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e5e7fd7-a21e-42ae-bad3-b35e4fab62f4.jpg?1",
             "name": "Living End",
             "text": "",
             "colours": [
@@ -63366,7 +63366,7 @@
         },
         {
             "id": "11056ae8-c046-5962-b7ac-68959d620951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90a8649-4303-4915-bb8b-f7bc76712afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90a8649-4303-4915-bb8b-f7bc76712afb.jpg?1",
             "name": "Eladamri's Call",
             "text": "",
             "colours": [
@@ -63400,7 +63400,7 @@
         },
         {
             "id": "ca88caa6-7d85-58cc-b5d8-fde33e3e7f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f2f6fa-80b0-45c8-92f3-b0c2826ffb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f2f6fa-80b0-45c8-92f3-b0c2826ffb06.jpg?1",
             "name": "Boros Charm",
             "text": "",
             "colours": [
@@ -63436,7 +63436,7 @@
         },
         {
             "id": "7b2361fb-7fa7-5bf2-9ce1-31836a19e0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19650c4e-d251-4659-ae35-3200cc4acb5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19650c4e-d251-4659-ae35-3200cc4acb5d.jpg?1",
             "name": "Unlicensed Hearse",
             "text": "",
             "colours": [],
@@ -63466,7 +63466,7 @@
         },
         {
             "id": "1c961503-d3f6-592b-9a6a-753f839a90e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada30541-faea-45af-853c-de85ff8e251e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada30541-faea-45af-853c-de85ff8e251e.jpg?1",
             "name": "The Mimeoplasm",
             "text": "",
             "colours": [
@@ -63508,7 +63508,7 @@
         },
         {
             "id": "7c970492-d20d-5735-95ac-4ec64642e539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b54349c-d649-4947-8dfa-bcf2aebeab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b54349c-d649-4947-8dfa-bcf2aebeab57.jpg?1",
             "name": "Trickbind",
             "text": "",
             "colours": [
@@ -63540,7 +63540,7 @@
         },
         {
             "id": "0b5769ee-3ed9-5ff4-9ecb-e5dcd27d583a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d30fc-b1a1-45cc-a89a-d2593bf22031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3d30fc-b1a1-45cc-a89a-d2593bf22031.jpg?1",
             "name": "Windfall",
             "text": "",
             "colours": [
@@ -63572,7 +63572,7 @@
         },
         {
             "id": "3eb9c1d1-d346-5121-8a42-525d06d15539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388e5b06-fbd0-4238-87e0-5ed44650870d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388e5b06-fbd0-4238-87e0-5ed44650870d.jpg?1",
             "name": "Incarnation Technique",
             "text": "",
             "colours": [
@@ -63604,7 +63604,7 @@
         },
         {
             "id": "4a2e188d-edf7-5c70-872b-b39bc0741c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cce1a-468a-430c-ba24-a60f1151e23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686cce1a-468a-430c-ba24-a60f1151e23a.jpg?1",
             "name": "Pernicious Deed",
             "text": "",
             "colours": [
@@ -63638,7 +63638,7 @@
         },
         {
             "id": "2b852c75-67f8-5940-8365-4eab6597c378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e8f6-d68f-480b-9fa3-5205cd6bfc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0615e8f6-d68f-480b-9fa3-5205cd6bfc83.jpg?1",
             "name": "Fell the Mighty",
             "text": "",
             "colours": [
@@ -63670,7 +63670,7 @@
         },
         {
             "id": "1ad1afd8-8ea9-5b8f-b603-1addb17a7d1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b069ede2-dec3-43b3-85ce-b9d60a1e96a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b069ede2-dec3-43b3-85ce-b9d60a1e96a7.jpg?1",
             "name": "Faithless Looting",
             "text": "",
             "colours": [
@@ -63702,7 +63702,7 @@
         },
         {
             "id": "419067bf-5832-5237-b649-05e17060811b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1183d4d7-094b-4024-ab1d-23c458cb7e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1183d4d7-094b-4024-ab1d-23c458cb7e71.jpg?1",
             "name": "Goldspan Dragon",
             "text": "",
             "colours": [
@@ -63736,7 +63736,7 @@
         },
         {
             "id": "557722d9-ce1f-5ad7-8e31-d789abe562be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2488c-c252-42a6-b487-c358c16b7ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c2488c-c252-42a6-b487-c358c16b7ae1.jpg?1",
             "name": "Reality Shift",
             "text": "",
             "colours": [
@@ -63768,7 +63768,7 @@
         },
         {
             "id": "013cb887-ead5-5e51-976e-2299e274678f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -63800,7 +63800,7 @@
         },
         {
             "id": "09a70481-ee89-5513-81f5-64ba4dbc34c9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/683383de-6f7d-4bdf-af38-6822f23d00be.jpg?1",
             "name": "Monster Manual // Zoological Study",
             "text": "",
             "colours": [
@@ -63834,7 +63834,7 @@
         },
         {
             "id": "51e1d30c-03a8-5c1c-be82-ff147d59233d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c17b3-53f6-4f2e-a6a2-36e851f6d001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636c17b3-53f6-4f2e-a6a2-36e851f6d001.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -63868,7 +63868,7 @@
         },
         {
             "id": "46b9c36a-03fd-5000-880e-fb01f1702bef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfd08aa-0e6b-42e1-aa4a-a2bd09581a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfd08aa-0e6b-42e1-aa4a-a2bd09581a70.jpg?1",
             "name": "Acererak the Archlich",
             "text": "",
             "colours": [
@@ -63905,7 +63905,7 @@
         },
         {
             "id": "acaacfcf-c2cc-5516-a5b8-770cf074cba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f1cd3-e93b-4b59-bcf2-e1c850ef7572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e3f1cd3-e93b-4b59-bcf2-e1c850ef7572.jpg?1",
             "name": "Xanathar, Guild Kingpin",
             "text": "",
             "colours": [
@@ -63943,7 +63943,7 @@
         },
         {
             "id": "d14c16d1-16b1-5e29-8430-d5282bb5c665",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b8a9a2-55d8-4cf8-9912-787bdbc90ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b8a9a2-55d8-4cf8-9912-787bdbc90ebb.jpg?1",
             "name": "Bribery",
             "text": "",
             "colours": [
@@ -63977,7 +63977,7 @@
         },
         {
             "id": "1f029b21-0fdf-5917-ade8-766a480fe040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f141feb-f6c3-4232-9a11-43d81cc8076f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f141feb-f6c3-4232-9a11-43d81cc8076f.jpg?1",
             "name": "Stifle",
             "text": "",
             "colours": [
@@ -64009,7 +64009,7 @@
         },
         {
             "id": "d41d9dcf-407c-560b-8463-1d9480ec4507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256283-be94-4a34-805e-fc17503c7fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d256283-be94-4a34-805e-fc17503c7fbd.jpg?1",
             "name": "Delay",
             "text": "",
             "colours": [
@@ -64041,7 +64041,7 @@
         },
         {
             "id": "64ac063a-a346-5a9e-80a2-9720e9d2e9bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bd6ec3-7597-499b-8b69-fe7d50ece069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65bd6ec3-7597-499b-8b69-fe7d50ece069.jpg?1",
             "name": "Blood Money",
             "text": "",
             "colours": [
@@ -64073,7 +64073,7 @@
         },
         {
             "id": "0eaa0518-e74a-5fa4-bb6f-21c1c5fc26a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b705171c-8bff-4394-9d4d-084b13b20159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b705171c-8bff-4394-9d4d-084b13b20159.jpg?1",
             "name": "Drown in the Loch",
             "text": "",
             "colours": [
@@ -64109,7 +64109,7 @@
         },
         {
             "id": "db720753-5a36-512f-9305-12af4fadc019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb382d12-88a2-4ace-942b-9c0f87bfbacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb382d12-88a2-4ace-942b-9c0f87bfbacc.jpg?1",
             "name": "Karazikar, the Eye Tyrant",
             "text": "",
             "colours": [
@@ -64147,7 +64147,7 @@
         },
         {
             "id": "b8ff58ea-1641-503a-9dbc-e731c406c51d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eba002c-3562-4295-81e4-5f408f1556c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eba002c-3562-4295-81e4-5f408f1556c6.jpg?1",
             "name": "Snuff Out",
             "text": "",
             "colours": [
@@ -64179,7 +64179,7 @@
         },
         {
             "id": "9f250c0d-c409-57a2-b6a4-011efcda2e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b48bd5d8-65f7-42a6-9910-556ad12e8899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b48bd5d8-65f7-42a6-9910-556ad12e8899.jpg?1",
             "name": "Defile",
             "text": "",
             "colours": [
@@ -64211,7 +64211,7 @@
         },
         {
             "id": "4dd84d06-1ea9-5c6a-9087-5043ed064f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149eb8-7935-4e45-8092-6baa2a6fb8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87149eb8-7935-4e45-8092-6baa2a6fb8d2.jpg?1",
             "name": "Oubliette",
             "text": "",
             "colours": [
@@ -64243,7 +64243,7 @@
         },
         {
             "id": "cac936f0-0a8f-570e-89b1-7fcffe7a51d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6873b4a8-90cb-4096-922a-4fa23cdec3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6873b4a8-90cb-4096-922a-4fa23cdec3c8.jpg?1",
             "name": "Fling",
             "text": "",
             "colours": [
@@ -64277,7 +64277,7 @@
         },
         {
             "id": "cb159e76-6172-5e2c-9d98-7e8ba76ddd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7eff10-4e4e-44f0-aa2b-f6c0f5e2edb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7eff10-4e4e-44f0-aa2b-f6c0f5e2edb8.jpg?1",
             "name": "Fire Covenant",
             "text": "",
             "colours": [
@@ -64313,7 +64313,7 @@
         },
         {
             "id": "2ee32611-21c6-5f55-9b9b-1b5826b3bb0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555f7253-0126-4c3c-a264-877d4c8e005b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555f7253-0126-4c3c-a264-877d4c8e005b.jpg?1",
             "name": "Astarion, the Decadent",
             "text": "",
             "colours": [
@@ -64353,7 +64353,7 @@
         },
         {
             "id": "c6e7403b-1f3f-5d37-8fe2-3dd44e783d1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba9d69-0a54-4a58-8d1a-25cca4f452a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cba9d69-0a54-4a58-8d1a-25cca4f452a2.jpg?1",
             "name": "Exquisite Blood",
             "text": "",
             "colours": [
@@ -64387,7 +64387,7 @@
         },
         {
             "id": "e489e162-44bc-57eb-9a36-e5d557b46f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a3356c-738e-4dd9-b25a-3f10f923d0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a3356c-738e-4dd9-b25a-3f10f923d0df.jpg?1",
             "name": "Sanguine Bond",
             "text": "",
             "colours": [
@@ -64419,7 +64419,7 @@
         },
         {
             "id": "7653a010-ed28-54cb-97fc-af30f1783a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47aeb51f-dca8-4862-be9a-4a633e43825c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47aeb51f-dca8-4862-be9a-4a633e43825c.jpg?1",
             "name": "Anguished Unmaking",
             "text": "",
             "colours": [
@@ -64455,7 +64455,7 @@
         },
         {
             "id": "0ee6df5e-f32d-5b9d-9eec-c570fcaafbb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad253c0d-c64a-4748-824b-3a999e6d5ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad253c0d-c64a-4748-824b-3a999e6d5ae3.jpg?1",
             "name": "Mortify",
             "text": "",
             "colours": [
@@ -64489,7 +64489,7 @@
         },
         {
             "id": "125d19b1-3fc4-5db0-af97-016c722eb462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6c502-08ba-4c0d-aee9-98ce40058227.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a6c502-08ba-4c0d-aee9-98ce40058227.jpg?1",
             "name": "Karlach, Fury of Avernus",
             "text": "",
             "colours": [
@@ -64526,7 +64526,7 @@
         },
         {
             "id": "9429d00e-4556-510a-ad63-08cae162ed93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a54c29a-cc7a-4d0e-a427-2d8be0cb1dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a54c29a-cc7a-4d0e-a427-2d8be0cb1dcd.jpg?1",
             "name": "City on Fire",
             "text": "",
             "colours": [
@@ -64558,7 +64558,7 @@
         },
         {
             "id": "201e4912-7e8d-531e-b2ac-e157ee953c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1fe16c-93c3-43a3-80b9-112e82a7321e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1fe16c-93c3-43a3-80b9-112e82a7321e.jpg?1",
             "name": "Stranglehold",
             "text": "",
             "colours": [
@@ -64590,7 +64590,7 @@
         },
         {
             "id": "13dad24b-1baa-5d3d-beba-e3add6bf69c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5746f057-7387-4fa9-aaaa-8f292e79036a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5746f057-7387-4fa9-aaaa-8f292e79036a.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -64622,7 +64622,7 @@
         },
         {
             "id": "f4662b94-8d0c-5194-bf12-07a0829933c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17518e8e-46ad-4730-b10b-b8875c0536b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17518e8e-46ad-4730-b10b-b8875c0536b6.jpg?1",
             "name": "Dolmen Gate",
             "text": "",
             "colours": [],
@@ -64650,7 +64650,7 @@
         },
         {
             "id": "89b4aa42-f221-56b3-93ac-680d52363933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg?1",
             "name": "Kardur, Doomscourge // Kardur, Doomscourge",
             "text": "",
             "colours": [
@@ -64689,7 +64689,7 @@
         },
         {
             "id": "392d6e41-a602-5719-8e35-e0a4f7b430a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d943cf2-0462-4f31-9a92-d76fe4971b17.jpg?1",
             "name": "Kardur, Doomscourge // Kardur, Doomscourge",
             "text": "",
             "colours": [
@@ -64728,7 +64728,7 @@
         },
         {
             "id": "fcaa49f4-b93a-5abd-9c97-966492e521bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490d482-535a-4080-bc36-941e2536282b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490d482-535a-4080-bc36-941e2536282b.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "",
             "colours": [
@@ -64760,7 +64760,7 @@
         },
         {
             "id": "de01de0c-605e-5bfd-aa73-d6c81f37794b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026dbfcb-6c83-478b-a790-1a7541c206aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026dbfcb-6c83-478b-a790-1a7541c206aa.jpg?1",
             "name": "Varragoth, Bloodsky Sire",
             "text": "",
             "colours": [
@@ -64797,7 +64797,7 @@
         },
         {
             "id": "a09f0ecc-9c46-5029-a378-8e4ae368134a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3459de92-62e8-482c-8241-3addc0a92066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3459de92-62e8-482c-8241-3addc0a92066.jpg?1",
             "name": "Twinflame",
             "text": "",
             "colours": [
@@ -64829,7 +64829,7 @@
         },
         {
             "id": "4234b1d7-ebf3-56d9-a096-fdcce237554e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c3656-5cdd-4be8-a158-5d5801f8e382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923c3656-5cdd-4be8-a158-5d5801f8e382.jpg?1",
             "name": "Genesis Chamber",
             "text": "",
             "colours": [],
@@ -64857,7 +64857,7 @@
         },
         {
             "id": "acc35265-be03-5571-ac25-06f40e492291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cfa-c08e-4c38-aeeb-dc6f0693ff72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83425cfa-c08e-4c38-aeeb-dc6f0693ff72.jpg?1",
             "name": "Mana Geyser",
             "text": "",
             "colours": [
@@ -64889,7 +64889,7 @@
         },
         {
             "id": "670e2919-0145-5657-b4fa-2ac40890222a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb6751-1072-4fc0-8b54-836d05950914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fbb6751-1072-4fc0-8b54-836d05950914.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -64931,7 +64931,7 @@
         },
         {
             "id": "e478762e-f1a7-52eb-9beb-aacfb1c272b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180679fa-b820-4793-8f2e-a2d8791192d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180679fa-b820-4793-8f2e-a2d8791192d5.jpg?1",
             "name": "Fierce Guardianship",
             "text": "",
             "colours": [
@@ -64963,7 +64963,7 @@
         },
         {
             "id": "13a3276f-2ee5-5295-b275-e852afa3812d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6468b6-ac2f-4af5-985f-e9cae5eb2251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a6468b6-ac2f-4af5-985f-e9cae5eb2251.jpg?1",
             "name": "Delayed Blast Fireball",
             "text": "",
             "colours": [
@@ -64995,7 +64995,7 @@
         },
         {
             "id": "84efcf29-d327-5693-a695-f8045c9ea4ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20e671-9b41-4591-b1ef-2a297411beb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d20e671-9b41-4591-b1ef-2a297411beb7.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "",
             "colours": [
@@ -65031,7 +65031,7 @@
         },
         {
             "id": "084501f1-884f-56ab-b879-bcdcde480ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da9358b-cfe4-4e95-9a9e-a236d6373dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da9358b-cfe4-4e95-9a9e-a236d6373dcf.jpg?1",
             "name": "Doom Blade",
             "text": "",
             "colours": [
@@ -65063,7 +65063,7 @@
         },
         {
             "id": "2b0d0c6d-defa-5b95-9386-0974b930ba71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4472b2e-b47a-4bc3-992b-9f8a218594f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4472b2e-b47a-4bc3-992b-9f8a218594f6.jpg?1",
             "name": "Massacre",
             "text": "",
             "colours": [
@@ -65095,7 +65095,7 @@
         },
         {
             "id": "727091a2-0fc3-5e84-95bc-699135507ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fc8dff-4d26-4dfd-b279-d06e10cba54f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71fc8dff-4d26-4dfd-b279-d06e10cba54f.jpg?1",
             "name": "Torment of Hailfire",
             "text": "",
             "colours": [
@@ -65127,7 +65127,7 @@
         },
         {
             "id": "8d73cb36-f526-5c17-913b-d2bbec2b069a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad3c3-da9c-4233-9d7c-2c786e860dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad3c3-da9c-4233-9d7c-2c786e860dd3.jpg?1",
             "name": "Ruination",
             "text": "",
             "colours": [
@@ -65159,7 +65159,7 @@
         },
         {
             "id": "9db1ea4e-b76d-52bc-b5d0-4eb23fafa8da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff7be28-275e-4a02-a4c6-f3040d64b9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff7be28-275e-4a02-a4c6-f3040d64b9a8.jpg?1",
             "name": "Mogis, God of Slaughter",
             "text": "",
             "colours": [
@@ -65200,7 +65200,7 @@
         },
         {
             "id": "dd8599d9-81aa-5717-a2f3-cc516c80a07c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08460-3043-4de7-b8ae-92f238318844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab08460-3043-4de7-b8ae-92f238318844.jpg?1",
             "name": "Garruk, Caller of Beasts",
             "text": "",
             "colours": [
@@ -65236,7 +65236,7 @@
         },
         {
             "id": "9dc5ca13-82c7-5452-bbad-c08e7d5ea957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb16341a-f793-4b0e-b4ef-3fc56aae3807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb16341a-f793-4b0e-b4ef-3fc56aae3807.jpg?1",
             "name": "Rograkh, Son of Rohgahh",
             "text": "",
             "colours": [
@@ -65273,7 +65273,7 @@
         },
         {
             "id": "148822d3-41c7-587c-8fae-a758dc97425d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dc44e-d207-4330-aa41-ba5683450e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752dc44e-d207-4330-aa41-ba5683450e60.jpg?1",
             "name": "Geralf's Messenger",
             "text": "",
             "colours": [
@@ -65307,7 +65307,7 @@
         },
         {
             "id": "b492a5d3-552d-5d45-b687-568c0d5f4589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76435d9-beab-4419-95f9-afc8b5c8f3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d76435d9-beab-4419-95f9-afc8b5c8f3f1.jpg?1",
             "name": "Empress Galina",
             "text": "",
             "colours": [
@@ -65344,7 +65344,7 @@
         },
         {
             "id": "4bd3715b-c984-57b6-8522-8a79dde1b564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcb20-219c-4175-8600-a946d83210e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcb20-219c-4175-8600-a946d83210e0.jpg?1",
             "name": "Sisay, Weatherlight Captain",
             "text": "",
             "colours": [
@@ -65387,7 +65387,7 @@
         },
         {
             "id": "43a4c626-e28a-58a9-a724-de287a1bd7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3271da-cc20-48c2-ac61-b64a8e47f9e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c3271da-cc20-48c2-ac61-b64a8e47f9e5.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -65421,7 +65421,7 @@
         },
         {
             "id": "a691ae77-149f-5aac-8b1d-b95d6f4935f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba1cf83-e13d-401e-b76f-b12a51b307f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba1cf83-e13d-401e-b76f-b12a51b307f9.jpg?1",
             "name": "Viscera Seer",
             "text": "",
             "colours": [
@@ -65455,7 +65455,7 @@
         },
         {
             "id": "f5e43c62-7cab-50dc-834c-9e552c029f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aceb1db-c48f-4985-a0b8-132fe12a5021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aceb1db-c48f-4985-a0b8-132fe12a5021.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65490,7 +65490,7 @@
         },
         {
             "id": "3f69e09e-11e0-5299-9384-811c264a97ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce18f1-0eff-4354-97b8-cb58295f4865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dce18f1-0eff-4354-97b8-cb58295f4865.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65525,7 +65525,7 @@
         },
         {
             "id": "65b923f1-61cc-5d2c-a2c5-4a7877ac8263",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f51f4d-eb6d-4503-b9a4-559db1b9b16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f51f4d-eb6d-4503-b9a4-559db1b9b16f.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65560,7 +65560,7 @@
         },
         {
             "id": "0ceb2be9-c70c-5370-976a-56308634f813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df94cc3-fed3-493d-9aa5-c85d6a2aeb05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df94cc3-fed3-493d-9aa5-c85d6a2aeb05.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -65595,7 +65595,7 @@
         },
         {
             "id": "01a9f60d-207a-56e2-9d39-9734ce7ba567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255dcc91-7b3d-4b58-85f3-b21be805966e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255dcc91-7b3d-4b58-85f3-b21be805966e.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -65629,7 +65629,7 @@
         },
         {
             "id": "7c4596d5-af5c-5e16-802e-38e3cee1fdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -65663,7 +65663,7 @@
         },
         {
             "id": "1f4c2ec0-a94c-5ff4-88aa-28a349501426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d03f760-6e5a-404e-beb9-07d78a53364d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d03f760-6e5a-404e-beb9-07d78a53364d.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65697,7 +65697,7 @@
         },
         {
             "id": "50fcb456-82d6-5452-8318-8a58a6ee5f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c637c4-c1cc-4852-9561-78add390ef52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4c637c4-c1cc-4852-9561-78add390ef52.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65731,7 +65731,7 @@
         },
         {
             "id": "7f4dc7cc-dad3-572a-9185-406ca1c9d075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a121c039-ec93-4383-bdb5-bc7acf9e1a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a121c039-ec93-4383-bdb5-bc7acf9e1a05.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65765,7 +65765,7 @@
         },
         {
             "id": "327bd47a-e2c3-515e-8d20-325a6a6ddfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7940307-6ae3-423e-b752-a72acddb9087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7940307-6ae3-423e-b752-a72acddb9087.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65799,7 +65799,7 @@
         },
         {
             "id": "81a3c48b-c87b-51f3-9a71-d4bf0838290c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b236f7a-62b0-4605-9328-6994ca65909b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b236f7a-62b0-4605-9328-6994ca65909b.jpg?1",
             "name": "Walker",
             "text": "",
             "colours": [
@@ -65833,7 +65833,7 @@
         },
         {
             "id": "537327a8-6f4c-529c-bdbc-21673381bd3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e752ca8-5404-4898-8b75-a0848e3850f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e752ca8-5404-4898-8b75-a0848e3850f2.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -65863,7 +65863,7 @@
         },
         {
             "id": "af354f52-13cb-522d-89b0-29ff3c182502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2311cf5-ab73-48d6-9fa0-54c19a7ae98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2311cf5-ab73-48d6-9fa0-54c19a7ae98f.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -65897,7 +65897,7 @@
         },
         {
             "id": "8b60170d-7935-583e-82ca-408c9c80ce9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99cc0a4-4868-47f3-bd1d-f46b7cb74650.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99cc0a4-4868-47f3-bd1d-f46b7cb74650.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -65932,7 +65932,7 @@
         },
         {
             "id": "d76af2c5-2e22-582a-bd84-97dc25d3601b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c52125-929a-4e03-a955-d55ae34a905b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c52125-929a-4e03-a955-d55ae34a905b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -65963,7 +65963,7 @@
         },
         {
             "id": "fe03a7b1-bbc4-5e44-89ec-3a2aab7e4cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb668a-c8f8-491f-8534-08a7f94baf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cb668a-c8f8-491f-8534-08a7f94baf19.jpg?1",
             "name": "Icingdeath, Frost Tongue",
             "text": "",
             "colours": [
@@ -65999,7 +65999,7 @@
         },
         {
             "id": "993318ee-4e8f-58a6-b55f-894b9310a3d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88aa73-baca-49c2-a6c3-0a1624b6078b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a88aa73-baca-49c2-a6c3-0a1624b6078b.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -66034,7 +66034,7 @@
         },
         {
             "id": "0976687a-e6ed-583f-a2ec-34c328ef73d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e82b125-df5e-4e5f-8759-51c32c447c1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e82b125-df5e-4e5f-8759-51c32c447c1d.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -66069,7 +66069,7 @@
         },
         {
             "id": "11aae81c-fac5-5132-b358-737931d73dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cad0da-ac47-4324-9810-cf2ae94fd5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cad0da-ac47-4324-9810-cf2ae94fd5e0.jpg?1",
             "name": "Hydra",
             "text": "",
             "colours": [
@@ -66103,7 +66103,7 @@
         },
         {
             "id": "80ba4741-7769-5d02-8088-a30b8b8a6474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089874c5-4f1e-4d03-a4c5-50f6ac0814dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089874c5-4f1e-4d03-a4c5-50f6ac0814dd.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -66137,7 +66137,7 @@
         },
         {
             "id": "a8d15e9b-675f-5c44-a604-70c49d17b8bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9b18e5-d842-4114-b395-ff5dd42c94d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9b18e5-d842-4114-b395-ff5dd42c94d9.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -66171,7 +66171,7 @@
         },
         {
             "id": "ce24f27b-16b5-596b-b810-805a9384991b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8150833a-9c83-4d00-ae2f-470088700fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8150833a-9c83-4d00-ae2f-470088700fdb.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -66206,7 +66206,7 @@
         },
         {
             "id": "73389c20-54f0-5c52-884b-3deff0fab42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e134190e-772a-458d-b0e1-633154f16809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e134190e-772a-458d-b0e1-633154f16809.jpg?1",
             "name": "Egg",
             "text": "",
             "colours": [
@@ -66240,7 +66240,7 @@
         },
         {
             "id": "2920e221-5ed1-517f-a049-cc6acbeb6f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b36476-71f3-4128-81a6-726ed18c0023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b36476-71f3-4128-81a6-726ed18c0023.jpg?1",
             "name": "Egg",
             "text": "",
             "colours": [
@@ -66274,7 +66274,7 @@
         },
         {
             "id": "e772badb-41b9-5571-a36c-15f08b6e5a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7c6d71-c575-4c1b-a161-a4d4186ea9c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7c6d71-c575-4c1b-a161-a4d4186ea9c6.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -66305,7 +66305,7 @@
         },
         {
             "id": "b038f379-b2fa-52ba-b9f9-b689ab164edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d07ad5-0701-4696-91fd-87451997ef23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d07ad5-0701-4696-91fd-87451997ef23.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -66339,7 +66339,7 @@
         },
         {
             "id": "d455d547-bb4c-5999-8561-b7cbe0ac2871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53bf06-f681-4d5c-b303-cc7c050f5b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c53bf06-f681-4d5c-b303-cc7c050f5b01.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -66373,7 +66373,7 @@
         },
         {
             "id": "838671eb-24c5-5246-b969-5190055b6e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ffdaf6-472e-46be-a74a-4be985b29df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1ffdaf6-472e-46be-a74a-4be985b29df4.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -66408,7 +66408,7 @@
         },
         {
             "id": "7499c3c7-8227-53a6-828e-788bcde1fa47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd2627-3118-4643-83e2-4637f8821ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5dd2627-3118-4643-83e2-4637f8821ab4.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -66445,7 +66445,7 @@
         },
         {
             "id": "5ea170f8-44cc-5e15-b536-99d283ab936a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bae2c8-9d6d-42d4-a63b-c1133d772fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88bae2c8-9d6d-42d4-a63b-c1133d772fec.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -66476,7 +66476,7 @@
         },
         {
             "id": "792e05f4-14b4-5f1f-b788-5a7b60d63d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3053e02b-7157-4fb6-9427-d64a68ea29c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3053e02b-7157-4fb6-9427-d64a68ea29c3.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/SNC.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SNC.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a7104e86-1f2e-5cf1-9664-032394204ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cce4d3-e6d8-4c6f-9d9c-c0a8a607a42f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6cce4d3-e6d8-4c6f-9d9c-c0a8a607a42f.jpg?1",
             "name": "Angelic Observer",
             "text": "This spell costs {1} less to cast for each Citizen you control.\nFlying",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "75b86b4c-f99c-5145-9743-09980bcf8e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a46af75-3880-4141-b26e-19834d67e7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a46af75-3880-4141-b26e-19834d67e7a8.jpg?1",
             "name": "Backup Agent",
             "text": "When Backup Agent enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "e28e6e49-36ed-5f0b-b261-95d36871aa0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5615a2-03a2-41f4-ab3b-de5e60d1504e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5615a2-03a2-41f4-ab3b-de5e60d1504e.jpg?1",
             "name": "Ballroom Brawlers",
             "text": "Whenever Ballroom Brawlers attacks, Ballroom Brawlers and up to one other target creature you control both gain your choice of first strike or lifelink until end of turn.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "671a76bb-def5-5dfd-9c42-d7ea3e6343fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2069310a-9fb6-41b7-bbd5-849e3df05632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2069310a-9fb6-41b7-bbd5-849e3df05632.jpg?1",
             "name": "Boon of Safety",
             "text": "Put a shield counter on target creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nScry 1.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "82c7749f-f290-518f-a8fc-5d5321bb69df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7867f2d-e89d-429f-9ab8-5337b40b4d8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7867f2d-e89d-429f-9ab8-5337b40b4d8d.jpg?1",
             "name": "Brokers Initiate",
             "text": "{4}{GW}: Brokers Initiate has base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -178,7 +178,7 @@
         },
         {
             "id": "1e65ce62-5937-5205-bace-3eb263767a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9ac05f-f47c-4569-a06e-793d28cbb936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c9ac05f-f47c-4569-a06e-793d28cbb936.jpg?1",
             "name": "Buy Your Silence",
             "text": "Exile target nonland permanent. Its controller creates a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "7da72ad5-47b5-55e4-ba63-7b3f3c807624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c0cecd-c718-4238-9164-ebb6c20fc99c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c0cecd-c718-4238-9164-ebb6c20fc99c.jpg?1",
             "name": "A-Buy Your Silence",
             "text": "",
             "colours": [
@@ -241,7 +241,7 @@
         },
         {
             "id": "343204bb-39ed-5d1a-8b36-a3961fa13527",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afb5c5c-06e0-4b11-ad07-aef7be6e2cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afb5c5c-06e0-4b11-ad07-aef7be6e2cd4.jpg?1",
             "name": "Celebrity Fencer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, put a +1/+1 counter on Celebrity Fencer.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "e3d3f0b7-048d-54ce-85b5-30908478d1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9428ae-9c59-4cac-a29b-039a34cfdb6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d9428ae-9c59-4cac-a29b-039a34cfdb6d.jpg?1",
             "name": "A-Celebrity Fencer",
             "text": "",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "5a5817f9-934b-5141-8321-0fe3463e2b12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68896f5-1e13-400a-a327-b6c6f00858b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68896f5-1e13-400a-a327-b6c6f00858b7.jpg?1",
             "name": "Citizen's Crowbar",
             "text": "When Citizen's Crowbar enters the battlefield, create a 1/1 green and white Citizen creature token, then attach Citizen's Crowbar to it.\nEquipped creature gets +1/+1 and has \"{W}, {T}, Sacrifice Citizen's Crowbar: Destroy target artifact or enchantment.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "722bf00d-695f-53e0-8355-da295a41b23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce9c33-4ab3-43c9-b6bc-ee2d40d8f9b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ce9c33-4ab3-43c9-b6bc-ee2d40d8f9b6.jpg?1",
             "name": "Dapper Shieldmate",
             "text": "Dapper Shieldmate enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nAs long as it's your turn, Dapper Shieldmate gets +2/+0.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "307d92d6-f4fb-566c-8507-fc075b2029ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53c1898-9107-4bf8-b249-d0502fb9596d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c53c1898-9107-4bf8-b249-d0502fb9596d.jpg?1",
             "name": "Depopulate",
             "text": "Each player who controls a multicolored creature draws a card. Then destroy all creatures.",
             "colours": [
@@ -413,7 +413,7 @@
         },
         {
             "id": "eebb0d09-cffe-5da6-bbba-a9519c5153b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c606af0-f3d1-44a4-b24e-ee1263569b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c606af0-f3d1-44a4-b24e-ee1263569b1f.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "+1: Choose up to one target creature. Put a +1/+1 counter and a counter from among flying, first strike, lifelink, or vigilance on it.\n\u22123: Look at the top seven cards of your library. You may put a permanent card with mana value 3 or less from among them onto the battlefield with a shield counter on it. Put the rest on the bottom of your library in a random order.\n\u22127: Create five 3/3 white Angel creature tokens with flying.",
             "colours": [
@@ -453,7 +453,7 @@
         },
         {
             "id": "dadfde8d-5774-5e36-a201-76032a5c85ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404d6c7-0b65-4c6a-b141-9dffbeb120db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b404d6c7-0b65-4c6a-b141-9dffbeb120db.jpg?1",
             "name": "Extraction Specialist",
             "text": "Lifelink\nWhen Extraction Specialist enters the battlefield, return target creature card with mana value 2 or less from your graveyard to the battlefield. That creature can't attack or block for as long as you control Extraction Specialist.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "c6da916a-a190-5813-9eba-3d8729b6ddde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290347b9-d3cc-4882-8da6-9d8b8677f276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/290347b9-d3cc-4882-8da6-9d8b8677f276.jpg?1",
             "name": "Gathering Throng",
             "text": "When Gathering Throng enters the battlefield, you may search your library for any number of cards named Gathering Throng, reveal them, put them into your hand, then shuffle.",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "71b42f72-5bfb-5d4f-8563-3e3b7f0c282f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae077bd-fc8d-44d7-8c75-8dc8699c168e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae077bd-fc8d-44d7-8c75-8dc8699c168e.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters the battlefield with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "347106a1-4241-5296-bca3-2fb9aa6a0efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee79399-715c-4c46-9fa1-e76b1087f009.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee79399-715c-4c46-9fa1-e76b1087f009.jpg?1",
             "name": "Halo Fountain",
             "text": "{W}, {T}, Untap a tapped creature you control: Create a 1/1 green and white Citizen creature token.\n{W}{W}, {T}, Untap two tapped creatures you control: Draw a card.\n{W}{W}{W}{W}{W}, {T}, Untap fifteen tapped creatures you control: You win the game.",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "e254e687-4541-5586-ad91-72224164d752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e74a99-11d9-40b8-b1d6-8f68a3f490fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e74a99-11d9-40b8-b1d6-8f68a3f490fa.jpg?1",
             "name": "Hold for Ransom",
             "text": "Enchant creature\nEnchanted creature can't attack or block and has \"{7}: Hold for Ransom's controller sacrifices it and draws a card. Activate only as a sorcery.\"",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "8030f1a5-9a25-529b-91e1-1da1de9f32b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba20d9-9423-4114-8734-1dac307483c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52ba20d9-9423-4114-8734-1dac307483c8.jpg?1",
             "name": "Illuminator Virtuoso",
             "text": "Double strike\nWhenever Illuminator Virtuoso becomes the target of a spell you control, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "1ee98c19-e6f5-5ca1-bc21-6e7bd320dac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d9da1d-8678-4252-b0f8-9960795642f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d9da1d-8678-4252-b0f8-9960795642f0.jpg?1",
             "name": "Inspiring Overseer",
             "text": "Flying\nWhen Inspiring Overseer enters the battlefield, you gain 1 life and draw a card.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "496dede2-f95a-5f81-bfe5-437a8bd4161e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b0b9a3-8f50-4fba-9978-409f3369afa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b0b9a3-8f50-4fba-9978-409f3369afa6.jpg?1",
             "name": "Kill Shot",
             "text": "Destroy target attacking creature.",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "4f6724c4-8ed5-5cc4-af10-70a249a16394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b00bbec-61d0-464c-bf82-4ecf5ddb3451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b00bbec-61d0-464c-bf82-4ecf5ddb3451.jpg?1",
             "name": "Knockout Blow",
             "text": "This spell costs {2} less to cast if it targets a red creature.\nKnockout Blow deals 4 damage to target attacking or blocking creature and you gain 2 life.",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "4908e50a-c26b-5a9f-b544-cc9495be7082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce08e8-340b-4a67-9884-4cbf01d63790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cce08e8-340b-4a67-9884-4cbf01d63790.jpg?1",
             "name": "Mage's Attendant",
             "text": "When Mage's Attendant enters the battlefield, create a 1/1 blue Wizard creature token with \"{1}, Sacrifice this creature: Counter target noncreature spell unless its controller pays {1}.\"",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "a00bb75a-c708-5724-975b-60a6e5e09523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cb742-0ba7-4795-9772-25d4db0bc4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cb742-0ba7-4795-9772-25d4db0bc4ce.jpg?1",
             "name": "Mysterious Limousine",
             "text": "Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2",
             "colours": [
@@ -838,7 +838,7 @@
         },
         {
             "id": "356cd720-c4ae-5e8b-a8f9-ffe2be175802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce30c92-c5f2-45d2-819e-177390bc26f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce30c92-c5f2-45d2-819e-177390bc26f5.jpg?1",
             "name": "Patch Up",
             "text": "Return up to three target creature cards with total mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "ce8f1063-d08f-56b5-993d-a16e58af6130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206c8529-56df-4ed9-97bc-6c9b5e2a04c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/206c8529-56df-4ed9-97bc-6c9b5e2a04c4.jpg?1",
             "name": "Rabble Rousing",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWhenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens. Then if you control ten or more creatures, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -904,7 +904,7 @@
         },
         {
             "id": "8bcd2834-fd16-5590-a313-a68cc4fc85e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36e25fa-9ab4-4832-afb9-827c4b6ba732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f36e25fa-9ab4-4832-afb9-827c4b6ba732.jpg?1",
             "name": "Raffine's Guidance",
             "text": "Enchant creature\nEnchanted creature gets +1/+1.\nYou may cast Raffine's Guidance from your graveyard by paying {2}{W} rather than paying its mana cost.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "cd1a95c4-5e7a-5f97-b347-2fd46fa268f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e64ff87-2099-4360-94f6-164277b7b514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e64ff87-2099-4360-94f6-164277b7b514.jpg?1",
             "name": "Raffine's Informant",
             "text": "When Raffine's Informant enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -973,7 +973,7 @@
         },
         {
             "id": "acc4960c-14eb-56cf-bd63-6ee8a76611f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b597b3-5792-49e4-9bcb-74012e4e9cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7b597b3-5792-49e4-9bcb-74012e4e9cb6.jpg?1",
             "name": "Refuse to Yield",
             "text": "Target creature gets +2/+7 until end of turn. Untap it.",
             "colours": [
@@ -1005,7 +1005,7 @@
         },
         {
             "id": "8037d08d-4224-5a07-9892-a65f01c87118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e010b11-8f3e-4792-afe4-0a376650b6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e010b11-8f3e-4792-afe4-0a376650b6c4.jpg?1",
             "name": "Revelation of Power",
             "text": "Target creature gets +2/+2 until end of turn. If it has a counter on it, it also gains flying and lifelink until end of turn.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "cd389091-91c0-5a44-82af-77a21e6326eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b87807-cac5-4e33-a8ed-a9ced0cd83a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b87807-cac5-4e33-a8ed-a9ced0cd83a1.jpg?1",
             "name": "Rumor Gatherer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, scry 1. If this is the second time this ability has resolved this turn, draw a card instead.",
             "colours": [
@@ -1074,7 +1074,7 @@
         },
         {
             "id": "3e8af920-fe10-5fae-bf77-77432036d24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfdab77-d7c3-4e6a-bb4b-55153bd2fd4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfdab77-d7c3-4e6a-bb4b-55153bd2fd4d.jpg?1",
             "name": "Sanctuary Warden",
             "text": "Flying\nSanctuary Warden enters the battlefield with two shield counters on it.\nWhenever Sanctuary Warden enters the battlefield or attacks, you may remove a counter from a creature or planeswalker you control. If you do, draw a card and create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "2309e6ac-ddd4-5f24-a022-e29fa5ad6d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e01fa9-9127-4250-94f1-39e71cc3c2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e01fa9-9127-4250-94f1-39e71cc3c2bc.jpg?1",
             "name": "Sky Crier",
             "text": "Flying, lifelink\n{3}{W}: You and target opponent each draw a card.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "074c9700-cc2b-5052-980b-62ff00fad23b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e014d9d0-e6e1-4afb-b94f-b927a09b76c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e014d9d0-e6e1-4afb-b94f-b927a09b76c1.jpg?1",
             "name": "Speakeasy Server",
             "text": "Flying\nWhen Speakeasy Server enters the battlefield, you gain 1 life for each other creature you control.",
             "colours": [
@@ -1182,7 +1182,7 @@
         },
         {
             "id": "7b490074-287d-5f47-aa06-a26ec2f1e77b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77ea3bd-0d52-4d36-9d73-2b9d68c01e88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77ea3bd-0d52-4d36-9d73-2b9d68c01e88.jpg?1",
             "name": "A-Speakeasy Server",
             "text": "",
             "colours": [
@@ -1216,7 +1216,7 @@
         },
         {
             "id": "6937a799-34f5-59e1-914d-06fdcb6e0eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8713498f-a467-4a11-9de2-53a1bbd0b18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8713498f-a467-4a11-9de2-53a1bbd0b18b.jpg?1",
             "name": "Swooping Protector",
             "text": "Flash\nFlying\nSwooping Protector enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -1251,7 +1251,7 @@
         },
         {
             "id": "220c642a-e0ba-5680-b27e-890d7f932cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832c0b8-aefa-459c-8de8-aa32400612cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832c0b8-aefa-459c-8de8-aa32400612cd.jpg?1",
             "name": "All-Seeing Arbiter",
             "text": "Flying\nWhenever All-Seeing Arbiter enters the battlefield or attacks, draw two cards, then discard a card.\nWhenever you discard a card, target creature an opponent controls gets -X/-0 until your next turn, where X is the number of different mana values among cards in your graveyard.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "7fda4e29-3413-55bc-bf7b-bab8fd1326df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3a94c8-a7eb-4f05-8d48-d42e5129b09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3a94c8-a7eb-4f05-8d48-d42e5129b09a.jpg?1",
             "name": "Backstreet Bruiser",
             "text": "Defender\nAs long as there are two or more counters among creatures you control, Backstreet Bruiser can attack as though it didn't have defender.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "61150275-1274-59ea-b941-68fff4ae0fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4a54bd-5598-4313-b5e6-29fd38da016a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4a54bd-5598-4313-b5e6-29fd38da016a.jpg?1",
             "name": "Brokers Veteran",
             "text": "When Brokers Veteran dies, put a shield counter on target creature you control. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "7aa5b644-7034-530b-b103-75b67e06d648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9edf04-681d-45f9-975f-704154040506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9edf04-681d-45f9-975f-704154040506.jpg?1",
             "name": "Case the Joint",
             "text": "Draw two cards, then look at the top card of each player's library.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "1508473b-5b9d-50be-a1dd-a2843c8473ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa1331-3a2b-4c1e-a1ab-b53756141b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97aa1331-3a2b-4c1e-a1ab-b53756141b35.jpg?1",
             "name": "A-Case the Joint",
             "text": "",
             "colours": [
@@ -1420,7 +1420,7 @@
         },
         {
             "id": "c9f92aea-0875-50dc-a790-f1ef2c135cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31184dd0-4080-44c1-a3e0-f6d10a4d1fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31184dd0-4080-44c1-a3e0-f6d10a4d1fcb.jpg?1",
             "name": "Cut Your Losses",
             "text": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nTarget player mills half their library, rounded down.",
             "colours": [
@@ -1454,7 +1454,7 @@
         },
         {
             "id": "180a3f6e-7a22-5e86-8ed0-dcd778ab8100",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492aa24c-61c4-48bc-b7b7-f423be2662da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492aa24c-61c4-48bc-b7b7-f423be2662da.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with mana value 4 or greater.",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "1e4818f5-b4d4-5c2d-a2d6-622b07fcf7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e530ea-ba51-4f7a-bf56-b657a48e86ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e530ea-ba51-4f7a-bf56-b657a48e86ae.jpg?1",
             "name": "Echo Inspector",
             "text": "Flying\nWhen Echo Inspector enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "ff5b09eb-02bf-562a-8e6a-9460d4d303aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d23407-9fe0-4cbf-b4b5-bc1e132c36e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d23407-9fe0-4cbf-b4b5-bc1e132c36e4.jpg?1",
             "name": "Errant, Street Artist",
             "text": "Flash\nDefender, haste\n{1}{U}, {T}: Copy target spell you control that wasn't cast. You may choose new targets for the copy.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "caf6d7bc-88fb-5c97-91ca-4a76b7cf4804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c629217f-4a10-4d92-86f8-22dc4067a724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c629217f-4a10-4d92-86f8-22dc4067a724.jpg?1",
             "name": "Even the Score",
             "text": "This spell costs {U}{U}{U} less to cast if an opponent has drawn four or more cards this turn.\nDraw X cards.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "48a7676a-7ad4-5806-b1f9-c04d04b846a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515329a-0738-4b23-a326-ff417f47da77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515329a-0738-4b23-a326-ff417f47da77.jpg?1",
             "name": "Expendable Lackey",
             "text": "{1}{U}, Exile Expendable Lackey from your graveyard: Create a 1/1 blue Fish creature token with \"This creature can't be blocked.\" Activate only as a sorcery.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "a9730b95-1875-5f7b-8c95-55f18f02d468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7645247b-e65a-4912-ac22-e6a0fa806dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7645247b-e65a-4912-ac22-e6a0fa806dd7.jpg?1",
             "name": "Faerie Vandal",
             "text": "Flash\nFlying\nWhenever you draw your second card each turn, put a +1/+1 counter on Faerie Vandal.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "4ece1119-11db-53f4-9279-b441769e695a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af30b3-d4b0-453a-891f-4506e06b5e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69af30b3-d4b0-453a-891f-4506e06b5e14.jpg?1",
             "name": "Hypnotic Grifter",
             "text": "{3}: Hypnotic Grifter connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "156f8195-a3ce-5faa-94a0-5897134708ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea4b5bc-18a4-45db-a56a-ab3f8bd2fb0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea4b5bc-18a4-45db-a56a-ab3f8bd2fb0d.jpg?1",
             "name": "Ledger Shredder",
             "text": "Flying\nWhenever a player casts their second spell each turn, Ledger Shredder connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "d5d6a8fe-9585-591d-9333-c7425f5e3333",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7424b6-b56a-47b7-8204-294d3dca925f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d7424b6-b56a-47b7-8204-294d3dca925f.jpg?1",
             "name": "A Little Chat",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nLook at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "7d600701-4251-52c7-b9c4-2278b4d305e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaebea6-9e3f-4ac7-abe1-5445912f5b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcaebea6-9e3f-4ac7-abe1-5445912f5b44.jpg?1",
             "name": "Majestic Metamorphosis",
             "text": "Until end of turn, target artifact or creature becomes a 4/4 Angel artifact creature and gains flying.\nDraw a card.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "dbe3d4da-c552-519a-85bd-8984ee7a24d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d6a21-ea77-484b-9e3a-1bd49806f907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2d6a21-ea77-484b-9e3a-1bd49806f907.jpg?1",
             "name": "Make Disappear",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nCounter target spell unless its controller pays {2}.",
             "colours": [
@@ -1833,7 +1833,7 @@
         },
         {
             "id": "78f4a2de-f0dd-54b8-9c7a-07351ce69198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67774a11-158b-437c-ac16-2d42fbb5c223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67774a11-158b-437c-ac16-2d42fbb5c223.jpg?1",
             "name": "Obscura Initiate",
             "text": "Flying\n{1}{WB}: Obscura Initiate gains lifelink until end of turn.",
             "colours": [
@@ -1870,7 +1870,7 @@
         },
         {
             "id": "1353cfed-ac40-52af-8f91-c34f51be1573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d349f3-5be2-4b1f-a4c3-ba94822cf0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d349f3-5be2-4b1f-a4c3-ba94822cf0cf.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "b2f0d4cf-2718-5194-82e8-76d809d964a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2201ade5-8add-49f2-8045-ae351aaf061c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2201ade5-8add-49f2-8045-ae351aaf061c.jpg?1",
             "name": "Out of the Way",
             "text": "This spell costs {2} less to cast if it targets a green permanent.\nReturn target nonland permanent an opponent controls to its owner's hand.\nDraw a card.",
             "colours": [
@@ -1936,7 +1936,7 @@
         },
         {
             "id": "9ce0a878-2ded-5335-b81a-d2f5956949b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e04834-7335-4b25-bedf-b7739c5c3aad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e04834-7335-4b25-bedf-b7739c5c3aad.jpg?1",
             "name": "Psionic Snoop",
             "text": "Flash\nWhen Psionic Snoop enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -1971,7 +1971,7 @@
         },
         {
             "id": "85646f6e-b800-53a3-b8f7-27f34cb6ae05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91372333-e02e-46ed-af2f-ea8b32a3e0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91372333-e02e-46ed-af2f-ea8b32a3e0fa.jpg?1",
             "name": "A-Psionic Snoop",
             "text": "",
             "colours": [
@@ -2005,7 +2005,7 @@
         },
         {
             "id": "a8321a97-949c-52ec-be25-aae0b0662501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b90ca-1012-4132-bf2f-bc3825ed16ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/956b90ca-1012-4132-bf2f-bc3825ed16ac.jpg?1",
             "name": "Psychic Pickpocket",
             "text": "When Psychic Pickpocket enters the battlefield, it connives. When it connives this way, return up to one target nonland permanent to its owner's hand. (To have a creature connive, draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)",
             "colours": [
@@ -2040,7 +2040,7 @@
         },
         {
             "id": "4a20bda5-2630-57ea-8f4e-4e4e9f027154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e69ba61-8c16-4112-9601-fac978b88667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e69ba61-8c16-4112-9601-fac978b88667.jpg?1",
             "name": "Public Enemy",
             "text": "Enchant creature\nAll creatures attack enchanted creature's controller each combat if able.\nWhen enchanted creature dies, draw a card.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "91b7b1a3-fb87-509e-b77d-3cad8f1cc048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c75011-1cad-49eb-b104-7223c2e3b1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c75011-1cad-49eb-b104-7223c2e3b1e0.jpg?1",
             "name": "A-Public Enemy",
             "text": "",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "d637112a-299a-5989-a3b7-19b4d96dd175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf9152-da16-4289-9a2d-331e7b9cb839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cf9152-da16-4289-9a2d-331e7b9cb839.jpg?1",
             "name": "Reservoir Kraken",
             "text": "Trample, ward {2}\nAt the beginning of each combat, if Reservoir Kraken is untapped, any opponent may tap an untapped creature they control. If they do, tap Reservoir Kraken and create a 1/1 blue Fish creature token with \"This creature can't be blocked.\"",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "3fe960c9-e079-574b-96cf-f43aa09caf65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a84781-b40c-41e0-a0b9-86e466c9b12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7a84781-b40c-41e0-a0b9-86e466c9b12d.jpg?1",
             "name": "Rooftop Nuisance",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -2175,7 +2175,7 @@
         },
         {
             "id": "b114d714-7246-589d-838c-12feebe9fb6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf00112-0844-49db-a061-d0eb488de68a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cf00112-0844-49db-a061-d0eb488de68a.jpg?1",
             "name": "Run Out of Town",
             "text": "The owner of target nonland permanent puts it on the top or bottom of their library.",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "44909dd6-fb99-5952-8412-2e1340b996fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c155be9-8432-4e35-b586-96b6339d27ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c155be9-8432-4e35-b586-96b6339d27ae.jpg?1",
             "name": "Security Bypass",
             "text": "Enchant creature\nAs long as enchanted creature is attacking alone, it can't be blocked.\nEnchanted creature has \"Whenever this creature deals combat damage to a player, it connives.\" (Its controller draws a card, then discards a card. If they discarded a nonland card, they put a +1/+1 counter on this creature.)",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "616e28b1-2832-5123-be09-83351badb2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06ac58b-6d72-4eb4-a1c9-61b5314c7769.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06ac58b-6d72-4eb4-a1c9-61b5314c7769.jpg?1",
             "name": "Sewer Crocodile",
             "text": "{3}{U}: Sewer Crocodile can't be blocked this turn. This ability costs {3} less to activate if there are five or more mana values among cards in your graveyard.",
             "colours": [
@@ -2275,7 +2275,7 @@
         },
         {
             "id": "1e12a7c6-8515-58d9-9537-02d4f90822e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c9b674-b13e-4ba0-8eef-067e62db1b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c9b674-b13e-4ba0-8eef-067e62db1b8a.jpg?1",
             "name": "A-Sewer Crocodile",
             "text": "",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "2379daf8-90aa-5d70-9a4c-0c6c7f3e271a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3742a0fb-4b86-49d6-b6fb-bd6a42fa1bcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3742a0fb-4b86-49d6-b6fb-bd6a42fa1bcb.jpg?1",
             "name": "Sleep with the Fishes",
             "text": "Enchant creature\nWhen Sleep with the Fishes enters the battlefield, tap enchanted creature and you create a 1/1 blue Fish creature token with \"This creature can't be blocked.\"\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "134e52c9-d7ec-5e1f-9795-a3f65067b93d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725f4c4-fad7-460e-b86c-ff81674f0980.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8725f4c4-fad7-460e-b86c-ff81674f0980.jpg?1",
             "name": "Slip Out the Back",
             "text": "Put a +1/+1 counter on target creature. It phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "99f04d72-2ec0-5337-b21b-c9d8df150cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecec953-ab86-409b-b618-04bb07ff3eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ecec953-ab86-409b-b618-04bb07ff3eac.jpg?1",
             "name": "Undercover Operative",
             "text": "You may have Undercover Operative enter the battlefield as a copy of any creature on the battlefield, except it enters with a shield counter on it if you control that creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "1e2d27db-506e-5e2e-adb9-72a38b8e6c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec36ec-1a9c-41db-b304-c23286a4d182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9ec36ec-1a9c-41db-b304-c23286a4d182.jpg?1",
             "name": "Wingshield Agent",
             "text": "Wingshield Agent enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever Wingshield Agent attacks, up to one other target creature gains flying until end of turn.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "99429fca-4b0d-5c52-b36e-10197c467346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859ed6fc-1f9a-428d-82d8-8e4b5bae6d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859ed6fc-1f9a-428d-82d8-8e4b5bae6d5a.jpg?1",
             "name": "Wiretapping",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWhenever you draw your first card during each of your draw steps, draw a card. Then if you have nine or more cards in hand, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -2480,7 +2480,7 @@
         },
         {
             "id": "8135a0bd-a7c4-5401-bd2e-41232e4504b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be6f2c-8ad0-402d-a7ca-9fe817e83b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2be6f2c-8ad0-402d-a7ca-9fe817e83b72.jpg?1",
             "name": "Witness Protection",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a green and white Citizen creature with base power and toughness 1/1 named Legitimate Businessperson. (It loses all other colors, card types, creature types, and names.)",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "13c245cc-3655-5287-b252-7025a423a99a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4aee25-496d-453e-95b7-d773fe21cacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd4aee25-496d-453e-95b7-d773fe21cacc.jpg?1",
             "name": "Angel of Suffering",
             "text": "Flying\nIf damage would be dealt to you, prevent that damage and mill twice that many cards.",
             "colours": [
@@ -2551,7 +2551,7 @@
         },
         {
             "id": "3d16fea1-8001-5967-ac8d-acde33a80fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d7d77a-35b6-451a-af44-ecaf38facccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d7d77a-35b6-451a-af44-ecaf38facccb.jpg?1",
             "name": "Body Launderer",
             "text": "Deathtouch\nWhenever another nontoken creature you control dies, Body Launderer connives.\nWhen Body Launderer dies, return another target non-Rogue creature card with equal or lesser power from your graveyard to the battlefield.",
             "colours": [
@@ -2588,7 +2588,7 @@
         },
         {
             "id": "aba0ced3-f350-59ed-bbaf-88c897ebaa89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6e8d37-badd-4b9a-94e5-2d50ec78182c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6e8d37-badd-4b9a-94e5-2d50ec78182c.jpg?1",
             "name": "Cemetery Tampering",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nAt the beginning of your upkeep, you may mill three cards. Then if there are twenty or more cards in your graveyard, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -2622,7 +2622,7 @@
         },
         {
             "id": "635f5f08-1ecc-52db-917a-61fe6bd97185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c6215-4006-4c4f-897a-be051cb73fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/505c6215-4006-4c4f-897a-be051cb73fa7.jpg?1",
             "name": "Corrupt Court Official",
             "text": "When Corrupt Court Official enters the battlefield, target opponent discards a card.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "80c4d8e3-3b27-51c2-9270-129778f9b8fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d6f60-3e8a-4c58-8b3c-9ba59a01c867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d6f60-3e8a-4c58-8b3c-9ba59a01c867.jpg?1",
             "name": "Crooked Custodian",
             "text": "Crooked Custodian enters the battlefield tapped.",
             "colours": [
@@ -2692,7 +2692,7 @@
         },
         {
             "id": "0a90b8d7-eb14-5d40-96ee-c5326855bb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e86078-1629-40dc-88a9-102c543255b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e86078-1629-40dc-88a9-102c543255b8.jpg?1",
             "name": "Cut of the Profits",
             "text": "Casualty 3 (As you cast this spell, you may sacrifice a creature with power 3 or greater. When you do, copy this spell.)\nYou draw X cards and you lose X life.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "daf89f89-b704-5def-958d-1e9a47ab70bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b23b3e4-58cf-4b5d-bdcb-410a403b4987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b23b3e4-58cf-4b5d-bdcb-410a403b4987.jpg?1",
             "name": "Cutthroat Contender",
             "text": "Pay 1 life: Cutthroat Contender gets +1/+0 until end of turn. Activate only once each turn.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "3c4a96d6-507e-58b4-83e7-c6304c0a1942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3359f13d-9946-49fa-b621-28b1ea714e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3359f13d-9946-49fa-b621-28b1ea714e55.jpg?1",
             "name": "Deal Gone Bad",
             "text": "Target creature gets -3/-3 until end of turn. Target player mills three cards. (They put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "21e385d3-b4fa-5cdd-bffa-8f34c3d20cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d88ac4-cde5-4878-934e-cd670a7c9b9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d88ac4-cde5-4878-934e-cd670a7c9b9e.jpg?1",
             "name": "A-Deal Gone Bad",
             "text": "",
             "colours": [
@@ -2824,7 +2824,7 @@
         },
         {
             "id": "d0499812-b2da-577e-91d0-69efc530c326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e59fb98-c887-42f1-a620-9e6b40b94cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e59fb98-c887-42f1-a620-9e6b40b94cb5.jpg?1",
             "name": "Demon's Due",
             "text": "Scry 2, then draw two cards. You lose 2 life.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "428fc6f0-8f3d-5d30-809a-e0bbf3bb70af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9f5336-130a-41aa-9df0-9bbb5dd747d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9f5336-130a-41aa-9df0-9bbb5dd747d9.jpg?1",
             "name": "A-Demon's Due",
             "text": "",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "3b342bb5-29ee-57be-b590-fa60001acc01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902abe4d-5c19-4c96-b825-e6cd4d954a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902abe4d-5c19-4c96-b825-e6cd4d954a84.jpg?1",
             "name": "Dig Up the Body",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nMill two cards, then you may return a creature card from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "28acbfb1-213e-5154-993e-106a72380e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86825b2-5b03-4311-b7d9-f8131b17249d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86825b2-5b03-4311-b7d9-f8131b17249d.jpg?1",
             "name": "Dusk Mangler",
             "text": "As an additional cost to cast this spell, sacrifice a creature, discard a card, or pay 4 life.\nWhen Dusk Mangler enters the battlefield, each opponent sacrifices a creature, discards a card, and loses 4 life.",
             "colours": [
@@ -2953,7 +2953,7 @@
         },
         {
             "id": "4205b972-2ea8-54d9-a1e9-b83fce8e79a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb9df1-4475-45e7-bc9c-40937c8c1722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb9df1-4475-45e7-bc9c-40937c8c1722.jpg?1",
             "name": "Extract the Truth",
             "text": "Choose one \u2014\n\u2022 Target opponent reveals their hand. You may choose a creature, enchantment, or planeswalker card from it. That player discards that card.\n\u2022 Target opponent sacrifices an enchantment.",
             "colours": [
@@ -2985,7 +2985,7 @@
         },
         {
             "id": "ca8099fe-492a-5165-8d7c-a2523915f538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e117a8-3291-4f9a-ab00-c820c8e2aa00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e117a8-3291-4f9a-ab00-c820c8e2aa00.jpg?1",
             "name": "Fake Your Own Death",
             "text": "Until end of turn, target creature gets +2/+0 and gains \"When this creature dies, return it to the battlefield tapped under its owner's control and you create a Treasure token.\" (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3017,7 +3017,7 @@
         },
         {
             "id": "3b0b0f66-3340-5e25-9124-a9d7a6c0a123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd6449-31a1-4572-8f9c-3f6f4670dc9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bfd6449-31a1-4572-8f9c-3f6f4670dc9d.jpg?1",
             "name": "Girder Goons",
             "text": "When Girder Goons dies, create a tapped 2/2 black Rogue creature token.\nBlitz {3}{B} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -3052,7 +3052,7 @@
         },
         {
             "id": "7e692266-839b-50e2-9dba-e8fb3f37cdc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394d7fb3-44ee-409f-a992-27e5aabd9c2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394d7fb3-44ee-409f-a992-27e5aabd9c2b.jpg?1",
             "name": "Graveyard Shift",
             "text": "This spell has flash as long as there are five or more mana values among cards in your graveyard.\nReturn target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "e73e5a18-0f18-5847-b281-135cee8099dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a87a-ecb2-4f1c-93ad-17091af3da15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fca8a87a-ecb2-4f1c-93ad-17091af3da15.jpg?1",
             "name": "A-Graveyard Shift",
             "text": "",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "c7f3792e-5197-5bd2-9c93-133f0aabb9ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322e12d-b932-4ca1-a51d-e2a928140cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6322e12d-b932-4ca1-a51d-e2a928140cc7.jpg?1",
             "name": "Grisly Sigil",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nChoose target creature or planeswalker. If it was dealt noncombat damage this turn, Grisly Sigil deals 3 damage to it and you gain 3 life. Otherwise, Grisly Sigil deals 1 damage to it and you gain 1 life.",
             "colours": [
@@ -3147,7 +3147,7 @@
         },
         {
             "id": "d4995138-f583-5c66-8888-0cb2b3a1980e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cced2-390b-499f-ace3-e52fd53d4712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7cced2-390b-499f-ace3-e52fd53d4712.jpg?1",
             "name": "Illicit Shipment",
             "text": "Casualty 3 (As you cast this spell, you may sacrifice a creature with power 3 or greater. When you do, copy this spell.)\nSearch your library for a card, put it into your hand, then shuffle.",
             "colours": [
@@ -3179,7 +3179,7 @@
         },
         {
             "id": "c13d50dc-197e-549c-abc1-73ca9ad43544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198ec497-4e95-4386-9ca4-35d2d3f59733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198ec497-4e95-4386-9ca4-35d2d3f59733.jpg?1",
             "name": "Incriminate",
             "text": "Choose two target creatures controlled by the same player. That player sacrifices one of them.",
             "colours": [
@@ -3213,7 +3213,7 @@
         },
         {
             "id": "0ccafea2-47bd-5dae-a70d-5bdc7f38585b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf60fdcf-f07a-4daa-b670-f6c2793e72eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf60fdcf-f07a-4daa-b670-f6c2793e72eb.jpg?1",
             "name": "A-Incriminate",
             "text": "",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "c8e0c504-a045-5905-9c7e-38643edaef94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2665f7-6cf8-4f9b-810e-17e264753225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff2665f7-6cf8-4f9b-810e-17e264753225.jpg?1",
             "name": "Join the Maestros",
             "text": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell.)\nCreate a 4/3 black Ogre Warrior creature token.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "98327724-2039-565f-8ae6-a93a016a2be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db94f2a9-53be-449e-8240-77f013cdd7e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db94f2a9-53be-449e-8240-77f013cdd7e3.jpg?1",
             "name": "Maestros Initiate",
             "text": "{4}{UR}, Exile Maestros Initiate from your graveyard: Draw two cards, then discard a card.",
             "colours": [
@@ -3313,7 +3313,7 @@
         },
         {
             "id": "8d9535ba-ef75-5f54-b1fc-9e43b50d0824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a4a5b3-0477-4709-8bce-3e01f54001b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a4a5b3-0477-4709-8bce-3e01f54001b6.jpg?1",
             "name": "Midnight Assassin",
             "text": "Flying, deathtouch",
             "colours": [
@@ -3348,7 +3348,7 @@
         },
         {
             "id": "4d98f663-7d4a-51d6-9850-53c625545331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37409205-a750-475a-9755-5ad21792acd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37409205-a750-475a-9755-5ad21792acd7.jpg?1",
             "name": "A-Midnight Assassin",
             "text": "",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "8a9222fd-3214-530d-94ad-a1be1acb0eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c13ac76-7cd9-456f-9b89-92bfa07c64c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c13ac76-7cd9-456f-9b89-92bfa07c64c5.jpg?1",
             "name": "Murder",
             "text": "Destroy target creature.",
             "colours": [
@@ -3414,7 +3414,7 @@
         },
         {
             "id": "bf3430b6-172b-5ab7-abc2-4d44b995666a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fd3f8a-a13b-4a0a-bb27-b9246949ea7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59fd3f8a-a13b-4a0a-bb27-b9246949ea7b.jpg?1",
             "name": "Night Clubber",
             "text": "When Night Clubber enters the battlefield, creatures your opponents control get -1/-1 until end of turn.\nBlitz {2}{B} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -3449,7 +3449,7 @@
         },
         {
             "id": "86ee8518-ea66-514f-9bc8-1aa8bb7b3bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba72399-c827-43f3-b072-08597dbafb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4ba72399-c827-43f3-b072-08597dbafb2d.jpg?1",
             "name": "Raffine's Silencer",
             "text": "When Raffine's Silencer enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)\nWhen Raffine's Silencer dies, target creature an opponent controls gets -X/-X until end of turn, where X is Raffine's Silencer's power.",
             "colours": [
@@ -3484,7 +3484,7 @@
         },
         {
             "id": "25f52318-6762-5fc5-b32f-c5cbe7b2d481",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fbe7f0-8a91-4832-8953-54ab3669372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3fbe7f0-8a91-4832-8953-54ab3669372c.jpg?1",
             "name": "Revel Ruiner",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Revel Ruiner enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -3519,7 +3519,7 @@
         },
         {
             "id": "7e487655-89ac-575e-80bb-be539dea0ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fe4c78-41da-4643-841f-07d54670f1be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fe4c78-41da-4643-841f-07d54670f1be.jpg?1",
             "name": "A-Revel Ruiner",
             "text": "",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "cc7b5fff-382f-5409-a49b-bd6956ce44c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b1fce-585f-442c-99a6-3b9767d68f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9b1fce-585f-442c-99a6-3b9767d68f13.jpg?1",
             "name": "Rogues' Gallery",
             "text": "For each color, return up to one target creature card of that color from your graveyard to your hand.",
             "colours": [
@@ -3585,7 +3585,7 @@
         },
         {
             "id": "bca4ead8-1d00-572c-b1b9-7d5e09200f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d52ea1e-5b66-47c7-9a6d-95f5996565d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d52ea1e-5b66-47c7-9a6d-95f5996565d8.jpg?1",
             "name": "Sanguine Spy",
             "text": "Menace, lifelink\n{1}, Sacrifice another creature: Look at the top card of your library. You may put that card into your graveyard.\nAt the beginning of your end step, if there are five or more mana values among cards in your graveyard, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "eedca4c7-5be6-5d46-bf75-0d8ce0c64959",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cbb0db-94e9-4988-b900-ced4f9e6d4ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cbb0db-94e9-4988-b900-ced4f9e6d4ed.jpg?1",
             "name": "Shadow of Mortality",
             "text": "If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.",
             "colours": [
@@ -3658,7 +3658,7 @@
         },
         {
             "id": "49b16ab0-9d08-5edb-9388-71256c721ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce418184-a672-46bc-a17d-c559614defb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce418184-a672-46bc-a17d-c559614defb5.jpg?1",
             "name": "Shakedown Heavy",
             "text": "Menace\nWhenever Shakedown Heavy attacks, defending player may have you draw a card. If they do, untap Shakedown Heavy and remove it from combat.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "112dbb10-8bc8-594a-9fbe-cb2c2c07f7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17114ed-f98f-4b82-ba03-ef7ec5f572ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b17114ed-f98f-4b82-ba03-ef7ec5f572ba.jpg?1",
             "name": "Tavern Swindler",
             "text": "{T}, Pay 3 life: Flip a coin. If you win the flip, you gain 6 life.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "a5a0d116-10c7-58ba-b382-77da93aa9a8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a6d00-3e00-4827-8420-13343ac3d0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a6d00-3e00-4827-8420-13343ac3d0fd.jpg?1",
             "name": "Tenacious Underdog",
             "text": "Blitz\u2014{2}{B}{B}, Pay 2 life. (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)\nYou may cast Tenacious Underdog from your graveyard using its blitz ability.",
             "colours": [
@@ -3768,7 +3768,7 @@
         },
         {
             "id": "cf31864f-54c6-5587-a4fe-134e28021cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702315d7-dec9-49e8-a508-feacd47198dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702315d7-dec9-49e8-a508-feacd47198dc.jpg?1",
             "name": "Vampire Scrivener",
             "text": "Flying\nWhenever you gain life during your turn, put a +1/+1 counter on Vampire Scrivener.\nWhenever you lose life during your turn, put a +1/+1 counter on Vampire Scrivener.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "5a9956bf-4e2f-55b3-8b81-191506a82495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7daf9711-4064-4f09-9371-aa1165d3d1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7daf9711-4064-4f09-9371-aa1165d3d1db.jpg?1",
             "name": "A-Vampire Scrivener",
             "text": "",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "b5ecf98a-4290-5f50-a5f7-9ca4232c7d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862769d-f8bd-4cb6-b2b2-816179795f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862769d-f8bd-4cb6-b2b2-816179795f8b.jpg?1",
             "name": "Whack",
             "text": "This spell costs {3} less to cast if it targets a white creature.\nTarget creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "5e1ae175-f5e3-5be6-9f65-fff36a0a7edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bac1d2a-99dd-40b3-8823-ce9225efcdcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bac1d2a-99dd-40b3-8823-ce9225efcdcf.jpg?1",
             "name": "Antagonize",
             "text": "Target creature gets +4/+3 until end of turn.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "d17ac04d-3615-5ecc-ab68-0dc6ef01f06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f1b2bd-fe06-45ec-99dc-ff357a7a31d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f1b2bd-fe06-45ec-99dc-ff357a7a31d2.jpg?1",
             "name": "Arcane Bombardment",
             "text": "Whenever you cast your first instant or sorcery spell each turn, exile an instant or sorcery card at random from your graveyard. Then copy each card exiled with Arcane Bombardment. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "d5abbcee-de41-5e9b-9338-8dd66f7f0506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d1578f-e2cf-4b93-8204-ed5434feb183.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d1578f-e2cf-4b93-8204-ed5434feb183.jpg?1",
             "name": "Big Score",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "6d93af53-1f4a-5b71-83af-07e9399ebb5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead68c0a-eed1-4a9c-a790-56f8a79b444c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead68c0a-eed1-4a9c-a790-56f8a79b444c.jpg?1",
             "name": "Call In a Professional",
             "text": "Players can't gain life this turn. Damage can't be prevented this turn. Call In a Professional deals 3 damage to any target. (Shield counters don't prevent this damage as they're removed.)",
             "colours": [
@@ -3999,7 +3999,7 @@
         },
         {
             "id": "68416cf0-de86-51f2-8a1e-d568481de223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09dbcd-188b-4b52-943e-947cbf2c0002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d09dbcd-188b-4b52-943e-947cbf2c0002.jpg?1",
             "name": "Daring Escape",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -4031,7 +4031,7 @@
         },
         {
             "id": "169a9ece-6111-5ca4-817a-6fd40f094e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d3fc69-6c5e-4ede-9f8d-c1cee096a78a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d3fc69-6c5e-4ede-9f8d-c1cee096a78a.jpg?1",
             "name": "Devilish Valet",
             "text": "Trample, haste\nAlliance \u2014 Whenever another creature enters the battlefield under your control, double Devilish Valet's power until end of turn.",
             "colours": [
@@ -4068,7 +4068,7 @@
         },
         {
             "id": "fa228e9b-1aa5-59ca-9f7a-eface296c7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb4479f-3157-44b4-b18b-7553c7513118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbb4479f-3157-44b4-b18b-7553c7513118.jpg?1",
             "name": "Exhibition Magician",
             "text": "When Exhibition Magician enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 green and white Citizen creature token.\n\u2022 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4103,7 +4103,7 @@
         },
         {
             "id": "def2f4e0-2ca1-57a5-985c-4e098b1046d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a222b6a5-27b9-4a8a-a727-ad113808ca7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a222b6a5-27b9-4a8a-a727-ad113808ca7d.jpg?1",
             "name": "A-Exhibition Magician",
             "text": "",
             "colours": [
@@ -4137,7 +4137,7 @@
         },
         {
             "id": "b98aac71-9558-55e4-bc5d-a77236be7005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973685e8-3df1-436b-b5c2-01573a92b61e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/973685e8-3df1-436b-b5c2-01573a92b61e.jpg?1",
             "name": "Glittering Stockpile",
             "text": "{T}: Add {R}. Put a stash counter on Glittering Stockpile.\n{T}, Sacrifice Glittering Stockpile: Add X mana of any one color, where X is the number of stash counters on Glittering Stockpile.",
             "colours": [
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "dea71bb5-52d3-54db-8607-37b9b460e804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059e4b4-1542-4b5c-810a-9f0abac5792b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c059e4b4-1542-4b5c-810a-9f0abac5792b.jpg?1",
             "name": "Goldhound",
             "text": "First strike\nMenace (This creature can't be blocked except by two or more creatures.)\n{T}, Sacrifice Goldhound: Add one mana of any color.",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "c4296f30-bf9b-5845-add2-8ac27f6e3bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f190e9-52f3-4e34-8fb6-88174c189ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f190e9-52f3-4e34-8fb6-88174c189ee7.jpg?1",
             "name": "Hoard Hauler",
             "text": "Trample\nWhenever Hoard Hauler deals combat damage to a player, create a Treasure token for each artifact they control.\nCrew 3",
             "colours": [
@@ -4243,7 +4243,7 @@
         },
         {
             "id": "f2fab2f0-08f9-56a7-aefc-c2f01b24e1eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7626e2-0041-4ac5-97b3-2db8dcb094d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7626e2-0041-4ac5-97b3-2db8dcb094d4.jpg?1",
             "name": "Involuntary Employment",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4275,7 +4275,7 @@
         },
         {
             "id": "9f6a0ceb-f2b9-56c2-a83d-4c30f8d2f6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74ba9fe-2dcb-4da7-ba64-cd932edb5b24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74ba9fe-2dcb-4da7-ba64-cd932edb5b24.jpg?1",
             "name": "Jackhammer",
             "text": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "3e1a7583-f759-520c-ac76-2fa17c7c4537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68068a3a-8258-4e7d-8031-3dc93adf3c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68068a3a-8258-4e7d-8031-3dc93adf3c3b.jpg?1",
             "name": "A-Jackhammer",
             "text": "",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "e706b0b7-fd25-55aa-9d58-4bec287a05d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78127c0c-672f-4e4b-9c23-6a5f237228fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78127c0c-672f-4e4b-9c23-6a5f237228fd.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "{R}, {T}, Discard a card: Create a token that's a copy of another target creature you control. It gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\nBlitz {1}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "5a308c44-f787-51f9-803a-2a6709fa7aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee31d56a-9b7e-4de0-81cb-3b7c76b6fbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee31d56a-9b7e-4de0-81cb-3b7c76b6fbd5.jpg?1",
             "name": "Light 'Em Up",
             "text": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nLight 'Em Up deals 2 damage to target creature or planeswalker.",
             "colours": [
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "f6b5031b-01dd-56ed-b0da-5d7373f6dff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50162cdd-ba30-48df-93ff-197c7f4a2913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50162cdd-ba30-48df-93ff-197c7f4a2913.jpg?1",
             "name": "Mayhem Patrol",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Mayhem Patrol attacks, target creature gets +1/+0 until end of turn.\nBlitz {1}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4451,7 +4451,7 @@
         },
         {
             "id": "26853c5e-254c-5bd2-ad02-391c6d6f0585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741ed811-cbcd-4178-a874-dc79d2a5d6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/741ed811-cbcd-4178-a874-dc79d2a5d6f1.jpg?1",
             "name": "Plasma Jockey",
             "text": "Whenever Plasma Jockey attacks, target creature an opponent controls can't block this turn.\nBlitz {2}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "14752dc2-de66-5a31-9e3c-928411540af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acbf52-b137-44f0-a815-2817fe8d2da2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42acbf52-b137-44f0-a815-2817fe8d2da2.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "Menace\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token.\nSacrifice a Treasure: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "b2638abe-1993-53e4-a013-f5a671f863f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98022d2-3b46-41f4-8f31-0a238d881ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98022d2-3b46-41f4-8f31-0a238d881ac6.jpg?1",
             "name": "Pugnacious Pugilist",
             "text": "Whenever Pugnacious Pugilist attacks, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\nBlitz {3}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4558,7 +4558,7 @@
         },
         {
             "id": "e8c6ddd5-8964-5359-a376-d06be20ed246",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c5fd3e-3799-4535-8c33-9c567f4f5709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33c5fd3e-3799-4535-8c33-9c567f4f5709.jpg?1",
             "name": "Pyre-Sledge Arsonist",
             "text": "{1}, {T}: Pyre-Sledge Arsonist deals X damage to any target, where X is the number of permanents you've sacrificed this turn.",
             "colours": [
@@ -4593,7 +4593,7 @@
         },
         {
             "id": "a2365a98-cc17-51f8-aa18-592ce10c0348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6016155a-d694-45af-bd05-1b2d8046d993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6016155a-d694-45af-bd05-1b2d8046d993.jpg?1",
             "name": "A-Pyre-Sledge Arsonist",
             "text": "",
             "colours": [
@@ -4627,7 +4627,7 @@
         },
         {
             "id": "4a835e9c-49f2-553b-8062-22d53a3ad0ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16998689-345d-41e3-a368-e97b696ed689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16998689-345d-41e3-a368-e97b696ed689.jpg?1",
             "name": "Ready to Rumble",
             "text": "Choose one \u2014\n\u2022 Ready to Rumble deals 5 damage to target creature or planeswalker.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "23ee4336-c573-5bd5-853b-35f0767f758a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392ab2d-d3aa-466f-837e-27365ebcec6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a392ab2d-d3aa-466f-837e-27365ebcec6e.jpg?1",
             "name": "A-Ready to Rumble",
             "text": "",
             "colours": [
@@ -4690,7 +4690,7 @@
         },
         {
             "id": "52587e79-87d9-5739-b16d-c349f8a9abd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e65a50-d2bc-43a0-a9d4-0e846d170f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e65a50-d2bc-43a0-a9d4-0e846d170f78.jpg?1",
             "name": "Riveteers Initiate",
             "text": "{1}{BG}: Riveteers Initiate gains deathtouch until end of turn.",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "c2acdf80-6adb-5bf3-a9b6-a96f93d8a695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62e39e3-f266-41ac-a0c3-3dce45e783f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62e39e3-f266-41ac-a0c3-3dce45e783f7.jpg?1",
             "name": "A-Riveteers Initiate",
             "text": "",
             "colours": [
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "c1d9f153-75be-55f7-92f2-95b809429627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5152d-767a-47d5-acfc-f439810aaeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ab5152d-767a-47d5-acfc-f439810aaeea.jpg?1",
             "name": "Riveteers Requisitioner",
             "text": "When Riveteers Requisitioner dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nBlitz {2}{R} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4798,7 +4798,7 @@
         },
         {
             "id": "25b043d0-32cc-5c36-98b2-d124d8d17cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ec95f6-88c8-4daf-882f-8b4bc73452c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ec95f6-88c8-4daf-882f-8b4bc73452c3.jpg?1",
             "name": "Rob the Archives",
             "text": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nExile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -4830,7 +4830,7 @@
         },
         {
             "id": "507c83ed-eaf6-5c7f-a28f-88890c2bef0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958dfd59-7dbd-45e0-b6e1-e432c78b6878.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958dfd59-7dbd-45e0-b6e1-e432c78b6878.jpg?1",
             "name": "Sizzling Soloist",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, target creature an opponent controls can't block this turn. If this is the second time this ability has resolved this turn, that creature attacks during its controller's next combat phase if able.",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "6fecc13a-5f15-5411-86d0-efe85dc8981b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a755e0ed-92fe-4910-8113-f2b9f83294e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a755e0ed-92fe-4910-8113-f2b9f83294e6.jpg?1",
             "name": "A-Sizzling Soloist",
             "text": "",
             "colours": [
@@ -4899,7 +4899,7 @@
         },
         {
             "id": "bb3e8638-59d7-5981-9712-585531304b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678fa3d-d41f-4b7a-b25e-6fc5f78876c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678fa3d-d41f-4b7a-b25e-6fc5f78876c7.jpg?1",
             "name": "Sticky Fingers",
             "text": "Enchant creature\nEnchanted creature has menace and \"Whenever this creature deals combat damage to a player, create a Treasure token.\" (It can't be blocked except by two or more creatures. The token is an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nWhen enchanted creature dies, draw a card.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "35b32e7c-6be7-566e-9e5d-4851b3d9ef4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b91d727-c0ee-4bf0-8c7d-8475ecb88083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b91d727-c0ee-4bf0-8c7d-8475ecb88083.jpg?1",
             "name": "Strangle",
             "text": "Strangle deals 3 damage to target creature or planeswalker.",
             "colours": [
@@ -4965,7 +4965,7 @@
         },
         {
             "id": "5f18dca7-2ed8-5fad-84ea-7317cd06d465",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbdb50e3-fe15-4431-b9bd-c4de65820734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbdb50e3-fe15-4431-b9bd-c4de65820734.jpg?1",
             "name": "Structural Assault",
             "text": "Destroy all artifacts, then Structural Assault deals damage to each creature equal to the number of artifacts that were put into graveyards from the battlefield this turn.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "12267498-968a-5e93-a5a7-13be63e2cc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbd4a8-c44c-42fc-b946-bdc7e20e1668.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9fbd4a8-c44c-42fc-b946-bdc7e20e1668.jpg?1",
             "name": "Torch Breath",
             "text": "This spell costs {2} less to cast if it targets a blue permanent.\nThis spell can't be countered.\nTorch Breath deals X damage to target creature or planeswalker.",
             "colours": [
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "d3ab66aa-cd12-58dd-8b1f-c43a5900ea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6430c0-67c1-4793-b4be-8f47545c57d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec6430c0-67c1-4793-b4be-8f47545c57d6.jpg?1",
             "name": "Unlucky Witness",
             "text": "When Unlucky Witness dies, exile the top two cards of your library. Until your next end step, you may play one of those cards.",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "685baf4b-1ede-5ff4-be0e-dc0bf8d1429d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a4ec18-1da4-43c6-a79a-03fbd4aef3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a4ec18-1da4-43c6-a79a-03fbd4aef3db.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "Haste\nAt the beginning of your upkeep, exile the top card of your library. You may play it this turn.\nAt the beginning of each opponent's upkeep, the next time they would draw a card this turn, instead they exile the top card of their library. They may play it this turn.",
             "colours": [
@@ -5109,7 +5109,7 @@
         },
         {
             "id": "107f2e6e-4d37-5d26-9d42-0672b44c9376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd22723d-855f-4b31-827f-a4e388ebbc07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd22723d-855f-4b31-827f-a4e388ebbc07.jpg?1",
             "name": "Widespread Thieving",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nWhenever you cast a multicolored spell, create a Treasure token. Then you may pay {W}{U}{B}{R}{G}. If you do, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -5147,7 +5147,7 @@
         },
         {
             "id": "7b785eba-d9dd-556b-959e-83ec218dab94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d13f19-482b-4a2e-9692-b7d7caf2f9f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71d13f19-482b-4a2e-9692-b7d7caf2f9f5.jpg?1",
             "name": "Witty Roastmaster",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, Witty Roastmaster deals 1 damage to each opponent.",
             "colours": [
@@ -5182,7 +5182,7 @@
         },
         {
             "id": "0cddd98a-3e7c-5888-88f2-1b74bed3e759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92691507-b1ce-40d0-87e7-b79e81370511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92691507-b1ce-40d0-87e7-b79e81370511.jpg?1",
             "name": "Wrecking Crew",
             "text": "Reach, trample",
             "colours": [
@@ -5217,7 +5217,7 @@
         },
         {
             "id": "43596353-6d32-5337-a6f9-db65ade1409b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bccccf9-3ee5-4485-ae01-4dcbad989d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bccccf9-3ee5-4485-ae01-4dcbad989d18.jpg?1",
             "name": "Attended Socialite",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, Attended Socialite gets +1/+1 until end of turn.",
             "colours": [
@@ -5252,7 +5252,7 @@
         },
         {
             "id": "8fa4658a-ff0e-552f-98a6-e9b9d3cf9fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg?1",
             "name": "Bootleggers' Stash",
             "text": "Lands you control have \"{T}: Create a Treasure token.\"",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "48f11fba-d67a-5e7b-9bd9-4cdbfdd26be7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54772e15-d99d-4eec-ba8d-b9202a7e318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54772e15-d99d-4eec-ba8d-b9202a7e318b.jpg?1",
             "name": "Bouncer's Beatdown",
             "text": "This spell costs {2} less to cast if it targets a black permanent.\nBouncer's Beatdown deals X damage to target creature or planeswalker, where X is the greatest power among creatures you control. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -5318,7 +5318,7 @@
         },
         {
             "id": "c16da7d7-bd82-5226-9c2f-dfb050b0b907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb94908-4f4a-487e-87ac-8d5bdefe9983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eb94908-4f4a-487e-87ac-8d5bdefe9983.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -5350,7 +5350,7 @@
         },
         {
             "id": "85225ced-5890-5544-91fc-99e4d5ce2492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c691f62-009b-4178-8e8b-d6e88229a282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c691f62-009b-4178-8e8b-d6e88229a282.jpg?1",
             "name": "Cabaretti Initiate",
             "text": "{2}{GU}: Cabaretti Initiate gains double strike until end of turn.",
             "colours": [
@@ -5387,7 +5387,7 @@
         },
         {
             "id": "32ab28eb-8598-563d-a7f7-15cb4fe34001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b431d2-33c1-49d8-b45d-690c174bb456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b431d2-33c1-49d8-b45d-690c174bb456.jpg?1",
             "name": "Caldaia Strongarm",
             "text": "When Caldaia Strongarm enters the battlefield, put two +1/+1 counters on target creature.\nBlitz {3}{G} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -5422,7 +5422,7 @@
         },
         {
             "id": "51e15047-3901-5b8f-b4df-00f2d759cf53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5530b04-f086-4d09-97e9-eda45f8b1f7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5530b04-f086-4d09-97e9-eda45f8b1f7b.jpg?1",
             "name": "Capenna Express",
             "text": "Sacrifice a Treasure: Capenna Express becomes an artifact creature until end of turn.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -5456,7 +5456,7 @@
         },
         {
             "id": "ee1015c0-caf7-5a04-affc-0ef5dddbc6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc5b78-2156-4a9a-863f-b2f82fbdc87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dbc5b78-2156-4a9a-863f-b2f82fbdc87d.jpg?1",
             "name": "A-Capenna Express",
             "text": "",
             "colours": [
@@ -5489,7 +5489,7 @@
         },
         {
             "id": "132621ef-a1bf-5470-a0cc-84c63901b80a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58d39d7-62bf-43c8-97b3-0f9069af0e29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58d39d7-62bf-43c8-97b3-0f9069af0e29.jpg?1",
             "name": "Civic Gardener",
             "text": "Whenever Civic Gardener attacks, untap target creature or land.",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "0c6db980-2c68-5e78-8c1c-f9d7357d7b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5354868b-c96b-4765-b0c8-8895093e4019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5354868b-c96b-4765-b0c8-8895093e4019.jpg?1",
             "name": "Cleanup Crew",
             "text": "When Cleanup Crew enters the battlefield, choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.\n\u2022 You gain 4 life.",
             "colours": [
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "99335ba6-d6a8-596c-a070-d50bd20d72fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f375674-7ae2-4430-b1f3-c26fa5b201d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f375674-7ae2-4430-b1f3-c26fa5b201d1.jpg?1",
             "name": "Courier's Briefcase",
             "text": "When Courier's Briefcase enters the battlefield, create a 1/1 green and white Citizen creature token.\n{T}, Sacrifice Courier's Briefcase: Add one mana of any color.\n{W}{U}{B}{R}{G}, {T}, Sacrifice Courier's Briefcase: Draw three cards.",
             "colours": [
@@ -5599,7 +5599,7 @@
         },
         {
             "id": "2f2f34c3-29c7-56d4-91ff-0f5acbf7139d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d3500e-09ba-48b6-933f-25b4625b79aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d3500e-09ba-48b6-933f-25b4625b79aa.jpg?1",
             "name": "Elegant Entourage",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, target creature other than Elegant Entourage gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -5634,7 +5634,7 @@
         },
         {
             "id": "94dbf776-bb5d-560a-8c99-dc778c9c2cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bc3b04-46b7-43df-9b29-1502b9f18bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bc3b04-46b7-43df-9b29-1502b9f18bbf.jpg?1",
             "name": "Evolving Door",
             "text": "{1}, {T}, Sacrifice a creature: Count the colors of the sacrificed creature, then search your library for a creature card that's exactly that many colors plus one. Exile that card, then shuffle. You may cast the exiled card. Activate only as a sorcery.",
             "colours": [
@@ -5668,7 +5668,7 @@
         },
         {
             "id": "d43bd345-1f49-5339-ba0b-300facdfab7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg?1",
             "name": "Fight Rigging",
             "text": "Hideaway 5 (When this enchantment enters the battlefield, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if you control a creature with power 7 or greater, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -5702,7 +5702,7 @@
         },
         {
             "id": "2d4b768b-857b-5b33-9d8c-58a6ec966bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052be93c-1970-4d05-a3d1-e87a6e51c423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/052be93c-1970-4d05-a3d1-e87a6e51c423.jpg?1",
             "name": "For the Family",
             "text": "Target creature gets +2/+2 until end of turn. If you control four or more creatures, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -5734,7 +5734,7 @@
         },
         {
             "id": "8c2c1cf2-df53-5eeb-8c88-2d02e22cf2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570f7c90-109b-4d6d-8205-d158753719e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/570f7c90-109b-4d6d-8205-d158753719e8.jpg?1",
             "name": "Freelance Muscle",
             "text": "Whenever Freelance Muscle attacks or blocks, it gets +X/+X until end of turn, where X is the greatest power and/or toughness among other creatures you control.",
             "colours": [
@@ -5769,7 +5769,7 @@
         },
         {
             "id": "18e8dca4-b446-50e2-891d-ce7bc114622a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1baaa2-bd0b-4627-b93a-0753e0acd0f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1baaa2-bd0b-4627-b93a-0753e0acd0f2.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -5817,7 +5817,7 @@
         },
         {
             "id": "108db9ee-97cd-5bd1-97d2-ce976f3579b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3d70d2-0604-41b3-8dd1-bfeb05832271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3d70d2-0604-41b3-8dd1-bfeb05832271.jpg?1",
             "name": "Glittermonger",
             "text": "{T}: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "5070c2ae-223a-517c-8f31-a339b4cb8d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf8438c-9738-4577-b55d-f1e270c06890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf8438c-9738-4577-b55d-f1e270c06890.jpg?1",
             "name": "A-Glittermonger",
             "text": "",
             "colours": [
@@ -5886,7 +5886,7 @@
         },
         {
             "id": "5f87fd59-b2ec-5c5c-b222-14c347957f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2399c6d7-57f9-4100-ad64-3c8897a438f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2399c6d7-57f9-4100-ad64-3c8897a438f7.jpg?1",
             "name": "High-Rise Sawjack",
             "text": "Reach\nWhenever High-Rise Sawjack blocks a creature with flying, High-Rise Sawjack gets +2/+0 until end of turn.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "cbd8bd62-cc9b-5da9-afd9-ea52adadbe18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287079a9-d2ae-4ba8-b74b-6cd49c0f4109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/287079a9-d2ae-4ba8-b74b-6cd49c0f4109.jpg?1",
             "name": "A-High-Rise Sawjack",
             "text": "",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "1f0ffe97-dfe4-56bc-955e-daa3de9c17db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e498e-1245-40c1-96a4-c9bcfd1cfe1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736e498e-1245-40c1-96a4-c9bcfd1cfe1f.jpg?1",
             "name": "Jewel Thief",
             "text": "Vigilance, trample\nWhen Jewel Thief enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5990,7 +5990,7 @@
         },
         {
             "id": "0906fd55-3248-5fe3-ac3c-717ae4bece94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0e818-db6a-453a-a1f0-a7fade6509d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e0e818-db6a-453a-a1f0-a7fade6509d3.jpg?1",
             "name": "Luxurious Libation",
             "text": "Target creature gets +X/+X until end of turn. Create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -6022,7 +6022,7 @@
         },
         {
             "id": "a5d91e9f-5632-5c77-aca7-8140d84c4eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573c0f68-9ed8-4657-b709-b7f3804aaa68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573c0f68-9ed8-4657-b709-b7f3804aaa68.jpg?1",
             "name": "Most Wanted",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +2/+1.\nWhen enchanted creature dies, create two Treasure tokens.",
             "colours": [
@@ -6056,7 +6056,7 @@
         },
         {
             "id": "e3179103-df36-5537-904d-72a2eb9134d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cdaf8e-1d2f-4443-b071-7fc500ea50ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43cdaf8e-1d2f-4443-b071-7fc500ea50ad.jpg?1",
             "name": "A-Most Wanted",
             "text": "",
             "colours": [
@@ -6089,7 +6089,7 @@
         },
         {
             "id": "a721500e-6354-51e4-a85f-72a6ad772423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544c810b-5f90-4535-aa76-14f8c6b9428a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544c810b-5f90-4535-aa76-14f8c6b9428a.jpg?1",
             "name": "Prizefight",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -6121,7 +6121,7 @@
         },
         {
             "id": "0feb75ff-f8d4-53c4-9b8a-5a6dba31d990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f5b02-16b9-4672-b0ec-f77662e9de76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f5b02-16b9-4672-b0ec-f77662e9de76.jpg?1",
             "name": "Rhox Pummeler",
             "text": "Rhox Pummeler enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nRhox Pummeler has trample as long as it has a shield counter on it.",
             "colours": [
@@ -6156,7 +6156,7 @@
         },
         {
             "id": "8f00943c-1355-53de-9624-4829604aa755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d21701b-6a99-4e1c-82b2-0219f170b09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d21701b-6a99-4e1c-82b2-0219f170b09f.jpg?1",
             "name": "Riveteers Decoy",
             "text": "Riveteers Decoy must be blocked if able.\nBlitz {3}{G} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -6191,7 +6191,7 @@
         },
         {
             "id": "f8e31d20-3644-5875-bf64-77f38213dc9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fb74fd-767f-4dd4-822a-828d59f633ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fb74fd-767f-4dd4-822a-828d59f633ad.jpg?1",
             "name": "Social Climber",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "d5bc7f7d-df49-580e-8aaa-d67c24de61fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666a480-33d9-4a4b-9c65-0dac90476541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3666a480-33d9-4a4b-9c65-0dac90476541.jpg?1",
             "name": "A-Social Climber",
             "text": "",
             "colours": [
@@ -6260,7 +6260,7 @@
         },
         {
             "id": "b4d8a15e-14a9-5b5c-8ee6-9d97eaae89e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4a5122-6922-4ab5-aa43-94cf2d7f9c8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b4a5122-6922-4ab5-aa43-94cf2d7f9c8a.jpg?1",
             "name": "Take to the Streets",
             "text": "Creatures you control get +2/+2 until end of turn. Citizens you control get an additional +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -6292,7 +6292,7 @@
         },
         {
             "id": "87267c6a-ed1c-56ad-bd51-69290d9992d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6f03c1-9e9d-4a0c-af3b-9753b440cd9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6f03c1-9e9d-4a0c-af3b-9753b440cd9f.jpg?1",
             "name": "Titan of Industry",
             "text": "Reach, trample\nWhen Titan of Industry enters the battlefield, choose two \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Target player gains 5 life.\n\u2022 Create a 4/4 green Rhino Warrior creature token.\n\u2022 Put a shield counter on a creature you control.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "62cb6537-d09e-52e1-8f2a-57e195138279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bb2699-280f-4e1e-b3f8-73efe6088f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87bb2699-280f-4e1e-b3f8-73efe6088f31.jpg?1",
             "name": "Topiary Stomper",
             "text": "Vigilance\nWhen Topiary Stomper enters the battlefield, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nTopiary Stomper can't attack or block unless you control seven or more lands.",
             "colours": [
@@ -6365,7 +6365,7 @@
         },
         {
             "id": "8915adaa-a39f-5dbc-8d5f-472e363a66ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04897d8c-ee05-45eb-80f7-76487dbcc449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04897d8c-ee05-45eb-80f7-76487dbcc449.jpg?1",
             "name": "Venom Connoisseur",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, Venom Connoisseur gains deathtouch until end of turn. If this is the second time this ability has resolved this turn, all creatures you control gain deathtouch until end of turn.",
             "colours": [
@@ -6400,7 +6400,7 @@
         },
         {
             "id": "6354e10c-550e-5498-bc32-807d4322b9a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edfb119-abc9-4d4d-bc46-33cce1a0922d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5edfb119-abc9-4d4d-bc46-33cce1a0922d.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "+2: You may sacrifice a creature. If you do, search your library for a creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it onto the battlefield, then shuffle.\n+1: Mill five cards, then put any number of creature cards milled this way into your hand.\n\u22121: Create a 4/4 green Rhino Warrior creature token.",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "3c964967-79bc-5b4b-b7f5-6fae70049b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e0eb-23a5-46a5-b719-5a6f9a1fc4ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfe4e0eb-23a5-46a5-b719-5a6f9a1fc4ce.jpg?1",
             "name": "Voice of the Vermin",
             "text": "Voice of the Vermin enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever Voice of the Vermin attacks, target creature you control has base power and toughness 4/4 until end of turn.",
             "colours": [
@@ -6475,7 +6475,7 @@
         },
         {
             "id": "bb7a8595-b012-5b2d-8a11-cf5ada140177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad9e58e-c9a3-4a0d-9a59-71c20a3275b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bad9e58e-c9a3-4a0d-9a59-71c20a3275b6.jpg?1",
             "name": "Warm Welcome",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -6507,7 +6507,7 @@
         },
         {
             "id": "ecd7d5d4-dbbe-5459-a59a-2cb35b622468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfc1b1d-66f5-49e9-b6bc-c7f78b206c11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfc1b1d-66f5-49e9-b6bc-c7f78b206c11.jpg?1",
             "name": "A-Warm Welcome",
             "text": "",
             "colours": [
@@ -6538,7 +6538,7 @@
         },
         {
             "id": "a863f580-ab35-5527-81d3-c4de46457d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27851834-688f-4929-967d-dfa015194f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27851834-688f-4929-967d-dfa015194f7f.jpg?1",
             "name": "Workshop Warchief",
             "text": "Trample\nWhen Workshop Warchief enters the battlefield, you gain 3 life.\nWhen Workshop Warchief dies, create a 4/4 green Rhino Warrior creature token.\nBlitz {4}{G}{G} (If you cast this spell for its blitz cost, it gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "055680c3-8ee8-5618-b533-7dcdaa9bb746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef329c-61e6-41c1-8d89-ff2417949839.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acef329c-61e6-41c1-8d89-ff2417949839.jpg?1",
             "name": "Aven Heartstabber",
             "text": "Flying\nAs long as there are five or more mana values among cards in your graveyard, Aven Heartstabber gets +2/+2 and has deathtouch.\nWhen Aven Heartstabber dies, mill two cards, then draw a card.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "70d7e6b8-adbe-5644-8b44-eea73b762086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92b13-8b23-4c78-b690-c5d9ca835809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d92b13-8b23-4c78-b690-c5d9ca835809.jpg?1",
             "name": "Black Market Tycoon",
             "text": "At the beginning of your upkeep, Black Market Tycoon deals 2 damage to you for each Treasure you control.\n{T}: Create a Treasure token.",
             "colours": [
@@ -6653,7 +6653,7 @@
         },
         {
             "id": "d40f437a-5467-5469-b2d8-e5c3c1182c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcb6d47-dccb-4b69-aed4-7a6215857606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcb6d47-dccb-4b69-aed4-7a6215857606.jpg?1",
             "name": "Body Dropper",
             "text": "Whenever you sacrifice another creature, put a +1/+1 counter on Body Dropper.\n{B}{R}, Sacrifice another creature: Body Dropper gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6690,7 +6690,7 @@
         },
         {
             "id": "74b430c9-e060-5827-bc55-d6224eff2431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae69722-9cb9-4fb7-830f-a284d4a72027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ae69722-9cb9-4fb7-830f-a284d4a72027.jpg?1",
             "name": "Brazen Upstart",
             "text": "Vigilance\nWhen Brazen Upstart dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6732,7 +6732,7 @@
         },
         {
             "id": "05a024b6-535f-588b-91ae-4f849401bb00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799de0f1-6bf2-4158-8a4f-bedc3d2f6578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799de0f1-6bf2-4158-8a4f-bedc3d2f6578.jpg?1",
             "name": "Brokers Ascendancy",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control and a loyalty counter on each planeswalker you control.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "14403351-8ace-5327-b23a-2a5699ea06b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c9c315-1cf4-468e-a74a-b5f3be4a63a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c9c315-1cf4-468e-a74a-b5f3be4a63a1.jpg?1",
             "name": "Brokers Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature or planeswalker an opponent controls.\n\u2022 Destroy target enchantment.\n\u2022 Draw two cards.",
             "colours": [
@@ -6810,7 +6810,7 @@
         },
         {
             "id": "603668e4-e9aa-5355-b0ea-249215f22c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9738d616-b38f-4968-89d6-805ae368e2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9738d616-b38f-4968-89d6-805ae368e2d4.jpg?1",
             "name": "Cabaretti Ascendancy",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it on the bottom of your library.",
             "colours": [
@@ -6849,7 +6849,7 @@
         },
         {
             "id": "7b0024ea-3746-535e-922b-85817f5cc610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f33c8a-8e93-4296-964b-da132a854b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f33c8a-8e93-4296-964b-da132a854b3b.jpg?1",
             "name": "Cabaretti Charm",
             "text": "Choose one \u2014\n\u2022 Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Create two 1/1 green and white Citizen creature tokens.",
             "colours": [
@@ -6888,7 +6888,7 @@
         },
         {
             "id": "617d7fa1-9c6a-5c12-89af-edb9c024a3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e82413-9736-4013-a39a-5498c1c85bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e82413-9736-4013-a39a-5498c1c85bba.jpg?1",
             "name": "A-Cabaretti Charm",
             "text": "",
             "colours": [
@@ -6923,7 +6923,7 @@
         },
         {
             "id": "767cade4-2bd0-57b9-bfae-a24838ff3973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25803f0b-4475-447e-abdf-dcd6a98dd654.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25803f0b-4475-447e-abdf-dcd6a98dd654.jpg?1",
             "name": "Celestial Regulator",
             "text": "Flying\nWhen Celestial Regulator enters the battlefield, choose target creature you don't control and tap it. If you control a creature with a counter on it, the chosen creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "87a1f65e-856b-53ca-a1da-439c758bc70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ede1b10-56df-4e17-bf86-1082edff1b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ede1b10-56df-4e17-bf86-1082edff1b51.jpg?1",
             "name": "A-Celestial Regulator",
             "text": "",
             "colours": [
@@ -6996,7 +6996,7 @@
         },
         {
             "id": "4f82d89d-f2b2-5e56-9d2c-a86a434802d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a542616-aa4d-40d9-acad-47bc98bd6281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a542616-aa4d-40d9-acad-47bc98bd6281.jpg?1",
             "name": "Ceremonial Groundbreaker",
             "text": "Equipped creature gets +2/+1 and has trample.\nEquip Citizen {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "a7915a9b-bf8a-5a42-8fd4-4f1f3507005f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf5da68-a79b-40a3-93bc-785fb2352b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf5da68-a79b-40a3-93bc-785fb2352b05.jpg?1",
             "name": "Civil Servant",
             "text": "Whenever Civil Servant attacks, you may tap another untapped Citizen you control. If you do, Civil Servant gets +1/+0 and gains lifelink until end of turn.",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "43d65e42-97f3-5961-ac82-8afe1492f725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e9707-b20e-4ea6-b353-9abd98174011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186e9707-b20e-4ea6-b353-9abd98174011.jpg?1",
             "name": "A-Civil Servant",
             "text": "",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "5f0c7709-f42b-5bb4-94e9-5c3882c46f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221ac34a-94ed-4c49-afad-b19cac541731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221ac34a-94ed-4c49-afad-b19cac541731.jpg?1",
             "name": "Cormela, Glamour Thief",
             "text": "Haste\n{1}, {T}: Add {U}{B}{R}. Spend this mana only to cast instant and/or sorcery spells.\nWhen Cormela, Glamour Thief dies, return up to one target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "b8bd116a-5c5e-5ab4-8d18-8d2528bac8b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f254bb-ec77-4147-ab9c-559bc7fba8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f254bb-ec77-4147-ab9c-559bc7fba8cd.jpg?1",
             "name": "Corpse Appraiser",
             "text": "When Corpse Appraiser enters the battlefield, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -7191,7 +7191,7 @@
         },
         {
             "id": "7fc0312e-166d-57cd-bd09-bfc7c6270c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700eff3-138b-4d4c-ba36-58b98986168c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c700eff3-138b-4d4c-ba36-58b98986168c.jpg?1",
             "name": "Corpse Explosion",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nCorpse Explosion deals damage equal to the exiled card's power to each creature and each planeswalker.",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "3c7a2e24-0964-57ee-9974-3ae95107b96b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99806615-2f4a-4fe4-82f8-83445ae93a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99806615-2f4a-4fe4-82f8-83445ae93a97.jpg?1",
             "name": "Crew Captain",
             "text": "Haste\nCrew Captain has indestructible as long as it entered the battlefield this turn.",
             "colours": [
@@ -7269,7 +7269,7 @@
         },
         {
             "id": "7d760970-5a2a-5a6e-8093-4e62567e6f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa9815-6b47-4c80-87c7-4277166ea0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52aa9815-6b47-4c80-87c7-4277166ea0df.jpg?1",
             "name": "Darling of the Masses",
             "text": "Other Citizens you control get +1/+0.\nWhenever Darling of the Masses attacks, create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "e3559818-5ede-5ba0-a507-d6f09db100f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23cdb0a-e114-47f8-aceb-c54c4683bbc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23cdb0a-e114-47f8-aceb-c54c4683bbc5.jpg?1",
             "name": "Disciplined Duelist",
             "text": "Double strike\nDisciplined Duelist enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
             "colours": [
@@ -7348,7 +7348,7 @@
         },
         {
             "id": "090ccd5b-d395-5103-98e9-21057b3e6c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13798c8c-1aa5-4f95-979b-b971e73d715f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13798c8c-1aa5-4f95-979b-b971e73d715f.jpg?1",
             "name": "Endless Detour",
             "text": "The owner of target spell, nonland permanent, or card in a graveyard puts it on the top or bottom of their library.",
             "colours": [
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "7237575a-a39f-5616-918f-d8927e515aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dad61f-36cd-46af-82b7-a02e04efd676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dad61f-36cd-46af-82b7-a02e04efd676.jpg?1",
             "name": "Evelyn, the Covetous",
             "text": "Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.",
             "colours": [
@@ -7431,7 +7431,7 @@
         },
         {
             "id": "96831799-d9b3-5e04-ac1d-e7b1b7acaf4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f1ed8-5c10-45e4-8f2f-182e800faab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f1ed8-5c10-45e4-8f2f-182e800faab4.jpg?1",
             "name": "Exotic Pets",
             "text": "Create two 1/1 blue Fish creature tokens with \"This creature can't be blocked.\" Then for each kind of counter among creatures you control, put a counter of that kind on either of those tokens.",
             "colours": [
@@ -7465,7 +7465,7 @@
         },
         {
             "id": "00adcf10-69b4-56f5-b393-c17511ba207c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae25db8c-3d10-4196-b002-9d2aabd5f4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae25db8c-3d10-4196-b002-9d2aabd5f4de.jpg?1",
             "name": "Falco Spara, Pactweaver",
             "text": "Flying, trample\nFalco Spara, Pactweaver enters the battlefield with a shield counter on it.\nYou may look at the top card of your library any time.\nYou may cast spells from the top of your library by removing a counter from a creature you control in addition to paying their other costs.",
             "colours": [
@@ -7509,7 +7509,7 @@
         },
         {
             "id": "e2562d73-1325-5812-8cd9-2ab39f923d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7de8d6-edad-4845-9868-781351480258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7de8d6-edad-4845-9868-781351480258.jpg?1",
             "name": "Fatal Grudge",
             "text": "As an additional cost to cast this spell, sacrifice a nonland permanent.\nEach opponent chooses a permanent they control that shares a type with the sacrificed permanent and sacrifices it.\nDraw a card.",
             "colours": [
@@ -7543,7 +7543,7 @@
         },
         {
             "id": "5118c416-027c-5148-bade-323be3f4c307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2473d738-fe15-402a-ad24-0d6e5c4dfda3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2473d738-fe15-402a-ad24-0d6e5c4dfda3.jpg?1",
             "name": "Fleetfoot Dancer",
             "text": "Trample, lifelink, haste",
             "colours": [
@@ -7585,7 +7585,7 @@
         },
         {
             "id": "51a693bc-d95c-5852-9b3c-86af8bbb4a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5052247d-ef72-47f0-973d-2be98bf754c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5052247d-ef72-47f0-973d-2be98bf754c1.jpg?1",
             "name": "Forge Boss",
             "text": "Whenever you sacrifice one or more other creatures, Forge Boss deals 2 damage to each opponent. This ability triggers only once each turn.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "4bb9d293-db66-5b25-b09f-9a74ea7528d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6942a-f6fd-455f-be4a-0cdd16d67e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e6942a-f6fd-455f-be4a-0cdd16d67e13.jpg?1",
             "name": "A-Forge Boss",
             "text": "",
             "colours": [
@@ -7658,7 +7658,7 @@
         },
         {
             "id": "cb07a160-3b21-5bed-a758-bb41007ed2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452abab0-cf23-4b9d-831a-7b9fa1fd582a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/452abab0-cf23-4b9d-831a-7b9fa1fd582a.jpg?1",
             "name": "Glamorous Outlaw",
             "text": "When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you scry 2.\n{2}, Exile Glamorous Outlaw from your hand: Target land gains \"{T}: Add {U}, {B}, or {R}\" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.",
             "colours": [
@@ -7700,7 +7700,7 @@
         },
         {
             "id": "989d2792-298a-5f7b-9f34-59da69b3236d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab334c44-0cdb-4521-bb7d-162131155796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab334c44-0cdb-4521-bb7d-162131155796.jpg?1",
             "name": "A-Glamorous Outlaw",
             "text": "",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "befaa804-b38b-5a47-9d78-791d386a97b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7df727-50ea-4ea8-bdb9-d7ef16199d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7df727-50ea-4ea8-bdb9-d7ef16199d8a.jpg?1",
             "name": "Hostile Takeover",
             "text": "Up to one target creature has base power and toughness 1/1 until end of turn. Up to one other target creature has base power and toughness 4/4 until end of turn. Then Hostile Takeover deals 3 damage to each creature.",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "a4e13092-2604-510d-ab8f-b80bcdf4427d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e2ed9e-ee1d-440a-94b4-d4b17d30b800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e2ed9e-ee1d-440a-94b4-d4b17d30b800.jpg?1",
             "name": "Incandescent Aria",
             "text": "Incandescent Aria deals 3 damage to each nontoken creature.",
             "colours": [
@@ -7816,7 +7816,7 @@
         },
         {
             "id": "8ef49fa1-ad88-580c-8934-0d92406638f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c69d75-651f-4b75-b65d-79999d2069f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c69d75-651f-4b75-b65d-79999d2069f6.jpg?1",
             "name": "Jetmir, Nexus of Revels",
             "text": "Creatures you control get +1/+0 and have vigilance as long as you control three or more creatures.\nCreatures you control also get +1/+0 and have trample as long as you control six or more creatures.\nCreatures you control also get +1/+0 and have double strike as long as you control nine or more creatures.",
             "colours": [
@@ -7860,7 +7860,7 @@
         },
         {
             "id": "f568f39a-04ed-57c1-a519-c6b399f9efe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5aa701-28e8-47fa-8c26-4da2f943f582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e5aa701-28e8-47fa-8c26-4da2f943f582.jpg?1",
             "name": "Jetmir's Fixer",
             "text": "{R}{G}: Jetmir's Fixer gets +1/+1 until end of turn. If mana from a Treasure was spent to activate this ability, put a +1/+1 counter on Jetmir's Fixer instead.",
             "colours": [
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "eb8f0320-29fd-5a13-909a-0c8cd6d060cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9326a-2a41-45b3-97c3-548f0bdc0882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f9326a-2a41-45b3-97c3-548f0bdc0882.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second",
             "text": "If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.",
             "colours": [
@@ -7941,7 +7941,7 @@
         },
         {
             "id": "b3675cb1-ed57-5402-a60a-5209e969d13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20f271-26c8-429f-a422-e7d95f3bda74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd20f271-26c8-429f-a422-e7d95f3bda74.jpg?1",
             "name": "Lagrella, the Magpie",
             "text": "When Lagrella, the Magpie enters the battlefield, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters the battlefield under your control this way, put two +1/+1 counters on it.",
             "colours": [
@@ -7985,7 +7985,7 @@
         },
         {
             "id": "28d239bb-1cd4-50c7-a478-9b2de2d797b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0a078d-045f-401b-a561-dcb1ad02bf62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0a078d-045f-401b-a561-dcb1ad02bf62.jpg?1",
             "name": "Lord Xander, the Collector",
             "text": "When Lord Xander, the Collector enters the battlefield, target opponent discards half the cards in their hand, rounded down.\nWhenever Lord Xander attacks, defending player mills half their library, rounded down.\nWhen Lord Xander dies, target opponent sacrifices half the nonland permanents they control, rounded down.",
             "colours": [
@@ -8030,7 +8030,7 @@
         },
         {
             "id": "361940e2-210a-5d54-bd33-4a6f479fdae6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469a0f03-7874-453d-b9e4-275c13244f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469a0f03-7874-453d-b9e4-275c13244f4a.jpg?1",
             "name": "Maestros Ascendancy",
             "text": "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -8069,7 +8069,7 @@
         },
         {
             "id": "8a890ec3-652b-5af9-9cd8-6b80acc1aa61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcdedb6-3c24-4a29-b9b9-27cc47d8ee56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dcdedb6-3c24-4a29-b9b9-27cc47d8ee56.jpg?1",
             "name": "Maestros Charm",
             "text": "Choose one \u2014\n\u2022 Look at the top five cards of your library. Put one of those cards into your hand and the rest into your graveyard.\n\u2022 Each opponent loses 3 life and you gain 3 life.\n\u2022 Maestros Charm deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "cd09970c-b19c-51a1-ad79-13df8698624e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7206db10-e248-420d-bf92-4d57bc72da56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7206db10-e248-420d-bf92-4d57bc72da56.jpg?1",
             "name": "Maestros Diabolist",
             "text": "Deathtouch, haste\nWhenever Maestros Diabolist attacks, if you don't control a Devil token, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -8150,7 +8150,7 @@
         },
         {
             "id": "53f54beb-0888-5b0f-8504-b8d6c955e22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03757415-6b58-42d3-9452-a862e90647ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03757415-6b58-42d3-9452-a862e90647ee.jpg?1",
             "name": "Masked Bandits",
             "text": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)\n{2}, Exile Masked Bandits from your hand: Target land gains \"{T}: Add {B}, {R}, or {G}\" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "196a3ca1-135e-5826-9678-9b2f421a3e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2073bd-be49-4d3a-9aca-b8ea6b747503.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c2073bd-be49-4d3a-9aca-b8ea6b747503.jpg?1",
             "name": "A-Masked Bandits",
             "text": "",
             "colours": [
@@ -8230,7 +8230,7 @@
         },
         {
             "id": "fd8a29d1-e9f1-5f5b-ae92-af45cb362977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c3c08f-ae9d-4932-ba0e-65652b8b318b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c3c08f-ae9d-4932-ba0e-65652b8b318b.jpg?1",
             "name": "Meeting of the Five",
             "text": "Exile the top ten cards of your library. You may cast spells with exactly three colors from among them this turn. Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Spend this mana only to cast spells with exactly three colors.",
             "colours": [
@@ -8272,7 +8272,7 @@
         },
         {
             "id": "931441a3-a739-5e27-a56f-15b3f87bb568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633c7e38-fdad-461c-9ecb-3e89d5b80f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633c7e38-fdad-461c-9ecb-3e89d5b80f24.jpg?1",
             "name": "Metropolis Angel",
             "text": "Flying\nWhenever you attack with one or more creatures with counters on them, draw a card.",
             "colours": [
@@ -8309,7 +8309,7 @@
         },
         {
             "id": "c3694bd1-bafa-51ee-995b-0c2c0a13c822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5601410-9c2b-488f-a123-9637d0d97d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5601410-9c2b-488f-a123-9637d0d97d06.jpg?1",
             "name": "A-Metropolis Angel",
             "text": "",
             "colours": [
@@ -8345,7 +8345,7 @@
         },
         {
             "id": "6d9de08a-3851-57a6-891e-24452497d4a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97caaa92-2a7d-4f79-8d42-86733c902072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97caaa92-2a7d-4f79-8d42-86733c902072.jpg?1",
             "name": "Mr. Orfeo, the Boulder",
             "text": "Whenever you attack, double target creature's power until end of turn.",
             "colours": [
@@ -8389,7 +8389,7 @@
         },
         {
             "id": "641f0f6f-09cb-5009-8ea2-16c414365d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b8196-ec05-4732-aec2-50629cf4ebb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db1b8196-ec05-4732-aec2-50629cf4ebb4.jpg?1",
             "name": "A-Mr. Orfeo, the Boulder",
             "text": "",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "221a37d5-2c14-53b8-af86-576042e2ac71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150d4c7-2c90-4a71-b2d3-3d9a0079fea1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0150d4c7-2c90-4a71-b2d3-3d9a0079fea1.jpg?1",
             "name": "Nimble Larcenist",
             "text": "Flying\nWhen Nimble Larcenist enters the battlefield, target opponent reveals their hand. You choose an artifact, instant, or sorcery card from it and exile that card.",
             "colours": [
@@ -8471,7 +8471,7 @@
         },
         {
             "id": "1c945fc7-d270-5e1d-86c5-8142240fd52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80226520-6b0a-48ea-a868-a29eb3fbd403.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80226520-6b0a-48ea-a868-a29eb3fbd403.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "Casualty X. The copy isn't legendary and has starting loyalty X. (As you cast this spell, you may sacrifice a creature with power X. When you do, copy this spell. The copy becomes a token.)\n+1: Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22127: Target player draws seven cards and loses 7 life.",
             "colours": [
@@ -8513,7 +8513,7 @@
         },
         {
             "id": "dfd1b523-d92b-5966-903a-8f737b7524cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a11e5e-d2a9-4490-90f3-a643fc7ed7c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a11e5e-d2a9-4490-90f3-a643fc7ed7c3.jpg?1",
             "name": "Obscura Ascendancy",
             "text": "Whenever you cast a spell, if its mana value is equal to 1 plus the number of soul counters on Obscura Ascendancy, put a soul counter on Obscura Ascendancy, then create a 2/2 white Spirit creature token with flying.\nAs long as there are five or more soul counters on Obscura Ascendancy, Spirits you control get +3/+3.",
             "colours": [
@@ -8552,7 +8552,7 @@
         },
         {
             "id": "99dc6b97-e5a3-5233-991f-e44da1b507ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961562d-cad9-40e5-afae-3ebce77a2260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9961562d-cad9-40e5-afae-3ebce77a2260.jpg?1",
             "name": "Obscura Charm",
             "text": "Choose one \u2014\n\u2022 Return target multicolored permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\n\u2022 Counter target instant or sorcery spell.\n\u2022 Destroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -8591,7 +8591,7 @@
         },
         {
             "id": "98f8289f-a8a8-534e-a18c-21a45690b7be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08886346-2405-47ee-997f-c0fb7776c783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08886346-2405-47ee-997f-c0fb7776c783.jpg?1",
             "name": "Obscura Interceptor",
             "text": "Flash\nLifelink\nWhen Obscura Interceptor enters the battlefield, it connives. When it connives this way, return up to one target spell to its owner's hand. (To have a creature connive, draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.)",
             "colours": [
@@ -8633,7 +8633,7 @@
         },
         {
             "id": "1fc40098-e282-524a-980c-0ef11ab3fa00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636058c3-bacc-4a66-8988-832ab0cc9be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/636058c3-bacc-4a66-8988-832ab0cc9be6.jpg?1",
             "name": "Ognis, the Dragon's Lash",
             "text": "Haste\nWhenever a creature you control with haste attacks, create a tapped Treasure token.",
             "colours": [
@@ -8677,7 +8677,7 @@
         },
         {
             "id": "86216679-02fd-5827-b575-d6350f4f33a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba250e8-1ceb-40f5-95f1-fb00a2a723eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bba250e8-1ceb-40f5-95f1-fb00a2a723eb.jpg?1",
             "name": "Park Heights Pegasus",
             "text": "Flying, trample\nWhenever Park Heights Pegasus deals combat damage to a player, draw a card if you had two or more creatures enter the battlefield under your control this turn.",
             "colours": [
@@ -8715,7 +8715,7 @@
         },
         {
             "id": "d473ada7-00e4-57be-9813-600ab3cc7f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edb7a26-82be-4efd-9a5c-a3816e1ee2d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edb7a26-82be-4efd-9a5c-a3816e1ee2d6.jpg?1",
             "name": "Queza, Augur of Agonies",
             "text": "Whenever you draw a card, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "dc0faba5-ac21-5610-b725-1ca2e9f25476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3da27e-4fdd-46ce-bb81-0b2dfec1c6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c3da27e-4fdd-46ce-bb81-0b2dfec1c6ed.jpg?1",
             "name": "A-Queza, Augur of Agonies",
             "text": "",
             "colours": [
@@ -8799,7 +8799,7 @@
         },
         {
             "id": "12151123-1ef3-5c66-a91e-31aee92a06c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716a44b4-f6b0-4f14-a270-6442aed3251f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/716a44b4-f6b0-4f14-a270-6442aed3251f.jpg?1",
             "name": "Raffine, Scheming Seer",
             "text": "Flying, ward {1}\nWhenever you attack, target attacking creature connives X, where X is the number of attacking creatures. (Draw X cards, then discard X cards. Put a +1/+1 counter on that creature for each nonland card discarded this way.)",
             "colours": [
@@ -8843,7 +8843,7 @@
         },
         {
             "id": "83e06117-fee3-5e58-97ae-982c1bc969fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c74197a-367c-40a4-9eb5-6943490bba09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c74197a-367c-40a4-9eb5-6943490bba09.jpg?1",
             "name": "Rakish Revelers",
             "text": "When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{2}, Exile Rakish Revelers from your hand: Target land gains \"{T}: Add {R}, {G}, or {W}\" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "7748f39d-fbc1-5aa5-80ff-7aab475c935a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b799b01d-2e9b-4ef0-b518-bb3684cd524d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b799b01d-2e9b-4ef0-b518-bb3684cd524d.jpg?1",
             "name": "A-Rakish Revelers",
             "text": "",
             "colours": [
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "ecaf5993-3299-511a-b284-c77755324a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c6aef6-d846-4e02-a5f9-6eb0b2212208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c6aef6-d846-4e02-a5f9-6eb0b2212208.jpg?1",
             "name": "Rigo, Streetwise Mentor",
             "text": "Rigo, Streetwise Mentor enters the battlefield with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever you attack a player or planeswalker with one or more creatures with power 1 or less, draw a card.",
             "colours": [
@@ -8969,7 +8969,7 @@
         },
         {
             "id": "15d1abbc-b7f3-5207-9075-d634cfb540c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21235916-2379-470c-b9ee-84246043d703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21235916-2379-470c-b9ee-84246043d703.jpg?1",
             "name": "Riveteers Ascendancy",
             "text": "Whenever you sacrifice a creature, you may return target creature card with lesser mana value from your graveyard to the battlefield tapped. Do this only once each turn.",
             "colours": [
@@ -9008,7 +9008,7 @@
         },
         {
             "id": "2de899c8-a028-569d-b844-712ff24ae768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784a5915-bc42-49d6-8a1b-45da7749f03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/784a5915-bc42-49d6-8a1b-45da7749f03a.jpg?1",
             "name": "Riveteers Charm",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature or planeswalker they control with the highest mana value among creatures and planeswalkers they control.\n\u2022 Exile the top three cards of your library. Until your next end step, you may play those cards.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -9047,7 +9047,7 @@
         },
         {
             "id": "4a9f6e45-b462-59fd-bc7c-49e96cfa0c2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cf8b35-2a81-40fd-b383-becb81bef806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cf8b35-2a81-40fd-b383-becb81bef806.jpg?1",
             "name": "Rocco, Cabaretti Caterer",
             "text": "When Rocco, Cabaretti Caterer enters the battlefield, if you cast it, you may search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -9091,7 +9091,7 @@
         },
         {
             "id": "08167fb4-cce0-5341-911e-e8a487eabd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7ef030-7bae-4820-b51a-8fad57a8ff2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7ef030-7bae-4820-b51a-8fad57a8ff2f.jpg?1",
             "name": "Scheming Fence",
             "text": "As Scheming Fence enters the battlefield, you may choose a nonland permanent.\nActivated abilities of the chosen permanent can't be activated.\nScheming Fence has all activated abilities of the chosen permanent except for loyalty abilities. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -9131,7 +9131,7 @@
         },
         {
             "id": "530c5ace-2c3a-5e19-999b-08a32ffec03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050dd40-9a18-41e4-97e6-fce5bf220ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0050dd40-9a18-41e4-97e6-fce5bf220ccf.jpg?1",
             "name": "Security Rhox",
             "text": "You may pay {R}{G} rather than pay this spell's mana cost. Spend only mana produced by Treasures to cast it this way.",
             "colours": [
@@ -9168,7 +9168,7 @@
         },
         {
             "id": "a22f5b9e-4863-5bfc-a132-99ca52151402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61a849b-601b-4d5a-9a4e-84e7eb685b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61a849b-601b-4d5a-9a4e-84e7eb685b09.jpg?1",
             "name": "A-Security Rhox",
             "text": "",
             "colours": [
@@ -9204,7 +9204,7 @@
         },
         {
             "id": "9a7ad1e4-e7e6-5379-9b82-4c546c601816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75ba0d-230e-4ca4-bb40-bd05af2a4457.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc75ba0d-230e-4ca4-bb40-bd05af2a4457.jpg?1",
             "name": "Shattered Seraph",
             "text": "Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{2}, Exile Shattered Seraph from your hand: Target land gains \"{T}: Add {W}, {U}, or {B}\" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.",
             "colours": [
@@ -9246,7 +9246,7 @@
         },
         {
             "id": "f33b68df-48d6-52e6-b5b2-c1f04e703097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574a8645-9f6e-4657-afac-5d8242e011cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574a8645-9f6e-4657-afac-5d8242e011cb.jpg?1",
             "name": "A-Shattered Seraph",
             "text": "",
             "colours": [
@@ -9284,7 +9284,7 @@
         },
         {
             "id": "ace33caf-b031-5a60-a62f-194dbb424d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed1e957-3df1-4640-9980-783817826602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed1e957-3df1-4640-9980-783817826602.jpg?1",
             "name": "Snooping Newsie",
             "text": "When Snooping Newsie enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)\nAs long as there are five or more mana values among cards in your graveyard, Snooping Newsie gets +1/+1 and has lifelink.",
             "colours": [
@@ -9321,7 +9321,7 @@
         },
         {
             "id": "2f84cef6-d0d6-5469-b68d-f22656cc7611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13b82-0650-48f2-9e42-3610b43e2e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b13b82-0650-48f2-9e42-3610b43e2e10.jpg?1",
             "name": "Soul of Emancipation",
             "text": "When Soul of Emancipation enters the battlefield, destroy up to three other target nonland permanents. For each of those permanents, its controller creates a 3/3 white Angel creature token with flying.",
             "colours": [
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "276cf6af-10c9-57de-9daf-d3e32c783608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29eb0e40-d184-423f-8484-ee288fda00cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29eb0e40-d184-423f-8484-ee288fda00cd.jpg?1",
             "name": "Spara's Adjudicators",
             "text": "When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{2}, Exile Spara's Adjudicators from your hand: Target land gains \"{T}: Add {G}, {W}, or {U}\" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.",
             "colours": [
@@ -9404,7 +9404,7 @@
         },
         {
             "id": "271e916e-c3ef-5ebc-a542-4fa1bedfb489",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564085e-2abd-4ecc-9b7a-19a69ddabc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f564085e-2abd-4ecc-9b7a-19a69ddabc84.jpg?1",
             "name": "A-Spara's Adjudicators",
             "text": "",
             "colours": [
@@ -9442,7 +9442,7 @@
         },
         {
             "id": "8e6fd3ca-3fc0-5579-b8e5-e94628dbddd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbe7459-8613-4ab8-84dc-deab19c08511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecbe7459-8613-4ab8-84dc-deab19c08511.jpg?1",
             "name": "Stimulus Package",
             "text": "When Stimulus Package enters the battlefield, create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nSacrifice a Treasure: Create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -9476,7 +9476,7 @@
         },
         {
             "id": "93cbf7ec-2a74-5acd-a058-69186dde9bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7187e3-0b8e-4a63-a6e5-aeef3c0e8872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd7187e3-0b8e-4a63-a6e5-aeef3c0e8872.jpg?1",
             "name": "A-Stimulus Package",
             "text": "",
             "colours": [
@@ -9509,7 +9509,7 @@
         },
         {
             "id": "64ac350f-d715-5386-97c7-7caf53eba902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf86c5f2-0caf-48ca-b7ad-a1cdcd014539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf86c5f2-0caf-48ca-b7ad-a1cdcd014539.jpg?1",
             "name": "Syndicate Infiltrator",
             "text": "Flying\nAs long as there are five or more mana values among cards in your graveyard, Syndicate Infiltrator gets +2/+2.",
             "colours": [
@@ -9546,7 +9546,7 @@
         },
         {
             "id": "1bdb024a-04db-5b79-9152-9b6650e5dbde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0edc749-8603-4849-9426-6105dddd7566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0edc749-8603-4849-9426-6105dddd7566.jpg?1",
             "name": "A-Syndicate Infiltrator",
             "text": "",
             "colours": [
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "71f162ec-d88d-5db0-b421-511af0a0a744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347d883c-84ab-4547-813b-f4385366fbce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/347d883c-84ab-4547-813b-f4385366fbce.jpg?1",
             "name": "Tainted Indulgence",
             "text": "Draw two cards. Then discard a card unless there are five or more mana values among cards in your graveyard.",
             "colours": [
@@ -9616,7 +9616,7 @@
         },
         {
             "id": "82b9e789-985a-5827-8323-ad752f99a35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01f12e0-f354-43aa-9e2d-b59a99571a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01f12e0-f354-43aa-9e2d-b59a99571a5f.jpg?1",
             "name": "Toluz, Clever Conductor",
             "text": "When Toluz, Clever Conductor enters the battlefield, it connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)\nWhenever you discard one or more cards, exile them from your graveyard.\nWhen Toluz dies, put the cards exiled with it into their owner's hand.",
             "colours": [
@@ -9660,7 +9660,7 @@
         },
         {
             "id": "c102bc68-8ce3-50ae-aaa6-e13827033cf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f892607-8672-4013-86e6-0779d0b726de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f892607-8672-4013-86e6-0779d0b726de.jpg?1",
             "name": "Unleash the Inferno",
             "text": "Unleash the Inferno deals 7 damage to target creature or planeswalker. When it deals excess damage this way, destroy target artifact or enchantment an opponent controls with mana value less than or equal to that amount of excess damage.",
             "colours": [
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "b3f8347a-8cc7-558d-99f7-537e74194e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daab74d-d66b-4164-aa19-24e8d5536f7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daab74d-d66b-4164-aa19-24e8d5536f7d.jpg?1",
             "name": "Void Rend",
             "text": "This spell can't be countered.\nDestroy target nonland permanent.",
             "colours": [
@@ -9738,7 +9738,7 @@
         },
         {
             "id": "c309e894-bdfb-582b-b110-f74f3137254c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4fa4c8-f09f-4d97-a7d1-1b93caf7d4f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba4fa4c8-f09f-4d97-a7d1-1b93caf7d4f9.jpg?1",
             "name": "Ziatora, the Incinerator",
             "text": "Flying\nAt the beginning of your end step, you may sacrifice another creature. When you do, Ziatora, the Incinerator deals damage equal to that creature's power to any target and you create three Treasure tokens.",
             "colours": [
@@ -9782,7 +9782,7 @@
         },
         {
             "id": "2ef058cb-bb32-5322-9dec-10e55a5d2f17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba39154c-aace-4d55-a3ad-7c9eb717ed2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba39154c-aace-4d55-a3ad-7c9eb717ed2b.jpg?1",
             "name": "Ziatora's Envoy",
             "text": "Trample\nWhenever Ziatora's Envoy deals combat damage to a player, look at the top card of your library. You may play a land from the top of your library or cast a spell with mana value less than or equal to the damage dealt from the top of your library without paying its mana cost. If you don't, put that card into your hand.\nBlitz {2}{B}{R}{G}",
             "colours": [
@@ -9824,7 +9824,7 @@
         },
         {
             "id": "7ca97156-5224-5271-ba6c-c786f0a8745a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a00ed-dc77-4dcd-9e14-6902565974b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95a00ed-dc77-4dcd-9e14-6902565974b5.jpg?1",
             "name": "Arc Spitter",
             "text": "Equipped creature has \"{1}: This creature deals 1 damage to target creature that's blocking it.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9854,7 +9854,7 @@
         },
         {
             "id": "3bc1de2b-964b-50ec-ad4e-1dc5840648bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd31ee9e-1af7-4eb4-bda8-11451ebd6927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd31ee9e-1af7-4eb4-bda8-11451ebd6927.jpg?1",
             "name": "Brass Knuckles",
             "text": "When you cast this spell, copy it. (The copy becomes a token.)\nEquipped creature has double strike as long as two or more Equipment are attached to it.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9884,7 +9884,7 @@
         },
         {
             "id": "a453cf7a-b244-5fff-91e3-ba12294db816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1100dba-de2d-481e-b29c-71f6d34663ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1100dba-de2d-481e-b29c-71f6d34663ba.jpg?1",
             "name": "Cement Shoes",
             "text": "Equipped creature gets +3/+3 and has \"At the beginning of your end step, tap this creature.\"\nEquipped creature doesn't untap during its controller's untap step.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9914,7 +9914,7 @@
         },
         {
             "id": "06a02af5-c940-5857-ab65-91b9004c9940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da50ba-2061-40f0-b3af-950b87f812cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85da50ba-2061-40f0-b3af-950b87f812cd.jpg?1",
             "name": "Chrome Cat",
             "text": "When Chrome Cat enters the battlefield, scry 1.",
             "colours": [],
@@ -9945,7 +9945,7 @@
         },
         {
             "id": "c04fdfb9-b6da-58e1-8e4b-63e1130105bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d2fa3-3f5a-4b6f-8b7e-6a8bf65c07ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6d2fa3-3f5a-4b6f-8b7e-6a8bf65c07ad.jpg?1",
             "name": "Getaway Car",
             "text": "Haste\nWhenever Getaway Car attacks or blocks, return up to one target creature that crewed it this turn to its owner's hand.\nCrew 1",
             "colours": [],
@@ -9977,7 +9977,7 @@
         },
         {
             "id": "58c7e5f7-3674-58f5-9af2-ed561883d130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca8554a-f74c-4d2d-95b6-ef6e74431d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca8554a-f74c-4d2d-95b6-ef6e74431d7c.jpg?1",
             "name": "Gilded Pinions",
             "text": "When Gilded Pinions enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nEquipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10007,7 +10007,7 @@
         },
         {
             "id": "ff39b047-eea7-5666-b122-7bf3faa1a377",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eead159-b9a1-4c64-affe-c77b0a9e4775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eead159-b9a1-4c64-affe-c77b0a9e4775.jpg?1",
             "name": "Halo Scarab",
             "text": "{2}, Exile Halo Scarab from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -10038,7 +10038,7 @@
         },
         {
             "id": "dc198ede-887f-55e3-95cb-627043929ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1833662b-ccf3-4c16-9767-666d6407aa65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1833662b-ccf3-4c16-9767-666d6407aa65.jpg?1",
             "name": "Luxior, Giada's Gift",
             "text": "Equipped creature gets +1/+1 for each counter on it.\nEquipped permanent isn't a planeswalker and is a creature in addition to its other types. (Loyalty abilities can still be activated.)\nEquip planeswalker {1}\nEquip {3}",
             "colours": [],
@@ -10072,7 +10072,7 @@
         },
         {
             "id": "15fdb024-c094-5fe7-8f36-56ea48965195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1691374-e9f2-4a8b-abdb-0bb1dbc96715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1691374-e9f2-4a8b-abdb-0bb1dbc96715.jpg?1",
             "name": "Ominous Parcel",
             "text": "{2}, {T}, Sacrifice Ominous Parcel: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{5}, {T}, Sacrifice Ominous Parcel: It deals 4 damage to target creature.",
             "colours": [],
@@ -10100,7 +10100,7 @@
         },
         {
             "id": "1d620f05-bddf-5c47-9424-f4d0f4cc6ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc9bf5-0f22-4e41-b2ad-f4c9ce390826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcc9bf5-0f22-4e41-b2ad-f4c9ce390826.jpg?1",
             "name": "A-Ominous Parcel",
             "text": "",
             "colours": [],
@@ -10127,7 +10127,7 @@
         },
         {
             "id": "aa7e0218-3eb8-5384-a482-697def437345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939450d7-1107-4645-ad23-68749b1ec4c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939450d7-1107-4645-ad23-68749b1ec4c2.jpg?1",
             "name": "Paragon of Modernity",
             "text": "Flying\n{3}: Paragon of Modernity gets +1/+1 until end of turn. If exactly three colors of mana were spent to activate this ability, put a +1/+1 counter on it instead.",
             "colours": [],
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "8d57c205-0a5b-5f24-a22f-21130098409c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58708-3d62-4ab9-bf65-1cd707f2b753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bc58708-3d62-4ab9-bf65-1cd707f2b753.jpg?1",
             "name": "A-Paragon of Modernity",
             "text": "",
             "colours": [],
@@ -10190,7 +10190,7 @@
         },
         {
             "id": "f26f0ea4-f3c5-50f3-a59a-ab7671225f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64110f4-c4b6-4966-a23a-8da7d1983499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64110f4-c4b6-4966-a23a-8da7d1983499.jpg?1",
             "name": "Quick-Draw Dagger",
             "text": "Flash\nWhen Quick-Draw Dagger enters the battlefield, attach it to target creature you control. That creature gains first strike until end of turn.\nEquipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10220,7 +10220,7 @@
         },
         {
             "id": "b4cbd923-0245-56e9-b87b-b5024f009d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edbece0-8444-4634-a47b-7c88d1b8325e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edbece0-8444-4634-a47b-7c88d1b8325e.jpg?1",
             "name": "Scuttling Butler",
             "text": "At the beginning of combat on your turn, if you control two or more multicolored permanents, Scuttling Butler gains double strike until end of turn.",
             "colours": [],
@@ -10251,7 +10251,7 @@
         },
         {
             "id": "5362af50-d8cb-53fd-a8ea-c40ccd956c98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc574b42-e1bb-428f-a71f-bc3d7f5451da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc574b42-e1bb-428f-a71f-bc3d7f5451da.jpg?1",
             "name": "Suspicious Bookcase",
             "text": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -10282,7 +10282,7 @@
         },
         {
             "id": "caf3eb8d-449b-58c2-8d27-7a7bb6abfbfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ee60f7-31dd-4bc6-b71f-57a1a0d19d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ee60f7-31dd-4bc6-b71f-57a1a0d19d20.jpg?1",
             "name": "Unlicensed Hearse",
             "text": "{T}: Exile up to two target cards from a single graveyard.\nUnlicensed Hearse's power and toughness are each equal to the number of cards exiled with it.\nCrew 2",
             "colours": [],
@@ -10314,7 +10314,7 @@
         },
         {
             "id": "7ff2b8fe-9fd1-5684-8ba5-5a346ecda6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a6f93-1fc8-4690-add4-538763277f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a6f93-1fc8-4690-add4-538763277f8e.jpg?1",
             "name": "Botanical Plaza",
             "text": "Botanical Plaza enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}, {T}, Sacrifice Botanical Plaza: Draw a card.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "babfd0d5-c4b2-561a-98ca-7eb6997b10cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b299b-daa9-4bda-94e2-9a2f0e8f2bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989b299b-daa9-4bda-94e2-9a2f0e8f2bce.jpg?1",
             "name": "Brokers Hideout",
             "text": "When Brokers Hideout enters the battlefield, sacrifice it. When you do, search your library for a basic Forest, Plains, or Island card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10375,7 +10375,7 @@
         },
         {
             "id": "77ae2788-503b-5114-a7e7-0d6f56a67085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda1e1c-b330-42e0-8547-97e2afc7615f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda1e1c-b330-42e0-8547-97e2afc7615f.jpg?1",
             "name": "Cabaretti Courtyard",
             "text": "When Cabaretti Courtyard enters the battlefield, sacrifice it. When you do, search your library for a basic Mountain, Forest, or Plains card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10403,7 +10403,7 @@
         },
         {
             "id": "125b1fac-a9a2-5114-99f6-a0881ee0baba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d40e03-6de4-4373-9fbf-04c1dd79e995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26d40e03-6de4-4373-9fbf-04c1dd79e995.jpg?1",
             "name": "Jetmir's Garden",
             "text": "({T}: Add {R}, {G}, or {W}.)\nJetmir's Garden enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10442,7 +10442,7 @@
         },
         {
             "id": "b97a06ac-b779-52a2-90b4-ec72b73ed22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb4a44-a5c8-49ed-b440-2462626bb638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eb4a44-a5c8-49ed-b440-2462626bb638.jpg?1",
             "name": "Maestros Theater",
             "text": "When Maestros Theater enters the battlefield, sacrifice it. When you do, search your library for a basic Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "00542ebe-9ff3-5ba1-9015-1028e95b7f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016b884-9a4c-41de-bd65-14271f4f6f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1016b884-9a4c-41de-bd65-14271f4f6f9a.jpg?1",
             "name": "Obscura Storefront",
             "text": "When Obscura Storefront enters the battlefield, sacrifice it. When you do, search your library for a basic Plains, Island, or Swamp card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10498,7 +10498,7 @@
         },
         {
             "id": "485589c2-6fac-5123-854b-640a1b60b1c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a11bdb2-a269-4038-85f3-69fbd02982e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a11bdb2-a269-4038-85f3-69fbd02982e9.jpg?1",
             "name": "Racers' Ring",
             "text": "Racers' Ring enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}, {T}, Sacrifice Racers' Ring: Draw a card.",
             "colours": [],
@@ -10531,7 +10531,7 @@
         },
         {
             "id": "f720ce4d-53e8-5609-85c1-b6c1a48ba9a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c56479-4bee-4edb-80d7-4af010b7c793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c56479-4bee-4edb-80d7-4af010b7c793.jpg?1",
             "name": "Raffine's Tower",
             "text": "({T}: Add {W}, {U}, or {B}.)\nRaffine's Tower enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10570,7 +10570,7 @@
         },
         {
             "id": "9b7b4f27-258f-5669-a017-ca2844dcd021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d161f81-c01a-4c91-b025-52dcb1881638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d161f81-c01a-4c91-b025-52dcb1881638.jpg?1",
             "name": "Riveteers Overlook",
             "text": "When Riveteers Overlook enters the battlefield, sacrifice it. When you do, search your library for a basic Swamp, Mountain, or Forest card, put it onto the battlefield tapped, then shuffle and you gain 1 life.",
             "colours": [],
@@ -10598,7 +10598,7 @@
         },
         {
             "id": "167cdd89-20de-54a5-a9a7-a49861378897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28c871f-a96a-4e7d-a159-2e93aeb276d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e28c871f-a96a-4e7d-a159-2e93aeb276d4.jpg?1",
             "name": "Skybridge Towers",
             "text": "Skybridge Towers enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice Skybridge Towers: Draw a card.",
             "colours": [],
@@ -10631,7 +10631,7 @@
         },
         {
             "id": "a4741f3f-c856-541b-ad21-1bdc8ef3603e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7363f1fb-9af3-4212-921f-d59533faf0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7363f1fb-9af3-4212-921f-d59533faf0e5.jpg?1",
             "name": "Spara's Headquarters",
             "text": "({T}: Add {G}, {W}, or {U}.)\nSpara's Headquarters enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10670,7 +10670,7 @@
         },
         {
             "id": "abdf3fb3-b44f-593a-8412-5fd75405f666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0532304-da6d-45cd-b1e6-4779d3f3b2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0532304-da6d-45cd-b1e6-4779d3f3b2bc.jpg?1",
             "name": "Tramway Station",
             "text": "Tramway Station enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice Tramway Station: Draw a card.",
             "colours": [],
@@ -10703,7 +10703,7 @@
         },
         {
             "id": "37854b64-5137-5d0d-be4d-1e5eae1fcb55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debf7aac-4d31-49b4-955b-79036258df69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/debf7aac-4d31-49b4-955b-79036258df69.jpg?1",
             "name": "Waterfront District",
             "text": "Waterfront District enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}, {T}, Sacrifice Waterfront District: Draw a card.",
             "colours": [],
@@ -10736,7 +10736,7 @@
         },
         {
             "id": "3ceba63f-5328-525b-ac05-463aa2572340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f449ff-4025-465e-9ec5-a5cf42c4c9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f449ff-4025-465e-9ec5-a5cf42c4c9d3.jpg?1",
             "name": "Xander's Lounge",
             "text": "({T}: Add {U}, {B}, or {R}.)\nXander's Lounge enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10775,7 +10775,7 @@
         },
         {
             "id": "0a37f434-4d9d-5b4d-834d-b7e26d1671b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fdce80-e338-4a50-bdc6-786511feaeef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75fdce80-e338-4a50-bdc6-786511feaeef.jpg?1",
             "name": "Ziatora's Proving Ground",
             "text": "({T}: Add {B}, {R}, or {G}.)\nZiatora's Proving Ground enters the battlefield tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
             "colours": [],
@@ -10814,7 +10814,7 @@
         },
         {
             "id": "534bbb04-1ee6-5bf2-a6e0-df2365eefe9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbb3646-c427-4302-86ac-9ac28d045959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bbb3646-c427-4302-86ac-9ac28d045959.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10852,7 +10852,7 @@
         },
         {
             "id": "f9a0b1b6-a02b-51f5-9602-c81db95aa26e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6f0743-c433-4348-bcef-20cfe7b28293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6f0743-c433-4348-bcef-20cfe7b28293.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10890,7 +10890,7 @@
         },
         {
             "id": "08ca354f-d163-5aa7-80cb-6b8dab4893e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef2c956-cf03-462c-8981-ae80edfc0c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef2c956-cf03-462c-8981-ae80edfc0c5a.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10928,7 +10928,7 @@
         },
         {
             "id": "3c120d84-891a-592a-a929-db42ace24012",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd1b4d2-ccf0-498d-81e0-c9d755f5eb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd1b4d2-ccf0-498d-81e0-c9d755f5eb13.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10966,7 +10966,7 @@
         },
         {
             "id": "58ba82cb-f820-5bc3-b18b-11a85dcb2a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0175a2a-db46-4d25-ab8e-feca7e565b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0175a2a-db46-4d25-ab8e-feca7e565b8d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "bbdc0fde-ad25-502e-b561-bda44c83992b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8515d2-e8a4-45ab-b361-88eb4ec959bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b8515d2-e8a4-45ab-b361-88eb4ec959bd.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "d6597d84-7cfa-55ab-83cf-5b60138132b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac247df-aa19-4627-8d65-6ddf5e7e5c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac247df-aa19-4627-8d65-6ddf5e7e5c8c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11080,7 +11080,7 @@
         },
         {
             "id": "432b0a1c-dceb-5a9c-ae8b-6e4a1ae9155d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abb2702-6f5e-4832-9e23-46aaf9f960f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abb2702-6f5e-4832-9e23-46aaf9f960f8.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11118,7 +11118,7 @@
         },
         {
             "id": "7b48a4f1-bca0-5957-a0fe-65845bda7e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086cb5e-3146-4a41-a471-fcbbf8fa4e09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c086cb5e-3146-4a41-a471-fcbbf8fa4e09.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11156,7 +11156,7 @@
         },
         {
             "id": "57271aa6-7adc-5753-a50f-fe04e8269c11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818442df-fb81-4f1c-bcf2-fbd6b05912ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818442df-fb81-4f1c-bcf2-fbd6b05912ed.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "673545ff-4a80-522f-a4fb-2cd55713b44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882099c-63cd-42f0-b160-35e6922106b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e882099c-63cd-42f0-b160-35e6922106b1.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11232,7 +11232,7 @@
         },
         {
             "id": "c0c0e897-4ca8-5e95-9c74-18cf30a6bef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa69cedc-49ce-48f3-88e1-94b9bc061bf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa69cedc-49ce-48f3-88e1-94b9bc061bf4.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "0e0fb850-9541-5bb0-8cd8-2010d5903ecf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8221d15c-c993-4345-a6bb-6a7d215e3273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8221d15c-c993-4345-a6bb-6a7d215e3273.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "e6d1f3b9-96f4-5f2d-9014-b154c0efa933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaba7cd-c1dc-49cf-8d63-8bb3594a6541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaba7cd-c1dc-49cf-8d63-8bb3594a6541.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11346,7 +11346,7 @@
         },
         {
             "id": "6aaf0f1d-8969-578f-a0ae-8ccdb269fc1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f917d8d-7037-4f11-91f6-1ef96b3541bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f917d8d-7037-4f11-91f6-1ef96b3541bb.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11384,7 +11384,7 @@
         },
         {
             "id": "fb9c240c-b962-529c-b028-c10793caae98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4569823-af23-4eea-acc9-2a2c62bce3b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4569823-af23-4eea-acc9-2a2c62bce3b0.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11422,7 +11422,7 @@
         },
         {
             "id": "34160ea7-88c7-5374-8533-6090560496fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a58066e-f9a2-4508-9cc0-908b1cf747e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a58066e-f9a2-4508-9cc0-908b1cf747e3.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11460,7 +11460,7 @@
         },
         {
             "id": "65fe61dc-09b9-5a36-88cd-17585de8df52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97dadd-0849-4c18-9523-4775d09fca9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97dadd-0849-4c18-9523-4775d09fca9a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11498,7 +11498,7 @@
         },
         {
             "id": "3f20eb1c-d261-54e2-bdd2-d18cf700e60b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c726424a-3336-4e15-9055-4a26371df361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c726424a-3336-4e15-9055-4a26371df361.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11536,7 +11536,7 @@
         },
         {
             "id": "2a25f107-c0c1-56d4-afd9-20bccc42b727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633eb269-916e-4d79-821e-1f304283416c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633eb269-916e-4d79-821e-1f304283416c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "b369aae6-5d3d-55b2-9072-45bc6735e46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d75499-1be8-42a0-8520-9cd8adbd0ca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d75499-1be8-42a0-8520-9cd8adbd0ca3.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "+1: Choose up to one target creature. Put a +1/+1 counter and a counter from among flying, first strike, lifelink, or vigilance on it.\n\u22123: Look at the top seven cards of your library. You may put a permanent card with mana value 3 or less from among them onto the battlefield with a shield counter on it. Put the rest on the bottom of your library in a random order.\n\u22127: Create five 3/3 white Angel creature tokens with flying.",
             "colours": [
@@ -11614,7 +11614,7 @@
         },
         {
             "id": "dfd29f52-5a15-5bcd-99f6-2b1ba55721a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3979b3d5-7551-4161-bfe5-fe4b54fd96e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3979b3d5-7551-4161-bfe5-fe4b54fd96e5.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "+2: You may sacrifice a creature. If you do, search your library for a creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it onto the battlefield, then shuffle.\n+1: Mill five cards, then put any number of creature cards milled this way into your hand.\n\u22121: Create a 4/4 green Rhino Warrior creature token.",
             "colours": [
@@ -11654,7 +11654,7 @@
         },
         {
             "id": "6113cfa0-182c-5789-9701-9a2f3b243cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb93677-12a7-489c-a88a-0963dc5f3f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb93677-12a7-489c-a88a-0963dc5f3f1d.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "Casualty X. The copy isn't legendary and has starting loyalty X. (As you cast this spell, you may sacrifice a creature with power X. When you do, copy this spell. The copy becomes a token.)\n+1: Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22127: Target player draws seven cards and loses 7 life.",
             "colours": [
@@ -11696,7 +11696,7 @@
         },
         {
             "id": "6620d5aa-2842-56c7-afb1-0edc3691907a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131b10f-f14f-40e1-969b-224fcce2ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5131b10f-f14f-40e1-969b-224fcce2ed18.jpg?1",
             "name": "Halo Fountain",
             "text": "{W}, {T}, Untap a tapped creature you control: Create a 1/1 green and white Citizen creature token.\n{W}{W}, {T}, Untap two tapped creatures you control: Draw a card.\n{W}{W}{W}{W}{W}, {T}, Untap fifteen tapped creatures you control: You win the game.",
             "colours": [
@@ -11730,7 +11730,7 @@
         },
         {
             "id": "743fa882-90fb-56d8-b547-498cfa891240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac7e199-c32e-4479-a92f-df52f1182c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac7e199-c32e-4479-a92f-df52f1182c9a.jpg?1",
             "name": "All-Seeing Arbiter",
             "text": "Flying\nWhenever All-Seeing Arbiter enters the battlefield or attacks, draw two cards, then discard a card.\nWhenever you discard a card, target creature an opponent controls gets -X/-0 until your next turn, where X is the number of different mana values among cards in your graveyard.",
             "colours": [
@@ -11766,7 +11766,7 @@
         },
         {
             "id": "fab575b9-45c6-5311-a8d2-1937ce3cbe09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a05539-ec37-46b4-92f3-feda5f02ddb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72a05539-ec37-46b4-92f3-feda5f02ddb3.jpg?1",
             "name": "Shadow of Mortality",
             "text": "If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.",
             "colours": [
@@ -11802,7 +11802,7 @@
         },
         {
             "id": "bbf5e68a-e6e9-59d6-80f8-332fcce894e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32eb60a-14ac-4ea9-a4c5-6597194af0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32eb60a-14ac-4ea9-a4c5-6597194af0c1.jpg?1",
             "name": "Bootleggers' Stash",
             "text": "Lands you control have \"{T}: Create a Treasure token.\"",
             "colours": [
@@ -11836,7 +11836,7 @@
         },
         {
             "id": "90eb020b-6e49-5748-bef1-3e697945abe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb623e9-384e-41bb-b3af-f593212a0e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb623e9-384e-41bb-b3af-f593212a0e77.jpg?1",
             "name": "Titan of Industry",
             "text": "Reach, trample\nWhen Titan of Industry enters the battlefield, choose two \u2014\n\u2022 Destroy target artifact or enchantment.\n\u2022 Target player gains 5 life.\n\u2022 Create a 4/4 green Rhino Warrior creature token.\n\u2022 Put a shield counter on a creature you control.",
             "colours": [
@@ -11872,7 +11872,7 @@
         },
         {
             "id": "2e8f6e08-f419-55ca-9610-26d3e7dca6c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4cf10c-be3f-42df-aaf8-42378b8a15d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad4cf10c-be3f-42df-aaf8-42378b8a15d1.jpg?1",
             "name": "Topiary Stomper",
             "text": "Vigilance\nWhen Topiary Stomper enters the battlefield, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nTopiary Stomper can't attack or block unless you control seven or more lands.",
             "colours": [
@@ -11909,7 +11909,7 @@
         },
         {
             "id": "3fa82687-0f93-59b9-8f8e-1272df5c955e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bb5f59-2a63-421b-94a1-4cbef00f0c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bb5f59-2a63-421b-94a1-4cbef00f0c7e.jpg?1",
             "name": "Jetmir's Garden",
             "text": "({T}: Add {R}, {G}, or {W}.)\nJetmir's Garden enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -11948,7 +11948,7 @@
         },
         {
             "id": "088c97ed-fbc0-52db-9896-3d732f8c5983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa23075-d826-4654-9d5e-993c9824593d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa23075-d826-4654-9d5e-993c9824593d.jpg?1",
             "name": "Raffine's Tower",
             "text": "({T}: Add {W}, {U}, or {B}.)\nRaffine's Tower enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -11987,7 +11987,7 @@
         },
         {
             "id": "e094d05e-ec3d-527c-851a-57d9feb1daf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a0d4a-3777-451d-a2fb-f1a2fdf8019f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229a0d4a-3777-451d-a2fb-f1a2fdf8019f.jpg?1",
             "name": "Spara's Headquarters",
             "text": "({T}: Add {G}, {W}, or {U}.)\nSpara's Headquarters enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -12026,7 +12026,7 @@
         },
         {
             "id": "57a68792-e6db-5cdd-809b-e18821e1a933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9412a7ce-ffaa-4224-8434-c326280283a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9412a7ce-ffaa-4224-8434-c326280283a8.jpg?1",
             "name": "Xander's Lounge",
             "text": "({T}: Add {U}, {B}, or {R}.)\nXander's Lounge enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "df152162-21b0-5533-a9c7-621f3fa278c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea8c9f0-cec9-4ba4-b8df-6e52f2d77dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea8c9f0-cec9-4ba4-b8df-6e52f2d77dff.jpg?1",
             "name": "Ziatora's Proving Ground",
             "text": "({T}: Add {B}, {R}, or {G}.)\nZiatora's Proving Ground enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -12104,7 +12104,7 @@
         },
         {
             "id": "32f197d7-82f8-5cbb-9ec1-fbddc1d511fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fd80c9-e86c-48bd-8c8b-654a29665931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25fd80c9-e86c-48bd-8c8b-654a29665931.jpg?1",
             "name": "Brazen Upstart",
             "text": "Vigilance\nWhen Brazen Upstart dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12146,7 +12146,7 @@
         },
         {
             "id": "361779da-167f-5d57-993f-94d1664637e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa2713b-5df0-4e54-89bf-30b5aeba9ac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa2713b-5df0-4e54-89bf-30b5aeba9ac7.jpg?1",
             "name": "Brokers Ascendancy",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control and a loyalty counter on each planeswalker you control.",
             "colours": [
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "87cbd0bb-e133-5d4a-88ae-e9e034c0b938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aac0943-6c9a-4c65-9d17-3ca0f2ba2340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aac0943-6c9a-4c65-9d17-3ca0f2ba2340.jpg?1",
             "name": "Brokers Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature or planeswalker an opponent controls.\n\u2022 Destroy target enchantment.\n\u2022 Draw two cards.",
             "colours": [
@@ -12224,7 +12224,7 @@
         },
         {
             "id": "fd9bbc2d-a5a9-582f-afd5-fb45cf741544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3951927-9649-4cde-8690-d371b7953738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3951927-9649-4cde-8690-d371b7953738.jpg?1",
             "name": "Cabaretti Ascendancy",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it on the bottom of your library.",
             "colours": [
@@ -12263,7 +12263,7 @@
         },
         {
             "id": "cb171706-95e7-5cde-bf95-16fcae6ddc85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb456da8-6a20-4d5e-9587-e8661ced525b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb456da8-6a20-4d5e-9587-e8661ced525b.jpg?1",
             "name": "Cabaretti Charm",
             "text": "Choose one \u2014\n\u2022 Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Create two 1/1 green and white Citizen creature tokens.",
             "colours": [
@@ -12302,7 +12302,7 @@
         },
         {
             "id": "555a23d5-0ca1-5092-a88b-fa08b44ab800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b43fca7-3b37-4d40-88c8-aa178b68f75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b43fca7-3b37-4d40-88c8-aa178b68f75c.jpg?1",
             "name": "Cormela, Glamour Thief",
             "text": "Haste\n{1}, {T}: Add {U}{B}{R}. Spend this mana only to cast instant and/or sorcery spells.\nWhen Cormela, Glamour Thief dies, return up to one target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -12346,7 +12346,7 @@
         },
         {
             "id": "000a1b60-9edf-55c7-89e4-2e7bf96448d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198ea7-729a-47ce-89dd-43f77f60247b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee198ea7-729a-47ce-89dd-43f77f60247b.jpg?1",
             "name": "Corpse Appraiser",
             "text": "When Corpse Appraiser enters the battlefield, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -12388,7 +12388,7 @@
         },
         {
             "id": "529a6409-21a6-59bd-b5d6-8f34bc083a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9e01f5-393e-4f01-86b9-112a9084ad2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9e01f5-393e-4f01-86b9-112a9084ad2f.jpg?1",
             "name": "Crew Captain",
             "text": "Haste\nCrew Captain has indestructible as long as it entered the battlefield this turn.",
             "colours": [
@@ -12430,7 +12430,7 @@
         },
         {
             "id": "377b95d3-b470-5852-8a2a-40d6b4e63d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b348b-c147-4d02-b26c-d610f515bce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b348b-c147-4d02-b26c-d610f515bce0.jpg?1",
             "name": "Disciplined Duelist",
             "text": "Double strike\nDisciplined Duelist enters the battlefield with a shield counter on it.",
             "colours": [
@@ -12472,7 +12472,7 @@
         },
         {
             "id": "f108c307-e3d2-5ef1-93b6-ecef0c95eee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55503d2-1b32-43cf-95c6-a4a61047a4dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55503d2-1b32-43cf-95c6-a4a61047a4dc.jpg?1",
             "name": "Endless Detour",
             "text": "The owner of target spell, nonland permanent, or card in a graveyard puts it on the top or bottom of their library.",
             "colours": [
@@ -12511,7 +12511,7 @@
         },
         {
             "id": "b00d2918-a700-5552-b3bd-cdfb09d5ad1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd914b-4f66-4b80-8249-86f2e77f0452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd914b-4f66-4b80-8249-86f2e77f0452.jpg?1",
             "name": "Evelyn, the Covetous",
             "text": "Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.",
             "colours": [
@@ -12555,7 +12555,7 @@
         },
         {
             "id": "37180584-80ec-5531-8751-b298eec4641d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bbac59-da58-49d8-887e-272dd90724b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17bbac59-da58-49d8-887e-272dd90724b4.jpg?1",
             "name": "Falco Spara, Pactweaver",
             "text": "Flying, trample\nFalco Spara, Pactweaver enters the battlefield with a shield counter on it.\nYou may look at the top card of your library any time.\nYou may cast spells from the top of your library by removing a counter from a creature you control in addition to paying their other costs.",
             "colours": [
@@ -12599,7 +12599,7 @@
         },
         {
             "id": "8c3a5bb7-16fe-5c5e-9053-205d741a13ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235929c8-a2eb-4afa-a058-ef733da01b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235929c8-a2eb-4afa-a058-ef733da01b66.jpg?1",
             "name": "Fleetfoot Dancer",
             "text": "Trample, lifelink, haste",
             "colours": [
@@ -12641,7 +12641,7 @@
         },
         {
             "id": "757beca7-a0e9-5967-bfa2-1d866d1220e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c50607c-8bf1-4a69-97da-41cd794fda62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c50607c-8bf1-4a69-97da-41cd794fda62.jpg?1",
             "name": "Glamorous Outlaw",
             "text": "When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you scry 2.\n{2}, Exile Glamorous Outlaw from your hand: Target land gains \"{T}: Add {U}, {B}, or {R}\" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.",
             "colours": [
@@ -12683,7 +12683,7 @@
         },
         {
             "id": "d5a24ec5-833a-50f9-be0f-4e9b76ecb55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8137f134-0148-4df1-b575-ec861192c65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8137f134-0148-4df1-b575-ec861192c65c.jpg?1",
             "name": "Hostile Takeover",
             "text": "Up to one target creature has base power and toughness 1/1 until end of turn. Up to one other target creature has base power and toughness 4/4 until end of turn. Then Hostile Takeover deals 3 damage to each creature.",
             "colours": [
@@ -12722,7 +12722,7 @@
         },
         {
             "id": "7b1bd61e-0f97-5236-afa0-2b1f46670ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63167d77-a8d5-468f-9132-a5000c57901a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63167d77-a8d5-468f-9132-a5000c57901a.jpg?1",
             "name": "Incandescent Aria",
             "text": "Incandescent Aria deals 3 damage to each nontoken creature.",
             "colours": [
@@ -12761,7 +12761,7 @@
         },
         {
             "id": "71af925f-9440-508d-994e-1736f901d8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca12f3-4649-4c3a-b9f3-7ed9b7254f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ca12f3-4649-4c3a-b9f3-7ed9b7254f18.jpg?1",
             "name": "Jetmir, Nexus of Revels",
             "text": "Creatures you control get +1/+0 and have vigilance as long as you control three or more creatures.\nCreatures you control also get +1/+0 and have trample as long as you control six or more creatures.\nCreatures you control also get +1/+0 and have double strike as long as you control nine or more creatures.",
             "colours": [
@@ -12805,7 +12805,7 @@
         },
         {
             "id": "3b768c16-8f46-5419-9980-4aa1b0e6dae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f2011-be9c-4b83-b503-59a59284ab51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/702f2011-be9c-4b83-b503-59a59284ab51.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second",
             "text": "If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.",
             "colours": [
@@ -12849,7 +12849,7 @@
         },
         {
             "id": "6fe33e47-b2b5-52ea-8f54-ea5cb2dca395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5956dbe0-0d4c-42b1-8554-0fa6de1ee6bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5956dbe0-0d4c-42b1-8554-0fa6de1ee6bc.jpg?1",
             "name": "Lagrella, the Magpie",
             "text": "When Lagrella, the Magpie enters the battlefield, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters the battlefield under your control this way, put two +1/+1 counters on it.",
             "colours": [
@@ -12893,7 +12893,7 @@
         },
         {
             "id": "c07a23c8-8695-5c53-8957-756c65043879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ef8f69-41d1-48f2-8ab8-69871399cc96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6ef8f69-41d1-48f2-8ab8-69871399cc96.jpg?1",
             "name": "Lord Xander, the Collector",
             "text": "When Lord Xander, the Collector enters the battlefield, target opponent discards half the cards in their hand, rounded down.\nWhenever Lord Xander attacks, defending player mills half their library, rounded down.\nWhen Lord Xander dies, target opponent sacrifices half the nonland permanents they control, rounded down.",
             "colours": [
@@ -12938,7 +12938,7 @@
         },
         {
             "id": "ce0bd237-0cc1-591e-a5fd-bb32e70c7838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7d57a-10f0-4079-9dec-8d6169dbdebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda7d57a-10f0-4079-9dec-8d6169dbdebc.jpg?1",
             "name": "Maestros Ascendancy",
             "text": "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -12977,7 +12977,7 @@
         },
         {
             "id": "eda91356-7a9c-556a-86cf-c0ac6f762402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e1bec-67d2-43fd-b799-b7c12b94d1f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3e1bec-67d2-43fd-b799-b7c12b94d1f0.jpg?1",
             "name": "Maestros Charm",
             "text": "Choose one \u2014\n\u2022 Look at the top five cards of your library. Put one of those cards into your hand and the rest into your graveyard.\n\u2022 Each opponent loses 3 life and you gain 3 life.\n\u2022 Maestros Charm deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -13016,7 +13016,7 @@
         },
         {
             "id": "8a694e38-5676-581e-9a0e-afeb2ac13bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d29c250-4673-4ae2-b9e5-cf463535a1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d29c250-4673-4ae2-b9e5-cf463535a1a3.jpg?1",
             "name": "Maestros Diabolist",
             "text": "Deathtouch, haste\nWhenever Maestros Diabolist attacks, if you don't control a Devil token, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -13058,7 +13058,7 @@
         },
         {
             "id": "db50e71b-abc7-57a8-ae5b-351f6b576c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b68f6f-d70b-4ed6-93f4-47964ee36a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b68f6f-d70b-4ed6-93f4-47964ee36a52.jpg?1",
             "name": "Masked Bandits",
             "text": "Vigilance, menace\n{2}, Exile Masked Bandits from your hand: Target land gains \"{T}: Add {B}, {R}, or {G}\" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.",
             "colours": [
@@ -13100,7 +13100,7 @@
         },
         {
             "id": "bfc60dce-989d-5442-84e9-6e5bc4567c5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0524fc64-f51c-4991-9e43-da56afd28c00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0524fc64-f51c-4991-9e43-da56afd28c00.jpg?1",
             "name": "Mr. Orfeo, the Boulder",
             "text": "Whenever you attack, double target creature's power until end of turn.",
             "colours": [
@@ -13144,7 +13144,7 @@
         },
         {
             "id": "7f9e3a79-c25c-5b4b-a65d-953f7be3ec9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f640d69-b690-4262-b3d8-e9e28c813f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f640d69-b690-4262-b3d8-e9e28c813f94.jpg?1",
             "name": "Nimble Larcenist",
             "text": "Flying\nWhen Nimble Larcenist enters the battlefield, target opponent reveals their hand. You choose an artifact, instant, or sorcery card from it and exile that card.",
             "colours": [
@@ -13186,7 +13186,7 @@
         },
         {
             "id": "2dd74cd0-36e5-59ca-b168-755b0f4bb5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9913f7-0e75-4b49-ada4-986e96b32f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9913f7-0e75-4b49-ada4-986e96b32f74.jpg?1",
             "name": "Obscura Ascendancy",
             "text": "Whenever you cast a spell, if its mana value is equal to 1 plus the number of soul counters on Obscura Ascendancy, put a soul counter on Obscura Ascendancy, then create a 2/2 white Spirit creature token with flying.\nAs long as there are five or more soul counters on Obscura Ascendancy, Spirits you control get +3/+3.",
             "colours": [
@@ -13225,7 +13225,7 @@
         },
         {
             "id": "5257dfdc-ac4c-507d-9eac-1730cf212deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a02b758-65b6-4c25-83b9-de63a1a92b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a02b758-65b6-4c25-83b9-de63a1a92b51.jpg?1",
             "name": "Obscura Charm",
             "text": "Choose one \u2014\n\u2022 Return target multicolored permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\n\u2022 Counter target instant or sorcery spell.\n\u2022 Destroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -13264,7 +13264,7 @@
         },
         {
             "id": "cefdf863-edaf-514b-a11e-814e48bd7fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3f849-bc0a-49fa-ae97-939a9eef075a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec3f849-bc0a-49fa-ae97-939a9eef075a.jpg?1",
             "name": "Obscura Interceptor",
             "text": "Flash\nLifelink\nWhen Obscura Interceptor enters the battlefield, it connives. When it connives this way, return up to one target spell to its owner's hand.",
             "colours": [
@@ -13306,7 +13306,7 @@
         },
         {
             "id": "92dd0299-4646-53eb-b53b-6b2cc3d685f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1279e32d-2921-41e1-9783-7cd4391a2eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1279e32d-2921-41e1-9783-7cd4391a2eb7.jpg?1",
             "name": "Ognis, the Dragon's Lash",
             "text": "Haste\nWhenever a creature you control with haste attacks, create a tapped Treasure token.",
             "colours": [
@@ -13350,7 +13350,7 @@
         },
         {
             "id": "d9146343-67ed-587b-9294-e343582fc451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be62891-93fa-4642-ad44-8c8695a9c960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be62891-93fa-4642-ad44-8c8695a9c960.jpg?1",
             "name": "Queza, Augur of Agonies",
             "text": "Whenever you draw a card, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -13394,7 +13394,7 @@
         },
         {
             "id": "7b1278d3-b67f-5785-99df-9da59fcb3b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a0ae-aee8-4a19-a8fc-9f915d7c1499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc85a0ae-aee8-4a19-a8fc-9f915d7c1499.jpg?1",
             "name": "Raffine, Scheming Seer",
             "text": "Flying, ward {1}\nWhenever you attack, target attacking creature connives X, where X is the number of attacking creatures.",
             "colours": [
@@ -13438,7 +13438,7 @@
         },
         {
             "id": "3c5e3b7b-58ba-586a-a582-980da3621703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2258b7b6-e679-4fcf-9cfe-2ff01a8996dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2258b7b6-e679-4fcf-9cfe-2ff01a8996dc.jpg?1",
             "name": "Rakish Revelers",
             "text": "When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{2}, Exile Rakish Revelers from your hand: Target land gains \"{T}: Add {R}, {G}, or {W}\" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.",
             "colours": [
@@ -13481,7 +13481,7 @@
         },
         {
             "id": "1bb82142-9887-5293-84e7-a7804b37850a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7f28a1-e9bb-4fba-8984-3e4e386f77ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a7f28a1-e9bb-4fba-8984-3e4e386f77ed.jpg?1",
             "name": "Rigo, Streetwise Mentor",
             "text": "Rigo, Streetwise Mentor enters the battlefield with a shield counter on it.\nWhenever you attack a player or planeswalker with one or more creatures with power 1 or less, draw a card.",
             "colours": [
@@ -13525,7 +13525,7 @@
         },
         {
             "id": "53d4dcf3-2cc7-589d-ae47-40fe2538c990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68904481-c02f-469a-806a-4db9fd151414.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68904481-c02f-469a-806a-4db9fd151414.jpg?1",
             "name": "Riveteers Ascendancy",
             "text": "Whenever you sacrifice a creature, you may return target creature card with lesser mana value from your graveyard to the battlefield tapped. Do this only once each turn.",
             "colours": [
@@ -13564,7 +13564,7 @@
         },
         {
             "id": "119b2173-3eaf-5e00-8deb-c35fe7b4bbc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca0eb05-95d2-4eba-a3de-0e08739459a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca0eb05-95d2-4eba-a3de-0e08739459a3.jpg?1",
             "name": "Riveteers Charm",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature or planeswalker they control with the highest mana value among creatures and planeswalkers they control.\n\u2022 Exile the top three cards of your library. Until your next end step, you may play those cards.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -13603,7 +13603,7 @@
         },
         {
             "id": "23304103-368e-51be-8b6c-9fc12bed5024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc93cb-8df4-446f-b99f-21238355ad64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbc93cb-8df4-446f-b99f-21238355ad64.jpg?1",
             "name": "Rocco, Cabaretti Caterer",
             "text": "When Rocco, Cabaretti Caterer enters the battlefield, if you cast it, you may search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -13647,7 +13647,7 @@
         },
         {
             "id": "36e858e5-6765-50f4-a454-fcb8428ab31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23dfcb-9e17-42bf-9a86-f9e3ce8b4b9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de23dfcb-9e17-42bf-9a86-f9e3ce8b4b9c.jpg?1",
             "name": "Shattered Seraph",
             "text": "Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{2}, Exile Shattered Seraph from your hand: Target land gains \"{T}: Add {W}, {U}, or {B}\" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.",
             "colours": [
@@ -13689,7 +13689,7 @@
         },
         {
             "id": "eea7931a-3550-510b-9827-515f06d1949b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b4f07d-eb74-4f7e-8705-3fd237133cb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b4f07d-eb74-4f7e-8705-3fd237133cb6.jpg?1",
             "name": "Soul of Emancipation",
             "text": "When Soul of Emancipation enters the battlefield, destroy up to three other target nonland permanents. For each of those permanents, its controller creates a 3/3 white Angel creature token with flying.",
             "colours": [
@@ -13730,7 +13730,7 @@
         },
         {
             "id": "8d08e6db-7086-5884-8a47-361188e7f9df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4495468f-a587-48f7-875d-dad80b86c156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4495468f-a587-48f7-875d-dad80b86c156.jpg?1",
             "name": "Spara's Adjudicators",
             "text": "When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{2}, Exile Spara's Adjudicators from your hand: Target land gains \"{T}: Add {G}, {W}, or {U}\" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.",
             "colours": [
@@ -13772,7 +13772,7 @@
         },
         {
             "id": "f891bf0b-982f-5d37-95bf-be197139b804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6da6284-1577-4bc2-85dd-5984aea72ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6da6284-1577-4bc2-85dd-5984aea72ac6.jpg?1",
             "name": "Toluz, Clever Conductor",
             "text": "When Toluz, Clever Conductor enters the battlefield, it connives.\nWhenever you discard one or more cards, exile them from your graveyard.\nWhen Toluz dies, put the cards exiled with it into their owner's hand.",
             "colours": [
@@ -13816,7 +13816,7 @@
         },
         {
             "id": "808a04c0-9076-50d4-936c-d25cfb0c0c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746c267f-ae38-45f4-9dca-8c7278843526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/746c267f-ae38-45f4-9dca-8c7278843526.jpg?1",
             "name": "Unleash the Inferno",
             "text": "Unleash the Inferno deals 7 damage to target creature or planeswalker. When it deals excess damage this way, destroy target artifact or enchantment an opponent controls with mana value less than or equal to that amount of excess damage.",
             "colours": [
@@ -13855,7 +13855,7 @@
         },
         {
             "id": "abd60a1d-883f-58d7-9bc0-57e297b9bcc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f2392d-7b1d-4521-b940-5ef44c464813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f2392d-7b1d-4521-b940-5ef44c464813.jpg?1",
             "name": "Void Rend",
             "text": "This spell can't be countered.\nDestroy target nonland permanent.",
             "colours": [
@@ -13894,7 +13894,7 @@
         },
         {
             "id": "a8cc1cff-ac1b-5f19-a695-9d4e70e64c9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be56f915-0c52-4824-b684-b0612ea76643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be56f915-0c52-4824-b684-b0612ea76643.jpg?1",
             "name": "Ziatora, the Incinerator",
             "text": "Flying\nAt the beginning of your end step, you may sacrifice another creature. When you do, Ziatora, the Incinerator deals damage equal to that creature's power to any target and you create three Treasure tokens.",
             "colours": [
@@ -13938,7 +13938,7 @@
         },
         {
             "id": "ae38c020-47e0-598a-b807-a1664b7ad52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c4ac9-f256-47a9-9dec-a42df3695fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c4ac9-f256-47a9-9dec-a42df3695fcd.jpg?1",
             "name": "Ziatora's Envoy",
             "text": "Trample\nWhenever Ziatora's Envoy deals combat damage to a player, look at the top card of your library. You may play a land from the top of your library or cast a spell with mana value less than or equal to the damage dealt from the top of your library without paying its mana cost. If you don't, put that card into your hand.\nBlitz {2}{B}{R}{G}",
             "colours": [
@@ -13980,7 +13980,7 @@
         },
         {
             "id": "31a668a2-724b-5716-8304-ab90120af5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a883eb5-2666-487b-b8c8-fd8ad12afaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a883eb5-2666-487b-b8c8-fd8ad12afaeb.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "+1: Choose up to one target creature. Put a +1/+1 counter and a counter from among flying, first strike, lifelink, or vigilance on it.\n\u22123: Look at the top seven cards of your library. You may put a permanent card with mana value 3 or less from among them onto the battlefield with a shield counter on it. Put the rest on the bottom of your library in a random order.\n\u22127: Create five 3/3 white Angel creature tokens with flying.",
             "colours": [
@@ -14020,7 +14020,7 @@
         },
         {
             "id": "b45d0946-4b2e-59ab-a13d-79d6961260fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80798911-6cb6-4b67-90b9-0fb83685ea92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80798911-6cb6-4b67-90b9-0fb83685ea92.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "Flying, vigilance\nEach other Angel you control enters the battlefield with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
             "colours": [
@@ -14059,7 +14059,7 @@
         },
         {
             "id": "a4562f92-3e17-51be-b337-1676c1edb6b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c43f0d-bca6-43c6-9fea-83fc5e178a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c43f0d-bca6-43c6-9fea-83fc5e178a70.jpg?1",
             "name": "Sanctuary Warden",
             "text": "Flying\nSanctuary Warden enters the battlefield with two shield counters on it.\nWhenever Sanctuary Warden enters the battlefield or attacks, you may remove a counter from a creature or planeswalker you control. If you do, draw a card and create a 1/1 green and white Citizen creature token.",
             "colours": [
@@ -14097,7 +14097,7 @@
         },
         {
             "id": "22fa4a4e-40f1-5c28-a9a7-f353b50f9db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0116c9-8b8a-4ffd-b688-bf7dd0d3a8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0116c9-8b8a-4ffd-b688-bf7dd0d3a8f8.jpg?1",
             "name": "Errant, Street Artist",
             "text": "Flash\nDefender, haste\n{1}{U}, {T}: Copy target spell you control that wasn't cast. You may choose new targets for the copy.",
             "colours": [
@@ -14137,7 +14137,7 @@
         },
         {
             "id": "a162be02-27d3-5f9a-9c78-97ca9333c540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a102db09-fae9-4714-951c-bbdf9d4658d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a102db09-fae9-4714-951c-bbdf9d4658d7.jpg?1",
             "name": "Tenacious Underdog",
             "text": "Blitz\u2014{2}{B}{B}, Pay 2 life.\nYou may cast Tenacious Underdog from your graveyard using its blitz ability.",
             "colours": [
@@ -14175,7 +14175,7 @@
         },
         {
             "id": "e621d8f1-11ea-5f82-bf85-ae07aef1733d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1152a35a-9483-446e-a2d8-539b4518a1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1152a35a-9483-446e-a2d8-539b4518a1ad.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "Haste\nAt the beginning of your upkeep, exile the top card of your library. You may play it this turn.\nAt the beginning of each opponent's upkeep, the next time they would draw a card this turn, instead they exile the top card of their library. They may play it this turn.",
             "colours": [
@@ -14218,7 +14218,7 @@
         },
         {
             "id": "7cafed23-cb48-5a76-be93-f9bc39242343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e23d7-f4db-437d-bfe4-be35f0a443b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890e23d7-f4db-437d-bfe4-be35f0a443b3.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "+2: You may sacrifice a creature. If you do, search your library for a creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it onto the battlefield, then shuffle.\n+1: Mill five cards, then put any number of creature cards milled this way into your hand.\n\u22121: Create a 4/4 green Rhino Warrior creature token.",
             "colours": [
@@ -14258,7 +14258,7 @@
         },
         {
             "id": "75dc2d77-46a0-5d7b-bd25-1f1260d3c51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8a7966-97cf-47f8-ab85-4f95335425a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8a7966-97cf-47f8-ab85-4f95335425a7.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "Casualty X. The copy isn't legendary and has starting loyalty X. (As you cast this spell, you may sacrifice a creature with power X. When you do, copy this spell. The copy becomes a token.)\n+1: Each opponent loses 2 life unless they discard a card. If you control a Demon or Devil, you gain 2 life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"\n\u22127: Target player draws seven cards and loses 7 life.",
             "colours": [
@@ -14300,7 +14300,7 @@
         },
         {
             "id": "d37cde89-7172-5765-ac34-b0b8da7a56c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08ce85-f030-485f-81d8-bdf47ed04a8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b08ce85-f030-485f-81d8-bdf47ed04a8e.jpg?1",
             "name": "Scheming Fence",
             "text": "As Scheming Fence enters the battlefield, you may choose a nonland permanent.\nActivated abilities of the chosen permanent can't be activated.\nScheming Fence has all activated abilities of the chosen permanent except for loyalty abilities. You may spend mana as though it were mana of any color to activate those abilities.",
             "colours": [
@@ -14340,7 +14340,7 @@
         },
         {
             "id": "3fcc53d9-d121-5f26-897d-b6a9b5792644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac068b57-568b-41f6-90d2-7b0eef99a74d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac068b57-568b-41f6-90d2-7b0eef99a74d.jpg?1",
             "name": "Botanical Plaza",
             "text": "Botanical Plaza enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}, {T}, Sacrifice Botanical Plaza: Draw a card.",
             "colours": [],
@@ -14373,7 +14373,7 @@
         },
         {
             "id": "b53edec2-f0d1-537f-a34c-f801b38d17f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9203fa-12db-4fa0-affd-4db277c871b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9203fa-12db-4fa0-affd-4db277c871b7.jpg?1",
             "name": "Jetmir's Garden",
             "text": "({T}: Add {R}, {G}, or {W}.)\nJetmir's Garden enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14412,7 +14412,7 @@
         },
         {
             "id": "7c5ee01e-c37e-5c43-b3ab-642f9f35e85c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa5d34b-b052-47f4-95e1-42a9c2d21cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa5d34b-b052-47f4-95e1-42a9c2d21cdf.jpg?1",
             "name": "Racers' Ring",
             "text": "Racers' Ring enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}, {T}, Sacrifice Racers' Ring: Draw a card.",
             "colours": [],
@@ -14445,7 +14445,7 @@
         },
         {
             "id": "e3bf9a28-c78d-5508-a3cc-f91c7fe42e04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb77f3-8ec4-4b8a-a283-4126037f4d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36bb77f3-8ec4-4b8a-a283-4126037f4d00.jpg?1",
             "name": "Raffine's Tower",
             "text": "({T}: Add {W}, {U}, or {B}.)\nRaffine's Tower enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14484,7 +14484,7 @@
         },
         {
             "id": "ff89be7c-64ae-5bd6-9609-ebb5a7f60de4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906bdba-534c-4f47-b00b-bb93f92774cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b906bdba-534c-4f47-b00b-bb93f92774cd.jpg?1",
             "name": "Skybridge Towers",
             "text": "Skybridge Towers enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice Skybridge Towers: Draw a card.",
             "colours": [],
@@ -14517,7 +14517,7 @@
         },
         {
             "id": "ee7b8caf-f0f9-5a81-b9e0-2986977da161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddd6093-eb29-4a1a-a0af-debb86c9cadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddd6093-eb29-4a1a-a0af-debb86c9cadd.jpg?1",
             "name": "Spara's Headquarters",
             "text": "({T}: Add {G}, {W}, or {U}.)\nSpara's Headquarters enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14556,7 +14556,7 @@
         },
         {
             "id": "c620370f-0541-5b62-b424-b962f3526d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c5428-0ec0-4778-801b-a5ea83c88691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c5428-0ec0-4778-801b-a5ea83c88691.jpg?1",
             "name": "Tramway Station",
             "text": "Tramway Station enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice Tramway Station: Draw a card.",
             "colours": [],
@@ -14589,7 +14589,7 @@
         },
         {
             "id": "fbad67b2-67f0-556a-8f20-dd024f373d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e3add-48d4-4330-9a5c-28f3f4defaf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e3add-48d4-4330-9a5c-28f3f4defaf8.jpg?1",
             "name": "Waterfront District",
             "text": "Waterfront District enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}, {T}, Sacrifice Waterfront District: Draw a card.",
             "colours": [],
@@ -14622,7 +14622,7 @@
         },
         {
             "id": "f43bb54e-22ad-5947-b3a1-c222a75f92db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96f496-1fc1-4e66-878a-b0905e920cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96f496-1fc1-4e66-878a-b0905e920cdc.jpg?1",
             "name": "Xander's Lounge",
             "text": "({T}: Add {U}, {B}, or {R}.)\nXander's Lounge enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14661,7 +14661,7 @@
         },
         {
             "id": "7084a384-47f1-52fb-817e-756dfabb5a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307c4a30-a859-487c-b72d-f10eebcd01c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307c4a30-a859-487c-b72d-f10eebcd01c4.jpg?1",
             "name": "Ziatora's Proving Ground",
             "text": "({T}: Add {B}, {R}, or {G}.)\nZiatora's Proving Ground enters the battlefield tapped.\nCycling {3}",
             "colours": [],
@@ -14700,7 +14700,7 @@
         },
         {
             "id": "cdca0e63-4e54-5618-8b84-6a79c20dc742",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979eee11-9843-49c0-8a1e-bb0616926f90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/979eee11-9843-49c0-8a1e-bb0616926f90.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "Haste\nAt the beginning of your upkeep, exile the top card of your library. You may play it this turn.\nAt the beginning of each opponent's upkeep, the next time they would draw a card this turn, instead they exile the top card of their library. They may play it this turn.",
             "colours": [
@@ -14743,7 +14743,7 @@
         },
         {
             "id": "711a4420-c625-500d-a659-2bd1a5ab6183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9387bd-25b9-4d40-8863-14b5a25272be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9387bd-25b9-4d40-8863-14b5a25272be.jpg?1",
             "name": "Brazen Upstart",
             "text": "Vigilance\nWhen Brazen Upstart dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14784,7 +14784,7 @@
         },
         {
             "id": "adc66b02-3d6e-59c2-9eb3-13f920cb2275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a87184-100d-415e-a4d4-d59d1269dbea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a87184-100d-415e-a4d4-d59d1269dbea.jpg?1",
             "name": "Brokers Ascendancy",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control and a loyalty counter on each planeswalker you control.",
             "colours": [
@@ -14822,7 +14822,7 @@
         },
         {
             "id": "983bc20e-4451-5ddb-887e-fe2e555a0076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51157e88-32c5-4add-9127-565d3833ce21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51157e88-32c5-4add-9127-565d3833ce21.jpg?1",
             "name": "Brokers Charm",
             "text": "Choose one \u2014\n\u2022 Target creature you control gets +1/+0 until end of turn. It deals damage equal to its power to target creature or planeswalker an opponent controls.\n\u2022 Destroy target enchantment.\n\u2022 Draw two cards.",
             "colours": [
@@ -14860,7 +14860,7 @@
         },
         {
             "id": "accf7549-3628-5b4a-afc1-4130daa83088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df8fcb2-9915-4b99-a192-90f28bf79f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df8fcb2-9915-4b99-a192-90f28bf79f53.jpg?1",
             "name": "Cabaretti Ascendancy",
             "text": "At the beginning of your upkeep, look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it on the bottom of your library.",
             "colours": [
@@ -14898,7 +14898,7 @@
         },
         {
             "id": "73a83fb5-24b4-559f-9d5e-73f7abe31e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce4e34d-cf32-48ab-8554-caa0518ab1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce4e34d-cf32-48ab-8554-caa0518ab1fb.jpg?1",
             "name": "Cabaretti Charm",
             "text": "Choose one \u2014\n\u2022 Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Create two 1/1 green and white Citizen creature tokens.",
             "colours": [
@@ -14936,7 +14936,7 @@
         },
         {
             "id": "13269147-2efc-58d5-baf3-b4b090b44e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31458c7-c1ad-44dd-9c9f-b4a16f1fad0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31458c7-c1ad-44dd-9c9f-b4a16f1fad0e.jpg?1",
             "name": "Cormela, Glamour Thief",
             "text": "Haste\n{1}, {T}: Add {U}{B}{R}. Spend this mana only to cast instant and/or sorcery spells.\nWhen Cormela, Glamour Thief dies, return up to one target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -14979,7 +14979,7 @@
         },
         {
             "id": "a9935aab-3885-5969-8f8f-7d8e30b2578d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a66da6-03bf-46e2-b729-3719d6bcc7ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a66da6-03bf-46e2-b729-3719d6bcc7ce.jpg?1",
             "name": "Corpse Appraiser",
             "text": "When Corpse Appraiser enters the battlefield, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -15020,7 +15020,7 @@
         },
         {
             "id": "c2c20d85-ed9a-5999-9272-da5d9afba58a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a66fa80-f385-44a7-95ef-b09e91ce6a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a66fa80-f385-44a7-95ef-b09e91ce6a60.jpg?1",
             "name": "Crew Captain",
             "text": "Haste\nCrew Captain has indestructible as long as it entered the battlefield this turn.",
             "colours": [
@@ -15061,7 +15061,7 @@
         },
         {
             "id": "0d836178-4215-558c-82ad-913052d1f693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77ba1d-9e88-49db-b4e4-63824a0fe490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de77ba1d-9e88-49db-b4e4-63824a0fe490.jpg?1",
             "name": "Disciplined Duelist",
             "text": "Double strike\nDisciplined Duelist enters the battlefield with a shield counter on it.",
             "colours": [
@@ -15102,7 +15102,7 @@
         },
         {
             "id": "3dcdcc1d-4291-512a-bd0d-c774d7a5b354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648d9f4-8f56-4bd4-8654-b166c959ebea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648d9f4-8f56-4bd4-8654-b166c959ebea.jpg?1",
             "name": "Endless Detour",
             "text": "The owner of target spell, nonland permanent, or card in a graveyard puts it on the top or bottom of their library.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "267bc7d5-6463-5fc9-af7c-d6cb0ba58828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf30b561-7ae6-4423-9184-6574e68f9038.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf30b561-7ae6-4423-9184-6574e68f9038.jpg?1",
             "name": "Evelyn, the Covetous",
             "text": "Flash\nWhenever Evelyn, the Covetous or another Vampire enters the battlefield under your control, exile the top card of each player's library with a collection counter on it.\nOnce each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were any color to cast it.",
             "colours": [
@@ -15183,7 +15183,7 @@
         },
         {
             "id": "af476609-bda9-598d-9f4c-b2a6660968b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518c19e-c8f4-4598-849c-c073c8c33923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6518c19e-c8f4-4598-849c-c073c8c33923.jpg?1",
             "name": "Falco Spara, Pactweaver",
             "text": "Flying, trample\nFalco Spara, Pactweaver enters the battlefield with a shield counter on it.\nYou may look at the top card of your library any time.\nYou may cast spells from the top of your library by removing a counter from a creature you control in addition to paying their other costs.",
             "colours": [
@@ -15226,7 +15226,7 @@
         },
         {
             "id": "a7a1cbef-97dc-5b6e-98f6-f93f4561ee30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84cd002-0780-45af-a4b9-1f8d2a3dc07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e84cd002-0780-45af-a4b9-1f8d2a3dc07a.jpg?1",
             "name": "Fleetfoot Dancer",
             "text": "Trample, lifelink, haste",
             "colours": [
@@ -15267,7 +15267,7 @@
         },
         {
             "id": "9e11720f-89c0-5f95-bfca-c6f81167e17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce205611-15c0-413e-ad2b-b561ae530a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce205611-15c0-413e-ad2b-b561ae530a30.jpg?1",
             "name": "Glamorous Outlaw",
             "text": "When Glamorous Outlaw enters the battlefield, it deals 2 damage to each opponent and you scry 2.\n{2}, Exile Glamorous Outlaw from your hand: Target land gains \"{T}: Add {U}, {B}, or {R}\" until Glamorous Outlaw is cast from exile. You may cast Glamorous Outlaw for as long as it remains exiled.",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "765e9ec9-1286-596e-81a8-6589b7162daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d196a9-25aa-44da-baa7-2a0191ad7609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d196a9-25aa-44da-baa7-2a0191ad7609.jpg?1",
             "name": "Hostile Takeover",
             "text": "Up to one target creature has base power and toughness 1/1 until end of turn. Up to one other target creature has base power and toughness 4/4 until end of turn. Then Hostile Takeover deals 3 damage to each creature.",
             "colours": [
@@ -15346,7 +15346,7 @@
         },
         {
             "id": "83a1ad3c-ce26-5e40-9379-2907a61007fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9c3c10-8524-4be3-b7a2-5ee34a582dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9c3c10-8524-4be3-b7a2-5ee34a582dd6.jpg?1",
             "name": "Incandescent Aria",
             "text": "Incandescent Aria deals 3 damage to each nontoken creature.",
             "colours": [
@@ -15384,7 +15384,7 @@
         },
         {
             "id": "188815f6-593a-5ba5-b2a9-7bcf647edf5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3530e3-aa7f-422b-b3f1-100afad673e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3530e3-aa7f-422b-b3f1-100afad673e4.jpg?1",
             "name": "Jetmir, Nexus of Revels",
             "text": "Creatures you control get +1/+0 and have vigilance as long as you control three or more creatures.\nCreatures you control also get +1/+0 and have trample as long as you control six or more creatures.\nCreatures you control also get +1/+0 and have double strike as long as you control nine or more creatures.",
             "colours": [
@@ -15427,7 +15427,7 @@
         },
         {
             "id": "4ba284c9-ee22-5a6f-add1-269d710f671a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5915902a-25b4-4e87-939a-2f9ba7552091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5915902a-25b4-4e87-939a-2f9ba7552091.jpg?1",
             "name": "Jinnie Fay, Jetmir's Second",
             "text": "If you would create one or more tokens, you may instead create that many 2/2 green Cat creature tokens with haste or that many 3/1 green Dog creature tokens with vigilance.",
             "colours": [
@@ -15470,7 +15470,7 @@
         },
         {
             "id": "3202a35f-6a0f-5777-a4ae-1f7903377f6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db9c6a-aa6c-44e1-86bd-8621abf64d4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db9c6a-aa6c-44e1-86bd-8621abf64d4f.jpg?1",
             "name": "Lagrella, the Magpie",
             "text": "When Lagrella, the Magpie enters the battlefield, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters the battlefield under your control this way, put two +1/+1 counters on it.",
             "colours": [
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "c890b624-2af2-5d58-8de6-3056d15c074d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8ad1ac-da5f-4852-b697-d77087f98d1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8ad1ac-da5f-4852-b697-d77087f98d1a.jpg?1",
             "name": "Lord Xander, the Collector",
             "text": "When Lord Xander, the Collector enters the battlefield, target opponent discards half the cards in their hand, rounded down.\nWhenever Lord Xander attacks, defending player mills half their library, rounded down.\nWhen Lord Xander dies, target opponent sacrifices half the nonland permanents they control, rounded down.",
             "colours": [
@@ -15557,7 +15557,7 @@
         },
         {
             "id": "574aac1f-0476-5cde-8db2-3bd037db2846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5003bd-fafa-4a91-a3ca-31d8b23e0561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f5003bd-fafa-4a91-a3ca-31d8b23e0561.jpg?1",
             "name": "Maestros Ascendancy",
             "text": "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -15595,7 +15595,7 @@
         },
         {
             "id": "7551f18a-3dd4-555e-be02-429299aeeadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b023c-3edc-4e34-9221-490e264e289c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b023c-3edc-4e34-9221-490e264e289c.jpg?1",
             "name": "Maestros Charm",
             "text": "Choose one \u2014\n\u2022 Look at the top five cards of your library. Put one of those cards into your hand and the rest into your graveyard.\n\u2022 Each opponent loses 3 life and you gain 3 life.\n\u2022 Maestros Charm deals 5 damage to target creature or planeswalker.",
             "colours": [
@@ -15633,7 +15633,7 @@
         },
         {
             "id": "9729bc88-7ca2-5ad1-bcf4-fd5c2b88f0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9875b763-0971-4124-bd12-30d4e9c5d674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9875b763-0971-4124-bd12-30d4e9c5d674.jpg?1",
             "name": "Maestros Diabolist",
             "text": "Deathtouch, haste\nWhenever Maestros Diabolist attacks, if you don't control a Devil token, create a tapped and attacking 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -15674,7 +15674,7 @@
         },
         {
             "id": "1d3f07d7-93d3-5cd0-8de3-abb8001561d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af412300-55ed-43ed-9c9a-87881e23f806.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af412300-55ed-43ed-9c9a-87881e23f806.jpg?1",
             "name": "Masked Bandits",
             "text": "Vigilance, menace\n{2}, Exile Masked Bandits from your hand: Target land gains \"{T}: Add {B}, {R}, or {G}\" until Masked Bandits is cast from exile. You may cast Masked Bandits for as long as it remains exiled.",
             "colours": [
@@ -15715,7 +15715,7 @@
         },
         {
             "id": "66d5f1d1-4e63-5282-8be8-d63c58daf99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319bd9a-23dc-4afc-b7fe-8e2469b521a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c319bd9a-23dc-4afc-b7fe-8e2469b521a3.jpg?1",
             "name": "Mr. Orfeo, the Boulder",
             "text": "Whenever you attack, double target creature's power until end of turn.",
             "colours": [
@@ -15758,7 +15758,7 @@
         },
         {
             "id": "e3b62996-0b40-5aed-a34e-7206e6c80415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dc7d21-e56a-4758-b5a0-3acd7eb8c367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31dc7d21-e56a-4758-b5a0-3acd7eb8c367.jpg?1",
             "name": "Nimble Larcenist",
             "text": "Flying\nWhen Nimble Larcenist enters the battlefield, target opponent reveals their hand. You choose an artifact, instant, or sorcery card from it and exile that card.",
             "colours": [
@@ -15799,7 +15799,7 @@
         },
         {
             "id": "4376dec7-436d-5dfd-8346-5f3263b8ce97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d3971-a35e-41a6-813d-a936575c45e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d3971-a35e-41a6-813d-a936575c45e5.jpg?1",
             "name": "Obscura Ascendancy",
             "text": "Whenever you cast a spell, if its mana value is equal to 1 plus the number of soul counters on Obscura Ascendancy, put a soul counter on Obscura Ascendancy, then create a 2/2 white Spirit creature token with flying.\nAs long as there are five or more soul counters on Obscura Ascendancy, Spirits you control get +3/+3.",
             "colours": [
@@ -15837,7 +15837,7 @@
         },
         {
             "id": "5290bbd0-f2e7-562f-a918-bcd2553fb530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529f8ae-a673-4573-b74c-2e3cafc67f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529f8ae-a673-4573-b74c-2e3cafc67f44.jpg?1",
             "name": "Obscura Charm",
             "text": "Choose one \u2014\n\u2022 Return target multicolored permanent card with mana value 3 or less from your graveyard to the battlefield tapped.\n\u2022 Counter target instant or sorcery spell.\n\u2022 Destroy target creature or planeswalker with mana value 3 or less.",
             "colours": [
@@ -15875,7 +15875,7 @@
         },
         {
             "id": "512262bf-8cb7-5178-97aa-7e99d2896f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfb1a4-ac28-4800-ae58-f729e6533680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8ddfb1a4-ac28-4800-ae58-f729e6533680.jpg?1",
             "name": "Obscura Interceptor",
             "text": "Flash\nLifelink\nWhen Obscura Interceptor enters the battlefield, it connives. When it connives this way, return up to one target spell to its owner's hand.",
             "colours": [
@@ -15916,7 +15916,7 @@
         },
         {
             "id": "53511276-375e-5768-bb94-f293e94da789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3941b30-ee01-47f8-895b-73b0f258fa80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3941b30-ee01-47f8-895b-73b0f258fa80.jpg?1",
             "name": "Ognis, the Dragon's Lash",
             "text": "Haste\nWhenever a creature you control with haste attacks, create a tapped Treasure token.",
             "colours": [
@@ -15959,7 +15959,7 @@
         },
         {
             "id": "f87c7646-04f8-597f-aaae-2a633533fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a84dd-bb7c-4980-a031-23c778e37f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064a84dd-bb7c-4980-a031-23c778e37f73.jpg?1",
             "name": "Queza, Augur of Agonies",
             "text": "Whenever you draw a card, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -16002,7 +16002,7 @@
         },
         {
             "id": "8105d5ce-7a6a-5b9c-b746-7c3cfa96633e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549bdaa3-15a9-4b59-b30b-9d3d013664d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/549bdaa3-15a9-4b59-b30b-9d3d013664d6.jpg?1",
             "name": "Raffine, Scheming Seer",
             "text": "Flying, ward {1}\nWhenever you attack, target attacking creature connives X, where X is the number of attacking creatures.",
             "colours": [
@@ -16045,7 +16045,7 @@
         },
         {
             "id": "f9f2effc-78e8-57ad-a712-3e1e3f5f0722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be3c9b0-88fa-441a-a61d-ba7e00760117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be3c9b0-88fa-441a-a61d-ba7e00760117.jpg?1",
             "name": "Rakish Revelers",
             "text": "When Rakish Revelers enters the battlefield, create a 1/1 green and white Citizen creature token.\n{2}, Exile Rakish Revelers from your hand: Target land gains \"{T}: Add {R}, {G}, or {W}\" until Rakish Revelers is cast from exile. You may cast Rakish Revelers for as long as it remains exiled.",
             "colours": [
@@ -16087,7 +16087,7 @@
         },
         {
             "id": "42c6dbb6-c5b8-5380-9e27-ff0b71705cd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ad3b18-1666-4cd8-ad7f-ddf021522dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62ad3b18-1666-4cd8-ad7f-ddf021522dfb.jpg?1",
             "name": "Rigo, Streetwise Mentor",
             "text": "Rigo, Streetwise Mentor enters the battlefield with a shield counter on it.\nWhenever you attack a player or planeswalker with one or more creatures with power 1 or less, draw a card.",
             "colours": [
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "3031e30a-e995-528e-ae51-e4af604d2302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3058460c-56cb-46b7-9c72-d239bc728714.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3058460c-56cb-46b7-9c72-d239bc728714.jpg?1",
             "name": "Riveteers Ascendancy",
             "text": "Whenever you sacrifice a creature, you may return target creature card with lesser mana value from your graveyard to the battlefield tapped. Do this only once each turn.",
             "colours": [
@@ -16168,7 +16168,7 @@
         },
         {
             "id": "5fc42b5d-5b2c-5d3b-9bca-90654300accc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a403bd2a-5759-45f6-a913-d28a2bbbb9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a403bd2a-5759-45f6-a913-d28a2bbbb9ff.jpg?1",
             "name": "Riveteers Charm",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature or planeswalker they control with the highest mana value among creatures and planeswalkers they control.\n\u2022 Exile the top three cards of your library. Until your next end step, you may play those cards.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "b86904ad-1794-5c05-9b25-6af1f2bad24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e024dea-ce4e-46a6-b9ae-4c5016cfe3b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e024dea-ce4e-46a6-b9ae-4c5016cfe3b5.jpg?1",
             "name": "Rocco, Cabaretti Caterer",
             "text": "When Rocco, Cabaretti Caterer enters the battlefield, if you cast it, you may search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -16249,7 +16249,7 @@
         },
         {
             "id": "172da40f-9134-5c60-af78-0a09661d82f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee468a-0dcf-42b5-bc8b-9b86727162ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee468a-0dcf-42b5-bc8b-9b86727162ae.jpg?1",
             "name": "Shattered Seraph",
             "text": "Flying\nWhen Shattered Seraph enters the battlefield, you gain 3 life.\n{2}, Exile Shattered Seraph from your hand: Target land gains \"{T}: Add {W}, {U}, or {B}\" until Shattered Seraph is cast from exile. You may cast Shattered Seraph for as long as it remains exiled.",
             "colours": [
@@ -16290,7 +16290,7 @@
         },
         {
             "id": "723572b0-221c-5e75-a039-8580001f2abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9294f6-6160-4c83-8f62-3e27ebbb020f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9294f6-6160-4c83-8f62-3e27ebbb020f.jpg?1",
             "name": "Soul of Emancipation",
             "text": "When Soul of Emancipation enters the battlefield, destroy up to three other target nonland permanents. For each of those permanents, its controller creates a 3/3 white Angel creature token with flying.",
             "colours": [
@@ -16330,7 +16330,7 @@
         },
         {
             "id": "a3a12e2e-4312-5f59-8355-76130e086f71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93df6b13-d898-4afe-a60c-828933f5be32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93df6b13-d898-4afe-a60c-828933f5be32.jpg?1",
             "name": "Spara's Adjudicators",
             "text": "When Spara's Adjudicators enters the battlefield, target creature an opponent controls can't attack or block until your next turn.\n{2}, Exile Spara's Adjudicators from your hand: Target land gains \"{T}: Add {G}, {W}, or {U}\" until Spara's Adjudicators is cast from exile. You may cast Spara's Adjudicators for as long as it remains exiled.",
             "colours": [
@@ -16371,7 +16371,7 @@
         },
         {
             "id": "caa45028-2ae1-5bfc-b3fc-10486e7cb2ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb9bc34-783e-492d-b97f-89b39d80a62f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb9bc34-783e-492d-b97f-89b39d80a62f.jpg?1",
             "name": "Toluz, Clever Conductor",
             "text": "When Toluz, Clever Conductor enters the battlefield, it connives.\nWhenever you discard one or more cards, exile them from your graveyard.\nWhen Toluz dies, put the cards exiled with it into their owner's hand.",
             "colours": [
@@ -16414,7 +16414,7 @@
         },
         {
             "id": "0c54a1be-3913-59da-a1b4-710e0678eb87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4436b093-2c8a-45ad-b84b-b4282d3b61c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4436b093-2c8a-45ad-b84b-b4282d3b61c3.jpg?1",
             "name": "Unleash the Inferno",
             "text": "Unleash the Inferno deals 7 damage to target creature or planeswalker. When it deals excess damage this way, destroy target artifact or enchantment an opponent controls with mana value less than or equal to that amount of excess damage.",
             "colours": [
@@ -16452,7 +16452,7 @@
         },
         {
             "id": "6c6c2e24-893b-5c11-92a0-2b198e657bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592e2cd-25f7-4968-8664-29288e5eaa82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592e2cd-25f7-4968-8664-29288e5eaa82.jpg?1",
             "name": "Void Rend",
             "text": "This spell can't be countered.\nDestroy target nonland permanent.",
             "colours": [
@@ -16490,7 +16490,7 @@
         },
         {
             "id": "b94aec21-bcaf-5f59-9ca0-ecf8c2c915f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd6b307-c3a5-4dfd-b137-e1077700c51f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbd6b307-c3a5-4dfd-b137-e1077700c51f.jpg?1",
             "name": "Ziatora, the Incinerator",
             "text": "Flying\nAt the beginning of your end step, you may sacrifice another creature. When you do, Ziatora, the Incinerator deals damage equal to that creature's power to any target and you create three Treasure tokens.",
             "colours": [
@@ -16533,7 +16533,7 @@
         },
         {
             "id": "1fe6c16b-318e-559e-9eb5-e86d0a36db63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640273fe-631c-4efb-9221-9fd808a60fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640273fe-631c-4efb-9221-9fd808a60fae.jpg?1",
             "name": "Ziatora's Envoy",
             "text": "Trample\nWhenever Ziatora's Envoy deals combat damage to a player, look at the top card of your library. You may play a land from the top of your library or cast a spell with mana value less than or equal to the damage dealt from the top of your library without paying its mana cost. If you don't, put that card into your hand.\nBlitz {2}{B}{R}{G}",
             "colours": [
@@ -16574,7 +16574,7 @@
         },
         {
             "id": "bd52cb38-afa2-5e6a-8d29-35bae05bad45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737f2d9a-171d-4b0d-bae3-930aa9c88e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737f2d9a-171d-4b0d-bae3-930aa9c88e95.jpg?1",
             "name": "Depopulate",
             "text": "Each player who controls a multicolored creature draws a card. Then destroy all creatures.",
             "colours": [
@@ -16608,7 +16608,7 @@
         },
         {
             "id": "4bafce64-0b8d-52cc-b99b-f90b63ecea8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a1ca00-820f-4c2c-af3b-912bf7aca0a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3a1ca00-820f-4c2c-af3b-912bf7aca0a0.jpg?1",
             "name": "Extraction Specialist",
             "text": "Lifelink\nWhen Extraction Specialist enters the battlefield, return target creature card with mana value 2 or less from your graveyard to the battlefield. That creature can't attack or block for as long as you control Extraction Specialist.",
             "colours": [
@@ -16645,7 +16645,7 @@
         },
         {
             "id": "825ca638-86ab-5d9f-91cf-f65f62e48c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5783904-0950-4034-8277-5cf3b3865856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5783904-0950-4034-8277-5cf3b3865856.jpg?1",
             "name": "Mysterious Limousine",
             "text": "Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2",
             "colours": [
@@ -16682,7 +16682,7 @@
         },
         {
             "id": "46f98473-acc9-5822-8426-65b78bd3d71f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dafe2f2-9b1e-484b-a60e-9cf9ec875a6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dafe2f2-9b1e-484b-a60e-9cf9ec875a6b.jpg?1",
             "name": "Rabble Rousing",
             "text": "Hideaway 5\nWhenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens. Then if you control ten or more creatures, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -16716,7 +16716,7 @@
         },
         {
             "id": "a1a8d137-e802-5f90-98dc-73c579248666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0717ca-7fc0-4e87-b904-e1584ea02c14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0717ca-7fc0-4e87-b904-e1584ea02c14.jpg?1",
             "name": "Cut Your Losses",
             "text": "Casualty 2\nTarget player mills half their library, rounded down.",
             "colours": [
@@ -16750,7 +16750,7 @@
         },
         {
             "id": "dc10732e-3260-55c4-b005-c97ce8e873c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcba6c-9d8e-4a66-99ac-48e737e14263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57dcba6c-9d8e-4a66-99ac-48e737e14263.jpg?1",
             "name": "Even the Score",
             "text": "This spell costs {U}{U}{U} less to cast if an opponent has drawn four or more cards this turn.\nDraw X cards.",
             "colours": [
@@ -16784,7 +16784,7 @@
         },
         {
             "id": "31dce0d0-a9e1-5ace-bdcb-b45bc6db5b76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b1bf08-aba1-4197-8afe-05c1fc783307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b1bf08-aba1-4197-8afe-05c1fc783307.jpg?1",
             "name": "Ledger Shredder",
             "text": "Flying\nWhenever a player casts their second spell each turn, Ledger Shredder connives.",
             "colours": [
@@ -16821,7 +16821,7 @@
         },
         {
             "id": "42158cd7-a5c4-57e0-bf5a-d9dd075174be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479b8a-b5a4-4d45-9073-5d24becad45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01479b8a-b5a4-4d45-9073-5d24becad45b.jpg?1",
             "name": "Reservoir Kraken",
             "text": "Trample, ward {2}\nAt the beginning of each combat, if Reservoir Kraken is untapped, any opponent may tap an untapped creature they control. If they do, tap Reservoir Kraken and create a 1/1 blue Fish creature token with \"This creature can't be blocked.\"",
             "colours": [
@@ -16857,7 +16857,7 @@
         },
         {
             "id": "fb723527-9d5d-50f7-8f89-3d4c2d3a1bee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7585bac-eee3-445e-87a0-befef301b440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7585bac-eee3-445e-87a0-befef301b440.jpg?1",
             "name": "Undercover Operative",
             "text": "You may have Undercover Operative enter the battlefield as a copy of any creature on the battlefield, except it enters with a shield counter on it if you control that creature.",
             "colours": [
@@ -16894,7 +16894,7 @@
         },
         {
             "id": "d2d4e84a-d5b6-514f-962b-1c30ab30c807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1aa2e-13cf-490d-b142-5735bac153a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea1aa2e-13cf-490d-b142-5735bac153a1.jpg?1",
             "name": "Wiretapping",
             "text": "Hideaway 5\nWhenever you draw your first card during each of your draw steps, draw a card. Then if you have nine or more cards in hand, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -16928,7 +16928,7 @@
         },
         {
             "id": "06a35cde-c54b-5599-b3e6-cd2322e190b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc0e94-f608-4a57-a719-3f8fe675d0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99cc0e94-f608-4a57-a719-3f8fe675d0ae.jpg?1",
             "name": "Angel of Suffering",
             "text": "Flying\nIf damage would be dealt to you, prevent that damage and mill twice that many cards.",
             "colours": [
@@ -16965,7 +16965,7 @@
         },
         {
             "id": "980319ad-1db8-5458-810d-8ecc40e46890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c9c2a3-3844-4524-a2cb-8c2c3e6ebea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c9c2a3-3844-4524-a2cb-8c2c3e6ebea3.jpg?1",
             "name": "Body Launderer",
             "text": "Deathtouch\nWhenever another nontoken creature you control dies, Body Launderer connives.\nWhen Body Launderer dies, return another target non-Rogue creature card with equal or lesser power from your graveyard to the battlefield.",
             "colours": [
@@ -17002,7 +17002,7 @@
         },
         {
             "id": "82239dba-32c6-5778-b901-3234b32b9ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f199fc-11ff-45bd-bed2-5ac98eb80456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f199fc-11ff-45bd-bed2-5ac98eb80456.jpg?1",
             "name": "Cemetery Tampering",
             "text": "Hideaway 5\nAt the beginning of your upkeep, you may mill three cards. Then if there are twenty or more cards in your graveyard, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -17036,7 +17036,7 @@
         },
         {
             "id": "a160cc04-02af-5edd-9114-e9e0df760549",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb8b328-7886-4e91-9f3d-4103cfdd5b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb8b328-7886-4e91-9f3d-4103cfdd5b23.jpg?1",
             "name": "Cut of the Profits",
             "text": "Casualty 3\nYou draw X cards and you lose X life.",
             "colours": [
@@ -17070,7 +17070,7 @@
         },
         {
             "id": "ac8c9b0c-f092-517f-83d5-de78322699fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef0a253-e822-4912-90d6-dd1a781a55b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef0a253-e822-4912-90d6-dd1a781a55b7.jpg?1",
             "name": "Sanguine Spy",
             "text": "Menace, lifelink\n{1}, Sacrifice another creature: Look at the top card of your library. You may put that card into your graveyard.\nAt the beginning of your end step, if there are five or more mana values among cards in your graveyard, you may pay 2 life. If you do, draw a card.",
             "colours": [
@@ -17107,7 +17107,7 @@
         },
         {
             "id": "33b127a1-6fa5-5dd5-ba24-1beec5b88698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044f9aeb-9cce-4eea-9ddb-868720cd8287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044f9aeb-9cce-4eea-9ddb-868720cd8287.jpg?1",
             "name": "Shakedown Heavy",
             "text": "Menace\nWhenever Shakedown Heavy attacks, defending player may have you draw a card. If they do, untap Shakedown Heavy and remove it from combat.",
             "colours": [
@@ -17144,7 +17144,7 @@
         },
         {
             "id": "431215bb-d32a-5244-a6f2-4a7d0ea7ff4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e05615-063d-40ea-9dbb-885934b61fc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e05615-063d-40ea-9dbb-885934b61fc9.jpg?1",
             "name": "Arcane Bombardment",
             "text": "Whenever you cast your first instant or sorcery spell each turn, exile an instant or sorcery card at random from your graveyard. Then copy each card exiled with Arcane Bombardment. You may cast any number of the copies without paying their mana costs.",
             "colours": [
@@ -17178,7 +17178,7 @@
         },
         {
             "id": "fcb609be-9004-5ef1-a363-57fad67d3f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae0d2c-f943-4100-92f9-61eb6e7ba1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ae0d2c-f943-4100-92f9-61eb6e7ba1df.jpg?1",
             "name": "Devilish Valet",
             "text": "Trample, haste\nAlliance \u2014 Whenever another creature enters the battlefield under your control, double Devilish Valet's power until end of turn.",
             "colours": [
@@ -17215,7 +17215,7 @@
         },
         {
             "id": "7d46684e-3f69-5f78-a27b-74dff4ee5003",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58dd56-0bbb-4b2b-95b3-6b2a7da9eabd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c58dd56-0bbb-4b2b-95b3-6b2a7da9eabd.jpg?1",
             "name": "Hoard Hauler",
             "text": "Trample\nWhenever Hoard Hauler deals combat damage to a player, create a Treasure token for each artifact they control.\nCrew 3",
             "colours": [
@@ -17251,7 +17251,7 @@
         },
         {
             "id": "1ce6402e-8c65-5195-8dcc-070fad6445c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fa6dc3-3f4d-4501-8647-07b0252b6d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fa6dc3-3f4d-4501-8647-07b0252b6d93.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "{R}, {T}, Discard a card: Create a token that's a copy of another target creature you control. It gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\nBlitz {1}{R}",
             "colours": [
@@ -17291,7 +17291,7 @@
         },
         {
             "id": "fe813900-9e90-52ae-b466-d9e3ade1ae26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7e703f-dcd2-4a99-846f-758d4858453a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b7e703f-dcd2-4a99-846f-758d4858453a.jpg?1",
             "name": "Professional Face-Breaker",
             "text": "Menace\nWhenever one or more creatures you control deal combat damage to a player, create a Treasure token.\nSacrifice a Treasure: Exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -17328,7 +17328,7 @@
         },
         {
             "id": "2c0b9e01-beb7-512c-b026-0c813e9efbd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83d83-6401-41ae-aa50-dfd14e4070b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf83d83-6401-41ae-aa50-dfd14e4070b3.jpg?1",
             "name": "Structural Assault",
             "text": "Destroy all artifacts, then Structural Assault deals damage to each creature equal to the number of artifacts that were put into graveyards from the battlefield this turn.",
             "colours": [
@@ -17362,7 +17362,7 @@
         },
         {
             "id": "16531353-39b8-56e6-aa97-be7784a30358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5503-4bc1-46e4-95b9-abafe0f38580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c3f5503-4bc1-46e4-95b9-abafe0f38580.jpg?1",
             "name": "Widespread Thieving",
             "text": "Hideaway 5\nWhenever you cast a multicolored spell, create a Treasure token. Then you may pay {W}{U}{B}{R}{G}. If you do, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -17400,7 +17400,7 @@
         },
         {
             "id": "ce4b2891-c225-5f11-969f-c186f955e281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bf264-9d93-4f5d-b0e1-15beae7c4702.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317bf264-9d93-4f5d-b0e1-15beae7c4702.jpg?1",
             "name": "Evolving Door",
             "text": "{1}, {T}, Sacrifice a creature: Count the colors of the sacrificed creature, then search your library for a creature card that's exactly that many colors plus one. Exile that card, then shuffle. You may cast the exiled card. Activate only as a sorcery.",
             "colours": [
@@ -17434,7 +17434,7 @@
         },
         {
             "id": "2b356a3b-2e00-5b9d-8816-b9496eba4703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a556e-615f-416d-9e1b-fcc3304e0199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a556e-615f-416d-9e1b-fcc3304e0199.jpg?1",
             "name": "Fight Rigging",
             "text": "Hideaway 5\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if you control a creature with power 7 or greater, you may play the exiled card without paying its mana cost.",
             "colours": [
@@ -17468,7 +17468,7 @@
         },
         {
             "id": "93c48108-c366-51d9-be63-ae2c316798e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f723ae1e-be60-4cd6-9485-7f07fa1f8fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f723ae1e-be60-4cd6-9485-7f07fa1f8fe7.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -17516,7 +17516,7 @@
         },
         {
             "id": "63772276-423a-5557-a1dc-04e9e330bdad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5052562-ea98-4703-ba40-58534beead90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5052562-ea98-4703-ba40-58534beead90.jpg?1",
             "name": "Workshop Warchief",
             "text": "Trample\nWhen Workshop Warchief enters the battlefield, you gain 3 life.\nWhen Workshop Warchief dies, create a 4/4 green Rhino Warrior creature token.\nBlitz {4}{G}{G}",
             "colours": [
@@ -17553,7 +17553,7 @@
         },
         {
             "id": "b6662877-5797-5ee0-a183-24a0611e9662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08c9c2e-f863-46cb-b3a4-f83291a1a03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08c9c2e-f863-46cb-b3a4-f83291a1a03b.jpg?1",
             "name": "Aven Heartstabber",
             "text": "Flying\nAs long as there are five or more mana values among cards in your graveyard, Aven Heartstabber gets +2/+2 and has deathtouch.\nWhen Aven Heartstabber dies, mill two cards, then draw a card.",
             "colours": [
@@ -17592,7 +17592,7 @@
         },
         {
             "id": "769fce8a-2b32-5c07-b2c9-6b440735dd04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b4930d-6a27-43d4-acef-3c36ed967a82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b4930d-6a27-43d4-acef-3c36ed967a82.jpg?1",
             "name": "Black Market Tycoon",
             "text": "At the beginning of your upkeep, Black Market Tycoon deals 2 damage to you for each Treasure you control.\n{T}: Create a Treasure token.",
             "colours": [
@@ -17631,7 +17631,7 @@
         },
         {
             "id": "08fe876f-cc69-5e66-8bfe-695074ba2fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f510ca1-8d33-4703-b36b-377b99bcc163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f510ca1-8d33-4703-b36b-377b99bcc163.jpg?1",
             "name": "Corpse Explosion",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nCorpse Explosion deals damage equal to the exiled card's power to each creature and each planeswalker.",
             "colours": [
@@ -17667,7 +17667,7 @@
         },
         {
             "id": "f032198c-3ce8-5ac8-9aa8-b9e746c419f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57055f98-a642-4d88-967d-7828fc6cea72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57055f98-a642-4d88-967d-7828fc6cea72.jpg?1",
             "name": "Meeting of the Five",
             "text": "Exile the top ten cards of your library. You may cast spells with exactly three colors from among them this turn. Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Spend this mana only to cast spells with exactly three colors.",
             "colours": [
@@ -17709,7 +17709,7 @@
         },
         {
             "id": "89a3e2fd-394f-5c42-893d-a12cced5da35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88d365a-99aa-4e76-833e-b08aa83476a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88d365a-99aa-4e76-833e-b08aa83476a0.jpg?1",
             "name": "Park Heights Pegasus",
             "text": "Flying, trample\nWhenever Park Heights Pegasus deals combat damage to a player, draw a card if you had two or more creatures enter the battlefield under your control this turn.",
             "colours": [
@@ -17747,7 +17747,7 @@
         },
         {
             "id": "a56b279e-c83e-5d6f-834d-e1c7b0ce3e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65100cc0-6a0e-4083-975c-9c6633885e6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65100cc0-6a0e-4083-975c-9c6633885e6c.jpg?1",
             "name": "Getaway Car",
             "text": "Haste\nWhenever Getaway Car attacks or blocks, return up to one target creature that crewed it this turn to its owner's hand.\nCrew 1",
             "colours": [],
@@ -17779,7 +17779,7 @@
         },
         {
             "id": "c4ccd051-ba24-5c48-86c0-2b55392bca95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7090d8-d9f8-4285-8898-b6fd26a608ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c7090d8-d9f8-4285-8898-b6fd26a608ef.jpg?1",
             "name": "Luxior, Giada's Gift",
             "text": "Equipped creature gets +1/+1 for each counter on it.\nEquipped permanent isn't a planeswalker and is a creature in addition to its other types. (Loyalty abilities can still be activated.)\nEquip planeswalker {1}\nEquip {3}",
             "colours": [],
@@ -17813,7 +17813,7 @@
         },
         {
             "id": "2367179e-73f9-5046-9c12-cb6a1188efd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9066fb8f-8568-4e87-bee9-573f6c204a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9066fb8f-8568-4e87-bee9-573f6c204a26.jpg?1",
             "name": "Unlicensed Hearse",
             "text": "{T}: Exile up to two target cards from a single graveyard.\nUnlicensed Hearse's power and toughness are each equal to the number of cards exiled with it.\nCrew 2",
             "colours": [],
@@ -17845,7 +17845,7 @@
         },
         {
             "id": "9a52e12c-220d-5d50-bcc6-1c014dad5883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b14a07-7cbf-48b4-91b1-af93837adbf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b14a07-7cbf-48b4-91b1-af93837adbf3.jpg?1",
             "name": "Elspeth Resplendent",
             "text": "",
             "colours": [
@@ -17884,7 +17884,7 @@
         },
         {
             "id": "36990199-e48a-5ef5-9615-99e0d96ce43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78b6d2e-29dd-4659-a162-3de5910ce948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c78b6d2e-29dd-4659-a162-3de5910ce948.jpg?1",
             "name": "Giada, Font of Hope",
             "text": "",
             "colours": [
@@ -17922,7 +17922,7 @@
         },
         {
             "id": "089a8c37-42be-557d-89f2-fca041494e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22288f-4fd4-45d4-9fcc-08aeba4d93a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22288f-4fd4-45d4-9fcc-08aeba4d93a7.jpg?1",
             "name": "Sanctuary Warden",
             "text": "",
             "colours": [
@@ -17959,7 +17959,7 @@
         },
         {
             "id": "5f5f0f88-7ab9-52a0-9bdf-969ba9e0661c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df2f7bd-2aa2-4ab4-b16a-557333efa02c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df2f7bd-2aa2-4ab4-b16a-557333efa02c.jpg?1",
             "name": "Errant, Street Artist",
             "text": "",
             "colours": [
@@ -17998,7 +17998,7 @@
         },
         {
             "id": "d1c4640d-c9cf-5c16-b5ab-03d8b8a16e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b133877c-0e62-464d-959d-131b9b626aea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b133877c-0e62-464d-959d-131b9b626aea.jpg?1",
             "name": "Tenacious Underdog",
             "text": "",
             "colours": [
@@ -18035,7 +18035,7 @@
         },
         {
             "id": "c48f4dac-076a-54e3-87a5-b37f9298899b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1269764e-cc05-4487-a75b-be8012287a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1269764e-cc05-4487-a75b-be8012287a80.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "",
             "colours": [
@@ -18077,7 +18077,7 @@
         },
         {
             "id": "f9f554a4-d905-5039-aca5-d9c4037458dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63c976-a6cd-42b4-b799-8624a9da4d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac63c976-a6cd-42b4-b799-8624a9da4d32.jpg?1",
             "name": "Vivien on the Hunt",
             "text": "",
             "colours": [
@@ -18116,7 +18116,7 @@
         },
         {
             "id": "1e0d46c0-6153-5c1d-8248-eddf0bbcb856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54630dd4-65bc-468a-b9a5-f24242459e61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54630dd4-65bc-468a-b9a5-f24242459e61.jpg?1",
             "name": "Ob Nixilis, the Adversary",
             "text": "",
             "colours": [
@@ -18157,7 +18157,7 @@
         },
         {
             "id": "a82b5034-98a7-5948-bf4e-40c7cff94eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac46c1-4439-46c3-8180-302057dbbd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53ac46c1-4439-46c3-8180-302057dbbd69.jpg?1",
             "name": "Scheming Fence",
             "text": "",
             "colours": [
@@ -18196,7 +18196,7 @@
         },
         {
             "id": "56dc3452-c05d-52ac-94c3-d13bce92ba34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746b45a-abd8-4a60-9139-48c1522bfd4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9746b45a-abd8-4a60-9139-48c1522bfd4b.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18243,7 +18243,7 @@
         },
         {
             "id": "964a360c-fc47-59ad-ae23-bb797ab6f97e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476c0f4b-7b16-47a6-946e-b658d7c26bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476c0f4b-7b16-47a6-946e-b658d7c26bfa.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18290,7 +18290,7 @@
         },
         {
             "id": "23af7b66-8adc-5b70-a2cf-8f1b4f53682b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0323-ec90-4f10-aaeb-f26033c1a7ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2daa0323-ec90-4f10-aaeb-f26033c1a7ea.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18337,7 +18337,7 @@
         },
         {
             "id": "db018c55-b1a3-56fa-93b5-893adb8f4b11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f7c23b-3091-4b13-9209-0d8d23301027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f7c23b-3091-4b13-9209-0d8d23301027.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18384,7 +18384,7 @@
         },
         {
             "id": "4c0e3f54-7980-5c5e-9fb4-cc6f7a14ac11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192e737a-57c9-4142-9613-cb19bbbbf2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/192e737a-57c9-4142-9613-cb19bbbbf2af.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18431,7 +18431,7 @@
         },
         {
             "id": "bb375d9e-d098-580a-9f80-4aec4de4d262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460db3d4-5c50-4c2c-a066-a4e264ecbb1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/460db3d4-5c50-4c2c-a066-a4e264ecbb1e.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18478,7 +18478,7 @@
         },
         {
             "id": "139048bf-7d25-50ba-ad95-987cee91ebf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da271d69-f086-4267-b044-5dbc01e5c6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da271d69-f086-4267-b044-5dbc01e5c6de.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18525,7 +18525,7 @@
         },
         {
             "id": "36edeb5c-f938-53bb-b5f9-62510d5ebc56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5475a6ab-7cab-4381-8814-257789fd5791.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5475a6ab-7cab-4381-8814-257789fd5791.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18572,7 +18572,7 @@
         },
         {
             "id": "3d616a02-8e3f-5a5b-84b2-e32470e20248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9fed5b-95ca-4ffa-8754-6b4e43b9e494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc9fed5b-95ca-4ffa-8754-6b4e43b9e494.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18619,7 +18619,7 @@
         },
         {
             "id": "c83b7d5a-9b79-5000-ade7-78a859910e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4440f3-bf89-4493-bb50-ebf84902e4d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d4440f3-bf89-4493-bb50-ebf84902e4d0.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18666,7 +18666,7 @@
         },
         {
             "id": "95151def-ad27-52f4-94a1-63960c4e5dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61760019-a7c7-4c11-871b-d72186b1d220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61760019-a7c7-4c11-871b-d72186b1d220.jpg?1",
             "name": "Gala Greeters",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, choose one that hasn't been chosen this turn \u2014\n\u2022 Put a +1/+1 counter on Gala Greeters.\n\u2022 Create a tapped Treasure token.\n\u2022 You gain 2 life.",
             "colours": [
@@ -18713,7 +18713,7 @@
         },
         {
             "id": "8681cb34-94c7-5328-8483-b795ff067b00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab120b59-8c50-47af-af21-5dd60377bc81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab120b59-8c50-47af-af21-5dd60377bc81.jpg?1",
             "name": "Jaxis, the Troublemaker",
             "text": "{R}, {T}, Discard a card: Create a token that's a copy of another target creature you control. It gains haste and \"When this creature dies, draw a card.\" Sacrifice it at the beginning of the next end step. Activate only as a sorcery.\nBlitz {1}{R}",
             "colours": [
@@ -18752,7 +18752,7 @@
         },
         {
             "id": "ab954754-3ace-5503-b424-a060b99bb8be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721bc380-00ac-40bd-a605-0853e97efad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/721bc380-00ac-40bd-a605-0853e97efad8.jpg?1",
             "name": "Mysterious Limousine",
             "text": "Whenever Mysterious Limousine enters the battlefield or attacks, exile up to one other target creature until Mysterious Limousine leaves the battlefield. If a creature is put into exile this way, return each other card exiled with Mysterious Limousine to the battlefield under its owner's control.\nCrew 2",
             "colours": [
@@ -18788,7 +18788,7 @@
         },
         {
             "id": "ade05a63-24a2-5618-aa7f-bf25c6093c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5a0c6a-6aac-44bc-88c0-52f589980679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce5a0c6a-6aac-44bc-88c0-52f589980679.jpg?1",
             "name": "Rumor Gatherer",
             "text": "Alliance \u2014 Whenever another creature enters the battlefield under your control, scry 1. If this is the second time this ability has resolved this turn, draw a card instead.",
             "colours": [
@@ -18825,7 +18825,7 @@
         },
         {
             "id": "83cbd9e2-2c30-5edf-a86f-381a55de614a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ecf5f7-db15-4917-ad7f-1c652b0a97da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41ecf5f7-db15-4917-ad7f-1c652b0a97da.jpg?1",
             "name": "An Offer You Can't Refuse",
             "text": "Counter target noncreature spell. Its controller creates two Treasure tokens.",
             "colours": [
@@ -18859,7 +18859,7 @@
         },
         {
             "id": "27b39b1c-9169-53a0-93d1-87439485baa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b46ca6-6fbd-41c5-9434-b18bce32165c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b46ca6-6fbd-41c5-9434-b18bce32165c.jpg?1",
             "name": "Incriminate",
             "text": "Choose two target creatures controlled by the same player. That player sacrifices one of them.",
             "colours": [
@@ -18893,7 +18893,7 @@
         },
         {
             "id": "4dcfad27-d6c2-5470-ba76-37cd0bc570a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c80b3da-bda1-4d8d-ba50-7162574f4564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c80b3da-bda1-4d8d-ba50-7162574f4564.jpg?1",
             "name": "Light 'Em Up",
             "text": "Casualty 2\nLight 'Em Up deals 2 damage to target creature or planeswalker.",
             "colours": [
@@ -18927,7 +18927,7 @@
         },
         {
             "id": "85706cc0-04d4-5567-8c7f-d0d0db149a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd325574-cdc9-48b1-bdcb-98afde83c6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd325574-cdc9-48b1-bdcb-98afde83c6b9.jpg?1",
             "name": "Courier's Briefcase",
             "text": "When Courier's Briefcase enters the battlefield, create a 1/1 green and white Citizen creature token.\n{T}, Sacrifice Courier's Briefcase: Add one mana of any color.\n{W}{U}{B}{R}{G}, {T}, Sacrifice Courier's Briefcase: Draw three cards.",
             "colours": [
@@ -18967,7 +18967,7 @@
         },
         {
             "id": "97be86fb-f947-5903-92bc-9be3bad43e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13670af-e266-4e19-b479-92fae2b15f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13670af-e266-4e19-b479-92fae2b15f4a.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "",
             "colours": [
@@ -19010,7 +19010,7 @@
         },
         {
             "id": "aff50d55-5c85-5871-b7b5-20f00bf6f617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0e4dae-1be7-430c-81a3-d1f9137a81e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0e4dae-1be7-430c-81a3-d1f9137a81e0.jpg?1",
             "name": "Urabrask, Heretic Praetor",
             "text": "",
             "colours": [
@@ -19052,7 +19052,7 @@
         },
         {
             "id": "9b02e27b-70be-56ba-a683-9e2a622ec8f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6ce56c-ca2e-48e8-a4d9-671cb4de8a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6ce56c-ca2e-48e8-a4d9-671cb4de8a9d.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -19080,7 +19080,7 @@
         },
         {
             "id": "96180d9e-f0c7-5108-af2b-3c2f1e2d76eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bae778-0dee-47d5-a7cd-f2be11b5e79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bae778-0dee-47d5-a7cd-f2be11b5e79b.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -19115,7 +19115,7 @@
         },
         {
             "id": "11a2bb16-b17e-5f8e-aef3-5e3c2cb97169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a7f7c-29e3-4b98-ad2f-2d585ec7610e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7a7f7c-29e3-4b98-ad2f-2d585ec7610e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -19150,7 +19150,7 @@
         },
         {
             "id": "5cd0f0ce-7820-5507-b6db-8ceb32d7830e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2e726b-f124-43f7-87e4-bb06bbe8e3d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2e726b-f124-43f7-87e4-bb06bbe8e3d7.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -19185,7 +19185,7 @@
         },
         {
             "id": "04a068bc-ff53-5736-9819-67f29d4e2bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3edaf7-0ebd-4a8b-9954-dd91bb797744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3edaf7-0ebd-4a8b-9954-dd91bb797744.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -19220,7 +19220,7 @@
         },
         {
             "id": "f0d54291-d008-5e6d-a4c8-0ee450ab575e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca43425-d007-4181-9182-18dc01ad7e90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca43425-d007-4181-9182-18dc01ad7e90.jpg?1",
             "name": "Ogre Warrior",
             "text": "",
             "colours": [
@@ -19256,7 +19256,7 @@
         },
         {
             "id": "0abeb86c-be42-5320-8192-82721ed09ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e503b9-a822-4c42-b478-1f598bc5941d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e503b9-a822-4c42-b478-1f598bc5941d.jpg?1",
             "name": "Rogue",
             "text": "",
             "colours": [
@@ -19291,7 +19291,7 @@
         },
         {
             "id": "be16489a-6054-58d9-ab8a-c7a4d7c91538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75fdab-818c-4f3a-94c1-fd3f577a87f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec75fdab-818c-4f3a-94c1-fd3f577a87f5.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -19326,7 +19326,7 @@
         },
         {
             "id": "88c22910-0015-50f7-8109-53e64e7c4784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bd0b29-0860-4ee3-832a-f62ba7bf4aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bd0b29-0860-4ee3-832a-f62ba7bf4aac.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -19361,7 +19361,7 @@
         },
         {
             "id": "b89a4851-8648-572f-b78e-f55c00c1f6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6736fe71-bd55-4602-b0aa-ece6193048a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6736fe71-bd55-4602-b0aa-ece6193048a9.jpg?1",
             "name": "Dog",
             "text": "",
             "colours": [
@@ -19396,7 +19396,7 @@
         },
         {
             "id": "76d4a480-d8bc-5786-ae16-c0c9cccc46fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230419f9-a9f7-441d-bad7-0ed867326aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/230419f9-a9f7-441d-bad7-0ed867326aa1.jpg?1",
             "name": "Rhino Warrior",
             "text": "",
             "colours": [
@@ -19432,7 +19432,7 @@
         },
         {
             "id": "6b8f4014-0a30-5459-9cd7-ad8f456e4d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f03e9fe-cb71-498e-bf16-5af6af37a192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f03e9fe-cb71-498e-bf16-5af6af37a192.jpg?1",
             "name": "Citizen",
             "text": "",
             "colours": [
@@ -19469,7 +19469,7 @@
         },
         {
             "id": "923ecdbd-0175-575b-b374-fc5fd6cd1397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19500,7 +19500,7 @@
         },
         {
             "id": "02235d38-af30-57e9-82d6-6e335a378023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883958b-1d82-4c1a-9f19-ab20fc01d5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b883958b-1d82-4c1a-9f19-ab20fc01d5f4.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19531,7 +19531,7 @@
         },
         {
             "id": "a5c96d41-cabd-57a5-b7d7-90957340d40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c7dce-a51b-4ce2-9359-a17c577f535d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c7dce-a51b-4ce2-9359-a17c577f535d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19562,7 +19562,7 @@
         },
         {
             "id": "49b2a8ce-fcd7-5a00-b706-d5001f70db86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a356a2-c851-41e5-a389-7019575d5ace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a356a2-c851-41e5-a389-7019575d5ace.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -19593,7 +19593,7 @@
         },
         {
             "id": "02eda719-658b-52e3-8f94-b66dda715865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116d98-2dad-4b80-a3af-9e36e34da6d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93116d98-2dad-4b80-a3af-9e36e34da6d4.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/SOI.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SOI.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "968190ab-528a-52cb-97ed-7732eedab72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84826f49-b5fb-4bd6-ab46-98e84b0d25c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84826f49-b5fb-4bd6-ab46-98e84b0d25c8.jpg?1",
             "name": "Always Watching",
             "text": "Nontoken creatures you control get +1/+1 and have vigilance.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "c97476d0-8dee-537b-86fc-0ce120e1a19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e12f83-eab8-4113-ab63-3f7a830861d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e12f83-eab8-4113-ab63-3f7a830861d4.jpg?1",
             "name": "Angel of Deliverance",
             "text": "Flying\nDelirium \u2014 Whenever Angel of Deliverance deals damage, if there are four or more card types among cards in your graveyard, exile target creature an opponent controls.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "6389c766-0830-51e3-85aa-6e8f99813fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38bae3e-95f3-413a-bb4d-6a0814112a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38bae3e-95f3-413a-bb4d-6a0814112a7a.jpg?1",
             "name": "Angelic Purge",
             "text": "As an additional cost to cast Angelic Purge, sacrifice a permanent.\nExile target artifact, creature, or enchantment.",
             "colours": [
@@ -102,7 +102,7 @@
         },
         {
             "id": "832a7296-f172-5b78-81d7-06f9fc83460d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e2358c-211e-4d79-8120-88bb9e656cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37e2358c-211e-4d79-8120-88bb9e656cba.jpg?1",
             "name": "Apothecary Geist",
             "text": "Flying\nWhen Apothecary Geist enters the battlefield, if you control another Spirit, you gain 3 life.",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "ad53597a-4448-5cbd-82bf-11d163b0c14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "Flash\nFlying, vigilance\nWhen Archangel Avacyn enters the battlefield, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "16371f62-73e5-54f5-bce1-801098de2d53",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1",
             "name": "Archangel Avacyn // Avacyn, the Purifier",
             "text": "Flying\nWhen this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other creature and each opponent.",
             "colours": [
@@ -210,7 +210,7 @@
         },
         {
             "id": "56e99141-2a16-519d-9090-196744bbef39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg?1",
             "name": "Avacynian Missionaries // Lunarch Inquisitors",
             "text": "At the beginning of your end step, if Avacynian Missionaries is equipped, transform it.",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "f697c781-350b-5b51-9b4b-779259528007",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/1001e708-e4f9-456a-8b9d-3421a2a3833d.jpg?1",
             "name": "Avacynian Missionaries // Lunarch Inquisitors",
             "text": "When this creature transforms into Lunarch Inquisitors, you may exile another target creature until Lunarch Inquisitors leaves the battlefield.",
             "colours": [
@@ -280,7 +280,7 @@
         },
         {
             "id": "4bee28c0-925b-5e11-8ff1-16c0595326c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdf107d-eb67-421c-a7a9-b3e62e03f766.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdf107d-eb67-421c-a7a9-b3e62e03f766.jpg?1",
             "name": "Bound by Moonsilver",
             "text": "Enchant creature\nEnchanted creature can't attack, block, or transform.\nSacrifice another permanent: Attach Bound by Moonsilver to target creature. Activate this ability only any time you could cast a sorcery and only once each turn.",
             "colours": [
@@ -314,7 +314,7 @@
         },
         {
             "id": "4a4720e5-1903-53b8-beb8-4eac31c9c868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c45198f-fb2b-4c83-abdc-8b1a0071cfed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c45198f-fb2b-4c83-abdc-8b1a0071cfed.jpg?1",
             "name": "Bygone Bishop",
             "text": "Flying\nWhenever you cast a creature spell with converted mana cost 3 or less, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -349,7 +349,7 @@
         },
         {
             "id": "99551a7b-4736-5273-b686-8b4d7daf61f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg?1",
             "name": "Cathar's Companion",
             "text": "Whenever you cast a noncreature spell, Cathar's Companion gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -383,7 +383,7 @@
         },
         {
             "id": "f3e05db8-b29f-5526-8a18-af3a685585eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70ea481-1751-4097-af41-2d13fe79e788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70ea481-1751-4097-af41-2d13fe79e788.jpg?1",
             "name": "Chaplain's Blessing",
             "text": "You gain 5 life.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "28f72709-958d-5145-9e55-0dfa08ec16e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1a458a-d3b6-44d9-ac80-a7a46b505805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1a458a-d3b6-44d9-ac80-a7a46b505805.jpg?1",
             "name": "Dauntless Cathar",
             "text": "{1}{W}, Exile Dauntless Cathar from your graveyard: Put a 1/1 white Spirit creature token with flying onto the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -450,7 +450,7 @@
         },
         {
             "id": "fb2bfd69-920b-56fa-9b32-fb80d99509c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f685445d-e2af-455f-b3b2-97cf15362f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f685445d-e2af-455f-b3b2-97cf15362f3c.jpg?1",
             "name": "Declaration in Stone",
             "text": "Exile target creature and all other creatures its controller controls with the same name as that creature. That player investigates for each nontoken creature exiled this way.",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "c120ef08-8b06-599f-bef5-6076124b1b9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ff2cbf-a1dc-4cc5-9a5d-8439899d4e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ff2cbf-a1dc-4cc5-9a5d-8439899d4e87.jpg?1",
             "name": "Descend upon the Sinful",
             "text": "Exile all creatures.\nDelirium \u2014 Put a 4/4 white Angel creature token with flying onto the battlefield if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "7d156a37-d258-58a7-ac64-81b61881d834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bea4c2-7a15-4f31-938d-c4c906e4ebe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57bea4c2-7a15-4f31-938d-c4c906e4ebe7.jpg?1",
             "name": "Devilthorn Fox",
             "text": "",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "f376f236-5ba1-5430-8e5e-ab7e1b6897a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg?1",
             "name": "Drogskol Cavalry",
             "text": "Flying\nWhenever another Spirit enters the battlefield under your control, you gain 2 life.\n{3}{W}: Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "823de294-576e-54fd-9602-ea0bc133412a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbab6e4-d317-4e73-a6ff-bed49aa6b70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcbab6e4-d317-4e73-a6ff-bed49aa6b70b.jpg?1",
             "name": "Eerie Interlude",
             "text": "Exile any number of target creatures you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "47f74f98-9ed2-527d-9f38-41867f954567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5fa496-a830-4031-a19a-d6467d074ad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5fa496-a830-4031-a19a-d6467d074ad1.jpg?1",
             "name": "Emissary of the Sleepless",
             "text": "Flying\nWhen Emissary of the Sleepless enters the battlefield, if a creature died this turn, put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "fb11c608-90ef-5239-92af-a11f9d9118a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47dd220-6193-4e31-a1df-591b6424ad27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f47dd220-6193-4e31-a1df-591b6424ad27.jpg?1",
             "name": "Ethereal Guidance",
             "text": "Creatures you control get +2/+1 until end of turn.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "1841fb54-3633-559c-adfa-241e2f9f320f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0341a-cd45-439c-adc2-8d24c47c4bd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de0341a-cd45-439c-adc2-8d24c47c4bd5.jpg?1",
             "name": "Expose Evil",
             "text": "Tap up to two target creatures.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "69998416-ca20-5ea2-9cdf-855e5cdaec4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8aecb0-c535-493c-bf64-4964e061deba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d8aecb0-c535-493c-bf64-4964e061deba.jpg?1",
             "name": "Gryff's Boon",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has flying.\n{3}{W}: Return Gryff's Boon from your graveyard to the battlefield attached to target creature. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -747,7 +747,7 @@
         },
         {
             "id": "a3a82054-33c3-53b2-81f5-6bd5faa8add9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg?1",
             "name": "Hanweir Militia Captain // Westvale Cult Leader",
             "text": "",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "4bb6738b-5e20-56f6-b82e-a8e821b9f6b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/e/7e137566-5033-48e8-88ba-65e3821b3cec.jpg?1",
             "name": "Hanweir Militia Captain // Westvale Cult Leader",
             "text": "",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "7be682bd-0c2b-56d0-a919-82af2a4e72d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f7c6f5-159a-40ed-823a-8740a1ce373e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f7c6f5-159a-40ed-823a-8740a1ce373e.jpg?1",
             "name": "Hope Against Hope",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each creature you control.\nAs long as enchanted creature is a Human, it has first strike.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "add688bc-7d47-57ab-9e22-562b2e090e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c105686-8b45-494a-b9ef-8aa267bb1b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c105686-8b45-494a-b9ef-8aa267bb1b5a.jpg?1",
             "name": "Humble the Brute",
             "text": "Destroy target creature with power 4 or greater.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -883,7 +883,7 @@
         },
         {
             "id": "d47725fd-f53a-55b5-9043-d421ab26a8b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1401fe-9e88-401b-96f0-5f58808a519f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1401fe-9e88-401b-96f0-5f58808a519f.jpg?1",
             "name": "Inquisitor's Ox",
             "text": "Delirium \u2014 Inquisitor's Ox gets +1/+0 and has vigilance as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -917,7 +917,7 @@
         },
         {
             "id": "f65afd64-5321-577b-b3cf-79a9a837b5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45704604-a1b3-4225-8466-aa76136c84a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45704604-a1b3-4225-8466-aa76136c84a8.jpg?1",
             "name": "Inspiring Captain",
             "text": "When Inspiring Captain enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -952,7 +952,7 @@
         },
         {
             "id": "b5b81dc2-cb6d-57a1-9657-70b9797c910b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d99f1f-80d6-4b5e-aeae-83fb8ae62cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68d99f1f-80d6-4b5e-aeae-83fb8ae62cdc.jpg?1",
             "name": "Militant Inquisitor",
             "text": "Militant Inquisitor gets +1/+0 for each Equipment you control.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "e8140b3c-b605-5498-adac-e8ada9b1b4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839942c-0ad1-4f77-97a0-142b8ef2266c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5839942c-0ad1-4f77-97a0-142b8ef2266c.jpg?1",
             "name": "Moorland Drifter",
             "text": "Delirium \u2014 Moorland Drifter has flying as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1021,7 +1021,7 @@
         },
         {
             "id": "0bc6adf4-dd98-5cfa-9d8d-4a966b32db61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba0f1c-8641-4f5a-8f2e-f969fc7a058a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ba0f1c-8641-4f5a-8f2e-f969fc7a058a.jpg?1",
             "name": "Nahiri's Machinations",
             "text": "At the beginning of combat on your turn, target creature you control gains indestructible until end of turn.\n{1}{R}: Nahiri's Machinations deals 1 damage to target blocking creature.",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "b594bcaa-e8ce-5941-97b5-eaa2cc9f2727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ec364-39c1-4a4b-8dfa-268fad2effdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/362ec364-39c1-4a4b-8dfa-268fad2effdd.jpg?1",
             "name": "Nearheath Chaplain",
             "text": "Lifelink\n{2}{W}, Exile Nearheath Chaplain from your graveyard: Put two 1/1 white Spirit creature tokens with flying onto the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "de7ad3c0-622e-5f26-97cd-b2ecb9cdb9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ecdadf-56f7-4dfb-9c3c-7d240ba19b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ecdadf-56f7-4dfb-9c3c-7d240ba19b00.jpg?1",
             "name": "Not Forgotten",
             "text": "Put target card from a graveyard on the top or bottom of its owner's library. Put a 1/1 white Spirit creature token with flying onto the battlefield.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "34c24b4a-8546-52d2-8de4-210dbbdf6db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77c30f-d813-46e6-9cdd-938b4a6359ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c77c30f-d813-46e6-9cdd-938b4a6359ad.jpg?1",
             "name": "Odric, Lunarch Marshal",
             "text": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
             "colours": [
@@ -1158,7 +1158,7 @@
         },
         {
             "id": "7b97f09d-0182-5fb7-886b-c354d8f50918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dc0c44-908f-40e9-9c6a-e1ef699e6d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07dc0c44-908f-40e9-9c6a-e1ef699e6d2e.jpg?1",
             "name": "Open the Armory",
             "text": "Search your library for an Aura or Equipment card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "d95a3cd9-1435-5369-af37-44584d831183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb6c60-1889-49ed-8767-8144cc5a9571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb6c60-1889-49ed-8767-8144cc5a9571.jpg?1",
             "name": "Paranoid Parish-Blade",
             "text": "Delirium \u2014 Paranoid Parish-Blade gets +1/+0 and has first strike as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "3a757a3e-d83b-5854-a672-1315c924b0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg?1",
             "name": "Pious Evangel // Wayward Disciple",
             "text": "Whenever Pious Evangel or another creature enters the battlefield under your control, you gain 1 life.\n{2}, {T}, Sacrifice another permanent: Transform Pious Evangel.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "e5bc22bb-3b80-5356-bd36-c131079a9722",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7ac2a5aa-71c3-482b-9431-5f0b228cf64d.jpg?1",
             "name": "Pious Evangel // Wayward Disciple",
             "text": "Whenever Wayward Disciple or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "475fb6c9-a833-5692-a5bc-98c5ff65281a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b101264-4994-43b7-9156-228f7d10d2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b101264-4994-43b7-9156-228f7d10d2bd.jpg?1",
             "name": "Puncturing Light",
             "text": "Destroy target attacking or blocking creature with power 3 or less.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "6399c97c-82c5-594e-8692-4efbfc115df0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cf3ac8-db59-4acc-abb6-e63b95b849ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cf3ac8-db59-4acc-abb6-e63b95b849ac.jpg?1",
             "name": "Reaper of Flight Moonsilver",
             "text": "Flying\nDelirium \u2014 Sacrifice another creature: Reaper of Flight Moonsilver gets +2/+1 until end of turn. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "56ddc013-4a6c-5219-af75-2c2ec18c5366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27b92a-cde9-41bc-9b23-d83b74b167d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f27b92a-cde9-41bc-9b23-d83b74b167d4.jpg?1",
             "name": "Silverstrike",
             "text": "Destroy target attacking creature. You gain 3 life.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "2b891732-bae9-5f0d-9bb9-ed1017458609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac355ae2-7553-4b51-bcce-1c4168dad0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac355ae2-7553-4b51-bcce-1c4168dad0d6.jpg?1",
             "name": "Spectral Shepherd",
             "text": "Flying\n{1}{U}: Return target Spirit you control to its owner's hand.",
             "colours": [
@@ -1430,7 +1430,7 @@
         },
         {
             "id": "ef83719c-6efc-592a-ad41-2c5561c4302f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f87d4-5fed-415c-918a-c3546697a3da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f0f87d4-5fed-415c-918a-c3546697a3da.jpg?1",
             "name": "Stern Constable",
             "text": "{T}, Discard a card: Tap target creature.",
             "colours": [
@@ -1465,7 +1465,7 @@
         },
         {
             "id": "7032b5e7-d382-5934-85d8-d93b6149bf61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c5c5cf-0ed6-4953-a03a-af51038e3f54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c5c5cf-0ed6-4953-a03a-af51038e3f54.jpg?1",
             "name": "Strength of Arms",
             "text": "Target creature gets +2/+2 until end of turn. If you control an Equipment, put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "8e8858dd-a88e-55ce-8742-3da65443c745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4a0bc-196a-466b-a704-377f5c7eb5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb4a0bc-196a-466b-a704-377f5c7eb5b7.jpg?1",
             "name": "Survive the Night",
             "text": "Target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "b66920af-1e59-5c5d-9cd3-95110ddc7bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fbe149-3e1f-495e-be1b-efc3a6dbcb08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fbe149-3e1f-495e-be1b-efc3a6dbcb08.jpg?1",
             "name": "Tenacity",
             "text": "Creatures you control get +1/+1 and gain lifelink until end of turn. Untap those creatures.",
             "colours": [
@@ -1561,7 +1561,7 @@
         },
         {
             "id": "a2239d00-3fd1-5c49-b893-e1d399f6af97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe162594-2332-4816-a9e1-57eb19b12651.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe162594-2332-4816-a9e1-57eb19b12651.jpg?1",
             "name": "Thalia's Lieutenant",
             "text": "When Thalia's Lieutenant enters the battlefield, put a +1/+1 counter on each other Human you control.\nWhenever another Human enters the battlefield under your control, put a +1/+1 counter on Thalia's Lieutenant.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "154e2745-5d63-5ee9-b8a4-e5a5a8a5ee15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d140c3b7-ca78-483d-baeb-307b624fea8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d140c3b7-ca78-483d-baeb-307b624fea8b.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "9b3bc399-139e-5415-98a0-6c5ecb1bf2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9e8653-13ae-446c-b341-85c9b3fa6ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9e8653-13ae-446c-b341-85c9b3fa6ca8.jpg?1",
             "name": "Topplegeist",
             "text": "Flying\nWhen Topplegeist enters the battlefield, tap target creature an opponent controls.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, tap target creature that player controls.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "927811db-dfed-5295-983f-951a460731c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg?1",
             "name": "Town Gossipmonger // Incited Rabble",
             "text": "{T}, Tap an untapped creature you control: Transform Town Gossipmonger.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "4692edd1-f8d4-56e8-96cf-4fef2e441036",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d238d324-8c88-43ca-b203-133830d29447.jpg?1",
             "name": "Town Gossipmonger // Incited Rabble",
             "text": "Incited Rabble attacks each combat if able.\n{2}: Incited Rabble gets +1/+0 until end of turn.",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "510d4709-4147-5bd2-821f-63f734c5c544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012d76b7-1445-4853-9e54-159154bbb144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012d76b7-1445-4853-9e54-159154bbb144.jpg?1",
             "name": "Unruly Mob",
             "text": "Whenever another creature you control dies, put a +1/+1 counter on Unruly Mob.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "ae2a58bd-0893-5ab5-a626-4ed7ccccf391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4051020-688c-473a-9a08-b62f0fd75675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4051020-688c-473a-9a08-b62f0fd75675.jpg?1",
             "name": "Vessel of Ephemera",
             "text": "{2}{W}, Sacrifice Vessel of Ephemera: Put two 1/1 white Spirit creature tokens with flying onto the battlefield.",
             "colours": [
@@ -1801,7 +1801,7 @@
         },
         {
             "id": "f6cfb232-a68b-5da3-8dac-fcbb825aaabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1",
             "name": "Aberrant Researcher // Perfected Form",
             "text": "Flying\nAt the beginning of your upkeep, put the top card of your library into your graveyard. If it's an instant or sorcery card, transform Aberrant Researcher.",
             "colours": [
@@ -1836,7 +1836,7 @@
         },
         {
             "id": "d5c07595-a48a-56b1-a6ee-77a95886974c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1",
             "name": "Aberrant Researcher // Perfected Form",
             "text": "Flying",
             "colours": [
@@ -1871,7 +1871,7 @@
         },
         {
             "id": "ee51532f-f0b6-527c-9ec5-15d6c894f42b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252eef1f-0a62-420d-aad8-e3d7f1e07c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/252eef1f-0a62-420d-aad8-e3d7f1e07c1b.jpg?1",
             "name": "Broken Concentration",
             "text": "Counter target spell.\nMadness {3}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "677c299e-9909-58b6-8ad0-fab0e30bddea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b069516-1465-4acf-b4b9-ca7f1238b4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b069516-1465-4acf-b4b9-ca7f1238b4fe.jpg?1",
             "name": "Catalog",
             "text": "Draw two cards, then discard a card.",
             "colours": [
@@ -1935,7 +1935,7 @@
         },
         {
             "id": "bdf8ae27-bfd4-5eaf-b8c1-7afaadc208e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b728f4-d209-4334-9501-4f69b1196739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b728f4-d209-4334-9501-4f69b1196739.jpg?1",
             "name": "Compelling Deterrence",
             "text": "Return target nonland permanent to its owner's hand. Then that player discards a card if you control a Zombie.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "13dd5b6a-2f55-5e93-a477-a3f09eae3d47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fcbc2-1034-442d-9f2a-7d79ea40ac3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fcbc2-1034-442d-9f2a-7d79ea40ac3d.jpg?1",
             "name": "Confirm Suspicions",
             "text": "Counter target spell.\nInvestigate three times. (To investigate, put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "bd7ebf46-cea6-5c33-b858-d765d5b1f4ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg?1",
             "name": "Daring Sleuth // Bearer of Overwhelming Truths",
             "text": "When you sacrifice a Clue, transform Daring Sleuth.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "3fe4768e-b540-5381-923b-b2e685666ebb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/440f9f10-6999-4cff-ab98-8aed77813b07.jpg?1",
             "name": "Daring Sleuth // Bearer of Overwhelming Truths",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever Bearer of Overwhelming Truths deals combat damage to a player, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2069,7 +2069,7 @@
         },
         {
             "id": "b3ba3d34-47c6-5cd4-a28c-e8472b7ad266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a14eeb-1c85-4029-a047-39a4efef3f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a14eeb-1c85-4029-a047-39a4efef3f74.jpg?1",
             "name": "Deny Existence",
             "text": "Counter target creature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -2101,7 +2101,7 @@
         },
         {
             "id": "034b172e-843d-5ce9-a983-27105d6a3b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714713f-deb4-4b1c-8764-35287293ca18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714713f-deb4-4b1c-8764-35287293ca18.jpg?1",
             "name": "Drownyard Explorers",
             "text": "When Drownyard Explorers enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "ced32fd1-d7b8-5012-8650-393005f1f8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1997e6a0-9e66-486d-921d-d64137c3221d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1997e6a0-9e66-486d-921d-d64137c3221d.jpg?1",
             "name": "Drunau Corpse Trawler",
             "text": "When Drunau Corpse Trawler enters the battlefield, put a 2/2 black Zombie creature token onto the battlefield.\n{2}{B}: Target Zombie gains deathtouch until end of turn.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "92f7b182-200d-515c-aab9-8b2bb50c40d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22909767-a088-49ff-83be-37f967d1da3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22909767-a088-49ff-83be-37f967d1da3d.jpg?1",
             "name": "Engulf the Shore",
             "text": "Return to their owners' hands all creatures with toughness less than or equal to the number of Islands you control.",
             "colours": [
@@ -2203,7 +2203,7 @@
         },
         {
             "id": "bb4ef9f9-4cba-54b5-9cc9-184ad3f89531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b44364-8f83-4dcf-8458-0fd54a698524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b44364-8f83-4dcf-8458-0fd54a698524.jpg?1",
             "name": "Epiphany at the Drownyard",
             "text": "Reveal the top X plus one cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -2235,7 +2235,7 @@
         },
         {
             "id": "9e815ad7-be35-560b-a1aa-c46bb27dcc16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63df99f9-4f85-4c76-8d76-9075c9ef2b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63df99f9-4f85-4c76-8d76-9075c9ef2b86.jpg?1",
             "name": "Erdwal Illuminator",
             "text": "Flying\nWhenever you investigate for the first time each turn, investigate an additional time.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "b8448bea-fc1a-54a6-8e97-5cc295e17d2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639bdbb5-8c2d-439d-bcea-dc54da9686ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/639bdbb5-8c2d-439d-bcea-dc54da9686ea.jpg?1",
             "name": "Essence Flux",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. If it's a Spirit, put a +1/+1 counter on it.",
             "colours": [
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "102aec35-4e4a-56e1-aea8-c818cd7fb0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9eaf90-2a9e-44a7-bdae-03c26f9d21e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9eaf90-2a9e-44a7-bdae-03c26f9d21e7.jpg?1",
             "name": "Fleeting Memories",
             "text": "When Fleeting Memories enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2333,7 +2333,7 @@
         },
         {
             "id": "bfc263c7-b447-516c-a583-04e9334e431b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f82ee6-b8cd-4dce-b213-3910302f30e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f82ee6-b8cd-4dce-b213-3910302f30e9.jpg?1",
             "name": "Forgotten Creation",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nAt the beginning of your upkeep, you may discard all the cards in your hand. If you do, draw that many cards.",
             "colours": [
@@ -2368,7 +2368,7 @@
         },
         {
             "id": "e2e7c95e-b8ea-5327-b845-83ef5d6b0bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f376ec9b-48ac-4ed7-bfa2-60e9dca32dd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f376ec9b-48ac-4ed7-bfa2-60e9dca32dd7.jpg?1",
             "name": "Furtive Homunculus",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)",
             "colours": [
@@ -2402,7 +2402,7 @@
         },
         {
             "id": "b3d8b85b-091a-5fef-b27e-146e75bb7bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d28b8-2ed8-4266-a870-d308f9ebd5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f00d28b8-2ed8-4266-a870-d308f9ebd5da.jpg?1",
             "name": "Geralf's Masterpiece",
             "text": "Flying\nGeralf's Masterpiece gets -1/-1 for each card in your hand.\n{3}{U}, Discard three cards: Return Geralf's Masterpiece from your graveyard to the battlefield tapped.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "79061cd1-16de-5f0a-9850-502987c38900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b1848c-3160-45f5-91a0-74ab6d91c01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b1848c-3160-45f5-91a0-74ab6d91c01b.jpg?1",
             "name": "Ghostly Wings",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nDiscard a card: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -2471,7 +2471,7 @@
         },
         {
             "id": "a1308f9e-893d-5a45-b7e0-fafc7ab66cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88ae6bf-9c58-4543-ba66-19ea41d01e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88ae6bf-9c58-4543-ba66-19ea41d01e9b.jpg?1",
             "name": "Gone Missing",
             "text": "Put target permanent on top of its owner's library.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "a6bcde5d-52bc-580c-b745-dd1b3c8b6878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e644e38-39bf-40bd-9be1-5eb80f472e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e644e38-39bf-40bd-9be1-5eb80f472e81.jpg?1",
             "name": "Invasive Surgery",
             "text": "Counter target sorcery spell.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, search the graveyard, hand, and library of that spell's controller for any number of cards with the same name as that spell, exile those cards, then that player shuffles his or her library.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "27e2e483-8064-5f92-a905-3d1984af4c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5521d-e9f1-49e0-aa13-8e6de794cb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d5521d-e9f1-49e0-aa13-8e6de794cb12.jpg?1",
             "name": "Jace, Unraveler of Secrets",
             "text": "+1: Scry 1, then draw a card.\n\u22122: Return target creature to its owner's hand.\n\u22128: You get an emblem with \"Whenever an opponent casts his or her first spell each turn, counter that spell.\"",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "8c76b6ad-39c7-5761-98e4-61f5b1fd33db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0eea0d-c790-4d91-962f-f05b22d0c8fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0eea0d-c790-4d91-962f-f05b22d0c8fa.jpg?1",
             "name": "Jace's Scrutiny",
             "text": "Target creature gets -4/-0 until end of turn.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "38b10c2f-db96-5fd1-bd27-4e56e2341ac8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b3d18c-7029-4eff-a918-f75e7d9d79d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b3d18c-7029-4eff-a918-f75e7d9d79d7.jpg?1",
             "name": "Just the Wind",
             "text": "Return target creature to its owner's hand.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "31ae6849-6e26-56a4-a91f-a8ce398b3a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dadecc-f1f1-44a2-8829-6c94aade73a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dadecc-f1f1-44a2-8829-6c94aade73a0.jpg?1",
             "name": "Lamplighter of Selhoff",
             "text": "When Lamplighter of Selhoff enters the battlefield, if you control another Zombie, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2670,7 +2670,7 @@
         },
         {
             "id": "10959d65-ead1-5070-88a4-9fceca1cb8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0fadba-4205-47ce-b4cf-e0ff7308749b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb0fadba-4205-47ce-b4cf-e0ff7308749b.jpg?1",
             "name": "Manic Scribe",
             "text": "When Manic Scribe enters the battlefield, each opponent puts the top three cards of his or her library into his or her graveyard.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, that player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2705,7 +2705,7 @@
         },
         {
             "id": "954f3b5a-bcec-5c94-99ae-294b9e1f075b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a6d6e4-e91f-444f-9eed-88fceaf1a4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a6d6e4-e91f-444f-9eed-88fceaf1a4b8.jpg?1",
             "name": "Nagging Thoughts",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\nMadness {1}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2737,7 +2737,7 @@
         },
         {
             "id": "d47cf17c-d443-55d3-8193-3e231c08f5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f714d6c4-b1e1-40dd-806f-a3d87020292e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f714d6c4-b1e1-40dd-806f-a3d87020292e.jpg?1",
             "name": "Nephalia Moondrakes",
             "text": "Flying\nWhen Nephalia Moondrakes enters the battlefield, target creature gains flying until end of turn.\n{4}{U}{U}, Exile Nephalia Moondrakes from your graveyard: Creatures you control gain flying until end of turn.",
             "colours": [
@@ -2771,7 +2771,7 @@
         },
         {
             "id": "057bdb71-2d77-551a-b99c-0d398ae23a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394dd931-e34e-4314-88c9-774a2f3c8c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/394dd931-e34e-4314-88c9-774a2f3c8c1b.jpg?1",
             "name": "Niblis of Dusk",
             "text": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "7df523f0-8b2a-5d98-bc91-c3dc95442e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b8f962-8d4e-4dd8-a157-c0a55f9e152a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b8f962-8d4e-4dd8-a157-c0a55f9e152a.jpg?1",
             "name": "Ongoing Investigation",
             "text": "Whenever one or more creatures you control deal combat damage to a player, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\n{1}{G}, Exile a creature card from your graveyard: Investigate. You gain 2 life.",
             "colours": [
@@ -2838,7 +2838,7 @@
         },
         {
             "id": "70033045-b1de-5b13-8598-0cd97f8c980d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69204c83-2e43-4ca1-a4cd-d75399a7d6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69204c83-2e43-4ca1-a4cd-d75399a7d6dd.jpg?1",
             "name": "Pieces of the Puzzle",
             "text": "Reveal the top five cards of your library. Put up to two instant and/or sorcery cards from among them into your hand and the rest into your graveyard.",
             "colours": [
@@ -2870,7 +2870,7 @@
         },
         {
             "id": "1577c8eb-32fb-5072-89d3-325728690193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2288f7b-05b1-4a6c-8d02-42ffcadc6f0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2288f7b-05b1-4a6c-8d02-42ffcadc6f0b.jpg?1",
             "name": "Pore Over the Pages",
             "text": "Draw three cards, untap up to two lands, then discard a card.",
             "colours": [
@@ -2902,7 +2902,7 @@
         },
         {
             "id": "d7a65050-d854-53c7-944a-6711b73a185b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec8b8bf-7b02-4f5e-bbd3-9560f9888192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ec8b8bf-7b02-4f5e-bbd3-9560f9888192.jpg?1",
             "name": "Press for Answers",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -2934,7 +2934,7 @@
         },
         {
             "id": "39fe9492-4f19-5f59-97c0-e39701a9f011",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fc4db9-a29c-4f50-8e41-105b45af0be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fc4db9-a29c-4f50-8e41-105b45af0be9.jpg?1",
             "name": "Rattlechains",
             "text": "Flash\nFlying\nWhen Rattlechains enters the battlefield, target Spirit gains hexproof until end of turn.\nYou may cast Spirit spells as though they had flash.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "1f9fa5e1-1eb4-5ec5-bf43-1fafe452abfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f9dd3-45cc-4682-a6a0-99f67c0b73c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46f9dd3-45cc-4682-a6a0-99f67c0b73c6.jpg?1",
             "name": "Reckless Scholar",
             "text": "{T}: Target player draws a card, then discards a card.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "eb9dcfeb-53ff-57ca-9c03-a8ad5d87e3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e099a6a-97c4-42cd-aca6-5e1a2da0d5e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e099a6a-97c4-42cd-aca6-5e1a2da0d5e5.jpg?1",
             "name": "Rise from the Tides",
             "text": "Put a 2/2 black Zombie creature token onto the battlefield tapped for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "75fa307b-e86b-54d7-8388-71d1cb806d92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065d497d-5cfd-43c9-8c86-9a1da3d7e17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065d497d-5cfd-43c9-8c86-9a1da3d7e17e.jpg?1",
             "name": "Seagraf Skaab",
             "text": "",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "4665fabb-f01c-5e04-8bf8-8c3ffd9a538b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7347f4c-a4b3-4c71-91e5-699475e5926e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7347f4c-a4b3-4c71-91e5-699475e5926e.jpg?1",
             "name": "Silburlind Snapper",
             "text": "Silburlind Snapper can't attack unless you've cast a noncreature spell this turn.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "fd2e6413-6bc2-58d9-9a3d-c306633e3d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535e3d1b-b71b-406a-bec6-73b2cb45f6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/535e3d1b-b71b-406a-bec6-73b2cb45f6c8.jpg?1",
             "name": "Silent Observer",
             "text": "Flying",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "8a301150-e576-5446-8ef4-c2cfa8f24f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f010e4f4-f1a3-4062-834c-eec5f1f443d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f010e4f4-f1a3-4062-834c-eec5f1f443d6.jpg?1",
             "name": "Sleep Paralysis",
             "text": "Enchant creature\nWhen Sleep Paralysis enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "1798c541-e178-57e0-983c-b570aaeae033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg?1",
             "name": "Startled Awake // Persistent Nightmare",
             "text": "Target opponent puts the top thirteen cards of his or her library into his or her graveyard.\n{3}{U}{U}: Put Startled Awake from your graveyard onto the battlefield transformed. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "24a04391-2ed8-5ead-8d5c-afa81139acdd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e630fc56-a96f-4abf-be8d-f0f40d5a9edf.jpg?1",
             "name": "Startled Awake // Persistent Nightmare",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Persistent Nightmare deals combat damage to a player, return it to its owner's hand.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "b88ad810-d710-5c5c-9e6a-0b11bd6106d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03c643c-8e4c-4dc9-8756-c253fa057729.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03c643c-8e4c-4dc9-8756-c253fa057729.jpg?1",
             "name": "Stitched Mangler",
             "text": "Stitched Mangler enters the battlefield tapped.\nWhen Stitched Mangler enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "0374be60-c356-5967-8abe-38e216d882da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84bb1ce-a8a0-4a29-9129-b1d7041fd01a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84bb1ce-a8a0-4a29-9129-b1d7041fd01a.jpg?1",
             "name": "Stitchwing Skaab",
             "text": "Flying\n{1}{U}, Discard two cards: Return Stitchwing Skaab from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3307,7 +3307,7 @@
         },
         {
             "id": "eed09232-bf57-5aaf-bf92-a47f1d9a1318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0fb4be-df73-43a9-bd48-fd47a4190fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0fb4be-df73-43a9-bd48-fd47a4190fc1.jpg?1",
             "name": "Stormrider Spirit",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "8bdd9d7d-3ed8-5569-a892-ad109dbd64e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1",
             "name": "Thing in the Ice // Awoken Horror",
             "text": "Defender\nThing in the Ice enters the battlefield with four ice counters on it.\nWhenever you cast an instant or sorcery spell, remove an ice counter from Thing in the Ice. Then if it has no ice counters on it, transform it.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "8c23c710-3169-5569-b5b4-08eebdab978a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1",
             "name": "Thing in the Ice // Awoken Horror",
             "text": "When this creature transforms into Awoken Horror, return all non-Horror creatures to their owners' hands.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "a211b3cc-febb-56f2-a4ae-06817fcdf03c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b150797-ee8d-42f8-adcb-2f4b1783c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b150797-ee8d-42f8-adcb-2f4b1783c074.jpg?1",
             "name": "Trail of Evidence",
             "text": "Whenever you cast an instant or sorcery spell, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "6d2eaae5-cae0-574d-99cc-b7299f4323a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg?1",
             "name": "Uninvited Geist // Unimpeded Trespasser",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Uninvited Geist deals combat damage to a player, transform it.",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "9c85b134-7c69-5ff9-a217-8994a572c76d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dea7c9f-ce66-447b-9f1b-d9bca5806153.jpg?1",
             "name": "Uninvited Geist // Unimpeded Trespasser",
             "text": "Unimpeded Trespasser can't be blocked.",
             "colours": [
@@ -3510,7 +3510,7 @@
         },
         {
             "id": "cbc6fcf8-d2f9-5766-8942-dc97a053a0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4596140-1113-4349-aabe-4e828ea574e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4596140-1113-4349-aabe-4e828ea574e8.jpg?1",
             "name": "Vessel of Paramnesia",
             "text": "{U}, Sacrifice Vessel of Paramnesia: Target player puts the top three cards of his or her library into his or her graveyard. Draw a card.",
             "colours": [
@@ -3542,7 +3542,7 @@
         },
         {
             "id": "2663e21b-d349-55af-8aff-288ab0c25f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d07fbe1-e66a-4893-86ee-7752ad77b120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d07fbe1-e66a-4893-86ee-7752ad77b120.jpg?1",
             "name": "Welcome to the Fold",
             "text": "Madness {X}{U}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nGain control of target creature if its toughness is 2 or less. If Welcome to the Fold's madness cost was paid, instead gain control of that creature if its toughness is X or less.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "b861e3ff-0099-5177-b3b2-5478c6cbe8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg?1",
             "name": "Accursed Witch // Infectious Curse",
             "text": "Spells your opponents cast that target Accursed Witch cost {1} less to cast.\nWhen Accursed Witch dies, return it to the battlefield transformed under your control attached to target opponent.",
             "colours": [
@@ -3609,7 +3609,7 @@
         },
         {
             "id": "8930db56-7b9b-5ad0-a7f0-89f785839fc6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8093f8b0-5d50-48ca-b616-e92535a47138.jpg?1",
             "name": "Accursed Witch // Infectious Curse",
             "text": "Enchant player\nSpells you cast that target enchanted player cost {1} less to cast.\nAt the beginning of enchanted player's upkeep, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "3c403e7e-838b-5184-824f-228b5fd4b300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b80948-a3cd-4962-8fce-d58f2db7e68e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b80948-a3cd-4962-8fce-d58f2db7e68e.jpg?1",
             "name": "Alms of the Vein",
             "text": "Target opponent loses 3 life and you gain 3 life.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "e7969d9e-21b5-5e3b-9fde-3471c7abbe03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a4bf6c-167a-4122-a55b-7bc28ca4f0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a4bf6c-167a-4122-a55b-7bc28ca4f0d4.jpg?1",
             "name": "Asylum Visitor",
             "text": "At the beginning of each player's upkeep, if that player has no cards in hand, you draw a card and you lose 1 life.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3711,7 +3711,7 @@
         },
         {
             "id": "33678b5f-1459-5880-a518-6b55d68475d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fac171d-a8b6-4bb7-a559-473574aa02a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fac171d-a8b6-4bb7-a559-473574aa02a8.jpg?1",
             "name": "Behind the Scenes",
             "text": "Creatures you control have skulk. (They can't be blocked by creatures with greater power.)\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "2ecf97c6-6b2b-5286-a465-f1bb305aafe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd22350b-d48c-4ae6-b95f-63336fabe0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd22350b-d48c-4ae6-b95f-63336fabe0e3.jpg?1",
             "name": "Behold the Beyond",
             "text": "Discard your hand. Search your library for three cards and put those cards into your hand. Then shuffle your library.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "7b56eee2-3d67-54bf-9cad-04533c262dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac62d2f-6834-4d98-b69d-bd7b5831d981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac62d2f-6834-4d98-b69d-bd7b5831d981.jpg?1",
             "name": "Biting Rain",
             "text": "All creatures get -2/-2 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "839e8d57-b28d-5000-9474-1ecced0ad3e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec85cca-ac2c-4b1b-850b-6a762df72bd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec85cca-ac2c-4b1b-850b-6a762df72bd0.jpg?1",
             "name": "Call the Bloodline",
             "text": "{1}, Discard a card: Put a 1/1 black Vampire Knight creature token with lifelink onto the battlefield. Activate this ability only once each turn.",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "582c372f-6a03-587a-a765-785852f0e7c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3376c4-369a-4d63-bd48-966bcfb0c9b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3376c4-369a-4d63-bd48-966bcfb0c9b9.jpg?1",
             "name": "Creeping Dread",
             "text": "At the beginning of your upkeep, each player discards a card. Each opponent who discarded a card that shares a card type with the card you discarded loses 3 life. (Players reveal the discarded cards simultaneously.)",
             "colours": [
@@ -3872,7 +3872,7 @@
         },
         {
             "id": "d3a75fe2-c639-50d7-968a-c2dd97e50640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4d1b5-72de-4062-9fdd-e9bfd655ee79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e4d1b5-72de-4062-9fdd-e9bfd655ee79.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -3907,7 +3907,7 @@
         },
         {
             "id": "1cebea6c-5a6e-5fdc-a018-b8813b47c295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09a09de-35c9-4a4e-a4ac-1ce24e166ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09a09de-35c9-4a4e-a4ac-1ce24e166ad9.jpg?1",
             "name": "Dead Weight",
             "text": "Enchant creature\nEnchanted creature gets -2/-2.",
             "colours": [
@@ -3941,7 +3941,7 @@
         },
         {
             "id": "7cd9e633-1d95-52d5-b5a3-d9e3be39d67e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039e8f6-5513-4307-a1b5-07209dc8e1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9039e8f6-5513-4307-a1b5-07209dc8e1c8.jpg?1",
             "name": "Diregraf Colossus",
             "text": "Diregraf Colossus enters the battlefield with a +1/+1 counter on it for each Zombie card in your graveyard.\nWhenever you cast a Zombie spell, put a 2/2 black Zombie creature token onto the battlefield tapped.",
             "colours": [
@@ -3976,7 +3976,7 @@
         },
         {
             "id": "b3141523-8960-53f1-9b5a-0b2b874d3341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg?1",
             "name": "Elusive Tormentor // Insidious Mist",
             "text": "{1}, Discard a card: Transform Elusive Tormentor.",
             "colours": [
@@ -4012,7 +4012,7 @@
         },
         {
             "id": "a9bfb7bd-4d95-5f98-9eb3-8ac1ac39ff53",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a32ce90d-9138-4aca-aa3c-a558dd16fad8.jpg?1",
             "name": "Elusive Tormentor // Insidious Mist",
             "text": "Hexproof, indestructible\nInsidious Mist can't block and can't be blocked.\nWhenever Insidious Mist attacks and isn't blocked, you may pay {2}{B}. If you do, transform it.",
             "colours": [
@@ -4047,7 +4047,7 @@
         },
         {
             "id": "19092dcc-c213-53e3-8bf1-0924e21b5c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a530a54-2711-4858-bc88-559d90be4f05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a530a54-2711-4858-bc88-559d90be4f05.jpg?1",
             "name": "Ever After",
             "text": "Return up to two target creature cards from your graveyard to the battlefield. Each of those creatures is a black Zombie in addition to its other colors and types. Put Ever After on the bottom of its owner's library.",
             "colours": [
@@ -4079,7 +4079,7 @@
         },
         {
             "id": "597c3208-fbf8-5275-84f0-66818fc392fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6de332-debb-49f3-8b29-1719060ab00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f6de332-debb-49f3-8b29-1719060ab00c.jpg?1",
             "name": "Farbog Revenant",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "8f2bc907-5bc6-54b7-8377-8dbdfd660651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644706-223d-4e56-9614-b224e281be2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e644706-223d-4e56-9614-b224e281be2f.jpg?1",
             "name": "From Under the Floorboards",
             "text": "Madness {X}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nPut three 2/2 black Zombie creature tokens onto the battlefield tapped and you gain 3 life. If From Under the Floorboards's madness cost was paid, instead put X of those tokens onto the battlefield tapped and you gain X life.",
             "colours": [
@@ -4145,7 +4145,7 @@
         },
         {
             "id": "2db77325-7638-53cc-b18d-207118d02909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f48828d-5f97-434f-a3b8-9e8c75cc8932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f48828d-5f97-434f-a3b8-9e8c75cc8932.jpg?1",
             "name": "Ghoulcaller's Accomplice",
             "text": "{3}{B}, Exile Ghoulcaller's Accomplice from your graveyard: Put a 2/2 black Zombie creature token onto the battlefield. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "5dd75cdc-a6dd-5e1c-ba8b-d7b4e0331a40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5ba8dd-d2cd-4ee6-bdb4-390968f1ff54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5ba8dd-d2cd-4ee6-bdb4-390968f1ff54.jpg?1",
             "name": "Ghoulsteed",
             "text": "{2}{B}, Discard two cards: Return Ghoulsteed from your graveyard to the battlefield tapped.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "623af577-386b-58c9-91a0-71331636f12e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01e904c-7d8e-447b-90cb-1f4ae3fb304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e01e904c-7d8e-447b-90cb-1f4ae3fb304d.jpg?1",
             "name": "Gisa's Bidding",
             "text": "Put two 2/2 black Zombie creature tokens onto the battlefield.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "42a3309d-7c37-5435-8c1c-4a65cbb970a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce84d54c-ef63-4b90-a2b6-99a4aa21c02d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce84d54c-ef63-4b90-a2b6-99a4aa21c02d.jpg?1",
             "name": "Grotesque Mutation",
             "text": "Target creature gets +3/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -4279,7 +4279,7 @@
         },
         {
             "id": "b12a47cb-dfd1-5b53-a7a3-1b01d514e786",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg?1",
             "name": "Heir of Falkenrath // Heir to the Night",
             "text": "",
             "colours": [
@@ -4313,7 +4313,7 @@
         },
         {
             "id": "4c713c08-4ea3-51a6-85f2-07ec2d726e99",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/f/cf2ad186-4d85-4628-ae84-3c58c88d34cb.jpg?1",
             "name": "Heir of Falkenrath // Heir to the Night",
             "text": "",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "ad112fbf-bebc-586c-aba8-b2fcda87bfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc37615-ef72-4176-9e94-080e56af1d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc37615-ef72-4176-9e94-080e56af1d8a.jpg?1",
             "name": "Hound of the Farbogs",
             "text": "Delirium \u2014 Hound of the Farbogs has menace as long as there are four or more card types among cards in your graveyard. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "15ae168a-76dd-5cdb-a978-a34da745be01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24200d4-cd98-424c-bc2f-69f8b361d8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24200d4-cd98-424c-bc2f-69f8b361d8fc.jpg?1",
             "name": "Indulgent Aristocrat",
             "text": "Lifelink\n{2}, Sacrifice a creature: Put a +1/+1 counter on each Vampire you control.",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "f2d3e38e-d1ab-597f-a86a-1580daff5c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg?1",
             "name": "Kindly Stranger // Demon-Possessed Witch",
             "text": "Delirium \u2014 {2}{B}: Transform Kindly Stranger. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -4452,7 +4452,7 @@
         },
         {
             "id": "9372b55f-19d0-5e88-921e-774954ae3393",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/3/e326d5f4-63e1-45fa-8c48-6fdc05709c52.jpg?1",
             "name": "Kindly Stranger // Demon-Possessed Witch",
             "text": "When this creature transforms into Demon-Possessed Witch, you may destroy target creature.",
             "colours": [
@@ -4487,7 +4487,7 @@
         },
         {
             "id": "a01e6a61-0078-5e38-91cf-304c0b64dead",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3817ea1a-b3d8-46f1-ac6c-69caf2466bab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3817ea1a-b3d8-46f1-ac6c-69caf2466bab.jpg?1",
             "name": "Liliana's Indignation",
             "text": "Put the top X cards of your library into your graveyard. Target player loses 2 life for each creature card put into your graveyard this way.",
             "colours": [
@@ -4519,7 +4519,7 @@
         },
         {
             "id": "7fa4d04e-3b5f-5698-a0fe-067458247aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ec8571-690e-405f-89d5-b7cc99e8ee63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ec8571-690e-405f-89d5-b7cc99e8ee63.jpg?1",
             "name": "Macabre Waltz",
             "text": "Return up to two target creature cards from your graveyard to your hand, then discard a card.",
             "colours": [
@@ -4551,7 +4551,7 @@
         },
         {
             "id": "594c8198-8116-516c-9c70-217978981479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg?1",
             "name": "Markov Dreadknight",
             "text": "Flying\n{2}{B}, Discard a card: Put two +1/+1 counters on Markov Dreadknight.",
             "colours": [
@@ -4586,7 +4586,7 @@
         },
         {
             "id": "54b7123a-a033-50c8-a510-5a0e980c4bba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356af156-a059-416c-b78b-d9058b742818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356af156-a059-416c-b78b-d9058b742818.jpg?1",
             "name": "Merciless Resolve",
             "text": "As an additional cost to cast Merciless Resolve, sacrifice a creature or land.\nDraw two cards.",
             "colours": [
@@ -4618,7 +4618,7 @@
         },
         {
             "id": "2deba3aa-6c3c-542c-9950-b5b883d00076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804cb9c-349e-4143-a372-cf65470d5b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b804cb9c-349e-4143-a372-cf65470d5b46.jpg?1",
             "name": "Mindwrack Demon",
             "text": "Flying, trample\nWhen Mindwrack Demon enters the battlefield, put the top four cards of your library into your graveyard.\nDelirium \u2014 At the beginning of your upkeep, you lose 4 life unless there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -4652,7 +4652,7 @@
         },
         {
             "id": "d98db9f8-d53e-54b4-b48e-8adbe192e047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726f215-d0a5-4e2c-b874-9dc209479993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f726f215-d0a5-4e2c-b874-9dc209479993.jpg?1",
             "name": "Morkrut Necropod",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Morkrut Necropod attacks or blocks, sacrifice another creature or land.",
             "colours": [
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "7157fd09-d3cd-5bc5-a656-d7819f1f5022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b94db1-ac8c-4667-81d5-408df0f30879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b94db1-ac8c-4667-81d5-408df0f30879.jpg?1",
             "name": "Murderous Compulsion",
             "text": "Destroy target tapped creature.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4719,7 +4719,7 @@
         },
         {
             "id": "b8a0bd7e-5d71-5223-89a7-4ebb96ad11d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdda34e9-f28b-4606-8298-b2d0c15033e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdda34e9-f28b-4606-8298-b2d0c15033e6.jpg?1",
             "name": "Olivia's Bloodsworn",
             "text": "Flying\nOlivia's Bloodsworn can't block.\n{R}: Target Vampire gains haste until end of turn.",
             "colours": [
@@ -4755,7 +4755,7 @@
         },
         {
             "id": "f24663e1-25f8-5efc-861b-c7582443893c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dad70b8-0dec-4634-a31a-b78438a313a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dad70b8-0dec-4634-a31a-b78438a313a2.jpg?1",
             "name": "Pale Rider of Trostad",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nWhen Pale Rider of Trostad enters the battlefield, discard a card.",
             "colours": [
@@ -4789,7 +4789,7 @@
         },
         {
             "id": "ef07ff13-bf1d-546b-a307-62ef4f951e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53503e59-6b6c-4de1-8528-458ab94f4e9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53503e59-6b6c-4de1-8528-458ab94f4e9a.jpg?1",
             "name": "Pick the Brain",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from it and exile that card.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, search that player's graveyard, hand, and library for any number of cards with the same name as the exiled card, exile those cards, then that player shuffles his or her library.",
             "colours": [
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "7e9bccf5-1cc2-555a-9189-599539c54be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336e0a75-8104-4e88-aad0-af7ac3efc115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/336e0a75-8104-4e88-aad0-af7ac3efc115.jpg?1",
             "name": "Rancid Rats",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "6910f954-4fc8-5cd5-aaa9-474e22ad759c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d7998-2f3d-43b8-a0be-6ff7e5c83223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0d7998-2f3d-43b8-a0be-6ff7e5c83223.jpg?1",
             "name": "Relentless Dead",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Relentless Dead dies, you may pay {B}. If you do, return it to its owner's hand.\nWhen Relentless Dead dies, you may pay {X}. If you do, return another target Zombie creature card with converted mana cost X from your graveyard to the battlefield.",
             "colours": [
@@ -4890,7 +4890,7 @@
         },
         {
             "id": "625168f5-4a95-5afc-9c9c-447f484e70e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933f0504-c611-4557-b1e6-f5be72154805.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933f0504-c611-4557-b1e6-f5be72154805.jpg?1",
             "name": "Rottenheart Ghoul",
             "text": "When Rottenheart Ghoul dies, target player discards a card.",
             "colours": [
@@ -4924,7 +4924,7 @@
         },
         {
             "id": "e755cdae-ffe9-5a36-857b-db4df783bb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b69045-2b22-4fba-868a-b91c93eb960a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b69045-2b22-4fba-868a-b91c93eb960a.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "8d328479-e635-54cc-810b-eaf3518e6ede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6913dce-05f5-4e1b-9dd9-67eb347b5be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6913dce-05f5-4e1b-9dd9-67eb347b5be8.jpg?1",
             "name": "Shamble Back",
             "text": "Exile target creature card from a graveyard. Put a 2/2 black Zombie creature token onto the battlefield. You gain 2 life.",
             "colours": [
@@ -4990,7 +4990,7 @@
         },
         {
             "id": "cc9cf18a-4dd5-5c90-af1e-28703d824cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815ca911-ccc1-4466-8d12-054b8d241992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815ca911-ccc1-4466-8d12-054b8d241992.jpg?1",
             "name": "Sinister Concoction",
             "text": "{B}, Pay 1 life, Put the top card of your library into your graveyard, Discard a card, Sacrifice Sinister Concoction: Destroy target creature.",
             "colours": [
@@ -5022,7 +5022,7 @@
         },
         {
             "id": "f0279149-7ca2-504e-8f98-0a08a12b3a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b465a5d-3ce4-4c96-a3f3-4ad9716946c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b465a5d-3ce4-4c96-a3f3-4ad9716946c4.jpg?1",
             "name": "Stallion of Ashmouth",
             "text": "Delirium \u2014 {1}{B}: Stallion of Ashmouth gets +1/+1 until end of turn. Activate this ability only if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "f59b7aef-5f27-5543-ba45-2eaec5337fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90b7dc-fb90-411e-a762-06a800bae0cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90b7dc-fb90-411e-a762-06a800bae0cf.jpg?1",
             "name": "Stromkirk Mentor",
             "text": "When Stromkirk Mentor enters the battlefield, put a +1/+1 counter on another target Vampire you control.",
             "colours": [
@@ -5092,7 +5092,7 @@
         },
         {
             "id": "d86ecd66-66ee-5eaf-b141-8be182b78e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f9001-17b2-4087-8d87-5dbaa6c48b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953f9001-17b2-4087-8d87-5dbaa6c48b16.jpg?1",
             "name": "Throttle",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -5124,7 +5124,7 @@
         },
         {
             "id": "b4babb4f-3d0c-5a52-a07e-0f457d8245f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a645c8d-7cfb-466b-9fd0-e1c26bf6f652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a645c8d-7cfb-466b-9fd0-e1c26bf6f652.jpg?1",
             "name": "To the Slaughter",
             "text": "Target player sacrifices a creature or planeswalker.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead that player sacrifices a creature and a planeswalker.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "c66efe39-9af0-5b38-b99a-7d05ebad7512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc9f63-a225-438d-b835-07a561ba91f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febc9f63-a225-438d-b835-07a561ba91f5.jpg?1",
             "name": "Tooth Collector",
             "text": "When Tooth Collector enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, target creature that player controls gets -1/-1 until end of turn.",
             "colours": [
@@ -5191,7 +5191,7 @@
         },
         {
             "id": "850618a6-9a6b-5c11-8892-dfa5d9d9fbb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8060b717-94c9-4962-9676-0b1ca6a357a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8060b717-94c9-4962-9676-0b1ca6a357a8.jpg?1",
             "name": "Triskaidekaphobia",
             "text": "At the beginning of your upkeep, choose one \u2014\n\u2022 Each player with exactly 13 life loses the game, then each player gains 1 life.\n\u2022 Each player with exactly 13 life loses the game, then each player loses 1 life.",
             "colours": [
@@ -5223,7 +5223,7 @@
         },
         {
             "id": "6d1fe9e1-618e-5ff2-a7b9-b8721185f505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc13a00-bd58-44fa-93af-846001ca4f84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc13a00-bd58-44fa-93af-846001ca4f84.jpg?1",
             "name": "Twins of Maurer Estate",
             "text": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5257,7 +5257,7 @@
         },
         {
             "id": "54055ab6-a3c9-5fe0-921e-23434d13b510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2435f17-0378-4480-8d56-d256245c7ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2435f17-0378-4480-8d56-d256245c7ced.jpg?1",
             "name": "Vampire Noble",
             "text": "",
             "colours": [
@@ -5292,7 +5292,7 @@
         },
         {
             "id": "743684e2-59a6-5538-b5a2-a7dbfa59560b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b44857-1edb-4de4-b646-917101faf881.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b44857-1edb-4de4-b646-917101faf881.jpg?1",
             "name": "Vessel of Malignity",
             "text": "{1}{B}, Sacrifice Vessel of Malignity: Target opponent exiles two cards from his or her hand. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -5324,7 +5324,7 @@
         },
         {
             "id": "12b60a03-402b-57f6-b847-2e0fcd7072e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5f44ce-1464-4282-9afa-20e9ea44c613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c5f44ce-1464-4282-9afa-20e9ea44c613.jpg?1",
             "name": "Avacyn's Judgment",
             "text": "Madness {X}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nAvacyn's Judgment deals 2 damage divided as you choose among any number of target creatures and/or players. If Avacyn's Judgment's madness cost was paid, it deals X damage divided as you choose among those creatures and/or players instead.",
             "colours": [
@@ -5356,7 +5356,7 @@
         },
         {
             "id": "540df9e6-6641-5074-8648-da3610a51dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e974a-3cf7-49f1-9d5a-c74f920f0169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64e974a-3cf7-49f1-9d5a-c74f920f0169.jpg?1",
             "name": "Bloodmad Vampire",
             "text": "Whenever Bloodmad Vampire deals combat damage to a player, put a +1/+1 counter on it.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5391,7 +5391,7 @@
         },
         {
             "id": "6f5cd81f-d833-5bc6-b3e7-ddd58c2c0adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg?1",
             "name": "Breakneck Rider // Neck Breaker",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Breakneck Rider.",
             "colours": [
@@ -5427,7 +5427,7 @@
         },
         {
             "id": "c5193e2e-11ed-57cb-a5ef-8c937ebb4e11",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fe9f85e8-1e4c-4478-8344-71fae357b694.jpg?1",
             "name": "Breakneck Rider // Neck Breaker",
             "text": "Attacking creatures you control get +1/+0 and have trample.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Neck Breaker.",
             "colours": [
@@ -5461,7 +5461,7 @@
         },
         {
             "id": "db5291b6-f0b1-5b9d-b99d-f294c57fdff6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bdc165-4c6f-47e6-8bda-877c0be3613b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8bdc165-4c6f-47e6-8bda-877c0be3613b.jpg?1",
             "name": "Burn from Within",
             "text": "Burn from Within deals X damage to target creature or player. If a creature is dealt damage this way, it loses indestructible until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "281b5e91-bd67-511d-883e-bc0805e8ee2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg?1",
             "name": "Convicted Killer // Branded Howler",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Convicted Killer.",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "da093346-5e2b-52b5-aaa1-ce1568451f3b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f43f5f02-1b29-4e75-a6af-378dcc88c3df.jpg?1",
             "name": "Convicted Killer // Branded Howler",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Branded Howler.",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "20ed97c9-4670-5c39-b634-7817aebf27bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1112ebe-2a42-48b9-b0e5-f708305d088a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1112ebe-2a42-48b9-b0e5-f708305d088a.jpg?1",
             "name": "Dance with Devils",
             "text": "Put two 1/1 red Devil creature tokens onto the battlefield. They have \"When this creature dies, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "4459544f-ac06-5b4f-88b8-fb69225e4a02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207e6eb-15a7-4ec4-91b3-880375704bb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207e6eb-15a7-4ec4-91b3-880375704bb6.jpg?1",
             "name": "Devils' Playground",
             "text": "Put four 1/1 red Devil creature tokens onto the battlefield. They have \"When this creature dies, it deals 1 damage to target creature or player.\"",
             "colours": [
@@ -5626,7 +5626,7 @@
         },
         {
             "id": "dd4fdba6-6fd2-5afc-9114-d22e8612e384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1b563a-7856-40bf-954a-a0110ed4880d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1b563a-7856-40bf-954a-a0110ed4880d.jpg?1",
             "name": "Dissension in the Ranks",
             "text": "Target blocking creature fights another target blocking creature.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "9dedb9ca-9cb7-59cf-9b13-b894cbd79dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ac4fa4-4a03-41a9-b7e4-c3a6da89472f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ac4fa4-4a03-41a9-b7e4-c3a6da89472f.jpg?1",
             "name": "Dual Shot",
             "text": "Dual Shot deals 1 damage to each of up to two target creatures.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "2850c055-510f-5e88-b7e8-544c9beb46b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fe1e1e-b14a-4efe-894b-b9da635f007f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fe1e1e-b14a-4efe-894b-b9da635f007f.jpg?1",
             "name": "Ember-Eye Wolf",
             "text": "Haste\n{1}{R}: Ember-Eye Wolf gets +2/+0 until end of turn.",
             "colours": [
@@ -5724,7 +5724,7 @@
         },
         {
             "id": "729ffd1e-98a9-568e-b40d-f3d831d41753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474895d8-1f2c-45bb-b721-4cf7c290eb23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474895d8-1f2c-45bb-b721-4cf7c290eb23.jpg?1",
             "name": "Falkenrath Gorger",
             "text": "Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost. (If you discard a card with madness, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5759,7 +5759,7 @@
         },
         {
             "id": "cd1693c5-0546-5074-be62-4a18b4429c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61caf82d-e077-4931-a6ad-09fa7f04b36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61caf82d-e077-4931-a6ad-09fa7f04b36f.jpg?1",
             "name": "Fiery Temper",
             "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5791,7 +5791,7 @@
         },
         {
             "id": "5b8c9d72-4eda-52d9-8c1c-ea6c756f9b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1031ec22-c99f-4843-a7cf-c8332234eca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1031ec22-c99f-4843-a7cf-c8332234eca8.jpg?1",
             "name": "Flameblade Angel",
             "text": "Flying\nWhenever a source an opponent controls deals damage to you or a permanent you control, you may have Flameblade Angel deal 1 damage to that source's controller.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "d620864f-6860-54ab-b32f-6d38134f5c28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg?1",
             "name": "Gatstaf Arsonists // Gatstaf Ravagers",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Gatstaf Arsonists.",
             "colours": [
@@ -5860,7 +5860,7 @@
         },
         {
             "id": "407b2282-9449-54d4-a3d6-088742c51a85",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/a/6ab67098-d3d5-4799-ae03-c734244f370e.jpg?1",
             "name": "Gatstaf Arsonists // Gatstaf Ravagers",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Gatstaf Ravagers.",
             "colours": [
@@ -5894,7 +5894,7 @@
         },
         {
             "id": "6bdd8ac3-d562-5bbd-8937-15aec59dc98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1",
             "name": "Geier Reach Bandit // Vildin-Pack Alpha",
             "text": "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform Geier Reach Bandit.",
             "colours": [
@@ -5930,7 +5930,7 @@
         },
         {
             "id": "b2a2095b-5ca3-5d1f-9366-a2a45c3ab3c2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1",
             "name": "Geier Reach Bandit // Vildin-Pack Alpha",
             "text": "Whenever a Werewolf enters the battlefield under your control, you may transform it.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Vildin-Pack Alpha.",
             "colours": [
@@ -5964,7 +5964,7 @@
         },
         {
             "id": "5aa7d6e8-b325-538d-8570-10a08f30ebd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b1dfd9-b717-4c23-b8e5-a6ec835b278a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b1dfd9-b717-4c23-b8e5-a6ec835b278a.jpg?1",
             "name": "Geistblast",
             "text": "Geistblast deals 2 damage to target creature or player.\n{2}{U}, Exile Geistblast from your graveyard: Copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "40c77f8c-21c9-59e7-b02a-8945c350f297",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5113c437-3276-4591-b95e-c2afb9d6329a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5113c437-3276-4591-b95e-c2afb9d6329a.jpg?1",
             "name": "Gibbering Fiend",
             "text": "When Gibbering Fiend enters the battlefield, it deals 1 damage to each opponent.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, Gibbering Fiend deals 1 damage to that player.",
             "colours": [
@@ -6031,7 +6031,7 @@
         },
         {
             "id": "77c06c61-8a04-565e-8eb8-f812b1c7f9f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d3c9a-d41b-4743-87a6-68d116460fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca3d3c9a-d41b-4743-87a6-68d116460fe2.jpg?1",
             "name": "Goldnight Castigator",
             "text": "Flying, haste\nIf a source would deal damage to you, it deals double that damage to you instead.\nIf a source would deal damage to Goldnight Castigator, it deals double that damage to Goldnight Castigator instead.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "0fdc0846-595b-577c-be09-d037d570ed25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5294d359-c599-40ed-9e06-2a3cc8624d6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5294d359-c599-40ed-9e06-2a3cc8624d6a.jpg?1",
             "name": "Harness the Storm",
             "text": "Whenever you cast an instant or sorcery spell from your hand, you may cast target card with the same name as that spell from your graveyard. (You still pay its costs.)",
             "colours": [
@@ -6097,7 +6097,7 @@
         },
         {
             "id": "ce636de3-662b-5a0d-8079-33db7469a29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7379689-8e4f-4c23-9276-3510f70ba7ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7379689-8e4f-4c23-9276-3510f70ba7ff.jpg?1",
             "name": "Howlpack Wolf",
             "text": "Howlpack Wolf can't block unless you control another Wolf or Werewolf.",
             "colours": [
@@ -6131,7 +6131,7 @@
         },
         {
             "id": "febef854-1bcd-5483-84ce-e9718535ccff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031ecfc4-cc84-4f74-8eb1-3eaa234d8093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031ecfc4-cc84-4f74-8eb1-3eaa234d8093.jpg?1",
             "name": "Hulking Devil",
             "text": "",
             "colours": [
@@ -6165,7 +6165,7 @@
         },
         {
             "id": "30330d1a-c07b-5a46-a465-56f85a87f82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e826571-6f00-4b40-975b-d51b2b17b4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e826571-6f00-4b40-975b-d51b2b17b4a4.jpg?1",
             "name": "Incorrigible Youths",
             "text": "Haste\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6199,7 +6199,7 @@
         },
         {
             "id": "6f8dbcc4-05e1-5718-b97e-cd4a5a0c73f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43be50a-8624-46f6-860a-39ffbfbdaa6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b43be50a-8624-46f6-860a-39ffbfbdaa6a.jpg?1",
             "name": "Inner Struggle",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -6231,7 +6231,7 @@
         },
         {
             "id": "dd130b6c-a8e2-5e67-ac7d-6b34d7966163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813104f6-e6e4-4709-8626-12fe4262a11f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813104f6-e6e4-4709-8626-12fe4262a11f.jpg?1",
             "name": "Insolent Neonate",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nDiscard a card, Sacrifice Insolent Neonate: Draw a card.",
             "colours": [
@@ -6265,7 +6265,7 @@
         },
         {
             "id": "e5ba9672-9bba-5d1b-b30b-b22994d7cd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg?1",
             "name": "Kessig Forgemaster // Flameheart Werewolf",
             "text": "Whenever Kessig Forgemaster blocks or becomes blocked by a creature, Kessig Forgemaster deals 1 damage to that creature.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Kessig Forgemaster.",
             "colours": [
@@ -6301,7 +6301,7 @@
         },
         {
             "id": "c33d3fb3-298d-5e1e-a484-1343803b815d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/33e542ce-1106-489d-9563-bd62886b8ed3.jpg?1",
             "name": "Kessig Forgemaster // Flameheart Werewolf",
             "text": "Whenever Flameheart Werewolf blocks or becomes blocked by a creature, Flameheart Werewolf deals 2 damage to that creature.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Flameheart Werewolf.",
             "colours": [
@@ -6335,7 +6335,7 @@
         },
         {
             "id": "c194d6c3-6f56-5753-92cb-2f69d92b57cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3105d-4cf9-48bf-8d12-27e856ae7a87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d3105d-4cf9-48bf-8d12-27e856ae7a87.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast Lightning Axe, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -6367,7 +6367,7 @@
         },
         {
             "id": "2a17e881-33ef-5743-8991-966d4abfe017",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f498cb6-2be2-4cd0-b002-564a0f006a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f498cb6-2be2-4cd0-b002-564a0f006a69.jpg?1",
             "name": "Mad Prophet",
             "text": "Haste\n{T}, Discard a card: Draw a card.",
             "colours": [
@@ -6402,7 +6402,7 @@
         },
         {
             "id": "176bb87b-2cba-5b90-b9e6-841c4ea13cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d5de8b-0286-4fca-86fd-e983a91f4a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d5de8b-0286-4fca-86fd-e983a91f4a8c.jpg?1",
             "name": "Magmatic Chasm",
             "text": "Creatures without flying can't block this turn.",
             "colours": [
@@ -6434,7 +6434,7 @@
         },
         {
             "id": "e7cef3f2-ba64-53f7-8f1e-9860d4ecc202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674d33d6-dfd4-4972-aaa3-6de0236a8c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674d33d6-dfd4-4972-aaa3-6de0236a8c45.jpg?1",
             "name": "Malevolent Whispers",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6466,7 +6466,7 @@
         },
         {
             "id": "be8b9603-c706-5124-ab31-a4779cf0ce5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d19c5fb-01af-4ca4-af7e-00ec2a748afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d19c5fb-01af-4ca4-af7e-00ec2a748afd.jpg?1",
             "name": "Pyre Hound",
             "text": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on Pyre Hound.",
             "colours": [
@@ -6501,7 +6501,7 @@
         },
         {
             "id": "7b7c44c6-f914-5996-9f41-5db576775bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4d04bc-6263-43b0-9b01-894a532cd3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4d04bc-6263-43b0-9b01-894a532cd3ed.jpg?1",
             "name": "Ravenous Bloodseeker",
             "text": "Discard a card: Ravenous Bloodseeker gets +2/-2 until end of turn.",
             "colours": [
@@ -6536,7 +6536,7 @@
         },
         {
             "id": "3e2a5a42-0365-5fee-b904-5b016d096528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e23215-ced7-4c44-8595-dd9df3d8227b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2e23215-ced7-4c44-8595-dd9df3d8227b.jpg?1",
             "name": "Reduce to Ashes",
             "text": "Reduce to Ashes deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -6568,7 +6568,7 @@
         },
         {
             "id": "3dd6a6c8-e927-5e2e-a9ea-0b2b4fc5501d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg?1",
             "name": "Rush of Adrenaline",
             "text": "Target creature gets +2/+1 and gains trample until end of turn.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "adadc0de-46c5-5453-8ed9-fe8e30a8bad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace86fac-769c-4440-9a40-318d7172555b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ace86fac-769c-4440-9a40-318d7172555b.jpg?1",
             "name": "Sanguinary Mage",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -6635,7 +6635,7 @@
         },
         {
             "id": "5ce62879-0166-5f30-b2c2-8b8aad298fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072f47ad-3055-4bd2-b7fd-cfbd22720d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/072f47ad-3055-4bd2-b7fd-cfbd22720d58.jpg?1",
             "name": "Scourge Wolf",
             "text": "First strike\nDelirium \u2014 Scourge Wolf has double strike as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -6670,7 +6670,7 @@
         },
         {
             "id": "dbffc493-5237-5a64-980c-d12b99d4bd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c779cb6-3454-4d5a-85a1-bea5cf8005b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c779cb6-3454-4d5a-85a1-bea5cf8005b1.jpg?1",
             "name": "Senseless Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "520a6b39-7615-5e0c-9688-bece4aae5c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefeb031-9dda-4717-a8d1-e2c21551e43a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cefeb031-9dda-4717-a8d1-e2c21551e43a.jpg?1",
             "name": "Sin Prodder",
             "text": "Menace\nAt the beginning of your upkeep, reveal the top card of your library. Any opponent may have you put that card into your graveyard. If a player does, Sin Prodder deals damage to that player equal to that card's converted mana cost. Otherwise, put that card into your hand.",
             "colours": [
@@ -6738,7 +6738,7 @@
         },
         {
             "id": "73a278af-00a6-5386-ad47-3791e00ceecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg?1",
             "name": "Skin Invasion // Skin Shedder",
             "text": "Enchant creature\nEnchanted creature attacks each combat if able.\nWhen enchanted creature dies, return Skin Invasion to the battlefield transformed under your control.",
             "colours": [
@@ -6772,7 +6772,7 @@
         },
         {
             "id": "8fedef1e-c540-5f2c-aa7e-fb95cf771b37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0243401-e3ae-41c6-a3a0-9cd4b330c200.jpg?1",
             "name": "Skin Invasion // Skin Shedder",
             "text": "",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "7ae26ebb-74b3-549a-9d90-ea58b6039766",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d7349-d066-49b0-9920-c1ec1595e00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592d7349-d066-49b0-9920-c1ec1595e00d.jpg?1",
             "name": "Spiteful Motives",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +3/+0 and has first strike.",
             "colours": [
@@ -6841,7 +6841,7 @@
         },
         {
             "id": "98fae5d3-d8b1-5d14-ac67-470bfc09cbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f1b024-d7d5-4e81-b016-06826e2b8bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48f1b024-d7d5-4e81-b016-06826e2b8bbf.jpg?1",
             "name": "Stensia Masquerade",
             "text": "Attacking creatures you control have first strike.\nWhenever a Vampire you control deals combat damage to a player, put a +1/+1 counter on it.\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "6d80eff1-0087-5398-852b-2754aa6299b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7895890-a774-4c7c-9f15-78b8aadfd9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7895890-a774-4c7c-9f15-78b8aadfd9ef.jpg?1",
             "name": "Structural Distortion",
             "text": "Exile target artifact or land. Structural Distortion deals 2 damage to that permanent's controller.",
             "colours": [
@@ -6905,7 +6905,7 @@
         },
         {
             "id": "b747d38b-10e5-5663-829f-7a501037e1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b0a20-2422-465e-b74e-4402b34fb57b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f5b0a20-2422-465e-b74e-4402b34fb57b.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast Tormenting Voice, discard a card.\nDraw two cards.",
             "colours": [
@@ -6937,7 +6937,7 @@
         },
         {
             "id": "43fe4bba-497e-54cc-8ea9-96e5e1ac54ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d0ee03-a8c6-4f37-9885-60a26a2e2728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d0ee03-a8c6-4f37-9885-60a26a2e2728.jpg?1",
             "name": "Ulrich's Kindred",
             "text": "Trample\n{3}{G}: Target attacking Wolf or Werewolf gains indestructible until end of turn.",
             "colours": [
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "09f4ea69-3f7d-5e90-b291-e52990425b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40440487-5ff2-43da-aa06-c649bf972ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40440487-5ff2-43da-aa06-c649bf972ef1.jpg?1",
             "name": "Uncaged Fury",
             "text": "Target creature gets +1/+1 and gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -7004,7 +7004,7 @@
         },
         {
             "id": "331efc27-0224-5da1-af65-5d1918afbc73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81647b86-2c84-4a14-8d5a-919f7a5b8bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81647b86-2c84-4a14-8d5a-919f7a5b8bc7.jpg?1",
             "name": "Vessel of Volatility",
             "text": "{1}{R}, Sacrifice Vessel of Volatility: Add {R}{R}{R}{R} to your mana pool.",
             "colours": [
@@ -7036,7 +7036,7 @@
         },
         {
             "id": "ff9bb16e-1697-5205-8201-6f36fff33391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1",
             "name": "Village Messenger // Moonrise Intruder",
             "text": "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform Village Messenger.",
             "colours": [
@@ -7071,7 +7071,7 @@
         },
         {
             "id": "80e1108f-03b5-52ff-ad95-51989989beb0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1",
             "name": "Village Messenger // Moonrise Intruder",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Moonrise Intruder.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "e76d3e0b-3d07-507c-93a8-846fb350e5a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ca081d-6771-407e-ae03-3d6b2ec61dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ca081d-6771-407e-ae03-3d6b2ec61dff.jpg?1",
             "name": "Voldaren Duelist",
             "text": "Haste\nWhen Voldaren Duelist enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -7140,7 +7140,7 @@
         },
         {
             "id": "08173ae3-7807-574f-aaa4-bb55b93fec0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedce04c-e7bc-4db0-94a1-66131761512c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedce04c-e7bc-4db0-94a1-66131761512c.jpg?1",
             "name": "Wolf of Devil's Breach",
             "text": "Whenever Wolf of Devil's Breach attacks, you may pay {1}{R} and discard a card. If you do, Wolf of Devil's Breach deals damage to target creature or planeswalker equal to the discarded card's converted mana cost.",
             "colours": [
@@ -7175,7 +7175,7 @@
         },
         {
             "id": "39bbbaca-a429-56d8-8d6f-fc2cfae0433b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cd33cc-df39-4db1-a4a0-09756ec8372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cd33cc-df39-4db1-a4a0-09756ec8372c.jpg?1",
             "name": "Aim High",
             "text": "Untap target creature. It gets +2/+2 and gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [
@@ -7207,7 +7207,7 @@
         },
         {
             "id": "ec30d374-624c-5028-8a2a-fb899486033b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg?1",
             "name": "Autumnal Gloom // Ancient of the Equinox",
             "text": "{B}: Put the top card of your library into your graveyard.\nDelirium \u2014 At the beginning of your end step, if there are four or more card types among cards in your graveyard, transform Autumnal Gloom.",
             "colours": [
@@ -7240,7 +7240,7 @@
         },
         {
             "id": "d7c24f54-ce35-515d-815f-d40c6280a31d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d41b07c8-f0c8-4654-bcc2-00c785c8c628.jpg?1",
             "name": "Autumnal Gloom // Ancient of the Equinox",
             "text": "Trample, hexproof",
             "colours": [
@@ -7275,7 +7275,7 @@
         },
         {
             "id": "fe6e209a-1e95-5c2b-b7b1-fcbb8ccc3a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a017b-40cb-4c15-b9ea-a3ed904e4e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44a017b-40cb-4c15-b9ea-a3ed904e4e49.jpg?1",
             "name": "Briarbridge Patrol",
             "text": "Whenever Briarbridge Patrol deals damage to one or more creatures, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nAt the beginning of each end step, if you sacrificed three or more Clues this turn, you may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -7310,7 +7310,7 @@
         },
         {
             "id": "bb9b68e4-1c65-5cc3-a57d-9419ad3b27f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f243a51-bbd3-4028-a469-469ab5591aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f243a51-bbd3-4028-a469-469ab5591aae.jpg?1",
             "name": "Byway Courier",
             "text": "When Byway Courier dies, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "c0ff9d43-24e9-5591-9235-5952578dba05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2835993-6c71-4a63-bad5-cb25aedc4a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2835993-6c71-4a63-bad5-cb25aedc4a15.jpg?1",
             "name": "Clip Wings",
             "text": "Each opponent sacrifices a creature with flying.",
             "colours": [
@@ -7377,7 +7377,7 @@
         },
         {
             "id": "c8bec8d6-5021-5d67-9cd4-c1324755de62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59557c3-aba2-4f80-8f37-accb7b991cb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59557c3-aba2-4f80-8f37-accb7b991cb9.jpg?1",
             "name": "Confront the Unknown",
             "text": "Investigate, then target creature gets +1/+1 until end of turn for each Clue you control. (To investigate, put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7409,7 +7409,7 @@
         },
         {
             "id": "aaabffba-1518-5c24-8e88-7cdb6327cedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d5abe-22b5-4ef1-ad74-af3e75e22a07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d5abe-22b5-4ef1-ad74-af3e75e22a07.jpg?1",
             "name": "Crawling Sensation",
             "text": "At the beginning of your upkeep, you may put the top two cards of your library into your graveyard.\nWhenever one or more land cards are put into your graveyard from anywhere for the first time each turn, put a 1/1 green Insect creature token onto the battlefield.",
             "colours": [
@@ -7441,7 +7441,7 @@
         },
         {
             "id": "e884ed8e-1ee0-5b8c-a94e-bda1d15b75b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2910adcd-882a-46af-8236-ca1a9e2c19ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2910adcd-882a-46af-8236-ca1a9e2c19ab.jpg?1",
             "name": "Cryptolith Rite",
             "text": "Creatures you control have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "f03bd93d-277a-54ba-9b25-3411f42fd7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a13669-4656-476a-8984-ec3d47960907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2a13669-4656-476a-8984-ec3d47960907.jpg?1",
             "name": "Cult of the Waxing Moon",
             "text": "Whenever a permanent you control transforms into a non-Human creature, put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -7508,7 +7508,7 @@
         },
         {
             "id": "009d31ce-b47f-5cd3-9a54-51dbca6c7f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4aee46-ac42-4ede-ad06-906e2955a9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4aee46-ac42-4ede-ad06-906e2955a9d3.jpg?1",
             "name": "Deathcap Cultivator",
             "text": "{T}: Add {B} or {G} to your mana pool.\nDelirium \u2014 Deathcap Cultivator has deathtouch as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "b8f2b734-6f99-5f8a-9003-31fa49aa1a26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1",
             "name": "Duskwatch Recruiter // Krallenhorde Howler",
             "text": "{2}{G}: Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Duskwatch Recruiter.",
             "colours": [
@@ -7580,7 +7580,7 @@
         },
         {
             "id": "ed551490-1e38-5b31-87ba-83ad03f23b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1",
             "name": "Duskwatch Recruiter // Krallenhorde Howler",
             "text": "Creature spells you cast cost {1} less to cast.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Krallenhorde Howler.",
             "colours": [
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "cad2aad7-bd3f-509c-bf7a-d9c8e5a29269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af14d1-a304-4744-9d6f-9ff5fcd92ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9af14d1-a304-4744-9d6f-9ff5fcd92ad3.jpg?1",
             "name": "Equestrian Skill",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nAs long as enchanted creature is a Human, it has trample.",
             "colours": [
@@ -7648,7 +7648,7 @@
         },
         {
             "id": "6ccf5c66-4840-5f4e-ac8f-26645e9c0b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7ad701-65c3-494a-8986-b4ea1bab46bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a7ad701-65c3-494a-8986-b4ea1bab46bc.jpg?1",
             "name": "Fork in the Road",
             "text": "Search your library for up to two basic land cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle your library.",
             "colours": [
@@ -7680,7 +7680,7 @@
         },
         {
             "id": "d01577e5-a066-536a-b779-6768edc47684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04dfd8-e704-46d7-bdf8-b0b2ee747a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee04dfd8-e704-46d7-bdf8-b0b2ee747a49.jpg?1",
             "name": "Gloomwidow",
             "text": "Reach\nGloomwidow can block only creatures with flying.",
             "colours": [
@@ -7714,7 +7714,7 @@
         },
         {
             "id": "b749d8cf-4bf4-587c-ab8f-3f5b330a4bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a40334-65d8-46d2-9c56-389e9b32107c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25a40334-65d8-46d2-9c56-389e9b32107c.jpg?1",
             "name": "Graf Mole",
             "text": "Whenever you sacrifice a Clue, you gain 3 life.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "d7afcbed-75cb-5bbc-a849-5f4fe030f4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae029a5b-bcfb-4004-86aa-aaeca561545c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae029a5b-bcfb-4004-86aa-aaeca561545c.jpg?1",
             "name": "Groundskeeper",
             "text": "{1}{G}: Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -7784,7 +7784,7 @@
         },
         {
             "id": "0b7eead2-861d-555e-885a-14b8a7892ac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg?1",
             "name": "Hermit of the Natterknolls // Lone Wolf of the Natterknolls",
             "text": "Whenever an opponent casts a spell during your turn, draw a card.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Hermit of the Natterknolls.",
             "colours": [
@@ -7819,7 +7819,7 @@
         },
         {
             "id": "8e3a188c-a417-5013-8a38-3984f15b7c31",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/5/d5e84d80-b5a6-4cd1-9f31-f6ca46bf2c0c.jpg?1",
             "name": "Hermit of the Natterknolls // Lone Wolf of the Natterknolls",
             "text": "Whenever an opponent casts a spell during your turn, draw two cards.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Lone Wolf of the Natterknolls.",
             "colours": [
@@ -7853,7 +7853,7 @@
         },
         {
             "id": "d5d4e44e-9fb1-5e19-9ab9-537a1d1bc5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1",
             "name": "Hinterland Logger // Timber Shredder",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Hinterland Logger.",
             "colours": [
@@ -7888,7 +7888,7 @@
         },
         {
             "id": "52937d0e-6bed-5f57-a045-74956142a6be",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1",
             "name": "Hinterland Logger // Timber Shredder",
             "text": "Trample\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Timber Shredder.",
             "colours": [
@@ -7922,7 +7922,7 @@
         },
         {
             "id": "c621867d-24b5-5858-b629-2a617c6f1077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0063470-3728-4d7e-8f77-5e9c9c7d6a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0063470-3728-4d7e-8f77-5e9c9c7d6a6a.jpg?1",
             "name": "Howlpack Resurgence",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEach creature you control that's a Wolf or a Werewolf gets +1/+1 and has trample.",
             "colours": [
@@ -7954,7 +7954,7 @@
         },
         {
             "id": "006cb9a2-0ee2-5404-b3c9-4a23e200f67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0210ff44-19d9-4d24-9d32-f1f9f219d9e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0210ff44-19d9-4d24-9d32-f1f9f219d9e0.jpg?1",
             "name": "Inexorable Blob",
             "text": "Delirium \u2014 Whenever Inexorable Blob attacks, if there are four or more card types among cards in your graveyard, put a 3/3 green Ooze creature token onto the battlefield tapped and attacking.",
             "colours": [
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "80a73a6e-a3ba-5740-ad24-295320742689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ac63b-8386-4175-9555-84c54566f5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3ac63b-8386-4175-9555-84c54566f5b4.jpg?1",
             "name": "Intrepid Provisioner",
             "text": "Trample\nWhen Intrepid Provisioner enters the battlefield, another target Human you control gets +2/+2 until end of turn.",
             "colours": [
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "15f7e245-1355-5116-a2e6-c60fda16a074",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ac46-dac9-46e6-9c7f-a69caaee1a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ac46-dac9-46e6-9c7f-a69caaee1a2e.jpg?1",
             "name": "Kessig Dire Swine",
             "text": "Delirium \u2014 Kessig Dire Swine has trample as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -8058,7 +8058,7 @@
         },
         {
             "id": "c45e24b8-c1e3-5fa8-b282-df5b290d0d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg?1",
             "name": "Lambholt Pacifist // Lambholt Butcher",
             "text": "Lambholt Pacifist can't attack unless you control a creature with power 4 or greater.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Lambholt Pacifist.",
             "colours": [
@@ -8094,7 +8094,7 @@
         },
         {
             "id": "b31f2f7d-1d86-551a-b76c-d9799c487767",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/23f3fa96-6276-463e-8033-a64c8f06c933.jpg?1",
             "name": "Lambholt Pacifist // Lambholt Butcher",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform Lambholt Butcher.",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "a053cca1-be2d-5b6f-819a-89add5a638e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9441d-18d9-4ec6-859e-e9a7893b54e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c9441d-18d9-4ec6-859e-e9a7893b54e3.jpg?1",
             "name": "Loam Dryad",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color to your mana pool.",
             "colours": [
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "dbb6848b-2425-5d52-9b22-5fa86d233c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a274689-82f1-488a-baf8-cd8ef3477b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a274689-82f1-488a-baf8-cd8ef3477b72.jpg?1",
             "name": "Might Beyond Reason",
             "text": "Put two +1/+1 counters on target creature.\nDelirium \u2014 Put three +1/+1 counters on that creature instead if there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "3ca21044-1be0-5d86-9ff5-bd84453cac50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76755763-7c02-451f-b799-2106a3a4973b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76755763-7c02-451f-b799-2106a3a4973b.jpg?1",
             "name": "Moldgraf Scavenger",
             "text": "Delirium \u2014 Moldgraf Scavenger gets +3/+0 as long as there are four or more card types among cards in your graveyard.",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "6d975f17-1a20-57ef-adda-c01cc535bc4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633603-a80f-448d-98d9-00064d379c26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9633603-a80f-448d-98d9-00064d379c26.jpg?1",
             "name": "Moonlight Hunt",
             "text": "Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf deals damage equal to its power to that creature.",
             "colours": [
@@ -8261,7 +8261,7 @@
         },
         {
             "id": "cfbb76b6-047b-53de-99ec-5a690a574865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cc3b9d-4b32-4b2e-9027-876210ccf18e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2cc3b9d-4b32-4b2e-9027-876210ccf18e.jpg?1",
             "name": "Obsessive Skinner",
             "text": "When Obsessive Skinner enters the battlefield, put a +1/+1 counter on target creature.\nDelirium \u2014 At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard, put a +1/+1 counter on target creature.",
             "colours": [
@@ -8296,7 +8296,7 @@
         },
         {
             "id": "389cb7e6-6824-5530-b729-a26c957aa814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dcc129-88c2-4f20-be0b-36c4141688c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dcc129-88c2-4f20-be0b-36c4141688c9.jpg?1",
             "name": "Pack Guardian",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Pack Guardian enters the battlefield, you may discard a land card. If you do, put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "61c89c82-6709-5655-a31d-426f60cfddcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1569b5-94ef-4ba5-98c6-f1bd4f73c7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa1569b5-94ef-4ba5-98c6-f1bd4f73c7d5.jpg?1",
             "name": "Quilled Wolf",
             "text": "{5}{G}: Quilled Wolf gets +4/+4 until end of turn.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "d591d074-3461-592c-bbc4-1d2317696d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f573622-877b-4d21-adfc-40a32b7c2e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f573622-877b-4d21-adfc-40a32b7c2e6d.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -8397,7 +8397,7 @@
         },
         {
             "id": "35ba4b1a-84eb-5e84-be41-6716e1a8e432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb04258-d6ab-440c-85d2-05a995aeba2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb04258-d6ab-440c-85d2-05a995aeba2c.jpg?1",
             "name": "Root Out",
             "text": "Destroy target artifact or enchantment.\nInvestigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "48d425cf-efc8-54ea-882f-e41c249b2f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg?1",
             "name": "Sage of Ancient Lore // Werewolf of Ancient Hunger",
             "text": "Sage of Ancient Lore's power and toughness are each equal to the number of cards in your hand.\nWhen Sage of Ancient Lore enters the battlefield, draw a card.\nAt the beginning of each upkeep, if no spells were cast last turn, transform Sage of Ancient Lore.",
             "colours": [
@@ -8465,7 +8465,7 @@
         },
         {
             "id": "ce8b1494-ef1d-53fd-afd5-454c4b4d0e03",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/94c5f7fe-9ca6-4040-bf7c-062ab22e6a02.jpg?1",
             "name": "Sage of Ancient Lore // Werewolf of Ancient Hunger",
             "text": "Vigilance, trample\nWerewolf of Ancient Hunger's power and toughness are each equal to the total number of cards in all players' hands.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform Werewolf of Ancient Hunger.",
             "colours": [
@@ -8499,7 +8499,7 @@
         },
         {
             "id": "8bdef707-c13e-521b-b375-c629abb44648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668afd78-3cf5-4daf-8dfb-fca90de0ae5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668afd78-3cf5-4daf-8dfb-fca90de0ae5a.jpg?1",
             "name": "Seasons Past",
             "text": "Return any number of cards with different converted mana costs from your graveyard to your hand. Put Seasons Past on the bottom of its owner's library.",
             "colours": [
@@ -8531,7 +8531,7 @@
         },
         {
             "id": "ab9a870e-2ad7-5c6b-a6b1-107679cc83c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0c5127-cd17-4859-8de8-165c4c748e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0c5127-cd17-4859-8de8-165c4c748e89.jpg?1",
             "name": "Second Harvest",
             "text": "For each token you control, put a token onto the battlefield that's a copy of that permanent.",
             "colours": [
@@ -8563,7 +8563,7 @@
         },
         {
             "id": "479a242e-8398-5e5b-b714-4a9ff3fb62a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20f5392-5cde-4326-a322-7463ec4b0515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20f5392-5cde-4326-a322-7463ec4b0515.jpg?1",
             "name": "Silverfur Partisan",
             "text": "Trample\nWhenever a Wolf or Werewolf you control becomes the target of an instant or sorcery spell, put a 2/2 green Wolf creature token onto the battlefield.",
             "colours": [
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "eb31a539-c7ca-5b9d-9d8a-bacbd64a8e10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg?1",
             "name": "Solitary Hunter // One of the Pack",
             "text": "At the beginning of each upkeep, if no spells were cast last turn, transform Solitary Hunter.",
             "colours": [
@@ -8634,7 +8634,7 @@
         },
         {
             "id": "ea346e0a-ec77-5ede-8b16-f66290dc7368",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/c/6c200ef1-ea08-48d4-ab50-77940a0e08c3.jpg?1",
             "name": "Solitary Hunter // One of the Pack",
             "text": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform One of the Pack.",
             "colours": [
@@ -8668,7 +8668,7 @@
         },
         {
             "id": "16f07200-e737-5e91-b0c5-9a7f2046af1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fbc045-2c86-4816-8622-db56929ae94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22fbc045-2c86-4816-8622-db56929ae94d.jpg?1",
             "name": "Soul Swallower",
             "text": "Trample\nDelirium \u2014 At the beginning of your upkeep, if there are four or more card types among cards in your graveyard, put three +1/+1 counters on Soul Swallower.",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "b6687728-4ee3-598d-8f10-fbf75a71fddf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0820f17c-ab4a-4a14-84ff-4ea200bef112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0820f17c-ab4a-4a14-84ff-4ea200bef112.jpg?1",
             "name": "Stoic Builder",
             "text": "When Stoic Builder enters the battlefield, you may return target land card from your graveyard to your hand.",
             "colours": [
@@ -8736,7 +8736,7 @@
         },
         {
             "id": "e8f84e42-0eed-56ad-ae10-db91caea22ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c699b5f-a2de-4c87-a7bc-16be4bc0a8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c699b5f-a2de-4c87-a7bc-16be4bc0a8cd.jpg?1",
             "name": "Thornhide Wolves",
             "text": "",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "93cfae75-d5de-5034-a75c-9de8a8522d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e9928-d9b2-4570-adb8-44b34115decd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8e9928-d9b2-4570-adb8-44b34115decd.jpg?1",
             "name": "Tireless Tracker",
             "text": "Whenever a land enters the battlefield under your control, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on Tireless Tracker.",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "fc0f0b4e-f99b-581d-83a6-edc55d62ad95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc69a17-db08-4b4a-bc37-98a12ea108dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbc69a17-db08-4b4a-bc37-98a12ea108dc.jpg?1",
             "name": "Traverse the Ulvenwald",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nDelirium \u2014 If there are four or more card types among cards in your graveyard, instead search your library for a creature or land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -8837,7 +8837,7 @@
         },
         {
             "id": "7152ff2e-426c-574b-8d4b-226671677c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5d48df-7d21-462c-b721-b769a785bb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a5d48df-7d21-462c-b721-b769a785bb00.jpg?1",
             "name": "Ulvenwald Hydra",
             "text": "Reach\nUlvenwald Hydra's power and toughness are each equal to the number of lands you control.\nWhen Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "92634ebf-3e7f-56f7-942b-2912b497dad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911a2b5d-7e2d-4358-8e38-cbae7192e4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911a2b5d-7e2d-4358-8e38-cbae7192e4d4.jpg?1",
             "name": "Ulvenwald Mysteries",
             "text": "Whenever a nontoken creature you control dies, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Clue, put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -8903,7 +8903,7 @@
         },
         {
             "id": "e533f3e4-a9ee-596f-8efa-44345b77a1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89533790-38c2-4b53-90fa-8abf8c1a6abb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89533790-38c2-4b53-90fa-8abf8c1a6abb.jpg?1",
             "name": "Vessel of Nascency",
             "text": "{1}{G}, Sacrifice Vessel of Nascency: Reveal the top four cards of your library. You may put an artifact, creature, enchantment, land, or planeswalker card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -8935,7 +8935,7 @@
         },
         {
             "id": "845d2d29-60ce-5755-9543-d73dabb471bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a471e83e-c0e0-4af6-bfcf-7f4a39f6fccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a471e83e-c0e0-4af6-bfcf-7f4a39f6fccf.jpg?1",
             "name": "Veteran Cathar",
             "text": "{3}{W}: Target Human gains double strike until end of turn.",
             "colours": [
@@ -8971,7 +8971,7 @@
         },
         {
             "id": "dbd54a82-c4a6-5007-ac40-cb722bce03b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1ee2d4-5992-4081-9907-4bc26750aff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be1ee2d4-5992-4081-9907-4bc26750aff0.jpg?1",
             "name": "Watcher in the Web",
             "text": "Reach (This creature can block creatures with flying.)\nWatcher in the Web can block an additional seven creatures each combat.",
             "colours": [
@@ -9005,7 +9005,7 @@
         },
         {
             "id": "0ef495aa-3817-5e3c-a63a-c3c7439575da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8033b16-7a48-4455-9b1b-f62ceb7b9b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8033b16-7a48-4455-9b1b-f62ceb7b9b61.jpg?1",
             "name": "Weirding Wood",
             "text": "Enchant land\nWhen Weirding Wood enters the battlefield, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "3d725f1e-83c4-5b27-9f7c-f3a88b56b365",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05da08d-8fac-47bc-80d8-78a80d1463d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05da08d-8fac-47bc-80d8-78a80d1463d2.jpg?1",
             "name": "Altered Ego",
             "text": "Altered Ego can't be countered.\nYou may have Altered Ego enter the battlefield as a copy of any creature on the battlefield, except it enters with X additional +1/+1 counters on it.",
             "colours": [
@@ -9075,7 +9075,7 @@
         },
         {
             "id": "fff27b15-ccc8-555f-a0df-a26e3bc1a3d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ced4fa-6509-4f7a-9da7-efc70de6f90c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ced4fa-6509-4f7a-9da7-efc70de6f90c.jpg?1",
             "name": "Anguished Unmaking",
             "text": "Exile target nonland permanent. You lose 3 life.",
             "colours": [
@@ -9109,7 +9109,7 @@
         },
         {
             "id": "b7c09e3f-f692-5ed0-8919-6a2875c4ab29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1",
             "name": "Arlinn Kord // Arlinn, Embraced by the Moon",
             "text": "+1: Until end of turn, up to one target creature gets +2/+2 and gains vigilance and haste.\n0: Put a 2/2 green Wolf creature token onto the battlefield. Transform Arlinn Kord.",
             "colours": [
@@ -9147,7 +9147,7 @@
         },
         {
             "id": "a815a066-80c8-5913-b94a-866c8af561df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1",
             "name": "Arlinn Kord // Arlinn, Embraced by the Moon",
             "text": "+1: Creatures you control get +1/+1 and gain trample until end of turn.\n\u22121: Arlinn, Embraced by the Moon deals 3 damage to target creature or player. Transform Arlinn, Embraced by the Moon.\n\u22126: You get an emblem with \"Creatures you control have haste and \u2018{T}: This creature deals damage equal to its power to target creature or player.'\"",
             "colours": [
@@ -9185,7 +9185,7 @@
         },
         {
             "id": "0add6147-a0ca-5ea2-81dc-906ebabe3717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3fc2b-c2e4-421d-ac1d-6a111bb44f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee3fc2b-c2e4-421d-ac1d-6a111bb44f44.jpg?1",
             "name": "Fevered Visions",
             "text": "At the beginning of each player's end step, that player draws a card. If the player is your opponent and has four or more cards in hand, Fevered Visions deals 2 damage to him or her.",
             "colours": [
@@ -9219,7 +9219,7 @@
         },
         {
             "id": "02b2a314-ab60-5dbe-ba6d-1a7959d2ea8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790dd89-2be5-4a77-9450-2d3c1422bfc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5790dd89-2be5-4a77-9450-2d3c1422bfc9.jpg?1",
             "name": "The Gitrog Monster",
             "text": "Deathtouch\nAt the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land.\nYou may play an additional land on each of your turns.\nWhenever one or more land cards are put into your graveyard from anywhere, draw a card.",
             "colours": [
@@ -9258,7 +9258,7 @@
         },
         {
             "id": "40f7cc69-aa01-58a0-ba44-638313da5c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64077da-9e55-4ced-91f7-db478383172f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64077da-9e55-4ced-91f7-db478383172f.jpg?1",
             "name": "Invocation of Saint Traft",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, put a 4/4 white Angel creature token with flying onto the battlefield tapped and attacking. Exile that token at end of combat.\"",
             "colours": [
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "eb5412a6-f19e-5d32-867f-ec08447f21d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d70487-21d1-4897-ac20-2a996e893b5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d70487-21d1-4897-ac20-2a996e893b5b.jpg?1",
             "name": "Nahiri, the Harbinger",
             "text": "+2: You may discard a card. If you do, draw a card.\n\u22122: Exile target enchantment, tapped artifact, or tapped creature.\n\u22128: Search your library for an artifact or creature card, put it onto the battlefield, then shuffle your library. It gains haste. Return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -9332,7 +9332,7 @@
         },
         {
             "id": "1564f560-914a-593a-8b20-203c71e3204b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7297dd81-8367-42e9-abf9-9227e202e7ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7297dd81-8367-42e9-abf9-9227e202e7ae.jpg?1",
             "name": "Olivia, Mobilized for War",
             "text": "Flying\nWhenever another creature enters the battlefield under your control, you may discard a card. If you do, put a +1/+1 counter on that creature, it gains haste until end of turn, and it becomes a Vampire in addition to its other types.",
             "colours": [
@@ -9371,7 +9371,7 @@
         },
         {
             "id": "b4bd7b86-501d-5123-af62-dc38c18483ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634cedb6-8b00-4f4b-8790-541188955295.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/634cedb6-8b00-4f4b-8790-541188955295.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -9407,7 +9407,7 @@
         },
         {
             "id": "c097973c-1a55-524f-8b33-f478b45b46cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db953cb9-52b4-4bf0-86ab-2c3af2faeccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db953cb9-52b4-4bf0-86ab-2c3af2faeccf.jpg?1",
             "name": "Sigarda, Heron's Grace",
             "text": "Flying\nYou and Humans you control have hexproof.\n{2}, Exile a card from your graveyard: Put a 1/1 white Human Soldier creature token onto the battlefield.",
             "colours": [
@@ -9445,7 +9445,7 @@
         },
         {
             "id": "d85b64b7-a42f-54ad-89c4-672673a07fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2933144-c931-498a-9e91-f5165873c3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2933144-c931-498a-9e91-f5165873c3b7.jpg?1",
             "name": "Sorin, Grim Nemesis",
             "text": "+1: Reveal the top card of your library and put that card into your hand. Each opponent loses life equal to its converted mana cost.\n\u2212X: Sorin, Grim Nemesis deals X damage to target creature or planeswalker and you gain X life.\n\u22129: Put a number of 1/1 black Vampire Knight creature tokens with lifelink onto the battlefield equal to the highest life total among all players.",
             "colours": [
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "17c985ef-c8f6-57a3-b8b7-1d023f4568bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ecfcbe-e8db-4f08-aa8b-5b7b3e6c6ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ecfcbe-e8db-4f08-aa8b-5b7b3e6c6ce7.jpg?1",
             "name": "Brain in a Jar",
             "text": "{1}, {T}: Put a charge counter on Brain in a Jar, then you may cast an instant or sorcery card with converted mana cost equal to the number of charge counters on Brain in a Jar from your hand without paying its mana cost.\n{3}, {T}, Remove X charge counters from Brain in a Jar: Scry X.",
             "colours": [],
@@ -9511,7 +9511,7 @@
         },
         {
             "id": "bb080b08-2fba-5a62-961d-5c48bab9319b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa34cc-4042-4d2b-a7a0-eca0b593eeb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ffa34cc-4042-4d2b-a7a0-eca0b593eeb6.jpg?1",
             "name": "Corrupted Grafstone",
             "text": "Corrupted Grafstone enters the battlefield tapped.\n{T}: Choose a color of a card in your graveyard. Add one mana of that color to your mana pool.",
             "colours": [],
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "17fd87b4-740f-5e94-833a-92faea179e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937aaed7-d9ad-45e0-915c-df61316c606a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937aaed7-d9ad-45e0-915c-df61316c606a.jpg?1",
             "name": "Epitaph Golem",
             "text": "{2}: Put target card from your graveyard on the bottom of your library.",
             "colours": [],
@@ -9570,7 +9570,7 @@
         },
         {
             "id": "ad3c8a84-68ac-5e51-9d04-af899f656cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7329a19-2f68-4d2c-a725-e0d862cd234e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7329a19-2f68-4d2c-a725-e0d862cd234e.jpg?1",
             "name": "Explosive Apparatus",
             "text": "{3}, {T}, Sacrifice Explosive Apparatus: Explosive Apparatus deals 2 damage to target creature or player.",
             "colours": [],
@@ -9598,7 +9598,7 @@
         },
         {
             "id": "1e379538-8581-5690-80a1-4ecf8b30946c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1",
             "name": "Harvest Hand // Scrounged Scythe",
             "text": "When Harvest Hand dies, return it to the battlefield transformed under your control.",
             "colours": [],
@@ -9629,7 +9629,7 @@
         },
         {
             "id": "1456b0c6-e03f-56df-b2b9-6779204ac011",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1",
             "name": "Harvest Hand // Scrounged Scythe",
             "text": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human, it has menace. (It can't be blocked except by two or more creatures.)\nEquip {2}",
             "colours": [],
@@ -9659,7 +9659,7 @@
         },
         {
             "id": "d64b7bf3-71cc-5231-b52a-341fef981a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef142a2a-08e8-4344-8626-239690b3bb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef142a2a-08e8-4344-8626-239690b3bb87.jpg?1",
             "name": "Haunted Cloak",
             "text": "Equipped creature has vigilance, trample, and haste.\nEquip {1}",
             "colours": [],
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "9c16027b-fb51-58ca-9e04-6aeaaa88c5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a708d5-f757-4fcf-a167-5b5920c6adeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a708d5-f757-4fcf-a167-5b5920c6adeb.jpg?1",
             "name": "Magnifying Glass",
             "text": "{T}: Add {C} to your mana pool.\n{4}, {T}: Investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -9717,7 +9717,7 @@
         },
         {
             "id": "bf3b86e4-0f2e-5acb-9ea4-bc95c113cf54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696dcb79-4915-424f-ba8f-5363ae3395a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/696dcb79-4915-424f-ba8f-5363ae3395a6.jpg?1",
             "name": "Murderer's Axe",
             "text": "Equipped creature gets +2/+2.\nEquip\u2014\nDiscard a card.",
             "colours": [],
@@ -9747,7 +9747,7 @@
         },
         {
             "id": "ca9311b9-9acd-5d99-b43f-b022d37880de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1",
             "name": "Neglected Heirloom // Ashmouth Blade",
             "text": "Equipped creature gets +1/+1.\nWhen equipped creature transforms, transform Neglected Heirloom.\nEquip {1}",
             "colours": [],
@@ -9777,7 +9777,7 @@
         },
         {
             "id": "66d7d0d7-56dc-50ed-8a44-81620036b310",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1",
             "name": "Neglected Heirloom // Ashmouth Blade",
             "text": "Equipped creature gets +3/+3 and has first strike.\nEquip {3}",
             "colours": [],
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "66ac6636-bec9-5a1a-b1c1-c04591b0ea96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8ce5d3-0184-4cfb-a41d-3d58229b2a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8ce5d3-0184-4cfb-a41d-3d58229b2a5f.jpg?1",
             "name": "Runaway Carriage",
             "text": "Trample\nWhen Runaway Carriage attacks or blocks, sacrifice it at end of combat.",
             "colours": [],
@@ -9838,7 +9838,7 @@
         },
         {
             "id": "7a95c41e-3eff-5ac3-8af6-d6119bd9d177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4924d7-f787-474b-beca-3b369903485c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4924d7-f787-474b-beca-3b369903485c.jpg?1",
             "name": "Shard of Broken Glass",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature attacks, you may put the top two cards of your library into your graveyard.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9868,7 +9868,7 @@
         },
         {
             "id": "a9b12123-56e4-5b69-a439-562b20b2b437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3168317b-b166-483e-9d9a-20cdfcdc255c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3168317b-b166-483e-9d9a-20cdfcdc255c.jpg?1",
             "name": "Skeleton Key",
             "text": "Equipped creature has skulk. (It can't be blocked by creatures with greater power.)\nWhenever equipped creature deals combat damage to a player, you may draw a card. If you do, discard a card.\nEquip {2}",
             "colours": [],
@@ -9898,7 +9898,7 @@
         },
         {
             "id": "ab6150a0-ff33-551f-91f5-e4f5dd458572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0810651-0301-46d4-b9d7-c2283ef4031a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0810651-0301-46d4-b9d7-c2283ef4031a.jpg?1",
             "name": "Slayer's Plate",
             "text": "Equipped creature gets +4/+2.\nWhenever equipped creature dies, if it was a Human, put a 1/1 white Spirit creature token with flying onto the battlefield.\nEquip {3}",
             "colours": [],
@@ -9928,7 +9928,7 @@
         },
         {
             "id": "b33e380c-0615-5559-93da-2ba3610d2b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b474378c-5fa8-418f-8d76-23e78003ed18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b474378c-5fa8-418f-8d76-23e78003ed18.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "At the beginning of your upkeep, investigate. (Put a colorless Clue artifact token onto the battlefield with \"{2}, Sacrifice this artifact: Draw a card.\")\n{T}, Sacrifice three Clues: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [],
@@ -9963,7 +9963,7 @@
         },
         {
             "id": "9b53ce45-735c-5247-b744-9fcac2dbdc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45242fd6-6e36-468c-b9ef-140fc969d343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45242fd6-6e36-468c-b9ef-140fc969d343.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -9998,7 +9998,7 @@
         },
         {
             "id": "eb08862e-454a-510e-90f4-04e5adc335d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae5c06-b8da-4f74-9ee6-dbcba6d638ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaae5c06-b8da-4f74-9ee6-dbcba6d638ad.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "7f10a3cb-8209-5273-bcfc-e5698aaaf5e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f4323-525f-440f-b7bd-3363f2180971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761f4323-525f-440f-b7bd-3363f2180971.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "c7843559-f071-5c8b-8384-8cc79b12be2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240c4920-09a8-452a-8fa3-784f3d00d434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/240c4920-09a8-452a-8fa3-784f3d00d434.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10103,7 +10103,7 @@
         },
         {
             "id": "bbb7dc42-0a75-5c32-b54d-a876a0b7ea14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f732c92e-8e0a-4c77-a3c0-d9b9384e363f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f732c92e-8e0a-4c77-a3c0-d9b9384e363f.jpg?1",
             "name": "Tamiyo's Journal",
             "text": "",
             "colours": [],
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "31e4954a-d167-57d2-9b5f-945798f7d855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg?1",
             "name": "Thraben Gargoyle // Stonewing Antagonizer",
             "text": "Defender\n{6}: Transform Thraben Gargoyle.",
             "colours": [],
@@ -10169,7 +10169,7 @@
         },
         {
             "id": "152a156b-d1b9-544e-913b-aba5ada950d4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2687683-2986-4e22-97d9-7820c870475b.jpg?1",
             "name": "Thraben Gargoyle // Stonewing Antagonizer",
             "text": "Flying",
             "colours": [],
@@ -10201,7 +10201,7 @@
         },
         {
             "id": "2294dd22-1783-525b-9aa1-574119828581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815eb91c-06fa-4362-803e-e9bf7d374856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/815eb91c-06fa-4362-803e-e9bf7d374856.jpg?1",
             "name": "True-Faith Censer",
             "text": "Equipped creature gets +1/+1 and has vigilance.\nAs long as equipped creature is a Human, it gets an additional +1/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10231,7 +10231,7 @@
         },
         {
             "id": "08e0baa8-fe4a-5515-88dc-7040178a3300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae115587-012d-40ff-a20d-270fabf2f8c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae115587-012d-40ff-a20d-270fabf2f8c6.jpg?1",
             "name": "Wicker Witch",
             "text": "",
             "colours": [],
@@ -10262,7 +10262,7 @@
         },
         {
             "id": "cd953f3f-1659-5067-b5e7-291bd90f19da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285b444-1668-4a3d-9fcd-8ce4e95c6d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285b444-1668-4a3d-9fcd-8ce4e95c6d2f.jpg?1",
             "name": "Wild-Field Scarecrow",
             "text": "Defender\n{2}, Sacrifice Wild-Field Scarecrow: Search your library for up to two basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [],
@@ -10293,7 +10293,7 @@
         },
         {
             "id": "2e92670c-400b-52fd-99fa-ca04865e6dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995d44ca-626d-4c95-97af-ee53fa8baaf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995d44ca-626d-4c95-97af-ee53fa8baaf0.jpg?1",
             "name": "Choked Estuary",
             "text": "As Choked Estuary enters the battlefield, you may reveal an Island or Swamp card from your hand. If you don't, Choked Estuary enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "5db6ba4e-8d09-5c72-b6c7-92bf2b2e07fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb5657-18a1-455c-a87a-4e67971184ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5bb5657-18a1-455c-a87a-4e67971184ac.jpg?1",
             "name": "Drownyard Temple",
             "text": "{T}: Add {C} to your mana pool.\n{3}: Return Drownyard Temple from your graveyard to the battlefield tapped.",
             "colours": [],
@@ -10352,7 +10352,7 @@
         },
         {
             "id": "89203438-f2b3-5f00-9580-c71847006ef4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26ee31-7e2a-4eed-b448-04989fb57523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c26ee31-7e2a-4eed-b448-04989fb57523.jpg?1",
             "name": "Foreboding Ruins",
             "text": "As Foreboding Ruins enters the battlefield, you may reveal a Swamp or Mountain card from your hand. If you don't, Foreboding Ruins enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -10383,7 +10383,7 @@
         },
         {
             "id": "8030adc4-cd4b-520f-8cd8-f63fa2324ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd86cac-08c1-4db0-ab54-4bb65a771efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd86cac-08c1-4db0-ab54-4bb65a771efe.jpg?1",
             "name": "Forsaken Sanctuary",
             "text": "Forsaken Sanctuary enters the battlefield tapped.\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -10414,7 +10414,7 @@
         },
         {
             "id": "6a7c91e3-f11b-5647-ad51-44fb5434963a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb9dc1-671d-43ad-ae22-ed1a9916b140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1feb9dc1-671d-43ad-ae22-ed1a9916b140.jpg?1",
             "name": "Fortified Village",
             "text": "As Fortified Village enters the battlefield, you may reveal a Forest or Plains card from your hand. If you don't, Fortified Village enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -10445,7 +10445,7 @@
         },
         {
             "id": "f70dd634-c7be-5ed1-8fdf-559c2f0f440a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2378ac21-9912-40d7-972d-b1b71a8e4984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2378ac21-9912-40d7-972d-b1b71a8e4984.jpg?1",
             "name": "Foul Orchard",
             "text": "Foul Orchard enters the battlefield tapped.\n{T}: Add {B} or {G} to your mana pool.",
             "colours": [],
@@ -10476,7 +10476,7 @@
         },
         {
             "id": "0ec60fc3-dd1d-5b44-b3c6-9227c83ab72b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb5950-adaa-438d-998b-3a64bd4a2b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb5950-adaa-438d-998b-3a64bd4a2b3e.jpg?1",
             "name": "Game Trail",
             "text": "As Game Trail enters the battlefield, you may reveal a Mountain or Forest card from your hand. If you don't, Game Trail enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -10507,7 +10507,7 @@
         },
         {
             "id": "be7ca0a0-bbff-5bd4-b617-76431991952d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b97a23-c4cf-47c9-9dbf-34215ea0e908.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b97a23-c4cf-47c9-9dbf-34215ea0e908.jpg?1",
             "name": "Highland Lake",
             "text": "Highland Lake enters the battlefield tapped.\n{T}: Add {U} or {R} to your mana pool.",
             "colours": [],
@@ -10538,7 +10538,7 @@
         },
         {
             "id": "085583ad-b39d-5cfe-88cf-3cf5fc74120c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866712a-c3ef-4a43-ac0f-146c7836f0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866712a-c3ef-4a43-ac0f-146c7836f0d6.jpg?1",
             "name": "Port Town",
             "text": "As Port Town enters the battlefield, you may reveal a Plains or Island card from your hand. If you don't, Port Town enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -10569,7 +10569,7 @@
         },
         {
             "id": "71ff8941-eebb-5007-8606-be992b364744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e636cdc3-4b83-4f15-ad4a-6c8fa3533408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e636cdc3-4b83-4f15-ad4a-6c8fa3533408.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -10600,7 +10600,7 @@
         },
         {
             "id": "9dc466a0-6900-5b10-90ae-edd8f11897f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16793435-8eb3-4d57-8683-de1120eb46b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16793435-8eb3-4d57-8683-de1120eb46b6.jpg?1",
             "name": "Warped Landscape",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Warped Landscape: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [],
@@ -10628,7 +10628,7 @@
         },
         {
             "id": "85a80a8d-8f95-5b94-a56d-42e6a83674f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "{T}: Add {C} to your mana pool.\n{5}, {T}, Pay 1 life: Put a 1/1 white and black Human Cleric creature token onto the battlefield.\n{5}, {T}, Sacrifice five creatures: Transform Westvale Abbey, then untap it.",
             "colours": [],
@@ -10658,7 +10658,7 @@
         },
         {
             "id": "18539842-2be6-5a9f-ae62-d12f943c870e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1",
             "name": "Westvale Abbey // Ormendahl, Profane Prince",
             "text": "Flying, lifelink, indestructible, haste",
             "colours": [
@@ -10694,7 +10694,7 @@
         },
         {
             "id": "9217a89a-f00a-5e5f-a1df-0e2dabb6ca87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a0c745-dee6-4cb2-acaa-3d2b8e0cce5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a0c745-dee6-4cb2-acaa-3d2b8e0cce5b.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "b49d1212-c06d-5ca1-8ba1-e9921fb7ebe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbcfb7-cfbc-4752-9b6c-ffbd5d3dd678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56bbcfb7-cfbc-4752-9b6c-ffbd5d3dd678.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10762,7 +10762,7 @@
         },
         {
             "id": "fb30c1ba-67e0-5429-9fb5-2900f7261538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6401c6e7-3415-4e68-b40c-9777c33785eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6401c6e7-3415-4e68-b40c-9777c33785eb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10799,7 +10799,7 @@
         },
         {
             "id": "04f32645-75cd-5405-9def-ed1b6f1bf697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcab7eaa-5e16-40b5-992b-9cc51a95376b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcab7eaa-5e16-40b5-992b-9cc51a95376b.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10836,7 +10836,7 @@
         },
         {
             "id": "a609b537-3df7-5a2e-a535-bdde0dedd819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffca348-2af9-44bb-815f-f7f7240ac975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffca348-2af9-44bb-815f-f7f7240ac975.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "5fb307a7-f155-566e-a007-b7cb7fd908dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74e713-11f7-4341-9b22-5300a4587a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d74e713-11f7-4341-9b22-5300a4587a51.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10910,7 +10910,7 @@
         },
         {
             "id": "a57d3a91-a4cc-5f2e-b160-8da22f895e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e4610-9bdc-4ee2-8aac-26cbdee13046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125e4610-9bdc-4ee2-8aac-26cbdee13046.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "2ac08ec2-b146-5870-a074-b445cff191bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f62f5c-ddea-4564-bc47-5845ab15d8e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f62f5c-ddea-4564-bc47-5845ab15d8e2.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10984,7 +10984,7 @@
         },
         {
             "id": "9b527ba1-cb13-5cbe-8bde-5701f74af4dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fae7689-a9df-4f69-8040-9fbe24f64838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fae7689-a9df-4f69-8040-9fbe24f64838.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11021,7 +11021,7 @@
         },
         {
             "id": "343ac1d0-30f8-57d9-be6f-a1dafbbaabf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87861e3c-d445-4452-b7e0-19b53e69b6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87861e3c-d445-4452-b7e0-19b53e69b6e3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -11058,7 +11058,7 @@
         },
         {
             "id": "cda553ec-aa69-58a0-875a-77255a1baee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7878436-bf83-45c6-a040-e2fad447862a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7878436-bf83-45c6-a040-e2fad447862a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11095,7 +11095,7 @@
         },
         {
             "id": "5f61e14b-4a0e-56fe-94c8-303097f236a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55384ef-6e5e-4e0b-8156-edad0fc9b25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d55384ef-6e5e-4e0b-8156-edad0fc9b25b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "e9ffdd5d-bf6d-5932-9eaa-9f5bee9e0b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37dc16e-3631-46df-acc4-19040fb8a86e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37dc16e-3631-46df-acc4-19040fb8a86e.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -11169,7 +11169,7 @@
         },
         {
             "id": "1e071913-2122-5572-9acc-1e44287a3013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42efdb6a-1c54-497a-9058-af4256241649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42efdb6a-1c54-497a-9058-af4256241649.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11206,7 +11206,7 @@
         },
         {
             "id": "6487f87a-627b-5fa6-a778-b0878859ecdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8c30af-055a-4921-99a8-f99c472c7315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8c30af-055a-4921-99a8-f99c472c7315.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11243,7 +11243,7 @@
         },
         {
             "id": "0e5a6ea7-57a7-5d69-8f74-4287e8fea227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1ebe0b-995f-4239-aad3-bfe471a88b6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee1ebe0b-995f-4239-aad3-bfe471a88b6e.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -11280,7 +11280,7 @@
         },
         {
             "id": "4ac5ff5a-42f4-59d9-8376-23d977f8ca3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb975fe-ac30-4249-bb55-7efb64645e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb975fe-ac30-4249-bb55-7efb64645e4d.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -11314,7 +11314,7 @@
         },
         {
             "id": "42280d88-63a2-5a69-93d9-76e021eae52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d323ead-24f5-42e4-9e23-aa14eb66264d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d323ead-24f5-42e4-9e23-aa14eb66264d.jpg?1",
             "name": "Shadows Over Innistrad Checklist 1",
             "text": "",
             "colours": [],
@@ -11341,7 +11341,7 @@
         },
         {
             "id": "e8584f9e-1a99-55f8-af35-5f3b831aeb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -11376,7 +11376,7 @@
         },
         {
             "id": "5b12b49c-65a3-5545-b9b1-d31786f4ba27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4825c59d-9e27-4a12-ba84-642b8540e573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4825c59d-9e27-4a12-ba84-642b8540e573.jpg?1",
             "name": "Shadows Over Innistrad Checklist 2",
             "text": "",
             "colours": [],
@@ -11403,7 +11403,7 @@
         },
         {
             "id": "f9d674a3-6c0b-5949-b09b-9bc93cd11a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53a7c6-6b32-4491-8c96-e564abea8880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a53a7c6-6b32-4491-8c96-e564abea8880.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -11437,7 +11437,7 @@
         },
         {
             "id": "5a28cd23-684e-554a-87dd-710c22b6f805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8989fdb4-723b-4c80-89b4-930ccac13b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8989fdb4-723b-4c80-89b4-930ccac13b22.jpg?1",
             "name": "Vampire Knight",
             "text": "",
             "colours": [
@@ -11472,7 +11472,7 @@
         },
         {
             "id": "7fe203e8-ade2-52ac-9171-1f08d59f5898",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a12a72-5cd9-4f1b-997d-7dabb65e9f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0a12a72-5cd9-4f1b-997d-7dabb65e9f51.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -11506,7 +11506,7 @@
         },
         {
             "id": "41c442fc-576c-5b46-8bd3-e344e40baf88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e78c4b8-371b-43d7-a315-fb299704aa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e78c4b8-371b-43d7-a315-fb299704aa60.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -11540,7 +11540,7 @@
         },
         {
             "id": "f8568c16-1f85-5473-a15c-997951b1e9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057f94e-c2be-44e1-a93b-e31432f4ffa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0057f94e-c2be-44e1-a93b-e31432f4ffa5.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -11574,7 +11574,7 @@
         },
         {
             "id": "f54e4a20-d38c-5779-84b9-61f23b630b0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a7905-3a10-4d23-96fa-4960cac8f4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/623a7905-3a10-4d23-96fa-4960cac8f4e3.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -11608,7 +11608,7 @@
         },
         {
             "id": "675657d3-e2cb-5145-b0fc-f9ba1f1f3951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5ac360-dc47-4bc5-a4cc-ff223abc3ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5ac360-dc47-4bc5-a4cc-ff223abc3ffc.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -11642,7 +11642,7 @@
         },
         {
             "id": "e1520eed-5f7f-5d76-8dd8-121276dae02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg?1",
             "name": "Human Cleric",
             "text": "",
             "colours": [
@@ -11679,7 +11679,7 @@
         },
         {
             "id": "8dd78d67-3a54-53ed-8da6-636e03f78a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c859e1-181e-44d1-afbd-bbd6e52cf42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c859e1-181e-44d1-afbd-bbd6e52cf42a.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "0b6f24fb-d1ec-517e-82fa-d55a3b1914f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1241c3-d960-4eb4-a726-ca474209645b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f1241c3-d960-4eb4-a726-ca474209645b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11739,7 +11739,7 @@
         },
         {
             "id": "a13cc16f-ab6b-5ae8-80fd-5c28416cf9c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271afa7e-2126-4497-b871-9795b7355d69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/271afa7e-2126-4497-b871-9795b7355d69.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11769,7 +11769,7 @@
         },
         {
             "id": "c3dec01c-0e74-565d-a796-093fb902f936",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291e6490-6727-45ae-90ba-de2ff8f63162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291e6490-6727-45ae-90ba-de2ff8f63162.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11799,7 +11799,7 @@
         },
         {
             "id": "cb8cfcde-9131-53c9-9523-5fbe4352dc5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d16818-7812-4d36-b1bf-fb954e5ac958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d16818-7812-4d36-b1bf-fb954e5ac958.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11829,7 +11829,7 @@
         },
         {
             "id": "927a866b-95f0-5216-b876-88d4ba2651c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66ec9c-7e5d-47ca-bce4-46798152d1f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d66ec9c-7e5d-47ca-bce4-46798152d1f4.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -11859,7 +11859,7 @@
         },
         {
             "id": "65cfc4bf-c7d7-5b2a-9d30-ab1b7c2b94dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa30438-3733-467e-aa31-f8e8ad2e62f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa30438-3733-467e-aa31-f8e8ad2e62f3.jpg?1",
             "name": "Jace, Unraveler of Secrets Emblem",
             "text": "",
             "colours": [],
@@ -11888,7 +11888,7 @@
         },
         {
             "id": "70572701-f73b-5376-a090-d772fcbad46b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0686c3-a44a-449d-ab12-eeb9c0c25489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb0686c3-a44a-449d-ab12-eeb9c0c25489.jpg?1",
             "name": "Arlinn Kord Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/SOK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SOK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fcbbd230-a29b-5dbb-9933-4b08a519c239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214d2e9-5aa1-42a7-8f1a-f4eaa2def1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8214d2e9-5aa1-42a7-8f1a-f4eaa2def1b1.jpg?1",
             "name": "Aether Shockwave",
             "text": "Choose one Tap all Spirits; or tap all non-Spirit creatures.",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "46a0bace-3832-5571-9798-ade7bfb9d66f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e4a170-1075-47e4-abe6-996b161573c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e4a170-1075-47e4-abe6-996b161573c1.jpg?1",
             "name": "Araba Mothrider",
             "text": "Flying\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "b11cd2ab-acc0-58ae-b8e6-a1e6ca8726af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003e99a0-2caa-407b-be40-92ec17836eb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/003e99a0-2caa-407b-be40-92ec17836eb3.jpg?1",
             "name": "Celestial Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, destroy all permanents with that spell's converted mana cost.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "7036978e-263f-5cee-ae19-5831d3d41dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e0bd8-d80f-4cda-b381-ed185072d83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3e0bd8-d80f-4cda-b381-ed185072d83c.jpg?1",
             "name": "Charge Across the Araba",
             "text": "Sweep Return any number of Plains you control to their owner's hand. Creatures you control get +1/+1 until end of turn for each Plains returned this way.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "b2e7ab3a-6139-5f40-9ec4-2aa261f5a8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81b329-4ef5-4b55-9fe7-9ed69477e96b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b81b329-4ef5-4b55-9fe7-9ed69477e96b.jpg?1",
             "name": "Cowed by Wisdom",
             "text": "Enchanted creature can't attack or block unless its controller pays {1} for each card in your hand. (This cost is paid as attackers or blockers are declared.)",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "6d5a2e3a-de21-5c61-8529-2521d5545fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc382831-e338-49bd-a37f-931bf611b165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc382831-e338-49bd-a37f-931bf611b165.jpg?1",
             "name": "Curtain of Light",
             "text": "Target attacking unblocked creature becomes blocked.\nDraw a card.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "18873a49-2749-5bca-bfdc-bd1f33b935cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354af7fc-fd15-4209-b3e8-8729a401b6a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354af7fc-fd15-4209-b3e8-8729a401b6a6.jpg?1",
             "name": "Descendant of Kiyomaro",
             "text": "As long as you have more cards in hand than each opponent, Descendant of Kiyomaro gets +1/+2 and has \"Whenever this creature deals combat damage, you gain 3 life.\"",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "05bcfc47-671c-549b-888a-0696b1f9173e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe47bbc5-6f7f-4135-9e83-9e2a428c97f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe47bbc5-6f7f-4135-9e83-9e2a428c97f5.jpg?1",
             "name": "Eiganjo Free-Riders",
             "text": "Flying\nAt the beginning of your upkeep, return a white creature you control to its owner's hand.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "bc15b328-bfa6-563e-b0e4-dab29e3bdcee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc7091e-0c98-434d-9190-dcab813d3e14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dc7091e-0c98-434d-9190-dcab813d3e14.jpg?1",
             "name": "Enduring Ideal",
             "text": "Search your library for an enchantment card and put it into play. Then shuffle your library.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability.)",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "035aa37c-6226-558a-955c-72c76199d4a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90c02d-3090-402e-b74b-fc0358953263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa90c02d-3090-402e-b74b-fc0358953263.jpg?1",
             "name": "Ghost-Lit Redeemer",
             "text": "{W}, {T}: You gain 2 life.\nChannel {1}{W}, Discard Ghost-Lit Redeemer: You gain 4 life.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "7ac76e3c-c875-59f9-99f5-74a5db11e3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a57083-e82c-41aa-94b9-2e6db97f7159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a57083-e82c-41aa-94b9-2e6db97f7159.jpg?1",
             "name": "Hail of Arrows",
             "text": "Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.",
             "colours": [
@@ -376,7 +376,7 @@
         },
         {
             "id": "a27a22f3-c2cd-5798-a56e-fd4cfa77124e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddef832c-b2be-4fa6-8d66-ac0d442f2d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddef832c-b2be-4fa6-8d66-ac0d442f2d7d.jpg?1",
             "name": "Hand of Honor",
             "text": "Protection from black\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -411,7 +411,7 @@
         },
         {
             "id": "3a080cad-2080-59e4-b7bb-50a43bbd5a2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d34bfb9-abc7-4469-9546-aa8988da8259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d34bfb9-abc7-4469-9546-aa8988da8259.jpg?1",
             "name": "Inner-Chamber Guard",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "e71b07dc-3fcd-5a80-b65a-4c0b4e37d6f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c99ac4-6551-4cc2-9a70-6e66b259b2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c99ac4-6551-4cc2-9a70-6e66b259b2a2.jpg?1",
             "name": "Kataki, War's Wage",
             "text": "All artifacts have \"At the beginning of your upkeep, sacrifice this artifact unless you pay {1}.\"",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "12097065-3f7d-5bea-b4fe-88c4550e43fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94c12e0-8eb1-43f9-a421-43ca9bcffb0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a94c12e0-8eb1-43f9-a421-43ca9bcffb0e.jpg?1",
             "name": "Kitsune Bonesetter",
             "text": "{T}: Prevent the next 3 damage that would be dealt to target creature this turn. Play this ability only if you have more cards in hand than each opponent.",
             "colours": [
@@ -517,7 +517,7 @@
         },
         {
             "id": "a6174963-79d5-57a7-9c52-fc3e3dc6dadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09ab22e-aa22-4d6b-87c6-970563486f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b09ab22e-aa22-4d6b-87c6-970563486f21.jpg?1",
             "name": "Kitsune Dawnblade",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhen Kitsune Dawnblade comes into play, you may tap target creature.",
             "colours": [
@@ -552,7 +552,7 @@
         },
         {
             "id": "cae74f33-1e2b-54ad-b6c7-144ab3fdbbf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11d4490-fe4f-4526-befd-f4c9c22c76a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c11d4490-fe4f-4526-befd-f4c9c22c76a6.jpg?1",
             "name": "Kitsune Loreweaver",
             "text": "{1}{W}: Kitsune Loreweaver gets +0/+X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "3c24604a-56bb-51f8-9104-523ed866236c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3351bb-5c4e-498b-b6c9-94f571baffd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3351bb-5c4e-498b-b6c9-94f571baffd5.jpg?1",
             "name": "Kiyomaro, First to Stand",
             "text": "Kiyomaro, First to Stand's power and toughness are each equal to the number of cards in your hand.\nAs long as you have four or more cards in hand, Kiyomaro has vigilance.\nWhenever Kiyomaro deals damage, if you have seven or more cards in hand, you gain 7 life.",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "bb18300e-03bc-51c9-81c4-594f44865f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c56bf0-ad9f-4419-902c-f3a3880c716c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c56bf0-ad9f-4419-902c-f3a3880c716c.jpg?1",
             "name": "Michiko Konda, Truth Seeker",
             "text": "Whenever a source an opponent controls deals damage to you, that player sacrifices a permanent.",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "edce9684-2d98-5ccc-a847-bc3e0ec561e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f646ed53-c323-4f84-b8c9-39e31da1aca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f646ed53-c323-4f84-b8c9-39e31da1aca8.jpg?1",
             "name": "Moonwing Moth",
             "text": "Flying\n{W}: Moonwing Moth gets +0/+1 until end of turn.",
             "colours": [
@@ -694,7 +694,7 @@
         },
         {
             "id": "0c08a78c-da61-53ce-9477-c6c08d97fca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7ecd0c-9cfb-4cf3-be62-d949b58b19a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7ecd0c-9cfb-4cf3-be62-d949b58b19a4.jpg?1",
             "name": "Nikko-Onna",
             "text": "When Nikko-Onna comes into play, destroy target enchantment.\nWhenever you play a Spirit or Arcane spell, you may return Nikko-Onna to its owner's hand.",
             "colours": [
@@ -728,7 +728,7 @@
         },
         {
             "id": "a06a05bf-e2ab-5618-89a0-57e4f8289424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e78f75-bf58-4c61-9654-c5d355b5e526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e78f75-bf58-4c61-9654-c5d355b5e526.jpg?1",
             "name": "Plow Through Reito",
             "text": "Sweep Return any number of Plains you control to their owner's hand. Target creature gets +1/+1 until end of turn for each Plains returned this way.",
             "colours": [
@@ -762,7 +762,7 @@
         },
         {
             "id": "2ce031bb-2fd0-56e6-942e-e5dbffe14ce3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aedb5a-48f5-47db-9469-14075e2b9269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aedb5a-48f5-47db-9469-14075e2b9269.jpg?1",
             "name": "Presence of the Wise",
             "text": "You gain 2 life for each card in your hand.",
             "colours": [
@@ -794,7 +794,7 @@
         },
         {
             "id": "2a3b0b0f-1689-52be-abb1-5e7a6d7d0337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250735d-d43b-488f-bddf-ed10261a6382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250735d-d43b-488f-bddf-ed10261a6382.jpg?1",
             "name": "Promise of Bunrei",
             "text": "Whenever a creature you control is put into a graveyard from play, sacrifice Promise of Bunrei. If you do, put four 1/1 colorless Spirit creature tokens into play.",
             "colours": [
@@ -826,7 +826,7 @@
         },
         {
             "id": "cfc784ff-a519-5729-95be-2e6c1f9ed74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231d818-df57-4e2d-9603-babe0c2c4568.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b231d818-df57-4e2d-9603-babe0c2c4568.jpg?1",
             "name": "Pure Intentions",
             "text": "Whenever a spell or ability an opponent controls causes you to discard cards this turn, return those cards from your graveyard to your hand.\nWhenever a spell or ability an opponent controls causes you to discard Pure Intentions, return Pure Intentions from your graveyard to your hand at end of turn.",
             "colours": [
@@ -860,7 +860,7 @@
         },
         {
             "id": "7358995d-884f-5cc2-9926-dc120e8912af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5e65e1-be52-4023-81cc-ee4948444195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5e65e1-be52-4023-81cc-ee4948444195.jpg?1",
             "name": "Reverence",
             "text": "Creatures with power 2 or less can't attack you.",
             "colours": [
@@ -892,7 +892,7 @@
         },
         {
             "id": "b0fbb04d-0861-57b6-858c-0cc09ab65afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg?1",
             "name": "Rune-Tail, Kitsune Ascendant // Rune-Tail's Essence",
             "text": "When you have 30 or more life, flip Rune-Tail, Kitsune Ascendant.",
             "colours": [
@@ -929,7 +929,7 @@
         },
         {
             "id": "43bfb2e8-8cb5-5fd4-b9e7-41af62494202",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg?1",
             "name": "Rune-Tail, Kitsune Ascendant // Rune-Tail's Essence",
             "text": "Prevent all damage that would be dealt to creatures you control.",
             "colours": [
@@ -963,7 +963,7 @@
         },
         {
             "id": "68562d9c-e038-5b5b-ace1-e2603c3e5c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd3ee0-d893-4346-98b6-7d7896ad7663.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd3ee0-d893-4346-98b6-7d7896ad7663.jpg?1",
             "name": "Shinen of Stars' Light",
             "text": "First strike\nChannel {1}{W}, Discard Shinen of Stars' Light: Target creature gains first strike until end of turn.",
             "colours": [
@@ -997,7 +997,7 @@
         },
         {
             "id": "e04f8244-680c-5309-8f59-6c579ca45df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4866e-13a8-4130-9895-60e762b7efea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4866e-13a8-4130-9895-60e762b7efea.jpg?1",
             "name": "Spiritual Visit",
             "text": "Put a 1/1 colorless Spirit creature token into play.\nSplice onto Arcane {W} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1031,7 +1031,7 @@
         },
         {
             "id": "dc4c4e8c-865b-5edc-ada4-a4ce5b430d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ec0916-f320-4fad-9ec5-99aeecfda0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8ec0916-f320-4fad-9ec5-99aeecfda0e3.jpg?1",
             "name": "Torii Watchward",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)\nSoulshift 4 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 4 or less from your graveyard to your hand.)",
             "colours": [
@@ -1065,7 +1065,7 @@
         },
         {
             "id": "0431ceae-10b7-58b0-8c08-d86d9ec2fd10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0d70-8d66-47aa-9228-25dcdb4e7dad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42aa0d70-8d66-47aa-9228-25dcdb4e7dad.jpg?1",
             "name": "Cloudhoof Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may put the top X cards of target player's library into his or her graveyard, where X is that spell's converted mana cost.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "bede805f-92c2-55cd-9ab9-fd9d09b828e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066f185d-5f81-472a-8aff-2c11ba10d18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066f185d-5f81-472a-8aff-2c11ba10d18c.jpg?1",
             "name": "Cut the Earthly Bond",
             "text": "Return target enchanted permanent to its owner's hand.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "47a2b48c-0e2a-57f9-8b0f-7c76fad097c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5217d17-3667-46c6-8fba-763197fb2970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5217d17-3667-46c6-8fba-763197fb2970.jpg?1",
             "name": "Descendant of Soramaro",
             "text": "{1}{U}: Look at the top X cards of your library, where X is the number of cards in your hand, then put them back in any order.",
             "colours": [
@@ -1171,7 +1171,7 @@
         },
         {
             "id": "b021f71e-ecd0-58b0-9d51-f11cfbfd5f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90ab82e-84d7-462a-b3c2-abaccfb46dd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90ab82e-84d7-462a-b3c2-abaccfb46dd3.jpg?1",
             "name": "Dreamcatcher",
             "text": "Whenever you play a Spirit or Arcane spell, you may sacrifice Dreamcatcher. If you do, draw a card.",
             "colours": [
@@ -1205,7 +1205,7 @@
         },
         {
             "id": "b51a897e-7184-53b2-a18f-6973c7d8a414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg?1",
             "name": "Erayo, Soratami Ascendant // Erayo's Essence",
             "text": "Flying\nWhenever the fourth spell of a turn is played, flip Erayo, Soratami Ascendant.",
             "colours": [
@@ -1242,7 +1242,7 @@
         },
         {
             "id": "16d280c8-0efc-5168-b1c9-68047cbffed9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg?1",
             "name": "Erayo, Soratami Ascendant // Erayo's Essence",
             "text": "Counter the first spell played by each opponent each turn.",
             "colours": [
@@ -1276,7 +1276,7 @@
         },
         {
             "id": "b46e9b01-47bf-5681-b78b-c0e329d86108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067a9bd-991a-462d-862a-2518ae31c382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3067a9bd-991a-462d-862a-2518ae31c382.jpg?1",
             "name": "Eternal Dominion",
             "text": "Search target opponent's library for an artifact, creature, enchantment, or land card. Put that card into play under your control. Then that player shuffles his or her library.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability. You may choose a new target for the copy.)",
             "colours": [
@@ -1308,7 +1308,7 @@
         },
         {
             "id": "baabc264-16a3-5176-8482-9b8d0e0a1c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0186a93c-000a-4b8f-983d-e1471185dc1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0186a93c-000a-4b8f-983d-e1471185dc1f.jpg?1",
             "name": "Evermind",
             "text": "(Spells without mana costs can't be played.)\nDraw a card.\nEvermind is blue.\nSplice onto Arcane {1}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1342,7 +1342,7 @@
         },
         {
             "id": "f60214cf-c219-54da-9a49-3aa198aa26b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ecee02-12c0-4aed-a679-41bce95e0cda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ecee02-12c0-4aed-a679-41bce95e0cda.jpg?1",
             "name": "Freed from the Real",
             "text": "{U}: Tap enchanted creature.\n{U}: Untap enchanted creature.",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "cc195f87-a7af-55ee-a8f8-6f0bc8ed6227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b7666-8c58-48e5-8ec3-754611700e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/042b7666-8c58-48e5-8ec3-754611700e75.jpg?1",
             "name": "Ghost-Lit Warder",
             "text": "{3}{U}, {T}: Counter target spell unless its controller pays {2}.\nChannel {3}{U}, Discard Ghost-Lit Warder: Counter target spell unless its controller pays {4}.",
             "colours": [
@@ -1410,7 +1410,7 @@
         },
         {
             "id": "f3dd5f22-35cd-573c-bb87-bc6414af904a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fe46d-08d6-48c3-be0d-650d8d3d66af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fe46d-08d6-48c3-be0d-650d8d3d66af.jpg?1",
             "name": "Ideas Unbound",
             "text": "Draw three cards. Discard three cards at end of turn.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "91b927df-2c89-5c09-a053-df93c566fee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a5f54-9b79-4c3d-b983-021b4b01b122.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85a5f54-9b79-4c3d-b983-021b4b01b122.jpg?1",
             "name": "Kaho, Minamo Historian",
             "text": "When Kaho, Minamo Historian comes into play, search your library for up to three instant cards and remove them from the game. Then shuffle your library.\n{X}, {T}: You may play a card with converted mana cost X removed from the game with Kaho without paying its mana cost.",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "928c1aec-551e-594f-9bd9-c212b84ef001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01ee008-76dd-4d4d-8273-ad5b28c8a2c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f01ee008-76dd-4d4d-8273-ad5b28c8a2c7.jpg?1",
             "name": "Kami of the Crescent Moon",
             "text": "At the beginning of each player's draw step, that player draws a card.",
             "colours": [
@@ -1517,7 +1517,7 @@
         },
         {
             "id": "ed249c3d-054c-5646-826d-f8912e1cddf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb963c-18a5-4770-afb9-0121c614de40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb963c-18a5-4770-afb9-0121c614de40.jpg?1",
             "name": "Kiri-Onna",
             "text": "When Kiri-Onna comes into play, return target creature to its owner's hand.\nWhenever you play a Spirit or Arcane spell, you may return Kiri-Onna to its owner's hand.",
             "colours": [
@@ -1551,7 +1551,7 @@
         },
         {
             "id": "1b55cf3a-fcac-5f13-a8e9-6c770b9b62ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc52b-7852-44c4-9825-d5e1bd796160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70efc52b-7852-44c4-9825-d5e1bd796160.jpg?1",
             "name": "Meishin, the Mind Cage",
             "text": "All creatures get -X/-0, where X is the number of cards in your hand.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "520005ec-73da-5910-be16-a0acbab65001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f85e2-63bb-4c9a-8290-0bb8e2318e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f85e2-63bb-4c9a-8290-0bb8e2318e68.jpg?1",
             "name": "Minamo Scrollkeeper",
             "text": "Defender (This creature can't attack.)\nYour maximum hand size is increased by one.",
             "colours": [
@@ -1620,7 +1620,7 @@
         },
         {
             "id": "f17b0f7b-c839-52c9-a133-7c2500407338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4960789-1a45-4273-b2f2-34713f19d697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4960789-1a45-4273-b2f2-34713f19d697.jpg?1",
             "name": "Moonbow Illusionist",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target land's type becomes the basic land type of your choice until end of turn.",
             "colours": [
@@ -1655,7 +1655,7 @@
         },
         {
             "id": "05268560-4d7c-50ba-a930-dd36a724f73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa70562c-8e1e-44d0-b46c-ccd791be6644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa70562c-8e1e-44d0-b46c-ccd791be6644.jpg?1",
             "name": "Murmurs from Beyond",
             "text": "Reveal the top three cards of your library. An opponent chooses one. Put that card into your graveyard and the rest into your hand.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "f33f12f6-7e5c-5db8-9411-c49b2be31d0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a382a9b8-0b19-46c2-a547-a22d6e23d0ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a382a9b8-0b19-46c2-a547-a22d6e23d0ac.jpg?1",
             "name": "Oboro Breezecaller",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Untap target land.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "6509860b-ee98-5f74-a58d-86bafc2594f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0309dcb-6c13-4ffe-b44d-3b735c8277d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0309dcb-6c13-4ffe-b44d-3b735c8277d2.jpg?1",
             "name": "Oboro Envoy",
             "text": "Flying\n{2}, Return a land you control to its owner's hand: Target creature gets -X/-0, where X is the number of cards in your hand.",
             "colours": [
@@ -1759,7 +1759,7 @@
         },
         {
             "id": "d985a5af-872c-5fb2-b06a-059c69f9b822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcb5e75-c7a1-41de-a952-05aefb115270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcb5e75-c7a1-41de-a952-05aefb115270.jpg?1",
             "name": "Oppressive Will",
             "text": "Counter target spell unless its controller pays {1} for each card in your hand.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "3a1fc8d0-77cf-5894-aa9d-7ef2d135f608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeea686-7efc-48f5-b90b-bf1befc76a30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbeea686-7efc-48f5-b90b-bf1befc76a30.jpg?1",
             "name": "Overwhelming Intellect",
             "text": "Counter target creature spell. Draw cards equal to that spell's converted mana cost.",
             "colours": [
@@ -1823,7 +1823,7 @@
         },
         {
             "id": "4e8633b4-1292-58d4-b2f3-96d235fdc75d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a5357b-b479-46a7-8c3a-d51ed8f71a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a5357b-b479-46a7-8c3a-d51ed8f71a17.jpg?1",
             "name": "Rushing-Tide Zubera",
             "text": "When Rushing-Tide Zubera is put into a graveyard from play, if 4 or more damage was dealt to it this turn, draw three cards.",
             "colours": [
@@ -1858,7 +1858,7 @@
         },
         {
             "id": "f77bd69d-3a33-59d8-b9e4-ca8d89f6fe9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2f54-3637-4caa-9741-36ff14dc5527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc2f54-3637-4caa-9741-36ff14dc5527.jpg?1",
             "name": "Sakashima the Impostor",
             "text": "As Sakashima the Impostor comes into play, you may choose a creature in play. If you do, Sakashima comes into play as a copy of that creature, except its name is still Sakashima the Impostor, it's still legendary, and it gains \"{2}{U}{U}: Return Sakashima the Impostor to its owner's hand at end of turn.\"",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "b3122445-9168-5c19-a038-7aac31098434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03247e03-747a-462a-ad74-49ce02d20f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03247e03-747a-462a-ad74-49ce02d20f13.jpg?1",
             "name": "Secretkeeper",
             "text": "As long as you have more cards in hand than each opponent, Secretkeeper gets +2/+2 and has flying.",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "0cb46eb0-f1fe-5720-ad7a-fa8661021644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a4871-8bc3-4db0-9f9e-b2e96b90ebd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2a4871-8bc3-4db0-9f9e-b2e96b90ebd5.jpg?1",
             "name": "Shape Stealer",
             "text": "Whenever Shape Stealer blocks or becomes blocked by a creature, change Shape Stealer's power and toughness to that creature's power and toughness until end of turn.",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "a7e9789e-2e6e-573e-b5e9-48322daa38bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbe44b0-e770-41f2-b91c-c574976e6b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbe44b0-e770-41f2-b91c-c574976e6b53.jpg?1",
             "name": "Shifting Borders",
             "text": "Exchange control of two target lands.\nSplice onto Arcane {3}{U} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -1998,7 +1998,7 @@
         },
         {
             "id": "efe9c770-594a-5182-bc65-b570bd4396db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cdad5d-5979-4bbd-90a4-00173d23707b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67cdad5d-5979-4bbd-90a4-00173d23707b.jpg?1",
             "name": "Shinen of Flight's Wings",
             "text": "Flying\nChannel {U}, Discard Shinen of Flight's Wings: Target creature gains flying until end of turn.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "a3a371da-1e66-5aaf-84fc-6713279758a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56de23d-7281-42f9-afce-7a81438dae5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56de23d-7281-42f9-afce-7a81438dae5d.jpg?1",
             "name": "Soramaro, First to Dream",
             "text": "Flying\nSoramaro, First to Dream's power and toughness are each equal to the number of cards in your hand.\n{4}, Return a land you control to its owner's hand: Draw a card.",
             "colours": [
@@ -2068,7 +2068,7 @@
         },
         {
             "id": "ceee8fed-43d1-5325-b053-ff93ecf85a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee63cba4-ab12-4adb-8463-d42edbf5794d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee63cba4-ab12-4adb-8463-d42edbf5794d.jpg?1",
             "name": "Trusted Advisor",
             "text": "Your maximum hand size is increased by two.\nAt the beginning of your upkeep, return a blue creature you control to its owner's hand.",
             "colours": [
@@ -2103,7 +2103,7 @@
         },
         {
             "id": "917e520a-728c-503d-bd27-63138d5b8788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a367559-1d84-4f6f-9e6e-ff90de420389.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a367559-1d84-4f6f-9e6e-ff90de420389.jpg?1",
             "name": "Twincast",
             "text": "Copy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -2135,7 +2135,7 @@
         },
         {
             "id": "686d7b2a-2195-5e23-bae6-db20e4c92b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08730b49-e51e-4868-9cc8-4ddc4a1dce4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08730b49-e51e-4868-9cc8-4ddc4a1dce4c.jpg?1",
             "name": "Akuta, Born of Ash",
             "text": "Haste\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may sacrifice a Swamp. If you do, return Akuta, Born of Ash from your graveyard to play.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "66fa580f-31db-5a9c-9f78-f6552a769851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05939f15-2d95-47df-b66f-131c3e7ea95f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05939f15-2d95-47df-b66f-131c3e7ea95f.jpg?1",
             "name": "Choice of Damnations",
             "text": "Target opponent chooses a number. You may have that player lose that much life. If you don't, that player sacrifices all but that many permanents.",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "0fd5a0d2-f53c-5ef8-b582-ac0adc05f402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f66ddc5-f5e6-44de-8189-87b6521d1fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f66ddc5-f5e6-44de-8189-87b6521d1fea.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "212c697a-3cfb-5b12-a4ed-13803ca4e3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31ca907-a274-436e-8433-7f11b0303f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31ca907-a274-436e-8433-7f11b0303f75.jpg?1",
             "name": "Death of a Thousand Stings",
             "text": "Target player loses 1 life and you gain 1 life.\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may return Death of a Thousand Stings from your graveyard to your hand.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "c5d874b8-9bfd-55a1-aa51-9250d08a2547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09535c14-ae50-4528-b9db-7eacee14e3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09535c14-ae50-4528-b9db-7eacee14e3fa.jpg?1",
             "name": "Deathknell Kami",
             "text": "Flying\n{2}: Deathknell Kami gets +1/+1 until end of turn. Sacrifice it at end of turn.\nSoulshift 1 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 1 or less from your graveyard to your hand.)",
             "colours": [
@@ -2307,7 +2307,7 @@
         },
         {
             "id": "8491afc1-c329-5db6-a19f-af843c315731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743e38d1-b1cd-4828-ad3d-529a9f882115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743e38d1-b1cd-4828-ad3d-529a9f882115.jpg?1",
             "name": "Deathmask Nezumi",
             "text": "As long as you have seven or more cards in hand, Deathmask Nezumi gets +2/+1 and has fear.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "c09716da-5eb7-5699-a1ea-7f06facc4a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6ac32c-9555-4408-8b18-c3098802b7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d6ac32c-9555-4408-8b18-c3098802b7ad.jpg?1",
             "name": "Exile into Darkness",
             "text": "Target player sacrifices a creature with converted mana cost 3 or less.\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may return Exile into Darkness from your graveyard to your hand.",
             "colours": [
@@ -2374,7 +2374,7 @@
         },
         {
             "id": "9b77b501-2875-5b1d-99e5-196bb5d63dd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7bedbe-8b87-402f-9a0c-83e46ae10279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca7bedbe-8b87-402f-9a0c-83e46ae10279.jpg?1",
             "name": "Footsteps of the Goryo",
             "text": "Return target creature card from your graveyard to play. Sacrifice that creature at end of turn.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "25371b7f-a3e1-574f-b4f2-7e8189f8afc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3cc092-b673-4f4e-b9a8-8e60ff562dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3cc092-b673-4f4e-b9a8-8e60ff562dbd.jpg?1",
             "name": "Ghost-Lit Stalker",
             "text": "{4}{B}, {T}: Target player discards two cards. Play this ability only any time you could play a sorcery.\nChannel {5}{B}{B}, Discard Ghost-Lit Stalker: Target player discards four cards. Play this ability only any time you could play a sorcery.",
             "colours": [
@@ -2442,7 +2442,7 @@
         },
         {
             "id": "d7e609ab-4bca-5aa2-bfa8-d6df6e082c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c51ee1-d6f6-42d7-9be6-fe3f982984ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1c51ee1-d6f6-42d7-9be6-fe3f982984ba.jpg?1",
             "name": "Gnat Miser",
             "text": "Each opponent's maximum hand size is reduced by one.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "d3635841-cb11-548f-b79f-a3f58f2256cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee194055-579a-4977-900e-e976259552ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee194055-579a-4977-900e-e976259552ab.jpg?1",
             "name": "Hand of Cruelty",
             "text": "Protection from white\nBushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)",
             "colours": [
@@ -2512,7 +2512,7 @@
         },
         {
             "id": "458e0088-f8f6-5f23-83ed-9e6251b4bed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79e7a4c-e0e7-42ac-b125-1db2f3d9325c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c79e7a4c-e0e7-42ac-b125-1db2f3d9325c.jpg?1",
             "name": "Infernal Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, target player reveals his or her hand and discards all cards with that spell's converted mana cost.",
             "colours": [
@@ -2549,7 +2549,7 @@
         },
         {
             "id": "98b15dfb-31ed-5839-8b48-ace61a8881e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f8672-1c37-4ab2-b290-fe3147784475.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752f8672-1c37-4ab2-b290-fe3147784475.jpg?1",
             "name": "Kagemaro, First to Suffer",
             "text": "Kagemaro, First to Suffer's power and toughness are each equal to the number of cards in your hand.\n{B}, Sacrifice Kagemaro: All creatures get -X/-X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "a5318b1f-2c2a-516e-8ada-581d4d21a5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe4bb8d-bed8-4373-af9d-9332de910e06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe4bb8d-bed8-4373-af9d-9332de910e06.jpg?1",
             "name": "Kagemaro's Clutch",
             "text": "Enchanted creature gets -X/-X, where X is the number of cards in your hand.",
             "colours": [
@@ -2620,7 +2620,7 @@
         },
         {
             "id": "dfd47231-0365-5014-a91c-ca186bf55a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30502f07-760c-46d1-8b4a-d4bd4a23201f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30502f07-760c-46d1-8b4a-d4bd4a23201f.jpg?1",
             "name": "Kami of Empty Graves",
             "text": "Soulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -2654,7 +2654,7 @@
         },
         {
             "id": "71bf2c6b-62e5-58b1-bfc7-640ef820958d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eed13fd-68be-4bc3-af6a-d88baaf9c98d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eed13fd-68be-4bc3-af6a-d88baaf9c98d.jpg?1",
             "name": "Kemuri-Onna",
             "text": "When Kemuri-Onna comes into play, target player discards a card.\nWhenever you play a Spirit or Arcane spell, you may return Kemuri-Onna to its owner's hand.",
             "colours": [
@@ -2688,7 +2688,7 @@
         },
         {
             "id": "a7d623d4-7ad5-5d9f-a8b1-70cc36c78f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38700c7d-2f24-47e4-a899-d294daed5549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38700c7d-2f24-47e4-a899-d294daed5549.jpg?1",
             "name": "Kiku's Shadow",
             "text": "Target creature deals damage to itself equal to its power.",
             "colours": [
@@ -2720,7 +2720,7 @@
         },
         {
             "id": "49ffa332-1496-5f66-8aef-9cf5d5a08f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg?1",
             "name": "Kuon, Ogre Ascendant // Kuon's Essence",
             "text": "At end of turn, if three or more creatures were put into graveyards from play this turn, flip Kuon, Ogre Ascendant.",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "d0c5851b-c827-52ba-94b2-817c11ab212d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg?1",
             "name": "Kuon, Ogre Ascendant // Kuon's Essence",
             "text": "At the beginning of each player's upkeep, that player sacrifices a creature.",
             "colours": [
@@ -2791,7 +2791,7 @@
         },
         {
             "id": "ec2515eb-d62b-574b-8882-aea47553ad1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e301a46-f321-4fa6-a8c4-08dd4079a458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e301a46-f321-4fa6-a8c4-08dd4079a458.jpg?1",
             "name": "Kuro's Taken",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{1}{B}: Regenerate Kuro's Taken.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "d3ea72c5-fd09-5be5-9cfb-7f54af05cfa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bf4dda-0ce8-4e35-88d9-18a22400e6cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bf4dda-0ce8-4e35-88d9-18a22400e6cb.jpg?1",
             "name": "Locust Miser",
             "text": "Each opponent's maximum hand size is reduced by two.",
             "colours": [
@@ -2861,7 +2861,7 @@
         },
         {
             "id": "a3e7c8c8-507e-5901-b909-3bcc4fdd021e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2563fd68-afdd-466f-8137-0769565674bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2563fd68-afdd-466f-8137-0769565674bf.jpg?1",
             "name": "Maga, Traitor to Mortals",
             "text": "Maga, Traitor to Mortals comes into play with X +1/+1 counters on it.\nWhen Maga comes into play, target player loses life equal to the number of +1/+1 counters on it.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "f520c589-440d-588d-a478-79c33b1a96e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6776c-f286-4b43-8f5f-d70b5585e635.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6776c-f286-4b43-8f5f-d70b5585e635.jpg?1",
             "name": "Measure of Wickedness",
             "text": "At the end of your turn, sacrifice Measure of Wickedness and you lose 8 life.\nWhenever another card is put into your graveyard from anywhere, target opponent gains control of Measure of Wickedness.",
             "colours": [
@@ -2930,7 +2930,7 @@
         },
         {
             "id": "b210c855-c69f-5bd2-b2c5-499d660899b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f91f678-9d3a-4502-81a6-3e1676aa447a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f91f678-9d3a-4502-81a6-3e1676aa447a.jpg?1",
             "name": "Neverending Torment",
             "text": "Search target player's library for X cards, where X is the number of cards in your hand, and remove them from the game. Then that player shuffles his or her library.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability. You may choose a new target for the copy.)",
             "colours": [
@@ -2962,7 +2962,7 @@
         },
         {
             "id": "5563c3b0-801b-5a5b-84a8-02d18bc33616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5841fa-4f30-495a-b840-3ef5a2af8fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5841fa-4f30-495a-b840-3ef5a2af8fad.jpg?1",
             "name": "One with Nothing",
             "text": "Discard your hand.",
             "colours": [
@@ -2994,7 +2994,7 @@
         },
         {
             "id": "9fe682e0-1435-5b79-b635-ad6c75b1ba7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d16da68-85f6-4d54-9751-9cf046f5e99a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d16da68-85f6-4d54-9751-9cf046f5e99a.jpg?1",
             "name": "Pain's Reward",
             "text": "You bid any amount of life. In turn order, each player may top the high bid. The bidding ends if the high bid stands. The high bidder loses life equal to the high bid and draws four cards.",
             "colours": [
@@ -3026,7 +3026,7 @@
         },
         {
             "id": "b9a6e440-1fba-56d8-bd09-b33701dee284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d16271-9302-463b-938d-01dad0c3ce29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d16271-9302-463b-938d-01dad0c3ce29.jpg?1",
             "name": "Raving Oni-Slave",
             "text": "When Raving Oni-Slave comes into play, you lose 3 life if you don't control a Demon.\nWhen Raving Oni-Slave leaves play, you lose 3 life if you don't control a Demon.",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "35d466ea-6e8d-5614-bcb2-627fd01f8291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a44255-2f3e-4e0b-aeab-9d2385b2afcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92a44255-2f3e-4e0b-aeab-9d2385b2afcd.jpg?1",
             "name": "Razorjaw Oni",
             "text": "Black creatures can't block.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "71d059ab-4c6a-545d-8a24-225812478d44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762499b4-4b4f-456e-8a03-2de300b2db5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762499b4-4b4f-456e-8a03-2de300b2db5e.jpg?1",
             "name": "Shinen of Fear's Chill",
             "text": "Shinen of Fear's Chill can't block.\nChannel {1}{B}, Discard Shinen of Fear's Chill: Target creature can't block this turn.",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "2826aa27-c0fd-5341-9810-3de602ef0aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d519df1b-0c81-4d0d-85c6-2a288c6fa269.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d519df1b-0c81-4d0d-85c6-2a288c6fa269.jpg?1",
             "name": "Sink into Takenuma",
             "text": "Sweep Return any number of Swamps you control to their owner's hand. Target player discards a card for each Swamp returned this way.",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "acc0cdec-0527-53cb-8cfd-8453db66ac02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4b1bf-eef5-4a86-a861-be448845a743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da4b1bf-eef5-4a86-a861-be448845a743.jpg?1",
             "name": "Skull Collector",
             "text": "At the beginning of your upkeep, return a black creature you control to its owner's hand.\n{1}{B}: Regenerate Skull Collector.",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "77bb5961-5c9b-5b17-912f-0ead8d96ba9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2fa85ea-f5d5-4be3-a874-ce246c3e4245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2fa85ea-f5d5-4be3-a874-ce246c3e4245.jpg?1",
             "name": "Adamaro, First to Desire",
             "text": "Adamaro, First to Desire's power and toughness are each equal to the number of cards in the hand of the opponent with the most cards in hand.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "d93846c8-a142-5349-9833-6966fb5076be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb63254-5786-43fb-8ccd-132095a55e64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb63254-5786-43fb-8ccd-132095a55e64.jpg?1",
             "name": "Akki Drillmaster",
             "text": "{T}: Target creature gains haste until end of turn.",
             "colours": [
@@ -3270,7 +3270,7 @@
         },
         {
             "id": "c4ad8d78-01d4-5eda-8efb-dc60025e78d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106382db-56aa-4061-9d1e-17821937f1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106382db-56aa-4061-9d1e-17821937f1de.jpg?1",
             "name": "Akki Underling",
             "text": "As long as you have seven or more cards in hand, Akki Underling gets +2/+1 and has first strike.",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "15ea617d-824b-58c2-b3e8-3de06b65eed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c52e00-ad17-42aa-9f5f-38fb52dad5ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c52e00-ad17-42aa-9f5f-38fb52dad5ea.jpg?1",
             "name": "Barrel Down Sokenzan",
             "text": "Sweep Return any number of Mountains you control to their owner's hand. Barrel Down Sokenzan deals damage to target creature equal to twice the number of Mountains returned this way.",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "05dfaae7-cb91-5194-8da2-9b76bfe4d593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ca5c3-8367-4e08-a318-634f9d36dbdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ca5c3-8367-4e08-a318-634f9d36dbdc.jpg?1",
             "name": "Burning-Eye Zubera",
             "text": "When Burning-Eye Zubera is put into a graveyard from play, if 4 or more damage was dealt to it this turn, Burning-Eye Zubera deals 3 damage to target creature or player.",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "e2f971b9-7949-5fd0-9103-803c78090b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd2142-b41b-4456-9b76-bb83ba91e6be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fd2142-b41b-4456-9b76-bb83ba91e6be.jpg?1",
             "name": "Captive Flame",
             "text": "{R}: Target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -3406,7 +3406,7 @@
         },
         {
             "id": "3fea6f69-13aa-564f-9490-9c067ed545ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2391265f-ef0c-463f-9371-5a0b71dbbb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2391265f-ef0c-463f-9371-5a0b71dbbb49.jpg?1",
             "name": "Feral Lightning",
             "text": "Put three 3/1 red Elemental creature tokens with haste into play. Remove them from the game at end of turn.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "b9955a6d-2832-5347-a16f-3e1a7d9ce45e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44cab92a-54d8-496c-8a97-7f3448f5b1e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44cab92a-54d8-496c-8a97-7f3448f5b1e9.jpg?1",
             "name": "Gaze of Adamaro",
             "text": "Gaze of Adamaro deals damage equal to the number of cards in target player's hand to that player.",
             "colours": [
@@ -3472,7 +3472,7 @@
         },
         {
             "id": "484ba96b-c73b-5f1e-8c4c-3fa65bef8356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4280a08a-90fe-445e-b49d-1a3b13d3c6e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4280a08a-90fe-445e-b49d-1a3b13d3c6e9.jpg?1",
             "name": "Ghost-Lit Raider",
             "text": "{2}{R}, {T}: Ghost-Lit Raider deals 2 damage to target creature.\nChannel {3}{R}, Discard Ghost-Lit Raider: Ghost-Lit Raider deals 4 damage to target creature.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "dfe42161-8ee2-5529-91d2-e7ba54a7ffb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1519521-7f53-4f13-a104-daf52e8c7234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1519521-7f53-4f13-a104-daf52e8c7234.jpg?1",
             "name": "Glitterfang",
             "text": "Haste\nAt end of turn, return Glitterfang to its owner's hand.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "7527c7c0-cf4b-5267-b32e-b94030b3f57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a7afc5-be73-459d-8bd1-116a0bf1210f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a7afc5-be73-459d-8bd1-116a0bf1210f.jpg?1",
             "name": "Godo's Irregulars",
             "text": "{R}: Godo's Irregulars deals 1 damage to target creature blocking it.",
             "colours": [
@@ -3575,7 +3575,7 @@
         },
         {
             "id": "a7749e24-6c44-53f9-ad14-f41670406c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg?1",
             "name": "Hidetsugu's Second Rite",
             "text": "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "3042d741-2594-57e5-a2b8-31a290600128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg?1",
             "name": "Homura, Human Ascendant // Homura's Essence",
             "text": "Homura, Human Ascendant can't block.\nWhen Homura is put into a graveyard from play, return it to play flipped.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "8eafaf05-aa1a-5989-acf0-4e4a90becacb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg?1",
             "name": "Homura, Human Ascendant // Homura's Essence",
             "text": "Creatures you control get +2/+2 and have flying and \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -3678,7 +3678,7 @@
         },
         {
             "id": "01d336d3-c397-5734-8b77-e3b0539faa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce461f7-385d-4379-83de-49571247c30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce461f7-385d-4379-83de-49571247c30d.jpg?1",
             "name": "Iizuka the Ruthless",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{2}{R}, Sacrifice a Samurai: Samurai you control gain double strike until end of turn.",
             "colours": [
@@ -3715,7 +3715,7 @@
         },
         {
             "id": "eae2e636-a9d2-58a5-ade9-dcc86fee25fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d886a2-ae83-4d95-9ec0-582c563181e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d886a2-ae83-4d95-9ec0-582c563181e6.jpg?1",
             "name": "Inner Fire",
             "text": "Add {R} to your mana pool for each card in your hand.",
             "colours": [
@@ -3747,7 +3747,7 @@
         },
         {
             "id": "6bf9d80f-dc1c-5431-a92e-decd9040ef0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99d116c-41c0-41af-9a68-9ac995f3000b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99d116c-41c0-41af-9a68-9ac995f3000b.jpg?1",
             "name": "Into the Fray",
             "text": "Target creature attacks this turn if able.\nSplice onto Arcane {R} (As you play an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "248ae485-a58c-5801-a0ac-7bc8468dab01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b46105b-32c2-48fc-b71d-c3e8fcb8a8ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b46105b-32c2-48fc-b71d-c3e8fcb8a8ea.jpg?1",
             "name": "Jiwari, the Earth Aflame",
             "text": "{X}{R}, {T}: Jiwari, the Earth Aflame deals X damage to target creature without flying.\nChannel {X}{R}{R}{R}, Discard Jiwari: Jiwari deals X damage to each creature without flying.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "dc471b26-3316-5a34-9044-8573809054b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf61b5-cb7e-4303-a6b4-4abc8332fd58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf61b5-cb7e-4303-a6b4-4abc8332fd58.jpg?1",
             "name": "Oni of Wild Places",
             "text": "Haste\nAt the beginning of your upkeep, return a red creature you control to its owner's hand.",
             "colours": [
@@ -3852,7 +3852,7 @@
         },
         {
             "id": "8f6e6f3a-e446-59e6-99a5-3e315a3cc280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fd4b1-d3a4-4859-a0d4-0e8341e6c6c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046fd4b1-d3a4-4859-a0d4-0e8341e6c6c7.jpg?1",
             "name": "Path of Anger's Flame",
             "text": "Creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "e1755d26-6a47-59bc-883e-f948670cbcb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b292a8d2-44b1-4c20-8035-0f5912cc09a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b292a8d2-44b1-4c20-8035-0f5912cc09a4.jpg?1",
             "name": "Rally the Horde",
             "text": "Remove the top three cards of your library from the game. If the last card removed isn't a land, repeat this process until the last card removed is a land. Put a 1/1 red Warrior creature token into play for each nonland card removed from the game this way.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "603fc9c4-2f3e-5bea-9b2d-1e48fabb36dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c532e5a-01f4-4258-ba48-99257cc577d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c532e5a-01f4-4258-ba48-99257cc577d4.jpg?1",
             "name": "Ronin Cavekeeper",
             "text": "Bushido 2 (When this blocks or becomes blocked, it gets +2/+2 until end of turn.)",
             "colours": [
@@ -3953,7 +3953,7 @@
         },
         {
             "id": "9e1f6104-8d97-5560-abbd-908c33fa71eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c05acc-7cb2-4a06-9e6f-cb9419298385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c05acc-7cb2-4a06-9e6f-cb9419298385.jpg?1",
             "name": "Shinen of Fury's Fire",
             "text": "Haste\nChannel {R}, Discard Shinen of Fury's Fire: Target creature gains haste until end of turn.",
             "colours": [
@@ -3987,7 +3987,7 @@
         },
         {
             "id": "f71b6680-e76f-5f5d-adca-d8b0861f830a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d425562-3f0f-4aa3-a761-48ba445b8380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d425562-3f0f-4aa3-a761-48ba445b8380.jpg?1",
             "name": "Skyfire Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may gain control of target creature with that spell's converted mana cost until end of turn.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "d11bc4d7-ca7d-5bbc-ba0c-e49aadee6ad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9b3164-3de2-4b25-88d0-2dffee32148a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9b3164-3de2-4b25-88d0-2dffee32148a.jpg?1",
             "name": "Sokenzan Renegade",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\nAt the beginning of your upkeep, if a player has more cards in hand than any other, the player with the most cards in hand gains control of Sokenzan Renegade.",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "0576cb0b-3ce1-5d94-8047-eb3babb5b9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500eeccb-aee2-48d4-8a43-bb9668f1c1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/500eeccb-aee2-48d4-8a43-bb9668f1c1ab.jpg?1",
             "name": "Sokenzan Spellblade",
             "text": "Bushido 1 (When this blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{1}{R}: Sokenzan Spellblade gets +X/+0 until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -4096,7 +4096,7 @@
         },
         {
             "id": "fa9a03aa-4bf6-530f-85c8-db98a7ffbca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73503423-30d8-42bc-a697-6d986e4945c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73503423-30d8-42bc-a697-6d986e4945c8.jpg?1",
             "name": "Spiraling Embers",
             "text": "Spiraling Embers deals damage to target creature or player equal to the number of cards in your hand.",
             "colours": [
@@ -4130,7 +4130,7 @@
         },
         {
             "id": "32f1acbc-f33a-57ee-8a4d-ea9ab03bed67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46783ba7-6e23-43d0-b5aa-9a0ea75cfb67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46783ba7-6e23-43d0-b5aa-9a0ea75cfb67.jpg?1",
             "name": "Sunder from Within",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4164,7 +4164,7 @@
         },
         {
             "id": "14b5b31b-9d31-58ee-b630-fd7a36c78c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0f2db3-41a6-4283-9812-46b6ae6d1df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0f2db3-41a6-4283-9812-46b6ae6d1df6.jpg?1",
             "name": "Thoughts of Ruin",
             "text": "Each player sacrifices a land for each card in your hand.",
             "colours": [
@@ -4196,7 +4196,7 @@
         },
         {
             "id": "fef17dfb-64dd-58f4-acd0-919f5b917ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606206c7-1a8a-46f4-b368-cf18e02f3df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606206c7-1a8a-46f4-b368-cf18e02f3df8.jpg?1",
             "name": "Undying Flames",
             "text": "Remove cards from the top of your library from the game until you remove a nonland card. Undying Flames deals damage to target creature or player equal to that card's converted mana cost.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability. You may choose a new target for the copy.)",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "0b9bcf1c-36a3-5aba-86d8-27757b5acbed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c6e1cd-e25d-41ff-a918-c495998376d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c6e1cd-e25d-41ff-a918-c495998376d8.jpg?1",
             "name": "Yuki-Onna",
             "text": "When Yuki-Onna comes into play, destroy target artifact.\nWhenever you play a Spirit or Arcane spell, you may return Yuki-Onna to its owner's hand.",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "fe0e210f-1b0b-5caa-8a2e-f7febf6681f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d627b2-5298-45f5-acd2-56de59209820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d627b2-5298-45f5-acd2-56de59209820.jpg?1",
             "name": "Arashi, the Sky Asunder",
             "text": "{X}{G}, {T}: Arashi, the Sky Asunder deals X damage to target creature with flying.\nChannel {X}{G}{G}, Discard Arashi: Arashi deals X damage to each creature with flying.",
             "colours": [
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "2fc6e0bd-9573-50e5-94bc-9087ace3e12f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f037520e-2a44-4650-b7cb-c81d93d1418d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f037520e-2a44-4650-b7cb-c81d93d1418d.jpg?1",
             "name": "Ayumi, the Last Visitor",
             "text": "Legendary landwalk",
             "colours": [
@@ -4334,7 +4334,7 @@
         },
         {
             "id": "1c9dd6de-a49a-5a07-a8b6-b083b932ea98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fe65e-81b1-4e69-913a-25fc99d96d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fe65e-81b1-4e69-913a-25fc99d96d81.jpg?1",
             "name": "Bounteous Kirin",
             "text": "Flying\nWhenever you play a Spirit or Arcane spell, you may gain life equal to that spell's converted mana cost.",
             "colours": [
@@ -4371,7 +4371,7 @@
         },
         {
             "id": "6dbf623f-a046-55f4-aa77-9ed3a046b1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c042f8b-df20-48c1-a291-4d7e1bc5b384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c042f8b-df20-48c1-a291-4d7e1bc5b384.jpg?1",
             "name": "Briarknit Kami",
             "text": "Whenever you play a Spirit or Arcane spell, put a +1/+1 counter on target creature.",
             "colours": [
@@ -4405,7 +4405,7 @@
         },
         {
             "id": "cd1b88da-8c0c-50d7-9e55-90f5154bbde8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1480d4-51f8-4233-874c-94502726fe0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d1480d4-51f8-4233-874c-94502726fe0d.jpg?1",
             "name": "Dense Canopy",
             "text": "Creatures with flying can't block creatures without flying.",
             "colours": [
@@ -4437,7 +4437,7 @@
         },
         {
             "id": "5d28aec1-4181-58e6-a3fa-d6d521a35870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7512d74-4330-4de7-9c0c-4bb7f37f6066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7512d74-4330-4de7-9c0c-4bb7f37f6066.jpg?1",
             "name": "Descendant of Masumaro",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on Descendant of Masumaro for each card in your hand, then remove a +1/+1 counter from Descendant of Masumaro for each card in target opponent's hand.",
             "colours": [
@@ -4472,7 +4472,7 @@
         },
         {
             "id": "4eecc672-693f-500f-be40-89c188f22a38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b525f824-fcce-48cc-887d-98d4058b1d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b525f824-fcce-48cc-887d-98d4058b1d31.jpg?1",
             "name": "Dosan's Oldest Chant",
             "text": "You gain 6 life.\nDraw a card.",
             "colours": [
@@ -4504,7 +4504,7 @@
         },
         {
             "id": "272e6888-1403-59d9-973b-c9843e341e71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c3e47b-a788-46b7-bf15-1216692e637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51c3e47b-a788-46b7-bf15-1216692e637a.jpg?1",
             "name": "Elder Pine of Jukai",
             "text": "Whenever you play a Spirit or Arcane spell, reveal the top three cards of your library. Put all land cards revealed this way into your hand and the rest on the bottom of your library in any order.\nSoulshift 2",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "468dcf22-2c6a-507c-9a7b-7af7b389ca6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64d9404-9685-495d-a591-63d6164a88a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f64d9404-9685-495d-a591-63d6164a88a9.jpg?1",
             "name": "Endless Swarm",
             "text": "Put a 1/1 green Snake creature token into play for each card in your hand.\nEpic (For the rest of the game, you can't play spells. At the beginning of each of your upkeeps, copy this spell except for its epic ability.)",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "71aa5daf-60f6-5557-b4bc-c4c95cf6c29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328ac4-1b7d-4310-9798-8c8dc8740062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db328ac4-1b7d-4310-9798-8c8dc8740062.jpg?1",
             "name": "Fiddlehead Kami",
             "text": "Whenever you play a Spirit or Arcane spell, regenerate Fiddlehead Kami.",
             "colours": [
@@ -4604,7 +4604,7 @@
         },
         {
             "id": "a1e45812-50b1-519e-afda-665c313c42db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4becdbb-9089-4c54-a681-6510d90cc99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4becdbb-9089-4c54-a681-6510d90cc99e.jpg?1",
             "name": "Ghost-Lit Nourisher",
             "text": "{2}{G}, {T}: Target creature gets +2/+2 until end of turn.\nChannel {3}{G}, Discard Ghost-Lit Nourisher: Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "f999f824-6aea-5af4-b1b2-2fef88e3b427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaacab4-f13b-4189-ac78-89fc4cdbaa55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceaacab4-f13b-4189-ac78-89fc4cdbaa55.jpg?1",
             "name": "Haru-Onna",
             "text": "When Haru-Onna comes into play, draw a card.\nWhenever you play a Spirit or Arcane spell, you may return Haru-Onna to its owner's hand.",
             "colours": [
@@ -4672,7 +4672,7 @@
         },
         {
             "id": "3923a10a-cf14-59b5-9d76-bea606c6ffc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f56817-aabf-469c-a82c-37315decc73c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f56817-aabf-469c-a82c-37315decc73c.jpg?1",
             "name": "Inner Calm, Outer Strength",
             "text": "Target creature gets +X/+X until end of turn, where X is the number of cards in your hand.",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "e93d31ce-2c80-532e-8f01-e43f9a71f658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedd830-9200-4e8b-84b4-00dc58cace35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdedd830-9200-4e8b-84b4-00dc58cace35.jpg?1",
             "name": "Kami of the Tended Garden",
             "text": "At the beginning of your upkeep, sacrifice Kami of the Tended Garden unless you pay {G}.\nSoulshift 3 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 3 or less from your graveyard to your hand.)",
             "colours": [
@@ -4740,7 +4740,7 @@
         },
         {
             "id": "a2cdb75a-ef0f-5926-a72e-253783a8e2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12adf2d-ebf9-464e-9957-c8518d364a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d12adf2d-ebf9-464e-9957-c8518d364a40.jpg?1",
             "name": "Kashi-Tribe Elite",
             "text": "Legendary Snakes you control can't be the targets of spells or abilities.\nWhenever Kashi-Tribe Elite deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -4775,7 +4775,7 @@
         },
         {
             "id": "3a32a637-2df7-5a87-867d-08d0dbee9b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4625b7-c8b1-4fdf-af9f-935313436b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4625b7-c8b1-4fdf-af9f-935313436b35.jpg?1",
             "name": "Masumaro, First to Live",
             "text": "Masumaro, First to Live's power and toughness are each equal to twice the number of cards in your hand.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "94acbe44-aa68-5048-a64b-00d2dd84fceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1afb0c0-e138-4d2b-b3aa-fa40778f8d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1afb0c0-e138-4d2b-b3aa-fa40778f8d79.jpg?1",
             "name": "Matsu-Tribe Birdstalker",
             "text": "Whenever Matsu-Tribe Birdstalker deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.\n{G}: Matsu-Tribe Birdstalker may block as though it had flying until end of turn.",
             "colours": [
@@ -4847,7 +4847,7 @@
         },
         {
             "id": "b3a6837a-0863-540b-8b87-afc9fe0dab3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0797186-01ae-4de0-b188-7fc3079b2800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0797186-01ae-4de0-b188-7fc3079b2800.jpg?1",
             "name": "Molting Skin",
             "text": "Return Molting Skin to its owner's hand: Regenerate target creature.",
             "colours": [
@@ -4879,7 +4879,7 @@
         },
         {
             "id": "cd2c7a36-876c-56d5-8e90-59ab90ee4c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5902f863-171e-4bb2-9d48-2c679d41f1a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5902f863-171e-4bb2-9d48-2c679d41f1a9.jpg?1",
             "name": "Nightsoil Kami",
             "text": "Soulshift 5 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 5 or less from your graveyard to your hand.)",
             "colours": [
@@ -4913,7 +4913,7 @@
         },
         {
             "id": "85de6f7e-02d0-50c1-9f04-0d1bcdae816c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eea50b1-ba6e-4c57-9b49-488b883be638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eea50b1-ba6e-4c57-9b49-488b883be638.jpg?1",
             "name": "Okina Nightwatch",
             "text": "As long as you have more cards in hand than each opponent, Okina Nightwatch gets +3/+3.",
             "colours": [
@@ -4948,7 +4948,7 @@
         },
         {
             "id": "55b6b7c2-f908-524c-94b4-bfd4f2d65842",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aac4236-9573-4cff-88d9-711a56da4346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aac4236-9573-4cff-88d9-711a56da4346.jpg?1",
             "name": "Promised Kannushi",
             "text": "Soulshift 7 (When this is put into a graveyard from play, you may return target Spirit card with converted mana cost 7 or less from your graveyard to your hand.)",
             "colours": [
@@ -4983,7 +4983,7 @@
         },
         {
             "id": "531f8101-00c4-542b-860b-19acd2906eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86317339-5a39-41eb-8aee-5ea926da8cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86317339-5a39-41eb-8aee-5ea926da8cd4.jpg?1",
             "name": "Reki, the History of Kamigawa",
             "text": "Whenever you play a legendary spell, draw a card.",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "1e33a9e9-915e-574f-8be2-31bcff029695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cf7931-d086-496e-98dc-5daa60e01f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cf7931-d086-496e-98dc-5daa60e01f5b.jpg?1",
             "name": "Rending Vines",
             "text": "Destroy target artifact or enchantment if its converted mana cost is less than or equal to the number of cards in your hand.\nDraw a card.",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "7755e874-4941-53e3-b414-eb7a6d2a9687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbdda50-8a27-4094-849d-b6f66def82ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbdda50-8a27-4094-849d-b6f66def82ce.jpg?1",
             "name": "Sakura-Tribe Scout",
             "text": "{T}: You may put a land card from your hand into play.",
             "colours": [
@@ -5090,7 +5090,7 @@
         },
         {
             "id": "1bc88089-68cc-56e6-a9d1-1617556f60c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg?1",
             "name": "Sasaya, Orochi Ascendant // Sasaya's Essence",
             "text": "Reveal your hand: If you have seven or more land cards in your hand, flip Sasaya, Orochi Ascendant.",
             "colours": [
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "36ba5bdd-881e-5282-8484-20a0eb0a095f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg?1",
             "name": "Sasaya, Orochi Ascendant // Sasaya's Essence",
             "text": "Whenever a land you control is tapped for mana, add one mana of that type to your mana pool for each other land you control with the same name.",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "dd616938-89f1-5569-b7fb-cb0b504a8d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b0a4e-e52e-4d4e-9b12-24676d8571b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b0a4e-e52e-4d4e-9b12-24676d8571b1.jpg?1",
             "name": "Seed the Land",
             "text": "Whenever a land comes into play, its controller puts a 1/1 green Snake creature token into play.",
             "colours": [
@@ -5193,7 +5193,7 @@
         },
         {
             "id": "fc701702-baea-5faa-a9c3-8ceff1668fe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f8a9e7-f505-4fc5-b820-0af1ee1960c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f8a9e7-f505-4fc5-b820-0af1ee1960c7.jpg?1",
             "name": "Seek the Horizon",
             "text": "Search your library for up to three basic land cards, reveal them, and put them into your hand. Then shuffle your library.",
             "colours": [
@@ -5225,7 +5225,7 @@
         },
         {
             "id": "3a93180d-50d2-5790-a02c-d908cc78045d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9883e973-54c3-4bec-91d8-22f2829cdfa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9883e973-54c3-4bec-91d8-22f2829cdfa2.jpg?1",
             "name": "Sekki, Seasons' Guide",
             "text": "Sekki, Seasons' Guide comes into play with eight +1/+1 counters on it.\nIf damage would be dealt to Sekki, prevent that damage, remove that many +1/+1 counters from Sekki, and put that many 1/1 colorless Spirit creature tokens into play.\nSacrifice eight Spirits: Return Sekki from your graveyard to play.",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "5c5bda93-a963-55a8-bb8e-72ff0ca0f4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d9516-7275-40df-8989-418933671263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a77d9516-7275-40df-8989-418933671263.jpg?1",
             "name": "Shinen of Life's Roar",
             "text": "All creatures able to block Shinen of Life's Roar do so.\nChannel {2}{G}{G}, Discard Shinen of Life's Roar: All creatures able to block target creature this turn do so.",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "b87a0578-930a-5a70-9a4c-01e9172e5808",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c63065-6051-4193-8457-713a8a800393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c63065-6051-4193-8457-713a8a800393.jpg?1",
             "name": "Stampeding Serow",
             "text": "Trample\nAt the beginning of your upkeep, return a green creature you control to its owner's hand.",
             "colours": [
@@ -5330,7 +5330,7 @@
         },
         {
             "id": "190237cd-da91-5ab4-8964-4bdb227b2a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e13f122-0dfe-42f3-9815-9ae1a29fca99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e13f122-0dfe-42f3-9815-9ae1a29fca99.jpg?1",
             "name": "Iname as One",
             "text": "When Iname as One comes into play, if you played it from your hand, you may search your library for a Spirit card, put it into play, then shuffle your library.\nWhen Iname as One is put into a graveyard from play, you may remove it from the game. If you do, return target Spirit card from your graveyard to play.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "7b3abb16-afac-573b-bced-b666147f7cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59df09f-d8b9-4398-a705-329b768d5004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59df09f-d8b9-4398-a705-329b768d5004.jpg?1",
             "name": "Ashes of the Fallen",
             "text": "As Ashes of the Fallen comes into play, choose a creature type.\nEach creature card in your graveyard has the chosen creature type in addition to its other types.",
             "colours": [],
@@ -5396,7 +5396,7 @@
         },
         {
             "id": "735d28b5-1718-5f4d-81e2-80fba800cae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28328b4d-99d1-4460-9bbe-a64c6c0b6cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28328b4d-99d1-4460-9bbe-a64c6c0b6cb2.jpg?1",
             "name": "Blood Clock",
             "text": "At the beginning of each player's upkeep, that player returns a permanent he or she controls to its owner's hand unless he or she pays 2 life.",
             "colours": [],
@@ -5424,7 +5424,7 @@
         },
         {
             "id": "eaa7fb58-2c5f-5ac5-a444-94a11eef40fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e0c24f-2312-4b40-9cd1-2b83d501e485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39e0c24f-2312-4b40-9cd1-2b83d501e485.jpg?1",
             "name": "Ebony Owl Netsuke",
             "text": "At the beginning of each opponent's upkeep, if that player has seven or more cards in hand, Ebony Owl Netsuke deals 4 damage to him or her.",
             "colours": [],
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "9c8d26dd-275d-5fb3-9fd2-7ae30e5b069c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd84d1a-1e74-4779-996f-f8518f0b5f8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd84d1a-1e74-4779-996f-f8518f0b5f8c.jpg?1",
             "name": "Ivory Crane Netsuke",
             "text": "At the beginning of your upkeep, if you have seven or more cards in hand, you gain 4 life.",
             "colours": [],
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "ae650f5e-d078-50f1-935a-0e01e82971b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc6542b-7672-4ea1-816c-33bc0c300f3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc6542b-7672-4ea1-816c-33bc0c300f3c.jpg?1",
             "name": "Manriki-Gusari",
             "text": "Equipped creature gets +1/+2 and has \"{T}: Destroy target Equipment.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "b0679358-a150-5a55-8541-c9bef0fc9e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a353d5-d3b1-4ec1-8f2e-792f1bc79c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a353d5-d3b1-4ec1-8f2e-792f1bc79c96.jpg?1",
             "name": "O-Naginata",
             "text": "O-Naginata can be attached only to a creature with 3 or more power.\nEquipped creature gets +3/+0 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "a6cf6b0a-947f-59b6-82b7-2d059734dc4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb9e1d-113e-45ff-8435-32ee42fa5631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78eb9e1d-113e-45ff-8435-32ee42fa5631.jpg?1",
             "name": "Pithing Needle",
             "text": "As Pithing Needle comes into play, name a card.\nActivated abilities of the named card can't be played unless they're mana abilities.",
             "colours": [],
@@ -5568,7 +5568,7 @@
         },
         {
             "id": "d6e1cad5-116a-51a0-8df7-17012f23b63c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b39d20-47b5-468b-aaf8-f6b7c7048b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b39d20-47b5-468b-aaf8-f6b7c7048b33.jpg?1",
             "name": "Scroll of Origins",
             "text": "{2}, {T}: Draw a card if you have seven or more cards in hand.",
             "colours": [],
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "04f14233-36f5-5724-bc59-9d66114d7e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e6129a-fa5c-4e27-a4d4-cbde7392164b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25e6129a-fa5c-4e27-a4d4-cbde7392164b.jpg?1",
             "name": "Soratami Cloud Chariot",
             "text": "{2}: Target creature you control gains flying until end of turn.\n{2}: Prevent all combat damage that would be dealt to and dealt by target creature you control this turn.",
             "colours": [],
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "d911812a-7531-5935-a707-0a7240629679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6f80dc-72a4-409b-bc92-69fa3885cd6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6f80dc-72a4-409b-bc92-69fa3885cd6d.jpg?1",
             "name": "Wine of Blood and Iron",
             "text": "{4}: Target creature gets +X/+0 until end of turn, where X is its power. Sacrifice Wine of Blood and Iron at end of turn.",
             "colours": [],
@@ -5652,7 +5652,7 @@
         },
         {
             "id": "1d36b391-2f1b-5d3a-b708-00f6f8c473bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef72797-328e-4303-8ffb-9686086648b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ef72797-328e-4303-8ffb-9686086648b8.jpg?1",
             "name": "Mikokoro, Center of the Sea",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Each player draws a card.",
             "colours": [],
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "427a56ab-56e5-5468-a8d3-01ccd25413ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d414f0-15ae-446b-a8d7-56c1b502740c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53d414f0-15ae-446b-a8d7-56c1b502740c.jpg?1",
             "name": "Miren, the Moaning Well",
             "text": "{T}: Add {1} to your mana pool.\n{3}, {T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [],
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "e07e29db-b50f-5ff7-a8c2-c0d0ba6a6404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc2d68e-6543-43ec-b67a-afff1325a32f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc2d68e-6543-43ec-b67a-afff1325a32f.jpg?1",
             "name": "Oboro, Palace in the Clouds",
             "text": "{T}: Add {U} to your mana pool.\n{1}: Return Oboro, Palace in the Clouds to its owner's hand.",
             "colours": [],
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "c0c920ea-7b9b-5bef-b095-553d817d3745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fedf90-825c-4814-8f0d-170f537db44c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fedf90-825c-4814-8f0d-170f537db44c.jpg?1",
             "name": "Tomb of Urami",
             "text": "{T}: Add {B} to your mana pool. Tomb of Urami deals 1 damage to you if you don't control an Ogre.\n{2}{B}{B}, {T}, Sacrifice all lands you control: Put a legendary 5/5 black Demon Spirit creature token with flying named Urami into play.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/SOM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/SOM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "116a354a-aa21-5431-89a1-2891d8040895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e17bbf7-00c0-46f2-9718-2762fd7388d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e17bbf7-00c0-46f2-9718-2762fd7388d3.jpg?1",
             "name": "Abuna Acolyte",
             "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.\n{T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "3d90e43f-e4c2-5c2a-a68c-5529d94f421a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52d6cf9-1d92-4d3b-8631-0db19a073b44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52d6cf9-1d92-4d3b-8631-0db19a073b44.jpg?1",
             "name": "Arrest",
             "text": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "669585f9-c691-500c-a677-624dbf634362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f76b18a-396b-41f5-b34b-ac232b7f316b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f76b18a-396b-41f5-b34b-ac232b7f316b.jpg?1",
             "name": "Auriok Edgewright",
             "text": "Metalcraft \u2014 Auriok Edgewright has double strike as long as you control three or more artifacts.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "edd41970-82c5-5af9-80cb-e1523fbf1eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e274a8b3-2d92-43d9-a436-d3f6f619ca95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e274a8b3-2d92-43d9-a436-d3f6f619ca95.jpg?1",
             "name": "Auriok Sunchaser",
             "text": "Metalcraft \u2014 As long as you control three or more artifacts, Auriok Sunchaser gets +2/+2 and has flying.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "a1865a89-27bd-53cc-a0be-3aa8efed372b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3330a1-98b6-4b09-9bca-6c7c89447ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b3330a1-98b6-4b09-9bca-6c7c89447ba2.jpg?1",
             "name": "Dispense Justice",
             "text": "Target player sacrifices an attacking creature.\nMetalcraft \u2014 That player sacrifices two attacking creatures instead if you control three or more artifacts.",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "4883a163-501c-56cc-8b5a-4e6e402852c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9116e-7b04-4f2a-aa67-89a42c6e1801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9116e-7b04-4f2a-aa67-89a42c6e1801.jpg?1",
             "name": "Elspeth Tirel",
             "text": "+2: You gain 1 life for each creature you control.\n-2: Put three 1/1 white Soldier creature tokens onto the battlefield.\n-5: Destroy all other permanents except\nfor lands and tokens.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "3f30989f-bdab-5578-a0ac-7dad0f7c7b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33a8cf1-e413-4633-b348-2ef594a945a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c33a8cf1-e413-4633-b348-2ef594a945a5.jpg?1",
             "name": "Fulgent Distraction",
             "text": "Choose two target creatures. Tap those creatures, then unattach all Equipment from them.",
             "colours": [
@@ -243,7 +243,7 @@
         },
         {
             "id": "c3a4e163-c1a1-596f-bfaf-f435743210ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbf5ff1-6539-4116-ad4f-ce412ae20640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efbf5ff1-6539-4116-ad4f-ce412ae20640.jpg?1",
             "name": "Ghalma's Warden",
             "text": "Metalcraft \u2014 Ghalma's Warden gets +2/+2 as long as you control three or more artifacts.",
             "colours": [
@@ -278,7 +278,7 @@
         },
         {
             "id": "94b5d736-be66-5e2f-898a-28ab71761d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb553f3-b1f6-47e7-94c1-8c09410c7163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fb553f3-b1f6-47e7-94c1-8c09410c7163.jpg?1",
             "name": "Glimmerpoint Stag",
             "text": "Vigilance\nWhen Glimmerpoint Stag enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -312,7 +312,7 @@
         },
         {
             "id": "81f8333a-4dd1-539f-a9a7-d2c0587ca188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c4710-4183-4743-9c8b-515cc98cbbb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/284c4710-4183-4743-9c8b-515cc98cbbb8.jpg?1",
             "name": "Glint Hawk",
             "text": "Flying\nWhen Glint Hawk enters the battlefield, sacrifice it unless you return an artifact you control to its owner's hand.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "fc1ec09b-a727-5440-8198-ab866950d00c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50e72a2-1e94-43cf-a605-bf3bb456d12f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50e72a2-1e94-43cf-a605-bf3bb456d12f.jpg?1",
             "name": "Indomitable Archangel",
             "text": "Flying\nMetalcraft \u2014 Artifacts you control have shroud as long as you control three or more artifacts.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "5897dad3-3ccc-5809-b99f-644088a20827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1964ca48-3260-4e2d-9014-984c1efc9a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1964ca48-3260-4e2d-9014-984c1efc9a43.jpg?1",
             "name": "Kemba, Kha Regent",
             "text": "At the beginning of your upkeep, put a 2/2 white Cat creature token onto the battlefield for each Equipment attached to Kemba, Kha Regent.",
             "colours": [
@@ -417,7 +417,7 @@
         },
         {
             "id": "be9e802d-efc0-51ba-a9af-b9f1096ad31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f20a74-7614-4bd9-ac08-0e098f98df0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f20a74-7614-4bd9-ac08-0e098f98df0c.jpg?1",
             "name": "Kemba's Skyguard",
             "text": "Flying\nWhen Kemba's Skyguard enters the battlefield, you gain 2 life.",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "62f24a52-4303-5b1d-bea8-d60b2c3f031a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0453cd-62ab-41ba-8d9c-9d6d25dc9a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0453cd-62ab-41ba-8d9c-9d6d25dc9a56.jpg?1",
             "name": "Leonin Arbiter",
             "text": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "d2109b0a-e870-5a15-b97a-1783eda6dd43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356c5e6a-c0bd-43f7-bc84-a6ae8718a7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/356c5e6a-c0bd-43f7-bc84-a6ae8718a7a2.jpg?1",
             "name": "Loxodon Wayfarer",
             "text": "",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "369a9e4f-06c8-5baf-9f3d-c722437ed2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13429b63-085c-4c78-9ce3-247db5841b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13429b63-085c-4c78-9ce3-247db5841b9d.jpg?1",
             "name": "Myrsmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, put a 1/1 colorless Myr artifact creature token onto the battlefield.",
             "colours": [
@@ -557,7 +557,7 @@
         },
         {
             "id": "c4257147-f419-56c6-bab6-c0772631adfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7ac3bf-eed2-417d-8b60-e8c84bfb98ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc7ac3bf-eed2-417d-8b60-e8c84bfb98ab.jpg?1",
             "name": "Razor Hippogriff",
             "text": "Flying\nWhen Razor Hippogriff enters the battlefield, return target artifact card from your graveyard to your hand. You gain life equal to that card's converted mana cost.",
             "colours": [
@@ -591,7 +591,7 @@
         },
         {
             "id": "3b16d502-d91e-51e7-930b-6d1c845371f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ae62f9-361c-4849-b0af-2b08fc0421c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18ae62f9-361c-4849-b0af-2b08fc0421c8.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -623,7 +623,7 @@
         },
         {
             "id": "3009d6fb-4b95-538a-ba71-d48f1d9f2a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5909e77e-a930-4713-bca4-c6b265238c17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5909e77e-a930-4713-bca4-c6b265238c17.jpg?1",
             "name": "Salvage Scout",
             "text": "{W}, Sacrifice Salvage Scout: Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -658,7 +658,7 @@
         },
         {
             "id": "8c4719f5-5d9d-5498-ac60-0ce1276e4c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d745f35-944a-4157-a351-baa06f67b725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d745f35-944a-4157-a351-baa06f67b725.jpg?1",
             "name": "Seize the Initiative",
             "text": "Target creature gets +1/+1 and gains first strike until end of turn.",
             "colours": [
@@ -690,7 +690,7 @@
         },
         {
             "id": "a3bd04f1-559c-5893-97c3-f07877abd6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e241ea47-cbbe-4241-94f9-315cc7cfd79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e241ea47-cbbe-4241-94f9-315cc7cfd79b.jpg?1",
             "name": "Soul Parry",
             "text": "Prevent all damage one or two target creatures would deal this turn.",
             "colours": [
@@ -722,7 +722,7 @@
         },
         {
             "id": "822ff758-f2a1-5f86-83c0-711c1b496801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32217d3b-8a44-40e3-a4fd-c849fdffc1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32217d3b-8a44-40e3-a4fd-c849fdffc1e4.jpg?1",
             "name": "Sunblast Angel",
             "text": "Flying\nWhen Sunblast Angel enters the battlefield, destroy all tapped creatures.",
             "colours": [
@@ -756,7 +756,7 @@
         },
         {
             "id": "3a29328c-c0be-5f0d-87c1-0d0e465487d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac29ef-02e1-4500-bb83-5987beeaa849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ac29ef-02e1-4500-bb83-5987beeaa849.jpg?1",
             "name": "Sunspear Shikari",
             "text": "As long as Sunspear Shikari is equipped, it has first strike and lifelink.",
             "colours": [
@@ -791,7 +791,7 @@
         },
         {
             "id": "231d9b07-265c-51e5-85cd-522509c4eaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6661b39d-505a-48f4-bc06-59084c6a3b0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6661b39d-505a-48f4-bc06-59084c6a3b0c.jpg?1",
             "name": "Tempered Steel",
             "text": "Artifact creatures you control get +2/+2.",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "7108b3c6-6b45-509b-8467-4c6e9e9f837e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a1d384-1b36-42d0-957f-48103f9cdbdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23a1d384-1b36-42d0-957f-48103f9cdbdd.jpg?1",
             "name": "True Conviction",
             "text": "Creatures you control have double strike and lifelink.",
             "colours": [
@@ -855,7 +855,7 @@
         },
         {
             "id": "53366845-32f2-5329-813e-d7f61fb3dab3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a87b48b-2ae9-4753-8719-62411f94ca87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a87b48b-2ae9-4753-8719-62411f94ca87.jpg?1",
             "name": "Vigil for the Lost",
             "text": "Whenever a creature you control is put into a graveyard from the battlefield, you may pay {X}. If you do, you gain X life.",
             "colours": [
@@ -887,7 +887,7 @@
         },
         {
             "id": "423032c6-4acb-5901-92a6-800e60e7fd2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d1bf3-4630-4be0-af5f-590789d27a0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74d1bf3-4630-4be0-af5f-590789d27a0c.jpg?1",
             "name": "Whitesun's Passage",
             "text": "You gain 5 life.",
             "colours": [
@@ -919,7 +919,7 @@
         },
         {
             "id": "b6e42188-cdf0-5181-b955-cd345cbc8804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e75af-7e43-4c15-a8a8-bec7389c6c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280e75af-7e43-4c15-a8a8-bec7389c6c4e.jpg?1",
             "name": "Argent Sphinx",
             "text": "Flying\nMetalcraft \u2014 {U}: Exile Argent Sphinx. Return it to the battlefield under your control at the beginning of the next end step. Activate this ability only if you control three or more artifacts.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "2539237f-964a-51b2-b231-faa90e68ab4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c071dca0-fccb-48b8-b65a-74741b12e3f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c071dca0-fccb-48b8-b65a-74741b12e3f0.jpg?1",
             "name": "Bonds of Quicksilver",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -987,7 +987,7 @@
         },
         {
             "id": "8fdf6421-242f-5fbf-8b26-5f514dd2fddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234f4131-1e7f-4220-b46c-bb4a6713876e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234f4131-1e7f-4220-b46c-bb4a6713876e.jpg?1",
             "name": "Darkslick Drake",
             "text": "Flying\nWhen Darkslick Drake is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -1022,7 +1022,7 @@
         },
         {
             "id": "fb113368-cd90-5102-a6e0-3cf0444b2b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1572457f-90e0-4ffc-a403-6f877c6a8186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1572457f-90e0-4ffc-a403-6f877c6a8186.jpg?1",
             "name": "Disperse",
             "text": "Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "674f0eeb-dcbd-549a-8ae0-2611cc2fb534",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247694c5-5813-4256-9fd8-478d4be52081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/247694c5-5813-4256-9fd8-478d4be52081.jpg?1",
             "name": "Dissipation Field",
             "text": "Whenever a permanent deals damage to you, return it to its owner's hand.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "aebd21fe-1737-528c-8160-c043e501be0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59599de-c781-4c26-a159-cbf0cd72d361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59599de-c781-4c26-a159-cbf0cd72d361.jpg?1",
             "name": "Grand Architect",
             "text": "Other blue creatures you control get +1/+1.\n{U}: Target artifact creature becomes blue until end of turn.\nTap an untapped blue creature you control: Add {2} to your mana pool. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
             "colours": [
@@ -1121,7 +1121,7 @@
         },
         {
             "id": "eab98698-4096-5f6e-be0c-3848e0d8fe18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fed18af-7301-4d03-ba7c-e94f07f078b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fed18af-7301-4d03-ba7c-e94f07f078b3.jpg?1",
             "name": "Halt Order",
             "text": "Counter target artifact spell.\nDraw a card.",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "6b4b4a0a-d9c8-55ae-8317-43ea95d8ebc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41e281-fcbb-450b-8a67-7b072c55c6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41e281-fcbb-450b-8a67-7b072c55c6f0.jpg?1",
             "name": "Inexorable Tide",
             "text": "Whenever you cast a spell, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "e51e43e3-768e-5841-bd6f-28657c7210ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e9820-2209-40a2-bc4f-46b440c05e9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f44e9820-2209-40a2-bc4f-46b440c05e9d.jpg?1",
             "name": "Lumengrid Drake",
             "text": "Flying\nMetalcraft \u2014 When Lumengrid Drake enters the battlefield, if you control three or more artifacts, return target creature to its owner's hand.",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "ab123ec3-6092-5ce2-a761-daec864cca15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88f78f4-77d8-4c3e-a5bf-a9dd902aaae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e88f78f4-77d8-4c3e-a5bf-a9dd902aaae1.jpg?1",
             "name": "Neurok Invisimancer",
             "text": "Neurok Invisimancer is unblockable.\nWhen Neurok Invisimancer enters the battlefield, target creature is unblockable this turn.",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "3643ddbc-3573-50e8-bc20-d2174ff34b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97171611-c677-48a6-b081-98a27ecef979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97171611-c677-48a6-b081-98a27ecef979.jpg?1",
             "name": "Plated Seastrider",
             "text": "",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "27b26876-de5f-5ce5-b8ce-56a49f87b40e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f5aea-80f2-4f3d-8508-9619413e0087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83f5aea-80f2-4f3d-8508-9619413e0087.jpg?1",
             "name": "Quicksilver Gargantuan",
             "text": "You may have Quicksilver Gargantuan enter the battlefield as a copy of any creature on the battlefield, except it's still 7/7.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "75f8af9d-0e14-50d1-a1c0-6ddf331a63e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e25713-05ea-4eed-aa7f-5ca4e57a8152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e25713-05ea-4eed-aa7f-5ca4e57a8152.jpg?1",
             "name": "Riddlesmith",
             "text": "Whenever you cast an artifact spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1357,7 +1357,7 @@
         },
         {
             "id": "9a636637-7353-5a52-bc6b-8004769e6545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b5db0-7d2c-4337-b1c4-9e1219f603c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c6b5db0-7d2c-4337-b1c4-9e1219f603c7.jpg?1",
             "name": "Scrapdiver Serpent",
             "text": "Scrapdiver Serpent is unblockable as long as defending player controls an artifact.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "910e33df-8fa4-5aee-9847-24e74d623bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1767355d-82a2-495e-ae95-d91984a9c62a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1767355d-82a2-495e-ae95-d91984a9c62a.jpg?1",
             "name": "Screeching Silcaw",
             "text": "Flying\nMetalcraft \u2014 Whenever Screeching Silcaw deals combat damage to a player, if you control three or more artifacts, that player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "68fa7911-b55c-5976-a34e-64695547daf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5462e-f60c-4550-b29e-4d9f9cd72385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d5462e-f60c-4550-b29e-4d9f9cd72385.jpg?1",
             "name": "Shape Anew",
             "text": "The controller of target artifact sacrifices it, then reveals cards from the top of his or her library until he or she reveals an artifact card. That player puts that card onto the battlefield, then shuffles all other cards revealed this way into his or her library.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "69a9d6e4-d840-5dac-aa97-82366f610e79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc4db7-13b5-4c88-91f2-581c9792f1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc4db7-13b5-4c88-91f2-581c9792f1ff.jpg?1",
             "name": "Sky-Eel School",
             "text": "Flying\nWhen Sky-Eel School enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "b0be3ab8-8456-5389-a62b-1c425bfafda5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe212ed-31cb-4f10-8ba7-e97af1d30d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe212ed-31cb-4f10-8ba7-e97af1d30d24.jpg?1",
             "name": "Steady Progress",
             "text": "Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)\nDraw a card.",
             "colours": [
@@ -1523,7 +1523,7 @@
         },
         {
             "id": "e5e998bb-7892-5684-9a04-72d564540937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2805239-f30a-4eca-a10b-41673daaa287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2805239-f30a-4eca-a10b-41673daaa287.jpg?1",
             "name": "Stoic Rebuttal",
             "text": "Metalcraft \u2014 Stoic Rebuttal costs {1} less to cast if you control three or more artifacts.\nCounter target spell.",
             "colours": [
@@ -1555,7 +1555,7 @@
         },
         {
             "id": "1e6d17ee-84dc-5d36-b297-376d945a779f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2dd336-e457-49a1-88ae-c35f0c846e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2dd336-e457-49a1-88ae-c35f0c846e99.jpg?1",
             "name": "Thrummingbird",
             "text": "Flying\nWhenever Thrummingbird deals combat damage to a player, proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [
@@ -1591,7 +1591,7 @@
         },
         {
             "id": "66160dd6-6de4-5fb1-8298-0f9374e685e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb52e7ba-5340-44e1-9b63-775e1f387925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb52e7ba-5340-44e1-9b63-775e1f387925.jpg?1",
             "name": "Trinket Mage",
             "text": "When Trinket Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. If you do, shuffle your library.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "147fe93a-fd02-5a5d-83f1-63b156589e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56226f57-6ff0-430e-aba6-6b3dd51f8d3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56226f57-6ff0-430e-aba6-6b3dd51f8d3c.jpg?1",
             "name": "Turn Aside",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -1658,7 +1658,7 @@
         },
         {
             "id": "5983b6cd-f5dd-5359-8226-275f80be6554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa18c2c2-f1a1-469d-acd8-9d6e0605bcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa18c2c2-f1a1-469d-acd8-9d6e0605bcf9.jpg?1",
             "name": "Twisted Image",
             "text": "Switch target creature's power and toughness until end of turn.\nDraw a card.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "90595c42-703c-511d-9831-b5a473dfbf57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934192-2ea3-48fe-a2a9-42c2ee9b22f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e934192-2ea3-48fe-a2a9-42c2ee9b22f7.jpg?1",
             "name": "Vault Skyward",
             "text": "Target creature gains flying until end of turn. Untap it.",
             "colours": [
@@ -1722,7 +1722,7 @@
         },
         {
             "id": "8cce22f2-64c3-5e9f-b98b-b33a5f3e58bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbc2a26-32f1-4d9c-8ee7-74698f64dce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffbc2a26-32f1-4d9c-8ee7-74698f64dce0.jpg?1",
             "name": "Vedalken Certarch",
             "text": "Metalcraft \u2014 {T}: Tap target artifact, creature, or land. Activate this ability only if you control three or more artifacts.",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "8ba68112-4be3-5126-9d52-3668c8347cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8fa025-56e6-4d24-a615-a51b6be937e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8fa025-56e6-4d24-a615-a51b6be937e9.jpg?1",
             "name": "Volition Reins",
             "text": "Enchant permanent\nWhen Volition Reins enters the battlefield, if enchanted permanent is tapped, untap it.\nYou control enchanted permanent.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "735b8149-7073-528e-b369-cbcbbc880e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95986875-59f5-414f-867f-94f30cefa5d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95986875-59f5-414f-867f-94f30cefa5d6.jpg?1",
             "name": "Blackcleave Goblin",
             "text": "Haste\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1827,7 +1827,7 @@
         },
         {
             "id": "f8aca348-cf0e-5c37-a26d-39606f091502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3386e4-bbd6-4756-b29d-f55619e98d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3386e4-bbd6-4756-b29d-f55619e98d0d.jpg?1",
             "name": "Bleak Coven Vampires",
             "text": "Metalcraft \u2014 When Bleak Coven Vampires enters the battlefield, if you control three or more artifacts, target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "d3d1946e-fa7a-5a59-b22a-976c38959235",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5431debc-0037-49ff-a38f-3fa2f9f5ee33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5431debc-0037-49ff-a38f-3fa2f9f5ee33.jpg?1",
             "name": "Blistergrub",
             "text": "Swampwalk\nWhen Blistergrub is put into a graveyard from the battlefield, each opponent loses 2 life.",
             "colours": [
@@ -1897,7 +1897,7 @@
         },
         {
             "id": "cd8b32f4-0cbc-5ca5-b770-f9dea6486410",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191dba2-659d-40e7-a558-c99ece872197.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c191dba2-659d-40e7-a558-c99ece872197.jpg?1",
             "name": "Carnifex Demon",
             "text": "Flying\nCarnifex Demon enters the battlefield with two -1/-1 counters on it.\n{B}, Remove a -1/-1 counter from Carnifex Demon: Put a -1/-1 counter on each other creature.",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "29a41d54-e82c-5273-9f60-98ff3184e491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a9dea-2aa1-48cd-afe2-f98057b95f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a9dea-2aa1-48cd-afe2-f98057b95f6e.jpg?1",
             "name": "Contagious Nim",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "e49480fe-df66-5a1f-b0d4-830f6a18eca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54625ac-484f-4522-8048-38e01c545ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54625ac-484f-4522-8048-38e01c545ac3.jpg?1",
             "name": "Corrupted Harvester",
             "text": "{B}, Sacrifice a creature: Regenerate Corrupted Harvester.",
             "colours": [
@@ -2002,7 +2002,7 @@
         },
         {
             "id": "3d94c809-3423-5c79-9665-52ddc3e1c453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0656f6-a016-479a-a003-72e106e986b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a0656f6-a016-479a-a003-72e106e986b0.jpg?1",
             "name": "Dross Hopper",
             "text": "Sacrifice a creature: Dross Hopper gains flying until end of turn.",
             "colours": [
@@ -2038,7 +2038,7 @@
         },
         {
             "id": "7cda8b30-2a5d-59e8-89ee-41cc356219be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878b541-a730-49db-b062-5a01656e269d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878b541-a730-49db-b062-5a01656e269d.jpg?1",
             "name": "Exsanguinate",
             "text": "Each opponent loses X life. You gain life equal to the life lost this way.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "f841865f-8d2a-5a51-bf24-1487f94e032c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c729525-b954-42dd-9877-f4360d99b961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c729525-b954-42dd-9877-f4360d99b961.jpg?1",
             "name": "Flesh Allergy",
             "text": "As an additional cost to cast Flesh Allergy, sacrifice a creature.\nDestroy target creature. Its controller loses life equal to the number of creatures put into all graveyards from the battlefield this turn.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "6ebb9805-3b84-56c7-acce-b7ac58b1dddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cd149b-ecf4-43ed-b6e5-98870953b4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58cd149b-ecf4-43ed-b6e5-98870953b4b8.jpg?1",
             "name": "Fume Spitter",
             "text": "Sacrifice Fume Spitter: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -2137,7 +2137,7 @@
         },
         {
             "id": "e6567b20-26fb-5d01-b1b7-841bb0b0a777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed31f2f-370d-4bbe-aa57-82249ed1b4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed31f2f-370d-4bbe-aa57-82249ed1b4d4.jpg?1",
             "name": "Geth, Lord of the Vault",
             "text": "Intimidate\n{X}{B}: Put target artifact or creature card with converted mana cost X from an opponent's graveyard onto the battlefield under your control tapped. Then that player puts the top X cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2174,7 +2174,7 @@
         },
         {
             "id": "c3d8406d-7f44-5cbb-8c96-9ef4a5e120d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda628ba-19f4-4e24-9500-cca295a992bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda628ba-19f4-4e24-9500-cca295a992bb.jpg?1",
             "name": "Grasp of Darkness",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "548218a7-db25-544e-a3f6-ddad80793e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca493e-f09b-4b11-bb47-0562dfc203ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94ca493e-f09b-4b11-bb47-0562dfc203ca.jpg?1",
             "name": "Hand of the Praetors",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nOther creatures you control with infect get +1/+1.\nWhenever you cast a creature spell with infect, target player gets a poison counter.",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "439a8fc0-f91e-5226-9378-1a5f4e143327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013aed6-7415-4bf0-a3bb-46d6beecbaff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013aed6-7415-4bf0-a3bb-46d6beecbaff.jpg?1",
             "name": "Ichor Rats",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Ichor Rats enters the battlefield, each player gets a poison counter.",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "02978515-f8c8-5afe-8d80-46dcf509926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef2567-f798-4447-9735-c7c0d88aba85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ef2567-f798-4447-9735-c7c0d88aba85.jpg?1",
             "name": "Instill Infection",
             "text": "Put a -1/-1 counter on target creature.\nDraw a card.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "847187d7-03ad-51aa-98e4-bbd6fefbdd08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc5b944-a9fe-4a64-bf11-51817a26f22b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acc5b944-a9fe-4a64-bf11-51817a26f22b.jpg?1",
             "name": "Memoricide",
             "text": "Name a nonland card. Search target player's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.",
             "colours": [
@@ -2340,7 +2340,7 @@
         },
         {
             "id": "3725872d-69e7-5fef-9808-86e5cd027704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a0410f-95c5-49bf-856d-dea796c96e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a0410f-95c5-49bf-856d-dea796c96e3b.jpg?1",
             "name": "Moriok Reaver",
             "text": "",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "ed2a3294-e470-50ee-8557-ed3afb54b506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d69c045-d705-478b-9e8f-272a24737225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d69c045-d705-478b-9e8f-272a24737225.jpg?1",
             "name": "Necrogen Scudder",
             "text": "Flying\nWhen Necrogen Scudder enters the battlefield, you lose 3 life.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "692b459a-907b-5757-ac9c-4bb44d722384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2c79f-a151-4628-90fe-c0ff7ccd9c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af2c79f-a151-4628-90fe-c0ff7ccd9c2c.jpg?1",
             "name": "Necrotic Ooze",
             "text": "As long as Necrotic Ooze is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
             "colours": [
@@ -2444,7 +2444,7 @@
         },
         {
             "id": "efcfcd26-febb-5eba-a258-d41fded27a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecf3dae-1a0c-4cf3-b9bd-ec2ad6acaa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fecf3dae-1a0c-4cf3-b9bd-ec2ad6acaa1b.jpg?1",
             "name": "Painful Quandary",
             "text": "Whenever an opponent casts a spell, that player loses 5 life unless he or she discards a card.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "caaae53b-770f-5531-80a6-650ad560b8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e531ab-29ed-4e54-ae9c-681a220666ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e531ab-29ed-4e54-ae9c-681a220666ad.jpg?1",
             "name": "Painsmith",
             "text": "Whenever you cast an artifact spell, you may have target creature get +2/+0 and gain deathtouch until end of turn.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "48ad23dd-06b8-587a-a97c-ae4f5234c20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae856bc-f65f-42ba-9344-1a30b356c041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae856bc-f65f-42ba-9344-1a30b356c041.jpg?1",
             "name": "Plague Stinger",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "02b24252-def9-5979-a4a5-87f02ead102d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9c3267-7988-416c-85a4-0e314e42ddb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd9c3267-7988-416c-85a4-0e314e42ddb9.jpg?1",
             "name": "Psychic Miasma",
             "text": "Target player discards a card. If a land card is discarded this way, return Psychic Miasma to its owner's hand.",
             "colours": [
@@ -2579,7 +2579,7 @@
         },
         {
             "id": "052548e8-6b6c-582d-934e-f90064c3295d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca940b4e-6f5e-4492-b6e0-dbf619eddadd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca940b4e-6f5e-4492-b6e0-dbf619eddadd.jpg?1",
             "name": "Relic Putrescence",
             "text": "Enchant artifact\nWhenever enchanted artifact becomes tapped, its controller gets a poison counter.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "9a5c98ca-d5a3-558d-9ead-bc49dcda7ece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be358357-2abe-4ead-bb18-76cad8274489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be358357-2abe-4ead-bb18-76cad8274489.jpg?1",
             "name": "Skinrender",
             "text": "When Skinrender enters the battlefield, put three -1/-1 counters on target creature.",
             "colours": [
@@ -2648,7 +2648,7 @@
         },
         {
             "id": "c5425ac3-e7e2-557e-ab91-31948e1e2184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c930c9cc-1b64-4f36-afe2-6bf120a74ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c930c9cc-1b64-4f36-afe2-6bf120a74ce2.jpg?1",
             "name": "Skithiryx, the Blight Dragon",
             "text": "Flying\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{B}: Skithiryx, the Blight Dragon gains haste until end of turn.\n{B}{B}: Regenerate Skithiryx.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "ee7eacb3-ac16-54a4-97b6-e16725f372ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f82007-99f6-4c6c-8182-ee631c33531f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f82007-99f6-4c6c-8182-ee631c33531f.jpg?1",
             "name": "Tainted Strike",
             "text": "Target creature gets +1/+0 and gains infect until end of turn. (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "967d7d8b-d1cf-5681-8d7a-309f1e740b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e3a0a-29a7-4dc0-80fe-569b9e751db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445e3a0a-29a7-4dc0-80fe-569b9e751db3.jpg?1",
             "name": "Arc Trail",
             "text": "Arc Trail deals 2 damage to target creature or player and 1 damage to another target creature or player.",
             "colours": [
@@ -2750,7 +2750,7 @@
         },
         {
             "id": "bedad837-5f8c-544f-a70f-be6861e6b3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b505c78-5dbd-483d-92bb-5144060e962f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b505c78-5dbd-483d-92bb-5144060e962f.jpg?1",
             "name": "Assault Strobe",
             "text": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "be60b273-ba2c-5ec6-9797-bdcac722fa89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c6f71-2448-47e1-9133-7af6a4d4577a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e02c6f71-2448-47e1-9133-7af6a4d4577a.jpg?1",
             "name": "Barrage Ogre",
             "text": "{T}, Sacrifice an artifact: Barrage Ogre deals 2 damage to target creature or player.",
             "colours": [
@@ -2817,7 +2817,7 @@
         },
         {
             "id": "e47346b1-3c26-5ba5-b349-518fae9500ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd124bb-1ed1-469c-8527-d7261ea720b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd124bb-1ed1-469c-8527-d7261ea720b9.jpg?1",
             "name": "Blade-Tribe Berserkers",
             "text": "Metalcraft \u2014 When Blade-Tribe Berserkers enters the battlefield, if you control three or more artifacts, Blade-Tribe Berserkers gets +3/+3 and gains haste until end of turn.",
             "colours": [
@@ -2852,7 +2852,7 @@
         },
         {
             "id": "b692d3e8-1924-5960-a3bc-e45ba424562d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5ce81-6cca-4990-a515-34ac44cae039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2d5ce81-6cca-4990-a515-34ac44cae039.jpg?1",
             "name": "Bloodshot Trainee",
             "text": "{T}: Bloodshot Trainee deals 4 damage to target creature. Activate this ability only if Bloodshot Trainee's power is 4 or greater.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "5468467a-d7c5-5640-bab7-80bf5c59bbb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77161159-ee2c-485d-8674-d8590ccc62e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77161159-ee2c-485d-8674-d8590ccc62e1.jpg?1",
             "name": "Cerebral Eruption",
             "text": "Target opponent reveals the top card of his or her library. Cerebral Eruption deals damage equal to the revealed card's converted mana cost to that player and each creature he or she controls. If a land card is revealed this way, return Cerebral Eruption to its owner's hand.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "005879e4-0fd0-5508-b175-5275d4a2677d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee86cfc8-9faa-474c-90a9-5405f3f6037c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee86cfc8-9faa-474c-90a9-5405f3f6037c.jpg?1",
             "name": "Embersmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, Embersmith deals 1 damage to target creature or player.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "9e3cdb0c-b0a4-57c3-b3ca-18d5ce521478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcc7170-38d9-4b9e-a5f9-73ac1208c439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcc7170-38d9-4b9e-a5f9-73ac1208c439.jpg?1",
             "name": "Ferrovore",
             "text": "{R}, Sacrifice an artifact: Ferrovore gets +3/+0 until end of turn.",
             "colours": [
@@ -2988,7 +2988,7 @@
         },
         {
             "id": "fab765e7-fe5e-5490-b554-5cdcf0e38368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0e5f5-b51a-4386-827b-c0eb8c877efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e0e5f5-b51a-4386-827b-c0eb8c877efb.jpg?1",
             "name": "Flameborn Hellion",
             "text": "Haste\nFlameborn Hellion attacks each turn if able.",
             "colours": [
@@ -3022,7 +3022,7 @@
         },
         {
             "id": "9c84746b-6ecd-5ffb-a1d4-bc825eb794c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21fa7cb-a8ac-4312-80d4-82ee87650a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a21fa7cb-a8ac-4312-80d4-82ee87650a55.jpg?1",
             "name": "Furnace Celebration",
             "text": "Whenever you sacrifice another permanent, you may pay {2}. If you do, Furnace Celebration deals 2 damage to target creature or player.",
             "colours": [
@@ -3054,7 +3054,7 @@
         },
         {
             "id": "60834b42-64dc-572a-8438-631417312191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5881bbc-8600-464d-9dcd-5a7780918d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5881bbc-8600-464d-9dcd-5a7780918d1d.jpg?1",
             "name": "Galvanic Blast",
             "text": "Galvanic Blast deals 2 damage to target creature or player.\nMetalcraft \u2014 Galvanic Blast deals 4 damage to that creature or player instead if you control three or more artifacts.",
             "colours": [
@@ -3086,7 +3086,7 @@
         },
         {
             "id": "d1876664-591a-59d0-ac30-7ea974303a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65af25-8007-415d-a3fa-7736f6118284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f65af25-8007-415d-a3fa-7736f6118284.jpg?1",
             "name": "Goblin Gaveleer",
             "text": "Trample\nGoblin Gaveleer gets +2/+0 for each Equipment attached to it.",
             "colours": [
@@ -3121,7 +3121,7 @@
         },
         {
             "id": "cc7bfd65-4a93-5190-ac17-2caf39b4933f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdd1d89-719d-4552-aeae-499c09b2ec6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcdd1d89-719d-4552-aeae-499c09b2ec6e.jpg?1",
             "name": "Hoard-Smelter Dragon",
             "text": "Flying\n{3}{R}: Destroy target artifact. Hoard-Smelter Dragon gets +X/+0 until end of turn, where X is that artifact's converted mana cost.",
             "colours": [
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "131b8963-eeac-5c4b-a551-6f0a584c11dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b9c79-a161-4d7d-944d-82a44a5f2ab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af8b9c79-a161-4d7d-944d-82a44a5f2ab9.jpg?1",
             "name": "Koth of the Hammer",
             "text": "+1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.\n-2: Add {R} to your mana pool for each Mountain you control.\n-5: You get an emblem with \"Mountains you control have \u2018{T}: This land deals 1 damage to target creature or player.'\"",
             "colours": [
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "f628d312-cb02-5971-9d0a-c535313db50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb79b56-81f1-417f-b5ad-030ad29f904b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb79b56-81f1-417f-b5ad-030ad29f904b.jpg?1",
             "name": "Kuldotha Phoenix",
             "text": "Flying, haste\nMetalcraft \u2014 {4}: Return Kuldotha Phoenix from your graveyard to the battlefield. Activate this ability only during your upkeep and only if you control three or more artifacts.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "76422066-3b3b-57ba-a17d-b4719b9f6437",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee07266-a95d-4cd8-9863-1664922e9490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee07266-a95d-4cd8-9863-1664922e9490.jpg?1",
             "name": "Kuldotha Rebirth",
             "text": "As an additional cost to cast Kuldotha Rebirth, sacrifice an artifact.\nPut three 1/1 red Goblin creature tokens onto the battlefield.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "e9cf87a0-9b2e-53be-ac23-7b77dd7520cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94a1d1-6d24-46e1-9568-42e1a810ad31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d94a1d1-6d24-46e1-9568-42e1a810ad31.jpg?1",
             "name": "Melt Terrain",
             "text": "Destroy target land. Melt Terrain deals 2 damage to that land's controller.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "ccbe3ddf-dd99-5aa9-99d4-72742eeeb316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2382d-1f27-40d1-b809-c188c19ebc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e2382d-1f27-40d1-b809-c188c19ebc72.jpg?1",
             "name": "Molten Psyche",
             "text": "Each player shuffles the cards from his or her hand into his or her library, then draws that many cards.\nMetalcraft \u2014 If you control three or more artifacts, Molten Psyche deals damage to each opponent equal to the number of cards that player has drawn this turn.",
             "colours": [
@@ -3321,7 +3321,7 @@
         },
         {
             "id": "05017f71-81c6-59f1-a5eb-62af43ee5908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f6e2c3-0e0d-47ff-9d92-afc86a8c8aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f6e2c3-0e0d-47ff-9d92-afc86a8c8aac.jpg?1",
             "name": "Ogre Geargrabber",
             "text": "Whenever Ogre Geargrabber attacks, gain control of target Equipment an opponent controls until end of turn. Attach it to Ogre Geargrabber. When you lose control of that Equipment, unattach it.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "7bfb5e99-88b0-51dd-9975-c87e5e85217e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bde7b-dc2d-45d2-b124-69b4b51ef3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0bde7b-dc2d-45d2-b124-69b4b51ef3d9.jpg?1",
             "name": "Oxidda Daredevil",
             "text": "Sacrifice an artifact: Oxidda Daredevil gains haste until end of turn.",
             "colours": [
@@ -3391,7 +3391,7 @@
         },
         {
             "id": "c6703068-1b93-5a28-8ca0-f950266cc460",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64fe85b-e471-489a-8c38-2357da1c7969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c64fe85b-e471-489a-8c38-2357da1c7969.jpg?1",
             "name": "Oxidda Scrapmelter",
             "text": "When Oxidda Scrapmelter enters the battlefield, destroy target artifact.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "5c146a24-8f3f-5b0d-aa7c-d34c083c8497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d9198-52a7-4dfe-8f7f-4fa6e19a2479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca4d9198-52a7-4dfe-8f7f-4fa6e19a2479.jpg?1",
             "name": "Scoria Elemental",
             "text": "",
             "colours": [
@@ -3459,7 +3459,7 @@
         },
         {
             "id": "d1c9c868-fe90-5a28-9610-5360ac4b46e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d70f7e-5ae9-455f-8430-123623920a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d70f7e-5ae9-455f-8430-123623920a92.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "d3da4b00-c23d-50d5-9995-8edf7cf0fd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad5621d-eb77-4b4a-80e7-1bfa75a6fcfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad5621d-eb77-4b4a-80e7-1bfa75a6fcfb.jpg?1",
             "name": "Spikeshot Elder",
             "text": "{1}{R}{R}: Spikeshot Elder deals damage equal to its power to target creature or player.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "cbd6ee7a-bd83-5cfc-a29a-f5027d4413f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3016e6b-32b2-4fa7-91c0-ec8fbe345760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3016e6b-32b2-4fa7-91c0-ec8fbe345760.jpg?1",
             "name": "Tunnel Ignus",
             "text": "Whenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under his or her control this turn, Tunnel Ignus deals 3 damage to that player.",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "dd2db92e-df0d-54f6-8e42-f5851b59aaed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fd5b49-b4f2-40da-94d5-6d6fc69506f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66fd5b49-b4f2-40da-94d5-6d6fc69506f6.jpg?1",
             "name": "Turn to Slag",
             "text": "Turn to Slag deals 5 damage to target creature. Destroy all Equipment attached to that creature.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "9cee4c80-2f68-522d-a4e3-88ffbd24b1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3152bc-5c59-4e98-95de-a51de05a3c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3152bc-5c59-4e98-95de-a51de05a3c98.jpg?1",
             "name": "Vulshok Heartstoker",
             "text": "When Vulshok Heartstoker enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "e689acce-2500-5cf3-9499-56d86f22b414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a25a5-9ec1-47fa-bf1f-e65eb75fdb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/968a25a5-9ec1-47fa-bf1f-e65eb75fdb00.jpg?1",
             "name": "Acid Web Spider",
             "text": "Reach\nWhen Acid Web Spider enters the battlefield, you may destroy target Equipment.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "ef685bf7-87d2-575f-83d2-04221aba8a2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e5279-f28c-4a78-9f8a-16c9f72f8d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e5279-f28c-4a78-9f8a-16c9f72f8d38.jpg?1",
             "name": "Alpha Tyrranax",
             "text": "",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "2946d60e-6493-5fce-9738-e60a9c56ca50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg?1",
             "name": "Asceticism",
             "text": "Creatures you control can't be the targets of spells or abilities your opponents control.\n{1}{G}: Regenerate target creature.",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "0c3c2bb1-0ed9-5f26-bedd-e1390eb8528d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44eb3e3a-60ee-4293-a321-daa452d4c70d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44eb3e3a-60ee-4293-a321-daa452d4c70d.jpg?1",
             "name": "Bellowing Tanglewurm",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nOther green creatures you control have intimidate.",
             "colours": [
@@ -3762,7 +3762,7 @@
         },
         {
             "id": "44bca4c8-afdc-5319-8d70-284847030b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b3335-565c-406d-bd94-f36974602552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf9b3335-565c-406d-bd94-f36974602552.jpg?1",
             "name": "Blight Mamba",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{1}{G}: Regenerate Blight Mamba.",
             "colours": [
@@ -3797,7 +3797,7 @@
         },
         {
             "id": "0a0f1783-67c3-5c94-8fc8-a49a4a750824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecff12a-37d5-4a7b-b615-4c5e3bd950bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecff12a-37d5-4a7b-b615-4c5e3bd950bb.jpg?1",
             "name": "Blunt the Assault",
             "text": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn.",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "4bd76b92-4922-54b4-b146-7d353e9b5592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9948e4c-d583-4fde-a305-df926cf00199.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9948e4c-d583-4fde-a305-df926cf00199.jpg?1",
             "name": "Carapace Forger",
             "text": "Metalcraft \u2014 Carapace Forger gets +2/+2 as long as you control three or more artifacts.",
             "colours": [
@@ -3864,7 +3864,7 @@
         },
         {
             "id": "99fac9be-4698-5c49-84a1-83e66930204d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c1a8e-3bdb-42cf-9442-5de7e4670d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3c1a8e-3bdb-42cf-9442-5de7e4670d66.jpg?1",
             "name": "Carrion Call",
             "text": "Put two 1/1 green Insect creature tokens with infect onto the battlefield. (They deal damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "0dcb1a28-5162-5320-aa26-8729c86f615b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7f99e-7324-4d16-b163-8f1b2edb7b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee7f99e-7324-4d16-b163-8f1b2edb7b89.jpg?1",
             "name": "Copperhorn Scout",
             "text": "Whenever Copperhorn Scout attacks, untap each other creature you control.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "2d89c1d9-f215-50f3-a6e7-7b68fa71760d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c10302-f0b3-4076-ae5c-a8c8c09a7d41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c10302-f0b3-4076-ae5c-a8c8c09a7d41.jpg?1",
             "name": "Cystbearer",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "6773272c-88d5-5643-8aef-b45992783461",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeabc4a-7b4f-4e3d-bcc7-423bb703563a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aeabc4a-7b4f-4e3d-bcc7-423bb703563a.jpg?1",
             "name": "Engulfing Slagwurm",
             "text": "Whenever Engulfing Slagwurm blocks or becomes blocked by a creature, destroy that creature. You gain life equal to that creature's toughness.",
             "colours": [
@@ -4000,7 +4000,7 @@
         },
         {
             "id": "8f21ee62-438e-55b8-95de-933caf33b1ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9544132-bbb5-4ec4-af82-dad56e5091af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9544132-bbb5-4ec4-af82-dad56e5091af.jpg?1",
             "name": "Ezuri, Renegade Leader",
             "text": "{G}: Regenerate another target Elf.\n{2}{G}{G}{G}: Elf creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "6951c244-7233-5777-8e7f-188c92720c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cc93af-d9a0-4ed8-8c22-686d005ea77e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32cc93af-d9a0-4ed8-8c22-686d005ea77e.jpg?1",
             "name": "Ezuri's Archers",
             "text": "Reach (This creature can block creatures with flying.)\nWhenever Ezuri's Archers blocks a creature with flying, Ezuri's Archers gets +3/+0 until end of turn.",
             "colours": [
@@ -4072,7 +4072,7 @@
         },
         {
             "id": "9e713af4-08ca-5728-a2f7-55008aea728a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg?1",
             "name": "Ezuri's Brigade",
             "text": "Metalcraft \u2014 As long as you control three or more artifacts, Ezuri's Brigade gets +4/+4 and has trample.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "e0048ebb-4e37-5d4d-8387-1739219bc677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c920236f-c3d7-421c-b021-103996da790e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c920236f-c3d7-421c-b021-103996da790e.jpg?1",
             "name": "Genesis Wave",
             "text": "Reveal the top X cards of your library. You may put any number of permanent cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "257b6dba-aa50-57f6-a3b5-0bdcde1ac009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fc5b67-f521-4ba4-a10f-103e8b6af688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fc5b67-f521-4ba4-a10f-103e8b6af688.jpg?1",
             "name": "Liege of the Tangle",
             "text": "Trample\nWhenever Liege of the Tangle deals combat damage to a player, you may choose any number of target lands you control and put an awakening counter on each of them. Each of those lands is an 8/8 green Elemental creature for as long as it has an awakening counter on it. They're still lands.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "69e48277-820d-5be2-955a-802f4846a4cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e5dcac-0d59-4bcc-8a0e-036cc23065b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e5dcac-0d59-4bcc-8a0e-036cc23065b5.jpg?1",
             "name": "Lifesmith",
             "text": "Whenever you cast an artifact spell, you may pay {1}. If you do, you gain 3 life.",
             "colours": [
@@ -4208,7 +4208,7 @@
         },
         {
             "id": "bf4837b9-f117-5a4b-8c38-1477bd7cebce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1340a63-f549-440b-aad3-14247113896a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1340a63-f549-440b-aad3-14247113896a.jpg?1",
             "name": "Molder Beast",
             "text": "Trample\nWhenever an artifact is put into a graveyard from the battlefield, Molder Beast gets +2/+0 until end of turn.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "a48e9c7f-6182-5bb5-bdcf-d019898a9b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b2c3f9-a831-4fd2-80e8-b67b0df3e98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b2c3f9-a831-4fd2-80e8-b67b0df3e98b.jpg?1",
             "name": "Putrefax",
             "text": "Trample, haste\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nAt the beginning of the end step, sacrifice Putrefax.",
             "colours": [
@@ -4277,7 +4277,7 @@
         },
         {
             "id": "809f1246-5a60-5f80-8e72-9d09aa858037",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c572a-6dc0-432f-92e9-c52fb0efddb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9c572a-6dc0-432f-92e9-c52fb0efddb5.jpg?1",
             "name": "Slice in Twain",
             "text": "Destroy target artifact or enchantment.\nDraw a card.",
             "colours": [
@@ -4309,7 +4309,7 @@
         },
         {
             "id": "bc90e2e6-401a-57d7-bf0f-5f130c700d5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b678bd68-e866-4081-95f9-2bd93a84d400.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b678bd68-e866-4081-95f9-2bd93a84d400.jpg?1",
             "name": "Tangle Angler",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\n{G}: Target creature blocks Tangle Angler this turn if able.",
             "colours": [
@@ -4344,7 +4344,7 @@
         },
         {
             "id": "6778dc31-bfaf-5443-a55d-9ae123959f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef01d3f6-c172-43fb-bc65-ff12567111da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef01d3f6-c172-43fb-bc65-ff12567111da.jpg?1",
             "name": "Tel-Jilad Defiance",
             "text": "Target creature gains protection from artifacts until end of turn.\nDraw a card.",
             "colours": [
@@ -4376,7 +4376,7 @@
         },
         {
             "id": "26551c5e-4ccb-5cad-9a8f-665477f2914a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643891b6-23d0-4734-81e0-b315d2d58f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/643891b6-23d0-4734-81e0-b315d2d58f50.jpg?1",
             "name": "Tel-Jilad Fallen",
             "text": "Protection from artifacts\nInfect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "269e86be-d51d-51e4-be56-b3057644e86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17979f0e-bd39-449f-b4ed-9156c229223b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17979f0e-bd39-449f-b4ed-9156c229223b.jpg?1",
             "name": "Untamed Might",
             "text": "Target creature gets +X/+X until end of turn.",
             "colours": [
@@ -4444,7 +4444,7 @@
         },
         {
             "id": "153b2b1f-149b-558a-8db0-7b7aa9953ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f565e-0fb8-40c8-9540-213d35af846a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7f565e-0fb8-40c8-9540-213d35af846a.jpg?1",
             "name": "Viridian Revel",
             "text": "Whenever an artifact is put into an opponent's graveyard from the battlefield, you may draw a card.",
             "colours": [
@@ -4476,7 +4476,7 @@
         },
         {
             "id": "52b46fab-f497-5dd7-9722-94b0cb2a5450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a5188b-9ae3-4ca0-8289-b8a266a9073b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a5188b-9ae3-4ca0-8289-b8a266a9073b.jpg?1",
             "name": "Wing Puncture",
             "text": "Target creature you control deals damage equal to its power to target creature with flying.",
             "colours": [
@@ -4508,7 +4508,7 @@
         },
         {
             "id": "83520e33-d9d2-5291-9836-70fb43492cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059cca0-2373-428b-a3a6-c8be5523c96f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059cca0-2373-428b-a3a6-c8be5523c96f.jpg?1",
             "name": "Withstand Death",
             "text": "Target creature is indestructible this turn. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [
@@ -4540,7 +4540,7 @@
         },
         {
             "id": "da2ccb29-71df-5026-940a-60412a9c5150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d48d62e-5c1f-464c-aa81-8a5d2690f48e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d48d62e-5c1f-464c-aa81-8a5d2690f48e.jpg?1",
             "name": "Venser, the Sojourner",
             "text": "+2: Exile target permanent you own. Return it to the battlefield under your control at the beginning of the next end step.\n-1: Creatures are unblockable this turn.\n-8: You get an emblem with \"Whenever you cast a spell, exile target permanent.\"",
             "colours": [
@@ -4578,7 +4578,7 @@
         },
         {
             "id": "43fc47a1-f95d-57e5-a323-eb3ac2db599b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7305c18-5058-42dd-b62a-7f6a42624036.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7305c18-5058-42dd-b62a-7f6a42624036.jpg?1",
             "name": "Accorder's Shield",
             "text": "Equipped creature gets +0/+3 and has vigilance.\nEquip {3}",
             "colours": [],
@@ -4608,7 +4608,7 @@
         },
         {
             "id": "b3de99b4-9f7f-5adf-90ae-899334850432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1283c05a-905b-421a-9096-e86b9c807aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1283c05a-905b-421a-9096-e86b9c807aaf.jpg?1",
             "name": "Argentum Armor",
             "text": "Equipped creature gets +6/+6.\nWhenever equipped creature attacks, destroy target permanent.\nEquip {6}",
             "colours": [],
@@ -4638,7 +4638,7 @@
         },
         {
             "id": "57920f91-f25f-5fd7-a652-a6b45540ea58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02745a0a-9872-4c30-a25d-61695c5fa9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02745a0a-9872-4c30-a25d-61695c5fa9cc.jpg?1",
             "name": "Auriok Replica",
             "text": "{W}, Sacrifice Auriok Replica: Prevent all damage a source of your choice would deal to you this turn.",
             "colours": [],
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "89758ea0-8eb2-50d6-9df8-6d962884f78e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b80b2f-8d07-4ad3-9b20-4ba0fe9f37a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b80b2f-8d07-4ad3-9b20-4ba0fe9f37a2.jpg?1",
             "name": "Barbed Battlegear",
             "text": "Equipped creature gets +4/-1.\nEquip {2}",
             "colours": [],
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "88e1a519-ad8b-562b-9d6a-0f483ab87139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf479c90-c791-4152-a8e6-fd3123f698df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf479c90-c791-4152-a8e6-fd3123f698df.jpg?1",
             "name": "Bladed Pinions",
             "text": "Equipped creature has flying and first strike.\nEquip {2}",
             "colours": [],
@@ -4731,7 +4731,7 @@
         },
         {
             "id": "ad8ff267-1f2c-5a7e-8bf1-4f7705b390d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdb3af4-eaba-47b0-b242-dafa25ff0969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdb3af4-eaba-47b0-b242-dafa25ff0969.jpg?1",
             "name": "Chimeric Mass",
             "text": "Chimeric Mass enters the battlefield with X charge counters on it.\n{1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"",
             "colours": [],
@@ -4759,7 +4759,7 @@
         },
         {
             "id": "72dd879a-b7cd-5769-83b5-ee12934cae66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce881675-690f-4d4c-a951-ab8302e904ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce881675-690f-4d4c-a951-ab8302e904ab.jpg?1",
             "name": "Chrome Steed",
             "text": "Metalcraft \u2014 Chrome Steed gets +2/+2 as long as you control three or more artifacts.",
             "colours": [],
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "babfa662-a06a-5930-be40-ece4ee45d618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc386c6c-c27e-4673-96eb-1d004fd71993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc386c6c-c27e-4673-96eb-1d004fd71993.jpg?1",
             "name": "Clone Shell",
             "text": "Imprint \u2014 When Clone Shell enters the battlefield, look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library in any order.\nWhen Clone Shell is put into a graveyard from the battlefield, turn the exiled card face up. If it's a creature card, put it onto the battlefield under your control.",
             "colours": [],
@@ -4821,7 +4821,7 @@
         },
         {
             "id": "f58bc388-234e-5f49-9fd9-59fb5921d6f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fafcefa-d33c-4d73-b3b7-2930f28b845e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fafcefa-d33c-4d73-b3b7-2930f28b845e.jpg?1",
             "name": "Contagion Clasp",
             "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "7dc86c33-dc1a-567b-930c-0e71c80894ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce72636-08e4-484e-ad81-4d1597a31ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce72636-08e4-484e-ad81-4d1597a31ffb.jpg?1",
             "name": "Contagion Engine",
             "text": "When Contagion Engine enters the battlefield, put a -1/-1 counter on each creature target player controls.\n{4}, {T}: Proliferate, then proliferate again. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there. Then do it again.)",
             "colours": [],
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "7a9f31b6-8c6b-5c5d-b3f3-a37448ad7ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323efe27-da58-4207-9c0c-dba5031bfa04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/323efe27-da58-4207-9c0c-dba5031bfa04.jpg?1",
             "name": "Copper Myr",
             "text": "{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -4910,7 +4910,7 @@
         },
         {
             "id": "0e236f50-d5c8-57c5-ba11-ab64f89a1109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6e19a1-b9ea-4724-96d6-63c4b4967257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6e19a1-b9ea-4724-96d6-63c4b4967257.jpg?1",
             "name": "Corpse Cur",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Corpse Cur enters the battlefield, you may return target creature card with infect from your graveyard to your hand.",
             "colours": [],
@@ -4942,7 +4942,7 @@
         },
         {
             "id": "b187f7cf-69c0-5f0d-bee9-70d5d5db920b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7665c7-c211-45d7-bde1-f7952548025f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7665c7-c211-45d7-bde1-f7952548025f.jpg?1",
             "name": "Culling Dais",
             "text": "{T}, Sacrifice a creature: Put a charge counter on Culling Dais.\n{1}, Sacrifice Culling Dais: Draw a card for each charge counter on Culling Dais.",
             "colours": [],
@@ -4970,7 +4970,7 @@
         },
         {
             "id": "9db73f43-9b62-5a35-94a3-1db83a44d87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b997c3e6-4b0e-4f4a-9f66-3fc1d8395494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b997c3e6-4b0e-4f4a-9f66-3fc1d8395494.jpg?1",
             "name": "Darksteel Axe",
             "text": "Darksteel Axe is indestructible. (Effects that say \"destroy\" don't destroy it.)\nEquipped creature gets +2/+0.\nEquip {2}",
             "colours": [],
@@ -5000,7 +5000,7 @@
         },
         {
             "id": "d3a0c73b-18d4-52fe-89e3-a4f516791873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1f540f-0d51-4e32-a4f9-c8977834572a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed1f540f-0d51-4e32-a4f9-c8977834572a.jpg?1",
             "name": "Darksteel Juggernaut",
             "text": "Darksteel Juggernaut's power and toughness are each equal to the number of artifacts you control.\nDarksteel Juggernaut is indestructible and attacks each turn if able.",
             "colours": [],
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "a2bccb1c-13c0-58a3-8c25-88b0f9f34a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5712cf-c6a9-4a2e-90db-8ca17c621724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f5712cf-c6a9-4a2e-90db-8ca17c621724.jpg?1",
             "name": "Darksteel Myr",
             "text": "Darksteel Myr is indestructible. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [],
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "f71969ff-63fe-54b3-a63a-d4181b4c5625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768e9dde-59e5-4b50-9b38-b46e2a593107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768e9dde-59e5-4b50-9b38-b46e2a593107.jpg?1",
             "name": "Darksteel Sentinel",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nVigilance\nDarksteel Sentinel is indestructible. (Lethal damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
             "colours": [],
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "ccc462d7-920c-5c6d-b9f2-37beb199bc37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e661c6-bc3e-45b4-ae1c-5002e381faf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49e661c6-bc3e-45b4-ae1c-5002e381faf3.jpg?1",
             "name": "Echo Circlet",
             "text": "Equipped creature can block an additional creature.\nEquip {1}",
             "colours": [],
@@ -5123,7 +5123,7 @@
         },
         {
             "id": "2022be11-8834-5f89-ac1f-ead55b1c8e6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2242c2-7379-4fff-a745-d180685da6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2242c2-7379-4fff-a745-d180685da6db.jpg?1",
             "name": "Etched Champion",
             "text": "Metalcraft \u2014 Etched Champion has protection from all colors as long as you control three or more artifacts.",
             "colours": [],
@@ -5154,7 +5154,7 @@
         },
         {
             "id": "586f8c07-4fad-5fae-b860-b53d8d5e9659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa09e06-08fd-4ecd-83fe-f0e0856547a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fa09e06-08fd-4ecd-83fe-f0e0856547a5.jpg?1",
             "name": "Flight Spellbomb",
             "text": "{T}, Sacrifice Flight Spellbomb: Target creature gains flying until end of turn.\nWhen Flight Spellbomb is put into a graveyard from the battlefield, you may pay {U}. If you do, draw a card.",
             "colours": [],
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "68491310-4595-5e9e-b19d-2f14458bc300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742da4-638d-4888-94f1-db2f4ada9f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a742da4-638d-4888-94f1-db2f4ada9f94.jpg?1",
             "name": "Glint Hawk Idol",
             "text": "Whenever another artifact enters the battlefield under your control, you may have Glint Hawk Idol become a 2/2 artifact creature with flying until end of turn.\n{W}: Glint Hawk Idol becomes a 2/2 artifact creature with flying until end of turn.",
             "colours": [],
@@ -5214,7 +5214,7 @@
         },
         {
             "id": "f18f75f8-7288-54cf-82cb-fff54a30a46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac92126c-fb22-4b97-bbc5-b0533a0baad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac92126c-fb22-4b97-bbc5-b0533a0baad8.jpg?1",
             "name": "Gold Myr",
             "text": "{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -5247,7 +5247,7 @@
         },
         {
             "id": "9426e21e-a307-5934-a66d-4c95b39c4cca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7abeca-da01-4962-b107-dd7a77469753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec7abeca-da01-4962-b107-dd7a77469753.jpg?1",
             "name": "Golden Urn",
             "text": "At the beginning of your upkeep, you may put a charge counter on Golden Urn.\n{T}, Sacrifice Golden Urn: You gain life equal to the number of charge counters on Golden Urn.",
             "colours": [],
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "8c56ccc9-a13d-58c9-b598-62ed6366a6ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc314-2f18-43c2-9ccd-59bb5dbe35e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ccfc314-2f18-43c2-9ccd-59bb5dbe35e9.jpg?1",
             "name": "Golem Artisan",
             "text": "{2}: Target artifact creature gets +1/+1 until end of turn.\n{2}: Target artifact creature gains your choice of flying, trample, or haste until end of turn.",
             "colours": [],
@@ -5306,7 +5306,7 @@
         },
         {
             "id": "efdf0b0a-00c3-54a1-9beb-f6a6b25b3a88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cef2e6a-e46b-4425-b507-3213cfd1400c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cef2e6a-e46b-4425-b507-3213cfd1400c.jpg?1",
             "name": "Golem Foundry",
             "text": "Whenever you cast an artifact spell, you may put a charge counter on Golem Foundry.\nRemove three charge counters from Golem Foundry: Put a 3/3 colorless Golem artifact creature token onto the battlefield.",
             "colours": [],
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "af0321a3-c960-5177-b908-6be9e72f3970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647ecb81-2d23-40f3-8570-0b86e2ed1c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/647ecb81-2d23-40f3-8570-0b86e2ed1c5e.jpg?1",
             "name": "Golem's Heart",
             "text": "Whenever a player casts an artifact spell, you may gain 1 life.",
             "colours": [],
@@ -5362,7 +5362,7 @@
         },
         {
             "id": "2a22d2ca-1001-51fd-87a8-a976bcbfc3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa64374-0693-47c9-8b69-56def3817b14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa64374-0693-47c9-8b69-56def3817b14.jpg?1",
             "name": "Grafted Exoskeleton",
             "text": "Equipped creature gets +2/+2 and has infect. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Grafted Exoskeleton becomes unattached from a permanent, sacrifice that permanent.\nEquip {2}",
             "colours": [],
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "e6e44a8c-f528-5de3-b9bd-53bf1e6eee04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6df2e7f-e46e-4808-8125-42a3aa66377c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6df2e7f-e46e-4808-8125-42a3aa66377c.jpg?1",
             "name": "Grindclock",
             "text": "{T}: Put a charge counter on Grindclock.\n{T}: Target player puts the top X cards of his or her library into his or her graveyard, where X is the number of charge counters on Grindclock.",
             "colours": [],
@@ -5420,7 +5420,7 @@
         },
         {
             "id": "bf3e5e01-f604-5abf-86e5-83f5f37cdff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5737246f-1292-4af6-aecf-8f161f5300cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5737246f-1292-4af6-aecf-8f161f5300cb.jpg?1",
             "name": "Heavy Arbalest",
             "text": "Equipped creature doesn't untap during its controller's untap step.\nEquipped creature has \"{T}: This creature deals 2 damage to target creature or player.\"\nEquip {4}",
             "colours": [],
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "83f99a4b-ec3d-598b-b273-cb2613d5badc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d93378e-1de2-4954-9458-dd3306f2996e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d93378e-1de2-4954-9458-dd3306f2996e.jpg?1",
             "name": "Horizon Spellbomb",
             "text": "{2}, {T}, Sacrifice Horizon Spellbomb: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.\nWhen Horizon Spellbomb is put into a graveyard from the battlefield, you may pay {G}. If you do, draw a card.",
             "colours": [],
@@ -5480,7 +5480,7 @@
         },
         {
             "id": "037cdfa9-56d8-566d-a4c8-76d07d3f34de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faef8b8b-2c45-4fed-b6ba-a8ac49c66330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faef8b8b-2c45-4fed-b6ba-a8ac49c66330.jpg?1",
             "name": "Ichorclaw Myr",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhenever Ichorclaw Myr becomes blocked, it gets +2/+2 until end of turn.",
             "colours": [],
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "827bed05-8af8-59aa-b783-7dad2ccbc0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baa10da-2733-4657-a1ea-74eb5a5a82b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baa10da-2733-4657-a1ea-74eb5a5a82b1.jpg?1",
             "name": "Infiltration Lens",
             "text": "Whenever equipped creature becomes blocked by a creature, you may draw two cards.\nEquip {1}",
             "colours": [],
@@ -5542,7 +5542,7 @@
         },
         {
             "id": "3b28d602-b0cb-51bb-a115-d5801a859a76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd0a588-b695-4060-b5d5-c6a74710ff0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd0a588-b695-4060-b5d5-c6a74710ff0f.jpg?1",
             "name": "Iron Myr",
             "text": "{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "a9ee6770-a805-5f90-86c9-a97b7189c03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad590bea-b872-4af7-a612-c8e8759d59df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad590bea-b872-4af7-a612-c8e8759d59df.jpg?1",
             "name": "Kuldotha Forgemaster",
             "text": "{T}, Sacrifice three artifacts: Search your library for an artifact card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "f754d138-18a0-5505-aab9-22817ffadac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a709559-fec3-44f4-a2bf-3396989b9189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a709559-fec3-44f4-a2bf-3396989b9189.jpg?1",
             "name": "Leaden Myr",
             "text": "{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -5639,7 +5639,7 @@
         },
         {
             "id": "9368df7b-e340-5e8b-8162-9f179e5ca0f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9201-06e7-4a70-8dcf-7462a019965d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9201-06e7-4a70-8dcf-7462a019965d.jpg?1",
             "name": "Liquimetal Coating",
             "text": "{T}: Target permanent becomes an artifact in addition to its other types until end of turn.",
             "colours": [],
@@ -5667,7 +5667,7 @@
         },
         {
             "id": "9403c3ac-3f88-5abb-a5b7-36645b84afc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef3e31-eb5a-43f7-a0b2-12348df6968d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbef3e31-eb5a-43f7-a0b2-12348df6968d.jpg?1",
             "name": "Livewire Lash",
             "text": "Equipped creature gets +2/+0 and has \"Whenever this creature becomes the target of a spell, this creature deals 2 damage to target creature or player.\"\nEquip {2}",
             "colours": [],
@@ -5697,7 +5697,7 @@
         },
         {
             "id": "d6c68192-f0f7-56b3-8196-4a490070f609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e274ea-e8f6-48ea-a877-c84b77c96d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e274ea-e8f6-48ea-a877-c84b77c96d0c.jpg?1",
             "name": "Lux Cannon",
             "text": "{T}: Put a charge counter on Lux Cannon.\n{T}, Remove three charge counters from Lux Cannon: Destroy target permanent.",
             "colours": [],
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "80fbb371-969d-5f8d-89a6-8c10b1d7c9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469cc4e0-49c0-4009-97ea-28e44addec69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/469cc4e0-49c0-4009-97ea-28e44addec69.jpg?1",
             "name": "Memnite",
             "text": "",
             "colours": [],
@@ -5756,7 +5756,7 @@
         },
         {
             "id": "09d82b86-d60b-5efe-a4d0-d4c157314185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736fff86-2417-4a77-b8eb-be2d1d142a9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736fff86-2417-4a77-b8eb-be2d1d142a9f.jpg?1",
             "name": "Mimic Vat",
             "text": "Imprint \u2014 Whenever a nontoken creature is put into a graveyard from the battlefield, you may exile that card. If you do, return each other card exiled with Mimic Vat to its owner's graveyard.\n{3}, {T}: Put a token onto the battlefield that's a copy of the exiled card. It gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -5784,7 +5784,7 @@
         },
         {
             "id": "d45c262a-2656-5f92-ad86-c54cec771bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d03b17-75ae-40d2-8570-b219ef0dfd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d03b17-75ae-40d2-8570-b219ef0dfd4a.jpg?1",
             "name": "Mindslaver",
             "text": "{4}, {T}, Sacrifice Mindslaver: You control target player during that player's next turn. (You see all cards that player could see and make all decisions for the player.)",
             "colours": [],
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "9d77fa8a-6a24-5d8e-9b79-b348da31fe2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48311a45-c0e1-4170-8dab-2b3495096c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48311a45-c0e1-4170-8dab-2b3495096c48.jpg?1",
             "name": "Molten-Tail Masticore",
             "text": "At the beginning of your upkeep, sacrifice Molten-Tail Masticore unless you discard a card.\n{4}, Exile a creature card from your graveyard: Molten-Tail Masticore deals 4 damage to target creature or player.\n{2}: Regenerate Molten-Tail Masticore.",
             "colours": [],
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "a9a8ce3a-2d95-566c-b3d3-d7ada7cf2ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480311ae-b9af-4fb7-881b-35566598cf07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480311ae-b9af-4fb7-881b-35566598cf07.jpg?1",
             "name": "Moriok Replica",
             "text": "{1}{B}, Sacrifice Moriok Replica: You draw two cards and lose 2 life.",
             "colours": [],
@@ -5878,7 +5878,7 @@
         },
         {
             "id": "766bf6fd-1dbc-5892-89c6-b98c69641451",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be9b1d5-9ab8-4adb-ba54-2c0117e842fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be9b1d5-9ab8-4adb-ba54-2c0117e842fa.jpg?1",
             "name": "Mox Opal",
             "text": "Metalcraft \u2014 {T}: Add one mana of any color to your mana pool. Activate this ability only if you control three or more artifacts.",
             "colours": [],
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "f76239ef-359a-592e-8c3b-808089704667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae94ed-7314-470b-baba-f2f58bbc894a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ae94ed-7314-470b-baba-f2f58bbc894a.jpg?1",
             "name": "Myr Battlesphere",
             "text": "When Myr Battlesphere enters the battlefield, put four 1/1 colorless Myr artifact creature tokens onto the battlefield.\nWhenever Myr Battlesphere attacks, you may tap X untapped Myr you control. If you do, Myr Battlesphere gets +X/+0 until end of turn and deals X damage to defending player.",
             "colours": [],
@@ -5940,7 +5940,7 @@
         },
         {
             "id": "3ce92115-cf3c-592f-a6aa-f29c13ae39f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ca835-b7f3-497c-b0bc-50a182cabecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55ca835-b7f3-497c-b0bc-50a182cabecf.jpg?1",
             "name": "Myr Galvanizer",
             "text": "Other Myr creatures you control get +1/+1.\n{1}, {T}: Untap each other Myr you control.",
             "colours": [],
@@ -5971,7 +5971,7 @@
         },
         {
             "id": "ebed48ca-6199-54e7-b14f-b59155316b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837e4b25-d70b-48d8-aaad-9622ad93e154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837e4b25-d70b-48d8-aaad-9622ad93e154.jpg?1",
             "name": "Myr Propagator",
             "text": "{3}, {T}: Put a token that's a copy of Myr Propagator onto the battlefield.",
             "colours": [],
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "84306e46-0bf5-53d2-b247-60423f86ea3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60678391-44b2-4525-94dc-ffc5a433b79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60678391-44b2-4525-94dc-ffc5a433b79b.jpg?1",
             "name": "Myr Reservoir",
             "text": "{T}: Add {2} to your mana pool. Spend this mana only to cast Myr spells or activate abilities of Myr.\n{3}, {T}: Return target Myr card from your graveyard to your hand.",
             "colours": [],
@@ -6030,7 +6030,7 @@
         },
         {
             "id": "6ad5da91-71fb-5745-9858-0146bb4d0a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f707119-ede9-4697-b723-d6cea96e6f2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f707119-ede9-4697-b723-d6cea96e6f2b.jpg?1",
             "name": "Necrogen Censer",
             "text": "Necrogen Censer enters the battlefield with two charge counters on it.\n{T}, Remove a charge counter from Necrogen Censer: Target player loses 2 life.",
             "colours": [],
@@ -6058,7 +6058,7 @@
         },
         {
             "id": "4507013e-cabb-5a64-9f19-04ee95d0af7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2e522b-e6f8-4fae-8c08-ce2bb8bed04f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2e522b-e6f8-4fae-8c08-ce2bb8bed04f.jpg?1",
             "name": "Necropede",
             "text": "Infect (This creature deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)\nWhen Necropede is put into a graveyard from the battlefield, you may put a -1/-1 counter on target creature.",
             "colours": [],
@@ -6090,7 +6090,7 @@
         },
         {
             "id": "7fad137a-9367-516b-8468-58afbb1f6c58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e32d5a8-0916-4728-9cb2-3903262bf873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e32d5a8-0916-4728-9cb2-3903262bf873.jpg?1",
             "name": "Neurok Replica",
             "text": "{1}{U}, Sacrifice Neurok Replica: Return target creature to its owner's hand.",
             "colours": [],
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "65dfa5c0-18cf-53f3-b6b9-3ee558200e29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603d217b-6375-46fc-992a-8dbd779da1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/603d217b-6375-46fc-992a-8dbd779da1e5.jpg?1",
             "name": "Nihil Spellbomb",
             "text": "{T}, Sacrifice Nihil Spellbomb: Exile all cards from target player's graveyard.\nWhen Nihil Spellbomb is put into a graveyard from the battlefield, you may pay {B}. If you do, draw a card.",
             "colours": [],
@@ -6153,7 +6153,7 @@
         },
         {
             "id": "25065b4f-42ba-5fe5-870f-e0a50d8e2ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f638bd96-8424-461f-87bf-4b7a7153fd35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f638bd96-8424-461f-87bf-4b7a7153fd35.jpg?1",
             "name": "Nim Deathmantle",
             "text": "Equipped creature gets +2/+2, has intimidate, and is a black Zombie.\nWhenever a nontoken creature is put into your graveyard from the battlefield, you may pay {4}. If you do, return that card to the battlefield and attach Nim Deathmantle to it.\nEquip {4}",
             "colours": [],
@@ -6183,7 +6183,7 @@
         },
         {
             "id": "bec1bfb1-03d0-5a9f-a507-daf95cfa48aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e7faa4-160e-47d9-a9a1-5928d9d2b5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e7faa4-160e-47d9-a9a1-5928d9d2b5e4.jpg?1",
             "name": "Origin Spellbomb",
             "text": "{1}, {T}, Sacrifice Origin Spellbomb: Put a 1/1 colorless Myr artifact creature token onto the battlefield.\nWhen Origin Spellbomb is put into a graveyard from the battlefield, you may pay {W}. If you do, draw a card.",
             "colours": [],
@@ -6213,7 +6213,7 @@
         },
         {
             "id": "59536d0e-a729-5594-a527-5ed981f8ca50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c016ad-bb82-4944-8c06-ab180b808041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c016ad-bb82-4944-8c06-ab180b808041.jpg?1",
             "name": "Palladium Myr",
             "text": "{T}: Add {2} to your mana pool.",
             "colours": [],
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "0addd93f-2430-5528-b53a-50d076ed0f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a29832-8630-498a-9ac3-bc709a6dc95d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9a29832-8630-498a-9ac3-bc709a6dc95d.jpg?1",
             "name": "Panic Spellbomb",
             "text": "{T}, Sacrifice Panic Spellbomb: Target creature can't block this turn.\nWhen Panic Spellbomb is put into a graveyard from the battlefield, you may pay {R}. If you do, draw a card.",
             "colours": [],
@@ -6274,7 +6274,7 @@
         },
         {
             "id": "367bcfb1-1f7f-5e5d-8780-252617fb05e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b942605-eb4a-452d-9b07-a4f912f96958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b942605-eb4a-452d-9b07-a4f912f96958.jpg?1",
             "name": "Perilous Myr",
             "text": "When Perilous Myr is put into a graveyard from the battlefield, it deals 2 damage to target creature or player.",
             "colours": [],
@@ -6306,7 +6306,7 @@
         },
         {
             "id": "f5609084-e5d4-5426-8df8-9f3404c828d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7919474-db2b-441a-b368-9e430ddf70ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7919474-db2b-441a-b368-9e430ddf70ab.jpg?1",
             "name": "Platinum Emperion",
             "text": "Your life total can't change. (You can't gain or lose life. You can't pay any amount of life except 0.)",
             "colours": [],
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "af7e6dc0-636e-538b-956a-9cee90365bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4625ad-1c83-4095-a5a2-0fc9fa4dd5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4625ad-1c83-4095-a5a2-0fc9fa4dd5f2.jpg?1",
             "name": "Precursor Golem",
             "text": "When Precursor Golem enters the battlefield, put two 3/3 colorless Golem artifact creature tokens onto the battlefield.\nWhenever a player casts an instant or sorcery spell that targets only a single Golem, that player copies that spell for each other Golem that spell could target. Each copy targets a different one of those Golems.",
             "colours": [],
@@ -6368,7 +6368,7 @@
         },
         {
             "id": "b5a4cc82-7886-5ea3-a0f1-1ce5489b3acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b264aa-303b-4982-a653-9573d39c28de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b264aa-303b-4982-a653-9573d39c28de.jpg?1",
             "name": "Prototype Portal",
             "text": "Imprint \u2014 When Prototype Portal enters the battlefield, you may exile an artifact card from your hand.\n{X}, {T}: Put a token that's a copy of the exiled card onto the battlefield. X is the converted mana cost of that card.",
             "colours": [],
@@ -6396,7 +6396,7 @@
         },
         {
             "id": "cfda9f24-8817-5ea7-8fda-b0d0ad8cf0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3db7645-20b9-4884-849b-a7d4b6d3aa00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3db7645-20b9-4884-849b-a7d4b6d3aa00.jpg?1",
             "name": "Ratchet Bomb",
             "text": "{T}: Put a charge counter on Ratchet Bomb.\n{T}, Sacrifice Ratchet Bomb: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Ratchet Bomb.",
             "colours": [],
@@ -6424,7 +6424,7 @@
         },
         {
             "id": "00b156fc-649b-593e-b62d-ba0fe89e648e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a74203-d342-489d-a584-bca78ef3331d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a74203-d342-489d-a584-bca78ef3331d.jpg?1",
             "name": "Razorfield Thresher",
             "text": "",
             "colours": [],
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "bc57f8a1-f6b2-516b-9d96-941b51d5210a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d638741-1cfe-4496-8d7e-7849a82dcb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d638741-1cfe-4496-8d7e-7849a82dcb24.jpg?1",
             "name": "Rust Tick",
             "text": "You may choose not to untap Rust Tick during your untap step.\n{1}, {T}: Tap target artifact. It doesn't untap during its controller's untap step for as long as Rust Tick remains tapped.",
             "colours": [],
@@ -6486,7 +6486,7 @@
         },
         {
             "id": "fcedce3c-f34b-56b1-80b6-75653c8897b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2419dd5-9c31-42b2-b6ef-bbdf11c558ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2419dd5-9c31-42b2-b6ef-bbdf11c558ac.jpg?1",
             "name": "Rusted Relic",
             "text": "Metalcraft \u2014 Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.",
             "colours": [],
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "fde6c2b6-a76c-5967-96b7-b38fb4574d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656b6d1-1c92-4da4-8afb-36f11610b0b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6656b6d1-1c92-4da4-8afb-36f11610b0b4.jpg?1",
             "name": "Saberclaw Golem",
             "text": "{R}: Saberclaw Golem gains first strike until end of turn.",
             "colours": [],
@@ -6547,7 +6547,7 @@
         },
         {
             "id": "4e87b8b7-077d-56de-b809-9fe1d67d6cdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380b46d-1660-404d-9d11-705d8809ea46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0380b46d-1660-404d-9d11-705d8809ea46.jpg?1",
             "name": "Semblance Anvil",
             "text": "Imprint \u2014 When Semblance Anvil enters the battlefield, you may exile a nonland card from your hand.\nSpells you cast that share a card type with the exiled card cost {2} less to cast.",
             "colours": [],
@@ -6575,7 +6575,7 @@
         },
         {
             "id": "ccd5b280-af91-58b2-a403-6e69fd6b2b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd60081-3942-4e0e-aacd-a0c121bb08c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd60081-3942-4e0e-aacd-a0c121bb08c7.jpg?1",
             "name": "Silver Myr",
             "text": "{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -6608,7 +6608,7 @@
         },
         {
             "id": "8f2f47b3-4e20-5c69-bdc2-8818baf707cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e0af-b18e-4172-bc56-19952ebd0303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc98e0af-b18e-4172-bc56-19952ebd0303.jpg?1",
             "name": "Snapsail Glider",
             "text": "Metalcraft \u2014 Snapsail Glider has flying as long as you control three or more artifacts.",
             "colours": [],
@@ -6639,7 +6639,7 @@
         },
         {
             "id": "5bef02c6-f28e-573c-bd20-e350584c0014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608c28-18cc-47d6-861e-2fd783aa3ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b608c28-18cc-47d6-861e-2fd783aa3ade.jpg?1",
             "name": "Soliton",
             "text": "{U}: Untap Soliton.",
             "colours": [],
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "91fdc245-fb65-5079-a019-5813ca1278b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126ee24-9597-4ee8-9c4d-5caed585424a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b126ee24-9597-4ee8-9c4d-5caed585424a.jpg?1",
             "name": "Steel Hellkite",
             "text": "Flying\n{2}: Steel Hellkite gets +1/+0 until end of turn.\n{X}: Destroy each nonland permanent with converted mana cost X whose controller was dealt combat damage by Steel Hellkite this turn. Activate this ability only once each turn.",
             "colours": [],
@@ -6703,7 +6703,7 @@
         },
         {
             "id": "ca32758a-7f43-5dc6-b564-b80d58d4a62a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2cb906-3748-4675-89b3-bde2f9a8444a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f2cb906-3748-4675-89b3-bde2f9a8444a.jpg?1",
             "name": "Strata Scythe",
             "text": "Imprint \u2014 When Strata Scythe enters the battlefield, search your library for a land card, exile it, then shuffle your library.\nEquipped creature gets +1/+1 for each land on the battlefield with the same name as the exiled card.\nEquip {3}",
             "colours": [],
@@ -6733,7 +6733,7 @@
         },
         {
             "id": "1eee5906-a598-5f48-a047-98008a4e2d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b9e54-b3ef-44fb-9240-0d67c1c4b7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d7b9e54-b3ef-44fb-9240-0d67c1c4b7f6.jpg?1",
             "name": "Strider Harness",
             "text": "Equipped creature gets +1/+1 and has haste.\nEquip {1}",
             "colours": [],
@@ -6763,7 +6763,7 @@
         },
         {
             "id": "fa97a94c-ca67-545b-a1b9-120959952077",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cc5caf-b2d7-4211-a1a4-f0ad6e70e3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03cc5caf-b2d7-4211-a1a4-f0ad6e70e3f4.jpg?1",
             "name": "Sword of Body and Mind",
             "text": "Equipped creature gets +2/+2 and has protection from green and from blue.\nWhenever equipped creature deals combat damage to a player, you put a 2/2 green Wolf creature token onto the battlefield and that player puts the top ten cards of his or her library into his or her graveyard.\nEquip {2}",
             "colours": [],
@@ -6793,7 +6793,7 @@
         },
         {
             "id": "a4b120c8-0344-55fa-ab7d-467d3df971af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbc5ae5-8e8b-4106-844f-2d49d2a51ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbc5ae5-8e8b-4106-844f-2d49d2a51ed9.jpg?1",
             "name": "Sylvok Lifestaff",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature is put into a graveyard, you gain 3 life.\nEquip {1}",
             "colours": [],
@@ -6823,7 +6823,7 @@
         },
         {
             "id": "1190bc1e-45b3-58df-a8c7-bc2ca6106213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caa3ce3-15a9-40ca-ad45-baff0f276483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7caa3ce3-15a9-40ca-ad45-baff0f276483.jpg?1",
             "name": "Sylvok Replica",
             "text": "{G}, Sacrifice Sylvok Replica: Destroy target artifact or enchantment.",
             "colours": [],
@@ -6856,7 +6856,7 @@
         },
         {
             "id": "6ab396ba-ad6c-51b6-8960-b6a29c7cf753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583d7386-3eb5-4f1d-8da9-f00e020a307b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583d7386-3eb5-4f1d-8da9-f00e020a307b.jpg?1",
             "name": "Throne of Geth",
             "text": "{T}, Sacrifice an artifact: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "0b76a866-a557-5b67-8783-ecb9e472232c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a77391b-5727-4408-bb50-970f7a13a83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a77391b-5727-4408-bb50-970f7a13a83c.jpg?1",
             "name": "Tower of Calamities",
             "text": "{8}, {T}: Tower of Calamities deals 12 damage to target creature.",
             "colours": [],
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "e0f2cd21-8879-5033-b12d-1e04954cce4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e215e0-836c-4b37-8f9a-9093a535bff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26e215e0-836c-4b37-8f9a-9093a535bff1.jpg?1",
             "name": "Trigon of Corruption",
             "text": "Trigon of Corruption enters the battlefield with three charge counters on it.\n{B}{B}, {T}: Put a charge counter on Trigon of Corruption.\n{2}, {T}, Remove a charge counter from Trigon of Corruption: Put a -1/-1 counter on target creature.",
             "colours": [],
@@ -6942,7 +6942,7 @@
         },
         {
             "id": "ddee5287-96c1-5cd9-8e76-18f451f66610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be409a80-846c-4883-8aee-c2e3f973fc0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be409a80-846c-4883-8aee-c2e3f973fc0f.jpg?1",
             "name": "Trigon of Infestation",
             "text": "Trigon of Infestation enters the battlefield with three charge counters on it.\n{G}{G}, {T}: Put a charge counter on Trigon of Infestation.\n{2}, {T}, Remove a charge counter from Trigon of Infestation: Put a 1/1 green Insect creature token with infect onto the battlefield.",
             "colours": [],
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "afcf5dac-22e6-51f6-abb2-8ec4ca68b50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241142e0-3a79-4bce-8535-18ae7e392f5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241142e0-3a79-4bce-8535-18ae7e392f5e.jpg?1",
             "name": "Trigon of Mending",
             "text": "Trigon of Mending enters the battlefield with three charge counters on it.\n{W}{W}, {T}: Put a charge counter on Trigon of Mending.\n{2}, {T}, Remove a charge counter from Trigon of Mending: Target player gains 3 life.",
             "colours": [],
@@ -7002,7 +7002,7 @@
         },
         {
             "id": "fca98a7f-9149-53e8-be8d-9e18746903ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1135f3b7-8c6b-47ff-b895-b7127836b0bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1135f3b7-8c6b-47ff-b895-b7127836b0bf.jpg?1",
             "name": "Trigon of Rage",
             "text": "Trigon of Rage enters the battlefield with three charge counters on it.\n{R}{R}, {T}: Put a charge counter on Trigon of Rage.\n{2}, {T}, Remove a charge counter from Trigon of Rage: Target creature gets +3/+0 until end of turn.",
             "colours": [],
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "ccc33e95-800a-53db-8191-91038e4faf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da37ba-52e3-417e-8d7b-6c3e060552a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da37ba-52e3-417e-8d7b-6c3e060552a4.jpg?1",
             "name": "Trigon of Thought",
             "text": "Trigon of Thought enters the battlefield with three charge counters on it.\n{U}{U}, {T}: Put a charge counter on Trigon of Thought.\n{2}, {T}, Remove a charge counter from Trigon of Thought: Draw a card.",
             "colours": [],
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "0491c938-4a32-5c63-ac20-751ccfa13672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6478389-15be-405f-b755-108c942d72ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6478389-15be-405f-b755-108c942d72ec.jpg?1",
             "name": "Tumble Magnet",
             "text": "Tumble Magnet enters the battlefield with three charge counters on it.\n{T}, Remove a charge counter from Tumble Magnet: Tap target artifact or creature.",
             "colours": [],
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "bd304b92-5a89-55d6-95d4-656fce3d0b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe86e1-ad47-4ccb-aa55-119dc681d370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ffe86e1-ad47-4ccb-aa55-119dc681d370.jpg?1",
             "name": "Vector Asp",
             "text": "{B}: Vector Asp gains infect until end of turn. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "d5605293-dffa-5353-9448-55c633534d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2763643d-5b53-49d0-bc3d-5626bf00f3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2763643d-5b53-49d0-bc3d-5626bf00f3f4.jpg?1",
             "name": "Venser's Journal",
             "text": "You have no maximum hand size.\nAt the beginning of your upkeep, you gain 1 life for each card in your hand.",
             "colours": [],
@@ -7152,7 +7152,7 @@
         },
         {
             "id": "206933ef-fda7-5778-a8b7-c919eee340d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32885a6c-b293-405f-9f2e-9e0dd7d1cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32885a6c-b293-405f-9f2e-9e0dd7d1cb8c.jpg?1",
             "name": "Vulshok Replica",
             "text": "{1}{R}, Sacrifice Vulshok Replica: Vulshok Replica deals 3 damage to target player.",
             "colours": [],
@@ -7185,7 +7185,7 @@
         },
         {
             "id": "7151e70c-f27b-579b-866a-f3d335e52d7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e2aed-ce6e-4fa1-a31c-a4574e5cf1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792e2aed-ce6e-4fa1-a31c-a4574e5cf1f5.jpg?1",
             "name": "Wall of Tanglecord",
             "text": "Defender\n{G}: Wall of Tanglecord gains reach until end of turn. (It can block creatures with flying.)",
             "colours": [],
@@ -7218,7 +7218,7 @@
         },
         {
             "id": "2cd697fb-53b0-54f1-a2b6-8a29c20073d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33672990-4860-4aa6-ac1b-f9da66f5da59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33672990-4860-4aa6-ac1b-f9da66f5da59.jpg?1",
             "name": "Wurmcoil Engine",
             "text": "Deathtouch, lifelink\nWhen Wurmcoil Engine is put into a graveyard from the battlefield, put a 3/3 colorless Wurm artifact creature token with deathtouch and a 3/3 colorless Wurm artifact creature token with lifelink onto the battlefield.",
             "colours": [],
@@ -7250,7 +7250,7 @@
         },
         {
             "id": "1849f292-cd71-567c-9c8f-4ae293796761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71be5f-0fd7-4a88-8041-f4d6bc4cc9ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d71be5f-0fd7-4a88-8041-f4d6bc4cc9ac.jpg?1",
             "name": "Blackcleave Cliffs",
             "text": "Blackcleave Cliffs enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "e7dfec87-8f0e-504a-957d-527470fff597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f1d784-f286-418d-a712-bc07ad10d4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f1d784-f286-418d-a712-bc07ad10d4a2.jpg?1",
             "name": "Copperline Gorge",
             "text": "Copperline Gorge enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7312,7 +7312,7 @@
         },
         {
             "id": "0fb9c18c-fdc2-525e-9ced-d4e5652e855b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530388b-eb19-4211-abd8-8a4c3c38c3af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530388b-eb19-4211-abd8-8a4c3c38c3af.jpg?1",
             "name": "Darkslick Shores",
             "text": "Darkslick Shores enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7343,7 +7343,7 @@
         },
         {
             "id": "e0cd6d4a-a610-52cd-b583-b010eddac408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63efb6-249c-4f57-9af1-baffe938520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b63efb6-249c-4f57-9af1-baffe938520c.jpg?1",
             "name": "Glimmerpost",
             "text": "When Glimmerpost enters the battlefield, you gain 1 life for each Locus on the battlefield.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -7373,7 +7373,7 @@
         },
         {
             "id": "d0701f80-4fc1-5549-9468-75db1f267506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345e053a-3178-485c-8602-1624bbf2f064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/345e053a-3178-485c-8602-1624bbf2f064.jpg?1",
             "name": "Razorverge Thicket",
             "text": "Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "4fbb40f8-934a-5ac3-8577-396133ddc2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99939b90-e88c-4c2f-ba78-56d455611703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99939b90-e88c-4c2f-ba78-56d455611703.jpg?1",
             "name": "Seachrome Coast",
             "text": "Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "a2852484-3e71-5f26-a710-48fa6de67dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e95b-afd0-4ac4-beb5-96163b411fe2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a410e95b-afd0-4ac4-beb5-96163b411fe2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7473,7 +7473,7 @@
         },
         {
             "id": "e6987881-ef68-536f-8504-816e1520ba35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440680d3-1eea-442a-b58e-96db09bc279e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440680d3-1eea-442a-b58e-96db09bc279e.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "bae5939e-d5c8-5e90-9279-7b0737a7e1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d5ea-eb76-4378-a3da-5d5cdad809b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4315d5ea-eb76-4378-a3da-5d5cdad809b8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7549,7 +7549,7 @@
         },
         {
             "id": "86c455d0-5781-56d9-866e-28cdb841517c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f48ac3-f0cb-4e5c-8ea6-e423aa92ce11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f48ac3-f0cb-4e5c-8ea6-e423aa92ce11.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7587,7 +7587,7 @@
         },
         {
             "id": "89558e11-4ce5-5e8e-a00c-f71ed09a9375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2748f53-0d81-4656-8e4b-5f0128215879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2748f53-0d81-4656-8e4b-5f0128215879.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7625,7 +7625,7 @@
         },
         {
             "id": "d0166b4f-c28f-57b6-9e62-b3190683737b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6549f83-e3da-4df2-a1e4-f01773607d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6549f83-e3da-4df2-a1e4-f01773607d56.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "06470238-8b38-5523-9610-b02a14aaa9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e879fe-a79b-427f-9901-c989fa73e234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e879fe-a79b-427f-9901-c989fa73e234.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7701,7 +7701,7 @@
         },
         {
             "id": "72c0489e-dd06-551f-86c9-00dc88f7b607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e160cb2a-1d8a-47cb-b136-8347eaab67d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e160cb2a-1d8a-47cb-b136-8347eaab67d7.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7739,7 +7739,7 @@
         },
         {
             "id": "8528bac9-e3ed-55cc-a6f9-5252adceb17e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a1264f-bda3-45ac-b959-463c6e532fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a1264f-bda3-45ac-b959-463c6e532fd3.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "7eb989e8-b9e3-5078-a283-d57911fc9c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8897b2-0ef2-4812-9772-cd99c5ce5586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8897b2-0ef2-4812-9772-cd99c5ce5586.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7815,7 +7815,7 @@
         },
         {
             "id": "4ead0bf8-44c7-5efb-bd77-6fadde9f20b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239511f0-34b7-423c-b53b-1327d6b7da28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/239511f0-34b7-423c-b53b-1327d6b7da28.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7853,7 +7853,7 @@
         },
         {
             "id": "52fa1705-0ce5-534d-939b-241ab371005d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeccfafb-0b3e-4e22-8c5c-6d5a0f5896c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aeccfafb-0b3e-4e22-8c5c-6d5a0f5896c5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -7891,7 +7891,7 @@
         },
         {
             "id": "9678b7e7-271a-5155-ac2c-da1f9832b84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df2f49d-097e-4685-8ddb-69c55f07f60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df2f49d-097e-4685-8ddb-69c55f07f60c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "0d16e923-8cb2-5aea-b8b9-2ec742005533",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68647c2-a343-4314-8abb-00e7de6ecf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68647c2-a343-4314-8abb-00e7de6ecf0d.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -7967,7 +7967,7 @@
         },
         {
             "id": "e25fb2c9-1e05-5596-87c2-6c7e35a28c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bad0eb-807f-4391-82c9-edc9d14070f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46bad0eb-807f-4391-82c9-edc9d14070f5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8005,7 +8005,7 @@
         },
         {
             "id": "43fd9ee5-87a4-5f0a-930e-aa0960093219",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dcb5ef-85f8-48ce-be39-d0a4eb8345af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dcb5ef-85f8-48ce-be39-d0a4eb8345af.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8043,7 +8043,7 @@
         },
         {
             "id": "4e454606-8a5a-56dc-95df-b4a03f5d73e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cc6a36-b551-40c7-b081-53beffbca235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34cc6a36-b551-40c7-b081-53beffbca235.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8081,7 +8081,7 @@
         },
         {
             "id": "de7270b3-24ae-5295-9dc5-badca38244e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c661a6-322a-4460-9d75-a2c95d1a49de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c661a6-322a-4460-9d75-a2c95d1a49de.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8119,7 +8119,7 @@
         },
         {
             "id": "51666869-9f49-5e10-931c-eb2f57f939fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798b4f41-1e33-4da6-99c1-de926297c073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798b4f41-1e33-4da6-99c1-de926297c073.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8157,7 +8157,7 @@
         },
         {
             "id": "b6344758-6965-5112-945f-6fd73232df3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2bf35-efe6-4ad4-bf6e-55848ba71dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb2bf35-efe6-4ad4-bf6e-55848ba71dfe.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "aaa57966-d63b-5b2b-bc7c-5b4dd6638678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ab51-43e8-4b24-9830-de0ad9b9d3dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ab51-43e8-4b24-9830-de0ad9b9d3dc.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "fdad2865-1030-5dcb-88a1-f00662ce7dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a563df7-7b9d-4692-ab1b-578be1887b62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a563df7-7b9d-4692-ab1b-578be1887b62.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "98f2791c-083f-5f95-a9ee-c6cbcf07a8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f4fdb-1533-4c38-a654-f715fbef6abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37f4fdb-1533-4c38-a654-f715fbef6abf.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "351ac8e7-77b1-548f-9a8c-a2847ef1f746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9e977-f718-41b2-b30b-77a9a17e9733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f9e977-f718-41b2-b30b-77a9a17e9733.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "566a357e-7469-513a-8123-7df7cc542f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde8b3e-c006-41fd-a926-8746c794e149.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cde8b3e-c006-41fd-a926-8746c794e149.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "22a0cb0c-791c-5899-83f3-033f51fff8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c705b843-ca62-47bb-95dd-f303c60088bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c705b843-ca62-47bb-95dd-f303c60088bb.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -8396,7 +8396,7 @@
         },
         {
             "id": "5fd00c20-e3d2-586d-91af-2701a638aa8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182308b3-86e0-46d8-9104-95576a3d3921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/182308b3-86e0-46d8-9104-95576a3d3921.jpg?1",
             "name": "Myr",
             "text": "",
             "colours": [],
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "b5e9130a-8862-51b5-abd3-147d3d2d9aee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e46e703-2157-41e5-9c21-c17af43e0d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e46e703-2157-41e5-9c21-c17af43e0d3f.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -8458,7 +8458,7 @@
         },
         {
             "id": "b6f48f68-a6b1-52b4-881a-273e566157fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee53b9a0-8e07-404d-87ae-ff8397a0ba29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee53b9a0-8e07-404d-87ae-ff8397a0ba29.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [],
@@ -8489,7 +8489,7 @@
         },
         {
             "id": "37d32a67-9435-513a-bbe1-48b94ae9ab12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856e308d-6268-4311-9667-c2f761db8f99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/856e308d-6268-4311-9667-c2f761db8f99.jpg?1",
             "name": "Poison Counter",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/STA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/STA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "88efa464-925a-5de1-a66a-5cdf8d159277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d18742-d661-4223-8880-9ed995379b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0d18742-d661-4223-8880-9ed995379b2e.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "9d2a92b9-948b-58b9-9c65-d38bba0eec61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf85d00-52cc-4594-b4fd-5ec424210524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf85d00-52cc-4594-b4fd-5ec424210524.jpg?1",
             "name": "Day of Judgment",
             "text": "",
             "colours": [
@@ -74,7 +74,7 @@
         },
         {
             "id": "48cfda73-cf41-5982-98ed-43edb8cae82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f339-4afb-477a-9434-e6cd9126cd10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade8f339-4afb-477a-9434-e6cd9126cd10.jpg?1",
             "name": "Defiant Strike",
             "text": "",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "178d0b92-79cc-5852-868c-023fbeecbcbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3b199-92a0-4d94-819c-fbf24a87d353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae3b199-92a0-4d94-819c-fbf24a87d353.jpg?1",
             "name": "Divine Gambit",
             "text": "",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "adddd59b-3e9a-5442-b845-e0b6d6ec3893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5092f-cd24-4aea-824e-67b9767019b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be5092f-cd24-4aea-824e-67b9767019b2.jpg?1",
             "name": "Ephemerate",
             "text": "",
             "colours": [
@@ -179,7 +179,7 @@
         },
         {
             "id": "b2c6af8d-cf32-5912-bddb-84618802cde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bc15bf-1923-45d7-988f-9a4adf3982ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bc15bf-1923-45d7-988f-9a4adf3982ee.jpg?1",
             "name": "Gift of Estates",
             "text": "",
             "colours": [
@@ -214,7 +214,7 @@
         },
         {
             "id": "efa08b5e-7551-50eb-a884-1874730b2d8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e547cd-eba4-4a75-9c4e-8eeb6e00ddc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e547cd-eba4-4a75-9c4e-8eeb6e00ddc4.jpg?1",
             "name": "Gods Willing",
             "text": "",
             "colours": [
@@ -249,7 +249,7 @@
         },
         {
             "id": "74fa505a-c62e-5cfe-b0b2-182cf86ff304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f32354-893d-4f0b-b555-e0757fb5443b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7f32354-893d-4f0b-b555-e0757fb5443b.jpg?1",
             "name": "Mana Tithe",
             "text": "",
             "colours": [
@@ -284,7 +284,7 @@
         },
         {
             "id": "f92b7147-0e3c-5d8a-9633-3b1aabc86e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da7312-91e8-4f8d-84ef-6888360b3718.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8da7312-91e8-4f8d-84ef-6888360b3718.jpg?1",
             "name": "Revitalize",
             "text": "",
             "colours": [
@@ -319,7 +319,7 @@
         },
         {
             "id": "0590be09-b330-5ebe-b4bb-4fa5d2b3906d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9ece2f-7eda-4fc5-a562-3e16e71560e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9ece2f-7eda-4fc5-a562-3e16e71560e9.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "c84aa1e0-61f0-5b48-bdca-9c5617378bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e21c8c-5ad1-4830-8621-f0fd6500ca79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28e21c8c-5ad1-4830-8621-f0fd6500ca79.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -389,7 +389,7 @@
         },
         {
             "id": "7614890a-ea60-5a3d-9029-5ff0ea90fd8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cad77b5-94eb-4715-9fc1-75c45c28e83a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cad77b5-94eb-4715-9fc1-75c45c28e83a.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "de91326d-b96c-5b5d-a357-efd949296c4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d27509-07c2-4445-a1d5-e56523fb8566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d27509-07c2-4445-a1d5-e56523fb8566.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "dffa8fdb-f9c0-5d3b-8206-1d544724a4fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f578fbf-c3c7-4407-9fda-3c13b165798c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f578fbf-c3c7-4407-9fda-3c13b165798c.jpg?1",
             "name": "Compulsive Research",
             "text": "",
             "colours": [
@@ -494,7 +494,7 @@
         },
         {
             "id": "7b1ef751-82d0-5318-8a19-3e159c8ab41a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf9d2a-c163-43df-9a2f-20b8749c86ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf9d2a-c163-43df-9a2f-20b8749c86ae.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "834c37f7-8d88-58fe-b00b-8c5b53bb3576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c1b465-b6d9-491b-bfc2-c034cc825d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98c1b465-b6d9-491b-bfc2-c034cc825d27.jpg?1",
             "name": "Memory Lapse",
             "text": "",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "377b3bc0-2182-5a7e-b0a9-1a127026e087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f4e609-7fb7-4903-8d4c-45d38cf743be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f4e609-7fb7-4903-8d4c-45d38cf743be.jpg?1",
             "name": "Mind's Desire",
             "text": "",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "cd52f045-8069-5cbf-a1ed-6bdfcbd3c73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfe3a17-3349-4fcc-a9b5-418faa55cc43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfe3a17-3349-4fcc-a9b5-418faa55cc43.jpg?1",
             "name": "Negate",
             "text": "",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "9f35aba6-72d9-565b-bb8b-2ba628282b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab59ac4f-2a77-4566-85c0-32666447dcf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab59ac4f-2a77-4566-85c0-32666447dcf2.jpg?1",
             "name": "Opt",
             "text": "",
             "colours": [
@@ -669,7 +669,7 @@
         },
         {
             "id": "aba109b4-61b3-518a-84e6-dcc73d892e88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7b2ee8-9f2f-4624-a788-15b88e6a2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7b2ee8-9f2f-4624-a788-15b88e6a2d50.jpg?1",
             "name": "Strategic Planning",
             "text": "",
             "colours": [
@@ -704,7 +704,7 @@
         },
         {
             "id": "0812003f-f7a8-59aa-b5ec-c5fb3fb9af2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e5dbfd-84cf-4fe1-850f-3d2965ed3120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e5dbfd-84cf-4fe1-850f-3d2965ed3120.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "",
             "colours": [
@@ -739,7 +739,7 @@
         },
         {
             "id": "aab28e8e-a9c6-5cdc-86b4-204292662a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e70332c-de0b-45ce-bbd1-5de4314c08db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e70332c-de0b-45ce-bbd1-5de4314c08db.jpg?1",
             "name": "Time Warp",
             "text": "",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "e942282d-8dcc-5730-9681-1fe21ba4ae75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a0c25a-8760-44ea-a418-fcd4a9761632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a0c25a-8760-44ea-a418-fcd4a9761632.jpg?1",
             "name": "Whirlwind Denial",
             "text": "",
             "colours": [
@@ -809,7 +809,7 @@
         },
         {
             "id": "26304f37-675a-5832-b1f5-e4f0aadad1c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b7f7bd-6db3-4716-b1c3-015b0a6d37e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57b7f7bd-6db3-4716-b1c3-015b0a6d37e3.jpg?1",
             "name": "Agonizing Remorse",
             "text": "",
             "colours": [
@@ -844,7 +844,7 @@
         },
         {
             "id": "50e6dca0-a622-5670-8117-9375b34afef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ccea48-ee90-4da8-832d-8c30c98bf1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ccea48-ee90-4da8-832d-8c30c98bf1dd.jpg?1",
             "name": "Crux of Fate",
             "text": "",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "817f1fd9-bd59-595a-a51c-e1b72005a739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc57076-cac4-4f5e-956b-e3d77bd258b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc57076-cac4-4f5e-956b-e3d77bd258b2.jpg?1",
             "name": "Dark Ritual",
             "text": "",
             "colours": [
@@ -914,7 +914,7 @@
         },
         {
             "id": "f2aa69f2-db69-5564-8661-d51855c6796a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009ba46-c9f8-46dc-8ffc-2aa4cef7b17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3009ba46-c9f8-46dc-8ffc-2aa4cef7b17c.jpg?1",
             "name": "Demonic Tutor",
             "text": "",
             "colours": [
@@ -949,7 +949,7 @@
         },
         {
             "id": "0c3b0de9-32a1-557f-ab42-1b886c73e625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6c0fe2-a82b-42cb-8629-b9f00b7f08e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e6c0fe2-a82b-42cb-8629-b9f00b7f08e9.jpg?1",
             "name": "Doom Blade",
             "text": "",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "103e51a2-feca-56d0-bb6c-f77d0e3a0ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb89f3f-f3b0-402d-9f3c-5b4b8a9d1e91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bb89f3f-f3b0-402d-9f3c-5b4b8a9d1e91.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -1019,7 +1019,7 @@
         },
         {
             "id": "8ffef6e3-ee90-5a11-8187-65e0770ca8e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b2b50-ac83-4a78-8f84-580193d1ca0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55b2b50-ac83-4a78-8f84-580193d1ca0f.jpg?1",
             "name": "Eliminate",
             "text": "",
             "colours": [
@@ -1054,7 +1054,7 @@
         },
         {
             "id": "6899e4fb-846e-5fb1-90d3-f63df501fcc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47df2c2-437d-4b8e-82cc-1707e3efd5b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d47df2c2-437d-4b8e-82cc-1707e3efd5b5.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "",
             "colours": [
@@ -1089,7 +1089,7 @@
         },
         {
             "id": "cd5f30e5-b26d-594d-b827-552510ad5cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef84fcc-7685-41e5-bcd0-25b974ce570f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef84fcc-7685-41e5-bcd0-25b974ce570f.jpg?1",
             "name": "Sign in Blood",
             "text": "",
             "colours": [
@@ -1124,7 +1124,7 @@
         },
         {
             "id": "2b2cf787-360b-528c-82a6-94954930ec4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c92756f-1dc2-49be-bb38-0f8cf10079fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c92756f-1dc2-49be-bb38-0f8cf10079fa.jpg?1",
             "name": "Tainted Pact",
             "text": "",
             "colours": [
@@ -1159,7 +1159,7 @@
         },
         {
             "id": "712fcd6d-86d2-5103-999e-b4ae10ef89f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659d0ca7-90c9-473a-8b46-4fe40351b57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659d0ca7-90c9-473a-8b46-4fe40351b57d.jpg?1",
             "name": "Tendrils of Agony",
             "text": "",
             "colours": [
@@ -1194,7 +1194,7 @@
         },
         {
             "id": "748b5456-64a6-587e-a334-ebf09bd1fff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3de5c0-acda-4116-b0c5-eceb2c19cb2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da3de5c0-acda-4116-b0c5-eceb2c19cb2d.jpg?1",
             "name": "Village Rites",
             "text": "",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "ac375796-adb4-5e37-bb1b-304b360f0df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0a3996-5a03-481b-9bda-15c6f6e5f9c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d0a3996-5a03-481b-9bda-15c6f6e5f9c4.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -1264,7 +1264,7 @@
         },
         {
             "id": "e259e555-7c57-5e1b-a4a7-4e2d2af428ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cb6157-ea56-4921-b803-59e3fbef0b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cb6157-ea56-4921-b803-59e3fbef0b94.jpg?1",
             "name": "Claim the Firstborn",
             "text": "",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "0639be88-adee-5b9b-94d3-efcb6ff8542f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b429172f-2182-49dd-b6f6-e5e09493628d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b429172f-2182-49dd-b6f6-e5e09493628d.jpg?1",
             "name": "Faithless Looting",
             "text": "",
             "colours": [
@@ -1334,7 +1334,7 @@
         },
         {
             "id": "0e49e698-cb26-5392-9d1a-6c4803991150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99b45df-9602-4037-a695-09decb5f21d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99b45df-9602-4037-a695-09decb5f21d7.jpg?1",
             "name": "Grapeshot",
             "text": "",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "a93f901c-e74f-5a71-9be5-8b8c70a17d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef32c03-14f5-4ee2-af3a-4cbee45cd152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ef32c03-14f5-4ee2-af3a-4cbee45cd152.jpg?1",
             "name": "Increasing Vengeance",
             "text": "",
             "colours": [
@@ -1404,7 +1404,7 @@
         },
         {
             "id": "3024219e-e13e-5d49-b57e-564164bc7ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5dfad-c8b4-46cc-9a06-73d23b269df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a5dfad-c8b4-46cc-9a06-73d23b269df8.jpg?1",
             "name": "Infuriate",
             "text": "",
             "colours": [
@@ -1439,7 +1439,7 @@
         },
         {
             "id": "952756ad-89fd-5524-95dc-baaa99cdbc19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaac4fd-95f5-4f38-b593-0101e79a20f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eaac4fd-95f5-4f38-b593-0101e79a20f9.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "42da1cdd-b371-50bc-b674-8f5e235193b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89978bd5-8222-4052-9625-3a5db81baa27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89978bd5-8222-4052-9625-3a5db81baa27.jpg?1",
             "name": "Mizzix's Mastery",
             "text": "",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "a2e4a35d-ff98-5460-ad3c-2d98a711f4e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60eeb025-704c-4a82-90b2-f91202ae30d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60eeb025-704c-4a82-90b2-f91202ae30d9.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "d15d4f5f-55a3-54d5-a94e-f75e234cf0e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60687e5-9384-4453-833e-2c76f25bfac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f60687e5-9384-4453-833e-2c76f25bfac5.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -1579,7 +1579,7 @@
         },
         {
             "id": "d6a74ae0-8494-54e6-b218-eafd3d1736bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ba24c2-73c3-4630-bb8e-7431e5b3aebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ba24c2-73c3-4630-bb8e-7431e5b3aebd.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "e0139acf-4043-52b6-a831-4ee7894f0214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e9897-d84c-4992-9e8e-3a00f377c7e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80e9897-d84c-4992-9e8e-3a00f377c7e5.jpg?1",
             "name": "Urza's Rage",
             "text": "",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "1d9cabd0-0d9a-5889-a42e-dfbef37723dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16782095-0b7f-4489-8a97-b74f8efef352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16782095-0b7f-4489-8a97-b74f8efef352.jpg?1",
             "name": "Abundant Harvest",
             "text": "",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "ea235ab0-fb4c-592b-ab41-29152e12a95d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b44893-e6d1-48d0-ba69-06b9569e1e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7b44893-e6d1-48d0-ba69-06b9569e1e38.jpg?1",
             "name": "Adventurous Impulse",
             "text": "",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "8f19c488-4679-5a78-b741-87ead6b987e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07a16f-d836-40f9-85e3-a78582a97109.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e07a16f-d836-40f9-85e3-a78582a97109.jpg?1",
             "name": "Channel",
             "text": "",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "c66ab597-41eb-5630-9649-188f334995cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3896717-1e46-4aa2-88b7-1c4fe76edde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3896717-1e46-4aa2-88b7-1c4fe76edde1.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -1789,7 +1789,7 @@
         },
         {
             "id": "7734305a-0e03-58c9-81c6-08e8b49277b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1f1110-0919-49cd-8b5b-979b2744fd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1f1110-0919-49cd-8b5b-979b2744fd3c.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -1824,7 +1824,7 @@
         },
         {
             "id": "f4815e02-8a63-5264-8690-ac8c16f3032e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f847439f-a9b6-4a3c-abd1-76d54e0aed99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f847439f-a9b6-4a3c-abd1-76d54e0aed99.jpg?1",
             "name": "Krosan Grip",
             "text": "",
             "colours": [
@@ -1859,7 +1859,7 @@
         },
         {
             "id": "f2dcba03-a3af-5765-a1cc-cf9d5c74be12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb72f05-5173-4e70-9e71-278249b378e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bb72f05-5173-4e70-9e71-278249b378e7.jpg?1",
             "name": "Natural Order",
             "text": "",
             "colours": [
@@ -1894,7 +1894,7 @@
         },
         {
             "id": "cc9bd5a0-29d0-567a-acf2-e4802f2b8e66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a95986b-532b-4e3a-acf4-c93c6db7282f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a95986b-532b-4e3a-acf4-c93c6db7282f.jpg?1",
             "name": "Primal Command",
             "text": "",
             "colours": [
@@ -1929,7 +1929,7 @@
         },
         {
             "id": "57c98957-faf8-5e50-b99d-e3a759b8b95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af727601-5251-48b6-b5e3-b68ca0608bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af727601-5251-48b6-b5e3-b68ca0608bc9.jpg?1",
             "name": "Regrowth",
             "text": "",
             "colours": [
@@ -1964,7 +1964,7 @@
         },
         {
             "id": "2ee6bf47-28c5-572c-bf13-814d89b0c97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9849b22-1fba-4f6a-bd94-df1bc1764e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9849b22-1fba-4f6a-bd94-df1bc1764e6b.jpg?1",
             "name": "Snakeskin Veil",
             "text": "",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "89201a00-004d-5c31-8ec3-22aa29955cc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f960f2-1324-4d48-bab7-c46b836a8907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f960f2-1324-4d48-bab7-c46b836a8907.jpg?1",
             "name": "Weather the Storm",
             "text": "",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "4e12c252-8472-585d-ab45-0899b881964d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2743ca3-8b4a-429a-9f9b-090d632b6601.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2743ca3-8b4a-429a-9f9b-090d632b6601.jpg?1",
             "name": "Despark",
             "text": "",
             "colours": [
@@ -2071,7 +2071,7 @@
         },
         {
             "id": "5505e002-9b32-5663-a6cf-e0f7feafdc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a4d142-b98b-4027-94cb-314f67fb1d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08a4d142-b98b-4027-94cb-314f67fb1d4a.jpg?1",
             "name": "Electrolyze",
             "text": "",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "548269c5-ec1b-57c9-9ee7-3ddf15b87342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f9b3d-d463-4bc6-b822-872a1f8867c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9f9b3d-d463-4bc6-b822-872a1f8867c8.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "f954cf5c-27f6-5697-bbbb-d0e9e0e512a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227ac87a-7196-40d0-ab00-98ebafcca09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227ac87a-7196-40d0-ab00-98ebafcca09a.jpg?1",
             "name": "Lightning Helix",
             "text": "",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "5b8b55a6-e617-5193-ae47-fbf37c1e7039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3882ebea-2864-40ef-a21d-6ba80a0bd417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3882ebea-2864-40ef-a21d-6ba80a0bd417.jpg?1",
             "name": "Putrefy",
             "text": "",
             "colours": [
@@ -2219,7 +2219,7 @@
         },
         {
             "id": "ed046aad-eca7-5748-9758-45cf57ec808d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058a72-ebfe-4957-a7dd-ee7471db2498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a058a72-ebfe-4957-a7dd-ee7471db2498.jpg?1",
             "name": "Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "4e6a712b-1915-5a36-871f-509c1e80bee5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6d72d-ef92-46b2-853f-003ae6250d30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5e6d72d-ef92-46b2-853f-003ae6250d30.jpg?1",
             "name": "Day of Judgment",
             "text": "",
             "colours": [
@@ -2289,7 +2289,7 @@
         },
         {
             "id": "f0b1e552-c3ae-55e4-87d4-b74e2603fe4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7d1e-8bf9-4558-9480-6f0423f36b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/447c7d1e-8bf9-4558-9480-6f0423f36b81.jpg?1",
             "name": "Defiant Strike",
             "text": "",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "12bcd131-e24e-5e41-90b9-a4029e7b4b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac62fae3-2525-4b71-80d1-83e608070e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac62fae3-2525-4b71-80d1-83e608070e4f.jpg?1",
             "name": "Divine Gambit",
             "text": "",
             "colours": [
@@ -2359,7 +2359,7 @@
         },
         {
             "id": "d408e6ad-7071-52f4-97fa-171008b0db3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704397a-c180-44ae-9e4e-90180556b87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f704397a-c180-44ae-9e4e-90180556b87b.jpg?1",
             "name": "Ephemerate",
             "text": "",
             "colours": [
@@ -2394,7 +2394,7 @@
         },
         {
             "id": "be9bf7bc-4443-542e-ac67-8d250301762c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfaa364-55d3-402b-83f0-69ffae82304f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdfaa364-55d3-402b-83f0-69ffae82304f.jpg?1",
             "name": "Gift of Estates",
             "text": "",
             "colours": [
@@ -2429,7 +2429,7 @@
         },
         {
             "id": "7f3eaea7-fb9e-5f64-8b51-9bf425d7233c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54bc478b-fb90-4071-acdd-ae6ff33334fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54bc478b-fb90-4071-acdd-ae6ff33334fd.jpg?1",
             "name": "Gods Willing",
             "text": "",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "8b415ddf-2d01-5e98-9b14-ac39df65cc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89aafeb7-31e3-4389-9c4e-4903c342a021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89aafeb7-31e3-4389-9c4e-4903c342a021.jpg?1",
             "name": "Mana Tithe",
             "text": "",
             "colours": [
@@ -2499,7 +2499,7 @@
         },
         {
             "id": "55405865-7008-553b-b538-9230c3097376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dbdc3f-aa48-4a59-adab-e0a8e981295a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64dbdc3f-aa48-4a59-adab-e0a8e981295a.jpg?1",
             "name": "Revitalize",
             "text": "",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "54146218-c228-5e3f-b7de-58fe8df5aabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d364f3-e3e7-46fb-8273-aabd56ded0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d364f3-e3e7-46fb-8273-aabd56ded0c5.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -2569,7 +2569,7 @@
         },
         {
             "id": "e96b5624-8d29-5d50-a9e4-7d76c84588a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f56fbb-c88a-4d10-a6c1-fef72403c4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f56fbb-c88a-4d10-a6c1-fef72403c4b9.jpg?1",
             "name": "Teferi's Protection",
             "text": "",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "58b1d759-8203-5f28-bdd6-560ed86c9197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ca1405-fb1d-467b-ab00-f28fc0fe6c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ca1405-fb1d-467b-ab00-f28fc0fe6c03.jpg?1",
             "name": "Blue Sun's Zenith",
             "text": "",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "ca755309-6af6-58f4-aa3b-46c39e59a94c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6118d1d-28c1-4f54-97cb-c4f934b6739c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6118d1d-28c1-4f54-97cb-c4f934b6739c.jpg?1",
             "name": "Brainstorm",
             "text": "",
             "colours": [
@@ -2674,7 +2674,7 @@
         },
         {
             "id": "8c0010d7-e40f-5d61-b6f1-6ff66d3dacb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5bd95-4de8-4acc-8e6f-bbfbf55d57a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76e5bd95-4de8-4acc-8e6f-bbfbf55d57a9.jpg?1",
             "name": "Compulsive Research",
             "text": "",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "401e8986-c5d1-5d58-a8af-5e4986281bc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8118282a-1473-4c0b-a283-1f58e0d0209a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8118282a-1473-4c0b-a283-1f58e0d0209a.jpg?1",
             "name": "Counterspell",
             "text": "",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "d7fdf083-e660-5529-b274-6188542b34fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13636e52-aee6-4262-9b4d-a2979193bfa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13636e52-aee6-4262-9b4d-a2979193bfa3.jpg?1",
             "name": "Memory Lapse",
             "text": "",
             "colours": [
@@ -2779,7 +2779,7 @@
         },
         {
             "id": "c9f23490-55b7-5c3c-a1fb-d59c8d38cb47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7550cf1f-bf03-489e-8ec5-19c835f785ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/7550cf1f-bf03-489e-8ec5-19c835f785ff.jpg?1",
             "name": "Mind's Desire",
             "text": "",
             "colours": [
@@ -2814,7 +2814,7 @@
         },
         {
             "id": "6c82bc6b-0e97-5283-ae43-e5d16f53e19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35308c10-f8e9-4c35-a680-a3dfe16ac63a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35308c10-f8e9-4c35-a680-a3dfe16ac63a.jpg?1",
             "name": "Negate",
             "text": "",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "147f4ba1-2e38-557c-bce6-4c9c46654d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5017e7-2da9-48be-8dc3-458a1374b97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5017e7-2da9-48be-8dc3-458a1374b97c.jpg?1",
             "name": "Opt",
             "text": "",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "a0989a7f-3ab5-5cf6-9581-312186301a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f48a9-4d6a-4ca6-b99e-d6b1dfac7e04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5f48a9-4d6a-4ca6-b99e-d6b1dfac7e04.jpg?1",
             "name": "Strategic Planning",
             "text": "",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "ca46692a-ee82-520f-931f-3810b818e6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de53b7d-f2de-47aa-b5d4-9427c12484b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6de53b7d-f2de-47aa-b5d4-9427c12484b0.jpg?1",
             "name": "Tezzeret's Gambit",
             "text": "",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "1701ae3a-110d-5281-946a-cae994a333d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f0f4cb-1ef6-44cd-8cca-1d1e138c0344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34f0f4cb-1ef6-44cd-8cca-1d1e138c0344.jpg?1",
             "name": "Time Warp",
             "text": "",
             "colours": [
@@ -2989,7 +2989,7 @@
         },
         {
             "id": "f41d4b9d-8e58-56d6-a889-92024fde8001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7949ab59-cd09-4500-a323-5ba05392623f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7949ab59-cd09-4500-a323-5ba05392623f.jpg?1",
             "name": "Whirlwind Denial",
             "text": "",
             "colours": [
@@ -3024,7 +3024,7 @@
         },
         {
             "id": "d50b8669-352c-58d9-8cb4-6352e1f0a5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31b98f3-acc0-4113-8f70-86bf2d36b9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31b98f3-acc0-4113-8f70-86bf2d36b9c1.jpg?1",
             "name": "Agonizing Remorse",
             "text": "",
             "colours": [
@@ -3059,7 +3059,7 @@
         },
         {
             "id": "bc6e4406-cd15-5fea-b6db-4244ded0c3bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb53cc-384e-4ae2-afa5-541100c92951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb53cc-384e-4ae2-afa5-541100c92951.jpg?1",
             "name": "Crux of Fate",
             "text": "",
             "colours": [
@@ -3094,7 +3094,7 @@
         },
         {
             "id": "3dc7594d-7284-57ad-ac69-6df7721f55d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734cb11-2024-411f-9885-dafda14bb431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b734cb11-2024-411f-9885-dafda14bb431.jpg?1",
             "name": "Dark Ritual",
             "text": "",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "b076bded-cee7-5f26-b9d8-3540918f68fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b6e466-784b-48a6-8e72-beff72f39231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b6e466-784b-48a6-8e72-beff72f39231.jpg?1",
             "name": "Demonic Tutor",
             "text": "",
             "colours": [
@@ -3164,7 +3164,7 @@
         },
         {
             "id": "ac7ced0f-271b-5894-bad8-b18ae97683c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6565f48-185f-4977-8edc-4840b784d29d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6565f48-185f-4977-8edc-4840b784d29d.jpg?1",
             "name": "Doom Blade",
             "text": "",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "306faf06-ccfb-52ec-a65c-472844647a09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e96127-83e2-42e2-9799-998b1408d444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11e96127-83e2-42e2-9799-998b1408d444.jpg?1",
             "name": "Duress",
             "text": "",
             "colours": [
@@ -3234,7 +3234,7 @@
         },
         {
             "id": "323320b5-ac87-5bbc-ae38-1ce1bc04f876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e93381-0192-4b89-af64-dcc7150b757b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e93381-0192-4b89-af64-dcc7150b757b.jpg?1",
             "name": "Eliminate",
             "text": "",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "66dea51f-cfc8-5b34-8eb7-0d3c9b576c88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6af6cee-a60a-4953-8e22-c3bddc435619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6af6cee-a60a-4953-8e22-c3bddc435619.jpg?1",
             "name": "Inquisition of Kozilek",
             "text": "",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "cc4c252a-2218-570b-bd74-507b4bd6532e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d32dfc4-ba8f-4421-b05f-4bf3afd592f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d32dfc4-ba8f-4421-b05f-4bf3afd592f7.jpg?1",
             "name": "Sign in Blood",
             "text": "",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "d61b8327-42fb-5ce2-a75d-e1446ceb5c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8f466f-83ec-4d72-90de-0e30069f7ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8f466f-83ec-4d72-90de-0e30069f7ecd.jpg?1",
             "name": "Tainted Pact",
             "text": "",
             "colours": [
@@ -3374,7 +3374,7 @@
         },
         {
             "id": "dff7bd91-c681-54e3-becd-1b5dec60a02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1541b593-a7f1-4e6b-aff6-d6341cf8fec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1541b593-a7f1-4e6b-aff6-d6341cf8fec5.jpg?1",
             "name": "Tendrils of Agony",
             "text": "",
             "colours": [
@@ -3409,7 +3409,7 @@
         },
         {
             "id": "271a4d0e-c34c-5d67-af23-fc6b43e92794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e6276c-0b80-4d11-b889-8a24b210c4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e6276c-0b80-4d11-b889-8a24b210c4f0.jpg?1",
             "name": "Village Rites",
             "text": "",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "ff95a769-1dd1-5576-bd0a-c754a73580b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb63b8-9c7f-411a-a1bf-6c9cccdc6307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cbb63b8-9c7f-411a-a1bf-6c9cccdc6307.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -3479,7 +3479,7 @@
         },
         {
             "id": "552dcb7d-66a5-5ef2-9b97-b87823452a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fba553e-eca3-453e-8f67-ec7e5c9f3946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fba553e-eca3-453e-8f67-ec7e5c9f3946.jpg?1",
             "name": "Claim the Firstborn",
             "text": "",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "f01f5f69-d141-5648-9db8-9261cfc16743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052a5cd-81b3-40ef-94e0-7c89e9554e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7052a5cd-81b3-40ef-94e0-7c89e9554e33.jpg?1",
             "name": "Faithless Looting",
             "text": "",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "c0a2cbd7-84cb-5158-93f5-71a439fb7f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc58957e-dbf0-40ac-9ec4-05fea0c61880.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc58957e-dbf0-40ac-9ec4-05fea0c61880.jpg?1",
             "name": "Grapeshot",
             "text": "",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "1c5df8c2-95a9-5bf0-8910-244cb8f33324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4867546-a609-4958-a48e-522fb9258faf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4867546-a609-4958-a48e-522fb9258faf.jpg?1",
             "name": "Increasing Vengeance",
             "text": "",
             "colours": [
@@ -3619,7 +3619,7 @@
         },
         {
             "id": "ae5d691c-6ddf-58b0-ada0-4a1c07fd904e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67983e97-a990-4f89-811c-a58a0a10a701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67983e97-a990-4f89-811c-a58a0a10a701.jpg?1",
             "name": "Infuriate",
             "text": "",
             "colours": [
@@ -3654,7 +3654,7 @@
         },
         {
             "id": "440af151-df38-5152-979d-84009ab7e1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14fae63-2e82-49c1-8e62-d84a65f27479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14fae63-2e82-49c1-8e62-d84a65f27479.jpg?1",
             "name": "Lightning Bolt",
             "text": "",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "655b0332-f1f3-5826-9267-1f09f5e25a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25534-2bc3-4813-ae63-63cadfe36df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e25534-2bc3-4813-ae63-63cadfe36df6.jpg?1",
             "name": "Mizzix's Mastery",
             "text": "",
             "colours": [
@@ -3724,7 +3724,7 @@
         },
         {
             "id": "bfa5663c-7ba1-59c7-b3f4-e59f2e4c838d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a8702-464b-44fd-b706-8a73dd9b0097.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a8702-464b-44fd-b706-8a73dd9b0097.jpg?1",
             "name": "Shock",
             "text": "",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "7f74148c-89e5-5b9a-995c-1ba08dab347c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290f3d7-3c45-464c-afae-78bb2615aaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d290f3d7-3c45-464c-afae-78bb2615aaf4.jpg?1",
             "name": "Stone Rain",
             "text": "",
             "colours": [
@@ -3794,7 +3794,7 @@
         },
         {
             "id": "daee9af1-069c-5c25-8582-6b40867e1ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05123ba5-7e35-4d3f-8354-e784ce8f1b98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05123ba5-7e35-4d3f-8354-e784ce8f1b98.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -3829,7 +3829,7 @@
         },
         {
             "id": "624254f7-c66d-5443-a51f-3df1d232c3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d27e1f-ed0d-44c6-8070-d764d4e9c0fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60d27e1f-ed0d-44c6-8070-d764d4e9c0fb.jpg?1",
             "name": "Urza's Rage",
             "text": "",
             "colours": [
@@ -3864,7 +3864,7 @@
         },
         {
             "id": "b9170a8e-452a-5f9d-8452-7ffbb762da24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb246be3-d9cb-4753-8d8c-0c770a584090.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb246be3-d9cb-4753-8d8c-0c770a584090.jpg?1",
             "name": "Abundant Harvest",
             "text": "",
             "colours": [
@@ -3899,7 +3899,7 @@
         },
         {
             "id": "d19869ca-98cd-58a0-a17e-0e5d518c382e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c56784-e106-4f17-a1a3-2c0bbb41d316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c56784-e106-4f17-a1a3-2c0bbb41d316.jpg?1",
             "name": "Adventurous Impulse",
             "text": "",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "ed372693-6581-5688-8c9f-5eb8927980b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f4583d-a532-4c67-ad50-138f35fa7490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f4583d-a532-4c67-ad50-138f35fa7490.jpg?1",
             "name": "Channel",
             "text": "",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "bd664d3f-7430-5f0f-95e8-cde214836267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8386ca9-0359-4a18-abea-0cb0e955a947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8386ca9-0359-4a18-abea-0cb0e955a947.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -4004,7 +4004,7 @@
         },
         {
             "id": "07e6a104-44d6-5ec4-859f-9d9af3d3204b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb853d72-9b29-4ea1-80db-da9e0b547ad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb853d72-9b29-4ea1-80db-da9e0b547ad5.jpg?1",
             "name": "Harmonize",
             "text": "",
             "colours": [
@@ -4039,7 +4039,7 @@
         },
         {
             "id": "1a23f3a0-c996-55b2-afbe-6662c30a9ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea70da6-8da5-4c9b-8b6d-6a876b046274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea70da6-8da5-4c9b-8b6d-6a876b046274.jpg?1",
             "name": "Krosan Grip",
             "text": "",
             "colours": [
@@ -4074,7 +4074,7 @@
         },
         {
             "id": "f1a12f85-224c-5cc6-b7c4-438d46ea6028",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac43bf2-08e1-4b63-ac4f-ccc565ca2cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac43bf2-08e1-4b63-ac4f-ccc565ca2cee.jpg?1",
             "name": "Natural Order",
             "text": "",
             "colours": [
@@ -4109,7 +4109,7 @@
         },
         {
             "id": "5d130600-f768-58db-804b-9498c0080b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f2c89-dbe9-4b44-b892-8e2325860e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5f2c89-dbe9-4b44-b892-8e2325860e62.jpg?1",
             "name": "Primal Command",
             "text": "",
             "colours": [
@@ -4144,7 +4144,7 @@
         },
         {
             "id": "52fdddb8-ba70-5af9-a307-fe74d2f90e89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d0ec3e-10c6-4401-a21f-b767318120b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d0ec3e-10c6-4401-a21f-b767318120b6.jpg?1",
             "name": "Regrowth",
             "text": "",
             "colours": [
@@ -4179,7 +4179,7 @@
         },
         {
             "id": "df348b74-ab45-5fcd-8103-9b959ab7690d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e909bd04-5394-4888-aa4a-4f90855663bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e909bd04-5394-4888-aa4a-4f90855663bb.jpg?1",
             "name": "Snakeskin Veil",
             "text": "",
             "colours": [
@@ -4214,7 +4214,7 @@
         },
         {
             "id": "24fe9ab0-39ed-582a-b9d5-3b4b94624f8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b9f50-2b6c-4ef5-8b72-0bf7e160909e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7b9f50-2b6c-4ef5-8b72-0bf7e160909e.jpg?1",
             "name": "Weather the Storm",
             "text": "",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "c8e877ab-1888-5e7a-bb97-2fd8f7a447d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e0de9d-de5b-4a95-95af-aef4cc546a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e0de9d-de5b-4a95-95af-aef4cc546a94.jpg?1",
             "name": "Despark",
             "text": "",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "fd84e759-71d3-5168-8a2e-d664c45429f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8212125e-1742-41db-a7e9-32df59441f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8212125e-1742-41db-a7e9-32df59441f4e.jpg?1",
             "name": "Electrolyze",
             "text": "",
             "colours": [
@@ -4323,7 +4323,7 @@
         },
         {
             "id": "5ffc4691-8ad0-5098-bedd-82123231fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffea9e1d-10e1-458b-afba-e33ce9695322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffea9e1d-10e1-458b-afba-e33ce9695322.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -4360,7 +4360,7 @@
         },
         {
             "id": "2a940483-818a-5090-9d38-ac59eaed5521",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47eb569f-9f8d-4856-acf9-f8e87baa19d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47eb569f-9f8d-4856-acf9-f8e87baa19d0.jpg?1",
             "name": "Lightning Helix",
             "text": "",
             "colours": [
@@ -4397,7 +4397,7 @@
         },
         {
             "id": "782fea05-9868-595d-889a-dcb6eb3034af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee093aa-87ad-4a9e-8edf-e397fb1dd6aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee093aa-87ad-4a9e-8edf-e397fb1dd6aa.jpg?1",
             "name": "Putrefy",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/STH.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/STH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "675bebc5-f1bd-5afb-9fd8-6539d4fefb7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ed559a-9a88-43d2-85d1-4bbec038f71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79ed559a-9a88-43d2-85d1-4bbec038f71e.jpg?1",
             "name": "Bandage",
             "text": "Prevent 1 damage to any creature or player.\nDraw a card.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "b2e435b3-11f6-564a-8945-41a51581a960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155fc239-c2eb-41cc-9a0a-2414da3c3d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155fc239-c2eb-41cc-9a0a-2414da3c3d7b.jpg?1",
             "name": "Calming Licid",
             "text": "o\nW, oc\nT: Calming Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature cannot attack\" instead of a creature. Move Calming Licid onto target creature. You may pay o\nW to end this effect.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "e0f32f03-8dfc-5ae7-8027-4b74d0a759a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afaf277e-b430-4c96-880c-ae654973478c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afaf277e-b430-4c96-880c-ae654973478c.jpg?1",
             "name": "Change of Heart",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature cannot attack this turn.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "933cbf49-c2d5-5c7c-a918-4c4e0e4b05ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848672be-b1cd-40ef-a7ed-ce1620aebd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848672be-b1cd-40ef-a7ed-ce1620aebd2e.jpg?1",
             "name": "Contemplation",
             "text": "Whenever you successfully cast a spell, gain 1 life.",
             "colours": [
@@ -130,7 +130,7 @@
         },
         {
             "id": "ce2f567b-34db-5dda-ad8e-38b30e070b03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190332b3-6a1c-4c25-af61-d8923fc9a0c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190332b3-6a1c-4c25-af61-d8923fc9a0c3.jpg?1",
             "name": "Conviction",
             "text": "Enchanted creature gets +1/+3.\noo\nW Return Conviction to owner's hand.",
             "colours": [
@@ -163,7 +163,7 @@
         },
         {
             "id": "75085e3d-ed0b-578c-9e47-2f621405d7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be86f1f-c85a-4396-aa16-a39fbf493c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be86f1f-c85a-4396-aa16-a39fbf493c96.jpg?1",
             "name": "Hidden Retreat",
             "text": "Choose a card in your hand and put it on top of your library: Prevent all damage from an instant or sorcery. (Treat further damage from that source normally.)",
             "colours": [
@@ -194,7 +194,7 @@
         },
         {
             "id": "b2e74650-cf80-553b-851c-bf97aedc2c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c44137-ddcc-42fa-baff-a0c3785b84ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c44137-ddcc-42fa-baff-a0c3785b84ee.jpg?1",
             "name": "Honor Guard",
             "text": "oo\nW Honor Guard gets +0/+1 until end of turn.",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "810874fa-d086-55bd-814a-5469f6f928a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7cd99c2-6d4a-48e8-8848-6fdc0788525d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7cd99c2-6d4a-48e8-8848-6fdc0788525d.jpg?1",
             "name": "Lancers en-Kor",
             "text": "Trample\no0: Redirect 1 damage from Lancers en-Kor to a creature you control.",
             "colours": [
@@ -262,7 +262,7 @@
         },
         {
             "id": "7e43fde6-6164-52f6-8e55-05733aaea941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a03c68-0ebe-488a-8e6c-7cbf7a448416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a03c68-0ebe-488a-8e6c-7cbf7a448416.jpg?1",
             "name": "Nomads en-Kor",
             "text": "o0: Redirect 1 damage from Nomads\nen-Kor to a creature you control.",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "f222e812-013d-5251-bdd5-12217fa71a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa577b1-2604-4065-a973-166521682a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa577b1-2604-4065-a973-166521682a86.jpg?1",
             "name": "Pursuit of Knowledge",
             "text": "Skip drawing a card: Put a study counter on Pursuit of Knowledge.\nRemove three study counters from Pursuit of Knowledge, Sacrifice Pursuit of Knowledge: Draw seven cards.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "9120f6dd-1fa6-570d-a6fd-6577d145e1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27e9c9-0a47-4fa3-9da5-1993f20305c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd27e9c9-0a47-4fa3-9da5-1993f20305c2.jpg?1",
             "name": "Rolling Stones",
             "text": "Walls can attack as though they were not Walls.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "186d626a-0758-5658-9a54-b469ff712e61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ae4b01-a9c1-4eec-9204-78cb2508e0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ae4b01-a9c1-4eec-9204-78cb2508e0df.jpg?1",
             "name": "Sacred Ground",
             "text": "Whenever an effect controlled by any opponent puts a land into your graveyard from play, put that land into play.",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "2c73e61e-a1e3-5154-8f93-b82ea14fc687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b21aa2e-df36-4101-89b6-515858f2ab88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b21aa2e-df36-4101-89b6-515858f2ab88.jpg?1",
             "name": "Samite Blessing",
             "text": "Enchanted creature gains \"oc\nT: Prevent all damage to any creature from any one source.\" (Treat further damage from that source normally.)",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "8fba3d96-0973-5145-98ab-d488c71793f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20454d36-d98d-4421-b3aa-d2dd4b368d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20454d36-d98d-4421-b3aa-d2dd4b368d84.jpg?1",
             "name": "Scapegoat",
             "text": "Sacrifice a creature: Return any number of target creatures you control to owner's hand.",
             "colours": [
@@ -454,7 +454,7 @@
         },
         {
             "id": "9225312b-0bc4-5731-81c4-ba550d7cdece",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a13c4c-d5c0-4947-bb68-d2e9611bcdea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a13c4c-d5c0-4947-bb68-d2e9611bcdea.jpg?1",
             "name": "Shaman en-Kor",
             "text": "o0: Redirect 1 damage from Shaman en-Kor to a creature you control.\no1oo\nW Redirect to Shaman en-Kor all damage dealt to any one creature from any one source.",
             "colours": [
@@ -489,7 +489,7 @@
         },
         {
             "id": "708332d1-35b0-53db-ab76-c23defb855a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb86621-1a6e-4d56-ab0e-531105775c56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb86621-1a6e-4d56-ab0e-531105775c56.jpg?1",
             "name": "Skyshroud Falcon",
             "text": "Flying\nAttacking does not cause Skyshroud Falcon to tap.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "eb74fc17-bf66-5a4d-b611-f0669e1dcbd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f165ad-cfe6-4a5d-8073-a70969494855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14f165ad-cfe6-4a5d-8073-a70969494855.jpg?1",
             "name": "Smite",
             "text": "Destroy target blocked creature.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "2c0ef642-0713-5393-bbeb-a23383b8c319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a112edf3-c976-426c-a407-e86255586e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a112edf3-c976-426c-a407-e86255586e41.jpg?1",
             "name": "Soltari Champion",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Champion attacks, all other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "26f8edd8-f69a-5e49-988c-764aab89b319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8adc368-ede3-4b1c-af93-a5e0f2e24d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8adc368-ede3-4b1c-af93-a5e0f2e24d83.jpg?1",
             "name": "Spirit en-Kor",
             "text": "Flying\no0: Redirect 1 damage from Spirit en-Kor to a creature you control.",
             "colours": [
@@ -621,7 +621,7 @@
         },
         {
             "id": "92a3aa8d-9893-531d-a889-e97c5350c0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bff910-24ab-45a0-b014-30bef6263c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4bff910-24ab-45a0-b014-30bef6263c38.jpg?1",
             "name": "Temper",
             "text": "Prevent up to X damage to target creature. For each 1 damage prevented in this way, put a +1/+1 counter on that creature.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "b615becb-2e05-5634-9e79-89280b090134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b8be3-4ed8-4e94-aa66-c7187a299088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/704b8be3-4ed8-4e94-aa66-c7187a299088.jpg?1",
             "name": "Venerable Monk",
             "text": "When Venerable Monk comes into play, gain 2 life.",
             "colours": [
@@ -687,7 +687,7 @@
         },
         {
             "id": "418f7715-2e6e-5205-a2b2-76f762188919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f237426-a657-4234-9f79-0a06558eeb39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f237426-a657-4234-9f79-0a06558eeb39.jpg?1",
             "name": "Wall of Essence",
             "text": "(Walls cannot attack.)\nFor each 1 combat damage dealt to Wall of Essence, gain 1 life.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "62bca95c-03f4-5226-96b9-0315db43adb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9ca33-3e9b-4ed9-b503-a1c09c17ca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16a9ca33-3e9b-4ed9-b503-a1c09c17ca8b.jpg?1",
             "name": "Warrior en-Kor",
             "text": "o0: Redirect 1 damage from Warrior en-Kor to a creature you control.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "bb9be985-8890-5773-93a1-e859e2ff4270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d2c6e3-e556-4cc6-94b6-fdbc62d6853e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d2c6e3-e556-4cc6-94b6-fdbc62d6853e.jpg?1",
             "name": "Warrior Angel",
             "text": "Flying\nFor each 1 damage Warrior Angel deals, gain 1 life.",
             "colours": [
@@ -789,7 +789,7 @@
         },
         {
             "id": "f5b894d4-cf06-513f-afdd-38711427b399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd3b7a7-c5e8-4179-ade3-31625620f3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd3b7a7-c5e8-4179-ade3-31625620f3a9.jpg?1",
             "name": "Youthful Knight",
             "text": "First strike",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "2b1d303c-14a8-541a-911e-c717d302d8d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d6c51-903b-4e0b-8702-291666581f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938d6c51-903b-4e0b-8702-291666581f2a.jpg?1",
             "name": "Cloud Spirit",
             "text": "Flying\nCloud Spirit can block only creatures with flying.",
             "colours": [
@@ -856,7 +856,7 @@
         },
         {
             "id": "ef342c7d-9d56-57d3-82cc-6bee47b9c745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fa8e60-c32f-4586-b133-224f0aec3355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fa8e60-c32f-4586-b133-224f0aec3355.jpg?1",
             "name": "Contempt",
             "text": "If enchanted creature attacks, return that creature and Contempt to owner's hand at end of combat.",
             "colours": [
@@ -889,7 +889,7 @@
         },
         {
             "id": "5c6b0226-1c2d-508c-a460-31cf3c2f41f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a22d9-007b-4eb7-af9e-b5c2cae36238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4a22d9-007b-4eb7-af9e-b5c2cae36238.jpg?1",
             "name": "Dream Halls",
             "text": "Instead of paying the casting cost for a spell of any color, its caster may choose and discard a card that shares at least one color with that spell. If the spell has o\nX in its casting cost, X is 0.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "4dc92ace-d99d-5ea2-afb1-aff99dc1fb61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1444f76b-c876-4166-b957-b17313221fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1444f76b-c876-4166-b957-b17313221fea.jpg?1",
             "name": "Dream Prowler",
             "text": "Dream Prowler is unblockable as long as no other creatures are attacking.",
             "colours": [
@@ -953,7 +953,7 @@
         },
         {
             "id": "f4eb5e64-6ab1-5c3c-8bcb-b74750b9d840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8ae53-a53f-4a0f-94f7-559aca041797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cb8ae53-a53f-4a0f-94f7-559aca041797.jpg?1",
             "name": "Evacuation",
             "text": "Return all creatures to owners' hands.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "cafe8b4e-1311-5e8a-a056-f715222abf8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0148f3ca-4dba-4408-86d0-1190c387ee69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0148f3ca-4dba-4408-86d0-1190c387ee69.jpg?1",
             "name": "Gliding Licid",
             "text": "o\nU, oc\nT: Gliding Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature gains flying\" instead of a creature. Move Gliding Licid onto target creature. You may pay o\nU to end this effect.",
             "colours": [
@@ -1017,7 +1017,7 @@
         },
         {
             "id": "86664b5b-f1ae-5d45-b0fa-b01c40af163c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854627ab-38bd-4894-94d8-9ef51a57579c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854627ab-38bd-4894-94d8-9ef51a57579c.jpg?1",
             "name": "Hammerhead Shark",
             "text": "Hammerhead Shark cannot attack unless defending player controls any islands.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "55d1ca21-c94e-5ee1-8388-bcb1bc51e28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ce5dbc-3597-42e8-859a-cac105c8102e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ce5dbc-3597-42e8-859a-cac105c8102e.jpg?1",
             "name": "Hesitation",
             "text": "If any spell is played, counter that spell and sacrifice Hesitation.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "7eca4342-5eb0-5d72-96b3-de3bb5015555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55f653-0952-4713-8d43-ca50acff9e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e55f653-0952-4713-8d43-ca50acff9e3b.jpg?1",
             "name": "Intruder Alarm",
             "text": "Creatures do not untap during their controllers' untap phases.\nWhenever any creature comes into play, untap all creatures.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "9c899942-cbf5-5b17-b229-c64917490240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0841423d-7a27-4bc5-9ac2-0ba47648c6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0841423d-7a27-4bc5-9ac2-0ba47648c6f1.jpg?1",
             "name": "Leap",
             "text": "Target creature gains flying until end of turn.\nDraw a card.",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "617799a8-2f8f-50a4-98fe-f2537f5c1563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcaf16d-aa02-43e2-aa38-bb1835d47a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abcaf16d-aa02-43e2-aa38-bb1835d47a05.jpg?1",
             "name": "Mana Leak",
             "text": "Counter target spell unless its caster pays an additional o3.",
             "colours": [
@@ -1174,7 +1174,7 @@
         },
         {
             "id": "36ca89b7-ada5-5906-9015-fca253ffc7c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09891c87-eb74-4174-ad46-11a7f79de859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09891c87-eb74-4174-ad46-11a7f79de859.jpg?1",
             "name": "Mask of the Mimic",
             "text": "Sacrifice a creature: Search your library for any copy of target creature card and put it into play. Shuffle your library afterwards.",
             "colours": [
@@ -1205,7 +1205,7 @@
         },
         {
             "id": "81ae7143-71fe-5f80-84c0-c5a237afb57f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da50979-1f5d-48d1-9406-dfc785273c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da50979-1f5d-48d1-9406-dfc785273c04.jpg?1",
             "name": "Mind Games",
             "text": "Buyback o2o\nU (You may pay an additional o2o\nU when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTap target artifact, creature, or land.",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "6d2ebf2f-0602-5945-b9dc-cf2321f803c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b438802b-629a-42c8-824d-f081a1619f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b438802b-629a-42c8-824d-f081a1619f68.jpg?1",
             "name": "Ransack",
             "text": "Look at the top five cards of target player's library. Put any number of those cards on the bottom of that library in any order and the rest on top of the library in any order.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "bfc7396c-7bbd-504f-883e-70e679e310e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6ca66e-1116-4739-8375-87af99e9bba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6ca66e-1116-4739-8375-87af99e9bba5.jpg?1",
             "name": "Rebound",
             "text": "Target spell, which targets only a single player, targets another player of your choice instead.",
             "colours": [
@@ -1298,7 +1298,7 @@
         },
         {
             "id": "7f9037ae-3986-56f3-8300-75312e0296fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a9242f-0516-4dae-8cbc-1f7f78931782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a9242f-0516-4dae-8cbc-1f7f78931782.jpg?1",
             "name": "Reins of Power",
             "text": "You and target opponent each untap and gain control of all creatures the other controls until end of turn. Those creatures are unaffected by summoning sickness this turn.",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "08176bc3-2707-53aa-ac1e-6ff5153d8965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b23da-9ba8-4b43-a5c9-51e1fc253913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b23da-9ba8-4b43-a5c9-51e1fc253913.jpg?1",
             "name": "Sift",
             "text": "Draw three cards, then choose and discard a card.",
             "colours": [
@@ -1360,7 +1360,7 @@
         },
         {
             "id": "68602373-23d5-5cc6-8ae2-2383003fcb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a20067-4ac2-4688-b8e8-3463185c4a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02a20067-4ac2-4688-b8e8-3463185c4a41.jpg?1",
             "name": "Silver Wyvern",
             "text": "Flying\noo\nU Target spell or ability, which targets only Silver Wyvern, targets another creature of your choice instead. Play this ability as an interrupt.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "82b756c1-7c31-5d6f-9eb7-0dfd4f51fde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c881c388-430f-4a4b-9cd1-fba0a2bc2cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c881c388-430f-4a4b-9cd1-fba0a2bc2cd6.jpg?1",
             "name": "Spindrift Drake",
             "text": "Flying\nDuring your upkeep, pay o\nU or sacrifice Spindrift Drake.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "7e8c8da9-ecb2-5aad-8048-e6128ec5cfaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cc2f5-3a50-40c8-87ea-6b92f081f55c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4cc2f5-3a50-40c8-87ea-6b92f081f55c.jpg?1",
             "name": "Thalakos Deceiver",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSacrifice Thalakos Deceiver: Gain control of target creature permanently. Use this ability only if Thalakos Deceiver is attacking and unblocked.",
             "colours": [
@@ -1460,7 +1460,7 @@
         },
         {
             "id": "8b981db6-4480-5bf6-ab9c-31aacbfd7bce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8737440b-0bf0-483f-895b-aa24da2b9cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8737440b-0bf0-483f-895b-aa24da2b9cfe.jpg?1",
             "name": "Tidal Surge",
             "text": "Tap up to three target creatures without flying.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "cfd2004e-5849-5253-bd00-7973e996d7db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab89a30a-ac4d-4a5e-bbff-a02366bc9cf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab89a30a-ac4d-4a5e-bbff-a02366bc9cf6.jpg?1",
             "name": "Tidal Warrior",
             "text": "oc\nT: Target land is an island until end of turn.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "1f38c990-914f-5ee1-908e-7d5f97c8bc6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec89ee13-34ef-41c8-8fe4-0a6b21df2032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec89ee13-34ef-41c8-8fe4-0a6b21df2032.jpg?1",
             "name": "Volrath's Shapeshifter",
             "text": "As long as the top card of your graveyard is a creature card, Volrath's Shapeshifter is a copy of that card, except that Volrath's Shapeshifter retains its abilities.\no2: Choose and discard a card.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "d83138d3-7134-59a1-b595-3588049e892a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2f906d-b127-400a-809b-449f1e7f647b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd2f906d-b127-400a-809b-449f1e7f647b.jpg?1",
             "name": "Walking Dream",
             "text": "Walking Dream is unblockable.\nWalking Dream does not untap during your untap phase if any opponent controls two or more creatures.",
             "colours": [
@@ -1592,7 +1592,7 @@
         },
         {
             "id": "b0120f4d-a14c-5cd6-931d-5259e08b8086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4638d815-fb86-490c-84d6-777a1c6131d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4638d815-fb86-490c-84d6-777a1c6131d6.jpg?1",
             "name": "Wall of Tears",
             "text": "(Walls cannot attack.)\nIf Wall of Tears blocks any creatures, return each of those creatures to owner's hand at end of combat.",
             "colours": [
@@ -1625,7 +1625,7 @@
         },
         {
             "id": "fb9d985f-65da-51e6-ba2e-d644592af2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f05fc3-da6e-45d4-8566-f4e7bdce1fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91f05fc3-da6e-45d4-8566-f4e7bdce1fe5.jpg?1",
             "name": "Bottomless Pit",
             "text": "During each player's upkeep, that player discards a card at random.",
             "colours": [
@@ -1656,7 +1656,7 @@
         },
         {
             "id": "12e89573-7164-58c8-9cc7-e09824810855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04013bc6-7774-400b-a6af-de755b4c324d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04013bc6-7774-400b-a6af-de755b4c324d.jpg?1",
             "name": "Brush with Death",
             "text": "Buyback o2o\nBo\nB (You may pay an additional o2o\nBo\nB when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget opponent loses 2 life. You gain 2 life.",
             "colours": [
@@ -1687,7 +1687,7 @@
         },
         {
             "id": "e8105f21-8e30-53e6-85f9-6f7ab9552402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0896ae6-fe96-44e8-ba62-a6d3fc1aae4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0896ae6-fe96-44e8-ba62-a6d3fc1aae4f.jpg?1",
             "name": "Cannibalize",
             "text": "Choose two target creatures controlled by any one player. Remove one of those creatures from the game and put two +1/+1 counters on the other.",
             "colours": [
@@ -1718,7 +1718,7 @@
         },
         {
             "id": "8987f955-a2d2-5880-8581-ab2d47ab58d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12c6548-20e6-4697-ba26-e711590f9e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c12c6548-20e6-4697-ba26-e711590f9e28.jpg?1",
             "name": "Corrupting Licid",
             "text": "o\nB, oc\nT: Corrupting Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature cannot be blocked except by artifact creatures and black creatures\" instead of a creature. Move Corrupting Licid onto target creature. You may pay o\nB to end this effect.",
             "colours": [
@@ -1751,7 +1751,7 @@
         },
         {
             "id": "e18cfffd-dd92-55a2-92e7-fd9ef0531ec2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a9b76d-6ce1-40d4-bc04-7ae6237f5eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88a9b76d-6ce1-40d4-bc04-7ae6237f5eaf.jpg?1",
             "name": "Crovax the Cursed",
             "text": "Crovax the Cursed counts as a Vampire.\nCrovax comes into play with four +1/+1 counters on it.\nDuring your upkeep, sacrifice a creature and put a +1/+1 counter on Crovax, or remove a +1/+1 counter from Crovax.\noo\nB Crovax gains flying until end of turn.",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "326d810e-2c26-545c-a4a6-d4ce2325e030",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d83770e-16ff-49c6-b4e7-eb7fc566eef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d83770e-16ff-49c6-b4e7-eb7fc566eef8.jpg?1",
             "name": "Dauthi Trapper",
             "text": "oc\nT: Target creature gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "8b780dbd-2c72-57e5-b2e8-5f0690034ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7478a471-3bd2-4038-a4eb-70c38a43afa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7478a471-3bd2-4038-a4eb-70c38a43afa9.jpg?1",
             "name": "Death Stroke",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -1852,7 +1852,7 @@
         },
         {
             "id": "bb7ff696-9066-510f-8366-5fca6bfc1abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a818483-de47-454d-bb24-3410aa95289c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a818483-de47-454d-bb24-3410aa95289c.jpg?1",
             "name": "Dungeon Shade",
             "text": "Flying\noo\nB Dungeon Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "dd04b71b-216b-5295-8da1-3bcd90d15eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35ab62e-d6c6-448c-bbe0-42abe5780adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35ab62e-d6c6-448c-bbe0-42abe5780adc.jpg?1",
             "name": "Foul Imp",
             "text": "Flying\nWhen Foul Imp comes into play, lose 2 life.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "cc027aeb-669d-5ea8-b577-4c94bdb952eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940536be-fce1-4a90-9126-195815a43e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940536be-fce1-4a90-9126-195815a43e0f.jpg?1",
             "name": "Grave Pact",
             "text": "Whenever any creature you control is put into any graveyard, each other player sacrifices a creature.",
             "colours": [
@@ -1950,7 +1950,7 @@
         },
         {
             "id": "405bfda4-8c81-5753-9624-808884938d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3132c128-e0bd-4524-9526-914b3c7181fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/3132c128-e0bd-4524-9526-914b3c7181fc.jpg?1",
             "name": "Lab Rats",
             "text": "Buyback o4 (You may pay an additional o4 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPut a Rat token into play. Treat this token as a 1/1 black creature.",
             "colours": [
@@ -1981,7 +1981,7 @@
         },
         {
             "id": "6d0672da-0a20-5c9b-a5e5-3acc27859aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eacd05b-078a-468c-b137-a802346d348a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eacd05b-078a-468c-b137-a802346d348a.jpg?1",
             "name": "Megrim",
             "text": "Whenever any opponent discards a card, Megrim deals 2 damage to him or her.",
             "colours": [
@@ -2012,7 +2012,7 @@
         },
         {
             "id": "fb175e29-7c19-5553-94b2-e636b9870ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bd531c-fdd1-4a22-816e-258b2975c1a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92bd531c-fdd1-4a22-816e-258b2975c1a3.jpg?1",
             "name": "Mind Peel",
             "text": "Buyback o2o\nBo\nB (You may pay an additional o2o\nBo\nB when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget player chooses and discards a card.",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "3afbccc7-5229-53dc-93f4-313b32a6c3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe796e1-97f9-469a-a6b6-a09161058e12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe796e1-97f9-469a-a6b6-a09161058e12.jpg?1",
             "name": "Mindwarper",
             "text": "Mindwarper comes into play with three +1/+1 counters on it.\no2o\nB, Remove a +1/+1 counter from Mindwarper: Target player chooses and discards a card. Play this ability as a sorcery.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "b4c42f35-6d39-5583-9b45-e9a3dbd26bed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a26ce-3435-4fef-bc34-abbc6f1cf3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/270a26ce-3435-4fef-bc34-abbc6f1cf3f4.jpg?1",
             "name": "Morgue Thrull",
             "text": "Sacrifice Morgue Thrull: Put the top three cards of your library into your graveyard.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "3813f06b-052c-5657-af38-57a19217ad1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860f46ea-6fd0-456d-971d-8d1eccc7fa60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860f46ea-6fd0-456d-971d-8d1eccc7fa60.jpg?1",
             "name": "Mortuary",
             "text": "Whenever any creature is put into your graveyard from play, put that creature on top of your library.",
             "colours": [
@@ -2140,7 +2140,7 @@
         },
         {
             "id": "f27fa1bf-8cc5-5c79-80d9-28af7f22cb3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8c028e-6656-47ef-97fb-de99f8833d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8c028e-6656-47ef-97fb-de99f8833d5f.jpg?1",
             "name": "Rabid Rats",
             "text": "oc\nT: Target blocking creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2173,7 +2173,7 @@
         },
         {
             "id": "8974d8ac-714c-55d2-8f76-8d31fda79e98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da40601-b6a3-47ca-b5b6-8fdbdf81f3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0da40601-b6a3-47ca-b5b6-8fdbdf81f3d4.jpg?1",
             "name": "Revenant",
             "text": "Flying\nRevenant has power and toughness each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "090983e9-557b-5c7c-aba5-07375e74f2c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab726e7d-171f-48b2-9652-545e17913330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab726e7d-171f-48b2-9652-545e17913330.jpg?1",
             "name": "Serpent Warrior",
             "text": "When Serpent Warrior comes into play, lose 3 life.",
             "colours": [
@@ -2240,7 +2240,7 @@
         },
         {
             "id": "67de1458-f311-58b9-b700-22233353336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57af1b3f-661a-4b02-be08-0ec721d7cab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57af1b3f-661a-4b02-be08-0ec721d7cab8.jpg?1",
             "name": "Skeleton Scavengers",
             "text": "Skeleton Scavengers comes into play with one +1/+1 counter on it.\nPay o1 for each +1/+1 counter on Skeleton Scavengers: Regenerate Skeleton Scavengers and put a +1/+1 counter on it.",
             "colours": [
@@ -2273,7 +2273,7 @@
         },
         {
             "id": "40e75e1f-f2e7-55cf-a17a-14445d18380f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0f043c-efb3-4392-ae25-b3ec180b0cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0f043c-efb3-4392-ae25-b3ec180b0cb2.jpg?1",
             "name": "Stronghold Assassin",
             "text": "oc\nT, Sacrifice a creature: Destroy target nonblack creature.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "dffe1042-6537-5186-93bb-bcb7f2fe9e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171c210-01b5-45a9-9dd3-dbf96a33a750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171c210-01b5-45a9-9dd3-dbf96a33a750.jpg?1",
             "name": "Stronghold Taskmaster",
             "text": "All other black creatures get -1/-1.",
             "colours": [
@@ -2342,7 +2342,7 @@
         },
         {
             "id": "ea01e34d-ad39-5299-9c99-31f96ba2a225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe74a415-ea8f-4f16-8889-ae649f1483b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe74a415-ea8f-4f16-8889-ae649f1483b2.jpg?1",
             "name": "Torment",
             "text": "Enchanted creature gets -3/-0.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "d5d40677-5087-5f5d-9a7a-9b1597160b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754b92b-d6f9-4503-af01-dee03f72a048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1754b92b-d6f9-4503-af01-dee03f72a048.jpg?1",
             "name": "Tortured Existence",
             "text": "o\nB, Choose and discard a creature card: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2406,7 +2406,7 @@
         },
         {
             "id": "f461a63e-d443-521f-bc72-f20587ec234d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca2c333-405f-4c1b-a02a-f1fadb3e1d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca2c333-405f-4c1b-a02a-f1fadb3e1d29.jpg?1",
             "name": "Wall of Souls",
             "text": "(Walls cannot attack.)\nWhenever Wall of Souls is dealt combat damage, it deals an equal amount of damage to target opponent.",
             "colours": [
@@ -2439,7 +2439,7 @@
         },
         {
             "id": "5b740c6e-e20f-528a-a2bf-fbc205953503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5bdb8c-2a2e-47cf-a502-2d62f9ada3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c5bdb8c-2a2e-47cf-a502-2d62f9ada3fa.jpg?1",
             "name": "Amok",
             "text": "o1, Discard a card at random: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "8d8824a0-2522-585d-8afb-d22a1263626b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e50a1d-b9f5-4a03-a1c2-ca45ace53a52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e50a1d-b9f5-4a03-a1c2-ca45ace53a52.jpg?1",
             "name": "Convulsing Licid",
             "text": "o\nR, oc\nT: Convulsing Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature cannot block\" instead of a creature. Move Convulsing Licid onto target creature. You may pay o\nR to end this effect.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "6e57cfe4-0d2a-5bd9-b773-e77161a9f814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cf964-88f6-4e62-97ce-cf0e179a53fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3cf964-88f6-4e62-97ce-cf0e179a53fb.jpg?1",
             "name": "Craven Giant",
             "text": "Craven Giant cannot block.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "df310d27-3c6b-511a-9bf2-fec7615a4637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90af852f-57a2-4a00-82dc-7c0f23899361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90af852f-57a2-4a00-82dc-7c0f23899361.jpg?1",
             "name": "Duct Crawler",
             "text": "o1oo\nR Target creature cannot block Duct Crawler this turn.",
             "colours": [
@@ -2569,7 +2569,7 @@
         },
         {
             "id": "33bbb19d-0117-5324-9996-2a17e5379130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79075361-e6ee-4cc9-990b-88fef27bbb1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79075361-e6ee-4cc9-990b-88fef27bbb1c.jpg?1",
             "name": "Fanning the Flames",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nFanning the Flames deals X damage to target creature or player.",
             "colours": [
@@ -2600,7 +2600,7 @@
         },
         {
             "id": "47524893-6553-5830-ac36-05ac49bf74e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069d90a-e7d9-4967-a872-0dd8a0a9934a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e069d90a-e7d9-4967-a872-0dd8a0a9934a.jpg?1",
             "name": "Flame Wave",
             "text": "Flame Wave deals 4 damage to target player and each creature he or she controls.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "927a1f22-5275-5f05-a262-83e9b30f55e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b144452-2e91-4e46-abe9-ed76b39f8314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b144452-2e91-4e46-abe9-ed76b39f8314.jpg?1",
             "name": "Fling",
             "text": "Sacrifice a creature: Fling deals damage equal to the sacrificed creature's power to target creature or player.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "b1a4233e-d7aa-540d-879d-af6e981c1a03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9781fd-10c9-4790-8279-51c3cc6653cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9781fd-10c9-4790-8279-51c3cc6653cf.jpg?1",
             "name": "Flowstone Blade",
             "text": "oo\nR Enchanted creature gets +1/-1 until end of turn.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "44f821eb-d309-521c-b74d-664bb8af5864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680ccbc7-aa97-4f01-9d26-0df184af3c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/680ccbc7-aa97-4f01-9d26-0df184af3c3e.jpg?1",
             "name": "Flowstone Hellion",
             "text": "Flowstone Hellion is unaffected by summoning sickness.\no0: Flowstone Hellion gets +1/-1 until end of turn.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "7c655ac8-a5ce-5fd2-bac4-5340f7468719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3165251-6ac6-4294-8bca-595c362f4ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3165251-6ac6-4294-8bca-595c362f4ceb.jpg?1",
             "name": "Flowstone Mauler",
             "text": "Trample\noo\nR Flowstone Mauler gets +1/-1 until end of turn.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "95289db7-c1b6-5690-a5a1-0b2a0bebfe97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2b70a5-db13-4c3f-829d-d4b9e0a16245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f2b70a5-db13-4c3f-829d-d4b9e0a16245.jpg?1",
             "name": "Flowstone Shambler",
             "text": "oo\nR Flowstone Shambler gets +1/-1 until end of turn.",
             "colours": [
@@ -2795,7 +2795,7 @@
         },
         {
             "id": "ea81d2ed-8292-55f5-bceb-32b5f48398cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a79dc7-ce46-41f7-9375-8d12afe6355a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a79dc7-ce46-41f7-9375-8d12afe6355a.jpg?1",
             "name": "Furnace Spirit",
             "text": "Furnace Spirit is unaffected by summoning sickness.\noo\nR Furnace Spirit gets +1/+0 until end of turn.",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "64465711-b806-50cc-8f28-ec571f683c7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb98db-f2ee-446f-9170-dd05b1a7dbd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dbb98db-f2ee-446f-9170-dd05b1a7dbd8.jpg?1",
             "name": "Heat of Battle",
             "text": "Whenever any creature blocks, Heat of Battle deals 1 damage to that creature's controller.",
             "colours": [
@@ -2859,7 +2859,7 @@
         },
         {
             "id": "3f39f757-9d7f-52e3-a45f-ca45b0a6c16a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c2f83-9535-4ee5-9964-5cc01e617981.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52c2f83-9535-4ee5-9964-5cc01e617981.jpg?1",
             "name": "Invasion Plans",
             "text": "Each creature blocks whenever able.\nAttacking player chooses how each creature blocks. (All blocking assignments must still be legal.)",
             "colours": [
@@ -2890,7 +2890,7 @@
         },
         {
             "id": "ab9a1ca9-513c-5e63-be64-d43efa449e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b790d789-bb21-4119-a0e3-43af9bef8acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b790d789-bb21-4119-a0e3-43af9bef8acc.jpg?1",
             "name": "Mob Justice",
             "text": "Mob Justice deals 1 damage to target player for each creature you control.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "855c7bf1-b53a-5f38-8b89-968221645d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16064ad4-eec2-4c32-b66d-a2bdb1a6191f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16064ad4-eec2-4c32-b66d-a2bdb1a6191f.jpg?1",
             "name": "Mogg Bombers",
             "text": "If any other creature comes into play, sacrifice Mogg Bombers and it deals 3 damage to target player.",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "a53d9cfa-b060-5d87-9599-77dc2e832c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1b384e-a7d5-4b5f-87d5-95ac1a6c6320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1b384e-a7d5-4b5f-87d5-95ac1a6c6320.jpg?1",
             "name": "Mogg Flunkies",
             "text": "Mogg Flunkies cannot attack or block during a turn in which no other creature you control attacks or blocks.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "c464fb45-f2e1-5c44-9457-2cc74d1d7942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a91aa6f-cb2f-4aad-9415-bba4eb9b76ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a91aa6f-cb2f-4aad-9415-bba4eb9b76ca.jpg?1",
             "name": "Mogg Infestation",
             "text": "Destroy all creatures target player controls. For each creature put into any graveyard in this way, put two Goblin tokens into play under that player's control. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "efd5c31d-9cd1-5ef5-a3dd-249ddc81c6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd33c58-f25d-4117-a266-75a91e9ddc75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd33c58-f25d-4117-a266-75a91e9ddc75.jpg?1",
             "name": "Mogg Maniac",
             "text": "Whenever Mogg Maniac is dealt damage, it deals an equal amount of damage to target opponent.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "ae00a93a-c62d-5e1c-ba75-315e6bbef400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eea06-806b-4163-ac86-de6ed6d1a91e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d45eea06-806b-4163-ac86-de6ed6d1a91e.jpg?1",
             "name": "Ruination",
             "text": "Destroy all nonbasic lands.",
             "colours": [
@@ -3082,7 +3082,7 @@
         },
         {
             "id": "27ed30e6-feac-58cf-8a84-552031878aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f1edb8-fff4-4f84-944c-fa5a032f4fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f1edb8-fff4-4f84-944c-fa5a032f4fb1.jpg?1",
             "name": "Seething Anger",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature gets +3/+0 until end of turn.",
             "colours": [
@@ -3113,7 +3113,7 @@
         },
         {
             "id": "84746f0b-116a-598a-9386-034ddba4ae8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6a6d56-e73f-4dc6-a7df-d105010e52ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6a6d56-e73f-4dc6-a7df-d105010e52ab.jpg?1",
             "name": "Shard Phoenix",
             "text": "Flying\no\nRo\nRoo\nR Put Shard Phoenix into your hand. Use this ability only if Shard Phoenix is in your graveyard and only during your upkeep.\nSacrifice Shard Phoenix: Shard Phoenix deals 2 damage to each creature without flying.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "84df7699-c0f1-571d-9a42-6cea0617d0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2ff2a-6dfe-4635-8da2-22d525e82b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9b2ff2a-6dfe-4635-8da2-22d525e82b94.jpg?1",
             "name": "Shock",
             "text": "Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "a4d6ebf6-186b-56b1-af1f-81a9a7dde8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c25d65-16bd-4628-b6ec-9e5495818277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c25d65-16bd-4628-b6ec-9e5495818277.jpg?1",
             "name": "Spitting Hydra",
             "text": "Spitting Hydra comes into play with four +1/+1 counters on it.\no1o\nR, Remove a +1/+1 counter from Spitting Hydra: Spitting Hydra deals 1 damage to target creature.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "a489fb53-f732-586f-ba95-55dd5db7d51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb37bcd-0bbd-4f3f-9623-803885750344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb37bcd-0bbd-4f3f-9623-803885750344.jpg?1",
             "name": "Wall of Razors",
             "text": "(Walls cannot attack.)\nFirst strike",
             "colours": [
@@ -3243,7 +3243,7 @@
         },
         {
             "id": "e3c82961-faa3-5aeb-9d72-50f738c370c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59612c02-6028-4953-ac4d-aca94b0ce4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59612c02-6028-4953-ac4d-aca94b0ce4b9.jpg?1",
             "name": "Awakening",
             "text": "At the beginning of each player's upkeep, untap all creatures and lands.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "a93741d6-2baf-5ab0-a6a1-45fc0a06df37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9af8e5-bc97-4704-ae5c-e3d2d5b72586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa9af8e5-bc97-4704-ae5c-e3d2d5b72586.jpg?1",
             "name": "Burgeoning",
             "text": "Whenever any opponent plays a land, you may choose a land card from your hand and put it into play.",
             "colours": [
@@ -3305,7 +3305,7 @@
         },
         {
             "id": "c7fa0286-d0af-53bf-a238-68e4c4218dec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae10e7fe-ee51-4c39-86ec-503324d19f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae10e7fe-ee51-4c39-86ec-503324d19f6c.jpg?1",
             "name": "Carnassid",
             "text": "Trample\no1oo\nG Regenerate Carnassid.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "209cba73-dc37-5761-9648-370fd070e9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a8a5fe-0391-489b-9556-0a1bf7e1900d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97a8a5fe-0391-489b-9556-0a1bf7e1900d.jpg?1",
             "name": "Constant Mists",
             "text": "Buyback\u2014\nSacrifice a land (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Constant Mists into your hand instead of your graveyard as part of the spell's effect.)\nCreatures deal no combat damage this turn.",
             "colours": [
@@ -3369,7 +3369,7 @@
         },
         {
             "id": "56e4dc71-29c7-58e3-b386-812d48a6fdc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283146fd-2307-4019-b23d-7fb1893dc46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/283146fd-2307-4019-b23d-7fb1893dc46c.jpg?1",
             "name": "Crossbow Ambush",
             "text": "All creatures you control can block creatures with flying until end of turn.",
             "colours": [
@@ -3400,7 +3400,7 @@
         },
         {
             "id": "0bcfaab6-31a4-53a4-8ef3-1421b5ad227a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daba8742-c246-4e64-8af1-8f4ebcdc4b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daba8742-c246-4e64-8af1-8f4ebcdc4b5f.jpg?1",
             "name": "Elven Rite",
             "text": "Put two +1/+1 counters, distributed any way you choose, on any number of target creatures.",
             "colours": [
@@ -3431,7 +3431,7 @@
         },
         {
             "id": "5c98d14d-06e5-53a4-964f-5748f052c2d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d43e8f-a914-44ed-bbd3-3746fb4ea6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d43e8f-a914-44ed-bbd3-3746fb4ea6da.jpg?1",
             "name": "Endangered Armodon",
             "text": "If you control any creature with toughness 2 or less, sacrifice Endangered Armodon.",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "02267816-b923-55cc-a0ae-797f7d03e3c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efc0622-ac2c-4722-ba05-961cc98c5940.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efc0622-ac2c-4722-ba05-961cc98c5940.jpg?1",
             "name": "Hermit Druid",
             "text": "o\nG, oc\nT: Reveal cards from the top of your library until you reveal a basic land card. Put that card into your hand and put all other revealed cards into your graveyard.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "f30e0af3-fc64-5917-9882-e8aa7175e268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454d6938-b87a-46b1-99d8-74573544ac5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/454d6938-b87a-46b1-99d8-74573544ac5b.jpg?1",
             "name": "Lowland Basilisk",
             "text": "Whenever Lowland Basilisk damages any creature, destroy that creature at end of combat.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "d805aa76-def2-5af6-b2ec-c01a9613c902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9e9a9-325a-4010-acb8-1406adcaeca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf9e9a9-325a-4010-acb8-1406adcaeca9.jpg?1",
             "name": "Mulch",
             "text": "Reveal the top four cards of your library to all players. Put any of those cards that are lands into your hand and the rest into your graveyard.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "4c23990e-fce2-5b9c-b106-024cc63b2f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9179f5-c3e0-4499-9cfb-6cb7e8329a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb9179f5-c3e0-4499-9cfb-6cb7e8329a59.jpg?1",
             "name": "Overgrowth",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional o\nGo\nG.",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "dcc9b660-8144-5d04-84e3-88f554c8c596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78026e4-edb8-4f55-bd80-4152f4dfb461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78026e4-edb8-4f55-bd80-4152f4dfb461.jpg?1",
             "name": "Primal Rage",
             "text": "All creatures you control gain trample.",
             "colours": [
@@ -3626,7 +3626,7 @@
         },
         {
             "id": "1eda3cb8-f846-5898-8a48-66193deaf5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c58f1-5276-420e-8c09-d256492ee87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa3c58f1-5276-420e-8c09-d256492ee87b.jpg?1",
             "name": "Provoke",
             "text": "Untap target creature you do not control. That creature blocks this turn if able.\nDraw a card.",
             "colours": [
@@ -3657,7 +3657,7 @@
         },
         {
             "id": "7bd425fd-b017-5b60-a51a-b309ceefa7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485aeabb-4a9b-4d88-80ad-83e31da6804b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485aeabb-4a9b-4d88-80ad-83e31da6804b.jpg?1",
             "name": "Skyshroud Archer",
             "text": "oc\nT: Target creature with flying gets -1/-1 until end of turn.",
             "colours": [
@@ -3691,7 +3691,7 @@
         },
         {
             "id": "d144b3a4-d232-5307-a109-e6e294e3186b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5197937-023c-412c-bf2c-b8e811ca04e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5197937-023c-412c-bf2c-b8e811ca04e1.jpg?1",
             "name": "Skyshroud Troopers",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "2ff18fd6-55b2-522a-92e0-d9bba571f0ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e11ef7-18a9-4ab1-981e-b337b1488ebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e11ef7-18a9-4ab1-981e-b337b1488ebd.jpg?1",
             "name": "Spike Breeder",
             "text": "Spike Breeder comes into play with three +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Breeder: Put a +1/+1 counter on target creature.\no2, Remove a +1/+1 counter from Spike Breeder: Put a Spike token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -3759,7 +3759,7 @@
         },
         {
             "id": "46d6301b-b0c2-50dc-9809-0f96c23a37c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea4703-8521-4576-8405-4b923e0a9522.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea4703-8521-4576-8405-4b923e0a9522.jpg?1",
             "name": "Spike Colony",
             "text": "Spike Colony comes into play with four +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Colony: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3792,7 +3792,7 @@
         },
         {
             "id": "d659a572-59c4-55c0-bb53-5e84585d5f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3751b2ae-a234-4691-984b-2f9f6b1cd1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3751b2ae-a234-4691-984b-2f9f6b1cd1df.jpg?1",
             "name": "Spike Feeder",
             "text": "Spike Feeder comes into play with two +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Feeder: Put a +1/+1 counter on target creature.\nRemove a +1/+1 counter from Spike Feeder: Gain 2 life.",
             "colours": [
@@ -3825,7 +3825,7 @@
         },
         {
             "id": "2f2aebc2-f70a-5ccc-bb57-df71dca59171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa45664c-ac39-40f8-9f56-cf25ed60a84a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa45664c-ac39-40f8-9f56-cf25ed60a84a.jpg?1",
             "name": "Spike Soldier",
             "text": "Spike Soldier comes into play with three +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Soldier: Put a +1/+1 counter on target creature.\nRemove a +1/+1 counter from Spike Soldier: Spike Soldier gets +2/+2 until end of turn.",
             "colours": [
@@ -3859,7 +3859,7 @@
         },
         {
             "id": "2f27b2d0-f938-595e-b9f6-0801523e19da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2713de6c-b754-435c-8d11-5215fd602a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2713de6c-b754-435c-8d11-5215fd602a40.jpg?1",
             "name": "Spike Worker",
             "text": "Spike Worker comes into play with two +1/+1 counters on it.\no2, Remove a +1/+1 counter from Spike Worker: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "0cd1b205-e1ec-5291-98b6-0154bb7888b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113fad70-36bc-4ab7-962a-cda3bddd02fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113fad70-36bc-4ab7-962a-cda3bddd02fc.jpg?1",
             "name": "Spined Wurm",
             "text": "",
             "colours": [
@@ -3925,7 +3925,7 @@
         },
         {
             "id": "bc0fae69-5eed-5dcc-8ccb-75b023a07fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7f3e0b-0600-4451-b621-e40c902a16cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da7f3e0b-0600-4451-b621-e40c902a16cb.jpg?1",
             "name": "Tempting Licid",
             "text": "o\nG, oc\nT: Tempting Licid loses ability and becomes a creature enchantment that reads \"All creatures able to block enchanted creature do so\" instead of a creature. Move Tempting Licid onto target creature. You may pay o\nG to end this effect.",
             "colours": [
@@ -3958,7 +3958,7 @@
         },
         {
             "id": "30864f09-78bc-5d63-8839-520884c4649c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7079bf55-4827-4b8b-a178-8c7b903d93b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7079bf55-4827-4b8b-a178-8c7b903d93b9.jpg?1",
             "name": "Verdant Touch",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget land becomes a 2/2 creature permanently. (This creature still counts as a land.)",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "6ef0c72f-3f9a-5d54-95e3-de7dee1cca2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d74f7d8-10eb-4082-9b07-41de13359b8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d74f7d8-10eb-4082-9b07-41de13359b8c.jpg?1",
             "name": "Volrath's Gardens",
             "text": "o2, Tap a creature you control: Gain 2 life. Play this ability as a sorcery.",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "bfa2a700-1b2a-5436-a7aa-fe0795f5c033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb4a1a3-efcf-4c9a-ad1f-0a3f8f2b456f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb4a1a3-efcf-4c9a-ad1f-0a3f8f2b456f.jpg?1",
             "name": "Wall of Blossoms",
             "text": "(Walls cannot attack.)\nWhen Wall of Blossoms comes into play, draw a card.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "eac4d995-632d-53f7-a8d6-c2817c24bee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92c3f7-a589-4c87-aa17-0d9707605ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d92c3f7-a589-4c87-aa17-0d9707605ff4.jpg?1",
             "name": "Acidic Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: This creature deals 2 damage to target creature or player.\"",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "1cdfde14-5af8-5d6a-98c9-58106cf45aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06551990-713c-4b8b-bebb-4e849babb5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06551990-713c-4b8b-bebb-4e849babb5bb.jpg?1",
             "name": "Crystalline Sliver",
             "text": "Slivers cannot be the target of spells or abilities.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "9eaa67cd-e4b5-545c-a693-a5836ca622dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94934d64-6518-4c5e-90d9-a3bf23b8973f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94934d64-6518-4c5e-90d9-a3bf23b8973f.jpg?1",
             "name": "Hibernation Sliver",
             "text": "Each Sliver gains \"Pay 2 life: Return this creature to owner's hand.\"",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "d1c0b29b-b820-5679-b7d8-e1caf25cdf75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c0ece-aed0-4120-99cc-5d0e28fa70ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c0ece-aed0-4120-99cc-5d0e28fa70ab.jpg?1",
             "name": "Sliver Queen",
             "text": "Sliver Queen counts as a Sliver.\no2: Put a Sliver token into play. Treat this token as a 1/1 colorless creature.",
             "colours": [
@@ -4202,7 +4202,7 @@
         },
         {
             "id": "311efb31-04fe-5c65-ade2-a6bf4b53e784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8a9442-7b08-4cc8-94ec-bddb8feab1a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8a9442-7b08-4cc8-94ec-bddb8feab1a8.jpg?1",
             "name": "Spined Sliver",
             "text": "If any Sliver is blocked, it gets +1/+1 until end of turn for each creature blocking it.",
             "colours": [
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "aef5604a-84b4-59e0-8849-0bffa93e64f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e58908e-7095-4fb9-b7cb-a67d12f33b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e58908e-7095-4fb9-b7cb-a67d12f33b8a.jpg?1",
             "name": "Victual Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: Gain 4 life.\"",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "34b1d2f2-e6d4-5b13-9199-a286218ce6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff312dd7-456c-4ce5-9614-e2cbe3c2219c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff312dd7-456c-4ce5-9614-e2cbe3c2219c.jpg?1",
             "name": "Bullwhip",
             "text": "o2, oc\nT: Bullwhip deals 1 damage to target creature. That creature attacks this turn if able.",
             "colours": [],
@@ -4299,7 +4299,7 @@
         },
         {
             "id": "b9feac79-3880-57e6-94b3-6d6cef2e5b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d838a1-2739-45f7-a856-6202334fa76a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27d838a1-2739-45f7-a856-6202334fa76a.jpg?1",
             "name": "Ensnaring Bridge",
             "text": "Each creature with power greater than the number of cards in your hand cannot attack.",
             "colours": [],
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "29fa5147-7b21-5c7b-aec2-f5277792895f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed17325-6d2f-404e-b13f-d2d419d522b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ed17325-6d2f-404e-b13f-d2d419d522b7.jpg?1",
             "name": "Heartstone",
             "text": "The cost of each creature ability requiring an activation cost is reduced by o1. This cannot reduce an ability's generic mana cost to less then o1.",
             "colours": [],
@@ -4353,7 +4353,7 @@
         },
         {
             "id": "03101362-e8cc-5864-9023-43d91e7d27a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950660f9-b185-4979-a08b-cce4ec6ce07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950660f9-b185-4979-a08b-cce4ec6ce07d.jpg?1",
             "name": "Horn of Greed",
             "text": "Whenever any player plays a land, that player draws a card.",
             "colours": [],
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "13845a3d-f3b9-52a1-90e5-b6afca6fd8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e9afeb-4d27-441c-b379-3dfe974053b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51e9afeb-4d27-441c-b379-3dfe974053b8.jpg?1",
             "name": "Hornet Cannon",
             "text": "o3, oc\nT: Put a Hornet token into play. Treat this token as a 1/1 artifact creature with flying that is unaffected by summoning sickness. At end of turn, destroy the token.",
             "colours": [],
@@ -4407,7 +4407,7 @@
         },
         {
             "id": "26920490-e5ee-50b2-8991-5bbb37211745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c675814-094c-45d4-93ee-0f50b4755e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c675814-094c-45d4-93ee-0f50b4755e79.jpg?1",
             "name": "Jinxed Ring",
             "text": "Whenever any card is put into your graveyard from play, Jinxed Ring deals 1 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Ring permanently",
             "colours": [],
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "d13aede2-f106-5d02-b52e-47d3a6871071",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28028830-83ed-45e2-b495-3b9ad9d3e988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28028830-83ed-45e2-b495-3b9ad9d3e988.jpg?1",
             "name": "Mox Diamond",
             "text": "When Mox Diamond comes into play, choose and discard a land card or sacrifice Mox Diamond.\noc\nT: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4461,7 +4461,7 @@
         },
         {
             "id": "6e65d7d4-8eac-5191-a516-9a5a7d1a8850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4de4af2-fa75-4a87-b0e1-0117727917a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4de4af2-fa75-4a87-b0e1-0117727917a5.jpg?1",
             "name": "Portcullis",
             "text": "Whenever any creature comes into play, if there are two or more other creatures in play, set that creature aside. If Portcullis leaves play, put the creature into play under its owner's control.",
             "colours": [],
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "035db611-b24d-542b-b843-41e74c260a4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b7a950-bf79-46fa-8b29-b7856b38e0fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b7a950-bf79-46fa-8b29-b7856b38e0fd.jpg?1",
             "name": "Shifting Wall",
             "text": "Shifting Wall counts as a Wall. (Walls cannot attack.)\nShifting Wall comes into play with X +1/+1 counters on it.",
             "colours": [],
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "9d184eaa-4752-54e1-8d4e-74fa4cb71331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401678d7-11dc-47ec-be28-4facdd949bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/401678d7-11dc-47ec-be28-4facdd949bc1.jpg?1",
             "name": "Sword of the Chosen",
             "text": "oc\nT: Target legend gets +2/+2 until end of turn.",
             "colours": [],
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "75fa03eb-7d51-501a-aa43-a9aca3cfbda1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e9e60a-5718-460d-b031-b47d6f6715d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e9e60a-5718-460d-b031-b47d6f6715d1.jpg?1",
             "name": "Volrath's Laboratory",
             "text": "When you play Volrath's Laboratory, choose a color and a creature type.\no5, oc\nT: Put a token creature into play. Treat this token as a 2/2 creature of the chosen color and creature type.",
             "colours": [],
@@ -4574,7 +4574,7 @@
         },
         {
             "id": "c5c88002-3a6d-50fa-9c80-fcb8e2623512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf015b-152e-4d67-b773-e75fb2487a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf015b-152e-4d67-b773-e75fb2487a32.jpg?1",
             "name": "Volrath's Stronghold",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no1o\nB, oc\nT: Put target creature card from your graveyard on top of your library.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/STX.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/STX.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ee54b9ff-a776-567a-b149-ca32caf17076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b394fc-a99c-44e7-9226-da0699167541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b394fc-a99c-44e7-9226-da0699167541.jpg?1",
             "name": "Environmental Sciences",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "f7c19487-0efe-5a39-a2d1-dc3f99dbcecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5642b9d-0daa-4e6b-ad48-f88dd37d6574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5642b9d-0daa-4e6b-ad48-f88dd37d6574.jpg?1",
             "name": "Expanded Anatomy",
             "text": "Put two +1/+1 counters on target creature. It gains vigilance until end of turn.",
             "colours": [],
@@ -64,7 +64,7 @@
         },
         {
             "id": "55be78d3-bbe2-53e3-89ba-b158134f7a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc4682-bcaf-4f51-be0b-9f2851a16e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bc4682-bcaf-4f51-be0b-9f2851a16e3b.jpg?1",
             "name": "Introduction to Annihilation",
             "text": "Exile target nonland permanent. Its controller draws a card.",
             "colours": [],
@@ -94,7 +94,7 @@
         },
         {
             "id": "85a585d3-dcd9-5282-929c-8fbb8b89470b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7820923e-bad2-4d6a-92b3-97b9737d2ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7820923e-bad2-4d6a-92b3-97b9737d2ca9.jpg?1",
             "name": "Introduction to Prophecy",
             "text": "Scry 2, then draw a card.",
             "colours": [],
@@ -124,7 +124,7 @@
         },
         {
             "id": "0ccc2be8-b6ca-5a71-89fc-d3d1a7cd6958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047592c-739c-41dd-b3e8-31ae1c7688ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2047592c-739c-41dd-b3e8-31ae1c7688ab.jpg?1",
             "name": "Mascot Exhibition",
             "text": "Create a 2/1 white and black Inkling creature token with flying, a 3/2 red and white Spirit creature token, and a 4/4 blue and red Elemental creature token.",
             "colours": [],
@@ -156,7 +156,7 @@
         },
         {
             "id": "d0903ef7-72e6-5a8e-842a-dd39839262ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -188,7 +188,7 @@
         },
         {
             "id": "bffa0c9a-7ab0-5166-80f0-d1e6389b1ee0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18a2bdc8-b705-4eb5-b3a5-ff2e2ab8f312.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -218,7 +218,7 @@
         },
         {
             "id": "4f708469-c678-56b0-8768-37b49616cf77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05521edf-f47f-4e7a-aec5-cdc4ae7368c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05521edf-f47f-4e7a-aec5-cdc4ae7368c2.jpg?1",
             "name": "Academic Probation",
             "text": "Choose one \u2014\n\u2022 Choose a nonland card name. Opponents can't cast spells with the chosen name until your next turn.\n\u2022 Choose target nonland permanent. Until your next turn, it can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -254,7 +254,7 @@
         },
         {
             "id": "d7e765d4-34b2-57fd-85f6-2f19a543f4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5ff6af-402f-4bf6-a75b-dc1e0e40aff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5ff6af-402f-4bf6-a75b-dc1e0e40aff6.jpg?1",
             "name": "Ageless Guardian",
             "text": "",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "1fc2e034-b085-5272-9c61-19f913838207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22411c-11c1-4770-8491-7952dd406e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e22411c-11c1-4770-8491-7952dd406e01.jpg?1",
             "name": "Beaming Defiance",
             "text": "Target creature you control gets +2/+2 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "92e91515-1792-5b3d-a449-e9541db7595b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69957656-cfdf-4001-8e84-0ef29e4a468d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69957656-cfdf-4001-8e84-0ef29e4a468d.jpg?1",
             "name": "Clever Lumimancer",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Clever Lumimancer gets +2/+2 until end of turn.",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "49424381-3ccb-59ad-b069-c705e6b8c889",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f669ac4-98ed-4e23-91a9-281f8277ab04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f669ac4-98ed-4e23-91a9-281f8277ab04.jpg?1",
             "name": "Combat Professor",
             "text": "Flying\nAt the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "c9b8e24d-95d1-51b8-b5d9-fea2853606ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4e1b5-77d6-4af4-b22e-6f6b4d129f5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e4e1b5-77d6-4af4-b22e-6f6b4d129f5d.jpg?1",
             "name": "Defend the Campus",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +1/+1 until end of turn.\n\u2022 Destroy target creature with power 4 or greater.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "258b0ad9-fc37-53a8-a2a4-4e250b0db22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ebe581-be17-415a-a160-28d8f4e95636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ebe581-be17-415a-a160-28d8f4e95636.jpg?1",
             "name": "Detention Vortex",
             "text": "Enchant nonland permanent\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.\n{3}: Destroy Detention Vortex. Only your opponents may activate this ability and only as a sorcery.",
             "colours": [
@@ -457,7 +457,7 @@
         },
         {
             "id": "ef101081-bd92-518b-86f4-0e44ac84d5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6be019-29b9-4c81-9899-aefeaf9cc977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b6be019-29b9-4c81-9899-aefeaf9cc977.jpg?1",
             "name": "Devastating Mastery",
             "text": "You may pay {2}{W}{W} rather than pay this spell's mana cost.\nIf the {2}{W}{W} cost was paid, an opponent chooses up to two nonland permanents they control and returns them to their owner's hand.\nDestroy all nonland permanents.",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "55b4c151-2e0f-5312-9c39-13eff8e7584a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3dbb0-0d68-4351-bfc9-a09c50454bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b3dbb0-0d68-4351-bfc9-a09c50454bf7.jpg?1",
             "name": "Dueling Coach",
             "text": "When Dueling Coach enters the battlefield, put a +1/+1 counter on target creature.\n{4}{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
             "colours": [
@@ -526,7 +526,7 @@
         },
         {
             "id": "d8e48e55-b80c-5632-89a4-4a3a350f92e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b19a46-f4e9-4a08-b118-a62a93901c1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b19a46-f4e9-4a08-b118-a62a93901c1e.jpg?1",
             "name": "A-Dueling Coach",
             "text": "",
             "colours": [
@@ -560,7 +560,7 @@
         },
         {
             "id": "19c9011e-5688-5226-8127-c3fd0b3b70f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83543b-3b6f-4e28-96f9-007b814bcfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a83543b-3b6f-4e28-96f9-007b814bcfd6.jpg?1",
             "name": "Eager First-Year",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Eager First-Year gets +1/+0 until end of turn.",
             "colours": [
@@ -595,7 +595,7 @@
         },
         {
             "id": "acaf336b-8483-5807-9844-e56861c9d7b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a7998-ccac-45ad-a4e9-3a2cb057f63b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3a7998-ccac-45ad-a4e9-3a2cb057f63b.jpg?1",
             "name": "Elite Spellbinder",
             "text": "Flying\nWhen Elite Spellbinder enters the battlefield, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A spell cast this way costs {2} more to cast.",
             "colours": [
@@ -632,7 +632,7 @@
         },
         {
             "id": "b54bd61b-b3c2-5a6f-8901-9915663256d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be517a58-b7ee-4213-98a5-8c19e1b2def6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be517a58-b7ee-4213-98a5-8c19e1b2def6.jpg?1",
             "name": "Expel",
             "text": "Exile target tapped creature.",
             "colours": [
@@ -664,7 +664,7 @@
         },
         {
             "id": "19ccd656-a63f-56a3-a265-e8f9951a5f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb3163-12ca-4a7f-a0c7-b8ddfc9408a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6fb3163-12ca-4a7f-a0c7-b8ddfc9408a0.jpg?1",
             "name": "Guiding Voice",
             "text": "Put a +1/+1 counter on target creature.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "edc7c20c-3cb1-557f-b79a-6b391e02c67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a465d7b-398c-444b-9eae-331ea2513f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a465d7b-398c-444b-9eae-331ea2513f6d.jpg?1",
             "name": "Leonin Lightscribe",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -733,7 +733,7 @@
         },
         {
             "id": "250a144b-4734-53d4-af58-820b8060ef9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3d521f-31cd-4bd2-b6b6-771c79252789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3d521f-31cd-4bd2-b6b6-771c79252789.jpg?1",
             "name": "Mavinda, Students' Advocate",
             "text": "Flying\n{0}: You may cast target instant or sorcery card from your graveyard this turn. If that spell doesn't target a creature you control, it costs {8} more to cast this way. If that spell would be put into your graveyard, exile it instead. Activate only once each turn. (You still pay the spell's costs. Timing rules for the spell still apply.)",
             "colours": [
@@ -772,7 +772,7 @@
         },
         {
             "id": "05d975b9-8c5f-5331-8c91-b8691795c572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86714f5-e909-413f-8eb6-99dbea4d1897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c86714f5-e909-413f-8eb6-99dbea4d1897.jpg?1",
             "name": "Pilgrim of the Ages",
             "text": "When Pilgrim of the Ages enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\n{6}: Return Pilgrim of the Ages from your graveyard to your hand.",
             "colours": [
@@ -806,7 +806,7 @@
         },
         {
             "id": "8c73e1cc-0311-5cde-b8aa-11e375492dd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884666e-8f9b-44b1-a1e3-c1c8941e2152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0884666e-8f9b-44b1-a1e3-c1c8941e2152.jpg?1",
             "name": "Pillardrop Rescuer",
             "text": "Flying\nWhen Pillardrop Rescuer enters the battlefield, return target creature card with mana value 3 or less from your graveyard to your hand.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "c7cf1265-b6d6-547e-acff-b7d85e8c3490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f427cf73-9f5e-4ef5-bc4f-29ffbfda9d57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f427cf73-9f5e-4ef5-bc4f-29ffbfda9d57.jpg?1",
             "name": "Professor of Symbology",
             "text": "When Professor of Symbology enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -876,7 +876,7 @@
         },
         {
             "id": "5a61dcea-89f2-5df0-9544-a4e017d4037d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfc408e-34d6-4e94-8678-4cc229cbc6f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bfc408e-34d6-4e94-8678-4cc229cbc6f5.jpg?1",
             "name": "Reduce to Memory",
             "text": "Exile target nonland permanent. Its controller creates a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "853765a2-31e0-5322-b76b-75f9ebf724ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39528cf0-343e-499b-a69f-c5c3c2898c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39528cf0-343e-499b-a69f-c5c3c2898c25.jpg?1",
             "name": "Secret Rendezvous",
             "text": "You and target opponent each draw three cards.",
             "colours": [
@@ -942,7 +942,7 @@
         },
         {
             "id": "02b6343a-cda5-578d-8bd8-e297bef461e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4743f7-28db-4d72-bfce-09cfbe413514.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef4743f7-28db-4d72-bfce-09cfbe413514.jpg?1",
             "name": "Semester's End",
             "text": "Exile any number of target creatures and/or planeswalkers you control. At the beginning of the next end step, return each of them to the battlefield under its owner's control. Each of them enters the battlefield with an additional +1/+1 counter on it if it's a creature and an additional loyalty counter on it if it's a planeswalker.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "18b977a1-ac7e-5fcd-b471-4340a4dd5036",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65837f39-deb7-4a4b-8b67-125a71cd0d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65837f39-deb7-4a4b-8b67-125a71cd0d45.jpg?1",
             "name": "Show of Confidence",
             "text": "When you cast this spell, copy it for each other instant and sorcery spell you've cast this turn. You may choose new targets for the copies.\nPut a +1/+1 counter on target creature. It gains vigilance until end of turn.",
             "colours": [
@@ -1008,7 +1008,7 @@
         },
         {
             "id": "06d0af1a-a51a-5c12-86e3-2d2ab0300f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg?1",
             "name": "Sparring Regimen",
             "text": "When Sparring Regimen enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nWhenever you attack, put a +1/+1 counter on target attacking creature and untap it.",
             "colours": [
@@ -1042,7 +1042,7 @@
         },
         {
             "id": "95713773-bf3c-5bbe-acb8-e632b378f441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9318f-2e17-4b6e-895f-c17cd5d0d282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e9318f-2e17-4b6e-895f-c17cd5d0d282.jpg?1",
             "name": "Star Pupil",
             "text": "Star Pupil enters the battlefield with a +1/+1 counter on it.\nWhen Star Pupil dies, put its counters on target creature you control.",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "d2e148ea-4041-54f6-bccb-95f7893fc346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de4a01-98d3-4af3-9c6e-29e16d2c1767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21de4a01-98d3-4af3-9c6e-29e16d2c1767.jpg?1",
             "name": "Stonebinder's Familiar",
             "text": "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on Stonebinder's Familiar. This ability triggers only once each turn.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "3bb58aca-1040-520e-ad46-ac41037084f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388f2e45-570f-4a35-b205-37e1345b5d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/388f2e45-570f-4a35-b205-37e1345b5d06.jpg?1",
             "name": "Stonerise Spirit",
             "text": "Flying\n{4}, Exile a card from your graveyard: Target creature gains flying until end of turn.",
             "colours": [
@@ -1147,7 +1147,7 @@
         },
         {
             "id": "deeabc53-f49b-5f9f-8194-60137f4455b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f1e36a-6838-49de-b7dc-697cbcd1e892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f1e36a-6838-49de-b7dc-697cbcd1e892.jpg?1",
             "name": "Strict Proctor",
             "text": "Flying\nWhenever a permanent entering the battlefield causes a triggered ability to trigger, counter that ability unless its controller pays {2}.",
             "colours": [
@@ -1185,7 +1185,7 @@
         },
         {
             "id": "aff19c2a-d3ad-588d-9672-b82d40f86128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0826e210-2002-43fe-942d-41922dfd7bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0826e210-2002-43fe-942d-41922dfd7bc2.jpg?1",
             "name": "Strict Proctor",
             "text": "",
             "colours": [
@@ -1222,7 +1222,7 @@
         },
         {
             "id": "a23c89c5-71d0-558b-8413-63f4bc663e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7cd813-0781-4fd7-8748-2716e1eeb4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7cd813-0781-4fd7-8748-2716e1eeb4b9.jpg?1",
             "name": "Study Break",
             "text": "Tap up to two target creatures.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1254,7 +1254,7 @@
         },
         {
             "id": "a18d1d5d-f2de-5a01-9606-e5d2033ffec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3b2961-559f-42b1-be13-ff3d03e62809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3b2961-559f-42b1-be13-ff3d03e62809.jpg?1",
             "name": "Thunderous Orator",
             "text": "Vigilance\nWhenever Thunderous Orator attacks, it gains flying until end of turn if you control a creature with flying. The same is true for first strike, double strike, deathtouch, indestructible, lifelink, menace, and trample.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "15e497fd-555c-5490-a3c9-b4ab0e1f5a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cdb00c-ea86-4b72-8f62-570820edfa1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cdb00c-ea86-4b72-8f62-570820edfa1b.jpg?1",
             "name": "Arcane Subtraction",
             "text": "Target creature gets -4/-0 until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "1c987201-cf20-5a34-9846-461b92fe2ae8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761df6cd-0928-4167-8902-58fdb50181a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761df6cd-0928-4167-8902-58fdb50181a0.jpg?1",
             "name": "Archmage Emeritus",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, draw a card.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "1db4b61e-f200-55cb-8ac6-770cdaf8fd1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6040c573-cd8c-4593-8ade-d9922482035c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6040c573-cd8c-4593-8ade-d9922482035c.jpg?1",
             "name": "Burrog Befuddler",
             "text": "Flash\nWhen Burrog Befuddler enters the battlefield, target creature an opponent controls gets -1/-0 until end of turn.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "c5dc7ac8-7498-5ede-b5c9-fdf1fc70b029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2cf5-80cf-4c06-8b04-bc04a5460de5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2a2cf5-80cf-4c06-8b04-bc04a5460de5.jpg?1",
             "name": "Bury in Books",
             "text": "This spell costs {2} less to cast if it targets an attacking creature.\nPut target creature into its owner's library second from the top.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "c3f83af7-ba47-59fd-805e-7183b03e51bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0e716-22b7-4a5e-9b7a-d4a806ee7427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a0e716-22b7-4a5e-9b7a-d4a806ee7427.jpg?1",
             "name": "Curate",
             "text": "Look at the top two cards of your library. Put any number of them into your graveyard and the rest back on top of your library in any order.\nDraw a card.",
             "colours": [
@@ -1458,7 +1458,7 @@
         },
         {
             "id": "f458f1e5-d4d6-52b4-87b2-d4f601518a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1958d96e-ec44-48ab-80b1-5b01a24ac7b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1958d96e-ec44-48ab-80b1-5b01a24ac7b8.jpg?1",
             "name": "Divide by Zero",
             "text": "Return target spell or permanent with mana value 1 or greater to its owner's hand.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "c9f36082-28ae-56b5-b936-bf6621d031a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg?1",
             "name": "Dream Strix",
             "text": "Flying\nWhen Dream Strix becomes the target of a spell, sacrifice it.\nWhen Dream Strix dies, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1527,7 +1527,7 @@
         },
         {
             "id": "5ff14a02-5ab0-5d42-9c1e-1f7c11a1f1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd79c9cc-0a8c-4d88-96e2-cb177134a18d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd79c9cc-0a8c-4d88-96e2-cb177134a18d.jpg?1",
             "name": "Frost Trickster",
             "text": "Flying\nWhen Frost Trickster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "f5326d64-fc7a-5df5-9f2a-417410c1c041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2386d020-a9ae-4d54-b5e4-f2cb5a7298cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2386d020-a9ae-4d54-b5e4-f2cb5a7298cc.jpg?1",
             "name": "Ingenious Mastery",
             "text": "You may pay {2}{U} rather than pay this spell's mana cost.\nIf the {2}{U} cost was paid, you draw three cards, then an opponent creates two Treasure tokens and they scry 2. If that cost wasn't paid, you draw X cards.",
             "colours": [
@@ -1596,7 +1596,7 @@
         },
         {
             "id": "8a1abf73-c0d2-56f0-b113-3064a5c291b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0112ebfb-55ad-401c-9dc5-ffd829f5b5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0112ebfb-55ad-401c-9dc5-ffd829f5b5bf.jpg?1",
             "name": "Kelpie Guide",
             "text": "{T}: Untap another target permanent you control.\n{T}: Tap target permanent. Activate only if you control eight or more lands.",
             "colours": [
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "978fb797-bc9e-5ecc-b8be-e843b1ad6592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbb1230-a465-4499-bb9c-35a06712a08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dbb1230-a465-4499-bb9c-35a06712a08b.jpg?1",
             "name": "Mentor's Guidance",
             "text": "When you cast this spell, copy it if you control a planeswalker, Cleric, Druid, Shaman, Warlock, or Wizard.\nScry 1, then draw a card.",
             "colours": [
@@ -1662,7 +1662,7 @@
         },
         {
             "id": "ba6356d0-db83-54b9-ac4c-de8ce0c91f2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf572a77-bd21-48e3-9640-3f17a5416ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf572a77-bd21-48e3-9640-3f17a5416ab1.jpg?1",
             "name": "A-Mentor's Guidance",
             "text": "",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "e1c806ac-37fd-5c4c-82dc-f195730479f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbe115-5482-4e5a-95bb-8ccbb01d3547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adcbe115-5482-4e5a-95bb-8ccbb01d3547.jpg?1",
             "name": "Mercurial Transformation",
             "text": "Until end of turn, target nonland permanent loses all abilities and becomes your choice of a blue Frog creature with base power and toughness 1/1 or a blue Octopus creature with base power and toughness 4/4.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "1294bd7f-15b6-5cab-acb1-e8ff912197a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c9890f-7081-42f6-89eb-35c83911b443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c9890f-7081-42f6-89eb-35c83911b443.jpg?1",
             "name": "Multiple Choice",
             "text": "If X is 1, scry 1, then draw a card.\nIf X is 2, you may choose a player. They return a creature they control to its owner's hand.\nIf X is 3, create a 4/4 blue and red Elemental creature token.\nIf X is 4 or more, do all of the above.",
             "colours": [
@@ -1761,7 +1761,7 @@
         },
         {
             "id": "d4caed8f-4f91-507c-bd40-88a5aea8c42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16892d8-9d10-45de-ab79-0e645c4b5588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16892d8-9d10-45de-ab79-0e645c4b5588.jpg?1",
             "name": "Pop Quiz",
             "text": "Draw a card.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "de3f9cdd-1a7d-529c-a1d6-ce3ee747017f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f0731-fb40-4dc2-8530-afcb5ce1f27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d77f0731-fb40-4dc2-8530-afcb5ce1f27f.jpg?1",
             "name": "Reject",
             "text": "Counter target creature or planeswalker spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "ea7a3205-d0d3-51b7-805f-d9f57a9b2b3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb1fcb-a411-4c1c-b8fc-496242ae3a9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfb1fcb-a411-4c1c-b8fc-496242ae3a9b.jpg?1",
             "name": "Resculpt",
             "text": "Exile target artifact or creature. Its controller creates a 4/4 blue and red Elemental creature token.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "7fb59d3a-0e67-56da-a695-4c1a0c928cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d651b9e9-d723-4340-a010-d71b2a697e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d651b9e9-d723-4340-a010-d71b2a697e73.jpg?1",
             "name": "Serpentine Curve",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is one plus the total number of instant and sorcery cards you own in exile and in your graveyard.",
             "colours": [
@@ -1889,7 +1889,7 @@
         },
         {
             "id": "9893ccbe-8aa6-5574-ad33-79c8f7c5877a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b6f17d-45ba-4d60-a963-5eee026f2219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b6f17d-45ba-4d60-a963-5eee026f2219.jpg?1",
             "name": "Snow Day",
             "text": "Tap up to two target creatures. Those creatures don't untap during their controller's next untap step.\nDraw two cards, then discard a card.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "3c8c6eac-f5aa-55bf-bc93-d179166bbbd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c04ee2-c1e0-45fb-aaf5-1b4459df80fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c04ee2-c1e0-45fb-aaf5-1b4459df80fc.jpg?1",
             "name": "Solve the Equation",
             "text": "Search your library for an instant or sorcery card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "8a0b907b-24c4-5a86-9b92-339a0c80bd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb93c9d2-88eb-403d-bb67-8e8b0462ac27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb93c9d2-88eb-403d-bb67-8e8b0462ac27.jpg?1",
             "name": "Soothsayer Adept",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "a16ef2e1-3688-523e-a270-07fcf4b08fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e726fc7-36cf-405c-9b7c-d1e41cd6c68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e726fc7-36cf-405c-9b7c-d1e41cd6c68f.jpg?1",
             "name": "Symmetry Sage",
             "text": "Flying\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, target creature you control has base power 2 until end of turn.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "9579d1df-ff66-5d0a-a3b7-14a745e434e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2409aee-3a80-4533-80bc-9383624c285d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2409aee-3a80-4533-80bc-9383624c285d.jpg?1",
             "name": "A-Symmetry Sage",
             "text": "",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "90ddb56f-87c5-5098-8223-1d88b6f2bf66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967148b1-2bb6-4bc0-95e6-c45fcf99afd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967148b1-2bb6-4bc0-95e6-c45fcf99afd2.jpg?1",
             "name": "Teachings of the Archaics",
             "text": "If an opponent has more cards in hand than you, draw two cards. Draw three cards instead if an opponent has at least four more cards in hand than you.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "aed563dd-6796-5a51-a762-0cae7cfa44b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23e64f9-531e-4735-9960-b0a76b32c340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23e64f9-531e-4735-9960-b0a76b32c340.jpg?1",
             "name": "Tempted by the Oriq",
             "text": "For each opponent, gain control of up to one target creature or planeswalker that player controls with mana value 3 or less.",
             "colours": [
@@ -2127,7 +2127,7 @@
         },
         {
             "id": "62e66ae0-25fc-5ef9-a175-0f05ed8acc3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b6236-b40c-430c-98b0-7940b942657a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2b6236-b40c-430c-98b0-7940b942657a.jpg?1",
             "name": "Test of Talents",
             "text": "Counter target instant or sorcery spell. Search its controller's graveyard, hand, and library for any number of cards with the same name as that spell and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "dd1de253-1315-5471-9557-c7f7e92f7279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab4a68d-5d26-42d8-bc51-15e3c1f95ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bab4a68d-5d26-42d8-bc51-15e3c1f95ebe.jpg?1",
             "name": "Vortex Runner",
             "text": "As long as you control eight or more lands, Vortex Runner gets +1/+0 and can't be blocked.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "b954ecf7-3f06-5a76-8f0f-def25aa34e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc6966c-18d9-4675-9594-6f0b2d11c405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc6966c-18d9-4675-9594-6f0b2d11c405.jpg?1",
             "name": "Waterfall Aerialist",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "96a4a991-2396-595f-a63f-0d0b51aac6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0fd73f-e161-4e42-b4f9-9246a9dba785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d0fd73f-e161-4e42-b4f9-9246a9dba785.jpg?1",
             "name": "Wormhole Serpent",
             "text": "{3}{U}: Target creature can't be blocked this turn.",
             "colours": [
@@ -2263,7 +2263,7 @@
         },
         {
             "id": "0869e433-2d7d-5bbb-ba60-0ac67edc0b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556a0816-83c5-41dc-8546-213b21e2cceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556a0816-83c5-41dc-8546-213b21e2cceb.jpg?1",
             "name": "Arrogant Poet",
             "text": "Whenever Arrogant Poet attacks, you may pay 2 life. If you do, it gains flying until end of turn.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "1496523b-b328-5fe9-9bf8-b30391b14322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f1a6ba-e46f-44fb-93f4-fb883d677b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f1a6ba-e46f-44fb-93f4-fb883d677b36.jpg?1",
             "name": "Baleful Mastery",
             "text": "You may pay {1}{B} rather than pay this spell's mana cost.\nIf the {1}{B} cost was paid, an opponent draws a card.\nExile target creature or planeswalker.",
             "colours": [
@@ -2332,7 +2332,7 @@
         },
         {
             "id": "94186fc8-bb56-5e20-898a-3dbcd21a4386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ba37ee-159f-421f-8d37-a7b5f1b562f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90ba37ee-159f-421f-8d37-a7b5f1b562f0.jpg?1",
             "name": "Brackish Trudge",
             "text": "Brackish Trudge enters the battlefield tapped.\n{1}{B}: Return Brackish Trudge from your graveyard to your hand. Activate only if you gained life this turn.",
             "colours": [
@@ -2367,7 +2367,7 @@
         },
         {
             "id": "b1517784-9912-5934-97e0-71dfac97781d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81358736-65cf-44d8-819e-d0268d14cc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81358736-65cf-44d8-819e-d0268d14cc76.jpg?1",
             "name": "Callous Bloodmage",
             "text": "When Callous Bloodmage enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\u2022 You draw a card and you lose 1 life.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -2404,7 +2404,7 @@
         },
         {
             "id": "e24f3df3-b854-5f68-8202-00815862746f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1951763-be97-400c-aa95-6b101f47bddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1951763-be97-400c-aa95-6b101f47bddf.jpg?1",
             "name": "Confront the Past",
             "text": "Choose one \u2014\n\u2022 Return target planeswalker card with mana value X or less from your graveyard to the battlefield.\n\u2022 Remove twice X loyalty counters from target planeswalker an opponent controls.",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "ca0e01ae-e4be-5d91-8057-0ce08878c26b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbe8cf1-11df-4ca4-9a6b-265193c49250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbe8cf1-11df-4ca4-9a6b-265193c49250.jpg?1",
             "name": "Crushing Disappointment",
             "text": "Each player loses 2 life. You draw two cards.",
             "colours": [
@@ -2472,7 +2472,7 @@
         },
         {
             "id": "9fdcd8b1-b22c-5712-923f-45802ad14a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a48d0c-1e5b-43f2-8974-e2e5bb06310d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71a48d0c-1e5b-43f2-8974-e2e5bb06310d.jpg?1",
             "name": "Essence Infusion",
             "text": "Put two +1/+1 counters on target creature. It gains lifelink until end of turn.",
             "colours": [
@@ -2504,7 +2504,7 @@
         },
         {
             "id": "aeff99be-3903-5e42-b542-12a223428105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4d1bb6-cb8f-4d01-9879-0b3a0585cbf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4d1bb6-cb8f-4d01-9879-0b3a0585cbf4.jpg?1",
             "name": "Eyetwitch",
             "text": "Flying\nWhen Eyetwitch dies, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -2539,7 +2539,7 @@
         },
         {
             "id": "867aa4de-ba46-57d2-9bed-6456e0b0b115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8487884-e991-4feb-823b-90d9125edf19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8487884-e991-4feb-823b-90d9125edf19.jpg?1",
             "name": "Flunk",
             "text": "Target creature gets -X/-X until end of turn, where X is 7 minus the number of cards in that creature's controller's hand.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "621be861-9c88-54df-bbb2-87e0cfdf7a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846e8657-7435-44c6-a997-b8b156d0cd2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/846e8657-7435-44c6-a997-b8b156d0cd2c.jpg?1",
             "name": "Go Blank",
             "text": "Target player discards two cards. Then exile all cards from that player's graveyard.",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "4d468474-e309-5b6b-aa1e-f11be577a7c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff0f47f-75cb-42b0-ba4d-78522cad9861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ff0f47f-75cb-42b0-ba4d-78522cad9861.jpg?1",
             "name": "Hunt for Specimens",
             "text": "Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "885d8bc1-03a3-5bec-a84d-dcaacef3ad6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3da2c6-29ed-4563-8bae-d1cc05df8897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3da2c6-29ed-4563-8bae-d1cc05df8897.jpg?1",
             "name": "Lash of Malice",
             "text": "Target creature gets +2/-2 until end of turn.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "970f7c7e-fa4d-5a16-9a3d-8978498d033e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f9fe7-241b-4eb6-a059-be5384b4a1b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f9fe7-241b-4eb6-a059-be5384b4a1b6.jpg?1",
             "name": "Leech Fanatic",
             "text": "As long as it's your turn, Leech Fanatic has lifelink.",
             "colours": [
@@ -2702,7 +2702,7 @@
         },
         {
             "id": "66a949d1-519b-53d0-ace7-4de888ce85f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fcbe4a-2d98-4fa9-a6c3-e28255171a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fcbe4a-2d98-4fa9-a6c3-e28255171a4d.jpg?1",
             "name": "Mage Hunter",
             "text": "Whenever an opponent casts or copies an instant or sorcery spell, they lose 1 life.",
             "colours": [
@@ -2736,7 +2736,7 @@
         },
         {
             "id": "035721d5-49cd-5409-bea4-b55800017a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed85140f-f0e0-4ac1-a67f-26d17ff95e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed85140f-f0e0-4ac1-a67f-26d17ff95e31.jpg?1",
             "name": "Mage Hunters' Onslaught",
             "text": "Destroy target creature or planeswalker.\nWhenever a creature blocks this turn, its controller loses 1 life.",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "7be72d1b-6bfa-5d0c-a777-6c173fcb5cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b68a4-fb8d-4b59-b049-73505296f775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e1b68a4-fb8d-4b59-b049-73505296f775.jpg?1",
             "name": "Necrotic Fumes",
             "text": "As an additional cost to cast this spell, exile a creature you control.\nExile target creature or planeswalker.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "acb827c0-effd-56ed-ad81-0b5d8d4baaa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4677bc-736b-4bf2-851e-b158718a4224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4677bc-736b-4bf2-851e-b158718a4224.jpg?1",
             "name": "Novice Dissector",
             "text": "{1}, Sacrifice another creature: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -2837,7 +2837,7 @@
         },
         {
             "id": "b0d89140-9711-5eb8-b8ba-eb2e1fcf984b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25214a91-2f64-46ee-9834-7fbf684800f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25214a91-2f64-46ee-9834-7fbf684800f7.jpg?1",
             "name": "Oriq Loremage",
             "text": "{T}: Search your library for a card, put it into your graveyard, then shuffle. If it's an instant or sorcery card, put a +1/+1 counter on Oriq Loremage.",
             "colours": [
@@ -2874,7 +2874,7 @@
         },
         {
             "id": "4d23ea02-252a-538b-954f-3317ba77e587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5034227f-3b8a-45bf-917c-c2cbd98f2192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5034227f-3b8a-45bf-917c-c2cbd98f2192.jpg?1",
             "name": "Plumb the Forbidden",
             "text": "As an additional cost to cast this spell, you may sacrifice one or more creatures. When you do, copy this spell for each creature sacrificed this way.\nYou draw a card and you lose 1 life.",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "bc37a4e4-e812-5681-a5d5-cc6f21cc97cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg?1",
             "name": "Poet's Quill",
             "text": "When Poet's Quill enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nEquipped creature gets +1/+1 and has lifelink.\nEquip {1}{B}",
             "colours": [
@@ -2942,7 +2942,7 @@
         },
         {
             "id": "1420f900-a294-5a49-8a03-3275a17dc90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013eeb99-1b66-4fba-ad96-78deee901ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013eeb99-1b66-4fba-ad96-78deee901ea4.jpg?1",
             "name": "Professor Onyx",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, each opponent loses 2 life and you gain 2 life.\n+1: You lose 1 life. Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n\u22123: Each opponent sacrifices a creature with the greatest power among creatures that player controls.\n\u22128: Each opponent may discard a card. If they don't, they lose 3 life. Repeat this process six more times.",
             "colours": [
@@ -2980,7 +2980,7 @@
         },
         {
             "id": "516cf4a7-cf2c-54cc-96ae-a68889b8c0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fded6-e474-4b20-86d8-fd9af5f25b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862fded6-e474-4b20-86d8-fd9af5f25b1a.jpg?1",
             "name": "Professor's Warning",
             "text": "Choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3012,7 +3012,7 @@
         },
         {
             "id": "1bf3503f-6ee9-5a9e-a13d-e8424eb28fd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea0dff9-71c3-4d56-aa7b-e0fb9938529a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ea0dff9-71c3-4d56-aa7b-e0fb9938529a.jpg?1",
             "name": "Promising Duskmage",
             "text": "When Promising Duskmage dies, if it had a +1/+1 counter on it, draw a card.",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "b0258edc-a8be-5b9a-9b72-8e95cfeb44f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e900c1eb-968b-4046-b824-c167a7a5b682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e900c1eb-968b-4046-b824-c167a7a5b682.jpg?1",
             "name": "Sedgemoor Witch",
             "text": "Menace\nWard\u2014\nPay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "889563cb-2e57-5027-91f8-b17bc23c305c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3cfbc-7177-4bbc-89c4-560c9c2f97db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73e3cfbc-7177-4bbc-89c4-560c9c2f97db.jpg?1",
             "name": "Specter of the Fens",
             "text": "Flying\n{5}{B}: Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -3118,7 +3118,7 @@
         },
         {
             "id": "9fe6076d-f2c0-551d-ba6f-0799f3bbddbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eba33e-efea-4e58-a832-1c6049fb211f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92eba33e-efea-4e58-a832-1c6049fb211f.jpg?1",
             "name": "Tenured Inkcaster",
             "text": "When Tenured Inkcaster enters the battlefield, put a +1/+1 counter on target creature.\nWhenever a creature you control with a +1/+1 counter on it attacks, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "3ad30ecf-43e9-52b9-b2ac-8800036709e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ea2dad-f276-47b8-912c-267a832f1d36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ea2dad-f276-47b8-912c-267a832f1d36.jpg?1",
             "name": "A-Tenured Inkcaster",
             "text": "",
             "colours": [
@@ -3187,7 +3187,7 @@
         },
         {
             "id": "09661ca1-1ab2-57ec-afca-96fe858c246b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbd0921-e953-492b-ad73-c8a8bfaa750b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fbd0921-e953-492b-ad73-c8a8bfaa750b.jpg?1",
             "name": "Umbral Juke",
             "text": "Choose one \u2014\n\u2022 Target player sacrifices a creature or planeswalker.\n\u2022 Create a 2/1 white and black Inkling creature token with flying.",
             "colours": [
@@ -3219,7 +3219,7 @@
         },
         {
             "id": "b8a11a8d-ecfc-5451-9cb3-7550cc497b15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30448144-639a-43c7-a408-bd6ed543c231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30448144-639a-43c7-a408-bd6ed543c231.jpg?1",
             "name": "Unwilling Ingredient",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{2}{B}, Exile Unwilling Ingredient from your graveyard: You draw a card and you lose 1 life.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "d4fd94e8-acbe-5863-8d66-4cd643e1ce3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620cc3b-e401-4096-b310-fed080806344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4620cc3b-e401-4096-b310-fed080806344.jpg?1",
             "name": "Academic Dispute",
             "text": "Target creature blocks this turn if able. You may have it gain reach until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3285,7 +3285,7 @@
         },
         {
             "id": "229da747-3dc8-542a-9684-36f095f07e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4832a-26c0-4da5-abbb-1941e7084e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff4832a-26c0-4da5-abbb-1941e7084e72.jpg?1",
             "name": "Ardent Dustspeaker",
             "text": "Whenever Ardent Dustspeaker attacks, you may put an instant or sorcery card from your graveyard on the bottom of your library. If you do, exile the top two cards of your library. You may play those cards this turn.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "a3662e76-73ff-5bee-b073-ce1c28cdb4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b12c44-9537-4863-a678-c982e8714a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b12c44-9537-4863-a678-c982e8714a5a.jpg?1",
             "name": "A-Ardent Dustspeaker",
             "text": "",
             "colours": [
@@ -3354,7 +3354,7 @@
         },
         {
             "id": "b13a39a2-951d-58e3-b106-9d6e9e8b74ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30237cc-27c8-4075-acbd-d75a16588a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30237cc-27c8-4075-acbd-d75a16588a68.jpg?1",
             "name": "Blood Age General",
             "text": "{T}: Attacking Spirits get +1/+0 until end of turn.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "c0502579-0903-57f8-8a77-01c372ada9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742a7487-70a2-448b-8e66-c33cba798a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/742a7487-70a2-448b-8e66-c33cba798a32.jpg?1",
             "name": "Conspiracy Theorist",
             "text": "Whenever Conspiracy Theorist attacks, you may pay {1} and discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards, you may exile one of them from your graveyard. If you do, you may cast it this turn.",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "e893af38-0a32-5027-b7b8-4a447e542e35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de547f52-3798-4b3a-947d-24873251204b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de547f52-3798-4b3a-947d-24873251204b.jpg?1",
             "name": "Crackle with Power",
             "text": "Crackle with Power deals five times X damage to each of up to X targets.",
             "colours": [
@@ -3460,7 +3460,7 @@
         },
         {
             "id": "a1a98abb-23dc-592d-9040-a494c3ef54d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657de246-b9fc-47b1-b932-091e9500bb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/657de246-b9fc-47b1-b932-091e9500bb82.jpg?1",
             "name": "Draconic Intervention",
             "text": "As an additional cost to cast this spell, exile an instant or sorcery card from your graveyard.\nDraconic Intervention deals X damage to each non-Dragon creature, where X is the exiled card's mana value. If a creature dealt damage this way would die this turn, exile it instead.\nExile Draconic Intervention.",
             "colours": [
@@ -3494,7 +3494,7 @@
         },
         {
             "id": "e0aa2342-1a29-5b34-8174-25f7d75b3e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb504a0-1dfb-49d0-84c3-7bd318d55481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb504a0-1dfb-49d0-84c3-7bd318d55481.jpg?1",
             "name": "Dragon's Approach",
             "text": "Dragon's Approach deals 3 damage to each opponent. You may exile Dragon's Approach and four cards named Dragon's Approach from your graveyard. If you do, search your library for a Dragon creature card, put it onto the battlefield, then shuffle.\nA deck can have any number of cards named Dragon's Approach.",
             "colours": [
@@ -3526,7 +3526,7 @@
         },
         {
             "id": "927c494a-fdc5-5bab-841c-e423b7630f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f0731c-2a3d-4613-bffa-8b967e4f142e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f0731c-2a3d-4613-bffa-8b967e4f142e.jpg?1",
             "name": "Efreet Flamepainter",
             "text": "Double strike\nWhenever Efreet Flamepainter deals combat damage to a player, you may cast target instant or sorcery card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -3563,7 +3563,7 @@
         },
         {
             "id": "ba28847e-89d5-5a97-afef-1a0e8f646e0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543c64ff-2c51-4a63-a940-dc8645717c85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543c64ff-2c51-4a63-a940-dc8645717c85.jpg?1",
             "name": "Enthusiastic Study",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3595,7 +3595,7 @@
         },
         {
             "id": "0b939e2f-5c3d-546e-a082-a1dc92915758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122c01e6-38a6-456e-971e-9004df85ac1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/122c01e6-38a6-456e-971e-9004df85ac1c.jpg?1",
             "name": "Explosive Welcome",
             "text": "Explosive Welcome deals 5 damage to any target and 3 damage to any other target. Add {R}{R}{R}.",
             "colours": [
@@ -3627,7 +3627,7 @@
         },
         {
             "id": "b7782885-29c5-5b11-a5f2-22d52fd70cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f824caf-b32c-442a-8631-887831a57360.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f824caf-b32c-442a-8631-887831a57360.jpg?1",
             "name": "Fervent Mastery",
             "text": "You may pay {2}{R}{R} rather than pay this spell's mana cost.\nIf the {2}{R}{R} cost was paid, an opponent discards any number of cards, then draws that many cards.\nSearch your library for up to three cards, put them into your hand, shuffle, then discard three cards at random.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "d4171971-acfe-5a89-b6c2-0adff025b7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091eb13d-9318-4b12-9f94-6276b11981d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091eb13d-9318-4b12-9f94-6276b11981d1.jpg?1",
             "name": "First Day of Class",
             "text": "Whenever a creature enters the battlefield under your control this turn, put a +1/+1 counter on it and it gains haste until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3693,7 +3693,7 @@
         },
         {
             "id": "55da3b0f-1a14-5d3b-b008-c1ef5080daf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce76a38-fc5f-4e29-ba24-4a877179a62c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce76a38-fc5f-4e29-ba24-4a877179a62c.jpg?1",
             "name": "Fuming Effigy",
             "text": "Whenever one or more cards leave your graveyard, Fuming Effigy deals 1 damage to each opponent.",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "8b870715-7326-5724-b859-f136a519c26a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04897-6438-45e5-a10b-2e8afaf2b9eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfa04897-6438-45e5-a10b-2e8afaf2b9eb.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {C}{C}{R}. Activate only as a sorcery.",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "88f4e95d-886f-58a4-8ac7-d6d032461ea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fdc551-0b22-49f4-8765-143ad82f16a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fdc551-0b22-49f4-8765-143ad82f16a3.jpg?1",
             "name": "Hall Monitor",
             "text": "Haste\n{1}{R}, {T}: Target creature can't block this turn.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "1eb27463-abee-5a62-ab17-ae2be76d8793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c88e2-28ed-4e5b-bcb3-4397d6a15a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40c88e2-28ed-4e5b-bcb3-4397d6a15a6f.jpg?1",
             "name": "Heated Debate",
             "text": "This spell can't be countered. (This includes by the ward ability.)\nHeated Debate deals 4 damage to target creature or planeswalker.",
             "colours": [
@@ -3828,7 +3828,7 @@
         },
         {
             "id": "99fd4bd9-0d11-541a-80ef-cd32e812869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5781ad7b-dc1b-4cc1-9e72-6e714b9ba1de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5781ad7b-dc1b-4cc1-9e72-6e714b9ba1de.jpg?1",
             "name": "Igneous Inspiration",
             "text": "Igneous Inspiration deals 3 damage to any target.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -3860,7 +3860,7 @@
         },
         {
             "id": "f67fa68e-5cc3-5601-9fac-2f696dd08b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98739789-80b5-4224-a2e4-09e00654aa9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98739789-80b5-4224-a2e4-09e00654aa9d.jpg?1",
             "name": "Illuminate History",
             "text": "Discard any number of cards, then draw that many cards. Then if there are seven or more cards in your graveyard, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -3896,7 +3896,7 @@
         },
         {
             "id": "e7445d36-852d-5e02-a8af-3ba3fb09ff97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc4e7d-3b06-4938-9023-d903912350c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc4e7d-3b06-4938-9023-d903912350c0.jpg?1",
             "name": "Illustrious Historian",
             "text": "{5}, Exile Illustrious Historian from your graveyard: Create a tapped 3/2 red and white Spirit creature token.",
             "colours": [
@@ -3931,7 +3931,7 @@
         },
         {
             "id": "9a05ec6f-deb6-5539-a53e-0276e5bda7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0ea66f-1756-4b0d-8ccc-3b3a7370b531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f0ea66f-1756-4b0d-8ccc-3b3a7370b531.jpg?1",
             "name": "Mascot Interception",
             "text": "This spell costs {3} less to cast if it targets a creature token.\nGain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "e6620102-4262-529d-97d8-acb19792fdb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d285a7a1-bb7e-4a78-a49f-c2add62b829a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d285a7a1-bb7e-4a78-a49f-c2add62b829a.jpg?1",
             "name": "Pigment Storm",
             "text": "Pigment Storm deals 5 damage to target creature. Excess damage is dealt to that creature's controller instead.",
             "colours": [
@@ -3995,7 +3995,7 @@
         },
         {
             "id": "1b4a82f1-032d-54cc-8f63-5af4a09a9609",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d509f73-cd62-4116-9652-0ed801ed8b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d509f73-cd62-4116-9652-0ed801ed8b36.jpg?1",
             "name": "Pillardrop Warden",
             "text": "Reach\n{2}, {T}, Sacrifice Pillardrop Warden: Return target instant or sorcery card from your graveyard to your hand. Activate only as a sorcery.",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "0b0cc9ce-0788-5241-ae58-9b05f4a7d48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd6cb53-3c82-4ac3-be1e-311322729198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd6cb53-3c82-4ac3-be1e-311322729198.jpg?1",
             "name": "Retriever Phoenix",
             "text": "Flying, haste\nWhen Retriever Phoenix enters the battlefield, if you cast it, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nAs long as Retriever Phoenix is in your graveyard, if you would learn, you may instead return Retriever Phoenix to the battlefield.",
             "colours": [
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "7a0b2101-f675-58c9-9f46-ca36c277e601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c99486-ae64-4293-81fb-a4b02e8fcae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c99486-ae64-4293-81fb-a4b02e8fcae6.jpg?1",
             "name": "Start from Scratch",
             "text": "Choose one \u2014\n\u2022 Start from Scratch deals 1 damage to any target.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -4100,7 +4100,7 @@
         },
         {
             "id": "55dc28b3-b20f-538d-a0eb-aafcb348be3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa96b8dc-233a-4884-ab84-235cbc7df0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa96b8dc-233a-4884-ab84-235cbc7df0b6.jpg?1",
             "name": "Storm-Kiln Artist",
             "text": "Storm-Kiln Artist gets +1/+0 for each artifact you control.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a Treasure token.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "d22f72a4-5adc-55cb-828f-f237ece17a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b011707a-471b-41c2-bc73-376a55d26bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b011707a-471b-41c2-bc73-376a55d26bee.jpg?1",
             "name": "Sudden Breakthrough",
             "text": "Target creature gets +2/+0 and gains first strike until end of turn.\nCreate a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -4167,7 +4167,7 @@
         },
         {
             "id": "f2227a3b-912c-5164-880d-ce00bb9b8694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cc9ea8-db4e-4f41-800f-fb0dbcb2c345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cc9ea8-db4e-4f41-800f-fb0dbcb2c345.jpg?1",
             "name": "Tome Shredder",
             "text": "Haste\n{T}, Exile an instant or sorcery card from your graveyard: Put a +1/+1 counter on Tome Shredder.",
             "colours": [
@@ -4201,7 +4201,7 @@
         },
         {
             "id": "86de9023-6281-5e06-b512-05d109d7bb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2952a34c-b0c0-4e1c-9a00-c74c7e6b7d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2952a34c-b0c0-4e1c-9a00-c74c7e6b7d32.jpg?1",
             "name": "A-Tome Shredder",
             "text": "",
             "colours": [
@@ -4234,7 +4234,7 @@
         },
         {
             "id": "b8d2f2a7-b630-57ee-b159-c309966ced0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193af5-4b6b-48d0-9b75-8171bb1d6e53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87193af5-4b6b-48d0-9b75-8171bb1d6e53.jpg?1",
             "name": "Twinscroll Shaman",
             "text": "Double strike",
             "colours": [
@@ -4269,7 +4269,7 @@
         },
         {
             "id": "68d2b8d8-f36d-51e1-b8fe-3c0a4516a9f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b7830-b65e-4c53-98e8-152026764e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7b7830-b65e-4c53-98e8-152026764e4b.jpg?1",
             "name": "Accomplished Alchemist",
             "text": "{T}: Add one mana of any color.\n{T}: Add X mana of any one color, where X is the amount of life you gained this turn.",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "5d44e374-6a7d-5ab4-b7fe-4d99917cf401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg?1",
             "name": "Basic Conjuration",
             "text": "Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life.",
             "colours": [
@@ -4342,7 +4342,7 @@
         },
         {
             "id": "bb7c872a-07e0-51ff-91ba-7a1610bdeaac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82b032-b1ba-456c-abab-c0f7430b0587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a82b032-b1ba-456c-abab-c0f7430b0587.jpg?1",
             "name": "Bayou Groff",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}.",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "01b6e372-397c-5938-9af1-a792b451e841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016d667-50a9-4093-9a99-b34dcdafe60b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9016d667-50a9-4093-9a99-b34dcdafe60b.jpg?1",
             "name": "Big Play",
             "text": "Target creature gets +2/+2 and gains reach until end of turn. Put a +1/+1 counter on it.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "919d569a-665b-5c07-a58e-41d0bb790e7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d230fc-d382-40b4-bdbd-5fe880fa16bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d230fc-d382-40b4-bdbd-5fe880fa16bf.jpg?1",
             "name": "Bookwurm",
             "text": "Trample\nWhen Bookwurm enters the battlefield, you gain 3 life and draw a card.\n{2}{G}: Put Bookwurm from your graveyard into your library third from the top.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "988fcafa-2144-54a0-a167-0688983a78c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed16926f-feb0-481a-8c5e-88ea119752cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed16926f-feb0-481a-8c5e-88ea119752cd.jpg?1",
             "name": "Charge Through",
             "text": "Target creature gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -4475,7 +4475,7 @@
         },
         {
             "id": "a18d7e04-9518-5f89-ab40-72dc8f3f84b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcca120-b72e-4007-98e1-cb22e7b9a705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcca120-b72e-4007-98e1-cb22e7b9a705.jpg?1",
             "name": "Containment Breach",
             "text": "Destroy target artifact or enchantment. If its mana value is 2 or less, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "9f19e2cd-5551-5db9-8b6d-9f3985048f36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7444555-da19-4d2d-ad81-233c54fbb78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7444555-da19-4d2d-ad81-233c54fbb78e.jpg?1",
             "name": "Devouring Tendrils",
             "text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control. When the permanent you don't control dies this turn, you gain 2 life.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "ca8b9a11-3bdd-5680-9088-365a4ffce125",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658ec634-3eb2-4967-b938-d20d31ab77e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658ec634-3eb2-4967-b938-d20d31ab77e3.jpg?1",
             "name": "Dragonsguard Elite",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Dragonsguard Elite.\n{4}{G}{G}: Double the number of +1/+1 counters on Dragonsguard Elite.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "66d29d3a-280c-54d8-a61f-9e89e204cbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115f3d72-1aaf-4237-91b9-389256e5e5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/115f3d72-1aaf-4237-91b9-389256e5e5c8.jpg?1",
             "name": "Ecological Appreciation",
             "text": "Search your library and graveyard for up to four creature cards with different names that each have mana value X or less and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest onto the battlefield. Exile Ecological Appreciation.",
             "colours": [
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "ae6067fc-2e5b-583c-8eda-4e2413bae84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a81975-5f0e-4593-a2da-b9689f9a985f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a81975-5f0e-4593-a2da-b9689f9a985f.jpg?1",
             "name": "Emergent Sequence",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. That land becomes a 0/0 green and blue Fractal creature that's still a land. Put a +1/+1 counter on it for each land you had enter the battlefield under your control this turn.",
             "colours": [
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "dd174633-ac4e-55b2-ae1a-e0ff1f00a0dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c129bb7-9489-44bd-a46d-c5f738bf9d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c129bb7-9489-44bd-a46d-c5f738bf9d25.jpg?1",
             "name": "Exponential Growth",
             "text": "Until end of turn, double target creature's power X times.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "4e62bc4c-ca9e-59b1-bc36-8ee7dab438af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f235060a-eb49-4a73-bb5f-01228c3c4070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f235060a-eb49-4a73-bb5f-01228c3c4070.jpg?1",
             "name": "Field Trip",
             "text": "Search your library for a basic Forest card, put that card onto the battlefield tapped, then shuffle.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -4711,7 +4711,7 @@
         },
         {
             "id": "7ebe8288-c967-5f4a-a5f5-5fd3c94ed922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6789b717-a000-464a-a39b-32c1aeefe560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6789b717-a000-464a-a39b-32c1aeefe560.jpg?1",
             "name": "Fortifying Draught",
             "text": "You gain 2 life. Target creature gets +X/+X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "66485f80-10b2-54ad-98a4-7e2d57d472bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg?1",
             "name": "Gnarled Professor",
             "text": "Trample\nWhen Gnarled Professor enters the battlefield, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "e1634908-4cec-5d28-9345-0a7a7bd650f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6a6b9-f00c-46a5-8dab-796483e3a262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9c6a6b9-f00c-46a5-8dab-796483e3a262.jpg?1",
             "name": "Honor Troll",
             "text": "Vigilance\nIf you would gain life, you gain that much life plus 1 instead.\nHonor Troll gets +2/+1 as long as you have 25 or more life.",
             "colours": [
@@ -4815,7 +4815,7 @@
         },
         {
             "id": "31fbdb67-ec53-5e65-8187-6302c32d1f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74729320-f6ee-4176-9463-397d6e477d7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74729320-f6ee-4176-9463-397d6e477d7a.jpg?1",
             "name": "Karok Wrangler",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -4850,7 +4850,7 @@
         },
         {
             "id": "d5a37960-5faa-5020-b9d9-917a1c8d8eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbed0-0c0d-4aa5-bfe0-5268aff0f958.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbed0-0c0d-4aa5-bfe0-5268aff0f958.jpg?1",
             "name": "Leyline Invocation",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of lands you control.",
             "colours": [
@@ -4882,7 +4882,7 @@
         },
         {
             "id": "10f41540-1e49-5872-8eaf-ad9469821f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92325638-0321-4409-8910-2287c64c182e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92325638-0321-4409-8910-2287c64c182e.jpg?1",
             "name": "Mage Duel",
             "text": "This spell costs {2} less to cast if you've cast another instant or sorcery spell this turn.\nTarget creature you control gets +1/+2 until end of turn. Then it fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -4914,7 +4914,7 @@
         },
         {
             "id": "0bd9370a-baef-553c-9761-004ec21771fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255cdc39-6ad8-4831-9718-6712cb17654c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/255cdc39-6ad8-4831-9718-6712cb17654c.jpg?1",
             "name": "Master Symmetrist",
             "text": "Reach\nWhenever a creature you control with power equal to its toughness attacks, it gains trample until end of turn.",
             "colours": [
@@ -4949,7 +4949,7 @@
         },
         {
             "id": "cf587c42-c21d-5f6e-864a-270d29cef923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71dddf5-8f72-4018-9cc8-5f63a17f1ee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a71dddf5-8f72-4018-9cc8-5f63a17f1ee5.jpg?1",
             "name": "Overgrown Arch",
             "text": "Defender\n{T}: You gain 1 life.\n{2}, Sacrifice Overgrown Arch: Learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -4984,7 +4984,7 @@
         },
         {
             "id": "339c8411-ee94-57bf-96d4-0aea20f23cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8347f2e8-ef70-4879-860a-12f7cab25902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8347f2e8-ef70-4879-860a-12f7cab25902.jpg?1",
             "name": "Professor of Zoomancy",
             "text": "When Professor of Zoomancy enters the battlefield, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -5019,7 +5019,7 @@
         },
         {
             "id": "15e24f7f-8822-5fb0-827e-b50d4777fdb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8072b1-6080-45cd-b1c7-353b54a55931.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8072b1-6080-45cd-b1c7-353b54a55931.jpg?1",
             "name": "Reckless Amplimancer",
             "text": "{4}{G}: Double Reckless Amplimancer's power and toughness until end of turn.",
             "colours": [
@@ -5054,7 +5054,7 @@
         },
         {
             "id": "244e8e81-0c6f-5053-8ef9-82dedc59664c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0a096-870d-443c-92d3-f7ec1f362616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9c0a096-870d-443c-92d3-f7ec1f362616.jpg?1",
             "name": "Scurrid Colony",
             "text": "Reach\nScurrid Colony gets +2/+2 as long as you control eight or more lands.",
             "colours": [
@@ -5088,7 +5088,7 @@
         },
         {
             "id": "0731017a-2eef-5795-afa6-69ef12b416b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37ae6b5-225a-410e-ab22-13e923bdfb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c37ae6b5-225a-410e-ab22-13e923bdfb65.jpg?1",
             "name": "Spined Karok",
             "text": "",
             "colours": [
@@ -5122,7 +5122,7 @@
         },
         {
             "id": "a87fb203-7298-5b11-b0ff-0672159e8b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b0eac4-0262-4eed-97d4-0f2e6f06c8e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5b0eac4-0262-4eed-97d4-0f2e6f06c8e1.jpg?1",
             "name": "Springmane Cervin",
             "text": "When Springmane Cervin enters the battlefield, you gain 2 life.",
             "colours": [
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "6ff57442-57a3-5901-9688-6114872e82bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fbf729-00c0-4237-8294-c857f96364d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fbf729-00c0-4237-8294-c857f96364d3.jpg?1",
             "name": "Tangletrap",
             "text": "Choose one \u2014\n\u2022 Tangletrap deals 5 damage to target creature with flying.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5188,7 +5188,7 @@
         },
         {
             "id": "34f18c07-6eb9-5e87-a604-50cb8f6f8210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197455e5-7929-47b8-ad00-8d3918949eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197455e5-7929-47b8-ad00-8d3918949eb7.jpg?1",
             "name": "Verdant Mastery",
             "text": "You may pay {3}{G} rather than pay this spell's mana cost.\nSearch your library for up to four basic land cards and reveal them. Put one of them onto the battlefield tapped under an opponent's control if the {3}{G} cost was paid. Put two of them onto the battlefield tapped under your control and the rest into your hand. Then shuffle.",
             "colours": [
@@ -5222,7 +5222,7 @@
         },
         {
             "id": "9e0936f9-4044-51e7-8c67-843a27d5ac9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "657f4e54-d473-56bb-be88-2796de7070cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/9/d9131fc3-018a-4975-8795-47be3956160d.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -5295,7 +5295,7 @@
         },
         {
             "id": "5a52cce7-3897-5901-a0ab-d1ed087c41ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -5334,7 +5334,7 @@
         },
         {
             "id": "55cd326c-01c3-5523-b2fe-22a614594d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/2/c204b7ca-0904-40fa-b20c-92400fae20b8.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "c3881b6c-fe9c-5fbf-bfcf-136795dd0e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -5411,7 +5411,7 @@
         },
         {
             "id": "1585babb-53a5-5c2b-bcbc-e239fa209d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/ba09360a-067e-48a5-bdc5-a19fd066a785.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -5448,7 +5448,7 @@
         },
         {
             "id": "993ad70a-a847-5a5f-bb1f-337f6a69526c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "bdae9711-1cd5-5232-9b44-4794195009b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -5521,7 +5521,7 @@
         },
         {
             "id": "ba2a5b47-8058-5de2-bc8b-28b57b56615e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "cf445c3c-3759-5b0c-aa94-78312ce2ed7c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/7/d7148d24-373e-4485-860b-c3429c2337f2.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -5596,7 +5596,7 @@
         },
         {
             "id": "67c72f64-55f6-5699-9ee7-e6fa5bf3a456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -5636,7 +5636,7 @@
         },
         {
             "id": "635efd48-a593-5ade-86ca-8b2ca6a17aed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b45dc40-6827-46a7-a9b7-802be698d053.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "8317df72-f217-529b-b3f3-33bac02d8971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -5715,7 +5715,7 @@
         },
         {
             "id": "a56db6de-2653-5737-b9b3-2b71592759d3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e4e0f81-f92b-4a3a-bb29-adcc3de211b4.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "d07c3edc-397e-5a1a-aa15-3c212ca1dcfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -5789,7 +5789,7 @@
         },
         {
             "id": "c82b54a3-005d-5985-bf04-83e2ce45ce79",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aaa1e6be-08cc-4ccc-b2de-3511613e4fd0.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "8a55d6cc-c013-5f09-9ff9-ebdff6a1b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -5864,7 +5864,7 @@
         },
         {
             "id": "3a8c839f-e8a2-5d79-846a-36dc1a642f5c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5bd9b5cf-f018-48af-a081-995ce8ecc539.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "fabd03c7-6c79-552c-ae47-a907a2dd60b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -5943,7 +5943,7 @@
         },
         {
             "id": "bec42168-2b9d-5bc6-815b-e4c120fc4f51",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/8/18c16872-3675-4a4d-962a-2e17ad6f3886.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -5982,7 +5982,7 @@
         },
         {
             "id": "c5b21dfd-cb00-5fea-b3ef-a0fafb4e91b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg?1",
             "name": "A-Rowan, Scholar of Sparks // A-Will, Scholar of Frost",
             "text": "",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "877af095-2742-58dc-b317-e042d600e697",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/6168bf9a-8a2e-46a5-ba87-7f88a4edc526.jpg?1",
             "name": "A-Rowan, Scholar of Sparks // A-Will, Scholar of Frost",
             "text": "",
             "colours": [
@@ -6054,7 +6054,7 @@
         },
         {
             "id": "21b5995b-8c46-5e6d-95a1-4d617b7c414c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "2d4b9802-2ac9-5997-9d0d-5b725d1a7439",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8982ff88-8595-4363-8cde-6e87fb57a2d8.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "e2d2a0fc-fca8-5c65-b05c-a7142981c3c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "d1a986ca-1e4e-5422-9975-b16428a4823c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/938cee8f-ac2c-49a5-9ff7-1367d0edfabe.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -6207,7 +6207,7 @@
         },
         {
             "id": "ededb64b-23a7-5be4-8536-946d19c43dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2}\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -6245,7 +6245,7 @@
         },
         {
             "id": "c0ffa53f-7cdd-5d8a-999e-4cd6f6e04c78",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87463b68-3642-41c7-a11c-67d524759b60.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -6280,7 +6280,7 @@
         },
         {
             "id": "ba394357-d2ed-5be4-a2a9-41ee487571f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "db8894bb-dcb4-5d7c-8572-9c2a88ad04b4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8cfd0887-0c83-4b33-a85e-8b8ec5bf758d.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "6eac70af-6c27-5b83-9514-0eb13f05ad48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -6400,7 +6400,7 @@
         },
         {
             "id": "c4983060-0fdf-5c60-9930-5db6683ab7eb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/65008352-bc7e-40b2-a832-b46813e5dc4c.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -6440,7 +6440,7 @@
         },
         {
             "id": "31e83999-43c6-56ab-a3a9-853532be5c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1c653e-f629-4105-a52c-379c5cd78208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d1c653e-f629-4105-a52c-379c5cd78208.jpg?1",
             "name": "Aether Helix",
             "text": "Return target permanent to its owner's hand. Return target permanent card from your graveyard to your hand.",
             "colours": [
@@ -6474,7 +6474,7 @@
         },
         {
             "id": "590ae1e0-a8c9-5407-81c9-d9f93285402f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f786a2-a7b7-4f9e-92e8-9a6a11efe290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f786a2-a7b7-4f9e-92e8-9a6a11efe290.jpg?1",
             "name": "Beledros Witherbloom",
             "text": "Flying\nAt the beginning of each upkeep, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\nPay 10 life: Untap all lands you control. Activate only once each turn.",
             "colours": [
@@ -6515,7 +6515,7 @@
         },
         {
             "id": "237fa397-f19b-59c1-b06e-e8b2de2bfd11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a35ef-dae1-4534-a12a-d3951b285273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b41a35ef-dae1-4534-a12a-d3951b285273.jpg?1",
             "name": "Biomathematician",
             "text": "When Biomathematician enters the battlefield, create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on each Fractal you control.",
             "colours": [
@@ -6552,7 +6552,7 @@
         },
         {
             "id": "6f90e775-194e-574e-a005-b7bfee276556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46d64ec-aca4-428e-bce6-66cd755c8cc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46d64ec-aca4-428e-bce6-66cd755c8cc3.jpg?1",
             "name": "Blade Historian",
             "text": "Attacking creatures you control have double strike.",
             "colours": [
@@ -6591,7 +6591,7 @@
         },
         {
             "id": "90370be4-443c-542c-9ef8-e4fcc80e5f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e35e9ba-a10e-4926-a7a6-3a65efc2a730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e35e9ba-a10e-4926-a7a6-3a65efc2a730.jpg?1",
             "name": "Blood Researcher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever you gain life, put a +1/+1 counter on Blood Researcher.",
             "colours": [
@@ -6628,7 +6628,7 @@
         },
         {
             "id": "494545b2-2e57-5c6c-ba39-07b289ca4bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0141312f-4b68-4c56-b1dc-5b7e6afbb96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0141312f-4b68-4c56-b1dc-5b7e6afbb96c.jpg?1",
             "name": "Blot Out the Sky",
             "text": "Create X tapped 2/1 white and black Inkling creature tokens with flying. If X is 6 or more, destroy all noncreature, nonland permanents.",
             "colours": [
@@ -6664,7 +6664,7 @@
         },
         {
             "id": "2569a3ee-b2aa-5aba-8a3b-136e39b2edd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b56823-0076-49cc-b5aa-4accb8e2782e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b56823-0076-49cc-b5aa-4accb8e2782e.jpg?1",
             "name": "Body of Research",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your library.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "1e5efac7-f7d8-5434-b71e-c5edab51aca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e6d07-fe40-4723-b963-02da0a0987c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/785e6d07-fe40-4723-b963-02da0a0987c7.jpg?1",
             "name": "Closing Statement",
             "text": "This spell costs {2} less to cast during your end step.\nDestroy target creature or planeswalker you don't control. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "d1514285-38e2-5ff5-80bf-bdca8c0cb63c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59a249f-35ed-447a-845b-32ba5a53124e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c59a249f-35ed-447a-845b-32ba5a53124e.jpg?1",
             "name": "Cram Session",
             "text": "You gain 4 life.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "9c44bf9d-9994-58d0-9cf7-c9f12885842e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab58d87-bf01-45dc-8958-e2b3375f914b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eab58d87-bf01-45dc-8958-e2b3375f914b.jpg?1",
             "name": "Creative Outburst",
             "text": "Creative Outburst deals 5 damage to any target. Look at the top five cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.\n{UR}{UR}, Discard Creative Outburst: Create a Treasure token.",
             "colours": [
@@ -6802,7 +6802,7 @@
         },
         {
             "id": "e1cdc29e-b9aa-558b-a657-7120167dd34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6f91d3-cc07-4a42-99a0-5fb83b29cc25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f6f91d3-cc07-4a42-99a0-5fb83b29cc25.jpg?1",
             "name": "Culling Ritual",
             "text": "Destroy each nonland permanent with mana value 2 or less. Add {B} or {G} for each permanent destroyed this way.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "6fe2417c-dc87-5d55-9db8-5a7dd842c06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2483060e-9d3f-48ae-80ea-0119bf6b4d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2483060e-9d3f-48ae-80ea-0119bf6b4d67.jpg?1",
             "name": "Culmination of Studies",
             "text": "Exile the top X cards of your library. For each land card exiled this way, create a Treasure token. For each blue card exiled this way, draw a card. For each red card exiled this way, Culmination of Studies deals 1 damage to each opponent.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "ce592fac-5d34-5f78-ab70-e04beb76f53c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f18828-ade7-4b99-97b2-e34bc2fdb68c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f18828-ade7-4b99-97b2-e34bc2fdb68c.jpg?1",
             "name": "Daemogoth Titan",
             "text": "Whenever Daemogoth Titan attacks or blocks, sacrifice a creature.",
             "colours": [
@@ -6912,7 +6912,7 @@
         },
         {
             "id": "f0510f58-64b3-50d1-a63b-b1329bb75662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c965cbe3-50e5-41bb-bdb9-e65d97aab716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c965cbe3-50e5-41bb-bdb9-e65d97aab716.jpg?1",
             "name": "Daemogoth Woe-Eater",
             "text": "At the beginning of your upkeep, sacrifice a creature.\nWhen you sacrifice Daemogoth Woe-Eater, each opponent discards a card, you draw a card, and you gain 2 life.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "3de709fc-2798-52a8-afe1-efab392bc9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33e48-90fc-4aac-b09a-68050bc053b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d33e48-90fc-4aac-b09a-68050bc053b5.jpg?1",
             "name": "Deadly Brew",
             "text": "Each player sacrifices a creature or planeswalker. If you sacrificed a permanent this way, you may return another permanent card from your graveyard to your hand.",
             "colours": [
@@ -6982,7 +6982,7 @@
         },
         {
             "id": "52e047af-7800-55e2-b3ae-05ebb0a1a2e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e9d132-95f7-4ee7-9c91-be19e4ad7a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e9d132-95f7-4ee7-9c91-be19e4ad7a5d.jpg?1",
             "name": "Decisive Denial",
             "text": "Choose one \u2014\n\u2022 Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\n\u2022 Counter target noncreature spell unless its controller pays {3}.",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "ba8b4d5c-8409-50c8-8d3a-010a99cc0513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd2b567-0cf7-4441-b3ce-e31141dd91c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd2b567-0cf7-4441-b3ce-e31141dd91c8.jpg?1",
             "name": "Dina, Soul Steeper",
             "text": "Whenever you gain life, each opponent loses 1 life.\n{1}, Sacrifice another creature: Dina, Soul Steeper gets +X/+0 until end of turn, where X is the sacrificed creature's power.",
             "colours": [
@@ -7057,7 +7057,7 @@
         },
         {
             "id": "67dd6c24-8393-5c99-8ee7-f7c25e35a1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d35413-8742-4443-8859-93c91112978d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3d35413-8742-4443-8859-93c91112978d.jpg?1",
             "name": "Double Major",
             "text": "Copy target creature spell you control, except it isn't legendary if the spell is legendary. (A copy of a creature spell becomes a token.)",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "bc6609f0-0592-52c8-9c15-43f88760b612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ec9be6-c8ad-4a82-8253-c49cdb9443ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8ec9be6-c8ad-4a82-8253-c49cdb9443ba.jpg?1",
             "name": "Dramatic Finale",
             "text": "Creature tokens you control get +1/+1.\nWhenever one or more nontoken creatures you control die, create a 2/1 white and black Inkling creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "72c86b4a-6059-595a-a3ca-5db89652ac16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473db42-905b-4fda-af8c-fd24d906b642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7473db42-905b-4fda-af8c-fd24d906b642.jpg?1",
             "name": "Elemental Expressionist",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, choose target creature you control. Until end of turn, it gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else\" and \"When you exile this creature, create a 4/4 blue and red Elemental creature token.\" (Each instance of that ability triggers separately.)",
             "colours": [
@@ -7168,7 +7168,7 @@
         },
         {
             "id": "9dc927c8-5ded-5a1b-b303-734208eaea6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4331a7a6-e98e-4517-b0f9-ace379426a94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4331a7a6-e98e-4517-b0f9-ace379426a94.jpg?1",
             "name": "Elemental Masterpiece",
             "text": "Create two 4/4 blue and red Elemental creature tokens.\n{UR}{UR}, Discard Elemental Masterpiece: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "3ec41a53-ce44-5e06-8dbf-e328262afea3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea51991c-1589-4c62-965b-5ae8d233520b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea51991c-1589-4c62-965b-5ae8d233520b.jpg?1",
             "name": "Elemental Summoning",
             "text": "Create a 4/4 blue and red Elemental creature token.",
             "colours": [
@@ -7238,7 +7238,7 @@
         },
         {
             "id": "6a538fbc-2272-5a57-9a21-6287af8a9e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400c9b7-c789-49dd-9f72-b9d1df03fcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e400c9b7-c789-49dd-9f72-b9d1df03fcca.jpg?1",
             "name": "Eureka Moment",
             "text": "Draw two cards. You may put a land card from your hand onto the battlefield.",
             "colours": [
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "ee516c09-537d-5365-8e42-0bd9e0dab9c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8468417d-7ef5-43e0-9190-e88f3eed9e82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/8468417d-7ef5-43e0-9190-e88f3eed9e82.jpg?1",
             "name": "Exhilarating Elocution",
             "text": "Put two +1/+1 counters on target creature you control. Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "82ee6986-02f8-50fb-81a5-26f0d3bc0b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b770cc-09e7-4c0b-b2a4-462ab4f7200d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b770cc-09e7-4c0b-b2a4-462ab4f7200d.jpg?1",
             "name": "Expressive Iteration",
             "text": "Look at the top three cards of your library. Put one of them into your hand, put one of them on the bottom of your library, and exile one of them. You may play the exiled card this turn.",
             "colours": [
@@ -7342,7 +7342,7 @@
         },
         {
             "id": "841e8b02-e657-5bcb-81c9-82c8040d3b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3f1f7e-eb19-49c1-a1ee-93b85ac8815c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3f1f7e-eb19-49c1-a1ee-93b85ac8815c.jpg?1",
             "name": "Fractal Summoning",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "afb258f6-63f8-58b6-8dc2-d39446885baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11224f8-06ea-4ec3-85e6-d5c8d906840c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a11224f8-06ea-4ec3-85e6-d5c8d906840c.jpg?1",
             "name": "Fracture",
             "text": "Destroy target artifact, enchantment, or planeswalker.",
             "colours": [
@@ -7414,7 +7414,7 @@
         },
         {
             "id": "995fd0ec-402a-5d0e-b462-9d790966157f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9158c-064b-4d12-b860-d2c1450d1897.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c9158c-064b-4d12-b860-d2c1450d1897.jpg?1",
             "name": "Galazeth Prismari",
             "text": "Flying\nWhen Galazeth Prismari enters the battlefield, create a Treasure token.\nArtifacts you control have \"{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.\"",
             "colours": [
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "37665229-ea67-537c-8ff8-fb57049c0743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626fbddb-3963-4dd2-8507-9777ed66bbbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626fbddb-3963-4dd2-8507-9777ed66bbbc.jpg?1",
             "name": "Golden Ratio",
             "text": "Draw a card for each different power among creatures you control.",
             "colours": [
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "fbf89fdd-c085-5a70-a0ce-b9cdfeb22440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74120ce-9f11-449f-bb72-04fe2a27a9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74120ce-9f11-449f-bb72-04fe2a27a9f6.jpg?1",
             "name": "Harness Infinity",
             "text": "Exchange your hand and graveyard.\nExile Harness Infinity.",
             "colours": [
@@ -7525,7 +7525,7 @@
         },
         {
             "id": "2e02531c-9439-577f-b3f3-838098b0a386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8deecf-eded-418b-ac4c-5c3e8f54e86d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8deecf-eded-418b-ac4c-5c3e8f54e86d.jpg?1",
             "name": "Hofri Ghostforge",
             "text": "Spirits you control get +1/+1 and have trample and haste.\nWhenever another nontoken creature you control dies, exile it. If you do, create a token that's a copy of that creature, except it's a Spirit in addition to its other types and it has \"When this creature leaves the battlefield, return the exiled card to your graveyard.\"",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "73bdcc8e-07df-5e45-807b-e4c2878208c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3ae8cb-fbdb-45a8-83c2-cbf4aff01f90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3ae8cb-fbdb-45a8-83c2-cbf4aff01f90.jpg?1",
             "name": "Humiliate",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Put a +1/+1 counter on a creature you control.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "2d6235a9-e0b8-5281-9ba2-2794e4bc12c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840600a9-3e78-48a6-b75b-860446b82c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840600a9-3e78-48a6-b75b-860446b82c1b.jpg?1",
             "name": "Infuse with Vitality",
             "text": "Until end of turn, target creature gains deathtouch and \"When this creature dies, return it to the battlefield tapped under its owner's control.\"\nYou gain 2 life.",
             "colours": [
@@ -7634,7 +7634,7 @@
         },
         {
             "id": "3686b458-2c93-5b15-a9a6-726b1d20fb4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a8a5b8-9743-4d1a-89e9-61bdf180b2e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04a8a5b8-9743-4d1a-89e9-61bdf180b2e0.jpg?1",
             "name": "Inkling Summoning",
             "text": "Create a 2/1 white and black Inkling creature token with flying.",
             "colours": [
@@ -7670,7 +7670,7 @@
         },
         {
             "id": "021c5b4a-120d-501a-b3c9-c29d94adb830",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bf300-38cf-4ab2-9e66-6fcaa112b649.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178bf300-38cf-4ab2-9e66-6fcaa112b649.jpg?1",
             "name": "Kasmina, Enigma Sage",
             "text": "Each other planeswalker you control has the loyalty abilities of Kasmina, Enigma Sage.\n+2: Scry 1.\n\u2212X: Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.\n\u22128: Search your library for an instant or sorcery card that shares a color with this planeswalker, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -7710,7 +7710,7 @@
         },
         {
             "id": "50cc691d-cd66-5f22-a153-cc8b5996df5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ef4f09-2aa1-4a03-b2e2-66d1522f1e46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23ef4f09-2aa1-4a03-b2e2-66d1522f1e46.jpg?1",
             "name": "Killian, Ink Duelist",
             "text": "Lifelink\nMenace (This creature can't be blocked except by two or more creatures.)\nSpells you cast that target a creature cost {2} less to cast.",
             "colours": [
@@ -7749,7 +7749,7 @@
         },
         {
             "id": "c8050495-655f-5de4-8a6c-4d75b543c289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048157c6-4626-4881-ba19-deddd13622dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/048157c6-4626-4881-ba19-deddd13622dc.jpg?1",
             "name": "Lorehold Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, until end of turn, Spirit creatures you control gain \"{T}: This creature deals 1 damage to each opponent.\"",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "48d7f3f9-3225-5104-ab39-b3f3c9808195",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0885f-1049-4a19-853d-f4e6d4bec29e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f0885f-1049-4a19-853d-f4e6d4bec29e.jpg?1",
             "name": "Lorehold Command",
             "text": "Choose two \u2014\n\u2022 Create a 3/2 red and white Spirit creature token.\n\u2022 Creatures you control get +1/+0 and gain indestructible and haste until end of turn.\n\u2022 Lorehold Command deals 3 damage to any target. Target player gains 3 life.\n\u2022 Sacrifice a permanent, then draw two cards.",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "0ca896cd-6565-57ac-b4a6-41048ed2b126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43105beb-46f3-4914-8222-4907bd76d48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43105beb-46f3-4914-8222-4907bd76d48f.jpg?1",
             "name": "Lorehold Excavation",
             "text": "At the beginning of your end step, mill a card. If a land card was milled this way, you gain 1 life. Otherwise, Lorehold Excavation deals 1 damage to each opponent. (To mill a card, put the top card of your library into your graveyard.)\n{5}, Exile a creature card from your graveyard: Create a tapped 3/2 red and white Spirit creature token.",
             "colours": [
@@ -7856,7 +7856,7 @@
         },
         {
             "id": "b519407c-4fa6-5d87-9976-8464523abda8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b88b38-6b5a-4a89-80ca-add79c11e8b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b88b38-6b5a-4a89-80ca-add79c11e8b9.jpg?1",
             "name": "Lorehold Pledgemage",
             "text": "First strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Lorehold Pledgemage gets +1/+0 until end of turn.",
             "colours": [
@@ -7893,7 +7893,7 @@
         },
         {
             "id": "fe4758ca-e854-53c7-800f-8aceb676821d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516e81e-16ea-411c-9df0-ed3b03670220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516e81e-16ea-411c-9df0-ed3b03670220.jpg?1",
             "name": "Maelstrom Muse",
             "text": "Flying\nWhenever Maelstrom Muse attacks, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is Maelstrom Muse's power as this ability resolves.",
             "colours": [
@@ -7930,7 +7930,7 @@
         },
         {
             "id": "6ffb8f88-4ddb-5b75-b8b4-27b5e4b6fe7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53e674b-5d48-4734-beeb-2a3deeb935e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53e674b-5d48-4734-beeb-2a3deeb935e0.jpg?1",
             "name": "A-Maelstrom Muse",
             "text": "",
             "colours": [
@@ -7966,7 +7966,7 @@
         },
         {
             "id": "b4d30a18-7e7c-54f7-aecc-9b9a6ce8e628",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c914a3-2294-4feb-9450-c012cfd307a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27c914a3-2294-4feb-9450-c012cfd307a6.jpg?1",
             "name": "Magma Opus",
             "text": "Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.\n{UR}{UR}, Discard Magma Opus: Create a Treasure token.",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "1bbc52e0-b429-599f-9692-514121c154cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e937830-3804-44e8-b9d0-3e5f5cf39eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e937830-3804-44e8-b9d0-3e5f5cf39eab.jpg?1",
             "name": "Make Your Mark",
             "text": "Target creature gets +1/+0 until end of turn. When that creature dies this turn, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -8036,7 +8036,7 @@
         },
         {
             "id": "7aae8080-879a-58f3-b9ad-3de19673479b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fc5cd2-fbb0-4d13-9089-0292b356de48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fc5cd2-fbb0-4d13-9089-0292b356de48.jpg?1",
             "name": "Manifestation Sage",
             "text": "When Manifestation Sage enters the battlefield, create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your hand.",
             "colours": [
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "5a728304-6b93-5815-b65a-2599944ea227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c2ef30-0db5-4ef5-999c-7ffa48769421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c2ef30-0db5-4ef5-999c-7ffa48769421.jpg?1",
             "name": "Moldering Karok",
             "text": "Trample, lifelink",
             "colours": [
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "c2cb909b-a773-520e-a96e-5a1e61fb0c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f39fe7-dc12-49c9-80ac-4135dc1f8f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1f39fe7-dc12-49c9-80ac-4135dc1f8f08.jpg?1",
             "name": "Mortality Spear",
             "text": "This spell costs {2} less to cast if you gained life this turn.\nDestroy target nonland permanent.",
             "colours": [
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "dd4a7b02-fe9b-5f8e-b912-14bad0d3540f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0cf2c4-723e-46c4-b2aa-4c957177209a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0cf2c4-723e-46c4-b2aa-4c957177209a.jpg?1",
             "name": "Needlethorn Drake",
             "text": "Flying, deathtouch",
             "colours": [
@@ -8184,7 +8184,7 @@
         },
         {
             "id": "509552e7-5d33-5cd1-844f-69b30d20e822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38329f1-af6e-47b8-86e4-f2a39e1edbf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a38329f1-af6e-47b8-86e4-f2a39e1edbf8.jpg?1",
             "name": "Oggyar Battle-Seer",
             "text": "Haste\n{T}: Scry 1.",
             "colours": [
@@ -8221,7 +8221,7 @@
         },
         {
             "id": "0dc382da-ee78-57c4-a882-5df7bba3cbef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3350367-42bd-44af-be13-ad31c002f8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3350367-42bd-44af-be13-ad31c002f8ac.jpg?1",
             "name": "Owlin Shieldmage",
             "text": "Flying\nWard\u2014\nPay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)",
             "colours": [
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "0194f654-381c-5aea-97c8-bd0f80e7851a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6267e19a-a777-4767-8433-86b6624362b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6267e19a-a777-4767-8433-86b6624362b6.jpg?1",
             "name": "Pest Summoning",
             "text": "Create two 1/1 black and green Pest creature tokens with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -8294,7 +8294,7 @@
         },
         {
             "id": "de47c882-1f2d-5fb9-8e17-20f7a6bb98b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74edd3e3-b2de-4ba0-a508-0418b0151d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74edd3e3-b2de-4ba0-a508-0418b0151d87.jpg?1",
             "name": "Practical Research",
             "text": "Draw four cards. Then discard two cards unless you discard an instant or sorcery card.",
             "colours": [
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "e6d5f05d-3e03-5867-a9b5-cec843880e74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca3aa59-c8ac-4930-abf7-0a74d657122a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca3aa59-c8ac-4930-abf7-0a74d657122a.jpg?1",
             "name": "Prismari Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Prismari Apprentice can't be blocked this turn. If that spell has mana value 5 or greater, put a +1/+1 counter on Prismari Apprentice.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "ba51cc14-e18b-5b04-b2e1-66c7f6620938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866b7fd4-86e3-4b42-b1ea-33bad0db1f9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866b7fd4-86e3-4b42-b1ea-33bad0db1f9f.jpg?1",
             "name": "Prismari Command",
             "text": "Choose two \u2014\n\u2022 Prismari Command deals 2 damage to any target.\n\u2022 Target player draws two cards, then discards two cards.\n\u2022 Target player creates a Treasure token.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -8401,7 +8401,7 @@
         },
         {
             "id": "b403ff54-aeb1-5022-92bb-6c0babd017ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404b4c7b-5d40-4ad1-bd40-3da1d08f5c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/404b4c7b-5d40-4ad1-bd40-3da1d08f5c78.jpg?1",
             "name": "Prismari Pledgemage",
             "text": "Defender\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Prismari Pledgemage can attack this turn as though it didn't have defender.",
             "colours": [
@@ -8438,7 +8438,7 @@
         },
         {
             "id": "a1eda01b-93cf-54b5-b34d-88e61c23f2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291c909-bb87-47cb-9b06-5e409e654f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0291c909-bb87-47cb-9b06-5e409e654f15.jpg?1",
             "name": "Quandrix Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, look at the top three cards of your library. You may reveal a land card from among them and put that card into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "4015addf-a9d0-5cc3-9c9c-bc05468ec069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b62d8-d160-47f5-bc51-0474f160d13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021b62d8-d160-47f5-bc51-0474f160d13f.jpg?1",
             "name": "Quandrix Command",
             "text": "Choose two \u2014\n\u2022 Return target creature or planeswalker to its owner's hand.\n\u2022 Counter target artifact or enchantment spell.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player shuffles up to three target cards from their graveyard into their library.",
             "colours": [
@@ -8511,7 +8511,7 @@
         },
         {
             "id": "2fe95b78-17f9-5125-b029-74f7dd2f8c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca9ff7-0dcf-4ecc-879c-957d290ad7f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ca9ff7-0dcf-4ecc-879c-957d290ad7f5.jpg?1",
             "name": "Quandrix Cultivator",
             "text": "When Quandrix Cultivator enters the battlefield, you may search your library for a basic Forest or Island card, put it onto the battlefield, then shuffle.",
             "colours": [
@@ -8548,7 +8548,7 @@
         },
         {
             "id": "2a10ba58-28a0-5c8c-9e76-b0ae516ce1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07633b7f-4150-458b-89c3-d05dc0e3c4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07633b7f-4150-458b-89c3-d05dc0e3c4bd.jpg?1",
             "name": "Quandrix Pledgemage",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Quandrix Pledgemage.",
             "colours": [
@@ -8585,7 +8585,7 @@
         },
         {
             "id": "8db139fd-7ccb-52fd-b358-af887b837a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c55ef1-8e62-4d43-bd4c-b2c3c5203338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06c55ef1-8e62-4d43-bd4c-b2c3c5203338.jpg?1",
             "name": "Quintorius, Field Historian",
             "text": "Spirits you control get +1/+0.\nWhenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -8624,7 +8624,7 @@
         },
         {
             "id": "9e22a8a8-17e1-560c-8a50-729eb6b1956c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8152ab0-c6fc-4568-b837-4e84129e7b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8152ab0-c6fc-4568-b837-4e84129e7b57.jpg?1",
             "name": "Radiant Scrollwielder",
             "text": "Instant and sorcery spells you control have lifelink.\nAt the beginning of your upkeep, exile an instant or sorcery card at random from your graveyard. You may cast it this turn. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -8663,7 +8663,7 @@
         },
         {
             "id": "10d3c681-1cdf-59ee-a712-eb0aaea538b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e565e38-43d5-482e-a911-ce525dfee74f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e565e38-43d5-482e-a911-ce525dfee74f.jpg?1",
             "name": "Reconstruct History",
             "text": "Return up to one target artifact card, up to one target enchantment card, up to one target instant card, up to one target sorcery card, and up to one target planeswalker card from your graveyard to your hand.\nExile Reconstruct History.",
             "colours": [
@@ -8697,7 +8697,7 @@
         },
         {
             "id": "fb4cb89d-ac23-58b5-a4ca-4456514c34fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cb483f-c567-4cfd-9fe8-1503e7b40542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cb483f-c567-4cfd-9fe8-1503e7b40542.jpg?1",
             "name": "Relic Sloth",
             "text": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -8733,7 +8733,7 @@
         },
         {
             "id": "afb26e65-3d60-5e89-8a52-f05a5ede2d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa0e762-0fec-4f6b-b3d7-ad8295bf557d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa0e762-0fec-4f6b-b3d7-ad8295bf557d.jpg?1",
             "name": "Returned Pastcaller",
             "text": "Flying\nWhen Returned Pastcaller enters the battlefield, return target Spirit, instant, or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "562ca1ed-0009-595c-a621-ec2d526fb6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b5b510-fd5c-415d-98b0-386e7508f7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b5b510-fd5c-415d-98b0-386e7508f7af.jpg?1",
             "name": "Rip Apart",
             "text": "Choose one \u2014\n\u2022 Rip Apart deals 3 damage to target creature or planeswalker.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -8806,7 +8806,7 @@
         },
         {
             "id": "0c43d62c-817b-5dba-932c-ac5cde05c2e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf97a71-485e-4d47-98de-bdf6f6dae0c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf97a71-485e-4d47-98de-bdf6f6dae0c2.jpg?1",
             "name": "Rise of Extus",
             "text": "Exile target creature. Exile up to one target instant or sorcery card from a graveyard.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
             "colours": [
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "22e24241-47ee-5d01-86b0-2b35cee253c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb8f24d-8d1d-48aa-a534-238e969a474c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb8f24d-8d1d-48aa-a534-238e969a474c.jpg?1",
             "name": "Rootha, Mercurial Artist",
             "text": "{2}, Return Rootha, Mercurial Artist to its owner's hand: Copy target instant or sorcery spell you control. You may choose new targets for the copy.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "f24d7333-3d46-5b9a-84d9-21ffa256426c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b7c952-5ab7-4546-8369-4d213bf868bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07b7c952-5ab7-4546-8369-4d213bf868bf.jpg?1",
             "name": "Rushed Rebirth",
             "text": "Choose target creature. When that creature dies this turn, search your library for a creature card with lesser mana value, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -8915,7 +8915,7 @@
         },
         {
             "id": "46650ffe-77d4-5357-969e-df7bff636822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64795a8b-8cf2-436e-8f95-9e8bb40c0d7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64795a8b-8cf2-436e-8f95-9e8bb40c0d7d.jpg?1",
             "name": "Shadewing Laureate",
             "text": "Flying\nWhenever another creature you control with flying dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8952,7 +8952,7 @@
         },
         {
             "id": "eed253c8-84f1-5a3e-ab23-056cf3fc7aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab701909-83d6-4d39-9a84-e6a9b2cb38d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab701909-83d6-4d39-9a84-e6a9b2cb38d6.jpg?1",
             "name": "Shadrix Silverquill",
             "text": "Flying, double strike\nAt the beginning of combat on your turn, you may choose two. Each mode must target a different player.\n\u2022 Target player creates a 2/1 white and black Inkling creature token with flying.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target player puts a +1/+1 counter on each creature they control.",
             "colours": [
@@ -8993,7 +8993,7 @@
         },
         {
             "id": "e5b182c7-8cd0-5456-8ac1-bcbd341a3d69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d0770e-9084-4aa7-b543-2b6ba18378dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42d0770e-9084-4aa7-b543-2b6ba18378dc.jpg?1",
             "name": "Silverquill Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -9030,7 +9030,7 @@
         },
         {
             "id": "e7c4d4d5-da34-5338-8d72-9fddfd489b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c55f533-9d31-4ad1-b336-927aba6e74d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c55f533-9d31-4ad1-b336-927aba6e74d6.jpg?1",
             "name": "Silverquill Command",
             "text": "Choose two \u2014\n\u2022 Target creature gets +3/+3 and gains flying until end of turn.\n\u2022 Return target creature card with mana value 2 or less from your graveyard to the battlefield.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target opponent sacrifices a creature.",
             "colours": [
@@ -9066,7 +9066,7 @@
         },
         {
             "id": "5cdd9127-e160-5438-8090-3cb6f5c93470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f64ad2-4041-421d-baa2-206cedcecf0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f64ad2-4041-421d-baa2-206cedcecf0e.jpg?1",
             "name": "Silverquill Pledgemage",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, Silverquill Pledgemage gains your choice of flying or lifelink until end of turn.",
             "colours": [
@@ -9103,7 +9103,7 @@
         },
         {
             "id": "93258f82-b432-55de-9ca1-1cbb55c04391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb60dcc-cb4a-414d-850f-c98efd872894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb60dcc-cb4a-414d-850f-c98efd872894.jpg?1",
             "name": "Silverquill Silencer",
             "text": "As Silverquill Silencer enters the battlefield, choose a nonland card name.\nWhenever an opponent casts a spell with the chosen name, they lose 3 life and you draw a card.",
             "colours": [
@@ -9142,7 +9142,7 @@
         },
         {
             "id": "90ed34a9-0672-5235-b231-4c9695c86a10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74223e1-b66b-42fa-aaac-001f5dab2aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74223e1-b66b-42fa-aaac-001f5dab2aac.jpg?1",
             "name": "Spectacle Mage",
             "text": "Flying\nInstant and sorcery spells you cast with mana value 5 or greater cost {1} less to cast.",
             "colours": [
@@ -9179,7 +9179,7 @@
         },
         {
             "id": "4b57cc09-bd57-5507-80fc-603941958f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74be6236-4095-419c-9927-fbd874df21f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74be6236-4095-419c-9927-fbd874df21f8.jpg?1",
             "name": "Spirit Summoning",
             "text": "Create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -9215,7 +9215,7 @@
         },
         {
             "id": "b47f36e7-ca1f-5dbf-93ad-80abc4a60ed8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88355e-c986-4b69-93b4-0abf04916e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be88355e-c986-4b69-93b4-0abf04916e86.jpg?1",
             "name": "Spiteful Squad",
             "text": "Deathtouch\nSpiteful Squad enters the battlefield with two +1/+1 counters on it.\nWhen Spiteful Squad dies, put its counters on target creature you control.",
             "colours": [
@@ -9252,7 +9252,7 @@
         },
         {
             "id": "2232ea00-9d5c-5842-8003-001d2ff6d60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d548d5a-1dd7-448a-8483-249572e08c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d548d5a-1dd7-448a-8483-249572e08c47.jpg?1",
             "name": "Square Up",
             "text": "Target creature has base power and toughness 4/4 until end of turn.",
             "colours": [
@@ -9286,7 +9286,7 @@
         },
         {
             "id": "30970086-dd03-5fab-88a0-f365420b1d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c64e954-adfc-40a2-a3b2-85f1b4626976.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c64e954-adfc-40a2-a3b2-85f1b4626976.jpg?1",
             "name": "Stonebound Mentor",
             "text": "Whenever one or more cards leave your graveyard, scry 1.",
             "colours": [
@@ -9323,7 +9323,7 @@
         },
         {
             "id": "e37993ef-6e3a-5523-8c8b-fccf7a2b87dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd62ee4-e654-44ba-a650-889782cc9ac3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd62ee4-e654-44ba-a650-889782cc9ac3.jpg?1",
             "name": "Tanazir Quandrix",
             "text": "Flying, trample\nWhen Tanazir Quandrix enters the battlefield, double the number of +1/+1 counters on target creature you control.\nWhenever Tanazir Quandrix attacks, you may have the base power and toughness of other creatures you control become equal to Tanazir Quandrix's power and toughness until end of turn.",
             "colours": [
@@ -9364,7 +9364,7 @@
         },
         {
             "id": "d4518fe9-c627-52d1-91b4-16b8f6b2f471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957117fe-ddc9-4c5d-bff8-f74602a24dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/957117fe-ddc9-4c5d-bff8-f74602a24dd8.jpg?1",
             "name": "A-Tanazir Quandrix",
             "text": "",
             "colours": [
@@ -9402,7 +9402,7 @@
         },
         {
             "id": "c9e371a9-2b44-5ec7-85ae-39af14390e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7fbb9b-50a8-4d18-a667-fe965468ca16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7fbb9b-50a8-4d18-a667-fe965468ca16.jpg?1",
             "name": "Teach by Example",
             "text": "When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -9436,7 +9436,7 @@
         },
         {
             "id": "2a6a7af1-1755-578b-9fb8-033a0d4fecc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43ed93-008d-44db-8204-ef2cc3b7cf8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f43ed93-008d-44db-8204-ef2cc3b7cf8a.jpg?1",
             "name": "Tend the Pests",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nCreate X 1/1 black and green Pest creature tokens with \"When this creature dies, you gain 1 life,\" where X is the sacrificed creature's power.",
             "colours": [
@@ -9470,7 +9470,7 @@
         },
         {
             "id": "5160373b-6973-5468-b3c1-82602fe01315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac1f45e-1884-490e-a94f-f7d312f0e229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac1f45e-1884-490e-a94f-f7d312f0e229.jpg?1",
             "name": "Thrilling Discovery",
             "text": "You gain 2 life. Then you may discard two cards. If you do, draw three cards.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "6cfd9a1f-0190-55c9-a2ad-b623b1905910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12573fe-aee3-49db-93e2-d00972cbb3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e12573fe-aee3-49db-93e2-d00972cbb3b1.jpg?1",
             "name": "Vanishing Verse",
             "text": "Exile target monocolored permanent.",
             "colours": [
@@ -9540,7 +9540,7 @@
         },
         {
             "id": "d5318727-2060-5162-a2b2-4082beedf3be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ea9067-ad50-4c43-ae4d-3f66890cd898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04ea9067-ad50-4c43-ae4d-3f66890cd898.jpg?1",
             "name": "Velomachus Lorehold",
             "text": "Flying, vigilance, haste\nWhenever Velomachus Lorehold attacks, look at the top seven cards of your library. You may cast an instant or sorcery spell with mana value less than or equal to Velomachus Lorehold's power from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -9581,7 +9581,7 @@
         },
         {
             "id": "7c76683e-96df-5779-bb2f-68e721ee40d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006313f8-cc60-4a4e-8ec6-953cdf1c16e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006313f8-cc60-4a4e-8ec6-953cdf1c16e3.jpg?1",
             "name": "Venerable Warsinger",
             "text": "Vigilance, trample\nWhenever Venerable Warsinger deals combat damage to a player, you may return target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of damage Venerable Warsinger dealt to that player.",
             "colours": [
@@ -9620,7 +9620,7 @@
         },
         {
             "id": "9bf23faa-5f42-56c3-ac10-527498819612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f80a11b-188b-464c-b00d-c9d1cfb8ddee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f80a11b-188b-464c-b00d-c9d1cfb8ddee.jpg?1",
             "name": "Witherbloom Apprentice",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "a8cb13d9-d835-5b86-b39a-aa10eae25763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5e94b-0b35-4efd-9158-1767dcaea38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d5e94b-0b35-4efd-9158-1767dcaea38c.jpg?1",
             "name": "Witherbloom Command",
             "text": "Choose two \u2014\n\u2022 Target player mills three cards, then you return a land card from your graveyard to your hand.\n\u2022 Destroy target noncreature, nonland permanent with mana value 2 or less.\n\u2022 Target creature gets -3/-1 until end of turn.\n\u2022 Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -9693,7 +9693,7 @@
         },
         {
             "id": "28c374c9-d41c-53ec-aa19-d5bb6339b63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc6914-2dcb-411d-90a5-01853ff2d5b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6cc6914-2dcb-411d-90a5-01853ff2d5b8.jpg?1",
             "name": "Witherbloom Pledgemage",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, you gain 1 life.",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "f4c002ad-63fd-55e2-b256-59c3e3a61156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca14c17-dc72-4f68-92f2-14a6c4019f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca14c17-dc72-4f68-92f2-14a6c4019f4e.jpg?1",
             "name": "Zimone, Quandrix Prodigy",
             "text": "{1}, {T}: You may put a land card from your hand onto the battlefield tapped.\n{4}, {T}: Draw a card. If you control eight or more lands, draw two cards instead.",
             "colours": [
@@ -9769,7 +9769,7 @@
         },
         {
             "id": "ceb12d3c-5458-5eb5-a727-874e5e43e134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e1117-0196-4268-be97-a1e81b5dc90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d74e1117-0196-4268-be97-a1e81b5dc90e.jpg?1",
             "name": "Biblioplex Assistant",
             "text": "Flying\nWhen Biblioplex Assistant enters the battlefield, put up to one target instant or sorcery card from your graveyard on top of your library.",
             "colours": [],
@@ -9800,7 +9800,7 @@
         },
         {
             "id": "406de8a0-5582-5013-9b1c-f93a43b7b6d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a9a8a2-de81-441b-b501-418311b677f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a9a8a2-de81-441b-b501-418311b677f7.jpg?1",
             "name": "Campus Guide",
             "text": "When Campus Guide enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
             "colours": [],
@@ -9831,7 +9831,7 @@
         },
         {
             "id": "aaf3d518-71c7-55c2-ad6e-4d3dea880de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea476ee1-67d9-4dd8-a5ac-f68a155eb18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea476ee1-67d9-4dd8-a5ac-f68a155eb18b.jpg?1",
             "name": "Codie, Vociferous Codex",
             "text": "You can't cast permanent spells.\n{4}, {T}: Add {W}{U}{B}{R}{G}. When you cast your next spell this turn, exile cards from the top of your library until you exile an instant or sorcery card with lesser mana value. Until end of turn, you may cast that card without paying its mana cost. Put each other card exiled this way on the bottom of your library in a random order.",
             "colours": [],
@@ -9872,7 +9872,7 @@
         },
         {
             "id": "a07d9c53-3614-5e64-aa56-4220fd87568e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c024a2d-20fb-478b-a62e-e3590a1e3ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c024a2d-20fb-478b-a62e-e3590a1e3ac1.jpg?1",
             "name": "Cogwork Archivist",
             "text": "Reach\n{2}, {T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9903,7 +9903,7 @@
         },
         {
             "id": "10214f80-a6ea-502b-9ff6-0879e7272833",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed54d00-b11f-4529-864c-63a114617b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed54d00-b11f-4529-864c-63a114617b36.jpg?1",
             "name": "Excavated Wall",
             "text": "Defender\n{1}, {T}: Mill a card. (Put the top card of your library into your graveyard.)",
             "colours": [],
@@ -9934,7 +9934,7 @@
         },
         {
             "id": "8f6c76c7-ef40-5b4c-ab3f-de2b1a762be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750231-34aa-401c-b192-47b56588923a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34750231-34aa-401c-b192-47b56588923a.jpg?1",
             "name": "Letter of Acceptance",
             "text": "{T}: Add one mana of any color.\n{2}, {T}, Sacrifice Letter of Acceptance: Draw a card.",
             "colours": [],
@@ -9962,7 +9962,7 @@
         },
         {
             "id": "6e57ad82-b39a-5912-9073-39660c19a007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01770c4-8848-495d-8af4-26152d45e9d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01770c4-8848-495d-8af4-26152d45e9d3.jpg?1",
             "name": "Reflective Golem",
             "text": "Whenever you cast an instant or sorcery spell that targets only Reflective Golem, you may pay {2}. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [],
@@ -9993,7 +9993,7 @@
         },
         {
             "id": "b2592e54-02e1-512b-9451-adee04f9166d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de826a0-6e68-4d40-a51c-8d6e7a4148d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de826a0-6e68-4d40-a51c-8d6e7a4148d1.jpg?1",
             "name": "Spell Satchel",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a book counter on Spell Satchel.\n{T}, Remove a book counter from Spell Satchel: Add {C}.\n{3}, {T}, Remove three book counters from Spell Satchel: Draw a card.",
             "colours": [],
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "63555550-6908-59df-8947-712b9abbf491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8acc65-c7e0-4ba5-b956-af0679ffb830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8acc65-c7e0-4ba5-b956-af0679ffb830.jpg?1",
             "name": "A-Spell Satchel",
             "text": "",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "2aa28782-1aa7-52f5-bb4d-2d652d59d59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421674ee-4b85-4942-b166-952598165826.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421674ee-4b85-4942-b166-952598165826.jpg?1",
             "name": "Strixhaven Stadium",
             "text": "{T}: Add {C}. Put a point counter on Strixhaven Stadium.\nWhenever a creature deals combat damage to you, remove a point counter from Strixhaven Stadium.\nWhenever a creature you control deals combat damage to an opponent, put a point counter on Strixhaven Stadium. Then if it has ten or more point counters on it, remove them all and that player loses the game.",
             "colours": [],
@@ -10078,7 +10078,7 @@
         },
         {
             "id": "191befce-57e3-5d01-b1b3-b5fbba9a4586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be294c4e-712b-459c-a36c-e26ed5c27edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be294c4e-712b-459c-a36c-e26ed5c27edb.jpg?1",
             "name": "Team Pennant",
             "text": "Equipped creature gets +1/+1 and has vigilance and trample.\nEquip creature token {1}\nEquip {3}",
             "colours": [],
@@ -10108,7 +10108,7 @@
         },
         {
             "id": "665afe18-cb19-5c67-bd20-5997935152a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0566fd-3775-48f1-ba22-6e659558c3d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0566fd-3775-48f1-ba22-6e659558c3d3.jpg?1",
             "name": "Zephyr Boots",
             "text": "Equipped creature has flying.\nWhenever equipped creature deals combat damage to a player, draw a card, then discard a card.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10138,7 +10138,7 @@
         },
         {
             "id": "72922bde-a549-58ab-a50e-ee62898e1b59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8eb51-9643-4c54-b38e-e7abea92bbe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8eb51-9643-4c54-b38e-e7abea92bbe1.jpg?1",
             "name": "Access Tunnel",
             "text": "{T}: Add {C}.\n{3}, {T}: Target creature with power 3 or less can't be blocked this turn.",
             "colours": [],
@@ -10166,7 +10166,7 @@
         },
         {
             "id": "fa8c87cb-e97f-529c-9015-1d191afef5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6a2ff-7eb7-4680-af2b-e69ac88a65c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f6a2ff-7eb7-4680-af2b-e69ac88a65c9.jpg?1",
             "name": "Archway Commons",
             "text": "Archway Commons enters the battlefield tapped.\nWhen Archway Commons enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -10194,7 +10194,7 @@
         },
         {
             "id": "5c5ae5d5-4cc4-5ae8-8c6a-41fa29b6e845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae4481-977f-4bb7-bb1a-ab7100e6ba47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eae4481-977f-4bb7-bb1a-ab7100e6ba47.jpg?1",
             "name": "The Biblioplex",
             "text": "{T}: Add {C}.\n{2}, {T}: Look at the top card of your library. If it's an instant or sorcery card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard. Activate only if you have exactly zero or seven cards in hand.",
             "colours": [],
@@ -10224,7 +10224,7 @@
         },
         {
             "id": "b862e0ce-b028-5741-a7a1-da37ce8e9a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ba565-da08-4957-93bb-8d266fe0b0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22ba565-da08-4957-93bb-8d266fe0b0d8.jpg?1",
             "name": "Frostboil Snarl",
             "text": "As Frostboil Snarl enters the battlefield, you may reveal an Island or Mountain card from your hand. If you don't, Frostboil Snarl enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -10257,7 +10257,7 @@
         },
         {
             "id": "b65d10a1-edcc-54f6-8887-0b7bb6b4c691",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e33f37-7fd1-4431-a032-cd61b644401c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e33f37-7fd1-4431-a032-cd61b644401c.jpg?1",
             "name": "Furycalm Snarl",
             "text": "As Furycalm Snarl enters the battlefield, you may reveal a Mountain or Plains card from your hand. If you don't, Furycalm Snarl enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10290,7 +10290,7 @@
         },
         {
             "id": "17733030-2217-5594-9589-79ab4345854a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642dddd-4461-46dd-b396-9e0a89f7232e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7642dddd-4461-46dd-b396-9e0a89f7232e.jpg?1",
             "name": "Hall of Oracles",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on target creature. Activate only as a sorcery and only if you've cast an instant or sorcery spell this turn.",
             "colours": [],
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "59a41526-a7dc-5683-a5d0-4e880b1f285b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35461cf-becf-4399-8329-64b4496b7fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35461cf-becf-4399-8329-64b4496b7fc2.jpg?1",
             "name": "Lorehold Campus",
             "text": "Lorehold Campus enters the battlefield tapped.\n{T}: Add {R} or {W}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "940655c3-b42b-5847-85ff-7622cef2cecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aed316-c28a-4c1a-a0a3-ab75ceba3ee7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aed316-c28a-4c1a-a0a3-ab75ceba3ee7.jpg?1",
             "name": "Necroblossom Snarl",
             "text": "As Necroblossom Snarl enters the battlefield, you may reveal a Swamp or Forest card from your hand. If you don't, Necroblossom Snarl enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -10384,7 +10384,7 @@
         },
         {
             "id": "48b0f651-c4a7-5bce-b261-07a1234c2fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768120f5-9401-4e52-924e-3374bde65b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/768120f5-9401-4e52-924e-3374bde65b3d.jpg?1",
             "name": "Prismari Campus",
             "text": "Prismari Campus enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10415,7 +10415,7 @@
         },
         {
             "id": "26f41d3b-6c73-5c6a-97cd-41821e3e7b6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f788da28-481b-41fa-a70c-b53db6b0f068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f788da28-481b-41fa-a70c-b53db6b0f068.jpg?1",
             "name": "Quandrix Campus",
             "text": "Quandrix Campus enters the battlefield tapped.\n{T}: Add {G} or {U}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10446,7 +10446,7 @@
         },
         {
             "id": "f6aefd9d-9445-5003-8b73-662325e93ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a46ebf-6938-4100-8f5f-0605ad2be4fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84a46ebf-6938-4100-8f5f-0605ad2be4fc.jpg?1",
             "name": "Shineshadow Snarl",
             "text": "As Shineshadow Snarl enters the battlefield, you may reveal a Plains or Swamp card from your hand. If you don't, Shineshadow Snarl enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10479,7 +10479,7 @@
         },
         {
             "id": "47fea69b-31c8-50d1-885e-147b8212b3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42583850-ba5c-4a71-8717-406b5c6d048f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42583850-ba5c-4a71-8717-406b5c6d048f.jpg?1",
             "name": "Silverquill Campus",
             "text": "Silverquill Campus enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10510,7 +10510,7 @@
         },
         {
             "id": "2f89640e-710f-5a81-ba17-57565e67163b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e5ca7-dde1-435f-9b40-87558dd88749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e5ca7-dde1-435f-9b40-87558dd88749.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "As Vineglimmer Snarl enters the battlefield, you may reveal a Forest or Island card from your hand. If you don't, Vineglimmer Snarl enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10543,7 +10543,7 @@
         },
         {
             "id": "228f69aa-5e38-5afd-a45c-46963b7996d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7346fb2e-754e-47de-b33d-eb089b357ee4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7346fb2e-754e-47de-b33d-eb089b357ee4.jpg?1",
             "name": "Witherbloom Campus",
             "text": "Witherbloom Campus enters the battlefield tapped.\n{T}: Add {B} or {G}.\n{4}, {T}: Scry 1.",
             "colours": [],
@@ -10574,7 +10574,7 @@
         },
         {
             "id": "1650c445-7420-5c07-9962-da32a94d0b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8536-15f6-42c1-8521-dc37feee8e67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ad8536-15f6-42c1-8521-dc37feee8e67.jpg?1",
             "name": "Professor Onyx",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, each opponent loses 2 life and you gain 2 life.\n+1: You lose 1 life. Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.\n\u22123: Each opponent sacrifices a creature with the greatest power among creatures that player controls.\n\u22128: Each opponent may discard a card. If they don't, they lose 3 life. Repeat this process six more times.",
             "colours": [
@@ -10612,7 +10612,7 @@
         },
         {
             "id": "90aea4cc-2057-5518-a41e-5d6d53d11e86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -10651,7 +10651,7 @@
         },
         {
             "id": "0f9214dc-2fc9-5bee-95e2-51ebd262625e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/4/34332dc9-d81c-4b16-bf59-2c75eaa05c21.jpg?1",
             "name": "Mila, Crafty Companion // Lukka, Wayward Bonder",
             "text": "Whenever an opponent attacks one or more planeswalkers you control, put a loyalty counter on each planeswalker you control.\nWhenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.\n\n\nLukka\n{4}{R}{R}",
             "colours": [
@@ -10690,7 +10690,7 @@
         },
         {
             "id": "b842741f-5393-5c0c-89c5-67bbc3bf5f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "9a44af27-5825-52f3-9b63-4412dc593176",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2cca8cf1-27f8-408d-b4bc-1d4090837f8a.jpg?1",
             "name": "Rowan, Scholar of Sparks // Will, Scholar of Frost",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\n+1: Up to one target creature has base power and toughness 0/2 until your next turn.\n\u22123: Draw two cards.\n\u22127: Exile up to five target permanents. For each permanent exiled this way, its controller creates a 4/4 blue and red Elemental creature token.\n\n\nRowan\n{2}{R}",
             "colours": [
@@ -10768,7 +10768,7 @@
         },
         {
             "id": "fdc4c759-e3e7-50b8-b316-359a9e552145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed5f87d-3bca-44fc-a1ea-fc01e36ba092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed5f87d-3bca-44fc-a1ea-fc01e36ba092.jpg?1",
             "name": "Kasmina, Enigma Sage",
             "text": "Each other planeswalker you control has the loyalty abilities of Kasmina, Enigma Sage.\n+2: Scry 1.\n\u2212X: Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it.\n\u22128: Search your library for an instant or sorcery card that shares a color with this planeswalker, exile that card, then shuffle. You may cast that card without paying its mana cost.",
             "colours": [
@@ -10808,7 +10808,7 @@
         },
         {
             "id": "39b0ac9f-b31e-56f4-a5eb-faa3df0ccd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23468e63-2e7a-4e3b-970c-cb57b067d6c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23468e63-2e7a-4e3b-970c-cb57b067d6c1.jpg?1",
             "name": "Shadrix Silverquill",
             "text": "Flying, double strike\nAt the beginning of combat on your turn, you may choose two. Each mode must target a different player.\n\u2022 Target player creates a 2/1 white and black Inkling creature token with flying.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target player puts a +1/+1 counter on each creature they control.",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "75c7edda-b257-5560-a031-f670db91128d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b9185-9033-4e57-a312-adcc91903aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265b9185-9033-4e57-a312-adcc91903aec.jpg?1",
             "name": "Galazeth Prismari",
             "text": "Flying\nWhen Galazeth Prismari enters the battlefield, create a Treasure token.\nArtifacts you control have \"{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.\"",
             "colours": [
@@ -10890,7 +10890,7 @@
         },
         {
             "id": "124d1e8e-030d-52be-87a8-a2298ebc1962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34dd2ef-a52d-48b6-becc-825f0e78eb75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34dd2ef-a52d-48b6-becc-825f0e78eb75.jpg?1",
             "name": "Beledros Witherbloom",
             "text": "Flying\nAt the beginning of each upkeep, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\nPay 10 life: Untap all lands you control. Activate only once each turn.",
             "colours": [
@@ -10931,7 +10931,7 @@
         },
         {
             "id": "49097800-a412-5832-9b17-01e6f1092d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7151c4b-4d42-44c1-a6f4-8be29ace1df3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7151c4b-4d42-44c1-a6f4-8be29ace1df3.jpg?1",
             "name": "Velomachus Lorehold",
             "text": "Flying, vigilance, haste\nWhenever Velomachus Lorehold attacks, look at the top seven cards of your library. You may cast an instant or sorcery spell with mana value less than or equal to Velomachus Lorehold's power from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "1d0ea9c0-0ccb-5da3-8b31-8ad1fc869aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7241c-c053-440b-b91c-f7298080d626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5c7241c-c053-440b-b91c-f7298080d626.jpg?1",
             "name": "Tanazir Quandrix",
             "text": "Flying, trample\nWhen Tanazir Quandrix enters the battlefield, double the number of +1/+1 counters on target creature you control.\nWhenever Tanazir Quandrix attacks, you may have the base power and toughness of other creatures you control become equal to Tanazir Quandrix's power and toughness until end of turn.",
             "colours": [
@@ -11013,7 +11013,7 @@
         },
         {
             "id": "d515f64c-fc10-5d34-9321-9a181af15bf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b3d46-8f46-4ddf-b4bb-53b0dfd1ab37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109b3d46-8f46-4ddf-b4bb-53b0dfd1ab37.jpg?1",
             "name": "Mascot Exhibition",
             "text": "Create a 2/1 white and black Inkling creature token with flying, a 3/2 red and white Spirit creature token, and a 4/4 blue and red Elemental creature token.",
             "colours": [],
@@ -11045,7 +11045,7 @@
         },
         {
             "id": "74d3aa3c-ada9-5520-a19d-87b9362fdaa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -11077,7 +11077,7 @@
         },
         {
             "id": "753e0e24-2204-562f-b077-6b1cd1d5e540",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63bd0484-4089-4d33-aa8b-3730791061c3.jpg?1",
             "name": "Wandering Archaic // Explore the Vastlands",
             "text": "Whenever an opponent casts an instant or sorcery spell, they may pay {2}. If they don't, you may copy that spell. You may choose new targets for the copy.\n\n\nSorcery\n{3}",
             "colours": [],
@@ -11107,7 +11107,7 @@
         },
         {
             "id": "e324627a-57bf-568a-ab47-732efdefdff0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4384-95b5-44ae-bec5-15b383777b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903b4384-95b5-44ae-bec5-15b383777b41.jpg?1",
             "name": "Academic Probation",
             "text": "Choose one \u2014\n\u2022 Choose a nonland card name. Opponents can't cast spells with the chosen name until your next turn.\n\u2022 Choose target nonland permanent. Until your next turn, it can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -11143,7 +11143,7 @@
         },
         {
             "id": "f2efd469-a321-586e-9d84-d0280125688b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a4740-7a11-4157-bfd7-1249980aa323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354a4740-7a11-4157-bfd7-1249980aa323.jpg?1",
             "name": "Devastating Mastery",
             "text": "You may pay {2}{W}{W} rather than pay this spell's mana cost.\nIf the {2}{W}{W} cost was paid, an opponent chooses up to two nonland permanents they control and returns them to their owner's hand.\nDestroy all nonland permanents.",
             "colours": [
@@ -11177,7 +11177,7 @@
         },
         {
             "id": "6305ac01-9de1-52fd-973d-a5c1f15ed710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25608957-fe71-4ed7-9c55-fb7f2fcf103e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25608957-fe71-4ed7-9c55-fb7f2fcf103e.jpg?1",
             "name": "Elite Spellbinder",
             "text": "Flying\nWhen Elite Spellbinder enters the battlefield, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A spell cast this way costs {2} more to cast.",
             "colours": [
@@ -11214,7 +11214,7 @@
         },
         {
             "id": "7ee0c5ac-7b78-579d-82a5-e929b206fdf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca307662-9454-4edb-ab64-13c6b41fb864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca307662-9454-4edb-ab64-13c6b41fb864.jpg?1",
             "name": "Leonin Lightscribe",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -11251,7 +11251,7 @@
         },
         {
             "id": "142e1c40-c16f-56d5-a1cf-acdf9f4b918a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32e0bb1-073f-4583-ad9c-1dc0c7eb8ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32e0bb1-073f-4583-ad9c-1dc0c7eb8ef8.jpg?1",
             "name": "Mavinda, Students' Advocate",
             "text": "Flying\n{0}: You may cast target instant or sorcery card from your graveyard this turn. If that spell doesn't target a creature you control, it costs {8} more to cast this way. If that spell would be put into your graveyard, exile it instead. Activate only once each turn. (You still pay the spell's costs. Timing rules for the spell still apply.)",
             "colours": [
@@ -11290,7 +11290,7 @@
         },
         {
             "id": "7520eb43-4ccf-5df6-9b44-0fe008bf9d0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121f61c8-2ddc-47bb-a8a1-b7e0b5cac156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/121f61c8-2ddc-47bb-a8a1-b7e0b5cac156.jpg?1",
             "name": "Semester's End",
             "text": "Exile any number of target creatures and/or planeswalkers you control. At the beginning of the next end step, return each of them to the battlefield under its owner's control. Each of them enters the battlefield with an additional +1/+1 counter on it if it's a creature and an additional loyalty counter on it if it's a planeswalker.",
             "colours": [
@@ -11324,7 +11324,7 @@
         },
         {
             "id": "da988a52-f75c-5350-84e4-35f5603daf3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584a3d18-0360-48aa-87d2-51e9078b00f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584a3d18-0360-48aa-87d2-51e9078b00f5.jpg?1",
             "name": "Sparring Regimen",
             "text": "When Sparring Regimen enters the battlefield, learn.\nWhenever you attack, put a +1/+1 counter on target attacking creature and untap it.",
             "colours": [
@@ -11358,7 +11358,7 @@
         },
         {
             "id": "a2ffd39d-a43e-5553-9e3d-7473e4d3ec3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833ffc46-bbfe-47b3-96ad-ff5fe14405cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833ffc46-bbfe-47b3-96ad-ff5fe14405cb.jpg?1",
             "name": "Strict Proctor",
             "text": "Flying\nWhenever a permanent entering the battlefield causes a triggered ability to trigger, counter that ability unless its controller pays {2}.",
             "colours": [
@@ -11396,7 +11396,7 @@
         },
         {
             "id": "e79bb025-5878-5982-80cf-f5cb6ed23f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5e6937-800c-4870-b234-f2907a55ce31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5e6937-800c-4870-b234-f2907a55ce31.jpg?1",
             "name": "Archmage Emeritus",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, draw a card.",
             "colours": [
@@ -11434,7 +11434,7 @@
         },
         {
             "id": "01fa4980-ddc3-51f6-a234-3d83395878bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9f0734-7bdf-4d06-b1ac-15919fb7bce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d9f0734-7bdf-4d06-b1ac-15919fb7bce3.jpg?1",
             "name": "Dream Strix",
             "text": "Flying\nWhen Dream Strix becomes the target of a spell, sacrifice it.\nWhen Dream Strix dies, learn.",
             "colours": [
@@ -11471,7 +11471,7 @@
         },
         {
             "id": "a15eb013-9e13-5624-ac9c-cc6a817cf065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b4f3c5-4129-4e4b-98b9-91d2ca33ab7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18b4f3c5-4129-4e4b-98b9-91d2ca33ab7c.jpg?1",
             "name": "Ingenious Mastery",
             "text": "You may pay {2}{U} rather than pay this spell's mana cost.\nIf the {2}{U} cost was paid, you draw three cards, then an opponent creates two Treasure tokens and they scry 2. If that cost wasn't paid, you draw X cards.",
             "colours": [
@@ -11505,7 +11505,7 @@
         },
         {
             "id": "fa963d86-db0e-5a3d-a905-dfaaada605d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc26b17-fff6-4bd1-8fb6-736ba7babac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc26b17-fff6-4bd1-8fb6-736ba7babac7.jpg?1",
             "name": "Multiple Choice",
             "text": "If X is 1, scry 1, then draw a card.\nIf X is 2, you may choose a player. They return a creature they control to its owner's hand.\nIf X is 3, create a 4/4 blue and red Elemental creature token.\nIf X is 4 or more, do all of the above.",
             "colours": [
@@ -11539,7 +11539,7 @@
         },
         {
             "id": "8586fff9-8474-569d-ae0d-c929c6d34666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2c8894-fb24-4356-a71e-2cb924dd4cf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2c8894-fb24-4356-a71e-2cb924dd4cf0.jpg?1",
             "name": "Teachings of the Archaics",
             "text": "If an opponent has more cards in hand than you, draw two cards. Draw three cards instead if an opponent has at least four more cards in hand than you.",
             "colours": [
@@ -11575,7 +11575,7 @@
         },
         {
             "id": "65de3c26-4c7a-59a4-bff8-52cb07a078d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c142a00b-ba0a-49a2-879f-ed46c4f81b64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c142a00b-ba0a-49a2-879f-ed46c4f81b64.jpg?1",
             "name": "Tempted by the Oriq",
             "text": "For each opponent, gain control of up to one target creature or planeswalker that player controls with mana value 3 or less.",
             "colours": [
@@ -11609,7 +11609,7 @@
         },
         {
             "id": "22c617f3-811f-5e6a-a08e-33e73365c3b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefe86f-9998-4259-bf71-2b2ed1d6bf50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcefe86f-9998-4259-bf71-2b2ed1d6bf50.jpg?1",
             "name": "Baleful Mastery",
             "text": "You may pay {1}{B} rather than pay this spell's mana cost.\nIf the {1}{B} cost was paid, an opponent draws a card.\nExile target creature or planeswalker.",
             "colours": [
@@ -11643,7 +11643,7 @@
         },
         {
             "id": "591c29a1-c671-5a53-b754-88a9aaa6e726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9786ce79-3cb1-4ac7-9f85-1f7c0e1acff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9786ce79-3cb1-4ac7-9f85-1f7c0e1acff7.jpg?1",
             "name": "Callous Bloodmage",
             "text": "When Callous Bloodmage enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\u2022 You draw a card and you lose 1 life.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -11680,7 +11680,7 @@
         },
         {
             "id": "41bf4ae7-a9d4-5618-81ef-c1c1def4dfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9975e3c0-cd32-4658-9802-3749a1a475aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9975e3c0-cd32-4658-9802-3749a1a475aa.jpg?1",
             "name": "Confront the Past",
             "text": "Choose one \u2014\n\u2022 Return target planeswalker card with mana value X or less from your graveyard to the battlefield.\n\u2022 Remove twice X loyalty counters from target planeswalker an opponent controls.",
             "colours": [
@@ -11716,7 +11716,7 @@
         },
         {
             "id": "ad8020b8-b83b-5cc7-a8b2-380e8e33e813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd30d87e-552d-4b30-9123-2047e4e381a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd30d87e-552d-4b30-9123-2047e4e381a2.jpg?1",
             "name": "Oriq Loremage",
             "text": "{T}: Search your library for a card, put it into your graveyard, then shuffle. If it's an instant or sorcery card, put a +1/+1 counter on Oriq Loremage.",
             "colours": [
@@ -11753,7 +11753,7 @@
         },
         {
             "id": "d891b14c-e774-5f76-a856-411e0db80c0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4802149c-b7f0-40d5-a312-df8cc920e7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4802149c-b7f0-40d5-a312-df8cc920e7d4.jpg?1",
             "name": "Poet's Quill",
             "text": "When Poet's Quill enters the battlefield, learn.\nEquipped creature gets +1/+1 and has lifelink.\nEquip {1}{B}",
             "colours": [
@@ -11789,7 +11789,7 @@
         },
         {
             "id": "7454c3aa-71d2-53b1-a294-b716b9025717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bfaa8-3d54-4934-aaf6-72be43a87324.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/075bfaa8-3d54-4934-aaf6-72be43a87324.jpg?1",
             "name": "Sedgemoor Witch",
             "text": "Menace\nWard\u2014\nPay 3 life.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"",
             "colours": [
@@ -11826,7 +11826,7 @@
         },
         {
             "id": "c6072381-f3ee-5f4e-ad0b-c60b73b276b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3509c-8d67-4c5e-83bf-1a67f87589b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d3509c-8d67-4c5e-83bf-1a67f87589b9.jpg?1",
             "name": "Conspiracy Theorist",
             "text": "Whenever Conspiracy Theorist attacks, you may pay {1} and discard a card. If you do, draw a card.\nWhenever you discard one or more nonland cards, you may exile one of them from your graveyard. If you do, you may cast it this turn.",
             "colours": [
@@ -11863,7 +11863,7 @@
         },
         {
             "id": "22c784f1-cf53-5fdb-b82b-3b4fd3cb5de3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c038e6-2346-4544-bea1-b64098f63f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1c038e6-2346-4544-bea1-b64098f63f23.jpg?1",
             "name": "Crackle with Power",
             "text": "Crackle with Power deals five times X damage to each of up to X targets.",
             "colours": [
@@ -11897,7 +11897,7 @@
         },
         {
             "id": "09722748-23af-5f83-8c5d-95206bacfe16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ddfc9-1ecd-45e1-b9aa-3390a2e3776f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854ddfc9-1ecd-45e1-b9aa-3390a2e3776f.jpg?1",
             "name": "Draconic Intervention",
             "text": "As an additional cost to cast this spell, exile an instant or sorcery card from your graveyard.\nDraconic Intervention deals X damage to each non-Dragon creature, where X is the exiled card's mana value. If a creature dealt damage this way would die this turn, exile it instead.\nExile Draconic Intervention.",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "9904863e-ac89-5e85-bf27-24093764710b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bdcfde9-1c0a-49fc-8996-37a24a2379e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bdcfde9-1c0a-49fc-8996-37a24a2379e3.jpg?1",
             "name": "Efreet Flamepainter",
             "text": "Double strike\nWhenever Efreet Flamepainter deals combat damage to a player, you may cast target instant or sorcery card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
             "colours": [
@@ -11968,7 +11968,7 @@
         },
         {
             "id": "1268b0d8-1e86-54b7-b8cd-f43e1a21ddaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf5c70-25e8-489a-9cab-ce45eab191ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8cf5c70-25e8-489a-9cab-ce45eab191ed.jpg?1",
             "name": "Fervent Mastery",
             "text": "You may pay {2}{R}{R} rather than pay this spell's mana cost.\nIf the {2}{R}{R} cost was paid, an opponent discards any number of cards, then draws that many cards.\nSearch your library for up to three cards, put them into your hand, shuffle, then discard three cards at random.",
             "colours": [
@@ -12002,7 +12002,7 @@
         },
         {
             "id": "1f02814a-5ab0-5374-acc8-d613ad4e4f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caa9c12-ac06-458e-bf03-21dd1b3ed986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1caa9c12-ac06-458e-bf03-21dd1b3ed986.jpg?1",
             "name": "Illuminate History",
             "text": "Discard any number of cards, then draw that many cards. Then if there are seven or more cards in your graveyard, create a 3/2 red and white Spirit creature token.",
             "colours": [
@@ -12038,7 +12038,7 @@
         },
         {
             "id": "d587edc6-a284-5487-a559-9cedb82a430f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81c6751-b97e-4935-a18f-fb97ee9e8a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a81c6751-b97e-4935-a18f-fb97ee9e8a68.jpg?1",
             "name": "Retriever Phoenix",
             "text": "Flying, haste\nWhen Retriever Phoenix enters the battlefield, if you cast it, learn.\nAs long as Retriever Phoenix is in your graveyard, if you would learn, you may instead return Retriever Phoenix to the battlefield.",
             "colours": [
@@ -12074,7 +12074,7 @@
         },
         {
             "id": "ebce9c48-14b4-5f70-9aad-04a369b11a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee50e9b-7414-4a4e-8c12-5b8c4043f4b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee50e9b-7414-4a4e-8c12-5b8c4043f4b1.jpg?1",
             "name": "Accomplished Alchemist",
             "text": "{T}: Add one mana of any color.\n{T}: Add X mana of any one color, where X is the amount of life you gained this turn.",
             "colours": [
@@ -12111,7 +12111,7 @@
         },
         {
             "id": "21049f9a-f473-5c9f-bf2b-33b19558e1bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f222fdb-eddd-4179-b779-a45171bfb010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f222fdb-eddd-4179-b779-a45171bfb010.jpg?1",
             "name": "Basic Conjuration",
             "text": "Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life.",
             "colours": [
@@ -12147,7 +12147,7 @@
         },
         {
             "id": "2a165d2e-3ad7-5fc4-9abe-8be6fb5f8d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87d007f-9dee-4525-8298-04c317c52c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87d007f-9dee-4525-8298-04c317c52c96.jpg?1",
             "name": "Dragonsguard Elite",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Dragonsguard Elite.\n{4}{G}{G}: Double the number of +1/+1 counters on Dragonsguard Elite.",
             "colours": [
@@ -12185,7 +12185,7 @@
         },
         {
             "id": "665cfb40-b945-55df-b363-f09dbe34b222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76ba861-beb0-4cd2-8e06-626f587f6f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76ba861-beb0-4cd2-8e06-626f587f6f44.jpg?1",
             "name": "Ecological Appreciation",
             "text": "Search your library and graveyard for up to four creature cards with different names that each have mana value X or less and reveal them. An opponent chooses two of those cards. Shuffle the chosen cards into your library and put the rest onto the battlefield. Exile Ecological Appreciation.",
             "colours": [
@@ -12219,7 +12219,7 @@
         },
         {
             "id": "db583f4b-1ffd-54be-a3ee-386616302c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7771e5a4-cc4b-43fb-8a44-9382de73fa0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7771e5a4-cc4b-43fb-8a44-9382de73fa0f.jpg?1",
             "name": "Exponential Growth",
             "text": "Until end of turn, double target creature's power X times.",
             "colours": [
@@ -12253,7 +12253,7 @@
         },
         {
             "id": "5034145c-5de8-5e53-a7c0-68639523c1b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831607fb-92ba-46d2-85a8-0aa7023e3e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/831607fb-92ba-46d2-85a8-0aa7023e3e30.jpg?1",
             "name": "Gnarled Professor",
             "text": "Trample\nWhen Gnarled Professor enters the battlefield, learn.",
             "colours": [
@@ -12290,7 +12290,7 @@
         },
         {
             "id": "454f4f08-1388-55ab-bb56-d884cd56cd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99b2e32-5272-4f66-b05e-a9d32d9e9f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99b2e32-5272-4f66-b05e-a9d32d9e9f8d.jpg?1",
             "name": "Verdant Mastery",
             "text": "You may pay {3}{G} rather than pay this spell's mana cost.\nSearch your library for up to four basic land cards and reveal them. Put one of them onto the battlefield tapped under an opponent's control if the {3}{G} cost was paid. Put two of them onto the battlefield tapped under your control and the rest into your hand. Then shuffle.",
             "colours": [
@@ -12324,7 +12324,7 @@
         },
         {
             "id": "19b80ef3-e8ad-55bd-92c5-92b1ce261508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -12362,7 +12362,7 @@
         },
         {
             "id": "0bd08e74-ee4a-5bdb-a850-35d3ffe2b155",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b120e3c2-21b1-43e3-b685-9cf62bd7aa07.jpg?1",
             "name": "Augmenter Pugilist // Echoing Equation",
             "text": "Choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary.\n\n\nDruid\n{1}{G}{G}",
             "colours": [
@@ -12397,7 +12397,7 @@
         },
         {
             "id": "70c713a0-f8a4-5980-9f69-4580764c3955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -12436,7 +12436,7 @@
         },
         {
             "id": "caa57405-19ac-5d47-923a-af2a132cc509",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/3/930d3b70-7e8e-4a39-b60d-7d14196912e0.jpg?1",
             "name": "Blex, Vexing Pest // Search for Blex",
             "text": "Look at the top five cards of your library. You may put any number of them into your hand and the rest into your graveyard. You lose 3 life for each card you put into your hand this way.\n\n\nPest\n{2}{G}",
             "colours": [
@@ -12471,7 +12471,7 @@
         },
         {
             "id": "47229f00-8426-5346-b41f-1d2c5b926197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -12513,7 +12513,7 @@
         },
         {
             "id": "b3ce0192-4259-50a2-8548-8be986fa454a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/786156ce-544c-4aa4-8381-756042d0bcda.jpg?1",
             "name": "Extus, Oriq Overlord // Awaken the Blood Avatar",
             "text": "Double strike\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, return target nonlegendary creature card from your graveyard to your hand.\n\n\nSorcery\n{6}{B}{R}",
             "colours": [
@@ -12550,7 +12550,7 @@
         },
         {
             "id": "9246ffb1-5d96-5932-b857-df34dc5fe4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -12588,7 +12588,7 @@
         },
         {
             "id": "46f49a85-f659-550f-8588-a270a607bd07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c917201-4691-4f31-a8e4-ca0192d5ff71.jpg?1",
             "name": "Flamescroll Celebrant // Revel in Silence",
             "text": "Your opponents can't cast spells or activate planeswalkers' loyalty abilities this turn.\nExile Revel in Silence.\n\n\nShaman\n{1}{R}",
             "colours": [
@@ -12623,7 +12623,7 @@
         },
         {
             "id": "1181384e-826b-5079-8d9a-064d2f955539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -12663,7 +12663,7 @@
         },
         {
             "id": "16d703d7-6310-58a6-b32b-a2c0ad852ced",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0a96416-9ee5-4202-a99f-e09db8794567.jpg?1",
             "name": "Jadzi, Oracle of Arcavios // Journey to the Oracle",
             "text": "Discard a card: Return Jadzi, Oracle of Arcavios to its owner's hand.\nMagecraft \u2014 Whenever you cast or copy an instant or sorcery spell, reveal the top card of your library. If it's a nonland card, you may cast it by paying {1} rather than paying its mana cost. If it's a land card, put it onto the battlefield.\n\n\nSorcery\n{2}{G}{G}",
             "colours": [
@@ -12698,7 +12698,7 @@
         },
         {
             "id": "fdb0d757-1597-5a87-acb6-f7f997d3eb0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -12738,7 +12738,7 @@
         },
         {
             "id": "557b13f5-780e-530d-aa82-6135158089ae",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/d/1d96ade2-fb2a-420e-a14f-e96c47f903ce.jpg?1",
             "name": "Kianne, Dean of Substance // Imbraham, Dean of Theory",
             "text": "{T}: Exile the top card of your library. If it's a land card, put it into your hand. Otherwise, put a study counter on it.\n{4}{G}: Create a 0/0 green and blue Fractal creature token. Put a +1/+1 counter on it for each different mana value among nonland cards you own in exile with study counters on them.\n\n\nWizard\n{2}{U}{U}",
             "colours": [
@@ -12778,7 +12778,7 @@
         },
         {
             "id": "77b6c21f-9e23-5f34-9895-6080a598bd3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -12813,7 +12813,7 @@
         },
         {
             "id": "239e98ea-8241-5860-88a1-43693287189b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1ebfe27-d5a4-4fc9-8049-fcebe65dd592.jpg?1",
             "name": "Pestilent Cauldron // Restorative Burst",
             "text": "{T}, Discard a card: Create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n{1}, {T}: Each opponent mills cards equal to the amount of life you gained this turn.\n{4}, {T}: Exile four target cards from a single graveyard. Draw a card.\n\n\nSorcery\n{3}{G}{G}",
             "colours": [
@@ -12848,7 +12848,7 @@
         },
         {
             "id": "682a19c7-f70b-5875-b29c-32f6df880995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -12888,7 +12888,7 @@
         },
         {
             "id": "cc6e71b3-4a8b-5add-b9dc-56531805bacd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/9/e92c8175-50be-412e-b42e-9fe92aa8d4f1.jpg?1",
             "name": "Plargg, Dean of Chaos // Augusta, Dean of Order",
             "text": "{T}, Discard a card: Draw a card.\n{4}{R}, {T}: Reveal cards from the top of your library until you reveal a nonlegendary, nonland card with mana value 3 or less. You may cast that card without paying its mana cost. Put all revealed cards not cast this way on the bottom of your library in a random order.\n\n\nCleric\n{2}{W}",
             "colours": [
@@ -12928,7 +12928,7 @@
         },
         {
             "id": "156944be-f868-56f3-b895-1fa640c65ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -12966,7 +12966,7 @@
         },
         {
             "id": "18fa77d7-3a9a-5c55-9dbd-052624cd3179",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b09d444-a687-4712-b193-265148748aaf.jpg?1",
             "name": "Selfless Glyphweaver // Deadly Vanity",
             "text": "Exile Selfless Glyphweaver: Creatures you control gain indestructible until end of turn.\n\n\nSorcery\n{5}{B}{B}{B}",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "39ee3f39-26ae-52cc-9553-d14c6ece8bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -13041,7 +13041,7 @@
         },
         {
             "id": "e3ae7f29-0054-503b-9ecd-8b2456cfec3c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/1/c18ebfe1-f953-4aa3-933e-eee58fc4a0dd.jpg?1",
             "name": "Shaile, Dean of Radiance // Embrose, Dean of Shadow",
             "text": "Flying, vigilance\n{T}: Put a +1/+1 counter on each creature that entered the battlefield under your control this turn.\n\n\nWarlock\n{2}{B}{B}",
             "colours": [
@@ -13081,7 +13081,7 @@
         },
         {
             "id": "ce9b41a9-71eb-58c8-bc04-3d0fce792601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -13119,7 +13119,7 @@
         },
         {
             "id": "fd68f24d-939d-5028-aacf-6d00a883e384",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/77e7417d-36b9-4a47-b6d2-aa589711a5ba.jpg?1",
             "name": "Torrent Sculptor // Flamethrower Sonata",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Torrent Sculptor enters the battlefield, exile an instant or sorcery card from your graveyard. Put a number of +1/+1 counters on Torrent Sculptor equal to half that card's mana value, rounded up.\n\n\nSorcery\n{1}{R}",
             "colours": [
@@ -13154,7 +13154,7 @@
         },
         {
             "id": "74cc26a4-2b6f-51de-8193-e0474ee88254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -13194,7 +13194,7 @@
         },
         {
             "id": "3915cc79-3148-5f08-b688-cd1a9f7699b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/298a4109-4f8d-449c-b13d-e678c1113b90.jpg?1",
             "name": "Uvilda, Dean of Perfection // Nassari, Dean of Expression",
             "text": "{T}: You may exile an instant or sorcery card from your hand and put three hone counters on it. It gains \"At the beginning of your upkeep, if this card is exiled, remove a hone counter from it\" and \"When the last hone counter is removed from this card, if it's exiled, you may cast it. It costs {4} less to cast this way.\"\n\n\nShaman\n{3}{R}{R}",
             "colours": [
@@ -13234,7 +13234,7 @@
         },
         {
             "id": "870a8de3-0179-5d80-a776-5c495879268b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -13274,7 +13274,7 @@
         },
         {
             "id": "783762f0-4049-5417-9378-76f563475f87",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/297696bb-0610-45fb-92d3-5b7d9a7da290.jpg?1",
             "name": "Valentin, Dean of the Vein // Lisette, Dean of the Root",
             "text": "Menace, lifelink\nIf a nontoken creature an opponent controls would die, exile it instead. When you do, you may pay {2}. If you do, create a 1/1 black and green Pest creature token with \"When this creature dies, you gain 1 life.\"\n\n\nDruid\n{2}{G}{G}",
             "colours": [
@@ -13314,7 +13314,7 @@
         },
         {
             "id": "9dfbdaeb-182c-5eed-8977-eb20a37a0162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a3aa-bc1b-4a57-915c-36c35ae9d92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc2a3aa-bc1b-4a57-915c-36c35ae9d92a.jpg?1",
             "name": "Blade Historian",
             "text": "Attacking creatures you control have double strike.",
             "colours": [
@@ -13353,7 +13353,7 @@
         },
         {
             "id": "4bc3f436-46dd-5eb3-b060-cd90b03bd52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdafd5bf-573d-4d3b-94ff-c39834a92d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdafd5bf-573d-4d3b-94ff-c39834a92d39.jpg?1",
             "name": "Blot Out the Sky",
             "text": "Create X tapped 2/1 white and black Inkling creature tokens with flying. If X is 6 or more, destroy all noncreature, nonland permanents.",
             "colours": [
@@ -13389,7 +13389,7 @@
         },
         {
             "id": "8fb5988b-f31c-58a1-828a-78f8cc85fb36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecda818-2729-436c-bde0-c893ca8be7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ecda818-2729-436c-bde0-c893ca8be7a8.jpg?1",
             "name": "Body of Research",
             "text": "Create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your library.",
             "colours": [
@@ -13425,7 +13425,7 @@
         },
         {
             "id": "af179fa7-f9a4-5a00-8d48-5b8a52503129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba72e51-ca69-48d4-96dc-df9519468c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba72e51-ca69-48d4-96dc-df9519468c01.jpg?1",
             "name": "Culling Ritual",
             "text": "Destroy each nonland permanent with mana value 2 or less. Add {B} or {G} for each permanent destroyed this way.",
             "colours": [
@@ -13461,7 +13461,7 @@
         },
         {
             "id": "3a399f7a-8651-5432-9935-2c444b22a3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f198c49-9192-4b7f-bbc6-9f01395836f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f198c49-9192-4b7f-bbc6-9f01395836f2.jpg?1",
             "name": "Culmination of Studies",
             "text": "Exile the top X cards of your library. For each land card exiled this way, create a Treasure token. For each blue card exiled this way, draw a card. For each red card exiled this way, Culmination of Studies deals 1 damage to each opponent.",
             "colours": [
@@ -13497,7 +13497,7 @@
         },
         {
             "id": "265bd0e8-f7d1-5481-a577-b77ea78877d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a595a8-20f3-49e9-82ca-18923958f21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a595a8-20f3-49e9-82ca-18923958f21b.jpg?1",
             "name": "Daemogoth Titan",
             "text": "Whenever Daemogoth Titan attacks or blocks, sacrifice a creature.",
             "colours": [
@@ -13535,7 +13535,7 @@
         },
         {
             "id": "e4e383bc-79d8-5ad9-a35a-b8299641d488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235079f1-2226-4a6d-9682-ae932e67d660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235079f1-2226-4a6d-9682-ae932e67d660.jpg?1",
             "name": "Double Major",
             "text": "Copy target creature spell you control, except it isn't legendary if the spell is legendary.",
             "colours": [
@@ -13571,7 +13571,7 @@
         },
         {
             "id": "39d0ecec-7607-5838-aef7-df6375e9f1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb164ab-ee63-4025-9d72-6db71b99bdd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb164ab-ee63-4025-9d72-6db71b99bdd7.jpg?1",
             "name": "Dramatic Finale",
             "text": "Creature tokens you control get +1/+1.\nWhenever one or more nontoken creatures you control die, create a 2/1 white and black Inkling creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -13607,7 +13607,7 @@
         },
         {
             "id": "77ca5ad4-bc4d-5cc4-a709-a12592fbfcb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b6e53f-f605-430e-9455-b3653cbd8e1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34b6e53f-f605-430e-9455-b3653cbd8e1d.jpg?1",
             "name": "Elemental Expressionist",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, choose target creature you control. Until end of turn, it gains \"If this creature would leave the battlefield, exile it instead of putting it anywhere else\" and \"When you exile this creature, create a 4/4 blue and red Elemental creature token.\"",
             "colours": [
@@ -13646,7 +13646,7 @@
         },
         {
             "id": "d0bb74a8-6440-5727-ad71-030a7efb9875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7b626d-8536-4c57-b075-8320fcf1cdec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce7b626d-8536-4c57-b075-8320fcf1cdec.jpg?1",
             "name": "Harness Infinity",
             "text": "Exchange your hand and graveyard.\nExile Harness Infinity.",
             "colours": [
@@ -13682,7 +13682,7 @@
         },
         {
             "id": "5ce988ab-6312-5be8-8a44-8bbb5e697cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b530c0-86ac-4054-8067-e08764438aaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b530c0-86ac-4054-8067-e08764438aaa.jpg?1",
             "name": "Hofri Ghostforge",
             "text": "Spirits you control get +1/+1 and have trample and haste.\nWhenever another nontoken creature you control dies, exile it. If you do, create a token that's a copy of that creature, except it's a Spirit in addition to its other types and it has \"When this creature leaves the battlefield, return the exiled card to your graveyard.\"",
             "colours": [
@@ -13723,7 +13723,7 @@
         },
         {
             "id": "3fce5952-94ad-524e-aa46-3fb9809de70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7df16-e01d-4053-88d3-db78ed26bfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b7df16-e01d-4053-88d3-db78ed26bfe1.jpg?1",
             "name": "Lorehold Command",
             "text": "Choose two \u2014\n\u2022 Create a 3/2 red and white Spirit creature token.\n\u2022 Creatures you control get +1/+0 and gain indestructible and haste until end of turn.\n\u2022 Lorehold Command deals 3 damage to any target. Target player gains 3 life.\n\u2022 Sacrifice a permanent, then draw two cards.",
             "colours": [
@@ -13759,7 +13759,7 @@
         },
         {
             "id": "a7f249b1-0148-5531-93ef-6be4726d6272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f15bee-c4fa-4ad4-acaf-bb8023ebd6f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82f15bee-c4fa-4ad4-acaf-bb8023ebd6f0.jpg?1",
             "name": "Magma Opus",
             "text": "Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.\n{UR}{UR}, Discard Magma Opus: Create a Treasure token.",
             "colours": [
@@ -13795,7 +13795,7 @@
         },
         {
             "id": "6b022dca-de20-59f0-9e68-041508c78ab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7a615-d187-45bd-8f65-3458d896ce5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14a7a615-d187-45bd-8f65-3458d896ce5e.jpg?1",
             "name": "Manifestation Sage",
             "text": "When Manifestation Sage enters the battlefield, create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your hand.",
             "colours": [
@@ -13834,7 +13834,7 @@
         },
         {
             "id": "68194a33-5a60-581f-8231-1aab5df013ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffb6717-93f5-4774-9cc3-29b883b144b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffb6717-93f5-4774-9cc3-29b883b144b5.jpg?1",
             "name": "Prismari Command",
             "text": "Choose two \u2014\n\u2022 Prismari Command deals 2 damage to any target.\n\u2022 Target player draws two cards, then discards two cards.\n\u2022 Target player creates a Treasure token.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -13870,7 +13870,7 @@
         },
         {
             "id": "f17ee1ca-2725-55e1-947e-d02854bdc138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b362583b-f5d7-45cf-add1-71e790547203.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b362583b-f5d7-45cf-add1-71e790547203.jpg?1",
             "name": "Quandrix Command",
             "text": "Choose two \u2014\n\u2022 Return target creature or planeswalker to its owner's hand.\n\u2022 Counter target artifact or enchantment spell.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player shuffles up to three target cards from their graveyard into their library.",
             "colours": [
@@ -13906,7 +13906,7 @@
         },
         {
             "id": "0c98cab2-b9d0-5186-b54c-d172651c2d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74eea36-f7b6-4586-a16c-cd20ab89ab54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f74eea36-f7b6-4586-a16c-cd20ab89ab54.jpg?1",
             "name": "Radiant Scrollwielder",
             "text": "Instant and sorcery spells you control have lifelink.\nAt the beginning of your upkeep, exile an instant or sorcery card at random from your graveyard. You may cast it this turn. If a spell cast this way would be put into your graveyard, exile it instead.",
             "colours": [
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "d851a317-5e8d-59ee-b899-3015fb57ae5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5ce6dd-5994-4e85-9479-fa924c8ab42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd5ce6dd-5994-4e85-9479-fa924c8ab42b.jpg?1",
             "name": "Rushed Rebirth",
             "text": "Choose target creature. When that creature dies this turn, search your library for a creature card with lesser mana value, put it onto the battlefield tapped, then shuffle.",
             "colours": [
@@ -13981,7 +13981,7 @@
         },
         {
             "id": "5e980a6e-f84e-5f90-8280-905f2fe010c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbde59f8-dadd-4b5f-a55c-69317af7c2b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbde59f8-dadd-4b5f-a55c-69317af7c2b7.jpg?1",
             "name": "Silverquill Command",
             "text": "Choose two \u2014\n\u2022 Target creature gets +3/+3 and gains flying until end of turn.\n\u2022 Return target creature card with mana value 2 or less from your graveyard to the battlefield.\n\u2022 Target player draws a card and loses 1 life.\n\u2022 Target opponent sacrifices a creature.",
             "colours": [
@@ -14017,7 +14017,7 @@
         },
         {
             "id": "375dcf31-adc4-5c41-8bb8-a530bad073cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ae964b-a3dd-4747-a229-d0b4e112179e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ae964b-a3dd-4747-a229-d0b4e112179e.jpg?1",
             "name": "Silverquill Silencer",
             "text": "As Silverquill Silencer enters the battlefield, choose a nonland card name.\nWhenever an opponent casts a spell with the chosen name, they lose 3 life and you draw a card.",
             "colours": [
@@ -14056,7 +14056,7 @@
         },
         {
             "id": "31dbfa17-da37-5712-aff3-1dfcf757b335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7441bf-8783-48b9-b828-31c071e97847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7441bf-8783-48b9-b828-31c071e97847.jpg?1",
             "name": "Vanishing Verse",
             "text": "Exile target monocolored permanent.",
             "colours": [
@@ -14092,7 +14092,7 @@
         },
         {
             "id": "8810ba59-b1c4-5a27-b5b7-864376f10d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cae78b-75a4-4c0e-92c3-f24379a23271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91cae78b-75a4-4c0e-92c3-f24379a23271.jpg?1",
             "name": "Venerable Warsinger",
             "text": "Vigilance, trample\nWhenever Venerable Warsinger deals combat damage to a player, you may return target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of damage Venerable Warsinger dealt to that player.",
             "colours": [
@@ -14131,7 +14131,7 @@
         },
         {
             "id": "86ac72b4-333c-5674-8e42-870f8a564895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f04535d-a6b7-4d91-918d-fccc1adfcaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f04535d-a6b7-4d91-918d-fccc1adfcaf3.jpg?1",
             "name": "Witherbloom Command",
             "text": "Choose two \u2014\n\u2022 Target player mills three cards, then you return a land card from your graveyard to your hand.\n\u2022 Destroy target noncreature, nonland permanent with mana value 2 or less.\n\u2022 Target creature gets -3/-1 until end of turn.\n\u2022 Target opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -14167,7 +14167,7 @@
         },
         {
             "id": "a9ad89b5-df19-53ce-943a-b4c8f6ad4ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7e96e-5d35-41dc-9a8a-2049e2e56350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d7e96e-5d35-41dc-9a8a-2049e2e56350.jpg?1",
             "name": "Codie, Vociferous Codex",
             "text": "You can't cast permanent spells.\n{4}, {T}: Add {W}{U}{B}{R}{G}. When you cast your next spell this turn, exile cards from the top of your library until you exile an instant or sorcery card with lesser mana value. Until end of turn, you may cast that card without paying its mana cost. Put each other card exiled this way on the bottom of your library in a random order.",
             "colours": [],
@@ -14208,7 +14208,7 @@
         },
         {
             "id": "df5c8820-391b-5326-8eb5-b4ae0f1b7973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795abd9-7294-4f8a-8491-0fe39ae6e273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0795abd9-7294-4f8a-8491-0fe39ae6e273.jpg?1",
             "name": "Strixhaven Stadium",
             "text": "{T}: Add {C}. Put a point counter on Strixhaven Stadium.\nWhenever a creature deals combat damage to you, remove a point counter from Strixhaven Stadium.\nWhenever a creature you control deals combat damage to an opponent, put a point counter on Strixhaven Stadium. Then if it has ten or more point counters on it, remove them all and that player loses the game.",
             "colours": [],
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "34b7c089-5aec-5147-8d1b-435696979ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de969f0a-23df-408e-9f92-4b909caf73d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de969f0a-23df-408e-9f92-4b909caf73d0.jpg?1",
             "name": "The Biblioplex",
             "text": "{T}: Add {C}.\n{2}, {T}: Look at the top card of your library. If it's an instant or sorcery card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard. Activate only if you have exactly zero or seven cards in hand.",
             "colours": [],
@@ -14268,7 +14268,7 @@
         },
         {
             "id": "554021a0-3d65-51e6-ba6d-262c8d67500f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79f483-88c5-461c-a7c5-6b898317b1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae79f483-88c5-461c-a7c5-6b898317b1e3.jpg?1",
             "name": "Frostboil Snarl",
             "text": "As Frostboil Snarl enters the battlefield, you may reveal an Island or Mountain card from your hand. If you don't, Frostboil Snarl enters the battlefield tapped.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -14301,7 +14301,7 @@
         },
         {
             "id": "9162a32c-a851-5da1-90ad-04dd07d794e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58115f3f-1157-4efd-94d8-3a1a71bd6816.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58115f3f-1157-4efd-94d8-3a1a71bd6816.jpg?1",
             "name": "Furycalm Snarl",
             "text": "As Furycalm Snarl enters the battlefield, you may reveal a Mountain or Plains card from your hand. If you don't, Furycalm Snarl enters the battlefield tapped.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -14334,7 +14334,7 @@
         },
         {
             "id": "2eacad9b-1808-5895-bf3a-3fb4ffc76dbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a1a974-8275-4878-9863-9466569aac00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a1a974-8275-4878-9863-9466569aac00.jpg?1",
             "name": "Hall of Oracles",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{T}: Put a +1/+1 counter on target creature. Activate only as a sorcery and only if you've cast an instant or sorcery spell this turn.",
             "colours": [],
@@ -14364,7 +14364,7 @@
         },
         {
             "id": "0a654fdf-ecf7-59f4-899c-6250bd514cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68589e-d71f-4a2b-9a97-b768e81aefa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68589e-d71f-4a2b-9a97-b768e81aefa4.jpg?1",
             "name": "Necroblossom Snarl",
             "text": "As Necroblossom Snarl enters the battlefield, you may reveal a Swamp or Forest card from your hand. If you don't, Necroblossom Snarl enters the battlefield tapped.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -14397,7 +14397,7 @@
         },
         {
             "id": "c34a12a4-6abf-5eb2-976c-591a48726d82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba00634-b62c-4a95-941d-775fc4c9e3a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7ba00634-b62c-4a95-941d-775fc4c9e3a2.jpg?1",
             "name": "Shineshadow Snarl",
             "text": "As Shineshadow Snarl enters the battlefield, you may reveal a Plains or Swamp card from your hand. If you don't, Shineshadow Snarl enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -14430,7 +14430,7 @@
         },
         {
             "id": "7dadd13d-67a4-5e31-82da-c1b4d1e27e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa184596-3a3c-43fe-8e20-b09ab100cd00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa184596-3a3c-43fe-8e20-b09ab100cd00.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "As Vineglimmer Snarl enters the battlefield, you may reveal a Forest or Island card from your hand. If you don't, Vineglimmer Snarl enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -14463,7 +14463,7 @@
         },
         {
             "id": "663a508e-294f-5fae-857d-d865c3d10929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abadcf9e-46ed-4a8b-888c-0cd3756bc8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abadcf9e-46ed-4a8b-888c-0cd3756bc8ab.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14499,7 +14499,7 @@
         },
         {
             "id": "a91545ec-1a4c-5846-8065-bd364a0d490d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7e5de-1fa8-406e-a411-fc8a11937000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f7e5de-1fa8-406e-a411-fc8a11937000.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -14535,7 +14535,7 @@
         },
         {
             "id": "79fc1f2b-9bbc-54df-8059-c3951a4eccb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96f9fb6-ef52-43f9-a458-8602a7c83333.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96f9fb6-ef52-43f9-a458-8602a7c83333.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14571,7 +14571,7 @@
         },
         {
             "id": "790c241b-3c46-5389-b6ef-70aaed263f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a217f-d532-4a7c-bcbf-d127641f6edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849a217f-d532-4a7c-bcbf-d127641f6edf.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -14607,7 +14607,7 @@
         },
         {
             "id": "4f1b0270-be24-5887-88a1-f2ff9e25e636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bd1c69-2561-4ff1-af00-bb519b3897c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13bd1c69-2561-4ff1-af00-bb519b3897c2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14643,7 +14643,7 @@
         },
         {
             "id": "163e1402-4a2d-5029-ba3b-3ca2841caa74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11093e3f-092e-49d9-aef9-b9855b040bf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11093e3f-092e-49d9-aef9-b9855b040bf2.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -14679,7 +14679,7 @@
         },
         {
             "id": "07be00b8-3035-52e4-9288-f7db23c14522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9660fb20-f499-4f7a-9f25-e463f095ab90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9660fb20-f499-4f7a-9f25-e463f095ab90.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14715,7 +14715,7 @@
         },
         {
             "id": "b1919663-4074-5309-b395-f1425bd5b705",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8fffd1-aff1-4aad-bfa0-9907adb5ce25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8fffd1-aff1-4aad-bfa0-9907adb5ce25.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -14751,7 +14751,7 @@
         },
         {
             "id": "399ca0f2-1540-5465-b38e-67d25f670e3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf517f-86a1-45eb-bd71-e0bffb610396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfaf517f-86a1-45eb-bd71-e0bffb610396.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14787,7 +14787,7 @@
         },
         {
             "id": "2f78811e-e99e-5d44-a78d-211f92c1c635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659a7d45-af0d-4a4a-a878-e8e40b732bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/659a7d45-af0d-4a4a-a878-e8e40b732bfa.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -14823,7 +14823,7 @@
         },
         {
             "id": "66468e25-da7d-56e7-8ae8-542eeadfbb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f213fb1e-f159-4088-8b0e-f10771e4b095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f213fb1e-f159-4088-8b0e-f10771e4b095.jpg?1",
             "name": "Dragonsguard Elite",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, put a +1/+1 counter on Dragonsguard Elite.\n{4}{G}{G}: Double the number of +1/+1 counters on Dragonsguard Elite.",
             "colours": [
@@ -14860,7 +14860,7 @@
         },
         {
             "id": "79636fc8-4089-5a80-ac3a-9d78569b8acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f7218a-511a-4ca8-899d-ae78a935f7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f7218a-511a-4ca8-899d-ae78a935f7a0.jpg?1",
             "name": "Archmage Emeritus",
             "text": "Magecraft \u2014 Whenever you cast or copy an instant or sorcery spell, draw a card.",
             "colours": [
@@ -14898,7 +14898,7 @@
         },
         {
             "id": "f38b6cfd-e43c-5b3c-802d-4148aa5c1689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033ffe6-3e81-440f-bde7-0cf267a54b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033ffe6-3e81-440f-bde7-0cf267a54b36.jpg?1",
             "name": "Fracture",
             "text": "Destroy target artifact, enchantment, or planeswalker.",
             "colours": [
@@ -14934,7 +14934,7 @@
         },
         {
             "id": "6a07c8a9-0429-54ff-a475-66e6b57c5007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e5c7e8-e6bf-4186-8140-d1171fbb8552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93e5c7e8-e6bf-4186-8140-d1171fbb8552.jpg?1",
             "name": "Expressive Iteration",
             "text": "Look at the top three cards of your library. Put one of them into your hand, put one of them on the bottom of your library, and exile one of them. You may play the exiled card this turn.",
             "colours": [
@@ -14970,7 +14970,7 @@
         },
         {
             "id": "fec2bc24-35a3-54bf-b616-2a1a4a107768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddfc5f7-911b-4159-8540-530d642d0e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddfc5f7-911b-4159-8540-530d642d0e7c.jpg?1",
             "name": "Mortality Spear",
             "text": "This spell costs {2} less to cast if you gained life this turn.\nDestroy target nonland permanent.",
             "colours": [
@@ -15006,7 +15006,7 @@
         },
         {
             "id": "341bf2d2-87e0-5e47-9644-5515a50c54c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f135f-1404-4333-946e-62d3aa919a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101f135f-1404-4333-946e-62d3aa919a62.jpg?1",
             "name": "Rip Apart",
             "text": "Choose one \u2014\n\u2022 Rip Apart deals 3 damage to target creature or planeswalker.\n\u2022 Destroy target artifact or enchantment.",
             "colours": [
@@ -15042,7 +15042,7 @@
         },
         {
             "id": "80df58da-e739-5b4c-9402-c90eeaa4cb2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b05c98-7799-4104-a0d0-3632bd5b8846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b05c98-7799-4104-a0d0-3632bd5b8846.jpg?1",
             "name": "Decisive Denial",
             "text": "Choose one \u2014\n\u2022 Target creature you control fights target creature you don't control.\n\u2022 Counter target noncreature spell unless its controller pays {3}.",
             "colours": [
@@ -15078,7 +15078,7 @@
         },
         {
             "id": "2ce340c2-2ee0-55a9-a085-f21475429fe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a50acd-ac2d-47bf-b331-0bcf5edd9c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a50acd-ac2d-47bf-b331-0bcf5edd9c75.jpg?1",
             "name": "Avatar",
             "text": "",
             "colours": [
@@ -15115,7 +15115,7 @@
         },
         {
             "id": "9a4cae1d-a07e-5a10-8fb3-776eefa1fc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0b9b88-705e-4df0-8a93-3e240b81355b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0b9b88-705e-4df0-8a93-3e240b81355b.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -15151,7 +15151,7 @@
         },
         {
             "id": "f1eeabc4-d35f-513e-a146-1f76051b3ad9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f48ab-b04e-4874-b31d-a86a7bc5af14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/910f48ab-b04e-4874-b31d-a86a7bc5af14.jpg?1",
             "name": "Fractal",
             "text": "",
             "colours": [
@@ -15187,7 +15187,7 @@
         },
         {
             "id": "aca46592-54ab-50f2-90ae-7dabf972573e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9deae5c-80d4-4701-b425-91853b7ee03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9deae5c-80d4-4701-b425-91853b7ee03b.jpg?1",
             "name": "Inkling",
             "text": "",
             "colours": [
@@ -15223,7 +15223,7 @@
         },
         {
             "id": "ef89b1c0-dd6f-59fd-9f80-d329f2fb5a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg?1",
             "name": "Pest",
             "text": "",
             "colours": [
@@ -15259,7 +15259,7 @@
         },
         {
             "id": "73d91ea5-cea0-51f3-9ad1-a7ee5f82804b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98c0167-7434-4607-87c4-315fa8b6972e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f98c0167-7434-4607-87c4-315fa8b6972e.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -15295,7 +15295,7 @@
         },
         {
             "id": "84e8350e-916c-5bde-9c98-f4ec1d2b1f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d027f-8996-4761-a776-47cd428f6779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2d027f-8996-4761-a776-47cd428f6779.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -15326,7 +15326,7 @@
         },
         {
             "id": "802758d8-7975-5041-80eb-69f438c279dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e090a47-3187-44f2-9dea-c2bc1407b053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e090a47-3187-44f2-9dea-c2bc1407b053.jpg?1",
             "name": "Lukka, Wayward Bonder Emblem",
             "text": "",
             "colours": [],
@@ -15354,7 +15354,7 @@
         },
         {
             "id": "4a610a7b-cf8d-5231-bc2f-a3cd64009fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18b93e-b590-4fbb-be47-d63a25cde811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc18b93e-b590-4fbb-be47-d63a25cde811.jpg?1",
             "name": "Rowan, Scholar of Sparks Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/TDM.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/TDM.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "22e8c995-d185-5f9f-84cf-a7e799daeeda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a5d494-efa1-446b-bebe-2ad36e154376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64a5d494-efa1-446b-bebe-2ad36e154376.jpg?1",
             "name": "Ugin, Eye of the Storms",
             "text": "When you cast this spell, exile up to one target permanent that's one or more colors.\nWhenever you cast a colorless spell, exile up to one target permanent that's one or more colors.\n+2: You gain 3 life and draw a card.\n0: Add {C}{C}{C}.\n\u221211: Search your library for any number of colorless nonland cards, exile them, then shuffle. Until end of turn, you may cast those cards without paying their mana costs.",
             "colours": [],
@@ -39,7 +39,7 @@
         },
         {
             "id": "760e6b1a-c1c9-5f1a-be46-a1fb6b85245b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29957f49-9a6b-42f6-b2fb-b48f653ab725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29957f49-9a6b-42f6-b2fb-b48f653ab725.jpg?1",
             "name": "Anafenza, Unyielding Lineage",
             "text": "Flash\nFirst strike\nWhenever another nontoken creature you control dies, Anafenza endures 2. (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)",
             "colours": [
@@ -78,7 +78,7 @@
         },
         {
             "id": "926b2054-5a1e-54e3-8fb9-feea8c6cde33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7102d8-90b3-45a1-b66d-dcca469b1fb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7102d8-90b3-45a1-b66d-dcca469b1fb6.jpg?1",
             "name": "Arashin Sunshield",
             "text": "When this creature enters, exile up to two target cards from a single graveyard.\n{W}, {T}: Tap target creature.",
             "colours": [
@@ -113,7 +113,7 @@
         },
         {
             "id": "46992657-f172-5163-a420-6dbd1bf403df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d91e42-43db-428d-a4dd-ef9d40306314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6d91e42-43db-428d-a4dd-ef9d40306314.jpg?1",
             "name": "Bearer of Glory",
             "text": "During your turn, this creature has first strike.\n{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -148,7 +148,7 @@
         },
         {
             "id": "9de42322-cb51-5a85-a711-766c4039ccdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f892d156-371c-4391-8ae6-25513c5032b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f892d156-371c-4391-8ae6-25513c5032b0.jpg?1",
             "name": "Clarion Conqueror",
             "text": "Flying\nActivated abilities of artifacts, creatures, and planeswalkers can't be activated.",
             "colours": [
@@ -185,7 +185,7 @@
         },
         {
             "id": "a56be8e0-36c9-5c52-857c-3183073126b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6569487-53c5-4b91-877d-e4e31bfa90c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6569487-53c5-4b91-877d-e4e31bfa90c0.jpg?1",
             "name": "Coordinated Maneuver",
             "text": "Choose one \u2014\n\u2022 Coordinated Maneuver deals damage equal to the number of creatures you control to target creature or planeswalker.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -217,7 +217,7 @@
         },
         {
             "id": "da9218fe-9065-5bb1-8440-c33f863be247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df7b253-6107-47d6-b650-cb4d3e0aec6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4df7b253-6107-47d6-b650-cb4d3e0aec6b.jpg?1",
             "name": "Dalkovan Packbeasts",
             "text": "Vigilance\nMobilize 3 (Whenever this creature attacks, create three tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)",
             "colours": [
@@ -251,7 +251,7 @@
         },
         {
             "id": "e89ec9d4-6752-5288-b513-b31a32bb5c71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f632be90-9e7f-41f8-a52e-a2952354d730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f632be90-9e7f-41f8-a52e-a2952354d730.jpg?1",
             "name": "Descendant of Storms",
             "text": "Whenever this creature attacks, you may pay {1}{W}. If you do, it endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "0d0c0f15-2645-50a6-94a0-3c345b34988b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200a8c5-3293-48d0-a523-ba148680f588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0200a8c5-3293-48d0-a523-ba148680f588.jpg?1",
             "name": "Dragonback Lancer",
             "text": "Flying\nMobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -321,7 +321,7 @@
         },
         {
             "id": "62538893-cd6a-53a7-b0a8-c5ad1d6ef70a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92640d-768b-4357-905f-bea017d351cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e92640d-768b-4357-905f-bea017d351cc.jpg?1",
             "name": "Duty Beyond Death",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nCreatures you control gain indestructible until end of turn. Put a +1/+1 counter on each creature you control. (Damage and effects that say \"destroy\" don't destroy those creatures.)",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "49fc65ab-f09a-5a9a-b550-f8fde7ac1b5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a065e3-b530-4e62-ab3c-4f6f908184ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a065e3-b530-4e62-ab3c-4f6f908184ec.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n+1: Create a 1/1 white Soldier creature token.\n0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your next turn.\n\u22123: Destroy target creature an opponent controls with mana value 3 or greater.",
             "colours": [
@@ -393,7 +393,7 @@
         },
         {
             "id": "dd0cb2f7-d303-54e5-b78b-95f9ad6bd31b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b647a018-1d70-43a1-a265-928bcd863689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b647a018-1d70-43a1-a265-928bcd863689.jpg?1",
             "name": "Fortress Kin-Guard",
             "text": "When this creature enters, it endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -428,7 +428,7 @@
         },
         {
             "id": "9898d496-cd30-5655-a951-b0f8788978e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f247b6-8212-4e78-a452-d2d3be228d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4f247b6-8212-4e78-a452-d2d3be228d8e.jpg?1",
             "name": "Furious Forebear",
             "text": "Whenever a creature you control dies while this card is in your graveyard, you may pay {1}{W}. If you do, return this card from your graveyard to your hand.",
             "colours": [
@@ -463,7 +463,7 @@
         },
         {
             "id": "b569148b-9f90-5529-aaf4-b75719e8a227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1a41-d44d-4184-9147-b4233e73de65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baac1a41-d44d-4184-9147-b4233e73de65.jpg?1",
             "name": "Lightfoot Technique",
             "text": "Put a +1/+1 counter on target creature. It gains flying and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "67332abb-86e6-5b9e-8004-029166f90930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a527cdb0-f54a-4b53-83a0-6b3e8cafa45e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a527cdb0-f54a-4b53-83a0-6b3e8cafa45e.jpg?1",
             "name": "Loxodon Battle Priest",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on another target creature you control.",
             "colours": [
@@ -530,7 +530,7 @@
         },
         {
             "id": "2925f044-bca0-5bb2-a342-b3a70d7ff41c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da45e9b0-a4f6-413b-9e62-666c511eb5b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da45e9b0-a4f6-413b-9e62-666c511eb5b0.jpg?1",
             "name": "Mardu Devotee",
             "text": "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{1}: Add {R}, {W}, or {B}. Activate only once each turn.",
             "colours": [
@@ -567,7 +567,7 @@
         },
         {
             "id": "2aeff58b-6d33-5faf-8941-c778c073e8df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300da2f-2297-4c2f-90c1-11ce2b42d91f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300da2f-2297-4c2f-90c1-11ce2b42d91f.jpg?1",
             "name": "Osseous Exhale",
             "text": "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)\nOsseous Exhale deals 5 damage to target attacking or blocking creature. If a Dragon was beheld, you gain 2 life.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "3768817d-2372-5cb6-8a90-b29ed03701ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb25366d-a647-4c5e-bcc7-7e54659aacbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb25366d-a647-4c5e-bcc7-7e54659aacbd.jpg?1",
             "name": "Poised Practitioner",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, put a +1/+1 counter on this creature. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
             "colours": [
@@ -634,7 +634,7 @@
         },
         {
             "id": "e12cf1d0-7e91-50da-b53f-6c135c2d51b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56e0037-8143-4c13-83e1-0c3f44e685ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56e0037-8143-4c13-83e1-0c3f44e685ea.jpg?1",
             "name": "Rally the Monastery",
             "text": "This spell costs {2} less to cast if you've cast another spell this turn.\nChoose one \u2014\n\u2022 Create two 1/1 white Monk creature tokens with prowess.\n\u2022 Up to two target creatures you control each get +2/+2 until end of turn.\n\u2022 Destroy target creature with power 4 or greater.",
             "colours": [
@@ -666,7 +666,7 @@
         },
         {
             "id": "8fe74dbd-e5a3-563c-a2f0-a88a6e1139c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bafe19-3bd6-4da0-b3e5-e0b89262504c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9bafe19-3bd6-4da0-b3e5-e0b89262504c.jpg?1",
             "name": "Rebellious Strike",
             "text": "Target creature gets +3/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "2e3b9f6b-f1de-5d43-ae9a-8d87f9c88b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Flying, vigilance\nAt the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "afa9211a-6738-5f6a-89ad-b1788cea68f6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/312f7072-3bf8-449f-bfb7-93727ef26c66.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Create a 2/2 white Soldier creature token. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "ac332121-208e-56a7-a086-f7110a62a53e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade6918-6d1d-448d-ab56-93996051e9a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade6918-6d1d-448d-ab56-93996051e9a9.jpg?1",
             "name": "Sage of the Skies",
             "text": "When you cast this spell, if you've cast another spell this turn, copy this spell. (The copy becomes a token.)\nFlying, lifelink",
             "colours": [
@@ -807,7 +807,7 @@
         },
         {
             "id": "ba163ee9-1825-51ab-9cd1-dda5d9788e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d548c9-42bc-4155-8211-0aea801c3724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98d548c9-42bc-4155-8211-0aea801c3724.jpg?1",
             "name": "Salt Road Packbeast",
             "text": "This spell costs {1} less to cast for each creature you control.\nWhen this creature enters, draw a card.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "4ad174ae-4315-5257-80de-fd571027a770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2da18f-0d7d-446c-b463-8bf170ed95da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2da18f-0d7d-446c-b463-8bf170ed95da.jpg?1",
             "name": "Smile at Death",
             "text": "At the beginning of your upkeep, return up to two target creature cards with power 2 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "b886d284-6601-5f4e-9e97-866135215388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3cc15e-1c82-454e-b541-4ab47c44814e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b3cc15e-1c82-454e-b541-4ab47c44814e.jpg?1",
             "name": "Starry-Eyed Skyrider",
             "text": "Flying\nWhenever this creature attacks, another target creature you control gains flying until end of turn.\nAttacking tokens you control have flying.",
             "colours": [
@@ -910,7 +910,7 @@
         },
         {
             "id": "1136f4f6-05df-5a33-a630-0804a1d6f095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce50932-03a6-48bc-8aee-bc8defd896cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce50932-03a6-48bc-8aee-bc8defd896cf.jpg?1",
             "name": "Static Snare",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature.\nWhen this enchantment enters, exile target artifact or creature an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -944,7 +944,7 @@
         },
         {
             "id": "3375afd5-0239-57c6-a685-14608fd96d60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f12684-c80a-422b-9c3f-ed4f31742b9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2f12684-c80a-422b-9c3f-ed4f31742b9d.jpg?1",
             "name": "Stormbeacon Blade",
             "text": "Equipped creature gets +3/+0.\nWhenever equipped creature attacks, draw a card if you control three or more attacking creatures.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "a8eb6e61-1382-51eb-b064-76ab52579b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f3aab5-7b54-4b55-8114-c6f9f79c255d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f3aab5-7b54-4b55-8114-c6f9f79c255d.jpg?1",
             "name": "Stormplain Detainment",
             "text": "When this enchantment enters, exile target nonland permanent an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -1010,7 +1010,7 @@
         },
         {
             "id": "474cb907-f981-581a-a9f1-1dfe325e141f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18292b9c-0f42-4ce2-8b85-35d06cf45a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18292b9c-0f42-4ce2-8b85-35d06cf45a63.jpg?1",
             "name": "Sunpearl Kirin",
             "text": "Flash\nFlying\nWhen this creature enters, return up to one other target nonland permanent you control to its owner's hand. If it was a token, draw a card.",
             "colours": [
@@ -1044,7 +1044,7 @@
         },
         {
             "id": "406e79eb-3cc1-54ae-b74c-0745c96243cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d771f-24dc-4ed6-8051-62df576a2ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d771f-24dc-4ed6-8051-62df576a2ba5.jpg?1",
             "name": "Teeming Dragonstorm",
             "text": "When this enchantment enters, create two 2/2 white Soldier creature tokens.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "3e18f169-8d68-518c-baab-2e0ca8551b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422f9453-ab12-4e3c-8c51-be87391395a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/422f9453-ab12-4e3c-8c51-be87391395a1.jpg?1",
             "name": "Tempest Hawk",
             "text": "Flying\nWhenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\nA deck can have any number of cards named Tempest Hawk.",
             "colours": [
@@ -1112,7 +1112,7 @@
         },
         {
             "id": "cb884575-e62b-5a08-a3b1-a41dabc1856b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff398be-4ba4-4976-9acc-be99d2e07a61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff398be-4ba4-4976-9acc-be99d2e07a61.jpg?1",
             "name": "United Battlefront",
             "text": "Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "986e3fe2-b49e-5158-8e51-05f6da78ba79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3de5f4-bb55-4ab9-995f-f3e0dc22c1bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec3de5f4-bb55-4ab9-995f-f3e0dc22c1bb.jpg?1",
             "name": "Voice of Victory",
             "text": "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -1183,7 +1183,7 @@
         },
         {
             "id": "a7f88b11-1920-5a9b-85bc-2abfa8e0092d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5b2324-69fe-4105-b6f8-14dfbe359d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e5b2324-69fe-4105-b6f8-14dfbe359d59.jpg?1",
             "name": "Wayspeaker Bodyguard",
             "text": "When this creature enters, return target nonland permanent card with mana value 2 or less from your graveyard to your hand.\nFlurry \u2014 Whenever you cast your second spell each turn, tap target creature an opponent controls.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "47c93168-0e06-56c6-ba1d-501cd4687ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c1417a-9719-46f6-8749-d92b93ce0529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c1417a-9719-46f6-8749-d92b93ce0529.jpg?1",
             "name": "Aegis Sculptor",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nAt the beginning of your upkeep, you may exile two cards from your graveyard. If you do, put a +1/+1 counter on this creature.",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "7327d54b-3567-5419-911b-2097de8f779a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0462-0158-467f-951d-a7a121188a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0462-0158-467f-951d-a7a121188a10.jpg?1",
             "name": "Agent of Kotis",
             "text": "Renew \u2014 {3}{U}, Exile this card from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "0cb54f9b-069c-527d-8692-fd98150ff73b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74d4a57-0f66-4965-9ed7-f88a08aa1d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c74d4a57-0f66-4965-9ed7-f88a08aa1d15.jpg?1",
             "name": "Ambling Stormshell",
             "text": "Ward {2}\nWhenever this creature attacks, put three stun counters on it and draw three cards. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you cast a Turtle spell, untap this creature.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "b055ae1a-0c5e-56ab-87cf-3fcfe637d378",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b25843-1aa0-484a-b6c7-0c284fe7214a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b25843-1aa0-484a-b6c7-0c284fe7214a.jpg?1",
             "name": "Bewildering Blizzard",
             "text": "Draw three cards. Creatures your opponents control get -3/-0 until end of turn.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "cd712915-c5b5-5588-98d6-f286f4761798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f160d7-c832-4b83-8f2e-aaeb190add3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f160d7-c832-4b83-8f2e-aaeb190add3f.jpg?1",
             "name": "Constrictor Sage",
             "text": "When this creature enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nRenew \u2014 {2}{U}, Exile this card from your graveyard: Tap target creature an opponent controls and put a stun counter on it. Activate only as a sorcery.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "7fb4b23d-c157-5a10-bd3b-c0e37cd2ee0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "64dd7d14-facf-5db3-b5f7-8a165d5fc30f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/1/b1d21a9a-6b0c-4fbc-a427-81be885d326b.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Tap up to one target creature. Draw a card. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "5ce9463f-21d2-5fd3-b84c-2157b301bfec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9af3f1-711e-42ae-803a-1100eba3fb13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c9af3f1-711e-42ae-803a-1100eba3fb13.jpg?1",
             "name": "Dispelling Exhale",
             "text": "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)\nCounter target spell unless its controller pays {2}. If a Dragon was beheld, counter that spell unless its controller pays {4} instead.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "5fd67db4-87e9-5c6c-8a06-6feddd08fca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8810ebb4-9e51-46f0-a54a-a0b4d77b762a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8810ebb4-9e51-46f0-a54a-a0b4d77b762a.jpg?1",
             "name": "Dragonologist",
             "text": "When this creature enters, look at the top six cards of your library. You may reveal an instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nUntapped Dragons you control have hexproof.",
             "colours": [
@@ -1532,7 +1532,7 @@
         },
         {
             "id": "94744d82-42c2-5e0d-a48f-73ea19c4c65a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec7a31-1893-493c-926b-dc3a8a770e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ec7a31-1893-493c-926b-dc3a8a770e72.jpg?1",
             "name": "Dragonstorm Forecaster",
             "text": "{2}, {T}: Search your library for a card named Dragonstorm Globe or Boulderborn Dragon, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "71247423-507b-5a6a-b29d-1d0e33e54d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c4509-918e-44ba-aa13-1991199fee9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e91c4509-918e-44ba-aa13-1991199fee9f.jpg?1",
             "name": "Essence Anchor",
             "text": "At the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{T}: Create a 2/2 black Zombie Druid creature token. Activate only during your turn and only if a card left your graveyard this turn.",
             "colours": [
@@ -1599,7 +1599,7 @@
         },
         {
             "id": "016939df-525f-58dc-85e1-3edf49a5cb6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb0ba34-6904-4c17-a04d-ea4f12c7cf21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abb0ba34-6904-4c17-a04d-ea4f12c7cf21.jpg?1",
             "name": "Focus the Mind",
             "text": "This spell costs {2} less to cast if you've cast another spell this turn.\nDraw three cards, then discard a card.",
             "colours": [
@@ -1631,7 +1631,7 @@
         },
         {
             "id": "6b914eca-41af-5ecb-8573-f214e584e6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f7af08-ac05-45d0-979f-282943130c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f7af08-ac05-45d0-979f-282943130c61.jpg?1",
             "name": "Fresh Start",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -5/-0 and loses all abilities.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "df234add-39ff-5e67-b013-3ac29eb57150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75dccf7-2894-4c4a-b516-3eee73acddd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e75dccf7-2894-4c4a-b516-3eee73acddd3.jpg?1",
             "name": "Highspire Bell-Ringer",
             "text": "Flying\nThe second spell you cast each turn costs {1} less to cast.",
             "colours": [
@@ -1700,7 +1700,7 @@
         },
         {
             "id": "4cf6f52f-734d-562f-99f2-dcd4dbc31557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a84c3f8-0030-4653-880e-b2d19272f5fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a84c3f8-0030-4653-880e-b2d19272f5fa.jpg?1",
             "name": "Humbling Elder",
             "text": "Flash\nWhen this creature enters, target creature an opponent controls gets -2/-0 until end of turn.",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "5299374a-390d-5ada-a285-d25178b85062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13f117b-b8e4-48db-8ce9-5da9c7ce23a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13f117b-b8e4-48db-8ce9-5da9c7ce23a5.jpg?1",
             "name": "Iceridge Serpent",
             "text": "When this creature enters, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "c70bfdc4-39fc-569e-849c-f9602d6f7331",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fbc55-e8e9-4077-9532-1de7406baabf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190fbc55-e8e9-4077-9532-1de7406baabf.jpg?1",
             "name": "Kishla Trawlers",
             "text": "When this creature enters, you may exile a creature card from your graveyard. When you do, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1804,7 +1804,7 @@
         },
         {
             "id": "926dfc80-8c5c-5cb2-bf53-18cf2a0bff01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg?1",
             "name": "Marang River Regent // Coil and Catch",
             "text": "",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "aa811ede-dcbf-557e-9792-a03ec078b8bb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg?1",
             "name": "Marang River Regent // Coil and Catch",
             "text": "",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "22247f86-2612-5cea-81d7-8bf7a1c00b50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df17423-9fdd-4432-8660-1d267c685595.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df17423-9fdd-4432-8660-1d267c685595.jpg?1",
             "name": "Naga Fleshcrafter",
             "text": "You may have this creature enter as a copy of any creature on the battlefield.\nRenew \u2014 {2}{U}, Exile this card from your graveyard: Put a +1/+1 counter on target nonlegendary creature you control. Each other creature you control becomes a copy of that creature until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -1909,7 +1909,7 @@
         },
         {
             "id": "33da33e2-ff60-5206-97af-b5a0241b2fe0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4fc7ec-05f5-479a-8fbb-31e12a67b57e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff4fc7ec-05f5-479a-8fbb-31e12a67b57e.jpg?1",
             "name": "Ringing Strike Mastery",
             "text": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nEnchanted creature has \"{5}: Untap this creature.\"",
             "colours": [
@@ -1943,7 +1943,7 @@
         },
         {
             "id": "bd3efd17-1da9-5609-9c34-00fae8138145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043c25d5-13ee-4cab-98d5-fb89db9cf6e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043c25d5-13ee-4cab-98d5-fb89db9cf6e3.jpg?1",
             "name": "Riverwalk Technique",
             "text": "Choose one \u2014\n\u2022 The owner of target nonland permanent puts it on their choice of the top or bottom of their library.\n\u2022 Counter target noncreature spell.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "0663aff5-789c-5dac-90a7-281f3859efcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4c96-684b-4b14-bd21-6799da2e1fa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/455f4c96-684b-4b14-bd21-6799da2e1fa7.jpg?1",
             "name": "Roiling Dragonstorm",
             "text": "When this enchantment enters, draw two cards, then discard a card.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -2010,7 +2010,7 @@
         },
         {
             "id": "4d3597fb-92c7-5a6e-a684-1e647019e3a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c5b96-bac6-449b-a2bd-cb43750d3911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670c5b96-bac6-449b-a2bd-cb43750d3911.jpg?1",
             "name": "Sibsig Appraiser",
             "text": "When this creature enters, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -2045,7 +2045,7 @@
         },
         {
             "id": "3de37533-6d41-551e-a35c-d88603fa878d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b3b131-704a-4586-84f8-db465cd4a277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6b3b131-704a-4586-84f8-db465cd4a277.jpg?1",
             "name": "Snowmelt Stag",
             "text": "Vigilance\nDuring your turn, this creature has base power and toughness 5/2.\n{5}{U}{U}: This creature can't be blocked this turn.",
             "colours": [
@@ -2080,7 +2080,7 @@
         },
         {
             "id": "09ad11fa-bec7-59e0-8cbc-f5caf65800ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e732a-1ffd-463d-92c2-26187659cfc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee4e732a-1ffd-463d-92c2-26187659cfc3.jpg?1",
             "name": "Spectral Denial",
             "text": "This spell costs {1} less to cast for each creature you control with power 4 or greater.\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "81702e04-ec5d-51df-9ae1-8edb49ad70df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6289251-17e4-4987-96b9-2fb1a8f90e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6289251-17e4-4987-96b9-2fb1a8f90e2a.jpg?1",
             "name": "Stillness in Motion",
             "text": "At the beginning of your upkeep, mill three cards. Then if your library has no cards in it, exile this enchantment and put five cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "d0bbfe65-d93a-5227-b51d-1035e7bcf073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693d631-05f6-414d-9e49-6385746e8960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693d631-05f6-414d-9e49-6385746e8960.jpg?1",
             "name": "Taigam, Master Opportunist",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, copy it, then exile the spell you cast with four time counters on it. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, they remove a time counter. When the last is removed, they may play it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "d0c0963b-1c1c-57bd-9dd1-1c3c44c56ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ef698e-5466-43bd-985d-020f2e5d8205.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ef698e-5466-43bd-985d-020f2e5d8205.jpg?1",
             "name": "Temur Devotee",
             "text": "Defender\n{1}: Add {G}, {U}, or {R}. Activate only once each turn.",
             "colours": [
@@ -2222,7 +2222,7 @@
         },
         {
             "id": "3db33e63-601d-55c4-b465-e9c6c1e53e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48180a-ccac-469f-938d-c050821d0160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc48180a-ccac-469f-938d-c050821d0160.jpg?1",
             "name": "Unending Whisper",
             "text": "Draw a card.\nHarmonize {5}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -2254,7 +2254,7 @@
         },
         {
             "id": "534555e9-9c0a-5e87-87cc-e2bffc8055ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722716df-9cea-40a7-924b-c28497e227e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722716df-9cea-40a7-924b-c28497e227e6.jpg?1",
             "name": "Ureni's Rebuff",
             "text": "Return target creature to its owner's hand.\nHarmonize {5}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -2286,7 +2286,7 @@
         },
         {
             "id": "4bb854ef-2423-53c6-a556-e9107053a816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcccfd7b-2846-4552-a89a-2b868bc9ab20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcccfd7b-2846-4552-a89a-2b868bc9ab20.jpg?1",
             "name": "Veteran Ice Climber",
             "text": "Vigilance\nThis creature can't be blocked.\nWhenever this creature attacks, up to one target player mills cards equal to this creature's power. (They put that many cards from the top of their library into their graveyard.)",
             "colours": [
@@ -2321,7 +2321,7 @@
         },
         {
             "id": "d32e3ca2-2918-5c4c-b6b9-9d14d861190a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de7dca-0231-4407-86a0-c7fc95f5aaa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71de7dca-0231-4407-86a0-c7fc95f5aaa0.jpg?1",
             "name": "Wingblade Disciple",
             "text": "Flying\nFlurry \u2014 Whenever you cast your second spell each turn, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "b11a6f7f-5a67-50ca-b3ac-5836e92f25bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a0e24-c332-4558-bb60-f5504ddde88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339a0e24-c332-4558-bb60-f5504ddde88c.jpg?1",
             "name": "Wingspan Stride",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\n{2}{U}: Return this Aura to its owner's hand.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "11580597-fe19-520c-bcde-61cd9d1a675a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9367c-f50c-4568-aa63-6760c44ecaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d9367c-f50c-4568-aa63-6760c44ecaeb.jpg?1",
             "name": "Winternight Stories",
             "text": "Draw three cards. Then discard two cards unless you discard a creature card.\nHarmonize {4}{U} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "3ef6f351-6508-5897-9d63-4a56b550ceb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66555946-e747-46fa-b1ac-b103a8edcd93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66555946-e747-46fa-b1ac-b103a8edcd93.jpg?1",
             "name": "Abzan Devotee",
             "text": "{1}: Add {W}, {B}, or {G}. Activate only once each turn.\n{2}{B}: Return this card from your graveyard to your hand.",
             "colours": [
@@ -2461,7 +2461,7 @@
         },
         {
             "id": "8ce55b02-57d2-5f8b-b9fc-62d59cc373a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb13a34b-6ac8-47cb-9e91-47106a585fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb13a34b-6ac8-47cb-9e91-47106a585fc1.jpg?1",
             "name": "Adorned Crocodile",
             "text": "When this creature dies, create a 2/2 black Zombie Druid creature token.\nRenew \u2014 {B}, Exile this card from your graveyard: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -2495,7 +2495,7 @@
         },
         {
             "id": "5e2a5ac0-b602-58cd-8f06-ff4e75efbdaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993ade84-031f-4a3e-bd68-55f61b559248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993ade84-031f-4a3e-bd68-55f61b559248.jpg?1",
             "name": "Aggressive Negotiations",
             "text": "Target opponent reveals their hand. You choose a nonland card from it and exile that card. Put a +1/+1 counter on up to one target creature you control.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "0f552c64-f190-5137-b416-b310ceee037c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d305609-64f8-4f3f-bf67-cd5257f0d01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d305609-64f8-4f3f-bf67-cd5257f0d01e.jpg?1",
             "name": "Alchemist's Assistant",
             "text": "Lifelink\nRenew \u2014 {1}{B}, Exile this card from your graveyard: Put a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "f46400e2-8d3f-5720-87b5-83e25aa88163",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9262bf6-df6a-446c-ba70-18270a09842d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9262bf6-df6a-446c-ba70-18270a09842d.jpg?1",
             "name": "Alesha's Legacy",
             "text": "Target creature you control gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -2593,7 +2593,7 @@
         },
         {
             "id": "54cbdf55-0815-5111-ae57-989521583726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5397366-151f-46b0-b9b2-fa4d5bd892d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5397366-151f-46b0-b9b2-fa4d5bd892d8.jpg?1",
             "name": "Avenger of the Fallen",
             "text": "Deathtouch\nMobilize X, where X is the number of creature cards in your graveyard. (Whenever this creature attacks, create X tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)",
             "colours": [
@@ -2630,7 +2630,7 @@
         },
         {
             "id": "5897a44b-b2c0-5e6d-b3ca-e15c926852fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488152ce-2048-4ccb-b2d6-b9628958286f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488152ce-2048-4ccb-b2d6-b9628958286f.jpg?1",
             "name": "Caustic Exhale",
             "text": "As an additional cost to cast this spell, behold a Dragon or pay {1}. (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\nTarget creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "00d93aa3-4e25-5022-82f8-65a542efd0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a2d395-26d6-4eb2-9e8c-ed7dbbd3a8f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2a2d395-26d6-4eb2-9e8c-ed7dbbd3a8f5.jpg?1",
             "name": "Corroding Dragonstorm",
             "text": "When this enchantment enters, each opponent loses 2 life and you gain 2 life. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "a2951dcd-2e13-5d6c-99a9-29003cc65087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6852b4d5-74e0-44ba-ba44-20aa91e3c4c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6852b4d5-74e0-44ba-ba44-20aa91e3c4c8.jpg?1",
             "name": "Cruel Truths",
             "text": "Surveil 2, then draw two cards. You lose 2 life. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "1e4a898c-eb1d-56cc-8f55-46ac93efcb43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119bb72d-aed9-47dc-9285-7bc836cc3776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119bb72d-aed9-47dc-9285-7bc836cc3776.jpg?1",
             "name": "Delta Bloodflies",
             "text": "Flying\nWhenever this creature attacks, if you control a creature with a counter on it, each opponent loses 1 life.",
             "colours": [
@@ -2762,7 +2762,7 @@
         },
         {
             "id": "fa293b8d-3b65-5ce3-a99e-dad6261e62dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc6fd0-42bc-4e8b-96bc-69a631ba7106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccbc6fd0-42bc-4e8b-96bc-69a631ba7106.jpg?1",
             "name": "Desperate Measures",
             "text": "Target creature gets +1/-1 until end of turn. When it dies under your control this turn, draw two cards.",
             "colours": [
@@ -2794,7 +2794,7 @@
         },
         {
             "id": "900cac44-2838-54bd-a05f-55b123f2093d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6004ff-4180-4332-8b51-960f8c7521d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6004ff-4180-4332-8b51-960f8c7521d9.jpg?1",
             "name": "Dragon's Prey",
             "text": "This spell costs {2} more to cast if it targets a Dragon.\nDestroy target creature.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "b2bbcbbd-6695-5c01-9b4f-408c0d5d880c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Flying, deathtouch\nWhen this creature enters, exile up to two target cards from a single graveyard.",
             "colours": [
@@ -2862,7 +2862,7 @@
         },
         {
             "id": "0120acd4-e5ae-57eb-87fd-c1d8599a2e22",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a147b94f-dfcf-44ce-8a73-b2fe6c4efc0e.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Put a +1/+1 counter on up to one target creature. Draw a card. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "ef01dc6e-35e8-5e01-a70f-b6b6189580c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05ad909-8860-473b-9a30-a322f7670b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f05ad909-8860-473b-9a30-a322f7670b32.jpg?1",
             "name": "Gurmag Rakshasa",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, target creature an opponent controls gets -2/-2 until end of turn and target creature you control gets +2/+2 until end of turn.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "894620e7-f101-5f31-9a07-282a2233b3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53adf93-2db5-4087-a2dc-c8f53401d700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e53adf93-2db5-4087-a2dc-c8f53401d700.jpg?1",
             "name": "Hundred-Battle Veteran",
             "text": "As long as there are three or more different kinds of counters among creatures you control, this creature gets +2/+4.\nYou may cast this card from your graveyard. If you do, it enters with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
             "colours": [
@@ -2967,7 +2967,7 @@
         },
         {
             "id": "28943f30-e152-53f4-83d8-d370c4684837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177ef64-28bf-4acf-b1f1-c1408f03c411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2177ef64-28bf-4acf-b1f1-c1408f03c411.jpg?1",
             "name": "Kin-Tree Nurturer",
             "text": "Lifelink\nWhen this creature enters, it endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -3002,7 +3002,7 @@
         },
         {
             "id": "986e47d9-6713-5c38-9adf-2f4629b9c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc66680f-24ab-433a-8197-feac3a174075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc66680f-24ab-433a-8197-feac3a174075.jpg?1",
             "name": "Krumar Initiate",
             "text": "{X}{B}, {T}, Pay X life: This creature endures X. Activate only as a sorcery. (Put X +1/+1 counters on it or create an X/X white Spirit creature token.)",
             "colours": [
@@ -3037,7 +3037,7 @@
         },
         {
             "id": "a120f078-8422-5c90-b484-5287c4ad403c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648debd9-d4cf-4788-8882-f1601a3d87f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648debd9-d4cf-4788-8882-f1601a3d87f5.jpg?1",
             "name": "Nightblade Brigade",
             "text": "Deathtouch\nMobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nWhen this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "a5f35eb4-bbc3-5098-a5eb-edf804ee2607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c93a0f6-5e50-4dda-9ff6-da741fb839ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c93a0f6-5e50-4dda-9ff6-da741fb839ff.jpg?1",
             "name": "Qarsi Revenant",
             "text": "Flying, deathtouch, lifelink\nRenew \u2014 {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch counter, and a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -3109,7 +3109,7 @@
         },
         {
             "id": "afa58949-29f5-5e73-a5a1-d725f320dfd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31276460-fa9d-47da-85c5-c4baa8074d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31276460-fa9d-47da-85c5-c4baa8074d0d.jpg?1",
             "name": "Rot-Curse Rakshasa",
             "text": "Trample\nDecayed (This creature can't block. When it attacks, sacrifice it at end of combat.)\nRenew \u2014 {X}{B}{B}, Exile this card from your graveyard: Put a decayed counter on each of X target creatures. Activate only as a sorcery.",
             "colours": [
@@ -3145,7 +3145,7 @@
         },
         {
             "id": "d52e5552-338f-5e19-a813-4270dff6da25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f529a2e-5102-492e-84ab-68541d83b5a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f529a2e-5102-492e-84ab-68541d83b5a3.jpg?1",
             "name": "Salt Road Skirmish",
             "text": "Destroy target creature. Create two 1/1 red Warrior creature tokens. They gain haste until end of turn. Sacrifice them at the beginning of the next end step.",
             "colours": [
@@ -3177,7 +3177,7 @@
         },
         {
             "id": "4dd1a262-3f7d-5598-bdf3-c09043064ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4bfebe-f10f-44bd-9368-33e273ba5a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4bfebe-f10f-44bd-9368-33e273ba5a55.jpg?1",
             "name": "Sandskitter Outrider",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, it endures 2. (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)",
             "colours": [
@@ -3212,7 +3212,7 @@
         },
         {
             "id": "b30a3061-ce20-54eb-b25c-7520aa76f8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg?1",
             "name": "Scavenger Regent // Exude Toxin",
             "text": "",
             "colours": [
@@ -3246,7 +3246,7 @@
         },
         {
             "id": "4ab899da-900a-576c-822c-ba6ac481381e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg?1",
             "name": "Scavenger Regent // Exude Toxin",
             "text": "",
             "colours": [
@@ -3280,7 +3280,7 @@
         },
         {
             "id": "8903ebca-b7c9-5e4a-a80f-b840c4f8e22f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9f2a62-1c61-4d2e-86d9-18cd84c31748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a9f2a62-1c61-4d2e-86d9-18cd84c31748.jpg?1",
             "name": "The Sibsig Ceremony",
             "text": "Creature spells you cast cost {2} less to cast.\nWhenever a creature you control enters, if you cast it, destroy that creature, then create a 2/2 black Zombie Druid creature token.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "845714ec-53bc-57f6-9066-c430842f43c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47374d23-662b-4ba7-a94f-37c9bc759cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47374d23-662b-4ba7-a94f-37c9bc759cc6.jpg?1",
             "name": "Sidisi, Regent of the Mire",
             "text": "{T}, Sacrifice a creature you control with mana value X other than Sidisi: Return target creature card with mana value X plus 1 from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "9aeded27-70dd-560c-a5f7-4f8a726630f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cb5599-7d2c-48e9-978b-902a01a74bde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37cb5599-7d2c-48e9-978b-902a01a74bde.jpg?1",
             "name": "Sinkhole Surveyor",
             "text": "Flying\nWhenever this creature attacks, you lose 1 life and this creature endures 1. (Put a +1/+1 counter on it or create a 1/1 white Spirit creature token.)",
             "colours": [
@@ -3393,7 +3393,7 @@
         },
         {
             "id": "4b5578c9-d5f6-50a9-8c9f-d8bc4cd0af7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95617742-548d-464a-bb89-a858ffa9018f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95617742-548d-464a-bb89-a858ffa9018f.jpg?1",
             "name": "Strategic Betrayal",
             "text": "Target opponent exiles a creature they control and their graveyard.",
             "colours": [
@@ -3427,7 +3427,7 @@
         },
         {
             "id": "d98af773-ed46-5b78-8f36-cf9cddcbeafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab5e71e-dc8d-4ed8-bcef-6497177c4a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab5e71e-dc8d-4ed8-bcef-6497177c4a9d.jpg?1",
             "name": "Unburied Earthcarver",
             "text": "{2}, Sacrifice another creature: Put a +1/+1 counter on this creature.",
             "colours": [
@@ -3462,7 +3462,7 @@
         },
         {
             "id": "bc64c117-3407-53e5-972a-37409853e2b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6394b125-21a8-4439-9958-94b76684138e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6394b125-21a8-4439-9958-94b76684138e.jpg?1",
             "name": "Unrooted Ancestor",
             "text": "Flash\n{1}, Sacrifice another creature: This creature gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "20e9643e-2123-573a-84e0-bc4b69516901",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4e985-facd-47e6-b680-3023c82c2957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a4e985-facd-47e6-b680-3023c82c2957.jpg?1",
             "name": "Venerated Stormsinger",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nWhenever this creature or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3532,7 +3532,7 @@
         },
         {
             "id": "c38a53e5-62b6-5a9d-b438-bcecde7ec4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9430dd-f583-400d-808a-64e2b5fa54f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e9430dd-f583-400d-808a-64e2b5fa54f1.jpg?1",
             "name": "Wail of War",
             "text": "Choose one \u2014\n\u2022 Creatures target opponent controls get -1/-1 until end of turn.\n\u2022 Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "363e307a-d1a6-5812-823d-6cc70273be10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc18edc-01d8-4a7e-a87b-a854e50aa75e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc18edc-01d8-4a7e-a87b-a854e50aa75e.jpg?1",
             "name": "Worthy Cost",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nExile target creature or planeswalker.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "b1befaad-d222-520e-aaf8-e284d0535c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e65d487-705a-4c3b-9bb6-69351e5dae81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e65d487-705a-4c3b-9bb6-69351e5dae81.jpg?1",
             "name": "Yathan Tombguard",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever a creature you control with a counter on it deals combat damage to a player, you draw a card and you lose 1 life.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "4d83e66d-0c88-5331-9d1f-25e33333bba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c2a069-7553-4879-abfb-b2aa3349e4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c2a069-7553-4879-abfb-b2aa3349e4b8.jpg?1",
             "name": "Breaching Dragonstorm",
             "text": "When this enchantment enters, exile cards from the top of your library until you exile a nonland card. You may cast it without paying its mana cost if that spell's mana value is 8 or less. If you don't, put that card into your hand.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "0bd1269f-ac1b-536b-9f98-ec32bc8e0634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24204881-690c-4043-8771-20cb93385072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24204881-690c-4043-8771-20cb93385072.jpg?1",
             "name": "Channeled Dragonfire",
             "text": "Channeled Dragonfire deals 2 damage to any target.\nHarmonize {5}{R}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "914298c5-4bfa-55e8-b398-25e109183c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg?1",
             "name": "Cori-Steel Cutter",
             "text": "Equipped creature gets +1/+1 and has trample and haste.\nFlurry \u2014 Whenever you cast your second spell each turn, create a 1/1 white Monk creature token with prowess. You may attach this Equipment to it. (Whenever you cast a noncreature spell, the token gets +1/+1 until end of turn.)\nEquip {1}{R}",
             "colours": [
@@ -3735,7 +3735,7 @@
         },
         {
             "id": "e77b3601-57bf-5e9f-a6d5-93d3e8d2ea76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9c673-37b4-48ed-a9ea-13f8e3e6c47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf9c673-37b4-48ed-a9ea-13f8e3e6c47b.jpg?1",
             "name": "Devoted Duelist",
             "text": "Haste\nFlurry \u2014 Whenever you cast your second spell each turn, this creature deals 1 damage to each opponent.",
             "colours": [
@@ -3770,7 +3770,7 @@
         },
         {
             "id": "51c8c874-9bfa-5af6-8570-b6ab9d63ba2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5674f9-22b2-45f9-902d-4fd245485c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5674f9-22b2-45f9-902d-4fd245485c60.jpg?1",
             "name": "Dracogenesis",
             "text": "You may cast Dragon spells without paying their mana costs.",
             "colours": [
@@ -3806,7 +3806,7 @@
         },
         {
             "id": "997f1a78-c793-5f29-85be-6a5b3c4bf2e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ba6d74-c6be-4a5e-8859-b791bb6b8f51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ba6d74-c6be-4a5e-8859-b791bb6b8f51.jpg?1",
             "name": "Equilibrium Adept",
             "text": "When this creature enters, exile the top card of your library. Until the end of your next turn, you may play that card.\nFlurry \u2014 Whenever you cast your second spell each turn, this creature gains double strike until end of turn.",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "1e058df0-8555-5e70-8ab3-855ece3f0388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dc1bf4-a135-449f-848f-361a5360fae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32dc1bf4-a135-449f-848f-361a5360fae1.jpg?1",
             "name": "Fire-Rim Form",
             "text": "Flash\nEnchant creature\nWhen this Aura enters, enchanted creature gains first strike until end of turn.\nEnchanted creature gets +2/+0.",
             "colours": [
@@ -3875,7 +3875,7 @@
         },
         {
             "id": "e5aecc5e-d228-5a3c-a2c0-e029dbd8b994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1971fd6c-0a1c-41b2-93a6-886a176fbb73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1971fd6c-0a1c-41b2-93a6-886a176fbb73.jpg?1",
             "name": "Fleeting Effigy",
             "text": "Haste\nAt the beginning of your end step, return this creature to its owner's hand. (Return it only if it's on the battlefield.)\n{2}{R}: This creature gets +2/+0 until end of turn.",
             "colours": [
@@ -3909,7 +3909,7 @@
         },
         {
             "id": "1007ad24-7288-5165-a8a0-19d983ae9eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbc8b-2bf8-478e-a541-f8019d150054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3abbc8b-2bf8-478e-a541-f8019d150054.jpg?1",
             "name": "Iridescent Tiger",
             "text": "When this creature enters, if you cast it, add {W}{U}{B}{R}{G}.",
             "colours": [
@@ -3947,7 +3947,7 @@
         },
         {
             "id": "4db22f04-9204-590f-9f1e-6702f01ef8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f31f9c-7149-4608-9b18-b3530a2efd4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f31f9c-7149-4608-9b18-b3530a2efd4a.jpg?1",
             "name": "Jeskai Devotee",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, this creature gets +1/+1 until end of turn.\n{1}: Add {U}, {R}, or {W}. Activate only once each turn.",
             "colours": [
@@ -3984,7 +3984,7 @@
         },
         {
             "id": "f7d05183-821d-57ff-ac3d-210dee74c890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b3aec8-d931-4c7f-86b5-1e7dfb717b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b3aec8-d931-4c7f-86b5-1e7dfb717b59.jpg?1",
             "name": "Magmatic Hellkite",
             "text": "Flying\nWhen this creature enters, destroy target nonbasic land an opponent controls. Its controller searches their library for a basic land card, puts it onto the battlefield tapped with a stun counter on it, then shuffles. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "ff94af76-5353-599a-9a44-886a205cec62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf4c9dd-0546-41ac-a7ba-0bc312fef31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baf4c9dd-0546-41ac-a7ba-0bc312fef31e.jpg?1",
             "name": "Meticulous Artisan",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
             "colours": [
@@ -4055,7 +4055,7 @@
         },
         {
             "id": "df6caa4f-d16e-5115-9ea5-11962a8b64cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab95aab-a4bf-4131-83a0-2c138b6f20c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab95aab-a4bf-4131-83a0-2c138b6f20c3.jpg?1",
             "name": "Molten Exhale",
             "text": "You may cast this spell as though it had flash if you behold a Dragon as an additional cost to cast it. (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\nMolten Exhale deals 4 damage to target creature or planeswalker.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "694dd7d6-68c3-5ff4-a95b-daf91496a2fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5098bd73-d51c-4db4-bf06-fd4854089d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5098bd73-d51c-4db4-bf06-fd4854089d37.jpg?1",
             "name": "Narset's Rebuke",
             "text": "Narset's Rebuke deals 5 damage to target creature. Add {U}{R}{W}. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4121,7 +4121,7 @@
         },
         {
             "id": "3377808a-5028-5425-a1b5-f21bebf92a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7af85f-354e-468a-990b-bd774e68240f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7af85f-354e-468a-990b-bd774e68240f.jpg?1",
             "name": "Overwhelming Surge",
             "text": "Choose one or both \u2014\n\u2022 Overwhelming Surge deals 3 damage to target creature.\n\u2022 Destroy target noncreature artifact.",
             "colours": [
@@ -4153,7 +4153,7 @@
         },
         {
             "id": "44cb3635-ead0-555b-92a7-8aa58ea84507",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056136a8-84be-477c-b654-63238fb8236e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/056136a8-84be-477c-b654-63238fb8236e.jpg?1",
             "name": "Rescue Leopard",
             "text": "Whenever this creature becomes tapped, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4187,7 +4187,7 @@
         },
         {
             "id": "42fe6060-40d9-5ba9-9d2f-1881805ce2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af19ce8-bc0c-420c-9e3b-9059b4df32cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af19ce8-bc0c-420c-9e3b-9059b4df32cb.jpg?1",
             "name": "Reverberating Summons",
             "text": "At the beginning of each combat, if you've cast two or more spells this turn, this enchantment becomes a 3/3 Monk creature with haste in addition to its other types until end of turn.\n{1}{R}, Discard your hand, Sacrifice this enchantment: Draw two cards.",
             "colours": [
@@ -4219,7 +4219,7 @@
         },
         {
             "id": "a496e8ba-a448-58c1-9332-973fd04d7027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2200646-7b7c-489d-bbae-16b03e1d7fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2200646-7b7c-489d-bbae-16b03e1d7fb2.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token. (To behold a Dragon, choose a Dragon you control or reveal a Dragon card from your hand.)\nWhenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "ad93fbdf-f66b-5566-9d1b-172a091b876d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7818d28-b9a5-4341-9adc-666070b8878d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7818d28-b9a5-4341-9adc-666070b8878d.jpg?1",
             "name": "Seize Opportunity",
             "text": "Choose one \u2014\n\u2022 Exile the top two cards of your library. Until the end of your next turn, you may play those cards.\n\u2022 Up to two target creatures each get +2/+1 until end of turn.",
             "colours": [
@@ -4292,7 +4292,7 @@
         },
         {
             "id": "58083b32-90ea-5c18-b8f7-6f22308f578a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66940466-8e9d-4a85-bfb0-e92189b7a121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66940466-8e9d-4a85-bfb0-e92189b7a121.jpg?1",
             "name": "Shock Brigade",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nMobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "d859d0c0-142c-5f69-a3dd-9b1995fb2f4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a10342d-ca04-4d1e-bca9-79f531951a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a10342d-ca04-4d1e-bca9-79f531951a16.jpg?1",
             "name": "Shocking Sharpshooter",
             "text": "Reach\nWhenever another creature you control enters, this creature deals 1 damage to target opponent.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "8093c4a6-1844-5d2b-9a98-b0e0884701bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4ab2a-a06a-4768-b5e1-e1def957d7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37d4ab2a-a06a-4768-b5e1-e1def957d7f4.jpg?1",
             "name": "Stadium Headliner",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\n{1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control to target creature.",
             "colours": [
@@ -4399,7 +4399,7 @@
         },
         {
             "id": "9709ca48-4092-5e8b-8e3e-c663bccec9af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac43386-bd32-425c-8776-cec00b064cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ac43386-bd32-425c-8776-cec00b064cbc.jpg?1",
             "name": "Stormscale Scion",
             "text": "Flying\nOther Dragons you control get +1/+1.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. Copies become tokens.)",
             "colours": [
@@ -4435,7 +4435,7 @@
         },
         {
             "id": "62d2d50b-77ba-5cca-9558-5c5ec1c9e3d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Flying, haste\n{1}{R}: This creature gets +1/+0 until end of turn.",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "1205d7f8-2685-55b5-a2b4-099ffa187b46",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ec92c44-7cf0-48a5-a3ca-bc633496d887.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Discard a card. If you do, draw two cards. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "9e49031e-4985-5494-abb4-e322feec7c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cba0b1-7c22-4e51-b9cf-5bf01e67a222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3cba0b1-7c22-4e51-b9cf-5bf01e67a222.jpg?1",
             "name": "Summit Intimidator",
             "text": "Reach\nWhen this creature enters, target creature can't block this turn.",
             "colours": [
@@ -4541,7 +4541,7 @@
         },
         {
             "id": "3c9634a4-1105-5360-b8cc-2499fd66b3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1a2f2-526d-4b2c-985b-0acfdc21a2ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8f1a2f2-526d-4b2c-985b-0acfdc21a2ee.jpg?1",
             "name": "Sunset Strikemaster",
             "text": "{T}: Add {R}.\n{2}{R}, {T}, Sacrifice this creature: It deals 6 damage to target creature with flying.",
             "colours": [
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "35630003-15d5-5c62-8936-13dbd9f1aede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e96b34-b1c4-4647-a38e-2cf1aedaaace.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99e96b34-b1c4-4647-a38e-2cf1aedaaace.jpg?1",
             "name": "Tersa Lightshatter",
             "text": "Haste\nWhen Tersa Lightshatter enters, discard up to two cards, then draw that many cards.\nWhenever Tersa Lightshatter attacks, if there are seven or more cards in your graveyard, exile a card at random from your graveyard. You may play that card this turn.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "9265667c-9d77-5f33-a70f-a070db00a117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688d8e93-d071-4089-9ef9-565ac4ae9ae0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688d8e93-d071-4089-9ef9-565ac4ae9ae0.jpg?1",
             "name": "Twin Bolt",
             "text": "Twin Bolt deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "cf7aa213-1bcd-592d-8207-eb55fb8ee3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049acc79-1d68-410f-a081-88a7d40e823a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/049acc79-1d68-410f-a081-88a7d40e823a.jpg?1",
             "name": "Underfoot Underdogs",
             "text": "When this creature enters, create a 1/1 red Goblin creature token.\n{1}, {T}: Target creature you control with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -4682,7 +4682,7 @@
         },
         {
             "id": "2af0e309-78f9-563b-9f11-234f5eee67a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f5e5e-d87f-4aee-84e3-28afe8e21591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/204f5e5e-d87f-4aee-84e3-28afe8e21591.jpg?1",
             "name": "Unsparing Boltcaster",
             "text": "When this creature enters, it deals 5 damage to target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "0fbc403f-68e0-5e40-8263-6a7cdb8aaac1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7f0413-c009-4c08-b877-9c1b776cbf26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd7f0413-c009-4c08-b877-9c1b776cbf26.jpg?1",
             "name": "War Effort",
             "text": "Creatures you control get +1/+0.\nWhenever you attack, create a 1/1 red Warrior creature token that's tapped and attacking. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "5e66aa98-36e0-5c51-b5f6-1ae98b07a30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8c6f5-6135-428e-8476-1751f82623f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc8c6f5-6135-428e-8476-1751f82623f9.jpg?1",
             "name": "Wild Ride",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nHarmonize {4}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -4781,7 +4781,7 @@
         },
         {
             "id": "7103934d-6cff-5c0c-8a80-f0617c47a3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa3501-5738-4063-a7f4-51d2600b0041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1aa3501-5738-4063-a7f4-51d2600b0041.jpg?1",
             "name": "Zurgo's Vanguard",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nThis creature's power is equal to the number of creatures you control.",
             "colours": [
@@ -4816,7 +4816,7 @@
         },
         {
             "id": "a81cb159-e6dd-576d-aacb-e672054798b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57695a9b-8f72-4ccc-a946-5d5037b09b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57695a9b-8f72-4ccc-a946-5d5037b09b8f.jpg?1",
             "name": "Ainok Wayfarer",
             "text": "When this creature enters, mill three cards. You may put a land card from among them into your hand. If you don't, put a +1/+1 counter on this creature. (To mill three cards, put the top three cards of your library into your graveyard.)",
             "colours": [
@@ -4851,7 +4851,7 @@
         },
         {
             "id": "79d1d88e-a603-5f4f-a399-709a97289ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4f502-86a9-49fb-9cb9-7918d13c5313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1a4f502-86a9-49fb-9cb9-7918d13c5313.jpg?1",
             "name": "Attuned Hunter",
             "text": "Trample\nWhenever one or more cards leave your graveyard during your turn, put a +1/+1 counter on this creature.",
             "colours": [
@@ -4886,7 +4886,7 @@
         },
         {
             "id": "4af6371b-944b-598e-89e0-265bca597d26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg?1",
             "name": "Bloomvine Regent // Claim Territory",
             "text": "",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "831bd9e8-299e-594a-a38e-7df008fff612",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg?1",
             "name": "Bloomvine Regent // Claim Territory",
             "text": "",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "32283932-026d-5cbb-aec6-10c6e91e0f19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c51dcdab-38ee-4804-8859-09adc353c182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c51dcdab-38ee-4804-8859-09adc353c182.jpg?1",
             "name": "Champion of Dusan",
             "text": "Trample\nRenew \u2014 {1}{G}, Exile this card from your graveyard: Put a +1/+1 counter and a trample counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "6ec5cd9b-aea6-54f0-8332-bc71ff98f5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f5cee-a501-4658-bd4d-7a044bf1ccbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/276f5cee-a501-4658-bd4d-7a044bf1ccbc.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen this creature enters, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "87dfbf12-7a6b-5720-b7b9-ac5826ba4568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074b1e00-45bb-4436-8f5e-058512b2d08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/074b1e00-45bb-4436-8f5e-058512b2d08a.jpg?1",
             "name": "Dragon Sniper",
             "text": "Vigilance, reach, deathtouch",
             "colours": [
@@ -5062,7 +5062,7 @@
         },
         {
             "id": "09d44499-6796-5ff1-9aa5-f9517ea63776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d634087-77ba-4543-aa7a-8a3774d69cd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d634087-77ba-4543-aa7a-8a3774d69cd7.jpg?1",
             "name": "Dragonbroods' Relic",
             "text": "{T}, Tap an untapped creature you control: Add one mana of any color.\n{3}{W}{U}{B}{R}{G}, Sacrifice this artifact: Create a 4/4 Dragon creature token named Reliquary Dragon that's all colors. It has flying, lifelink, and \"When this token enters, it deals 3 damage to any target.\" Activate only as a sorcery.",
             "colours": [
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "03619678-7720-578e-b980-96beb524ced1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98ecc96-f557-479a-8685-2b5487d5b407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b98ecc96-f557-479a-8685-2b5487d5b407.jpg?1",
             "name": "Dusyut Earthcarver",
             "text": "Reach\nWhen this creature enters, it endures 3. (Put three +1/+1 counters on it or create a 3/3 white Spirit creature token.)",
             "colours": [
@@ -5133,7 +5133,7 @@
         },
         {
             "id": "4dab92ca-65dd-540b-bf3c-070d2b8c376b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddd4477-f8c9-4d05-9177-f8344ba8f40b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4ddd4477-f8c9-4d05-9177-f8344ba8f40b.jpg?1",
             "name": "Encroaching Dragonstorm",
             "text": "When this enchantment enters, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -5168,7 +5168,7 @@
         },
         {
             "id": "71b4fc95-7bf8-5ab7-9a42-88048c9c4ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8e8f-3ef6-4339-8c66-68c5aca4867a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8e8f-3ef6-4339-8c66-68c5aca4867a.jpg?1",
             "name": "Formation Breaker",
             "text": "Creatures with power less than this creature's power can't block it.\nAs long as you control a creature with a counter on it, this creature gets +1/+2.",
             "colours": [
@@ -5202,7 +5202,7 @@
         },
         {
             "id": "76bdf413-e394-57ef-8eac-287016377485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c7713-b3a9-4685-b1d3-623d35b62365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88c7713-b3a9-4685-b1d3-623d35b62365.jpg?1",
             "name": "Herd Heirloom",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\n{T}: Until end of turn, target creature you control with power 4 or greater gains trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -5236,7 +5236,7 @@
         },
         {
             "id": "532f9a7d-25f1-5ea3-aa86-b8ccb35811ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8fee37-a050-4329-8b10-46d150e7a95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8fee37-a050-4329-8b10-46d150e7a95e.jpg?1",
             "name": "Heritage Reclamation",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile up to one target card from a graveyard. Draw a card.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "575ba3a6-243d-5380-ab73-f15049bc6fa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c642d6ac-f0f0-4b4c-a7ee-50631531f6d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c642d6ac-f0f0-4b4c-a7ee-50631531f6d1.jpg?1",
             "name": "Inspirited Vanguard",
             "text": "Whenever this creature enters or attacks, it endures 2. (Put two +1/+1 counters on it or create a 2/2 white Spirit creature token.)",
             "colours": [
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "35e9c2d7-1656-5560-a370-840c0a11a662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d218831-2a41-46a3-8e9d-93462cae5cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d218831-2a41-46a3-8e9d-93462cae5cab.jpg?1",
             "name": "Knockout Maneuver",
             "text": "Put a +1/+1 counter on target creature you control, then it deals damage equal to its power to target creature an opponent controls.",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "51ee683d-554a-5e04-b613-9d4385ad9535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d0a9fb-1068-478d-a78c-6fd77cc313f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5d0a9fb-1068-478d-a78c-6fd77cc313f0.jpg?1",
             "name": "Krotiq Nestguard",
             "text": "Defender\n{2}{G}: This creature can attack this turn as though it didn't have defender.",
             "colours": [
@@ -5369,7 +5369,7 @@
         },
         {
             "id": "43417fc1-214a-5280-a1f9-757f3d65d4cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f5c8ef-8e9e-4264-a7d2-126a30a5d341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f5c8ef-8e9e-4264-a7d2-126a30a5d341.jpg?1",
             "name": "Lasyd Prowler",
             "text": "When this creature enters, you may mill cards equal to the number of lands you control.\nRenew \u2014 {1}{G}, Exile this card from your graveyard: Put X +1/+1 counters on target creature, where X is the number of land cards in your graveyard. Activate only as a sorcery.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "309fef85-6d9b-5234-8651-1e4c5c9c2e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397d904-c51d-451e-8505-7f3118acc1f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1397d904-c51d-451e-8505-7f3118acc1f6.jpg?1",
             "name": "Nature's Rhythm",
             "text": "Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.\nHarmonize {X}{G}{G}{G}{G} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by an amount of generic mana equal to its power. Then exile this spell.)",
             "colours": [
@@ -5440,7 +5440,7 @@
         },
         {
             "id": "4b9d9df0-d051-5111-9604-e89c265bc585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a0deb9-5bc3-42d5-9e1e-5f463d176aef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a0deb9-5bc3-42d5-9e1e-5f463d176aef.jpg?1",
             "name": "Piercing Exhale",
             "text": "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)\nTarget creature you control deals damage equal to its power to target creature or planeswalker. If a Dragon was beheld, surveil 2.",
             "colours": [
@@ -5472,7 +5472,7 @@
         },
         {
             "id": "ac3dfb86-94c2-58b9-a638-1fe550342653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc5c316-6a41-48ba-864b-da3030dd3e0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc5c316-6a41-48ba-864b-da3030dd3e0e.jpg?1",
             "name": "Rainveil Rejuvenator",
             "text": "When this creature enters, you may mill three cards. (You may put the top three cards of your library into your graveyard.)\n{T}: Add an amount of {G} equal to this creature's power.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "b39aa61c-7a73-5aad-b0cb-161437f86c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737698a-d934-4851-b238-828959ef4835.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737698a-d934-4851-b238-828959ef4835.jpg?1",
             "name": "Rite of Renewal",
             "text": "Return up to two target permanent cards from your graveyard to your hand. Target player shuffles up to four target cards from their graveyard into their library. Exile Rite of Renewal.",
             "colours": [
@@ -5539,7 +5539,7 @@
         },
         {
             "id": "3d811e19-2b06-538f-89c9-042769ea7bcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8c2d5c-ba0c-4d50-8898-5c6574b1e974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb8c2d5c-ba0c-4d50-8898-5c6574b1e974.jpg?1",
             "name": "Roamer's Routine",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nHarmonize {4}{G} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "f79c0e7e-3d74-5fd4-bfc4-a321f2e1b042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebf4a9d-d90c-4017-9f00-fca89899f301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ebf4a9d-d90c-4017-9f00-fca89899f301.jpg?1",
             "name": "Sage of the Fang",
             "text": "When this creature enters, put a +1/+1 counter on target creature.\nRenew \u2014 {3}{G}, Exile this card from your graveyard: Put a +1/+1 counter on target creature, then double the number of +1/+1 counters on that creature. Activate only as a sorcery.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "7ada5b5a-1f3a-5beb-b086-4bfddfa0e3ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def9cb5b-4062-481e-b682-3a30443c2e56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def9cb5b-4062-481e-b682-3a30443c2e56.jpg?1",
             "name": "Sagu Pummeler",
             "text": "Reach\nRenew \u2014 {4}{G}, Exile this card from your graveyard: Put two +1/+1 counters and a reach counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -5640,7 +5640,7 @@
         },
         {
             "id": "5a1e59f8-b2ba-5bb8-873c-d9bf96758acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Flying\nWhen this creature enters, you gain 3 life.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "60e631dd-3511-539a-a0a1-ccf76eeee5df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8b43b00-f4d1-436c-bf3f-6d414cd4ce38.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle. (Also shuffle this card.)",
             "colours": [
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "c0f3427e-19ca-5a33-81c0-127db358fd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae56fef-b661-4bc5-b9a1-3871ae06e491.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae56fef-b661-4bc5-b9a1-3871ae06e491.jpg?1",
             "name": "Sarkhan's Resolve",
             "text": "Choose one \u2014\n\u2022 Target creature gets +3/+3 until end of turn.\n\u2022 Destroy target creature with flying.",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "220afd9d-cbb5-5e56-8f58-cedde65bed6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d2c692-7566-468e-9c86-47a9f768fde2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d2c692-7566-468e-9c86-47a9f768fde2.jpg?1",
             "name": "Snakeskin Veil",
             "text": "Put a +1/+1 counter on target creature you control. It gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -5776,7 +5776,7 @@
         },
         {
             "id": "48a54fcc-7517-5fae-b18d-e99aaffd1eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32487e9-f3ac-472e-b6ea-81bd9254770c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32487e9-f3ac-472e-b6ea-81bd9254770c.jpg?1",
             "name": "Sultai Devotee",
             "text": "Deathtouch\n{1}: Add {B}, {G}, or {U}. Activate only once each turn.",
             "colours": [
@@ -5814,7 +5814,7 @@
         },
         {
             "id": "3d9fc7ef-55d6-575e-a1c9-c5117c919e4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4775a26-0b66-40e9-8f64-41d9308ca032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4775a26-0b66-40e9-8f64-41d9308ca032.jpg?1",
             "name": "Surrak, Elusive Hunter",
             "text": "This spell can't be countered.\nTrample\nWhenever a creature you control or a creature spell you control becomes the target of a spell or ability an opponent controls, draw a card.",
             "colours": [
@@ -5853,7 +5853,7 @@
         },
         {
             "id": "f5bd431d-2983-52ba-88db-0cf0349f540d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f721f8d-fd2f-480b-8645-4bf6ce38dde9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f721f8d-fd2f-480b-8645-4bf6ce38dde9.jpg?1",
             "name": "Synchronized Charge",
             "text": "Distribute two +1/+1 counters among one or two target creatures you control. Creatures you control with counters on them gain vigilance and trample until end of turn.\nHarmonize {4}{G} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -5885,7 +5885,7 @@
         },
         {
             "id": "5cc57a65-08d3-5816-9408-10fffb64e1cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c89d95-d697-4cfa-9dfa-52d7adb96176.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c89d95-d697-4cfa-9dfa-52d7adb96176.jpg?1",
             "name": "Trade Route Envoy",
             "text": "When this creature enters, draw a card if you control a creature with a counter on it. If you don't draw a card this way, put a +1/+1 counter on this creature.",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "b13bfeb2-42ab-55d9-9295-cbd7adbf74b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890b11b4-777a-4f1e-8c4d-21c5ebbfb0a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890b11b4-777a-4f1e-8c4d-21c5ebbfb0a2.jpg?1",
             "name": "Traveling Botanist",
             "text": "Whenever this creature becomes tapped, look at the top card of your library. If it's a land card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [
@@ -5955,7 +5955,7 @@
         },
         {
             "id": "f3be5f9d-3487-52e1-8a60-26d1dea58930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8f9a-b17c-452f-b4ef-a3f91909e3de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67ab8f9a-b17c-452f-b4ef-a3f91909e3de.jpg?1",
             "name": "Undergrowth Leopard",
             "text": "Vigilance\n{1}, Sacrifice this creature: Destroy target artifact or enchantment.",
             "colours": [
@@ -5989,7 +5989,7 @@
         },
         {
             "id": "19ae21a6-f2d5-5627-b3bc-da5e6d9c628f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2414db96-0e2b-4f7c-9b97-41f8e310b752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2414db96-0e2b-4f7c-9b97-41f8e310b752.jpg?1",
             "name": "Warden of the Grove",
             "text": "At the beginning of your end step, put a +1/+1 counter on this creature.\nWhenever another nontoken creature you control enters, it endures X, where X is the number of counters on this creature. (Put X +1/+1 counters on the creature that entered or create an X/X white Spirit creature token.)",
             "colours": [
@@ -6025,7 +6025,7 @@
         },
         {
             "id": "d249c274-5f3f-57f4-9102-da6d0b515b75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74876d8-f6a6-4b47-b960-b01a331bab01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b74876d8-f6a6-4b47-b960-b01a331bab01.jpg?1",
             "name": "All-Out Assault",
             "text": "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment enters, if it's your main phase, there is an additional combat phase after this phase followed by an additional main phase. When you next attack this turn, untap each creature you control.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "c6508d07-4b04-5042-b097-97f66b908f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f61c01-0a41-4fa1-ac34-ffa83baad989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f61c01-0a41-4fa1-ac34-ffa83baad989.jpg?1",
             "name": "Armament Dragon",
             "text": "Flying\nWhen this creature enters, distribute three +1/+1 counters among one, two, or three target creatures you control.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "b241adf3-0d69-5855-99b9-84e095897fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f94ad-65d6-4c7d-925d-165ef264626f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672f94ad-65d6-4c7d-925d-165ef264626f.jpg?1",
             "name": "Auroral Procession",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -6139,7 +6139,7 @@
         },
         {
             "id": "0860270f-fa0b-535d-96b4-a375cca0ec72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14078a49-2230-4ad7-aea0-0c253813c646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14078a49-2230-4ad7-aea0-0c253813c646.jpg?1",
             "name": "Awaken the Honored Dead",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target nonland permanent.\nII \u2014 Mill three cards.\nIII \u2014 You may discard a card. When you do, return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "9410b8b5-8f1f-5b9b-a9c3-ba199b8c5f3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2556a35b-2229-42c7-8cb3-c8c668403dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2556a35b-2229-42c7-8cb3-c8c668403dd2.jpg?1",
             "name": "Barrensteppe Siege",
             "text": "As this enchantment enters, choose Abzan or Mardu.\n\u2022 Abzan \u2014 At the beginning of your end step, put a +1/+1 counter on each creature you control.\n\u2022 Mardu \u2014 At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "6dc09ffa-7a9b-5110-890b-7352b5bdf8b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b475b071-5545-483e-a397-89451f258602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b475b071-5545-483e-a397-89451f258602.jpg?1",
             "name": "Betor, Kin to All",
             "text": "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
             "colours": [
@@ -6259,7 +6259,7 @@
         },
         {
             "id": "d3263501-ae28-5838-b397-54c13f5f6c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf36bc-6702-4c5d-b52d-ab7217cc8787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78bf36bc-6702-4c5d-b52d-ab7217cc8787.jpg?1",
             "name": "Bone-Cairn Butcher",
             "text": "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\nAttacking tokens you control have deathtouch.",
             "colours": [
@@ -6297,7 +6297,7 @@
         },
         {
             "id": "ccd54215-0baf-53d6-9533-6065f5a39fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ad91db-5f16-4392-baf1-f8400ec11e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ad91db-5f16-4392-baf1-f8400ec11e0a.jpg?1",
             "name": "Call the Spirit Dragons",
             "text": "Dragons you control have indestructible.\nAt the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control of that color. If you put +1/+1 counters on five Dragons this way, you win the game.",
             "colours": [
@@ -6339,7 +6339,7 @@
         },
         {
             "id": "03016f67-fe67-5325-a191-9f06196371c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cbf54e-f30e-4e7b-b17c-217fa424971c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cbf54e-f30e-4e7b-b17c-217fa424971c.jpg?1",
             "name": "Cori Mountain Stalwart",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, this creature deals 2 damage to each opponent and you gain 2 life.",
             "colours": [
@@ -6376,7 +6376,7 @@
         },
         {
             "id": "22234ee0-03f6-583f-8841-26872116c3aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faab43d-587d-44f6-9516-c8e3965bbc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1faab43d-587d-44f6-9516-c8e3965bbc20.jpg?1",
             "name": "Death Begets Life",
             "text": "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "f39f0a34-b27f-5842-9f57-4c9951491f77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a18cf-03db-4eb0-8d53-0c1a71e184da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3a18cf-03db-4eb0-8d53-0c1a71e184da.jpg?1",
             "name": "Defibrillating Current",
             "text": "Defibrillating Current deals 4 damage to target creature or planeswalker and you gain 2 life.",
             "colours": [
@@ -6452,7 +6452,7 @@
         },
         {
             "id": "9982f6ef-e616-5b0d-ba61-7e8d3534c060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Flying\nWhen this creature enters, destroy up to one target artifact or enchantment.",
             "colours": [
@@ -6489,7 +6489,7 @@
         },
         {
             "id": "1de8a051-80eb-53b6-94f5-30b1a9cbc607",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/d/bd78e8ae-e927-40e7-9580-966c5e81f53c.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Destroy target creature with power 3 or less. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -6526,7 +6526,7 @@
         },
         {
             "id": "989d1917-e3fe-53b2-a4fa-8571dbf5b5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54cc838-d79d-433a-99fb-d6e4d1c1431d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54cc838-d79d-433a-99fb-d6e4d1c1431d.jpg?1",
             "name": "Dragonback Assault",
             "text": "When this enchantment enters, it deals 3 damage to each creature and each planeswalker.\nLandfall \u2014 Whenever a land you control enters, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "d776213e-0bf8-531c-b61f-1ac18957b728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7692ef-7091-4365-85a8-1edbd374f279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7692ef-7091-4365-85a8-1edbd374f279.jpg?1",
             "name": "Dragonclaw Strike",
             "text": "Double the power and toughness of target creature you control until end of turn. Then it fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "95358c96-720d-52fe-abc6-19cfdd6a943c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae03ca5-cd4b-42b7-8cd5-3f7e753b4147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae03ca5-cd4b-42b7-8cd5-3f7e753b4147.jpg?1",
             "name": "Effortless Master",
             "text": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)\nThis creature enters with two +1/+1 counters on it if you've cast two or more spells this turn.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "545d78ef-9ec5-5c45-a2d2-71861696851a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d369c44-78ee-4f3c-bf2b-cddba7fe26d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d369c44-78ee-4f3c-bf2b-cddba7fe26d4.jpg?1",
             "name": "Eshki Dragonclaw",
             "text": "Vigilance, trample, ward {1}\nAt the beginning of combat on your turn, if you've cast both a creature spell and a noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw.",
             "colours": [
@@ -6680,7 +6680,7 @@
         },
         {
             "id": "70c7b210-fc7f-5f73-83fd-458813deceee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655fa2e1-3e1c-424c-b17a-daa7b8fface4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/655fa2e1-3e1c-424c-b17a-daa7b8fface4.jpg?1",
             "name": "Fangkeeper's Familiar",
             "text": "Flash\nWhen this creature enters, choose one \u2014\n\u2022 You gain 3 life and surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\n\u2022 Destroy target enchantment.\n\u2022 Counter target creature spell.",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "c1f7ce4c-092d-5d47-8740-bf6357b2f239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e11f20-6524-4fba-9603-0b97e2d69aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83e11f20-6524-4fba-9603-0b97e2d69aac.jpg?1",
             "name": "Felothar, Dawn of the Abzan",
             "text": "Trample\nWhenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -6763,7 +6763,7 @@
         },
         {
             "id": "65c1fb47-dcd9-5c1f-8e49-1aa6ddb0a06d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8443a6-282f-4218-9dc8-144b5570d891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc8443a6-282f-4218-9dc8-144b5570d891.jpg?1",
             "name": "Flamehold Grappler",
             "text": "First strike\nWhen this creature enters, copy the next spell you cast this turn when you cast it. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -6804,7 +6804,7 @@
         },
         {
             "id": "cc54256c-4c49-5a08-b1fe-76a0b899998a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce8a205-99d6-4a9c-83a7-18b7220177d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce8a205-99d6-4a9c-83a7-18b7220177d3.jpg?1",
             "name": "Frontline Rush",
             "text": "Choose one \u2014\n\u2022 Create two 1/1 red Goblin creature tokens.\n\u2022 Target creature gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "d2b9c781-b783-523d-b488-05c37af8b91f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a750aabb-9788-494a-841f-bf75717970a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a750aabb-9788-494a-841f-bf75717970a7.jpg?1",
             "name": "Frostcliff Siege",
             "text": "As this enchantment enters, choose Jeskai or Temur.\n\u2022 Jeskai \u2014 Whenever one or more creatures you control deal combat damage to a player, draw a card.\n\u2022 Temur \u2014 Creatures you control get +1/+0 and have trample and haste.",
             "colours": [
@@ -6874,7 +6874,7 @@
         },
         {
             "id": "79dfdc0b-b3fb-50d6-ad83-56aa0d61cd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95994c88-e404-4a4f-8be6-b99d703d4609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95994c88-e404-4a4f-8be6-b99d703d4609.jpg?1",
             "name": "Glacial Dragonhunt",
             "text": "Draw a card, then you may discard a card. When you discard a nonland card this way, Glacial Dragonhunt deals 3 damage to target creature.\nHarmonize {4}{U}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -6908,7 +6908,7 @@
         },
         {
             "id": "00ddf81f-e719-5099-9a97-7142885c2c4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f37fad7-2385-409b-8375-fa5dfbcad833.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f37fad7-2385-409b-8375-fa5dfbcad833.jpg?1",
             "name": "Glacierwood Siege",
             "text": "As this enchantment enters, choose Temur or Sultai.\n\u2022 Temur \u2014 Whenever you cast an instant or sorcery spell, target player mills four cards.\n\u2022 Sultai \u2014 You may play lands from your graveyard.",
             "colours": [
@@ -6944,7 +6944,7 @@
         },
         {
             "id": "c25c5b87-ec93-5767-a8e3-9a9d3e40521b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de731430-6bbf-4782-953e-b69c46353959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de731430-6bbf-4782-953e-b69c46353959.jpg?1",
             "name": "Gurmag Nightwatch",
             "text": "When this creature enters, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
             "colours": [
@@ -6983,7 +6983,7 @@
         },
         {
             "id": "7d03cb0a-9c6e-5514-830b-4f7bc526c202",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b225cb-5c45-4da1-a64e-b04091e483e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86b225cb-5c45-4da1-a64e-b04091e483e8.jpg?1",
             "name": "Hardened Tactician",
             "text": "{1}, Sacrifice a token: Draw a card.",
             "colours": [
@@ -7020,7 +7020,7 @@
         },
         {
             "id": "4682ecf2-2723-57d4-b2b8-6751f7ee3486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac0e136-8877-4bfc-a831-2bf7b7b5ad1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ac0e136-8877-4bfc-a831-2bf7b7b5ad1e.jpg?1",
             "name": "Hollowmurk Siege",
             "text": "As this enchantment enters, choose Sultai or Abzan.\n\u2022 Sultai \u2014 Whenever a counter is put on a creature you control, draw a card. This ability triggers only once each turn.\n\u2022 Abzan \u2014 Whenever you attack, put a +1/+1 counter on target attacking creature. It gains menace until end of turn.",
             "colours": [
@@ -7056,7 +7056,7 @@
         },
         {
             "id": "ff73bc5b-1558-5462-86dc-05c295387262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f182957-8133-45a7-80a3-1944bead4d43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f182957-8133-45a7-80a3-1944bead4d43.jpg?1",
             "name": "Host of the Hereafter",
             "text": "This creature enters with two +1/+1 counters on it.\nWhenever this creature or another creature you control dies, if it had counters on it, put its counters on up to one target creature you control.",
             "colours": [
@@ -7093,7 +7093,7 @@
         },
         {
             "id": "67875c08-75fd-51db-b288-149f7a894441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d677980-b608-407e-9f17-790a81263f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d677980-b608-407e-9f17-790a81263f15.jpg?1",
             "name": "Inevitable Defeat",
             "text": "This spell can't be countered.\nExile target nonland permanent. Its controller loses 3 life and you gain 3 life.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "a80842a1-01ba-5d2d-946f-509a5cd7c84f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb06c36-cf7e-47a9-819e-adfc54284153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2eb06c36-cf7e-47a9-819e-adfc54284153.jpg?1",
             "name": "Jeskai Brushmaster",
             "text": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -7170,7 +7170,7 @@
         },
         {
             "id": "8f3d82fa-0978-536f-9b05-71ae9cae1726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cac0ad3-5107-4ed6-a688-d44bbd65e407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cac0ad3-5107-4ed6-a688-d44bbd65e407.jpg?1",
             "name": "Jeskai Revelation",
             "text": "Return target spell or permanent to its owner's hand. Jeskai Revelation deals 4 damage to any target. Create two 1/1 white Monk creature tokens with prowess. Draw two cards. You gain 4 life.",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "33d8cac4-f528-59cf-8fe6-d2411629915e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec8fa0b-c695-4326-aebd-042cb1974925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ec8fa0b-c695-4326-aebd-042cb1974925.jpg?1",
             "name": "Jeskai Shrinekeeper",
             "text": "Flying, haste\nWhenever this creature deals combat damage to a player, you gain 1 life and draw a card.",
             "colours": [
@@ -7248,7 +7248,7 @@
         },
         {
             "id": "d2a65357-3ec3-586d-9a8b-a5c2e30dd9fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77b08-c3f6-4458-8636-f226f9843b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c77b08-c3f6-4458-8636-f226f9843b6d.jpg?1",
             "name": "Karakyk Guardian",
             "text": "Flying, vigilance, trample\nThis creature has hexproof if it hasn't dealt damage yet. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -7288,7 +7288,7 @@
         },
         {
             "id": "11e44f82-3bca-5345-bf0a-dee2588c6c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d11183a-57f5-4ddb-8a6e-15fff704b114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d11183a-57f5-4ddb-8a6e-15fff704b114.jpg?1",
             "name": "Kheru Goldkeeper",
             "text": "Flying\nWhenever one or more cards leave your graveyard during your turn, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nRenew \u2014 {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a flying counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -7328,7 +7328,7 @@
         },
         {
             "id": "6e332de8-7b67-50e2-bcc0-33f5ae816ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b577e246-3377-42aa-856e-b9fa89f3603a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b577e246-3377-42aa-856e-b9fa89f3603a.jpg?1",
             "name": "Kin-Tree Severance",
             "text": "Exile target permanent with mana value 3 or greater.",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "ee243735-5c81-5e07-876b-d17ca48e4c5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f1acb0-d73e-4814-8158-3645daf5c4cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f1acb0-d73e-4814-8158-3645daf5c4cc.jpg?1",
             "name": "Kishla Skimmer",
             "text": "Flying\nWhenever a card leaves your graveyard during your turn, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -7401,7 +7401,7 @@
         },
         {
             "id": "188a5a74-a4bb-5f69-a54f-d6386db0b1d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3736f17-f80b-4b2c-b919-2c963bc14682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3736f17-f80b-4b2c-b919-2c963bc14682.jpg?1",
             "name": "Kotis, the Fangkeeper",
             "text": "Indestructible\nWhenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -7444,7 +7444,7 @@
         },
         {
             "id": "f0139f32-f199-51d9-ac76-1cb6b677c851",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff22c-282b-4849-82ce-890013b53262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fff22c-282b-4849-82ce-890013b53262.jpg?1",
             "name": "Lie in Wait",
             "text": "Return target creature card from your graveyard to your hand. Lie in Wait deals damage equal to that card's power to target creature.",
             "colours": [
@@ -7480,7 +7480,7 @@
         },
         {
             "id": "547f3d1d-261a-5450-abc2-7a86dd7f54b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aa2593-4a79-46f1-a2bd-b71fb504d0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82aa2593-4a79-46f1-a2bd-b71fb504d0ab.jpg?1",
             "name": "Lotuslight Dancers",
             "text": "Lifelink\nWhen this creature enters, search your library for a black card, a green card, and a blue card. Put those cards into your graveyard, then shuffle.",
             "colours": [
@@ -7521,7 +7521,7 @@
         },
         {
             "id": "c3d81c5f-7b82-57bd-bc32-6ab0ad13f467",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b17b4-79ce-4dfa-8873-a9cfc347e38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468b17b4-79ce-4dfa-8873-a9cfc347e38f.jpg?1",
             "name": "Mammoth Bellow",
             "text": "Create a 5/5 green Elephant creature token.\nHarmonize {5}{G}{U}{R} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile this spell.)",
             "colours": [
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "e0074151-d042-5905-94d6-311ddc91eef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044b232-edf4-4000-9273-cc4653ad653a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044b232-edf4-4000-9273-cc4653ad653a.jpg?1",
             "name": "Mardu Siegebreaker",
             "text": "Deathtouch, haste\nWhen this creature enters, exile up to one other target creature you control until this creature leaves the battlefield.\nWhenever this creature attacks, for each opponent, create a tapped token that's a copy of the exiled card attacking that opponent. At the beginning of your end step, sacrifice those tokens.",
             "colours": [
@@ -7598,7 +7598,7 @@
         },
         {
             "id": "30fb18af-7adc-54ad-b9fc-f003866f9759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fbaa16-67c3-4ed2-9545-39abbbde61dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fbaa16-67c3-4ed2-9545-39abbbde61dc.jpg?1",
             "name": "Marshal of the Lost",
             "text": "Deathtouch\nWhenever you attack, target creature gets +X/+X until end of turn, where X is the number of attacking creatures.",
             "colours": [
@@ -7635,7 +7635,7 @@
         },
         {
             "id": "66054d69-242f-502d-bc77-f780b6a8d13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9eeced-6464-41f0-bbea-05b3af4cc005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9eeced-6464-41f0-bbea-05b3af4cc005.jpg?1",
             "name": "Monastery Messenger",
             "text": "Flying, vigilance\nWhen this creature enters, put up to one target noncreature, nonland card from your graveyard on top of your library.",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "7cb21941-9187-52f7-9859-acf604a59373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77cbc1-dbc8-44d9-aa29-15cbb19afecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b77cbc1-dbc8-44d9-aa29-15cbb19afecd.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "At the beginning of your end step, you may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "c6a95111-f7b3-58bc-b704-981ee44399fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58112b0-a05c-4b98-b650-fd27ad97789f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b58112b0-a05c-4b98-b650-fd27ad97789f.jpg?1",
             "name": "Neriv, Heart of the Storm",
             "text": "Flying\nIf a creature you control that entered this turn would deal damage, it deals twice that much damage instead.",
             "colours": [
@@ -7763,7 +7763,7 @@
         },
         {
             "id": "3354a9f8-1df3-552c-aae6-03fc9c219c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d48f9e-79f0-478c-9db0-ff7ac4a8f401.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9d48f9e-79f0-478c-9db0-ff7ac4a8f401.jpg?1",
             "name": "New Way Forward",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. When damage is prevented this way, New Way Forward deals that much damage to that source's controller and you draw that many cards.",
             "colours": [
@@ -7801,7 +7801,7 @@
         },
         {
             "id": "41920764-c3e0-5b52-a580-9709b5310d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe7071e-a214-44e8-a571-129f0db44f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe7071e-a214-44e8-a571-129f0db44f76.jpg?1",
             "name": "Perennation",
             "text": "Return target permanent card from your graveyard to the battlefield with a hexproof counter and an indestructible counter on it.",
             "colours": [
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "59851cfc-f7e6-53aa-9c29-17f414551e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Flying\nWard\u2014\nPay 2 life.\nWhen this creature enters, remove all counters from up to one target creature.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "fd02f823-23fd-5c22-883a-c6b98307a20c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/3988dc76-072c-4f43-849d-2e73c6f6ff58.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Target creature gets +2/+2 and gains lifelink and hexproof until end of turn. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -7913,7 +7913,7 @@
         },
         {
             "id": "e5d0f341-c801-59dd-8a79-bee331fb8432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c409f4f-3b2c-4c33-b850-55b2a46f51ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c409f4f-3b2c-4c33-b850-55b2a46f51ca.jpg?1",
             "name": "Rakshasa's Bargain",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard.",
             "colours": [
@@ -7949,7 +7949,7 @@
         },
         {
             "id": "6ecbb40f-83c3-5b74-be2b-fd3d1043e862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6decf-afd5-4e96-b87e-fd7ab7e3c068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6decf-afd5-4e96-b87e-fd7ab7e3c068.jpg?1",
             "name": "Rediscover the Way",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\nIII \u2014 Whenever you cast a noncreature spell this turn, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -7989,7 +7989,7 @@
         },
         {
             "id": "33af6e3b-1dfd-513b-8ca1-1567740a6d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a394112a-032b-4047-887a-6522cf7b83d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a394112a-032b-4047-887a-6522cf7b83d5.jpg?1",
             "name": "Reigning Victor",
             "text": "Mobilize 1 (Whenever this creature attacks, create a tapped and attacking 1/1 red Warrior creature token. Sacrifice it at the beginning of the next end step.)\nWhen this creature enters, target creature gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "495ccff1-2d1c-58cb-a177-f5fb843270ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d0591e-7fb7-40ea-ba2a-cfe544d40216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d0591e-7fb7-40ea-ba2a-cfe544d40216.jpg?1",
             "name": "Reputable Merchant",
             "text": "When this creature enters or dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -8067,7 +8067,7 @@
         },
         {
             "id": "cf43733f-454e-5f63-822b-e9aba7033731",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd742ff5-f0ea-4f4b-911e-4c09e2154dba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd742ff5-f0ea-4f4b-911e-4c09e2154dba.jpg?1",
             "name": "Revival of the Ancestors",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create three 1/1 white Spirit creature tokens.\nII \u2014 Distribute three +1/+1 counters among one, two, or three target creatures you control.\nIII \u2014 Creatures you control gain trample and lifelink until end of turn.",
             "colours": [
@@ -8107,7 +8107,7 @@
         },
         {
             "id": "8345b71c-e5a8-5aa4-8915-e13fddf729b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686fe623-ee50-407d-87c9-664fb039f4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686fe623-ee50-407d-87c9-664fb039f4d9.jpg?1",
             "name": "Riverwheel Sweep",
             "text": "Tap target creature. Put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nExile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -8143,7 +8143,7 @@
         },
         {
             "id": "8cd2944f-9bcf-5fea-870f-b18892ee869a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9c3531-61a8-43f5-82a2-5166e5f5a6b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9c3531-61a8-43f5-82a2-5166e5f5a6b9.jpg?1",
             "name": "Roar of Endless Song",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a 5/5 green Elephant creature token.\nIII \u2014 Double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -8183,7 +8183,7 @@
         },
         {
             "id": "4a71a68d-061a-5faf-945a-046bdf43bbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Flying\nWhenever you cast a noncreature spell or a Dragon spell, this creature gets +2/+0 until end of turn.",
             "colours": [
@@ -8220,7 +8220,7 @@
         },
         {
             "id": "0326e0d3-8af0-510e-9deb-c65029593058",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/317744d1-ed78-4b53-a4d8-8c7ecfd9c4ae.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Counter target spell with mana value 2 or less. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -8257,7 +8257,7 @@
         },
         {
             "id": "039a562e-68c0-57cf-85e7-087da1bd11fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc779a1b-128c-4c74-bebd-bdb687867f68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc779a1b-128c-4c74-bebd-bdb687867f68.jpg?1",
             "name": "Severance Priest",
             "text": "Deathtouch\nWhen this creature enters, target opponent reveals their hand. You may choose a nonland card from it. If you do, exile that card.\nWhen this creature leaves the battlefield, the exiled card's owner creates an X/X white Spirit creature token, where X is the mana value of the exiled card.",
             "colours": [
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "885d1973-b375-577f-a6bf-b7207aae3fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8138cf10-1e3e-483f-86ad-cc399192657d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8138cf10-1e3e-483f-86ad-cc399192657d.jpg?1",
             "name": "Shiko, Paragon of the Way",
             "text": "Flying, vigilance\nWhen Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "ccecdfae-a133-555c-83ce-f4bdba0b5a51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e9ba1-c254-41e3-9845-4e81f9fec38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2e9ba1-c254-41e3-9845-4e81f9fec38d.jpg?1",
             "name": "Skirmish Rhino",
             "text": "Trample\nWhen this creature enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "5c2a2488-b663-5fbc-9ae8-b60cbbe8c169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9523bc07-49e5-409c-ae6b-b28e305eef36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9523bc07-49e5-409c-ae6b-b28e305eef36.jpg?1",
             "name": "Songcrafter Mage",
             "text": "Flash\nWhen this creature enters, target instant or sorcery card in your graveyard gains harmonize until end of turn. Its harmonize cost is equal to its mana cost. (You may cast that card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {X}, where X is its power. Then exile the spell.)",
             "colours": [
@@ -8424,7 +8424,7 @@
         },
         {
             "id": "69b8d250-ceaa-5702-b7cb-4565800ef102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c231437-8bec-42e0-9175-af74c752b119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c231437-8bec-42e0-9175-af74c752b119.jpg?1",
             "name": "Sonic Shrieker",
             "text": "Flying\nWhen this creature enters, it deals 2 damage to any target and you gain 2 life. If a player is dealt damage this way, they discard a card.",
             "colours": [
@@ -8464,7 +8464,7 @@
         },
         {
             "id": "2fdfc097-97e4-5610-a7d3-53f8194596f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b206f-8190-46e6-bb9e-44763d3eb4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a7b206f-8190-46e6-bb9e-44763d3eb4ac.jpg?1",
             "name": "Stalwart Successor",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever one or more counters are put on a creature you control, if it's the first time counters have been put on that creature this turn, put a +1/+1 counter on that creature.",
             "colours": [
@@ -8501,7 +8501,7 @@
         },
         {
             "id": "82150fed-3464-5f9e-bbab-336685b4540c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72184791-0767-4108-920c-763e92dae2d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72184791-0767-4108-920c-763e92dae2d4.jpg?1",
             "name": "Temur Battlecrier",
             "text": "During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.",
             "colours": [
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "47469a54-6b24-5e17-ba92-61f4fd69dce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb383f-bc04-46d1-aa3a-7459d57f1fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cdb383f-bc04-46d1-aa3a-7459d57f1fec.jpg?1",
             "name": "Temur Tawnyback",
             "text": "When this creature enters, draw a card, then discard a card.",
             "colours": [
@@ -8581,7 +8581,7 @@
         },
         {
             "id": "1e071805-cd26-5a7e-a882-535e5d67fd12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a93f5b-7b32-49f0-a179-b897828fe49a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a93f5b-7b32-49f0-a179-b897828fe49a.jpg?1",
             "name": "Teval, Arbiter of Virtue",
             "text": "Flying, lifelink\nSpells you cast have delve. (Each card you exile from your graveyard while casting those spells pays for {1}.)\nWhenever you cast a spell, you lose life equal to its mana value.",
             "colours": [
@@ -8625,7 +8625,7 @@
         },
         {
             "id": "b509e306-9b7c-5493-aa45-5225cedf261c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c953b36-f5e4-4258-91cb-f07e799321f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c953b36-f5e4-4258-91cb-f07e799321f7.jpg?1",
             "name": "Thunder of Unity",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 You draw two cards and you lose 2 life.\nII, III \u2014 Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -8665,7 +8665,7 @@
         },
         {
             "id": "ea33b50c-09a0-5f64-a692-33f1abc8e4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Flying\nWhen this creature enters, you gain 5 life.",
             "colours": [
@@ -8702,7 +8702,7 @@
         },
         {
             "id": "5966987d-57ff-577f-8161-d1a5712fc249",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/9/2999e3b1-6510-42b2-9429-28c07a64a44f.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Charring Bite deals 5 damage to target creature without flying. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "f3d6e464-e338-5266-8ffb-7c05062c524d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227802c0-4ff6-43a8-a850-ed0f546dc5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227802c0-4ff6-43a8-a850-ed0f546dc5ac.jpg?1",
             "name": "Ureni, the Song Unending",
             "text": "Flying, protection from white and from black\nWhen Ureni enters, it deals X damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control, where X is the number of lands you control.",
             "colours": [
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "8a3d21cb-9061-5413-ae3c-e5e836359427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Flash\nFlying\nYou may cast sorcery spells and Dragon spells as though they had flash.",
             "colours": [
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "d2516742-2a1e-5302-8382-e2de4ff3e27f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/6/56a25eb1-bdb8-4f86-8d9a-3055ad1b2a13.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Put three +1/+1 counters on target creature you control. (Then shuffle this card into its owner's library.)",
             "colours": [
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "47366dca-0ac2-5560-93f1-f4901d8d3025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a8329b-23a1-4c49-a579-a5da8d01435a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a8329b-23a1-4c49-a579-a5da8d01435a.jpg?1",
             "name": "Windcrag Siege",
             "text": "As this enchantment enters, choose Mardu or Jeskai.\n\u2022 Mardu \u2014 If a creature attacking causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n\u2022 Jeskai \u2014 At the beginning of your upkeep, create a 1/1 red Goblin creature token. It gains lifelink and haste until end of turn.",
             "colours": [
@@ -8893,7 +8893,7 @@
         },
         {
             "id": "d7bae76c-6406-5303-87f5-05ba4c19d6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e77339b-dd82-481c-9ee2-4156ca69ad35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e77339b-dd82-481c-9ee2-4156ca69ad35.jpg?1",
             "name": "Yathan Roadwatcher",
             "text": "When this creature enters, if you cast it, mill four cards. When you do, return target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -8934,7 +8934,7 @@
         },
         {
             "id": "c688ab18-c6fe-5c35-8331-0c976b86a1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd93fb95-4268-45dc-8f0d-590c481a526d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd93fb95-4268-45dc-8f0d-590c481a526d.jpg?1",
             "name": "Zurgo, Thunder's Decree",
             "text": "Mobilize 2 (Whenever this creature attacks, create two tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)\nDuring your end step, Warrior tokens you control have \"This token can't be sacrificed.\"",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "95a09b28-a742-54e4-822c-9daedb6220e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2da9024-3b58-4a57-8f7d-4094c193daee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2da9024-3b58-4a57-8f7d-4094c193daee.jpg?1",
             "name": "Abzan Monument",
             "text": "When this artifact enters, search your library for a basic Plains, Swamp, or Forest card, reveal it, put it into your hand, then shuffle.\n{1}{W}{B}{G}, {T}, Sacrifice this artifact: Create an X/X white Spirit creature token, where X is the greatest toughness among creatures you control. Activate only as a sorcery.",
             "colours": [],
@@ -9009,7 +9009,7 @@
         },
         {
             "id": "c23b0e78-2752-5e1c-bbe8-781651b7157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c6e815-bfe7-4599-9227-d36504a3640f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c6e815-bfe7-4599-9227-d36504a3640f.jpg?1",
             "name": "Boulderborn Dragon",
             "text": "Flying, vigilance\nWhenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
             "colours": [],
@@ -9042,7 +9042,7 @@
         },
         {
             "id": "51cb9979-cd26-5e6a-8aa7-bd9cb0a827e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031afea3-fbfb-4663-a8cc-9b7eb7b16020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031afea3-fbfb-4663-a8cc-9b7eb7b16020.jpg?1",
             "name": "Dragonfire Blade",
             "text": "Equipped creature gets +2/+2 and has hexproof from monocolored.\nEquip {4}. This ability costs {1} less to activate for each color of the creature it targets.",
             "colours": [],
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "c3576a11-5eeb-58fd-b362-9a52682c3835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f50aa6e-ce6a-4479-9725-202926245f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f50aa6e-ce6a-4479-9725-202926245f2c.jpg?1",
             "name": "Dragonstorm Globe",
             "text": "Each Dragon you control enters with an additional +1/+1 counter on it.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9102,7 +9102,7 @@
         },
         {
             "id": "99d25e00-84b8-5fc2-9bac-342c8f512f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f75d5-da5b-4605-885a-561ccd999cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485f75d5-da5b-4605-885a-561ccd999cc6.jpg?1",
             "name": "Embermouth Sentinel",
             "text": "When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top. If you control a Dragon, put that card onto the battlefield tapped instead.",
             "colours": [],
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "3b7bb38b-aa77-5ea3-a0ed-58eaae48dd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ce5fa-bd00-429b-ba22-b38c7dd9306c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/516ce5fa-bd00-429b-ba22-b38c7dd9306c.jpg?1",
             "name": "Jade-Cast Sentinel",
             "text": "Reach\n{2}, {T}: Put target card from a graveyard on the bottom of its owner's library.",
             "colours": [],
@@ -9165,7 +9165,7 @@
         },
         {
             "id": "43cf017c-d0e9-5310-bb84-bb560b4611c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0193ad6-39b7-4558-bd3e-36f809332ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0193ad6-39b7-4558-bd3e-36f809332ea2.jpg?1",
             "name": "Jeskai Monument",
             "text": "When this artifact enters, search your library for a basic Island, Mountain, or Plains card, reveal it, put it into your hand, then shuffle.\n{1}{U}{R}{W}, {T}, Sacrifice this artifact: Create two 1/1 white Bird creature tokens with flying. Activate only as a sorcery.",
             "colours": [],
@@ -9197,7 +9197,7 @@
         },
         {
             "id": "f265e641-80a3-5c2b-9678-10163d39d311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd0c794-77bc-4d4a-a769-3829e2ce4bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bd0c794-77bc-4d4a-a769-3829e2ce4bdf.jpg?1",
             "name": "Mardu Monument",
             "text": "When this artifact enters, search your library for a basic Mountain, Plains, or Swamp card, reveal it, put it into your hand, then shuffle.\n{2}{R}{W}{B}, {T}, Sacrifice this artifact: Create three 1/1 red Warrior creature tokens. They gain menace and haste until end of turn. Activate only as a sorcery. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [],
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "0bb61288-bcc4-56fe-8eb5-a6cc401aeb26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a851d2d3-7e93-4887-bee5-4d6c9aaf9419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a851d2d3-7e93-4887-bee5-4d6c9aaf9419.jpg?1",
             "name": "Mox Jasper",
             "text": "{T}: Add one mana of any color. Activate only if you control a Dragon.",
             "colours": [],
@@ -9262,7 +9262,7 @@
         },
         {
             "id": "587123ed-943a-55df-9762-f193411edc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45308e0e-b515-49ac-9960-a24e898dd321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45308e0e-b515-49ac-9960-a24e898dd321.jpg?1",
             "name": "Sultai Monument",
             "text": "When this artifact enters, search your library for a basic Swamp, Forest, or Island card, reveal it, put it into your hand, then shuffle.\n{2}{B}{G}{U}, {T}, Sacrifice this artifact: Create two 2/2 black Zombie Druid creature tokens. Activate only as a sorcery.",
             "colours": [],
@@ -9294,7 +9294,7 @@
         },
         {
             "id": "157e74d0-355b-5ad1-a64e-74db2f104497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e97b40-d898-4da5-8159-cca48eb298eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e97b40-d898-4da5-8159-cca48eb298eb.jpg?1",
             "name": "Temur Monument",
             "text": "When this artifact enters, search your library for a basic Forest, Island, or Mountain card, reveal it, put it into your hand, then shuffle.\n{3}{G}{U}{R}, {T}, Sacrifice this artifact: Create a 5/5 green Elephant creature token. Activate only as a sorcery.",
             "colours": [],
@@ -9326,7 +9326,7 @@
         },
         {
             "id": "7301b2f7-461c-57e2-9ecb-895f6f1bb8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcafdac-a293-4adc-a540-3b3f469cf6f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dcafdac-a293-4adc-a540-3b3f469cf6f3.jpg?1",
             "name": "Watcher of the Wayside",
             "text": "When this creature enters, target player mills two cards. You gain 2 life. (To mill two cards, a player puts the top two cards of their library into their graveyard.)",
             "colours": [],
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "21076e8f-7473-5e7b-87e0-48bdfaa8ea85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde3c68-6f29-4c00-b668-c25ac9e3e13b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dde3c68-6f29-4c00-b668-c25ac9e3e13b.jpg?1",
             "name": "Bloodfell Caves",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -9388,7 +9388,7 @@
         },
         {
             "id": "80734665-9a30-5a21-a46a-2b65d6a32d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9df994-e0f4-4919-af99-4f643eb9199c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a9df994-e0f4-4919-af99-4f643eb9199c.jpg?1",
             "name": "Blossoming Sands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -9419,7 +9419,7 @@
         },
         {
             "id": "4408b2a5-ea1a-5a22-930a-2088bfc5e5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312821a-2059-4f44-9b20-c9522b827e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9312821a-2059-4f44-9b20-c9522b827e38.jpg?1",
             "name": "Cori Mountain Monastery",
             "text": "This land enters tapped unless you control a Plains or an Island.\n{T}: Add {R}.\n{3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [],
@@ -9451,7 +9451,7 @@
         },
         {
             "id": "ddd08f46-d88d-5e04-a552-5441d40b37ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ad5f0c-8775-4e89-8e92-84a6ade93e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ad5f0c-8775-4e89-8e92-84a6ade93e35.jpg?1",
             "name": "Dalkovan Encampment",
             "text": "This land enters tapped unless you control a Swamp or a Mountain.\n{T}: Add {W}.\n{2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens that are tapped and attacking. Sacrifice them at the beginning of the next end step.",
             "colours": [],
@@ -9483,7 +9483,7 @@
         },
         {
             "id": "0e338302-0243-544a-b9a7-278ec4f07f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b52c9-c46e-44d3-b723-546ba528e07b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b52c9-c46e-44d3-b723-546ba528e07b.jpg?1",
             "name": "Dismal Backwater",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "5726bb05-ea3c-5714-99f8-a009e50c27e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62209251-4118-4843-895b-46afb7284c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62209251-4118-4843-895b-46afb7284c75.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -9542,7 +9542,7 @@
         },
         {
             "id": "16fa0b8c-ad66-5fae-a10e-f721fec79d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/679fff07-4796-4d91-8dd6-4e294383ce88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/679fff07-4796-4d91-8dd6-4e294383ce88.jpg?1",
             "name": "Frontier Bivouac",
             "text": "This land enters tapped.\n{T}: Add {G}, {U}, or {R}.",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "279ebff6-f9dd-5920-a886-6d6f241a0640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba23b6-9f3a-431e-bc22-f1fb04d27b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecba23b6-9f3a-431e-bc22-f1fb04d27b68.jpg?1",
             "name": "Great Arashin City",
             "text": "This land enters tapped unless you control a Forest or a Plains.\n{T}: Add {B}.\n{1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit creature token.",
             "colours": [],
@@ -9606,7 +9606,7 @@
         },
         {
             "id": "42fc89ce-a3f0-5d8d-8fdc-f6b8e4faa9bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea13440b-3f7b-4182-9541-27c1fa3121e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea13440b-3f7b-4182-9541-27c1fa3121e5.jpg?1",
             "name": "Jungle Hollow",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -9637,7 +9637,7 @@
         },
         {
             "id": "6fa6dc8b-9935-50dc-8eb5-ca1edd39892c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0ff90d-7312-44df-afc5-29c768fa7758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0ff90d-7312-44df-afc5-29c768fa7758.jpg?1",
             "name": "Kishla Village",
             "text": "This land enters tapped unless you control an Island or a Swamp.\n{T}: Add {G}.\n{3}{G}, {T}: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
             "colours": [],
@@ -9669,7 +9669,7 @@
         },
         {
             "id": "5eb5434e-6367-5549-ba1d-288621e8c10b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e90bfb-d9a5-48a9-9ff9-b0f50a813eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e90bfb-d9a5-48a9-9ff9-b0f50a813eee.jpg?1",
             "name": "Maelstrom of the Spirit Dragon",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.\n{4}, {T}, Sacrifice this land: Search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "7703e3b6-8694-53fb-8e63-e17649e610b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44bccbf-6fab-46e4-8ddb-6577e27ec6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d44bccbf-6fab-46e4-8ddb-6577e27ec6e8.jpg?1",
             "name": "Mistrise Village",
             "text": "This land enters tapped unless you control a Mountain or a Forest.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn can't be countered.",
             "colours": [],
@@ -9731,7 +9731,7 @@
         },
         {
             "id": "dca7b69f-246e-52fd-83dc-e2f452522064",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b8a01c-c400-47c7-8270-78902efe850e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b8a01c-c400-47c7-8270-78902efe850e.jpg?1",
             "name": "Mystic Monastery",
             "text": "This land enters tapped.\n{T}: Add {U}, {R}, or {W}.",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "0076c28f-c93d-56ae-aee7-13c325f7f52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fbeaa-941f-4d53-becd-f93ed22b9a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68fbeaa-941f-4d53-becd-f93ed22b9a54.jpg?1",
             "name": "Nomad Outpost",
             "text": "This land enters tapped.\n{T}: Add {R}, {W}, or {B}.",
             "colours": [],
@@ -9795,7 +9795,7 @@
         },
         {
             "id": "f05d3b0a-d43d-5b63-b7a4-eac882267f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb3b3b-0738-4c2e-a3fc-927fd6b9d3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21cb3b3b-0738-4c2e-a3fc-927fd6b9d3fb.jpg?1",
             "name": "Opulent Palace",
             "text": "This land enters tapped.\n{T}: Add {B}, {G}, or {U}.",
             "colours": [],
@@ -9827,7 +9827,7 @@
         },
         {
             "id": "bcfb9a29-0435-5b99-903b-b7f329e8b620",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31261eca-28ad-407c-84ef-0c124d0d7451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31261eca-28ad-407c-84ef-0c124d0d7451.jpg?1",
             "name": "Rugged Highlands",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -9858,7 +9858,7 @@
         },
         {
             "id": "0109de79-a881-5811-8660-dfdf308024a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f47e7f-39ba-4807-8e32-7262a61dfbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f47e7f-39ba-4807-8e32-7262a61dfbba.jpg?1",
             "name": "Sandsteppe Citadel",
             "text": "This land enters tapped.\n{T}: Add {W}, {B}, or {G}.",
             "colours": [],
@@ -9890,7 +9890,7 @@
         },
         {
             "id": "5c73ca42-b4ef-5d04-a7c6-11757f06cd43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b47b80-69ed-44b0-afa0-ca90206dc16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b47b80-69ed-44b0-afa0-ca90206dc16d.jpg?1",
             "name": "Scoured Barrens",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -9921,7 +9921,7 @@
         },
         {
             "id": "a27b82b2-7fe2-5ead-b6c2-d58cc96a865b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca53fb19-b8ca-485b-af1a-5117ae54bfe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca53fb19-b8ca-485b-af1a-5117ae54bfe3.jpg?1",
             "name": "Swiftwater Cliffs",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -9952,7 +9952,7 @@
         },
         {
             "id": "e64f2ef2-48c4-5a00-bb4a-273eec19524d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb502c2-5fd0-46a9-b77d-010f4a942056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebb502c2-5fd0-46a9-b77d-010f4a942056.jpg?1",
             "name": "Thornwood Falls",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "23bb0b86-c90a-5eb0-9c16-ddbc2b3e0128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4efa6c-4f29-41cd-a728-bf0e479ace05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4efa6c-4f29-41cd-a728-bf0e479ace05.jpg?1",
             "name": "Tranquil Cove",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -10014,7 +10014,7 @@
         },
         {
             "id": "15dd825a-25f0-577f-b4ac-227e335b70db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4912e4d0-b16a-4aa6-a583-3430d26bd591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4912e4d0-b16a-4aa6-a583-3430d26bd591.jpg?1",
             "name": "Wind-Scarred Crag",
             "text": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -10045,7 +10045,7 @@
         },
         {
             "id": "14d18dda-5a48-5bb3-adc9-b8223560cbd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f1dd6-9564-4adc-af7d-f83252e8581a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0f1dd6-9564-4adc-af7d-f83252e8581a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10083,7 +10083,7 @@
         },
         {
             "id": "40bd478c-3ecf-50c5-9f6e-6d0732fb3566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4208e66c-8c98-4c48-ab07-8523c0b26ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4208e66c-8c98-4c48-ab07-8523c0b26ca4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "4015a9de-b920-5be9-a4a5-5e8187d1d787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef235170-8276-4ef0-bdfd-ba68d5b218ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef235170-8276-4ef0-bdfd-ba68d5b218ec.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "6ba271fa-0b3c-5ece-9133-dac432001a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0865ba-47c0-40bc-b0c6-e1ea5ae08a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0865ba-47c0-40bc-b0c6-e1ea5ae08a98.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10197,7 +10197,7 @@
         },
         {
             "id": "620a04ad-e485-51e1-a5a8-2a1a277e1dbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48811e13-5774-4da1-95ec-6ea5dc4976ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48811e13-5774-4da1-95ec-6ea5dc4976ad.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10235,7 +10235,7 @@
         },
         {
             "id": "17166409-51ab-50bc-8259-35c538537473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cff32a-a365-43ee-a196-8ce32b3bb9fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12cff32a-a365-43ee-a196-8ce32b3bb9fd.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10273,7 +10273,7 @@
         },
         {
             "id": "1cfa64b7-ea43-5b5f-ac64-121ec8b622e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c391f2-b340-43c7-89e6-afac5b70491f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8c391f2-b340-43c7-89e6-afac5b70491f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10311,7 +10311,7 @@
         },
         {
             "id": "f48089ee-4511-5278-ae10-02002ba23df9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff6acc9-581c-468f-894d-41f725da7f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff6acc9-581c-468f-894d-41f725da7f33.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10349,7 +10349,7 @@
         },
         {
             "id": "0e723169-35a9-5800-999f-438afb9e6773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15be7923-6efc-4650-b8d1-f61cb33ef81d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15be7923-6efc-4650-b8d1-f61cb33ef81d.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10387,7 +10387,7 @@
         },
         {
             "id": "0a85e2cf-c4c0-5da7-9ae8-5599c520dd7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfdb9e-318f-4acd-9fbd-41b98a8875d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfdb9e-318f-4acd-9fbd-41b98a8875d6.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10425,7 +10425,7 @@
         },
         {
             "id": "8b5fa12b-33ae-571b-8f17-57270ed6ec8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac885eb7-9dae-4c48-b45c-97ef9c62c99e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac885eb7-9dae-4c48-b45c-97ef9c62c99e.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10463,7 +10463,7 @@
         },
         {
             "id": "c56f6511-7ce6-59e6-9bd0-41dca5093249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa10a88-12e0-4b79-80bb-6f4620277e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfa10a88-12e0-4b79-80bb-6f4620277e20.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "c2143cb7-99b2-5cf7-a374-cb7146d46ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df7c206-97b6-49d7-ba01-7a35fd8c61d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df7c206-97b6-49d7-ba01-7a35fd8c61d9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "4699678e-00c2-57fd-9315-f4e95d0002fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8100bceb-ffba-487a-bb45-4fe2a156a8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8100bceb-ffba-487a-bb45-4fe2a156a8dc.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10577,7 +10577,7 @@
         },
         {
             "id": "96e0cf4b-a8b0-5f04-9c30-affa24189153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e83d2-96ba-4d5c-a1ed-6c08a90b339c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3e83d2-96ba-4d5c-a1ed-6c08a90b339c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10615,7 +10615,7 @@
         },
         {
             "id": "0812ab63-65f6-5923-a54b-18ddf265ea3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c67e5-587a-43b2-af47-bbad1f8b52e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c67e5-587a-43b2-af47-bbad1f8b52e9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "6dc572dc-9211-5488-9834-2bb1a88ef0ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b300be80-6618-4284-b5c3-95c1ab373e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b300be80-6618-4284-b5c3-95c1ab373e6f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10691,7 +10691,7 @@
         },
         {
             "id": "4589786e-9dc5-5135-956e-91515d41895a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57da24a0-89a7-4756-b4ca-4dea132e8f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57da24a0-89a7-4756-b4ca-4dea132e8f67.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "65151c13-b4c2-59b9-a765-9d160ce6e191",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db1b7a-93f2-40a5-b649-80a099ddeb62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db1b7a-93f2-40a5-b649-80a099ddeb62.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10767,7 +10767,7 @@
         },
         {
             "id": "a29f61fa-fdc5-5ac1-bf1c-a5541f843d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e33e540-2828-46ad-a441-366552843d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e33e540-2828-46ad-a441-366552843d9c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10805,7 +10805,7 @@
         },
         {
             "id": "d712f631-b0d7-50e6-a566-06d67b7d36f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Flying, vigilance\nAt the beginning of combat on your turn, another target creature you control gets +1/+0 until end of turn.",
             "colours": [
@@ -10841,7 +10841,7 @@
         },
         {
             "id": "1fb9ec32-f91e-5c34-9f17-3661d09a97a9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/48b73810-3abd-4469-a6f0-993b6fedc315.jpg?1",
             "name": "Riling Dawnbreaker // Signaling Roar",
             "text": "Create a 2/2 white Soldier creature token.",
             "colours": [
@@ -10877,7 +10877,7 @@
         },
         {
             "id": "78408a3c-96ee-53be-8a46-c1fb7c350b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717301c-1ae8-44b4-b6e5-d3bdf052f5da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f717301c-1ae8-44b4-b6e5-d3bdf052f5da.jpg?1",
             "name": "Teeming Dragonstorm",
             "text": "When this enchantment enters, create two 2/2 white Soldier creature tokens.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -10911,7 +10911,7 @@
         },
         {
             "id": "473ef613-93b7-5340-8d27-1e356226755d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Flying, ward {2}",
             "colours": [
@@ -10947,7 +10947,7 @@
         },
         {
             "id": "67d74fb4-04dd-5a09-b238-c046a7e214ac",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7def6d6-c80a-4597-8a3f-3855423bc960.jpg?1",
             "name": "Dirgur Island Dragon // Skimming Strike",
             "text": "Tap up to one target creature. Draw a card.",
             "colours": [
@@ -10983,7 +10983,7 @@
         },
         {
             "id": "2edab94a-a3cc-540a-b2ca-45b703b5c151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8d7d3-7e80-4742-9951-eb6679a0aa66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8d7d3-7e80-4742-9951-eb6679a0aa66.jpg?1",
             "name": "Dragonologist",
             "text": "When this creature enters, look at the top six cards of your library. You may reveal an instant, sorcery, or Dragon card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nUntapped Dragons you control have hexproof.",
             "colours": [
@@ -11020,7 +11020,7 @@
         },
         {
             "id": "31e75a75-a0de-51c1-bcac-664214f5e8fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c725add-1cca-4003-8f37-c68f8f8fcc33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c725add-1cca-4003-8f37-c68f8f8fcc33.jpg?1",
             "name": "Roiling Dragonstorm",
             "text": "When this enchantment enters, draw two cards, then discard a card.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11055,7 +11055,7 @@
         },
         {
             "id": "f79a344c-2f52-54a2-9799-c1822e5cc3e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f19964-b37b-4877-bdd5-c5c3022439ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f19964-b37b-4877-bdd5-c5c3022439ef.jpg?1",
             "name": "Corroding Dragonstorm",
             "text": "When this enchantment enters, each opponent loses 2 life and you gain 2 life. Surveil 2.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11089,7 +11089,7 @@
         },
         {
             "id": "6f1b3818-22a3-5675-bc28-5e7fa98a9076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Flying, deathtouch\nWhen this creature enters, exile up to two target cards from a single graveyard.",
             "colours": [
@@ -11125,7 +11125,7 @@
         },
         {
             "id": "c5208366-64c8-5a77-9c78-45b659120eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c446e6-8ffb-45ed-aca2-95161ac88d5c.jpg?1",
             "name": "Feral Deathgorger // Dusk Sight",
             "text": "Put a +1/+1 counter on up to one target creature. Draw a card.",
             "colours": [
@@ -11161,7 +11161,7 @@
         },
         {
             "id": "f3c8775b-55ce-5c8b-8580-cc7ff9e7a98d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbfdf32-8b21-4f7a-aa30-42d5362ee352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bbfdf32-8b21-4f7a-aa30-42d5362ee352.jpg?1",
             "name": "Breaching Dragonstorm",
             "text": "When this enchantment enters, exile cards from the top of your library until you exile a nonland card. You may cast it without paying its mana cost if that spell's mana value is 8 or less. If you don't, put that card into your hand.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11195,7 +11195,7 @@
         },
         {
             "id": "e84ba09b-95c4-5893-9e10-cfba0d9723ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f7c75a-c8f7-4f34-bc86-9d0441dc3a40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f7c75a-c8f7-4f34-bc86-9d0441dc3a40.jpg?1",
             "name": "Dracogenesis",
             "text": "You may cast Dragon spells without paying their mana costs.",
             "colours": [
@@ -11231,7 +11231,7 @@
         },
         {
             "id": "f6150b8e-04be-5146-a89d-0bd2cce459db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a8906f-8593-4ae8-ba65-f2a1cc4c8fa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a8906f-8593-4ae8-ba65-f2a1cc4c8fa6.jpg?1",
             "name": "Magmatic Hellkite",
             "text": "Flying\nWhen this creature enters, destroy target nonbasic land an opponent controls. Its controller searches their library for a basic land card, puts it onto the battlefield tapped with a stun counter on it, then shuffles.",
             "colours": [
@@ -11267,7 +11267,7 @@
         },
         {
             "id": "18d9cd0c-3903-528b-99ad-ebf4fecda30a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c03255-e3dc-44c2-982b-7efa188280df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c03255-e3dc-44c2-982b-7efa188280df.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token.\nWhenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying.",
             "colours": [
@@ -11308,7 +11308,7 @@
         },
         {
             "id": "4c762144-26fc-526f-8681-9ead4a95c12c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c250cbd2-2b78-4721-9977-02de20c3d7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c250cbd2-2b78-4721-9977-02de20c3d7d1.jpg?1",
             "name": "Stormscale Scion",
             "text": "Flying\nOther Dragons you control get +1/+1.\nStorm",
             "colours": [
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "d4a127de-95ad-5674-9c78-02e74bce22cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Flying, haste\n{1}{R}: This creature gets +1/+0 until end of turn.",
             "colours": [
@@ -11380,7 +11380,7 @@
         },
         {
             "id": "a47ed85a-8e94-5626-bca2-9045f278d4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/322e4880-f3f0-44d8-8f95-48b496af0e81.jpg?1",
             "name": "Stormshriek Feral // Flush Out",
             "text": "Discard a card. If you do, draw two cards.",
             "colours": [
@@ -11416,7 +11416,7 @@
         },
         {
             "id": "673bcab7-23d6-5dc7-9723-9545179916c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1e6797-f938-4161-a231-dac2da23b573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1e6797-f938-4161-a231-dac2da23b573.jpg?1",
             "name": "Encroaching Dragonstorm",
             "text": "When this enchantment enters, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -11451,7 +11451,7 @@
         },
         {
             "id": "9ce827a1-e18d-5773-af12-0411cbad8223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Flying\nWhen this creature enters, you gain 3 life.",
             "colours": [
@@ -11487,7 +11487,7 @@
         },
         {
             "id": "fe35bb56-ee0c-573d-9233-9ea274d807cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/7/b72ee8f9-5e79-4f77-ae7e-e4c274f78187.jpg?1",
             "name": "Sagu Wildling // Roost Seek",
             "text": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -11523,7 +11523,7 @@
         },
         {
             "id": "c28f4f1a-5fd9-5a29-931e-8b0b9d0be616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a49553-fc4a-427d-9818-dc8b33fe6127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77a49553-fc4a-427d-9818-dc8b33fe6127.jpg?1",
             "name": "Armament Dragon",
             "text": "Flying\nWhen this creature enters, distribute three +1/+1 counters among one, two, or three target creatures you control.",
             "colours": [
@@ -11563,7 +11563,7 @@
         },
         {
             "id": "1f882c53-ff76-5e9c-a6e2-914c5e3875c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1969dec-4d6b-493a-8233-76faf8fa3cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1969dec-4d6b-493a-8233-76faf8fa3cea.jpg?1",
             "name": "Betor, Kin to All",
             "text": "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
             "colours": [
@@ -11607,7 +11607,7 @@
         },
         {
             "id": "e7f14ccf-f52d-5ec9-adcf-4c503c27a0b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473ac65-acb4-454b-84ce-2a505387cc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9473ac65-acb4-454b-84ce-2a505387cc24.jpg?1",
             "name": "Call the Spirit Dragons",
             "text": "Dragons you control have indestructible.\nAt the beginning of your upkeep, for each color, put a +1/+1 counter on a Dragon you control of that color. If you put +1/+1 counters on five Dragons this way, you win the game.",
             "colours": [
@@ -11649,7 +11649,7 @@
         },
         {
             "id": "f4571dda-8c6d-525e-9de7-cc8d58b91d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Flying\nWhen this creature enters, destroy up to one target artifact or enchantment.",
             "colours": [
@@ -11686,7 +11686,7 @@
         },
         {
             "id": "cd798ff4-840b-5e83-9cc8-c4221bcfb5de",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/24ca444d-f4ab-4375-a670-63f29eb863dd.jpg?1",
             "name": "Disruptive Stormbrood // Petty Revenge",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "6d6868a1-4cc3-5bad-9cce-32677168c860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171ba15b-f981-4b0f-8062-24e4c78fc213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171ba15b-f981-4b0f-8062-24e4c78fc213.jpg?1",
             "name": "Jeskai Shrinekeeper",
             "text": "Flying, haste\nWhenever this creature deals combat damage to a player, you gain 1 life and draw a card.",
             "colours": [
@@ -11763,7 +11763,7 @@
         },
         {
             "id": "1c8713b3-9910-523d-863c-956a76ebcf70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a7d6a-c429-4b66-b5b0-953335c5108e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8a7d6a-c429-4b66-b5b0-953335c5108e.jpg?1",
             "name": "Karakyk Guardian",
             "text": "Flying, vigilance, trample\nThis creature has hexproof if it hasn't dealt damage yet.",
             "colours": [
@@ -11803,7 +11803,7 @@
         },
         {
             "id": "f28a0520-23a8-59ff-acd1-cd80f8a5cc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d85ba44-8f29-4c49-b77f-8a6692d23c8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d85ba44-8f29-4c49-b77f-8a6692d23c8c.jpg?1",
             "name": "Kheru Goldkeeper",
             "text": "Flying\nWhenever one or more cards leave your graveyard during your turn, create a Treasure token.\nRenew \u2014 {2}{B}{G}{U}, Exile this card from your graveyard: Put two +1/+1 counters and a flying counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -11843,7 +11843,7 @@
         },
         {
             "id": "034afac2-7835-5f10-85c1-9e25410f81ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc53504-0eab-4ed2-b498-d8a5267bd40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc53504-0eab-4ed2-b498-d8a5267bd40f.jpg?1",
             "name": "Neriv, Heart of the Storm",
             "text": "Flying\nIf a creature you control that entered this turn would deal damage, it deals twice that much damage instead.",
             "colours": [
@@ -11887,7 +11887,7 @@
         },
         {
             "id": "ec9a7771-205f-542e-974c-82bbd18627bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Flying\nWard\u2014\nPay 2 life.\nWhen this creature enters, remove all counters from up to one target creature.",
             "colours": [
@@ -11924,7 +11924,7 @@
         },
         {
             "id": "17153ab0-839f-5f8a-95c1-ead5b13b45f1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/b/fb293f4f-9ba2-48f5-a4fb-d902aa531bfc.jpg?1",
             "name": "Purging Stormbrood // Absorb Essence",
             "text": "Target creature gets +2/+2 and gains lifelink and hexproof until end of turn.",
             "colours": [
@@ -11961,7 +11961,7 @@
         },
         {
             "id": "aa14ba88-f174-5e11-a88b-ebeaebccc2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Flying\nWhenever you cast a noncreature spell or a Dragon spell, this creature gets +2/+0 until end of turn.",
             "colours": [
@@ -11998,7 +11998,7 @@
         },
         {
             "id": "7cf045a5-8535-5edf-8d61-a5326984a29e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72e8f916-5a01-4918-bcb5-7fd69fe32785.jpg?1",
             "name": "Runescale Stormbrood // Chilling Screech",
             "text": "Counter target spell with mana value 2 or less.",
             "colours": [
@@ -12035,7 +12035,7 @@
         },
         {
             "id": "46e3359c-42e0-5a0d-aad9-f439a1399218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465b6a8-3b8a-47c6-b3d0-119552556d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e465b6a8-3b8a-47c6-b3d0-119552556d35.jpg?1",
             "name": "Shiko, Paragon of the Way",
             "text": "Flying, vigilance\nWhen Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost.",
             "colours": [
@@ -12079,7 +12079,7 @@
         },
         {
             "id": "a51b34bc-767e-50ff-b569-3c62d484c020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a8ee3f-cee5-4971-9112-393f639a210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a8ee3f-cee5-4971-9112-393f639a210e.jpg?1",
             "name": "Sonic Shrieker",
             "text": "Flying\nWhen this creature enters, it deals 2 damage to any target and you gain 2 life. If a player is dealt damage this way, they discard a card.",
             "colours": [
@@ -12119,7 +12119,7 @@
         },
         {
             "id": "a0cba0b4-aec1-5d64-813c-46f1762ce906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3e165a-60e2-4e50-a0de-1cf7c46cb406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d3e165a-60e2-4e50-a0de-1cf7c46cb406.jpg?1",
             "name": "Teval, Arbiter of Virtue",
             "text": "Flying, lifelink\nSpells you cast have delve.\nWhenever you cast a spell, you lose life equal to its mana value.",
             "colours": [
@@ -12163,7 +12163,7 @@
         },
         {
             "id": "8a2e4296-6ff6-599e-bb28-c7674fd67569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Flying\nWhen this creature enters, you gain 5 life.",
             "colours": [
@@ -12200,7 +12200,7 @@
         },
         {
             "id": "de548080-b357-5270-ae8b-16ed4704e35f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/f/ef466256-7d9c-46d0-a860-a0db6930db61.jpg?1",
             "name": "Twinmaw Stormbrood // Charring Bite",
             "text": "Charring Bite deals 5 damage to target creature without flying.",
             "colours": [
@@ -12237,7 +12237,7 @@
         },
         {
             "id": "3a75d55a-6ea1-5668-a753-3b98659817d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683c32f-325a-42f5-826f-5cc978b8333c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a683c32f-325a-42f5-826f-5cc978b8333c.jpg?1",
             "name": "Ureni, the Song Unending",
             "text": "Flying, protection from white and from black\nWhen Ureni enters, it deals X damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control, where X is the number of lands you control.",
             "colours": [
@@ -12281,7 +12281,7 @@
         },
         {
             "id": "c28156ff-a993-57c6-97cf-68410bd21744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Flash\nFlying\nYou may cast sorcery spells and Dragon spells as though they had flash.",
             "colours": [
@@ -12318,7 +12318,7 @@
         },
         {
             "id": "5fc1cb34-1b78-5016-bed4-9552a5ecdd1d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a621ea7f-f6d5-4663-897a-bbdc2556d665.jpg?1",
             "name": "Whirlwing Stormbrood // Dynamic Soar",
             "text": "Put three +1/+1 counters on target creature you control.",
             "colours": [
@@ -12355,7 +12355,7 @@
         },
         {
             "id": "8431c225-aac9-55f5-83e8-e56a6c19ca91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970e11f0-337a-46b5-9bff-4bcb7843ed3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/970e11f0-337a-46b5-9bff-4bcb7843ed3a.jpg?1",
             "name": "Boulderborn Dragon",
             "text": "Flying, vigilance\nWhenever this creature attacks, surveil 1.",
             "colours": [],
@@ -12388,7 +12388,7 @@
         },
         {
             "id": "e89ea40b-1d3f-5987-97cb-9dd88e7c4649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f039ce-cbfd-46d7-a575-5e6c049f83ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f039ce-cbfd-46d7-a575-5e6c049f83ff.jpg?1",
             "name": "Dragonfire Blade",
             "text": "Equipped creature gets +2/+2 and has hexproof from monocolored.\nEquip {4}. This ability costs {1} less to activate for each color of the creature it targets.",
             "colours": [],
@@ -12420,7 +12420,7 @@
         },
         {
             "id": "2266f524-232c-53ad-9fd2-bbca85627469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0372d8-362d-486e-96c0-5738427a1087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0372d8-362d-486e-96c0-5738427a1087.jpg?1",
             "name": "Mox Jasper",
             "text": "{T}: Add one mana of any color. Activate only if you control a Dragon.",
             "colours": [],
@@ -12453,7 +12453,7 @@
         },
         {
             "id": "c61dac4e-cd87-5f82-ae80-cadf12b0d4b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b89e6d-da58-465e-a9b1-69629da159f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b89e6d-da58-465e-a9b1-69629da159f6.jpg?1",
             "name": "Maelstrom of the Spirit Dragon",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Dragon spell or an Omen spell.\n{4}, {T}, Sacrifice this land: Search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
             "colours": [],
@@ -12483,7 +12483,7 @@
         },
         {
             "id": "82df3262-c519-5a46-a8e4-fb3ad5cc03ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f31696-2307-4ec6-a568-c255a25b59b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f31696-2307-4ec6-a568-c255a25b59b6.jpg?1",
             "name": "Anafenza, Unyielding Lineage",
             "text": "Flash\nFirst strike\nWhenever another nontoken creature you control dies, Anafenza endures 2.",
             "colours": [
@@ -12522,7 +12522,7 @@
         },
         {
             "id": "3b07fdcb-7c5d-554f-bfa5-4b76b5e856b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e7ddf5-5aaf-4233-834d-c9992a9c2b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53e7ddf5-5aaf-4233-834d-c9992a9c2b0e.jpg?1",
             "name": "Sage of the Skies",
             "text": "When you cast this spell, if you've cast another spell this turn, copy this spell.\nFlying, lifelink",
             "colours": [
@@ -12559,7 +12559,7 @@
         },
         {
             "id": "8f2d3e58-dca9-5d45-9e91-792687b20751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5121b5a4-5f91-4bd3-a8b1-c2dc2a449378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5121b5a4-5f91-4bd3-a8b1-c2dc2a449378.jpg?1",
             "name": "Smile at Death",
             "text": "At the beginning of your upkeep, return up to two target creature cards with power 2 or less from your graveyard to the battlefield. Put a +1/+1 counter on each of those creatures.",
             "colours": [
@@ -12593,7 +12593,7 @@
         },
         {
             "id": "61720e0c-3f75-500e-91fb-37e1e70defd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d8e5c-4b3d-4c5c-89c5-a2746cd4b578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6d8e5c-4b3d-4c5c-89c5-a2746cd4b578.jpg?1",
             "name": "United Battlefront",
             "text": "Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12627,7 +12627,7 @@
         },
         {
             "id": "919f2be0-249b-5bca-9b2a-54c098adbf9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f24785-c7b3-46ab-833e-666af3d86c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73f24785-c7b3-46ab-833e-666af3d86c63.jpg?1",
             "name": "Voice of Victory",
             "text": "Mobilize 2\nYour opponents can't cast spells during your turn.",
             "colours": [
@@ -12664,7 +12664,7 @@
         },
         {
             "id": "80326b0e-3aa9-5d50-a745-eca125ca2b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67235e-13d3-40ba-9cb7-03c1db6d455e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c67235e-13d3-40ba-9cb7-03c1db6d455e.jpg?1",
             "name": "Ambling Stormshell",
             "text": "Ward {2}\nWhenever this creature attacks, put three stun counters on it and draw three cards.\nWhenever you cast a Turtle spell, untap this creature.",
             "colours": [
@@ -12700,7 +12700,7 @@
         },
         {
             "id": "d3bd7639-f0f2-5825-927b-a2b1d85fcc49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4863c-51bc-445d-97a5-289b5a87c871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95b4863c-51bc-445d-97a5-289b5a87c871.jpg?1",
             "name": "Naga Fleshcrafter",
             "text": "You may have this creature enter as a copy of any creature on the battlefield.\nRenew \u2014 {2}{U}, Exile this card from your graveyard: Put a +1/+1 counter on target nonlegendary creature you control. Each other creature you control becomes a copy of that creature until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -12737,7 +12737,7 @@
         },
         {
             "id": "3a6161db-d36f-5daf-b7ca-52d36a243a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ae35fd-5fb6-440a-9e82-13998b928ee3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70ae35fd-5fb6-440a-9e82-13998b928ee3.jpg?1",
             "name": "Stillness in Motion",
             "text": "At the beginning of your upkeep, mill three cards. Then if your library has no cards in it, exile this enchantment and put five cards from your graveyard on top of your library in any order.",
             "colours": [
@@ -12771,7 +12771,7 @@
         },
         {
             "id": "c76c7adf-015e-5757-a512-6b173967d008",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8c278-781d-4c9c-9f1c-99d799384a29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ea8c278-781d-4c9c-9f1c-99d799384a29.jpg?1",
             "name": "Taigam, Master Opportunist",
             "text": "Flurry \u2014 Whenever you cast your second spell each turn, copy it, then exile the spell you cast with four time counters on it. If it doesn't have suspend, it gains suspend.",
             "colours": [
@@ -12810,7 +12810,7 @@
         },
         {
             "id": "d6bece2e-e235-597b-803c-1af2ca39462e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94538c3-320c-4903-a689-bb8e9f4ae40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94538c3-320c-4903-a689-bb8e9f4ae40f.jpg?1",
             "name": "Winternight Stories",
             "text": "Draw three cards. Then discard two cards unless you discard a creature card.\nHarmonize {4}{U}",
             "colours": [
@@ -12844,7 +12844,7 @@
         },
         {
             "id": "789719b8-2375-578a-93ae-f8b42fc13b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae9ca3b-cc32-410f-82e9-85cb9c4fa447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae9ca3b-cc32-410f-82e9-85cb9c4fa447.jpg?1",
             "name": "Avenger of the Fallen",
             "text": "Deathtouch\nMobilize X, where X is the number of creature cards in your graveyard.",
             "colours": [
@@ -12881,7 +12881,7 @@
         },
         {
             "id": "1a22d2b2-87ca-5329-b675-0fb192c7b35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca69694-c345-4255-9c92-0110aa5c8004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca69694-c345-4255-9c92-0110aa5c8004.jpg?1",
             "name": "Qarsi Revenant",
             "text": "Flying, deathtouch, lifelink\nRenew \u2014 {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch counter, and a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -12918,7 +12918,7 @@
         },
         {
             "id": "59696c13-d8ed-59b8-9526-b63d6f36a3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd34da53-1a96-4f06-aaf6-e70581de112d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd34da53-1a96-4f06-aaf6-e70581de112d.jpg?1",
             "name": "Rot-Curse Rakshasa",
             "text": "Trample\nDecayed\nRenew \u2014 {X}{B}{B}, Exile this card from your graveyard: Put a decayed counter on each of X target creatures. Activate only as a sorcery.",
             "colours": [
@@ -12954,7 +12954,7 @@
         },
         {
             "id": "2e49d5aa-c132-5430-ab91-7e5239779c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daa156c-478f-47dd-9284-b95e82ccfd68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6daa156c-478f-47dd-9284-b95e82ccfd68.jpg?1",
             "name": "The Sibsig Ceremony",
             "text": "Creature spells you cast cost {2} less to cast.\nWhenever a creature you control enters, if you cast it, destroy that creature, then create a 2/2 black Zombie Druid creature token.",
             "colours": [
@@ -12990,7 +12990,7 @@
         },
         {
             "id": "261956d1-43b9-5590-96e9-1afb3d896722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9e3ddc-a4e7-4304-bfd8-890c9c71f53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f9e3ddc-a4e7-4304-bfd8-890c9c71f53d.jpg?1",
             "name": "Sidisi, Regent of the Mire",
             "text": "{T}, Sacrifice a creature you control with mana value X other than Sidisi: Return target creature card with mana value X plus 1 from your graveyard to the battlefield. Activate only as a sorcery.",
             "colours": [
@@ -13030,7 +13030,7 @@
         },
         {
             "id": "744ab549-a1cd-52ae-8690-f837d57c4403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b155cd-c3a0-4f27-8d3c-7778354abbd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b155cd-c3a0-4f27-8d3c-7778354abbd4.jpg?1",
             "name": "Sinkhole Surveyor",
             "text": "Flying\nWhenever this creature attacks, you lose 1 life and this creature endures 1.",
             "colours": [
@@ -13067,7 +13067,7 @@
         },
         {
             "id": "d152ccf9-4f01-54f8-9c43-e3db60eebe22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470dd3c8-07c9-42ef-aa9e-3c73b23607ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/470dd3c8-07c9-42ef-aa9e-3c73b23607ff.jpg?1",
             "name": "Cori-Steel Cutter",
             "text": "Equipped creature gets +1/+1 and has trample and haste.\nFlurry \u2014 Whenever you cast your second spell each turn, create a 1/1 white Monk creature token with prowess. You may attach this Equipment to it.\nEquip {1}{R}",
             "colours": [
@@ -13103,7 +13103,7 @@
         },
         {
             "id": "0f4e43d1-0bce-56e8-8cec-4899028d5fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7a1ddf-bf52-4d44-92cd-8d8127472bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7a1ddf-bf52-4d44-92cd-8d8127472bd9.jpg?1",
             "name": "Stadium Headliner",
             "text": "Mobilize 1\n{1}{R}, Sacrifice this creature: It deals damage equal to the number of creatures you control to target creature.",
             "colours": [
@@ -13140,7 +13140,7 @@
         },
         {
             "id": "3eebfc13-e1d4-5f4c-83f2-4a7568b964c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1689bb-f7a4-4b53-8473-75b7ce7b496d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a1689bb-f7a4-4b53-8473-75b7ce7b496d.jpg?1",
             "name": "Tersa Lightshatter",
             "text": "Haste\nWhen Tersa Lightshatter enters, discard up to two cards, then draw that many cards.\nWhenever Tersa Lightshatter attacks, if there are seven or more cards in your graveyard, exile a card at random from your graveyard. You may play that card this turn.",
             "colours": [
@@ -13179,7 +13179,7 @@
         },
         {
             "id": "07cd6e47-ce93-52ce-8d79-6a7b5dd79d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c966c8a0-e73d-4484-9307-a793a65222ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c966c8a0-e73d-4484-9307-a793a65222ea.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen this creature enters, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -13217,7 +13217,7 @@
         },
         {
             "id": "6c522b08-9860-5937-816a-27ac960c4fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e7d936-60f8-40fc-b6a9-be677a97395b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e7d936-60f8-40fc-b6a9-be677a97395b.jpg?1",
             "name": "Herd Heirloom",
             "text": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.\n{T}: Until end of turn, target creature you control with power 4 or greater gains trample and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "5d29751f-e733-5569-8be2-aba18d6b3531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2683ba05-13aa-44ca-8465-d9fa19ae610d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2683ba05-13aa-44ca-8465-d9fa19ae610d.jpg?1",
             "name": "Lasyd Prowler",
             "text": "When this creature enters, you may mill cards equal to the number of lands you control.\nRenew \u2014 {1}{G}, Exile this card from your graveyard: Put X +1/+1 counters on target creature, where X is the number of land cards in your graveyard. Activate only as a sorcery.",
             "colours": [
@@ -13288,7 +13288,7 @@
         },
         {
             "id": "42a5809c-bd9b-5c85-90e3-ee44337dc16e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0ee309-b6c4-455d-8af6-48d8ac1426cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0ee309-b6c4-455d-8af6-48d8ac1426cb.jpg?1",
             "name": "Nature's Rhythm",
             "text": "Search your library for a creature card with mana value X or less, put it onto the battlefield, then shuffle.\nHarmonize {X}{G}{G}{G}{G}",
             "colours": [
@@ -13322,7 +13322,7 @@
         },
         {
             "id": "8557f671-af04-50b0-8b7f-ab1dc0972999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc80d937-a166-42e7-a7b3-56150e11d27e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc80d937-a166-42e7-a7b3-56150e11d27e.jpg?1",
             "name": "Surrak, Elusive Hunter",
             "text": "This spell can't be countered.\nTrample\nWhenever a creature you control or a creature spell you control becomes the target of a spell or ability an opponent controls, draw a card.",
             "colours": [
@@ -13361,7 +13361,7 @@
         },
         {
             "id": "707f1d02-3458-5023-8013-6ad3b97c0c05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3d7969-5dcb-434d-8a8b-fb16da288bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3d7969-5dcb-434d-8a8b-fb16da288bc4.jpg?1",
             "name": "Warden of the Grove",
             "text": "At the beginning of your end step, put a +1/+1 counter on this creature.\nWhenever another nontoken creature you control enters, it endures X, where X is the number of counters on this creature.",
             "colours": [
@@ -13397,7 +13397,7 @@
         },
         {
             "id": "fe85a233-b23b-5a85-aeb8-3cba2bc09d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febe8c-7e00-485a-bd06-1d7c4d4e816e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0febe8c-7e00-485a-bd06-1d7c4d4e816e.jpg?1",
             "name": "All-Out Assault",
             "text": "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment enters, if it's your main phase, there is an additional combat phase after this phase followed by an additional main phase. When you next attack this turn, untap each creature you control.",
             "colours": [
@@ -13437,7 +13437,7 @@
         },
         {
             "id": "7a2237f0-fa18-5dd3-9a9a-0c9e90d9d50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cf348-7db8-4f93-8f83-8b1f2035ed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c8cf348-7db8-4f93-8f83-8b1f2035ed4e.jpg?1",
             "name": "Betor, Kin to All",
             "text": "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
             "colours": [
@@ -13481,7 +13481,7 @@
         },
         {
             "id": "90a0e078-a974-5cf4-bbb9-036a3831c384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e94b23-955b-45c0-9cef-713a0a6c38ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8e94b23-955b-45c0-9cef-713a0a6c38ac.jpg?1",
             "name": "Death Begets Life",
             "text": "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.",
             "colours": [
@@ -13521,7 +13521,7 @@
         },
         {
             "id": "91830022-db72-5e8a-a4ca-35a9015e1499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87970548-bbec-4f07-b534-e463c9128469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87970548-bbec-4f07-b534-e463c9128469.jpg?1",
             "name": "Dragonback Assault",
             "text": "When this enchantment enters, it deals 3 damage to each creature and each planeswalker.\nLandfall \u2014 Whenever a land you control enters, create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -13559,7 +13559,7 @@
         },
         {
             "id": "fe172a43-7776-5044-86b9-5832dfa72094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafaa59e-87e1-4953-8c04-8e7a3a509827.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafaa59e-87e1-4953-8c04-8e7a3a509827.jpg?1",
             "name": "Eshki Dragonclaw",
             "text": "Vigilance, trample, ward {1}\nAt the beginning of combat on your turn, if you've cast both a creature spell and a noncreature spell this turn, draw a card and put two +1/+1 counters on Eshki Dragonclaw.",
             "colours": [
@@ -13602,7 +13602,7 @@
         },
         {
             "id": "8d265b9c-3f3a-5fa3-9a6c-90a3783e699c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8178e63d-caa6-4088-aaef-367fb24638a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8178e63d-caa6-4088-aaef-367fb24638a4.jpg?1",
             "name": "Fangkeeper's Familiar",
             "text": "Flash\nWhen this creature enters, choose one \u2014\n\u2022 You gain 3 life and surveil 3.\n\u2022 Destroy target enchantment.\n\u2022 Counter target creature spell.",
             "colours": [
@@ -13642,7 +13642,7 @@
         },
         {
             "id": "7a4228ea-df00-5648-a8f7-f4eac0b0ef1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4f9d0f-11fa-4986-a7e8-64a922681906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c4f9d0f-11fa-4986-a7e8-64a922681906.jpg?1",
             "name": "Felothar, Dawn of the Abzan",
             "text": "Trample\nWhenever Felothar enters or attacks, you may sacrifice a nonland permanent. When you do, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -13685,7 +13685,7 @@
         },
         {
             "id": "e93a7579-d411-5d34-8a79-6cae9bc5c7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60667979-40c1-4144-a3f8-0115fb77341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60667979-40c1-4144-a3f8-0115fb77341d.jpg?1",
             "name": "Flamehold Grappler",
             "text": "First strike\nWhen this creature enters, copy the next spell you cast this turn when you cast it. You may choose new targets for the copy.",
             "colours": [
@@ -13726,7 +13726,7 @@
         },
         {
             "id": "a00747b3-01bc-5e44-8a43-61e428763ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f049ce-6bc7-437d-a530-8c4278151569.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4f049ce-6bc7-437d-a530-8c4278151569.jpg?1",
             "name": "Inevitable Defeat",
             "text": "This spell can't be countered.\nExile target nonland permanent. Its controller loses 3 life and you gain 3 life.",
             "colours": [
@@ -13764,7 +13764,7 @@
         },
         {
             "id": "d6569638-b53b-54e7-b46e-bc9d886fdb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7679a6a2-7704-4f37-9fdd-24414d411599.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7679a6a2-7704-4f37-9fdd-24414d411599.jpg?1",
             "name": "Jeskai Revelation",
             "text": "Return target spell or permanent to its owner's hand. Jeskai Revelation deals 4 damage to any target. Create two 1/1 white Monk creature tokens with prowess. Draw two cards. You gain 4 life.",
             "colours": [
@@ -13802,7 +13802,7 @@
         },
         {
             "id": "3001522a-bc02-589b-a27b-15f9bbb25855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70098f2-e5a8-4056-b5b3-1229fc290c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70098f2-e5a8-4056-b5b3-1229fc290c51.jpg?1",
             "name": "Kotis, the Fangkeeper",
             "text": "Indestructible\nWhenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "39f2f18a-c019-5c5a-ab83-a7d135438bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc69dc-6245-43fc-95a2-85b2c2957182.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79dc69dc-6245-43fc-95a2-85b2c2957182.jpg?1",
             "name": "Lotuslight Dancers",
             "text": "Lifelink\nWhen this creature enters, search your library for a black card, a green card, and a blue card. Put those cards into your graveyard, then shuffle.",
             "colours": [
@@ -13886,7 +13886,7 @@
         },
         {
             "id": "5c4adf3a-be95-58f5-930f-afed30dc76e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa10a98-1d1f-4e66-b81d-615ffaf43ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa10a98-1d1f-4e66-b81d-615ffaf43ca1.jpg?1",
             "name": "Mardu Siegebreaker",
             "text": "Deathtouch, haste\nWhen this creature enters, exile up to one other target creature you control until this creature leaves the battlefield.\nWhenever this creature attacks, for each opponent, create a tapped token that's a copy of the exiled card attacking that opponent. At the beginning of your end step, sacrifice those tokens.",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "6b2c9a4f-3cf8-5722-81bc-d5a4b8273471",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccfb58a-4844-466c-81ea-5fb73863bccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cccfb58a-4844-466c-81ea-5fb73863bccf.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "At the beginning of your end step, you may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn.",
             "colours": [
@@ -13972,7 +13972,7 @@
         },
         {
             "id": "8f2e38cb-6fcb-57ca-9a58-f1e9bc05e555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72f191b-81d5-4db4-ac42-c5482f15385d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72f191b-81d5-4db4-ac42-c5482f15385d.jpg?1",
             "name": "Neriv, Heart of the Storm",
             "text": "Flying\nIf a creature you control that entered this turn would deal damage, it deals twice that much damage instead.",
             "colours": [
@@ -14016,7 +14016,7 @@
         },
         {
             "id": "9cefef1e-f127-5aaa-adff-801327cdf564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc8ee7-3a1c-49f7-aa67-ff68c377e38c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebc8ee7-3a1c-49f7-aa67-ff68c377e38c.jpg?1",
             "name": "New Way Forward",
             "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. When damage is prevented this way, New Way Forward deals that much damage to that source's controller and you draw that many cards.",
             "colours": [
@@ -14054,7 +14054,7 @@
         },
         {
             "id": "851ce330-44a1-50f4-a1f7-2b688deb3c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5596f0c7-8007-4136-bab0-58a9cd852a6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5596f0c7-8007-4136-bab0-58a9cd852a6e.jpg?1",
             "name": "Perennation",
             "text": "Return target permanent card from your graveyard to the battlefield with a hexproof counter and an indestructible counter on it.",
             "colours": [
@@ -14092,7 +14092,7 @@
         },
         {
             "id": "fdb6fcde-c5a6-5a57-b51c-931ce98c6277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ccfa2-24e3-47aa-b244-31e29b216058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585ccfa2-24e3-47aa-b244-31e29b216058.jpg?1",
             "name": "Severance Priest",
             "text": "Deathtouch\nWhen this creature enters, target opponent reveals their hand. You may choose a nonland card from it. If you do, exile that card.\nWhen this creature leaves the battlefield, the exiled card's owner creates an X/X white Spirit creature token, where X is the mana value of the exiled card.",
             "colours": [
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "5b9cde5e-7e77-5407-a9cd-d50bf0962f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fd0437-bfb4-4a9e-9109-d172bfb3faab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47fd0437-bfb4-4a9e-9109-d172bfb3faab.jpg?1",
             "name": "Shiko, Paragon of the Way",
             "text": "Flying, vigilance\nWhen Shiko enters, exile target nonland card with mana value 3 or less from your graveyard. Copy it, then you may cast the copy without paying its mana cost.",
             "colours": [
@@ -14177,7 +14177,7 @@
         },
         {
             "id": "3312282d-221a-5335-86dd-889a8b958469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584eb844-91e2-47fb-b4e0-f5def65b824a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584eb844-91e2-47fb-b4e0-f5def65b824a.jpg?1",
             "name": "Songcrafter Mage",
             "text": "Flash\nWhen this creature enters, target instant or sorcery card in your graveyard gains harmonize until end of turn. Its harmonize cost is equal to its mana cost.",
             "colours": [
@@ -14218,7 +14218,7 @@
         },
         {
             "id": "bbd3e325-955b-52f4-a3f9-737ff8bf4b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141492f-f971-4b7f-afdd-e37537f4d3f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141492f-f971-4b7f-afdd-e37537f4d3f5.jpg?1",
             "name": "Temur Battlecrier",
             "text": "During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.",
             "colours": [
@@ -14260,7 +14260,7 @@
         },
         {
             "id": "dcbebd66-cf08-5e8d-8933-fa872f4ee5aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19c38bc-946c-438a-ac8b-f59ff0b4c613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19c38bc-946c-438a-ac8b-f59ff0b4c613.jpg?1",
             "name": "Teval, Arbiter of Virtue",
             "text": "Flying, lifelink\nSpells you cast have delve.\nWhenever you cast a spell, you lose life equal to its mana value.",
             "colours": [
@@ -14304,7 +14304,7 @@
         },
         {
             "id": "92e1f5b4-d20b-5ee4-9810-269d1350949e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ea13cf-2fa3-411f-9dc5-13d75f0c67dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ea13cf-2fa3-411f-9dc5-13d75f0c67dd.jpg?1",
             "name": "Ureni, the Song Unending",
             "text": "Flying, protection from white and from black\nWhen Ureni enters, it deals X damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control, where X is the number of lands you control.",
             "colours": [
@@ -14348,7 +14348,7 @@
         },
         {
             "id": "d6ccd2a5-944e-59f1-89a7-cf4dd94a59a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715afdde-ef3b-40c0-8b1d-59c59381a54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/715afdde-ef3b-40c0-8b1d-59c59381a54e.jpg?1",
             "name": "Yathan Roadwatcher",
             "text": "When this creature enters, if you cast it, mill four cards. When you do, return target creature card with mana value 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -14389,7 +14389,7 @@
         },
         {
             "id": "d9a8c368-1e36-55fc-a152-b11a86ec5607",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d899dde2-68e6-4807-b0e9-3f4e28824822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d899dde2-68e6-4807-b0e9-3f4e28824822.jpg?1",
             "name": "Zurgo, Thunder's Decree",
             "text": "Mobilize 2\nDuring your end step, Warrior tokens you control have \"This token can't be sacrificed.\"",
             "colours": [
@@ -14432,7 +14432,7 @@
         },
         {
             "id": "1aaaaffe-949e-528f-8738-c9fcfb770942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg?1",
             "name": "Clarion Conqueror // Clarion Conqueror",
             "text": "Flying\nActivated abilities of artifacts, creatures, and planeswalkers can't be activated.",
             "colours": [
@@ -14466,7 +14466,7 @@
         },
         {
             "id": "8c72b366-acf7-52ab-b68d-a58c66387d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3aecdfc-9d37-4f1f-9123-fc07b669d747.jpg?1",
             "name": "Clarion Conqueror // Clarion Conqueror",
             "text": "",
             "colours": [
@@ -14500,7 +14500,7 @@
         },
         {
             "id": "86bff115-01db-56ff-98e0-be341b3a5418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg?1",
             "name": "Marang River Regent // Coil and Catch // Marang River Regent",
             "text": "",
             "colours": [
@@ -14534,7 +14534,7 @@
         },
         {
             "id": "0f2a46c0-bcd9-5daa-9c0b-f54781ac224f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/8/484b5580-b179-4dce-8bdf-d714eb4635e5.jpg?1",
             "name": "Marang River Regent // Coil and Catch // Marang River Regent",
             "text": "",
             "colours": [
@@ -14568,7 +14568,7 @@
         },
         {
             "id": "8b4d35ae-8a75-5b17-80b1-1d74905aaca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg?1",
             "name": "Scavenger Regent // Exude Toxin // Scavenger Regent",
             "text": "",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "929154b4-131f-5a71-8804-5b21e2e1940d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/c/9cf54062-7b5b-4e46-ae1e-fab7e419a9fa.jpg?1",
             "name": "Scavenger Regent // Exude Toxin // Scavenger Regent",
             "text": "",
             "colours": [
@@ -14636,7 +14636,7 @@
         },
         {
             "id": "a530ac93-a5a3-5405-b88a-0567d12dd958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg?1",
             "name": "Magmatic Hellkite // Magmatic Hellkite",
             "text": "Flying\nWhen this creature enters, destroy target nonbasic land an opponent controls. Its controller searches their library for a basic land card, puts it onto the battlefield tapped with a stun counter on it, then shuffles.",
             "colours": [
@@ -14670,7 +14670,7 @@
         },
         {
             "id": "20908821-b28a-5709-b6a1-1d63bce29407",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/4981dc79-4efd-40e1-9fc1-c08e284aff22.jpg?1",
             "name": "Magmatic Hellkite // Magmatic Hellkite",
             "text": "",
             "colours": [
@@ -14704,7 +14704,7 @@
         },
         {
             "id": "f673f839-7985-5159-ad35-61c3c553c94e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg?1",
             "name": "Bloomvine Regent // Claim Territory // Bloomvine Regent",
             "text": "",
             "colours": [
@@ -14738,7 +14738,7 @@
         },
         {
             "id": "188638aa-0bdd-5690-9333-e51cdd087eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/8/081f2de5-251a-41c9-a62f-11487f54d355.jpg?1",
             "name": "Bloomvine Regent // Claim Territory // Bloomvine Regent",
             "text": "",
             "colours": [
@@ -14772,7 +14772,7 @@
         },
         {
             "id": "6fca668c-fd12-5512-a110-9de5c1634c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg?1",
             "name": "Ugin, Eye of the Storms // Ugin, Eye of the Storms",
             "text": "When you cast this spell, exile up to one target permanent that's one or more colors.\nWhenever you cast a colorless spell, exile up to one target permanent that's one or more colors.\n+2: You gain 3 life and draw a card.\n0: Add {C}{C}{C}.\n\u221211: Search your library for any number of colorless nonland cards, exile them, then shuffle. Until end of turn, you may cast those cards without paying their mana costs.",
             "colours": [],
@@ -14804,7 +14804,7 @@
         },
         {
             "id": "0d3dfdf9-27b9-5077-b13a-5ea3ebea2d91",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/3/53b11c30-1c4e-4238-9d42-2e1480df60c1.jpg?1",
             "name": "Ugin, Eye of the Storms // Ugin, Eye of the Storms",
             "text": "",
             "colours": [],
@@ -14836,7 +14836,7 @@
         },
         {
             "id": "cacfb167-dfce-52b3-b845-4b113102dfb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bd76c7-7a1e-4119-8f4a-12b536b30a32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76bd76c7-7a1e-4119-8f4a-12b536b30a32.jpg?1",
             "name": "Awaken the Honored Dead",
             "text": "I \u2014 Destroy target nonland permanent.\nII \u2014 Mill three cards.\nIII \u2014 You may discard a card. When you do, return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -14876,7 +14876,7 @@
         },
         {
             "id": "a5d4170c-cb6d-5f62-9719-c1cf9d0374f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09d4015-f101-4529-a603-c66192dcfd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09d4015-f101-4529-a603-c66192dcfd92.jpg?1",
             "name": "Barrensteppe Siege",
             "text": "As this enchantment enters, choose Abzan or Mardu.\n\u2022 Abzan \u2014 At the beginning of your end step, put a +1/+1 counter on each creature you control.\n\u2022 Mardu \u2014 At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
             "colours": [
@@ -14912,7 +14912,7 @@
         },
         {
             "id": "a3511d29-d929-5ed9-8288-a1b3c3a85144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32ab782-5f99-489c-895a-49c5c5ea249d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32ab782-5f99-489c-895a-49c5c5ea249d.jpg?1",
             "name": "Frostcliff Siege",
             "text": "As this enchantment enters, choose Jeskai or Temur.\n\u2022 Jeskai \u2014 Whenever one or more creatures you control deal combat damage to a player, draw a card.\n\u2022 Temur \u2014 Creatures you control get +1/+0 and have trample and haste.",
             "colours": [
@@ -14948,7 +14948,7 @@
         },
         {
             "id": "51561b32-c0a3-5fa6-8621-46ec41b7df07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6626cc5e-3a9f-4832-a88a-abf6466e2bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6626cc5e-3a9f-4832-a88a-abf6466e2bae.jpg?1",
             "name": "Glacierwood Siege",
             "text": "As this enchantment enters, choose Temur or Sultai.\n\u2022 Temur \u2014 Whenever you cast an instant or sorcery spell, target player mills four cards.\n\u2022 Sultai \u2014 You may play lands from your graveyard.",
             "colours": [
@@ -14984,7 +14984,7 @@
         },
         {
             "id": "e686dfe3-c104-5e7c-8e62-da44fd9f3e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9a6427-09cc-4ddf-88a6-fc23498a7c08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9a6427-09cc-4ddf-88a6-fc23498a7c08.jpg?1",
             "name": "Hollowmurk Siege",
             "text": "As this enchantment enters, choose Sultai or Abzan.\n\u2022 Sultai \u2014 Whenever a counter is put on a creature you control, draw a card. This ability triggers only once each turn.\n\u2022 Abzan \u2014 Whenever you attack, put a +1/+1 counter on target attacking creature. It gains menace until end of turn.",
             "colours": [
@@ -15020,7 +15020,7 @@
         },
         {
             "id": "3f7de260-8a02-5493-bf72-4e09f9e6725d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0797b4-7e06-4f64-95f3-3a7d694d601a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0797b4-7e06-4f64-95f3-3a7d694d601a.jpg?1",
             "name": "Rediscover the Way",
             "text": "I, II \u2014 Look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.\nIII \u2014 Whenever you cast a noncreature spell this turn, target creature you control gains double strike until end of turn.",
             "colours": [
@@ -15060,7 +15060,7 @@
         },
         {
             "id": "9a7e66d3-e97b-5670-ac52-3f73c2b202f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae833e4-b1b8-44cf-a831-d10b78328b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae833e4-b1b8-44cf-a831-d10b78328b81.jpg?1",
             "name": "Revival of the Ancestors",
             "text": "I \u2014 Create three 1/1 white Spirit creature tokens.\nII \u2014 Distribute three +1/+1 counters among one, two, or three target creatures you control.\nIII \u2014 Creatures you control gain trample and lifelink until end of turn.",
             "colours": [
@@ -15100,7 +15100,7 @@
         },
         {
             "id": "bcc68561-b809-5ae5-9578-323229ea0bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2624c7f-1c10-49c7-be74-e7b2dc8dac12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2624c7f-1c10-49c7-be74-e7b2dc8dac12.jpg?1",
             "name": "Roar of Endless Song",
             "text": "I, II \u2014 Create a 5/5 green Elephant creature token.\nIII \u2014 Double the power and toughness of each creature you control until end of turn.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "31cde842-b500-52c2-997e-d44947559dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd218be-b4c1-4dc7-9672-a16892f1b1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fd218be-b4c1-4dc7-9672-a16892f1b1e7.jpg?1",
             "name": "Thunder of Unity",
             "text": "I \u2014 You draw two cards and you lose 2 life.\nII, III \u2014 Whenever a creature you control enters this turn, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -15180,7 +15180,7 @@
         },
         {
             "id": "35526741-35c6-5b8b-ab70-ef9aa7c134e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32111e6-c389-4dcd-9dcd-29ee7ee238e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b32111e6-c389-4dcd-9dcd-29ee7ee238e6.jpg?1",
             "name": "Windcrag Siege",
             "text": "As this enchantment enters, choose Mardu or Jeskai.\n\u2022 Mardu \u2014 If a creature attacking causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.\n\u2022 Jeskai \u2014 At the beginning of your upkeep, create a 1/1 red Goblin creature token. It gains lifelink and haste until end of turn.",
             "colours": [
@@ -15216,7 +15216,7 @@
         },
         {
             "id": "bd83e20a-0bee-5382-8358-3221287b64be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b84c4c-465d-4d8d-8d38-2ed08a9213b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85b84c4c-465d-4d8d-8d38-2ed08a9213b3.jpg?1",
             "name": "Cori Mountain Monastery",
             "text": "This land enters tapped unless you control a Plains or an Island.\n{T}: Add {R}.\n{3}{R}, {T}: Exile the top card of your library. Until the end of your next turn, you may play that card.",
             "colours": [],
@@ -15248,7 +15248,7 @@
         },
         {
             "id": "bc9b810f-1605-55a9-891a-c51a6814e1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af006f6-135e-4ea0-8ce4-7824934e87da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af006f6-135e-4ea0-8ce4-7824934e87da.jpg?1",
             "name": "Dalkovan Encampment",
             "text": "This land enters tapped unless you control a Swamp or a Mountain.\n{T}: Add {W}.\n{2}{W}, {T}: Whenever you attack this turn, create two 1/1 red Warrior creature tokens that are tapped and attacking. Sacrifice them at the beginning of the next end step.",
             "colours": [],
@@ -15280,7 +15280,7 @@
         },
         {
             "id": "b2ff3a0f-1b47-5741-b93c-aea65f63f15c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98fdfc0-5dd2-4059-8fd6-73378235de55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98fdfc0-5dd2-4059-8fd6-73378235de55.jpg?1",
             "name": "Great Arashin City",
             "text": "This land enters tapped unless you control a Forest or a Plains.\n{T}: Add {B}.\n{1}{B}, {T}, Exile a creature card from your graveyard: Create a 1/1 white Spirit creature token.",
             "colours": [],
@@ -15312,7 +15312,7 @@
         },
         {
             "id": "a730ceee-a34f-5837-9818-526b29db1c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687459d1-f487-4ef6-9532-d68425d71210.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/687459d1-f487-4ef6-9532-d68425d71210.jpg?1",
             "name": "Kishla Village",
             "text": "This land enters tapped unless you control an Island or a Swamp.\n{T}: Add {G}.\n{3}{G}, {T}: Surveil 2.",
             "colours": [],
@@ -15344,7 +15344,7 @@
         },
         {
             "id": "0dcfd635-84c9-5f2b-bc5b-eb2a09c18896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4f775c-98dd-4506-a02c-d22024f31d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c4f775c-98dd-4506-a02c-d22024f31d67.jpg?1",
             "name": "Mistrise Village",
             "text": "This land enters tapped unless you control a Mountain or a Forest.\n{T}: Add {U}.\n{U}, {T}: The next spell you cast this turn can't be countered.",
             "colours": [],
@@ -15376,7 +15376,7 @@
         },
         {
             "id": "ef7955f4-0aca-53a4-9b00-ffb5ddbae260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdf9438-fd5f-4638-8f41-dae35ae8f257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdf9438-fd5f-4638-8f41-dae35ae8f257.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n+1: Create a 1/1 white Soldier creature token.\n0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your next turn.\n\u22123: Destroy target creature an opponent controls with mana value 3 or greater.",
             "colours": [
@@ -15416,7 +15416,7 @@
         },
         {
             "id": "8cc28706-1594-582f-b0d1-ae4bbfa6e5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43085bc6-4d16-4a78-af31-b10cea602fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43085bc6-4d16-4a78-af31-b10cea602fc8.jpg?1",
             "name": "Ugin, Eye of the Storms",
             "text": "When you cast this spell, exile up to one target permanent that's one or more colors.\nWhenever you cast a colorless spell, exile up to one target permanent that's one or more colors.\n+2: You gain 3 life and draw a card.\n0: Add {C}{C}{C}.\n\u221211: Search your library for any number of colorless nonland cards, exile them, then shuffle. Until end of turn, you may cast those cards without paying their mana costs.",
             "colours": [],
@@ -15450,7 +15450,7 @@
         },
         {
             "id": "a571b4ec-fc18-5297-95c3-6b0f990cc6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa73d25-c887-487a-ba77-0d4ca992f106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa73d25-c887-487a-ba77-0d4ca992f106.jpg?1",
             "name": "Clarion Conqueror",
             "text": "Flying\nActivated abilities of artifacts, creatures, and planeswalkers can't be activated.",
             "colours": [
@@ -15486,7 +15486,7 @@
         },
         {
             "id": "f305af5b-7c2a-52f4-8a6f-b296a1664f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f421da3b-b88d-4e9f-865b-61120bff917a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f421da3b-b88d-4e9f-865b-61120bff917a.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\n+1: Create a 1/1 white Soldier creature token.\n0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your next turn.\n\u22123: Destroy target creature an opponent controls with mana value 3 or greater.",
             "colours": [
@@ -15525,7 +15525,7 @@
         },
         {
             "id": "79dcdacb-7e9f-5730-be27-3e773ce0d57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737d2ab6-bb45-432c-9ce2-e9ecb513ee4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737d2ab6-bb45-432c-9ce2-e9ecb513ee4d.jpg?1",
             "name": "Dracogenesis",
             "text": "You may cast Dragon spells without paying their mana costs.",
             "colours": [
@@ -15560,7 +15560,7 @@
         },
         {
             "id": "7b0d3123-e1b3-5278-ae77-29bf44bb74d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be50dc-3735-47a6-9af3-e8d8e425b5b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3be50dc-3735-47a6-9af3-e8d8e425b5b2.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "When Sarkhan enters, you may behold a Dragon. If you do, create a Treasure token.\nWhenever a Dragon you control enters, put a +1/+1 counter on Sarkhan. Until end of turn, Sarkhan becomes a Dragon in addition to its other types and gains flying.",
             "colours": [
@@ -15600,7 +15600,7 @@
         },
         {
             "id": "0c563730-02bd-5be9-9001-9583763bc768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e172790-7ab4-4dea-9439-e3cedd3e5cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e172790-7ab4-4dea-9439-e3cedd3e5cab.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "Haste\nWhen this creature enters, creatures you control gain trample and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "bdd58a30-e494-55c5-829f-81aa9c8e73b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c0f348-2435-4c62-9bf7-c1efded1fca0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c0f348-2435-4c62-9bf7-c1efded1fca0.jpg?1",
             "name": "All-Out Assault",
             "text": "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment enters, if it's your main phase, there is an additional combat phase after this phase followed by an additional main phase. When you next attack this turn, untap each creature you control.",
             "colours": [
@@ -15676,7 +15676,7 @@
         },
         {
             "id": "bfebc48e-84c5-5ddc-b4b8-3a8acdaebd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08cb3168-6872-43b6-9980-35ddc20cf192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08cb3168-6872-43b6-9980-35ddc20cf192.jpg?1",
             "name": "Death Begets Life",
             "text": "Destroy all creatures and enchantments. Draw a card for each permanent destroyed this way.",
             "colours": [
@@ -15715,7 +15715,7 @@
         },
         {
             "id": "14cea93c-589e-54e3-864a-4e0a4ebc1632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a1c532-e0f6-456a-a6d9-5f7bf1a6b47c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a1c532-e0f6-456a-a6d9-5f7bf1a6b47c.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "At the beginning of your end step, you may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn.",
             "colours": [
@@ -15759,7 +15759,7 @@
         },
         {
             "id": "2e5b82ab-4b43-5174-a97e-aad9948fcecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaca731-0886-4617-b012-451a5ba768db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaca731-0886-4617-b012-451a5ba768db.jpg?1",
             "name": "Skirmish Rhino",
             "text": "Trample\nWhen this creature enters, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -15799,7 +15799,7 @@
         },
         {
             "id": "186c47bd-4d0c-57a2-a3b4-ebada06aa583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7cb37b-3ab5-42d0-860a-0c0760924850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7cb37b-3ab5-42d0-860a-0c0760924850.jpg?1",
             "name": "Ugin, Eye of the Storms",
             "text": "",
             "colours": [],
@@ -15833,7 +15833,7 @@
         },
         {
             "id": "cbf169a5-761c-5873-9249-37c13eeaab21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eada03-eaca-4091-8fa0-f8e996a402ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5eada03-eaca-4091-8fa0-f8e996a402ad.jpg?1",
             "name": "Clarion Conqueror",
             "text": "",
             "colours": [
@@ -15869,7 +15869,7 @@
         },
         {
             "id": "15693f55-81b8-500b-9fd2-90d7893015ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b98fd0-e2e5-4533-af2b-5230af2c88bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b98fd0-e2e5-4533-af2b-5230af2c88bd.jpg?1",
             "name": "Elspeth, Storm Slayer",
             "text": "",
             "colours": [
@@ -15908,7 +15908,7 @@
         },
         {
             "id": "e01bdac8-c83f-52b3-a203-4cdd6554141d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b6d099-e31f-45b5-b78a-72a4b38d60f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b6d099-e31f-45b5-b78a-72a4b38d60f0.jpg?1",
             "name": "Dracogenesis",
             "text": "",
             "colours": [
@@ -15943,7 +15943,7 @@
         },
         {
             "id": "afe8f05c-11ed-5b2a-9157-4270d3f6eae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267ced0-34af-483c-ba42-517f3f7e22dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267ced0-34af-483c-ba42-517f3f7e22dc.jpg?1",
             "name": "Sarkhan, Dragon Ascendant",
             "text": "",
             "colours": [
@@ -15983,7 +15983,7 @@
         },
         {
             "id": "3b19c00f-4af2-5263-9d80-4b61f9c78192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13f37b1-48ff-45b5-8625-d089073ca90b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13f37b1-48ff-45b5-8625-d089073ca90b.jpg?1",
             "name": "Craterhoof Behemoth",
             "text": "",
             "colours": [
@@ -16020,7 +16020,7 @@
         },
         {
             "id": "cefe78f6-8c84-55ed-8a5c-ba7e80cf3edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37821af8-a873-497a-82cc-51095f1eed37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37821af8-a873-497a-82cc-51095f1eed37.jpg?1",
             "name": "All-Out Assault",
             "text": "",
             "colours": [
@@ -16059,7 +16059,7 @@
         },
         {
             "id": "08fb8375-5c62-5848-9de4-64193caa312e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1251fb-1f39-4afb-b902-140032f20192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b1251fb-1f39-4afb-b902-140032f20192.jpg?1",
             "name": "Death Begets Life",
             "text": "",
             "colours": [
@@ -16098,7 +16098,7 @@
         },
         {
             "id": "232404a7-0c55-5cb6-b594-9f7c24c4667e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104106-2922-404e-a959-5d6d071aad74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f104106-2922-404e-a959-5d6d071aad74.jpg?1",
             "name": "Narset, Jeskai Waymaster",
             "text": "",
             "colours": [
@@ -16142,7 +16142,7 @@
         },
         {
             "id": "235c80f7-7c22-5085-9d99-ed665ae23bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5346269a-aa11-4a93-9fbc-109421afe579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5346269a-aa11-4a93-9fbc-109421afe579.jpg?1",
             "name": "Skirmish Rhino",
             "text": "",
             "colours": [
@@ -16182,7 +16182,7 @@
         },
         {
             "id": "b48f16cd-53a6-57f7-a5d1-3385075cc0c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec33ea23-c8e8-4066-91b9-5e0ad191bcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec33ea23-c8e8-4066-91b9-5e0ad191bcdb.jpg?1",
             "name": "Mox Jasper",
             "text": "",
             "colours": [],
@@ -16214,7 +16214,7 @@
         },
         {
             "id": "ada1c311-94fa-5e5d-9d6a-b166996b7a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3c128-e4a9-4d21-8cf4-dfc122cc0957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cf3c128-e4a9-4d21-8cf4-dfc122cc0957.jpg?1",
             "name": "Static Snare",
             "text": "Flash\nThis spell costs {1} less to cast for each attacking creature.\nWhen this enchantment enters, exile target artifact or creature an opponent controls until this enchantment leaves the battlefield.",
             "colours": [
@@ -16248,7 +16248,7 @@
         },
         {
             "id": "0e7e80f4-edcf-5ca6-9211-8f6790afcd1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31cd0d01-8d3f-4a00-acfd-a43a93e14e7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31cd0d01-8d3f-4a00-acfd-a43a93e14e7d.jpg?1",
             "name": "Roiling Dragonstorm",
             "text": "When this enchantment enters, draw two cards, then discard a card.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -16283,7 +16283,7 @@
         },
         {
             "id": "63bc614a-e22b-586e-86f8-6d05c685a0e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8e99f9-7557-45e3-af72-c5cb87927202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc8e99f9-7557-45e3-af72-c5cb87927202.jpg?1",
             "name": "Strategic Betrayal",
             "text": "Target opponent exiles a creature they control and their graveyard.",
             "colours": [
@@ -16317,7 +16317,7 @@
         },
         {
             "id": "c3712143-38ec-5566-b060-254d5675d74c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377aac92-3278-4c81-9095-04ff7d7a81dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/377aac92-3278-4c81-9095-04ff7d7a81dc.jpg?1",
             "name": "Channeled Dragonfire",
             "text": "Channeled Dragonfire deals 2 damage to any target.\nHarmonize {5}{R}{R}",
             "colours": [
@@ -16351,7 +16351,7 @@
         },
         {
             "id": "e29b2af3-2234-5f59-a29c-9881140805df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07d668d-bff0-4bae-a42e-4130fdc1016d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07d668d-bff0-4bae-a42e-4130fdc1016d.jpg?1",
             "name": "Encroaching Dragonstorm",
             "text": "When this enchantment enters, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle.\nWhen a Dragon you control enters, return this enchantment to its owner's hand.",
             "colours": [
@@ -16386,7 +16386,7 @@
         },
         {
             "id": "2a6157b9-f349-574e-942a-f039b8e78b93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee706aa4-3188-47ee-b164-35287b26e677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee706aa4-3188-47ee-b164-35287b26e677.jpg?1",
             "name": "Temur Battlecrier",
             "text": "During your turn, spells you cast cost {1} less to cast for each creature you control with power 4 or greater.",
             "colours": [
@@ -16427,7 +16427,7 @@
         },
         {
             "id": "5aa634bb-b8b5-5190-bc3e-be77dc92b46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f54ff0-e10a-4f22-ada8-43b61d46ee75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03f54ff0-e10a-4f22-ada8-43b61d46ee75.jpg?1",
             "name": "Qarsi Revenant",
             "text": "Flying, deathtouch, lifelink\nRenew \u2014 {2}{B}, Exile this card from your graveyard: Put a flying counter, a deathtouch counter, and a lifelink counter on target creature. Activate only as a sorcery.",
             "colours": [
@@ -16463,7 +16463,7 @@
         },
         {
             "id": "bfc3fdde-e02b-5444-995c-bd8fcbbd9724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45364163-62b7-4641-b2c9-c2e46d61335c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45364163-62b7-4641-b2c9-c2e46d61335c.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -16491,7 +16491,7 @@
         },
         {
             "id": "67253fa4-f6af-57e9-b7e2-bf973e4c1bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6105623a-ff2c-46bf-8881-e8b899d47d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6105623a-ff2c-46bf-8881-e8b899d47d54.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16526,7 +16526,7 @@
         },
         {
             "id": "f8052c87-e8c0-5b14-a382-60686eee82a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633d2d10-def7-426f-8496-ed6b45684299.jpg?1",
             "name": "Monk",
             "text": "",
             "colours": [
@@ -16561,7 +16561,7 @@
         },
         {
             "id": "df272d7c-be2c-5f53-8edf-9816e578f5fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6455d903-6996-448f-9148-9068febecb00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6455d903-6996-448f-9148-9068febecb00.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16596,7 +16596,7 @@
         },
         {
             "id": "56f90b98-163e-52ad-a14d-6996fda56f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddd5153-2d16-4a4e-b9bc-f20313d322da.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -16631,7 +16631,7 @@
         },
         {
             "id": "aa9952f1-590d-551e-a881-cb4be1e83adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22410b3-5c0b-4282-9b0b-5ba61229b6e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f22410b3-5c0b-4282-9b0b-5ba61229b6e7.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16666,7 +16666,7 @@
         },
         {
             "id": "c5d0dea4-a25d-5c20-8ddd-f9684af1a48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a7343-9f5f-4b79-8929-c84011de401c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83a7343-9f5f-4b79-8929-c84011de401c.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16701,7 +16701,7 @@
         },
         {
             "id": "e5d40de2-cdaf-5c3a-a4e1-e8cc8d2383ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997edcc4-6021-4443-9470-3fd7f7595cc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997edcc4-6021-4443-9470-3fd7f7595cc6.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16736,7 +16736,7 @@
         },
         {
             "id": "ce47d822-2ec8-5683-91d7-96716305caac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4fc2f-95a4-49d0-b06e-b88d19637737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4fc2f-95a4-49d0-b06e-b88d19637737.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -16771,7 +16771,7 @@
         },
         {
             "id": "ff34c783-11e6-5b8d-af52-5d3ce32c3599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d5813-7818-43e8-b08d-4ed8c54d0366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10d5813-7818-43e8-b08d-4ed8c54d0366.jpg?1",
             "name": "Zombie Druid",
             "text": "",
             "colours": [],
@@ -16805,7 +16805,7 @@
         },
         {
             "id": "3faefddb-e3f0-521e-a62f-1aea5459f650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434c2965-82b8-4e89-bf45-a8fc093f9a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434c2965-82b8-4e89-bf45-a8fc093f9a21.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -16840,7 +16840,7 @@
         },
         {
             "id": "624155e0-9fb2-5dc4-ab66-fb7cd6196d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e265ca24-96c0-4654-a8f3-bbffe288970a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e265ca24-96c0-4654-a8f3-bbffe288970a.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -16875,7 +16875,7 @@
         },
         {
             "id": "0639a7f1-e1a9-5c70-9d2f-e43e36448115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edc0515-a130-45a7-aa09-0e23bba41587.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -16910,7 +16910,7 @@
         },
         {
             "id": "6c2e98d6-9d2b-563f-85b9-c902eee269e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243bcfa9-0310-4d68-9864-df46069906fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243bcfa9-0310-4d68-9864-df46069906fa.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -16945,7 +16945,7 @@
         },
         {
             "id": "51357bef-a714-5243-8133-3edafc0b71b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44465924-8cc2-49a4-bc07-8dbae7570af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44465924-8cc2-49a4-bc07-8dbae7570af6.jpg?1",
             "name": "Reliquary Dragon",
             "text": "",
             "colours": [
@@ -16988,7 +16988,7 @@
         },
         {
             "id": "198c5204-6b23-5085-b962-e6db6c948bd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8f66e1-4eab-4d51-b10e-9cedd607d709.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8f66e1-4eab-4d51-b10e-9cedd607d709.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/THB.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/THB.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "aa8816f1-8810-5132-af0e-96fbd1e08888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c8c075-9597-412e-9fc4-9d73b4405d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36c8c075-9597-412e-9fc4-9d73b4405d12.jpg?1",
             "name": "Alseid of Life's Bounty",
             "text": "Lifelink\n{1}, Sacrifice Alseid of Life's Bounty: Target creature or enchantment you control gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -41,7 +41,7 @@
         },
         {
             "id": "c7bbaa90-21aa-531b-a16b-72adf3b84346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dd1e40-a514-42df-8cc1-364998c7700c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0dd1e40-a514-42df-8cc1-364998c7700c.jpg?1",
             "name": "Archon of Falling Stars",
             "text": "Flying\nWhen Archon of Falling Stars dies, you may return target enchantment card from your graveyard to the battlefield.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "3b93324d-e472-59a5-8bdf-a77c1dd92771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e5999-e8e5-4093-adff-9d47aec70d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235e5999-e8e5-4093-adff-9d47aec70d10.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "Flying, lifelink\nPegasus creatures you control have lifelink.\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, create a 2/2 white Pegasus creature token with flying.",
             "colours": [
@@ -111,7 +111,7 @@
         },
         {
             "id": "8ddf8751-7b37-53b8-aefc-379a2ea10ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddd113-140f-49c9-b45c-cf1b0d1dffd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ddd113-140f-49c9-b45c-cf1b0d1dffd8.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield.",
             "colours": [
@@ -143,7 +143,7 @@
         },
         {
             "id": "262785a1-96ca-5a63-b325-0f5aff23d979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d824f8bd-58f8-4796-80b5-5cd3033d35e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d824f8bd-58f8-4796-80b5-5cd3033d35e8.jpg?1",
             "name": "The Birth of Meletis",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle your library.\nII \u2014 Create a 0/4 colorless Wall artifact creature token with defender.\nIII \u2014 You gain 2 life.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "cd7db13c-d0cc-53ce-b68b-10e1d0444632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13893599-0b87-4fc0-863d-f3e0ae51cc31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13893599-0b87-4fc0-863d-f3e0ae51cc31.jpg?1",
             "name": "Captivating Unicorn",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -211,7 +211,7 @@
         },
         {
             "id": "14dea815-1242-58b0-a495-02e03b6da059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e2f681-918e-4f1f-afb1-0f9587c0d7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24e2f681-918e-4f1f-afb1-0f9587c0d7bf.jpg?1",
             "name": "Commanding Presence",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has first strike and \"Whenever this creature deals combat damage to a player, create a 1/1 white Human Soldier creature token.\"",
             "colours": [
@@ -245,7 +245,7 @@
         },
         {
             "id": "5ab92e40-6d8a-5127-a686-ac3930174553",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e152ae-43ec-4b9d-a43f-786c2f6c7366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e152ae-43ec-4b9d-a43f-786c2f6c7366.jpg?1",
             "name": "Dawn Evangel",
             "text": "Whenever a creature dies, if an Aura you controlled was attached to it, return target creature card with converted mana cost 2 or less from your graveyard to your hand.",
             "colours": [
@@ -281,7 +281,7 @@
         },
         {
             "id": "33bb725c-5cbe-50b7-accd-dd714a2e610e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd2adb3-a6f4-448e-af2a-15ca92b1de63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd2adb3-a6f4-448e-af2a-15ca92b1de63.jpg?1",
             "name": "Daxos, Blessed by the Sun",
             "text": "Daxos's toughness is equal to your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)\nWhenever another creature you control enters the battlefield or dies, you gain 1 life.",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "b93c2a9e-6e7e-5e00-9b32-e63c6d7e0eb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c1de31-73d4-4c32-9f99-e15df48638e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9c1de31-73d4-4c32-9f99-e15df48638e9.jpg?1",
             "name": "Daybreak Chimera",
             "text": "This spell costs {X} less to cast, where X is your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)\nFlying",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "6bb55a8e-4e44-50f9-9205-45ede947601e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20c2369-db77-465e-9f0e-bb009225345a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20c2369-db77-465e-9f0e-bb009225345a.jpg?1",
             "name": "Dreadful Apathy",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
             "colours": [
@@ -388,7 +388,7 @@
         },
         {
             "id": "8a339c7f-b4f6-5309-8d1a-8952e0f2de17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48f802-df9d-45b2-afea-98699bcdf0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f48f802-df9d-45b2-afea-98699bcdf0d6.jpg?1",
             "name": "Eidolon of Obstruction",
             "text": "First strike\nLoyalty abilities of planeswalkers your opponents control cost {1} more to activate.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "1ac3ade3-a329-5325-a710-ef85dc8aa014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20208b-1939-4c69-8cfd-c0a42f9dc427.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea20208b-1939-4c69-8cfd-c0a42f9dc427.jpg?1",
             "name": "Elspeth Conquers Death",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile target permanent an opponent controls with converted mana cost 3 or greater.\nII \u2014 Noncreature spells your opponents cast cost {2} more to cast until your next turn.\nIII \u2014 Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter or a loyalty counter on it.",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "57f20483-d1a9-56ea-ba93-28b4ac1ddde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aec42f-abb7-42f9-96f5-f1ee2f94db52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aec42f-abb7-42f9-96f5-f1ee2f94db52.jpg?1",
             "name": "Elspeth, Sun's Nemesis",
             "text": "\u22121: Up to two target creatures you control each get +2/+1 until end of turn.\n\u22122: Create two 1/1 white Human Soldier creature tokens.\n\u22123: You gain 5 life.\nEscape\u2014{4}{W}{W}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -497,7 +497,7 @@
         },
         {
             "id": "652ff129-9588-5dda-84c9-0675fe60e5f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09e7aff-d873-4420-b0d5-1c63d686dd73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09e7aff-d873-4420-b0d5-1c63d686dd73.jpg?1",
             "name": "Favored of Iroas",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Favored of Iroas gains double strike until end of turn.",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "022c745c-b45c-5645-8689-17a7a06f94dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e19bac-176c-4e37-bfc8-27c00de7c37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e19bac-176c-4e37-bfc8-27c00de7c37f.jpg?1",
             "name": "Flicker of Fate",
             "text": "Exile target creature or enchantment, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -564,7 +564,7 @@
         },
         {
             "id": "d1542b77-fe30-555c-885a-f3f4f62496e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a70e1be-f04a-43c1-8fca-205a24e3db38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a70e1be-f04a-43c1-8fca-205a24e3db38.jpg?1",
             "name": "Glory Bearers",
             "text": "Whenever another creature you control attacks, it gets +0/+1 until end of turn.",
             "colours": [
@@ -600,7 +600,7 @@
         },
         {
             "id": "3d745060-ab05-541d-9677-7fd7aff1b64d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a8576e-cadc-4521-aadd-3a05f0bc4d20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01a8576e-cadc-4521-aadd-3a05f0bc4d20.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature.\nWhenever you gain life, put a +1/+1 counter on target creature or enchantment you control.\n{1}{W}: Another target creature gains lifelink until end of turn.",
             "colours": [
@@ -639,7 +639,7 @@
         },
         {
             "id": "c67e23df-18de-5668-83f8-4fc9c23299bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1c16dd-38e9-4974-b570-8678c114a549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1c16dd-38e9-4974-b570-8678c114a549.jpg?1",
             "name": "Heliod's Intervention",
             "text": "Choose one \u2014\n\u2022 Destroy X target artifacts and/or enchantments.\n\u2022 Target player gains twice X life.",
             "colours": [
@@ -673,7 +673,7 @@
         },
         {
             "id": "ece6f08a-85c1-50df-8d6c-ee0273cc1be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafce2f5-f4f4-465b-96dc-bcdd29d4e4bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cafce2f5-f4f4-465b-96dc-bcdd29d4e4bb.jpg?1",
             "name": "Heliod's Pilgrim",
             "text": "When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -708,7 +708,7 @@
         },
         {
             "id": "9a31c5b9-d3a0-5488-beab-d8c3a997a8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8e6878-06aa-4505-b3a5-172083b7d258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8e6878-06aa-4505-b3a5-172083b7d258.jpg?1",
             "name": "Heliod's Punishment",
             "text": "Enchant creature\nHeliod's Punishment enters the battlefield with four task counters on it.\nEnchanted creature can't attack or block. It loses all abilities and has \"{T}: Remove a task counter from Heliod's Punishment. Then if it has no task counters on it, destroy Heliod's Punishment.\"",
             "colours": [
@@ -742,7 +742,7 @@
         },
         {
             "id": "05319d55-caae-59ec-854f-dd907b07b132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b56863-a52a-4559-a662-f6d9145d5804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81b56863-a52a-4559-a662-f6d9145d5804.jpg?1",
             "name": "Hero of the Pride",
             "text": "Whenever you cast a spell that targets Hero of the Pride, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -777,7 +777,7 @@
         },
         {
             "id": "d09384c0-b4da-52cf-953a-9b06d0986426",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da95097-dbe7-416a-8571-6ab6d88a531a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da95097-dbe7-416a-8571-6ab6d88a531a.jpg?1",
             "name": "Hero of the Winds",
             "text": "Flying\nWhenever you cast a spell that targets Hero of the Winds, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "32607cf3-a4d1-5f09-af20-26659fc052e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06edd53-f3ac-44b0-a087-5670ba8f0fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06edd53-f3ac-44b0-a087-5670ba8f0fa5.jpg?1",
             "name": "Idyllic Tutor",
             "text": "Search your library for an enchantment card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "825782e1-f5fc-510f-b781-b4812c4ac875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47772a34-c72f-44e8-b272-4ef2d2af5c82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47772a34-c72f-44e8-b272-4ef2d2af5c82.jpg?1",
             "name": "Indomitable Will",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -880,7 +880,7 @@
         },
         {
             "id": "fe1f7415-f552-5c72-9d63-2769dc94e164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c8e4dc-5378-48d6-85b2-f5ea9ec7cf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c8e4dc-5378-48d6-85b2-f5ea9ec7cf36.jpg?1",
             "name": "Karametra's Blessing",
             "text": "Target creature gets +2/+2 until end of turn. If it's an enchanted creature or enchantment creature, it also gains hexproof and indestructible until end of turn. (It can't be the target of spells or abilities your opponents control. Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "5da6274b-799d-52cd-8f25-f7e9d15b5c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a87498-2c2c-411a-aa71-d594b2c6cb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a87498-2c2c-411a-aa71-d594b2c6cb26.jpg?1",
             "name": "Lagonna-Band Storyteller",
             "text": "When Lagonna-Band Storyteller enters the battlefield, you may put target enchantment card from your graveyard on top of your library. If you do, you gain life equal to its converted mana cost.",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "2b42a8fa-26a6-5b9c-97fc-9e1e5a0698e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1be3729-7970-45df-8c26-4fe09e56629d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1be3729-7970-45df-8c26-4fe09e56629d.jpg?1",
             "name": "Leonin of the Lost Pride",
             "text": "When Leonin of the Lost Pride dies, exile target card from an opponent's graveyard.",
             "colours": [
@@ -982,7 +982,7 @@
         },
         {
             "id": "df22ce58-abba-5753-b17e-436a44e15f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd32240-c003-4e18-adf1-e2e992c702b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fd32240-c003-4e18-adf1-e2e992c702b1.jpg?1",
             "name": "Nyxborn Courser",
             "text": "",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "00234fb5-1fea-5993-8303-ab1bd0bb2e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86586fe3-1a6e-4648-b3ff-b0d9340e66ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86586fe3-1a6e-4648-b3ff-b0d9340e66ff.jpg?1",
             "name": "Omen of the Sun",
             "text": "Flash\nWhen Omen of the Sun enters the battlefield, create two 1/1 white Human Soldier creature tokens and you gain 2 life.\n{2}{W}, Sacrifice Omen of the Sun: Scry 2.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "85eb8d28-7a1f-538b-b6af-fc55ab97c279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f114a10-0b00-4f3a-bd73-d4c791fbf4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f114a10-0b00-4f3a-bd73-d4c791fbf4d5.jpg?1",
             "name": "Phalanx Tactics",
             "text": "Target creature you control gets +2/+1 until end of turn. Each other creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "a370cee0-c785-5231-8035-d3a71a023fcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg?1",
             "name": "Pious Wayfarer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "b838d14f-a7fa-5c21-b9e6-3d4e1f0e7c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54153b9c-483e-4e5c-a1ab-b1c8a7a657d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54153b9c-483e-4e5c-a1ab-b1c8a7a657d4.jpg?1",
             "name": "Reverent Hoplite",
             "text": "When Reverent Hoplite enters the battlefield, create a number of 1/1 white Human Soldier creature tokens equal to your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "5de5bca0-7d03-58b9-894c-0820ad95758c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb9f86-f487-44b1-815f-30d87868b531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb9f86-f487-44b1-815f-30d87868b531.jpg?1",
             "name": "Revoke Existence",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "a6a0ad77-0628-5c7b-9001-8f9b2b43aada",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f93f3c9-b317-40c1-87f5-0038c09b646d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f93f3c9-b317-40c1-87f5-0038c09b646d.jpg?1",
             "name": "Rumbling Sentry",
             "text": "When Rumbling Sentry enters the battlefield, scry 1.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "cee1fbfb-f780-50ef-8fa4-e1db9798b21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32adc118-b81e-48c2-b7ef-b62e8c3308d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32adc118-b81e-48c2-b7ef-b62e8c3308d6.jpg?1",
             "name": "Sentinel's Eyes",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has vigilance.\nEscape\u2014{W}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "330c7051-1ada-5935-baea-f9f20c408019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b706977b-db8e-4810-882d-ed3745404489.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b706977b-db8e-4810-882d-ed3745404489.jpg?1",
             "name": "Shatter the Sky",
             "text": "Each player who controls a creature with power 4 or greater draws a card. Then destroy all creatures.",
             "colours": [
@@ -1286,7 +1286,7 @@
         },
         {
             "id": "1f3cbefd-2aba-5bae-b2ae-00df4c4cda53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg?1",
             "name": "Sunmane Pegasus",
             "text": "Flying\n{1}{W}: Sunmane Pegasus gains vigilance and lifelink until end of turn.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "cfa25e48-918f-5d00-8e6b-478c37e75d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8edd707-5ba3-4978-9a0b-efd0cda367c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8edd707-5ba3-4978-9a0b-efd0cda367c1.jpg?1",
             "name": "Taranika, Akroan Veteran",
             "text": "Vigilance\nWhenever Taranika, Akroan Veteran attacks, untap another target creature you control. Until end of turn, that creature has base power and toughness 4/4 and gains indestructible.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "50b3a49c-d0fb-5b37-948e-3cec37ab604a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9241289-28d2-4827-970e-81bdecbb5c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9241289-28d2-4827-970e-81bdecbb5c16.jpg?1",
             "name": "Transcendent Envoy",
             "text": "Flying\nAura spells you cast cost {1} less to cast.",
             "colours": [
@@ -1394,7 +1394,7 @@
         },
         {
             "id": "87d65077-bc12-53fd-80c1-e09f0a204a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d6eb18-a49d-4fa5-a333-78aafbc4abcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75d6eb18-a49d-4fa5-a333-78aafbc4abcb.jpg?1",
             "name": "Triumphant Surge",
             "text": "Destroy target creature with power 4 or greater. You gain 3 life.",
             "colours": [
@@ -1426,7 +1426,7 @@
         },
         {
             "id": "af413de0-1e2f-5eb7-97b6-cdf4f7b1993b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f9ebbe-3791-4d19-88d2-d5de95faff48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f9ebbe-3791-4d19-88d2-d5de95faff48.jpg?1",
             "name": "Alirios, Enraptured",
             "text": "Alirios, Enraptured enters the battlefield tapped.\nAlirios doesn't untap during your untap step if you control a Reflection.\nWhen Alirios enters the battlefield, create a 3/2 blue Reflection creature token.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "84207d23-4633-59dd-9dc1-797763561d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568c679-8421-4184-a73c-b18c4164fea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d568c679-8421-4184-a73c-b18c4164fea5.jpg?1",
             "name": "Ashiok's Erasure",
             "text": "Flash\nWhen Ashiok's Erasure enters the battlefield, exile target spell.\nYour opponents can't cast spells with the same name as the exiled card.\nWhen Ashiok's Erasure leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -1496,7 +1496,7 @@
         },
         {
             "id": "f7ef1bf2-ecb0-5a40-85b1-4d9b0ddf1896",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6811a9dc-e521-4c9e-accb-1efb8346c1db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6811a9dc-e521-4c9e-accb-1efb8346c1db.jpg?1",
             "name": "Brine Giant",
             "text": "This spell costs {1} less to cast for each enchantment you control.",
             "colours": [
@@ -1530,7 +1530,7 @@
         },
         {
             "id": "352c3e24-88d5-50d8-bba7-235361147381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d433f2-0a3b-4f45-83a3-ed600a6d10b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d433f2-0a3b-4f45-83a3-ed600a6d10b1.jpg?1",
             "name": "Callaphe, Beloved of the Sea",
             "text": "Callaphe's power is equal to your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)\nCreatures and enchantments you control have \"Spells your opponents cast that target this permanent cost {1} more to cast.\"",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "e99c1832-05e5-51da-9e82-537f592f58f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0e1a22-8f27-4c5b-a65c-c35abd2ff05b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa0e1a22-8f27-4c5b-a65c-c35abd2ff05b.jpg?1",
             "name": "Chain to Memory",
             "text": "Target creature gets -4/-0 until end of turn. Scry 2.",
             "colours": [
@@ -1601,7 +1601,7 @@
         },
         {
             "id": "6955a085-32f8-5582-9533-c506ef88213b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1200f68a-a8ea-4777-b6b0-de48b2203fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1200f68a-a8ea-4777-b6b0-de48b2203fd1.jpg?1",
             "name": "Deny the Divine",
             "text": "Counter target creature or enchantment spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1633,7 +1633,7 @@
         },
         {
             "id": "ad74973c-e006-5d3d-ac8e-30459e2699b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2897635-b387-485d-932f-5655244a381f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2897635-b387-485d-932f-5655244a381f.jpg?1",
             "name": "Eidolon of Philosophy",
             "text": "{6}{U}, Sacrifice Eidolon of Philosophy: Draw three cards.",
             "colours": [
@@ -1668,7 +1668,7 @@
         },
         {
             "id": "ed54f11c-cdae-5c26-ae32-06dda743f23a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cd2dd-aa03-4c55-b9e4-98e0284889d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821cd2dd-aa03-4c55-b9e4-98e0284889d3.jpg?1",
             "name": "Elite Instructor",
             "text": "When Elite Instructor enters the battlefield, draw a card, then discard a card.",
             "colours": [
@@ -1703,7 +1703,7 @@
         },
         {
             "id": "8a478c6f-d930-5f92-9a52-b147e41fc06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9c025-1cdb-4da8-8d28-14ad5efb512d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1e9c025-1cdb-4da8-8d28-14ad5efb512d.jpg?1",
             "name": "Glimpse of Freedom",
             "text": "Draw a card.\nEscape\u2014{2}{U}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -1735,7 +1735,7 @@
         },
         {
             "id": "c1ea0da4-7858-5fad-834d-86686fc6f940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4763b6c-6471-41bd-b3e4-785564bcf06f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4763b6c-6471-41bd-b3e4-785564bcf06f.jpg?1",
             "name": "Ichthyomorphosis",
             "text": "Enchant creature\nEnchanted creature loses all abilities and is a blue Fish with base power and toughness 0/1.",
             "colours": [
@@ -1769,7 +1769,7 @@
         },
         {
             "id": "0b922fe8-0130-5a97-bea1-141f9e6705f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b604451-4f6c-4cfa-8d3a-01f18d01d88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b604451-4f6c-4cfa-8d3a-01f18d01d88f.jpg?1",
             "name": "Kiora Bests the Sea God",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create an 8/8 blue Kraken creature token with hexproof.\nII \u2014 Tap all nonland permanents target opponent controls. They don't untap during their controller's next untap step.\nIII \u2014 Gain control of target permanent an opponent controls. Untap it.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "dd73cb5c-2553-527f-a198-56e07fe82be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2bd7b4-28de-4d9e-86c5-a46bd608cb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2bd7b4-28de-4d9e-86c5-a46bd608cb02.jpg?1",
             "name": "Medomai's Prophecy",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI \u2014 Scry 2.\nII \u2014 Choose a card name.\nIII \u2014 When you cast a spell with the chosen name for the first time this turn, draw two cards.\nIV \u2014 Look at the top card of each player's library.",
             "colours": [
@@ -1837,7 +1837,7 @@
         },
         {
             "id": "3495a86b-e37c-545a-961e-cc538c841a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadc1809-d6bb-455c-b6ce-dd11521808b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadc1809-d6bb-455c-b6ce-dd11521808b6.jpg?1",
             "name": "Memory Drain",
             "text": "Counter target spell. Scry 2.",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "d5953f14-1221-51bc-8917-5d532fbe08cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7817e039-e509-4b6f-b5a3-deb3769bbdc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7817e039-e509-4b6f-b5a3-deb3769bbdc8.jpg?1",
             "name": "Nadir Kraken",
             "text": "Whenever you draw a card, you may pay {1}. If you do, put a +1/+1 counter on Nadir Kraken and create a 1/1 blue Tentacle creature token.",
             "colours": [
@@ -1905,7 +1905,7 @@
         },
         {
             "id": "b7acf506-6547-5ce4-acc3-ba137e15327c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6ae489-658b-4c12-b204-f7b58ce84375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc6ae489-658b-4c12-b204-f7b58ce84375.jpg?1",
             "name": "Naiad of Hidden Coves",
             "text": "As long as it's not your turn, spells you cast cost {1} less to cast.",
             "colours": [
@@ -1940,7 +1940,7 @@
         },
         {
             "id": "5ff31e60-202e-584e-979f-60fa475cc4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad0c7d7-0e44-496f-a2fc-fafc604cb1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad0c7d7-0e44-496f-a2fc-fafc604cb1f1.jpg?1",
             "name": "Nyxborn Seaguard",
             "text": "",
             "colours": [
@@ -1976,7 +1976,7 @@
         },
         {
             "id": "4466b7e2-ecc8-590a-baf7-9f45ff7971f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f30ecd-d009-4d44-aef4-c926ed55a521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f30ecd-d009-4d44-aef4-c926ed55a521.jpg?1",
             "name": "Omen of the Sea",
             "text": "Flash\nWhen Omen of the Sea enters the battlefield, scry 2, then draw a card.\n{2}{U}, Sacrifice Omen of the Sea: Scry 2.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "25620574-ecff-5b31-a3d7-d38a7822ad72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b7070d-4b09-4390-aa21-1bc0aa2b629c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b7070d-4b09-4390-aa21-1bc0aa2b629c.jpg?1",
             "name": "One with the Stars",
             "text": "Enchant creature or enchantment\nEnchanted permanent is an enchantment and loses all other card types. (It still has its abilities, but it's no longer a creature.)",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "a124b943-2cec-584d-9ce3-056cbf462523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749bfd81-c61b-4901-8efb-72611fd08244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/749bfd81-c61b-4901-8efb-72611fd08244.jpg?1",
             "name": "Protean Thaumaturge",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may have Protean Thaumaturge become a copy of another target creature, except it has this ability.",
             "colours": [
@@ -2079,7 +2079,7 @@
         },
         {
             "id": "497e942d-68b6-5c1a-ac11-8c8ddb609843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4ba296-950c-4e39-ab5e-06be07e4a190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc4ba296-950c-4e39-ab5e-06be07e4a190.jpg?1",
             "name": "Riptide Turtle",
             "text": "Flash\nDefender",
             "colours": [
@@ -2113,7 +2113,7 @@
         },
         {
             "id": "7f71dd8e-b657-5f67-90b1-627a0a794f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138fd65-e0c3-42a1-9c0d-4d5f20228b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4138fd65-e0c3-42a1-9c0d-4d5f20228b55.jpg?1",
             "name": "Sage of Mysteries",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.",
             "colours": [
@@ -2148,7 +2148,7 @@
         },
         {
             "id": "a20efd71-cd6f-56af-aa9c-c79341af5902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9504dc26-f5d8-4b9d-9eb1-51a12b893beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9504dc26-f5d8-4b9d-9eb1-51a12b893beb.jpg?1",
             "name": "Sea God's Scorn",
             "text": "Return up to three target creatures and/or enchantments to their owners' hands.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "86adb2fc-ae2f-5381-8889-04c89931f129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b54bea-f2c5-4000-9cbd-04c03a1d2ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b54bea-f2c5-4000-9cbd-04c03a1d2ea2.jpg?1",
             "name": "Shimmerwing Chimera",
             "text": "Flying\nAt the beginning of your upkeep, return up to one other target enchantment you control to its owner's hand.",
             "colours": [
@@ -2215,7 +2215,7 @@
         },
         {
             "id": "c2d367cb-a3f9-5666-9d8d-ce9eeb8fd5fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec538182-efba-48d0-91ad-457461b44748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec538182-efba-48d0-91ad-457461b44748.jpg?1",
             "name": "Shoal Kraken",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2249,7 +2249,7 @@
         },
         {
             "id": "71e287b8-1605-51cf-b41d-ad3365e32d2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4007572b-a6c8-4a56-b1a7-ff099189c9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4007572b-a6c8-4a56-b1a7-ff099189c9c0.jpg?1",
             "name": "Sleep of the Dead",
             "text": "Tap target creature. It doesn't untap during its controller's next untap step.\nEscape\u2014{2}{U}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -2281,7 +2281,7 @@
         },
         {
             "id": "aa85f029-5dde-59d4-b864-27c10d1d9171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c53625-6928-494a-af87-7eee2f6643a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c53625-6928-494a-af87-7eee2f6643a5.jpg?1",
             "name": "Starlit Mantle",
             "text": "Flash\nEnchant creature you control\nWhen Starlit Mantle enters the battlefield, enchanted creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2315,7 +2315,7 @@
         },
         {
             "id": "76bae12a-6047-57f3-a3f8-153ad67d19c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aec4d0f-ba1e-45f8-9764-9bcc3fa50e51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aec4d0f-ba1e-45f8-9764-9bcc3fa50e51.jpg?1",
             "name": "Stern Dismissal",
             "text": "Return target creature or enchantment an opponent controls to its owner's hand.",
             "colours": [
@@ -2347,7 +2347,7 @@
         },
         {
             "id": "abc19e5b-4b66-5974-ab88-7e9a56a072ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162a0b8-a2d1-4664-a445-331aee6d5175.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0162a0b8-a2d1-4664-a445-331aee6d5175.jpg?1",
             "name": "Stinging Lionfish",
             "text": "Whenever you cast your first spell during each opponent's turn, you may tap or untap target nonland permanent.",
             "colours": [
@@ -2382,7 +2382,7 @@
         },
         {
             "id": "f7e7638a-1237-5a9f-8709-c622f7722b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ac77d4-f918-4bbc-b023-8117a8c401ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ac77d4-f918-4bbc-b023-8117a8c401ee.jpg?1",
             "name": "Sweet Oblivion",
             "text": "Target player puts the top four cards of their library into their graveyard.\nEscape\u2014{3}{U}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "d10be5ed-839b-5b56-bddb-8a4be0aff8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ed3e0-82d0-4410-a6ca-b0f923eadf83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c83ed3e0-82d0-4410-a6ca-b0f923eadf83.jpg?1",
             "name": "Thassa, Deep-Dwelling",
             "text": "Indestructible\nAs long as your devotion to blue is less than five, Thassa isn't a creature.\nAt the beginning of your end step, exile up to one other target creature you control, then return that card to the battlefield under your control.\n{3}{U}: Tap another target creature.",
             "colours": [
@@ -2453,7 +2453,7 @@
         },
         {
             "id": "d51ac0b9-f323-517f-b33f-ff4079e2f3aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1241d0-20d4-4eab-970d-74e476f023b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c1241d0-20d4-4eab-970d-74e476f023b4.jpg?1",
             "name": "Thassa's Intervention",
             "text": "Choose one \u2014\n\u2022 Look at the top X cards of your library. Put up to two of them into your hand and the rest on the bottom of your library in a random order.\n\u2022 Counter target spell unless its controller pays twice {X}.",
             "colours": [
@@ -2487,7 +2487,7 @@
         },
         {
             "id": "3c2b75a7-05c5-54eb-a56f-7ae202ccd748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e8b29-13e9-4138-b6a9-d2a0d8188d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e8b29-13e9-4138-b6a9-d2a0d8188d1c.jpg?1",
             "name": "Thassa's Oracle",
             "text": "When Thassa's Oracle enters the battlefield, look at the top X cards of your library, where X is your devotion to blue. Put up to one of them on top of your library and the rest on the bottom of your library in a random order. If X is greater than or equal to the number of cards in your library, you win the game. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -2524,7 +2524,7 @@
         },
         {
             "id": "fcec5935-d8da-56de-9756-01bbf53632f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2422973d-36ee-4b8c-9a47-fcd160aa9f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2422973d-36ee-4b8c-9a47-fcd160aa9f63.jpg?1",
             "name": "Thirst for Meaning",
             "text": "Draw three cards. Then discard two cards unless you discard an enchantment card.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "8e5c790c-87dd-59ac-9cdc-b59d473933f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242cdffb-5037-4d49-b194-4b60274a8758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242cdffb-5037-4d49-b194-4b60274a8758.jpg?1",
             "name": "Threnody Singer",
             "text": "Flash\nFlying\nWhen Threnody Singer enters the battlefield, target creature an opponent controls gets -X/-0 until end of turn, where X is your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "13289b16-fdc1-5e59-8cf4-fe94658999b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238b089-c6d8-4e4b-b6a1-a0f89e3b4968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4238b089-c6d8-4e4b-b6a1-a0f89e3b4968.jpg?1",
             "name": "Thryx, the Sudden Storm",
             "text": "Flash\nFlying\nSpells you cast with converted mana cost 5 or greater cost {1} less to cast and can't be countered.",
             "colours": [
@@ -2631,7 +2631,7 @@
         },
         {
             "id": "e97ffd62-cf7a-53c2-89ca-3d7f404f21c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2b4ffc-b1e1-4b16-9a51-1a12f8256a27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2b4ffc-b1e1-4b16-9a51-1a12f8256a27.jpg?1",
             "name": "Towering-Wave Mystic",
             "text": "Whenever Towering-Wave Mystic deals damage, target player puts that many cards from the top of their library into their graveyard.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "7e6695f0-ebfe-5d28-82fe-c791585e2d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb11d7-feae-4511-9a03-bda23119b6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8cb11d7-feae-4511-9a03-bda23119b6a5.jpg?1",
             "name": "Triton Waverider",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Triton Waverider gains flying until end of turn.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "17250fe8-0786-502f-b42a-722a7599130f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fee23-df75-448d-9fca-6ba6713d459f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/869fee23-df75-448d-9fca-6ba6713d459f.jpg?1",
             "name": "Vexing Gull",
             "text": "Flash\nFlying",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "ade86b64-cd7d-5f2e-8fac-3f6bbbfedc60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d900dff5-1196-443f-b9b0-b8e75c67c868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d900dff5-1196-443f-b9b0-b8e75c67c868.jpg?1",
             "name": "Wavebreak Hippocamp",
             "text": "Whenever you cast your first spell during each opponent's turn, draw a card.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "07954e51-60a3-5ddc-abdc-c74b1671743c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e127856-bedd-40a9-9e8e-d1f9fbefe07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e127856-bedd-40a9-9e8e-d1f9fbefe07d.jpg?1",
             "name": "Whirlwind Denial",
             "text": "For each spell and ability your opponents control, counter it unless its controller pays {4}.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "aa06bd0b-9691-5466-931e-a6914e836671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd9d60-826c-4b35-9684-dccb0880399e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd9d60-826c-4b35-9684-dccb0880399e.jpg?1",
             "name": "Witness of Tomorrows",
             "text": "Flying\n{3}{U}: Scry 1.",
             "colours": [
@@ -2840,7 +2840,7 @@
         },
         {
             "id": "af58bcd5-2b99-50ad-8bf8-d1ea3e6b9eb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09270c65-546e-4737-a6b7-402cbb87917a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09270c65-546e-4737-a6b7-402cbb87917a.jpg?1",
             "name": "Agonizing Remorse",
             "text": "Target opponent reveals their hand. You choose a nonland card from it or a card from their graveyard. Exile that card. You lose 1 life.",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "4846ee70-007c-592b-ad1c-ad2cfae8de03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b359607-d699-4ba9-a438-48f0dd8f1bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b359607-d699-4ba9-a438-48f0dd8f1bf5.jpg?1",
             "name": "Aphemia, the Cacophony",
             "text": "Flying\nAt the beginning of your end step, you may exile an enchantment card from your graveyard. If you do, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -2911,7 +2911,7 @@
         },
         {
             "id": "05aeced9-889b-5b7c-842e-c7db2504a704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27157f01-8aed-4485-9f0f-9e7486492e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27157f01-8aed-4485-9f0f-9e7486492e6e.jpg?1",
             "name": "Aspect of Lamprey",
             "text": "Enchant creature you control\nWhen Aspect of Lamprey enters the battlefield, target opponent discards two cards.\nEnchanted creature has lifelink.",
             "colours": [
@@ -2945,7 +2945,7 @@
         },
         {
             "id": "90965b96-0b9c-55bb-800d-9539ddc78500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7865c079-1d91-48d4-852d-d104b6e0c157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7865c079-1d91-48d4-852d-d104b6e0c157.jpg?1",
             "name": "Blight-Breath Catoblepas",
             "text": "When Blight-Breath Catoblepas enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "32c98e4b-1776-51a8-bdbd-364a1c6e2cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c2de5f-e486-4cfe-9fb6-be0078ce5f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c2de5f-e486-4cfe-9fb6-be0078ce5f93.jpg?1",
             "name": "Cling to Dust",
             "text": "Exile target card from a graveyard. If it was a creature card, you gain 3 life. Otherwise, you draw a card.\nEscape\u2014{3}{B}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "f6a4b7f1-41fb-5422-a019-036886c84dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cce294-f6ee-4b18-8b65-7d01d0317b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cce294-f6ee-4b18-8b65-7d01d0317b00.jpg?1",
             "name": "Discordant Piper",
             "text": "When Discordant Piper dies, create a 0/1 white Goat creature token.",
             "colours": [
@@ -3046,7 +3046,7 @@
         },
         {
             "id": "25890017-c880-59f1-8d53-614155d02f42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91852444-9361-4588-a44f-fb90ba1b30e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91852444-9361-4588-a44f-fb90ba1b30e5.jpg?1",
             "name": "Drag to the Underworld",
             "text": "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\nDestroy target creature.",
             "colours": [
@@ -3078,7 +3078,7 @@
         },
         {
             "id": "71ba4ae1-36a5-56ee-9267-82227418ba95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg?1",
             "name": "Eat to Extinction",
             "text": "Exile target creature or planeswalker. Look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "a1f08713-0eed-5cbc-8345-4730d3f0e9de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ccd974-d2bc-4fcf-94a7-0a868a04cb98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ccd974-d2bc-4fcf-94a7-0a868a04cb98.jpg?1",
             "name": "Elspeth's Nightmare",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target creature an opponent controls with power 2 or less.\nII \u2014 Target opponent reveals their hand. You choose a noncreature, nonland card from it. That player discards that card.\nIII \u2014 Exile target opponent's graveyard.",
             "colours": [
@@ -3146,7 +3146,7 @@
         },
         {
             "id": "2360b80c-6f9c-5e8e-b2c4-86676bfa0075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf15e0-f61b-43b9-9113-39bd341a0163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28bf15e0-f61b-43b9-9113-39bd341a0163.jpg?1",
             "name": "Enemy of Enlightenment",
             "text": "Flying\nEnemy of Enlightenment gets -1/-1 for each card in your opponents' hands.\nAt the beginning of your upkeep, each player discards a card.",
             "colours": [
@@ -3181,7 +3181,7 @@
         },
         {
             "id": "1cd63876-2f4e-5b7a-aa3b-b76a31e836e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340df19-b89a-403f-9736-4bd30b65de74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340df19-b89a-403f-9736-4bd30b65de74.jpg?1",
             "name": "Erebos, Bleak-Hearted",
             "text": "Indestructible\nAs long as your devotion to black is less than five, Erebos isn't a creature.\nWhenever another creature you control dies, you may pay 2 life. If you do, draw a card.\n{1}{B}, Sacrifice another creature: Target creature gets -2/-1 until end of turn.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "3e280979-2766-5e5f-ae33-47e49631c7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e35c80-6cfe-49fc-8138-562233ccf987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e35c80-6cfe-49fc-8138-562233ccf987.jpg?1",
             "name": "Erebos's Intervention",
             "text": "Choose one \u2014\n\u2022 Target creature gets -X/-X until end of turn. You gain X life.\n\u2022 Exile up to twice X target cards from graveyards.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "fdfe4558-1d6e-5687-adac-f9205a6533a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b8580-9198-4735-83c1-289400c1d814.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5b8580-9198-4735-83c1-289400c1d814.jpg?1",
             "name": "Final Death",
             "text": "Exile target creature.",
             "colours": [
@@ -3286,7 +3286,7 @@
         },
         {
             "id": "750a7acf-8d5b-5f65-b54d-fffa02e172ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e577a0-e5d7-4e6a-919c-d85c2ae819ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66e577a0-e5d7-4e6a-919c-d85c2ae819ce.jpg?1",
             "name": "Fruit of Tizerus",
             "text": "Target player loses 2 life.\nEscape\u2014{3}{B}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3318,7 +3318,7 @@
         },
         {
             "id": "39b3dbdf-de3b-5ad7-a98c-a54e63c9e5d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30aa6796-0cb6-426b-9e3f-4d7e4959a6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30aa6796-0cb6-426b-9e3f-4d7e4959a6a4.jpg?1",
             "name": "Funeral Rites",
             "text": "You draw two cards, lose 2 life, and put the top two cards of your library into your graveyard.",
             "colours": [
@@ -3350,7 +3350,7 @@
         },
         {
             "id": "117bd555-86c2-55ef-9fbe-8892cc8012f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408a2073-d068-44bc-b596-5a3a3a446ee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408a2073-d068-44bc-b596-5a3a3a446ee1.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "Lifelink\nWhen Gravebreaker Lamia enters the battlefield, search your library for a card, put it into your graveyard, then shuffle your library.\nSpells you cast from your graveyard cost {1} less to cast.",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "6a048699-0569-5805-abb2-7520a4d7198d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a7dd8-8034-4f59-a351-33666b26ff5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a7dd8-8034-4f59-a351-33666b26ff5a.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "When Gray Merchant of Asphodel enters the battlefield, each opponent loses X life, where X is your devotion to black. You gain life equal to the life lost this way. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "296cf984-ce59-53f4-9650-7b90f831afce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e92c82-840f-4c75-b617-7b58a07be5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e92c82-840f-4c75-b617-7b58a07be5b4.jpg?1",
             "name": "Grim Physician",
             "text": "When Grim Physician dies, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3458,7 +3458,7 @@
         },
         {
             "id": "318c7cfd-f66d-5c83-b20a-be296cbc3543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0f15-f738-4644-9d29-2589d7e66915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812d0f15-f738-4644-9d29-2589d7e66915.jpg?1",
             "name": "Hateful Eidolon",
             "text": "Lifelink\nWhenever an enchanted creature dies, draw a card for each Aura you controlled that was attached to it.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "68ac45fd-e7ec-5a66-8450-3cf9c92f4d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6522f01-ae7a-467e-9a05-530a5ccd304d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6522f01-ae7a-467e-9a05-530a5ccd304d.jpg?1",
             "name": "Inevitable End",
             "text": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, sacrifice a creature.\"",
             "colours": [
@@ -3527,7 +3527,7 @@
         },
         {
             "id": "241db690-fd49-55cf-a607-c3fc2074a9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c9ada9-ea25-4a96-a4be-e4cf8f7a014f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8c9ada9-ea25-4a96-a4be-e4cf8f7a014f.jpg?1",
             "name": "Lampad of Death's Vigil",
             "text": "{1}, Sacrifice a creature: Each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "a3da4db7-8c02-5fde-870f-6f29eaf2e254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce763778-0a35-41d2-9286-fdf2302554f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce763778-0a35-41d2-9286-fdf2302554f5.jpg?1",
             "name": "Minion's Return",
             "text": "Flash\nEnchant creature\nWhen enchanted creature dies, return that card to the battlefield under your control.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "b53122ff-ea2c-5921-8934-fe2805da041d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8427d3-4d9e-48c9-838b-239fd1357d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8427d3-4d9e-48c9-838b-239fd1357d95.jpg?1",
             "name": "Mire Triton",
             "text": "Deathtouch\nWhen Mire Triton enters the battlefield, put the top two cards of your library into your graveyard and you gain 2 life.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "09c7fed3-1886-50a0-b31c-538c82658d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae0c536-612d-4916-a8da-5aaaf14218b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ae0c536-612d-4916-a8da-5aaaf14218b1.jpg?1",
             "name": "Mire's Grasp",
             "text": "Enchant creature\nEnchanted creature gets -3/-3.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "73a985a4-025a-5c39-b01c-20cfe7c5ad73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6bf7fb-11ca-4878-8072-cebaa763a549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de6bf7fb-11ca-4878-8072-cebaa763a549.jpg?1",
             "name": "Mogis's Favor",
             "text": "Enchant creature\nEnchanted creature gets +2/-1.\nEscape\u2014{2}{B}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "9de38d69-f317-5d94-99a5-009bcb87daab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a46eec7-bb79-441c-959f-eea599e5c341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a46eec7-bb79-441c-959f-eea599e5c341.jpg?1",
             "name": "Nightmare Shepherd",
             "text": "Flying\nWhenever another nontoken creature you control dies, you may exile it. If you do, create a token that's a copy of that creature, except it's 1/1 and it's a Nightmare in addition to its other types.",
             "colours": [
@@ -3736,7 +3736,7 @@
         },
         {
             "id": "050f6696-dd09-586c-9013-fb90fe6d7c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2a923a-1f9c-4a29-9c6b-344ae4d5ae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2a923a-1f9c-4a29-9c6b-344ae4d5ae8f.jpg?1",
             "name": "Nyxborn Marauder",
             "text": "",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "1c004f44-4c62-5b5e-a538-9c6b3b7c9771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8023fc44-fb8e-420d-a68c-b45912c4e5bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8023fc44-fb8e-420d-a68c-b45912c4e5bd.jpg?1",
             "name": "Omen of the Dead",
             "text": "Flash\nWhen Omen of the Dead enters the battlefield, return target creature card from your graveyard to your hand.\n{2}{B}, Sacrifice Omen of the Dead: Scry 2.",
             "colours": [
@@ -3803,7 +3803,7 @@
         },
         {
             "id": "267f1bef-eea5-59f6-8331-76bf81a0e26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0307bb5c-0a46-4f6b-b6d5-58cf31987bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0307bb5c-0a46-4f6b-b6d5-58cf31987bb5.jpg?1",
             "name": "Pharika's Libation",
             "text": "Choose one \u2014\n\u2022 Target opponent sacrifices a creature.\n\u2022 Target opponent sacrifices an enchantment.",
             "colours": [
@@ -3835,7 +3835,7 @@
         },
         {
             "id": "76adb30f-be96-52db-b243-a4e62f3ef293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c8244b-7d86-4dff-9419-3945beb2a7b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c8244b-7d86-4dff-9419-3945beb2a7b7.jpg?1",
             "name": "Pharika's Spawn",
             "text": "Escape\u2014{5}{B}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nPharika's Spawn escapes with two +1/+1 counters on it. When it enters the battlefield this way, each opponent sacrifices a non-Gorgon creature.",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "d02b5b43-81fa-5173-bfea-2b1f3b9103f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f76d7c4-a5d6-4144-b5f3-e43b96b695b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f76d7c4-a5d6-4144-b5f3-e43b96b695b7.jpg?1",
             "name": "Rage-Scarred Berserker",
             "text": "When Rage-Scarred Berserker enters the battlefield, target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3904,7 +3904,7 @@
         },
         {
             "id": "505b4f82-43d2-59b9-9e8b-f53fb5aa3c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e237c5-45b4-49df-adb9-62b9f3b62986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e237c5-45b4-49df-adb9-62b9f3b62986.jpg?1",
             "name": "Scavenging Harpy",
             "text": "Flying\nWhen Scavenging Harpy enters the battlefield, exile target card from an opponent's graveyard.",
             "colours": [
@@ -3938,7 +3938,7 @@
         },
         {
             "id": "3a3617df-0186-56c5-a1ec-55578d61e2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e2f383-d2a0-4424-bf7a-79e82d6f691f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e2f383-d2a0-4424-bf7a-79e82d6f691f.jpg?1",
             "name": "Soulreaper of Mogis",
             "text": "{2}{B}, Sacrifice a creature: Draw a card.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "af311dbe-8576-5f64-8338-58c7ee6ae038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4a61aa-75d2-46bc-b13f-b863f5f49d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4a61aa-75d2-46bc-b13f-b863f5f49d32.jpg?1",
             "name": "Temple Thief",
             "text": "Temple Thief can't be blocked by enchanted creatures or enchantment creatures.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "516b0999-70cd-5050-aeb8-b4be278cb0c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3ad6b-9966-489f-a4c9-2639a634fd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35b3ad6b-9966-489f-a4c9-2639a634fd62.jpg?1",
             "name": "Treacherous Blessing",
             "text": "When Treacherous Blessing enters the battlefield, draw three cards.\nWhenever you cast a spell, you lose 1 life.\nWhen Treacherous Blessing becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -4043,7 +4043,7 @@
         },
         {
             "id": "b0067ca9-1abb-57fa-8894-651fb74a73a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c0d087-540a-4249-9265-f13cc8e776ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68c0d087-540a-4249-9265-f13cc8e776ea.jpg?1",
             "name": "Tymaret Calls the Dead",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Put the top three cards of your library into your graveyard. Then you may exile a creature or enchantment card from your graveyard. If you do, create a 2/2 black Zombie creature token.\nIII \u2014 You gain X life and scry X, where X is the number of Zombies you control.",
             "colours": [
@@ -4077,7 +4077,7 @@
         },
         {
             "id": "17f931e5-d09f-5c47-a577-12cc13b4e20e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b28eae-e8ed-4b99-b6ec-86d0716ec473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b28eae-e8ed-4b99-b6ec-86d0716ec473.jpg?1",
             "name": "Tymaret, Chosen from Death",
             "text": "Tymaret's toughness is equal to your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n{1}{B}: Exile up to two target cards from graveyards. You gain 1 life for each creature card exiled this way.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "30a41704-456c-5658-9ebe-27fd48cc6c78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dd847f-0db2-4f6a-bdfb-5c88ce7802f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dd847f-0db2-4f6a-bdfb-5c88ce7802f9.jpg?1",
             "name": "Underworld Charger",
             "text": "Underworld Charger can't block.\nEscape\u2014{4}{B}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nUnderworld Charger escapes with two +1/+1 counters on it.",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "356014f0-1cf5-5ef0-8728-4645a77554a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03919c86-1c4a-43b0-a2db-54ca6ae1ac57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03919c86-1c4a-43b0-a2db-54ca6ae1ac57.jpg?1",
             "name": "Underworld Dreams",
             "text": "Whenever an opponent draws a card, Underworld Dreams deals 1 damage to that player.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "2cc6611b-aab7-575c-af60-68e6ce58837a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc2b661-2f42-419d-837f-bbf097c1153c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dc2b661-2f42-419d-837f-bbf097c1153c.jpg?1",
             "name": "Venomous Hierophant",
             "text": "Deathtouch\nWhen Venomous Hierophant enters the battlefield, put the top three cards of your library into your graveyard.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "40d69dbd-17dd-5a97-9829-3bf0827b7717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457b558-b35b-49fd-b499-b1ec755f86ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3457b558-b35b-49fd-b499-b1ec755f86ce.jpg?1",
             "name": "Woe Strider",
             "text": "When Woe Strider enters the battlefield, create a 0/1 white Goat creature token.\nSacrifice another creature: Scry 1.\nEscape\u2014{3}{B}{B}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nWoe Strider escapes with two +1/+1 counters on it.",
             "colours": [
@@ -4254,7 +4254,7 @@
         },
         {
             "id": "b9f2a87e-3b67-5547-8cca-91b6bd06b4f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ea046b-1bbc-4430-a859-321602c9e928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28ea046b-1bbc-4430-a859-321602c9e928.jpg?1",
             "name": "The Akroan War",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Gain control of target creature for as long as The Akroan War remains on the battlefield.\nII \u2014 Until your next turn, creatures your opponents control attack each combat if able.\nIII \u2014 Each tapped creature deals damage to itself equal to its power.",
             "colours": [
@@ -4288,7 +4288,7 @@
         },
         {
             "id": "7eaed8a7-3cd9-5895-b11c-be17aad8a462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07285b4-77c5-4a38-8810-20d7e49593ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07285b4-77c5-4a38-8810-20d7e49593ec.jpg?1",
             "name": "Anax, Hardened in the Forge",
             "text": "Anax's power is equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)\nWhenever Anax or another nontoken creature you control dies, create a 1/1 red Satyr creature token with \"This creature can't block.\" If the creature had power 4 or greater, create two of those tokens instead.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "18a774fc-c616-5404-a5ef-8d60df0aaaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e096049d-9f02-4abb-bb5a-97b14fd17099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e096049d-9f02-4abb-bb5a-97b14fd17099.jpg?1",
             "name": "Arena Trickster",
             "text": "Whenever you cast your first spell during each opponent's turn, put a +1/+1 counter on Arena Trickster.",
             "colours": [
@@ -4362,7 +4362,7 @@
         },
         {
             "id": "bc85b359-e715-5d49-a124-4f14a254b328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d0091-1925-44a5-89f3-21c2afd5665c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67d0091-1925-44a5-89f3-21c2afd5665c.jpg?1",
             "name": "Aspect of Manticore",
             "text": "Flash\nEnchant creature\nWhen Aspect of Manticore enters the battlefield, enchanted creature gains first strike until end of turn.\nEnchanted creature gets +2/+0.",
             "colours": [
@@ -4396,7 +4396,7 @@
         },
         {
             "id": "5ea26bab-cc00-599d-bf40-e04ba7a51803",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f3fa3-ba1f-48dc-a56b-738936f1bf86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d4f3fa3-ba1f-48dc-a56b-738936f1bf86.jpg?1",
             "name": "Blood Aspirant",
             "text": "Whenever you sacrifice a permanent, put a +1/+1 counter on Blood Aspirant.\n{1}{R}, {T}, Sacrifice a creature or enchantment: Blood Aspirant deals 1 damage to target creature. That creature can't block this turn.",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "735d4cc2-156f-5b24-92ea-c233228cc320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6bdd4-b25b-41f6-835d-7d1570cdb951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6bdd4-b25b-41f6-835d-7d1570cdb951.jpg?1",
             "name": "Careless Celebrant",
             "text": "When Careless Celebrant dies, it deals 2 damage to target creature or planeswalker an opponent controls.",
             "colours": [
@@ -4466,7 +4466,7 @@
         },
         {
             "id": "b083057f-dcad-5c5e-85c6-c01427706916",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b04ec8-68c9-468c-b137-707db994af68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b04ec8-68c9-468c-b137-707db994af68.jpg?1",
             "name": "Dreamshaper Shaman",
             "text": "At the beginning of your end step, you may pay {2}{R} and sacrifice a nonland permanent. If you do, reveal cards from the top of your library until you reveal a nonland permanent card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "ab9b4826-b2df-5146-859a-46666c7d512d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee10eaa0-dbe0-45ee-9a7d-395ec5d27e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee10eaa0-dbe0-45ee-9a7d-395ec5d27e08.jpg?1",
             "name": "Dreamstalker Manticore",
             "text": "Whenever you cast your first spell during each opponent's turn, Dreamstalker Manticore deals 1 damage to any target.",
             "colours": [
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "3c26b805-7f48-5d16-a957-ab205e63359a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2a3da-2458-4921-8574-9eb9d5925ae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c2a3da-2458-4921-8574-9eb9d5925ae8.jpg?1",
             "name": "Escape Velocity",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has haste.\nEscape\u2014{1}{R}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "27a0b59d-6d7f-5845-9616-9be319f13272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56455067-92c0-45b5-ac2e-525c35b41215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56455067-92c0-45b5-ac2e-525c35b41215.jpg?1",
             "name": "Fateful End",
             "text": "Fateful End deals 3 damage to any target. Scry 1.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "14e61178-c2e1-599c-84ee-f8a9ab487721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c95dee-a480-4878-a967-9e46be9ee372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c95dee-a480-4878-a967-9e46be9ee372.jpg?1",
             "name": "Final Flare",
             "text": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nFinal Flare deals 5 damage to target creature.",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "b1eb22be-e22d-5802-9c7e-16beeed9afc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70bcef-7ab6-4547-aca4-dd3ba68fd26b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70bcef-7ab6-4547-aca4-dd3ba68fd26b.jpg?1",
             "name": "Flummoxed Cyclops",
             "text": "Reach\nWhenever two or more creatures your opponents control attack, Flummoxed Cyclops can't block this combat.",
             "colours": [
@@ -4669,7 +4669,7 @@
         },
         {
             "id": "fecf6825-43da-5fd0-a8a1-760c47e016f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2531fb76-038b-49ab-b4d6-31b291faa7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2531fb76-038b-49ab-b4d6-31b291faa7ca.jpg?1",
             "name": "Furious Rise",
             "text": "At the beginning of your end step, if you control a creature with power 4 or greater, exile the top card of your library. You may play that card until you exile another card with Furious Rise.",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "31319ded-6690-5f90-befe-055d61b8a0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb7c7a6-4e9b-4300-a776-b7e7916950c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb7c7a6-4e9b-4300-a776-b7e7916950c8.jpg?1",
             "name": "Hero of the Games",
             "text": "Whenever you cast a spell that targets Hero of the Games, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "b30cdd1c-5b0b-5629-b578-8c0b217f7fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfb481-3446-42f4-a1c3-a88b69f2189a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfdfb481-3446-42f4-a1c3-a88b69f2189a.jpg?1",
             "name": "Heroes of the Revel",
             "text": "When Heroes of the Revel enters the battlefield, create a 1/1 red Satyr creature token with \"This creature can't block.\"\nWhenever you cast a spell that targets Heroes of the Revel, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4771,7 +4771,7 @@
         },
         {
             "id": "8d379429-d624-5a30-996e-3f081c7deb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681db91-5dab-41e6-96f2-275ec9495e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5681db91-5dab-41e6-96f2-275ec9495e5b.jpg?1",
             "name": "Impending Doom",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and attacks each combat if able.\nWhen enchanted creature dies, Impending Doom deals 3 damage to that creature's controller.",
             "colours": [
@@ -4805,7 +4805,7 @@
         },
         {
             "id": "d0c19b45-55f2-545f-89e6-3d6e6ae28258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6b9b5c-35ff-47ac-9b04-71257314b686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb6b9b5c-35ff-47ac-9b04-71257314b686.jpg?1",
             "name": "Incendiary Oracle",
             "text": "{1}{R}: Incendiary Oracle gets +1/+0 until end of turn.\nIf a creature dealt damage by Incendiary Oracle this turn would die, exile it instead.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "67b00420-7887-5c7c-b219-95e9ad2e18cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a74392-4056-428c-a807-b062957e838e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a74392-4056-428c-a807-b062957e838e.jpg?1",
             "name": "Infuriate",
             "text": "Target creature gets +3/+2 until end of turn.",
             "colours": [
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "46c62c43-73b0-58a2-87e4-532583e26b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e99a5-b105-489e-aff6-7d2ca50d8ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab6e99a5-b105-489e-aff6-7d2ca50d8ba9.jpg?1",
             "name": "Iroas's Blessing",
             "text": "Enchant creature you control\nWhen Iroas's Blessing enters the battlefield, it deals 4 damage to target creature or planeswalker an opponent controls.\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "c349a957-4907-5e86-87fc-31d74b45bcc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg?1",
             "name": "Irreverent Revelers",
             "text": "When Irreverent Revelers enters the battlefield, choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Irreverent Revelers gains haste until end of turn.",
             "colours": [
@@ -4940,7 +4940,7 @@
         },
         {
             "id": "ea31f3c8-0f36-5344-8579-b7adc2638856",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bc4236-566f-401b-b9d7-f58126fa228b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05bc4236-566f-401b-b9d7-f58126fa228b.jpg?1",
             "name": "Nyxborn Brute",
             "text": "",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "488bbeac-6461-5181-8762-b7985f8884b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70388773-709b-4cd8-a8b7-56093fd77a1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70388773-709b-4cd8-a8b7-56093fd77a1d.jpg?1",
             "name": "Omen of the Forge",
             "text": "Flash\nWhen Omen of the Forge enters the battlefield, it deals 2 damage to any target.\n{2}{R}, Sacrifice Omen of the Forge: Scry 2.",
             "colours": [
@@ -5007,7 +5007,7 @@
         },
         {
             "id": "dda5d473-b744-50e5-94ed-72d9114071d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9bb73a-5b4e-4c9b-b0a6-8e531dc27394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9bb73a-5b4e-4c9b-b0a6-8e531dc27394.jpg?1",
             "name": "Oread of Mountain's Blaze",
             "text": "{2}{R}, Discard a card: Draw a card.",
             "colours": [
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "82cd6def-fef5-5e08-8af8-934f1be45237",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75caefa7-94d5-472e-a540-daad3ee69899.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75caefa7-94d5-472e-a540-daad3ee69899.jpg?1",
             "name": "Ox of Agonas",
             "text": "When Ox of Agonas enters the battlefield, discard your hand, then draw three cards.\nEscape\u2014{R}{R}, Exile eight other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nOx of Agonas escapes with a +1/+1 counter on it.",
             "colours": [
@@ -5078,7 +5078,7 @@
         },
         {
             "id": "6ed2ceda-d928-56d9-8322-c0fe5670352a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7010ce26-16de-44cb-ba7e-3d904175b429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7010ce26-16de-44cb-ba7e-3d904175b429.jpg?1",
             "name": "Phoenix of Ash",
             "text": "Flying, haste\n{2}{R}: Phoenix of Ash gets +2/+0 until end of turn.\nEscape\u2014{2}{R}{R}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nPhoenix of Ash escapes with a +1/+1 counter on it.",
             "colours": [
@@ -5114,7 +5114,7 @@
         },
         {
             "id": "937db07f-6d46-5c77-aee8-f81070c2d843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c2b855-5079-418e-bfb4-9fc575ebe4f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c2b855-5079-418e-bfb4-9fc575ebe4f7.jpg?1",
             "name": "Portent of Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1.",
             "colours": [
@@ -5146,7 +5146,7 @@
         },
         {
             "id": "d9dc4f37-a58a-5f7f-9f87-eaa6e37b9e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3af5c4-0960-44a2-976e-abdf7803c436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af3af5c4-0960-44a2-976e-abdf7803c436.jpg?1",
             "name": "Purphoros, Bronze-Blooded",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nOther creatures you control have haste.\n{2}{R}: You may put a red creature card or an artifact creature card from your hand onto the battlefield. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "e06a4d6c-dc62-5ce9-9fbd-4aea646d1ee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc911ee-0e12-4b10-add7-9a9d63c29443.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecc911ee-0e12-4b10-add7-9a9d63c29443.jpg?1",
             "name": "Purphoros's Intervention",
             "text": "Choose one \u2014\n\u2022 Create an X/1 red Elemental creature token with trample and haste. Sacrifice it at the beginning of the next end step.\n\u2022 Purphoros's Intervention deals twice X damage to target creature or planeswalker.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "0798c148-9813-5efe-b516-0c0e2f3e5a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d8201-be68-42fa-bcfd-42d81a2ad195.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d8201-be68-42fa-bcfd-42d81a2ad195.jpg?1",
             "name": "Satyr's Cunning",
             "text": "Create a 1/1 red Satyr creature token with \"This creature can't block.\"\nEscape\u2014{2}{R}, Exile two other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -5251,7 +5251,7 @@
         },
         {
             "id": "1794449f-5002-5d3a-8d7d-6e52052183d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f470a7b-63ef-4efa-855e-f8a3ce1ab534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f470a7b-63ef-4efa-855e-f8a3ce1ab534.jpg?1",
             "name": "Skophos Maze-Warden",
             "text": "{1}: Skophos Maze-Warden gets +1/-1 until end of turn.\nWhenever another creature becomes the target of an ability of a land you control named Labyrinth of Skophos, you may have Skophos Maze-Warden fight that creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "fd57d7a5-4847-5412-b2c5-de3645984be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c39c70-8360-4c7c-b5fa-61c42828609a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c39c70-8360-4c7c-b5fa-61c42828609a.jpg?1",
             "name": "Skophos Warleader",
             "text": "{R}, Sacrifice another creature or an enchantment: Skophos Warleader gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -5321,7 +5321,7 @@
         },
         {
             "id": "c2103439-16a4-540c-a556-2679e57dd87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32c6192-2f8d-4656-af8b-c488e27a75e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c32c6192-2f8d-4656-af8b-c488e27a75e1.jpg?1",
             "name": "Stampede Rider",
             "text": "Trample\nAt the beginning of each combat, if you control a creature with power 4 or greater, Stampede Rider gets +1/+1 until end of turn.",
             "colours": [
@@ -5355,7 +5355,7 @@
         },
         {
             "id": "022eb4c1-4216-5443-84e1-3743bcf6e19a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0594aa2-1c53-4271-a0d0-9002c07f3697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0594aa2-1c53-4271-a0d0-9002c07f3697.jpg?1",
             "name": "Storm Herald",
             "text": "Haste\nWhen Storm Herald enters the battlefield, return any number of Aura cards from your graveyard to the battlefield attached to creatures you control. Exile those Auras at the beginning of your next end step. If those Auras would leave the battlefield, exile them instead of putting them anywhere else.",
             "colours": [
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "0f01c41a-7011-5059-a646-84396cc70fc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9ecd2-7664-471b-90f2-2d0dd1acec80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc9ecd2-7664-471b-90f2-2d0dd1acec80.jpg?1",
             "name": "Storm's Wrath",
             "text": "Storm's Wrath deals 4 damage to each creature and each planeswalker.",
             "colours": [
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "774b6d6b-76c4-556c-9b10-a9be9558a987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f226550-fc9f-4964-ac62-74f84d0ac3f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f226550-fc9f-4964-ac62-74f84d0ac3f3.jpg?1",
             "name": "Tectonic Giant",
             "text": "Whenever Tectonic Giant attacks or becomes the target of a spell an opponent controls, choose one \u2014\n\u2022 Tectonic Giant deals 3 damage to each opponent.\n\u2022 Exile the top two cards of your library. Choose one of them. Until the end of your next turn, you may play that card.",
             "colours": [
@@ -5463,7 +5463,7 @@
         },
         {
             "id": "50a15975-6cf0-5171-83d6-3ce4e815e89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e807edb-838d-44fe-a37e-fb864d59beaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e807edb-838d-44fe-a37e-fb864d59beaa.jpg?1",
             "name": "Thrill of Possibility",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -5497,7 +5497,7 @@
         },
         {
             "id": "0dcd85c3-7a40-5d64-8be1-805d2c118d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b5b348-1415-4062-a2a7-017694424c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b5b348-1415-4062-a2a7-017694424c05.jpg?1",
             "name": "The Triumph of Anax",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III \u2014 Until end of turn, target creature gains trample and gets +X/+0, where X is the number of lore counters on The Triumph of Anax.\nIV \u2014 Target creature you control fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -5531,7 +5531,7 @@
         },
         {
             "id": "4ef5567b-6c15-5306-b7d6-c434b71c5e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e51d796-7279-4c06-87f0-37adbdaa41df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e51d796-7279-4c06-87f0-37adbdaa41df.jpg?1",
             "name": "Underworld Breach",
             "text": "Each nonland card in your graveyard has escape. The escape cost is equal to the card's mana cost plus exile three other cards from your graveyard. (You may cast cards from your graveyard for their escape cost.)\nAt the beginning of the end step, sacrifice Underworld Breach.",
             "colours": [
@@ -5565,7 +5565,7 @@
         },
         {
             "id": "3d1f0f19-17ab-5eef-afc5-cafaded60938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe616c4-dcb0-4284-ba10-6fbf7cecd217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fe616c4-dcb0-4284-ba10-6fbf7cecd217.jpg?1",
             "name": "Underworld Fires",
             "text": "Underworld Fires deals 1 damage to each creature and each planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -5597,7 +5597,7 @@
         },
         {
             "id": "ac3f9f56-e55e-5d9f-8ce3-b5a9f0a852e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04eef82-fd53-41f4-9c7e-28b9ac039032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a04eef82-fd53-41f4-9c7e-28b9ac039032.jpg?1",
             "name": "Underworld Rage-Hound",
             "text": "Underworld Rage-Hound attacks each combat if able.\nEscape\u2014{3}{R}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nUnderworld Rage-Hound escapes with a +1/+1 counter on it.",
             "colours": [
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "c11c6a73-6bc4-56aa-85b1-5a25b42a234d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f7ff4f-3fd6-4084-aaf7-9f290ecc0181.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f7ff4f-3fd6-4084-aaf7-9f290ecc0181.jpg?1",
             "name": "Wrap in Flames",
             "text": "Wrap in Flames deals 1 damage to each of up to three target creatures. Those creatures can't block this turn.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "ea4dc631-6483-5ec2-8879-52a578f6fd8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "e315c459-a7d3-529f-8a40-862d2f5a8bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fb94ad-f9be-48b4-b65a-4e736e5ffdbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fb94ad-f9be-48b4-b65a-4e736e5ffdbb.jpg?1",
             "name": "The Binding of the Titans",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Each player puts the top three cards of their library into their graveyard.\nII \u2014 Exile up to two target cards from graveyards. For each creature card exiled this way, you gain 1 life.\nIII \u2014 Return target creature or land card from your graveyard to your hand.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "f3ed51c4-958d-5845-b488-4f3945f10eb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874afaad-546a-4cb2-ad01-2b4a4862b219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/874afaad-546a-4cb2-ad01-2b4a4862b219.jpg?1",
             "name": "Chainweb Aracnir",
             "text": "Reach\nWhen Chainweb Aracnir enters the battlefield, it deals damage equal to its power to target creature with flying an opponent controls.\nEscape\u2014{3}{G}{G}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nChainweb Aracnir escapes with three +1/+1 counters on it.",
             "colours": [
@@ -5772,7 +5772,7 @@
         },
         {
             "id": "7cf75f1b-e193-5c4e-aa45-2adade7fe822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba264166-948b-47d4-b302-64476acc1a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba264166-948b-47d4-b302-64476acc1a55.jpg?1",
             "name": "Destiny Spinner",
             "text": "Creature and enchantment spells you control can't be countered.\n{3}{G}: Target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is the number of enchantments you control. It's still a land.",
             "colours": [
@@ -5807,7 +5807,7 @@
         },
         {
             "id": "58e20f22-5b6d-53f7-a1e6-02efb650a67a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d964876-194b-49f1-8e74-cfe9269f2c62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d964876-194b-49f1-8e74-cfe9269f2c62.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "You may play an additional land on each of your turns.\nLands you control are every basic land type in addition to their other types.",
             "colours": [
@@ -5845,7 +5845,7 @@
         },
         {
             "id": "f48206a6-6ac2-5f8e-98b3-64d443543ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b05ada5-8e5f-4158-bd28-e6c24e4a2299.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b05ada5-8e5f-4158-bd28-e6c24e4a2299.jpg?1",
             "name": "The First Iroan Games",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI \u2014 Create a 1/1 white Human Soldier creature token.\nII \u2014 Put three +1/+1 counters on target creature you control.\nIII \u2014 If you control a creature with power 4 or greater, draw two cards.\nIV \u2014 Create a Gold token.",
             "colours": [
@@ -5879,7 +5879,7 @@
         },
         {
             "id": "6c0b2969-16e4-5d29-b622-64c2165320cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5e144-4dd6-441f-b3e2-433aa82bdf7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f5e144-4dd6-441f-b3e2-433aa82bdf7b.jpg?1",
             "name": "Gift of Strength",
             "text": "Target creature gets +3/+3 and gains reach until end of turn.",
             "colours": [
@@ -5911,7 +5911,7 @@
         },
         {
             "id": "e12e1086-8273-5916-b90d-0f487290fe32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112ee2a-a6f3-4280-a915-000a97a9cdef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5112ee2a-a6f3-4280-a915-000a97a9cdef.jpg?1",
             "name": "Hydra's Growth",
             "text": "Enchant creature\nWhen Hydra's Growth enters the battlefield, put a +1/+1 counter on enchanted creature.\nAt the beginning of your upkeep, double the number of +1/+1 counters on enchanted creature.",
             "colours": [
@@ -5945,7 +5945,7 @@
         },
         {
             "id": "85630686-a2d8-5133-ab25-e923266fff81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7f2638-d757-4df6-90b0-b616534dd3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7f2638-d757-4df6-90b0-b616534dd3a0.jpg?1",
             "name": "Hyrax Tower Scout",
             "text": "When Hyrax Tower Scout enters the battlefield, untap target creature.",
             "colours": [
@@ -5980,7 +5980,7 @@
         },
         {
             "id": "b9ba2b05-4133-5ad8-8db6-c5a837fe3c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdf8ab8-f221-4f7b-9af9-3849cad1f596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdf8ab8-f221-4f7b-9af9-3849cad1f596.jpg?1",
             "name": "Ilysian Caryatid",
             "text": "{T}: Add one mana of any color. If you control a creature with power 4 or greater, add two mana of any one color instead.",
             "colours": [
@@ -6014,7 +6014,7 @@
         },
         {
             "id": "8971ae82-f791-5f5a-a1ee-784b2b152801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c8b5a-2e18-4dd8-b236-5b1fd356f867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23c8b5a-2e18-4dd8-b236-5b1fd356f867.jpg?1",
             "name": "Inspire Awe",
             "text": "Prevent all combat damage that would be dealt this turn except combat damage that would be dealt by enchanted creatures and enchantment creatures. Scry 2.",
             "colours": [
@@ -6046,7 +6046,7 @@
         },
         {
             "id": "a8f58718-1f50-53cb-a04a-5e948c3938f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b6b7a7-0ac8-470a-949b-4779ded95359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b6b7a7-0ac8-470a-949b-4779ded95359.jpg?1",
             "name": "Klothys's Design",
             "text": "Creatures you control get +X/+X until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "7fe695a1-e064-5b3a-a863-6690981d0464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe6283-3642-4883-ac6e-83ae3280af9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afe6283-3642-4883-ac6e-83ae3280af9c.jpg?1",
             "name": "Loathsome Chimera",
             "text": "Escape\u2014{4}{G}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nLoathsome Chimera escapes with a +1/+1 counter on it.",
             "colours": [
@@ -6112,7 +6112,7 @@
         },
         {
             "id": "0d3fa0b8-1a84-50d3-88ab-a962ecc9396d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a786fa-4b86-40f7-ac58-1a05fb38fcdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a786fa-4b86-40f7-ac58-1a05fb38fcdb.jpg?1",
             "name": "Mantle of the Wolf",
             "text": "Enchant creature\nEnchanted creature gets +4/+4.\nWhen Mantle of the Wolf is put into a graveyard from the battlefield, create two 2/2 green Wolf creature tokens.",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "10fbd30b-1b25-549d-8a32-836cb864e9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg?1",
             "name": "Moss Viper",
             "text": "Deathtouch",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "07a3716e-3335-5ce0-8823-69f274b3a6c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6797195a-508f-45b1-964d-da842dc46ca8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6797195a-508f-45b1-964d-da842dc46ca8.jpg?1",
             "name": "Mystic Repeal",
             "text": "Put target enchantment on the bottom of its owner's library.",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "25d2afff-6850-5de1-be74-1ff0300c4532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf91fc2-7317-47e4-9e6c-d7d74cdf0153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf91fc2-7317-47e4-9e6c-d7d74cdf0153.jpg?1",
             "name": "Nessian Boar",
             "text": "All creatures able to block Nessian Boar do so.\nWhenever Nessian Boar becomes blocked by a creature, that creature's controller draws a card.",
             "colours": [
@@ -6250,7 +6250,7 @@
         },
         {
             "id": "63704522-3ee1-573b-afcf-e366c596608b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200fcda-e30c-460f-9964-47e657b7c758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200fcda-e30c-460f-9964-47e657b7c758.jpg?1",
             "name": "Nessian Hornbeetle",
             "text": "At the beginning of combat on your turn, if you control another creature with power 4 or greater, put a +1/+1 counter on Nessian Hornbeetle.",
             "colours": [
@@ -6284,7 +6284,7 @@
         },
         {
             "id": "7173e8f1-4044-5c37-9442-fe54310aecb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d50576-c3ee-479a-8533-6c147f5cb1c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50d50576-c3ee-479a-8533-6c147f5cb1c4.jpg?1",
             "name": "Nessian Wanderer",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, look at the top three cards of your library. You may reveal a land card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "8f0f4a37-2d43-577a-8776-c314f8744b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb4e56-bcad-43a3-8600-a3594047205a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cb4e56-bcad-43a3-8600-a3594047205a.jpg?1",
             "name": "Nexus Wardens",
             "text": "Reach\nConstellation \u2014 Whenever an enchantment enters the battlefield under your control, you gain 2 life.",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "820520f3-09d0-53ed-bf82-d7ed56f8df78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf894d4-1a06-4952-a481-22786ab87a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf894d4-1a06-4952-a481-22786ab87a73.jpg?1",
             "name": "Nylea, Keen-Eyed",
             "text": "Indestructible\nAs long as your devotion to green is less than five, Nylea isn't a creature.\nCreature spells you cast cost {1} less to cast.\n{2}{G}: Reveal the top card of your library. If it's a creature card, put it into your hand. Otherwise, you may put it into your graveyard.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "6313907b-6895-581e-a4b1-73e27b6b4f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2b6be-80a8-4464-a909-8cc658196a14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf2b6be-80a8-4464-a909-8cc658196a14.jpg?1",
             "name": "Nylea's Forerunner",
             "text": "Trample\nOther creatures you control have trample.",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "600407f1-d5f2-5155-902d-f5eba0e8d090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4fe89a-0d2b-493f-883e-a1e0b0918340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4fe89a-0d2b-493f-883e-a1e0b0918340.jpg?1",
             "name": "Nylea's Huntmaster",
             "text": "When Nylea's Huntmaster enters the battlefield, target creature you control gets +X/+0 until end of turn, where X is your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -6463,7 +6463,7 @@
         },
         {
             "id": "f72f9e0a-8a02-5128-995e-0c8f8b3491ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2f963-9d16-4224-b24e-b6a79f2b9d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daa2f963-9d16-4224-b24e-b6a79f2b9d75.jpg?1",
             "name": "Nylea's Intervention",
             "text": "Choose one \u2014\n\u2022 Search your library for up to X land cards, reveal them, put them into your hand, then shuffle your library.\n\u2022 Nylea's Intervention deals twice X damage to each creature with flying.",
             "colours": [
@@ -6497,7 +6497,7 @@
         },
         {
             "id": "f93ffcdc-7057-518c-a181-27ee311c4fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866dcef0-8d3e-4126-963a-05598d8a9e79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866dcef0-8d3e-4126-963a-05598d8a9e79.jpg?1",
             "name": "Nyx Herald",
             "text": "At the beginning of combat on your turn, target enchanted creature or enchantment creature you control gets +1/+1 and gains trample until end of turn.",
             "colours": [
@@ -6533,7 +6533,7 @@
         },
         {
             "id": "484b4501-a6a7-5fba-a62e-c309a4e0c5e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391da36-0b40-46ea-b771-50d2b920207e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a391da36-0b40-46ea-b771-50d2b920207e.jpg?1",
             "name": "Nyxbloom Ancient",
             "text": "Trample\nIf you tap a permanent for mana, it produces three times as much of that mana instead.",
             "colours": [
@@ -6570,7 +6570,7 @@
         },
         {
             "id": "681b84bf-fd9a-55b9-86df-4602af85b096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f003c-1e99-4e53-ad6d-81ff3c592b2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b4f003c-1e99-4e53-ad6d-81ff3c592b2c.jpg?1",
             "name": "Nyxborn Colossus",
             "text": "",
             "colours": [
@@ -6605,7 +6605,7 @@
         },
         {
             "id": "722a3230-4712-5c49-aed8-b80c30af942d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ebdea-78d4-4034-921b-735bdb11a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ebdea-78d4-4034-921b-735bdb11a716.jpg?1",
             "name": "Omen of the Hunt",
             "text": "Flash\nWhen Omen of the Hunt enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\n{2}{G}, Sacrifice Omen of the Hunt: Scry 2.",
             "colours": [
@@ -6637,7 +6637,7 @@
         },
         {
             "id": "07af694c-36eb-5c4f-bf0f-977634727349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ac20a9-6b10-4165-ad81-a47587b64d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ac20a9-6b10-4165-ad81-a47587b64d1e.jpg?1",
             "name": "Pheres-Band Brawler",
             "text": "When Pheres-Band Brawler enters the battlefield, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "437d3f42-ff9e-5549-8e6f-1718889923da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b2f186-4e04-49cb-a206-257cfb7e9361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b2f186-4e04-49cb-a206-257cfb7e9361.jpg?1",
             "name": "Plummet",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "0b778d79-e588-5534-be7e-54e3acf9527c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b9560-b1d6-441c-8bc8-bf6988112d25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752b9560-b1d6-441c-8bc8-bf6988112d25.jpg?1",
             "name": "Relentless Pursuit",
             "text": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6736,7 +6736,7 @@
         },
         {
             "id": "c28e6a4f-c5ca-5bf2-99cc-a7d411c70d38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27e6b2-13ad-42b2-a121-70935913723d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b27e6b2-13ad-42b2-a121-70935913723d.jpg?1",
             "name": "Renata, Called to the Hunt",
             "text": "Renata's power is equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)\nEach other creature you control enters the battlefield with an additional +1/+1 counter on it.",
             "colours": [
@@ -6775,7 +6775,7 @@
         },
         {
             "id": "562a6d1b-f445-5ea2-805b-9a53f6555931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4515a76-53f0-40a2-8b88-70b73447d1e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4515a76-53f0-40a2-8b88-70b73447d1e6.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "5ec2ee5c-3908-5815-bdeb-562a3ed1239d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ce9858-747e-441c-95a8-6af44aa2098d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8ce9858-747e-441c-95a8-6af44aa2098d.jpg?1",
             "name": "Setessan Champion",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, put a +1/+1 counter on Setessan Champion and draw a card.",
             "colours": [
@@ -6844,7 +6844,7 @@
         },
         {
             "id": "f320c7d6-f13e-5d11-8a5e-f1ba0c05603c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384495c2-238b-4f8d-89c2-e05b64f9dde0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384495c2-238b-4f8d-89c2-e05b64f9dde0.jpg?1",
             "name": "Setessan Petitioner",
             "text": "When Setessan Petitioner enters the battlefield, you gain life equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -6879,7 +6879,7 @@
         },
         {
             "id": "ba0b3755-2365-5273-8f6a-05a2c8fb90b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46739993-6afe-428d-bf63-b57649e38a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46739993-6afe-428d-bf63-b57649e38a65.jpg?1",
             "name": "Setessan Skirmisher",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, Setessan Skirmisher gets +1/+1 until end of turn.",
             "colours": [
@@ -6914,7 +6914,7 @@
         },
         {
             "id": "df4d1799-22a5-5c25-ad42-bb10e302055a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322d31-6194-4fda-99a3-b6426c57488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8322d31-6194-4fda-99a3-b6426c57488a.jpg?1",
             "name": "Setessan Training",
             "text": "Enchant creature you control\nWhen Setessan Training enters the battlefield, draw a card.\nEnchanted creature gets +1/+0 and has trample.",
             "colours": [
@@ -6948,7 +6948,7 @@
         },
         {
             "id": "794b71e8-452d-548d-82fa-f3552fa84f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076ec900-345d-4720-96b6-441bce01618a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076ec900-345d-4720-96b6-441bce01618a.jpg?1",
             "name": "Skola Grovedancer",
             "text": "Whenever a land card is put into your graveyard from anywhere, you gain 1 life.\n{2}{G}: Put the top card of your library into your graveyard.",
             "colours": [
@@ -6984,7 +6984,7 @@
         },
         {
             "id": "0e84a444-7d05-5c2a-88e2-0c744103f13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2bccb-0e01-4629-b9a8-5c0ea26239b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efa2bccb-0e01-4629-b9a8-5c0ea26239b3.jpg?1",
             "name": "Voracious Typhon",
             "text": "Escape\u2014{5}{G}{G}, Exile four other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)\nVoracious Typhon escapes with three +1/+1 counters on it.",
             "colours": [
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "ec7baadc-0c57-5460-a03e-638c79a9a8d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d64cab-2ed1-46d9-8034-0c2ba3f2e1ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d64cab-2ed1-46d9-8034-0c2ba3f2e1ed.jpg?1",
             "name": "Warbriar Blessing",
             "text": "Enchant creature you control\nWhen Warbriar Blessing enters the battlefield, enchanted creature fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "c94d1a5a-82ee-5caa-8739-b4769754f500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b886c3-234c-49ce-9a11-456c1e8f092f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b886c3-234c-49ce-9a11-456c1e8f092f.jpg?1",
             "name": "Wolfwillow Haven",
             "text": "Enchant land\nWhenever enchanted land is tapped for mana, its controller adds an additional {G}.\n{4}{G}, Sacrifice Wolfwillow Haven: Create a 2/2 green Wolf creature token. Activate this ability only during your turn.",
             "colours": [
@@ -7089,7 +7089,7 @@
         },
         {
             "id": "3a61e0b3-4c1a-5971-a27d-81ee96d85b4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14afed6-ca42-442d-ba86-621179e6957c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a14afed6-ca42-442d-ba86-621179e6957c.jpg?1",
             "name": "Acolyte of Affliction",
             "text": "When Acolyte of Affliction enters the battlefield, put the top two cards of your library into your graveyard, then you may return a permanent card from your graveyard to your hand.",
             "colours": [
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "828e4c85-e1d9-5aea-bbef-b646b9f9cae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e09c3-917c-4bbb-bb94-60f4e9417832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77e09c3-917c-4bbb-bb94-60f4e9417832.jpg?1",
             "name": "Allure of the Unknown",
             "text": "Reveal the top six cards of your library. An opponent exiles a nonland card from among them, then you put the rest into your hand. That opponent may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "f2772c04-3e2a-5262-8e62-1954e2767d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112eb5ce-4fe5-45b3-b810-79fef74b07f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112eb5ce-4fe5-45b3-b810-79fef74b07f9.jpg?1",
             "name": "Ashiok, Nightmare Muse",
             "text": "+1: Create a 2/3 blue and black Nightmare creature token with \"Whenever this creature attacks or blocks, each opponent exiles the top two cards of their library.\"\n\u22123: Return target nonland permanent to its owner's hand, then that player exiles a card from their hand.\n\u22127: You may cast up to three face-up cards your opponents own from exile without paying their mana costs.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "dfdef194-7a62-5626-8924-40a25c155755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c91ec-df14-460f-967c-f182562fe7d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db6c91ec-df14-460f-967c-f182562fe7d8.jpg?1",
             "name": "Atris, Oracle of Half-Truths",
             "text": "Menace\nWhen Atris, Oracle of Half-Truths enters the battlefield, target opponent looks at the top three cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard.",
             "colours": [
@@ -7243,7 +7243,7 @@
         },
         {
             "id": "8d3c89fb-3851-54c8-bdf0-13d97b8fab24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdafadb-fa04-4282-b576-b85e79c242c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdafadb-fa04-4282-b576-b85e79c242c9.jpg?1",
             "name": "Bronzehide Lion",
             "text": "{G}{W}: Bronzehide Lion gains indestructible until end of turn.\nWhen Bronzehide Lion dies, return it to the battlefield. It's an Aura enchantment with enchant creature you control and \"{G}{W}: Enchanted creature gains indestructible until end of turn,\" and it loses all other abilities.",
             "colours": [
@@ -7281,7 +7281,7 @@
         },
         {
             "id": "8411f0c8-7ca7-58b2-8f8f-8f4c721c56f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86458929-ea21-4de8-84d8-a07398ed3bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86458929-ea21-4de8-84d8-a07398ed3bc0.jpg?1",
             "name": "Calix, Destiny's Hand",
             "text": "+1: Look at the top four cards of your library. You may reveal an enchantment card from among them and put that card into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Exile target creature or enchantment you don't control until target enchantment you control leaves the battlefield.\n\u22127: Return all enchantment cards from your graveyard to the battlefield.",
             "colours": [
@@ -7321,7 +7321,7 @@
         },
         {
             "id": "f793d4f3-f6c9-5bc2-99c6-53a15f0cf5ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ea0ba2-3ccf-4313-ad1d-161272c48851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ea0ba2-3ccf-4313-ad1d-161272c48851.jpg?1",
             "name": "Dalakos, Crafter of Wonders",
             "text": "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.\nEquipped creatures you control have flying and haste.",
             "colours": [
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "e0ce9a72-3f2d-5f69-aeec-bf6b14a9da8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514a6206-c2e5-4a0f-8a20-7efd6628dd0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514a6206-c2e5-4a0f-8a20-7efd6628dd0a.jpg?1",
             "name": "Devourer of Memory",
             "text": "Whenever one or more cards are put into your graveyard from your library, Devourer of Memory gets +1/+1 until end of turn and can't be blocked this turn.\n{1}{U}{B}: Put the top card of your library into your graveyard.",
             "colours": [
@@ -7398,7 +7398,7 @@
         },
         {
             "id": "a42cd1f8-bee3-57cc-8b25-c9f4cd11afac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e97d8-92c7-43c4-bdaf-7b0a6ce7cb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d3e97d8-92c7-43c4-bdaf-7b0a6ce7cb5f.jpg?1",
             "name": "Dream Trawler",
             "text": "Flying, lifelink\nWhenever you draw a card, Dream Trawler gets +1/+0 until end of turn.\nWhenever Dream Trawler attacks, draw a card.\nDiscard a card: Dream Trawler gains hexproof until end of turn. Tap it.",
             "colours": [
@@ -7436,7 +7436,7 @@
         },
         {
             "id": "6ef2dc1f-3ca3-5fed-a53a-92aaca6728ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd116c0b-0404-42ba-978f-7044b1a03d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd116c0b-0404-42ba-978f-7044b1a03d90.jpg?1",
             "name": "Enigmatic Incarnation",
             "text": "At the beginning of your end step, you may sacrifice another enchantment. If you do, search your library for a creature card with converted mana cost equal to 1 plus the sacrificed enchantment's converted mana cost, put that card onto the battlefield, then shuffle your library.",
             "colours": [
@@ -7472,7 +7472,7 @@
         },
         {
             "id": "21fb030f-30e5-57ed-9680-b99f7279c540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2159949-3d21-448d-bc34-a3dbaf219476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2159949-3d21-448d-bc34-a3dbaf219476.jpg?1",
             "name": "Eutropia the Twice-Favored",
             "text": "Constellation \u2014 Whenever an enchantment enters the battlefield under your control, put a +1/+1 counter on target creature. That creature gains flying until end of turn.",
             "colours": [
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "23688b6d-341f-5fb6-84b2-e6979d78cac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0744f08e-a588-4efe-ad56-5e9ed91dda40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0744f08e-a588-4efe-ad56-5e9ed91dda40.jpg?1",
             "name": "Gallia of the Endless Dance",
             "text": "Haste\nOther Satyrs you control get +1/+1 and have haste.\nWhenever you attack with three or more creatures, you may discard a card at random. If you do, draw two cards.",
             "colours": [
@@ -7551,7 +7551,7 @@
         },
         {
             "id": "df3d4450-0921-5d5b-9cc7-1717bcb031db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe5cbef-0f4e-4d05-9a94-4739e09d7a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe5cbef-0f4e-4d05-9a94-4739e09d7a9c.jpg?1",
             "name": "Haktos the Unscarred",
             "text": "Haktos the Unscarred attacks each combat if able.\nAs Haktos enters the battlefield, choose 2, 3, or 4 at random.\nHaktos has protection from each converted mana cost other than the chosen number.",
             "colours": [
@@ -7592,7 +7592,7 @@
         },
         {
             "id": "7ce033f9-de61-5935-b6e9-cb6eed43da9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854e673-1816-4a76-b9db-bb399ac7489f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854e673-1816-4a76-b9db-bb399ac7489f.jpg?1",
             "name": "Hero of the Nyxborn",
             "text": "When Hero of the Nyxborn enters the battlefield, create a 1/1 white Human Soldier creature token.\nWhenever you cast a spell that targets Hero of the Nyxborn, creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -7630,7 +7630,7 @@
         },
         {
             "id": "bed702eb-e2ed-5989-9341-3b1198980180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c393c-3596-4bd9-a553-e0b03c2eb950.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c393c-3596-4bd9-a553-e0b03c2eb950.jpg?1",
             "name": "Klothys, God of Destiny",
             "text": "Indestructible\nAs long as your devotion to red and green is less than seven, Klothys isn't a creature.\nAt the beginning of your precombat main phase, exile target card from a graveyard. If it was a land card, add {R} or {G}. Otherwise, you gain 2 life and Klothys deals 2 damage to each opponent.",
             "colours": [
@@ -7671,7 +7671,7 @@
         },
         {
             "id": "bfeed138-46d7-5ff0-9717-962e331c22ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee0459b-9aac-4d2f-abe4-4d5fedde7eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cee0459b-9aac-4d2f-abe4-4d5fedde7eb8.jpg?1",
             "name": "Kroxa, Titan of Death's Hunger",
             "text": "When Kroxa enters the battlefield, sacrifice it unless it escaped.\nWhenever Kroxa enters the battlefield or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.\nEscape\u2014{B}{B}{R}{R}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "939cfd55-3be9-58f1-a807-c71b0b222914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc0d2c3-8060-4155-b10e-d641648a4e6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc0d2c3-8060-4155-b10e-d641648a4e6b.jpg?1",
             "name": "Kunoros, Hound of Athreos",
             "text": "Vigilance, menace, lifelink\nCreature cards in graveyards can't enter the battlefield.\nPlayers can't cast spells from graveyards.",
             "colours": [
@@ -7752,7 +7752,7 @@
         },
         {
             "id": "521298ff-5a0e-591f-8fe7-8f8b1cbdf8a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3df0e-4ee8-458b-adf5-56aca20493e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3df0e-4ee8-458b-adf5-56aca20493e9.jpg?1",
             "name": "Mischievous Chimera",
             "text": "Flying\nWhenever you cast your first spell during each opponent's turn, Mischievous Chimera deals 1 damage to each opponent. Scry 1.",
             "colours": [
@@ -7789,7 +7789,7 @@
         },
         {
             "id": "e5338395-ff6e-5959-b163-9c5842371ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87858278-632c-4d82-b3a3-adfc6f2f4fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87858278-632c-4d82-b3a3-adfc6f2f4fc6.jpg?1",
             "name": "Polukranos, Unchained",
             "text": "Polukranos enters the battlefield with six +1/+1 counters on it. It escapes with twelve +1/+1 counters on it instead.\nIf damage would be dealt to Polukranos while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from it.\n{1}{B}{G}: Polukranos fights another target creature.\nEscape\u2014{4}{B}{G}, Exile six other cards from your graveyard.",
             "colours": [
@@ -7830,7 +7830,7 @@
         },
         {
             "id": "84492fe4-ad28-5ae0-a399-a6e3b76c1695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6c11c8-64a1-46a4-979c-56a6d5b873d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6c11c8-64a1-46a4-979c-56a6d5b873d3.jpg?1",
             "name": "Rise to Glory",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to the battlefield.\n\u2022 Return target Aura card from your graveyard to the battlefield.",
             "colours": [
@@ -7864,7 +7864,7 @@
         },
         {
             "id": "b20c0aaf-5b35-5d82-8dad-0f0aa6e435eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1d890f-7ef8-47b9-9ec8-f3884a1d09db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1d890f-7ef8-47b9-9ec8-f3884a1d09db.jpg?1",
             "name": "Siona, Captain of the Pyleas",
             "text": "When Siona, Captain of the Pyleas enters the battlefield, look at the top seven cards of your library. You may reveal an Aura card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nWhenever an Aura you control becomes attached to a creature you control, create a 1/1 white Human Soldier creature token.",
             "colours": [
@@ -7903,7 +7903,7 @@
         },
         {
             "id": "0788871e-f510-5576-8925-8877208e1a5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b441c0-261e-4094-b694-5e11ea3c14ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2b441c0-261e-4094-b694-5e11ea3c14ab.jpg?1",
             "name": "Slaughter-Priest of Mogis",
             "text": "Whenever you sacrifice a permanent, Slaughter-Priest of Mogis gets +2/+0 until end of turn.\n{2}, Sacrifice another creature or an enchantment: Slaughter-Priest of Mogis gains first strike until end of turn.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "664be9a7-acf5-5d97-8ccb-c21dd49e2566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125b8be1-76b9-434e-a505-5099d950767c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125b8be1-76b9-434e-a505-5099d950767c.jpg?1",
             "name": "Staggering Insight",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has lifelink and \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -7976,7 +7976,7 @@
         },
         {
             "id": "0b70248d-ff8a-555b-b003-4146ebe4370a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6a71e-56cb-4d25-8f2b-7a4f1b60900d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0b6a71e-56cb-4d25-8f2b-7a4f1b60900d.jpg?1",
             "name": "Uro, Titan of Nature's Wrath",
             "text": "When Uro enters the battlefield, sacrifice it unless it escaped.\nWhenever Uro enters the battlefield or attacks, you gain 3 life and draw a card, then you may put a land card from your hand onto the battlefield.\nEscape\u2014{G}{G}{U}{U}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)",
             "colours": [
@@ -8017,7 +8017,7 @@
         },
         {
             "id": "6bcc75d3-c090-5dcb-b506-96a1bd08c84c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff48d55e-aa8b-4061-9c77-fd7e696fd7ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff48d55e-aa8b-4061-9c77-fd7e696fd7ba.jpg?1",
             "name": "Warden of the Chained",
             "text": "Trample\nWarden of the Chained can't attack unless you control another creature with power 4 or greater.",
             "colours": [
@@ -8054,7 +8054,7 @@
         },
         {
             "id": "e43442bd-067c-5c4c-b3b3-b07b61156658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2a587-443d-4626-a6f6-9a26838a42b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1f2a587-443d-4626-a6f6-9a26838a42b1.jpg?1",
             "name": "Altar of the Pantheon",
             "text": "Your devotion to each color and each combination of colors is increased by one.\n{T}: Add one mana of any color. If you control a God, a Demigod, or a legendary enchantment, you gain 1 life.",
             "colours": [],
@@ -8082,7 +8082,7 @@
         },
         {
             "id": "335f443a-5290-57c8-ac56-61aacba7caab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33162d-8d8f-4312-b31e-04ce86e3b914.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b33162d-8d8f-4312-b31e-04ce86e3b914.jpg?1",
             "name": "Bronze Sword",
             "text": "Equipped creature gets +2/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "6ed57dc7-e6c7-50cc-acd1-666055df6ad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064abee6-7394-4b75-946f-4ad9840034ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/064abee6-7394-4b75-946f-4ad9840034ac.jpg?1",
             "name": "Entrancing Lyre",
             "text": "You may choose not to untap Entrancing Lyre during your untap step.\n{X}, {T}: Tap target creature with power X or less. It doesn't untap during its controller's untap step for as long as Entrancing Lyre remains tapped.",
             "colours": [],
@@ -8140,7 +8140,7 @@
         },
         {
             "id": "7ed2faef-d768-518e-b5bb-4c7b189c0087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7624e84-93ce-4983-8624-ebc934cab67f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7624e84-93ce-4983-8624-ebc934cab67f.jpg?1",
             "name": "Mirror Shield",
             "text": "Equipped creature gets +0/+2 and has hexproof and \"Whenever a creature with deathtouch blocks or becomes blocked by this creature, destroy that creature.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "ad501554-c342-5e97-b139-790c879110a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd6353f-d119-40e6-895c-030a11a7a2fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd6353f-d119-40e6-895c-030a11a7a2fe.jpg?1",
             "name": "Nyx Lotus",
             "text": "Nyx Lotus enters the battlefield tapped.\n{T}: Choose a color. Add an amount of mana of that color equal to your devotion to that color. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)",
             "colours": [],
@@ -8202,7 +8202,7 @@
         },
         {
             "id": "22982d8a-5424-587a-a3c1-c98047c801f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939c6e19-4b27-4023-bb9c-ae440f91e21c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939c6e19-4b27-4023-bb9c-ae440f91e21c.jpg?1",
             "name": "Shadowspear",
             "text": "Equipped creature gets +1/+1 and has trample and lifelink.\n{1}: Permanents your opponents control lose hexproof and indestructible until end of turn.\nEquip {2}",
             "colours": [],
@@ -8236,7 +8236,7 @@
         },
         {
             "id": "f1d6ff7c-e756-5b78-be96-204de60b1ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "When Soul-Guide Lantern enters the battlefield, exile target card from a graveyard.\n{T}, Sacrifice Soul-Guide Lantern: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice Soul-Guide Lantern: Draw a card.",
             "colours": [],
@@ -8264,7 +8264,7 @@
         },
         {
             "id": "98cd5be0-aa66-5d24-b30d-de002205ac98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg?1",
             "name": "Thaumaturge's Familiar",
             "text": "Flying\nWhen Thaumaturge's Familiar enters the battlefield, scry 1.",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "6c7e6630-df83-51a1-a675-d51266aacdbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2fa92d-5521-421c-b3f8-7c14bbef3080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2fa92d-5521-421c-b3f8-7c14bbef3080.jpg?1",
             "name": "Thundering Chariot",
             "text": "First strike, trample, haste\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "d5de0e91-931e-527b-a20a-846e0d5cc290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590926db-279c-494a-b92d-680b8abf9699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590926db-279c-494a-b92d-680b8abf9699.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "e3e4ebc2-dcb5-5677-82fd-3a15dfbd0b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ef8f96-3e3c-4b1b-8180-3b38c7deaaff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3ef8f96-3e3c-4b1b-8180-3b38c7deaaff.jpg?1",
             "name": "Wings of Hubris",
             "text": "Equipped creature has flying.\nSacrifice Wings of Hubris: Equipped creature can't be blocked this turn. Sacrifice it at the beginning of the next end step.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8383,7 +8383,7 @@
         },
         {
             "id": "5cfed6ed-f19a-5943-a441-75b0ffce0302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84e179-9d59-4d08-8a36-51ad2fc32ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84e179-9d59-4d08-8a36-51ad2fc32ae3.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles their library.",
             "colours": [],
@@ -8411,7 +8411,7 @@
         },
         {
             "id": "216271f1-8703-5e29-81ff-f67350ee3753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0dd221-2660-43f6-8e28-8000e3fe72a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0dd221-2660-43f6-8e28-8000e3fe72a4.jpg?1",
             "name": "Labyrinth of Skophos",
             "text": "{T}: Add {C}.\n{4}, {T}: Remove target attacking or blocking creature from combat.",
             "colours": [],
@@ -8441,7 +8441,7 @@
         },
         {
             "id": "cc39002d-4973-5a0c-bec3-9e40357e2554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5f8481-47f7-4531-9dad-686cdfb5d2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d5f8481-47f7-4531-9dad-686cdfb5d2ad.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1.\n{T}: Add {R} or {G}.",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "1223134d-1168-51b6-b274-61f532c1e606",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4fd29-dab5-481f-94c9-eeb70f3c29dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d4fd29-dab5-481f-94c9-eeb70f3c29dd.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1.\n{T}: Add {U} or {B}.",
             "colours": [],
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "2aa51f70-e23d-5355-8acb-e1025992aa42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adad8390-66d8-4022-a059-c68e44e718fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adad8390-66d8-4022-a059-c68e44e718fe.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "Temple of Enlightenment enters the battlefield tapped.\nWhen Temple of Enlightenment enters the battlefield, scry 1.\n{T}: Add {W} or {U}.",
             "colours": [],
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "6a9d0209-b78e-56f5-a451-541712ddf1e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9490a495-9f17-45a8-b10c-7de4fcbd2778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9490a495-9f17-45a8-b10c-7de4fcbd2778.jpg?1",
             "name": "Temple of Malice",
             "text": "Temple of Malice enters the battlefield tapped.\nWhen Temple of Malice enters the battlefield, scry 1.\n{T}: Add {B} or {R}.",
             "colours": [],
@@ -8574,7 +8574,7 @@
         },
         {
             "id": "61c04daf-db4f-5dcf-aaf4-44ae08f20a0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6256ea-ccb5-4595-8278-44266f922e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e6256ea-ccb5-4595-8278-44266f922e31.jpg?1",
             "name": "Temple of Plenty",
             "text": "Temple of Plenty enters the battlefield tapped.\nWhen Temple of Plenty enters the battlefield, scry 1.\n{T}: Add {G} or {W}.",
             "colours": [],
@@ -8607,7 +8607,7 @@
         },
         {
             "id": "00f6a8fe-62d8-5996-9ad6-e4e0577a3ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492181e4-5825-45d4-b8a1-37f29c32a845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492181e4-5825-45d4-b8a1-37f29c32a845.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "bb363f5e-b338-5d50-b31c-461faeeb9774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9891b7b-fc52-470c-9f74-292ae665f378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9891b7b-fc52-470c-9f74-292ae665f378.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "ed23bfd4-0cb8-5015-a96a-8a3870eb276d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7b664-3e75-4018-81f6-2a14ab59f258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf7b664-3e75-4018-81f6-2a14ab59f258.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8709,7 +8709,7 @@
         },
         {
             "id": "7661719d-f392-5ff9-94d6-ae1783c0522f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cb5cfd-018e-4c5e-bef1-166262aa5f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02cb5cfd-018e-4c5e-bef1-166262aa5f1d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8746,7 +8746,7 @@
         },
         {
             "id": "67bc64a0-fef7-5bf6-9709-949e961c48d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fb7b99-9e47-46a6-9c8a-88e28b5197f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53fb7b99-9e47-46a6-9c8a-88e28b5197f1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8783,7 +8783,7 @@
         },
         {
             "id": "c39b4bb8-fe17-55fc-bdee-651c74bc2f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af9f41-89e2-4e7a-9fec-fffe79cae077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32af9f41-89e2-4e7a-9fec-fffe79cae077.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8820,7 +8820,7 @@
         },
         {
             "id": "73dd9a92-8dc7-5b19-b2ea-616c3ee2d4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedff53b-b5c7-470e-bb66-797d5d20b983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fedff53b-b5c7-470e-bb66-797d5d20b983.jpg?1",
             "name": "Elspeth, Sun's Nemesis",
             "text": "",
             "colours": [
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "4aee7d96-11f6-5bf1-87df-7ea0b7f807a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18d2a4a-cfde-434e-85eb-f9aae0da9dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18d2a4a-cfde-434e-85eb-f9aae0da9dce.jpg?1",
             "name": "Ashiok, Nightmare Muse",
             "text": "",
             "colours": [
@@ -8898,7 +8898,7 @@
         },
         {
             "id": "ac3a03fb-f346-59cf-b196-743a112efc5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11529e37-0558-4ba9-ad04-3ddda05d25f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11529e37-0558-4ba9-ad04-3ddda05d25f5.jpg?1",
             "name": "Calix, Destiny's Hand",
             "text": "",
             "colours": [
@@ -8938,7 +8938,7 @@
         },
         {
             "id": "e499ebe7-6154-5180-9818-4b2336358979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5770e8a-045d-42bc-b6aa-17b89488c9d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5770e8a-045d-42bc-b6aa-17b89488c9d4.jpg?1",
             "name": "Daxos, Blessed by the Sun",
             "text": "",
             "colours": [
@@ -8977,7 +8977,7 @@
         },
         {
             "id": "a8aabe56-13b2-584f-8def-28617d525c8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11cf760-da35-41f2-8cf5-a5141103eeb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11cf760-da35-41f2-8cf5-a5141103eeb3.jpg?1",
             "name": "Heliod, Sun-Crowned",
             "text": "",
             "colours": [
@@ -9016,7 +9016,7 @@
         },
         {
             "id": "fcf571c1-2b6e-5245-96fb-4ceec471a1c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69641e64-d4f5-4654-8da8-9eb9a71e51c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69641e64-d4f5-4654-8da8-9eb9a71e51c8.jpg?1",
             "name": "Callaphe, Beloved of the Sea",
             "text": "",
             "colours": [
@@ -9055,7 +9055,7 @@
         },
         {
             "id": "c485d8a2-6cdb-5dca-8708-b0631abcbf89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b52628-de05-4ec1-9978-e998cf17bb26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27b52628-de05-4ec1-9978-e998cf17bb26.jpg?1",
             "name": "Thassa, Deep-Dwelling",
             "text": "",
             "colours": [
@@ -9094,7 +9094,7 @@
         },
         {
             "id": "f57a58d7-d4b4-5c54-86a3-2a5c79c5fc90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3c60d-2fcb-476f-bcc6-eec5879b08ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f3c60d-2fcb-476f-bcc6-eec5879b08ee.jpg?1",
             "name": "Erebos, Bleak-Hearted",
             "text": "",
             "colours": [
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "ac8a60bc-93ca-5413-96ee-5475c7746f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bcb02d3-dcf4-41a6-8b9a-f8ad477faea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bcb02d3-dcf4-41a6-8b9a-f8ad477faea0.jpg?1",
             "name": "Tymaret, Chosen from Death",
             "text": "",
             "colours": [
@@ -9172,7 +9172,7 @@
         },
         {
             "id": "5f89b684-6c2a-540d-977e-1dfae9df4b55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badac9b4-bfaf-4b02-a48a-ec141393566c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/badac9b4-bfaf-4b02-a48a-ec141393566c.jpg?1",
             "name": "Anax, Hardened in the Forge",
             "text": "",
             "colours": [
@@ -9211,7 +9211,7 @@
         },
         {
             "id": "c61d4134-9b72-5443-9fbb-57bd00b2f6ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176596fd-fc6d-46ae-a64d-d9147430fe0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176596fd-fc6d-46ae-a64d-d9147430fe0f.jpg?1",
             "name": "Purphoros, Bronze-Blooded",
             "text": "",
             "colours": [
@@ -9250,7 +9250,7 @@
         },
         {
             "id": "4c21956a-fa3c-5101-9cde-8d8af8ede238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a022e36-5074-4875-ac30-aaa09b7ef421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a022e36-5074-4875-ac30-aaa09b7ef421.jpg?1",
             "name": "Nylea, Keen-Eyed",
             "text": "",
             "colours": [
@@ -9289,7 +9289,7 @@
         },
         {
             "id": "cb0847b3-ef9b-560c-9cbd-37e91acfd86d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ce113d-6757-45ac-8517-5fd531079ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97ce113d-6757-45ac-8517-5fd531079ff9.jpg?1",
             "name": "Renata, Called to the Hunt",
             "text": "",
             "colours": [
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "2d343b2e-9dd7-5125-8768-7fb2dd194c10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d747889-04db-4e7a-ad4c-7549514b5112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d747889-04db-4e7a-ad4c-7549514b5112.jpg?1",
             "name": "Klothys, God of Destiny",
             "text": "",
             "colours": [
@@ -9369,7 +9369,7 @@
         },
         {
             "id": "5636e28c-6778-5aa9-bf4d-05d545c6edc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c19fc-7d99-4022-9e13-d679a9e3547e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/871c19fc-7d99-4022-9e13-d679a9e3547e.jpg?1",
             "name": "Athreos, Shroud-Veiled",
             "text": "Indestructible\nAs long as your devotion to white and black is less than seven, Athreos isn't a creature.\nAt the beginning of your end step, put a coin counter on another target creature.\nWhenever a creature with a coin counter on it dies or is put into exile, return that card to the battlefield under your control.",
             "colours": [
@@ -9408,7 +9408,7 @@
         },
         {
             "id": "ac8fc242-0d73-591f-8abf-5fde183f5dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9867e5-9d69-400c-a84f-3b085a4fd510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf9867e5-9d69-400c-a84f-3b085a4fd510.jpg?1",
             "name": "Elspeth, Undaunted Hero",
             "text": "+2: Put a +1/+1 counter on each of up to two target creatures.\n\u22122: Search your library and/or graveyard for a card named Sunlit Hoplite and put it onto the battlefield. If you search your library this way, shuffle it.\n\u22128: Until end of turn, creatures you control gain flying and get +X/+X, where X is your devotion to white.",
             "colours": [
@@ -9444,7 +9444,7 @@
         },
         {
             "id": "1a727ecd-8325-5f6e-80dd-809889a42ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53343a0c-d97c-4d6f-b696-5343a962e3dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53343a0c-d97c-4d6f-b696-5343a962e3dd.jpg?1",
             "name": "Eidolon of Inspiration",
             "text": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.",
             "colours": [
@@ -9478,7 +9478,7 @@
         },
         {
             "id": "193c4fcf-e45b-52b3-abf6-4010ea54299f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f82064c-b335-454c-9be6-9fbcb21aa8e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f82064c-b335-454c-9be6-9fbcb21aa8e5.jpg?1",
             "name": "Elspeth's Devotee",
             "text": "When Elspeth's Devotee enters the battlefield, you may search your library and/or graveyard for a card named Elspeth, Undaunted Hero, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9512,7 +9512,7 @@
         },
         {
             "id": "f3a45f6c-f419-5ab7-b4c7-b2e725697208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89cf0f-f682-44f8-879c-ed1e22f849b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89cf0f-f682-44f8-879c-ed1e22f849b0.jpg?1",
             "name": "Sunlit Hoplite",
             "text": "As long as it's your turn, Sunlit Hoplite has first strike.\nSunlit Hoplite gets +1/+0 as long as you control an Elspeth planeswalker.",
             "colours": [
@@ -9546,7 +9546,7 @@
         },
         {
             "id": "3d93625b-fd10-5a2f-bfad-d5ec5d9a0d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a5fc37-e7bd-41a9-88ac-74a3f14fea8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36a5fc37-e7bd-41a9-88ac-74a3f14fea8b.jpg?1",
             "name": "Ashiok, Sculptor of Fears",
             "text": "+2: Draw a card. Each player puts the top two cards of their library into their graveyard.\n\u22125: Put target creature card from a graveyard onto the battlefield under your control.\n\u221211: Gain control of all creatures target opponent controls.",
             "colours": [
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "602c3bd3-d383-5903-8ffe-c62698a1818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc6b5ee-e764-444e-8b27-26e00f4b2074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc6b5ee-e764-444e-8b27-26e00f4b2074.jpg?1",
             "name": "Swimmer in Nightmares",
             "text": "Swimmer in Nightmares gets +3/+0 as long as there are ten or more cards in a single graveyard.\nSwimmer in Nightmares can't be blocked as long as you control an Ashiok planeswalker.",
             "colours": [
@@ -9618,7 +9618,7 @@
         },
         {
             "id": "921db3e2-3d8a-561d-8fff-4027b2158900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5ce79a-fcbd-46ab-8911-480f967ca57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c5ce79a-fcbd-46ab-8911-480f967ca57f.jpg?1",
             "name": "Mindwrack Harpy",
             "text": "Flying\nAt the beginning of combat on your turn, each player puts the top three cards of their library into their graveyard.",
             "colours": [
@@ -9652,7 +9652,7 @@
         },
         {
             "id": "0679efa4-1580-5e44-ad22-785ae74fad8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781bfbae-acd9-4583-88d2-d31978eef565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/781bfbae-acd9-4583-88d2-d31978eef565.jpg?1",
             "name": "Ashiok's Forerunner",
             "text": "Flash\nWhen Ashiok's Forerunner enters the battlefield, you may search your library and/or graveyard for a card named Ashiok, Sculptor of Fears, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "7c416def-b8db-5457-a430-6d006596af8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40aca5ca-a37b-4919-aef6-2510b4779161.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40aca5ca-a37b-4919-aef6-2510b4779161.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9725,7 +9725,7 @@
         },
         {
             "id": "c4ee840e-2c11-5312-adbe-d9313fa965bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db68b6a3-10e5-42d1-9325-94a4a821782a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db68b6a3-10e5-42d1-9325-94a4a821782a.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9762,7 +9762,7 @@
         },
         {
             "id": "9a8020da-28ae-5cf2-a7c2-c4db716957fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92daaa39-cd2f-4c03-8f41-92d99d0a3366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92daaa39-cd2f-4c03-8f41-92d99d0a3366.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "5a181c25-6347-54ed-b378-b90d66e9f438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c12c2-2ebf-470b-b0d2-92ccc5faa056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b82c12c2-2ebf-470b-b0d2-92ccc5faa056.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9836,7 +9836,7 @@
         },
         {
             "id": "3661c754-96b2-5cf2-bb6f-128993c98aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66bb5192-58bc-4efe-a145-2e804fd3483d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66bb5192-58bc-4efe-a145-2e804fd3483d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9873,7 +9873,7 @@
         },
         {
             "id": "942cf74e-7ac1-5f62-ba69-26c18366f6db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54a44f2-70bf-4782-bd13-9d03e109d60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e54a44f2-70bf-4782-bd13-9d03e109d60d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9910,7 +9910,7 @@
         },
         {
             "id": "4ee811f0-c35f-5ddc-ab95-5f7a20362fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3f4154-9347-4ceb-8744-9f1ace90d33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc3f4154-9347-4ceb-8744-9f1ace90d33f.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9947,7 +9947,7 @@
         },
         {
             "id": "b0e27953-1173-5cde-9763-aadc57414efb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d759b-db5b-4a59-840c-05bcbf2381f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d10d759b-db5b-4a59-840c-05bcbf2381f3.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9984,7 +9984,7 @@
         },
         {
             "id": "61b496d7-8dfa-589d-ace9-8b44465eba1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4be31c4-9cb3-4a07-865b-5621127df660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4be31c4-9cb3-4a07-865b-5621127df660.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "dfb58178-c3a8-5059-87a8-d8a44596b351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af0c659-f182-4ad4-bca7-e6c3377f808d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6af0c659-f182-4ad4-bca7-e6c3377f808d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10058,7 +10058,7 @@
         },
         {
             "id": "9ae2c11b-e156-5501-876e-883f77f042e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238aa9c-661e-449a-8f05-70b7954e544f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a238aa9c-661e-449a-8f05-70b7954e544f.jpg?1",
             "name": "Grasping Giant",
             "text": "Vigilance\nWhenever Grasping Giant becomes blocked by a creature, exile that creature until Grasping Giant leaves the battlefield.",
             "colours": [
@@ -10091,7 +10091,7 @@
         },
         {
             "id": "243d868a-78a2-5191-9b9e-7c9f22782eb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7fa9e2-4c16-4e94-9b0e-09657303132c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e7fa9e2-4c16-4e94-9b0e-09657303132c.jpg?1",
             "name": "Victory's Envoy",
             "text": "At the beginning of your upkeep, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -10125,7 +10125,7 @@
         },
         {
             "id": "960a9267-9aae-591b-b81b-53a6c9bf4e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg?1",
             "name": "Sphinx Mindbreaker",
             "text": "Flying\nWhen Sphinx Mindbreaker enters the battlefield, each opponent puts the top ten cards of their library into their graveyard.",
             "colours": [
@@ -10158,7 +10158,7 @@
         },
         {
             "id": "caf035a9-1060-548c-8e97-656498df3e96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac18ae-0d1e-43f5-9cc9-722fa6e36fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ac18ae-0d1e-43f5-9cc9-722fa6e36fe5.jpg?1",
             "name": "Serpent of Yawning Depths",
             "text": "Krakens, Leviathans, Octopuses, and Serpents you control can't be blocked except by Krakens, Leviathans, Octopuses, and Serpents.",
             "colours": [
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "3365d3cb-d481-5d77-aa47-910cc85392ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57564f6f-7c99-4325-8a0e-22342e73767b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57564f6f-7c99-4325-8a0e-22342e73767b.jpg?1",
             "name": "Demon of Loathing",
             "text": "Flying, trample\nWhenever Demon of Loathing deals combat damage to a player, that player sacrifices a creature.",
             "colours": [
@@ -10226,7 +10226,7 @@
         },
         {
             "id": "da8244ce-fde3-5398-9639-4fa7648ae15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c7aa89-3777-49ec-a6d0-c568150864e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8c7aa89-3777-49ec-a6d0-c568150864e8.jpg?1",
             "name": "Underworld Sentinel",
             "text": "Whenever Underworld Sentinel attacks, exile target creature card from your graveyard.\nWhen Underworld Sentinel dies, put all cards exiled with it onto the battlefield.",
             "colours": [
@@ -10260,7 +10260,7 @@
         },
         {
             "id": "6a34e617-33bc-516f-8f25-d4a1601faf7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f58ac-88ef-445c-a12b-0bb1cf482298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf0f58ac-88ef-445c-a12b-0bb1cf482298.jpg?1",
             "name": "Deathbellow War Cry",
             "text": "Search your library for up to four Minotaur creature cards with different names, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "a492a455-24ff-5949-9611-484bc472120f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332dc6c3-7802-4bde-aa4e-0feab70c216f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332dc6c3-7802-4bde-aa4e-0feab70c216f.jpg?1",
             "name": "Terror of Mount Velus",
             "text": "Flying, double strike\nWhen Terror of Mount Velus enters the battlefield, creatures you control gain double strike until end of turn.",
             "colours": [
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "9b1aa4e0-b0fe-54ba-b87b-aa398f731618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0215cbbf-7bac-4ff7-bceb-23d728797848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0215cbbf-7bac-4ff7-bceb-23d728797848.jpg?1",
             "name": "Ironscale Hydra",
             "text": "If a creature would deal combat damage to Ironscale Hydra, prevent that damage and put a +1/+1 counter on Ironscale Hydra.",
             "colours": [
@@ -10358,7 +10358,7 @@
         },
         {
             "id": "ac362d48-c5ca-5090-95ba-19609a39edbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456627ec-81a4-40db-91dc-d25a59cd2837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456627ec-81a4-40db-91dc-d25a59cd2837.jpg?1",
             "name": "Treeshaker Chimera",
             "text": "All creatures able to block Treeshaker Chimera do so.\nWhen Treeshaker Chimera dies, draw three cards.",
             "colours": [
@@ -10391,7 +10391,7 @@
         },
         {
             "id": "3c078eb4-d1b3-5ba3-ae8d-7738e1c169c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146a721-8655-496c-97c0-d6691fa2043e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e146a721-8655-496c-97c0-d6691fa2043e.jpg?1",
             "name": "Archon of Sun's Grace",
             "text": "",
             "colours": [
@@ -10427,7 +10427,7 @@
         },
         {
             "id": "15351096-6b95-5a8c-bbb2-80bfdf7d5a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02694fb6-7695-4296-b5d6-cfe60829f1e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02694fb6-7695-4296-b5d6-cfe60829f1e7.jpg?1",
             "name": "Eidolon of Obstruction",
             "text": "",
             "colours": [
@@ -10464,7 +10464,7 @@
         },
         {
             "id": "39b197ca-526c-5aa4-be3c-97b5db042efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0674c3-4e6c-4dbb-a4b0-a5607fcfc3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0674c3-4e6c-4dbb-a4b0-a5607fcfc3f1.jpg?1",
             "name": "Heliod's Intervention",
             "text": "",
             "colours": [
@@ -10498,7 +10498,7 @@
         },
         {
             "id": "2dea177d-9732-5f09-9692-9bcc4cb8bcff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef062a2-8664-49fd-92d6-413fcf2b9dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef062a2-8664-49fd-92d6-413fcf2b9dae.jpg?1",
             "name": "Idyllic Tutor",
             "text": "",
             "colours": [
@@ -10532,7 +10532,7 @@
         },
         {
             "id": "2e6314a8-82ce-51ed-90d6-5021469792fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ca9f3-f8d4-4fd3-b6dd-1a1d56ffd97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ca9f3-f8d4-4fd3-b6dd-1a1d56ffd97c.jpg?1",
             "name": "Shatter the Sky",
             "text": "",
             "colours": [
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "ae356bcb-1055-5937-9caa-1d9e8e41bb08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef670df9-0dda-4542-b1c1-3e8963e5f5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef670df9-0dda-4542-b1c1-3e8963e5f5a8.jpg?1",
             "name": "Taranika, Akroan Veteran",
             "text": "",
             "colours": [
@@ -10605,7 +10605,7 @@
         },
         {
             "id": "2a5f7b56-fec9-5d44-bd8d-57c12508ab45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a0d2ba-c75b-4f40-a03b-914a10c35939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a0d2ba-c75b-4f40-a03b-914a10c35939.jpg?1",
             "name": "Ashiok's Erasure",
             "text": "",
             "colours": [
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "58d145c7-a271-5538-8286-9e1c8dc0e655",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5d004-78bd-4564-9f4a-fcf463f3a76a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5d004-78bd-4564-9f4a-fcf463f3a76a.jpg?1",
             "name": "Nadir Kraken",
             "text": "",
             "colours": [
@@ -10675,7 +10675,7 @@
         },
         {
             "id": "0c4cb366-deb6-5836-a7a5-7364fa528c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8206247e-43e6-4936-9ef5-42b174ff57c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8206247e-43e6-4936-9ef5-42b174ff57c9.jpg?1",
             "name": "Protean Thaumaturge",
             "text": "",
             "colours": [
@@ -10712,7 +10712,7 @@
         },
         {
             "id": "5ce03192-3e6f-5ccb-bc34-2880944e1c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8688bfcb-4d31-423f-bee3-de8f6ca2f99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8688bfcb-4d31-423f-bee3-de8f6ca2f99d.jpg?1",
             "name": "Thassa's Intervention",
             "text": "",
             "colours": [
@@ -10746,7 +10746,7 @@
         },
         {
             "id": "ff53f78e-abe3-5732-8531-965288544d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d7e352-4d01-4947-a76f-f8a01dd876cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d7e352-4d01-4947-a76f-f8a01dd876cc.jpg?1",
             "name": "Thassa's Oracle",
             "text": "",
             "colours": [
@@ -10783,7 +10783,7 @@
         },
         {
             "id": "0ae02851-33db-557e-acc8-3e35c94bf2c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044489e-84e0-453e-9248-a200d27ad17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3044489e-84e0-453e-9248-a200d27ad17c.jpg?1",
             "name": "Thryx, the Sudden Storm",
             "text": "",
             "colours": [
@@ -10822,7 +10822,7 @@
         },
         {
             "id": "1d413cd8-9807-5f4a-95f8-7ebb73d12ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543356bc-d4ab-4250-80c8-5ca69c11af87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/543356bc-d4ab-4250-80c8-5ca69c11af87.jpg?1",
             "name": "Wavebreak Hippocamp",
             "text": "",
             "colours": [
@@ -10860,7 +10860,7 @@
         },
         {
             "id": "86284b38-b719-5be7-b9e0-59603c5f671b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f0dd24-d28c-4f94-8131-3061a1b92e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f0dd24-d28c-4f94-8131-3061a1b92e93.jpg?1",
             "name": "Aphemia, the Cacophony",
             "text": "",
             "colours": [
@@ -10899,7 +10899,7 @@
         },
         {
             "id": "83688735-7a63-57f4-977e-9a7d3bb54209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c06877-a78b-470d-82ab-9d93d5c5e189.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c06877-a78b-470d-82ab-9d93d5c5e189.jpg?1",
             "name": "Eat to Extinction",
             "text": "",
             "colours": [
@@ -10933,7 +10933,7 @@
         },
         {
             "id": "01901d2d-02f4-5a9e-9ceb-8ac94ed2ad28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e0691a-7a97-497c-9b57-6a8afa156d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5e0691a-7a97-497c-9b57-6a8afa156d87.jpg?1",
             "name": "Erebos's Intervention",
             "text": "",
             "colours": [
@@ -10967,7 +10967,7 @@
         },
         {
             "id": "adcd2b41-f1f6-5b56-bfd1-8e1c69571d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f75fdb-1559-4f4e-b14b-0dfb7305f55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f75fdb-1559-4f4e-b14b-0dfb7305f55b.jpg?1",
             "name": "Gravebreaker Lamia",
             "text": "",
             "colours": [
@@ -11005,7 +11005,7 @@
         },
         {
             "id": "cb6f0119-f9af-5ef5-8c49-be2bfb896d02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210d25be-7766-4994-9ae5-dce945449d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/210d25be-7766-4994-9ae5-dce945449d98.jpg?1",
             "name": "Nightmare Shepherd",
             "text": "",
             "colours": [
@@ -11042,7 +11042,7 @@
         },
         {
             "id": "31662ed1-823c-5532-bd11-09ad3e9aea12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cde9bcb-1c60-4f3f-af07-7db3f8baf1cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cde9bcb-1c60-4f3f-af07-7db3f8baf1cc.jpg?1",
             "name": "Treacherous Blessing",
             "text": "",
             "colours": [
@@ -11076,7 +11076,7 @@
         },
         {
             "id": "7a0ea79c-acbc-54fb-a424-9b1ff11ef8ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05500b14-d36d-49b3-82b0-d0c533d4ec00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05500b14-d36d-49b3-82b0-d0c533d4ec00.jpg?1",
             "name": "Woe Strider",
             "text": "",
             "colours": [
@@ -11112,7 +11112,7 @@
         },
         {
             "id": "3c805777-8278-5cd4-9546-f4820e6207a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38beac66-fab1-4999-b43c-524e3225d70c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38beac66-fab1-4999-b43c-524e3225d70c.jpg?1",
             "name": "Ox of Agonas",
             "text": "",
             "colours": [
@@ -11148,7 +11148,7 @@
         },
         {
             "id": "4a975221-2258-5d81-995b-ce72794b200d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2be6f0-1cc1-4153-bdcf-528d49a474f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2be6f0-1cc1-4153-bdcf-528d49a474f4.jpg?1",
             "name": "Phoenix of Ash",
             "text": "",
             "colours": [
@@ -11184,7 +11184,7 @@
         },
         {
             "id": "ad5bfbd7-f044-5d1e-98e2-bdf35034db46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b23ba3-0b20-492d-a529-c6e4aeafd5aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b23ba3-0b20-492d-a529-c6e4aeafd5aa.jpg?1",
             "name": "Purphoros's Intervention",
             "text": "",
             "colours": [
@@ -11218,7 +11218,7 @@
         },
         {
             "id": "8dde3391-41f8-5d17-9ce6-542f05ac6cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d50d7-6b7c-4109-8f47-443bce9c4451.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d50d7-6b7c-4109-8f47-443bce9c4451.jpg?1",
             "name": "Storm Herald",
             "text": "",
             "colours": [
@@ -11255,7 +11255,7 @@
         },
         {
             "id": "225eec1e-5b98-5061-aab9-1209e70db3f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f774b26-7b8b-4d06-bec8-764429445e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f774b26-7b8b-4d06-bec8-764429445e93.jpg?1",
             "name": "Storm's Wrath",
             "text": "",
             "colours": [
@@ -11289,7 +11289,7 @@
         },
         {
             "id": "94891233-11c3-5e13-8aa7-8777872bfb11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a270521e-5db7-480b-9320-abd64c589f3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a270521e-5db7-480b-9320-abd64c589f3d.jpg?1",
             "name": "Tectonic Giant",
             "text": "",
             "colours": [
@@ -11326,7 +11326,7 @@
         },
         {
             "id": "1f438093-8e90-5ded-bca1-34686856abc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e1bdc9-be60-4abd-9756-d3e70e2fcdb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e1bdc9-be60-4abd-9756-d3e70e2fcdb5.jpg?1",
             "name": "Underworld Breach",
             "text": "",
             "colours": [
@@ -11360,7 +11360,7 @@
         },
         {
             "id": "4cf8f4d5-8213-5e7a-a129-8b0b1aaeb83f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9304c-9993-4539-9165-48568eb81db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b9304c-9993-4539-9165-48568eb81db1.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "",
             "colours": [
@@ -11400,7 +11400,7 @@
         },
         {
             "id": "2669e8f7-745b-5dc5-8d13-514c49ed38b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36adefc7-44a8-40d0-8bdf-ad12d010b0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36adefc7-44a8-40d0-8bdf-ad12d010b0bd.jpg?1",
             "name": "Dryad of the Ilysian Grove",
             "text": "",
             "colours": [
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "d72b27b7-673c-5c5f-b243-62a18770135d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168614ac-0126-47f6-a491-5a57490c74a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168614ac-0126-47f6-a491-5a57490c74a7.jpg?1",
             "name": "Mantle of the Wolf",
             "text": "",
             "colours": [
@@ -11474,7 +11474,7 @@
         },
         {
             "id": "54f1337b-39e6-56e6-91c6-6a321b481c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12df807-f100-4a22-b75c-ae7f69431b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12df807-f100-4a22-b75c-ae7f69431b61.jpg?1",
             "name": "Nessian Boar",
             "text": "",
             "colours": [
@@ -11510,7 +11510,7 @@
         },
         {
             "id": "50f49a76-df0d-526a-8c3d-79797da159b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cadcc3a-653d-48f3-8f0f-13c9bb502f37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cadcc3a-653d-48f3-8f0f-13c9bb502f37.jpg?1",
             "name": "Nylea's Intervention",
             "text": "",
             "colours": [
@@ -11544,7 +11544,7 @@
         },
         {
             "id": "2a0dc2c9-219a-52e1-8cdb-3066c5156b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a8e37b-0b97-4355-8e00-169a82c38ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8a8e37b-0b97-4355-8e00-169a82c38ea0.jpg?1",
             "name": "Nyxbloom Ancient",
             "text": "",
             "colours": [
@@ -11581,7 +11581,7 @@
         },
         {
             "id": "12592467-3670-5b05-8e6f-d15011403589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b2168d-38e5-429f-8663-f0d258c9c441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b2168d-38e5-429f-8663-f0d258c9c441.jpg?1",
             "name": "Setessan Champion",
             "text": "",
             "colours": [
@@ -11618,7 +11618,7 @@
         },
         {
             "id": "ebb27451-f88f-5b72-a411-8bc36daf754d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c543e785-2c6b-4347-a9c3-25940bbadcff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c543e785-2c6b-4347-a9c3-25940bbadcff.jpg?1",
             "name": "Allure of the Unknown",
             "text": "",
             "colours": [
@@ -11654,7 +11654,7 @@
         },
         {
             "id": "f074ae9e-0a30-5be9-a69c-587204fb969c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3085763-e65b-49cb-a4e0-2cbad2658a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3085763-e65b-49cb-a4e0-2cbad2658a1b.jpg?1",
             "name": "Atris, Oracle of Half-Truths",
             "text": "",
             "colours": [
@@ -11695,7 +11695,7 @@
         },
         {
             "id": "2b80549d-0c28-5f5c-b338-7260aefd916a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f4d9d-aa87-439c-8db5-3789cabcce4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c65f4d9d-aa87-439c-8db5-3789cabcce4c.jpg?1",
             "name": "Bronzehide Lion",
             "text": "",
             "colours": [
@@ -11733,7 +11733,7 @@
         },
         {
             "id": "a9d98dac-db30-5221-8f75-79fed98ef13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadfb33-7082-47b8-a498-f3bb963a8d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dadfb33-7082-47b8-a498-f3bb963a8d78.jpg?1",
             "name": "Dalakos, Crafter of Wonders",
             "text": "",
             "colours": [
@@ -11774,7 +11774,7 @@
         },
         {
             "id": "ba1b6923-64ed-5e1c-bc72-cfdcc0a166e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1072d6-afda-4282-8dff-06a76ceb447d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1072d6-afda-4282-8dff-06a76ceb447d.jpg?1",
             "name": "Dream Trawler",
             "text": "",
             "colours": [
@@ -11812,7 +11812,7 @@
         },
         {
             "id": "c473c93e-a932-5ca0-ab44-37c995b62aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1059102b-d094-47ea-b39c-8627a50f5bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1059102b-d094-47ea-b39c-8627a50f5bbf.jpg?1",
             "name": "Enigmatic Incarnation",
             "text": "",
             "colours": [
@@ -11848,7 +11848,7 @@
         },
         {
             "id": "ae652f27-5a37-58d9-91dd-787a67ea1761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f721cc84-8d76-4c57-b4ba-e384c67aeef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f721cc84-8d76-4c57-b4ba-e384c67aeef7.jpg?1",
             "name": "Gallia of the Endless Dance",
             "text": "",
             "colours": [
@@ -11888,7 +11888,7 @@
         },
         {
             "id": "8661c7c1-aaee-5d7b-9499-fdbef212852b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426919af-93d1-4825-ac38-98c0d6b5f62e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426919af-93d1-4825-ac38-98c0d6b5f62e.jpg?1",
             "name": "Haktos the Unscarred",
             "text": "",
             "colours": [
@@ -11929,7 +11929,7 @@
         },
         {
             "id": "b2184e08-fbf6-5a23-bea9-e454464f5117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050ff430-2ad8-46d0-bfdc-cc7323b87101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050ff430-2ad8-46d0-bfdc-cc7323b87101.jpg?1",
             "name": "Kroxa, Titan of Death's Hunger",
             "text": "",
             "colours": [
@@ -11970,7 +11970,7 @@
         },
         {
             "id": "c75f4ec0-4157-5a41-b926-132b84f4b5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee5698-1a40-434c-937b-9462825a752b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ee5698-1a40-434c-937b-9462825a752b.jpg?1",
             "name": "Kunoros, Hound of Athreos",
             "text": "",
             "colours": [
@@ -12010,7 +12010,7 @@
         },
         {
             "id": "31938571-ce74-5765-a9ec-5ec4d2a2e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2674-7882-46b5-9b99-3a13b434a2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2674-7882-46b5-9b99-3a13b434a2a2.jpg?1",
             "name": "Polukranos, Unchained",
             "text": "",
             "colours": [
@@ -12051,7 +12051,7 @@
         },
         {
             "id": "095ecbbf-7e08-5bc7-85f9-7d830b9141a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf6e4d1-1b4f-450c-a0fc-2d02313979ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf6e4d1-1b4f-450c-a0fc-2d02313979ca.jpg?1",
             "name": "Uro, Titan of Nature's Wrath",
             "text": "",
             "colours": [
@@ -12092,7 +12092,7 @@
         },
         {
             "id": "6765d376-9ca8-58aa-8581-9819a4f51a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e73185-afdf-4fae-82c3-b5ea355c1572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e73185-afdf-4fae-82c3-b5ea355c1572.jpg?1",
             "name": "Nyx Lotus",
             "text": "",
             "colours": [],
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "a82e3d86-2ffb-593d-88b5-16db79ce2025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131cb967-9569-4fbf-8143-c410d3a94538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131cb967-9569-4fbf-8143-c410d3a94538.jpg?1",
             "name": "Shadowspear",
             "text": "",
             "colours": [],
@@ -12158,7 +12158,7 @@
         },
         {
             "id": "886095ef-4a62-5321-8e5e-8410e9dbd084",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c49891-3972-4af8-a86a-f37320a280ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c49891-3972-4af8-a86a-f37320a280ae.jpg?1",
             "name": "Labyrinth of Skophos",
             "text": "",
             "colours": [],
@@ -12188,7 +12188,7 @@
         },
         {
             "id": "38fc8e52-821b-5701-a5bd-7402ee13a51c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4471a4-efcf-46a9-87df-62af9d616bd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4471a4-efcf-46a9-87df-62af9d616bd1.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -12221,7 +12221,7 @@
         },
         {
             "id": "a67c3cd2-d09d-5c2e-807b-5f4772c367e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b543f825-dc15-4267-8579-5d07c771dd95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b543f825-dc15-4267-8579-5d07c771dd95.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -12254,7 +12254,7 @@
         },
         {
             "id": "84eeea1a-8845-5665-b69f-50ed0505f750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c6be18-356e-4e8b-899c-4a82f5d41a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c6be18-356e-4e8b-899c-4a82f5d41a41.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -12287,7 +12287,7 @@
         },
         {
             "id": "c7ea1c94-3c16-5e9c-9743-27db61d02119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b705a44-b1b6-491b-aaab-53e0577fdde3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b705a44-b1b6-491b-aaab-53e0577fdde3.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -12320,7 +12320,7 @@
         },
         {
             "id": "d0cc0b4a-2586-5808-9cd2-6f59b0f74f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f80f4d-0858-46ff-9305-ee6e380eb521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f80f4d-0858-46ff-9305-ee6e380eb521.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -12353,7 +12353,7 @@
         },
         {
             "id": "36e6b862-67b5-5db5-aa59-3cc25879092b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc9a80-850c-4945-b84a-85381cc3ee85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61dc9a80-850c-4945-b84a-85381cc3ee85.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -12386,7 +12386,7 @@
         },
         {
             "id": "911c3ff3-8068-5580-bb92-049bb5a67deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5ea68-b77d-4fe0-a277-b20d55bc78a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55a5ea68-b77d-4fe0-a277-b20d55bc78a6.jpg?1",
             "name": "Arasta of the Endless Web",
             "text": "",
             "colours": [
@@ -12425,7 +12425,7 @@
         },
         {
             "id": "61ca0be6-5672-5d82-a9df-b10d15fc6be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad40aed-f247-41b3-8198-6367fdeee953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad40aed-f247-41b3-8198-6367fdeee953.jpg?1",
             "name": "Alseid of Life's Bounty",
             "text": "",
             "colours": [
@@ -12462,7 +12462,7 @@
         },
         {
             "id": "c030ff43-7e47-554c-8c1e-f749bb1920a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb95d4e0-02e6-4159-8cc0-c8da27edf2f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb95d4e0-02e6-4159-8cc0-c8da27edf2f9.jpg?1",
             "name": "Thirst for Meaning",
             "text": "",
             "colours": [
@@ -12496,7 +12496,7 @@
         },
         {
             "id": "1651644f-fc18-5464-9473-59b903ecd096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d794d0a4-4041-43c0-aedb-e2a76611a3ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d794d0a4-4041-43c0-aedb-e2a76611a3ea.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "",
             "colours": [
@@ -12532,7 +12532,7 @@
         },
         {
             "id": "aa3f32c1-74dd-5ab1-8518-92a283c3a86e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38a0c3-0e1d-487d-99c8-4504d327c64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a38a0c3-0e1d-487d-99c8-4504d327c64d.jpg?1",
             "name": "Thrill of Possibility",
             "text": "",
             "colours": [
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "f723ff72-acca-50a1-bd6c-00fc67f1176b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc4be7b-a948-464d-8327-575ccb7dccf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc4be7b-a948-464d-8327-575ccb7dccf3.jpg?1",
             "name": "Wolfwillow Haven",
             "text": "",
             "colours": [
@@ -12602,7 +12602,7 @@
         },
         {
             "id": "a6e497f6-6cdd-57f3-be8c-55c6efd96005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd5f96-5683-4959-b973-37f3c2fcf9bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd5f96-5683-4959-b973-37f3c2fcf9bf.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -12636,7 +12636,7 @@
         },
         {
             "id": "67cca079-4ef0-5c92-a8a4-495d84a5d5e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e76f0e3-9411-401d-ab38-9c3c64769483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e76f0e3-9411-401d-ab38-9c3c64769483.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -12671,7 +12671,7 @@
         },
         {
             "id": "ab6a49f3-7679-59c9-873b-d56dd6b6780a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1c2ee-d92e-409a-995a-b4c91620c918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dee1c2ee-d92e-409a-995a-b4c91620c918.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -12705,7 +12705,7 @@
         },
         {
             "id": "428dbbb9-3246-58f4-9c76-e07283c3ac55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3365aea-823d-44a9-94d3-ed2a31d85f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3365aea-823d-44a9-94d3-ed2a31d85f34.jpg?1",
             "name": "Kraken",
             "text": "",
             "colours": [
@@ -12739,7 +12739,7 @@
         },
         {
             "id": "9ecf9c47-d8b4-5708-b014-a650cd59f5bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c23b2-ac39-46b1-aa2b-7d6cbedba767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab1c23b2-ac39-46b1-aa2b-7d6cbedba767.jpg?1",
             "name": "Reflection",
             "text": "",
             "colours": [
@@ -12773,7 +12773,7 @@
         },
         {
             "id": "24c94ad6-fea2-5622-8c67-2f127fc68254",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9f04f7-587e-4774-8aaa-09e8520efacb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9f04f7-587e-4774-8aaa-09e8520efacb.jpg?1",
             "name": "Tentacle",
             "text": "",
             "colours": [
@@ -12807,7 +12807,7 @@
         },
         {
             "id": "bf36c4da-3480-500f-bada-b0ace2b290af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -12841,7 +12841,7 @@
         },
         {
             "id": "d2064065-01fd-54fb-89d7-a4bdd51f9ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60466c78-155e-442b-8022-795e1e9de8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60466c78-155e-442b-8022-795e1e9de8df.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -12875,7 +12875,7 @@
         },
         {
             "id": "8ce68783-b5c6-5d6e-a6fe-dcf41cf0ab45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903e30f3-580e-4a14-989b-ae0632363407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903e30f3-580e-4a14-989b-ae0632363407.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -12909,7 +12909,7 @@
         },
         {
             "id": "8eefbdfc-a8cd-561b-a4ce-0fc89dc39635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f28541-9711-42cd-9c83-993a81af96b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f28541-9711-42cd-9c83-993a81af96b6.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -12943,7 +12943,7 @@
         },
         {
             "id": "1bd8aa0a-9d1f-58c9-815a-7c6867b35285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411f4bf6-7f09-4e24-b483-0068d2f974e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/411f4bf6-7f09-4e24-b483-0068d2f974e5.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -12977,7 +12977,7 @@
         },
         {
             "id": "0413f5cd-b054-5f30-8e6c-dad8fe9071d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c528581f-f671-45ae-8d7a-ae26a4e62ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c528581f-f671-45ae-8d7a-ae26a4e62ceb.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -13013,7 +13013,7 @@
         },
         {
             "id": "ecdcdb66-d39d-5491-a127-238ff8ec1236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c315a76-9561-426e-b726-288424a5069b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c315a76-9561-426e-b726-288424a5069b.jpg?1",
             "name": "Gold",
             "text": "",
             "colours": [],
@@ -13043,7 +13043,7 @@
         },
         {
             "id": "d25ca38c-26d0-56d5-985c-2fcd0d3e3bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdd5d53-65e7-42c3-a325-791f11335e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdd5d53-65e7-42c3-a325-791f11335e62.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/THS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/THS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "230bc14b-04a1-5dff-90e1-41eafb73c745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d967a4c-2323-4361-a907-5ca9140d8793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d967a4c-2323-4361-a907-5ca9140d8793.jpg?1",
             "name": "Battlewise Valor",
             "text": "Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "b8442a94-14d3-5593-9876-9ed2cb9401f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecd213-2e03-40a8-9323-7b9e6e521a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55ecd213-2e03-40a8-9323-7b9e6e521a9a.jpg?1",
             "name": "Cavalry Pegasus",
             "text": "Flying\nWhenever Cavalry Pegasus attacks, each attacking Human gains flying until end of turn.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "d3d3595c-4914-5e24-96d3-2c9f5c0a812c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa9a809-eda4-406a-8bce-d2a1c5f06388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa9a809-eda4-406a-8bce-d2a1c5f06388.jpg?1",
             "name": "Celestial Archon",
             "text": "Bestow {5}{W}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying, first strike\nEnchanted creature gets +4/+4 and has flying and first strike.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "01caa474-14be-5983-bd08-c8f50b054fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5af083f-5820-4185-ac04-4c4368f7703c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5af083f-5820-4185-ac04-4c4368f7703c.jpg?1",
             "name": "Chained to the Rocks",
             "text": "Enchant Mountain you control\nWhen Chained to the Rocks enters the battlefield, exile target creature an opponent controls until Chained to the Rocks leaves the battlefield. (That creature returns under its owner's control.)",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "1a093f6d-9fc2-5d3a-a026-00d44cc95ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ead499-920c-465a-a23d-f08710d7e9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ead499-920c-465a-a23d-f08710d7e9bc.jpg?1",
             "name": "Chosen by Heliod",
             "text": "Enchant creature\nWhen Chosen by Heliod enters the battlefield, draw a card.\nEnchanted creature gets +0/+2.",
             "colours": [
@@ -173,7 +173,7 @@
         },
         {
             "id": "91f5873f-7fa7-57db-85f0-f776e498fd98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e652229d-81fe-4261-bebc-9e405bb2d991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e652229d-81fe-4261-bebc-9e405bb2d991.jpg?1",
             "name": "Dauntless Onslaught",
             "text": "Up to two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "c69559ab-8cda-5dc5-8419-84818e23f88b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2f3a0-444d-4cad-970f-6c4a63b02cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc2f3a0-444d-4cad-970f-6c4a63b02cce.jpg?1",
             "name": "Decorated Griffin",
             "text": "Flying\n{1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "53f454c7-ee96-548f-a277-9ff9685b8414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f46ac0-9e2f-4f9f-beee-0a7914475ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f46ac0-9e2f-4f9f-beee-0a7914475ac1.jpg?1",
             "name": "Divine Verdict",
             "text": "Destroy target attacking or blocking creature.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "0e1d4ca6-9c17-5382-810c-59cf75c4db28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5b1633-c41d-42b1-af1b-4a872077ffbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5b1633-c41d-42b1-af1b-4a872077ffbd.jpg?1",
             "name": "Elspeth, Sun's Champion",
             "text": "+1: Put three 1/1 white Soldier creature tokens onto the battlefield.\n-3: Destroy all creatures with power 4 or greater.\n-7: You get an emblem with \"Creatures you control get +2/+2 and have flying.\"",
             "colours": [
@@ -307,7 +307,7 @@
         },
         {
             "id": "2b0f03b4-af39-5170-b9b1-2f080e87099f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f7f788-2795-46a7-82ae-270f1e9415ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f7f788-2795-46a7-82ae-270f1e9415ca.jpg?1",
             "name": "Ephara's Warden",
             "text": "{T}: Tap target creature with power 3 or less.",
             "colours": [
@@ -342,7 +342,7 @@
         },
         {
             "id": "0c0a106e-bcdd-5cec-9bf0-6b61f515698f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb914a85-3755-4663-8309-6f6d0319262e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb914a85-3755-4663-8309-6f6d0319262e.jpg?1",
             "name": "Evangel of Heliod",
             "text": "When Evangel of Heliod enters the battlefield, put a number of 1/1 white Soldier creature tokens onto the battlefield equal to your devotion to white. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)",
             "colours": [
@@ -377,7 +377,7 @@
         },
         {
             "id": "badb3783-ebae-521c-94eb-0914ec564c86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9a5c-5697-4747-adce-5a71bcf1c086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9a5c-5697-4747-adce-5a71bcf1c086.jpg?1",
             "name": "Fabled Hero",
             "text": "Double strike\nHeroic \u2014 Whenever you cast a spell that targets Fabled Hero, put a +1/+1 counter on Fabled Hero.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "8214fe88-7941-5654-9db8-403492f6351a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251015ed-9408-4941-894a-158551ed2613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/251015ed-9408-4941-894a-158551ed2613.jpg?1",
             "name": "Favored Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Favored Hoplite, put a +1/+1 counter on Favored Hoplite and prevent all damage that would be dealt to it this turn.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "11c14208-e282-538d-90aa-d1c0e2ac8f8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336faaa-fc6d-4fbb-bdd4-969eae565c72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336faaa-fc6d-4fbb-bdd4-969eae565c72.jpg?1",
             "name": "Gift of Immortality",
             "text": "Enchant creature\nWhen enchanted creature dies, return that card to the battlefield under its owner's control. Return Gift of Immortality to the battlefield attached to that creature at the beginning of the next end step.",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "6d1dda40-291f-5587-bbd9-e586ffc8ee37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3d16f-f0c6-4080-8913-758208b08234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed3d16f-f0c6-4080-8913-758208b08234.jpg?1",
             "name": "Glare of Heresy",
             "text": "Exile target white permanent.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "99687962-d5e1-552a-9a5c-61fe8c39bfea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abafabb3-b2e7-4d78-b4b7-d8f701d3ee8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abafabb3-b2e7-4d78-b4b7-d8f701d3ee8b.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "7a8005b0-280f-51cb-9b89-20645ea8965d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d01c9-e76e-42ff-b0fa-8b6786242aae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90d01c9-e76e-42ff-b0fa-8b6786242aae.jpg?1",
             "name": "Heliod, God of the Sun",
             "text": "Indestructible\nAs long as your devotion to white is less than five, Heliod isn't a creature. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)\nOther creatures you control have vigilance.\n{2}{W}{W}: Put a 2/1 white Cleric enchantment creature token onto the battlefield.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "3857f9d5-b703-58ae-a2b7-62c128afe6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49663acb-582e-495a-b45e-5fc5f4949f22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49663acb-582e-495a-b45e-5fc5f4949f22.jpg?1",
             "name": "Heliod's Emissary",
             "text": "Bestow {6}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhenever Heliod's Emissary or enchanted creature attacks, tap target creature an opponent controls.\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "6749867e-00b3-5019-b7db-e7ee4f79bf85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c69995b-ef31-4635-8d5a-b31f73993364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c69995b-ef31-4635-8d5a-b31f73993364.jpg?1",
             "name": "Hopeful Eidolon",
             "text": "Bestow {3}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nEnchanted creature gets +1/+1 and has lifelink.",
             "colours": [
@@ -652,7 +652,7 @@
         },
         {
             "id": "38ac0d46-4ec0-5921-b46b-1233f3721c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8dae-6248-41a4-80a7-7e8102479de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/817b8dae-6248-41a4-80a7-7e8102479de4.jpg?1",
             "name": "Hundred-Handed One",
             "text": "Vigilance\n{3}{W}{W}{W}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nAs long as Hundred-Handed One is monstrous, it has reach and can block an additional ninety-nine creatures each combat.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "f5c5872a-1a4c-57f6-afac-c9582e8a6ff5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9df54-e78e-4a86-a8b1-b735ec08a812.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b9df54-e78e-4a86-a8b1-b735ec08a812.jpg?1",
             "name": "Lagonna-Band Elder",
             "text": "When Lagonna-Band Elder enters the battlefield, if you control an enchantment, you gain 3 life.",
             "colours": [
@@ -721,7 +721,7 @@
         },
         {
             "id": "18391d76-2b33-56f0-bba6-67165f561cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1857fc37-1e7e-4b93-9fa9-ec139f16b7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1857fc37-1e7e-4b93-9fa9-ec139f16b7fa.jpg?1",
             "name": "Last Breath",
             "text": "Exile target creature with power 2 or less. Its controller gains 4 life.",
             "colours": [
@@ -753,7 +753,7 @@
         },
         {
             "id": "6743309f-ac2f-541d-9fbb-452ba95bc8c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade9b739-122c-4659-b1b2-ea0510d96dbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ade9b739-122c-4659-b1b2-ea0510d96dbc.jpg?1",
             "name": "Leonin Snarecaster",
             "text": "When Leonin Snarecaster enters the battlefield, you may tap target creature.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "477084ad-71d0-5526-9207-a620676a8159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1410d10-476a-4ed2-ae44-75383ed0e359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1410d10-476a-4ed2-ae44-75383ed0e359.jpg?1",
             "name": "Observant Alseid",
             "text": "Bestow {4}{W} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nVigilance\nEnchanted creature gets +2/+2 and has vigilance.",
             "colours": [
@@ -823,7 +823,7 @@
         },
         {
             "id": "c2e6cc8f-f751-57e0-a7cf-c5da6b1c22a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e85180-f3c9-4b03-9c25-223599b937ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77e85180-f3c9-4b03-9c25-223599b937ad.jpg?1",
             "name": "Ordeal of Heliod",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Heliod.\nWhen you sacrifice Ordeal of Heliod, you gain 10 life.",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "6de1ca74-0f6a-595f-96cc-e1aad456d6a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c2458-edb7-4822-866b-ca1b2ea7a8e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c6c2458-edb7-4822-866b-ca1b2ea7a8e8.jpg?1",
             "name": "Phalanx Leader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Phalanx Leader, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -892,7 +892,7 @@
         },
         {
             "id": "57ab6bd9-8f66-597a-ab47-bff17d40d94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55c31d1-6b05-4ea1-a444-51ad57ebcfa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b55c31d1-6b05-4ea1-a444-51ad57ebcfa0.jpg?1",
             "name": "Ray of Dissolution",
             "text": "Destroy target enchantment. You gain 3 life.",
             "colours": [
@@ -924,7 +924,7 @@
         },
         {
             "id": "45476981-e55f-506f-b8b0-4e22f6d60f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a36e06-39f3-47d0-b6a9-43728afceb4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a36e06-39f3-47d0-b6a9-43728afceb4a.jpg?1",
             "name": "Scholar of Athreos",
             "text": "{2}{B}: Each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -960,7 +960,7 @@
         },
         {
             "id": "d96c724d-ef64-5106-a0c4-fd16981fce1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfa33-dcec-4b34-9218-c08ad932d27b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c9cfa33-dcec-4b34-9218-c08ad932d27b.jpg?1",
             "name": "Setessan Battle Priest",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Setessan Battle Priest, you gain 2 life.",
             "colours": [
@@ -995,7 +995,7 @@
         },
         {
             "id": "462e83b1-f584-5aed-90f0-33542f01d806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2ae77-b16c-4a01-84ce-5c78be5a54d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d2ae77-b16c-4a01-84ce-5c78be5a54d8.jpg?1",
             "name": "Setessan Griffin",
             "text": "Flying\n{2}{G}{G}: Setessan Griffin gets +2/+2 until end of turn. Activate this ability only once each turn.",
             "colours": [
@@ -1030,7 +1030,7 @@
         },
         {
             "id": "3d6386e0-77e8-502e-b296-69b55be2318f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5647d-1546-4eff-a2a2-9e9ef26db533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce5647d-1546-4eff-a2a2-9e9ef26db533.jpg?1",
             "name": "Silent Artisan",
             "text": "",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "1cd47d1a-6ff8-5f40-bd8e-2d756551f4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc0f46-4df4-4ae3-bfe6-391916eb590f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfc0f46-4df4-4ae3-bfe6-391916eb590f.jpg?1",
             "name": "Soldier of the Pantheon",
             "text": "Protection from multicolored\nWhenever an opponent casts a multicolored spell, you gain 1 life.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "da95f43f-b71d-53a0-b06d-e76552c21d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ef01da-d311-4d4f-9f7b-328e7bb17db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34ef01da-d311-4d4f-9f7b-328e7bb17db4.jpg?1",
             "name": "Spear of Heliod",
             "text": "Creatures you control get +1/+1.\n{1}{W}{W}, {T}: Destroy target creature that dealt damage to you this turn.",
             "colours": [
@@ -1134,7 +1134,7 @@
         },
         {
             "id": "e2a8a4aa-69ab-506a-bef6-52358e4c303d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edad0276-45d1-45e5-a6b1-1cd2a99b4f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edad0276-45d1-45e5-a6b1-1cd2a99b4f2c.jpg?1",
             "name": "Traveling Philosopher",
             "text": "",
             "colours": [
@@ -1169,7 +1169,7 @@
         },
         {
             "id": "a654649c-8833-5409-b9be-06119d98921b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdcec06-e33c-4737-b81e-b156d6e3fd77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdcec06-e33c-4737-b81e-b156d6e3fd77.jpg?1",
             "name": "Vanquish the Foul",
             "text": "Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "a18999b5-09ca-51f2-892f-8857f982546d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04751f2-b571-49fa-94b6-ec589d314ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04751f2-b571-49fa-94b6-ec589d314ee6.jpg?1",
             "name": "Wingsteed Rider",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "1b0f59c4-d34d-586b-adea-3c29c5489a7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc09d4-e6ce-428b-818b-b465093af88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fc09d4-e6ce-428b-818b-b465093af88e.jpg?1",
             "name": "Yoked Ox",
             "text": "",
             "colours": [
@@ -1270,7 +1270,7 @@
         },
         {
             "id": "0ab3985f-a160-529f-8d2c-5b9fa278987e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e71b6ad-4b81-4277-8512-0a3f2266cd23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e71b6ad-4b81-4277-8512-0a3f2266cd23.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -1302,7 +1302,7 @@
         },
         {
             "id": "4c282718-9eed-5163-8f5b-57f2a44dd2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba104245-0483-407f-971b-ad6d8efd9733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba104245-0483-407f-971b-ad6d8efd9733.jpg?1",
             "name": "Aqueous Form",
             "text": "Enchant creature\nEnchanted creature can't be blocked.\nWhenever enchanted creature attacks, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "c3791ddf-8bc3-57a7-ac96-6eb8a3c0564b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f10198-1eef-4577-b375-b900b15060e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f10198-1eef-4577-b375-b900b15060e1.jpg?1",
             "name": "Artisan of Forms",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Artisan of Forms, you may have Artisan of Forms become a copy of target creature and gain this ability.",
             "colours": [
@@ -1371,7 +1371,7 @@
         },
         {
             "id": "dd61a575-d3c8-57a9-8be0-2e9a8c73cb88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f9eb0-5a75-4f86-aca9-3f76b0213c41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f9eb0-5a75-4f86-aca9-3f76b0213c41.jpg?1",
             "name": "Benthic Giant",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "781d310f-080a-5788-b1b5-544babf91f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e45d14-a501-40b9-af0a-720ecd20dad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e45d14-a501-40b9-af0a-720ecd20dad7.jpg?1",
             "name": "Bident of Thassa",
             "text": "Whenever a creature you control deals combat damage to a player, you may draw a card.\n{1}{U}, {T}: Creatures your opponents control attack this turn if able.",
             "colours": [
@@ -1440,7 +1440,7 @@
         },
         {
             "id": "62f88189-04a0-51e2-bb57-a0b186bf189f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8841c01e-015e-4541-942a-f8859dd03fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8841c01e-015e-4541-942a-f8859dd03fea.jpg?1",
             "name": "Breaching Hippocamp",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Breaching Hippocamp enters the battlefield, untap another target creature you control.",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "48936cb2-3369-590b-b84e-bac5ac03c0a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01320a31-25fa-4324-8225-d150c6aa58a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01320a31-25fa-4324-8225-d150c6aa58a1.jpg?1",
             "name": "Coastline Chimera",
             "text": "Flying\n{1}{W}: Coastline Chimera can block an additional creature this turn.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "acb507a9-1d72-5bc6-8336-25bd7e4f2e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6bb19c-3610-4609-b23c-21d4d80e4582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d6bb19c-3610-4609-b23c-21d4d80e4582.jpg?1",
             "name": "Crackling Triton",
             "text": "{2}{R}, Sacrifice Crackling Triton: Crackling Triton deals 2 damage to target creature or player.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "5888d5fb-39d1-5114-b81c-46cd40e76af0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78831fc6-ea90-4546-b46a-9c192dbefc65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78831fc6-ea90-4546-b46a-9c192dbefc65.jpg?1",
             "name": "Curse of the Swine",
             "text": "Exile X target creatures. For each creature exiled this way, its controller puts a 2/2 green Boar creature token onto the battlefield.",
             "colours": [
@@ -1578,7 +1578,7 @@
         },
         {
             "id": "ab5494a6-fca4-5993-82b5-f721511c7b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992e8119-f933-4e54-bb04-e1cc78f7e87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/992e8119-f933-4e54-bb04-e1cc78f7e87b.jpg?1",
             "name": "Dissolve",
             "text": "Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1610,7 +1610,7 @@
         },
         {
             "id": "0b3a62ea-46e6-5089-9b4e-5f3b6519803f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d3ef99-6c86-4d70-a9a4-9c3cd4eb9538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90d3ef99-6c86-4d70-a9a4-9c3cd4eb9538.jpg?1",
             "name": "Fate Foretold",
             "text": "Enchant creature\nWhen Fate Foretold enters the battlefield, draw a card.\nWhen enchanted creature dies, its controller draws a card.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "6e4b510a-5373-5546-aa2f-c8f75d06f977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e658939a-fa5a-4497-b35c-b6fbfa3f6882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e658939a-fa5a-4497-b35c-b6fbfa3f6882.jpg?1",
             "name": "Gainsay",
             "text": "Counter target blue spell.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "3657b31b-a6af-5869-8b9c-91398c834411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8228b-ff9c-4a2a-a0e3-12f6d388a3c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fe8228b-ff9c-4a2a-a0e3-12f6d388a3c2.jpg?1",
             "name": "Griptide",
             "text": "Put target creature on top of its owner's library.",
             "colours": [
@@ -1708,7 +1708,7 @@
         },
         {
             "id": "00bda72f-3d27-543b-8fde-d1a7510c9552",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbbb721-0c80-4cc2-b036-e629c0c95956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbbb721-0c80-4cc2-b036-e629c0c95956.jpg?1",
             "name": "Horizon Scholar",
             "text": "Flying\nWhen Horizon Scholar enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "1a48d716-2904-5997-9fc2-0a3af869dab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa7744-680f-4c2a-8fa0-9cb0c176ae8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09aa7744-680f-4c2a-8fa0-9cb0c176ae8f.jpg?1",
             "name": "Lost in a Labyrinth",
             "text": "Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "2c4f1d73-877f-5c5e-a8c1-8a7563c35587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19242db3-660d-4d66-800c-d6cee636bcaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19242db3-660d-4d66-800c-d6cee636bcaf.jpg?1",
             "name": "Master of Waves",
             "text": "Protection from red\nElemental creatures you control get +1/+1.\nWhen Master of Waves enters the battlefield, put a number of 1/0 blue Elemental creature tokens onto the battlefield equal to your devotion to blue. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)",
             "colours": [
@@ -1809,7 +1809,7 @@
         },
         {
             "id": "c362ee3f-1d52-585e-8e94-bcc42a5a273a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22da0c-5bf5-4c81-9422-671ce17c8ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22da0c-5bf5-4c81-9422-671ce17c8ffa.jpg?1",
             "name": "Meletis Charlatan",
             "text": "{2}{U}, {T}: The controller of target instant or sorcery spell copies it. That player may choose new targets for the copy.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "dd6128eb-e2b6-5849-8e77-67e6da98c452",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a5946-6f9a-433f-9f1c-b99144daa170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415a5946-6f9a-433f-9f1c-b99144daa170.jpg?1",
             "name": "Mnemonic Wall",
             "text": "Defender\nWhen Mnemonic Wall enters the battlefield, you may return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "6d8ae824-6e2c-500f-877c-cda0adb22bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e9c9a2-4c5b-4518-a127-e4ffb23437d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e9c9a2-4c5b-4518-a127-e4ffb23437d6.jpg?1",
             "name": "Nimbus Naiad",
             "text": "Bestow {4}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFlying\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -1913,7 +1913,7 @@
         },
         {
             "id": "8c3e5ca5-b593-591a-add5-acab1c0af026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f347eb88-7d1d-4ed5-b841-2bf81f00d5f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f347eb88-7d1d-4ed5-b841-2bf81f00d5f0.jpg?1",
             "name": "Omenspeaker",
             "text": "When Omenspeaker enters the battlefield, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -1948,7 +1948,7 @@
         },
         {
             "id": "9c413b5f-fc94-5c96-a5ff-9b5bae5ab587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa764244-c5d5-4f27-9c56-866566a1404a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa764244-c5d5-4f27-9c56-866566a1404a.jpg?1",
             "name": "Ordeal of Thassa",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Thassa.\nWhen you sacrifice Ordeal of Thassa, draw two cards.",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "8b64c11d-94a7-572b-8ff0-c4f2e656fd09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9342aba-e3aa-4210-ad72-e609c7c027b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9342aba-e3aa-4210-ad72-e609c7c027b8.jpg?1",
             "name": "Prescient Chimera",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "2c12728a-bdfe-50a2-ae34-62b2f802c994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0a27a6-54b8-4615-89b3-591a4e3ef626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0a27a6-54b8-4615-89b3-591a4e3ef626.jpg?1",
             "name": "Prognostic Sphinx",
             "text": "Flying\nDiscard a card: Prognostic Sphinx gains hexproof until end of turn. Tap it.\nWhenever Prognostic Sphinx attacks, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2050,7 +2050,7 @@
         },
         {
             "id": "a95ad08a-3c12-502a-ae98-439bc392f951",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acdf4e4-5933-43dc-bf8b-25f89415db5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acdf4e4-5933-43dc-bf8b-25f89415db5b.jpg?1",
             "name": "Sea God's Revenge",
             "text": "Return up to three target creatures your opponents control to their owners' hands. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "f4be6763-0d55-5852-8230-508feb54996b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f942075-b285-495c-941e-6f1da48d7948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f942075-b285-495c-941e-6f1da48d7948.jpg?1",
             "name": "Sealock Monster",
             "text": "Sealock Monster can't attack unless defending player controls an Island.\n{5}{U}{U}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Sealock Monster becomes monstrous, target land becomes an Island in addition to its other types.",
             "colours": [
@@ -2116,7 +2116,7 @@
         },
         {
             "id": "846d32fb-698f-5150-b244-b5c5745f6aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4585565b-c743-4264-a647-4480ff5a3bbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4585565b-c743-4264-a647-4480ff5a3bbf.jpg?1",
             "name": "Shipbreaker Kraken",
             "text": "{6}{U}{U}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)\nWhen Shipbreaker Kraken becomes monstrous, tap up to four target creatures. Those creatures don't untap during their controllers' untap steps for as long as you control Shipbreaker Kraken.",
             "colours": [
@@ -2150,7 +2150,7 @@
         },
         {
             "id": "b88d8416-f3f2-555c-8816-2846308c0913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702b757-5be5-4a48-bc73-a87ec4f3193b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5702b757-5be5-4a48-bc73-a87ec4f3193b.jpg?1",
             "name": "Stymied Hopes",
             "text": "Counter target spell unless its controller pays {1}. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "d6ca6fc5-52f4-5d69-b94d-d98c109ade9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd26041-059b-4a1e-9ce8-c3cfd69a3721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd26041-059b-4a1e-9ce8-c3cfd69a3721.jpg?1",
             "name": "Swan Song",
             "text": "Counter target enchantment, instant, or sorcery spell. Its controller puts a 2/2 blue Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -2214,7 +2214,7 @@
         },
         {
             "id": "3de293d5-9d5e-5fbe-a06c-a24f09dd5cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6876c7a-8bbe-484e-b733-70229fa336cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6876c7a-8bbe-484e-b733-70229fa336cd.jpg?1",
             "name": "Thassa, God of the Sea",
             "text": "Indestructible\nAs long as your devotion to blue is less than five, Thassa isn't a creature. (Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)\nAt the beginning of your upkeep, scry 1.\n{1}{U}: Target creature you control can't be blocked this turn.",
             "colours": [
@@ -2251,7 +2251,7 @@
         },
         {
             "id": "b2af76f8-338c-5bbb-b33c-e797ce6e7774",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac987ac-3f81-4704-b42c-651f44670641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac987ac-3f81-4704-b42c-651f44670641.jpg?1",
             "name": "Thassa's Bounty",
             "text": "Draw three cards. Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2283,7 +2283,7 @@
         },
         {
             "id": "c90135d3-85bc-5207-8d77-81bb11d8348f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b325b-3ea9-4a99-ae99-9d158560e45b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f52b325b-3ea9-4a99-ae99-9d158560e45b.jpg?1",
             "name": "Thassa's Emissary",
             "text": "Bestow {5}{U} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nWhenever Thassa's Emissary or enchanted creature deals combat damage to a player, draw a card.\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -2318,7 +2318,7 @@
         },
         {
             "id": "12ba3023-d384-5569-944c-2b7037b2c4b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1173ff96-998c-4fe7-9b28-602d990e0339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1173ff96-998c-4fe7-9b28-602d990e0339.jpg?1",
             "name": "Triton Fortune Hunter",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Triton Fortune Hunter, draw a card.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "b3becf8c-b102-5cb6-b66a-fa3ae0e2f092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg?1",
             "name": "Triton Shorethief",
             "text": "",
             "colours": [
@@ -2388,7 +2388,7 @@
         },
         {
             "id": "76e22acd-11d4-5e63-a6d5-975b4b0714c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2609e3-ec28-4a41-884e-3d10be5e31b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef2609e3-ec28-4a41-884e-3d10be5e31b4.jpg?1",
             "name": "Triton Tactics",
             "text": "Up to two target creatures each get +0/+3 until end of turn. Untap those creatures. At this turn's next end of combat, tap each creature that was blocked by one of those creatures this turn and it doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "b2fba37f-dce3-5cb2-a442-d9a2c7d7f6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b661a5-359b-4f21-b1b6-aa0988810b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b661a5-359b-4f21-b1b6-aa0988810b4d.jpg?1",
             "name": "Vaporkin",
             "text": "Flying\nVaporkin can block only creatures with flying.",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "a1c24d79-409a-5fc6-909e-f7d3c915b647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992ae67-ad0b-40be-a97d-d7fb36754918.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3992ae67-ad0b-40be-a97d-d7fb36754918.jpg?1",
             "name": "Voyage's End",
             "text": "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -2486,7 +2486,7 @@
         },
         {
             "id": "c1815852-d608-511f-a9d2-58ff3c6eec86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7336ca1e-13ef-4e49-a526-3f285bc339bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7336ca1e-13ef-4e49-a526-3f285bc339bb.jpg?1",
             "name": "Wavecrash Triton",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Wavecrash Triton, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2521,7 +2521,7 @@
         },
         {
             "id": "56c53552-6f92-51fa-974a-40edcb6ca76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4415d050-7a76-4f8b-bf78-e33dd21fe4f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4415d050-7a76-4f8b-bf78-e33dd21fe4f1.jpg?1",
             "name": "Abhorrent Overlord",
             "text": "Flying\nWhen Abhorrent Overlord enters the battlefield, put a number of 1/1 black Harpy creature tokens with flying onto the battlefield equal to your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\nAt the beginning of your upkeep, sacrifice a creature.",
             "colours": [
@@ -2555,7 +2555,7 @@
         },
         {
             "id": "9229ed47-d286-5bb9-bd02-4b056d53a253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd59977-8788-417d-ba50-e21b8a636bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd59977-8788-417d-ba50-e21b8a636bd3.jpg?1",
             "name": "Agent of the Fates",
             "text": "Deathtouch\nHeroic \u2014 Whenever you cast a spell that targets Agent of the Fates, each opponent sacrifices a creature.",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "e748475e-fabc-546a-aab0-1a52c70f7091",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675112db-c477-43f4-b755-54162445fb49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675112db-c477-43f4-b755-54162445fb49.jpg?1",
             "name": "Asphodel Wanderer",
             "text": "{2}{B}: Regenerate Asphodel Wanderer.",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "1bc5ba0d-80b6-5c45-af79-0bf69c8e046d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853a89c6-63f9-4b12-8a5b-2c382e22b226.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853a89c6-63f9-4b12-8a5b-2c382e22b226.jpg?1",
             "name": "Baleful Eidolon",
             "text": "Bestow {4}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nEnchanted creature gets +1/+1 and has deathtouch.",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "6d9dda76-4665-535a-83da-4f82f8f86a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d334fc9b-c1f4-411e-8619-a92f1cc4e7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d334fc9b-c1f4-411e-8619-a92f1cc4e7db.jpg?1",
             "name": "Blood-Toll Harpy",
             "text": "Flying\nWhen Blood-Toll Harpy enters the battlefield, each player loses 1 life.",
             "colours": [
@@ -2694,7 +2694,7 @@
         },
         {
             "id": "a8b51edd-a073-5b60-90c3-fd01c66cf564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4371083b-c300-4464-a7ea-6168db4e345c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4371083b-c300-4464-a7ea-6168db4e345c.jpg?1",
             "name": "Boon of Erebos",
             "text": "Target creature gets +2/+0 until end of turn. Regenerate it. You lose 2 life.",
             "colours": [
@@ -2726,7 +2726,7 @@
         },
         {
             "id": "1857ac1f-f31b-56b6-a113-1320c1e394fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340de29-026f-4c76-8cb5-1abfcecbb3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e340de29-026f-4c76-8cb5-1abfcecbb3b1.jpg?1",
             "name": "Cavern Lampad",
             "text": "Bestow {5}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nIntimidate\nEnchanted creature gets +2/+2 and has intimidate.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "5049aec5-1d49-5285-a299-3c9ad4337cbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62497880-64dc-4911-8513-f95b73086136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62497880-64dc-4911-8513-f95b73086136.jpg?1",
             "name": "Cutthroat Maneuver",
             "text": "Up to two target creatures each get +1/+1 and gain lifelink until end of turn.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "8f277e41-a99a-561f-8c84-91bf8ca382f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56adf4ea-1b1c-4737-8574-1848ca47d4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56adf4ea-1b1c-4737-8574-1848ca47d4f3.jpg?1",
             "name": "Dark Betrayal",
             "text": "Destroy target black creature.",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "ba4cbc7a-2fee-501a-977f-742e6a56c89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1137c-1cbd-4918-9d1c-a9d2bd88562e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81c1137c-1cbd-4918-9d1c-a9d2bd88562e.jpg?1",
             "name": "Disciple of Phenax",
             "text": "When Disciple of Phenax enters the battlefield, target player reveals a number of cards from his or her hand equal to your devotion to black. You choose one of them. That player discards that card. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -2860,7 +2860,7 @@
         },
         {
             "id": "6a110de8-0d7a-5946-a344-cf85143501fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0787e1f-0b75-44ab-a8fd-90358906a787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0787e1f-0b75-44ab-a8fd-90358906a787.jpg?1",
             "name": "Erebos, God of the Dead",
             "text": "Indestructible\nAs long as your devotion to black is less than five, Erebos isn't a creature. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\nYour opponents can't gain life.\n{1}{B}, Pay 2 life: Draw a card.",
             "colours": [
@@ -2897,7 +2897,7 @@
         },
         {
             "id": "f253f437-9bd8-5aae-8587-29ded15e6212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96f63-d5c3-47d3-a54d-a67883406fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa96f63-d5c3-47d3-a54d-a67883406fc5.jpg?1",
             "name": "Erebos's Emissary",
             "text": "Bestow {5}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nDiscard a creature card: Erebos's Emissary gets +2/+2 until end of turn. If Erebos's Emissary is an Aura, enchanted creature gets +2/+2 until end of turn instead.\nEnchanted creature gets +3/+3.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "d68d3674-ff55-5361-abe7-a90787f380b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e424de-81be-4f90-a7a2-4102c8ba8989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e424de-81be-4f90-a7a2-4102c8ba8989.jpg?1",
             "name": "Felhide Minotaur",
             "text": "",
             "colours": [
@@ -2966,7 +2966,7 @@
         },
         {
             "id": "b9c549c2-f516-57f7-a6d3-911832e762b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378c5ba0-bf4f-43d5-b371-0991db5a2e32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/378c5ba0-bf4f-43d5-b371-0991db5a2e32.jpg?1",
             "name": "Fleshmad Steed",
             "text": "Whenever another creature dies, tap Fleshmad Steed.",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "90c843d9-d4c2-5e61-8492-e9dc292489ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06078ce-f534-4e16-9a70-d51620a33eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b06078ce-f534-4e16-9a70-d51620a33eb2.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "When Gray Merchant of Asphodel enters the battlefield, each opponent loses X life, where X is your devotion to black. You gain life equal to the life lost this way. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3034,7 +3034,7 @@
         },
         {
             "id": "e0f6f377-76cf-5ff1-a299-3e86f8022c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596822f6-dbd4-4cc8-aa50-9331ff42544e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596822f6-dbd4-4cc8-aa50-9331ff42544e.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -3066,7 +3066,7 @@
         },
         {
             "id": "a3b74065-fa6f-5f01-986d-7007a7a26663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fbc814-4281-4ac6-a844-68bcd848f229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fbc814-4281-4ac6-a844-68bcd848f229.jpg?1",
             "name": "Hythonia the Cruel",
             "text": "Deathtouch\n{6}{B}{B}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Hythonia the Cruel becomes monstrous, destroy all non-Gorgon creatures.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "b70ba267-ff83-5703-9eeb-aa599dec3b56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439ed8d-ae11-4159-9420-5d98c6cc93b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1439ed8d-ae11-4159-9420-5d98c6cc93b3.jpg?1",
             "name": "Insatiable Harpy",
             "text": "Flying, lifelink",
             "colours": [
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "9069285b-96ca-51a7-9567-d9ba79727a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac988f7b-9a10-4b48-8215-50376dc8678c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac988f7b-9a10-4b48-8215-50376dc8678c.jpg?1",
             "name": "Keepsake Gorgon",
             "text": "Deathtouch\n{5}{B}{B}: Monstrosity 1. (If this creature isn't monstrous, put a +1/+1 counter on it and it becomes monstrous.)\nWhen Keepsake Gorgon becomes monstrous, destroy target non-Gorgon creature an opponent controls.",
             "colours": [
@@ -3170,7 +3170,7 @@
         },
         {
             "id": "8ef9ff40-9408-5613-a2d3-0830e436b466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32cf1f-375c-4cc5-9963-c4f9510e3b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba32cf1f-375c-4cc5-9963-c4f9510e3b39.jpg?1",
             "name": "Lash of the Whip",
             "text": "Target creature gets -4/-4 until end of turn.",
             "colours": [
@@ -3202,7 +3202,7 @@
         },
         {
             "id": "5118664b-1ea0-5565-8c06-6a831191c21d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8cff2f-ba52-4d22-83e8-13c56368f1df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8cff2f-ba52-4d22-83e8-13c56368f1df.jpg?1",
             "name": "Loathsome Catoblepas",
             "text": "{2}{G}: Loathsome Catoblepas must be blocked this turn if able.\nWhen Loathsome Catoblepas dies, target creature an opponent controls gets -3/-3 until end of turn.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "3c5df390-303a-5a8b-84bd-b2609d0f7d4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f7521-16e3-4057-a482-7d86392daa57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/983f7521-16e3-4057-a482-7d86392daa57.jpg?1",
             "name": "March of the Returned",
             "text": "Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3269,7 +3269,7 @@
         },
         {
             "id": "f52171a0-d622-5e89-90e1-47bf04c0e128",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfd36c5-a484-4973-873c-b6a433da8e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dfd36c5-a484-4973-873c-b6a433da8e7a.jpg?1",
             "name": "Mogis's Marauder",
             "text": "When Mogis's Marauder enters the battlefield, up to X target creatures each gain intimidate and haste until end of turn, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "a8cbe21c-88e9-5cfc-91b3-4a9dd618d47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2527a490-6c56-41ba-949c-c78905a128ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2527a490-6c56-41ba-949c-c78905a128ba.jpg?1",
             "name": "Nighthowler",
             "text": "Bestow {2}{B}{B} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nNighthowler and enchanted creature each get +X/+X, where X is the number of creature cards in all graveyards.",
             "colours": [
@@ -3339,7 +3339,7 @@
         },
         {
             "id": "53d37c85-1c25-5760-a0f3-6b3f8ddc76c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e02ddba-fdc1-4d7b-89eb-00a0417f8963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e02ddba-fdc1-4d7b-89eb-00a0417f8963.jpg?1",
             "name": "Ordeal of Erebos",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Erebos.\nWhen you sacrifice Ordeal of Erebos, target player discards two cards.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "5602ba3d-6c4e-5290-92c6-76b02a6a21f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efc963-5848-44eb-a654-c08b5bd4501d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0efc963-5848-44eb-a654-c08b5bd4501d.jpg?1",
             "name": "Pharika's Cure",
             "text": "Pharika's Cure deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3405,7 +3405,7 @@
         },
         {
             "id": "3f087218-35dd-5796-9ff5-6c3af18d523c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbdbf1a-2d15-4291-aa19-614f854d8cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbdbf1a-2d15-4291-aa19-614f854d8cb3.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -3437,7 +3437,7 @@
         },
         {
             "id": "c3b7a09e-1a81-550d-b8c2-9c580fcc8d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e46aa9c-7a29-4eb4-bc44-a201c22824d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e46aa9c-7a29-4eb4-bc44-a201c22824d2.jpg?1",
             "name": "Rescue from the Underworld",
             "text": "As an additional cost to cast Rescue from the Underworld, sacrifice a creature.\nChoose target creature card in your graveyard. Return that card and the sacrificed card to the battlefield under your control at the beginning of your next upkeep. Exile Rescue from the Underworld.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "421fc1f6-c09a-5b54-8d88-5928410f84c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1067cf71-a270-4b1b-aa06-0ec0e732ed16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1067cf71-a270-4b1b-aa06-0ec0e732ed16.jpg?1",
             "name": "Returned Centaur",
             "text": "When Returned Centaur enters the battlefield, target player puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -3504,7 +3504,7 @@
         },
         {
             "id": "f8579903-ad2e-5b4f-9962-e3ffe14d6df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93613e23-b363-4bcb-8f63-8f1d25f7f174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93613e23-b363-4bcb-8f63-8f1d25f7f174.jpg?1",
             "name": "Returned Phalanx",
             "text": "Defender\n{1}{U}: Returned Phalanx can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "9bed296f-819c-5a38-9819-be94198288b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed36a150-a686-4fa6-8364-8be262ad7d98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed36a150-a686-4fa6-8364-8be262ad7d98.jpg?1",
             "name": "Scourgemark",
             "text": "Enchant creature\nWhen Scourgemark enters the battlefield, draw a card.\nEnchanted creature gets +1/+0.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "50fe9506-dd6d-5c92-84ad-809c16a904b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22051427-9b2a-4571-8c9f-ee84d8d0e4d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22051427-9b2a-4571-8c9f-ee84d8d0e4d1.jpg?1",
             "name": "Sip of Hemlock",
             "text": "Destroy target creature. Its controller loses 2 life.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "63d66511-e1db-5693-b3c1-2534e27dbc91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7275a-5305-42e6-b5c3-8b88568b4e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b7275a-5305-42e6-b5c3-8b88568b4e28.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals his or her hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -3638,7 +3638,7 @@
         },
         {
             "id": "6f5b7257-23ed-5507-8ce3-adab87ba2434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c101cf1b-cedf-4b74-9e3c-35f9a8695a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c101cf1b-cedf-4b74-9e3c-35f9a8695a8f.jpg?1",
             "name": "Tormented Hero",
             "text": "Tormented Hero enters the battlefield tapped.\nHeroic \u2014 Whenever you cast a spell that targets Tormented Hero, each opponent loses 1 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "59174bd3-7339-533e-b991-751a15b8dbda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906ebfc-4756-4caf-83ff-859e181f3bef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0906ebfc-4756-4caf-83ff-859e181f3bef.jpg?1",
             "name": "Viper's Kiss",
             "text": "Enchant creature\nEnchanted creature gets -1/-1, and its activated abilities can't be activated.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "cacb3198-0a84-57d7-91fc-319f7ecd13f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ec47c-47a2-4eda-b81a-4a07f04e5989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e5ec47c-47a2-4eda-b81a-4a07f04e5989.jpg?1",
             "name": "Whip of Erebos",
             "text": "Creatures you control have lifelink.\n{2}{B}{B}, {T}: Return target creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step. If it would leave the battlefield, exile it instead of putting it anywhere else. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3742,7 +3742,7 @@
         },
         {
             "id": "19ee36b2-2a45-552d-8be4-a9a71123df32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c50d9-11ec-486b-a5ce-5a6b70858f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a47c50d9-11ec-486b-a5ce-5a6b70858f30.jpg?1",
             "name": "Akroan Crusader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Crusader, put a 1/1 red Soldier creature token with haste onto the battlefield.",
             "colours": [
@@ -3777,7 +3777,7 @@
         },
         {
             "id": "3113de16-5d09-5443-9378-7baddad56c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90795891-5e67-47c0-8d52-a5e5c5a9ef81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90795891-5e67-47c0-8d52-a5e5c5a9ef81.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -3809,7 +3809,7 @@
         },
         {
             "id": "bebc21c5-9014-572e-8a64-8c673f99fc0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e201d9e6-d611-4dc4-b665-9062b449f859.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e201d9e6-d611-4dc4-b665-9062b449f859.jpg?1",
             "name": "Arena Athlete",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Arena Athlete, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -3843,7 +3843,7 @@
         },
         {
             "id": "2186d924-373a-57f8-a044-a75bf8e120dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7f6eb2-feae-4dc9-a009-0ad60f89a592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7f6eb2-feae-4dc9-a009-0ad60f89a592.jpg?1",
             "name": "Borderland Minotaur",
             "text": "",
             "colours": [
@@ -3878,7 +3878,7 @@
         },
         {
             "id": "258d812d-c2f6-56e7-a18d-a8dd12a20bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66470bac-cce0-4e79-82f9-9fb77aa950eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66470bac-cce0-4e79-82f9-9fb77aa950eb.jpg?1",
             "name": "Boulderfall",
             "text": "Boulderfall deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -3910,7 +3910,7 @@
         },
         {
             "id": "19630929-2761-5924-9f7a-1ffb0fcd7098",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c29f484-5f4b-4d29-846f-192425ab7fe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c29f484-5f4b-4d29-846f-192425ab7fe3.jpg?1",
             "name": "Coordinated Assault",
             "text": "Up to two target creatures each get +1/+0 and gain first strike until end of turn.",
             "colours": [
@@ -3942,7 +3942,7 @@
         },
         {
             "id": "d678f617-a92a-5e77-9cd2-4d1491fff48a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29fc64e-297e-4e10-8f4e-289dc1c3ebfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b29fc64e-297e-4e10-8f4e-289dc1c3ebfd.jpg?1",
             "name": "Deathbellow Raider",
             "text": "Deathbellow Raider attacks each turn if able.\n{2}{B}: Regenerate Deathbellow Raider.",
             "colours": [
@@ -3978,7 +3978,7 @@
         },
         {
             "id": "be4c3b43-07cc-5c88-b5f3-3a3fb0c126f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2446dd-d70f-4fdd-87d0-d402ba35d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2446dd-d70f-4fdd-87d0-d402ba35d044.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4010,7 +4010,7 @@
         },
         {
             "id": "9ab2b708-6f65-5a0c-9fcb-4e1f0d01531f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b1080-9001-4751-b2f5-7f56d9f58dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b1080-9001-4751-b2f5-7f56d9f58dff.jpg?1",
             "name": "Dragon Mantle",
             "text": "Enchant creature\nWhen Dragon Mantle enters the battlefield, draw a card.\nEnchanted creature has \"{R}: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -4044,7 +4044,7 @@
         },
         {
             "id": "fef651fe-167a-5ef4-accb-4113d2931ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2715851-9def-42a0-bed4-0923e599e19a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2715851-9def-42a0-bed4-0923e599e19a.jpg?1",
             "name": "Ember Swallower",
             "text": "{5}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Ember Swallower becomes monstrous, each player sacrifices three lands.",
             "colours": [
@@ -4078,7 +4078,7 @@
         },
         {
             "id": "e7501a2f-979e-512a-922b-332fb805fb13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581eaadb-442b-40c9-b8f9-9e19d5eba824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581eaadb-442b-40c9-b8f9-9e19d5eba824.jpg?1",
             "name": "Fanatic of Mogis",
             "text": "When Fanatic of Mogis enters the battlefield, it deals damage to each opponent equal to your devotion to red. (Each {R} in the mana costs of permanents you control counts toward your devotion to red.)",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "2638170f-08ea-5bd4-88dd-8c8f4b6524e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683eaf5a-2f43-477f-b212-70ca5fe04f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683eaf5a-2f43-477f-b212-70ca5fe04f13.jpg?1",
             "name": "Firedrinker Satyr",
             "text": "Whenever Firedrinker Satyr is dealt damage, it deals that much damage to you.\n{1}{R}: Firedrinker Satyr gets +1/+0 until end of turn and deals 1 damage to you.",
             "colours": [
@@ -4148,7 +4148,7 @@
         },
         {
             "id": "bdef3e49-69f4-5052-bbdd-99f60a6c626c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84b90b6-71e2-429e-9853-50bcbd6538db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84b90b6-71e2-429e-9853-50bcbd6538db.jpg?1",
             "name": "Flamespeaker Adept",
             "text": "Whenever you scry, Flamespeaker Adept gets +2/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "d4529fe6-8fa2-5288-a570-e624add0b3b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f867f61-676e-40b3-8e22-e60d0606c733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f867f61-676e-40b3-8e22-e60d0606c733.jpg?1",
             "name": "Hammer of Purphoros",
             "text": "Creatures you control have haste.\n{2}{R}, {T}, Sacrifice a land: Put a 3/3 colorless Golem enchantment artifact creature token onto the battlefield.",
             "colours": [
@@ -4218,7 +4218,7 @@
         },
         {
             "id": "53144fd3-9da9-55eb-b084-41afdc608035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f7f757-31ac-43e6-8be0-c5948d478d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f7f757-31ac-43e6-8be0-c5948d478d2f.jpg?1",
             "name": "Ill-Tempered Cyclops",
             "text": "Trample\n{5}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "f167b228-4d12-51bd-9d4a-7a54e6a3ecdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f86d035-a86d-4c2a-a19d-3b90e0f9ff0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f86d035-a86d-4c2a-a19d-3b90e0f9ff0f.jpg?1",
             "name": "Labyrinth Champion",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Labyrinth Champion, Labyrinth Champion deals 2 damage to target creature or player.",
             "colours": [
@@ -4287,7 +4287,7 @@
         },
         {
             "id": "8579aa67-2d39-59c1-a293-2ac55038ae92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb03f2e-2b92-4aa1-afae-301ed5d151d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbb03f2e-2b92-4aa1-afae-301ed5d151d3.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to target creature or player.",
             "colours": [
@@ -4319,7 +4319,7 @@
         },
         {
             "id": "4cd3c18b-4225-5dc2-9193-8923e0d67db2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0686b0-27a2-46bc-bc04-717f368d9a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0686b0-27a2-46bc-bc04-717f368d9a78.jpg?1",
             "name": "Magma Jet",
             "text": "Magma Jet deals 2 damage to target creature or player. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -4351,7 +4351,7 @@
         },
         {
             "id": "41d35d1c-435d-5112-bc98-f8a566314a31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d7f033-217f-4fb3-a57b-e32291257ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d7f033-217f-4fb3-a57b-e32291257ec8.jpg?1",
             "name": "Messenger's Speed",
             "text": "Enchant creature\nEnchanted creature has trample and haste.",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "c75e2bf6-f3bf-5600-9aa1-31460052d509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6854c913-d4bd-42f7-901c-f3c25be5c4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6854c913-d4bd-42f7-901c-f3c25be5c4b2.jpg?1",
             "name": "Minotaur Skullcleaver",
             "text": "Haste\nWhen Minotaur Skullcleaver enters the battlefield, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "d07019e3-01f6-50c0-bd3e-1e43e5fc14c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb74ccc-5ae5-4437-a0b4-c621ab4c2257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb74ccc-5ae5-4437-a0b4-c621ab4c2257.jpg?1",
             "name": "Ordeal of Purphoros",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Purphoros.\nWhen you sacrifice Ordeal of Purphoros, it deals 3 damage to target creature or player.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "5e6cbfa6-7bc3-55d0-9b38-3d74f901e8bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0a00f7-aee0-4ab2-bab6-bc0949176a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed0a00f7-aee0-4ab2-bab6-bc0949176a7a.jpg?1",
             "name": "Peak Eruption",
             "text": "Destroy target Mountain. Peak Eruption deals 3 damage to that land's controller.",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "eb63e1cd-41fd-5df1-8762-89925977e56f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcdf4df-1900-427b-998f-957754ce1b75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcdf4df-1900-427b-998f-957754ce1b75.jpg?1",
             "name": "Portent of Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4518,7 +4518,7 @@
         },
         {
             "id": "30cb2f48-eb57-5aae-92ce-d1467a343f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013ec9f5-8bf3-4067-a942-d535d011af82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013ec9f5-8bf3-4067-a942-d535d011af82.jpg?1",
             "name": "Priest of Iroas",
             "text": "{3}{W}, Sacrifice Priest of Iroas: Destroy target enchantment.",
             "colours": [
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "0289496f-53e7-5d8b-b8ff-330abcf15cb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf6baf2-d20b-467d-8929-abefcf7dfa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf6baf2-d20b-467d-8929-abefcf7dfa99.jpg?1",
             "name": "Purphoros, God of the Forge",
             "text": "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "1941d22d-3462-52e1-aeec-e8e542845fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4ddc30-844c-4860-b394-d3c807c31162.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4ddc30-844c-4860-b394-d3c807c31162.jpg?1",
             "name": "Purphoros's Emissary",
             "text": "Bestow {6}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nPurphoros's Emissary can't be blocked except by two or more creatures.\nEnchanted creature gets +3/+3 and can't be blocked except by two or more creatures.",
             "colours": [
@@ -4626,7 +4626,7 @@
         },
         {
             "id": "c6d8ccd7-5f0a-52d7-bcff-686b663d68b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e249f31-cc67-4d0c-9db5-962d10cf74ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e249f31-cc67-4d0c-9db5-962d10cf74ca.jpg?1",
             "name": "Rage of Purphoros",
             "text": "Rage of Purphoros deals 4 damage to target creature. It can't be regenerated this turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4658,7 +4658,7 @@
         },
         {
             "id": "405a826b-ba15-5533-a120-c54bcc46a9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaa31fd-5ba5-49d4-90b6-fafb9f1a8b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffaa31fd-5ba5-49d4-90b6-fafb9f1a8b3a.jpg?1",
             "name": "Rageblood Shaman",
             "text": "Trample\nOther Minotaur creatures you control get +1/+1 and have trample.",
             "colours": [
@@ -4693,7 +4693,7 @@
         },
         {
             "id": "a1145800-2955-575c-a703-fe19efca69f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabccddd-c0ea-45a5-bebc-d8f858242a2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fabccddd-c0ea-45a5-bebc-d8f858242a2a.jpg?1",
             "name": "Satyr Rambler",
             "text": "Trample",
             "colours": [
@@ -4727,7 +4727,7 @@
         },
         {
             "id": "d8d2b4b1-10cd-58f6-bb67-698bbf01bafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee479c2-a115-450b-bc2e-b03d23b82f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee479c2-a115-450b-bc2e-b03d23b82f2d.jpg?1",
             "name": "Spark Jolt",
             "text": "Spark Jolt deals 1 damage to target creature or player. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4759,7 +4759,7 @@
         },
         {
             "id": "e1bd7be9-3002-5f20-9043-81566a52e336",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d9d241-74b8-4b40-b4b7-b8584012d482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22d9d241-74b8-4b40-b4b7-b8584012d482.jpg?1",
             "name": "Spearpoint Oread",
             "text": "Bestow {5}{R} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nFirst strike\nEnchanted creature gets +2/+2 and has first strike.",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "f47d77aa-a862-55b2-98ca-6dbdd37aa6f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d890801-5ffa-48af-959f-72e5f371fc61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d890801-5ffa-48af-959f-72e5f371fc61.jpg?1",
             "name": "Stoneshock Giant",
             "text": "{6}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Stoneshock Giant becomes monstrous, creatures without flying your opponents control can't block this turn.",
             "colours": [
@@ -4828,7 +4828,7 @@
         },
         {
             "id": "809bd9cf-5b28-5a2f-8123-e7b0092b666d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471979de-f569-444a-8651-12d7e726949a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/471979de-f569-444a-8651-12d7e726949a.jpg?1",
             "name": "Stormbreath Dragon",
             "text": "Flying, haste, protection from white\n{5}{R}{R}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Stormbreath Dragon becomes monstrous, it deals damage to each opponent equal to the number of cards in that player's hand.",
             "colours": [
@@ -4862,7 +4862,7 @@
         },
         {
             "id": "9020af19-3cc4-5c6b-b016-b55e563356e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb8e4df-930c-4fb1-9258-184ff6c415d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb8e4df-930c-4fb1-9258-184ff6c415d0.jpg?1",
             "name": "Titan of Eternal Fire",
             "text": "Each Human creature you control has \"{R}, {T}: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -4896,7 +4896,7 @@
         },
         {
             "id": "54cf8999-5880-5bc7-9f57-6cddf7a9e7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6ee53-c5e6-4344-9f35-084cd8cc9cd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db6ee53-c5e6-4344-9f35-084cd8cc9cd3.jpg?1",
             "name": "Titan's Strength",
             "text": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "937058ce-e120-5173-bf14-db82476e3722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d2f75c-ef2a-4d30-86d1-c47307fc47ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d2f75c-ef2a-4d30-86d1-c47307fc47ac.jpg?1",
             "name": "Two-Headed Cerberus",
             "text": "Double strike (This creature deals both first-strike and regular combat damage.)",
             "colours": [
@@ -4962,7 +4962,7 @@
         },
         {
             "id": "8de41ea4-21c3-5e04-8e35-3fd39c70efb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ab4e29-44c7-431a-ba11-b2f4f9c75ab1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7ab4e29-44c7-431a-ba11-b2f4f9c75ab1.jpg?1",
             "name": "Wild Celebrants",
             "text": "When Wild Celebrants enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "1c5a3a15-4a5b-5538-8d15-d229126e39cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc08576f-1d48-4db4-9bb9-e039f75c98b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc08576f-1d48-4db4-9bb9-e039f75c98b8.jpg?1",
             "name": "Agent of Horizons",
             "text": "{2}{U}: Agent of Horizons can't be blocked this turn.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "f0ff1973-a630-5edd-a751-33d40fca7c35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca89e4d4-185d-4a08-b7af-03f6eff38ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca89e4d4-185d-4a08-b7af-03f6eff38ba3.jpg?1",
             "name": "Anthousa, Setessan Hero",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Anthousa, Setessan Hero, up to three target lands you control each become 2/2 Warrior creatures until end of turn. They're still lands.",
             "colours": [
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "7b89a8e0-9433-593a-a47e-51351986d82d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbd7c65-ebe5-47a6-8d2f-9a8c63a30a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfbd7c65-ebe5-47a6-8d2f-9a8c63a30a7b.jpg?1",
             "name": "Arbor Colossus",
             "text": "Reach\n{3}{G}{G}{G}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhen Arbor Colossus becomes monstrous, destroy target creature with flying an opponent controls.",
             "colours": [
@@ -5103,7 +5103,7 @@
         },
         {
             "id": "25eb1266-37d5-518c-a98f-b8c62091c764",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f38f7e-2369-48c9-9121-4b13c29ea869.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f38f7e-2369-48c9-9121-4b13c29ea869.jpg?1",
             "name": "Artisan's Sorrow",
             "text": "Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "cd4195c1-80ab-5b0b-99bd-e5d35a15dcad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50c12c4-5565-449a-b30e-7cd896da7735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50c12c4-5565-449a-b30e-7cd896da7735.jpg?1",
             "name": "Boon Satyr",
             "text": "Flash\nBestow {3}{G}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nEnchanted creature gets +4/+2.",
             "colours": [
@@ -5170,7 +5170,7 @@
         },
         {
             "id": "801d1852-1d24-5666-8151-8d9601b9218b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a2c408-e953-4386-abaf-4af85aba9620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a2c408-e953-4386-abaf-4af85aba9620.jpg?1",
             "name": "Bow of Nylea",
             "text": "Attacking creatures you control have deathtouch.\n{1}{G}, {T}: Choose one \u2014 Put a +1/+1 counter on target creature; or Bow of Nylea deals 2 damage to target creature with flying; or you gain 3 life; or put up to four target cards from your graveyard on the bottom of your library in any order.",
             "colours": [
@@ -5205,7 +5205,7 @@
         },
         {
             "id": "75cd0e58-6e8f-54bd-ad34-26acd19d0800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975a0b4-7436-4588-8f79-c001a291c459.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2975a0b4-7436-4588-8f79-c001a291c459.jpg?1",
             "name": "Centaur Battlemaster",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Centaur Battlemaster, put three +1/+1 counters on Centaur Battlemaster.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "731c3367-5cf4-5c3e-93ea-9c95e9ae55b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101ae5f-c3ea-4788-b27f-d9452234eaef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e101ae5f-c3ea-4788-b27f-d9452234eaef.jpg?1",
             "name": "Commune with the Gods",
             "text": "Reveal the top five cards of your library. You may put a creature or enchantment card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -5272,7 +5272,7 @@
         },
         {
             "id": "d358125a-e0ac-5465-9281-ec06b93a67e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e4c4c3-db3c-49d4-8080-1c93470f8b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e4c4c3-db3c-49d4-8080-1c93470f8b4d.jpg?1",
             "name": "Defend the Hearth",
             "text": "Prevent all combat damage that would be dealt to players this turn.",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "fff1ecb0-c0e3-538d-bfda-6336ed71ba42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e46a6-f7de-482a-a386-73932d1d9002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43e46a6-f7de-482a-a386-73932d1d9002.jpg?1",
             "name": "Fade into Antiquity",
             "text": "Exile target artifact or enchantment.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "c46bbaf0-b14d-503f-8fa0-283530861581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f15a2-0058-4188-9696-385fa6974bd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f15a2-0058-4188-9696-385fa6974bd4.jpg?1",
             "name": "Feral Invocation",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+2.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "4e3c2397-54f4-503c-b761-36b7eb15e4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d4899f-11a4-4a2c-a499-3a447b792f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61d4899f-11a4-4a2c-a499-3a447b792f86.jpg?1",
             "name": "Hunt the Hunter",
             "text": "Target green creature you control gets +2/+2 until end of turn. It fights target green creature an opponent controls.",
             "colours": [
@@ -5402,7 +5402,7 @@
         },
         {
             "id": "bf3f15a2-2b67-5009-8b7b-93b357e86516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374a1b7c-ce11-4734-aff2-b0bd00857fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/374a1b7c-ce11-4734-aff2-b0bd00857fad.jpg?1",
             "name": "Karametra's Acolyte",
             "text": "{T}: Add an amount of {G} to your mana pool equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -5437,7 +5437,7 @@
         },
         {
             "id": "7bb0fba4-e97e-5574-ba32-aad7e532b940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8202e426-ad91-4d2e-9373-7a829b58fff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8202e426-ad91-4d2e-9373-7a829b58fff5.jpg?1",
             "name": "Leafcrown Dryad",
             "text": "Bestow {3}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nReach\nEnchanted creature gets +2/+2 and has reach.",
             "colours": [
@@ -5473,7 +5473,7 @@
         },
         {
             "id": "aa8e9af1-f6fc-508a-a9fc-a30c2f9d6b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg?1",
             "name": "Mistcutter Hydra",
             "text": "Mistcutter Hydra can't be countered.\nHaste, protection from blue\nMistcutter Hydra enters the battlefield with X +1/+1 counters on it.",
             "colours": [
@@ -5507,7 +5507,7 @@
         },
         {
             "id": "576939ab-64cb-544e-9ce3-a8482f43419e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4010889-1d7a-4db3-a27c-c39baa024765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4010889-1d7a-4db3-a27c-c39baa024765.jpg?1",
             "name": "Nemesis of Mortals",
             "text": "Nemesis of Mortals costs {1} less to cast for each creature card in your graveyard.\n{7}{G}{G}: Monstrosity 5. This ability costs {1} less to activate for each creature card in your graveyard. (If this creature isn't monstrous, put five +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "87e5de24-9054-5606-a57b-db89d3da9f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d922596-4c2d-47fd-8c28-0e62972effbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d922596-4c2d-47fd-8c28-0e62972effbf.jpg?1",
             "name": "Nessian Asp",
             "text": "Reach\n{6}{G}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.)",
             "colours": [
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "14e19573-a095-5905-93c1-4c87e6f311a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4697f3aa-abde-4379-af82-f30115f59be0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4697f3aa-abde-4379-af82-f30115f59be0.jpg?1",
             "name": "Nessian Courser",
             "text": "",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "18288b67-754e-5627-8ec4-6bd4633a6d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f185a734-a32a-4244-88e8-dabafbfd064f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f185a734-a32a-4244-88e8-dabafbfd064f.jpg?1",
             "name": "Nylea, God of the Hunt",
             "text": "Indestructible\nAs long as your devotion to green is less than five, Nylea isn't a creature. (Each o\nG in the mana costs of permanents you control counts toward your devotion to green.)\nOther creatures you control have trample.\n{3}{G}: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -5647,7 +5647,7 @@
         },
         {
             "id": "ff421438-f4ea-531c-b0f5-9faf24ea34e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365d716a-1435-48ac-b85f-2cceca1056dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/365d716a-1435-48ac-b85f-2cceca1056dd.jpg?1",
             "name": "Nylea's Disciple",
             "text": "When Nylea's Disciple enters the battlefield, you gain life equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -5682,7 +5682,7 @@
         },
         {
             "id": "0641c111-ef7e-5ab4-b8b1-48483a4f9f63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f133775-09b3-4df4-a97f-0df75809b724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f133775-09b3-4df4-a97f-0df75809b724.jpg?1",
             "name": "Nylea's Emissary",
             "text": "Bestow {5}{G} (If you cast this card for its bestow cost, it's an Aura spell with enchant creature. It becomes a creature again if it's not attached to a creature.)\nTrample\nEnchanted creature gets +3/+3 and has trample.",
             "colours": [
@@ -5717,7 +5717,7 @@
         },
         {
             "id": "aa8f512e-1e3b-5c8f-805b-ad7916c85aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68f1fd4-1a2f-405b-a592-6c4af6214eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e68f1fd4-1a2f-405b-a592-6c4af6214eae.jpg?1",
             "name": "Nylea's Presence",
             "text": "Enchant land\nWhen Nylea's Presence enters the battlefield, draw a card.\nEnchanted land is every basic land type in addition to its other types.",
             "colours": [
@@ -5751,7 +5751,7 @@
         },
         {
             "id": "b46e717d-3968-5568-8edb-c48a0f1a8112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c48950-c246-47ad-94e1-bf42a62c2fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c48950-c246-47ad-94e1-bf42a62c2fe7.jpg?1",
             "name": "Ordeal of Nylea",
             "text": "Enchant creature\nWhenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea.\nWhen you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5785,7 +5785,7 @@
         },
         {
             "id": "2cae07b4-ce60-5723-bad8-0ae0aa1e353e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168fcf4-cf87-4ab8-9710-6ec672750a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168fcf4-cf87-4ab8-9710-6ec672750a9a.jpg?1",
             "name": "Pheres-Band Centaurs",
             "text": "",
             "colours": [
@@ -5820,7 +5820,7 @@
         },
         {
             "id": "097c4814-d88e-5abc-b0ab-2d6f6ee6928b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979cc1b-9c1a-47e4-ae37-7c41798eb89a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4979cc1b-9c1a-47e4-ae37-7c41798eb89a.jpg?1",
             "name": "Polukranos, World Eater",
             "text": "{X}{X}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen Polukranos, World Eater becomes monstrous, it deals X damage divided as you choose among any number of target creatures your opponents control. Each of those creatures deals damage equal to its power to Polukranos.",
             "colours": [
@@ -5856,7 +5856,7 @@
         },
         {
             "id": "e182d6bd-bd9e-5a88-b6c9-45b9976c7b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b4e736-d19a-42ac-8bcb-b8e6b7b7b539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b4e736-d19a-42ac-8bcb-b8e6b7b7b539.jpg?1",
             "name": "Reverent Hunter",
             "text": "When Reverent Hunter enters the battlefield, put a number of +1/+1 counters on it equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts toward your devotion to green.)",
             "colours": [
@@ -5891,7 +5891,7 @@
         },
         {
             "id": "159b8393-353e-5f3a-8f37-e16735c65a9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c67e15-833c-406a-b75f-8de97fbacf5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c67e15-833c-406a-b75f-8de97fbacf5a.jpg?1",
             "name": "Satyr Hedonist",
             "text": "{R}, Sacrifice Satyr Hedonist: Add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5926,7 +5926,7 @@
         },
         {
             "id": "48176ff3-0b84-5002-a899-015ba5c4ae5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c4d0-2c30-4a56-94bb-0fff9ffe4a6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e244c4d0-2c30-4a56-94bb-0fff9ffe4a6a.jpg?1",
             "name": "Satyr Piper",
             "text": "{3}{G}: Target creature must be blocked this turn if able.",
             "colours": [
@@ -5961,7 +5961,7 @@
         },
         {
             "id": "59028d57-fe27-58dd-a33e-6de2d654584c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5916d5e7-0825-4d72-82e4-1e4c86d1fafe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5916d5e7-0825-4d72-82e4-1e4c86d1fafe.jpg?1",
             "name": "Savage Surge",
             "text": "Target creature gets +2/+2 until end of turn. Untap that creature.",
             "colours": [
@@ -5993,7 +5993,7 @@
         },
         {
             "id": "1f895f10-9fc5-5508-9f20-2fbc2fdcff5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66733fcb-fddc-4c15-bc51-c2cd42ac5a70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66733fcb-fddc-4c15-bc51-c2cd42ac5a70.jpg?1",
             "name": "Sedge Scorpion",
             "text": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "a82c8c6f-42f2-5e38-ae59-00875848f8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f36143-85b6-412c-8c79-053728b45c25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f36143-85b6-412c-8c79-053728b45c25.jpg?1",
             "name": "Shredding Winds",
             "text": "Shredding Winds deals 7 damage to target creature with flying.",
             "colours": [
@@ -6059,7 +6059,7 @@
         },
         {
             "id": "6294df85-7a33-58db-bd8a-b384ba662b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3485eb83-f83c-4776-b164-abd72f3c9547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3485eb83-f83c-4776-b164-abd72f3c9547.jpg?1",
             "name": "Staunch-Hearted Warrior",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Staunch-Hearted Warrior, put two +1/+1 counters on Staunch-Hearted Warrior.",
             "colours": [
@@ -6094,7 +6094,7 @@
         },
         {
             "id": "da9f85d4-caa4-545e-b992-6ccc24ba70b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40b65c1-b24d-492d-81b9-d8474ebdc08c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40b65c1-b24d-492d-81b9-d8474ebdc08c.jpg?1",
             "name": "Sylvan Caryatid",
             "text": "Defender, hexproof\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -6128,7 +6128,7 @@
         },
         {
             "id": "3350738a-bb3d-5dd3-b312-b4e16cc6b820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799d08a6-d978-4731-98ad-38acd57f3196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799d08a6-d978-4731-98ad-38acd57f3196.jpg?1",
             "name": "Time to Feed",
             "text": "Choose target creature an opponent controls. When that creature dies this turn, you gain 3 life. Target creature you control fights that\ncreature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6160,7 +6160,7 @@
         },
         {
             "id": "686e80ce-1992-51ba-9f80-68f29fd741ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155ae6c0-5085-45f1-ba9f-508d501fee2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/155ae6c0-5085-45f1-ba9f-508d501fee2c.jpg?1",
             "name": "Voyaging Satyr",
             "text": "{T}: Untap target land.",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "a22cb634-7b50-5620-a084-1e484df85375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdacb147-35ce-4751-961e-576b5f958048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdacb147-35ce-4751-961e-576b5f958048.jpg?1",
             "name": "Vulpine Goliath",
             "text": "Trample",
             "colours": [
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "97a87b14-d8dd-5d77-995e-84f6e2c138f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7e81a-6f9e-4cad-a911-fba7a431cd55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63f7e81a-6f9e-4cad-a911-fba7a431cd55.jpg?1",
             "name": "Warriors' Lesson",
             "text": "Until end of turn, up to two target creatures you control each gain \"Whenever this creature deals combat damage to a player, draw a card.\"",
             "colours": [
@@ -6261,7 +6261,7 @@
         },
         {
             "id": "38fd0936-e113-5642-8988-2b5e8cd90d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695ccac5-c87e-49af-9131-8f1730e84bc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/695ccac5-c87e-49af-9131-8f1730e84bc0.jpg?1",
             "name": "Akroan Hoplite",
             "text": "Whenever Akroan Hoplite attacks, it gets +X/+0 until end of turn, where X is the number of attacking creatures you control.",
             "colours": [
@@ -6298,7 +6298,7 @@
         },
         {
             "id": "7a6feb5a-99fc-5b8b-80da-7bb64d767a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb977e-bd42-43b1-83d1-124e7a413aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb977e-bd42-43b1-83d1-124e7a413aca.jpg?1",
             "name": "Anax and Cymede",
             "text": "First strike, vigilance\nHeroic \u2014 Whenever you cast a spell that targets Anax and Cymede, creatures you control get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "d98bf477-d9ed-59ba-9a01-ce9fc9752a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602e43b1-1b1c-4eb1-be0a-61b673646c6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602e43b1-1b1c-4eb1-be0a-61b673646c6f.jpg?1",
             "name": "Ashen Rider",
             "text": "Flying\nWhen Ashen Rider enters the battlefield or dies, exile target permanent.",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "8e0baa3b-a457-53e7-b6e0-27a1e18194f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599c3c9f-dfb7-4357-9d9c-9a1a4616b103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/599c3c9f-dfb7-4357-9d9c-9a1a4616b103.jpg?1",
             "name": "Ashiok, Nightmare Weaver",
             "text": "+2: Exile the top three cards of target opponent's library.\n-X: Put a creature card with converted mana cost X exiled with Ashiok, Nightmare Weaver onto the battlefield under your control. That creature is a Nightmare in addition to its other types.\n-10: Exile all cards from all opponents' hands and graveyards.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "5e1a3147-c08d-5b26-8318-cc94aa2b5b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c929a57-2c23-4bbf-b265-666630a4fde8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c929a57-2c23-4bbf-b265-666630a4fde8.jpg?1",
             "name": "Battlewise Hoplite",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Battlewise Hoplite, put a +1/+1 counter on Battlewise Hoplite, then scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -6448,7 +6448,7 @@
         },
         {
             "id": "9fb5c140-5c54-5078-8945-b4070c72c47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1cbee6-61f4-40f0-86fe-93831a0b87d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de1cbee6-61f4-40f0-86fe-93831a0b87d8.jpg?1",
             "name": "Chronicler of Heroes",
             "text": "When Chronicler of Heroes enters the battlefield, draw a card if you control a creature with a +1/+1 counter on it.",
             "colours": [
@@ -6485,7 +6485,7 @@
         },
         {
             "id": "a45ba28d-7fa5-571a-9f05-8bc7297983c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb68644-e99d-4ecb-a804-8d4ad1c3325d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb68644-e99d-4ecb-a804-8d4ad1c3325d.jpg?1",
             "name": "Daxos of Meletis",
             "text": "Daxos of Meletis can't be blocked by creatures with power 3 or greater.\nWhenever Daxos of Meletis deals combat damage to a player, exile the top card of that player's library. You gain life equal to that card's converted mana cost. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.",
             "colours": [
@@ -6524,7 +6524,7 @@
         },
         {
             "id": "29396a36-31bf-50d1-bcc0-ce00c74eca11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798af7cb-645f-4526-8a19-6e4595b93964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/798af7cb-645f-4526-8a19-6e4595b93964.jpg?1",
             "name": "Destructive Revelry",
             "text": "Destroy target artifact or enchantment. Destructive Revelry deals 2 damage to that permanent's controller.",
             "colours": [
@@ -6558,7 +6558,7 @@
         },
         {
             "id": "fa047a14-2bf0-5ac9-af6d-493737e426b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622d6c46-82bb-4a97-abe6-b388def44bda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/622d6c46-82bb-4a97-abe6-b388def44bda.jpg?1",
             "name": "Fleecemane Lion",
             "text": "{3}{G}{W}: Monstrosity 1. (If this creature isn't monstrous, put a +1/+1 counter on it and it becomes monstrous.)\nAs long as Fleecemane Lion is monstrous, it has hexproof and indestructible.",
             "colours": [
@@ -6594,7 +6594,7 @@
         },
         {
             "id": "fc6a857b-cf3f-54a0-a488-69c7f499f38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b0e296-d556-4e76-bb2e-5a640e070bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b0e296-d556-4e76-bb2e-5a640e070bb5.jpg?1",
             "name": "Horizon Chimera",
             "text": "Flash (You may cast this spell any time you could cast an instant.)\nFlying, trample\nWhenever you draw a card, you gain 1 life.",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "a9a369fb-73eb-5046-a04e-52790059743d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78791fc6-054f-45eb-b8b0-28f2512d72b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78791fc6-054f-45eb-b8b0-28f2512d72b6.jpg?1",
             "name": "Kragma Warcaller",
             "text": "Minotaur creatures you control have haste.\nWhenever a Minotaur you control attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -6667,7 +6667,7 @@
         },
         {
             "id": "9ef64e5b-2feb-5710-84d3-687246244f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f4b3cf-2c78-42c9-9873-3758c7f7bb7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f4b3cf-2c78-42c9-9873-3758c7f7bb7d.jpg?1",
             "name": "Medomai the Ageless",
             "text": "Flying\nWhenever Medomai the Ageless deals combat damage to a player, take an extra turn after this one.\nMedomai the Ageless can't attack during extra turns.",
             "colours": [
@@ -6705,7 +6705,7 @@
         },
         {
             "id": "386c6151-346b-5565-b42c-647d3af8c3f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcd1ce-717c-431a-9895-f7701d276743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3dcd1ce-717c-431a-9895-f7701d276743.jpg?1",
             "name": "Pharika's Mender",
             "text": "When Pharika's Mender enters the battlefield, you may return target creature or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -6741,7 +6741,7 @@
         },
         {
             "id": "ded936ed-1b66-54d0-a9a3-d7e3cc61a923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80874006-d057-49b8-981c-1d685ad1474b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80874006-d057-49b8-981c-1d685ad1474b.jpg?1",
             "name": "Polis Crusher",
             "text": "Trample, protection from enchantments\n{4}{R}{G}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.)\nWhenever Polis Crusher deals combat damage to a player, if Polis Crusher is monstrous, destroy target enchantment that player controls.",
             "colours": [
@@ -6777,7 +6777,7 @@
         },
         {
             "id": "fb7dd906-b404-53f1-a89b-82adf6d0e798",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45de923f-fdab-460c-96f4-f62aefa9ad73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45de923f-fdab-460c-96f4-f62aefa9ad73.jpg?1",
             "name": "Prophet of Kruphix",
             "text": "Untap all creatures and lands you control during each other player's untap step.\nYou may cast creature cards as though they had flash.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "fe928bd0-ac91-5192-b655-7158bb3e62a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6e1d03-ad24-4bde-ab3c-28f94e776a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6e1d03-ad24-4bde-ab3c-28f94e776a4e.jpg?1",
             "name": "Psychic Intrusion",
             "text": "Target opponent reveals his or her hand. You choose a nonland card from that player's graveyard or hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -6848,7 +6848,7 @@
         },
         {
             "id": "b0a4bce2-f4b4-54b2-a643-76d5ae332974",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6c78f-b868-4171-b231-4dee45cfa6e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d6c78f-b868-4171-b231-4dee45cfa6e0.jpg?1",
             "name": "Reaper of the Wilds",
             "text": "Whenever another creature dies, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{B}: Reaper of the Wilds gains deathtouch until end of turn.\n{1}{G}: Reaper of the Wilds gains hexproof until end of turn.",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "3b2c2d28-d1aa-5c9e-8ff4-cf8c7c5e0754",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a9c98-1cb4-4c53-a765-c15808c4ab44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018a9c98-1cb4-4c53-a765-c15808c4ab44.jpg?1",
             "name": "Sentry of the Underworld",
             "text": "Flying, vigilance\n{W}{B}, Pay 3 life: Regenerate Sentry of the Underworld.",
             "colours": [
@@ -6921,7 +6921,7 @@
         },
         {
             "id": "43ecff8f-c523-5918-b28f-5e9b61dc659f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ad0c03-66d9-4fe3-bc0d-ca67d959c285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ad0c03-66d9-4fe3-bc0d-ca67d959c285.jpg?1",
             "name": "Shipwreck Singer",
             "text": "Flying\n{1}{U}: Target creature an opponent controls attacks this turn if able.\n{1}{B}, {T}: Attacking creatures get -1/-1 until end of turn.",
             "colours": [
@@ -6957,7 +6957,7 @@
         },
         {
             "id": "f82ee6ab-7903-5b66-9713-caa2e0ba6dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19670c-5afa-4e22-b3ff-258faca19556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a19670c-5afa-4e22-b3ff-258faca19556.jpg?1",
             "name": "Spellheart Chimera",
             "text": "Flying, trample\nSpellheart Chimera's power is equal to the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "84fc40d8-d24b-52ff-8440-24370a58c1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb69801-b574-4b5f-82e7-8fd34cdadf74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb69801-b574-4b5f-82e7-8fd34cdadf74.jpg?1",
             "name": "Steam Augury",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "fc901b35-df67-5db3-b363-7b3e2d7eb139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588a8f90-4344-4882-9671-4c7295186a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588a8f90-4344-4882-9671-4c7295186a58.jpg?1",
             "name": "Triad of Fates",
             "text": "{1}, {T}: Put a fate counter on another target creature.\n{W}, {T}: Exile target creature that has a fate counter on it, then return it to the battlefield under its owner's control.\n{B}, {T}: Exile target creature that has a fate counter on it. Its controller draws two cards.",
             "colours": [
@@ -7066,7 +7066,7 @@
         },
         {
             "id": "4e7b4762-b610-529f-8a86-0b654c6332c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4ce848-a57d-4e88-8093-9fb1408523bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4ce848-a57d-4e88-8093-9fb1408523bc.jpg?1",
             "name": "Tymaret, the Murder King",
             "text": "{1}{R}, Sacrifice another creature: Tymaret, the Murder King deals 2 damage to target player.\n{1}{B}, Sacrifice a creature: Return Tymaret from your graveyard to your hand.",
             "colours": [
@@ -7105,7 +7105,7 @@
         },
         {
             "id": "6b83a1c3-cdee-5e33-9c35-b954645b643c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a078c3d-88db-4459-9667-ce610ae2f660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a078c3d-88db-4459-9667-ce610ae2f660.jpg?1",
             "name": "Underworld Cerberus",
             "text": "Underworld Cerberus can't be blocked except by three or more creatures.\nCards in graveyards can't be the targets of spells or abilities.\nWhen Underworld Cerberus dies, exile it and each player returns all creature cards from his or her graveyard to his or her hand.",
             "colours": [
@@ -7141,7 +7141,7 @@
         },
         {
             "id": "2f4d970e-2031-5bf6-b1d0-46f792485985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecfe99-9c4b-4087-84ee-fb208fd22820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecfe99-9c4b-4087-84ee-fb208fd22820.jpg?1",
             "name": "Xenagos, the Reveler",
             "text": "+1: Add X mana in any combination of {R} and/or {G} to your mana pool, where X is the number of creatures you control.\n0: Put a 2/2 red and green Satyr creature token with haste onto the battlefield.\n-6: Exile the top seven cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield.",
             "colours": [
@@ -7179,7 +7179,7 @@
         },
         {
             "id": "4ddd4c29-d187-585e-846a-1e949bb91b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec95a60f-5164-47f9-9430-11b114c87815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec95a60f-5164-47f9-9430-11b114c87815.jpg?1",
             "name": "Akroan Horse",
             "text": "Defender\nWhen Akroan Horse enters the battlefield, an opponent gains control of it.\nAt the beginning of your upkeep, each opponent puts a 1/1 white Soldier creature token onto the battlefield.",
             "colours": [],
@@ -7210,7 +7210,7 @@
         },
         {
             "id": "591b95c2-e63d-56e1-89dd-67fa12b26c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76330494-ce39-444e-b5da-8905bcccb8ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76330494-ce39-444e-b5da-8905bcccb8ad.jpg?1",
             "name": "Anvilwrought Raptor",
             "text": "Flying, first strike",
             "colours": [],
@@ -7241,7 +7241,7 @@
         },
         {
             "id": "1a6200fd-f88a-5b4d-816f-42e8796f43f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7e563d-964c-4afd-9e21-9d400f8719d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba7e563d-964c-4afd-9e21-9d400f8719d4.jpg?1",
             "name": "Bronze Sable",
             "text": "",
             "colours": [],
@@ -7272,7 +7272,7 @@
         },
         {
             "id": "62e2bb8a-2c0a-505c-8c47-7f0c2d08f49d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772cbcba-9efa-4894-9b57-e73fd296333d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772cbcba-9efa-4894-9b57-e73fd296333d.jpg?1",
             "name": "Burnished Hart",
             "text": "{3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -7303,7 +7303,7 @@
         },
         {
             "id": "fa1ec580-5fd1-5fa7-b9fc-a6ad5a5a0b23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e394ffe-7460-4c59-a403-e9404b0d10c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e394ffe-7460-4c59-a403-e9404b0d10c1.jpg?1",
             "name": "Colossus of Akros",
             "text": "Defender, indestructible\n{1}0: Monstrosity 10. (If this creature isn't monstrous, put ten +1/+1 counters on it and it becomes monstrous.)\nAs long as Colossus of Akros is monstrous, it has trample and can attack as though it didn't have defender.",
             "colours": [],
@@ -7334,7 +7334,7 @@
         },
         {
             "id": "0b8d9eaa-3435-511a-aaa7-d8a512c80690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfa31c9-5a11-4366-9063-056a659f3d0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cfa31c9-5a11-4366-9063-056a659f3d0d.jpg?1",
             "name": "Flamecast Wheel",
             "text": "{5}, {T}, Sacrifice Flamecast Wheel: Flamecast Wheel deals 3 damage to target creature.",
             "colours": [],
@@ -7362,7 +7362,7 @@
         },
         {
             "id": "dfd8a93a-845f-5d51-b388-5df465498f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2222f499-09f9-45a6-8255-9de79df76f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2222f499-09f9-45a6-8255-9de79df76f1c.jpg?1",
             "name": "Fleetfeather Sandals",
             "text": "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "d38d64fe-1d33-5e10-8cad-919626523e76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85284586-7a9d-4344-aebd-f0e072c1f266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85284586-7a9d-4344-aebd-f0e072c1f266.jpg?1",
             "name": "Guardians of Meletis",
             "text": "Defender",
             "colours": [],
@@ -7423,7 +7423,7 @@
         },
         {
             "id": "766a998c-20f8-5cbf-839c-7ed3267c8d8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba304c-9cb8-4d5c-b70d-b7f61a365977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfba304c-9cb8-4d5c-b70d-b7f61a365977.jpg?1",
             "name": "Opaline Unicorn",
             "text": "{T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7454,7 +7454,7 @@
         },
         {
             "id": "ffaacfbd-9547-5f5e-9e6a-121e6929997a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c100a22c-bf34-42b7-9339-4733698c0935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c100a22c-bf34-42b7-9339-4733698c0935.jpg?1",
             "name": "Prowler's Helm",
             "text": "Equipped creature can't be blocked except by Walls.\nEquip {2}",
             "colours": [],
@@ -7484,7 +7484,7 @@
         },
         {
             "id": "6418f321-2d28-569b-9aa5-8836743ccc22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc6a246-f32a-4dc0-9785-4038804f372f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbc6a246-f32a-4dc0-9785-4038804f372f.jpg?1",
             "name": "Pyxis of Pandemonium",
             "text": "{T}: Each player exiles the top card of his or her library face down.\n{7}, {T}, Sacrifice Pyxis of Pandemonium: Each player turns face up all cards he or she owns exiled with Pyxis of Pandemonium, then puts all permanent cards among them onto the battlefield.",
             "colours": [],
@@ -7512,7 +7512,7 @@
         },
         {
             "id": "2023d6ff-81cd-5d50-a1ba-fd485b0204d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245a683f-280e-405c-aa2a-dfabb78dc34e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245a683f-280e-405c-aa2a-dfabb78dc34e.jpg?1",
             "name": "Traveler's Amulet",
             "text": "{1}, Sacrifice Traveler's Amulet: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -7540,7 +7540,7 @@
         },
         {
             "id": "441d58a8-8ca5-506f-8d71-3b2026ce75f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d989daa-78eb-4120-81b5-7866a7b04590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d989daa-78eb-4120-81b5-7866a7b04590.jpg?1",
             "name": "Witches' Eye",
             "text": "Equipped creature has \"{1}, {T}: Scry 1.\" (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)\nEquip {1}",
             "colours": [],
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "2146dc43-13a0-58d5-b622-e2a69fd8ab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b27a0-dfd7-4f96-8cde-cacac4b24acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834b27a0-dfd7-4f96-8cde-cacac4b24acc.jpg?1",
             "name": "Nykthos, Shrine to Nyx",
             "text": "{T}: Add {1} to your mana pool.\n{2}, {T}: Choose a color. Add to your mana pool an amount of mana of that color equal to your devotion to that color. (Your devotion to a color is the number of mana symbols of that color in the mana costs of permanents you control.)",
             "colours": [],
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "e3433b72-1b36-5079-b596-0577b37afcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46febc5d-1625-4e48-bb3f-31ee06fc13dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46febc5d-1625-4e48-bb3f-31ee06fc13dd.jpg?1",
             "name": "Temple of Abandon",
             "text": "Temple of Abandon enters the battlefield tapped.\nWhen Temple of Abandon enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "847fa90a-b899-5c3c-9c83-60cba4d0e0f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686559d7-8ac1-496b-a5a6-1467bf8fc7c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686559d7-8ac1-496b-a5a6-1467bf8fc7c5.jpg?1",
             "name": "Temple of Deceit",
             "text": "Temple of Deceit enters the battlefield tapped.\nWhen Temple of Deceit enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7662,7 +7662,7 @@
         },
         {
             "id": "c0a266ee-64b6-5819-88b6-be4b3caa8271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66945b-3e64-498a-9478-5f96a61d4ec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f66945b-3e64-498a-9478-5f96a61d4ec7.jpg?1",
             "name": "Temple of Mystery",
             "text": "Temple of Mystery enters the battlefield tapped.\nWhen Temple of Mystery enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -7693,7 +7693,7 @@
         },
         {
             "id": "2acc900e-8911-5a65-a77b-40b18555e29d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f14b6b3-5f40-4328-a3be-28fe32dd7cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f14b6b3-5f40-4328-a3be-28fe32dd7cb1.jpg?1",
             "name": "Temple of Silence",
             "text": "Temple of Silence enters the battlefield tapped.\nWhen Temple of Silence enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {W} or {B} to your mana pool.",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "925c9cee-7bd0-5780-a9c9-8522504d4068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f53049c-2491-4d20-aa19-00eb5c55b438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f53049c-2491-4d20-aa19-00eb5c55b438.jpg?1",
             "name": "Temple of Triumph",
             "text": "Temple of Triumph enters the battlefield tapped.\nWhen Temple of Triumph enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "1712e524-94cd-5909-988c-d33daac434c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff118a5-765b-4ba1-8f12-ce6f24b2459b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff118a5-765b-4ba1-8f12-ce6f24b2459b.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "4df17997-b991-56fe-a7ab-c1d900edac2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18013a78-d156-42bf-89b7-72e7070872c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18013a78-d156-42bf-89b7-72e7070872c0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "a721a881-7539-54c9-8de2-4919c7365894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e891d622-9369-4eeb-b7e2-183c60ec54d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e891d622-9369-4eeb-b7e2-183c60ec54d2.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7859,7 +7859,7 @@
         },
         {
             "id": "b748d169-c818-510c-81d4-3d3d1b5aba13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa4b03f-60f1-441f-8066-8bc13d5637d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa4b03f-60f1-441f-8066-8bc13d5637d1.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7897,7 +7897,7 @@
         },
         {
             "id": "8a5cd30b-3cd7-5ffa-aefe-6b11540a4902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37db921-ab2a-46db-82c1-1f1abf7a3cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f37db921-ab2a-46db-82c1-1f1abf7a3cf7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7935,7 +7935,7 @@
         },
         {
             "id": "0adc470d-9e5d-5011-8827-6b5cd1ad4d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d851b88b-6ce6-4889-83c2-e191307bcee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d851b88b-6ce6-4889-83c2-e191307bcee6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "e9b566da-fd12-58cf-ae6d-59a1271b19cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac928336-f534-4682-a952-c536a1b14e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac928336-f534-4682-a952-c536a1b14e1e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8011,7 +8011,7 @@
         },
         {
             "id": "36730c74-4f7b-53e8-92c0-4a4e6e8e2357",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c266e3-d403-434a-b645-dcb9cf441680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c266e3-d403-434a-b645-dcb9cf441680.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8049,7 +8049,7 @@
         },
         {
             "id": "ae863d06-4045-5bd6-8e62-41472ed6aeb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51852e9d-9183-4f9a-a724-cb60cf677e38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51852e9d-9183-4f9a-a724-cb60cf677e38.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8087,7 +8087,7 @@
         },
         {
             "id": "3a69d732-3920-5989-882d-0e554c08a797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b153bb8-f9d9-44dc-ae19-d0eb2ea26ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b153bb8-f9d9-44dc-ae19-d0eb2ea26ba1.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "864bfd43-ab00-5568-a4b9-10605e3a1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc9f472-c410-4595-b08d-87c115b9148d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc9f472-c410-4595-b08d-87c115b9148d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8163,7 +8163,7 @@
         },
         {
             "id": "f5e6f375-d476-5931-ba2f-e22a0e496ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a9a01-46fb-4e9d-8e7d-5f2c267ab1f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e49a9a01-46fb-4e9d-8e7d-5f2c267ab1f9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8201,7 +8201,7 @@
         },
         {
             "id": "105cec81-df12-5d34-a7e0-ed00c87f7af9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81047292-e537-47b5-acfa-ed839707109c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81047292-e537-47b5-acfa-ed839707109c.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8239,7 +8239,7 @@
         },
         {
             "id": "3e491015-5d10-5ffe-9f7b-e7704c76f977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78801a7-af8c-4f1d-b29e-7a36676b6818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78801a7-af8c-4f1d-b29e-7a36676b6818.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8277,7 +8277,7 @@
         },
         {
             "id": "0f5e0f6f-414d-5cca-a1e3-8321f7dc5180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0a5a9c-e59a-4e33-b584-d6daa7f81547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0a5a9c-e59a-4e33-b584-d6daa7f81547.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8315,7 +8315,7 @@
         },
         {
             "id": "a10db8c0-1614-596f-8779-62cf89a028e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7245d4-7a29-4423-8b44-5e9694e1d9a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7245d4-7a29-4423-8b44-5e9694e1d9a1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "447e0157-bd87-5d35-ab1a-64574586a30c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29557b92-fded-4aa8-8db7-99168c8e70d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29557b92-fded-4aa8-8db7-99168c8e70d8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8391,7 +8391,7 @@
         },
         {
             "id": "b1062523-47d5-5912-829d-5f08f0e0c2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1469-94b9-4964-ada6-4fb43b0b9282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfd1469-94b9-4964-ada6-4fb43b0b9282.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "c5363eac-648d-5cf6-bf16-052a9391fce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a37f57-5d3e-488e-a909-f53bd4c2576b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a37f57-5d3e-488e-a909-f53bd4c2576b.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8467,7 +8467,7 @@
         },
         {
             "id": "27e3e966-5ec2-515d-89bf-c160e50fbf7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b34d7-e2a6-4cbc-9d5f-b6fe05a1c701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f13b34d7-e2a6-4cbc-9d5f-b6fe05a1c701.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8505,7 +8505,7 @@
         },
         {
             "id": "bee00f89-d874-53d0-833b-6d9b006412ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a80d346-84e3-4eaf-9635-09da472475d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a80d346-84e3-4eaf-9635-09da472475d8.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8543,7 +8543,7 @@
         },
         {
             "id": "41f58752-13d7-531e-803c-97dcf276ac58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4c9173-e530-4237-a03b-9aeca60ab0e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4c9173-e530-4237-a03b-9aeca60ab0e4.jpg?1",
             "name": "Cleric",
             "text": "",
             "colours": [
@@ -8578,7 +8578,7 @@
         },
         {
             "id": "bbea12aa-a847-5a57-b8d3-2c247d82f7da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f320f4-baae-46cb-840e-421f010a0a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f320f4-baae-46cb-840e-421f010a0a20.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8612,7 +8612,7 @@
         },
         {
             "id": "d4ada9c2-4c71-59c8-a16f-9316fa9955de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c8e63-1462-4ad6-8872-216384160b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/688c8e63-1462-4ad6-8872-216384160b58.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8646,7 +8646,7 @@
         },
         {
             "id": "ffd6ec4a-93f8-5371-a1e0-4957168a2bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca72703f-d45b-4c80-98a8-55fad1fcf431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca72703f-d45b-4c80-98a8-55fad1fcf431.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -8680,7 +8680,7 @@
         },
         {
             "id": "14d38ed8-49f6-5ef4-bb6a-db81e08afeb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e68ed9-d863-4822-b281-e184f3d62faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e68ed9-d863-4822-b281-e184f3d62faa.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8714,7 +8714,7 @@
         },
         {
             "id": "665541d3-79df-5179-8339-762a1d974503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b24bbe-f5bc-44d3-b716-6612d39b07bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b24bbe-f5bc-44d3-b716-6612d39b07bc.jpg?1",
             "name": "Harpy",
             "text": "",
             "colours": [
@@ -8748,7 +8748,7 @@
         },
         {
             "id": "54e19b43-4fbd-56b2-97ed-9cfc0f5381f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e44d4-72c1-4d68-b942-c3e8de6ed7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/509e44d4-72c1-4d68-b942-c3e8de6ed7a8.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8782,7 +8782,7 @@
         },
         {
             "id": "dc555351-c611-56b1-be9a-81cc7fc72722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f40613b-1bde-4939-86ad-6bd40f9db0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f40613b-1bde-4939-86ad-6bd40f9db0d6.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "5ddad5c0-c242-5bc9-a33e-a5ddc2156f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa93038-2849-4c26-ab4f-1d50d276659f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa93038-2849-4c26-ab4f-1d50d276659f.jpg?1",
             "name": "Satyr",
             "text": "",
             "colours": [
@@ -8852,7 +8852,7 @@
         },
         {
             "id": "aabe516a-3436-5a37-b36d-ef4beb5c470a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee70ef-6285-4f09-8a71-8b7960e8fa99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcee70ef-6285-4f09-8a71-8b7960e8fa99.jpg?1",
             "name": "Golem",
             "text": "",
             "colours": [],
@@ -8884,7 +8884,7 @@
         },
         {
             "id": "c577e7bc-c4c4-5106-afc0-ad752fbf494b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177c37bd-c53d-43b2-88c4-0b80d17a5744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/177c37bd-c53d-43b2-88c4-0b80d17a5744.jpg?1",
             "name": "Elspeth, Sun's Champion Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/TMP.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/TMP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f0d7f313-cdb1-5759-be20-ad93098bcaa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ce7e1e-ffe5-4ced-8967-9a6917245240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ce7e1e-ffe5-4ced-8967-9a6917245240.jpg?1",
             "name": "Advance Scout",
             "text": "First strike\no\nW: Target creature gains first strike until end of turn.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "97439bc8-720f-5439-914d-d43f8c7fb59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44faefbe-d5e7-48f3-ba88-833da0b19707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44faefbe-d5e7-48f3-ba88-833da0b19707.jpg?1",
             "name": "Angelic Protector",
             "text": "Flying\nIf Angelic Protector is the target of a spell or ability, it gets +0/+3 until end of turn.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "1b87afc9-0ade-589e-b8af-80a58f3be05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65ee0f-fdd7-4a5e-a4a3-5dd9c62096ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca65ee0f-fdd7-4a5e-a4a3-5dd9c62096ab.jpg?1",
             "name": "Anoint",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPrevent up to 3 damage to any creature.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "1ddd86ce-9016-59e3-96de-6c6634039d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c275aba7-cac6-48e8-b12c-6bd77a5c38fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c275aba7-cac6-48e8-b12c-6bd77a5c38fe.jpg?1",
             "name": "Armor Sliver",
             "text": "Each Sliver gains \"o2: This creature gets +0/+1 until end of turn.\"",
             "colours": [
@@ -136,7 +136,7 @@
         },
         {
             "id": "64e9fdd5-50d9-58e7-90db-da4067c3e37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012049f8-0936-49ed-948d-0d34af28550f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012049f8-0936-49ed-948d-0d34af28550f.jpg?1",
             "name": "Armored Pegasus",
             "text": "Flying",
             "colours": [
@@ -169,7 +169,7 @@
         },
         {
             "id": "f6b7417f-6f43-57c6-b036-27211d462d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dca066-d5e3-442a-95a0-e695c1d5850c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86dca066-d5e3-442a-95a0-e695c1d5850c.jpg?1",
             "name": "Auratog",
             "text": "Sacrifice an enchantment: Auratog gets +2/+2 until end of turn.",
             "colours": [
@@ -202,7 +202,7 @@
         },
         {
             "id": "4e6979af-ea4e-5097-a26f-dfe15827a947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28333138-60bc-459b-a0cd-1b7fd19c89cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28333138-60bc-459b-a0cd-1b7fd19c89cd.jpg?1",
             "name": "Avenging Angel",
             "text": "Flying\nIf Avenging Angel is put into any graveyard from play, you may put Avenging Angel on top of owner's library.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "f9daa28e-2ef6-548d-8e95-756844099cf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6dda88-fc2a-4404-8a82-40c5d77860da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da6dda88-fc2a-4404-8a82-40c5d77860da.jpg?1",
             "name": "Circle of Protection: Black",
             "text": "o1: Prevent all damage to you from a black source. (Treat further damage from that source normally.)",
             "colours": [
@@ -266,7 +266,7 @@
         },
         {
             "id": "7f917c34-02bb-5422-8677-295e62eb3f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430fb60-78f6-4577-9ec5-a93d6662ef76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0430fb60-78f6-4577-9ec5-a93d6662ef76.jpg?1",
             "name": "Circle of Protection: Blue",
             "text": "o1: Prevent all damage to you from a blue source. (Treat further damage from that source normally.)",
             "colours": [
@@ -297,7 +297,7 @@
         },
         {
             "id": "909d173a-ec1f-522e-872e-9755c1dee71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c76e49-ddd2-4967-a81a-86405260b4bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c76e49-ddd2-4967-a81a-86405260b4bc.jpg?1",
             "name": "Circle of Protection: Green",
             "text": "o1: Prevent all damage to you from a green source. (Treat further damage from that source normally.)",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "ffc7da4f-5b80-5be2-b242-8594946203bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38872d-f389-43aa-b6f7-97b2c90e5a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc38872d-f389-43aa-b6f7-97b2c90e5a1f.jpg?1",
             "name": "Circle of Protection: Red",
             "text": "o1: Prevent all damage to you from a red source. (Treat further damage from that source normally.)",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "77b42787-9b79-5863-a863-d01f0a96fc92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f29a3b-7136-496c-bc29-8808bfff0f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f29a3b-7136-496c-bc29-8808bfff0f82.jpg?1",
             "name": "Circle of Protection: Shadow",
             "text": "o1: Prevent all damage to you from a creature with shadow. (Treat further damage from that source normally.)",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "60a8b937-86ab-5943-9158-ec2a8115fcaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eff4351-5501-4061-a409-49f518ba9628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eff4351-5501-4061-a409-49f518ba9628.jpg?1",
             "name": "Circle of Protection: White",
             "text": "o1: Prevent all damage to you from a white source. (Treat further damage from that source normally.)",
             "colours": [
@@ -421,7 +421,7 @@
         },
         {
             "id": "4b9571b7-6012-5544-bc67-d64bebc8beb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb0e068-16d0-4e1c-acad-0a6d34148c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcb0e068-16d0-4e1c-acad-0a6d34148c5a.jpg?1",
             "name": "Clergy en-Vec",
             "text": "oc\nT: Prevent 1 damage to any creature or player.",
             "colours": [
@@ -455,7 +455,7 @@
         },
         {
             "id": "9ad7b6f9-7502-5c24-9044-9057cc9bb882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a70a6da-dea3-49c0-8c49-6a2229c3ac91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a70a6da-dea3-49c0-8c49-6a2229c3ac91.jpg?1",
             "name": "Cloudchaser Eagle",
             "text": "Flying\nWhen Cloudchaser Eagle comes into play, destroy target enchantment.",
             "colours": [
@@ -488,7 +488,7 @@
         },
         {
             "id": "dd87e4e9-be52-54a0-beda-cd8a5f8d52d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65e678-dcb9-4c6c-9a30-8332030dead6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a65e678-dcb9-4c6c-9a30-8332030dead6.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -519,7 +519,7 @@
         },
         {
             "id": "cfef9a05-78ab-51d6-b362-ac07affa6d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1c730f-76da-4eae-b3fc-b428b860ea93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1c730f-76da-4eae-b3fc-b428b860ea93.jpg?1",
             "name": "Elite Javelineer",
             "text": "If Elite Javelineer blocks, it deals 1 damage to target attacking creature.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "42e50284-68c2-5bb0-87a0-4309b505432b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9816a3ef-e2a8-4d97-afbf-d190a62265bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9816a3ef-e2a8-4d97-afbf-d190a62265bf.jpg?1",
             "name": "Field of Souls",
             "text": "Whenever a nontoken creature is put into your graveyard from play, put an Essence token into play. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "14a1fb0b-1f97-5607-a511-48f83e896ce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d2b011-bb0d-463c-bf2a-04b6650771a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d2b011-bb0d-463c-bf2a-04b6650771a3.jpg?1",
             "name": "Flickering Ward",
             "text": "When you play Flickering Ward, choose a color.\nEnchanted creature gains protection from the chosen color.\no\nW: Return Flickering Ward to owner's hand.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "d5fdc3c8-52d5-5579-a937-694f068e629a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdca3b-7d53-4d19-bd15-9a1b148c4aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccdca3b-7d53-4d19-bd15-9a1b148c4aaf.jpg?1",
             "name": "Gallantry",
             "text": "Target blocking creature gets +4/+4 until end of turn.\nDraw a card.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "7a1e696a-823a-5b77-9bdd-eb94e956b242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504950d5-2df7-4518-b987-fe3a57ad1c58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/504950d5-2df7-4518-b987-fe3a57ad1c58.jpg?1",
             "name": "Gerrard's Battle Cry",
             "text": "o2o\nW: All creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "378efd48-3f84-58d9-bff3-f0c2678f16fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea44536-ef4e-4dcf-9c1a-c1122dd00cbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea44536-ef4e-4dcf-9c1a-c1122dd00cbb.jpg?1",
             "name": "Hanna's Custody",
             "text": "Artifacts cannot be the target of spells or abilities.",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "f17dda3c-40f3-5fd6-8c78-6caab0d80f95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4cdcc7c-0d01-4aa2-8934-079dfc00eef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4cdcc7c-0d01-4aa2-8934-079dfc00eef2.jpg?1",
             "name": "Hero's Resolve",
             "text": "Enchanted creature gets +1/+5.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "dab4f41a-6119-54ed-adb8-d95c99344220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fb7128-806b-4148-80fe-eb967f248021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fb7128-806b-4148-80fe-eb967f248021.jpg?1",
             "name": "Humility",
             "text": "Each creature loses all abilities and is a 1/1 creature.",
             "colours": [
@@ -774,7 +774,7 @@
         },
         {
             "id": "4af22df6-28be-5218-a11f-aacdd855beff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66d1f00-e857-4bc3-a36d-a33669d281e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66d1f00-e857-4bc3-a36d-a33669d281e9.jpg?1",
             "name": "Invulnerability",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPrevent all damage to you from one source. (Treat further damage from that source normally.)",
             "colours": [
@@ -805,7 +805,7 @@
         },
         {
             "id": "9c70f5e6-d389-520e-8d9c-c2330e844f4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e5034-a134-4eb6-af8e-b2419b92b3a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e5034-a134-4eb6-af8e-b2419b92b3a6.jpg?1",
             "name": "Knight of Dawn",
             "text": "First strike\no\nWo\nW: Knight of Dawn gains protection from the color of your choice until end of turn.",
             "colours": [
@@ -839,7 +839,7 @@
         },
         {
             "id": "fe2e4f4c-70c9-5102-a3fd-2ab1825b27a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fa9ebe-bdf5-4359-aa3e-6cfa1a1d96cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70fa9ebe-bdf5-4359-aa3e-6cfa1a1d96cf.jpg?1",
             "name": "Light of Day",
             "text": "Black creatures cannot attack or block",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "7fcc24d5-b9ea-5e6d-a4f9-d96e88ac55e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca62c97-0bbd-4f74-afd5-99b48c063aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca62c97-0bbd-4f74-afd5-99b48c063aa0.jpg?1",
             "name": "Marble Titan",
             "text": "Creatures with power 3 or greater do not untap during their controllers' untap phases.",
             "colours": [
@@ -903,7 +903,7 @@
         },
         {
             "id": "a3da25ea-cb80-5d73-9eb2-caadc742aa03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e11097-1ace-4ae8-a9e8-d00b9f709e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e11097-1ace-4ae8-a9e8-d00b9f709e54.jpg?1",
             "name": "Master Decoy",
             "text": "o\nW, oc\nT: Tap target creature.",
             "colours": [
@@ -937,7 +937,7 @@
         },
         {
             "id": "85984128-0760-5588-ab52-c67b39cd951f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3abcf2-fe52-4096-8fdb-6917d75a04e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f3abcf2-fe52-4096-8fdb-6917d75a04e3.jpg?1",
             "name": "Mounted Archers",
             "text": "Mounted Archers can block creatures with flying.\no\nW: Mounted Archers can block an additional creature this turn. (All blocking assignments must still be legal.)",
             "colours": [
@@ -972,7 +972,7 @@
         },
         {
             "id": "3b904b30-52ec-5e10-b00a-00a048a14fb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc538730-c46c-4e5f-bc1f-0efb7765086d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc538730-c46c-4e5f-bc1f-0efb7765086d.jpg?1",
             "name": "Oracle en-Vec",
             "text": "oc\nT: Target opponent chooses any number of creatures he or she controls. During that player's next turn, those creatures attack if able, and no other creatures can attack. At the end of that turn, destroy each of those creatures that did not attack. Use this ability only during your turn.",
             "colours": [
@@ -1006,7 +1006,7 @@
         },
         {
             "id": "142684db-8e16-590c-82a3-0864a48d5a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc45565-4b56-49ba-b115-be8e0de7d937.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc45565-4b56-49ba-b115-be8e0de7d937.jpg?1",
             "name": "Orim's Prayer",
             "text": "If any creatures attack you, gain 1 life for each attacking creature.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "dbd59829-b65a-5695-b1ee-42e88a4eb899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7086d077-f083-4870-8b0b-2d34aca49df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7086d077-f083-4870-8b0b-2d34aca49df1.jpg?1",
             "name": "Orim, Samite Healer",
             "text": "Orim, Samite Healer counts as a Cleric.\noc\nT: Prevent up to 3 damage to any creature or player.",
             "colours": [
@@ -1073,7 +1073,7 @@
         },
         {
             "id": "ac654749-a783-52c2-9681-9c0d884477c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6492bf53-ad49-4cd5-83df-0005a5b77811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6492bf53-ad49-4cd5-83df-0005a5b77811.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature cannot attack or block.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "9c903bb2-491a-54bb-9e88-2f4b9ca65d68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bce334-0ae6-4a7d-85db-99ee205ce546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2bce334-0ae6-4a7d-85db-99ee205ce546.jpg?1",
             "name": "Pegasus Refuge",
             "text": "o2, Choose and discard a card: Put a Pegasus token into play. Treat this token as a 1/1 white creature with flying.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "bdd1151a-2828-57a6-bd41-ba22af8bbf98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e91f3d-5a23-4df1-a879-d18a3af92a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e91f3d-5a23-4df1-a879-d18a3af92a28.jpg?1",
             "name": "Quickening Licid",
             "text": "o1o\nW, oc\nT: Quickening Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature gains first strike\" instead of a creature. Move Quickening Licid onto target creature. You may pay o\nW to end this effect.",
             "colours": [
@@ -1170,7 +1170,7 @@
         },
         {
             "id": "a2c0a9da-4995-54c4-80d7-1d4a8f9e7984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e28ac76-c671-4be1-bcfc-17f2d7bbe08f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e28ac76-c671-4be1-bcfc-17f2d7bbe08f.jpg?1",
             "name": "Repentance",
             "text": "Target creature deals to itself damage equal to its power.",
             "colours": [
@@ -1201,7 +1201,7 @@
         },
         {
             "id": "e837fa66-1bbf-5af3-96d0-9433384edb7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f10c37d-d25a-47d6-83b0-dbe0a9cfc938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f10c37d-d25a-47d6-83b0-dbe0a9cfc938.jpg?1",
             "name": "Sacred Guide",
             "text": "o1o\nW, Sacrifice Sacred Guide: Reveal cards from your library until you reveal a white card. Put that card into your hand. Remove all other revealed cards from the game.",
             "colours": [
@@ -1235,7 +1235,7 @@
         },
         {
             "id": "21745536-d59b-5df7-bcc0-80abf4cfaa14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8e174c-7abb-4a93-aa1d-8c2a2e815ba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c8e174c-7abb-4a93-aa1d-8c2a2e815ba6.jpg?1",
             "name": "Safeguard",
             "text": "o2o\nW: Target creature deals no combat damage this turn.",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "f3f30fef-73b8-5513-b632-34ed37f3443c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0b3795-7f30-4c61-b5d8-f238055d6be1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0b3795-7f30-4c61-b5d8-f238055d6be1.jpg?1",
             "name": "Serene Offering",
             "text": "Destroy target enchantment. Gain life equal to that enchantment's total casting cost.",
             "colours": [
@@ -1297,7 +1297,7 @@
         },
         {
             "id": "e0d18b0e-e286-5892-a16f-03313d9c0c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd07471-b216-465c-9946-1eac689db32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd07471-b216-465c-9946-1eac689db32e.jpg?1",
             "name": "Soltari Crusader",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no1o\nW: Soltari Crusader gets +1/+0 until end of turn.",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "230effb4-ebf3-5707-b579-ab33c18ace8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18751d3-052b-4ae5-ba07-16f00a1af40e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18751d3-052b-4ae5-ba07-16f00a1af40e.jpg?1",
             "name": "Soltari Emissary",
             "text": "o\nW: Soltari Emissary gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "ed8b0bc5-9da3-503d-a5f9-bedadc07a2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf295dc-72df-4097-b767-d89ab807bf2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf295dc-72df-4097-b767-d89ab807bf2e.jpg?1",
             "name": "Soltari Foot Soldier",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "9b1e4e0b-d196-51fa-a849-5da843fe6134",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b6c91-dd07-4d39-bd36-6fbf28e7698e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4b6c91-dd07-4d39-bd36-6fbf28e7698e.jpg?1",
             "name": "Soltari Lancer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nFirst strike when attacking",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "b8fdc4bd-74f4-5ff1-8f30-6a2470bab2bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0d969-3e4d-4ff9-8bda-3a6ac8df01b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54e0d969-3e4d-4ff9-8bda-3a6ac8df01b2.jpg?1",
             "name": "Soltari Monk",
             "text": "Protection from black; shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "c4d46cf7-f639-552e-a558-6413a4600024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a71390-3fa8-43eb-ad86-67de2a7aeab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a71390-3fa8-43eb-ad86-67de2a7aeab8.jpg?1",
             "name": "Soltari Priest",
             "text": "Protection from red; shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -1502,7 +1502,7 @@
         },
         {
             "id": "dd2b0963-7821-50f8-a124-82d6b53a8719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f74aa3-4003-4f53-b774-22b111935391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32f74aa3-4003-4f53-b774-22b111935391.jpg?1",
             "name": "Soltari Trooper",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Trooper attacks, it gets +1/+1 until end of turn.",
             "colours": [
@@ -1536,7 +1536,7 @@
         },
         {
             "id": "e7757853-c2f9-5ead-b62b-2085ce328c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7089c9-70ba-4009-86a5-d4e322c00fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a7089c9-70ba-4009-86a5-d4e322c00fba.jpg?1",
             "name": "Spirit Mirror",
             "text": "During your upkeep, if there are no Reflection tokens in play, put a Reflection token into play. Treat this token as a 2/2 white creature.\no0: Destroy target Reflection.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "59f0923a-5156-5c0a-9a78-cb3acbd4845d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed7210-17a4-4750-a003-617ba75bff3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ed7210-17a4-4750-a003-617ba75bff3e.jpg?1",
             "name": "Staunch Defenders",
             "text": "When Staunch Defenders comes into play, gain 4 life.",
             "colours": [
@@ -1601,7 +1601,7 @@
         },
         {
             "id": "0d2d72eb-dd17-5444-a784-c17f8735e873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186c4b1-b7ec-46eb-a961-257411b401b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f186c4b1-b7ec-46eb-a961-257411b401b0.jpg?1",
             "name": "Talon Sliver",
             "text": "All Slivers gain first strike.",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "afe8af21-4063-5bb1-9d16-df2ebf1fdfb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbeea8-06b0-4482-bdae-aa82b9db8856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dbeea8-06b0-4482-bdae-aa82b9db8856.jpg?1",
             "name": "Warmth",
             "text": "Whenever target opponent successfully casts a red spell, gain 2 life.",
             "colours": [
@@ -1665,7 +1665,7 @@
         },
         {
             "id": "3727b742-eb55-5480-b01e-b0ee820c68a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d731b2-0113-4fd5-8b78-1aa1064bb4f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6d731b2-0113-4fd5-8b78-1aa1064bb4f5.jpg?1",
             "name": "Winds of Rath",
             "text": "Destroy all creatures with no enchantments on them. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "76b7f8c1-e457-52b3-8bdb-af867e39f8d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f610d8b-1782-43a4-bfb3-40887bdedba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f610d8b-1782-43a4-bfb3-40887bdedba0.jpg?1",
             "name": "Worthy Cause",
             "text": "Buyback o2 (You may pay an additional o2 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nSacrifice a creature: Gain life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -1727,7 +1727,7 @@
         },
         {
             "id": "60052f07-1cf8-51f2-a292-c38a8763ba52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9fb7b6-d20c-4c08-9dae-4ccc9138b662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc9fb7b6-d20c-4c08-9dae-4ccc9138b662.jpg?1",
             "name": "Benthic Behemoth",
             "text": "Islandwalk (If defending player controls any islands, this creature is unblockable.)",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "fa277afa-5e22-5f66-8f57-a1b36c0bd4c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e538b359-d893-422d-9d60-5f3e8ee0fa9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e538b359-d893-422d-9d60-5f3e8ee0fa9e.jpg?1",
             "name": "Capsize",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nReturn target permanent to owner's hand.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "8ebc5af2-45f2-5734-869b-475a60861e00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7bd777-6f11-441e-887f-9cee1ef96035.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7bd777-6f11-441e-887f-9cee1ef96035.jpg?1",
             "name": "Chill",
             "text": "Red spells cost an additional o2 to play.",
             "colours": [
@@ -1822,7 +1822,7 @@
         },
         {
             "id": "03debc19-ddaa-5ff2-9474-f2bb9e3210f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdd380-71cf-4832-bd02-3697501325f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dacdd380-71cf-4832-bd02-3697501325f3.jpg?1",
             "name": "Counterspell",
             "text": "Counter target spell.",
             "colours": [
@@ -1853,7 +1853,7 @@
         },
         {
             "id": "50a7645d-aaa0-58da-a250-3c900a6119e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e55d6be-7682-4786-9872-e847afd710b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e55d6be-7682-4786-9872-e847afd710b0.jpg?1",
             "name": "Dismiss",
             "text": "Counter target spell.\nDraw a card.",
             "colours": [
@@ -1884,7 +1884,7 @@
         },
         {
             "id": "b3537ac6-03ef-51ef-8800-2dd6275b7e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875f81cf-5f27-451e-9248-746fad1e43d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875f81cf-5f27-451e-9248-746fad1e43d7.jpg?1",
             "name": "Dream Cache",
             "text": "Draw three cards. Choose two cards from your hand and put both on either the top or the bottom of your library.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "4b2e6481-b18f-5f67-a83f-60b34879471d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529cb33-292d-40e3-8cfe-db5eeb0d711e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d529cb33-292d-40e3-8cfe-db5eeb0d711e.jpg?1",
             "name": "Duplicity",
             "text": "When Duplicity comes into play, put the top five cards of your library face down on Duplicity.\nDuring your upkeep, you may exchange all the cards in your hand for the cards on Duplicity.\nAt the end of your turn, choose and discard a card.\nIf you lose control of Duplicity, put all cards on it into owner's graveyard.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "dd3eaad9-b4e2-5cba-a484-067b6f6ccc8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7e7fa-1493-4ef8-9cdb-b02b07a1ad85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35c7e7fa-1493-4ef8-9cdb-b02b07a1ad85.jpg?1",
             "name": "Ertai's Meddling",
             "text": "When target spell is successfully cast, put X delay counters on it. X cannot be 0.\nDuring each upkeep of that spell's caster, remove a delay counter from the spell. If the spell has no delay counters on it, it resolves.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "96b7e149-cd52-55ed-baef-77bc29fc2984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0171d4f-c871-4a7f-821a-82b7f401e9ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0171d4f-c871-4a7f-821a-82b7f401e9ca.jpg?1",
             "name": "Escaped Shapeshifter",
             "text": "As long as your opponent controls any creatures with flying, Escaped Shapeshifter gains flying. The same is true for first strike, trample, and protection from any color.",
             "colours": [
@@ -2010,7 +2010,7 @@
         },
         {
             "id": "da13a986-6280-50bd-bd0c-417e29832679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be436b65-9193-45ca-93e0-c5e9718f7e72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be436b65-9193-45ca-93e0-c5e9718f7e72.jpg?1",
             "name": "Fighting Drake",
             "text": "Flying",
             "colours": [
@@ -2043,7 +2043,7 @@
         },
         {
             "id": "e68555fd-f321-54e8-b853-05647abbb5b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4f686-79e3-4067-81f9-7fae0c25dc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd4f686-79e3-4067-81f9-7fae0c25dc8f.jpg?1",
             "name": "Fylamarid",
             "text": "Flying\nFylamarid cannot be blocked by blue creatures.\no\nU: Target creature is blue until end of turn.",
             "colours": [
@@ -2077,7 +2077,7 @@
         },
         {
             "id": "1b181f7e-d47f-53a9-9257-5d09d34dca59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8402d6-b509-4771-ba80-128db343880d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8402d6-b509-4771-ba80-128db343880d.jpg?1",
             "name": "Gaseous Form",
             "text": "Enchanted creature neither deals nor receives combat damage.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "fef756f5-e1eb-58eb-aef9-a9d4c560f756",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c65a35-e219-4b60-ab95-ce7eff67d646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c65a35-e219-4b60-ab95-ce7eff67d646.jpg?1",
             "name": "Giant Crab",
             "text": "o\nU: Until end of turn, Giant Crab cannot be the target of spells or abilities.",
             "colours": [
@@ -2143,7 +2143,7 @@
         },
         {
             "id": "45806b72-c2d4-56cb-8de9-ce6237a8c1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348ce1-6305-42a7-8061-64275f6dc5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2348ce1-6305-42a7-8061-64275f6dc5c6.jpg?1",
             "name": "Horned Turtle",
             "text": "",
             "colours": [
@@ -2176,7 +2176,7 @@
         },
         {
             "id": "1bb3b4b6-e77c-5f2a-8b24-4551e5e44b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfd9cb9-51f6-4d09-b5c0-5b0ed9d16542.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1dfd9cb9-51f6-4d09-b5c0-5b0ed9d16542.jpg?1",
             "name": "Insight",
             "text": "Whenever target opponent successfully casts a green spell, draw a card.",
             "colours": [
@@ -2207,7 +2207,7 @@
         },
         {
             "id": "d9b1df67-45ee-5de6-a68d-f27b7c65cb93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3442c919-73b9-4d29-a014-87293f456325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3442c919-73b9-4d29-a014-87293f456325.jpg?1",
             "name": "Interdict",
             "text": "Counter target artifact, creature, enchantment, or land ability requiring an activation cost. Abilities of that permanent cannot be played again this turn.\nDraw a card.",
             "colours": [
@@ -2238,7 +2238,7 @@
         },
         {
             "id": "349602f1-ca72-53a4-809a-d0431bc18041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f6785-e5a1-4fdc-9fb5-e1a372e7e848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c99f6785-e5a1-4fdc-9fb5-e1a372e7e848.jpg?1",
             "name": "Intuition",
             "text": "Search your library for any three cards and reveal them to target opponent. He or she chooses one. Put that card into your hand and the rest into your graveyard. Shuffle your library afterwards.",
             "colours": [
@@ -2269,7 +2269,7 @@
         },
         {
             "id": "1560a1af-eb61-55c2-82f3-ac3c737e7610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a89c5-71bd-4fee-ae35-78081e4e0353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649a89c5-71bd-4fee-ae35-78081e4e0353.jpg?1",
             "name": "Legacy's Allure",
             "text": "During your upkeep, you may put a treasure counter on Legacy's Allure.\nSacrifice Legacy's Allure: Permanently gain control of target creature with power no greater than the number of treasure counters on Legacy's Allure.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "6f45ac4c-2ec2-5ff2-b51a-48dfc8240143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65506830-fa2c-4e3b-9f64-5a569dd28249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65506830-fa2c-4e3b-9f64-5a569dd28249.jpg?1",
             "name": "Legerdemain",
             "text": "Permanently exchange control of target artifact or creature for control of target permanent of the same type.",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "af860e7e-a714-575a-a282-a01fb80be3cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854dc5e6-63f7-4c8b-83e5-a364f41c9a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854dc5e6-63f7-4c8b-83e5-a364f41c9a15.jpg?1",
             "name": "Mana Severance",
             "text": "Search your library for any number of land cards and remove them from the game. Shuffle your library afterwards.",
             "colours": [
@@ -2362,7 +2362,7 @@
         },
         {
             "id": "d2efd5cd-35c6-51ed-acd7-8c3b1e6d6fd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdff306c-1c7e-49ae-b10f-99e1927bbef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdff306c-1c7e-49ae-b10f-99e1927bbef1.jpg?1",
             "name": "Manta Riders",
             "text": "o\nU: Manta Riders gains flying until end of turn.",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "3d925d81-2f26-543f-97b3-e4d479809557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f50971e-2a18-4db7-8b5b-83dd5e85766e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f50971e-2a18-4db7-8b5b-83dd5e85766e.jpg?1",
             "name": "Mawcor",
             "text": "Flying\noc\nT: Mawcor deals 1 damage to target creature or player.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "c5cee9c7-5cd3-502b-84ce-462c008a2f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb79a97-c1fc-4aa3-bb13-3d24a6dabeea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb79a97-c1fc-4aa3-bb13-3d24a6dabeea.jpg?1",
             "name": "Meditate",
             "text": "Skip your next turn: Draw four cards.",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "c7454834-abdc-5657-8b1e-1ed037109693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b167347-2f8f-4338-a651-c7543d812597.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b167347-2f8f-4338-a651-c7543d812597.jpg?1",
             "name": "Mnemonic Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: Draw a card.\"",
             "colours": [
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "a77b7d97-bba9-5fae-805e-842d8abdff91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc58c34-c3de-47f8-a42f-3a974dcb9c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abc58c34-c3de-47f8-a42f-3a974dcb9c47.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless its caster pays an additional o\nX. If he or she does not, tap all mana-producing lands that player controls and remove all mana from his or her mana pool.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "7ad6534b-af42-5a16-a84e-31e9177b4182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a0e317-5a76-4eac-a903-b0e3f0a45873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76a0e317-5a76-4eac-a903-b0e3f0a45873.jpg?1",
             "name": "Precognition",
             "text": "During your upkeep, you may look at the top card of target opponent's library. You may then put that card on the bottom of his or her library.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "70bc2262-21c2-539d-affb-f5e9bb187ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67dde4d-3df1-480d-a8b8-ab22c768bb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67dde4d-3df1-480d-a8b8-ab22c768bb12.jpg?1",
             "name": "Propaganda",
             "text": "Each turn, each creature cannot attack you unless its controller pays an additional o2 for that creature.",
             "colours": [
@@ -2585,7 +2585,7 @@
         },
         {
             "id": "c37c6c88-8448-5205-91b4-841c2c4626f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6315323-cf82-46c0-b164-e6ea1bf809f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6315323-cf82-46c0-b164-e6ea1bf809f4.jpg?1",
             "name": "Rootwater Diver",
             "text": "oc\nT, Sacrifice Rootwater Diver: Return target artifact card from your graveyard to your hand.",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "97afb46f-6080-5da9-967c-4b19eff3400f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf7ea34-2cde-4ec5-9b12-99b0002da986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdf7ea34-2cde-4ec5-9b12-99b0002da986.jpg?1",
             "name": "Rootwater Hunter",
             "text": "oc\nT: Rootwater Hunter deals 1 damage to target creature or player.",
             "colours": [
@@ -2651,7 +2651,7 @@
         },
         {
             "id": "b034ec46-4ca1-5f54-9e0c-be7a6257737b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46812d-0721-4e93-b1a7-1d38f477fab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46812d-0721-4e93-b1a7-1d38f477fab6.jpg?1",
             "name": "Rootwater Matriarch",
             "text": "oc\nT: Gain control of target creature as long as that creature has any enchantments on it.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "2ef78d1e-c8bf-59bf-96d1-7d5aa90d4ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa1b84b-efda-4324-9106-0d1d00385cdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa1b84b-efda-4324-9106-0d1d00385cdc.jpg?1",
             "name": "Rootwater Shaman",
             "text": "You may play creature enchantments whenever you could play an instant.",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "7dabca43-0548-5caf-8ff7-0632f2ade721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3837ac-54af-44f7-b576-ad5badbee9f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3837ac-54af-44f7-b576-ad5badbee9f2.jpg?1",
             "name": "Sea Monster",
             "text": "Sea Monster cannot attack unless defending player controls any islands.",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "5e65c9fb-8895-52ac-8788-a43d215ba114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c11175-9feb-4801-9b46-d577d5ecef40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57c11175-9feb-4801-9b46-d577d5ecef40.jpg?1",
             "name": "Shadow Rift",
             "text": "Target creature gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)\nDraw a card.",
             "colours": [
@@ -2782,7 +2782,7 @@
         },
         {
             "id": "81174841-7299-5b6c-851f-9fd8b81154b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a8dc46-04c7-479a-90c1-b55e6c67e0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6a8dc46-04c7-479a-90c1-b55e6c67e0e3.jpg?1",
             "name": "Shimmering Wings",
             "text": "Enchanted creature gains flying.\no\nU: Return Shimmering Wings to owner's hand.",
             "colours": [
@@ -2815,7 +2815,7 @@
         },
         {
             "id": "6857fc88-8cf5-52fd-8b6b-44162557d6af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d05ef5-c046-4929-b59d-988f0313a645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7d05ef5-c046-4929-b59d-988f0313a645.jpg?1",
             "name": "Skyshroud Condor",
             "text": "Flying\nYou cannot play Skyshroud Condor unless you have successfully cast another spell this turn.",
             "colours": [
@@ -2848,7 +2848,7 @@
         },
         {
             "id": "8a818b43-806d-5304-accf-73ad0e85a358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe58a24-f6a6-4858-82a5-0ca1d524efe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe58a24-f6a6-4858-82a5-0ca1d524efe1.jpg?1",
             "name": "Spell Blast",
             "text": "Counter target spell with total casting cost equal to X.",
             "colours": [
@@ -2879,7 +2879,7 @@
         },
         {
             "id": "7020c08a-a88d-5093-ad82-3598848f8ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734be7fa-0998-4771-9b97-4989b3fc1471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/734be7fa-0998-4771-9b97-4989b3fc1471.jpg?1",
             "name": "Steal Enchantment",
             "text": "Gain control of enchanted enchantment",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "d1d2ecfb-bf4b-534d-931b-28f102ecc3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807227d7-2eb2-4d47-bb3c-9d1ec9befeb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807227d7-2eb2-4d47-bb3c-9d1ec9befeb7.jpg?1",
             "name": "Stinging Licid",
             "text": "o1o\nU, oc\nT: Stinging Licid loses this ability and becomes a creature enchantment that reads \"Whenever enchanted creature becomes tapped, Stinging Licid deals 2 damage to that creature's controller\" instead of a creature. Move Stinging Licid onto target creature. You may pay o\nU to end this effect.",
             "colours": [
@@ -2945,7 +2945,7 @@
         },
         {
             "id": "570edb3b-f63a-5310-b8c7-29ccc3f3eed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d725cdc0-3a85-4722-bb13-40c336f511b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d725cdc0-3a85-4722-bb13-40c336f511b6.jpg?1",
             "name": "Thalakos Dreamsower",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nYou may choose not to untap Thalakos Dreamsower during your untap phase.\nIf Thalakos Dreamsower damages any opponent, tap target creature. As long as Thalakos Dreamsower remains tapped, that creature does not untap during its controller's untap phase.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "55999112-78fe-5eac-9cd4-0bbb7c25ed14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7b5b00-9d14-4090-b8c3-28b70375571e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7b5b00-9d14-4090-b8c3-28b70375571e.jpg?1",
             "name": "Thalakos Mistfolk",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no\nU: Put Thalakos Mistfolk on top of owner's library.",
             "colours": [
@@ -3013,7 +3013,7 @@
         },
         {
             "id": "d404f511-59ea-50e1-882c-38db19691b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a7d63-94ae-4d92-86ab-12bf9d78a803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136a7d63-94ae-4d92-86ab-12bf9d78a803.jpg?1",
             "name": "Thalakos Seer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Thalakos Seer leaves play, draw a card.",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "a2ef9ac3-b014-5bf7-941e-c6b7527f0990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a13d6-5f73-4166-b923-9db8ee3f2cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a13d6-5f73-4166-b923-9db8ee3f2cf7.jpg?1",
             "name": "Thalakos Sentry",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow)",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "180f38c8-58db-5597-8c5d-876add5612d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e63f0c-a09f-493d-a8a9-ddcc0a0ca383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e63f0c-a09f-493d-a8a9-ddcc0a0ca383.jpg?1",
             "name": "Time Ebb",
             "text": "Put target creature on top of owner's library.",
             "colours": [
@@ -3112,7 +3112,7 @@
         },
         {
             "id": "a1870678-360f-5e90-b936-c9afa5c4e4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447aeaf-3b26-442a-99d4-0a7ee76c8e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3447aeaf-3b26-442a-99d4-0a7ee76c8e76.jpg?1",
             "name": "Time Warp",
             "text": "Target player takes an extra turn after this one.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "a1120060-415c-501a-90ab-c0fc68e56e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09412374-3645-4644-952e-2beaefb3104b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09412374-3645-4644-952e-2beaefb3104b.jpg?1",
             "name": "Tradewind Rider",
             "text": "Flying\noc\nT, Tap two creatures you control: Return target permanent to owner's hand.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "63179f11-93c0-5ba6-b335-85067a67868c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba021eb-3d8b-41bf-aec4-af211e0860ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cba021eb-3d8b-41bf-aec4-af211e0860ad.jpg?1",
             "name": "Twitch",
             "text": "Tap or untap target artifact, creature, or land.\nDraw a card.",
             "colours": [
@@ -3207,7 +3207,7 @@
         },
         {
             "id": "261b3644-8080-5325-a2f9-be5d9c2a19d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8cbd4-f49d-420d-a027-3be64ca58989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8cbd4-f49d-420d-a027-3be64ca58989.jpg?1",
             "name": "Unstable Shapeshifter",
             "text": "Whenever any creature comes into play, Unstable Shapeshifter permanently becomes a copy of that creature and retains this ability.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "360c013d-47ab-5e72-a091-aba495e8502b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce63d86-8748-428a-aa9c-d3c0526537a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bce63d86-8748-428a-aa9c-d3c0526537a2.jpg?1",
             "name": "Volrath's Curse",
             "text": "Enchanted creature cannot attack, block, or play any ability requiring an activation cost. That creature's controller may sacrifice a permanent to ignore this ability until end of turn.\no1o\nU: Return Volrath's Curse to owner's hand.",
             "colours": [
@@ -3273,7 +3273,7 @@
         },
         {
             "id": "d2a6eaf5-a9a7-5844-b462-88c112855c46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e259da60-c8bc-4a77-98ed-e529dc067732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e259da60-c8bc-4a77-98ed-e529dc067732.jpg?1",
             "name": "Whim of Volrath",
             "text": "Buyback o2 (You may pay an additional o2 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nChange the text of target permanent by replacing all instances of one color word or basic land type with another until end of turn.",
             "colours": [
@@ -3304,7 +3304,7 @@
         },
         {
             "id": "46ee2739-ea66-53d3-b2e3-df0f0c857524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c5cfd1-3f7c-4250-a84d-8db83c6d7eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75c5cfd1-3f7c-4250-a84d-8db83c6d7eb7.jpg?1",
             "name": "Whispers of the Muse",
             "text": "Buyback o5 (You may pay an additional o5 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nDraw a card.",
             "colours": [
@@ -3335,7 +3335,7 @@
         },
         {
             "id": "876356c7-e36c-520d-8375-463c20531aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7f7a94-700a-4f3b-846c-a36505b80875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7f7a94-700a-4f3b-846c-a36505b80875.jpg?1",
             "name": "Wind Dancer",
             "text": "Flying\noc\nT: Target creature gains flying until end of turn.",
             "colours": [
@@ -3368,7 +3368,7 @@
         },
         {
             "id": "f118c486-ba96-56b6-872c-0244b6bfcfb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0c9e2-a45d-44d1-b73e-73c0a22d0752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e0c9e2-a45d-44d1-b73e-73c0a22d0752.jpg?1",
             "name": "Wind Drake",
             "text": "Flying",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "ed56502a-ce4a-505a-8b2f-ff609b083a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03aa58b4-dbc2-414e-aa7a-f09360d59b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03aa58b4-dbc2-414e-aa7a-f09360d59b3c.jpg?1",
             "name": "Winged Sliver",
             "text": "All Slivers gain flying.",
             "colours": [
@@ -3434,7 +3434,7 @@
         },
         {
             "id": "abf27f5f-85f8-5c84-997a-6c6271b3ec3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942cf220-472c-48f6-8f60-993939ea5ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942cf220-472c-48f6-8f60-993939ea5ab8.jpg?1",
             "name": "Abandon Hope",
             "text": "Choose and discard X cards: Look at target opponent's hand and choose X of those cards. That player discards the chosen cards.",
             "colours": [
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "6b0bc964-606d-56a7-8a96-b08be9065d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26915b4b-ada1-45f3-b908-04a774011b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26915b4b-ada1-45f3-b908-04a774011b66.jpg?1",
             "name": "Bellowing Fiend",
             "text": "Flying\nWhenever Bellowing Fiend damages any creature, Bellowing Fiend deals 3 damage to that creature's controller and 3 damage to you.",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "a9dbe133-0934-5f0b-99a2-b382038935ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a89ba1b-e68b-4d70-a25e-27be9bf48a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a89ba1b-e68b-4d70-a25e-27be9bf48a3b.jpg?1",
             "name": "Blood Pet",
             "text": "Sacrifice Blood Pet: Add o\nB to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -3531,7 +3531,7 @@
         },
         {
             "id": "c4a55b73-b824-5294-b670-6f9b43b1a025",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98319fd3-0aad-4fc3-bb83-3c027d0ed652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98319fd3-0aad-4fc3-bb83-3c027d0ed652.jpg?1",
             "name": "Bounty Hunter",
             "text": "oc\nT: Put a bounty counter on target nonblack creature.\noc\nT: Destroy target creature with any bounty counters on it.",
             "colours": [
@@ -3566,7 +3566,7 @@
         },
         {
             "id": "511f3129-da24-53a3-8560-190422be12a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884e19fb-67a4-42d8-b163-720a99cb8506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/884e19fb-67a4-42d8-b163-720a99cb8506.jpg?1",
             "name": "Carrionette",
             "text": "o2o\nBo\nB: Remove Carrionette and target creature from the game. That creature's controller may pay o2 to counter this ability. Use this ability only if Carrionette is in your graveyard.",
             "colours": [
@@ -3599,7 +3599,7 @@
         },
         {
             "id": "29d01d6b-74b1-544f-af44-d9c134153762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdead1f4-a6e4-4370-80ae-811881a90d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdead1f4-a6e4-4370-80ae-811881a90d01.jpg?1",
             "name": "Clot Sliver",
             "text": "Each Sliver gains \"o2: Regenerate this creature.\"",
             "colours": [
@@ -3632,7 +3632,7 @@
         },
         {
             "id": "6f8e8551-623d-5ae1-aa42-f922068232c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df7b947-bdb2-4204-8eb0-92fe66411613.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df7b947-bdb2-4204-8eb0-92fe66411613.jpg?1",
             "name": "Coercion",
             "text": "Look at target opponent's hand and choose one of those cards. That player discards that card.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "b7e9a982-e4c7-59d2-aa9f-db87e0d2ac10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8af70-c26d-4b78-aad6-bd51b5afc590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edf8af70-c26d-4b78-aad6-bd51b5afc590.jpg?1",
             "name": "Coffin Queen",
             "text": "You may choose not to untap Coffin Queen during your untap phase.\no2o\nB, oc\nT: Put target creature card from any graveyard into play under your control. Remove that creature from the game if Coffin Queen becomes untapped or if you lose control of Coffin Queen.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "0aff0691-2b01-5bfe-bd48-1b84909c8548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ce69f-a259-4801-9ac3-f6754040434c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab0ce69f-a259-4801-9ac3-f6754040434c.jpg?1",
             "name": "Commander Greven il-Vec",
             "text": "When Commander Greven il-Vec comes into play, sacrifice a creature.\nGreven cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "77bc2c2b-fc67-537f-8a5b-5efb87664b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae81ea-13e3-4ab8-b956-4c7b139a5e9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ae81ea-13e3-4ab8-b956-4c7b139a5e9c.jpg?1",
             "name": "Corpse Dance",
             "text": "Buyback o2 (You may pay an additional o2 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nPut the top creature card from your graveyard into play. That creature is unaffected by summoning sickness this turn. Remove the creature from the game at end of turn.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "d34a69a6-3c3e-5099-a3b1-760f66ff1224",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922d6c8b-70ae-4db4-bf26-1904e4906211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922d6c8b-70ae-4db4-bf26-1904e4906211.jpg?1",
             "name": "Dark Banishing",
             "text": "Destroy target nonblack creature. That creature cannot be regenerated this turn.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "a09a9fab-0d6e-54e4-9cc7-49c095004ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4708e8-2149-4990-987c-2ea55fc6c508.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf4708e8-2149-4990-987c-2ea55fc6c508.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -3827,7 +3827,7 @@
         },
         {
             "id": "86e0bd44-7390-5cb8-95f4-236c93977e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb883b7-da6a-45c3-9dde-61334a0ddcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eb883b7-da6a-45c3-9dde-61334a0ddcae.jpg?1",
             "name": "Darkling Stalker",
             "text": "o\nB: Regenerate Darkling Stalker.\no\nB: Darkling Stalker gets +1/+1 until end of turn.",
             "colours": [
@@ -3861,7 +3861,7 @@
         },
         {
             "id": "b2613736-9235-51c3-9a77-7a66fd1b395e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84bb94-d654-4d69-89d9-0a398a940125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e84bb94-d654-4d69-89d9-0a398a940125.jpg?1",
             "name": "Dauthi Embrace",
             "text": "o\nBo\nB: Target creature gains shadow until end of turn. (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -3892,7 +3892,7 @@
         },
         {
             "id": "03319ea9-da2c-5dee-8867-b19a288152b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70778e-8171-4d97-b86c-d4d92b7e7f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a70778e-8171-4d97-b86c-d4d92b7e7f06.jpg?1",
             "name": "Dauthi Ghoul",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever any creature with shadow is put into any graveyard from play, put a +1/+1 counter on Dauthi Ghoul.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "1b48951c-99db-55f7-a2d9-f321421789d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8bb3a-3a84-442f-8e31-8af2f04408ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a8bb3a-3a84-442f-8e31-8af2f04408ab.jpg?1",
             "name": "Dauthi Horror",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nDauthi Horror cannot be blocked by white creatures.",
             "colours": [
@@ -3960,7 +3960,7 @@
         },
         {
             "id": "999b3b4c-78d9-5911-aac8-6bb5f06e8b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee847d84-ec8d-4ec3-8436-68d6f144e22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee847d84-ec8d-4ec3-8436-68d6f144e22f.jpg?1",
             "name": "Dauthi Marauder",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "1c1d5412-5ed0-5ffb-b4d5-5d44dc46aad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c340e779-c648-48fd-a159-174b46f2d1b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c340e779-c648-48fd-a159-174b46f2d1b3.jpg?1",
             "name": "Dauthi Mercenary",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\no1o\nB: Dauthi Mercenary gets +1/+0 until end of turn.",
             "colours": [
@@ -4029,7 +4029,7 @@
         },
         {
             "id": "2b18ec64-d26b-56cb-bfc6-10f696b8b567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb990ee-f027-4c74-a67e-98ada6aa21e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fb990ee-f027-4c74-a67e-98ada6aa21e4.jpg?1",
             "name": "Dauthi Mindripper",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSacrifice Dauthi Mindripper: Defending player chooses and discards three cards. Use this ability only if Dauthi Mindripper is attacking and unblocked.",
             "colours": [
@@ -4063,7 +4063,7 @@
         },
         {
             "id": "7328f413-46f2-5f6d-bb1b-9aa3c30a26af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652ccd79-aefd-4b45-b747-75190da0cfc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/652ccd79-aefd-4b45-b747-75190da0cfc6.jpg?1",
             "name": "Dauthi Slayer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nEach turn, Dauthi Slayer attacks if able.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "898cdb98-40dd-5934-a7fe-f7d694f65618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72122e8f-97ab-495e-aade-5d736c432873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72122e8f-97ab-495e-aade-5d736c432873.jpg?1",
             "name": "Death Pits of Rath",
             "text": "Whenever any creature is dealt damage, destroy it. That creature cannot be regenerated this turn.",
             "colours": [
@@ -4128,7 +4128,7 @@
         },
         {
             "id": "d4c7a523-fa21-58dc-8837-b456d77a73f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2ee-1e2d-4ab2-8b2c-717c794b09b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ecf2ee-1e2d-4ab2-8b2c-717c794b09b2.jpg?1",
             "name": "Diabolic Edict",
             "text": "Target player sacrifices a creature.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "f94632af-8349-5e2e-a8fc-a67d46a6e558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06254b6c-eb22-4ec9-9420-74e9ee15e072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06254b6c-eb22-4ec9-9420-74e9ee15e072.jpg?1",
             "name": "Disturbed Burial",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nReturn target creature card from your graveyard to your hand.",
             "colours": [
@@ -4190,7 +4190,7 @@
         },
         {
             "id": "26a56253-cc4a-5ca3-852c-dda682952137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08586d4-8163-454c-b8d8-c5034c4aee6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d08586d4-8163-454c-b8d8-c5034c4aee6c.jpg?1",
             "name": "Dread of Night",
             "text": "All white creatures get -1/-1.",
             "colours": [
@@ -4221,7 +4221,7 @@
         },
         {
             "id": "e6625084-3005-5e0a-a14f-dd6d786a5e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e4203a-ff11-4075-a03a-11448779b413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80e4203a-ff11-4075-a03a-11448779b413.jpg?1",
             "name": "Dregs of Sorrow",
             "text": "Destroy X target nonblack creatures. Draw X cards.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "55f4075a-5ca8-5b5e-b3a0-30afbf8e92b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9474231-34c5-4563-8a61-fd1bc2693f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9474231-34c5-4563-8a61-fd1bc2693f86.jpg?1",
             "name": "Endless Scream",
             "text": "Enchanted creature gets +X/+0.",
             "colours": [
@@ -4285,7 +4285,7 @@
         },
         {
             "id": "c3780723-4970-5832-b0d0-bf45f4d717bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71705205-0165-4774-8209-90ce800b9450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71705205-0165-4774-8209-90ce800b9450.jpg?1",
             "name": "Enfeeblement",
             "text": "Enchanted creature gets -2/-2.",
             "colours": [
@@ -4318,7 +4318,7 @@
         },
         {
             "id": "5977cf32-9c29-51a9-b427-cd01a1b3d09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d53f46f-b069-4b34-af4b-98143328c078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d53f46f-b069-4b34-af4b-98143328c078.jpg?1",
             "name": "Evincar's Justice",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nEvincar's Justice deals 2 damage to each creature and player.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "94a73106-24df-5bf1-af34-118d5058e067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a233a244-7f84-4525-b0ce-e10db0a95385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a233a244-7f84-4525-b0ce-e10db0a95385.jpg?1",
             "name": "Extinction",
             "text": "Destroy all creatures of any creature type of your choice.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "38689d27-5a85-50e6-a427-dcbc74732213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a790769-e76e-49e9-9d6d-05ce8e858243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a790769-e76e-49e9-9d6d-05ce8e858243.jpg?1",
             "name": "Fevered Convulsions",
             "text": "o2o\nBo\nB: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -4411,7 +4411,7 @@
         },
         {
             "id": "a7dcc664-c4a4-58af-8e66-80c482a5a111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f3328-c65d-49eb-a1bb-ca40e9c05627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872f3328-c65d-49eb-a1bb-ca40e9c05627.jpg?1",
             "name": "Gravedigger",
             "text": "When Gravedigger comes into play, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4444,7 +4444,7 @@
         },
         {
             "id": "7c336716-90b7-51f4-abdc-3f33097020c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6ed64-9f5c-4233-85a9-028b8e5949c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d6ed64-9f5c-4233-85a9-028b8e5949c3.jpg?1",
             "name": "Imps' Taunt",
             "text": "Buyback o3 (You may pay an additional o3 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature attacks this turn if able.",
             "colours": [
@@ -4475,7 +4475,7 @@
         },
         {
             "id": "2d8243a4-9dff-51c3-8d5b-7662b83bbc21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95d3a-bb19-474d-9939-8817038fe9fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b95d3a-bb19-474d-9939-8817038fe9fc.jpg?1",
             "name": "Kezzerdrix",
             "text": "First strike\nDuring your upkeep, if your opponents control no creatures, Kezzerdrix deals 4 damage to you.",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "d3dbd08d-af5f-508c-812c-f8639fa5d694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aba09c4-9259-4743-9e4a-a63505f1efe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aba09c4-9259-4743-9e4a-a63505f1efe6.jpg?1",
             "name": "Knight of Dusk",
             "text": "o\nBo\nB: Destroy target creature blocking Knight of Dusk.",
             "colours": [
@@ -4543,7 +4543,7 @@
         },
         {
             "id": "88d6b320-1a79-535b-9925-b89de9562275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bffefb-23c0-4d03-b716-b1a7eff39a05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27bffefb-23c0-4d03-b716-b1a7eff39a05.jpg?1",
             "name": "Leeching Licid",
             "text": "o\nB, oc\nT: Leeching Licid loses this ability and becomes a creature enchantment that reads \"During the upkeep of enchanted creature's controller, Leeching Licid deals 1 damage to that player\" instead of a creature. Move Leeching Licid onto target creature. You may pay o\nB to end this effect.",
             "colours": [
@@ -4576,7 +4576,7 @@
         },
         {
             "id": "f9d34eca-e79f-540c-b995-ca0c0b3b4c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c820476-fbda-4073-baf6-51e71f45ed58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c820476-fbda-4073-baf6-51e71f45ed58.jpg?1",
             "name": "Living Death",
             "text": "Set aside all creature cards in all graveyards. Then, put each creature that is in play into its owner's graveyard. Then, put each creature card set aside in this way into play under its owner's control.",
             "colours": [
@@ -4607,7 +4607,7 @@
         },
         {
             "id": "71bba96d-0a2d-5cdb-a04b-0ec70a4cb070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda08eb5-c75c-4c21-bfd1-1f04a3575241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda08eb5-c75c-4c21-bfd1-1f04a3575241.jpg?1",
             "name": "Maddening Imp",
             "text": "Flying\noc\nT: All non-Wall creatures target opponent controls attack this turn if able. At end of turn, destroy each of those creatures that did not attack. Use this ability only during target opponent's turn and only before combat.",
             "colours": [
@@ -4640,7 +4640,7 @@
         },
         {
             "id": "0c84a12b-640f-507b-b49e-13bad4230f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b759-f53d-4977-8d97-a93762622e75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90c4b759-f53d-4977-8d97-a93762622e75.jpg?1",
             "name": "Marsh Lurker",
             "text": "Sacrifice a swamp: Marsh Lurker cannot be blocked this turn except by artifact creatures and black creatures.",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "69e81102-e150-52c0-ad65-f7bcc0037bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa966fbb-140d-4057-a4fc-998ebe07c307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa966fbb-140d-4057-a4fc-998ebe07c307.jpg?1",
             "name": "Mindwhip Sliver",
             "text": "Each Sliver gains \"o2, Sacrifice this creature: Target player discards a card at random. Play this ability as a sorcery.\"",
             "colours": [
@@ -4706,7 +4706,7 @@
         },
         {
             "id": "0f3336be-30cd-5405-bd19-328a66ca9c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f120fc-c681-47b6-827e-1cc7ead47a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f120fc-c681-47b6-827e-1cc7ead47a0f.jpg?1",
             "name": "Minion of the Wastes",
             "text": "Trample\nWhen you play Minion of the Wastes, pay any amount of life.\nMinion of the Wastes has power and toughness each equal to that amount.",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "8c50b2ef-0ebd-52dd-bea1-6363e4b3287b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47ace1d-73de-44aa-a3fe-2e2a21ebec79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47ace1d-73de-44aa-a3fe-2e2a21ebec79.jpg?1",
             "name": "Perish",
             "text": "Destroy all green creatures. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "07bd8c3e-a2ac-584c-897c-a7dc273f8c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7acfe-b5b2-426f-a5a1-1ff8ef7ebf72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7acfe-b5b2-426f-a5a1-1ff8ef7ebf72.jpg?1",
             "name": "Pit Imp",
             "text": "Flying\no\nB: Pit Imp gets +1/+0 until end of turn. You cannot spend more than o\nBo\nB in this way each turn.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "d6d167eb-eef8-5e90-9300-2a1820520f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad93919-273f-4a26-8ebd-13503dd6b220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cad93919-273f-4a26-8ebd-13503dd6b220.jpg?1",
             "name": "Rain of Tears",
             "text": "Destroy target land.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "dbb98845-d9e8-5a86-ac24-e512949407c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb8d3a2-ed96-4490-9432-401da19ad3c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cb8d3a2-ed96-4490-9432-401da19ad3c5.jpg?1",
             "name": "Rats of Rath",
             "text": "o\nB: Destroy target artifact, creature, or land you control.",
             "colours": [
@@ -4867,7 +4867,7 @@
         },
         {
             "id": "7e1e1ecc-fb74-5617-80e9-d82b0f959c59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1ef31c-8ca5-444c-8f39-e1d1827318f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae1ef31c-8ca5-444c-8f39-e1d1827318f5.jpg?1",
             "name": "Reanimate",
             "text": "Put target creature card from any graveyard into play under your control. Lose life equal to that creature's total casting cost.",
             "colours": [
@@ -4898,7 +4898,7 @@
         },
         {
             "id": "b429c716-f2b7-5b28-90f1-7d3c2c30d560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9141daea-1f4f-4227-b7d7-20753e3cb4d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9141daea-1f4f-4227-b7d7-20753e3cb4d4.jpg?1",
             "name": "Reckless Spite",
             "text": "Destroy two target nonblack creatures. Lose 5 life.",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "37d0c1c2-9bcb-5180-8b47-2e88cdbb2653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e1959c-b87b-4e17-a0d2-0489ea79220b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9e1959c-b87b-4e17-a0d2-0489ea79220b.jpg?1",
             "name": "Sadistic Glee",
             "text": "Whenever any creature is put into any graveyard from play, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -4962,7 +4962,7 @@
         },
         {
             "id": "c3822d63-2c83-59b4-b817-8b96cd3d1999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5730f5-a44c-4f75-a26f-90815cfcd31e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb5730f5-a44c-4f75-a26f-90815cfcd31e.jpg?1",
             "name": "Sarcomancy",
             "text": "When Sarcomancy comes into play, put a Zombie token into play. Treat this token as a 2/2 black creature.\nDuring your upkeep, if there are no Zombies in play, Sarcomancy deals 1 damage to you.",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "dc8ed4e6-e173-5d25-b20b-5dc42b1cf300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c02902-4e3a-445e-9dd9-116806ddc966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c02902-4e3a-445e-9dd9-116806ddc966.jpg?1",
             "name": "Screeching Harpy",
             "text": "Flying\no1o\nB: Regenerate Screeching Harpy.",
             "colours": [
@@ -5027,7 +5027,7 @@
         },
         {
             "id": "48ed7a17-a040-58a5-9eea-5a7d6ab0d934",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691afabb-f266-45fd-b5a3-577be4f10f86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691afabb-f266-45fd-b5a3-577be4f10f86.jpg?1",
             "name": "Servant of Volrath",
             "text": "If Servant of Volrath leaves play, sacrifice a creature.",
             "colours": [
@@ -5060,7 +5060,7 @@
         },
         {
             "id": "e66bc9ba-ed48-5183-912b-ee4f94ec9b83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed2c97b-f003-436c-9faa-5518aba42fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed2c97b-f003-436c-9faa-5518aba42fc1.jpg?1",
             "name": "Skyshroud Vampire",
             "text": "Flying\nChoose and discard a creature card: Skyshroud Vampire gets +2/+2 until end of turn.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "7ada7491-6a85-5cd4-ac91-f6d861079d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d2d0ff-e44e-427a-9d68-3ed2d51b1b86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07d2d0ff-e44e-427a-9d68-3ed2d51b1b86.jpg?1",
             "name": "Souldrinker",
             "text": "Pay 3 life: Put a +1/+1 counter on Souldrinker.",
             "colours": [
@@ -5126,7 +5126,7 @@
         },
         {
             "id": "4068fa91-a525-55bc-8228-f9a451a6b14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a073b0c-2309-4070-a18e-0937ec8d4d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a073b0c-2309-4070-a18e-0937ec8d4d1c.jpg?1",
             "name": "Spinal Graft",
             "text": "Enchanted creature gets +3/+3.\nIf enchanted creature is the target of a spell or ability, destroy that creature. The creature cannot be regenerated this turn.",
             "colours": [
@@ -5159,7 +5159,7 @@
         },
         {
             "id": "629883c3-78c3-5c25-9e14-fd99460ca845",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91a26b2-03f8-43f0-a3a4-ff6c5a3690c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c91a26b2-03f8-43f0-a3a4-ff6c5a3690c4.jpg?1",
             "name": "Aftershock",
             "text": "Destroy target artifact, creature, or land. Aftershock deals 3 damage to you.",
             "colours": [
@@ -5190,7 +5190,7 @@
         },
         {
             "id": "5daeb4be-e577-5c7d-ad48-222824b7772d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e315c1c2-436e-48ff-9214-938697178393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e315c1c2-436e-48ff-9214-938697178393.jpg?1",
             "name": "Ancient Runes",
             "text": "During each player's upkeep, Ancient Runes deals 1 damage to that player for each artifact he or she controls.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "747eb3b0-104f-5c01-9eed-9e69eb949f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff23780-d183-4cca-ad0c-448ef325bf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff23780-d183-4cca-ad0c-448ef325bf36.jpg?1",
             "name": "Apocalypse",
             "text": "Remove all permanents from the game. Discard your hand.",
             "colours": [
@@ -5252,7 +5252,7 @@
         },
         {
             "id": "662c141a-09c9-53bd-80cd-028a4313d4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bddea7-daa7-4bdb-9b91-f7fcbc0d7a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19bddea7-daa7-4bdb-9b91-f7fcbc0d7a57.jpg?1",
             "name": "Barbed Sliver",
             "text": "Each Sliver gains \"o2: This creature gets +1/+0 until end of turn.\"",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "277e2e45-0799-5f66-9883-aca07377db82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f39d83-e1ea-45c9-8181-2a2b6e5148da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f39d83-e1ea-45c9-8181-2a2b6e5148da.jpg?1",
             "name": "Blood Frenzy",
             "text": "Target attacking or blocking creature gets +4/+0 until end of turn. At end of turn, destroy that creature.",
             "colours": [
@@ -5316,7 +5316,7 @@
         },
         {
             "id": "8fc1cd83-a76a-54b9-85c6-eb60d30c5ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa1c529-44e5-41b6-9704-ae2319f31f13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fa1c529-44e5-41b6-9704-ae2319f31f13.jpg?1",
             "name": "Boil",
             "text": "Destroy all islands.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "33d2b7ef-96f1-5787-8fcc-dea928257721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg?1",
             "name": "Canyon Drake",
             "text": "Flying\no1, Discard a card at random: Canyon Drake gets +2/+0 until end of turn.",
             "colours": [
@@ -5380,7 +5380,7 @@
         },
         {
             "id": "23519797-725b-5efa-bc84-93728e916fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0169e52b-7909-4a8f-8ca2-62f030f9a85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0169e52b-7909-4a8f-8ca2-62f030f9a85a.jpg?1",
             "name": "Canyon Wildcat",
             "text": "Mountainwalk (If defending player controls any mountains, this creature is unblockable.)",
             "colours": [
@@ -5413,7 +5413,7 @@
         },
         {
             "id": "0108d635-1c56-57d8-877b-b8f040ce59cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9881a4-3078-4fe0-be09-54ddad1d18a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e9881a4-3078-4fe0-be09-54ddad1d18a0.jpg?1",
             "name": "Chaotic Goo",
             "text": "Chaotic Goo comes into play with three +1/+1 counters on it.\nDuring your upkeep, you may flip a coin. If you win the flip, add a +1/+1 counter to Chaotic Goo. Otherwise, remove a +1/+1 counter from it.",
             "colours": [
@@ -5446,7 +5446,7 @@
         },
         {
             "id": "6bc8b1cd-a03e-5216-822e-096a740ad54e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c82741-2869-41f9-82f4-6ed88756e2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c82741-2869-41f9-82f4-6ed88756e2fd.jpg?1",
             "name": "Crown of Flames",
             "text": "o\nR: Enchanted creature gets +1/+0 until end of turn.\no\nR: Return Crown of Flames to owner's hand.",
             "colours": [
@@ -5479,7 +5479,7 @@
         },
         {
             "id": "f739fbb6-cb73-5fe0-acde-a4a29fd7607c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d212c5-1642-456f-829f-57f68a2116b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55d212c5-1642-456f-829f-57f68a2116b6.jpg?1",
             "name": "Deadshot",
             "text": "Tap target creature. That creature deals damage equal to its power to another target creature.",
             "colours": [
@@ -5510,7 +5510,7 @@
         },
         {
             "id": "748ba962-678a-5019-91a4-bc6b6a4353b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7bff44-36e1-4855-aa2d-5c7bd6bf6f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7bff44-36e1-4855-aa2d-5c7bd6bf6f10.jpg?1",
             "name": "Enraging Licid",
             "text": "o\nR, oc\nT: Enraging Licid loses this ability and becomes a creature enchantment that reads \"Enchanted creature is unaffected by summoning sickness\" instead of a creature. Move Enraging Licid onto target creature. You may pay o\nR to end this effect.",
             "colours": [
@@ -5543,7 +5543,7 @@
         },
         {
             "id": "4cde2e39-6836-524c-8d50-46acafa4eb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a312f0cf-225a-4f3d-b9a7-c47dd03b25c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a312f0cf-225a-4f3d-b9a7-c47dd03b25c3.jpg?1",
             "name": "Firefly",
             "text": "Flying\no\nR: Firefly gets +1/+0 until end of turn.",
             "colours": [
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "d5a6a940-cc5b-5e98-a917-7c6b4695d727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de253d94-9968-47da-bb7a-9c8ebf50f4e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de253d94-9968-47da-bb7a-9c8ebf50f4e0.jpg?1",
             "name": "Fireslinger",
             "text": "oc\nT: Fireslinger deals 1 damage to target creature or player and 1 damage to you.",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "efe81109-ac4a-5ebc-a945-ff07ae4d90fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8240a-d882-4f60-8960-1856284e04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46e8240a-d882-4f60-8960-1856284e04a0.jpg?1",
             "name": "Flowstone Giant",
             "text": "o\nR: Flowstone Giant gets +2/-2 until end of turn.",
             "colours": [
@@ -5643,7 +5643,7 @@
         },
         {
             "id": "28bf920e-5215-594a-9db1-7e0a04f48f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b6749-42a6-498b-8908-b28d1749dea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5b6749-42a6-498b-8908-b28d1749dea6.jpg?1",
             "name": "Flowstone Salamander",
             "text": "o\nR: Flowstone Salamander deals 1 damage to target creature blocking it.",
             "colours": [
@@ -5676,7 +5676,7 @@
         },
         {
             "id": "4db9a84b-d96a-5f3f-af2b-78dfcbdbb566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7949c7-ab80-46a1-9cf7-d8e8c004df6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7949c7-ab80-46a1-9cf7-d8e8c004df6e.jpg?1",
             "name": "Flowstone Wyvern",
             "text": "Flying\no\nR: Flowstone Wyvern gets +2/-2 until end of turn.",
             "colours": [
@@ -5709,7 +5709,7 @@
         },
         {
             "id": "9f65716e-3c89-53f4-9b00-3ab60cb70500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606abea6-109a-4dd5-99cf-0d5ce492d7f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/606abea6-109a-4dd5-99cf-0d5ce492d7f0.jpg?1",
             "name": "Furnace of Rath",
             "text": "Double all damage assigned to any creature or player.",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "8b29acd6-cab9-58f4-a6ee-5f69f601aa1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb43289-35dc-4983-9c49-22b1b3a7d85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfb43289-35dc-4983-9c49-22b1b3a7d85a.jpg?1",
             "name": "Giant Strength",
             "text": "Enchanted creature gets +2/+2.",
             "colours": [
@@ -5773,7 +5773,7 @@
         },
         {
             "id": "928e2a80-0519-5778-9e30-6cc95340dd59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179e954f-1d90-4ef4-b800-25845cc338e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/179e954f-1d90-4ef4-b800-25845cc338e2.jpg?1",
             "name": "Goblin Bombardment",
             "text": "Sacrifice a creature: Goblin Bombardment deals 1 damage to target creature or player.",
             "colours": [
@@ -5804,7 +5804,7 @@
         },
         {
             "id": "254651b1-b177-5ddf-a4c2-2edc318b8f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cb86a-db01-4d9a-99e9-bb50ce23507f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4cb86a-db01-4d9a-99e9-bb50ce23507f.jpg?1",
             "name": "Hand to Hand",
             "text": "Instants and abilities requiring an activation cost cannot be played during combat.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "dd84f384-bc5b-5b43-9117-e30dccd4985b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b032a1-6e43-4e22-9efa-43cfbf211e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b032a1-6e43-4e22-9efa-43cfbf211e1c.jpg?1",
             "name": "Havoc",
             "text": "Whenever target opponent successfully casts a white spell, he or she loses 2 life.",
             "colours": [
@@ -5866,7 +5866,7 @@
         },
         {
             "id": "68e65ef3-55a8-5f26-8ce9-7a78f4261ce8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a83ab6-0d15-49e4-90e3-b3a2a095c632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a83ab6-0d15-49e4-90e3-b3a2a095c632.jpg?1",
             "name": "Heart Sliver",
             "text": "All Slivers are unaffected by summoning sickness.",
             "colours": [
@@ -5899,7 +5899,7 @@
         },
         {
             "id": "af74b4a7-c02a-5f9a-8a29-0b6b38d7d5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707ab74-9aec-4d30-86e0-ffa5f72d5b4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707ab74-9aec-4d30-86e0-ffa5f72d5b4f.jpg?1",
             "name": "Jackal Pup",
             "text": "For each 1 damage dealt to Jackal Pup, it deals 1 damage to you.",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "c166b069-6173-57bd-8a4d-6d309f1a43d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930745eb-b038-4b55-97f3-bf8d99b54d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930745eb-b038-4b55-97f3-bf8d99b54d32.jpg?1",
             "name": "Kindle",
             "text": "Kindle deals to target creature or player an amount of damage equal to 2 plus the number of Kindle cards in all graveyards.",
             "colours": [
@@ -5963,7 +5963,7 @@
         },
         {
             "id": "b0f90832-3d66-5bd5-ade3-7fc8dd3a3913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fec3f9-d399-48e6-84b6-c8410c24c382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fec3f9-d399-48e6-84b6-c8410c24c382.jpg?1",
             "name": "Lightning Blast",
             "text": "Lightning Blast deals 4 damage to target creature or player.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "a514ffe4-905c-574a-a215-c67b00424e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f6d2a4-cc97-43f3-a8b2-f96262c27371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f6d2a4-cc97-43f3-a8b2-f96262c27371.jpg?1",
             "name": "Lightning Elemental",
             "text": "Lightning Elemental is unaffected by summoning sickness.",
             "colours": [
@@ -6027,7 +6027,7 @@
         },
         {
             "id": "5c2c7c64-a26a-5125-97b2-1c0605894547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7398dec7-5e60-43c0-81a0-ab49beb37077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7398dec7-5e60-43c0-81a0-ab49beb37077.jpg?1",
             "name": "Lowland Giant",
             "text": "",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "7989968a-a8ac-521f-9ed7-64837670209b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48115601-fa00-4d33-8205-faac02997bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48115601-fa00-4d33-8205-faac02997bb4.jpg?1",
             "name": "Magmasaur",
             "text": "Magmasaur comes into play with five +1/+1 counters on it.\nDuring your upkeep, remove a +1/+1 counter from Magmasaur, or sacrifice Magmasaur and it deals 1 damage for each +1/+1 counter on it to each creature without flying and each player.",
             "colours": [
@@ -6094,7 +6094,7 @@
         },
         {
             "id": "8899a60c-b4cb-529c-8854-6dee53fd21b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73719325-b091-4464-b0b0-77dfbb19562a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73719325-b091-4464-b0b0-77dfbb19562a.jpg?1",
             "name": "Mogg Conscripts",
             "text": "Mogg Conscripts cannot attack unless you have successfully cast a creature spell this turn.",
             "colours": [
@@ -6127,7 +6127,7 @@
         },
         {
             "id": "6f86cc82-9f50-5665-a80e-31fbab1da20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2ecfd4-c874-4468-8601-87aa110d5a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2ecfd4-c874-4468-8601-87aa110d5a00.jpg?1",
             "name": "Mogg Fanatic",
             "text": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
             "colours": [
@@ -6160,7 +6160,7 @@
         },
         {
             "id": "6dd26fe3-0933-5773-ab85-7bff97115df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e9cc0a-c210-4525-8c7f-9c6306cc21b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94e9cc0a-c210-4525-8c7f-9c6306cc21b0.jpg?1",
             "name": "Mogg Raider",
             "text": "Sacrifice a Goblin: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -6193,7 +6193,7 @@
         },
         {
             "id": "12e22e5e-d947-5039-b519-55138cf99ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b267071-42a6-4e25-9c92-5bca32f8d9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b267071-42a6-4e25-9c92-5bca32f8d9af.jpg?1",
             "name": "Mogg Squad",
             "text": "Mogg Squad gets -1/-1 for each other creature in play.",
             "colours": [
@@ -6226,7 +6226,7 @@
         },
         {
             "id": "df8f80d0-657f-5f59-851f-94325ff9f789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c317ee7-ed92-4e3e-92bb-502099caccf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c317ee7-ed92-4e3e-92bb-502099caccf8.jpg?1",
             "name": "No Quarter",
             "text": "Whenever any creature blocks or is blocked by a creature with lesser power, destroy the creature with the lesser power.",
             "colours": [
@@ -6257,7 +6257,7 @@
         },
         {
             "id": "ad300b23-7294-5fb9-8618-eb75885fd716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0026c0-8f61-4485-8909-6a44c2ca9169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0026c0-8f61-4485-8909-6a44c2ca9169.jpg?1",
             "name": "Opportunist",
             "text": "oc\nT: Opportunist deals 1 damage to target creature that was damaged this turn.",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "41bc96bf-5c0d-56a8-ac78-3c69d381a824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61adc314-cfb2-4fdd-925c-cc1dc4692992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61adc314-cfb2-4fdd-925c-cc1dc4692992.jpg?1",
             "name": "Pallimud",
             "text": "Pallimud has power equal to the number of tapped lands target opponent controls.",
             "colours": [
@@ -6324,7 +6324,7 @@
         },
         {
             "id": "3af612d1-d9a9-55b4-8457-8e7e2891e58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df61bff-a459-4ddb-a084-f47859a43795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7df61bff-a459-4ddb-a084-f47859a43795.jpg?1",
             "name": "Rathi Dragon",
             "text": "Flying\nWhen Rathi Dragon comes into play, sacrifice two mountains or sacrifice Rathi Dragon.",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "181e733f-0bdc-5a2d-8aae-45699d940c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69ea676-60ba-4807-bc9b-976bf5666485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69ea676-60ba-4807-bc9b-976bf5666485.jpg?1",
             "name": "Renegade Warlord",
             "text": "First strike\nIf Renegade Warlord attacks, each other attacking creature gets +1/+0 until end of turn.",
             "colours": [
@@ -6391,7 +6391,7 @@
         },
         {
             "id": "39ca7e65-c60c-5726-83fb-e66dc63a00a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb07402-d526-4938-89a3-9174d5b5a4de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb07402-d526-4938-89a3-9174d5b5a4de.jpg?1",
             "name": "Rolling Thunder",
             "text": "Rolling Thunder deals X damage divided any way you choose among any number of target creatures and/or players.",
             "colours": [
@@ -6422,7 +6422,7 @@
         },
         {
             "id": "bad8c50a-af9b-50b0-a25b-d9886d8fcf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa61413-3c6a-4895-b8e7-2723e273a952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa61413-3c6a-4895-b8e7-2723e273a952.jpg?1",
             "name": "Sandstone Warrior",
             "text": "First strike\no\nR: Sandstone Warrior gets +1/+0 until end of turn.",
             "colours": [
@@ -6457,7 +6457,7 @@
         },
         {
             "id": "92834498-b035-53f0-a72d-539af9df2f96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a97817-d1fd-4ba4-9ced-c2702b081523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6a97817-d1fd-4ba4-9ced-c2702b081523.jpg?1",
             "name": "Scorched Earth",
             "text": "Choose and discard X land cards: Destroy X target lands.",
             "colours": [
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "ad27bc6c-a59b-5565-8b45-57642eec6de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9091667-d5a8-4978-9023-032ff65f9642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9091667-d5a8-4978-9023-032ff65f9642.jpg?1",
             "name": "Searing Touch",
             "text": "Buyback o4 (You may pay an additional o4 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nSearing Touch deals 1 damage to target creature or player.",
             "colours": [
@@ -6519,7 +6519,7 @@
         },
         {
             "id": "3a7285b9-85cd-5f29-82e5-8d2b07fd2b24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367c4ad6-973d-47ba-9431-312f9f2996f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367c4ad6-973d-47ba-9431-312f9f2996f6.jpg?1",
             "name": "Shadowstorm",
             "text": "Shadowstorm deals 2 damage to each creature with shadow.",
             "colours": [
@@ -6550,7 +6550,7 @@
         },
         {
             "id": "3edf98f6-b158-536b-9ec6-54b762acd562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa05258-2ce3-4604-938c-e8c3fb8cf142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa05258-2ce3-4604-938c-e8c3fb8cf142.jpg?1",
             "name": "Shatter",
             "text": "Destroy target artifact.",
             "colours": [
@@ -6581,7 +6581,7 @@
         },
         {
             "id": "e8616716-2bcb-5abc-bdaa-4bb4a5829ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90954848-af7e-47b3-82e7-9fedde6ad606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90954848-af7e-47b3-82e7-9fedde6ad606.jpg?1",
             "name": "Shocker",
             "text": "If Shocker damages any player, that player discards his or her hand, then draws a new hand of as many cards as he or she had before.",
             "colours": [
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "51f802cc-757f-50d9-8768-0ac6f4c5db70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de398b32-10a3-45aa-9886-76806e1602c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de398b32-10a3-45aa-9886-76806e1602c6.jpg?1",
             "name": "Starke of Rath",
             "text": "oc\nT: Destroy target artifact or creature. That permanent's controller gains control of Starke of Rath permanently.",
             "colours": [
@@ -6650,7 +6650,7 @@
         },
         {
             "id": "b3befb02-6b2c-5b30-abe7-4faef0181702",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92548d9-cba6-495f-bef1-73e4519fe336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92548d9-cba6-495f-bef1-73e4519fe336.jpg?1",
             "name": "Stone Rain",
             "text": "Destroy target land.",
             "colours": [
@@ -6681,7 +6681,7 @@
         },
         {
             "id": "6d008a04-48f2-5a35-9838-049ad8452294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09c0da6-37a7-42ba-b264-18898ee372f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c09c0da6-37a7-42ba-b264-18898ee372f0.jpg?1",
             "name": "Stun",
             "text": "Target creature cannot block this turn.\nDraw a card.",
             "colours": [
@@ -6712,7 +6712,7 @@
         },
         {
             "id": "711a721c-01aa-5225-a75f-8759f94998a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fd516-4b0d-407f-b0c2-d656ad160b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7fd516-4b0d-407f-b0c2-d656ad160b8d.jpg?1",
             "name": "Sudden Impact",
             "text": "Sudden Impact deals 1 damage to target player for each card in his or her hand.",
             "colours": [
@@ -6743,7 +6743,7 @@
         },
         {
             "id": "18412687-2b7a-5367-a764-cd27f661674e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36658368-88c8-4c55-8147-f6e581f6af36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36658368-88c8-4c55-8147-f6e581f6af36.jpg?1",
             "name": "Tahngarth's Rage",
             "text": "If enchanted creature is attacking, it gets +3/+0. Otherwise, it gets -2/-1.",
             "colours": [
@@ -6776,7 +6776,7 @@
         },
         {
             "id": "3c65cd4b-2e6d-563f-aa1a-697781ea7119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71696093-0867-4889-8fb4-56fa143f9b27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71696093-0867-4889-8fb4-56fa143f9b27.jpg?1",
             "name": "Tooth and Claw",
             "text": "Sacrifice two creatures: Put a Carnivore token into play. Treat this token as a 3/1 red creature.",
             "colours": [
@@ -6807,7 +6807,7 @@
         },
         {
             "id": "e9177e5f-2a18-5b3a-935a-c00d71eaa7e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6a469e-3d67-4edf-a735-03dcd626f858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e6a469e-3d67-4edf-a735-03dcd626f858.jpg?1",
             "name": "Wall of Diffusion",
             "text": "(Walls cannot attack.)\nWall of Diffusion can block creatures with shadow.",
             "colours": [
@@ -6840,7 +6840,7 @@
         },
         {
             "id": "d6d1b26e-dee0-5437-9dff-00d1bb62e902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a1b213-cba0-4eca-b058-93f4fde717c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5a1b213-cba0-4eca-b058-93f4fde717c8.jpg?1",
             "name": "Wild Wurm",
             "text": "When Wild Wurm comes into play, flip a coin. If you lose the flip, return Wild Wurm to owner's hand.",
             "colours": [
@@ -6873,7 +6873,7 @@
         },
         {
             "id": "89cad384-b845-5268-bdd7-df51190cfbb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268403bc-733d-446e-a7c1-abc957c42bc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268403bc-733d-446e-a7c1-abc957c42bc2.jpg?1",
             "name": "Aluren",
             "text": "Any player may play a creature card with total casting cost 3 or less whenever he or she could play an instant and without paying its casting cost.",
             "colours": [
@@ -6904,7 +6904,7 @@
         },
         {
             "id": "73491e40-bbee-5edc-aa98-370f8475ef1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff287-6b53-4e6d-9da2-d80d05bb8c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25eff287-6b53-4e6d-9da2-d80d05bb8c51.jpg?1",
             "name": "Apes of Rath",
             "text": "If Apes of Rath attacks, it does not untap during your next untap phase.",
             "colours": [
@@ -6937,7 +6937,7 @@
         },
         {
             "id": "d26a5d41-2993-5e5c-8c2d-5b98a95fabd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cfcca5-070b-4946-b17b-0c94b1e47fcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93cfcca5-070b-4946-b17b-0c94b1e47fcd.jpg?1",
             "name": "Bayou Dragonfly",
             "text": "Flying; swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -6970,7 +6970,7 @@
         },
         {
             "id": "4ac73b29-7ce7-5f0d-ab83-148a07279174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43f5349-a3f8-492d-a835-24a9f948741c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43f5349-a3f8-492d-a835-24a9f948741c.jpg?1",
             "name": "Broken Fall",
             "text": "Return Broken Fall to owner's hand: Regenerate target creature.",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "c408493e-2580-530b-a72c-1403cc31f03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc114b0-2e95-4143-a4b6-6537813946e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afc114b0-2e95-4143-a4b6-6537813946e7.jpg?1",
             "name": "Canopy Spider",
             "text": "Canopy Spider can block creatures with flying.",
             "colours": [
@@ -7034,7 +7034,7 @@
         },
         {
             "id": "1932fa29-3c32-5870-9534-30fdede715f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f89e5-9ce2-4713-aca9-6581005f6ca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651f89e5-9ce2-4713-aca9-6581005f6ca2.jpg?1",
             "name": "Charging Rhino",
             "text": "Charging Rhino cannot be blocked by more than one creature.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "01cfeb86-c276-5644-8d42-e93065baaee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f85205-3c4f-4411-b09c-d1271be56dde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f85205-3c4f-4411-b09c-d1271be56dde.jpg?1",
             "name": "Choke",
             "text": "Islands do not untap during their controllers' untap phases.",
             "colours": [
@@ -7098,7 +7098,7 @@
         },
         {
             "id": "f6ff50c6-d2dc-53f1-aacf-69701672d048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e4b36-57c1-493d-ab79-52075990b2d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83e4b36-57c1-493d-ab79-52075990b2d5.jpg?1",
             "name": "Crazed Armodon",
             "text": "o\nG: Crazed Armodon gets +3/+0 and gains trample until end of turn. At end of turn, destroy Crazed Armodon. Use this ability only once each turn.",
             "colours": [
@@ -7131,7 +7131,7 @@
         },
         {
             "id": "51cd21e5-3486-5fe4-acd3-0a57d1de4995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2df7d-5d72-4a32-a453-6d8611f0d63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e2df7d-5d72-4a32-a453-6d8611f0d63c.jpg?1",
             "name": "Dirtcowl Wurm",
             "text": "Whenever any opponent plays a land, put a +1/+1 counter on Dirtcowl Wurm.",
             "colours": [
@@ -7164,7 +7164,7 @@
         },
         {
             "id": "9edfe8f4-204e-5b6e-9a74-ac2f8b0d6a45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda7531-82a1-4f49-8858-601ddbc6e2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dda7531-82a1-4f49-8858-601ddbc6e2bc.jpg?1",
             "name": "Earthcraft",
             "text": "Tap an untapped creature you control: Untap target basic land.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "f5638076-4574-583d-a9ba-01b7b3647aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8531643-5657-44b6-89d1-9cdf67ed09c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8531643-5657-44b6-89d1-9cdf67ed09c4.jpg?1",
             "name": "Eladamri's Vineyard",
             "text": "At the beginning of each player's main phase, add o\nGo\nG to that player's mana pool.",
             "colours": [
@@ -7226,7 +7226,7 @@
         },
         {
             "id": "88336bb5-51a0-5252-a01a-d6aadad90a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1689f3-9dfa-4525-90b3-7af15f7eb720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1689f3-9dfa-4525-90b3-7af15f7eb720.jpg?1",
             "name": "Eladamri, Lord of Leaves",
             "text": "All Elves gain forestwalk. (If defending player controls any forests, those creatures are unblockable.)\nElves cannot be the target of spells or abilities.",
             "colours": [
@@ -7262,7 +7262,7 @@
         },
         {
             "id": "d0076174-521c-560f-b29d-32746dbfa68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29138c1e-11cb-488f-8e04-f5488e08a81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29138c1e-11cb-488f-8e04-f5488e08a81e.jpg?1",
             "name": "Elven Warhounds",
             "text": "If Elven Warhounds is blocked by any creature, put that creature on top of owner's library.",
             "colours": [
@@ -7295,7 +7295,7 @@
         },
         {
             "id": "f8d07edf-a03a-5624-bd89-bc198f931127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99c10b5-b93b-40c3-936c-d1b81b49c5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99c10b5-b93b-40c3-936c-d1b81b49c5a4.jpg?1",
             "name": "Elvish Fury",
             "text": "Buyback o4 (You may pay an additional o4 when you play this spell. If you do, put it into your hand instead of your graveyard as part of the spell's effect.)\nTarget creature gets +2/+2 until end of turn.",
             "colours": [
@@ -7326,7 +7326,7 @@
         },
         {
             "id": "117d438c-c8b8-56fe-860b-c0b8345f7ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d246ac-1ca5-4c55-856c-4a83a4d638ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d246ac-1ca5-4c55-856c-4a83a4d638ab.jpg?1",
             "name": "Flailing Drake",
             "text": "Flying\nIf Flailing Drake blocks or is blocked by any creature, that creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7359,7 +7359,7 @@
         },
         {
             "id": "05ecfa54-c6eb-52d9-89d5-cc288d5ee59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941e799-a254-423e-90bb-091dbe56ca6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3941e799-a254-423e-90bb-091dbe56ca6a.jpg?1",
             "name": "Frog Tongue",
             "text": "When Frog Tongue comes into play, draw a card.\nEnchanted creature can block creatures with flying.",
             "colours": [
@@ -7392,7 +7392,7 @@
         },
         {
             "id": "e0d8a90e-99cd-532b-88a7-c96a0d2bcba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe165cd-8ef7-408e-ae56-3c6a0cc4e409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe165cd-8ef7-408e-ae56-3c6a0cc4e409.jpg?1",
             "name": "Fugitive Druid",
             "text": "Whenever any player successfully casts an enchantment spell that targets Fugitive Druid, draw a card.",
             "colours": [
@@ -7426,7 +7426,7 @@
         },
         {
             "id": "166b286c-6c0f-5271-8d1c-d353474af37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c207142-4880-4935-9827-b91bc7d9d643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c207142-4880-4935-9827-b91bc7d9d643.jpg?1",
             "name": "Harrow",
             "text": "Sacrifice a land: Search your library for up to two basic land cards and put them into play. Shuffle your library afterwards.",
             "colours": [
@@ -7457,7 +7457,7 @@
         },
         {
             "id": "47316b2d-61da-5138-b000-1919029706c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b9a001-2a1e-4fc4-9b84-c776f741a858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2b9a001-2a1e-4fc4-9b84-c776f741a858.jpg?1",
             "name": "Heartwood Dryad",
             "text": "Heartwood Dryad can block creatures with shadow.",
             "colours": [
@@ -7490,7 +7490,7 @@
         },
         {
             "id": "775f42e6-05c0-555d-a7d2-bd4160637917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baacffe-76d1-4cfb-a047-d6d126bb8de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4baacffe-76d1-4cfb-a047-d6d126bb8de0.jpg?1",
             "name": "Heartwood Giant",
             "text": "oc\nT, Sacrifice a forest: Heartwood Giant deals 2 damage to target player.",
             "colours": [
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "a5468020-84b5-5402-a935-0789c07ba79c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de263f02-8e3e-4785-9c06-9adc168994f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de263f02-8e3e-4785-9c06-9adc168994f3.jpg?1",
             "name": "Heartwood Treefolk",
             "text": "Forestwalk (If defending player controls any forests, this creature is unblockable.)",
             "colours": [
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "b0c0bcf4-4ee8-5a2c-aec1-7deb86e8f722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0175cec-e64c-45c6-9208-76127e76a7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0175cec-e64c-45c6-9208-76127e76a7cf.jpg?1",
             "name": "Horned Sliver",
             "text": "All Slivers gain trample.",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "ef9d49d9-2c16-5c4a-b3c9-379abc93507b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90442e8-9d22-4767-9e08-bd314169ea70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90442e8-9d22-4767-9e08-bd314169ea70.jpg?1",
             "name": "Krakilin",
             "text": "Krakilin comes into play with X +1/+1 counters on it.\no1o\nG: Regenerate Krakilin.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "b514e4e4-1272-575d-a238-829ec1c2b5ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d51a3c-95c0-4810-b847-4b8afd12fd64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d51a3c-95c0-4810-b847-4b8afd12fd64.jpg?1",
             "name": "Mirri's Guile",
             "text": "During your upkeep, you may look at the top three cards of your library and put them back in any order.",
             "colours": [
@@ -7653,7 +7653,7 @@
         },
         {
             "id": "a6042fef-225f-53fe-ba96-949f80a07342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b84315-5287-4401-a4c8-34c192423270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b84315-5287-4401-a4c8-34c192423270.jpg?1",
             "name": "Mongrel Pack",
             "text": "If Mongrel Pack is put into any graveyard from play during combat, put four Hound tokens into play. Treat these tokens as 1/1 green creatures.",
             "colours": [
@@ -7686,7 +7686,7 @@
         },
         {
             "id": "72b4c462-570e-5918-93b2-473cfac15d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602a1e1f-4195-48c0-8290-562e7e0db6d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/602a1e1f-4195-48c0-8290-562e7e0db6d8.jpg?1",
             "name": "Muscle Sliver",
             "text": "All Slivers get +1/+1.",
             "colours": [
@@ -7719,7 +7719,7 @@
         },
         {
             "id": "ec28b4da-08ad-5769-b153-fecdb47b9449",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff5d12a-8634-468b-86ca-4ba0f7c013ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1ff5d12a-8634-468b-86ca-4ba0f7c013ca.jpg?1",
             "name": "Natural Spring",
             "text": "Target player gains 8 life.",
             "colours": [
@@ -7750,7 +7750,7 @@
         },
         {
             "id": "aa81b531-f7ed-5a65-9780-c6ea9889d490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70386c5-053a-46c4-b26d-c6f92f536bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70386c5-053a-46c4-b26d-c6f92f536bed.jpg?1",
             "name": "Nature's Revolt",
             "text": "All lands are 2/2 creatures. (These creatures still count as lands.)",
             "colours": [
@@ -7781,7 +7781,7 @@
         },
         {
             "id": "264345aa-f7e7-53e1-b6f5-aa3c8bb8a5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be80dd2d-f595-4d80-84ae-66d3d18e7399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be80dd2d-f595-4d80-84ae-66d3d18e7399.jpg?1",
             "name": "Needle Storm",
             "text": "Needle Storm deals 4 damage to each creature with flying.",
             "colours": [
@@ -7812,7 +7812,7 @@
         },
         {
             "id": "136eaefa-78b7-5dde-9f75-ec0a5715a01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf53069-44ac-49c5-83bf-9c3c1274e407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf53069-44ac-49c5-83bf-9c3c1274e407.jpg?1",
             "name": "Nurturing Licid",
             "text": "o\nG, oc\nT: Nurturing Licid loses this ability and becomes a creature enchantment that reads \"o\nG: Regenerate enchanted creature\" instead of a creature. Move Nurturing Licid onto target creature. You may pay o\nG to end this effect.",
             "colours": [
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "058d39de-fb6e-52e6-9c8a-0fd4590a6f06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad7a961-d3a1-471a-8472-8407d1057de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad7a961-d3a1-471a-8472-8407d1057de0.jpg?1",
             "name": "Overrun",
             "text": "All creatures you control get +3/+3 and gain trample until end of turn.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "6b051b86-2e0f-58ae-8a05-84ad783237d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba68902-1e05-414a-8c3d-1f97da61d09d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba68902-1e05-414a-8c3d-1f97da61d09d.jpg?1",
             "name": "Pincher Beetles",
             "text": "Pincher Beetles cannot be the target of spells or abilities.",
             "colours": [
@@ -7909,7 +7909,7 @@
         },
         {
             "id": "80dc87a8-f0d8-55ed-a9bc-393a0e47f021",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffbf716-9c3a-45aa-8fdb-632128cc97e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffbf716-9c3a-45aa-8fdb-632128cc97e2.jpg?1",
             "name": "Rampant Growth",
             "text": "Search your library for a basic land card and put it into play, tapped. Shuffle your library afterwards.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "05925dd2-1ff8-5b59-934b-f3e4f5d8e727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21204f62-c253-4d88-a4cd-7c0f6f0513e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21204f62-c253-4d88-a4cd-7c0f6f0513e0.jpg?1",
             "name": "Reality Anchor",
             "text": "Target creature loses shadow until end of turn.\nDraw a card.",
             "colours": [
@@ -7971,7 +7971,7 @@
         },
         {
             "id": "549769f3-876d-58f3-a248-6fee896522cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229f8a3d-d1a5-46d7-9b1b-e165397e6579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229f8a3d-d1a5-46d7-9b1b-e165397e6579.jpg?1",
             "name": "Reap",
             "text": "Return any number of target cards from your graveyard to your hand. You cannot choose more cards than the number of black permanents target opponent controls.",
             "colours": [
@@ -8002,7 +8002,7 @@
         },
         {
             "id": "86c71ae6-9d20-5379-bfd1-637c24ff82bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae984b86-ac6d-45e2-9c8d-0b7ac50021a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae984b86-ac6d-45e2-9c8d-0b7ac50021a1.jpg?1",
             "name": "Recycle",
             "text": "Skip your draw phase.\nWhenever you play a card, draw a card.\nDuring your discard phase, choose and discard all but two cards.",
             "colours": [
@@ -8033,7 +8033,7 @@
         },
         {
             "id": "f14f9839-cc20-59b9-b5a3-943f3b24ca22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a8d29-cc14-49c7-ae24-5847344583ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a8d29-cc14-49c7-ae24-5847344583ed.jpg?1",
             "name": "Respite",
             "text": "Creatures deal no combat damage this turn. Gain 1 life for each attacking creature.",
             "colours": [
@@ -8064,7 +8064,7 @@
         },
         {
             "id": "c7f52912-f1e7-52c4-9d6f-79930f0287cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a12b74-f191-4362-81ab-77590ae5e68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99a12b74-f191-4362-81ab-77590ae5e68f.jpg?1",
             "name": "Root Maze",
             "text": "All artifacts and lands come into play tapped.",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "3ae93f02-3ad8-519a-8476-6e4e3df1296d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a686ed6-fc13-4882-b56c-667f556d9804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a686ed6-fc13-4882-b56c-667f556d9804.jpg?1",
             "name": "Rootbreaker Wurm",
             "text": "Trample",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "64ee24f6-4549-54b1-8f47-3c902694510f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce4d5d-63cb-47b6-94ce-2063977db9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03ce4d5d-63cb-47b6-94ce-2063977db9b4.jpg?1",
             "name": "Rootwalla",
             "text": "o1o\nG: Rootwalla gets +2/+2 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -8161,7 +8161,7 @@
         },
         {
             "id": "60208f44-3abb-554e-beab-ec1831cdd033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80f7fa7-e7c4-4fc4-99bf-8a8502965fc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80f7fa7-e7c4-4fc4-99bf-8a8502965fc8.jpg?1",
             "name": "Scragnoth",
             "text": "Protection from blue\nWhile Scragnoth is being cast, it cannot be countered.",
             "colours": [
@@ -8194,7 +8194,7 @@
         },
         {
             "id": "2827ecd0-3322-5320-925c-1cabc1527c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bb98ba-d599-4597-911c-2b472fa8817c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bb98ba-d599-4597-911c-2b472fa8817c.jpg?1",
             "name": "Seeker of Skybreak",
             "text": "oc\nT: Untap target creature.",
             "colours": [
@@ -8227,7 +8227,7 @@
         },
         {
             "id": "b86a6181-8016-5d46-9c9f-e75b1751110e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26877a52-dec3-433d-b7a5-767f6cdf2365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26877a52-dec3-433d-b7a5-767f6cdf2365.jpg?1",
             "name": "Skyshroud Elf",
             "text": "oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.\no1: Add o\nW or o\nR to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -8263,7 +8263,7 @@
         },
         {
             "id": "8a0c3a70-599b-562e-9518-1012ecdaceb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe01296-2b8b-4cdf-a041-a08bebea9c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe01296-2b8b-4cdf-a041-a08bebea9c29.jpg?1",
             "name": "Skyshroud Ranger",
             "text": "oc\nT: Choose a land card in your hand and put it into play. Play this ability as a sorcery.",
             "colours": [
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "b1a7a59d-00d9-56a8-9e8b-3eeff73b00d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c488d-79db-47d1-b7be-851f31732026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/925c488d-79db-47d1-b7be-851f31732026.jpg?1",
             "name": "Skyshroud Troll",
             "text": "o1o\nG: Regenerate Skyshroud Troll.",
             "colours": [
@@ -8331,7 +8331,7 @@
         },
         {
             "id": "42c48186-33e6-5c29-97ab-859bd522a90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45a3d3-a114-496e-b575-504179a297cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d45a3d3-a114-496e-b575-504179a297cc.jpg?1",
             "name": "Spike Drone",
             "text": "Spike Drone comes into play with one +1/+1 counter on it.\no2, Remove a +1/+1 counter from Spike Drone: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -8365,7 +8365,7 @@
         },
         {
             "id": "fe441cd3-a63b-5537-844c-541fb87f9a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994bb02d-6fef-454b-b1b1-d3d1af8dcd1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994bb02d-6fef-454b-b1b1-d3d1af8dcd1a.jpg?1",
             "name": "Storm Front",
             "text": "o\nGo\nG: Tap target creature with flying.",
             "colours": [
@@ -8396,7 +8396,7 @@
         },
         {
             "id": "2eb18c6c-bb66-55de-af52-66eb5fe2e6d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2380ab8f-58d2-4e1c-a115-cd2615b5a871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2380ab8f-58d2-4e1c-a115-cd2615b5a871.jpg?1",
             "name": "Trained Armodon",
             "text": "",
             "colours": [
@@ -8429,7 +8429,7 @@
         },
         {
             "id": "3e0bdc2a-f694-5bd6-9946-6422b35556ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b8060-e755-4a96-9193-b76550d4a6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160b8060-e755-4a96-9193-b76550d4a6ba.jpg?1",
             "name": "Tranquility",
             "text": "Destroy all enchantments.",
             "colours": [
@@ -8460,7 +8460,7 @@
         },
         {
             "id": "19bbfbf8-0110-5c95-a186-e9a1cb07537b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f94fd1-6f85-41ad-9674-f05cc893324f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38f94fd1-6f85-41ad-9674-f05cc893324f.jpg?1",
             "name": "Trumpeting Armodon",
             "text": "o1o\nG: Target creature blocks Trumpeting Armodon this turn if able.",
             "colours": [
@@ -8493,7 +8493,7 @@
         },
         {
             "id": "a2a9fab5-2d84-5c35-95bd-105015cf96ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bd094c-fcc1-4abf-ba3e-03a5b9b6d1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29bd094c-fcc1-4abf-ba3e-03a5b9b6d1c2.jpg?1",
             "name": "Verdant Force",
             "text": "During each player's upkeep, put a Saproling token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -8526,7 +8526,7 @@
         },
         {
             "id": "515d195e-0379-5a0e-8d73-379906157bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79664d-3461-44e7-afe6-33ec54e312ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c79664d-3461-44e7-afe6-33ec54e312ad.jpg?1",
             "name": "Verdigris",
             "text": "Destroy target artifact.",
             "colours": [
@@ -8557,7 +8557,7 @@
         },
         {
             "id": "59e963bf-2e8a-5f15-a337-a15102bd2cbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af28a5d-45dc-4e31-9009-5c0bd25a9032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7af28a5d-45dc-4e31-9009-5c0bd25a9032.jpg?1",
             "name": "Winter's Grasp",
             "text": "Destroy target land.",
             "colours": [
@@ -8588,7 +8588,7 @@
         },
         {
             "id": "8c85a01b-3e32-5ea6-a355-0d221ed11b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3560556c-f1d3-4d69-afe7-c2a5fa2a5c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3560556c-f1d3-4d69-afe7-c2a5fa2a5c3d.jpg?1",
             "name": "Dracoplasm",
             "text": "Flying\nWhen you play Dracoplasm, sacrifice any number of creatures.\nDracoplasm comes into play with power equal to the total power of the sacrificed creatures and toughness equal to the total toughness of those creatures.\no\nR: Dracoplasm gets +1/+0 until end of turn.",
             "colours": [
@@ -8623,7 +8623,7 @@
         },
         {
             "id": "ec5602cd-8764-5a91-93ba-b3b7d2c34f4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7ba92d-d327-4b1c-be40-708c5abb27df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee7ba92d-d327-4b1c-be40-708c5abb27df.jpg?1",
             "name": "Lobotomy",
             "text": "Look at target player's hand and choose any of those cards other than a basic land. Search that player's graveyard, hand, and library for all copies of the chosen card and remove them from the game. That player shuffles his or her library afterwards.",
             "colours": [
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "6ae48dd2-d08c-5e32-a918-2d43cbc61450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a89e82c-7206-4d74-95c6-ad3627e5a9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a89e82c-7206-4d74-95c6-ad3627e5a9ce.jpg?1",
             "name": "Ranger en-Vec",
             "text": "First strike\no\nG: Regenerate Ranger en-Vec.",
             "colours": [
@@ -8694,7 +8694,7 @@
         },
         {
             "id": "514624c1-e4bb-5fcd-894d-59c17c00a5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be7cfa-bf75-407d-b79f-2fec4b1aacf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18be7cfa-bf75-407d-b79f-2fec4b1aacf5.jpg?1",
             "name": "Segmented Wurm",
             "text": "Whenever Segmented Wurm is the target of a spell or ability, put a -1/-1 counter on it.",
             "colours": [
@@ -8729,7 +8729,7 @@
         },
         {
             "id": "1082a564-ed2c-5319-bcf7-58a19b9d8ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1624f7-8275-46d3-ab7e-7b162e27593f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1624f7-8275-46d3-ab7e-7b162e27593f.jpg?1",
             "name": "Selenia, Dark Angel",
             "text": "Flying\nSelenia, Dark Angel counts as an Angel.\nPay 2 life: Return Selenia to owner's hand.",
             "colours": [
@@ -8767,7 +8767,7 @@
         },
         {
             "id": "ee4d47a2-7678-5084-970e-25cf8b8e0fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8efbec-e8bf-4e34-bf13-b43916d2e9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb8efbec-e8bf-4e34-bf13-b43916d2e9ff.jpg?1",
             "name": "Sky Spirit",
             "text": "Flying, first strike",
             "colours": [
@@ -8802,7 +8802,7 @@
         },
         {
             "id": "cf967b93-9b78-594d-8739-c7d46a2d116a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b683571-6ac5-4d65-99a6-981755ed4764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b683571-6ac5-4d65-99a6-981755ed4764.jpg?1",
             "name": "Soltari Guerrillas",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nIf Soltari Guerrillas assigns combat damage to any opponent, you may redirect that damage to target creature.",
             "colours": [
@@ -8838,7 +8838,7 @@
         },
         {
             "id": "0e900f01-a8d8-5964-9564-80ffcafeffee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e6c04f-9d1a-497b-bc96-a0e48a1c1904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e6c04f-9d1a-497b-bc96-a0e48a1c1904.jpg?1",
             "name": "Spontaneous Combustion",
             "text": "Sacrifice a creature: Spontaneous Combustion deals 3 damage to each creature.",
             "colours": [
@@ -8871,7 +8871,7 @@
         },
         {
             "id": "f3cd08af-7432-5777-8e25-426360213511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be535a4a-c00d-4c58-a663-a3419a54da51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be535a4a-c00d-4c58-a663-a3419a54da51.jpg?1",
             "name": "Vhati il-Dal",
             "text": "oc\nT: Target creature's power or toughness is 1 until end of turn.",
             "colours": [
@@ -8909,7 +8909,7 @@
         },
         {
             "id": "e7b6a6da-ecff-5718-8fcc-f3f63ddca4ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073ac1-be1b-49c0-98b4-bf8165e2f872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b073ac1-be1b-49c0-98b4-bf8165e2f872.jpg?1",
             "name": "Wood Sage",
             "text": "oc\nT: Name a creature card. Reveal the top four cards of your library to all players. If any of those cards are the named card, put them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "222ce096-8616-508e-82ee-3362beb4b807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2da99f-3c53-4980-97d6-2158c765aac0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2da99f-3c53-4980-97d6-2158c765aac0.jpg?1",
             "name": "Altar of Dementia",
             "text": "Sacrifice a creature: Target player puts a number of cards equal to that creature's power from the top of his or her library into his or her graveyard.",
             "colours": [],
@@ -8972,7 +8972,7 @@
         },
         {
             "id": "d047619b-ecc6-5169-b6e7-63a0a60f2abb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedc78e-47dc-43e3-aed7-2d5c8e97fdac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfedc78e-47dc-43e3-aed7-2d5c8e97fdac.jpg?1",
             "name": "Booby Trap",
             "text": "When Booby Trap comes into play, name a card other than a basic land.\nWhenever target opponent draws any cards, he or she reveals those cards to all players. If any of those cards is the named card, Sacrifice Booby Trap and it deals 10 damage to that player.",
             "colours": [],
@@ -8999,7 +8999,7 @@
         },
         {
             "id": "1e5de5dc-f49e-5033-afd9-4bfc63d691c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645297d1-ee77-4879-83eb-8114fbabb9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/645297d1-ee77-4879-83eb-8114fbabb9a4.jpg?1",
             "name": "Bottle Gnomes",
             "text": "Sacrifice Bottle Gnomes: Gain 3 life.",
             "colours": [],
@@ -9029,7 +9029,7 @@
         },
         {
             "id": "15ce30ba-e6e6-5a25-b4b1-bd5ffcac25a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426a28bd-033d-41af-b577-ece73cbd7b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/426a28bd-033d-41af-b577-ece73cbd7b3a.jpg?1",
             "name": "Coiled Tinviper",
             "text": "First strike",
             "colours": [],
@@ -9059,7 +9059,7 @@
         },
         {
             "id": "240d8053-572c-5f07-a167-6c55130d217b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e28d4-50e1-41db-984d-c55781295012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b26e28d4-50e1-41db-984d-c55781295012.jpg?1",
             "name": "Cold Storage",
             "text": "o3: Put target creature you control on Cold Storage.\nSacrifice Cold Storage: Put all creature cards on Cold Storage into play.",
             "colours": [],
@@ -9086,7 +9086,7 @@
         },
         {
             "id": "1af8b1b8-9572-503a-8ea8-ed9628925206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31415b9b-fb30-4132-a9a3-795b4573a901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31415b9b-fb30-4132-a9a3-795b4573a901.jpg?1",
             "name": "Cursed Scroll",
             "text": "o3, oc\nT: Name a card. Target opponent chooses a card at random from your hand. If he or she chooses the named card, Cursed Scroll deals 2 damage to target creature or player.",
             "colours": [],
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "3a287189-df95-5ba8-84bd-4784ca65c277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06425615-6c10-4766-8128-a1a09a35649d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06425615-6c10-4766-8128-a1a09a35649d.jpg?1",
             "name": "Echo Chamber",
             "text": "o4, oc\nT: Target opponent chooses target creature he or she controls. Put a token creature into play and treat it as a copy of that creature. The token creature is unaffected by summoning sickness this turn. At end of turn, remove the token creature from the game. Play this ability as a sorcery.",
             "colours": [],
@@ -9140,7 +9140,7 @@
         },
         {
             "id": "707451c9-a9fa-51ea-88e1-247de9324d40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e87f30-b27a-48e2-a133-192309dd5902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e87f30-b27a-48e2-a133-192309dd5902.jpg?1",
             "name": "Emerald Medallion",
             "text": "Your green spells cost o1 less to play.",
             "colours": [],
@@ -9167,7 +9167,7 @@
         },
         {
             "id": "c6b66c06-2903-57ef-b4c4-7f1baa2ea976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a870e48a-41ae-4d9f-b181-074deb067d40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a870e48a-41ae-4d9f-b181-074deb067d40.jpg?1",
             "name": "Emmessi Tome",
             "text": "o5, oc\nT: Draw two cards, then choose and discard a card.",
             "colours": [],
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "3f7dc8c4-d47c-55a5-958e-80b3b3fa8072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f204c-7f3d-41f2-a771-0b6227d539eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/914f204c-7f3d-41f2-a771-0b6227d539eb.jpg?1",
             "name": "Energizer",
             "text": "o2, oc\nT: Put a +1/+1 counter on Energizer.",
             "colours": [],
@@ -9224,7 +9224,7 @@
         },
         {
             "id": "08878a0e-b850-5a65-bfc8-2d813b80085a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3c7760-04d8-424d-a097-df0ca8297837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e3c7760-04d8-424d-a097-df0ca8297837.jpg?1",
             "name": "Essence Bottle",
             "text": "o3, oc\nT: Put an elixir counter on Essence Bottle.\noc\nT, Remove all elixir counters from Essence Bottle: Gain 2 life for each elixir counter removed in this way.",
             "colours": [],
@@ -9251,7 +9251,7 @@
         },
         {
             "id": "3d962848-d6cd-5041-a26f-151d2dc60b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc3d5b4-b04f-4b34-afd2-72fb3de0a33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dc3d5b4-b04f-4b34-afd2-72fb3de0a33b.jpg?1",
             "name": "Excavator",
             "text": "oc\nT, Sacrifice a basic land: Target creature gains that landwalk ability until end of turn. (If defending player controls any lands of that type, this creature is unblockable.)",
             "colours": [],
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "f458deb3-0a62-5554-81be-8bcf24e3d27f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89f599-b063-4568-b7b9-08b96d04bde1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89f599-b063-4568-b7b9-08b96d04bde1.jpg?1",
             "name": "Flowstone Sculpture",
             "text": "o2, Choose and discard a card: Flowstone Sculpture gains flying, first strike, or trample permanently, or put a +1/+1 counter on Flowstone Sculpture.",
             "colours": [],
@@ -9308,7 +9308,7 @@
         },
         {
             "id": "126e5f4c-c842-57da-b7a5-22f808fab74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83be257c-8945-46be-8b58-fb2881084026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83be257c-8945-46be-8b58-fb2881084026.jpg?1",
             "name": "Fool's Tome",
             "text": "o2, oc\nT: Draw a card. Use this ability only if you have no cards in your hand.",
             "colours": [],
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "255abdf0-6cea-57f1-9d6c-d5d3d3bd4196",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4459187-de64-456f-bb66-56dea40d5c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4459187-de64-456f-bb66-56dea40d5c3e.jpg?1",
             "name": "Grindstone",
             "text": "o3, oc\nT: Put the top two cards of target player's library into that player's graveyard. If both cards share at least one color, repeat this process.",
             "colours": [],
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "94db1ee4-9f87-5ee1-87e1-341e4bc0db6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e16191-8dca-491b-b892-17696023d581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e16191-8dca-491b-b892-17696023d581.jpg?1",
             "name": "Helm of Possession",
             "text": "You may choose not to untap Helm of Possession during your untap phase.\no2, oc\nT, Sacrifice a creature: Gain control of target creature as long as you control Helm of Possession and Helm of Possession remains tapped.",
             "colours": [],
@@ -9389,7 +9389,7 @@
         },
         {
             "id": "81dbb83e-a116-5b77-ae5a-4fb91f9b638e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0db458c-2ced-454c-8061-fff8bd363b33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0db458c-2ced-454c-8061-fff8bd363b33.jpg?1",
             "name": "Jet Medallion",
             "text": "Your black spells cost o1 less to play.",
             "colours": [],
@@ -9416,7 +9416,7 @@
         },
         {
             "id": "377e7437-2494-56d0-9a76-eb1779502e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c728e38-5656-4feb-8610-0cf45fb38094.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c728e38-5656-4feb-8610-0cf45fb38094.jpg?1",
             "name": "Jinxed Idol",
             "text": "During your upkeep, Jinxed Idol deals 2 damage to you.\nSacrifice a creature: Target opponent gains control of Jinxed Idol permanently.",
             "colours": [],
@@ -9443,7 +9443,7 @@
         },
         {
             "id": "8f3cb64b-4d14-5ecd-a0ae-03dfa2584f7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c877da3-68fa-41d0-8a24-8c79fcd8ecc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c877da3-68fa-41d0-8a24-8c79fcd8ecc1.jpg?1",
             "name": "Lotus Petal",
             "text": "oc\nT, Sacrifice Lotus Petal: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9470,7 +9470,7 @@
         },
         {
             "id": "7c652607-d1fc-5f4a-9e16-c41e93b90160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3c7309-4efb-49ce-a9cc-a8f7b04c1a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f3c7309-4efb-49ce-a9cc-a8f7b04c1a15.jpg?1",
             "name": "Magnetic Web",
             "text": "If any creature with any magnet counters on it attacks, all creatures with magnet counters on them that the attacking player controls attack if able.\nIf any creature with any magnet counters on it attacks, all creatures with magnet counters on them that the defending player controls block that creature if able.\no1, oc\nT: Put a magnet counter on target creature.",
             "colours": [],
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "3ac8b989-03c8-526c-b18f-8a1482f46fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d33ce7f-f318-4161-843a-f5bb6d6e3d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d33ce7f-f318-4161-843a-f5bb6d6e3d29.jpg?1",
             "name": "Manakin",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -9527,7 +9527,7 @@
         },
         {
             "id": "4cc7c7c3-88d6-5ed9-b01a-a2195b0a651b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30143f4f-9846-448d-8797-8fe0bc0cc5df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30143f4f-9846-448d-8797-8fe0bc0cc5df.jpg?1",
             "name": "Metallic Sliver",
             "text": "Metallic Sliver counts as a Sliver.",
             "colours": [],
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "4075b7b4-24f5-51ff-be8b-fafe029ec225",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee64a77-5308-45c7-b865-400820968c74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ee64a77-5308-45c7-b865-400820968c74.jpg?1",
             "name": "Mogg Cannon",
             "text": "oc\nT: Target creature you control gets +1/+0 and gains flying until end of turn. At end of turn, destroy that creature.",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "b705cec3-7d7b-55db-908c-c56278318fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaa9ac4-b742-4a24-a316-97538adfd361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaa9ac4-b742-4a24-a316-97538adfd361.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Choose and discard a card: Regenerate Patchwork Gnomes.",
             "colours": [],
@@ -9614,7 +9614,7 @@
         },
         {
             "id": "2dbbc1ae-1725-5df0-a938-c37cd5aa7d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44588d53-7cce-406a-8e61-cd9866691966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44588d53-7cce-406a-8e61-cd9866691966.jpg?1",
             "name": "Pearl Medallion",
             "text": "Your white spells cost o1 less to play.",
             "colours": [],
@@ -9641,7 +9641,7 @@
         },
         {
             "id": "0b460db5-c40a-5bac-b825-031253302df4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcf5b8a-563b-48d7-a874-e9c226192320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fcf5b8a-563b-48d7-a874-e9c226192320.jpg?1",
             "name": "Phyrexian Grimoire",
             "text": "o4, oc\nT: Target opponent chooses one of the top two cards in your graveyard. Remove that card from the game and put the other into your hand.",
             "colours": [],
@@ -9668,7 +9668,7 @@
         },
         {
             "id": "8689b23b-5255-5305-9bf1-023006a497a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f5d5e-3a4b-430e-8769-fb553216befa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307f5d5e-3a4b-430e-8769-fb553216befa.jpg?1",
             "name": "Phyrexian Hulk",
             "text": "",
             "colours": [],
@@ -9699,7 +9699,7 @@
         },
         {
             "id": "86c9c999-e517-5244-ae77-6bb38d8e15ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e9061a-b9e6-49ec-bc7e-c18557da9fd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e9061a-b9e6-49ec-bc7e-c18557da9fd5.jpg?1",
             "name": "Phyrexian Splicer",
             "text": "o2, oc\nT: Choose flying, first strike, trample, or shadow. Target creature with that ability loses it until end of turn. Another target creature gains that ability until end of turn.",
             "colours": [],
@@ -9726,7 +9726,7 @@
         },
         {
             "id": "8e4c5aa3-e0cf-53c3-b648-8eb2fe76abc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b55586-9ea3-403e-96ec-2604f91c79cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b55586-9ea3-403e-96ec-2604f91c79cc.jpg?1",
             "name": "Puppet Strings",
             "text": "o2, oc\nT: Tap or untap target creature.",
             "colours": [],
@@ -9753,7 +9753,7 @@
         },
         {
             "id": "305998c4-b9f0-557a-8024-8dcc19ef533a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb28b-85f3-41ae-b1f5-fac766b2dcd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb28b-85f3-41ae-b1f5-fac766b2dcd2.jpg?1",
             "name": "Ruby Medallion",
             "text": "Your red spells cost o1 less to play.",
             "colours": [],
@@ -9780,7 +9780,7 @@
         },
         {
             "id": "6353030e-ea72-53f9-9873-c1dab4b6bd31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab1e253-47cb-4089-87d5-0f998025d98c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ab1e253-47cb-4089-87d5-0f998025d98c.jpg?1",
             "name": "Sapphire Medallion",
             "text": "Your blue spells cost o1 less to play.",
             "colours": [],
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "9e92ea3d-0a34-5c08-b3fc-c9035bbe5ff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34136f2c-3edd-4ca3-b1ef-1fdcaa4518a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34136f2c-3edd-4ca3-b1ef-1fdcaa4518a0.jpg?1",
             "name": "Scalding Tongs",
             "text": "During your upkeep, if you have three or fewer cards in your hand, Scalding Tongs deals 1 damage to target opponent.",
             "colours": [],
@@ -9834,7 +9834,7 @@
         },
         {
             "id": "d548df5d-5bbd-520b-b829-bbd34272e10e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7346d8-1aef-4618-88e6-74bd8865e0f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7346d8-1aef-4618-88e6-74bd8865e0f3.jpg?1",
             "name": "Scroll Rack",
             "text": "o1, oc\nT: Choose any number of cards in your hand and set those cards aside. Put an equal number of cards from the top of your library into your hand. Then put the cards set aside in this way on top of your library in any order.",
             "colours": [],
@@ -9861,7 +9861,7 @@
         },
         {
             "id": "d38e5290-d399-56a6-8209-161cdcc0f8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b524ae7-cb24-41af-b41b-3cb3ee8cf3b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b524ae7-cb24-41af-b41b-3cb3ee8cf3b0.jpg?1",
             "name": "Squee's Toy",
             "text": "oc\nT: Prevent 1 damage to any creature.",
             "colours": [],
@@ -9888,7 +9888,7 @@
         },
         {
             "id": "8ac9f441-5750-5e73-82cb-074b7efd08eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3574d758-9143-4a2b-9ebd-ed8dab238251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3574d758-9143-4a2b-9ebd-ed8dab238251.jpg?1",
             "name": "Static Orb",
             "text": "Players cannot untap more than two permanents during their untap phases.",
             "colours": [],
@@ -9915,7 +9915,7 @@
         },
         {
             "id": "cef0077d-8122-599c-86e8-379088fd8ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d26c29-cd98-446b-b4e1-687561ed6d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d26c29-cd98-446b-b4e1-687561ed6d3f.jpg?1",
             "name": "Telethopter",
             "text": "Tap a creature you control: Telethopter gains flying until end of turn.",
             "colours": [],
@@ -9945,7 +9945,7 @@
         },
         {
             "id": "7d5c3cf7-8dc9-53d4-806f-2c96d3fe3954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71025a6b-3aed-4943-a907-9584d135f6c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71025a6b-3aed-4943-a907-9584d135f6c0.jpg?1",
             "name": "Thumbscrews",
             "text": "During your upkeep, if you have five or more cards in your hand, Thumbscrews deals 1 damage to target opponent.",
             "colours": [],
@@ -9972,7 +9972,7 @@
         },
         {
             "id": "e505cd40-4a58-5951-94c4-539311aa6ae0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5648158d-38d4-4167-8af5-ee5d7d6fd7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5648158d-38d4-4167-8af5-ee5d7d6fd7cb.jpg?1",
             "name": "Torture Chamber",
             "text": "During your upkeep, put a pain counter on Torture Chamber.\nAt the end of your turn, Torture Chamber deals 1 damage to you for each pain counter on it.\no1, oc\nT, Remove all pain counters from Torture Chamber: Torture Chamber deals 1 damage for each pain counter on it to target creature.",
             "colours": [],
@@ -9999,7 +9999,7 @@
         },
         {
             "id": "8b7bbdfb-3b99-54b4-b3a9-3a09272d4150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ffc07-9993-40de-b36e-33c7afd4cfc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c2ffc07-9993-40de-b36e-33c7afd4cfc2.jpg?1",
             "name": "Watchdog",
             "text": "Watchdog blocks if able.\nAs long as Watchdog is untapped, all creatures attacking you get -1/-0.",
             "colours": [],
@@ -10029,7 +10029,7 @@
         },
         {
             "id": "b487402f-54ef-56d8-8490-d655b7a7f251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e401e3-282b-4524-87e1-c6cd50cd6d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e401e3-282b-4524-87e1-c6cd50cd6d00.jpg?1",
             "name": "Ancient Tomb",
             "text": "oc\nT: Add two colorless mana to your mana pool. Ancient Tomb deals 2 damage to you.",
             "colours": [],
@@ -10056,7 +10056,7 @@
         },
         {
             "id": "e45e8a74-89eb-5c40-b28f-892f91f49f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01fe22-e8ff-4106-8ac5-693ef920b2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f01fe22-e8ff-4106-8ac5-693ef920b2c9.jpg?1",
             "name": "Caldera Lake",
             "text": "Caldera Lake comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nR to your mana pool. Caldera Lake deals 1 damage to you.",
             "colours": [],
@@ -10086,7 +10086,7 @@
         },
         {
             "id": "1c80ccea-d41a-54c0-b99b-1cadb2b52e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fee067d-c31f-4b09-99f5-84d1102f96b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fee067d-c31f-4b09-99f5-84d1102f96b0.jpg?1",
             "name": "Cinder Marsh",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Cinder Marsh does not untap during your next untap phase.",
             "colours": [],
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "e3475cc5-893d-540e-978e-1a77fc1e72cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4218cdda-3a62-43fb-aaf7-7ac836392796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4218cdda-3a62-43fb-aaf7-7ac836392796.jpg?1",
             "name": "Ghost Town",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no0: Return Ghost Town to owner's hand. Use this ability only during another player's turn.",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "df331a3d-bd88-50c1-b08c-df5ab24f7d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg?1",
             "name": "Maze of Shadows",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Untap target attacking creature with shadow. That creature neither deals nor receives combat damage this turn.",
             "colours": [],
@@ -10170,7 +10170,7 @@
         },
         {
             "id": "1777ff7e-c953-58ad-8ebc-98c7a516a372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474e3fb0-b0f9-4c6d-8c57-e5079a3a3c66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/474e3fb0-b0f9-4c6d-8c57-e5079a3a3c66.jpg?1",
             "name": "Mogg Hollows",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nG to your mana pool. Mogg Hollows does not untap during your next untap phase.",
             "colours": [],
@@ -10200,7 +10200,7 @@
         },
         {
             "id": "544488d1-622b-55cf-b9dd-fecca0751145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac39e8-bd0e-4fa3-bc1e-a93944d013f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ac39e8-bd0e-4fa3-bc1e-a93944d013f3.jpg?1",
             "name": "Pine Barrens",
             "text": "Pine Barrens comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nG to your mana pool. Pine Barrens deals 1 damage to you.",
             "colours": [],
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "76a83d04-c864-5274-8cf3-54e48a653ae4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b633ac2-bf98-42bd-8c26-8737a7d8edc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b633ac2-bf98-42bd-8c26-8737a7d8edc7.jpg?1",
             "name": "Reflecting Pool",
             "text": "oc\nT: Add to your mana pool one mana of any type that any land you control can produce.",
             "colours": [],
@@ -10257,7 +10257,7 @@
         },
         {
             "id": "2b997f85-c7e4-5eb9-af12-0144e35ef440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4bcbef-66bf-4625-82d5-a01c39d3d78e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d4bcbef-66bf-4625-82d5-a01c39d3d78e.jpg?1",
             "name": "Rootwater Depths",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Rootwater Depths does not untap during your next untap phase.",
             "colours": [],
@@ -10287,7 +10287,7 @@
         },
         {
             "id": "96e6dece-21b1-51b6-9a9c-439b9c274da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224cb63f-9af0-4b00-ba0b-0b604abf20c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/224cb63f-9af0-4b00-ba0b-0b604abf20c8.jpg?1",
             "name": "Salt Flats",
             "text": "Salt Flats comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nB to your mana pool. Salt Flats deals 1 damage to you.",
             "colours": [],
@@ -10317,7 +10317,7 @@
         },
         {
             "id": "a3fb9209-827d-59a6-932c-26b76ad43e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374f269-b07e-43af-911a-5454b35f14e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0374f269-b07e-43af-911a-5454b35f14e6.jpg?1",
             "name": "Scabland",
             "text": "Scabland comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nR or o\nW to your mana pool. Scabland deals 1 damage to you.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "d7fa33d9-d2f8-5395-8da7-081fae05561f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01f43b-d0b3-4cd5-9694-aed30a79462c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa01f43b-d0b3-4cd5-9694-aed30a79462c.jpg?1",
             "name": "Skyshroud Forest",
             "text": "Skyshroud Forest comes into play tapped.\noc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nG to your mana pool. Skyshroud Forest deals 1 damage to you.",
             "colours": [],
@@ -10377,7 +10377,7 @@
         },
         {
             "id": "c6a4a1a1-e598-5987-8e88-da1675e3533c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3d349-5c23-43a9-b25e-0e1a35b84673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d3d349-5c23-43a9-b25e-0e1a35b84673.jpg?1",
             "name": "Stalking Stones",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no6: Stalking Stones becomes a 3/3 artifact creature permanently. (This creature still counts as a land.)",
             "colours": [],
@@ -10404,7 +10404,7 @@
         },
         {
             "id": "d73a6e7f-bf7e-5847-af3b-19c53b49f6b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3dcb12-e224-40c8-aecf-941fceb1d323.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3dcb12-e224-40c8-aecf-941fceb1d323.jpg?1",
             "name": "Thalakos Lowlands",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nU to your mana pool. Thalakos Lowlands does not untap during your next untap phase.",
             "colours": [],
@@ -10434,7 +10434,7 @@
         },
         {
             "id": "4b8a13f9-9012-5a61-8932-3f4d19e10d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15377e49-e929-413f-9501-8f3e4afa0050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15377e49-e929-413f-9501-8f3e4afa0050.jpg?1",
             "name": "Vec Townships",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nG or o\nW to your mana pool. Vec Townships does not untap during your next untap phase.",
             "colours": [],
@@ -10464,7 +10464,7 @@
         },
         {
             "id": "2392456a-7a4a-5554-884f-b7ccaef08651",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff731b-8399-40c8-b539-ba6ba5783771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99ff731b-8399-40c8-b539-ba6ba5783771.jpg?1",
             "name": "Wasteland",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Wasteland: Destroy target nonbasic land.",
             "colours": [],
@@ -10491,7 +10491,7 @@
         },
         {
             "id": "1747e687-231b-59e8-87a3-56431946d886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e339a9-3f9b-401e-a459-dc3affc9a114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62e339a9-3f9b-401e-a459-dc3affc9a114.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10528,7 +10528,7 @@
         },
         {
             "id": "e8b1924f-5a4e-5c78-a2c8-38fc89f42a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da37f78a-a0a6-4ca3-921c-4bc2c17ccda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da37f78a-a0a6-4ca3-921c-4bc2c17ccda6.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10565,7 +10565,7 @@
         },
         {
             "id": "c9c45a3b-ffc1-5728-8383-a99f11cae83f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd35bef-1702-4b3d-b149-8761c5cc5ed9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd35bef-1702-4b3d-b149-8761c5cc5ed9.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10602,7 +10602,7 @@
         },
         {
             "id": "4cd7be76-69c4-5182-a578-3e9a06bbb559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f7baf6-de14-40f8-871f-dda889672608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7f7baf6-de14-40f8-871f-dda889672608.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10639,7 +10639,7 @@
         },
         {
             "id": "e5b357bd-2c3a-5019-93f8-dd2950a3d18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22578bc8-10c6-4598-82bc-70e970a8f518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22578bc8-10c6-4598-82bc-70e970a8f518.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10676,7 +10676,7 @@
         },
         {
             "id": "913ee0c4-5ab7-5d1f-9037-c87265893eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f891c3f-82e2-4f9d-ae4b-443fce0bdd71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f891c3f-82e2-4f9d-ae4b-443fce0bdd71.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10713,7 +10713,7 @@
         },
         {
             "id": "bf1ea798-07c2-5268-91d2-3e58b2e6a42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38e48ff-17c8-470c-ba8b-966da1777e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38e48ff-17c8-470c-ba8b-966da1777e77.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10750,7 +10750,7 @@
         },
         {
             "id": "acfea428-2fa8-5f12-8994-f9a5ccfa547e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6e59d7-5038-46b4-9f60-3d9d0cbf0a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e6e59d7-5038-46b4-9f60-3d9d0cbf0a4e.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10787,7 +10787,7 @@
         },
         {
             "id": "b3f49a68-1590-5e6b-95ef-15e3c9b340e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5912d2aa-fe91-4cea-9c7a-6dca745f8560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5912d2aa-fe91-4cea-9c7a-6dca745f8560.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10824,7 +10824,7 @@
         },
         {
             "id": "e7f4cbbc-3c8f-5e82-a9a6-533b9b0debf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000366c8-7a43-49d7-a103-ac5bd7efd9aa.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10861,7 +10861,7 @@
         },
         {
             "id": "854e9559-122c-52d5-a5d6-186167ff9418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96dbfea-3b79-4e5b-a356-3c04d1e78e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c96dbfea-3b79-4e5b-a356-3c04d1e78e83.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10898,7 +10898,7 @@
         },
         {
             "id": "b77d2bea-6adc-5f7a-9bc7-b37e988b6e82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9330376c-0242-4e28-b535-26c84b43c3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9330376c-0242-4e28-b535-26c84b43c3e6.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -10935,7 +10935,7 @@
         },
         {
             "id": "b491f8f6-1349-5a15-8814-f7642bc35d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6dc341-89dc-4e99-baa2-ad0ae59f0e94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6dc341-89dc-4e99-baa2-ad0ae59f0e94.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -10972,7 +10972,7 @@
         },
         {
             "id": "09ff5e23-3a99-546d-8eaf-e72de329f23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fb0ed-5a19-4fde-b2c4-f46c7e0915f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/676fb0ed-5a19-4fde-b2c4-f46c7e0915f8.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11009,7 +11009,7 @@
         },
         {
             "id": "a87d8455-9b61-5e88-aea2-63d60da77407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515ced4-b679-48f0-bf62-8b7baef5e1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9515ced4-b679-48f0-bf62-8b7baef5e1c2.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11046,7 +11046,7 @@
         },
         {
             "id": "40273ea8-5c14-5791-9ac1-69e05efa4773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e043bf-a6d7-4778-8460-13bdf38b7d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23e043bf-a6d7-4778-8460-13bdf38b7d39.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11083,7 +11083,7 @@
         },
         {
             "id": "bba765cb-187a-58eb-b976-fb7b7942142c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b3ffbd-3f3e-4fca-80c2-94f9fdc198a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36b3ffbd-3f3e-4fca-80c2-94f9fdc198a5.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11120,7 +11120,7 @@
         },
         {
             "id": "c5b0850e-b467-5a6a-a3db-0af6027e7e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bac71a-c326-4640-bdf8-43682f59060b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72bac71a-c326-4640-bdf8-43682f59060b.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11157,7 +11157,7 @@
         },
         {
             "id": "5ff15278-d1d0-5487-9122-a26d6f088b97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b667225-a808-43e9-955e-6c4e7ecd53f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b667225-a808-43e9-955e-6c4e7ecd53f2.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11194,7 +11194,7 @@
         },
         {
             "id": "26981e7a-8dff-55f6-bc90-bcdbdd93c7d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32411c3a-da2b-4316-9848-971e90951303.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32411c3a-da2b-4316-9848-971e90951303.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/TOR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/TOR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "fc1a0569-b60f-5552-9e70-4173a8ed2ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3215ba-e492-4cfd-aa16-0da4818eed1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3215ba-e492-4cfd-aa16-0da4818eed1b.jpg?1",
             "name": "Angel of Retribution",
             "text": "Flying, first strike",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "ddb07907-9ce1-5938-b972-d34c53eaa94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c8f774-6d4f-4fd0-85c0-26ef713e6b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c8f774-6d4f-4fd0-85c0-26ef713e6b89.jpg?1",
             "name": "Aven Trooper",
             "text": "Flying\no2o\nW, Discard a card from your hand: Aven Trooper gets +1/+2 until end of turn.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "441ceda3-1ceb-5502-bad4-43254850608e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6609ef-71af-4775-affc-34153700c556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd6609ef-71af-4775-affc-34153700c556.jpg?1",
             "name": "Cleansing Meditation",
             "text": "Destroy all enchantments.\nThreshold Instead destroy all enchantments, then return to play all cards in your graveyard destroyed this way. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "bc146494-d03f-5c9f-81ff-71aea02c7946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310cb525-9299-471e-b310-392353b25472.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/310cb525-9299-471e-b310-392353b25472.jpg?1",
             "name": "Equal Treatment",
             "text": "If any source would deal 1 or more damage to a creature or player this turn, it deals 2 damage to that creature or player instead.\nDraw a card.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "1f6c1d56-0c51-5274-a2d4-7bc58e56be59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbda39b-a998-4ad9-95df-72ed9556c390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbda39b-a998-4ad9-95df-72ed9556c390.jpg?1",
             "name": "Floating Shield",
             "text": "As Floating Shield comes into play, choose a color.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Floating Shield.\nSacrifice Floating Shield: Target creature gains protection from the chosen color until end of turn.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "08f51ca5-bd07-5616-a787-a75d0cebd0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f156d1-2655-42aa-a785-d8eb15cb5422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f156d1-2655-42aa-a785-d8eb15cb5422.jpg?1",
             "name": "Frantic Purification",
             "text": "Destroy target enchantment.\nMadness o\nW (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -203,7 +203,7 @@
         },
         {
             "id": "c55b66dc-8ca0-5396-a889-981c0f86a055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467c940-dae4-4667-bec8-524dbce13283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467c940-dae4-4667-bec8-524dbce13283.jpg?1",
             "name": "Hypochondria",
             "text": "o\nW, Discard a card from your hand: Prevent the next 3 damage that would be dealt to target creature or player this turn.\no\nW, Sacrifice Hypochondria: Prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -235,7 +235,7 @@
         },
         {
             "id": "519e48b8-482c-561f-99e2-7c103c1adc1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3229ca5a-5340-48b8-bd46-b0b924c8faf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3229ca5a-5340-48b8-bd46-b0b924c8faf7.jpg?1",
             "name": "Major Teroh",
             "text": "Flying\no3o\nWo\nW, Sacrifice Major Teroh: Remove all black creatures from the game.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "d6b06a6f-7427-5b46-8f97-f6beb053d727",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886a3cfd-7f83-480a-bb22-eec67ad35e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/886a3cfd-7f83-480a-bb22-eec67ad35e4f.jpg?1",
             "name": "Militant Monk",
             "text": "Attacking doesn't cause Militant Monk to tap.\noc\nT: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "6f4643e0-8b63-536f-996b-e5dbfe8b28e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62e17a7-3602-45af-bdb6-fa5f2a9f1155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62e17a7-3602-45af-bdb6-fa5f2a9f1155.jpg?1",
             "name": "Morningtide",
             "text": "Remove all cards in all graveyards from the game.",
             "colours": [
@@ -340,7 +340,7 @@
         },
         {
             "id": "0874b6d9-0619-5649-9208-e02fbed73a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b235567a-424e-48da-a94b-c6674a73b3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b235567a-424e-48da-a94b-c6674a73b3fa.jpg?1",
             "name": "Mystic Familiar",
             "text": "Flying\nThreshold Mystic Familiar gets +1/+1 and has protection from black. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -374,7 +374,7 @@
         },
         {
             "id": "1fcdafc5-bbbe-5cc8-97ee-34d542ccae5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9520a1be-db77-4f31-a67d-6309a3ddc566.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9520a1be-db77-4f31-a67d-6309a3ddc566.jpg?1",
             "name": "Pay No Heed",
             "text": "Prevent all damage a source of your choice would deal this turn.",
             "colours": [
@@ -406,7 +406,7 @@
         },
         {
             "id": "cf426dc0-d57a-5d18-b439-7ab99d16b5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9dfae5-63f6-401a-9dec-afe838190824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9dfae5-63f6-401a-9dec-afe838190824.jpg?1",
             "name": "Possessed Nomad",
             "text": "Attacking doesn't cause Possessed Nomad to tap.\nThreshold Possessed Nomad gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target white creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -443,7 +443,7 @@
         },
         {
             "id": "29dadd6e-660b-52a0-80b7-ef4e3a714a01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4acbc7f-c86e-4285-a66d-d7b03fe44377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4acbc7f-c86e-4285-a66d-d7b03fe44377.jpg?1",
             "name": "Reborn Hero",
             "text": "Attacking doesn't cause Reborn Hero to tap.\nThreshold When Reborn Hero is put into a graveyard from play, you may pay o\nWo\nW. If you do, return Reborn Hero to play under your control. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "0fa43b6d-f844-5790-89c9-834903b07496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdbe7c6-99ad-4c73-bffe-7bbdc6965854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efdbe7c6-99ad-4c73-bffe-7bbdc6965854.jpg?1",
             "name": "Spirit Flare",
             "text": "Tap target untapped creature you control. If you do, it deals damage equal to its power to target attacking or blocking creature an opponent controls.\nFlashback\u2014o1o\nW, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -510,7 +510,7 @@
         },
         {
             "id": "d4a31710-0637-50eb-8fe3-41817842b686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436044d7-981c-4273-a0b4-6dd455608c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/436044d7-981c-4273-a0b4-6dd455608c47.jpg?1",
             "name": "Stern Judge",
             "text": "oc\nT: Each player loses 1 life for each swamp he or she controls.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "cba1546a-9dc6-5b14-8b38-8f14b66ab860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676e6fb-030d-40aa-a914-27ab6d7d5fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7676e6fb-030d-40aa-a914-27ab6d7d5fc5.jpg?1",
             "name": "Strength of Isolation",
             "text": "Enchanted creature gets +1/+2 and has protection from black.\nMadness o\nW (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "3cc5aa27-fd04-51ea-9165-fc2be033009c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff8cf45-c84f-49d7-ad3d-b5e046286cb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bff8cf45-c84f-49d7-ad3d-b5e046286cb3.jpg?1",
             "name": "Teroh's Faithful",
             "text": "When Teroh's Faithful comes into play, you gain 4 life.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "c018f0c1-d898-5b54-837f-03dc011182c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a39f909-7114-4482-8302-b2a56ca9f556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a39f909-7114-4482-8302-b2a56ca9f556.jpg?1",
             "name": "Teroh's Vanguard",
             "text": "You may play Teroh's Vanguard any time you could play an instant.\nThreshold When Teroh's Vanguard comes into play, creatures you control gain protection from black until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "9a42fd02-1943-568d-9fc3-7a2d9b7a6e91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8bee2-9e3d-493c-a937-645bf3dcf0db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e8bee2-9e3d-493c-a937-645bf3dcf0db.jpg?1",
             "name": "Transcendence",
             "text": "You don't lose the game for having 0 or less life.\nWhen you have 20 or more life, you lose the game.\nWhenever you lose life, you gain 2 life for each 1 life you lost. (Damage dealt to you causes you to lose life.)",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "23f5d9b5-4bb5-576e-a00b-ebd15fb35dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfe8b2-cc98-4430-b576-085163bdf0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48bfe8b2-cc98-4430-b576-085163bdf0b6.jpg?1",
             "name": "Vengeful Dreams",
             "text": "As an additional cost to play Vengeful Dreams, discard X cards from your hand.\nRemove X target attacking creatures from the game.",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "ab88c891-75d4-5d09-acf9-a758cd440f32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd68be-6e6a-4577-8465-a892463b6d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64cd68be-6e6a-4577-8465-a892463b6d6c.jpg?1",
             "name": "Alter Reality",
             "text": "Change the text of target permanent or spell by replacing all instances of one color word with another. (This effect doesn't end at end of turn.)\nFlashback o1o\nU (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "bc9aee0e-058a-5127-a7fd-83a6d730caf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887cac61-2001-4bd1-aeeb-20149ebc5856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/887cac61-2001-4bd1-aeeb-20149ebc5856.jpg?1",
             "name": "Ambassador Laquatus",
             "text": "o3: Target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -782,7 +782,7 @@
         },
         {
             "id": "ba9a0a67-c125-5d43-9344-d723c316127f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1243552a-ca57-42ce-817e-d6268fc673e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1243552a-ca57-42ce-817e-d6268fc673e0.jpg?1",
             "name": "Aquamoeba",
             "text": "Discard a card from your hand: Switch Aquamoeba's power and toughness until end of turn.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "2610df1e-b8cc-5b79-8abc-e02e17ba4675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23ebd3b-59bf-4f3d-b320-9283871c4540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23ebd3b-59bf-4f3d-b320-9283871c4540.jpg?1",
             "name": "Balshan Collaborator",
             "text": "Flying\no\nB: Balshan Collaborator gets +1/+1 until end of turn.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "71c348ea-ccbf-52df-9a9c-990675344cc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59a2cea-3b65-43da-bc6e-0e3c82f25b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59a2cea-3b65-43da-bc6e-0e3c82f25b3c.jpg?1",
             "name": "Breakthrough",
             "text": "Draw four cards, then choose X cards in your hand and discard the rest from it.",
             "colours": [
@@ -885,7 +885,7 @@
         },
         {
             "id": "e2151173-fc41-5970-96e1-4a4291e72dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9ca63d-7e77-48f3-abdc-2d2f9cb3a0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9ca63d-7e77-48f3-abdc-2d2f9cb3a0d9.jpg?1",
             "name": "Cephalid Aristocrat",
             "text": "Whenever Cephalid Aristocrat becomes the target of a spell or ability, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -920,7 +920,7 @@
         },
         {
             "id": "0d815dba-bbcc-5a5e-a2cd-556a618d6bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dceb8cf5-b31a-400e-aea5-ad0c3552d697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dceb8cf5-b31a-400e-aea5-ad0c3552d697.jpg?1",
             "name": "Cephalid Illusionist",
             "text": "Whenever Cephalid Illusionist becomes the target of a spell or ability, put the top three cards of your library into your graveyard.\no2o\nU, oc\nT: This turn prevent all combat damage that would be dealt to and dealt by target creature you control.",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "1e6a2789-eff5-5d79-9904-26898236e81b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434e2ece-7b00-4ad1-9c35-cca16fbb002b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434e2ece-7b00-4ad1-9c35-cca16fbb002b.jpg?1",
             "name": "Cephalid Sage",
             "text": "Threshold When Cephalid Sage comes into play, draw three cards, then discard two cards from your hand. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "412122d4-1f92-5039-81c5-53b246e31b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d989b2-0198-4e5b-8aad-ee939191dd28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33d989b2-0198-4e5b-8aad-ee939191dd28.jpg?1",
             "name": "Cephalid Snitch",
             "text": "Sacrifice Cephalid Snitch: Target creature loses protection from black until end of turn.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "4987901a-a992-5217-b716-9243a0c6f8b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2500976f-a329-4a51-bcc1-cafe39bc3ccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2500976f-a329-4a51-bcc1-cafe39bc3ccf.jpg?1",
             "name": "Cephalid Vandal",
             "text": "At the beginning of your upkeep, put a shred counter on Cephalid Vandal. Then put the top card of your library into your graveyard for each shred counter on Cephalid Vandal.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "44185394-1935-5e9f-9bd3-5b9771ac7697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd28bc8e-842f-4788-92a0-3019e3c2385f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd28bc8e-842f-4788-92a0-3019e3c2385f.jpg?1",
             "name": "Churning Eddy",
             "text": "Return target creature and target land to their owners' hands.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "e8462ebd-de29-557a-8358-b88d87d8d34a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9198d6-201d-4175-8f70-eef92d7d5bb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9198d6-201d-4175-8f70-eef92d7d5bb5.jpg?1",
             "name": "Circular Logic",
             "text": "Counter target spell unless its controller pays o1 for each card in your graveyard.\nMadness o\nU (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "5c150d9b-681a-50e8-8395-294543ffaeae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1f56e8-55cb-4b81-9946-9f0f813e3d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d1f56e8-55cb-4b81-9946-9f0f813e3d4a.jpg?1",
             "name": "Compulsion",
             "text": "o1o\nU, Discard a card from your hand: Draw a card.\no1o\nU, Sacrifice Compulsion: Draw a card.",
             "colours": [
@@ -1155,7 +1155,7 @@
         },
         {
             "id": "78de564a-f64b-51d7-90b1-4c84496409b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9cf1e-d398-41e0-8b11-afe1015e4fd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9cf1e-d398-41e0-8b11-afe1015e4fd9.jpg?1",
             "name": "Coral Net",
             "text": "Coral Net can enchant only a green or white creature.\nEnchanted creature has \"At the beginning of your upkeep, sacrifice this creature unless you discard a card from your hand.\"",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "63e92ee1-de37-5cc9-85f3-2cf9d9ad750f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e3c2e9-d8df-4a7a-be86-7be8c6254fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01e3c2e9-d8df-4a7a-be86-7be8c6254fa2.jpg?1",
             "name": "Deep Analysis",
             "text": "Target player draws two cards.\nFlashback\u2014o1o\nU, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "d565f956-c713-5105-800a-07cf2deec32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a45ea90-03af-446e-9df3-ef64e9613f2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a45ea90-03af-446e-9df3-ef64e9613f2c.jpg?1",
             "name": "False Memories",
             "text": "Put the top seven cards of your library into your graveyard. At end of turn, remove seven cards in your graveyard from the game.",
             "colours": [
@@ -1253,7 +1253,7 @@
         },
         {
             "id": "5f54f814-b452-59ff-8fbb-a791fb7c4462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb2705-82e7-49d9-b8cc-f98f652dd6c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58fb2705-82e7-49d9-b8cc-f98f652dd6c1.jpg?1",
             "name": "Ghostly Wings",
             "text": "Enchanted creature gets +1/+1 and has flying.\nDiscard a card from your hand: Return enchanted creature to its owner's hand.",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "e44d3e62-17dc-5cd7-b637-f1c0f18cf811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e4ace0-421d-4e8e-ab85-8f74757e99c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40e4ace0-421d-4e8e-ab85-8f74757e99c7.jpg?1",
             "name": "Hydromorph Guardian",
             "text": "o\nU, Sacrifice Hydromorph Guardian: Counter target spell that targets one or more creatures you control.",
             "colours": [
@@ -1321,7 +1321,7 @@
         },
         {
             "id": "d317e668-b43c-5760-ba06-62765c8d1bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b1c8fc-e09b-479b-ac15-f659acb2f50f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b1c8fc-e09b-479b-ac15-f659acb2f50f.jpg?1",
             "name": "Hydromorph Gull",
             "text": "Flying\no\nU, Sacrifice Hydromorph Gull: Counter target spell that targets one or more creatures you control.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "b9839771-6017-5edd-8c0f-250cb73c6d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fadf25-0995-440d-a3e6-7964ed86cff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12fadf25-0995-440d-a3e6-7964ed86cff6.jpg?1",
             "name": "Liquify",
             "text": "Counter target spell with converted mana cost 3 or less. If it's countered this way, remove it from the game instead of putting it into its owner's graveyard.",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "a913c87d-8234-5ee5-ae72-0ec343f9e62d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9821970-a5da-4045-93d8-f58c9e5797c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9821970-a5da-4045-93d8-f58c9e5797c1.jpg?1",
             "name": "Llawan, Cephalid Empress",
             "text": "When Llawan, Cephalid Empress comes into play, return all blue creatures your opponents control to their owners' hands.\nYour opponents can't play blue creature spells.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "ced723da-ba01-575d-9bb1-417982807a28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79977d84-7a20-47ef-930f-0ce7a5eff88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79977d84-7a20-47ef-930f-0ce7a5eff88e.jpg?1",
             "name": "Obsessive Search",
             "text": "Draw a card.\nMadness o\nU (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "addaa28a-1f9c-5197-968d-3170447224bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333bbcba-19a7-4307-abe7-7cffa3569e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333bbcba-19a7-4307-abe7-7cffa3569e4d.jpg?1",
             "name": "Plagiarize",
             "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "393bf366-6e5d-5170-8458-fd5e8dc2f91c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997c56c7-c625-4209-b4b6-d274dee2db48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997c56c7-c625-4209-b4b6-d274dee2db48.jpg?1",
             "name": "Possessed Aven",
             "text": "Flying\nThreshold Possessed Aven gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target blue creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1526,7 +1526,7 @@
         },
         {
             "id": "44627f26-cd3b-5a40-a724-b92d4df76e6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62fa778-ce44-4a3e-958a-91dfe5398944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62fa778-ce44-4a3e-958a-91dfe5398944.jpg?1",
             "name": "Retraced Image",
             "text": "Reveal a card in your hand, then put that card into play if it has the same name as a permanent in play.",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "77a56a80-ccff-560f-8994-7b882a5eaaba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a20b6b-43e6-4feb-9792-909332e1a846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91a20b6b-43e6-4feb-9792-909332e1a846.jpg?1",
             "name": "Skywing Aven",
             "text": "Flying\nDiscard a card from your hand: Return Skywing Aven to its owner's hand.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "d23e0bc2-550e-5718-872d-b6e8529672d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f817379-9c0b-4e43-a345-492516ccb6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f817379-9c0b-4e43-a345-492516ccb6e1.jpg?1",
             "name": "Stupefying Touch",
             "text": "When Stupefying Touch comes into play, draw a card.\nEnchanted creature's activated abilities can't be played.",
             "colours": [
@@ -1627,7 +1627,7 @@
         },
         {
             "id": "f2d75518-971f-5b19-8f68-4a03aed356c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d879226b-8ee3-4a48-b03a-d183594dc586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d879226b-8ee3-4a48-b03a-d183594dc586.jpg?1",
             "name": "Turbulent Dreams",
             "text": "As an additional cost to play Turbulent Dreams, discard X cards from your hand.\nReturn X target nonland permanents to their owners' hands.",
             "colours": [
@@ -1659,7 +1659,7 @@
         },
         {
             "id": "c77bbbae-3eac-5600-9d8c-bb6c30f7315e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27201370-32cc-4b90-890d-8c3f5362ad70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27201370-32cc-4b90-890d-8c3f5362ad70.jpg?1",
             "name": "Boneshard Slasher",
             "text": "Flying\nThreshold Boneshard Slasher gets +2/+2 and has \"When Boneshard Slasher becomes the target of a spell or ability, sacrifice it.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -1693,7 +1693,7 @@
         },
         {
             "id": "87ba5908-55bc-52df-aecc-98f3ec6edad3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5403b49d-03a7-4cc3-af3c-df098c1c9c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/5403b49d-03a7-4cc3-af3c-df098c1c9c2e.jpg?1",
             "name": "Cabal Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.\nThreshold Instead add o\nBo\nBo\nBo\nBo\nB to your mana pool. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -1725,7 +1725,7 @@
         },
         {
             "id": "0e7cf4e2-dd04-55be-87ca-cf437596ed23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ce55a2-d838-48ab-862e-d419b0cda3c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ce55a2-d838-48ab-862e-d419b0cda3c9.jpg?1",
             "name": "Cabal Surgeon",
             "text": "o2o\nBo\nB, oc\nT, Remove two cards in your graveyard from the game: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "4c6f714f-a315-5464-8622-1844834013a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcf8dd7-f45c-4ac2-9507-fa175fe89887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebcf8dd7-f45c-4ac2-9507-fa175fe89887.jpg?1",
             "name": "Cabal Torturer",
             "text": "o\nB, oc\nT: Target creature gets -1/-1 until end of turn.\nThreshold o3o\nBo\nB, oc\nT: Target creature gets -2/-2 until end of turn. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -1795,7 +1795,7 @@
         },
         {
             "id": "e23652ea-49ac-5817-b59f-8e380a7eada0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efa2579-c048-4506-babc-ec1c29bb99a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2efa2579-c048-4506-babc-ec1c29bb99a8.jpg?1",
             "name": "Carrion Rats",
             "text": "Whenever Carrion Rats attacks or blocks, any player may remove a card in his or her graveyard from the game. If a player does, Carrion Rats deals no combat damage this turn.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "dadc3a3e-4ea8-5658-904d-4b246b432fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b228-94c0-4e84-ad6d-80b170bb6c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37c2b228-94c0-4e84-ad6d-80b170bb6c0c.jpg?1",
             "name": "Carrion Wurm",
             "text": "Whenever Carrion Wurm attacks or blocks, any player may remove three cards in his or her graveyard from the game. If a player does, Carrion Wurm deals no combat damage this turn.",
             "colours": [
@@ -1864,7 +1864,7 @@
         },
         {
             "id": "9b8a549d-4cd1-53d6-900c-7f10cbf8a14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40342b11-1005-4ccc-bef4-9ea4c640b048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40342b11-1005-4ccc-bef4-9ea4c640b048.jpg?1",
             "name": "Chainer, Dementia Master",
             "text": "All Nightmares get +1/+1.\no\nBo\nBo\nB, Pay 3 life: Put target creature card from a graveyard into play under your control. That creature is black and is a Nightmare in addition to its creature types.\nWhen Chainer, Dementia Master leaves play, remove all Nightmares from the game.",
             "colours": [
@@ -1901,7 +1901,7 @@
         },
         {
             "id": "96789104-3d73-5cc6-be73-02f78ccf43e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014af391-3b4a-4aab-a3e9-f60e61016985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014af391-3b4a-4aab-a3e9-f60e61016985.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback o5o\nBo\nB (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1933,7 +1933,7 @@
         },
         {
             "id": "3aef2983-40c6-544b-9393-27814e6df47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb53a87-ba48-4c77-b284-3be321c8836e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb53a87-ba48-4c77-b284-3be321c8836e.jpg?1",
             "name": "Crippling Fatigue",
             "text": "Target creature gets -2/-2 until end of turn.\nFlashback\u2014o1o\nB, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "54c78af4-d7ea-5a67-ba83-4caf764364a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabadd3-3fc1-4c9a-ad3b-c79d60fb3390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baabadd3-3fc1-4c9a-ad3b-c79d60fb3390.jpg?1",
             "name": "Dawn of the Dead",
             "text": "At the beginning of your upkeep, you lose 1 life.\nAt the beginning of your upkeep, you may return target creature card from your graveyard to play. That creature gains haste until end of turn. Remove it from the game at end of turn.",
             "colours": [
@@ -1997,7 +1997,7 @@
         },
         {
             "id": "29217f6e-fdd2-5eaa-aa4f-31b0cb668e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073be21-c54a-4eee-9109-f3adfe757c4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4073be21-c54a-4eee-9109-f3adfe757c4e.jpg?1",
             "name": "Faceless Butcher",
             "text": "When Faceless Butcher comes into play, remove target creature other than Faceless Butcher from the game.\nWhen Faceless Butcher leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "4fbeefa6-7da4-57b4-b4f0-43532ff49a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaf8c24-3f5e-4ea5-941b-40ad1299af39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baaf8c24-3f5e-4ea5-941b-40ad1299af39.jpg?1",
             "name": "Gloomdrifter",
             "text": "Flying\nThreshold When Gloomdrifter comes into play, nonblack creatures get -2/-2 until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2067,7 +2067,7 @@
         },
         {
             "id": "ee49e3aa-982f-58ed-9fd3-598d6e10b48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfcd559-374e-4e6f-9333-2e5c855abff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfcd559-374e-4e6f-9333-2e5c855abff5.jpg?1",
             "name": "Gravegouger",
             "text": "When Gravegouger comes into play, remove up to two target cards in a single graveyard from the game.\nWhen Gravegouger leaves play, return the removed cards to their owner's graveyard.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "86ddd9ce-bbb6-5a6c-b2eb-16459cd0b4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b063c3a-267f-4f22-be51-0a14880afc24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b063c3a-267f-4f22-be51-0a14880afc24.jpg?1",
             "name": "Grotesque Hybrid",
             "text": "Whenever Grotesque Hybrid deals combat damage to a creature, destroy that creature. It can't be regenerated.\nDiscard a card from your hand: Grotesque Hybrid gains flying and protection from green and from white until end of turn.",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "5f648e9e-a131-5068-82be-9e88c0ab0bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0e53a1-11d5-4975-b698-8b5d72d241f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0e53a1-11d5-4975-b698-8b5d72d241f0.jpg?1",
             "name": "Hypnox",
             "text": "Flying\nWhen Hypnox comes into play, if you played it from your hand, remove all cards in target opponent's hand from the game.\nWhen Hypnox leaves play, return the removed cards to their owner's hand.",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "0ba5cbc3-2ed7-53db-bc33-485b75072aba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97431dca-54ca-47ef-ab00-943140e8e758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97431dca-54ca-47ef-ab00-943140e8e758.jpg?1",
             "name": "Ichorid",
             "text": "Haste\nAt end of turn, sacrifice Ichorid.\nAt the beginning of your upkeep, if Ichorid is in your graveyard, you may remove a black creature card in your graveyard other than Ichorid from the game. If you do, return Ichorid to play.",
             "colours": [
@@ -2205,7 +2205,7 @@
         },
         {
             "id": "12318b18-d6b9-5e91-81ff-48b4c9296a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a29622-23a6-42c7-8e56-690613572c94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a29622-23a6-42c7-8e56-690613572c94.jpg?1",
             "name": "Insidious Dreams",
             "text": "As an additional cost to play Insidious Dreams, discard X cards from your hand.\nSearch your library for X cards. Then shuffle your library and put those cards on top of it in any order.",
             "colours": [
@@ -2237,7 +2237,7 @@
         },
         {
             "id": "06906c32-7d54-54c7-aa9a-babed68c0d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a397bb-6910-4724-833d-7f2d92723e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74a397bb-6910-4724-833d-7f2d92723e3b.jpg?1",
             "name": "Laquatus's Champion",
             "text": "When Laquatus's Champion comes into play, target player loses 6 life.\nWhen Laquatus's Champion leaves play, that player gains 6 life.\no\nB: Regenerate Laquatus's Champion.",
             "colours": [
@@ -2272,7 +2272,7 @@
         },
         {
             "id": "31d67ad5-fb18-51e0-88df-c48586cc52c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c05f2a-b844-42b3-af91-65694b4211dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4c05f2a-b844-42b3-af91-65694b4211dd.jpg?1",
             "name": "Last Laugh",
             "text": "Whenever a permanent other than Last Laugh is put into a graveyard from play, Last Laugh deals 1 damage to each creature and each player.\nWhen no creatures are in play, sacrifice Last Laugh.",
             "colours": [
@@ -2304,7 +2304,7 @@
         },
         {
             "id": "0629f77d-c16f-595f-885c-b35e4612ed86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edd4ea-c587-4d93-a675-4cdec3e0b1ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edd4ea-c587-4d93-a675-4cdec3e0b1ca.jpg?1",
             "name": "Mesmeric Fiend",
             "text": "When Mesmeric Fiend comes into play, target opponent reveals his or her hand and you choose a nonland card from it. Remove that card from the game.\nWhen Mesmeric Fiend leaves play, return the removed card to its owner's hand.",
             "colours": [
@@ -2339,7 +2339,7 @@
         },
         {
             "id": "f1dcaea8-e6b3-5580-9660-3736d7060e90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bf3c19-f148-4542-8505-604191fd5a02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34bf3c19-f148-4542-8505-604191fd5a02.jpg?1",
             "name": "Mind Sludge",
             "text": "Target player discards a card from his or her hand for each swamp you control.",
             "colours": [
@@ -2371,7 +2371,7 @@
         },
         {
             "id": "ea852198-b417-5208-b049-965d625f6726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21146226-ff05-40d5-bc4e-42f2263104b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21146226-ff05-40d5-bc4e-42f2263104b1.jpg?1",
             "name": "Mortal Combat",
             "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
             "colours": [
@@ -2403,7 +2403,7 @@
         },
         {
             "id": "0d8a104e-4254-59dc-b494-5f56402faa18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b93caa-0f43-43ac-84e9-99f6bcbf9e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b93caa-0f43-43ac-84e9-99f6bcbf9e81.jpg?1",
             "name": "Mortiphobia",
             "text": "o1o\nB, Discard a card from your hand: Remove target card in a graveyard from the game.\no1o\nB, Sacrifice Mortiphobia: Remove target card in a graveyard from the game.",
             "colours": [
@@ -2435,7 +2435,7 @@
         },
         {
             "id": "a8f0ce54-9847-5e65-8fcd-3040a7418828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6189cab3-1963-4590-9cbc-7ab4a693d7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6189cab3-1963-4590-9cbc-7ab4a693d7c6.jpg?1",
             "name": "Mutilate",
             "text": "All creatures get -1/-1 until end of turn for each swamp you control.",
             "colours": [
@@ -2467,7 +2467,7 @@
         },
         {
             "id": "dd8a801e-f880-548f-8d7a-5c9bd2d4f5c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed9dc9c-b92b-4305-8c54-1a63f750f8d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed9dc9c-b92b-4305-8c54-1a63f750f8d1.jpg?1",
             "name": "Nantuko Shade",
             "text": "o\nB: Nantuko Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -2502,7 +2502,7 @@
         },
         {
             "id": "bc2ea9b7-1007-562c-bafe-341c729008a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6233d4c3-9407-41b0-92a9-5f90dfd6a584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6233d4c3-9407-41b0-92a9-5f90dfd6a584.jpg?1",
             "name": "Organ Grinder",
             "text": "oc\nT, Remove three cards in your graveyard from the game: Target player loses 3 life.",
             "colours": [
@@ -2536,7 +2536,7 @@
         },
         {
             "id": "e2ee3a3f-3025-56e7-8742-a7085d65531b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3f6cd2-0138-40e7-a975-3f7c68db0d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d3f6cd2-0138-40e7-a975-3f7c68db0d93.jpg?1",
             "name": "Psychotic Haze",
             "text": "Psychotic Haze deals 1 damage to each creature and each player.\nMadness o1o\nB (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "2b3144bc-c36e-5269-886b-114b16f91893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e6c5c-4bc4-4f41-8c2c-f5b8c97c53c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b9e6c5c-4bc4-4f41-8c2c-f5b8c97c53c5.jpg?1",
             "name": "Putrid Imp",
             "text": "Discard a card from your hand: Putrid Imp gains flying until end of turn.\nThreshold Putrid Imp gets +1/+1 and can't block. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -2603,7 +2603,7 @@
         },
         {
             "id": "8f6ec1be-a0bf-566c-a1ee-b1ab090dc701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d07a96-85ba-4714-94a5-4a8125954f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23d07a96-85ba-4714-94a5-4a8125954f58.jpg?1",
             "name": "Rancid Earth",
             "text": "Destroy target land.\nThreshold Instead destroy that land and Rancid Earth deals 1 damage to each creature and each player. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "abceaf8b-c9e6-5eef-b8c9-38be124bc7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63795680-5310-4c99-92c1-70e453391de9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63795680-5310-4c99-92c1-70e453391de9.jpg?1",
             "name": "Restless Dreams",
             "text": "As an additional cost to play Restless Dreams, discard X cards from your hand.\nReturn X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "16409fb6-a1d0-5fe7-8169-9e975490210a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2308c0c4-7a78-4da8-8dd8-5b35b49a1896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2308c0c4-7a78-4da8-8dd8-5b35b49a1896.jpg?1",
             "name": "Sengir Vampire",
             "text": "Flying\nWhenever a creature dealt damage by Sengir Vampire this turn is put into a graveyard, put a +1/+1 counter on Sengir Vampire.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "a7114daf-eee0-5326-93cb-c1c1ad5cbf68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449baad3-9a4a-4f5f-9e9f-02cc97ab71e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449baad3-9a4a-4f5f-9e9f-02cc97ab71e6.jpg?1",
             "name": "Shade's Form",
             "text": "Enchanted creature has \"o\nB: This creature gets +1/+1 until end of turn.\"\nWhen enchanted creature is put into a graveyard, return that creature to play under your control.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "63254f5b-a7ee-540f-8296-8935fe0c6389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b93715-985f-4719-a3c3-044c2a150e96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5b93715-985f-4719-a3c3-044c2a150e96.jpg?1",
             "name": "Shambling Swarm",
             "text": "When Shambling Swarm is put into a graveyard from play, distribute three -1/-1 counters among one, two, or three target creatures. Remove those counters at end of turn.",
             "colours": [
@@ -2769,7 +2769,7 @@
         },
         {
             "id": "c5b09b6c-5252-5740-8de1-8b9b0d37f2e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9396ac77-9f53-46bd-b126-02441a0f5594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9396ac77-9f53-46bd-b126-02441a0f5594.jpg?1",
             "name": "Sickening Dreams",
             "text": "As an additional cost to play Sickening Dreams, discard X cards from your hand.\nSickening Dreams deals X damage to each creature and each player.",
             "colours": [
@@ -2801,7 +2801,7 @@
         },
         {
             "id": "989060b0-a72d-5936-a287-e94701f05e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c875bb6-55bb-41cc-8825-8011581ff001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c875bb6-55bb-41cc-8825-8011581ff001.jpg?1",
             "name": "Slithery Stalker",
             "text": "Swampwalk\nWhen Slithery Stalker comes into play, remove target green or white creature an opponent controls from the game.\nWhen Slithery Stalker leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "5766dd59-450c-518c-9dd5-dcbaaff2b734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7d91b-cfbb-4da0-97fa-3c0a15f1dbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aa7d91b-cfbb-4da0-97fa-3c0a15f1dbb9.jpg?1",
             "name": "Soul Scourge",
             "text": "Flying\nWhen Soul Scourge comes into play, target player loses 3 life.\nWhen Soul Scourge leaves play, that player gains 3 life.",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "48368a13-87b7-53b1-ae7f-112abcccac04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afda26e7-4fdd-45e1-bcd1-f0abf91979aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afda26e7-4fdd-45e1-bcd1-f0abf91979aa.jpg?1",
             "name": "Strength of Lunacy",
             "text": "Enchanted creature gets +2/+1 and has protection from white.\nMadness o\nB (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "05ac49fe-e971-557f-be97-387837f991ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89deafd-cb7c-4da7-ab9b-8f795554a705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89deafd-cb7c-4da7-ab9b-8f795554a705.jpg?1",
             "name": "Unhinge",
             "text": "Target player discards a card from his or her hand.\nDraw a card.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "b016c395-47e6-5a94-88af-3e554fcab6ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e859c2-3457-4c4c-9b1c-0db647dcf259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78e859c2-3457-4c4c-9b1c-0db647dcf259.jpg?1",
             "name": "Waste Away",
             "text": "As an additional cost to play Waste Away, discard a card from your hand.\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "52d19dcf-afe7-56ac-9b20-e5d8842ff71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4675f-ebec-483f-a111-b505629760fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e4675f-ebec-483f-a111-b505629760fd.jpg?1",
             "name": "Zombie Trailblazer",
             "text": "Tap an untapped Zombie you control: Target land becomes a swamp until end of turn.\nTap an untapped Zombie you control: Target creature gains swampwalk until end of turn.",
             "colours": [
@@ -3004,7 +3004,7 @@
         },
         {
             "id": "63c421f3-b215-5f52-82b5-74300e2a5ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a28dd88-db90-4f02-8aa9-39051d2c4763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a28dd88-db90-4f02-8aa9-39051d2c4763.jpg?1",
             "name": "Accelerate",
             "text": "Target creature gains haste until end of turn.\nDraw a card.",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "106af149-efa9-51ae-8ae6-abdd46ac1a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecdc5-d2c7-4292-9b59-fd6bf3ba29d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81ecdc5-d2c7-4292-9b59-fd6bf3ba29d5.jpg?1",
             "name": "Balthor the Stout",
             "text": "All Barbarians get +1/+1.\no\nR: Target Barbarian gets +1/+0 until end of turn.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "9a1dda5d-6cc4-56f0-8778-adc95a352787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d67b5c-ab20-456e-8ff5-7521be8273b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d67b5c-ab20-456e-8ff5-7521be8273b2.jpg?1",
             "name": "Barbarian Outcast",
             "text": "When you control no swamps, sacrifice Barbarian Outcast.",
             "colours": [
@@ -3109,7 +3109,7 @@
         },
         {
             "id": "f4131788-1a62-5b26-8abf-e5a32f0348d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810f7e3-03ff-4c46-a88f-2f8144540780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810f7e3-03ff-4c46-a88f-2f8144540780.jpg?1",
             "name": "Crackling Club",
             "text": "Enchanted creature gets +1/+0.\nSacrifice Crackling Club: Crackling Club deals 1 damage to target creature.",
             "colours": [
@@ -3143,7 +3143,7 @@
         },
         {
             "id": "e2046740-daff-5234-8cbc-0b65f7807c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef809de-ff64-4832-95dd-2ebda5942df8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef809de-ff64-4832-95dd-2ebda5942df8.jpg?1",
             "name": "Crazed Firecat",
             "text": "When Crazed Firecat comes into play, flip a coin until you lose a flip. Put a +1/+1 counter on Crazed Firecat for each flip you win.",
             "colours": [
@@ -3178,7 +3178,7 @@
         },
         {
             "id": "b0ff65aa-9350-5432-9c7c-0658ecbd626d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fffeed0-a5ea-47ac-a7a4-0cc3bb1d408a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fffeed0-a5ea-47ac-a7a4-0cc3bb1d408a.jpg?1",
             "name": "Devastating Dreams",
             "text": "As an additional cost to play Devastating Dreams, discard X cards at random from your hand.\nEach player sacrifices X lands. Devastating Dreams deals X damage to each creature.",
             "colours": [
@@ -3210,7 +3210,7 @@
         },
         {
             "id": "d902e008-29eb-5815-a4da-2aa3c3ce94c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5003a6-211e-43d3-9a3c-756496357163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da5003a6-211e-43d3-9a3c-756496357163.jpg?1",
             "name": "Enslaved Dwarf",
             "text": "o\nR, Sacrifice Enslaved Dwarf: Target black creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "5b6fc518-5813-5bef-ab8e-c44b1b0f21d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918e46b7-cbca-4acf-8e83-94b5fcadcc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/918e46b7-cbca-4acf-8e83-94b5fcadcc49.jpg?1",
             "name": "Fiery Temper",
             "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness o\nR (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "4eb9ace4-8006-5cc9-93fd-902073549fb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7fd9b7-c394-4ab3-b945-b4aab694eb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7fd9b7-c394-4ab3-b945-b4aab694eb6a.jpg?1",
             "name": "Flaming Gambit",
             "text": "Flaming Gambit deals X damage to target player. That player may choose a creature he or she controls and have Flaming Gambit deal that damage to it instead.\nFlashback o\nXo\nRo\nR (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "8db065b8-01ed-5b51-a9d0-afd0578a7f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e550776-b806-4f66-8aab-e6a5dac6d5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e550776-b806-4f66-8aab-e6a5dac6d5cc.jpg?1",
             "name": "Flash of Defiance",
             "text": "Players can't block with green and/or white creatures this turn.\nFlashback\u2014o1o\nR, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "dffe11c6-c922-560b-a7d0-a87b5f594baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd72697-24be-42c7-a6d9-a837bdbd4662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dd72697-24be-42c7-a6d9-a837bdbd4662.jpg?1",
             "name": "Grim Lavamancer",
             "text": "o\nR, oc\nT, Remove two cards in your graveyard from the game: Grim Lavamancer deals 2 damage to target creature or player.",
             "colours": [
@@ -3375,7 +3375,7 @@
         },
         {
             "id": "bd6bbd55-0507-5c2a-9435-a170a5b09698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41ac1c-2603-4234-8963-cd47bb894024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f41ac1c-2603-4234-8963-cd47bb894024.jpg?1",
             "name": "Hell-Bent Raider",
             "text": "First strike, haste\nDiscard a card at random from your hand: Hell-Bent Raider gains protection from white until end of turn.",
             "colours": [
@@ -3410,7 +3410,7 @@
         },
         {
             "id": "ed777d42-0c42-52d7-a3aa-ee53b9befa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c55518-7bdf-4a42-ae30-cd6525557a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c55518-7bdf-4a42-ae30-cd6525557a59.jpg?1",
             "name": "Kamahl's Sledge",
             "text": "Kamahl's Sledge deals 4 damage to target creature.\nThreshold Instead Kamahl's Sledge deals 4 damage to that creature and 4 damage to that creature's controller. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "7e49f29b-f0b3-573a-aa0a-541853ddb78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0dcf33-8d3f-429c-8ad8-a65d07d7c790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0dcf33-8d3f-429c-8ad8-a65d07d7c790.jpg?1",
             "name": "Longhorn Firebeast",
             "text": "When Longhorn Firebeast comes into play, any opponent may have it deal 5 damage to him or her. If a player does, sacrifice Longhorn Firebeast.",
             "colours": [
@@ -3478,7 +3478,7 @@
         },
         {
             "id": "5eddb334-6cf2-50ac-b25f-d0caaf61b258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2e0f0-8a8e-4021-bd24-aff1a3212345.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afd2e0f0-8a8e-4021-bd24-aff1a3212345.jpg?1",
             "name": "Overmaster",
             "text": "The next instant or sorcery spell you play this turn can't be countered by spells or abilities.\nDraw a card.",
             "colours": [
@@ -3510,7 +3510,7 @@
         },
         {
             "id": "988e9471-589f-595d-95b7-621de9007955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2538fa-2eb7-47ca-a1cf-e5546e26e584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2538fa-2eb7-47ca-a1cf-e5546e26e584.jpg?1",
             "name": "Pardic Arsonist",
             "text": "Threshold When Pardic Arsonist comes into play, it deals 3 damage to target creature or player. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -3545,7 +3545,7 @@
         },
         {
             "id": "19ddbe76-0037-511e-900f-329a182026a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a60f33-1d1a-4c7c-9eb2-d9fc0d56b127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a60f33-1d1a-4c7c-9eb2-d9fc0d56b127.jpg?1",
             "name": "Pardic Collaborator",
             "text": "First strike\no\nB: Pardic Collaborator gets +1/+1 until end of turn.",
             "colours": [
@@ -3581,7 +3581,7 @@
         },
         {
             "id": "475599f4-d6fd-5e0c-aa8e-2d3ecc370055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487a6a7-066a-49bb-ab76-d79fc4300c29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f487a6a7-066a-49bb-ab76-d79fc4300c29.jpg?1",
             "name": "Pardic Lancer",
             "text": "Discard a card at random from your hand: Pardic Lancer gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -3616,7 +3616,7 @@
         },
         {
             "id": "a527f2a8-656e-53fe-a0a7-e1274895af0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac6311-8516-4db2-8c1f-626f0db0d36f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75ac6311-8516-4db2-8c1f-626f0db0d36f.jpg?1",
             "name": "Petradon",
             "text": "When Petradon comes into play, remove two target lands from the game.\nWhen Petradon leaves play, return the removed cards to play under their owners' control.\no\nR: Petradon gets +1/+0 until end of turn.",
             "colours": [
@@ -3651,7 +3651,7 @@
         },
         {
             "id": "38c8bbf7-b63c-55eb-b6c8-31feecfbf7be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc98d09-439e-426b-8403-4a3e12167336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffc98d09-439e-426b-8403-4a3e12167336.jpg?1",
             "name": "Petravark",
             "text": "When Petravark comes into play, remove target land from the game.\nWhen Petravark leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "7297032b-c487-5ec5-95d8-f6f27fb90def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfea263-6ff0-41be-9755-03bcdebfb255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfea263-6ff0-41be-9755-03bcdebfb255.jpg?1",
             "name": "Pitchstone Wall",
             "text": "(Walls can't attack.)\nWhenever you discard a card from your hand, you may sacrifice Pitchstone Wall. If you do, return the discarded card from your graveyard to your hand.",
             "colours": [
@@ -3720,7 +3720,7 @@
         },
         {
             "id": "b176c4bd-74a3-51a4-b223-930edf3e81fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e79610-8cfe-4711-bc71-8c25d68036da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e79610-8cfe-4711-bc71-8c25d68036da.jpg?1",
             "name": "Possessed Barbarian",
             "text": "First strike\nThreshold Possessed Barbarian gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target red creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -3757,7 +3757,7 @@
         },
         {
             "id": "49a12b66-156a-50a6-8058-b29da5cde6f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5af4e9-a2b6-43c7-8ff4-e761fbf693a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5af4e9-a2b6-43c7-8ff4-e761fbf693a7.jpg?1",
             "name": "Pyromania",
             "text": "o1o\nR, Discard a card at random from your hand: Pyromania deals 1 damage to target creature or player.\no1o\nR, Sacrifice Pyromania: Pyromania deals 1 damage to target creature or player.",
             "colours": [
@@ -3789,7 +3789,7 @@
         },
         {
             "id": "fa1c13c4-3989-5d83-9e27-c6b0ee423183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2562c25a-999e-4fb5-a595-f376c8abf1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2562c25a-999e-4fb5-a595-f376c8abf1ff.jpg?1",
             "name": "Radiate",
             "text": "Choose target instant or sorcery spell that targets only a single permanent or player. For each other permanent or player that spell could target, put a copy of the spell onto the stack. Each copy targets a different one of those permanents and players.",
             "colours": [
@@ -3821,7 +3821,7 @@
         },
         {
             "id": "80d91e47-765f-5895-8ed3-b62319ce17f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f1343c-77bf-4f44-8226-fdfb2c2c7015.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88f1343c-77bf-4f44-8226-fdfb2c2c7015.jpg?1",
             "name": "Skullscorch",
             "text": "Target player discards two cards at random from his or her hand unless that player has Skullscorch deal 4 damage to him or her.",
             "colours": [
@@ -3853,7 +3853,7 @@
         },
         {
             "id": "1b4cd2f6-e517-5379-9841-9fb78d80f289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98eb9371-aa20-4790-baf8-a1ad95de39de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98eb9371-aa20-4790-baf8-a1ad95de39de.jpg?1",
             "name": "Sonic Seizure",
             "text": "As an additional cost to play Sonic Seizure, discard a card at random from your hand.\nSonic Seizure deals 3 damage to target creature or player.",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "5c63e915-0e02-5b2e-ab25-1c6fff519046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415d0678-539f-4c19-8a6e-b43e747a97de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/415d0678-539f-4c19-8a6e-b43e747a97de.jpg?1",
             "name": "Temporary Insanity",
             "text": "Untap target creature with power less than the number of cards in your graveyard and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "ff666c15-0491-520f-b264-3a2986b10362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff19c870-331d-4703-a92d-c5b1d4289338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff19c870-331d-4703-a92d-c5b1d4289338.jpg?1",
             "name": "Violent Eruption",
             "text": "Violent Eruption deals 4 damage divided as you choose among any number of target creatures and/or players.\nMadness o1o\nRo\nR (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -3949,7 +3949,7 @@
         },
         {
             "id": "1abe8b04-69c4-5f90-af2c-5f3868a2c89c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32987720-cc0c-416b-b79b-217d3b37542d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32987720-cc0c-416b-b79b-217d3b37542d.jpg?1",
             "name": "Acorn Harvest",
             "text": "Put two 1/1 green Squirrel creature tokens into play.\nFlashback\u2014o1o\nG, Pay 3 life. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "3bbe2a88-8983-5b7b-8aa8-ac90210289e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a21190-3c05-40fe-9310-493ed0f9e42e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21a21190-3c05-40fe-9310-493ed0f9e42e.jpg?1",
             "name": "Anurid Scavenger",
             "text": "Protection from black\nAt the beginning of your upkeep, sacrifice Anurid Scavenger unless you put a card from your graveyard on the bottom of your library.",
             "colours": [
@@ -4016,7 +4016,7 @@
         },
         {
             "id": "7248c346-3952-5cd8-9717-174224fe4f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b849c7-c91d-4c67-a357-f7d17f9b187a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b849c7-c91d-4c67-a357-f7d17f9b187a.jpg?1",
             "name": "Arrogant Wurm",
             "text": "Trample\nMadness o2o\nG (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -4050,7 +4050,7 @@
         },
         {
             "id": "e8e569e1-993c-5c44-b2ca-1a76e0bcfb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67768a-6cd9-4163-b941-752f29c87a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a67768a-6cd9-4163-b941-752f29c87a8d.jpg?1",
             "name": "Basking Rootwalla",
             "text": "o1o\nG: Basking Rootwalla gets +2/+2 until end of turn. Play this ability only once each turn.\nMadness o0 (You may play this card for its madness cost at the time you discard it from your hand.)",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "9d00e2a7-604e-52a9-8417-c92a00f88f16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fa0a57-e7eb-454e-9527-3db702b54935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fa0a57-e7eb-454e-9527-3db702b54935.jpg?1",
             "name": "Centaur Chieftain",
             "text": "Haste\nThreshold When Centaur Chieftain comes into play, creatures you control get +1/+1 and gain trample until end of turn. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "b8dff7c3-d5be-543f-b9ea-2c4a563743c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83903c1-40fe-47a5-8bcc-2f0877c58225.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a83903c1-40fe-47a5-8bcc-2f0877c58225.jpg?1",
             "name": "Centaur Veteran",
             "text": "Trample\no\nG, Discard a card from your hand: Regenerate Centaur Veteran.",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "908b7e06-78e0-5495-bb55-c92cd41ab886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ac905a-839b-4fb5-8c17-7fd6c2c0c492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ac905a-839b-4fb5-8c17-7fd6c2c0c492.jpg?1",
             "name": "Dwell on the Past",
             "text": "Target player shuffles up to four target cards from his or her graveyard into his or her library.",
             "colours": [
@@ -4184,7 +4184,7 @@
         },
         {
             "id": "56dfb15c-6075-5802-ab33-75a8087c0080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3a735a-5f51-41af-99d1-92296cec7b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3a735a-5f51-41af-99d1-92296cec7b22.jpg?1",
             "name": "Far Wanderings",
             "text": "Search your library for a basic land card and put that card into play tapped. Then shuffle your library.\nThreshold Instead search your library for three basic land cards and put them into play tapped. Then shuffle your library. (You have threshold if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "f18cd46b-b364-5825-92c6-53dd633cb5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e672c6-6ddc-4dd2-b4c7-5083d7566e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e672c6-6ddc-4dd2-b4c7-5083d7566e87.jpg?1",
             "name": "Gurzigost",
             "text": "At the beginning of your upkeep, sacrifice Gurzigost unless you put two cards from your graveyard on the bottom of your library.\no\nGo\nG, Discard a card from your hand: You may have Gurzigost deal its combat damage to defending player this turn as though it weren't blocked.",
             "colours": [
@@ -4250,7 +4250,7 @@
         },
         {
             "id": "bfeb3ac2-3de7-509c-8f6d-f32aee83c139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1f72d-ef5e-4cea-a0ee-645570a36104.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48e1f72d-ef5e-4cea-a0ee-645570a36104.jpg?1",
             "name": "Insist",
             "text": "The next creature spell you play this turn can't be countered by spells or abilities.\nDraw a card.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "70feeeae-10b1-5969-9c2c-a0098ac2a24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec74e797-390e-4ebd-a53b-098ef3edd7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec74e797-390e-4ebd-a53b-098ef3edd7d1.jpg?1",
             "name": "Invigorating Falls",
             "text": "You gain life equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "d2ca9cac-8d4d-536f-844f-c4dcae200843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b3479-18c3-4c43-b8d1-8b4a25d271a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f24b3479-18c3-4c43-b8d1-8b4a25d271a7.jpg?1",
             "name": "Krosan Constrictor",
             "text": "Swampwalk\noc\nT: Target black creature gets -2/-0 until end of turn.",
             "colours": [
@@ -4348,7 +4348,7 @@
         },
         {
             "id": "30d87966-33f2-505c-a6b7-df6f3593c1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f9f54d-b8c7-407d-bc25-dad4db833208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f9f54d-b8c7-407d-bc25-dad4db833208.jpg?1",
             "name": "Krosan Restorer",
             "text": "oc\nT: Untap target land.\nThreshold oc\nT: Untap up to three target lands. (Play this ability only if seven or more cards are in your graveyard.)",
             "colours": [
@@ -4383,7 +4383,7 @@
         },
         {
             "id": "7b115352-628b-5e26-b4d5-71b5b0ecd657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a6f1b6-e1ed-497a-b50e-1bfa257c18c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a6f1b6-e1ed-497a-b50e-1bfa257c18c0.jpg?1",
             "name": "Nantuko Blightcutter",
             "text": "Protection from black\nThreshold Nantuko Blightcutter gets +1/+1 for each black permanent your opponents control. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4418,7 +4418,7 @@
         },
         {
             "id": "4c8b8e7e-c1ac-5e51-b505-429ed98dc7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b1198-feff-437c-9d4c-94785144c98f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76b1198-feff-437c-9d4c-94785144c98f.jpg?1",
             "name": "Nantuko Calmer",
             "text": "o\nG, oc\nT, Sacrifice Nantuko Calmer: Destroy target enchantment.\nThreshold Nantuko Calmer gets +1/+1. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4453,7 +4453,7 @@
         },
         {
             "id": "c3db5cd9-0568-5af8-a4e1-547aa1122491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d258fe7-7906-43ca-8ebd-344aa81cb85b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d258fe7-7906-43ca-8ebd-344aa81cb85b.jpg?1",
             "name": "Nantuko Cultivator",
             "text": "When Nantuko Cultivator comes into play, you may discard any number of land cards from your hand. Put that many +1/+1 counters on Nantuko Cultivator and draw that many cards.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "c3158763-e39d-5b9b-a518-6f26087f70dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea658dd-7567-4b93-88a4-08b4ffb3dad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eea658dd-7567-4b93-88a4-08b4ffb3dad7.jpg?1",
             "name": "Narcissism",
             "text": "o\nG, Discard a card from your hand: Target creature gets +2/+2 until end of turn.\no\nG, Sacrifice Narcissism: Target creature gets +2/+2 until end of turn.",
             "colours": [
@@ -4520,7 +4520,7 @@
         },
         {
             "id": "73eb451f-925c-536a-a490-2d3bb532b839",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1e794-a32e-4f91-acbb-7e60dad4cf53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1e794-a32e-4f91-acbb-7e60dad4cf53.jpg?1",
             "name": "Nostalgic Dreams",
             "text": "As an additional cost to play Nostalgic Dreams, discard X cards from your hand.\nReturn X target cards from your graveyard to your hand. Remove Nostalgic Dreams from the game.",
             "colours": [
@@ -4552,7 +4552,7 @@
         },
         {
             "id": "1bb0806a-46d6-501f-9f8e-f03fd42391c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cce010-a8e7-477b-9179-bbad38aa6438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cce010-a8e7-477b-9179-bbad38aa6438.jpg?1",
             "name": "Parallel Evolution",
             "text": "For each creature token in play, its controller puts a creature token into play that's a copy of that creature.\nFlashback o4o\nGo\nGo\nG (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "71fabf1e-b2b7-5ec9-9a98-12ef81fb3c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e11b2-9636-48a0-8705-f5ce3bc98117.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608e11b2-9636-48a0-8705-f5ce3bc98117.jpg?1",
             "name": "Possessed Centaur",
             "text": "Trample\nThreshold Possessed Centaur gets +1/+1, is black, and has \"o2o\nB, oc\nT: Destroy target green creature.\" (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4620,7 +4620,7 @@
         },
         {
             "id": "70a30893-d11b-50a7-83ef-2be0cf5837a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732bf7bb-5326-4742-8311-96ddbfe14b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/732bf7bb-5326-4742-8311-96ddbfe14b38.jpg?1",
             "name": "Seton's Scout",
             "text": "Seton's Scout may block as though it had flying.\nThreshold Seton's Scout gets +2/+2. (You have threshold as long as seven or more cards are in your graveyard.)",
             "colours": [
@@ -4657,7 +4657,7 @@
         },
         {
             "id": "53a58169-e2c5-5191-a125-87353eb951c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b934c78-258e-4b1e-9783-ec9f734e8776.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b934c78-258e-4b1e-9783-ec9f734e8776.jpg?1",
             "name": "Cabal Coffers",
             "text": "o2, oc\nT: Add o\nB to your mana pool for each swamp you control.",
             "colours": [],
@@ -4687,7 +4687,7 @@
         },
         {
             "id": "40698409-a9af-53b7-850d-4411fe01fe49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b5f0aa-1570-4064-ad20-aac7be8b2c9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b5f0aa-1570-4064-ad20-aac7be8b2c9c.jpg?1",
             "name": "Tainted Field",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nW or o\nB to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],
@@ -4718,7 +4718,7 @@
         },
         {
             "id": "cc9dc60e-4b34-5477-8e5d-24a5c8cfc238",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b462e121-015c-49c4-838a-ab788f213322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b462e121-015c-49c4-838a-ab788f213322.jpg?1",
             "name": "Tainted Isle",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nU or o\nB to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],
@@ -4749,7 +4749,7 @@
         },
         {
             "id": "a2684ded-4874-5516-9398-96182a6c50ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcaaabe-e1d7-4047-9960-79178af3d903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dcaaabe-e1d7-4047-9960-79178af3d903.jpg?1",
             "name": "Tainted Peak",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nR to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],
@@ -4780,7 +4780,7 @@
         },
         {
             "id": "d352b51b-fc4e-5926-b674-aa0871efe326",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20a35cc-69e5-42b8-b28c-ae5147451150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a20a35cc-69e5-42b8-b28c-ae5147451150.jpg?1",
             "name": "Tainted Wood",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Add o\nB or o\nG to your mana pool. Play this ability only if you control a swamp.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/TSP.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/TSP.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "02ea741e-e664-50ea-b4c6-f461870d309a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e05e5-1340-4010-b39b-3571a5829840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3e05e5-1340-4010-b39b-3571a5829840.jpg?1",
             "name": "Amrou Scout",
             "text": "{4}, {T}: Search your library for a Rebel card with converted mana cost 3 or less and put it into play. Then shuffle your library.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "1268e445-d62c-51cb-9b12-db98607e628d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc2a06d-54f7-436f-b32a-4a8daa199fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bc2a06d-54f7-436f-b32a-4a8daa199fb8.jpg?1",
             "name": "Amrou Seekers",
             "text": "Amrou Seekers can't be blocked except by artifact creatures and/or white creatures.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "9c640706-0239-5838-82eb-a96b95991799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580cb5be-fa59-4eb9-8808-7d2943fb6413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580cb5be-fa59-4eb9-8808-7d2943fb6413.jpg?1",
             "name": "Angel's Grace",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -107,7 +107,7 @@
         },
         {
             "id": "f77a31eb-1f7b-53e5-9aa2-0d0ccc9cca76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013ca9c-1d29-42f6-8665-92f98d076ff8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1013ca9c-1d29-42f6-8665-92f98d076ff8.jpg?1",
             "name": "Benalish Cavalry",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "03068b2b-e046-5513-92fd-7aa5d52461f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a3ed1e-f07e-486d-8a44-b2fbfaffa547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a3ed1e-f07e-486d-8a44-b2fbfaffa547.jpg?1",
             "name": "Castle Raptors",
             "text": "Flying\nAs long as Castle Raptors is untapped, it gets +0/+2.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "b00e4490-e8d4-5e06-a499-06de84ef8e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b19194-87bf-432c-8d34-91dd9520cbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b19194-87bf-432c-8d34-91dd9520cbd2.jpg?1",
             "name": "Cavalry Master",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nOther creatures you control with flanking have flanking. (Each instance of flanking triggers separately.)",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "eb1b5c04-f308-52ca-8b5a-b56d97395eb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5624d6-2c27-4c7a-8001-73edb2512ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f5624d6-2c27-4c7a-8001-73edb2512ffb.jpg?1",
             "name": "Celestial Crusader",
             "text": "Flash (You may play this spell any time you could play an instant.)\nSplit second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nFlying\nOther white creatures get +1/+1.",
             "colours": [
@@ -246,7 +246,7 @@
         },
         {
             "id": "8c6f6243-ffc5-5210-a777-24cc9df527ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221a5895-bc21-4f10-b5fc-a4980fde843e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221a5895-bc21-4f10-b5fc-a4980fde843e.jpg?1",
             "name": "Children of Korlis",
             "text": "Sacrifice Children of Korlis: You gain life equal to the life you've lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "4792926b-ba4f-5187-9246-1df1eb7c5301",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg?1",
             "name": "Chronosavant",
             "text": "{1}{W}: Return Chronosavant from your graveyard to play tapped. Skip your next turn.",
             "colours": [
@@ -316,7 +316,7 @@
         },
         {
             "id": "0282a355-bff6-5569-902e-56801267b806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87003295-fd7c-489a-b724-b76eef187b57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87003295-fd7c-489a-b724-b76eef187b57.jpg?1",
             "name": "Cloudchaser Kestrel",
             "text": "Flying\nWhen Cloudchaser Kestrel comes into play, destroy target enchantment.\n{W}: Target permanent becomes white until end of turn.",
             "colours": [
@@ -350,7 +350,7 @@
         },
         {
             "id": "327b2381-717a-55fc-8007-3dd570fc1924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deac6492-ce39-4137-8418-6169d3b1b632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deac6492-ce39-4137-8418-6169d3b1b632.jpg?1",
             "name": "D'Avenant Healer",
             "text": "{T}: D'Avenant Healer deals 1 damage to target attacking or blocking creature.\n{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "6303ad80-f33f-5748-9e02-af10c3ef2e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c467446b-0168-4c7d-9ab6-57ad8b664877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c467446b-0168-4c7d-9ab6-57ad8b664877.jpg?1",
             "name": "Detainment Spell",
             "text": "Enchant creature\nEnchanted creature's activated abilities can't be played.\n{1}{W}: Attach Detainment Spell to target creature.",
             "colours": [
@@ -420,7 +420,7 @@
         },
         {
             "id": "86a3bc81-54b7-527c-9b67-b44bf925e502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f781071-e9bc-49ee-ac94-23490134b909.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f781071-e9bc-49ee-ac94-23490134b909.jpg?1",
             "name": "Divine Congregation",
             "text": "You gain 2 life for each creature target player controls.\nSuspend 5\u2014{1}{W} (Rather than play this card from your hand, you may pay {1}{W} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -452,7 +452,7 @@
         },
         {
             "id": "7a8177dc-e2be-51f1-b6a8-31ef2c248ec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfad8c3e-e459-477c-b602-34df2dda1efe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfad8c3e-e459-477c-b602-34df2dda1efe.jpg?1",
             "name": "Duskrider Peregrine",
             "text": "Flying, protection from black\nSuspend 3\u2014{1}{W} (Rather than play this card from your hand, you may pay {1}{W} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "f24b13a6-1fe2-5f87-8333-7a54ef1358ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a2daf3-4d66-43f8-beda-285d85eefb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a2daf3-4d66-43f8-beda-285d85eefb57.jpg?1",
             "name": "Errant Doomsayers",
             "text": "{T}: Tap target creature with toughness 2 or less.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "9fd2b5b0-c33f-5eb4-9f9d-eb8216d3cd22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f58e1aa-587c-4f89-9552-1128c8c2da1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f58e1aa-587c-4f89-9552-1128c8c2da1a.jpg?1",
             "name": "Evangelize",
             "text": "Buyback {2}{W}{W} (You may pay an additional {2}{W}{W} as you play this spell. If you do, put this card into your hand as it resolves.)\nGain control of target creature of an opponent's choice that he or she controls.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "75f5a742-7cda-51bd-ba35-8a8a85b7e8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ef9188-737e-4cc6-b3a5-95aafddcf665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ef9188-737e-4cc6-b3a5-95aafddcf665.jpg?1",
             "name": "Flickering Spirit",
             "text": "Flying\n{3}{W}: Remove Flickering Spirit from the game, then return it to play under its owner's control.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "f1e85810-372e-578c-941d-4b6403090214",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a3622-9f24-47a3-816f-1732c0e077d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833a3622-9f24-47a3-816f-1732c0e077d0.jpg?1",
             "name": "Foriysian Interceptor",
             "text": "Flash (You may play this spell any time you could play an instant.)\nDefender\nForiysian Interceptor can block an additional creature.",
             "colours": [
@@ -622,7 +622,7 @@
         },
         {
             "id": "b98593b7-b009-5258-8898-2e7bfdc4245d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd063dc7-a35c-44c9-9f8d-b7bb2dc95bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd063dc7-a35c-44c9-9f8d-b7bb2dc95bec.jpg?1",
             "name": "Fortify",
             "text": "Choose one Creatures you control get +2/+0 until end of turn; or creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -654,7 +654,7 @@
         },
         {
             "id": "da8b32da-1f29-5527-b2cd-ba9d7894248d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d565ec-541d-429e-ab45-58db16c2f41d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24d565ec-541d-429e-ab45-58db16c2f41d.jpg?1",
             "name": "Gaze of Justice",
             "text": "As an additional cost to play Gaze of Justice, tap three untapped white creatures you control.\nRemove target creature from the game.\nFlashback {5}{W} (You may play this card from your graveyard for its flashback cost and any additional costs. Then remove it from the game.)",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "65622ec4-7a56-5d54-84ce-1d77ffdbe89b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a15d9-5899-4b84-9c00-345b19df53ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e19a15d9-5899-4b84-9c00-345b19df53ae.jpg?1",
             "name": "Griffin Guide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\nWhen enchanted creature is put into a graveyard, put a 2/2 white Griffin creature token with flying into play.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "cc9c36dd-ae06-5596-b4a9-1ac3a77720cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36a5462-3a21-4d64-af92-b541b425cdf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c36a5462-3a21-4d64-af92-b541b425cdf5.jpg?1",
             "name": "Gustcloak Cavalier",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nWhenever Gustcloak Cavalier attacks, you may tap target creature.\nWhenever Gustcloak Cavalier becomes blocked, you may untap Gustcloak Cavalier and remove it from combat.",
             "colours": [
@@ -755,7 +755,7 @@
         },
         {
             "id": "d99f6925-4e48-5b22-bb70-ce140dbe5240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab784-c77e-4b78-99fc-b5d7ed985d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/523ab784-c77e-4b78-99fc-b5d7ed985d76.jpg?1",
             "name": "Icatian Crier",
             "text": "{1}{W}, {T}, Discard a card: Put two 1/1 white Citizen creature tokens into play.",
             "colours": [
@@ -790,7 +790,7 @@
         },
         {
             "id": "6df674bc-b4b1-552a-a44d-a323df294a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb30d9-a826-4f29-ae2a-6873997674a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72eb30d9-a826-4f29-ae2a-6873997674a7.jpg?1",
             "name": "Ivory Giant",
             "text": "When Ivory Giant comes into play, tap all nonwhite creatures.\nSuspend 5\u2014{W} (Rather than play this card from your hand, you may pay {W} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "fa0d2e4d-5de3-5b3d-a258-a41c86140e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29cc9e5-29b7-4e3c-a0cd-46265b0f74ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e29cc9e5-29b7-4e3c-a0cd-46265b0f74ac.jpg?1",
             "name": "Jedit's Dragoons",
             "text": "Vigilance\nWhen Jedit's Dragoons comes into play, you gain 4 life.",
             "colours": [
@@ -859,7 +859,7 @@
         },
         {
             "id": "4a124488-10d0-5e62-9f93-01557b1a5e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdeb716-4632-4895-b771-0ebd59c868d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fdeb716-4632-4895-b771-0ebd59c868d5.jpg?1",
             "name": "Knight of the Holy Nimbus",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Knight of the Holy Nimbus would be destroyed, regenerate it.\n{2}: Knight of the Holy Nimbus can't be regenerated this turn. Only any opponent may play this ability.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "876804d2-412b-51d3-bcd5-06e143bd09cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febbea40-74c7-431f-a88f-c15d4fdda89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/febbea40-74c7-431f-a88f-c15d4fdda89d.jpg?1",
             "name": "Magus of the Disk",
             "text": "Magus of the Disk comes into play tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
             "colours": [
@@ -930,7 +930,7 @@
         },
         {
             "id": "2191f4f3-7c5a-5086-b5fd-bdf4f90ec9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785b66c-c5a4-4520-a9fa-aa199f7f56e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a785b66c-c5a4-4520-a9fa-aa199f7f56e5.jpg?1",
             "name": "Mangara of Corondor",
             "text": "{T}: Remove Mangara of Corondor and target permanent from the game.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "d1cde194-b455-58cc-bb71-445e0e37cea5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e072a-0630-472b-9106-5df554dff785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032e072a-0630-472b-9106-5df554dff785.jpg?1",
             "name": "Momentary Blink",
             "text": "Remove target creature you control from the game, then return it to play under its owner's control.\nFlashback {3}{U} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -1000,7 +1000,7 @@
         },
         {
             "id": "4e4ef91a-928b-5633-8146-1e91a06d4927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905ad286-e70b-46cd-87fd-eec13ed2d43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905ad286-e70b-46cd-87fd-eec13ed2d43b.jpg?1",
             "name": "Opal Guardian",
             "text": "When an opponent plays a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.",
             "colours": [
@@ -1032,7 +1032,7 @@
         },
         {
             "id": "0f005ec2-44b6-51d7-a961-6f4d84e2d536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e0d923-d94f-4f12-a025-86587b18878f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3e0d923-d94f-4f12-a025-86587b18878f.jpg?1",
             "name": "Outrider en-Kor",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n{0}: The next 1 damage that would be dealt to Outrider en-Kor this turn is dealt to target creature you control instead.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "e3588be2-6477-55d8-abe9-38ba7242100d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced01039-e19f-466b-bbc6-9bcb8d3ae845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced01039-e19f-466b-bbc6-9bcb8d3ae845.jpg?1",
             "name": "Pentarch Paladin",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nAs Pentarch Paladin comes into play, choose a color.\n{W}{W}, {T}: Destroy target permanent of the chosen color.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "b56689fd-ad95-5a98-a5d5-5055b510fcf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c70894-dd4a-4cbb-b3c1-57135cc151a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10c70894-dd4a-4cbb-b3c1-57135cc151a9.jpg?1",
             "name": "Pentarch Ward",
             "text": "Enchant creature\nAs Pentarch Ward comes into play, choose a color.\nWhen Pentarch Ward comes into play, draw a card.\nEnchanted creature has protection from the chosen color. This effect doesn't remove Pentarch Ward.",
             "colours": [
@@ -1137,7 +1137,7 @@
         },
         {
             "id": "25d8fbc9-105b-5c69-8065-0fc97655102c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873fddf3-40e7-41ee-9519-98d0a5268fd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873fddf3-40e7-41ee-9519-98d0a5268fd1.jpg?1",
             "name": "Plated Pegasus",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nIf a spell would deal damage to a creature or player, prevent 1 damage that spell would deal to that creature or player.",
             "colours": [
@@ -1171,7 +1171,7 @@
         },
         {
             "id": "e288597d-1db2-5a73-92d5-b9ab864f77a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d218091-d218-41ad-b666-c8ab3de7160a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d218091-d218-41ad-b666-c8ab3de7160a.jpg?1",
             "name": "Pull from Eternity",
             "text": "Put target face-up card that's removed from the game into its owner's graveyard.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "99079e5a-0996-5142-9c21-c64fb0506373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c19d42-aaaf-417c-a303-74262f82e365.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c19d42-aaaf-417c-a303-74262f82e365.jpg?1",
             "name": "Pulmonic Sliver",
             "text": "All Slivers have flying and \"If this creature would be put into a graveyard, you may put it on top of its owner's library instead.\"",
             "colours": [
@@ -1237,7 +1237,7 @@
         },
         {
             "id": "6c7dea4a-943f-5ca3-b4cb-38c1407b6c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72486240-eabb-4b37-99cc-ab13413683fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72486240-eabb-4b37-99cc-ab13413683fa.jpg?1",
             "name": "Quilled Sliver",
             "text": "All Slivers have \"{T}: This creature deals 1 damage to target attacking or blocking creature.\"",
             "colours": [
@@ -1271,7 +1271,7 @@
         },
         {
             "id": "021880ef-1f06-5da0-9542-e56c253a6e72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3be9788-2360-4ff0-b7f6-0bfbefa03ce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3be9788-2360-4ff0-b7f6-0bfbefa03ce0.jpg?1",
             "name": "Restore Balance",
             "text": "Restore Balance is white.\nSuspend 6\u2014{W}\nEach player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.",
             "colours": [
@@ -1303,7 +1303,7 @@
         },
         {
             "id": "22a4aad4-f46c-53fb-bae3-d44f8225ddf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185c8f-ac41-46e2-85b1-760abac914ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48185c8f-ac41-46e2-85b1-760abac914ac.jpg?1",
             "name": "Return to Dust",
             "text": "Remove target artifact or enchantment from the game. If you played this spell during your main phase, you may remove up to one other target artifact or enchantment from the game.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "9847a145-529f-54d6-b0ca-db1a45d12ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9d7c1c-3bfd-4705-9bc2-5ca3f84cc32a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9d7c1c-3bfd-4705-9bc2-5ca3f84cc32a.jpg?1",
             "name": "Serra Avenger",
             "text": "You can't play Serra Avenger during your first, second, or third turns of the game.\nFlying, vigilance",
             "colours": [
@@ -1369,7 +1369,7 @@
         },
         {
             "id": "e5c892f1-4f71-5286-a3a7-4fdfc4601e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073b8f2-b42d-40f2-b5fb-e78ffb1733ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b073b8f2-b42d-40f2-b5fb-e78ffb1733ea.jpg?1",
             "name": "Sidewinder Sliver",
             "text": "All Slivers have flanking. (Whenever a creature without flanking blocks a Sliver, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "8a9170a1-f8dd-5ce0-ab13-18a1ee4a526b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ffb2e6-b1bc-41c5-9e52-294c060b1d45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ffb2e6-b1bc-41c5-9e52-294c060b1d45.jpg?1",
             "name": "Spirit Loop",
             "text": "Enchant creature you control\nWhenever enchanted creature deals damage, you gain that much life.\nWhen Spirit Loop is put into a graveyard from play, return Spirit Loop to its owner's hand.",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "656385b5-13f1-5f93-9120-3a3163643b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb406292-1879-4aa9-a369-082822dae1d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb406292-1879-4aa9-a369-082822dae1d7.jpg?1",
             "name": "Temporal Isolation",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature has shadow. (It can block or be blocked by only creatures with shadow.)\nPrevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -1471,7 +1471,7 @@
         },
         {
             "id": "7c0bccf5-b69e-506a-a181-fca69a1d21f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d3a74-496e-462d-afa6-370dc2b8347d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34d3a74-496e-462d-afa6-370dc2b8347d.jpg?1",
             "name": "Tivadar of Thorn",
             "text": "First strike, protection from red\nWhen Tivadar of Thorn comes into play, destroy target Goblin.",
             "colours": [
@@ -1508,7 +1508,7 @@
         },
         {
             "id": "371b46e7-167c-582b-ae10-d70fa7ff46b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d72a950-82ed-4e7b-9e18-b8231a2ebea7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d72a950-82ed-4e7b-9e18-b8231a2ebea7.jpg?1",
             "name": "Watcher Sliver",
             "text": "All Slivers get +0/+2.",
             "colours": [
@@ -1542,7 +1542,7 @@
         },
         {
             "id": "57a4509b-1637-58ce-9be3-6e42821d1904",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991a18e5-a183-4b84-b157-5a3609b3f910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/991a18e5-a183-4b84-b157-5a3609b3f910.jpg?1",
             "name": "Weathered Bodyguards",
             "text": "As long as Weathered Bodyguards is untapped, all combat damage that would be dealt to you by unblocked creatures is dealt to Weathered Bodyguards instead.\nMorph {3}{W} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -1577,7 +1577,7 @@
         },
         {
             "id": "851a49ad-6f53-5980-b0ca-dcad98f8a869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2a2740-68cb-48c9-9716-081d369075e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2a2740-68cb-48c9-9716-081d369075e0.jpg?1",
             "name": "Zealot il-Vec",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Zealot il-Vec attacks and isn't blocked, you may have it deal 1 damage to target creature. If you do, prevent all combat damage Zealot il-Vec would deal this turn.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "5174f624-c725-5b74-b967-4aa531c88d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccedc4d-38c7-4bf3-9ca7-4febd6c49d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bccedc4d-38c7-4bf3-9ca7-4febd6c49d3d.jpg?1",
             "name": "Ancestral Vision",
             "text": "Ancestral Vision is blue.\nSuspend 4\u2014{U} (Rather than play this card from your hand, pay {U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)\nTarget player draws three cards.",
             "colours": [
@@ -1644,7 +1644,7 @@
         },
         {
             "id": "37864ff3-3679-52bb-bc07-eafda610e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be63098-6446-4e64-85b0-9af914f5e075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7be63098-6446-4e64-85b0-9af914f5e075.jpg?1",
             "name": "Bewilder",
             "text": "Target creature gets -3/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "b2d0174f-1c0b-56a1-9de0-c2c65f7c5f33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2c73-501b-46c9-bc76-134b50d35bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dab2c73-501b-46c9-bc76-134b50d35bb8.jpg?1",
             "name": "Brine Elemental",
             "text": "Morph {5}{U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Brine Elemental is turned face up, each opponent skips his or her next untap step.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "1a6dd217-e05c-510c-82ff-8cee876e643a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e175f7-f649-451b-9ee5-ad1140b2e8a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4e175f7-f649-451b-9ee5-ad1140b2e8a7.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1742,7 +1742,7 @@
         },
         {
             "id": "fea919f6-ddd7-5550-a268-c00ef3969c29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf71574-5b1e-4483-9a8e-c3212148ce9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcf71574-5b1e-4483-9a8e-c3212148ce9c.jpg?1",
             "name": "Careful Consideration",
             "text": "Target player draws four cards, then discards three cards. If you played this spell during your main phase, instead that player draws four cards, then discards two cards.",
             "colours": [
@@ -1774,7 +1774,7 @@
         },
         {
             "id": "6d11f4b3-b3f1-510b-9b8e-8a3287873275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1323d548-e2fe-47c5-8df3-f181aed537c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1323d548-e2fe-47c5-8df3-f181aed537c5.jpg?1",
             "name": "Clockspinning",
             "text": "Buyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nChoose a counter on target permanent or suspended card. Remove that counter from that permanent or card or put another of those counters on it.",
             "colours": [
@@ -1806,7 +1806,7 @@
         },
         {
             "id": "94a1e077-f870-5a9e-8940-b2e4ba42bc15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdcfa1-f499-4d95-9d79-3b3996cd75ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffcdcfa1-f499-4d95-9d79-3b3996cd75ed.jpg?1",
             "name": "Coral Trickster",
             "text": "Morph {U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Coral Trickster is turned face up, you may tap or untap target permanent.",
             "colours": [
@@ -1841,7 +1841,7 @@
         },
         {
             "id": "65ec9256-0816-5b0b-ba29-76059d467e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2266726-1832-4b7b-92e1-9bb0c43b7d5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2266726-1832-4b7b-92e1-9bb0c43b7d5d.jpg?1",
             "name": "Crookclaw Transmuter",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Crookclaw Transmuter comes into play, switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "0e4b4d39-e2d1-52fc-bbc0-2932a1f1a442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e050532-e245-4eea-90a5-03e3e410dcbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e050532-e245-4eea-90a5-03e3e410dcbe.jpg?1",
             "name": "Deep-Sea Kraken",
             "text": "Deep-Sea Kraken is unblockable.\nSuspend 9\u2014{2}{U}\nWhenever an opponent plays a spell, if Deep-Sea Kraken is suspended, remove a time counter from it.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "31727bcf-ef42-52a6-8cfe-0fa3eafec7c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559d326-b97b-43d9-b7c9-c09e1a0e9db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c559d326-b97b-43d9-b7c9-c09e1a0e9db6.jpg?1",
             "name": "Draining Whelk",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Draining Whelk comes into play, counter target spell. Put X +1/+1 counters on Draining Whelk, where X is that spell's converted mana cost.",
             "colours": [
@@ -1944,7 +1944,7 @@
         },
         {
             "id": "4d40e2b6-9c14-574e-9096-a7974e7c03ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8fc8e-3b23-4275-b19b-43aa6a307619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e8fc8e-3b23-4275-b19b-43aa6a307619.jpg?1",
             "name": "Dream Stalker",
             "text": "When Dream Stalker comes into play, return a permanent you control to its owner's hand.",
             "colours": [
@@ -1978,7 +1978,7 @@
         },
         {
             "id": "43919fca-013c-5fbc-b0a4-6dc68b492714",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3de909-b47e-45d7-9922-8d5e08a76ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3de909-b47e-45d7-9922-8d5e08a76ec9.jpg?1",
             "name": "Drifter il-Dal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nAt the beginning of your upkeep, sacrifice Drifter il-Dal unless you pay {U}.",
             "colours": [
@@ -2013,7 +2013,7 @@
         },
         {
             "id": "67648277-479e-5900-8f6e-eef793810bf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398c26cc-cd55-42c6-a744-aaefd7018960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398c26cc-cd55-42c6-a744-aaefd7018960.jpg?1",
             "name": "Errant Ephemeron",
             "text": "Flying\nSuspend 4\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2047,7 +2047,7 @@
         },
         {
             "id": "0e789258-ef50-5703-aaff-b714374680a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de753839-cf75-48d0-98c3-5765779678c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de753839-cf75-48d0-98c3-5765779678c0.jpg?1",
             "name": "Eternity Snare",
             "text": "Enchant creature\nWhen Eternity Snare comes into play, draw a card.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -2081,7 +2081,7 @@
         },
         {
             "id": "1ec2df86-8f91-5086-a13c-272b3a4d1f28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20de275a-2e11-4452-8037-bc397dd53a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20de275a-2e11-4452-8037-bc397dd53a8c.jpg?1",
             "name": "Fathom Seer",
             "text": "Morph\u2014\nReturn two Islands you control to their owner's hand. (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Fathom Seer is turned face up, draw two cards.",
             "colours": [
@@ -2115,7 +2115,7 @@
         },
         {
             "id": "5ea0f226-18da-5f19-8704-f57103f7a76b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464923e-ae6e-4c1d-9315-0ddb86c07b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c464923e-ae6e-4c1d-9315-0ddb86c07b40.jpg?1",
             "name": "Fledgling Mawcor",
             "text": "Flying\n{T}: Fledgling Mawcor deals 1 damage to target creature or player.\nMorph {U}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2149,7 +2149,7 @@
         },
         {
             "id": "41ac0506-78e0-5b26-b3a1-1e7e8c3d0031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbc7ac4-c28e-4155-b3c8-60946653b9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cbc7ac4-c28e-4155-b3c8-60946653b9b4.jpg?1",
             "name": "Fool's Demise",
             "text": "Enchant creature\nWhen enchanted creature is put into a graveyard, return that creature to play under your control.\nWhen Fool's Demise is put into a graveyard from play, return Fool's Demise to its owner's hand.",
             "colours": [
@@ -2183,7 +2183,7 @@
         },
         {
             "id": "3e3ca885-e392-57d4-878a-bd388582c7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f5c613-80ad-487f-995a-6a869c137798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f5c613-80ad-487f-995a-6a869c137798.jpg?1",
             "name": "Ixidron",
             "text": "As Ixidron comes into play, turn all other nontoken creatures in play face down. They're 2/2 creatures.\nIxidron's power and toughness are each equal to the number of face-down creatures in play.",
             "colours": [
@@ -2217,7 +2217,7 @@
         },
         {
             "id": "0d907c2b-fae2-5075-a989-5d53288809c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee06f-9021-4b65-9f53-9c326bf3a27f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368ee06f-9021-4b65-9f53-9c326bf3a27f.jpg?1",
             "name": "Looter il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Looter il-Kor deals damage to an opponent, draw a card, then discard a card.",
             "colours": [
@@ -2252,7 +2252,7 @@
         },
         {
             "id": "bd518eee-f7e5-5e75-9d3a-1e2a6fb73e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31961041-a9e6-4d96-bd4a-5c5f88a79e74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31961041-a9e6-4d96-bd4a-5c5f88a79e74.jpg?1",
             "name": "Magus of the Jar",
             "text": "{T}, Sacrifice Magus of the Jar: Each player removes his or her hand from the game face down and draws seven cards. At end of turn, each player discards his or her hand and returns to his or her hand each card he or she removed from the game this way.",
             "colours": [
@@ -2287,7 +2287,7 @@
         },
         {
             "id": "d8eb958d-5210-5f72-b262-7ce01e28608d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781cc80-5f57-4677-a9da-3523191cc7c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c781cc80-5f57-4677-a9da-3523191cc7c6.jpg?1",
             "name": "Moonlace",
             "text": "Target spell or permanent becomes colorless.",
             "colours": [
@@ -2319,7 +2319,7 @@
         },
         {
             "id": "61904af3-b273-53c9-8ea4-72f07db91375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a057e5f3-b6bd-4995-b990-714201f36989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a057e5f3-b6bd-4995-b990-714201f36989.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, and put it into your hand. Then shuffle your library.\nFlashback {5}{B} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2352,7 +2352,7 @@
         },
         {
             "id": "63c9b509-fb9b-53f1-bb92-175b92ea055b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26836ff5-b3c3-4b10-af1e-df3658781cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26836ff5-b3c3-4b10-af1e-df3658781cb2.jpg?1",
             "name": "Ophidian Eye",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -2386,7 +2386,7 @@
         },
         {
             "id": "de83949d-a2b7-55a8-871f-d409d5fe9967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c74def-83e5-4420-989d-2304bf4743ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c74def-83e5-4420-989d-2304bf4743ae.jpg?1",
             "name": "Paradox Haze",
             "text": "Enchant player\nAt the beginning of enchanted player's first upkeep each turn, that player gets an additional upkeep step after this step.",
             "colours": [
@@ -2420,7 +2420,7 @@
         },
         {
             "id": "e9a7633f-6546-5538-8a51-62cff130d52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559ca03-4442-47c5-bd6e-84e71cfa6ca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2559ca03-4442-47c5-bd6e-84e71cfa6ca5.jpg?1",
             "name": "Psionic Sliver",
             "text": "All Slivers have \"{T}: This creature deals 2 damage to target creature or player and 3 damage to itself.\"",
             "colours": [
@@ -2454,7 +2454,7 @@
         },
         {
             "id": "72f329eb-8361-5d30-b555-2c612d778bd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ad6c86-8cfb-4f24-b8e8-ecbeffc949b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ad6c86-8cfb-4f24-b8e8-ecbeffc949b8.jpg?1",
             "name": "Riftwing Cloudskate",
             "text": "Flying\nWhen Riftwing Cloudskate comes into play, return target permanent to its owner's hand.\nSuspend 3\u2014{1}{U} (Rather than play this card from your hand, you may pay {1}{U} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2488,7 +2488,7 @@
         },
         {
             "id": "7f044031-d973-5ecb-8fd1-bfdb2134d4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ea578-069e-4020-a762-d108a3e14861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e2ea578-069e-4020-a762-d108a3e14861.jpg?1",
             "name": "Sage of Epityr",
             "text": "When Sage of Epityr comes into play, look at the top four cards of your library, then put them back in any order.",
             "colours": [
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "6cb83e1b-bef6-590c-bad5-01d7ec78dcf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313e71da-ce72-4976-8286-f4495ea56485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/313e71da-ce72-4976-8286-f4495ea56485.jpg?1",
             "name": "Screeching Sliver",
             "text": "All Slivers have \"{T}: Target player puts the top card of his or her library into his or her graveyard.\"",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "52d1edc6-aa5c-5186-9c99-90eb553b3a06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb725914-1b0f-4efc-808b-9fe2eaa7f17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb725914-1b0f-4efc-808b-9fe2eaa7f17d.jpg?1",
             "name": "Shadow Sliver",
             "text": "All Slivers have shadow. (They can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "68d56978-c784-5e87-bdb0-bfdfc57a6afe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc6ee4-4b8a-4746-9d3f-4f66b3809670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8dc6ee4-4b8a-4746-9d3f-4f66b3809670.jpg?1",
             "name": "Slipstream Serpent",
             "text": "Slipstream Serpent can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice Slipstream Serpent.\nMorph {5}{U} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2625,7 +2625,7 @@
         },
         {
             "id": "018c3064-82bd-5d59-891a-2a15f1e18576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9135ba-9b6a-4443-a1c4-882f9bfae626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9135ba-9b6a-4443-a1c4-882f9bfae626.jpg?1",
             "name": "Snapback",
             "text": "You may remove a blue card in your hand from the game rather than pay Snapback's mana cost.\nReturn target creature to its owner's hand.",
             "colours": [
@@ -2657,7 +2657,7 @@
         },
         {
             "id": "95e1b428-4e53-5f7e-bb16-10c030d0f112",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95c8015-fd7d-4329-ab23-aec37a824083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95c8015-fd7d-4329-ab23-aec37a824083.jpg?1",
             "name": "Spell Burst",
             "text": "Buyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nCounter target spell with converted mana cost X.",
             "colours": [
@@ -2689,7 +2689,7 @@
         },
         {
             "id": "0af146c9-9615-5c7c-af5c-4cd1c390d986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c752a0b9-cc87-4c3e-a1e8-0162715e011a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c752a0b9-cc87-4c3e-a1e8-0162715e011a.jpg?1",
             "name": "Spiketail Drakeling",
             "text": "Flying\nSacrifice Spiketail Drakeling: Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -2723,7 +2723,7 @@
         },
         {
             "id": "2a933a10-3a99-556c-b1e2-f332bd4cbd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de52e53-8a45-4c0a-bb7d-6dc0d659a7c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de52e53-8a45-4c0a-bb7d-6dc0d659a7c0.jpg?1",
             "name": "Sprite Noble",
             "text": "Flying\nOther creatures you control with flying get +0/+1.\n{T}: Other creatures you control with flying get +1/+0 until end of turn.",
             "colours": [
@@ -2758,7 +2758,7 @@
         },
         {
             "id": "737ce9c9-6e5e-56df-a12f-a5b21d05ac14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b0791-618b-4060-b4d9-3bd7a778098e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1b0791-618b-4060-b4d9-3bd7a778098e.jpg?1",
             "name": "Stormcloud Djinn",
             "text": "Flying\nStormcloud Djinn can block only creatures with flying.\n{R}{R}: Stormcloud Djinn gets +2/+0 until end of turn and deals 1 damage to you.",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "40c0d3b3-b4ba-578d-a15d-9c5c4765b370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0145f6-4e27-49e7-9ef6-bac6fa3de26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0145f6-4e27-49e7-9ef6-bac6fa3de26d.jpg?1",
             "name": "Teferi, Mage of Zhalfir",
             "text": "Flash (You may play this spell any time you could play an instant.)\nCreature cards you own that aren't in play have flash.\nEach opponent can play spells only any time he or she could play a sorcery.",
             "colours": [
@@ -2830,7 +2830,7 @@
         },
         {
             "id": "22861d5d-faf1-5cd8-9fea-524ed333f5d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b934ad-4858-4680-924a-53ea4f250f9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61b934ad-4858-4680-924a-53ea4f250f9e.jpg?1",
             "name": "Telekinetic Sliver",
             "text": "All Slivers have \"{T}: Tap target permanent.\"",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "ad0fc2ef-85f3-5b93-87b3-60728ba590ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab2147-d496-489b-aaf0-b354e31a6b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab2147-d496-489b-aaf0-b354e31a6b45.jpg?1",
             "name": "Temporal Eddy",
             "text": "Put target creature or land on top of its owner's library.",
             "colours": [
@@ -2896,7 +2896,7 @@
         },
         {
             "id": "888818d6-af6d-5137-b855-8ecd1525fe15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d99db-de6d-4405-90ec-b144abbaa5a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352d99db-de6d-4405-90ec-b144abbaa5a4.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -2928,7 +2928,7 @@
         },
         {
             "id": "6ed0ed0b-1932-5436-9826-4277160ced36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97ec8b-6163-41ff-9e6f-af091a7c529e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e97ec8b-6163-41ff-9e6f-af091a7c529e.jpg?1",
             "name": "Tolarian Sentinel",
             "text": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -2963,7 +2963,7 @@
         },
         {
             "id": "d0620205-b895-51dc-9e02-eecf2166758e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e58ff2-dea3-42b3-8c22-3e6202a7d433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2e58ff2-dea3-42b3-8c22-3e6202a7d433.jpg?1",
             "name": "Trickbind",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nCounter target activated or triggered ability. If a permanent's ability is countered this way, activated abilities of that permanent can't be played this turn. (Mana abilities can't be targeted.)",
             "colours": [
@@ -2995,7 +2995,7 @@
         },
         {
             "id": "53ab8d1f-7493-54b3-83f3-49ba5b25d1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3e301a-02a5-4d92-9cdd-5ab877bf8ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3e301a-02a5-4d92-9cdd-5ab877bf8ed3.jpg?1",
             "name": "Truth or Tale",
             "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put a card from the chosen pile into your hand, then put all other cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -3027,7 +3027,7 @@
         },
         {
             "id": "26bac3f2-1a63-5f55-91d8-826858d42aaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458031cc-238d-45f0-9a81-b52e82286e0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/458031cc-238d-45f0-9a81-b52e82286e0f.jpg?1",
             "name": "Vesuvan Shapeshifter",
             "text": "As Vesuvan Shapeshifter comes into play or is turned face up, you may choose another creature in play. If you do, until Vesuvan Shapeshifter is turned face down, it becomes a copy of that creature and gains \"At the beginning of your upkeep, you may turn this creature face down.\"\nMorph {1}{U}",
             "colours": [
@@ -3061,7 +3061,7 @@
         },
         {
             "id": "c6b24406-0dc5-5c7d-abab-76778e75b8b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc9f54e-7fba-4f03-83ca-6d293dffc07a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc9f54e-7fba-4f03-83ca-6d293dffc07a.jpg?1",
             "name": "Viscerid Deepwalker",
             "text": "{U}: Viscerid Deepwalker gets +1/+0 until end of turn.\nSuspend 4\u2014{U} (Rather than play this card from your hand, you may pay {U} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "e72b60b4-9b4b-5297-8e0f-cddd121d2bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9765c83-fe52-43c5-9466-7318809bbfe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9765c83-fe52-43c5-9466-7318809bbfe0.jpg?1",
             "name": "Voidmage Husher",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Voidmage Husher comes into play, counter target activated ability. (Mana abilities can't be targeted.)\nWhenever you play a spell, you may return Voidmage Husher to its owner's hand.",
             "colours": [
@@ -3131,7 +3131,7 @@
         },
         {
             "id": "0c48524d-6fa8-5f56-8887-87fda8765802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db567cf-3d26-4216-932b-53ca4cfeb5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9db567cf-3d26-4216-932b-53ca4cfeb5b7.jpg?1",
             "name": "Walk the Aeons",
             "text": "Buyback\u2014\nSacrifice three Islands. (You may sacrifice three Islands in addition to any other costs as you play this spell. If you do, put this card into your hand as it resolves.)\nTarget player takes an extra turn after this one.",
             "colours": [
@@ -3163,7 +3163,7 @@
         },
         {
             "id": "4ce76a99-940a-521a-8915-a497bd337299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb43af-367c-4778-a7cc-7ee3b3103379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37eb43af-367c-4778-a7cc-7ee3b3103379.jpg?1",
             "name": "Wipe Away",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "8eab22db-89b5-58cc-b463-57897ed814da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b67839-622d-41c1-b9c7-1a26b021ec78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40b67839-622d-41c1-b9c7-1a26b021ec78.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "886a33bd-8f85-5de0-989e-4d115584ea32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4564e9df-bfa3-48e5-a12e-f7e96a504cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4564e9df-bfa3-48e5-a12e-f7e96a504cb1.jpg?1",
             "name": "Basal Sliver",
             "text": "All Slivers have \"Sacrifice this creature: Add {B}{B} to your mana pool.\"",
             "colours": [
@@ -3261,7 +3261,7 @@
         },
         {
             "id": "e227585b-9d68-5cea-8487-cfe2dc203cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7322e2-dbea-46e1-ba29-a86a13e5d33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7322e2-dbea-46e1-ba29-a86a13e5d33e.jpg?1",
             "name": "Call to the Netherworld",
             "text": "Return target black creature card from your graveyard to your hand.\nMadness {0} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "bbe8be3a-d72f-5c99-961f-a3202cc848ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58b842a-a4c0-475d-a8b3-62d4e5bb2eaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58b842a-a4c0-475d-a8b3-62d4e5bb2eaf.jpg?1",
             "name": "Corpulent Corpse",
             "text": "Fear\nSuspend 5\u2014{B} (Rather than play this card from your hand, you may pay {B} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -3327,7 +3327,7 @@
         },
         {
             "id": "1437d860-9d00-55e7-9198-96674cd06636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4323aa6-a1fb-42ee-9634-3747129fde3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4323aa6-a1fb-42ee-9634-3747129fde3b.jpg?1",
             "name": "Curse of the Cabal",
             "text": "Target player sacrifices half the permanents he or she controls, rounded down.\nSuspend 2\u2014{2}{B}{B}\nAt the beginning of each player's upkeep, if Curse of the Cabal is suspended, that player may sacrifice a permanent. If he or she does, put two time counters on Curse of the Cabal.",
             "colours": [
@@ -3359,7 +3359,7 @@
         },
         {
             "id": "9a939fc9-0436-548b-86f3-b3f2aa7ce2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6bc89-492a-46a4-90dc-95ae2e2bc483.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab6bc89-492a-46a4-90dc-95ae2e2bc483.jpg?1",
             "name": "Cyclopean Giant",
             "text": "When Cyclopean Giant is put into a graveyard from play, target land becomes a Swamp. Remove Cyclopean Giant from the game.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "2d166f37-732a-504c-8af7-fcabaec59ba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da58e0d-5877-43c4-b129-993e154b6087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da58e0d-5877-43c4-b129-993e154b6087.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -3426,7 +3426,7 @@
         },
         {
             "id": "52d4eecc-584c-5301-9808-b31e217d7749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b.jpg?1",
             "name": "Deathspore Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Deathspore Thallid.\nRemove three spore counters from Deathspore Thallid: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "98686b72-8cac-59a7-bdb1-abd48c7dc5d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a68a28-05fa-4c6e-896d-ddb9aea3a38d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1a68a28-05fa-4c6e-896d-ddb9aea3a38d.jpg?1",
             "name": "Demonic Collusion",
             "text": "Buyback\u2014\nDiscard two cards. (You may discard two cards in addition to any other costs as you play this spell. If you do, put this card into your hand as it resolves.)\nSearch your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "8ec728f7-587c-516f-8632-bceb75e39863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e304fc-0ace-459e-8d2f-376f1899639c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7e304fc-0ace-459e-8d2f-376f1899639c.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to play.\nFlashback\u2014\nSacrifice three creatures. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "6e39c160-c3b1-5f20-ab43-362a0e7b7b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c07d9a-afed-4028-9fa1-ec439b60f08f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c07d9a-afed-4028-9fa1-ec439b60f08f.jpg?1",
             "name": "Drudge Reavers",
             "text": "Flash (You may play this spell any time you could play an instant.)\n{B}: Regenerate Drudge Reavers.",
             "colours": [
@@ -3559,7 +3559,7 @@
         },
         {
             "id": "680d81f9-0a25-5bc5-9fee-2f12f1bb175c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac6faba-59f2-436f-addb-c53db2b0cc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dac6faba-59f2-436f-addb-c53db2b0cc17.jpg?1",
             "name": "Endrek Sahr, Master Breeder",
             "text": "Whenever you play a creature spell, put X 1/1 black Thrull creature tokens into play, where X is that spell's converted mana cost.\nWhen you control seven or more Thrulls, sacrifice Endrek Sahr, Master Breeder.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "75b63e4e-fc7d-54ec-ad2d-e023255bd39c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc17fe31-11f1-48e0-9b0d-7c7dcda417a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc17fe31-11f1-48e0-9b0d-7c7dcda417a6.jpg?1",
             "name": "Evil Eye of Urborg",
             "text": "Non-Eye creatures you control can't attack.\nWhenever Evil Eye of Urborg becomes blocked by a creature, destroy that creature.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "f39e546c-456a-5794-9385-089b2d68a6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17146f8-d517-4941-b01e-09ecf00ec8e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17146f8-d517-4941-b01e-09ecf00ec8e4.jpg?1",
             "name": "Faceless Devourer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhen Faceless Devourer comes into play, remove another target creature with shadow from the game.\nWhen Faceless Devourer leaves play, return the removed card to play under its owner's control.",
             "colours": [
@@ -3665,7 +3665,7 @@
         },
         {
             "id": "97694ce0-9370-5da1-a2e3-c815520fa252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2d24b0-f0d3-40f0-a51f-074f8e95e6af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2d24b0-f0d3-40f0-a51f-074f8e95e6af.jpg?1",
             "name": "Fallen Ideal",
             "text": "Enchant creature\nEnchanted creature has flying and \"Sacrifice a creature: This creature gets +2/+1 until end of turn.\"\nWhen Fallen Ideal is put into a graveyard from play, return Fallen Ideal to its owner's hand.",
             "colours": [
@@ -3699,7 +3699,7 @@
         },
         {
             "id": "442df62a-5e10-5066-a2b6-539e4db32d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2660d-b661-4266-b7e5-07bb8b72bce6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba2660d-b661-4266-b7e5-07bb8b72bce6.jpg?1",
             "name": "Feebleness",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets -2/-1.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "36f1288b-5f00-5703-9c23-c966dbef7103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdeb7c9-98bd-4143-87e4-1c78c0ce627e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdeb7c9-98bd-4143-87e4-1c78c0ce627e.jpg?1",
             "name": "Gorgon Recluse",
             "text": "Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.\nMadness {B}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "c05bd7b0-eff6-5a31-82dd-b67185448df5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8163a9d-5a1b-4d36-b20a-b220207a3b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8163a9d-5a1b-4d36-b20a-b220207a3b94.jpg?1",
             "name": "Haunting Hymn",
             "text": "Target player discards two cards. If you played this spell during your main phase, that player discards four cards instead.",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "9c8193ed-8db5-5520-a873-7db96f795dab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e7c608-d224-472b-8736-273874211f24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e7c608-d224-472b-8736-273874211f24.jpg?1",
             "name": "Liege of the Pit",
             "text": "Flying, trample\nAt the beginning of your upkeep, sacrifice a creature other than Liege of the Pit. If you can't, Liege of the Pit deals 7 damage to you.\nMorph {B}{B}{B}{B} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "dfee3094-6043-5959-866c-f06cf88bf92f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3cdfe-0289-474b-b9c4-07e8c6588ec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a3cdfe-0289-474b-b9c4-07e8c6588ec5.jpg?1",
             "name": "Lim-D\u00fbl the Necromancer",
             "text": "Whenever a creature an opponent controls is put into a graveyard from play, you may pay {1}{B}. If you do, return that card to play under your control. If it's a creature, it's a Zombie in addition to its other creature types.\n{1}{B}: Regenerate target Zombie.",
             "colours": [
@@ -3870,7 +3870,7 @@
         },
         {
             "id": "a7171431-f4df-5d1a-80d3-c6faa56afd67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be0ff69-d9f3-4b81-b02f-1360e4064aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3be0ff69-d9f3-4b81-b02f-1360e4064aff.jpg?1",
             "name": "Living End",
             "text": "Living End is black.\nSuspend 3\u2014{2}{B}{B}\nEach player removes all creature cards in his or her graveyard from the game, then sacrifices all creatures he or she controls, then puts into play all cards he or she removed this way.",
             "colours": [
@@ -3902,7 +3902,7 @@
         },
         {
             "id": "0ebe5682-6b5e-509a-93d5-018e5cf1e56a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6e8ff6-323d-4cc3-b7b6-8607bf89597e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a6e8ff6-323d-4cc3-b7b6-8607bf89597e.jpg?1",
             "name": "Magus of the Mirror",
             "text": "{T}, Sacrifice Magus of the Mirror: Exchange life totals with target opponent. Play this ability only during your upkeep.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "70278633-1ed8-567a-ada2-2e7525c2f73c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a39ed44-bc0c-40e2-ba53-cd586c2d5877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a39ed44-bc0c-40e2-ba53-cd586c2d5877.jpg?1",
             "name": "Mana Skimmer",
             "text": "Flying\nWhenever Mana Skimmer deals damage to a player, tap target land that player controls. That land doesn't untap during its controller's next untap step.",
             "colours": [
@@ -3971,7 +3971,7 @@
         },
         {
             "id": "4faa2d54-efe1-54d3-b182-95ff6b9a5c85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54575-dc1d-491c-a4f6-41f76eba2a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c54575-dc1d-491c-a4f6-41f76eba2a2d.jpg?1",
             "name": "Mindlash Sliver",
             "text": "All Slivers have \"{1}, Sacrifice this creature: Each player discards a card.\"",
             "colours": [
@@ -4005,7 +4005,7 @@
         },
         {
             "id": "103730f9-c16a-5ef9-95af-5a53c662a6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efd28ef-77db-4e7b-a69d-5a089e016737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3efd28ef-77db-4e7b-a69d-5a089e016737.jpg?1",
             "name": "Mindstab",
             "text": "Target player discards three cards.\nSuspend 4\u2014{B} (Rather than play this card from your hand, you may pay {B} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "f25efe6f-2339-5fb3-8f36-5fc118f9cd15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911d2271-8998-4193-9d1a-1768c5dfaaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/911d2271-8998-4193-9d1a-1768c5dfaaad.jpg?1",
             "name": "Nether Traitor",
             "text": "Haste\nShadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever another creature is put into your graveyard from play, you may pay {B}. If you do, return Nether Traitor from your graveyard to play.",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "26c91c11-a72a-5650-a58c-5f2aea51e240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e57492c-ca26-4f75-a27e-5c54967534ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e57492c-ca26-4f75-a27e-5c54967534ea.jpg?1",
             "name": "Nightshade Assassin",
             "text": "First strike\nWhen Nightshade Assassin comes into play, you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn.\nMadness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -4106,7 +4106,7 @@
         },
         {
             "id": "cb91875b-a64d-5636-b5c5-ccc6b4f043f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba55f16-a37c-4caa-9417-227a06cf4061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9ba55f16-a37c-4caa-9417-227a06cf4061.jpg?1",
             "name": "Phthisis",
             "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5\u2014{1}{B} (Rather than play this card from your hand, you may pay {1}{B} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "fcf3e647-14e0-594f-a729-ebbb2d2f5e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936e767-0e48-4adb-93e9-790fe0cc19f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8936e767-0e48-4adb-93e9-790fe0cc19f2.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper comes into play, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "19b7380e-d56f-5998-8051-f227f5557d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703d491e-b25f-44fa-8b76-b955a4e75ba5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703d491e-b25f-44fa-8b76-b955a4e75ba5.jpg?1",
             "name": "Plague Sliver",
             "text": "All Slivers have \"At the beginning of your upkeep, this creature deals 1 damage to you.\"",
             "colours": [
@@ -4207,7 +4207,7 @@
         },
         {
             "id": "1465ecb2-e263-5f84-adf2-508f2e5b0a7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96cea6a-fea6-4a6b-84b2-7b57237be96a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96cea6a-fea6-4a6b-84b2-7b57237be96a.jpg?1",
             "name": "Premature Burial",
             "text": "Destroy target nonblack creature that came into play since your last turn ended.",
             "colours": [
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "2294cf58-e15b-5ecd-9d44-6a5afdf89039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e61fbcd-b673-4d1d-bc38-a791a56a9aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e61fbcd-b673-4d1d-bc38-a791a56a9aac.jpg?1",
             "name": "Psychotic Episode",
             "text": "Target player reveals his or her hand and the top card of his or her library. You choose a card revealed this way. That player puts the chosen card on the bottom of his or her library.\nMadness {1}{B} (If you discard this card, you may play it for its madness cost instead of putting it into your graveyard.)",
             "colours": [
@@ -4271,7 +4271,7 @@
         },
         {
             "id": "55343d25-ee49-5030-9052-a79d0e9c2208",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9abc52-76f6-4b1f-8602-2e5abdd23b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab9abc52-76f6-4b1f-8602-2e5abdd23b6b.jpg?1",
             "name": "Sangrophage",
             "text": "At the beginning of your upkeep, tap Sangrophage unless you pay 2 life.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "e2ce2b31-7fea-578b-96b8-9ea94da447ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd9cc4c-708b-41cb-9cac-fd6d8ce9922d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cd9cc4c-708b-41cb-9cac-fd6d8ce9922d.jpg?1",
             "name": "Sengir Nosferatu",
             "text": "Flying\n{1}{B}, Remove Sengir Nosferatu from the game: Put a 1/2 black Bat creature token with flying into play. It has \"{1}{B}, Sacrifice this creature: Return to play under its owner's control a card named Sengir Nosferatu that's removed from the game.\"",
             "colours": [
@@ -4339,7 +4339,7 @@
         },
         {
             "id": "3e386776-43a1-5b41-a162-d05427c201f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d21e39-b1dd-476d-86dc-4317858e4f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0d21e39-b1dd-476d-86dc-4317858e4f8e.jpg?1",
             "name": "Skittering Monstrosity",
             "text": "When you play a creature spell, sacrifice Skittering Monstrosity.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "233a789c-991d-5ba2-b19f-0c13bf1c8f2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7927b-64ae-4448-9540-8d7bbe88c9cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f7927b-64ae-4448-9540-8d7bbe88c9cc.jpg?1",
             "name": "Skulking Knight",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nWhen Skulking Knight becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "6ddc333a-72dd-5ef3-960a-48b586ca6005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175d5a88-2597-4e85-aed6-7a65c0595fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/175d5a88-2597-4e85-aed6-7a65c0595fb4.jpg?1",
             "name": "Smallpox",
             "text": "Each player loses 1 life, discards a card, sacrifices a creature, then sacrifices a land.",
             "colours": [
@@ -4440,7 +4440,7 @@
         },
         {
             "id": "f9673160-b1bc-5f8a-91ea-f274d779ac36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723e552-baf5-4b6a-8af6-843fd8597f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6723e552-baf5-4b6a-8af6-843fd8597f6c.jpg?1",
             "name": "Strangling Soot",
             "text": "Destroy target creature with toughness 3 or less.\nFlashback {5}{R} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4473,7 +4473,7 @@
         },
         {
             "id": "b4160f99-57e2-504b-b883-1a0411ec04cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg?1",
             "name": "Stronghold Overseer",
             "text": "Flying\nShadow (This creature can block or be blocked by only creatures with shadow.)\n{B}{B}: Creatures with shadow get +1/+0 until end of turn and creatures without shadow get -1/-0 until end of turn.",
             "colours": [
@@ -4507,7 +4507,7 @@
         },
         {
             "id": "1f42f2ba-0e71-549d-89a8-55d8a971bf95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e889c4-105b-4f4e-8a3d-ace753a24a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e889c4-105b-4f4e-8a3d-ace753a24a4e.jpg?1",
             "name": "Sudden Death",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nTarget creature gets -4/-4 until end of turn.",
             "colours": [
@@ -4539,7 +4539,7 @@
         },
         {
             "id": "dcbcfdbe-1c68-5192-9058-ba387bc2cdd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f89f1e4-4d55-48b8-bf81-54cfd34f4aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f89f1e4-4d55-48b8-bf81-54cfd34f4aa0.jpg?1",
             "name": "Sudden Spoiling",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nCreatures target player controls become 0/2 and lose all abilities until end of turn.",
             "colours": [
@@ -4571,7 +4571,7 @@
         },
         {
             "id": "e9eb8a20-9d35-520b-9cd2-c541b5a4a3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f61db9e-ef88-4dc8-b90c-1f8b2d7e9bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f61db9e-ef88-4dc8-b90c-1f8b2d7e9bb9.jpg?1",
             "name": "Tendrils of Corruption",
             "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -4603,7 +4603,7 @@
         },
         {
             "id": "cff4e966-d6b7-5e05-a642-e3cc840b0d5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6313a601-5d26-487b-a70c-2c7184b7cc91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6313a601-5d26-487b-a70c-2c7184b7cc91.jpg?1",
             "name": "Traitor's Clutch",
             "text": "Target creature gets +1/+0, becomes black, and gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)\nFlashback {1}{B} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4635,7 +4635,7 @@
         },
         {
             "id": "01649eaf-6dfe-5afc-8a59-ea50d98b1685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4903171e-76b2-437d-8965-e871e47a3482.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4903171e-76b2-437d-8965-e871e47a3482.jpg?1",
             "name": "Trespasser il-Vec",
             "text": "Discard a card: Trespasser il-Vec gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "e5b8256b-3443-52dd-a30f-ea6aba0ab7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8376f6-5c26-4b87-b226-960466e16cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e8376f6-5c26-4b87-b226-960466e16cb0.jpg?1",
             "name": "Urborg Syphon-Mage",
             "text": "{2}{B}, {T}, Discard a card: Each other player loses 2 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "3d5d3e3c-5cb1-5092-9a07-e20539996b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c56db1-bb2d-4383-90aa-72d00fe476b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28c56db1-bb2d-4383-90aa-72d00fe476b2.jpg?1",
             "name": "Vampiric Sliver",
             "text": "All Slivers have \"Whenever a creature dealt damage by this creature this turn is put into a graveyard, put a +1/+1 counter on this creature.\"",
             "colours": [
@@ -4739,7 +4739,7 @@
         },
         {
             "id": "56125128-7421-5e04-829c-75f9b515f723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f04d7-da34-41e3-9153-97891a428889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/863f04d7-da34-41e3-9153-97891a428889.jpg?1",
             "name": "Viscid Lemures",
             "text": "{0}: Viscid Lemures gets -1/-0 and gains swampwalk until end of turn.",
             "colours": [
@@ -4773,7 +4773,7 @@
         },
         {
             "id": "a14e7ce7-bd9f-5fd5-a833-3f30e1195d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b14f08-dd93-4a9f-a616-8f8d0b26b966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b14f08-dd93-4a9f-a616-8f8d0b26b966.jpg?1",
             "name": "Aetherflame Wall",
             "text": "Defender\n\u00c6therflame Wall can block creatures with shadow as though they didn't have shadow.\n{R}: \u00c6therflame Wall gets +1/+0 until end of turn.",
             "colours": [
@@ -4807,7 +4807,7 @@
         },
         {
             "id": "e0763cff-87db-5986-b127-5ceaa1971cf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cbad1f-4f16-4d5f-a485-5bf950565216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89cbad1f-4f16-4d5f-a485-5bf950565216.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "2d64a670-b23a-5458-a018-e95fc279f6b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6f45a-7219-4b59-bf0a-9e374599ae5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b6f45a-7219-4b59-bf0a-9e374599ae5e.jpg?1",
             "name": "Barbed Shocker",
             "text": "Trample, haste\nWhenever Barbed Shocker deals damage to a player, that player discards all the cards in his or her hand, then draws that many cards.",
             "colours": [
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "b53ef69d-6264-51c1-859c-37e97107a09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34945e1-b982-48a0-8c03-9b97c13cc73d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f34945e1-b982-48a0-8c03-9b97c13cc73d.jpg?1",
             "name": "Basalt Gargoyle",
             "text": "Flying\nEcho {2}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{R}: Basalt Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -4908,7 +4908,7 @@
         },
         {
             "id": "4b278b4b-1991-50db-8782-a06d9ad7005e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabf35d5-de8a-4d9d-be59-7ad7039873c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cabf35d5-de8a-4d9d-be59-7ad7039873c6.jpg?1",
             "name": "Blazing Blade Askari",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n{2}: Blazing Blade Askari becomes colorless until end of turn.",
             "colours": [
@@ -4943,7 +4943,7 @@
         },
         {
             "id": "c1af5460-a744-55ce-bc04-7152bcd86874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5852f528-92aa-45cf-8436-5774691676d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5852f528-92aa-45cf-8436-5774691676d3.jpg?1",
             "name": "Bogardan Hellkite",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying\nWhen Bogardan Hellkite comes into play, it deals 5 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -4977,7 +4977,7 @@
         },
         {
             "id": "974b397f-7ddf-5adc-95e5-8bd39953ef89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53d26b-ad3e-474f-a374-05fcdc00e49c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec53d26b-ad3e-474f-a374-05fcdc00e49c.jpg?1",
             "name": "Bogardan Rager",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Bogardan Rager comes into play, target creature gets +4/+0 until end of turn.",
             "colours": [
@@ -5011,7 +5011,7 @@
         },
         {
             "id": "8b587c57-f0f8-51a4-8c43-ffe1f34bdb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705e29c5-2d9b-44ad-a04c-9a62dd74eb12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705e29c5-2d9b-44ad-a04c-9a62dd74eb12.jpg?1",
             "name": "Bonesplitter Sliver",
             "text": "All Slivers get +2/+0.",
             "colours": [
@@ -5045,7 +5045,7 @@
         },
         {
             "id": "1999a73f-7a8c-5dd9-966e-a2d4a7dee1fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6bdc34-1ef6-4de3-a9a9-b5dd503e02c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6bdc34-1ef6-4de3-a9a9-b5dd503e02c0.jpg?1",
             "name": "Coal Stoker",
             "text": "When Coal Stoker comes into play, if you played it from your hand, add {R}{R}{R} to your mana pool.",
             "colours": [
@@ -5079,7 +5079,7 @@
         },
         {
             "id": "91083e40-553f-5825-a0ba-2f7f272e8e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc5f7fb-b7a6-433d-a0bb-240c7aa0a720.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc5f7fb-b7a6-433d-a0bb-240c7aa0a720.jpg?1",
             "name": "Conflagrate",
             "text": "Conflagrate deals X damage divided as you choose among any number of target creatures and/or players.\nFlashback\u2014{R}{R}, Discard X cards. (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -5111,7 +5111,7 @@
         },
         {
             "id": "707d9c55-ec87-5b60-b076-88b31be812b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bb27c-c58a-478a-b637-eb4f7e1e0ab4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bb27c-c58a-478a-b637-eb4f7e1e0ab4.jpg?1",
             "name": "Empty the Warrens",
             "text": "Put two 1/1 red Goblin creature tokens into play.\nStorm (When you play this spell, copy it for each spell played before it this turn.)",
             "colours": [
@@ -5143,7 +5143,7 @@
         },
         {
             "id": "64a551ed-fb4e-59bd-bc4c-c76c5590b20c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d592bc85-41ca-48a4-b35a-4d86c8e76d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d592bc85-41ca-48a4-b35a-4d86c8e76d54.jpg?1",
             "name": "Firemaw Kavu",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Firemaw Kavu comes into play, it deals 2 damage to target creature.\nWhen Firemaw Kavu leaves play, it deals 4 damage to target creature.",
             "colours": [
@@ -5177,7 +5177,7 @@
         },
         {
             "id": "c4db7807-4ced-5044-bc00-659e756f4241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940bfe4f-bc18-4506-b6f4-13d339fd3e55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940bfe4f-bc18-4506-b6f4-13d339fd3e55.jpg?1",
             "name": "Flamecore Elemental",
             "text": "Echo {2}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -5211,7 +5211,7 @@
         },
         {
             "id": "6149b305-3dd2-51ad-bbf8-d09280200982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f10fa1c-2c7b-49ba-87b6-3b652b65704d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f10fa1c-2c7b-49ba-87b6-3b652b65704d.jpg?1",
             "name": "Flowstone Channeler",
             "text": "{1}{R}, {T}, Discard a card: Target creature gets +1/-1 and gains haste until end of turn.",
             "colours": [
@@ -5246,7 +5246,7 @@
         },
         {
             "id": "dfdfa896-0923-51a0-a819-78ff2b8c0746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893bbb7-0589-4544-a488-f84f9aa1d058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c893bbb7-0589-4544-a488-f84f9aa1d058.jpg?1",
             "name": "Fortune Thief",
             "text": "Damage that would reduce your life total to less than 1 reduces it to 1 instead.\nMorph {R}{R} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5281,7 +5281,7 @@
         },
         {
             "id": "9f203094-9e28-5fef-847b-5508b798ec53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg?1",
             "name": "Fury Sliver",
             "text": "All Slivers have double strike.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "595b2987-8c80-58ae-80d2-45df58f0203e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9098b989-072a-4e5b-8972-22c61645c5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9098b989-072a-4e5b-8972-22c61645c5bb.jpg?1",
             "name": "Ghitu Firebreathing",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\n{R}: Enchanted creature gets +1/+0 until end of turn.\n{R}: Return Ghitu Firebreathing to its owner's hand.",
             "colours": [
@@ -5349,7 +5349,7 @@
         },
         {
             "id": "5ae2e274-288f-5b5d-bfbf-b36a71b284d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45406cd-a036-45d5-a0fb-3c195d40d746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c45406cd-a036-45d5-a0fb-3c195d40d746.jpg?1",
             "name": "Goblin Skycutter",
             "text": "Sacrifice Goblin Skycutter: Goblin Skycutter deals 2 damage to target creature with flying. That creature loses flying until end of turn.",
             "colours": [
@@ -5384,7 +5384,7 @@
         },
         {
             "id": "0026ba71-f6f6-5f0e-b3b4-4b44ff1c440b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee33cb6-768e-44a0-b6f4-b8638aa84330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee33cb6-768e-44a0-b6f4-b8638aa84330.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to target creature or player.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "545dcd44-2511-5e0a-b499-87bed1688545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653ddfa0-2088-4503-a3ab-b0f1d55d8351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653ddfa0-2088-4503-a3ab-b0f1d55d8351.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Play this ability only if Greater Gargadon is suspended.",
             "colours": [
@@ -5450,7 +5450,7 @@
         },
         {
             "id": "593dc9e6-6072-5389-b20f-274ba95c35ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62333783-6a18-4461-88ce-1c37eaf64e2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62333783-6a18-4461-88ce-1c37eaf64e2b.jpg?1",
             "name": "Ground Rift",
             "text": "Target creature without flying can't block this turn.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5482,7 +5482,7 @@
         },
         {
             "id": "e5709e12-302d-5f68-a390-522a555bb7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38134389-b471-4f58-a9ae-26bf9dc1557a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38134389-b471-4f58-a9ae-26bf9dc1557a.jpg?1",
             "name": "Ib Halfheart, Goblin Tactician",
             "text": "Whenever another Goblin you control becomes blocked, sacrifice it. If you do, it deals 4 damage to each creature blocking it.\nSacrifice two Mountains: Put two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -5519,7 +5519,7 @@
         },
         {
             "id": "eca01659-a70a-5a9c-84c0-7fa69cccf4c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7b7831-27a1-4c0a-8ed1-6dddf2754d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7b7831-27a1-4c0a-8ed1-6dddf2754d65.jpg?1",
             "name": "Ignite Memories",
             "text": "Target player reveals a card at random from his or her hand. Ignite Memories deals damage to that player equal to that card's converted mana cost.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5551,7 +5551,7 @@
         },
         {
             "id": "2f78f7d2-8caa-5268-a322-6e4397d17c06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07e37ea-aa8d-4443-9af6-4351994bc00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07e37ea-aa8d-4443-9af6-4351994bc00c.jpg?1",
             "name": "Ironclaw Buzzardiers",
             "text": "Ironclaw Buzzardiers can't block creatures with power 2 or greater.\n{R}: Ironclaw Buzzardiers gains flying until end of turn.",
             "colours": [
@@ -5586,7 +5586,7 @@
         },
         {
             "id": "8ae1eb71-866d-523d-81a7-d8a3a485852c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f85b2a-7836-4058-87a5-859c4311a7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f85b2a-7836-4058-87a5-859c4311a7e4.jpg?1",
             "name": "Jaya Ballard, Task Mage",
             "text": "{R}, {T}, Discard a card: Destroy target blue permanent.\n{1}{R}, {T}, Discard a card: Jaya Ballard, Task Mage deals 3 damage to target creature or player. A creature dealt damage this way can't be regenerated this turn.\n{5}{R}{R}, {T}, Discard a card: Jaya Ballard deals 6 damage to each creature and each player.",
             "colours": [
@@ -5623,7 +5623,7 @@
         },
         {
             "id": "030b4df4-93f5-54a0-a381-43c8ef563ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90723e0-fbb3-4976-9463-0373f8ed337c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a90723e0-fbb3-4976-9463-0373f8ed337c.jpg?1",
             "name": "Keldon Halberdier",
             "text": "First strike\nSuspend 4\u2014{R} (Rather than play this card from your hand, you may pay {R} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "e68fdf69-2f0d-5369-8f3b-3fce3995168b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b748290-04b0-48a9-81aa-ab43182cf339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b748290-04b0-48a9-81aa-ab43182cf339.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to play Lightning Axe, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "caf69553-ddc9-5541-b501-14783b54d6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6060cada-52bf-4ef2-8a26-8ba04dded458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6060cada-52bf-4ef2-8a26-8ba04dded458.jpg?1",
             "name": "Magus of the Scroll",
             "text": "{3}, {T}: Name a card. Reveal a card at random from your hand. If it's the named card, Magus of the Scroll deals 2 damage to target creature or player.",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "424fdaf8-4466-5541-aab3-2041fdb8a852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e0bdb-b615-447a-b80d-d7244c25c56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b9e0bdb-b615-447a-b80d-d7244c25c56e.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal comes into play or is put into a graveyard from play, put a 1/1 red Goblin creature token into play.",
             "colours": [
@@ -5760,7 +5760,7 @@
         },
         {
             "id": "ff3749ae-8091-5bdc-8d9a-b89eb72a88bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61ea59a-1db0-4e6b-bcde-19787c76a49b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61ea59a-1db0-4e6b-bcde-19787c76a49b.jpg?1",
             "name": "Norin the Wary",
             "text": "When a player plays a spell or a creature attacks, remove Norin the Wary from the game. Return it to play under its owner's control at end of turn.",
             "colours": [
@@ -5797,7 +5797,7 @@
         },
         {
             "id": "6103db7a-270c-555a-a1a1-9de631098363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e40f99c-9608-4463-8c6f-c6e142f0d716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e40f99c-9608-4463-8c6f-c6e142f0d716.jpg?1",
             "name": "Orcish Cannonade",
             "text": "Orcish Cannonade deals 2 damage to target creature or player and 3 damage to you.\nDraw a card.",
             "colours": [
@@ -5829,7 +5829,7 @@
         },
         {
             "id": "562bde17-3432-5d4b-bdc2-df7876fce121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad47d954-dda8-412a-b69b-a213bbd2f309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad47d954-dda8-412a-b69b-a213bbd2f309.jpg?1",
             "name": "Pardic Dragon",
             "text": "Flying\n{R}: Pardic Dragon gets +1/+0 until end of turn.\nSuspend 2\u2014{R}{R}\nWhenever an opponent plays a spell, if Pardic Dragon is suspended, that player may put a time counter on Pardic Dragon.",
             "colours": [
@@ -5863,7 +5863,7 @@
         },
         {
             "id": "d9d4f283-773c-5f16-ab19-46c2a7465099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cff220-b1a6-4da6-b765-25a583b33de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79cff220-b1a6-4da6-b765-25a583b33de2.jpg?1",
             "name": "Plunder",
             "text": "Destroy target artifact or land.\nSuspend 4\u2014{1}{R} (Rather than play this card from your hand, you may pay {1}{R} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "3e928c6c-cb24-5bed-8b48-a54158927e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc2151b-acec-4237-8f6f-ed97055f3bb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc2151b-acec-4237-8f6f-ed97055f3bb9.jpg?1",
             "name": "Reiterate",
             "text": "Buyback {3} (You may pay an additional {3} as you play this spell. If you do, put this card into your hand as it resolves.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -5927,7 +5927,7 @@
         },
         {
             "id": "26995916-9d28-5d0f-8df8-79227f145147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dde96e-6824-4d26-9fb5-86b9f3c50959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88dde96e-6824-4d26-9fb5-86b9f3c50959.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to target creature or player.\nSuspend 1\u2014{R} (Rather than play this card from your hand, you may pay {R} and remove it from the game with a time counter on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -5959,7 +5959,7 @@
         },
         {
             "id": "1da18008-9b77-5fdb-ae8b-cdd38b53e5b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dc8d7e-745c-46ba-842c-526f1beb89a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18dc8d7e-745c-46ba-842c-526f1beb89a7.jpg?1",
             "name": "Sedge Sliver",
             "text": "All Slivers have \"This creature gets +1/+1 as long as you control a Swamp\" and \"{B}: Regenerate this creature.\"",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "821767c9-7d17-54be-93b3-9c076e55563f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9429ec0-ff23-494d-ab1c-b88f3a0dee1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9429ec0-ff23-494d-ab1c-b88f3a0dee1b.jpg?1",
             "name": "Subterranean Shambler",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Subterranean Shambler comes into play or leaves play, it deals 1 damage to each creature without flying.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "7080205b-7fdf-5250-b103-7a619b13864d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2691ee-8eec-437d-9bc1-113264525fb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d2691ee-8eec-437d-9bc1-113264525fb8.jpg?1",
             "name": "Sudden Shock",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
             "colours": [
@@ -6060,7 +6060,7 @@
         },
         {
             "id": "3b50bf52-3caf-59f4-b94f-f099f0586bb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67511e0e-be09-4f4e-9949-b9ecbdc7f536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67511e0e-be09-4f4e-9949-b9ecbdc7f536.jpg?1",
             "name": "Sulfurous Blast",
             "text": "Sulfurous Blast deals 2 damage to each creature and each player. If you played this spell during your main phase, Sulfurous Blast deals 3 damage to each creature and each player instead.",
             "colours": [
@@ -6092,7 +6092,7 @@
         },
         {
             "id": "d7483fb7-bce1-5784-992f-443ea04577cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8aaf09-312f-4c82-9e0a-bd797e7f26c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8aaf09-312f-4c82-9e0a-bd797e7f26c3.jpg?1",
             "name": "Tectonic Fiend",
             "text": "Echo {4}{R}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nTectonic Fiend attacks each turn if able.",
             "colours": [
@@ -6126,7 +6126,7 @@
         },
         {
             "id": "a0f096f1-1266-5855-8965-b99b17c5c386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a82da-ae5c-4f3d-8aa0-4bd3de7bf0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a82da-ae5c-4f3d-8aa0-4bd3de7bf0b6.jpg?1",
             "name": "Thick-Skinned Goblin",
             "text": "You may pay {0} rather than pay the echo cost for permanents you control.\n{R}: Thick-Skinned Goblin gains protection from red until end of turn.",
             "colours": [
@@ -6161,7 +6161,7 @@
         },
         {
             "id": "190eaf2d-ff02-54dd-8124-dc6b526059cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89fb3b-0238-4d76-a46d-7d6fa4a74620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f89fb3b-0238-4d76-a46d-7d6fa4a74620.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "All Slivers have \"This creature can't be blocked except by two or more creatures.\"",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "1a8c078f-a61e-5289-932f-ccd75623f8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7ff7d2-a8f1-4ce4-acad-828ef36afe07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7ff7d2-a8f1-4ce4-acad-828ef36afe07.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from play, return Undying Rage to its owner's hand.",
             "colours": [
@@ -6229,7 +6229,7 @@
         },
         {
             "id": "ed4e2914-e2cc-5ef4-af43-fbb7ee5ed2ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fce1b3-0961-4672-845f-e1c6ce101c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fce1b3-0961-4672-845f-e1c6ce101c1b.jpg?1",
             "name": "Viashino Bladescout",
             "text": "Flash (You may play this spell any time you could play an instant.)\nWhen Viashino Bladescout comes into play, target creature gains first strike until end of turn.",
             "colours": [
@@ -6264,7 +6264,7 @@
         },
         {
             "id": "1e218ae5-2041-5563-9b10-6517e9a014a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebd5c57-cfc8-4a3c-b4a2-0cd64a5e3575.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aebd5c57-cfc8-4a3c-b4a2-0cd64a5e3575.jpg?1",
             "name": "Volcanic Awakening",
             "text": "Destroy target land.\nStorm (When you play this spell, copy it for each spell played before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -6296,7 +6296,7 @@
         },
         {
             "id": "c0ea7bbf-054d-50ae-ac48-fc4aafed4a56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9eb9fc-0a69-480d-be17-3e80e34c453b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d9eb9fc-0a69-480d-be17-3e80e34c453b.jpg?1",
             "name": "Wheel of Fate",
             "text": "Wheel of Fate is red.\nSuspend 4\u2014{1}{R} (Rather than play this card from your hand, pay {1}{R} and remove it from the game with four time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)\nEach player discards his or her hand, then draws seven cards.",
             "colours": [
@@ -6328,7 +6328,7 @@
         },
         {
             "id": "c87f11ec-8b68-5fe0-bcf2-386a8fc70ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3c98-ec84-4686-bc21-c8572a736e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6db3c98-ec84-4686-bc21-c8572a736e62.jpg?1",
             "name": "Word of Seizing",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
             "colours": [
@@ -6360,7 +6360,7 @@
         },
         {
             "id": "5554df1b-d6e4-5e50-9b05-ccadd1e02bd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a6af9-1b39-41e1-bd71-210700b7608b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce9a6af9-1b39-41e1-bd71-210700b7608b.jpg?1",
             "name": "Aether Web",
             "text": "Flash (You may play this spell any time you could play an instant.)\nEnchant creature\nEnchanted creature gets +1/+1, can block as though it had flying, and can block creatures with shadow as though they didn't have shadow.",
             "colours": [
@@ -6394,7 +6394,7 @@
         },
         {
             "id": "12017277-3f36-5caf-90a0-d880d7b28f6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7a6ab5-8a8f-492c-8484-3089354ce8cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b7a6ab5-8a8f-492c-8484-3089354ce8cf.jpg?1",
             "name": "Ashcoat Bear",
             "text": "Flash (You may play this spell any time you could play an instant.)",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "69cfd1a3-9d32-582e-9a73-69d4079bdd29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3eb61f4-627b-4f42-85aa-eb676a035fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3eb61f4-627b-4f42-85aa-eb676a035fbd.jpg?1",
             "name": "Aspect of Mongoose",
             "text": "Enchant creature\nEnchanted creature can't be the target of spells or abilities.\nWhen Aspect of Mongoose is put into a graveyard from play, return Aspect of Mongoose to its owner's hand.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "b732ec9a-5ae4-5fed-b637-76db8d379138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d506b1c-f329-4e07-8926-a87b4abf16a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d506b1c-f329-4e07-8926-a87b4abf16a7.jpg?1",
             "name": "Chameleon Blur",
             "text": "Prevent all damage that creatures would deal to players this turn.",
             "colours": [
@@ -6494,7 +6494,7 @@
         },
         {
             "id": "21ab4d9a-be7e-5407-964c-405a8ab1ba2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670521c3-df02-487d-a299-49419e41889f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670521c3-df02-487d-a299-49419e41889f.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than play this card from your hand, you may pay {G} and remove it from the game with five time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -6528,7 +6528,7 @@
         },
         {
             "id": "a0b4caef-b318-56ba-8b79-87f59b83c8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49f5835-c933-4ba7-a3c9-34f4eb01f00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b49f5835-c933-4ba7-a3c9-34f4eb01f00d.jpg?1",
             "name": "Durkwood Tracker",
             "text": "{1}{G}, {T}: If Durkwood Tracker is in play, it deals damage equal to its power to target attacking creature. That creature deals damage equal to its power to Durkwood Tracker.",
             "colours": [
@@ -6562,7 +6562,7 @@
         },
         {
             "id": "629da528-b6c3-5c66-afe0-743caf9c3322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c0486a-288d-443a-bb07-62dc1dddaed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c0486a-288d-443a-bb07-62dc1dddaed7.jpg?1",
             "name": "Fungus Sliver",
             "text": "All Slivers have \"Whenever this creature is dealt damage, put a +1/+1 counter on it.\" (The damage is dealt before the counter is put on.)",
             "colours": [
@@ -6597,7 +6597,7 @@
         },
         {
             "id": "270295d3-10f7-5559-b38f-ff40495b67cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09135b0-fd57-4205-aa74-c9869946c264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f09135b0-fd57-4205-aa74-c9869946c264.jpg?1",
             "name": "Gemhide Sliver",
             "text": "All Slivers have \"{T}: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6631,7 +6631,7 @@
         },
         {
             "id": "9c1ae99b-888d-551e-98e5-10839545454b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118253e9-f33a-455d-b785-dd9df657e7cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118253e9-f33a-455d-b785-dd9df657e7cf.jpg?1",
             "name": "Glass Asp",
             "text": "Whenever Glass Asp deals combat damage to a player, that player loses 2 life at the beginning of his or her next draw step unless he or she pays {2} before that step.",
             "colours": [
@@ -6665,7 +6665,7 @@
         },
         {
             "id": "7aa3c8e1-2b60-5971-8092-aca90bc49497",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dfa231-349a-4dce-bed6-c82a136fe0a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2dfa231-349a-4dce-bed6-c82a136fe0a1.jpg?1",
             "name": "Greenseeker",
             "text": "{G}, {T}, Discard a card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "836e2440-49f3-58ea-b7cd-aa4476131a82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561a4bb5-285a-4d52-b372-d165e442cff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/561a4bb5-285a-4d52-b372-d165e442cff3.jpg?1",
             "name": "Havenwood Wurm",
             "text": "Flash (You may play this spell any time you could play an instant.)\nTrample",
             "colours": [
@@ -6734,7 +6734,7 @@
         },
         {
             "id": "798bdc6b-6bf5-5736-a9f9-8381007be8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf4fd75-34b1-4afa-b8cd-777dfc9e6376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf4fd75-34b1-4afa-b8cd-777dfc9e6376.jpg?1",
             "name": "Herd Gnarr",
             "text": "Whenever another creature comes into play under your control, Herd Gnarr gets +2/+2 until end of turn.",
             "colours": [
@@ -6768,7 +6768,7 @@
         },
         {
             "id": "7e9e4e57-ef52-59b0-9a74-3bb4018e1450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6969-e579-4b28-a76b-5a99c7488f15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6969-e579-4b28-a76b-5a99c7488f15.jpg?1",
             "name": "Hypergenesis",
             "text": "Hypergenesis is green.\nSuspend 3\u2014{1}{G}{G}\nStarting with you, each player may put an artifact, creature, enchantment, or land card from his or her hand into play. Repeat this process until no one puts a card into play.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "b4a10492-668a-50b6-a17c-35d0c7bb072b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b524bb-5a18-4dda-9c45-26ce9ff0f0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b524bb-5a18-4dda-9c45-26ce9ff0f0c1.jpg?1",
             "name": "Krosan Grip",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -6832,7 +6832,7 @@
         },
         {
             "id": "73847b9e-7f90-5abc-b282-f7ed6616d33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ba1a0-eb35-4622-a7c5-6f9eb1357e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ba1a0-eb35-4622-a7c5-6f9eb1357e23.jpg?1",
             "name": "Magus of the Candelabra",
             "text": "{X}, {T}: Untap X target lands.",
             "colours": [
@@ -6867,7 +6867,7 @@
         },
         {
             "id": "0f6bddbb-f465-5174-ba0b-7361180500a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7b2c47-2123-45c1-993c-e7a2c9438855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b7b2c47-2123-45c1-993c-e7a2c9438855.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you played this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -6899,7 +6899,7 @@
         },
         {
             "id": "246a1421-6d8b-5803-aa99-139888855829",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8c52f-e608-4710-872f-8a8ae2b5c00c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb8c52f-e608-4710-872f-8a8ae2b5c00c.jpg?1",
             "name": "Might Sliver",
             "text": "All Slivers get +2/+2.",
             "colours": [
@@ -6933,7 +6933,7 @@
         },
         {
             "id": "32516e53-b40d-5ce1-adf1-b86724b8a337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0eb32c-89b1-40be-a77c-62c114a73ccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c0eb32c-89b1-40be-a77c-62c114a73ccc.jpg?1",
             "name": "Molder",
             "text": "Destroy target artifact or enchantment with converted mana cost X. It can't be regenerated. You gain X life.",
             "colours": [
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "c5cc6063-9c77-5a50-9050-673f4186ebf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6841dbf6-5023-4612-bbd7-182fd35b05c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6841dbf6-5023-4612-bbd7-182fd35b05c8.jpg?1",
             "name": "Mwonvuli Acid-Moss",
             "text": "Destroy target land. Search your library for a Forest card and put that card into play tapped. Then shuffle your library.",
             "colours": [
@@ -6997,7 +6997,7 @@
         },
         {
             "id": "d249b9d9-6945-5d98-9ec5-93987e0308b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e75970f-b41e-406a-9c22-f5df871e70e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e75970f-b41e-406a-9c22-f5df871e70e6.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman comes into play, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than play this card from your hand, you may pay {2}{G}{G} and remove it from the game with a time counter on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7032,7 +7032,7 @@
         },
         {
             "id": "9f801cce-88d8-5255-b210-f264ce9597a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d759b5-1739-414e-9616-723625883ebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d759b5-1739-414e-9616-723625883ebf.jpg?1",
             "name": "Pendelhaven Elder",
             "text": "{T}: Each 1/1 creature you control gets +1/+2 until end of turn.",
             "colours": [
@@ -7067,7 +7067,7 @@
         },
         {
             "id": "10ac706e-ccda-5576-bcd8-4b4d09939f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a989ac1-df69-45e7-98bf-564cc7c38973.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a989ac1-df69-45e7-98bf-564cc7c38973.jpg?1",
             "name": "Penumbra Spider",
             "text": "Penumbra Spider can block as though it had flying.\nWhen Penumbra Spider is put into a graveyard from play, put a 2/4 black Spider creature token into play that can block as though it had flying.",
             "colours": [
@@ -7101,7 +7101,7 @@
         },
         {
             "id": "ea72815b-f422-5def-9325-232822b2ea2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94722ba-adb5-4613-b8f0-da1c34591c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94722ba-adb5-4613-b8f0-da1c34591c10.jpg?1",
             "name": "Phantom Wurm",
             "text": "Phantom Wurm comes into play with four +1/+1 counters on it.\nIf damage would be dealt to Phantom Wurm, prevent that damage. Remove a +1/+1 counter from Phantom Wurm.",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "3df09e6b-4832-5ecc-9421-ec1ea99228a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7f5c-8a10-4037-9a94-42e0559b4b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7f5c-8a10-4037-9a94-42e0559b4b72.jpg?1",
             "name": "Primal Forcemage",
             "text": "Whenever another creature comes into play under your control, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7171,7 +7171,7 @@
         },
         {
             "id": "6f215f5e-1a33-51f5-a6bf-cd86961bf5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cbbdb-3bbc-48da-b5e3-fcdbddebec81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87cbbdb-3bbc-48da-b5e3-fcdbddebec81.jpg?1",
             "name": "Savage Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Savage Thallid.\nRemove three spore counters from Savage Thallid: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Regenerate target Fungus.",
             "colours": [
@@ -7205,7 +7205,7 @@
         },
         {
             "id": "f7592a49-9e9e-51bb-b39f-5fb4ca23d475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6dece3-058c-4738-a22f-8893345ddd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed6dece3-058c-4738-a22f-8893345ddd1c.jpg?1",
             "name": "Scarwood Treefolk",
             "text": "Scarwood Treefolk comes into play tapped.",
             "colours": [
@@ -7239,7 +7239,7 @@
         },
         {
             "id": "c07b8315-4e9a-55ff-a2c7-bc8f8861f840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aacabde-f5ec-4519-895d-17f5e48746ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aacabde-f5ec-4519-895d-17f5e48746ee.jpg?1",
             "name": "Scryb Ranger",
             "text": "Flash (You may play this spell any time you could play an instant.)\nFlying, protection from blue\nReturn a Forest you control to its owner's hand: Untap target creature. Play this ability only once each turn.",
             "colours": [
@@ -7274,7 +7274,7 @@
         },
         {
             "id": "d39abd2d-90b9-5666-83ee-64eb9f8e2dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f739e8-b4ba-426a-a159-0e0d5a0ebb6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f739e8-b4ba-426a-a159-0e0d5a0ebb6f.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card and put it into play. Then shuffle your library.\nSuspend 2\u2014{G} (Rather than play this card from your hand, you may pay {G} and remove it from the game with two time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)",
             "colours": [
@@ -7306,7 +7306,7 @@
         },
         {
             "id": "2916dd37-9c22-5ac4-a75f-f76cbd0e882c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dff1c4-6297-46f6-9c70-544c67319dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7dff1c4-6297-46f6-9c70-544c67319dd0.jpg?1",
             "name": "Spectral Force",
             "text": "Trample\nWhenever Spectral Force attacks, if defending player controls no black permanents, it doesn't untap during your next untap step.",
             "colours": [
@@ -7341,7 +7341,7 @@
         },
         {
             "id": "d98202e2-7ba7-5ef2-ab10-75a978149db4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf3643a-502f-4736-8063-5b567bdfbcc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caf3643a-502f-4736-8063-5b567bdfbcc4.jpg?1",
             "name": "Spike Tiller",
             "text": "Spike Tiller comes into play with three +1/+1 counters on it.\n{2}, Remove a +1/+1 counter from Spike Tiller: Put a +1/+1 counter on target creature.\n{2}, Remove a +1/+1 counter from Spike Tiller: Target land becomes a 2/2 creature that's still a land. Put a +1/+1 counter on it.",
             "colours": [
@@ -7375,7 +7375,7 @@
         },
         {
             "id": "b59f5c80-4e3e-5399-8dfd-7f354595af27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da698c63-f167-4129-a650-b50c080a24b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da698c63-f167-4129-a650-b50c080a24b5.jpg?1",
             "name": "Spinneret Sliver",
             "text": "All Slivers have \"This creature can block as though it had flying.\"",
             "colours": [
@@ -7409,7 +7409,7 @@
         },
         {
             "id": "32af5e58-7aae-559d-a93d-964e6f3c8e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f834b1f-9f05-4553-a9b5-828a8348ed30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f834b1f-9f05-4553-a9b5-828a8348ed30.jpg?1",
             "name": "Sporesower Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on each Fungus you control.\nRemove three spore counters from Sporesower Thallid: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7443,7 +7443,7 @@
         },
         {
             "id": "ed6263f0-3730-5cae-bebe-7efc61da627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967363f-1e05-4484-8790-47f7be68455c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6967363f-1e05-4484-8790-47f7be68455c.jpg?1",
             "name": "Sprout",
             "text": "Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7475,7 +7475,7 @@
         },
         {
             "id": "966ad5c0-ab44-5282-b4e3-53618aa6a19b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg?1",
             "name": "Squall Line",
             "text": "Squall Line deals X damage to each creature with flying and each player.",
             "colours": [
@@ -7507,7 +7507,7 @@
         },
         {
             "id": "c39cd306-325e-5cfc-98d6-af14ed12017d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b300e67-04d2-4c69-b516-c5cc0a6ff2e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b300e67-04d2-4c69-b516-c5cc0a6ff2e7.jpg?1",
             "name": "Stonewood Invocation",
             "text": "Split second (As long as this spell is on the stack, players can't play spells or activated abilities that aren't mana abilities.)\nTarget creature gets +5/+5 until end of turn and can't be the target of spells or abilities this turn.",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "42eac7c9-3e13-5484-8ac2-d61b4b908d85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5a571a-f323-473a-b5ec-f881bea82ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5a571a-f323-473a-b5ec-f881bea82ce1.jpg?1",
             "name": "Strength in Numbers",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
             "colours": [
@@ -7571,7 +7571,7 @@
         },
         {
             "id": "a1af20e1-8690-5352-b1e9-6bfd1341c61e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac526fb0-e6d0-4ee0-9888-15098c1704df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac526fb0-e6d0-4ee0-9888-15098c1704df.jpg?1",
             "name": "Thallid Germinator",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid Germinator.\nRemove three spore counters from Thallid Germinator: Put a 1/1 green Saproling creature token into play.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "ac4ff448-52b3-5e47-b429-9f153a38ccd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee36256-022f-49b3-8914-9b1c2f4dc506.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee36256-022f-49b3-8914-9b1c2f4dc506.jpg?1",
             "name": "Thallid Shell-Dweller",
             "text": "Defender\nAt the beginning of your upkeep, put a spore counter on Thallid Shell-Dweller.\nRemove three spore counters from Thallid Shell-Dweller: Put a 1/1 green Saproling creature token into play.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "257dbe04-2cca-56b4-b3cc-5621320f3280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b0be6d-9183-4938-b7a1-ae7f04ba78a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b0be6d-9183-4938-b7a1-ae7f04ba78a0.jpg?1",
             "name": "Thelon of Havenwood",
             "text": "Each Fungus gets +1/+1 for each spore counter on it.\n{B}{G}, Remove a Fungus card in a graveyard from the game: Put a spore counter on each Fungus in play.",
             "colours": [
@@ -7677,7 +7677,7 @@
         },
         {
             "id": "989491ed-7968-57b9-9af3-c770484b89f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95b6b0-ff20-405f-81ae-87f5cce45fb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be95b6b0-ff20-405f-81ae-87f5cce45fb2.jpg?1",
             "name": "Thelonite Hermit",
             "text": "All Saprolings get +1/+1.\nMorph {3}{G}{G} (You may play this face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Thelonite Hermit is turned face up, put four 1/1 green Saproling creature tokens into play.",
             "colours": [
@@ -7712,7 +7712,7 @@
         },
         {
             "id": "52bb7290-aefc-56fb-bd52-4bcad8c588f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe0c8e-f361-4eac-8c2c-ca6602dad352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe0c8e-f361-4eac-8c2c-ca6602dad352.jpg?1",
             "name": "Thrill of the Hunt",
             "text": "Target creature gets +1/+2 until end of turn.\nFlashback {W} (You may play this card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "cbdc2caf-3750-56b7-981f-615e80983f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832b67f4-60ec-44ad-9bcc-c3d247c22705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832b67f4-60ec-44ad-9bcc-c3d247c22705.jpg?1",
             "name": "Tromp the Domains",
             "text": "Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -7777,7 +7777,7 @@
         },
         {
             "id": "78b74b6e-b868-57d7-b59a-de54ecdd4d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg?1",
             "name": "Unyaro Bees",
             "text": "Flying\n{G}: Unyaro Bees gets +1/+1 until end of turn.\n{3}{G}, Sacrifice Unyaro Bees: Unyaro Bees deals 2 damage to target creature or player.",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "4483c6a8-2ec3-52ff-8fc5-47c43dbff7ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd1d130-98e7-4898-9f13-2bb58fa4777b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd1d130-98e7-4898-9f13-2bb58fa4777b.jpg?1",
             "name": "Verdant Embrace",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has \"At the beginning of each upkeep, put a 1/1 green Saproling creature token into play under your control.\"",
             "colours": [
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "c5ad72cf-b4f9-5386-8680-2049bc9e0624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad370-1b7e-4926-9580-7acf919787f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ad370-1b7e-4926-9580-7acf919787f2.jpg?1",
             "name": "Wormwood Dryad",
             "text": "{G}: Wormwood Dryad gains forestwalk until end of turn and it deals 1 damage to you.\n{B}: Wormwood Dryad gains swampwalk until end of turn and it deals 1 damage to you.",
             "colours": [
@@ -7880,7 +7880,7 @@
         },
         {
             "id": "050990c5-1197-5da5-9131-b91da0e474c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85402aef-3fb1-4e78-9103-e2e47e5f3c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85402aef-3fb1-4e78-9103-e2e47e5f3c65.jpg?1",
             "name": "Wurmcalling",
             "text": "Buyback {2}{G} (You may pay an additional {2}{G} as you play this spell. If you do, put this card into your hand as it resolves.)\nPut an X/X green Wurm creature token into play.",
             "colours": [
@@ -7912,7 +7912,7 @@
         },
         {
             "id": "6041bf6c-3880-5f60-9ddf-badb8cab75f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b56d65-b1ac-4aa3-aee6-433770c3dfbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1b56d65-b1ac-4aa3-aee6-433770c3dfbc.jpg?1",
             "name": "Yavimaya Dryad",
             "text": "Forestwalk\nWhen Yavimaya Dryad comes into play, you may search your library for a Forest card and put it into play tapped under target player's control. If you do, shuffle your library.",
             "colours": [
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "41ca0689-29d2-5470-a1ec-6b5248459173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955028d2-33df-4295-8ee3-572e5979b04c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/955028d2-33df-4295-8ee3-572e5979b04c.jpg?1",
             "name": "Dementia Sliver",
             "text": "All Slivers have \"{T}: Name a card. Target opponent reveals a card at random from his or her hand. If it's the named card, that player discards it. Play this ability only during your turn.\"",
             "colours": [
@@ -7982,7 +7982,7 @@
         },
         {
             "id": "71c97040-a17b-5c32-b084-e41c9c84fede",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3828efe-cbe1-473c-8dde-60ea9aaf23a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3828efe-cbe1-473c-8dde-60ea9aaf23a2.jpg?1",
             "name": "Dralnu, Lich Lord",
             "text": "If damage would be dealt to Dralnu, sacrifice that many permanents instead.\n{T}: Target instant or sorcery card in your graveyard has flashback until end of turn. Its flashback cost becomes equal to its mana cost as you play it. (You may play that card from your graveyard for its flashback cost. Then remove it from the game.)",
             "colours": [
@@ -8021,7 +8021,7 @@
         },
         {
             "id": "2009197f-fe1c-5052-a000-158ea739de84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d3f5a0d-029e-44fd-b3e6-c70176b5b4ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d3f5a0d-029e-44fd-b3e6-c70176b5b4ac.jpg?1",
             "name": "Firewake Sliver",
             "text": "All Slivers have haste and \"{1}, Sacrifice this creature: Target Sliver gets +2/+2 until end of turn.\"",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "e5ee5132-3ae9-50c4-8cae-030858c8333e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64eb10d1-22c6-4848-a7f4-c6ccd2c66dae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64eb10d1-22c6-4848-a7f4-c6ccd2c66dae.jpg?1",
             "name": "Ghostflame Sliver",
             "text": "All Slivers are colorless.",
             "colours": [
@@ -8093,7 +8093,7 @@
         },
         {
             "id": "dc07cf83-225e-5667-b245-43e2736cd98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7904997-a857-44f0-91d8-b78651bb4e83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7904997-a857-44f0-91d8-b78651bb4e83.jpg?1",
             "name": "Harmonic Sliver",
             "text": "All Slivers have \"When this creature comes into play, destroy target artifact or enchantment.\"",
             "colours": [
@@ -8129,7 +8129,7 @@
         },
         {
             "id": "a93c28ea-df82-567b-8179-273d827caf57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd98dea-8012-49bb-84cf-dd8ed5c032cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd98dea-8012-49bb-84cf-dd8ed5c032cf.jpg?1",
             "name": "Ith, High Arcanist",
             "text": "Vigilance\n{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nSuspend 4\u2014{W}{U}",
             "colours": [
@@ -8168,7 +8168,7 @@
         },
         {
             "id": "2577f2fd-bfe3-57c7-bf7c-ae960afc78a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444fa5a5-b5b0-4555-bd69-67c1c0cbf317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/444fa5a5-b5b0-4555-bd69-67c1c0cbf317.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent plays a spell, Kaervek the Merciless deals damage to target creature or player equal to that spell's converted mana cost.",
             "colours": [
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "8aaabb76-19e5-5446-9927-ee74b0d55513",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5deaec5-499d-4e19-b879-8bcd1dc35f3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5deaec5-499d-4e19-b879-8bcd1dc35f3e.jpg?1",
             "name": "Mishra, Artificer Prodigy",
             "text": "Whenever you play an artifact spell, you may search your graveyard, hand, and/or library for a card with the same name as that spell and put it into play. If you search your library this way, shuffle it.",
             "colours": [
@@ -8248,7 +8248,7 @@
         },
         {
             "id": "9f057de2-6f99-55d4-b351-3087d8542821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75af1cc6-cb40-48c8-818b-91e64bdbe691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75af1cc6-cb40-48c8-818b-91e64bdbe691.jpg?1",
             "name": "Opaline Sliver",
             "text": "All Slivers have \"Whenever this creature becomes the target of a spell an opponent controls, you may draw a card.\"",
             "colours": [
@@ -8284,7 +8284,7 @@
         },
         {
             "id": "0d55af7c-79ac-59b6-ac4f-3355a3f4c014",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34bb91e-138b-4491-bb2d-5df2cd272bf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34bb91e-138b-4491-bb2d-5df2cd272bf0.jpg?1",
             "name": "Saffi Eriksdotter",
             "text": "Sacrifice Saffi Eriksdotter: When target creature is put into your graveyard from play this turn, return that card to play.",
             "colours": [
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "9a63a154-421b-5b10-8c12-66841bf66f3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb6f85b-60e9-4191-b557-ec952b7f22fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb6f85b-60e9-4191-b557-ec952b7f22fc.jpg?1",
             "name": "Scion of the Ur-Dragon",
             "text": "Flying\n{2}: Search your library for a Dragon card and put it into your graveyard. If you do, Scion of the Ur-Dragon becomes a copy of that card until end of turn. Then shuffle your library.",
             "colours": [
@@ -8368,7 +8368,7 @@
         },
         {
             "id": "a3c8e3b0-03f2-57c8-af32-69dd18548284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c62102-0562-4b09-a05d-986aa4212f44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c62102-0562-4b09-a05d-986aa4212f44.jpg?1",
             "name": "Stonebrow, Krosan Hero",
             "text": "Trample\nWhenever a creature you control with trample attacks, it gets +2/+2 until end of turn.",
             "colours": [
@@ -8407,7 +8407,7 @@
         },
         {
             "id": "ec2f15d5-ff9f-5b84-baf4-fda3f1598328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d662-3740-4704-9184-c42c6a16d829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e086d662-3740-4704-9184-c42c6a16d829.jpg?1",
             "name": "Assembly-Worker",
             "text": "{T}: Target Assembly-Worker gets +1/+1 until end of turn.",
             "colours": [],
@@ -8438,7 +8438,7 @@
         },
         {
             "id": "f2624c24-697f-5103-bb36-93870aafc71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ae7c6-347c-4b29-b7a9-3ca3bb050396.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/386ae7c6-347c-4b29-b7a9-3ca3bb050396.jpg?1",
             "name": "Brass Gnat",
             "text": "Flying\nBrass Gnat doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap Brass Gnat.",
             "colours": [],
@@ -8469,7 +8469,7 @@
         },
         {
             "id": "4af8162f-35b5-5ecf-9985-003443e0e0fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee874779-e654-48f0-8f2d-cc98ef150d75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee874779-e654-48f0-8f2d-cc98ef150d75.jpg?1",
             "name": "Candles of Leng",
             "text": "{4}, {T}: Reveal the top card of your library. If it has the same name as a card in your graveyard, put it into your graveyard. Otherwise, draw a card.",
             "colours": [],
@@ -8497,7 +8497,7 @@
         },
         {
             "id": "22f99e59-832f-525c-af59-3f9d93c16db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7a1357-debd-49b0-9fd5-560d5b3f589e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7a1357-debd-49b0-9fd5-560d5b3f589e.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color to your mana pool.\nWhen Chromatic Star is put into a graveyard from play, draw a card.",
             "colours": [],
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "ec808989-a0ac-57bf-a51f-35f9a7993a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acd482c-9815-4ff5-99ef-fb1a014251bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acd482c-9815-4ff5-99ef-fb1a014251bb.jpg?1",
             "name": "Chronatog Totem",
             "text": "{T}: Add {U} to your mana pool.\n{1}{U}: Chronatog Totem becomes a 1/2 blue Atog artifact creature until end of turn.\n{0}: Chronatog Totem gets +3/+3 until end of turn. You skip your next turn. Play this ability only once each turn and only if Chronatog Totem is a creature.",
             "colours": [],
@@ -8555,7 +8555,7 @@
         },
         {
             "id": "04c87875-80e6-5752-beda-6335739e404e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54522c50-5333-47ac-ba3e-d87c599404c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54522c50-5333-47ac-ba3e-d87c599404c4.jpg?1",
             "name": "Clockwork Hydra",
             "text": "Clockwork Hydra comes into play with four +1/+1 counters on it.\nWhenever Clockwork Hydra attacks or blocks, remove a +1/+1 counter from it. If you do, Clockwork Hydra deals 1 damage to target creature or player.\n{T}: Put a +1/+1 counter on Clockwork Hydra.",
             "colours": [],
@@ -8586,7 +8586,7 @@
         },
         {
             "id": "ad57af82-3f4a-520d-8d34-33d6b335651d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba87d-3c8c-4f38-bdd8-51072ba6365b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45cba87d-3c8c-4f38-bdd8-51072ba6365b.jpg?1",
             "name": "Foriysian Totem",
             "text": "{T}: Add {R} to your mana pool.\n{4}{R}: Foriysian Totem becomes a 4/4 red Giant artifact creature with trample until end of turn.\nAs long as Foriysian Totem is a creature, it can block an additional creature.",
             "colours": [],
@@ -8616,7 +8616,7 @@
         },
         {
             "id": "cfa8f461-5bbb-5480-a9df-5913a28e3db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109f93ac-86e9-42f1-9fba-fec8bcd521b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/109f93ac-86e9-42f1-9fba-fec8bcd521b0.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power comes into play, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds one mana of that color to his or her mana pool.",
             "colours": [],
@@ -8644,7 +8644,7 @@
         },
         {
             "id": "a67859a0-c4d9-574c-bf5e-e6865db44531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685fc2f8-4cad-46a1-b9d7-d94c13990994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/685fc2f8-4cad-46a1-b9d7-d94c13990994.jpg?1",
             "name": "Hivestone",
             "text": "Creatures you control are Slivers in addition to their other creature types.",
             "colours": [],
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "b32b03e6-17d7-5815-a779-c2f20b6c4a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce2c6d7-505b-490b-9c6f-b5166c9ff71d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce2c6d7-505b-490b-9c6f-b5166c9ff71d.jpg?1",
             "name": "Jhoira's Timebug",
             "text": "{T}: Choose target permanent you control or suspended card you own. If that permanent or card has a time counter on it, you may remove a time counter from it or put another time counter on it.",
             "colours": [],
@@ -8703,7 +8703,7 @@
         },
         {
             "id": "8dcb9b69-a576-50c5-88a0-5b1d84c3587c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b316f198-4465-4fb5-a7a6-a92bf8eae8c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b316f198-4465-4fb5-a7a6-a92bf8eae8c1.jpg?1",
             "name": "Locket of Yesterdays",
             "text": "Spells you play cost {1} less to play for each card with the same name as that spell in your graveyard.",
             "colours": [],
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "f9500c62-96f6-53d7-8449-acf13347d12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73127ee0-9a0c-48fa-9c60-b4c600ace8f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73127ee0-9a0c-48fa-9c60-b4c600ace8f7.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than play this card from your hand, pay {0} and remove it from the game with three time counters on it. At the beginning of your upkeep, remove a time counter. When you remove the last, play it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -8759,7 +8759,7 @@
         },
         {
             "id": "5ae08f1b-0360-5c61-84e2-8d9a27564a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205ac7e-4d4e-4849-b3ae-1e4e0558fd96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1205ac7e-4d4e-4849-b3ae-1e4e0558fd96.jpg?1",
             "name": "Paradise Plume",
             "text": "As Paradise Plume comes into play, choose a color.\nWhenever a player plays a spell of the chosen color, you may gain 1 life.\n{T}: Add one mana of the chosen color to your mana pool.",
             "colours": [],
@@ -8787,7 +8787,7 @@
         },
         {
             "id": "941ee164-4807-5e2f-9b2f-fecefe7d19f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b9fee-88ce-4725-82a5-335d8645aca2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b9fee-88ce-4725-82a5-335d8645aca2.jpg?1",
             "name": "Phyrexian Totem",
             "text": "{T}: Add {B} to your mana pool.\n{2}{B}: Phyrexian Totem becomes a 5/5 black Horror artifact creature with trample until end of turn.\nWhenever Phyrexian Totem is dealt damage, if it's a creature, sacrifice that many permanents.",
             "colours": [],
@@ -8817,7 +8817,7 @@
         },
         {
             "id": "69f00f65-e6ff-5a44-bd0f-b4604b9308c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f058a7-c3c7-4bdf-a66c-a2636a8bd9db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f058a7-c3c7-4bdf-a66c-a2636a8bd9db.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8845,7 +8845,7 @@
         },
         {
             "id": "9020d538-c5d9-5827-9e44-458ffc955b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37a6cf7-f239-4bca-b4c3-a48932ef56b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37a6cf7-f239-4bca-b4c3-a48932ef56b5.jpg?1",
             "name": "Sarpadian Empires, Vol. VII",
             "text": "As Sarpadian Empires, Vol. VII comes into play, choose white Citizen, blue Camarid, black Thrull, red Goblin, or green Saproling.\n{3}, {T}: Put a 1/1 creature token of the chosen color and type into play.",
             "colours": [],
@@ -8873,7 +8873,7 @@
         },
         {
             "id": "422d6c11-d2b9-54b4-a53d-2e1225011596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ca7425-a499-4864-b955-369ef2577849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ca7425-a499-4864-b955-369ef2577849.jpg?1",
             "name": "Stuffy Doll",
             "text": "As Stuffy Doll comes into play, choose a player.\nStuffy Doll is indestructible.\nWhenever damage is dealt to Stuffy Doll, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -8904,7 +8904,7 @@
         },
         {
             "id": "db55ae1e-e836-5aa6-aac5-00023d747048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc332da-e93f-45b1-912c-06af41b412e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fc332da-e93f-45b1-912c-06af41b412e9.jpg?1",
             "name": "Thunder Totem",
             "text": "{T}: Add {W} to your mana pool.\n{1}{W}{W}: Thunder Totem becomes a 2/2 white Spirit artifact creature with flying and first strike until end of turn.",
             "colours": [],
@@ -8934,7 +8934,7 @@
         },
         {
             "id": "fad5a574-462c-57ad-aede-e9be9bbb07fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978d11e7-cfb7-41bf-bb98-deb79549a074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/978d11e7-cfb7-41bf-bb98-deb79549a074.jpg?1",
             "name": "Triskelavus",
             "text": "Flying\nTriskelavus comes into play with three +1/+1 counters on it.\n{1}, Remove a +1/+1 counter from Triskelavus: Put a 1/1 Triskelavite artifact creature token with flying into play. It has \"Sacrifice this creature: This creature deals 1 damage to target creature or player.\"",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "a620801e-351b-5c40-b20e-7de376c31c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg?1",
             "name": "Venser's Sliver",
             "text": "",
             "colours": [],
@@ -8996,7 +8996,7 @@
         },
         {
             "id": "22e0b3e9-7437-52ba-91bf-1c0f3bc2790f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3275df49-c3f1-4310-87dd-25e3e0ee7fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3275df49-c3f1-4310-87dd-25e3e0ee7fca.jpg?1",
             "name": "Weatherseed Totem",
             "text": "{T}: Add {G} to your mana pool.\n{2}{G}{G}{G}: Weatherseed Totem becomes a 5/3 green Treefolk artifact creature with trample until end of turn.\nWhen Weatherseed Totem is put into a graveyard from play, if it was a creature, return this card to its owner's hand.",
             "colours": [],
@@ -9026,7 +9026,7 @@
         },
         {
             "id": "dfd8e69a-0cca-5091-bd98-d37cbcb334ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af09af65-0a3b-42df-b0fd-372e2158beac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af09af65-0a3b-42df-b0fd-372e2158beac.jpg?1",
             "name": "Academy Ruins",
             "text": "{T}: Add {1} to your mana pool.\n{1}{U}, {T}: Put target artifact card in your graveyard on top of your library.",
             "colours": [],
@@ -9058,7 +9058,7 @@
         },
         {
             "id": "42a6cdec-8f5c-5f33-a02d-19557a053373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cead86-b8ff-4975-90b2-3badcc452fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cead86-b8ff-4975-90b2-3badcc452fdb.jpg?1",
             "name": "Calciform Pools",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Calciform Pools.\n{1}, Remove X storage counters from Calciform Pools: Add X mana in any combination of {W} and/or {U} to your mana pool.",
             "colours": [],
@@ -9089,7 +9089,7 @@
         },
         {
             "id": "6304fa9f-6abd-58bf-91c0-e516df9accef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a83915-07b7-4912-bdf2-089b05796378.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4a83915-07b7-4912-bdf2-089b05796378.jpg?1",
             "name": "Dreadship Reef",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Dreadship Reef.\n{1}, Remove X storage counters from Dreadship Reef: Add X mana in any combination of {U} and/or {B} to your mana pool.",
             "colours": [],
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "60e32328-b786-5483-a186-5970b31308fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad23cd0e-6871-4ba6-b5bf-cfd14f8f71b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad23cd0e-6871-4ba6-b5bf-cfd14f8f71b2.jpg?1",
             "name": "Flagstones of Trokair",
             "text": "{T}: Add {W} to your mana pool.\nWhen Flagstones of Trokair is put into a graveyard from play, you may search your library for a Plains card and put it into play tapped. If you do, shuffle your library.",
             "colours": [],
@@ -9152,7 +9152,7 @@
         },
         {
             "id": "8b3736a1-01b2-551a-8b97-8d924518ab4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4521b3-a3b0-4a1d-a623-cc630058eee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4521b3-a3b0-4a1d-a623-cc630058eee2.jpg?1",
             "name": "Fungal Reaches",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Fungal Reaches.\n{1}, Remove X storage counters from Fungal Reaches: Add X mana in any combination of {R} and/or {G} to your mana pool.",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "3bf15b28-2abc-5ef1-9703-2a5c1c71e693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d74254-4750-4fb3-9e53-473a5f98b315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94d74254-4750-4fb3-9e53-473a5f98b315.jpg?1",
             "name": "Gemstone Caverns",
             "text": "If Gemstone Caverns is in your opening hand and you're not playing first, you may begin the game with Gemstone Caverns in play with a luck counter on it. If you do, remove a card in your hand from the game.\n{T}: Add {1} to your mana pool. If Gemstone Caverns has a luck counter on it, instead add one mana of any color to your mana pool.",
             "colours": [],
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "bd45d763-43b8-5c97-977e-a03c8ba8000e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde3b332-5bc3-47bc-ba24-5437f04c21a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde3b332-5bc3-47bc-ba24-5437f04c21a0.jpg?1",
             "name": "Kher Keep",
             "text": "{T}: Add {1} to your mana pool.\n{1}{R}, {T}: Put a 0/1 red Kobold creature token named Kobolds of Kher Keep into play.",
             "colours": [],
@@ -9245,7 +9245,7 @@
         },
         {
             "id": "6aefe6ee-17ed-57e6-b574-b42182965f66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d090288c-48f3-49fe-87c4-3766eb7bb240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d090288c-48f3-49fe-87c4-3766eb7bb240.jpg?1",
             "name": "Molten Slagheap",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Molten Slagheap.\n{1}, Remove X storage counters from Molten Slagheap: Add X mana in any combination of {B} and/or {R} to your mana pool.",
             "colours": [],
@@ -9276,7 +9276,7 @@
         },
         {
             "id": "10e19a9a-4e37-5f00-9fc4-cdda64fee1ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adc67a6-9b05-4480-be0c-70b860075d70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2adc67a6-9b05-4480-be0c-70b860075d70.jpg?1",
             "name": "Saltcrusted Steppe",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}: Put a storage counter on Saltcrusted Steppe.\n{1}, Remove X storage counters from Saltcrusted Steppe: Add X mana in any combination of {G} and/or {W} to your mana pool.",
             "colours": [],
@@ -9307,7 +9307,7 @@
         },
         {
             "id": "f36008e7-7255-5624-bdb2-f17172620a18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bfe849-a508-4fa8-8999-909fe8ec34fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25bfe849-a508-4fa8-8999-909fe8ec34fa.jpg?1",
             "name": "Swarmyard",
             "text": "{T}: Add {1} to your mana pool.\n{T}: Regenerate target Insect, Rat, Spider, or Squirrel.",
             "colours": [],
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "8cf08475-c4e7-53fe-8e5a-1120d2eaf18d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd097ea2-0a1c-44a0-824b-d5373df513fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd097ea2-0a1c-44a0-824b-d5373df513fb.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card and put it into play tapped. Then shuffle your library.",
             "colours": [],
@@ -9363,7 +9363,7 @@
         },
         {
             "id": "6a45518e-533c-5e1f-bd45-7a8882cb63b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22d97f3-08cf-4c19-bbe2-5a36096187cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22d97f3-08cf-4c19-bbe2-5a36096187cd.jpg?1",
             "name": "Urza's Factory",
             "text": "{T}: Add {1} to your mana pool.\n{7}, {T}: Put a 2/2 Assembly-Worker artifact creature token into play.",
             "colours": [],
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "201e0fa2-e371-5fd7-af74-f5b30ff2c5df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc9498-7397-4857-87fe-7c9010944ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fc9498-7397-4857-87fe-7c9010944ed8.jpg?1",
             "name": "Vesuva",
             "text": "As Vesuva comes into play, you may choose a land in play. If you do, Vesuva comes into play tapped as a copy of the chosen land.",
             "colours": [],
@@ -9421,7 +9421,7 @@
         },
         {
             "id": "c94a3c6b-697e-5845-bb21-6662099fc15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9a8337-e4ca-458d-8fcd-672d8d6f1c0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9a8337-e4ca-458d-8fcd-672d8d6f1c0d.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "e884bd08-78b6-5aba-8472-6ff899e4de94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0aaf3-eba0-445e-b560-f889b800e6b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e0aaf3-eba0-445e-b560-f889b800e6b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9497,7 +9497,7 @@
         },
         {
             "id": "18ace20b-f8fb-57ed-934e-91665ff073b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d056a94a-a07d-4494-a75c-b3f6f59457b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d056a94a-a07d-4494-a75c-b3f6f59457b3.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9535,7 +9535,7 @@
         },
         {
             "id": "647af4f2-4815-59a4-8254-fad8a14d97be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa21cca2-59cb-4223-b67b-1a8fc54aadd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa21cca2-59cb-4223-b67b-1a8fc54aadd8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9573,7 +9573,7 @@
         },
         {
             "id": "dc528aa4-749c-57cb-9b1b-f1fcb1ef70b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdeb2c-afb8-4850-bcdc-86283ffa3486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fdeb2c-afb8-4850-bcdc-86283ffa3486.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9611,7 +9611,7 @@
         },
         {
             "id": "1ba1d4de-7a1e-5c02-bef1-6634faf3a13f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08915c9-78ff-450b-a47f-0c9678d16bbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e08915c9-78ff-450b-a47f-0c9678d16bbd.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9649,7 +9649,7 @@
         },
         {
             "id": "c238ce67-4a6a-5db9-993c-560a7a6fa4f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8c7cf-6705-4ff7-8aa8-113c1400ffda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8c7cf-6705-4ff7-8aa8-113c1400ffda.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9687,7 +9687,7 @@
         },
         {
             "id": "2b4eef37-d6b1-5627-950c-09467916099b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1a989a-38d4-4225-a41f-37d54f2f42ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1a989a-38d4-4225-a41f-37d54f2f42ae.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9725,7 +9725,7 @@
         },
         {
             "id": "e412fa48-3d44-5ad3-b8b0-9bc828f77c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fecc759-61fa-4040-9b46-710512baa4bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fecc759-61fa-4040-9b46-710512baa4bf.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "67294962-7f41-58bb-a996-3c401b5648d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53dbcc0-169d-4b5c-b4e5-d82716c1539d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53dbcc0-169d-4b5c-b4e5-d82716c1539d.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9801,7 +9801,7 @@
         },
         {
             "id": "1414305d-ace2-52d4-a571-73b0995ff8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dc4523-075d-425e-9b53-77921d26c173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7dc4523-075d-425e-9b53-77921d26c173.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9839,7 +9839,7 @@
         },
         {
             "id": "a1d25dbb-b5ab-5bbb-ac60-49fefccd738a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd634a88-c114-469a-8133-59cfc9bf3215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd634a88-c114-469a-8133-59cfc9bf3215.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9877,7 +9877,7 @@
         },
         {
             "id": "af6ec5e3-13c3-547f-99fa-5354d4fc563a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34229e7-5dc4-47b3-9ba2-609e5b3ca6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34229e7-5dc4-47b3-9ba2-609e5b3ca6c2.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9915,7 +9915,7 @@
         },
         {
             "id": "3b4081b0-f088-50e5-a4ec-9ff3fff698fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c71906a-f885-49ba-a889-8baf4e74cce8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c71906a-f885-49ba-a889-8baf4e74cce8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "ada0390b-d92e-595c-bfbe-d0bec68ad68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e3961c-d092-4a15-b5db-d7b5c70e4fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3e3961c-d092-4a15-b5db-d7b5c70e4fc1.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9991,7 +9991,7 @@
         },
         {
             "id": "62e143d3-1aa6-5305-a3a4-99df42570c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae3e69d-ec38-43e2-b4a2-3a9064835a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae3e69d-ec38-43e2-b4a2-3a9064835a97.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10029,7 +10029,7 @@
         },
         {
             "id": "c7a20c53-3a15-5d61-bbdc-9a88111c5d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bd3e1-45ef-43b7-8796-6085842278df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5bd3e1-45ef-43b7-8796-6085842278df.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10067,7 +10067,7 @@
         },
         {
             "id": "f5f66768-18d6-592d-9e60-52d2496f21f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a10ed4f-2c9a-424d-bcca-730af7727854.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a10ed4f-2c9a-424d-bcca-730af7727854.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10105,7 +10105,7 @@
         },
         {
             "id": "40f7153f-a960-5bf2-abd3-d2e90b5da97f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b176d24-a4d6-489e-af69-4547693e7de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b176d24-a4d6-489e-af69-4547693e7de1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "c890761b-781b-56e6-a1bc-c8a709c22a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393d66f7-7dbf-4a92-912f-377f99c8f164.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/393d66f7-7dbf-4a92-912f-377f99c8f164.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/TSR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/TSR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a4ac2a93-dac1-5a51-892c-4a3c5f7d058c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2b6d3a-15e7-4305-9384-3635159cb421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da2b6d3a-15e7-4305-9384-3635159cb421.jpg?1",
             "name": "Amrou Scout",
             "text": "{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "ab4a70c6-9460-526f-9337-2b914d3a5e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c3c08-a91d-48cc-8837-993614b6a32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379c3c08-a91d-48cc-8837-993614b6a32e.jpg?1",
             "name": "Amrou Seekers",
             "text": "Amrou Seekers can't be blocked except by artifact creatures and/or white creatures.",
             "colours": [
@@ -75,7 +75,7 @@
         },
         {
             "id": "a4281380-193f-5637-9a6a-907292c33fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cdee5-134f-4008-91ce-9e7d0fdb5750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a55cdee5-134f-4008-91ce-9e7d0fdb5750.jpg?1",
             "name": "Angel of Salvation",
             "text": "Flash; convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nWhen Angel of Salvation enters the battlefield, prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.",
             "colours": [
@@ -109,7 +109,7 @@
         },
         {
             "id": "69f967db-b2c6-53f4-81f9-7003ba349777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e39ea-20be-4196-992c-7ed2cb8150c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e39ea-20be-4196-992c-7ed2cb8150c1.jpg?1",
             "name": "Angel's Grace",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "b2e4d90a-7411-55c9-b089-a1ea0e2ec1dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf42b4-f767-48b7-b38c-b98306909f06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76cf42b4-f767-48b7-b38c-b98306909f06.jpg?1",
             "name": "Aven Mindcensor",
             "text": "Flash\nFlying\nIf an opponent would search a library, that player searches the top four cards of that library instead.",
             "colours": [
@@ -176,7 +176,7 @@
         },
         {
             "id": "50c6c9e8-05fd-5e76-8826-823d21e99c02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261691c8-371d-49b6-9c9b-50ece5984aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261691c8-371d-49b6-9c9b-50ece5984aa2.jpg?1",
             "name": "Aven Riftwatcher",
             "text": "Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher enters the battlefield or leaves the battlefield, you gain 2 life.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "427fd944-0c9e-5136-ae7e-068aaf945ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fd40fa-4144-41b4-b441-a71d09a11305.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0fd40fa-4144-41b4-b441-a71d09a11305.jpg?1",
             "name": "Benalish Cavalry",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -247,7 +247,7 @@
         },
         {
             "id": "6ee1404f-dc19-538d-98b6-5a78456ce8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d57fb-abe1-483b-8b94-85d39a1c31e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8d57fb-abe1-483b-8b94-85d39a1c31e1.jpg?1",
             "name": "Benalish Commander",
             "text": "Benalish Commander's power and toughness are each equal to the number of Soldiers you control.\nSuspend X\u2014{X}{W}{W}. X can't be 0.\nWhenever a time counter is removed from Benalish Commander while it's exiled, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -282,7 +282,7 @@
         },
         {
             "id": "6dfcdb99-cb24-5d0f-831b-1b23ff9be5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1b493-2dec-4816-a427-4813a00ca3e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b1b493-2dec-4816-a427-4813a00ca3e9.jpg?1",
             "name": "Blade of the Sixth Pride",
             "text": "",
             "colours": [
@@ -317,7 +317,7 @@
         },
         {
             "id": "7dd688ae-e9ec-5417-a8d6-e76c4ed9505c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a0a78e-08cc-4eb0-8891-6c3eec5b595b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a0a78e-08cc-4eb0-8891-6c3eec5b595b.jpg?1",
             "name": "Bound in Silence",
             "text": "Enchant creature\nEnchanted creature can't attack or block.",
             "colours": [
@@ -353,7 +353,7 @@
         },
         {
             "id": "3dbe0551-fa87-5302-ab22-20dc5da4da5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae9641c-5792-4f72-b40c-f029af28dab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ae9641c-5792-4f72-b40c-f029af28dab9.jpg?1",
             "name": "Calciderm",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nVanishing 4 (This creature enters the battlefield with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "bf705ea3-4fb4-5ac8-a294-749829fdd1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b980a75-8d2d-4d56-be76-48159ef33631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b980a75-8d2d-4d56-be76-48159ef33631.jpg?1",
             "name": "Castle Raptors",
             "text": "Flying\nAs long as Castle Raptors is untapped, it gets +0/+2.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "1b7fc8c1-2e02-58a8-8dad-d88e5df9f18c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f371f5-9c2a-4a00-a4d2-e4f97ac0f3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f371f5-9c2a-4a00-a4d2-e4f97ac0f3e0.jpg?1",
             "name": "Celestial Crusader",
             "text": "Flash\nSplit second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nFlying\nOther white creatures get +1/+1.",
             "colours": [
@@ -456,7 +456,7 @@
         },
         {
             "id": "ab448847-2974-57b9-a422-41a3e7362678",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6cbece-f9d8-4c40-b72b-dfdb86430ff2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a6cbece-f9d8-4c40-b72b-dfdb86430ff2.jpg?1",
             "name": "Children of Korlis",
             "text": "Sacrifice Children of Korlis: You gain life equal to the life you've lost this turn. (Damage causes loss of life.)",
             "colours": [
@@ -492,7 +492,7 @@
         },
         {
             "id": "37ce768c-95db-5ec5-860c-237b6016b709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a9dfa5-0e94-433e-8f4a-edfa2dac4913.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94a9dfa5-0e94-433e-8f4a-edfa2dac4913.jpg?1",
             "name": "Crovax, Ascendant Hero",
             "text": "Other white creatures get +1/+1.\nNonwhite creatures get -1/-1.\nPay 2 life: Return Crovax, Ascendant Hero to its owner's hand.",
             "colours": [
@@ -529,7 +529,7 @@
         },
         {
             "id": "d6ba87c6-662d-5b41-926d-83cb8cdd07af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321ff631-54f0-4501-852a-569790d05cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/321ff631-54f0-4501-852a-569790d05cf1.jpg?1",
             "name": "Duskrider Peregrine",
             "text": "Flying, protection from black\nSuspend 3\u2014{1}{W} (Rather than cast this card from your hand, you may pay {1}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -563,7 +563,7 @@
         },
         {
             "id": "9def36a4-a8cb-5491-8415-ef73a6a91c9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb5c6e6-7251-4b80-9561-742442d8a497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb5c6e6-7251-4b80-9561-742442d8a497.jpg?1",
             "name": "Errant Doomsayers",
             "text": "{T}: Tap target creature with toughness 2 or less.",
             "colours": [
@@ -598,7 +598,7 @@
         },
         {
             "id": "44589fec-d9a0-5fab-9e50-5064fe738cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af529-6ba1-4900-a6f6-7647c9632e11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b47af529-6ba1-4900-a6f6-7647c9632e11.jpg?1",
             "name": "Fortify",
             "text": "Choose one \u2014\n\u2022 Creatures you control get +2/+0 until end of turn.\n\u2022 Creatures you control get +0/+2 until end of turn.",
             "colours": [
@@ -630,7 +630,7 @@
         },
         {
             "id": "b0347377-17fa-5231-9085-1211ed5ccc65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d038ee-1648-49cf-8775-c191fca252aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d038ee-1648-49cf-8775-c191fca252aa.jpg?1",
             "name": "Griffin Guide",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\nWhen enchanted creature dies, create a 2/2 white Griffin creature token with flying.",
             "colours": [
@@ -664,7 +664,7 @@
         },
         {
             "id": "12347e0d-539b-5c61-97ff-abc62b5bd835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b1b580-4a2c-41a4-a1e0-85b659b3a30e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b1b580-4a2c-41a4-a1e0-85b659b3a30e.jpg?1",
             "name": "Ivory Giant",
             "text": "When Ivory Giant enters the battlefield, tap all nonwhite creatures.\nSuspend 5\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -698,7 +698,7 @@
         },
         {
             "id": "d219a00b-c944-59cf-8fcb-2d455be1a19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce06e910-e130-4975-92db-1399ff3d44b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce06e910-e130-4975-92db-1399ff3d44b7.jpg?1",
             "name": "Judge Unworthy",
             "text": "Choose target attacking or blocking creature. Scry 3, then reveal the top card of your library. Judge Unworthy deals damage equal to that card's converted mana cost to that creature.",
             "colours": [
@@ -730,7 +730,7 @@
         },
         {
             "id": "b97c45c1-96c0-5e50-9d70-33d4ba231701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693bec1-9bd9-4840-9d7f-954f92d968c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8693bec1-9bd9-4840-9d7f-954f92d968c9.jpg?1",
             "name": "Knight of Sursi",
             "text": "Flying; flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nSuspend 3\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -765,7 +765,7 @@
         },
         {
             "id": "79232f04-8438-5dc5-8782-4e97a2d1ef4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ac76c0-54ce-41b2-9000-e21eecaf7e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4ac76c0-54ce-41b2-9000-e21eecaf7e99.jpg?1",
             "name": "Knight of the Holy Nimbus",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nIf Knight of the Holy Nimbus would be destroyed, regenerate it. (Tap it, remove it from combat, and heal all damage on it.)\n{2}: Knight of the Holy Nimbus can't be regenerated this turn. Only your opponents may activate this ability.",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "58178a9e-a648-5955-9d76-1bc276ae9491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0595c72-5b32-4d7b-8efc-7ce5c83504dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0595c72-5b32-4d7b-8efc-7ce5c83504dd.jpg?1",
             "name": "Lost Auramancers",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Lost Auramancers dies, if it had no time counters on it, you may search your library for an enchantment card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "b0163288-d504-5c2d-af33-f8ddd709f84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8b4d4-4400-46cc-bd3c-e8a781cfc6f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8b4d4-4400-46cc-bd3c-e8a781cfc6f2.jpg?1",
             "name": "Lymph Sliver",
             "text": "All Sliver creatures have absorb 1. (If a source would deal damage to a Sliver, prevent 1 of that damage.)",
             "colours": [
@@ -870,7 +870,7 @@
         },
         {
             "id": "befe8230-3cd1-5b8f-90c2-4c2cebd27010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae707d5-d81d-4320-b947-6016dc188898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ae707d5-d81d-4320-b947-6016dc188898.jpg?1",
             "name": "Mana Tithe",
             "text": "Counter target spell unless its controller pays {1}.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "a84da07b-deba-5175-9239-d2553253c771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5686b7-4b7b-4127-9330-9282f36bd70b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5686b7-4b7b-4127-9330-9282f36bd70b.jpg?1",
             "name": "Mangara of Corondor",
             "text": "{T}: Exile Mangara of Corondor and target permanent.",
             "colours": [
@@ -939,7 +939,7 @@
         },
         {
             "id": "7564d040-a263-5117-bc4f-1e260c0ff02f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7ab3b-beca-411e-bc27-024f42c013e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be7ab3b-beca-411e-bc27-024f42c013e1.jpg?1",
             "name": "Momentary Blink",
             "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -972,7 +972,7 @@
         },
         {
             "id": "957a9e0f-a302-5e31-9801-2231ea879789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca60d13-137f-4438-bc51-7ea02ec3c515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cca60d13-137f-4438-bc51-7ea02ec3c515.jpg?1",
             "name": "Mycologist",
             "text": "At the beginning of your upkeep, put a spore counter on Mycologist.\nRemove three spore counters from Mycologist: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: You gain 2 life.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "c11c6937-c843-5fd7-83f2-63c165d05459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9b2506-ead4-49ff-a733-66f3f13dbe17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de9b2506-ead4-49ff-a733-66f3f13dbe17.jpg?1",
             "name": "Outrider en-Kor",
             "text": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n{0}: The next 1 damage that would be dealt to Outrider en-Kor this turn is dealt to target creature you control instead.",
             "colours": [
@@ -1043,7 +1043,7 @@
         },
         {
             "id": "1325d6d7-1423-5e4d-9126-ec6e3f4c2bcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a2a28e-c241-4228-9ece-2e49d4d3733a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a2a28e-c241-4228-9ece-2e49d4d3733a.jpg?1",
             "name": "Pallid Mycoderm",
             "text": "At the beginning of your upkeep, put a spore counter on Pallid Mycoderm.\nRemove three spore counters from Pallid Mycoderm: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Each creature you control that's a Fungus or a Saproling gets +1/+1 until end of turn.",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "25f126ed-683a-503a-bddb-f860941d1c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6f333-ccb4-44ea-be59-bba6335acf99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe6f333-ccb4-44ea-be59-bba6335acf99.jpg?1",
             "name": "Porphyry Nodes",
             "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Porphyry Nodes.",
             "colours": [
@@ -1109,7 +1109,7 @@
         },
         {
             "id": "1e281677-146c-5b2b-bdd0-af1dfe08e9bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6db2cf-5171-4791-82b4-c9fac37902a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc6db2cf-5171-4791-82b4-c9fac37902a3.jpg?1",
             "name": "Poultice Sliver",
             "text": "All Slivers have \"{2}, {T}: Regenerate target Sliver.\" (The next time that Sliver would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -1143,7 +1143,7 @@
         },
         {
             "id": "fdb30248-cce1-50cb-924c-6de5b100035d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4eb560-97a7-4f5f-bf12-1f9e1be63095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc4eb560-97a7-4f5f-bf12-1f9e1be63095.jpg?1",
             "name": "Pulmonic Sliver",
             "text": "All Sliver creatures have flying.\nAll Slivers have \"If this permanent would be put into a graveyard, you may put it on top of its owner's library instead.\"",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "df37c9a2-88cb-54a9-954c-792a12a5f7a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea5111-5a5c-4c40-8686-8123c822843a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ea5111-5a5c-4c40-8686-8123c822843a.jpg?1",
             "name": "Rebuff the Wicked",
             "text": "Counter target spell that targets a permanent you control.",
             "colours": [
@@ -1209,7 +1209,7 @@
         },
         {
             "id": "d2e0a4cb-267a-52f2-aa34-7b05921ea82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0febc7fe-4172-4285-9804-a62ce4506c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0febc7fe-4172-4285-9804-a62ce4506c39.jpg?1",
             "name": "Restore Balance",
             "text": "Suspend 6\u2014{W}\nEach player chooses a number of lands they control equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "abda8ff5-d47e-587a-992e-a6417245e245",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efa90c9-ff9a-4a99-b991-8e4dc54bb131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5efa90c9-ff9a-4a99-b991-8e4dc54bb131.jpg?1",
             "name": "Return to Dust",
             "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
             "colours": [
@@ -1273,7 +1273,7 @@
         },
         {
             "id": "69db7d05-d620-561c-8d1e-cd2b3710b351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4cb76-c895-4862-8099-d306b1bb06e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20c4cb76-c895-4862-8099-d306b1bb06e9.jpg?1",
             "name": "Riftmarked Knight",
             "text": "Protection from black; flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nSuspend 3\u2014{1}{W}{W}\nWhen the last time counter is removed from Riftmarked Knight while it's exiled, create a 2/2 black Knight creature token with flanking, protection from white, and haste.",
             "colours": [
@@ -1309,7 +1309,7 @@
         },
         {
             "id": "a20c6107-dece-506b-b12b-64fbee391c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61475a0c-f33a-43a7-937c-5a63fc8a54b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61475a0c-f33a-43a7-937c-5a63fc8a54b4.jpg?1",
             "name": "Saltblast",
             "text": "Destroy target nonwhite permanent.",
             "colours": [
@@ -1341,7 +1341,7 @@
         },
         {
             "id": "736c1262-1c86-5d74-ba33-b3dff0b7d596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb21c04-d3f7-4960-9b9b-2354e98becb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecb21c04-d3f7-4960-9b9b-2354e98becb7.jpg?1",
             "name": "Saltfield Recluse",
             "text": "{T}: Target creature gets -2/-0 until end of turn.",
             "colours": [
@@ -1377,7 +1377,7 @@
         },
         {
             "id": "361d11a9-f82e-5a34-bd59-1cd7c96c238b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5627de-fda7-4e39-a6ec-1e895bc353ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5627de-fda7-4e39-a6ec-1e895bc353ed.jpg?1",
             "name": "Serra Avenger",
             "text": "You can't cast this spell during your first, second, or third turns of the game.\nFlying, vigilance",
             "colours": [
@@ -1411,7 +1411,7 @@
         },
         {
             "id": "1a5e96d4-fbe0-5c55-8e28-17fda73e72c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e4d9c6-416b-47fd-93a5-6c19d89b7c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e4d9c6-416b-47fd-93a5-6c19d89b7c7f.jpg?1",
             "name": "Shade of Trokair",
             "text": "{W}: Shade of Trokair gets +1/+1 until end of turn.\nSuspend 3\u2014{W} (Rather than cast this card from your hand, you may pay {W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -1445,7 +1445,7 @@
         },
         {
             "id": "4c768990-98de-5101-ba86-ca0141bb3236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5616e0c7-1f1d-4716-95e5-773a8e3ae5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5616e0c7-1f1d-4716-95e5-773a8e3ae5e3.jpg?1",
             "name": "Sidewinder Sliver",
             "text": "All Sliver creatures have flanking. (Whenever a creature without flanking blocks a Sliver, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -1479,7 +1479,7 @@
         },
         {
             "id": "aca3df97-9aa0-53c9-944d-c5fac59a4e7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/000edc61-b3ae-49e3-87f4-0250fa6a4501.jpg?1",
             "name": "Sinew Sliver",
             "text": "All Sliver creatures get +1/+1.",
             "colours": [
@@ -1513,7 +1513,7 @@
         },
         {
             "id": "eb678cc7-ded7-5534-812c-94a65f141a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0997f0-865f-422b-b34e-485ff8178625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad0997f0-865f-422b-b34e-485ff8178625.jpg?1",
             "name": "Stonecloaker",
             "text": "Flash\nFlying\nWhen Stonecloaker enters the battlefield, return a creature you control to its owner's hand.\nWhen Stonecloaker enters the battlefield, exile target card from a graveyard.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "8e2a9b5b-1313-5fd2-b8ae-88d4f047680d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3181709-42d2-4e1a-8de9-4f1d2deac232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3181709-42d2-4e1a-8de9-4f1d2deac232.jpg?1",
             "name": "Stormfront Riders",
             "text": "Flying\nWhen Stormfront Riders enters the battlefield, return two creatures you control to their owner's hand.\nWhenever Stormfront Riders or another creature is returned to your hand from the battlefield, create a 1/1 white Soldier creature token.",
             "colours": [
@@ -1582,7 +1582,7 @@
         },
         {
             "id": "68ac61a4-705e-551f-a8c6-abd49f755ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ab72c3-1f76-45ff-84b4-05f403866d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ab72c3-1f76-45ff-84b4-05f403866d44.jpg?1",
             "name": "Sunlance",
             "text": "Sunlance deals 3 damage to target nonwhite creature.",
             "colours": [
@@ -1614,7 +1614,7 @@
         },
         {
             "id": "ee4361bb-f15d-56b0-a87b-7efd487c7fc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72380757-6344-43e6-a4ed-bd753f2431d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72380757-6344-43e6-a4ed-bd753f2431d5.jpg?1",
             "name": "Temporal Isolation",
             "text": "Flash\nEnchant creature\nEnchanted creature has shadow. (It can block or be blocked by only creatures with shadow.)\nPrevent all damage that would be dealt by enchanted creature.",
             "colours": [
@@ -1648,7 +1648,7 @@
         },
         {
             "id": "9b441258-d5b6-5057-bd5f-ab08f22ad353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5395039-4f1d-4b16-a8b9-b80593dbde76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5395039-4f1d-4b16-a8b9-b80593dbde76.jpg?1",
             "name": "Watcher Sliver",
             "text": "All Sliver creatures get +0/+2.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "87dc26cd-c0bf-5707-a0d0-9bcffeec8d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d243be1-b67a-44b5-9453-a9f8583c0014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d243be1-b67a-44b5-9453-a9f8583c0014.jpg?1",
             "name": "Whitemane Lion",
             "text": "Flash\nWhen Whitemane Lion enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "3f62d380-e306-5857-bfec-a0a8512f9ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cec8dcc-8ebb-4640-a5f3-90e6e62c27e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cec8dcc-8ebb-4640-a5f3-90e6e62c27e5.jpg?1",
             "name": "Aeon Chronicler",
             "text": "Aeon Chronicler's power and toughness are each equal to the number of cards in your hand.\nSuspend X\u2014{X}{3}{U}. X can't be 0.\nWhenever a time counter is removed from Aeon Chronicler while it's exiled, draw a card.",
             "colours": [
@@ -1750,7 +1750,7 @@
         },
         {
             "id": "31cb499a-8325-555f-883a-75399d83c5ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9079c93e-3da8-442a-89d2-609a3eac83b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9079c93e-3da8-442a-89d2-609a3eac83b0.jpg?1",
             "name": "Ancestral Vision",
             "text": "Suspend 4\u2014{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
             "colours": [
@@ -1782,7 +1782,7 @@
         },
         {
             "id": "fc48f3ed-4735-5022-aace-a962fec13b73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aa1ab5-0085-4043-8272-64e10f3dcf2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9aa1ab5-0085-4043-8272-64e10f3dcf2a.jpg?1",
             "name": "Bewilder",
             "text": "Target creature gets -3/-0 until end of turn.\nDraw a card.",
             "colours": [
@@ -1814,7 +1814,7 @@
         },
         {
             "id": "52de3cd5-22b4-5f6c-a630-826677478e0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de72afaf-a4b4-431c-8831-86ddfba2403c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de72afaf-a4b4-431c-8831-86ddfba2403c.jpg?1",
             "name": "Bonded Fetch",
             "text": "Defender, haste\n{T}: Draw a card, then discard a card.",
             "colours": [
@@ -1848,7 +1848,7 @@
         },
         {
             "id": "a03796d7-a7d2-5ee8-ae80-0a7b5787e8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb038efc-2cb2-4635-a183-42b6e0b6b5f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb038efc-2cb2-4635-a183-42b6e0b6b5f8.jpg?1",
             "name": "Brine Elemental",
             "text": "Morph {5}{U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Brine Elemental is turned face up, each opponent skips their next untap step.",
             "colours": [
@@ -1882,7 +1882,7 @@
         },
         {
             "id": "74058b0c-593b-56e1-86b6-0d602671653f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7224b-adb9-4c31-b0bb-1c498f2922fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b7224b-adb9-4c31-b0bb-1c498f2922fb.jpg?1",
             "name": "Careful Consideration",
             "text": "Target player draws four cards, then discards three cards. If you cast this spell during your main phase, instead that player draws four cards, then discards two cards.",
             "colours": [
@@ -1914,7 +1914,7 @@
         },
         {
             "id": "17decf82-4bef-51f3-9be6-175d0d0516bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9adcc82-0754-4cb7-ac28-e5624f563b7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9adcc82-0754-4cb7-ac28-e5624f563b7f.jpg?1",
             "name": "Cloudseeder",
             "text": "Flying\n{U}, {T}, Discard a card: Create a 1/1 blue Faerie creature token named Cloud Sprite. It has flying and \"Cloud Sprite can block only creatures with flying.\"",
             "colours": [
@@ -1949,7 +1949,7 @@
         },
         {
             "id": "620f2ce9-7d95-544b-8cca-d064ef56c444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eacbc6-362e-4257-b29f-78682f4130c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8eacbc6-362e-4257-b29f-78682f4130c1.jpg?1",
             "name": "Coral Trickster",
             "text": "Morph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Coral Trickster is turned face up, you may tap or untap target permanent.",
             "colours": [
@@ -1984,7 +1984,7 @@
         },
         {
             "id": "236e8e0f-3d51-5250-993b-266019076425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba5f411-668b-4344-be2f-c8f6cc3255e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba5f411-668b-4344-be2f-c8f6cc3255e8.jpg?1",
             "name": "Crookclaw Transmuter",
             "text": "Flash\nFlying\nWhen Crookclaw Transmuter enters the battlefield, switch target creature's power and toughness until end of turn.",
             "colours": [
@@ -2019,7 +2019,7 @@
         },
         {
             "id": "cb2b0a7d-4102-5086-956c-007a77fd00d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5377e2d9-a846-4533-aeaf-9144ca8765da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5377e2d9-a846-4533-aeaf-9144ca8765da.jpg?1",
             "name": "Cryptic Annelid",
             "text": "When Cryptic Annelid enters the battlefield, scry 1, then scry 2, then scry 3. (To scry X, look at the top X cards of your library, then put any number of them on the bottom of your library and the rest on top in any order.)",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "7613c3d3-6972-579a-a332-d8e4874dd229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906d538-f1ca-4799-b91c-2e0d2934f241.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3906d538-f1ca-4799-b91c-2e0d2934f241.jpg?1",
             "name": "Delay",
             "text": "Counter target spell. If the spell is countered this way, exile it with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, remove a time counter from that card. When the last is removed, the player plays it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "6133c5ed-57d6-592e-8bd7-f0760c248505",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eca246-591e-4ea8-8432-9f4c1f16a65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51eca246-591e-4ea8-8432-9f4c1f16a65e.jpg?1",
             "name": "Draining Whelk",
             "text": "Flash\nFlying\nWhen Draining Whelk enters the battlefield, counter target spell. Put X +1/+1 counters on Draining Whelk, where X is that spell's converted mana cost.",
             "colours": [
@@ -2120,7 +2120,7 @@
         },
         {
             "id": "90a89f55-a8f5-5f88-a9f7-10ec957ef6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59b4729-74c1-4aa9-937d-27cda960f157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59b4729-74c1-4aa9-937d-27cda960f157.jpg?1",
             "name": "Dream Stalker",
             "text": "When Dream Stalker enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -2154,7 +2154,7 @@
         },
         {
             "id": "2b5732f7-abd4-515a-8453-dc5b1d2159d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f244985e-7487-44db-bd69-47c781753f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f244985e-7487-44db-bd69-47c781753f2e.jpg?1",
             "name": "Dreamscape Artist",
             "text": "{2}{U}, {T}, Discard a card, Sacrifice a land: Search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -2189,7 +2189,7 @@
         },
         {
             "id": "f7824b00-012c-5d70-9041-05b67ac1ba8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c45e7-f157-4b3f-a627-09b5c27473ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40c45e7-f157-4b3f-a627-09b5c27473ae.jpg?1",
             "name": "Drifter il-Dal",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nAt the beginning of your upkeep, sacrifice Drifter il-Dal unless you pay {U}.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "23b79e79-e54e-5177-918a-42b25b0d088a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3779a76a-0171-4714-9713-a65dc173a33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3779a76a-0171-4714-9713-a65dc173a33f.jpg?1",
             "name": "Errant Ephemeron",
             "text": "Flying\nSuspend 4\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "fe65e2a9-85b1-580f-9255-cefdb74e2b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac93762-9377-49c3-9593-6d02bfb66903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3ac93762-9377-49c3-9593-6d02bfb66903.jpg?1",
             "name": "Erratic Mutation",
             "text": "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's converted mana cost. Put all cards revealed this way on the bottom of your library in any order.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "a5d258f2-c1f1-548d-9df1-6bb5d12697d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0f831e-2eb0-499f-9502-418c04ac34a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0f831e-2eb0-499f-9502-418c04ac34a0.jpg?1",
             "name": "Fathom Seer",
             "text": "Morph\u2014\nReturn two Islands you control to their owner's hand. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Fathom Seer is turned face up, draw two cards.",
             "colours": [
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "8254f7fd-e18b-56ab-9338-24d4b2db5c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecf2ee8-6b93-4757-89c4-f1e76509a217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecf2ee8-6b93-4757-89c4-f1e76509a217.jpg?1",
             "name": "Foresee",
             "text": "Scry 4, then draw two cards.",
             "colours": [
@@ -2356,7 +2356,7 @@
         },
         {
             "id": "5251cf54-7160-5605-b490-d826a2d0ca90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf05ed80-8abf-4c2c-97d7-a96961c35f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf05ed80-8abf-4c2c-97d7-a96961c35f35.jpg?1",
             "name": "Gossamer Phantasm",
             "text": "Flying\nWhen Gossamer Phantasm becomes the target of a spell or ability, sacrifice it.",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "00cd686b-96c5-5da4-9ffc-1044f9743a60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ab190b-c96f-4b00-8e97-33a11bb2ed08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3ab190b-c96f-4b00-8e97-33a11bb2ed08.jpg?1",
             "name": "Infiltrator il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nSuspend 2\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2425,7 +2425,7 @@
         },
         {
             "id": "deca81b5-0489-5d1b-a6c7-a12185100580",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707277a-f0ba-4f35-9274-7a38efbc11e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707277a-f0ba-4f35-9274-7a38efbc11e8.jpg?1",
             "name": "Jodah's Avenger",
             "text": "{0}: Until end of turn, Jodah's Avenger gets -1/-1 and gains your choice of double strike, protection from red, vigilance, or shadow. (A creature with shadow can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -2459,7 +2459,7 @@
         },
         {
             "id": "14877986-1b4b-53b0-a75c-f1cecee688f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624feb0e-f683-4eb6-a63b-7872d0e28f1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/624feb0e-f683-4eb6-a63b-7872d0e28f1f.jpg?1",
             "name": "Logic Knot",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nCounter target spell unless its controller pays {X}.",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "d45794de-9c64-5941-bdb0-3af2c4950cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d891cb5-c575-4c63-b053-a2315947c3e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d891cb5-c575-4c63-b053-a2315947c3e0.jpg?1",
             "name": "Looter il-Kor",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Looter il-Kor deals damage to an opponent, draw a card, then discard a card.",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "511d2813-62b1-53d8-9e78-b95bbe3ea5e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ba1ea5-c861-4bb4-a681-fc0633268bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27ba1ea5-c861-4bb4-a681-fc0633268bd9.jpg?1",
             "name": "Magus of the Future",
             "text": "Play with the top card of your library revealed.\nYou may play lands and cast spells from the top of your library.",
             "colours": [
@@ -2561,7 +2561,7 @@
         },
         {
             "id": "b7e4fc02-81a4-5a52-9a62-c5b43c9e4b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb51cd-8418-43ee-bf4f-6b959cc5b131.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7cb51cd-8418-43ee-bf4f-6b959cc5b131.jpg?1",
             "name": "Mystical Teachings",
             "text": "Search your library for an instant card or a card with flash, reveal it, put it into your hand, then shuffle your library.\nFlashback {5}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2594,7 +2594,7 @@
         },
         {
             "id": "6f0868d6-7470-573d-a2d4-0efa21fd7126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed4c0bb-b710-44a1-b8bc-6bd11c27b8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ed4c0bb-b710-44a1-b8bc-6bd11c27b8b8.jpg?1",
             "name": "Pact of Negation",
             "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
             "colours": [
@@ -2626,7 +2626,7 @@
         },
         {
             "id": "6fb6c32a-932d-5dc4-8e06-27b25e10c45d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb19ac2-edf9-4f9a-b9ba-2a33ba96a4d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb19ac2-edf9-4f9a-b9ba-2a33ba96a4d8.jpg?1",
             "name": "Piracy Charm",
             "text": "Choose one \u2014\n\u2022 Target creature gains islandwalk until end of turn. (It can't be blocked as long as defending player controls an Island.)\n\u2022 Target creature gets +2/-1 until end of turn.\n\u2022 Target player discards a card.",
             "colours": [
@@ -2658,7 +2658,7 @@
         },
         {
             "id": "1b3f6c08-8f24-5d8b-92c2-c45bb7cee66d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501dea-4e0e-49b0-86b5-e8a01f77077d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1501dea-4e0e-49b0-86b5-e8a01f77077d.jpg?1",
             "name": "Pongify",
             "text": "Destroy target creature. It can't be regenerated. Its controller creates a 3/3 green Ape creature token.",
             "colours": [
@@ -2690,7 +2690,7 @@
         },
         {
             "id": "70084461-4c7b-585f-a157-71c70695d64f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27064d4f-aeaf-4432-964a-97dfc1db835d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27064d4f-aeaf-4432-964a-97dfc1db835d.jpg?1",
             "name": "Primal Plasma",
             "text": "As Primal Plasma enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.",
             "colours": [
@@ -2725,7 +2725,7 @@
         },
         {
             "id": "d84db383-5bf8-51ad-a618-be4e711c324b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8510381-e05c-4cc4-98aa-c9327e18ec02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8510381-e05c-4cc4-98aa-c9327e18ec02.jpg?1",
             "name": "Reality Acid",
             "text": "Enchant permanent\nVanishing 3 (This Aura enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves the battlefield, enchanted permanent's controller sacrifices it.",
             "colours": [
@@ -2759,7 +2759,7 @@
         },
         {
             "id": "7eb4d3be-461f-5580-9551-587a396dab2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2b228d-db4d-44a3-b208-6cf7a9f57da6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2b228d-db4d-44a3-b208-6cf7a9f57da6.jpg?1",
             "name": "Riftwing Cloudskate",
             "text": "Flying\nWhen Riftwing Cloudskate enters the battlefield, return target permanent to its owner's hand.\nSuspend 3\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "2a3256a3-723c-5b2e-8120-63fe40a5cc7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb9744-79cc-48d6-9e3b-f16073dde1e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb9744-79cc-48d6-9e3b-f16073dde1e4.jpg?1",
             "name": "Riptide Pilferer",
             "text": "Whenever Riptide Pilferer deals combat damage to a player, that player discards a card.\nMorph {U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "5252bbeb-ffe3-5060-9cca-3c3cb0b06568",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636ba4f-07ef-4327-8e4a-6c2d8f90b264.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8636ba4f-07ef-4327-8e4a-6c2d8f90b264.jpg?1",
             "name": "Sarcomite Myr",
             "text": "{2}: Sarcomite Myr gains flying until end of turn.\n{2}, Sacrifice Sarcomite Myr: Draw a card.",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "a3c3fe16-2020-5591-bbee-a69dde075e97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc15d7-9e3f-4293-978e-809a6a5b9aa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc15d7-9e3f-4293-978e-809a6a5b9aa0.jpg?1",
             "name": "Shaper Parasite",
             "text": "Morph {2}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Shaper Parasite is turned face up, target creature gets +2/-2 or -2/+2 until end of turn.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "2c193ca5-3e3e-56cf-a626-623d60c50fe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16dac30-52d2-4b87-90b4-4bc7f8f729ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f16dac30-52d2-4b87-90b4-4bc7f8f729ee.jpg?1",
             "name": "Slipstream Serpent",
             "text": "Slipstream Serpent can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice Slipstream Serpent.\nMorph {5}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "03a8beba-3036-58d0-93a2-3c5075ed66c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367d46d1-fa7a-403d-8949-b478a1f83f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367d46d1-fa7a-403d-8949-b478a1f83f46.jpg?1",
             "name": "Snapback",
             "text": "You may exile a blue card from your hand rather than pay this spell's mana cost.\nReturn target creature to its owner's hand.",
             "colours": [
@@ -2964,7 +2964,7 @@
         },
         {
             "id": "a616deee-dacb-5c9f-b462-163606df88bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169929c-641f-41c8-a48e-1a7d0c57726b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8169929c-641f-41c8-a48e-1a7d0c57726b.jpg?1",
             "name": "Spell Burst",
             "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCounter target spell with converted mana cost X.",
             "colours": [
@@ -2996,7 +2996,7 @@
         },
         {
             "id": "1c4bce9f-32f4-57ca-907b-6e610ca0df8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a696a-11fb-4573-bf95-1fec643bf418.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43a696a-11fb-4573-bf95-1fec643bf418.jpg?1",
             "name": "Spiketail Drakeling",
             "text": "Flying\nSacrifice Spiketail Drakeling: Counter target spell unless its controller pays {2}.",
             "colours": [
@@ -3030,7 +3030,7 @@
         },
         {
             "id": "a6f10a22-024e-5eeb-a845-8229ad2e30e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25283518-cabb-4fa6-ab92-c989190ec9f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25283518-cabb-4fa6-ab92-c989190ec9f3.jpg?1",
             "name": "Stormcloud Djinn",
             "text": "Flying\nStormcloud Djinn can block only creatures with flying.\n{R}{R}: Stormcloud Djinn gets +2/+0 until end of turn and deals 1 damage to you.",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "73b344fd-1c4f-574b-bdb4-2bd290aa1adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5e4a8-ea7b-4803-a7ed-3b915708661f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc5e4a8-ea7b-4803-a7ed-3b915708661f.jpg?1",
             "name": "Teferi, Mage of Zhalfir",
             "text": "Flash\nCreature cards you own that aren't on the battlefield have flash.\nEach opponent can cast spells only any time they could cast a sorcery.",
             "colours": [
@@ -3102,7 +3102,7 @@
         },
         {
             "id": "fd02428c-6f4a-5f2f-9e72-85a4d7a0b05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e1d85b-f094-40e2-8811-640076d7d546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e1d85b-f094-40e2-8811-640076d7d546.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3134,7 +3134,7 @@
         },
         {
             "id": "a4188a48-0896-5dfc-ba04-4183830ea9e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea286fe-0768-4e46-a8dd-a3522db844e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea286fe-0768-4e46-a8dd-a3522db844e1.jpg?1",
             "name": "Timebender",
             "text": "Morph {U}\nWhen Timebender is turned face up, choose one \u2014\n\u2022 Remove two time counters from target permanent or suspended card.\n\u2022 Put two time counters on target permanent with a time counter on it or suspended card.",
             "colours": [
@@ -3169,7 +3169,7 @@
         },
         {
             "id": "1a1dc6a7-50a6-5382-9750-7fc14f6a1ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6572-4748-4242-98d2-62e668a59a48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da4d6572-4748-4242-98d2-62e668a59a48.jpg?1",
             "name": "Tolarian Sentinel",
             "text": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "a80b29db-4822-50c8-b251-a49758cb2ef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c211958-1ee2-4dda-9ef1-c59de599ebc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c211958-1ee2-4dda-9ef1-c59de599ebc1.jpg?1",
             "name": "Veiling Oddity",
             "text": "Suspend 4\u2014{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)\nWhen the last time counter is removed from Veiling Oddity while it's exiled, creatures can't be blocked this turn.",
             "colours": [
@@ -3238,7 +3238,7 @@
         },
         {
             "id": "ae79b5ad-2b7a-5f04-995d-e04fc18a41f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dabd1-c043-4bcf-afa8-271225a099e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c08dabd1-c043-4bcf-afa8-271225a099e1.jpg?1",
             "name": "Venser, Shaper Savant",
             "text": "Flash\nWhen Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "73286290-15c5-5fc5-b084-e79b2f882d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b59d2-ad4b-4dc6-a730-0d19f2774ae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1b59d2-ad4b-4dc6-a730-0d19f2774ae9.jpg?1",
             "name": "Vesuvan Shapeshifter",
             "text": "As Vesuvan Shapeshifter enters the battlefield or is turned face up, you may choose another creature on the battlefield. If you do, until Vesuvan Shapeshifter is turned face down, it becomes a copy of that creature, except it has \"At the beginning of your upkeep, you may turn this creature face down.\"\nMorph {1}{U}",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "baf1ef45-615b-558a-b306-ca4d767d0671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d09ae-a995-482f-848e-7f99477bd6f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794d09ae-a995-482f-848e-7f99477bd6f3.jpg?1",
             "name": "Walk the Aeons",
             "text": "Buyback\u2014\nSacrifice three Islands. (You may sacrifice three Islands in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nTarget player takes an extra turn after this one.",
             "colours": [
@@ -3341,7 +3341,7 @@
         },
         {
             "id": "f214f070-51c3-5945-8627-84c36a4ef130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80e0723-0d0a-42df-90ac-0ba9b5c3a82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80e0723-0d0a-42df-90ac-0ba9b5c3a82d.jpg?1",
             "name": "Whip-Spine Drake",
             "text": "Flying\nMorph {2}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "af4b6f9c-aa2c-5144-9b6d-928bc2a3d4ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ece0707-72f7-4a0a-8c37-9fbe0c694f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ece0707-72f7-4a0a-8c37-9fbe0c694f9b.jpg?1",
             "name": "Wipe Away",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nReturn target permanent to its owner's hand.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "cfe83ab1-ea1a-5812-a644-170f6e9e1316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a1dc6-215f-4738-8ae4-7b6aa1c7d80b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0a1dc6-215f-4738-8ae4-7b6aa1c7d80b.jpg?1",
             "name": "Assassinate",
             "text": "Destroy target tapped creature.",
             "colours": [
@@ -3440,7 +3440,7 @@
         },
         {
             "id": "61c84955-5bc1-59b8-a0e6-4e9cee74cea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec1014-375c-4877-95e3-093d24c02bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cec1014-375c-4877-95e3-093d24c02bc8.jpg?1",
             "name": "Big Game Hunter",
             "text": "When Big Game Hunter enters the battlefield, destroy target creature with power 4 or greater. It can't be regenerated.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3476,7 +3476,7 @@
         },
         {
             "id": "7dcf7052-00a9-5c61-ade8-1a43acfc1e57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ab3455-f464-41b0-ac63-d40d27abbfb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ab3455-f464-41b0-ac63-d40d27abbfb1.jpg?1",
             "name": "Blightspeaker",
             "text": "{T}: Target player loses 1 life.\n{4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "46993703-2fc7-5fa7-a93e-879311169ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8680e7c-f180-45b9-9af6-a8e93037b851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8680e7c-f180-45b9-9af6-a8e93037b851.jpg?1",
             "name": "Corpulent Corpse",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nSuspend 5\u2014{B} (Rather than cast this card from your hand, you may pay {B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -3546,7 +3546,7 @@
         },
         {
             "id": "c1016f12-3c9c-54ae-bbe5-540bd3a0271d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4123bab-d61e-4d69-b9ca-1fff3a11335a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4123bab-d61e-4d69-b9ca-1fff3a11335a.jpg?1",
             "name": "Cutthroat il-Dal",
             "text": "Hellbent \u2014 Cutthroat il-Dal has shadow as long as you have no cards in hand. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -3581,7 +3581,7 @@
         },
         {
             "id": "4a4a6d9b-1b72-5084-bb81-1dba685e9686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b65da-b9b3-4e15-bab5-bcbfd20dbe05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/941b65da-b9b3-4e15-bab5-bcbfd20dbe05.jpg?1",
             "name": "Damnation",
             "text": "Destroy all creatures. They can't be regenerated.",
             "colours": [
@@ -3613,7 +3613,7 @@
         },
         {
             "id": "d34eeb2c-f76f-5b01-9ec6-9f235a853778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9366fa8-f0af-4eb4-a063-7869ca85b9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9366fa8-f0af-4eb4-a063-7869ca85b9c2.jpg?1",
             "name": "Dark Withering",
             "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3645,7 +3645,7 @@
         },
         {
             "id": "350f73ee-1412-5a48-915e-051b8c8f8957",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e872ae-2e41-49f5-9015-e8f9fa7da987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e872ae-2e41-49f5-9015-e8f9fa7da987.jpg?1",
             "name": "Deadly Grub",
             "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadly Grub dies, if it had no time counters on it, create a 6/1 green Insect creature token with shroud. (It can't be the target of spells or abilities.)",
             "colours": [
@@ -3679,7 +3679,7 @@
         },
         {
             "id": "e9aa6ef5-a896-5cfe-a773-c2f30a319e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b368-6fb0-4430-807e-d124f3077361.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74c1b368-6fb0-4430-807e-d124f3077361.jpg?1",
             "name": "Deathspore Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on Deathspore Thallid.\nRemove three spore counters from Deathspore Thallid: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -3714,7 +3714,7 @@
         },
         {
             "id": "3db1f071-cd35-547b-81a1-2488b04ea984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfa5f3-495f-457b-ad44-bd2cf3414ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13cfa5f3-495f-457b-ad44-bd2cf3414ce4.jpg?1",
             "name": "Deepcavern Imp",
             "text": "Flying, haste\nEcho\u2014\nDiscard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -3749,7 +3749,7 @@
         },
         {
             "id": "c7006b88-1122-5ec8-aa58-fe7ab85a3b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a548c9b-bdea-4c11-891e-e472fc63ae9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a548c9b-bdea-4c11-891e-e472fc63ae9b.jpg?1",
             "name": "Dread Return",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback\u2014\nSacrifice three creatures. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3781,7 +3781,7 @@
         },
         {
             "id": "afb6678d-517b-56ae-b732-4eaf9be995b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f6f584-9ed3-4e93-ac1a-31878a6b7118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f6f584-9ed3-4e93-ac1a-31878a6b7118.jpg?1",
             "name": "Dunerider Outlaw",
             "text": "Protection from green\nAt the beginning of each end step, if Dunerider Outlaw dealt damage to an opponent this turn, put a +1/+1 counter on it.",
             "colours": [
@@ -3817,7 +3817,7 @@
         },
         {
             "id": "98052a9b-8cfe-568b-ba17-df5181c48908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00440fc-e3e1-4a1c-b32b-f7946a76cd62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a00440fc-e3e1-4a1c-b32b-f7946a76cd62.jpg?1",
             "name": "Enslave",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, enchanted creature deals 1 damage to its owner.",
             "colours": [
@@ -3851,7 +3851,7 @@
         },
         {
             "id": "02b99e1b-e604-5be0-9193-485daf8df84e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4171dbd3-96d6-4e7a-afac-5b2882bf3872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4171dbd3-96d6-4e7a-afac-5b2882bf3872.jpg?1",
             "name": "Extirpate",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles their library.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "806fb112-908e-5a1a-8c54-f6dbe726338c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49d6139-fc0c-41db-be08-dfa87c685092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49d6139-fc0c-41db-be08-dfa87c685092.jpg?1",
             "name": "Faceless Devourer",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhen Faceless Devourer enters the battlefield, exile another target creature with shadow.\nWhen Faceless Devourer leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -3918,7 +3918,7 @@
         },
         {
             "id": "5a70d1be-bac9-5439-8ac9-6be52d704684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265960a9-bea6-4111-b9a7-b6a37194b1c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/265960a9-bea6-4111-b9a7-b6a37194b1c5.jpg?1",
             "name": "Feebleness",
             "text": "Flash\nEnchant creature\nEnchanted creature gets -2/-1.",
             "colours": [
@@ -3952,7 +3952,7 @@
         },
         {
             "id": "965fefa2-6bf6-5892-b19e-83b207ecf5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bf2a33-0eb6-4898-a0fb-f5afb47ea1aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0bf2a33-0eb6-4898-a0fb-f5afb47ea1aa.jpg?1",
             "name": "Gorgon Recluse",
             "text": "Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.\nMadness {B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3986,7 +3986,7 @@
         },
         {
             "id": "5d0a96ab-715c-5312-961a-c53e27714d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c53e52-8d63-4628-bfb9-8abe4c7c7f4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c53e52-8d63-4628-bfb9-8abe4c7c7f4a.jpg?1",
             "name": "Grave Scrabbler",
             "text": "Madness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nWhen Grave Scrabbler enters the battlefield, if its madness cost was paid, you may return target creature card from a graveyard to its owner's hand.",
             "colours": [
@@ -4020,7 +4020,7 @@
         },
         {
             "id": "18d6e9ea-f0ba-5db9-a01e-6fc2bba13fd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33faa287-2a12-4a94-8d42-77da2b24d86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33faa287-2a12-4a94-8d42-77da2b24d86f.jpg?1",
             "name": "Ichor Slick",
             "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4052,7 +4052,7 @@
         },
         {
             "id": "b43c05fd-204b-5aba-a97c-3dc1dbfbfcc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55cf5e9-b343-4307-a379-925d94a8a003.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e55cf5e9-b343-4307-a379-925d94a8a003.jpg?1",
             "name": "Kor Dirge",
             "text": "All damage that would be dealt this turn to target creature you control by a source of your choice is dealt to another target creature instead.",
             "colours": [
@@ -4084,7 +4084,7 @@
         },
         {
             "id": "6638f3e9-1c72-59e7-854b-4899af2edb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eede29-17a4-437f-a5c2-e24cccbc6a33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eede29-17a4-437f-a5c2-e24cccbc6a33.jpg?1",
             "name": "Living End",
             "text": "Suspend 3\u2014{2}{B}{B}\nEach player exiles all creature cards from their graveyard, then sacrifices all creatures they control, then puts all cards they exiled this way onto the battlefield.",
             "colours": [
@@ -4116,7 +4116,7 @@
         },
         {
             "id": "b734f3af-ff7a-5974-8ef4-71755ae4720a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd816d37-7a9e-485e-9ed9-20c1c15a26dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd816d37-7a9e-485e-9ed9-20c1c15a26dd.jpg?1",
             "name": "Mass of Ghouls",
             "text": "",
             "colours": [
@@ -4151,7 +4151,7 @@
         },
         {
             "id": "a06bbfd1-4c73-5e7d-8171-659a4c5459a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542f97fa-6295-4c87-86a8-7ff2bc8b5e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/542f97fa-6295-4c87-86a8-7ff2bc8b5e81.jpg?1",
             "name": "Mindstab",
             "text": "Target player discards three cards.\nSuspend 4\u2014{B} (Rather than cast this card from your hand, you may pay {B} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "e760dce0-93f7-5512-b939-9387ca76314c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42fded-49e8-4c69-8ade-ba5e76e44b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c42fded-49e8-4c69-8ade-ba5e76e44b45.jpg?1",
             "name": "Minions' Murmurs",
             "text": "You draw X cards and you lose X life, where X is the number of creatures you control.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "64706533-c1d9-5dd8-96c4-7d8dae7f0674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1706d-2faa-452b-a192-204386df29f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c1706d-2faa-452b-a192-204386df29f6.jpg?1",
             "name": "Mirri the Cursed",
             "text": "Flying, first strike, haste\nWhenever Mirri the Cursed deals combat damage to a creature, put a +1/+1 counter on Mirri the Cursed.",
             "colours": [
@@ -4252,7 +4252,7 @@
         },
         {
             "id": "c5c788ef-9806-56ab-8f97-ba0b3649104d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2aaec8-43a0-4639-8190-3ce1273a2711.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb2aaec8-43a0-4639-8190-3ce1273a2711.jpg?1",
             "name": "Muck Drubb",
             "text": "Flash\nWhen Muck Drubb enters the battlefield, change the target of target spell that targets only a single creature to Muck Drubb.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "707912c6-1a9b-57d0-9c96-9872978f4c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3482ec-8466-4680-bfdc-e1029c0fbe89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3482ec-8466-4680-bfdc-e1029c0fbe89.jpg?1",
             "name": "Nether Traitor",
             "text": "Haste\nShadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever another creature is put into your graveyard from the battlefield, you may pay {B}. If you do, return Nether Traitor from your graveyard to the battlefield.",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "62061072-2390-54c3-b0e5-974888f9e3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd610675-f8ab-47a7-a4db-c1bfb0e9d5c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd610675-f8ab-47a7-a4db-c1bfb0e9d5c8.jpg?1",
             "name": "Nightshade Assassin",
             "text": "First strike\nWhen Nightshade Assassin enters the battlefield, you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4355,7 +4355,7 @@
         },
         {
             "id": "f06f5ef6-a006-52b2-adc2-5323e80c8370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e798d8e-cc01-4cd1-9325-37d1bf73e042.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e798d8e-cc01-4cd1-9325-37d1bf73e042.jpg?1",
             "name": "Phthisis",
             "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5\u2014{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -4387,7 +4387,7 @@
         },
         {
             "id": "50ff3c40-ad1d-54f8-a84e-60037fa25818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f731d16-d969-40a8-a002-4d40eb8f6bac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f731d16-d969-40a8-a002-4d40eb8f6bac.jpg?1",
             "name": "Pit Keeper",
             "text": "When Pit Keeper enters the battlefield, if you have four or more creature cards in your graveyard, you may return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4422,7 +4422,7 @@
         },
         {
             "id": "f1fd5921-9a10-5119-89d6-17e3a283160a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42f83e3-631b-432e-8d2f-f62d3207e95e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42f83e3-631b-432e-8d2f-f62d3207e95e.jpg?1",
             "name": "Premature Burial",
             "text": "Destroy target nonblack creature that entered the battlefield since your last turn ended.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "c1556856-54f1-5d52-8891-61585e66ac32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6d8c51-bff9-4eba-8c1b-2d45b7635c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa6d8c51-bff9-4eba-8c1b-2d45b7635c52.jpg?1",
             "name": "Psychotic Episode",
             "text": "Target player reveals their hand and the top card of their library. You choose a card revealed this way. That player puts the chosen card on the bottom of their library.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4486,7 +4486,7 @@
         },
         {
             "id": "1641f887-b179-5922-8d19-08e81600c67d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30c08c7-ff2b-40cb-93d0-18e48bf0cf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30c08c7-ff2b-40cb-93d0-18e48bf0cf4d.jpg?1",
             "name": "Rathi Trapper",
             "text": "{B}, {T}: Tap target creature.",
             "colours": [
@@ -4522,7 +4522,7 @@
         },
         {
             "id": "24f84be8-1ce4-50f6-b5bd-306b72c9c972",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51ea7d3-a9d7-4b1d-bf3b-3fcfb6a49624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a51ea7d3-a9d7-4b1d-bf3b-3fcfb6a49624.jpg?1",
             "name": "Ridged Kusite",
             "text": "{1}{B}, {T}, Discard a card: Target creature gets +1/+0 and gains first strike until end of turn.",
             "colours": [
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "64a9de72-5b40-53c7-b515-33f1f0c1a416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ceaa1f-4c11-4f06-aa87-2f2a0deb47e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ceaa1f-4c11-4f06-aa87-2f2a0deb47e1.jpg?1",
             "name": "Sangrophage",
             "text": "At the beginning of your upkeep, tap Sangrophage unless you pay 2 life.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "8f86689b-8e45-53a6-b9fd-b6a89914f6d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc9f1e-b889-402d-a5a1-fa0d7d493246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71dc9f1e-b889-402d-a5a1-fa0d7d493246.jpg?1",
             "name": "Sengir Nosferatu",
             "text": "Flying\n{1}{B}, Exile Sengir Nosferatu: Create a 1/2 black Bat creature token with flying. It has \"{1}{B}, Sacrifice this creature: Return an exiled card named Sengir Nosferatu to the battlefield under its owner's control.\"",
             "colours": [
@@ -4625,7 +4625,7 @@
         },
         {
             "id": "202b09c7-a301-56de-a0b4-592a3dfe4a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6f872f-adfa-4d29-87df-9d39fb06b5be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb6f872f-adfa-4d29-87df-9d39fb06b5be.jpg?1",
             "name": "Skittering Monstrosity",
             "text": "When you cast a creature spell, sacrifice Skittering Monstrosity.",
             "colours": [
@@ -4659,7 +4659,7 @@
         },
         {
             "id": "f693afa4-e933-5978-bb8c-4c40e794e5f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e00341-030f-433e-b22b-aca42e0a88d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81e00341-030f-433e-b22b-aca42e0a88d2.jpg?1",
             "name": "Slaughter Pact",
             "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
             "colours": [
@@ -4691,7 +4691,7 @@
         },
         {
             "id": "8a831fcc-a21a-59b4-846d-056d71a19e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28db9a4-6696-460b-a9d3-98f4a31abe75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c28db9a4-6696-460b-a9d3-98f4a31abe75.jpg?1",
             "name": "Smallpox",
             "text": "Each player loses 1 life, discards a card, sacrifices a creature, then sacrifices a land.",
             "colours": [
@@ -4723,7 +4723,7 @@
         },
         {
             "id": "90eefd70-1e0c-5aad-9ea5-2dd36b5c3216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872d8f4d-6ee5-4494-9900-db62d3e4cedd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872d8f4d-6ee5-4494-9900-db62d3e4cedd.jpg?1",
             "name": "Strangling Soot",
             "text": "Destroy target creature with toughness 3 or less.\nFlashback {5}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4756,7 +4756,7 @@
         },
         {
             "id": "673663cc-9c29-5c12-a9eb-e451dc7246fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d078cad-7f2b-4bef-b637-46aec9c8ed36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d078cad-7f2b-4bef-b637-46aec9c8ed36.jpg?1",
             "name": "Street Wraith",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nCycling\u2014\nPay 2 life. (Pay 2 life, Discard this card: Draw a card.)",
             "colours": [
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "05cc02fe-b0ea-54d7-9119-e6d80fe577a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87761f00-bfbc-42dc-b96d-9f4258b43a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87761f00-bfbc-42dc-b96d-9f4258b43a8b.jpg?1",
             "name": "Stronghold Rats",
             "text": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nWhenever Stronghold Rats deals combat damage to a player, each player discards a card.",
             "colours": [
@@ -4824,7 +4824,7 @@
         },
         {
             "id": "07e93c10-3676-51dc-893d-e4ed7f70e7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d724faa-a988-4c08-875d-d18f48926a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d724faa-a988-4c08-875d-d18f48926a0a.jpg?1",
             "name": "Sudden Death",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget creature gets -4/-4 until end of turn.",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "3bfdae13-9373-5a55-971e-ec7070706cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73514b51-6c19-4b3c-9cf9-2cf5028d7708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73514b51-6c19-4b3c-9cf9-2cf5028d7708.jpg?1",
             "name": "Sudden Spoiling",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntil end of turn, creatures target player controls lose all abilities and have base power and toughness 0/2.",
             "colours": [
@@ -4888,7 +4888,7 @@
         },
         {
             "id": "cefa9c1a-fe85-596f-a8f0-eaf118b7eec1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c338b459-6bb8-4bc7-a6b5-945a09589c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c338b459-6bb8-4bc7-a6b5-945a09589c05.jpg?1",
             "name": "Tendrils of Corruption",
             "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
             "colours": [
@@ -4920,7 +4920,7 @@
         },
         {
             "id": "c5cf1702-6839-5a5a-ba79-25b942deacea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f02d59-0786-41c8-940b-4ef6ef01c646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78f02d59-0786-41c8-940b-4ef6ef01c646.jpg?1",
             "name": "Tombstalker",
             "text": "Flying\nDelve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -4954,7 +4954,7 @@
         },
         {
             "id": "9f1765ba-1ff8-5969-8372-987e874eb051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278421ff-5324-44e5-b24f-dfbf9aa9b604.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278421ff-5324-44e5-b24f-dfbf9aa9b604.jpg?1",
             "name": "Trespasser il-Vec",
             "text": "Discard a card: Trespasser il-Vec gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)",
             "colours": [
@@ -4989,7 +4989,7 @@
         },
         {
             "id": "bf95d1eb-a9fc-52fa-8c66-02869e2c7325",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7b098-82ba-4015-aaa5-df9aa0a05e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c7b098-82ba-4015-aaa5-df9aa0a05e40.jpg?1",
             "name": "Urborg Syphon-Mage",
             "text": "{2}{B}, {T}, Discard a card: Each other player loses 2 life. You gain life equal to the life lost this way.",
             "colours": [
@@ -5024,7 +5024,7 @@
         },
         {
             "id": "d735ef37-aabf-5c66-aa1a-a476c20c862a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2ef91f-d113-4e8d-a164-c6e261aa9c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f2ef91f-d113-4e8d-a164-c6e261aa9c12.jpg?1",
             "name": "Yixlid Jailer",
             "text": "Cards in graveyards lose all abilities.",
             "colours": [
@@ -5059,7 +5059,7 @@
         },
         {
             "id": "7296d372-3411-523d-816c-2bf346b11001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21655e-fda4-4852-a801-c5593644044a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c21655e-fda4-4852-a801-c5593644044a.jpg?1",
             "name": "Akroma, Angel of Fury",
             "text": "This spell can't be countered.\nFlying, trample, protection from white and from blue\n{R}: Akroma, Angel of Fury gets +1/+0 until end of turn.\nMorph {3}{R}{R}{R} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5095,7 +5095,7 @@
         },
         {
             "id": "65992061-33ab-50a9-b46d-2d2bba5a3a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f28d4a2-6c75-44c2-93ac-e7159c1c623f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f28d4a2-6c75-44c2-93ac-e7159c1c623f.jpg?1",
             "name": "Ancient Grudge",
             "text": "Destroy target artifact.\nFlashback {G} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5128,7 +5128,7 @@
         },
         {
             "id": "0a99a831-790e-5651-b88e-ea57758143cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8fe7c-fe36-4f6d-9c7f-85286b745865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92b8fe7c-fe36-4f6d-9c7f-85286b745865.jpg?1",
             "name": "Arc Blade",
             "text": "Arc Blade deals 2 damage to any target. Exile Arc Blade with three time counters on it.\nSuspend 3\u2014{2}{R} (Rather than cast this card from your hand, you may pay {2}{R} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -5160,7 +5160,7 @@
         },
         {
             "id": "153bc79c-4b40-50f4-b55d-1913d05b076b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d49201b-bd41-49b7-b00e-4ab8034a3a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d49201b-bd41-49b7-b00e-4ab8034a3a03.jpg?1",
             "name": "Basalt Gargoyle",
             "text": "Flying\nEcho {2}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{R}: Basalt Gargoyle gets +0/+1 until end of turn.",
             "colours": [
@@ -5194,7 +5194,7 @@
         },
         {
             "id": "b6a784e7-e5e7-57d6-b827-dffd0a0ad292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65a72b-d24c-4016-befc-91018a1b62e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f65a72b-d24c-4016-befc-91018a1b62e1.jpg?1",
             "name": "Battering Sliver",
             "text": "All Sliver creatures have trample.",
             "colours": [
@@ -5228,7 +5228,7 @@
         },
         {
             "id": "fca6d0fd-2263-50a2-9f5b-d712272b0141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29672365-f059-4ff2-93c5-437b9ab01297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29672365-f059-4ff2-93c5-437b9ab01297.jpg?1",
             "name": "Bonesplitter Sliver",
             "text": "All Sliver creatures get +2/+0.",
             "colours": [
@@ -5262,7 +5262,7 @@
         },
         {
             "id": "f5c48cee-a372-5359-bccb-66480756fad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy target land you control and target land you don't control.",
             "colours": [
@@ -5294,7 +5294,7 @@
         },
         {
             "id": "8903a04a-9211-56f5-83e6-709334496a8e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg?1",
             "name": "Boom // Bust",
             "text": "Destroy all lands.",
             "colours": [
@@ -5326,7 +5326,7 @@
         },
         {
             "id": "604eadb8-4ac3-5e18-b19e-0b501970a79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89db7256-3bd0-4c1d-9c6f-de81f7d3c1a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89db7256-3bd0-4c1d-9c6f-de81f7d3c1a2.jpg?1",
             "name": "Brute Force",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -5358,7 +5358,7 @@
         },
         {
             "id": "2cf24e49-e843-5172-bd1e-525db488821c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f696f9-afa2-40c4-950a-e1e01c452017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f696f9-afa2-40c4-950a-e1e01c452017.jpg?1",
             "name": "Char-Rumbler",
             "text": "Double strike\n{R}: Char-Rumbler gets +1/+0 until end of turn.",
             "colours": [
@@ -5392,7 +5392,7 @@
         },
         {
             "id": "8d186c3f-aa36-5c54-a307-58dbbf414042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59871c54-7873-4fc5-8084-55918a11e6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59871c54-7873-4fc5-8084-55918a11e6f4.jpg?1",
             "name": "Coal Stoker",
             "text": "When Coal Stoker enters the battlefield, if you cast it from your hand, add {R}{R}{R}.",
             "colours": [
@@ -5426,7 +5426,7 @@
         },
         {
             "id": "ede13a3b-c4f9-5a6e-a2eb-91d72c504b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbbcc1a-c6cc-4671-91ab-9dcf454f62e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfbbcc1a-c6cc-4671-91ab-9dcf454f62e0.jpg?1",
             "name": "Conflagrate",
             "text": "Conflagrate deals X damage divided as you choose among any number of targets.\nFlashback\u2014{R}{R}, Discard X cards. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -5458,7 +5458,7 @@
         },
         {
             "id": "201fa252-7c18-58f2-babb-ddf4d7b1c948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg?1",
             "name": "Dead // Gone",
             "text": "Dead deals 2 damage to target creature.",
             "colours": [
@@ -5490,7 +5490,7 @@
         },
         {
             "id": "a7b619e0-ba58-51fc-a45c-e56454588116",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/5/45b090c7-f1ba-4656-8b51-915fc1876922.jpg?1",
             "name": "Dead // Gone",
             "text": "Return target creature you don't control to its owner's hand.",
             "colours": [
@@ -5522,7 +5522,7 @@
         },
         {
             "id": "0393e3b1-2aec-5d19-8988-76f0071db8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06462b57-1b0e-4c9c-9531-c14b9f2d5a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06462b57-1b0e-4c9c-9531-c14b9f2d5a3b.jpg?1",
             "name": "Empty the Warrens",
             "text": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5554,7 +5554,7 @@
         },
         {
             "id": "7e2f4033-7ca5-5257-aae8-26981de86f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2376735d-7812-4fab-baba-0d331f6e2211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2376735d-7812-4fab-baba-0d331f6e2211.jpg?1",
             "name": "Firemaw Kavu",
             "text": "Echo {5}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Firemaw Kavu enters the battlefield, it deals 2 damage to target creature.\nWhen Firemaw Kavu leaves the battlefield, it deals 4 damage to target creature.",
             "colours": [
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "f636625b-4d83-5446-a49f-e48f1987b073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a64329-09fc-4e0d-b7d1-378635f2801a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a64329-09fc-4e0d-b7d1-378635f2801a.jpg?1",
             "name": "Fury Sliver",
             "text": "All Sliver creatures have double strike.",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "72d09917-e2cb-5336-9d88-effba8e74d32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c232e5-54e2-44b7-85b1-ed039a8e5a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c232e5-54e2-44b7-85b1-ed039a8e5a73.jpg?1",
             "name": "Gathan Raiders",
             "text": "Hellbent \u2014 Gathan Raiders gets +2/+2 as long as you have no cards in hand.\nMorph\u2014\nDiscard a card. (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
             "colours": [
@@ -5657,7 +5657,7 @@
         },
         {
             "id": "09db974b-82f1-5c64-8050-5ebf57633bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585bed40-9ca6-46a0-80c4-c769cd8e2b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/585bed40-9ca6-46a0-80c4-c769cd8e2b20.jpg?1",
             "name": "Grapeshot",
             "text": "Grapeshot deals 1 damage to any target.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
             "colours": [
@@ -5689,7 +5689,7 @@
         },
         {
             "id": "5518c3db-31de-5c1e-8855-da5ab9c82fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6d6eb2-beed-4c84-af6a-bf8ebdc62f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef6d6eb2-beed-4c84-af6a-bf8ebdc62f50.jpg?1",
             "name": "Greater Gargadon",
             "text": "Suspend 10\u2014{R}\nSacrifice an artifact, creature, or land: Remove a time counter from Greater Gargadon. Activate this ability only if Greater Gargadon is suspended.",
             "colours": [
@@ -5723,7 +5723,7 @@
         },
         {
             "id": "982a830a-8ce2-599e-94d6-5359771ed4d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8215cb7b-9c8c-4d2b-adb1-c1d1d22bb54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8215cb7b-9c8c-4d2b-adb1-c1d1d22bb54e.jpg?1",
             "name": "Grinning Ignus",
             "text": "{R}, Return Grinning Ignus to its owner's hand: Add {C}{C}{R}. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -5757,7 +5757,7 @@
         },
         {
             "id": "ffcd0286-e1ba-504b-ab63-187affe47a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344b885-68c6-43d2-b6c1-6c89b3c94983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344b885-68c6-43d2-b6c1-6c89b3c94983.jpg?1",
             "name": "Haze of Rage",
             "text": "Buyback {2} (You may pay an additional {2} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreatures you control get +1/+0 until end of turn.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -5789,7 +5789,7 @@
         },
         {
             "id": "59f5782c-ed01-5f5a-8400-39de187cb1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8f7ae-bb2b-4ecc-b020-427486315855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a8f7ae-bb2b-4ecc-b020-427486315855.jpg?1",
             "name": "Henchfiend of Ukor",
             "text": "Haste\nEcho {1}{B} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\n{BR}: Henchfiend of Ukor gets +1/+0 until end of turn.",
             "colours": [
@@ -5824,7 +5824,7 @@
         },
         {
             "id": "52f5948e-a560-5ceb-9b9b-fd7814bb72ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f2073b-bc1f-4611-9bdf-73cb86892886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f2073b-bc1f-4611-9bdf-73cb86892886.jpg?1",
             "name": "Homing Sliver",
             "text": "Each Sliver card in each player's hand has slivercycling {3}.\nSlivercycling {3} ({3}, Discard this card: Search your library for a Sliver card, reveal it, put it into your hand, then shuffle your library.)",
             "colours": [
@@ -5858,7 +5858,7 @@
         },
         {
             "id": "8aed7a8f-011b-5533-bff2-2798ce6d9d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2890840e-da0b-40ba-b3c2-7e4af39922b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2890840e-da0b-40ba-b3c2-7e4af39922b3.jpg?1",
             "name": "Jaya Ballard, Task Mage",
             "text": "{R}, {T}, Discard a card: Destroy target blue permanent.\n{1}{R}, {T}, Discard a card: Jaya Ballard, Task Mage deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.\n{5}{R}{R}, {T}, Discard a card: Jaya Ballard deals 6 damage to each creature and each player.",
             "colours": [
@@ -5895,7 +5895,7 @@
         },
         {
             "id": "4b8ce7ba-312c-5bf1-a382-c0f7890f6380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0caef-215a-4433-8a85-322e62e3590d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e0caef-215a-4433-8a85-322e62e3590d.jpg?1",
             "name": "Keldon Halberdier",
             "text": "First strike\nSuspend 4\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -5930,7 +5930,7 @@
         },
         {
             "id": "c773ae0c-865b-5c31-a113-9abbdaedf2f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca33c171-ab9e-4908-8f97-82cd83b173c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca33c171-ab9e-4908-8f97-82cd83b173c0.jpg?1",
             "name": "Lightning Axe",
             "text": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
             "colours": [
@@ -5962,7 +5962,7 @@
         },
         {
             "id": "9441b1b3-5093-5adf-8461-10d362150201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9bd75c-9606-4607-bfa6-d6acdee12820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9bd75c-9606-4607-bfa6-d6acdee12820.jpg?1",
             "name": "Magus of the Moon",
             "text": "Nonbasic lands are Mountains.",
             "colours": [
@@ -5997,7 +5997,7 @@
         },
         {
             "id": "fad9a81b-6645-509e-91d5-7708640a2bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6d241-f68b-45c8-a79a-f6c274bd8512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb6d241-f68b-45c8-a79a-f6c274bd8512.jpg?1",
             "name": "Mogg War Marshal",
             "text": "Echo {1}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Mogg War Marshal enters the battlefield or dies, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -6032,7 +6032,7 @@
         },
         {
             "id": "814c5745-ffeb-57e1-b461-7e274e0da1c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c7d94f-3760-4c97-b0bf-c895f4132c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00c7d94f-3760-4c97-b0bf-c895f4132c7f.jpg?1",
             "name": "Needlepeak Spider",
             "text": "Reach",
             "colours": [
@@ -6066,7 +6066,7 @@
         },
         {
             "id": "a9f30f7d-38a0-5a81-8c73-a9035d138b3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afae574-aa96-4500-9882-a4b10337b6f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0afae574-aa96-4500-9882-a4b10337b6f5.jpg?1",
             "name": "Orcish Cannonade",
             "text": "Orcish Cannonade deals 2 damage to any target and 3 damage to you.\nDraw a card.",
             "colours": [
@@ -6098,7 +6098,7 @@
         },
         {
             "id": "fcb5d54f-242b-52e9-b5c3-3c2d3e69d19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4612effe-8ca2-4c27-90d2-d9255acc80d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4612effe-8ca2-4c27-90d2-d9255acc80d9.jpg?1",
             "name": "Pact of the Titan",
             "text": "Create a 4/4 red Giant creature token.\nAt the beginning of your next upkeep, pay {4}{R}. If you don't, you lose the game.",
             "colours": [
@@ -6130,7 +6130,7 @@
         },
         {
             "id": "d30da3bb-5148-5429-aab5-74024536b45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16600a-c2a5-49e4-89e2-260cfaf58b52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf16600a-c2a5-49e4-89e2-260cfaf58b52.jpg?1",
             "name": "Prodigal Pyromancer",
             "text": "{T}: Prodigal Pyromancer deals 1 damage to any target.",
             "colours": [
@@ -6165,7 +6165,7 @@
         },
         {
             "id": "cd023f2a-58f7-58ea-b3e4-360982d57d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59243436-b55d-44c3-962b-751eff429f71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59243436-b55d-44c3-962b-751eff429f71.jpg?1",
             "name": "Reckless Wurm",
             "text": "Trample\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -6199,7 +6199,7 @@
         },
         {
             "id": "dc21a4c4-7b88-58ba-80bf-7d39699fbe73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99302c41-434f-41ff-a61a-2c3681a0c135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99302c41-434f-41ff-a61a-2c3681a0c135.jpg?1",
             "name": "Reiterate",
             "text": "Buyback {3} (You may pay an additional {3} as you cast this spell. If you do, put this card into your hand as it resolves.)\nCopy target instant or sorcery spell. You may choose new targets for the copy.",
             "colours": [
@@ -6231,7 +6231,7 @@
         },
         {
             "id": "2c8f3c2b-ea37-5640-9359-509fe37ecb22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e380151-abb6-457c-bac9-39f1a3744ed0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e380151-abb6-457c-bac9-39f1a3744ed0.jpg?1",
             "name": "Riddle of Lightning",
             "text": "Choose any target. Scry 3, then reveal the top card of your library. Riddle of Lightning deals damage equal to that card's converted mana cost to that permanent or player.",
             "colours": [
@@ -6263,7 +6263,7 @@
         },
         {
             "id": "accf4d50-a4a6-560f-81f7-e3e3dd47a23e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3459a44-0c26-4ee1-ad7f-67be7cd7d80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3459a44-0c26-4ee1-ad7f-67be7cd7d80a.jpg?1",
             "name": "Rift Bolt",
             "text": "Rift Bolt deals 3 damage to any target.\nSuspend 1\u2014{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -6295,7 +6295,7 @@
         },
         {
             "id": "4a7b1e1f-aeef-55c2-931c-b54c5f9909e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dd1bc9-734b-41c6-941f-f9ed5eaa2337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39dd1bc9-734b-41c6-941f-f9ed5eaa2337.jpg?1",
             "name": "Rift Elemental",
             "text": "{1}{R}, Remove a time counter from a permanent you control or suspended card you own: Rift Elemental gets +2/+0 until end of turn.",
             "colours": [
@@ -6329,7 +6329,7 @@
         },
         {
             "id": "609b3e64-4e46-595c-a99d-bcbb04691d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg?1",
             "name": "Rough // Tumble",
             "text": "Rough deals 2 damage to each creature without flying.",
             "colours": [
@@ -6361,7 +6361,7 @@
         },
         {
             "id": "983b268c-9dcd-5381-aa23-a0542a890667",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea0cdb87-030a-4696-a16f-c971cdced3ca.jpg?1",
             "name": "Rough // Tumble",
             "text": "Tumble deals 6 damage to each creature with flying.",
             "colours": [
@@ -6393,7 +6393,7 @@
         },
         {
             "id": "d0711dcd-314e-5de9-9502-ffb15538c897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af3c6b1-9139-46a3-ad41-91aabbdda55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af3c6b1-9139-46a3-ad41-91aabbdda55f.jpg?1",
             "name": "Sedge Sliver",
             "text": "All Sliver creatures have \"This creature gets +1/+1 as long as you control a Swamp.\"\nAll Slivers have \"{B}: Regenerate this permanent.\" (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -6428,7 +6428,7 @@
         },
         {
             "id": "c1adda27-7b49-57d7-bf21-e60bb43ff4ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a98f0-ceb4-4e23-b2ec-1c4f4e4e22aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb5a98f0-ceb4-4e23-b2ec-1c4f4e4e22aa.jpg?1",
             "name": "Shivan Meteor",
             "text": "Shivan Meteor deals 13 damage to target creature.\nSuspend 2\u2014{1}{R}{R} (Rather than cast this card from your hand, you may pay {1}{R}{R} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "28c7159f-17cf-50ba-b163-ce2135e70693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21beb25-09a4-4d7f-84e3-87178e1721eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21beb25-09a4-4d7f-84e3-87178e1721eb.jpg?1",
             "name": "Shivan Sand-Mage",
             "text": "When Shivan Sand-Mage enters the battlefield, choose one \u2014\n\u2022 Remove two time counters from target permanent or suspended card.\n\u2022 Put two time counters on target permanent with a time counter on it or suspended card.\nSuspend 4\u2014{R}",
             "colours": [
@@ -6495,7 +6495,7 @@
         },
         {
             "id": "49cf85f2-d2f1-53e1-a82f-6cc880b7a930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e57335d-4066-4d73-83cd-67a215e01a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e57335d-4066-4d73-83cd-67a215e01a4e.jpg?1",
             "name": "Simian Spirit Guide",
             "text": "Exile Simian Spirit Guide from your hand: Add {R}.",
             "colours": [
@@ -6530,7 +6530,7 @@
         },
         {
             "id": "9d70bf5e-8fc3-5c35-ac3c-6ce0d11305a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b675da-f709-4aa3-8967-c9771234f9d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b675da-f709-4aa3-8967-c9771234f9d8.jpg?1",
             "name": "Skirk Shaman",
             "text": "Skirk Shaman can't be blocked except by artifact creatures and/or red creatures.",
             "colours": [
@@ -6565,7 +6565,7 @@
         },
         {
             "id": "04452308-e212-53e2-a192-9c4b367c5654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bcc2bc-75a7-4b01-856b-4e0b8703e302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6bcc2bc-75a7-4b01-856b-4e0b8703e302.jpg?1",
             "name": "Stingscourger",
             "text": "Echo {3}{R} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)\nWhen Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.",
             "colours": [
@@ -6600,7 +6600,7 @@
         },
         {
             "id": "0331579e-b79b-5e1b-99a3-8de97b259fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6e88a5-0d1f-4587-b855-42ab5452ddc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6e88a5-0d1f-4587-b855-42ab5452ddc8.jpg?1",
             "name": "Storm Entity",
             "text": "Haste\nStorm Entity enters the battlefield with a +1/+1 counter on it for each other spell cast this turn.",
             "colours": [
@@ -6634,7 +6634,7 @@
         },
         {
             "id": "66cb1cca-f225-580d-9cd3-5639d84c0b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b659a3b-0f66-40f2-8e2e-f13b694e270e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b659a3b-0f66-40f2-8e2e-f13b694e270e.jpg?1",
             "name": "Sudden Shock",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to any target.",
             "colours": [
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "1ec4b7d7-557c-520f-bb27-b80f4e0650ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aed10f9-8c52-400b-a432-a0d8c6458e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aed10f9-8c52-400b-a432-a0d8c6458e87.jpg?1",
             "name": "Sulfur Elemental",
             "text": "Flash\nSplit second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nWhite creatures get +1/-1.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "511981ea-ed2e-5c9c-b76b-a6cb61b8a3f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f6dfd2-f4b1-41bc-b848-5afa30b13e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f6dfd2-f4b1-41bc-b848-5afa30b13e36.jpg?1",
             "name": "Thick-Skinned Goblin",
             "text": "You may pay {0} rather than pay the echo cost for permanents you control.\n{R}: Thick-Skinned Goblin gains protection from red until end of turn.",
             "colours": [
@@ -6735,7 +6735,7 @@
         },
         {
             "id": "217ff08f-668f-50eb-9bfe-2721a017793d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260cf43a-f3a4-48f7-9c51-5884d106ff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260cf43a-f3a4-48f7-9c51-5884d106ff56.jpg?1",
             "name": "Two-Headed Sliver",
             "text": "All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6769,7 +6769,7 @@
         },
         {
             "id": "30c5c4dd-1303-5d8f-a3d2-cb36fffa4649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7937e12-76d9-4030-a68c-7a93a3c852cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7937e12-76d9-4030-a68c-7a93a3c852cb.jpg?1",
             "name": "Wheel of Fate",
             "text": "Suspend 4\u2014{1}{R} (Rather than cast this card from your hand, pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player discards their hand, then draws seven cards.",
             "colours": [
@@ -6801,7 +6801,7 @@
         },
         {
             "id": "b38e4e6d-686a-5c31-8a9f-c764bf6e5f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0cd9af6-3729-4c9c-9669-a2800a693b39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0cd9af6-3729-4c9c-9669-a2800a693b39.jpg?1",
             "name": "Citanul Woodreaders",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nWhen Citanul Woodreaders enters the battlefield, if it was kicked, draw two cards.",
             "colours": [
@@ -6836,7 +6836,7 @@
         },
         {
             "id": "81cba021-c140-5c36-b7a9-cba079807435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce39dd1-ca51-420f-a627-1511192d34c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dce39dd1-ca51-420f-a627-1511192d34c2.jpg?1",
             "name": "Durkwood Baloth",
             "text": "Suspend 5\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -6870,7 +6870,7 @@
         },
         {
             "id": "bfdba67a-b7f6-5453-ad2b-298802f546cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c72229c-f3da-4e35-af79-14452efe581b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c72229c-f3da-4e35-af79-14452efe581b.jpg?1",
             "name": "Edge of Autumn",
             "text": "If you control four or fewer lands, search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.\nCycling\u2014\nSacrifice a land. (Sacrifice a land, Discard this card: Draw a card.)",
             "colours": [
@@ -6902,7 +6902,7 @@
         },
         {
             "id": "f88bc9b7-dc64-5a35-8f75-2e9a7a2f5f91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d21cb-f506-4ad4-89d8-ecfdaed5952f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/723d21cb-f506-4ad4-89d8-ecfdaed5952f.jpg?1",
             "name": "Evolution Charm",
             "text": "Choose one \u2014\n\u2022 Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Target creature gains flying until end of turn.",
             "colours": [
@@ -6934,7 +6934,7 @@
         },
         {
             "id": "9592d98f-c8b7-5fb2-b16e-74cbdaddc184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a67e4-5deb-45d5-bd42-3078716e142b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a67e4-5deb-45d5-bd42-3078716e142b.jpg?1",
             "name": "Fungus Sliver",
             "text": "All Sliver creatures have \"Whenever this creature is dealt damage, put a +1/+1 counter on it.\" (It must survive the damage to get the counter.)",
             "colours": [
@@ -6969,7 +6969,7 @@
         },
         {
             "id": "64d0ce68-6717-5ce7-96ad-f919fc0c8e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43febc63-597d-4392-b8ea-a00841148c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43febc63-597d-4392-b8ea-a00841148c45.jpg?1",
             "name": "Gaea's Anthem",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -7001,7 +7001,7 @@
         },
         {
             "id": "5004f5fd-7edb-5cab-8299-93a00eb1f3d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110887a5-cbfd-431f-9208-06acc4ed2602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/110887a5-cbfd-431f-9208-06acc4ed2602.jpg?1",
             "name": "Gemhide Sliver",
             "text": "All Slivers have \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -7035,7 +7035,7 @@
         },
         {
             "id": "ff65f7b4-3d44-5968-ba40-0e62eb19c02c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8aec78a-9fd4-4cf9-a9ec-e234f6a552e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8aec78a-9fd4-4cf9-a9ec-e234f6a552e4.jpg?1",
             "name": "Giant Dustwasp",
             "text": "Flying\nSuspend 4\u2014{1}{G} (Rather than cast this card from your hand, you may pay {1}{G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7069,7 +7069,7 @@
         },
         {
             "id": "2823e767-344a-5436-9481-4c79c39a7cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423d0c1d-1791-4c80-86d1-f87f3c6a8611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/423d0c1d-1791-4c80-86d1-f87f3c6a8611.jpg?1",
             "name": "Greenseeker",
             "text": "{G}, {T}, Discard a card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -7104,7 +7104,7 @@
         },
         {
             "id": "62527fbf-555e-51e8-9c43-5479e3aa2bf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcb8138-0d0c-43bd-a3d3-1a57c0a19764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcb8138-0d0c-43bd-a3d3-1a57c0a19764.jpg?1",
             "name": "Harmonize",
             "text": "Draw three cards.",
             "colours": [
@@ -7136,7 +7136,7 @@
         },
         {
             "id": "522860e8-8f0d-5447-be8f-cac2197fda25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e2f7a-8cfe-4d1b-a68d-7e6d8d10bd27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5e2f7a-8cfe-4d1b-a68d-7e6d8d10bd27.jpg?1",
             "name": "Heartwood Storyteller",
             "text": "Whenever a player casts a noncreature spell, each of that player's opponents may draw a card.",
             "colours": [
@@ -7170,7 +7170,7 @@
         },
         {
             "id": "dc421abb-0000-5fb0-a68b-a85efa6c7f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65757321-2f26-44dc-a4f8-31d40fbf1681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65757321-2f26-44dc-a4f8-31d40fbf1681.jpg?1",
             "name": "Hypergenesis",
             "text": "Suspend 3\u2014{1}{G}{G}\nStarting with you, each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "afb6dec8-aad7-5ea3-a339-e4a98aa15d1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f189aaf0-474a-4701-9bda-e67dc057e347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f189aaf0-474a-4701-9bda-e67dc057e347.jpg?1",
             "name": "Imperiosaur",
             "text": "Spend only mana produced by basic lands to cast this spell.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "7dec7663-c11e-5c37-a434-58d23bdad977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c3439-74a9-4a53-9e8b-c1c84b60ea35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475c3439-74a9-4a53-9e8b-c1c84b60ea35.jpg?1",
             "name": "Kavu Primarch",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nConvoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIf Kavu Primarch was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -7270,7 +7270,7 @@
         },
         {
             "id": "4a444865-60c1-5292-8ae0-a84500f036d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16e927d-0f23-4fac-9b35-3cfcb22ebc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d16e927d-0f23-4fac-9b35-3cfcb22ebc26.jpg?1",
             "name": "Keen Sense",
             "text": "Enchant creature\nWhenever enchanted creature deals damage to an opponent, you may draw a card.",
             "colours": [
@@ -7304,7 +7304,7 @@
         },
         {
             "id": "da1d256d-bc07-50fb-8e7b-0536e2a4194e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253352d1-26e1-4074-94d8-f88c697e910e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253352d1-26e1-4074-94d8-f88c697e910e.jpg?1",
             "name": "Krosan Grip",
             "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
             "colours": [
@@ -7336,7 +7336,7 @@
         },
         {
             "id": "10299d89-bd7f-5218-93f9-642d003dce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2721724d-92ae-4c0c-88dd-628888c468bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2721724d-92ae-4c0c-88dd-628888c468bf.jpg?1",
             "name": "Life and Limb",
             "text": "All Forests and all Saprolings are 1/1 green Saproling creatures and Forest lands in addition to their other types. (They're affected by summoning sickness.)",
             "colours": [
@@ -7368,7 +7368,7 @@
         },
         {
             "id": "f5df0b4b-c64c-5e43-8cf3-fe5fea382f7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f894e7-adf7-4fe5-811a-8e2d8c8a88d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f894e7-adf7-4fe5-811a-8e2d8c8a88d6.jpg?1",
             "name": "Llanowar Mentor",
             "text": "{G}, {T}, Discard a card: Create a 1/1 green Elf Druid creature token named Llanowar Elves. It has \"{T}: Add {G}.\"",
             "colours": [
@@ -7403,7 +7403,7 @@
         },
         {
             "id": "0e4fce86-8d16-5c98-8796-62604db1e02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4246cfd0-f150-4142-8dd4-7ebeb707b6f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4246cfd0-f150-4142-8dd4-7ebeb707b6f4.jpg?1",
             "name": "Might of Old Krosa",
             "text": "Target creature gets +2/+2 until end of turn. If you cast this spell during your main phase, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "d8552f5e-4cc8-5044-815c-55d29f01a92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c72fc3-72ac-4727-9872-33dc71049894.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97c72fc3-72ac-4727-9872-33dc71049894.jpg?1",
             "name": "Might Sliver",
             "text": "All Sliver creatures get +2/+2.",
             "colours": [
@@ -7469,7 +7469,7 @@
         },
         {
             "id": "3a0199b2-0061-53de-b105-e090ac0b6268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab20019-d4b7-4bbb-b258-c9cc14bf2b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab20019-d4b7-4bbb-b258-c9cc14bf2b3a.jpg?1",
             "name": "Mire Boa",
             "text": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n{G}: Regenerate Mire Boa. (The next time this creature would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "d2c5743b-9826-548f-a44d-7d132ab7863d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b103cb22-93b2-4206-9f80-5f966155e07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b103cb22-93b2-4206-9f80-5f966155e07e.jpg?1",
             "name": "Muraganda Petroglyphs",
             "text": "Creatures with no abilities get +2/+2.",
             "colours": [
@@ -7535,7 +7535,7 @@
         },
         {
             "id": "53bfb536-35db-5626-b0a1-6528586e5b4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3370c6d-a743-49b3-b869-da65b49391d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3370c6d-a743-49b3-b869-da65b49391d9.jpg?1",
             "name": "Nantuko Shaman",
             "text": "When Nantuko Shaman enters the battlefield, if you control no tapped lands, draw a card.\nSuspend 1\u2014{2}{G}{G} (Rather than cast this card from your hand, you may pay {2}{G}{G} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost. It has haste.)",
             "colours": [
@@ -7570,7 +7570,7 @@
         },
         {
             "id": "f066f314-0895-5c11-baba-67193f5b063e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafc1724-af33-491e-b834-9a3cf30039ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafc1724-af33-491e-b834-9a3cf30039ca.jpg?1",
             "name": "Pendelhaven Elder",
             "text": "{T}: Each 1/1 creature you control gets +1/+2 until end of turn.",
             "colours": [
@@ -7605,7 +7605,7 @@
         },
         {
             "id": "d7a9bd14-fb94-5b29-9b37-6115118086a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862a2f7-673e-44bd-b8ee-e4295da1e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c862a2f7-673e-44bd-b8ee-e4295da1e0d5.jpg?1",
             "name": "Penumbra Spider",
             "text": "Reach\nWhen Penumbra Spider dies, create a 2/4 black Spider creature token with reach.",
             "colours": [
@@ -7639,7 +7639,7 @@
         },
         {
             "id": "c6cb4d62-daba-5cb5-92c9-5c0465340658",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f48a57-5005-46c7-8b52-97e2f9112b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f48a57-5005-46c7-8b52-97e2f9112b85.jpg?1",
             "name": "Phantom Wurm",
             "text": "Phantom Wurm enters the battlefield with four +1/+1 counters on it.\nIf damage would be dealt to Phantom Wurm, prevent that damage. Remove a +1/+1 counter from Phantom Wurm.",
             "colours": [
@@ -7674,7 +7674,7 @@
         },
         {
             "id": "d33437e4-b41f-5ba1-aa9e-bd71bd89cfad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503078a-c5a8-4292-a573-82d062870c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0503078a-c5a8-4292-a573-82d062870c7f.jpg?1",
             "name": "Primal Forcemage",
             "text": "Whenever another creature enters the battlefield under your control, that creature gets +3/+3 until end of turn.",
             "colours": [
@@ -7709,7 +7709,7 @@
         },
         {
             "id": "cc61239b-e243-59ab-84e8-5b3c35c82b20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14da2f-0e35-4586-8435-de0859aad060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e14da2f-0e35-4586-8435-de0859aad060.jpg?1",
             "name": "Reflex Sliver",
             "text": "All Sliver creatures have haste.",
             "colours": [
@@ -7743,7 +7743,7 @@
         },
         {
             "id": "4970bba0-cef5-5a72-a21a-364c8788b442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c122a-d350-420f-ba7b-4523a28e48a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885c122a-d350-420f-ba7b-4523a28e48a6.jpg?1",
             "name": "Scryb Ranger",
             "text": "Flash\nFlying, protection from blue\nReturn a Forest you control to its owner's hand: Untap target creature. Activate this ability only once each turn.",
             "colours": [
@@ -7778,7 +7778,7 @@
         },
         {
             "id": "4030cd50-2d9b-588e-9a30-1e8f3cab1f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5592ab-6883-4c5a-8d50-d9530d905b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd5592ab-6883-4c5a-8d50-d9530d905b19.jpg?1",
             "name": "Seal of Primordium",
             "text": "Sacrifice Seal of Primordium: Destroy target artifact or enchantment.",
             "colours": [
@@ -7810,7 +7810,7 @@
         },
         {
             "id": "3fa9036f-9653-5aad-bfa5-5e9b154c9d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c65336f-f735-4c35-9278-ad97255eb5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c65336f-f735-4c35-9278-ad97255eb5bb.jpg?1",
             "name": "Search for Tomorrow",
             "text": "Search your library for a basic land card, put it onto the battlefield, then shuffle your library.\nSuspend 2\u2014{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
             "colours": [
@@ -7842,7 +7842,7 @@
         },
         {
             "id": "1a67ea5b-f9fa-5758-9fb3-de6bf1b0f7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f86e30d-d9e8-48f7-8bd1-f2645f0ab3f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f86e30d-d9e8-48f7-8bd1-f2645f0ab3f4.jpg?1",
             "name": "Spinneret Sliver",
             "text": "All Sliver creatures have reach.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "48341ada-6047-58ac-8b77-8c06f9ec6758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babc8043-bfed-45e3-9d04-1967534f77b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babc8043-bfed-45e3-9d04-1967534f77b2.jpg?1",
             "name": "Sporesower Thallid",
             "text": "At the beginning of your upkeep, put a spore counter on each Fungus you control.\nRemove three spore counters from Sporesower Thallid: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -7910,7 +7910,7 @@
         },
         {
             "id": "12bea01a-1f21-5c5b-8c3f-cfac027b2495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a96041-1b20-464e-9119-93c19675ac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57a96041-1b20-464e-9119-93c19675ac46.jpg?1",
             "name": "Sporoloth Ancient",
             "text": "At the beginning of your upkeep, put a spore counter on Sporoloth Ancient.\nCreatures you control have \"Remove two spore counters from this creature: Create a 1/1 green Saproling creature token.\"",
             "colours": [
@@ -7944,7 +7944,7 @@
         },
         {
             "id": "23806dbb-4ef2-5361-82c9-94287ca6dfb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d900d0-3f3a-4716-bcc7-b27a0cbbc339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51d900d0-3f3a-4716-bcc7-b27a0cbbc339.jpg?1",
             "name": "Strength in Numbers",
             "text": "Until end of turn, target creature gains trample and gets +X/+X, where X is the number of attacking creatures.",
             "colours": [
@@ -7976,7 +7976,7 @@
         },
         {
             "id": "39d37852-bc97-5865-bc8f-45099990927d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f88ac-8a90-4057-b0e6-c15fbd02da38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee0f88ac-8a90-4057-b0e6-c15fbd02da38.jpg?1",
             "name": "Summoner's Pact",
             "text": "Search your library for a green creature card, reveal it, put it into your hand, then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
             "colours": [
@@ -8008,7 +8008,7 @@
         },
         {
             "id": "48f77718-82d7-5cb8-a419-3b1e09d4c19f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69daba76-96e8-4bcc-ab79-2f00189ad8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69daba76-96e8-4bcc-ab79-2f00189ad8fb.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -8042,7 +8042,7 @@
         },
         {
             "id": "ac5e644e-1680-5777-a81f-fbd3852dfd13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799e835b-98ad-41b2-a8a9-a7c661efd86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/799e835b-98ad-41b2-a8a9-a7c661efd86f.jpg?1",
             "name": "Thallid Germinator",
             "text": "At the beginning of your upkeep, put a spore counter on Thallid Germinator.\nRemove three spore counters from Thallid Germinator: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
             "colours": [
@@ -8076,7 +8076,7 @@
         },
         {
             "id": "df01d422-69ae-55fa-b172-83bdcf26a43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd5ff-79a2-43d9-bd69-94be175d19b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1fd5ff-79a2-43d9-bd69-94be175d19b4.jpg?1",
             "name": "Thallid Shell-Dweller",
             "text": "Defender\nAt the beginning of your upkeep, put a spore counter on Thallid Shell-Dweller.\nRemove three spore counters from Thallid Shell-Dweller: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -8110,7 +8110,7 @@
         },
         {
             "id": "1c1529c4-d855-5331-82c5-d72dbd165a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f1b9f-9866-4ead-96cf-88babf459ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f1b9f-9866-4ead-96cf-88babf459ce2.jpg?1",
             "name": "Thelon of Havenwood",
             "text": "Each Fungus creature gets +1/+1 for each spore counter on it.\n{B}{G}, Exile a Fungus card from a graveyard: Put a spore counter on each Fungus on the battlefield.",
             "colours": [
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "1284f47b-ee7b-5a4d-99cf-1aa93212cbdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803ebda-2f6b-41e4-9ffe-b1f2888996b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f803ebda-2f6b-41e4-9ffe-b1f2888996b6.jpg?1",
             "name": "Thelonite Hermit",
             "text": "All Saprolings get +1/+1.\nMorph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen Thelonite Hermit is turned face up, create four 1/1 green Saproling creature tokens.",
             "colours": [
@@ -8183,7 +8183,7 @@
         },
         {
             "id": "8e939602-34ed-503c-b72e-fe2419500503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b7811-ff6c-4767-921d-e8e88913e820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f61b7811-ff6c-4767-921d-e8e88913e820.jpg?1",
             "name": "Thornweald Archer",
             "text": "Reach, deathtouch",
             "colours": [
@@ -8218,7 +8218,7 @@
         },
         {
             "id": "282b112c-c49d-5a2d-8d03-ebe8ea42423b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bed96ea-f509-40eb-80b7-71a02d9ac69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bed96ea-f509-40eb-80b7-71a02d9ac69f.jpg?1",
             "name": "Thrill of the Hunt",
             "text": "Target creature gets +1/+2 until end of turn.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "a76c14f7-419a-5207-a5df-40dae7156a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef40007b-47eb-4881-9467-30ce5b9a0fa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef40007b-47eb-4881-9467-30ce5b9a0fa3.jpg?1",
             "name": "Tromp the Domains",
             "text": "Domain \u2014 Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
             "colours": [
@@ -8283,7 +8283,7 @@
         },
         {
             "id": "74ca8aaa-24f7-5221-883f-1339614bc11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c401a-8c66-4054-894f-afd866b3b95b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8c401a-8c66-4054-894f-afd866b3b95b.jpg?1",
             "name": "Uktabi Drake",
             "text": "Flying, haste\nEcho {1}{G}{G} (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)",
             "colours": [
@@ -8317,7 +8317,7 @@
         },
         {
             "id": "125e9600-7283-533e-9e08-0afe2ee40d4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5664e121-d3f1-4ff5-9576-ef515e22bde7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5664e121-d3f1-4ff5-9576-ef515e22bde7.jpg?1",
             "name": "Utopia Mycon",
             "text": "At the beginning of your upkeep, put a spore counter on Utopia Mycon.\nRemove three spore counters from Utopia Mycon: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Add one mana of any color.",
             "colours": [
@@ -8351,7 +8351,7 @@
         },
         {
             "id": "25fae8ae-6c79-51bd-8d17-bbcca1f1df31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55dcec32-6ff2-4f47-b3e2-ab621f58d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55dcec32-6ff2-4f47-b3e2-ab621f58d498.jpg?1",
             "name": "Utopia Vow",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\nEnchanted creature has \"{T}: Add one mana of any color.\"",
             "colours": [
@@ -8385,7 +8385,7 @@
         },
         {
             "id": "f523db25-4fff-5b66-88e2-f3af7be414f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5082a2a-e8b1-4799-ad29-a632d95ae1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5082a2a-e8b1-4799-ad29-a632d95ae1da.jpg?1",
             "name": "Virulent Sliver",
             "text": "All Sliver creatures have poisonous 1. (Whenever a Sliver deals combat damage to a player, that player gets a poison counter. A player with ten or more poison counters loses the game.)",
             "colours": [
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "0678ed38-b3d3-5683-91b9-708a2266bf7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9807f9a8-a994-4fb2-ad33-3d80d9702bfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9807f9a8-a994-4fb2-ad33-3d80d9702bfe.jpg?1",
             "name": "Yavimaya Dryad",
             "text": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)\nWhen Yavimaya Dryad enters the battlefield, you may search your library for a Forest card, put it onto the battlefield tapped under target player's control, then shuffle your library.",
             "colours": [
@@ -8453,7 +8453,7 @@
         },
         {
             "id": "34c4a3c6-e434-5cce-a8b1-baeb9a17d3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11df0ed7-ae08-4a95-8b79-d6be0df9e31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11df0ed7-ae08-4a95-8b79-d6be0df9e31a.jpg?1",
             "name": "Cautery Sliver",
             "text": "All Slivers have \"{1}, Sacrifice this permanent: This permanent deals 1 damage to any target.\"\nAll Slivers have \"{1}, Sacrifice this permanent: Prevent the next 1 damage that would be dealt to target player, planeswalker, or Sliver creature this turn.\"",
             "colours": [
@@ -8489,7 +8489,7 @@
         },
         {
             "id": "e5010f70-7253-573e-b719-3822b48cfa68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0b1a4-5372-424f-99b0-8abf500d5ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b0b1a4-5372-424f-99b0-8abf500d5ece.jpg?1",
             "name": "Darkheart Sliver",
             "text": "All Slivers have \"Sacrifice this permanent: You gain 3 life.\"",
             "colours": [
@@ -8525,7 +8525,7 @@
         },
         {
             "id": "15a5a1c8-34ff-59a9-a3f0-a354751c93cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d646252-6d42-4000-bfc1-ad12f2386b99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d646252-6d42-4000-bfc1-ad12f2386b99.jpg?1",
             "name": "Dormant Sliver",
             "text": "All Sliver creatures have defender.\nAll Slivers have \"When this permanent enters the battlefield, draw a card.\"",
             "colours": [
@@ -8561,7 +8561,7 @@
         },
         {
             "id": "be81a18f-717e-556d-be81-9524470bf7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554f402-35d4-43ac-9494-9d17d2a79092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9554f402-35d4-43ac-9494-9d17d2a79092.jpg?1",
             "name": "Dralnu, Lich Lord",
             "text": "If damage would be dealt to Dralnu, Lich Lord, sacrifice that many permanents instead.\n{T}: Target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -8600,7 +8600,7 @@
         },
         {
             "id": "d2924393-10c7-523c-a6ef-b0b42e02c915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7972f0a2-eb3f-4b67-82c8-73b0ae02722b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7972f0a2-eb3f-4b67-82c8-73b0ae02722b.jpg?1",
             "name": "Firewake Sliver",
             "text": "All Sliver creatures have haste.\nAll Slivers have \"{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn.\"",
             "colours": [
@@ -8636,7 +8636,7 @@
         },
         {
             "id": "00dc5683-b09e-5860-8ebb-ed9ad78bf9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c89645b-5e53-48c0-b4bb-9f22332c7658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c89645b-5e53-48c0-b4bb-9f22332c7658.jpg?1",
             "name": "Glittering Wish",
             "text": "You may reveal a multicolored card you own from outside the game and put it into your hand. Exile Glittering Wish.",
             "colours": [
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "b8e7b241-5837-59a7-9748-ab1b06a6ae2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cfc5db-3fc0-428e-8d4b-f6ea6caea36d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1cfc5db-3fc0-428e-8d4b-f6ea6caea36d.jpg?1",
             "name": "Harmonic Sliver",
             "text": "All Slivers have \"When this permanent enters the battlefield, destroy target artifact or enchantment.\"",
             "colours": [
@@ -8706,7 +8706,7 @@
         },
         {
             "id": "c9401d33-abb7-5f3b-825e-f6a796c3f283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c32735-e8e7-46a1-84ea-92806f459e84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c32735-e8e7-46a1-84ea-92806f459e84.jpg?1",
             "name": "Ith, High Arcanist",
             "text": "Vigilance\n{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nSuspend 4\u2014{W}{U}",
             "colours": [
@@ -8745,7 +8745,7 @@
         },
         {
             "id": "a47b81d7-c055-518d-b024-0751e012451b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6c3c8a-aa35-46b3-8769-27b4244457b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa6c3c8a-aa35-46b3-8769-27b4244457b0.jpg?1",
             "name": "Jhoira of the Ghitu",
             "text": "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend. (At the beginning of your upkeep, remove a time counter from that card. When the last is removed, cast it without paying its mana cost. If it's a creature, it has haste.)",
             "colours": [
@@ -8784,7 +8784,7 @@
         },
         {
             "id": "3ad9ee8d-1736-5b51-8a76-639f6349c264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a163e-7896-47bf-9b9b-dcf011402ce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e9a163e-7896-47bf-9b9b-dcf011402ce7.jpg?1",
             "name": "Kaervek the Merciless",
             "text": "Whenever an opponent casts a spell, Kaervek the Merciless deals damage equal to that spell's converted mana cost to any target.",
             "colours": [
@@ -8823,7 +8823,7 @@
         },
         {
             "id": "4f63f020-d857-536c-ae93-3ebd33b5d924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e57239-bbd8-49c3-acee-b7455f296c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e57239-bbd8-49c3-acee-b7455f296c9d.jpg?1",
             "name": "Necrotic Sliver",
             "text": "All Slivers have \"{3}, Sacrifice this permanent: Destroy target permanent.\"",
             "colours": [
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "09b0d812-f935-5e4b-9bae-76f25ec810c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7924e5a5-9614-4fd0-a621-80fa3103cc22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7924e5a5-9614-4fd0-a621-80fa3103cc22.jpg?1",
             "name": "Radha, Heir to Keld",
             "text": "Whenever Radha, Heir to Keld attacks, you may add {R}{R}.\n{T}: Add {G}.",
             "colours": [
@@ -8898,7 +8898,7 @@
         },
         {
             "id": "ab724c07-1c8b-5152-a99c-587994fc4f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4176dda4-ec5c-4734-bb48-0876304aa219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4176dda4-ec5c-4734-bb48-0876304aa219.jpg?1",
             "name": "Saffi Eriksdotter",
             "text": "Sacrifice Saffi Eriksdotter: When target creature is put into your graveyard this turn, return that card to the battlefield.",
             "colours": [
@@ -8937,7 +8937,7 @@
         },
         {
             "id": "aca9b08d-da19-5413-90a6-d0d651e7ab6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87545415-2e27-4841-a3af-7653af2ba6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87545415-2e27-4841-a3af-7653af2ba6d3.jpg?1",
             "name": "Sliver Legion",
             "text": "All Sliver creatures get +1/+1 for each other Sliver on the battlefield.",
             "colours": [
@@ -8981,7 +8981,7 @@
         },
         {
             "id": "be8a04c7-c7ea-5dfc-938c-52289949f70b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ee61d-0bc1-4d7b-ba68-157061aa98eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950ee61d-0bc1-4d7b-ba68-157061aa98eb.jpg?1",
             "name": "Akroma's Memorial",
             "text": "Creatures you control have flying, first strike, vigilance, trample, haste, and protection from black and from red.",
             "colours": [],
@@ -9011,7 +9011,7 @@
         },
         {
             "id": "bc85a76c-ceb2-5991-bb33-642e7d1600ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8d492-2c67-410b-b556-c157a14c4cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e8d492-2c67-410b-b556-c157a14c4cec.jpg?1",
             "name": "Chromatic Star",
             "text": "{1}, {T}, Sacrifice Chromatic Star: Add one mana of any color.\nWhen Chromatic Star is put into a graveyard from the battlefield, draw a card.",
             "colours": [],
@@ -9039,7 +9039,7 @@
         },
         {
             "id": "a979cd0a-5cc5-57bc-8ddb-6ead3a14e08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babba9f7-86e4-4e11-9fb8-acd50fbd8031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/babba9f7-86e4-4e11-9fb8-acd50fbd8031.jpg?1",
             "name": "Clockwork Hydra",
             "text": "Clockwork Hydra enters the battlefield with four +1/+1 counters on it.\nWhenever Clockwork Hydra attacks or blocks, remove a +1/+1 counter from it. If you do, Clockwork Hydra deals 1 damage to any target.\n{T}: Put a +1/+1 counter on Clockwork Hydra.",
             "colours": [],
@@ -9070,7 +9070,7 @@
         },
         {
             "id": "a0c213a0-5442-5710-b82b-94e79678177d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f880de5-8fc5-4e4e-a4bb-cc3e61a7697b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f880de5-8fc5-4e4e-a4bb-cc3e61a7697b.jpg?1",
             "name": "Cloud Key",
             "text": "As Cloud Key enters the battlefield, choose artifact, creature, enchantment, instant, or sorcery.\nSpells you cast of the chosen type cost {1} less to cast.",
             "colours": [],
@@ -9098,7 +9098,7 @@
         },
         {
             "id": "2e7978b4-f18e-551e-a5c9-4a3bb9003c82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fae620-8fa5-44db-8326-11cb323c626e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9fae620-8fa5-44db-8326-11cb323c626e.jpg?1",
             "name": "Coalition Relic",
             "text": "{T}: Add one mana of any color.\n{T}: Put a charge counter on Coalition Relic.\nAt the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color for each charge counter removed this way.",
             "colours": [],
@@ -9126,7 +9126,7 @@
         },
         {
             "id": "fed801f8-e157-5462-9346-8de853f4d739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e870a0-5699-4f42-b67a-8dbd24e0c9c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e870a0-5699-4f42-b67a-8dbd24e0c9c2.jpg?1",
             "name": "Gauntlet of Power",
             "text": "As Gauntlet of Power enters the battlefield, choose a color.\nCreatures of the chosen color get +1/+1.\nWhenever a basic land is tapped for mana of the chosen color, its controller adds an additional one mana of that color.",
             "colours": [],
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "cdd3ba5f-2e36-55e8-8872-0ec439dc4895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e62171-713c-49c0-8e16-b193ff181dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e62171-713c-49c0-8e16-b193ff181dcd.jpg?1",
             "name": "Hivestone",
             "text": "Creatures you control are Slivers in addition to their other creature types.",
             "colours": [],
@@ -9182,7 +9182,7 @@
         },
         {
             "id": "cdb02719-a9de-5f4c-be59-0bd8787fcd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d14746-3b57-4f8e-8155-e578cc84850d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d14746-3b57-4f8e-8155-e578cc84850d.jpg?1",
             "name": "Jhoira's Timebug",
             "text": "{T}: Choose target permanent you control or suspended card you own. If that permanent or card has a time counter on it, you may remove a time counter from it or put another time counter on it.",
             "colours": [],
@@ -9213,7 +9213,7 @@
         },
         {
             "id": "8f8fdc46-cab4-5ef7-852c-f74ca05af17a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89ae4d-1cc2-41d8-a4de-a54b958c4429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db89ae4d-1cc2-41d8-a4de-a54b958c4429.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color.",
             "colours": [],
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "a01efab0-1774-5546-b824-758f3808b223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794e97e-8b2c-4bde-8028-4348de5aec83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b794e97e-8b2c-4bde-8028-4348de5aec83.jpg?1",
             "name": "Paradise Plume",
             "text": "As Paradise Plume enters the battlefield, choose a color.\nWhenever a player casts a spell of the chosen color, you may gain 1 life.\n{T}: Add one mana of the chosen color.",
             "colours": [],
@@ -9271,7 +9271,7 @@
         },
         {
             "id": "ccc41f94-6ecd-5637-816f-b722e4607db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3be020-37a3-49ce-8604-27794175bf9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3be020-37a3-49ce-8604-27794175bf9d.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -9299,7 +9299,7 @@
         },
         {
             "id": "b18302b1-1f17-5aeb-a633-55a20d2fbb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83458352-9634-4cd7-bed1-6f7743c56c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83458352-9634-4cd7-bed1-6f7743c56c1f.jpg?1",
             "name": "Sliversmith",
             "text": "{1}, {T}, Discard a card: Create a 1/1 colorless Sliver artifact creature token named Metallic Sliver.",
             "colours": [],
@@ -9330,7 +9330,7 @@
         },
         {
             "id": "da6b98e1-3191-5a95-9243-5400366434e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce427213-4ce5-478e-83d8-fe80ec446a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce427213-4ce5-478e-83d8-fe80ec446a58.jpg?1",
             "name": "Stuffy Doll",
             "text": "Indestructible\nAs Stuffy Doll enters the battlefield, choose a player.\nWhenever Stuffy Doll is dealt damage, it deals that much damage to the chosen player.\n{T}: Stuffy Doll deals 1 damage to itself.",
             "colours": [],
@@ -9361,7 +9361,7 @@
         },
         {
             "id": "10b57907-0bc0-5a8e-87dc-f784e32573fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297a2b09-562a-46d8-905d-0b32e854e9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297a2b09-562a-46d8-905d-0b32e854e9d2.jpg?1",
             "name": "Calciform Pools",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Calciform Pools.\n{1}, Remove X storage counters from Calciform Pools: Add X mana in any combination of {W} and/or {U}.",
             "colours": [],
@@ -9392,7 +9392,7 @@
         },
         {
             "id": "e5b95d94-8c5f-5ff2-be98-83d3903b19fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18642a9e-ac45-402b-bb56-08cb6336c485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18642a9e-ac45-402b-bb56-08cb6336c485.jpg?1",
             "name": "Dreadship Reef",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Dreadship Reef.\n{1}, Remove X storage counters from Dreadship Reef: Add X mana in any combination of {U} and/or {B}.",
             "colours": [],
@@ -9423,7 +9423,7 @@
         },
         {
             "id": "efa6c108-f237-5b51-bb56-34b69755e567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3a843b-2dea-4b44-be74-c09c18b9b969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3a843b-2dea-4b44-be74-c09c18b9b969.jpg?1",
             "name": "Dryad Arbor",
             "text": "(Dryad Arbor isn't a spell, it's affected by summoning sickness, and it has \"{T}: Add {G}.\")",
             "colours": [
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "e58b388c-3114-5ad4-b97e-7a9fe37017c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acea27-88de-4d27-8da2-8f82439526a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0acea27-88de-4d27-8da2-8f82439526a1.jpg?1",
             "name": "Flagstones of Trokair",
             "text": "{T}: Add {W}.\nWhen Flagstones of Trokair is put into a graveyard from the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -9491,7 +9491,7 @@
         },
         {
             "id": "03f18618-b517-5c5e-9aa6-41986f29a4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3580d6-345a-46ba-a327-0e924989d6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a3580d6-345a-46ba-a327-0e924989d6b1.jpg?1",
             "name": "Fungal Reaches",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Fungal Reaches.\n{1}, Remove X storage counters from Fungal Reaches: Add X mana in any combination of {R} and/or {G}.",
             "colours": [],
@@ -9522,7 +9522,7 @@
         },
         {
             "id": "27178af1-4848-5ea1-a98f-4d3be5384044",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f273641-c5f3-48bc-b89e-3cff52d26a0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f273641-c5f3-48bc-b89e-3cff52d26a0b.jpg?1",
             "name": "Gemstone Caverns",
             "text": "If Gemstone Caverns is in your opening hand and you're not the starting player, you may begin the game with Gemstone Caverns on the battlefield with a luck counter on it. If you do, exile a card from your hand.\n{T}: Add {C}. If Gemstone Caverns has a luck counter on it, instead add one mana of any color.",
             "colours": [],
@@ -9552,7 +9552,7 @@
         },
         {
             "id": "051eb390-678f-51cf-853e-baaa435e8fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daf0fe9-d567-4749-b649-4bfc929cb238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daf0fe9-d567-4749-b649-4bfc929cb238.jpg?1",
             "name": "Kher Keep",
             "text": "{T}: Add {C}.\n{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep.",
             "colours": [],
@@ -9584,7 +9584,7 @@
         },
         {
             "id": "a98b5cf4-e166-52ed-9aa8-1c014e663921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d952491-3a33-42af-9748-d2cb9c5a2f76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d952491-3a33-42af-9748-d2cb9c5a2f76.jpg?1",
             "name": "Molten Slagheap",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Molten Slagheap.\n{1}, Remove X storage counters from Molten Slagheap: Add X mana in any combination of {B} and/or {R}.",
             "colours": [],
@@ -9615,7 +9615,7 @@
         },
         {
             "id": "6374eb80-6c99-5da6-947f-9ebf4ae19dc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d757f1-9398-494f-9a24-b01c5c8c6db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d757f1-9398-494f-9a24-b01c5c8c6db5.jpg?1",
             "name": "Saltcrusted Steppe",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Saltcrusted Steppe.\n{1}, Remove X storage counters from Saltcrusted Steppe: Add X mana in any combination of {G} and/or {W}.",
             "colours": [],
@@ -9646,7 +9646,7 @@
         },
         {
             "id": "90af5491-b6cc-5229-9a41-329df3bb8412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89329f2-d386-40a7-9098-6d80beeb8843.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b89329f2-d386-40a7-9098-6d80beeb8843.jpg?1",
             "name": "Swarmyard",
             "text": "{T}: Add {C}.\n{T}: Regenerate target Insect, Rat, Spider, or Squirrel. (The next time it would be destroyed, instead tap it, remove it from combat, and heal all damage on it.)",
             "colours": [],
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "23387971-7b19-5a16-a4f7-477202c0e728",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2564ec-f092-45d6-a519-6f18dbcdaee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2564ec-f092-45d6-a519-6f18dbcdaee6.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -9702,7 +9702,7 @@
         },
         {
             "id": "f7c3bae8-fa93-5e5b-98a9-0c059508a9a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b005eef6-75f3-454f-a42b-d851bc84ac4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b005eef6-75f3-454f-a42b-d851bc84ac4e.jpg?1",
             "name": "Tolaria West",
             "text": "Tolaria West enters the battlefield tapped.\n{T}: Add {U}.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with converted mana cost 0, reveal it, put it into your hand, then shuffle your library. Transmute only as a sorcery.)",
             "colours": [],
@@ -9732,7 +9732,7 @@
         },
         {
             "id": "70be3f1f-8a6b-50e5-9b45-acb245fa5310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1a9e38-6ffc-490f-b0be-23ba4e8204c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1a9e38-6ffc-490f-b0be-23ba4e8204c6.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],
@@ -9762,7 +9762,7 @@
         },
         {
             "id": "9887e47c-43d3-51d6-ac4a-9bdd21482446",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03f17f1-b0fd-4b84-82ea-085c2f87eeda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03f17f1-b0fd-4b84-82ea-085c2f87eeda.jpg?1",
             "name": "Urza's Factory",
             "text": "{T}: Add {C}.\n{7}, {T}: Create a 2/2 colorless Assembly-Worker artifact creature token.",
             "colours": [],
@@ -9792,7 +9792,7 @@
         },
         {
             "id": "4ad0d5bb-f365-5d5f-90ff-e57be359bfa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0726f70a-c1c4-4edb-86fb-9be280d9ea73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0726f70a-c1c4-4edb-86fb-9be280d9ea73.jpg?1",
             "name": "Vesuva",
             "text": "You may have Vesuva enter the battlefield tapped as a copy of any land on the battlefield.",
             "colours": [],
@@ -9820,7 +9820,7 @@
         },
         {
             "id": "01296cbc-3a64-559b-99c0-8a5f76529855",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab58d83-5930-4d28-a26c-225c7a872216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab58d83-5930-4d28-a26c-225c7a872216.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -9855,7 +9855,7 @@
         },
         {
             "id": "5922467e-bb4c-5426-a3c4-6237a89c6992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f27dd19-a475-4024-aecf-ba6142806656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f27dd19-a475-4024-aecf-ba6142806656.jpg?1",
             "name": "Banishing Light",
             "text": "When Banishing Light enters the battlefield, exile target nonland permanent an opponent controls until Banishing Light leaves the battlefield.",
             "colours": [
@@ -9887,7 +9887,7 @@
         },
         {
             "id": "f54d1ec8-92e8-5d4f-bfd8-17033f6a6ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65975f50-70b1-4d64-8d81-5ef2da479c48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65975f50-70b1-4d64-8d81-5ef2da479c48.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "e43a4ba8-474e-5ebc-b4bb-3ff30c7de70e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167e245-dbdc-4a4b-b475-05b23f84a98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2167e245-dbdc-4a4b-b475-05b23f84a98b.jpg?1",
             "name": "Ethereal Armor",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 for each enchantment you control and has first strike.",
             "colours": [
@@ -9956,7 +9956,7 @@
         },
         {
             "id": "628a2f4d-59f5-590a-804d-ee14b11b999e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6931aad2-aa2c-4069-9e5a-2566b9f3eae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6931aad2-aa2c-4069-9e5a-2566b9f3eae4.jpg?1",
             "name": "Flickerwisp",
             "text": "Flying\nWhen Flickerwisp enters the battlefield, exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -9990,7 +9990,7 @@
         },
         {
             "id": "6d28fed4-c9bc-56c5-8930-db8450455c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa180a-772d-4d4a-9c1b-22b3cf18e2b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edfa180a-772d-4d4a-9c1b-22b3cf18e2b0.jpg?1",
             "name": "Intangible Virtue",
             "text": "Creature tokens you control get +1/+1 and have vigilance.",
             "colours": [
@@ -10022,7 +10022,7 @@
         },
         {
             "id": "dbdf1770-6552-517e-b65d-4bd624968a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278e97cf-312d-4e9e-bc39-023f4e547121.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/278e97cf-312d-4e9e-bc39-023f4e547121.jpg?1",
             "name": "Lingering Souls",
             "text": "Create two 1/1 white Spirit creature tokens with flying.\nFlashback {1}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -10055,7 +10055,7 @@
         },
         {
             "id": "bba42d0f-56a7-5d9a-8e74-da0c2ec21a9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f71a96-94d1-4cbb-b21c-0e5075840777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f71a96-94d1-4cbb-b21c-0e5075840777.jpg?1",
             "name": "Mirror Entity",
             "text": "Changeling (This card is every creature type.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
             "colours": [
@@ -10089,7 +10089,7 @@
         },
         {
             "id": "0d02f774-8734-538a-ad75-b87e5b4f8b8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed869151-02e9-4daa-994d-ccdf9f9dc3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed869151-02e9-4daa-994d-ccdf9f9dc3c8.jpg?1",
             "name": "Palace Jailer",
             "text": "When Palace Jailer enters the battlefield, you become the monarch.\nWhen Palace Jailer enters the battlefield, exile target creature an opponent controls until an opponent becomes the monarch.",
             "colours": [
@@ -10124,7 +10124,7 @@
         },
         {
             "id": "36e7671e-ed7c-518f-a75c-5ae3eaef1f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee3e42e-120c-468a-988d-4441b6025bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee3e42e-120c-468a-988d-4441b6025bbe.jpg?1",
             "name": "Path to Exile",
             "text": "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle their library.",
             "colours": [
@@ -10156,7 +10156,7 @@
         },
         {
             "id": "00338347-2db3-523f-9758-d12f2c7ef69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1266de-3a58-4579-9781-78aaf852bbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc1266de-3a58-4579-9781-78aaf852bbac.jpg?1",
             "name": "Restoration Angel",
             "text": "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under your control.",
             "colours": [
@@ -10190,7 +10190,7 @@
         },
         {
             "id": "9b08ffa3-e171-51ee-9de1-4268a30ac66e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3584cdf0-9e46-480d-bc73-78e1180d32d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3584cdf0-9e46-480d-bc73-78e1180d32d3.jpg?1",
             "name": "Sigil of the Empty Throne",
             "text": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
             "colours": [
@@ -10222,7 +10222,7 @@
         },
         {
             "id": "e9bd8b51-7e14-5f45-9bec-27a1f51791e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93c1860-a27e-426c-9fbb-3bd20ead1afc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d93c1860-a27e-426c-9fbb-3bd20ead1afc.jpg?1",
             "name": "Silence",
             "text": "Your opponents can't cast spells this turn.",
             "colours": [
@@ -10254,7 +10254,7 @@
         },
         {
             "id": "2f7ac489-c526-53e4-ae67-e25496b499df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc08ef6-61fc-4d01-a78b-df0cf99585d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc08ef6-61fc-4d01-a78b-df0cf99585d9.jpg?1",
             "name": "Sram, Senior Edificer",
             "text": "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
             "colours": [
@@ -10291,7 +10291,7 @@
         },
         {
             "id": "ce232f83-94b4-5f7d-94b8-7369c7e45a07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d14bf-78dd-4a51-a8df-04636d2141f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04d14bf-78dd-4a51-a8df-04636d2141f3.jpg?1",
             "name": "Stonehorn Dignitary",
             "text": "When Stonehorn Dignitary enters the battlefield, target opponent skips their next combat phase.",
             "colours": [
@@ -10326,7 +10326,7 @@
         },
         {
             "id": "4c7ff267-a6bd-56ee-9fc5-3c9734ad8c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec18fa41-6948-4d94-8dcc-31fb63fb53ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec18fa41-6948-4d94-8dcc-31fb63fb53ec.jpg?1",
             "name": "Thraben Inspector",
             "text": "When Thraben Inspector enters the battlefield, investigate. (Create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -10361,7 +10361,7 @@
         },
         {
             "id": "b026c919-ed80-53de-9e2c-b5dcce24670b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103a725-4750-4d9e-8792-6fbbb81bba0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a103a725-4750-4d9e-8792-6fbbb81bba0e.jpg?1",
             "name": "Baral, Chief of Compliance",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -10398,7 +10398,7 @@
         },
         {
             "id": "7444058d-157c-5806-a997-7b80f2a54cc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83fbd7f-1757-4dcf-9972-0c8f71843f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83fbd7f-1757-4dcf-9972-0c8f71843f03.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with converted mana cost 4 or greater.",
             "colours": [
@@ -10430,7 +10430,7 @@
         },
         {
             "id": "6e3a8477-c7e9-56b8-b5ab-51cc287ba81b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7308076-755c-4508-8920-5a6641a17a8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7308076-755c-4508-8920-5a6641a17a8a.jpg?1",
             "name": "Fblthp, the Lost",
             "text": "When Fblthp, the Lost enters the battlefield, draw a card. If it entered from your library or was cast from your library, draw two cards instead.\nWhen Fblthp becomes the target of a spell, shuffle Fblthp into its owner's library.",
             "colours": [
@@ -10466,7 +10466,7 @@
         },
         {
             "id": "b75e2506-f2d5-5831-b689-5a3d5b67aa4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840b48c-7a14-481e-9d21-0c68aee16020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5840b48c-7a14-481e-9d21-0c68aee16020.jpg?1",
             "name": "Laboratory Maniac",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.",
             "colours": [
@@ -10501,7 +10501,7 @@
         },
         {
             "id": "05d9ced2-e828-5dc8-8ee6-22ed3f74e162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367f862-cd88-4e6d-8e87-693080e5c431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3367f862-cd88-4e6d-8e87-693080e5c431.jpg?1",
             "name": "Master of the Pearl Trident",
             "text": "Other Merfolk creatures you control get +1/+1 and have islandwalk. (They can't be blocked as long as defending player controls an Island.)",
             "colours": [
@@ -10535,7 +10535,7 @@
         },
         {
             "id": "232bccae-067d-57fd-83e5-91c3b7d8bab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea86b5bf-c38f-4168-a4dd-96859948423c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea86b5bf-c38f-4168-a4dd-96859948423c.jpg?1",
             "name": "Mulldrifter",
             "text": "Flying\nWhen Mulldrifter enters the battlefield, draw two cards.\nEvoke {2}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -10569,7 +10569,7 @@
         },
         {
             "id": "4f20ceef-1f89-56bc-8b51-d67350626d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337214ad-2976-4692-89c4-2c5001bf087f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337214ad-2976-4692-89c4-2c5001bf087f.jpg?1",
             "name": "Mystic Confluence",
             "text": "Choose three. You may choose the same mode more than once.\n\u2022 Counter target spell unless its controller pays {3}.\n\u2022 Return target creature to its owner's hand.\n\u2022 Draw a card.",
             "colours": [
@@ -10601,7 +10601,7 @@
         },
         {
             "id": "51d81354-9d18-574b-9fba-ec4dce2dc41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101b32f-2a7f-4cfa-80a4-fdae3756a7f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2101b32f-2a7f-4cfa-80a4-fdae3756a7f1.jpg?1",
             "name": "Ninja of the Deep Hours",
             "text": "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Ninja of the Deep Hours deals combat damage to a player, you may draw a card.",
             "colours": [
@@ -10636,7 +10636,7 @@
         },
         {
             "id": "d0ec417d-fd81-54ca-aa76-15e270acc0bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad659f3-11c8-4cc0-a716-43bb3ad18a9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad659f3-11c8-4cc0-a716-43bb3ad18a9c.jpg?1",
             "name": "Paradoxical Outcome",
             "text": "Return any number of target nonland, nontoken permanents you control to their owners' hands. Draw a card for each card returned to your hand this way.",
             "colours": [
@@ -10668,7 +10668,7 @@
         },
         {
             "id": "d3d4b101-fb5e-55b2-988b-2a9317e909ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af450adb-23be-4332-a54c-d647a1fd0248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af450adb-23be-4332-a54c-d647a1fd0248.jpg?1",
             "name": "Ponder",
             "text": "Look at the top three cards of your library, then put them back in any order. You may shuffle your library.\nDraw a card.",
             "colours": [
@@ -10700,7 +10700,7 @@
         },
         {
             "id": "0d518adb-b442-5674-b1ac-37d849a109d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69001c08-2541-47e3-8343-2e5089a9b193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69001c08-2541-47e3-8343-2e5089a9b193.jpg?1",
             "name": "Remand",
             "text": "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.",
             "colours": [
@@ -10732,7 +10732,7 @@
         },
         {
             "id": "760a585c-5d9e-5029-bdbf-0d2052f25812",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67954eb1-1c61-432c-9113-104909511ad4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67954eb1-1c61-432c-9113-104909511ad4.jpg?1",
             "name": "Repeal",
             "text": "Return target nonland permanent with converted mana cost X to its owner's hand.\nDraw a card.",
             "colours": [
@@ -10764,7 +10764,7 @@
         },
         {
             "id": "e7256b66-5d76-514a-8a1c-0e32b72f9e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7f794-71b7-433f-9d43-863058efa134.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c7f794-71b7-433f-9d43-863058efa134.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -10801,7 +10801,7 @@
         },
         {
             "id": "2a112a05-961c-5898-a9db-b9750dd3e63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e86d8e-8d58-41e8-8c4d-b73482bcba45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e86d8e-8d58-41e8-8c4d-b73482bcba45.jpg?1",
             "name": "Treasure Cruise",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -10833,7 +10833,7 @@
         },
         {
             "id": "35900df9-3dec-5497-ba15-9346ee2fdcf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e006682-5236-4a32-9f3d-7337b2c42b21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e006682-5236-4a32-9f3d-7337b2c42b21.jpg?1",
             "name": "Trinket Mage",
             "text": "When Trinket Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, put it into your hand, then shuffle your library.",
             "colours": [
@@ -10868,7 +10868,7 @@
         },
         {
             "id": "68713514-ca1d-5798-8c17-bb57790adf2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ad086b-9bf2-4086-b820-a4ff7854a674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33ad086b-9bf2-4086-b820-a4ff7854a674.jpg?1",
             "name": "True-Name Nemesis",
             "text": "As True-Name Nemesis enters the battlefield, choose a player.\nTrue-Name Nemesis has protection from the chosen player.",
             "colours": [
@@ -10903,7 +10903,7 @@
         },
         {
             "id": "4f0083dc-1815-5f5e-91d9-1c95ddf2cdd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d405dc-180f-4edb-8c53-80a034ee622e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d405dc-180f-4edb-8c53-80a034ee622e.jpg?1",
             "name": "Dismember",
             "text": "({PB} can be paid with either {B} or 2 life.)\nTarget creature gets -5/-5 until end of turn.",
             "colours": [
@@ -10935,7 +10935,7 @@
         },
         {
             "id": "368f0a6f-21d8-5e93-a2f5-929aab3947dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be62041-fec2-44e0-aec9-5368d1c7f1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5be62041-fec2-44e0-aec9-5368d1c7f1da.jpg?1",
             "name": "Gray Merchant of Asphodel",
             "text": "When Gray Merchant of Asphodel enters the battlefield, each opponent loses X life, where X is your devotion to black. You gain life equal to the life lost this way. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)",
             "colours": [
@@ -10969,7 +10969,7 @@
         },
         {
             "id": "72082e26-62b0-5526-9871-b79e88a0f292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361fe303-34a5-4d12-b927-dfb858699c6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361fe303-34a5-4d12-b927-dfb858699c6c.jpg?1",
             "name": "Gurmag Angler",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -11004,7 +11004,7 @@
         },
         {
             "id": "a29a8a5e-e6c6-575a-aae0-53d2ec297d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d222691-1eb4-407e-a94a-5a71c0f1e376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d222691-1eb4-407e-a94a-5a71c0f1e376.jpg?1",
             "name": "Harvester of Souls",
             "text": "Deathtouch\nWhenever another nontoken creature dies, you may draw a card.",
             "colours": [
@@ -11038,7 +11038,7 @@
         },
         {
             "id": "90ce16ec-6b5d-5398-b153-e552f128dd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186eea73-46c5-4532-ac94-326db7d6f0cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/186eea73-46c5-4532-ac94-326db7d6f0cb.jpg?1",
             "name": "Leyline of the Void",
             "text": "If Leyline of the Void is in your opening hand, you may begin the game with it on the battlefield.\nIf a card would be put into an opponent's graveyard from anywhere, exile it instead.",
             "colours": [
@@ -11070,7 +11070,7 @@
         },
         {
             "id": "34c4cb9a-e9d6-599a-bf60-e84651cd3895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f0f9e-556c-40b7-bba9-a539c4c4fd30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe1f0f9e-556c-40b7-bba9-a539c4c4fd30.jpg?1",
             "name": "Liliana's Triumph",
             "text": "Each opponent sacrifices a creature. If you control a Liliana planeswalker, each opponent also discards a card.",
             "colours": [
@@ -11102,7 +11102,7 @@
         },
         {
             "id": "4ec2fb78-2f3f-580e-891d-b2ad9a626421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daf00e8-f95b-410f-9e6f-a7fd6c2b8588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4daf00e8-f95b-410f-9e6f-a7fd6c2b8588.jpg?1",
             "name": "Read the Bones",
             "text": "Scry 2, then draw two cards. You lose 2 life.",
             "colours": [
@@ -11134,7 +11134,7 @@
         },
         {
             "id": "69c11c4c-3876-58ed-b948-811ea4341dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28de0281-0370-44df-9ee0-6e1bb9925a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28de0281-0370-44df-9ee0-6e1bb9925a92.jpg?1",
             "name": "Relentless Rats",
             "text": "Relentless Rats gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
             "colours": [
@@ -11168,7 +11168,7 @@
         },
         {
             "id": "a1804535-c5e9-5ca7-9e4c-024cb373dbb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c16b0-bdab-44e1-b235-47fe8d32f4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c16b0-bdab-44e1-b235-47fe8d32f4d2.jpg?1",
             "name": "Sanguine Bond",
             "text": "Whenever you gain life, target opponent loses that much life.",
             "colours": [
@@ -11200,7 +11200,7 @@
         },
         {
             "id": "1ca4718a-c7b0-539e-baeb-9032c0f8d70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d007da5a-6bd9-433b-b04e-b740e61dfc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d007da5a-6bd9-433b-b04e-b740e61dfc50.jpg?1",
             "name": "Shriekmaw",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhen Shriekmaw enters the battlefield, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -11234,7 +11234,7 @@
         },
         {
             "id": "84a7bf23-0877-543f-a1bf-ac5144d6f72e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd78ce3d-cf5a-4f1a-9a47-7872be8cf45c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd78ce3d-cf5a-4f1a-9a47-7872be8cf45c.jpg?1",
             "name": "Stinkweed Imp",
             "text": "Flying\nWhenever Stinkweed Imp deals combat damage to a creature, destroy that creature.\nDredge 5 (If you would draw a card, you may mill five cards instead. If you do, return this card from your graveyard to your hand.)",
             "colours": [
@@ -11268,7 +11268,7 @@
         },
         {
             "id": "711a82f7-88a0-5011-a0b7-bab10ff6d96c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b6fd9-d0e5-4026-895a-851a462cbf90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/095b6fd9-d0e5-4026-895a-851a462cbf90.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n{2}{GW}{GW}: Mill two cards, then return a nonland card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -11307,7 +11307,7 @@
         },
         {
             "id": "89c871d9-5914-54e6-a601-4582b4f87b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e76c6b-9d60-4bc8-b88d-6c9c7fade9a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6e76c6b-9d60-4bc8-b88d-6c9c7fade9a6.jpg?1",
             "name": "Thoughtseize",
             "text": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
             "colours": [
@@ -11339,7 +11339,7 @@
         },
         {
             "id": "7f1b21cc-11fe-513c-8bf1-2188c4e512ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d945e64f-cbe9-4b72-aaec-0b97be1e12d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d945e64f-cbe9-4b72-aaec-0b97be1e12d2.jpg?1",
             "name": "Vampire Hexmage",
             "text": "First strike\nSacrifice Vampire Hexmage: Remove all counters from target permanent.",
             "colours": [
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "dc1a084b-57ba-509d-966e-2c5e80994250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81564970-23ad-41a3-b5e0-21bdf13f6248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81564970-23ad-41a3-b5e0-21bdf13f6248.jpg?1",
             "name": "Yawgmoth, Thran Physician",
             "text": "Protection from Humans\nPay 1 life, Sacrifice another creature: Put a -1/-1 counter on up to one target creature and draw a card.\n{B}{B}, Discard a card: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -11411,7 +11411,7 @@
         },
         {
             "id": "8cda3f8e-2b70-5285-be0d-911a2e89fe25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8a6636-eab2-4aee-bd55-4d62c2e2e266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc8a6636-eab2-4aee-bd55-4d62c2e2e266.jpg?1",
             "name": "Zulaport Cutthroat",
             "text": "Whenever Zulaport Cutthroat or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -11447,7 +11447,7 @@
         },
         {
             "id": "e26806bb-1c3b-5262-a49d-1eeb5ca8bca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ba1276-0fe6-419f-9d91-fac9eb23cca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ba1276-0fe6-419f-9d91-fac9eb23cca4.jpg?1",
             "name": "Alesha, Who Smiles at Death",
             "text": "First strike\nWhenever Alesha, Who Smiles at Death attacks, you may pay {WB}{WB}. If you do, return target creature card with power 2 or less from your graveyard to the battlefield tapped and attacking.",
             "colours": [
@@ -11486,7 +11486,7 @@
         },
         {
             "id": "46b1c4fa-1b71-53ea-a8d3-e80a76f9309c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89888597-e9bf-431a-8664-da66f22c7ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89888597-e9bf-431a-8664-da66f22c7ea0.jpg?1",
             "name": "Anger of the Gods",
             "text": "Anger of the Gods deals 3 damage to each creature. If a creature dealt damage this way would die this turn, exile it instead.",
             "colours": [
@@ -11518,7 +11518,7 @@
         },
         {
             "id": "7d64a303-98f0-57e1-b185-3f5e3131ab2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526682f2-011c-4cab-9115-ef605489ee01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/526682f2-011c-4cab-9115-ef605489ee01.jpg?1",
             "name": "Bedlam Reveler",
             "text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess\nWhen Bedlam Reveler enters the battlefield, discard your hand, then draw three cards.",
             "colours": [
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "27ba2912-7367-5c9f-891a-bf9ac68f5605",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933adb-9c7a-4248-9908-f01e6a6bf12c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27933adb-9c7a-4248-9908-f01e6a6bf12c.jpg?1",
             "name": "Dreadhorde Arcanist",
             "text": "Trample\nWhenever Dreadhorde Arcanist attacks, you may cast target instant or sorcery card with converted mana cost less than or equal to Dreadhorde Arcanist's power from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -11588,7 +11588,7 @@
         },
         {
             "id": "dcac1e61-f5b6-5a78-b349-70e0eb7796b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f9f8b0-f0de-4dff-a8ea-857919366000.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f9f8b0-f0de-4dff-a8ea-857919366000.jpg?1",
             "name": "Etali, Primal Storm",
             "text": "Whenever Etali, Primal Storm attacks, exile the top card of each player's library, then you may cast any number of spells from among those cards without paying their mana costs.",
             "colours": [
@@ -11625,7 +11625,7 @@
         },
         {
             "id": "8760d0bc-f696-55eb-9a7b-73f533528abe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7109a9-9eec-48fe-9081-5a0424f255ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7109a9-9eec-48fe-9081-5a0424f255ce.jpg?1",
             "name": "Exquisite Firecraft",
             "text": "Exquisite Firecraft deals 4 damage to any target.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, this spell can't be countered.",
             "colours": [
@@ -11657,7 +11657,7 @@
         },
         {
             "id": "40dfb7b5-ba30-5e66-8676-ba070466e984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44130046-cd48-42d5-8083-5e4e7dd37a7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44130046-cd48-42d5-8083-5e4e7dd37a7b.jpg?1",
             "name": "Feldon of the Third Path",
             "text": "{2}{R}, {T}: Create a token that's a copy of target creature card in your graveyard, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -11694,7 +11694,7 @@
         },
         {
             "id": "216bdcfd-aabc-5225-9cac-70bdc85d76cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f675f6-df29-4b90-a5e6-26d915fdc6a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f675f6-df29-4b90-a5e6-26d915fdc6a1.jpg?1",
             "name": "Goblin Engineer",
             "text": "When Goblin Engineer enters the battlefield, you may search your library for an artifact card, put it into your graveyard, then shuffle your library.\n{R}, {T}, Sacrifice an artifact: Return target artifact card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -11729,7 +11729,7 @@
         },
         {
             "id": "30118563-af77-5c66-b3ff-d4326143acff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a30fe7c-3c6b-4d05-adb7-9f87df29cd3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a30fe7c-3c6b-4d05-adb7-9f87df29cd3b.jpg?1",
             "name": "Kiki-Jiki, Mirror Breaker",
             "text": "Haste\n{T}: Create a token that's a copy of target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
             "colours": [
@@ -11766,7 +11766,7 @@
         },
         {
             "id": "21485a46-03ca-50e2-b323-4821ee082c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0852af16-f650-4293-81d8-9008882ff45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0852af16-f650-4293-81d8-9008882ff45a.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player or planeswalker.",
             "colours": [
@@ -11800,7 +11800,7 @@
         },
         {
             "id": "f147a2e5-c57e-5f65-a6dd-11c2fc4b8d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f29ab4-79f8-4bcf-ab0e-c21d3c40d63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f29ab4-79f8-4bcf-ab0e-c21d3c40d63e.jpg?1",
             "name": "Molten Rain",
             "text": "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.",
             "colours": [
@@ -11832,7 +11832,7 @@
         },
         {
             "id": "4b6ca226-a25c-57ec-80d9-6ad33a58cfd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439d4ade-45c8-414b-a2fe-a57f9672bceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/439d4ade-45c8-414b-a2fe-a57f9672bceb.jpg?1",
             "name": "Monastery Swiftspear",
             "text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -11867,7 +11867,7 @@
         },
         {
             "id": "0d29223b-1883-5598-ac7d-81061dc87ca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e655061a-8071-4b7b-b993-27f9ea360f7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e655061a-8071-4b7b-b993-27f9ea360f7c.jpg?1",
             "name": "Past in Flames",
             "text": "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -11899,7 +11899,7 @@
         },
         {
             "id": "3c6f070e-e66c-5545-b8ac-9e3b3b0b8d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6af20a0-ef9b-4827-a9ef-4958b9d80820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6af20a0-ef9b-4827-a9ef-4958b9d80820.jpg?1",
             "name": "Temur Battle Rage",
             "text": "Target creature gains double strike until end of turn.\nFerocious \u2014 That creature also gains trample until end of turn if you control a creature with power 4 or greater.",
             "colours": [
@@ -11931,7 +11931,7 @@
         },
         {
             "id": "4c1f8b7a-48ab-50cd-bc32-7ad2f95d297f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb320986-0a52-4084-a8c4-e09659432b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb320986-0a52-4084-a8c4-e09659432b22.jpg?1",
             "name": "Vandalblast",
             "text": "Destroy target artifact you don't control.\nOverload {4}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")",
             "colours": [
@@ -11963,7 +11963,7 @@
         },
         {
             "id": "c5ec9fb9-76eb-57c4-8f33-92da9f1d2013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63195ed-5c3e-40e8-9cc2-5cbc1faf7f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63195ed-5c3e-40e8-9cc2-5cbc1faf7f7f.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -11998,7 +11998,7 @@
         },
         {
             "id": "f3f94633-6069-52b6-9275-191fddf8b260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576152c-d8c1-4412-89db-6e21295c9b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2576152c-d8c1-4412-89db-6e21295c9b18.jpg?1",
             "name": "Zealous Conscripts",
             "text": "Haste\nWhen Zealous Conscripts enters the battlefield, gain control of target permanent until end of turn. Untap that permanent. It gains haste until end of turn.",
             "colours": [
@@ -12033,7 +12033,7 @@
         },
         {
             "id": "f9d4e177-a001-5b35-86a7-e97a1514ec17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2a4717-3914-46bc-886e-1eddee94e098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2a4717-3914-46bc-886e-1eddee94e098.jpg?1",
             "name": "Ancient Stirrings",
             "text": "Look at the top five cards of your library. You may reveal a colorless card from among them and put it into your hand. Then put the rest on the bottom of your library in any order.",
             "colours": [
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "8b945171-bbc3-5c07-a0de-79022f0db0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbebd9-9faf-4a7b-8e79-b67c074eba8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbebd9-9faf-4a7b-8e79-b67c074eba8c.jpg?1",
             "name": "Beast Whisperer",
             "text": "Whenever you cast a creature spell, draw a card.",
             "colours": [
@@ -12100,7 +12100,7 @@
         },
         {
             "id": "63d5910f-336a-5c4e-83ce-cd72160d9e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1f93-ecee-4ed8-a77e-6ebc4b85328d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1f93-ecee-4ed8-a77e-6ebc4b85328d.jpg?1",
             "name": "Beast Within",
             "text": "Destroy target permanent. Its controller creates a 3/3 green Beast creature token.",
             "colours": [
@@ -12132,7 +12132,7 @@
         },
         {
             "id": "572e687b-6803-57e4-b77e-52d8e823cf1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cbd578-4b3c-4de8-8418-0dd6f85972ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2cbd578-4b3c-4de8-8418-0dd6f85972ae.jpg?1",
             "name": "Become Immense",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget creature gets +6/+6 until end of turn.",
             "colours": [
@@ -12164,7 +12164,7 @@
         },
         {
             "id": "6322df71-702f-5426-977a-a313f001c9d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c341be76-664f-4665-a4c3-708d97605a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c341be76-664f-4665-a4c3-708d97605a16.jpg?1",
             "name": "Courser of Kruphix",
             "text": "Play with the top card of your library revealed.\nYou may play lands from the top of your library.\nWhenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "e87f90e1-1453-5c4d-9196-adddaf575760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d50fa57-db11-419e-b73b-666a6b25f7de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d50fa57-db11-419e-b73b-666a6b25f7de.jpg?1",
             "name": "Elvish Mystic",
             "text": "{T}: Add {G}.",
             "colours": [
@@ -12234,7 +12234,7 @@
         },
         {
             "id": "4b2b072d-4c59-56de-852b-033579aa12c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584dfb52-4a6c-4a33-9ae1-12227b938f9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584dfb52-4a6c-4a33-9ae1-12227b938f9a.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -12269,7 +12269,7 @@
         },
         {
             "id": "16747de0-2a87-5e65-87e6-cf2fe48a5d21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c731ba3b-3c48-472b-88ec-05205690e703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c731ba3b-3c48-472b-88ec-05205690e703.jpg?1",
             "name": "Evolutionary Leap",
             "text": "{G}, Sacrifice a creature: Reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -12301,7 +12301,7 @@
         },
         {
             "id": "b235f55d-83c4-5a51-a85b-d199289a4ed0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74db0dd4-3bb6-41f7-803c-a04647327dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74db0dd4-3bb6-41f7-803c-a04647327dec.jpg?1",
             "name": "Farseek",
             "text": "Search your library for a Plains, Island, Swamp, or Mountain card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -12333,7 +12333,7 @@
         },
         {
             "id": "b1eb9a52-dca2-5f04-a466-04db8e2a1c6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faca514-b7f3-4d34-a259-d03bad50611b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0faca514-b7f3-4d34-a259-d03bad50611b.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -12365,7 +12365,7 @@
         },
         {
             "id": "c0b6c996-4da3-515d-b72a-76179d9c157a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53760940-50e4-45d4-8297-353c9fc896e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53760940-50e4-45d4-8297-353c9fc896e9.jpg?1",
             "name": "Primeval Titan",
             "text": "Trample\nWhenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -12399,7 +12399,7 @@
         },
         {
             "id": "4f1da9f2-1337-51f0-9b5b-0e805cf745b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fba2e4-ea27-4ef0-9b27-bc61a7c6b0ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6fba2e4-ea27-4ef0-9b27-bc61a7c6b0ab.jpg?1",
             "name": "Reclamation Sage",
             "text": "When Reclamation Sage enters the battlefield, you may destroy target artifact or enchantment.",
             "colours": [
@@ -12434,7 +12434,7 @@
         },
         {
             "id": "14b6affd-b84f-5714-a7fa-f3edc4bb700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f882c71-dd90-4eac-9756-0bf487cba625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f882c71-dd90-4eac-9756-0bf487cba625.jpg?1",
             "name": "Sylvan Scrying",
             "text": "Search your library for a land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -12466,7 +12466,7 @@
         },
         {
             "id": "24f65d9f-aefa-58fc-9863-605fe3891969",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30267b1-a7ea-45cd-99a8-6b0e6ddbc395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c30267b1-a7ea-45cd-99a8-6b0e6ddbc395.jpg?1",
             "name": "Thragtusk",
             "text": "When Thragtusk enters the battlefield, you gain 5 life.\nWhen Thragtusk leaves the battlefield, create a 3/3 green Beast creature token.",
             "colours": [
@@ -12500,7 +12500,7 @@
         },
         {
             "id": "e53de842-9b7e-519e-a330-f0d79822d6dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a42d3fb-fc5b-4b8e-bc23-167bc21b5194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a42d3fb-fc5b-4b8e-bc23-167bc21b5194.jpg?1",
             "name": "Time of Need",
             "text": "Search your library for a legendary creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -12532,7 +12532,7 @@
         },
         {
             "id": "0c425aeb-8d8c-5fe7-9f2a-c36100fe1706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57010ba9-52be-484d-9976-7576c4ce48d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57010ba9-52be-484d-9976-7576c4ce48d0.jpg?1",
             "name": "Abrupt Decay",
             "text": "This spell can't be countered.\nDestroy target nonland permanent with converted mana cost 3 or less.",
             "colours": [
@@ -12566,7 +12566,7 @@
         },
         {
             "id": "c9b6781a-b2b6-514b-9316-138c2e6004f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0652f9e2-ba2a-4c0a-bbfc-9b00ee5d28d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0652f9e2-ba2a-4c0a-bbfc-9b00ee5d28d4.jpg?1",
             "name": "Arcades, the Strategist",
             "text": "Flying, vigilance\nWhenever a creature with defender enters the battlefield under your control, draw a card.\nEach creature you control with defender assigns combat damage equal to its toughness rather than its power and can attack as though it didn't have defender.",
             "colours": [
@@ -12607,7 +12607,7 @@
         },
         {
             "id": "2d4acc41-7e5a-5426-8ea3-b7e9fdfbbf09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9445d57a-da77-4456-9e69-c898c4d57853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9445d57a-da77-4456-9e69-c898c4d57853.jpg?1",
             "name": "Bloodbraid Elf",
             "text": "Haste\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",
             "colours": [
@@ -12644,7 +12644,7 @@
         },
         {
             "id": "541100e5-1d65-5cf0-8a8a-fe02b86a82d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b8521e-8706-4480-9a47-9600a015cc96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b8521e-8706-4480-9a47-9600a015cc96.jpg?1",
             "name": "Cloudshredder Sliver",
             "text": "Sliver creatures you control have flying and haste.",
             "colours": [
@@ -12680,7 +12680,7 @@
         },
         {
             "id": "f09edfb1-ab7c-543d-bcb4-9ce8e6b1a50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc894fb3-011c-441c-8843-34d84b4115ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc894fb3-011c-441c-8843-34d84b4115ef.jpg?1",
             "name": "Consuming Aberration",
             "text": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
             "colours": [
@@ -12716,7 +12716,7 @@
         },
         {
             "id": "a1e0cbef-8429-5a9c-8df8-db3cf2483b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2392b542-5ae6-4d0e-808c-734f1d06afa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2392b542-5ae6-4d0e-808c-734f1d06afa4.jpg?1",
             "name": "Dovin's Veto",
             "text": "This spell can't be countered.\nCounter target noncreature spell.",
             "colours": [
@@ -12750,7 +12750,7 @@
         },
         {
             "id": "f906e52a-6fb1-5a57-b3a3-f2c68569f46a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2212c653-0daa-4c7a-86fc-493d49db210a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2212c653-0daa-4c7a-86fc-493d49db210a.jpg?1",
             "name": "Epic Experiment",
             "text": "Exile the top X cards of your library. You may cast instant and sorcery spells with converted mana cost X or less from among them without paying their mana costs. Then put all cards exiled this way that weren't cast into your graveyard.",
             "colours": [
@@ -12784,7 +12784,7 @@
         },
         {
             "id": "226b5364-6d70-53dc-86ca-297b8be7cd5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e8bb8-fa07-4858-aafb-7eab7f01ddae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4e8bb8-fa07-4858-aafb-7eab7f01ddae.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "Flying\nWhenever you cast an instant or sorcery spell that targets a creature you control, exile that card instead of putting it into your graveyard as it resolves. If you do, return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -12822,7 +12822,7 @@
         },
         {
             "id": "1a946674-d53e-51bd-9ff7-12855fc607f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dba110-0319-4c64-8a96-539627e315ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43dba110-0319-4c64-8a96-539627e315ad.jpg?1",
             "name": "Grenzo, Dungeon Warden",
             "text": "Grenzo, Dungeon Warden enters the battlefield with X +1/+1 counters on it.\n{2}: Put the bottom card of your library into your graveyard. If it's a creature card with power less than or equal to Grenzo's power, put it onto the battlefield.",
             "colours": [
@@ -12861,7 +12861,7 @@
         },
         {
             "id": "9ae19325-489a-5942-8fa3-55672a94d878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcba497e-14de-4977-9e5a-0533b6b0de60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcba497e-14de-4977-9e5a-0533b6b0de60.jpg?1",
             "name": "Knight of the Reliquary",
             "text": "Knight of the Reliquary gets +1/+1 for each land card in your graveyard.\n{T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -12898,7 +12898,7 @@
         },
         {
             "id": "76f40a40-90a5-5581-a950-23c439a17594",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bee8ea6-8903-4bed-977b-b6c2cd0126f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bee8ea6-8903-4bed-977b-b6c2cd0126f9.jpg?1",
             "name": "Lavinia, Azorius Renegade",
             "text": "Each opponent can't cast noncreature spells with converted mana cost greater than the number of lands that player controls.\nWhenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.",
             "colours": [
@@ -12937,7 +12937,7 @@
         },
         {
             "id": "c6d8fdc7-4926-56e5-9160-931c8b9f7cad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767a344e-e2ab-462f-9da3-2e1ee8868a26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767a344e-e2ab-462f-9da3-2e1ee8868a26.jpg?1",
             "name": "Mortify",
             "text": "Destroy target creature or enchantment.",
             "colours": [
@@ -12971,7 +12971,7 @@
         },
         {
             "id": "cf43cc52-6510-5992-8346-34c54d4c59cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf17671-5323-4c84-8215-d58dd2189cdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bf17671-5323-4c84-8215-d58dd2189cdd.jpg?1",
             "name": "Prized Amalgam",
             "text": "Whenever a creature enters the battlefield, if it entered from your graveyard or you cast it from your graveyard, return Prized Amalgam from your graveyard to the battlefield tapped at the beginning of the next end step.",
             "colours": [
@@ -13007,7 +13007,7 @@
         },
         {
             "id": "98e53ca1-e089-5779-afd6-f38fd519a3c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f749c4-3a00-4a9f-b8ad-5c7c3a96e8f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f749c4-3a00-4a9f-b8ad-5c7c3a96e8f0.jpg?1",
             "name": "Qasali Pridemage",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{1}, Sacrifice Qasali Pridemage: Destroy target artifact or enchantment.",
             "colours": [
@@ -13044,7 +13044,7 @@
         },
         {
             "id": "5a048c17-1d71-58fa-b28f-2cbe416d8acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cbac09-6c0c-4c5d-be20-d558815990fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5cbac09-6c0c-4c5d-be20-d558815990fb.jpg?1",
             "name": "Rakdos Charm",
             "text": "Choose one \u2014\n\u2022 Exile all cards from target player's graveyard.\n\u2022 Destroy target artifact.\n\u2022 Each creature deals 1 damage to its controller.",
             "colours": [
@@ -13078,7 +13078,7 @@
         },
         {
             "id": "ef96122f-fce1-5e5a-b831-f84b3c05d755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b921da9a-b140-463f-aeee-6d16aaa5246c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b921da9a-b140-463f-aeee-6d16aaa5246c.jpg?1",
             "name": "Secret Plans",
             "text": "Face-down creatures you control get +0/+1.\nWhenever a permanent you control is turned face up, draw a card.",
             "colours": [
@@ -13112,7 +13112,7 @@
         },
         {
             "id": "b2e8eace-0609-5a5b-9275-358c41a9a18a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4d684a-2de8-477c-a4d5-d7ae80d62318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4d684a-2de8-477c-a4d5-d7ae80d62318.jpg?1",
             "name": "Slimefoot, the Stowaway",
             "text": "Whenever a Saproling you control dies, Slimefoot, the Stowaway deals 1 damage to each opponent and you gain 1 life.\n{4}: Create a 1/1 green Saproling creature token.",
             "colours": [
@@ -13150,7 +13150,7 @@
         },
         {
             "id": "27469bab-c643-5b4d-9420-3e37dfd26c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512f8d1-0d81-424a-a6e4-2a38411dc84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4512f8d1-0d81-424a-a6e4-2a38411dc84b.jpg?1",
             "name": "Temur Ascendancy",
             "text": "Creatures you control have haste.\nWhenever a creature with power 4 or greater enters the battlefield under your control, you may draw a card.",
             "colours": [
@@ -13186,7 +13186,7 @@
         },
         {
             "id": "83c12f56-cfb9-578b-a3d0-b4ff1f71a6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eecfbd-00c6-435c-9d16-70db2d6872a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eecfbd-00c6-435c-9d16-70db2d6872a7.jpg?1",
             "name": "Tidehollow Sculler",
             "text": "When Tidehollow Sculler enters the battlefield, target opponent reveals their hand and you choose a nonland card from it. Exile that card.\nWhen Tidehollow Sculler leaves the battlefield, return the exiled card to its owner's hand.",
             "colours": [
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "b26a773e-b282-59e0-880d-1be97ef8ce9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a7756e-2f01-4422-a370-3319fc5145fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a7756e-2f01-4422-a370-3319fc5145fe.jpg?1",
             "name": "Trygon Predator",
             "text": "Flying\nWhenever Trygon Predator deals combat damage to a player, you may destroy target artifact or enchantment that player controls.",
             "colours": [
@@ -13259,7 +13259,7 @@
         },
         {
             "id": "6468d7f6-aad6-54fe-bc3f-086240bd93cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25674e46-e15b-4fc0-9813-39b4e1c23de4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25674e46-e15b-4fc0-9813-39b4e1c23de4.jpg?1",
             "name": "Chalice of the Void",
             "text": "Chalice of the Void enters the battlefield with X charge counters on it.\nWhenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.",
             "colours": [],
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "a8b43417-fd97-5e17-8762-cba6ded7e3da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1f5bf0-14d8-4b47-8b94-8741d1cc8bd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1f5bf0-14d8-4b47-8b94-8741d1cc8bd9.jpg?1",
             "name": "Contagion Clasp",
             "text": "When Contagion Clasp enters the battlefield, put a -1/-1 counter on target creature.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -13315,7 +13315,7 @@
         },
         {
             "id": "368a54cf-91ef-5e0f-b2d7-9fd2fca56cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26d52d-7437-44cf-90b7-b536a5b8c94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd26d52d-7437-44cf-90b7-b536a5b8c94d.jpg?1",
             "name": "Cranial Plating",
             "text": "Equipped creature gets +1/+0 for each artifact you control.\n{B}{B}: Attach Cranial Plating to target creature you control.\nEquip {1}",
             "colours": [],
@@ -13347,7 +13347,7 @@
         },
         {
             "id": "0f558812-baad-5bb6-8a78-b185a8ee4344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b7bf9-4087-4235-a21e-33f52ae69b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b7bf9-4087-4235-a21e-33f52ae69b48.jpg?1",
             "name": "Crystal Shard",
             "text": "{3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}.",
             "colours": [],
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "13a9c202-2da7-5448-bba9-3769909e4848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27875258-47af-4105-9ded-56e03dcbd9e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27875258-47af-4105-9ded-56e03dcbd9e7.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2}\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {C} for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "5a79ee4d-779d-5ded-8ee4-54f6dab76946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ca366-2a43-4930-9c16-0ba72c1de3b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45ca366-2a43-4930-9c16-0ba72c1de3b8.jpg?1",
             "name": "Hedron Archive",
             "text": "{T}: Add {C}{C}.\n{2}, {T}, Sacrifice Hedron Archive: Draw two cards.",
             "colours": [],
@@ -13433,7 +13433,7 @@
         },
         {
             "id": "bf42e88c-de59-51e7-a443-d1c48d07f508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b167fef0-a3ef-4e76-bd69-51ed7501cba8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b167fef0-a3ef-4e76-bd69-51ed7501cba8.jpg?1",
             "name": "Hollow One",
             "text": "This spell costs {2} less to cast for each card you've cycled or discarded this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
             "colours": [],
@@ -13464,7 +13464,7 @@
         },
         {
             "id": "72d13d43-07fc-5374-9e81-82dd9982d3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9d8fa-2427-49fb-af69-3b2688dc8a8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b9d8fa-2427-49fb-af69-3b2688dc8a8c.jpg?1",
             "name": "Leveler",
             "text": "When Leveler enters the battlefield, exile all cards from your library.",
             "colours": [],
@@ -13495,7 +13495,7 @@
         },
         {
             "id": "97f3cf46-3249-5046-b4cf-bacf25a5ea1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e74de1-1f1f-4886-ba33-644db34df588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15e74de1-1f1f-4886-ba33-644db34df588.jpg?1",
             "name": "Manifold Key",
             "text": "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -13523,7 +13523,7 @@
         },
         {
             "id": "13050cfb-9a41-5c62-b135-e548bd131961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c88ec62-c3c9-4bb8-99f6-04c7a9d65e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c88ec62-c3c9-4bb8-99f6-04c7a9d65e45.jpg?1",
             "name": "Panharmonicon",
             "text": "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [],
@@ -13551,7 +13551,7 @@
         },
         {
             "id": "9b80359a-dec2-5f0c-a4bf-6b76346e55f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7272e1b-439b-4283-932d-e1084468c32b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7272e1b-439b-4283-932d-e1084468c32b.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.\nWhen Solemn Simulacrum dies, you may draw a card.",
             "colours": [],
@@ -13582,7 +13582,7 @@
         },
         {
             "id": "43799ab3-9790-5c4e-8bb8-53195605f242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa420ea4-93ef-44e5-ad13-c186a4451624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa420ea4-93ef-44e5-ad13-c186a4451624.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -13610,7 +13610,7 @@
         },
         {
             "id": "16d7e562-1b61-5399-85dc-a97b27606c6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b54a7-30c9-4955-8e71-7437528de18c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c92b54a7-30c9-4955-8e71-7437528de18c.jpg?1",
             "name": "Vanquisher's Banner",
             "text": "As Vanquisher's Banner enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\nWhenever you cast a creature spell of the chosen type, draw a card.",
             "colours": [],
@@ -13638,7 +13638,7 @@
         },
         {
             "id": "dd081b5e-7f60-5e89-91ee-77d1b14ce5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddf6c54-d928-42f7-b2b6-7ee58be58148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cddf6c54-d928-42f7-b2b6-7ee58be58148.jpg?1",
             "name": "Ancient Den",
             "text": "{T}: Add {W}.",
             "colours": [],
@@ -13669,7 +13669,7 @@
         },
         {
             "id": "9fd37d07-d14e-58af-b4a9-031b416a9b99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2216c70-91c2-43d5-9156-9b4f7828c821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2216c70-91c2-43d5-9156-9b4f7828c821.jpg?1",
             "name": "Arch of Orazca",
             "text": "Ascend (If you control ten or more permanents, you get the city's blessing for the rest of the game.)\n{T}: Add {C}.\n{5}, {T}: Draw a card. Activate this ability only if you have the city's blessing.",
             "colours": [],
@@ -13697,7 +13697,7 @@
         },
         {
             "id": "52d4dfe4-4f5d-50cc-98df-d386a7e56c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a29ec4-ec55-4754-b832-35b39e8b23ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a29ec4-ec55-4754-b832-35b39e8b23ae.jpg?1",
             "name": "Blighted Woodland",
             "text": "{T}: Add {C}.\n{3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -13727,7 +13727,7 @@
         },
         {
             "id": "6b07bb35-51f8-5865-a072-b5bcb57b4095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46ca7cb-4a04-4081-8834-6bc29e0762d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d46ca7cb-4a04-4081-8834-6bc29e0762d2.jpg?1",
             "name": "Bojuka Bog",
             "text": "Bojuka Bog enters the battlefield tapped.\nWhen Bojuka Bog enters the battlefield, exile all cards from target player's graveyard.\n{T}: Add {B}.",
             "colours": [],
@@ -13757,7 +13757,7 @@
         },
         {
             "id": "d2c209e7-138b-5eb5-9574-f9ae78233b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284d3ba-0542-48d7-8305-bfb2775c3674.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5284d3ba-0542-48d7-8305-bfb2775c3674.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C}.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles their library.",
             "colours": [],
@@ -13785,7 +13785,7 @@
         },
         {
             "id": "9a6845c8-278f-50cf-a3bf-13bfd919de84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f83f35-c4dc-46f0-9109-9d0d0181d9c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31f83f35-c4dc-46f0-9109-9d0d0181d9c8.jpg?1",
             "name": "Mystic Sanctuary",
             "text": "({T}: Add {U}.)\nMystic Sanctuary enters the battlefield tapped unless you control three or more other Islands.\nWhen Mystic Sanctuary enters the battlefield untapped, you may put target instant or sorcery card from your graveyard on top of your library.",
             "colours": [],
@@ -13817,7 +13817,7 @@
         },
         {
             "id": "7bf16df1-1cec-5d5c-969f-b186bbdb164f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a7ea8-aa1c-4ff9-b1f7-06452492c788.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82a7ea8-aa1c-4ff9-b1f7-06452492c788.jpg?1",
             "name": "Ramunap Ruins",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add {R}.\n{2}{R}{R}, {T}, Sacrifice a Desert: Ramunap Ruins deals 2 damage to each opponent.",
             "colours": [],
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "16c84ee9-fcc0-5d6c-a22e-df3ebf514f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10c264-c7f6-4ae3-b3ef-ff12bd7b64c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10c264-c7f6-4ae3-b3ef-ff12bd7b64c0.jpg?1",
             "name": "Wastes",
             "text": "{T}: Add {C}.",
             "colours": [],
@@ -13879,7 +13879,7 @@
         },
         {
             "id": "9940c435-2bf3-50e8-9e9b-ce3651bfb6f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7466be25-5d41-408d-90eb-6de47ea11484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7466be25-5d41-408d-90eb-6de47ea11484.jpg?1",
             "name": "Lotus Bloom",
             "text": "Suspend 3\u2014{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\n{T}, Sacrifice Lotus Bloom: Add three mana of any one color.",
             "colours": [],
@@ -13908,7 +13908,7 @@
         },
         {
             "id": "a1562632-0989-5122-b108-3cb73a6ac90e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7a7388-3f80-41c0-a042-d6b8ef3cf291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e7a7388-3f80-41c0-a042-d6b8ef3cf291.jpg?1",
             "name": "Griffin",
             "text": "",
             "colours": [
@@ -13942,7 +13942,7 @@
         },
         {
             "id": "48ab910b-8770-50e2-bd1f-1d505e07c1fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6090f44-034f-4069-a328-5c81ab774cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6090f44-034f-4069-a328-5c81ab774cea.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -13976,7 +13976,7 @@
         },
         {
             "id": "0ee365ef-02d4-580f-b535-1706b0ea5204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2144f2-d4be-419e-bfca-116cedfdf18b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2144f2-d4be-419e-bfca-116cedfdf18b.jpg?1",
             "name": "Cloud Sprite",
             "text": "",
             "colours": [
@@ -14010,7 +14010,7 @@
         },
         {
             "id": "3968de9a-3aac-5b38-8a48-51f1cdfe3f9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c532e0f-8934-4ad3-bb1a-640abe946e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c532e0f-8934-4ad3-bb1a-640abe946e10.jpg?1",
             "name": "Bat",
             "text": "",
             "colours": [
@@ -14044,7 +14044,7 @@
         },
         {
             "id": "362cdc6f-d7d0-5dca-884e-0a3e4e120508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31ce82f-6c4a-4986-be1e-032348504ad6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31ce82f-6c4a-4986-be1e-032348504ad6.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -14078,7 +14078,7 @@
         },
         {
             "id": "43524a68-f7fd-5050-8aae-65dcbc86eab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e8f429-5a66-4bcd-8a1f-69f9b79c0f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e8f429-5a66-4bcd-8a1f-69f9b79c0f5b.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -14112,7 +14112,7 @@
         },
         {
             "id": "bd17bd9c-4774-5ad1-a696-b46cfe9d4041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0197284c-3c17-438b-a46d-83131d56c768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0197284c-3c17-438b-a46d-83131d56c768.jpg?1",
             "name": "Giant",
             "text": "",
             "colours": [
@@ -14146,7 +14146,7 @@
         },
         {
             "id": "8d32e4af-d168-5a47-9b9e-4512e2063e6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234007e2-624f-42d0-af7f-9788f9f35fab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/234007e2-624f-42d0-af7f-9788f9f35fab.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -14180,7 +14180,7 @@
         },
         {
             "id": "3ef49466-2745-594c-80c3-c598fb5ef612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e8e64-7caa-4d98-8e20-0a4a20056143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f4e8e64-7caa-4d98-8e20-0a4a20056143.jpg?1",
             "name": "Kobolds of Kher Keep",
             "text": "",
             "colours": [
@@ -14214,7 +14214,7 @@
         },
         {
             "id": "f32064f0-133f-5e83-bfb8-7f7b82c1fb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e0924c-e4b7-482d-9076-1d3b8ff09e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17e0924c-e4b7-482d-9076-1d3b8ff09e9b.jpg?1",
             "name": "Ape",
             "text": "",
             "colours": [
@@ -14248,7 +14248,7 @@
         },
         {
             "id": "56407688-2fea-5806-be9d-04c0eea6ae2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -14282,7 +14282,7 @@
         },
         {
             "id": "5f62e8ff-2cc2-546b-b58f-da255e8171a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcb0668-e88c-4462-b079-34f140c0277e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbcb0668-e88c-4462-b079-34f140c0277e.jpg?1",
             "name": "Llanowar Elves",
             "text": "",
             "colours": [
@@ -14317,7 +14317,7 @@
         },
         {
             "id": "5940e002-54ac-564a-958f-4f70f7f8becb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed58cd8c-b11a-4109-b789-0eb92eaf0184.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed58cd8c-b11a-4109-b789-0eb92eaf0184.jpg?1",
             "name": "Saproling",
             "text": "",
             "colours": [
@@ -14351,7 +14351,7 @@
         },
         {
             "id": "2fc6f9fb-404d-5f5b-b6e6-d3c435749337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72daa68-0680-431c-a616-b3693fd58813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72daa68-0680-431c-a616-b3693fd58813.jpg?1",
             "name": "Assembly-Worker",
             "text": "",
             "colours": [],
@@ -14382,7 +14382,7 @@
         },
         {
             "id": "134a8ff3-eddb-5e65-9e27-ac521c0357e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e0d67-b627-4cf7-8f56-e1f0bd75cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c7e0d67-b627-4cf7-8f56-e1f0bd75cd5c.jpg?1",
             "name": "Metallic Sliver",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/UDS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UDS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b0e69425-f47f-5879-a526-5396994655d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4367bc78-0912-4abd-8edd-bc792558d01a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4367bc78-0912-4abd-8edd-bc792558d01a.jpg?1",
             "name": "Academy Rector",
             "text": "When Academy Rector is put into a graveyard from play, you may remove Academy Rector from the game. If you do, search your library for an enchantment card and put that card into play. Then shuffle your library.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b1246365-728a-5dd6-82cf-7e51d308ce99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151232e6-68cc-4cac-a532-9ade8e925961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151232e6-68cc-4cac-a532-9ade8e925961.jpg?1",
             "name": "Archery Training",
             "text": "At the beginning of your upkeep, you may put an arrow counter on Archery Training.\nEnchanted creature gains \"oc\nT: This creature deals X damage to target attacking or blocking creature, where X is the number of arrow counters on the Archery Training enchanting this creature.\"",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "83a63214-23b9-5485-b90a-5843f54c5307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d7f78e-d310-4305-942e-7839583bd893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34d7f78e-d310-4305-942e-7839583bd893.jpg?1",
             "name": "Capashen Knight",
             "text": "First strike\no1oo\nW Capashen Knight gets +1/+0 until end of turn.",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "8fc693d6-4903-500e-b1b2-23967b58405d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16665386-405e-48c9-8c69-c21b03931c2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16665386-405e-48c9-8c69-c21b03931c2f.jpg?1",
             "name": "Capashen Standard",
             "text": "Enchanted creature gets +1/+1.\no2, Sacrifice Capashen Standard: Draw a card.",
             "colours": [
@@ -142,7 +142,7 @@
         },
         {
             "id": "dc332d75-f08f-5cc7-ba42-6578c13054ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0976a193-463a-4bcb-a951-ca73347a5572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0976a193-463a-4bcb-a951-ca73347a5572.jpg?1",
             "name": "Capashen Templar",
             "text": "oo\nW Capashen Templar gets +0/+1 until end of turn.",
             "colours": [
@@ -177,7 +177,7 @@
         },
         {
             "id": "4f63c818-48ba-5556-a98c-0fb5d9deaa93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcb46d3-1ddf-4e3b-9ac7-a3fee49f04c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fcb46d3-1ddf-4e3b-9ac7-a3fee49f04c6.jpg?1",
             "name": "False Prophet",
             "text": "When False Prophet is put into a graveyard from play, remove all creatures from the game.",
             "colours": [
@@ -212,7 +212,7 @@
         },
         {
             "id": "ffbb07f0-1846-5990-b85c-1710ff1f3c72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d7a33-986d-45ad-8662-7bca80d3628d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a64d7a33-986d-45ad-8662-7bca80d3628d.jpg?1",
             "name": "Fend Off",
             "text": "Cycling o2\nTarget creature deals no combat damage this turn.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "ed459912-5954-5f82-800c-340768be09f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb830403-0832-47f7-b4b4-4f241f1b9112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb830403-0832-47f7-b4b4-4f241f1b9112.jpg?1",
             "name": "Field Surgeon",
             "text": "Tap an untapped creature you control: Prevent the next 1 damage to target creature this turn.",
             "colours": [
@@ -279,7 +279,7 @@
         },
         {
             "id": "e2759759-106b-5a0c-9d89-64df82b6f8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e7ec5-6488-483f-8020-b48e1a951f09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f55e7ec5-6488-483f-8020-b48e1a951f09.jpg?1",
             "name": "Flicker",
             "text": "Remove target nontoken permanent from the game, then return it to play under its owner's control.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "b15644b3-8da5-5938-a2e9-a62f28cfe257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6641dd2-5b9c-4089-8a71-a3a1a9c29f8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6641dd2-5b9c-4089-8a71-a3a1a9c29f8b.jpg?1",
             "name": "Jasmine Seer",
             "text": "o2o\nW, oc\nT: Reveal any number of white cards in your hand. You gain 2 life for each card revealed this way.",
             "colours": [
@@ -346,7 +346,7 @@
         },
         {
             "id": "6fdc10fc-15e9-54a9-84cf-564cf45c4960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd97150-b405-4bb5-b5a8-fceda4a45ebb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bd97150-b405-4bb5-b5a8-fceda4a45ebb.jpg?1",
             "name": "Mask of Law and Grace",
             "text": "Enchanted creature gains protection from black and protection from red.",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "85db7ad3-6d16-538c-989a-914ec7cd69cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a342c-ad80-43e4-8b2d-1c48241c52b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21a342c-ad80-43e4-8b2d-1c48241c52b1.jpg?1",
             "name": "Master Healer",
             "text": "oc\nT: Prevent the next 4 damage to target creature or player this turn.",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "aa03644e-01c9-5ef7-a2b2-ef3da6014aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0071fb-afa5-47b5-b266-2b10a4f5a98a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0071fb-afa5-47b5-b266-2b10a4f5a98a.jpg?1",
             "name": "Opalescence",
             "text": "Each other global enchantment is a creature with power and toughness each equal to its converted mana cost. It's still an enchantment.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "70df1168-6ed2-533d-abb7-1da3dec72d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243e9386-2a7f-406a-9ed3-77d4bf1b50fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243e9386-2a7f-406a-9ed3-77d4bf1b50fd.jpg?1",
             "name": "Reliquary Monk",
             "text": "When Reliquary Monk is put into a graveyard from play, destroy target artifact or enchantment.",
             "colours": [
@@ -483,7 +483,7 @@
         },
         {
             "id": "7f2288a2-7217-5cfc-b04d-6d410cb8dea9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2fe13-bbc0-42b7-bc42-3b51910ce118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fd2fe13-bbc0-42b7-bc42-3b51910ce118.jpg?1",
             "name": "Replenish",
             "text": "Return all enchantment cards from your graveyard to play. (Local enchantments with no permanent to enchant remain in your graveyard.)",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "4b5c5aa5-bbb6-5053-94a5-96134660d176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc6b744-92c7-4839-9b27-833bedb92bba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfc6b744-92c7-4839-9b27-833bedb92bba.jpg?1",
             "name": "Sanctimony",
             "text": "Whenever one of your opponents taps a mountain for mana, you may gain 1 life.",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "fc02dea7-cbcc-571f-b5ac-4af283b97939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dae0cf-9696-498c-8d28-dc8c239faec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0dae0cf-9696-498c-8d28-dc8c239faec7.jpg?1",
             "name": "Scent of Jasmine",
             "text": "Reveal any number of white cards in your hand. You gain 2 life for each card revealed this way.",
             "colours": [
@@ -579,7 +579,7 @@
         },
         {
             "id": "c3199633-3df9-5b78-8e50-b1b125b6f1cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac5162e-39ea-4f01-92eb-182fe23c1608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac5162e-39ea-4f01-92eb-182fe23c1608.jpg?1",
             "name": "Scour",
             "text": "Remove target enchantment from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "a0fac403-93a4-5014-9eba-6f4e91553686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac540c7-8b3a-4e28-96a2-d414ff613640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cac540c7-8b3a-4e28-96a2-d414ff613640.jpg?1",
             "name": "Serra Advocate",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +2/+2 until end of turn.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "d5767d51-547a-5c59-9484-a12de098657d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e1589a-ec4f-47a4-b758-ada7f49ffb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e1589a-ec4f-47a4-b758-ada7f49ffb8f.jpg?1",
             "name": "Solidarity",
             "text": "Creatures you control get +0/+5 until end of turn.",
             "colours": [
@@ -677,7 +677,7 @@
         },
         {
             "id": "ca6a3bf0-35e0-598e-a155-3d13a8e90d46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bed19fa-e497-48de-8459-030e60fdc9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bed19fa-e497-48de-8459-030e60fdc9a8.jpg?1",
             "name": "Tethered Griffin",
             "text": "Flying\nWhen you control no enchantments, sacrifice Tethered Griffin.",
             "colours": [
@@ -711,7 +711,7 @@
         },
         {
             "id": "4ae811a8-f0b3-58f6-afc6-3f784a9e1787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d4d751-50df-4d8f-a6d9-4e76797c429a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d4d751-50df-4d8f-a6d9-4e76797c429a.jpg?1",
             "name": "Tormented Angel",
             "text": "Flying",
             "colours": [
@@ -745,7 +745,7 @@
         },
         {
             "id": "ecfe3c40-785d-51b9-a0c0-475ea488f37e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c648e59-c872-4e04-b45f-2729b42410af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c648e59-c872-4e04-b45f-2729b42410af.jpg?1",
             "name": "Voice of Duty",
             "text": "Flying, protection from green",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "6805405e-49e7-549a-b207-e4cfbf16a70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3d5a10-6d4b-4383-b400-7323f2b4670e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3d5a10-6d4b-4383-b400-7323f2b4670e.jpg?1",
             "name": "Voice of Reason",
             "text": "Flying, protection from blue",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "aa3cee08-9c8b-5d02-a476-a1778cc11375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f159193-fcf8-437c-b14a-06718a446a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f159193-fcf8-437c-b14a-06718a446a5c.jpg?1",
             "name": "Wall of Glare",
             "text": "(Walls can't attack.)\nWall of Glare may block any number of creatures each combat.",
             "colours": [
@@ -847,7 +847,7 @@
         },
         {
             "id": "dc32ed0e-137c-5c99-9434-bf2dc1e293a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae591d2-b9d3-4bc5-bcec-5d3d79a13b41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ae591d2-b9d3-4bc5-bcec-5d3d79a13b41.jpg?1",
             "name": "Aura Thief",
             "text": "Flying\nWhen Aura Thief is put into a graveyard from play, you gain control of all enchantments. (You don't get to move local enchantments.)",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "248776ce-5d76-577a-a5a8-fba6ee8f4220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949c5a7-9656-466a-add8-1800973fefee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949c5a7-9656-466a-add8-1800973fefee.jpg?1",
             "name": "Blizzard Elemental",
             "text": "Flying\no3oo\nU Untap Blizzard Elemental.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "efaed608-df00-5b44-8b21-27dd3b1070cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6e5575-b004-417f-9366-6ba7840a79e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f6e5575-b004-417f-9366-6ba7840a79e7.jpg?1",
             "name": "Brine Seer",
             "text": "o2o\nU, oc\nT: Reveal any number of blue cards in your hand. Counter target spell unless its controller pays o1 for each card revealed this way.",
             "colours": [
@@ -950,7 +950,7 @@
         },
         {
             "id": "53e68e3b-07a0-52a9-8397-928c5a92c8c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/002cf7d8-3fc2-48eb-a727-a1ce5a049665.jpg?1",
             "name": "Bubbling Beebles",
             "text": "Bubbling Beebles is unblockable as long as defending player controls an enchantment.",
             "colours": [
@@ -984,7 +984,7 @@
         },
         {
             "id": "ead8866e-fa99-559b-85e3-05db07f24bbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf280f4-74a1-4e6f-aec6-1852f04204e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf280f4-74a1-4e6f-aec6-1852f04204e4.jpg?1",
             "name": "Disappear",
             "text": "oo\nU Return enchanted creature and Disappear to their owners' hands.",
             "colours": [
@@ -1018,7 +1018,7 @@
         },
         {
             "id": "90f4b30a-abf7-5114-bbb6-ac5f567c9b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d8ce9-f8c8-45ad-b74c-97fba0e2982e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f6d8ce9-f8c8-45ad-b74c-97fba0e2982e.jpg?1",
             "name": "Donate",
             "text": "Target player gains control of target permanent you control.",
             "colours": [
@@ -1050,7 +1050,7 @@
         },
         {
             "id": "cad6361a-7aa0-565d-9e7d-87a5d4d9cc18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660fb109-dd65-4410-99b9-a2a14f8ea202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660fb109-dd65-4410-99b9-a2a14f8ea202.jpg?1",
             "name": "Fatigue",
             "text": "Target player skips his or her next draw step.",
             "colours": [
@@ -1082,7 +1082,7 @@
         },
         {
             "id": "02075eb8-fb7e-5f5a-8bb0-3e378f21736c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd46bfa-ca09-422f-9891-db9399fa2d3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd46bfa-ca09-422f-9891-db9399fa2d3a.jpg?1",
             "name": "Fledgling Osprey",
             "text": "Fledgling Osprey gains flying as long as it's enchanted.",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "bc0a51e2-217b-5835-bf8f-af1704db43f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f98e703-a0d3-497f-840a-aa026b02d47f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f98e703-a0d3-497f-840a-aa026b02d47f.jpg?1",
             "name": "Illuminated Wings",
             "text": "Enchanted creature gains flying.\no2, Sacrifice Illuminated Wings: Draw a card.",
             "colours": [
@@ -1150,7 +1150,7 @@
         },
         {
             "id": "3a1be31b-5f4a-5609-85a5-224f5c31654b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cbc36d-3391-4086-9b81-fb1ef0b83046.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70cbc36d-3391-4086-9b81-fb1ef0b83046.jpg?1",
             "name": "Iridescent Drake",
             "text": "Flying\nWhen Iridescent Drake comes into play, return target enchant creature card from a graveyard to play enchanting Iridescent Drake. (You control that enchantment.)",
             "colours": [
@@ -1184,7 +1184,7 @@
         },
         {
             "id": "5532e74f-4e11-5103-928b-4fd9c365edff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442bc3ba-00b3-4616-a5b2-55524ff8a736.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/442bc3ba-00b3-4616-a5b2-55524ff8a736.jpg?1",
             "name": "Kingfisher",
             "text": "Flying\nWhen Kingfisher is put into a graveyard from play, draw a card.",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "eb05dd87-7c42-52ec-bb62-e33ead1e8660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ffd83-b5c9-46b4-bc5a-172ca34ddc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e9ffd83-b5c9-46b4-bc5a-172ca34ddc79.jpg?1",
             "name": "Mental Discipline",
             "text": "o1o\nU, Choose and discard a card from your hand: Draw a card.",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "7734c4b3-e710-5a38-82d3-eb27e266b2e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa941f17-1b81-4017-90ae-4466eba8da2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa941f17-1b81-4017-90ae-4466eba8da2f.jpg?1",
             "name": "Metathran Elite",
             "text": "Metathran Elite is unblockable as long as it's enchanted.",
             "colours": [
@@ -1285,7 +1285,7 @@
         },
         {
             "id": "8f2a7b23-7447-52a7-a94e-29e4004b20b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650d40d0-78ec-4b6e-8ea0-28d43ce175d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650d40d0-78ec-4b6e-8ea0-28d43ce175d5.jpg?1",
             "name": "Metathran Soldier",
             "text": "Metathran Soldier is unblockable.",
             "colours": [
@@ -1320,7 +1320,7 @@
         },
         {
             "id": "197c45bf-2cb1-5003-843e-e5c75c5f0211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95be2701-af7c-483e-8165-e8bd4b2774ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95be2701-af7c-483e-8165-e8bd4b2774ed.jpg?1",
             "name": "Opposition",
             "text": "Tap an untapped creature you control: Tap target artifact, creature, or land.",
             "colours": [
@@ -1352,7 +1352,7 @@
         },
         {
             "id": "fbc49538-3f1c-5b61-bb3a-cd35f9de88f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f9849-a4bd-4501-9473-79345c751701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f7f9849-a4bd-4501-9473-79345c751701.jpg?1",
             "name": "Private Research",
             "text": "At the beginning of your upkeep, you may put a page counter on Private Research.\nWhen enchanted creature is put into a graveyard, draw a card for each page counter on Private Research.",
             "colours": [
@@ -1386,7 +1386,7 @@
         },
         {
             "id": "408d9636-1938-5a77-b7e2-d9702123db70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62019ac4-a5a1-4a8c-bfb4-96e818949bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62019ac4-a5a1-4a8c-bfb4-96e818949bbe.jpg?1",
             "name": "Quash",
             "text": "Counter target instant or sorcery spell. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -1418,7 +1418,7 @@
         },
         {
             "id": "ebe7fab8-a1bd-5bc9-9136-46297176e4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee6480c-7697-47e2-893b-ca88c0ab3376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ee6480c-7697-47e2-893b-ca88c0ab3376.jpg?1",
             "name": "Rayne, Academy Chancellor",
             "text": "Whenever you or a permanent you control is the target of a spell or ability controlled by one of your opponents, you may draw a card, and if Rayne, Academy Chancellor is enchanted, you may draw another card.",
             "colours": [
@@ -1455,7 +1455,7 @@
         },
         {
             "id": "f176cf58-7abc-5696-9517-6a1c3df371a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fc979e-7758-4310-9259-659e9ced2c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63fc979e-7758-4310-9259-659e9ced2c7f.jpg?1",
             "name": "Rescue",
             "text": "Return target permanent you control to its owner's hand.",
             "colours": [
@@ -1487,7 +1487,7 @@
         },
         {
             "id": "68b0be19-4739-57d2-a026-b54cfa740d3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117bf8d-23ec-4f9d-99d0-3a990c5f7075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117bf8d-23ec-4f9d-99d0-3a990c5f7075.jpg?1",
             "name": "Scent of Brine",
             "text": "Reveal any number of blue cards in your hand. Counter target spell unless its controller pays o1 for each card revealed this way.",
             "colours": [
@@ -1519,7 +1519,7 @@
         },
         {
             "id": "23ed8ac1-00ec-5491-a4ce-cccd9c3c41df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f3c70-e2c3-479e-8d22-2fd1429e9857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f3c70-e2c3-479e-8d22-2fd1429e9857.jpg?1",
             "name": "Sigil of Sleep",
             "text": "Whenever enchanted creature deals damage to a player, return target creature that player controls to its owner's hand.",
             "colours": [
@@ -1553,7 +1553,7 @@
         },
         {
             "id": "87fed47f-c822-51ed-abe4-699b5ac69acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e7f64-e32c-4242-aae9-45d50b89ff1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769e7f64-e32c-4242-aae9-45d50b89ff1f.jpg?1",
             "name": "Telepathic Spies",
             "text": "When Telepathic Spies comes into play, look at target opponent's hand.",
             "colours": [
@@ -1588,7 +1588,7 @@
         },
         {
             "id": "87cd283a-b7d3-5eef-b2d2-7e40ee910b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bb9695-a8b0-47b4-9a03-11d559412f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07bb9695-a8b0-47b4-9a03-11d559412f33.jpg?1",
             "name": "Temporal Adept",
             "text": "o\nUo\nUo\nU, oc\nT: Return target permanent to its owner's hand.",
             "colours": [
@@ -1623,7 +1623,7 @@
         },
         {
             "id": "3a20c68d-bfa5-53b3-b115-317865da6c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b23b9-4569-40ff-988f-ad1d5d3fe573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6b23b9-4569-40ff-988f-ad1d5d3fe573.jpg?1",
             "name": "Thieving Magpie",
             "text": "Flying\nWhenever Thieving Magpie deals damage to one of your opponents, you draw a card.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "58ddf2a3-1810-5ebd-a8be-2e0957b29bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613694aa-b169-400d-8063-2b83d8303611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613694aa-b169-400d-8063-2b83d8303611.jpg?1",
             "name": "Treachery",
             "text": "When Treachery comes into play, untap up to five lands.\nYou control enchanted creature.",
             "colours": [
@@ -1691,7 +1691,7 @@
         },
         {
             "id": "50d8ee20-8fe0-5396-97f4-af34d38f95a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cc1f6-9897-4de4-8e94-40cbe2d962a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7cc1f6-9897-4de4-8e94-40cbe2d962a2.jpg?1",
             "name": "Apprentice Necromancer",
             "text": "o\nB, oc\nT, Sacrifice Apprentice Necromancer: Return target creature card from your graveyard to play. That creature gains haste. At end of turn, sacrifice it. (The creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -1726,7 +1726,7 @@
         },
         {
             "id": "7b6abdfe-6aff-5d80-949c-bfdb2b7cbca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb615b-249d-433f-a521-8310e8784b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb615b-249d-433f-a521-8310e8784b5d.jpg?1",
             "name": "Attrition",
             "text": "o\nB, Sacrifice a creature: Destroy target nonblack creature.",
             "colours": [
@@ -1758,7 +1758,7 @@
         },
         {
             "id": "9a2d2c91-3391-59a1-a7e4-930b050ba541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d4c858-5a11-485d-a514-12a6d80459f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7d4c858-5a11-485d-a514-12a6d80459f0.jpg?1",
             "name": "Body Snatcher",
             "text": "When Body Snatcher comes into play, you may choose and discard a creature card from your hand. If you don't, remove Body Snatcher from the game.\nWhen Body Snatcher is put into a graveyard from play, remove Body Snatcher from the game and return target creature card from your graveyard to play.",
             "colours": [
@@ -1793,7 +1793,7 @@
         },
         {
             "id": "d1025350-d221-5446-9d6a-e070aafa9428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca76614-78a1-4535-9162-70469d1e8a13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca76614-78a1-4535-9162-70469d1e8a13.jpg?1",
             "name": "Bubbling Muck",
             "text": "Until end of turn, whenever a player taps a swamp for mana, it produces an additional o\nB.",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "35f68312-c536-5df5-bf6d-582192a41bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847340fb-9251-4439-b33b-f86bff507dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847340fb-9251-4439-b33b-f86bff507dcd.jpg?1",
             "name": "Carnival of Souls",
             "text": "Whenever a creature comes into play, you lose 1 life and add o\nB to your mana pool.",
             "colours": [
@@ -1857,7 +1857,7 @@
         },
         {
             "id": "479fa3eb-332e-5ba4-a717-47fd7a349f10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec7c917-b254-4643-afc2-b6387f267469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec7c917-b254-4643-afc2-b6387f267469.jpg?1",
             "name": "Chime of Night",
             "text": "When Chime of Night is put into a graveyard from play, destroy target nonblack creature.",
             "colours": [
@@ -1891,7 +1891,7 @@
         },
         {
             "id": "234fe6d9-63c1-5185-8d9f-97a8d5bc655c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49125cfc-dbae-4543-9d2d-4cc78f45ce9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49125cfc-dbae-4543-9d2d-4cc78f45ce9a.jpg?1",
             "name": "Disease Carriers",
             "text": "When Disease Carriers is put into a graveyard from play, target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -1925,7 +1925,7 @@
         },
         {
             "id": "49b61440-2740-580a-8a66-06627f8c32be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a25a472-495e-4062-b66f-c37f148b494f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a25a472-495e-4062-b66f-c37f148b494f.jpg?1",
             "name": "Dying Wail",
             "text": "When enchanted creature is put into a graveyard from play, target player chooses and discards two cards from his or her hand.",
             "colours": [
@@ -1959,7 +1959,7 @@
         },
         {
             "id": "a96218d1-4648-5e55-be1b-4746b84db1a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd48dac-0a1a-49c4-8daf-11972b990454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd48dac-0a1a-49c4-8daf-11972b990454.jpg?1",
             "name": "Encroach",
             "text": "Look at target player's hand and choose a nonbasic land card from it. That player discards that card.",
             "colours": [
@@ -1991,7 +1991,7 @@
         },
         {
             "id": "473abae9-677b-5b72-8941-74a34d7c466b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fad4607-c11d-4407-b5fa-bd34f74e41b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fad4607-c11d-4407-b5fa-bd34f74e41b3.jpg?1",
             "name": "Eradicate",
             "text": "Remove target nonblack creature from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "68c91cdd-1367-5443-91de-9126593cc117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927eed13-510b-4b06-811d-91a6a069cb8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927eed13-510b-4b06-811d-91a6a069cb8c.jpg?1",
             "name": "Festering Wound",
             "text": "At the beginning of your upkeep, you may put an infection counter on Festering Wound.\nAt the beginning of the upkeep of enchanted creature's controller, Festering Wound deals X damage to that player, where X is the number of infection counters on Festering Wound.",
             "colours": [
@@ -2057,7 +2057,7 @@
         },
         {
             "id": "4e4d0bdb-6401-506b-9114-fdbda54ceb5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d082d8-f401-47ad-845c-77776ee647ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97d082d8-f401-47ad-845c-77776ee647ba.jpg?1",
             "name": "Lurking Jackals",
             "text": "When one of your opponents has 10 life or less, if Lurking Jackals is an enchantment, it becomes a 3/2 Hound creature.",
             "colours": [
@@ -2089,7 +2089,7 @@
         },
         {
             "id": "722f00ed-823f-5a4a-9e0f-85a710f7cd30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2262467-1354-4aec-84a2-21916c44b9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2262467-1354-4aec-84a2-21916c44b9ef.jpg?1",
             "name": "Nightshade Seer",
             "text": "o2o\nB, oc\nT: Reveal any number of black cards in your hand. Target creature gets -X/-X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "fa43dfc5-37d3-5c33-942a-b95eba8486e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/571058b0-7e10-4259-8db9-5c8b78c1e13d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/571058b0-7e10-4259-8db9-5c8b78c1e13d.jpg?1",
             "name": "Phyrexian Monitor",
             "text": "oo\nB Regenerate Phyrexian Monitor.",
             "colours": [
@@ -2159,7 +2159,7 @@
         },
         {
             "id": "93624615-209a-57c3-8520-0b68b9440910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a02d67-5931-49ae-a28e-57aa6f9c7f83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45a02d67-5931-49ae-a28e-57aa6f9c7f83.jpg?1",
             "name": "Phyrexian Negator",
             "text": "Trample\nWhenever Phyrexian Negator is dealt damage, sacrifice a permanent for each 1 damage dealt to it.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "ffd0eb74-20c8-50b8-9256-3a4858c3d652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9cebd8-aa3f-4e22-8d15-d4b7bad355e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9cebd8-aa3f-4e22-8d15-d4b7bad355e4.jpg?1",
             "name": "Plague Dogs",
             "text": "When Plague Dogs is put into a graveyard from play, all creatures get -1/-1 until end of turn.\no2, Sacrifice Plague Dogs: Draw a card.",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "dc2ba3f0-9754-5d94-bc01-167deccf2e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1678d911-1456-4631-a2f4-d7de4906644b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1678d911-1456-4631-a2f4-d7de4906644b.jpg?1",
             "name": "Rapid Decay",
             "text": "Cycling o2\nRemove from the game up to three target cards in a single graveyard.",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "3312ed41-aab2-5fe7-bd5b-f84ee7ba0b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9185188-9a32-4ccd-8f33-b0c299901d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9185188-9a32-4ccd-8f33-b0c299901d81.jpg?1",
             "name": "Ravenous Rats",
             "text": "When Ravenous Rats comes into play, target opponent chooses and discards a card from his or her hand.",
             "colours": [
@@ -2296,7 +2296,7 @@
         },
         {
             "id": "c555a96d-c96d-577f-8251-5219b508837a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582468a6-0ea9-411e-a694-13977d47c877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/582468a6-0ea9-411e-a694-13977d47c877.jpg?1",
             "name": "Scent of Nightshade",
             "text": "Reveal any number of black cards in your hand. Target creature gets -X/-X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -2328,7 +2328,7 @@
         },
         {
             "id": "972d8bfe-fe9b-55f6-8ed4-2eb33858b26d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cd2771-9681-4b4a-8c2c-a2ffd7361c35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80cd2771-9681-4b4a-8c2c-a2ffd7361c35.jpg?1",
             "name": "Skittering Horror",
             "text": "When you play a creature spell, sacrifice Skittering Horror.",
             "colours": [
@@ -2363,7 +2363,7 @@
         },
         {
             "id": "fa899bf9-0d6b-5384-bce5-8cc02fd6854f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00522c4b-4e64-4403-96b1-df41afbe255f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00522c4b-4e64-4403-96b1-df41afbe255f.jpg?1",
             "name": "Slinking Skirge",
             "text": "Flying\no2, Sacrifice Slinking Skirge: Draw a card.",
             "colours": [
@@ -2398,7 +2398,7 @@
         },
         {
             "id": "021d9bf0-3f3c-57a4-9959-5fac926f4cba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417a9db-5101-4fe1-84b7-283ca1fd42e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9417a9db-5101-4fe1-84b7-283ca1fd42e5.jpg?1",
             "name": "Soul Feast",
             "text": "Target player loses 4 life and you gain 4 life.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "c83b5d41-049f-572f-ab88-a2d9b41f7c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47793a3-9a98-4733-8d6a-2fb1a67b15c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47793a3-9a98-4733-8d6a-2fb1a67b15c9.jpg?1",
             "name": "Squirming Mass",
             "text": "Squirming Mass can't be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -2464,7 +2464,7 @@
         },
         {
             "id": "e79ee2a5-39ce-5a86-92a2-8d8a7c3ea692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e37889-7dc0-476b-8b99-8f06881d352c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e37889-7dc0-476b-8b99-8f06881d352c.jpg?1",
             "name": "Twisted Experiment",
             "text": "Enchanted creature gets +3/-1.",
             "colours": [
@@ -2498,7 +2498,7 @@
         },
         {
             "id": "3726bacc-49c6-5846-b034-a0fc292d778c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86901bf2-7722-43f8-b879-7a30630371fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86901bf2-7722-43f8-b879-7a30630371fa.jpg?1",
             "name": "Yawgmoth's Bargain",
             "text": "Skip your draw step.\nPay 1 life: Draw a card.",
             "colours": [
@@ -2530,7 +2530,7 @@
         },
         {
             "id": "aff51fd7-2955-5b77-afc2-a7e77b86f9eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a09917-50ce-4b51-a5cf-e28e88a45762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a09917-50ce-4b51-a5cf-e28e88a45762.jpg?1",
             "name": "Aether Sting",
             "text": "Whenever one of your opponents plays a creature spell, \u00c6ther Sting deals 1 damage to that player.",
             "colours": [
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "81b9f2ad-5e89-5c54-89e2-193fc3bb79ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9320f3d8-0e51-43d0-aedb-bfed771101e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9320f3d8-0e51-43d0-aedb-bfed771101e9.jpg?1",
             "name": "Bloodshot Cyclops",
             "text": "oc\nT, Sacrifice a creature: Bloodshot Cyclops deals X damage to target creature or player, where X is the sacrificed creature's power.",
             "colours": [
@@ -2597,7 +2597,7 @@
         },
         {
             "id": "0786d784-77e8-5831-8b81-a7c689e3f11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96e7522-e0bc-4e23-8e4b-40a0c28ea986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d96e7522-e0bc-4e23-8e4b-40a0c28ea986.jpg?1",
             "name": "Cinder Seer",
             "text": "o2o\nR, oc\nT: Reveal any number of red cards in your hand. Cinder Seer deals X damage to target creature or player, where X is the number of cards revealed this way.",
             "colours": [
@@ -2632,7 +2632,7 @@
         },
         {
             "id": "d3775406-1442-5c88-8acd-5719ee100085",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d68eb62-9f86-4c85-8696-46a248c744ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d68eb62-9f86-4c85-8696-46a248c744ff.jpg?1",
             "name": "Colos Yearling",
             "text": "Mountainwalk (This creature is unblockable as long as defending player controls a mountain.)\noo\nR Colos Yearling gets +1/+0 until end of turn.",
             "colours": [
@@ -2667,7 +2667,7 @@
         },
         {
             "id": "9b7f4929-3417-5e1f-aa57-0aaa8643c7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f37e36-c004-4b89-a668-5cd984c59019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f37e36-c004-4b89-a668-5cd984c59019.jpg?1",
             "name": "Covetous Dragon",
             "text": "Flying\nWhen you control no artifacts, sacrifice Covetous Dragon.",
             "colours": [
@@ -2701,7 +2701,7 @@
         },
         {
             "id": "3dd5a073-184c-5165-a54a-2e70e86aff56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a511f9df-b53b-4fea-87cd-9f18f6833f92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a511f9df-b53b-4fea-87cd-9f18f6833f92.jpg?1",
             "name": "Flame Jet",
             "text": "Cycling o2\nFlame Jet deals 3 damage to target player.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "39ae221e-1f7d-546b-b707-6102127768f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c7635d-98b2-4505-9153-d7e9e53ea16d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c7635d-98b2-4505-9153-d7e9e53ea16d.jpg?1",
             "name": "Goblin Berserker",
             "text": "First strike; haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -2768,7 +2768,7 @@
         },
         {
             "id": "203a53aa-d597-5a16-a185-320c90da448b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac067eb8-427f-4bfa-b392-0bb41ac8370e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac067eb8-427f-4bfa-b392-0bb41ac8370e.jpg?1",
             "name": "Goblin Festival",
             "text": "o2: Goblin Festival deals 1 damage to target creature or player. Flip a coin. If you lose the flip, choose one of your opponents. That player gains control of Goblin Festival.",
             "colours": [
@@ -2800,7 +2800,7 @@
         },
         {
             "id": "42b8feca-0c85-5161-abc9-9b83eb732105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eab0544-9c0b-4365-86bb-bc0c3e9d87ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eab0544-9c0b-4365-86bb-bc0c3e9d87ce.jpg?1",
             "name": "Goblin Gardener",
             "text": "When Goblin Gardener is put into a graveyard from play, destroy target land.",
             "colours": [
@@ -2834,7 +2834,7 @@
         },
         {
             "id": "3d8dbeee-839a-5752-8d6d-e2efd2cba48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9.jpg?1",
             "name": "Goblin Marshal",
             "text": "Echo\nWhenever Goblin Marshal comes into play or is put into a graveyard from play, put two 1/1 red Goblin creature tokens into play.",
             "colours": [
@@ -2869,7 +2869,7 @@
         },
         {
             "id": "4d073f26-79a5-5637-9eeb-ca71b58b4383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124070d9-c362-4053-a405-9438b1cfac02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/124070d9-c362-4053-a405-9438b1cfac02.jpg?1",
             "name": "Goblin Masons",
             "text": "When Goblin Masons is put into a graveyard from play, destroy target Wall.",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "5e342d15-15f4-5f7f-93ef-a89c524d8d03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0676d39e-229f-480b-874e-ff0cb8e335d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0676d39e-229f-480b-874e-ff0cb8e335d8.jpg?1",
             "name": "Hulking Ogre",
             "text": "Hulking Ogre can't block.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "6ee50c72-eb06-5f61-9d2f-4f5e7a4f666b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39c8166-9e63-4b02-af7b-4caf14ca73ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d39c8166-9e63-4b02-af7b-4caf14ca73ac.jpg?1",
             "name": "Impatience",
             "text": "At the end of each player's turn, if that player didn't play a spell that turn, Impatience deals 2 damage to him or her.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "4b5e9fad-ba3f-522a-baef-142d311eebd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f4775-29b1-4ed1-94d9-db5930a35157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/854f4775-29b1-4ed1-94d9-db5930a35157.jpg?1",
             "name": "Incendiary",
             "text": "At the beginning of your upkeep, you may put a fuse counter on Incendiary.\nWhen enchanted creature is put into a graveyard, Incendiary deals X damage to target creature or player, where X is the number of fuse counters on Incendiary.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "ae80cc9e-e6bc-55fe-aba5-2d238c27e72d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eee4d2-fe28-418e-a81f-73a66e831b05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eee4d2-fe28-418e-a81f-73a66e831b05.jpg?1",
             "name": "Keldon Champion",
             "text": "Echo; haste (This creature may attack and oc\nT the turn it comes under your control.)\nWhen Keldon Champion comes into play, it deals 3 damage to target player.",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "cedb4186-e146-5a03-96a6-7f86e2f85189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18cdf4d-42ce-4f2d-8b8f-8cf52a1b8db4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18cdf4d-42ce-4f2d-8b8f-8cf52a1b8db4.jpg?1",
             "name": "Keldon Vandals",
             "text": "Echo\nWhen Keldon Vandals comes into play, destroy target artifact.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "a154e9a0-6e85-5a25-acd2-2e8e1d627cd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ddc0dc-8783-4659-bbbd-db6698843b47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0ddc0dc-8783-4659-bbbd-db6698843b47.jpg?1",
             "name": "Landslide",
             "text": "Sacrifice any number of mountains. Landslide deals that much damage to target player.",
             "colours": [
@@ -3105,7 +3105,7 @@
         },
         {
             "id": "9ac067eb-03a0-588e-80ff-684a6ff4b1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b21b2f4-a05d-477b-8a39-632f7ff7f5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b21b2f4-a05d-477b-8a39-632f7ff7f5f5.jpg?1",
             "name": "Mark of Fury",
             "text": "Enchanted creature gains haste. (It may attack and oc\nT the turn it comes under your control.)\nAt end of turn, return Mark of Fury to its owner's hand.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "b7ecdd90-a948-5774-b219-c7c5d41ece15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f335d43-cacb-40ad-93c1-9a861e9f66c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f335d43-cacb-40ad-93c1-9a861e9f66c7.jpg?1",
             "name": "Reckless Abandon",
             "text": "As an additional cost to play Reckless Abandon, sacrifice a creature.\nReckless Abandon deals 4 damage to target creature or player.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "887e10bf-833a-54dd-ba85-e1078e9eb99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f3c78e-16c0-4fbc-8ef4-fbf610f9d464.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f3c78e-16c0-4fbc-8ef4-fbf610f9d464.jpg?1",
             "name": "Repercussion",
             "text": "Whenever a creature is dealt damage, Repercussion deals that much damage to that creature's controller.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "194117c1-4eb2-5516-bf36-886bf5758e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c030eca0-bc5f-403b-8600-1f295fc85fee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c030eca0-bc5f-403b-8600-1f295fc85fee.jpg?1",
             "name": "Scent of Cinder",
             "text": "Reveal any number of red cards in your hand. Scent of Cinder deals X damage to target creature or player, where X is the number of cards revealed this way.",
             "colours": [
@@ -3235,7 +3235,7 @@
         },
         {
             "id": "03ec0b47-023e-53b9-bd9e-770dc0029d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f7251-f71a-47d2-a779-c898d94e807c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2f7251-f71a-47d2-a779-c898d94e807c.jpg?1",
             "name": "Sowing Salt",
             "text": "Remove target nonbasic land from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -3267,7 +3267,7 @@
         },
         {
             "id": "19e7a911-da90-52e2-b217-b17e15be9400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcce5fd-9efb-42fa-9cd6-ed45d8ee46d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fcce5fd-9efb-42fa-9cd6-ed45d8ee46d7.jpg?1",
             "name": "Trumpet Blast",
             "text": "Attacking creatures get +2/+0 until end of turn.",
             "colours": [
@@ -3299,7 +3299,7 @@
         },
         {
             "id": "d0975290-baa2-5436-9b29-eb6f78e39fa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c070f12-0342-48d5-ab0e-4fc4701c3669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c070f12-0342-48d5-ab0e-4fc4701c3669.jpg?1",
             "name": "Wake of Destruction",
             "text": "Destroy target land and all lands with the same name as that land.",
             "colours": [
@@ -3331,7 +3331,7 @@
         },
         {
             "id": "ecb639d4-91da-59f4-aecd-25fcd9d1ed6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d39f746-7b82-476a-9774-3375debb47bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d39f746-7b82-476a-9774-3375debb47bd.jpg?1",
             "name": "Wild Colos",
             "text": "Haste (This creature may attack and oc\nT the turn it comes under your control.)",
             "colours": [
@@ -3366,7 +3366,7 @@
         },
         {
             "id": "e7f5f4d6-21d3-5f91-8072-0b799770283c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49651dd4-a489-42d3-b4eb-51f5353b334e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49651dd4-a489-42d3-b4eb-51f5353b334e.jpg?1",
             "name": "Ancient Silverback",
             "text": "oo\nG Regenerate Ancient Silverback.",
             "colours": [
@@ -3400,7 +3400,7 @@
         },
         {
             "id": "8d56d218-631b-51d4-9f5a-820ae43fdc2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2523c403-0025-48c7-8ff1-e66ca27ee585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2523c403-0025-48c7-8ff1-e66ca27ee585.jpg?1",
             "name": "Compost",
             "text": "Whenever a black card is put into one of your opponents' graveyards, you may draw a card.",
             "colours": [
@@ -3432,7 +3432,7 @@
         },
         {
             "id": "447a015b-83af-5a07-8f31-987ec120093b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8a0e2-311a-4627-8a48-43df045c3112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9a8a0e2-311a-4627-8a48-43df045c3112.jpg?1",
             "name": "Elvish Lookout",
             "text": "Elvish Lookout can't be the target of spells or abilities.",
             "colours": [
@@ -3466,7 +3466,7 @@
         },
         {
             "id": "5a4974b7-a661-5b8d-a148-364c78332949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e76333-0959-4572-a1ca-d77f76da1279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55e76333-0959-4572-a1ca-d77f76da1279.jpg?1",
             "name": "Elvish Piper",
             "text": "o\nG, oc\nT: Put a creature card from your hand into play.",
             "colours": [
@@ -3501,7 +3501,7 @@
         },
         {
             "id": "1bbeaa7e-3640-58af-872a-df1a8245ee84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccba208-1e24-45bb-a556-a3eb936efb10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccba208-1e24-45bb-a556-a3eb936efb10.jpg?1",
             "name": "Emperor Crocodile",
             "text": "When you control no other creatures, sacrifice Emperor Crocodile.",
             "colours": [
@@ -3535,7 +3535,7 @@
         },
         {
             "id": "efcb920c-bd3a-56b8-a4f1-115625b12888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6006c21-28b5-4550-8b4e-ac631f39cdf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6006c21-28b5-4550-8b4e-ac631f39cdf7.jpg?1",
             "name": "Gamekeeper",
             "text": "When Gamekeeper is put into a graveyard from play, you may remove Gamekeeper from the game. If you do, reveal cards from your library until you reveal a creature card. Put that card into play and put the other cards revealed this way into your graveyard.",
             "colours": [
@@ -3569,7 +3569,7 @@
         },
         {
             "id": "c95b74de-0fdf-538a-9222-80f02c2c2371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83d8765-f654-4837-9b06-739610188415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83d8765-f654-4837-9b06-739610188415.jpg?1",
             "name": "Goliath Beetle",
             "text": "Trample",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "a1abcaaa-c481-5e5a-87c9-9ccda0340a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e42dbe-3eeb-4367-bb6d-0f5c71f5da80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e42dbe-3eeb-4367-bb6d-0f5c71f5da80.jpg?1",
             "name": "Heart Warden",
             "text": "oc\nT: Add one green mana to your mana pool.\no2, Sacrifice Heart Warden: Draw a card.",
             "colours": [
@@ -3638,7 +3638,7 @@
         },
         {
             "id": "2fe8693c-e033-566f-965c-2689ffe9f6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926cefa1-3c5c-4bd6-859b-de620a3ee777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/926cefa1-3c5c-4bd6-859b-de620a3ee777.jpg?1",
             "name": "Hunting Moa",
             "text": "Echo\nWhenever Hunting Moa comes into play or is put into a graveyard from play, put a +1/+1 counter on target creature.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "f57beb0a-fd89-5546-b465-6ea8527b35c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ad11c-1351-4eff-94ac-3926037d7247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/018ad11c-1351-4eff-94ac-3926037d7247.jpg?1",
             "name": "Ivy Seer",
             "text": "o2o\nG, oc\nT: Reveal any number of green cards in your hand. Target creature gets +X/+X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -3708,7 +3708,7 @@
         },
         {
             "id": "91f94f9b-8ec1-5af2-b404-44456b9b3a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb2c6-f1a6-42c3-a7cb-3a1a46854c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b9bb2c6-f1a6-42c3-a7cb-3a1a46854c9b.jpg?1",
             "name": "Magnify",
             "text": "All creatures get +1/+1 until end of turn.",
             "colours": [
@@ -3740,7 +3740,7 @@
         },
         {
             "id": "8b1be586-6890-5d11-bac8-75ed7b937d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd3c78-197a-40b9-94d1-bbb1ec1e64b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cbd3c78-197a-40b9-94d1-bbb1ec1e64b1.jpg?1",
             "name": "Marker Beetles",
             "text": "When Marker Beetles is put into a graveyard from play, target creature gets +1/+1 until end of turn.\no2, Sacrifice Marker Beetles: Draw a card.",
             "colours": [
@@ -3774,7 +3774,7 @@
         },
         {
             "id": "57f76675-f77b-5109-9fa3-27e30ab9d46d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bd11a2-7cab-4d3f-b52b-f5bb66fbbec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10bd11a2-7cab-4d3f-b52b-f5bb66fbbec6.jpg?1",
             "name": "Momentum",
             "text": "At the beginning of your upkeep, you may put a growth counter on Momentum.\nEnchanted creature gets +1/+1 for each growth counter on Momentum.",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "d551fe59-bf69-5dc1-bdf6-3351c86c54e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b4d5c8-23fc-4fb8-99d6-bb64e66cc4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58b4d5c8-23fc-4fb8-99d6-bb64e66cc4db.jpg?1",
             "name": "Multani's Decree",
             "text": "Destroy all enchantments. You gain 2 life for each enchantment destroyed this way.",
             "colours": [
@@ -3840,7 +3840,7 @@
         },
         {
             "id": "6138d6f6-3d88-5ed8-a7ab-d9b5c1d32545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23c4f4-a191-4225-a3b7-dab5b1462922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f23c4f4-a191-4225-a3b7-dab5b1462922.jpg?1",
             "name": "Pattern of Rebirth",
             "text": "When enchanted creature is put into a graveyard from play, that creature's controller may search his or her library for a creature card and put that card into play. If that player does, he or she then shuffles his or her library.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "bf74c9e7-f4fd-5a64-8ef4-293cd5c87eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3529f49b-7e5e-4fa8-a03d-a94877761525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3529f49b-7e5e-4fa8-a03d-a94877761525.jpg?1",
             "name": "Plated Spider",
             "text": "Plated Spider may block as though it had flying.",
             "colours": [
@@ -3908,7 +3908,7 @@
         },
         {
             "id": "d8701233-0bfd-5c61-be59-e1cc3646e23c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30735c4-7f12-4db9-972b-9b7568a8ada8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a30735c4-7f12-4db9-972b-9b7568a8ada8.jpg?1",
             "name": "Plow Under",
             "text": "Put two target lands on top of their owner's library.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "22badd84-bc17-5eae-a8d1-b9650f7a6733",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa5cc65-f8f1-4f6f-8b4e-2fedccbda684.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa5cc65-f8f1-4f6f-8b4e-2fedccbda684.jpg?1",
             "name": "Rofellos, Llanowar Emissary",
             "text": "oc\nT: Add one green mana to your mana pool for each forest you control.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "4008d0ed-68e3-5333-8598-342c8c387bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41347ba-b2e3-4d7e-8018-e6fd30243559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a41347ba-b2e3-4d7e-8018-e6fd30243559.jpg?1",
             "name": "Rofellos's Gift",
             "text": "Reveal any number of green cards in your hand. Return an enchantment card from your graveyard to your hand for each card revealed this way.",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "8b69c0bf-e0b5-5a67-afc5-b93999926aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b4894-b959-4d00-b631-95d26eb85a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a56b4894-b959-4d00-b631-95d26eb85a4e.jpg?1",
             "name": "Scent of Ivy",
             "text": "Reveal any number of green cards in your hand. Target creature gets +X/+X until end of turn, where X is the number of cards revealed this way.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "dc68a089-ecaf-58a6-8967-505405fbc441",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32175c-f2e6-460b-b4bf-dd85cac3eb4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb32175c-f2e6-460b-b4bf-dd85cac3eb4f.jpg?1",
             "name": "Splinter",
             "text": "Remove target artifact from the game. Search its controller's graveyard, hand, and library for all copies of that card and remove them from the game. That player then shuffles his or her library.",
             "colours": [
@@ -4073,7 +4073,7 @@
         },
         {
             "id": "cfa6450e-b511-53f8-9c5c-b21dd70038b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bfa6b9-c898-4bb6-a444-6cf336bfb260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85bfa6b9-c898-4bb6-a444-6cf336bfb260.jpg?1",
             "name": "Taunting Elf",
             "text": "All creatures able to block Taunting Elf do so.",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "b3331d09-74c0-5c20-a441-5dd4cdfe90d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d4b0d-fe3e-46f5-86df-3fbac6b900b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d4b0d-fe3e-46f5-86df-3fbac6b900b0.jpg?1",
             "name": "Thorn Elemental",
             "text": "Thorn Elemental may deal its combat damage to defending player as though it weren't blocked.",
             "colours": [
@@ -4141,7 +4141,7 @@
         },
         {
             "id": "ebbae453-4e06-594c-85c4-2316bb244d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325d9372-01c9-4e99-a966-13c8f8566e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/325d9372-01c9-4e99-a966-13c8f8566e2e.jpg?1",
             "name": "Yavimaya Elder",
             "text": "When Yavimaya Elder is put into a graveyard from play, you may search your library for up to two basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.\no2, Sacrifice Yavimaya Elder: Draw a card.",
             "colours": [
@@ -4176,7 +4176,7 @@
         },
         {
             "id": "6d593dc8-bf00-5b63-8ea7-d79fbb0dd58b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e3934e-6169-416e-92bb-359e41900c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9e3934e-6169-416e-92bb-359e41900c3b.jpg?1",
             "name": "Yavimaya Enchantress",
             "text": "Yavimaya Enchantress gets +1/+1 for each enchantment in play.",
             "colours": [
@@ -4211,7 +4211,7 @@
         },
         {
             "id": "de58f4ec-99dd-5e37-83af-42e7c8c0b353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e783b7-9bd1-4f82-bf20-5d201413f5e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2e783b7-9bd1-4f82-bf20-5d201413f5e8.jpg?1",
             "name": "Braidwood Cup",
             "text": "oc\nT: You gain 1 life.",
             "colours": [],
@@ -4239,7 +4239,7 @@
         },
         {
             "id": "9b0e371e-6720-545a-a4ec-3106f601719d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc7634-8ef5-4a03-8276-7e1dae4244c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16dc7634-8ef5-4a03-8276-7e1dae4244c2.jpg?1",
             "name": "Braidwood Sextant",
             "text": "o2, oc\nT, Sacrifice Braidwood Sextant: Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -4267,7 +4267,7 @@
         },
         {
             "id": "8db5c541-2958-50c5-99ed-d70eb0530a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5685cff-b607-4a81-aa47-6676ab1a5782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5685cff-b607-4a81-aa47-6676ab1a5782.jpg?1",
             "name": "Brass Secretary",
             "text": "o2, Sacrifice Brass Secretary: Draw a card.",
             "colours": [],
@@ -4298,7 +4298,7 @@
         },
         {
             "id": "9ffbb6b6-5d07-5ebe-9890-952ed2e8fe80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cf74e4-31d2-4cd2-8f3a-b2141301f686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9cf74e4-31d2-4cd2-8f3a-b2141301f686.jpg?1",
             "name": "Caltrops",
             "text": "Whenever a creature attacks, Caltrops deals 1 damage to it.",
             "colours": [],
@@ -4326,7 +4326,7 @@
         },
         {
             "id": "f241a1d5-94f9-53d0-b473-b786ba51d072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc2f0d0-273d-428f-9a8a-c582f4d16394.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc2f0d0-273d-428f-9a8a-c582f4d16394.jpg?1",
             "name": "Extruder",
             "text": "Echo\nSacrifice an artifact: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "59fecc9a-7a4f-5938-912a-007a71a1117e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ba320-69c9-4400-a0d7-f0f79e8d9856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/229ba320-69c9-4400-a0d7-f0f79e8d9856.jpg?1",
             "name": "Fodder Cannon",
             "text": "o4, oc\nT, Sacrifice a creature: Fodder Cannon deals 4 damage to target creature.",
             "colours": [],
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "eab65b38-7d18-5295-9796-15747b193fe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f5a9d8-80b9-4765-adb2-10d53baaacb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4f5a9d8-80b9-4765-adb2-10d53baaacb0.jpg?1",
             "name": "Junk Diver",
             "text": "Flying\nWhen Junk Diver is put into a graveyard from play, return another target artifact card from your graveyard to your hand.",
             "colours": [],
@@ -4416,7 +4416,7 @@
         },
         {
             "id": "3657c541-d387-5cb6-a874-ee918c5d4843",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f7ebfb-f955-4849-a0f5-6806ff6ae891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97f7ebfb-f955-4849-a0f5-6806ff6ae891.jpg?1",
             "name": "Mantis Engine",
             "text": "o2: Mantis Engine gains flying until end of turn.\no2: Mantis Engine gains first strike until end of turn.",
             "colours": [],
@@ -4447,7 +4447,7 @@
         },
         {
             "id": "3e2b946f-0a62-58c3-aeba-68588d825d23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908a2215-7231-43a4-8fec-5d1e4233c028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908a2215-7231-43a4-8fec-5d1e4233c028.jpg?1",
             "name": "Masticore",
             "text": "At the beginning of your upkeep, you may choose and discard a card from your hand. If you don't, sacrifice Masticore.\no2: Masticore deals 1 damage to target creature.\no2: Regenerate Masticore.",
             "colours": [],
@@ -4478,7 +4478,7 @@
         },
         {
             "id": "dcd05bd8-60aa-5a11-8ac1-1f6d40d14be3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050d414-71c7-4c42-a1ff-4c04068ba7f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2050d414-71c7-4c42-a1ff-4c04068ba7f2.jpg?1",
             "name": "Metalworker",
             "text": "oc\nT: Reveal any number of artifact cards in your hand. Add two colorless mana to your mana pool for each card revealed this way.",
             "colours": [],
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "b027e7be-84c3-543f-b1bd-8241518de3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9715c2-9036-4ae2-a5b4-1b190d50c963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9715c2-9036-4ae2-a5b4-1b190d50c963.jpg?1",
             "name": "Powder Keg",
             "text": "At the beginning of your upkeep, you may put a fuse counter on Powder Keg.\noc\nT, Sacrifice Powder Keg: Destroy each artifact and creature with converted mana cost equal to the number of fuse counters on Powder Keg.",
             "colours": [],
@@ -4537,7 +4537,7 @@
         },
         {
             "id": "531a3146-0140-5050-9ac3-a8971c09430f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286819f-6c57-4503-898c-528786ad86e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7286819f-6c57-4503-898c-528786ad86e9.jpg?1",
             "name": "Scrying Glass",
             "text": "o3, oc\nT: Choose a number greater than 0 and a color. Target opponent reveals his or her hand. If that opponent reveals exactly the chosen number of cards of the chosen color, you draw a card.",
             "colours": [],
@@ -4565,7 +4565,7 @@
         },
         {
             "id": "758edb30-c44a-5ade-acc3-d90141b89dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77378279-024c-4c36-b5bf-6294fe5c32f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77378279-024c-4c36-b5bf-6294fe5c32f5.jpg?1",
             "name": "Storage Matrix",
             "text": "As long as Storage Matrix is untapped, instead of each player untapping the permanents he or she controls during his or her untap step, that player chooses artifacts, creatures, or lands and untaps all permanents of the chosen type he or she controls.",
             "colours": [],
@@ -4593,7 +4593,7 @@
         },
         {
             "id": "d96a4072-944e-5862-921d-f951055f91f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c9dee-fab5-4522-9821-343f84b0c8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0c9dee-fab5-4522-9821-343f84b0c8ab.jpg?1",
             "name": "Thran Dynamo",
             "text": "oc\nT: Add three colorless mana to your mana pool.",
             "colours": [],
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "d1096803-ee6f-5650-8666-571616d23626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdc0d42-d96f-490f-87cb-3577dfdce807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cdc0d42-d96f-490f-87cb-3577dfdce807.jpg?1",
             "name": "Thran Foundry",
             "text": "o1, oc\nT, Remove Thran Foundry from the game: Target player shuffles his or her graveyard into his or her library.",
             "colours": [],
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "17901676-3afc-57a9-a629-397a57555a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5778c52b-248b-4131-b5c0-12ea1986786e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5778c52b-248b-4131-b5c0-12ea1986786e.jpg?1",
             "name": "Thran Golem",
             "text": "As long as Thran Golem is enchanted, it gets +2/+2 and gains flying, first strike, and trample.",
             "colours": [],
@@ -4680,7 +4680,7 @@
         },
         {
             "id": "83beb4d1-d3f5-545e-bf0a-66659ee25f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96c2c-b3d6-4d84-9572-fb115a795bed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdf96c2c-b3d6-4d84-9572-fb115a795bed.jpg?1",
             "name": "Urza's Incubator",
             "text": "When Urza's Incubator comes into play, choose a creature type.\nCreature spells of the chosen type cost o2 less to play.",
             "colours": [],
@@ -4708,7 +4708,7 @@
         },
         {
             "id": "4d8175a8-cecc-5526-92e5-c16dfd4d04ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dd5c4b-5972-43e1-ae2a-ebf275006458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47dd5c4b-5972-43e1-ae2a-ebf275006458.jpg?1",
             "name": "Yavimaya Hollow",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no\nG, oc\nT: Regenerate target creature.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/UGL.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UGL.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "b0ea3c7e-dde2-5c80-a88a-6319955ae946",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b690ef-9fcb-42be-bbee-6aad516534a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93b690ef-9fcb-42be-bbee-6aad516534a5.jpg?1",
             "name": "Charm School",
             "text": "When Charm School comes into play, choose a color and balance Charm School on your head.\nPrevent all damage to you of the chosen color.\nIf Charm School falls off your head, sacrifice Charm School.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "58efe678-594a-5778-839a-d444cd30acf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a114f-3349-4a62-bfad-0dc33b78a53f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a114f-3349-4a62-bfad-0dc33b78a53f.jpg?1",
             "name": "The Cheese Stands Alone",
             "text": "If you control no cards in play other than The Cheese Stands Alone and have no cards in your hand, you win the game.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "926e0671-b2e8-5622-8271-521eb8cab24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbdbd92-ec36-4fe9-b75d-13f55574db5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebbdbd92-ec36-4fe9-b75d-13f55574db5e.jpg?1",
             "name": "Double Dip",
             "text": "Choose another player. Gain 5 life now and an additional 5 life at the beginning of the next game with that player.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "57f770a0-a47f-5728-98fc-81c0649de4d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2757b582-d995-45f9-9482-0792b0f0784d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2757b582-d995-45f9-9482-0792b0f0784d.jpg?1",
             "name": "Get a Life",
             "text": "Target player and each of his or her teammates exchange life totals.",
             "colours": [
@@ -128,7 +128,7 @@
         },
         {
             "id": "531b29bc-b32b-5abb-a265-47dbeebcbbfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5979237f-ff41-4e87-b2e4-d09b81eca2dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5979237f-ff41-4e87-b2e4-d09b81eca2dc.jpg?1",
             "name": "I'm Rubber, You're Glue",
             "text": "Speak only in rhyming sentences. If you do not, sacrifice I'm Rubber, You're Glue.\nSay \"I'm rubber, you're glue. Everything bounces off me and sticks to you\": Target spell or ability, which targets only you, targets another player of your choice instead. (The new target must be legal.)",
             "colours": [
@@ -159,7 +159,7 @@
         },
         {
             "id": "8b6429db-1771-573b-8c6d-7205fdc02e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53daa7-9130-4187-9e53-1075c6ab67d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd53daa7-9130-4187-9e53-1075c6ab67d0.jpg?1",
             "name": "Knight of the Hokey Pokey",
             "text": "First strike\no1o\nW, Do the Hokey Pokey (Stand up, wiggle your butt, raise your hands above your head, and shake them wildly as you rotate 360 degrees): Prevent all damage to Knight of the Hokey Pokey from any one source.",
             "colours": [
@@ -192,7 +192,7 @@
         },
         {
             "id": "10828bbb-6600-51c7-bf20-0bed42990528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39db7a3-028e-4c01-8ff9-64d2a1397379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b39db7a3-028e-4c01-8ff9-64d2a1397379.jpg?1",
             "name": "Lexivore",
             "text": "If Lexivore damages any player, destroy target card in play, other than Lexivore, with the most lines of text in its text box. (If more than one card has the most lines of text, you choose which of those cards to destroy.)",
             "colours": [
@@ -225,7 +225,7 @@
         },
         {
             "id": "d9b2fd1e-4934-5e16-aa59-f84e884b5b82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fb0d87-b086-4546-8f7f-786cb0b7b2f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14fb0d87-b086-4546-8f7f-786cb0b7b2f5.jpg?1",
             "name": "Look at Me, I'm the DCI",
             "text": "Ban one card, other than a basic land, for the remainder of the match. (For the remainder of the match, each player removes from the game all copies of that card in play or in any graveyard, hand, library, or sideboard.)",
             "colours": [
@@ -256,7 +256,7 @@
         },
         {
             "id": "82c35563-a96b-58ed-bcd2-7d5ab83d59a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1edbc-ea37-42c4-8fb9-deac011372b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfd1edbc-ea37-42c4-8fb9-deac011372b5.jpg?1",
             "name": "Mesa Chicken",
             "text": "Stand up, Flap your arms, Cluck like a chicken: Mesa Chicken gains flying until end of turn.",
             "colours": [
@@ -289,7 +289,7 @@
         },
         {
             "id": "09bb53fb-787d-5fd4-86c4-bc18aaebb4ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747ff5d4-69cd-447e-a18d-edcf583d0539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747ff5d4-69cd-447e-a18d-edcf583d0539.jpg?1",
             "name": "Miss Demeanor",
             "text": "Flying, first strike\nDuring each other player's turn, compliment that player on his or her game play or sacrifice Miss Demeanor.",
             "colours": [
@@ -325,7 +325,7 @@
         },
         {
             "id": "96d9c768-dbe1-5b7c-9951-74e64700d099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba42881b-9275-4b54-a17f-dec87d21a270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba42881b-9275-4b54-a17f-dec87d21a270.jpg?1",
             "name": "Once More with Feeling",
             "text": "Remove Once More with Feeling from the game as well as all cards in play and in all graveyards. Each player shuffles his or her hand into her or his library, then draws seven cards. Each player's life total is set to 10.\nDCI ruling: This card is restricted. (You cannot play with more than one in a deck.)",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "1c401a89-735f-52cb-a781-040242bc902c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79624ebe-7110-486d-82ff-b64c662dc6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79624ebe-7110-486d-82ff-b64c662dc6de.jpg?1",
             "name": "Prismatic Wardrobe",
             "text": "Destroy target card that does not share a color with clothing worn by its controller. You cannot choose an artifact or land card.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "cc377cd4-a3e9-5f79-a7a5-d71e9b91f99b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cfc18c-ed01-4016-86a2-162d7bc1bf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97cfc18c-ed01-4016-86a2-162d7bc1bf33.jpg?1",
             "name": "Sex Appeal",
             "text": "Prevent up to 3 damage total to any number of creatures and/or players. If there are more players in the room of the opposite sex, prevent up to 3 additional damage total to any number of creatures and/or players.",
             "colours": [
@@ -418,7 +418,7 @@
         },
         {
             "id": "5cf3e6e9-e2a0-5f69-a33e-caa252ab894c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43417d07-725e-4c3d-99d2-bbbfbdeee770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43417d07-725e-4c3d-99d2-bbbfbdeee770.jpg?1",
             "name": "Bureaucracy",
             "text": "Pursuant to subsection 3.1(4) of Richard's Rules of Order, during the upkeep of each participant in this game of the Magic: The Gathering\u00ae trading card game (hereafter known as \"PLAYER\"), that PLAYER performs all actions in the sequence of previously added actions (hereafter known as \"ACTION QUEUE\"), in the order those actions were added, then adds another action to the end of the ACTION QUEUE. All actions must be simple physical or verbal actions that a player can perform while sitting in a chair, without jeopardizing the health and security of said PLAYER.\nIf any PLAYER does not perform all the prescribed actions in the correct order, sacrifice Bureaucracy and said PLAYER discards his or her complement of cards in hand (hereafter known as \"HAND\").",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "3f00c3d1-be2d-51e2-825d-d74f14b1ad6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d4fba-cf12-4ad3-bca3-6824dbc639af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24d4fba-cf12-4ad3-bca3-6824dbc639af.jpg?1",
             "name": "Censorship",
             "text": "When Censorship comes into play, choose a CENSORED word.\nWhenever any CENSORED player says the chosen CENSORED word, Censorship deals 2 CENSORED damage to him or her.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "5e65f63f-b46f-54fc-9e80-5748ace9122d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70457a-34dc-48a1-8643-4a78c1e6f2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70457a-34dc-48a1-8643-4a78c1e6f2d3.jpg?1",
             "name": "Checks and Balances",
             "text": "Whenever any spell is played, counter that spell if each player, other than the caster and his or her teammates, agrees to choose and discard a card. Those players must discard those cards after agreeing.\nChecks and Balances may be played only in a game with three or more players.",
             "colours": [
@@ -511,7 +511,7 @@
         },
         {
             "id": "baf06116-3094-56f2-b7cb-2e65f0a231bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcefcab-8988-47e8-89bb-9b76f14c9d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcefcab-8988-47e8-89bb-9b76f14c9d8b.jpg?1",
             "name": "Chicken \u00e0 la King",
             "text": "Whenever a 6 is rolled on a six-sided die, put a +1/+1 counter on each Chicken in play. (You may roll dice only when a card instructs you to.)\nTap a Chicken you control: Roll a six-sided die.",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "4826be91-6ee1-54e7-ad83-5f5e3308611e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ba052-10f7-4612-91b7-a1528c188ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/349ba052-10f7-4612-91b7-a1528c188ec3.jpg?1",
             "name": "Clambassadors",
             "text": "If Clambassadors damages any player, choose an artifact, creature, or land you control. That player gains control of that artifact, creature, or land.",
             "colours": [
@@ -578,7 +578,7 @@
         },
         {
             "id": "0e3b5d6c-d300-5ca6-8830-e0a4ed9f2962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e1b62-df2b-48dc-9cb1-d86c9d3ab986.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57e1b62-df2b-48dc-9cb1-d86c9d3ab986.jpg?1",
             "name": "Clam-I-Am",
             "text": "Whenever you roll a 3 on a six-sided die, you may reroll that die.",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "93ec0222-31e5-5cdd-a788-8a4259acad96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2953cd-1b7e-41aa-959f-fb7ba2964bfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c2953cd-1b7e-41aa-959f-fb7ba2964bfb.jpg?1",
             "name": "Clam Session",
             "text": "When Clam Session comes into play, choose a word.\nDuring your upkeep, sing at least six words of a song, one of which must be the chosen word, or sacrifice Clam Session. You cannot repeat a song.",
             "colours": [
@@ -644,7 +644,7 @@
         },
         {
             "id": "2e4c8a4f-d46d-523c-b29d-dbafa49d92dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad6b646-a2b2-4817-856c-580a5953d87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ad6b646-a2b2-4817-856c-580a5953d87e.jpg?1",
             "name": "Common Courtesy",
             "text": "Counter any spell unless its caster asks your permission to play that spell. If you refuse permission, Sacrifice Common Courtesy and counter the spell.",
             "colours": [
@@ -675,7 +675,7 @@
         },
         {
             "id": "a2b7d300-e422-5348-9b0d-8288a7070d37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285c125-e145-4565-a029-352ac6adf688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1285c125-e145-4565-a029-352ac6adf688.jpg?1",
             "name": "Denied!",
             "text": "Play Denied only as any opponent casts target spell. Name a card, then look at all cards in that player's hand. If the named card is in the player's hand, counter target spell.",
             "colours": [
@@ -706,7 +706,7 @@
         },
         {
             "id": "2126334c-064f-59ed-bcb0-72572240f53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71941f1f-b41e-4ec9-a7c6-61eccaa47b0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71941f1f-b41e-4ec9-a7c6-61eccaa47b0e.jpg?1",
             "name": "Double Take",
             "text": "Choose another player. Draw two cards now and draw an additional two cards at the beginning of the next game with that player.",
             "colours": [
@@ -737,7 +737,7 @@
         },
         {
             "id": "9cd156c7-a60d-5d60-9133-08880eaf5b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2303a4e0-b8eb-4e8b-bc62-507eee52e7bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2303a4e0-b8eb-4e8b-bc62-507eee52e7bc.jpg?1",
             "name": "Fowl Play",
             "text": "Enchanted creature loses all abilities and is a 1/1 creature that counts as a Chicken.",
             "colours": [
@@ -770,7 +770,7 @@
         },
         {
             "id": "0cf28ac9-fb9b-55ad-b8ee-1ab210a84e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630efac8-3033-4c2d-9127-b3b2f78bb136.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/630efac8-3033-4c2d-9127-b3b2f78bb136.jpg?1",
             "name": "Free-for-All",
             "text": "When Free-for-All comes into play, set aside all creatures in play, face down.\nDuring each player's upkeep, that player chooses a creature card at random from those set aside in this way and puts that creature into play under his or her control.\nIf Free-for-All leaves play, put each creature still set aside this way into its owner's graveyard.",
             "colours": [
@@ -801,7 +801,7 @@
         },
         {
             "id": "5ac0d90c-a367-507b-8686-c3864a8419bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60dfba09-9e75-4fb9-a163-40e3149f7785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60dfba09-9e75-4fb9-a163-40e3149f7785.jpg?1",
             "name": "Psychic Network",
             "text": "Each player reveals the top card of his or her library to all other players by continuously holding it against his or her forehead. This does not allow a player to look at his or her own card. (That card still counts as the top card of your library. Whenever you draw a card, draw that one and replace it with the next card of your library.)",
             "colours": [
@@ -832,7 +832,7 @@
         },
         {
             "id": "5e615232-4d37-5396-8f68-053f8297259c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14606012-d57b-4fe7-908b-b5cfc272994b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14606012-d57b-4fe7-908b-b5cfc272994b.jpg?1",
             "name": "Sorry",
             "text": "Before playing any spell, if a copy of that spell card is in any graveyard, the spell's caster may say \"Sorry.\" If he or she does not, any other player may counter the spell by saying \"Sorry\" as it is cast.\nIf any player says \"Sorry\" at any other time, Sorry deals 2 damage to that player.",
             "colours": [
@@ -863,7 +863,7 @@
         },
         {
             "id": "33b10155-90dc-5846-9c82-af414ba6c1e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f9c279-e382-4feb-9575-196e7cf5d7dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9f9c279-e382-4feb-9575-196e7cf5d7dc.jpg?1",
             "name": "B.F.M. (Big Furry Monster)",
             "text": "You must play both B.\nF.\nM. cards to put\nleaves play, sacrifice the other.\nB.\nF.\nM. can be blocked only by three or",
             "colours": [
@@ -901,7 +901,7 @@
         },
         {
             "id": "451ac233-9ba8-59db-8fff-6962e0b173f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c6375-2e4e-47f7-88e1-d90794e7f724.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d15c6375-2e4e-47f7-88e1-d90794e7f724.jpg?1",
             "name": "B.F.M. (Big Furry Monster)",
             "text": "You must play both B.\nF.\nM. cards to put\nleaves play, sacrifice the other.\nB.\nF.\nM. can be blocked only by three or",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "5c176335-a5d5-5a91-9c2f-74875ae58625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3998e-b4a1-4dd1-8e12-24579ec8938b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb3998e-b4a1-4dd1-8e12-24579ec8938b.jpg?1",
             "name": "Deadhead",
             "text": "Put Deadhead into play. Use this ability only if any opponent loses contact with his or her hand of cards and only if Deadhead is in your graveyard.",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "04dcf162-1039-5fcd-ac4f-562b769bca54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f90e34-3736-42ed-aade-e31247b3472d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8f90e34-3736-42ed-aade-e31247b3472d.jpg?1",
             "name": "Double Cross",
             "text": "Choose another player. Look at that player's hand and choose one of those cards other than a basic land. He or she discards that card. At the beginning of the next game with the player, look at the player's hand and choose one of those cards other than a basic land. He or she discards that card.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "2a176d87-a2c5-5966-a00b-176424d5bc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae92f5-4219-4194-b152-c2b2653aef3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ae92f5-4219-4194-b152-c2b2653aef3f.jpg?1",
             "name": "Handcuffs",
             "text": "Target player keeps both hands in contact with each other. If he or she does not, sacrifice Handcuffs and that player sacrifices three cards in play.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "42b47054-7009-5f19-9e0d-e39e4ad1b3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99711b5b-3cb2-4d57-ac9a-f43cc86a7ca9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99711b5b-3cb2-4d57-ac9a-f43cc86a7ca9.jpg?1",
             "name": "Infernal Spawn of Evil",
             "text": "Flying, first strike\no1o\nB, Reveal Infernal Spawn of Evil from your hand, Say \"It's coming\": Infernal Spawn of Evil deals 1 damage to target opponent. Use this ability only during your upkeep and only once each upkeep.",
             "colours": [
@@ -1066,7 +1066,7 @@
         },
         {
             "id": "4b0aceba-90f8-5e0f-82b1-e759f81100ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135b61b-eb8c-44d7-8227-bd268c3ca463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a135b61b-eb8c-44d7-8227-bd268c3ca463.jpg?1",
             "name": "Jumbo Imp",
             "text": "Flying\nWhen you play Jumbo Imp, roll a six-sided die. Jumbo Imp comes into play with a number of +1/+1 counters on it equal to the die roll.\nDuring your upkeep, roll a six-sided die and put on Jumbo Imp a number of +1/+1 counters equal to the die roll.\nAt the end of your turn, roll a six-sided die and remove from Jumbo Imp a number of +1/+1 counters equal to the die roll.",
             "colours": [
@@ -1099,7 +1099,7 @@
         },
         {
             "id": "7010e071-313e-55e5-9d18-bb06c71c1193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05213eec-322f-4bc7-b607-217290447f40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05213eec-322f-4bc7-b607-217290447f40.jpg?1",
             "name": "Organ Harvest",
             "text": "You and your teammates may sacrifice any number of creatures. For each creature sacrificed in this way, add o\nBo\nB to your mana pool.",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "161f4356-f12c-5c35-9bfc-164371af8520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd26c2a6-7b08-4de6-afbf-e34d321995ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd26c2a6-7b08-4de6-afbf-e34d321995ab.jpg?1",
             "name": "Ow",
             "text": "Whenever any creature damages a player, for each Ow card in play, that player says \"Ow\" once or Ow deals 1 damage to him or her.",
             "colours": [
@@ -1161,7 +1161,7 @@
         },
         {
             "id": "29db17ff-dbcb-5419-8f13-bf0cf40e946c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bec883-a2e0-49a5-8cdd-2755c0963a2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6bec883-a2e0-49a5-8cdd-2755c0963a2d.jpg?1",
             "name": "Poultrygeist",
             "text": "Flying\nWhenever a creature is put into any graveyard from play, you may roll a six-sided die. On a 1, sacrifice Poultrygeist. Otherwise, put a +1/+1 counter on Poultrygeist.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "bd512631-b500-57e9-89d3-6c8b55472bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7105d13-798e-472b-bb00-d419886e9cc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7105d13-798e-472b-bb00-d419886e9cc7.jpg?1",
             "name": "Temp of the Damned",
             "text": "When you play Temp of the Damned, roll a six-sided die. Temp of the Damned comes into play with a number of funk counters on it equal to the die roll.\nDuring your upkeep, remove a funk counter from Temp of the Damned or sacrifice Temp of the Damned.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "7bc2bb63-2081-53fd-85d0-aba4741b8004",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b915b6-4436-4007-a014-415694117c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2b915b6-4436-4007-a014-415694117c7e.jpg?1",
             "name": "Volrath's Motion Sensor",
             "text": "When Volrath's Motion Sensor comes into play, choose target hand controlled by an opponent. Enchanted player balances Volrath's Motion Sensor on the back of that hand.\nIf Volrath's Motion Sensor falls off the hand, sacrifice Volrath's Motion Sensor and that player loses 3 life.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "6a54b561-0bc4-5ab6-a780-4c6a2145913d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ed4800-dc0f-4681-9ae6-74bd0018e8dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17ed4800-dc0f-4681-9ae6-74bd0018e8dc.jpg?1",
             "name": "Burning Cinder Fury of Crimson Chaos Fire",
             "text": "Whenever any player taps a card, that player gives control of that card to an opponent at end of turn.\nIf a player does not tap any nonland cards during his or her turn, Burning Cinder Fury of Crimson Chaos Fire deals 3 damage to that player at end of turn.",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "9173b925-8b75-5abc-9365-48b51651c611",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640ac565-331b-47e2-b2af-a8a94a96488a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640ac565-331b-47e2-b2af-a8a94a96488a.jpg?1",
             "name": "Chicken Egg",
             "text": "During your upkeep, roll a six-sided die. On a 6, sacrifice Chicken Egg and put a Giant Chicken token into play. Treat this token as a 4/4 red creature that counts as a Chicken.",
             "colours": [
@@ -1325,7 +1325,7 @@
         },
         {
             "id": "609e62c5-13bd-5a5e-8d3f-361c502b2ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8b3def-30ee-4dd2-9a25-ecf7d5663f96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed8b3def-30ee-4dd2-9a25-ecf7d5663f96.jpg?1",
             "name": "Double Deal",
             "text": "Choose another player. Double Deal deals 3 damage to that player now and deals an additional 3 damage to the player at the beginning of the next game with the player.",
             "colours": [
@@ -1356,7 +1356,7 @@
         },
         {
             "id": "045bb960-50d6-5478-b370-224cdce8fb73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc880e76-1e92-4af1-b89f-b5a2b60b86f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc880e76-1e92-4af1-b89f-b5a2b60b86f0.jpg?1",
             "name": "Goblin Bookie",
             "text": "o\nR, oc\nT: Reflip any coin or reroll any die.",
             "colours": [
@@ -1389,7 +1389,7 @@
         },
         {
             "id": "32c9718b-f1c1-531d-8736-2f8aa72abe89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00325992-ec1c-469a-8df0-ffb9a197d221.jpg?1",
             "name": "Goblin Bowling Team",
             "text": "Whenever Goblin Bowling Team damages any creature or player, roll a six-sided die. Goblin Bowling Team deals to that creature or player additional damage equal to the die roll.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "027bde8b-0fb7-5eda-9d72-19843c86998c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bc822d-a028-4162-bf23-6ff4b9f43688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bc822d-a028-4162-bf23-6ff4b9f43688.jpg?1",
             "name": "Goblin Tutor",
             "text": "Roll a six-sided die for Goblin Tutor. On a 1, Goblin Tutor has no effect. Otherwise, search your library for the indicated card, reveal that card to all players, and put it into your hand. Shuffle your library afterwards.\n2 Any Goblin Tutor\n3 Any enchantment\n4 Any artifact\n5 Any creature\n6 Any sorcery, instant, or interrupt",
             "colours": [
@@ -1453,7 +1453,7 @@
         },
         {
             "id": "7a868b76-5093-5f49-8cea-02ce9f759f6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d957abcb-ba56-42b4-9316-f30ac821ecf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d957abcb-ba56-42b4-9316-f30ac821ecf9.jpg?1",
             "name": "Hurloon Wrangler",
             "text": "Denimwalk (If defending player is wearing any clothing made of denim, this creature is unblockable.)",
             "colours": [
@@ -1486,7 +1486,7 @@
         },
         {
             "id": "955be9e7-b1f6-58c1-9bf3-4c5e88706881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5d0ead-7798-49a2-8106-418db1d4fd69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5d0ead-7798-49a2-8106-418db1d4fd69.jpg?1",
             "name": "Jalum Grifter",
             "text": "o1o\nR, oc\nT: Put Jalum Grifter and two lands you control face down in front of target opponent after revealing each card to him or her. Then, rearrange the order of the three cards as often as you wish, keeping them on the table at all times. That opponent then chooses one of those cards. If a land is chosen, destroy target card in play. Otherwise, sacrifice Jalum Grifter.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "9b3e875b-0ae4-5e73-a3e7-081c11c9e455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e978fdf7-2243-49d0-b265-a3287f19b17d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e978fdf7-2243-49d0-b265-a3287f19b17d.jpg?1",
             "name": "Krazy Kow",
             "text": "During your upkeep, roll a six-sided die. On a 1, sacrifice Krazy Kow and it deals 3 damage to each creature and player.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "f2d95364-07b1-532f-87b5-122de4fab7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef5452d-b5cb-4772-a5ac-1b4c976e03a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ef5452d-b5cb-4772-a5ac-1b4c976e03a5.jpg?1",
             "name": "Landfill",
             "text": "Choose a land type. Remove from play all lands of that type that you control. Drop those cards, one at a time, onto the playing area from a height of at least one foot. Destroy each card in play that is completely covered by those cards. Then return to play, tapped, all lands dropped in this way.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "ceea7467-fdd1-520e-8027-7abd3127140a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea993e57-b72f-48f8-9132-0693f2e78ce4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea993e57-b72f-48f8-9132-0693f2e78ce4.jpg?1",
             "name": "Ricochet",
             "text": "Whenever any spell targets a single player, each player rolls a six-sided die. That spell is redirected to the player or players with the lowest die roll. If two or more players tie for the lowest die roll, they reroll until there is no tie.",
             "colours": [
@@ -1616,7 +1616,7 @@
         },
         {
             "id": "b162a4be-1a66-523c-850a-a6efaa3ca92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea73a7ef-e9da-4d5b-aa4d-a953cbacd6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea73a7ef-e9da-4d5b-aa4d-a953cbacd6c2.jpg?1",
             "name": "Spark Fiend",
             "text": "When Spark Fiend comes into play, roll two six-sided dice. On a total of 2, 3, or 12, sacrifice Spark Fiend. On a total of 7 or 11, do not roll dice for Spark Fiend during any of your following upkeep phases. If you roll any other total, note it.\nDuring your upkeep, roll two six-sided dice. On a total of 7, sacrifice Spark Fiend. If you roll the noted total, do not roll dice for Spark Fiend during any of your following upkeep phases. On any other roll, there is no effect.",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "aa083a5e-20d4-5c98-910b-09844d94620e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2996a63-9fb6-4455-906d-13f917a8bb29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2996a63-9fb6-4455-906d-13f917a8bb29.jpg?1",
             "name": "Strategy, Schmategy",
             "text": "Roll a six-sided die for Strategy, Schmategy. On a 1, Strategy, Schmategy has no effect. Otherwise, it has one of the following effects.\n2 Destroy all artifacts.\n3 Destroy all lands.\n4 Strategy, Schmategy deals 3 damage to each creature and player.\n5 Each player discards his or her hand and draws seven cards.\n6 Roll the die two more times.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "b23bc758-25fc-5f75-8619-0e9d664c48c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616abc97-4276-4e96-bbe8-e47ba7cac075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616abc97-4276-4e96-bbe8-e47ba7cac075.jpg?1",
             "name": "The Ultimate Nightmare of Wizards of the Coast\u00ae Customer Service",
             "text": "The Ultimate Nightmare of Wizards of the Coast\u00ae Customer Service deals X damage to each of Y target creatures and Z target players.",
             "colours": [
@@ -1711,7 +1711,7 @@
         },
         {
             "id": "71377d26-db92-55c1-8c56-3375e72294cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059fc73f-7a00-4014-9e92-75765798cf2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059fc73f-7a00-4014-9e92-75765798cf2d.jpg?1",
             "name": "Cardboard Carapace",
             "text": "For each other Cardboard Carapace card you have with you, enchanted creature gets +1/+1.\nErrata: This does not count any Cardboard Carapace cards in play that you control or in your graveyard, hand, or library.",
             "colours": [
@@ -1744,7 +1744,7 @@
         },
         {
             "id": "d69f95eb-1c76-5fd8-a098-5a4c00148019",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c66e0-0ca8-447f-b8d9-b03ce7ffaf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c66e0-0ca8-447f-b8d9-b03ce7ffaf7f.jpg?1",
             "name": "Double Play",
             "text": "Choose another player. Search your library for a basic land and put that land into play. At the beginning of the next game with that player, search your library for an additional basic land and put that land into play. In both cases, shuffle your library afterwards.",
             "colours": [
@@ -1775,7 +1775,7 @@
         },
         {
             "id": "28973feb-0e45-5507-bf1c-8c745da08b58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922663f0-f444-4364-a706-eb6b91ac36ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922663f0-f444-4364-a706-eb6b91ac36ef.jpg?1",
             "name": "Elvish Impersonators",
             "text": "When you play Elvish Impersonators, roll two six-sided dice one after the other. Elvish Impersonators comes into play with power equal to the first die roll and toughness equal to the second.",
             "colours": [
@@ -1808,7 +1808,7 @@
         },
         {
             "id": "9e5898b1-894e-52fa-a2ce-fc09948ef6c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce65cbd-e2cf-4fbf-8424-287cd87c97f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce65cbd-e2cf-4fbf-8424-287cd87c97f1.jpg?1",
             "name": "Flock of Rabid Sheep",
             "text": "Flip X coins; an opponent calls heads or tails. For each flip you win, put a Rabid Sheep token into play. Treat these tokens as 2/2 green creatures that count as Sheep.",
             "colours": [
@@ -1839,7 +1839,7 @@
         },
         {
             "id": "2e415ee0-7861-553c-8164-a14e853c03f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59e6414-62ac-427e-8e37-690ed401b4dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59e6414-62ac-427e-8e37-690ed401b4dd.jpg?1",
             "name": "Free-Range Chicken",
             "text": "o1o\nG: Roll two six-sided dice. If both die rolls are the same, Free-Range Chicken gets +X/+X until end of turn, where X is the number rolled on each die. Otherwise, if the total rolled is equal to any other total you have rolled this turn for Free-Range Chicken, sacrifice it. (For example, if you roll two 3s, Free-Range Chicken gets +3/+3. If you roll a total of 6 for Free-Range Chicken later in that turn, sacrifice it.)",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "081165b2-452a-55f9-b6a4-1872ec20a07b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea8ab0f-6898-4312-9989-915d6357515f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aea8ab0f-6898-4312-9989-915d6357515f.jpg?1",
             "name": "Gerrymandering",
             "text": "Remove all lands from play and shuffle them together. Randomly deal to each player one land card for each land he or she had before. Each player puts those lands into play under his or her control, untapped.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "53d7f8b1-8ab0-5cf2-917a-40790bdfbb2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c18690-cf8c-4006-a981-6258d18ba538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17c18690-cf8c-4006-a981-6258d18ba538.jpg?1",
             "name": "Ghazb\u00e1n Ogress",
             "text": "When Ghazb\u00e1n Ogress comes into play, the player who has won the most Magic games that day gains control of it. If more than one player has won the same number of games, you retain control of Ghazb\u00e1n Ogress.",
             "colours": [
@@ -1936,7 +1936,7 @@
         },
         {
             "id": "cd9beb6a-1adb-59f4-b9a7-64150678d5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905accf-ea94-48fa-8dbe-b4a7dd57a277.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2905accf-ea94-48fa-8dbe-b4a7dd57a277.jpg?1",
             "name": "Growth Spurt",
             "text": "Roll a six-sided die. Target creature gets +X/+X until end of turn, where X is equal to the die roll.",
             "colours": [
@@ -1967,7 +1967,7 @@
         },
         {
             "id": "e0a315ed-f9db-5bf4-8cb5-d9524375dca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b05428-d9f3-42ec-bef4-286f1ad06901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9b05428-d9f3-42ec-bef4-286f1ad06901.jpg?1",
             "name": "Gus",
             "text": "Gus comes into play with one +1/+1 counter on it for each game you have lost to your opponent since you last won a Magic game against him or her.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "1c1c12ac-c243-5b04-ae0c-77207d0c7500",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a17ecb8-cf64-420a-9038-609bfdb4c669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a17ecb8-cf64-420a-9038-609bfdb4c669.jpg?1",
             "name": "Hungry Hungry Heifer",
             "text": "During your upkeep, remove a counter from any card you control or sacrifice Hungry Hungry Heifer.",
             "colours": [
@@ -2033,7 +2033,7 @@
         },
         {
             "id": "88f60557-ccd8-5438-923e-e00654b4b816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573cf5e6-35ee-4eb6-990a-524ba7335797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573cf5e6-35ee-4eb6-990a-524ba7335797.jpg?1",
             "name": "Incoming!",
             "text": "Each player searches his or her library for any number of artifacts, creatures, enchantments, and lands and puts those cards into play. Each player shuffles his or her library afterwards.",
             "colours": [
@@ -2064,7 +2064,7 @@
         },
         {
             "id": "5033ea8d-6662-581c-978b-57470cfea713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91f28e0-867a-4713-955d-582201af63ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a91f28e0-867a-4713-955d-582201af63ae.jpg?1",
             "name": "Mine, Mine, Mine!",
             "text": "When Mine, Mine, Mine comes into play, each player puts his or her library into his or her hand.\nEach player skips his or her discard phase and does not lose as a result of being unable to draw a card.\nEach player cannot play more than one spell each turn.\nIf Mine, Mine, Mine leaves play, each player shuffles his or her hand and graveyard into his or her library.",
             "colours": [
@@ -2095,7 +2095,7 @@
         },
         {
             "id": "62785ad6-f56f-53e0-9fd3-5e3d31bb4007",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987ddd67-305a-4c95-9f1a-17eeeb058aaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/987ddd67-305a-4c95-9f1a-17eeeb058aaa.jpg?1",
             "name": "Squirrel Farm",
             "text": "o1o\nG: Choose a card in your hand. Covering the artist's name, reveal the card to target player. If that player cannot name the artist, reveal the artist's name and put a Squirrel token into play. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -2126,7 +2126,7 @@
         },
         {
             "id": "28eab892-c663-5205-ac4c-64da6c777ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8369211-e7e1-45e1-a142-274f4236e230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8369211-e7e1-45e1-a142-274f4236e230.jpg?1",
             "name": "Team Spirit",
             "text": "All creatures controlled by target player and his or her teammates get +1/+1 until end of turn.",
             "colours": [
@@ -2157,7 +2157,7 @@
         },
         {
             "id": "cb3f1aa7-5242-52b6-b7dc-1f07ca99e04c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43ce658-12be-4eb2-b679-0aefea348de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e43ce658-12be-4eb2-b679-0aefea348de2.jpg?1",
             "name": "Timmy, Power Gamer",
             "text": "o4: Put a creature into play from your hand.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "f8175a6a-f790-5c38-94c5-f3005f3a27d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420010f-5389-4aa2-a5f8-d9631249679a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d420010f-5389-4aa2-a5f8-d9631249679a.jpg?1",
             "name": "Ashnod's Coupon",
             "text": "oc\nT, Sacrifice Ashnod's Coupon: Target player gets you target drink.\nErrata: You pay any costs for the drink.",
             "colours": [],
@@ -2220,7 +2220,7 @@
         },
         {
             "id": "9b04fa89-b946-58e9-88ee-de5cf015a3a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c85d097-e87b-41ee-93c6-0e54ec41b174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c85d097-e87b-41ee-93c6-0e54ec41b174.jpg?1",
             "name": "Blacker Lotus",
             "text": "oc\nT: Tear Blacker Lotus into pieces. Add four mana of any one color to your mana pool. Play this ability as a mana source. Remove the pieces from the game afterwards.",
             "colours": [],
@@ -2247,7 +2247,7 @@
         },
         {
             "id": "d739225a-6ed8-52be-8585-e53887edd5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21943fe2-3eeb-441a-a3ae-99866c6e76bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21943fe2-3eeb-441a-a3ae-99866c6e76bd.jpg?1",
             "name": "Bronze Calendar",
             "text": "Your spells cost o1 less to play as long as you speak in a voice other than your normal voice.\nIf you speak in your normal voice, sacrifice Bronze Calendar.",
             "colours": [],
@@ -2274,7 +2274,7 @@
         },
         {
             "id": "4013c717-93a0-5e85-8eee-8a6c1b613c20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cee00a-5ab5-43c3-8017-db20d37e69c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5cee00a-5ab5-43c3-8017-db20d37e69c4.jpg?1",
             "name": "Chaos Confetti",
             "text": "o4, oc\nT: Tear Chaos Confetti into pieces. Throw the pieces onto the playing area from a distance of at least five feet. Destroy each card in play that a piece touches. Remove the pieces from the game afterwards.",
             "colours": [],
@@ -2301,7 +2301,7 @@
         },
         {
             "id": "27373004-c893-5124-a904-12b00f913072",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfacc30-0acc-4b2d-bc7b-6ff72afc1077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dfacc30-0acc-4b2d-bc7b-6ff72afc1077.jpg?1",
             "name": "Clay Pigeon",
             "text": "Flying\no1, Throw Clay Pigeon into the air at least two feet above your head while seated, Attempt to catch it with one hand: If you catch Clay Pigeon, prevent all damage to you from any one source and return Clay Pigeon to play, tapped. Otherwise, sacrifice it.",
             "colours": [],
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "6ab4214d-3f8e-554e-9190-a0427487e050",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdb8678-3c0c-4ee3-aeff-52a4db4e09c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdb8678-3c0c-4ee3-aeff-52a4db4e09c4.jpg?1",
             "name": "Giant Fan",
             "text": "o2, oc\nT: Move target counter from one card to another. If the second card's rules text refers to any type of counters, the moved counter becomes one of those counters. Otherwise, it becomes a +1/+1 counter.",
             "colours": [],
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "37f4bd2f-1393-59f9-b76b-fb0278e04d22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1834ac92-8b4e-4442-a834-acd580e1ef99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1834ac92-8b4e-4442-a834-acd580e1ef99.jpg?1",
             "name": "Jack-in-the-Mox",
             "text": "oc\nT: Roll a six-sided die for Jack-in-the-Mox. On a 1, sacrifice Jack-in-the-Mox and lose 5 life. Otherwise, Jack-in-the-Mox has one of the following effects. Treat this ability as a mana source.\n2 Add o\nW to your mana pool.\n3 Add o\nU to your mana pool.\n4 Add o\nB to your mana pool.\n5 Add o\nR to your mana pool.\n6 Add o\nG to your mana pool.",
             "colours": [],
@@ -2391,7 +2391,7 @@
         },
         {
             "id": "f4f45a83-a98c-5c4e-970a-5e1b4aa7c7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68f012-307f-4ffb-909e-1284fb39e64f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e68f012-307f-4ffb-909e-1284fb39e64f.jpg?1",
             "name": "Jester's Sombrero",
             "text": "o2, oc\nT, Sacrifice Jester's Sombrero: Look through target player's sideboard and remove any three of those cards from it for the remainder of the match.",
             "colours": [],
@@ -2418,7 +2418,7 @@
         },
         {
             "id": "d2df03d0-2696-506a-b37f-d4b9a461ddb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf208d-5fe6-4030-a19d-7505832dab3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abf208d-5fe6-4030-a19d-7505832dab3b.jpg?1",
             "name": "Mirror Mirror",
             "text": "Mirror Mirror comes into play tapped.\no7, oc\nT, Sacrifice Mirror Mirror: At end of turn, exchange life totals with target player and exchange all cards in play that you control, and all cards in your hand, library, and graveyard, with that player until end of game.",
             "colours": [],
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "ad530bf0-179b-5ff8-aaaa-1d6d5b3c466c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1cb9ab-512e-4bb1-8d77-37a0b2d3e7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d1cb9ab-512e-4bb1-8d77-37a0b2d3e7f8.jpg?1",
             "name": "Paper Tiger",
             "text": "Rock Lobsters cannot attack or block.",
             "colours": [],
@@ -2475,7 +2475,7 @@
         },
         {
             "id": "568eaa81-563a-5fb8-8a6b-615b999b8a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba96c2a-9ccf-4b28-8af5-f8c221fc6823.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba96c2a-9ccf-4b28-8af5-f8c221fc6823.jpg?1",
             "name": "Rock Lobster",
             "text": "Scissors Lizards cannot attack or block.",
             "colours": [],
@@ -2505,7 +2505,7 @@
         },
         {
             "id": "a713c635-f87d-56c6-ab33-2c3b91337005",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b3502d-5519-4254-b946-226edc3bd7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7b3502d-5519-4254-b946-226edc3bd7e4.jpg?1",
             "name": "Scissors Lizard",
             "text": "Paper Tigers cannot attack or block.",
             "colours": [],
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "89f3c5da-de85-5f4c-9c8a-46f3d0d4527e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d1435-bde3-46f7-a35d-2a663e05fb97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/777d1435-bde3-46f7-a35d-2a663e05fb97.jpg?1",
             "name": "Spatula of the Ages",
             "text": "o4, oc\nT, Sacrifice Spatula of the Ages: Put into play from your hand any card from an Unglued supplement.",
             "colours": [],
@@ -2562,7 +2562,7 @@
         },
         {
             "id": "1c6761fe-ada4-55db-9cc1-28a52d94d0d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f386c088-fa37-4134-96bb-9fb784719101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f386c088-fa37-4134-96bb-9fb784719101.jpg?1",
             "name": "Urza's Contact Lenses",
             "text": "Urza's Contact Lenses comes into play tapped and does not untap during its controller's untap phase.\nAll players play with their hands face up.\nClap your hands twice: Tap or untap Urza's Contact Lenses.",
             "colours": [],
@@ -2589,7 +2589,7 @@
         },
         {
             "id": "db24ae5c-9e2d-5036-8d1e-43c97eb117b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfe56d0-c15f-4a68-a0b8-911e13b1bc9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bfe56d0-c15f-4a68-a0b8-911e13b1bc9a.jpg?1",
             "name": "Urza's Science Fair Project",
             "text": "o2: Roll a six-sided die for Urza's Science Fair Project.\n1 It gets -2/-2 until end of turn.\n2 It deals no combat damage this turn.\n3 Attacking does not cause it to tap this turn.\n4 It gains first strike until end of turn.\n5 It gains flying until end of turn.\n6 It gets +2/+2 until end of turn.",
             "colours": [],
@@ -2619,7 +2619,7 @@
         },
         {
             "id": "58f9ae77-a62a-53e4-a0db-96f7c6f87229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb382733-ff3d-43e2-9b1e-efa2f7c28173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb382733-ff3d-43e2-9b1e-efa2f7c28173.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -2652,7 +2652,7 @@
         },
         {
             "id": "6e1c70a2-447a-5f18-9b4c-87a547a81ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f89f2-30a0-493a-914e-6251d2574099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547f89f2-30a0-493a-914e-6251d2574099.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -2685,7 +2685,7 @@
         },
         {
             "id": "d9a2e581-d292-5ec3-9424-f497a760c232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69384f97-3333-4aa7-bc4f-928ba49a2c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69384f97-3333-4aa7-bc4f-928ba49a2c80.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "18548922-7199-5e53-a68e-13e18b239be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c2e1a-181e-4275-ad09-51c9de039d32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c2e1a-181e-4275-ad09-51c9de039d32.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "536d955c-bb4c-5ad2-ac79-c51c6a8c6a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed8a17-ce32-4100-8ffc-fb8af1c35142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ed8a17-ce32-4100-8ffc-fb8af1c35142.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -2784,7 +2784,7 @@
         },
         {
             "id": "88308b13-9d63-5450-8152-54a09e60e259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc944579-b6d8-40f7-8c46-146513960d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc944579-b6d8-40f7-8c46-146513960d61.jpg?1",
             "name": "Pegasus",
             "text": "",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "01a52fbf-27cd-5ccb-993d-d60faf1c6280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159b57d-bc52-4cef-ac7a-e364e40c3d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159b57d-bc52-4cef-ac7a-e364e40c3d03.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -2852,7 +2852,7 @@
         },
         {
             "id": "6427bb52-c4c3-5918-bf64-421f8bff5978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7b5995-ee8b-40d1-b157-8df96c02cc5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e7b5995-ee8b-40d1-b157-8df96c02cc5b.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -2886,7 +2886,7 @@
         },
         {
             "id": "9085fbb5-b423-540e-9bdb-da12104801a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd728ed-d5dc-44b3-9159-6c86cab3be0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbd728ed-d5dc-44b3-9159-6c86cab3be0c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "6c328ab8-3fdf-5fbc-8179-f4780c70df80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281d2c14-2343-44c9-a589-7f4da37978a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281d2c14-2343-44c9-a589-7f4da37978a2.jpg?1",
             "name": "Sheep",
             "text": "",
             "colours": [
@@ -2954,7 +2954,7 @@
         },
         {
             "id": "f47e3eeb-f1d4-5fd2-852e-5f08ec9bd5c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf24a09-0a54-4e1d-a515-ed5ae99294be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abf24a09-0a54-4e1d-a515-ed5ae99294be.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/ULG.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ULG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "6019df9f-5c1b-568a-a3c9-97242a2317f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ba2da-6dea-44ac-8439-527222da565b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c63ba2da-6dea-44ac-8439-527222da565b.jpg?1",
             "name": "Angelic Curator",
             "text": "Flying, protection from artifacts",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "d6fa1aa9-32e8-5ad5-86d9-78458dc60b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb6d738-f6a8-4626-8103-68e63874eda4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb6d738-f6a8-4626-8103-68e63874eda4.jpg?1",
             "name": "Blessed Reversal",
             "text": "Gain 3 life for each creature attacking you.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "dfcbfd2b-6134-54b1-9243-eba7507364f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d590d2-cfa3-43d1-9e65-bc68b5a2a3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d590d2-cfa3-43d1-9e65-bc68b5a2a3ee.jpg?1",
             "name": "Burst of Energy",
             "text": "Untap target permanent.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "05abed58-e64f-5244-ae52-87c2cbc542ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a113f0c-8249-427b-979b-10898ec66a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a113f0c-8249-427b-979b-10898ec66a3a.jpg?1",
             "name": "Cessation",
             "text": "Enchanted creature cannot attack.\nWhen Cessation is put into a graveyard from play, return Cessation to owner's hand.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "1fa66e8a-cfda-5685-bc8d-1cdc54e21bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8e8719-8c33-429d-8b95-b7f813888850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c8e8719-8c33-429d-8b95-b7f813888850.jpg?1",
             "name": "Defender of Law",
             "text": "Protection from red\nYou may play Defender of Law any time you could play an instant.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "dc6a871e-fe51-5d03-b46f-1d8644006965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b5c60-8a5e-4473-ba43-583aef50f19e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985b5c60-8a5e-4473-ba43-583aef50f19e.jpg?1",
             "name": "Devout Harpist",
             "text": "oc\nT: Destroy target creature enchantment.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "9490d240-7066-5d0d-a69e-09d842c0417d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c89d61-3c2e-4d70-86d6-f70eba3d327f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c89d61-3c2e-4d70-86d6-f70eba3d327f.jpg?1",
             "name": "Erase",
             "text": "Remove target enchantment from the game.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "b4eafc53-7d74-5ab3-80b6-1e05bc0e0eaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31d7d1b-a219-4653-be99-a885bc9b2e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31d7d1b-a219-4653-be99-a885bc9b2e2f.jpg?1",
             "name": "Expendable Troops",
             "text": "oc\nT, Sacrifice Expendable Troops: Expendable Troops deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "71153f87-9f78-57fe-8a01-0b99a5c4af8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6478f-4ae5-4f26-baa9-b28e992f962e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc6478f-4ae5-4f26-baa9-b28e992f962e.jpg?1",
             "name": "Hope and Glory",
             "text": "Untap two target creatures. Each of them gets +1/+1 until end of turn.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "4e4ccf2d-5a07-5977-bee1-92cc7ecbd0b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee0ee84-6c22-4649-b621-e3fdb08bbe45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee0ee84-6c22-4649-b621-e3fdb08bbe45.jpg?1",
             "name": "Iron Will",
             "text": "Target creature gets +0/+4 until end of turn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -337,7 +337,7 @@
         },
         {
             "id": "b7afaca8-748a-571a-9290-61c775624b4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d23045-905b-44cb-9af9-cc6ad717477d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77d23045-905b-44cb-9af9-cc6ad717477d.jpg?1",
             "name": "Karmic Guide",
             "text": "Flying, protection from black; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Karmic Guide comes into play, choose target creature card in your graveyard and put that creature into play.",
             "colours": [
@@ -372,7 +372,7 @@
         },
         {
             "id": "1d8e69c4-8af8-5c23-98eb-4e429dbe7318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5e98d3-2521-4340-8d48-98e8c2c7818d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d5e98d3-2521-4340-8d48-98e8c2c7818d.jpg?1",
             "name": "Knighthood",
             "text": "All creatures you control gain first strike.",
             "colours": [
@@ -404,7 +404,7 @@
         },
         {
             "id": "6063f93f-a46a-5583-9fa9-e4ab6977734a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1f026b-8c7f-4051-9922-5684a6b2c06b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1f026b-8c7f-4051-9922-5684a6b2c06b.jpg?1",
             "name": "Martyr's Cause",
             "text": "Sacrifice a creature: Prevent all damage to a creature or player from one source. (Treat further damage from that source normally.)",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "2d9077d1-de7c-5515-b6e2-d4034747a220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1a46ab-95cb-4c24-924f-fc2afd4fcac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1a46ab-95cb-4c24-924f-fc2afd4fcac7.jpg?1",
             "name": "Mother of Runes",
             "text": "oc\nT: Target creature you control gains protection from a color of your choice until end of turn.",
             "colours": [
@@ -471,7 +471,7 @@
         },
         {
             "id": "1c82c9d6-fc19-513d-833b-1c0fbb142a32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9337bbe-e092-469d-8122-77f92e233306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9337bbe-e092-469d-8122-77f92e233306.jpg?1",
             "name": "Opal Avenger",
             "text": "When you have 10 life or less, if Opal Avenger is an enchantment, Opal Avenger becomes a 3/5 creature that counts as a Guardian.",
             "colours": [
@@ -503,7 +503,7 @@
         },
         {
             "id": "e0df75b6-e382-5ce4-828a-aca1a3d2566f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699cf3b-df54-4c77-ba19-3bc7598ae3fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699cf3b-df54-4c77-ba19-3bc7598ae3fa.jpg?1",
             "name": "Opal Champion",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Champion is an enchantment, Opal Champion becomes a 3/3 creature with first strike that counts as a Knight.",
             "colours": [
@@ -535,7 +535,7 @@
         },
         {
             "id": "f00e02d5-c0f2-575b-8556-683085794637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d73accc-8f19-44d4-8216-c1acdbef3856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d73accc-8f19-44d4-8216-c1acdbef3856.jpg?1",
             "name": "Peace and Quiet",
             "text": "Destroy two target enchantments.",
             "colours": [
@@ -567,7 +567,7 @@
         },
         {
             "id": "11b51444-0705-5386-8618-7977ee1527b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee22cf3c-51b0-4790-ab13-985cbe900c3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee22cf3c-51b0-4790-ab13-985cbe900c3b.jpg?1",
             "name": "Planar Collapse",
             "text": "During your upkeep, if there are four or more creatures in play, sacrifice Planar Collapse and destroy all creatures. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -599,7 +599,7 @@
         },
         {
             "id": "73c30f75-46da-5087-8da5-37c75b5df4b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5341da18-df05-4135-b948-7aa3e3d7a492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5341da18-df05-4135-b948-7aa3e3d7a492.jpg?1",
             "name": "Purify",
             "text": "Destroy all artifacts and enchantments.",
             "colours": [
@@ -631,7 +631,7 @@
         },
         {
             "id": "56f91cd7-27ce-584d-8bba-e51c399ed11e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99509da7-3e11-4c38-804b-286ce572f36e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99509da7-3e11-4c38-804b-286ce572f36e.jpg?1",
             "name": "Radiant, Archangel",
             "text": "Flying\nRadiant, Archangel counts as an Angel.\nAttacking does not cause Radiant to tap.\nRadiant gets +1/+1 for each other creature with flying in play.",
             "colours": [
@@ -667,7 +667,7 @@
         },
         {
             "id": "7aee37a4-b2a4-578e-a80b-ee5f49d5f52d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f39de-6ad2-410c-bc6c-75fd3c8d159b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a0f39de-6ad2-410c-bc6c-75fd3c8d159b.jpg?1",
             "name": "Radiant's Dragoons",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Radiant's Dragoons comes into play, gain 5 life.",
             "colours": [
@@ -702,7 +702,7 @@
         },
         {
             "id": "4573a62b-b39c-5514-badd-88cf0b65ef3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2718e-c6fc-4961-b094-11f25f1177ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28d2718e-c6fc-4961-b094-11f25f1177ff.jpg?1",
             "name": "Radiant's Judgment",
             "text": "Destroy target creature with power 4 or greater.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -734,7 +734,7 @@
         },
         {
             "id": "c8ab1d58-7835-5c03-8e90-6c21992d0c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca280e1e-4231-48e5-be1b-965480822c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca280e1e-4231-48e5-be1b-965480822c46.jpg?1",
             "name": "Sustainer of the Realm",
             "text": "Flying\nWhenever Sustainer of the Realm blocks, it gets +0/+2 until end of turn.",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "64678420-8607-5a3d-8486-05ffa835d0f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294aa7fc-12be-4722-b288-de14a28919b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294aa7fc-12be-4722-b288-de14a28919b2.jpg?1",
             "name": "Tragic Poet",
             "text": "oc\nT, Sacrifice Tragic Poet: Return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -802,7 +802,7 @@
         },
         {
             "id": "50c0447f-f023-5a69-bcf8-b3c566dfa96a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089e2bc7-0063-47bf-8f66-48bed6eb046b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/089e2bc7-0063-47bf-8f66-48bed6eb046b.jpg?1",
             "name": "Anthroplasm",
             "text": "Anthroplasm comes into play with two +1/+1 counters on it.\no\nX, oc\nT: Remove all +1/+1 counters from Anthroplasm and put X +1/+1 counters on it.",
             "colours": [
@@ -836,7 +836,7 @@
         },
         {
             "id": "96248a07-e29d-5b79-84cf-4c292fc641f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9936cb4d-f4e3-4fc7-869e-8f17056e57d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9936cb4d-f4e3-4fc7-869e-8f17056e57d5.jpg?1",
             "name": "Archivist",
             "text": "oc\nT: Draw a card.",
             "colours": [
@@ -871,7 +871,7 @@
         },
         {
             "id": "bbe6231a-daea-5e75-8637-ed76ca7f7e23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6be1542-70b8-4e97-a951-100966dc46ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6be1542-70b8-4e97-a951-100966dc46ce.jpg?1",
             "name": "Aura Flux",
             "text": "Each other enchantment gains \"During your upkeep, pay o2 or sacrifice this enchantment.\"",
             "colours": [
@@ -903,7 +903,7 @@
         },
         {
             "id": "f268877a-8a96-52bc-b647-e036df401b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8656bdd4-0c45-43f9-b2dc-d11a355ff747.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8656bdd4-0c45-43f9-b2dc-d11a355ff747.jpg?1",
             "name": "Bouncing Beebles",
             "text": "Bouncing Beebles is unblockable if defending player controls an artifact.",
             "colours": [
@@ -937,7 +937,7 @@
         },
         {
             "id": "c032be25-ebcf-5c2e-925d-ee50eb6e30ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e76d04a-0038-4b5b-a026-3056ee940da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e76d04a-0038-4b5b-a026-3056ee940da9.jpg?1",
             "name": "Cloud of Faeries",
             "text": "Flying\nWhen Cloud of Faeries comes into play, untap up to two lands.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "4783bc65-dd02-58d2-b3aa-9ea14158d137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899088b3-4cdf-47c0-8c52-3c9f55c086c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899088b3-4cdf-47c0-8c52-3c9f55c086c4.jpg?1",
             "name": "Delusions of Mediocrity",
             "text": "When Delusions of Mediocrity comes into play, gain 10 life.\nWhen Delusions of Mediocrity leaves play, lose 10 life.",
             "colours": [
@@ -1003,7 +1003,7 @@
         },
         {
             "id": "d56a3e48-1bd4-5e7d-a776-5f53a24d816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9a5501-f149-47d0-9d79-151a524c7c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef9a5501-f149-47d0-9d79-151a524c7c54.jpg?1",
             "name": "Fleeting Image",
             "text": "Flying\no1oo\nU Return Fleeting Image to owner's hand.",
             "colours": [
@@ -1037,7 +1037,7 @@
         },
         {
             "id": "fc1b6960-10c4-5304-9f64-344016aeb31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1904db14-6df7-424f-afa5-e3dfab31300a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1904db14-6df7-424f-afa5-e3dfab31300a.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then choose and discard two cards. Untap up to three lands.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "35da17a7-e1fd-5c14-8ca2-3adb2b0199a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e3894-5dfe-4d03-9996-eebf96c58168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0e3894-5dfe-4d03-9996-eebf96c58168.jpg?1",
             "name": "Intervene",
             "text": "Counter target spell that targets a creature.",
             "colours": [
@@ -1101,7 +1101,7 @@
         },
         {
             "id": "014f08dc-5f90-56b5-a002-143b4187cb20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedea953-b5f1-4ec7-bd9f-b7827f9d40fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aedea953-b5f1-4ec7-bd9f-b7827f9d40fe.jpg?1",
             "name": "King Crab",
             "text": "o1o\nU, oc\nT: Put target green creature on top of owner's library.",
             "colours": [
@@ -1135,7 +1135,7 @@
         },
         {
             "id": "716b22af-d935-512e-97aa-669cb58d0400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca18a2e7-6b01-4d10-82b5-0c1cb6ba0d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca18a2e7-6b01-4d10-82b5-0c1cb6ba0d2b.jpg?1",
             "name": "Levitation",
             "text": "All creatures you control gain flying.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "aa45f70b-a8f4-5bc0-ae86-75a570599f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4956a2-9a39-4152-9c98-70e4b2acfa26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b4956a2-9a39-4152-9c98-70e4b2acfa26.jpg?1",
             "name": "Miscalculation",
             "text": "Counter target spell unless its caster pays an additional o2.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1199,7 +1199,7 @@
         },
         {
             "id": "70cb4eda-6b22-528d-97d6-98071ec21284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a09767-a15d-42b0-aaa3-794a4e11037a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a09767-a15d-42b0-aaa3-794a4e11037a.jpg?1",
             "name": "Opportunity",
             "text": "Target player draws four cards.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "184f3e89-8188-5a22-846b-f35a6231ad46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5621db3f-a9e7-4350-9c6a-0ba04a628947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5621db3f-a9e7-4350-9c6a-0ba04a628947.jpg?1",
             "name": "Palinchron",
             "text": "Flying\nWhen Palinchron comes into play, untap up to seven lands.\no2o\nUoo\nU Return Palinchron to owner's hand.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "3b197524-7105-520a-ad66-26a49f8fd272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104638d-29aa-490c-8cfb-e08fc94efb59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b104638d-29aa-490c-8cfb-e08fc94efb59.jpg?1",
             "name": "Raven Familiar",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Raven Familiar comes into play, look at the top three cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "26b95319-6a7e-58b1-aa94-7ae3c02a5fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc1613c-a149-4f04-9950-41637d35d675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc1613c-a149-4f04-9950-41637d35d675.jpg?1",
             "name": "Rebuild",
             "text": "Return all artifacts to owners' hands.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "a7bcf387-18e2-502a-95d1-59097072f39a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d1a0da-40b9-4e79-bace-b93f98ae4695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62d1a0da-40b9-4e79-bace-b93f98ae4695.jpg?1",
             "name": "Second Chance",
             "text": "During your upkeep, if you have 5 life or less, sacrifice Second Chance and take an extra turn after this one.",
             "colours": [
@@ -1363,7 +1363,7 @@
         },
         {
             "id": "f20143c5-2e3f-594f-ab63-0fdf280b7082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2860a20d-e1bf-4e46-8c07-a858f616d5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2860a20d-e1bf-4e46-8c07-a858f616d5a5.jpg?1",
             "name": "Slow Motion",
             "text": "During the upkeep of enchanted creature's controller, that player pays o2 or sacrifices that creature.\nWhen Slow Motion is put into a graveyard from play, return Slow Motion to owner's hand.",
             "colours": [
@@ -1397,7 +1397,7 @@
         },
         {
             "id": "14f6f8a5-4d45-5927-ba97-3986c69f2634",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0549e-2d23-4ea8-b8d1-ae21af2c9091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e0549e-2d23-4ea8-b8d1-ae21af2c9091.jpg?1",
             "name": "Snap",
             "text": "Return target creature to owner's hand. Untap up to two lands.",
             "colours": [
@@ -1429,7 +1429,7 @@
         },
         {
             "id": "b1f0d7dd-a67d-57bc-88d0-224e9b1cd127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4b20a-448a-4855-9e60-19625f921a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb4b20a-448a-4855-9e60-19625f921a4d.jpg?1",
             "name": "Thornwind Faeries",
             "text": "Flying\noc\nT: Thornwind Faeries deals 1 damage to target creature or player.",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "5a59d111-6137-5f00-8448-81269da4900d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da23b15-dfb8-4267-9b33-d7a4c035c434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7da23b15-dfb8-4267-9b33-d7a4c035c434.jpg?1",
             "name": "Tinker",
             "text": "At the time you play Tinker, sacrifice an artifact.\nSearch your library for an artifact card and put that artifact into play. Shuffle your library afterward.",
             "colours": [
@@ -1495,7 +1495,7 @@
         },
         {
             "id": "fb31b360-68dd-5470-8ad0-9026fd57685a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37940486-2d7f-40d9-9c19-151b9307d374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37940486-2d7f-40d9-9c19-151b9307d374.jpg?1",
             "name": "Vigilant Drake",
             "text": "Flying\no2oo\nU Untap Vigilant Drake.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "6a27a9fb-7fdf-59a5-a170-b92418e2d8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b125d1e7-5d9b-4997-88b0-71bdfc19c6f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b125d1e7-5d9b-4997-88b0-71bdfc19c6f2.jpg?1",
             "name": "Walking Sponge",
             "text": "oc\nT: Target creature loses flying, first strike, or trample until end of turn.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "2cb02da6-5539-5c69-a785-b013c002bf5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7ebec7-7375-4362-9489-437ff9305f19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c7ebec7-7375-4362-9489-437ff9305f19.jpg?1",
             "name": "Weatherseed Faeries",
             "text": "Flying, protection from red",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "941c2689-8a4f-5422-ac36-ac3fcfd4de1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece050ad-788e-4451-b773-ca42c37549d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece050ad-788e-4451-b773-ca42c37549d2.jpg?1",
             "name": "Bone Shredder",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.) When Bone Shredder comes into play, destroy target nonartifact, nonblack creature.",
             "colours": [
@@ -1632,7 +1632,7 @@
         },
         {
             "id": "08a94fff-6856-5a96-909e-322104de9697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5391d8-b546-4159-955e-16bb58052311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff5391d8-b546-4159-955e-16bb58052311.jpg?1",
             "name": "Brink of Madness",
             "text": "During your upkeep, if you have no cards in hand, sacrifice Brink of Madness and target opponent discards his or her hand.",
             "colours": [
@@ -1664,7 +1664,7 @@
         },
         {
             "id": "860b01b7-0eb2-5493-9ec4-a9e4dbebb259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e158d5-efb2-4f90-8898-60ede98f7d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e158d5-efb2-4f90-8898-60ede98f7d29.jpg?1",
             "name": "Engineered Plague",
             "text": "When Engineered Plague comes into play, choose a creature type.\nAll creatures of the chosen type get -1/-1.",
             "colours": [
@@ -1696,7 +1696,7 @@
         },
         {
             "id": "9a6c858b-b9eb-5f90-99da-f59f7bf0ab75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167e7f67-8d44-4134-b7b9-54ccdfb8675c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167e7f67-8d44-4134-b7b9-54ccdfb8675c.jpg?1",
             "name": "Eviscerator",
             "text": "Protection from white\nWhen Eviscerator comes into play, lose 5 life.",
             "colours": [
@@ -1731,7 +1731,7 @@
         },
         {
             "id": "9fdc16ea-a654-5e9a-adb4-e10f36668872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e9c54-134b-41da-8c3d-ec699d96778a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e9c54-134b-41da-8c3d-ec699d96778a.jpg?1",
             "name": "Fog of Gnats",
             "text": "Flying\noo\nB Regenerate Fog of Gnats.",
             "colours": [
@@ -1765,7 +1765,7 @@
         },
         {
             "id": "b3a97028-9440-5168-be51-86d38f643a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521bf0c-9f43-402e-8065-d2fc02e20194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0521bf0c-9f43-402e-8065-d2fc02e20194.jpg?1",
             "name": "Giant Cockroach",
             "text": "",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "8387d9f9-cb2c-5485-8b9b-ebe5e86e105b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9063cc12-a822-4488-856e-93d70ecfe37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/9063cc12-a822-4488-856e-93d70ecfe37f.jpg?1",
             "name": "Lurking Skirge",
             "text": "When a creature is put into one of your opponents' graveyards, if Lurking Skirge is an enchantment, Lurking Skirge becomes a 3/2 creature with flying that counts as an Imp.",
             "colours": [
@@ -1831,7 +1831,7 @@
         },
         {
             "id": "fbe5f099-1056-594d-96bd-7b24ee679cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fc29c-0223-4b03-864f-eb9149abc921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2fc29c-0223-4b03-864f-eb9149abc921.jpg?1",
             "name": "No Mercy",
             "text": "Whenever a creature successfully deals damage to you, destroy it.",
             "colours": [
@@ -1863,7 +1863,7 @@
         },
         {
             "id": "56c1f135-2d5f-504d-99b7-e3e50d1ebdb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b00193a-84ae-4465-943d-01e3d5fa9aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b00193a-84ae-4465-943d-01e3d5fa9aca.jpg?1",
             "name": "Ostracize",
             "text": "Look at target opponent's hand and choose a creature card there. That player discards that card.",
             "colours": [
@@ -1895,7 +1895,7 @@
         },
         {
             "id": "89077323-e7b7-5f6f-a7f9-ee713bfc8e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2313481c-baf9-4dc7-80c7-1ebc6502dce7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2313481c-baf9-4dc7-80c7-1ebc6502dce7.jpg?1",
             "name": "Phyrexian Broodlings",
             "text": "o1, Sacrifice a creature: Put a +1/+1 counter on Phyrexian Broodlings.",
             "colours": [
@@ -1930,7 +1930,7 @@
         },
         {
             "id": "9e60e1db-02c9-55ef-8a5d-1e1abaffde63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672dcca2-096b-4bcc-9b02-7180c4c0d4c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672dcca2-096b-4bcc-9b02-7180c4c0d4c7.jpg?1",
             "name": "Phyrexian Debaser",
             "text": "Flying\noc\nT, Sacrifice Phyrexian Debaser: Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "a7db5fee-0654-52bf-88f7-38ceab815e58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d555b5e-9f8a-4b1b-a4a6-dee8e177d9e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d555b5e-9f8a-4b1b-a4a6-dee8e177d9e8.jpg?1",
             "name": "Phyrexian Defiler",
             "text": "oc\nT, Sacrifice Phyrexian Defiler: Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "57b0ab3b-1a2e-5ba8-949a-da8dc0edb111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf849a0-9b53-4a8a-87a7-dc38d97311ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf849a0-9b53-4a8a-87a7-dc38d97311ab.jpg?1",
             "name": "Phyrexian Denouncer",
             "text": "oc\nT, Sacrifice Phyrexian Denouncer: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "523360f1-ead5-51f1-b2b1-e69c9a13b194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bd530-4b11-428e-864e-e24e96051e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/307bd530-4b11-428e-864e-e24e96051e3e.jpg?1",
             "name": "Phyrexian Plaguelord",
             "text": "oc\nT, Sacrifice Phyrexian Plaguelord: Target creature gets -4/-4 until end of turn.\nSacrifice a creature: Target creature gets -1/-1 until end of turn.",
             "colours": [
@@ -2070,7 +2070,7 @@
         },
         {
             "id": "e7dcda1e-8a8a-51d1-9dc6-15b13cd340c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a2bb7-d9f0-47b5-a0d9-2adf1b33e995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228a2bb7-d9f0-47b5-a0d9-2adf1b33e995.jpg?1",
             "name": "Phyrexian Reclamation",
             "text": "o1o\nB, Pay 2 life: Return target creature card from your graveyard to your hand.",
             "colours": [
@@ -2102,7 +2102,7 @@
         },
         {
             "id": "0fae8f58-756b-5556-bbcf-37aaf3ad0ee8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07f4e55-57f9-49f6-a1a2-1c94dcbe7d71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c07f4e55-57f9-49f6-a1a2-1c94dcbe7d71.jpg?1",
             "name": "Plague Beetle",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)",
             "colours": [
@@ -2136,7 +2136,7 @@
         },
         {
             "id": "691bd3d1-c6b1-5a70-900c-260a47c2d5c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59481cb5-2cb0-4b8c-84ee-519399862d46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59481cb5-2cb0-4b8c-84ee-519399862d46.jpg?1",
             "name": "Rank and File",
             "text": "When Rank and File comes into play, all green creatures get -1/-1 until end of turn.",
             "colours": [
@@ -2170,7 +2170,7 @@
         },
         {
             "id": "8ec37c3d-8601-5f14-b73c-24516a4264db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8736f8a2-ee8d-49d2-883f-b22cbe3f3645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/8736f8a2-ee8d-49d2-883f-b22cbe3f3645.jpg?1",
             "name": "Sick and Tired",
             "text": "Two target creatures each get -1/-1 until end of turn.",
             "colours": [
@@ -2202,7 +2202,7 @@
         },
         {
             "id": "64d48f06-9161-55fa-96d5-9e4f8a13b419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a001ca83-35b5-48e5-8337-92258d5affc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a001ca83-35b5-48e5-8337-92258d5affc2.jpg?1",
             "name": "Sleeper's Guile",
             "text": "Enchanted creature cannot be blocked except by artifact creatures and black creatures.\nWhen Sleeper's Guile is put into a graveyard from play, return Sleeper's Guile to owner's hand.",
             "colours": [
@@ -2236,7 +2236,7 @@
         },
         {
             "id": "031c875a-0c4b-50a0-a94f-88c38ae65773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f1bca9-5831-4e8b-8920-f28ebb3ffb27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50f1bca9-5831-4e8b-8920-f28ebb3ffb27.jpg?1",
             "name": "Subversion",
             "text": "During your upkeep, each of your opponents loses 1 life. Gain 1 life for each 1 life lost this way.",
             "colours": [
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "64c7b80f-98a6-5432-a00d-3fa55bd98d10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947b8923-d9d6-4dd8-928b-91be9105ffb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947b8923-d9d6-4dd8-928b-91be9105ffb4.jpg?1",
             "name": "Swat",
             "text": "Destroy target creature with power 2 or less.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "0a17de72-0f2d-5cd6-b0cb-fe8181927f09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1d02c-5d9d-4436-af3b-fb7190c1c028.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab1d02c-5d9d-4436-af3b-fb7190c1c028.jpg?1",
             "name": "Tethered Skirge",
             "text": "Flying\nWhenever Tethered Skirge becomes the target of a spell or ability, lose 1 life.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "1f01fd65-6c5e-5f65-9eee-cb2882978762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f8581-411b-4403-9c3a-3cf2156f6779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5f8581-411b-4403-9c3a-3cf2156f6779.jpg?1",
             "name": "Treacherous Link",
             "text": "Redirect to its controller all damage dealt to enchanted creature.",
             "colours": [
@@ -2369,7 +2369,7 @@
         },
         {
             "id": "2f8a6f9c-4a5e-5fe9-8437-4a267cfcd17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb2549-e485-44d6-9d65-7605c568909e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6cb2549-e485-44d6-9d65-7605c568909e.jpg?1",
             "name": "Unearth",
             "text": "Choose target creature card in your graveyard with total casting cost 3 or less and put that creature into play.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2401,7 +2401,7 @@
         },
         {
             "id": "0913e75b-c685-5093-9f49-ca0a5df365ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e71828-095b-4729-ab11-c6c39ba29aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e71828-095b-4729-ab11-c6c39ba29aab.jpg?1",
             "name": "About Face",
             "text": "Switch target creature's power and toughness until end of turn. Effects that alter the creature's power alter its toughness instead, and vice versa, this turn.",
             "colours": [
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "4a83afa7-11f9-5cda-b2a7-6b92ddbc427f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdc5330-c76b-40ca-a694-58fa4b9b7304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdc5330-c76b-40ca-a694-58fa4b9b7304.jpg?1",
             "name": "Avalanche Riders",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nAvalanche Riders is unaffected by summoning sickness.\nWhen Avalanche Riders comes into play, destroy target land.",
             "colours": [
@@ -2468,7 +2468,7 @@
         },
         {
             "id": "8889f660-ea6c-524a-b2e4-e9ed75078498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ae26a-e5a0-4478-9995-00ea6bd84c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717ae26a-e5a0-4478-9995-00ea6bd84c03.jpg?1",
             "name": "Defender of Chaos",
             "text": "Protection from white\nYou may play Defender of Chaos any time you could play an instant.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "0e391573-48e3-5906-8004-2bdc16a39692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131dce1c-e9c8-437a-b7aa-36a47049d2d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/131dce1c-e9c8-437a-b7aa-36a47049d2d2.jpg?1",
             "name": "Ghitu Fire-Eater",
             "text": "oc\nT, Sacrifice Ghitu Fire-Eater: Ghitu Fire-Eater deals damage equal to its power to target creature or player.",
             "colours": [
@@ -2538,7 +2538,7 @@
         },
         {
             "id": "78d6504c-7934-514e-aedc-883c63beffa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e4bc1d-6a4b-408a-8921-433249c960f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e4bc1d-6a4b-408a-8921-433249c960f9.jpg?1",
             "name": "Ghitu Slinger",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Ghitu Slinger comes into play, it deals 2 damage to target creature or player.",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "feee926e-1726-53c1-9e5b-58765f85cd07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9786c4f-f09b-46ce-966c-10efb1e5e609.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9786c4f-f09b-46ce-966c-10efb1e5e609.jpg?1",
             "name": "Ghitu War Cry",
             "text": "oo\nR Target creature gets +1/+0 until end of turn.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "44fe604e-4225-5824-8917-570a23988c2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc08b6-f31a-46b3-b233-f6bb2c6b1106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72cc08b6-f31a-46b3-b233-f6bb2c6b1106.jpg?1",
             "name": "Goblin Medics",
             "text": "Whenever Goblin Medics becomes tapped, it deals 1 damage to target creature or player.",
             "colours": [
@@ -2640,7 +2640,7 @@
         },
         {
             "id": "0dd58ee1-d018-5681-9baa-3596881c0578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171e136-1167-4329-acb2-6853d3a814e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6171e136-1167-4329-acb2-6853d3a814e5.jpg?1",
             "name": "Goblin Welder",
             "text": "oc\nT: Exchange target artifact a player controls for target artifact card in that player's graveyard.",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "b7db3a6b-4ab9-5ec3-90bd-bc58072d9617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9e0e7e-ada8-49f5-9dd9-f62464697675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9e0e7e-ada8-49f5-9dd9-f62464697675.jpg?1",
             "name": "Granite Grip",
             "text": "Enchanted creature gets +1/+0 for each mountain you control.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "201382ad-67ef-54b4-aa79-17600be5a168",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44497303-9686-4810-bf0f-876dd9696cab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44497303-9686-4810-bf0f-876dd9696cab.jpg?1",
             "name": "Impending Disaster",
             "text": "During your upkeep, if there are seven or more lands in play, sacrifice Impending Disaster and destroy all lands.",
             "colours": [
@@ -2741,7 +2741,7 @@
         },
         {
             "id": "69992aab-14a9-5567-a311-8c8f7faa18e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f7fe0-0681-4b25-807f-30ed70ec78d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/295f7fe0-0681-4b25-807f-30ed70ec78d5.jpg?1",
             "name": "Last-Ditch Effort",
             "text": "Sacrifice X creatures. Last-Ditch Effort deals X damage to target creature or player.",
             "colours": [
@@ -2773,7 +2773,7 @@
         },
         {
             "id": "d7f21c30-29e3-58a5-81b7-03786f8f5269",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11ec278-46f5-4970-ad0b-f6718c73de6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e11ec278-46f5-4970-ad0b-f6718c73de6c.jpg?1",
             "name": "Lava Axe",
             "text": "Lava Axe deals 5 damage to target player.",
             "colours": [
@@ -2805,7 +2805,7 @@
         },
         {
             "id": "d4b34350-924b-5cc3-82c2-c40108b9b6c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95234b29-9ac8-4200-b42d-9653ba51b010.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95234b29-9ac8-4200-b42d-9653ba51b010.jpg?1",
             "name": "Molten Hydra",
             "text": "o1o\nRoo\nR Put a +1/+1 counter on Molten Hydra.\noc\nT, Remove all +1/+1 counters from Molten Hydra: Molten Hydra deals 1 damage to target creature or player for each +1/+1 counter removed this way.",
             "colours": [
@@ -2839,7 +2839,7 @@
         },
         {
             "id": "bc2988b6-7cc7-5997-b8b0-7c319bd511e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab8065-cecc-4b19-be93-7cf791a93e62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3ab8065-cecc-4b19-be93-7cf791a93e62.jpg?1",
             "name": "Parch",
             "text": "Choose one Parch deals 2 damage to target creature or player; or Parch deals 4 damage to target blue creature.",
             "colours": [
@@ -2871,7 +2871,7 @@
         },
         {
             "id": "5825a803-c3d1-5c71-bf33-041b9baf2096",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96136626-4777-4e58-865b-c4d3f6ceb59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96136626-4777-4e58-865b-c4d3f6ceb59d.jpg?1",
             "name": "Pygmy Pyrosaur",
             "text": "Pygmy Pyrosaur cannot block.\noo\nR Pygmy Pyrosaur gets +1/+0 until end of turn.",
             "colours": [
@@ -2905,7 +2905,7 @@
         },
         {
             "id": "287c9548-4b6f-5b22-9556-c03fbadd6d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a91a58-cc8b-47a3-8c53-43c32753a00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35a91a58-cc8b-47a3-8c53-43c32753a00d.jpg?1",
             "name": "Pyromancy",
             "text": "o3, Discard a card at random: Pyromancy deals to target creature or player damage equal to the total casting cost of the discarded card.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "e262a1ba-5feb-5122-a122-28dda54b8a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e8f6a-3a1a-4c30-9348-4b31882267eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a46e8f6a-3a1a-4c30-9348-4b31882267eb.jpg?1",
             "name": "Rack and Ruin",
             "text": "Destroy two target artifacts.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "6cff6f01-fde3-5697-ba58-89b2064af571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b79677b-d5b9-47c7-a5f5-45446d5cddff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b79677b-d5b9-47c7-a5f5-45446d5cddff.jpg?1",
             "name": "Rivalry",
             "text": "During each player's upkeep, if that player controls more lands than any other, Rivalry deals 2 damage to him or her.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "9f2c8db1-595a-58db-85ce-8aa25aba2a6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112aa0e2-7e4a-4ae8-bedb-d84b4116df5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112aa0e2-7e4a-4ae8-bedb-d84b4116df5e.jpg?1",
             "name": "Shivan Phoenix",
             "text": "Flying\nWhen Shivan Phoenix is put into a graveyard from play, return Shivan Phoenix to owner's hand.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "90756eee-c12b-552d-9afb-b09256dd5e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba91431-3fcd-4b44-ae7b-a69eb18efd5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2ba91431-3fcd-4b44-ae7b-a69eb18efd5f.jpg?1",
             "name": "Sluggishness",
             "text": "Enchanted creature cannot block.\nWhen Sluggishness is put into a graveyard from play, return Sluggishness to owner's hand.",
             "colours": [
@@ -3069,7 +3069,7 @@
         },
         {
             "id": "59fad638-4516-504d-b90e-a7bb7b1fdb3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc07c6-60c7-4abe-8197-7544887ec64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26cc07c6-60c7-4abe-8197-7544887ec64d.jpg?1",
             "name": "Viashino Bey",
             "text": "When Viashino Bey attacks, all creatures you control attack if able.",
             "colours": [
@@ -3103,7 +3103,7 @@
         },
         {
             "id": "28fd6d50-9e87-5676-8a73-b8eda4b63e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbab69d-3259-40f4-a588-ab550858a178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcbab69d-3259-40f4-a588-ab550858a178.jpg?1",
             "name": "Viashino Cutthroat",
             "text": "Viashino Cutthroat is unaffected by summoning sickness.\nAt end of turn, return Viashino Cutthroat to owner's hand.",
             "colours": [
@@ -3137,7 +3137,7 @@
         },
         {
             "id": "8ea7255d-c7bc-5e2b-8b31-8ca1d4542683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e435e-e3a1-45b0-81c3-bd47916df8ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/143e435e-e3a1-45b0-81c3-bd47916df8ac.jpg?1",
             "name": "Viashino Heretic",
             "text": "o1o\nR, oc\nT: Destroy target artifact. Viashino Heretic deals to that artifact's controller damage equal to the artifact's total casting cost.",
             "colours": [
@@ -3171,7 +3171,7 @@
         },
         {
             "id": "6f6de059-9e8d-50da-b4cf-2dff2efa0bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd888a-ca98-44dd-a213-858c3539dc97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12dd888a-ca98-44dd-a213-858c3539dc97.jpg?1",
             "name": "Viashino Sandscout",
             "text": "Viashino Sandscout is unaffected by summoning sickness.\nAt end of turn, return Viashino Sandscout to owner's hand.",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "1cf1811b-db81-5562-9e94-7fc2c51d5589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9686f1a8-035e-415e-9a06-933d6ce1cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9686f1a8-035e-415e-9a06-933d6ce1cd5c.jpg?1",
             "name": "Bloated Toad",
             "text": "Protection from blue\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "f14438a8-a8d4-59a8-8221-535cd8cb43de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6563f790-862c-465a-b963-7a61f2385516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6563f790-862c-465a-b963-7a61f2385516.jpg?1",
             "name": "Crop Rotation",
             "text": "At the time you play Crop Rotation, sacrifice a land.\nSearch your library for a land card and put that land into play. Shuffle your library afterward.",
             "colours": [
@@ -3272,7 +3272,7 @@
         },
         {
             "id": "af4af472-43bc-56ab-a27d-ff8f282ce900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a807f-d5d0-4787-b390-3351783a1ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/212a807f-d5d0-4787-b390-3351783a1ae4.jpg?1",
             "name": "Darkwatch Elves",
             "text": "Protection from black\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3306,7 +3306,7 @@
         },
         {
             "id": "09bbb964-d134-59af-b967-458555e94647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e93381f-627f-41b6-b1b6-45d712a44d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e93381f-627f-41b6-b1b6-45d712a44d8e.jpg?1",
             "name": "Defense of the Heart",
             "text": "During your upkeep, if one of your opponents controls three or more creatures, sacrifice Defense of the Heart, search your library for up to two creature cards, and put those creatures into play. Shuffle your library afterward.",
             "colours": [
@@ -3338,7 +3338,7 @@
         },
         {
             "id": "03b78dda-0a5b-5295-af5c-ef255abb7acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e94c9-61c4-4cc0-b5ce-db62bc2660ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0e94c9-61c4-4cc0-b5ce-db62bc2660ee.jpg?1",
             "name": "Deranged Hermit",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Deranged Hermit comes into play, put four Squirrel tokens into play. Treat these tokens as 1/1 green creatures.\nAll Squirrels get +1/+1.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "e3b7149a-4906-5cee-a6e2-ba11722bf87e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84177f-43a3-4d14-9a4c-2ca931cfe092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a84177f-43a3-4d14-9a4c-2ca931cfe092.jpg?1",
             "name": "Gang of Elk",
             "text": "Whenever a creature blocks it, Gang of Elk gets +2/+2 until end of turn.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "288296dc-c79c-5678-8fd8-abb9d14e818e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aafc380-cf4d-4843-b9c3-c389d9c5e942.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aafc380-cf4d-4843-b9c3-c389d9c5e942.jpg?1",
             "name": "Harmonic Convergence",
             "text": "Return all enchantments to top of owners' libraries.",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "daa40298-e8cf-530d-bf61-3936ed57b882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f94da51-b4d9-4d79-9113-39f8f4a1be34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f94da51-b4d9-4d79-9113-39f8f4a1be34.jpg?1",
             "name": "Hidden Gibbons",
             "text": "When one of your opponents successfully casts an instant or interrupt spell, if Hidden Gibbons is an enchantment, Hidden Gibbons becomes a 4/4 creature that counts as an Ape.",
             "colours": [
@@ -3471,7 +3471,7 @@
         },
         {
             "id": "5839e309-1880-5123-9e4c-8d5d60106ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70ae8e9-852e-4e47-b48d-d1847666fc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70ae8e9-852e-4e47-b48d-d1847666fc50.jpg?1",
             "name": "Lone Wolf",
             "text": "You may have Lone Wolf deal combat damage to defending player instead of to creatures blocking it.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "e549c771-a332-576d-9cad-45e4906c5953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e48b989-bb64-4c71-9921-0a230fed5b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e48b989-bb64-4c71-9921-0a230fed5b11.jpg?1",
             "name": "Might of Oaks",
             "text": "Target creature gets +7/+7 until end of turn.",
             "colours": [
@@ -3537,7 +3537,7 @@
         },
         {
             "id": "bec05e4f-c529-5be4-8737-2529eef08b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6cc98b-b376-40af-8308-198bab00b2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d6cc98b-b376-40af-8308-198bab00b2b1.jpg?1",
             "name": "Multani, Maro-Sorcerer",
             "text": "Multani, Maro-Sorcerer has power and toughness each equal to the total number of cards in all players' hands.\nMultani cannot be the target of spells or abilities.",
             "colours": [
@@ -3573,7 +3573,7 @@
         },
         {
             "id": "0ec96b74-6c92-5400-ad99-804706989be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fdecb-bca0-48ea-b5bb-d0886c7d3316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5fdecb-bca0-48ea-b5bb-d0886c7d3316.jpg?1",
             "name": "Multani's Acolyte",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Multani's Acolyte comes into play, draw a card.",
             "colours": [
@@ -3607,7 +3607,7 @@
         },
         {
             "id": "7b7c2b9e-59b1-5fba-9afe-8b2475c376c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bfa984-5fe9-44ad-b13f-3276951f9f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38bfa984-5fe9-44ad-b13f-3276951f9f10.jpg?1",
             "name": "Multani's Presence",
             "text": "Whenever a spell you play is countered, draw a card.",
             "colours": [
@@ -3639,7 +3639,7 @@
         },
         {
             "id": "61d0d767-692b-556f-ace6-d0d080d5861e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e256c2-38df-4012-9308-ce17dd889e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e256c2-38df-4012-9308-ce17dd889e5f.jpg?1",
             "name": "Rancor",
             "text": "Enchanted creature gains +2/+0 and trample.\nWhen Rancor is put into a graveyard from play, return Rancor to owner's hand.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "b2ead781-2b26-5ede-a643-7dfe7103a22d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac77869-97bc-4976-9ee0-3d60e162b78a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aac77869-97bc-4976-9ee0-3d60e162b78a.jpg?1",
             "name": "Repopulate",
             "text": "Shuffle all creature cards from target player's graveyard into that player's library.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3705,7 +3705,7 @@
         },
         {
             "id": "e9d46d46-0265-5d30-9bf8-54e71c72a3c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9498a97a-0e32-4eb8-9cb4-0698ff3a7ded.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9498a97a-0e32-4eb8-9cb4-0698ff3a7ded.jpg?1",
             "name": "Silk Net",
             "text": "Target creature gets +1/+1 and can block creatures with flying until end of turn.",
             "colours": [
@@ -3737,7 +3737,7 @@
         },
         {
             "id": "65cd2130-1cae-54f4-be10-442beb720b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aaea3e-a67a-4d9c-9059-e6beb05f97b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0aaea3e-a67a-4d9c-9059-e6beb05f97b1.jpg?1",
             "name": "Simian Grunts",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nYou may play Simian Grunts any time you could play an instant.",
             "colours": [
@@ -3771,7 +3771,7 @@
         },
         {
             "id": "24f1a08e-81b5-5fd6-9822-1bde4ba93635",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697acf5-9bc5-411d-8574-fe6185f18672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9697acf5-9bc5-411d-8574-fe6185f18672.jpg?1",
             "name": "Treefolk Mystic",
             "text": "Whenever a creature blocks or is blocked by Treefolk Mystic, destroy all enchantments on that creature.",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "138843eb-3a96-5ae6-9ad4-8146188c053f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74f8ae-992b-40a6-87e3-7b321dba4ffa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74f8ae-992b-40a6-87e3-7b321dba4ffa.jpg?1",
             "name": "Weatherseed Elf",
             "text": "oc\nT: Target creature gains forestwalk until end of turn. (If defending player controls a forest, this creature is unblockable.)",
             "colours": [
@@ -3839,7 +3839,7 @@
         },
         {
             "id": "7db49e3a-8db8-572c-8908-8a13bbff3cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42cce45-3b6a-43e2-8329-68c30135c5c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f42cce45-3b6a-43e2-8329-68c30135c5c1.jpg?1",
             "name": "Weatherseed Treefolk",
             "text": "Trample\nWhen Weatherseed Treefolk is put into a graveyard from play, return Weatherseed Treefolk to owner's hand.",
             "colours": [
@@ -3873,7 +3873,7 @@
         },
         {
             "id": "3c3f4903-ab64-501f-963f-d961a8ebb3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19116d5d-8f2d-4e85-849d-1fbaa67e8cfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19116d5d-8f2d-4e85-849d-1fbaa67e8cfd.jpg?1",
             "name": "Wing Snare",
             "text": "Destroy target creature with flying.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "5b18bd48-be7b-5860-bff0-c50caae466ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414a41-b50c-49b6-9c27-f3170017d9b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05414a41-b50c-49b6-9c27-f3170017d9b0.jpg?1",
             "name": "Yavimaya Granger",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Yavimaya Granger comes into play, you may search your library for a basic land card and put that land into play tapped. Shuffle your library afterward.",
             "colours": [
@@ -3939,7 +3939,7 @@
         },
         {
             "id": "2a22f96e-74e5-5f41-ab12-f4b187a52844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f80036-1058-4513-8549-0557df9b5d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2f80036-1058-4513-8549-0557df9b5d61.jpg?1",
             "name": "Yavimaya Scion",
             "text": "Protection from artifacts",
             "colours": [
@@ -3973,7 +3973,7 @@
         },
         {
             "id": "fc701eaa-6d6a-51df-b71e-7e86c9617b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde16069-7176-42dc-88d8-fb37b7894007.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde16069-7176-42dc-88d8-fb37b7894007.jpg?1",
             "name": "Yavimaya Wurm",
             "text": "Trample",
             "colours": [
@@ -4007,7 +4007,7 @@
         },
         {
             "id": "248ca95b-5028-56a0-9e97-09c857455092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7b248a-3c74-4592-b357-47989568298c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c7b248a-3c74-4592-b357-47989568298c.jpg?1",
             "name": "Angel's Trumpet",
             "text": "Attacking does not cause creatures to tap.\nAt the end of each player's turn, tap all untapped creatures he or she controls that did not attack this turn. Angel's Trumpet deals 1 damage to that player for each creature tapped this way.",
             "colours": [],
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "24ca99ea-03fb-5e02-8920-eab75d899d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06578d72-50e9-468d-96d2-c0cbda14961a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06578d72-50e9-468d-96d2-c0cbda14961a.jpg?1",
             "name": "Beast of Burden",
             "text": "Beast of Burden has power and toughness each equal to the total number of creatures in play.",
             "colours": [],
@@ -4066,7 +4066,7 @@
         },
         {
             "id": "73de3536-1224-54eb-989c-9b0301531f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4913a54f-f4d0-483a-a181-716007f65658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4913a54f-f4d0-483a-a181-716007f65658.jpg?1",
             "name": "Crawlspace",
             "text": "No more than two creatures can attack you each combat.",
             "colours": [],
@@ -4094,7 +4094,7 @@
         },
         {
             "id": "4a0fe7f5-b117-5086-b7af-d4c2638577b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87841977-75ff-49c3-b832-3f0cf48b50b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87841977-75ff-49c3-b832-3f0cf48b50b2.jpg?1",
             "name": "Damping Engine",
             "text": "A player who controls more permanents than any other cannot play lands or artifact, creature, or enchantment spells. That player may sacrifice a permanent to ignore this effect until end of turn.",
             "colours": [],
@@ -4122,7 +4122,7 @@
         },
         {
             "id": "a7cf7d5a-661d-5417-b93c-7e85af91a448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2592c9-7e64-40c1-a9cb-c0994094a1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c2592c9-7e64-40c1-a9cb-c0994094a1e0.jpg?1",
             "name": "Defense Grid",
             "text": "During each player's turn, spells played by another player cost an additional o3.",
             "colours": [],
@@ -4150,7 +4150,7 @@
         },
         {
             "id": "2064bb5c-089c-5dc6-adf5-e885dec0cd24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc9fe1-17c8-4e1d-aeb8-c4214e881280.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9ddc9fe1-17c8-4e1d-aeb8-c4214e881280.jpg?1",
             "name": "Grim Monolith",
             "text": "Grim Monolith does not untap during your untap phase.\noc\nT: Add three colorless mana to your mana pool. Play this ability as a mana source.\no4: Untap Grim Monolith.",
             "colours": [],
@@ -4178,7 +4178,7 @@
         },
         {
             "id": "40ce73a9-2024-5feb-a916-f87d4d4d1e7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad925fb0-1d5c-44a0-8347-202a38c23107.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad925fb0-1d5c-44a0-8347-202a38c23107.jpg?1",
             "name": "Iron Maiden",
             "text": "During each of your opponent's upkeeps, Iron Maiden deals 1 damage to that player for each card more than four in his or her hand.",
             "colours": [],
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "5fc70b2f-655e-5f7e-a36e-ea6a1bfce06b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb38309-c02c-496c-894f-786a2f6e3d1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edb38309-c02c-496c-894f-786a2f6e3d1c.jpg?1",
             "name": "Jhoira's Toolbox",
             "text": "o2: Regenerate target artifact creature.",
             "colours": [],
@@ -4237,7 +4237,7 @@
         },
         {
             "id": "d290f0dd-ff0e-5387-8f5b-d922d84a90d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15d33d6-7213-4482-a1be-ac0a73644af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15d33d6-7213-4482-a1be-ac0a73644af6.jpg?1",
             "name": "Memory Jar",
             "text": "oc\nT, Sacrifice Memory Jar: Each player sets aside his or her hand, face down, and draws seven cards. At end of turn, each player discards his or her hand and returns to his or her hand each card he or she set aside this way.",
             "colours": [],
@@ -4265,7 +4265,7 @@
         },
         {
             "id": "2065bd1f-8ae1-52fe-a5d8-dc010774cf56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfdebbe-6432-426f-ac2a-5a9af3047813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecfdebbe-6432-426f-ac2a-5a9af3047813.jpg?1",
             "name": "Quicksilver Amulet",
             "text": "o4, oc\nT: Choose a creature card in your hand and put that creature into play.",
             "colours": [],
@@ -4293,7 +4293,7 @@
         },
         {
             "id": "18fb2a65-dcab-5f21-b458-02cd735c7bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09dc9b-ed01-49de-9675-48c41f428385.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b09dc9b-ed01-49de-9675-48c41f428385.jpg?1",
             "name": "Ring of Gix",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\no1, oc\nT: Tap target artifact, creature, or land.",
             "colours": [],
@@ -4321,7 +4321,7 @@
         },
         {
             "id": "2de0d9ef-5e3f-5ae4-a16d-fa62a76e3805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14aa4474-96a0-4c1d-a09d-73b9c1073b00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14aa4474-96a0-4c1d-a09d-73b9c1073b00.jpg?1",
             "name": "Scrapheap",
             "text": "Whenever an artifact or enchantment is put into your graveyard from play, gain 1 life.",
             "colours": [],
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "bd8693e8-5b29-5509-ba0a-7cfb54f1e8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c3666-5ba0-4f0a-adbe-a97af0aa28d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c3666-5ba0-4f0a-adbe-a97af0aa28d1.jpg?1",
             "name": "Thran Lens",
             "text": "All permanents are colorless.",
             "colours": [],
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "ff70e14d-8c48-5516-a230-958ae4276c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5908714a-be91-4279-b87e-e2bc09dbaaba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5908714a-be91-4279-b87e-e2bc09dbaaba.jpg?1",
             "name": "Thran War Machine",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nThran War Machine attacks each turn if able.",
             "colours": [],
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "7b073425-5f56-5f68-b6d0-f87039bf5c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f005ae-fca1-4a48-84a3-4b217ac879ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f005ae-fca1-4a48-84a3-4b217ac879ce.jpg?1",
             "name": "Thran Weaponry",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nYou may choose not to untap Thran Weaponry during your untap phase.\no2, oc\nT: All creatures get +2/+2 as long as Thran Weaponry remains tapped.",
             "colours": [],
@@ -4436,7 +4436,7 @@
         },
         {
             "id": "8a94ad84-6833-5720-bd4b-8ec429ece93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6241755c-ff3d-44db-a99d-960bea54633e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6241755c-ff3d-44db-a99d-960bea54633e.jpg?1",
             "name": "Ticking Gnomes",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nSacrifice Ticking Gnomes: Ticking Gnomes deals 1 damage to target creature or player.",
             "colours": [],
@@ -4467,7 +4467,7 @@
         },
         {
             "id": "341537dd-7c54-5a0b-86e9-485a922d2e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f0d4b-c13e-48a6-915f-b0edd2ac0ae8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026f0d4b-c13e-48a6-915f-b0edd2ac0ae8.jpg?1",
             "name": "Urza's Blueprints",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\noc\nT: Draw a card.",
             "colours": [],
@@ -4495,7 +4495,7 @@
         },
         {
             "id": "903a0972-1ecf-559d-94ee-f39d7eaab352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87edc873-169a-4cd3-8a94-84b5810b5ed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87edc873-169a-4cd3-8a94-84b5810b5ed8.jpg?1",
             "name": "Wheel of Torture",
             "text": "During each of your opponents' upkeeps, Wheel of Torture deals 1 damage to that player for each card fewer than three in his or her hand.",
             "colours": [],
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "6f0dc7d4-ec1a-5a6e-bc13-9d336279fc5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3ede87-b026-4781-81ab-8652664f8e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae3ede87-b026-4781-81ab-8652664f8e41.jpg?1",
             "name": "Faerie Conclave",
             "text": "Faerie Conclave comes into play tapped.\noc\nT: Add one blue mana to your mana pool.\no1oo\nU Faerie Conclave becomes a 2/1 blue creature with flying until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "cc7b0d64-1895-5bab-82ab-58db87ead554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96503ed7-aa68-439f-95b0-6ac2c48e3935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96503ed7-aa68-439f-95b0-6ac2c48e3935.jpg?1",
             "name": "Forbidding Watchtower",
             "text": "Forbidding Watchtower comes into play tapped.\noc\nT: Add one white mana to your mana pool.\no1oo\nW Forbidding Watchtower becomes a 1/5 white creature until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "e6f2d060-8dcc-564d-8e94-88c8fa854290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09ecef-1e30-4206-9648-8fe5c8a71c71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09ecef-1e30-4206-9648-8fe5c8a71c71.jpg?1",
             "name": "Ghitu Encampment",
             "text": "Ghitu Encampment comes into play tapped.\noc\nT: Add one red mana to your mana pool.\no1oo\nR Ghitu Encampment becomes a 2/1 red creature with first strike until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "042963f2-73d6-514a-b68e-4fdada5bc958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ffec42-57f7-4592-99ab-6284d59829a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ffec42-57f7-4592-99ab-6284d59829a1.jpg?1",
             "name": "Spawning Pool",
             "text": "Spawning Pool comes into play tapped.\noc\nT: Add one black mana to your mana pool.\no1oo\nB Spawning Pool becomes a 1/1 black creature with \"oo\nB Regenerate this creature\" until end of turn. This creature still counts as a land.",
             "colours": [],
@@ -4643,7 +4643,7 @@
         },
         {
             "id": "001f424c-6ae7-55f8-8a47-b396d77bc59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02212bd8-0c0f-4e8e-99f1-a8477476c03a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02212bd8-0c0f-4e8e-99f1-a8477476c03a.jpg?1",
             "name": "Treetop Village",
             "text": "Treetop Village comes into play tapped.\noc\nT: Add one green mana to your mana pool.\no1oo\nG Treetop Village becomes a 3/3 green creature with trample until end of turn. This creature still counts as a land.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/UMA.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UMA.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "05c7bdc4-44ed-5902-83cb-e8dfec9afba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf632ef-70e3-46f2-af21-14ea7ef30237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cf632ef-70e3-46f2-af21-14ea7ef30237.jpg?1",
             "name": "All Is Dust",
             "text": "Each player sacrifices all colored permanents they control.",
             "colours": [],
@@ -35,7 +35,7 @@
         },
         {
             "id": "288f57e6-ef6f-574d-962a-0c75610bae96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03648eff-8652-4750-a3d2-3338ce9e5a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03648eff-8652-4750-a3d2-3338ce9e5a81.jpg?1",
             "name": "Artisan of Kozilek",
             "text": "When you cast this spell, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -65,7 +65,7 @@
         },
         {
             "id": "c4200f49-324e-5bc7-b756-9dd0b4c84459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3909816-5cc2-4712-bc7d-534ae0b9229c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3909816-5cc2-4712-bc7d-534ae0b9229c.jpg?1",
             "name": "Eldrazi Conscription",
             "text": "Enchant creature\nEnchanted creature gets +10/+10 and has trample and annihilator 2. (Whenever it attacks, defending player sacrifices two permanents.)",
             "colours": [],
@@ -97,7 +97,7 @@
         },
         {
             "id": "6e19a078-9ed1-55de-bc16-9e1cc2c92a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1",
             "name": "Emrakul, the Aeons Torn",
             "text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -129,7 +129,7 @@
         },
         {
             "id": "351d222e-eb1d-5d2d-9fcf-941df021e2ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69714257-2848-48e1-95cf-cdb6595215f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69714257-2848-48e1-95cf-cdb6595215f0.jpg?1",
             "name": "Karn Liberated",
             "text": "+4: Target player exiles a card from their hand.\n\u22123: Exile target permanent.\n\u221214: Restart the game, leaving in exile all non-Aura permanent cards exiled with Karn Liberated. Then put those cards onto the battlefield under your control.",
             "colours": [],
@@ -161,7 +161,7 @@
         },
         {
             "id": "95fd5ccb-168d-581f-aa9a-ea8e96d3cbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d47a1c7-d32b-425a-b15d-24eb35318f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d47a1c7-d32b-425a-b15d-24eb35318f6f.jpg?1",
             "name": "Kozilek, Butcher of Truth",
             "text": "When you cast this spell, draw four cards.\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Kozilek, Butcher of Truth is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -193,7 +193,7 @@
         },
         {
             "id": "7cb58593-21c9-5444-b943-234bdd0d07e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe0f77f-5092-4372-83fb-269dfb11f9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffe0f77f-5092-4372-83fb-269dfb11f9b5.jpg?1",
             "name": "Ulamog, the Infinite Gyre",
             "text": "When you cast this spell, destroy target permanent.\nIndestructible\nAnnihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents.)\nWhen Ulamog, the Infinite Gyre is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
             "colours": [],
@@ -225,7 +225,7 @@
         },
         {
             "id": "ad6d1578-7ab6-58f3-ae64-8b282cd56157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda0fd38-38e6-4e9b-9c17-4d855e01b1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/eda0fd38-38e6-4e9b-9c17-4d855e01b1e1.jpg?1",
             "name": "Ulamog's Crusher",
             "text": "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents.)\nUlamog's Crusher attacks each combat if able.",
             "colours": [],
@@ -255,7 +255,7 @@
         },
         {
             "id": "02f098cf-93bc-5a4e-8d29-724d3b273cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f39f9-fbdf-4096-9bd7-a7b2481e2dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f39f9-fbdf-4096-9bd7-a7b2481e2dbd.jpg?1",
             "name": "Ancestor's Chosen",
             "text": "First strike\nWhen Ancestor's Chosen enters the battlefield, you gain 1 life for each card in your graveyard.",
             "colours": [
@@ -290,7 +290,7 @@
         },
         {
             "id": "c23c14ab-26a1-587c-8f6a-e38b51797aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03fc1f1-31f6-4e52-87d0-e3d18ea60d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a03fc1f1-31f6-4e52-87d0-e3d18ea60d3b.jpg?1",
             "name": "Angelic Renewal",
             "text": "Whenever a creature is put into your graveyard from the battlefield, you may sacrifice Angelic Renewal. If you do, return that card to the battlefield.",
             "colours": [
@@ -322,7 +322,7 @@
         },
         {
             "id": "10bcd0b5-e33a-5ec4-80f2-f8c6e596d0d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bece9c5-1a2f-44e1-b7f4-9498da558bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bece9c5-1a2f-44e1-b7f4-9498da558bc8.jpg?1",
             "name": "Containment Priest",
             "text": "Flash\nIf a nontoken creature would enter the battlefield and it wasn't cast, exile it instead.",
             "colours": [
@@ -357,7 +357,7 @@
         },
         {
             "id": "0e871107-1ee2-566b-9d00-cc26d52b342f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94507660-cf60-4fd8-a796-7a6e6f28396d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94507660-cf60-4fd8-a796-7a6e6f28396d.jpg?1",
             "name": "Conviction",
             "text": "Enchant creature\nEnchanted creature gets +1/+3.\n{W}: Return Conviction to its owner's hand.",
             "colours": [
@@ -391,7 +391,7 @@
         },
         {
             "id": "a35e078e-d519-513c-92d5-d6c3d486444f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec653f1-32ce-4eb5-8d18-f56a7bbabac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec653f1-32ce-4eb5-8d18-f56a7bbabac6.jpg?1",
             "name": "Dawn Charm",
             "text": "Choose one \u2014\n\u2022 Prevent all combat damage that would be dealt this turn.\n\u2022 Regenerate target creature.\n\u2022 Counter target spell that targets you.",
             "colours": [
@@ -423,7 +423,7 @@
         },
         {
             "id": "f0fd7a1d-33a5-5249-88c7-aeda5e5ad310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818537cd-4c95-4538-b61f-c276a6fc8864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/818537cd-4c95-4538-b61f-c276a6fc8864.jpg?1",
             "name": "Daybreak Coronet",
             "text": "Enchant creature with another Aura attached to it\nEnchanted creature gets +3/+3 and has first strike, vigilance, and lifelink.",
             "colours": [
@@ -457,7 +457,7 @@
         },
         {
             "id": "f3b1addf-c375-5753-9ce7-cff99bfbd908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189e0728-94e3-43af-a341-d2bbb33b6b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/189e0728-94e3-43af-a341-d2bbb33b6b32.jpg?1",
             "name": "Emancipation Angel",
             "text": "Flying\nWhen Emancipation Angel enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -491,7 +491,7 @@
         },
         {
             "id": "e310cf84-2575-5cd0-8313-079e83311e22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8e887e-bf53-44e3-b3e5-d00d8974d0b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c8e887e-bf53-44e3-b3e5-d00d8974d0b3.jpg?1",
             "name": "Faith's Fetters",
             "text": "Enchant permanent\nWhen Faith's Fetters enters the battlefield, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
             "colours": [
@@ -525,7 +525,7 @@
         },
         {
             "id": "c5a54f1b-a2e0-5a0c-905a-3e4b8843f683",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02e3c30-e540-4d7b-a17b-3eece63743cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02e3c30-e540-4d7b-a17b-3eece63743cb.jpg?1",
             "name": "Fiend Hunter",
             "text": "When Fiend Hunter enters the battlefield, you may exile another target creature.\nWhen Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -560,7 +560,7 @@
         },
         {
             "id": "5fb3457f-dcab-543c-b0e7-77e8d589426e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d95d57f-daaf-49d2-b26f-2058c065f0fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d95d57f-daaf-49d2-b26f-2058c065f0fe.jpg?1",
             "name": "Gods Willing",
             "text": "Target creature you control gains protection from the color of your choice until end of turn. Scry 1.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "3fd293a6-d0f0-5120-a8ff-69103aee2130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753dd235-55d3-4124-9b43-74517534bd87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/753dd235-55d3-4124-9b43-74517534bd87.jpg?1",
             "name": "Heliod's Pilgrim",
             "text": "When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -627,7 +627,7 @@
         },
         {
             "id": "d1ef694b-3bac-55b5-979a-100217937482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc9a63b-e7cd-404a-8d5c-0c1396e16d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc9a63b-e7cd-404a-8d5c-0c1396e16d0b.jpg?1",
             "name": "Hero of Iroas",
             "text": "Aura spells you cast cost {1} less to cast.\nHeroic \u2014 Whenever you cast a spell that targets Hero of Iroas, put a +1/+1 counter on Hero of Iroas.",
             "colours": [
@@ -662,7 +662,7 @@
         },
         {
             "id": "190b3a1d-1365-5a5a-b7aa-2e823a993c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87128a82-bcde-4def-9447-0ab8165d6b5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87128a82-bcde-4def-9447-0ab8165d6b5e.jpg?1",
             "name": "Hyena Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has first strike.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "b67b7df3-0b5b-5d10-8696-7622d5096d05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ba6543-ede7-45a5-8e8d-e17d3f545d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ba6543-ede7-45a5-8e8d-e17d3f545d3f.jpg?1",
             "name": "Icatian Crier",
             "text": "{1}{W}, {T}, Discard a card: Create two 1/1 white Citizen creature tokens.",
             "colours": [
@@ -731,7 +731,7 @@
         },
         {
             "id": "80308f62-a223-5b5f-88e5-b59f273cf847",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3170852-60a9-46bc-8183-b1a65fc3b82b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3170852-60a9-46bc-8183-b1a65fc3b82b.jpg?1",
             "name": "Lotus-Eye Mystics",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen Lotus-Eye Mystics enters the battlefield, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -766,7 +766,7 @@
         },
         {
             "id": "7dbdc989-a069-525d-bf97-b0f94f0ccf00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9195c-cd12-47b7-8ebc-5c4a77a9002a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9195c-cd12-47b7-8ebc-5c4a77a9002a.jpg?1",
             "name": "Mammoth Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3 and has vigilance.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -800,7 +800,7 @@
         },
         {
             "id": "43334efa-a18e-505a-8ec0-a32337ff7c62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d4a6b-af72-4d44-a25f-dce8e12da727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010d4a6b-af72-4d44-a25f-dce8e12da727.jpg?1",
             "name": "Martyr of Sands",
             "text": "{1}, Reveal X white cards from your hand, Sacrifice Martyr of Sands: You gain three times X life.",
             "colours": [
@@ -835,7 +835,7 @@
         },
         {
             "id": "63cf5042-0594-554b-8bff-135d69911e02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3459d9-a667-4cee-9b39-844013576d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b3459d9-a667-4cee-9b39-844013576d0b.jpg?1",
             "name": "Miraculous Recovery",
             "text": "Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.",
             "colours": [
@@ -867,7 +867,7 @@
         },
         {
             "id": "ce51cbe9-065e-511e-a0da-ed86299bba06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d22985-4354-4015-bd74-0ddf4f0cdf17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d22985-4354-4015-bd74-0ddf4f0cdf17.jpg?1",
             "name": "Phalanx Leader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Phalanx Leader, put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -902,7 +902,7 @@
         },
         {
             "id": "b12965cf-d3d7-582b-8a69-d6729ad40a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b300df0-c867-41e6-a1fd-fe547ed3dc51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b300df0-c867-41e6-a1fd-fe547ed3dc51.jpg?1",
             "name": "Rally the Peasants",
             "text": "Creatures you control get +2/+0 until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -935,7 +935,7 @@
         },
         {
             "id": "898b7dbd-98ed-5cd1-9249-8608a19a96e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced55b-27e2-4549-90e4-31c9718e1395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ced55b-27e2-4549-90e4-31c9718e1395.jpg?1",
             "name": "Repel the Darkness",
             "text": "Tap up to two target creatures.\nDraw a card.",
             "colours": [
@@ -967,7 +967,7 @@
         },
         {
             "id": "1bfcefe6-3156-5d50-99d4-1977e5f7b7d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a176b295-9406-4d6b-b15c-e81a72e66874.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a176b295-9406-4d6b-b15c-e81a72e66874.jpg?1",
             "name": "Resurrection",
             "text": "Return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -999,7 +999,7 @@
         },
         {
             "id": "7f20e0de-35bc-5c06-b4b8-218dfead93e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcf9b52-d249-41e7-8ed1-ba9acc816f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bcf9b52-d249-41e7-8ed1-ba9acc816f30.jpg?1",
             "name": "Reveillark",
             "text": "Flying\nWhen Reveillark leaves the battlefield, return up to two target creature cards with power 2 or less from your graveyard to the battlefield.\nEvoke {5}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "58bec4ad-afeb-5459-8473-ed8f3da6b25c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b45bdd-829a-4fc1-ad37-17c2bd57fac8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b45bdd-829a-4fc1-ad37-17c2bd57fac8.jpg?1",
             "name": "Reya Dawnbringer",
             "text": "Flying\nAt the beginning of your upkeep, you may return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "a05977f6-93ae-5bb1-aeb5-ba7e6cebe08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810e22f-11fd-48a8-a057-2d80f3088691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810e22f-11fd-48a8-a057-2d80f3088691.jpg?1",
             "name": "Ronom Unicorn",
             "text": "Sacrifice Ronom Unicorn: Destroy target enchantment.",
             "colours": [
@@ -1103,7 +1103,7 @@
         },
         {
             "id": "c486e539-7dbb-521c-87b1-ad2f58797dbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c401fabd-52fb-4c59-9c72-10ff97dda45f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c401fabd-52fb-4c59-9c72-10ff97dda45f.jpg?1",
             "name": "Runed Halo",
             "text": "As Runed Halo enters the battlefield, choose a card name.\nYou have protection from the chosen name. (You can't be targeted, dealt damage, or enchanted by anything with that name.)",
             "colours": [
@@ -1135,7 +1135,7 @@
         },
         {
             "id": "469085c4-6105-5fbb-9e6e-cc8b3596a6ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64393586-42c6-4874-9473-85c63c7ed2ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64393586-42c6-4874-9473-85c63c7ed2ad.jpg?1",
             "name": "Sigil of the New Dawn",
             "text": "Whenever a creature is put into your graveyard from the battlefield, you may pay {1}{W}. If you do, return that card to your hand.",
             "colours": [
@@ -1167,7 +1167,7 @@
         },
         {
             "id": "6c6d960b-a8ef-559d-9925-eef50579ed00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41a35c6-14d9-4b8f-88f1-f1442e4ef222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41a35c6-14d9-4b8f-88f1-f1442e4ef222.jpg?1",
             "name": "Skyspear Cavalry",
             "text": "Flying, double strike",
             "colours": [
@@ -1202,7 +1202,7 @@
         },
         {
             "id": "a7e172e9-d995-5ccf-b606-3d35181a7744",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3ee404-0501-41bc-b56a-ebf16f693511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3ee404-0501-41bc-b56a-ebf16f693511.jpg?1",
             "name": "Spirit Cairn",
             "text": "Whenever a player discards a card, you may pay {W}. If you do, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -1234,7 +1234,7 @@
         },
         {
             "id": "6ae222ce-482b-500e-8cdb-63aa16c208b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e53129-c49b-4bb8-a816-629fc87e58bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e53129-c49b-4bb8-a816-629fc87e58bb.jpg?1",
             "name": "Sublime Archangel",
             "text": "Flying\nExalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nOther creatures you control have exalted. (If a creature has multiple instances of exalted, each triggers separately.)",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "80064910-e5f0-5f59-a569-7093b9129897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820096b5-0d64-47a0-88a4-17d3f24cb165.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/820096b5-0d64-47a0-88a4-17d3f24cb165.jpg?1",
             "name": "Swift Reckoning",
             "text": "Spell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you may cast Swift Reckoning as though it had flash.\nDestroy target tapped creature.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "7febf777-aa47-5698-9f89-366d661ef7ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51baeea2-a922-4e98-8253-f395546c30c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51baeea2-a922-4e98-8253-f395546c30c8.jpg?1",
             "name": "Tethmos High Priest",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Tethmos High Priest, return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.",
             "colours": [
@@ -1335,7 +1335,7 @@
         },
         {
             "id": "4f43738e-c0f6-5a71-9160-f42005b8808f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1515e039-b838-40b6-b087-eb9e9d9ff008.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1515e039-b838-40b6-b087-eb9e9d9ff008.jpg?1",
             "name": "Wall of Reverence",
             "text": "Defender, flying\nAt the beginning of your end step, you may gain life equal to the power of target creature you control.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "b33f129d-04dd-5bfa-baa5-24ef5ed7bbfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02599bd-c5d8-4bdc-9478-a7bad8185552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02599bd-c5d8-4bdc-9478-a7bad8185552.jpg?1",
             "name": "Wandering Champion",
             "text": "Whenever Wandering Champion deals combat damage to a player, if you control a blue or red permanent, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -1405,7 +1405,7 @@
         },
         {
             "id": "06143991-52a7-5f0e-84a1-8865a064698f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b189050-522b-4b8a-b4e6-1f5158ebe519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b189050-522b-4b8a-b4e6-1f5158ebe519.jpg?1",
             "name": "Wingsteed Rider",
             "text": "Flying\nHeroic \u2014 Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.",
             "colours": [
@@ -1440,7 +1440,7 @@
         },
         {
             "id": "3f8073ad-f3ae-566a-84f6-25e4b19be6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f04e69-aa5b-495c-ab17-31fc2ff7288a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5f04e69-aa5b-495c-ab17-31fc2ff7288a.jpg?1",
             "name": "Aethersnipe",
             "text": "When Aethersnipe enters the battlefield, return target nonland permanent to its owner's hand.\nEvoke {1}{U}{U} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -1474,7 +1474,7 @@
         },
         {
             "id": "36e15f96-82f0-59cc-ba1e-12b4b73f3dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc258713-6ce3-44e0-9b4b-8fa7d1d093a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc258713-6ce3-44e0-9b4b-8fa7d1d093a1.jpg?1",
             "name": "Archaeomancer",
             "text": "When Archaeomancer enters the battlefield, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1509,7 +1509,7 @@
         },
         {
             "id": "6663837c-665b-503b-ab35-717f9e40c44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6c2-0f72-4e79-a55d-1f06dffa48c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0600d6c2-0f72-4e79-a55d-1f06dffa48c2.jpg?1",
             "name": "Back to Basics",
             "text": "Nonbasic lands don't untap during their controllers' untap steps.",
             "colours": [
@@ -1541,7 +1541,7 @@
         },
         {
             "id": "1696f7b9-1edd-5c89-a531-2eef2885fade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472de0e2-c15b-49c4-b2fd-74b776daac34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/472de0e2-c15b-49c4-b2fd-74b776daac34.jpg?1",
             "name": "Circular Logic",
             "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -1573,7 +1573,7 @@
         },
         {
             "id": "eb0c8680-6e92-5e57-9cd8-045c52afc291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6c69-e5c4-47b0-b226-4e1d84fabfa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c31e6c69-e5c4-47b0-b226-4e1d84fabfa7.jpg?1",
             "name": "Defy Gravity",
             "text": "Target creature gains flying until end of turn.\nFlashback {U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "d75c9e2e-3be5-5ae2-ae4e-2d11a5fec543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093610b6-3fe3-4f12-859f-569857fa341b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093610b6-3fe3-4f12-859f-569857fa341b.jpg?1",
             "name": "Deranged Assistant",
             "text": "{T}, Put the top card of your library into your graveyard: Add {C}.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "8adfd3be-8dfc-5995-8bbb-f0eb9d1113cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cd4184-93ce-4005-b6d1-140afa3dd429.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cd4184-93ce-4005-b6d1-140afa3dd429.jpg?1",
             "name": "Dig Through Time",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nLook at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "860d21e5-e629-5928-99b5-7823b1a11fde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b20c4-f69b-45ed-8c9e-50847f215e73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b46b20c4-f69b-45ed-8c9e-50847f215e73.jpg?1",
             "name": "Disrupting Shoal",
             "text": "You may exile a blue card with converted mana cost X from your hand rather than pay this spell's mana cost.\nCounter target spell if its converted mana cost is X.",
             "colours": [
@@ -1706,7 +1706,7 @@
         },
         {
             "id": "6f448448-c1bb-5bac-880b-34fe4fe7ebaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527bc84-fa66-4763-a035-344e6458e54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f527bc84-fa66-4763-a035-344e6458e54b.jpg?1",
             "name": "Dreamscape Artist",
             "text": "{2}{U}, {T}, Discard a card, Sacrifice a land: Search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.",
             "colours": [
@@ -1741,7 +1741,7 @@
         },
         {
             "id": "f98483bf-deca-5c73-acc4-a31b40a0f43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc0fa64-0e2e-4f7a-8516-20c06fc57351.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc0fa64-0e2e-4f7a-8516-20c06fc57351.jpg?1",
             "name": "Eel Umbra",
             "text": "Flash\nEnchant creature\nEnchanted creature gets +1/+1.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -1775,7 +1775,7 @@
         },
         {
             "id": "45bf07f3-68a6-58bc-a868-d13ef46ee63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b770973-2061-44cb-8c02-b2251d711e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b770973-2061-44cb-8c02-b2251d711e92.jpg?1",
             "name": "Flight of Fancy",
             "text": "Enchant creature\nWhen Flight of Fancy enters the battlefield, draw two cards.\nEnchanted creature has flying.",
             "colours": [
@@ -1809,7 +1809,7 @@
         },
         {
             "id": "b9bf282f-2d26-5277-afc4-a87133d9f4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b39fd6-9240-4f76-b12c-e7d9aa88f061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8b39fd6-9240-4f76-b12c-e7d9aa88f061.jpg?1",
             "name": "Foil",
             "text": "You may discard an Island card and another card rather than pay this spell's mana cost.\nCounter target spell.",
             "colours": [
@@ -1841,7 +1841,7 @@
         },
         {
             "id": "e78298d6-463c-5dd9-85fe-7147e3bc1fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70dcc0d-aaa2-4815-be83-daafe441ceb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70dcc0d-aaa2-4815-be83-daafe441ceb4.jpg?1",
             "name": "Forbidden Alchemy",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "6f7d304f-f335-515c-a367-3a0ab3df49ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a6d5a5-ea8a-4d13-a8a6-11587f1bde44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8a6d5a5-ea8a-4d13-a8a6-11587f1bde44.jpg?1",
             "name": "Frantic Search",
             "text": "Draw two cards, then discard two cards. Untap up to three lands.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "bbb2d174-c8d5-51d3-96c7-8ea065069372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9af767-42da-46c7-a2b8-3957b2e3063f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd9af767-42da-46c7-a2b8-3957b2e3063f.jpg?1",
             "name": "Glen Elendra Archmage",
             "text": "Flying\n{U}, Sacrifice Glen Elendra Archmage: Counter target noncreature spell.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "1e40e99b-977e-52e8-81eb-8618592c8913",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c99c962-aa33-4e19-96b2-7a05b97d06d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c99c962-aa33-4e19-96b2-7a05b97d06d4.jpg?1",
             "name": "Iridescent Drake",
             "text": "Flying\nWhen Iridescent Drake enters the battlefield, put target Aura card from a graveyard onto the battlefield under your control attached to Iridescent Drake.",
             "colours": [
@@ -1975,7 +1975,7 @@
         },
         {
             "id": "e830232a-8c0f-548b-b0a8-0a8f27eb6c0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e40878-358d-48ec-a35f-3d9867728143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e40878-358d-48ec-a35f-3d9867728143.jpg?1",
             "name": "Just the Wind",
             "text": "Return target creature to its owner's hand.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -2007,7 +2007,7 @@
         },
         {
             "id": "e518a1e0-0222-553f-852d-2503aeefc28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608567fd-9f94-4058-831a-77cb6019ef02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608567fd-9f94-4058-831a-77cb6019ef02.jpg?1",
             "name": "Laboratory Maniac",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.",
             "colours": [
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "909ec540-187d-587e-a370-0c0badf81215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa314d92-51e5-4c09-963c-761e83dc84bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa314d92-51e5-4c09-963c-761e83dc84bc.jpg?1",
             "name": "Living Lore",
             "text": "As Living Lore enters the battlefield, exile an instant or sorcery card from your graveyard.\nLiving Lore's power and toughness are each equal to the exiled card's converted mana cost.\nWhenever Living Lore deals combat damage, you may sacrifice it. If you do, you may cast the exiled card without paying its mana cost.",
             "colours": [
@@ -2076,7 +2076,7 @@
         },
         {
             "id": "6c97a1d1-d0d9-59fd-bb40-6dddfe9fab75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117ed81-7b5c-4e29-b958-6126d48ac5a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d117ed81-7b5c-4e29-b958-6126d48ac5a6.jpg?1",
             "name": "Magus of the Bazaar",
             "text": "{T}: Draw two cards, then discard three cards.",
             "colours": [
@@ -2111,7 +2111,7 @@
         },
         {
             "id": "45b505dd-9fb7-57f7-85b8-52b1045282e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855de173-6bec-457b-828e-28678b7d396e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855de173-6bec-457b-828e-28678b7d396e.jpg?1",
             "name": "Mahamoti Djinn",
             "text": "Flying",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "f972585f-574c-5194-98d8-e6eb1b745e30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a288d3-c769-4681-828b-9b7579d93469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a288d3-c769-4681-828b-9b7579d93469.jpg?1",
             "name": "Marang River Prowler",
             "text": "Marang River Prowler can't block and can't be blocked.\nYou may cast Marang River Prowler from your graveyard as long as you control a black or green permanent.",
             "colours": [
@@ -2180,7 +2180,7 @@
         },
         {
             "id": "2ec5246b-f0f7-514b-b504-bb3e59585a5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5a2f5e-b9b3-41ee-a659-76dd763bad65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e5a2f5e-b9b3-41ee-a659-76dd763bad65.jpg?1",
             "name": "Mystic Retrieval",
             "text": "Return target instant or sorcery card from your graveyard to your hand.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2213,7 +2213,7 @@
         },
         {
             "id": "d13749b6-1e41-50e8-b707-34e000b1b9a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbca952-b4e8-4833-aee3-7da8ae82906e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdbca952-b4e8-4833-aee3-7da8ae82906e.jpg?1",
             "name": "Rise from the Tides",
             "text": "Create a tapped 2/2 black Zombie creature token for each instant and sorcery card in your graveyard.",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "e5e1bb76-9ffa-5a39-919a-f333ed01e3d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d72a34-0f31-4fec-b5a5-4574199bc312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40d72a34-0f31-4fec-b5a5-4574199bc312.jpg?1",
             "name": "Rune Snag",
             "text": "Counter target spell unless its controller pays {2} plus an additional {2} for each card named Rune Snag in each graveyard.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "8af8f805-a52c-53fa-a6e4-fa0037bc1929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712408f9-4bc2-447d-8efe-59c5d53ae364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/712408f9-4bc2-447d-8efe-59c5d53ae364.jpg?1",
             "name": "Skywing Aven",
             "text": "Flying\nDiscard a card: Return Skywing Aven to its owner's hand.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "05795614-2951-5a56-9b61-1b67ff6d4ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1766d117-6ee1-4103-88e8-47b932a94d65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1766d117-6ee1-4103-88e8-47b932a94d65.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "d25046d3-845e-5722-8a48-7f0521acaf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41765e-43fe-461d-baeb-ee30d13d2d93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41765e-43fe-461d-baeb-ee30d13d2d93.jpg?1",
             "name": "Snapcaster Mage",
             "text": "Flash\nWhen Snapcaster Mage enters the battlefield, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "f90184bc-6710-53b1-9d41-72f95ec62a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736f293a-10b5-43bc-8aad-cb63f00601a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736f293a-10b5-43bc-8aad-cb63f00601a6.jpg?1",
             "name": "Stitched Drake",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nFlying",
             "colours": [
@@ -2414,7 +2414,7 @@
         },
         {
             "id": "7b2a221c-9be8-54a0-86b5-9b04e3bbb66b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717e34b9-161e-4b11-afb1-f41ee8027433.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717e34b9-161e-4b11-afb1-f41ee8027433.jpg?1",
             "name": "Stitcher's Apprentice",
             "text": "{1}{U}, {T}: Create a 2/2 blue Homunculus creature token, then sacrifice a creature.",
             "colours": [
@@ -2448,7 +2448,7 @@
         },
         {
             "id": "4b7d52a5-6f30-5274-bb45-eaf38193b92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4faef057-8734-442b-a213-c309c219cdee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4faef057-8734-442b-a213-c309c219cdee.jpg?1",
             "name": "Stream of Consciousness",
             "text": "Target player shuffles up to four target cards from their graveyard into their library.",
             "colours": [
@@ -2482,7 +2482,7 @@
         },
         {
             "id": "64ee7a7c-2123-5f65-93de-55d8fe0c631e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c3936-1d30-4b1b-85ae-64c2be7d37c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f83c3936-1d30-4b1b-85ae-64c2be7d37c0.jpg?1",
             "name": "Sultai Skullkeeper",
             "text": "When Sultai Skullkeeper enters the battlefield, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -2517,7 +2517,7 @@
         },
         {
             "id": "986f4b04-21a1-5161-8128-3c0aa302656f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74e76-c6ce-4107-8816-0be8c20d7617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83c74e76-c6ce-4107-8816-0be8c20d7617.jpg?1",
             "name": "Talrand, Sky Summoner",
             "text": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -2554,7 +2554,7 @@
         },
         {
             "id": "dc3ed620-63db-5469-9459-dc6acad4fc25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270b93e-8cd2-4668-982a-f4c4628da9d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6270b93e-8cd2-4668-982a-f4c4628da9d9.jpg?1",
             "name": "Temporal Manipulation",
             "text": "Take an extra turn after this one.",
             "colours": [
@@ -2586,7 +2586,7 @@
         },
         {
             "id": "aa559b7f-090f-5970-865a-503d4317e16b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73db9c10-109a-417f-81cd-489d9510cc78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73db9c10-109a-417f-81cd-489d9510cc78.jpg?1",
             "name": "Think Twice",
             "text": "Draw a card.\nFlashback {2}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2618,7 +2618,7 @@
         },
         {
             "id": "90a92698-0b3e-5db3-8df6-1d8fd8168771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff91245-57d8-4020-b260-495c938a515b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff91245-57d8-4020-b260-495c938a515b.jpg?1",
             "name": "Treasure Cruise",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDraw three cards.",
             "colours": [
@@ -2650,7 +2650,7 @@
         },
         {
             "id": "326a85f3-0571-5af8-b5a3-09f31e94f618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66b93a-11a6-4861-a775-d309b7adc461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66b93a-11a6-4861-a775-d309b7adc461.jpg?1",
             "name": "Unstable Mutation",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nAt the beginning of the upkeep of enchanted creature's controller, put a -1/-1 counter on that creature.",
             "colours": [
@@ -2684,7 +2684,7 @@
         },
         {
             "id": "ec1f67e5-1903-506e-8452-6e9e904f7031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b97772-9490-4db3-b4dd-a87d973680a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b97772-9490-4db3-b4dd-a87d973680a5.jpg?1",
             "name": "Visions of Beyond",
             "text": "Draw a card. If a graveyard has twenty or more cards in it, draw three cards instead.",
             "colours": [
@@ -2716,7 +2716,7 @@
         },
         {
             "id": "b02f4068-2594-51fd-8ebc-478a0c2e02d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdbe6b5-7f67-42f1-be8f-637c35417925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdbe6b5-7f67-42f1-be8f-637c35417925.jpg?1",
             "name": "Whirlwind Adept",
             "text": "Hexproof\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -2751,7 +2751,7 @@
         },
         {
             "id": "fb905337-235a-5701-9d9d-1f5c0b0fe566",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f20b88-7b48-4d3b-b836-c7aef71cd337.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f20b88-7b48-4d3b-b836-c7aef71cd337.jpg?1",
             "name": "Appetite for Brains",
             "text": "Target opponent reveals their hand. You choose a card from it with converted mana cost 4 or greater and exile that card.",
             "colours": [
@@ -2783,7 +2783,7 @@
         },
         {
             "id": "968ad7ce-9bb4-53f4-a7a8-2fe621623185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d86ad3-e0a1-43da-9dc1-a9028b719c99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18d86ad3-e0a1-43da-9dc1-a9028b719c99.jpg?1",
             "name": "Apprentice Necromancer",
             "text": "{B}, {T}, Sacrifice Apprentice Necromancer: Return target creature card from your graveyard to the battlefield. That creature gains haste. At the beginning of the next end step, sacrifice it.",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "f993a629-cd4c-5d87-b071-40d2d3484d15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547872bd-d2b3-4c24-b3fb-481e0c90c3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/547872bd-d2b3-4c24-b3fb-481e0c90c3c0.jpg?1",
             "name": "Bitterblossom",
             "text": "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
             "colours": [
@@ -2853,7 +2853,7 @@
         },
         {
             "id": "287c6e8e-9b14-5d88-8d8b-750e43c2fb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a788fb3-fc21-47b2-b387-ceff438969af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a788fb3-fc21-47b2-b387-ceff438969af.jpg?1",
             "name": "Bloodflow Connoisseur",
             "text": "Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.",
             "colours": [
@@ -2887,7 +2887,7 @@
         },
         {
             "id": "558143cf-fcd8-5bca-9270-2ed114676a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faaa657-8b02-41a9-8a99-31a223d2caa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3faaa657-8b02-41a9-8a99-31a223d2caa5.jpg?1",
             "name": "Bridge from Below",
             "text": "Whenever a nontoken creature is put into your graveyard from the battlefield, if Bridge from Below is in your graveyard, create a 2/2 black Zombie creature token.\nWhen a creature is put into an opponent's graveyard from the battlefield, if Bridge from Below is in your graveyard, exile Bridge from Below.",
             "colours": [
@@ -2919,7 +2919,7 @@
         },
         {
             "id": "66b727f1-4e3c-542f-88a6-983f57e01623",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f51145-aade-4955-b9e7-4a34074253d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5f51145-aade-4955-b9e7-4a34074253d6.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards, put them into your graveyard, then shuffle your library.",
             "colours": [
@@ -2951,7 +2951,7 @@
         },
         {
             "id": "2e3becb4-5f3a-5eab-9f0a-7ca9f6da6b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36a583a-d4be-4589-a43c-a2854de062c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a36a583a-d4be-4589-a43c-a2854de062c6.jpg?1",
             "name": "Chainer's Edict",
             "text": "Target player sacrifices a creature.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -2983,7 +2983,7 @@
         },
         {
             "id": "96dc1ffb-6c7d-5296-bef9-cf041b3aa19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d66d3-03e1-4a6e-bb8e-7ad32faea2bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7d66d3-03e1-4a6e-bb8e-7ad32faea2bc.jpg?1",
             "name": "Crow of Dark Tidings",
             "text": "Flying\nWhen Crow of Dark Tidings enters the battlefield or dies, put the top two cards of your library into your graveyard.",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "c54d4fda-25f7-52b9-97e7-d2bd2fa90945",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320791b-a64f-4249-9a78-7b28cfe58743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f320791b-a64f-4249-9a78-7b28cfe58743.jpg?1",
             "name": "Dark Dabbling",
             "text": "Regenerate target creature. Draw a card.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, also regenerate each other creature you control.",
             "colours": [
@@ -3050,7 +3050,7 @@
         },
         {
             "id": "cb88210b-03b2-54e6-94a0-520500f34167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d0a239-4d45-4762-968a-d4b9479346d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d0a239-4d45-4762-968a-d4b9479346d9.jpg?1",
             "name": "Death Denied",
             "text": "Return X target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "d9b5061e-c871-58b4-8393-abf7f6f6b232",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdbc231-5316-4abd-9d8d-d87cff2c9847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdbc231-5316-4abd-9d8d-d87cff2c9847.jpg?1",
             "name": "Demonic Tutor",
             "text": "Search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -3116,7 +3116,7 @@
         },
         {
             "id": "240fffcc-7fd9-5a90-b5e7-79740aea43b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66f864b-b1bb-4596-93b8-3b4bfe6b1332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d66f864b-b1bb-4596-93b8-3b4bfe6b1332.jpg?1",
             "name": "Entomb",
             "text": "Search your library for a card and put that card into your graveyard. Then shuffle your library.",
             "colours": [
@@ -3148,7 +3148,7 @@
         },
         {
             "id": "1e5f68fc-6c1a-5151-8a2c-c322ff21ff02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1ef824-306c-4975-abca-19f0bd77449f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1ef824-306c-4975-abca-19f0bd77449f.jpg?1",
             "name": "Fume Spitter",
             "text": "Sacrifice Fume Spitter: Put a -1/-1 counter on target creature.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "18b42212-ca2c-55ae-bf4c-196c86caa155",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e27974c-1279-486f-8e14-b326cd90cb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e27974c-1279-486f-8e14-b326cd90cb06.jpg?1",
             "name": "Ghoulcaller's Accomplice",
             "text": "{3}{B}, Exile Ghoulcaller's Accomplice from your graveyard: Create a 2/2 black Zombie creature token. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -3218,7 +3218,7 @@
         },
         {
             "id": "13c3122d-6e92-5144-9c09-578f6629434d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8f7cfd-88db-4cc1-b65f-3462332a2873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8f7cfd-88db-4cc1-b65f-3462332a2873.jpg?1",
             "name": "Ghoulsteed",
             "text": "{2}{B}, Discard two cards: Return Ghoulsteed from your graveyard to the battlefield tapped.",
             "colours": [
@@ -3253,7 +3253,7 @@
         },
         {
             "id": "d3b69ef6-87dc-5550-ad77-be5cc5a7b317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfb37f-aa3f-46ca-9bff-01a874f8cc59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ecfb37f-aa3f-46ca-9bff-01a874f8cc59.jpg?1",
             "name": "Golgari Thug",
             "text": "When Golgari Thug dies, put target creature card from your graveyard on top of your library.\nDredge 4 (If you would draw a card, instead you may put exactly four cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "8459a876-abcf-51b1-a1c0-354343b5be88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261205d-3506-4f0a-98ce-690f40df7a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6261205d-3506-4f0a-98ce-690f40df7a5a.jpg?1",
             "name": "Goryo's Vengeance",
             "text": "Return target legendary creature card from your graveyard to the battlefield. That creature gains haste. Exile it at the beginning of the next end step.\nSplice onto Arcane {2}{B} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -3322,7 +3322,7 @@
         },
         {
             "id": "e06e378a-b7a6-5544-9fb7-c783634e72d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30af93c-9cb6-48a2-92c2-92506969756a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30af93c-9cb6-48a2-92c2-92506969756a.jpg?1",
             "name": "Grave Scrabbler",
             "text": "Madness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nWhen Grave Scrabbler enters the battlefield, if its madness cost was paid, you may return target creature card from a graveyard to its owner's hand.",
             "colours": [
@@ -3356,7 +3356,7 @@
         },
         {
             "id": "a6354d24-96a6-5707-a594-cd31ea93c06a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51b6c19-d8f8-4249-83c8-f3c4fa12291e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b51b6c19-d8f8-4249-83c8-f3c4fa12291e.jpg?1",
             "name": "Grave Strength",
             "text": "Choose target creature. Put the top three cards of your library into your graveyard, then put a +1/+1 counter on that creature for each creature card in your graveyard.",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "f02de313-bbbb-59c1-b96e-e0a42e207109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedd44eb-f381-46e1-bcb0-88416b4ce33d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedd44eb-f381-46e1-bcb0-88416b4ce33d.jpg?1",
             "name": "Gurmag Angler",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "726a4073-bfed-5a2d-bbe9-ced0ada6041b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2897581c-20ec-497e-9562-2d39ceca628e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2897581c-20ec-497e-9562-2d39ceca628e.jpg?1",
             "name": "Last Gasp",
             "text": "Target creature gets -3/-3 until end of turn.",
             "colours": [
@@ -3455,7 +3455,7 @@
         },
         {
             "id": "45450cae-f41e-553f-b9e0-d92611d7c42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e653437e-2e56-4443-aec5-5bb7d8860238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e653437e-2e56-4443-aec5-5bb7d8860238.jpg?1",
             "name": "Liliana of the Veil",
             "text": "+1: Each player discards a card.\n\u22122: Target player sacrifices a creature.\n\u22126: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
             "colours": [
@@ -3491,7 +3491,7 @@
         },
         {
             "id": "77295f9a-91e2-5fe2-b573-398fd99efc98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150090cc-27ac-4d18-b6e6-3ddaa40c822e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/150090cc-27ac-4d18-b6e6-3ddaa40c822e.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "53f073fa-1bed-5633-a45d-884f1ccd4868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8879190f-d8ff-47ce-a5d8-6a481a67236a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8879190f-d8ff-47ce-a5d8-6a481a67236a.jpg?1",
             "name": "Mikaeus, the Unhallowed",
             "text": "Intimidate\nWhenever a Human deals damage to you, destroy it.\nOther non-Human creatures you control get +1/+1 and have undying. (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3562,7 +3562,7 @@
         },
         {
             "id": "c19b8c82-3ce9-5f9a-8e4d-3fba354a0164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1f42ee-7f4e-4b2a-b60b-750662878a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a1f42ee-7f4e-4b2a-b60b-750662878a5c.jpg?1",
             "name": "Moan of the Unhallowed",
             "text": "Create two 2/2 black Zombie creature tokens.\nFlashback {5}{B}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "2b1fdd97-7ae1-5665-b0e8-3a7dc36293ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737679bd-b38f-402e-a6b2-7964da0f8d2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737679bd-b38f-402e-a6b2-7964da0f8d2f.jpg?1",
             "name": "Offalsnout",
             "text": "Flash\nWhen Offalsnout leaves the battlefield, exile target card from a graveyard.\nEvoke {B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -3628,7 +3628,7 @@
         },
         {
             "id": "bfd8c717-84c4-511a-8c6b-cfb40c7b0528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d0f7a-8418-455a-aa0c-02e8c9ad7820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145d0f7a-8418-455a-aa0c-02e8c9ad7820.jpg?1",
             "name": "Olivia's Dragoon",
             "text": "Discard a card: Olivia's Dragoon gains flying until end of turn.",
             "colours": [
@@ -3663,7 +3663,7 @@
         },
         {
             "id": "b0f3ef8f-2387-53ff-9555-64b66f9b4a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fc99dc-bfbe-4567-b791-6b1db96471ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04fc99dc-bfbe-4567-b791-6b1db96471ec.jpg?1",
             "name": "Reanimate",
             "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
             "colours": [
@@ -3695,7 +3695,7 @@
         },
         {
             "id": "21d0b2f5-e88a-5d53-b44a-e2680c47e1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d79c616-32d7-4d20-8dd8-8f56f5c04a0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d79c616-32d7-4d20-8dd8-8f56f5c04a0a.jpg?1",
             "name": "Sanitarium Skeleton",
             "text": "{2}{B}: Return Sanitarium Skeleton from your graveyard to your hand.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "089b65ce-969e-54c6-af8a-f9f5966a458a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0757cb66-7aa2-41a2-8efc-f3f35b70ab9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0757cb66-7aa2-41a2-8efc-f3f35b70ab9e.jpg?1",
             "name": "Shirei, Shizo's Caretaker",
             "text": "Whenever a creature with power 1 or less is put into your graveyard from the battlefield, you may return that card to the battlefield at the beginning of the next end step if Shirei, Shizo's Caretaker is still on the battlefield.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "c4da91ac-4832-5fb5-bc9a-bafd6714468b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5b89f-ec60-46b5-9160-9255cbb858a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce5b89f-ec60-46b5-9160-9255cbb858a9.jpg?1",
             "name": "Shriekmaw",
             "text": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhen Shriekmaw enters the battlefield, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -3799,7 +3799,7 @@
         },
         {
             "id": "16ea9ef5-5891-54d9-bc33-1831632f704c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475690db-4934-4c2e-b869-a6499d86a9c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475690db-4934-4c2e-b869-a6499d86a9c5.jpg?1",
             "name": "Slum Reaper",
             "text": "When Slum Reaper enters the battlefield, each player sacrifices a creature.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "2a6ea82d-d878-5650-b747-2b10f9c81749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9133b267-295d-4987-b1d6-f32a85b66081.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9133b267-295d-4987-b1d6-f32a85b66081.jpg?1",
             "name": "Songs of the Damned",
             "text": "Add {B} for each creature card in your graveyard.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "3eb858d0-2c72-547f-991b-978bbe844f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb97a96-2c56-4638-b971-00cdf1eafd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6eb97a96-2c56-4638-b971-00cdf1eafd43.jpg?1",
             "name": "Spoils of the Vault",
             "text": "Choose a card name. Reveal cards from the top of your library until you reveal a card with that name, then put that card into your hand. Exile all other cards revealed this way, and you lose 1 life for each of the exiled cards.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "c4df64ce-5c8c-554d-ad3c-42d396653748",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b7d726-c395-4af4-aa6a-e8e0c0582a1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7b7d726-c395-4af4-aa6a-e8e0c0582a1f.jpg?1",
             "name": "Tasigur, the Golden Fang",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n{2}{GW}{GW}: Put the top two cards of your library into your graveyard, then return a nonland card of an opponent's choice from your graveyard to your hand.",
             "colours": [
@@ -3936,7 +3936,7 @@
         },
         {
             "id": "f700e7de-a926-5f46-a85f-8ad7a18b8b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f689e20a-2c24-44a3-9e1b-7717df3d1948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f689e20a-2c24-44a3-9e1b-7717df3d1948.jpg?1",
             "name": "Twins of Maurer Estate",
             "text": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -3970,7 +3970,7 @@
         },
         {
             "id": "ea7083a6-6818-5b38-bf58-3a6f4ccb8401",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faffb7ad-4d85-48de-80c8-dcf2ebf190fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faffb7ad-4d85-48de-80c8-dcf2ebf190fd.jpg?1",
             "name": "Unburial Rites",
             "text": "Return target creature card from your graveyard to the battlefield.\nFlashback {3}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "9d073f7a-8387-5a76-b5c5-81e1650b6787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6883e3c-265e-408a-b733-35b89b66dabd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6883e3c-265e-408a-b733-35b89b66dabd.jpg?1",
             "name": "Unholy Hunger",
             "text": "Destroy target creature.\nSpell mastery \u2014 If there are two or more instant and/or sorcery cards in your graveyard, you gain 2 life.",
             "colours": [
@@ -4035,7 +4035,7 @@
         },
         {
             "id": "be37f35f-6526-556c-96b1-f5aa4b72e5a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d295ac-3c83-47db-a324-aa4907bcefdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73d295ac-3c83-47db-a324-aa4907bcefdd.jpg?1",
             "name": "Akroan Crusader",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Akroan Crusader, create a 1/1 red Soldier creature token with haste.",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "bf799f02-b59f-53da-9826-e528dc1b42a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0768df-40c3-4b07-9274-e619cae3dd2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0768df-40c3-4b07-9274-e619cae3dd2b.jpg?1",
             "name": "Anger",
             "text": "Haste\nAs long as Anger is in your graveyard and you control a Mountain, creatures you control have haste.",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "a34676b5-03b7-531c-a621-0cdde3d36f39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacc2881-26b8-4199-9b7d-e12c75effe6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacc2881-26b8-4199-9b7d-e12c75effe6e.jpg?1",
             "name": "Arena Athlete",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Arena Athlete, target creature an opponent controls can't block this turn.",
             "colours": [
@@ -4138,7 +4138,7 @@
         },
         {
             "id": "ba1c1f42-2cde-5cd5-bd80-0ec5b140b3df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468d5308-2a6c-440e-a8d0-1c5e084afb82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/468d5308-2a6c-440e-a8d0-1c5e084afb82.jpg?1",
             "name": "Balefire Dragon",
             "text": "Flying\nWhenever Balefire Dragon deals combat damage to a player, it deals that much damage to each creature that player controls.",
             "colours": [
@@ -4172,7 +4172,7 @@
         },
         {
             "id": "5cde3046-67c3-53ab-bc45-1fec206a4484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e987cd-94a0-4332-89c4-c7662c8dc001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7e987cd-94a0-4332-89c4-c7662c8dc001.jpg?1",
             "name": "Brazen Scourge",
             "text": "Haste",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "723599f5-1cbc-5f97-b890-99c698a4f416",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ffb4-3c9d-4d5c-a927-8988166c2d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ffb4-3c9d-4d5c-a927-8988166c2d94.jpg?1",
             "name": "Conflagrate",
             "text": "Conflagrate deals X damage divided as you choose among any number of targets.\nFlashback\u2014{R}{R}, Discard X cards. (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4238,7 +4238,7 @@
         },
         {
             "id": "d516086b-7978-5edc-b38e-b018a1736d81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3825b85d-07df-43b9-a8d8-930863262d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3825b85d-07df-43b9-a8d8-930863262d83.jpg?1",
             "name": "Desperate Ritual",
             "text": "Add {R}{R}{R}.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -4272,7 +4272,7 @@
         },
         {
             "id": "ff3b25aa-8b4c-5b91-b0b1-0a8cfc16715a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0865d7-3325-489f-bbe6-b7d2a43c23af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e0865d7-3325-489f-bbe6-b7d2a43c23af.jpg?1",
             "name": "Faithless Looting",
             "text": "Draw two cards, then discard two cards.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4304,7 +4304,7 @@
         },
         {
             "id": "18e975ef-e176-55bb-9d6a-fea41704a61e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2610d0e0-2824-4d40-816b-e487ac8f0e03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2610d0e0-2824-4d40-816b-e487ac8f0e03.jpg?1",
             "name": "Fiery Temper",
             "text": "Fiery Temper deals 3 damage to any target.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4336,7 +4336,7 @@
         },
         {
             "id": "941b54f8-9129-5db9-952a-a69bc766e6fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d7c90a-b999-4e0b-87df-7355d6c36fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08d7c90a-b999-4e0b-87df-7355d6c36fb1.jpg?1",
             "name": "Firewing Phoenix",
             "text": "Flying\n{1}{R}{R}{R}: Return Firewing Phoenix from your graveyard to your hand.",
             "colours": [
@@ -4370,7 +4370,7 @@
         },
         {
             "id": "bd37f254-779b-5ad2-8553-0acce2085f67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5879ce5-7bc0-4688-a506-8b0796a00485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5879ce5-7bc0-4688-a506-8b0796a00485.jpg?1",
             "name": "Furnace Celebration",
             "text": "Whenever you sacrifice another permanent, you may pay {2}. If you do, Furnace Celebration deals 2 damage to any target.",
             "colours": [
@@ -4402,7 +4402,7 @@
         },
         {
             "id": "6a71b548-1ad4-5b72-9eda-7aa48d3c2c43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01c9474-90a1-4c2e-bd90-471ff4fd04e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01c9474-90a1-4c2e-bd90-471ff4fd04e5.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, discard a card at random, then shuffle your library.",
             "colours": [
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "c17afd96-e446-5c03-b0f4-c7383ea5db33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea15262-c00f-4865-bb6a-37ccb2ef62bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea15262-c00f-4865-bb6a-37ccb2ef62bd.jpg?1",
             "name": "Generator Servant",
             "text": "{T}, Sacrifice Generator Servant: Add {C}{C}. If that mana is spent on a creature spell, it gains haste until end of turn.",
             "colours": [
@@ -4468,7 +4468,7 @@
         },
         {
             "id": "4bd9c738-47dd-50dc-ab6b-1d501b00370b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549b7d4-0120-44d1-8692-e5e997d26535.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e549b7d4-0120-44d1-8692-e5e997d26535.jpg?1",
             "name": "Hissing Iguanar",
             "text": "Whenever another creature dies, you may have Hissing Iguanar deal 1 damage to target player or planeswalker.",
             "colours": [
@@ -4502,7 +4502,7 @@
         },
         {
             "id": "01a5f51b-daa3-578a-bb2c-2718ab83240e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84b4b61-0e92-4ca2-b4e0-ae846a2a8e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f84b4b61-0e92-4ca2-b4e0-ae846a2a8e37.jpg?1",
             "name": "Ingot Chewer",
             "text": "When Ingot Chewer enters the battlefield, destroy target artifact.\nEvoke {R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -4536,7 +4536,7 @@
         },
         {
             "id": "be89b7de-6f2c-5ef6-80bf-abe9939a9f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c21c1f-eaa4-454d-a1c7-b41466d0a428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79c21c1f-eaa4-454d-a1c7-b41466d0a428.jpg?1",
             "name": "Lava Spike",
             "text": "Lava Spike deals 3 damage to target player or planeswalker.",
             "colours": [
@@ -4570,7 +4570,7 @@
         },
         {
             "id": "5135ad3d-0d57-5cb9-8949-53c21bdc2bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a62145-8dad-4385-9c6d-8cf8bfdad681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89a62145-8dad-4385-9c6d-8cf8bfdad681.jpg?1",
             "name": "Mad Prophet",
             "text": "Haste\n{T}, Discard a card: Draw a card.",
             "colours": [
@@ -4605,7 +4605,7 @@
         },
         {
             "id": "09087083-955c-5264-a6cc-397b14c446fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c571fe-54ef-4234-98c3-5d4a7b07e7d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08c571fe-54ef-4234-98c3-5d4a7b07e7d2.jpg?1",
             "name": "Magmaw",
             "text": "{1}, Sacrifice a nonland permanent: Magmaw deals 1 damage to any target.",
             "colours": [
@@ -4639,7 +4639,7 @@
         },
         {
             "id": "697f11c6-6ff8-58db-b57d-eb813ac7897f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b781ed-9f16-4cef-8b97-7a3e90abfdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b781ed-9f16-4cef-8b97-7a3e90abfdb3.jpg?1",
             "name": "Malevolent Whispers",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gets +2/+0 and gains haste until end of turn.\nMadness {3}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4671,7 +4671,7 @@
         },
         {
             "id": "db56cd6e-07f9-584d-9f62-1488c60fcbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7ea3f3-900e-4dc5-ad83-1d5c5320d031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd7ea3f3-900e-4dc5-ad83-1d5c5320d031.jpg?1",
             "name": "Molten Birth",
             "text": "Create two 1/1 red Elemental creature tokens, then flip a coin. If you win the flip, return Molten Birth to its owner's hand.",
             "colours": [
@@ -4703,7 +4703,7 @@
         },
         {
             "id": "2ebf32e9-b571-56b1-8a2c-ef1ae8943504",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8952ef0-d81e-491e-a137-be08a74ed005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8952ef0-d81e-491e-a137-be08a74ed005.jpg?1",
             "name": "Nightbird's Clutches",
             "text": "Up to two target creatures can't block this turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "bee32ca3-ec1e-53b0-917e-9b12d01a042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75d458-4947-4075-89b6-e93936c67370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca75d458-4947-4075-89b6-e93936c67370.jpg?1",
             "name": "Raid Bombardment",
             "text": "Whenever a creature you control with power 2 or less attacks, Raid Bombardment deals 1 damage to the player or planeswalker that creature is attacking.",
             "colours": [
@@ -4767,7 +4767,7 @@
         },
         {
             "id": "34d0e6e1-469b-5a55-94cd-827be567270e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9275605-15a0-4db6-bd7d-66755138e8d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9275605-15a0-4db6-bd7d-66755138e8d7.jpg?1",
             "name": "Reckless Charge",
             "text": "Target creature gets +3/+0 and gains haste until end of turn.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4799,7 +4799,7 @@
         },
         {
             "id": "a39a2340-1074-5b3c-92bf-9e697458e5e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3aa26a-ae7b-4239-948d-ce12d7f3ea41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b3aa26a-ae7b-4239-948d-ce12d7f3ea41.jpg?1",
             "name": "Reckless Wurm",
             "text": "Trample\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -4833,7 +4833,7 @@
         },
         {
             "id": "c5c2641b-1d94-52a1-b413-80b3a1190941",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebe6be-6d36-4ed4-a23d-770faed22e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15ebe6be-6d36-4ed4-a23d-770faed22e15.jpg?1",
             "name": "Rolling Temblor",
             "text": "Rolling Temblor deals 2 damage to each creature without flying.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4865,7 +4865,7 @@
         },
         {
             "id": "445e02ec-8c7c-59ec-9e3d-4ae6c00ff33e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2eb4e6-4ce1-4f72-9b3d-b6a44b22bd2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b2eb4e6-4ce1-4f72-9b3d-b6a44b22bd2e.jpg?1",
             "name": "Seismic Assault",
             "text": "Discard a land card: Seismic Assault deals 2 damage to any target.",
             "colours": [
@@ -4897,7 +4897,7 @@
         },
         {
             "id": "9dc957d7-98e6-503a-8b02-46f9d7d288ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee67808-abe3-4755-83a0-03681ad5f82f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee67808-abe3-4755-83a0-03681ad5f82f.jpg?1",
             "name": "Seize the Day",
             "text": "Untap target creature. After this main phase, there is an additional combat phase followed by an additional main phase.\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "1996edd3-1d7d-50dd-afc4-43194b366ff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11217e72-9009-40c7-a9eb-98e10b41667b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11217e72-9009-40c7-a9eb-98e10b41667b.jpg?1",
             "name": "Soul's Fire",
             "text": "Target creature you control deals damage equal to its power to any target.",
             "colours": [
@@ -4961,7 +4961,7 @@
         },
         {
             "id": "a3abaeb6-f1c8-5551-99ec-76b665e249cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e67cab-496b-4b07-a045-b332d378ae74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e67cab-496b-4b07-a045-b332d378ae74.jpg?1",
             "name": "Sparkspitter",
             "text": "{R}, {T}, Discard a card: Create a 3/1 red Elemental creature token named Spark Elemental. It has trample, haste, and \"At the beginning of the end step, sacrifice Spark Elemental.\"",
             "colours": [
@@ -4996,7 +4996,7 @@
         },
         {
             "id": "aee03847-c6ae-50cc-84dc-de8a6c8647c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fa9fdb-1458-4e34-8d2a-dfc083a7a223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fa9fdb-1458-4e34-8d2a-dfc083a7a223.jpg?1",
             "name": "Squee, Goblin Nabob",
             "text": "At the beginning of your upkeep, you may return Squee, Goblin Nabob from your graveyard to your hand.",
             "colours": [
@@ -5032,7 +5032,7 @@
         },
         {
             "id": "41a74c4a-9a7c-5520-a22d-e37f3b390a7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cac6a6-ded0-47cb-88d2-8838db9cc6b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cac6a6-ded0-47cb-88d2-8838db9cc6b2.jpg?1",
             "name": "Thermo-Alchemist",
             "text": "Defender\n{T}: Thermo-Alchemist deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Thermo-Alchemist.",
             "colours": [
@@ -5067,7 +5067,7 @@
         },
         {
             "id": "7adf1e71-2477-51ae-8350-ea498447e8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088dab4a-0090-4509-a851-25d916b30236.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/088dab4a-0090-4509-a851-25d916b30236.jpg?1",
             "name": "Through the Breach",
             "text": "You may put a creature card from your hand onto the battlefield. That creature gains haste. Sacrifice that creature at the beginning of the next end step.\nSplice onto Arcane {2}{R}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "eeda6d19-ac51-5669-a1f5-db68f34f9a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e987d8-b80e-49cd-9e9d-068027556b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06e987d8-b80e-49cd-9e9d-068027556b83.jpg?1",
             "name": "Undying Rage",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and can't block.\nWhen Undying Rage is put into a graveyard from the battlefield, return Undying Rage to its owner's hand.",
             "colours": [
@@ -5135,7 +5135,7 @@
         },
         {
             "id": "57217c4f-8fe0-5a4d-880d-fd79bc47da37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ebb551-6b0d-45fa-88c8-3746214094f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5ebb551-6b0d-45fa-88c8-3746214094f6.jpg?1",
             "name": "Vexing Devil",
             "text": "When Vexing Devil enters the battlefield, any opponent may have it deal 4 damage to them. If a player does, sacrifice Vexing Devil.",
             "colours": [
@@ -5169,7 +5169,7 @@
         },
         {
             "id": "1bd09932-bef3-5d14-99e5-f442cf885b06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1f44d0-7fb2-40f5-93a9-1a465372dd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c1f44d0-7fb2-40f5-93a9-1a465372dd82.jpg?1",
             "name": "Young Pyromancer",
             "text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
             "colours": [
@@ -5204,7 +5204,7 @@
         },
         {
             "id": "854fd314-7510-53e1-b000-c6533dae6c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bfde99-7761-48e1-851a-522f888d0f6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bfde99-7761-48e1-851a-522f888d0f6c.jpg?1",
             "name": "Basking Rootwalla",
             "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
             "colours": [
@@ -5238,7 +5238,7 @@
         },
         {
             "id": "8e4d0357-51cd-5b62-8c2b-647dd3b5d095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573e1673-3ab5-4b28-9cf1-b0d43cad5ef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/573e1673-3ab5-4b28-9cf1-b0d43cad5ef3.jpg?1",
             "name": "Become Immense",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTarget creature gets +6/+6 until end of turn.",
             "colours": [
@@ -5270,7 +5270,7 @@
         },
         {
             "id": "69ff3c40-0e2e-5802-93b3-6c1bb5a688c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8ce72b-605c-4a05-93d2-64fa65308d96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8ce72b-605c-4a05-93d2-64fa65308d96.jpg?1",
             "name": "Boar Umbra",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -5304,7 +5304,7 @@
         },
         {
             "id": "8a554634-2838-5787-9a05-22b877068e0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605038e9-2840-4c2d-bd7a-1004ae210e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/605038e9-2840-4c2d-bd7a-1004ae210e2a.jpg?1",
             "name": "Boneyard Wurm",
             "text": "Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -5338,7 +5338,7 @@
         },
         {
             "id": "3edc5251-d0e7-5203-aa96-9df0417a126d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c517b-4b29-45c5-b985-32dd7af8cfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7c517b-4b29-45c5-b985-32dd7af8cfcd.jpg?1",
             "name": "Brawn",
             "text": "Trample\nAs long as Brawn is in your graveyard and you control a Forest, creatures you control have trample.",
             "colours": [
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "8a7da7b3-c846-5d20-86e8-29c9dafcc697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2b20b-6255-450d-a848-f7aaf0d80721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84c2b20b-6255-450d-a848-f7aaf0d80721.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -5404,7 +5404,7 @@
         },
         {
             "id": "8a592e82-af1e-54f9-973f-1af3cc3105ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8a8dbb-cba7-4e1d-8888-73ab6f4aff07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c8a8dbb-cba7-4e1d-8888-73ab6f4aff07.jpg?1",
             "name": "Devoted Druid",
             "text": "{T}: Add {G}.\nPut a -1/-1 counter on Devoted Druid: Untap Devoted Druid.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "b4d0c6ce-70ba-5bf8-a1c3-5ce01f57f0d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4448f49-ebe8-43f1-958f-308c4c20a01f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4448f49-ebe8-43f1-958f-308c4c20a01f.jpg?1",
             "name": "Eternal Witness",
             "text": "When Eternal Witness enters the battlefield, you may return target card from your graveyard to your hand.",
             "colours": [
@@ -5474,7 +5474,7 @@
         },
         {
             "id": "2c19611f-be1a-579e-bf93-3db9a4c0bfa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddcec63-a60a-4d73-af6d-9ac978703811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bddcec63-a60a-4d73-af6d-9ac978703811.jpg?1",
             "name": "Fauna Shaman",
             "text": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "b9e9e29f-730e-5e04-973e-947d36e6242b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979578b-a82f-4d5e-8871-9e45401038a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b979578b-a82f-4d5e-8871-9e45401038a8.jpg?1",
             "name": "Fecundity",
             "text": "Whenever a creature dies, that creature's controller may draw a card.",
             "colours": [
@@ -5541,7 +5541,7 @@
         },
         {
             "id": "97225938-59cd-5236-87be-4964c479f310",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f3323-f702-46a6-92db-33ec0afd75d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41f3323-f702-46a6-92db-33ec0afd75d2.jpg?1",
             "name": "Golgari Brownscale",
             "text": "When Golgari Brownscale is put into your hand from your graveyard, you gain 2 life.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5575,7 +5575,7 @@
         },
         {
             "id": "14d619ef-fdb3-59af-b738-e8bd2925a203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a065808-643e-4123-a1ae-f65d62223106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a065808-643e-4123-a1ae-f65d62223106.jpg?1",
             "name": "Golgari Grave-Troll",
             "text": "Golgari Grave-Troll enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.\n{1}, Remove a +1/+1 counter from Golgari Grave-Troll: Regenerate Golgari Grave-Troll.\nDredge 6",
             "colours": [
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "b5adb818-66c7-5102-ba6d-025f4054eba0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625498e-82e5-49e2-a7fa-f4ea0bb838db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9625498e-82e5-49e2-a7fa-f4ea0bb838db.jpg?1",
             "name": "Groundskeeper",
             "text": "{1}{G}: Return target basic land card from your graveyard to your hand.",
             "colours": [
@@ -5645,7 +5645,7 @@
         },
         {
             "id": "c72c603d-be2a-5c5c-9264-1ab4162cd844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f3f0ce-e8f5-4020-b8db-23a6aa7f7cb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93f3f0ce-e8f5-4020-b8db-23a6aa7f7cb5.jpg?1",
             "name": "Hero of Leina Tower",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Hero of Leina Tower, you may pay {X}. If you do, put X +1/+1 counters on Hero of Leina Tower.",
             "colours": [
@@ -5680,7 +5680,7 @@
         },
         {
             "id": "ae47d0f1-0d81-50bf-8448-2ab82430d448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfbd094-1d59-4539-80e1-595227d3e64d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfbd094-1d59-4539-80e1-595227d3e64d.jpg?1",
             "name": "Hooting Mandrills",
             "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nTrample",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "c21b66c5-7970-545e-b4c8-ce27206df230",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102d20e6-5179-44b7-9abd-f1defc15ca6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/102d20e6-5179-44b7-9abd-f1defc15ca6a.jpg?1",
             "name": "Kodama's Reach",
             "text": "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Then shuffle your library.",
             "colours": [
@@ -5748,7 +5748,7 @@
         },
         {
             "id": "1966a9ed-117e-5b7f-b18b-1afb6a539711",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7447c11-05a1-44e4-831a-0bacf97d447d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7447c11-05a1-44e4-831a-0bacf97d447d.jpg?1",
             "name": "Life from the Loam",
             "text": "Return up to three target land cards from your graveyard to your hand.\nDredge 3 (If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [
@@ -5780,7 +5780,7 @@
         },
         {
             "id": "b2988a9f-a8db-5b9b-9b82-01ce3c9ad250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d816cd-9ca6-4118-893e-5c6b167d9d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d816cd-9ca6-4118-893e-5c6b167d9d81.jpg?1",
             "name": "Miming Slime",
             "text": "Create an X/X green Ooze creature token, where X is the greatest power among creatures you control.",
             "colours": [
@@ -5812,7 +5812,7 @@
         },
         {
             "id": "a3d63b73-9913-5336-8e89-691b96ba2022",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff782973-e33c-4edd-bbd7-5c8dc8d59554.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff782973-e33c-4edd-bbd7-5c8dc8d59554.jpg?1",
             "name": "Noble Hierarch",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\n{T}: Add {G}, {W}, or {U}.",
             "colours": [
@@ -5849,7 +5849,7 @@
         },
         {
             "id": "ffb684ad-65e9-5764-8d4d-4099045fe640",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472cd09-0b0a-49c9-ab10-ec5b73ddb74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9472cd09-0b0a-49c9-ab10-ec5b73ddb74b.jpg?1",
             "name": "Nourishing Shoal",
             "text": "You may exile a green card with converted mana cost X from your hand rather than pay this spell's mana cost.\nYou gain X life.",
             "colours": [
@@ -5883,7 +5883,7 @@
         },
         {
             "id": "fd59c754-190d-58e8-8780-3fe785aa16f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e34219-9fd9-4f11-a244-670fb75ef938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0e34219-9fd9-4f11-a244-670fb75ef938.jpg?1",
             "name": "Pattern of Rebirth",
             "text": "Enchant creature\nWhen enchanted creature dies, that creature's controller may search their library for a creature card, put that card onto the battlefield, then shuffle their library.",
             "colours": [
@@ -5917,7 +5917,7 @@
         },
         {
             "id": "78f649d5-04fd-56e8-a856-e86b0ad7327e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ce98d-0a19-42c5-9ef9-32408da1d2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4ce98d-0a19-42c5-9ef9-32408da1d2a1.jpg?1",
             "name": "Penumbra Wurm",
             "text": "Trample\nWhen Penumbra Wurm dies, create a 6/6 black Wurm creature token with trample.",
             "colours": [
@@ -5951,7 +5951,7 @@
         },
         {
             "id": "0fff9d28-bfd3-5715-b7da-407e462e2eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb1b036-0856-4cfb-ace5-2731f13696bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb1b036-0856-4cfb-ace5-2731f13696bd.jpg?1",
             "name": "Prey Upon",
             "text": "Target creature you control fights target creature you don't control.",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "8162d0c9-afc4-5489-8fc0-fc44c48e899a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88143d08-081f-4463-aef8-aedd47f86898.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88143d08-081f-4463-aef8-aedd47f86898.jpg?1",
             "name": "Pulse of Murasa",
             "text": "Return target creature or land card from a graveyard to its owner's hand. You gain 6 life.",
             "colours": [
@@ -6015,7 +6015,7 @@
         },
         {
             "id": "b774db59-0d0a-559f-acb7-5ddac02fdef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702caa-c9eb-4538-83ff-3b015c6b1349.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95702caa-c9eb-4538-83ff-3b015c6b1349.jpg?1",
             "name": "Satyr Wayfinder",
             "text": "When Satyr Wayfinder enters the battlefield, reveal the top four cards of your library. You may put a land card from among them into your hand. Put the rest into your graveyard.",
             "colours": [
@@ -6049,7 +6049,7 @@
         },
         {
             "id": "f74555b2-a470-58d7-a8ec-a72a1d823484",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467d9e99-5624-44ac-ab33-c4ebb338e6bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467d9e99-5624-44ac-ab33-c4ebb338e6bf.jpg?1",
             "name": "Shed Weakness",
             "text": "Target creature gets +2/+2 until end of turn. You may remove a -1/-1 counter from it.",
             "colours": [
@@ -6081,7 +6081,7 @@
         },
         {
             "id": "41f6cc9e-8d4d-57a5-a1a3-b4081cfd2c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3071a8b-05b1-490c-89f6-4bf97c02833b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3071a8b-05b1-490c-89f6-4bf97c02833b.jpg?1",
             "name": "Snake Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals damage to an opponent, you may draw a card.\"\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6115,7 +6115,7 @@
         },
         {
             "id": "7b9d48a9-1d5a-5d4e-b0ee-d0b0f1a0647d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef12c5a-deb9-48dd-9805-cba89aab51c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef12c5a-deb9-48dd-9805-cba89aab51c1.jpg?1",
             "name": "Spider Spawning",
             "text": "Create a 1/2 green Spider creature token with reach for each creature card in your graveyard.\nFlashback {6}{B} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6148,7 +6148,7 @@
         },
         {
             "id": "0b50dbd7-3be3-542a-9ca5-c775462352ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762b8d61-53c9-41e1-aaa7-098b91d9b938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/762b8d61-53c9-41e1-aaa7-098b91d9b938.jpg?1",
             "name": "Spider Umbra",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has reach.\nTotem armor (If enchanted creature would be destroyed, instead remove all damage from it and destroy this Aura.)",
             "colours": [
@@ -6182,7 +6182,7 @@
         },
         {
             "id": "a5add884-ef64-5ac3-b1c5-babe29b83140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c754202d-adc9-4d02-b1b3-ec253f7e637a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c754202d-adc9-4d02-b1b3-ec253f7e637a.jpg?1",
             "name": "Staunch-Hearted Warrior",
             "text": "Heroic \u2014 Whenever you cast a spell that targets Staunch-Hearted Warrior, put two +1/+1 counters on Staunch-Hearted Warrior.",
             "colours": [
@@ -6217,7 +6217,7 @@
         },
         {
             "id": "a9753e87-ca95-5608-a14f-c78febe6a2f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9596be71-290a-4955-aa34-dcffa9422664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9596be71-290a-4955-aa34-dcffa9422664.jpg?1",
             "name": "Stingerfling Spider",
             "text": "Reach\nWhen Stingerfling Spider enters the battlefield, you may destroy target creature with flying.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "2bd00f57-00c1-5230-891a-97ca8ad5fc88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e56220-81c3-4440-9f97-8616d630a8ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42e56220-81c3-4440-9f97-8616d630a8ee.jpg?1",
             "name": "Tarmogoyf",
             "text": "Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
             "colours": [
@@ -6285,7 +6285,7 @@
         },
         {
             "id": "f16058af-5b85-52ce-a8bb-9bee1b2b9625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb41317e-9263-49a1-92d4-323613677e34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb41317e-9263-49a1-92d4-323613677e34.jpg?1",
             "name": "Travel Preparations",
             "text": "Put a +1/+1 counter on each of up to two target creatures.\nFlashback {1}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "c1343e4e-1624-557d-9890-c1858da8fd06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b205bc3-379a-4790-90a0-c589bbbb1803.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b205bc3-379a-4790-90a0-c589bbbb1803.jpg?1",
             "name": "Vengevine",
             "text": "Haste\nWhenever you cast a spell, if it's the second creature spell you cast this turn, you may return Vengevine from your graveyard to the battlefield.",
             "colours": [
@@ -6352,7 +6352,7 @@
         },
         {
             "id": "c2046137-fea4-5c85-bafe-8b43e64ca334",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878d18d-aff7-4b49-b849-9dab0e4949ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0878d18d-aff7-4b49-b849-9dab0e4949ca.jpg?1",
             "name": "Verdant Eidolon",
             "text": "{G}, Sacrifice Verdant Eidolon: Add three mana of any one color.\nWhenever you cast a multicolored spell, you may return Verdant Eidolon from your graveyard to your hand.",
             "colours": [
@@ -6386,7 +6386,7 @@
         },
         {
             "id": "1af10f7f-863f-5be1-b484-650441b8eedc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab879034-2400-4451-9ba2-0325f61db537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab879034-2400-4451-9ba2-0325f61db537.jpg?1",
             "name": "Walker of the Grove",
             "text": "When Walker of the Grove leaves the battlefield, create a 4/4 green Elemental creature token.\nEvoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters the battlefield.)",
             "colours": [
@@ -6420,7 +6420,7 @@
         },
         {
             "id": "525fe1e2-24a6-5c6a-b755-a33c350ce4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833dff5c-63b4-413c-9956-67c84d036c2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/833dff5c-63b4-413c-9956-67c84d036c2e.jpg?1",
             "name": "Wickerbough Elder",
             "text": "Wickerbough Elder enters the battlefield with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from Wickerbough Elder: Destroy target artifact or enchantment.",
             "colours": [
@@ -6455,7 +6455,7 @@
         },
         {
             "id": "2316b6f1-0dd9-5d03-b607-ebe979b39aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bacc50a-71d7-4660-be1d-4db10c9b8fa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bacc50a-71d7-4660-be1d-4db10c9b8fa8.jpg?1",
             "name": "Wild Hunger",
             "text": "Target creature gets +3/+1 and gains trample until end of turn.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
             "colours": [
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "e0a684ea-0208-5c86-a6be-d22624202ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5be4ab-f85a-4272-ac08-99cb0105eb11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d5be4ab-f85a-4272-ac08-99cb0105eb11.jpg?1",
             "name": "Wild Mongrel",
             "text": "Discard a card: Wild Mongrel gets +1/+1 and becomes the color of your choice until end of turn.",
             "colours": [
@@ -6522,7 +6522,7 @@
         },
         {
             "id": "46a6376b-c24a-5f98-afd0-f849a2cf19ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da88d23-8650-4b55-a3f9-e964427660ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5da88d23-8650-4b55-a3f9-e964427660ed.jpg?1",
             "name": "Woodfall Primus",
             "text": "Trample\nWhen Woodfall Primus enters the battlefield, destroy target noncreature permanent.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -6557,7 +6557,7 @@
         },
         {
             "id": "640b2371-ce93-532d-bf62-1b6ebe1a52fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07809b2-dabe-4242-84c3-fd640d7d5998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a07809b2-dabe-4242-84c3-fd640d7d5998.jpg?1",
             "name": "Angel of Despair",
             "text": "Flying\nWhen Angel of Despair enters the battlefield, destroy target permanent.",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "97ad6c01-de59-55eb-8563-19a09d2406d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a97c6e7-affd-455a-925c-332ca6b7a6a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a97c6e7-affd-455a-925c-332ca6b7a6a5.jpg?1",
             "name": "Blast of Genius",
             "text": "Choose any target. Draw three cards, then discard a card. Blast of Genius deals damage equal to the discarded card's converted mana cost to that permanent or player.",
             "colours": [
@@ -6627,7 +6627,7 @@
         },
         {
             "id": "6afa4733-2b47-5d62-a0e7-990fe7eaaadf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f864e-a10f-47f4-94c5-4571b5c11b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99f864e-a10f-47f4-94c5-4571b5c11b3b.jpg?1",
             "name": "Countersquall",
             "text": "Counter target noncreature spell. Its controller loses 2 life.",
             "colours": [
@@ -6661,7 +6661,7 @@
         },
         {
             "id": "36cf32c6-a7c0-5503-b86a-5c09eef6b35d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40cfba1-08b5-4241-bd36-8ae18e584557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40cfba1-08b5-4241-bd36-8ae18e584557.jpg?1",
             "name": "Gaddock Teeg",
             "text": "Noncreature spells with converted mana cost 4 or greater can't be cast.\nNoncreature spells with {X} in their mana costs can't be cast.",
             "colours": [
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "792ff109-54e9-5632-99c0-a4e7fd6fafc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc84b7cf-5c68-4bb1-a1dc-2a5fae3baf04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc84b7cf-5c68-4bb1-a1dc-2a5fae3baf04.jpg?1",
             "name": "Garna, the Bloodflame",
             "text": "Flash\nWhen Garna, the Bloodflame enters the battlefield, return to your hand all creature cards in your graveyard that were put there from anywhere this turn.\nOther creatures you control have haste.",
             "colours": [
@@ -6739,7 +6739,7 @@
         },
         {
             "id": "4b91eff4-78cd-521a-9677-7bf1519c056d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d467e61-bbec-4cea-bd5d-f10555910c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d467e61-bbec-4cea-bd5d-f10555910c9d.jpg?1",
             "name": "Golgari Charm",
             "text": "Choose one \u2014\n\u2022 All creatures get -1/-1 until end of turn.\n\u2022 Destroy target enchantment.\n\u2022 Regenerate each creature you control.",
             "colours": [
@@ -6773,7 +6773,7 @@
         },
         {
             "id": "18a18737-9ed0-57c7-abef-b7e5931b0fac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedfc5b7-9242-4680-b284-debc8b5a9bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cedfc5b7-9242-4680-b284-debc8b5a9bc7.jpg?1",
             "name": "Leovold, Emissary of Trest",
             "text": "Each opponent can't draw more than one card each turn.\nWhenever you or a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.",
             "colours": [
@@ -6814,7 +6814,7 @@
         },
         {
             "id": "9d1f8b72-55eb-59ea-a6ce-b80e4cfc190a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8862c680-01ed-4794-bc75-47dd840778a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8862c680-01ed-4794-bc75-47dd840778a6.jpg?1",
             "name": "Lord of Extinction",
             "text": "Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "dd4aedd4-041a-5709-81a1-c056b93cba1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30ea59f-c582-4044-b639-dce6fc429b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d30ea59f-c582-4044-b639-dce6fc429b72.jpg?1",
             "name": "Maelstrom Pulse",
             "text": "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "8e4b760c-eb07-5955-b11d-c62bb226724c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a6c902-4705-4210-8e5e-08d6a6f67573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a6c902-4705-4210-8e5e-08d6a6f67573.jpg?1",
             "name": "Reviving Vapors",
             "text": "Reveal the top three cards of your library and put one of them into your hand. You gain life equal to that card's converted mana cost. Put all other cards revealed this way into your graveyard.",
             "colours": [
@@ -6918,7 +6918,7 @@
         },
         {
             "id": "27202f35-7b76-5765-92ad-07316931284c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1",
             "name": "Sigarda, Host of Herons",
             "text": "Flying, hexproof\nSpells and abilities your opponents control can't cause you to sacrifice permanents.",
             "colours": [
@@ -6956,7 +6956,7 @@
         },
         {
             "id": "232052c5-7830-565f-8ed2-911ecec5bb8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68ea02-66d3-4cca-ba0c-96f4340f683c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d68ea02-66d3-4cca-ba0c-96f4340f683c.jpg?1",
             "name": "Sovereigns of Lost Alara",
             "text": "Exalted (Whenever a creature you control attacks alone, that creature gets +1/+1 until end of turn.)\nWhenever a creature you control attacks alone, you may search your library for an Aura card that could enchant that creature, put it onto the battlefield attached to that creature, then shuffle your library.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "a5bd3247-8398-5dfc-95af-740dc3db4c66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d74ebd-9674-4bcc-b51e-d46e7b5cbc72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d74ebd-9674-4bcc-b51e-d46e7b5cbc72.jpg?1",
             "name": "Urban Evolution",
             "text": "Draw three cards. You may play an additional land this turn.",
             "colours": [
@@ -7026,7 +7026,7 @@
         },
         {
             "id": "51b35d51-f1b7-5992-8b3d-45be79f35bb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03bb160-8113-409a-a130-2b3fdc476e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b03bb160-8113-409a-a130-2b3fdc476e6a.jpg?1",
             "name": "Vengeful Rebirth",
             "text": "Return target card from your graveyard to your hand. If you return a nonland card to your hand this way, Vengeful Rebirth deals damage equal to that card's converted mana cost to any target.\nExile Vengeful Rebirth.",
             "colours": [
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "7a3290dc-13ae-528a-99c8-abfd89780e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989f8049-c4d2-4729-b35f-7bd7d8cbcb06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989f8049-c4d2-4729-b35f-7bd7d8cbcb06.jpg?1",
             "name": "Warleader's Helix",
             "text": "Warleader's Helix deals 4 damage to any target and you gain 4 life.",
             "colours": [
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "c666b510-d1a7-50ee-8a46-bad607033de7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bdd5f-2aad-48ba-a4b1-f2b2365a1a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396bdd5f-2aad-48ba-a4b1-f2b2365a1a53.jpg?1",
             "name": "Beckon Apparition",
             "text": "Exile target card from a graveyard. Create a 1/1 white and black Spirit creature token with flying.",
             "colours": [
@@ -7128,7 +7128,7 @@
         },
         {
             "id": "ac605089-50a9-59d6-9493-09ca8b8d91d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7158f78-daf3-46ff-aa5f-f8cff3a24ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7158f78-daf3-46ff-aa5f-f8cff3a24ed5.jpg?1",
             "name": "Canker Abomination",
             "text": "As Canker Abomination enters the battlefield, choose an opponent. Canker Abomination enters the battlefield with a -1/-1 counter on it for each creature that player controls.",
             "colours": [
@@ -7165,7 +7165,7 @@
         },
         {
             "id": "df43a385-7afb-5430-8dec-b29a22d430c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6822ef8f-ff27-410d-934f-c87baef03266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6822ef8f-ff27-410d-934f-c87baef03266.jpg?1",
             "name": "Dimir Guildmage",
             "text": "{3}{U}: Target player draws a card. Activate this ability only any time you could cast a sorcery.\n{3}{B}: Target player discards a card. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -7202,7 +7202,7 @@
         },
         {
             "id": "98f16881-6ce2-5699-b969-9f876e12c015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82505754-a22f-4ae9-8efd-75eff17cbed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82505754-a22f-4ae9-8efd-75eff17cbed6.jpg?1",
             "name": "Double Cleave",
             "text": "Target creature gains double strike until end of turn.",
             "colours": [
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "51c74350-fc33-5e1f-ac63-3fb0c1995978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168dd99-f4a9-4fe9-89d4-fc0effeb8f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2168dd99-f4a9-4fe9-89d4-fc0effeb8f89.jpg?1",
             "name": "Fulminator Mage",
             "text": "Sacrifice Fulminator Mage: Destroy target nonbasic land.",
             "colours": [
@@ -7273,7 +7273,7 @@
         },
         {
             "id": "f59b125b-b38d-5714-be8f-8626c554f1f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a844d537-df73-422d-a154-f1c6b92d0469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a844d537-df73-422d-a154-f1c6b92d0469.jpg?1",
             "name": "Kitchen Finks",
             "text": "When Kitchen Finks enters the battlefield, you gain 2 life.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7309,7 +7309,7 @@
         },
         {
             "id": "e5c3f012-940e-577d-892e-5b21f31f0d51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadf575-2076-4f0c-b66e-994898adf375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acadf575-2076-4f0c-b66e-994898adf375.jpg?1",
             "name": "Murderous Redcap",
             "text": "When Murderous Redcap enters the battlefield, it deals damage equal to its power to any target.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7346,7 +7346,7 @@
         },
         {
             "id": "0ad5ef2c-b933-56ae-ba7c-1f494ec05220",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6c9c6-53db-4f6f-a20b-16dcbae42d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aad6c9c6-53db-4f6f-a20b-16dcbae42d0c.jpg?1",
             "name": "Plumeveil",
             "text": "Flash\nDefender, flying",
             "colours": [
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "de704d4e-47d2-5745-9b0c-b96e62d5fa9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aed1803-7936-4329-bb8a-7cdb0de23633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aed1803-7936-4329-bb8a-7cdb0de23633.jpg?1",
             "name": "Rakdos Shred-Freak",
             "text": "Haste",
             "colours": [
@@ -7419,7 +7419,7 @@
         },
         {
             "id": "4c5ef25c-53de-5f05-9325-090222a2de27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d049f233-7fcb-49cb-897b-a12d57692fe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d049f233-7fcb-49cb-897b-a12d57692fe0.jpg?1",
             "name": "Safehold Elite",
             "text": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7456,7 +7456,7 @@
         },
         {
             "id": "44d0bbe2-c409-5a4f-a1c2-b950b1cf6b43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013b28-7a90-4b4e-a91c-7d864105d28b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e013b28-7a90-4b4e-a91c-7d864105d28b.jpg?1",
             "name": "Scuzzback Marauders",
             "text": "Trample\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
             "colours": [
@@ -7493,7 +7493,7 @@
         },
         {
             "id": "34d5061e-59a3-58dc-9932-64067e374841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a99c3c-0041-49c0-9d81-e8ec731ba072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a99c3c-0041-49c0-9d81-e8ec731ba072.jpg?1",
             "name": "Shielding Plax",
             "text": "Enchant creature\nWhen Shielding Plax enters the battlefield, draw a card.\nEnchanted creature can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -7529,7 +7529,7 @@
         },
         {
             "id": "8dd6574f-3031-57f1-bdaf-c69fda823c17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4bbea-7e3f-4de0-bb01-dfd67f21c254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e4bbea-7e3f-4de0-bb01-dfd67f21c254.jpg?1",
             "name": "Slippery Bogle",
             "text": "Hexproof",
             "colours": [
@@ -7565,7 +7565,7 @@
         },
         {
             "id": "b04386d5-c992-5e9f-b418-b9cd0d2cbb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d3bf1-5f8b-431c-bb4e-a6874c69817a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/160d3bf1-5f8b-431c-bb4e-a6874c69817a.jpg?1",
             "name": "Turn to Mist",
             "text": "Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -7599,7 +7599,7 @@
         },
         {
             "id": "6a586d99-dede-56e6-ab57-34c25ba565cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg?1",
             "name": "Fire // Ice",
             "text": "Fire deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "b4464e15-7786-5518-9df7-09c31a628921",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f822331-315e-4297-bb69-f1069032c6c5.jpg?1",
             "name": "Fire // Ice",
             "text": "Tap target permanent.\nDraw a card.",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "e5b26e01-2d32-5503-9651-a1d815af7dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ba6c14-9393-4420-adfe-6b2ef85d2ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ba6c14-9393-4420-adfe-6b2ef85d2ce9.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion dies, add {C}{C}{C}.",
             "colours": [],
@@ -7696,7 +7696,7 @@
         },
         {
             "id": "e9796f2a-22ff-53a2-b41e-6fee4768f8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e2b69e-b06b-46a5-ac57-a6a180eeecc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e2b69e-b06b-46a5-ac57-a6a180eeecc7.jpg?1",
             "name": "Engineered Explosives",
             "text": "Sunburst (This enters the battlefield with a charge counter on it for each color of mana spent to cast it.)\n{2}, Sacrifice Engineered Explosives: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Engineered Explosives.",
             "colours": [],
@@ -7724,7 +7724,7 @@
         },
         {
             "id": "7e39cdd0-0624-5bc7-b752-c9e8f2d2424c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09a887-958c-4a63-81d6-f5ec484223c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d09a887-958c-4a63-81d6-f5ec484223c2.jpg?1",
             "name": "Heap Doll",
             "text": "Sacrifice Heap Doll: Exile target card from a graveyard.",
             "colours": [],
@@ -7755,7 +7755,7 @@
         },
         {
             "id": "a835418d-2ba7-5304-988e-71b4848166a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdf9706-acdb-48fc-89db-93bc50b3b9ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfdf9706-acdb-48fc-89db-93bc50b3b9ad.jpg?1",
             "name": "Mana Vault",
             "text": "Mana Vault doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap Mana Vault.\nAt the beginning of your draw step, if Mana Vault is tapped, it deals 1 damage to you.\n{T}: Add {C}{C}{C}.",
             "colours": [],
@@ -7783,7 +7783,7 @@
         },
         {
             "id": "1d084470-4c85-5466-81a0-67876d29e5a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53712a0-e11d-4b83-aebc-8e97244f085b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d53712a0-e11d-4b83-aebc-8e97244f085b.jpg?1",
             "name": "Myr Servitor",
             "text": "At the beginning of your upkeep, if Myr Servitor is on the battlefield, each player returns all cards named Myr Servitor from their graveyard to the battlefield.",
             "colours": [],
@@ -7814,7 +7814,7 @@
         },
         {
             "id": "f6098975-d2e2-57a2-a3d2-2f62e9e84948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6b8ca-2e72-4f19-b73b-08b3f9fe6966.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab6b8ca-2e72-4f19-b73b-08b3f9fe6966.jpg?1",
             "name": "Patchwork Gnomes",
             "text": "Discard a card: Regenerate Patchwork Gnomes.",
             "colours": [],
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "769a75f5-6864-595e-95e8-44bea5e1fd7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c66c54b-b2d1-494d-ae10-a950c184a52f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c66c54b-b2d1-494d-ae10-a950c184a52f.jpg?1",
             "name": "Phyrexian Altar",
             "text": "Sacrifice a creature: Add one mana of any color.",
             "colours": [],
@@ -7873,7 +7873,7 @@
         },
         {
             "id": "dc9c1e74-3c51-5ab0-b931-c8b015ede11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b03143-9e85-4061-88e6-ad621f75ec3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b03143-9e85-4061-88e6-ad621f75ec3b.jpg?1",
             "name": "Platinum Emperion",
             "text": "Your life total can't change.",
             "colours": [],
@@ -7904,7 +7904,7 @@
         },
         {
             "id": "42a65f78-afde-51f3-92d1-748e871b0813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618fb0b-099c-47f6-b16f-49854bc5be6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7618fb0b-099c-47f6-b16f-49854bc5be6b.jpg?1",
             "name": "Prismatic Lens",
             "text": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -7932,7 +7932,7 @@
         },
         {
             "id": "07218191-e151-59b7-8bab-09bcbbfdc601",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ec86a5-7d2f-4413-919e-b4f7c70457df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93ec86a5-7d2f-4413-919e-b4f7c70457df.jpg?1",
             "name": "Vessel of Endless Rest",
             "text": "When Vessel of Endless Rest enters the battlefield, put target card from a graveyard on the bottom of its owner's library.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -7960,7 +7960,7 @@
         },
         {
             "id": "15da53d9-25f2-5190-a0ea-137ac7894c5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3d4b4b-cf31-4f89-8140-9650edb03c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd3d4b4b-cf31-4f89-8140-9650edb03c7b.jpg?1",
             "name": "Ancient Tomb",
             "text": "{T}: Add {C}{C}. Ancient Tomb deals 2 damage to you.",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "43619dcf-341f-5068-ad7a-6d88e5e6267b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976cb2-3123-4935-adcc-70e3db51d381.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25976cb2-3123-4935-adcc-70e3db51d381.jpg?1",
             "name": "Cavern of Souls",
             "text": "As Cavern of Souls enters the battlefield, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered.",
             "colours": [],
@@ -8016,7 +8016,7 @@
         },
         {
             "id": "ca22ca6d-05ca-5e57-92c4-b712c4b512c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c830a99-595b-4aed-9f6b-85a78917f498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c830a99-595b-4aed-9f6b-85a78917f498.jpg?1",
             "name": "Celestial Colonnade",
             "text": "Celestial Colonnade enters the battlefield tapped.\n{T}: Add {W} or {U}.\n{3}{W}{U}: Until end of turn, Celestial Colonnade becomes a 4/4 white and blue Elemental creature with flying and vigilance. It's still a land.",
             "colours": [],
@@ -8047,7 +8047,7 @@
         },
         {
             "id": "9aba2219-da83-5b31-8794-1ba3753c5ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250441b-8255-4ae1-b064-a75eb24faaf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1250441b-8255-4ae1-b064-a75eb24faaf3.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B}.\n{1}{U}{B}: Creeping Tar Pit becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land.",
             "colours": [],
@@ -8078,7 +8078,7 @@
         },
         {
             "id": "50810b90-8e77-57eb-8798-d9c908ed478c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58329049-2141-498a-8b73-653610c05ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58329049-2141-498a-8b73-653610c05ea6.jpg?1",
             "name": "Dakmor Salvage",
             "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B}.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
             "colours": [],
@@ -8108,7 +8108,7 @@
         },
         {
             "id": "37eb9619-1516-5cba-a071-d20f18b26183",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00d16f9-ea27-4aa3-a134-4e04f934d020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00d16f9-ea27-4aa3-a134-4e04f934d020.jpg?1",
             "name": "Dark Depths",
             "text": "Dark Depths enters the battlefield with ten ice counters on it.\n{3}: Remove an ice counter from Dark Depths.\nWhen Dark Depths has no ice counters on it, sacrifice it. If you do, create Marit Lage, a legendary 20/20 black Avatar creature token with flying and indestructible.",
             "colours": [],
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "3766f227-a7fe-59af-ba71-7bb665db749e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12cfe8-76cf-4709-bdc4-62c059f4eebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f12cfe8-76cf-4709-bdc4-62c059f4eebd.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "{T}: Add {C}.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
             "colours": [],
@@ -8170,7 +8170,7 @@
         },
         {
             "id": "29f4a8f8-a2c0-5640-9356-3f1317af98ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93d3a9f-abc2-4f63-a74d-e5936609386f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e93d3a9f-abc2-4f63-a74d-e5936609386f.jpg?1",
             "name": "Flagstones of Trokair",
             "text": "{T}: Add {W}.\nWhen Flagstones of Trokair is put into a graveyard from the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8202,7 +8202,7 @@
         },
         {
             "id": "dd033e0e-1cce-5300-bf1e-07ae98bcc8b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52214e1-404a-405a-b08e-20e13c087338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e52214e1-404a-405a-b08e-20e13c087338.jpg?1",
             "name": "Karakas",
             "text": "{T}: Add {W}.\n{T}: Return target legendary creature to its owner's hand.",
             "colours": [],
@@ -8234,7 +8234,7 @@
         },
         {
             "id": "e63f1d57-8d68-5791-b838-4d4a66f7cc59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409fcd0c-8449-4623-8bf0-cd7ca0937a4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409fcd0c-8449-4623-8bf0-cd7ca0937a4a.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "Lavaclaw Reaches enters the battlefield tapped.\n{T}: Add {B} or {R}.\n{1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with \"{X}: This creature gets +X/+0 until end of turn.\" It's still a land.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "d197487a-6c2b-55ee-8622-a8a1aa5a93e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297e677f-5092-49bb-a63b-ac3269a4c016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297e677f-5092-49bb-a63b-ac3269a4c016.jpg?1",
             "name": "Mage-Ring Network",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a storage counter on Mage-Ring Network.\n{T}, Remove any number of storage counters from Mage-Ring Network: Add {C} for each storage counter removed this way.",
             "colours": [],
@@ -8293,7 +8293,7 @@
         },
         {
             "id": "137b369b-b78d-5347-81e1-d806b0b0e7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724acbe2-4c82-4360-a738-38cc6aa0c4a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/724acbe2-4c82-4360-a738-38cc6aa0c4a4.jpg?1",
             "name": "Mistveil Plains",
             "text": "({T}: Add {W}.)\nMistveil Plains enters the battlefield tapped.\n{W}, {T}: Put target card from your graveyard on the bottom of your library. Activate this ability only if you control two or more white permanents.",
             "colours": [],
@@ -8325,7 +8325,7 @@
         },
         {
             "id": "b93a3774-3e7a-580f-88f0-dd2ce224dc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25dc997-219f-44e9-9003-384f75a606a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25dc997-219f-44e9-9003-384f75a606a3.jpg?1",
             "name": "Phyrexian Tower",
             "text": "{T}: Add {C}.\n{T}, Sacrifice a creature: Add {B}{B}.",
             "colours": [],
@@ -8357,7 +8357,7 @@
         },
         {
             "id": "f57b2f15-1214-5b41-a1e9-e09862f203d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e6b8fc-6627-47ab-bfd1-7300e13debec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e6b8fc-6627-47ab-bfd1-7300e13debec.jpg?1",
             "name": "Raging Ravine",
             "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
             "colours": [],
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "eb9a8de1-47d8-5385-8fb2-1950aef8ea98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e32c53-cd0c-4c57-8cf6-23fc8fcde054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8e32c53-cd0c-4c57-8cf6-23fc8fcde054.jpg?1",
             "name": "Rogue's Passage",
             "text": "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.",
             "colours": [],
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "7a437379-273b-58bb-a254-c03da014bb97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f40dfc-a35d-4094-9805-0de8b7f61cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f40dfc-a35d-4094-9805-0de8b7f61cb0.jpg?1",
             "name": "Stirring Wildwood",
             "text": "Stirring Wildwood enters the battlefield tapped.\n{T}: Add {G} or {W}.\n{1}{G}{W}: Until end of turn, Stirring Wildwood becomes a 3/4 green and white Elemental creature with reach. It's still a land.",
             "colours": [],
@@ -8447,7 +8447,7 @@
         },
         {
             "id": "d8593a17-bff5-5f7a-aa84-11ad45918c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d3fa52-93ee-40a8-a4ce-41b91ff20eb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80d3fa52-93ee-40a8-a4ce-41b91ff20eb8.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "{T}, Sacrifice Terramorphic Expanse: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [],
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "de6d979d-9764-52ce-8b9a-ee14a5a35afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492bd-b32f-4692-917c-7771986b5bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107492bd-b32f-4692-917c-7771986b5bf7.jpg?1",
             "name": "Thespian's Stage",
             "text": "{T}: Add {C}.\n{2}, {T}: Thespian's Stage becomes a copy of target land, except it has this ability.",
             "colours": [],
@@ -8503,7 +8503,7 @@
         },
         {
             "id": "62c12ea6-7049-5a8f-b784-33b48ade7f1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e17705-739e-409f-a6fd-7bab22120b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e17705-739e-409f-a6fd-7bab22120b22.jpg?1",
             "name": "Urborg, Tomb of Yawgmoth",
             "text": "Each land is a Swamp in addition to its other land types.",
             "colours": [],
@@ -8533,7 +8533,7 @@
         },
         {
             "id": "55f6b605-5c55-5f16-a501-fbed2ee04a3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165164e7-5693-4d65-b789-8ed8a222365b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/165164e7-5693-4d65-b789-8ed8a222365b.jpg?1",
             "name": "Citizen",
             "text": "",
             "colours": [
@@ -8567,7 +8567,7 @@
         },
         {
             "id": "8dea83bc-b672-56ea-8f6b-024476b90279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31830977-e096-4736-bb30-1d70008d7488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31830977-e096-4736-bb30-1d70008d7488.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -8601,7 +8601,7 @@
         },
         {
             "id": "028e4800-4d6a-5e34-b063-954a0d39ee48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd81e9a-69b5-4764-91a7-8b6cdddcaa40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fd81e9a-69b5-4764-91a7-8b6cdddcaa40.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -8635,7 +8635,7 @@
         },
         {
             "id": "b4bc4560-c20a-5637-970f-0d2ecc9d5a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c6ef29-b879-4813-87b0-0e3ba2b5cb29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c6ef29-b879-4813-87b0-0e3ba2b5cb29.jpg?1",
             "name": "Homunculus",
             "text": "",
             "colours": [
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "84534351-3a79-50ce-abe2-5b5776bf4768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67457137-64f2-413d-b62e-658b3f1b1043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67457137-64f2-413d-b62e-658b3f1b1043.jpg?1",
             "name": "Faerie Rogue",
             "text": "",
             "colours": [
@@ -8704,7 +8704,7 @@
         },
         {
             "id": "417106fb-eca9-5ef6-86fc-861cf8bea2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105e687e-7196-4010-a6b7-cfa42d998fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105e687e-7196-4010-a6b7-cfa42d998fa4.jpg?1",
             "name": "Marit Lage",
             "text": "",
             "colours": [
@@ -8740,7 +8740,7 @@
         },
         {
             "id": "e4816192-d5de-577f-86fa-cd160534d09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31107acf-5969-42ff-a805-9152f439b7fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31107acf-5969-42ff-a805-9152f439b7fa.jpg?1",
             "name": "Wurm",
             "text": "",
             "colours": [
@@ -8774,7 +8774,7 @@
         },
         {
             "id": "3de757dd-9448-59ac-9d97-e96adc6ba66a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e8ff7-3cb7-4ef9-a480-76d664924cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/096e8ff7-3cb7-4ef9-a480-76d664924cff.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -8808,7 +8808,7 @@
         },
         {
             "id": "354f77e0-4448-53cb-8715-b2493678684f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae1c136-7319-45d1-882a-3d838b344773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae1c136-7319-45d1-882a-3d838b344773.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "4d3d1d6f-5817-57d6-8568-7b234f094c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7cb791-ac35-4c69-aa85-23e14b821c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f7cb791-ac35-4c69-aa85-23e14b821c6a.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8876,7 +8876,7 @@
         },
         {
             "id": "de4fe0ae-18d6-56f5-9ac4-c2a79ae54657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b8e44-b435-4e05-b94c-02c4dda11943.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/039b8e44-b435-4e05-b94c-02c4dda11943.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -8910,7 +8910,7 @@
         },
         {
             "id": "1b592ced-e93e-54d3-81d4-e95251bfe81a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1270173-72fc-489a-beef-85e2d8096bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1270173-72fc-489a-beef-85e2d8096bd7.jpg?1",
             "name": "Spark Elemental",
             "text": "",
             "colours": [
@@ -8944,7 +8944,7 @@
         },
         {
             "id": "99e687c5-4402-51fc-99fb-335ec554881e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea0857b-0f9e-4a87-83d7-85723e33f26c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea0857b-0f9e-4a87-83d7-85723e33f26c.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -8978,7 +8978,7 @@
         },
         {
             "id": "75e2af1c-33af-5f39-9787-2d242a91e882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d299e48d-fb74-49a1-b94a-29975056378a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d299e48d-fb74-49a1-b94a-29975056378a.jpg?1",
             "name": "Ooze",
             "text": "",
             "colours": [
@@ -9012,7 +9012,7 @@
         },
         {
             "id": "ad252f9f-adf3-5412-be42-f4c12577a351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ede910-a0cb-4cf1-82f4-69fce0076c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ede910-a0cb-4cf1-82f4-69fce0076c4d.jpg?1",
             "name": "Spider",
             "text": "",
             "colours": [
@@ -9046,7 +9046,7 @@
         },
         {
             "id": "c024f57b-b8ec-55a7-937f-db99918c2a1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a306c6-57e9-4c99-b2a9-ee27a557d69b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9a306c6-57e9-4c99-b2a9-ee27a557d69b.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/UND.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UND.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "e1b54271-89ea-5b05-ad7f-50a537c9e865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25ff6aa-a01d-49f2-926f-8f5457143b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d25ff6aa-a01d-49f2-926f-8f5457143b5c.jpg?1",
             "name": "Adorable Kitten",
             "text": "When this creature enters the battlefield,\nroll a six-sided die. You gain life equal to the result.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "1ac5559b-5589-5dcc-8f5d-2d3ecb3b9e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da3387-454c-4c09-b78f-6fcc36c426ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3da3387-454c-4c09-b78f-6fcc36c426ce.jpg?1",
             "name": "AWOL",
             "text": "Exile target attacking creature. Then remove it from the game. Then put it into the absolutely-removed-from-the-freaking-game-forever zone.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "79ff343f-b8fc-5cb2-9df3-76c4cb0f0173",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa7c80e-86bf-4156-8370-d40f864c3704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa7c80e-86bf-4156-8370-d40f864c3704.jpg?1",
             "name": "Emcee",
             "text": "Whenever another creature enters the battlefield, you may stand up and say in a deep, booming voice, \"Presenting . . . \" and that creature's name. If you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "289af0ca-e261-5f02-8af0-ba257954bc7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abce5940-e84f-4f9f-89a9-13da1cd7fd43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abce5940-e84f-4f9f-89a9-13da1cd7fd43.jpg?1",
             "name": "Flavor Judge",
             "text": "{T}: Choose target spell or ability that targets a permanent you control. Then ask a person outside the game if the story of what will happen makes sense. If they say no, sacrifice Flavor Judge and counter that spell or ability.",
             "colours": [
@@ -138,7 +138,7 @@
         },
         {
             "id": "7463f2a8-b9ba-534f-a315-f8aff14b0286",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c3e8b-d9c6-46cd-9f39-86db077fb89d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/440c3e8b-d9c6-46cd-9f39-86db077fb89d.jpg?1",
             "name": "Frankie Peanuts",
             "text": "At the beginning of your upkeep, you may ask target player a yes-or-no question. If you do, that player answers the question truthfully and abides by that answer if able until end of turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "9e7dff50-8d34-5bda-a914-6ca08f3591e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40eb8f1-7dec-47cd-99dd-b6147ad5593d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40eb8f1-7dec-47cd-99dd-b6147ad5593d.jpg?1",
             "name": "GO TO JAIL",
             "text": "When GO TO JAIL enters the battlefield, exile target creature an opponent controls until GO TO JAIL leaves the battlefield.\nAt the beginning of the upkeep of the exiled card's owner, that player rolls two six-sided dice. If they roll doubles, sacrifice GO TO JAIL.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "cd88f21d-3c1a-5ab6-90fd-4c11592e9989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8d36-92e3-43b5-b9ce-79cb8d2bfd76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cdb8d36-92e3-43b5-b9ce-79cb8d2bfd76.jpg?1",
             "name": "Humming-",
             "text": "Flying\nWhenever you attack with two or more creatures,\nAugment {3}{W} ({3}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "23036e2e-4a3c-506c-a4e6-3f26562ddf29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d81b09-aa21-4206-bdc5-21819e36d9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d81b09-aa21-4206-bdc5-21819e36d9b3.jpg?1",
             "name": "Knight of the Hokey Pokey",
             "text": "First strike\n{1}{W}, Do the Hokey Pokey: Prevent all damage a source of your choice would deal to Knight of the Hokey Pokey this turn. (To do the Hokey Pokey, choose an arm, a leg, or your whole self and put it in. Put it out. Put it in. Shake it all about. You do the Hokey Pokey Turn yourself around.)",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "76e70d5f-abd8-5cb4-8dd4-32da5fab6f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaee15d7-db3d-4aa2-ab04-b883ff41d12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaee15d7-db3d-4aa2-ab04-b883ff41d12a.jpg?1",
             "name": "Look at Me, I'm R&D",
             "text": "As Look at Me, I'm R&D comes into play, choose a number and a second number one higher or one lower than that number.\nAll instances of the first chosen number on permanents, spells, and cards in any zone are the second chosen number.",
             "colours": [
@@ -302,7 +302,7 @@
         },
         {
             "id": "e048657a-fbb6-52d7-ae57-ddc578ba8ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa69802-c392-4004-9d58-ad1fc42de0bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa69802-c392-4004-9d58-ad1fc42de0bd.jpg?1",
             "name": "Look at Me, I'm the DCI",
             "text": "Ban a card other than a basic land card for the rest of the match. (All cards with that name in any zone or sideboard are removed from the match.)",
             "colours": [
@@ -333,7 +333,7 @@
         },
         {
             "id": "461281bf-52c7-5cd3-bc88-2faaf6a53104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b0cbc6-fe14-484a-a5ab-ea04d7b9e487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8b0cbc6-fe14-484a-a5ab-ea04d7b9e487.jpg?1",
             "name": "Old Guard",
             "text": "{W}, {T}: Tap target creature without reminder text. (Reminder text is any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -368,7 +368,7 @@
         },
         {
             "id": "4b7faffc-7f75-56ad-8b7d-e44f02ffdce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d2083-2022-4d49-90ab-ec52e584842c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/763d2083-2022-4d49-90ab-ec52e584842c.jpg?1",
             "name": "Ordinary Pony",
             "text": "When this creature enters the battlefield,\nyou may exile target non-Horse creature you control that wasn't put onto the battlefield with this ability this turn, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "b23e355d-5190-5db8-ad5a-5ff9d0fe9bea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc13f28-6d2e-4589-b475-3c18d0eea2de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcc13f28-6d2e-4589-b475-3c18d0eea2de.jpg?1",
             "name": "Staying Power",
             "text": "\"Until end of turn\" and \"this turn\" effects don't end.",
             "colours": [
@@ -434,7 +434,7 @@
         },
         {
             "id": "ebed16ae-db40-50db-b83f-a202f5661acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef766e71-d67a-4656-90c0-3628bcca640b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef766e71-d67a-4656-90c0-3628bcca640b.jpg?1",
             "name": "Strutting Turkey",
             "text": "When this creature enters the battlefield,\nexile target creature card with converted mana cost 2 or less from your graveyard. If it has augment, combine it with a host you control. Otherwise, put it onto the battlefield.",
             "colours": [
@@ -469,7 +469,7 @@
         },
         {
             "id": "08e4b1bc-e247-5850-9aee-d0415c22d6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0b109c-eaf3-49ab-a61c-853e8ca239fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae0b109c-eaf3-49ab-a61c-853e8ca239fc.jpg?1",
             "name": "Syr Cadian, Knight Owl",
             "text": "Knightlifelink (Damage dealt by Knights you control also causes you to gain that much life.)\n{W}: Syr Cadian, Knight Owl gains vigilance until end of turn. Activate this ability only from sunrise to sunset.\n{B}: Syr Cadian, Knight Owl gains flying until end of turn. Activate this ability only from sunset to sunrise.",
             "colours": [
@@ -506,7 +506,7 @@
         },
         {
             "id": "119a7726-0291-5067-b85d-5fafa28ca0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1572109-df70-4335-aac2-1670fe99be54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1572109-df70-4335-aac2-1670fe99be54.jpg?1",
             "name": "Alexander Clamilton",
             "text": "Whenever you cast a wordy spell, scry 2. (A spell is wordy if it has four or more lines of rules text.)\n{1}{R}, {T}: Choose target creature you don't control. Reveal the top card of your library. Alexander Clamilton gets +X/+0 until end of turn, where X is the number of lines of rules text of the revealed card. Alexander Clamilton fights that creature.",
             "colours": [
@@ -544,7 +544,7 @@
         },
         {
             "id": "44c3aebc-584a-5590-b3dc-296f645482a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da4dcb0-285e-4948-8155-4b536bce202d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8da4dcb0-285e-4948-8155-4b536bce202d.jpg?1",
             "name": "Avatar of Me",
             "text": "This spell costs {1} more to cast for each ten years you've been alive.\nAvatar of Me's power is equal to your height in feet and its toughness is equal to your American shoe size. Round to the nearest \u00bd.\nAvatar of Me is the color of your eyes.",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "25463956-7fc1-5781-88cb-abba28a59ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41ecd9-8875-4765-a9a9-372f948b5ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e41ecd9-8875-4765-a9a9-372f948b5ad7.jpg?1",
             "name": "B.O.B. (Bevy of Beebles)",
             "text": "As B.\nO.\nB. enters the battlefield, create four 1/1 blue Beeble creature tokens.\nThe number of loyalty counters on B.\nO.\nB. is equal to the number of Beebles you control. (Create or sacrifice Beebles whenever B.\nO.\nB. gains or loses loyalty.)\n+1: Up to X target Beebles can't be blocked this turn, where X is the number of cards in your hand.\n\u22121: Draw a card.",
             "colours": [
@@ -612,7 +612,7 @@
         },
         {
             "id": "306494e3-f2d7-5efb-9cd6-cff7fc2b7172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fa790-e131-4871-841b-ad8ee2a0a716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d38fa790-e131-4871-841b-ad8ee2a0a716.jpg?1",
             "name": "Carnivorous Death-Parrot",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Carnivorous Death-Parrot unless you say its flavor text.",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "f006f1c0-36b1-5f98-a8d6-499cecb11f9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebafd1c7-c248-494c-b9b7-3521c6c4352c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebafd1c7-c248-494c-b9b7-3521c6c4352c.jpg?1",
             "name": "Cheatyface",
             "text": "If Cheatyface is in your hand, you may sneak Cheatyface onto the battlefield. If an opponent catches you right away, that player may exile Cheatyface.\nFlying",
             "colours": [
@@ -678,7 +678,7 @@
         },
         {
             "id": "c6c4bfd9-bcec-5267-867c-d93b66d3e8a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbd4ef-3bf4-4f22-9069-2a11c9619a43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efcbd4ef-3bf4-4f22-9069-2a11c9619a43.jpg?1",
             "name": "Chicken \u00e0 la King",
             "text": "Whenever a 6 is rolled on a six-sided die, put a +1/+1 counter on each Bird. (You may roll dice only when instructed to.)\nTap an untapped Bird you control: Roll a six-sided die. (Like now.)",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "6bfe9a93-7ff8-58e1-a68c-389f94605b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cb220-47c4-438d-bc24-abd68ed4273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357cb220-47c4-438d-bc24-abd68ed4273c.jpg?1",
             "name": "Common Courtesy",
             "text": "Whenever a player casts a spell without asking your permission while casting it, counter that spell.\nWhen a player asks you permission to cast a spell and you refuse, counter that spell and sacrifice Common Courtesy.",
             "colours": [
@@ -743,7 +743,7 @@
         },
         {
             "id": "efd1829b-27f5-58b8-b9a5-89494535da8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fc7a61-226c-426a-9b99-21d87aca2f6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8fc7a61-226c-426a-9b99-21d87aca2f6f.jpg?1",
             "name": "Johnny, Combo Player",
             "text": "{4}: Search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "87b82b46-4ebb-5be2-b5a0-518e7e6fb429",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111f985b-d33e-4ecd-93d4-1be4a730463b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/111f985b-d33e-4ecd-93d4-1be4a730463b.jpg?1",
             "name": "Magic Word",
             "text": "Enchant creature\nAs Magic Word enters the battlefield, choose a word.\nWhisper the chosen word: Tap enchanted creature.",
             "colours": [
@@ -812,7 +812,7 @@
         },
         {
             "id": "7c903143-4f2e-5bfd-84c6-02ac9631e746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece674d3-6c39-4489-b097-a7e875bc6655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ece674d3-6c39-4489-b097-a7e875bc6655.jpg?1",
             "name": "Mer Man",
             "text": "When this creature enters the battlefield,\nyou may draw a card.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "6bbadd17-5f08-5055-9c25-9a7bf4c61356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616a3755-f08c-4b8f-954b-7e3f3a8fa71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/616a3755-f08c-4b8f-954b-7e3f3a8fa71f.jpg?1",
             "name": "Richard Garfield, Ph.D.",
             "text": "You may play cards as though they were other cards of your choice with the same mana cost. You can't choose the same card twice. (Mana cost includes color.)",
             "colours": [
@@ -884,7 +884,7 @@
         },
         {
             "id": "865c8147-f27b-5318-bd97-8488bbcd6e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4b5dfe-9947-42fb-859d-291a608a7309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb4b5dfe-9947-42fb-859d-291a608a7309.jpg?1",
             "name": "Rings a Bell",
             "text": "As Rings a Bell enters the battlefield, choose a word with four or more letters.\nAfter you say the chosen word for the first time each turn, an opponent may ring or imitate a bell within five seconds. When no opponent does, draw a card.",
             "colours": [
@@ -915,7 +915,7 @@
         },
         {
             "id": "416c0488-d0c1-52e6-a644-5dd5680743fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ef21-ef1c-4524-9d06-1792840cbe2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa86ef21-ef1c-4524-9d06-1792840cbe2e.jpg?1",
             "name": "Time Out",
             "text": "Roll a six-sided die. Put target nonland permanent into its owner's library just beneath the top X cards of that library, where X is the result.",
             "colours": [
@@ -946,7 +946,7 @@
         },
         {
             "id": "dc550dcd-1405-5691-a5c3-c98e9128ccd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf253a-eca6-405d-8216-a362854b4ae1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aadf253a-eca6-405d-8216-a362854b4ae1.jpg?1",
             "name": "Topsy Turvy",
             "text": "The phases of each player's turn are reversed. (The phases are, in reverse order, ending, postcombat main, combat, precombat main, and beginning.)\nAs long as there are more than two players in the game, the turn order is reversed.",
             "colours": [
@@ -977,7 +977,7 @@
         },
         {
             "id": "f1c3600a-ed9a-5f92-b96d-b2ddbda582d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d09f247-99c6-4038-9cd1-7c4ccc3d7005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d09f247-99c6-4038-9cd1-7c4ccc3d7005.jpg?1",
             "name": "Wall of Fortune",
             "text": "Defender\nYou may tap an untapped Wall you control to have any player reroll a die that player rolled.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "6888bc2d-33b9-56da-b17a-c683032dc171",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c37a83-3d5e-4019-b180-88e2bc106dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c37a83-3d5e-4019-b180-88e2bc106dd0.jpg?1",
             "name": "Acornelia, Fashionable Filcher",
             "text": "Whenever you cast a spell with a squirrel in its art, you get  (an acorn counter).\nWhenever a Squirrel you control enters the battlefield or dies, you get .\n{2}{B}, Pay X : Target creature gets -X/-X until end of turn.\n{G}, Pay X : Target creature gets +X/+X until end of turn.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "7aab776d-ebfe-5665-8c9d-fec741ec7929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14ebf7a-c616-4a89-904b-75c5602c54de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b14ebf7a-c616-4a89-904b-75c5602c54de.jpg?1",
             "name": "Bat-",
             "text": "Flying\nAt the beginning of each end step, if an opponent lost 3 or more life this turn,\nAugment {1}{B} ({1}{B}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -1080,7 +1080,7 @@
         },
         {
             "id": "e2fc4ff6-5816-50b8-b04a-4a9e3dd42ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5718db-e67d-468a-95ba-11a08fcf9fea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a5718db-e67d-468a-95ba-11a08fcf9fea.jpg?1",
             "name": "Booster Tutor",
             "text": "Open a sealed Magic booster pack, reveal the cards, and put one of them into your hand. (Remove that card from your deck before beginning a new game.)",
             "colours": [
@@ -1111,7 +1111,7 @@
         },
         {
             "id": "e2b0c02e-a519-58eb-8653-dc1e6deee027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17596a17-b062-41e9-a8c6-76fb67e36e48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17596a17-b062-41e9-a8c6-76fb67e36e48.jpg?1",
             "name": "Dirty Rat",
             "text": "When this creature enters the battlefield,\ntarget opponent discards a card.",
             "colours": [
@@ -1146,7 +1146,7 @@
         },
         {
             "id": "c0a3fb00-3846-53d2-a0a1-6d70af42f85a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318bc78c-65ef-4d1b-a710-cdf08636b572.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/318bc78c-65ef-4d1b-a710-cdf08636b572.jpg?1",
             "name": "Duh",
             "text": "Destroy target creature with reminder text. (Reminder text is any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -1177,7 +1177,7 @@
         },
         {
             "id": "371fdc8c-2d58-5898-b5a9-118a8ee67320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696f3a6-88c3-4aab-9c1f-05b5e36094fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d696f3a6-88c3-4aab-9c1f-05b5e36094fa.jpg?1",
             "name": "Enter the Dungeon",
             "text": "Players play a Magic subgame under the table, starting at 5 life and using their libraries as their decks. The winner searches their library for two cards, puts those cards into their hand, then shuffles their library.",
             "colours": [
@@ -1208,7 +1208,7 @@
         },
         {
             "id": "4795e57f-dfd1-5a77-a580-9b28c2c4d0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293106ab-da9b-4932-8227-96b7e55e7d26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293106ab-da9b-4932-8227-96b7e55e7d26.jpg?1",
             "name": "Hoisted Hireling",
             "text": "Hoisted Hireling has flying as long as it's being held above the battlefield.",
             "colours": [
@@ -1241,7 +1241,7 @@
         },
         {
             "id": "b996f0e6-1e5f-5e5c-a9c9-fe3786268491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c28a60a-8b2b-45f5-b46e-c0c50218b239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c28a60a-8b2b-45f5-b46e-c0c50218b239.jpg?1",
             "name": "Infernal Spawn of Evil",
             "text": "Flying, first strike\n{1}{B}, Reveal Infernal Spawn of Evil from your hand, Say \"It's coming\": Infernal Spawn of Evil deals 1 damage to target opponent or planeswalker. Activate this ability only during your upkeep and only once each turn.",
             "colours": [
@@ -1274,7 +1274,7 @@
         },
         {
             "id": "31e0ff52-217d-5955-bc9a-6991594cc041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2c80d5-960b-4624-9b3e-96943d7b4144.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2c80d5-960b-4624-9b3e-96943d7b4144.jpg?1",
             "name": "Infernal Spawn of Infernal Spawn of Evil",
             "text": "Flying, first strike, trample\nOnce each turn, while you're searching your library, you may pay {1}{B}, reveal Infernal Spawn of Infernal Spawn of Evil from your library and say \"I'm coming, too\" If you do, Infernal Spawn of Infernal Spawn of Evil deals 2 damage to a player of your choice.",
             "colours": [
@@ -1308,7 +1308,7 @@
         },
         {
             "id": "d3a41575-6a96-51c6-8836-ad9a49dbd9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3b1317-f024-4e34-89ad-538fc148cd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e3b1317-f024-4e34-89ad-538fc148cd5c.jpg?1",
             "name": "Infernius Spawnington III, Esq.",
             "text": "Flying, first strike, trample, haste\nThis spell costs {3} less to cast for each card you've revealed this turn.\nWhen Infernius Spawnington III, Esq. enters the battlefield, you may say \"I'm here.\" If you do, it deals 3 damage to target player.",
             "colours": [
@@ -1343,7 +1343,7 @@
         },
         {
             "id": "46d0c4d8-6c32-5b3c-8326-d56254f90818",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1150ef5-b529-4ad2-ba27-dd0fcffd8888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1150ef5-b529-4ad2-ba27-dd0fcffd8888.jpg?1",
             "name": "Inhumaniac",
             "text": "At the beginning of your upkeep, roll a six-sided die. On a 3 or 4, put a +1/+1 counter on Inhumaniac. On a 5 or higher, put two +1/+1 counters on it. On a 1, remove all +1/+1 counters from Inhumaniac.",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "9d2c59ac-f3fc-5718-8421-4f26dd5cdc3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d761c0b3-ae18-49a2-b1b7-f820b645a258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d761c0b3-ae18-49a2-b1b7-f820b645a258.jpg?1",
             "name": "Jumbo Imp",
             "text": "Flying\nAs Jumbo Imp enters the battlefield, roll a six-sided die. Jumbo Imp enters the battlefield with a number of +1/+1 counters on it equal to the result.\nAt the beginning of your upkeep, roll a six-sided die and put a number of +1/+1 counters on Jumbo Imp equal to the result.\nAt the beginning of your end step, roll a six-sided die and remove a number of +1/+1 counters from Jumbo Imp equal to the result.",
             "colours": [
@@ -1409,7 +1409,7 @@
         },
         {
             "id": "6764410c-2100-5058-9b2c-87f60b49c77a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7317f1f-dff3-4d38-98be-2b4907bdd523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7317f1f-dff3-4d38-98be-2b4907bdd523.jpg?1",
             "name": "Poultrygeist",
             "text": "Flying\nWhenever a creature dies, you may roll a six-sided die. If you roll a 1, sacrifice Poultrygeist. Otherwise, put a +1/+1 counter on Poultrygeist.",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "289fcb55-c34a-5422-80cc-5b0bad05dd5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80cfcad-c82b-461d-8002-a8e1acddacf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f80cfcad-c82b-461d-8002-a8e1acddacf2.jpg?1",
             "name": "Skull Saucer",
             "text": "Flying\nWhen Skull Saucer enters the battlefield, destroy target creature and put your head on the table. Sacrifice Skull Saucer when your head stops touching the table.",
             "colours": [
@@ -1477,7 +1477,7 @@
         },
         {
             "id": "fe2fd969-cb4b-5ac1-969d-8649142529db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98469f4c-40b6-4ca8-886f-6d1879641641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98469f4c-40b6-4ca8-886f-6d1879641641.jpg?1",
             "name": "Snickering Squirrel",
             "text": "You may tap Snickering Squirrel to increase the result of a die any player rolled by 1.",
             "colours": [
@@ -1511,7 +1511,7 @@
         },
         {
             "id": "467b454e-6b5a-5b38-86e1-2ed53987c68a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67248450-7135-43ed-a1ec-d8a2da556066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67248450-7135-43ed-a1ec-d8a2da556066.jpg?1",
             "name": "Stinging Scorpion",
             "text": "When this creature enters the battlefield,\ntarget creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -1546,7 +1546,7 @@
         },
         {
             "id": "82448769-bbfe-5f3b-be44-c4b11f719060",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c244e904-89ab-4486-a467-16e86f179fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c244e904-89ab-4486-a467-16e86f179fcc.jpg?1",
             "name": "Abstract Iguanart",
             "text": "Whenever you cast a spell, note the first letter of its artist's name. If that letter wasn't already noted, put a +1/+1 counter on Abstract Iguanart.",
             "colours": [
@@ -1580,7 +1580,7 @@
         },
         {
             "id": "547ee5c2-42ad-5ad6-81e2-770a6da73d84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a784dde5-cfce-464f-a134-8894ba3faf5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a784dde5-cfce-464f-a134-8894ba3faf5b.jpg?1",
             "name": "Blast from the Past",
             "text": "Madness {R}, cycling {1}{R}, kicker {2}{R}, flashback {3}{R}, buyback {4}{R}\nBlast from the Past deals 2 damage to any target. If this spell was kicked, create a 1/1 red Goblin creature token.",
             "colours": [
@@ -1611,7 +1611,7 @@
         },
         {
             "id": "fbb867e7-afb4-5af1-9d27-8d71947284db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747788b4-42ab-4e3e-bdbe-eb5040432db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747788b4-42ab-4e3e-bdbe-eb5040432db1.jpg?1",
             "name": "Boomstacker",
             "text": "As Boomstacker enters the battlefield and whenever it attacks, stack two dice on top of it. (All dice must be stacked vertically, one on top of another.)\nBoomstacker gets +1/+1 for each die in its stack.\nBoomstacker attacks each combat if able.\nWhen the stack falls, sacrifice Boomstacker.",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "0f8c3b4a-a1a4-588a-8e3f-341340e99042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487de7fb-51b5-48bf-89cc-a0539ac1b994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487de7fb-51b5-48bf-89cc-a0539ac1b994.jpg?1",
             "name": "Common Iguana",
             "text": "When this creature enters the battlefield,\nyou may discard a card. If you do, draw a card.",
             "colours": [
@@ -1680,7 +1680,7 @@
         },
         {
             "id": "fcce5e54-4313-5631-98e0-b95f3039fb9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0520e8-794e-403e-855c-2cb4ba79189d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c0520e8-794e-403e-855c-2cb4ba79189d.jpg?1",
             "name": "Goblin Haberdasher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nOther creatures you control wearing hats in their art have menace.",
             "colours": [
@@ -1714,7 +1714,7 @@
         },
         {
             "id": "cf3476d9-292b-5377-ba72-9be334cad74d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103d84da-2a1b-48b1-973f-5a995218d0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103d84da-2a1b-48b1-973f-5a995218d0e0.jpg?1",
             "name": "Goblin S.W.A.T. Team",
             "text": "Say \"Goblin S.W.A.T. Team\": Put a +1/+1 counter on Goblin S.W.A.T. Team unless an opponent swats the table within five seconds. Activate this ability only once each turn.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "376ad6ae-ac1d-5014-932c-c236e780a02e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba2055e-c668-4fe5-9c2b-0ef17557548c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba2055e-c668-4fe5-9c2b-0ef17557548c.jpg?1",
             "name": "Goblin Tutor",
             "text": "Roll a six-sided die. If you roll a 1, Goblin Tutor has no effect. Otherwise, search your library for the indicated card, reveal it, put it into your hand, then shuffle your library.\n2 \u2014 A card named Goblin Tutor\n3 \u2014 An enchantment\n4 \u2014 An artifact\n5 \u2014 A creature\n6 \u2014 An instant or sorcery",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "a06bc59c-e61c-50db-b60c-63d0966f7f92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9330f67-0f79-4374-804c-5ca30841b8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9330f67-0f79-4374-804c-5ca30841b8bb.jpg?1",
             "name": "Infinity Elemental",
             "text": "(This creature has INFINITE POWER.)",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "f31460f6-91d6-5cb4-b9ef-b3074bfd8351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33292b84-331d-490f-b96e-43341b367df0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33292b84-331d-490f-b96e-43341b367df0.jpg?1",
             "name": "Painiac",
             "text": "At the beginning of your upkeep, roll a six-sided die. Painiac gets +X/+0 until end of turn, where X is the result.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "438dd605-f6d8-51f7-aef3-0b2bd1f44f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706e573e-3e3b-4684-b51c-8b583fddc549.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706e573e-3e3b-4684-b51c-8b583fddc549.jpg?1",
             "name": "Six-y Beast",
             "text": "As Six-y Beast enters the battlefield, you secretly put six or fewer +1/+1 counters on it, then an opponent guesses the number of counters. If that player guesses right, sacrifice Six-y Beast after it enters the battlefield.",
             "colours": [
@@ -1878,7 +1878,7 @@
         },
         {
             "id": "952ba4d4-ef21-587f-b104-a4645d81c066",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57a6d9d-f0e9-4c5a-bacf-7a6c30d65b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d57a6d9d-f0e9-4c5a-bacf-7a6c30d65b08.jpg?1",
             "name": "Stet, Draconic Proofreader",
             "text": "Flying\nWhenever Stet, Draconic Proofreader attacks, you may exile a card from your graveyard. When you do, Stet, Draconic Proofreader deals 4 damage to any target whose name begins with the same letter as the exiled card.\n{W}: Delete the first letter of target permanent or player's name until end of turn.",
             "colours": [
@@ -1915,7 +1915,7 @@
         },
         {
             "id": "74955d47-80c6-5ffa-a18a-7acc518b2c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6159df84-64a3-4252-99d8-30971b07cec5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6159df84-64a3-4252-99d8-30971b07cec5.jpg?1",
             "name": "Strategy, Schmategy",
             "text": "Roll a six-sided die. Strategy, Schmategy has the indicated effect.\n1 \u2014 Do nothing.\n2 \u2014 Destroy all artifacts.\n3 \u2014 Destroy all lands.\n4 \u2014 Strategy, Schmategy deals 3 damage to each creature and each player.\n5 \u2014 Each player discards their hand and draws seven cards.\n6 \u2014 Repeat this process two more times.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "aed5ad42-e52f-5bb9-b21e-a2d1c6adb24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b0255d-0dde-4a0c-b5fd-70ac4b72133e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5b0255d-0dde-4a0c-b5fd-70ac4b72133e.jpg?1",
             "name": "Super-Duper Death Ray",
             "text": "Trample (This spell can deal excess damage to its target's controller.)\nSuper-Duper Death Ray deals 4 damage to target creature.",
             "colours": [
@@ -1977,7 +1977,7 @@
         },
         {
             "id": "87874c83-6b86-5b71-ae64-f02d102bb4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d85779-89f6-4f4e-b34a-d44a6d15ce06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d85779-89f6-4f4e-b34a-d44a6d15ce06.jpg?1",
             "name": "Yet Another Aether Vortex",
             "text": "All creatures have haste.\nPlayers play with the top card of their libraries revealed.\nNoninstant, nonsorcery cards on top of a library are on the battlefield under their owner's control in addition to being in that library.",
             "colours": [
@@ -2008,7 +2008,7 @@
         },
         {
             "id": "5d7b2689-007c-5f3c-9eae-b5d2f10823c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf4a081-3532-45e5-be72-1ff2fb88bb08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cf4a081-3532-45e5-be72-1ff2fb88bb08.jpg?1",
             "name": "B-I-N-G-O",
             "text": "Trample\nWhenever a player casts a spell, put a chip counter on its converted mana cost.\nB-I-N-G-O gets +9/+9 for each set of three numbers in a row with chip counters on them.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "44e9c9c0-88e9-532d-bac8-82d4ded43547",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159e36d-8e4c-4ac8-8b1f-1111ba73ac12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b159e36d-8e4c-4ac8-8b1f-1111ba73ac12.jpg?1",
             "name": "Elvish Impersonators",
             "text": "As Elvish Impersonators enters the battlefield, roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result.",
             "colours": [
@@ -2074,7 +2074,7 @@
         },
         {
             "id": "12c5ee36-0d50-5cca-8bbb-25e73b570bec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70124c3-7188-418f-bc7d-fb6294d79a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c70124c3-7188-418f-bc7d-fb6294d79a56.jpg?1",
             "name": "Free-Range Chicken",
             "text": "{1}{G}: Roll two six-sided dice. If both results are the same, Free-Range Chicken gets +X/+X until end of turn, where X is that result. If the total of those results is equal to any other total you have rolled this turn for this ability, sacrifice it. (For example, if you roll two 3s, it gets +3/+3. If you roll a 4 and a 2 for this ability later that turn, sacrifice it.)",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "e91458f8-6495-55c7-82f0-498956cde217",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8052788-65d6-4809-a338-68ff40ef5b0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8052788-65d6-4809-a338-68ff40ef5b0f.jpg?1",
             "name": "Growth Spurt",
             "text": "Roll a six-sided die. Target creature gets +X/+X until end of turn, where X is the result.",
             "colours": [
@@ -2138,7 +2138,7 @@
         },
         {
             "id": "816efcf3-d1f2-524d-a1b5-aefa2654c09b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd59e69-0dfe-4161-8e95-41be9ae07716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd59e69-0dfe-4161-8e95-41be9ae07716.jpg?1",
             "name": "Half-Squirrel, Half-",
             "text": "Whenever a nontoken creature enters the battlefield,\nAugment {G} ({G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -2171,7 +2171,7 @@
         },
         {
             "id": "4b710611-4598-5bee-9499-78cdfb4a15c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933630cb-e812-436e-a35e-8247557f72a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/933630cb-e812-436e-a35e-8247557f72a3.jpg?1",
             "name": "Mother Kangaroo",
             "text": "When this creature enters the battlefield,\nroll a six-sided die. Put a number of +1/+1 counters on this creature equal to the result.",
             "colours": [
@@ -2206,7 +2206,7 @@
         },
         {
             "id": "17ccd14d-a756-5f95-a80d-6b423ae525b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccae52dd-3ffd-4974-8915-61f816d29a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccae52dd-3ffd-4974-8915-61f816d29a64.jpg?1",
             "name": "Old Fogey",
             "text": "Phasing, cumulative upkeep {1}, echo, fading 3, bands with other Dinosaurs, protection from Homarids, snow-covered plainswalk, flanking, rampage 2",
             "colours": [
@@ -2239,7 +2239,7 @@
         },
         {
             "id": "f8a6d3ab-7cd8-5877-85be-cdd6a20b6259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f42b1a-5404-496a-b6e4-98794a4d8bee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2f42b1a-5404-496a-b6e4-98794a4d8bee.jpg?1",
             "name": "Pippa, Duchess of Dice",
             "text": "{2}{G}, {T}: Roll a six-sided die. It becomes a green Die creature token with power and toughness each equal to its result.\n{2}{U}, {T}: Reroll any die. (Activate this ability only any time it makes sense.)",
             "colours": [
@@ -2276,7 +2276,7 @@
         },
         {
             "id": "df55aede-0f2c-5ff0-ac6e-91d52cb23a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349a387-1803-49c6-975c-49fe1491521a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6349a387-1803-49c6-975c-49fe1491521a.jpg?1",
             "name": "Slaying Mantis",
             "text": "Just a second (As long as this spell is on the stack, players can't move cards on the battlefield.)\nSlaying Mantis enters the battlefield by being thrown from a distance of at least three feet.\nWhen Slaying Mantis enters the battlefield, it fights each creature an opponent controls that it touched as it entered.",
             "colours": [
@@ -2310,7 +2310,7 @@
         },
         {
             "id": "a7b21be3-20fa-507b-9743-c61ec81564b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479c30a3-9358-4db0-ac99-6da5018a3830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479c30a3-9358-4db0-ac99-6da5018a3830.jpg?1",
             "name": "Spirit of the Season",
             "text": "When Spirit of the Season enters the battlefield, it gains haste if it's summer. Put a +1/+1 counter on it if it's autumn. You gain 5 life if it's winter. If it's spring, search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "03113fed-fb42-5e9b-bfa3-d56bcc915541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc67b0f2-c36d-4ad8-b2ec-08934568526b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc67b0f2-c36d-4ad8-b2ec-08934568526b.jpg?1",
             "name": "Squirrel Farm",
             "text": "{1}{G}: Reveal a card in your hand, covering the artist credit. Target opponent guesses the artist. If they guess wrong, create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -2375,7 +2375,7 @@
         },
         {
             "id": "faf9bb72-f54c-5a66-80dc-e92a82b9184e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e21568-5474-4406-ad54-9e9330e5ff5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e21568-5474-4406-ad54-9e9330e5ff5c.jpg?1",
             "name": "Surgeon General Commander",
             "text": "Whenever you augment, enchant, or mutate a creature you control, draw a card.\n{T}: Add {W}, {U}, {B}, {R}, or {G}.",
             "colours": [
@@ -2416,7 +2416,7 @@
         },
         {
             "id": "1414742d-55f5-5401-a792-a747eb9b9c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa57822-8bca-4cdd-916f-261dae494228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa57822-8bca-4cdd-916f-261dae494228.jpg?1",
             "name": "Timmy, Power Gamer",
             "text": "{4}: You may put a creature card from your hand onto the battlefield.",
             "colours": [
@@ -2452,7 +2452,7 @@
         },
         {
             "id": "dfe8a94f-0182-5d76-abd8-a89eed68437f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af3038-5106-42e3-b9ed-29db209de4d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44af3038-5106-42e3-b9ed-29db209de4d1.jpg?1",
             "name": "Wild Crocodile",
             "text": "When this creature enters the battlefield,\nsearch your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -2487,7 +2487,7 @@
         },
         {
             "id": "6eba118a-91ac-5734-a776-0fba67684a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "Who\no\nXo\nW\nInstant\nTarget player gains X life.\n//\nWhat\no2o\nR\nInstant\nDestroy target artifact.\n//\nWhen\no2o\nU\nInstant\nCounter target creature spell.\n//\nWhere\no3o\nB\nInstant\nDestroy target land.\n//\nWhy\no1o\nG\nInstant\nDestroy target enchantment.",
             "colours": [
@@ -2522,7 +2522,7 @@
         },
         {
             "id": "035da06a-c4fe-54c2-946d-66cd0481fa12",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "823b9f86-5d85-55bf-96a3-bab429a852aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "e1b00e53-7b48-5bc6-842a-66839f08ca7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "5b138950-4f9a-56e0-a614-5d1627471b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea4a077-718b-44af-87be-90df61aab643.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -2662,7 +2662,7 @@
         },
         {
             "id": "a0fdab50-c217-55ab-bf24-f13eafc88e54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bc518c-6752-4a2a-92c0-ed95029dc2ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44bc518c-6752-4a2a-92c0-ed95029dc2ca.jpg?1",
             "name": "Bronze Calendar",
             "text": "Spells you cast cost {1} less to cast.\nYou must speak in a voice other than your normal voice.\nWhen you speak in your normal voice, sacrifice Bronze Calendar.",
             "colours": [],
@@ -2689,7 +2689,7 @@
         },
         {
             "id": "9d95e3d3-88ad-5458-977b-32abe0ebb8ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889b42c8-f009-4a75-b4bf-812fbbd87626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889b42c8-f009-4a75-b4bf-812fbbd87626.jpg?1",
             "name": "Entirely Normal Armchair",
             "text": "During your turn, if Entirely Normal Armchair is in your hand, you may hide it on the battlefield.\n{0}: Return Entirely Normal Armchair to its owner's hand. Only any opponent may activate this ability and only if they see Entirely Normal Armchair.\n{2}, Sacrifice Entirely Normal Armchair: Destroy target attacking creature.",
             "colours": [],
@@ -2716,7 +2716,7 @@
         },
         {
             "id": "76370db3-0da9-5295-b51e-3e99a54e2cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30889-d245-4f20-938a-1295ddbcfac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4e30889-d245-4f20-938a-1295ddbcfac6.jpg?1",
             "name": "Jack-in-the-Mox",
             "text": "{T}: Roll a six-sided die. This ability has the indicated effect.\n1 \u2014 Sacrifice Jack-in-the-Mox and you lose 5 life.\n2 \u2014 Add {W}.\n3 \u2014 Add {U}.\n4 \u2014 Add {B}.\n5 \u2014 Add {R}.\n6 \u2014 Add {G}.",
             "colours": [],
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "6d9047dc-3e2c-56fa-b55d-8091eea05b04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f267de8-2849-4abd-834e-11bbd82dccf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f267de8-2849-4abd-834e-11bbd82dccf5.jpg?1",
             "name": "Krark's Other Thumb",
             "text": "If you would roll a die, instead roll two of those dice and ignore one of those results.",
             "colours": [],
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "d56d93bc-1586-5d79-b536-970d4e64084b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8041ade-5522-4f81-950c-7a610a28da00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8041ade-5522-4f81-950c-7a610a28da00.jpg?1",
             "name": "Paper Tiger",
             "text": "Creatures named Rock Lobster can't attack or block.",
             "colours": [],
@@ -2808,7 +2808,7 @@
         },
         {
             "id": "0e9565c3-ded7-5fa8-94cc-88f7e609f08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab83fbe-c8b7-448c-81b6-b2e46b9f5f95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab83fbe-c8b7-448c-81b6-b2e46b9f5f95.jpg?1",
             "name": "Pointy Finger of Doom",
             "text": "{3}, {T}: Spin Pointy Finger of Doom in the middle of the table so that it rotates completely at least once, then destroy the closest permanent the finger points to.",
             "colours": [],
@@ -2835,7 +2835,7 @@
         },
         {
             "id": "276de3e0-5f7f-54ac-a491-4f50ca5c2ba7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e216977-d414-4e04-aca9-765ea8ea298c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e216977-d414-4e04-aca9-765ea8ea298c.jpg?1",
             "name": "Rock Lobster",
             "text": "Creatures named Scissors Lizard can't attack or block.",
             "colours": [],
@@ -2865,7 +2865,7 @@
         },
         {
             "id": "a1059b69-5c1a-5fd0-a056-264ad09cadf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ec736-67af-443a-a91a-dfd1b2151030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f95ec736-67af-443a-a91a-dfd1b2151030.jpg?1",
             "name": "Scissors Lizard",
             "text": "Creatures named Paper Tiger can't attack or block.",
             "colours": [],
@@ -2895,7 +2895,7 @@
         },
         {
             "id": "36b595c1-f6f0-5042-a812-27cfbc50a400",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf451d4b-0884-4ab5-8d85-312d9db82e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf451d4b-0884-4ab5-8d85-312d9db82e76.jpg?1",
             "name": "Sword of Dungeons & Dragons",
             "text": "Equipped creature gets +2/+2 and has protection from Rogues and from Clerics.\nWhenever equipped creature deals combat damage to a player, create a 4/4 gold Dragon creature token with flying and roll a d20 (a twenty-sided die). If you roll a 20, repeat this process.\nEquip {2}",
             "colours": [],
@@ -2924,7 +2924,7 @@
         },
         {
             "id": "e8fc008f-3f26-55d5-845a-c6f823d6e724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242e7c36-8f1a-4614-86c2-07d97cf516fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242e7c36-8f1a-4614-86c2-07d97cf516fc.jpg?1",
             "name": "Water Gun Balloon Game",
             "text": "As Water Gun Balloon Game enters the battlefield, each player puts a pop counter on \"0.\"\nWhenever a player casts a spell, move that player's pop counter up one.\nWhenever a player's pop counter hits \"5,\" that player creates a 5/5 pink Giant Teddy Bear creature token and resets all pop counters to \"0.\"",
             "colours": [],
@@ -2951,7 +2951,7 @@
         },
         {
             "id": "dc0309c2-c4e7-5abc-9cfd-ca0287f73b3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c362ea-16e2-4c13-bed2-735c8c09d975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c362ea-16e2-4c13-bed2-735c8c09d975.jpg?1",
             "name": "Underdome",
             "text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to pay silver-bordered costs.",
             "colours": [],
@@ -2978,7 +2978,7 @@
         },
         {
             "id": "df3a4387-62c5-5fcc-a675-1c5e04d6103b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116a7806-1513-44b9-ae95-cbedb7e96b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116a7806-1513-44b9-ae95-cbedb7e96b89.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -3013,7 +3013,7 @@
         },
         {
             "id": "19c6f196-f59b-5e2c-b412-a03c4795427e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296cffa-be1f-49af-aaca-3166e7043de0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2296cffa-be1f-49af-aaca-3166e7043de0.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "fd1d49da-582f-5633-81db-d2d8f76559fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5258f33-02c6-4b45-b4de-4429b4508924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5258f33-02c6-4b45-b4de-4429b4508924.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "9f97a994-46a4-5cf8-a8ac-aad1ed82a819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad5cbb-b64e-4e18-9aa0-ac076d4b2448.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ad5cbb-b64e-4e18-9aa0-ac076d4b2448.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "9e9f8fa6-9754-5105-97d9-aa156b2e3c24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e269461e-638f-433b-979b-820f87fb431a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e269461e-638f-433b-979b-820f87fb431a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "81ac82de-a2a6-5e60-946f-56ff32de6c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4996-ed4e-4818-a9ec-f5d8ee84ad26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b1d4996-ed4e-4818-a9ec-f5d8ee84ad26.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -3191,7 +3191,7 @@
         },
         {
             "id": "675635e6-2801-552c-a45b-7aeaf20150e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee851c64-4bf9-4dde-b73e-41366828a1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee851c64-4bf9-4dde-b73e-41366828a1dc.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -3226,7 +3226,7 @@
         },
         {
             "id": "6e450b23-72fb-5d1e-a68f-8fd4d0a6b119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737ac24f-a47b-486c-89df-3e3eaf495ff5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/737ac24f-a47b-486c-89df-3e3eaf495ff5.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "2fd26ecb-9919-5468-a775-2ec526a2db0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f283c-8aae-44ab-b245-c239feb23c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/743f283c-8aae-44ab-b245-c239feb23c16.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -3297,7 +3297,7 @@
         },
         {
             "id": "32bf6053-6ffb-5ab6-9b8d-0db1d38fa4e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a035fe-8847-4678-84f7-01bac77ae011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12a035fe-8847-4678-84f7-01bac77ae011.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "fadc5bb5-e83e-5b93-96e6-7310294ea7a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa4d4-106b-4fec-86ac-b81b71a8f432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bbfa4d4-106b-4fec-86ac-b81b71a8f432.jpg?1",
             "name": "Beeble",
             "text": "",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "5ba1754c-e73f-53bd-887c-702d23c189b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f874f9-7ac2-4d1a-97e3-722db719cd1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f874f9-7ac2-4d1a-97e3-722db719cd1c.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -3401,7 +3401,7 @@
         },
         {
             "id": "43508041-6dab-5759-858c-a3123188292d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c6d816-d9b2-4b11-b0e1-ab00be74cbda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c6d816-d9b2-4b11-b0e1-ab00be74cbda.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -3435,7 +3435,7 @@
         },
         {
             "id": "26d669dc-4e1b-5d56-bdad-22f9202d8b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819b8c9-73a3-4e8e-ad7a-95cffabf873a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6819b8c9-73a3-4e8e-ad7a-95cffabf873a.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [],
@@ -3465,7 +3465,7 @@
         },
         {
             "id": "6101c4b1-4dbe-5e69-99c7-ce9f45cb9390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628c542b-7579-4070-9143-6f1f7221468f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628c542b-7579-4070-9143-6f1f7221468f.jpg?1",
             "name": "Giant Teddy Bear",
             "text": "",
             "colours": [],
@@ -3497,7 +3497,7 @@
         },
         {
             "id": "1cd42be8-2df1-5c7f-9721-8c1bac440e48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fb396f-3ae1-4705-bf94-3e1b0556e910.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fb396f-3ae1-4705-bf94-3e1b0556e910.jpg?1",
             "name": "Acorn Stash",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/UNF.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UNF.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f1bcd64f-bc78-5e47-9b21-ca6bc3e91f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a72769-f691-48c1-939f-54df244fb209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4a72769-f691-48c1-939f-54df244fb209.jpg?1",
             "name": "Standard Procedure",
             "text": "",
             "colours": [],
@@ -34,7 +34,7 @@
         },
         {
             "id": "3550ba55-cde8-5974-8db1-725c35e36fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f4abd-089e-4015-a207-8a62616668b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a2f4abd-089e-4015-a207-8a62616668b1.jpg?1",
             "name": "Aerialephant",
             "text": "Flying\nWhen Aerialephant enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "b3421e63-70cc-5444-918d-fac19f50c6a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e3ec6e-1375-4647-9d15-37ff4697da5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e3ec6e-1375-4647-9d15-37ff4697da5c.jpg?1",
             "name": "Assembled Ensemble",
             "text": "",
             "colours": [
@@ -110,7 +110,7 @@
         },
         {
             "id": "e10470f4-b511-5b67-a426-6b1569586150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c045f20-353f-4e65-a770-dd4e2a7668c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c045f20-353f-4e65-a770-dd4e2a7668c8.jpg?1",
             "name": "Bar Entry",
             "text": "",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "a919f7dd-3486-5f09-9b44-b5a54379042f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e86e72f-4c12-443a-adf7-f733945a6317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e86e72f-4c12-443a-adf7-f733945a6317.jpg?1",
             "name": "_____ Bird Gets the Worm",
             "text": "",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "6850b21a-cdb7-5ef5-a471-b87a77f44f51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859428e7-0795-423b-b16f-fdb4335de2b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859428e7-0795-423b-b16f-fdb4335de2b8.jpg?1",
             "name": "Clowning Around",
             "text": "Create two 1/1 white Clown Robot artifact creature tokens, then roll a six-sided die. If the result is equal to or less than the number of Robots you control, create a 1/1 white Clown Robot artifact creature token.",
             "colours": [
@@ -215,7 +215,7 @@
         },
         {
             "id": "40fc8103-5143-5434-a0e8-7ba4d1ced6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c733e915-aead-4f82-92d0-37eabbfd0017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c733e915-aead-4f82-92d0-37eabbfd0017.jpg?1",
             "name": "Complaints Clerk",
             "text": "When Complaints Clerk enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nWhenever you roll a 1, create a 1/1 white Clown Robot artifact creature token.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "010aaf42-d474-5b0c-8902-7767a8dd69f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c47667-1ae3-464b-9c5f-732a08a53707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c47667-1ae3-464b-9c5f-732a08a53707.jpg?1",
             "name": "Far Out",
             "text": "",
             "colours": [
@@ -286,7 +286,7 @@
         },
         {
             "id": "614227a6-39a0-5fa7-badd-50ff7b53bf8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2149da9d-35ad-4f32-8072-fb515100b2fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2149da9d-35ad-4f32-8072-fb515100b2fd.jpg?1",
             "name": "Form of the Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -320,7 +320,7 @@
         },
         {
             "id": "7a74649f-f518-57dc-b73b-a9e1d6105be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bb8e82-bc4d-4140-a53b-df8844d63b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40bb8e82-bc4d-4140-a53b-df8844d63b01.jpg?1",
             "name": "Get Your Head in the Game",
             "text": "",
             "colours": [
@@ -354,7 +354,7 @@
         },
         {
             "id": "852b5a6b-cd9a-593f-a668-c8e7d047d9e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937d151e-8912-4377-8afc-dc5c742c8a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937d151e-8912-4377-8afc-dc5c742c8a92.jpg?1",
             "name": "Gobsmacked",
             "text": "",
             "colours": [
@@ -390,7 +390,7 @@
         },
         {
             "id": "410b7a27-110f-53c3-81bd-5358e7cfc94d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc2b6b4-399d-411a-a057-8dd1fff0d3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cc2b6b4-399d-411a-a057-8dd1fff0d3b7.jpg?1",
             "name": "A Good Day to Pie",
             "text": "Tap up to two target creatures.\nWhenever you put a name sticker on a creature, you may return A Good Day to Pie from your graveyard to your hand.",
             "colours": [
@@ -424,7 +424,7 @@
         },
         {
             "id": "64e959fa-ca41-5549-bf30-45d27fdd642c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0111a98-4720-4ad8-80b0-929d08a99b04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0111a98-4720-4ad8-80b0-929d08a99b04.jpg?1",
             "name": "Hat Trick",
             "text": "",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "48911cfb-8743-5aa5-b65c-5a434c469865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a8cbef-e95c-4bc0-9043-8a18e02385cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7a8cbef-e95c-4bc0-9043-8a18e02385cb.jpg?1",
             "name": "Impounding Lot-Bot",
             "text": "",
             "colours": [
@@ -495,7 +495,7 @@
         },
         {
             "id": "cd93e0a8-3aa2-553c-8c9c-ecaee1ce95e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca01d8c3-0b5d-4fcc-92e7-1e28956f4297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca01d8c3-0b5d-4fcc-92e7-1e28956f4297.jpg?1",
             "name": "Jetpack Janitor",
             "text": "",
             "colours": [
@@ -532,7 +532,7 @@
         },
         {
             "id": "ed8b0c8a-92ad-5baf-b88b-1c8837baa6d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191da6ec-22a5-4eab-a016-01cd588cce9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/191da6ec-22a5-4eab-a016-01cd588cce9f.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -573,7 +573,7 @@
         },
         {
             "id": "04755679-cee3-5adb-9c27-92675e945b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caddc44-35c1-4171-a4a1-060df29d4da9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3caddc44-35c1-4171-a4a1-060df29d4da9.jpg?1",
             "name": "Knight in _____ Armor",
             "text": "",
             "colours": [
@@ -611,7 +611,7 @@
         },
         {
             "id": "66b61d03-6df8-57da-9db0-c57c6f4487d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f9f520-5e0a-4114-b778-6019f89d2a16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f9f520-5e0a-4114-b778-6019f89d2a16.jpg?1",
             "name": "Leading Performance",
             "text": "",
             "colours": [
@@ -645,7 +645,7 @@
         },
         {
             "id": "9df4b531-0e21-58a8-ad14-a3ad9a94dbbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c4a63-2561-4c52-908f-7d1c08e1d9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315c4a63-2561-4c52-908f-7d1c08e1d9a7.jpg?1",
             "name": "Main Event Horizon",
             "text": "",
             "colours": [
@@ -679,7 +679,7 @@
         },
         {
             "id": "a6aca6f9-ac7a-540f-a1cb-dc6435154f4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9745205-8bbf-4bea-a360-7662de05e47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9745205-8bbf-4bea-a360-7662de05e47b.jpg?1",
             "name": "Now You See Me . . .",
             "text": "",
             "colours": [
@@ -713,7 +713,7 @@
         },
         {
             "id": "42940319-7c4f-5c22-8d12-8bc3b52e0ad6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711784fe-e36b-44ac-bbcc-c29921e231f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711784fe-e36b-44ac-bbcc-c29921e231f3.jpg?1",
             "name": "Park Bleater",
             "text": "Whenever another creature you own enters the battlefield, you get {Ticket}.\n{W}, {T}: You may put a sticker on a creature you own that entered the battlefield this turn.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "17807ed2-b35d-5979-8f56-c0676d25d485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff504c0-ace6-4bbb-a2b9-3518ba31f0e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff504c0-ace6-4bbb-a2b9-3518ba31f0e7.jpg?1",
             "name": "Park Re-Entry",
             "text": "",
             "colours": [
@@ -784,7 +784,7 @@
         },
         {
             "id": "cf022b7d-6b88-5fa2-a506-1fca06dbbbca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f0d7ac-8145-46e3-a594-dd2668e30c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54f0d7ac-8145-46e3-a594-dd2668e30c0c.jpg?1",
             "name": "Pin Collection",
             "text": "When Pin Collection enters the battlefield, you may put an ability sticker with ticket cost X or less on it without paying that sticker's ticket cost.\nEquipped creature gets +1/+1 and has all abilities of ability stickers on Pin Collection.\nEquip {2}",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "ac57aa92-06b4-532e-bc25-44f6ae6f59da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541f80d-f4f2-4a2a-8e17-1d6835e24469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3541f80d-f4f2-4a2a-8e17-1d6835e24469.jpg?1",
             "name": "Ride Guide",
             "text": "When Ride Guide enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "44bbd6e4-30d9-5e9c-a8aa-8069d9130ce4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8febd2c-2f6a-47c6-bebc-6f80e175ee95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8febd2c-2f6a-47c6-bebc-6f80e175ee95.jpg?1",
             "name": "Robo-Pi\u00f1ata",
             "text": "When Robo-Pi\u00f1ata dies, choose one \u2014\n\u2022 You get {Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -895,7 +895,7 @@
         },
         {
             "id": "2200a828-2ef1-5452-9246-fc3e716c0ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8ae57-74d4-4484-aead-56fe125f26f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2b8ae57-74d4-4484-aead-56fe125f26f8.jpg?1",
             "name": "Sanguine Sipper",
             "text": "Sanguine Sipper has lifelink as long as you control a stickered permanent.",
             "colours": [
@@ -932,7 +932,7 @@
         },
         {
             "id": "dc148059-19ae-52af-967d-d97545f83ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a97764c-0d47-4cca-8a02-2b9aade662e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a97764c-0d47-4cca-8a02-2b9aade662e1.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -973,7 +973,7 @@
         },
         {
             "id": "ec9d3b45-86f8-5ecb-a885-f6f1ad4259fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25090e-dd32-4267-a661-da3083d1737a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de25090e-dd32-4267-a661-da3083d1737a.jpg?1",
             "name": "Starlight Spectacular",
             "text": "Parade \u2014 At the beginning of combat on your turn, choose creatures you control one at a time until each creature you control has been chosen. Each of those creatures gets +1/+1 until end of turn for each creature chosen before it. (Places everyone The first creature in line gets +0/+0.)",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "47e100cb-9a6b-59fd-b018-8200ac61dc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dcfb90-8720-4a85-ab5b-169668871bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dcfb90-8720-4a85-ab5b-169668871bb2.jpg?1",
             "name": "Surprise Party",
             "text": "",
             "colours": [
@@ -1041,7 +1041,7 @@
         },
         {
             "id": "1533dc94-889d-5715-bfe3-4d37eceebc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105f7d98-5288-4867-b081-c0541e5d75cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105f7d98-5288-4867-b081-c0541e5d75cc.jpg?1",
             "name": "Sword-Swallowing Seraph",
             "text": "Flying, vigilance\nWhen Sword-Swallowing Seraph enters the battlefield, you may put a name sticker on a nonland permanent you own.\n{1}{W}, {T}: Put a +1/+1 counter on another target creature with a name sticker on it. Activate only as a sorcery.",
             "colours": [
@@ -1078,7 +1078,7 @@
         },
         {
             "id": "aa293451-6533-5f51-b894-23fd4223c0e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77912a6f-774e-4bd5-8632-8fb90c9af82d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77912a6f-774e-4bd5-8632-8fb90c9af82d.jpg?1",
             "name": "T.A.P.P.E.R.",
             "text": "",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "87a61251-6069-5dd9-be34-2260db24e103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490fa81f-3557-4f01-ba2d-0da10fb68a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490fa81f-3557-4f01-ba2d-0da10fb68a20.jpg?1",
             "name": "Trapeze Artist",
             "text": "",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "bc205d7d-1fe2-54cd-9ed6-6b4affb2e975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af548aa-802f-4057-8afb-225cdf19d98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9af548aa-802f-4057-8afb-225cdf19d98b.jpg?1",
             "name": "Animate Object",
             "text": "",
             "colours": [
@@ -1187,7 +1187,7 @@
         },
         {
             "id": "fd6ccb9a-813f-5575-a732-2f139e89aa9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4995ce0-c588-4df5-b6e0-b4f99b861334.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4995ce0-c588-4df5-b6e0-b4f99b861334.jpg?1",
             "name": "Astroquarium",
             "text": "",
             "colours": [
@@ -1221,7 +1221,7 @@
         },
         {
             "id": "3234f7d6-e163-518c-a9e7-67340cc29ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b2911-5b22-4847-a570-c16ce719d9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db5b2911-5b22-4847-a570-c16ce719d9b4.jpg?1",
             "name": "Baaallerina",
             "text": "Flying\nWhen Baaallerina enters the battlefield, you may put a name sticker on a nonland permanent you own.\n{2}{U}: Another target creature with a name sticker on it gains flying until end of turn.",
             "colours": [
@@ -1258,7 +1258,7 @@
         },
         {
             "id": "60e7c3a1-fa46-5b86-816d-b7098968ff89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c3fae-9d73-42bd-88cb-0f7571059c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051c3fae-9d73-42bd-88cb-0f7571059c12.jpg?1",
             "name": "Bag Check",
             "text": "",
             "colours": [
@@ -1292,7 +1292,7 @@
         },
         {
             "id": "1afb572f-b28f-5c28-8051-998859e9170d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03511d64-3c8d-40a1-8ce2-afb46922df1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03511d64-3c8d-40a1-8ce2-afb46922df1d.jpg?1",
             "name": "Bamboozling Beeble",
             "text": "Protection from Robots\n{1}, {T}: The next time target player would roll one or more dice this turn, instead they roll that many dice plus one and you choose one of those rolls to ignore.",
             "colours": [
@@ -1328,7 +1328,7 @@
         },
         {
             "id": "4f8bbb5c-b19a-5d72-bb0f-0c8275347801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3293a-35f4-4ae3-8d88-ae4dbfb38012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccd3293a-35f4-4ae3-8d88-ae4dbfb38012.jpg?1",
             "name": "Bioluminary",
             "text": "Whenever Bioluminary deals combat damage to a player, you get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "4d8502fc-41f6-5016-bb76-b31a8c1a412f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0d1cc-222c-4203-8bf7-a6941d2970ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f0d1cc-222c-4203-8bf7-a6941d2970ff.jpg?1",
             "name": "Blufferfish",
             "text": "",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "3eb78409-5a2e-5ce0-b91d-7e52883ff5cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefcc37a-d3d6-472e-86a5-7197c69c7217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefcc37a-d3d6-472e-86a5-7197c69c7217.jpg?1",
             "name": "Boing!",
             "text": "Return target creature to its owner's hand, then roll a six-sided die. If the result is 3 or less, scry a number of cards equal to the result.",
             "colours": [
@@ -1435,7 +1435,7 @@
         },
         {
             "id": "2eadd5ad-3791-5268-a5dd-278e234e869e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233a7a72-74b8-43de-8638-ea2f2edecb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/233a7a72-74b8-43de-8638-ea2f2edecb87.jpg?1",
             "name": "Busted!",
             "text": "",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "af8effe6-fd0e-591d-894e-bc7c96f0f087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b93fc-3490-4598-95a3-302481e8679d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/082b93fc-3490-4598-95a3-302481e8679d.jpg?1",
             "name": "Command Performance",
             "text": "Choose two \u2014\n\u2022 Open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\n\u2022 Roll to visit your Attractions.\n\u2022 You get {Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "2163d995-017d-5f3a-8bbd-f463a7537bf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28693e54-c171-4c14-bfa3-bed417779cd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28693e54-c171-4c14-bfa3-bed417779cd4.jpg?1",
             "name": "Croakid Amphibonaut",
             "text": "Croakid Amphibonaut has flying as long as you control a stickered permanent.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "50964302-8f53-523d-9209-dcbe08058890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de388bf5-373e-4f3a-a7ab-cfa121f15964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de388bf5-373e-4f3a-a7ab-cfa121f15964.jpg?1",
             "name": "Decisions, Decisions",
             "text": "",
             "colours": [
@@ -1574,7 +1574,7 @@
         },
         {
             "id": "da0d5876-9c0d-5e46-8f29-321f006bf442",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c28cebf-f849-4353-9dd1-c62f05c15d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c28cebf-f849-4353-9dd1-c62f05c15d0f.jpg?1",
             "name": "Exchange of Words",
             "text": "When Exchange of Words enters the battlefield, choose two target creatures. For as long as Exchange of Words remains on the battlefield, exchange the text boxes of those creatures.",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "2f38f665-b018-55d7-9968-b61122c2f749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c974d9a-40a6-4072-90b2-01c3b3461a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c974d9a-40a6-4072-90b2-01c3b3461a75.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -1649,7 +1649,7 @@
         },
         {
             "id": "49f39c5a-7ac1-50bc-acba-fe448931b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba6fc40-1289-4b29-88f9-28de94585b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba6fc40-1289-4b29-88f9-28de94585b46.jpg?1",
             "name": "Focused Funambulist",
             "text": "",
             "colours": [
@@ -1686,7 +1686,7 @@
         },
         {
             "id": "5880d58d-db5f-5b3c-936b-d9d60877bf9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03dfb51-c0df-4cb7-8e42-57d52cec4e89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e03dfb51-c0df-4cb7-8e42-57d52cec4e89.jpg?1",
             "name": "Glitterflitter",
             "text": "Flying\nWhen Glitterflitter enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -1723,7 +1723,7 @@
         },
         {
             "id": "f64812bf-fe37-5031-911e-006fb44189ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e47aa-563d-4501-bbb3-2442b4ca037d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c49e47aa-563d-4501-bbb3-2442b4ca037d.jpg?1",
             "name": "How Is This a Par Three?!",
             "text": "",
             "colours": [
@@ -1757,7 +1757,7 @@
         },
         {
             "id": "e486d4d0-e66f-5e1b-8ee4-76d5e1b8c982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a10b13c-ad97-49a7-9026-dcbd3599ce4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a10b13c-ad97-49a7-9026-dcbd3599ce4c.jpg?1",
             "name": "Make a _____ Splash",
             "text": "",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "d0456cb1-7118-5b3d-9b6b-b08fd285b88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f080ab50-c78c-4a27-a7e5-abfbd93f4e41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f080ab50-c78c-4a27-a7e5-abfbd93f4e41.jpg?1",
             "name": "Mobile Clone",
             "text": "",
             "colours": [
@@ -1825,7 +1825,7 @@
         },
         {
             "id": "09e173b5-4e1c-5dfd-a3c1-ba86b7b0c412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e042a9-0321-4092-8512-ee1d93f3a5f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e042a9-0321-4092-8512-ee1d93f3a5f4.jpg?1",
             "name": "Monitor Monitor",
             "text": "When Monitor Monitor enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nOnce each turn, you may pay {1} to reroll one or more dice you rolled.",
             "colours": [
@@ -1862,7 +1862,7 @@
         },
         {
             "id": "ccf4948b-8623-5908-b703-e0515a1b2688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1d2b1d-d264-4a8e-9c33-c35f5d1e80bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1d2b1d-d264-4a8e-9c33-c35f5d1e80bc.jpg?1",
             "name": "Motion Sickness",
             "text": "Enchant creature\nWhen Motion Sickness enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhenever you visit an Attraction, you may attach Motion Sickness to target tapped creature.",
             "colours": [
@@ -1898,7 +1898,7 @@
         },
         {
             "id": "25fdda67-861a-557a-85b7-0e50f7fca581",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c590e5-be42-4acc-80ef-b27def8d896b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73c590e5-be42-4acc-80ef-b27def8d896b.jpg?1",
             "name": "Octo Opus",
             "text": "",
             "colours": [
@@ -1932,7 +1932,7 @@
         },
         {
             "id": "30c79851-753c-5865-9583-6a74de69f16f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66e33a-3a11-494f-9c23-8e410f7cdae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da66e33a-3a11-494f-9c23-8e410f7cdae4.jpg?1",
             "name": "Phone a Friend",
             "text": "",
             "colours": [
@@ -1966,7 +1966,7 @@
         },
         {
             "id": "dba17347-1500-5e99-b814-87b65ddcd3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba43188f-ac49-4c6a-b53c-9170fe047aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba43188f-ac49-4c6a-b53c-9170fe047aa5.jpg?1",
             "name": "Plate Spinning",
             "text": "",
             "colours": [
@@ -2000,7 +2000,7 @@
         },
         {
             "id": "8a0bab82-5e06-5a44-a84e-c8fdccecc399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffd0fd2-2e53-41a8-8824-7ae4ba1a886f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffd0fd2-2e53-41a8-8824-7ae4ba1a886f.jpg?1",
             "name": "Prize Wall",
             "text": "Defender\n{U}, {T}: You get {Ticket}.\n{4}{U}, {T}: You may put a sticker on a nonland permanent you own. Activate only as a sorcery.",
             "colours": [
@@ -2036,7 +2036,7 @@
         },
         {
             "id": "0e68e360-2c80-5387-9797-3ca6fe3d3522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d43a529-5005-463f-98f7-8931d955b07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d43a529-5005-463f-98f7-8931d955b07e.jpg?1",
             "name": "Seasoned Buttoneer",
             "text": "When Seasoned Buttoneer enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -2073,7 +2073,7 @@
         },
         {
             "id": "2a353a31-523b-54bc-b70a-76a2eb804b2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450c264f-008b-4360-b0ee-f0448ca8fedc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/450c264f-008b-4360-b0ee-f0448ca8fedc.jpg?1",
             "name": "Super-Duper Lost",
             "text": "",
             "colours": [
@@ -2107,7 +2107,7 @@
         },
         {
             "id": "8509bd35-99d6-5d16-8f61-6db10519dbbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456149a1-0f15-466a-8d07-803efb5721d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/456149a1-0f15-466a-8d07-803efb5721d5.jpg?1",
             "name": "Treacherous Trapezist",
             "text": "",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "b19b4372-736d-5f27-9bdf-122977c6c5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacc52b-9e52-42d3-a152-0c96ff55ab44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cacc52b-9e52-42d3-a152-0c96ff55ab44.jpg?1",
             "name": "_____ _____ _____ Trespasser",
             "text": "When this creature enters the battlefield, you may put a name sticker on it.\n{3}{U}: This creature gets +1/+0 until end of turn for each name sticker on it. It can't be blocked this turn.",
             "colours": [
@@ -2182,7 +2182,7 @@
         },
         {
             "id": "f0da1cd3-7601-56ba-86b4-b14dacf6057c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402a29c1-1270-4a2a-8099-4c489e3c1adf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/402a29c1-1270-4a2a-8099-4c489e3c1adf.jpg?1",
             "name": "Unlawful Entry",
             "text": "Target creature gets +1/+0 and gains flying until end of turn.\nWhenever you put an art sticker on a creature, you may return Unlawful Entry from your graveyard to your hand.",
             "colours": [
@@ -2216,7 +2216,7 @@
         },
         {
             "id": "d4f547c7-a7d4-5f97-8e7b-9e8c1d30924a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdc091b-c528-4058-ae10-d9b209d5cee8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bdc091b-c528-4058-ae10-d9b209d5cee8.jpg?1",
             "name": "Vedalken Squirrel-Whacker",
             "text": "As Vedalken Squirrel-Whacker enters the battlefield, roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result.\nIf you would roll one or more six-sided dice, instead roll them and you may exchange one result with Vedalken Squirrel-Whacker's base power or base toughness.",
             "colours": [
@@ -2253,7 +2253,7 @@
         },
         {
             "id": "67d49392-426f-526d-a294-99e9b9a9887b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0df840-e050-42b9-8f81-6682fe16d377.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd0df840-e050-42b9-8f81-6682fe16d377.jpg?1",
             "name": "Wizards of the _____",
             "text": "",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "1716cd04-e660-5de9-bb7f-cfdce17e9b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f7b63b-44b1-4119-a4bf-c10fe3429d91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f7b63b-44b1-4119-a4bf-c10fe3429d91.jpg?1",
             "name": "Animate Graveyard",
             "text": "",
             "colours": [
@@ -2327,7 +2327,7 @@
         },
         {
             "id": "fb70000e-2b0e-5d93-bd78-b9dacae67b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840dd63f-55c7-4bf3-b748-b157721054ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/840dd63f-55c7-4bf3-b748-b157721054ad.jpg?1",
             "name": "Attempted Murder",
             "text": "Choose target creature. Roll X six-sided dice. For each even result, put two -1/-1 counters on that creature. For each odd result, create a 1/2 blue Bird creature token with flying named Storm Crow.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "841c9620-f9c3-5511-a13a-1effb040cb8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed3fc60-9079-486b-a05e-00f926a99b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed3fc60-9079-486b-a05e-00f926a99b4e.jpg?1",
             "name": "Black Hole",
             "text": "",
             "colours": [
@@ -2395,7 +2395,7 @@
         },
         {
             "id": "e9cef9eb-dc21-5065-a811-ca534c8a5143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e6ce64-0907-4db2-a0b6-4f79ba76616b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59e6ce64-0907-4db2-a0b6-4f79ba76616b.jpg?1",
             "name": "Carnival Carnivore",
             "text": "Deathtouch\nWhen Carnival Carnivore enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -2433,7 +2433,7 @@
         },
         {
             "id": "7b48a425-1eea-579d-84b3-72e34b90067f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850c354-6737-4b72-a5bf-fd99f866259a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d850c354-6737-4b72-a5bf-fd99f866259a.jpg?1",
             "name": "Deadbeat Attendant",
             "text": "When Deadbeat Attendant enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -2470,7 +2470,7 @@
         },
         {
             "id": "799302a9-ff50-5631-97db-b0bb287c5e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2658ceab-8d96-44d2-b443-ef671deca928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2658ceab-8d96-44d2-b443-ef671deca928.jpg?1",
             "name": "Discourtesy Clerk",
             "text": "When Discourtesy Clerk enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nAt the beginning of your end step, if you control three or more Attractions, you draw a card and you lose 1 life.",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "046d1a6e-2e7d-5e97-95d2-728e521141df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a467916f-f0dd-4211-a96f-4a01fbad6f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a467916f-f0dd-4211-a96f-4a01fbad6f4e.jpg?1",
             "name": "Disemvowel",
             "text": "",
             "colours": [
@@ -2541,7 +2541,7 @@
         },
         {
             "id": "0c16b404-8032-5292-a046-d1555ff5f4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5df2dd-0a16-4f3c-9352-91bd87b955b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef5df2dd-0a16-4f3c-9352-91bd87b955b4.jpg?1",
             "name": "Dissatisfied Customer",
             "text": "Flying, haste\nWhen Dissatisfied Customer enters the battlefield, roll a six-sided die. If the result is 3 or less, you lose that much life.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "0e936c9e-82af-59bd-8107-ee59b9f70fcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad23c10-3180-456f-b781-84d3893a6815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad23c10-3180-456f-b781-84d3893a6815.jpg?1",
             "name": "Down for Repairs",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Destroy up to one target Attraction that player controls. (It's put into their junkyard.)",
             "colours": [
@@ -2612,7 +2612,7 @@
         },
         {
             "id": "fd3001f0-efb3-56f6-977e-f7822165bfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b584e-4646-4301-b1de-44717336e590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9b584e-4646-4301-b1de-44717336e590.jpg?1",
             "name": "Exit Through the Grift Shop",
             "text": "",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "698369c8-ecf3-51d0-af7f-4b04f25c9f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf4ab1-f558-41fb-a7b5-3e543a307e1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fbf4ab1-f558-41fb-a7b5-3e543a307e1c.jpg?1",
             "name": "Gray Merchant of Alphabet",
             "text": "",
             "colours": [
@@ -2683,7 +2683,7 @@
         },
         {
             "id": "eb55ed1a-341c-594b-859b-74c195efd992",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35fa37b-5119-49b1-a51b-bb359ee272be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a35fa37b-5119-49b1-a51b-bb359ee272be.jpg?1",
             "name": "Haberthrasher",
             "text": "",
             "colours": [
@@ -2721,7 +2721,7 @@
         },
         {
             "id": "9d80181f-e1a7-5c12-a950-3f9d4dc1cf03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b0c89-e811-426c-b185-6d51946c4235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4b0c89-e811-426c-b185-6d51946c4235.jpg?1",
             "name": "Knife and Death",
             "text": "",
             "colours": [
@@ -2755,7 +2755,7 @@
         },
         {
             "id": "84765d33-4468-5d52-ae4a-307f62737e80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b746c03f-85bf-429f-ba93-cd5d6a6999fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b746c03f-85bf-429f-ba93-cd5d6a6999fb.jpg?1",
             "name": "Last Voyage of the _____",
             "text": "",
             "colours": [
@@ -2789,7 +2789,7 @@
         },
         {
             "id": "45080400-cacf-5ae0-a069-4c4e7a1eeafe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fede7f75-0dff-4f3e-816d-e52b43e8b33b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fede7f75-0dff-4f3e-816d-e52b43e8b33b.jpg?1",
             "name": "\"Lifetime\" Pass Holder",
             "text": "\"Lifetime\" Pass Holder enters the battlefield tapped.\nWhen \"Lifetime\" Pass Holder dies, open an Attraction.\nWhenever you roll to visit your Attractions, if you roll a 6, you may return \"Lifetime\" Pass Holder from your graveyard to the battlefield.",
             "colours": [
@@ -2826,7 +2826,7 @@
         },
         {
             "id": "3fdd8ae2-023d-5e1c-9aab-5521735fb86b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ddf4-e86f-406e-a31b-47aede5a97c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d07ddf4-e86f-406e-a31b-47aede5a97c6.jpg?1",
             "name": "Line Cutter",
             "text": "",
             "colours": [
@@ -2864,7 +2864,7 @@
         },
         {
             "id": "66aaea5d-dfdf-5872-9fd0-c70d134b55a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ccea2d-5cde-4c30-a498-66199cbc90a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ccea2d-5cde-4c30-a498-66199cbc90a2.jpg?1",
             "name": "Night Shift of the Living Dead",
             "text": "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.\nWhenever you roll a 6, create a 2/2 black Zombie Employee creature token.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "dc2645f8-31f2-5396-a3ef-d720393c27e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d19cd-e51d-4cee-97ca-1aa646d5bf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1d19cd-e51d-4cee-97ca-1aa646d5bf30.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -2939,7 +2939,7 @@
         },
         {
             "id": "36d1fe5f-94de-5081-9624-8704042b53c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eb480e-c7e7-4177-83b7-ebd4334b15f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58eb480e-c7e7-4177-83b7-ebd4334b15f0.jpg?1",
             "name": "Photo Op",
             "text": "",
             "colours": [
@@ -2973,7 +2973,7 @@
         },
         {
             "id": "21bd4331-b49e-5782-b85c-248872ca1182",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1219a1c-21da-468e-8aa2-085ba2d9db6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1219a1c-21da-468e-8aa2-085ba2d9db6d.jpg?1",
             "name": "Questionable Cuisine",
             "text": "",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "5a232b48-ebfc-5219-bf4d-e78a26cbb0cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78c8da1-7220-4fbf-b672-547af59d2490.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a78c8da1-7220-4fbf-b672-547af59d2490.jpg?1",
             "name": "Quick Fixer",
             "text": "",
             "colours": [
@@ -3044,7 +3044,7 @@
         },
         {
             "id": "8db18424-b8b3-55c4-bb5a-291fcee41282",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c41ae26-23be-4ebe-9ca2-b972ca2b8f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c41ae26-23be-4ebe-9ca2-b972ca2b8f91.jpg?1",
             "name": "Rat in the Hat",
             "text": "",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "99ed7914-775c-5ad6-a87e-a622cb1b320d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e053a-1287-4f4d-b1c2-daf0819c9230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef3e053a-1287-4f4d-b1c2-daf0819c9230.jpg?1",
             "name": "A Real Handful",
             "text": "",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "79833cec-eeb0-546a-abd3-3e33413800bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e6a7bc-a35a-4e68-99a0-be264553b5de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e6a7bc-a35a-4e68-99a0-be264553b5de.jpg?1",
             "name": "Saw in Half",
             "text": "Destroy target creature. If that creature dies this way, its controller creates two tokens that are copies of that creature, except their base power is half that creature's power and their base toughness is half that creature's toughness. Round up each time.",
             "colours": [
@@ -3153,7 +3153,7 @@
         },
         {
             "id": "e226b6f5-6319-5df3-af1e-672db3d30c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31950e19-83ca-45d4-8ca1-e109b875fd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31950e19-83ca-45d4-8ca1-e109b875fd67.jpg?1",
             "name": "Scampire",
             "text": "When Scampire enters the battlefield, you get {Ticket}, then you may put a sticker on a creature card in your graveyard.\n{3}{B}: Return target creature card with a sticker on it from your graveyard to the battlefield. That creature gains haste. Exile it at the beginning of the next end step. Activate only as a sorcery.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "f5c82f29-e7ac-5256-ad8a-7f097d345524",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc479ea0-7c38-49ae-9dc6-1c85183fe6c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc479ea0-7c38-49ae-9dc6-1c85183fe6c8.jpg?1",
             "name": "Scared Stiff",
             "text": "Scared Stiff has menace as long you control a stickered permanent.",
             "colours": [
@@ -3228,7 +3228,7 @@
         },
         {
             "id": "befe1198-35d3-5c94-a4b1-49a4b8869a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443a18c0-0e72-4dd5-ba5e-8e2a486ae0a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443a18c0-0e72-4dd5-ba5e-8e2a486ae0a7.jpg?1",
             "name": "Scooch",
             "text": "",
             "colours": [
@@ -3262,7 +3262,7 @@
         },
         {
             "id": "acccc971-d158-596e-aff3-1c4ea82b70c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0902a-1bc7-4231-8530-2b0fe28a6030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81f0902a-1bc7-4231-8530-2b0fe28a6030.jpg?1",
             "name": "Six-Sided Die",
             "text": "Choose target creature. Roll a six-sided die.\n1 \u2014 It has base toughness 1 until end of turn.\n2 \u2014 Put two -1/-1 counters on it.\n3 \u2014 Six-Sided Die deals 3 damage to it and you gain 3 life.\n4 \u2014 It gets -4/-4 until end of turn.\n5 \u2014 Destroy it.\n6 \u2014 Exile it.",
             "colours": [
@@ -3296,7 +3296,7 @@
         },
         {
             "id": "0005fe8b-170d-5381-baaf-3d6bd58042f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d07a8e-2880-40bd-a80b-c8d938a3761b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89d07a8e-2880-40bd-a80b-c8d938a3761b.jpg?1",
             "name": "Soul Swindler",
             "text": "As long as you've visited an Attraction this turn, Soul Swindler has indestructible. (Damage and effects that say \"destroy\" don't destroy it.)\nWhen Soul Swindler enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -3333,7 +3333,7 @@
         },
         {
             "id": "9344f47d-b912-5c61-8a83-0022a0ee6121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea143b9-140a-4e73-9c23-79327df1ccfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ea143b9-140a-4e73-9c23-79327df1ccfa.jpg?1",
             "name": "Step Right Up",
             "text": "Open two Attractions. (Put the top two cards of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -3367,7 +3367,7 @@
         },
         {
             "id": "5e5afbea-e855-5504-a824-441af557e2ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d009df3-4a15-4614-b365-ac42755b386f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d009df3-4a15-4614-b365-ac42755b386f.jpg?1",
             "name": "Wolf in _____ Clothing",
             "text": "",
             "colours": [
@@ -3404,7 +3404,7 @@
         },
         {
             "id": "a4c8e8be-33fa-5ef2-9f74-e58679a07f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc45cb-0bf5-423d-adeb-112b24c4d57f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fc45cb-0bf5-423d-adeb-112b24c4d57f.jpg?1",
             "name": "Xenosquirrels",
             "text": "Xenosquirrels enters the battlefield with two +1/+1 counters on it.\nAfter you roll a die, you may remove a +1/+1 counter from Xenosquirrels. If you do, increase or decrease the result by 1.",
             "colours": [
@@ -3441,7 +3441,7 @@
         },
         {
             "id": "98cb2d85-6133-5780-ab3e-e2353b980da7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c775a7d1-a1f7-460b-b1f4-888006058e15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c775a7d1-a1f7-460b-b1f4-888006058e15.jpg?1",
             "name": "Aardwolf's Advantage",
             "text": "",
             "colours": [
@@ -3475,7 +3475,7 @@
         },
         {
             "id": "9c56d5bb-fde4-5486-865c-3df6f1d81f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9a9810-ad37-4575-8773-de428174af8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc9a9810-ad37-4575-8773-de428174af8d.jpg?1",
             "name": "Amped Up",
             "text": "",
             "colours": [
@@ -3509,7 +3509,7 @@
         },
         {
             "id": "d2801d98-cc43-5ce7-a921-dd9ecd60ac51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ece617-f845-47e9-8fee-8533db5c7a2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ece617-f845-47e9-8fee-8533db5c7a2f.jpg?1",
             "name": "Art Appreciation",
             "text": "",
             "colours": [
@@ -3543,7 +3543,7 @@
         },
         {
             "id": "ad17c807-d5d9-5377-88ac-229bab2abc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb567441-1880-4b34-9c48-6d2c45062eb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb567441-1880-4b34-9c48-6d2c45062eb0.jpg?1",
             "name": "_____ Balls of Fire",
             "text": "",
             "colours": [
@@ -3577,7 +3577,7 @@
         },
         {
             "id": "c538171e-c8f0-513c-ae97-33d734fb603b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68808b7-b22f-47c6-b654-16d95fc9169b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f68808b7-b22f-47c6-b654-16d95fc9169b.jpg?1",
             "name": "Big Winner",
             "text": "",
             "colours": [
@@ -3615,7 +3615,7 @@
         },
         {
             "id": "17b9bdc9-ff74-5109-aeed-a0b728227d63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c29dab-5cd4-4158-9a12-f14004e08484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c29dab-5cd4-4158-9a12-f14004e08484.jpg?1",
             "name": "Carnival Barker",
             "text": "",
             "colours": [
@@ -3652,7 +3652,7 @@
         },
         {
             "id": "4c9cd78b-257e-56cb-a9cd-8e95ba47c2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21045d6-638e-4267-b353-c2c11db8d965.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21045d6-638e-4267-b353-c2c11db8d965.jpg?1",
             "name": "Circuits Act",
             "text": "Roll three six-sided dice. For each different result, create a 1/1 white Clown Robot artifact creature token.",
             "colours": [
@@ -3686,7 +3686,7 @@
         },
         {
             "id": "d1d1df68-eae4-5701-a2c2-9fdff7e21860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e71131-9591-4773-9c6a-1dc381d0e1ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89e71131-9591-4773-9c6a-1dc381d0e1ab.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -3727,7 +3727,7 @@
         },
         {
             "id": "cc8b4ad6-a9df-5150-92d2-1f883afebeb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c5c1e-1d48-481d-b3b3-97e9cc8416f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5c5c1e-1d48-481d-b3b3-97e9cc8416f3.jpg?1",
             "name": "Don't Try This at Home",
             "text": "",
             "colours": [
@@ -3761,7 +3761,7 @@
         },
         {
             "id": "7958b797-2eb7-5872-9c77-3053f068225a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19d1e98-f667-4a3b-9e78-a416118aec52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b19d1e98-f667-4a3b-9e78-a416118aec52.jpg?1",
             "name": "Eelectrocute",
             "text": "Eelectrocute deals 2 damage to any target.\nYou may cast Eelectrocute from your graveyard as long as you've rolled a 6 this turn. If you cast Eelectrocute this way and it would be put into your graveyard, exile it instead.",
             "colours": [
@@ -3795,7 +3795,7 @@
         },
         {
             "id": "2149c489-5ddc-5aeb-bda6-b53c24e4562c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5819e3f3-da49-4003-88ce-f3b7bb495787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5819e3f3-da49-4003-88ce-f3b7bb495787.jpg?1",
             "name": "_____ Goblin",
             "text": "",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "22718764-ec13-50f4-b019-aaf94df0ee0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a42d2c-8ef3-4789-a0c9-eacdc9005fc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85a42d2c-8ef3-4789-a0c9-eacdc9005fc2.jpg?1",
             "name": "Goblin Airbrusher",
             "text": "Whenever you place a sticker, create a Treasure token. If it's an art sticker, instead create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "a5c0136c-1f93-50b4-99d0-0170938ece07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f4263e-4630-4e22-b3b5-d2abf829567d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f4263e-4630-4e22-b3b5-d2abf829567d.jpg?1",
             "name": "Goblin Blastronauts",
             "text": "",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "b8369e15-cd47-56f6-a6af-508b22dcab61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90bd23d-0f0f-41d7-ba12-776f012714f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b90bd23d-0f0f-41d7-ba12-776f012714f7.jpg?1",
             "name": "Goblin Cruciverbalist",
             "text": "",
             "colours": [
@@ -3944,7 +3944,7 @@
         },
         {
             "id": "1c566088-6d40-5e0a-93cb-30200ec633a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cff141a-6202-436c-ac91-bc3a357aa25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cff141a-6202-436c-ac91-bc3a357aa25e.jpg?1",
             "name": "Goblin Girder Gang",
             "text": "",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "1fe57a4e-0f93-5dea-83d0-c3c33558bf6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6342b-0b9e-4379-b433-70bbaeb04c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb6342b-0b9e-4379-b433-70bbaeb04c19.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "73ad2c9d-d56b-569a-a206-f670ca6d2846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81503e0b-02cb-4441-9fd6-2c3dced877a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81503e0b-02cb-4441-9fd6-2c3dced877a2.jpg?1",
             "name": "Juggletron",
             "text": "",
             "colours": [
@@ -4060,7 +4060,7 @@
         },
         {
             "id": "b1f2b6e5-6a24-5bd3-a88f-dba1e1bdbcdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8994e99-2a63-4b2f-906f-373065aa3319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8994e99-2a63-4b2f-906f-373065aa3319.jpg?1",
             "name": "Minotaur de Force",
             "text": "Haste\nWhen Minotaur de Force enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -4097,7 +4097,7 @@
         },
         {
             "id": "2ddd44cc-66f6-5ff2-a400-9711f69a9709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc051b2-9119-4a12-a8eb-8369954442be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbc051b2-9119-4a12-a8eb-8369954442be.jpg?1",
             "name": "Non-Human Cannonball",
             "text": "When Non-Human Cannonball dies, roll a six-sided die. If the result is 4 or less, Non-Human Cannonball deals that much damage to you.",
             "colours": [
@@ -4135,7 +4135,7 @@
         },
         {
             "id": "fc67e003-fae4-5b85-9ffc-69190efb5c81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -4173,7 +4173,7 @@
         },
         {
             "id": "1b032576-c900-5132-b9a2-c8a6c09b5e43",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "33bab751-55e2-527e-8fe3-465771a0641d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96e3f29-bb0d-49d0-9649-19c3c9b9f40d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96e3f29-bb0d-49d0-9649-19c3c9b9f40d.jpg?1",
             "name": "One-Clown Band",
             "text": "{2}{R}: Target Robot gets +2/+0 until end of turn.",
             "colours": [
@@ -4248,7 +4248,7 @@
         },
         {
             "id": "d72b09c5-7683-5ed7-b4bf-c730c500fc91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1725526f-9a18-4cbd-83cf-16334aa56e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1725526f-9a18-4cbd-83cf-16334aa56e76.jpg?1",
             "name": "Opening Ceremony",
             "text": "",
             "colours": [
@@ -4286,7 +4286,7 @@
         },
         {
             "id": "aed8fe33-181e-5d35-9869-5a4e114bb133",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26243a5b-c489-4691-b1aa-347f7e0d2080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26243a5b-c489-4691-b1aa-347f7e0d2080.jpg?1",
             "name": "Priority Boarding",
             "text": "",
             "colours": [
@@ -4320,7 +4320,7 @@
         },
         {
             "id": "ee781801-d76d-5aad-a32c-30a4ec308e95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e10062a-4406-478d-a594-0be78a982c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e10062a-4406-478d-a594-0be78a982c76.jpg?1",
             "name": "Proficient Pyrodancer",
             "text": "When Proficient Pyrodancer enters the battlefield, you may put an art sticker on a nonland permanent you own.\n{2}{R}: Another target creature with an art sticker on it gets +2/+0 and gains menace until end of turn.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "f19f246b-2c59-5504-b3ca-f1961b3ac89b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18961324-dbfb-4491-af66-ba8ccfbc94f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18961324-dbfb-4491-af66-ba8ccfbc94f4.jpg?1",
             "name": "Rad Rascal",
             "text": "When Rad Rascal enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -4394,7 +4394,7 @@
         },
         {
             "id": "1fa705f7-0cc2-5df2-b038-fa86f46a7770",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66425c96-9fa9-4ba5-8198-619ae4632ed6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66425c96-9fa9-4ba5-8198-619ae4632ed6.jpg?1",
             "name": "Rock Star",
             "text": "",
             "colours": [
@@ -4431,7 +4431,7 @@
         },
         {
             "id": "c247681c-7cc1-51aa-a8e4-bdcc166b4a44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128cc33-05e3-4b2b-8b24-7f574d3f0d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5128cc33-05e3-4b2b-8b24-7f574d3f0d53.jpg?1",
             "name": "Slight Malfunction",
             "text": "",
             "colours": [
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "ec76f3dc-e73d-53b7-843d-8eeb8605b26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8c30b-15e5-44c4-8fe0-431e905f4f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8c30b-15e5-44c4-8fe0-431e905f4f42.jpg?1",
             "name": "Ticking Mime Bomb",
             "text": "",
             "colours": [
@@ -4504,7 +4504,7 @@
         },
         {
             "id": "7dd133c6-9dfb-5676-8f75-dbe63cdea545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cafb84c-6e35-488c-a219-c6bbdb3ac565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cafb84c-6e35-488c-a219-c6bbdb3ac565.jpg?1",
             "name": "Trigger Happy",
             "text": "",
             "colours": [
@@ -4538,7 +4538,7 @@
         },
         {
             "id": "8070623c-6079-5985-a951-000c9a7cb241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd42cab5-3285-48bf-a8f2-f57a474565ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd42cab5-3285-48bf-a8f2-f57a474565ad.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "174fef55-6406-52df-88e9-4ad48a90a563",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7338aa7e-09d0-485c-a223-9395ed9704e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7338aa7e-09d0-485c-a223-9395ed9704e3.jpg?1",
             "name": "Wee Champion",
             "text": "Whenever you place a sticker, Wee Champion gets +1/+1 until end of turn. If it's an art sticker, instead put a +1/+1 counter on Wee Champion.",
             "colours": [
@@ -4621,7 +4621,7 @@
         },
         {
             "id": "71cd8dc7-011a-5a99-96d8-6afa20498d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6eb108-d865-4f9f-8fd5-d10495c036a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a6eb108-d865-4f9f-8fd5-d10495c036a3.jpg?1",
             "name": "Well Done",
             "text": "",
             "colours": [
@@ -4655,7 +4655,7 @@
         },
         {
             "id": "501fdd3b-98c5-56bf-8ded-666a2928802c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782e572-0cea-47a3-9ce9-3c431fbd44f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e782e572-0cea-47a3-9ce9-3c431fbd44f8.jpg?1",
             "name": "Alpha Guard",
             "text": "",
             "colours": [
@@ -4692,7 +4692,7 @@
         },
         {
             "id": "017c5c8d-7481-5819-8fbc-6b049008c448",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cc109-0f43-4957-a4a8-6313b851edae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13cc109-0f43-4957-a4a8-6313b851edae.jpg?1",
             "name": "Atomwheel Acrobats",
             "text": "Whenever you roll a 1 or 2, put that many +1/+1 counters on Atomwheel Acrobats.\n{2}{G}: Roll a six-sided die.",
             "colours": [
@@ -4729,7 +4729,7 @@
         },
         {
             "id": "b6027e03-b09e-54be-a70d-6b9b9db21e08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8de9fc5-9d0b-456b-8ce4-90e6d76f3838.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8de9fc5-9d0b-456b-8ce4-90e6d76f3838.jpg?1",
             "name": "Blorbian Buddy",
             "text": "Trample\n{G}, {T}: You get {Ticket} (a ticket counter).",
             "colours": [
@@ -4766,7 +4766,7 @@
         },
         {
             "id": "8c869c02-eb1c-5af1-bfa2-74ca8066ead4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eecbc0a-237d-433f-9edf-7420819f1301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eecbc0a-237d-433f-9edf-7420819f1301.jpg?1",
             "name": "Centaur of Attention",
             "text": "When Centaur of Attention enters the battlefield, roll five six-sided dice and store those results on it.\nAt the beginning of combat on your turn, you may reroll any number of Centaur of Attention's stored results.\nCentaur of Attention gets +X/+X, where X is the greatest number of stored results on it of the same value.",
             "colours": [
@@ -4803,7 +4803,7 @@
         },
         {
             "id": "1d29926e-d8a0-55d1-8628-96648271daeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68cf6bc-3b4f-4765-87a7-f4b390d08bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68cf6bc-3b4f-4765-87a7-f4b390d08bca.jpg?1",
             "name": "Chicken Troupe",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Chicken Troupe enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -4840,7 +4840,7 @@
         },
         {
             "id": "e3b2d231-0f49-5353-8f40-85388e54ebbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7254a-68fd-4841-9f88-ebf54d5e9731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7c7254a-68fd-4841-9f88-ebf54d5e9731.jpg?1",
             "name": "Clandestine Chameleon",
             "text": "When Clandestine Chameleon enters the battlefield, you get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own.\nClandestine Chameleon has all abilities of ability stickers on other permanents you own and cards in your graveyard.",
             "colours": [
@@ -4877,7 +4877,7 @@
         },
         {
             "id": "1ae02284-ebbd-59e1-9d02-b82c967f3bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0f726-fc72-42ac-b350-3c2813abefa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a0f726-fc72-42ac-b350-3c2813abefa4.jpg?1",
             "name": "Coming Attraction",
             "text": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -4911,7 +4911,7 @@
         },
         {
             "id": "20e39b5e-4d46-5c45-8032-3b4f6edaa5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba0d7c-1e1e-4378-b25b-a531d1937779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0aba0d7c-1e1e-4378-b25b-a531d1937779.jpg?1",
             "name": "Done for the Day",
             "text": "At the beginning of your end step, if you control an Employee, a Performer, or a Robot, you may get {Ticket} or create a Treasure token. If you control all three, you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -4945,7 +4945,7 @@
         },
         {
             "id": "131d2bb8-f0fe-5d53-9927-28419f767ab6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b759c27-9fb6-4c23-adc1-f6d3f3a0eb52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b759c27-9fb6-4c23-adc1-f6d3f3a0eb52.jpg?1",
             "name": "Embiggen",
             "text": "Until end of turn, target non-Brushwagg creature gets +1/+1 for each supertype, card type, and subtype it has.",
             "colours": [
@@ -4979,7 +4979,7 @@
         },
         {
             "id": "fe7f1ac6-7ad2-50fe-ae82-02535983d2c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dcd89f-a626-4dcb-ae73-7b8605747099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5dcd89f-a626-4dcb-ae73-7b8605747099.jpg?1",
             "name": "Fight the _____ Fight",
             "text": "",
             "colours": [
@@ -5015,7 +5015,7 @@
         },
         {
             "id": "c4451d8c-f954-5f2a-b6e3-0f684f991a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadd9acf-3c42-4be4-bb45-551736535cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadd9acf-3c42-4be4-bb45-551736535cb7.jpg?1",
             "name": "Finishing Move",
             "text": "You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "36251069-e2e2-521d-b180-f2d45f842b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9975e-a363-4874-b357-ed3e0183a7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9975e-a363-4874-b357-ed3e0183a7a2.jpg?1",
             "name": "Grabby Tabby",
             "text": "Grabby Tabby has vigilance as long as you control a stickered permanent.",
             "colours": [
@@ -5086,7 +5086,7 @@
         },
         {
             "id": "ffc6c69e-cb16-5bda-b806-8399b5c19ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80225482-6566-41fb-ade7-d9646426a4be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80225482-6566-41fb-ade7-d9646426a4be.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "8ae6c9ec-5e9f-5339-8728-dd3dec25af68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d270c5-9619-41a3-849f-d0d836bb1b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95d270c5-9619-41a3-849f-d0d836bb1b2e.jpg?1",
             "name": "Icing Manipulator",
             "text": "",
             "colours": [
@@ -5164,7 +5164,7 @@
         },
         {
             "id": "33a6fb25-6783-580f-a590-225e91d0bac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ba21ae-9b76-426b-9d79-52373ca0ca20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ba21ae-9b76-426b-9d79-52373ca0ca20.jpg?1",
             "name": "An Incident Has Occurred",
             "text": "",
             "colours": [
@@ -5198,7 +5198,7 @@
         },
         {
             "id": "4c8d5dc8-0638-5d1a-8534-fe51bbc0d750",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b423097-a056-4673-bd7e-ca94a41a7aee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b423097-a056-4673-bd7e-ca94a41a7aee.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -5239,7 +5239,7 @@
         },
         {
             "id": "1679a94b-fae5-5d55-b95b-27381304ba0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c0ac1f-8e40-427e-832c-4d1c6d2ce41c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c0ac1f-8e40-427e-832c-4d1c6d2ce41c.jpg?1",
             "name": "Killer Cosplay",
             "text": "",
             "colours": [
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "6c625c6d-6a31-51db-8467-b3b80f01ee40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbb63c-ffc7-4183-a5e2-b55b035dc033.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17fbb63c-ffc7-4183-a5e2-b55b035dc033.jpg?1",
             "name": "Lineprancers",
             "text": "When Lineprancers enters the battlefield, you get {Ticket}{Ticket}, then you may put a power and toughness sticker on a creature you own.\n{3}{G}: Target creature you don't control blocks target creature you control with a power and toughness sticker on it other than Lineprancers this turn if able.",
             "colours": [
@@ -5312,7 +5312,7 @@
         },
         {
             "id": "457f2652-0563-58cc-9fd3-fcd857b5fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4764da-c508-4a7e-aabc-771f22a32c23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a4764da-c508-4a7e-aabc-771f22a32c23.jpg?1",
             "name": "Mistakes Were Made",
             "text": "",
             "colours": [
@@ -5346,7 +5346,7 @@
         },
         {
             "id": "5c13469e-09fc-5220-bbf4-c5e97969c5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db23c3-7ff6-4b86-a6a6-7c1d9c810e6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4db23c3-7ff6-4b86-a6a6-7c1d9c810e6e.jpg?1",
             "name": "_____-o-saurus",
             "text": "",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "909602a5-f336-5afe-a85d-a46b88698687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567665f3-4227-4f3c-bfbe-4e9576f32b50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/567665f3-4227-4f3c-bfbe-4e9576f32b50.jpg?1",
             "name": "Pair o' Dice Lost",
             "text": "Roll two six-sided dice. Return any number of cards with total mana value X or less from your graveyard to your hand, where X is the total of those results. Exile Pair o' Dice Lost.",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "c140c331-0cb7-5517-98ba-6ab71e367bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb72280-0544-450a-afc6-afec159e6c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb72280-0544-450a-afc6-afec159e6c1f.jpg?1",
             "name": "Petting Zookeeper",
             "text": "Reach\nWhen Petting Zookeeper enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)",
             "colours": [
@@ -5454,7 +5454,7 @@
         },
         {
             "id": "c0acfd21-0ec0-51f0-8930-4165601a548d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1898d1-af70-4386-bd81-b1804dc0a801.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd1898d1-af70-4386-bd81-b1804dc0a801.jpg?1",
             "name": "Pie-Eating Contest",
             "text": "",
             "colours": [
@@ -5488,7 +5488,7 @@
         },
         {
             "id": "08aab601-961f-5ba3-a382-5eca12296cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77594270-42ca-4578-96b6-9a3af18e44de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77594270-42ca-4578-96b6-9a3af18e44de.jpg?1",
             "name": "Plot Armor",
             "text": "",
             "colours": [
@@ -5524,7 +5524,7 @@
         },
         {
             "id": "e6b11987-382d-5984-9c1c-4d1d984eb777",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95cc18-128e-45ca-9255-49b15307f271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b95cc18-128e-45ca-9255-49b15307f271.jpg?1",
             "name": "Resolute Veggiesaur",
             "text": "Trample\nWhenever you roll your third die each turn, put a +1/+1 counter on Resolute Veggiesaur.",
             "colours": [
@@ -5561,7 +5561,7 @@
         },
         {
             "id": "fec1abfa-93ee-55cb-8483-0d5939876411",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65e8d13-10b1-4d0b-813f-c45058560e5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e65e8d13-10b1-4d0b-813f-c45058560e5c.jpg?1",
             "name": "Sole Performer",
             "text": "",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "2ed1684d-9bcc-5974-90c1-4857f40e311f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ceb595-33cd-4b5c-8a23-83b1cd5709d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40ceb595-33cd-4b5c-8a23-83b1cd5709d0.jpg?1",
             "name": "Spelling Bee",
             "text": "",
             "colours": [
@@ -5635,7 +5635,7 @@
         },
         {
             "id": "0c5c324d-f5c9-553a-8710-e547af4b6f79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ba935d-43b9-4661-8d2c-9e6b457c5b68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ba935d-43b9-4661-8d2c-9e6b457c5b68.jpg?1",
             "name": "Squirrel Squatters",
             "text": "When Squirrel Squatters enters the battlefield, open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\nWhenever Squirrel Squatters attacks, create a 1/1 green Squirrel creature token that's tapped and attacking for each Attraction you've visited this turn.",
             "colours": [
@@ -5671,7 +5671,7 @@
         },
         {
             "id": "d204880a-c468-5656-a808-4e71eaa4bb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd16fe9d-9f31-4fe8-941e-f5728cd394a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd16fe9d-9f31-4fe8-941e-f5728cd394a9.jpg?1",
             "name": "Stiltstrider",
             "text": "Reach\nWhen Stiltstrider enters the battlefield, you get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [
@@ -5708,7 +5708,7 @@
         },
         {
             "id": "656d7f3f-3583-51ef-b8a3-043a676ec5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658d1a66-27dc-45fa-9b2a-91b012b1a86f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658d1a66-27dc-45fa-9b2a-91b012b1a86f.jpg?1",
             "name": "Tchotchke Elemental",
             "text": "",
             "colours": [
@@ -5744,7 +5744,7 @@
         },
         {
             "id": "c53df4b5-2efb-5d2c-9960-71cb696e419f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db51cafc-7177-4644-b149-4bef3b73fea8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db51cafc-7177-4644-b149-4bef3b73fea8.jpg?1",
             "name": "Tug of War",
             "text": "",
             "colours": [
@@ -5778,7 +5778,7 @@
         },
         {
             "id": "ed41c6a5-32c5-5aa8-80b6-de1d6fbbe895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78514029-667b-4102-bfea-e154a341be3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78514029-667b-4102-bfea-e154a341be3c.jpg?1",
             "name": "Vegetation Abomination",
             "text": "Deathtouch\n{T}, Sacrifice Vegetation Abomination: Roll a six-sided die. You gain life equal to the result.",
             "colours": [
@@ -5817,7 +5817,7 @@
         },
         {
             "id": "3b5709b6-f83e-5108-a32c-5fce6cbfe591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49600fe1-8c1f-4940-bb1e-7e28131d6d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49600fe1-8c1f-4940-bb1e-7e28131d6d5f.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -5861,7 +5861,7 @@
         },
         {
             "id": "94e50d17-6109-50b6-9db2-9904891dd6f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770aa4e1-a28c-45a4-ab8c-185ccaeb86d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770aa4e1-a28c-45a4-ab8c-185ccaeb86d5.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "9551b2bb-e58f-5b0e-b052-63a64f4263aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68832214-2943-4253-8884-ffa490e84087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68832214-2943-4253-8884-ffa490e84087.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -5947,7 +5947,7 @@
         },
         {
             "id": "b524f7d4-6db3-5547-997d-1e3ac8bf413e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e8bdd9-24a3-42f0-8b0c-dbc05be8fc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e8bdd9-24a3-42f0-8b0c-dbc05be8fc20.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -5991,7 +5991,7 @@
         },
         {
             "id": "14e2b540-0a24-509f-8abc-8d3468de5920",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc9331-0f35-4921-bb27-58a22d3980a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ecc9331-0f35-4921-bb27-58a22d3980a7.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -6034,7 +6034,7 @@
         },
         {
             "id": "61ec1a4c-6b0f-51fc-b01d-557eac0d69b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76fa8d4-923d-4afc-ba47-ba10fc0fe46e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a76fa8d4-923d-4afc-ba47-ba10fc0fe46e.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "0: Roll a six-sided die.\n1 or 2 \u2014 +2, then create two 1/1 green Squirrel creature tokens. They gain haste until end of turn.\n3 \u2014 \u22121, then return a card with mana value 2 or less from your graveyard to your hand.\n4 or 5 \u2014 Comet, Stellar Pup deals damage equal to the number of loyalty counters on him to a creature or player, then \u22122.\n6 \u2014 +1, and you may activate Comet, Stellar Pup's loyalty ability two more times this turn.",
             "colours": [
@@ -6076,7 +6076,7 @@
         },
         {
             "id": "89dade5c-73c7-57ef-a54a-e9b027674256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6607b2ac-e196-4586-b7a5-7c68621084c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6607b2ac-e196-4586-b7a5-7c68621084c4.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -6119,7 +6119,7 @@
         },
         {
             "id": "ed04d25b-43be-512d-920b-b807adba68fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d196ad09-a3b3-445b-8ae4-fa231758c350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d196ad09-a3b3-445b-8ae4-fa231758c350.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "88689b73-0063-541a-8ef9-f18662796523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93330c2-b79b-4211-87ca-6ebc45b70dd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93330c2-b79b-4211-87ca-6ebc45b70dd9.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "a043db54-4f32-5bfe-bfbd-8698d24c4ccd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f5873d-2c62-4f46-b3be-056f6c25fe22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6f5873d-2c62-4f46-b3be-056f6c25fe22.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -6248,7 +6248,7 @@
         },
         {
             "id": "8e9241da-e406-569c-9244-bc2554b8eb82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f2ba13-cd72-4f7a-8443-8e3962f2ac46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f2ba13-cd72-4f7a-8443-8e3962f2ac46.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -6291,7 +6291,7 @@
         },
         {
             "id": "bc04dea7-8cd0-53d5-ab2e-cfb577d00ffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c2e47d-f537-4108-b548-37b294482af6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46c2e47d-f537-4108-b548-37b294482af6.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -6334,7 +6334,7 @@
         },
         {
             "id": "35c8df48-7d48-5d77-8f59-ebcfb92aa9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b43168-44fb-439f-80e7-cb2539ca511f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b43168-44fb-439f-80e7-cb2539ca511f.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "83501f61-e0e6-5c6c-a0ce-8332dbb2810a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b8ff8-13e4-46e7-b028-d055e4548f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08b8ff8-13e4-46e7-b028-d055e4548f6a.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -6421,7 +6421,7 @@
         },
         {
             "id": "3fbe2dee-27dd-5c53-8ec9-8903da5d9fe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e57baea-00ee-49dc-80ce-a8c11a67a6db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e57baea-00ee-49dc-80ce-a8c11a67a6db.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -6464,7 +6464,7 @@
         },
         {
             "id": "59a3f406-c3f3-5000-8865-265dc583a922",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da5dd8-1e56-4c0a-a18f-f094a1cfe2c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5da5dd8-1e56-4c0a-a18f-f094a1cfe2c9.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -6508,7 +6508,7 @@
         },
         {
             "id": "bcbbd0c1-dc44-520c-a977-51e40319a577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7999a76-35b0-43de-8d13-8fc0d447a9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7999a76-35b0-43de-8d13-8fc0d447a9d1.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -6551,7 +6551,7 @@
         },
         {
             "id": "c739441d-479d-554f-a215-ae5c52f91285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ddb2e7-6bc6-43ce-aeec-175a0ce17ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ddb2e7-6bc6-43ce-aeec-175a0ce17ed5.jpg?1",
             "name": "Space Beleren",
             "text": "Space sculptor (Space Beleren divides the battlefield into alpha, beta, and gamma sectors. If a creature isn't assigned to a sector, its controller assigns it to one. Opponents assign first.)\n+1: Creatures in each sector can be blocked this turn only by creatures in the same sector.\n\u22121: Put a +1/+1 counter on each creature in the sector of your choice.\n\u22125: Destroy all creatures in the sector of your choice.",
             "colours": [
@@ -6593,7 +6593,7 @@
         },
         {
             "id": "923b092f-13a0-557b-a253-626921cde862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26177224-3c0e-4081-8468-3cd9981ddb0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26177224-3c0e-4081-8468-3cd9981ddb0a.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "a0002a16-a233-532a-a15d-5567b7db6fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a92336-2ed7-4496-9476-9fe3368bbdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a92336-2ed7-4496-9476-9fe3368bbdfd.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -6679,7 +6679,7 @@
         },
         {
             "id": "46e0434c-0f6e-5857-bf4f-e51f8ccf4a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6f092-08b9-4c67-836a-28006ea3b2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b6f092-08b9-4c67-836a-28006ea3b2df.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -6723,7 +6723,7 @@
         },
         {
             "id": "4d3a781a-4dbf-5ac1-a6df-a0fde2317923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903168f6-c195-47af-bdf7-b5748108d2a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903168f6-c195-47af-bdf7-b5748108d2a8.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -6767,7 +6767,7 @@
         },
         {
             "id": "56aad74f-2df6-5a89-8c2c-c732db25f790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e53c1d-56cf-4d3f-8150-df307c5a3ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e53c1d-56cf-4d3f-8150-df307c5a3ae4.jpg?1",
             "name": "Autograph Book",
             "text": "",
             "colours": [],
@@ -6797,7 +6797,7 @@
         },
         {
             "id": "3bf6015d-785a-5465-b7f9-b9678e1a3b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da67aec2-18ff-426a-a074-25cd34b01f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da67aec2-18ff-426a-a074-25cd34b01f9c.jpg?1",
             "name": "Blue Ribbon",
             "text": "",
             "colours": [],
@@ -6829,7 +6829,7 @@
         },
         {
             "id": "a4bdf296-541a-5c9c-88bf-f748c3a161d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa7b481-9332-4140-9a46-11e4e384d8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa7b481-9332-4140-9a46-11e4e384d8f1.jpg?1",
             "name": "Celebr-8000",
             "text": "At the beginning of combat on your turn, roll two six-sided dice. For each result of 1, Celebr-8000 gets +1/+1 until end of turn. For each other result, it gains the indicated ability until end of turn. If you rolled doubles, it also gains double strike until end of turn.\n\u2022 2 \u2014 menace \u2022 5 \u2014 flying\n\u2022 3 \u2014 vigilance \u2022 6 \u2014 indestructible\n\u2022 4 \u2014 lifelink",
             "colours": [],
@@ -6863,7 +6863,7 @@
         },
         {
             "id": "8d4c3e95-957b-543e-a7f9-5c8822539be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6667e4f-f0f6-4416-940a-d03bed75f5a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6667e4f-f0f6-4416-940a-d03bed75f5a7.jpg?1",
             "name": "Clown Car",
             "text": "When Clown Car enters the battlefield, roll X six-sided dice. For each odd result, create a 1/1 white Clown Robot artifact creature token. For each even result, put a +1/+1 counter on Clown Car.\nCrew 2",
             "colours": [],
@@ -6895,7 +6895,7 @@
         },
         {
             "id": "865b60bf-be0a-5547-967b-a756bb2345b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72beb4e7-7044-4b10-b585-ee35760827b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72beb4e7-7044-4b10-b585-ee35760827b1.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "f184b4a3-1b46-51c1-b95e-f89f52062c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c97bdec-d085-4929-927b-ba0d81a2987d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c97bdec-d085-4929-927b-ba0d81a2987d.jpg?1",
             "name": "Draconian Gate-Bot",
             "text": "When Draconian Gate-Bot enters the battlefield, choose one \u2014\n\u2022 Open an Attraction. (Put the top card of your Attraction deck onto the battlefield.)\n\u2022 Destroy target Attraction. (It's put into its owner's junkyard.)",
             "colours": [],
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "9b129c7f-82eb-5e9e-9265-e4a9cf8d1989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a5413-290b-484b-b754-06ec7f1a62ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92a5413-290b-484b-b754-06ec7f1a62ac.jpg?1",
             "name": "Greatest Show in the Multiverse",
             "text": "",
             "colours": [],
@@ -6998,7 +6998,7 @@
         },
         {
             "id": "51e2eb66-504a-5f13-96ac-1a659f81bb13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f895a-5c2e-4530-9a09-835d2b02ccae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/420f895a-5c2e-4530-9a09-835d2b02ccae.jpg?1",
             "name": "Park Map",
             "text": "",
             "colours": [],
@@ -7028,7 +7028,7 @@
         },
         {
             "id": "e19a5f35-6104-53f6-8d11-ddabbaf47cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97957307-f8ec-412f-a720-9b03b93fac56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97957307-f8ec-412f-a720-9b03b93fac56.jpg?1",
             "name": "_____ _____ Rocketship",
             "text": "",
             "colours": [],
@@ -7060,7 +7060,7 @@
         },
         {
             "id": "2373c2da-2ac0-56fe-abeb-03f7a0bb4a0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c468d-7faa-43f9-8221-1640c76403b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267c468d-7faa-43f9-8221-1640c76403b9.jpg?1",
             "name": "Souvenir T-Shirt",
             "text": "",
             "colours": [],
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "162b2bcb-0d62-5250-a02e-4cb1fea81dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b654514f-b1a0-4d96-8d05-55e2cf386518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b654514f-b1a0-4d96-8d05-55e2cf386518.jpg?1",
             "name": "Strength-Testing Hammer",
             "text": "Whenever equipped creature attacks, roll a six-sided die. That creature gets +X/+0 until end of turn, where X is the result. Then if it has the greatest power or is tied for greatest power among creatures on the battlefield, draw a card.\nEquip {3}",
             "colours": [],
@@ -7124,7 +7124,7 @@
         },
         {
             "id": "81be2535-ab40-56f4-a0ca-682d845614b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6086ebe1-a8d4-4fd4-8d68-487553ce1405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6086ebe1-a8d4-4fd4-8d68-487553ce1405.jpg?1",
             "name": "Ticket Turbotubes",
             "text": "{T}: Add one mana of any color.\n{3}, {T}: You get {Ticket} (a ticket counter).",
             "colours": [],
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "fd3d60f6-3795-5b50-8ded-19a088f7daeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4906051-0f74-4a0c-9508-2fa52d98b618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4906051-0f74-4a0c-9508-2fa52d98b618.jpg?1",
             "name": "Ticketomaton",
             "text": "When Ticketomaton enters the battlefield, you get {Ticket}, then you may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -7187,7 +7187,7 @@
         },
         {
             "id": "74563ac6-2a0c-56ee-9e07-6579f7c7e638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7db6e16-357c-4872-8b23-338953ffefb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7db6e16-357c-4872-8b23-338953ffefb4.jpg?1",
             "name": "Wicker Picker",
             "text": "Creature spells you cast have sticker kicker {1}. (You may pay an additional {1} as you cast a creature spell. If you do, you get {Ticket}, then you may put a sticker on it.)",
             "colours": [],
@@ -7221,7 +7221,7 @@
         },
         {
             "id": "181276bc-57d5-52dc-bd15-172d53fe3bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c98d7-a5c4-41ce-9179-0f06ae72b7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8c98d7-a5c4-41ce-9179-0f06ae72b7f4.jpg?1",
             "name": "The Big Top",
             "text": "",
             "colours": [],
@@ -7251,7 +7251,7 @@
         },
         {
             "id": "a8312c09-290f-5e07-9219-04a1fbc2a108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da785d1b-6b90-4b65-9efb-d7f329405318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da785d1b-6b90-4b65-9efb-d7f329405318.jpg?1",
             "name": "Nearby Planet",
             "text": "",
             "colours": [],
@@ -7287,7 +7287,7 @@
         },
         {
             "id": "5d646a97-f63e-5573-b5ca-a7ce9b1d2f83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c47a99-965c-4bde-935a-10f28cf5ccba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42c47a99-965c-4bde-935a-10f28cf5ccba.jpg?1",
             "name": "Urza's Fun House",
             "text": "",
             "colours": [],
@@ -7319,7 +7319,7 @@
         },
         {
             "id": "2ec0d664-e1f7-5a49-a76d-93ba96dc3414",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9eaed8-e956-4fb2-a23d-3d442cd2fa5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9eaed8-e956-4fb2-a23d-3d442cd2fa5c.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7353,7 +7353,7 @@
         },
         {
             "id": "9d7b7368-4040-50fb-a141-3cc0abba5885",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7412ea3f-646c-41bd-be94-cf2a2c0cee14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7412ea3f-646c-41bd-be94-cf2a2c0cee14.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7387,7 +7387,7 @@
         },
         {
             "id": "c5a60901-f11e-50ad-b4f6-d39c730f048f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a7de59-f3d4-4092-b23d-0e519a108ced.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a7de59-f3d4-4092-b23d-0e519a108ced.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7421,7 +7421,7 @@
         },
         {
             "id": "60dc836f-deb5-5274-9045-b749e67d44b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb8928-8178-439b-803e-35f5681b8ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26bb8928-8178-439b-803e-35f5681b8ff4.jpg?1",
             "name": "Balloon Stand",
             "text": "Visit \u2014 Choose one.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Sacrifice a Balloon. If you do, target creature gains flying until end of turn.",
             "colours": [],
@@ -7455,7 +7455,7 @@
         },
         {
             "id": "7ae44751-89eb-52d6-8a3e-c1622601e47c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5985a9-2f9c-45b9-ac59-f29e7197b301.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e5985a9-2f9c-45b9-ac59-f29e7197b301.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7489,7 +7489,7 @@
         },
         {
             "id": "e0840ffa-6136-5461-9033-60405c545a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8c158f-52be-4cb4-a0bd-1f6419a12da0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8c158f-52be-4cb4-a0bd-1f6419a12da0.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7523,7 +7523,7 @@
         },
         {
             "id": "711b8fc4-49c1-528c-a666-29e6a3637a14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756164bc-6d3a-4d0f-96b6-fd0ae9a5371e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/756164bc-6d3a-4d0f-96b6-fd0ae9a5371e.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7557,7 +7557,7 @@
         },
         {
             "id": "7c74bcbc-e603-597f-a885-01573be8816f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a818c-125a-48ac-9e3a-9502c69b9386.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a818c-125a-48ac-9e3a-9502c69b9386.jpg?1",
             "name": "Bounce Chamber",
             "text": "Visit \u2014 Return a creature you don't control with the lowest toughness among creatures you don't control to its owner's hand. (If multiple creatures are tied, choose any one of them.)",
             "colours": [],
@@ -7591,7 +7591,7 @@
         },
         {
             "id": "5a2b4057-bf9b-5598-ba95-f7beda0bcfe3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdefffa-14bb-4a2b-9e75-13e29eaa6677.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdefffa-14bb-4a2b-9e75-13e29eaa6677.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7627,7 +7627,7 @@
         },
         {
             "id": "68e00e79-c8f6-5126-90aa-91de7fc2cd27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e52d857-b673-427a-84b7-fd8a65650aec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e52d857-b673-427a-84b7-fd8a65650aec.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7663,7 +7663,7 @@
         },
         {
             "id": "0a31971c-02b5-59f8-8a90-db63e0b6f32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ccdc1b-ad12-4d2d-bb9e-0b0d50b9a644.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ccdc1b-ad12-4d2d-bb9e-0b0d50b9a644.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7699,7 +7699,7 @@
         },
         {
             "id": "546fe317-78e7-5060-9675-ad4829434999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7254a788-ea08-4daa-b8db-c8f0c3c84a2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7254a788-ea08-4daa-b8db-c8f0c3c84a2e.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7735,7 +7735,7 @@
         },
         {
             "id": "ab15c6a7-163d-5260-b5cd-7d9d8c59f730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fa2347-5967-4736-ad11-d8299a331907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56fa2347-5967-4736-ad11-d8299a331907.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7771,7 +7771,7 @@
         },
         {
             "id": "12603d87-e49f-5f98-9e9c-e3434fda33e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb790c6-8195-488c-b64d-83faf8699304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb790c6-8195-488c-b64d-83faf8699304.jpg?1",
             "name": "Bumper Cars",
             "text": "Visit \u2014 Target creature must be blocked this turn if able.",
             "colours": [],
@@ -7807,7 +7807,7 @@
         },
         {
             "id": "fb0955d8-e21b-5b5f-8e78-06e9de258e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eed5075-0632-4af1-8a16-9b959317e154.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eed5075-0632-4af1-8a16-9b959317e154.jpg?1",
             "name": "Centrifuge",
             "text": "Visit \u2014 Each player draws a card from the library of the player to their right. You create three Treasure tokens.",
             "colours": [],
@@ -7839,7 +7839,7 @@
         },
         {
             "id": "33f8140d-9719-583e-986c-48c312489e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb4473-6c19-44ba-ba57-b2a9646d80d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bb4473-6c19-44ba-ba57-b2a9646d80d7.jpg?1",
             "name": "Centrifuge",
             "text": "Visit \u2014 Each player draws a card from the library of the player to their right. You create three Treasure tokens.",
             "colours": [],
@@ -7871,7 +7871,7 @@
         },
         {
             "id": "6d4afa3b-1a98-5f40-bf66-b3cda32d0c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cd6f28-11b0-4d69-bc2c-9050c2478b1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cd6f28-11b0-4d69-bc2c-9050c2478b1d.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -7905,7 +7905,7 @@
         },
         {
             "id": "5d5e166d-1e78-5d73-9592-75a98116d3d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e23dec-67c1-446a-b599-2a8ea8f7c716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e23dec-67c1-446a-b599-2a8ea8f7c716.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -7939,7 +7939,7 @@
         },
         {
             "id": "f40e19bd-c1c8-5382-a6bf-bac579a55f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e8c2a-62bd-4c12-b2c2-287b8ef68b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8e8c2a-62bd-4c12-b2c2-287b8ef68b53.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -7973,7 +7973,7 @@
         },
         {
             "id": "8646bb99-19a6-5973-b4cb-c131e02aa6a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0accf374-76ed-4829-9fb2-87d6a411b0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0accf374-76ed-4829-9fb2-87d6a411b0dc.jpg?1",
             "name": "Clown Extruder",
             "text": "Visit \u2014 Create a 1/1 white Clown Robot artifact creature token.",
             "colours": [],
@@ -8007,7 +8007,7 @@
         },
         {
             "id": "83045a4c-76df-585e-9103-add474594f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ab8948-1080-487b-b0a0-c5d11935141f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ab8948-1080-487b-b0a0-c5d11935141f.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "2c58f345-548e-5522-8989-3fb34eca721b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443739b2-22da-4ac8-907e-71a3b6c49a3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/443739b2-22da-4ac8-907e-71a3b6c49a3f.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8075,7 +8075,7 @@
         },
         {
             "id": "5fdfd43b-f222-5e43-81bc-b8683c57d105",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6289bc9-e77f-4764-bae8-96d4569ac737.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6289bc9-e77f-4764-bae8-96d4569ac737.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8109,7 +8109,7 @@
         },
         {
             "id": "e070e404-6b94-522a-bf23-bfb89fccfdc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514e6039-2722-4350-a8e0-b2964d6c100d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514e6039-2722-4350-a8e0-b2964d6c100d.jpg?1",
             "name": "Concession Stand",
             "text": "Visit \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [],
@@ -8143,7 +8143,7 @@
         },
         {
             "id": "16a26793-623d-5ad8-ac1a-668433e4e0dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81dd9df-0eeb-42fd-8dd0-fd7f154954e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c81dd9df-0eeb-42fd-8dd0-fd7f154954e0.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "f7d2fed7-12cb-5984-bd20-634fa7102c4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f89ff2-6da0-40ea-998c-cb6893c5d0fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f89ff2-6da0-40ea-998c-cb6893c5d0fa.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8215,7 +8215,7 @@
         },
         {
             "id": "294b48e4-0e48-566e-935c-6abb0eb15759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9e5578-266c-45d2-86b8-0ff32fa9f80a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9e5578-266c-45d2-86b8-0ff32fa9f80a.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8251,7 +8251,7 @@
         },
         {
             "id": "e36e200a-67a7-5e91-8e36-6dad44aaf61b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610d3b7-1066-4dbf-af12-55e2d9a984b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0610d3b7-1066-4dbf-af12-55e2d9a984b5.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8287,7 +8287,7 @@
         },
         {
             "id": "0ac328d7-8ec7-58da-b90d-a0edc49c60c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd3e471-c342-4590-ac8e-1064ba2c6beb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cd3e471-c342-4590-ac8e-1064ba2c6beb.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8323,7 +8323,7 @@
         },
         {
             "id": "68e9d157-392d-52a0-992b-790e68377488",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64539d25-b2af-4a12-b8ee-03d24a91b07e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64539d25-b2af-4a12-b8ee-03d24a91b07e.jpg?1",
             "name": "Costume Shop",
             "text": "Visit \u2014 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "856e40e1-798c-5208-8e2e-3e93625add8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174517f4-efdc-4932-bc6a-53703dfa6875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174517f4-efdc-4932-bc6a-53703dfa6875.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8393,7 +8393,7 @@
         },
         {
             "id": "231855ea-dcff-5893-97c7-9bf3607d848e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866f977-5641-4c20-8c06-e4c9cfd2e065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b866f977-5641-4c20-8c06-e4c9cfd2e065.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8427,7 +8427,7 @@
         },
         {
             "id": "694ad33d-51b4-500e-8492-8f6fcd729788",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52860ef5-e884-4c15-afa1-2ea21c67e608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52860ef5-e884-4c15-afa1-2ea21c67e608.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8461,7 +8461,7 @@
         },
         {
             "id": "ec1edc15-02f6-5d4d-9a2b-164717953f8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb2b98a-0f88-41f5-b87c-8622cd8939e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb2b98a-0f88-41f5-b87c-8622cd8939e5.jpg?1",
             "name": "Cover the Spot",
             "text": "Visit \u2014 Drop three cards you own from outside the game one at a time onto the playing area from a height of at least one foot (about 0.3 meters). If those cards completely cover Cover the Spot, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Cover the Spot, then open an Attraction.",
             "colours": [],
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "224a2af2-aea7-5e34-a7fa-78a942fa79ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d11e43-6942-408a-a585-7f431b154f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1d11e43-6942-408a-a585-7f431b154f65.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8529,7 +8529,7 @@
         },
         {
             "id": "10e77ea4-606b-5bfe-88d2-09c5185ae1ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ff30a-d56b-455a-8d15-10c23da8ec82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6ff30a-d56b-455a-8d15-10c23da8ec82.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8563,7 +8563,7 @@
         },
         {
             "id": "a60c8057-5984-5e3b-9191-33a8a37d9043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c553b00c-1b5a-4a4c-a4eb-e7b573c9cb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c553b00c-1b5a-4a4c-a4eb-e7b573c9cb33.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8597,7 +8597,7 @@
         },
         {
             "id": "df740b54-43b3-5a49-8c96-ca25496441c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac24e8e-69de-4e3e-8f3c-b4436c65bc28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac24e8e-69de-4e3e-8f3c-b4436c65bc28.jpg?1",
             "name": "Dart Throw",
             "text": "Visit \u2014 Throw a card you own from outside the game onto the playing area from a distance of three feet (about one meter). If that card touches Dart Throw, claim the prize\nPrize \u2014 Create two 2/2 pink Teddy Bear creature tokens. Sacrifice Dart Throw, then open an Attraction.",
             "colours": [],
@@ -8631,7 +8631,7 @@
         },
         {
             "id": "f2f120c0-af49-5fe1-8277-4ad1230c2029",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738cd8d-f88b-431e-b66f-dc32e39a9606.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b738cd8d-f88b-431e-b66f-dc32e39a9606.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8667,7 +8667,7 @@
         },
         {
             "id": "47524c89-e456-5b4d-bd97-1bb1d5431712",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e070e-bc22-416a-a424-2ac285704b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019e070e-bc22-416a-a424-2ac285704b8f.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8703,7 +8703,7 @@
         },
         {
             "id": "5cedef9d-c3fc-50b5-b38e-c9eb79e2b519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99613047-706f-450d-90bf-d66a11293ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99613047-706f-450d-90bf-d66a11293ec6.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8739,7 +8739,7 @@
         },
         {
             "id": "499c0e3c-ed18-51a5-b766-0a9fefa6c33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4573d1a0-f4b0-43f2-a7fb-8af6b1c4ecde.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4573d1a0-f4b0-43f2-a7fb-8af6b1c4ecde.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8775,7 +8775,7 @@
         },
         {
             "id": "2392debf-dd0b-5978-9977-6ccd41c24f07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cb926f-22c1-450b-82cd-bb3c861b80a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cb926f-22c1-450b-82cd-bb3c861b80a3.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "e745a6c3-f2ea-585b-bedb-4a6ce88e1d33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0aedb2-de98-4abc-9d4e-7f682ee9a26b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0aedb2-de98-4abc-9d4e-7f682ee9a26b.jpg?1",
             "name": "Drop Tower",
             "text": "Visit \u2014 Target creature gains flying until end of turn or until any player rolls a 1, whichever comes first.",
             "colours": [],
@@ -8847,7 +8847,7 @@
         },
         {
             "id": "6cb33b2c-793c-549d-9ef6-fb3db3c74935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91562ab3-1153-48d9-9f8e-4c79155548f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91562ab3-1153-48d9-9f8e-4c79155548f2.jpg?1",
             "name": "Ferris Wheel",
             "text": "",
             "colours": [],
@@ -8877,7 +8877,7 @@
         },
         {
             "id": "aa64e910-4054-5cc8-ab75-da887cc5c078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9456ca6-a721-4b61-8afb-19d811f21a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9456ca6-a721-4b61-8afb-19d811f21a3c.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -8911,7 +8911,7 @@
         },
         {
             "id": "9231a1a7-ab40-5a05-9212-37488d32d370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c57f5f-2a7c-4d85-a06a-0692a8b71989.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6c57f5f-2a7c-4d85-a06a-0692a8b71989.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -8945,7 +8945,7 @@
         },
         {
             "id": "24a7236d-e8d8-59f9-aebb-ed4cba16b559",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1a5df-2279-49f3-a658-865565d6464d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f1a5df-2279-49f3-a658-865565d6464d.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -8979,7 +8979,7 @@
         },
         {
             "id": "edbdb8f1-3798-5651-ad70-633fcb83953c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2c9aa0-1f1b-481b-acd2-718a1813c91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2c9aa0-1f1b-481b-acd2-718a1813c91a.jpg?1",
             "name": "Foam Weapons Kiosk",
             "text": "Visit \u2014 Put a +1/+1 counter on target creature you control. That creature gains vigilance until end of turn.",
             "colours": [],
@@ -9013,7 +9013,7 @@
         },
         {
             "id": "16eb73fe-58bb-5b18-a398-0032c295c8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde28457-2a4d-44e0-9d03-31173d411c34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fde28457-2a4d-44e0-9d03-31173d411c34.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9049,7 +9049,7 @@
         },
         {
             "id": "6a8368aa-c6d0-55b3-a36f-e4b498d6204c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e68a801-fe89-46a7-b097-2ba79214482b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e68a801-fe89-46a7-b097-2ba79214482b.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "491fc62d-b041-5d00-b950-6f821b5e873f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eece7-f94f-4988-a5ba-11cab94152d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/477eece7-f94f-4988-a5ba-11cab94152d2.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "eec9ff00-2699-5b9d-a61d-560828761608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74018663-1f57-44ed-8c98-97bd96e8100d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74018663-1f57-44ed-8c98-97bd96e8100d.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9157,7 +9157,7 @@
         },
         {
             "id": "ccab4343-4545-5959-9030-79850b72e8a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68ac1c8-d802-4854-b2bf-4686efa62a97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a68ac1c8-d802-4854-b2bf-4686efa62a97.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "3de997f1-fbdc-5dc5-8e03-e4e6b9459900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533f3be9-82a1-45a4-bd91-f34eab32ade4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533f3be9-82a1-45a4-bd91-f34eab32ade4.jpg?1",
             "name": "Fortune Teller",
             "text": "Visit \u2014 Scry 1.",
             "colours": [],
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "9b65868e-db7d-5666-97e4-a414691db4f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ad0d58-b1f6-4549-b0b3-f655b006dbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9ad0d58-b1f6-4549-b0b3-f655b006dbb4.jpg?1",
             "name": "Gallery of Legends",
             "text": "Visit \u2014 Exile cards from the top of your library until you exile a nonland card, then choose a legendary creature card name with the same mana value as that card. Create a token that's a copy of the card with the chosen name. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -9261,7 +9261,7 @@
         },
         {
             "id": "faff9920-c495-5d8b-9d3a-9fe857cb37f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ec3a9-e706-46f9-bf90-ba9aacd2d6cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e00ec3a9-e706-46f9-bf90-ba9aacd2d6cd.jpg?1",
             "name": "Gallery of Legends",
             "text": "Visit \u2014 Exile cards from the top of your library until you exile a nonland card, then choose a legendary creature card name with the same mana value as that card. Create a token that's a copy of the card with the chosen name. That token gains haste. Exile it at the beginning of the next end step.",
             "colours": [],
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "bc0ba63e-d5a9-5678-ab4c-a6cc1de79289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723e0-4e14-4910-905c-0292b84a0272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0be723e0-4e14-4910-905c-0292b84a0272.jpg?1",
             "name": "Gift Shop",
             "text": "Visit \u2014 Choose one that hasn't been chosen.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Create a 2/2 pink Teddy Bear creature token.\n\u2022 Create two Food tokens.\n\u2022 You get {Ticket}{Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -9325,7 +9325,7 @@
         },
         {
             "id": "4b6af18c-88a3-53d0-b9bd-a7b9b7ab3d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc33291-a597-4c70-8072-aa7251e57e78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbc33291-a597-4c70-8072-aa7251e57e78.jpg?1",
             "name": "Gift Shop",
             "text": "Visit \u2014 Choose one that hasn't been chosen.\n\u2022 Create a 1/1 red Balloon creature token with flying.\n\u2022 Create a 2/2 pink Teddy Bear creature token.\n\u2022 Create two Food tokens.\n\u2022 You get {Ticket}{Ticket}{Ticket}.\n\u2022 You may put a sticker on a nonland permanent you own.",
             "colours": [],
@@ -9357,7 +9357,7 @@
         },
         {
             "id": "bc703cc3-9908-575e-8278-904b1f7343d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdf92c4-1645-4e48-8294-8b10f62dd45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cdf92c4-1645-4e48-8294-8b10f62dd45a.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9391,7 +9391,7 @@
         },
         {
             "id": "42c07e79-04e2-5124-a877-b3611310d0f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb74882-b66b-4397-9b17-1d114472b655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eb74882-b66b-4397-9b17-1d114472b655.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9425,7 +9425,7 @@
         },
         {
             "id": "22829dc5-4570-5ae9-bcfd-10c216d92937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c02968-b930-4be8-ab6e-6a388704b1f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c02968-b930-4be8-ab6e-6a388704b1f1.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "b5118311-f41e-5b3a-b5c1-3ccf94bb5b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7347a-30a3-48cf-9257-48cf240e0178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db7347a-30a3-48cf-9257-48cf240e0178.jpg?1",
             "name": "Guess Your Fate",
             "text": "Visit \u2014 Look at the bottom card of your library, then give a person outside the game a one-word clue not on that card. They guess a word. If their guess appears in that card's name, claim the prize\nPrize \u2014 Reveal the card, put it into your hand, then sacrifice Guess Your Fate and open an Attraction.",
             "colours": [],
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "bcd4142e-8ba4-561b-83dc-3a85560d5923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c887a-9879-4f62-8058-ece831d6fb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825c887a-9879-4f62-8058-ece831d6fb65.jpg?1",
             "name": "Hall of Mirrors",
             "text": "Visit \u2014 Choose target creature you control. Each other creature you control becomes a copy of that creature until end of turn, except it isn't legendary if the chosen creature is legendary.",
             "colours": [],
@@ -9525,7 +9525,7 @@
         },
         {
             "id": "f794f050-20ba-56bf-a9dd-cc0b44f35b22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1ce311-3a27-432b-8d77-1548c50afa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1ce311-3a27-432b-8d77-1548c50afa52.jpg?1",
             "name": "Hall of Mirrors",
             "text": "",
             "colours": [],
@@ -9557,7 +9557,7 @@
         },
         {
             "id": "33195709-1778-5b09-baee-e77804063d09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8d4551-3adc-4ce4-bcea-1a555208de8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f8d4551-3adc-4ce4-bcea-1a555208de8b.jpg?1",
             "name": "Haunted House",
             "text": "Visit \u2014 Return target creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of your next end step.",
             "colours": [],
@@ -9589,7 +9589,7 @@
         },
         {
             "id": "e6ccf367-39b4-582c-b877-f5cb7791b63e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a651c53-b345-482b-b732-f0a5098068c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a651c53-b345-482b-b732-f0a5098068c3.jpg?1",
             "name": "Haunted House",
             "text": "Visit \u2014 Return target creature card from your graveyard to the battlefield. It gains haste. Exile it at the beginning of your next end step.",
             "colours": [],
@@ -9621,7 +9621,7 @@
         },
         {
             "id": "0def53d4-b985-5b7b-8ba1-4941eaf78fdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015dc10f-d1cb-41ed-a32e-3382540109b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/015dc10f-d1cb-41ed-a32e-3382540109b0.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9655,7 +9655,7 @@
         },
         {
             "id": "308354c4-c2db-51fe-93c4-c751b814f1e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb7aed1-99e8-494c-9bc5-c483d0577f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcb7aed1-99e8-494c-9bc5-c483d0577f91.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9689,7 +9689,7 @@
         },
         {
             "id": "c4ded5fd-48de-57db-9cd0-c2dce72d25dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9591b2-7cbc-48e4-82c7-103ca6cef37d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d9591b2-7cbc-48e4-82c7-103ca6cef37d.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9723,7 +9723,7 @@
         },
         {
             "id": "4daef6ac-4778-5fa2-b099-873970ff56ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64218e2c-0e5b-48f1-8eea-698c20fbb017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64218e2c-0e5b-48f1-8eea-698c20fbb017.jpg?1",
             "name": "Information Booth",
             "text": "Visit \u2014 Draw a card.",
             "colours": [],
@@ -9757,7 +9757,7 @@
         },
         {
             "id": "1dd8501e-6284-56ef-94b8-a0eae3e78b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451731e1-ac14-426c-a853-d502d10394a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451731e1-ac14-426c-a853-d502d10394a0.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9793,7 +9793,7 @@
         },
         {
             "id": "3253bc2c-c3bf-5a03-969c-66720a9c1c16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7df12a-6284-441c-8bc0-abd1c01dca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7df12a-6284-441c-8bc0-abd1c01dca4f.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9829,7 +9829,7 @@
         },
         {
             "id": "642d6838-f55a-5021-ba9b-e2504337679b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008d7d1f-8635-41d5-9921-11d8043a6206.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008d7d1f-8635-41d5-9921-11d8043a6206.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9865,7 +9865,7 @@
         },
         {
             "id": "c8224252-c34f-54f1-a78e-e869732e77c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f999ad-05df-4c95-bcce-e3d8c0827c3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f999ad-05df-4c95-bcce-e3d8c0827c3e.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9901,7 +9901,7 @@
         },
         {
             "id": "71317b27-024e-5ab9-b529-b68542557cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edec11-0d16-4228-af1b-92c0cafb8a3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6edec11-0d16-4228-af1b-92c0cafb8a3a.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9937,7 +9937,7 @@
         },
         {
             "id": "89ad761a-dbd8-5077-8cf4-f1404668567c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d386c2a-df7e-4839-b81d-99e2b9e364df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d386c2a-df7e-4839-b81d-99e2b9e364df.jpg?1",
             "name": "Kiddie Coaster",
             "text": "Visit \u2014 Creatures you control get +1/+0 until end of turn.",
             "colours": [],
@@ -9973,7 +9973,7 @@
         },
         {
             "id": "83aac216-2240-58fe-b260-0ca155451e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b29fde-e065-4edf-96e7-88318b61c260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b29fde-e065-4edf-96e7-88318b61c260.jpg?1",
             "name": "Log Flume",
             "text": "Visit \u2014 Choose up to four creatures you control. Those creatures jump in a log until end of turn. (Creatures in a log together can't be blocked unless they're all blocked. If a spell or ability you control targets one of them, it targets all of them.)",
             "colours": [],
@@ -10005,7 +10005,7 @@
         },
         {
             "id": "3a33411e-6ebe-567d-80a1-033222a77da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7090cb0-70ec-4966-88bd-4e4bf7efb142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7090cb0-70ec-4966-88bd-4e4bf7efb142.jpg?1",
             "name": "Log Flume",
             "text": "Visit \u2014 Choose up to four creatures you control. Those creatures jump in a log until end of turn. (Creatures in a log together can't be blocked unless they're all blocked. If a spell or ability you control targets one of them, it targets all of them.)",
             "colours": [],
@@ -10037,7 +10037,7 @@
         },
         {
             "id": "9d7c7012-4c99-5960-972c-0d5f302088be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb35be9-4fe3-4db7-81d6-d66f5e399d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eb35be9-4fe3-4db7-81d6-d66f5e399d03.jpg?1",
             "name": "Memory Test",
             "text": "When Memory Test enters the battlefield, target opponent exiles cards from the bottom of their library until they exile five nonland cards, then turns those nonland cards face down.\nVisit \u2014 Name the exiled face-down cards, then look at them. If you named them correctly, turn them face up, then claim the prize\nPrize \u2014 Create three 1/1 red Balloon creature tokens with flying, then sacrifice Memory Test and open an Attraction.",
             "colours": [],
@@ -10069,7 +10069,7 @@
         },
         {
             "id": "40ff777d-b64a-53c5-8954-9737ef41fe45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd511185-f55b-49f2-a1ab-31683ae827e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd511185-f55b-49f2-a1ab-31683ae827e0.jpg?1",
             "name": "Memory Test",
             "text": "When Memory Test enters the battlefield, target opponent exiles cards from the bottom of their library until they exile five nonland cards, then turns those cards face down.\nVisit \u2014 Name the exiled nonland cards, then look at the exiled cards. If you named them correctly, claim the prize\nPrize \u2014 Create three 1/1 red Balloon creature tokens with flying, then sacrifice Memory Test and open an Attraction.",
             "colours": [],
@@ -10101,7 +10101,7 @@
         },
         {
             "id": "e9748ccc-1be2-58c1-a8f6-da48cfa2f5d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df9d6db-5b97-464b-a880-364fa33567e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df9d6db-5b97-464b-a880-364fa33567e8.jpg?1",
             "name": "Merry-Go-Round",
             "text": "Visit \u2014 Creatures you control with power 2 or less gain horsemanship until end of turn. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [],
@@ -10133,7 +10133,7 @@
         },
         {
             "id": "c80df02a-3c60-509b-aa08-dfb13f5f22c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d4e4af-0587-40ea-86f1-992c80240adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d4e4af-0587-40ea-86f1-992c80240adb.jpg?1",
             "name": "Merry-Go-Round",
             "text": "Visit \u2014 Creatures you control with power 2 or less gain horsemanship until end of turn. (They can't be blocked except by creatures with horsemanship.)",
             "colours": [],
@@ -10165,7 +10165,7 @@
         },
         {
             "id": "a44f55e6-b355-586f-ace5-1975fa7cb5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1f5d3f-7702-4446-a672-d149053abcc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f1f5d3f-7702-4446-a672-d149053abcc5.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10201,7 +10201,7 @@
         },
         {
             "id": "8a3be1c9-0449-5aae-a57e-f4b60ce03d74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfdd446-3618-44dd-9521-2e223c8ccae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcfdd446-3618-44dd-9521-2e223c8ccae3.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10237,7 +10237,7 @@
         },
         {
             "id": "5852292d-7737-56d3-8017-ba4e793ec751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334d1755-a875-42eb-91f8-a7a90ecce367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334d1755-a875-42eb-91f8-a7a90ecce367.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10273,7 +10273,7 @@
         },
         {
             "id": "8f2151da-472c-55ee-b8ed-148e21620d71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa86716-5f94-4943-8dc3-56d760e2eff6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa86716-5f94-4943-8dc3-56d760e2eff6.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10309,7 +10309,7 @@
         },
         {
             "id": "d8e984ad-44d2-5c29-8bc8-a5a64d9517dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f97ddf7-c394-48c2-95e5-751df20befea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f97ddf7-c394-48c2-95e5-751df20befea.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10345,7 +10345,7 @@
         },
         {
             "id": "f874e68c-c336-59f5-88c8-9faa1766e332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18088e7-9bad-40d1-af40-d9a65847d1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18088e7-9bad-40d1-af40-d9a65847d1cd.jpg?1",
             "name": "Pick-a-Beeble",
             "text": "Visit \u2014 Roll a six-sided die. Put a number of luck counters on Pick-a-Beeble equal to the result and create a Treasure token. Then if there are six or more luck counters on Pick-a-Beeble, claim the prize\nPrize \u2014 Create two Treasure tokens, then sacrifice Pick-a-Beeble and open an Attraction.",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "5d0ec2a8-3eb9-5219-a6df-86864b4c6aec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a60cc-4561-4f96-9df1-9cbe9545f1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75a60cc-4561-4f96-9df1-9cbe9545f1dc.jpg?1",
             "name": "Push Your Luck",
             "text": "Visit \u2014 Reveal cards from the top of your library until you decide to stop. If the total mana value of the cards revealed this way is 7 or less, create a 2/2 pink Teddy Bear creature token. If the total is exactly 7, claim the prize Shuffle the revealed cards into your library.\nPrize \u2014 Put five +1/+1 counters on a Teddy Bear you control. It gains haste. Sacrifice Push Your Luck and open an Attraction.",
             "colours": [],
@@ -10413,7 +10413,7 @@
         },
         {
             "id": "2b3b89f8-2b58-530c-963b-2f9ef81cbf4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05269f3c-b549-401a-8f7f-c5993fc211c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05269f3c-b549-401a-8f7f-c5993fc211c9.jpg?1",
             "name": "Push Your Luck",
             "text": "Visit \u2014 Reveal cards from the top of your library until you decide to stop. If the total mana value of the cards revealed this way is 7 or less, create a 2/2 pink Teddy Bear creature token. If the total is exactly 7, claim the prize Shuffle the revealed cards into your library.\nPrize \u2014 Put five +1/+1 counters on a Teddy Bear you control. It gains haste. Sacrifice Push Your Luck and open an Attraction.",
             "colours": [],
@@ -10445,7 +10445,7 @@
         },
         {
             "id": "2b979faa-ee43-5557-8e67-bebb94767086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff3a7a-d9b7-494f-991d-db1d0ff2de56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9ff3a7a-d9b7-494f-991d-db1d0ff2de56.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10479,7 +10479,7 @@
         },
         {
             "id": "87202a84-5468-508f-b69c-6ad696cb4dac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5636b2c4-ca50-4435-807d-13d74bd15d7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5636b2c4-ca50-4435-807d-13d74bd15d7c.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10513,7 +10513,7 @@
         },
         {
             "id": "05a6ddce-1e31-54b6-b9e4-8f1b5ff85475",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea3a2df-d327-4d0b-b711-53347a9ff0b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ea3a2df-d327-4d0b-b711-53347a9ff0b5.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10547,7 +10547,7 @@
         },
         {
             "id": "fb88c9c2-43ce-5c5d-ad11-1dba4b64ccd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a66ff6a-5194-4139-9323-e23b99a42742.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a66ff6a-5194-4139-9323-e23b99a42742.jpg?1",
             "name": "Roller Coaster",
             "text": "Visit \u2014 Creatures you control get +2/+0 until end of turn.",
             "colours": [],
@@ -10581,7 +10581,7 @@
         },
         {
             "id": "c162e47b-7a2e-5f93-9efe-382216e07a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69b2b85-77d5-4e11-9858-c2403e49219a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69b2b85-77d5-4e11-9858-c2403e49219a.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a humanoid animal or alien,\" \"food,\" or \"horns or tusks\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10617,7 +10617,7 @@
         },
         {
             "id": "7b8b533d-22d4-51a2-9765-cda7c7a8e348",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d95e12-b648-4a2c-b1d0-931b99949a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d95e12-b648-4a2c-b1d0-931b99949a8f.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"an elf or goblin,\" \"a tail,\" or \"a flying creature or flying vehicle\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10653,7 +10653,7 @@
         },
         {
             "id": "22a8be36-e6a8-5c99-9480-eae00caf7971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7106f347-677f-4a2a-87ab-705389b2be7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7106f347-677f-4a2a-87ab-705389b2be7e.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a creature wearing a hat,\" \"a book or scroll,\" or \"teeth\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10689,7 +10689,7 @@
         },
         {
             "id": "d1b8ae8a-7ead-5dd2-9035-b8439596a2a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0080c6-a4fc-481c-b7bd-90692deb1873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0080c6-a4fc-481c-b7bd-90692deb1873.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a weapon,\" \"five or more creatures,\" or \"words or numbers\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10725,7 +10725,7 @@
         },
         {
             "id": "ae60f689-d4b5-54ed-9212-0d4319393ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e559da14-5e2e-4312-85dd-b1e652d8a7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e559da14-5e2e-4312-85dd-b1e652d8a7b2.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a vampire or zombie,\" \"fire, lightning, or an explosion,\" or \"a metallic creature\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10761,7 +10761,7 @@
         },
         {
             "id": "1f889edd-6cec-51bd-a391-43e73ea51fc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1d6397-930d-4eac-b500-144b23d28811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1d6397-930d-4eac-b500-144b23d28811.jpg?1",
             "name": "Scavenger Hunt",
             "text": "Visit \u2014 Choose \"a four-legged creature,\" \"a liquid other than water,\" or \"a door\" at random. You have ten seconds to search your library and reveal a card with the chosen item in its art. If you do, claim the prize Then shuffle.\nPrize \u2014 You get {Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Scavenger Hunt and open an Attraction.",
             "colours": [],
@@ -10797,7 +10797,7 @@
         },
         {
             "id": "172b4299-0dfb-5c0a-a3c6-cf930cd7ad63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ceb59c-fdd7-43f8-8824-fff5e0154271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ceb59c-fdd7-43f8-8824-fff5e0154271.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10833,7 +10833,7 @@
         },
         {
             "id": "1f2059cd-a192-5171-b451-b32162aa31fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810dc84-dd78-4f49-bc75-92887fd7f653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0810dc84-dd78-4f49-bc75-92887fd7f653.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10869,7 +10869,7 @@
         },
         {
             "id": "63b82a42-c685-5188-b45c-bbb94d5451ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06396eac-94d2-4f25-a9b0-7c90cbc0f79d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06396eac-94d2-4f25-a9b0-7c90cbc0f79d.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10905,7 +10905,7 @@
         },
         {
             "id": "aad9e5af-92fe-56a3-9557-f6c3ab66e570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f0bac-098f-4d88-9b8e-82d12ad25dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/113f0bac-098f-4d88-9b8e-82d12ad25dfa.jpg?1",
             "name": "Spinny Ride",
             "text": "Visit \u2014 Tap target creature an opponent controls.",
             "colours": [],
@@ -10941,7 +10941,7 @@
         },
         {
             "id": "71cd756e-81ae-504e-82f9-1b2f28d4fb91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ecd2b9-4a23-44fa-93e2-210225d3da47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78ecd2b9-4a23-44fa-93e2-210225d3da47.jpg?1",
             "name": "Spinny Ride",
             "text": "",
             "colours": [],
@@ -10977,7 +10977,7 @@
         },
         {
             "id": "d18720fd-85a2-5314-9457-40226fcda381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f6b339-06cf-4608-8f66-25c20bdc1230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83f6b339-06cf-4608-8f66-25c20bdc1230.jpg?1",
             "name": "Spinny Ride",
             "text": "",
             "colours": [],
@@ -11013,7 +11013,7 @@
         },
         {
             "id": "0cedb0b4-dc5d-546f-9b41-f9f22e88edac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de665505-0896-46c6-a6b5-d3b57a9a01e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de665505-0896-46c6-a6b5-d3b57a9a01e4.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11049,7 +11049,7 @@
         },
         {
             "id": "c1bd72cb-3b32-5d11-a5d3-a8aaf959cafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ead87da-b031-41b0-8904-f9069d85ca57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ead87da-b031-41b0-8904-f9069d85ca57.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11085,7 +11085,7 @@
         },
         {
             "id": "e2229c8d-73fc-5723-87c7-2e3a2d65b4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b16dc-8c0c-4747-9512-e679f69a9c38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/718b16dc-8c0c-4747-9512-e679f69a9c38.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11121,7 +11121,7 @@
         },
         {
             "id": "24c7b304-7621-5771-8a21-6e4d58709554",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcaaa3a8-ced5-43ec-94fe-12e662d8261e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcaaa3a8-ced5-43ec-94fe-12e662d8261e.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11157,7 +11157,7 @@
         },
         {
             "id": "bbb40e89-9c26-5cdc-870a-6cd7d1b3018f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ad144-9846-4097-bb51-c473c55b2f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/174ad144-9846-4097-bb51-c473c55b2f74.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11193,7 +11193,7 @@
         },
         {
             "id": "150443bd-317f-59f2-b5c8-8c3250f0a50d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04423fcd-fdfe-477a-9d92-eda91dc16f85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04423fcd-fdfe-477a-9d92-eda91dc16f85.jpg?1",
             "name": "Squirrel Stack",
             "text": "Visit \u2014 You have five seconds to stack dice on top of one another. If you stack at least five dice, claim the prize\nPrize \u2014 Create a 1/1 green Squirrel creature token for each die you stacked above the fourth, then sacrifice Squirrel Stack and open an Attraction.",
             "colours": [],
@@ -11229,7 +11229,7 @@
         },
         {
             "id": "5708bba7-499b-502b-bbb3-1efafa55e820",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42aeb2e-26ca-49b1-8e4d-1454c3783a84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42aeb2e-26ca-49b1-8e4d-1454c3783a84.jpg?1",
             "name": "Storybook Ride",
             "text": "Visit \u2014 Exile the top X cards of your library, where X is the number of Attractions you've visited this turn (including this one). You may play those cards. At the beginning of the next end step, put them on the bottom of your library in any order.",
             "colours": [],
@@ -11261,7 +11261,7 @@
         },
         {
             "id": "0b6608cc-0251-50fc-8d64-cbdd6c1893f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070cf701-53ae-463f-b6ce-47b489557e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/070cf701-53ae-463f-b6ce-47b489557e8a.jpg?1",
             "name": "Storybook Ride",
             "text": "Visit \u2014 Exile the top X cards of your library, where X is the number of Attractions you've visited this turn (including this one). You may play those cards. At the beginning of the next end step, put them on the bottom of your library in any order.",
             "colours": [],
@@ -11293,7 +11293,7 @@
         },
         {
             "id": "c45015b0-c454-59e1-8a4d-72e450ff782c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0319b2d1-1d63-4f3f-a1da-10ec64d74f03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0319b2d1-1d63-4f3f-a1da-10ec64d74f03.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the fastest,\" \"the scariest,\" or \"the weakest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11329,7 +11329,7 @@
         },
         {
             "id": "b7fed820-e91c-5fb1-b05d-9f3e2d58e55a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65ff7de-ed00-41cf-8320-74f98c87212e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d65ff7de-ed00-41cf-8320-74f98c87212e.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the cutest,\" \"the loudest,\" or \"the strongest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11365,7 +11365,7 @@
         },
         {
             "id": "737ebc52-5254-5347-b642-e3d9d99c0985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d298f389-4c97-413c-ac83-9c928cb5c3e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d298f389-4c97-413c-ac83-9c928cb5c3e4.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the quietest,\" \"the slowest,\" or \"the ugliest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11401,7 +11401,7 @@
         },
         {
             "id": "7644248f-e034-51eb-9ff7-09143c3e4ab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f21a33a-ef9d-495d-a475-7042cbd9f6f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f21a33a-ef9d-495d-a475-7042cbd9f6f5.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the cleanest,\" \"the hungriest,\" or \"the strangest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11437,7 +11437,7 @@
         },
         {
             "id": "fea3ff94-81cb-502d-b4fe-b3ac68d513a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801ff015-e322-4a85-a060-326a74bed703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801ff015-e322-4a85-a060-326a74bed703.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the friendliest,\" \"the smartest,\" or \"the wildest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11473,7 +11473,7 @@
         },
         {
             "id": "3c0d032d-2419-54da-b5b1-fb41765e07f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25f5c7-2352-4d21-a48f-11dddc310a1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc25f5c7-2352-4d21-a48f-11dddc310a1b.jpg?1",
             "name": "The Superlatorium",
             "text": "Visit \u2014 An opponent chooses \"the funniest,\" \"the smelliest,\" or \"the sturdiest.\" You choose a creature, then ask a person outside the game to choose the creature that best fits the chosen criteria. If they chose the same creature you chose, claim the prize\nPrize \u2014 Create two 1/1 red Balloon creature tokens with flying, then sacrifice The Superlatorium and open an Attraction.",
             "colours": [],
@@ -11509,7 +11509,7 @@
         },
         {
             "id": "d49f5c18-29eb-51d6-ab39-f03d40f1cd48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782b5d-57a9-4595-8f35-18d1881263f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0782b5d-57a9-4595-8f35-18d1881263f8.jpg?1",
             "name": "Swinging Ship",
             "text": "Visit \u2014 After the first combat phase this turn, there's an additional combat phase. At the beginning of that combat, untap all creatures that attacked this turn.",
             "colours": [],
@@ -11541,7 +11541,7 @@
         },
         {
             "id": "b11a3957-a90c-598c-b229-430c25388062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a7dfaa-f2dc-4975-a4c2-25537a4874fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38a7dfaa-f2dc-4975-a4c2-25537a4874fc.jpg?1",
             "name": "Swinging Ship",
             "text": "Visit \u2014 After the first combat phase this turn, there's an additional combat phase. At the beginning of that combat, untap all creatures that attacked this turn.",
             "colours": [],
@@ -11573,7 +11573,7 @@
         },
         {
             "id": "567e8cd7-d565-5751-836d-73ab9ec5e564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07c39f7-5c3e-40f6-b584-458b65282a7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f07c39f7-5c3e-40f6-b584-458b65282a7e.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11607,7 +11607,7 @@
         },
         {
             "id": "cc44b702-ebe3-5e51-ba15-df0e0dbb6bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba10e7e-f2fc-4b30-88e9-cfc850b852ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba10e7e-f2fc-4b30-88e9-cfc850b852ab.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11641,7 +11641,7 @@
         },
         {
             "id": "4e9c1b9d-097e-568e-910a-d86b95a2e783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4da5c2-17e8-4fa1-a8b2-d8ec4ff585d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4da5c2-17e8-4fa1-a8b2-d8ec4ff585d8.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11675,7 +11675,7 @@
         },
         {
             "id": "f2aa5ffc-0616-50be-89eb-866a4dc56697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e371d860-aaf1-4a81-b607-f5494921e55f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e371d860-aaf1-4a81-b607-f5494921e55f.jpg?1",
             "name": "Trash Bin",
             "text": "Visit \u2014 Mill two cards, then return a card at random from your graveyard to your hand. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [],
@@ -11709,7 +11709,7 @@
         },
         {
             "id": "a7331c28-312c-58db-a19d-7c93ee65a198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6083e23-9050-4221-b1c9-06a83f0ce53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6083e23-9050-4221-b1c9-06a83f0ce53b.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses white card, land card, or planeswalker card, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11745,7 +11745,7 @@
         },
         {
             "id": "8ee08441-de0e-5f99-857d-e1f67bb9e24e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2900cf-4d92-4192-b4f2-2445a06f120f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2900cf-4d92-4192-b4f2-2445a06f120f.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses blue card, enchantment card, or creature type, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11781,7 +11781,7 @@
         },
         {
             "id": "5f2e36c5-f263-56a4-90cb-92ac11727677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0543f27-d2ec-44bc-b9e3-1044d292a3e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0543f27-d2ec-44bc-b9e3-1044d292a3e6.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses black card, artifact card, or expansion, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11817,7 +11817,7 @@
         },
         {
             "id": "78729f10-9d52-5a4c-b5c7-ad1eaa34aa52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52057f7-a78a-4edc-8e95-edaea6376e76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c52057f7-a78a-4edc-8e95-edaea6376e76.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses red card, sorcery card, or legendary card, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11853,7 +11853,7 @@
         },
         {
             "id": "dc124f98-9a17-5470-961e-1c1450bae776",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecd115-48a8-48d3-8eff-0ec4ddb2174c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ecd115-48a8-48d3-8eff-0ec4ddb2174c.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses green card, instant card, or named mechanic, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11889,7 +11889,7 @@
         },
         {
             "id": "1bf7cc09-7e22-5fd0-b7be-64d528427930",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b20bcc6-69ed-432d-ab10-c7bceb7cdfb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b20bcc6-69ed-432d-ab10-c7bceb7cdfb9.jpg?1",
             "name": "Trivia Contest",
             "text": "Visit \u2014 An opponent chooses colorless card, creature card, or plane, then mills a card. You have ten seconds to name something from the chosen category that starts with the same letter as the milled card. If you do, claim the prize\nPrize \u2014 You get {Ticket}{Ticket}{Ticket}, then you may put a sticker on a nonland permanent you own. Sacrifice Trivia Contest and open an Attraction.",
             "colours": [],
@@ -11925,7 +11925,7 @@
         },
         {
             "id": "a39390f6-dcc6-5479-8350-2ae08499cb1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f902fef-5905-4e72-b838-22acdb01ccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f902fef-5905-4e72-b838-22acdb01ccc8.jpg?1",
             "name": "Tunnel of Love",
             "text": "Visit \u2014 Choose an opponent. They choose a creature they control, then you choose a creature you control. You may exile the chosen creatures. If you do, return them to the battlefield under their owners' control at the beginning of the next end step. Otherwise, the chosen creatures fight each other.",
             "colours": [],
@@ -11957,7 +11957,7 @@
         },
         {
             "id": "6fe445b9-0278-5053-83e5-74789cd6e734",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45997b5-880e-4df0-8001-8118972c2fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a45997b5-880e-4df0-8001-8118972c2fcc.jpg?1",
             "name": "Tunnel of Love",
             "text": "Visit \u2014 Choose an opponent. They choose a creature they control, then you choose a creature you control. You may exile the chosen creatures. If you do, return them to the battlefield under their owners' control at the beginning of the next end step. Otherwise, the chosen creatures fight each other.",
             "colours": [],
@@ -11989,7 +11989,7 @@
         },
         {
             "id": "0d9b97a5-28b7-5d0e-9afa-2163ef59ef27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c453d1ea-9a42-4ccb-9391-eec122025647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c453d1ea-9a42-4ccb-9391-eec122025647.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12027,7 +12027,7 @@
         },
         {
             "id": "1a2d1b98-6ea4-5966-b739-6fbea2c1e7ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d018af9-dd14-46fa-8fd5-226defc9698f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d018af9-dd14-46fa-8fd5-226defc9698f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12065,7 +12065,7 @@
         },
         {
             "id": "6c684672-510b-5d83-87c1-8eca4d5d6095",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a6375e-9477-4871-8a15-02439f3f6f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46a6375e-9477-4871-8a15-02439f3f6f34.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12103,7 +12103,7 @@
         },
         {
             "id": "a41722c4-e480-5c1f-ad94-4702c21052a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6da8eb-31b0-48c1-9ad9-552827967f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d6da8eb-31b0-48c1-9ad9-552827967f91.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12141,7 +12141,7 @@
         },
         {
             "id": "1367a94a-915c-5977-a4ac-3a7da20f98e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dda1113-352c-471a-a7e0-a9a3cb3f19c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dda1113-352c-471a-a7e0-a9a3cb3f19c5.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12179,7 +12179,7 @@
         },
         {
             "id": "8084b2e3-90ed-5726-816b-9508411718cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82283c22-9b64-4f41-a5bb-aeb737eee5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82283c22-9b64-4f41-a5bb-aeb737eee5c9.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -12217,7 +12217,7 @@
         },
         {
             "id": "a0fe6618-f01f-5941-a29a-e53da509d614",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15303b22-ddf0-488d-b07e-a118f35ef00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15303b22-ddf0-488d-b07e-a118f35ef00f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -12255,7 +12255,7 @@
         },
         {
             "id": "8d25fc09-4ea7-5670-9ea0-46de68c6e4fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c850b9-d014-4cd1-8ffd-361ed4fe1e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c850b9-d014-4cd1-8ffd-361ed4fe1e6d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -12293,7 +12293,7 @@
         },
         {
             "id": "0db9b62c-e6ce-5cfe-8b8b-c01a45566afa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1170a5-e5bb-4b86-8718-f75eec679b4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e1170a5-e5bb-4b86-8718-f75eec679b4e.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -12331,7 +12331,7 @@
         },
         {
             "id": "ea8041e2-5bfb-5ea0-9bd9-c5383c7619a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1488e6b-f677-44c5-8ff3-6a2f9bdb28c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1488e6b-f677-44c5-8ff3-6a2f9bdb28c2.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12369,7 +12369,7 @@
         },
         {
             "id": "e42e9ada-2430-5d8b-a36b-12f674219958",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef89827b-39b0-4dbb-9516-ee2e47012938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef89827b-39b0-4dbb-9516-ee2e47012938.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12410,7 +12410,7 @@
         },
         {
             "id": "6a7a313a-570b-520a-8797-0b93c3d44c0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9cf49-3c2b-4f18-8bd3-2cf82095fc70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04f9cf49-3c2b-4f18-8bd3-2cf82095fc70.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -12451,7 +12451,7 @@
         },
         {
             "id": "fab3abcf-0aa2-5e83-92c3-8f4b36e127eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8beaf424-5974-4007-a396-08355f802283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8beaf424-5974-4007-a396-08355f802283.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12492,7 +12492,7 @@
         },
         {
             "id": "587973aa-8546-544a-9563-7b50029704e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20db599-f382-4a9b-ad55-4660b7219ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20db599-f382-4a9b-ad55-4660b7219ece.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12533,7 +12533,7 @@
         },
         {
             "id": "d28f6ced-770d-5114-bf3b-bbb4568fa9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee1213-f65b-4df9-a891-5a2863254c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cee1213-f65b-4df9-a891-5a2863254c60.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -12574,7 +12574,7 @@
         },
         {
             "id": "b27e6eec-3628-5353-9e75-853485c957b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4a844-0f75-4f5c-8c05-45614641184f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd4a844-0f75-4f5c-8c05-45614641184f.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12615,7 +12615,7 @@
         },
         {
             "id": "96aaebd2-451d-59c6-b4a0-334f89a511eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae98fcd-434c-4e58-b891-2a733adac7f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae98fcd-434c-4e58-b891-2a733adac7f6.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -12660,7 +12660,7 @@
         },
         {
             "id": "03c64bd2-e1f9-5451-bc06-aee5f1db8612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14234b9-a2c8-41b7-9ee0-9a13ae318bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d14234b9-a2c8-41b7-9ee0-9a13ae318bdb.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -12701,7 +12701,7 @@
         },
         {
             "id": "f162de1d-b0e1-5368-bb67-6ada96f67c0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f50fbc-96a0-44e7-b13d-69856d9dbb96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f50fbc-96a0-44e7-b13d-69856d9dbb96.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -12742,7 +12742,7 @@
         },
         {
             "id": "e24f64c4-24ab-52d2-b540-76b29c6d954a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b28211-bfc2-458a-a65e-1e70d85c206c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73b28211-bfc2-458a-a65e-1e70d85c206c.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -12786,7 +12786,7 @@
         },
         {
             "id": "dc4642b8-a8e8-58aa-9e98-fb5c8173d93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a9752-ae60-42e2-b5ed-74a30070d06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a9752-ae60-42e2-b5ed-74a30070d06e.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -12829,7 +12829,7 @@
         },
         {
             "id": "8466f5d3-b178-5ce7-98ec-4aad1ef1f689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d23de-0d40-4dad-be40-e7724e63168a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d23de-0d40-4dad-be40-e7724e63168a.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -12872,7 +12872,7 @@
         },
         {
             "id": "71e8d356-a9ac-5dd3-8053-fb67dfb1c5a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69145398-96b2-453c-9bb1-93cd33fb54c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69145398-96b2-453c-9bb1-93cd33fb54c7.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -12916,7 +12916,7 @@
         },
         {
             "id": "3daaaf34-a86c-515f-a987-f58f23e26c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c3064-0e03-44f9-93e7-9031de1c4116.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c0c3064-0e03-44f9-93e7-9031de1c4116.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -12959,7 +12959,7 @@
         },
         {
             "id": "4037d420-5653-523f-a6fb-94cb188cac02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171a969e-3d5e-4110-a770-4183c2a2710d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/171a969e-3d5e-4110-a770-4183c2a2710d.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -13002,7 +13002,7 @@
         },
         {
             "id": "5a7329b2-2c3c-5d4b-a952-2e4a4971cf2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2c9ae3-ba1b-4582-b6c3-1fa38791f3a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2c9ae3-ba1b-4582-b6c3-1fa38791f3a9.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -13045,7 +13045,7 @@
         },
         {
             "id": "e3245608-7f9f-5912-a0ab-dfb7af759206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18eb4f1-74fd-4df1-b087-83ebe86d2dc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18eb4f1-74fd-4df1-b087-83ebe86d2dc2.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -13088,7 +13088,7 @@
         },
         {
             "id": "539c7e15-0af6-5028-b96d-828487eeffb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a2d471-25e9-4fb0-88fd-bb0698724a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52a2d471-25e9-4fb0-88fd-bb0698724a42.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -13131,7 +13131,7 @@
         },
         {
             "id": "074edce7-8033-5c25-b4cb-774a3492721a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee0bbf-312a-493c-a8d0-13b8dae8ba71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6ee0bbf-312a-493c-a8d0-13b8dae8ba71.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -13174,7 +13174,7 @@
         },
         {
             "id": "7edd2b9e-9a8b-552f-b7bf-415469878166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14360131-4108-4968-874f-935f920e0837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14360131-4108-4968-874f-935f920e0837.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -13217,7 +13217,7 @@
         },
         {
             "id": "1fb81dd4-14b2-5616-82fa-59e7fb14cc77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad95fc-7f3e-49f9-82e2-3d3673ec27a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbad95fc-7f3e-49f9-82e2-3d3673ec27a3.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -13260,7 +13260,7 @@
         },
         {
             "id": "1c06c501-6c2d-5f07-bfba-5b8db5620111",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774c25d1-7e31-4e67-8601-a3b4c9320223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/774c25d1-7e31-4e67-8601-a3b4c9320223.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -13304,7 +13304,7 @@
         },
         {
             "id": "50bb65d4-f9f8-545d-a9f6-e0d6742ac709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2dd07-89db-40a4-b7b3-158c15a66861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef2dd07-89db-40a4-b7b3-158c15a66861.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -13347,7 +13347,7 @@
         },
         {
             "id": "977c0613-340b-5e96-ad96-d73d5a10c36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd71020-beb5-4682-91f3-cb71bbddc796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fd71020-beb5-4682-91f3-cb71bbddc796.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -13391,7 +13391,7 @@
         },
         {
             "id": "19666dfe-03fd-5438-b623-2ca1a41d0bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a29c058-aeff-4f77-954f-1e1a4ea92c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a29c058-aeff-4f77-954f-1e1a4ea92c83.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -13434,7 +13434,7 @@
         },
         {
             "id": "217c0d00-0fcf-52df-8aa3-e4b9f91bf9ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db161073-7fb1-465c-8878-e2584ac27458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db161073-7fb1-465c-8878-e2584ac27458.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -13477,7 +13477,7 @@
         },
         {
             "id": "a87d5fce-fb68-52b5-ab31-2ecbb9f81f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbcd448-23fc-4e8d-985d-df2801f5c78c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cbcd448-23fc-4e8d-985d-df2801f5c78c.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -13520,7 +13520,7 @@
         },
         {
             "id": "569ddd6d-a96d-5225-b1ed-4aa1550c799a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01af935e-f8ca-4315-9e2b-a6f06787ff25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01af935e-f8ca-4315-9e2b-a6f06787ff25.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -13564,7 +13564,7 @@
         },
         {
             "id": "2ab3682e-d325-56ee-b64f-7ea5c3b4b3a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7d2436-0ba3-4827-ae9a-aa75735ba3ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f7d2436-0ba3-4827-ae9a-aa75735ba3ff.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -13608,7 +13608,7 @@
         },
         {
             "id": "b2133b14-fb18-53d7-8a50-d4852e4b9119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36ba173-e4a1-42df-baa6-fc2e854fa3fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e36ba173-e4a1-42df-baa6-fc2e854fa3fe.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -13645,7 +13645,7 @@
         },
         {
             "id": "157260cb-ba4d-5c5f-940a-7c495e4ec834",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cac4ebc-fdc3-4dd4-b988-9a924ee3c781.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cac4ebc-fdc3-4dd4-b988-9a924ee3c781.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "",
             "colours": [
@@ -13687,7 +13687,7 @@
         },
         {
             "id": "e652bab7-775e-5ec0-9707-2641e9d4217d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec649bac-f332-4e66-91d2-1ff0e041f8b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec649bac-f332-4e66-91d2-1ff0e041f8b0.jpg?1",
             "name": "Space Beleren",
             "text": "",
             "colours": [
@@ -13729,7 +13729,7 @@
         },
         {
             "id": "cbfdc1b0-39c9-516f-8f03-70affcbe8506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029eaaa9-e45e-4c50-a03d-ad67e3dfcc3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/029eaaa9-e45e-4c50-a03d-ad67e3dfcc3e.jpg?1",
             "name": "Hallowed Fountain",
             "text": "({T}: Add {W} or {U}.)\nAs Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13765,7 +13765,7 @@
         },
         {
             "id": "4f83f35e-ff54-55d1-a006-6e004d98e3d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81706879-ec5d-4b17-b4bc-5f7cb37557a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81706879-ec5d-4b17-b4bc-5f7cb37557a5.jpg?1",
             "name": "Watery Grave",
             "text": "({T}: Add {U} or {B}.)\nAs Watery Grave enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13801,7 +13801,7 @@
         },
         {
             "id": "de0be7e3-b0c1-5d35-8784-957f80616ac9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1cebcb-0e3f-4dce-81ff-44bc8c0b9ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1cebcb-0e3f-4dce-81ff-44bc8c0b9ad7.jpg?1",
             "name": "Blood Crypt",
             "text": "({T}: Add {B} or {R}.)\nAs Blood Crypt enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13837,7 +13837,7 @@
         },
         {
             "id": "d79eaece-b4b3-5252-b236-fc5d833b10c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dd057e-1f38-4a5f-819c-f3af9134fecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1dd057e-1f38-4a5f-819c-f3af9134fecf.jpg?1",
             "name": "Stomping Ground",
             "text": "({T}: Add {R} or {G}.)\nAs Stomping Ground enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13873,7 +13873,7 @@
         },
         {
             "id": "22d7ef95-42b3-5cdf-8882-c070a4982dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43609973-6c01-4f03-9e08-a347364dfa76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43609973-6c01-4f03-9e08-a347364dfa76.jpg?1",
             "name": "Temple Garden",
             "text": "({T}: Add {G} or {W}.)\nAs Temple Garden enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13909,7 +13909,7 @@
         },
         {
             "id": "4e6acd3c-9f6e-566a-9261-e11cff0e2837",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e739c7e-cc16-4557-836f-fdec53a7ed8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e739c7e-cc16-4557-836f-fdec53a7ed8c.jpg?1",
             "name": "Godless Shrine",
             "text": "({T}: Add {W} or {B}.)\nAs Godless Shrine enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13945,7 +13945,7 @@
         },
         {
             "id": "73751bd4-20f9-595d-8078-2d1da506605b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af478684-ea34-4275-ab45-a9512aaa0758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af478684-ea34-4275-ab45-a9512aaa0758.jpg?1",
             "name": "Steam Vents",
             "text": "({T}: Add {U} or {R}.)\nAs Steam Vents enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -13981,7 +13981,7 @@
         },
         {
             "id": "f16c3aad-8391-5384-8b67-1f657753e122",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5de5eb-442d-48de-bb5a-e316ea44520d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba5de5eb-442d-48de-bb5a-e316ea44520d.jpg?1",
             "name": "Overgrown Tomb",
             "text": "({T}: Add {B} or {G}.)\nAs Overgrown Tomb enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -14017,7 +14017,7 @@
         },
         {
             "id": "a43a8e7e-2cb9-5ddb-b76f-0caad2177b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3142a41-8718-4955-9fec-18f3d4875493.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3142a41-8718-4955-9fec-18f3d4875493.jpg?1",
             "name": "Sacred Foundry",
             "text": "({T}: Add {R} or {W}.)\nAs Sacred Foundry enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -14053,7 +14053,7 @@
         },
         {
             "id": "186fb101-5401-5627-9404-12aae0432571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830eb270-f7aa-4694-8fe1-7c19e148a39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830eb270-f7aa-4694-8fe1-7c19e148a39f.jpg?1",
             "name": "Breeding Pool",
             "text": "({T}: Add {G} or {U}.)\nAs Breeding Pool enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",
             "colours": [],
@@ -14089,7 +14089,7 @@
         },
         {
             "id": "f88ba09a-35e0-5209-9cef-f511261c8303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18450a2a-c9b6-4746-a1a5-14e4db552037.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18450a2a-c9b6-4746-a1a5-14e4db552037.jpg?1",
             "name": "Standard Procedure",
             "text": "",
             "colours": [],
@@ -14118,7 +14118,7 @@
         },
         {
             "id": "cd074a47-cb37-52f1-8168-dfec328b7391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57516816-4adb-4567-a26d-e08d0513c6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57516816-4adb-4567-a26d-e08d0513c6f7.jpg?1",
             "name": "Aerialephant",
             "text": "",
             "colours": [
@@ -14154,7 +14154,7 @@
         },
         {
             "id": "0ace18be-2c82-5bd9-893b-2a5fbd1eac64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f5a08-f3a5-4632-a050-d9bdaae57dce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514f5a08-f3a5-4632-a050-d9bdaae57dce.jpg?1",
             "name": "Assembled Ensemble",
             "text": "",
             "colours": [
@@ -14192,7 +14192,7 @@
         },
         {
             "id": "02fe27e2-7238-5812-a24c-39c05756206d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0828457-8ac6-4fb6-afc9-d103bb5b8408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0828457-8ac6-4fb6-afc9-d103bb5b8408.jpg?1",
             "name": "Bar Entry",
             "text": "",
             "colours": [
@@ -14225,7 +14225,7 @@
         },
         {
             "id": "4712ca63-64d5-539b-9d8e-61a84e78f25b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10200c-b525-4751-9f4b-15e0055de9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe10200c-b525-4751-9f4b-15e0055de9e2.jpg?1",
             "name": "_____ Bird Gets the Worm",
             "text": "",
             "colours": [
@@ -14261,7 +14261,7 @@
         },
         {
             "id": "49d8a4c9-a608-5da6-acb9-5e1cba7e7c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcf4209-373b-4665-93c2-56496ece5b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcf4209-373b-4665-93c2-56496ece5b61.jpg?1",
             "name": "Clowning Around",
             "text": "",
             "colours": [
@@ -14294,7 +14294,7 @@
         },
         {
             "id": "b7288919-78d4-5f64-a867-2078e25cc32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74e4feb-f3d5-4122-866c-421f4f24b829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a74e4feb-f3d5-4122-866c-421f4f24b829.jpg?1",
             "name": "Complaints Clerk",
             "text": "",
             "colours": [
@@ -14330,7 +14330,7 @@
         },
         {
             "id": "3d4476e6-3718-5733-a0df-a6664e445d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412833b3-e1f7-4378-8e1b-5805cc6f7998.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/412833b3-e1f7-4378-8e1b-5805cc6f7998.jpg?1",
             "name": "Far Out",
             "text": "",
             "colours": [
@@ -14363,7 +14363,7 @@
         },
         {
             "id": "00a587d6-64e2-55c5-9a40-fb6401596632",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658bd8ee-831f-4b42-a866-2f21a3fb6c61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/658bd8ee-831f-4b42-a866-2f21a3fb6c61.jpg?1",
             "name": "Form of the Approach of the Second Sun",
             "text": "",
             "colours": [
@@ -14396,7 +14396,7 @@
         },
         {
             "id": "a610013a-b287-5b88-a502-bc3553d5143c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d2a66-a548-4739-aabe-6d68fee89b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e9d2a66-a548-4739-aabe-6d68fee89b6d.jpg?1",
             "name": "Get Your Head in the Game",
             "text": "",
             "colours": [
@@ -14429,7 +14429,7 @@
         },
         {
             "id": "c444abc3-9d52-5f07-9a69-d2f2084881ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a2c71-838c-457f-b928-e00dccca9527.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee8a2c71-838c-457f-b928-e00dccca9527.jpg?1",
             "name": "Gobsmacked",
             "text": "",
             "colours": [
@@ -14464,7 +14464,7 @@
         },
         {
             "id": "571af159-f894-523f-897c-647c1bda8aab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76647500-477c-4ecc-a4b3-e7fd17c7d1ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76647500-477c-4ecc-a4b3-e7fd17c7d1ee.jpg?1",
             "name": "A Good Day to Pie",
             "text": "",
             "colours": [
@@ -14497,7 +14497,7 @@
         },
         {
             "id": "720a103a-e3df-5b6e-8243-9868df71148f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0f9df8-2883-4673-bfad-b62f79b09198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b0f9df8-2883-4673-bfad-b62f79b09198.jpg?1",
             "name": "Hat Trick",
             "text": "",
             "colours": [
@@ -14530,7 +14530,7 @@
         },
         {
             "id": "7c176478-eeee-5400-93fa-8952d91861b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29852adf-bbec-40ae-8c47-38126a12a426.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29852adf-bbec-40ae-8c47-38126a12a426.jpg?1",
             "name": "Impounding Lot-Bot",
             "text": "",
             "colours": [
@@ -14566,7 +14566,7 @@
         },
         {
             "id": "83c96965-bb1f-5f87-af59-c5b3a453655e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363b47ed-7b70-40d2-bde7-bb6ac3f8d0f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/363b47ed-7b70-40d2-bde7-bb6ac3f8d0f6.jpg?1",
             "name": "Jetpack Janitor",
             "text": "",
             "colours": [
@@ -14602,7 +14602,7 @@
         },
         {
             "id": "d34af78d-71ff-553c-8492-2141de3fc6d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98665cc0-efb1-4079-95cc-8dca6148c320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98665cc0-efb1-4079-95cc-8dca6148c320.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -14642,7 +14642,7 @@
         },
         {
             "id": "e3930ac3-0af8-5177-8c89-35be18c3ddb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87264d92-761f-435b-a907-3ef6c0c9a91a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87264d92-761f-435b-a907-3ef6c0c9a91a.jpg?1",
             "name": "Knight in _____ Armor",
             "text": "",
             "colours": [
@@ -14679,7 +14679,7 @@
         },
         {
             "id": "3048b477-c877-5b7a-bd49-29da31565700",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb77639-c7cd-428d-8a98-09b70bf1330b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb77639-c7cd-428d-8a98-09b70bf1330b.jpg?1",
             "name": "Leading Performance",
             "text": "",
             "colours": [
@@ -14712,7 +14712,7 @@
         },
         {
             "id": "0131e5c9-7ff1-5df7-8473-fb08bfb4cf6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cbbeba-d236-4635-8f07-df2500c0ef68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69cbbeba-d236-4635-8f07-df2500c0ef68.jpg?1",
             "name": "Main Event Horizon",
             "text": "",
             "colours": [
@@ -14745,7 +14745,7 @@
         },
         {
             "id": "6a57098f-3676-5cf2-80e0-bf5e0cf7b276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57be0f52-1a11-479e-8242-29539fce76e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57be0f52-1a11-479e-8242-29539fce76e6.jpg?1",
             "name": "Now You See Me . . .",
             "text": "",
             "colours": [
@@ -14778,7 +14778,7 @@
         },
         {
             "id": "097f2b69-0e57-5031-b1b9-c69375bd45a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c155fd-bab7-4f86-b10c-6c9f1f43b330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c155fd-bab7-4f86-b10c-6c9f1f43b330.jpg?1",
             "name": "Park Bleater",
             "text": "",
             "colours": [
@@ -14814,7 +14814,7 @@
         },
         {
             "id": "d8df4ce4-5f8a-532d-8f4f-80288178b4aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765a4d36-200b-4401-811f-03244656ff6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/765a4d36-200b-4401-811f-03244656ff6f.jpg?1",
             "name": "Park Re-Entry",
             "text": "",
             "colours": [
@@ -14847,7 +14847,7 @@
         },
         {
             "id": "9ec25025-af44-596a-85c8-b36f37ed9ced",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ce7df4-3aec-4f2b-a0f4-fd100a9d7660.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2ce7df4-3aec-4f2b-a0f4-fd100a9d7660.jpg?1",
             "name": "Pin Collection",
             "text": "",
             "colours": [
@@ -14882,7 +14882,7 @@
         },
         {
             "id": "e1f5dd14-89da-562c-af9a-3ccc3b0c8d6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe85619-4936-4782-b3d6-8fa77514bb43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe85619-4936-4782-b3d6-8fa77514bb43.jpg?1",
             "name": "Ride Guide",
             "text": "",
             "colours": [
@@ -14918,7 +14918,7 @@
         },
         {
             "id": "80ca86c8-8661-55bb-a400-bd1a39cb2323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeafb4a7-2766-4452-8442-1386d4c4dd44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeafb4a7-2766-4452-8442-1386d4c4dd44.jpg?1",
             "name": "Robo-Pi\u00f1ata",
             "text": "",
             "colours": [
@@ -14955,7 +14955,7 @@
         },
         {
             "id": "4f4f6d13-c429-57f4-a4bc-8749a8437713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648ddac-8c5f-425f-a8c9-8c37a5a7a02a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1648ddac-8c5f-425f-a8c9-8c37a5a7a02a.jpg?1",
             "name": "Sanguine Sipper",
             "text": "",
             "colours": [
@@ -14991,7 +14991,7 @@
         },
         {
             "id": "22418cae-fffa-53b5-8f66-d998c349da61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec35de35-bbb3-479f-8e0e-4d937b86d8fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec35de35-bbb3-479f-8e0e-4d937b86d8fe.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -15031,7 +15031,7 @@
         },
         {
             "id": "59c4d0a7-70a5-5ffd-b964-27e80328602a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c7d4d8-bfc3-41a1-ad27-5c8d0c69f551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6c7d4d8-bfc3-41a1-ad27-5c8d0c69f551.jpg?1",
             "name": "Starlight Spectacular",
             "text": "",
             "colours": [
@@ -15064,7 +15064,7 @@
         },
         {
             "id": "de870f0f-9497-5ab7-88b5-2588dca7dab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f1c0d9-f302-487e-857b-555a326924c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86f1c0d9-f302-487e-857b-555a326924c6.jpg?1",
             "name": "Surprise Party",
             "text": "",
             "colours": [
@@ -15097,7 +15097,7 @@
         },
         {
             "id": "6e9e2b0e-755f-5b51-8204-b42df94eb44d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef91852-4dea-4d2a-b1a1-8d0c8366830c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef91852-4dea-4d2a-b1a1-8d0c8366830c.jpg?1",
             "name": "Sword-Swallowing Seraph",
             "text": "",
             "colours": [
@@ -15133,7 +15133,7 @@
         },
         {
             "id": "c1d20817-ee3d-5f7d-a3a6-9f510cfb6893",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266bec4a-c2a3-4793-a409-fbcf432c7ffb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/266bec4a-c2a3-4793-a409-fbcf432c7ffb.jpg?1",
             "name": "T.A.P.P.E.R.",
             "text": "",
             "colours": [
@@ -15170,7 +15170,7 @@
         },
         {
             "id": "202fa79b-e8ec-5c9c-943f-1a9a92c2d817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df25d01-5d82-453a-b50f-337c38d8806d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6df25d01-5d82-453a-b50f-337c38d8806d.jpg?1",
             "name": "Trapeze Artist",
             "text": "",
             "colours": [
@@ -15206,7 +15206,7 @@
         },
         {
             "id": "6a6935e0-91f7-5390-a072-6a36015f5db0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87342791-ae77-40e3-9b38-dce94dbeffe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87342791-ae77-40e3-9b38-dce94dbeffe9.jpg?1",
             "name": "Animate Object",
             "text": "",
             "colours": [
@@ -15239,7 +15239,7 @@
         },
         {
             "id": "fb6e23f4-c208-5b3e-9526-4d4028ed767e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c5e1f-6615-48da-beaa-abaf1d11a72c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8c5e1f-6615-48da-beaa-abaf1d11a72c.jpg?1",
             "name": "Astroquarium",
             "text": "",
             "colours": [
@@ -15272,7 +15272,7 @@
         },
         {
             "id": "27ba853f-d47f-5123-ae1b-58a191f0ad8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc1c903-9194-4155-a469-2a6fbe7508a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc1c903-9194-4155-a469-2a6fbe7508a1.jpg?1",
             "name": "Baaallerina",
             "text": "",
             "colours": [
@@ -15308,7 +15308,7 @@
         },
         {
             "id": "dc5fa71e-e1c5-59d6-985f-1f43677bf5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f0d12-8f97-42f0-b305-37563310b09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31f0d12-8f97-42f0-b305-37563310b09e.jpg?1",
             "name": "Bag Check",
             "text": "",
             "colours": [
@@ -15341,7 +15341,7 @@
         },
         {
             "id": "b6c8e7a4-c93f-5a0f-9af0-95d4e0e3be5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9bca30a-51bd-4ba5-8a5d-cd6413da6ba1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9bca30a-51bd-4ba5-8a5d-cd6413da6ba1.jpg?1",
             "name": "Bamboozling Beeble",
             "text": "",
             "colours": [
@@ -15376,7 +15376,7 @@
         },
         {
             "id": "92844214-7f34-5db9-b4b2-946f3a3078fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a1b1ac-55fd-489d-b110-4a394ed46d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a1b1ac-55fd-489d-b110-4a394ed46d16.jpg?1",
             "name": "Bioluminary",
             "text": "",
             "colours": [
@@ -15412,7 +15412,7 @@
         },
         {
             "id": "b212c5b5-4428-57fc-825b-f771838c8a8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71876c-7cf9-4bbe-843f-bd1c488d7060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c71876c-7cf9-4bbe-843f-bd1c488d7060.jpg?1",
             "name": "Blufferfish",
             "text": "",
             "colours": [
@@ -15447,7 +15447,7 @@
         },
         {
             "id": "9220a851-c043-5447-a52c-b17e699bd512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324cb7ad-a4be-413f-a69e-90363c52feac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/324cb7ad-a4be-413f-a69e-90363c52feac.jpg?1",
             "name": "Boing!",
             "text": "",
             "colours": [
@@ -15480,7 +15480,7 @@
         },
         {
             "id": "b0c0ea34-bfa9-5fd9-93da-862aa11a81a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d55929c-d08e-42d3-89b2-07bca9d0f05c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d55929c-d08e-42d3-89b2-07bca9d0f05c.jpg?1",
             "name": "Busted!",
             "text": "",
             "colours": [
@@ -15513,7 +15513,7 @@
         },
         {
             "id": "0b8d1f56-de4d-5084-bd00-0e45f5eda9b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811e7fca-c9e8-4ee7-bffa-6e0b84b167b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811e7fca-c9e8-4ee7-bffa-6e0b84b167b7.jpg?1",
             "name": "Command Performance",
             "text": "",
             "colours": [
@@ -15546,7 +15546,7 @@
         },
         {
             "id": "d6b6f5ef-25c0-579a-9f28-34fba7115476",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e01dec-1ab1-404f-9758-e82a313a3d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68e01dec-1ab1-404f-9758-e82a313a3d50.jpg?1",
             "name": "Croakid Amphibonaut",
             "text": "",
             "colours": [
@@ -15582,7 +15582,7 @@
         },
         {
             "id": "33c77d8b-b2dc-5787-9eb8-98a13753b4fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f27012d-f284-4b66-90e3-0ef2c256186c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f27012d-f284-4b66-90e3-0ef2c256186c.jpg?1",
             "name": "Decisions, Decisions",
             "text": "",
             "colours": [
@@ -15615,7 +15615,7 @@
         },
         {
             "id": "dcb13be8-f6ef-5ca0-9af0-2eeb8cc16166",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698fbc7-63de-449c-a668-8828e47aff8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8698fbc7-63de-449c-a668-8828e47aff8a.jpg?1",
             "name": "Exchange of Words",
             "text": "",
             "colours": [
@@ -15648,7 +15648,7 @@
         },
         {
             "id": "6aa3b847-02ff-5bab-9356-3368e4cb8c7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e868b8-9c6b-402f-aec9-ce18eb877705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91e868b8-9c6b-402f-aec9-ce18eb877705.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -15688,7 +15688,7 @@
         },
         {
             "id": "6507a50f-dc7f-5566-ad6b-a02c735b3f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c74b3-43b0-4a97-8470-6ee5749ec892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a87c74b3-43b0-4a97-8470-6ee5749ec892.jpg?1",
             "name": "Focused Funambulist",
             "text": "",
             "colours": [
@@ -15724,7 +15724,7 @@
         },
         {
             "id": "69aad17d-d7e2-5e6b-89e1-5891e26e358f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89074aca-a093-46f2-9d63-0f992c198e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89074aca-a093-46f2-9d63-0f992c198e85.jpg?1",
             "name": "Glitterflitter",
             "text": "",
             "colours": [
@@ -15760,7 +15760,7 @@
         },
         {
             "id": "4dc174c4-a302-51ef-8c13-819acf02a1ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32311d5a-6604-469b-b616-bd96d1ddc31b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32311d5a-6604-469b-b616-bd96d1ddc31b.jpg?1",
             "name": "How Is This a Par Three?!",
             "text": "",
             "colours": [
@@ -15793,7 +15793,7 @@
         },
         {
             "id": "97614c00-9f7d-5e48-9160-3c004b2a055f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff28845-1da7-4116-a7e9-d0392ce992b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff28845-1da7-4116-a7e9-d0392ce992b5.jpg?1",
             "name": "Make a _____ Splash",
             "text": "",
             "colours": [
@@ -15826,7 +15826,7 @@
         },
         {
             "id": "831e0fc1-b268-5471-a27c-d77dcc887af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7956f-938e-4478-9638-1167221d3bd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c7956f-938e-4478-9638-1167221d3bd2.jpg?1",
             "name": "Mobile Clone",
             "text": "",
             "colours": [
@@ -15859,7 +15859,7 @@
         },
         {
             "id": "8f46808a-e4c5-599a-b21a-5ad20308684d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13156d62-e0b4-4449-8691-9110b1938cb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13156d62-e0b4-4449-8691-9110b1938cb2.jpg?1",
             "name": "Monitor Monitor",
             "text": "",
             "colours": [
@@ -15895,7 +15895,7 @@
         },
         {
             "id": "15e44a4d-056d-5945-b937-5f89dd896f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173423de-2fea-454f-b9a4-2da16f5966f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/173423de-2fea-454f-b9a4-2da16f5966f5.jpg?1",
             "name": "Motion Sickness",
             "text": "",
             "colours": [
@@ -15930,7 +15930,7 @@
         },
         {
             "id": "e23a4c70-6f03-5f5c-b4ad-8be8d2d0e3c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffb2105-d640-42c8-b723-9aaf42748585.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ffb2105-d640-42c8-b723-9aaf42748585.jpg?1",
             "name": "Octo Opus",
             "text": "",
             "colours": [
@@ -15963,7 +15963,7 @@
         },
         {
             "id": "2cc225a4-af84-5dda-890f-0b46e2ee8c44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28e7d40-58f3-4b16-9edb-230c01bcc562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28e7d40-58f3-4b16-9edb-230c01bcc562.jpg?1",
             "name": "Phone a Friend",
             "text": "",
             "colours": [
@@ -15996,7 +15996,7 @@
         },
         {
             "id": "b8905b28-6c4f-53ac-9162-e3589afcb8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaf7c50-fce6-48ba-9d44-cda9b6054f4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccaf7c50-fce6-48ba-9d44-cda9b6054f4b.jpg?1",
             "name": "Plate Spinning",
             "text": "",
             "colours": [
@@ -16029,7 +16029,7 @@
         },
         {
             "id": "16cf5f0b-1a4b-5fee-ac42-ecf6b52d0cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb5662-e7ab-4670-898d-93f1f11aacd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fb5662-e7ab-4670-898d-93f1f11aacd2.jpg?1",
             "name": "Prize Wall",
             "text": "",
             "colours": [
@@ -16064,7 +16064,7 @@
         },
         {
             "id": "254fb38a-0307-5129-8c3a-781df4edd653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3268a25-4e65-4064-983f-99671b052211.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3268a25-4e65-4064-983f-99671b052211.jpg?1",
             "name": "Seasoned Buttoneer",
             "text": "",
             "colours": [
@@ -16100,7 +16100,7 @@
         },
         {
             "id": "d9392826-9a2d-5a49-8eb9-b90207fb55e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0487a865-87a9-4226-a1d3-4d120b30dbc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0487a865-87a9-4226-a1d3-4d120b30dbc2.jpg?1",
             "name": "Super-Duper Lost",
             "text": "",
             "colours": [
@@ -16133,7 +16133,7 @@
         },
         {
             "id": "e0616b92-cb29-5fb2-b368-7919f232998e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd8fb4b-691b-4e26-80c6-e7178d3b26f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dd8fb4b-691b-4e26-80c6-e7178d3b26f2.jpg?1",
             "name": "Treacherous Trapezist",
             "text": "",
             "colours": [
@@ -16169,7 +16169,7 @@
         },
         {
             "id": "9bd24db7-89e6-563e-b230-341a4f3777e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e39c752-7f04-4a6a-8917-1177ae807273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e39c752-7f04-4a6a-8917-1177ae807273.jpg?1",
             "name": "_____ _____ _____ Trespasser",
             "text": "",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "00262af8-7af0-5099-bcb2-6c81c2ffbcd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fbc62e-2dd1-4b87-af05-d994c605db8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29fbc62e-2dd1-4b87-af05-d994c605db8d.jpg?1",
             "name": "Unlawful Entry",
             "text": "",
             "colours": [
@@ -16239,7 +16239,7 @@
         },
         {
             "id": "912f6082-d276-5821-9abd-21238a3be6ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c1355f-da17-4035-96b8-28f7fd22e9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c1355f-da17-4035-96b8-28f7fd22e9ee.jpg?1",
             "name": "Vedalken Squirrel-Whacker",
             "text": "",
             "colours": [
@@ -16275,7 +16275,7 @@
         },
         {
             "id": "c9f5f07b-3646-5f2e-ae29-5f8798a4e239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4544507e-fd90-43de-ade3-baa8a40f732b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4544507e-fd90-43de-ade3-baa8a40f732b.jpg?1",
             "name": "Wizards of the _____",
             "text": "",
             "colours": [
@@ -16312,7 +16312,7 @@
         },
         {
             "id": "541439b6-7387-557c-b73b-ab6517bcf28e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4711607a-ad57-4f11-87b6-6d69ca1d010e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4711607a-ad57-4f11-87b6-6d69ca1d010e.jpg?1",
             "name": "Animate Graveyard",
             "text": "",
             "colours": [
@@ -16347,7 +16347,7 @@
         },
         {
             "id": "228eb0ff-0b52-51b1-9429-7619e1efb1ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c97d3c-420b-4050-b1e2-19eff7afa790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c97d3c-420b-4050-b1e2-19eff7afa790.jpg?1",
             "name": "Attempted Murder",
             "text": "",
             "colours": [
@@ -16380,7 +16380,7 @@
         },
         {
             "id": "bc6cc1a9-60c4-54ad-9fd7-5f6ef5f727d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cdfebc-fb99-497e-9202-feca5125744b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2cdfebc-fb99-497e-9202-feca5125744b.jpg?1",
             "name": "Black Hole",
             "text": "",
             "colours": [
@@ -16413,7 +16413,7 @@
         },
         {
             "id": "d3b49366-5b0f-524a-9503-0b0f4e9fde33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c973bce5-77d7-43f7-a559-25acb80d876a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c973bce5-77d7-43f7-a559-25acb80d876a.jpg?1",
             "name": "Carnival Carnivore",
             "text": "",
             "colours": [
@@ -16450,7 +16450,7 @@
         },
         {
             "id": "03b12284-5db4-5fc2-9050-7f3a4bc4ff35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a6b0c3-a8e2-4de6-a676-d7357ee929fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2a6b0c3-a8e2-4de6-a676-d7357ee929fe.jpg?1",
             "name": "Deadbeat Attendant",
             "text": "",
             "colours": [
@@ -16486,7 +16486,7 @@
         },
         {
             "id": "9551f35e-c5af-5bbc-b13a-3f959911771d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdfeed7-90f7-4520-8c82-cbd468aed0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbdfeed7-90f7-4520-8c82-cbd468aed0ae.jpg?1",
             "name": "Discourtesy Clerk",
             "text": "",
             "colours": [
@@ -16522,7 +16522,7 @@
         },
         {
             "id": "4d6deac2-e863-51c5-97f6-408301dd4982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151f67eb-a55d-4149-8f93-39ab7379b887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151f67eb-a55d-4149-8f93-39ab7379b887.jpg?1",
             "name": "Disemvowel",
             "text": "",
             "colours": [
@@ -16555,7 +16555,7 @@
         },
         {
             "id": "a861ef6e-1747-50fc-be1e-5bb3e156198c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01ae3f1-6809-4282-9e23-12e60f100297.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b01ae3f1-6809-4282-9e23-12e60f100297.jpg?1",
             "name": "Dissatisfied Customer",
             "text": "",
             "colours": [
@@ -16591,7 +16591,7 @@
         },
         {
             "id": "19510adf-ab2a-570e-9751-dc7c39c90038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5bd289-6069-4d99-83cd-d1dda24bc224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c5bd289-6069-4d99-83cd-d1dda24bc224.jpg?1",
             "name": "Down for Repairs",
             "text": "",
             "colours": [
@@ -16624,7 +16624,7 @@
         },
         {
             "id": "9fa1e647-6a01-5f22-9895-55614b0eea0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b352f4df-b2a0-4fe9-8c96-c53208f08379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b352f4df-b2a0-4fe9-8c96-c53208f08379.jpg?1",
             "name": "Exit Through the Grift Shop",
             "text": "",
             "colours": [
@@ -16657,7 +16657,7 @@
         },
         {
             "id": "82b4a062-e2a3-5919-af74-f48afd2fdadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318a63-ee98-4668-b4a7-ff09a65b2d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88318a63-ee98-4668-b4a7-ff09a65b2d50.jpg?1",
             "name": "Gray Merchant of Alphabet",
             "text": "",
             "colours": [
@@ -16693,7 +16693,7 @@
         },
         {
             "id": "b3fa5d11-8772-5b5c-be28-42ee6f6de483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab83f9-e415-4e72-aa81-cc401f0e7933.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ab83f9-e415-4e72-aa81-cc401f0e7933.jpg?1",
             "name": "Haberthrasher",
             "text": "",
             "colours": [
@@ -16730,7 +16730,7 @@
         },
         {
             "id": "6639a8de-9e62-5575-9b96-b43278181ee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae675f5d-b6b2-49da-9eae-b686bedcf340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae675f5d-b6b2-49da-9eae-b686bedcf340.jpg?1",
             "name": "Knife and Death",
             "text": "",
             "colours": [
@@ -16763,7 +16763,7 @@
         },
         {
             "id": "9efd3e36-d28a-5024-935c-26a480de9b57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e394ce-1857-45ac-9950-1cc912692315.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79e394ce-1857-45ac-9950-1cc912692315.jpg?1",
             "name": "Last Voyage of the _____",
             "text": "",
             "colours": [
@@ -16796,7 +16796,7 @@
         },
         {
             "id": "ff00f069-23e7-5fad-b76c-8225e6d00c87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42293306-aaea-4542-8df4-8138234bf556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42293306-aaea-4542-8df4-8138234bf556.jpg?1",
             "name": "\"Lifetime\" Pass Holder",
             "text": "",
             "colours": [
@@ -16832,7 +16832,7 @@
         },
         {
             "id": "3565cd31-fd7c-5fbe-be84-3b109af61bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bf283-3e03-4b85-9250-441c98b78c7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701bf283-3e03-4b85-9250-441c98b78c7e.jpg?1",
             "name": "Line Cutter",
             "text": "",
             "colours": [
@@ -16869,7 +16869,7 @@
         },
         {
             "id": "3fa18453-ad97-5c27-bdfe-a863b3b733af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9b37f-20e5-4bda-a23b-950a313486e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10b9b37f-20e5-4bda-a23b-950a313486e8.jpg?1",
             "name": "Night Shift of the Living Dead",
             "text": "",
             "colours": [
@@ -16902,7 +16902,7 @@
         },
         {
             "id": "5ece4f7f-f77b-58c4-b385-b74bce7f11e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b1f051-4fe6-4dab-a5b4-758a51f83d72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b1f051-4fe6-4dab-a5b4-758a51f83d72.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -16942,7 +16942,7 @@
         },
         {
             "id": "b96ff6a5-35cf-540e-9d50-a4459e40b055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb2a46-8b4e-4793-9414-228d6baa7040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51bb2a46-8b4e-4793-9414-228d6baa7040.jpg?1",
             "name": "Photo Op",
             "text": "",
             "colours": [
@@ -16975,7 +16975,7 @@
         },
         {
             "id": "ba265357-7c86-5543-92fb-4e56ae6c28db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103fa2de-6c5d-419b-8261-ad027cd229b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/103fa2de-6c5d-419b-8261-ad027cd229b9.jpg?1",
             "name": "Questionable Cuisine",
             "text": "",
             "colours": [
@@ -17008,7 +17008,7 @@
         },
         {
             "id": "3e4a937b-0802-5f4d-afc3-af5b575c415a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16477afb-7e82-4c84-95a7-e3619e9f7492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16477afb-7e82-4c84-95a7-e3619e9f7492.jpg?1",
             "name": "Quick Fixer",
             "text": "",
             "colours": [
@@ -17044,7 +17044,7 @@
         },
         {
             "id": "be53ef19-36c2-531c-9360-ac5a1a316fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae99e189-4912-4a71-922e-bfced7689abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae99e189-4912-4a71-922e-bfced7689abd.jpg?1",
             "name": "Rat in the Hat",
             "text": "",
             "colours": [
@@ -17080,7 +17080,7 @@
         },
         {
             "id": "39970b89-3132-509a-9fd8-5cddc22f98ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc45d25-b74e-4a59-a00d-0db53651386c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bc45d25-b74e-4a59-a00d-0db53651386c.jpg?1",
             "name": "A Real Handful",
             "text": "",
             "colours": [
@@ -17117,7 +17117,7 @@
         },
         {
             "id": "14465672-2d11-5ebc-9edd-63e85404175f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d727549-842c-4105-b6e0-b25c945359df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d727549-842c-4105-b6e0-b25c945359df.jpg?1",
             "name": "Saw in Half",
             "text": "",
             "colours": [
@@ -17150,7 +17150,7 @@
         },
         {
             "id": "9d86dd97-c48d-5a3c-94d2-b09b41942d5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689edb7-bc20-46bc-82e5-119f7ca04356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3689edb7-bc20-46bc-82e5-119f7ca04356.jpg?1",
             "name": "Scampire",
             "text": "",
             "colours": [
@@ -17186,7 +17186,7 @@
         },
         {
             "id": "85899917-1c50-5d1c-ad1f-8740d8103989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b2f6d6-01ad-431f-835e-62fe0670fe8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13b2f6d6-01ad-431f-835e-62fe0670fe8f.jpg?1",
             "name": "Scared Stiff",
             "text": "",
             "colours": [
@@ -17223,7 +17223,7 @@
         },
         {
             "id": "12f4f5e2-88b1-5bda-9f5b-3dbb52cc4692",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af7d064-f448-412c-a105-b3accaec8628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af7d064-f448-412c-a105-b3accaec8628.jpg?1",
             "name": "Scooch",
             "text": "",
             "colours": [
@@ -17256,7 +17256,7 @@
         },
         {
             "id": "0727e514-b98b-5b2d-9445-ce815db59157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb77893-d196-458e-b37f-b2d79975a7f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb77893-d196-458e-b37f-b2d79975a7f1.jpg?1",
             "name": "Six-Sided Die",
             "text": "",
             "colours": [
@@ -17289,7 +17289,7 @@
         },
         {
             "id": "029a3a20-831d-521c-a793-df2d6d280e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe6c89-1036-4daf-8c77-25a31e1d0aba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8fe6c89-1036-4daf-8c77-25a31e1d0aba.jpg?1",
             "name": "Soul Swindler",
             "text": "",
             "colours": [
@@ -17325,7 +17325,7 @@
         },
         {
             "id": "c4ace71c-57bd-570c-a69f-66abda358af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb4e22f-2ae8-47cf-a160-431a42c2cf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdb4e22f-2ae8-47cf-a160-431a42c2cf1b.jpg?1",
             "name": "Step Right Up",
             "text": "",
             "colours": [
@@ -17358,7 +17358,7 @@
         },
         {
             "id": "a1df1f04-f146-598e-ba1b-924299e12883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98be4570-f223-4413-8d5e-dff0e667cdd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98be4570-f223-4413-8d5e-dff0e667cdd6.jpg?1",
             "name": "Wolf in _____ Clothing",
             "text": "",
             "colours": [
@@ -17394,7 +17394,7 @@
         },
         {
             "id": "6e7df926-10a2-55e9-b2fc-08df85f0de81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd13e204-3e5b-4491-b9b0-49d2ab728473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd13e204-3e5b-4491-b9b0-49d2ab728473.jpg?1",
             "name": "Xenosquirrels",
             "text": "",
             "colours": [
@@ -17430,7 +17430,7 @@
         },
         {
             "id": "c7d55066-27ac-5ff0-bf00-23fb7022f5fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d8efe5-3356-4dbe-a05f-c87c9b4264a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1d8efe5-3356-4dbe-a05f-c87c9b4264a8.jpg?1",
             "name": "Aardwolf's Advantage",
             "text": "",
             "colours": [
@@ -17463,7 +17463,7 @@
         },
         {
             "id": "715d3a8f-5f72-5af9-9ad6-29df925ce3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4a5918-2d31-4e07-a7ae-3322a3cebce0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed4a5918-2d31-4e07-a7ae-3322a3cebce0.jpg?1",
             "name": "Amped Up",
             "text": "",
             "colours": [
@@ -17496,7 +17496,7 @@
         },
         {
             "id": "7f568b52-ef2e-55a3-85d8-02068a76da81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998684bf-4a99-4d46-a6af-76ce7189bd22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/998684bf-4a99-4d46-a6af-76ce7189bd22.jpg?1",
             "name": "Art Appreciation",
             "text": "",
             "colours": [
@@ -17529,7 +17529,7 @@
         },
         {
             "id": "10cb1b14-24cb-5a61-b58c-4754c9460069",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41134e27-8d2c-4db2-8c0d-d2f3484ec3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41134e27-8d2c-4db2-8c0d-d2f3484ec3f1.jpg?1",
             "name": "_____ Balls of Fire",
             "text": "",
             "colours": [
@@ -17562,7 +17562,7 @@
         },
         {
             "id": "cf52a1b5-7515-5e58-9e19-25d2189d9cc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ad6c1-355a-4a99-8a7d-c754cea81fb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660ad6c1-355a-4a99-8a7d-c754cea81fb4.jpg?1",
             "name": "Big Winner",
             "text": "",
             "colours": [
@@ -17599,7 +17599,7 @@
         },
         {
             "id": "9b4efed2-9d20-5731-bc92-5f72e1acc324",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c16c3d1-cc8c-45b5-88df-03166eb4e373.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c16c3d1-cc8c-45b5-88df-03166eb4e373.jpg?1",
             "name": "Carnival Barker",
             "text": "",
             "colours": [
@@ -17635,7 +17635,7 @@
         },
         {
             "id": "59991f44-c682-5b25-bd32-933a306e7a8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96b2ddc-9da9-4375-b044-f2c9a53c2e1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b96b2ddc-9da9-4375-b044-f2c9a53c2e1e.jpg?1",
             "name": "Circuits Act",
             "text": "",
             "colours": [
@@ -17668,7 +17668,7 @@
         },
         {
             "id": "3574c497-dc4d-5fd8-9aab-cfa75b1efb94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0d1c7-4036-425e-8445-c3448c40ded2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24f0d1c7-4036-425e-8445-c3448c40ded2.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -17708,7 +17708,7 @@
         },
         {
             "id": "2eaee88a-aaee-5770-9662-dca33d604f59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cdf65e-bdb9-41f4-9834-8fc335efa7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46cdf65e-bdb9-41f4-9834-8fc335efa7a7.jpg?1",
             "name": "Don't Try This at Home",
             "text": "",
             "colours": [
@@ -17741,7 +17741,7 @@
         },
         {
             "id": "cb399ebd-c1df-586b-8ec1-5311a7af526a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd8fc49-1218-408d-af29-8f4fd77cf8a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd8fc49-1218-408d-af29-8f4fd77cf8a9.jpg?1",
             "name": "Eelectrocute",
             "text": "",
             "colours": [
@@ -17774,7 +17774,7 @@
         },
         {
             "id": "b349cc63-1757-59eb-a1b8-e0e2cfdf4900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f80bd8-7ce2-449d-b06c-d3e353b54daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40f80bd8-7ce2-449d-b06c-d3e353b54daa.jpg?1",
             "name": "_____ Goblin",
             "text": "",
             "colours": [
@@ -17810,7 +17810,7 @@
         },
         {
             "id": "d53f434e-eadd-54c2-b43f-b1e02bc780ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4702fcd-49ac-49f1-b0b9-db38efa6ce8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4702fcd-49ac-49f1-b0b9-db38efa6ce8b.jpg?1",
             "name": "Goblin Airbrusher",
             "text": "",
             "colours": [
@@ -17846,7 +17846,7 @@
         },
         {
             "id": "0c1ba9f3-a6f6-5d6c-bab5-a1894fdcd70f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fee86e-3916-436a-8e18-85cdd5215f7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10fee86e-3916-436a-8e18-85cdd5215f7e.jpg?1",
             "name": "Goblin Blastronauts",
             "text": "",
             "colours": [
@@ -17882,7 +17882,7 @@
         },
         {
             "id": "0ca70b42-e9a1-51ae-905a-e4bb71d96c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e808958-2a5d-4d1f-90a1-d32e5f477c5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e808958-2a5d-4d1f-90a1-d32e5f477c5e.jpg?1",
             "name": "Goblin Cruciverbalist",
             "text": "",
             "colours": [
@@ -17919,7 +17919,7 @@
         },
         {
             "id": "353598c3-b41f-54db-8ccf-0d3def527283",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a43acea-4768-4411-9653-a711770011d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a43acea-4768-4411-9653-a711770011d2.jpg?1",
             "name": "Goblin Girder Gang",
             "text": "",
             "colours": [
@@ -17955,7 +17955,7 @@
         },
         {
             "id": "e5f34607-41de-5e76-bd43-bcaef4a9915f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdaf330-5600-4baa-a56c-7f912218c4db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cdaf330-5600-4baa-a56c-7f912218c4db.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -17995,7 +17995,7 @@
         },
         {
             "id": "6c3f02d7-edbe-52dd-87f8-a0f172437dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7b0fa-163d-4e38-9f0b-a5ca00b3329c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bca7b0fa-163d-4e38-9f0b-a5ca00b3329c.jpg?1",
             "name": "Juggletron",
             "text": "",
             "colours": [
@@ -18032,7 +18032,7 @@
         },
         {
             "id": "6dc7e35e-6f49-5901-b5ab-ff3dfd00fe08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaa8a1a-512b-413d-a83f-668c3e07c127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaa8a1a-512b-413d-a83f-668c3e07c127.jpg?1",
             "name": "Minotaur de Force",
             "text": "",
             "colours": [
@@ -18068,7 +18068,7 @@
         },
         {
             "id": "1cdbe66a-4458-5cd1-8e7c-c00f352f1de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bb149-2e50-462e-8b83-5c8339bb3aff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34bb149-2e50-462e-8b83-5c8339bb3aff.jpg?1",
             "name": "Non-Human Cannonball",
             "text": "",
             "colours": [
@@ -18105,7 +18105,7 @@
         },
         {
             "id": "85a8e127-fae1-547c-82fb-0185a64aad2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -18142,7 +18142,7 @@
         },
         {
             "id": "b70593a5-4091-5d28-87f6-293a019efbe9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61129353-5944-406f-a8e5-8c952fa3d89f.jpg?1",
             "name": "Omniclown Colossus // Pie-roclasm",
             "text": "",
             "colours": [
@@ -18177,7 +18177,7 @@
         },
         {
             "id": "2517ac9e-13e1-5dc7-8453-dac60ee86ad7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240c08c-4dca-4271-88d1-715432714bb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f240c08c-4dca-4271-88d1-715432714bb1.jpg?1",
             "name": "One-Clown Band",
             "text": "",
             "colours": [
@@ -18215,7 +18215,7 @@
         },
         {
             "id": "b7502f9b-f561-5ecb-9326-0351abe2f610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7876202-d04f-49b3-9561-c98bc8e7513c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7876202-d04f-49b3-9561-c98bc8e7513c.jpg?1",
             "name": "Opening Ceremony",
             "text": "",
             "colours": [
@@ -18252,7 +18252,7 @@
         },
         {
             "id": "f17f1c0b-f622-58d2-bde0-c787263e0cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209203c1-348d-4d3a-bbd4-5a8219505515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209203c1-348d-4d3a-bbd4-5a8219505515.jpg?1",
             "name": "Priority Boarding",
             "text": "",
             "colours": [
@@ -18285,7 +18285,7 @@
         },
         {
             "id": "66a94768-6f96-5692-bf50-02173cfacabf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5262fc99-3f9a-4452-9248-e1705d6f2202.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5262fc99-3f9a-4452-9248-e1705d6f2202.jpg?1",
             "name": "Proficient Pyrodancer",
             "text": "",
             "colours": [
@@ -18321,7 +18321,7 @@
         },
         {
             "id": "dda685a2-6459-54c5-86f8-8e6be29ea9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194c217b-5ade-4e93-9e05-48359fe4619f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/194c217b-5ade-4e93-9e05-48359fe4619f.jpg?1",
             "name": "Rad Rascal",
             "text": "",
             "colours": [
@@ -18357,7 +18357,7 @@
         },
         {
             "id": "fea77332-1f60-5679-8b33-caaf18668129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae55cd76-5959-457c-9c19-747e3183d8c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae55cd76-5959-457c-9c19-747e3183d8c0.jpg?1",
             "name": "Rock Star",
             "text": "",
             "colours": [
@@ -18393,7 +18393,7 @@
         },
         {
             "id": "ae8d543f-8349-550c-a0b6-12aed87e5aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ea8772-4060-4f9f-86ac-6e6a6088f372.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16ea8772-4060-4f9f-86ac-6e6a6088f372.jpg?1",
             "name": "Slight Malfunction",
             "text": "",
             "colours": [
@@ -18426,7 +18426,7 @@
         },
         {
             "id": "e94cfea2-7e3f-5e6f-b425-ddb55ea6ab3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cd8b8b-b800-44f6-a395-0ba032c09646.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cd8b8b-b800-44f6-a395-0ba032c09646.jpg?1",
             "name": "Ticking Mime Bomb",
             "text": "",
             "colours": [
@@ -18464,7 +18464,7 @@
         },
         {
             "id": "58bb8ea0-b322-53b7-bc3e-df379c7f3fa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb346c6-4732-4e35-b6e4-7b2a50b65d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fb346c6-4732-4e35-b6e4-7b2a50b65d44.jpg?1",
             "name": "Trigger Happy",
             "text": "",
             "colours": [
@@ -18497,7 +18497,7 @@
         },
         {
             "id": "d512fc07-9942-5b58-aa10-081421c95b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bfa5cf-87b5-43a6-a5c7-24a41e287545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bfa5cf-87b5-43a6-a5c7-24a41e287545.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -18541,7 +18541,7 @@
         },
         {
             "id": "ac619c9d-1e15-54df-86ca-2717c247e949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59e34b6-352e-4a0f-b251-66af1ca5101c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59e34b6-352e-4a0f-b251-66af1ca5101c.jpg?1",
             "name": "Wee Champion",
             "text": "",
             "colours": [
@@ -18578,7 +18578,7 @@
         },
         {
             "id": "eff31d4e-2b5f-5ceb-85d0-726d84ba9e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23c1ade-c751-4071-beb5-9f47d6f8b557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23c1ade-c751-4071-beb5-9f47d6f8b557.jpg?1",
             "name": "Well Done",
             "text": "",
             "colours": [
@@ -18611,7 +18611,7 @@
         },
         {
             "id": "92c90bf4-b890-5610-83d4-976ae38df7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fcdd26-669b-4f0f-a932-708abfc1711c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4fcdd26-669b-4f0f-a932-708abfc1711c.jpg?1",
             "name": "Alpha Guard",
             "text": "",
             "colours": [
@@ -18647,7 +18647,7 @@
         },
         {
             "id": "ff0b6274-640e-5237-9230-7460b5109b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdc8c7-9bb2-49f3-a633-6e009fa8586f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdc8c7-9bb2-49f3-a633-6e009fa8586f.jpg?1",
             "name": "Atomwheel Acrobats",
             "text": "",
             "colours": [
@@ -18683,7 +18683,7 @@
         },
         {
             "id": "45c0128b-fa43-59f7-a2f7-4d30e8c90c64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53899f04-d0b5-464c-bac9-c3e9490ed127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53899f04-d0b5-464c-bac9-c3e9490ed127.jpg?1",
             "name": "Blorbian Buddy",
             "text": "",
             "colours": [
@@ -18719,7 +18719,7 @@
         },
         {
             "id": "8669679d-ccf3-5523-8b06-4971e610606f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71057f4e-8730-4f88-a2bc-ccf920465762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71057f4e-8730-4f88-a2bc-ccf920465762.jpg?1",
             "name": "Centaur of Attention",
             "text": "",
             "colours": [
@@ -18755,7 +18755,7 @@
         },
         {
             "id": "ec11022d-09f2-5c4b-92e3-88f906575e17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddeb24e8-5caa-4a18-bdfa-47334286a920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddeb24e8-5caa-4a18-bdfa-47334286a920.jpg?1",
             "name": "Chicken Troupe",
             "text": "",
             "colours": [
@@ -18791,7 +18791,7 @@
         },
         {
             "id": "20f9abd2-7732-589e-8b1f-5ec12c5d4f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70fe267-d1d4-43f1-a95e-7fc275bde243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70fe267-d1d4-43f1-a95e-7fc275bde243.jpg?1",
             "name": "Clandestine Chameleon",
             "text": "",
             "colours": [
@@ -18827,7 +18827,7 @@
         },
         {
             "id": "5c64ecfa-ddd2-5cc2-9f47-a3569cef700b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4e96bf-e6b8-48bf-af10-d4857c724153.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e4e96bf-e6b8-48bf-af10-d4857c724153.jpg?1",
             "name": "Coming Attraction",
             "text": "",
             "colours": [
@@ -18860,7 +18860,7 @@
         },
         {
             "id": "2fb85c08-6d25-5f80-9328-7503551bfaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84ff6c-0380-4dec-879d-610876b2f57d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e84ff6c-0380-4dec-879d-610876b2f57d.jpg?1",
             "name": "Done for the Day",
             "text": "",
             "colours": [
@@ -18893,7 +18893,7 @@
         },
         {
             "id": "affce140-4236-5d55-bc55-d7bb1a3fb52c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f31b7e-fb62-4bec-b726-4da344d2ab82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f31b7e-fb62-4bec-b726-4da344d2ab82.jpg?1",
             "name": "Embiggen",
             "text": "",
             "colours": [
@@ -18926,7 +18926,7 @@
         },
         {
             "id": "b51e4d00-6083-5ba0-8c3a-ab576085b162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0646993-4387-4df5-8ba0-a2ed630e8077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0646993-4387-4df5-8ba0-a2ed630e8077.jpg?1",
             "name": "Fight the _____ Fight",
             "text": "",
             "colours": [
@@ -18961,7 +18961,7 @@
         },
         {
             "id": "fc8aead9-f101-51f4-bb79-a79567a82ec9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64724b2-8e31-4145-a4c2-79a1fbfa936b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d64724b2-8e31-4145-a4c2-79a1fbfa936b.jpg?1",
             "name": "Finishing Move",
             "text": "",
             "colours": [
@@ -18994,7 +18994,7 @@
         },
         {
             "id": "3c3f4a9d-55d9-55e8-868c-8be520115bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774107d-f5d3-4aa8-8f55-b4b109a8c0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0774107d-f5d3-4aa8-8f55-b4b109a8c0df.jpg?1",
             "name": "Grabby Tabby",
             "text": "",
             "colours": [
@@ -19030,7 +19030,7 @@
         },
         {
             "id": "c439ca4c-2be3-5874-a9df-442026c2692b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad70398-6522-4e77-905c-32519a896bd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ad70398-6522-4e77-905c-32519a896bd8.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -19070,7 +19070,7 @@
         },
         {
             "id": "59863087-7126-58c1-8588-38ad92782790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a92b80-f944-40c5-b789-213afd1436ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a92b80-f944-40c5-b789-213afd1436ef.jpg?1",
             "name": "Icing Manipulator",
             "text": "",
             "colours": [
@@ -19106,7 +19106,7 @@
         },
         {
             "id": "b3fc7a07-96ef-5f54-bd9f-6a0d1ba7d281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9cb34-7ba1-4bce-a2a3-cc65cbbdbe5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd9cb34-7ba1-4bce-a2a3-cc65cbbdbe5c.jpg?1",
             "name": "An Incident Has Occurred",
             "text": "",
             "colours": [
@@ -19139,7 +19139,7 @@
         },
         {
             "id": "7b398373-b253-50d0-8ddc-dfeb08b7acb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58f01de-aede-489f-866a-720b67f0e138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d58f01de-aede-489f-866a-720b67f0e138.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -19179,7 +19179,7 @@
         },
         {
             "id": "d54994d1-dc7e-5438-87ff-55960da663a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da27712-70f0-49e6-9ecc-da92199afe9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3da27712-70f0-49e6-9ecc-da92199afe9c.jpg?1",
             "name": "Killer Cosplay",
             "text": "",
             "colours": [
@@ -19214,7 +19214,7 @@
         },
         {
             "id": "e0368369-8879-538c-94b4-25829c0e3900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900f91be-10dc-4f4a-b6a6-013b372b982b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/900f91be-10dc-4f4a-b6a6-013b372b982b.jpg?1",
             "name": "Lineprancers",
             "text": "",
             "colours": [
@@ -19250,7 +19250,7 @@
         },
         {
             "id": "1b6791f0-850f-56f5-99d3-fc0b69ca4557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca0f438-d0f9-40ae-959c-90971c878b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca0f438-d0f9-40ae-959c-90971c878b0d.jpg?1",
             "name": "Mistakes Were Made",
             "text": "",
             "colours": [
@@ -19283,7 +19283,7 @@
         },
         {
             "id": "b90e95e8-d202-54f4-8bf7-f4095b318efa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8783af-3904-4f2f-bad2-9f5c36fb0639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe8783af-3904-4f2f-bad2-9f5c36fb0639.jpg?1",
             "name": "_____-o-saurus",
             "text": "",
             "colours": [
@@ -19319,7 +19319,7 @@
         },
         {
             "id": "d82e916f-37f3-5e2f-96c4-d76cb652e564",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a4342b-823f-4f60-bba9-f83dfb050397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79a4342b-823f-4f60-bba9-f83dfb050397.jpg?1",
             "name": "Pair o' Dice Lost",
             "text": "",
             "colours": [
@@ -19352,7 +19352,7 @@
         },
         {
             "id": "da2df91d-b4dd-5639-9342-166e4d960909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e8bda-77d3-4031-9fcd-c5c4838fd88c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e8bda-77d3-4031-9fcd-c5c4838fd88c.jpg?1",
             "name": "Petting Zookeeper",
             "text": "",
             "colours": [
@@ -19388,7 +19388,7 @@
         },
         {
             "id": "467b9f20-aa7e-54ad-90ac-fd084257ec9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afccff1-a590-435d-821e-3e0e1a9738b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6afccff1-a590-435d-821e-3e0e1a9738b9.jpg?1",
             "name": "Pie-Eating Contest",
             "text": "",
             "colours": [
@@ -19421,7 +19421,7 @@
         },
         {
             "id": "e736f0f4-25a2-50bd-877e-4d8353791df7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a967f75-f189-4cfc-abc5-6633583790ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a967f75-f189-4cfc-abc5-6633583790ed.jpg?1",
             "name": "Plot Armor",
             "text": "",
             "colours": [
@@ -19456,7 +19456,7 @@
         },
         {
             "id": "7fbe9beb-9857-5be1-a7b5-16b0ec50932f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb297-ec1b-41fa-a2f8-884c42475809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480eb297-ec1b-41fa-a2f8-884c42475809.jpg?1",
             "name": "Resolute Veggiesaur",
             "text": "",
             "colours": [
@@ -19492,7 +19492,7 @@
         },
         {
             "id": "d0fbb6f9-7a15-5825-9a73-45ab1bbca948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24649a26-822e-456f-8f28-8e1d002fdd81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24649a26-822e-456f-8f28-8e1d002fdd81.jpg?1",
             "name": "Sole Performer",
             "text": "",
             "colours": [
@@ -19528,7 +19528,7 @@
         },
         {
             "id": "f7f7f6e5-6533-5d18-a227-47d50010924a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf848f3-4716-4b1b-b469-ae6bb112d15c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf848f3-4716-4b1b-b469-ae6bb112d15c.jpg?1",
             "name": "Spelling Bee",
             "text": "",
             "colours": [
@@ -19564,7 +19564,7 @@
         },
         {
             "id": "f13d6134-b435-57a7-8ea8-5f9b568fc8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff9491e-ea18-4b80-ae27-8ce8a8eca9cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff9491e-ea18-4b80-ae27-8ce8a8eca9cb.jpg?1",
             "name": "Squirrel Squatters",
             "text": "",
             "colours": [
@@ -19599,7 +19599,7 @@
         },
         {
             "id": "1f5d759d-e562-5010-a0de-70a5dc71a8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202595c2-958c-416c-8d01-a7d4136628cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/202595c2-958c-416c-8d01-a7d4136628cf.jpg?1",
             "name": "Stiltstrider",
             "text": "",
             "colours": [
@@ -19635,7 +19635,7 @@
         },
         {
             "id": "d65d371b-76c6-5cf8-b093-dd902dff09c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d27927c-30b7-42e9-8a71-e16f60381d54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d27927c-30b7-42e9-8a71-e16f60381d54.jpg?1",
             "name": "Tchotchke Elemental",
             "text": "",
             "colours": [
@@ -19670,7 +19670,7 @@
         },
         {
             "id": "e5830ea3-1013-59a8-a798-cf03d099a1d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2743c817-fbe3-436d-96ab-00cd69c23423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2743c817-fbe3-436d-96ab-00cd69c23423.jpg?1",
             "name": "Tug of War",
             "text": "",
             "colours": [
@@ -19703,7 +19703,7 @@
         },
         {
             "id": "073edb94-4c9d-5c93-b4fd-9a66ce79dae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65d1ab8-ab8e-44db-b6fe-0d1a19835935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65d1ab8-ab8e-44db-b6fe-0d1a19835935.jpg?1",
             "name": "Vegetation Abomination",
             "text": "",
             "colours": [
@@ -19741,7 +19741,7 @@
         },
         {
             "id": "ed86e8ba-35b6-5b66-beb1-58d0775301d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707be12-b255-47ea-a938-f4b03a1e9247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4707be12-b255-47ea-a938-f4b03a1e9247.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -19784,7 +19784,7 @@
         },
         {
             "id": "17984c5d-bc4c-5a44-baed-bb6b0103d76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2624ed75-81ea-49aa-8acb-36d0084a9312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2624ed75-81ea-49aa-8acb-36d0084a9312.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -19826,7 +19826,7 @@
         },
         {
             "id": "a6321f1b-3988-58dd-b148-f02b05b4fc3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b0f07-999f-437a-af88-5d3f391afe12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24b0f07-999f-437a-af88-5d3f391afe12.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -19868,7 +19868,7 @@
         },
         {
             "id": "37f3af28-3c8a-5609-8f51-697ad401b9f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d354e-0485-4469-9781-fe03c78c624a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af4d354e-0485-4469-9781-fe03c78c624a.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -19911,7 +19911,7 @@
         },
         {
             "id": "8871f80f-547b-50fc-873b-da676b39c38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f415ac7-24e7-4cbf-a0ed-5086aa6e7cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f415ac7-24e7-4cbf-a0ed-5086aa6e7cea.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -19953,7 +19953,7 @@
         },
         {
             "id": "866a6a1c-dd1f-5c75-99bd-c66ce302a8de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e571-402b-4caa-afd8-562dff0ef341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e571-402b-4caa-afd8-562dff0ef341.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "",
             "colours": [
@@ -19994,7 +19994,7 @@
         },
         {
             "id": "1429a0bf-8f48-5c98-a434-2ee76868a7cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227984-b6d5-417f-a00e-6d6ec1fd9cfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb227984-b6d5-417f-a00e-6d6ec1fd9cfc.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -20036,7 +20036,7 @@
         },
         {
             "id": "e115851a-0a98-52bc-86c4-d25859ec5121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c0d46-7a88-40d0-9652-712c60bb3a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5c0d46-7a88-40d0-9652-712c60bb3a03.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -20078,7 +20078,7 @@
         },
         {
             "id": "e0049a60-f8a1-5c4a-b869-12c58702953b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ebcd89-7dc2-4a38-83f2-edccd319c8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0ebcd89-7dc2-4a38-83f2-edccd319c8fb.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -20120,7 +20120,7 @@
         },
         {
             "id": "47caf335-9de6-5e03-ba13-5e79b9685ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fda05f-01c6-487f-b264-949271114316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5fda05f-01c6-487f-b264-949271114316.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -20162,7 +20162,7 @@
         },
         {
             "id": "8fc1e197-2527-5579-8bb3-fd73ad6ee5db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd970a38-6575-4302-a308-fce3688bb795.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd970a38-6575-4302-a308-fce3688bb795.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -20204,7 +20204,7 @@
         },
         {
             "id": "6121f9c0-a100-5814-bd96-8d68c84a6a70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90b69a-aad6-4dcf-b060-52cef300f48d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90b69a-aad6-4dcf-b060-52cef300f48d.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -20246,7 +20246,7 @@
         },
         {
             "id": "a6744f05-1770-57a5-ac5f-014230d4f866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fdf560-a106-4991-bb0b-2811db33ee1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45fdf560-a106-4991-bb0b-2811db33ee1e.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -20288,7 +20288,7 @@
         },
         {
             "id": "f4f99e08-9069-5786-9a4b-fab50fa0e3a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f43d58-b64c-4726-a1a9-8d71d2da4507.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02f43d58-b64c-4726-a1a9-8d71d2da4507.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -20331,7 +20331,7 @@
         },
         {
             "id": "6d68a633-e7bf-5bd6-925a-75cd68f8667d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b92f4b-570a-431c-a6e3-4974e9316e9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42b92f4b-570a-431c-a6e3-4974e9316e9e.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -20373,7 +20373,7 @@
         },
         {
             "id": "e819aa75-7344-5683-a920-8ec5d2eafbbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed669650-8776-4aef-b9a7-21ce32e77a44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed669650-8776-4aef-b9a7-21ce32e77a44.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -20416,7 +20416,7 @@
         },
         {
             "id": "972377f6-7647-5d50-b9a9-4984dfd71055",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4228a057-e617-428b-b119-35659d10aeba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4228a057-e617-428b-b119-35659d10aeba.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -20458,7 +20458,7 @@
         },
         {
             "id": "533e84f0-05f5-50c9-856d-f9db6dfd787c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b5ebec-503c-4fcc-b73b-b7c1fbed425b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7b5ebec-503c-4fcc-b73b-b7c1fbed425b.jpg?1",
             "name": "Space Beleren",
             "text": "",
             "colours": [
@@ -20499,7 +20499,7 @@
         },
         {
             "id": "f08c42fe-e742-5173-8180-5acbe4d6c892",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200905c-ed18-45aa-8a24-3e1ef688bc6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5200905c-ed18-45aa-8a24-3e1ef688bc6f.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -20541,7 +20541,7 @@
         },
         {
             "id": "7bb97baa-a027-5990-9e2e-ffed24ef8857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d732d0c-9b77-477a-b867-a0086753ed1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d732d0c-9b77-477a-b867-a0086753ed1e.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -20583,7 +20583,7 @@
         },
         {
             "id": "05f06df8-52d5-5f4a-8317-e0e3540c11ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8663120-01f9-49cb-aeb7-8eac274b3a62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8663120-01f9-49cb-aeb7-8eac274b3a62.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -20626,7 +20626,7 @@
         },
         {
             "id": "b8e767e2-70bb-5ab6-97f6-ffc709878076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af667ba8-10ac-4ba9-bb12-0ce356ecba2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af667ba8-10ac-4ba9-bb12-0ce356ecba2a.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -20669,7 +20669,7 @@
         },
         {
             "id": "044684bb-d5fd-5d0e-8228-d18837f34480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4087522-a795-4bb4-91e5-506dbcf07cae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4087522-a795-4bb4-91e5-506dbcf07cae.jpg?1",
             "name": "Autograph Book",
             "text": "",
             "colours": [],
@@ -20698,7 +20698,7 @@
         },
         {
             "id": "a7c90807-b6a2-59a4-bbf7-125b5eb96745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506ec976-0347-4a62-b895-3fa443d99577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/506ec976-0347-4a62-b895-3fa443d99577.jpg?1",
             "name": "Blue Ribbon",
             "text": "",
             "colours": [],
@@ -20729,7 +20729,7 @@
         },
         {
             "id": "d5302c51-4e56-5d5e-859d-bb6fc4160509",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce90e68-1765-4c78-90ab-7435517349e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce90e68-1765-4c78-90ab-7435517349e4.jpg?1",
             "name": "Celebr-8000",
             "text": "",
             "colours": [],
@@ -20762,7 +20762,7 @@
         },
         {
             "id": "41d0be0f-8d87-544d-b878-485e01a8a4d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd9541-3b1c-4af1-ad23-92c1b1bd01e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44fd9541-3b1c-4af1-ad23-92c1b1bd01e2.jpg?1",
             "name": "Clown Car",
             "text": "",
             "colours": [],
@@ -20793,7 +20793,7 @@
         },
         {
             "id": "a3f969df-dabf-54cf-b484-3e5c84bbb6b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ec39e-7790-4621-b095-69bbc4ba1b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/580ec39e-7790-4621-b095-69bbc4ba1b3c.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -20829,7 +20829,7 @@
         },
         {
             "id": "ab20d313-8d98-568e-ae8f-0ac77311fdd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862780d6-3f3b-440b-bef1-3c24c1be4486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/862780d6-3f3b-440b-bef1-3c24c1be4486.jpg?1",
             "name": "Draconian Gate-Bot",
             "text": "",
             "colours": [],
@@ -20861,7 +20861,7 @@
         },
         {
             "id": "3401a84f-333f-5f39-b7b2-ac7368c6879c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ae2b25-93f9-4111-b377-68c300e425a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ae2b25-93f9-4111-b377-68c300e425a3.jpg?1",
             "name": "Greatest Show in the Multiverse",
             "text": "",
             "colours": [],
@@ -20893,7 +20893,7 @@
         },
         {
             "id": "fb4f919d-3a66-5efb-bca4-ed6c48440ab5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d881c16e-978c-4ecb-9009-d4ff30932647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d881c16e-978c-4ecb-9009-d4ff30932647.jpg?1",
             "name": "Park Map",
             "text": "",
             "colours": [],
@@ -20922,7 +20922,7 @@
         },
         {
             "id": "2bfd08ab-5d03-5ddf-83b0-ab3c95094569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2d7cbc-3d21-4191-923f-08e603c818f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2d7cbc-3d21-4191-923f-08e603c818f0.jpg?1",
             "name": "_____ _____ Rocketship",
             "text": "",
             "colours": [],
@@ -20953,7 +20953,7 @@
         },
         {
             "id": "f9aa7c14-999f-5437-9435-b7ee2a776bf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f39645-0448-4355-98cc-e47295f19681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4f39645-0448-4355-98cc-e47295f19681.jpg?1",
             "name": "Souvenir T-Shirt",
             "text": "",
             "colours": [],
@@ -20984,7 +20984,7 @@
         },
         {
             "id": "49475d00-a70b-51e9-94b5-ad1cc2ba3fa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce70c02-01e4-4a3d-8670-4b6b1456e050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ce70c02-01e4-4a3d-8670-4b6b1456e050.jpg?1",
             "name": "Strength-Testing Hammer",
             "text": "",
             "colours": [],
@@ -21015,7 +21015,7 @@
         },
         {
             "id": "e32bbd82-eee6-5d8b-97ee-4cb6b846fd94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de8b26f-1afb-4a87-9766-3b7961d81987.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1de8b26f-1afb-4a87-9766-3b7961d81987.jpg?1",
             "name": "Ticket Turbotubes",
             "text": "",
             "colours": [],
@@ -21044,7 +21044,7 @@
         },
         {
             "id": "00f0c6fa-8a42-5d3e-a0e2-215e86d7af9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ac22a3-9ac6-48aa-86f1-0b7e8836ad1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ac22a3-9ac6-48aa-86f1-0b7e8836ad1c.jpg?1",
             "name": "Ticketomaton",
             "text": "",
             "colours": [],
@@ -21076,7 +21076,7 @@
         },
         {
             "id": "5b5e05ad-833b-5967-abaf-02da41a9da67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2c656-2b4a-4541-8934-29d0db93f794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99b2c656-2b4a-4541-8934-29d0db93f794.jpg?1",
             "name": "Wicker Picker",
             "text": "",
             "colours": [],
@@ -21109,7 +21109,7 @@
         },
         {
             "id": "a085d24d-fd9b-514f-86cf-41100da28870",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6017b7d-7444-4946-a760-95cf30966b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6017b7d-7444-4946-a760-95cf30966b45.jpg?1",
             "name": "The Big Top",
             "text": "",
             "colours": [],
@@ -21138,7 +21138,7 @@
         },
         {
             "id": "db8ce153-3463-5b42-bf5c-56c7c04f40e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cb79f6-a274-4595-a579-3865d73b8dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6cb79f6-a274-4595-a579-3865d73b8dec.jpg?1",
             "name": "Nearby Planet",
             "text": "",
             "colours": [],
@@ -21173,7 +21173,7 @@
         },
         {
             "id": "36a529c8-6cc8-5a49-9bf9-ca27959dfc86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559be6bc-cce8-43b1-b8a5-1795e727f1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559be6bc-cce8-43b1-b8a5-1795e727f1c2.jpg?1",
             "name": "Urza's Fun House",
             "text": "",
             "colours": [],
@@ -21204,7 +21204,7 @@
         },
         {
             "id": "ffbf9e65-bc44-5a8f-ad29-054c7b8211e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4af7f5-c89c-4e61-9d4b-b9e467ca55b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a4af7f5-c89c-4e61-9d4b-b9e467ca55b4.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -21241,7 +21241,7 @@
         },
         {
             "id": "8245f416-1346-5e63-b629-d1da37b0ffac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e083ce-0f15-4ff0-8af1-747565f2d0d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38e083ce-0f15-4ff0-8af1-747565f2d0d8.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21278,7 +21278,7 @@
         },
         {
             "id": "627786cd-b6b9-5e17-985d-a38d21afe12e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c4bbf1-2e52-4b43-ad35-9272b48d36a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c4bbf1-2e52-4b43-ad35-9272b48d36a8.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21315,7 +21315,7 @@
         },
         {
             "id": "8d86d944-12fd-5d37-ae41-ceeb37c429f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e998ce9-4853-44d1-a01a-e2d493718ceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e998ce9-4853-44d1-a01a-e2d493718ceb.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21352,7 +21352,7 @@
         },
         {
             "id": "c40f5914-fedc-5248-b62e-55591430cde9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46df0e0-648d-4dc9-a2c7-ac96125ba77c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46df0e0-648d-4dc9-a2c7-ac96125ba77c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -21389,7 +21389,7 @@
         },
         {
             "id": "c3b5bfbc-a3c9-595c-9235-f32c9d63b5cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb3077-484d-42d4-a54b-5fade5335420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3deb3077-484d-42d4-a54b-5fade5335420.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -21426,7 +21426,7 @@
         },
         {
             "id": "31acf70d-12bf-562f-a1d7-b3fabbd0d895",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670e5e4-721b-422a-b10e-09bb742cbc4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f670e5e4-721b-422a-b10e-09bb742cbc4b.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -21463,7 +21463,7 @@
         },
         {
             "id": "200ed23d-7d2c-5df6-84eb-8b690d9ce3cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d49fc14-e848-4c44-a03c-6dfb83efed80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d49fc14-e848-4c44-a03c-6dfb83efed80.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -21500,7 +21500,7 @@
         },
         {
             "id": "ee5dd420-745c-5003-95c1-baa7249ca4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc7313-8b12-4ce1-9016-59b4e3c78ff1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bc7313-8b12-4ce1-9016-59b4e3c78ff1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -21537,7 +21537,7 @@
         },
         {
             "id": "27a17bfc-8a53-521c-866e-9c34d07cbdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ec5e4-3b44-4359-9ab8-4e25e2a9ec86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/977ec5e4-3b44-4359-9ab8-4e25e2a9ec86.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -21574,7 +21574,7 @@
         },
         {
             "id": "e65f6303-91e6-5448-9eb3-9225a4b61f86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b58b-3d12-4385-b634-7ee7bc1c2964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6109b58b-3d12-4385-b634-7ee7bc1c2964.jpg?1",
             "name": "Katerina of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21614,7 +21614,7 @@
         },
         {
             "id": "2dd642b8-fabe-5597-ad91-46805e392f5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371aeeb3-9c17-44d9-a191-fde80da1e37e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/371aeeb3-9c17-44d9-a191-fde80da1e37e.jpg?1",
             "name": "Solaflora, Intergalactic Icon",
             "text": "",
             "colours": [
@@ -21654,7 +21654,7 @@
         },
         {
             "id": "616ba59a-d535-570e-bae7-93017fdd63e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a5124-b0dc-4bc7-8b30-46a85bbe7d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/739a5124-b0dc-4bc7-8b30-46a85bbe7d38.jpg?1",
             "name": "Fluros of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21694,7 +21694,7 @@
         },
         {
             "id": "dd47a366-74ea-5f38-9e23-c7f4eb657802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242f9727-5fd6-4f6e-9447-58731e5aff20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/242f9727-5fd6-4f6e-9447-58731e5aff20.jpg?1",
             "name": "Nocturno of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21734,7 +21734,7 @@
         },
         {
             "id": "e9694fbc-86c7-5ff6-8e70-717c69a53f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66deec5a-f459-4c91-8de2-c24d83dfebf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66deec5a-f459-4c91-8de2-c24d83dfebf5.jpg?1",
             "name": "Devil K. Nevil",
             "text": "",
             "colours": [
@@ -21774,7 +21774,7 @@
         },
         {
             "id": "e6f64c87-a612-54d3-b063-a96d45cd6ec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f380fcd-dbd8-4d30-a332-7627d51b237f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f380fcd-dbd8-4d30-a332-7627d51b237f.jpg?1",
             "name": "Ignacio of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21814,7 +21814,7 @@
         },
         {
             "id": "d953c865-24db-5735-8552-95906bcf613a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9bb6a5-76e8-4490-895b-287d7db11449.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af9bb6a5-76e8-4490-895b-287d7db11449.jpg?1",
             "name": "Vorthos, Steward of Myth",
             "text": "",
             "colours": [
@@ -21858,7 +21858,7 @@
         },
         {
             "id": "4f448fc0-e57d-5634-9b36-28b4040b9319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0d0f9a-9018-45fb-9e14-023e2268ad35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc0d0f9a-9018-45fb-9e14-023e2268ad35.jpg?1",
             "name": "Hardy of Myra's Marvels",
             "text": "",
             "colours": [
@@ -21898,7 +21898,7 @@
         },
         {
             "id": "7e36537b-9309-5666-b547-5027d657ed2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f83eab-98ae-47c2-a4ca-3b2137feaa64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17f83eab-98ae-47c2-a4ca-3b2137feaa64.jpg?1",
             "name": "Jermane, Pride of the Circus",
             "text": "",
             "colours": [
@@ -21938,7 +21938,7 @@
         },
         {
             "id": "fd898be6-92fb-5537-b36b-fc68de26959c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8862a56-028b-462a-b789-e01f1abacceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8862a56-028b-462a-b789-e01f1abacceb.jpg?1",
             "name": "Ambassador Blorpityblorpboop",
             "text": "",
             "colours": [
@@ -21981,7 +21981,7 @@
         },
         {
             "id": "5197f4de-fd5f-5686-bed4-d768512b4c93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627e21e6-b2fb-41d6-b8f2-ef7f8360a3ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627e21e6-b2fb-41d6-b8f2-ef7f8360a3ce.jpg?1",
             "name": "Angelic Harold",
             "text": "",
             "colours": [
@@ -22023,7 +22023,7 @@
         },
         {
             "id": "f064ff0b-40b8-5680-b9c7-c5ee43398d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ffb0ab-d7bf-4136-9aa7-0a4965581a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ffb0ab-d7bf-4136-9aa7-0a4965581a75.jpg?1",
             "name": "\"Brims\" Barone, Midway Mobster",
             "text": "",
             "colours": [
@@ -22065,7 +22065,7 @@
         },
         {
             "id": "267e0705-f5d9-5133-a25a-8c5eefe7f63b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32494237-9d3f-4624-8762-2641fffc2115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32494237-9d3f-4624-8762-2641fffc2115.jpg?1",
             "name": "Captain Rex Nebula",
             "text": "",
             "colours": [
@@ -22108,7 +22108,7 @@
         },
         {
             "id": "62ce5141-7f33-558f-9b29-a8b2ebf40cb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3866b64b-2d6d-4708-9a7d-be2be2f1d59d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3866b64b-2d6d-4708-9a7d-be2be2f1d59d.jpg?1",
             "name": "Claire D'Loon, Joy Sculptor",
             "text": "",
             "colours": [
@@ -22150,7 +22150,7 @@
         },
         {
             "id": "6277d1f3-b8ea-57d7-9e0f-64cc1b36f57a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b5a57-21d3-4504-8b53-3d583ba3f438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827b5a57-21d3-4504-8b53-3d583ba3f438.jpg?1",
             "name": "Dee Kay, Finder of the Lost",
             "text": "",
             "colours": [
@@ -22192,7 +22192,7 @@
         },
         {
             "id": "ed8b5a6e-9908-5b9a-93a6-6b479be79804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445fb505-05c6-4a15-89db-7dcbb1d83c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/445fb505-05c6-4a15-89db-7dcbb1d83c91.jpg?1",
             "name": "Grand Marshal Macie",
             "text": "",
             "colours": [
@@ -22234,7 +22234,7 @@
         },
         {
             "id": "3d7c32fe-3c8f-5bbc-856c-25a8d3ce9af4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d781ac53-88fa-451c-a747-ba178c251c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d781ac53-88fa-451c-a747-ba178c251c3c.jpg?1",
             "name": "It Came from Planet Glurg",
             "text": "",
             "colours": [
@@ -22276,7 +22276,7 @@
         },
         {
             "id": "71a199b1-adf7-5955-8ea8-d225c4463fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e43e41e-782a-4d28-bb45-0a1265bf9732.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e43e41e-782a-4d28-bb45-0a1265bf9732.jpg?1",
             "name": "Lila, Hospitality Hostess",
             "text": "",
             "colours": [
@@ -22318,7 +22318,7 @@
         },
         {
             "id": "6a07f6f5-972c-5b02-8129-267cf3345db3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0909366b-b578-4829-afd3-6b4d6ef474a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0909366b-b578-4829-afd3-6b4d6ef474a4.jpg?1",
             "name": "Magar of the Magic Strings",
             "text": "",
             "colours": [
@@ -22360,7 +22360,7 @@
         },
         {
             "id": "d0815555-07a2-511f-9349-5dae327a51de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816683ec-cfd2-4a66-bb9d-a13c1ad60d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816683ec-cfd2-4a66-bb9d-a13c1ad60d1e.jpg?1",
             "name": "Meet and Greet \"Sisay\"",
             "text": "",
             "colours": [
@@ -22402,7 +22402,7 @@
         },
         {
             "id": "f44e7474-d776-5c6b-bcda-4f8e4f889bbb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e56f12-2097-413d-9a79-8476067900b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50e56f12-2097-413d-9a79-8476067900b7.jpg?1",
             "name": "Monoxa, Midway Manager",
             "text": "",
             "colours": [
@@ -22444,7 +22444,7 @@
         },
         {
             "id": "3c686e35-bb9e-5bc8-80aa-a812fd911f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1107d-f478-48dc-b721-6eb1f6bc1b22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1107d-f478-48dc-b721-6eb1f6bc1b22.jpg?1",
             "name": "The Most Dangerous Gamer",
             "text": "",
             "colours": [
@@ -22487,7 +22487,7 @@
         },
         {
             "id": "a4806bed-7118-548f-9939-a24474295710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ba4d49-d7fa-43f4-b5c4-8da0619ef553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ba4d49-d7fa-43f4-b5c4-8da0619ef553.jpg?1",
             "name": "Myra the Magnificent",
             "text": "",
             "colours": [
@@ -22529,7 +22529,7 @@
         },
         {
             "id": "8e11627c-1803-533a-8ef5-4c41f1787790",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b392d1a2-6feb-47de-8f89-657f275c520d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b392d1a2-6feb-47de-8f89-657f275c520d.jpg?1",
             "name": "Pietra, Crafter of Clowns",
             "text": "",
             "colours": [
@@ -22572,7 +22572,7 @@
         },
         {
             "id": "71c436b3-8f11-50eb-9acb-1ffaa869e165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa261-9737-4228-9767-b9d36a2c3c30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483fa261-9737-4228-9767-b9d36a2c3c30.jpg?1",
             "name": "Roxi, Publicist to the Stars",
             "text": "",
             "colours": [
@@ -22614,7 +22614,7 @@
         },
         {
             "id": "8d528e2a-fbe7-54f5-a74b-6d022a8ab663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9969b4-cb64-4275-b7fd-93565dadaaf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9969b4-cb64-4275-b7fd-93565dadaaf7.jpg?1",
             "name": "The Space Family Goblinson",
             "text": "",
             "colours": [
@@ -22656,7 +22656,7 @@
         },
         {
             "id": "52e3c730-5df8-522b-89fe-a824bb6b164c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e140a98a-ad97-40c9-a666-9d5055f7edd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e140a98a-ad97-40c9-a666-9d5055f7edd4.jpg?1",
             "name": "Spinnerette, Arachnobat",
             "text": "",
             "colours": [
@@ -22698,7 +22698,7 @@
         },
         {
             "id": "8e04ca20-5f25-5dab-81e3-0ec2eb9b2ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47975755-d7a2-4c04-a493-efe422096d3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47975755-d7a2-4c04-a493-efe422096d3d.jpg?1",
             "name": "Truss, Chief Engineer",
             "text": "",
             "colours": [
@@ -22741,7 +22741,7 @@
         },
         {
             "id": "23342a95-59cb-5dcb-9f0d-609c541936b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6b5393-8c49-4736-a7fd-0b4a4a2f1676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b6b5393-8c49-4736-a7fd-0b4a4a2f1676.jpg?1",
             "name": "Tusk and Whiskers",
             "text": "",
             "colours": [
@@ -22784,7 +22784,7 @@
         },
         {
             "id": "a00211bf-2903-580d-b5d1-b27393056899",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf0a5a5-cb0b-4cfa-8c5b-f1bcd1004979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cf0a5a5-cb0b-4cfa-8c5b-f1bcd1004979.jpg?1",
             "name": "D00-DL, Caricaturist",
             "text": "",
             "colours": [],
@@ -22820,7 +22820,7 @@
         },
         {
             "id": "8721bab6-6dab-5d37-a6aa-4fdcfc642f62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360668f0-c76c-4fb3-94ce-dfab9969f6d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/360668f0-c76c-4fb3-94ce-dfab9969f6d3.jpg?1",
             "name": "Comet, Stellar Pup",
             "text": "0: Roll a six-sided die.\n1 or 2 \u2014 +2, then create two 1/1 green Squirrel creature tokens. They gain haste until end of turn.\n3 \u2014 \u22121, then return a card with mana value 2 or less from your graveyard to your hand.\n4 or 5 \u2014 Comet, Stellar Pup deals damage equal to the number of loyalty counters on him to a creature or player, then \u22122.\n6 \u2014 +1, and you may activate Comet, Stellar Pup's loyalty ability two more times this turn.",
             "colours": [
@@ -22861,7 +22861,7 @@
         },
         {
             "id": "c44d9054-ebce-5661-8fbb-372ff5965315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b416fd-27cc-4d22-9d44-345b46b1cdcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b416fd-27cc-4d22-9d44-345b46b1cdcb.jpg?1",
             "name": "Space Beleren",
             "text": "Space sculptor (Space Beleren divides the battlefield into alpha, beta, and gamma sectors. If a creature isn't assigned to a sector, its controller assigns it to one. Opponents assign first.)\n+1: Creatures in each sector can be blocked this turn only by creatures in the same sector.\n\u22121: Put a +1/+1 counter on each creature in the sector of your choice.\n\u22125: Destroy all creatures in the sector of your choice.",
             "colours": [
@@ -22902,7 +22902,7 @@
         },
         {
             "id": "3373ff29-c605-5f94-8dcf-93f8acad1794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a4070-18e8-4f5e-bf64-a191ddf3210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a3a4070-18e8-4f5e-bf64-a191ddf3210e.jpg?1",
             "name": "Hallowed Fountain",
             "text": "",
             "colours": [],
@@ -22937,7 +22937,7 @@
         },
         {
             "id": "0608ab2f-66a6-55c0-9117-bd831ebf6f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3721bac-4e1c-438e-b0a2-a557dd530077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3721bac-4e1c-438e-b0a2-a557dd530077.jpg?1",
             "name": "Watery Grave",
             "text": "",
             "colours": [],
@@ -22972,7 +22972,7 @@
         },
         {
             "id": "214279fa-3cdc-5742-add8-8ba08358a6ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737d6df-a20d-46ac-a340-b119c7791f1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f737d6df-a20d-46ac-a340-b119c7791f1b.jpg?1",
             "name": "Blood Crypt",
             "text": "",
             "colours": [],
@@ -23007,7 +23007,7 @@
         },
         {
             "id": "c16ba014-104d-5541-8a0c-2c9877b7e1f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982711bc-cdfa-467a-9675-0b719963045c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/982711bc-cdfa-467a-9675-0b719963045c.jpg?1",
             "name": "Stomping Ground",
             "text": "",
             "colours": [],
@@ -23042,7 +23042,7 @@
         },
         {
             "id": "522bb6e5-f23f-556b-8e8f-d8b59b66ff27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a0d368-993a-473d-9da9-9ed50fc5670e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6a0d368-993a-473d-9da9-9ed50fc5670e.jpg?1",
             "name": "Temple Garden",
             "text": "",
             "colours": [],
@@ -23077,7 +23077,7 @@
         },
         {
             "id": "7f8d9790-246a-5a1b-9dcd-fad03fd564ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1296cc-59aa-412d-9115-99fdc9ada754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f1296cc-59aa-412d-9115-99fdc9ada754.jpg?1",
             "name": "Godless Shrine",
             "text": "",
             "colours": [],
@@ -23112,7 +23112,7 @@
         },
         {
             "id": "0d6d1e13-6ac4-5751-a5af-d7e5c489e262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be874189-b715-4e7c-85d7-e887328b9d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be874189-b715-4e7c-85d7-e887328b9d3f.jpg?1",
             "name": "Steam Vents",
             "text": "",
             "colours": [],
@@ -23147,7 +23147,7 @@
         },
         {
             "id": "48a2455b-b2bd-5622-911b-ae521a2dd03b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315a5f0-d473-4566-9420-7f214b0c76e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8315a5f0-d473-4566-9420-7f214b0c76e2.jpg?1",
             "name": "Overgrown Tomb",
             "text": "",
             "colours": [],
@@ -23182,7 +23182,7 @@
         },
         {
             "id": "53db2c0b-64a5-579e-9ec4-a25e22ab5f2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b86558b-655f-482f-9d81-09efc917f8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b86558b-655f-482f-9d81-09efc917f8fc.jpg?1",
             "name": "Sacred Foundry",
             "text": "",
             "colours": [],
@@ -23217,7 +23217,7 @@
         },
         {
             "id": "2c6ebc86-ae39-56b8-9ac8-491a731a5e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ded082-0e6e-4aed-90cc-1bc4aea77dfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29ded082-0e6e-4aed-90cc-1bc4aea77dfa.jpg?1",
             "name": "Breeding Pool",
             "text": "",
             "colours": [],
@@ -23252,7 +23252,7 @@
         },
         {
             "id": "cd0e3312-700b-5b29-b240-c40eb58fbe5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb587e1-1243-4422-8ee3-198bd247b42c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb587e1-1243-4422-8ee3-198bd247b42c.jpg?1",
             "name": "Water Gun Balloon Game",
             "text": "",
             "colours": [],
@@ -23279,7 +23279,7 @@
         },
         {
             "id": "6b70f468-ac73-5e14-a0ba-c5388b439dff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16b4228-ed85-4d31-8760-88539b9a3cf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16b4228-ed85-4d31-8760-88539b9a3cf9.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -23314,7 +23314,7 @@
         },
         {
             "id": "9af30052-def7-5631-9fee-735a6b6caf7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d001ca-285e-4033-9d97-0a1db3a8ec7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54d001ca-285e-4033-9d97-0a1db3a8ec7b.jpg?1",
             "name": "Clown Robot",
             "text": "",
             "colours": [],
@@ -23347,7 +23347,7 @@
         },
         {
             "id": "837671c9-3c78-59ae-b945-ecac938d9140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd324b-8325-40f3-8a02-b84102cc63ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcd324b-8325-40f3-8a02-b84102cc63ab.jpg?1",
             "name": "Clown Robot",
             "text": "",
             "colours": [],
@@ -23380,7 +23380,7 @@
         },
         {
             "id": "94942e99-5e62-58a6-862b-587f46220b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg?1",
             "name": "Contortionist // Contortionist",
             "text": "",
             "colours": [
@@ -23416,7 +23416,7 @@
         },
         {
             "id": "5467878f-d200-5dd7-b420-668c87ef6c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg?1",
             "name": "Contortionist // Contortionist",
             "text": "",
             "colours": [
@@ -23452,7 +23452,7 @@
         },
         {
             "id": "5776a0a9-6827-5e8b-8ea8-669d8c096a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c73960-1dd9-4f11-81b3-2ae4d3a5e283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c73960-1dd9-4f11-81b3-2ae4d3a5e283.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -23487,7 +23487,7 @@
         },
         {
             "id": "9f7c2c23-0bc1-5b68-9daf-de6355875618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d7d1d3-8989-4c54-9029-c1298c6ff8ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d7d1d3-8989-4c54-9029-c1298c6ff8ca.jpg?1",
             "name": "Zombie Employee",
             "text": "",
             "colours": [
@@ -23523,7 +23523,7 @@
         },
         {
             "id": "aeaa0582-78d4-5bbb-848d-472aa3bbb01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2c0f-7ed8-4d72-8f94-33ad615bf21d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8f2c0f-7ed8-4d72-8f94-33ad615bf21d.jpg?1",
             "name": "Balloon",
             "text": "",
             "colours": [
@@ -23558,7 +23558,7 @@
         },
         {
             "id": "2f870f14-6517-5fcc-8656-66db0fedf25e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4170e0-c899-481a-8076-cae9f3effc37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4170e0-c899-481a-8076-cae9f3effc37.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -23593,7 +23593,7 @@
         },
         {
             "id": "a51bf167-c9c0-5a66-af04-b9bc7cc36cb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aef57de-7b99-47f3-af44-3c0bc546bbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4aef57de-7b99-47f3-af44-3c0bc546bbac.jpg?1",
             "name": "Teddy Bear",
             "text": "",
             "colours": [],
@@ -23625,7 +23625,7 @@
         },
         {
             "id": "4fafd1b0-4281-54a5-b3c1-7811a0200625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01136e91-1ad3-4e01-8f7e-2718c3a9da27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01136e91-1ad3-4e01-8f7e-2718c3a9da27.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -23656,7 +23656,7 @@
         },
         {
             "id": "2066c068-0bfe-5cf9-bde5-b2726bd59211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95643f5-16f8-4ea6-8328-b3c227d87d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b95643f5-16f8-4ea6-8328-b3c227d87d83.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -23687,7 +23687,7 @@
         },
         {
             "id": "7daecc09-9012-5a81-86c2-3f6a831f41a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef2b17-e7cd-49e3-a84d-cc4653b1ca8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef2b17-e7cd-49e3-a84d-cc4653b1ca8b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -23718,7 +23718,7 @@
         },
         {
             "id": "0650b215-3a3d-5d23-97d4-6e2256fd6840",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab1ec58-5299-4604-8feb-212a6c5e7ffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab1ec58-5299-4604-8feb-212a6c5e7ffd.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -23749,7 +23749,7 @@
         },
         {
             "id": "a963dd53-b432-5cd6-9a12-d8d54734cad4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52942a5c-0552-4a9b-9c0f-7a9ffd04d0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52942a5c-0552-4a9b-9c0f-7a9ffd04d0af.jpg?1",
             "name": "Ticket Bucket-Bot",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/UNH.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UNH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "554eefda-6c6f-5ad4-9007-cd102ce74c65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0076e3-e538-4f4f-87fb-467851a8d8dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d0076e3-e538-4f4f-87fb-467851a8d8dd.jpg?1",
             "name": "Atinlay Igpay",
             "text": "Oubleday ikestray\nEneverwhay Atinlay Igpay's ontrollercay eaksspay ay onnay-Igpay-Atinlay ordway, acrificesay Atinlay Igpay.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "8b38766f-c20d-54cd-91a6-2ea3d79a2b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf3447a-ec7d-47d7-bf6b-e2bbe0ac58df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf3447a-ec7d-47d7-bf6b-e2bbe0ac58df.jpg?1",
             "name": "AWOL",
             "text": "Remove target attacking creature from the game. Then remove it from the removed-from-game zone and put it into the absolutely-removed-from-the-freaking-game-forever zone.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "2192d5e3-3f36-5abc-bf3c-4cf7d1f3782b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c94a52-fc1e-4f5d-a95c-47e6d6c8bef9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c94a52-fc1e-4f5d-a95c-47e6d6c8bef9.jpg?1",
             "name": "AWOL",
             "text": "",
             "colours": [
@@ -104,7 +104,7 @@
         },
         {
             "id": "adb9e553-de2c-5a80-9960-72b8c147c5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9701ab2-acb5-431a-a442-8df33bcb75a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9701ab2-acb5-431a-a442-8df33bcb75a3.jpg?1",
             "name": "Bosom Buddy",
             "text": "Whenever you play a spell, you may gain \u00bd life for each word in that spell's name.",
             "colours": [
@@ -139,7 +139,7 @@
         },
         {
             "id": "85253fe3-1543-5bcf-b997-b151ebcc19df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e0273-133f-4326-91d4-a1281b388d2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408e0273-133f-4326-91d4-a1281b388d2c.jpg?1",
             "name": "Cardpecker",
             "text": "Flying\nGotcha Whenever an opponent touches the table with his or her hand, you may say \"Gotcha\" If you do, return Cardpecker from your graveyard to your hand.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "07f98b20-42d1-5aff-80bd-9fdab39e7991",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42bbacc-b9ad-42fe-b726-e2dccf030bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a42bbacc-b9ad-42fe-b726-e2dccf030bb8.jpg?1",
             "name": "Cardpecker",
             "text": "",
             "colours": [
@@ -209,7 +209,7 @@
         },
         {
             "id": "1a24d642-1fd8-5a04-a91f-49f37e6341b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c3f0ea-d4b5-428c-abd2-93e09998d63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c3f0ea-d4b5-428c-abd2-93e09998d63c.jpg?1",
             "name": "Cheap Ass",
             "text": "Spells you play cost  less to play.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "3ec510aa-e378-5256-9eb2-081f70e2ab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbdb5ed-2d8a-4c95-b0fd-f19ff82e1302.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbdb5ed-2d8a-4c95-b0fd-f19ff82e1302.jpg?1",
             "name": "Circle of Protection: Art",
             "text": "As Circle of Protection: Art comes into play, choose an artist.\n{1}{W}: The next time a source of your choice by the chosen artist would deal damage to you this turn, prevent that damage.\n{1}{W}: Return Circle of Protection: Art to its owner's hand.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "67bee778-91ce-5744-98b8-cacaa427144a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de4c754-dfff-4c0b-93c6-3725ad1efbb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7de4c754-dfff-4c0b-93c6-3725ad1efbb0.jpg?1",
             "name": "Collector Protector",
             "text": "{W}, Give an opponent a nonland card you own from outside the game: Prevent the next 1 damage that would be dealt to you or Collector Protector this turn.",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "d35fa7b5-5779-5c37-ac82-010fee4eabf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa9cd0-2152-4c01-a5d7-d257ae109d0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50fa9cd0-2152-4c01-a5d7-d257ae109d0f.jpg?1",
             "name": "Drawn Together",
             "text": "As Drawn Together comes into play, choose an artist.\nCreatures by the chosen artist get +2/+2.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "6cc3cf14-b0f9-5291-94ef-0a6dc727f46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcef9e39-c9e9-401a-b389-962877b3d763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcef9e39-c9e9-401a-b389-962877b3d763.jpg?1",
             "name": "Emcee",
             "text": "Whenever another creature comes into play, you may stand up and say in a deep, booming voice \"Presenting . . . \" and that creature's name. If you do, put a +1/+1 counter on that creature.",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "1dc4b98e-0bbd-5458-a24a-af22437bfb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9109252-2630-4550-a815-98a6c3725591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9109252-2630-4550-a815-98a6c3725591.jpg?1",
             "name": "Emcee",
             "text": "",
             "colours": [
@@ -415,7 +415,7 @@
         },
         {
             "id": "c98bf90b-e3b8-5a16-a797-73391ca6e4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3d2a7-3c62-4aaa-bfa4-5a97af6c276a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3f3d2a7-3c62-4aaa-bfa4-5a97af6c276a.jpg?1",
             "name": "Erase (Not the Urza's Legacy One)",
             "text": "If you control two or more white permanents that share an artist, you may play Erase (Not the Urza's Legacy One) without paying its mana cost.\nRemove target enchantment from the game.",
             "colours": [
@@ -447,7 +447,7 @@
         },
         {
             "id": "9fa2ce28-ac2d-5c19-9c51-544c74ef8249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d2f904-3d68-4192-aa8d-9521b9747fbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d2f904-3d68-4192-aa8d-9521b9747fbd.jpg?1",
             "name": "Fascist Art Director",
             "text": "{W}{W}: Fascist Art Director gains protection from the artist of your choice until end of turn..",
             "colours": [
@@ -482,7 +482,7 @@
         },
         {
             "id": "49b1a86c-d918-5cbb-99e6-aad5ec3c4115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8affab3-be32-4b9b-b4d1-8d2d7299580b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8affab3-be32-4b9b-b4d1-8d2d7299580b.jpg?1",
             "name": "First Come, First Served",
             "text": "The attacking or blocking creature with the lowest collector number has first strike. If two or more creatures are tied, they all have first strike.",
             "colours": [
@@ -514,7 +514,7 @@
         },
         {
             "id": "43b5cc22-b384-5df1-af20-2a93fd35b259",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b884afa-705c-432c-9783-22df4dd658b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b884afa-705c-432c-9783-22df4dd658b2.jpg?1",
             "name": "Frankie Peanuts",
             "text": "At the beginning of your upkeep, you may ask target player a yes-or-no question. If you do, that player answers the question truthfully and abides by that answer if able until end of turn.",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "8d464e9a-7e15-5119-b1bd-3d26408ae177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a209e1-9171-4433-ad04-07cd849ad71f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9a209e1-9171-4433-ad04-07cd849ad71f.jpg?1",
             "name": "Head to Head",
             "text": "You and target opponent play Seven Questions about the top card of that player's library. (That player looks at the card, then you ask up to six yes-or-no questions about the card that he or she answers truthfully. You guess the card's name\u2014that's question seven\u2014and the player reveals the card.) If you win, prevent all damage that would be dealt this turn by a source of your choice.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "3564dd96-651d-5c4a-836a-80ba477392e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1a661c-7acd-44cb-ae18-35a1f1e860e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1a661c-7acd-44cb-ae18-35a1f1e860e9.jpg?1",
             "name": "Ladies' Knight",
             "text": "Flying\nSpells that players wearing at least one item of women's clothing play cost {1} less to play. (Women's clothing is designed to be worn exclusively by women.)",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "07c3fd84-835e-5423-91d9-cea624914bd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f17b85-a866-48e8-aae0-55330109550e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90f17b85-a866-48e8-aae0-55330109550e.jpg?1",
             "name": "Little Girl",
             "text": "",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "ebd770e7-728d-58c3-a0de-910ed6f20d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f9c8f9-dbb4-408f-835a-4b6c6abfdc74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f9c8f9-dbb4-408f-835a-4b6c6abfdc74.jpg?1",
             "name": "Look at Me, I'm R&D",
             "text": "As Look at Me, I'm R&D comes into play, choose a number and a second number one higher or one lower than that number.\nAll instances of the first chosen number on permanents, spells, and cards in any zone are the second chosen number.",
             "colours": [
@@ -685,7 +685,7 @@
         },
         {
             "id": "65b12a17-d12e-545b-8127-0742a69cb864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a45371-46b2-416c-a850-021fbf32ed51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a45371-46b2-416c-a850-021fbf32ed51.jpg?1",
             "name": "Man of Measure",
             "text": "As long as you're shorter than an opponent, Man of Measure has first strike and gets +0/+1.\nAs long as you're taller than an opponent, Man of Measure gets +1/+0.",
             "colours": [
@@ -720,7 +720,7 @@
         },
         {
             "id": "8f9c24a0-71ea-593d-ac6d-d59e5cd4a0f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba47805c-c8f2-4bcd-bf14-b3fa950039b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba47805c-c8f2-4bcd-bf14-b3fa950039b6.jpg?1",
             "name": "Save Life",
             "text": "Choose one Target player gains 2\u00bd life; or prevent the next 2\u00bd damage that would be dealt to target creature this turn.\nGotcha Whenever an opponent says \"Save\" or \"Life,\" you may say \"Gotcha\" If you do, return Save Life from your graveyard to your hand.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "7a173e9b-6866-543d-b699-804a25cb6185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba002c-d955-46d1-ae40-3467c863f42b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dba002c-d955-46d1-ae40-3467c863f42b.jpg?1",
             "name": "Standing Army",
             "text": "As long as you're standing, Standing Army has vigilance. (Attacking doesn't cause it to tap.)",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "c159a184-6f03-5d80-839e-6d28b77afc07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3790b-9fc9-4788-bebc-a978d39d09e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc3790b-9fc9-4788-bebc-a978d39d09e9.jpg?1",
             "name": "Standing Army",
             "text": "",
             "colours": [
@@ -824,7 +824,7 @@
         },
         {
             "id": "336e4e45-83e4-52f4-b2e4-6aecc5c48a20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924127a5-a364-489a-804f-a4f4174064ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924127a5-a364-489a-804f-a4f4174064ae.jpg?1",
             "name": "Staying Power",
             "text": "As long as Staying Power is in play, \"until end of turn\" and \"this turn\" effects don't end.",
             "colours": [
@@ -856,7 +856,7 @@
         },
         {
             "id": "ad2111fc-ab40-51ce-914f-ebc2037f1785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e15af-194e-4456-8b5e-c66e8e1bbe27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433e15af-194e-4456-8b5e-c66e8e1bbe27.jpg?1",
             "name": "Wordmail",
             "text": "Enchanted creature gets +1/+1 for each word in its name.",
             "colours": [
@@ -890,7 +890,7 @@
         },
         {
             "id": "26ff1d87-2638-5eff-90d6-3a7f46c64104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa90ab6-2686-4462-8725-5d4370c05437.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aa90ab6-2686-4462-8725-5d4370c05437.jpg?1",
             "name": "_____",
             "text": "{1}: This card's name becomes the name of your choice. Play this ability anywhere, anytime.",
             "colours": [
@@ -924,7 +924,7 @@
         },
         {
             "id": "c007ca64-8d5c-5896-8979-757d511efdf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f834c86-cd38-40bf-9aad-b4098895de86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f834c86-cd38-40bf-9aad-b4098895de86.jpg?1",
             "name": "Ambiguity",
             "text": "Whenever a player plays a spell that counters a spell that has been played or a player plays a spell that comes into play with counters, that player may counter the next spell played or put an additional counter on a permanent that has already been played, but not countered.",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "3be6dd71-e336-530b-97d0-09b4a7087993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3ba2a4-3784-4bb5-8a60-7bae80e97eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f3ba2a4-3784-4bb5-8a60-7bae80e97eba.jpg?1",
             "name": "Artful Looter",
             "text": "{T}: Draw a card, then discard a card.\nWhenever a permanent comes into play that shares an artist with another permanent you control, untap Artful Looter.",
             "colours": [
@@ -991,7 +991,7 @@
         },
         {
             "id": "514bda78-8855-52e7-8458-e2bebef4f953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d07cd08-42db-4fff-bd63-c1da48966cba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d07cd08-42db-4fff-bd63-c1da48966cba.jpg?1",
             "name": "Avatar of Me",
             "text": "Avatar of Me costs {1} more to play for each ten years you've been alive.\nAvatar of Me's power is equal to your height in feet and its toughness is equal to your American shoe size. Round to the nearest \u00bd.\nAvatar of Me's color is the color of your eyes.",
             "colours": [
@@ -1025,7 +1025,7 @@
         },
         {
             "id": "2bcc40fd-90bb-5c97-934a-dfb183b584aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdacb38-8f75-4d4f-bcb1-d2641f4d817f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fdacb38-8f75-4d4f-bcb1-d2641f4d817f.jpg?1",
             "name": "Brushstroke Paintermage",
             "text": "{T}: Target permanent's artist becomes the artist of your choice until end of turn.",
             "colours": [
@@ -1060,7 +1060,7 @@
         },
         {
             "id": "4daeb65d-5db6-5569-b583-cf03d283a860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7262a7-f48c-411b-8a0e-c5bd8f646145.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7262a7-f48c-411b-8a0e-c5bd8f646145.jpg?1",
             "name": "Bursting Beebles",
             "text": "Bursting Beebles is unblockable as long as defending player controls two or more nonland permanents that share an artist.",
             "colours": [
@@ -1094,7 +1094,7 @@
         },
         {
             "id": "01f94d75-d4ff-579a-9bdf-1d4fa695a5c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db678d7f-4d9a-450a-be92-b6aeaf06d120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db678d7f-4d9a-450a-be92-b6aeaf06d120.jpg?1",
             "name": "Carnivorous Death-Parrot",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Carnivorous Death-Parrot unless you say its flavor text.",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "a4f6b074-48d6-57eb-92a1-becb2fb7ab8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab857e73-ac20-4013-bc34-ed675de84c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab857e73-ac20-4013-bc34-ed675de84c7c.jpg?1",
             "name": "Cheatyface",
             "text": "You may sneak Cheatyface into play at any time without paying for it, but if an opponent catches you right away, that player may remove Cheatyface from the game.\nFlying",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "d3b0603d-8754-52e0-8073-9c8c19ae1573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c9c9f-a622-4bc3-b9be-38ed70b5c0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/532c9c9f-a622-4bc3-b9be-38ed70b5c0f1.jpg?1",
             "name": "Double Header",
             "text": "Flying\nWhen Double Header comes into play, you may return target permanent with a two-word name to its owner's hand.",
             "colours": [
@@ -1196,7 +1196,7 @@
         },
         {
             "id": "4b74400c-d115-5f39-b4ec-8c183fbb1800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409cb48a-572a-40df-ae1a-a43feab6bdfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/409cb48a-572a-40df-ae1a-a43feab6bdfd.jpg?1",
             "name": "Flaccify",
             "text": "Counter target spell unless its controller pays {3}.",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "efceb742-ec4b-5a32-8119-0741f0da3fa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf8efc4-ac10-4195-b389-181732c12ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf8efc4-ac10-4195-b389-181732c12ada.jpg?1",
             "name": "Framed!",
             "text": "Tap or untap all permanents by the artist of your choice.",
             "colours": [
@@ -1260,7 +1260,7 @@
         },
         {
             "id": "804bba8a-8977-586d-bb02-d8c9d906a372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec1ebe-805d-41f5-a131-cc4113ffab44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec1ebe-805d-41f5-a131-cc4113ffab44.jpg?1",
             "name": "Greater Morphling",
             "text": "{2}: Greater Morphling gains your choice of banding, bushido 1, double strike, fear, flying, first strike, haste, landwalk of your choice, protection from a color of your choice, provoke, rampage 1, shadow, or trample until end of turn.\n{2}: Greater Morphling becomes the colors of your choice until end of turn.\n{2}: Greater Morphling's type becomes the creature type of your choice until end of turn.\n{2}: Greater Morphling's expansion symbol becomes the symbol of your choice until end of turn.\n{2}: Greater Morphling's artist becomes the artist of your choice until end of turn.\n{2}: Greater Morphling gets +2/-2 or -2/+2 until end of turn.\n{2}: Untap Greater Morphling.",
             "colours": [
@@ -1295,7 +1295,7 @@
         },
         {
             "id": "a4b54a66-5c16-5cba-9db6-6e5847c7e675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31ed653-86ca-4962-8030-c8cba979129b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d31ed653-86ca-4962-8030-c8cba979129b.jpg?1",
             "name": "Greater Morphling",
             "text": "",
             "colours": [
@@ -1330,7 +1330,7 @@
         },
         {
             "id": "f1d410f6-c040-5ed5-87a6-e059120c17e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff24f82-afd6-48be-ba99-2f9e8a3d0231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/eff24f82-afd6-48be-ba99-2f9e8a3d0231.jpg?1",
             "name": "Johnny, Combo Player",
             "text": "{4}: Search your library for a card and put that card into your hand. Then shuffle your library.",
             "colours": [
@@ -1367,7 +1367,7 @@
         },
         {
             "id": "947fd259-f614-561f-b804-4edfb28fb9fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a2f131-e0d1-4583-929f-c009aee8bc20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a2f131-e0d1-4583-929f-c009aee8bc20.jpg?1",
             "name": "Loose Lips",
             "text": "As Loose Lips comes into play, choose a sentence with eight or fewer words.\nEnchanted creature has flying.\nWhenever enchanted creature deals damage to an opponent, you draw two cards unless that player says the chosen sentence.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "0e4187ea-d33e-5c02-b80e-d07b86aeab02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651626f5-aca6-4653-aa27-36c919566cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/651626f5-aca6-4653-aa27-36c919566cb0.jpg?1",
             "name": "Magical Hacker",
             "text": "{U}: Change the text of target spell or permanent by replacing all instances of + with -, and vice versa, until end of turn.",
             "colours": [
@@ -1436,7 +1436,7 @@
         },
         {
             "id": "fa9a2a88-26d8-5ef1-811d-7750b2cf141b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039b1f3-6bcd-4578-af5b-e13fb2036ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0039b1f3-6bcd-4578-af5b-e13fb2036ef2.jpg?1",
             "name": "Mise",
             "text": "Name a nonland card, then reveal the top card of your library. If that card is the named card, draw three cards.",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "37d2f0bb-30b7-50d5-933f-9d2790f4e70d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0697ef17-6aa5-4fe0-96ae-9aa0f4c92f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0697ef17-6aa5-4fe0-96ae-9aa0f4c92f21.jpg?1",
             "name": "Moniker Mage",
             "text": "{U}, Say your middle name: Moniker Mage can't be the target of spells or abilities this turn.\n{U}, Say an opponent's middle name: Moniker Mage gains flying until end of turn.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "0d66dcad-93dd-5ebf-9b31-0bf6c818b32e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9307a6-7eb1-4e20-afd4-8a723db89048.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9307a6-7eb1-4e20-afd4-8a723db89048.jpg?1",
             "name": "Mouth to Mouth",
             "text": "You and target opponent have a breath-holding contest. If you win, you gain control of target creature that player controls.",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "7e7eed44-a71d-5793-aa27-2b2cec44e3e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c790e6-340f-42c2-af88-e458b7b9690c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c790e6-340f-42c2-af88-e458b7b9690c.jpg?1",
             "name": "Now I Know My ABC's",
             "text": "At the beginning of your upkeep, if you control permanents with names that include all twenty-six letters of the English alphabet, you win the game.",
             "colours": [
@@ -1567,7 +1567,7 @@
         },
         {
             "id": "7dc969b0-e98d-599a-84e4-9f362fdc0431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e31d8-8d4f-4335-9191-1369302632d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/498e31d8-8d4f-4335-9191-1369302632d5.jpg?1",
             "name": "Number Crunch",
             "text": "Return target permanent to its owner's hand.\nGotcha Whenever an opponent says a number, you may say \"Gotcha\" If you do, return Number Crunch from your graveyard to your hand.",
             "colours": [
@@ -1599,7 +1599,7 @@
         },
         {
             "id": "a6fde033-e523-5b53-949c-b65330d9a17f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ec2c53-2958-46d0-8322-b673cf0b79d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ec2c53-2958-46d0-8322-b673cf0b79d4.jpg?1",
             "name": "Question Elemental?",
             "text": "Flying\nAre you aware that when you say something that isn't a question, the player who first points out this fact gains control of Question Elemental?",
             "colours": [
@@ -1634,7 +1634,7 @@
         },
         {
             "id": "12b2dc5c-5225-54a1-a346-96f689f76ab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e92e32-1b13-4f31-a2ce-b3d9308a5de2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e92e32-1b13-4f31-a2ce-b3d9308a5de2.jpg?1",
             "name": "Question Elemental?",
             "text": "",
             "colours": [
@@ -1669,7 +1669,7 @@
         },
         {
             "id": "4c70c1a7-b2be-5b92-b042-cfc579789b66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b8afa9-9e9d-4552-8709-4ba4af79ead3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08b8afa9-9e9d-4552-8709-4ba4af79ead3.jpg?1",
             "name": "Richard Garfield, Ph.D.",
             "text": "You may play cards as though they were other Magic cards of your choice with the same mana cost. (Mana cost includes color.) You can't choose the same card twice.",
             "colours": [
@@ -1707,7 +1707,7 @@
         },
         {
             "id": "7341ef82-468e-56d5-bd7a-92e9fd2f3447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493f3c04-2e12-44b3-957e-50c7861c4667.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/493f3c04-2e12-44b3-957e-50c7861c4667.jpg?1",
             "name": "Richard Garfield, Ph.D.",
             "text": "",
             "colours": [
@@ -1745,7 +1745,7 @@
         },
         {
             "id": "1ee7e64c-2286-53a7-bada-882fb6625816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090e83c2-375d-4470-a559-c37e8e7cefca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090e83c2-375d-4470-a559-c37e8e7cefca.jpg?1",
             "name": "Smart Ass",
             "text": "Whenever Smart Ass attacks, name a card. Defending player may reveal his or her hand and show you that the named card isn't there. If that player doesn't, Smart Ass is unblockable this turn.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "84b26f71-9a6c-5dcb-9156-ad937a2c6f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d323f0-334f-49d1-b338-24c4b854a112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3d323f0-334f-49d1-b338-24c4b854a112.jpg?1",
             "name": "Spell Counter",
             "text": "Counter target spell.\nGotcha Whenever an opponent says \"Spell\" or \"Counter,\" you may say \"Gotcha\" If you do, return Spell Counter from your graveyard to your hand.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "796d0cc7-0a15-586f-8991-70f127c91c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdca743d-f861-4aec-b9cb-b7490dd3425a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdca743d-f861-4aec-b9cb-b7490dd3425a.jpg?1",
             "name": "Topsy Turvy",
             "text": "The phases of each player's turn are reversed. (The phases are, in reverse order, end, postcombat main, combat, precombat main, and beginning.)\nIf there are more than two players in the game, the turn order is reversed.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "f6c59f6c-e339-5b96-bd21-5165c7af6996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0464a507-20e5-42d5-8aca-12504a869f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0464a507-20e5-42d5-8aca-12504a869f21.jpg?1",
             "name": "Aesthetic Consultation",
             "text": "Name an artist. Remove the top six cards of your library from the game, then reveal cards from the top of your library until you reveal a card by the named artist. Put that card in your hand, then remove all the other cards revealed this way from the game.",
             "colours": [
@@ -1877,7 +1877,7 @@
         },
         {
             "id": "f23e7343-5497-561e-8ee7-d91028bfb4fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee7b1f-e300-411a-957d-5253300c36cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fee7b1f-e300-411a-957d-5253300c36cf.jpg?1",
             "name": "Aesthetic Consultation",
             "text": "",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "8f8877be-d091-59e9-9a80-dd286dd8d249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b41832-f549-42e3-871e-e3a03372dbba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33b41832-f549-42e3-871e-e3a03372dbba.jpg?1",
             "name": "Bad Ass",
             "text": "{1}{B}, Growl: Regenerate Bad Ass.",
             "colours": [
@@ -1946,7 +1946,7 @@
         },
         {
             "id": "adfad74d-14de-57e1-acd3-eb1b28ab5703",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee08949-7cd4-4099-a109-de041a201529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ee08949-7cd4-4099-a109-de041a201529.jpg?1",
             "name": "Bad Ass",
             "text": "",
             "colours": [
@@ -1982,7 +1982,7 @@
         },
         {
             "id": "ac49d5ac-a6f1-55c3-85b7-a50a28bc7439",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53556e90-1da6-4721-8ab4-da98de52a1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53556e90-1da6-4721-8ab4-da98de52a1a5.jpg?1",
             "name": "Bloodletter",
             "text": "When the names of three or more nonland permanents begin with the same letter, sacrifice Bloodletter. If you do, it deals 2 damage to each creature and each player.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "c998c1bf-21a3-5e30-ba60-274b81eef7e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a5b25e-c5af-417e-8675-162ab18ac2b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3a5b25e-c5af-417e-8675-162ab18ac2b1.jpg?1",
             "name": "Booster Tutor",
             "text": "Open a sealed Magic booster pack, reveal the cards, and put one of those cards into your hand. (Remove that card from your deck before beginning a new game.)",
             "colours": [
@@ -2048,7 +2048,7 @@
         },
         {
             "id": "0b0e286b-c781-51ed-9bc0-57d3fbd81192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5b9b30-4950-4c9c-9ce8-6d271bb7aa01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa5b9b30-4950-4c9c-9ce8-6d271bb7aa01.jpg?1",
             "name": "Duh",
             "text": "Destroy target creature with reminder text. (Reminder text is any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -2080,7 +2080,7 @@
         },
         {
             "id": "145d3b9d-728a-5f62-a12c-7ae850a2163c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f85f32-5bc3-46c1-82a5-7a8d8f03effb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96f85f32-5bc3-46c1-82a5-7a8d8f03effb.jpg?1",
             "name": "Enter the Dungeon",
             "text": "Players play a Magic subgame under the table starting at 5 life, using their libraries as their decks. After the subgame ends, the winner searches his or her library for two cards, puts those cards into his or her hand, then shuffles his or her library.",
             "colours": [
@@ -2112,7 +2112,7 @@
         },
         {
             "id": "0d069999-b557-5825-a7ce-d9ab49ace9ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0276e9da-73fc-4d27-bbf1-726a37f5d5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0276e9da-73fc-4d27-bbf1-726a37f5d5a0.jpg?1",
             "name": "Eye to Eye",
             "text": "You and target creature's controller have a staring contest. If you win, destroy that creature.",
             "colours": [
@@ -2144,7 +2144,7 @@
         },
         {
             "id": "ba1a92b3-9469-5537-a0cb-b2dcc1e2bad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b458a3a2-b047-4edb-a621-87aee8be3a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b458a3a2-b047-4edb-a621-87aee8be3a3c.jpg?1",
             "name": "The Fallen Apart",
             "text": "The Fallen Apart comes into play with two arms and two legs.\nWhenever damage is dealt to The Fallen Apart, remove an arm or a leg from it.\nThe Fallen Apart can't attack if it has no legs and can't block if it has no arms.",
             "colours": [
@@ -2178,7 +2178,7 @@
         },
         {
             "id": "30cf8e74-542f-55cf-9ac3-93dbf4a98ccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bc23dc-ae0e-499b-824a-7eb0e20a3282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71bc23dc-ae0e-499b-824a-7eb0e20a3282.jpg?1",
             "name": "Farewell to Arms",
             "text": "As Farewell to Arms comes into play, choose a hand attached to an opponent's arm.\nWhen the chosen hand isn't behind its owner's back, sacrifice Farewell to Arms. If you do, that player discards his or her hand . . . of cards. (The lawyers wouldn't let us do it the other way.)",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "e58eb760-9dbf-5c40-8035-fc275d6632a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b61c3a-5e76-4529-9878-603e49c82743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47b61c3a-5e76-4529-9878-603e49c82743.jpg?1",
             "name": "Farewell to Arms",
             "text": "",
             "colours": [
@@ -2244,7 +2244,7 @@
         },
         {
             "id": "bb8ccd04-58fa-59cb-a9cc-0dcfcabb3e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033e627-9c4f-4b36-adfc-1afe97174c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4033e627-9c4f-4b36-adfc-1afe97174c98.jpg?1",
             "name": "Infernal Spawn of Infernal Spawn of Evil",
             "text": "Flying, first strike, trample\nIf you say \"I'm coming, too\" as you search your library, you may pay {1}{B} and reveal Infernal Spawn of Infernal Spawn of Evil from your library to have it deal 2 damage to a player of your choice. Do this no more than once each turn.",
             "colours": [
@@ -2279,7 +2279,7 @@
         },
         {
             "id": "19fcfece-84d4-557b-af79-882a839ed42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd5a66-101d-4f88-b1ba-e2368203d408.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49dd5a66-101d-4f88-b1ba-e2368203d408.jpg?1",
             "name": "Kill! Destroy!",
             "text": "Destroy target nonblack creature.\nGotcha Whenever an opponent says \"Kill\" or \"Destroy,\" you may say \"Gotcha\" If you do, return Kill Destroy from your graveyard to your hand.",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "1ee1a3ba-3d5b-5d1d-90fd-a9fb38cc7c32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6c3e15-ecae-4719-9b00-eb088223632b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e6c3e15-ecae-4719-9b00-eb088223632b.jpg?1",
             "name": "Mother of Goons",
             "text": "Whenever a creature an opponent controls is put into a graveyard from play, sacrifice Mother of Goons unless you insult that creature.",
             "colours": [
@@ -2346,7 +2346,7 @@
         },
         {
             "id": "c6d1fec2-4c34-5649-9c9a-44c7b18f109f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead51a23-db13-4424-9191-dc992c510921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ead51a23-db13-4424-9191-dc992c510921.jpg?1",
             "name": "Necro-Impotence",
             "text": "Skip your untap step.\nAt the beginning of your upkeep, you may pay X life. If you do, untap X permanents.\nPay \u00bd life: Remove the top card of your library from the game face down. Put that card into your hand at end of turn.",
             "colours": [
@@ -2378,7 +2378,7 @@
         },
         {
             "id": "d3bf7199-c41b-5734-9e6e-da97cb765a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acfbc21-ffd7-4253-9f79-a1a3217f243a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5acfbc21-ffd7-4253-9f79-a1a3217f243a.jpg?1",
             "name": "Persecute Artist",
             "text": "Choose an artist other than Rebecca Guay. Target player reveals his or her hand and discards all nonland cards by the chosen artist.",
             "colours": [
@@ -2410,7 +2410,7 @@
         },
         {
             "id": "496e4bba-7a8b-5cbe-850e-000ece9457e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340903b7-992c-43c2-9ee5-a1d76819fccf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340903b7-992c-43c2-9ee5-a1d76819fccf.jpg?1",
             "name": "Phyrexian Librarian",
             "text": "Flying, trample\nAt the beginning of your upkeep, remove the top card of your library from the game face up and balance it on your body.\nWhen a balanced card falls or touches another balanced card, sacrifice Phyrexian Librarian.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "9ab8c558-1d79-5cf8-8af4-2834a67b1d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24f8edd-0998-4a59-b5b1-9e494626b166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e24f8edd-0998-4a59-b5b1-9e494626b166.jpg?1",
             "name": "Stop That",
             "text": "Target player discards a card.\nGotcha Whenever an opponent audibly flicks the cards in his or her hand, you may say \"Gotcha\" If you do, return Stop That from your graveyard to your hand.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "1d13662c-0644-5a9f-a627-201787f14b9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef1259-c415-46f5-be9f-dfd6cd76d2c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91ef1259-c415-46f5-be9f-dfd6cd76d2c3.jpg?1",
             "name": "Tainted Monkey",
             "text": "{T}: Choose a word. Target player puts the top card of his or her library into his or her graveyard. If that card has the chosen word in its text box, that player loses 3 life.",
             "colours": [
@@ -2511,7 +2511,7 @@
         },
         {
             "id": "32f6b2ba-fb0f-5756-acf0-d2b9d70b4f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333be977-050e-4885-b631-70fd043ebeca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/333be977-050e-4885-b631-70fd043ebeca.jpg?1",
             "name": "Vile Bile",
             "text": "Whenever a player's skin or fingernail touches Vile Bile, that player loses 2 life.",
             "colours": [
@@ -2545,7 +2545,7 @@
         },
         {
             "id": "7bf84120-1695-5d1d-b2f2-f8b46d964b1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1d16-4781-4f65-bbe8-79fad472396c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/943f1d16-4781-4f65-bbe8-79fad472396c.jpg?1",
             "name": "Wet Willie of the Damned",
             "text": "Wet Willie of the Damned deals 2\u00bd damage to target creature or player and you gain 2\u00bd life.",
             "colours": [
@@ -2577,7 +2577,7 @@
         },
         {
             "id": "0c2ae7ad-2b55-57fa-93e2-3ee03522aec5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62d1ce8-9c41-41f8-9f96-d8b6177b85a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a62d1ce8-9c41-41f8-9f96-d8b6177b85a4.jpg?1",
             "name": "When Fluffy Bunnies Attack",
             "text": "Target creature gets -X/-X until end of turn, where X is the number of times the letter of your choice appears in that creature's name.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "c2b35326-de65-5e10-8401-aa65df7ae9a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21960405-d7a4-4b10-9fde-3cb0d2456f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21960405-d7a4-4b10-9fde-3cb0d2456f07.jpg?1",
             "name": "When Fluffy Bunnies Attack",
             "text": "",
             "colours": [
@@ -2643,7 +2643,7 @@
         },
         {
             "id": "7d5f49fe-d272-512e-aaeb-a5c4a19e791b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a5e4c9-8452-4fdc-a5f0-5fd168e18050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a5e4c9-8452-4fdc-a5f0-5fd168e18050.jpg?1",
             "name": "Working Stiff",
             "text": "As Working Stiff comes into play, straighten your arms.\nWhen you bend an elbow, sacrifice Working Stiff.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "1ec478d7-5c64-5b7f-a8d0-d449d8146ac6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963fb55a-7cf6-4984-844f-afbcdb4db551.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/963fb55a-7cf6-4984-844f-afbcdb4db551.jpg?1",
             "name": "Zombie Fanboy",
             "text": "As Zombie Fanboy comes into play, choose an artist.\nWhenever a permanent by the chosen artist is put into a graveyard, put two +1/+1 counters on Zombie Fanboy.",
             "colours": [
@@ -2712,7 +2712,7 @@
         },
         {
             "id": "f6dd9fe8-41cc-586a-bc71-da987c247f0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead203-b976-46d7-81c7-86ada091a4ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1ead203-b976-46d7-81c7-86ada091a4ec.jpg?1",
             "name": "Zzzyxas's Abyss",
             "text": "At the beginning of your upkeep, destroy all nonland permanents with the first name alphabetically among nonland permanents in play.",
             "colours": [
@@ -2744,7 +2744,7 @@
         },
         {
             "id": "cc3d0c4f-0d31-5e4a-9dcf-cd6a0e0faaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13248b-5abb-4246-b639-1a8a6681a157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b13248b-5abb-4246-b639-1a8a6681a157.jpg?1",
             "name": "Assquatch",
             "text": "Each other Donkey gets +1\u00bd/+1\u00bd.\nWhenever another Donkey comes into play, untap target creature and gain control of it until end of turn. That creature gains haste until end of turn.",
             "colours": [
@@ -2778,7 +2778,7 @@
         },
         {
             "id": "f1857a68-aec8-5a33-9d2f-969151456e5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca23782-80d3-4656-afba-f8440c813253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5ca23782-80d3-4656-afba-f8440c813253.jpg?1",
             "name": "Blast from the Past",
             "text": "Madness {R}, cycling {1}{R}, kicker {2}{R}, flashback {3}{R}, buyback {4}{R}\nBlast from the Past deals 2 damage to target creature or player.\nIf the kicker cost was paid, put a 1/1 red Goblin creature token into play.",
             "colours": [
@@ -2811,7 +2811,7 @@
         },
         {
             "id": "9954df08-0479-5921-ac9d-dbe08360924c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa30bf92-5281-4b74-8d2a-dc7b0467cb0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa30bf92-5281-4b74-8d2a-dc7b0467cb0a.jpg?1",
             "name": "Blast from the Past",
             "text": "",
             "colours": [
@@ -2844,7 +2844,7 @@
         },
         {
             "id": "f193238a-07a8-53b6-8383-e30e95353891",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg?1",
             "name": "Curse of the Fire Penguin // Curse of the Fire Penguin Creature",
             "text": "Curse of the Fire Penquin consumes and confuses enchanted creature.\n-----\nCreature Penguin\nTrample\nWhen this creature is put into a graveyard from play, return Curse of the Fire Penguin from your graveyard to play.\n6/5",
             "colours": [
@@ -2878,7 +2878,7 @@
         },
         {
             "id": "4b0c2060-5ce5-563b-8b1f-50eb87da82fb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg?1",
             "name": "Curse of the Fire Penguin // Curse of the Fire Penguin Creature",
             "text": "",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "8586b7eb-8e8c-5fd6-a4d5-56c7f539e11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de905517-983d-4996-a680-3a5cf91bfe11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de905517-983d-4996-a680-3a5cf91bfe11.jpg?1",
             "name": "Deal Damage",
             "text": "Deal Damage deals 4 damage to target creature or player.\nGotcha Whenever an opponent says \"Deal\" or \"Damage,\" you may say \"Gotcha\" If you do, return Deal Damage from your graveyard to your hand.",
             "colours": [
@@ -2944,7 +2944,7 @@
         },
         {
             "id": "c51658d2-0e04-5f90-88b8-42f9fce34081",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd769b2-8823-4c1e-b92f-c1bccc0b6026.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd769b2-8823-4c1e-b92f-c1bccc0b6026.jpg?1",
             "name": "Dumb Ass",
             "text": "At the beginning of your upkeep, flip a coin. If you lose the flip, target opponent chooses whether Dumb Ass attacks this turn.",
             "colours": [
@@ -2979,7 +2979,7 @@
         },
         {
             "id": "8d957851-68b0-5e8b-b9bd-05fc922b3c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c93900-1af7-4c6b-a844-055bb7e27ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c93900-1af7-4c6b-a844-055bb7e27ddb.jpg?1",
             "name": "Face to Face",
             "text": "You and target opponent play a best two-out-of-three Rock, Paper, Scissors match. If you win, Face to Face deals 5 damage to that opponent.",
             "colours": [
@@ -3011,7 +3011,7 @@
         },
         {
             "id": "554bb8ac-7ba6-5d2e-95e3-7b983968da5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08bd24-5710-4548-8966-9c5e81744680.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c08bd24-5710-4548-8966-9c5e81744680.jpg?1",
             "name": "Frazzled Editor",
             "text": "Protection from wordy (Something is wordy if it has four or more lines of text in its text box.)",
             "colours": [
@@ -3047,7 +3047,7 @@
         },
         {
             "id": "0be4d642-c2c9-588b-9097-74a71799ca78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae110a-d76f-4433-bb1b-ccb311656af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bae110a-d76f-4433-bb1b-ccb311656af5.jpg?1",
             "name": "Frazzled Editor",
             "text": "",
             "colours": [
@@ -3083,7 +3083,7 @@
         },
         {
             "id": "983fb8de-44e1-549b-a064-2bffefee4e2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b3f29a-b3a3-4dad-94ea-28999286bccc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b3f29a-b3a3-4dad-94ea-28999286bccc.jpg?1",
             "name": "Goblin Mime",
             "text": "When you speak, sacrifice Goblin Mime.",
             "colours": [
@@ -3119,7 +3119,7 @@
         },
         {
             "id": "13942218-34d0-5aaa-87e1-56a99cfe9f26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca4db3-9ef0-4d0b-a03b-2e8437a72ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ca4db3-9ef0-4d0b-a03b-2e8437a72ba7.jpg?1",
             "name": "Goblin Mime",
             "text": "",
             "colours": [
@@ -3155,7 +3155,7 @@
         },
         {
             "id": "f99158b2-bb24-54c8-b7f8-09fed4b2cafd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219d9bf5-2145-4805-8128-eda990c97739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/219d9bf5-2145-4805-8128-eda990c97739.jpg?1",
             "name": "Goblin Secret Agent",
             "text": "First strike\nAt the beginning of your upkeep, reveal a card from your hand at random.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "d07efcc9-5d11-5ccf-926e-1d30a1374acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91848051-4c72-44be-b779-53dbb528e265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91848051-4c72-44be-b779-53dbb528e265.jpg?1",
             "name": "Goblin S.W.A.T. Team",
             "text": "Say \"Goblin S.W.A.T. Team\": Put a +1/+1 counter on Goblin S.W.A.T. Team unless an opponent swats the table within five seconds. Play this ability only once each turn.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "4b8c33aa-f928-5cea-8f75-5f0295917940",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2c83a1-b06a-4a3c-b025-f58b04caec3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2c83a1-b06a-4a3c-b025-f58b04caec3e.jpg?1",
             "name": "Mana Flair",
             "text": "Add {R} to your mana pool for each nonland permanent by the artist of your choice.",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "b0fa8f64-aca1-56d8-9d04-f6798c006545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729238ee-b3ea-4c1d-852c-2dc9a2c58356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729238ee-b3ea-4c1d-852c-2dc9a2c58356.jpg?1",
             "name": "Mons's Goblin Waiters",
             "text": "Sacrifice a creature or land: Add {HR} to your mana pool.",
             "colours": [
@@ -3293,7 +3293,7 @@
         },
         {
             "id": "a2d66ef7-36e7-5eb5-b29f-5f3290910ce6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae733007-3089-43fc-a14d-7c1919554923.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae733007-3089-43fc-a14d-7c1919554923.jpg?1",
             "name": "Mons's Goblin Waiters",
             "text": "",
             "colours": [
@@ -3329,7 +3329,7 @@
         },
         {
             "id": "70214e8f-a289-5b0e-bbbd-f24ddfb4406d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864cddb-7b2e-434c-8cb6-4e44b802add6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5864cddb-7b2e-434c-8cb6-4e44b802add6.jpg?1",
             "name": "Orcish Paratroopers",
             "text": "When Orcish Paratroopers comes into play, flip it from a height of at least one foot. Sacrifice Orcish Paratroopers unless it lands face up after turning over completely.",
             "colours": [
@@ -3364,7 +3364,7 @@
         },
         {
             "id": "17611604-e27e-5e8d-b978-fcb43b61e4bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b90711-1bf8-446c-9431-df693b8d8d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b90711-1bf8-446c-9431-df693b8d8d79.jpg?1",
             "name": "Punctuate",
             "text": "Punctuate deals damage to target creature equal to half the number of punctuation marks in that creature's text box. (The punctuation marks are  ? , ; : - ( ) / \" ' & .)",
             "colours": [
@@ -3396,7 +3396,7 @@
         },
         {
             "id": "9c7408c2-114b-59a2-8849-ee1b984c60a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af443b8c-203f-46f0-9233-60f962e5baa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af443b8c-203f-46f0-9233-60f962e5baa6.jpg?1",
             "name": "Pygmy Giant",
             "text": "{R}, {T}, Sacrifice a creature: Pygmy Giant deals X damage to target creature, where X is a number in the sacrificed creature's text box.",
             "colours": [
@@ -3430,7 +3430,7 @@
         },
         {
             "id": "04c7d285-fb9b-516b-8f06-f7a7affa1090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f65a9d6-12d8-472c-b9d4-cc2460aa58ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f65a9d6-12d8-472c-b9d4-cc2460aa58ae.jpg?1",
             "name": "Red-Hot Hottie",
             "text": "Whenever Red-Hot Hottie deals damage to a creature, put a third-degree-burn counter on that creature. It has \"At the end of each turn, sacrifice this creature unless you scream \u2018\nAaah' at the top of your lungs.\"",
             "colours": [
@@ -3464,7 +3464,7 @@
         },
         {
             "id": "8ac89a6b-fc06-51e1-b3b1-93b11ef08148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e405361f-70df-459d-9385-2210fbe7e115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e405361f-70df-459d-9385-2210fbe7e115.jpg?1",
             "name": "Rocket-Powered Turbo Slug",
             "text": "Super haste (This may attack the turn before you play it. (You may put this card into play from your hand, tapped and attacking, during your declare attackers step. If you do, you lose the game at the end of your next turn unless you pay this card's mana cost during that turn.))",
             "colours": [
@@ -3498,7 +3498,7 @@
         },
         {
             "id": "1da7da62-ea34-5984-9772-da780474bfc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbebbb-7ea4-4140-933f-186cad08697d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85cbebbb-7ea4-4140-933f-186cad08697d.jpg?1",
             "name": "Saut\u00e9",
             "text": "Saut\u00e9 deals 3\u00bd damage to target creature or player.",
             "colours": [
@@ -3530,7 +3530,7 @@
         },
         {
             "id": "dac26ae4-c0a0-5177-8a4a-9ee3a09cd1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0379c99c-94b1-4c48-b62d-7accb594ef1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0379c99c-94b1-4c48-b62d-7accb594ef1a.jpg?1",
             "name": "Six-y Beast",
             "text": "As Six-y Beast comes into play, you secretly put six or fewer +1/+1 counters on it, then an opponent guesses the number of counters. If that player guesses right, sacrifice Six-y Beast.",
             "colours": [
@@ -3564,7 +3564,7 @@
         },
         {
             "id": "6d579da2-4247-5a7a-806e-013cf129a5ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec8666-9417-49df-9261-38bfb550088d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eec8666-9417-49df-9261-38bfb550088d.jpg?1",
             "name": "Touch and Go",
             "text": "Destroy target land.\nGotcha Whenever an opponent touches his or her face, you may say \"Gotcha\" If you do, return Touch and Go from your graveyard to your hand.",
             "colours": [
@@ -3597,7 +3597,7 @@
         },
         {
             "id": "eac799a5-4307-586c-bc17-8815759967dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed3d84-b68f-4eec-95f4-3e3366cecdfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fed3d84-b68f-4eec-95f4-3e3366cecdfc.jpg?1",
             "name": "Touch and Go",
             "text": "",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "e930979d-cf3b-56e9-bc5d-668141c6f960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e731ba8c-e909-4053-84ae-0793a7319540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e731ba8c-e909-4053-84ae-0793a7319540.jpg?1",
             "name": "Yet Another Aether Vortex",
             "text": "All creatures have haste.\nPlayers play with the top card of their libraries revealed.\nNoninstant, nonsorcery cards on top of a library are in play under their owner's control in addition to being in that library.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "eaa1c01b-5fd5-5e4c-bc60-22fa3981280b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4dabd2-2d1c-44e6-80a7-67e0af9bf468.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4dabd2-2d1c-44e6-80a7-67e0af9bf468.jpg?1",
             "name": "B-I-N-G-O",
             "text": "Trample\nWhenever a player plays a spell, put a chip counter on its converted mana cost.\nB-I-N-G-O gets +9/+9 for each set of three numbers in a row with chip counters on them.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "60a40d90-f608-5af5-ac1a-d362bb69bf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac8bde-7a3e-4d14-91f4-f4325c93f6a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13ac8bde-7a3e-4d14-91f4-f4325c93f6a8.jpg?1",
             "name": "Creature Guy",
             "text": "Gotcha Whenever an opponent says \"Creature\" or \"Guy,\" you may say \"Gotcha\" If you do, return Creature Guy from your graveyard to your hand.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "63dc8842-2995-5d9d-b964-bc88eb31ebf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6301ea0-cf66-49ba-87c5-dde566ce5d01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6301ea0-cf66-49ba-87c5-dde566ce5d01.jpg?1",
             "name": "Elvish House Party",
             "text": "Elvish House Party's power and toughness are each equal to the current hour, using the twelve-hour system.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "8dde27d8-3f18-5ced-aa86-0320eae48bc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc72766-06a0-4874-92c4-9debfaa97e05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc72766-06a0-4874-92c4-9debfaa97e05.jpg?1",
             "name": "Fat Ass",
             "text": "Fat Ass gets +2/+2 and has trample as long as you're eating. (Food is in your mouth and you're chewing, licking, sucking, or swallowing it.)",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "7e662f20-688b-5c04-9cde-151e827336f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2241203c-1219-4e75-9973-7e1a44885341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2241203c-1219-4e75-9973-7e1a44885341.jpg?1",
             "name": "Form of the Squirrel",
             "text": "As Form of the Squirrel comes into play, put a 1/1 green Squirrel creature token into play. You lose the game when it leaves play.\nCreatures can't attack you.\nYou can't be the target of spells or abilities.\nYou can't play spells.",
             "colours": [
@@ -3832,7 +3832,7 @@
         },
         {
             "id": "554b089b-81f6-5b36-bf15-09ef880ab54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d42015-6cab-485f-9266-428db0b2b773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86d42015-6cab-485f-9266-428db0b2b773.jpg?1",
             "name": "Fraction Jackson",
             "text": "{G}, {T}: Return target card with a \u00bd on it from your graveyard to your hand.",
             "colours": [
@@ -3867,7 +3867,7 @@
         },
         {
             "id": "4fa66c26-64f5-5edb-bcea-4f52acc9e25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7626ff-814f-4d9f-9595-ac7fa5334d4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa7626ff-814f-4d9f-9595-ac7fa5334d4b.jpg?1",
             "name": "Gluetius Maximus",
             "text": "As Gluetius Maximus comes into play, an opponent chooses one of your fingers. (Thumbs are fingers, too.)\nWhen the chosen finger isn't touching Gluetius Maximus, sacrifice Gluetius Maximus.",
             "colours": [
@@ -3901,7 +3901,7 @@
         },
         {
             "id": "9e39ec1d-b46e-5710-966a-ede9c21b3f04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949269fa-5d90-4ed5-b148-ee06de227e99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/949269fa-5d90-4ed5-b148-ee06de227e99.jpg?1",
             "name": "Granny's Payback",
             "text": "You gain life equal to your age.",
             "colours": [
@@ -3933,7 +3933,7 @@
         },
         {
             "id": "5dea3392-4565-5205-a819-5f4a89535cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92ab617-2b06-4030-a15b-5a6db3e5b1fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b92ab617-2b06-4030-a15b-5a6db3e5b1fb.jpg?1",
             "name": "Graphic Violence",
             "text": "All creatures by the artist of your choice get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -3965,7 +3965,7 @@
         },
         {
             "id": "b5c0b902-aee5-5c93-9094-5d173f6ce40a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8100f78-0dd1-4750-8a8a-d4fda30d8432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8100f78-0dd1-4750-8a8a-d4fda30d8432.jpg?1",
             "name": "Keeper of the Sacred Word",
             "text": "As Keeper of the Sacred Word comes into play, choose a word.\nWhenever an opponent says the chosen word, Keeper of the Sacred Word gets +3/+3 until end of turn.",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "815303cb-a016-5e46-ab2e-8d0c65f19a36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c5b9d-ee0a-4d36-a099-00483882fb24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2c5b9d-ee0a-4d36-a099-00483882fb24.jpg?1",
             "name": "Keeper of the Sacred Word",
             "text": "",
             "colours": [
@@ -4037,7 +4037,7 @@
         },
         {
             "id": "d80e6345-3a46-5e60-b455-218b0376cf22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a457d88-268c-4be0-bfd7-e57dd1ac364c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a457d88-268c-4be0-bfd7-e57dd1ac364c.jpg?1",
             "name": "Land Aid '04",
             "text": "Search your library for a basic land card, put that card into play tapped, then shuffle your library. If you sang a song the whole time you were searching and shuffling, you may untap that land.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "aec9aca7-ae93-5d6a-9070-4f6829af218c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e8440d-fce1-4a02-8029-f20a7617ae4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e8440d-fce1-4a02-8029-f20a7617ae4f.jpg?1",
             "name": "Laughing Hyena",
             "text": "Gotcha Whenever an opponent laughs, you may say \"Gotcha\" If you do, return Laughing Hyena from your graveyard to your hand.",
             "colours": [
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "f3567523-c62d-5903-aee8-7bdfcfc5d993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0712ff-c689-42fa-9384-f36d1f75c1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0712ff-c689-42fa-9384-f36d1f75c1dd.jpg?1",
             "name": "Laughing Hyena",
             "text": "",
             "colours": [
@@ -4139,7 +4139,7 @@
         },
         {
             "id": "c19500d4-f826-560f-bc0e-54736000bbf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7c17f-b5fc-4c58-945b-4972bce4614e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39a7c17f-b5fc-4c58-945b-4972bce4614e.jpg?1",
             "name": "Monkey Monkey Monkey",
             "text": "As Monkey Monkey Monkey comes into play, choose a letter.\nMonkey Monkey Monkey gets +1/+1 for each nonland permanent whose name begins with the chosen letter.",
             "colours": [
@@ -4174,7 +4174,7 @@
         },
         {
             "id": "03b10384-1d5a-5d9f-8894-71b2e90b668b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08588205-11d8-4f0c-9ed0-e9b5ed66de4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08588205-11d8-4f0c-9ed0-e9b5ed66de4b.jpg?1",
             "name": "Monkey Monkey Monkey",
             "text": "",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "28f686f8-2d71-50f4-97af-291e80bff8d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8f650-9e47-4649-a8e2-8c6ff4e72d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb8f650-9e47-4649-a8e2-8c6ff4e72d9e.jpg?1",
             "name": "Name Dropping",
             "text": "Gotcha Whenever an opponent says a word that's in the name of a card in your graveyard, you may say \"Gotcha\" If you do, return that card to your hand.",
             "colours": [
@@ -4241,7 +4241,7 @@
         },
         {
             "id": "9d36443d-3ee5-598d-9b12-8cce6eafe6cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ce51c4-16ea-48e8-a976-402b15450b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ce51c4-16ea-48e8-a976-402b15450b88.jpg?1",
             "name": "Old Fogey",
             "text": "Phasing, cumulative upkeep {1}, echo, fading 3, bands with other Dinosaurs, protection from Homarids, snow-covered plainswalk, flanking, rampage 2",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "17ad0580-e193-5bf1-9df1-1db70c3532c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac29717c-c586-4adb-94a3-f41096cce110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac29717c-c586-4adb-94a3-f41096cce110.jpg?1",
             "name": "Old Fogey",
             "text": "",
             "colours": [
@@ -4311,7 +4311,7 @@
         },
         {
             "id": "5c7be4e4-0955-5318-92eb-aa7e912e1739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f3f52-cb9b-4b2a-bb02-6175897ae76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1f3f52-cb9b-4b2a-bb02-6175897ae76e.jpg?1",
             "name": "Our Market Research Shows That Players Like Really Long Card Names So We Made this Card to Have the Absolute Longest Card Name Ever Elemental",
             "text": "Art rampage 2 (Whenever this becomes blocked by a creature, it gets +2/+2 for each creature in the blocker's art beyond the first.)",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "28d66e76-f2e5-5d35-9b50-856cb1f91f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7c0b-8104-47c9-9fb2-6cb50259fae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98fa7c0b-8104-47c9-9fb2-6cb50259fae2.jpg?1",
             "name": "Remodel",
             "text": "If you control two or more green permanents that share an artist, you may play Remodel without paying its mana cost.\nRemove target artifact from the game.",
             "colours": [
@@ -4377,7 +4377,7 @@
         },
         {
             "id": "7b490f42-d2ac-54d8-bdce-d303860b728d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa1912-cced-491a-867d-7f21acaf1e3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73fa1912-cced-491a-867d-7f21acaf1e3b.jpg?1",
             "name": "Shoe Tree",
             "text": "Shoe Tree comes into play with up to two shoe counters on it. Use your shoes as counters.\nShoe Tree gets +1/+1 for each shoe counter on it.",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "17d43be4-2c93-566d-8682-a48cf07dfb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c08e26f-70c6-481e-b68b-3fad145a07e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c08e26f-70c6-481e-b68b-3fad145a07e7.jpg?1",
             "name": "Shoe Tree",
             "text": "",
             "colours": [
@@ -4447,7 +4447,7 @@
         },
         {
             "id": "d251d501-54af-5760-8354-2ec1bbe7a58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8512b3c-9a44-4c15-8217-0f13898846cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8512b3c-9a44-4c15-8217-0f13898846cd.jpg?1",
             "name": "Side to Side",
             "text": "You and target opponent arm-wrestle. If you win, put a 3/3 green Ape creature token into play.",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "a68f090a-346a-5fbd-b6bd-e92b5cbe6c47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a2e16-f729-44ec-969f-d7011c623907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77a2e16-f729-44ec-969f-d7011c623907.jpg?1",
             "name": "S.N.O.T.",
             "text": "As S.N.O.T. comes into play, you may stick it onto another creature named S.N.O.T. in play. If you do, all those creatures form a single creature.\nS.N.O.T.'s power and toughness are equal to the square of the number of S.N.O.T.s stuck together. (One is a 1/1, two are a 4/4, three are a 9/9, and four are a 16/16.)",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "9363f07d-c6ea-5b72-994b-1a17886e73fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1768bb4-1626-47c8-a96f-374895c816e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1768bb4-1626-47c8-a96f-374895c816e3.jpg?1",
             "name": "Stone-Cold Basilisk",
             "text": "Whenever Stone-Cold Basilisk blocks or becomes blocked by a creature with fewer letters in its name, destroy that creature at end of combat. (Punctuation and spaces aren't letters.)\nWhenever an opponent reads Stone-Cold Basilisk, that player is turned to stone until end of turn. Stoned players can't attack, block, or play spells or abilities.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "bfabaf8a-9752-56d1-aa8e-06fed5992f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb07d9b-947d-475f-b4fd-2590b95a7f91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfb07d9b-947d-475f-b4fd-2590b95a7f91.jpg?1",
             "name": "Supersize",
             "text": "Target creature gets +3\u00bd/+3\u00bd until end of turn.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "5d4c2950-a099-5f15-8707-a697920fd127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9480a100-19a0-4964-b5d0-27ff9987497e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9480a100-19a0-4964-b5d0-27ff9987497e.jpg?1",
             "name": "Symbol Status",
             "text": "Put a 1/1 colorless Expansion-Symbol creature token into play for each different expansion symbol among permanents you control.",
             "colours": [
@@ -4611,7 +4611,7 @@
         },
         {
             "id": "0aaddebf-a1e4-5479-8bd3-d7bf45775719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6d8520-0a7c-489c-8ae9-aed07c7df6df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6d8520-0a7c-489c-8ae9-aed07c7df6df.jpg?1",
             "name": "Uktabi Kong",
             "text": "Trample\nWhen Uktabi Kong comes into play, destroy all artifacts.\nTap two untapped Apes you control: Put a 1/1 green Ape creature token into play.",
             "colours": [
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "6869d699-5f2b-5a41-886c-4e74b52ca763",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f2c8f5-8e11-4639-b7de-00e4a2cbabee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f2c8f5-8e11-4639-b7de-00e4a2cbabee.jpg?1",
             "name": "\"Ach! Hans, Run!\"",
             "text": "At the beginning of your upkeep, you may say \"Ach Hans, run It's the . . .\" and name a creature card. If you do, search your library for the named card, put it into play, then shuffle your library. That creature has haste. Remove it from the game at end of turn.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "78983557-74fa-5d93-aeef-a2fc779fc555",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf33d6-e00d-4d60-9c7f-c56c3b1f84c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbbf33d6-e00d-4d60-9c7f-c56c3b1f84c0.jpg?1",
             "name": "Ass Whuppin'",
             "text": "Destroy target silver-bordered permanent in any game you can see from your seat.",
             "colours": [
@@ -4713,7 +4713,7 @@
         },
         {
             "id": "ad3415fb-aef6-572e-b411-241cccffba10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c86f1b5-d95d-4f44-8078-4572101997b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c86f1b5-d95d-4f44-8078-4572101997b4.jpg?1",
             "name": "Meddling Kids",
             "text": "As Meddling Kids comes into play, choose a word with four or more letters.\nNonland cards with the chosen word in their text box can't be played.",
             "colours": [
@@ -4750,7 +4750,7 @@
         },
         {
             "id": "bad12d87-1010-5d75-a69a-5e73a2b80923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09274a32-c764-4239-bab0-675ddcb57c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09274a32-c764-4239-bab0-675ddcb57c13.jpg?1",
             "name": "Rare-B-Gone",
             "text": "Each player sacrifices all rare permanents, then reveals his or her hand and discards all rare cards.",
             "colours": [
@@ -4784,7 +4784,7 @@
         },
         {
             "id": "0e0cfbbd-51d0-5490-b74e-a84a7d219233",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "Who\no\nXo\nW\nInstant\nTarget player gains X life.\n-----\nWhat\no2o\nR\nInstant\nDestroy target artifact.\n-----\nWhen\no2o\nU\nInstant\nCounter target creature spell.\n-----\nWhere\no3o\nB\nInstant\nDestroy target land.\n-----\nWhy\no1o\nG\nInstant\nDestroy target enchantment.",
             "colours": [
@@ -4820,7 +4820,7 @@
         },
         {
             "id": "57e1525f-e346-599d-915d-c4c754688859",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4856,7 +4856,7 @@
         },
         {
             "id": "56b368a2-e1db-5aa6-ad4c-c034b9b52294",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4892,7 +4892,7 @@
         },
         {
             "id": "26e6e262-4217-50f6-941a-029ec09776c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "64cffe98-fd90-5f01-a600-5a5c82d61508",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8987644d-5a31-4a4e-9a8a-3d6260ed0fd6.jpg?1",
             "name": "Who // What // When // Where // Why",
             "text": "",
             "colours": [
@@ -4964,7 +4964,7 @@
         },
         {
             "id": "64c50f5b-49a7-55ef-85e7-791182d08d98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fe1662-7927-4909-8d25-6924e6fc27eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77fe1662-7927-4909-8d25-6924e6fc27eb.jpg?1",
             "name": "Gleemax",
             "text": "You choose all targets for all spells and abilities.",
             "colours": [],
@@ -4995,7 +4995,7 @@
         },
         {
             "id": "ab7ef8c2-d943-5ccd-bd40-cf7233e747bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2b9db1-c091-4ccc-b7b6-061de7132a18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a2b9db1-c091-4ccc-b7b6-061de7132a18.jpg?1",
             "name": "Gleemax",
             "text": "",
             "colours": [],
@@ -5026,7 +5026,7 @@
         },
         {
             "id": "6bbcf1ee-80c1-5450-9fd3-66b3796516be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ed7580-1b92-446b-b074-99517116fb6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ed7580-1b92-446b-b074-99517116fb6a.jpg?1",
             "name": "Letter Bomb",
             "text": "When Letter Bomb comes into play, sign it and shuffle it into target player's library. That player reveals each card he or she draws until Letter Bomb is drawn. When that player draws Letter Bomb, it deals 19\u00bd damage to him or her.",
             "colours": [],
@@ -5055,7 +5055,7 @@
         },
         {
             "id": "f288f1bb-8219-539e-9f5d-5b78fa7bdaaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cec1cd-c122-4508-a302-517f174a2b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2cec1cd-c122-4508-a302-517f174a2b3c.jpg?1",
             "name": "Letter Bomb",
             "text": "",
             "colours": [],
@@ -5084,7 +5084,7 @@
         },
         {
             "id": "72e71ac7-a2cb-51b1-a269-33db181c7458",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd58d98d-9597-4d5a-be06-6747a5ba8406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd58d98d-9597-4d5a-be06-6747a5ba8406.jpg?1",
             "name": "Mana Screw",
             "text": "{1}: Flip a coin. If you win the flip, add {2} to your mana pool. Play this ability only any time you could play an instant.",
             "colours": [],
@@ -5113,7 +5113,7 @@
         },
         {
             "id": "d6dbcfbf-49bb-5127-b034-b35aa3366d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebad46e-a069-49d4-9bb3-1a07434bc61d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ebad46e-a069-49d4-9bb3-1a07434bc61d.jpg?1",
             "name": "Mana Screw",
             "text": "",
             "colours": [],
@@ -5142,7 +5142,7 @@
         },
         {
             "id": "efd0c48a-9b80-57a5-9cfb-d8b1d83a9124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8241a53-8b88-474e-a46c-44b3d1f3b0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8241a53-8b88-474e-a46c-44b3d1f3b0df.jpg?1",
             "name": "Mox Lotus",
             "text": "{T}: Add {\u221e} to your mana pool.\n{100}: Add one mana of any color to your mana pool.\nYou don't lose life due to mana burn.",
             "colours": [],
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "eefeb967-3d6e-5f94-b0d4-fb64131390f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7f1b-ef9d-4fb4-93e4-d03702375d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afcb7f1b-ef9d-4fb4-93e4-d03702375d0c.jpg?1",
             "name": "Mox Lotus",
             "text": "",
             "colours": [],
@@ -5200,7 +5200,7 @@
         },
         {
             "id": "c4cb342f-6313-5f5c-9b02-33a2d04225a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56ccbd2-c17d-4625-bc11-181d36a84936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56ccbd2-c17d-4625-bc11-181d36a84936.jpg?1",
             "name": "My First Tome",
             "text": "{1}, {T}: Say the flavor text on a card in your hand. Target opponent guesses that card's name. You may reveal that card. If you do and your opponent guessed wrong, draw a card.",
             "colours": [],
@@ -5229,7 +5229,7 @@
         },
         {
             "id": "159f3c3d-4d3a-577b-880b-e6605ba5c466",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334316ea-f0a0-4616-9aed-4bed3b9cef60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/334316ea-f0a0-4616-9aed-4bed3b9cef60.jpg?1",
             "name": "My First Tome",
             "text": "",
             "colours": [],
@@ -5258,7 +5258,7 @@
         },
         {
             "id": "f2c70238-fbee-5ae3-8e76-03c0ae7c6358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5695a3e9-e30f-4569-ae0f-a395230f653c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5695a3e9-e30f-4569-ae0f-a395230f653c.jpg?1",
             "name": "Pointy Finger of Doom",
             "text": "{3}, {T}: Spin Pointy Finger of Doom in the middle of the table so that it rotates completely at least once, then destroy the closest permanent the finger points to.",
             "colours": [],
@@ -5286,7 +5286,7 @@
         },
         {
             "id": "65f95291-f457-5f81-bd1a-48037f58b1a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe7ff52-aa0e-4a97-8a36-b67518a020d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe7ff52-aa0e-4a97-8a36-b67518a020d7.jpg?1",
             "name": "Rod of Spanking",
             "text": "{2}, {T}: Rod of Spanking deals 1 damage to target player. Then untap Rod of Spanking unless that player says \"Thank you, sir. May I have another?\"",
             "colours": [],
@@ -5314,7 +5314,7 @@
         },
         {
             "id": "e73e32af-f050-5548-ad84-09aa916723a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b5f1eb-172b-40e5-92dd-ff1f5889001f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b5f1eb-172b-40e5-92dd-ff1f5889001f.jpg?1",
             "name": "Time Machine",
             "text": "{T}: Remove Time Machine and target nontoken creature you own from the game. Return both cards to play at the beginning of your upkeep on your turn X of the next game you play with the same opponent, where X is the removed creature's converted mana cost.",
             "colours": [],
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "2bab65ff-98f7-59e3-b3d5-52c8c135e4f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583f4691-d3cb-41f0-b718-75d022d81ef1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583f4691-d3cb-41f0-b718-75d022d81ef1.jpg?1",
             "name": "Time Machine",
             "text": "",
             "colours": [],
@@ -5372,7 +5372,7 @@
         },
         {
             "id": "97c25505-4bb9-53eb-b503-28243ad5a68b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046cd853-0cde-4d44-9111-962d6670710b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/046cd853-0cde-4d44-9111-962d6670710b.jpg?1",
             "name": "Togglodyte",
             "text": "Togglodyte comes into play turned on.\nWhenever a player plays a spell, toggle Togglodyte's ON/OFF switch.\nAs long as Togglodyte is turned off, it can't attack or block, and all damage it would deal is prevented.",
             "colours": [],
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "ef0afc95-9a48-5844-af20-84f575d55bbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f000911c-5a4a-4498-bb69-6f6e13f45447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f000911c-5a4a-4498-bb69-6f6e13f45447.jpg?1",
             "name": "Toy Boat",
             "text": "Cumulative upkeep\u2014\nSay \"Toy Boat\" quickly. (At the beginning of your upkeep, put an age counter on Toy Boat, then sacrifice it unless you say \"Toy Boat\" once for each age counter on it\u2014without pausing between or fumbling it.)",
             "colours": [],
@@ -5434,7 +5434,7 @@
         },
         {
             "id": "a329e1d6-0928-5448-b141-0a7829db59b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17722a-3509-45ac-ae5c-c230482c69e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e17722a-3509-45ac-ae5c-c230482c69e4.jpg?1",
             "name": "Urza's Hot Tub",
             "text": "{2}, Discard a card: Search your library for a card that shares a complete word in its name with the discarded card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -5462,7 +5462,7 @@
         },
         {
             "id": "f0c4fd7e-2bbd-5f11-ac15-15df682746c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ffee-28ec-4aa4-8433-a009273a4ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3002ffee-28ec-4aa4-8433-a009273a4ada.jpg?1",
             "name": "Water Gun Balloon Game",
             "text": "As Water Gun Balloon Game comes into play, each player puts a pop counter on a 0.\nWhenever a player plays a spell, move that player's pop counter up 1.\nWhenever a player's pop counter hits 5, that player puts a 5/5 pink Giant Teddy Bear creature token into play and resets all pop counters to 0.",
             "colours": [],
@@ -5490,7 +5490,7 @@
         },
         {
             "id": "f607394f-c428-5f9e-93a3-d02a9c164860",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1be145-cf42-4a9a-8d0a-d7174d96834e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1be145-cf42-4a9a-8d0a-d7174d96834e.jpg?1",
             "name": "World-Bottling Kit",
             "text": "{5}, Sacrifice World-Bottling Kit: Choose a Magic set. Remove from the game all permanents with that set's expansion symbol except for basic lands.",
             "colours": [],
@@ -5518,7 +5518,7 @@
         },
         {
             "id": "edd0b105-e224-5d40-a242-9a8cad9b347b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fe2e7-bd1b-4c11-a098-6c8abfbdf06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726fe2e7-bd1b-4c11-a098-6c8abfbdf06e.jpg?1",
             "name": "City of Ass",
             "text": "City of Ass comes into play tapped.\n{T}: Add one and one-half mana of any one color to your mana pool.",
             "colours": [],
@@ -5546,7 +5546,7 @@
         },
         {
             "id": "6f93a382-f512-5ff5-97a5-303eda1d253f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdc6a9-0a44-43ef-b065-02ef5d6110dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bfdc6a9-0a44-43ef-b065-02ef5d6110dc.jpg?1",
             "name": "R&D's Secret Lair",
             "text": "Play cards as written. Ignore all errata.\n{T}: Add {1} to your mana pool.",
             "colours": [],
@@ -5576,7 +5576,7 @@
         },
         {
             "id": "f97e44ef-a6bb-54cb-89ea-06250cabe74e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dba1c-a702-43c0-8fca-e47bbad4a00f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d7dba1c-a702-43c0-8fca-e47bbad4a00f.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -5610,7 +5610,7 @@
         },
         {
             "id": "09d44003-974a-577a-8f9b-b3a67645340e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4eaecf-dd4c-45ab-9b50-2abe987d35d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c4eaecf-dd4c-45ab-9b50-2abe987d35d4.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -5644,7 +5644,7 @@
         },
         {
             "id": "a7604ebc-44fd-5d44-9046-14ae16bea8c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8365ab45-6d78-47ad-a6ed-282069b0fabc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8365ab45-6d78-47ad-a6ed-282069b0fabc.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "a5ab2362-b495-50ec-a45c-5b221fe8ca0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42232ea6-e31d-46a6-9f94-b2ad2416d79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42232ea6-e31d-46a6-9f94-b2ad2416d79b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -5712,7 +5712,7 @@
         },
         {
             "id": "afc52162-e37d-5645-ac1b-06b814d61c48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e71532-3f79-4fec-974f-b0e85c7fe701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19e71532-3f79-4fec-974f-b0e85c7fe701.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -5746,7 +5746,7 @@
         },
         {
             "id": "bcab8547-3756-5c5f-a121-06a02620660e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45af7f55-9a69-43dd-969f-65411711b13e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45af7f55-9a69-43dd-969f-65411711b13e.jpg?1",
             "name": "Super Secret Tech",
             "text": "All premium spells cost {1} less to play.\nAll premium creatures get +1/+1.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/USG.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/USG.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "0877107a-de72-5913-94be-921cf3d06e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d1839-7180-4b4c-8ddb-7df24573f740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe7d1839-7180-4b4c-8ddb-7df24573f740.jpg?1",
             "name": "Absolute Grace",
             "text": "All creatures gain protection from black.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "a3e5dfab-d380-5f5c-9187-21e48478f4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d1f05b-f165-47c7-8a78-3b60ee3298ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59d1f05b-f165-47c7-8a78-3b60ee3298ca.jpg?1",
             "name": "Absolute Law",
             "text": "All creatures gain protection from red.",
             "colours": [
@@ -66,7 +66,7 @@
         },
         {
             "id": "6554e6ed-2935-508f-9ef8-819f9504ee7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bf221-a1bf-41ab-9b7e-e5a64c385642.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/907bf221-a1bf-41ab-9b7e-e5a64c385642.jpg?1",
             "name": "Angelic Chorus",
             "text": "Whenever a creature comes into play under your control, gain life equal to that creature's toughness.",
             "colours": [
@@ -97,7 +97,7 @@
         },
         {
             "id": "78e7ede1-4bca-54a0-b7a3-d4d92e71fe8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a4378-8b14-484c-b285-09cc4c4e1b3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f50a4378-8b14-484c-b285-09cc4c4e1b3c.jpg?1",
             "name": "Angelic Page",
             "text": "Flying\noc\nT: Target attacking or blocking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -131,7 +131,7 @@
         },
         {
             "id": "15225852-6e33-50d2-9680-076be2fddc3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d454961-1ab3-442b-935d-68c25b56aea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d454961-1ab3-442b-935d-68c25b56aea0.jpg?1",
             "name": "Brilliant Halo",
             "text": "Enchanted creature gets +1/+2.\nWhen Brilliant Halo is put into a graveyard from play, return Brilliant Halo to owner's hand.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "c2c7753d-377f-5118-9fec-e2769650c9cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294d21dc-5c76-4449-936f-9b7541d37c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/294d21dc-5c76-4449-936f-9b7541d37c86.jpg?1",
             "name": "Catastrophe",
             "text": "Destroy all lands or all creatures. Creatures destroyed this way cannot regenerate this turn.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "319db9c4-68ce-57af-a423-8b86f67475a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cdb977-7d5b-4050-bb01-181f6b363de7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cdb977-7d5b-4050-bb01-181f6b363de7.jpg?1",
             "name": "Clear",
             "text": "Destroy target enchantment.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -226,7 +226,7 @@
         },
         {
             "id": "3f93aa82-6782-56d4-b0e9-eafdf47e564f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7923b-eb1c-49ce-8250-a1ea6efbb56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80b7923b-eb1c-49ce-8250-a1ea6efbb56e.jpg?1",
             "name": "Congregate",
             "text": "Target player gains 2 life for each creature in play.",
             "colours": [
@@ -257,7 +257,7 @@
         },
         {
             "id": "0b318ff3-6f2d-5546-b267-41324a30f1b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd76db0-1a67-4965-81a5-1d8d86b63971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdd76db0-1a67-4965-81a5-1d8d86b63971.jpg?1",
             "name": "Defensive Formation",
             "text": "Instead of the attacking player, you choose how creatures attacking you deal combat damage.",
             "colours": [
@@ -288,7 +288,7 @@
         },
         {
             "id": "fe4c8619-363e-53d2-8192-7ba15250ddd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa36d2-0a60-40a5-a182-a63e1e65b2bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83fa36d2-0a60-40a5-a182-a63e1e65b2bd.jpg?1",
             "name": "Disciple of Grace",
             "text": "Protection from black\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -322,7 +322,7 @@
         },
         {
             "id": "4938ae25-c4ae-5fd7-9dbc-f161d28b8273",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5c8701-a294-4474-9747-129f972cfb18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a5c8701-a294-4474-9747-129f972cfb18.jpg?1",
             "name": "Disciple of Law",
             "text": "Protection from red\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -356,7 +356,7 @@
         },
         {
             "id": "7818642c-3c98-58ce-8f6a-891ad9e6ef31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da67d77-1cbd-4f0e-a109-87fb4c84bcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da67d77-1cbd-4f0e-a109-87fb4c84bcca.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -387,7 +387,7 @@
         },
         {
             "id": "6b084b10-1b73-507d-9780-4605918958d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ee95c-3ce8-4b8c-a1a7-1caa5b8a3cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d7ee95c-3ce8-4b8c-a1a7-1caa5b8a3cc9.jpg?1",
             "name": "Elite Archers",
             "text": "oc\nT: Elite Archers deals 3 damage to target attacking or blocking creature.",
             "colours": [
@@ -422,7 +422,7 @@
         },
         {
             "id": "2def9013-b377-5074-b998-de5b0902c2df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51ff6a-ba1b-4015-8d0b-df1a1bb5a0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51ff6a-ba1b-4015-8d0b-df1a1bb5a0c1.jpg?1",
             "name": "Faith Healer",
             "text": "Sacrifice an enchantment: Gain life equal to the sacrificed enchantment's total casting cost.",
             "colours": [
@@ -456,7 +456,7 @@
         },
         {
             "id": "c1a4fea5-67e6-5618-b3fe-c2798584f192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f867c5-0727-4408-b479-b81518daa0ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f867c5-0727-4408-b479-b81518daa0ec.jpg?1",
             "name": "Glorious Anthem",
             "text": "All creatures you control get +1/+1.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "968c5f2a-6ece-5edd-86d3-a73b10c6d6be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89146f6a-583f-4ed1-8b43-75e9a55892c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89146f6a-583f-4ed1-8b43-75e9a55892c6.jpg?1",
             "name": "Healing Salve",
             "text": "Choose one Target player gains 3 life; or prevent up to 3 damage to a creature or player.",
             "colours": [
@@ -518,7 +518,7 @@
         },
         {
             "id": "92f0964a-56b3-57be-b64f-eb18be6fa708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a2b882-d616-495e-99f6-196031235f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a2b882-d616-495e-99f6-196031235f93.jpg?1",
             "name": "Herald of Serra",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nAttacking does not cause Herald of Serra to tap.",
             "colours": [
@@ -551,7 +551,7 @@
         },
         {
             "id": "9c685cbb-7c94-58d1-b7d5-3413a3970561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01383c7f-685f-4e77-a143-8418fe1fe436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01383c7f-685f-4e77-a143-8418fe1fe436.jpg?1",
             "name": "Humble",
             "text": "Target creature loses all abilities and is a 0/1 creature until end of turn.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "cfd49ee3-f257-5f32-af6f-a2b7b1217487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a5c67-f76a-4021-959e-3e084a06b80f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f2a5c67-f76a-4021-959e-3e084a06b80f.jpg?1",
             "name": "Intrepid Hero",
             "text": "oc\nT: Destroy target creature with power 4 or greater.",
             "colours": [
@@ -616,7 +616,7 @@
         },
         {
             "id": "ab3035d2-bd8e-5c61-8f11-9d3e069d1a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285a867b-f82e-49cb-a59c-31a25129baf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/285a867b-f82e-49cb-a59c-31a25129baf9.jpg?1",
             "name": "Monk Idealist",
             "text": "When Monk Idealist comes into play, return target enchantment card from your graveyard to your hand.",
             "colours": [
@@ -651,7 +651,7 @@
         },
         {
             "id": "f81d6df2-afe7-50de-ac49-397aca7ea3db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7fe9f1-f3c0-43e4-aa30-d0bdab4ae94d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7fe9f1-f3c0-43e4-aa30-d0bdab4ae94d.jpg?1",
             "name": "Monk Realist",
             "text": "When Monk Realist comes into play, destroy target enchantment.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "8203a88f-d8dd-5819-a336-1b3d1027c3a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839b4c10-f68f-4321-82ee-5ec257f63866.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839b4c10-f68f-4321-82ee-5ec257f63866.jpg?1",
             "name": "Opal Acrolith",
             "text": "Whenever one of your opponents successfully casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 creature that counts as a Guardian.\no0: Opal Acrolith becomes an enchantment.",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "900a8aef-53c3-5d5a-b95a-f7d3323f6a87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75fca33-fa06-4385-866c-5d463ae6aaf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a75fca33-fa06-4385-866c-5d463ae6aaf6.jpg?1",
             "name": "Opal Archangel",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Archangel is an enchantment, Opal Archangel becomes a 5/5 creature with flying that counts as an Angel. Attacking does not cause Opal Archangel to tap.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "1dab404f-c664-533d-a026-b498cc163fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8a2e24-c959-40a2-883d-c0114589cfe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8a2e24-c959-40a2-883d-c0114589cfe7.jpg?1",
             "name": "Opal Caryatid",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Caryatid is an enchantment, Opal Caryatid becomes a 2/2 creature that counts as a Soldier.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "a0777214-14a6-5185-bc73-6dfdc54cb65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a67943-8f07-445b-a84c-893879dae7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8a67943-8f07-445b-a84c-893879dae7ca.jpg?1",
             "name": "Opal Gargoyle",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Gargoyle is an enchantment, Opal Gargoyle becomes a 2/2 creature with flying that counts as a Gargoyle.",
             "colours": [
@@ -810,7 +810,7 @@
         },
         {
             "id": "437bde50-69ca-57ee-9b0c-6b85e5cb1ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379f1f01-88c6-4cc2-9049-078aa6980582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/379f1f01-88c6-4cc2-9049-078aa6980582.jpg?1",
             "name": "Opal Titan",
             "text": "When one of your opponents successfully casts a creature spell, if Opal Titan is an enchantment, Opal Titan becomes a 4/4 creature with protection from each of that spell's colors and that counts as a Giant.",
             "colours": [
@@ -841,7 +841,7 @@
         },
         {
             "id": "a56a316f-6d97-5185-9f24-260453e70ac3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81638f-a74c-47fc-825a-ae778c524f66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc81638f-a74c-47fc-825a-ae778c524f66.jpg?1",
             "name": "Pacifism",
             "text": "Enchanted creature cannot attack or block.",
             "colours": [
@@ -874,7 +874,7 @@
         },
         {
             "id": "a5ec6088-49cf-5e38-92bf-87e8eb2176dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0447f9e1-792b-4200-9ef3-7cd95c326b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/0447f9e1-792b-4200-9ef3-7cd95c326b88.jpg?1",
             "name": "Pariah",
             "text": "Redirect to enchanted creature all damage dealt to you.",
             "colours": [
@@ -907,7 +907,7 @@
         },
         {
             "id": "29e29f67-a7c1-56cc-aa42-90db57b1b147",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7a2719-7910-4601-be88-7b3c249199d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af7a2719-7910-4601-be88-7b3c249199d3.jpg?1",
             "name": "Path of Peace",
             "text": "Destroy target creature. That creature's owner gains 4 life.",
             "colours": [
@@ -938,7 +938,7 @@
         },
         {
             "id": "fa3130bb-eadb-57da-a3cb-b9687f610545",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62a5287-25ec-4e13-9e39-1c87a4052c4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d62a5287-25ec-4e13-9e39-1c87a4052c4d.jpg?1",
             "name": "Pegasus Charger",
             "text": "Flying, first strike",
             "colours": [
@@ -971,7 +971,7 @@
         },
         {
             "id": "1ae2d48c-2c34-5004-8116-d90de1c1539b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cacdff-aa83-4644-b2f0-ce8c89dddfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7cacdff-aa83-4644-b2f0-ce8c89dddfbf.jpg?1",
             "name": "Planar Birth",
             "text": "Put all basic lands from all graveyards into play under their owners' control, tapped.",
             "colours": [
@@ -1002,7 +1002,7 @@
         },
         {
             "id": "cd9ed8e9-3778-5e5c-907e-db5f41dbc215",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849adb29-61ad-4307-98b9-61e33aec6500.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849adb29-61ad-4307-98b9-61e33aec6500.jpg?1",
             "name": "Presence of the Master",
             "text": "Whenever a player plays an enchantment spell, counter it.",
             "colours": [
@@ -1033,7 +1033,7 @@
         },
         {
             "id": "85adb37b-23a3-5f06-aa67-9c8fffc083cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a7756d-df25-4969-96ad-b006df09788b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05a7756d-df25-4969-96ad-b006df09788b.jpg?1",
             "name": "Redeem",
             "text": "Prevent all damage to one or two creatures. (Treat further damage normally.)",
             "colours": [
@@ -1064,7 +1064,7 @@
         },
         {
             "id": "9ee9e793-286f-51ae-9adf-1ba3358a5a66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556d334e-3ac9-45b0-98d2-aff49ada0f75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/556d334e-3ac9-45b0-98d2-aff49ada0f75.jpg?1",
             "name": "Remembrance",
             "text": "Whenever a nontoken creature you control is put into a graveyard, you may search your library for a copy of that creature card. If you do, reveal the card, put it into your hand, and shuffle your library afterward.",
             "colours": [
@@ -1095,7 +1095,7 @@
         },
         {
             "id": "4f774317-47ed-569b-a3a9-8ba1efef2048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18cce33-92be-4189-9f99-cb47bd617fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e18cce33-92be-4189-9f99-cb47bd617fd2.jpg?1",
             "name": "Rune of Protection: Artifacts",
             "text": "oo\nW Prevent all damage to you from an artifact source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1126,7 +1126,7 @@
         },
         {
             "id": "7373b297-b5e8-50c1-8559-84671f299d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f69050b-c54d-43f2-8348-2801c365dc4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f69050b-c54d-43f2-8348-2801c365dc4c.jpg?1",
             "name": "Rune of Protection: Black",
             "text": "oo\nW Prevent all damage to you from a black source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "65224cc1-e06e-58cb-ace8-4448b2cc3135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4ed3a-1851-49b1-baac-fdc8c00b6b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f4ed3a-1851-49b1-baac-fdc8c00b6b71.jpg?1",
             "name": "Rune of Protection: Blue",
             "text": "oo\nW Prevent all damage to you from a blue source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "b79fe89c-87fc-5f6c-8c28-0fee8f69f389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905712b2-3177-4935-bca1-6990439b8d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905712b2-3177-4935-bca1-6990439b8d78.jpg?1",
             "name": "Rune of Protection: Green",
             "text": "oo\nW Prevent all damage to you from a green source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1219,7 +1219,7 @@
         },
         {
             "id": "30613811-490f-514a-97fd-8c05d03c9200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e874700-8002-41e7-8861-b4ce29ba6d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e874700-8002-41e7-8861-b4ce29ba6d9e.jpg?1",
             "name": "Rune of Protection: Lands",
             "text": "oo\nW Prevent all damage to you from a land source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1250,7 +1250,7 @@
         },
         {
             "id": "311b1aa7-6712-500e-95ca-96fcddd112c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2916023b-cf67-443f-9ac7-f03313f9d3b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2916023b-cf67-443f-9ac7-f03313f9d3b7.jpg?1",
             "name": "Rune of Protection: Red",
             "text": "oo\nW Prevent all damage to you from a red source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1281,7 +1281,7 @@
         },
         {
             "id": "ff1e78ba-14b9-5d48-a65f-e6f2c025cec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6408417e-aca3-43f3-9eea-fed5a402d8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6408417e-aca3-43f3-9eea-fed5a402d8ab.jpg?1",
             "name": "Rune of Protection: White",
             "text": "oo\nW Prevent all damage to you from a white source. (Treat further damage from that source normally.)\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1312,7 +1312,7 @@
         },
         {
             "id": "a1c23714-77ea-52d9-81d8-7cc9e522da60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a64b98-9002-48fe-a3e5-4449050c87e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27a64b98-9002-48fe-a3e5-4449050c87e1.jpg?1",
             "name": "Sanctum Custodian",
             "text": "oc\nT: Prevent up to 2 damage to a creature or player.",
             "colours": [
@@ -1346,7 +1346,7 @@
         },
         {
             "id": "4e4458f4-d290-5e30-8ba0-3012879d3bb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09137f-0f4c-4389-a915-0ce02c833d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d09137f-0f4c-4389-a915-0ce02c833d94.jpg?1",
             "name": "Sanctum Guardian",
             "text": "Sacrifice Sanctum Guardian: Prevent all damage to a creature or player from one source. (Treat further damage from that source normally.)",
             "colours": [
@@ -1380,7 +1380,7 @@
         },
         {
             "id": "4c9e92b1-4680-5cb2-9cc9-0a4129a934f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de20845-06b7-4542-8d61-4b97309669f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de20845-06b7-4542-8d61-4b97309669f9.jpg?1",
             "name": "Seasoned Marshal",
             "text": "Whenever Seasoned Marshal attacks, you may tap target creature.",
             "colours": [
@@ -1414,7 +1414,7 @@
         },
         {
             "id": "c50e5fb2-38a5-5793-bb0a-aafc94aa07b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b0976-78e8-4fbe-8607-2e55d8761d3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288b0976-78e8-4fbe-8607-2e55d8761d3e.jpg?1",
             "name": "Serra Avatar",
             "text": "Serra Avatar has power and toughness each equal to your life total.\nWhen Serra Avatar is put into a graveyard, shuffle Serra Avatar into owner's library.",
             "colours": [
@@ -1447,7 +1447,7 @@
         },
         {
             "id": "d4f555c4-ce8e-5d06-b4f5-fe3a378156d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b311542-599f-4d2f-a871-18d5b0b7bbe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b311542-599f-4d2f-a871-18d5b0b7bbe5.jpg?1",
             "name": "Serra Zealot",
             "text": "First strike",
             "colours": [
@@ -1481,7 +1481,7 @@
         },
         {
             "id": "486e58b0-eacd-5d62-be2c-b7e1edeb5063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145c3ebd-7a67-4606-8427-f3b91ab26b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145c3ebd-7a67-4606-8427-f3b91ab26b84.jpg?1",
             "name": "Serra's Embrace",
             "text": "Enchanted creature gets +2/+2 and gains flying. Attacking does not cause enchanted creature to tap.",
             "colours": [
@@ -1514,7 +1514,7 @@
         },
         {
             "id": "a3429529-36b4-5181-81b8-9d80bce987d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8205a-608e-4274-a32c-802a7ce52d9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b8205a-608e-4274-a32c-802a7ce52d9c.jpg?1",
             "name": "Serra's Hymn",
             "text": "During your upkeep, you may put a verse counter on Serra's Hymn.\nSacrifice Serra's Hymn: Prevent up to X damage total to any number of creatures and/or players, where X is the number of verse counters on Serra's Hymn.",
             "colours": [
@@ -1545,7 +1545,7 @@
         },
         {
             "id": "0bc4a894-51a7-5004-bc6e-0112ab8fe8e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84be3ef-a820-41e3-b66a-09303dad32dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b84be3ef-a820-41e3-b66a-09303dad32dd.jpg?1",
             "name": "Serra's Liturgy",
             "text": "During your upkeep, you may put a verse counter on Serra's Liturgy.\no\nW, Sacrifice Serra's Liturgy: Destroy up to X target artifacts and/or enchantments, where X is the number of verse counters on Serra's Liturgy.",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "560c0cb7-bb46-5c05-8ac2-bf29adbcbd05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa7158a-5c00-4969-a116-c40cefdf4591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa7158a-5c00-4969-a116-c40cefdf4591.jpg?1",
             "name": "Shimmering Barrier",
             "text": "(Walls cannot attack.)\nFirst strike\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -1609,7 +1609,7 @@
         },
         {
             "id": "e1268655-8af1-560a-89f6-ca0baa465813",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e90087-3738-40df-929b-d2f880264b55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e90087-3738-40df-929b-d2f880264b55.jpg?1",
             "name": "Silent Attendant",
             "text": "oc\nT: Gain 1 life.",
             "colours": [
@@ -1643,7 +1643,7 @@
         },
         {
             "id": "6c303455-0866-5a94-8a22-6321b91c5fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d306f-3f4e-4c21-9461-caa3daf4fc50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa8d306f-3f4e-4c21-9461-caa3daf4fc50.jpg?1",
             "name": "Songstitcher",
             "text": "o1oo\nW Target attacking creature with flying deals no combat damage this turn.",
             "colours": [
@@ -1677,7 +1677,7 @@
         },
         {
             "id": "9264da26-6a04-5967-8da8-df26321f4d2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6ef073-1c83-47a4-b19d-86fb8bed5db9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6ef073-1c83-47a4-b19d-86fb8bed5db9.jpg?1",
             "name": "Soul Sculptor",
             "text": "o1o\nW, oc\nT: Target creature becomes an enchantment and loses all abilities until a player successfully casts a creature spell.",
             "colours": [
@@ -1710,7 +1710,7 @@
         },
         {
             "id": "cdff691c-dfbc-5dbb-93cc-17b165375a99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8eb3b-3ebf-426c-8dc8-138ec9b7c671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72e8eb3b-3ebf-426c-8dc8-138ec9b7c671.jpg?1",
             "name": "Voice of Grace",
             "text": "Flying, protection from black",
             "colours": [
@@ -1743,7 +1743,7 @@
         },
         {
             "id": "77b674b3-7ced-53be-acec-da313902212a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daec52a4-02da-4bff-aff4-5247baed1326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daec52a4-02da-4bff-aff4-5247baed1326.jpg?1",
             "name": "Voice of Law",
             "text": "Flying, protection from red",
             "colours": [
@@ -1776,7 +1776,7 @@
         },
         {
             "id": "808a887b-a30c-546e-9b8b-d96ed08af690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867a33ee-0340-413a-8243-9d6bc2d944e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867a33ee-0340-413a-8243-9d6bc2d944e2.jpg?1",
             "name": "Waylay",
             "text": "Put three Knight tokens into play. Treat these tokens as 2/2 white creatures. Remove them from the game at end of turn.",
             "colours": [
@@ -1807,7 +1807,7 @@
         },
         {
             "id": "f3434b7c-8235-53bd-b14b-4bc90b781bdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908781a0-1ba4-4027-bd9d-13f9faf08686.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/908781a0-1ba4-4027-bd9d-13f9faf08686.jpg?1",
             "name": "Worship",
             "text": "Damage that would reduce your life total to less than 1 instead reduces it to 1 if you control a creature.",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "e0bc810a-7ef4-5eb0-b0a9-426234abfc30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca58c8e-9f40-4ed8-a3ed-a01fe67c600d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca58c8e-9f40-4ed8-a3ed-a01fe67c600d.jpg?1",
             "name": "Academy Researchers",
             "text": "When Academy Researchers comes into play, you may choose an enchant creature card in your hand and put that enchantment into play on Academy Researchers.",
             "colours": [
@@ -1872,7 +1872,7 @@
         },
         {
             "id": "3501d513-9a59-5c4a-b08a-b0883a802e07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c73ff-be92-41ca-93a7-76f9823adb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f8c73ff-be92-41ca-93a7-76f9823adb38.jpg?1",
             "name": "Annul",
             "text": "Counter target artifact or enchantment spell.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "82e15fcf-83ac-5759-9d59-4442112e3eb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a88e8-aab0-488a-a0b8-fa3feedbf278.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4a88e8-aab0-488a-a0b8-fa3feedbf278.jpg?1",
             "name": "Arcane Laboratory",
             "text": "Each player cannot play more than one spell each turn.",
             "colours": [
@@ -1934,7 +1934,7 @@
         },
         {
             "id": "e19c4b0e-5b73-52cc-b934-05fcf25b9160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6723528-8b2c-4beb-a465-800300faf158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6723528-8b2c-4beb-a465-800300faf158.jpg?1",
             "name": "Attunement",
             "text": "Return Attunement to owner's hand: Draw three cards, then choose and discard four cards.",
             "colours": [
@@ -1965,7 +1965,7 @@
         },
         {
             "id": "4345caef-856a-528e-a987-a74949e911dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab4cd7e-b56f-4408-a0e9-c07e040cc38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab4cd7e-b56f-4408-a0e9-c07e040cc38f.jpg?1",
             "name": "Back to Basics",
             "text": "Nonbasic lands do not untap during their controllers' untap phases.",
             "colours": [
@@ -1996,7 +1996,7 @@
         },
         {
             "id": "08eb29cb-8772-5049-a2ac-a91cd1038c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec79e35f-9e78-462d-8b71-4f044e2eff90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec79e35f-9e78-462d-8b71-4f044e2eff90.jpg?1",
             "name": "Barrin, Master Wizard",
             "text": "Barrin, Master Wizard counts as a Wizard.\no2, Sacrifice a permanent: Return target creature to owner's hand.",
             "colours": [
@@ -2032,7 +2032,7 @@
         },
         {
             "id": "7b88f854-6899-555b-aa38-d55b488d810f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bdef28-0e27-4c8d-a04c-5413519dcb4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31bdef28-0e27-4c8d-a04c-5413519dcb4e.jpg?1",
             "name": "Catalog",
             "text": "Draw two cards, then choose and discard a card.",
             "colours": [
@@ -2063,7 +2063,7 @@
         },
         {
             "id": "6601ed6d-0f66-506d-a093-d98c750f857e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54251c-5a2e-48e4-9790-a64dcc44eb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd54251c-5a2e-48e4-9790-a64dcc44eb8e.jpg?1",
             "name": "Cloak of Mists",
             "text": "Enchanted creature is unblockable.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "69edc2e8-2e4d-53c3-9fcc-21006e0f0ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cba6d4a-58d0-42d6-b49b-65c72b86007f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cba6d4a-58d0-42d6-b49b-65c72b86007f.jpg?1",
             "name": "Confiscate",
             "text": "You control enchanted permanent.",
             "colours": [
@@ -2129,7 +2129,7 @@
         },
         {
             "id": "0d601243-32e1-5b91-8b07-2df5d8397aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837d82a9-aef8-4079-a485-05ada1b66322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/837d82a9-aef8-4079-a485-05ada1b66322.jpg?1",
             "name": "Coral Merfolk",
             "text": "",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "751892b9-4b94-548c-8273-2d75678e1f76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ee9af3-d61c-4964-88a6-6e8ad6a6a29a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49ee9af3-d61c-4964-88a6-6e8ad6a6a29a.jpg?1",
             "name": "Curfew",
             "text": "Each player chooses a creature he or she controls and returns it to owner's hand.",
             "colours": [
@@ -2193,7 +2193,7 @@
         },
         {
             "id": "e5447f28-af35-59b9-9144-75af131c619e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee43681d-e0f7-422b-a363-0d630f68d363.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee43681d-e0f7-422b-a363-0d630f68d363.jpg?1",
             "name": "Disruptive Student",
             "text": "oc\nT: Counter target spell unless its caster pays an additional o1. Play this ability as an interrupt.",
             "colours": [
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "c2c06954-3427-59b0-9905-9334b922f864",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a8d857-184d-4339-88f4-261378e5bd3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93a8d857-184d-4339-88f4-261378e5bd3c.jpg?1",
             "name": "Douse",
             "text": "o1oo\nU Counter target red spell. Play this ability as an interrupt.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "cdefb4cb-26db-5189-ad28-94f9bfb06bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d0eda-91b8-48f2-a988-016bcc7ab35e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/971d0eda-91b8-48f2-a988-016bcc7ab35e.jpg?1",
             "name": "Drifting Djinn",
             "text": "Flying\nDuring your upkeep, pay o1o\nU or sacrifice Drifting Djinn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2291,7 +2291,7 @@
         },
         {
             "id": "dfa65a6d-5257-5f07-830f-7244b5aa7d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254aa8d0-f0f5-4fb2-a6ba-07453d71e229.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254aa8d0-f0f5-4fb2-a6ba-07453d71e229.jpg?1",
             "name": "Enchantment Alteration",
             "text": "Move target enchantment from one creature to another or from one land to another. (The enchantment's new target must be legal.)",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "410401a0-17d7-55c5-bd6a-49b684babb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff5770-b207-41e1-97b7-b9347c72b407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81ff5770-b207-41e1-97b7-b9347c72b407.jpg?1",
             "name": "Energy Field",
             "text": "Prevent all damage dealt to you from sources you do not control.\nWhen a card is put into your graveyard, sacrifice Energy Field.",
             "colours": [
@@ -2353,7 +2353,7 @@
         },
         {
             "id": "86a3b896-fcce-5dac-8d6e-d7c31e2587f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666efc89-b566-4b2b-a0e2-52f1dedc9e10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/666efc89-b566-4b2b-a0e2-52f1dedc9e10.jpg?1",
             "name": "Exhaustion",
             "text": "Creatures and lands target opponent controls do not untap during his or her next untap phase.",
             "colours": [
@@ -2384,7 +2384,7 @@
         },
         {
             "id": "b8829fdc-b778-5d07-8878-3ef5f14700c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade0d30-5a57-439e-95e8-5f865880031f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ade0d30-5a57-439e-95e8-5f865880031f.jpg?1",
             "name": "Fog Bank",
             "text": "(Walls cannot attack.)\nFlying\nFog Bank does not deal or receive combat damage.",
             "colours": [
@@ -2417,7 +2417,7 @@
         },
         {
             "id": "9e74408d-4424-5200-bf64-1fd6e806ad56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de3fdae-cc2c-4a14-b15b-4fe1a983dfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8de3fdae-cc2c-4a14-b15b-4fe1a983dfbf.jpg?1",
             "name": "Gilded Drake",
             "text": "Flying\nWhen Gilded Drake comes into play, exchange control of Gilded Drake for target creature one of your opponents controls or sacrifice Gilded Drake.",
             "colours": [
@@ -2450,7 +2450,7 @@
         },
         {
             "id": "94b34059-d245-53b9-a05f-4ea01dd12de1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a2acf1-dad8-4f93-a34e-891e5178a48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a2acf1-dad8-4f93-a34e-891e5178a48f.jpg?1",
             "name": "Great Whale",
             "text": "When Great Whale comes into play, untap up to seven lands.",
             "colours": [
@@ -2483,7 +2483,7 @@
         },
         {
             "id": "8644488d-9b25-5fea-b0d6-2950f0bd0bfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321888a-a450-4c15-9461-255cfaa05367.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8321888a-a450-4c15-9461-255cfaa05367.jpg?1",
             "name": "Hermetic Study",
             "text": "Enchanted creature gains \"oc\nT: This creature deals 1 damage to target creature or player.\"",
             "colours": [
@@ -2516,7 +2516,7 @@
         },
         {
             "id": "0b27990e-b7b8-541f-aaee-72ac94dd7247",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7444c-fabb-4437-8db9-a1008ea09415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68b7444c-fabb-4437-8db9-a1008ea09415.jpg?1",
             "name": "Hibernation",
             "text": "Return all green permanents to owners' hands.",
             "colours": [
@@ -2547,7 +2547,7 @@
         },
         {
             "id": "d4c423f4-6931-5d0b-ae19-9eacaca04398",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33646b-a0e3-4344-873e-6711743bc85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b33646b-a0e3-4344-873e-6711743bc85c.jpg?1",
             "name": "Horseshoe Crab",
             "text": "oo\nU Untap Horseshoe Crab.",
             "colours": [
@@ -2580,7 +2580,7 @@
         },
         {
             "id": "0b920694-8042-57c6-9eab-d3a40e736ba2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa19ecb-146e-4109-b4ef-74675b35d8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa19ecb-146e-4109-b4ef-74675b35d8c4.jpg?1",
             "name": "Imaginary Pet",
             "text": "During your upkeep, if you have a card in hand, return Imaginary Pet to owner's hand.",
             "colours": [
@@ -2613,7 +2613,7 @@
         },
         {
             "id": "f463403b-72ac-5024-9b59-4a600f11650e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f78667-b3ab-44af-89df-9e9332dc5485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58f78667-b3ab-44af-89df-9e9332dc5485.jpg?1",
             "name": "Launch",
             "text": "Enchanted creature gains flying.\nWhen Launch is put into a graveyard from play, return Launch to owner's hand.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "52b2249e-cf39-52ff-9140-c6c5e5672510",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef319154-c5fc-4432-a860-a05508c132d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef319154-c5fc-4432-a860-a05508c132d4.jpg?1",
             "name": "Lilting Refrain",
             "text": "During your upkeep, you may put a verse counter on Lilting Refrain.\nSacrifice Lilting Refrain: Counter target spell unless its caster pays an additional o\nX, where X is the number of verse counters on Lilting Refrain. Play this ability as an interrupt.",
             "colours": [
@@ -2677,7 +2677,7 @@
         },
         {
             "id": "6e403ebb-41a0-52e2-8f8a-fd4da5d3d425",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b4a82-a1d5-4dcc-9264-96005fdf53f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050b4a82-a1d5-4dcc-9264-96005fdf53f5.jpg?1",
             "name": "Lingering Mirage",
             "text": "Enchanted land is an island.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2710,7 +2710,7 @@
         },
         {
             "id": "108c8a91-7f86-5dcd-ad4e-f2611488b9b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4d5c-aacf-4bd8-849d-80a357a7804d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/812f4d5c-aacf-4bd8-849d-80a357a7804d.jpg?1",
             "name": "Morphling",
             "text": "oo\nU Untap Morphling.\noo\nU Morphling gains flying until end of turn.\noo\nU Morphling cannot be the target of spells or abilities until end of turn.\no1: Morphling gets +1/-1 until end of turn.\no1: Morphling gets -1/+1 until end of turn.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "c903cfbd-457c-5b56-b206-a3396620124a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b6708-5ed4-4085-b9b7-d359b2d5b26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b6708-5ed4-4085-b9b7-d359b2d5b26f.jpg?1",
             "name": "Pendrell Drake",
             "text": "Flying\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2776,7 +2776,7 @@
         },
         {
             "id": "1fdf2f0d-8d96-51f3-bd17-4d7fe065632c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34847e03-c529-415e-9d49-fd4647ca8892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34847e03-c529-415e-9d49-fd4647ca8892.jpg?1",
             "name": "Pendrell Flux",
             "text": "Enchanted creature gains \"During your upkeep, pay this creature's casting cost or sacrifice it.\"",
             "colours": [
@@ -2809,7 +2809,7 @@
         },
         {
             "id": "7c2e27a2-19e8-526e-aef0-dd77171cf550",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951863f-1c16-4d09-ba9a-f57dc3d81a20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4951863f-1c16-4d09-ba9a-f57dc3d81a20.jpg?1",
             "name": "Peregrine Drake",
             "text": "Flying\nWhen Peregrine Drake comes into play, untap up to five lands.",
             "colours": [
@@ -2842,7 +2842,7 @@
         },
         {
             "id": "bf831162-0891-5194-9751-398023530227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662cf693-18c4-4169-bcce-09862778f60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/662cf693-18c4-4169-bcce-09862778f60c.jpg?1",
             "name": "Power Sink",
             "text": "Counter target spell unless its caster pays an additional o\nX. If he or she does not, tap all mana-producing lands that player controls and remove all mana from his or her mana pool.",
             "colours": [
@@ -2873,7 +2873,7 @@
         },
         {
             "id": "06045f16-c79b-5203-ae4a-020ef2800995",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d0296c-c0f5-491e-9e61-be8f5af2e631.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d0296c-c0f5-491e-9e61-be8f5af2e631.jpg?1",
             "name": "Power Taint",
             "text": "During the upkeep of enchanted enchantment's controller, that player pays o2 or loses 2 life.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2906,7 +2906,7 @@
         },
         {
             "id": "9266bb89-4577-5d7c-8905-8bd4c7a5ff98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95479839-779e-4dbe-8989-ccf26cc488fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95479839-779e-4dbe-8989-ccf26cc488fe.jpg?1",
             "name": "Recantation",
             "text": "During your upkeep, you may put a verse counter on Recantation.\no\nU, Sacrifice Recantation: Return up to X target permanents to owner's hand, where X is the number of verse counters on Recantation.",
             "colours": [
@@ -2937,7 +2937,7 @@
         },
         {
             "id": "68874a15-7ef6-5af6-bc13-e728159bdc2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dde1dc-8eee-4a66-87d9-fdfb42270744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58dde1dc-8eee-4a66-87d9-fdfb42270744.jpg?1",
             "name": "Rescind",
             "text": "Return target permanent to owner's hand.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "3397625f-b5d1-57cc-8e55-d4e694e1a4ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51c4fb-fb29-4b1c-b78e-1fadf94fc9a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51c4fb-fb29-4b1c-b78e-1fadf94fc9a5.jpg?1",
             "name": "Rewind",
             "text": "Counter target spell. Untap up to four lands.",
             "colours": [
@@ -2999,7 +2999,7 @@
         },
         {
             "id": "5efd3495-be53-59a6-8deb-7ae97b553993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ce3960-abf1-4f28-8434-ab3b27d3b7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65ce3960-abf1-4f28-8434-ab3b27d3b7cb.jpg?1",
             "name": "Sandbar Merfolk",
             "text": "Cycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3032,7 +3032,7 @@
         },
         {
             "id": "a67ee534-bbec-5a8d-995f-dd330b5620e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b430ec-28e1-4b2c-bea8-3bfd3a0e8cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b430ec-28e1-4b2c-bea8-3bfd3a0e8cf8.jpg?1",
             "name": "Sandbar Serpent",
             "text": "Cycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3065,7 +3065,7 @@
         },
         {
             "id": "0bdf25e0-3f7f-5178-8ca2-c39349c25eff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b851c17-55ed-4671-b471-dc7b34944432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b851c17-55ed-4671-b471-dc7b34944432.jpg?1",
             "name": "Show and Tell",
             "text": "Each player may choose an artifact, creature, enchantment, or land card in his or her hand and put that permanent into play.",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "6be84a72-dbad-526e-aef6-2dbb6ae8ffec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35aa7a8-5579-46b7-83ef-f5ecc2b31847.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c35aa7a8-5579-46b7-83ef-f5ecc2b31847.jpg?1",
             "name": "Somnophore",
             "text": "Flying\nWhenever Somnophore successfully deals damage to a player, tap target creature that player controls. That creature does not untap during its controller's untap phase as long as Somnophore remains in play.",
             "colours": [
@@ -3129,7 +3129,7 @@
         },
         {
             "id": "a5bef70a-40fd-5b77-bf94-7128a5545e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66b2aa6-e891-4ae5-b6c9-1537b797c3ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c66b2aa6-e891-4ae5-b6c9-1537b797c3ab.jpg?1",
             "name": "Spire Owl",
             "text": "Flying\nWhen Spire Owl comes into play, look at the top four cards of your library and put them back in any order.",
             "colours": [
@@ -3162,7 +3162,7 @@
         },
         {
             "id": "88be0ba4-1d02-5aee-b85d-781a83832f61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7042fdc8-e2dd-4f9a-97b9-00d95c9eae74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7042fdc8-e2dd-4f9a-97b9-00d95c9eae74.jpg?1",
             "name": "Stern Proctor",
             "text": "When Stern Proctor comes into play, return target artifact or enchantment to owner's hand.",
             "colours": [
@@ -3196,7 +3196,7 @@
         },
         {
             "id": "632e1e0f-161e-569d-b558-36c3d8a5e809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e977755-8ea4-4a8b-90c4-dd175321e05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e977755-8ea4-4a8b-90c4-dd175321e05d.jpg?1",
             "name": "Stroke of Genius",
             "text": "Target player draws X cards.",
             "colours": [
@@ -3227,7 +3227,7 @@
         },
         {
             "id": "e23abbd6-74ae-58d1-a168-caf2baef2cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9dd7c6-36b6-4fe2-b3d3-f62a6e10a428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9dd7c6-36b6-4fe2-b3d3-f62a6e10a428.jpg?1",
             "name": "Sunder",
             "text": "Return all lands to owners' hands.",
             "colours": [
@@ -3258,7 +3258,7 @@
         },
         {
             "id": "9134f723-3bd7-599b-bab8-7c641447d0ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51729f36-0a0c-47fb-a3bf-22afc78df7a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51729f36-0a0c-47fb-a3bf-22afc78df7a4.jpg?1",
             "name": "Telepathy",
             "text": "Each of your opponents plays with his or her hand revealed.",
             "colours": [
@@ -3289,7 +3289,7 @@
         },
         {
             "id": "19763626-a349-5578-a256-7243ff7c22ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d62dbd-63db-4ac9-950f-9852627f23f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d62dbd-63db-4ac9-950f-9852627f23f2.jpg?1",
             "name": "Time Spiral",
             "text": "Remove Time Spiral from the game. Each player shuffles his or her graveyard and hand into his or her library, then draws seven cards. You untap up to six lands.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "716dc38a-7e2b-564b-859f-3849a3785dfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c29399d-0a59-4dcb-9bd4-f31eea3f39f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c29399d-0a59-4dcb-9bd4-f31eea3f39f9.jpg?1",
             "name": "Tolarian Winds",
             "text": "Discard your hand, then draw that many cards.",
             "colours": [
@@ -3351,7 +3351,7 @@
         },
         {
             "id": "b95d681a-4979-5656-9a81-468d5090a36d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52000066-a8cd-418f-98d2-30354b959b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52000066-a8cd-418f-98d2-30354b959b32.jpg?1",
             "name": "Turnabout",
             "text": "Tap or untap all artifacts, creatures, or lands target player controls.",
             "colours": [
@@ -3382,7 +3382,7 @@
         },
         {
             "id": "ea9dfdff-101c-599e-b907-585ea24dd0f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bd3fac-44b6-4078-a096-8d47b01ea979.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55bd3fac-44b6-4078-a096-8d47b01ea979.jpg?1",
             "name": "Veil of Birds",
             "text": "When one of your opponents successfully casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 creature with flying that counts as a Bird.",
             "colours": [
@@ -3413,7 +3413,7 @@
         },
         {
             "id": "e459bb41-28e7-5ed3-8eb2-1468d7978d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ea09f-5017-423c-84ad-c332329992b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f9ea09f-5017-423c-84ad-c332329992b3.jpg?1",
             "name": "Veiled Apparition",
             "text": "When one of your opponents successfully casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 creature with flying and \"During your upkeep, pay o1o\nU or sacrifice Veiled Apparition\" and that counts as an Illusion.",
             "colours": [
@@ -3444,7 +3444,7 @@
         },
         {
             "id": "f39bf22a-af4f-5b13-afd2-fe8c8fdbfd03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be15ae1-5262-40ba-937c-217a33d131da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9be15ae1-5262-40ba-937c-217a33d131da.jpg?1",
             "name": "Veiled Crocodile",
             "text": "When a player has no cards in hand, if Veiled Crocodile is an enchantment, Veiled Crocodile becomes a 4/4 creature that counts as a Crocodile.",
             "colours": [
@@ -3475,7 +3475,7 @@
         },
         {
             "id": "6c2f806a-491c-5f06-9f4f-a79380ac06cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de458a9d-6c09-42bb-b470-c2691e95345a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de458a9d-6c09-42bb-b470-c2691e95345a.jpg?1",
             "name": "Veiled Sentry",
             "text": "When one of your opponents successfully casts a spell, if Veiled Sentry is an enchantment, Veiled Sentry becomes a creature with power and toughness each equal to the total casting cost of that spell and that counts as an Illusion.",
             "colours": [
@@ -3506,7 +3506,7 @@
         },
         {
             "id": "8ccbb092-d32f-586f-87a8-1882daa02aa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193fd6-3156-48ff-90fa-71328ee7adf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193fd6-3156-48ff-90fa-71328ee7adf5.jpg?1",
             "name": "Veiled Serpent",
             "text": "When one of your opponents successfully casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 creature that cannot attack unless defending player controls an island and that counts as a Serpent.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -3537,7 +3537,7 @@
         },
         {
             "id": "a5049f97-d198-5431-b250-7baba73ba782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aef4608-5ba8-4636-b5e7-cac57c5c0608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aef4608-5ba8-4636-b5e7-cac57c5c0608.jpg?1",
             "name": "Windfall",
             "text": "Each player discards his or her hand and draws cards equal to the greatest number a player discarded this way.",
             "colours": [
@@ -3568,7 +3568,7 @@
         },
         {
             "id": "be7be1e8-37ab-5cc6-bcc0-aba052d1c687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49805401-9bd9-48a3-9b99-0120a8bb1fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49805401-9bd9-48a3-9b99-0120a8bb1fb5.jpg?1",
             "name": "Wizard Mentor",
             "text": "oc\nT: Return Wizard Mentor and target creature you control to owner's hand.",
             "colours": [
@@ -3602,7 +3602,7 @@
         },
         {
             "id": "b155724c-b46f-59f8-9f78-95a11ad69d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0317fff-dbad-4c47-a191-0369d81cdda2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0317fff-dbad-4c47-a191-0369d81cdda2.jpg?1",
             "name": "Zephid",
             "text": "Flying\nZephid cannot be the target of spells or abilities.",
             "colours": [
@@ -3635,7 +3635,7 @@
         },
         {
             "id": "0fa60212-e879-5d8a-be75-e498df18199a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3312de-c153-4e75-8f8c-b7762b30d492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb3312de-c153-4e75-8f8c-b7762b30d492.jpg?1",
             "name": "Zephid's Embrace",
             "text": "Enchanted creature gets +2/+2, gains flying, and cannot be the target of spells or abilities.",
             "colours": [
@@ -3668,7 +3668,7 @@
         },
         {
             "id": "837f42c8-475f-5f55-82f3-6615a14e16f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94396d26-cede-4a61-b30a-50aecc730407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94396d26-cede-4a61-b30a-50aecc730407.jpg?1",
             "name": "Abyssal Horror",
             "text": "Flying\nWhen Abyssal Horror comes into play, target player chooses and discards two cards.",
             "colours": [
@@ -3701,7 +3701,7 @@
         },
         {
             "id": "8f6463c4-3cb5-5b22-98fd-a59b6009f09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92cb48d-315b-4877-b615-ffdf275c4d61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f92cb48d-315b-4877-b615-ffdf275c4d61.jpg?1",
             "name": "Befoul",
             "text": "Destroy target land or nonblack creature. A creature destroyed this way cannot be regenerated this turn.",
             "colours": [
@@ -3732,7 +3732,7 @@
         },
         {
             "id": "5b05e2d2-f936-5e51-8dd7-ade6645768aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1e5f5-a164-4359-bae1-e5dfd4801688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06a1e5f5-a164-4359-bae1-e5dfd4801688.jpg?1",
             "name": "Bereavement",
             "text": "Whenever a green creature is put into a graveyard from play, its controller chooses and discards a card.",
             "colours": [
@@ -3763,7 +3763,7 @@
         },
         {
             "id": "56af8b6e-3923-50b1-9c2b-a21a5ac66f31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e692dea-750b-40b2-9440-8b570e67c23e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e692dea-750b-40b2-9440-8b570e67c23e.jpg?1",
             "name": "Blood Vassal",
             "text": "Sacrifice Blood Vassal: Add o\nBo\nB to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "97e2036e-7243-5fb1-bd2b-bda4447fd86f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3739188b-f2b3-4ab0-8e5c-b3a1d2a1ad09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3739188b-f2b3-4ab0-8e5c-b3a1d2a1ad09.jpg?1",
             "name": "Bog Raiders",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)",
             "colours": [
@@ -3831,7 +3831,7 @@
         },
         {
             "id": "6c4d593d-4219-5f3d-952f-98547a642597",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a8e6f-4c3b-4d92-bd05-9bbb0150d653.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c8a8e6f-4c3b-4d92-bd05-9bbb0150d653.jpg?1",
             "name": "Bog Raiders",
             "text": "",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "adb3fea6-94fe-5c9a-b812-930af88df493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eada28cb-92bf-47e0-b09d-4709be32dbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eada28cb-92bf-47e0-b09d-4709be32dbe6.jpg?1",
             "name": "Breach",
             "text": "Target creature gets +2/+0 until end of turn. That creature cannot be blocked except by artifact creatures and black creatures this turn.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "51ef3c33-31ff-5954-bdbc-ec98d7b6f876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae410ae8-1e72-4727-96df-c7c195063fb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae410ae8-1e72-4727-96df-c7c195063fb5.jpg?1",
             "name": "Cackling Fiend",
             "text": "When Cackling Fiend comes into play, each of your opponents chooses and discards a card.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "9a0b0c2b-ccd8-55c4-b165-7f3b857cfb4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d4f4d7-a35b-45ea-ba51-ee65b3ff98d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d4f4d7-a35b-45ea-ba51-ee65b3ff98d4.jpg?1",
             "name": "Carrion Beetles",
             "text": "o2o\nB, oc\nT: Remove from the game up to three target cards in one graveyard.",
             "colours": [
@@ -3963,7 +3963,7 @@
         },
         {
             "id": "d27995ec-6c25-591c-aeb1-486138828c18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86067dfe-65c3-4c96-bccd-b3915d6663f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86067dfe-65c3-4c96-bccd-b3915d6663f9.jpg?1",
             "name": "Contamination",
             "text": "During your upkeep, sacrifice a creature or sacrifice Contamination.\nWhenever a land is tapped for mana, it produces o\nB instead of its normal type and amount.",
             "colours": [
@@ -3994,7 +3994,7 @@
         },
         {
             "id": "8c34e61d-9fe9-54b6-ab92-6c065137c4f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e1c65c-ced6-484d-b3b4-db913c6bf84b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32e1c65c-ced6-484d-b3b4-db913c6bf84b.jpg?1",
             "name": "Corrupt",
             "text": "Corrupt deals 1 damage to target creature or player for each swamp you control. When Corrupt successfully deals damage to a creature or player, gain life equal to that damage.",
             "colours": [
@@ -4025,7 +4025,7 @@
         },
         {
             "id": "9d2f441a-eb42-571a-8ced-f2e8d0a67e34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816272de-f134-45fa-ac1f-70d35d30c7e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816272de-f134-45fa-ac1f-70d35d30c7e1.jpg?1",
             "name": "Crazed Skirge",
             "text": "Flying\nCrazed Skirge is unaffected by summoning sickness.",
             "colours": [
@@ -4059,7 +4059,7 @@
         },
         {
             "id": "53d3c6db-6cdd-5007-b9e5-50922ccd996d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a538c1-8539-4955-ae3e-27312ce9e800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a538c1-8539-4955-ae3e-27312ce9e800.jpg?1",
             "name": "Dark Hatchling",
             "text": "Flying\nWhen Dark Hatchling comes into play, destroy target nonblack creature. That creature cannot be regenerated this turn.",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "2eb8f803-c6d3-55d5-9b97-fc2e40a76ca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e9d0d-e1a3-4e0a-bf39-e9aaf4d36d67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f0e9d0d-e1a3-4e0a-bf39-e9aaf4d36d67.jpg?1",
             "name": "Dark Ritual",
             "text": "Add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4123,7 +4123,7 @@
         },
         {
             "id": "ddd1581d-b73b-5743-bdeb-826631bfec74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad98ca8-d358-450a-8439-5abf57197b83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad98ca8-d358-450a-8439-5abf57197b83.jpg?1",
             "name": "Darkest Hour",
             "text": "All creatures are black.",
             "colours": [
@@ -4154,7 +4154,7 @@
         },
         {
             "id": "2815bf7f-60a6-5f22-aeaa-3d76d31c674a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef400a6a-628a-40d6-80dc-feabe40d6ce1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef400a6a-628a-40d6-80dc-feabe40d6ce1.jpg?1",
             "name": "Despondency",
             "text": "Enchanted creature gets -2/-0.\nWhen Despondency is put into a graveyard from play, return Despondency to owner's hand.",
             "colours": [
@@ -4187,7 +4187,7 @@
         },
         {
             "id": "48628f4c-2d03-503e-9788-86170c54cd62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb1e0c9-9041-44cd-9e96-87cf14c67068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb1e0c9-9041-44cd-9e96-87cf14c67068.jpg?1",
             "name": "Diabolic Servitude",
             "text": "When Diabolic Servitude comes into play, choose target creature card in your graveyard and put that creature into play.\nWhen the chosen creature is put into a graveyard, remove the creature from the game and return Diabolic Servitude to owner's hand.\nWhen Diabolic Servitude leaves play, remove the chosen creature from the game.",
             "colours": [
@@ -4220,7 +4220,7 @@
         },
         {
             "id": "2ffa7609-03b7-58eb-a04b-2ca6298b813b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d6bc-693b-4c2b-9c3b-b0db241ebb42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d353d6bc-693b-4c2b-9c3b-b0db241ebb42.jpg?1",
             "name": "Diabolic Servitude",
             "text": "",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "393102a3-6dc6-593b-b0d1-0015ed5657d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48e753c-ba11-4aa3-9a73-584f8a7538f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48e753c-ba11-4aa3-9a73-584f8a7538f5.jpg?1",
             "name": "Discordant Dirge",
             "text": "During your upkeep, you may put a verse counter on Discordant Dirge.\no\nB, Sacrifice Discordant Dirge: Look at target opponent's hand and choose up to X of those cards, where X is the number of verse counters on Discordant Dirge. That player discards those cards.",
             "colours": [
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "4a35f58f-536a-5935-9d83-cf1571c9ed03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367f49-0f4a-4b7f-8104-851893fbcd8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca367f49-0f4a-4b7f-8104-851893fbcd8a.jpg?1",
             "name": "Duress",
             "text": "Look at target opponent's hand and choose a noncreature, nonland card there. That player discards that card.",
             "colours": [
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "ef2b477a-e621-5dc9-9f61-0290c9fe0015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f042a8c7-f07b-42bd-8251-c588d890683c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f042a8c7-f07b-42bd-8251-c588d890683c.jpg?1",
             "name": "Eastern Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target green creature.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "edc118a2-8775-5be3-8419-78fe870735a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88b23ce-ce19-47da-b9f2-055a4d6bdc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a88b23ce-ce19-47da-b9f2-055a4d6bdc79.jpg?1",
             "name": "Exhume",
             "text": "Each player chooses a creature card in his or her graveyard and puts that creature into play.",
             "colours": [
@@ -4381,7 +4381,7 @@
         },
         {
             "id": "c206713e-69db-5c66-9013-208bdfce8197",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0576ffe8-a7b9-479b-8ea0-418b430b1aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0576ffe8-a7b9-479b-8ea0-418b430b1aa1.jpg?1",
             "name": "Expunge",
             "text": "Destroy target nonartifact, nonblack creature. That creature cannot be regenerated this turn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -4412,7 +4412,7 @@
         },
         {
             "id": "38d75d88-4aaa-5147-b919-4ad802d588dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dc6a91-ca13-45da-ba65-8fbb16c159c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dc6a91-ca13-45da-ba65-8fbb16c159c0.jpg?1",
             "name": "Flesh Reaver",
             "text": "Whenever Flesh Reaver successfully deals damage to a creature or opponent, Flesh Reaver deals an equal amount of damage to you.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "bc683913-87d1-5c4b-bb47-fa8c090fd65f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e84fa4f-617d-4449-8141-783a9ce017c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e84fa4f-617d-4449-8141-783a9ce017c1.jpg?1",
             "name": "Hollow Dogs",
             "text": "Whenever Hollow Dogs attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -4481,7 +4481,7 @@
         },
         {
             "id": "d6c1c3e0-a5e9-5570-8aad-03a07dbec48b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826230ad-6b2b-42a0-9d6f-ed07d3554efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/826230ad-6b2b-42a0-9d6f-ed07d3554efd.jpg?1",
             "name": "Ill-Gotten Gains",
             "text": "Remove Ill-Gotten Gains from the game. All players discard their hands, then each player puts up to three cards from his or her graveyard into his or her hand.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "8cd4d6a8-3dda-56c2-a01d-34bcd5531b8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525f63ae-e002-4d47-bea5-b24dc89d4d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/525f63ae-e002-4d47-bea5-b24dc89d4d06.jpg?1",
             "name": "Looming Shade",
             "text": "oo\nB Looming Shade gets +1/+1 until end of turn.",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "0d81db79-a661-5b42-a66a-195ebe7bc876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e94ab55-4390-4b3d-8e7f-a95996e2c5b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e94ab55-4390-4b3d-8e7f-a95996e2c5b7.jpg?1",
             "name": "Looming Shade",
             "text": "",
             "colours": [
@@ -4582,7 +4582,7 @@
         },
         {
             "id": "34925eae-837c-5c2a-b992-9c64522a1be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ef7201-4443-4a77-b9e1-6f1f39e8f993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ef7201-4443-4a77-b9e1-6f1f39e8f993.jpg?1",
             "name": "Lurking Evil",
             "text": "Pay half your life, rounded up: Lurking Evil becomes a 4/4 creature with flying that counts as a Horror.",
             "colours": [
@@ -4613,7 +4613,7 @@
         },
         {
             "id": "1e2ca1de-7bcc-5ed6-a2f9-5c46fdbb0f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a288616-5350-43eb-b718-5bfeb5be4ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a288616-5350-43eb-b718-5bfeb5be4ed4.jpg?1",
             "name": "Mana Leech",
             "text": "You may choose not to untap Mana Leech during your untap phase.\noc\nT: Tap target land. As long as Mana Leech remains tapped, that land does not untap during its controller's untap phase.",
             "colours": [
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "dc0be188-e00e-5d3c-a2c4-10dd4fb36f01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9b2b0-65aa-42a1-b9f8-563b194ca5b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9f9b2b0-65aa-42a1-b9f8-563b194ca5b1.jpg?1",
             "name": "No Rest for the Wicked",
             "text": "Sacrifice No Rest for the Wicked: Return to your hand all creature cards put into your graveyard from play this turn.",
             "colours": [
@@ -4679,7 +4679,7 @@
         },
         {
             "id": "267b7e36-cf52-5bec-96ab-eb97d18f9e60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a4bce-15db-43a7-9514-5e657b618aac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c20a4bce-15db-43a7-9514-5e657b618aac.jpg?1",
             "name": "No Rest for the Wicked",
             "text": "",
             "colours": [
@@ -4712,7 +4712,7 @@
         },
         {
             "id": "502843ec-cd41-548c-96cd-1ea005fbc6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838e751-b206-4052-9263-a67b8fea05cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8838e751-b206-4052-9263-a67b8fea05cc.jpg?1",
             "name": "Oppression",
             "text": "Whenever a player successfully casts a spell, that player chooses and discards a card.",
             "colours": [
@@ -4743,7 +4743,7 @@
         },
         {
             "id": "ba46b93c-6dde-5b45-ab01-a3911bcad93e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e858d-d8d2-4626-9343-070cf86949ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555e858d-d8d2-4626-9343-070cf86949ab.jpg?1",
             "name": "Order of Yawgmoth",
             "text": "Order of Yawgmoth cannot be blocked except by artifact creatures and black creatures.\nWhenever Order of Yawgmoth successfully deals damage to a player, that player chooses and discards a card.",
             "colours": [
@@ -4778,7 +4778,7 @@
         },
         {
             "id": "9293a064-5a24-51d5-85da-80a40d721b38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bd3995-3013-468e-b586-0c5720a0bde6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47bd3995-3013-468e-b586-0c5720a0bde6.jpg?1",
             "name": "Parasitic Bond",
             "text": "During the upkeep of enchanted creature's controller, Parasitic Bond deals 2 damage to that player.",
             "colours": [
@@ -4811,7 +4811,7 @@
         },
         {
             "id": "4092dc2b-0d39-50ef-adaa-ed126b3a4dc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8e2be6-124d-412e-be34-aa4495a83e02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f8e2be6-124d-412e-be34-aa4495a83e02.jpg?1",
             "name": "Persecute",
             "text": "Choose a color. Look at target player's hand. That player discards all cards of the chosen color.",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "6a826a50-2b19-538c-80e6-0d6d2d8f55e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f5630-647f-4789-8506-e7fafcbdd671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f1f5630-647f-4789-8506-e7fafcbdd671.jpg?1",
             "name": "Pestilence",
             "text": "At the end of each turn, if no creatures are in play, sacrifice Pestilence.\noo\nB Pestilence deals 1 damage to each creature and player.",
             "colours": [
@@ -4873,7 +4873,7 @@
         },
         {
             "id": "dfb1b4aa-159e-5a1d-a0c2-42dacddeb32d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4843ba92-fde2-4b46-8fdb-e0f8aca96959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4843ba92-fde2-4b46-8fdb-e0f8aca96959.jpg?1",
             "name": "Phyrexian Ghoul",
             "text": "Sacrifice a creature: Phyrexian Ghoul gets +2/+2 until end of turn.",
             "colours": [
@@ -4907,7 +4907,7 @@
         },
         {
             "id": "371f63e0-fbd7-5cfb-aa47-95ea3b6de3ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035c718-ac11-4c97-a9bb-0cd88dc71904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b035c718-ac11-4c97-a9bb-0cd88dc71904.jpg?1",
             "name": "Planar Void",
             "text": "Whenever a card is put into a graveyard, remove that card from the game.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "dfb10134-93ac-5796-892f-71cbcb6f5e78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64166899-fcc6-4000-9994-643f5a4cd214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64166899-fcc6-4000-9994-643f5a4cd214.jpg?1",
             "name": "Priest of Gix",
             "text": "When Priest of Gix comes into play, add o\nBo\nBo\nB to your mana pool.",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "75631035-0337-51f4-b255-91ed1515ead6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf07d5a-6618-48e2-a9f0-669b75bb6e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cf07d5a-6618-48e2-a9f0-669b75bb6e85.jpg?1",
             "name": "Rain of Filth",
             "text": "Each land you control gains \"Sacrifice this land: Add o\nB to your mana pool\" until end of turn.",
             "colours": [
@@ -5005,7 +5005,7 @@
         },
         {
             "id": "f78bbc38-eb16-51bc-a3b8-d835ad1b38be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b6e655-e05e-44b5-9c7f-9dbbc66e6e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b6e655-e05e-44b5-9c7f-9dbbc66e6e28.jpg?1",
             "name": "Ravenous Skirge",
             "text": "Flying\nWhenever Ravenous Skirge attacks, it gets +2/+0 until end of turn.",
             "colours": [
@@ -5039,7 +5039,7 @@
         },
         {
             "id": "8e0882dd-fffa-5bb1-821d-5236d4a16192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b14c6-78a0-4e82-924e-781719c8defb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/384b14c6-78a0-4e82-924e-781719c8defb.jpg?1",
             "name": "Reclusive Wight",
             "text": "During your upkeep, if you control any other nonland permanents, sacrifice Reclusive Wight.",
             "colours": [
@@ -5073,7 +5073,7 @@
         },
         {
             "id": "280b1d7e-7cc8-54ba-ac78-3d65add7da71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569408b3-43c8-4cb1-a70f-15ab2aeaf8ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569408b3-43c8-4cb1-a70f-15ab2aeaf8ed.jpg?1",
             "name": "Reprocess",
             "text": "Sacrifice any number of artifacts, creatures, and/or lands and draw a card for each one sacrificed this way.",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "5cc0bf33-9422-5a7a-994a-83f619b8dff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c33fbb0-f49d-4b4d-804d-84b03e0daf4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c33fbb0-f49d-4b4d-804d-84b03e0daf4d.jpg?1",
             "name": "Sanguine Guard",
             "text": "First strike\no1oo\nB Regenerate Sanguine Guard.",
             "colours": [
@@ -5139,7 +5139,7 @@
         },
         {
             "id": "f7b80490-6e3c-512b-8e76-ac167ea34dda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1beb5d-0ef2-4013-932b-5e4a5d0af559.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa1beb5d-0ef2-4013-932b-5e4a5d0af559.jpg?1",
             "name": "Sicken",
             "text": "Enchanted creature gets -1/-1.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -5172,7 +5172,7 @@
         },
         {
             "id": "e9a00d47-f9aa-571b-a8a6-a481594c4fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935ee538-3ea1-4a80-bb8f-01d562f63b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935ee538-3ea1-4a80-bb8f-01d562f63b5d.jpg?1",
             "name": "Skirge Familiar",
             "text": "Flying\nChoose and discard a card: Add o\nB to your mana pool. Play this ability as a mana source.",
             "colours": [
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "78b15046-b2f2-53e1-b236-5eb8a577b7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aba9d5-5f96-4aba-8248-74398b8bfe9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93aba9d5-5f96-4aba-8248-74398b8bfe9d.jpg?1",
             "name": "Skittering Skirge",
             "text": "Flying\nWhen you successfully cast a creature spell, sacrifice Skittering Skirge.",
             "colours": [
@@ -5240,7 +5240,7 @@
         },
         {
             "id": "621ab515-d5c4-516d-97ba-85fc6f06b31e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b2c4bd-2397-4ebd-b4fb-3b3e9c6c7dec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1b2c4bd-2397-4ebd-b4fb-3b3e9c6c7dec.jpg?1",
             "name": "Sleeper Agent",
             "text": "When Sleeper Agent comes into play, target opponent gains control of it.\nDuring your upkeep, Sleeper Agent deals 2 damage to you.",
             "colours": [
@@ -5274,7 +5274,7 @@
         },
         {
             "id": "164e8514-8eed-59e8-b974-317f8ff53846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a14524b-e690-4f77-b43e-416d5ec3cbb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a14524b-e690-4f77-b43e-416d5ec3cbb9.jpg?1",
             "name": "Spined Fluke",
             "text": "When Spined Fluke comes into play, sacrifice a creature.\noo\nB Regenerate Spined Fluke.",
             "colours": [
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "2a71c849-3e4d-5f72-a01c-d18e3090a689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd33a1-1603-4368-9c32-e4c9fd6ecd08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1dd33a1-1603-4368-9c32-e4c9fd6ecd08.jpg?1",
             "name": "Tainted Aether",
             "text": "Whenever a creature comes into play, its controller sacrifices a creature or land.",
             "colours": [
@@ -5339,7 +5339,7 @@
         },
         {
             "id": "0e4ed857-d91d-5230-a271-763faed937ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72779ce-bcd3-41dc-8b3f-bfb9a1b137d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72779ce-bcd3-41dc-8b3f-bfb9a1b137d8.jpg?1",
             "name": "Unnerve",
             "text": "Each of your opponents chooses and discards two cards.",
             "colours": [
@@ -5370,7 +5370,7 @@
         },
         {
             "id": "e46c896c-0b26-5fa2-b4f4-3b6fa80b800d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f42c561-1762-43c4-a539-0cf9a5ce7f4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f42c561-1762-43c4-a539-0cf9a5ce7f4f.jpg?1",
             "name": "Unworthy Dead",
             "text": "oo\nB Regenerate Unworthy Dead.",
             "colours": [
@@ -5406,7 +5406,7 @@
         },
         {
             "id": "e8ae330e-b788-5433-b6d3-65379a857981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf88542-e5af-430e-9d48-03a216d7526f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf88542-e5af-430e-9d48-03a216d7526f.jpg?1",
             "name": "Unworthy Dead",
             "text": "",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "f2f6cfd1-7b18-54aa-9aa3-25b485469e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889be765-5716-4549-b544-0a49d3962e16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/889be765-5716-4549-b544-0a49d3962e16.jpg?1",
             "name": "Vampiric Embrace",
             "text": "Enchanted creature gets +2/+2 and gains flying.\nWhenever a creature successfully dealt damage by enchanted creature this turn is put into a graveyard, put a +1/+1 counter on enchanted creature.",
             "colours": [
@@ -5475,7 +5475,7 @@
         },
         {
             "id": "e7e96d85-0b0e-5d5a-9d8c-2ecedecd9ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5623194-0cd9-4f3f-bab1-133d6b1e94fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5623194-0cd9-4f3f-bab1-133d6b1e94fe.jpg?1",
             "name": "Vebulid",
             "text": "Vebulid comes into play with one +1/+1 counter on it.\nDuring your upkeep, you may put a +1/+1 counter on Vebulid.\nWhen Vebulid attacks or blocks, destroy it at end of combat.",
             "colours": [
@@ -5509,7 +5509,7 @@
         },
         {
             "id": "3d9e9717-f6bd-5e9a-bd0a-2a52eae5ba7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caafe7da-0167-4c53-bbad-172f900d137b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caafe7da-0167-4c53-bbad-172f900d137b.jpg?1",
             "name": "Victimize",
             "text": "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, put the two chosen creatures into play tapped.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "32454058-1407-504c-8ef0-f19f5b1e669d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be44b37-2383-4bf4-ba30-d8d4e2cb8939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be44b37-2383-4bf4-ba30-d8d4e2cb8939.jpg?1",
             "name": "Vile Requiem",
             "text": "During your upkeep, you may put a verse counter on Vile Requiem.\no1o\nB, Sacrifice Vile Requiem: Destroy up to X target nonblack creatures, where X is the number of verse counters on Vile Requiem. Those creatures cannot be regenerated this turn.",
             "colours": [
@@ -5571,7 +5571,7 @@
         },
         {
             "id": "ec36983c-abb6-5088-9215-6f1a255d53a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bcfe0f-2397-488b-8f02-dae1f6cd5824.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bcfe0f-2397-488b-8f02-dae1f6cd5824.jpg?1",
             "name": "Western Paladin",
             "text": "o\nBo\nB, oc\nT: Destroy target white creature.",
             "colours": [
@@ -5606,7 +5606,7 @@
         },
         {
             "id": "0662924f-f773-5faa-ba65-c253712a6c38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef749290-58e2-4b40-a141-5fe294f9b995.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef749290-58e2-4b40-a141-5fe294f9b995.jpg?1",
             "name": "Witch Engine",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)\noc\nT: Add o\nBo\nBo\nBo\nB to your mana pool. Target opponent gains control of Witch Engine. (Play this ability as an instant.)",
             "colours": [
@@ -5639,7 +5639,7 @@
         },
         {
             "id": "177f9c6b-1fc4-5ecb-9ac3-dfa0ab6c4d17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16be4b-4540-476a-b3ac-7442507ed314.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f16be4b-4540-476a-b3ac-7442507ed314.jpg?1",
             "name": "Yawgmoth's Edict",
             "text": "Whenever one of your opponents successfully casts a white spell, that player loses 1 life and you gain 1 life.",
             "colours": [
@@ -5670,7 +5670,7 @@
         },
         {
             "id": "78cc0f77-ee21-5941-b708-7902aec2ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e3c3a-d351-4d91-8884-312d4b6f540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d3e3c3a-d351-4d91-8884-312d4b6f540d.jpg?1",
             "name": "Yawgmoth's Will",
             "text": "Until end of turn, you may play cards in your graveyard as though they were in your hand. Cards put into your graveyard this turn are removed from the game instead.",
             "colours": [
@@ -5701,7 +5701,7 @@
         },
         {
             "id": "3acc697f-2874-5482-9455-f7689d8b5192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790157c9-b1ed-4da5-9d50-e99e0dd807b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/790157c9-b1ed-4da5-9d50-e99e0dd807b7.jpg?1",
             "name": "Acidic Soil",
             "text": "Acidic Soil deals 1 damage to each player for each land he or she controls.",
             "colours": [
@@ -5732,7 +5732,7 @@
         },
         {
             "id": "54300b17-1d80-59fb-9059-bb49e10db1c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9db511-089e-413f-8005-ccb05ec3b06e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9db511-089e-413f-8005-ccb05ec3b06e.jpg?1",
             "name": "Antagonism",
             "text": "During each player's discard phase, Antagonism deals 2 damage to that player unless one of his or her opponents was successfully dealt damage that turn.",
             "colours": [
@@ -5763,7 +5763,7 @@
         },
         {
             "id": "189e8cb5-b33a-5315-aefb-9afd64bcad17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c81ade7-0074-4447-ba2c-b16fa0f09ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c81ade7-0074-4447-ba2c-b16fa0f09ccb.jpg?1",
             "name": "Arc Lightning",
             "text": "Arc Lightning deals 3 damage divided as you choose among any number of target creatures and/or players.",
             "colours": [
@@ -5794,7 +5794,7 @@
         },
         {
             "id": "d35fa5e6-ebb5-53ef-bd11-43dd028fcb07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e97dc9-8df3-4912-8564-7bdb2ac6564b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3e97dc9-8df3-4912-8564-7bdb2ac6564b.jpg?1",
             "name": "Bedlam",
             "text": "Creatures cannot block.",
             "colours": [
@@ -5825,7 +5825,7 @@
         },
         {
             "id": "7000de85-0e60-553a-b83d-629815db86c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafbd034-c8a0-4798-a680-555c13bdd251.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafbd034-c8a0-4798-a680-555c13bdd251.jpg?1",
             "name": "Brand",
             "text": "Gain control of all permanents you own.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -5856,7 +5856,7 @@
         },
         {
             "id": "38c67e41-eeb2-51d2-ab5c-e2b965ea7b74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba422-4837-400c-a913-b56d87b49e26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019ba422-4837-400c-a913-b56d87b49e26.jpg?1",
             "name": "Bravado",
             "text": "Enchanted creature gets +1/+1 for each other creature you control.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "5a24cd50-ab91-5953-8cd8-43616d23d804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2041b95-ec5b-4512-b012-f875ca686669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2041b95-ec5b-4512-b012-f875ca686669.jpg?1",
             "name": "Bulwark",
             "text": "During your upkeep, Bulwark deals 1 damage to target opponent for each card in your hand greater than the number of cards in that player's hand.",
             "colours": [
@@ -5920,7 +5920,7 @@
         },
         {
             "id": "41fd2081-37fe-5c5e-b295-68117d8b0cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2382e525-1750-484a-bf95-dbb42bbb30ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2382e525-1750-484a-bf95-dbb42bbb30ae.jpg?1",
             "name": "Crater Hellion",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nWhen Crater Hellion comes into play, it deals 4 damage to each other creature.",
             "colours": [
@@ -5954,7 +5954,7 @@
         },
         {
             "id": "58992e6b-8834-5811-8347-87215248be24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479645b3-54af-4fbf-928e-2224540fe892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/479645b3-54af-4fbf-928e-2224540fe892.jpg?1",
             "name": "Destructive Urge",
             "text": "Whenever enchanted creature successfully deals combat damage to a player, that player sacrifices a land.",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "ef35f3bf-b281-5344-b9a0-c9912f387bf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5ec10-dfea-4e6d-8996-553a4a0eb8a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5ec10-dfea-4e6d-8996-553a4a0eb8a4.jpg?1",
             "name": "Disorder",
             "text": "Disorder deals 2 damage to each white creature and each player who controls a white creature.",
             "colours": [
@@ -6018,7 +6018,7 @@
         },
         {
             "id": "546fc0ff-1625-57ca-aca9-f33b45f8d26f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65de0b43-64df-44dc-850c-25f48d6ab53b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65de0b43-64df-44dc-850c-25f48d6ab53b.jpg?1",
             "name": "Dromosaur",
             "text": "Whenever Dromosaur blocks or becomes blocked, it gets +2/-2 until end of turn.",
             "colours": [
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "09371731-330d-5ad9-9523-116c67d142b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c3d04f-4010-4db3-9e4e-afa8116b263d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c3d04f-4010-4db3-9e4e-afa8116b263d.jpg?1",
             "name": "Electryte",
             "text": "Whenever Electryte successfully deals combat damage to defending player, Electryte deals damage equal to its power to each blocking creature.",
             "colours": [
@@ -6085,7 +6085,7 @@
         },
         {
             "id": "3f51e600-ae3d-52ea-8604-82f0ea9c4752",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e279126c-0512-4ee6-ad83-6fdfc7ae46c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e279126c-0512-4ee6-ad83-6fdfc7ae46c5.jpg?1",
             "name": "Falter",
             "text": "Creatures without flying cannot block this turn.",
             "colours": [
@@ -6116,7 +6116,7 @@
         },
         {
             "id": "a8650772-0910-5fe0-a23d-30b3faaa562c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4fd0e-9f84-4628-92a7-858ad8064531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cab4fd0e-9f84-4628-92a7-858ad8064531.jpg?1",
             "name": "Fault Line",
             "text": "Fault Line deals X damage to each creature without flying and each player.",
             "colours": [
@@ -6147,7 +6147,7 @@
         },
         {
             "id": "68586634-e0f8-55d6-9626-d1d21a502deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41deea2-c12f-40cd-8fc4-47227c762f42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41deea2-c12f-40cd-8fc4-47227c762f42.jpg?1",
             "name": "Fiery Mantle",
             "text": "When Fiery Mantle is put into a graveyard from play, return Fiery Mantle to owner's hand.\noo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -6180,7 +6180,7 @@
         },
         {
             "id": "6a5bd8ed-6e07-5319-be2a-40d612cfec34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e38af-a2e5-4d52-870e-1b6e0cb33cef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2e38af-a2e5-4d52-870e-1b6e0cb33cef.jpg?1",
             "name": "Fire Ants",
             "text": "oc\nT: Fire Ants deals 1 damage to each other creature without flying.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "6563615c-5a8e-551f-9e97-fffbba5d62b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e32a3d-c477-419a-97c2-851974c6b89e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e32a3d-c477-419a-97c2-851974c6b89e.jpg?1",
             "name": "Fire Ants",
             "text": "",
             "colours": [
@@ -6250,7 +6250,7 @@
         },
         {
             "id": "c2efae71-ca4d-5810-ba66-a2ddeb5ff708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0f160-7339-4d98-8a8c-f08889ee52f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ee0f160-7339-4d98-8a8c-f08889ee52f5.jpg?1",
             "name": "Gamble",
             "text": "Search your library for a card, put that card into your hand, then discard a card at random. Shuffle your library afterward.",
             "colours": [
@@ -6281,7 +6281,7 @@
         },
         {
             "id": "1430634c-9d38-59de-9d76-b22e03c46d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60081115-16bc-4924-b76d-7cfc0ad2287c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60081115-16bc-4924-b76d-7cfc0ad2287c.jpg?1",
             "name": "Goblin Cadets",
             "text": "Whenever Goblin Cadets blocks or becomes blocked, target opponent gains control of it. (This removes Goblin Cadets from combat.)",
             "colours": [
@@ -6314,7 +6314,7 @@
         },
         {
             "id": "1d0c45f3-76bd-5fe7-bb87-808b4ff9963a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b848caa-aad8-4060-8f86-304a8556de2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b848caa-aad8-4060-8f86-304a8556de2d.jpg?1",
             "name": "Goblin Lackey",
             "text": "Whenever Goblin Lackey successfully deals damage to a player, you may choose a Goblin card in your hand and put that Goblin into play.",
             "colours": [
@@ -6347,7 +6347,7 @@
         },
         {
             "id": "b1e61696-b770-564c-96a6-04a938147be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e2e5d-ad06-4378-9afb-ffb174e6a5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e9e2e5d-ad06-4378-9afb-ffb174e6a5b4.jpg?1",
             "name": "Goblin Matron",
             "text": "When Goblin Matron comes into play, you may search your library for a Goblin card. If you do, reveal that card, put it into your hand, and shuffle your library afterward.",
             "colours": [
@@ -6380,7 +6380,7 @@
         },
         {
             "id": "507c6ee3-22ea-5baa-8929-584c63c17c5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9813857-5527-4499-af86-758a5971e21a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9813857-5527-4499-af86-758a5971e21a.jpg?1",
             "name": "Goblin Offensive",
             "text": "Put X Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
             "colours": [
@@ -6411,7 +6411,7 @@
         },
         {
             "id": "c1f89a22-c3fe-5827-b8a8-b2db316ce0de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fcd8d3-f159-49a1-8dd9-582ae4a0adc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0fcd8d3-f159-49a1-8dd9-582ae4a0adc3.jpg?1",
             "name": "Goblin Patrol",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -6444,7 +6444,7 @@
         },
         {
             "id": "822b4466-8aa7-57e5-be08-e769a35ae8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150a460-8a81-4097-8100-ccb8a9bb1bd7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e150a460-8a81-4097-8100-ccb8a9bb1bd7.jpg?1",
             "name": "Goblin Raider",
             "text": "Goblin Raider cannot block.",
             "colours": [
@@ -6478,7 +6478,7 @@
         },
         {
             "id": "47a1c480-ace1-5c1d-be45-49008e093e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d02a81f-2dac-41f7-a818-811baa238021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d02a81f-2dac-41f7-a818-811baa238021.jpg?1",
             "name": "Goblin Spelunkers",
             "text": "Mountainwalk (If defending player controls a mountain, this creature is unblockable.)",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "b780a517-7b6f-5d13-868d-4da959ca3421",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d0fc9e-fb6b-4a00-b422-32565f7ce454.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d0fc9e-fb6b-4a00-b422-32565f7ce454.jpg?1",
             "name": "Goblin War Buggy",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nGoblin War Buggy is unaffected by summoning sickness.",
             "colours": [
@@ -6545,7 +6545,7 @@
         },
         {
             "id": "c518d2d4-e605-5cd5-ab0b-b20ce0184ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6246f17-6034-4423-82c5-1aea8d71f94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6246f17-6034-4423-82c5-1aea8d71f94e.jpg?1",
             "name": "Guma",
             "text": "Protection from blue",
             "colours": [
@@ -6578,7 +6578,7 @@
         },
         {
             "id": "4e9ff8d3-fb68-5b4b-9b73-a9e1cbe15a6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0db04c-5101-4a43-9109-3964ac66bdab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f0db04c-5101-4a43-9109-3964ac66bdab.jpg?1",
             "name": "Headlong Rush",
             "text": "All attacking creatures gain first strike until end of turn.",
             "colours": [
@@ -6609,7 +6609,7 @@
         },
         {
             "id": "6915b519-2478-5406-8051-891dc72cfe39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27f90e-d156-439c-b5e5-6d53bd510fe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a27f90e-d156-439c-b5e5-6d53bd510fe7.jpg?1",
             "name": "Heat Ray",
             "text": "Heat Ray deals X damage to target creature.",
             "colours": [
@@ -6640,7 +6640,7 @@
         },
         {
             "id": "1c13f61d-eb94-53b4-aded-8e96ca47e621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49304f24-a961-4d1e-b85c-af6e3d8d5edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49304f24-a961-4d1e-b85c-af6e3d8d5edc.jpg?1",
             "name": "Jagged Lightning",
             "text": "Jagged Lightning deals 3 damage to target creature and 3 damage to another target creature.",
             "colours": [
@@ -6671,7 +6671,7 @@
         },
         {
             "id": "1ded5362-7c2c-5394-8f77-8f09f7dd5adb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa1186-51fa-419a-9cd0-42403d1dd4a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46fa1186-51fa-419a-9cd0-42403d1dd4a7.jpg?1",
             "name": "Lay Waste",
             "text": "Destroy target land.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -6702,7 +6702,7 @@
         },
         {
             "id": "77b04e79-9681-5224-befd-308bfc8f4ed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fc7bc-657f-43a3-9558-f516fa545a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/342fc7bc-657f-43a3-9558-f516fa545a09.jpg?1",
             "name": "Lightning Dragon",
             "text": "Flying; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\noo\nR Lightning Dragon gets +1/+0 until end of turn.",
             "colours": [
@@ -6735,7 +6735,7 @@
         },
         {
             "id": "b71d3b61-ed39-55ca-ab0b-ff588cc2015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7a967a-35a0-4e5c-a32b-123a9cfdb79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7a967a-35a0-4e5c-a32b-123a9cfdb79e.jpg?1",
             "name": "Meltdown",
             "text": "Destroy each artifact with total casting cost X or less.",
             "colours": [
@@ -6766,7 +6766,7 @@
         },
         {
             "id": "0220a4d8-a928-574d-9a4b-35000e8ad647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecbdbc-dcfb-42ee-956c-a508db6eaafa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fecbdbc-dcfb-42ee-956c-a508db6eaafa.jpg?1",
             "name": "Okk",
             "text": "Okk cannot attack unless a creature with greater power also attacks.\nOkk cannot block unless a creature with greater power also blocks.",
             "colours": [
@@ -6799,7 +6799,7 @@
         },
         {
             "id": "2ecad6eb-fa98-5603-b39c-36c6d0e23399",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5a69fa-71ff-4e4f-9406-7cfebccb3384.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5a69fa-71ff-4e4f-9406-7cfebccb3384.jpg?1",
             "name": "Outmaneuver",
             "text": "X target blocked creatures deal combat damage to defending player instead of to blocking creatures this turn.",
             "colours": [
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "2e510040-c925-5feb-8d4c-28f889c8c8e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4792293a-e11d-4c5e-bbd9-6f09e69ee617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4792293a-e11d-4c5e-bbd9-6f09e69ee617.jpg?1",
             "name": "Rain of Salt",
             "text": "Destroy two target lands.",
             "colours": [
@@ -6861,7 +6861,7 @@
         },
         {
             "id": "fe06399b-0d63-5b85-a29f-afc6c0f7629c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d51b3c-24e9-41b6-b7cd-c70329e498ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56d51b3c-24e9-41b6-b7cd-c70329e498ca.jpg?1",
             "name": "Raze",
             "text": "At the time you play Raze, sacrifice a land.\nDestroy target land.",
             "colours": [
@@ -6892,7 +6892,7 @@
         },
         {
             "id": "e090a96b-a250-5092-9d26-5e9197fbc982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614782c2-a38a-4b3e-9716-7f5c09c4ad43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614782c2-a38a-4b3e-9716-7f5c09c4ad43.jpg?1",
             "name": "Reflexes",
             "text": "Enchanted creature gains first strike.",
             "colours": [
@@ -6925,7 +6925,7 @@
         },
         {
             "id": "821bb7d2-2478-5e83-8d1d-fc24e784d8dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fbf63d-7106-47d5-97c3-4596d8239925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9fbf63d-7106-47d5-97c3-4596d8239925.jpg?1",
             "name": "Retromancer",
             "text": "Whenever Retromancer is the target of a spell or ability, Retromancer deals 3 damage to that spell or ability's controller.",
             "colours": [
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "249a1bd3-02b8-54bf-b657-ac8a517484d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf267c2-c3d5-48ba-93af-dd0af133add3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf267c2-c3d5-48ba-93af-dd0af133add3.jpg?1",
             "name": "Rumbling Crescendo",
             "text": "During your upkeep, you may put a verse counter on Rumbling Crescendo.\no\nR, Sacrifice Rumbling Crescendo: Destroy up to X target lands, where X is the number of verse counters on Rumbling Crescendo.",
             "colours": [
@@ -6990,7 +6990,7 @@
         },
         {
             "id": "8de6121a-8fe5-5f9f-814d-1498d062b275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff97d4b-301f-4ade-a6df-2667dff566c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff97d4b-301f-4ade-a6df-2667dff566c2.jpg?1",
             "name": "Scald",
             "text": "Whenever a player taps an island for mana, Scald deals 1 damage to that player.",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "73172f84-7bc2-544f-b4b8-3e644b579d28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4175d6e4-98fc-46f6-b549-c13e9f647eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4175d6e4-98fc-46f6-b549-c13e9f647eef.jpg?1",
             "name": "Scoria Wurm",
             "text": "During your upkeep, flip a coin. If you lose the flip, return Scoria Wurm to owner's hand.",
             "colours": [
@@ -7054,7 +7054,7 @@
         },
         {
             "id": "9355b7a1-552d-584e-9ff5-f836cb20e5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f070430-59d6-462f-9f04-306ffc2ae01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f070430-59d6-462f-9f04-306ffc2ae01b.jpg?1",
             "name": "Scrap",
             "text": "Destroy target artifact.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -7085,7 +7085,7 @@
         },
         {
             "id": "3670d004-4fdc-533d-ac41-d6e38ab73fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f30e-277f-4d8d-ad75-567545a78d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d74f30e-277f-4d8d-ad75-567545a78d97.jpg?1",
             "name": "Shivan Hellkite",
             "text": "Flying\no1oo\nR Shivan Hellkite deals 1 damage to target creature or player.",
             "colours": [
@@ -7118,7 +7118,7 @@
         },
         {
             "id": "b6a84751-9d94-5d96-b2aa-34e282a6b7b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc45153-3cb1-43bc-b694-06f6a74b3eb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc45153-3cb1-43bc-b694-06f6a74b3eb7.jpg?1",
             "name": "Shivan Raptor",
             "text": "First strike; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nShivan Raptor is unaffected by summoning sickness.",
             "colours": [
@@ -7151,7 +7151,7 @@
         },
         {
             "id": "cc243b32-e4c7-54bf-bfe4-41c96b40d1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9ba1a3-1de4-4771-b76a-89354bc799d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9ba1a3-1de4-4771-b76a-89354bc799d3.jpg?1",
             "name": "Shiv's Embrace",
             "text": "Enchanted creature gets +2/+2 and gains flying.\noo\nR Enchanted creature gets +1/+0 until end of turn.",
             "colours": [
@@ -7184,7 +7184,7 @@
         },
         {
             "id": "e2e7e36e-7bc4-5054-bedb-1662302121a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428999-a83d-40a5-9753-dfefdf705a9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54428999-a83d-40a5-9753-dfefdf705a9e.jpg?1",
             "name": "Shower of Sparks",
             "text": "Shower of Sparks deals 1 damage to target creature and 1 damage to target player.",
             "colours": [
@@ -7215,7 +7215,7 @@
         },
         {
             "id": "973848a0-46a2-5854-b5ce-ae822753ed87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07dc95d-82a8-4a58-8ea2-d4513bd7316d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d07dc95d-82a8-4a58-8ea2-d4513bd7316d.jpg?1",
             "name": "Sneak Attack",
             "text": "oo\nR Choose a creature card from your hand and put that creature into play. The creature is unaffected by summoning sickness. At end of turn, sacrifice the creature.",
             "colours": [
@@ -7246,7 +7246,7 @@
         },
         {
             "id": "30104f29-8e79-52d4-bcb9-53a5a8fae824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144a1b4e-d960-4c3a-810b-11a0c78635ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/144a1b4e-d960-4c3a-810b-11a0c78635ad.jpg?1",
             "name": "Steam Blast",
             "text": "Steam Blast deals 2 damage to each creature and player.",
             "colours": [
@@ -7277,7 +7277,7 @@
         },
         {
             "id": "37eef8e7-c32e-536c-b217-83840bf80444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e133997f-1620-4fe9-8275-057edc998fba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e133997f-1620-4fe9-8275-057edc998fba.jpg?1",
             "name": "Sulfuric Vapors",
             "text": "Whenever a red spell deals damage, it instead deals that amount of damage plus 1.",
             "colours": [
@@ -7308,7 +7308,7 @@
         },
         {
             "id": "bbb20d03-831b-56ef-a1c9-3bde08a9ee07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98afd54f-2f86-4694-a688-ce3dcefccdbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98afd54f-2f86-4694-a688-ce3dcefccdbc.jpg?1",
             "name": "Thundering Giant",
             "text": "Thundering Giant is unaffected by summoning sickness.",
             "colours": [
@@ -7341,7 +7341,7 @@
         },
         {
             "id": "8b4d3821-f95b-5ef6-bfec-8722521da984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba8cdf0-492a-4e64-9143-4ccb29ba1d56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba8cdf0-492a-4e64-9143-4ccb29ba1d56.jpg?1",
             "name": "Torch Song",
             "text": "During your upkeep, you may put a verse counter on Torch Song.\no2o\nR, Sacrifice Torch Song: Torch Song deals X damage to target creature or player, where X is the number of verse counters on Torch Song.",
             "colours": [
@@ -7372,7 +7372,7 @@
         },
         {
             "id": "90d22cd6-fea2-537b-97aa-1e696d0bbf32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ba659c-7e0f-4d8b-b91c-3c0725102ba2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ba659c-7e0f-4d8b-b91c-3c0725102ba2.jpg?1",
             "name": "Viashino Outrider",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -7405,7 +7405,7 @@
         },
         {
             "id": "aa480225-6f03-5f0f-85af-41af75e515aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bf72e0-0b0c-4b29-8709-9dcd460508cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15bf72e0-0b0c-4b29-8709-9dcd460508cb.jpg?1",
             "name": "Viashino Runner",
             "text": "Viashino Runner cannot be blocked by only one creature.",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "63f5c7c7-6c9f-5de4-aec9-c799c9e078ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0790607f-51b7-40ff-80f9-4f7f5cd2d63c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0790607f-51b7-40ff-80f9-4f7f5cd2d63c.jpg?1",
             "name": "Viashino Sandswimmer",
             "text": "oo\nR Flip a coin. If you win the flip, return Viashino Sandswimmer to owner's hand. Otherwise, sacrifice Viashino Sandswimmer.",
             "colours": [
@@ -7471,7 +7471,7 @@
         },
         {
             "id": "75b3290a-1aff-5b8a-ae16-09699d8f39a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def316ed-b080-4d1d-b946-d7a86ebb8ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def316ed-b080-4d1d-b946-d7a86ebb8ad9.jpg?1",
             "name": "Viashino Weaponsmith",
             "text": "Whenever a creature blocks it, Viashino Weaponsmith gets +2/+2 until end of turn.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "acde0081-4dab-5fbf-bcdc-66244b140f80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bbb1f6-f3c4-4e11-bb71-91ea31797d1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bbb1f6-f3c4-4e11-bb71-91ea31797d1e.jpg?1",
             "name": "Vug Lizard",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nMountainwalk (If defending player controls a mountain, this creature is unblockable.)",
             "colours": [
@@ -7537,7 +7537,7 @@
         },
         {
             "id": "dbe0e385-6624-5458-bd70-22eaa9eab7f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d50972-4549-40cd-9c33-4b341333803f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d50972-4549-40cd-9c33-4b341333803f.jpg?1",
             "name": "Wildfire",
             "text": "Each player sacrifices four lands, then Wildfire deals 4 damage to each creature.",
             "colours": [
@@ -7568,7 +7568,7 @@
         },
         {
             "id": "95bb8ed4-ad8f-50dc-8ae3-45b0842268f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d051fa-bd3a-4c94-ae41-34d89a7bb77d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d051fa-bd3a-4c94-ae41-34d89a7bb77d.jpg?1",
             "name": "Abundance",
             "text": "Instead of drawing a card, you may choose land or nonland and reveal cards from your library until you reveal a card of the chosen kind. Put that card into your hand and put all other revealed cards on the bottom of your library in any order.",
             "colours": [
@@ -7599,7 +7599,7 @@
         },
         {
             "id": "4d0725a0-0569-537a-a129-7e6669146c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a38f-5a60-46da-af1c-440e4bf7fe9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05d5a38f-5a60-46da-af1c-440e4bf7fe9e.jpg?1",
             "name": "Acridian",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "be365d5c-ba26-5a9f-90af-82076e86d9fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a3c112-f0c1-4d30-8df6-63fc01356a4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a3c112-f0c1-4d30-8df6-63fc01356a4f.jpg?1",
             "name": "Albino Troll",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\no1oo\nG Regenerate Albino Troll.",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "afa60ef9-3d7c-5cb5-ada9-a6ff21465fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be798fd-18c9-45b0-8207-7e5e01c83f49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be798fd-18c9-45b0-8207-7e5e01c83f49.jpg?1",
             "name": "Anaconda",
             "text": "Swampwalk (If defending player controls a swamp, this creature is unblockable.)",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "ccce7178-51cc-503e-8b6f-e636b545e359",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453e7cb4-bc37-4932-85b7-3a4e160b73dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/453e7cb4-bc37-4932-85b7-3a4e160b73dc.jpg?1",
             "name": "Argothian Elder",
             "text": "oc\nT: Untap two target lands.",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "34cc8c8d-8d09-54ea-a15b-e9b51243f3fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ababc1a-515e-4e20-8819-19d84d9b0af5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9ababc1a-515e-4e20-8819-19d84d9b0af5.jpg?1",
             "name": "Argothian Enchantress",
             "text": "Argothian Enchantress cannot be the target of spells or abilities.\nWhenever you successfully cast an enchantment spell, draw a card.",
             "colours": [
@@ -7766,7 +7766,7 @@
         },
         {
             "id": "381b8004-aae1-56d8-9366-0b7a82827110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe5e4ec-9c0e-4b1a-b3c6-e9631cf214eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afe5e4ec-9c0e-4b1a-b3c6-e9631cf214eb.jpg?1",
             "name": "Argothian Swine",
             "text": "Trample",
             "colours": [
@@ -7799,7 +7799,7 @@
         },
         {
             "id": "2f0d8fcd-bd7a-5f48-b882-acc7eeae22ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93294349-75ae-4a6b-896d-b403a5d69e98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93294349-75ae-4a6b-896d-b403a5d69e98.jpg?1",
             "name": "Argothian Wurm",
             "text": "Trample\nWhen Argothian Wurm comes into play, any player may sacrifice a land to put Argothian Wurm on top of owner's library.",
             "colours": [
@@ -7832,7 +7832,7 @@
         },
         {
             "id": "6cea9f1d-3527-5ccb-b0ed-4e3f009769b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f3776-74f4-4626-833b-e1b0921d3cbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5f3776-74f4-4626-833b-e1b0921d3cbc.jpg?1",
             "name": "Blanchwood Armor",
             "text": "Enchanted creature gets +X/+X, where X is the number of forests you control.",
             "colours": [
@@ -7865,7 +7865,7 @@
         },
         {
             "id": "1ffd825a-9c8c-580a-a3d7-f5aa2e628189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f824502c-d712-41af-ba44-33e8294c3735.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f824502c-d712-41af-ba44-33e8294c3735.jpg?1",
             "name": "Blanchwood Treefolk",
             "text": "",
             "colours": [
@@ -7898,7 +7898,7 @@
         },
         {
             "id": "b9447280-d6a4-51d7-b80d-a4dee792ce4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1f8259-1825-4a46-8026-75adc4480322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1f8259-1825-4a46-8026-75adc4480322.jpg?1",
             "name": "Bull Hippo",
             "text": "Islandwalk (If defending player controls an island, this creature is unblockable.)",
             "colours": [
@@ -7931,7 +7931,7 @@
         },
         {
             "id": "96024a32-b94f-5141-97c0-632526346726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93abb48a-85f2-432d-8602-0a1d17fbb409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93abb48a-85f2-432d-8602-0a1d17fbb409.jpg?1",
             "name": "Carpet of Flowers",
             "text": "During your main phase, you may add up to X mana of one color to your mana pool, where X is the number of islands target opponent controls.",
             "colours": [
@@ -7962,7 +7962,7 @@
         },
         {
             "id": "804db7d6-e913-5073-b7d3-d1842d7e348e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c782eb28-0cdd-4c3d-9d89-8b23c29cddd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c782eb28-0cdd-4c3d-9d89-8b23c29cddd4.jpg?1",
             "name": "Cave Tiger",
             "text": "Whenever a creature blocks it, Cave Tiger gets +1/+1 until end of turn.",
             "colours": [
@@ -7995,7 +7995,7 @@
         },
         {
             "id": "6f076468-3a7f-52d8-bc94-3cf6e12e33b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a836d9bd-a4cb-4676-935c-5fb7b793a42f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a836d9bd-a4cb-4676-935c-5fb7b793a42f.jpg?1",
             "name": "Child of Gaea",
             "text": "Trample\nDuring your upkeep, pay o\nGo\nG or sacrifice Child of Gaea.\no1oo\nG Regenerate Child of Gaea.",
             "colours": [
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "3548cc81-7b69-5839-bd13-5f72bb784783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac987-7906-4159-a007-ed409baea9d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a3ac987-7906-4159-a007-ed409baea9d7.jpg?1",
             "name": "Citanul Centaurs",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)\nCitanul Centaurs cannot be the target of spells or abilities.",
             "colours": [
@@ -8061,7 +8061,7 @@
         },
         {
             "id": "400258a2-a267-5b5e-aab5-b56fc023ef41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905506cc-f77e-4214-8eb3-6f141997336c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/905506cc-f77e-4214-8eb3-6f141997336c.jpg?1",
             "name": "Citanul Hierophants",
             "text": "Each creature you control gains \"oc\nT: Add o\nG to your mana pool. Play this ability as a mana source.\"",
             "colours": [
@@ -8095,7 +8095,7 @@
         },
         {
             "id": "49f86319-a5ab-5f4f-a158-1e409c44cd83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b659c1c-cc0b-40f0-87b4-aeddb44dfac5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b659c1c-cc0b-40f0-87b4-aeddb44dfac5.jpg?1",
             "name": "Cradle Guard",
             "text": "Trample; echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -8128,7 +8128,7 @@
         },
         {
             "id": "52414b56-e9a1-58fd-a31f-a6bec52b3c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f182a85b-a119-46e2-8b8b-48b6758d9c39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f182a85b-a119-46e2-8b8b-48b6758d9c39.jpg?1",
             "name": "Crosswinds",
             "text": "All creatures with flying get -2/-0.",
             "colours": [
@@ -8159,7 +8159,7 @@
         },
         {
             "id": "1aefc8da-4126-50b0-b4fd-5e8fb4edc174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb2b07e-3d50-4b85-be2a-c99e9c8ebf25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb2b07e-3d50-4b85-be2a-c99e9c8ebf25.jpg?1",
             "name": "Elvish Herder",
             "text": "oo\nG Target creature gains trample until end of turn.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "be1742ec-66e5-5e2f-a2e1-425db2c2867c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c63ea60-4ce0-4dc7-bda6-7f623b0f9e2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c63ea60-4ce0-4dc7-bda6-7f623b0f9e2a.jpg?1",
             "name": "Elvish Lyrist",
             "text": "o\nG, oc\nT, Sacrifice Elvish Lyrist: Destroy target enchantment.",
             "colours": [
@@ -8225,7 +8225,7 @@
         },
         {
             "id": "201ad28f-170a-5324-af6b-1d388bb93b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53772435-e20e-4b9e-a2f1-c1c6a4dcac79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53772435-e20e-4b9e-a2f1-c1c6a4dcac79.jpg?1",
             "name": "Endless Wurm",
             "text": "Trample\nDuring your upkeep, sacrifice an enchantment or sacrifice Endless Wurm.",
             "colours": [
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "9dfcc18d-1b2f-5447-8908-0c9836dede1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f09e451-0246-45a2-8bfd-07d3c65ddfe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f09e451-0246-45a2-8bfd-07d3c65ddfe6.jpg?1",
             "name": "Exploration",
             "text": "You may play an additional land each turn.",
             "colours": [
@@ -8289,7 +8289,7 @@
         },
         {
             "id": "2a663452-6e4e-5c9e-a9b9-a8088b9aa2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c93c11-448c-402d-ac55-8d5ab4c83d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c93c11-448c-402d-ac55-8d5ab4c83d7b.jpg?1",
             "name": "Fecundity",
             "text": "Whenever a creature is put into a graveyard from play, that creature's controller may draw a card.",
             "colours": [
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "6b0608ff-6d32-550a-b6bd-4b246a8976df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091dda35-59e5-456d-8804-61513a610aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/091dda35-59e5-456d-8804-61513a610aed.jpg?1",
             "name": "Fertile Ground",
             "text": "Whenever enchanted land is tapped for mana, it produces an additional one mana of any color.",
             "colours": [
@@ -8353,7 +8353,7 @@
         },
         {
             "id": "38c2096e-4d81-5df8-bd42-74945b0c2bad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54d5240-8afc-4c61-aaf6-a78d2b92e5c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54d5240-8afc-4c61-aaf6-a78d2b92e5c9.jpg?1",
             "name": "Fortitude",
             "text": "When Fortitude is put into a graveyard from play, return Fortitude to owner's hand.\nSacrifice a forest: Regenerate enchanted creature.",
             "colours": [
@@ -8386,7 +8386,7 @@
         },
         {
             "id": "08ac289e-06f1-5529-8361-4817a8b7f3e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b55e37-fcad-4d50-89d4-5d88269fee66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66b55e37-fcad-4d50-89d4-5d88269fee66.jpg?1",
             "name": "Gaea's Bounty",
             "text": "Search your library for up to two forest cards, reveal them, and put them into your hand. Shuffle your library afterward.",
             "colours": [
@@ -8417,7 +8417,7 @@
         },
         {
             "id": "3e7ad39c-60ad-571c-8a79-ba23cd6f769f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce99456-d7cc-480f-b283-0ba063c89e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cce99456-d7cc-480f-b283-0ba063c89e0a.jpg?1",
             "name": "Gaea's Embrace",
             "text": "Enchanted creature gets +3/+3 and gains trample.\noo\nG Regenerate enchanted creature.",
             "colours": [
@@ -8450,7 +8450,7 @@
         },
         {
             "id": "28e1d200-df07-51c9-9824-035866768a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c7e2b0-2df0-4cde-8565-762c93e6c14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c7e2b0-2df0-4cde-8565-762c93e6c14f.jpg?1",
             "name": "Gorilla Warrior",
             "text": "",
             "colours": [
@@ -8484,7 +8484,7 @@
         },
         {
             "id": "544e3686-87a6-5701-ac85-a2dd0ae30343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12befd35-2dc6-4852-a153-75b553042643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12befd35-2dc6-4852-a153-75b553042643.jpg?1",
             "name": "Greater Good",
             "text": "Sacrifice a creature: Draw cards equal to the sacrificed creature's power, then choose and discard three cards.",
             "colours": [
@@ -8515,7 +8515,7 @@
         },
         {
             "id": "a6ea320a-0fa9-55af-afcd-171b0c75739a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c3222e-ac18-4f57-9c9e-50deb0a69db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55c3222e-ac18-4f57-9c9e-50deb0a69db3.jpg?1",
             "name": "Greener Pastures",
             "text": "During each player's upkeep, if that player controls more lands than any other, the player puts a Saproling token into play under his or her control. Treat this token as a 1/1 green creature.",
             "colours": [
@@ -8546,7 +8546,7 @@
         },
         {
             "id": "0a049d8e-2de6-5ac0-a7e0-1a04f40a1aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/842e8c4c-32f3-4ec3-b636-1d7dc9f0023e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/842e8c4c-32f3-4ec3-b636-1d7dc9f0023e.jpg?1",
             "name": "Hawkeater Moth",
             "text": "Flying\nHawkeater Moth cannot be the target of spells or abilities.",
             "colours": [
@@ -8579,7 +8579,7 @@
         },
         {
             "id": "be3c8678-5514-52c3-91ab-b32c8dc8fbcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f4f257-c04e-489f-8ffd-814bf075e7d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45f4f257-c04e-489f-8ffd-814bf075e7d1.jpg?1",
             "name": "Hidden Ancients",
             "text": "When one of your opponents successfully casts an enchantment spell, if Hidden Ancients is an enchantment, Hidden Ancients becomes a 5/5 creature that counts as a Treefolk.",
             "colours": [
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "c4136601-e02f-5b03-8fe7-665fc5f74da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab16fbb-1542-4ba6-9a06-30806176572c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ab16fbb-1542-4ba6-9a06-30806176572c.jpg?1",
             "name": "Hidden Guerrillas",
             "text": "When one of your opponents successfully casts an artifact spell, if Hidden Guerrillas is an enchantment, Hidden Guerrillas becomes a 5/3 creature with trample and that counts as a Soldier.",
             "colours": [
@@ -8641,7 +8641,7 @@
         },
         {
             "id": "c30d8300-6276-5a11-b87f-e63b8107323e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f07992-1f81-440a-a80a-164c44d0a471.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20f07992-1f81-440a-a80a-164c44d0a471.jpg?1",
             "name": "Hidden Herd",
             "text": "When one of your opponents plays a nonbasic land, if Hidden Herd is an enchantment, Hidden Herd becomes a 3/3 creature that counts as a Beast.",
             "colours": [
@@ -8672,7 +8672,7 @@
         },
         {
             "id": "c9770b23-09fe-5d11-ba7a-f9bbf8b2b27f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ee86-a576-4f40-b165-be5b4558507d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f8ee86-a576-4f40-b165-be5b4558507d.jpg?1",
             "name": "Hidden Predators",
             "text": "When one of your opponents controls a creature with power 4 or greater, if Hidden Predators is an enchantment, Hidden Predators becomes a 4/4 creature that counts as a Beast.",
             "colours": [
@@ -8703,7 +8703,7 @@
         },
         {
             "id": "aada2e92-ef12-5c06-ad07-b9d76b6d046b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2640cb-7d0b-40e5-9624-02c64b2f9830.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2640cb-7d0b-40e5-9624-02c64b2f9830.jpg?1",
             "name": "Hidden Spider",
             "text": "When one of your opponents successfully casts a creature with flying, if Hidden Spider is an enchantment, Hidden Spider becomes a 3/5 creature that can block creatures with flying and that counts as a Spider.",
             "colours": [
@@ -8734,7 +8734,7 @@
         },
         {
             "id": "727bb8d9-b75f-5b6a-af0c-5b360d45272e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0501e115-ef61-4db5-bdb3-36dc4334431c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0501e115-ef61-4db5-bdb3-36dc4334431c.jpg?1",
             "name": "Hidden Stag",
             "text": "Whenever one of your opponents plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 creature that counts as a Beast.\nWhenever you play a land, if Hidden Stag is a creature, Hidden Stag becomes an enchantment.",
             "colours": [
@@ -8765,7 +8765,7 @@
         },
         {
             "id": "49a26953-b4c4-5f63-882e-45ef102bde31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f01c95-ce9e-4b45-9d15-a5d37100a5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35f01c95-ce9e-4b45-9d15-a5d37100a5d8.jpg?1",
             "name": "Hush",
             "text": "Destroy all enchantments.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -8796,7 +8796,7 @@
         },
         {
             "id": "a740c17f-886d-5267-b63e-348c2473887f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec5d627-b3d7-4e11-81c7-bf4cef5409a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eec5d627-b3d7-4e11-81c7-bf4cef5409a6.jpg?1",
             "name": "Lull",
             "text": "Creatures deal no combat damage this turn.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -8827,7 +8827,7 @@
         },
         {
             "id": "389296c3-06b4-5c28-ab75-eed7419098a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40a7f65-10fe-4ce5-ad1c-be53a635d7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b40a7f65-10fe-4ce5-ad1c-be53a635d7a9.jpg?1",
             "name": "Midsummer Revel",
             "text": "During your upkeep, you may put a verse counter on Midsummer Revel.\no\nG, Sacrifice Midsummer Revel: Put X Beast tokens into play, where X is the number of verse counters on Midsummer Revel. Treat these tokens as 3/3 green creatures.",
             "colours": [
@@ -8858,7 +8858,7 @@
         },
         {
             "id": "6dabf774-49f7-5008-992a-abe230f65633",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ac6e5-3e46-4290-9683-51d6f54e4edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d35ac6e5-3e46-4290-9683-51d6f54e4edf.jpg?1",
             "name": "Pouncing Jaguar",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -8891,7 +8891,7 @@
         },
         {
             "id": "e64a0425-720d-507e-b756-92ef70bad14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965c33c3-0c68-4516-b8b0-5a0552ed44b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/965c33c3-0c68-4516-b8b0-5a0552ed44b6.jpg?1",
             "name": "Priest of Titania",
             "text": "oc\nT: Add o\nG to your mana pool for each Elf in play. Play this ability as a mana source.",
             "colours": [
@@ -8925,7 +8925,7 @@
         },
         {
             "id": "cb566109-bbb3-5ed0-b95e-4825e896d4a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3709a3-7a1b-4644-b1d5-e1ffef549f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe3709a3-7a1b-4644-b1d5-e1ffef549f94.jpg?1",
             "name": "Rejuvenate",
             "text": "Gain 6 life.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -8956,7 +8956,7 @@
         },
         {
             "id": "6d649980-aca3-5124-a677-aaec8f217381",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e3814-5b9f-40da-8205-263fc49294da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6e3814-5b9f-40da-8205-263fc49294da.jpg?1",
             "name": "Retaliation",
             "text": "Each creature you control gains \"Whenever a creature blocks it, this creature gets +1/+1 until end of turn.\"",
             "colours": [
@@ -8987,7 +8987,7 @@
         },
         {
             "id": "84eb9284-83ee-56c0-9675-23ebbeb70ba8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839d969b-b1f7-4978-b00c-db0766161f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/839d969b-b1f7-4978-b00c-db0766161f63.jpg?1",
             "name": "Sporogenesis",
             "text": "During your upkeep, you may put a fungus counter on target nontoken creature.\nWhenever a creature with a fungus counter on it is put into a graveyard, put a Saproling token into play for each of those fungus counters. Treat these tokens as 1/1 green creatures.\nWhen Sporogenesis leaves play, remove all fungus counters from all creatures.",
             "colours": [
@@ -9018,7 +9018,7 @@
         },
         {
             "id": "df88fc8e-312a-55bb-952f-4802c96f5e8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cfc00e-180c-4277-8911-43afa691b9d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20cfc00e-180c-4277-8911-43afa691b9d7.jpg?1",
             "name": "Spreading Algae",
             "text": "Play Spreading Algae only on a swamp.\nWhen enchanted land becomes tapped, destroy that land.\nWhen Spreading Algae is put into a graveyard from play, return Spreading Algae to owner's hand.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "72f94d6b-b3dd-5360-a25f-e4cfc996ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d35e2c5-1871-4749-aefa-4a7a69645c03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d35e2c5-1871-4749-aefa-4a7a69645c03.jpg?1",
             "name": "Symbiosis",
             "text": "Two target creatures each get +2/+2 until end of turn.",
             "colours": [
@@ -9082,7 +9082,7 @@
         },
         {
             "id": "c80f8654-182a-5053-bf8e-fecb61927a39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d64591-8552-4e94-b932-7a23922513a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8d64591-8552-4e94-b932-7a23922513a1.jpg?1",
             "name": "Titania's Boon",
             "text": "Put a +1/+1 counter on each creature you control.",
             "colours": [
@@ -9113,7 +9113,7 @@
         },
         {
             "id": "4b7563c3-9203-55dc-adf3-f59f2b757322",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9450340-2c29-4573-8da2-0d3cae9759c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9450340-2c29-4573-8da2-0d3cae9759c1.jpg?1",
             "name": "Titania's Chosen",
             "text": "Whenever a player successfully casts a green spell, put a +1/+1 counter on Titania's Chosen.",
             "colours": [
@@ -9147,7 +9147,7 @@
         },
         {
             "id": "562eff23-da8d-593a-9301-750c20220e51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec5ee47-c2ef-442d-b1e7-323a8dba6627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ec5ee47-c2ef-442d-b1e7-323a8dba6627.jpg?1",
             "name": "Treefolk Seedlings",
             "text": "Treefolk Seedlings has toughness equal to the number of forests you control.",
             "colours": [
@@ -9180,7 +9180,7 @@
         },
         {
             "id": "a25ba444-db50-58f4-b892-735894a84d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f1a343-250b-4a30-a3b5-296282a70446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33f1a343-250b-4a30-a3b5-296282a70446.jpg?1",
             "name": "Treetop Rangers",
             "text": "Treetop Rangers cannot be blocked except by creatures with flying.",
             "colours": [
@@ -9214,7 +9214,7 @@
         },
         {
             "id": "8b3fa1c1-2213-5cf5-a1f6-0bda9871c652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ae1348-c063-4ec8-9d8c-3d19a6421800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5ae1348-c063-4ec8-9d8c-3d19a6421800.jpg?1",
             "name": "Venomous Fangs",
             "text": "Whenever enchanted creature successfully deals damage to a creature, destroy that creature.",
             "colours": [
@@ -9247,7 +9247,7 @@
         },
         {
             "id": "41ea46f1-d86c-5776-8ecf-ae6e7526ef36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a49c80-02ee-4d5a-83cb-53ac3e7870e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80a49c80-02ee-4d5a-83cb-53ac3e7870e7.jpg?1",
             "name": "Vernal Bloom",
             "text": "Whenever a forest is tapped for mana, it produces an additional o\nG.",
             "colours": [
@@ -9278,7 +9278,7 @@
         },
         {
             "id": "f352aae5-98fe-5d1c-8ca1-77724f1ff6a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392b4acf-4548-47dd-be58-bdf4ca4ece7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392b4acf-4548-47dd-be58-bdf4ca4ece7e.jpg?1",
             "name": "War Dance",
             "text": "During your upkeep, you may put a verse counter on War Dance.\nSacrifice War Dance: Target creature gets +X/+X until end of turn, where X is the number of verse counters on War Dance.",
             "colours": [
@@ -9309,7 +9309,7 @@
         },
         {
             "id": "8b760662-8e29-52e5-937f-bef25579c81f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8101bab4-ef93-451a-a24f-e1456c82837c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8101bab4-ef93-451a-a24f-e1456c82837c.jpg?1",
             "name": "Whirlwind",
             "text": "Destroy all creatures with flying.",
             "colours": [
@@ -9340,7 +9340,7 @@
         },
         {
             "id": "ce47414f-fd26-53a2-ab66-275606f77584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7811e2-8bff-44a9-96bf-8e302c3cade9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c7811e2-8bff-44a9-96bf-8e302c3cade9.jpg?1",
             "name": "Wild Dogs",
             "text": "During your upkeep, if a player has more life than any other, that player gains control of Wild Dogs.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "307bc8f4-aa73-54ae-8854-ab7fe0201edb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed75dc43-172c-4302-8807-23bfdd65baf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed75dc43-172c-4302-8807-23bfdd65baf4.jpg?1",
             "name": "Winding Wurm",
             "text": "Echo (During your next upkeep after this permanent comes under your control, pay its casting cost or sacrifice it.)",
             "colours": [
@@ -9406,7 +9406,7 @@
         },
         {
             "id": "6573b089-3eba-5f2d-96a4-bac36d486392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951b225-f11e-41bd-ab6e-e1fda957dff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9951b225-f11e-41bd-ab6e-e1fda957dff3.jpg?1",
             "name": "Barrin's Codex",
             "text": "During your upkeep, you may put a page counter on Barrin's Codex.\no4, oc\nT, Sacrifice Barrin's Codex: Draw X cards, where X is the number of page counters on Barrin's Codex.",
             "colours": [],
@@ -9433,7 +9433,7 @@
         },
         {
             "id": "9180f96a-119e-5a3f-b64d-10d99a97c9b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28def495-1806-40ec-b170-ca727c914f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28def495-1806-40ec-b170-ca727c914f30.jpg?1",
             "name": "Cathodion",
             "text": "When Cathodion is put into a graveyard from play, add three colorless mana to your mana pool.",
             "colours": [],
@@ -9463,7 +9463,7 @@
         },
         {
             "id": "f334e38b-3c54-5dba-8905-7e0c7e608243",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c228b-8339-49d1-af0c-05e7d7ba4c9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27c228b-8339-49d1-af0c-05e7d7ba4c9d.jpg?1",
             "name": "Chimeric Staff",
             "text": "oo\nX Chimeric Staff is an artifact creature with power and toughness each equal to X until end of turn.",
             "colours": [],
@@ -9490,7 +9490,7 @@
         },
         {
             "id": "615b0cea-4ff1-5b2c-93e3-fe632a716d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf71fab2-d936-40f0-bda2-b0630948e1fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf71fab2-d936-40f0-bda2-b0630948e1fa.jpg?1",
             "name": "Citanul Flute",
             "text": "o\nX, oc\nT: Search your library for a creature card with total casting cost no greater than X. Reveal that card and put it into your hand. Shuffle your library afterward.",
             "colours": [],
@@ -9517,7 +9517,7 @@
         },
         {
             "id": "780fcb27-61ea-5c16-abe1-15d192f8e8cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78372366-8c4c-46ac-bd7c-a735c2b24b5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78372366-8c4c-46ac-bd7c-a735c2b24b5d.jpg?1",
             "name": "Claws of Gix",
             "text": "o1, Sacrifice a permanent: Gain 1 life.",
             "colours": [],
@@ -9544,7 +9544,7 @@
         },
         {
             "id": "bad13c3d-2502-5761-a0c0-5b638211abe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e326b7-6f6a-4249-a315-c5f017931c73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5e326b7-6f6a-4249-a315-c5f017931c73.jpg?1",
             "name": "Copper Gnomes",
             "text": "o4, Sacrifice Copper Gnomes: Choose an artifact card in your hand and put that artifact into play.",
             "colours": [],
@@ -9574,7 +9574,7 @@
         },
         {
             "id": "30456b17-9b92-5c2e-a3c5-c677438a6a97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d03d54-7aa4-4586-bb4b-8a5d269fe289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5d03d54-7aa4-4586-bb4b-8a5d269fe289.jpg?1",
             "name": "Crystal Chimes",
             "text": "o3, oc\nT, Sacrifice Crystal Chimes: Return all enchantment cards from your graveyard to your hand.",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "afa13967-41f0-5d6e-b04e-0a6bf2c67aa1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff72806a-ae41-44f5-ad74-56c3338ebfcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff72806a-ae41-44f5-ad74-56c3338ebfcb.jpg?1",
             "name": "Dragon Blood",
             "text": "o3, oc\nT: Put a +1/+1 counter on target creature.",
             "colours": [],
@@ -9628,7 +9628,7 @@
         },
         {
             "id": "27c65442-445a-5aa9-ac49-4185654f4672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4630c3-bf8e-46ac-be68-f454c4ca1047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce4630c3-bf8e-46ac-be68-f454c4ca1047.jpg?1",
             "name": "Endoskeleton",
             "text": "You may choose not to untap Endoskeleton during your untap phase.\no2, oc\nT: Target creature gets +0/+3 as long as Endoskeleton remains tapped.",
             "colours": [],
@@ -9655,7 +9655,7 @@
         },
         {
             "id": "a918ac63-684d-5bd0-a960-18b7122dd317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92078408-e0e4-443e-b0fd-aac0ac651f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92078408-e0e4-443e-b0fd-aac0ac651f46.jpg?1",
             "name": "Fluctuator",
             "text": "Cycling costs you up to o2 less to play.",
             "colours": [],
@@ -9682,7 +9682,7 @@
         },
         {
             "id": "c45ab4bf-0791-597d-b5ab-bbae0c8524ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8424e6-4a92-4be3-b69e-49ac9a736f94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b8424e6-4a92-4be3-b69e-49ac9a736f94.jpg?1",
             "name": "Grafted Skullcap",
             "text": "During your draw phase, draw an additional card.\nAt the end of each of your turns, discard your hand.",
             "colours": [],
@@ -9709,7 +9709,7 @@
         },
         {
             "id": "a310c646-e697-54cd-960e-494357ccc32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4717b6c3-9fba-454f-9d02-e8c2869c4450.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/4717b6c3-9fba-454f-9d02-e8c2869c4450.jpg?1",
             "name": "Hopping Automaton",
             "text": "o0: Hopping Automaton gets -1/-1 and gains flying until end of turn.",
             "colours": [],
@@ -9739,7 +9739,7 @@
         },
         {
             "id": "57eb2889-d0f8-5ab5-9705-6b23ef180ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a0988-2900-426c-9413-8f1778d99678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811a0988-2900-426c-9413-8f1778d99678.jpg?1",
             "name": "Karn, Silver Golem",
             "text": "Whenever Karn, Silver Golem blocks or becomes blocked, it gets -4/+4 until end of turn.\no1: Target noncreature artifact is an artifact creature with power and toughness each equal to its casting cost until end of turn. (That artifact retains its abilities.)",
             "colours": [],
@@ -9771,7 +9771,7 @@
         },
         {
             "id": "9e977384-5e05-572a-ae9e-43d23471e570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee82f-36b2-48a9-930a-8e23cb2742fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40cee82f-36b2-48a9-930a-8e23cb2742fc.jpg?1",
             "name": "Lifeline",
             "text": "Whenever a creature is put into a graveyard and a creature is in play, return that creature from your graveyard to play at end of turn.",
             "colours": [],
@@ -9798,7 +9798,7 @@
         },
         {
             "id": "956a3936-6003-5938-8e5a-3402adbad65b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d17e0a-5407-4fde-8eb0-8f580eab5565.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46d17e0a-5407-4fde-8eb0-8f580eab5565.jpg?1",
             "name": "Lotus Blossom",
             "text": "During your upkeep, you may put a petal counter on Lotus Blossom.\noc\nT, Sacrifice Lotus Blossom: Add X mana of one color to your mana pool, where X is the number of petal counters on Lotus Blossom. Play this ability as a mana source.",
             "colours": [],
@@ -9825,7 +9825,7 @@
         },
         {
             "id": "204bd054-0ef6-5332-bbba-17c048bae9bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71f153d-2d07-4a8a-b725-747bb96afe00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d71f153d-2d07-4a8a-b725-747bb96afe00.jpg?1",
             "name": "Metrognome",
             "text": "When a spell or ability one of your opponents controls causes you to discard Metrognome, put four Gnome tokens into play. Treat these tokens as 1/1 artifact creatures.\no4, oc\nT: Put a Gnome token into play. Treat this token as a 1/1 artifact creature.",
             "colours": [],
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "b919d4a3-998d-5c32-a86a-3ec5b6630349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62507f-465d-45e9-96bf-06671d19e79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c62507f-465d-45e9-96bf-06671d19e79e.jpg?1",
             "name": "Mishra's Helix",
             "text": "o\nX, oc\nT: Tap X lands.",
             "colours": [],
@@ -9879,7 +9879,7 @@
         },
         {
             "id": "1d02db4a-12c1-53cd-8162-bd23a99b0ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f642246-5b2a-46a6-9236-524a297d7608.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f642246-5b2a-46a6-9236-524a297d7608.jpg?1",
             "name": "Mobile Fort",
             "text": "Mobile Fort counts as a Wall. (Walls cannot attack.)\no3: Mobile Fort gets +3/-1 until end of turn and can attack this turn as though it were not a Wall. Play this ability only once each turn.",
             "colours": [],
@@ -9909,7 +9909,7 @@
         },
         {
             "id": "42c00b33-1fda-5684-9da9-53613e053474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18506777-cd69-42f6-99c9-cde9b0958868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18506777-cd69-42f6-99c9-cde9b0958868.jpg?1",
             "name": "Noetic Scales",
             "text": "During each player's upkeep, return to owner's hand each creature that player controls with power greater than the number of cards in his or her hand.",
             "colours": [],
@@ -9936,7 +9936,7 @@
         },
         {
             "id": "831af3cb-ab43-5b94-9561-e28ff38617ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0ba37a-ce52-4c01-89aa-25e90cda04ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0ba37a-ce52-4c01-89aa-25e90cda04ba.jpg?1",
             "name": "Phyrexian Colossus",
             "text": "Phyrexian Colossus does not untap during your untap phase.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus cannot be blocked by fewer than three creatures.",
             "colours": [],
@@ -9967,7 +9967,7 @@
         },
         {
             "id": "017935cd-fac7-52a6-8752-0a3b20336e24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6875ce99-badd-44da-8e5d-509600efa1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6875ce99-badd-44da-8e5d-509600efa1d0.jpg?1",
             "name": "Phyrexian Processor",
             "text": "When Phyrexian Processor comes into play, pay any amount of life.\no4, oc\nT: Put a Minion token into play. Treat this token as a black creature with power and toughness each equal to the amount of life paid at the time Phyrexian Processor came into play.",
             "colours": [],
@@ -9994,7 +9994,7 @@
         },
         {
             "id": "edbd86e1-581d-55ec-92ee-966a59a85ba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2003c1-356b-4714-9a2a-4e12f782321e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e2003c1-356b-4714-9a2a-4e12f782321e.jpg?1",
             "name": "Pit Trap",
             "text": "o2, oc\nT, Sacrifice Pit Trap: Destroy target attacking creature without flying. That creature cannot be regenerated this turn.",
             "colours": [],
@@ -10021,7 +10021,7 @@
         },
         {
             "id": "8317e2cc-8c3b-5f46-a442-e50ccb00d36f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef8128a-e0f5-43d6-b7bd-3f2003d83eab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef8128a-e0f5-43d6-b7bd-3f2003d83eab.jpg?1",
             "name": "Purging Scythe",
             "text": "During your upkeep, Purging Scythe deals 2 damage to the creature with the lowest toughness. If two or more creatures are tied for the lowest toughness, you decide to which creature Purging Scythe deals damage.",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "3ea9b8c9-06b8-5612-8066-feed09b4a787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a37ab2d-094f-431e-878f-93aef0360413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a37ab2d-094f-431e-878f-93aef0360413.jpg?1",
             "name": "Smokestack",
             "text": "During your upkeep, you may put a soot counter on Smokestack.\nDuring each player's upkeep, that player sacrifices a permanent for each soot counter on Smokestack.",
             "colours": [],
@@ -10075,7 +10075,7 @@
         },
         {
             "id": "aafe78b9-ee71-5c17-b486-41a334a4720b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5c2555-c707-4814-933a-c275b9ebc0a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5c2555-c707-4814-933a-c275b9ebc0a3.jpg?1",
             "name": "Temporal Aperture",
             "text": "o5, oc\nT: Shuffle your library and reveal the top card. Until end of turn, as long as that card remains on top of your library, you may play the card as though it were in your hand without paying its casting cost. (If the spell has o\nX in its casting cost, X is 0.)",
             "colours": [],
@@ -10102,7 +10102,7 @@
         },
         {
             "id": "1d82bdaf-7b47-5ec8-b790-0505515f3740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c310f-b50d-4993-9add-9f585f6172af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/791c310f-b50d-4993-9add-9f585f6172af.jpg?1",
             "name": "Thran Turbine",
             "text": "During your upkeep, you may add up to two colorless mana to your mana pool. This mana cannot be spent to play spells.",
             "colours": [],
@@ -10129,7 +10129,7 @@
         },
         {
             "id": "06640751-e51c-5fcb-b704-671f212a133d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a6db88-a11d-49b4-8692-28b24d23f3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a6db88-a11d-49b4-8692-28b24d23f3c7.jpg?1",
             "name": "Umbilicus",
             "text": "During each player's upkeep, that player pays 2 life or returns a permanent he or she controls to owner's hand.",
             "colours": [],
@@ -10156,7 +10156,7 @@
         },
         {
             "id": "5d4f63fe-cd95-584a-8cba-c2cdca8ca42f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901d78-e8fb-4adf-bafe-99a567a375c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901d78-e8fb-4adf-bafe-99a567a375c1.jpg?1",
             "name": "Urza's Armor",
             "text": "Whenever a source deals damage to you, that damage is reduced by 1.",
             "colours": [],
@@ -10183,7 +10183,7 @@
         },
         {
             "id": "28e105a4-4c5b-53b9-b5c6-2bacf6525210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4baf7-4693-4c55-af04-2fa5d901d701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aa4baf7-4693-4c55-af04-2fa5d901d701.jpg?1",
             "name": "Voltaic Key",
             "text": "o1, oc\nT: Untap target artifact.",
             "colours": [],
@@ -10210,7 +10210,7 @@
         },
         {
             "id": "46990671-7961-597f-8d28-4397bde4d088",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3f88b3-9796-4d4d-af8b-543f0d280e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd3f88b3-9796-4d4d-af8b-543f0d280e77.jpg?1",
             "name": "Wall of Junk",
             "text": "Whenever Wall of Junk blocks, return it to owner's hand at end of combat.",
             "colours": [],
@@ -10240,7 +10240,7 @@
         },
         {
             "id": "11056bc1-5339-58a3-b279-33f10be9f713",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627805a0-535f-4cba-8176-a4de290b9c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/627805a0-535f-4cba-8176-a4de290b9c15.jpg?1",
             "name": "Whetstone",
             "text": "o3: Each player puts the top two cards of his or her library into his or her graveyard.",
             "colours": [],
@@ -10267,7 +10267,7 @@
         },
         {
             "id": "2ec7c905-3180-5130-8eb6-c893b4ef4262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6333d686-58ec-4360-8929-9f7302f9a09c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6333d686-58ec-4360-8929-9f7302f9a09c.jpg?1",
             "name": "Wirecat",
             "text": "Wirecat cannot attack or block if an enchantment is in play.",
             "colours": [],
@@ -10297,7 +10297,7 @@
         },
         {
             "id": "90c12fc9-1c39-53b8-8f5a-26bc9461fb65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2224d7ef-2e2f-47dd-a4a0-e36b3170b124.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2224d7ef-2e2f-47dd-a4a0-e36b3170b124.jpg?1",
             "name": "Worn Powerstone",
             "text": "Worn Powerstone comes into play tapped.\noc\nT: Add two colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -10324,7 +10324,7 @@
         },
         {
             "id": "d94ac6e6-74ff-5f78-9b68-6bc50d7c2e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71d910-6c50-4894-8092-d39cbb7a83b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac71d910-6c50-4894-8092-d39cbb7a83b4.jpg?1",
             "name": "Blasted Landscape",
             "text": "oc\nT: Add one colorless mana to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10351,7 +10351,7 @@
         },
         {
             "id": "7cded439-dfb5-523f-be91-10c6ac3ce48f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f669f7-0b36-4c82-8e32-15314ec0c0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f669f7-0b36-4c82-8e32-15314ec0c0c4.jpg?1",
             "name": "Drifting Meadow",
             "text": "Drifting Meadow comes into play tapped.\noc\nT: Add o\nW to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10380,7 +10380,7 @@
         },
         {
             "id": "aca602fa-8308-5f6f-8f45-9367ffcdc4d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1",
             "name": "Gaea's Cradle",
             "text": "oc\nT: Add o\nG to your mana pool for each creature you control.",
             "colours": [],
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "a103086b-802c-5f24-bb32-dfc97bbb90fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f915cf0-6273-4896-bf24-fb0ec17b6096.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f915cf0-6273-4896-bf24-fb0ec17b6096.jpg?1",
             "name": "Phyrexian Tower",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice a creature: Add o\nBo\nB to your mana pool.",
             "colours": [],
@@ -10442,7 +10442,7 @@
         },
         {
             "id": "2d6a1039-b936-5aa0-83f7-396278d81e41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe2c562-ac25-4395-a9f0-8b246c7954b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfe2c562-ac25-4395-a9f0-8b246c7954b6.jpg?1",
             "name": "Polluted Mire",
             "text": "Polluted Mire comes into play tapped.\noc\nT: Add o\nB to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10471,7 +10471,7 @@
         },
         {
             "id": "25e97ed8-9118-5011-a81e-38f9f92d182e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48d55ff-10d0-4d9b-9202-02ebb2137953.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e48d55ff-10d0-4d9b-9202-02ebb2137953.jpg?1",
             "name": "Remote Isle",
             "text": "Remote Isle comes into play tapped.\noc\nT: Add o\nU to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10500,7 +10500,7 @@
         },
         {
             "id": "23cf163e-bcef-5613-bcbb-864e2e77825b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a18130-dbaa-4657-a885-3a96a985935a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a18130-dbaa-4657-a885-3a96a985935a.jpg?1",
             "name": "Serra's Sanctum",
             "text": "oc\nT: Add o\nW to your mana pool for each enchantment you control.",
             "colours": [],
@@ -10531,7 +10531,7 @@
         },
         {
             "id": "76548380-18b5-57da-b7f7-e9084bbe336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531eb8c-af8a-45c6-9058-3337c44e609f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1531eb8c-af8a-45c6-9058-3337c44e609f.jpg?1",
             "name": "Shivan Gorge",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2o\nR, oc\nT: Shivan Gorge deals 1 damage to each of your opponents.",
             "colours": [],
@@ -10562,7 +10562,7 @@
         },
         {
             "id": "b5aea189-5877-522e-824c-65c2cf2d35c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d01a6a7-c006-4fce-a546-8138baef421b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d01a6a7-c006-4fce-a546-8138baef421b.jpg?1",
             "name": "Slippery Karst",
             "text": "Slippery Karst comes into play tapped.\noc\nT: Add o\nG to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "bd7c9e76-51ca-584b-9a82-16b9f257754a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9940ce4-09d7-4e89-b456-e3126a83cfe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9940ce4-09d7-4e89-b456-e3126a83cfe1.jpg?1",
             "name": "Smoldering Crater",
             "text": "Smoldering Crater comes into play tapped.\noc\nT: Add o\nR to your mana pool.\nCycling o2 (You may pay o2 and discard this card from your hand to draw a card. Play this ability as an instant.)",
             "colours": [],
@@ -10620,7 +10620,7 @@
         },
         {
             "id": "3dbd84e5-7ef4-5e48-8e46-f23940758db7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2d6c41-7d82-4062-a783-37d88536279c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b2d6c41-7d82-4062-a783-37d88536279c.jpg?1",
             "name": "Thran Quarry",
             "text": "At the end of each turn, if you control no creatures, sacrifice Thran Quarry.\noc\nT: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -10647,7 +10647,7 @@
         },
         {
             "id": "5a757133-8ef9-5ffa-afe9-4ff0f5ebd548",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7ac9a5-340f-4509-826c-7b9416d47887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad7ac9a5-340f-4509-826c-7b9416d47887.jpg?1",
             "name": "Tolarian Academy",
             "text": "oc\nT: Add o\nU to your mana pool for each artifact you control.",
             "colours": [],
@@ -10678,7 +10678,7 @@
         },
         {
             "id": "566fb554-5412-50b2-8563-20e3b88a3443",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e35567-05df-4a3f-8c29-d8327abc2e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e35567-05df-4a3f-8c29-d8327abc2e8d.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10715,7 +10715,7 @@
         },
         {
             "id": "57bd34f7-317e-517c-8143-51c9cd3b3cde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34ef351-2864-42f6-8943-75bb6fffc9f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a34ef351-2864-42f6-8943-75bb6fffc9f7.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10752,7 +10752,7 @@
         },
         {
             "id": "8b1cdc8a-763a-59ed-9443-cdf2ebd270cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54db7822-ebed-4c7c-8ede-469d72fd694a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54db7822-ebed-4c7c-8ede-469d72fd694a.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10789,7 +10789,7 @@
         },
         {
             "id": "51ed2a66-b091-5e69-a513-8574bad7d25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f87b5c-78b4-443c-ad92-f37bb62d0bbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11f87b5c-78b4-443c-ad92-f37bb62d0bbe.jpg?1",
             "name": "Plains",
             "text": "oc\nT: Add o\nW to your mana pool.",
             "colours": [],
@@ -10826,7 +10826,7 @@
         },
         {
             "id": "0679ec70-fd3f-52ff-8e7c-14f685353db5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4ce9ff-c295-475b-b9fa-88ed65a84f35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4ce9ff-c295-475b-b9fa-88ed65a84f35.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10863,7 +10863,7 @@
         },
         {
             "id": "a5780572-29d8-52b7-a551-bdf30160cbff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf69bc5-8ee3-4b17-a3b1-51e35dd2d0dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbf69bc5-8ee3-4b17-a3b1-51e35dd2d0dc.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10900,7 +10900,7 @@
         },
         {
             "id": "19254d0b-971b-508e-92bd-9a4608da2d8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92724530-9c7a-44ab-9381-ee56bfccb641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92724530-9c7a-44ab-9381-ee56bfccb641.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10937,7 +10937,7 @@
         },
         {
             "id": "5bbd9f9e-fa99-5c25-b86f-10fe7c49ae90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43297ca7-846c-4bc4-a347-997279bc73d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43297ca7-846c-4bc4-a347-997279bc73d6.jpg?1",
             "name": "Island",
             "text": "oc\nT: Add o\nU to your mana pool.",
             "colours": [],
@@ -10974,7 +10974,7 @@
         },
         {
             "id": "fa45a692-879d-567d-8477-c2e5ef4cf3ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04dac6d-a7c2-44ee-b735-bd4eade06e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c04dac6d-a7c2-44ee-b735-bd4eade06e4e.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11011,7 +11011,7 @@
         },
         {
             "id": "70c732bd-81ac-5bcb-ae41-d86af16484eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a97cc92-6894-4c6f-8c8d-bfc9fdd4f974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a97cc92-6894-4c6f-8c8d-bfc9fdd4f974.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11048,7 +11048,7 @@
         },
         {
             "id": "9e16e053-eb3d-527d-8acb-f3679a96db8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d1102-0ad5-40df-9ca2-26448321d3d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72d1102-0ad5-40df-9ca2-26448321d3d1.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11085,7 +11085,7 @@
         },
         {
             "id": "61696d33-7e28-5d01-9599-383c5c5af12a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f24df7-65c6-4488-967a-e847bdec7db0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f24df7-65c6-4488-967a-e847bdec7db0.jpg?1",
             "name": "Swamp",
             "text": "oc\nT: Add o\nB to your mana pool.",
             "colours": [],
@@ -11122,7 +11122,7 @@
         },
         {
             "id": "165a01bb-4136-55d8-b375-256394a508af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d34a2f-09ed-4fb4-891a-890f450699bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9d34a2f-09ed-4fb4-891a-890f450699bd.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11159,7 +11159,7 @@
         },
         {
             "id": "9f273661-1a4f-5190-abf3-b0958635198f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be7e4b30-7f45-4109-b5ed-9223a9422d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be7e4b30-7f45-4109-b5ed-9223a9422d95.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11196,7 +11196,7 @@
         },
         {
             "id": "ed88aee7-f619-5b56-a563-522922c7fdb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d811021-40b1-43b1-88f1-04d711c2ab57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d811021-40b1-43b1-88f1-04d711c2ab57.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11233,7 +11233,7 @@
         },
         {
             "id": "41f55faa-3e44-50b3-8315-a64c260ca79a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b39c91-e367-487d-9820-893870df23b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b39c91-e367-487d-9820-893870df23b1.jpg?1",
             "name": "Mountain",
             "text": "oc\nT: Add o\nR to your mana pool.",
             "colours": [],
@@ -11270,7 +11270,7 @@
         },
         {
             "id": "facd71a4-bd47-5062-9bb4-ecf7b020cd70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38c68a5-86eb-4fb2-8a43-4a7d63195462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b38c68a5-86eb-4fb2-8a43-4a7d63195462.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11307,7 +11307,7 @@
         },
         {
             "id": "dfbc3eca-eab8-5025-a8d7-d79510256346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c151d945-7da0-4ab8-b0db-e41d10c0eb91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c151d945-7da0-4ab8-b0db-e41d10c0eb91.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11344,7 +11344,7 @@
         },
         {
             "id": "85413a85-8717-567f-9136-84a4c5d1c148",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8990632-f055-4583-ae85-5ac742549b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8990632-f055-4583-ae85-5ac742549b61.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],
@@ -11381,7 +11381,7 @@
         },
         {
             "id": "4366df09-610d-5509-bb9d-93fb2d06cbe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b43815e-8b8a-4745-bdf3-f72c8d60c48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b43815e-8b8a-4745-bdf3-f72c8d60c48c.jpg?1",
             "name": "Forest",
             "text": "oc\nT: Add o\nG to your mana pool.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/UST.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/UST.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "954658ae-c7f7-55b0-b96d-33db85205302",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2729cce6-f380-4c94-ac64-3a2487da6130.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2729cce6-f380-4c94-ac64-3a2487da6130.jpg?1",
             "name": "Adorable Kitten",
             "text": "When this creature enters the battlefield, roll a six-sided die. You gain life equal to the result.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "756ec740-7f4c-5447-8f18-8332010d7f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7290b56-22c2-4905-8add-0550a12db082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7290b56-22c2-4905-8add-0550a12db082.jpg?1",
             "name": "Aerial Toastmaster",
             "text": "Flying\n{3}{W}, Sacrifice another artifact: Aerial Toastmaster assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -76,7 +76,7 @@
         },
         {
             "id": "cc53cc02-6a60-5314-b3bb-36c31518f0f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426dc98-daae-4785-8384-d2b2dc2bbaad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f426dc98-daae-4785-8384-d2b2dc2bbaad.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -114,7 +114,7 @@
         },
         {
             "id": "22dc8b2a-f053-5a83-a1f0-f14c41715dde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd9d460-733f-44e5-a174-98b5636dc13c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cd9d460-733f-44e5-a174-98b5636dc13c.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -152,7 +152,7 @@
         },
         {
             "id": "76a3d519-7687-52d5-a91b-ef9de2845264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b77675-cf32-477f-8fdb-cbfa99c6de17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74b77675-cf32-477f-8fdb-cbfa99c6de17.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -190,7 +190,7 @@
         },
         {
             "id": "52f5fb21-1e01-52e5-a19a-df0363b9b97b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4f6-91e2-40fd-8fef-bb4deca39b15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4da8a4f6-91e2-40fd-8fef-bb4deca39b15.jpg?1",
             "name": "Amateur Auteur",
             "text": "Sacrifice Amateur Auteur: Destroy target enchantment.",
             "colours": [
@@ -228,7 +228,7 @@
         },
         {
             "id": "e370fd66-6838-5b25-8aa1-2f94fc25aa1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6921466-edac-40fc-8f5e-d8b2e766d1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6921466-edac-40fc-8f5e-d8b2e766d1dd.jpg?1",
             "name": "By Gnome Means",
             "text": "{1}{W}, Remove a counter from a permanent you control: Create a 1/1 colorless Gnome artifact creature token.\n{1}{W}, Sacrifice an artifact: Choose any kind of counter a printed card refers to, then put one of that counter on target permanent.",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "6d3f1dcd-4d69-5d17-a214-d3d0b1c56931",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94393ae5-5cae-4818-aed4-3a6b7c3eba76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94393ae5-5cae-4818-aed4-3a6b7c3eba76.jpg?1",
             "name": "Chivalrous Chevalier",
             "text": "Flying\nWhen Chivalrous Chevalier enters the battlefield, return a creature you control to its owner's hand unless you compliment an opponent.",
             "colours": [
@@ -296,7 +296,7 @@
         },
         {
             "id": "0bc59408-6985-5be3-8024-b129a12f3e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f4e8c-6519-4b35-b7b5-54a4c4e32c18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e4f4e8c-6519-4b35-b7b5-54a4c4e32c18.jpg?1",
             "name": "Do-It-Yourself Seraph",
             "text": "Flying\nWhenever Do-It-Yourself Seraph attacks, you may search your library for an artifact card, exile it, then shuffle your library.\nDo-It-Yourself Seraph has the text box of each card exiled with Do-It-Yourself Seraph in addition to its own.",
             "colours": [
@@ -332,7 +332,7 @@
         },
         {
             "id": "ed181229-d92a-5f9f-b905-bc3266b30b1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587ddc67-99ac-490d-93e1-e90a72b55ade.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587ddc67-99ac-490d-93e1-e90a72b55ade.jpg?1",
             "name": "Gimme Five",
             "text": "You gain 1 life for each person who high-fives you in the next thirty seconds. Each player in a silver-bordered game who high-fives you gains 1 life. (Offer high fives. Don't hit people.)",
             "colours": [
@@ -364,7 +364,7 @@
         },
         {
             "id": "24506898-4d8f-5714-8493-057e09d70fe1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b86826-307b-499b-92a4-a2de0839dc47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06b86826-307b-499b-92a4-a2de0839dc47.jpg?1",
             "name": "GO TO JAIL",
             "text": "When GO TO JAIL enters the battlefield, exile target creature an opponent controls until GO TO JAIL leaves the battlefield.\nAt the beginning of the upkeep of the exiled card's owner, that player rolls two six-sided dice. If he or she rolls doubles, sacrifice GO TO JAIL.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "182a17b1-06b5-58f1-9c82-22b15be3ac7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0053e1-96c7-40cd-84b2-b213195199c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf0053e1-96c7-40cd-84b2-b213195199c9.jpg?1",
             "name": "Half-Kitten, Half-",
             "text": "Whenever you're dealt damage,\nAugment {2}{W} ({2}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -430,7 +430,7 @@
         },
         {
             "id": "523ff187-2970-5b7e-8397-a33a7e0cdd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e1f7bd-972a-4e76-93eb-8c8acfa6ec43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07e1f7bd-972a-4e76-93eb-8c8acfa6ec43.jpg?1",
             "name": "Humming-",
             "text": "Flying\nWhenever you attack with two or more creatures,\nAugment {3}{W} ({3}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -464,7 +464,7 @@
         },
         {
             "id": "dc28f942-cf45-5c7b-8152-2428d6814d5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d84953b-c59c-45f8-aedd-e68bff7c7ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d84953b-c59c-45f8-aedd-e68bff7c7ce3.jpg?1",
             "name": "Jackknight",
             "text": "Whenever another artifact enters the battlefield under your control, put a +1/+1 counter on Jackknight. If that artifact is a Contraption, Jackknight gains lifelink until end of turn.",
             "colours": [
@@ -500,7 +500,7 @@
         },
         {
             "id": "84983ebf-3ea9-50a7-8b6d-2e75111beeab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c98931-cad7-4cea-97eb-f5e233ab2b36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39c98931-cad7-4cea-97eb-f5e233ab2b36.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from black borders (Nothing with a black border can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -542,7 +542,7 @@
         },
         {
             "id": "034884b5-f125-57e3-9676-5365f644096a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa78eb3f-cf10-4827-ab37-53383596c7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa78eb3f-cf10-4827-ab37-53383596c7f4.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from even collector numbers (Nothing with an even collector number can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -584,7 +584,7 @@
         },
         {
             "id": "7d8d2bf3-3bcd-5776-98d6-a862c6240320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b50cba-faa4-4847-90af-6fc20f62843e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b50cba-faa4-4847-90af-6fc20f62843e.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from loose lips (Nothing with an open mouth in its artwork can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -626,7 +626,7 @@
         },
         {
             "id": "af9b8c51-3ae2-5de8-b8a4-d511c6ab0bf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e3bd17-9928-4e7e-8f68-051aae75725e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e3bd17-9928-4e7e-8f68-051aae75725e.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from odd collector numbers (Nothing with an odd collector number can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -668,7 +668,7 @@
         },
         {
             "id": "d35ab476-cf46-5c01-8fdb-f33f3caf0acf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06b6fb8-27fc-4d5b-92b2-1a6a5005a262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e06b6fb8-27fc-4d5b-92b2-1a6a5005a262.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from two-word names (Nothing with exactly two words in its name can block, target, deal damage to, or attach to this creature. Hyphenated words are one word.)",
             "colours": [
@@ -710,7 +710,7 @@
         },
         {
             "id": "d36fe96d-cde0-5dc8-a429-68db67e3f84d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d81180a-71c8-403f-90c0-48daf81e43a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d81180a-71c8-403f-90c0-48daf81e43a1.jpg?1",
             "name": "Knight of the Kitchen Sink",
             "text": "First strike, protection from watermarks (Nothing with a watermark can block, target, deal damage to, or attach to this creature.)",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "31f945ff-0831-5da9-b9e5-3005e30931dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012cae92-bb03-48bc-9e34-01be54405f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/012cae92-bb03-48bc-9e34-01be54405f74.jpg?1",
             "name": "Knight of the Widget",
             "text": "Vigilance\nKnight of the Widget's power and toughness are each equal to the number of Order of the Widget watermarks among permanents you control.",
             "colours": [
@@ -788,7 +788,7 @@
         },
         {
             "id": "2826798a-ea8a-568f-a996-1ff9925039ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6e37a1-0dfd-4b8a-83d1-8f6d99123516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6e37a1-0dfd-4b8a-83d1-8f6d99123516.jpg?1",
             "name": "Midlife Upgrade",
             "text": "As an additional cost to cast Midlife Upgrade, sacrifice X Contraptions.\nAssemble X plus one Contraptions. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -820,7 +820,7 @@
         },
         {
             "id": "a67a5b16-afc8-5bf7-9ab1-95bdc2aea6ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d5f87-1c8b-414a-a91e-4805f5bdca54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830d5f87-1c8b-414a-a91e-4805f5bdca54.jpg?1",
             "name": "Oddly Uneven",
             "text": "Choose one \u2014\n\u2022 Destroy each creature with an odd number of words in its name. (Hyphenated words are one word.)\n\u2022 Destroy each creature with an even number of words in its name.",
             "colours": [
@@ -852,7 +852,7 @@
         },
         {
             "id": "8412fbe8-b471-5d69-b310-e7c08055458b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06081fa-857f-40b3-8041-257d5c5457bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a06081fa-857f-40b3-8041-257d5c5457bd.jpg?1",
             "name": "Old Guard",
             "text": "{W}, {T}: Tap target creature without reminder text. (Reminder text is still any italicized text in parentheses that explains rules you already know.)",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "e63d96af-f9ec-5b35-adcb-2e7c729a68ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d79ba7e-82a8-44ec-b72d-3cdd81126bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d79ba7e-82a8-44ec-b72d-3cdd81126bfa.jpg?1",
             "name": "Ordinary Pony",
             "text": "When this creature enters the battlefield, you may exile target non-Horse creature you control, then return it to the battlefield under its owner's control.",
             "colours": [
@@ -924,7 +924,7 @@
         },
         {
             "id": "c2c51a25-5213-5f5a-a54e-b8f131ce00ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c56df0-3f4d-489d-90c2-e9574f50929a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c56df0-3f4d-489d-90c2-e9574f50929a.jpg?1",
             "name": "Rhino-",
             "text": "Whenever this creature blocks,\nAugment {3}{W} ({3}{W}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "babdcaec-c896-5923-8700-b6866cae96e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcd4ec-d3bc-4aeb-824d-dc79543f8700.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcd4ec-d3bc-4aeb-824d-dc79543f8700.jpg?1",
             "name": "Riveting Rigger",
             "text": "When Riveting Rigger enters the battlefield, you may sacrifice another artifact. If you do, put two +1/+1 counters on Riveting Rigger and it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -994,7 +994,7 @@
         },
         {
             "id": "99cb1a66-a4d8-55c5-b48a-5a8ee5e96724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02c575-5685-44f5-8b47-89d888529d1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c02c575-5685-44f5-8b47-89d888529d1b.jpg?1",
             "name": "Rules Lawyer",
             "text": "State-based actions don't apply to you or other permanents you control. (You don't lose the game due to having 0 or less life or drawing from an empty library. Your creatures aren't destroyed due to damage or deathtouch and aren't put into a graveyard due to having 0 or less toughness. Your planeswalkers aren't put into a graveyard if they have 0 loyalty. You don't put a legendary permanent into a graveyard if you control two with the same name. Counters aren't removed from your permanents due to game rules. Permanents you control attached or combined illegally remain on the battlefield. For complete rules and regulations, see rule 704.)",
             "colours": [
@@ -1030,7 +1030,7 @@
         },
         {
             "id": "00ff33b2-92ea-56b0-9c2c-bba965f10d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc709f-c046-48c4-99a0-e9a3a7e79d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0bc709f-c046-48c4-99a0-e9a3a7e79d66.jpg?1",
             "name": "Sacrifice Play",
             "text": "A person outside the game chooses an attacking or blocking creature target opponent controls. That player sacrifices that creature.",
             "colours": [
@@ -1062,7 +1062,7 @@
         },
         {
             "id": "da98f418-01c3-53bf-945e-e46c1c1664a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483ab3dd-f2d5-49c8-b380-562236709561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/483ab3dd-f2d5-49c8-b380-562236709561.jpg?1",
             "name": "Shaggy Camel",
             "text": "When this creature enters the battlefield, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1098,7 +1098,7 @@
         },
         {
             "id": "f96777ac-7ccd-5f30-a8af-3ab4160c296c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f79554-5e9f-45aa-94ed-e765ee933fd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5f79554-5e9f-45aa-94ed-e765ee933fd3.jpg?1",
             "name": "Side Quest",
             "text": "Target player in a silver-bordered game you can see from your seat gains control of target creature you control until your next turn. At the beginning of your next upkeep, put two +1/+1 counters on that creature. (A creature is on the battlefield of only the game its controller is playing.)",
             "colours": [
@@ -1130,7 +1130,7 @@
         },
         {
             "id": "20ca9e1a-49ec-5314-ae01-486ba6ac0ef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf598741-c252-4388-979f-ad7392c8bf36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf598741-c252-4388-979f-ad7392c8bf36.jpg?1",
             "name": "Success!",
             "text": "Target creature gets +2/+2 until end of turn. If it's a host or has augment, it gains lifelink until end of turn.",
             "colours": [
@@ -1162,7 +1162,7 @@
         },
         {
             "id": "7c1d01e1-a15a-56d1-b581-c2e044145be8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942dd271-396c-4c79-9f67-20f2a494eb74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942dd271-396c-4c79-9f67-20f2a494eb74.jpg?1",
             "name": "Teacher's Pet",
             "text": "{2}{W}, Sacrifice Teacher's Pet: Search your library for a card with augment, combine it with target host you control, then shuffle your library.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "fbd411f8-c55b-5ca4-b335-f58b765d5a0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add4f168-c69e-4045-9725-47208ef69935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add4f168-c69e-4045-9725-47208ef69935.jpg?1",
             "name": "Animate Library",
             "text": "Enchant your library\nEnchanted library is an artifact creature on the battlefield with power and toughness each equal to the number of cards in it. It's still a library.\nIf enchanted library would leave the battlefield, exile Animate Library instead.",
             "colours": [
@@ -1232,7 +1232,7 @@
         },
         {
             "id": "e3aeb4ee-5957-5105-84a8-374ecca2210b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1a368e-51da-454d-a474-ff14fd2e7b76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a1a368e-51da-454d-a474-ff14fd2e7b76.jpg?1",
             "name": "Blurry Beeble",
             "text": "Blurry (This creature can be blocked only if defending player was wearing glasses as it was cast.)\nWhenever Blurry Beeble deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1268,7 +1268,7 @@
         },
         {
             "id": "f920476e-7599-5c0d-9c17-3bba4a818298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac8dd95-4a5a-496d-95ce-c3356fce7df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8ac8dd95-4a5a-496d-95ce-c3356fce7df4.jpg?1",
             "name": "Chipper Chopper",
             "text": "Flying\nWhen Chipper Chopper enters the battlefield, you may sacrifice another artifact. If you do, put two +1/+1 counters on Chipper Chopper and it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "41b478a6-af0f-54e2-b2fe-bafae034c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e34f0b-f94b-49fb-a667-8c11dd9d59d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14e34f0b-f94b-49fb-a667-8c11dd9d59d4.jpg?1",
             "name": "Clocknapper",
             "text": "When Clocknapper enters the battlefield, choose beginning phase, precombat main phase, combat phase, postcombat main phase, or ending phase. Steal that phase from target player during his or her next turn. (That phase occurs as though it's your turn instead.)",
             "colours": [
@@ -1339,7 +1339,7 @@
         },
         {
             "id": "3bde8afb-51bf-5e03-a483-1283df80a9ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c2219-a372-435e-9857-3ed949971d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c4c2219-a372-435e-9857-3ed949971d8e.jpg?1",
             "name": "Crafty Octopus",
             "text": "When this creature enters the battlefield, this creature assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -1376,7 +1376,7 @@
         },
         {
             "id": "97456cfa-ab54-57f5-bf80-2501c451b592",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e0713c-8358-46fc-9618-66a986d681cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5e0713c-8358-46fc-9618-66a986d681cb.jpg?1",
             "name": "Crow Storm",
             "text": "Create a 1/2 blue Bird creature token with flying named Storm Crow.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
             "colours": [
@@ -1408,7 +1408,7 @@
         },
         {
             "id": "6fd036b4-a60c-5da7-88be-6013c48eff5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f829be-d4f5-4231-a45d-1869222e5e24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f829be-d4f5-4231-a45d-1869222e5e24.jpg?1",
             "name": "Defective Detective",
             "text": "Defective Detective can't be blocked.\nWhen Defective Detective enters the battlefield, a person outside the game looks at target opponent's hand and chooses a card from it. That player reveals that card.",
             "colours": [
@@ -1443,7 +1443,7 @@
         },
         {
             "id": "03cd6ff2-32aa-5d40-9786-98da22f78e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2655be-7c53-4350-86ee-6c0053809b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab2655be-7c53-4350-86ee-6c0053809b59.jpg?1",
             "name": "Five-Finger Discount",
             "text": "Put target nonland permanent into your hand. You may spend mana as though it were mana of any color the next time you cast that card.",
             "colours": [
@@ -1475,7 +1475,7 @@
         },
         {
             "id": "c54954bb-9be7-5ce8-a5df-112bdae3d34c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b913bbbd-a4c5-4e90-98ff-74be2c907d87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b913bbbd-a4c5-4e90-98ff-74be2c907d87.jpg?1",
             "name": "Graveyard Busybody",
             "text": "All graveyards are also your graveyards.\nGraveyard Busybody's power and toughness are each equal to the number of cards with flavor text in your graveyards.",
             "colours": [
@@ -1510,7 +1510,7 @@
         },
         {
             "id": "226f144d-9118-50bc-84e3-cd16fa73f253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e36f79-4621-4f0c-be98-90c2efb2ace7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4e36f79-4621-4f0c-be98-90c2efb2ace7.jpg?1",
             "name": "Half-Shark, Half-",
             "text": "At the beginning of your upkeep,\nAugment {5}{U} ({5}{U}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -1544,7 +1544,7 @@
         },
         {
             "id": "abd7114a-f29d-55a8-a0fe-5445918731c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba905b6e-9568-4aa6-a281-248c79af87ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba905b6e-9568-4aa6-a281-248c79af87ec.jpg?1",
             "name": "Incite Insight",
             "text": "Assemble X Contraptions. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -1576,7 +1576,7 @@
         },
         {
             "id": "5098ca81-9795-5132-aa82-4f0747d45772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c28ba7-2270-4a59-bc0a-528e2a97970f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c28ba7-2270-4a59-bc0a-528e2a97970f.jpg?1",
             "name": "Kindly Cognician",
             "text": "Spells you cast that refer to artifacts or Contraptions in their rules text cost {1} less to cast.",
             "colours": [
@@ -1612,7 +1612,7 @@
         },
         {
             "id": "30fee560-d62e-5b24-b452-d8d020a52121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a81eb1b-e97b-46a7-aa5f-dcb5d20f2e22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a81eb1b-e97b-46a7-aa5f-dcb5d20f2e22.jpg?1",
             "name": "Magic Word",
             "text": "Enchant creature\nAs Magic Word enters the battlefield, choose a word.\nWhisper the chosen word: Tap enchanted creature.",
             "colours": [
@@ -1646,7 +1646,7 @@
         },
         {
             "id": "f99d335e-1390-5136-90a3-b76404e92b51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e99b47-acda-4888-8b2e-0852ba3b931c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30e99b47-acda-4888-8b2e-0852ba3b931c.jpg?1",
             "name": "Mer Man",
             "text": "When this creature enters the battlefield, you may draw a card.",
             "colours": [
@@ -1683,7 +1683,7 @@
         },
         {
             "id": "41b44da1-718f-53c9-b158-118352c6c2e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b111425a-adaa-4938-88a1-6fdd0bcecc39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b111425a-adaa-4938-88a1-6fdd0bcecc39.jpg?1",
             "name": "More or Less",
             "text": "Add or subtract 1 or one from a number or number word on target spell or permanent until end of turn.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "a59dc1fd-eb01-50bf-808e-afc03f7f59ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c121f3-01cb-4e1c-a8a7-6841de28645b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05c121f3-01cb-4e1c-a8a7-6841de28645b.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1753,7 +1753,7 @@
         },
         {
             "id": "ff48fde3-2d7b-52d3-8617-46fb8b497a57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b946b9bd-501c-4d3c-80f2-aac31aadd083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b946b9bd-501c-4d3c-80f2-aac31aadd083.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1791,7 +1791,7 @@
         },
         {
             "id": "73ac067e-181b-54c6-8890-23b113e63daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73115807-ab27-4c13-928b-dbd6ba990da3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73115807-ab27-4c13-928b-dbd6ba990da3.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1829,7 +1829,7 @@
         },
         {
             "id": "aaddf260-62f4-527b-9c6e-9ce695032360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bffb474-4f90-47ec-ae45-833ea825049e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bffb474-4f90-47ec-ae45-833ea825049e.jpg?1",
             "name": "Novellamental",
             "text": "Flying\nNovellamental can block only creatures with flying.",
             "colours": [
@@ -1867,7 +1867,7 @@
         },
         {
             "id": "798ef64d-8db8-510a-b17a-f3d290ea6a9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752537c6-ee47-46c5-a6c7-cbf16e3a1dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752537c6-ee47-46c5-a6c7-cbf16e3a1dcf.jpg?1",
             "name": "Numbing Jellyfish",
             "text": "When this creature enters the battlefield, roll a six-sided die. Target player puts the top X cards of his or her library into his or her graveyard, where X is the result.",
             "colours": [
@@ -1903,7 +1903,7 @@
         },
         {
             "id": "5565f6fc-3534-5fb2-abbc-a1a41f9cd767",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6237d7-454b-4b1b-b732-1adda35d746d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e6237d7-454b-4b1b-b732-1adda35d746d.jpg?1",
             "name": "S.N.E.A.K. Dispatcher",
             "text": "{2}{U}, {T}: Look at the top card of target player's library. If it has an Agents of S.\nN.\nE.\nA.\nK. watermark, you may reveal it and put it into your hand. Otherwise, put it on the top or bottom of its owner's library.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "9183e564-93ae-571f-840f-8a3d9de2a086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd90f0f-9009-4002-86ae-3353843735c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bd90f0f-9009-4002-86ae-3353843735c7.jpg?1",
             "name": "Socketed Sprocketer",
             "text": "{T}: Uninstall all results from Socketed Sprocketer, then roll a six-sided die. Install the result on Socketed Sprocketer. (Put the die on this card.)\nYou may uninstall a result from Socketed Sprocketer to use it for a die you rolled.\nUninstall a 6 from Socketed Sprocketer: Draw a card.",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "f807cf5d-18ac-5e37-95e9-62517bafa9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631bd92-2046-468d-8b10-d583a318ed24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f631bd92-2046-468d-8b10-d583a318ed24.jpg?1",
             "name": "Spell Suck",
             "text": "Counter target spell, then assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -2006,7 +2006,7 @@
         },
         {
             "id": "912536e1-4ccb-5100-8904-061745b3c805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84a9db-8130-489b-9f76-e3ecd35a0fd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e84a9db-8130-489b-9f76-e3ecd35a0fd8.jpg?1",
             "name": "Spy Eye",
             "text": "Flying\nWhenever Spy Eye deals combat damage to a player, you may draw a card from that player's library.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "2319b140-7959-5526-a0a3-a7771a95dbe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e1f2c-da19-45aa-9f48-997a0d62587e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/726e1f2c-da19-45aa-9f48-997a0d62587e.jpg?1",
             "name": "Suspicious Nanny",
             "text": "Whenever Suspicious Nanny deals combat damage to a player, it reassembles target Contraption that player controls. (Gain control of it and move it onto one of your sprockets.)",
             "colours": [
@@ -2077,7 +2077,7 @@
         },
         {
             "id": "608164c0-27b3-566d-be98-5bf1a8679464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bb1492-99de-4606-b2fd-6bbe1961611f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32bb1492-99de-4606-b2fd-6bbe1961611f.jpg?1",
             "name": "Time Out",
             "text": "Roll a six-sided die. Put target nonland permanent into its owner's library just beneath the top X cards of that library, where X is the result.",
             "colours": [
@@ -2109,7 +2109,7 @@
         },
         {
             "id": "97f655a9-8b81-5953-89d0-d2953719a20f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a650610-20e2-4f16-b59c-2ea7779f6e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a650610-20e2-4f16-b59c-2ea7779f6e47.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Switch target creature's power and toughness until end of turn.\n\u2022 Target creature can't be blocked this turn.\n\u2022 Draw a card. If that card's art is by Wayne England, you may reveal it and draw another card.\n\u2022 Assemble a Contraption.",
             "colours": [
@@ -2147,7 +2147,7 @@
         },
         {
             "id": "7d4c7d8b-0be9-55db-93f4-22a78866defe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a90b2b6-d96e-4c13-83be-849d2ec1d845.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a90b2b6-d96e-4c13-83be-849d2ec1d845.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Untap two target permanents.\n\u2022 Tap each permanent target player controls with exactly one word in its name.\n\u2022 Discard all the cards in your hand, then draw that many cards.\n\u2022 Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2185,7 +2185,7 @@
         },
         {
             "id": "a30c83fa-5268-5b8c-bcdb-49b6a4c5f588",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfc9416-06d6-40af-8b3d-62371b3da7c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfc9416-06d6-40af-8b3d-62371b3da7c5.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Draw a card from an opponent's library.\n\u2022 Copy target instant or sorcery spell. You may choose new targets for the copy.\n\u2022 Until end of turn, target creature loses all abilities and becomes a blue Frog with base power and toughness 1/1.\n\u2022 Create a 1/1 colorless Gnome artifact creature token.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "1db7ffa8-b78c-5f80-ad78-199be5b7afe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12272ce6-ab1f-4576-9e50-21d324263c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12272ce6-ab1f-4576-9e50-21d324263c44.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Return target permanent to its controller's hand.\n\u2022 Draw two cards, then discard a card.\n\u2022 Change the target of target spell with a single target.\n\u2022 Turn over target nontoken creature.",
             "colours": [
@@ -2261,7 +2261,7 @@
         },
         {
             "id": "b8551573-9c09-5dc2-a440-d260fcbe6fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e84dd2-01f9-4fad-8a24-cc86424d09a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8e84dd2-01f9-4fad-8a24-cc86424d09a2.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Counter target black-bordered spell.\n\u2022 Return target creature to its owner's hand.\n\u2022 Untap each permanent you control with a watermark.\n\u2022 Roll two six-sided dice. Target player puts the top X cards of his or her library into his or her graveyard, where X is the total of those results.",
             "colours": [
@@ -2299,7 +2299,7 @@
         },
         {
             "id": "3ad5d66e-8406-5a35-bcee-ae747a88a917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41e6c51-d96a-436f-94c5-5d1e19c5e0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41e6c51-d96a-436f-94c5-5d1e19c5e0d5.jpg?1",
             "name": "Very Cryptic Command",
             "text": "Choose two \u2014\n\u2022 Scry 3.\n\u2022 Create a 2/2 black Rogue creature token with menace.\n\u2022 Add or subtract 1 or one from a number or number word on target spell or permanent until end of turn.\n\u2022 Return all artifacts target player controls to their owner's hand.",
             "colours": [
@@ -2337,7 +2337,7 @@
         },
         {
             "id": "b1eee0bb-f848-5487-b62b-249331d1843d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766cfce-6edd-4e89-aa78-f30182120804.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f766cfce-6edd-4e89-aa78-f30182120804.jpg?1",
             "name": "Wall of Fortune",
             "text": "Defender\nYou may tap an untapped Wall you control to have any player reroll a die that player rolled.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "26e1bb24-a541-5fcc-907c-c60dbdde87a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30980d4-b12e-4504-b257-c920b073fd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e30980d4-b12e-4504-b257-c920b073fd91.jpg?1",
             "name": "Big Boa Constrictor",
             "text": "When this creature enters the battlefield, roll a six-sided die. Target opponent loses life equal to the result.",
             "colours": [
@@ -2408,7 +2408,7 @@
         },
         {
             "id": "dc79e8a5-1f5d-5f90-ab0e-f99a38e789dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8a98f2-c777-4dc0-ab68-2b1df7ce1ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8a98f2-c777-4dc0-ab68-2b1df7ce1ddd.jpg?1",
             "name": "capital offense",
             "text": "target creature gets -x/-x until end of turn, where x is the number of times a capital letter appears in its rules text. (ignore reminder text and flavor text.)",
             "colours": [
@@ -2440,7 +2440,7 @@
         },
         {
             "id": "53ad8c80-413e-56df-809e-4766b48979d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bba0ec-d2d4-45e8-84f5-7c6baf40afcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9bba0ec-d2d4-45e8-84f5-7c6baf40afcb.jpg?1",
             "name": "Dirty Rat",
             "text": "When this creature enters the battlefield, target opponent discards a card.",
             "colours": [
@@ -2476,7 +2476,7 @@
         },
         {
             "id": "465e104b-a40b-59a2-ac8f-95e8141bd2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a2f09c-60b8-4020-a4f6-f3d51600b234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49a2f09c-60b8-4020-a4f6-f3d51600b234.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2514,7 +2514,7 @@
         },
         {
             "id": "f27167b1-cdae-5fce-8b94-a394e52ef392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36cc317-c78f-4941-9a45-541c11efd7af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b36cc317-c78f-4941-9a45-541c11efd7af.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2552,7 +2552,7 @@
         },
         {
             "id": "d2f3cbdc-f8f5-53dd-8a62-f499f4e09a53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6c930e-a20a-436a-96c4-531c7a4961d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6c930e-a20a-436a-96c4-531c7a4961d7.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2590,7 +2590,7 @@
         },
         {
             "id": "5365f877-084f-5411-8bc1-d42c939d8da0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23561cc-007c-483a-ae08-9e87ef7774c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b23561cc-007c-483a-ae08-9e87ef7774c7.jpg?1",
             "name": "Extremely Slow Zombie",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)",
             "colours": [
@@ -2628,7 +2628,7 @@
         },
         {
             "id": "f2151178-8cb0-5ef3-96c3-2058cf90ff84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b7148-e98f-40a4-95e3-ffdd2daa324b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f4b7148-e98f-40a4-95e3-ffdd2daa324b.jpg?1",
             "name": "Finders, Keepers",
             "text": "Destroy target creature, then assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -2660,7 +2660,7 @@
         },
         {
             "id": "f4352e65-e2e4-5e66-957b-db8c5a7115f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380d297c-674a-4d0f-964d-7405db81b27a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/380d297c-674a-4d0f-964d-7405db81b27a.jpg?1",
             "name": "Hangman",
             "text": "As Hangman enters the battlefield, secretly note a word with six to eight letters.\n{1}: Target player who doesn't control Hangman guesses the noted word or an unguessed letter in that word. If he or she guesses wrong, put a +1/+1 counter on Hangman. Any player may activate this ability.\nWhen a player guesses the noted word or all of its letters, sacrifice Hangman.",
             "colours": [
@@ -2695,7 +2695,7 @@
         },
         {
             "id": "c40542a6-bd62-55c8-aef7-d19e87e0fa70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329d79a-08d8-4228-9ca2-97747eec2c44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4329d79a-08d8-4228-9ca2-97747eec2c44.jpg?1",
             "name": "Hazmat Suit (Used)",
             "text": "Enchant creature\nEnchanted creature gets +2/+1 and has menace.\nWhenever a player's skin or fingernail touches enchanted creature, that player loses 2 life.",
             "colours": [
@@ -2729,7 +2729,7 @@
         },
         {
             "id": "6ae5c235-65fe-59c4-a541-46cb2bef04c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc122cf-a4bf-42e0-884a-f655c68a46e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fc122cf-a4bf-42e0-884a-f655c68a46e5.jpg?1",
             "name": "Hoisted Hireling",
             "text": "Hoisted Hireling has flying as long as it's being held above the battlefield.",
             "colours": [
@@ -2763,7 +2763,7 @@
         },
         {
             "id": "4396b0bc-50d5-5633-89ed-c57b8add5eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9acc1ce-964e-425c-88a6-fe641d3f1f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9acc1ce-964e-425c-88a6-fe641d3f1f5b.jpg?1",
             "name": "Inhumaniac",
             "text": "At the beginning of your upkeep, roll a six-sided die. On a 3 or 4, put a +1/+1 counter on Inhumaniac. On a 5 or higher, put two +1/+1 counters on it. On a 1, remove all +1/+1 counters from Inhumaniac.",
             "colours": [
@@ -2797,7 +2797,7 @@
         },
         {
             "id": "a60385a2-ac0a-56d6-9843-5b930665f69d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0b8b2-0202-4e68-970d-cd006f63de61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7f0b8b2-0202-4e68-970d-cd006f63de61.jpg?1",
             "name": "Masterful Ninja",
             "text": "Haste\nReveal Masterful Ninja from your hand: Masterful Ninja is on the battlefield and in your hand until end of turn.\n{1}{B}: Masterful Ninja gets +1/+1 until end of turn.",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "d4f5c755-5bdd-5c28-8fbe-1d892e451203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c50dc-2bd6-47e3-9ca5-49e38898e774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff0c50dc-2bd6-47e3-9ca5-49e38898e774.jpg?1",
             "name": "Ninja",
             "text": "You may activate Ninja's augment ability any time you could cast an instant.\nWhenever this creature deals combat damage to a player,\nAugment {2}{B} ({2}{B}, Reveal this card from your hand: Combine it with target host. Augment only as\u2014oh, nevermind.)",
             "colours": [
@@ -2866,7 +2866,7 @@
         },
         {
             "id": "659950fb-d7c4-5603-bd1f-f9238ce7a8db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c576ec-bb05-446b-8b0b-20d4246831ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c576ec-bb05-446b-8b0b-20d4246831ee.jpg?1",
             "name": "Old-Fashioned Vampire",
             "text": "Flying\nOld-Fashioned Vampire gets +2/+2 and has deathtouch as long as it's dark outdoors.",
             "colours": [
@@ -2900,7 +2900,7 @@
         },
         {
             "id": "66f4d0a0-1d04-52e2-83a0-dea5a9c9daa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5279543-3678-40f2-9bea-0a75c2044017.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5279543-3678-40f2-9bea-0a75c2044017.jpg?1",
             "name": "Over My Dead Bodies",
             "text": "Creature cards in graveyards can attack and block as though they were on the battlefield, can block or be blocked only by creature cards in graveyards, are Zombies in addition to their other types, and have undeathtouch. (If they would deal damage to a creature card, exile that creature card instead.)\nCreature cards in your graveyard have haste.",
             "colours": [
@@ -2932,7 +2932,7 @@
         },
         {
             "id": "ef10a4ba-ce01-578f-b207-28bdf590f578",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3492b7-325b-40f4-b84f-cd1ba1d0256e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb3492b7-325b-40f4-b84f-cd1ba1d0256e.jpg?1",
             "name": "Overt Operative",
             "text": "Menace\nWhenever Overt Operative deals combat damage to a player, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "bdd8e35c-88e2-5b09-b630-468450d8c28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3587b9-e727-4f37-b4d6-1baa7316262f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3587b9-e727-4f37-b4d6-1baa7316262f.jpg?1",
             "name": "\"Rumors of My Death . . .\"",
             "text": "{3}{B}, Exile a permanent you control with a League of Dastardly Doom watermark: Return a permanent card with a League of Dastardly Doom watermark from your graveyard to the battlefield.",
             "colours": [
@@ -3000,7 +3000,7 @@
         },
         {
             "id": "1d0d7e55-b402-5890-8f7b-cb36fdb8903e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246e2a7b-c7dd-4b30-9d7a-60a02b605a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/246e2a7b-c7dd-4b30-9d7a-60a02b605a04.jpg?1",
             "name": "Skull Saucer",
             "text": "Flying\nWhen Skull Saucer enters the battlefield, destroy target creature and put your head on the table. Sacrifice Skull Saucer when your head stops touching the table.",
             "colours": [
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "3ac81113-4804-5887-8c9e-1a4a49d07627",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d37a3fc-d652-4c87-892e-bf8b8dc71e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d37a3fc-d652-4c87-892e-bf8b8dc71e35.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, that player reveals his or her hand. You choose a card from it with the longest name. That player discards that card.",
             "colours": [
@@ -3076,7 +3076,7 @@
         },
         {
             "id": "b5360a7b-8995-52e6-96df-7101985c0179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4df93-078e-4266-82f2-cf4fc5945ce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5d4df93-078e-4266-82f2-cf4fc5945ce3.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, you may destroy target creature facing left in its art. (Creatures without faces don't face anywhere.)",
             "colours": [
@@ -3117,7 +3117,7 @@
         },
         {
             "id": "a0f484a6-1f64-5f0b-b9a0-bf0463c7cfd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94008ffb-f0fe-4e83-bf73-d8ade4104d86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94008ffb-f0fe-4e83-bf73-d8ade4104d86.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, that player loses a finger until Sly Spy leaves the battlefield. (The finger is chosen by its owner and can't roll dice or touch cards.)",
             "colours": [
@@ -3158,7 +3158,7 @@
         },
         {
             "id": "bdb4b8fd-d187-50f2-a50c-5974389c82c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596ee7af-cc78-41b5-93c5-945189d5e46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/596ee7af-cc78-41b5-93c5-945189d5e46c.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, you may destroy target creature facing right in its art. (Creatures without faces don't face anywhere.)",
             "colours": [
@@ -3199,7 +3199,7 @@
         },
         {
             "id": "1fbd80e9-6547-5131-9ad5-5a1eefa3b7bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc2eae1-8e24-4bef-aa03-a3e428f291a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc2eae1-8e24-4bef-aa03-a3e428f291a1.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, that player reveals the top card of his or her library. Put that card into your hand and you lose life equal to its converted mana cost.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "fbb23fa9-744e-5577-a43a-def19d3ae121",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaf902f-4139-4a54-a519-a60aea84e669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaf902f-4139-4a54-a519-a60aea84e669.jpg?1",
             "name": "Sly Spy",
             "text": "Whenever Sly Spy deals combat damage to a player, roll a six-sided die. That player loses life equal to the result.",
             "colours": [
@@ -3281,7 +3281,7 @@
         },
         {
             "id": "05850043-d6a5-57d8-8a15-2ef8a80ed7de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca78c52-f1b5-4c3a-aa7e-99b54332c332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ca78c52-f1b5-4c3a-aa7e-99b54332c332.jpg?1",
             "name": "Snickering Squirrel",
             "text": "You may tap Snickering Squirrel to increase the result of a die any player rolled by 1.",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "14bb21f3-5ab7-5c46-b861-fd4aaa53c7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e90b22-6f43-4e9a-a236-f33191768813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0e90b22-6f43-4e9a-a236-f33191768813.jpg?1",
             "name": "Spike, Tournament Grinder",
             "text": "({PB} can be paid with either {B} or 2 life.)\n{PB}{PB}{PB}{PB}: Choose a card you own from outside the game that has been banned or restricted in a Constructed format, reveal that card, and put it into your hand.",
             "colours": [
@@ -3353,7 +3353,7 @@
         },
         {
             "id": "e4be2b4a-3f4c-577e-8fe3-f81d0b93e0ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f735f1-2528-424d-8454-e94746a2b58f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6f735f1-2528-424d-8454-e94746a2b58f.jpg?1",
             "name": "Squirrel-Powered Scheme",
             "text": "Increase the result of each die you roll by 2.",
             "colours": [
@@ -3385,7 +3385,7 @@
         },
         {
             "id": "bc8f8e2b-8041-56f1-bb57-51a2821226e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a393ca-3bb1-4da2-9ece-6421b3814091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a393ca-3bb1-4da2-9ece-6421b3814091.jpg?1",
             "name": "Steady-Handed Mook",
             "text": "Deathtouch\nWhen Steady-Handed Mook enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -3420,7 +3420,7 @@
         },
         {
             "id": "6f3366da-545b-50c5-8584-a39f5907634d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b719a4-3ac5-4e45-baa6-4c058e764129.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90b719a4-3ac5-4e45-baa6-4c058e764129.jpg?1",
             "name": "Stinging Scorpion",
             "text": "When this creature enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "b2b04baa-4ef7-5f6e-9136-c92475d9258b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c349f19b-1f9e-4541-943a-a6933d01ad73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c349f19b-1f9e-4541-943a-a6933d01ad73.jpg?1",
             "name": "Subcontract",
             "text": "A person outside the game looks at target opponent's hand and chooses a nonland card from it. That player discards that card.",
             "colours": [
@@ -3488,7 +3488,7 @@
         },
         {
             "id": "d7238442-60d2-5ec4-9701-d3d40563336a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66d5bb-a0cc-48fa-9d98-4195debc188a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd66d5bb-a0cc-48fa-9d98-4195debc188a.jpg?1",
             "name": "Summon the Pack",
             "text": "Open a sealed Magic booster pack, reveal the cards, and put all creature cards revealed this way onto the battlefield under your control. They're Zombies in addition to their other types. (Remove those cards from your deck before beginning a new game.)",
             "colours": [
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "930d1fc3-3d81-5167-b923-27e73a3cefe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2d319-f03b-4a39-a177-07161e72c416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64e2d319-f03b-4a39-a177-07161e72c416.jpg?1",
             "name": "Zombified",
             "text": "{4}{B}: Combine Zombified from your graveyard with target host.\n{2}{B}, Exile a creature card from your graveyard:\nAugment {4}{B} ({4}{B}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -3554,7 +3554,7 @@
         },
         {
             "id": "4f0aa84a-6efd-539a-9d55-49038d7c3c8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec4563d-1a83-402c-b209-0e1f740a6523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec4563d-1a83-402c-b209-0e1f740a6523.jpg?1",
             "name": "The Big Idea",
             "text": "{2}{BR}{BR}, {T}: Roll a six-sided die. Create a number of 1/1 red Brainiac creature tokens equal to the result.\nTap three untapped Brainiacs you control: The next time you would roll a six-sided die, instead roll two six-sided dice and use the total of those results.",
             "colours": [
@@ -3592,7 +3592,7 @@
         },
         {
             "id": "f1b1928a-393d-56b8-9058-80a1c145a518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6964c3d5-4bb7-46b1-a057-878af73f2e5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6964c3d5-4bb7-46b1-a057-878af73f2e5f.jpg?1",
             "name": "Box of Free-Range Goblins",
             "text": "Roll a six-sided die. Create a number of 1/1 red Goblin creature tokens equal to the result.",
             "colours": [
@@ -3624,7 +3624,7 @@
         },
         {
             "id": "a543eae4-ed87-5870-88e9-08be0262aa1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4930b9d5-939f-4463-9f9a-235aa3a4f8c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4930b9d5-939f-4463-9f9a-235aa3a4f8c4.jpg?1",
             "name": "Bumbling Pangolin",
             "text": "When this creature enters the battlefield, you may destroy target artifact.",
             "colours": [
@@ -3661,7 +3661,7 @@
         },
         {
             "id": "d918bf8f-7fea-5f5a-9045-7fe6b999bc53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2225f-4bac-4579-b8ee-9ded9af3294b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fe2225f-4bac-4579-b8ee-9ded9af3294b.jpg?1",
             "name": "Common Iguana",
             "text": "When this creature enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -3697,7 +3697,7 @@
         },
         {
             "id": "60795102-0cdf-5589-bb5c-e6bd63f66382",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb8115-3a47-4d7e-a3ed-b2e81ca27255.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4afb8115-3a47-4d7e-a3ed-b2e81ca27255.jpg?1",
             "name": "The Countdown Is at One",
             "text": "Players play a Magic subgame, starting at 1 life and using their libraries as their decks. For the rest of the main game, if a source would deal damage to a player who didn't win the subgame, it deals double that damage to that player instead.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "edce57dc-8189-5028-a653-cf809165812e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f49ff5d-292d-432a-8548-aed8cb0d98ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f49ff5d-292d-432a-8548-aed8cb0d98ea.jpg?1",
             "name": "Feisty Stegosaurus",
             "text": "When this creature enters the battlefield, roll a six-sided die. This creature deals damage equal to the result to target creature an opponent controls.",
             "colours": [
@@ -3765,7 +3765,7 @@
         },
         {
             "id": "81ebd535-68de-5439-abfd-48af42da922b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33c84b-3807-430e-8315-5de2d7f6fa32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33c84b-3807-430e-8315-5de2d7f6fa32.jpg?1",
             "name": "Garbage Elemental",
             "text": "Frenzy 2 (Whenever this creature attacks and isn't blocked, it gets +2/+0 until end of turn.)\nGarbage Elemental can't be blocked by wordy creatures. (A creature is wordy if it has four or more lines of rules text.)",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "26c99733-b1cb-53ed-9a03-f38b2dbe1fda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427b338-42d0-44cc-9594-9e50ccbdd809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9427b338-42d0-44cc-9594-9e50ccbdd809.jpg?1",
             "name": "Garbage Elemental",
             "text": "When Garbage Elemental enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
             "colours": [
@@ -3846,7 +3846,7 @@
         },
         {
             "id": "566dc68c-78c6-51e1-98ad-5e3044556281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5579dfb-4e63-4e7b-80c5-56949518c71e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5579dfb-4e63-4e7b-80c5-56949518c71e.jpg?1",
             "name": "Garbage Elemental",
             "text": "Battle cry (Whenever this creature attacks, each other attacking creature gets +1/+0 until end of turn.)\nWhen Garbage Elemental enters the battlefield, roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "c8647f26-3414-5b12-80fa-b2304fbf5e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1a004-4d80-481b-8f3f-30cc362556bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c1a004-4d80-481b-8f3f-30cc362556bc.jpg?1",
             "name": "Garbage Elemental",
             "text": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)\nWhen Garbage Elemental enters the battlefield, roll a six-sided die. Garbage Elemental deals damage equal to the result to target opponent.",
             "colours": [
@@ -3926,7 +3926,7 @@
         },
         {
             "id": "37ae4a82-7e9f-5556-b787-fcc1a2b61535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8ae74c-6aba-4ea7-8afd-ce319ef6b047.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef8ae74c-6aba-4ea7-8afd-ce319ef6b047.jpg?1",
             "name": "Garbage Elemental",
             "text": "Unleash (You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)\nEach creature you control with any kind of counter on it has art menace. (They can't be blocked except by creatures with two or more visible figures in their art.)",
             "colours": [
@@ -3966,7 +3966,7 @@
         },
         {
             "id": "96073680-2173-5fe9-bc04-ad71974bc3ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de96731b-d4b1-4c6c-8413-f9e00030d11d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de96731b-d4b1-4c6c-8413-f9e00030d11d.jpg?1",
             "name": "Garbage Elemental",
             "text": "Last strike (This creature deals combat damage after creatures without last strike.)\nBattalion \u2014 Whenever Garbage Elemental and at least two other creatures attack, target creature can't block this turn.",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "a12af461-73dd-5ebc-b972-cc8af1806090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e94470-ca77-4b4d-929c-9f694a74260f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e94470-ca77-4b4d-929c-9f694a74260f.jpg?1",
             "name": "Goblin Haberdasher",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nOther creatures you control wearing hats in their art have menace.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "db0b93f4-7897-599d-9f52-963726310815",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e6915b-2077-45aa-93e7-29b5f14beb51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e6915b-2077-45aa-93e7-29b5f14beb51.jpg?1",
             "name": "Half-Orc, Half-",
             "text": "Trample\nAt the beginning of each end step, if an opponent was dealt damage this turn,\nAugment {1}{R}{R} ({1}{R}{R}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "16c3e901-50e1-5729-ba33-a5c86f35b53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d58edc-0881-4bfb-aa47-143741cd66e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84d58edc-0881-4bfb-aa47-143741cd66e7.jpg?1",
             "name": "Hammer Helper",
             "text": "Gain control of target creature until end of turn. Untap that creature and roll a six-sided die. Until end of turn, it gains haste and gets +X/+0, where X is the result.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "effc4f77-f9f7-5b56-9089-4b7bd997c2f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e613e-817c-42c4-8124-407a85f633b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72e613e-817c-42c4-8124-407a85f633b3.jpg?1",
             "name": "Hammer Jammer",
             "text": "As Hammer Jammer enters the battlefield, roll a six-sided die. Hammer Jammer enters the battlefield with a number of +1/+1 counters on it equal to the result.\nWhenever you roll a die, remove all +1/+1 counters from Hammer Jammer, then put a number of +1/+1 counters on it equal to the result.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "cb36062f-9856-5748-9c87-06e6398d34af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591d888-b9c4-4c42-a9ef-abf6c06b10c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f591d888-b9c4-4c42-a9ef-abf6c06b10c8.jpg?1",
             "name": "Hammerfest Boomtacular",
             "text": "Whenever you cast a spell with a Goblin Explosioneers watermark, Hammerfest Boomtacular deals 2 damage to target creature or player.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "8598b3c0-d145-527d-9680-157a757b4c9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13295f5-c3ce-4392-885c-f21d5fbeaaa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c13295f5-c3ce-4392-885c-f21d5fbeaaa3.jpg?1",
             "name": "Infinity Elemental",
             "text": "(This creature has INFINITE POWER.)",
             "colours": [
@@ -4209,7 +4209,7 @@
         },
         {
             "id": "99443a6d-fc62-5b82-86c3-46efdb1a6cb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1131b87-8e59-47e7-a760-848a455c82b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1131b87-8e59-47e7-a760-848a455c82b0.jpg?1",
             "name": "It That Gets Left Hanging",
             "text": "When It That Gets Left Hanging enters the battlefield, ask a person outside the game to high-five you. If he or she won't, It That Gets Left Hanging gains haste until end of turn.",
             "colours": [
@@ -4244,7 +4244,7 @@
         },
         {
             "id": "0db1962d-eb28-51c3-b80a-1588ea7902eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b9e63f-4cf5-454d-a368-d5cce2529272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7b9e63f-4cf5-454d-a368-d5cce2529272.jpg?1",
             "name": "Just Desserts",
             "text": "Just Desserts deals \u03c0 damage to target creature. (\u03c0 is the ratio of a circle's circumference to its diameter. (It's a smidgen more than 3.))",
             "colours": [
@@ -4276,7 +4276,7 @@
         },
         {
             "id": "f3b33da7-ae27-580c-b295-617073a960ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01dc452-5938-499b-a70f-7f40323faf76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01dc452-5938-499b-a70f-7f40323faf76.jpg?1",
             "name": "Painiac",
             "text": "At the beginning of your upkeep, roll a six-sided die. Painiac gets +X/+0 until end of turn, where X is the result.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "58ae59e9-b61a-5a25-a612-841861f0ff7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f3203-e79c-47af-8c3d-b37c0537de34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/597f3203-e79c-47af-8c3d-b37c0537de34.jpg?1",
             "name": "Party Crasher",
             "text": "Haste\nYou can attack with Party Crasher once each combat during each opponent's turn.",
             "colours": [
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "5bb30094-f210-5e4c-9ed0-290fdb91b28a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9110d5b8-1fe3-44f8-8159-e0e72ce55152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9110d5b8-1fe3-44f8-8159-e0e72ce55152.jpg?1",
             "name": "Steamflogger Boss",
             "text": "Other Riggers you control get +1/+0 and have haste.\nIf a Rigger you control would assemble a Contraption, it assembles two Contraptions instead.",
             "colours": [
@@ -4380,7 +4380,7 @@
         },
         {
             "id": "6a4a5cf2-2f63-5628-83ce-b9f1a8191d78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d536048-86fd-4ea0-bd1c-5a82c76d58b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d536048-86fd-4ea0-bd1c-5a82c76d58b7.jpg?1",
             "name": "Steamflogger of the Month",
             "text": "When Steamflogger of the Month enters the battlefield, it assembles a Contraption for each Contraption you control. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "6d9deada-cc3f-56b3-a45d-6ac737b90231",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a67262-a5f9-4830-97df-ecaaff2badc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a67262-a5f9-4830-97df-ecaaff2badc1.jpg?1",
             "name": "Steamflogger Temp",
             "text": "{6}, {T}: Steamflogger Temp assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4450,7 +4450,7 @@
         },
         {
             "id": "783b5979-5eb3-5845-9055-3f10213d165f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c690d386-bd4f-4251-a475-0b016e2f29ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c690d386-bd4f-4251-a475-0b016e2f29ee.jpg?1",
             "name": "Steamfloggery",
             "text": "Roll a six-sided die. Assemble a number of Contraptions equal to the result. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4482,7 +4482,7 @@
         },
         {
             "id": "7bf2f89f-f8c3-5054-8e01-2b75d29f3d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3400a39f-9dd1-4e86-b29a-3cb9758b60be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3400a39f-9dd1-4e86-b29a-3cb9758b60be.jpg?1",
             "name": "Super-Duper Death Ray",
             "text": "Trample (This spell can deal excess damage to its target's controller.)\nSuper-Duper Death Ray deals 4 damage to target creature.",
             "colours": [
@@ -4514,7 +4514,7 @@
         },
         {
             "id": "00c24f80-3f6a-5d77-a9d1-aa60a8a02126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3093a4-e115-4d88-b7c0-33dee8a11142.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3093a4-e115-4d88-b7c0-33dee8a11142.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4553,7 +4553,7 @@
         },
         {
             "id": "fe56ec01-d6ba-5bc6-ad93-0952ca57bc83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807812cc-74a2-4609-9555-7e0a2463090e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/807812cc-74a2-4609-9555-7e0a2463090e.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "743ce4b2-2519-531b-9143-07fcc28bea3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b552dd-1e0d-41e6-a79b-5a6c1ff28851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77b552dd-1e0d-41e6-a79b-5a6c1ff28851.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "e33a8081-f53b-59d3-bc73-214ebf1aa37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a2cdb5-18a8-4fb2-8eb8-920c95beeea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a2cdb5-18a8-4fb2-8eb8-920c95beeea9.jpg?1",
             "name": "Target Minotaur",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
             "colours": [
@@ -4670,7 +4670,7 @@
         },
         {
             "id": "07a32c1c-5a51-5b02-aaed-ad8680b7184b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c6dd7-84eb-42ff-a950-705bc0d1811e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e35c6dd7-84eb-42ff-a950-705bc0d1811e.jpg?1",
             "name": "Three-Headed Goblin",
             "text": "Triple strike (This creature deals first-strike, regular, and last-strike combat damage.)",
             "colours": [
@@ -4705,7 +4705,7 @@
         },
         {
             "id": "18612437-5231-58bf-99e6-23a476d2f5c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4cf5c-ac9e-45d4-ae4e-ce0162e9f5bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0b4cf5c-ac9e-45d4-ae4e-ce0162e9f5bb.jpg?1",
             "name": "Work a Double",
             "text": "Assemble two Contraptions. (Put the top card of your Contraption deck face up onto one of your sprockets. Then repeat this process.)",
             "colours": [
@@ -4737,7 +4737,7 @@
         },
         {
             "id": "7ea3da71-f604-5027-87b8-ccfcf1f12715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4fcdd5-8f7b-48b1-8841-afc3f8f35853.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c4fcdd5-8f7b-48b1-8841-afc3f8f35853.jpg?1",
             "name": "Wrench-Rigger",
             "text": "When Wrench-Rigger enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -4772,7 +4772,7 @@
         },
         {
             "id": "aae145bd-e85a-5894-810a-38ff701a3583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17892f5-5c4a-4149-8d5e-ba9df013866e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d17892f5-5c4a-4149-8d5e-ba9df013866e.jpg?1",
             "name": "As Luck Would Have It",
             "text": "Hexproof\nWhenever you roll a die, put a number of luck counters on As Luck Would Have It equal to the result. Then if there are 100 or more luck counters on As Luck Would Have It, you win the game. (Count both rolls if you reroll a die.)",
             "colours": [
@@ -4804,7 +4804,7 @@
         },
         {
             "id": "b046ad64-d571-58c7-9a52-9a8c329c733b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed069c-410f-4b30-afd1-8d04742068e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ed069c-410f-4b30-afd1-8d04742068e7.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4842,7 +4842,7 @@
         },
         {
             "id": "4321861b-d291-56ca-8b9d-60acce7dad5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7693877c-958f-4c67-93d5-7db8f2dd87e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/7693877c-958f-4c67-93d5-7db8f2dd87e7.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4880,7 +4880,7 @@
         },
         {
             "id": "9e0be1f6-28ca-5e43-bbb1-be3beb9a5e7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90b6269-7406-40c9-8d4c-3448698a1fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c90b6269-7406-40c9-8d4c-3448698a1fdd.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4918,7 +4918,7 @@
         },
         {
             "id": "3bf39565-9497-56cf-9402-55af84737849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7191d7-2c2c-470e-a2b6-eeb8f3031cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7191d7-2c2c-470e-a2b6-eeb8f3031cc2.jpg?1",
             "name": "Beast in Show",
             "text": "Trample",
             "colours": [
@@ -4956,7 +4956,7 @@
         },
         {
             "id": "c63940a8-1aae-5d5a-9073-6d9f6f1df4ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b60a89-cf45-4e90-a84f-d4674b926bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83b60a89-cf45-4e90-a84f-d4674b926bf7.jpg?1",
             "name": "Chittering Doom",
             "text": "Whenever you roll a 4 or higher on a die, create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -4988,7 +4988,7 @@
         },
         {
             "id": "64630a98-501d-5875-9041-f0e053469782",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1590cf0a-42bf-4ffd-a83e-eec516a71590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1590cf0a-42bf-4ffd-a83e-eec516a71590.jpg?1",
             "name": "Clever Combo",
             "text": "Search your library for a host card or a card with augment, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "7ac3f4e3-1d05-5496-8d80-e73b15899da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae93229-be0f-4721-85ee-bfccf4e28971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae93229-be0f-4721-85ee-bfccf4e28971.jpg?1",
             "name": "Druid of the Sacred Beaker",
             "text": "{T}: Add {G} to your mana pool for each Crossbreed Labs watermark among permanents you control.",
             "colours": [
@@ -5057,7 +5057,7 @@
         },
         {
             "id": "516a0044-d46e-5fe3-b852-0426eb4deea8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07ec8f9-ffa9-43e9-bd75-babf3f8ed322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b07ec8f9-ffa9-43e9-bd75-babf3f8ed322.jpg?1",
             "name": "Eager Beaver",
             "text": "When this creature enters the battlefield, you may untap target permanent.",
             "colours": [
@@ -5093,7 +5093,7 @@
         },
         {
             "id": "9c4b45d1-3dd8-5131-8b41-5de9338b6686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bbf567-bdb4-4f88-906c-eb1503c02d9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3bbf567-bdb4-4f88-906c-eb1503c02d9f.jpg?1",
             "name": "Earl of Squirrel",
             "text": "Squirrellink (Damage dealt by this creature also causes you to create that many 1/1 green Squirrel creature tokens.)\nCreature tokens you control are Squirrels in addition to their other creature types.\nOther Squirrels you control get +1/+1.",
             "colours": [
@@ -5129,7 +5129,7 @@
         },
         {
             "id": "49660a09-f460-529d-bd33-4411270453b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5fb06-7371-421e-bab6-e0a5c3123948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c5fb06-7371-421e-bab6-e0a5c3123948.jpg?1",
             "name": "First Pick",
             "text": "Destroy target artifact or enchantment. Assemble a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -5161,7 +5161,7 @@
         },
         {
             "id": "0a2c9ff3-a32b-56fa-bdab-c274d1371aa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f8801-4dff-4192-a783-2b5dfda24784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c39f8801-4dff-4192-a783-2b5dfda24784.jpg?1",
             "name": "Ground Pounder",
             "text": "{3}{G}: Roll a six-sided die. Ground Pounder gets +X/+X until end of turn, where X is the result.\nWhenever you roll a 5 or higher on a die, Ground Pounder gains trample until end of turn.",
             "colours": [
@@ -5196,7 +5196,7 @@
         },
         {
             "id": "420d3f64-2707-5e6c-a97b-5b45323dbaaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7793b65-d752-4563-85b4-e7666a51f2be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7793b65-d752-4563-85b4-e7666a51f2be.jpg?1",
             "name": "Half-Squirrel, Half-",
             "text": "Whenever a nontoken creature enters the battlefield,\nAugment {G} ({G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -5230,7 +5230,7 @@
         },
         {
             "id": "2be0d342-f38a-5cc5-b576-9cc28c4373b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760e482c-8725-410e-9d9f-c377649fe8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760e482c-8725-410e-9d9f-c377649fe8bb.jpg?1",
             "name": "Hydradoodle",
             "text": "As Hydradoodle enters the battlefield, roll X six-sided dice. Hydradoodle enters the battlefield with a number of +1/+1 counters on it equal to the total of those results.\nReach, trample",
             "colours": [
@@ -5265,7 +5265,7 @@
         },
         {
             "id": "b6872a2f-9721-53c8-976c-5f7cfe5d33b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be3e867a-208d-4a23-b8a8-a48866889a8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be3e867a-208d-4a23-b8a8-a48866889a8d.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose Flavorful or Bland.\n\u2022 Flavorful \u2014 Whenever a creature with flavor text enters the battlefield under your control, draw a card.\n\u2022 Bland \u2014 Whenever a creature without flavor text enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5303,7 +5303,7 @@
         },
         {
             "id": "c021e39d-5a9c-5295-9003-82f55124e871",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80545e3d-aff4-4501-a173-b7fa02ef816c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80545e3d-aff4-4501-a173-b7fa02ef816c.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose an artist.\nWhenever a creature with art by the chosen artist enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5341,7 +5341,7 @@
         },
         {
             "id": "888b40fa-c8e1-5bd9-9cbb-3e4b2919b6d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91144259-d0a1-4e49-9f9b-9be7e36361d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91144259-d0a1-4e49-9f9b-9be7e36361d9.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose white-bordered or silver-bordered.\nWhenever a creature with the chosen border enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5379,7 +5379,7 @@
         },
         {
             "id": "811f8d16-fca4-528d-8147-7e2b393021e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0d8fc5-5841-403f-96db-2259048ff424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd0d8fc5-5841-403f-96db-2259048ff424.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose a rarity.\nWhenever a creature with the chosen rarity enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "1cb355f1-5c65-57ba-b27f-eed9042df257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962272f8-7cea-4766-9980-da99a503ca6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/962272f8-7cea-4766-9980-da99a503ca6d.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose odd or even.\nWhenever a creature with a collector number of the chosen value enters the battlefield under your control, draw a card.",
             "colours": [
@@ -5455,7 +5455,7 @@
         },
         {
             "id": "8b8c821a-730a-5bf1-ab33-beb3e9faf961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b25c91-892d-48d6-b42e-045d16d35316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b25c91-892d-48d6-b42e-045d16d35316.jpg?1",
             "name": "Ineffable Blessing",
             "text": "As Ineffable Blessing enters the battlefield, choose a number.\nWhenever a creature with exactly the chosen number of words in its name enters the battlefield under your control, draw a card. (Hyphenated words are one word.)",
             "colours": [
@@ -5493,7 +5493,7 @@
         },
         {
             "id": "974f7094-2f06-5176-9655-a714c1821090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199304-1b6e-417f-9855-82c38454dff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b199304-1b6e-417f-9855-82c38454dff9.jpg?1",
             "name": "Joyride Rigger",
             "text": "When Joyride Rigger enters the battlefield, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -5528,7 +5528,7 @@
         },
         {
             "id": "f0da11d9-7208-5b0e-bdb9-da36e4de3f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569f48f9-db8c-458d-b1c8-fed5fd844bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569f48f9-db8c-458d-b1c8-fed5fd844bfd.jpg?1",
             "name": "Monkey-",
             "text": "Whenever a nontoken creature you control dies,\nAugment {2}{G} ({2}{G}, Reveal this card from your hand: Combine it with target  host. Augment only as a sorcery.)",
             "colours": [
@@ -5562,7 +5562,7 @@
         },
         {
             "id": "cbccee7d-41cc-5d50-8f2b-e0b75796ebd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e96d8-2c6d-43c6-b9c9-512fdb98a30d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93e96d8-2c6d-43c6-b9c9-512fdb98a30d.jpg?1",
             "name": "Mother Kangaroo",
             "text": "When this creature enters the battlefield, roll a six-sided die. Put a number of +1/+1 counters on this creature equal to the result.",
             "colours": [
@@ -5598,7 +5598,7 @@
         },
         {
             "id": "0c282577-878e-556b-8e66-da30eee4d55f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9fdfa-c361-465e-9639-097d441a3f74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe9fdfa-c361-465e-9639-097d441a3f74.jpg?1",
             "name": "Multi-Headed",
             "text": "At the beginning of each end step, if you rolled a die this turn,\nAugment {4}{G} ({4}{G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -5632,7 +5632,7 @@
         },
         {
             "id": "58dc68f1-d9c9-5522-967b-06f78f2086c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabefc4a-4d5a-41bc-a791-38aa8ab0f9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eabefc4a-4d5a-41bc-a791-38aa8ab0f9e6.jpg?1",
             "name": "Really Epic Punch",
             "text": "Target creature you control gets +2/+2 if it's a host or has augment. Then it fights target creature you don't control.",
             "colours": [
@@ -5664,7 +5664,7 @@
         },
         {
             "id": "510a91d7-956a-59ca-a4f2-f31b00c1163f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88375ad9-50cb-4529-982b-82f9653c69f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88375ad9-50cb-4529-982b-82f9653c69f6.jpg?1",
             "name": "Selfie Preservation",
             "text": "Search your library for a basic land card and reveal it. If there's a tree in its art, put it onto the battlefield tapped. Otherwise, put it into your hand. Then shuffle your library.",
             "colours": [
@@ -5696,7 +5696,7 @@
         },
         {
             "id": "4b87b880-b312-50d2-89bd-c4ec84787a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a6611-db7e-48a5-8eb1-2886f8d3665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25a6611-db7e-48a5-8eb1-2886f8d3665a.jpg?1",
             "name": "Serpentine",
             "text": "Whenever a land enters the battlefield under your control,\nAugment {2}{G} ({2}{G}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "bbd1208c-3f93-5b45-8cd9-d62eef774160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad58131-2bfe-4796-ab7d-44364a0d0acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad58131-2bfe-4796-ab7d-44364a0d0acc.jpg?1",
             "name": "Shellephant",
             "text": "{0}: Choose one. You may activate this ability while Shellephant is in any zone.\n\u2022 Shellephant has base power and toughness 1/4.\n\u2022 Shellephant has base power and toughness 3/3.",
             "colours": [
@@ -5766,7 +5766,7 @@
         },
         {
             "id": "924205fb-c267-5f31-8098-de87130fbbda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87be87-258e-4a84-8f43-fcaa55e8ad3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf87be87-258e-4a84-8f43-fcaa55e8ad3a.jpg?1",
             "name": "Slaying Mantis",
             "text": "Just a second (As long as this spell is on the stack, players can't move cards on the battlefield.)\nSlaying Mantis enters the battlefield by being thrown from a distance of at least three feet.\nWhen Slaying Mantis enters the battlefield, it fights each creature an opponent controls that it touched as it entered.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "2269ca43-c339-531e-996d-aaebcea94f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89757c05-72af-4bfe-a4c0-abc5d1155b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89757c05-72af-4bfe-a4c0-abc5d1155b61.jpg?1",
             "name": "Squirrel Dealer",
             "text": "When Squirrel Dealer enters the battlefield, ask a person outside the game \"Do you like Squirrels?\" If he or she does, create a 1/1 green Squirrel creature token.",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "0ac96bc0-227b-5b79-83e9-da34801305fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea9d1a-d7ee-47ac-b010-ec0b0afc7886.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25ea9d1a-d7ee-47ac-b010-ec0b0afc7886.jpg?1",
             "name": "Steamflogger Service Rep",
             "text": "Whenever another Goblin enters the battlefield under your control, you may pay {1}. If you do, Steamflogger Service Rep assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [
@@ -5872,7 +5872,7 @@
         },
         {
             "id": "d12d5e09-f6af-599f-adf4-ab9cdbda19a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332188f4-ff05-4a07-9200-ad03bd650c3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/332188f4-ff05-4a07-9200-ad03bd650c3f.jpg?1",
             "name": "Wild Crocodile",
             "text": "When this creature enters the battlefield, search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "3e17f557-889d-56b0-bb0c-d0b67df0a11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958c27db-68fa-47e9-a9c3-82f0c92e86c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/958c27db-68fa-47e9-a9c3-82f0c92e86c1.jpg?1",
             "name": "Willing Test Subject",
             "text": "Reach\nWhenever you roll a 4 or higher on a die, put a +1/+1 counter on Willing Test Subject.\n{6}: Roll a six-sided die.",
             "colours": [
@@ -5944,7 +5944,7 @@
         },
         {
             "id": "dab95af3-dea5-513c-8360-5746571d798e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d31d5c-6d4d-4bd8-b69c-b44c5b7f089f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19d31d5c-6d4d-4bd8-b69c-b44c5b7f089f.jpg?1",
             "name": "Baron Von Count",
             "text": "Baron Von Count enters the battlefield with a doom counter on \"5.\"\nWhenever you cast a spell with the indicated numeral in its mana cost, text box, power, or toughness, move the doom counter one numeral to the left.\nWhen the doom counter moves from \"1,\" destroy target player and put that doom counter on \"5.\"",
             "colours": [
@@ -5983,7 +5983,7 @@
         },
         {
             "id": "32f7b856-2faf-511d-ae54-57ee6810dc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd5cc29-3490-4e35-b7ef-5cd07eb43bf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd5cc29-3490-4e35-b7ef-5cd07eb43bf7.jpg?1",
             "name": "Better Than One",
             "text": "A person outside the game becomes your teammate. (Choose any number of cards in your hand, on top of your library, or on the battlefield under your control. Those cards become your teammate's hand, library, and permanents, respectively.)",
             "colours": [
@@ -6017,7 +6017,7 @@
         },
         {
             "id": "e71ac09d-c496-5bea-a6cb-4964d073a4c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa775e1e-2322-4981-bf14-4f24a3be983e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa775e1e-2322-4981-bf14-4f24a3be983e.jpg?1",
             "name": "Cramped Bunker",
             "text": "At the beginning of each opponent's upkeep, that player moves a permanent he or she controls to touch Cramped Bunker and no other permanents. If he or she can't, destroy each permanent that player controls that isn't touching Cramped Bunker, then sacrifice it.",
             "colours": [
@@ -6051,7 +6051,7 @@
         },
         {
             "id": "5d7f1428-e62c-5f0c-8881-dc77b991c020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a8222-7760-41bb-b524-9036a036bc8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564a8222-7760-41bb-b524-9036a036bc8b.jpg?1",
             "name": "Dr. Julius Jumblemorph",
             "text": "Dr. Julius Jumblemorph is every creature type (even if this card isn't on the battlefield).\nWhenever a host enters the battlefield under your control, you may search your library and/or graveyard for a card with augment and combine it with that host. If you search your library this way, shuffle it.",
             "colours": [
@@ -6087,7 +6087,7 @@
         },
         {
             "id": "2410be48-8227-573c-9eb0-a54f4c579b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1e38a2-d817-4f19-aabf-02dc72c78259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c1e38a2-d817-4f19-aabf-02dc72c78259.jpg?1",
             "name": "The Grand Calcutron",
             "text": "When The Grand Calcutron enters the battlefield, each player's hand becomes a program (an ordered row of revealed cards).\nPlayers can only play the first card of their program.\nIf a card would be put into a player's hand from anywhere, that player reveals it and places it anywhere within his or her program instead.\nAt the beginning of each player's end step, if that player's program has fewer than five cards, he or she draws cards equal to the difference.",
             "colours": [
@@ -6123,7 +6123,7 @@
         },
         {
             "id": "16ed97b8-7055-57d9-b475-6ac4e88debfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ca9cf7-d6ca-4403-84be-719480eb4b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82ca9cf7-d6ca-4403-84be-719480eb4b7d.jpg?1",
             "name": "Grusilda, Monster Masher",
             "text": "Combined, enchanted, and equipped creatures you control have menace.\n{3}{B}{R}, {T}: Put two target creature cards from graveyards onto the battlefield combined into one creature under your control. (Its power is equal to their total power, its toughness is equal to their total toughness, and it has their names, mana costs, types, text boxes, etc.)",
             "colours": [
@@ -6162,7 +6162,7 @@
         },
         {
             "id": "813b4e71-91d5-5c42-9745-73b5c45f9ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f3b4c8-76c2-4f50-87bc-4e863796309c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79f3b4c8-76c2-4f50-87bc-4e863796309c.jpg?1",
             "name": "Hot Fix",
             "text": "You have ten seconds to look at and rearrange the cards in your library. At the end of those ten seconds, if you're touching one or more of those cards, shuffle your library.",
             "colours": [
@@ -6196,7 +6196,7 @@
         },
         {
             "id": "c3222fca-ddf1-5ffb-a4d8-416c0c92df69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5135b251-002b-453d-a4f8-0455617ebb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5135b251-002b-453d-a4f8-0455617ebb81.jpg?1",
             "name": "Ol' Buzzbark",
             "text": "When Ol' Buzzbark enters the battlefield, roll X six-sided dice onto the battlefield from a height of at least X inches. For each die, put a number of +1/+1 counters equal to the result on each creature you control that die is touching. For each die, Ol' Buzzbark deals damage equal to the result to each creature an opponent controls that die is touching.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "bf82c445-7258-540e-bee7-45e34a05dd73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54d145-a570-49cc-bbb0-8c12c168ec23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d54d145-a570-49cc-bbb0-8c12c168ec23.jpg?1",
             "name": "Phoebe, Head of S.N.E.A.K.",
             "text": "Phoebe, Head of S.N.E.A.K. can't be blocked by creatures with flavor text.\n{2}{U}{B}: Phoebe permanently steals target creature's text box. (That creature loses all rules text, flavor text, and watermarks. This creature gains them.)",
             "colours": [
@@ -6274,7 +6274,7 @@
         },
         {
             "id": "7028db1f-7465-52b4-ad97-0be076abc0bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4581455-5fa1-4c96-96b3-e9e9654f5a28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4581455-5fa1-4c96-96b3-e9e9654f5a28.jpg?1",
             "name": "Urza, Academy Headmaster",
             "text": "+1: Head to Ask\nUrza.com and click +1.\n-1: Head to Ask\nUrza.com and click -1.\n-6: Head to Ask\nUrza.com and click -6.",
             "colours": [
@@ -6318,7 +6318,7 @@
         },
         {
             "id": "55cd11df-cb7c-54a8-977d-c570bb837c90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77f6e64-2470-4c6a-a92b-328e4edc3ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f77f6e64-2470-4c6a-a92b-328e4edc3ea9.jpg?1",
             "name": "X",
             "text": "As long as X is in X's owner's opponent's hand, X's owner may cast X and activate X's abilities. That opponent can't cast X and plays with his or her hand revealed.\n{U}{B}, {T}: Put X into target opponent's hand.\n{3}{U}{B}: You may play a card in the same hand as X without paying its mana cost.",
             "colours": [
@@ -6357,7 +6357,7 @@
         },
         {
             "id": "5ed3f632-7c42-56d4-a666-8e4e9b765e5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ccdda-07a0-445b-b146-51c1e3a05421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b1ccdda-07a0-445b-b146-51c1e3a05421.jpg?1",
             "name": "Mary O'Kill",
             "text": "{1}{BR}: Switch a Killbot or Mary O'Kill in your hand with one on the battlefield. (If a creature is tapped, the switched creature is tapped. The same is true for untapped, attacking, blocking, enchanted, equipped, and targeted. Any counters on a creature are on the switched creature instead.)",
             "colours": [
@@ -6396,7 +6396,7 @@
         },
         {
             "id": "fb0afb51-4eff-5dd1-8d51-7dcc1d17ac9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b8287-7af4-4c5b-8d76-7f865bd602c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8b8287-7af4-4c5b-8d76-7f865bd602c0.jpg?1",
             "name": "Angelic Rocket",
             "text": "Flying\nWhen this creature enters the battlefield, you may destroy target nonland permanent.",
             "colours": [],
@@ -6429,7 +6429,7 @@
         },
         {
             "id": "f9be4361-4287-5c4a-b578-5cc459c1983b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480e3b96-f7fa-4dcc-a956-6b48d55097c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/480e3b96-f7fa-4dcc-a956-6b48d55097c9.jpg?1",
             "name": "Border Guardian",
             "text": "Whenever you cast a silver-bordered spell, put a +1/+1 counter on Border Guardian.\nWhenever you cast a black-bordered spell, Border Guardian can't be blocked this turn.\nWhenever you cast a white-bordered spell, Border Guardian gains double strike until end of turn.",
             "colours": [],
@@ -6460,7 +6460,7 @@
         },
         {
             "id": "bedcb479-3d5c-53ca-8f86-de86c10f5e40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e18540e-6a64-4f0e-89d4-bd67c41194c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e18540e-6a64-4f0e-89d4-bd67c41194c6.jpg?1",
             "name": "Buzzing Whack-a-Doodle",
             "text": "As Buzzing Whack-a-Doodle enters the battlefield, you and an opponent each secretly choose Whack or Doodle. Then those choices are revealed. If the choices match, Buzzing Whack-a-Doodle has that ability. Otherwise, it has Buzz.\n\u2022 Whack \u2014 {T}: Target player loses 2 life.\n\u2022 Doodle \u2014 {T}: You gain 3 life.\n\u2022 Buzz \u2014 {2}, {T}: Draw a card.",
             "colours": [],
@@ -6488,7 +6488,7 @@
         },
         {
             "id": "8b0dbdd8-85b3-5e68-b2ad-042c1db4a428",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5765e68-20ee-43dc-a0d5-8e777719de44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5765e68-20ee-43dc-a0d5-8e777719de44.jpg?1",
             "name": "Clock of DOOOOOOOOOOOOM!",
             "text": "{4}, {T}: Move the CRANK counter to your Contraption deck's next sprocket and crank any number of that sprocket's Contraptions.",
             "colours": [],
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "83bbb7c8-c217-5f00-809d-4d3b50fcb387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af687c72-e5b9-4074-a3aa-1bf04fa06ce9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af687c72-e5b9-4074-a3aa-1bf04fa06ce9.jpg?1",
             "name": "Cogmentor",
             "text": "Flying\n{4}: Reassemble target Contraption you control. (Move it onto another one of your sprockets.)",
             "colours": [],
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "28bba9dd-9985-539b-ad4c-db4148a7d736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2253a4-5ebe-488c-9715-15917408006f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a2253a4-5ebe-488c-9715-15917408006f.jpg?1",
             "name": "Contraption Cannon",
             "text": "{2}, Sacrifice Contraption Cannon: It deals damage to target creature or player equal to the number of Contraptions you control.",
             "colours": [],
@@ -6576,7 +6576,7 @@
         },
         {
             "id": "ccfcf2be-6464-5bfd-8884-c462f40fa542",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2b7e0-1f6c-4c17-9648-2d74d7789442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51a2b7e0-1f6c-4c17-9648-2d74d7789442.jpg?1",
             "name": "Curious Killbot",
             "text": "",
             "colours": [],
@@ -6607,7 +6607,7 @@
         },
         {
             "id": "3fa6926c-99e5-52c7-8fab-9882d8d91fd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa7a8ac-65ed-4f16-9f31-08183f97da74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa7a8ac-65ed-4f16-9f31-08183f97da74.jpg?1",
             "name": "Delighted Killbot",
             "text": "",
             "colours": [],
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "5b9d346d-5f61-5527-afa8-4452b2b1da00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62acc75-484e-4945-bcd0-cba5e098ef4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e62acc75-484e-4945-bcd0-cba5e098ef4e.jpg?1",
             "name": "Despondent Killbot",
             "text": "",
             "colours": [],
@@ -6669,7 +6669,7 @@
         },
         {
             "id": "015dee75-9066-5317-bdb2-26f100813869",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205fb956-6e2a-4b5f-bae3-eb547a8838aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/205fb956-6e2a-4b5f-bae3-eb547a8838aa.jpg?1",
             "name": "Enraged Killbot",
             "text": "",
             "colours": [],
@@ -6700,7 +6700,7 @@
         },
         {
             "id": "7e54fdde-3f95-55cd-82f0-2fd3acd2929c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef04b83-c11a-498f-ab5e-5f05a97b7c98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef04b83-c11a-498f-ab5e-5f05a97b7c98.jpg?1",
             "name": "Entirely Normal Armchair",
             "text": "During your turn, if Entirely Normal Armchair is in your hand, you may hide it on the battlefield.\n{0}: Return Entirely Normal Armchair to its owner's hand. Only any opponent may activate this ability and only if he or she sees Entirely Normal Armchair.\n{2}, Sacrifice Entirely Normal Armchair: Destroy target attacking creature.",
             "colours": [],
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "41ec313a-aac3-5002-99aa-19142e517e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09bef24-a186-4697-bd33-446fe6e25376.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e09bef24-a186-4697-bd33-446fe6e25376.jpg?1",
             "name": "Everythingamajig",
             "text": "{2}, {T}: Move a counter from one permanent onto another. If the second permanent refers to any kind of counter, the moved counter becomes one of those counters. Otherwise, it becomes a +1/+1 counter.\n{3}, {T}: Put a +1/+1 counter on target creature.\n{4}, {T}: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)",
             "colours": [],
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "a00fa005-74d6-57e3-a1cf-5e99b300472d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ab7126-4191-4632-be2b-3e972a96bc30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3ab7126-4191-4632-be2b-3e972a96bc30.jpg?1",
             "name": "Everythingamajig",
             "text": "{2}, {T}: Draw a card. Activate this ability only if you have no cards in hand.\n{8}, {T}: You gain 10 life.\n{4}, {T}, Sacrifice Everythingamajig: You may put a silver-bordered permanent card from your hand onto the battlefield.",
             "colours": [],
@@ -6796,7 +6796,7 @@
         },
         {
             "id": "a28b87b7-10d4-5822-872d-d01788d7a126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8a3f9b-8ddd-4bce-95ea-f6ecfe2a5502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8a3f9b-8ddd-4bce-95ea-f6ecfe2a5502.jpg?1",
             "name": "Everythingamajig",
             "text": "{1}: Flip a coin. If you win the flip, add {C}{C} to your mana pool. Activate this ability only any time you could cast an instant.\n{3}, {T}: Target player discards a card. Activate this ability only during your turn.\n{X}: Everythingamajig becomes an X/X Construct artifact creature until end of turn.",
             "colours": [],
@@ -6830,7 +6830,7 @@
         },
         {
             "id": "ed53807e-68c2-537f-b32a-ae43b6ba986e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6870324-16c9-4cb7-8889-8ec49d59f89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6870324-16c9-4cb7-8889-8ec49d59f89f.jpg?1",
             "name": "Everythingamajig",
             "text": "{T}: Add one mana of any color to your mana pool.\n{1}, {T}: Say the flavor text on a card in your hand. Target opponent guesses that card's name. You may reveal that card. If you do and your opponent guessed wrong, draw a card.\n{8}, {T}: Everythingamajig deals 12 damage to target creature.",
             "colours": [],
@@ -6864,7 +6864,7 @@
         },
         {
             "id": "643f38ad-8865-5bb6-9d68-094f0f3d6f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca90bc5e-e448-47b7-a011-c19ac23c5eaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca90bc5e-e448-47b7-a011-c19ac23c5eaa.jpg?1",
             "name": "Everythingamajig",
             "text": "Sacrifice a land: You gain 2 life.\nSacrifice a creature: Add {C}{C} to your mana pool.\n{2}, Discard a card: Search your library for a card that shares a complete word in its name with the name of the discarded card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -6898,7 +6898,7 @@
         },
         {
             "id": "c86d15cd-efb3-5ee6-9406-48e7206bf536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c6b55b-2dbb-4740-af86-3fe0e4aa03f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1c6b55b-2dbb-4740-af86-3fe0e4aa03f8.jpg?1",
             "name": "Everythingamajig",
             "text": "{1}, {T}: Scry 2.\n{1}, {T}, Pay 1 life: Create a 0/1 white Goat creature token.\n{7}, {T}, Sacrifice Everythingamajig: Choose target player. At the beginning of the next end step, exchange life totals with that player, exchange control of all permanents you and that player control, and exchange cards in your hands, cards in your libraries, and cards in your graveyards.",
             "colours": [],
@@ -6932,7 +6932,7 @@
         },
         {
             "id": "1fa7b14f-85c5-54da-8be9-c75fa7d6a8ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c110c56-cf58-4c04-a567-c55928f5d640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c110c56-cf58-4c04-a567-c55928f5d640.jpg?1",
             "name": "Gnome-Made Engine",
             "text": "When this creature enters the battlefield, create a 1/1 colorless Gnome artifact creature token.",
             "colours": [],
@@ -6965,7 +6965,7 @@
         },
         {
             "id": "1685d45c-fd26-5956-a376-3530bd163295",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9ae44-6da4-44f4-8b24-679d84e122de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d9ae44-6da4-44f4-8b24-679d84e122de.jpg?1",
             "name": "Handy Dandy Clone Machine",
             "text": "{2}, {T}: Create a 2/2 colorless Homunculus creature token. It must be represented by a unique hand and two fingers at all times, or it ceases to exist.",
             "colours": [],
@@ -6993,7 +6993,7 @@
         },
         {
             "id": "929b7895-fe9d-5cd0-97c2-a4d65a7f4918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf4f4ac-f793-4996-8f29-252398c26eef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf4f4ac-f793-4996-8f29-252398c26eef.jpg?1",
             "name": "Kindslaver",
             "text": "{5}, {T}, Sacrifice Kindslaver: A person outside the game controls target player during that player's next turn. Neither player may advise that person until the end of that turn.",
             "colours": [],
@@ -7023,7 +7023,7 @@
         },
         {
             "id": "ff9c81a2-c11a-5b2d-bb3b-660fc1075bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6eab86-ca0c-4fd6-9839-dda15ba2b1ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe6eab86-ca0c-4fd6-9839-dda15ba2b1ac.jpg?1",
             "name": "Krark's Other Thumb",
             "text": "If you would roll a die, instead roll two of those dice and ignore one of those results.",
             "colours": [],
@@ -7053,7 +7053,7 @@
         },
         {
             "id": "a3cc1648-60d5-5e76-8225-725be3621261",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eae1cf-f7e8-4281-a50c-fc4b728d23dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71eae1cf-f7e8-4281-a50c-fc4b728d23dd.jpg?1",
             "name": "Labro Bot",
             "text": "When this creature enters the battlefield, return target host card or card with augment from your graveyard to your hand.",
             "colours": [],
@@ -7086,7 +7086,7 @@
         },
         {
             "id": "d3206d6a-f8a3-545b-9d05-2b5a98b2f304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7bc6c4-3755-4ae8-8dc2-69ac2d0a6d92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c7bc6c4-3755-4ae8-8dc2-69ac2d0a6d92.jpg?1",
             "name": "Lobe Lobber",
             "text": "Equipped creature has \"{T}: This creature deals 1 damage to target player. Roll a six-sided die. On a 5 or higher, untap it.\"\nEquip {2}",
             "colours": [],
@@ -7116,7 +7116,7 @@
         },
         {
             "id": "766a5629-5547-5d24-be7f-464f72076bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b605c5-c2fa-452d-a062-8ca67c1d5243.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82b605c5-c2fa-452d-a062-8ca67c1d5243.jpg?1",
             "name": "Mad Science Fair Project",
             "text": "{T}: Roll a six-sided die. On a 3 or lower,\ntarget player adds o\nC to his or her mana\npool. Otherwise, that player adds one\nmana of any color he or she chooses to\nhis or her mana pool.",
             "colours": [],
@@ -7144,7 +7144,7 @@
         },
         {
             "id": "3df98040-f11f-54ad-aa7a-deee6ca5c42c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1498cb2-9f95-4c24-924b-a9a98e54f24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1498cb2-9f95-4c24-924b-a9a98e54f24c.jpg?1",
             "name": "Modular Monstrosity",
             "text": "Whenever an opponent casts a spell, you have five seconds to choose a keyword you haven't chosen for a card named Modular Monstrosity today that's been printed on a creature card. If you do, Modular Monstrosity gains that ability. Otherwise, Modular Monstrosity loses all keyword abilities.",
             "colours": [],
@@ -7175,7 +7175,7 @@
         },
         {
             "id": "06f71902-56fd-51a3-a3b2-a088ef29ae0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18ab484-e12b-4e3f-9e72-16f9031f35f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18ab484-e12b-4e3f-9e72-16f9031f35f7.jpg?1",
             "name": "Proper Laboratory Attire",
             "text": "Equipped creature gets +2/+1 and has protection from die rolls. (Nothing that lets a player roll a die can block, target, deal damage to, or attach to equipped creature.)\nEquip {2}",
             "colours": [],
@@ -7205,7 +7205,7 @@
         },
         {
             "id": "ebccee55-b816-5fff-9510-328ddff04897",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d54442-caca-412d-a716-032eaa587944.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4d54442-caca-412d-a716-032eaa587944.jpg?1",
             "name": "Robo-",
             "text": "At the beginning of each end step, if an artifact entered the battlefield under your control this turn,\nAugment {2} ({2}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [],
@@ -7236,7 +7236,7 @@
         },
         {
             "id": "6a1fb044-0572-57d8-868c-77e04d145498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc5106-5dba-4eae-a102-771a4e893b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02dc5106-5dba-4eae-a102-771a4e893b23.jpg?1",
             "name": "Split Screen",
             "text": "When Split Screen enters the battlefield, shuffle your library and deal it into four libraries. If anything refers to your library, choose one of your libraries for it.\nPlay with your libraries' top cards revealed.\nWhen Split Screen leaves the battlefield, shuffle your libraries together.",
             "colours": [],
@@ -7264,7 +7264,7 @@
         },
         {
             "id": "879425e1-c3ab-5243-98e1-0d58e1b2b7ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e57af4-b126-41e1-979a-7bce8f75217e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e57af4-b126-41e1-979a-7bce8f75217e.jpg?1",
             "name": "Staff of the Letter Magus",
             "text": "As Staff of the Letter Magus enters the battlefield, choose a consonant other than N, R, S, or T.\nWhenever a player casts a spell, you gain 1 life for each time the chosen letter appears in that spell's name.",
             "colours": [],
@@ -7292,7 +7292,7 @@
         },
         {
             "id": "478f9b1b-c6c9-53e7-bd83-f314cdfd02ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e832a07d-b417-47fa-8a29-c31f590c2e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e832a07d-b417-47fa-8a29-c31f590c2e59.jpg?1",
             "name": "Stamp of Approval",
             "text": "As Stamp of Approval enters the battlefield, choose a watermark.\nCreatures you control with the chosen watermark get +1/+1.",
             "colours": [],
@@ -7320,7 +7320,7 @@
         },
         {
             "id": "43e72702-16d2-5d21-83d2-c6916eed4586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be251636-acbe-4bbc-97f6-de583d0769b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be251636-acbe-4bbc-97f6-de583d0769b6.jpg?1",
             "name": "Steam-Powered",
             "text": "{5}:\nAugment {4} ({4}, Reveal this card from your hand: Combine it with target host. Augment only as a sorcery.)",
             "colours": [],
@@ -7351,7 +7351,7 @@
         },
         {
             "id": "7c3079ba-5aa7-5d16-8274-9c67583e0a93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feacac-9496-44bf-ad58-0fd5f3b5675a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00feacac-9496-44bf-ad58-0fd5f3b5675a.jpg?1",
             "name": "Steel Squirrel",
             "text": "Whenever you roll a 5 or higher on a die, Steel Squirrel gets +X/+X until end of turn, where X is the result.\n{6}: Roll a six-sided die.",
             "colours": [],
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "5eaf4df7-8267-5519-85e3-3ef8a9e6dda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacce818-96b4-4b6f-97c4-74a22c8d9afb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacce818-96b4-4b6f-97c4-74a22c8d9afb.jpg?1",
             "name": "Sword of Dungeons & Dragons",
             "text": "Equipped creature gets +2/+2 and has protection from Rogues and from Clerics.\nWhenever equipped creature deals combat damage to a player, create a 4/4 gold Dragon creature token with flying and roll a d20 (a twenty-sided die). If you roll a 20, repeat this process.\nEquip {2}",
             "colours": [],
@@ -7412,7 +7412,7 @@
         },
         {
             "id": "bb56ba44-24e5-5913-9d7c-bbdc95500198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffcbb9f-a605-4f7f-a005-b237b4f60052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8ffcbb9f-a605-4f7f-a005-b237b4f60052.jpg?1",
             "name": "Voracious Vacuum",
             "text": "When this creature enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -7445,7 +7445,7 @@
         },
         {
             "id": "d72d3515-636e-5520-b150-44b701ade2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4306c2-1b92-4ccc-8d92-9f27f1505113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a4306c2-1b92-4ccc-8d92-9f27f1505113.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7478,7 +7478,7 @@
         },
         {
             "id": "0aad334d-ac52-54b1-a044-1dd3641a6569",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728c905-41b9-438f-a9f4-4a1192c93c42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1728c905-41b9-438f-a9f4-4a1192c93c42.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "46b2b144-ab4a-551d-aa0b-32c8ee0878af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d836021-9289-4ab2-be85-6362670cb9de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d836021-9289-4ab2-be85-6362670cb9de.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7544,7 +7544,7 @@
         },
         {
             "id": "3f457b52-53a4-53b1-b4d4-6578b0e67c14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c658-0a3f-4079-b565-a491061090f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb35c658-0a3f-4079-b565-a491061090f0.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7577,7 +7577,7 @@
         },
         {
             "id": "145bf970-b532-5526-ab50-fe049e0f8027",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba52527-191f-4b6e-a524-f2a7a01813bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6ba52527-191f-4b6e-a524-f2a7a01813bf.jpg?1",
             "name": "Secret Base",
             "text": "{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a spell that shares a watermark with Secret Base.",
             "colours": [],
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "87f219e3-b93c-5faf-93cf-915b067a803b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf98bb09-c479-4dba-b542-ac5475fac697.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf98bb09-c479-4dba-b542-ac5475fac697.jpg?1",
             "name": "Watermarket",
             "text": "{T}: Add {C}{C} to your mana pool. Spend this mana only to cast spells with watermarks.",
             "colours": [],
@@ -7638,7 +7638,7 @@
         },
         {
             "id": "2fd75397-ee58-50b9-a64a-57e4db28adef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ca02a0-5acf-4d89-847b-bad0d7560682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ca02a0-5acf-4d89-847b-bad0d7560682.jpg?1",
             "name": "Accessories to Murder",
             "text": "Whenever you crank Accessories to Murder, target creature gets +X/+0 until end of turn, where X is the number of creatures you control.",
             "colours": [],
@@ -7668,7 +7668,7 @@
         },
         {
             "id": "c2d67c95-c5b1-5620-b9ff-b6cff0c612d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd1fe5-1b80-45eb-921d-8d1a90816754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dcd1fe5-1b80-45eb-921d-8d1a90816754.jpg?1",
             "name": "Applied Aeronautics",
             "text": "Whenever you crank Applied Aeronautics, until end of turn, target creature gets +1/+0, gains flying, and becomes an artifact in addition to its other types.",
             "colours": [],
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "16060451-518c-5fd0-91ec-1ae43b64556c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8277ff56-067f-49dc-8f83-b9fe7b37990f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8277ff56-067f-49dc-8f83-b9fe7b37990f.jpg?1",
             "name": "Arms Depot",
             "text": "Whenever you crank Arms Depot, put two +1/+1 counters on target creature.",
             "colours": [],
@@ -7728,7 +7728,7 @@
         },
         {
             "id": "29550cc9-1610-5b56-b448-4132ea2ae42d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dcdef4-7898-4620-a176-fcabd3f1fa4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29dcdef4-7898-4620-a176-fcabd3f1fa4f.jpg?1",
             "name": "Auto-Key",
             "text": "Whenever you crank Auto-Key, until end of turn, target creature becomes an artifact in addition to its other types and gains \"{T}: You gain 3 life.\"",
             "colours": [],
@@ -7758,7 +7758,7 @@
         },
         {
             "id": "87a61aff-e72d-5c38-aa15-7c25ce164c41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4927de5-69a4-4461-9ebe-b243e9cf00c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4927de5-69a4-4461-9ebe-b243e9cf00c4.jpg?1",
             "name": "Bee-Bee Gun",
             "text": "Whenever you crank Bee-Bee Gun, until end of turn, target creature gains \"{2}: This creature fights another target creature.\"",
             "colours": [],
@@ -7788,7 +7788,7 @@
         },
         {
             "id": "3aa71e3b-14da-5449-97a1-f0f3231f57ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fb2587-6661-4596-9fcb-15f97aeedd37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6fb2587-6661-4596-9fcb-15f97aeedd37.jpg?1",
             "name": "Boomflinger",
             "text": "Whenever you crank Boomflinger, roll two six-sided dice. Boomflinger deals damage to target player equal to the difference between those results.",
             "colours": [],
@@ -7818,7 +7818,7 @@
         },
         {
             "id": "e480472e-b538-5637-815e-324aee4519b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bac075-aa1f-4c8a-9d82-8b6c1ff9b97a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bac075-aa1f-4c8a-9d82-8b6c1ff9b97a.jpg?1",
             "name": "Buzz Buggy",
             "text": "Whenever you crank Buzz Buggy, target creature gets +2/+0 and gains trample until end of turn.",
             "colours": [],
@@ -7848,7 +7848,7 @@
         },
         {
             "id": "cb854504-ccae-5539-aced-dafcf11ee47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0242175-3e91-4a6e-bcaf-036ff75cef49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0242175-3e91-4a6e-bcaf-036ff75cef49.jpg?1",
             "name": "Deadly Poison Sampler",
             "text": "Whenever you crank Deadly Poison Sampler, until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, destroy target creature that player controls.\"",
             "colours": [],
@@ -7878,7 +7878,7 @@
         },
         {
             "id": "507db51a-c0ba-5a3a-a347-e76ffec014a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782d7294-14e6-4773-af8e-40b39f4f701a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782d7294-14e6-4773-af8e-40b39f4f701a.jpg?1",
             "name": "Dictation Quillograph",
             "text": "Whenever you crank Dictation Quillograph, until end of turn, target creature gains \"Whenever this creature deals combat damage to a player, you may draw a card. If you do, discard a card.\"",
             "colours": [],
@@ -7908,7 +7908,7 @@
         },
         {
             "id": "b20c429b-7b1a-570b-9eed-1b490b257d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eced6323-cfb6-4429-badb-2c249c6c69f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eced6323-cfb6-4429-badb-2c249c6c69f4.jpg?1",
             "name": "Dispatch Dispensary",
             "text": "Whenever you crank Dispatch Dispensary, create a 2/2 black Rogue creature token with menace.",
             "colours": [],
@@ -7938,7 +7938,7 @@
         },
         {
             "id": "aeed39b2-face-596c-94ee-89349bef09f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fcd1f0-0ed3-46f9-a12a-fc0e9f99e97f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90fcd1f0-0ed3-46f9-a12a-fc0e9f99e97f.jpg?1",
             "name": "Division Table",
             "text": "Whenever you crank Division Table, target player loses 2 life.",
             "colours": [],
@@ -7968,7 +7968,7 @@
         },
         {
             "id": "6c743c36-1d66-5898-87ce-d32a1e9594c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003732e-efa5-42c7-8656-90fb4c9fc1e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2003732e-efa5-42c7-8656-90fb4c9fc1e5.jpg?1",
             "name": "Dogsnail Engine",
             "text": "Whenever you crank Dogsnail Engine, target player gains life equal to the greatest power among creatures you control.",
             "colours": [],
@@ -7998,7 +7998,7 @@
         },
         {
             "id": "4c3fa1b3-a232-522f-8361-92e87d9d78d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c91e63-284e-4403-af01-0cfe6af914c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5c91e63-284e-4403-af01-0cfe6af914c1.jpg?1",
             "name": "Dual Doomsuits",
             "text": "Whenever you crank Dual Doomsuits, each time a source you control would deal damage this turn, it deals double that damage instead.",
             "colours": [],
@@ -8028,7 +8028,7 @@
         },
         {
             "id": "9c8d1bc7-dc63-52d6-944c-95b5146542bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b586c92c-ebd7-473c-ae55-2628a9eac390.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b586c92c-ebd7-473c-ae55-2628a9eac390.jpg?1",
             "name": "Duplication Device",
             "text": "Whenever you crank Duplication Device, until end of turn, target creature becomes a copy of any creature on the battlefield, except it's an artifact in addition to its other types.",
             "colours": [],
@@ -8058,7 +8058,7 @@
         },
         {
             "id": "6c42dedb-801c-5cfd-bf39-2ee063ee27c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ea8a49-9644-4de9-8633-a38431a29c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07ea8a49-9644-4de9-8633-a38431a29c0b.jpg?1",
             "name": "Faerie Aerie",
             "text": "Whenever you crank Faerie Aerie, create two 1/1 blue Faerie Spy creature tokens with flying, haste, and \"Whenever this creature deals combat damage to a player, draw a card.\" Exile them at the beginning of the next end step.",
             "colours": [],
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "3007fc64-4a95-50f3-a770-40d9bc1b8846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd63e12-3851-441b-9cd6-566c08940031.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cd63e12-3851-441b-9cd6-566c08940031.jpg?1",
             "name": "Genetic Recombinator",
             "text": "Whenever you crank Genetic Recombinator, up to two target creatures each get +2/+2 until end of turn.",
             "colours": [],
@@ -8118,7 +8118,7 @@
         },
         {
             "id": "b89cdbf0-eb80-5171-afe0-71dafb3c2406",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190dd17-adf3-4174-ab4b-cc49698b7901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4190dd17-adf3-4174-ab4b-cc49698b7901.jpg?1",
             "name": "Gift Horse",
             "text": "Whenever you crank Gift Horse, roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results.",
             "colours": [],
@@ -8148,7 +8148,7 @@
         },
         {
             "id": "c6a2001a-6e11-5e37-b2a0-f9e4227f6048",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291989b2-d87f-4e5a-a159-4d564d1c2c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291989b2-d87f-4e5a-a159-4d564d1c2c6a.jpg?1",
             "name": "Gnomeball Machine",
             "text": "Whenever you crank Gnomeball Machine, create two 1/1 colorless Gnome artifact creature tokens.",
             "colours": [],
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "b19037b9-7c48-5ae9-b472-21746ee959ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368a5ae-5642-4e90-9e73-9f0283067c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7368a5ae-5642-4e90-9e73-9f0283067c15.jpg?1",
             "name": "Goblin Slingshot",
             "text": "Whenever you crank Goblin Slingshot, creatures you control get +2/+0 and gain trample until end of turn.",
             "colours": [],
@@ -8208,7 +8208,7 @@
         },
         {
             "id": "621e290d-7bdb-50bd-91a2-8352888dbd9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9968bad-07fb-4fc5-8ce7-78936c4e6c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9968bad-07fb-4fc5-8ce7-78936c4e6c28.jpg?1",
             "name": "Guest List",
             "text": "Whenever you crank Guest List, target creature gets -X/-X until end of turn, where X is the number of creature cards in its controller's graveyard.",
             "colours": [],
@@ -8238,7 +8238,7 @@
         },
         {
             "id": "860d6591-3593-5636-b00e-532627c0670b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc6c38-18e7-44b1-91d0-dfa1acdb4106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30dc6c38-18e7-44b1-91d0-dfa1acdb4106.jpg?1",
             "name": "Hard Hat Area",
             "text": "Whenever you crank Hard Hat Area, roll two six-sided dice. Hard Hat Area assembles a number of Contraptions equal to the difference between those results. (To assemble a Contraption, put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [],
@@ -8268,7 +8268,7 @@
         },
         {
             "id": "1542d7a4-0064-5dba-8447-aa129654aa2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c3fc99-227b-402e-9b33-07bbec9a7699.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32c3fc99-227b-402e-9b33-07bbec9a7699.jpg?1",
             "name": "Head Banger",
             "text": "Whenever you crank Head Banger, target creature must be blocked this turn if able.",
             "colours": [],
@@ -8298,7 +8298,7 @@
         },
         {
             "id": "8fcfec31-465d-58d0-89b6-4590a62ac3a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d193e9-8bcd-452e-a7d8-37b519b6c2b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d193e9-8bcd-452e-a7d8-37b519b6c2b5.jpg?1",
             "name": "Hypnotic Swirly Disc",
             "text": "Whenever you crank Hypnotic Swirly Disc, target player puts the top X cards of his or her library into his or her graveyard, where X is the number of creatures you control.",
             "colours": [],
@@ -8328,7 +8328,7 @@
         },
         {
             "id": "d63ddb6f-51e2-5255-b84a-9bc827f972ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60b15f8-95e8-43b2-a21e-26cb7e686745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60b15f8-95e8-43b2-a21e-26cb7e686745.jpg?1",
             "name": "Inflation Station",
             "text": "Whenever you crank Inflation Station, target creature gets +3/+3 until end of turn.",
             "colours": [],
@@ -8358,7 +8358,7 @@
         },
         {
             "id": "6b2cab30-6c96-51cc-995d-a0b5fa77c08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0741c7b2-0e1e-42ed-aa97-5b3ba123d44f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0741c7b2-0e1e-42ed-aa97-5b3ba123d44f.jpg?1",
             "name": "Insufferable Syphon",
             "text": "Whenever you crank Insufferable Syphon, target player discards a card.",
             "colours": [],
@@ -8388,7 +8388,7 @@
         },
         {
             "id": "e7402580-71aa-5b21-b809-f399e9bdd8dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe920f24-720b-4b92-bac4-651b8faae90e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe920f24-720b-4b92-bac4-651b8faae90e.jpg?1",
             "name": "Jamming Device",
             "text": "Whenever you crank Jamming Device, creatures target player controls get -1/-1 until end of turn.",
             "colours": [],
@@ -8418,7 +8418,7 @@
         },
         {
             "id": "96b7e568-01cb-5fe8-92d8-536e9b0991e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7bc397-eb40-4647-a06c-d3f427eb8c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f7bc397-eb40-4647-a06c-d3f427eb8c3a.jpg?1",
             "name": "Lackey Recycler",
             "text": "Whenever you crank Lackey Recycler, put target creature card from your graveyard on top of your library.",
             "colours": [],
@@ -8448,7 +8448,7 @@
         },
         {
             "id": "f302de50-f886-5f29-aa2e-c670eed6f2cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ad93ba-dd05-4a29-ac36-2b9b4474309a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6ad93ba-dd05-4a29-ac36-2b9b4474309a.jpg?1",
             "name": "Mandatory Friendship Shackles",
             "text": "Whenever you crank Mandatory Friendship Shackles, target creature gets -1/-1 until end of turn.",
             "colours": [],
@@ -8478,7 +8478,7 @@
         },
         {
             "id": "b663a55f-352d-58a8-962a-3c90d7ce5a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b8f6cd-04d1-4c99-9fac-e606b08e750a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2b8f6cd-04d1-4c99-9fac-e606b08e750a.jpg?1",
             "name": "Neural Network",
             "text": "Whenever you crank Neural Network, gain control of target creature an opponent controls with power less than or equal to the number of creature cards in its controller's graveyard until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [],
@@ -8508,7 +8508,7 @@
         },
         {
             "id": "c4e4c21a-70e7-5084-a5c8-7f9a921164e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488398b3-8b85-4017-87db-f7b683eef3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/488398b3-8b85-4017-87db-f7b683eef3d6.jpg?1",
             "name": "Oaken Power Suit",
             "text": "Whenever you crank Oaken Power Suit, target creature gets +X/+X until end of turn, where X is the greatest power among creatures you control.",
             "colours": [],
@@ -8538,7 +8538,7 @@
         },
         {
             "id": "6a7258b0-e50a-51ab-bd17-02de8ba7bf17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505f1be-4d9f-4536-a3f7-c6e6e19d5678.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c505f1be-4d9f-4536-a3f7-c6e6e19d5678.jpg?1",
             "name": "Optical Optimizer",
             "text": "Whenever you crank Optical Optimizer, until end of turn, target creature becomes an artifact in addition to its other types and gains \"{T}: Draw a card.\"",
             "colours": [],
@@ -8568,7 +8568,7 @@
         },
         {
             "id": "2f832189-3171-5586-9ed9-1dced0a91a41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1430162-6df1-4b24-b533-559ac2f97a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1430162-6df1-4b24-b533-559ac2f97a09.jpg?1",
             "name": "Pet Project",
             "text": "Whenever you crank Pet Project, put target creature card from an opponent's graveyard onto the battlefield under your control.",
             "colours": [],
@@ -8598,7 +8598,7 @@
         },
         {
             "id": "0b443b5c-7202-5ea6-b26d-74e7ed30c698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eccf9ee-3909-49d4-b489-fe0798d1a3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eccf9ee-3909-49d4-b489-fe0798d1a3a1.jpg?1",
             "name": "Quick-Stick Lick Trick",
             "text": "Whenever you crank Quick-Stick Lick Trick, target creature gets +1/+1 and gains lifelink until end of turn.",
             "colours": [],
@@ -8628,7 +8628,7 @@
         },
         {
             "id": "af7f2d13-21cc-58f3-89be-a9fd2ae8e9ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337af8e8-940f-4afd-bd0c-330de63f79c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337af8e8-940f-4afd-bd0c-330de63f79c9.jpg?1",
             "name": "Rapid Prototyper",
             "text": "Whenever you crank Rapid Prototyper, create an X/X colorless Construct artifact creature token, where X is the number of artifacts you control.",
             "colours": [],
@@ -8658,7 +8658,7 @@
         },
         {
             "id": "2c86ec97-956c-5bc6-9291-c44fe1f67eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1028aa-0a08-4851-a108-93c3c72ebe99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1028aa-0a08-4851-a108-93c3c72ebe99.jpg?1",
             "name": "Record Store",
             "text": "Whenever you crank Record Store, look at the top X cards of your library, where X is the number of artifacts you control. Put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [],
@@ -8688,7 +8688,7 @@
         },
         {
             "id": "7941df9f-8511-5d68-b6a7-489cade3e704",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3b81f-7393-4f85-8b1c-59d560778ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b3b81f-7393-4f85-8b1c-59d560778ca1.jpg?1",
             "name": "Refibrillator",
             "text": "Whenever you crank Refibrillator, return target creature card from your graveyard to your hand.",
             "colours": [],
@@ -8718,7 +8718,7 @@
         },
         {
             "id": "09618c19-c87e-51e2-959c-8b176156c9ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8d38a8-e835-4314-80eb-6a574756431d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8d38a8-e835-4314-80eb-6a574756431d.jpg?1",
             "name": "Sap Sucker",
             "text": "Whenever you crank Sap Sucker, add {G} to your mana pool. Until end of turn, this mana doesn't empty from your mana pool as steps and phases end.",
             "colours": [],
@@ -8750,7 +8750,7 @@
         },
         {
             "id": "3dfaad31-d6a0-57f5-807e-dc4084caffbf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2420ee20-c7f1-42e8-b8c5-efc0206887aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2420ee20-c7f1-42e8-b8c5-efc0206887aa.jpg?1",
             "name": "Sundering Fork",
             "text": "Whenever you crank Sundering Fork, destroy target artifact.",
             "colours": [],
@@ -8780,7 +8780,7 @@
         },
         {
             "id": "ca7fc729-c29b-5d8f-953c-170a7a8d9817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52882b9b-fbf2-405e-9eee-ddb434874070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52882b9b-fbf2-405e-9eee-ddb434874070.jpg?1",
             "name": "Targeting Rocket",
             "text": "Whenever you crank Targeting Rocket, target creature blocks this turn if able.",
             "colours": [],
@@ -8810,7 +8810,7 @@
         },
         {
             "id": "ca8f36b8-9208-5976-9145-0ba042c3f963",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40dafec-1243-413c-84db-c07a8cf6d628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40dafec-1243-413c-84db-c07a8cf6d628.jpg?1",
             "name": "Thud-for-Duds",
             "text": "Whenever you crank Thud-for-Duds, roll two six-sided dice. Thud-for-Duds deals damage to target creature equal to the difference between those results.",
             "colours": [],
@@ -8840,7 +8840,7 @@
         },
         {
             "id": "863a254b-6422-5ae3-bc92-40c5ac8dc543",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f6ce-1c39-453a-8edf-5461a9db8b8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d5f6ce-1c39-453a-8edf-5461a9db8b8f.jpg?1",
             "name": "Top-Secret Tunnel",
             "text": "Whenever you crank Top-Secret Tunnel, target creature can't be blocked this turn.",
             "colours": [],
@@ -8870,7 +8870,7 @@
         },
         {
             "id": "182275a2-be91-5a7a-93d1-b80c7fcd8560",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d2f8f3-7bd0-4775-806b-1583da4814a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70d2f8f3-7bd0-4775-806b-1583da4814a5.jpg?1",
             "name": "Tread Mill",
             "text": "Whenever you crank Tread Mill, until end of turn, target creature gets +1/+2, gains vigilance, and becomes an artifact in addition to its other types.",
             "colours": [],
@@ -8900,7 +8900,7 @@
         },
         {
             "id": "83e0fc96-aa7c-59a4-863c-62a685c4c973",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be96ad59-cec0-4b82-877d-7ffa2755cebf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be96ad59-cec0-4b82-877d-7ffa2755cebf.jpg?1",
             "name": "Turbo-Thwacking Auto-Hammer",
             "text": "Whenever you crank Turbo-Thwacking Auto-Hammer, target creature gains double strike until end of turn.",
             "colours": [],
@@ -8930,7 +8930,7 @@
         },
         {
             "id": "1c617718-b025-5d5e-8cbb-bbf652af6165",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce1145-ca48-4fee-a11d-df88c20bd852.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9ce1145-ca48-4fee-a11d-df88c20bd852.jpg?1",
             "name": "Twiddlestick Charger",
             "text": "Whenever you crank Twiddlestick Charger, tap or untap target creature.",
             "colours": [],
@@ -8960,7 +8960,7 @@
         },
         {
             "id": "198eb6ac-6e8e-56ad-92e4-58e7ae5992b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11519144-1f4c-4f11-9a36-4456d45098a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11519144-1f4c-4f11-9a36-4456d45098a1.jpg?1",
             "name": "Widget Contraption",
             "text": "Whenever you crank Widget Contraption, it assembles a Contraption. (Put the top card of your Contraption deck face up onto one of your sprockets.)",
             "colours": [],
@@ -8990,7 +8990,7 @@
         },
         {
             "id": "c7f233d4-0770-5b10-9836-b4034047a9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c8b8e-2e28-4f10-b04f-9b313c60c0bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a2c8b8e-2e28-4f10-b04f-9b313c60c0bb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -9024,7 +9024,7 @@
         },
         {
             "id": "f25771fd-0ee8-5499-95cb-aa8093c0c45c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b2118-b22c-4ef5-bac7-836db4b8b9ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b2118-b22c-4ef5-bac7-836db4b8b9ee.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -9058,7 +9058,7 @@
         },
         {
             "id": "d0a61ccf-d4ca-5640-9e36-562088817708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108b0fb-420a-422d-ae85-9a99c0f73169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108b0fb-420a-422d-ae85-9a99c0f73169.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -9092,7 +9092,7 @@
         },
         {
             "id": "203688a0-57b3-5560-9fd3-3cc193667827",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1a862-00fc-4e79-a83a-289fef81503a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c1a862-00fc-4e79-a83a-289fef81503a.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -9126,7 +9126,7 @@
         },
         {
             "id": "2e38aa40-48bd-5a1b-bce7-a53f5ae2911d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8772631-d4a1-440d-ac89-ac6659bdc073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8772631-d4a1-440d-ac89-ac6659bdc073.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -9160,7 +9160,7 @@
         },
         {
             "id": "8e1f827f-baa9-50b9-a165-2e33175d4b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg?1",
             "name": "Angel // Angel",
             "text": "",
             "colours": [
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "b6f3e90f-2ddf-5067-ad65-4150865fcad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg?1",
             "name": "Angel // Angel",
             "text": "",
             "colours": [
@@ -9225,7 +9225,7 @@
         },
         {
             "id": "49f34b52-a64a-5352-a362-1a7bfea5baab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b44a88-85e8-4f82-8968-cf1352f0fb87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b44a88-85e8-4f82-8968-cf1352f0fb87.jpg?1",
             "name": "Goat",
             "text": "",
             "colours": [
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "c6704eb3-dc05-5ba4-8138-e578e5d6ce3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg?1",
             "name": "Spirit // Spirit",
             "text": "",
             "colours": [
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "105fb6c8-1ec4-5eca-a024-1603b2a8fe84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg?1",
             "name": "Spirit // Spirit",
             "text": "",
             "colours": [
@@ -9324,7 +9324,7 @@
         },
         {
             "id": "00599669-2f9c-5f4d-ae77-64b2840ce3bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008e47a-a8c4-4f4f-8628-ac4b8f978dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1008e47a-a8c4-4f4f-8628-ac4b8f978dd0.jpg?1",
             "name": "Faerie Spy",
             "text": "",
             "colours": [
@@ -9359,7 +9359,7 @@
         },
         {
             "id": "583a9407-fae0-5b72-8017-c49e5c4701dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80165be4-c6c8-4b22-b259-c64eb4b7fc95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80165be4-c6c8-4b22-b259-c64eb4b7fc95.jpg?1",
             "name": "Storm Crow",
             "text": "",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "d8fcf9ab-0a1e-5bb9-9095-d9f21ecef810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg?1",
             "name": "Thopter // Thopter",
             "text": "",
             "colours": [
@@ -9428,7 +9428,7 @@
         },
         {
             "id": "01a2b9ed-170e-51d9-8cd0-50582b393393",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg?1",
             "name": "Thopter // Thopter",
             "text": "",
             "colours": [
@@ -9459,7 +9459,7 @@
         },
         {
             "id": "0289045f-4003-52c1-a805-9c3759130054",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633d7b-6d61-4b1a-8d65-6e1f3d5ffba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b633d7b-6d61-4b1a-8d65-6e1f3d5ffba7.jpg?1",
             "name": "Rogue",
             "text": "",
             "colours": [
@@ -9493,7 +9493,7 @@
         },
         {
             "id": "d1fed647-a495-51e4-904b-85946036fbc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg?1",
             "name": "Vampire // Vampire",
             "text": "",
             "colours": [
@@ -9527,7 +9527,7 @@
         },
         {
             "id": "3d8ead38-b452-5999-8d82-2247cf92c602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg?1",
             "name": "Vampire // Vampire",
             "text": "",
             "colours": [
@@ -9558,7 +9558,7 @@
         },
         {
             "id": "510ddecb-189f-5951-82a0-f2704fc079b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg?1",
             "name": "Zombie // Zombie",
             "text": "",
             "colours": [
@@ -9592,7 +9592,7 @@
         },
         {
             "id": "64a647cc-efa5-5c52-87d1-9a4cfedf52ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg?1",
             "name": "Zombie // Zombie",
             "text": "",
             "colours": [
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "3cee8fbc-9a87-5ec9-906c-4ddcb978f6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1a8115-127d-4268-a4d0-95360862e5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af1a8115-127d-4268-a4d0-95360862e5fb.jpg?1",
             "name": "Brainiac",
             "text": "",
             "colours": [
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "a0fc88f2-fde4-581d-9bca-111e01888e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -9691,7 +9691,7 @@
         },
         {
             "id": "b26bd125-c227-5c1b-a00e-660af80a3ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -9722,7 +9722,7 @@
         },
         {
             "id": "2774cdb5-a6d6-5f29-9092-aa29913f1562",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be4b0d5-b3f8-4a5d-8a38-eb0e1886f655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be4b0d5-b3f8-4a5d-8a38-eb0e1886f655.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -9756,7 +9756,7 @@
         },
         {
             "id": "aaa77154-0683-5efd-b433-401a3a156f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg?1",
             "name": "Beast // Beast",
             "text": "",
             "colours": [
@@ -9790,7 +9790,7 @@
         },
         {
             "id": "47b64de2-bcbb-5a99-8364-a292f7d6daef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg?1",
             "name": "Beast // Beast",
             "text": "",
             "colours": [
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "f2df0021-b3ad-540b-9f9d-794fd2e208bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg?1",
             "name": "Saproling // Saproling",
             "text": "",
             "colours": [
@@ -9855,7 +9855,7 @@
         },
         {
             "id": "d2a392d6-599f-5ceb-ab99-90d47f0e4685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg?1",
             "name": "Saproling // Saproling",
             "text": "",
             "colours": [
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "635c3b86-6abb-5d76-8cb9-edf324c55576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53500f0f-ef65-4534-a8db-80ce73030bc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53500f0f-ef65-4534-a8db-80ce73030bc1.jpg?1",
             "name": "Squirrel",
             "text": "",
             "colours": [
@@ -9920,7 +9920,7 @@
         },
         {
             "id": "8fa3153c-0257-5bab-b1af-b95f1a77c905",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c65dfd-69be-4345-92e9-51a35a486f21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44c65dfd-69be-4345-92e9-51a35a486f21.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [],
@@ -9950,7 +9950,7 @@
         },
         {
             "id": "65af3978-a2ad-5607-8c7b-1d7c82292fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "f01363ef-2fbd-56b2-80b1-017ccfa6f907",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg?1",
             "name": "Elemental // Elemental",
             "text": "",
             "colours": [
@@ -10019,7 +10019,7 @@
         },
         {
             "id": "0ed8e23f-eae3-5f95-abed-b1bea07d2503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg?1",
             "name": "Clue // Clue",
             "text": "",
             "colours": [],
@@ -10049,7 +10049,7 @@
         },
         {
             "id": "a8f45998-a850-5176-b877-8f771ef980ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg?1",
             "name": "Clue // Clue",
             "text": "",
             "colours": [],
@@ -10076,7 +10076,7 @@
         },
         {
             "id": "d223b599-3253-5f87-8e98-1dfe083fa7d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1935902c-d84f-496a-b9f1-f96d1f5e2b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1935902c-d84f-496a-b9f1-f96d1f5e2b84.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -10107,7 +10107,7 @@
         },
         {
             "id": "32d8fbf9-e5f4-5d90-8f0c-01b7fa813113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf33cc3-254f-4c5c-be22-3a2d96f29b80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbf33cc3-254f-4c5c-be22-3a2d96f29b80.jpg?1",
             "name": "Gnome",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/VIS.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/VIS.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9521f4ad-1d27-50cc-87c3-af89ddae109a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368144bf-d415-48ab-a957-9d7ac1ceb353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368144bf-d415-48ab-a957-9d7ac1ceb353.jpg?1",
             "name": "Archangel",
             "text": "Flying\nAttacking does not cause Archangel to tap.",
             "colours": [
@@ -37,7 +37,7 @@
         },
         {
             "id": "39341424-6f21-57db-bf0f-a7a2890315ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7afcaa-9df8-4dd6-89ad-bc2e15f1ec4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f7afcaa-9df8-4dd6-89ad-bc2e15f1ec4b.jpg?1",
             "name": "Daraja Griffin",
             "text": "Flying\nSacrifice Daraja Griffin: Destroy target black creature.",
             "colours": [
@@ -70,7 +70,7 @@
         },
         {
             "id": "9cc92819-c954-5cc9-a884-dfadffba12b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53783312-3551-4361-ab02-c9651ce2a926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53783312-3551-4361-ab02-c9651ce2a926.jpg?1",
             "name": "Equipoise",
             "text": "During your upkeep, for each land target player controls in excess of the number of lands you control, target land he or she controls phases out. Repeat this process for artifacts and then for creatures.",
             "colours": [
@@ -101,7 +101,7 @@
         },
         {
             "id": "1b87b003-7b5e-549c-9a38-d0bccdbd73cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa84e4ad-738a-4d23-a84c-06c39ff4200b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa84e4ad-738a-4d23-a84c-06c39ff4200b.jpg?1",
             "name": "Eye of Singularity",
             "text": "When Eye of Singularity comes into play, bury all permanents with the same name except basic lands.\nWhenever any permanent other than a basic land comes into play, bury any permanent already in play with the same name.",
             "colours": [
@@ -134,7 +134,7 @@
         },
         {
             "id": "1908536e-4c6d-596a-9605-758a28c1e362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dc0244-319c-4e15-9083-8d21ad0364d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33dc0244-319c-4e15-9083-8d21ad0364d8.jpg?1",
             "name": "Freewind Falcon",
             "text": "Flying, protection from red",
             "colours": [
@@ -167,7 +167,7 @@
         },
         {
             "id": "57d17fcb-7fb1-5822-ac39-ae3ef9a19242",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9917a29-c6b4-4e0a-a301-21868bd27e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9917a29-c6b4-4e0a-a301-21868bd27e17.jpg?1",
             "name": "Gossamer Chains",
             "text": "Return Gossamer Chains to owner's hand: Target unblocked creature deals no combat damage this turn.",
             "colours": [
@@ -198,7 +198,7 @@
         },
         {
             "id": "77821b34-9612-5dc2-895f-670875fefef1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559d301-98bd-40a9-abf4-1079d7283214.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559d301-98bd-40a9-abf4-1079d7283214.jpg?1",
             "name": "Honorable Passage",
             "text": "Prevent all damage to you or target creature from any one source. If that source is red, Honorable Passage deals to the source's controller an amount of damage equal to the amount of damage prevented.",
             "colours": [
@@ -229,7 +229,7 @@
         },
         {
             "id": "596fd214-760b-5f48-b49b-9bda84d6a54d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a8980f-07ab-49b7-b83d-f394952ced57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1a8980f-07ab-49b7-b83d-f394952ced57.jpg?1",
             "name": "Hope Charm",
             "text": "Choose one Target creature gains first strike until end of turn; or target player gains 2 life; or destroy target local enchantment.",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "dffad234-9995-5ac5-836d-3902f927bcf6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0350470b-feea-4e15-bdf0-850b71dbeea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0350470b-feea-4e15-bdf0-850b71dbeea6.jpg?1",
             "name": "Infantry Veteran",
             "text": "oc\nT: Target attacking creature gets +1/+1 until end of turn.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "0bdd505c-9816-59eb-8000-c42a5288f6f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc681f5-9fff-48b6-98d9-e85c85e582a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfc681f5-9fff-48b6-98d9-e85c85e582a3.jpg?1",
             "name": "Jamuraan Lion",
             "text": "o\nW, oc\nT: Target creature cannot block this turn.",
             "colours": [
@@ -327,7 +327,7 @@
         },
         {
             "id": "8d2cb294-bd42-5e31-a94c-a10fbc0107b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa80ae-bb17-4e52-a269-efe75cf4c041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25aa80ae-bb17-4e52-a269-efe75cf4c041.jpg?1",
             "name": "Knight of Valor",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1oo\nW Each creature without flanking blocking Knight of Valor gets -1/-1 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "4d9d55f2-f9ac-530a-99af-4e3a0a75b068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee185d-f5ae-4b1d-90a4-840182f87ab8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ee185d-f5ae-4b1d-90a4-840182f87ab8.jpg?1",
             "name": "Longbow Archer",
             "text": "First strike\nLongbow Archer can block creatures with flying.",
             "colours": [
@@ -396,7 +396,7 @@
         },
         {
             "id": "de966bfd-c5fe-537f-aad2-01d99589775a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fecb31-790a-4454-918e-5aeb253021f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76fecb31-790a-4454-918e-5aeb253021f0.jpg?1",
             "name": "Miraculous Recovery",
             "text": "Put target creature card from your graveyard into play and put a +1/+1 counter on that creature. Treat the creature as though it were just played.",
             "colours": [
@@ -427,7 +427,7 @@
         },
         {
             "id": "8c84425c-f028-5678-9d03-5bd2e46a2e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bbcaa9-edbf-48ad-bcd2-65e8fb9bb938.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7bbcaa9-edbf-48ad-bcd2-65e8fb9bb938.jpg?1",
             "name": "Parapet",
             "text": "You may choose to play Parapet as an instant; if you do, bury it at end of turn.\nAll creatures you control get +0/+1.",
             "colours": [
@@ -458,7 +458,7 @@
         },
         {
             "id": "f759753b-1626-5d32-9817-54fc863f2600",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21da279d-a723-4902-bf84-dfe2c569d4c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21da279d-a723-4902-bf84-dfe2c569d4c8.jpg?1",
             "name": "Peace Talks",
             "text": "During this turn and the next one, players cannot declare an attack and cannot play spells or abilities that target any permanent or player.",
             "colours": [
@@ -489,7 +489,7 @@
         },
         {
             "id": "52d8f995-f7a2-5b45-ac3b-1bf735ce3d91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0459667-b7da-43bd-b981-0e515432d147.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0459667-b7da-43bd-b981-0e515432d147.jpg?1",
             "name": "Relic Ward",
             "text": "You may choose to play Relic Ward as an instant; if you do, bury it at end of turn.\nEnchanted artifact cannot be the target of spells or effects.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "fb5916ca-8777-5803-86af-cda8557dd3b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0b7162-4422-4dfb-a6ca-8d89fa74e6dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0b7162-4422-4dfb-a6ca-8d89fa74e6dc.jpg?1",
             "name": "Remedy",
             "text": "Prevent up to 5 damage total to any number of creatures and/or players.",
             "colours": [
@@ -553,7 +553,7 @@
         },
         {
             "id": "eb3cb1a0-f1eb-57a8-9775-3ebbe3c4d211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21250bdb-9431-41b3-9fef-d66a4d3f6ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21250bdb-9431-41b3-9fef-d66a4d3f6ecd.jpg?1",
             "name": "Resistance Fighter",
             "text": "Sacrifice Resistance Fighter: Target creature deals no combat damage this turn.",
             "colours": [
@@ -587,7 +587,7 @@
         },
         {
             "id": "96b754e0-34c2-5f27-8e6c-5c229466c82a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860b8633-1bfc-426a-8666-5e6a584d4525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/860b8633-1bfc-426a-8666-5e6a584d4525.jpg?1",
             "name": "Retribution of the Meek",
             "text": "Bury all creatures with power 4 or greater.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "c788644f-8f8f-5e8c-95c3-000ca51eb84b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed82843-2853-42d3-bcf6-b831032b7a69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fed82843-2853-42d3-bcf6-b831032b7a69.jpg?1",
             "name": "Righteous Aura",
             "text": "o\nW, Pay 2 life: Prevent all damage to you from any one source.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "2b2209bc-459a-5c73-a501-2f53d551514b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f1fb74-bc08-4c3b-9fbe-da6973aaeaa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3f1fb74-bc08-4c3b-9fbe-da6973aaeaa2.jpg?1",
             "name": "Sun Clasp",
             "text": "Enchanted creature gets +1/+3.\noo\nW Return enchanted creature to owner's hand.",
             "colours": [
@@ -682,7 +682,7 @@
         },
         {
             "id": "435411cd-9ff9-5d0d-ba57-ac6f0435de86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177d5bf-db48-4bbf-bbd4-ee6313031920.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4177d5bf-db48-4bbf-bbd4-ee6313031920.jpg?1",
             "name": "Teferi's Honor Guard",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no\nUoo\nU Phase out",
             "colours": [
@@ -717,7 +717,7 @@
         },
         {
             "id": "12c17218-27cb-5f8d-bec7-8071c9bc1558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae08938-e563-4322-b2eb-db81913ea730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aae08938-e563-4322-b2eb-db81913ea730.jpg?1",
             "name": "Tithe",
             "text": "Search your library for a plains card. If you control fewer lands than target opponent, you may search your library for an additional plains card. Reveal those cards to all players and put them into your hand. Shuffle your library afterwards.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "7440af79-cc9e-5646-a2d2-f0fceb3938fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7babd273-3e20-4cf9-bf21-c602eb729fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7babd273-3e20-4cf9-bf21-c602eb729fc5.jpg?1",
             "name": "Warrior's Honor",
             "text": "All creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -779,7 +779,7 @@
         },
         {
             "id": "98036d65-0f7e-5c97-b629-6345e19aff9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed802f-6e54-4fed-a71e-6d404c2c664b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed802f-6e54-4fed-a71e-6d404c2c664b.jpg?1",
             "name": "Zhalfirin Crusader",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\no1oo\nW Redirect 1 damage from Zhalfirin Crusader to target creature or player.",
             "colours": [
@@ -813,7 +813,7 @@
         },
         {
             "id": "ea020bf4-0b8b-543c-ac4b-f2ed6940eb67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9b5c75-882e-4fe4-827f-584080e91485.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9b5c75-882e-4fe4-827f-584080e91485.jpg?1",
             "name": "Betrayal",
             "text": "Play only on a creature an opponent controls.\nIf enchanted creature becomes tapped, draw a card.",
             "colours": [
@@ -846,7 +846,7 @@
         },
         {
             "id": "ab1f8fbd-a04f-5422-aeb0-1c089780e43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaefa77-6e4a-4724-a443-fa6b45803db5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/beaefa77-6e4a-4724-a443-fa6b45803db5.jpg?1",
             "name": "Breezekeeper",
             "text": "Flying, phasing",
             "colours": [
@@ -879,7 +879,7 @@
         },
         {
             "id": "cba1477f-ad31-5304-ab78-d31bfff73f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ada02f-04e9-4269-b04a-97a7eaac2c46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05ada02f-04e9-4269-b04a-97a7eaac2c46.jpg?1",
             "name": "Chronatog",
             "text": "Skip your next turn: Chronatog gets +3/+3 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -912,7 +912,7 @@
         },
         {
             "id": "594cd2f3-17ac-5bd2-9f29-f617e1133abd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2a5146-cf2e-40c0-b498-06e611343196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f2a5146-cf2e-40c0-b498-06e611343196.jpg?1",
             "name": "Cloud Elemental",
             "text": "Flying\nCloud Elemental can block only creatures with flying.",
             "colours": [
@@ -945,7 +945,7 @@
         },
         {
             "id": "48f031f2-7db6-5786-92ab-680408204e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2a1779-af08-4a9a-aba4-e6892ce2332c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2a1779-af08-4a9a-aba4-e6892ce2332c.jpg?1",
             "name": "Desertion",
             "text": "Counter target spell. If that spell is an artifact or summon spell, put that card into play under your control as though it were just played.",
             "colours": [
@@ -976,7 +976,7 @@
         },
         {
             "id": "9396c7a9-8ef0-5cca-85b3-b4091d30987c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd292a0-ec08-4250-8d75-0802e985d6e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd292a0-ec08-4250-8d75-0802e985d6e6.jpg?1",
             "name": "Dream Tides",
             "text": "Creatures do not untap during their controllers' untap phase.\nEach nongreen creature's controller may pay an additional o2 during his or her upkeep to untap that creature.",
             "colours": [
@@ -1007,7 +1007,7 @@
         },
         {
             "id": "f2d35836-03d8-554a-bec8-00f086300e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49db9f58-380f-496e-9d3d-6776d30fb564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49db9f58-380f-496e-9d3d-6776d30fb564.jpg?1",
             "name": "Flooded Shoreline",
             "text": "o\nUo\nU, Return two islands you control to owner's hand: Return target creature to owner's hand.",
             "colours": [
@@ -1038,7 +1038,7 @@
         },
         {
             "id": "3fc3f63c-fad2-5814-943f-74ebc3a9a0af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54c51de-bfac-4198-a7c4-37b4db74e525.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54c51de-bfac-4198-a7c4-37b4db74e525.jpg?1",
             "name": "Foreshadow",
             "text": "Name a card. Put the top card from target opponent's library into his or her graveyard. If that card is the one named, draw a card.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -1069,7 +1069,7 @@
         },
         {
             "id": "ae66cd65-91a4-5df7-8fab-d3cd97122fb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d710a97-062f-4773-b6c6-8aeddeb3b6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d710a97-062f-4773-b6c6-8aeddeb3b6e8.jpg?1",
             "name": "Impulse",
             "text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library. Shuffle your library afterwards.",
             "colours": [
@@ -1100,7 +1100,7 @@
         },
         {
             "id": "63dc205b-7055-5a17-a5bc-cdf2f444750d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5247d0b0-660e-4f27-8e76-62effbe12221.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5247d0b0-660e-4f27-8e76-62effbe12221.jpg?1",
             "name": "Inspiration",
             "text": "Target player draws two cards.",
             "colours": [
@@ -1131,7 +1131,7 @@
         },
         {
             "id": "e05325ad-1a4c-554a-a477-17704414cfe2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37924cbc-fb9d-4906-9ad2-9b6d4ccfff0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37924cbc-fb9d-4906-9ad2-9b6d4ccfff0f.jpg?1",
             "name": "Knight of the Mists",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nWhen Knight of the Mists comes into play, pay o\nU or bury target Knight.",
             "colours": [
@@ -1165,7 +1165,7 @@
         },
         {
             "id": "c002fdda-f978-5370-90a6-c8ffbe8d17a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbf9bf9-75cd-4b25-a3a1-43b7e029700b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbf9bf9-75cd-4b25-a3a1-43b7e029700b.jpg?1",
             "name": "Man-o'-War",
             "text": "When Man-o'-War comes into play, return target creature to owner's hand.",
             "colours": [
@@ -1198,7 +1198,7 @@
         },
         {
             "id": "63e49727-62e6-51bb-b999-138f0296e751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb640d-5c54-4d0a-b8c2-e22fe04f96c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddb640d-5c54-4d0a-b8c2-e22fe04f96c2.jpg?1",
             "name": "Mystic Veil",
             "text": "You may choose to play Mystic Veil as an instant; if you do, bury it at end of turn.\nEnchanted creature cannot be the target of spells or effects.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "16a69039-088e-591e-a346-0add4e998194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f0988-4194-4481-a6b7-27753261174a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae4f0988-4194-4481-a6b7-27753261174a.jpg?1",
             "name": "Ovinomancer",
             "text": "When Ovinomancer comes into play, return three basic lands you control to owner's hand or bury Ovinomancer.\noc\nT, Return Ovinomancer to owner's hand: Bury target creature and put a Sheep token into play under the control of the creature's controller. Treat this token as a 0/1 green creature.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "15260d66-27d5-5ae8-bf8d-df2f6e779f7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5e806-3cf2-4241-b45d-a05d2b715efd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fa5e806-3cf2-4241-b45d-a05d2b715efd.jpg?1",
             "name": "Prosperity",
             "text": "Each player draws X cards.",
             "colours": [
@@ -1296,7 +1296,7 @@
         },
         {
             "id": "0dc321b6-9db8-5e65-a623-5dbd1fded5af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6f03a6-3665-40e4-ae68-640913972770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d6f03a6-3665-40e4-ae68-640913972770.jpg?1",
             "name": "Rainbow Efreet",
             "text": "Flying\no\nUo\nU: Phase out",
             "colours": [
@@ -1329,7 +1329,7 @@
         },
         {
             "id": "2de59638-bb8c-5910-a744-72f5655aae9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5704f-5856-4422-9d82-14558dbe1434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23c5704f-5856-4422-9d82-14558dbe1434.jpg?1",
             "name": "Shimmering Efreet",
             "text": "Flying, phasing\nWhen Shimmering Efreet phases in, target creature phases out.",
             "colours": [
@@ -1362,7 +1362,7 @@
         },
         {
             "id": "3c7053bb-2cdf-5822-9dca-3f3203082e8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63971a64-c5f3-4d1f-ae0d-489d7d5b18f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63971a64-c5f3-4d1f-ae0d-489d7d5b18f0.jpg?1",
             "name": "Shrieking Drake",
             "text": "Flying\nWhen Shrieking Drake comes into play, return a creature you control to owner's hand.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "a12ff333-e1cf-56a2-8801-3abba7358599",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba3e4ea-2241-4f1e-a46b-70f512fe729e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba3e4ea-2241-4f1e-a46b-70f512fe729e.jpg?1",
             "name": "Teferi's Realm",
             "text": "At the beginning of each player's upkeep, that player chooses artifacts, creatures, lands, or global enchantments. All cards of that type phase out.",
             "colours": [
@@ -1428,7 +1428,7 @@
         },
         {
             "id": "82923bcc-eb48-53db-9250-b76b37ba564c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2b253-7023-44d1-963b-eae98d48f498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbb2b253-7023-44d1-963b-eae98d48f498.jpg?1",
             "name": "Three Wishes",
             "text": "Take the top three cards from your library, look at them, and set them aside face down. You may play those cards as though they were in your hand. At the beginning of your next turn, bury any of those cards not played.",
             "colours": [
@@ -1459,7 +1459,7 @@
         },
         {
             "id": "103d28fd-3b69-5604-b103-3a05120d8f54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b348a-0301-4d45-a2c1-d78802c445ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/152b348a-0301-4d45-a2c1-d78802c445ba.jpg?1",
             "name": "Time and Tide",
             "text": "All creatures that are phased out phase in and all creatures with phasing phase out.",
             "colours": [
@@ -1490,7 +1490,7 @@
         },
         {
             "id": "36fb7bd8-11d3-5345-88a9-3b24bb8c5c9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bef942e-9d17-4d40-a4c9-8be715e73a08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bef942e-9d17-4d40-a4c9-8be715e73a08.jpg?1",
             "name": "Undo",
             "text": "Return two target creatures to owner's hand.",
             "colours": [
@@ -1521,7 +1521,7 @@
         },
         {
             "id": "7063d8c9-6ab4-5b0c-ba46-03292ced0c45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1fb805-1382-458c-b98d-4491f13833b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1fb805-1382-458c-b98d-4491f13833b6.jpg?1",
             "name": "Vanishing",
             "text": "o\nUoo\nU Enchanted creature phases out.",
             "colours": [
@@ -1554,7 +1554,7 @@
         },
         {
             "id": "a7842c17-9736-5c4c-874b-e2b23338100f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b384d3-3adf-493a-8b89-bfe68fd1c3e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b384d3-3adf-493a-8b89-bfe68fd1c3e2.jpg?1",
             "name": "Vision Charm",
             "text": "Choose one Target artifact phases out; or put the top four cards from target player's library into his or her graveyard; or all lands of one type are basic lands of your choice until end of turn.",
             "colours": [
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "c255557c-5a2a-5346-97d4-2356dc3372ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6946a75e-e9d1-4a56-86d1-dd81f7b1b125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6946a75e-e9d1-4a56-86d1-dd81f7b1b125.jpg?1",
             "name": "Waterspout Djinn",
             "text": "Flying\nDuring your upkeep, return an untapped island you control to owner's hand or bury Waterspout Djinn.",
             "colours": [
@@ -1618,7 +1618,7 @@
         },
         {
             "id": "2e5ee823-dd12-5532-a554-873173032738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369a5df5-fc36-476c-84f4-ec4bdeb4f9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/369a5df5-fc36-476c-84f4-ec4bdeb4f9d2.jpg?1",
             "name": "Aku Djinn",
             "text": "Trample\nDuring your upkeep, each opponent puts a +1/+1 counter on each creature he or she controls.",
             "colours": [
@@ -1651,7 +1651,7 @@
         },
         {
             "id": "a0a27a80-13ac-56a5-a20b-072788d38c03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe012fd0-9ff0-4436-a890-3ab436e42201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe012fd0-9ff0-4436-a890-3ab436e42201.jpg?1",
             "name": "Blanket of Night",
             "text": "Each mana-producing land is a swamp in addition to its normal land type.",
             "colours": [
@@ -1682,7 +1682,7 @@
         },
         {
             "id": "5852d611-1733-5f66-99c2-418237a61da3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b6150e-7d0c-4361-b99b-79de96dfc53a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30b6150e-7d0c-4361-b99b-79de96dfc53a.jpg?1",
             "name": "Brood of Cockroaches",
             "text": "If Brood of Cockroaches is put into your graveyard from play, pay 1 life and return Brood of Cockroaches to your hand at end of turn.",
             "colours": [
@@ -1715,7 +1715,7 @@
         },
         {
             "id": "14b6a11e-c2ad-5608-97d6-75e2039454fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b07d33-f5f5-45cc-b2ac-360eaf2d4146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3b07d33-f5f5-45cc-b2ac-360eaf2d4146.jpg?1",
             "name": "Coercion",
             "text": "Look at target opponent's hand. Choose a card from that player's hand. That player discards that card.",
             "colours": [
@@ -1746,7 +1746,7 @@
         },
         {
             "id": "7b1f90c2-ca96-5898-aa4a-a55dda440362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736455f6-c1b3-4a5a-a91f-a0cd3986ed53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/736455f6-c1b3-4a5a-a91f-a0cd3986ed53.jpg?1",
             "name": "Crypt Rats",
             "text": "oo\nX Crypt Rats deals X damage to each creature and player. Spend only black mana in this way.",
             "colours": [
@@ -1779,7 +1779,7 @@
         },
         {
             "id": "830d997b-1a35-5550-b250-87eb5908aa74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2cf44-cc20-4a37-81ae-930f8c6d0896.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10d2cf44-cc20-4a37-81ae-930f8c6d0896.jpg?1",
             "name": "Dark Privilege",
             "text": "Enchanted creature gets +1/+1.\nSacrifice a creature: Regenerate enchanted creature.",
             "colours": [
@@ -1812,7 +1812,7 @@
         },
         {
             "id": "328ed91f-3fc6-50bf-ba72-2b1ec5baaea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e939d8f-6989-4884-989b-9cba566c9963.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e939d8f-6989-4884-989b-9cba566c9963.jpg?1",
             "name": "Death Watch",
             "text": "If enchanted creature is put into any graveyard, that creature's controller loses an amount of life equal to its power and you gain an amount of life equal to its toughness.",
             "colours": [
@@ -1845,7 +1845,7 @@
         },
         {
             "id": "aff631a1-31b2-55ce-8099-b93b0a72ebc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b186460-d2af-4912-ba19-95b2cb5f1639.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b186460-d2af-4912-ba19-95b2cb5f1639.jpg?1",
             "name": "Desolation",
             "text": "At the end of each turn, each player who tapped a land for mana during that turn sacrifices a land. If a plains is sacrificed in this way, Desolation deals 2 damage to that plains' controller.",
             "colours": [
@@ -1876,7 +1876,7 @@
         },
         {
             "id": "08c56700-abfd-505b-8d85-8b2eb7c4c3f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00107210-313f-49c1-84ff-92628f75b764.jpg?1",
             "name": "Fallen Askari",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nFallen Askari cannot block.",
             "colours": [
@@ -1910,7 +1910,7 @@
         },
         {
             "id": "820519f8-4f8a-5cf6-bd81-e1e8751f512d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5327e6d-db4e-4b44-a00e-b764e80b8946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5327e6d-db4e-4b44-a00e-b764e80b8946.jpg?1",
             "name": "Forbidden Ritual",
             "text": "Sacrifice a card in play: Target opponent loses 2 life unless he or she sacrifices a permanent or chooses and discards a card.\nYou may repeat this process as many times as you choose.",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "57f26343-1699-5b5e-a60d-b85c5e7268d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d7240-2014-4838-bace-80666192a73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79d7240-2014-4838-bace-80666192a73e.jpg?1",
             "name": "Funeral Charm",
             "text": "Choose one Target player chooses and discards a card; or target creature gets +2/-1 until end of turn; or target creature gains swampwalk until end of turn. (If defending player controls any swamps, that creature is unblockable.)",
             "colours": [
@@ -1972,7 +1972,7 @@
         },
         {
             "id": "4b90524f-9476-5dc4-b868-aded4ba15135",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf85ac9-f5d8-4a36-aa6c-3a31427a0348.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccf85ac9-f5d8-4a36-aa6c-3a31427a0348.jpg?1",
             "name": "Infernal Harvest",
             "text": "Return X swamps you control to owner's hand: Infernal Harvest deals X damage, divided any way you choose, among any number of target creatures.",
             "colours": [
@@ -2003,7 +2003,7 @@
         },
         {
             "id": "3013a4fd-2cf9-504b-a31a-d53fe896d73f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d385b9e5-e13d-4098-ba74-ea55bde164d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d385b9e5-e13d-4098-ba74-ea55bde164d9.jpg?1",
             "name": "Kaervek's Spite",
             "text": "Sacrifice all permanents, Discard your hand: Target player loses 5 life.",
             "colours": [
@@ -2034,7 +2034,7 @@
         },
         {
             "id": "c7896b11-1cb7-5702-bb03-765517477212",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a6257-dd77-4bb6-81cb-c8e7862350f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311a6257-dd77-4bb6-81cb-c8e7862350f3.jpg?1",
             "name": "Necromancy",
             "text": "You may choose to play Necromancy as an instant; if you do, bury it at end of turn.\nWhen you play Necromancy, choose target creature card in any graveyard. When Necromancy comes into play, put that creature into play as though it were just played and Necromancy becomes a creature enchantment that targets the creature. If Necromancy leaves play, bury the creature.",
             "colours": [
@@ -2065,7 +2065,7 @@
         },
         {
             "id": "cc295880-7079-52e4-b746-08072d4d6200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70cd5fa-ae66-4ea4-90d2-28af2aa34dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70cd5fa-ae66-4ea4-90d2-28af2aa34dd4.jpg?1",
             "name": "Necrosavant",
             "text": "o3o\nBo\nB, Sacrifice a creature: Put Necrosavant into play. Use this ability only during your upkeep and only if Necrosavant is in your graveyard.",
             "colours": [
@@ -2099,7 +2099,7 @@
         },
         {
             "id": "a72b65e8-7e44-5054-9620-7939c80df11f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba3e342-88b7-4692-a3f7-a3f56c0cf6b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba3e342-88b7-4692-a3f7-a3f56c0cf6b5.jpg?1",
             "name": "Nekrataal",
             "text": "First strike\nWhen Nekrataal comes into play, bury target nonartifact, nonblack creature.",
             "colours": [
@@ -2133,7 +2133,7 @@
         },
         {
             "id": "97bf6d52-23b6-5a8e-9a98-03d4ceb6f30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f93fd-4f2c-4dce-a774-4483031ed532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153f93fd-4f2c-4dce-a774-4483031ed532.jpg?1",
             "name": "Pillar Tombs of Aku",
             "text": "During each player's upkeep, that player sacrifices a creature, or that player loses 5 life and you bury Pillar Tombs of Aku.",
             "colours": [
@@ -2166,7 +2166,7 @@
         },
         {
             "id": "5de1e656-d388-5dfd-9dea-b80fabc5037a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e99969-6c21-4de6-ba57-44ef7f9c8c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7e99969-6c21-4de6-ba57-44ef7f9c8c47.jpg?1",
             "name": "Python",
             "text": "",
             "colours": [
@@ -2199,7 +2199,7 @@
         },
         {
             "id": "76147635-8968-58fb-8737-319ca94058e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7178c6-f989-437d-83e3-04b9817f2c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b7178c6-f989-437d-83e3-04b9817f2c54.jpg?1",
             "name": "Suq'Ata Assassin",
             "text": "Suq'Ata Assassin cannot be blocked except by artifact or black creatures.\nIf Suq'Ata Assassin attacks and is not blocked, defending player gets a poison counter. If any player has ten or more poison counters, he or she loses the game.",
             "colours": [
@@ -2233,7 +2233,7 @@
         },
         {
             "id": "3968ea21-63f1-5a59-8b8b-39a93125bc9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1283190-094e-4a9f-bf67-f9fd05778744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1283190-094e-4a9f-bf67-f9fd05778744.jpg?1",
             "name": "Tar Pit Warrior",
             "text": "If Tar Pit Warrior is the target of a spell or effect, bury Tar Pit Warrior.",
             "colours": [
@@ -2267,7 +2267,7 @@
         },
         {
             "id": "aaa5ea10-44b3-5a6e-b6e3-611db3f113aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78405864-fc83-47ab-9238-8e0464a700ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78405864-fc83-47ab-9238-8e0464a700ec.jpg?1",
             "name": "Urborg Mindsucker",
             "text": "o\nB, Sacrifice Urborg Mindsucker: Target opponent discards a card at random. Play this ability as a sorcery.",
             "colours": [
@@ -2300,7 +2300,7 @@
         },
         {
             "id": "ae335858-71fd-5db2-9fa0-7cfee7b8c2b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a07cba3-2e8d-48ec-a6f8-4d2edfcd833d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a07cba3-2e8d-48ec-a6f8-4d2edfcd833d.jpg?1",
             "name": "Vampiric Tutor",
             "text": "Pay 2 life: Search your library for any one card. Shuffle your library, then put that card on top of your library.",
             "colours": [
@@ -2331,7 +2331,7 @@
         },
         {
             "id": "4572168f-22bf-5885-97bb-3994e6bb5162",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dff2817-1813-410f-aca7-96e8f9f4ce81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dff2817-1813-410f-aca7-96e8f9f4ce81.jpg?1",
             "name": "Vampirism",
             "text": "Draw a card at the beginning of the upkeep of the turn after Vampirism comes into play.\nEnchanted creature gets +1/+1 for each other creature you control. All other creatures you control get -1/-1.",
             "colours": [
@@ -2364,7 +2364,7 @@
         },
         {
             "id": "2775346b-ea42-5667-a281-9e444eb20a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52420b80-7f34-4426-ac97-a6e15167c7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52420b80-7f34-4426-ac97-a6e15167c7a9.jpg?1",
             "name": "Wake of Vultures",
             "text": "Flying\no1o\nB, Sacrifice a creature: Regenerate",
             "colours": [
@@ -2397,7 +2397,7 @@
         },
         {
             "id": "f908c457-bfe0-5d3c-b601-22a69cc92573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee32f8ba-3547-4913-a555-d43ee2978ba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee32f8ba-3547-4913-a555-d43ee2978ba9.jpg?1",
             "name": "Wicked Reward",
             "text": "Sacrifice a creature: Target creature gets +4/+2 until end of turn.",
             "colours": [
@@ -2428,7 +2428,7 @@
         },
         {
             "id": "ee36ff8c-616c-52bb-a6f8-82674c35ad9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253db28a-3873-4364-80d7-a8164000ea9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/253db28a-3873-4364-80d7-a8164000ea9e.jpg?1",
             "name": "Bogardan Phoenix",
             "text": "Flying\nIf Bogardan Phoenix is put into any graveyard from play and has no death counter on it, return Bogardan Phoenix to play and put a death counter on it.\nIf Bogardan Phoenix is put into any graveyard from play and has a death counter on it, remove it from the game.",
             "colours": [
@@ -2461,7 +2461,7 @@
         },
         {
             "id": "8afb52ff-7593-5c24-89f2-ecc0550cf328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d33bb-41bf-440d-939b-67ab5aacb092.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/077d33bb-41bf-440d-939b-67ab5aacb092.jpg?1",
             "name": "Dwarven Vigilantes",
             "text": "If Dwarven Vigilantes attacks and is not blocked, you may choose to have it deal no combat damage this turn. If you do, Dwarven Vigilantes deals an amount of damage equal to its power to target creature.",
             "colours": [
@@ -2494,7 +2494,7 @@
         },
         {
             "id": "54237c5c-0076-5c04-be7b-a89824301c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb625ba-3718-4988-962c-bf2e11eb4c16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcb625ba-3718-4988-962c-bf2e11eb4c16.jpg?1",
             "name": "Elkin Lair",
             "text": "During each player's upkeep, that player chooses a card at random from his or her hand and sets it aside face up. The player may play that card as though it were in his or her hand. If the player does not play the card by end of turn, bury that card.",
             "colours": [
@@ -2527,7 +2527,7 @@
         },
         {
             "id": "59e8e854-17ba-52cf-a307-649c9ace1c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eb5b2c-1f02-48a6-a287-88eb189d6780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1eb5b2c-1f02-48a6-a287-88eb189d6780.jpg?1",
             "name": "Fireblast",
             "text": "You may sacrifice two mountains instead of paying Fireblast's casting cost. Fireblast deals 4 damage to target creature or player.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "6cb2bcc2-c43e-51ce-87e3-52b7fb88833f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee791d5-1d48-40e8-b65f-b6aa889f3467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee791d5-1d48-40e8-b65f-b6aa889f3467.jpg?1",
             "name": "Goblin Recruiter",
             "text": "When Goblin Recruiter comes into play, search your library for any number of Goblin cards. Reveal those cards to all players. Shuffle your library, then put the cards on top of your library in any order.",
             "colours": [
@@ -2591,7 +2591,7 @@
         },
         {
             "id": "3d008cad-0c68-5f2b-b137-e4ae06edd593",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49980982-d534-4204-bc15-3e6c4ffa1a53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49980982-d534-4204-bc15-3e6c4ffa1a53.jpg?1",
             "name": "Goblin Swine-Rider",
             "text": "If Goblin Swine-Rider is blocked, it deals 2 damage to each attacking creature and 2 damage to each blocking creature.",
             "colours": [
@@ -2624,7 +2624,7 @@
         },
         {
             "id": "a42820b3-6398-5f87-8bcb-2bbb38dcdde1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa9ac66-51b7-4aec-92dc-0f0656b0f7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/caa9ac66-51b7-4aec-92dc-0f0656b0f7fe.jpg?1",
             "name": "Hearth Charm",
             "text": "Choose one Destroy target artifact creature; or all attacking creatures get +1/+0 until end of turn; or target creature with power 2 or less is unblockable this turn.",
             "colours": [
@@ -2655,7 +2655,7 @@
         },
         {
             "id": "e3508fc4-a266-5449-bb05-26b2969efcac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dd0810-4528-4a88-add8-923bb2057821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42dd0810-4528-4a88-add8-923bb2057821.jpg?1",
             "name": "Heat Wave",
             "text": "Cumulative upkeep o\nR\nBlue creatures cannot block creatures you control. Nonblue creatures cannot block creatures you control unless their controller pays an additional 1 life for each blocking creature.",
             "colours": [
@@ -2686,7 +2686,7 @@
         },
         {
             "id": "022f81be-fa1f-5095-ad74-7196f1fde644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ee5ea8-7023-4dde-ab51-d3ba234d74b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ee5ea8-7023-4dde-ab51-d3ba234d74b9.jpg?1",
             "name": "Hulking Cyclops",
             "text": "Hulking Cyclops cannot block.",
             "colours": [
@@ -2719,7 +2719,7 @@
         },
         {
             "id": "09fcf745-f682-5a9e-a177-11d03875365d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11b6df4-449f-44ea-a4fa-f079bcd26a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11b6df4-449f-44ea-a4fa-f079bcd26a54.jpg?1",
             "name": "Keeper of Kookus",
             "text": "oo\nR Protection from red until end of turn.",
             "colours": [
@@ -2752,7 +2752,7 @@
         },
         {
             "id": "b7e0b2c8-309c-502b-8a08-2e17527752b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb90922-99d2-4b36-9039-bb806fd01756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb90922-99d2-4b36-9039-bb806fd01756.jpg?1",
             "name": "Kookus",
             "text": "Trample\nDuring your upkeep, if you do not control at least one Keeper of Kookus, Kookus deals 3 damage to you and attacks this turn if able.\noo\nR +1/+0 until end of turn.",
             "colours": [
@@ -2785,7 +2785,7 @@
         },
         {
             "id": "182adfa1-d909-5750-bb75-c00e328c8438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfc2ad-a1a4-4f65-a239-f11383aaafe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fcfc2ad-a1a4-4f65-a239-f11383aaafe1.jpg?1",
             "name": "Lightning Cloud",
             "text": "oo\nR Lightning Cloud deals 1 damage to target creature or player. Use this ability only when a red spell is successfully cast and only once for each such spell.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "b10d8d8b-24a1-5b21-aeaa-487f3dcf0a80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e428d56a-9445-4e86-b281-656e2d251e0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e428d56a-9445-4e86-b281-656e2d251e0b.jpg?1",
             "name": "Mob Mentality",
             "text": "Enchanted creature gains trample.\nIf all non-Wall creatures you control attack, enchanted creature gets +*/+0 until end of turn, where * is equal to the number of attacking creatures.",
             "colours": [
@@ -2849,7 +2849,7 @@
         },
         {
             "id": "85f79ee7-8094-5dcc-90bb-e70d44b849fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f072d6-7489-4eb0-8c53-1fa42ad806a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0f072d6-7489-4eb0-8c53-1fa42ad806a4.jpg?1",
             "name": "Ogre Enforcer",
             "text": "Ogre Enforcer cannot be destroyed by lethal damage unless a single source deals enough damage to destroy it.",
             "colours": [
@@ -2882,7 +2882,7 @@
         },
         {
             "id": "8c559f70-e997-5e1a-8e41-b7b2a885c981",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c284ce-33b8-4fb2-9dd9-4c477bedc774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c284ce-33b8-4fb2-9dd9-4c477bedc774.jpg?1",
             "name": "Raging Gorilla",
             "text": "If Raging Gorilla blocks or is blocked, it gets +2/-2 until end of turn.",
             "colours": [
@@ -2915,7 +2915,7 @@
         },
         {
             "id": "a5e93a13-9051-5123-bc1f-fd49047d6cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747161ea-cb65-4960-84dd-a05bfe5f3ba0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747161ea-cb65-4960-84dd-a05bfe5f3ba0.jpg?1",
             "name": "Relentless Assault",
             "text": "Untap all creatures that attacked this turn. You may declare an additional attack during your main phase this turn.",
             "colours": [
@@ -2946,7 +2946,7 @@
         },
         {
             "id": "f46e9488-71e8-5d67-b200-79845274c209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e01717a-d6ed-42c1-9a9a-f3f4a3d73bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e01717a-d6ed-42c1-9a9a-f3f4a3d73bca.jpg?1",
             "name": "Rock Slide",
             "text": "Rock Slide deals X damage, divided any way you choose, among any number of target attacking or blocking creatures without flying.",
             "colours": [
@@ -2977,7 +2977,7 @@
         },
         {
             "id": "16163a60-493f-5b3f-8a96-57380f026659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d4bd6f-b019-4594-aa41-138fa58ba529.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5d4bd6f-b019-4594-aa41-138fa58ba529.jpg?1",
             "name": "Solfatara",
             "text": "Target player cannot play any land cards this turn. Draw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3008,7 +3008,7 @@
         },
         {
             "id": "c8c40958-e0fe-53bf-8384-819c7ef58408",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4497a1d7-6604-4f2d-9484-1f1d77a6228f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4497a1d7-6604-4f2d-9484-1f1d77a6228f.jpg?1",
             "name": "Song of Blood",
             "text": "Put the top four cards from your library into your graveyard. For each creature card put into your graveyard in this way, all creatures that attack this turn get +1/+0 until end of turn.",
             "colours": [
@@ -3039,7 +3039,7 @@
         },
         {
             "id": "81e18cc2-0eec-568f-8c66-b1b9a1bb2b09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6ef97-587f-4f7b-98a2-e3cc8b39df8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6ef97-587f-4f7b-98a2-e3cc8b39df8b.jpg?1",
             "name": "Spitting Drake",
             "text": "Flying\noo\nR +1/+0 until end of turn. You cannot spend more than o\nR in this way each turn.",
             "colours": [
@@ -3072,7 +3072,7 @@
         },
         {
             "id": "0fe48ca4-3828-56bb-8b55-8e4a03db8346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2884d8df-7fd5-4247-9da5-38c31333ff5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2884d8df-7fd5-4247-9da5-38c31333ff5d.jpg?1",
             "name": "Suq'Ata Lancer",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)\nSuq'Ata Lancer is unaffected by summoning sickness.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "e753a88f-9b93-5389-ac04-ad3f54d49e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33730a07-754c-4606-bfac-d73454af9567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33730a07-754c-4606-bfac-d73454af9567.jpg?1",
             "name": "Talruum Champion",
             "text": "First strike\nWhenever Talruum Champion blocks or is blocked by any creature, that creature loses first strike until end of turn.",
             "colours": [
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "709dead3-b2c1-59b0-8e04-45c065565b0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2cb9a7-5063-4b31-9782-8bfd784bca0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca2cb9a7-5063-4b31-9782-8bfd784bca0a.jpg?1",
             "name": "Talruum Piper",
             "text": "All creatures with flying able to block Talruum Piper do so.",
             "colours": [
@@ -3172,7 +3172,7 @@
         },
         {
             "id": "47a247e4-f90a-52a3-b9e5-8de35eae814a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d64665-c1e0-40ab-a358-247f82966379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d64665-c1e0-40ab-a358-247f82966379.jpg?1",
             "name": "Tremor",
             "text": "Tremor deals 1 damage to each creature without flying.",
             "colours": [
@@ -3203,7 +3203,7 @@
         },
         {
             "id": "9057619b-ada3-5983-8973-644ea7b37239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01770e13-ebd4-4c83-9e72-99374239a63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01770e13-ebd4-4c83-9e72-99374239a63d.jpg?1",
             "name": "Viashino Sandstalker",
             "text": "Viashino Sandstalker is unaffected by summoning sickness.\nAt the end of any turn, return Viashino Sandstalker to owner's hand.",
             "colours": [
@@ -3237,7 +3237,7 @@
         },
         {
             "id": "31a36f4c-a39c-541e-a116-9e925403c6f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7f5f41-ed30-412b-b51e-37d26e9e6455.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7f5f41-ed30-412b-b51e-37d26e9e6455.jpg?1",
             "name": "Bull Elephant",
             "text": "When Bull Elephant comes into play, return two forests you control to owner's hand or bury Bull Elephant.",
             "colours": [
@@ -3270,7 +3270,7 @@
         },
         {
             "id": "7cf19545-be13-5449-ae80-f2265fd5c80f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be499b81-bb2d-4f1d-9deb-c8bfcdca8e13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be499b81-bb2d-4f1d-9deb-c8bfcdca8e13.jpg?1",
             "name": "City of Solitude",
             "text": "Each player may play spells and abilities only during his or her turn.",
             "colours": [
@@ -3301,7 +3301,7 @@
         },
         {
             "id": "a2ceb8bd-95db-5b09-99b2-308e856b42fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e7691f-c771-4451-ac54-3532ca10d48f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e7691f-c771-4451-ac54-3532ca10d48f.jpg?1",
             "name": "Creeping Mold",
             "text": "Destroy target artifact, land, or enchantment.",
             "colours": [
@@ -3332,7 +3332,7 @@
         },
         {
             "id": "6210d1fb-6297-57d0-9b9f-f4135f2ee93a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c1f5a7-0d28-43ab-9b66-937e963f42cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c1f5a7-0d28-43ab-9b66-937e963f42cd.jpg?1",
             "name": "Elephant Grass",
             "text": "Cumulative upkeep o1\nBlack creatures cannot attack you. Nonblack creatures cannot attack you unless their controller pays an additional o2 for each attacking creature.",
             "colours": [
@@ -3363,7 +3363,7 @@
         },
         {
             "id": "f1334e4a-3c78-552b-bfe9-b71499983976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fa078f-c74a-42b2-af97-7ca2c29dc316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80fa078f-c74a-42b2-af97-7ca2c29dc316.jpg?1",
             "name": "Elven Cache",
             "text": "Return target card from your graveyard to your hand.",
             "colours": [
@@ -3394,7 +3394,7 @@
         },
         {
             "id": "3eab4e06-2f0d-5d69-84f5-f976976f7751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c9199b-61b3-4794-878b-f065058f50f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9c9199b-61b3-4794-878b-f065058f50f3.jpg?1",
             "name": "Emerald Charm",
             "text": "Choose one Untap target permanent; or destroy target global enchantment; or target creature loses flying until end of turn.",
             "colours": [
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "66b26b5b-81f2-5466-aa05-b616b1285c00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dec7cf-2865-4642-9022-d3006fd7ac30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20dec7cf-2865-4642-9022-d3006fd7ac30.jpg?1",
             "name": "Feral Instinct",
             "text": "Target creature gets +1/+1 until end of turn.\nDraw a card at the beginning of the next turn's upkeep.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "5be8b1dc-0246-51f9-8ef0-5f31e671104a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f602a6-3d35-49a3-b5cb-d754e03a9573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7f602a6-3d35-49a3-b5cb-d754e03a9573.jpg?1",
             "name": "Giant Caterpillar",
             "text": "o\nG, Sacrifice Giant Caterpillar: Put a Butterfly token into play at end of turn. Treat this token as a 1/1 green creature with flying.",
             "colours": [
@@ -3489,7 +3489,7 @@
         },
         {
             "id": "291b09fa-bf95-526f-b813-b6c8e5206894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b34ce8-1eb2-44eb-813a-09d0308e27a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97b34ce8-1eb2-44eb-813a-09d0308e27a0.jpg?1",
             "name": "Katabatic Winds",
             "text": "Phasing\nCreatures with flying cannot attack, block, or use any ability that includes oc\nT in the activation cost.",
             "colours": [
@@ -3520,7 +3520,7 @@
         },
         {
             "id": "239aa1bc-8a76-52ac-9f86-07e4d7b2b2dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38149d49-8661-427c-9338-93c11a2a8093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38149d49-8661-427c-9338-93c11a2a8093.jpg?1",
             "name": "King Cheetah",
             "text": "You may choose to play King Cheetah whenever you could play an instant.",
             "colours": [
@@ -3553,7 +3553,7 @@
         },
         {
             "id": "81314d38-9a73-5b00-a79e-4aadeee5b4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f14bbe-2436-4a5a-8e2a-8066b740b715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f14bbe-2436-4a5a-8e2a-8066b740b715.jpg?1",
             "name": "Kyscu Drake",
             "text": "Flying\noo\nG +0/+1 until end of turn. You cannot spend more than o\nG in this way each turn.\nSacrifice Kyscu Drake and Spitting Drake: Search your library for Viashivan Dragon and put it into play. Shuffle your library afterwards.",
             "colours": [
@@ -3586,7 +3586,7 @@
         },
         {
             "id": "83dc9f95-60d6-523a-9c2b-1ea8acda6853",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0c356-a81d-41d4-a8b7-8c159146a8b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f0c356-a81d-41d4-a8b7-8c159146a8b8.jpg?1",
             "name": "Lichenthrope",
             "text": "For each 1 damage dealt to Lichenthrope, put a -1/-1 counter on it instead.\nDuring your upkeep, remove one of these -1/-1 counters from Lichenthrope.",
             "colours": [
@@ -3620,7 +3620,7 @@
         },
         {
             "id": "4b598341-8cca-5462-8548-0d6bb596c626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808830ff-496a-41dc-8b64-334ddaca9435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/808830ff-496a-41dc-8b64-334ddaca9435.jpg?1",
             "name": "Mortal Wound",
             "text": "If damage is dealt to enchanted creature, destroy it.",
             "colours": [
@@ -3653,7 +3653,7 @@
         },
         {
             "id": "d776abc3-5ae4-5e0e-b863-2479cabd9f1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0845f0b0-9413-4ddd-861d-9607636bebc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0845f0b0-9413-4ddd-861d-9607636bebc6.jpg?1",
             "name": "Natural Order",
             "text": "Sacrifice a green creature: Search your library for a green creature card and put it into play as though it were just played. Shuffle your library afterwards.",
             "colours": [
@@ -3684,7 +3684,7 @@
         },
         {
             "id": "c2956731-a9c0-5c9e-a9c5-b67a7d93e865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c9bc99-28e3-4d64-8383-2b92011104ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76c9bc99-28e3-4d64-8383-2b92011104ed.jpg?1",
             "name": "Panther Warriors",
             "text": "",
             "colours": [
@@ -3718,7 +3718,7 @@
         },
         {
             "id": "535e217b-2408-5e44-b991-7a0e6850b6bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca5319a-5c26-487f-ba87-d317633122ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ca5319a-5c26-487f-ba87-d317633122ba.jpg?1",
             "name": "Quirion Druid",
             "text": "o\nG, oc\nT: Target land becomes a 2/2 green creature permanently. That land still counts as a land.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "9b771df0-92de-5869-bbaf-7ef3f59366b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56efe72c-6d7f-44f6-ac74-01af9305c4b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56efe72c-6d7f-44f6-ac74-01af9305c4b6.jpg?1",
             "name": "Quirion Ranger",
             "text": "Return a forest you control to owner's hand: Untap target creature. Use this ability only once each turn.",
             "colours": [
@@ -3786,7 +3786,7 @@
         },
         {
             "id": "93e9c02c-5735-5a73-8dd6-34edd95ee424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9d5aaf-b7e8-4676-aec8-7d29a0169a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e9d5aaf-b7e8-4676-aec8-7d29a0169a2c.jpg?1",
             "name": "River Boa",
             "text": "Islandwalk (If defending player controls an island, this creature is unblockable.)\noo\nG Regenerate",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "d6659200-4fb7-5515-b2f2-494fd9f38dc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07144d84-f7f3-4101-805d-07cce8342a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07144d84-f7f3-4101-805d-07cce8342a64.jpg?1",
             "name": "Rowen",
             "text": "During your draw phase, reveal the first card you draw to all players. If that card is a basic land, draw a card.",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "c45bc8ff-d347-5b8f-bbf5-259d1634b8f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1818812-4cb8-4fe1-98c0-b40086b4991c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1818812-4cb8-4fe1-98c0-b40086b4991c.jpg?1",
             "name": "Spider Climb",
             "text": "You may choose to play Spider Climb as an instant; if you do, bury it at end of turn.\nEnchanted creature gets +0/+3 and can block creatures with flying.",
             "colours": [
@@ -3883,7 +3883,7 @@
         },
         {
             "id": "a867e33f-ad96-540e-aeb6-2473ae075ef2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb5f524-fad6-4a63-b20f-3348a844fefa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddb5f524-fad6-4a63-b20f-3348a844fefa.jpg?1",
             "name": "Stampeding Wildebeests",
             "text": "Trample\nDuring your upkeep, return a green creature you control to owner's hand.",
             "colours": [
@@ -3917,7 +3917,7 @@
         },
         {
             "id": "a9704fe2-d06b-534a-ba68-becddf99bd34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d78f4e-d95d-49bc-9971-06a68a4e35fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35d78f4e-d95d-49bc-9971-06a68a4e35fd.jpg?1",
             "name": "Summer Bloom",
             "text": "You may play up to three additional lands this turn.",
             "colours": [
@@ -3948,7 +3948,7 @@
         },
         {
             "id": "04eec290-7289-563e-a320-a697121e0c3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c7d58-43cc-4ebd-87f1-2016fbff56dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/101c7d58-43cc-4ebd-87f1-2016fbff56dd.jpg?1",
             "name": "Uktabi Orangutan",
             "text": "When Uktabi Orangutan comes into play, destroy target artifact.",
             "colours": [
@@ -3981,7 +3981,7 @@
         },
         {
             "id": "45bf83d9-9a8a-5c14-8df9-081eceb9490e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2510b8-52d6-4d2e-89a5-31b27b732dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2510b8-52d6-4d2e-89a5-31b27b732dd8.jpg?1",
             "name": "Warthog",
             "text": "Swampwalk (If defending player controls any swamps, this creature is unblockable.)",
             "colours": [
@@ -4014,7 +4014,7 @@
         },
         {
             "id": "00bd1866-4cad-590c-a545-9d63d79763d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8324f44-c7f5-41ee-bc8d-16822bd8942f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8324f44-c7f5-41ee-bc8d-16822bd8942f.jpg?1",
             "name": "Wind Shear",
             "text": "All attacking creatures with flying get -2/-2 and lose flying until end of turn.",
             "colours": [
@@ -4045,7 +4045,7 @@
         },
         {
             "id": "89ce82ca-9f26-5471-a1a3-555aa12b791b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e129be5-e2c5-4f69-b8e8-539ac2085c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e129be5-e2c5-4f69-b8e8-539ac2085c7a.jpg?1",
             "name": "Army Ants",
             "text": "oc\nT, Sacrifice a land: Destroy target land.",
             "colours": [
@@ -4080,7 +4080,7 @@
         },
         {
             "id": "f280d496-70fe-5cbc-959b-bbf9851012a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87ace53-d77c-4df5-b200-4be2ac2b7fdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f87ace53-d77c-4df5-b200-4be2ac2b7fdb.jpg?1",
             "name": "Breathstealer's Crypt",
             "text": "Whenever any player draws a card, he or she reveals that card. If the card is a creature card, that player pays 3 life or discards the card.",
             "colours": [
@@ -4113,7 +4113,7 @@
         },
         {
             "id": "a08cb2c2-e4ce-5fd1-a6f1-03c4a53cd584",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176122b2-f60f-4150-8c0c-757c8f8914d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176122b2-f60f-4150-8c0c-757c8f8914d2.jpg?1",
             "name": "Corrosion",
             "text": "Cumulative upkeep o1\nDuring your upkeep, put a rust counter on each artifact target opponent controls. If the number of rust counters on an artifact equals or exceeds that artifact's casting cost, bury the artifact.\nIf Corrosion leaves play, remove all rust counters from the game.",
             "colours": [
@@ -4146,7 +4146,7 @@
         },
         {
             "id": "d9b51885-a54d-59ed-b84a-835c96c035f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ba72c7-7957-4d02-b41e-c0132fe1f2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ba72c7-7957-4d02-b41e-c0132fe1f2e6.jpg?1",
             "name": "Femeref Enchantress",
             "text": "Whenever an enchantment is put into any graveyard from play, draw a card.",
             "colours": [
@@ -4182,7 +4182,7 @@
         },
         {
             "id": "87a7a841-d8b1-54c7-b705-bf7fb131b638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def23574-4a41-4323-84d9-49f58b2ca322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def23574-4a41-4323-84d9-49f58b2ca322.jpg?1",
             "name": "Firestorm Hellkite",
             "text": "Flying, trample\nCumulative upkeep o\nUo\nR",
             "colours": [
@@ -4217,7 +4217,7 @@
         },
         {
             "id": "a1d23d44-e9ee-576f-88f8-e15b558346b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96d184-0ef8-40f7-98bc-bd4c53c57072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96d184-0ef8-40f7-98bc-bd4c53c57072.jpg?1",
             "name": "Guiding Spirit",
             "text": "Flying\noc\nT: If the top card of target player's graveyard is a creature card, put that card on the top of that player's library.",
             "colours": [
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "52169eee-7ff8-590c-9ad1-9a0279d5fac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e320ca-848b-4743-93f1-ec04ef1ce402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e320ca-848b-4743-93f1-ec04ef1ce402.jpg?1",
             "name": "Mundungu",
             "text": "oc\nT: Counter target spell unless that spell's caster pays an additional o1 and 1 life. Play this ability as an interrupt.",
             "colours": [
@@ -4289,7 +4289,7 @@
         },
         {
             "id": "b68fb713-b09e-518b-bbd1-84fb700219a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f6220-6ead-46b4-8663-57609ef5a12e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e3f6220-6ead-46b4-8663-57609ef5a12e.jpg?1",
             "name": "Pygmy Hippo",
             "text": "If Pygmy Hippo attacks and is not blocked, you may choose to have it deal no combat damage this turn. If you do, defending player draws all mana from his or her lands and then his or her mana pool is emptied. After combat, add an equal amount of colorless mana to your mana pool.",
             "colours": [
@@ -4324,7 +4324,7 @@
         },
         {
             "id": "1a008e97-4fe2-5d5d-b696-5e2c190c644a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcacb8e-1aff-4807-b70c-a17d6703d279.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbcacb8e-1aff-4807-b70c-a17d6703d279.jpg?1",
             "name": "Righteous War",
             "text": "All white creatures you control gain protection from black.\nAll black creatures you control gain protection from white.",
             "colours": [
@@ -4357,7 +4357,7 @@
         },
         {
             "id": "08c2dd2e-ee9c-5e9b-9214-e551b9e1569f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3bff610-783a-46b7-bd15-061da41027bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3bff610-783a-46b7-bd15-061da41027bb.jpg?1",
             "name": "Scalebane's Elite",
             "text": "Protection from black",
             "colours": [
@@ -4393,7 +4393,7 @@
         },
         {
             "id": "28f34393-8b2b-5724-998a-bc3712c7fdac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9239-82e0-4696-ad99-10796042d1f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d9239-82e0-4696-ad99-10796042d1f8.jpg?1",
             "name": "Simoon",
             "text": "Simoon deals 1 damage to each creature target opponent controls.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "fb296a80-7f79-5338-8871-71f5f31064d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcddbea7-3025-47b1-a597-2d2b2711fb81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcddbea7-3025-47b1-a597-2d2b2711fb81.jpg?1",
             "name": "Squandered Resources",
             "text": "Sacrifice a land: Add to your mana pool one mana of any type the sacrificed land could produce. Play this ability as a mana source.",
             "colours": [
@@ -4459,7 +4459,7 @@
         },
         {
             "id": "e83fb428-dee4-5557-920f-a01dc147dbd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a15e970-e605-425a-b4ec-391d9cacde38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a15e970-e605-425a-b4ec-391d9cacde38.jpg?1",
             "name": "Suleiman's Legacy",
             "text": "When Suleiman's Legacy comes into play, bury all Djinns and Efreets.\nWhenever a Djinn or Efreet comes into play, bury it.",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "02760c06-1979-502a-ae7d-1c8417c5d351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa5262-d0d9-4b4a-8027-00393568b3df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54aa5262-d0d9-4b4a-8027-00393568b3df.jpg?1",
             "name": "Tempest Drake",
             "text": "Flying\nAttacking does not cause Tempest Drake to tap.",
             "colours": [
@@ -4527,7 +4527,7 @@
         },
         {
             "id": "d51d0a4f-b525-5ed8-b086-fea3435614ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172ef0b-ca9e-47cf-8ec6-2d8cb18f2283.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7172ef0b-ca9e-47cf-8ec6-2d8cb18f2283.jpg?1",
             "name": "Viashivan Dragon",
             "text": "Flying\noo\nR +1/+0 until end of turn\noo\nG +0/+1 until end of turn",
             "colours": [
@@ -4562,7 +4562,7 @@
         },
         {
             "id": "d818d5cf-5ecc-503c-a447-afcbffd5c2ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff965dd-54b4-4f21-a52f-81c0dd1e691e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff965dd-54b4-4f21-a52f-81c0dd1e691e.jpg?1",
             "name": "Anvil of Bogardan",
             "text": "Each player skips his or her discard phase.\nDuring each player's draw phase, that player draws an additional card and then chooses and discards a card.",
             "colours": [],
@@ -4589,7 +4589,7 @@
         },
         {
             "id": "7f6db842-a120-5d6c-ac5c-5720e25a8342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c9655-e51c-4b63-96cf-7f3fba3ec75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/200c9655-e51c-4b63-96cf-7f3fba3ec75c.jpg?1",
             "name": "Brass-Talon Chimera",
             "text": "First strike\nBrass-Talon Chimera counts as a Chimera.\nSacrifice Brass-Talon Chimera: Put a +2/+2 counter on target Chimera and that Chimera gains first strike permanently.",
             "colours": [],
@@ -4619,7 +4619,7 @@
         },
         {
             "id": "fdbf6686-ea5d-54f6-90a9-aab45136a34b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548ff852-274d-4068-818d-58a883e74a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548ff852-274d-4068-818d-58a883e74a5f.jpg?1",
             "name": "Diamond Kaleidoscope",
             "text": "o3, oc\nT: Put a Prism token into play. Treat this token as a 0/1 artifact creature.\nSacrifice a Prism token: Add one mana of any color to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4646,7 +4646,7 @@
         },
         {
             "id": "8e0cde13-8752-5dd2-82f7-263f3c7cb8c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098e329-adc8-42dd-b779-d00d9ccc3dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f098e329-adc8-42dd-b779-d00d9ccc3dbd.jpg?1",
             "name": "Dragon Mask",
             "text": "o3, oc\nT: Target creature you control gets +2/+2 until end of turn. At end of turn, if that creature is in play, return it to owner's hand.",
             "colours": [],
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "123276f7-e53d-52df-9e94-6e403387d388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bba882-39b8-42db-9a01-54c6712b8019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41bba882-39b8-42db-9a01-54c6712b8019.jpg?1",
             "name": "Helm of Awakening",
             "text": "All spells cost one generic mana less to play.",
             "colours": [],
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "7e2f05bc-d6c7-5a11-a4c9-0460f83064f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5899a575-a97d-4850-b55c-22ad6900ba20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5899a575-a97d-4850-b55c-22ad6900ba20.jpg?1",
             "name": "Iron-Heart Chimera",
             "text": "Attacking does not cause Iron-Heart Chimera to tap.\nIron-Heart Chimera counts as a Chimera.\nSacrifice Iron-Heart Chimera: Put a +2/+2 counter on target Chimera and attacking any turn does not cause that Chimera to tap.",
             "colours": [],
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "deced70d-88f5-57c3-9261-3bbcb1db2338",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5fa8208-7d65-4f8f-b07e-f5c3a66e1143.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5fa8208-7d65-4f8f-b07e-f5c3a66e1143.jpg?1",
             "name": "Juju Bubble",
             "text": "Cumulative upkeep o1\nIf you play a card, bury Juju Bubble.\no2: Gain 1 life.",
             "colours": [],
@@ -4757,7 +4757,7 @@
         },
         {
             "id": "41f736ce-b9dc-5b77-a90d-0dbbd474f010",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89b377-80d2-42a0-b84e-a455a72ed9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d89b377-80d2-42a0-b84e-a455a72ed9fe.jpg?1",
             "name": "Lead-Belly Chimera",
             "text": "Trample\nLead-Belly Chimera counts as a Chimera.\nSacrifice Lead-Belly Chimera: Put a +2/+2 counter on target Chimera and that Chimera gains trample permanently.",
             "colours": [],
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "7bc72aab-9a88-541f-aebc-122fd96796db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aecc3df-7ce6-419c-b3d6-60fc28bfe941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aecc3df-7ce6-419c-b3d6-60fc28bfe941.jpg?1",
             "name": "Magma Mine",
             "text": "o4: Put a pressure counter on Magma Mine.\noc\nT, Sacrifice Magam Mine: For each pressure counter on it, Magma Mine deals 1 damage to target creature or player.",
             "colours": [],
@@ -4814,7 +4814,7 @@
         },
         {
             "id": "0e965f8f-5614-5c15-92f6-272fa1743ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92378d6f-89ee-49dc-8964-0e9c55daeffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92378d6f-89ee-49dc-8964-0e9c55daeffc.jpg?1",
             "name": "Matopi Golem",
             "text": "o1: Regenerate and put a -1/-1 counter on Matopi Golem.",
             "colours": [],
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "aa043981-5fef-5f14-82ad-1c30aab44123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a75dc8-1c24-4063-8944-d7e71b4a5755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a75dc8-1c24-4063-8944-d7e71b4a5755.jpg?1",
             "name": "Phyrexian Marauder",
             "text": "Phryexian Marauder comes into play with X +1/+1 counters on it.\nPhyrexian Marauder cannot block.\nPhyrexian Marauder cannot attack unless you pay o1 for each +1/+1 counter on it.",
             "colours": [],
@@ -4875,7 +4875,7 @@
         },
         {
             "id": "e9d5ac33-9f8a-5f91-8791-2fd4c9c5a397",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a3979-2947-4692-8b2f-d4c07c534777.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f8a3979-2947-4692-8b2f-d4c07c534777.jpg?1",
             "name": "Phyrexian Walker",
             "text": "",
             "colours": [],
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "8204bfb2-1f7a-5c43-8722-b118333f68c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782ee95-bde4-41f4-a947-b073cc4c1e7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a782ee95-bde4-41f4-a947-b073cc4c1e7c.jpg?1",
             "name": "Sands of Time",
             "text": "Each player skips his or her untap phase.\nAt the beginning of each player's turn, untap each tapped artifact, creature, and land he or she controls and tap each untapped artifact, creature, and land he or she controls.",
             "colours": [],
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "8533cee9-8658-5dd4-a014-bd14476585b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08becd3-ca5e-4150-8d28-52436a3eaffd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08becd3-ca5e-4150-8d28-52436a3eaffd.jpg?1",
             "name": "Sisay's Ring",
             "text": "oc\nT: Add two colorless mana to your mana pool. Play this ability as a mana source.",
             "colours": [],
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "7cbfbf98-b945-5a4c-8996-0c47a740c6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfda9a16-9cdb-494a-b662-ac24e3b89d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bfda9a16-9cdb-494a-b662-ac24e3b89d0c.jpg?1",
             "name": "Snake Basket",
             "text": "o\nX, Sacrifice Snake Basket: Put X Cobra tokens into play. Treat these tokens as 1/1 green creatures. Play this ability as a sorcery.",
             "colours": [],
@@ -4987,7 +4987,7 @@
         },
         {
             "id": "3f380b0e-5b5d-58fc-95ac-6b9fc7738758",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1377dab4-b814-46cc-a097-24a3cf8d0f8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/1377dab4-b814-46cc-a097-24a3cf8d0f8f.jpg?1",
             "name": "Teferi's Puzzle Box",
             "text": "During each player's draw phase, that player counts the cards in his or her hand, puts those cards on the bottom of his or her library, and then draws that number of cards.",
             "colours": [],
@@ -5014,7 +5014,7 @@
         },
         {
             "id": "c76fc460-be81-516a-b995-ef6b73432ffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3375dcc6-9399-48eb-9aa4-7b40c3686cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3375dcc6-9399-48eb-9aa4-7b40c3686cc5.jpg?1",
             "name": "Tin-Wing Chimera",
             "text": "Flying\nTin-Wing Chimera counts as a Chimera.\nSacrifice Tin-Wing Chimera: Put a +2/+2 counter on target Chimera and that Chimera gains flying permanently.",
             "colours": [],
@@ -5044,7 +5044,7 @@
         },
         {
             "id": "84d78730-ff1f-58fe-983a-b39d508e99f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1d7d4d-bed7-4d28-a304-ad33f42e9831.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c1d7d4d-bed7-4d28-a304-ad33f42e9831.jpg?1",
             "name": "Triangle of War",
             "text": "o2, Sacrifice Triangle of War: Choose target creature you control and target creature an opponent controls. Each creature deals an amount of damage equal to its power to the other.",
             "colours": [],
@@ -5071,7 +5071,7 @@
         },
         {
             "id": "eec8acf4-dffe-5f62-872e-845ba4476f75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1c856f-6d29-4bfc-976e-7875d60abd52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b1c856f-6d29-4bfc-976e-7875d60abd52.jpg?1",
             "name": "Wand of Denial",
             "text": "oc\nT: Look at the top card of target player's library. If that card is a nonland card, you may pay 2 life to put it into that player's graveyard.",
             "colours": [],
@@ -5098,7 +5098,7 @@
         },
         {
             "id": "a34be966-4999-587f-a2d1-eebca467e9ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7c4619-e5af-4aa0-bd3f-6bf0e1fdc1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d7c4619-e5af-4aa0-bd3f-6bf0e1fdc1fc.jpg?1",
             "name": "Coral Atoll",
             "text": "Coral Atoll comes into play tapped.\nWhen Coral Atoll comes into play, return an untapped island you control to owner's hand or bury Coral Atoll.\noc\nT: Add o\nU and one colorless mana to your mana pool.",
             "colours": [],
@@ -5127,7 +5127,7 @@
         },
         {
             "id": "747ba60f-83e5-52de-a40b-8171c7990307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa92be7-883f-42bd-8623-00eb2df28a98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aa92be7-883f-42bd-8623-00eb2df28a98.jpg?1",
             "name": "Dormant Volcano",
             "text": "Dormant Volcano comes into play tapped.\nWhen Dormant Volcano comes into play, return an untapped mountain you control to owner's hand or bury Dormant Volcano.\noc\nT: Add o\nR and one colorless mana to your mana pool.",
             "colours": [],
@@ -5156,7 +5156,7 @@
         },
         {
             "id": "5ea90fc5-d383-500c-85c1-82598ba7af8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f2eaf7-7f08-446b-892f-5a844f74808f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f2eaf7-7f08-446b-892f-5a844f74808f.jpg?1",
             "name": "Everglades",
             "text": "Everglades comes into play tapped.\nWhen Everglades comes into play, return an untapped swamp you control to owner's hand or bury Everglades.\noc\nT: Add o\nB and one colorless mana to your mana pool.",
             "colours": [],
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "64ffafa8-43ad-5253-9917-777c096741ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705d8194-3ad0-41b7-ae32-9c0cd8cd46b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/705d8194-3ad0-41b7-ae32-9c0cd8cd46b9.jpg?1",
             "name": "Griffin Canyon",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT: Untap target Griffin. That Griffin gets +1/+1 until end of turn.",
             "colours": [],
@@ -5212,7 +5212,7 @@
         },
         {
             "id": "dafe0924-2c94-5608-872a-5fca5463aab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3146db-2f86-4728-9af1-ff651f871652.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3146db-2f86-4728-9af1-ff651f871652.jpg?1",
             "name": "Jungle Basin",
             "text": "Jungle Basin comes into play tapped.\nWhen Jungle Basin comes into play, return an untapped forest you control to owner's hand or bury Jungle Basin.\noc\nT: Add o\nG and one colorless mana to your mana pool.",
             "colours": [],
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "f1bc5bdc-e4e1-570f-8b06-ba26be43e144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786815c-53ec-483e-ad56-382778a57b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d786815c-53ec-483e-ad56-382778a57b1a.jpg?1",
             "name": "Karoo",
             "text": "Karoo comes into play tapped.\nWhen Karoo comes into play, return an untapped plains you control to owner's hand or bury Karoo.\noc\nT: Add o\nW and one colorless mana to your mana pool.",
             "colours": [],
@@ -5270,7 +5270,7 @@
         },
         {
             "id": "9ea5b7eb-b25d-59b2-93ed-0ecfb78f8ac4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11370658-8d80-4d2f-afa5-ec6df6dee369.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11370658-8d80-4d2f-afa5-ec6df6dee369.jpg?1",
             "name": "Quicksand",
             "text": "oc\nT: Add one colorless mana to your mana pool.\noc\nT, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "9460969e-62f1-528e-b9ef-2d9aa7b2cc06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e8830-5e62-4945-8b73-60f0628d38e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f6e8830-5e62-4945-8b73-60f0628d38e7.jpg?1",
             "name": "Undiscovered Paradise",
             "text": "oc\nT: Add one mana of any color to your mana pool. At the beginning of your next untap phase, return Undiscovered Paradise to owner's hand.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/VOW.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/VOW.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "14bf8abf-b718-5cc7-8b5d-847f9ee85eb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd091f3e-5fcc-4d12-b0c3-3b6340ab01d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd091f3e-5fcc-4d12-b0c3-3b6340ab01d8.jpg?1",
             "name": "Adamant Will",
             "text": "Target creature gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "a5c04d16-e1c3-5913-a33e-01f4b3f468f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d81b88-c19b-4148-89ba-ae8fb53843e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41d81b88-c19b-4148-89ba-ae8fb53843e1.jpg?1",
             "name": "Angelic Quartermaster",
             "text": "Flying\nWhen Angelic Quartermaster enters the battlefield, put a +1/+1 counter on each of up to two other target creatures.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "a8b84b37-8b72-5ecc-b849-cf688a8cee34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2004a20c-e434-4691-8ef2-740846ce6a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2004a20c-e434-4691-8ef2-740846ce6a51.jpg?1",
             "name": "Arm the Cathars",
             "text": "Until end of turn, target creature gets +3/+3, up to one other target creature gets +2/+2, and up to one other target creature gets +1/+1. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "2d08d62a-ee1b-50f2-8fb2-f83727a5309d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e5dbbe-ca99-41a5-901d-511b9f3ccea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e5dbbe-ca99-41a5-901d-511b9f3ccea6.jpg?1",
             "name": "Bride's Gown",
             "text": "Equipped creature gets +2/+0. It gets an additional +0/+2 and has first strike as long as an Equipment named Groom's Finery is attached to a creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "d914e85e-b153-533d-a4b5-f70c10202a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46764e49-64da-4a94-b61c-75e006b2c5a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46764e49-64da-4a94-b61c-75e006b2c5a9.jpg?1",
             "name": "By Invitation Only",
             "text": "Choose a number between 0 and 13. Each player sacrifices that many creatures.",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "fa771e07-a925-5ec9-a16d-9ef441b049f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00731eb-69fe-42f3-9919-66a4cdec00f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00731eb-69fe-42f3-9919-66a4cdec00f7.jpg?1",
             "name": "Cemetery Protector",
             "text": "Flash\nWhen Cemetery Protector enters the battlefield, exile a card from a graveyard.\nWhenever you play a land or cast a spell, if it shares a card type with the exiled card, create a 1/1 white Human creature token.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "61d350d7-95fc-5445-a82e-219097f6fc1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13031fb6-9d5a-4add-9a86-28b2a9373fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13031fb6-9d5a-4add-9a86-28b2a9373fd2.jpg?1",
             "name": "Circle of Confinement",
             "text": "When Circle of Confinement enters the battlefield, exile target creature an opponent controls with mana value 3 or less until Circle of Confinement leaves the battlefield.\nWhenever an opponent casts a Vampire spell with the same name as a card exiled with Circle of Confinement, you gain 2 life.",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "4a5f9032-3bff-56db-9e4d-7326016c69e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d27617-2d3d-44a1-b93f-0694253b6774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1d27617-2d3d-44a1-b93f-0694253b6774.jpg?1",
             "name": "Dawnhart Geist",
             "text": "Whenever you cast an enchantment spell, you gain 2 life.",
             "colours": [
@@ -277,7 +277,7 @@
         },
         {
             "id": "97e74168-5f9b-518e-85a0-2dd9bb52370c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1",
             "name": "Distracting Geist // Clever Distraction",
             "text": "Whenever Distracting Geist attacks, tap target creature defending player controls.\nDisturb {4}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -311,7 +311,7 @@
         },
         {
             "id": "18cbb350-9bb3-5969-964a-9efe9d087668",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1",
             "name": "Distracting Geist // Clever Distraction",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, tap target creature defending player controls.\"\nIf Clever Distraction would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -345,7 +345,7 @@
         },
         {
             "id": "e4184bf3-7c33-5f05-a696-5f3a5e2ad13a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1",
             "name": "Drogskol Infantry // Drogskol Armaments",
             "text": "Disturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -380,7 +380,7 @@
         },
         {
             "id": "b0ebe8e4-82d9-5be8-8d6a-0088c3fac447",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1",
             "name": "Drogskol Infantry // Drogskol Armaments",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\nIf Drogskol Armaments would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "dfcdd07b-b150-5927-b5ca-6fbe991fdc19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg?1",
             "name": "Estwald Shieldbasher",
             "text": "Whenever Estwald Shieldbasher attacks, you may pay {1}. If you do, it gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -449,7 +449,7 @@
         },
         {
             "id": "6a1b4bce-5776-5334-bfb5-b158a515c944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Defender, flying, vigilance\nAt the beginning of your upkeep, if Faithbound Judge has two or fewer judgment counters on it, put a judgment counter on it.\nAs long as Faithbound Judge has three or more judgment counters on it, it can attack as though it didn't have defender.\nDisturb {5}{W}{W}",
             "colours": [
@@ -486,7 +486,7 @@
         },
         {
             "id": "6e392c3f-a94f-5ca6-afe1-8fedb0f9cd8b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Enchant player\nAt the beginning of your upkeep, put a judgment counter on Sinner's Judgment. Then if there are three or more judgment counters on it, enchanted player loses the game.\nIf Sinner's Judgment would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -523,7 +523,7 @@
         },
         {
             "id": "c42a3140-dcd1-5633-a4f1-72b440a88c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597b163-5c6b-4f64-b1f1-5f1fa2e23e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597b163-5c6b-4f64-b1f1-5f1fa2e23e5d.jpg?1",
             "name": "Fierce Retribution",
             "text": "Cleave {5}{W} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDestroy target [attacking] creature.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "987ff12a-2ee6-59f7-aeaa-40fad8a37664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9d80f7-9742-4437-a9f4-6717a678f935.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9d80f7-9742-4437-a9f4-6717a678f935.jpg?1",
             "name": "Fleeting Spirit",
             "text": "{W}, Exile three cards from your graveyard: Fleeting Spirit gains first strike until end of turn.\nDiscard a card: Exile Fleeting Spirit. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -589,7 +589,7 @@
         },
         {
             "id": "5162ad3b-5227-5609-9762-d1705ebcef98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5317077b-370e-41a9-9162-c713362fd7f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5317077b-370e-41a9-9162-c713362fd7f4.jpg?1",
             "name": "Gryff Rider",
             "text": "Flying\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "6dd42308-7a20-516f-8646-bc25447ff89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792d5b41-27f3-455b-890e-a1771944fc7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/792d5b41-27f3-455b-890e-a1771944fc7d.jpg?1",
             "name": "Gryffwing Cavalry",
             "text": "Flying\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever Gryffwing Cavalry attacks, you may pay {1}{W}. If you do, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -659,7 +659,7 @@
         },
         {
             "id": "78a14e65-6f6c-5c7e-85b8-a9205c4943a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674c0a50-9c37-4c29-84d8-eb3e34f34d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674c0a50-9c37-4c29-84d8-eb3e34f34d37.jpg?1",
             "name": "Hallowed Haunting",
             "text": "As long as you control seven or more enchantments, creatures you control have flying and vigilance.\nWhenever you cast an enchantment spell, create a white Spirit Cleric creature token with \"This creature's power and toughness are each equal to the number of Spirits you control.\"",
             "colours": [
@@ -693,7 +693,7 @@
         },
         {
             "id": "3d0d3865-3d1b-5a71-abd2-8b2b769c2978",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e6933-5c64-4fcd-bb7f-740767a149cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa7e6933-5c64-4fcd-bb7f-740767a149cb.jpg?1",
             "name": "Heron of Hope",
             "text": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\n{1}{W}: Heron of Hope gains lifelink until end of turn.",
             "colours": [
@@ -727,7 +727,7 @@
         },
         {
             "id": "d1cd26ed-0d4d-5eb8-a715-606bd3e70924",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bacf4a-4e99-4008-97e4-3a82dddd4e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83bacf4a-4e99-4008-97e4-3a82dddd4e45.jpg?1",
             "name": "Heron-Blessed Geist",
             "text": "Flying\n{3}{W}, Exile Heron-Blessed Geist from your graveyard: Create two 1/1 white Spirit creature tokens with flying. Activate only if you control an enchantment and only as a sorcery.",
             "colours": [
@@ -761,7 +761,7 @@
         },
         {
             "id": "db3d471a-d3c1-5d22-8dfa-afefec86683d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b3fd1-952a-4bc6-9b31-bd9bd13072f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec1b3fd1-952a-4bc6-9b31-bd9bd13072f5.jpg?1",
             "name": "Hopeful Initiate",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\n{2}{W}, Remove two +1/+1 counters from among creatures you control: Destroy target artifact or enchantment.",
             "colours": [
@@ -798,7 +798,7 @@
         },
         {
             "id": "9307c39d-121b-56bd-8ae2-da2e099f6706",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Flying, lifelink, protection from Vampires\nKatilda, Dawnhart Martyr's power and toughness are each equal to the number of permanents you control that are Spirits and/or enchantments.\nDisturb {3}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -837,7 +837,7 @@
         },
         {
             "id": "d49fed4c-f5c3-5d7d-bfa2-eab6af267bd2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Enchant creature\nEnchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, where X is the number of permanents you control that are Spirits and/or enchantments.\nIf Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -875,7 +875,7 @@
         },
         {
             "id": "fb1eaab6-b533-57f3-81cb-6ec1c134d349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1",
             "name": "Kindly Ancestor // Ancestor's Embrace",
             "text": "Lifelink\nDisturb {1}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -909,7 +909,7 @@
         },
         {
             "id": "cb8ba0c5-cbc6-511a-ad4b-58593847f7bb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1",
             "name": "Kindly Ancestor // Ancestor's Embrace",
             "text": "Enchant creature\nEnchanted creature has lifelink.\nIf Ancestor's Embrace would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -943,7 +943,7 @@
         },
         {
             "id": "f1c071f1-e4de-5dd6-91d7-9bd3dba1aea0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd59300-7b5c-4263-a7fd-775c9fcb05ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfd59300-7b5c-4263-a7fd-775c9fcb05ad.jpg?1",
             "name": "Lantern Flare",
             "text": "Cleave {X}{R}{W} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nLantern Flare deals X damage to target creature or planeswalker and you gain X life. [\nX is the number of creatures you control.]",
             "colours": [
@@ -978,7 +978,7 @@
         },
         {
             "id": "f93cbf50-4f1f-588e-ae8b-3552682826cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b3ff40-3185-4369-985e-17613bb6ad22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51b3ff40-3185-4369-985e-17613bb6ad22.jpg?1",
             "name": "Militia Rallier",
             "text": "Militia Rallier can't attack alone.\nWhenever Militia Rallier attacks, untap target creature.",
             "colours": [
@@ -1013,7 +1013,7 @@
         },
         {
             "id": "a1652f7f-740a-50ad-9d9e-a6880ccf3746",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c68dbd-e61b-49a7-aa17-da6b26c9fd29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c68dbd-e61b-49a7-aa17-da6b26c9fd29.jpg?1",
             "name": "Nebelgast Beguiler",
             "text": "{W}, {T}: Tap target creature.",
             "colours": [
@@ -1047,7 +1047,7 @@
         },
         {
             "id": "30789e1d-e3bf-5568-bb62-6326cce7c2d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e109ea-8b86-4432-b15e-5a6201caf2aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35e109ea-8b86-4432-b15e-5a6201caf2aa.jpg?1",
             "name": "Nurturing Presence",
             "text": "Enchant creature\nEnchanted creature has \"Whenever a creature enters the battlefield under your control, this creature gets +1/+1 until end of turn.\"\nWhen Nurturing Presence enters the battlefield, create a 1/1 white Spirit creature token with flying.",
             "colours": [
@@ -1081,7 +1081,7 @@
         },
         {
             "id": "40dcfa13-9706-515f-bcb6-b2c612196987",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a659bf-9d85-4011-980e-c3a8dc4513e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7a659bf-9d85-4011-980e-c3a8dc4513e9.jpg?1",
             "name": "Ollenbock Escort",
             "text": "Vigilance\nSacrifice Ollenbock Escort: Target creature you control with a +1/+1 counter on it gains lifelink and indestructible until end of turn.",
             "colours": [
@@ -1116,7 +1116,7 @@
         },
         {
             "id": "3e3d9a1b-2646-573b-ad28-0aa85de390f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg?1",
             "name": "Panicked Bystander // Cackling Culprit",
             "text": "Whenever Panicked Bystander or another creature you control dies, you gain 1 life.\nAt the beginning of your end step, if you gained 3 or more life this turn, transform Panicked Bystander.",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "52db4391-758b-5e5a-aa1d-e13f761a1581",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/3/031c5cff-e579-432a-bcee-864b12eb0558.jpg?1",
             "name": "Panicked Bystander // Cackling Culprit",
             "text": "Whenever Cackling Culprit or another creature you control dies, you gain 1 life.\n{1}{B}: Cackling Culprit gains deathtouch until end of turn.",
             "colours": [
@@ -1188,7 +1188,7 @@
         },
         {
             "id": "fcb1c91d-7a0f-551b-a518-ad66e473cf8e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9845cdf2-e5ba-44a0-8136-72a1eb03a6a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9845cdf2-e5ba-44a0-8136-72a1eb03a6a1.jpg?1",
             "name": "Parish-Blade Trainee",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhen Parish-Blade Trainee dies, put its counters on target creature you control.",
             "colours": [
@@ -1223,7 +1223,7 @@
         },
         {
             "id": "bb981eec-21a1-5fe0-b41b-0de7adc9c8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cc4e2b-1497-4788-afb4-9e42b7683b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54cc4e2b-1497-4788-afb4-9e42b7683b5a.jpg?1",
             "name": "Piercing Light",
             "text": "Piercing Light deals 2 damage to target attacking or blocking creature. Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)",
             "colours": [
@@ -1255,7 +1255,7 @@
         },
         {
             "id": "b63ce99e-f42c-5e8c-b634-89cbff3a14cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1",
             "name": "Radiant Grace // Radiant Restraints",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 and has vigilance.\nWhen enchanted creature dies, return Radiant Grace to the battlefield transformed under your control attached to target opponent.",
             "colours": [
@@ -1289,7 +1289,7 @@
         },
         {
             "id": "4f075837-246d-5fcd-a76b-a179a894d809",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1",
             "name": "Radiant Grace // Radiant Restraints",
             "text": "Enchant player\nCreatures enchanted player controls enter the battlefield tapped.",
             "colours": [
@@ -1324,7 +1324,7 @@
         },
         {
             "id": "02fb6859-ca30-53b5-b26a-229c1033372f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ae747-350f-4253-b903-8c6892d78c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093ae747-350f-4253-b903-8c6892d78c83.jpg?1",
             "name": "Resistance Squad",
             "text": "When Resistance Squad enters the battlefield, if you control another Human, draw a card.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "0e6ce937-f727-54e5-b7ff-fe3b87d4ccf4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880e071a-6d6c-41c4-b2eb-c9e6626d0c7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880e071a-6d6c-41c4-b2eb-c9e6626d0c7f.jpg?1",
             "name": "Sanctify",
             "text": "Destroy target artifact or enchantment. You gain 3 life.",
             "colours": [
@@ -1391,7 +1391,7 @@
         },
         {
             "id": "d1775172-1134-50d1-843c-391b1f3b035c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77e83b-1846-4c42-bea0-2e304429fbe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77e83b-1846-4c42-bea0-2e304429fbe0.jpg?1",
             "name": "Savior of Ollenbock",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever Savior of Ollenbock trains, exile up to one other target creature from the battlefield or creature card from a graveyard.\nWhen Savior of Ollenbock leaves the battlefield, put the exiled cards onto the battlefield under their owners' control.",
             "colours": [
@@ -1429,7 +1429,7 @@
         },
         {
             "id": "3f6b4d4c-510a-5b40-a846-8d383f012436",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118995a6-8471-47ac-9404-700ce7fc46f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/118995a6-8471-47ac-9404-700ce7fc46f6.jpg?1",
             "name": "Sigarda's Imprisonment",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{4}{W}: Exile enchanted creature. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -1463,7 +1463,7 @@
         },
         {
             "id": "650105c0-7aef-534f-bed5-02bb3bbbeb5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27f647a-d48e-4f53-ae5b-64c76f4fc745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27f647a-d48e-4f53-ae5b-64c76f4fc745.jpg?1",
             "name": "Sigarda's Summons",
             "text": "Creatures you control with +1/+1 counters on them have base power and toughness 4/4, have flying, and are Angels in addition to their other types.",
             "colours": [
@@ -1498,7 +1498,7 @@
         },
         {
             "id": "3eff7573-2a10-5d85-a9b0-eb8ce885244b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ca69c-916d-4af3-82a4-5f6fb614d6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/960ca69c-916d-4af3-82a4-5f6fb614d6a4.jpg?1",
             "name": "Supernatural Rescue",
             "text": "This spell has flash as long as you control a Spirit.\nWhen you cast this spell, tap up to two target creatures you don't control.\nEnchant creature you control\nEnchanted creature gets +1/+2.",
             "colours": [
@@ -1532,7 +1532,7 @@
         },
         {
             "id": "f9925a8a-584e-511d-b4bf-393028652722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f8b8fb-1cd8-450e-a1fe-892e7a323479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f8b8fb-1cd8-450e-a1fe-892e7a323479.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -1572,7 +1572,7 @@
         },
         {
             "id": "ca1b0d95-6fb0-5cd6-bea0-5e96a52220fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e672a05c-5f1a-4aa6-9398-e33df01c7c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e672a05c-5f1a-4aa6-9398-e33df01c7c96.jpg?1",
             "name": "Traveling Minister",
             "text": "{T}: Target creature gets +1/+0 until end of turn. You gain 1 life. Activate only as a sorcery.",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "213640ae-9ca7-541d-854f-84fcde7c7353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg?1",
             "name": "Twinblade Geist // Twinblade Invocation",
             "text": "Double strike\nDisturb {2}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1642,7 +1642,7 @@
         },
         {
             "id": "6e603d28-cbc7-502a-84ac-5da0c2adba21",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1deb24b-3d8f-4251-a901-85eeb891f26f.jpg?1",
             "name": "Twinblade Geist // Twinblade Invocation",
             "text": "Enchant creature\nEnchanted creature has double strike.\nIf Twinblade Invocation would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -1676,7 +1676,7 @@
         },
         {
             "id": "1254b99c-2cbe-545c-a1d9-5e9a54714b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4c04a4-e68b-4d3d-89c8-29cdaaac36b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4c04a4-e68b-4d3d-89c8-29cdaaac36b2.jpg?1",
             "name": "Unholy Officiant",
             "text": "Vigilance\n{4}{W}: Put a +1/+1 counter on Unholy Officiant.",
             "colours": [
@@ -1713,7 +1713,7 @@
         },
         {
             "id": "d7f22aa8-46bd-56c9-8ceb-bc452fdcd189",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6b9a3b-8a19-4094-8dbb-08a0a9ca04a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e6b9a3b-8a19-4094-8dbb-08a0a9ca04a0.jpg?1",
             "name": "Valorous Stance",
             "text": "Choose one \u2014\n\u2022 Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)\n\u2022 Destroy target creature with toughness 4 or greater.",
             "colours": [
@@ -1745,7 +1745,7 @@
         },
         {
             "id": "6eda450d-f85d-5e1f-9416-2b09e952a26c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f6f03b-5a4e-4532-9c9e-24c75df2769f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f6f03b-5a4e-4532-9c9e-24c75df2769f.jpg?1",
             "name": "Vampire Slayer",
             "text": "Whenever Vampire Slayer deals damage to a Vampire, destroy that creature.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "ae9863df-f515-5a40-84bb-9622b3d880aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16c0871-3f40-4d5a-9d21-e7f944b64a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a16c0871-3f40-4d5a-9d21-e7f944b64a65.jpg?1",
             "name": "Voice of the Blessed",
             "text": "Whenever you gain life, put a +1/+1 counter on Voice of the Blessed.\nAs long as Voice of the Blessed has four or more +1/+1 counters on it, it has flying and vigilance.\nAs long as Voice of the Blessed has ten or more +1/+1 counters on it, it has indestructible.",
             "colours": [
@@ -1817,7 +1817,7 @@
         },
         {
             "id": "c85dc20f-82b3-539d-9171-f0cc9bb55376",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "At the beginning of your end step, put an invitation counter on Wedding Announcement. If you attacked with two or more creatures this turn, draw a card. Otherwise, create a 1/1 white Human creature token. Then if Wedding Announcement has three or more invitation counters on it, transform it.",
             "colours": [
@@ -1851,7 +1851,7 @@
         },
         {
             "id": "eb9aa9d0-6ad9-55ff-9836-71132ca0d6f5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/c/2c3ddb1f-a1de-4fea-9042-5e9caa16ceb2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -1885,7 +1885,7 @@
         },
         {
             "id": "32c0afdf-82b5-5dde-92a6-f53365eee360",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f69cea-823c-482b-a605-8138b3d950e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f69cea-823c-482b-a605-8138b3d950e6.jpg?1",
             "name": "Welcoming Vampire",
             "text": "Flying\nWhenever one or more other creatures with power 2 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "e38824d5-483c-5aa7-909a-cee8100bbcce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbf9d4f-6027-40b8-81c1-7f001a9119dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edbf9d4f-6027-40b8-81c1-7f001a9119dd.jpg?1",
             "name": "Alchemist's Retrieval",
             "text": "Cleave {1}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nReturn target nonland permanent [you control] to its owner's hand.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "cec10798-3fdb-526c-948f-5bea71c99f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1",
             "name": "Binding Geist // Spectral Binding",
             "text": "Whenever Binding Geist attacks, target creature an opponent controls gets -2/-0 until end of turn.\nDisturb {1}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -1987,7 +1987,7 @@
         },
         {
             "id": "a649aee7-e7ee-565c-8ba6-235b922b8468",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1",
             "name": "Binding Geist // Spectral Binding",
             "text": "Enchant creature\nEnchanted creature gets -2/-0.\nIf Spectral Binding would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2021,7 +2021,7 @@
         },
         {
             "id": "c8389e50-b89b-518d-9935-b735b83d3d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg?1",
             "name": "A-Binding Geist // A-Spectral Binding",
             "text": "",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "f389f93b-6ccb-51ab-948d-3f2b6e31df0f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/e/6e40e8f7-38f9-454a-9127-164b39737cb8.jpg?1",
             "name": "A-Binding Geist // A-Spectral Binding",
             "text": "",
             "colours": [
@@ -2087,7 +2087,7 @@
         },
         {
             "id": "abdd3364-cd0c-5411-8f07-dbaed5c3044e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg?1",
             "name": "Biolume Egg // Biolume Serpent",
             "text": "Defender\nWhen Biolume Egg enters the battlefield, scry 2.\nWhen you sacrifice Biolume Egg, return it to the battlefield transformed under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -2122,7 +2122,7 @@
         },
         {
             "id": "10f3bd54-535e-5347-8a55-ebd86e49cfad",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/7/57039230-bf5a-4489-9dc1-37e27b17bd84.jpg?1",
             "name": "Biolume Egg // Biolume Serpent",
             "text": "Sacrifice two Islands: Biolume Serpent can't be blocked this turn.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "14a942aa-929a-5c37-b5a1-ab02b1302c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg?1",
             "name": "Cemetery Illuminator",
             "text": "Flying\nWhenever Cemetery Illuminator enters the battlefield or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with Cemetery Illuminator.",
             "colours": [
@@ -2192,7 +2192,7 @@
         },
         {
             "id": "a9a7ba6d-5533-54d3-8583-600153df7674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60222e91-a688-4113-a8c2-ab08f52bb6e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60222e91-a688-4113-a8c2-ab08f52bb6e1.jpg?1",
             "name": "Chill of the Grave",
             "text": "This spell costs {1} less to cast if you control a Zombie.\nTap target creature. It doesn't untap during its controller's next untap step.\nDraw a card.",
             "colours": [
@@ -2224,7 +2224,7 @@
         },
         {
             "id": "b32f35e1-56b2-5a26-bb82-49f42533aa5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2d3ba4-07c7-46bd-8241-0fa41105b771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a2d3ba4-07c7-46bd-8241-0fa41105b771.jpg?1",
             "name": "Cobbled Lancer",
             "text": "As an additional cost to cast this spell, exile a creature card from your graveyard.\n{3}{U}, Exile Cobbled Lancer from your graveyard: Draw a card.",
             "colours": [
@@ -2259,7 +2259,7 @@
         },
         {
             "id": "e4856bec-930c-5543-831a-461702793087",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72382e-920b-4695-a91c-4980c8c37a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f72382e-920b-4695-a91c-4980c8c37a12.jpg?1",
             "name": "A-Cobbled Lancer",
             "text": "",
             "colours": [
@@ -2293,7 +2293,7 @@
         },
         {
             "id": "5fa7a08e-b7f8-5b3e-9649-97bb95d5ab5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg?1",
             "name": "Consuming Tide",
             "text": "Each player chooses a nonland permanent they control. Return all nonland permanents not chosen this way to their owners' hands. Then you draw a card for each opponent who has more cards in their hand than you.",
             "colours": [
@@ -2327,7 +2327,7 @@
         },
         {
             "id": "9b778fb4-f81b-57ff-aed0-6e492588bdd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42cbad81-152a-435f-9289-f4b6483a059b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42cbad81-152a-435f-9289-f4b6483a059b.jpg?1",
             "name": "Cradle of Safety",
             "text": "Flash\nEnchant creature you control\nWhen Cradle of Safety enters the battlefield, enchanted creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nEnchanted creature gets +1/+1.",
             "colours": [
@@ -2361,7 +2361,7 @@
         },
         {
             "id": "bb3f9a24-4fbb-5aa9-a1de-335c08a10e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf2c686-efb0-46c7-b34e-c77987914b96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bf2c686-efb0-46c7-b34e-c77987914b96.jpg?1",
             "name": "Cruel Witness",
             "text": "Flying\nWhenever you cast a noncreature spell, look at the top card of your library. You may put that card into your graveyard.",
             "colours": [
@@ -2396,7 +2396,7 @@
         },
         {
             "id": "4496523f-c57e-5006-b87c-875462038114",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b5fdf4-3884-436f-8066-bc7593e72b02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38b5fdf4-3884-436f-8066-bc7593e72b02.jpg?1",
             "name": "Diver Skaab",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Diver Skaab exploits a creature, target creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "5e65540b-92d2-5f16-8673-4c3cf96f5ceb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16345278-7565-406b-a958-835081082bc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16345278-7565-406b-a958-835081082bc8.jpg?1",
             "name": "Dreadlight Monstrosity",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\n{3}{U}{U}: Dreadlight Monstrosity can't be blocked this turn. Activate only if you own a card in exile.",
             "colours": [
@@ -2465,7 +2465,7 @@
         },
         {
             "id": "c52ff1dc-4236-525a-ac81-cee87c3219c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b81d90b-708a-48c9-a478-e3b0a3d7e982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b81d90b-708a-48c9-a478-e3b0a3d7e982.jpg?1",
             "name": "Dreamshackle Geist",
             "text": "Flying\nAt the beginning of combat on your turn, choose up to one \u2014\n\u2022 Tap target creature.\n\u2022 Target creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "15a4f57c-8671-5f93-915d-1d250cb9a0ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb3ee1-54f6-4523-9bec-435fade6332f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63cb3ee1-54f6-4523-9bec-435fade6332f.jpg?1",
             "name": "A-Dreamshackle Geist",
             "text": "",
             "colours": [
@@ -2534,7 +2534,7 @@
         },
         {
             "id": "e2fd18de-def4-55ec-82cf-27399fc668f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81704d2-d555-4894-b36c-6b65d1ebe681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b81704d2-d555-4894-b36c-6b65d1ebe681.jpg?1",
             "name": "Fear of Death",
             "text": "Enchant creature\nWhen Fear of Death enters the battlefield, mill two cards. (Put the top two cards of your library into your graveyard.)\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
             "colours": [
@@ -2568,7 +2568,7 @@
         },
         {
             "id": "82a71dd9-14f6-5377-955c-4a93cdaf0f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302b5da-cac5-4ce7-ad38-2ff4e410891b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302b5da-cac5-4ce7-ad38-2ff4e410891b.jpg?1",
             "name": "Geistlight Snare",
             "text": "This spell costs {1} less to cast if you control a Spirit. It also costs {1} less to cast if you control an enchantment.\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -2602,7 +2602,7 @@
         },
         {
             "id": "e7e5109b-9668-52a0-9175-e0d9f4df9772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69890076-9cc4-434f-8618-63b00fdf4515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69890076-9cc4-434f-8618-63b00fdf4515.jpg?1",
             "name": "Geralf, Visionary Stitcher",
             "text": "Zombies you control have flying.\n{U}, {T}, Sacrifice another nontoken creature: Create an X/X blue Zombie creature token, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "c8df5dc9-75a2-5e40-b096-2f8db9973ca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg?1",
             "name": "Gutter Skulker // Gutter Shortcut",
             "text": "Gutter Skulker can't be blocked as long as it's attacking alone.\nDisturb {3}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2675,7 +2675,7 @@
         },
         {
             "id": "0846117c-935a-5c96-bfb5-158a54002e45",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/e/ceb84515-7b8f-444d-b6a9-61231621f9b7.jpg?1",
             "name": "Gutter Skulker // Gutter Shortcut",
             "text": "Enchant creature\nEnchanted creature can't be blocked as long as it's attacking alone.\nIf Gutter Shortcut would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -2709,7 +2709,7 @@
         },
         {
             "id": "cdec08c7-6dcd-5217-8137-97bee73a4c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg?1",
             "name": "A-Gutter Skulker // A-Gutter Shortcut",
             "text": "",
             "colours": [
@@ -2742,7 +2742,7 @@
         },
         {
             "id": "32ee944d-d97e-593a-9534-e8619f1bf9cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/7/f7c3cf39-c49f-4055-87e6-c82a224b273c.jpg?1",
             "name": "A-Gutter Skulker // A-Gutter Shortcut",
             "text": "",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "5eb40487-e9cd-5694-822e-bab8820f50e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b546bcf-2e86-42af-bf32-81c7fd36ef8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b546bcf-2e86-42af-bf32-81c7fd36ef8c.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "e8e02df6-89b5-55a1-8579-c3151cd19013",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43799d-c83c-4774-bd39-3d94d6c8360e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec43799d-c83c-4774-bd39-3d94d6c8360e.jpg?1",
             "name": "A-Hullbreaker Horror",
             "text": "",
             "colours": [
@@ -2846,7 +2846,7 @@
         },
         {
             "id": "d5d0f3bc-7caa-5775-ad07-af8fb716c065",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe4ee8e-579d-4bfa-8c19-bfdb1c0b7177.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe4ee8e-579d-4bfa-8c19-bfdb1c0b7177.jpg?1",
             "name": "Inspired Idea",
             "text": "Cleave {3}{U}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDraw three cards. [\nYour maximum hand size is reduced by three for the rest of the game.]",
             "colours": [
@@ -2880,7 +2880,7 @@
         },
         {
             "id": "34e30c28-282b-5510-bf00-a2dbc571e5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "{T}: Draw a card, then exile a card from your hand face down. You may look at that card for as long as it remains exiled. You may pay {4}{U}{U}. If you do, transform Jacob Hauken, Inspector.",
             "colours": [
@@ -2920,7 +2920,7 @@
         },
         {
             "id": "5133fd60-dd96-5e8e-a31b-f1222e1e499b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b4529c3-8edb-4909-b910-806450a39d2e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "At the beginning of your upkeep, exile the top card of your library face down. You may look at that card for as long as it remains exiled.\nOnce during each of your turns, you may play a land or cast a spell from among the cards exiled with this permanent without paying its mana cost.",
             "colours": [
@@ -2957,7 +2957,7 @@
         },
         {
             "id": "f4f0b664-c2e7-5dfe-991a-c115627f8f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg?1",
             "name": "Lantern Bearer // Lanterns' Lift",
             "text": "Flying\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -2991,7 +2991,7 @@
         },
         {
             "id": "6c2e3128-4d0c-5819-8527-03ecdb14cf8a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/4/a4d3652a-6774-4b16-aa8b-cb11d72ec7aa.jpg?1",
             "name": "Lantern Bearer // Lanterns' Lift",
             "text": "Enchant creature\nEnchanted creature gets +1/+1 and has flying.\nIf Lanterns' Lift would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "655e68e4-4683-581f-aa7d-f2ae3007fa8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg?1",
             "name": "A-Lantern Bearer // A-Lanterns' Lift",
             "text": "",
             "colours": [
@@ -3058,7 +3058,7 @@
         },
         {
             "id": "4d5b6c73-5522-5fa3-a418-6f6b4166da37",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/942d9122-f380-4bc0-8bf1-2ba6f49fd3ee.jpg?1",
             "name": "A-Lantern Bearer // A-Lanterns' Lift",
             "text": "",
             "colours": [
@@ -3091,7 +3091,7 @@
         },
         {
             "id": "3c209370-48f6-5351-a493-cd8f9af15567",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66511c-355f-4e8a-96fc-3afc7a315231.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f66511c-355f-4e8a-96fc-3afc7a315231.jpg?1",
             "name": "Lunar Rejection",
             "text": "Cleave {3}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nReturn target [\nWolf or Werewolf] creature to its owner's hand.\nDraw a card.",
             "colours": [
@@ -3123,7 +3123,7 @@
         },
         {
             "id": "57a2fdb2-8f63-5652-a756-5aaae838fccf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "You may have Mirrorhall Mimic enter the battlefield as a copy of any creature on the battlefield, except it's a Spirit in addition to its other types.\nDisturb {3}{U}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -3159,7 +3159,7 @@
         },
         {
             "id": "07823919-e0b7-5f5e-a2a7-f1b8128dac06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "Enchant creature\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except it's a Spirit in addition to its other types.\nIf Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3195,7 +3195,7 @@
         },
         {
             "id": "d12f2d2e-bbc5-5888-b58c-ff309fded097",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1",
             "name": "Mischievous Catgeist // Catlike Curiosity",
             "text": "Whenever Mischievous Catgeist deals combat damage to a player, draw a card.\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -3230,7 +3230,7 @@
         },
         {
             "id": "a17ef2ec-2875-5bad-b748-ccf43a3c5645",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1",
             "name": "Mischievous Catgeist // Catlike Curiosity",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, draw a card.\"\nIf Catlike Curiosity would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -3264,7 +3264,7 @@
         },
         {
             "id": "c93e7487-7800-5299-86a3-e16b92e0aeaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg?1",
             "name": "A-Mischievous Catgeist // A-Catlike Curiosity",
             "text": "",
             "colours": [
@@ -3298,7 +3298,7 @@
         },
         {
             "id": "6561d6dd-1052-5930-b7b9-189fe8bd4abb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dd4f872-1af1-4bb7-81e7-409861c45b20.jpg?1",
             "name": "A-Mischievous Catgeist // A-Catlike Curiosity",
             "text": "",
             "colours": [
@@ -3331,7 +3331,7 @@
         },
         {
             "id": "eee0e4ed-17c8-5d1d-8dde-277007a572dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b674053-1f0f-436d-b106-f91f41cf3959.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b674053-1f0f-436d-b106-f91f41cf3959.jpg?1",
             "name": "Necroduality",
             "text": "Whenever a nontoken Zombie enters the battlefield under your control, create a token that's a copy of that creature.",
             "colours": [
@@ -3365,7 +3365,7 @@
         },
         {
             "id": "308006ca-fe84-589b-9364-f725b19e7fd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd63d-6c25-47a6-a76c-ac53bf12949c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbbcd63d-6c25-47a6-a76c-ac53bf12949c.jpg?1",
             "name": "Overcharged Amalgam",
             "text": "Flash\nFlying\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Overcharged Amalgam exploits a creature, counter target spell, activated ability, or triggered ability.",
             "colours": [
@@ -3402,7 +3402,7 @@
         },
         {
             "id": "d33dde45-88f9-5298-a885-5bfb5c51ebd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg?1",
             "name": "Patchwork Crawler",
             "text": "{2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter on Patchwork Crawler.\nPatchwork Crawler has all activated abilities of all creature cards exiled with it.",
             "colours": [
@@ -3439,7 +3439,7 @@
         },
         {
             "id": "1e0305c7-7664-59fc-8a1a-ddb2ca3cacfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc22c2a-535a-46b5-817c-da5850abd669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc22c2a-535a-46b5-817c-da5850abd669.jpg?1",
             "name": "Repository Skaab",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Repository Skaab exploits a creature, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -3473,7 +3473,7 @@
         },
         {
             "id": "a1a7f6f7-d879-5f0d-afac-9f87e5b266bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5c6675-6e0f-427d-9399-a6e7fc6215f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc5c6675-6e0f-427d-9399-a6e7fc6215f1.jpg?1",
             "name": "Scattered Thoughts",
             "text": "Look at the top four cards of your library. Put two of those cards into your hand and the rest into your graveyard.",
             "colours": [
@@ -3505,7 +3505,7 @@
         },
         {
             "id": "5c4bed81-1276-5ae6-85c8-611031583d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9faf98-11bb-4407-aec9-d0d43dbaba34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c9faf98-11bb-4407-aec9-d0d43dbaba34.jpg?1",
             "name": "Screaming Swarm",
             "text": "Flying\nWhenever you attack with one or more creatures, target player mills that many cards. (To mill a card, a player puts the top card of their library into their graveyard.)\n{2}{U}: Put Screaming Swarm from your graveyard into your library second from the top.",
             "colours": [
@@ -3540,7 +3540,7 @@
         },
         {
             "id": "f789d77c-f8f8-5058-8723-3172559a69c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8805db2-5a26-43cf-9b74-f882c283e5e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8805db2-5a26-43cf-9b74-f882c283e5e4.jpg?1",
             "name": "Selhoff Entomber",
             "text": "{T}, Discard a creature card: Draw a card.",
             "colours": [
@@ -3574,7 +3574,7 @@
         },
         {
             "id": "05de4376-3bf6-5d14-b72b-c7a3b76b2c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8214b1c-29f8-4986-89ac-2d7fc929edf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8214b1c-29f8-4986-89ac-2d7fc929edf3.jpg?1",
             "name": "Serpentine Ambush",
             "text": "Until end of turn, target creature becomes a blue Serpent with base power and toughness 5/5.",
             "colours": [
@@ -3606,7 +3606,7 @@
         },
         {
             "id": "9fad1682-6718-52b4-bda3-92fca004f539",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73168804-3c22-4fcb-907a-2f08999c0cea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73168804-3c22-4fcb-907a-2f08999c0cea.jpg?1",
             "name": "Skywarp Skaab",
             "text": "Flying\nWhen Skywarp Skaab enters the battlefield, you may exile two creature cards from your graveyard. If you do, draw a card.",
             "colours": [
@@ -3641,7 +3641,7 @@
         },
         {
             "id": "885bcad2-125d-5733-9eec-0c09785a2a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg?1",
             "name": "Soulcipher Board // Cipherbound Spirit",
             "text": "Soulcipher Board enters the battlefield with three omen counters on it.\n{1}{U}, {T}: Look at the top two cards of your library. Put one of them into your graveyard.\nWhenever a creature card is put into your graveyard from anywhere, remove an omen counter from Soulcipher Board. Then if it has no omen counters on it, transform it.",
             "colours": [
@@ -3673,7 +3673,7 @@
         },
         {
             "id": "5255c8f6-07bf-5be1-860c-7855402da55a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/c/3c0fae23-1278-499f-9df7-4a29691726b1.jpg?1",
             "name": "Soulcipher Board // Cipherbound Spirit",
             "text": "Flying\nCipherbound Spirit can block only creatures with flying.\n{3}{U}: Draw two cards, then discard a card.",
             "colours": [
@@ -3707,7 +3707,7 @@
         },
         {
             "id": "28d9ca66-722e-537d-b035-4b59ba02d2a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fb1426-5a6f-48dd-938b-c64b1a28ee59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fb1426-5a6f-48dd-938b-c64b1a28ee59.jpg?1",
             "name": "Steelclad Spirit",
             "text": "Defender\nWhenever an enchantment enters the battlefield under your control, Steelclad Spirit can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3741,7 +3741,7 @@
         },
         {
             "id": "64f7152e-00fb-5ff0-9a7e-c35bbfbe343b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1debb8c-d5e0-49e5-ab27-2d50e6f9d8d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1debb8c-d5e0-49e5-ab27-2d50e6f9d8d2.jpg?1",
             "name": "Stitched Assistant",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Stitched Assistant exploits a creature, scry 1, then draw a card. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)",
             "colours": [
@@ -3775,7 +3775,7 @@
         },
         {
             "id": "0b275505-8ac9-556d-a667-2f73adb8e1ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753d235-24d6-47a9-aed8-b3e13211c222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5753d235-24d6-47a9-aed8-b3e13211c222.jpg?1",
             "name": "A-Stitched Assistant",
             "text": "",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "c31d5b4c-c831-5921-a70a-2ef479f115c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd5c860-9d27-40d9-af38-aaf40bd52423.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dd5c860-9d27-40d9-af38-aaf40bd52423.jpg?1",
             "name": "Stormchaser Drake",
             "text": "Flying\nWhenever Stormchaser Drake becomes the target of a spell you control, draw a card.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "6b3066fc-d7df-5981-9ea2-3eadd12b6f27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08375017-4432-4296-9799-966db145ed7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08375017-4432-4296-9799-966db145ed7c.jpg?1",
             "name": "Syncopate",
             "text": "Counter target spell unless its controller pays {X}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
             "colours": [
@@ -3874,7 +3874,7 @@
         },
         {
             "id": "fc7f19b4-e73e-5e01-9d6d-08531d50eb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a2d31-ac2c-45aa-8369-6c2d6fbba4e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/435a2d31-ac2c-45aa-8369-6c2d6fbba4e4.jpg?1",
             "name": "Syphon Essence",
             "text": "Counter target creature or planeswalker spell. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -3906,7 +3906,7 @@
         },
         {
             "id": "1a7c0af7-5017-5e54-8fb3-3a51b67eda15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea179e9-9c0d-46c1-9ee8-60be68e1f79c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ea179e9-9c0d-46c1-9ee8-60be68e1f79c.jpg?1",
             "name": "Thirst for Discovery",
             "text": "Draw three cards. Then discard two cards unless you discard a basic land card.",
             "colours": [
@@ -3940,7 +3940,7 @@
         },
         {
             "id": "8129a5b3-52c2-5deb-ae3f-75875d595116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb3ce5d-330d-427e-a053-8cc4eeb2941b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bb3ce5d-330d-427e-a053-8cc4eeb2941b.jpg?1",
             "name": "Wanderlight Spirit",
             "text": "Flying\nWanderlight Spirit can block only creatures with flying.",
             "colours": [
@@ -3974,7 +3974,7 @@
         },
         {
             "id": "c6bb7348-fc09-5d73-acea-0b64c4e15b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43411ade-be80-4535-8baa-7055e78496df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43411ade-be80-4535-8baa-7055e78496df.jpg?1",
             "name": "Wash Away",
             "text": "Cleave {1}{U}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nCounter target spell [that wasn't cast from its owner's hand].",
             "colours": [
@@ -4006,7 +4006,7 @@
         },
         {
             "id": "c1cdfd9d-b1c2-52fc-bc44-88276c38418d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg?1",
             "name": "Whispering Wizard",
             "text": "Whenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying. This ability triggers only once each turn.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "dc7e6a62-5dc0-5582-9c48-9e0158f48d99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg?1",
             "name": "Winged Portent",
             "text": "Cleave {4}{G}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDraw a card for each creature [with flying] you control.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "53ddb642-d650-54d2-9b14-64a39ff62146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b3683f-a68b-458c-8f70-bba0f8779b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b3683f-a68b-458c-8f70-bba0f8779b8a.jpg?1",
             "name": "Witness the Future",
             "text": "Target player shuffles up to four target cards from their graveyard into their library. You look at the top four cards of your library, then put one of those cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -4108,7 +4108,7 @@
         },
         {
             "id": "7c6ba013-373b-5141-a963-5a16c72897b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3991f0-76b8-4f77-9d67-0e2b11fda750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb3991f0-76b8-4f77-9d67-0e2b11fda750.jpg?1",
             "name": "Wretched Throng",
             "text": "When Wretched Throng dies, you may search your library for a card named Wretched Throng, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "0b713075-53e4-59ed-b585-400e75679d6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1174e8e1-2e8e-4070-9871-7d5d93e0dd56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1174e8e1-2e8e-4070-9871-7d5d93e0dd56.jpg?1",
             "name": "Aim for the Head",
             "text": "Choose one \u2014\n\u2022 Exile target Zombie.\n\u2022 Target opponent exiles two cards from their hand.",
             "colours": [
@@ -4175,7 +4175,7 @@
         },
         {
             "id": "a61230dd-d509-516e-8ace-c5939a92303a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf81c9d-ddb2-470e-8a4a-590049713e95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cf81c9d-ddb2-470e-8a4a-590049713e95.jpg?1",
             "name": "Archghoul of Thraben",
             "text": "Whenever Archghoul of Thraben or another Zombie you control dies, look at the top card of your library. If it's a Zombie card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
             "colours": [
@@ -4210,7 +4210,7 @@
         },
         {
             "id": "98aac3c0-23fb-5872-b82c-b3908ee654ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65755-f104-4de9-bcc9-0a4a7bc66b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db65755-f104-4de9-bcc9-0a4a7bc66b51.jpg?1",
             "name": "Bleed Dry",
             "text": "Target creature gets -13/-13 until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "6e7bc76d-4bcc-57e2-b625-4f56684d643e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd03651e-ada0-41dc-8722-0eba476943e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd03651e-ada0-41dc-8722-0eba476943e3.jpg?1",
             "name": "Blood Fountain",
             "text": "When Blood Fountain enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{3}{B}, {T}, Sacrifice Blood Fountain: Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "38547fe6-0676-5be5-8c48-57c6d052139c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12c378-1103-4a50-88fa-cf5a2deef463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b12c378-1103-4a50-88fa-cf5a2deef463.jpg?1",
             "name": "Bloodcrazed Socialite",
             "text": "Menace\nWhen Bloodcrazed Socialite enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.",
             "colours": [
@@ -4310,7 +4310,7 @@
         },
         {
             "id": "1103220c-b98b-5987-b760-64424fa28ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "{1}{B}, Discard a card: Bloodsworn Squire gains indestructible until end of turn. Tap it. Then if there are four or more creature cards in your graveyard, transform Bloodsworn Squire. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4347,7 +4347,7 @@
         },
         {
             "id": "aba94310-12d5-54b4-b137-95cd59e85421",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/7/a7cbdd54-7685-4921-ab60-dc36e647a4c5.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "Bloodsworn Knight's power and toughness are each equal to the number of creature cards in your graveyard.\n{1}{B}, Discard a card: Bloodsworn Knight gains indestructible until end of turn. Tap it. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "a8693cfe-ddb9-5150-b636-4ae02f2fa9b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4889c58b-8b84-42af-a56c-e886655aa997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4889c58b-8b84-42af-a56c-e886655aa997.jpg?1",
             "name": "Bloodvial Purveyor",
             "text": "Flying, trample\nWhenever an opponent casts a spell, that player creates a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.",
             "colours": [
@@ -4420,7 +4420,7 @@
         },
         {
             "id": "b38955ff-c2ad-51ce-a373-b5469ba41537",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1",
             "name": "Catapult Fodder // Catapult Captain",
             "text": "At the beginning of combat on your turn, if you control three or more creatures that each have toughness greater than their power, transform Catapult Fodder.",
             "colours": [
@@ -4454,7 +4454,7 @@
         },
         {
             "id": "a3dac4c9-f667-5714-b913-5799233e9cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1",
             "name": "Catapult Fodder // Catapult Captain",
             "text": "{2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal to the sacrificed creature's toughness.",
             "colours": [
@@ -4488,7 +4488,7 @@
         },
         {
             "id": "ef1d3238-cdaa-58bb-a0cd-d20280b3a31d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg?1",
             "name": "Cemetery Desecrator",
             "text": "Menace\nWhen Cemetery Desecrator enters the battlefield or dies, exile another card from a graveyard. When you do, choose one \u2014\n\u2022 Remove X counters from target permanent, where X is the mana value of the exiled card.\n\u2022 Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card.",
             "colours": [
@@ -4524,7 +4524,7 @@
         },
         {
             "id": "5581d890-0e6b-5cd5-8a4f-23050383719e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Defender\n{2}{B}: Transform Concealing Curtains. Activate only as a sorcery.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "572749c9-631b-5ce0-ae98-9c0c1a5f87b1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/612b2e6e-fe8d-49ad-b845-6fa7fa59ffd1.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Menace\nWhen this creature transforms into Revealing Eye, target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -4597,7 +4597,7 @@
         },
         {
             "id": "eb12ccd9-5866-562b-b59d-735d3bf72b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a8dc7-1ee9-4731-bd72-3d02f4e7c6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d9a8dc7-1ee9-4731-bd72-3d02f4e7c6c4.jpg?1",
             "name": "Courier Bat",
             "text": "Flying\nWhen Courier Bat enters the battlefield, if you gained life this turn, return up to one target creature card from your graveyard to your hand.",
             "colours": [
@@ -4631,7 +4631,7 @@
         },
         {
             "id": "e7ae62d5-9917-5178-b8c4-b17e4117125a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c3741e-cf04-4aa2-a6a9-ce19f043b22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80c3741e-cf04-4aa2-a6a9-ce19f043b22c.jpg?1",
             "name": "Demonic Bargain",
             "text": "Exile the top thirteen cards of your library, then search your library for a card. Put that card into your hand, then shuffle.",
             "colours": [
@@ -4665,7 +4665,7 @@
         },
         {
             "id": "7a03e1a8-7680-5e02-88bf-f6809bb8cca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg?1",
             "name": "Desperate Farmer // Depraved Harvester",
             "text": "Lifelink\nWhen another creature you control dies, transform Desperate Farmer.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "c1ea4a6b-af19-58d1-ae22-22992ea40c69",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/6/467c566e-7f6a-40c9-8fd7-da6ae96df56c.jpg?1",
             "name": "Desperate Farmer // Depraved Harvester",
             "text": "Lifelink",
             "colours": [
@@ -4735,7 +4735,7 @@
         },
         {
             "id": "9b3ec6e9-70c4-5cdf-a071-e3e0e28d1405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg?1",
             "name": "Diregraf Scavenger",
             "text": "Deathtouch\nWhen Diregraf Scavenger enters the battlefield, exile up to one target card from a graveyard. If a creature card was exiled this way, each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "55da5515-9b60-5aec-bfa3-a76670dd7266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0cf16-81ea-45e3-99cc-4424d59bb44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c0cf16-81ea-45e3-99cc-4424d59bb44b.jpg?1",
             "name": "Doomed Dissenter",
             "text": "When Doomed Dissenter dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -4804,7 +4804,7 @@
         },
         {
             "id": "88b75259-2ee2-52ae-b383-b7e57c579435",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad4c472-b8ce-4ae0-a6f0-726ea74722c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad4c472-b8ce-4ae0-a6f0-726ea74722c5.jpg?1",
             "name": "Dread Fugue",
             "text": "Cleave {2}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nTarget player reveals their hand. You choose a nonland card from it [with mana value 2 or less]. That player discards that card.",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "9b3578eb-25fa-523f-a38d-30f41b16023c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269199ea-2106-4299-ade0-10cce1320434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/269199ea-2106-4299-ade0-10cce1320434.jpg?1",
             "name": "Dreadfeast Demon",
             "text": "Flying\nAt the beginning of your end step, sacrifice a non-Demon creature. If you do, create a token that's a copy of Dreadfeast Demon.",
             "colours": [
@@ -4872,7 +4872,7 @@
         },
         {
             "id": "22334416-a411-5af4-af66-a1232b005320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea16cd-801e-478a-b924-5431582b70d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ea16cd-801e-478a-b924-5431582b70d1.jpg?1",
             "name": "Dying to Serve",
             "text": "Whenever you discard one or more cards, create a tapped 2/2 black Zombie creature token. This ability triggers only once each turn.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "2a45ef19-08f5-5b6b-93cb-18f8e3d67b3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ff9de6-f9ae-4b1c-9fd1-4ba9663922af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96ff9de6-f9ae-4b1c-9fd1-4ba9663922af.jpg?1",
             "name": "Edgar's Awakening",
             "text": "Return target creature card from your graveyard to the battlefield.\nWhen you discard Edgar's Awakening, you may pay {B}. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -4938,7 +4938,7 @@
         },
         {
             "id": "bca2c03d-5d5e-5b9d-b414-f687455726d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451559d0-b62d-4757-8eb5-f6b0e240899c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/451559d0-b62d-4757-8eb5-f6b0e240899c.jpg?1",
             "name": "Falkenrath Forebear",
             "text": "Flying\nFalkenrath Forebear can't block.\nWhenever Falkenrath Forebear deals combat damage to a player, create a Blood token.\n{B}, Sacrifice two Blood tokens: Return Falkenrath Forebear from your graveyard to the battlefield.",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "72479027-b2cf-5bb5-8475-bd07e6366826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347849-6c07-42c0-bee4-74f93d7ad511.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27347849-6c07-42c0-bee4-74f93d7ad511.jpg?1",
             "name": "Fell Stinger",
             "text": "Deathtouch\nExploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Fell Stinger exploits a creature, target player draws two cards and loses 2 life.",
             "colours": [
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "b1b4d68e-1e42-5c8f-b6b4-5877f5fdb3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a864375f-99c3-4c68-9440-bc25ff6d0dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a864375f-99c3-4c68-9440-bc25ff6d0dc0.jpg?1",
             "name": "Gift of Fangs",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Vampire. Otherwise, it gets -2/-2.",
             "colours": [
@@ -5046,7 +5046,7 @@
         },
         {
             "id": "e4479e63-3cbd-54a9-8476-03a1e71af2ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c07288-1c71-4e71-bdf5-910eb583a1d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c07288-1c71-4e71-bdf5-910eb583a1d8.jpg?1",
             "name": "Gluttonous Guest",
             "text": "When Gluttonous Guest enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Blood token, you gain 1 life.",
             "colours": [
@@ -5082,7 +5082,7 @@
         },
         {
             "id": "da1ed74f-99d9-5e28-ab1d-e1226763090e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg?1",
             "name": "Graf Reaver",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Graf Reaver exploits a creature, destroy target planeswalker.\nAt the beginning of your upkeep, Graf Reaver deals 1 damage to you.",
             "colours": [
@@ -5119,7 +5119,7 @@
         },
         {
             "id": "1a8e5fd7-a95b-5aeb-a4b7-9c604bb51b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cdf2ab-3acd-49bd-8273-84c1cfc92883.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53cdf2ab-3acd-49bd-8273-84c1cfc92883.jpg?1",
             "name": "Grisly Ritual",
             "text": "Destroy target creature or planeswalker. Create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "a930e1e8-91a7-5ebe-954d-535ba756b7c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bc65cf-4444-4db3-9bb3-a7d91e560470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bc65cf-4444-4db3-9bb3-a7d91e560470.jpg?1",
             "name": "Groom's Finery",
             "text": "Equipped creature gets +2/+0. It gets an additional +0/+2 and has deathtouch as long as an Equipment named Bride's Gown is attached to a creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -5185,7 +5185,7 @@
         },
         {
             "id": "0d693c10-4709-5adc-ad33-86e061ccbb7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24018e8-b8f1-44a5-9355-8b79f363569d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c24018e8-b8f1-44a5-9355-8b79f363569d.jpg?1",
             "name": "Headless Rider",
             "text": "Whenever Headless Rider or another nontoken Zombie you control dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "ba2ee893-217a-510d-bbcb-bf08ea32ad5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen \u2014\n\u2022 Each player sacrifices a creature.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Transform Henrika Domnathi.",
             "colours": [
@@ -5260,7 +5260,7 @@
         },
         {
             "id": "a0ee90ad-676b-523c-9a6c-871b4713eece",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/4/946ca338-5f43-4cff-bd93-1b28449c5fdc.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying, deathtouch, lifelink\n{1}{B}{B}: Each creature you control with flying, deathtouch, and/or lifelink gets +1/+0 until end of turn.",
             "colours": [
@@ -5299,7 +5299,7 @@
         },
         {
             "id": "ef7568a3-95d1-5bc5-8b05-e2f28a9cb01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b0751e-3a7e-4568-8c64-7429d6829687.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1b0751e-3a7e-4568-8c64-7429d6829687.jpg?1",
             "name": "Hero's Downfall",
             "text": "Destroy target creature or planeswalker.",
             "colours": [
@@ -5331,7 +5331,7 @@
         },
         {
             "id": "604145b4-defd-5570-acd1-0c61a8c839a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "At the beginning of your upkeep, any opponent may sacrifice a creature. If no one does, transform Innocent Traveler.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "6f1a9d11-690a-5328-9115-d14a8006e42f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "Flying\nMalicious Invader gets +2/+0 as long as an opponent controls a Human.",
             "colours": [
@@ -5405,7 +5405,7 @@
         },
         {
             "id": "3501c7e8-fe9e-5ef5-94f1-1fa389bf8501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c4e00d-128a-4ddb-9e1b-3ee93121b262.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5c4e00d-128a-4ddb-9e1b-3ee93121b262.jpg?1",
             "name": "Mindleech Ghoul",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Mindleech Ghoul exploits a creature, each opponent exiles a card from their hand.",
             "colours": [
@@ -5439,7 +5439,7 @@
         },
         {
             "id": "91ec91fc-b315-5ed4-8382-e91dd940d3de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0713adf7-1770-4d5b-80f7-d6cbd24f7890.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0713adf7-1770-4d5b-80f7-d6cbd24f7890.jpg?1",
             "name": "Parasitic Grasp",
             "text": "Cleave {1}{B}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nParasitic Grasp deals 3 damage to target [\nHuman] creature. You gain 3 life.",
             "colours": [
@@ -5471,7 +5471,7 @@
         },
         {
             "id": "f5bf25c1-ff47-5538-b759-9bcdfbdf434f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5449a-d63b-4b22-9432-8f0365c3c4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0c5449a-d63b-4b22-9432-8f0365c3c4d9.jpg?1",
             "name": "Path of Peril",
             "text": "Cleave {4}{W}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDestroy all creatures [with mana value 2 or less].",
             "colours": [
@@ -5506,7 +5506,7 @@
         },
         {
             "id": "21a1cc6d-7d02-54b2-86e6-7004471ce967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7baf973-3202-4fea-8861-a4a5ec228640.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7baf973-3202-4fea-8861-a4a5ec228640.jpg?1",
             "name": "Persistent Specimen",
             "text": "{2}{B}: Return Persistent Specimen from your graveyard to the battlefield tapped.",
             "colours": [
@@ -5540,7 +5540,7 @@
         },
         {
             "id": "00ef2ebb-0d40-56d8-b21c-7aa78282e0d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076deb63-f7e2-498f-a66a-8a190370a3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/076deb63-f7e2-498f-a66a-8a190370a3b3.jpg?1",
             "name": "Pointed Discussion",
             "text": "You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "8886cdac-18a2-562f-bc5d-d29d7390e0f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg?1",
             "name": "Ragged Recluse // Odious Witch",
             "text": "At the beginning of your end step, if you discarded a card this turn, transform Ragged Recluse.",
             "colours": [
@@ -5607,7 +5607,7 @@
         },
         {
             "id": "87c5dc77-4f67-57ea-a201-8a9a89b1b507",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7fb728de-0d6e-4b32-b0c4-edd7382d1391.jpg?1",
             "name": "Ragged Recluse // Odious Witch",
             "text": "Whenever Odious Witch attacks, defending player loses 1 life and you gain 1 life.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "b05823b8-4e22-57d9-93db-0548c81b9327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nSacrifice two Blood tokens: Transform Restless Bloodseeker. Activate only as a sorcery.",
             "colours": [
@@ -5678,7 +5678,7 @@
         },
         {
             "id": "40cdfae0-8dc6-5ebb-a545-1b7d6e7be767",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/1/71f67ac0-7901-4248-9cb7-2200fb8f893e.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{4}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -5714,7 +5714,7 @@
         },
         {
             "id": "86dfd633-57eb-588a-9e30-25dd601a8188",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eafefd0-3a9e-400e-8c75-0825aeb2ded1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1eafefd0-3a9e-400e-8c75-0825aeb2ded1.jpg?1",
             "name": "Rot-Tide Gargantua",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhen Rot-Tide Gargantua exploits a creature, each opponent sacrifices a creature.",
             "colours": [
@@ -5749,7 +5749,7 @@
         },
         {
             "id": "354f11cd-b8f1-5245-87b9-20dc70a320aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497b94b9-c5d7-4e94-87c2-ca1342588d79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497b94b9-c5d7-4e94-87c2-ca1342588d79.jpg?1",
             "name": "Skulking Killer",
             "text": "When Skulking Killer enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn if that opponent controls no other creatures.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "a3a10243-2d04-5d53-9494-debf602e0c75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7ff5f4-a7cc-41a1-a22b-8cf67ad18707.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc7ff5f4-a7cc-41a1-a22b-8cf67ad18707.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -5826,7 +5826,7 @@
         },
         {
             "id": "0e997854-f8e6-5ca0-98a1-fee654b79e64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e64f38-b1f3-47cd-8cfb-a4861369aca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84e64f38-b1f3-47cd-8cfb-a4861369aca3.jpg?1",
             "name": "Toxrill, the Corrosive",
             "text": "At the beginning of each end step, put a slime counter on each creature you don't control.\nCreatures you don't control get -1/-1 for each slime counter on them.\nWhenever a creature you don't control with a slime counter on it dies, create a 1/1 black Slug creature token.\n{U}{B}, Sacrifice a Slug: Draw a card.",
             "colours": [
@@ -5866,7 +5866,7 @@
         },
         {
             "id": "0644169c-b392-5eb4-961c-8ba2b689afd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b8582-8887-4652-82e2-f9b11ee21545.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9b8582-8887-4652-82e2-f9b11ee21545.jpg?1",
             "name": "Undead Butler",
             "text": "When Undead Butler enters the battlefield, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen Undead Butler dies, you may exile it. When you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -5900,7 +5900,7 @@
         },
         {
             "id": "92334bd0-e0d9-5b6f-8954-d32de1187092",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb38041-043a-4b18-9d9a-f1283684e8f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8eb38041-043a-4b18-9d9a-f1283684e8f1.jpg?1",
             "name": "Undying Malice",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
             "colours": [
@@ -5932,7 +5932,7 @@
         },
         {
             "id": "3f372b80-b237-59b4-aed6-4f0cf1d6dcf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec541b-1799-4c0e-a3fb-c008cf2eb911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5ec541b-1799-4c0e-a3fb-c008cf2eb911.jpg?1",
             "name": "Unhallowed Phalanx",
             "text": "Unhallowed Phalanx enters the battlefield tapped.",
             "colours": [
@@ -5967,7 +5967,7 @@
         },
         {
             "id": "004d27a9-3296-5633-b826-5ded7b49da6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf8cc-4259-48cc-8e7f-1580bb010d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/974bf8cc-4259-48cc-8e7f-1580bb010d3f.jpg?1",
             "name": "Vampire's Kiss",
             "text": "Target player loses 2 life and you gain 2 life. Create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "cb5067fe-fe6e-5253-af3e-5a032903ec24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "2dd36e10-21c2-5b6f-944c-3eb8e012204d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
             "colours": [
@@ -6075,7 +6075,7 @@
         },
         {
             "id": "3cf0fd6a-177e-5703-8ffe-0cf4152c1d56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddfdd10-2a99-4376-abee-f868b0d5e7c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1ddfdd10-2a99-4376-abee-f868b0d5e7c1.jpg?1",
             "name": "Wedding Security",
             "text": "Whenever Wedding Security attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter on Wedding Security and draw a card.",
             "colours": [
@@ -6112,7 +6112,7 @@
         },
         {
             "id": "4913a0dc-3870-5ef3-86fc-1637bf544cb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e47d11-cb21-402b-a39e-588a94cc57b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e47d11-cb21-402b-a39e-588a94cc57b4.jpg?1",
             "name": "Abrade",
             "text": "Choose one \u2014\n\u2022 Abrade deals 3 damage to target creature.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "aef55052-2ab7-50fc-8e80-dc5c2f412693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fbf5d3-4677-4bf0-891f-57d6dcddaff7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8fbf5d3-4677-4bf0-891f-57d6dcddaff7.jpg?1",
             "name": "Alchemist's Gambit",
             "text": "Cleave {4}{U}{U}{R} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nTake an extra turn after this one. During that turn, damage can't be prevented. At the beginning of that turn's end step, you lose the game.\nExile Alchemist's Gambit.",
             "colours": [
@@ -6179,7 +6179,7 @@
         },
         {
             "id": "89fd1d7f-ba05-5525-bb4f-e076c9f3db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "When you attack with exactly two creatures, transform Alluring Suitor.",
             "colours": [
@@ -6215,7 +6215,7 @@
         },
         {
             "id": "472e2e3a-9ffe-5243-989d-d55da189e594",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "Trample\nWhen this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't lose this mana as steps and phases end.\n{R}{R}: Deadly Dancer and another target creature each get +1/+0 until end of turn.",
             "colours": [
@@ -6251,7 +6251,7 @@
         },
         {
             "id": "6c1b624f-dfee-576d-b9d0-0a768394db0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dee47ab-d603-4346-97f4-a25dc3f47765.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dee47ab-d603-4346-97f4-a25dc3f47765.jpg?1",
             "name": "Ancestral Anger",
             "text": "Target creature gains trample and gets +X/+0 until end of turn, where X is 1 plus the number of cards named Ancestral Anger in your graveyard.\nDraw a card.",
             "colours": [
@@ -6283,7 +6283,7 @@
         },
         {
             "id": "c65601dc-fd33-5276-bce9-8a5e4d42a082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg?1",
             "name": "Ballista Watcher // Ballista Wielder",
             "text": "{2}{R}, {T}: Ballista Watcher deals 1 damage to any target.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6319,7 +6319,7 @@
         },
         {
             "id": "bfb803bf-5e79-5f9d-9a41-3fb570464ce2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63d96c52-66ce-4b46-9a0b-7cd9a43f9253.jpg?1",
             "name": "Ballista Watcher // Ballista Wielder",
             "text": "{2}{R}: Ballista Wielder deals 1 damage to any target. A creature dealt damage this way can't block this turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6353,7 +6353,7 @@
         },
         {
             "id": "ddd19e6f-c7f0-574d-8dfd-fe9a9833f849",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb844c4-f41c-4411-a80a-c19e1d97b272.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bb844c4-f41c-4411-a80a-c19e1d97b272.jpg?1",
             "name": "Belligerent Guest",
             "text": "Trample\nWhenever Belligerent Guest deals combat damage to a player, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6389,7 +6389,7 @@
         },
         {
             "id": "c690ef52-de76-5024-92ac-4472a1b82ace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85e0477-9176-4a3e-badc-f1c1c734e59c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d85e0477-9176-4a3e-badc-f1c1c734e59c.jpg?1",
             "name": "Blood Hypnotist",
             "text": "Blood Hypnotist can't block.\nWhenever you sacrifice one or more Blood tokens, target creature can't block this turn. This ability triggers only once each turn.",
             "colours": [
@@ -6425,7 +6425,7 @@
         },
         {
             "id": "be3fa911-012c-562e-8d2a-f3f001f27c34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3a4927-f06c-424d-92a9-b40cf8e3e209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c3a4927-f06c-424d-92a9-b40cf8e3e209.jpg?1",
             "name": "Blood Petal Celebrant",
             "text": "Blood Petal Celebrant has first strike as long as it's attacking.\nWhen Blood Petal Celebrant dies, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6461,7 +6461,7 @@
         },
         {
             "id": "2d6226fa-c463-50b4-827c-a8e49087252e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8970a5d6-dcab-415a-851b-20e228ef7d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8970a5d6-dcab-415a-851b-20e228ef7d16.jpg?1",
             "name": "Bloody Betrayal",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6493,7 +6493,7 @@
         },
         {
             "id": "95ea1b20-717a-5dc8-9297-dc40c7d81272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457086c4-1b4e-4f79-8f2a-10b16174c8bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457086c4-1b4e-4f79-8f2a-10b16174c8bb.jpg?1",
             "name": "Cemetery Gatekeeper",
             "text": "First strike\nWhen Cemetery Gatekeeper enters the battlefield, exile a card from a graveyard.\nWhenever a player plays a land or casts a spell, if it shares a card type with the exiled card, Cemetery Gatekeeper deals 2 damage to that player.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "29ce18c1-48d3-5692-ba14-c5cf79e3adc4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681f7c73-92c6-47ba-af56-3ff032ac12da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/681f7c73-92c6-47ba-af56-3ff032ac12da.jpg?1",
             "name": "Chandra, Dressed to Kill",
             "text": "+1: Add {R}. Chandra, Dressed to Kill deals 1 damage to up to one target player or planeswalker.\n+1: Exile the top card of your library. If it's red, you may cast it this turn.\n\u22127: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"",
             "colours": [
@@ -6567,7 +6567,7 @@
         },
         {
             "id": "16387216-cc90-5a18-b26b-37a1c6f56d7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ca5ce5-94e7-43a1-8f2b-f0a4532f617a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ca5ce5-94e7-43a1-8f2b-f0a4532f617a.jpg?1",
             "name": "Change of Fortune",
             "text": "Discard your hand, then draw a card for each card you've discarded this turn.",
             "colours": [
@@ -6601,7 +6601,7 @@
         },
         {
             "id": "700eed52-28b3-5cf3-9494-a49373422fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg?1",
             "name": "Creepy Puppeteer",
             "text": "Haste\nWhenever Creepy Puppeteer attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn.",
             "colours": [
@@ -6638,7 +6638,7 @@
         },
         {
             "id": "e2235fda-df7e-550b-b03b-a11c1101e942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg?1",
             "name": "Curse of Hospitality",
             "text": "Enchant player\nCreatures attacking enchanted player have trample.\nWhenever a creature deals combat damage to enchanted player, that player exiles the top card of their library. Until end of turn, that creature's controller may play that card and they may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -6675,7 +6675,7 @@
         },
         {
             "id": "eb030e56-9f8c-584b-aac2-1e6a3ff8deec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8697a861-0f67-4ed3-bed8-f264fc78565e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/8697a861-0f67-4ed3-bed8-f264fc78565e.jpg?1",
             "name": "Daybreak Combatants",
             "text": "Haste\nWhen Daybreak Combatants enters the battlefield, target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -6710,7 +6710,7 @@
         },
         {
             "id": "7ab1bf93-b5cc-5f9e-a896-99382bcebdce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11d234-c6e4-45b2-a3c2-dcacc77cc084.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b11d234-c6e4-45b2-a3c2-dcacc77cc084.jpg?1",
             "name": "Dominating Vampire",
             "text": "When Dominating Vampire enters the battlefield, gain control of target creature with mana value less than or equal to the number of Vampires you control until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -6747,7 +6747,7 @@
         },
         {
             "id": "946a1e75-2eb8-532f-8dfc-603a4b011c04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec748e6-7245-4a71-aeee-cefed8346948.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec748e6-7245-4a71-aeee-cefed8346948.jpg?1",
             "name": "End the Festivities",
             "text": "End the Festivities deals 1 damage to each opponent and each creature and planeswalker they control.",
             "colours": [
@@ -6779,7 +6779,7 @@
         },
         {
             "id": "3c113ba5-1f73-51bc-b0fd-ab2123864444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3c5778-4760-4a8c-8d8d-693e29a0a74b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c3c5778-4760-4a8c-8d8d-693e29a0a74b.jpg?1",
             "name": "Falkenrath Celebrants",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Falkenrath Celebrants enters the battlefield, create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -6815,7 +6815,7 @@
         },
         {
             "id": "6456e418-60c9-5e12-bd03-570fd3d139a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg?1",
             "name": "Fearful Villager // Fearsome Werewolf",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -6850,7 +6850,7 @@
         },
         {
             "id": "d6fa3986-5abf-55c9-af99-cfa2d5c1a0a1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5eb3a08e-1d31-4ab9-854f-a86b060696ec.jpg?1",
             "name": "Fearful Villager // Fearsome Werewolf",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -6884,7 +6884,7 @@
         },
         {
             "id": "c5aa8f3c-e5e7-5ffd-af28-26e565e7aec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1771a8f-7bea-4bb0-9949-566ee6613b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1771a8f-7bea-4bb0-9949-566ee6613b93.jpg?1",
             "name": "Flame-Blessed Bolt",
             "text": "Flame-Blessed Bolt deals 2 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
             "colours": [
@@ -6916,7 +6916,7 @@
         },
         {
             "id": "a42f5e8d-5f63-578c-b05f-6edf4bf1e675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7912206-6de3-4085-b5f6-a2e90ea55b90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7912206-6de3-4085-b5f6-a2e90ea55b90.jpg?1",
             "name": "Frenzied Devils",
             "text": "Haste\nWhenever you cast a noncreature spell, Frenzied Devils gets +2/+2 until end of turn.",
             "colours": [
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "d8ce6762-a988-5769-9c58-436ce12e5eba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e491a1-b195-45bb-bf06-345eaee30b81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04e491a1-b195-45bb-bf06-345eaee30b81.jpg?1",
             "name": "Honeymoon Hearse",
             "text": "Trample\nTap two untapped creatures you control: Honeymoon Hearse becomes an artifact creature until end of turn.",
             "colours": [
@@ -6984,7 +6984,7 @@
         },
         {
             "id": "149459e2-da3e-52e9-8d28-b30e24d1560f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804e0e1d-9c9c-46e6-8533-88e18a91ceff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804e0e1d-9c9c-46e6-8533-88e18a91ceff.jpg?1",
             "name": "Hungry Ridgewolf",
             "text": "As long as you control another Wolf or Werewolf, Hungry Ridgewolf gets +1/+0 and has trample.",
             "colours": [
@@ -7018,7 +7018,7 @@
         },
         {
             "id": "61de9b66-8c4a-50cd-96c0-30a8495b2f81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever Ill-Tempered Loner is dealt damage, it deals that much damage to any target.\n{1}{R}: Ill-Tempered Loner gets +2/+0 until end of turn.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7055,7 +7055,7 @@
         },
         {
             "id": "efe7daf2-bd75-5878-91d5-5e1f79b0cdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3d1e90b-0c99-46da-b4f6-4b7be27dbd5c.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever a permanent you control is dealt damage, Howlpack Avenger deals that much damage to any target.\n{1}{R}: Howlpack Avenger gets +2/+0 until end of turn.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7091,7 +7091,7 @@
         },
         {
             "id": "633e6d81-c183-5083-8a19-062bcb334f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a96286-0dda-4761-a1c5-241288c36275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5a96286-0dda-4761-a1c5-241288c36275.jpg?1",
             "name": "Into the Night",
             "text": "It becomes night. Discard any number of cards, then draw that many cards plus one.",
             "colours": [
@@ -7123,7 +7123,7 @@
         },
         {
             "id": "b1a92756-3c7f-5254-81b1-c1f8326ba433",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ad78a-b02a-44dc-afe6-7f95781a5062.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/303ad78a-b02a-44dc-afe6-7f95781a5062.jpg?1",
             "name": "Kessig Flamebreather",
             "text": "Whenever you cast a noncreature spell, Kessig Flamebreather deals 1 damage to each opponent.",
             "colours": [
@@ -7158,7 +7158,7 @@
         },
         {
             "id": "28481847-407b-5e4c-9959-1da3052dea4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg?1",
             "name": "Kessig Wolfrider",
             "text": "Menace\n{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.",
             "colours": [
@@ -7195,7 +7195,7 @@
         },
         {
             "id": "bd47c307-d725-53c7-890c-21998545cd92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e0c0dc-2d35-4e5a-81da-dd5f35b8e579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7e0c0dc-2d35-4e5a-81da-dd5f35b8e579.jpg?1",
             "name": "Lacerate Flesh",
             "text": "Lacerate Flesh deals 4 damage to target creature. Create a number of Blood tokens equal to the amount of excess damage dealt to that creature this way. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7227,7 +7227,7 @@
         },
         {
             "id": "66b34f01-ba41-5a2f-94ac-861774f41496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg?1",
             "name": "Lambholt Raconteur // Lambholt Ravager",
             "text": "Whenever you cast a noncreature spell, Lambholt Raconteur deals 1 damage to each opponent.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7262,7 +7262,7 @@
         },
         {
             "id": "6f53fdf0-bd73-5ca3-adf2-a1b7583c7a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/c/0cbee24c-9147-46cb-a5f9-8d919c021aa4.jpg?1",
             "name": "Lambholt Raconteur // Lambholt Ravager",
             "text": "Whenever you cast a noncreature spell, Lambholt Ravager deals 2 damage to each opponent.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7296,7 +7296,7 @@
         },
         {
             "id": "aca7acf6-b459-5c4b-b209-6c73327e0f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7211e4c3-e940-41da-88e4-4630eab447a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/7211e4c3-e940-41da-88e4-4630eab447a6.jpg?1",
             "name": "Lightning Wolf",
             "text": "{1}{R}: Lightning Wolf gains first strike until end of turn. Activate only as a sorcery.",
             "colours": [
@@ -7330,7 +7330,7 @@
         },
         {
             "id": "236a6a7e-ebd5-5925-83df-f72a4a4227b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f133d6-35c3-49b7-85f6-d6cfa6bac3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42f133d6-35c3-49b7-85f6-d6cfa6bac3d9.jpg?1",
             "name": "Magma Pummeler",
             "text": "Magma Pummeler enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Magma Pummeler while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from it. When one or more counters are removed from Magma Pummeler this way, it deals that much damage to any target.",
             "colours": [
@@ -7364,7 +7364,7 @@
         },
         {
             "id": "dbd85237-3c8f-53b4-9c32-8544fffca303",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59170-aa80-45e1-ad0d-ce4818e78d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e59170-aa80-45e1-ad0d-ce4818e78d2a.jpg?1",
             "name": "Manaform Hellkite",
             "text": "Flying\nWhenever you cast a noncreature spell, create an X/X red Dragon Illusion creature token with flying and haste, where X is the amount of mana spent to cast that spell. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -7400,7 +7400,7 @@
         },
         {
             "id": "04aa7896-01c3-5c48-8f86-190543d1b814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d3840c-db27-4512-bfe3-92249094e5b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d3840c-db27-4512-bfe3-92249094e5b4.jpg?1",
             "name": "Markov Retribution",
             "text": "Choose one or both \u2014\n\u2022 Creatures you control get +1/+0 until end of turn.\n\u2022 Target Vampire you control deals damage equal to its power to another target creature.",
             "colours": [
@@ -7432,7 +7432,7 @@
         },
         {
             "id": "60e5b8f2-0571-5400-87f5-e72ef992d284",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9702fa3-9323-4e2f-92c9-6c31df198af2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9702fa3-9323-4e2f-92c9-6c31df198af2.jpg?1",
             "name": "Olivia's Attendants",
             "text": "Menace\nWhenever Olivia's Attendants deals damage, create that many Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{2}{R}: Olivia's Attendants deals 1 damage to any target.",
             "colours": [
@@ -7468,7 +7468,7 @@
         },
         {
             "id": "fc6d2574-1687-5666-b206-4a2264c05cd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80255777-de00-4ffa-a8a0-f522bf4198fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80255777-de00-4ffa-a8a0-f522bf4198fb.jpg?1",
             "name": "Pyre Spawn",
             "text": "When Pyre Spawn dies, it deals 3 damage to any target.",
             "colours": [
@@ -7502,7 +7502,7 @@
         },
         {
             "id": "c87b343b-9f7a-517b-804a-8da7ebb82fb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6943c07f-ab0d-4f5a-bbe9-c0a83dc98546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6943c07f-ab0d-4f5a-bbe9-c0a83dc98546.jpg?1",
             "name": "Reckless Impulse",
             "text": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
             "colours": [
@@ -7534,7 +7534,7 @@
         },
         {
             "id": "38de3cd7-6efc-5fdb-8f13-b08d9652023c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51332c31-41df-4379-aa63-6a734a4df618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51332c31-41df-4379-aa63-6a734a4df618.jpg?1",
             "name": "Rending Flame",
             "text": "Rending Flame deals 5 damage to target creature or planeswalker. If that permanent is a Spirit, Rending Flame also deals 2 damage to that permanent's controller.",
             "colours": [
@@ -7566,7 +7566,7 @@
         },
         {
             "id": "50246049-844e-588e-9502-f71d5c9bc04e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9615f0-376f-4ac0-b269-5f497f2b5223.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f9615f0-376f-4ac0-b269-5f497f2b5223.jpg?1",
             "name": "Runebound Wolf",
             "text": "{3}{R}, {T}: Runebound Wolf deals damage equal to the number of Wolves and Werewolves you control to target opponent.",
             "colours": [
@@ -7600,7 +7600,7 @@
         },
         {
             "id": "3e534d1d-666c-506b-afc9-2858b79cc650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fafd4-443f-4e16-972e-86c16f22670a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/706fafd4-443f-4e16-972e-86c16f22670a.jpg?1",
             "name": "Sanguine Statuette",
             "text": "When Sanguine Statuette enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nWhenever you sacrifice a Blood token, you may have Sanguine Statuette become a 3/3 Vampire artifact creature with haste until end of turn.",
             "colours": [
@@ -7632,7 +7632,7 @@
         },
         {
             "id": "b54d0d16-fede-562d-9283-f01161b25e21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df71a8c1-25af-4e6a-9197-11b96b959b46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df71a8c1-25af-4e6a-9197-11b96b959b46.jpg?1",
             "name": "Stensia Uprising",
             "text": "At the beginning of your end step, create a 1/1 red Human creature token. Then if you control exactly thirteen permanents, you may sacrifice Stensia Uprising. When you do, it deals 7 damage to any target.",
             "colours": [
@@ -7666,7 +7666,7 @@
         },
         {
             "id": "506b9bd7-dc44-51ff-aba7-494fa02406c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d872736-fafb-44e8-a809-48c5436c665a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d872736-fafb-44e8-a809-48c5436c665a.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -7698,7 +7698,7 @@
         },
         {
             "id": "d2a50c74-2e25-5dd4-a046-ac3cf959d6ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d2d886-13a2-44f1-966a-ec674622fd01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20d2d886-13a2-44f1-966a-ec674622fd01.jpg?1",
             "name": "Vampires' Vengeance",
             "text": "Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7732,7 +7732,7 @@
         },
         {
             "id": "68e6cc61-908e-5116-b3d9-5ba20af355d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Volatile Arsonist attacks, it deals 1 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7769,7 +7769,7 @@
         },
         {
             "id": "d9c387d6-ee18-50dc-8a6e-791c87687e04",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/7/87a02ac1-c43a-43cc-9c2b-628cfdeb4cbf.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Dire-Strain Anarchist attacks, it deals 2 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7805,7 +7805,7 @@
         },
         {
             "id": "a17db2a7-04dd-5592-9284-aa035c4babb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae154e64-f626-45fb-bd52-840c1c27b2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae154e64-f626-45fb-bd52-840c1c27b2d3.jpg?1",
             "name": "Voldaren Epicure",
             "text": "When Voldaren Epicure enters the battlefield, it deals 1 damage to each opponent. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [
@@ -7841,7 +7841,7 @@
         },
         {
             "id": "5581eb36-c490-5f1b-a5ee-821ccd292ecd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg?1",
             "name": "Voltaic Visionary // Volt-Charged Berserker",
             "text": "{T}: Voltaic Visionary deals 2 damage to you. Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\nWhen you play a card exiled with Voltaic Visionary, transform Voltaic Visionary.",
             "colours": [
@@ -7876,7 +7876,7 @@
         },
         {
             "id": "61d7ebca-daf3-5718-8512-c6322154545e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8b85386-462b-46f8-9412-fd47ed1dc1da.jpg?1",
             "name": "Voltaic Visionary // Volt-Charged Berserker",
             "text": "Volt-Charged Berserker can't block.",
             "colours": [
@@ -7911,7 +7911,7 @@
         },
         {
             "id": "2383c721-d8f7-5918-b741-2ed2d490b82b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg?1",
             "name": "Weary Prisoner // Wrathful Jailbreaker",
             "text": "Defender\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "3a59a116-8a25-524c-bf2a-b617609c069a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e641467b-ac2e-4d29-aed7-5cc227c3b1ce.jpg?1",
             "name": "Weary Prisoner // Wrathful Jailbreaker",
             "text": "Wrathful Jailbreaker attacks each combat if able.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -7980,7 +7980,7 @@
         },
         {
             "id": "77ea7682-28fc-5d69-bcdf-c55991c4d831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03f0790-cdc9-4bb4-ae54-2c248435b0a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03f0790-cdc9-4bb4-ae54-2c248435b0a4.jpg?1",
             "name": "Apprentice Sharpshooter",
             "text": "Reach\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)",
             "colours": [
@@ -8015,7 +8015,7 @@
         },
         {
             "id": "f52ca772-48a8-543d-8def-bd285edef3dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c5b67-5de9-41da-b57f-7ce771457a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/142c5b67-5de9-41da-b57f-7ce771457a3e.jpg?1",
             "name": "Ascendant Packleader",
             "text": "Ascendant Packleader enters the battlefield with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.\nWhenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on Ascendant Packleader.",
             "colours": [
@@ -8051,7 +8051,7 @@
         },
         {
             "id": "0c258f5e-d050-526a-b5f7-e768ba0b0493",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nAt the beginning of combat on your turn, put two +1/+1 counters on another target creature you control.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8088,7 +8088,7 @@
         },
         {
             "id": "53987de7-c8c2-5f85-9df3-918be109e63a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0c358b4-5af2-438f-8bd5-beb0ee6b518b.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nOther permanents you control have hexproof.\nAt the beginning of combat on your turn, put two +1/+1 counters on each creature you control.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8124,7 +8124,7 @@
         },
         {
             "id": "650a0d57-8cdb-5361-b0b0-607ed2e454ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3017ae1-9744-493b-a1a2-fb2a60f7e7e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3017ae1-9744-493b-a1a2-fb2a60f7e7e4.jpg?1",
             "name": "Bramble Armor",
             "text": "When Bramble Armor enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "5635a80b-ad76-59fa-b87e-f73c37fc5b1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f16f137-4ceb-469c-a381-e575d58f456b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f16f137-4ceb-469c-a381-e575d58f456b.jpg?1",
             "name": "Bramble Wurm",
             "text": "Reach, trample\nWhen Bramble Wurm enters the battlefield, you gain 5 life.\n{2}{G}, Exile Bramble Wurm from your graveyard: You gain 5 life.",
             "colours": [
@@ -8192,7 +8192,7 @@
         },
         {
             "id": "788b53d3-eb73-504c-910a-8e420ea9d71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a41cfc-f329-4e69-a785-835f69c7d2ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9a41cfc-f329-4e69-a785-835f69c7d2ba.jpg?1",
             "name": "Cartographer's Survey",
             "text": "Look at the top seven cards of your library. Put up to two land cards from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8224,7 +8224,7 @@
         },
         {
             "id": "21b4acda-d7c7-5d55-84eb-165d5848efed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b124ccc4-76e3-41a4-92b2-8f1d06ea9cb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b124ccc4-76e3-41a4-92b2-8f1d06ea9cb8.jpg?1",
             "name": "Cemetery Prowler",
             "text": "Vigilance\nWhenever Cemetery Prowler enters the battlefield or attacks, exile a card from a graveyard.\nSpells you cast cost {1} less to cast for each card type they share with cards exiled with Cemetery Prowler.",
             "colours": [
@@ -8260,7 +8260,7 @@
         },
         {
             "id": "7e95c7b9-72d1-5a48-8115-8549a22f4ee7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d86c79-d2c7-4900-9474-4d4bc4c74d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06d86c79-d2c7-4900-9474-4d4bc4c74d44.jpg?1",
             "name": "Cloaked Cadet",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever one or more +1/+1 counters are put on one or more Humans you control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "27d6a371-221d-5fcd-9b76-4d8f2da44ab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab55dae-5393-4356-9f81-66d6ea5d23c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab55dae-5393-4356-9f81-66d6ea5d23c0.jpg?1",
             "name": "Crawling Infestation",
             "text": "At the beginning of your upkeep, you may mill two cards. (You may put the top two cards of your library into your graveyard.)\nWhenever one or more creature cards are put into your graveyard from anywhere during your turn, create a 1/1 green Insect creature token. This ability triggers only once each turn.",
             "colours": [
@@ -8327,7 +8327,7 @@
         },
         {
             "id": "099c7f47-2bec-548c-ac12-fbba2dfb7329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae67d98-5167-442b-8586-0b2bcb0c56eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae67d98-5167-442b-8586-0b2bcb0c56eb.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -8359,7 +8359,7 @@
         },
         {
             "id": "84c1cd81-238d-548c-a2ca-29bf1225be3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dffe04-c431-440d-a8da-33c74b4bb683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62dffe04-c431-440d-a8da-33c74b4bb683.jpg?1",
             "name": "Cultivator Colossus",
             "text": "Trample\nCultivator Colossus's power and toughness are each equal to the number of lands you control.\nWhen Cultivator Colossus enters the battlefield, you may put a land card from your hand onto the battlefield tapped. If you do, draw a card and repeat this process.",
             "colours": [
@@ -8396,7 +8396,7 @@
         },
         {
             "id": "9f0ff1f1-5678-5d3d-bd0f-fb3296e216ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb669c-155e-4002-ba55-7e901760c0e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4bb669c-155e-4002-ba55-7e901760c0e8.jpg?1",
             "name": "Dawnhart Disciple",
             "text": "Whenever another Human enters the battlefield under your control, Dawnhart Disciple gets +1/+1 until end of turn.",
             "colours": [
@@ -8431,7 +8431,7 @@
         },
         {
             "id": "34a499a5-8f9b-51b7-9d32-d70b031e5141",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14c947-2452-4fd6-8f1a-391cf5898100.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f14c947-2452-4fd6-8f1a-391cf5898100.jpg?1",
             "name": "Dig Up",
             "text": "Cleave {1}{B}{B}{G} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nSearch your library for a basic land card, [reveal it,] put it into your hand, then shuffle.",
             "colours": [
@@ -8466,7 +8466,7 @@
         },
         {
             "id": "a77d8d1f-5a4e-5d42-a3d2-0d7e94fd29a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1",
             "name": "Dormant Grove // Gnarled Grovestrider",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if that creature has toughness 6 or greater, transform Dormant Grove.",
             "colours": [
@@ -8498,7 +8498,7 @@
         },
         {
             "id": "3acea3f9-570b-58ec-8571-1eefc1179948",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1",
             "name": "Dormant Grove // Gnarled Grovestrider",
             "text": "Vigilance\nOther creatures you control have vigilance.",
             "colours": [
@@ -8532,7 +8532,7 @@
         },
         {
             "id": "1d6d0b88-686d-545e-82b9-9ec279d3b1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc54df-773d-4f46-b241-e1f42af8ab95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2abc54df-773d-4f46-b241-e1f42af8ab95.jpg?1",
             "name": "Flourishing Hunter",
             "text": "When Flourishing Hunter enters the battlefield, you gain life equal to the greatest toughness among other creatures you control.",
             "colours": [
@@ -8567,7 +8567,7 @@
         },
         {
             "id": "13fb1f5c-8c22-5fc5-b37b-f20cfd29b3ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2caf73e-c3eb-4fa8-996a-d3d18b2ffaeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2caf73e-c3eb-4fa8-996a-d3d18b2ffaeb.jpg?1",
             "name": "Glorious Sunrise",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Target land gains \"{T}: Add {G}{G}{G}\" until end of turn.\n\u2022 Draw a card if you control a creature with power 3 or greater.\n\u2022 You gain 3 life.",
             "colours": [
@@ -8601,7 +8601,7 @@
         },
         {
             "id": "8194b518-6805-5741-9799-8206da90eeb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31e108b-8cb5-4f30-b68b-274aa7ac2a81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f31e108b-8cb5-4f30-b68b-274aa7ac2a81.jpg?1",
             "name": "Hamlet Vanguard",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nHamlet Vanguard enters the battlefield with two +1/+1 counters on it for each other nontoken Human you control.",
             "colours": [
@@ -8638,7 +8638,7 @@
         },
         {
             "id": "7c407209-94fe-583c-8766-148918aeddee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg?1",
             "name": "Hiveheart Shaman",
             "text": "Whenever Hiveheart Shaman attacks, you may search your library for a basic land card that doesn't share a land type with a land you control, put that card onto the battlefield, then shuffle.\n{5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is the number of basic land types among lands you control. Activate only as a sorcery.",
             "colours": [
@@ -8675,7 +8675,7 @@
         },
         {
             "id": "ca51a502-3104-5113-b0d5-89cb32a9a47e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg?1",
             "name": "Hookhand Mariner // Riphook Raider",
             "text": "Daybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8710,7 +8710,7 @@
         },
         {
             "id": "caf12634-b122-5591-be5f-d7053ac0d177",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/4/54a4b031-0919-44aa-a35e-68da7a27235a.jpg?1",
             "name": "Hookhand Mariner // Riphook Raider",
             "text": "Riphook Raider can't be blocked by creatures with power 2 or less.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8744,7 +8744,7 @@
         },
         {
             "id": "b4f26a07-bffa-5964-be4d-ec6dee6e94ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50b6a5-2e58-4de3-b0e1-0b33536f69a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50b6a5-2e58-4de3-b0e1-0b33536f69a6.jpg?1",
             "name": "Howling Moon",
             "text": "At the beginning of combat on your turn, target Wolf or Werewolf you control gets +2/+2 until end of turn.\nWhenever an opponent casts their second spell each turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -8778,7 +8778,7 @@
         },
         {
             "id": "5bbed948-58ea-5b2d-a0cb-d26e8dbdaa53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "This spell can't be countered.\n{1}{G}, {T}: You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap Howlpack Piper. Activate only as a sorcery.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8815,7 +8815,7 @@
         },
         {
             "id": "c832bca2-a4a8-5313-b477-f772f84116cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/7/c7ceaf83-09c0-4492-a75d-4c47bd421858.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "Whenever this creature enters the battlefield or transforms into Wildsong Howler, look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8851,7 +8851,7 @@
         },
         {
             "id": "dd994999-af50-5a3a-a264-791611b5e2a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg?1",
             "name": "Infestation Expert // Infested Werewolf",
             "text": "Whenever Infestation Expert enters the battlefield or attacks, create a 1/1 green Insect creature token.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "90140ae8-3a0b-5eb9-baae-877f5b0b0ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0936761c-7cdc-49ef-8a0d-ed79219f1056.jpg?1",
             "name": "Infestation Expert // Infested Werewolf",
             "text": "Whenever Infested Werewolf enters the battlefield or attacks, create two 1/1 green Insect creature tokens.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -8920,7 +8920,7 @@
         },
         {
             "id": "1550f0fb-898e-5b37-a712-4893bff5dc5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141f7948-3140-40f2-95dd-ab6c79f2a821.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141f7948-3140-40f2-95dd-ab6c79f2a821.jpg?1",
             "name": "Laid to Rest",
             "text": "Whenever a Human you control dies, draw a card.\nWhenever a creature you control with a +1/+1 counter on it dies, you gain 2 life.",
             "colours": [
@@ -8952,7 +8952,7 @@
         },
         {
             "id": "b26c3968-8ef2-5d67-bbe2-e10b05932811",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd50b-4825-4d85-b0f9-e2a51d2a7df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5cd50b-4825-4d85-b0f9-e2a51d2a7df1.jpg?1",
             "name": "Massive Might",
             "text": "Target creature gets +2/+2 and gains trample until end of turn.",
             "colours": [
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "19baed50-2ba4-5e20-8739-132cfaa80b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ea27-63d1-4b80-beae-8e016373d004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5252ea27-63d1-4b80-beae-8e016373d004.jpg?1",
             "name": "Moldgraf Millipede",
             "text": "When Moldgraf Millipede enters the battlefield, mill three cards, then put a +1/+1 counter on Moldgraf Millipede for each creature card in your graveyard. (To mill a card, put the top card of your library into your graveyard.)",
             "colours": [
@@ -9019,7 +9019,7 @@
         },
         {
             "id": "818b734b-3945-5eec-abdc-8dcc451ec7e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950dd57e-b2e1-4a27-a212-86fbfdbf914d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/950dd57e-b2e1-4a27-a212-86fbfdbf914d.jpg?1",
             "name": "Mulch",
             "text": "Reveal the top four cards of your library. Put all land cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -9051,7 +9051,7 @@
         },
         {
             "id": "e85f838b-73dd-5cb4-a30b-4bb141d19c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d757af-86fd-4f99-a09a-0f3898ed95f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d757af-86fd-4f99-a09a-0f3898ed95f6.jpg?1",
             "name": "Nature's Embrace",
             "text": "Enchant creature or land\nAs long as enchanted permanent is a creature, it gets +2/+2.\nAs long as enchanted permanent is a land, it has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -9085,7 +9085,7 @@
         },
         {
             "id": "1f7357fb-a6c9-5843-82f4-49fff92a6039",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg?1",
             "name": "Oakshade Stalker // Moonlit Ambusher",
             "text": "You may cast this spell as though it had flash if you pay {2} more to cast it.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9121,7 +9121,7 @@
         },
         {
             "id": "3d152b12-ef5e-5d56-932c-131ee28444f2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8bcaa944-4e45-457c-be9c-07377b6ed08b.jpg?1",
             "name": "Oakshade Stalker // Moonlit Ambusher",
             "text": "Nightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9155,7 +9155,7 @@
         },
         {
             "id": "3162ecd0-58d0-58f1-8323-66ad231724cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43d9686-a5e4-413b-8a34-3430788dd1b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d43d9686-a5e4-413b-8a34-3430788dd1b9.jpg?1",
             "name": "Packsong Pup",
             "text": "At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1 counter on Packsong Pup.\nWhen Packsong Pup dies, you gain life equal to its power.",
             "colours": [
@@ -9189,7 +9189,7 @@
         },
         {
             "id": "dfe75531-ab21-5b00-9723-b52ff7cbfc1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10edf37a-ee35-491d-b83a-39035f7df65a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10edf37a-ee35-491d-b83a-39035f7df65a.jpg?1",
             "name": "Reclusive Taxidermist",
             "text": "Reclusive Taxidermist gets +3/+2 as long as there are four or more creature cards in your graveyard.\n{T}: Add one mana of any color.",
             "colours": [
@@ -9226,7 +9226,7 @@
         },
         {
             "id": "96468dd8-30b0-5bb8-8073-b7284fda0832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e997f78-22a2-4b66-ac10-1adc9a72ce3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e997f78-22a2-4b66-ac10-1adc9a72ce3b.jpg?1",
             "name": "Retrieve",
             "text": "Return up to one target creature card and up to one target noncreature permanent card from your graveyard to your hand. Exile Retrieve.",
             "colours": [
@@ -9258,7 +9258,7 @@
         },
         {
             "id": "970c975f-c86b-5c80-9880-35376302e8b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf35971-f1c4-4ccb-af5c-fd396391bb4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf35971-f1c4-4ccb-af5c-fd396391bb4b.jpg?1",
             "name": "Rural Recruit",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhen Rural Recruit enters the battlefield, create a 3/1 green Boar creature token.",
             "colours": [
@@ -9293,7 +9293,7 @@
         },
         {
             "id": "33c3c063-4165-55a8-8857-a8082792c470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225773f9-1843-4ee0-8564-8e4a5dfef775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225773f9-1843-4ee0-8564-8e4a5dfef775.jpg?1",
             "name": "Sawblade Slinger",
             "text": "When Sawblade Slinger enters the battlefield, choose up to one \u2014\n\u2022 Destroy target artifact an opponent controls.\n\u2022 Sawblade Slinger fights target Zombie an opponent controls.",
             "colours": [
@@ -9328,7 +9328,7 @@
         },
         {
             "id": "6431653f-0507-5d20-a43a-f7d7925682f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd4c2-0e9f-440c-8e4c-80db351a5eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915dd4c2-0e9f-440c-8e4c-80db351a5eba.jpg?1",
             "name": "Sheltering Boughs",
             "text": "Enchant creature\nWhen Sheltering Boughs enters the battlefield, draw a card.\nEnchanted creature gets +1/+3.",
             "colours": [
@@ -9362,7 +9362,7 @@
         },
         {
             "id": "c5b38839-3c61-5c8f-874d-55c809b090be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd271d7-a3c8-4448-b8e2-bcef5d7e9118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd271d7-a3c8-4448-b8e2-bcef5d7e9118.jpg?1",
             "name": "Snarling Wolf",
             "text": "{1}{G}: Snarling Wolf gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -9396,7 +9396,7 @@
         },
         {
             "id": "b83263c3-9a3a-5aa5-b2a9-98cf89f2f915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e95ec-b630-4492-be1d-f66aa19889e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241e95ec-b630-4492-be1d-f66aa19889e5.jpg?1",
             "name": "Spiked Ripsaw",
             "text": "Equipped creature gets +3/+3.\nWhenever equipped creature attacks, you may sacrifice a Forest. If you do, that creature gains trample until end of turn.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -9430,7 +9430,7 @@
         },
         {
             "id": "51f25f18-3e1a-52d5-b31b-3b690437521d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4ca85-4d2d-4d1e-86ca-aa25edfcda61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fad4ca85-4d2d-4d1e-86ca-aa25edfcda61.jpg?1",
             "name": "Splendid Reclamation",
             "text": "Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -9464,7 +9464,7 @@
         },
         {
             "id": "d5ccb8a8-3a20-53d4-930e-f23ebce0110e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628dbc4c-3640-44a9-8439-873103989409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/628dbc4c-3640-44a9-8439-873103989409.jpg?1",
             "name": "Spore Crawler",
             "text": "When Spore Crawler dies, draw a card.",
             "colours": [
@@ -9498,7 +9498,7 @@
         },
         {
             "id": "db74dbfb-37e3-5932-8295-6232d337c52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb04879-9348-4d4f-9a23-c82fd99d04c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fb04879-9348-4d4f-9a23-c82fd99d04c6.jpg?1",
             "name": "Sporeback Wolf",
             "text": "As long as it's your turn, Sporeback Wolf gets +0/+2.",
             "colours": [
@@ -9532,7 +9532,7 @@
         },
         {
             "id": "6aaeb0b6-21f3-5c61-99e6-590317b5073f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfca481-cf2d-435d-b4b6-07b1fe2a8e5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cfca481-cf2d-435d-b4b6-07b1fe2a8e5d.jpg?1",
             "name": "Toxic Scorpion",
             "text": "Deathtouch\nWhen Toxic Scorpion enters the battlefield, another target creature you control gains deathtouch until end of turn.",
             "colours": [
@@ -9566,7 +9566,7 @@
         },
         {
             "id": "44fd016f-d15e-5474-87db-95a1ee90ace8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\n{5}{G}{G}: Transform Ulvenwald Oddity.",
             "colours": [
@@ -9602,7 +9602,7 @@
         },
         {
             "id": "bdd375d9-25d2-521f-b786-02c6c96993b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\nOther creatures you control get +1/+1 and have trample and haste.",
             "colours": [
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "f8d22816-d97c-543f-9f93-fa022abf7468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg?1",
             "name": "Weaver of Blossoms // Blossom-Clad Werewolf",
             "text": "{T}: Add one mana of any color.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9674,7 +9674,7 @@
         },
         {
             "id": "1a176191-f3d7-569d-b2d5-1186ae046499",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/73bf2a0a-b97d-4b90-abd6-d1755734ea15.jpg?1",
             "name": "Weaver of Blossoms // Blossom-Clad Werewolf",
             "text": "{T}: Add two mana of any one color.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9708,7 +9708,7 @@
         },
         {
             "id": "c3b69e46-0755-5e42-a01e-4d69a63730d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d021207-76be-4bc9-bb71-df991a04d8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d021207-76be-4bc9-bb71-df991a04d8d8.jpg?1",
             "name": "Witch's Web",
             "text": "Target creature gets +3/+3 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -9740,7 +9740,7 @@
         },
         {
             "id": "fc6599bc-b222-5c3c-b36b-b33cdee3c8ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9cd00-7ffd-44e1-aa0f-c94489ff4a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e9cd00-7ffd-44e1-aa0f-c94489ff4a0f.jpg?1",
             "name": "Wolf Strike",
             "text": "Target creature you control gets +2/+0 until end of turn if it's night. Then it deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -9772,7 +9772,7 @@
         },
         {
             "id": "65fae7fe-fab7-59c9-abf4-fc4036693c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg?1",
             "name": "Wolfkin Outcast // Wedding Crasher",
             "text": "This spell costs {2} less to cast if you control a Wolf or Werewolf.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -9807,7 +9807,7 @@
         },
         {
             "id": "5ac82e55-ddc7-5bd1-926f-85378736add2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a743426-6333-4ca6-9207-163b325ba435.jpg?1",
             "name": "Wolfkin Outcast // Wedding Crasher",
             "text": "Whenever Wedding Crasher or another Wolf or Werewolf you control dies, draw a card.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "952af4aa-f3fa-5a89-99d8-82a1f4595fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22264087-bac4-4746-b6ce-0d44cce163e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22264087-bac4-4746-b6ce-0d44cce163e6.jpg?1",
             "name": "Ancient Lumberknot",
             "text": "Each creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -9877,7 +9877,7 @@
         },
         {
             "id": "55b3a42b-f56f-5c50-98b6-89a197280528",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfac4ab-97f1-448c-8554-42ed03eb5656.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfac4ab-97f1-448c-8554-42ed03eb5656.jpg?1",
             "name": "Anje, Maid of Dishonor",
             "text": "Whenever Anje, Maid of Dishonor and/or one or more other Vampires enter the battlefield under your control, create a Blood token. This ability triggers only once each turn. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{2}, Sacrifice another creature or a Blood token: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -9917,7 +9917,7 @@
         },
         {
             "id": "c22f1a85-9583-539b-8520-17acc9de1b2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0192cf7-3391-4720-b9c8-72dec5dde01e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0192cf7-3391-4720-b9c8-72dec5dde01e.jpg?1",
             "name": "Bloodtithe Harvester",
             "text": "When Bloodtithe Harvester enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\n{T}, Sacrifice Bloodtithe Harvester: Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.",
             "colours": [
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "37087751-cd5c-5ee0-8a7f-1d4d34af8422",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1",
             "name": "Brine Comber // Brinebound Gift",
             "text": "Whenever Brine Comber enters the battlefield or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nDisturb {W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -9991,7 +9991,7 @@
         },
         {
             "id": "0cdcfe6c-6cac-50c1-8db5-15d452115b42",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1",
             "name": "Brine Comber // Brinebound Gift",
             "text": "Enchant creature\nWhenever Brinebound Gift enters the battlefield or enchanted creature becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nIf Brinebound Gift would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -10027,7 +10027,7 @@
         },
         {
             "id": "2f2c79aa-6787-5a10-9678-48adf998db6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg?1",
             "name": "A-Brine Comber // A-Brinebound Gift",
             "text": "",
             "colours": [
@@ -10062,7 +10062,7 @@
         },
         {
             "id": "1f96a408-f0e2-5bcd-9839-ae98a82dac33",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/0/d0e03cdb-1082-448b-ae5c-501fb8bc3f3b.jpg?1",
             "name": "A-Brine Comber // A-Brinebound Gift",
             "text": "",
             "colours": [
@@ -10097,7 +10097,7 @@
         },
         {
             "id": "6e98a6dc-d955-5f25-a440-9cc3ac675142",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg?1",
             "name": "Child of the Pack // Savage Packmate",
             "text": "{2}{R}{G}: Create a 2/2 green Wolf creature token.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.)",
             "colours": [
@@ -10134,7 +10134,7 @@
         },
         {
             "id": "bcabc25f-9f4c-5128-8277-e0b17167f435",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/b/cb168e3c-2c78-4e70-a39b-06aa6a47998c.jpg?1",
             "name": "Child of the Pack // Savage Packmate",
             "text": "Trample\nOther creatures you control get +1/+0.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
             "colours": [
@@ -10170,7 +10170,7 @@
         },
         {
             "id": "e3427911-19b6-5cc5-ad0c-2b229ef5395c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Flying\nWhen Dorothea, Vengeful Victim attacks or blocks, sacrifice it at end of combat.\nDisturb {1}{W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
             "colours": [
@@ -10210,7 +10210,7 @@
         },
         {
             "id": "1bdb25c4-34ef-5145-be01-40e5ec13b2b8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c927707-abb5-4a9d-ac53-25df182d6e9b.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat.\"\nIf Dorothea's Retribution would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -10248,7 +10248,7 @@
         },
         {
             "id": "ea57a618-f931-5d14-83a7-c77a6ae9a153",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg?1",
             "name": "A-Dorothea, Vengeful Victim // A-Dorothea's Retribution",
             "text": "",
             "colours": [
@@ -10285,7 +10285,7 @@
         },
         {
             "id": "d254f73c-f13b-53e1-8a38-2df98913cc07",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/b/9b21d350-9b89-41d0-8def-00ef5189449c.jpg?1",
             "name": "A-Dorothea, Vengeful Victim // A-Dorothea's Retribution",
             "text": "",
             "colours": [
@@ -10320,7 +10320,7 @@
         },
         {
             "id": "c63aa2d2-7882-57da-8498-63ea294c91e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "Other Vampires you control get +1/+1.\nWhen Edgar, Charmed Groom dies, return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -10362,7 +10362,7 @@
         },
         {
             "id": "b37ee2b4-ab96-5aa9-b474-135e9a26da46",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/3/63ba8eef-b834-4031-b0a1-0f8505d53813.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "At the beginning of your upkeep, create a 1/1 white and black Vampire creature token with lifelink and put a bloodline counter on Edgar Markov's Coffin. Then if there are three or more bloodline counters on it, remove those counters and transform it.",
             "colours": [
@@ -10401,7 +10401,7 @@
         },
         {
             "id": "5ccc35ed-ca34-5ef2-8c2c-ccbb167701a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764077-df2d-4ac7-b507-2c8e08386d49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f764077-df2d-4ac7-b507-2c8e08386d49.jpg?1",
             "name": "Eruth, Tormented Prophet",
             "text": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
             "colours": [
@@ -10443,7 +10443,7 @@
         },
         {
             "id": "67386448-09e2-5714-8fde-2c7587b7e8bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaba76b-9cec-4c2b-b0eb-8f44201f6422.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaba76b-9cec-4c2b-b0eb-8f44201f6422.jpg?1",
             "name": "Grolnok, the Omnivore",
             "text": "Whenever a Frog you control attacks, mill three cards.\nWhenever a permanent card is put into your graveyard from your library, exile it with a croak counter on it.\nYou may play lands and cast spells from among cards you own in exile with croak counters on them.",
             "colours": [
@@ -10483,7 +10483,7 @@
         },
         {
             "id": "452ec549-794e-5100-923d-0e0f8287078b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608fa232-f5fe-4c58-9efe-fb780f454b19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/608fa232-f5fe-4c58-9efe-fb780f454b19.jpg?1",
             "name": "Halana and Alena, Partners",
             "text": "First strike, reach\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is Halana and Alena's power. That creature gains haste until end of turn.",
             "colours": [
@@ -10524,7 +10524,7 @@
         },
         {
             "id": "704756a0-a6b7-51d9-8de7-18acad07f3c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a208c-ee2b-4672-a43b-f4a708585b1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a98a208c-ee2b-4672-a43b-f4a708585b1a.jpg?1",
             "name": "Kaya, Geist Hunter",
             "text": "+1: Creatures you control gain deathtouch until end of turn. Put a +1/+1 counter on up to one target creature token you control.\n\u22122: Until end of turn, if one or more tokens would be created under your control, twice that many of those tokens are created instead.\n\u22126: Exile all cards from all graveyards, then create a 1/1 white Spirit creature token with flying for each card exiled this way.",
             "colours": [
@@ -10564,7 +10564,7 @@
         },
         {
             "id": "106117c2-52ae-5627-8a85-a033b8cea8b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95d34a-0b13-4533-9efc-08381c81e6cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb95d34a-0b13-4533-9efc-08381c81e6cd.jpg?1",
             "name": "Markov Purifier",
             "text": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay {2}. If you do, draw a card.",
             "colours": [
@@ -10603,7 +10603,7 @@
         },
         {
             "id": "a350d5a1-8e20-5833-b033-bbfc2ad12694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f45bc0-36ed-44ec-9bc8-31ea7c7fafdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2f45bc0-36ed-44ec-9bc8-31ea7c7fafdb.jpg?1",
             "name": "Markov Waltzer",
             "text": "Flying, haste\nAt the beginning of combat on your turn, up to two target creatures you control each get +1/+0 until end of turn.",
             "colours": [
@@ -10641,7 +10641,7 @@
         },
         {
             "id": "2e8bf7bd-75a9-509e-b03d-5b11404071ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a79f5f-a65a-4b43-b58c-cdfa09cc7855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a79f5f-a65a-4b43-b58c-cdfa09cc7855.jpg?1",
             "name": "Odric, Blood-Cursed",
             "text": "When Odric, Blood-Cursed enters the battlefield, create X Blood tokens, where X is the number of abilities from among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance found among creatures you control. (Count each ability only once.)",
             "colours": [
@@ -10682,7 +10682,7 @@
         },
         {
             "id": "352ecef4-837f-519e-8ca6-5b1c95c6e307",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b8023-2ef1-4b7b-9e48-4f774fee14e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625b8023-2ef1-4b7b-9e48-4f774fee14e0.jpg?1",
             "name": "Old Rutstein",
             "text": "When Old Rutstein enters the battlefield or at the beginning of your upkeep, mill a card. If a land card is milled this way, create a Treasure token. If a creature card is milled this way, create a 1/1 green Insect creature token. If a noncreature, nonland card is milled this way, create a Blood token.",
             "colours": [
@@ -10723,7 +10723,7 @@
         },
         {
             "id": "91153fb8-a021-5b44-b41b-4362b9af9290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301dacc9-ef92-4515-b907-a70d6c3fd73e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301dacc9-ef92-4515-b907-a70d6c3fd73e.jpg?1",
             "name": "Olivia, Crimson Bride",
             "text": "Flying, haste\nWhenever Olivia, Crimson Bride attacks, return target creature card from your graveyard to the battlefield tapped and attacking. It gains \"When you don't control a legendary Vampire, exile this creature.\"",
             "colours": [
@@ -10765,7 +10765,7 @@
         },
         {
             "id": "fdd66690-4700-564b-a569-4189ee585d4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhen Runo Stromkirk enters the battlefield, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo Stromkirk.",
             "colours": [
@@ -10807,7 +10807,7 @@
         },
         {
             "id": "b4fb1a2d-73aa-5aa0-8afa-ef8743eb705c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhenever Krothuss, Lord of the Deep attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
             "colours": [
@@ -10849,7 +10849,7 @@
         },
         {
             "id": "4d54f1c9-d5f7-58f0-a4e4-181603d98cf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34228fdd-e466-488e-84b2-4c595e758688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34228fdd-e466-488e-84b2-4c595e758688.jpg?1",
             "name": "Sigardian Paladin",
             "text": "As long as you've put one or more +1/+1 counters on a creature this turn, Sigardian Paladin has trample and lifelink.\n{1}{G}{W}: Target creature you control with a +1/+1 counter on it gains trample and lifelink until end of turn.",
             "colours": [
@@ -10886,7 +10886,7 @@
         },
         {
             "id": "cbb79b64-9b16-52bf-bf1d-e518166558cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220003ce-cf2e-4595-91f4-c3462407d293.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/220003ce-cf2e-4595-91f4-c3462407d293.jpg?1",
             "name": "A-Sigardian Paladin",
             "text": "",
             "colours": [
@@ -10922,7 +10922,7 @@
         },
         {
             "id": "dede4788-d6aa-5f8d-8818-37487674f903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268fd7e7-0105-4c39-a3ea-77ed32214ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/268fd7e7-0105-4c39-a3ea-77ed32214ff3.jpg?1",
             "name": "Skull Skaab",
             "text": "Exploit (When this creature enters the battlefield, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -10958,7 +10958,7 @@
         },
         {
             "id": "1bb0a9ca-0533-553d-9ba7-c7ab51b07b42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302dfa1-7302-4b3c-a894-b780b5474d8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7302dfa1-7302-4b3c-a894-b780b5474d8f.jpg?1",
             "name": "A-Skull Skaab",
             "text": "",
             "colours": [
@@ -10993,7 +10993,7 @@
         },
         {
             "id": "9440068d-09f4-5593-8fec-f3565a0167b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd111dc9-b8de-4e92-a63d-75a961b2db3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd111dc9-b8de-4e92-a63d-75a961b2db3b.jpg?1",
             "name": "Torens, Fist of the Angels",
             "text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
             "colours": [
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "e64b8341-3315-5eab-b20d-b1b3d2e14144",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad9ae64-6526-4747-9b0c-77d113f58c33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad9ae64-6526-4747-9b0c-77d113f58c33.jpg?1",
             "name": "Vilespawn Spider",
             "text": "Reach\nAt the beginning of your upkeep, mill a card. (Put the top card of your library into your graveyard.)\n{2}{G}{U}, {T}, Sacrifice Vilespawn Spider: Create a 1/1 green Insect creature token for each creature card in your graveyard. Activate only as a sorcery.",
             "colours": [
@@ -11071,7 +11071,7 @@
         },
         {
             "id": "d0a45a32-ac9a-5051-a12d-cc37588d3f94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a1096-6313-4245-be18-1588c219b842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9a1096-6313-4245-be18-1588c219b842.jpg?1",
             "name": "Wandering Mind",
             "text": "Flying\nWhen Wandering Mind enters the battlefield, look at the top six cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -11107,7 +11107,7 @@
         },
         {
             "id": "d416771c-1334-575c-b20f-92eb070155b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87845cc2-bf5d-491d-bfa2-b33b034557a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87845cc2-bf5d-491d-bfa2-b33b034557a4.jpg?1",
             "name": "Blood Servitor",
             "text": "When Blood Servitor enters the battlefield, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -11138,7 +11138,7 @@
         },
         {
             "id": "8d5dcadd-d8ac-5cb8-91ae-1196dbd9b799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02cf94c-94d3-4c4c-a7ae-b4d48ef5b14e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f02cf94c-94d3-4c4c-a7ae-b4d48ef5b14e.jpg?1",
             "name": "Boarded Window",
             "text": "Creatures attacking you get -1/-0.\nAt the beginning of each end step, if you were dealt 4 or more damage this turn, exile Boarded Window.",
             "colours": [],
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "90ac6fd9-1d9f-50e5-a5f6-5a175a9c8c2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccb4b1e-ef8f-4c5f-8b5b-6148455442f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ccb4b1e-ef8f-4c5f-8b5b-6148455442f7.jpg?1",
             "name": "Ceremonial Knife",
             "text": "Equipped creature gets +1/+0 and has \"Whenever this creature deals combat damage, create a Blood token.\" (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -11196,7 +11196,7 @@
         },
         {
             "id": "66b52eff-8cf5-5054-a4f0-c828fcca3cdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396abc9e-a738-430d-85cc-448ace2548f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/396abc9e-a738-430d-85cc-448ace2548f9.jpg?1",
             "name": "Dollhouse of Horrors",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a token that's a copy of the exiled card, except it's a 0/0 Construct artifact in addition to its other types and it has \"This creature gets +1/+1 for each Construct you control.\" It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -11226,7 +11226,7 @@
         },
         {
             "id": "22d2d2b0-3299-5d32-94f5-f88717e0c2c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1",
             "name": "Foreboding Statue // Forsaken Thresher",
             "text": "{T}: Add one mana of any color. Put an omen counter on Foreboding Statue.\nAt the beginning of your end step, if there are three or more omen counters on Foreboding Statue, untap it, then transform it.",
             "colours": [],
@@ -11257,7 +11257,7 @@
         },
         {
             "id": "ff0531ad-76ee-576b-993c-a460bf5cb307",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1",
             "name": "Foreboding Statue // Forsaken Thresher",
             "text": "At the beginning of your precombat main phase, add one mana of any color.",
             "colours": [],
@@ -11288,7 +11288,7 @@
         },
         {
             "id": "e2d366ce-a5af-5485-949a-88a0d37e9d5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3390e4d-9137-40ff-b998-bdb19c90b7d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3390e4d-9137-40ff-b998-bdb19c90b7d5.jpg?1",
             "name": "Honored Heirloom",
             "text": "{T}: Add one mana of any color.\n{2}, {T}: Exile target card from a graveyard.",
             "colours": [],
@@ -11316,7 +11316,7 @@
         },
         {
             "id": "10a4e7eb-5884-51b4-ad19-98e30d63e3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a606e5-7a90-4a89-b51a-7f4e68705f97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a606e5-7a90-4a89-b51a-7f4e68705f97.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -11349,7 +11349,7 @@
         },
         {
             "id": "5aae641c-323f-5cd1-b2b3-1928bccd2f68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2303f11-2c82-44d5-893a-8e71dece7746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2303f11-2c82-44d5-893a-8e71dece7746.jpg?1",
             "name": "Lantern of the Lost",
             "text": "When Lantern of the Lost enters the battlefield, exile target card from a graveyard.\n{1}, {T}, Exile Lantern of the Lost: Exile all cards from all graveyards, then draw a card.",
             "colours": [],
@@ -11377,7 +11377,7 @@
         },
         {
             "id": "1f458628-afd9-5384-94db-5dd8b859ec79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc22ff6-4081-47ce-bc8a-e063f5f4d044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddc22ff6-4081-47ce-bc8a-e063f5f4d044.jpg?1",
             "name": "Wedding Invitation",
             "text": "When Wedding Invitation enters the battlefield, draw a card.\n{T}, Sacrifice Wedding Invitation: Target creature can't be blocked this turn. If it's a Vampire, it also gains lifelink until end of turn.",
             "colours": [],
@@ -11405,7 +11405,7 @@
         },
         {
             "id": "133121cd-0e80-54b9-b6a8-bc36b7bb8120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5523659-98a8-4ae2-9ec7-d77e7352c374.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5523659-98a8-4ae2-9ec7-d77e7352c374.jpg?1",
             "name": "Deathcap Glade",
             "text": "Deathcap Glade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "936c3617-8070-5cc1-8bb0-2306a3203272",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb604455-c411-414d-a2ef-e7567ee86a4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb604455-c411-414d-a2ef-e7567ee86a4d.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "Dreamroot Cascade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -11471,7 +11471,7 @@
         },
         {
             "id": "57984d21-ccfe-58a9-a4be-d0f147cbf031",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80fe230-745d-42ae-a1f5-a8cc950783d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e80fe230-745d-42ae-a1f5-a8cc950783d0.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -11499,7 +11499,7 @@
         },
         {
             "id": "818f2a99-e932-5b0f-a1e2-71b5824714e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad44c9aa-eb8f-4200-8dfe-2af728d80083.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad44c9aa-eb8f-4200-8dfe-2af728d80083.jpg?1",
             "name": "Shattered Sanctum",
             "text": "Shattered Sanctum enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -11532,7 +11532,7 @@
         },
         {
             "id": "b196578a-9cde-527b-9644-6669ba33666a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1dee-b3d7-472b-aa0b-2f9b46a96da5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299f1dee-b3d7-472b-aa0b-2f9b46a96da5.jpg?1",
             "name": "Stormcarved Coast",
             "text": "Stormcarved Coast enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -11565,7 +11565,7 @@
         },
         {
             "id": "b8e239ec-1de4-5dd5-a9dd-25205ff8ddf9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3fddd7-ede4-41c7-a645-a6af298a3d35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f3fddd7-ede4-41c7-a645-a6af298a3d35.jpg?1",
             "name": "Sundown Pass",
             "text": "Sundown Pass enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "23df94c4-ae72-5f0f-bc7a-a450bb55b08f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2577e5fd-903a-44ce-989a-d53d56511ad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2577e5fd-903a-44ce-989a-d53d56511ad3.jpg?1",
             "name": "Voldaren Estate",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card.\")",
             "colours": [],
@@ -11629,7 +11629,7 @@
         },
         {
             "id": "e16e3fb9-90d1-5c27-928d-86327b9ade5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabdaa1-6227-48e4-82d5-63a1771320b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deabdaa1-6227-48e4-82d5-63a1771320b2.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11667,7 +11667,7 @@
         },
         {
             "id": "fb839df4-8322-5cc3-88f4-4af553ffeaf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b069f97-735a-4d85-8504-b5a863bd659b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b069f97-735a-4d85-8504-b5a863bd659b.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11705,7 +11705,7 @@
         },
         {
             "id": "2c5b1ab7-eed5-5d00-86ae-6d337c8cf1e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ddd3aa-593c-4adb-b591-33c15d02131c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54ddd3aa-593c-4adb-b591-33c15d02131c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11743,7 +11743,7 @@
         },
         {
             "id": "93c0f594-ddb5-5074-aa9f-d503f371e222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54591ec7-94a1-470c-927a-788b6a514444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54591ec7-94a1-470c-927a-788b6a514444.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11781,7 +11781,7 @@
         },
         {
             "id": "f8b44690-c734-50e6-913e-70f259c1692f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abfe418-15f8-46ce-9b39-fd5a38b25d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abfe418-15f8-46ce-9b39-fd5a38b25d12.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11819,7 +11819,7 @@
         },
         {
             "id": "348e609b-c281-5904-bcab-0382db8d738e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55a405-bf5b-4158-ba9a-239627ac9701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e55a405-bf5b-4158-ba9a-239627ac9701.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11857,7 +11857,7 @@
         },
         {
             "id": "c689a37a-09b2-51dd-9e83-0753057a85e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4448b6-0dbe-427c-b145-8ac915fc0dfc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4448b6-0dbe-427c-b145-8ac915fc0dfc.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11895,7 +11895,7 @@
         },
         {
             "id": "fc857222-27c3-5a92-ad80-0fb9bc11c5c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f72e53-52bb-4cf4-9b8b-34ed0c5f7c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f72e53-52bb-4cf4-9b8b-34ed0c5f7c3c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11933,7 +11933,7 @@
         },
         {
             "id": "b60bb2b8-c393-5ef7-be3b-bd9b671fdaa3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c83b60-3d49-4fdc-a6b7-06d1a0c4a126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c83b60-3d49-4fdc-a6b7-06d1a0c4a126.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11971,7 +11971,7 @@
         },
         {
             "id": "fb9495c4-3db2-5642-9098-79bb4dcdeffe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8760175-e9bb-4ef9-87ca-591d1edd5163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8760175-e9bb-4ef9-87ca-591d1edd5163.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -12009,7 +12009,7 @@
         },
         {
             "id": "1ad90d63-7713-50bf-b415-441c3be54aa0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112394a6-7819-43b4-adad-f6900aff2936.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112394a6-7819-43b4-adad-f6900aff2936.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -12049,7 +12049,7 @@
         },
         {
             "id": "484d9c02-f7e0-5bd0-930d-1bca26f74b5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7129a358-4628-4426-ae3b-e3d9288a6355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/7129a358-4628-4426-ae3b-e3d9288a6355.jpg?1",
             "name": "Chandra, Dressed to Kill",
             "text": "+1: Add {R}. Chandra, Dressed to Kill deals 1 damage to up to one target player or planeswalker.\n+1: Exile the top card of your library. If it's red, you may cast it this turn.\n\u22127: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"",
             "colours": [
@@ -12087,7 +12087,7 @@
         },
         {
             "id": "9faaf785-17cb-550c-a26e-cae9b2196137",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86c212a-180d-4fd5-94d0-c0c946683f00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e86c212a-180d-4fd5-94d0-c0c946683f00.jpg?1",
             "name": "Kaya, Geist Hunter",
             "text": "+1: Creatures you control gain deathtouch until end of turn. Put a +1/+1 counter on up to one target creature token you control.\n\u22122: Until end of turn, if one or more tokens would be created under your control, twice that many of those tokens are created instead.\n\u22126: Exile all cards from all graveyards, then create a 1/1 white Spirit creature token with flying for each card exiled this way.",
             "colours": [
@@ -12127,7 +12127,7 @@
         },
         {
             "id": "21d1e73a-6ec8-5035-a18f-036bd5a8f583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619474c0-2978-4152-9943-292707d99fb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/619474c0-2978-4152-9943-292707d99fb3.jpg?1",
             "name": "Deathcap Glade",
             "text": "Deathcap Glade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {B} or {G}.",
             "colours": [],
@@ -12160,7 +12160,7 @@
         },
         {
             "id": "e1cc31bd-38c8-5895-9474-251d32257b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2997c3b1-0255-41be-9189-03da53838f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2997c3b1-0255-41be-9189-03da53838f63.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "Dreamroot Cascade enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -12193,7 +12193,7 @@
         },
         {
             "id": "8f4d203b-1a51-5e75-aaef-aea05a69a7fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9885da74-30bd-461d-98ca-0dc72d817dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9885da74-30bd-461d-98ca-0dc72d817dbd.jpg?1",
             "name": "Shattered Sanctum",
             "text": "Shattered Sanctum enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -12226,7 +12226,7 @@
         },
         {
             "id": "bd4f754d-5a13-5fd0-b3bf-4075de170e36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e589848-2c25-43e8-a940-7769f7936815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e589848-2c25-43e8-a940-7769f7936815.jpg?1",
             "name": "Stormcarved Coast",
             "text": "Stormcarved Coast enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {U} or {R}.",
             "colours": [],
@@ -12259,7 +12259,7 @@
         },
         {
             "id": "87231134-2a0d-56bc-b298-e8dce04c5dc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e7d34-f250-4a61-a95b-75450d134eec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e7d34-f250-4a61-a95b-75450d134eec.jpg?1",
             "name": "Sundown Pass",
             "text": "Sundown Pass enters the battlefield tapped unless you control two or more other lands.\n{T}: Add {R} or {W}.",
             "colours": [],
@@ -12292,7 +12292,7 @@
         },
         {
             "id": "ff990e4e-49c6-5634-afc2-79f5850205ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722b6cc7-16f2-43cd-bac6-42f5e7962d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/722b6cc7-16f2-43cd-bac6-42f5e7962d99.jpg?1",
             "name": "Unholy Officiant",
             "text": "Vigilance\n{4}{W}: Put a +1/+1 counter on Unholy Officiant.",
             "colours": [
@@ -12329,7 +12329,7 @@
         },
         {
             "id": "4f83e3eb-a7d9-5538-bf3a-1f840e374002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd60ee8d-fb50-41df-89a8-aed5a53d755f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd60ee8d-fb50-41df-89a8-aed5a53d755f.jpg?1",
             "name": "Welcoming Vampire",
             "text": "Flying\nWhenever one or more other creatures with power 2 or less enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -12365,7 +12365,7 @@
         },
         {
             "id": "cfdf065a-49b9-5b61-a4ba-ec1cb6868b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df22639-7e98-43a1-801e-cbf882558c53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df22639-7e98-43a1-801e-cbf882558c53.jpg?1",
             "name": "Bloodcrazed Socialite",
             "text": "Menace\nWhen Bloodcrazed Socialite enters the battlefield, create a Blood token.\nWhenever Bloodcrazed Socialite attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.",
             "colours": [
@@ -12401,7 +12401,7 @@
         },
         {
             "id": "15cc7f06-9268-5a93-ad85-7c16fd7c5637",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "{1}{B}, Discard a card: Bloodsworn Squire gains indestructible until end of turn. Tap it. Then if there are four or more creature cards in your graveyard, transform Bloodsworn Squire.",
             "colours": [
@@ -12438,7 +12438,7 @@
         },
         {
             "id": "3f3cec04-1f92-5cd9-af78-e913c19ff5d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/0/50ea34d6-e690-4087-baf0-0b7a88739760.jpg?1",
             "name": "Bloodsworn Squire // Bloodsworn Knight",
             "text": "Bloodsworn Knight's power and toughness are each equal to the number of creature cards in your graveyard.\n{1}{B}, Discard a card: Bloodsworn Knight gains indestructible until end of turn. Tap it.",
             "colours": [
@@ -12475,7 +12475,7 @@
         },
         {
             "id": "84736eb4-e66c-5a3a-942a-af8f349abd09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e1e62-9862-4e14-b6fd-071f025cb867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c22e1e62-9862-4e14-b6fd-071f025cb867.jpg?1",
             "name": "Bloodvial Purveyor",
             "text": "Flying, trample\nWhenever an opponent casts a spell, that player creates a Blood token.\nWhenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.",
             "colours": [
@@ -12511,7 +12511,7 @@
         },
         {
             "id": "ee6f8412-2871-5eef-8ce9-107dee84b1c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a99150a-4ab0-4cac-8c25-eece703f8d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a99150a-4ab0-4cac-8c25-eece703f8d58.jpg?1",
             "name": "Falkenrath Forebear",
             "text": "Flying\nFalkenrath Forebear can't block.\nWhenever Falkenrath Forebear deals combat damage to a player, create a Blood token.\n{B}, Sacrifice two Blood tokens: Return Falkenrath Forebear from your graveyard to the battlefield.",
             "colours": [
@@ -12548,7 +12548,7 @@
         },
         {
             "id": "2c077d2b-2a09-5f91-af83-cbee00263872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6abfce-ffe0-4506-89f9-41c2820b188f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d6abfce-ffe0-4506-89f9-41c2820b188f.jpg?1",
             "name": "Gluttonous Guest",
             "text": "When Gluttonous Guest enters the battlefield, create a Blood token.\nWhenever you sacrifice a Blood token, you gain 1 life.",
             "colours": [
@@ -12584,7 +12584,7 @@
         },
         {
             "id": "d8b431d0-7574-5fd5-bb26-cdd7aaa6614c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen \u2014\n\u2022 Each player sacrifices a creature.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Transform Henrika Domnathi.",
             "colours": [
@@ -12623,7 +12623,7 @@
         },
         {
             "id": "4300fc34-0c2c-52d4-9852-a66ad482c948",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/4/4457ff96-a65d-4e9f-bb99-ac5226446263.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying, deathtouch, lifelink\n{1}{B}{B}: Each creature you control with flying, deathtouch, and/or lifelink gets +1/+0 until end of turn.",
             "colours": [
@@ -12662,7 +12662,7 @@
         },
         {
             "id": "97651114-3e16-5eea-ad20-5161f20eaedf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "At the beginning of your upkeep, any opponent may sacrifice a creature. If no one does, transform Innocent Traveler.",
             "colours": [
@@ -12699,7 +12699,7 @@
         },
         {
             "id": "80dbd4ff-833c-547b-8c0a-21019a750923",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/49691eb6-a6a4-4171-ae34-d43b44eb2ac6.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "Flying\nMalicious Invader gets +2/+0 as long as an opponent controls a Human.",
             "colours": [
@@ -12736,7 +12736,7 @@
         },
         {
             "id": "13eefcb1-327a-5e5e-b88e-31357d353edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token.\nSacrifice two Blood tokens: Transform Restless Bloodseeker. Activate only as a sorcery.",
             "colours": [
@@ -12772,7 +12772,7 @@
         },
         {
             "id": "1be26724-e3e4-5d2c-b0e0-49f6f62a5ed3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c05a85ef-5ac0-4bd1-8ef1-de2ff84e448d.jpg?1",
             "name": "Restless Bloodseeker // Bloodsoaked Reveler",
             "text": "At the beginning of your end step, if you gained life this turn, create a Blood token.\n{4}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -12808,7 +12808,7 @@
         },
         {
             "id": "d63b0080-6db0-57e0-9c1f-b10351c01e69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c491af90-b224-4795-adb4-d7ea4c8464ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c491af90-b224-4795-adb4-d7ea4c8464ce.jpg?1",
             "name": "Skulking Killer",
             "text": "When Skulking Killer enters the battlefield, target creature an opponent controls gets -2/-2 until end of turn if that opponent controls no other creatures.",
             "colours": [
@@ -12845,7 +12845,7 @@
         },
         {
             "id": "a2afd3c1-bb5d-5365-a0e7-524f56e31258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51089813-8ad5-4ee0-af75-cfba870b675c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51089813-8ad5-4ee0-af75-cfba870b675c.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -12885,7 +12885,7 @@
         },
         {
             "id": "79f546ad-9452-5880-b095-9496480a9561",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token.\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.",
             "colours": [
@@ -12923,7 +12923,7 @@
         },
         {
             "id": "b2cd6db0-34b7-561d-9736-7b5d783c9d06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/995a53e1-61ca-4635-96b0-c6f52c46da04.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
             "colours": [
@@ -12961,7 +12961,7 @@
         },
         {
             "id": "8f1e1ddd-5e33-53ab-82ea-60af16ca409b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b1a617-96bf-4960-bffe-dddf3a3c1868.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b1a617-96bf-4960-bffe-dddf3a3c1868.jpg?1",
             "name": "Wedding Security",
             "text": "Whenever Wedding Security attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter on Wedding Security and draw a card.",
             "colours": [
@@ -12998,7 +12998,7 @@
         },
         {
             "id": "ebe14f13-8b52-5e82-be80-0cd8b88c5ffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "When you attack with exactly two creatures, transform Alluring Suitor.",
             "colours": [
@@ -13034,7 +13034,7 @@
         },
         {
             "id": "5a46d2f6-b2a5-5831-8e0f-f08ee41840f5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/0/8075878b-b673-4d0c-b335-8a37295cd8d8.jpg?1",
             "name": "Alluring Suitor // Deadly Dancer",
             "text": "Trample\nWhen this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't lose this mana as steps and phases end.\n{R}{R}: Deadly Dancer and another target creature each get +1/+0 until end of turn.",
             "colours": [
@@ -13070,7 +13070,7 @@
         },
         {
             "id": "de39a6bb-db84-517b-9763-d409d1a2148e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924b1c15-811a-4d11-a481-f904002a6740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/924b1c15-811a-4d11-a481-f904002a6740.jpg?1",
             "name": "Belligerent Guest",
             "text": "Trample\nWhenever Belligerent Guest deals combat damage to a player, create a Blood token.",
             "colours": [
@@ -13106,7 +13106,7 @@
         },
         {
             "id": "941e05b3-c8f3-5734-80f0-10f20e361660",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a5fafe-951f-44c5-8de9-7d2261525c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7a5fafe-951f-44c5-8de9-7d2261525c05.jpg?1",
             "name": "Blood Hypnotist",
             "text": "Blood Hypnotist can't block.\nWhenever you sacrifice one or more Blood tokens, target creature can't block this turn. This ability triggers only once each turn.",
             "colours": [
@@ -13142,7 +13142,7 @@
         },
         {
             "id": "21cd6820-cc15-5df9-8366-61091582d1d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592609d-48f5-4762-b95c-b2eaa2ea4d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4592609d-48f5-4762-b95c-b2eaa2ea4d51.jpg?1",
             "name": "Blood Petal Celebrant",
             "text": "Blood Petal Celebrant has first strike as long as it's attacking.\nWhen Blood Petal Celebrant dies, create a Blood token.",
             "colours": [
@@ -13178,7 +13178,7 @@
         },
         {
             "id": "93996e31-8379-5920-a2e4-d87a8e6b7bf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63141c56-f0dd-4bb3-808d-6b7031253cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63141c56-f0dd-4bb3-808d-6b7031253cad.jpg?1",
             "name": "Cemetery Gatekeeper",
             "text": "First strike\nWhen Cemetery Gatekeeper enters the battlefield, exile a card from a graveyard.\nWhenever a player plays a land or casts a spell, if it shares a card type with the exiled card, Cemetery Gatekeeper deals 2 damage to that player.",
             "colours": [
@@ -13214,7 +13214,7 @@
         },
         {
             "id": "717d62eb-661c-534f-ac86-1ab16d38acb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213112df-439b-454e-ade4-90e4176411c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/213112df-439b-454e-ade4-90e4176411c5.jpg?1",
             "name": "Dominating Vampire",
             "text": "When Dominating Vampire enters the battlefield, gain control of target creature with mana value less than or equal to the number of Vampires you control until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -13251,7 +13251,7 @@
         },
         {
             "id": "81a77ee7-1ea7-54b9-ad32-2c71adcffdd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aacc8fa-9440-494b-a3d9-7b1678c5a9f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6aacc8fa-9440-494b-a3d9-7b1678c5a9f6.jpg?1",
             "name": "Falkenrath Celebrants",
             "text": "Menace\nWhen Falkenrath Celebrants enters the battlefield, create two Blood tokens.",
             "colours": [
@@ -13287,7 +13287,7 @@
         },
         {
             "id": "1aff0233-7bc0-5011-90bc-61cdebe091b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b68fbf-7fc7-4fd5-9bdf-f3ef846d4c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25b68fbf-7fc7-4fd5-9bdf-f3ef846d4c22.jpg?1",
             "name": "Olivia's Attendants",
             "text": "Menace\nWhenever Olivia's Attendants deals damage, create that many Blood tokens.\n{2}{R}: Olivia's Attendants deals 1 damage to any target.",
             "colours": [
@@ -13323,7 +13323,7 @@
         },
         {
             "id": "1897deef-cd1e-5cf1-a273-e8d248b4dfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feda6bb3-ee22-489c-bcfd-52ef04841024.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feda6bb3-ee22-489c-bcfd-52ef04841024.jpg?1",
             "name": "Voldaren Epicure",
             "text": "When Voldaren Epicure enters the battlefield, it deals 1 damage to each opponent. Create a Blood token.",
             "colours": [
@@ -13359,7 +13359,7 @@
         },
         {
             "id": "1af69051-3251-5faa-9bc9-0720f597a9c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dd1ee6-a9da-4c89-a3b8-b293ac28467f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4dd1ee6-a9da-4c89-a3b8-b293ac28467f.jpg?1",
             "name": "Anje, Maid of Dishonor",
             "text": "Whenever Anje, Maid of Dishonor and/or one or more other Vampires enter the battlefield under your control, create a Blood token. This ability triggers only once each turn.\n{2}, Sacrifice another creature or a Blood token: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -13399,7 +13399,7 @@
         },
         {
             "id": "e7b2d8f5-1204-5e49-b800-33d67f1ba0cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01182501-2b50-4b87-835a-fea3c5e6e330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01182501-2b50-4b87-835a-fea3c5e6e330.jpg?1",
             "name": "Bloodtithe Harvester",
             "text": "When Bloodtithe Harvester enters the battlefield, create a Blood token.\n{T}, Sacrifice Bloodtithe Harvester: Target creature gets -X/-X until end of turn, where X is twice the number of Blood tokens you control. Activate only as a sorcery.",
             "colours": [
@@ -13437,7 +13437,7 @@
         },
         {
             "id": "daf26d55-b1a4-5576-83c9-7da3a5717a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "Other Vampires you control get +1/+1.\nWhen Edgar, Charmed Groom dies, return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -13479,7 +13479,7 @@
         },
         {
             "id": "7534be9b-15c3-5805-bb78-a78cf90b735e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7abf10e9-6f06-4424-b156-dd03e4d3e4f6.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "At the beginning of your upkeep, create a 1/1 white and black Vampire creature token with lifelink and put a bloodline counter on Edgar Markov's Coffin. Then if there are three or more bloodline counters on it, remove those counters and transform it.",
             "colours": [
@@ -13518,7 +13518,7 @@
         },
         {
             "id": "ee0f5b0c-a7c1-51a4-8716-74a9b314cc7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533673f3-5e18-4630-bd71-001774d698a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533673f3-5e18-4630-bd71-001774d698a8.jpg?1",
             "name": "Markov Purifier",
             "text": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay {2}. If you do, draw a card.",
             "colours": [
@@ -13557,7 +13557,7 @@
         },
         {
             "id": "d49dcfee-8b89-5490-bcf3-64c6b91ed76f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd545edd-699a-4ee9-8d8e-1e875cf4f2af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd545edd-699a-4ee9-8d8e-1e875cf4f2af.jpg?1",
             "name": "Markov Waltzer",
             "text": "Flying, haste\nAt the beginning of combat on your turn, up to two target creatures you control each get +1/+0 until end of turn.",
             "colours": [
@@ -13595,7 +13595,7 @@
         },
         {
             "id": "4d598151-676b-5214-b1d1-943f1e956f78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8335a9-2880-4e12-8d93-b75a297272dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e8335a9-2880-4e12-8d93-b75a297272dc.jpg?1",
             "name": "Odric, Blood-Cursed",
             "text": "When Odric, Blood-Cursed enters the battlefield, create X Blood tokens, where X is the number of abilities from among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance found among creatures you control. (Count each ability only once.)",
             "colours": [
@@ -13636,7 +13636,7 @@
         },
         {
             "id": "aa33985d-3379-50ec-b905-116aaeaa91f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7964ed78-c0c2-4555-bc25-b0eac14d0b34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7964ed78-c0c2-4555-bc25-b0eac14d0b34.jpg?1",
             "name": "Olivia, Crimson Bride",
             "text": "Flying, haste\nWhenever Olivia, Crimson Bride attacks, return target creature card from your graveyard to the battlefield tapped and attacking. It gains \"When you don't control a legendary Vampire, exile this creature.\"",
             "colours": [
@@ -13678,7 +13678,7 @@
         },
         {
             "id": "9921e75c-6b47-5620-81e1-b30449e93d9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhen Runo Stromkirk enters the battlefield, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo Stromkirk.",
             "colours": [
@@ -13720,7 +13720,7 @@
         },
         {
             "id": "c22c43cb-00ee-529b-bf38-d4c9ad10afed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/2/12c50b51-776c-472b-bda3-f7b82eebe2f4.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhenever Krothuss, Lord of the Deep attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
             "colours": [
@@ -13762,7 +13762,7 @@
         },
         {
             "id": "c2a95d60-9dfb-5714-9ea6-3dbaa9c8662f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Flying, lifelink, protection from Vampires\nKatilda, Dawnhart Martyr's power and toughness are each equal to the number of permanents you control that are Spirits and/or enchantments.\nDisturb {3}{W}{W}",
             "colours": [
@@ -13801,7 +13801,7 @@
         },
         {
             "id": "6221d122-1fb9-5ec9-8860-972f4626544e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/6/866828f0-71f7-454b-93a7-2f2ea707f53d.jpg?1",
             "name": "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
             "text": "Enchant creature\nEnchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, where X is the number of permanents you control that are Spirits and/or enchantments.\nIf Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -13839,7 +13839,7 @@
         },
         {
             "id": "28a78ede-a937-57c9-98be-e604b6686f8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7cbfc-e655-4f82-8bde-fbc95461361e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4c7cbfc-e655-4f82-8bde-fbc95461361e.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -13879,7 +13879,7 @@
         },
         {
             "id": "bd8bf43c-646d-5095-8247-b61b9541fd52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d474-5620-4c5f-95a4-8a128825df83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c5d474-5620-4c5f-95a4-8a128825df83.jpg?1",
             "name": "Geralf, Visionary Stitcher",
             "text": "Zombies you control have flying.\n{U}, {T}, Sacrifice another nontoken creature: Create an X/X blue Zombie creature token, where X is the sacrificed creature's toughness.",
             "colours": [
@@ -13918,7 +13918,7 @@
         },
         {
             "id": "98ce28b2-0189-59cd-bb09-3ce45c32b78f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "{T}: Draw a card, then exile a card from your hand face down. You may look at that card for as long as it remains exiled. You may pay {4}{U}{U}. If you do, transform Jacob Hauken, Inspector.",
             "colours": [
@@ -13958,7 +13958,7 @@
         },
         {
             "id": "83638ea8-ad03-52a9-95ec-22222ad372d7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/31acfd80-38c2-413a-b6bf-3325b342f045.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "At the beginning of your upkeep, exile the top card of your library face down. You may look at that card for as long as it remains exiled.\nOnce during each of your turns, you may play a land or cast a spell from among the cards exiled with this permanent without paying its mana cost.",
             "colours": [
@@ -13995,7 +13995,7 @@
         },
         {
             "id": "43b3b820-fdf9-539a-a864-3a7cc3e0e994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78808d46-a3a7-4598-bddf-a302977808fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78808d46-a3a7-4598-bddf-a302977808fb.jpg?1",
             "name": "Toxrill, the Corrosive",
             "text": "At the beginning of each end step, put a slime counter on each creature you don't control.\nCreatures you don't control get -1/-1 for each slime counter on them.\nWhenever a creature you don't control with a slime counter on it dies, create a 1/1 black Slug creature token.\n{U}{B}, Sacrifice a Slug: Draw a card.",
             "colours": [
@@ -14035,7 +14035,7 @@
         },
         {
             "id": "d0470c18-986f-5934-89d2-51eb4982941a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Flying\nWhen Dorothea, Vengeful Victim attacks or blocks, sacrifice it at end of combat.\nDisturb {1}{W}{U}",
             "colours": [
@@ -14075,7 +14075,7 @@
         },
         {
             "id": "64d86c8b-2e9b-5d93-a076-2bf245a3f0a6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff66ee02-6b68-405e-a5c0-f59bb8020865.jpg?1",
             "name": "Dorothea, Vengeful Victim // Dorothea's Retribution",
             "text": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, create a 4/4 white Spirit creature token with flying that's tapped and attacking. Sacrifice that token at end of combat.\"\nIf Dorothea's Retribution would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -14113,7 +14113,7 @@
         },
         {
             "id": "e980d553-1710-5482-a6e3-409ed546de24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2481acb-9738-4069-b772-99fdbacc3857.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2481acb-9738-4069-b772-99fdbacc3857.jpg?1",
             "name": "Eruth, Tormented Prophet",
             "text": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
             "colours": [
@@ -14155,7 +14155,7 @@
         },
         {
             "id": "16cebdd2-ff4f-5d24-875f-ca9f5017133a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51e8d9-a837-4b53-8943-220c0e1d4c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b51e8d9-a837-4b53-8943-220c0e1d4c3c.jpg?1",
             "name": "Grolnok, the Omnivore",
             "text": "Whenever a Frog you control attacks, mill three cards.\nWhenever a permanent card is put into your graveyard from your library, exile it with a croak counter on it.\nYou may play lands and cast spells from among cards you own in exile with croak counters on them.",
             "colours": [
@@ -14195,7 +14195,7 @@
         },
         {
             "id": "20b42d7c-78b4-5ee4-8e7c-59885861e6bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87684bef-8ef9-4709-a50e-fa5ff2f67acc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87684bef-8ef9-4709-a50e-fa5ff2f67acc.jpg?1",
             "name": "Halana and Alena, Partners",
             "text": "First strike, reach\nAt the beginning of combat on your turn, put X +1/+1 counters on another target creature you control, where X is Halana and Alena's power. That creature gains haste until end of turn.",
             "colours": [
@@ -14236,7 +14236,7 @@
         },
         {
             "id": "4d6fc84f-0ade-5dcb-9d57-1ea119bc39f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90930e16-4a77-4ce6-bab4-e099184d1b54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90930e16-4a77-4ce6-bab4-e099184d1b54.jpg?1",
             "name": "Old Rutstein",
             "text": "When Old Rutstein enters the battlefield or at the beginning of your upkeep, mill a card. If a land card is milled this way, create a Treasure token. If a creature card is milled this way, create a 1/1 green Insect creature token. If a noncreature, nonland card is milled this way, create a Blood token.",
             "colours": [
@@ -14277,7 +14277,7 @@
         },
         {
             "id": "00bd4df8-ff81-52a2-bdb7-a5e104eca541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhen Runo Stromkirk enters the battlefield, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo Stromkirk.",
             "colours": [
@@ -14319,7 +14319,7 @@
         },
         {
             "id": "0b199ffa-90e3-5e65-8f71-c1c42e3b4038",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/7/17171779-e5d2-4431-a92d-def5606e9825.jpg?1",
             "name": "Runo Stromkirk // Krothuss, Lord of the Deep",
             "text": "Flying\nWhenever Krothuss, Lord of the Deep attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
             "colours": [
@@ -14361,7 +14361,7 @@
         },
         {
             "id": "ba8cfcd9-77c4-5b67-a1ea-23f0a03a4e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8fa32-f5fb-441a-8c53-28cd44723672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d8fa32-f5fb-441a-8c53-28cd44723672.jpg?1",
             "name": "Torens, Fist of the Angels",
             "text": "Training\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
             "colours": [
@@ -14403,7 +14403,7 @@
         },
         {
             "id": "b90a5274-07f5-5268-9435-ffdb5e36dee4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cb7bbb-9216-43b7-abd8-387f6c7864e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0cb7bbb-9216-43b7-abd8-387f6c7864e6.jpg?1",
             "name": "Circle of Confinement",
             "text": "When Circle of Confinement enters the battlefield, exile target creature an opponent controls with mana value 3 or less until Circle of Confinement leaves the battlefield.\nWhenever an opponent casts a Vampire spell with the same name as a card exiled with Circle of Confinement, you gain 2 life.",
             "colours": [
@@ -14437,7 +14437,7 @@
         },
         {
             "id": "ccd21ae8-ca0b-529c-8dd4-006e4834b09c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2d232-484c-4ec2-814b-e1018277a1ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a2d232-484c-4ec2-814b-e1018277a1ff.jpg?1",
             "name": "Savior of Ollenbock",
             "text": "Training\nWhenever Savior of Ollenbock trains, exile up to one other target creature from the battlefield or creature card from a graveyard.\nWhen Savior of Ollenbock leaves the battlefield, put the exiled cards onto the battlefield under their owners' control.",
             "colours": [
@@ -14475,7 +14475,7 @@
         },
         {
             "id": "5d36fe9d-6ce1-5d7c-8f15-c0d3968ee4cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1830002a-b512-4e51-b3fa-0137d2b4c749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/1830002a-b512-4e51-b3fa-0137d2b4c749.jpg?1",
             "name": "Thalia, Guardian of Thraben",
             "text": "First strike\nNoncreature spells cost {1} more to cast.",
             "colours": [
@@ -14515,7 +14515,7 @@
         },
         {
             "id": "624bdbbd-f73e-5e13-ae98-a7d1064ecb13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "{T}: Draw a card, then exile a card from your hand face down. You may look at that card for as long as it remains exiled. You may pay {4}{U}{U}. If you do, transform Jacob Hauken, Inspector.",
             "colours": [
@@ -14555,7 +14555,7 @@
         },
         {
             "id": "e6b11575-ba94-552a-a6ee-051294080edd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f0004e-ee4c-4372-be5d-a5102f45210e.jpg?1",
             "name": "Jacob Hauken, Inspector // Hauken's Insight",
             "text": "At the beginning of your upkeep, exile the top card of your library face down. You may look at that card for as long as it remains exiled.\nOnce during each of your turns, you may play a land or cast a spell from among the cards exiled with this permanent without paying its mana cost.",
             "colours": [
@@ -14592,7 +14592,7 @@
         },
         {
             "id": "54a94fc6-7197-5f1f-8fec-62e11d441c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ed095e-6b77-4262-a2fa-d04dde96f9e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1ed095e-6b77-4262-a2fa-d04dde96f9e4.jpg?1",
             "name": "Thirst for Discovery",
             "text": "Draw three cards. Then discard two cards unless you discard a basic land card.",
             "colours": [
@@ -14626,7 +14626,7 @@
         },
         {
             "id": "ea7f0224-cd76-5d73-9c40-067aa598e8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d43ab9-772d-4f4d-8536-3ea60e8f9f82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d43ab9-772d-4f4d-8536-3ea60e8f9f82.jpg?1",
             "name": "Falkenrath Forebear",
             "text": "Flying\nFalkenrath Forebear can't block.\nWhenever Falkenrath Forebear deals combat damage to a player, create a Blood token.\n{B}, Sacrifice two Blood tokens: Return Falkenrath Forebear from your graveyard to the battlefield.",
             "colours": [
@@ -14663,7 +14663,7 @@
         },
         {
             "id": "d0a03e2c-3f7f-5a87-91c7-64c19784be7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying\nAt the beginning of combat on your turn, choose one that hasn't been chosen \u2014\n\u2022 Each player sacrifices a creature.\n\u2022 You draw a card and you lose 1 life.\n\u2022 Transform Henrika Domnathi.",
             "colours": [
@@ -14702,7 +14702,7 @@
         },
         {
             "id": "357a2aaa-7be5-511a-b03e-1918d184b113",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aafe47a8-0223-4c0b-b6ce-e25446a07c96.jpg?1",
             "name": "Henrika Domnathi // Henrika, Infernal Seer",
             "text": "Flying, deathtouch, lifelink\n{1}{B}{B}: Each creature you control with flying, deathtouch, and/or lifelink gets +1/+0 until end of turn.",
             "colours": [
@@ -14741,7 +14741,7 @@
         },
         {
             "id": "8e6cbd54-3006-5363-bf36-c5e63420d5e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "At the beginning of your upkeep, any opponent may sacrifice a creature. If no one does, transform Innocent Traveler.",
             "colours": [
@@ -14778,7 +14778,7 @@
         },
         {
             "id": "35444858-85c9-5242-b62a-aa57f8501e99",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/a/7a043975-59b4-490c-bf33-c08bd7b40bd3.jpg?1",
             "name": "Innocent Traveler // Malicious Invader",
             "text": "Flying\nMalicious Invader gets +2/+0 as long as an opponent controls a Human.",
             "colours": [
@@ -14815,7 +14815,7 @@
         },
         {
             "id": "87209059-8177-59b0-93a9-8b4e9b958dba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260d784d-0213-44da-8f78-58968a185012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/260d784d-0213-44da-8f78-58968a185012.jpg?1",
             "name": "Sorin the Mirthless",
             "text": "+1: Look at the top card of your library. You may reveal that card and put it into your hand. If you do, you lose life equal to its mana value.\n\u22122: Create a 2/3 black Vampire creature token with flying and lifelink.\n\u22127: Sorin the Mirthless deals 13 damage to any target. You gain 13 life.",
             "colours": [
@@ -14855,7 +14855,7 @@
         },
         {
             "id": "ee52dc1d-3c5b-5fba-ae84-e2017c039deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nWhenever Voldaren Bloodcaster or another nontoken creature you control dies, create a Blood token.\nWhenever you create a Blood token, if you control five or more Blood tokens, transform Voldaren Bloodcaster.",
             "colours": [
@@ -14893,7 +14893,7 @@
         },
         {
             "id": "409a24b6-f398-586f-a09c-881b79f3b9f9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/0954ed3d-a5d8-4330-b07c-bf3e51192e4b.jpg?1",
             "name": "Voldaren Bloodcaster // Bloodbat Summoner",
             "text": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
             "colours": [
@@ -14931,7 +14931,7 @@
         },
         {
             "id": "572b89e6-31e5-516b-ad8a-3a43416daa1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4ba693-0323-415d-ad91-c083fbbab7f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f4ba693-0323-415d-ad91-c083fbbab7f7.jpg?1",
             "name": "Vampires' Vengeance",
             "text": "Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token.",
             "colours": [
@@ -14965,7 +14965,7 @@
         },
         {
             "id": "a0c430bc-2fc8-56d3-b0d5-68bed8692cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626eacad-6ea5-410a-9a3f-af97b5e52ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/626eacad-6ea5-410a-9a3f-af97b5e52ff0.jpg?1",
             "name": "Reclusive Taxidermist",
             "text": "Reclusive Taxidermist gets +3/+2 as long as there are four or more creature cards in your graveyard.\n{T}: Add one mana of any color.",
             "colours": [
@@ -15002,7 +15002,7 @@
         },
         {
             "id": "7c24d5e5-d467-522e-a26a-01c0207d698a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "Other Vampires you control get +1/+1.\nWhen Edgar, Charmed Groom dies, return it to the battlefield transformed under its owner's control.",
             "colours": [
@@ -15044,7 +15044,7 @@
         },
         {
             "id": "8d59cb71-e741-57c3-a4fc-87265611cd08",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/0/10732397-68eb-4f1d-a2e6-10479f66805f.jpg?1",
             "name": "Edgar, Charmed Groom // Edgar Markov's Coffin",
             "text": "At the beginning of your upkeep, create a 1/1 white and black Vampire creature token with lifelink and put a bloodline counter on Edgar Markov's Coffin. Then if there are three or more bloodline counters on it, remove those counters and transform it.",
             "colours": [
@@ -15083,7 +15083,7 @@
         },
         {
             "id": "17c01956-5f85-550e-ade9-e5400b63133d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecbb622-f33b-4192-9b42-8872b35cc409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecbb622-f33b-4192-9b42-8872b35cc409.jpg?1",
             "name": "Eruth, Tormented Prophet",
             "text": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
             "colours": [
@@ -15125,7 +15125,7 @@
         },
         {
             "id": "d9d355f6-a4b8-5189-9d2a-6a074bf216cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5552d3-6860-42e5-8a13-1d36dce77322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d5552d3-6860-42e5-8a13-1d36dce77322.jpg?1",
             "name": "Olivia, Crimson Bride",
             "text": "Flying, haste\nWhenever Olivia, Crimson Bride attacks, return target creature card from your graveyard to the battlefield tapped and attacking. It gains \"When you don't control a legendary Vampire, exile this creature.\"",
             "colours": [
@@ -15167,7 +15167,7 @@
         },
         {
             "id": "8e3de8cf-3769-5484-aefa-c99724ea361f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3448-34fd-4de6-a6b4-f6d636eead8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162a3448-34fd-4de6-a6b4-f6d636eead8c.jpg?1",
             "name": "Torens, Fist of the Angels",
             "text": "Training\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
             "colours": [
@@ -15209,7 +15209,7 @@
         },
         {
             "id": "3471dadd-e2d0-51c2-af46-2ae3e51e3315",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8191ff1-458f-4295-b253-c4748c933e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8191ff1-458f-4295-b253-c4748c933e92.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -15242,7 +15242,7 @@
         },
         {
             "id": "12c9e400-8d82-555d-a159-d4f27b0f3a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab11a4db-5504-4f52-9c2f-eae05a0a8415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab11a4db-5504-4f52-9c2f-eae05a0a8415.jpg?1",
             "name": "By Invitation Only",
             "text": "Choose a number between 0 and 13. Each player sacrifices that many creatures.",
             "colours": [
@@ -15276,7 +15276,7 @@
         },
         {
             "id": "8f4a1f81-f769-5281-9f68-5bebe4d2761e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa2f823-d66d-42b0-ab3c-180b9a927cb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aa2f823-d66d-42b0-ab3c-180b9a927cb1.jpg?1",
             "name": "Cemetery Protector",
             "text": "Flash\nWhen Cemetery Protector enters the battlefield, exile a card from a graveyard.\nWhenever you play a land or cast a spell, if it shares a card type with the exiled card, create a 1/1 white Human creature token.",
             "colours": [
@@ -15313,7 +15313,7 @@
         },
         {
             "id": "785b309d-36ec-5781-9e60-0de69260e536",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Defender, flying, vigilance\nAt the beginning of your upkeep, if Faithbound Judge has two or fewer judgment counters on it, put a judgment counter on it.\nAs long as Faithbound Judge has three or more judgment counters on it, it can attack as though it didn't have defender.\nDisturb {5}{W}{W}",
             "colours": [
@@ -15350,7 +15350,7 @@
         },
         {
             "id": "00f8f397-9d44-5d5e-ba25-a57a2533e153",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2699d2a8-8f17-42d2-9eb2-8c1ab8dda6c4.jpg?1",
             "name": "Faithbound Judge // Sinner's Judgment",
             "text": "Enchant player\nAt the beginning of your upkeep, put a judgment counter on Sinner's Judgment. Then if there are three or more judgment counters on it, enchanted player loses the game.\nIf Sinner's Judgment would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -15387,7 +15387,7 @@
         },
         {
             "id": "16a2a122-b88a-5ee1-a590-047293f1167e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0904640-40e8-45bf-ac9c-94b1dd0bab8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0904640-40e8-45bf-ac9c-94b1dd0bab8f.jpg?1",
             "name": "Hallowed Haunting",
             "text": "As long as you control seven or more enchantments, creatures you control have flying and vigilance.\nWhenever you cast an enchantment spell, create a white Spirit Cleric creature token with \"This creature's power and toughness are each equal to the number of Spirits you control.\"",
             "colours": [
@@ -15421,7 +15421,7 @@
         },
         {
             "id": "65e4f746-2aed-57cc-aaf0-8aadf9de885b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169b4aa8-9597-4b57-a957-abee147fdde4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169b4aa8-9597-4b57-a957-abee147fdde4.jpg?1",
             "name": "Hopeful Initiate",
             "text": "Training\n{2}{W}, Remove two +1/+1 counters from among creatures you control: Destroy target artifact or enchantment.",
             "colours": [
@@ -15458,7 +15458,7 @@
         },
         {
             "id": "9ba6f39a-f4c9-5dc4-a7ff-8c0331b7e9da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95751a49-398b-4d95-9475-2bdfed9b791b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95751a49-398b-4d95-9475-2bdfed9b791b.jpg?1",
             "name": "Lantern Flare",
             "text": "Cleave {X}{R}{W}\nLantern Flare deals X damage to target creature or planeswalker and you gain X life. [\nX is the number of creatures you control.]",
             "colours": [
@@ -15493,7 +15493,7 @@
         },
         {
             "id": "054a8bbb-d342-5ec8-94ab-34e96510d8ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec42176-cf5b-44b7-801a-2550a065692b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec42176-cf5b-44b7-801a-2550a065692b.jpg?1",
             "name": "Savior of Ollenbock",
             "text": "Training\nWhenever Savior of Ollenbock trains, exile up to one other target creature from the battlefield or creature card from a graveyard.\nWhen Savior of Ollenbock leaves the battlefield, put the exiled cards onto the battlefield under their owners' control.",
             "colours": [
@@ -15531,7 +15531,7 @@
         },
         {
             "id": "87a4c580-fc93-53ca-8f1e-3dd1867fdadc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da14fe94-9a64-4e98-a827-0f4588a6d832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da14fe94-9a64-4e98-a827-0f4588a6d832.jpg?1",
             "name": "Sigarda's Summons",
             "text": "Creatures you control with +1/+1 counters on them have base power and toughness 4/4, have flying, and are Angels in addition to their other types.",
             "colours": [
@@ -15566,7 +15566,7 @@
         },
         {
             "id": "056611f3-819e-557f-8859-05493a334bc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008aac8-0e84-49ae-8905-68db2b2900ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d008aac8-0e84-49ae-8905-68db2b2900ef.jpg?1",
             "name": "Voice of the Blessed",
             "text": "Whenever you gain life, put a +1/+1 counter on Voice of the Blessed.\nAs long as Voice of the Blessed has four or more +1/+1 counters on it, it has flying and vigilance.\nAs long as Voice of the Blessed has ten or more +1/+1 counters on it, it has indestructible.",
             "colours": [
@@ -15603,7 +15603,7 @@
         },
         {
             "id": "f938c276-7eba-528c-9100-e8895351b60c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "At the beginning of your end step, put an invitation counter on Wedding Announcement. If you attacked with two or more creatures this turn, draw a card. Otherwise, create a 1/1 white Human creature token. Then if Wedding Announcement has three or more invitation counters on it, transform it.",
             "colours": [
@@ -15637,7 +15637,7 @@
         },
         {
             "id": "3f840a21-aa97-53a2-b814-dd66783da008",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/3/f3e60e71-bf44-475b-bfce-815ad8abf9e2.jpg?1",
             "name": "Wedding Announcement // Wedding Festivity",
             "text": "Creatures you control get +1/+1.",
             "colours": [
@@ -15671,7 +15671,7 @@
         },
         {
             "id": "e49685a1-10fe-52a1-ba6a-9f58b22977fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c330f8-7461-48d3-9743-25e66d153538.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1c330f8-7461-48d3-9743-25e66d153538.jpg?1",
             "name": "Cemetery Illuminator",
             "text": "Flying\nWhenever Cemetery Illuminator enters the battlefield or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with Cemetery Illuminator.",
             "colours": [
@@ -15707,7 +15707,7 @@
         },
         {
             "id": "96345e66-4003-5a49-bab8-0ab000b73274",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc518e53-1fd5-4eeb-a8b7-6db871cc16d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc518e53-1fd5-4eeb-a8b7-6db871cc16d6.jpg?1",
             "name": "Consuming Tide",
             "text": "Each player chooses a nonland permanent they control. Return all nonland permanents not chosen this way to their owners' hands. Then you draw a card for each opponent who has more cards in their hand than you.",
             "colours": [
@@ -15741,7 +15741,7 @@
         },
         {
             "id": "f9fa5087-17db-53e7-9dad-d33eaf877156",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e591ed36-2a6f-493d-b57d-43a18608e811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e591ed36-2a6f-493d-b57d-43a18608e811.jpg?1",
             "name": "Dreamshackle Geist",
             "text": "Flying\nAt the beginning of combat on your turn, choose up to one \u2014\n\u2022 Tap target creature.\n\u2022 Target creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -15777,7 +15777,7 @@
         },
         {
             "id": "bad5044a-7574-5733-b87b-f2002336acb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e073047-fba8-41bd-b260-1eefb084fc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e073047-fba8-41bd-b260-1eefb084fc80.jpg?1",
             "name": "Hullbreaker Horror",
             "text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one \u2014\n\u2022 Return target spell you don't control to its owner's hand.\n\u2022 Return target nonland permanent to its owner's hand.",
             "colours": [
@@ -15814,7 +15814,7 @@
         },
         {
             "id": "e6f9a2f1-71d5-5228-ac5b-3c9e13ed1c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c531001-3401-428e-a064-880bddc8c246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c531001-3401-428e-a064-880bddc8c246.jpg?1",
             "name": "Inspired Idea",
             "text": "Cleave {3}{U}{U}\nDraw three cards. [\nYour maximum hand size is reduced by three for the rest of the game.]",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "1c650e33-eafd-5c9d-87a9-0c092cb6675f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "You may have Mirrorhall Mimic enter the battlefield as a copy of any creature on the battlefield, except it's a Spirit in addition to its other types.\nDisturb {3}{U}{U}",
             "colours": [
@@ -15884,7 +15884,7 @@
         },
         {
             "id": "f08a630f-f7ad-53a9-9506-9c68f6ed44ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/4/f4135910-57ba-4f1a-ad48-4e14d44bf2a1.jpg?1",
             "name": "Mirrorhall Mimic // Ghastly Mimicry",
             "text": "Enchant creature\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except it's a Spirit in addition to its other types.\nIf Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead.",
             "colours": [
@@ -15920,7 +15920,7 @@
         },
         {
             "id": "0b08e33f-9db1-523e-8609-7b8b79f5ce53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400ca655-68ed-4714-96e9-55df00a325b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/400ca655-68ed-4714-96e9-55df00a325b3.jpg?1",
             "name": "Necroduality",
             "text": "Whenever a nontoken Zombie enters the battlefield under your control, create a token that's a copy of that creature.",
             "colours": [
@@ -15954,7 +15954,7 @@
         },
         {
             "id": "8f78e14d-9f8f-5004-acff-f208cd9aebe5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8d93bf-8836-469e-a28c-39633959a212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8d93bf-8836-469e-a28c-39633959a212.jpg?1",
             "name": "Overcharged Amalgam",
             "text": "Flash\nFlying, exploit\nWhen Overcharged Amalgam exploits a creature, counter target spell, activated ability, or triggered ability.",
             "colours": [
@@ -15991,7 +15991,7 @@
         },
         {
             "id": "52b28b5c-3739-5123-8d7e-4aa3cdcfd57c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5afa6a-c1e2-4cb1-a04c-67c9cf605c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a5afa6a-c1e2-4cb1-a04c-67c9cf605c20.jpg?1",
             "name": "Patchwork Crawler",
             "text": "{2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter on Patchwork Crawler.\nPatchwork Crawler has all activated abilities of all creature cards exiled with it.",
             "colours": [
@@ -16028,7 +16028,7 @@
         },
         {
             "id": "86e51219-2498-54e5-a1d4-698767c93f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b369e3-5057-49ff-b87e-1126571334f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b369e3-5057-49ff-b87e-1126571334f5.jpg?1",
             "name": "Winged Portent",
             "text": "Cleave {4}{G}{U}\nDraw a card for each creature [with flying] you control.",
             "colours": [
@@ -16063,7 +16063,7 @@
         },
         {
             "id": "bfed5962-f578-5d7f-bfd0-f0b97d150b37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dcf3c1-8b2c-4b2a-8ba7-9c65ae1e04d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3dcf3c1-8b2c-4b2a-8ba7-9c65ae1e04d5.jpg?1",
             "name": "Cemetery Desecrator",
             "text": "Menace\nWhen Cemetery Desecrator enters the battlefield or dies, exile another card from a graveyard. When you do, choose one \u2014\n\u2022 Remove X counters from target permanent, where X is the mana value of the exiled card.\n\u2022 Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card.",
             "colours": [
@@ -16099,7 +16099,7 @@
         },
         {
             "id": "50a99452-fbe4-5ff4-a0fe-615a608c2d1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Defender\n{2}{B}: Transform Concealing Curtains. Activate only as a sorcery.",
             "colours": [
@@ -16135,7 +16135,7 @@
         },
         {
             "id": "33f0df49-b381-56d9-a044-94818ae7bf73",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/5/25f96283-0dab-49d3-a1b1-d77d07c172ae.jpg?1",
             "name": "Concealing Curtains // Revealing Eye",
             "text": "Menace\nWhen this creature transforms into Revealing Eye, target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card, then draws a card.",
             "colours": [
@@ -16172,7 +16172,7 @@
         },
         {
             "id": "2d1ae06c-bca2-51e1-9337-34c174173257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5603d9-085c-48ac-b78b-5d95f412e577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df5603d9-085c-48ac-b78b-5d95f412e577.jpg?1",
             "name": "Demonic Bargain",
             "text": "Exile the top thirteen cards of your library, then search your library for a card. Put that card into your hand, then shuffle.",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "36eb71fb-aefc-52c1-b1c3-eb8698d5a5dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46089fef-1b9a-4796-b1fd-8c11494631aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46089fef-1b9a-4796-b1fd-8c11494631aa.jpg?1",
             "name": "Dreadfeast Demon",
             "text": "Flying\nAt the beginning of your end step, sacrifice a non-Demon creature. If you do, create a token that's a copy of Dreadfeast Demon.",
             "colours": [
@@ -16242,7 +16242,7 @@
         },
         {
             "id": "9dd83e5c-b5ec-57ea-8a61-fbec63294afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e70a-c00c-4c9e-8a52-e69a94103594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f813e70a-c00c-4c9e-8a52-e69a94103594.jpg?1",
             "name": "Dying to Serve",
             "text": "Whenever you discard one or more cards, create a tapped 2/2 black Zombie creature token. This ability triggers only once each turn.",
             "colours": [
@@ -16276,7 +16276,7 @@
         },
         {
             "id": "f7525000-ee9a-51f0-af08-8dcd2853f35c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c1efe-b1c9-4830-a1cc-d897913e10c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad2c1efe-b1c9-4830-a1cc-d897913e10c5.jpg?1",
             "name": "Graf Reaver",
             "text": "Exploit\nWhen Graf Reaver exploits a creature, destroy target planeswalker.\nAt the beginning of your upkeep, Graf Reaver deals 1 damage to you.",
             "colours": [
@@ -16313,7 +16313,7 @@
         },
         {
             "id": "d7912f5b-9d62-5f44-b268-a1726597e1d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544d7162-b78f-4a70-86e7-83cec7062039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/544d7162-b78f-4a70-86e7-83cec7062039.jpg?1",
             "name": "Headless Rider",
             "text": "Whenever Headless Rider or another nontoken Zombie you control dies, create a 2/2 black Zombie creature token.",
             "colours": [
@@ -16349,7 +16349,7 @@
         },
         {
             "id": "1563b119-92ac-5848-9a4f-d1f0604a74c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061be997-1519-41b6-9933-eb625db88eb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/061be997-1519-41b6-9933-eb625db88eb2.jpg?1",
             "name": "Path of Peril",
             "text": "Cleave {4}{W}{B}\nDestroy all creatures [with mana value 2 or less].",
             "colours": [
@@ -16384,7 +16384,7 @@
         },
         {
             "id": "3be56dff-efb4-5330-95a7-0793f5eb26fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab8938-57c9-4e08-b808-09eb02b040a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eab8938-57c9-4e08-b808-09eb02b040a0.jpg?1",
             "name": "Alchemist's Gambit",
             "text": "Cleave {4}{U}{U}{R}\nTake an extra turn after this one. During that turn, damage can't be prevented. [\nAt the beginning of that turn's end step, you lose the game.]\nExile Alchemist's Gambit.",
             "colours": [
@@ -16419,7 +16419,7 @@
         },
         {
             "id": "d0fe8fea-a9ad-5dc1-8f89-22b7857ef213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e09ecd-a8fc-45a6-a997-49b0fc5c88b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31e09ecd-a8fc-45a6-a997-49b0fc5c88b9.jpg?1",
             "name": "Change of Fortune",
             "text": "Discard your hand, then draw a card for each card you've discarded this turn.",
             "colours": [
@@ -16453,7 +16453,7 @@
         },
         {
             "id": "fc735da2-4296-549c-92c4-a08a4b7ad87b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0694ead-c2cb-4c0d-a7f7-959b641f2294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0694ead-c2cb-4c0d-a7f7-959b641f2294.jpg?1",
             "name": "Creepy Puppeteer",
             "text": "Haste\nWhenever Creepy Puppeteer attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn.",
             "colours": [
@@ -16490,7 +16490,7 @@
         },
         {
             "id": "fcd07d75-2988-59a5-8549-7a1a12e6556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583344df-41ac-4950-ae63-275df9b0a9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/583344df-41ac-4950-ae63-275df9b0a9e9.jpg?1",
             "name": "Curse of Hospitality",
             "text": "Enchant player\nCreatures attacking enchanted player have trample.\nWhenever a creature deals combat damage to enchanted player, that player exiles the top card of their library. Until end of turn, that creature's controller may play that card and they may spend mana as though it were mana of any color to cast that spell.",
             "colours": [
@@ -16527,7 +16527,7 @@
         },
         {
             "id": "54a57b92-6047-5701-9f58-a92350b564e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever Ill-Tempered Loner is dealt damage, it deals that much damage to any target.\n{1}{R}: Ill-Tempered Loner gets +2/+0 until end of turn.\nDaybound",
             "colours": [
@@ -16564,7 +16564,7 @@
         },
         {
             "id": "518d2a7b-c827-55f6-b9ca-86e790360432",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/a/4a1ce3cd-380a-4ecc-b837-7ffeaccd5c91.jpg?1",
             "name": "Ill-Tempered Loner // Howlpack Avenger",
             "text": "Whenever a permanent you control is dealt damage, Howlpack Avenger deals that much damage to any target.\n{1}{R}: Howlpack Avenger gets +2/+0 until end of turn.\nNightbound",
             "colours": [
@@ -16600,7 +16600,7 @@
         },
         {
             "id": "a762ef7d-e6bb-561e-985f-c3944855809b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d54673a-2147-474c-9bcb-ef89dbe54456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d54673a-2147-474c-9bcb-ef89dbe54456.jpg?1",
             "name": "Kessig Wolfrider",
             "text": "Menace\n{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.",
             "colours": [
@@ -16637,7 +16637,7 @@
         },
         {
             "id": "6772a6c0-ca0f-5156-aed9-d90934e10341",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8f0f2-3694-4f82-9e45-0130248875ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69c8f0f2-3694-4f82-9e45-0130248875ea.jpg?1",
             "name": "Manaform Hellkite",
             "text": "Flying\nWhenever you cast a noncreature spell, create an X/X red Dragon Illusion creature token with flying and haste, where X is the amount of mana spent to cast that spell. Exile that token at the beginning of the next end step.",
             "colours": [
@@ -16673,7 +16673,7 @@
         },
         {
             "id": "3b2c0e46-214c-5796-9345-34a13492d806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832a58cd-804d-4c1a-b24e-478357873b93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/832a58cd-804d-4c1a-b24e-478357873b93.jpg?1",
             "name": "Stensia Uprising",
             "text": "At the beginning of your end step, create a 1/1 red Human creature token. Then if you control exactly thirteen permanents, you may sacrifice Stensia Uprising. When you do, it deals 7 damage to any target.",
             "colours": [
@@ -16707,7 +16707,7 @@
         },
         {
             "id": "21fd3c99-610d-5cac-aea2-ff9eca2fbb4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Volatile Arsonist attacks, it deals 1 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nDaybound",
             "colours": [
@@ -16744,7 +16744,7 @@
         },
         {
             "id": "61909d09-c1cb-5d9a-a0d5-5b82ba2542d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/2/52d94eb6-d96c-4b88-9450-b1ee472795fa.jpg?1",
             "name": "Volatile Arsonist // Dire-Strain Anarchist",
             "text": "Menace, haste\nWhenever Dire-Strain Anarchist attacks, it deals 2 damage to each of up to one target creature, up to one target player, and/or up to one target planeswalker.\nNightbound",
             "colours": [
@@ -16780,7 +16780,7 @@
         },
         {
             "id": "f70622e6-fbd1-5bc4-9620-5fe66507e456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af47752-f5d9-471a-a10b-1ba06d58e0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af47752-f5d9-471a-a10b-1ba06d58e0e5.jpg?1",
             "name": "Ascendant Packleader",
             "text": "Ascendant Packleader enters the battlefield with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.\nWhenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on Ascendant Packleader.",
             "colours": [
@@ -16816,7 +16816,7 @@
         },
         {
             "id": "ae38fd25-5a29-5807-adf5-43430dab1e3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nAt the beginning of combat on your turn, put two +1/+1 counters on another target creature you control.\nDaybound",
             "colours": [
@@ -16853,7 +16853,7 @@
         },
         {
             "id": "401ddfef-7260-50a3-b91c-1bb5a370724d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/b/6b525a96-17cb-427e-a88b-484e23f78537.jpg?1",
             "name": "Avabruck Caretaker // Hollowhenge Huntmaster",
             "text": "Hexproof\nOther permanents you control have hexproof.\nAt the beginning of combat on your turn, put two +1/+1 counters on each creature you control.\nNightbound",
             "colours": [
@@ -16889,7 +16889,7 @@
         },
         {
             "id": "1b97a54c-8862-5958-a341-719de68ae2cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352dcf9-fcdf-45c2-a581-87c5ec965618.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7352dcf9-fcdf-45c2-a581-87c5ec965618.jpg?1",
             "name": "Cemetery Prowler",
             "text": "Vigilance\nWhenever Cemetery Prowler enters the battlefield or attacks, exile a card from a graveyard.\nSpells you cast cost {1} less to cast for each card type they share with cards exiled with Cemetery Prowler.",
             "colours": [
@@ -16925,7 +16925,7 @@
         },
         {
             "id": "0078d827-6c03-5684-900e-7094ab5be190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d752b67-93ea-4f76-ad80-09787427398e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d752b67-93ea-4f76-ad80-09787427398e.jpg?1",
             "name": "Cultivator Colossus",
             "text": "Trample\nCultivator Colossus's power and toughness are each equal to the number of lands you control.\nWhen Cultivator Colossus enters the battlefield, you may put a land card from your hand onto the battlefield tapped. If you do, draw a card and repeat this process.",
             "colours": [
@@ -16962,7 +16962,7 @@
         },
         {
             "id": "c3df45d8-8056-53c8-a21b-ee478e51613d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078d0194-0137-45cd-977a-eefae67f9bca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078d0194-0137-45cd-977a-eefae67f9bca.jpg?1",
             "name": "Dig Up",
             "text": "Cleave {1}{B}{B}{G}\nSearch your library for a basic land card, [reveal it,] put it into your hand, then shuffle.",
             "colours": [
@@ -16997,7 +16997,7 @@
         },
         {
             "id": "b4ed3060-d345-5590-a541-71c59bf2f5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bd18f-29f0-422e-a28e-4fc7ce21b9c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/952bd18f-29f0-422e-a28e-4fc7ce21b9c9.jpg?1",
             "name": "Glorious Sunrise",
             "text": "At the beginning of combat on your turn, choose one \u2014\n\u2022 Creatures you control get +1/+1 and gain trample until end of turn.\n\u2022 Target land gains \"{T}: Add {G}{G}{G}\" until end of turn.\n\u2022 Draw a card if you control a creature with power 3 or greater.\n\u2022 You gain 3 life.",
             "colours": [
@@ -17031,7 +17031,7 @@
         },
         {
             "id": "9a8a0436-3421-538d-bc50-134dc26db515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf4689-53a6-434d-9795-97f9c3777fac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99bf4689-53a6-434d-9795-97f9c3777fac.jpg?1",
             "name": "Hamlet Vanguard",
             "text": "Ward {2}\nHamlet Vanguard enters the battlefield with two +1/+1 counters on it for each other nontoken Human you control.",
             "colours": [
@@ -17068,7 +17068,7 @@
         },
         {
             "id": "d9bededa-e940-54ad-a145-4200c799b05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c150b7b-5a78-4f84-bff7-d5000e266a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c150b7b-5a78-4f84-bff7-d5000e266a55.jpg?1",
             "name": "Hiveheart Shaman",
             "text": "Whenever Hiveheart Shaman attacks, you may search your library for a basic land card that doesn't share a land type with a land you control, put that card onto the battlefield, then shuffle.\n{5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is the number of basic land types among lands you control. Activate only as a sorcery.",
             "colours": [
@@ -17105,7 +17105,7 @@
         },
         {
             "id": "43ef64b8-5f67-5a64-a2a6-1da63b4b24b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c9612e-3acd-4eb7-b34c-c300084625d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4c9612e-3acd-4eb7-b34c-c300084625d4.jpg?1",
             "name": "Howling Moon",
             "text": "At the beginning of combat on your turn, target Wolf or Werewolf you control gets +2/+2 until end of turn.\nWhenever an opponent casts their second spell each turn, create a 2/2 green Wolf creature token.",
             "colours": [
@@ -17139,7 +17139,7 @@
         },
         {
             "id": "5e01b051-8739-581a-b3a2-db6b41264ce9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "This spell can't be countered.\n{1}{G}, {T}: You may put a creature card from your hand onto the battlefield. If it's a Wolf or Werewolf, untap Howlpack Piper. Activate only as a sorcery.\nDaybound",
             "colours": [
@@ -17176,7 +17176,7 @@
         },
         {
             "id": "5986dc93-8cba-5956-b466-ea1ae210c3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c598c30a-056e-44ca-8469-73304763491c.jpg?1",
             "name": "Howlpack Piper // Wildsong Howler",
             "text": "Whenever this creature enters the battlefield or transforms into Wildsong Howler, look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nNightbound",
             "colours": [
@@ -17212,7 +17212,7 @@
         },
         {
             "id": "5f7271d9-fb0d-54d7-b85b-20125dc6061f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfdaf0-6507-4c46-afe1-b4281a645cbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bbfdaf0-6507-4c46-afe1-b4281a645cbf.jpg?1",
             "name": "Splendid Reclamation",
             "text": "Return all land cards from your graveyard to the battlefield tapped.",
             "colours": [
@@ -17246,7 +17246,7 @@
         },
         {
             "id": "6573a18e-3268-5e84-a6c1-99bfd9292626",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\n{5}{G}{G}: Transform Ulvenwald Oddity.",
             "colours": [
@@ -17282,7 +17282,7 @@
         },
         {
             "id": "ca42e483-f4c4-5c2b-8ab8-ee046b8639f4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/e/8e857c4e-9d85-418a-9200-3bdcceff3f6b.jpg?1",
             "name": "Ulvenwald Oddity // Ulvenwald Behemoth",
             "text": "Trample, haste\nOther creatures you control get +1/+1 and have trample and haste.",
             "colours": [
@@ -17319,7 +17319,7 @@
         },
         {
             "id": "d4267ba5-d1e3-5536-ad2e-0ce92a22406e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d2885-82f1-424d-ba95-c4dd15b6639d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540d2885-82f1-424d-ba95-c4dd15b6639d.jpg?1",
             "name": "Dollhouse of Horrors",
             "text": "{1}, {T}, Exile a creature card from your graveyard: Create a token that's a copy of the exiled card, except it's a 0/0 Construct artifact in addition to its other types and it has \"This creature gets +1/+1 for each Construct you control.\" It gains haste until end of turn. Activate only as a sorcery.",
             "colours": [],
@@ -17349,7 +17349,7 @@
         },
         {
             "id": "fe0e7e78-b0e3-5c39-83b5-d6dd93fbe87a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f35a26f-f31e-497c-a604-0157f81a3540.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f35a26f-f31e-497c-a604-0157f81a3540.jpg?1",
             "name": "Investigator's Journal",
             "text": "Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n{2}, {T}, Remove a suspect counter from Investigator's Journal: Draw a card.\n{2}, Sacrifice Investigator's Journal: Draw a card.",
             "colours": [],
@@ -17382,7 +17382,7 @@
         },
         {
             "id": "6ee89f05-b140-58e1-9b16-3db99917aae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2437225-d6a9-4cc6-9b3b-148f9300e6b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2437225-d6a9-4cc6-9b3b-148f9300e6b1.jpg?1",
             "name": "Voldaren Estate",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control.",
             "colours": [],
@@ -17413,7 +17413,7 @@
         },
         {
             "id": "5257fea9-ca8e-5453-a019-5b229ecc9239",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ddb0be-d62d-46fa-b753-36dfab935e8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ddb0be-d62d-46fa-b753-36dfab935e8a.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17451,7 +17451,7 @@
         },
         {
             "id": "018bd152-3bca-588a-bc3a-52c16c2c997b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82b281f-d3c7-4eb8-9a10-b4808ca6cfcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82b281f-d3c7-4eb8-9a10-b4808ca6cfcd.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17489,7 +17489,7 @@
         },
         {
             "id": "ead3d5ae-4314-52b7-93e1-c91aee7340c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87de91-aa10-4ed8-83a2-261b4f57e7db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be87de91-aa10-4ed8-83a2-261b4f57e7db.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17527,7 +17527,7 @@
         },
         {
             "id": "449c0c6a-ba8f-5afe-8be5-fd2a9e8166c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86fbf78-57ec-4a0f-9fb6-e4bf13861563.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b86fbf78-57ec-4a0f-9fb6-e4bf13861563.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17565,7 +17565,7 @@
         },
         {
             "id": "d1ff8036-c078-5ac1-9fc7-76ffa3966252",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6380e-b1b6-4a5a-a8d9-7cdf8eab3557.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae6380e-b1b6-4a5a-a8d9-7cdf8eab3557.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17603,7 +17603,7 @@
         },
         {
             "id": "6a305874-0e44-519e-84c4-02e2baeae9be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9524-0958-4ce5-b521-ce38dd54a9d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43ec9524-0958-4ce5-b521-ce38dd54a9d1.jpg?1",
             "name": "Voldaren Estate",
             "text": "{T}: Add {C}.\n{T}, Pay 1 life: Add one mana of any color. Spend this mana only to cast a Vampire spell.\n{5}, {T}: Create a Blood token. This ability costs {1} less to activate for each Vampire you control.",
             "colours": [],
@@ -17633,7 +17633,7 @@
         },
         {
             "id": "54d3d08b-8bba-5e26-96e3-b788e166aded",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06242f90-5709-482c-8d45-a60a4dc9e8bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06242f90-5709-482c-8d45-a60a4dc9e8bc.jpg?1",
             "name": "Sigarda's Summons",
             "text": "Creatures you control with +1/+1 counters on them have base power and toughness 4/4, have flying, and are Angels in addition to their other types.",
             "colours": [
@@ -17667,7 +17667,7 @@
         },
         {
             "id": "ac0df35a-9418-5a66-97af-c402ecc6b807",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a081700-a29a-40ff-a198-00d32f0ea11d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a081700-a29a-40ff-a198-00d32f0ea11d.jpg?1",
             "name": "Geistlight Snare",
             "text": "This spell costs {1} less to cast if you control a Spirit. It also costs {1} less to cast if you control an enchantment.\nCounter target spell unless its controller pays {3}.",
             "colours": [
@@ -17700,7 +17700,7 @@
         },
         {
             "id": "6650c7e1-fdce-59d5-b8ee-d16b674397f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53e7eb0-7468-41b7-aba8-f4977703f867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53e7eb0-7468-41b7-aba8-f4977703f867.jpg?1",
             "name": "Fell Stinger",
             "text": "Deathtouch\nExploit\nWhen Fell Stinger exploits a creature, target player draws two cards and loses 2 life.",
             "colours": [
@@ -17736,7 +17736,7 @@
         },
         {
             "id": "809ad170-defa-5f44-ab96-c6ba861330a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acfc15c-048a-4e16-94f5-935f0e9ba068.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4acfc15c-048a-4e16-94f5-935f0e9ba068.jpg?1",
             "name": "Dominating Vampire",
             "text": "When Dominating Vampire enters the battlefield, gain control of target creature with mana value less than or equal to the number of Vampires you control until end of turn. Untap that creature. It gains haste until end of turn.",
             "colours": [
@@ -17772,7 +17772,7 @@
         },
         {
             "id": "3a40c646-c09c-51ea-8208-521b33e5a2f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80897666-ade2-4f70-9c4d-235753b44a23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80897666-ade2-4f70-9c4d-235753b44a23.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -17809,7 +17809,7 @@
         },
         {
             "id": "9f91350e-c7e4-566f-b353-da466d46573d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fddf4cb-0680-4bc7-8bb3-cb15268aff46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fddf4cb-0680-4bc7-8bb3-cb15268aff46.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -17846,7 +17846,7 @@
         },
         {
             "id": "65077995-4af9-543a-bc34-acc9e50c7dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91afb4f0-70ef-4539-9081-dc130c7c63f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91afb4f0-70ef-4539-9081-dc130c7c63f5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -17883,7 +17883,7 @@
         },
         {
             "id": "d0b64708-7286-50cb-a74c-fe318a1ba482",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117716bf-43c8-4534-92da-d7948d4b5628.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117716bf-43c8-4534-92da-d7948d4b5628.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -17920,7 +17920,7 @@
         },
         {
             "id": "fc187bf4-9fe2-5f99-ae9e-13380a8a0d5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7279281-42d5-4226-b841-f1f4deff919b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7279281-42d5-4226-b841-f1f4deff919b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -17957,7 +17957,7 @@
         },
         {
             "id": "6d9ac173-1396-5fa3-baeb-88b5214d5dfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d13a93a-a43d-4cf5-8300-8341f3b7f1b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d13a93a-a43d-4cf5-8300-8341f3b7f1b1.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -17992,7 +17992,7 @@
         },
         {
             "id": "5457bab4-6167-50ce-8933-ff06f7c8c92d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -18027,7 +18027,7 @@
         },
         {
             "id": "f0bc8e29-4b4f-5c21-8209-32a86ffdb49c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61e7f44-c112-4501-8850-0565fc857397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b61e7f44-c112-4501-8850-0565fc857397.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [
@@ -18062,7 +18062,7 @@
         },
         {
             "id": "0ef3b09e-ec53-5e89-a255-38ce73adb6b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bae5-d768-45ab-aba8-94c4f9fabc79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5212bae5-d768-45ab-aba8-94c4f9fabc79.jpg?1",
             "name": "Spirit Cleric",
             "text": "",
             "colours": [
@@ -18098,7 +18098,7 @@
         },
         {
             "id": "d3d7ce7b-5ea0-5653-ad6c-0de20e759e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539f4b60-667b-469d-9191-eacaad5c0db1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/539f4b60-667b-469d-9191-eacaad5c0db1.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -18133,7 +18133,7 @@
         },
         {
             "id": "5c80ec44-74e2-5bfc-824f-275b73753026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2ae34f-4558-46e0-95c5-e00d813fa355.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e2ae34f-4558-46e0-95c5-e00d813fa355.jpg?1",
             "name": "Slug",
             "text": "",
             "colours": [
@@ -18168,7 +18168,7 @@
         },
         {
             "id": "fe9ee815-6717-5dbc-9c88-30054c02cd69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd12ac1-d1b2-4e22-9a17-8f3964294e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebd12ac1-d1b2-4e22-9a17-8f3964294e35.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -18203,7 +18203,7 @@
         },
         {
             "id": "e032730f-4759-505f-a38f-bbe44fd7f41d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e21cd-079d-493f-ab8d-e62f16ec1581.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84e21cd-079d-493f-ab8d-e62f16ec1581.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -18238,7 +18238,7 @@
         },
         {
             "id": "a819ecc0-e17d-5a7d-b7b4-2e9c098bfa1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ca01e-d2ff-45ce-bf6f-9f756808c8fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04ca01e-d2ff-45ce-bf6f-9f756808c8fb.jpg?1",
             "name": "Dragon Illusion",
             "text": "",
             "colours": [
@@ -18274,7 +18274,7 @@
         },
         {
             "id": "332b3d4e-183f-5f93-89bb-adfef34a51a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c8ff82-b598-4ccc-83a7-99f1e53b64d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11c8ff82-b598-4ccc-83a7-99f1e53b64d3.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -18309,7 +18309,7 @@
         },
         {
             "id": "31e17edf-e40c-531d-ae1b-6340f8dc2709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -18344,7 +18344,7 @@
         },
         {
             "id": "d35b3ce0-91d2-5be9-bd34-84fc7c10f305",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975c4329-418a-4ada-82fa-9286fb61d61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975c4329-418a-4ada-82fa-9286fb61d61a.jpg?1",
             "name": "Boar",
             "text": "",
             "colours": [
@@ -18379,7 +18379,7 @@
         },
         {
             "id": "15cdbf33-de46-5228-bcdc-08295c9a6038",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ac66f8-4bb2-42bd-9a18-7da9c3839c8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ac66f8-4bb2-42bd-9a18-7da9c3839c8b.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -18414,7 +18414,7 @@
         },
         {
             "id": "d089be24-e720-50f4-8ac7-d9a928910659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -18449,7 +18449,7 @@
         },
         {
             "id": "3fc32629-0485-5851-b51b-cb8f20600499",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg?1",
             "name": "Human Soldier",
             "text": "",
             "colours": [
@@ -18487,7 +18487,7 @@
         },
         {
             "id": "5846af2a-b320-5784-9096-f6b26e1f157f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee78d3-c65f-4454-bd3c-1c55388422f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eee78d3-c65f-4454-bd3c-1c55388422f5.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -18524,7 +18524,7 @@
         },
         {
             "id": "57469ddb-d4b7-5e59-9df7-199251b58fc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f374bc-cd29-469f-808a-6a6c004ee8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6f374bc-cd29-469f-808a-6a6c004ee8aa.jpg?1",
             "name": "Blood",
             "text": "",
             "colours": [],
@@ -18555,7 +18555,7 @@
         },
         {
             "id": "4b0b11fb-6382-5e5d-bbab-e77c1ed5cab0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a89fdcf-0672-4241-834f-5db2c861694d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a89fdcf-0672-4241-834f-5db2c861694d.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -18586,7 +18586,7 @@
         },
         {
             "id": "2a0c52f6-dc87-5d78-bccc-2682d94072e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2942a8-68e8-4f73-956f-f19c690fa512.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd2942a8-68e8-4f73-956f-f19c690fa512.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -18614,7 +18614,7 @@
         },
         {
             "id": "d1e6d9db-2420-5250-a2f4-c0688e0c5ac0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01783a68-4f61-43ff-94ef-eb0eae654cb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01783a68-4f61-43ff-94ef-eb0eae654cb7.jpg?1",
             "name": "Chandra, Dressed to Kill Emblem",
             "text": "",
             "colours": [],
@@ -18642,7 +18642,7 @@
         },
         {
             "id": "deef0d85-4dee-5cc5-a53c-205ef82254c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],
@@ -18669,7 +18669,7 @@
         },
         {
             "id": "c7d1ebd5-fe83-58d1-83ed-b35e8773fc0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc26e13b-7a0f-4e7f-8593-4f22234f4517.jpg?1",
             "name": "Day // Night",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/WAR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/WAR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "0a679f46-9f50-5ac1-a6bf-c802c67fc0a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec0c0fb-1a4f-45f4-85b7-346a6d3ce2c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ec0c0fb-1a4f-45f4-85b7-346a6d3ce2c5.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "Activated abilities of artifacts your opponents control can't be activated.\n+1: Until your next turn, up to one target noncreature artifact becomes an artifact creature with power and toughness each equal to its converted mana cost.\n\u22122: You may choose an artifact card you own from outside the game or in exile, reveal that card, and put it into your hand.",
             "colours": [],
@@ -38,7 +38,7 @@
         },
         {
             "id": "ba2d7f48-9846-5343-ae02-913b7e6a18d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b572739-0a10-4af0-9014-dd81b67b3dbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b572739-0a10-4af0-9014-dd81b67b3dbb.jpg?1",
             "name": "Karn, the Great Creator",
             "text": "",
             "colours": [],
@@ -72,7 +72,7 @@
         },
         {
             "id": "52b531a3-d0eb-58ee-af14-c69f6a05b327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b003521-3da3-41bf-9765-36630653f902.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b003521-3da3-41bf-9765-36630653f902.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "Colorless spells you cast cost {2} less to cast.\n+1: Exile the top card of your library face down and look at it. Create a 2/2 colorless Spirit creature token. When that token leaves the battlefield, put the exiled card into your hand.\n\u22123: Destroy target permanent that's one or more colors.",
             "colours": [],
@@ -106,7 +106,7 @@
         },
         {
             "id": "2ab585b3-9529-55b0-8c89-782578877fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7f23ba-1a98-416a-ac97-3f15ed000c60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a7f23ba-1a98-416a-ac97-3f15ed000c60.jpg?1",
             "name": "Ugin, the Ineffable",
             "text": "",
             "colours": [],
@@ -140,7 +140,7 @@
         },
         {
             "id": "e796a3c2-b34f-5b13-888b-45ff0c94ef57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9957ecca-5ea0-446f-bfd3-46c2aaa42f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9957ecca-5ea0-446f-bfd3-46c2aaa42f08.jpg?1",
             "name": "Ugin's Conjurant",
             "text": "Ugin's Conjurant enters the battlefield with X +1/+1 counters on it.\nIf damage would be dealt to Ugin's Conjurant while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from Ugin's Conjurant.",
             "colours": [],
@@ -171,7 +171,7 @@
         },
         {
             "id": "d451691b-6cc7-5ea7-968b-2abae1beb622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3656310-093d-4724-a399-7f7010843b1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3656310-093d-4724-a399-7f7010843b1f.jpg?1",
             "name": "Ajani's Pridemate",
             "text": "Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.",
             "colours": [
@@ -206,7 +206,7 @@
         },
         {
             "id": "470332c9-e7d4-5b11-b0ca-4c9f877f8e5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8e970-b90c-4829-8970-0a3364027bbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f8e970-b90c-4829-8970-0a3364027bbb.jpg?1",
             "name": "Battlefield Promotion",
             "text": "Put a +1/+1 counter on target creature. That creature gains first strike until end of turn. You gain 2 life.",
             "colours": [
@@ -238,7 +238,7 @@
         },
         {
             "id": "50f8a302-b981-5940-823c-e5892ef630ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7c78bb-9f2a-47a4-adc4-b497bb38f46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb7c78bb-9f2a-47a4-adc4-b497bb38f46f.jpg?1",
             "name": "Bond of Discipline",
             "text": "Tap all creatures your opponents control. Creatures you control gain lifelink until end of turn.",
             "colours": [
@@ -270,7 +270,7 @@
         },
         {
             "id": "4b60a0b8-ddee-5a88-a578-22fb009c117e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11510817-edb3-40d4-bd27-6161fedadd11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11510817-edb3-40d4-bd27-6161fedadd11.jpg?1",
             "name": "Bulwark Giant",
             "text": "When Bulwark Giant enters the battlefield, you gain 5 life.",
             "colours": [
@@ -305,7 +305,7 @@
         },
         {
             "id": "4bae03de-a6cb-59a5-a470-b5a57c0e2f9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357513b9-0505-4b67-9a29-36a705a175b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357513b9-0505-4b67-9a29-36a705a175b1.jpg?1",
             "name": "Charmed Stray",
             "text": "Lifelink\nWhen Charmed Stray enters the battlefield, put a +1/+1 counter on each other creature you control named Charmed Stray.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "fe669d77-6304-5ff9-a9cd-e0e2d23b8b96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc183a40-7e15-40b1-9faa-b243401b3d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc183a40-7e15-40b1-9faa-b243401b3d10.jpg?1",
             "name": "Defiant Strike",
             "text": "Target creature gets +1/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -371,7 +371,7 @@
         },
         {
             "id": "2cfc2f2d-d3a3-5875-b24a-102bd414bae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbb58a-1b00-4883-9b45-da7ded7317e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbb58a-1b00-4883-9b45-da7ded7317e3.jpg?1",
             "name": "Divine Arrow",
             "text": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
             "colours": [
@@ -403,7 +403,7 @@
         },
         {
             "id": "01013cab-be73-532f-b6bf-0f24d0c3792f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d6d488-01df-4d61-92ff-9881838b4018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4d6d488-01df-4d61-92ff-9881838b4018.jpg?1",
             "name": "Enforcer Griffin",
             "text": "Flying",
             "colours": [
@@ -437,7 +437,7 @@
         },
         {
             "id": "981628d3-14b8-55fe-b9b8-d6d2afd78bc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccacb84-2b8e-40b8-8d53-d1b97bb2971f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccacb84-2b8e-40b8-8d53-d1b97bb2971f.jpg?1",
             "name": "Finale of Glory",
             "text": "Create X 2/2 white Soldier creature tokens with vigilance. If X is 10 or more, also create X 4/4 white Angel creature tokens with flying and vigilance.",
             "colours": [
@@ -469,7 +469,7 @@
         },
         {
             "id": "d6e42c74-0bb6-5036-a6a9-3746d7ed223c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d51c5e-26cb-4276-a676-fabfef866248.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d51c5e-26cb-4276-a676-fabfef866248.jpg?1",
             "name": "Gideon Blackblade",
             "text": "As long as it's your turn, Gideon Blackblade is a 4/4 Human Soldier creature with indestructible that's still a planeswalker.\nPrevent all damage that would be dealt to Gideon Blackblade during your turn.\n+1: Up to one other target creature you control gains your choice of vigilance, lifelink, or indestructible until end of turn.\n\u22126: Exile target nonland permanent.",
             "colours": [
@@ -507,7 +507,7 @@
         },
         {
             "id": "2a56dbcf-d091-56cc-ac20-1f8ce7c7ec4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9581ba4-8b7a-410c-9a7d-d4a976880435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9581ba4-8b7a-410c-9a7d-d4a976880435.jpg?1",
             "name": "Gideon Blackblade",
             "text": "",
             "colours": [
@@ -545,7 +545,7 @@
         },
         {
             "id": "5ec4ceb6-405c-559b-986e-fb76bfea5b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849c79ad-8bfc-4512-ab41-f213b6b285ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/849c79ad-8bfc-4512-ab41-f213b6b285ab.jpg?1",
             "name": "Gideon's Sacrifice",
             "text": "Choose a creature or planeswalker you control. All damage that would be dealt this turn to you and permanents you control is dealt to the chosen permanent instead (if it's still on the battlefield).",
             "colours": [
@@ -577,7 +577,7 @@
         },
         {
             "id": "a9183560-ed4a-5744-bcc0-2ca2b20d1487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6610c6a-717f-406e-a49d-b6e548880946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6610c6a-717f-406e-a49d-b6e548880946.jpg?1",
             "name": "Gideon's Triumph",
             "text": "Target opponent sacrifices a creature that attacked or blocked this turn. If you control a Gideon planeswalker, that player sacrifices two of those creatures instead.",
             "colours": [
@@ -609,7 +609,7 @@
         },
         {
             "id": "3712322d-1c14-5840-b9ce-c6e5949842ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70f155-2336-421c-8a9d-69772d2b51a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df70f155-2336-421c-8a9d-69772d2b51a8.jpg?1",
             "name": "God-Eternal Oketra",
             "text": "Double strike\nWhenever you cast a creature spell, create a 4/4 black Zombie Warrior creature token with vigilance.\nWhen God-Eternal Oketra dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -646,7 +646,7 @@
         },
         {
             "id": "7f3c0e8a-b5d1-53d9-bfd3-6c66968599f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcb1f9d-105d-48c6-bd66-d7e8839de9e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dcb1f9d-105d-48c6-bd66-d7e8839de9e1.jpg?1",
             "name": "Grateful Apparition",
             "text": "Flying\nWhenever Grateful Apparition deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -680,7 +680,7 @@
         },
         {
             "id": "fb88ffcc-0821-5a08-80e7-3caeef0fc6c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11d6f9-0b80-4b19-ab96-23f80b66b409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e11d6f9-0b80-4b19-ab96-23f80b66b409.jpg?1",
             "name": "Ignite the Beacon",
             "text": "Search your library for up to two planeswalker cards, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -712,7 +712,7 @@
         },
         {
             "id": "19f9723e-e36d-5df8-82ab-27f3a1e19453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb16895-6542-405e-9793-154ffc439f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afb16895-6542-405e-9793-154ffc439f23.jpg?1",
             "name": "Ironclad Krovod",
             "text": "",
             "colours": [
@@ -746,7 +746,7 @@
         },
         {
             "id": "44dcd2cf-ffac-5df5-9538-06a3ec158573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d39238-e21d-4345-84c8-648ef3a66703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3d39238-e21d-4345-84c8-648ef3a66703.jpg?1",
             "name": "Law-Rune Enforcer",
             "text": "{1}, {T}: Tap target creature with converted mana cost 2 or greater.",
             "colours": [
@@ -781,7 +781,7 @@
         },
         {
             "id": "242791b2-926a-5865-b28f-66143021c5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57f873b-5fb2-4638-b66c-f6d1aec156ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c57f873b-5fb2-4638-b66c-f6d1aec156ba.jpg?1",
             "name": "Loxodon Sergeant",
             "text": "Vigilance\nWhen Loxodon Sergeant enters the battlefield, other creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "d0192592-1b1a-5ee7-b5c8-291a71431618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82293d58-d3b4-4cf6-8a16-32ae3e509696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82293d58-d3b4-4cf6-8a16-32ae3e509696.jpg?1",
             "name": "Makeshift Battalion",
             "text": "Whenever Makeshift Battalion and at least two other creatures attack, put a +1/+1 counter on Makeshift Battalion.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "e306e8bc-7b20-5f95-b625-53a41a654b68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbc8ca-a574-461e-92ea-c6010daa8230.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfbc8ca-a574-461e-92ea-c6010daa8230.jpg?1",
             "name": "Martyr for the Cause",
             "text": "When Martyr for the Cause dies, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "8e4d50a9-f385-570b-a73a-d7883284d42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ba80e-3aca-423e-a0b7-19c2d4b44dbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/261ba80e-3aca-423e-a0b7-19c2d4b44dbf.jpg?1",
             "name": "Parhelion II",
             "text": "Flying, first strike, vigilance\nWhenever Parhelion II attacks, create two 4/4 white Angel creature tokens with flying and vigilance that are attacking.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "a9705de7-bdc9-5859-a738-d0d85c136684",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9383956f-90bc-40e4-ae5c-503e98e21832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/9383956f-90bc-40e4-ae5c-503e98e21832.jpg?1",
             "name": "Pouncing Lynx",
             "text": "As long as it's your turn, Pouncing Lynx has first strike.",
             "colours": [
@@ -956,7 +956,7 @@
         },
         {
             "id": "35d1b37b-b29e-5bb7-b0b6-282284664c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476e8e5-2377-464b-b2d5-a3cd66ee2e45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d476e8e5-2377-464b-b2d5-a3cd66ee2e45.jpg?1",
             "name": "Prison Realm",
             "text": "When Prison Realm enters the battlefield, exile target creature or planeswalker an opponent controls until Prison Realm leaves the battlefield.\nWhen Prison Realm enters the battlefield, scry 1.",
             "colours": [
@@ -988,7 +988,7 @@
         },
         {
             "id": "8681699e-1abb-5f39-a615-777eb2670653",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f043642d-35fe-4ea9-a1d3-78ddfdddeaf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f043642d-35fe-4ea9-a1d3-78ddfdddeaf4.jpg?1",
             "name": "Rally of Wings",
             "text": "Untap all creatures you control. Creatures you control with flying get +2/+2 until end of turn.",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "6880451e-b6bb-5284-9974-fefd56bb0cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f83824-43c6-4101-88fd-9109958b23e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f83824-43c6-4101-88fd-9109958b23e2.jpg?1",
             "name": "Ravnica at War",
             "text": "Exile all multicolored permanents.",
             "colours": [
@@ -1052,7 +1052,7 @@
         },
         {
             "id": "c203b669-c6e0-517c-a032-bde4aa972d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcacc28-aacf-4d40-b8cc-f8c028380340.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edcacc28-aacf-4d40-b8cc-f8c028380340.jpg?1",
             "name": "Rising Populace",
             "text": "Whenever another creature or planeswalker you control dies, put a +1/+1 counter on Rising Populace.",
             "colours": [
@@ -1086,7 +1086,7 @@
         },
         {
             "id": "9bf42aa4-962f-5269-aa17-af5866e0818b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e7c6a-e628-4327-a16f-2062c5a662df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce0e7c6a-e628-4327-a16f-2062c5a662df.jpg?1",
             "name": "Single Combat",
             "text": "Each player chooses a creature or planeswalker they control, then sacrifices the rest. Players can't cast creature or planeswalker spells until the end of your next turn.",
             "colours": [
@@ -1118,7 +1118,7 @@
         },
         {
             "id": "150f54d6-43b9-5b9a-9c1c-300b4d989f2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211c0e1-b314-495f-9c43-9a0e95c9efb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9211c0e1-b314-495f-9c43-9a0e95c9efb9.jpg?1",
             "name": "Sunblade Angel",
             "text": "Flying, first strike, vigilance, lifelink",
             "colours": [
@@ -1152,7 +1152,7 @@
         },
         {
             "id": "5991b55d-ae2e-5ffc-8afd-5930507ddd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a974571c-d8d5-4860-9077-2023e5f32a24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a974571c-d8d5-4860-9077-2023e5f32a24.jpg?1",
             "name": "Teyo, the Shieldmage",
             "text": "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\n\u22122: Create a 0/3 white Wall creature token with defender.",
             "colours": [
@@ -1190,7 +1190,7 @@
         },
         {
             "id": "2f4942dd-d6d7-5b79-8dd9-91c9cd0daf1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc3498-b837-4444-b388-2d11c883a08a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52cc3498-b837-4444-b388-2d11c883a08a.jpg?1",
             "name": "Teyo, the Shieldmage",
             "text": "",
             "colours": [
@@ -1228,7 +1228,7 @@
         },
         {
             "id": "5de7f2c0-626c-5c8e-8e25-705f9806c0fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfffe235-98b1-43db-9461-1b2da5f0690e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfffe235-98b1-43db-9461-1b2da5f0690e.jpg?1",
             "name": "Teyo's Lightshield",
             "text": "When Teyo's Lightshield enters the battlefield, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1262,7 +1262,7 @@
         },
         {
             "id": "097cd96b-1043-5905-a227-1fa2e91cc59b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346387c-2f13-472b-b5b1-968b490eb38f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f346387c-2f13-472b-b5b1-968b490eb38f.jpg?1",
             "name": "Tomik, Distinguished Advokist",
             "text": "Flying\nLands on the battlefield and land cards in graveyards can't be the targets of spells or abilities your opponents control.\nYour opponents can't play land cards from graveyards.",
             "colours": [
@@ -1299,7 +1299,7 @@
         },
         {
             "id": "b7e80a1e-1cd4-5bbb-aac2-03b95d44d624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2829fa40-92e4-4017-aacd-9d9feae04aa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2829fa40-92e4-4017-aacd-9d9feae04aa2.jpg?1",
             "name": "Topple the Statue",
             "text": "Tap target permanent. If it's an artifact, destroy it.\nDraw a card.",
             "colours": [
@@ -1331,7 +1331,7 @@
         },
         {
             "id": "349613bc-3594-564e-b95d-1ecaa92e6cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bbcaf5-80e9-43f2-b470-de6cbed6a95a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89bbcaf5-80e9-43f2-b470-de6cbed6a95a.jpg?1",
             "name": "Trusted Pegasus",
             "text": "Flying\nWhenever Trusted Pegasus attacks, target attacking creature without flying gains flying until end of turn.",
             "colours": [
@@ -1365,7 +1365,7 @@
         },
         {
             "id": "c1e62a67-65b3-5c9b-8045-94ae5bdbbfb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f0e463-9eed-4348-af7c-fde5f0d8188c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f0e463-9eed-4348-af7c-fde5f0d8188c.jpg?1",
             "name": "The Wanderer",
             "text": "Prevent all noncombat damage that would be dealt to you and other permanents you control.\n\u22122: Exile target creature with power 4 or greater.",
             "colours": [
@@ -1401,7 +1401,7 @@
         },
         {
             "id": "fc82e07b-fa39-56ec-8b31-3e5837753347",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28037c63-67ec-4a57-9a8c-3ba88127a258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28037c63-67ec-4a57-9a8c-3ba88127a258.jpg?1",
             "name": "The Wanderer",
             "text": "",
             "colours": [
@@ -1437,7 +1437,7 @@
         },
         {
             "id": "248cb87f-8fa4-5e2d-8ae9-fdb7ca09cb23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e1d63e-9692-4988-bda2-7c2c9b42217b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85e1d63e-9692-4988-bda2-7c2c9b42217b.jpg?1",
             "name": "Wanderer's Strike",
             "text": "Exile target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1469,7 +1469,7 @@
         },
         {
             "id": "2e95c376-f7f2-5453-9092-3e9d9045ffa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ff7868-eeb9-4292-a2f4-cac18f9ba270.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2ff7868-eeb9-4292-a2f4-cac18f9ba270.jpg?1",
             "name": "War Screecher",
             "text": "Flying\n{5}{W}, {T}: Other creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1503,7 +1503,7 @@
         },
         {
             "id": "7b4e809a-ca53-5a72-a89a-81e2c665ebfe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd5b0a1-104d-4e0f-82de-65487fbf01ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dd5b0a1-104d-4e0f-82de-65487fbf01ff.jpg?1",
             "name": "Ashiok's Skulker",
             "text": "{3}{U}: Ashiok's Skulker can't be blocked this turn.",
             "colours": [
@@ -1537,7 +1537,7 @@
         },
         {
             "id": "0aca5931-a2f4-5710-9087-ca9fdf1fea16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fbfe6-69bb-452a-be3c-b9c625e23193.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19fbfe6-69bb-452a-be3c-b9c625e23193.jpg?1",
             "name": "Augur of Bolas",
             "text": "When Augur of Bolas enters the battlefield, look at the top three cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -1572,7 +1572,7 @@
         },
         {
             "id": "10d6434f-4d3e-5497-ab53-92018c1c8efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe479484-a827-4d3c-8e35-e905e4f6664a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe479484-a827-4d3c-8e35-e905e4f6664a.jpg?1",
             "name": "Aven Eternal",
             "text": "Flying\nWhen Aven Eternal enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1608,7 +1608,7 @@
         },
         {
             "id": "f578a3e3-fb93-53f3-bfa8-9ce139ac0643",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648629af-e911-49e1-b564-c98f339b84a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/648629af-e911-49e1-b564-c98f339b84a1.jpg?1",
             "name": "Bond of Insight",
             "text": "Each player puts the top four cards of their library into their graveyard. Return up to two instant and/or sorcery cards from your graveyard to your hand. Exile Bond of Insight.",
             "colours": [
@@ -1640,7 +1640,7 @@
         },
         {
             "id": "fac498b3-76a0-5fdb-8533-247b33457aa7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cef326-339c-49e5-9905-21a1603a46ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66cef326-339c-49e5-9905-21a1603a46ae.jpg?1",
             "name": "Callous Dismissal",
             "text": "Return target nonland permanent to its owner's hand.\nAmass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1672,7 +1672,7 @@
         },
         {
             "id": "6be49a63-db65-5954-a5da-68bc29ede7e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209d70a2-c8c1-4072-ab1f-57804b55a09a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/209d70a2-c8c1-4072-ab1f-57804b55a09a.jpg?1",
             "name": "Commence the Endgame",
             "text": "This spell can't be countered.\nDraw two cards, then amass X, where X is the number of cards in your hand. (Put X +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1704,7 +1704,7 @@
         },
         {
             "id": "ae99fe47-f3b6-54b9-a206-1081e18779cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e30deb6-9e1f-4545-ae30-c30ba6c7b3a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e30deb6-9e1f-4545-ae30-c30ba6c7b3a0.jpg?1",
             "name": "Contentious Plan",
             "text": "Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)\nDraw a card.",
             "colours": [
@@ -1736,7 +1736,7 @@
         },
         {
             "id": "46bd1799-9a0a-5fd1-93d6-708a585dc71b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c70f23-0ca9-425e-a53a-6c09921c0075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94c70f23-0ca9-425e-a53a-6c09921c0075.jpg?1",
             "name": "Crush Dissent",
             "text": "Counter target spell unless its controller pays {2}.\nAmass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -1768,7 +1768,7 @@
         },
         {
             "id": "cadda636-34e1-5556-a9fb-ac9f76ead093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03188bc3-0ef1-40cd-9c3c-4bb4d806fb92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03188bc3-0ef1-40cd-9c3c-4bb4d806fb92.jpg?1",
             "name": "Erratic Visionary",
             "text": "{1}{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -1803,7 +1803,7 @@
         },
         {
             "id": "6526da20-d411-520b-863d-64604f79b30e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aacfc9-1d45-4250-9abc-698d8941699f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5aacfc9-1d45-4250-9abc-698d8941699f.jpg?1",
             "name": "Eternal Skylord",
             "text": "When Eternal Skylord enters the battlefield, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have flying.",
             "colours": [
@@ -1838,7 +1838,7 @@
         },
         {
             "id": "ccefb41c-79d7-5103-866b-6ec1116a0719",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52558748-6893-4c72-a9e2-e87d31796b59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52558748-6893-4c72-a9e2-e87d31796b59.jpg?1",
             "name": "Fblthp, the Lost",
             "text": "When Fblthp, the Lost enters the battlefield, draw a card. If it entered from your library or was cast from your library, draw two cards instead.\nWhen Fblthp becomes the target of a spell, shuffle Fblthp into its owner's library.",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "aaa8f0c2-5bd4-567a-96fc-36a6bbae6e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6630c34a-1a97-4e31-9d2c-1150b0aa903e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6630c34a-1a97-4e31-9d2c-1150b0aa903e.jpg?1",
             "name": "Finale of Revelation",
             "text": "Draw X cards. If X is 10 or more, instead shuffle your graveyard into your library, draw X cards, untap up to five lands, and you have no maximum hand size for the rest of the game.\nExile Finale of Revelation.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "62322fa3-842a-5665-a121-a21340b70710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202e82-e159-482f-9224-292cb533171c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6202e82-e159-482f-9224-292cb533171c.jpg?1",
             "name": "Flux Channeler",
             "text": "Whenever you cast a noncreature spell, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -1941,7 +1941,7 @@
         },
         {
             "id": "14bde121-71a2-5ea9-8145-6022b329c24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14060f-9167-4e28-a053-77689e066e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14060f-9167-4e28-a053-77689e066e30.jpg?1",
             "name": "God-Eternal Kefnet",
             "text": "Flying\nYou may reveal the first card you draw each turn as you draw it. Whenever you reveal an instant or sorcery card this way, copy that card and you may cast the copy. That copy costs {2} less to cast.\nWhen God-Eternal Kefnet dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -1978,7 +1978,7 @@
         },
         {
             "id": "de19d916-8688-5083-9608-5f09f09be8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb7d73-4482-4930-8497-cffd169b57e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6adb7d73-4482-4930-8497-cffd169b57e2.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "If you would draw a card while your library has no cards in it, you win the game instead.\n+1: Target player puts the top two cards of their library into their graveyard. Draw a card.\n\u22128: Draw seven cards. Then if your library has no cards in it, you win the game.",
             "colours": [
@@ -2016,7 +2016,7 @@
         },
         {
             "id": "6c88eb11-319a-5061-befd-1073c165e603",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50eb8cf-dc8d-4c7e-bff7-db9254ff8a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d50eb8cf-dc8d-4c7e-bff7-db9254ff8a90.jpg?1",
             "name": "Jace, Wielder of Mysteries",
             "text": "",
             "colours": [
@@ -2054,7 +2054,7 @@
         },
         {
             "id": "a1d983f9-e380-5457-bb91-a5fdd8426a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4924f177-5ee2-4d3f-9603-4b9aef4dac09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/4924f177-5ee2-4d3f-9603-4b9aef4dac09.jpg?1",
             "name": "Jace's Triumph",
             "text": "Draw two cards. If you control a Jace planeswalker, draw three cards instead.",
             "colours": [
@@ -2086,7 +2086,7 @@
         },
         {
             "id": "0fe56d65-a3e6-559c-8c89-068f4694d32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77d9454-a78c-4063-ad66-46b2f5a030aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c77d9454-a78c-4063-ad66-46b2f5a030aa.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "Spells your opponents cast that target a creature or planeswalker you control cost {2} more to cast.\n\u22122: Create a 2/2 blue Wizard creature token. Draw a card, then discard a card.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "a2a8ab63-1d7a-5c6c-aef5-2ff698b4e4d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac128e-5784-467c-85ed-e46c6ab25547.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9eac128e-5784-467c-85ed-e46c6ab25547.jpg?1",
             "name": "Kasmina, Enigmatic Mentor",
             "text": "",
             "colours": [
@@ -2162,7 +2162,7 @@
         },
         {
             "id": "9197605c-a8cd-59f3-9ec4-8ee58a904e09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9771412-695a-4e89-b146-0e3a7336d319.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9771412-695a-4e89-b146-0e3a7336d319.jpg?1",
             "name": "Kasmina's Transmutation",
             "text": "Enchant creature\nEnchanted creature loses all abilities and has base power and toughness 1/1.",
             "colours": [
@@ -2196,7 +2196,7 @@
         },
         {
             "id": "0d49a203-86df-536e-abdd-38193187f5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd61fb0-a82b-4f46-8043-c6b89764720b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acd61fb0-a82b-4f46-8043-c6b89764720b.jpg?1",
             "name": "Kiora's Dambreaker",
             "text": "When Kiora's Dambreaker enters the battlefield, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -2230,7 +2230,7 @@
         },
         {
             "id": "bd1e3301-e099-5695-928f-76c8b06db444",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03b5405-6016-405b-a504-a454731b9276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f03b5405-6016-405b-a504-a454731b9276.jpg?1",
             "name": "Lazotep Plating",
             "text": "Amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nYou and permanents you control gain hexproof until end of turn. (You and they can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -2262,7 +2262,7 @@
         },
         {
             "id": "557e146d-0f14-54b2-8cb8-f202621c56c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f244233-f2e8-48f8-9106-e7cd186efd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f244233-f2e8-48f8-9106-e7cd186efd51.jpg?1",
             "name": "Naga Eternal",
             "text": "",
             "colours": [
@@ -2297,7 +2297,7 @@
         },
         {
             "id": "4fa9e9f5-c36f-507e-abbb-0c90f4fd8772",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c39f9b4-02b9-4d44-b8d6-4fd02ebbb0c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c39f9b4-02b9-4d44-b8d6-4fd02ebbb0c5.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "Each opponent can't draw more than one card each turn.\n\u22122: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2335,7 +2335,7 @@
         },
         {
             "id": "ee637963-2d06-5ab7-9678-a3428c4ce419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078151b-74b7-426a-9ee5-d83799ca2b85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e078151b-74b7-426a-9ee5-d83799ca2b85.jpg?1",
             "name": "Narset, Parter of Veils",
             "text": "",
             "colours": [
@@ -2373,7 +2373,7 @@
         },
         {
             "id": "bc654c56-bae4-5998-9c1d-ec43537eed6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63754036-d51e-47bb-925b-564d9dc922ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63754036-d51e-47bb-925b-564d9dc922ff.jpg?1",
             "name": "Narset's Reversal",
             "text": "Copy target instant or sorcery spell, then return it to its owner's hand. You may choose new targets for the copy.",
             "colours": [
@@ -2405,7 +2405,7 @@
         },
         {
             "id": "61fa7145-af2b-59a2-92dd-48d19be60152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9888a1-6f35-4802-b8fb-902017736d4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9888a1-6f35-4802-b8fb-902017736d4a.jpg?1",
             "name": "No Escape",
             "text": "Counter target creature or planeswalker spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.\nScry 1.",
             "colours": [
@@ -2437,7 +2437,7 @@
         },
         {
             "id": "0abe85a1-668c-50cd-a669-1453d00c2f33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258e242-91c6-4b30-86ec-7759705aa97c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4258e242-91c6-4b30-86ec-7759705aa97c.jpg?1",
             "name": "Relentless Advance",
             "text": "Amass 3. (Put three +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "1c659d00-2878-587f-9347-64a900ca1440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ba9fa2-bfd2-4dc7-b96d-d22a8886a6ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00ba9fa2-bfd2-4dc7-b96d-d22a8886a6ae.jpg?1",
             "name": "Rescuer Sphinx",
             "text": "Flying\nAs Rescuer Sphinx enters the battlefield, you may return a nonland permanent you control to its owner's hand. If you do, Rescuer Sphinx enters the battlefield with a +1/+1 counter on it.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "05444e76-0331-53d6-a734-12eaee10b5f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2f3dee-1768-4562-9333-a50b9ee7570f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae2f3dee-1768-4562-9333-a50b9ee7570f.jpg?1",
             "name": "Silent Submersible",
             "text": "Whenever Silent Submersible deals combat damage to a player or planeswalker, draw a card.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -2537,7 +2537,7 @@
         },
         {
             "id": "1c74cb7d-39f3-527a-b3d1-9dea4a7287ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98902dd9-f21c-4419-8205-4b9d6592bf28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98902dd9-f21c-4419-8205-4b9d6592bf28.jpg?1",
             "name": "Sky Theater Strix",
             "text": "Flying\nWhenever you cast a noncreature spell, Sky Theater Strix gets +1/+0 until end of turn.",
             "colours": [
@@ -2571,7 +2571,7 @@
         },
         {
             "id": "2411ffb6-b1ef-52c5-865e-c87e30460d3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8a103c-b776-4501-9441-a45b90391045.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb8a103c-b776-4501-9441-a45b90391045.jpg?1",
             "name": "Spark Double",
             "text": "You may have Spark Double enter the battlefield as a copy of a creature or planeswalker you control, except it enters with an additional +1/+1 counter on it if it's a creature, it enters with an additional loyalty counter on it if it's a planeswalker, and it isn't legendary if that permanent is legendary.",
             "colours": [
@@ -2605,7 +2605,7 @@
         },
         {
             "id": "93487570-31c1-5213-91a0-fdce2928e9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e42dad-5958-443f-a196-12b3f3e44213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74e42dad-5958-443f-a196-12b3f3e44213.jpg?1",
             "name": "Spellkeeper Weird",
             "text": "{2}, {T}, Sacrifice Spellkeeper Weird: Return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2639,7 +2639,7 @@
         },
         {
             "id": "4a99f85f-5d1f-5870-b5a0-2eccb277f384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfd4f5-7fe1-4a22-9a85-bd9b75b16380.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7ddfd4f5-7fe1-4a22-9a85-bd9b75b16380.jpg?1",
             "name": "Stealth Mission",
             "text": "Put two +1/+1 counters on target creature you control. That creature can't be blocked this turn.",
             "colours": [
@@ -2671,7 +2671,7 @@
         },
         {
             "id": "b42398ff-b92c-5eec-8fb2-7e0e5e40ec3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce338cf3-46dc-4c87-8df5-af27097c7dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce338cf3-46dc-4c87-8df5-af27097c7dd4.jpg?1",
             "name": "Tamiyo's Epiphany",
             "text": "Scry 4, then draw two cards.",
             "colours": [
@@ -2703,7 +2703,7 @@
         },
         {
             "id": "eb459f4b-50c6-5a93-a773-1f88d168d971",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c878bdc0-d697-4a2f-bba5-758b27f4247a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c878bdc0-d697-4a2f-bba5-758b27f4247a.jpg?1",
             "name": "Teferi's Time Twist",
             "text": "Exile target permanent you control. Return that card to the battlefield under its owner's control at the beginning of the next end step. If it enters the battlefield as a creature, it enters with an additional +1/+1 counter on it.",
             "colours": [
@@ -2735,7 +2735,7 @@
         },
         {
             "id": "f5014458-218e-5625-bbbc-f1895a9509e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a9bc4-1b15-4a91-9376-730d2f5b3336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f88a9bc4-1b15-4a91-9376-730d2f5b3336.jpg?1",
             "name": "Thunder Drake",
             "text": "Flying\nWhenever you cast your second spell each turn, put a +1/+1 counter on Thunder Drake.",
             "colours": [
@@ -2770,7 +2770,7 @@
         },
         {
             "id": "08f8bb29-6091-50d2-afab-6b80087ce067",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffef78-f776-42d3-ab40-3347c8e5c88b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adffef78-f776-42d3-ab40-3347c8e5c88b.jpg?1",
             "name": "Totally Lost",
             "text": "Put target nonland permanent on top of its owner's library.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "7610bd8e-d995-51a9-a46a-6e295f9488a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96613089-3508-429a-9f90-23168d56bbe7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96613089-3508-429a-9f90-23168d56bbe7.jpg?1",
             "name": "Wall of Runes",
             "text": "Defender\nWhen Wall of Runes enters the battlefield, scry 1.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "d11acd0d-21cc-5dbb-bbe8-2603146a20ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bc010-f1af-42a2-9009-2039cf3d8f0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f8bc010-f1af-42a2-9009-2039cf3d8f0a.jpg?1",
             "name": "Aid the Fallen",
             "text": "Choose one or both \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return target planeswalker card from your graveyard to your hand.",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "fc0f3291-22a4-58e5-b03e-b971c5403c53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e03567-c95a-40b8-a75a-971076093f57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9e03567-c95a-40b8-a75a-971076093f57.jpg?1",
             "name": "Banehound",
             "text": "Lifelink, haste",
             "colours": [
@@ -2903,7 +2903,7 @@
         },
         {
             "id": "bed79a7b-995f-5103-8b6f-d626053b4203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82422c-8ac8-4fbb-b9b9-d0aa23dded61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac82422c-8ac8-4fbb-b9b9-d0aa23dded61.jpg?1",
             "name": "Bleeding Edge",
             "text": "Up to one target creature gets -2/-2 until end of turn. Amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -2935,7 +2935,7 @@
         },
         {
             "id": "4ae50b85-70ab-5cc3-b836-dd273375f5ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2124603-d20e-40eb-97f0-a66323397ac2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2124603-d20e-40eb-97f0-a66323397ac2.jpg?1",
             "name": "Bolas's Citadel",
             "text": "You may look at the top card of your library any time.\nYou may play the top card of your library. If you cast a spell this way, pay life equal to its converted mana cost rather than pay its mana cost.\n{T}, Sacrifice ten nonland permanents: Each opponent loses 10 life.",
             "colours": [
@@ -2969,7 +2969,7 @@
         },
         {
             "id": "56a30d0f-fb9d-554f-bbab-61c863e41169",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6482fb9-f874-4e33-aa74-7a0da4c9760c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6482fb9-f874-4e33-aa74-7a0da4c9760c.jpg?1",
             "name": "Bond of Revival",
             "text": "Return target creature card from your graveyard to the battlefield. It gains haste until your next turn.",
             "colours": [
@@ -3001,7 +3001,7 @@
         },
         {
             "id": "5f61c1b9-63ad-5a82-9438-360edd6eea85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3594f726-cdbb-4b7d-bcfe-17d5f8cd5228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3594f726-cdbb-4b7d-bcfe-17d5f8cd5228.jpg?1",
             "name": "Charity Extractor",
             "text": "Lifelink",
             "colours": [
@@ -3036,7 +3036,7 @@
         },
         {
             "id": "b132e71e-617c-5a0d-acef-c27efce402ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ec307-45e0-4853-85fe-9ce859b188c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ec307-45e0-4853-85fe-9ce859b188c2.jpg?1",
             "name": "Command the Dreadhorde",
             "text": "Choose any number of target creature and/or planeswalker cards in graveyards. Command the Dreadhorde deals damage to you equal to the total converted mana cost of those cards. Put them onto the battlefield under your control.",
             "colours": [
@@ -3068,7 +3068,7 @@
         },
         {
             "id": "450bcf93-03fd-59f8-a8ed-1ac506f2786c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a44f0-1db8-406a-b7d9-f883f947f7bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b1a44f0-1db8-406a-b7d9-f883f947f7bd.jpg?1",
             "name": "Davriel, Rogue Shadowmage",
             "text": "At the beginning of each opponent's upkeep, if that player has one or fewer cards in hand, Davriel, Rogue Shadowmage deals 2 damage to them.\n\u22121: Target player discards a card.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "e514382a-9f86-5af0-bcdd-623eb2da60ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce03906-fef8-4636-945c-95b857cbeab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce03906-fef8-4636-945c-95b857cbeab0.jpg?1",
             "name": "Davriel, Rogue Shadowmage",
             "text": "",
             "colours": [
@@ -3144,7 +3144,7 @@
         },
         {
             "id": "1fb4ee52-0ee4-5117-bf54-538f17eb9822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8fe63-37a7-478d-b9ba-33a0f6519cf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8fe63-37a7-478d-b9ba-33a0f6519cf1.jpg?1",
             "name": "Davriel's Shadowfugue",
             "text": "Target player discards two cards and loses 2 life.",
             "colours": [
@@ -3176,7 +3176,7 @@
         },
         {
             "id": "b7c73fc0-f175-57df-9b59-01dfd2ec8e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aa7104-7acc-4827-b763-ac053c99baab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aa7104-7acc-4827-b763-ac053c99baab.jpg?1",
             "name": "Deliver Unto Evil",
             "text": "Choose up to four target cards in your graveyard. If you control a Bolas planeswalker, return those cards to your hand. Otherwise, an opponent chooses two of them. Leave the chosen cards in your graveyard and put the rest into your hand.\nExile Deliver Unto Evil.",
             "colours": [
@@ -3208,7 +3208,7 @@
         },
         {
             "id": "5589028d-25c2-556b-9aa5-dff384ae6200",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c6e42d-991d-4e6b-a900-38480931f79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04c6e42d-991d-4e6b-a900-38480931f79e.jpg?1",
             "name": "Dreadhorde Invasion",
             "text": "At the beginning of your upkeep, you lose 1 life and amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nWhenever a Zombie token you control with power 6 or greater attacks, it gains lifelink until end of turn.",
             "colours": [
@@ -3240,7 +3240,7 @@
         },
         {
             "id": "0736085a-62ee-58bf-aa23-fef2afef4e43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327cfac-a4a4-445e-9d04-51c1ca142140.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327cfac-a4a4-445e-9d04-51c1ca142140.jpg?1",
             "name": "Dreadmalkin",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\n{2}{B}, Sacrifice another creature or planeswalker: Put two +1/+1 counters on Dreadmalkin.",
             "colours": [
@@ -3275,7 +3275,7 @@
         },
         {
             "id": "73e28193-a44b-5c38-bb10-82e832bec6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16eb5a6b-5e69-497c-a0c9-4165ad0f5d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16eb5a6b-5e69-497c-a0c9-4165ad0f5d0b.jpg?1",
             "name": "Duskmantle Operative",
             "text": "Duskmantle Operative can't be blocked by creatures with power 4 or greater.",
             "colours": [
@@ -3310,7 +3310,7 @@
         },
         {
             "id": "be75eb27-bb09-589b-8115-102852c8baf7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b16625-7faf-4de6-abf7-d397988e32fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3b16625-7faf-4de6-abf7-d397988e32fb.jpg?1",
             "name": "The Elderspell",
             "text": "Destroy any number of target planeswalkers. Choose a planeswalker you control. Put two loyalty counters on it for each planeswalker destroyed this way.",
             "colours": [
@@ -3342,7 +3342,7 @@
         },
         {
             "id": "71b101c1-e8cf-5f25-93b3-534bb11f285b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7789188e-5caa-4500-b3e4-bb95f7657903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7789188e-5caa-4500-b3e4-bb95f7657903.jpg?1",
             "name": "Eternal Taskmaster",
             "text": "Eternal Taskmaster enters the battlefield tapped.\nWhenever Eternal Taskmaster attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand.",
             "colours": [
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "3e448b1f-26b7-54e4-b0e2-ba9555b19d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c60177-8b71-4e24-87e7-395d5e4f93ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85c60177-8b71-4e24-87e7-395d5e4f93ff.jpg?1",
             "name": "Finale of Eternity",
             "text": "Destroy up to three target creatures with toughness X or less. If X is 10 or more, return all creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -3408,7 +3408,7 @@
         },
         {
             "id": "7877d2ca-9220-5e0d-840e-68c6b5975b52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714a135-e2b9-43a7-a2a2-fa5a2e0ac61a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3714a135-e2b9-43a7-a2a2-fa5a2e0ac61a.jpg?1",
             "name": "God-Eternal Bontu",
             "text": "Menace\nWhen God-Eternal Bontu enters the battlefield, sacrifice any number of other permanents, then draw that many cards.\nWhen God-Eternal Bontu dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -3445,7 +3445,7 @@
         },
         {
             "id": "d2b2455f-2026-5384-875b-8958d85207a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae9cb7-a3af-4224-89a5-a72f4d09dacf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae9cb7-a3af-4224-89a5-a72f4d09dacf.jpg?1",
             "name": "Herald of the Dreadhorde",
             "text": "When Herald of the Dreadhorde dies, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -3480,7 +3480,7 @@
         },
         {
             "id": "315620f5-2920-574f-b428-feafdf9e885b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f3be88-24e2-433f-9138-f0cb59d09a0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98f3be88-24e2-433f-9138-f0cb59d09a0f.jpg?1",
             "name": "Kaya's Ghostform",
             "text": "Enchant creature or planeswalker you control\nWhen enchanted permanent dies or is put into exile, return that card to the battlefield under your control.",
             "colours": [
@@ -3514,7 +3514,7 @@
         },
         {
             "id": "793a2190-c40b-5ee8-8736-d03a778e1e9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be6f22-e9e8-462a-956b-e1c78bbadacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4be6f22-e9e8-462a-956b-e1c78bbadacc.jpg?1",
             "name": "Lazotep Behemoth",
             "text": "",
             "colours": [
@@ -3549,7 +3549,7 @@
         },
         {
             "id": "17a987be-195f-58a4-8e0f-a8d1979d0337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594bbe43-a8aa-42aa-bc49-cb4f3bc05cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/594bbe43-a8aa-42aa-bc49-cb4f3bc05cad.jpg?1",
             "name": "Lazotep Reaver",
             "text": "When Lazotep Reaver enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -3584,7 +3584,7 @@
         },
         {
             "id": "8f8ae2ff-0bcc-575d-bb3e-4f26b0bc7b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75ebba8-34ca-47a0-bf13-8318ad73b343.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d75ebba8-34ca-47a0-bf13-8318ad73b343.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n\u22124: Each player sacrifices two creatures.\n\u22129: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
             "colours": [
@@ -3622,7 +3622,7 @@
         },
         {
             "id": "09683aa4-d39d-518d-8e22-d13c129f3ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e3667-33be-415f-8f10-1c42a78d7637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/199e3667-33be-415f-8f10-1c42a78d7637.jpg?1",
             "name": "Liliana, Dreadhorde General",
             "text": "",
             "colours": [
@@ -3660,7 +3660,7 @@
         },
         {
             "id": "88b9bd21-a393-5aa8-bc37-3c2a4ec676d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84803db8-fdb0-462b-92f6-33d591593d2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84803db8-fdb0-462b-92f6-33d591593d2d.jpg?1",
             "name": "Liliana's Triumph",
             "text": "Each opponent sacrifices a creature. If you control a Liliana planeswalker, each opponent also discards a card.",
             "colours": [
@@ -3692,7 +3692,7 @@
         },
         {
             "id": "0092adb5-ab0a-5315-baa0-c389c994f52f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8ec9e1-2c8e-496d-9111-4d453b75b578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be8ec9e1-2c8e-496d-9111-4d453b75b578.jpg?1",
             "name": "Massacre Girl",
             "text": "Menace\nWhen Massacre Girl enters the battlefield, each other creature gets -1/-1 until end of turn. Whenever a creature dies this turn, each creature other than Massacre Girl gets -1/-1 until end of turn.",
             "colours": [
@@ -3729,7 +3729,7 @@
         },
         {
             "id": "745de871-6f1e-5f41-95ca-069289359d8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14916e2d-73af-4747-a927-d2d4cb3e32db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14916e2d-73af-4747-a927-d2d4cb3e32db.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "Whenever an opponent draws a card, Ob Nixilis, the Hate-Twisted deals 1 damage to that player.\n\u22122: Destroy target creature. Its controller draws two cards.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "9ee15cd2-7dc1-5db7-b6d6-81aed4a84db8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b67ca03-f759-4d7c-8527-7a569e7bfad1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b67ca03-f759-4d7c-8527-7a569e7bfad1.jpg?1",
             "name": "Ob Nixilis, the Hate-Twisted",
             "text": "",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "4310b589-7fd2-597e-bdd4-1be54c5af6da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db72a8-57f7-4f17-9f09-cae90ef50304.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94db72a8-57f7-4f17-9f09-cae90ef50304.jpg?1",
             "name": "Ob Nixilis's Cruelty",
             "text": "Target creature gets -5/-5 until end of turn. If that creature would die this turn, exile it instead.",
             "colours": [
@@ -3837,7 +3837,7 @@
         },
         {
             "id": "0cc0f683-bb90-56ca-a34a-4f47eeba1bac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd68e918-5089-46c9-8836-b05a3da3c7a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd68e918-5089-46c9-8836-b05a3da3c7a3.jpg?1",
             "name": "Price of Betrayal",
             "text": "Remove up to five counters from target artifact, creature, planeswalker, or opponent.",
             "colours": [
@@ -3869,7 +3869,7 @@
         },
         {
             "id": "a370d47d-42a3-546f-b2bc-743d0cef6035",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1c3148-7a6f-4963-af0b-18d9a156bf22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a1c3148-7a6f-4963-af0b-18d9a156bf22.jpg?1",
             "name": "Shriekdiver",
             "text": "Flying\n{1}: Shriekdiver gains haste until end of turn.",
             "colours": [
@@ -3905,7 +3905,7 @@
         },
         {
             "id": "49c8722b-11e4-5007-a871-a88e56ea1bdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eecfc2-452d-461c-a37c-8aa10183e5a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50eecfc2-452d-461c-a37c-8aa10183e5a0.jpg?1",
             "name": "Sorin's Thirst",
             "text": "Sorin's Thirst deals 2 damage to target creature and you gain 2 life.",
             "colours": [
@@ -3937,7 +3937,7 @@
         },
         {
             "id": "89ba71fa-c8c6-55f3-a1df-138cbd5a4319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013a138-f8e2-4a67-91e8-759288d985a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/2013a138-f8e2-4a67-91e8-759288d985a7.jpg?1",
             "name": "Spark Harvest",
             "text": "As an additional cost to cast this spell, sacrifice a creature or pay {3}{B}.\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3969,7 +3969,7 @@
         },
         {
             "id": "50350615-04ba-5d26-aaff-578314d2d25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922537f0-4caf-481c-b431-826f0c44e5c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/922537f0-4caf-481c-b431-826f0c44e5c5.jpg?1",
             "name": "Spark Reaper",
             "text": "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card.",
             "colours": [
@@ -4003,7 +4003,7 @@
         },
         {
             "id": "79e7cdeb-5d82-53e4-888b-afd2173658cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c305ccb-62f5-496a-a205-e818e34ead82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c305ccb-62f5-496a-a205-e818e34ead82.jpg?1",
             "name": "Tithebearer Giant",
             "text": "When Tithebearer Giant enters the battlefield, you draw a card and you lose 1 life.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "cb61867b-e6af-5d15-aed9-5200e89ea040",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471c2a5-aa2c-47e2-8238-1eb366c8adc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4471c2a5-aa2c-47e2-8238-1eb366c8adc9.jpg?1",
             "name": "Toll of the Invasion",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nAmass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4070,7 +4070,7 @@
         },
         {
             "id": "1d18dedb-2446-5b68-965c-fc5a7ec53c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c260c5c-e796-4f81-9e15-0c5be75106b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c260c5c-e796-4f81-9e15-0c5be75106b9.jpg?1",
             "name": "Unlikely Aid",
             "text": "Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and  effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -4102,7 +4102,7 @@
         },
         {
             "id": "349a59bc-cc3e-5402-b2a5-6e30442befe8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf21a4-616d-48a5-a104-180c24491761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8cf21a4-616d-48a5-a104-180c24491761.jpg?1",
             "name": "Vampire Opportunist",
             "text": "{6}{B}: Each opponent loses 2 life and you gain 2 life.",
             "colours": [
@@ -4136,7 +4136,7 @@
         },
         {
             "id": "077ea8a8-24b7-575b-9c34-ba7f54fb5099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2444c7dc-7aa1-4476-8660-19d26607306d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2444c7dc-7aa1-4476-8660-19d26607306d.jpg?1",
             "name": "Vizier of the Scorpion",
             "text": "When Vizier of the Scorpion enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have deathtouch.",
             "colours": [
@@ -4171,7 +4171,7 @@
         },
         {
             "id": "ce6a2697-5f3a-5857-ab1b-ac015d9f32f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89fa379-7fae-4fbf-8e31-0ef3645353c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f89fa379-7fae-4fbf-8e31-0ef3645353c5.jpg?1",
             "name": "Vraska's Finisher",
             "text": "When Vraska's Finisher enters the battlefield, destroy target creature or planeswalker an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4206,7 +4206,7 @@
         },
         {
             "id": "40d6739e-7d71-559a-8756-35d42dcac450",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dea2466-5c7f-40ce-b749-100ae89d2c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dea2466-5c7f-40ce-b749-100ae89d2c90.jpg?1",
             "name": "Ahn-Crop Invader",
             "text": "As long as it's your turn, Ahn-Crop Invader has first strike.\n{1}, Sacrifice another creature: Ahn-Crop Invader gets +2/+0 until end of turn.",
             "colours": [
@@ -4242,7 +4242,7 @@
         },
         {
             "id": "19827ebf-3b49-5021-ac7f-f6c125a3bdd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d49637b-2255-4f16-8f24-140145966bfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d49637b-2255-4f16-8f24-140145966bfa.jpg?1",
             "name": "Blindblast",
             "text": "Blindblast deals 1 damage to target creature. That creature can't block this turn.\nDraw a card.",
             "colours": [
@@ -4274,7 +4274,7 @@
         },
         {
             "id": "5af182ba-dc7c-5177-961e-bcc07ee1f180",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b35408-3728-4e1b-9f58-b0775df914d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b35408-3728-4e1b-9f58-b0775df914d6.jpg?1",
             "name": "Bolt Bend",
             "text": "This spell costs {3} less to cast if you control a creature with power 4 or greater.\nChange the target of target spell or ability with a single target.",
             "colours": [
@@ -4306,7 +4306,7 @@
         },
         {
             "id": "cb422986-4248-54ca-8a3a-d5e842ecd0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae644e9d-9bc4-4ccd-aef4-3d0559948aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae644e9d-9bc4-4ccd-aef4-3d0559948aa6.jpg?1",
             "name": "Bond of Passion",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Bond of Passion deals 2 damage to any other target.",
             "colours": [
@@ -4338,7 +4338,7 @@
         },
         {
             "id": "42909c0b-ed28-5e9f-abe2-d8abc284f7c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5b095-13c9-4673-bf0c-553de455e521.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c5b095-13c9-4673-bf0c-553de455e521.jpg?1",
             "name": "Burning Prophet",
             "text": "Whenever you cast a noncreature spell, Burning Prophet gets +1/+0 until end of turn, then scry 1.",
             "colours": [
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "e2b23487-2a53-5b2d-a4f7-ca6a487fc388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f18df2-5910-4c5d-8b04-6fe5d04e8150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2f18df2-5910-4c5d-8b04-6fe5d04e8150.jpg?1",
             "name": "Chainwhip Cyclops",
             "text": "{3}{R}: Target creature can't block this turn.",
             "colours": [
@@ -4408,7 +4408,7 @@
         },
         {
             "id": "638fe5e4-2dbe-5aee-9f9a-f7b47ee3275a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21a7b23-8827-49f2-ade4-75a602d17743.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d21a7b23-8827-49f2-ade4-75a602d17743.jpg?1",
             "name": "Chandra, Fire Artisan",
             "text": "Whenever one or more loyalty counters are removed from Chandra, Fire Artisan, she deals that much damage to target opponent or planeswalker.\n+1: Exile the top card of your library. You may play it this turn.\n\u22127: Exile the top seven cards of your library. You may play them this turn.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "29741223-18c8-5ad7-b1fc-0b9a68dbd768",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b129f92-e6c4-4967-bd0c-02ff85f09636.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b129f92-e6c4-4967-bd0c-02ff85f09636.jpg?1",
             "name": "Chandra, Fire Artisan",
             "text": "",
             "colours": [
@@ -4484,7 +4484,7 @@
         },
         {
             "id": "4c926dd3-a5d5-5fa3-80b0-c0f61110ea7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c482f51-9222-4e9e-a9fd-bb14a0afe156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c482f51-9222-4e9e-a9fd-bb14a0afe156.jpg?1",
             "name": "Chandra's Pyrohelix",
             "text": "Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.",
             "colours": [
@@ -4516,7 +4516,7 @@
         },
         {
             "id": "176681b6-28dd-5e3c-b5dc-02e8b9117371",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f43c17-7022-4052-86b8-90b74382b7bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70f43c17-7022-4052-86b8-90b74382b7bf.jpg?1",
             "name": "Chandra's Triumph",
             "text": "Chandra's Triumph deals 3 damage to target creature or planeswalker an opponent controls. Chandra's Triumph deals 5 damage to that permanent instead if you control a Chandra planeswalker.",
             "colours": [
@@ -4548,7 +4548,7 @@
         },
         {
             "id": "eb8d5ba3-3eb1-5a20-8451-2d52fb4d3353",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0966a6-f378-4975-88ae-23b600d578bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da0966a6-f378-4975-88ae-23b600d578bf.jpg?1",
             "name": "Cyclops Electromancer",
             "text": "When Cyclops Electromancer enters the battlefield, it deals X damage to target creature an opponent controls, where X is the number of instant and sorcery cards in your graveyard.",
             "colours": [
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "483cf41b-2659-5bee-a737-5f70b394bdfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00211dd-6dd7-40d9-80f3-f909f6d112db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b00211dd-6dd7-40d9-80f3-f909f6d112db.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "f92874f5-a27c-5f8e-951b-5b21af4ab78b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88205574-bf2b-46e7-aac7-4b8ea217f94c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88205574-bf2b-46e7-aac7-4b8ea217f94c.jpg?1",
             "name": "Devouring Hellion",
             "text": "As Devouring Hellion enters the battlefield, you may sacrifice any number of creatures and/or planeswalkers. If you do, it enters with twice that many +1/+1 counters on it.",
             "colours": [
@@ -4649,7 +4649,7 @@
         },
         {
             "id": "f9c065dc-1677-52a6-891c-0130e443c624",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97b3cf-924e-4f77-bb82-0bf19592389f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd97b3cf-924e-4f77-bb82-0bf19592389f.jpg?1",
             "name": "Dreadhorde Arcanist",
             "text": "Trample\nWhenever Dreadhorde Arcanist attacks, you may cast target instant or sorcery card with converted mana cost less than or equal to Dreadhorde Arcanist's power from your graveyard without paying its mana cost. If that card would be put into your graveyard this turn, exile it instead.",
             "colours": [
@@ -4684,7 +4684,7 @@
         },
         {
             "id": "7db415c9-fd0a-509b-a5a8-44da6b18e496",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82017bf6-352f-4e81-8fd5-c1b0daf05b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82017bf6-352f-4e81-8fd5-c1b0daf05b01.jpg?1",
             "name": "Dreadhorde Twins",
             "text": "When Dreadhorde Twins enters the battlefield, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have trample.",
             "colours": [
@@ -4720,7 +4720,7 @@
         },
         {
             "id": "6f6fdec6-cbe0-594b-bd8f-582ff3a14aa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b2dda-e1b7-4a46-83cc-5cdc17554836.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b2dda-e1b7-4a46-83cc-5cdc17554836.jpg?1",
             "name": "Finale of Promise",
             "text": "You may cast up to one target instant card and/or up to one target sorcery card from your graveyard each with converted mana cost X or less without paying their mana costs. If a card cast this way would be put into your graveyard this turn, exile it instead. If X is 10 or more, copy each of those spells twice. You may choose new targets for the copies.",
             "colours": [
@@ -4752,7 +4752,7 @@
         },
         {
             "id": "249cf960-24ec-5fca-9a48-fe636c2e51ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41acc81-7c22-4b59-97b8-54473623db6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41acc81-7c22-4b59-97b8-54473623db6f.jpg?1",
             "name": "Goblin Assailant",
             "text": "",
             "colours": [
@@ -4787,7 +4787,7 @@
         },
         {
             "id": "fd401566-339d-5cb8-aa09-7a4b47f60c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880047fd-d258-40fb-bcd5-37cb26678dfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/880047fd-d258-40fb-bcd5-37cb26678dfe.jpg?1",
             "name": "Goblin Assault Team",
             "text": "Haste\nWhen Goblin Assault Team dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -4822,7 +4822,7 @@
         },
         {
             "id": "c062dba2-9085-5a97-803d-5529a4b11a49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b6ec9d-3861-48bf-a198-dc7efba5d89c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29b6ec9d-3861-48bf-a198-dc7efba5d89c.jpg?1",
             "name": "Grim Initiate",
             "text": "First strike\nWhen Grim Initiate dies, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4857,7 +4857,7 @@
         },
         {
             "id": "da9c6cbe-b7c9-502d-a3d9-9b26b30b5279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db219ea-2ed1-4a86-955c-d61ecedbc019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db219ea-2ed1-4a86-955c-d61ecedbc019.jpg?1",
             "name": "Heartfire",
             "text": "As an additional cost to cast this spell, sacrifice a creature or planeswalker.\nHeartfire deals 4 damage to any target.",
             "colours": [
@@ -4889,7 +4889,7 @@
         },
         {
             "id": "39c545fc-99ba-5d4b-b11a-346639422041",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75844d13-74f5-4008-9bc6-2f6d04f378aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75844d13-74f5-4008-9bc6-2f6d04f378aa.jpg?1",
             "name": "Honor the God-Pharaoh",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards. Amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4921,7 +4921,7 @@
         },
         {
             "id": "055930a7-4004-551d-82f0-60686ba51ab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0109b60-09aa-4a03-92e7-0c651d976d51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0109b60-09aa-4a03-92e7-0c651d976d51.jpg?1",
             "name": "Ilharg, the Raze-Boar",
             "text": "Trample\nWhenever Ilharg, the Raze-Boar attacks, you may put a creature card from your hand onto the battlefield tapped and attacking. Return that creature to your hand at the beginning of the next end step.\nWhen Ilharg, the Raze-Boar dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -4958,7 +4958,7 @@
         },
         {
             "id": "f689a73c-545b-59a0-b9cd-389445c8a848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e408b-f052-451c-9bf9-ac6f98753a9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/674e408b-f052-451c-9bf9-ac6f98753a9d.jpg?1",
             "name": "Invading Manticore",
             "text": "When Invading Manticore enters the battlefield, amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -4993,7 +4993,7 @@
         },
         {
             "id": "79c77484-155c-5e8f-88b5-ba8912ab5b79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129dc8a8-9fbc-4300-b559-243395dc6ed5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129dc8a8-9fbc-4300-b559-243395dc6ed5.jpg?1",
             "name": "Jaya, Venerated Firemage",
             "text": "If another red source you control would deal damage to a permanent or player, it deals that much damage plus 1 to that permanent or player instead.\n\u22122: Jaya, Venerated Firemage deals 2 damage to any target.",
             "colours": [
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "2896c920-1b81-526a-b211-a931ba0f4a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd5ff8-0591-4e58-aae1-4f441750518d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfd5ff8-0591-4e58-aae1-4f441750518d.jpg?1",
             "name": "Jaya, Venerated Firemage",
             "text": "",
             "colours": [
@@ -5069,7 +5069,7 @@
         },
         {
             "id": "41d8d564-27fa-5ea0-8131-b51d2d26a39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66f169-5cf9-4d7c-a5ab-c64fc4801358.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec66f169-5cf9-4d7c-a5ab-c64fc4801358.jpg?1",
             "name": "Jaya's Greeting",
             "text": "Jaya's Greeting deals 3 damage to target creature. Scry 1.",
             "colours": [
@@ -5101,7 +5101,7 @@
         },
         {
             "id": "df73e10a-6b0b-5b2e-9ed9-2a9d3bcb936e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ed04d3-cfa1-4778-aea6-b4c2c29e6e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37ed04d3-cfa1-4778-aea6-b4c2c29e6e0a.jpg?1",
             "name": "Krenko, Tin Street Kingpin",
             "text": "Whenever Krenko, Tin Street Kingpin attacks, put a +1/+1 counter on it, then create a number of 1/1 red Goblin creature tokens equal to Krenko's power.",
             "colours": [
@@ -5137,7 +5137,7 @@
         },
         {
             "id": "69ce976f-1371-5256-9f61-1b0345f9137f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5643253b-0996-45a8-9488-5bcc9192f867.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5643253b-0996-45a8-9488-5bcc9192f867.jpg?1",
             "name": "Mizzium Tank",
             "text": "Trample\nWhenever you cast a noncreature spell, Mizzium Tank becomes an artifact creature and gets +1/+1 until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [
@@ -5171,7 +5171,7 @@
         },
         {
             "id": "9b55ced1-064b-593d-a8bb-c1317291b08a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14331e-8da5-4455-ac69-e510684e989c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a14331e-8da5-4455-ac69-e510684e989c.jpg?1",
             "name": "Nahiri's Stoneblades",
             "text": "Up to two target creatures each get +2/+0 until end of turn.",
             "colours": [
@@ -5203,7 +5203,7 @@
         },
         {
             "id": "f7cb76de-5710-5b2c-b6e1-5abf4d88b55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c90d5d-7b3b-48d2-85f6-d6a2a452c0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c90d5d-7b3b-48d2-85f6-d6a2a452c0e9.jpg?1",
             "name": "Neheb, Dreadhorde Champion",
             "text": "Trample\nWhenever Neheb, Dreadhorde Champion deals combat damage to a player or planeswalker, you may discard any number of cards. If you do, draw that many cards and add that much {R}. Until end of turn, you don't lose this mana as steps and phases end.",
             "colours": [
@@ -5241,7 +5241,7 @@
         },
         {
             "id": "38d1637f-7c7e-555d-b059-a740f3350962",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae38aa2d-6c0e-409a-bfc7-ed4281457670.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae38aa2d-6c0e-409a-bfc7-ed4281457670.jpg?1",
             "name": "Raging Kronch",
             "text": "Raging Kronch can't attack alone.",
             "colours": [
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "6f16a789-102e-553d-a5ed-3fbe5d3fdf93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bda699-2b5d-4f5b-bee5-792b99d2b64a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94bda699-2b5d-4f5b-bee5-792b99d2b64a.jpg?1",
             "name": "Samut's Sprint",
             "text": "Target creature gets +2/+1 and gains haste until end of turn. Scry 1.",
             "colours": [
@@ -5307,7 +5307,7 @@
         },
         {
             "id": "b822babc-a8a1-575b-9cf2-ef7478b554be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb96971-5bf1-4ae3-98f4-7cd7a614bf97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bb96971-5bf1-4ae3-98f4-7cd7a614bf97.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "Whenever a creature attacks you or a planeswalker you control, each Dragon you control deals 1 damage to that creature.\n+1: Until end of turn, each planeswalker you control becomes a 4/4 red Dragon creature and gains flying.\n\u22123: Create a 4/4 red Dragon creature token with flying.",
             "colours": [
@@ -5345,7 +5345,7 @@
         },
         {
             "id": "865eecad-2284-53a7-afe3-703310a6f5ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df04f130-e9ea-4f5f-82d0-63d3f74d8234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df04f130-e9ea-4f5f-82d0-63d3f74d8234.jpg?1",
             "name": "Sarkhan the Masterless",
             "text": "",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "ad2365f6-b11b-5ba1-b1c8-9d80b95e04ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b6f26-c66b-4048-9503-af0a886ef14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b6f26-c66b-4048-9503-af0a886ef14f.jpg?1",
             "name": "Sarkhan's Catharsis",
             "text": "Sarkhan's Catharsis deals 5 damage to target player or planeswalker.",
             "colours": [
@@ -5415,7 +5415,7 @@
         },
         {
             "id": "173caa83-8aef-5c07-aa0c-7b78d428ef63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91551f85-4630-43a0-af72-8332d2ff0752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91551f85-4630-43a0-af72-8332d2ff0752.jpg?1",
             "name": "Spellgorger Weird",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Spellgorger Weird.",
             "colours": [
@@ -5449,7 +5449,7 @@
         },
         {
             "id": "c28a0e0b-6f52-5249-99d1-9222bb3e9e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a24dc-8bc3-4528-8780-57fb108fdfbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f9a24dc-8bc3-4528-8780-57fb108fdfbf.jpg?1",
             "name": "Tibalt, Rakish Instigator",
             "text": "Your opponents can't gain life.\n\u22122: Create a 1/1 red Devil creature token with \"When this creature dies, it deals 1 damage to any target.\"",
             "colours": [
@@ -5487,7 +5487,7 @@
         },
         {
             "id": "a3935d99-8f12-5a3f-8e30-2ce727dc7943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68718639-a767-4f4e-b7bf-1fbb65e6cae5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68718639-a767-4f4e-b7bf-1fbb65e6cae5.jpg?1",
             "name": "Tibalt, Rakish Instigator",
             "text": "",
             "colours": [
@@ -5525,7 +5525,7 @@
         },
         {
             "id": "22532515-400f-5649-8969-05cfbc008ef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2985520d-dfce-414e-a4ac-61695be67406.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2985520d-dfce-414e-a4ac-61695be67406.jpg?1",
             "name": "Tibalt's Rager",
             "text": "When Tibalt's Rager dies, it deals 1 damage to any target.\n{1}{R}: Tibalt's Rager gets +2/+0 until end of turn.",
             "colours": [
@@ -5559,7 +5559,7 @@
         },
         {
             "id": "33f4cc82-7b2f-5462-a355-41007862577e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f624f-c5eb-4150-b36e-6147b440ff56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f624f-c5eb-4150-b36e-6147b440ff56.jpg?1",
             "name": "Turret Ogre",
             "text": "Reach\nWhen Turret Ogre enters the battlefield, if you control another creature with power 4 or greater, Turret Ogre deals 2 damage to each opponent.",
             "colours": [
@@ -5594,7 +5594,7 @@
         },
         {
             "id": "ff209b2c-1d8c-5749-8659-43ddf24a3320",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5f86f-44a8-4735-909a-770586d33a15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5f86f-44a8-4735-909a-770586d33a15.jpg?1",
             "name": "Arboreal Grazer",
             "text": "Reach\nWhen Arboreal Grazer enters the battlefield, you may put a land card from your hand onto the battlefield tapped.",
             "colours": [
@@ -5628,7 +5628,7 @@
         },
         {
             "id": "9c2c42d5-6cf3-5298-a7e9-9b14d6503d52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5391d2f1-e8d3-4d39-98cf-367888e10534.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5391d2f1-e8d3-4d39-98cf-367888e10534.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "Each creature you control that's a Wolf or a Werewolf enters the battlefield with an additional +1/+1 counter on it.\n\u22122: Create a 2/2 green Wolf creature token.",
             "colours": [
@@ -5666,7 +5666,7 @@
         },
         {
             "id": "1804176d-2d08-5cea-b77e-4b442ff376b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43261927-7655-474b-ac61-dfef9e63f428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43261927-7655-474b-ac61-dfef9e63f428.jpg?1",
             "name": "Arlinn, Voice of the Pack",
             "text": "",
             "colours": [
@@ -5704,7 +5704,7 @@
         },
         {
             "id": "67df542e-fb46-5268-a7ae-c73ec7bc357a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747223a5-c669-4d0e-a062-265eb47710cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747223a5-c669-4d0e-a062-265eb47710cd.jpg?1",
             "name": "Arlinn's Wolf",
             "text": "Arlinn's Wolf can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -5738,7 +5738,7 @@
         },
         {
             "id": "6739063b-938e-5bfb-ae02-9a10a9cdac1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42b2fb4-8016-462c-8764-2639adec931f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b42b2fb4-8016-462c-8764-2639adec931f.jpg?1",
             "name": "Awakening of Vitu-Ghazi",
             "text": "Put nine +1/+1 counters on target land you control. It becomes a legendary 0/0 Elemental creature with haste named Vitu-Ghazi. It's still a land.",
             "colours": [
@@ -5770,7 +5770,7 @@
         },
         {
             "id": "c3116d5f-3040-51b0-9780-5cd11be0283e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1d8aa1-d742-477c-819a-0113912d5011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1d8aa1-d742-477c-819a-0113912d5011.jpg?1",
             "name": "Band Together",
             "text": "Up to two target creatures you control each deal damage equal to their power to another target creature.",
             "colours": [
@@ -5802,7 +5802,7 @@
         },
         {
             "id": "30aa01b9-f697-56ee-92fc-0502fb15bf8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c9129-254d-4d1d-9d95-112292bd6bcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd1c9129-254d-4d1d-9d95-112292bd6bcc.jpg?1",
             "name": "Bloom Hulk",
             "text": "When Bloom Hulk enters the battlefield, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5837,7 +5837,7 @@
         },
         {
             "id": "9e7999e1-62ba-5968-8c1a-f19d39fa35e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901fdc-8672-44f5-ade5-7c4e0b5c5d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df901fdc-8672-44f5-ade5-7c4e0b5c5d81.jpg?1",
             "name": "Bond of Flourishing",
             "text": "Look at the top three cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in any order. You gain 3 life.",
             "colours": [
@@ -5869,7 +5869,7 @@
         },
         {
             "id": "6b9bb917-3152-537a-94d6-6addecbb7495",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf020acb-e0c6-43b4-8324-0f2ec68b73d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf020acb-e0c6-43b4-8324-0f2ec68b73d6.jpg?1",
             "name": "Centaur Nurturer",
             "text": "When Centaur Nurturer enters the battlefield, you gain 3 life.\n{T}: Add one mana of any color.",
             "colours": [
@@ -5904,7 +5904,7 @@
         },
         {
             "id": "e476bc1e-6a4a-5f49-8d58-0daa0500edf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d778a-ef16-437f-9a9d-204cf061919b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/328d778a-ef16-437f-9a9d-204cf061919b.jpg?1",
             "name": "Challenger Troll",
             "text": "Each creature you control with power 4 or greater can't be blocked by more than one creature.",
             "colours": [
@@ -5938,7 +5938,7 @@
         },
         {
             "id": "e63d7d93-9b27-5d7f-8743-a852299595a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a22083-9ef9-4ff7-8502-3a77e69299df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67a22083-9ef9-4ff7-8502-3a77e69299df.jpg?1",
             "name": "Courage in Crisis",
             "text": "Put a +1/+1 counter on target creature, then proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -5970,7 +5970,7 @@
         },
         {
             "id": "2634269a-6457-5157-a2d0-27415ee848d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4042db8-6032-49a2-bc96-ad15f55db6c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4042db8-6032-49a2-bc96-ad15f55db6c3.jpg?1",
             "name": "Evolution Sage",
             "text": "Whenever a land enters the battlefield under your control, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6005,7 +6005,7 @@
         },
         {
             "id": "76f9f095-f516-5dfd-899e-75ba4a662630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985453e7-997e-4d77-a338-cc0290791ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985453e7-997e-4d77-a338-cc0290791ebe.jpg?1",
             "name": "Finale of Devastation",
             "text": "Search your library and/or graveyard for a creature card with converted mana cost X or less and put it onto the battlefield. If you search your library this way, shuffle it. If X is 10 or more, creatures you control get +X/+X and gain haste until end of turn.",
             "colours": [
@@ -6037,7 +6037,7 @@
         },
         {
             "id": "2e3c42d4-d1d8-590e-a2a4-4fafe2c592e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb319a7-564c-4748-82cf-c26ab110c32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb319a7-564c-4748-82cf-c26ab110c32c.jpg?1",
             "name": "Forced Landing",
             "text": "Put target creature with flying on the bottom of its owner's library.",
             "colours": [
@@ -6069,7 +6069,7 @@
         },
         {
             "id": "a503cb41-a414-576e-97c4-40d64a3a91c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec9e8b-4bd8-4caf-a559-6514b7ab4ca4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06ec9e8b-4bd8-4caf-a559-6514b7ab4ca4.jpg?1",
             "name": "Giant Growth",
             "text": "Target creature gets +3/+3 until end of turn.",
             "colours": [
@@ -6101,7 +6101,7 @@
         },
         {
             "id": "56788492-50a1-54f5-b6ef-85e18365290a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb444f0-69cc-47c8-8cd6-1f9edad5d903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eb444f0-69cc-47c8-8cd6-1f9edad5d903.jpg?1",
             "name": "God-Eternal Rhonas",
             "text": "Deathtouch\nWhen God-Eternal Rhonas enters the battlefield, double the power of each other creature you control until end of turn. Those creatures gain vigilance until end of turn.\nWhen God-Eternal Rhonas dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",
             "colours": [
@@ -6138,7 +6138,7 @@
         },
         {
             "id": "f3db8dfc-2fb4-539f-aca5-2d61eca652c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0d47d-b13c-4d48-881f-8aaa347ef209.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10e0d47d-b13c-4d48-881f-8aaa347ef209.jpg?1",
             "name": "Jiang Yanggu, Wildcrafter",
             "text": "Each creature you control with a +1/+1 counter on it has \"{T}: Add one mana of any color.\"\n\u22121: Put a +1/+1 counter on target creature.",
             "colours": [
@@ -6176,7 +6176,7 @@
         },
         {
             "id": "4c49c839-b070-573a-a231-4484998c7490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a66171-1143-4d23-81c3-ae8bb0ef63ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31a66171-1143-4d23-81c3-ae8bb0ef63ad.jpg?1",
             "name": "Jiang Yanggu, Wildcrafter",
             "text": "",
             "colours": [
@@ -6214,7 +6214,7 @@
         },
         {
             "id": "6f2d2422-ae83-5836-a3de-3f309753ba05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b88fe9-2450-47ee-ac1e-bbbccbf5684f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46b88fe9-2450-47ee-ac1e-bbbccbf5684f.jpg?1",
             "name": "Kraul Stinger",
             "text": "Deathtouch",
             "colours": [
@@ -6249,7 +6249,7 @@
         },
         {
             "id": "d8798669-f034-5a9a-a481-7b559a4baef5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41d22a-ee37-4d69-a9ca-98c91315b9e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f41d22a-ee37-4d69-a9ca-98c91315b9e6.jpg?1",
             "name": "Kronch Wrangler",
             "text": "Trample\nWhenever a creature with power 4 or greater enters the battlefield under your control, put a +1/+1 counter on Kronch Wrangler.",
             "colours": [
@@ -6284,7 +6284,7 @@
         },
         {
             "id": "aeffa888-35eb-5855-b3d6-a211cbd2c86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41a191c-c42e-42ec-89bd-cc1bc215ffbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f41a191c-c42e-42ec-89bd-cc1bc215ffbc.jpg?1",
             "name": "Mowu, Loyal Companion",
             "text": "Trample, vigilance\nIf one or more +1/+1 counters would be put on Mowu, Loyal Companion, that many plus one +1/+1 counters are put on it instead.",
             "colours": [
@@ -6320,7 +6320,7 @@
         },
         {
             "id": "1ae82207-e017-5539-ac71-5ecdb5d1b7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c521da-677e-43b9-b5fe-c84dc64e66ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c521da-677e-43b9-b5fe-c84dc64e66ec.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen New Horizons enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
             "colours": [
@@ -6354,7 +6354,7 @@
         },
         {
             "id": "ffccf80c-e56f-5bc2-9838-d77166da4eb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857bbe4-5619-4733-a0c7-69700f2ef4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f857bbe4-5619-4733-a0c7-69700f2ef4f3.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "Whenever you tap a Forest for mana, add an additional {G}.\n+1: Put three +1/+1 counters on up to one target noncreature land you control. Untap it. It becomes a 0/0 Elemental creature with vigilance and haste that's still a land.\n\u22128: You get an emblem with \"Lands you control have indestructible.\" Search your library for any number of Forest cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6392,7 +6392,7 @@
         },
         {
             "id": "8ca09437-8a78-5065-8bec-3cc36eab7939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d63632-c019-4f34-926a-42f829a4665c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25d63632-c019-4f34-926a-42f829a4665c.jpg?1",
             "name": "Nissa, Who Shakes the World",
             "text": "",
             "colours": [
@@ -6430,7 +6430,7 @@
         },
         {
             "id": "65b241eb-8093-580e-aac6-7b47e993795f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7946b256-ae79-4b99-8bf4-0d627baf9044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7946b256-ae79-4b99-8bf4-0d627baf9044.jpg?1",
             "name": "Nissa's Triumph",
             "text": "Search your library for up to two basic Forest cards. If you control a Nissa planeswalker, instead search your library for up to three land cards. Reveal those cards, put them into your hand, then shuffle your library.",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "462a3159-19c3-5506-992f-e264e634bcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed8d9e7-cdad-450d-8329-fa653d387a63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ed8d9e7-cdad-450d-8329-fa653d387a63.jpg?1",
             "name": "Paradise Druid",
             "text": "Paradise Druid has hexproof as long as it's untapped.(It can't be the target of spells or abilities your opponents control.)\n{T}: Add one mana of any color.",
             "colours": [
@@ -6497,7 +6497,7 @@
         },
         {
             "id": "d9737859-bb86-5455-abe2-8f6159d7e0e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11016840-56b6-4759-bde6-3dc0e339e87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11016840-56b6-4759-bde6-3dc0e339e87e.jpg?1",
             "name": "Planewide Celebration",
             "text": "Choose four. You may choose the same mode more than once.\n\u2022 Create a 2/2 Citizen creature token that's all colors.\n\u2022 Return target permanent card from your graveyard to your hand.\n\u2022 Proliferate.\n\u2022 You gain 4 life.",
             "colours": [
@@ -6529,7 +6529,7 @@
         },
         {
             "id": "633f54dd-6b69-5eb6-b1fe-6a144a207a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0f478c-54f8-4087-ad52-d089e2049dda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0f478c-54f8-4087-ad52-d089e2049dda.jpg?1",
             "name": "Pollenbright Druid",
             "text": "When Pollenbright Druid enters the battlefield, choose one \u2014\n\u2022 Put a +1/+1 counter on target creature.\n\u2022 Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -6564,7 +6564,7 @@
         },
         {
             "id": "caa87172-dc22-5c72-be26-7046068aae01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0e8298-adac-4922-8824-a1fafa089f72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc0e8298-adac-4922-8824-a1fafa089f72.jpg?1",
             "name": "Primordial Wurm",
             "text": "",
             "colours": [
@@ -6598,7 +6598,7 @@
         },
         {
             "id": "ed015dda-2818-5ea2-a4ad-2eb3d498c00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085e3129-591b-46ec-ac8b-cff428927c01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/085e3129-591b-46ec-ac8b-cff428927c01.jpg?1",
             "name": "Return to Nature",
             "text": "Choose one \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target enchantment.\n\u2022 Exile target card from a graveyard.",
             "colours": [
@@ -6630,7 +6630,7 @@
         },
         {
             "id": "b4d70fe7-e3f2-55f5-9f92-a1820bb6e270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a0fcc5-57d3-43ab-9e3d-0e015792239a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48a0fcc5-57d3-43ab-9e3d-0e015792239a.jpg?1",
             "name": "Snarespinner",
             "text": "Reach\nWhenever Snarespinner blocks a creature with flying, Snarespinner gets +2/+0 until end of turn.",
             "colours": [
@@ -6664,7 +6664,7 @@
         },
         {
             "id": "211a1eee-e2d2-5f01-8f15-35c6d5d2ca52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af6a1b5-a561-4d92-b429-de13b2ccaf81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af6a1b5-a561-4d92-b429-de13b2ccaf81.jpg?1",
             "name": "Steady Aim",
             "text": "Untap target creature. It gets +1/+4 and gains reach until end of turn.",
             "colours": [
@@ -6696,7 +6696,7 @@
         },
         {
             "id": "7370a76b-f407-5105-9d7c-f0dec075fe09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b3b12e-bef7-409e-86b3-9e90640e598c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b3b12e-bef7-409e-86b3-9e90640e598c.jpg?1",
             "name": "Storm the Citadel",
             "text": "Until end of turn, creatures you control get +2/+2 and gain \"Whenever this creature deals combat damage to a player or planeswalker, destroy target artifact or enchantment defending player controls.\"",
             "colours": [
@@ -6728,7 +6728,7 @@
         },
         {
             "id": "31d92cfc-8aee-5596-be49-f7d73201575a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9888d9a4-ad72-43f6-8031-1031877171a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9888d9a4-ad72-43f6-8031-1031877171a9.jpg?1",
             "name": "Thundering Ceratok",
             "text": "Trample\nWhen Thundering Ceratok enters the battlefield, other creatures you control gain trample until end of turn.",
             "colours": [
@@ -6762,7 +6762,7 @@
         },
         {
             "id": "f4f7168b-127e-57f3-af5c-9f5320dbcb83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3986d7-9b3d-4082-8d72-ce59c9fcd5d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff3986d7-9b3d-4082-8d72-ce59c9fcd5d5.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "You may cast creature spells as though they had flash.\n+1: Until your next turn, up to one target creature gains vigilance and reach.\n\u22122: Look at the top three cards of your library. Exile one face down and put the rest on the bottom of your library in any order. For as long as it remains exiled, you may look at that card and you may cast it if it's a creature card.",
             "colours": [
@@ -6800,7 +6800,7 @@
         },
         {
             "id": "b0aada96-91d4-51ab-93ca-0f952d2cd3e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4422e69e-a7db-4582-b37d-59519b6871f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4422e69e-a7db-4582-b37d-59519b6871f9.jpg?1",
             "name": "Vivien, Champion of the Wilds",
             "text": "",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "93ef91a8-df9c-5705-b1f0-df3abe2e2b0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc846f-5b78-4d54-8d29-642ad7a852bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eecc846f-5b78-4d54-8d29-642ad7a852bc.jpg?1",
             "name": "Vivien's Arkbow",
             "text": "{X}, {T}, Discard a card: Look at the top X cards of your library. You may put a creature card with converted mana cost X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "e249f978-c9bf-5895-a844-7b6cd601fc4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f2571b-6756-462c-9e71-3121fa458160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37f2571b-6756-462c-9e71-3121fa458160.jpg?1",
             "name": "Vivien's Grizzly",
             "text": "{3}{G}: Look at the top card of your library. If it's a creature or planeswalker card, you may reveal it and put it into your hand. If you don't put the card into your hand, put it on the bottom of your library.",
             "colours": [
@@ -6907,7 +6907,7 @@
         },
         {
             "id": "083a4a7d-220e-586f-a7c8-4647bf258c33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5341b9-06e4-4360-a75d-f405d468276e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5341b9-06e4-4360-a75d-f405d468276e.jpg?1",
             "name": "Wardscale Crocodile",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -6941,7 +6941,7 @@
         },
         {
             "id": "d52aebee-9ea7-5bf6-897f-e34c45e5edb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc78151-8cb0-4521-9674-fb0c67e24a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc78151-8cb0-4521-9674-fb0c67e24a17.jpg?1",
             "name": "Ajani, the Greathearted",
             "text": "Creatures you control have vigilance.\n+1: You gain 3 life.\n\u22122: Put a +1/+1 counter on each creature you control and a loyalty counter on each other planeswalker you control.",
             "colours": [
@@ -6981,7 +6981,7 @@
         },
         {
             "id": "c73d1680-63cd-501a-b828-b163428e57a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee535c3-4ccd-4eb1-85e9-d28bf6dc0710.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee535c3-4ccd-4eb1-85e9-d28bf6dc0710.jpg?1",
             "name": "Ajani, the Greathearted",
             "text": "",
             "colours": [
@@ -7021,7 +7021,7 @@
         },
         {
             "id": "4e17b405-08e8-5d22-88ce-3e8e37ad27cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a39379-7313-463a-9a02-e5157b9557f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a39379-7313-463a-9a02-e5157b9557f4.jpg?1",
             "name": "Angrath's Rampage",
             "text": "Choose one \u2014\n\u2022 Target player sacrifices an artifact.\n\u2022 Target player sacrifices a creature.\n\u2022 Target player sacrifices a planeswalker.",
             "colours": [
@@ -7055,7 +7055,7 @@
         },
         {
             "id": "73b21bac-d5fd-5361-9f93-25515b696afc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01a161-49a1-407c-8410-6933bc8f7b6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb01a161-49a1-407c-8410-6933bc8f7b6a.jpg?1",
             "name": "Bioessence Hydra",
             "text": "Trample\nBioessence Hydra enters the battlefield with a +1/+1 counter on it for each loyalty counter on planeswalkers you control.\nWhenever one or more loyalty counters are put on planeswalkers you control, put that many +1/+1 counters on Bioessence Hydra.",
             "colours": [
@@ -7092,7 +7092,7 @@
         },
         {
             "id": "51c2c882-b31c-5d30-b647-6ae98db12925",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc5e50-c6f7-41ec-815a-5667eefded78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fc5e50-c6f7-41ec-815a-5667eefded78.jpg?1",
             "name": "Casualties of War",
             "text": "Choose one or more \u2014\n\u2022 Destroy target artifact.\n\u2022 Destroy target creature.\n\u2022 Destroy target enchantment.\n\u2022 Destroy target land.\n\u2022 Destroy target planeswalker.",
             "colours": [
@@ -7126,7 +7126,7 @@
         },
         {
             "id": "1ee550f8-ee51-5a89-b121-5af6c7d73d95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ead6ac-b1c5-4852-8413-7fa43c6cfc57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ead6ac-b1c5-4852-8413-7fa43c6cfc57.jpg?1",
             "name": "Cruel Celebrant",
             "text": "Whenever Cruel Celebrant or another creature or planeswalker you control dies, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -7162,7 +7162,7 @@
         },
         {
             "id": "b61d5f96-30c1-5bcd-ac30-84960831339a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d615557-aea8-4057-9fbd-d62dd98edc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d615557-aea8-4057-9fbd-d62dd98edc13.jpg?1",
             "name": "Deathsprout",
             "text": "Destroy target creature. Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -7196,7 +7196,7 @@
         },
         {
             "id": "2105a674-59b9-57c5-b7fd-18ccbf2cdf06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b17dfc-b916-4134-ba77-501cff435e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32b17dfc-b916-4134-ba77-501cff435e7e.jpg?1",
             "name": "Despark",
             "text": "Exile target permanent with converted mana cost 4 or greater.",
             "colours": [
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "cf65b0d5-04d2-53f5-a0e8-bb0b07e9f7ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1af9881-e35b-4be2-8716-ea7c6664e22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1af9881-e35b-4be2-8716-ea7c6664e22c.jpg?1",
             "name": "Domri, Anarch of Bolas",
             "text": "Creatures you control get +1/+0.\n+1: Add {R} or {G}. Creature spells you cast this turn can't be countered.\n\u22122: Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7270,7 +7270,7 @@
         },
         {
             "id": "c4f2db39-0198-53ed-a8f0-e527cfa18852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ec2a4-e6b1-42a4-9a20-3b55eda4377f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b8ec2a4-e6b1-42a4-9a20-3b55eda4377f.jpg?1",
             "name": "Domri, Anarch of Bolas",
             "text": "",
             "colours": [
@@ -7310,7 +7310,7 @@
         },
         {
             "id": "e0e05e4f-a336-5625-b3a9-5c86e15dd8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dcae59-e9be-45a8-8ed8-5b47309bb716.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0dcae59-e9be-45a8-8ed8-5b47309bb716.jpg?1",
             "name": "Domri's Ambush",
             "text": "Put a +1/+1 counter on target creature you control. Then that creature deals damage equal to its power to target creature or planeswalker you don't control.",
             "colours": [
@@ -7344,7 +7344,7 @@
         },
         {
             "id": "830832c9-2b37-56b6-8200-f1415923f139",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6b5054-2224-4f68-9d82-3ed17c5dacc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d6b5054-2224-4f68-9d82-3ed17c5dacc4.jpg?1",
             "name": "Dovin's Veto",
             "text": "This spell can't be countered.\nCounter target noncreature spell.",
             "colours": [
@@ -7378,7 +7378,7 @@
         },
         {
             "id": "d5233d3e-5fd2-5731-9a1e-d392629c539e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457bc402-4c31-465c-95e1-694f686e257e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457bc402-4c31-465c-95e1-694f686e257e.jpg?1",
             "name": "Dreadhorde Butcher",
             "text": "Haste\nWhenever Dreadhorde Butcher deals combat damage to a player or planeswalker, put a +1/+1 counter on Dreadhorde Butcher.\nWhen Dreadhorde Butcher dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -7415,7 +7415,7 @@
         },
         {
             "id": "3602f881-3a52-5449-abc0-e4dbb76294dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e40b14-48a2-4b9e-b767-e914cab04b30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2e40b14-48a2-4b9e-b767-e914cab04b30.jpg?1",
             "name": "Elite Guardmage",
             "text": "Flying\nWhen Elite Guardmage enters the battlefield, you gain 3 life and draw a card.",
             "colours": [
@@ -7452,7 +7452,7 @@
         },
         {
             "id": "be4eef08-4518-53f7-8d86-e380aaabe591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7070-2266-4c93-8c89-084e12ba7a4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67e7070-2266-4c93-8c89-084e12ba7a4e.jpg?1",
             "name": "Enter the God-Eternals",
             "text": "Enter the God-Eternals deals 4 damage to target creature and you gain life equal to the damage dealt this way. Target player puts the top four cards of their library into their graveyard. Amass 4. (Put four +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -7486,7 +7486,7 @@
         },
         {
             "id": "9c936b88-a365-576d-b074-e8a8d9b1f6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a2d2c6-8eaa-4760-b620-921b807baa2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a2d2c6-8eaa-4760-b620-921b807baa2e.jpg?1",
             "name": "Feather, the Redeemed",
             "text": "Flying\nWhenever you cast an instant or sorcery spell that targets a creature you control, exile that card instead of putting it into your graveyard as it resolves. If you do, return it to your hand at the beginning of the next end step.",
             "colours": [
@@ -7524,7 +7524,7 @@
         },
         {
             "id": "4dd2b6e8-4999-5c70-b9b1-6b89c1245ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4604b4-df53-485c-a604-4d823b33d8ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4604b4-df53-485c-a604-4d823b33d8ba.jpg?1",
             "name": "Gleaming Overseer",
             "text": "When Gleaming Overseer enters the battlefield, amass 1. (Put a +1/+1 counter on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)\nZombie tokens you control have hexproof and menace.",
             "colours": [
@@ -7561,7 +7561,7 @@
         },
         {
             "id": "63289f00-b5b2-5c16-ada5-fe6e05be49a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af569235-f5cb-4e3e-ba77-c1c429ed0a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af569235-f5cb-4e3e-ba77-c1c429ed0a60.jpg?1",
             "name": "Heartwarming Redemption",
             "text": "Discard all the cards in your hand, then draw that many cards plus one. You gain life equal to the number of cards in your hand.",
             "colours": [
@@ -7595,7 +7595,7 @@
         },
         {
             "id": "f1c4e98d-80f7-5ddc-a3c2-0f70eba20150",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba680ad0-6134-46e0-8fcb-532b2052eca7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba680ad0-6134-46e0-8fcb-532b2052eca7.jpg?1",
             "name": "Huatli's Raptor",
             "text": "Vigilance\nWhen Huatli's Raptor enters the battlefield, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -7631,7 +7631,7 @@
         },
         {
             "id": "fea4fd6f-cd52-59d1-ba38-2b418edb5954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a587eb67-c2df-486c-9c48-dfeac540efe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a587eb67-c2df-486c-9c48-dfeac540efe8.jpg?1",
             "name": "Invade the City",
             "text": "Amass X, where X is the number of instant and sorcery cards in your graveyard. (Put X +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -7665,7 +7665,7 @@
         },
         {
             "id": "b47b3aee-0384-574b-a750-1ef2704e1251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b4e8f-d48e-4bb0-883d-29f978033f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c56b4e8f-d48e-4bb0-883d-29f978033f65.jpg?1",
             "name": "Leyline Prowler",
             "text": "Deathtouch, lifelink\n{T}: Add one mana of any color.",
             "colours": [
@@ -7702,7 +7702,7 @@
         },
         {
             "id": "2378f517-597d-56f0-bf47-b26c54c17577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d92676-a994-4031-834c-6cf7c43bd170.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8d92676-a994-4031-834c-6cf7c43bd170.jpg?1",
             "name": "Living Twister",
             "text": "{1}{R}, Discard a land card: Living Twister deals 2 damage to any target.\n{G}: Return a tapped land you control to its owner's hand.",
             "colours": [
@@ -7738,7 +7738,7 @@
         },
         {
             "id": "489b4151-9369-5706-9de2-10327e6b6f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17416926-168b-49b3-9231-acbb8f8a1d13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17416926-168b-49b3-9231-acbb8f8a1d13.jpg?1",
             "name": "Mayhem Devil",
             "text": "Whenever a player sacrifices a permanent, Mayhem Devil deals 1 damage to any target.",
             "colours": [
@@ -7774,7 +7774,7 @@
         },
         {
             "id": "3b1a9e81-b53d-5d0c-a248-7e4a3a2d8fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf211eb-837b-4c02-b02e-8d9e62f1abb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bf211eb-837b-4c02-b02e-8d9e62f1abb1.jpg?1",
             "name": "Merfolk Skydiver",
             "text": "Flying\nWhen Merfolk Skydiver enters the battlefield, put a +1/+1 counter on target creature you control.\n{3}{G}{U}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -7811,7 +7811,7 @@
         },
         {
             "id": "01e31b26-7b7f-5c89-9099-ba2df6f2d343",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8f67e-4f2f-4a1f-b190-7c3f39e477e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92d8f67e-4f2f-4a1f-b190-7c3f39e477e4.jpg?1",
             "name": "Neoform",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost, put that card onto the battlefield with an additional +1/+1 counter on it, then shuffle your library.",
             "colours": [
@@ -7845,7 +7845,7 @@
         },
         {
             "id": "ad06d0fe-1d5c-5d62-9134-e97294333d90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b68dea-a7be-4f99-8a50-4c8cf0e0f7a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98b68dea-a7be-4f99-8a50-4c8cf0e0f7a9.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "Nicol Bolas, Dragon-God has all loyalty abilities of all other planeswalkers on the battlefield.\n+1: You draw a card. Each opponent exiles a card from their hand or a permanent they control.\n\u22123: Destroy target creature or planeswalker.\n\u22128: Each opponent who doesn't control a legendary creature or planeswalker loses the game.",
             "colours": [
@@ -7887,7 +7887,7 @@
         },
         {
             "id": "4e13c7ce-6811-5d13-9675-3baafa9d3910",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5770e-533d-479f-b469-1fbef08614c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a5770e-533d-479f-b469-1fbef08614c1.jpg?1",
             "name": "Nicol Bolas, Dragon-God",
             "text": "",
             "colours": [
@@ -7929,7 +7929,7 @@
         },
         {
             "id": "eb76191d-5004-5735-a618-663b3411898e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a2609d-b535-400b-81d9-72989a33c70f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56a2609d-b535-400b-81d9-72989a33c70f.jpg?1",
             "name": "Niv-Mizzet Reborn",
             "text": "Flying\nWhen Niv-Mizzet Reborn enters the battlefield, reveal the top ten cards of your library. For each color pair, choose a card that's exactly those colors from among them. Put the chosen cards into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7974,7 +7974,7 @@
         },
         {
             "id": "d14b23fb-7a3c-5d0a-84d6-9993338710e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faba010d-5b1b-4562-91d6-ec55303c4dcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faba010d-5b1b-4562-91d6-ec55303c4dcd.jpg?1",
             "name": "Oath of Kaya",
             "text": "When Oath of Kaya enters the battlefield, it deals 3 damage to any target and you gain 3 life.\nWhenever an opponent attacks a planeswalker you control with one or more creatures, Oath of Kaya deals 2 damage to that player and you gain 2 life.",
             "colours": [
@@ -8010,7 +8010,7 @@
         },
         {
             "id": "3041ff06-b062-5b9e-84a4-4ef50f01b298",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9b3518-7fcd-49e2-a4c4-e5daa8be6c21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca9b3518-7fcd-49e2-a4c4-e5daa8be6c21.jpg?1",
             "name": "Pledge of Unity",
             "text": "Put a +1/+1 counter on each creature you control. You gain 1 life for each creature you control.",
             "colours": [
@@ -8044,7 +8044,7 @@
         },
         {
             "id": "d26a1c5d-25a3-56fd-9559-bc3a0e910e8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ce3bf-152d-45ca-87ae-ad46c921328b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/678ce3bf-152d-45ca-87ae-ad46c921328b.jpg?1",
             "name": "Ral, Storm Conduit",
             "text": "Whenever you cast or copy an instant or sorcery spell, Ral, Storm Conduit deals 1 damage to target opponent or planeswalker.\n+2: Scry 1.\n\u22122: When you cast your next instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -8084,7 +8084,7 @@
         },
         {
             "id": "8d0fcede-8da7-567e-87eb-ec87154550e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad09cd7-52c3-4c13-919c-e113b6dc3419.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ad09cd7-52c3-4c13-919c-e113b6dc3419.jpg?1",
             "name": "Ral, Storm Conduit",
             "text": "",
             "colours": [
@@ -8124,7 +8124,7 @@
         },
         {
             "id": "0ebc529b-6c1e-5d96-8f98-fda74777f386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3dd3e-50d2-4729-9caa-b2cd984f4c97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be3dd3e-50d2-4729-9caa-b2cd984f4c97.jpg?1",
             "name": "Ral's Outburst",
             "text": "Ral's Outburst deals 3 damage to any target. Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
             "colours": [
@@ -8158,7 +8158,7 @@
         },
         {
             "id": "057bb70b-58de-5f49-8e50-1f45f548f519",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de14b4fd-fb4e-4986-9123-69ae68b5050a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de14b4fd-fb4e-4986-9123-69ae68b5050a.jpg?1",
             "name": "Roalesk, Apex Hybrid",
             "text": "Flying, trample\nWhen Roalesk, Apex Hybrid enters the battlefield, put two +1/+1 counters on another target creature you control.\nWhen Roalesk dies, proliferate, then proliferate again. (Choose any number of permanents and/or players, then give each another counter of each kind already there. Then do it again.)",
             "colours": [
@@ -8197,7 +8197,7 @@
         },
         {
             "id": "fc24aaad-c086-589a-b869-f38c18b35193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b47017-d982-4d4c-94fc-f265a5b7f36a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b47017-d982-4d4c-94fc-f265a5b7f36a.jpg?1",
             "name": "Role Reversal",
             "text": "Exchange control of two target permanents that share a permanent type.",
             "colours": [
@@ -8231,7 +8231,7 @@
         },
         {
             "id": "d3fcf363-1b10-595d-b906-a4d75dfdc6a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf8df62-eca1-4a45-84af-fd7c88245a42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bf8df62-eca1-4a45-84af-fd7c88245a42.jpg?1",
             "name": "Rubblebelt Rioters",
             "text": "Haste\nWhenever Rubblebelt Rioters attacks, it gets +X/+0 until end of turn, where X is the greatest power among creatures you control.",
             "colours": [
@@ -8268,7 +8268,7 @@
         },
         {
             "id": "8d5e4d8d-581d-5ae0-b40c-2ba55337c619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb72ba0f-ab3a-41e6-906d-a84039efa0af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb72ba0f-ab3a-41e6-906d-a84039efa0af.jpg?1",
             "name": "Solar Blaze",
             "text": "Each creature deals damage to itself equal to its power.",
             "colours": [
@@ -8302,7 +8302,7 @@
         },
         {
             "id": "aa4ef53e-b4fb-5baa-9b1f-ca98b5e9a108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354fe9bd-4ec8-409c-8ce5-b29393f3d169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354fe9bd-4ec8-409c-8ce5-b29393f3d169.jpg?1",
             "name": "Sorin, Vengeful Bloodlord",
             "text": "As long as it's your turn, creatures and planeswalkers you control have lifelink.\n+2: Sorin, Vengeful Bloodlord deals 1 damage to target player or planeswalker.\n\u2212X: Return target creature card with converted mana cost X from your graveyard to the battlefield. That creature is a Vampire in addition to its other types.",
             "colours": [
@@ -8342,7 +8342,7 @@
         },
         {
             "id": "8657ec09-9371-5ae5-b003-c47f9559760d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a29e375-081c-43ac-aeb5-9d71d65c5ddd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a29e375-081c-43ac-aeb5-9d71d65c5ddd.jpg?1",
             "name": "Sorin, Vengeful Bloodlord",
             "text": "",
             "colours": [
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "da466d68-ad03-578d-a86a-75d84007ba0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb66ccd-a930-4757-832c-c4b0259741e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fb66ccd-a930-4757-832c-c4b0259741e2.jpg?1",
             "name": "Soul Diviner",
             "text": "{T}, Remove a counter from an artifact, creature, land, or planeswalker you control: Draw a card.",
             "colours": [
@@ -8419,7 +8419,7 @@
         },
         {
             "id": "62891624-ecec-50f4-92ce-bb0b3593f595",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c906bd-f443-4f4b-b40b-9218e71f1196.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c906bd-f443-4f4b-b40b-9218e71f1196.jpg?1",
             "name": "Storrev, Devkarin Lich",
             "text": "Trample\nWhenever Storrev, Devkarin Lich deals combat damage to a player or planeswalker, return to your hand target creature or planeswalker card in your graveyard that wasn't put there this combat.",
             "colours": [
@@ -8459,7 +8459,7 @@
         },
         {
             "id": "f5d4e818-4fe5-557f-8967-e41be29a8edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76776b24-a2e1-4590-88e7-8a421baf2fc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76776b24-a2e1-4590-88e7-8a421baf2fc4.jpg?1",
             "name": "Tamiyo, Collector of Tales",
             "text": "Spells and abilities your opponents control can't cause you to discard cards or sacrifice permanents.\n+1: Choose a nonland card name, then reveal the top four cards of your library. Put all cards with the chosen name from among them into your hand and the rest into your graveyard.\n\u22123: Return target card from your graveyard to your hand.",
             "colours": [
@@ -8499,7 +8499,7 @@
         },
         {
             "id": "1340ff21-3a0c-5889-ad60-a3830ca8d6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ad78c6-8af3-4efa-b47a-29a646ea412a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5ad78c6-8af3-4efa-b47a-29a646ea412a.jpg?1",
             "name": "Tamiyo, Collector of Tales",
             "text": "",
             "colours": [
@@ -8539,7 +8539,7 @@
         },
         {
             "id": "643aea97-faaa-5cf2-8f7d-4b07d5c45e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb76266-ae50-4bbc-8f96-d98f309b02d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb76266-ae50-4bbc-8f96-d98f309b02d3.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "Each opponent can cast spells only any time they could cast a sorcery.\n+1: Until your next turn, you may cast sorcery spells as though they had flash.\n\u22123: Return up to one target artifact, creature, or enchantment to its owner's hand. Draw a card.",
             "colours": [
@@ -8579,7 +8579,7 @@
         },
         {
             "id": "2547a2ff-267b-5f64-aadd-623ca9e3f6ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01091bfd-e9b8-4a9b-89a9-56da625a5d18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01091bfd-e9b8-4a9b-89a9-56da625a5d18.jpg?1",
             "name": "A-Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -8616,7 +8616,7 @@
         },
         {
             "id": "6ba6c3fb-480a-5c58-b481-476b89b433b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb4cc4-b79a-4ac8-ba33-ceeb55012022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7eb4cc4-b79a-4ac8-ba33-ceeb55012022.jpg?1",
             "name": "Teferi, Time Raveler",
             "text": "",
             "colours": [
@@ -8656,7 +8656,7 @@
         },
         {
             "id": "9f44df25-b9b4-58bd-9394-e55752aead75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f3090b-917b-4122-b522-27c30dca8e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f3090b-917b-4122-b522-27c30dca8e69.jpg?1",
             "name": "Tenth District Legionnaire",
             "text": "Haste\nWhenever you cast a spell that targets Tenth District Legionnaire, put a +1/+1 counter on Tenth District Legionnaire, then scry 1.",
             "colours": [
@@ -8693,7 +8693,7 @@
         },
         {
             "id": "52a150fe-a4b9-5e4c-9dad-55e5e6dd7ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c59475-6f15-48d2-b105-f49901f20d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c59475-6f15-48d2-b105-f49901f20d44.jpg?1",
             "name": "Time Wipe",
             "text": "Return a creature you control to its owner's hand, then destroy all creatures.",
             "colours": [
@@ -8727,7 +8727,7 @@
         },
         {
             "id": "6200a999-c695-5023-813f-fb1f031775fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fce047-49f1-40ae-8410-6501cb0f8201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7fce047-49f1-40ae-8410-6501cb0f8201.jpg?1",
             "name": "Tolsimir, Friend to Wolves",
             "text": "When Tolsimir, Friend to Wolves enters the battlefield, create Voja, Friend to Elves, a legendary 3/3 green and white Wolf creature token.\nWhenever a Wolf enters the battlefield under your control, you gain 3 life and that creature fights up to one target creature you don't control.",
             "colours": [
@@ -8766,7 +8766,7 @@
         },
         {
             "id": "ec637ce6-77cf-588b-b6a2-128f375565a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e2708c-2824-4925-b529-d625deb77924.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e2708c-2824-4925-b529-d625deb77924.jpg?1",
             "name": "Tyrant's Scorn",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with converted mana cost 3 or less.\n\u2022 Return target creature to its owner's hand.",
             "colours": [
@@ -8800,7 +8800,7 @@
         },
         {
             "id": "45f14f0b-c356-5cb0-9292-2f3adb722418",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97715d22-f432-4f67-b4ea-47b8fe6edca5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97715d22-f432-4f67-b4ea-47b8fe6edca5.jpg?1",
             "name": "Widespread Brutality",
             "text": "Amass 2, then the Army you amassed deals damage equal to its power to each non-Army creature. (To amass 2, put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -8834,7 +8834,7 @@
         },
         {
             "id": "438ea174-d61e-5373-802b-aefeb468d6e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3a4cb5-945e-4caf-8a18-1ef977879fe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3a4cb5-945e-4caf-8a18-1ef977879fe8.jpg?1",
             "name": "Angrath, Captain of Chaos",
             "text": "Creatures you control have menace.\n\u22122: Amass 2. (Put two +1/+1 counters on an Army you control. If you don't control one, create a 0/0 black Zombie Army creature token first.)",
             "colours": [
@@ -8874,7 +8874,7 @@
         },
         {
             "id": "4c4668a9-c195-5e3e-b4ec-577d8a487403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98da7c-e61b-4921-9b27-eed3ce41221d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e98da7c-e61b-4921-9b27-eed3ce41221d.jpg?1",
             "name": "Angrath, Captain of Chaos",
             "text": "",
             "colours": [
@@ -8914,7 +8914,7 @@
         },
         {
             "id": "77b1743c-77f0-500a-bd82-3edb82b71ea2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2df3258-c053-48a8-974f-d80899b2cd93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2df3258-c053-48a8-974f-d80899b2cd93.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "Spells and abilities your opponents control can't cause their controller to search their library.\n\u22121: Target player puts the top four cards of their library into their graveyard. Then exile each opponent's graveyard.",
             "colours": [
@@ -8954,7 +8954,7 @@
         },
         {
             "id": "bff5937c-ea19-54d0-8729-4441da6add14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df061ce-dd56-4a11-a932-f16d69f47d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3df061ce-dd56-4a11-a932-f16d69f47d3b.jpg?1",
             "name": "Ashiok, Dream Render",
             "text": "",
             "colours": [
@@ -8994,7 +8994,7 @@
         },
         {
             "id": "79ad285b-2485-50ff-aad2-a1320cff715b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ff745-919b-4688-9e9e-ab7835b3b891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd6ff745-919b-4688-9e9e-ab7835b3b891.jpg?1",
             "name": "Dovin, Hand of Control",
             "text": "Artifact, instant, and sorcery spells your opponents cast cost {1} more to cast.\n\u22121: Until your next turn, prevent all damage that would be dealt to and dealt by target permanent an opponent controls.",
             "colours": [
@@ -9034,7 +9034,7 @@
         },
         {
             "id": "eed57490-6091-5655-bfba-aba1862e70ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c347f3-157e-45ca-95a8-bdf300b0811b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62c347f3-157e-45ca-95a8-bdf300b0811b.jpg?1",
             "name": "Dovin, Hand of Control",
             "text": "",
             "colours": [
@@ -9074,7 +9074,7 @@
         },
         {
             "id": "00d36b0f-e866-54df-b4aa-447ba0f681e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d709742c-82a2-457e-9991-85e98d78029d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d709742c-82a2-457e-9991-85e98d78029d.jpg?1",
             "name": "Huatli, the Sun's Heart",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.\n\u22123: You gain life equal to the greatest toughness among creatures you control.",
             "colours": [
@@ -9114,7 +9114,7 @@
         },
         {
             "id": "d7f9064a-1e5e-545e-9d53-08412f26e7d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7c88ec-0537-4d94-81d1-e1ba877d2cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d7c88ec-0537-4d94-81d1-e1ba877d2cdb.jpg?1",
             "name": "Huatli, the Sun's Heart",
             "text": "",
             "colours": [
@@ -9154,7 +9154,7 @@
         },
         {
             "id": "d5220486-1689-5ada-8838-7999645b000b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b575d3-f3f9-4ff4-8e5c-da7c2ec69882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b575d3-f3f9-4ff4-8e5c-da7c2ec69882.jpg?1",
             "name": "Kaya, Bane of the Dead",
             "text": "Your opponents and permanents your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof.\n\u22123: Exile target creature.",
             "colours": [
@@ -9194,7 +9194,7 @@
         },
         {
             "id": "31f5245d-0d8e-5240-bcfa-a5a3b3aaaf2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981850b2-3013-4f12-ab13-6410431585f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/981850b2-3013-4f12-ab13-6410431585f2.jpg?1",
             "name": "Kaya, Bane of the Dead",
             "text": "",
             "colours": [
@@ -9234,7 +9234,7 @@
         },
         {
             "id": "7220bde9-27de-5afd-bda5-dc94bec60ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b1a6-a75f-47b0-b215-de9708b6d773.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b1a6-a75f-47b0-b215-de9708b6d773.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "Whenever a creature with power 4 or greater enters the battlefield under your control, draw a card.\n\u22121: Untap target permanent.",
             "colours": [
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "c7405131-4417-5d62-ab10-020f44cb5118",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2b1975-183b-4989-aa1f-a653ec732abf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f2b1975-183b-4989-aa1f-a653ec732abf.jpg?1",
             "name": "Kiora, Behemoth Beckoner",
             "text": "",
             "colours": [
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "6c4f3a22-7a6a-53c1-9bdc-bbf5210b654e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8806605c-0cb7-4360-96e4-afb424ccad90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8806605c-0cb7-4360-96e4-afb424ccad90.jpg?1",
             "name": "Nahiri, Storm of Stone",
             "text": "As long as it's your turn, creatures you control have first strike and equip abilities you activate cost {1} less to activate.\n\u2212X: Nahiri, Storm of Stone deals X damage to target tapped creature.",
             "colours": [
@@ -9354,7 +9354,7 @@
         },
         {
             "id": "00c40864-6487-5497-af84-da7ceac90570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f17544a-7bcd-4315-8e14-bea8317ee13a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f17544a-7bcd-4315-8e14-bea8317ee13a.jpg?1",
             "name": "Nahiri, Storm of Stone",
             "text": "",
             "colours": [
@@ -9394,7 +9394,7 @@
         },
         {
             "id": "9db8bfe0-8f19-5575-b36d-0d822c8b1929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a10b543-d5d4-42a8-9ee8-dada59a2ad7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a10b543-d5d4-42a8-9ee8-dada59a2ad7e.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "Whenever you cast a noncreature spell, create a 1/1 colorless Servo artifact creature token.\n\u22122: Target artifact you control becomes a copy of another target artifact or creature you control until end of turn, except it's an artifact in addition to its other types.",
             "colours": [
@@ -9434,7 +9434,7 @@
         },
         {
             "id": "2238f49a-461c-51de-b858-9e6f616e7372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555b4e-c682-46d2-a99e-1bd1656155d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac555b4e-c682-46d2-a99e-1bd1656155d7.jpg?1",
             "name": "Saheeli, Sublime Artificer",
             "text": "",
             "colours": [
@@ -9474,7 +9474,7 @@
         },
         {
             "id": "9a4bc4b2-4b62-513d-a25d-e941c2d3e00f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0457e3f-56c1-401b-8e08-f04b95c55e2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0457e3f-56c1-401b-8e08-f04b95c55e2d.jpg?1",
             "name": "Samut, Tyrant Smasher",
             "text": "Creatures you control have haste.\n\u22121: Target creature gets +2/+1 and gains haste until end of turn. Scry 1.",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "554bee2e-bd0c-5b8d-a3e4-bf538e99a391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197c8c75-3b53-49ab-adb5-32937b49e834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197c8c75-3b53-49ab-adb5-32937b49e834.jpg?1",
             "name": "Samut, Tyrant Smasher",
             "text": "",
             "colours": [
@@ -9554,7 +9554,7 @@
         },
         {
             "id": "a0c99852-b08e-5f09-9f48-317f2253df15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ee2974-07e9-4506-903c-457cb7327dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59ee2974-07e9-4506-903c-457cb7327dd8.jpg?1",
             "name": "Vraska, Swarm's Eminence",
             "text": "Whenever a creature you control with deathtouch deals damage to a player or planeswalker, put a +1/+1 counter on that creature.\n\u22122: Create a 1/1 black Assassin creature token with deathtouch and \"Whenever this creature deals damage to a planeswalker, destroy that planeswalker.\"",
             "colours": [
@@ -9594,7 +9594,7 @@
         },
         {
             "id": "bfbf2df1-007f-500a-bfe5-1310ad1bad5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1523eed-d417-44bc-90fc-f67ecb3dc2c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1523eed-d417-44bc-90fc-f67ecb3dc2c4.jpg?1",
             "name": "Vraska, Swarm's Eminence",
             "text": "",
             "colours": [
@@ -9634,7 +9634,7 @@
         },
         {
             "id": "49cb18a1-3ebd-5f6c-b0c3-e4434cd5aa38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0ebb6b-d35a-47db-8071-7fef2a46c17b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec0ebb6b-d35a-47db-8071-7fef2a46c17b.jpg?1",
             "name": "Firemind Vessel",
             "text": "Firemind Vessel enters the battlefield tapped.\n{T}: Add two mana of different colors.",
             "colours": [],
@@ -9662,7 +9662,7 @@
         },
         {
             "id": "8a6db6ec-f645-510c-9cfb-e52827ad748f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dce06ba-c1e1-45ec-82a7-fc10b0fa8870.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dce06ba-c1e1-45ec-82a7-fc10b0fa8870.jpg?1",
             "name": "God-Pharaoh's Statue",
             "text": "Spells your opponents cast cost {2} more to cast.\nAt the beginning of your end step, each opponent loses 1 life.",
             "colours": [],
@@ -9692,7 +9692,7 @@
         },
         {
             "id": "7246a4e8-0537-5016-b07a-433c59c2c285",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7faf99e-f61f-46cb-a275-2e12c41f1e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7faf99e-f61f-46cb-a275-2e12c41f1e31.jpg?1",
             "name": "Guild Globe",
             "text": "When Guild Globe enters the battlefield, draw a card.\n{2}, {T}, Sacrifice Guild Globe: Add two mana of different colors.",
             "colours": [],
@@ -9720,7 +9720,7 @@
         },
         {
             "id": "7c489a49-7bb9-5573-a464-00e33fc95e8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2c66e-402c-4d5c-b987-402679aa914b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/ded2c66e-402c-4d5c-b987-402679aa914b.jpg?1",
             "name": "Iron Bully",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Iron Bully enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [],
@@ -9751,7 +9751,7 @@
         },
         {
             "id": "0cd9f299-f255-5114-9297-da3fa19f29f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17315a12-a7f8-45ba-ac3b-a62c789e75d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17315a12-a7f8-45ba-ac3b-a62c789e75d0.jpg?1",
             "name": "Mana Geode",
             "text": "When Mana Geode enters the battlefield, scry 1.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9779,7 +9779,7 @@
         },
         {
             "id": "a3aca765-02a0-51c7-8cc5-f5687723a88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40475e96-0283-445f-97fb-1da008707399.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40475e96-0283-445f-97fb-1da008707399.jpg?1",
             "name": "Prismite",
             "text": "{2}: Add one mana of any color.",
             "colours": [],
@@ -9810,7 +9810,7 @@
         },
         {
             "id": "104f39bb-55d3-56d4-82d4-f6b1c34975f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba77c07-5d23-4a1a-90a0-b8293848d637.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba77c07-5d23-4a1a-90a0-b8293848d637.jpg?1",
             "name": "Saheeli's Silverwing",
             "text": "Flying\nWhen Saheeli's Silverwing enters the battlefield, look at the top card of target opponent's library.",
             "colours": [],
@@ -9841,7 +9841,7 @@
         },
         {
             "id": "c5571152-b10a-5f16-8c80-11bf0122910a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6bc7d5-e8f6-4103-920c-9f7ec5cd6c28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6bc7d5-e8f6-4103-920c-9f7ec5cd6c28.jpg?1",
             "name": "Blast Zone",
             "text": "Blast Zone enters the battlefield with a charge counter on it.\n{T}: Add {C}.\n{X}{X}, {T}: Put X charge counters on Blast Zone.\n{3}, {T}, Sacrifice Blast Zone: Destroy each nonland permanent with converted mana cost equal to the number of charge counters on Blast Zone.",
             "colours": [],
@@ -9869,7 +9869,7 @@
         },
         {
             "id": "b632cecc-63a2-5589-b49d-8b17dad0493f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95f6e7-b806-47fe-a071-6c38b3176d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab95f6e7-b806-47fe-a071-6c38b3176d94.jpg?1",
             "name": "Emergence Zone",
             "text": "{T}: Add {C}.\n{1}, {T}, Sacrifice Emergence Zone: You may cast spells this turn as though they had flash.",
             "colours": [],
@@ -9897,7 +9897,7 @@
         },
         {
             "id": "867dc5ee-8945-5d55-8ddc-28adf77d7c1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d69cf2-8643-4926-857e-febbd54d870f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81d69cf2-8643-4926-857e-febbd54d870f.jpg?1",
             "name": "Gateway Plaza",
             "text": "Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -9927,7 +9927,7 @@
         },
         {
             "id": "cd13979a-8623-5460-b4a4-b9eb503a0682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d8e2a-e1dd-4867-8e8c-e48b9450b350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/132d8e2a-e1dd-4867-8e8c-e48b9450b350.jpg?1",
             "name": "Interplanar Beacon",
             "text": "Whenever you cast a planeswalker spell, you gain 1 life.\n{T}: Add {C}.\n{1}, {T}: Add two mana of different colors. Spend this mana only to cast planeswalker spells.",
             "colours": [],
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "be235975-8cc2-5d04-9413-cb24078a10c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d895af-7e8c-419f-bc5d-5596083fbfb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d895af-7e8c-419f-bc5d-5596083fbfb6.jpg?1",
             "name": "Karn's Bastion",
             "text": "{T}: Add {C}.\n{4}, {T}: Proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [],
@@ -9983,7 +9983,7 @@
         },
         {
             "id": "9e0bac4f-5eb9-5bdb-ba4c-fb3ef2495485",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214792e9-a172-4547-b148-b9b368cb3432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214792e9-a172-4547-b148-b9b368cb3432.jpg?1",
             "name": "Mobilized District",
             "text": "{T}: Add {C}.\n{4}: Mobilized District becomes a 3/3 Citizen creature with vigilance until end of turn. It's still a land. This ability costs {1} less to activate for each legendary creature and planeswalker you control.",
             "colours": [],
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "f752014a-4084-5cf0-8ad8-ef1abbc42ee6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92ef517-2417-43a2-8b1a-0673d1531c65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d92ef517-2417-43a2-8b1a-0673d1531c65.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "84f7df64-3236-5564-af46-d92f8bf3d82c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84144d57-f0b6-4011-aee8-c626c21998c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84144d57-f0b6-4011-aee8-c626c21998c4.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10085,7 +10085,7 @@
         },
         {
             "id": "6398dfb7-92c3-514e-9dcd-56eb5cf61407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ae52e-9ea7-4e9d-a9c9-c819cc768cd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d7ae52e-9ea7-4e9d-a9c9-c819cc768cd6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -10122,7 +10122,7 @@
         },
         {
             "id": "00ec69b3-2ee6-505c-a5aa-190713ce2342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7014b9fc-a906-4ffd-a482-22ba8dbe3b4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7014b9fc-a906-4ffd-a482-22ba8dbe3b4a.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10159,7 +10159,7 @@
         },
         {
             "id": "ffc37bdd-e379-5cad-851a-b18eeee2d857",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb7b85-8c0f-4311-85f3-11bcb45ba0b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40eb7b85-8c0f-4311-85f3-11bcb45ba0b6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10196,7 +10196,7 @@
         },
         {
             "id": "b641bd1b-2b9d-5354-9c63-d47ed4aa3741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e28a0-a10f-4324-b008-09564e85573e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24e28a0-a10f-4324-b008-09564e85573e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -10233,7 +10233,7 @@
         },
         {
             "id": "29c0a93a-31d3-5e34-a3e1-dfe16c7979c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eeb424-235d-4346-9355-57914e740ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24eeb424-235d-4346-9355-57914e740ec6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10270,7 +10270,7 @@
         },
         {
             "id": "3cef4025-fecf-5c80-aa2d-e01726d40852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211b98e5-8ec2-4108-bacd-97e854a85b6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/211b98e5-8ec2-4108-bacd-97e854a85b6f.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10307,7 +10307,7 @@
         },
         {
             "id": "e604ae3d-dde1-50d6-b3f2-b05995c79cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04559991-3278-469f-b2be-07c3b27ad5a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04559991-3278-469f-b2be-07c3b27ad5a5.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -10344,7 +10344,7 @@
         },
         {
             "id": "9a3c07b1-7f17-582c-a32f-711c63fd7023",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489fdba7-5c25-4cf3-a1e0-3e0fda6c6ee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/489fdba7-5c25-4cf3-a1e0-3e0fda6c6ee6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10381,7 +10381,7 @@
         },
         {
             "id": "8a7eda3c-35ce-58d2-8a46-51f5a0fae7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7878e1-28a5-4527-ba61-ed6c6b855309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7878e1-28a5-4527-ba61-ed6c6b855309.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10418,7 +10418,7 @@
         },
         {
             "id": "27ecba1a-6dd3-5611-9054-5be611b73349",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef001a8-adb5-4125-aa1a-f5e3f8ca898b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ef001a8-adb5-4125-aa1a-f5e3f8ca898b.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -10455,7 +10455,7 @@
         },
         {
             "id": "3ff03579-4891-5929-8e6d-516c9e18fffb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d61651-349e-40d0-a7c4-c9561e190405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9d61651-349e-40d0-a7c4-c9561e190405.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10492,7 +10492,7 @@
         },
         {
             "id": "ffc29ec9-5994-5857-8963-37987b5ff2da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ef8358-9812-4d40-9532-d667513d7701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ef8358-9812-4d40-9532-d667513d7701.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10529,7 +10529,7 @@
         },
         {
             "id": "02ef4428-b7c7-55b2-84ed-e07e26d44bcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120879f-df13-4583-b260-0fc298518f16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/0120879f-df13-4583-b260-0fc298518f16.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -10566,7 +10566,7 @@
         },
         {
             "id": "afa65aca-d3c0-5ec5-a3ab-ae8e45d858c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7331d-98b8-420f-a346-3f3521c3b258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e7331d-98b8-420f-a346-3f3521c3b258.jpg?1",
             "name": "Gideon, the Oathsworn",
             "text": "Whenever you attack with two or more non-Gideon creatures, put a +1/+1 counter on each of those creatures.\n+2: Until end of turn, Gideon, the Oathsworn becomes a 5/5 white Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn. (He can't attack if he was cast this turn.)\n\u22129: Exile Gideon, the Oathsworn and each creature your opponents control.",
             "colours": [
@@ -10601,7 +10601,7 @@
         },
         {
             "id": "c26eea1c-45b8-5669-aedd-3478617f4c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce134a-25ef-4f8d-a385-7c29fc5707dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69ce134a-25ef-4f8d-a385-7c29fc5707dc.jpg?1",
             "name": "Desperate Lunge",
             "text": "Target creature gets +2/+2 and gains flying until end of turn. You gain 2 life.",
             "colours": [
@@ -10632,7 +10632,7 @@
         },
         {
             "id": "bf37df13-6eb3-59f9-ae91-63063737742b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52de8fc6-6d9b-402e-a6c8-4c39b0c92f07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52de8fc6-6d9b-402e-a6c8-4c39b0c92f07.jpg?1",
             "name": "Gideon's Battle Cry",
             "text": "Put a +1/+1 counter on each creature you control. You may search your library and/or graveyard for a card named Gideon, the Oathsworn, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10663,7 +10663,7 @@
         },
         {
             "id": "4bfb89dd-6d4a-5da5-ab7d-ed387781606f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a64d2e-8b89-4642-84c2-b01dfe11312e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a64d2e-8b89-4642-84c2-b01dfe11312e.jpg?1",
             "name": "Gideon's Company",
             "text": "Whenever you gain life, put two +1/+1 counters on Gideon's Company.\n{3}{W}: Put a loyalty counter on target Gideon planeswalker.",
             "colours": [
@@ -10697,7 +10697,7 @@
         },
         {
             "id": "eab81823-e710-52b2-88b3-be3dfcf88da2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbadf8cf-02bf-45f6-b3c1-a684d9bc5228.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbadf8cf-02bf-45f6-b3c1-a684d9bc5228.jpg?1",
             "name": "Orzhov Guildgate",
             "text": "Orzhov Guildgate enters the battlefield tapped.\n{T}: Add {W} or {B}.",
             "colours": [],
@@ -10729,7 +10729,7 @@
         },
         {
             "id": "fc9d6f40-8ae4-59ce-a184-4224a864f17d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a857fb-159f-40c4-8988-da91d8521a60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a857fb-159f-40c4-8988-da91d8521a60.jpg?1",
             "name": "Jace, Arcane Strategist",
             "text": "Whenever you draw your second card each turn, put a +1/+1 counter on target creature you control.\n+1: Draw a card.\n\u22127: Creatures you control can't be blocked this turn.",
             "colours": [
@@ -10764,7 +10764,7 @@
         },
         {
             "id": "c1a0a165-01c5-538d-bcde-8169054bb06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a304200f-86d5-4eed-a775-cc24e72872ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a304200f-86d5-4eed-a775-cc24e72872ac.jpg?1",
             "name": "Guildpact Informant",
             "text": "Flying\nWhenever Guildpact Informant deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)",
             "colours": [
@@ -10798,7 +10798,7 @@
         },
         {
             "id": "3ad0900e-596e-5b9a-8503-7180b6a3cd55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d35a34-01b7-41e1-8491-a6589175d027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4d35a34-01b7-41e1-8491-a6589175d027.jpg?1",
             "name": "Jace's Projection",
             "text": "Whenever you draw a card, put a +1/+1 counter on Jace's Projection.\n{3}{U}: Put a loyalty counter on target Jace planeswalker.",
             "colours": [
@@ -10832,7 +10832,7 @@
         },
         {
             "id": "aa0a67a1-cb52-5d46-bbfe-e56546c90a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e8d2c7-cd6e-48bf-9d54-73f3d6cff0aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03e8d2c7-cd6e-48bf-9d54-73f3d6cff0aa.jpg?1",
             "name": "Jace's Ruse",
             "text": "Return up to two target creatures to their owner's hand. You may search your library and/or graveyard for a card named Jace, Arcane Strategist, reveal it, and put it into your hand. If you search your library this way, shuffle it.",
             "colours": [
@@ -10863,7 +10863,7 @@
         },
         {
             "id": "16eff56b-1261-51ce-86db-a59a9e8cd28d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989d6851-2a5d-4d8f-a7b8-724818236c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/989d6851-2a5d-4d8f-a7b8-724818236c47.jpg?1",
             "name": "Simic Guildgate",
             "text": "Simic Guildgate enters the battlefield tapped.\n{T}: Add {G} or {U}.",
             "colours": [],
@@ -10895,7 +10895,7 @@
         },
         {
             "id": "e381bfa0-b8d7-52ff-a6fe-1bc22133edda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1eea2-961f-445d-b035-6baed454f289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ee1eea2-961f-445d-b035-6baed454f289.jpg?1",
             "name": "Tezzeret, Master of the Bridge",
             "text": "Creature and planeswalker spells you cast have affinity for artifacts.\n+2: Tezzeret, Master of the Bridge deals X damage to each opponent, where X is the number of artifacts you control. You gain X life.\n\u22123: Return target artifact card from your graveyard to your hand.\n\u22128: Exile the top ten cards of your library. Put all artifact cards from among them onto the battlefield.",
             "colours": [
@@ -10932,7 +10932,7 @@
         },
         {
             "id": "fd5fe8a4-bb00-5884-9468-86d63c58d1fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d7514-35a9-446b-be0d-a5b6b4001291.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d7514-35a9-446b-be0d-a5b6b4001291.jpg?1",
             "name": "Spirit",
             "text": "",
             "colours": [],
@@ -10962,7 +10962,7 @@
         },
         {
             "id": "80298dd1-6460-5e53-8390-f1a1c6ee1e45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b81e0-5525-4be3-96db-807146fdc5b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16b81e0-5525-4be3-96db-807146fdc5b3.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -10996,7 +10996,7 @@
         },
         {
             "id": "6250feea-3f95-5c08-955f-323be591443c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11c711-93fe-45ca-b393-3851148defc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca11c711-93fe-45ca-b393-3851148defc4.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -11030,7 +11030,7 @@
         },
         {
             "id": "24eb5aaf-70f4-5d91-8762-0c027557b192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae8c31-70cb-44e1-a105-f4d29f1f9356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8ae8c31-70cb-44e1-a105-f4d29f1f9356.jpg?1",
             "name": "Wall",
             "text": "",
             "colours": [
@@ -11064,7 +11064,7 @@
         },
         {
             "id": "9b47488c-320d-5b91-b7be-fd6a32c343a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0b95ce-4821-4955-a27c-93471240f54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b0b95ce-4821-4955-a27c-93471240f54b.jpg?1",
             "name": "Wizard",
             "text": "",
             "colours": [
@@ -11098,7 +11098,7 @@
         },
         {
             "id": "20d740ce-f9b0-580c-9f23-ec1b0c6ea42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e997ac-5a4a-4555-9b37-06c25a5db356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7e997ac-5a4a-4555-9b37-06c25a5db356.jpg?1",
             "name": "Assassin",
             "text": "",
             "colours": [
@@ -11132,7 +11132,7 @@
         },
         {
             "id": "87201137-39ed-586a-985a-90821d3de996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg?1",
             "name": "Zombie",
             "text": "",
             "colours": [
@@ -11166,7 +11166,7 @@
         },
         {
             "id": "3e61718a-ebb5-5b67-929d-1eafdafd1388",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b7c63-8430-4ca4-baee-dc958d5bd22f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f4b7c63-8430-4ca4-baee-dc958d5bd22f.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -11201,7 +11201,7 @@
         },
         {
             "id": "a915e4c4-e12a-5e5f-ae47-f04e31c547c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3f2ad9-d362-4602-8e49-b44c0659c112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f3f2ad9-d362-4602-8e49-b44c0659c112.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -11236,7 +11236,7 @@
         },
         {
             "id": "b58e80b0-3835-5eda-8aa0-b600a9a7cc6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12742d1f-eb2e-4262-88e2-403c9ae6c431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12742d1f-eb2e-4262-88e2-403c9ae6c431.jpg?1",
             "name": "Zombie Army",
             "text": "",
             "colours": [
@@ -11271,7 +11271,7 @@
         },
         {
             "id": "69d5ed6f-fcf2-5d44-896b-4c2b2df9407c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06aa97-1611-4af6-8bad-32051927fcfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e06aa97-1611-4af6-8bad-32051927fcfd.jpg?1",
             "name": "Zombie Warrior",
             "text": "",
             "colours": [
@@ -11306,7 +11306,7 @@
         },
         {
             "id": "85006970-f095-5f8f-8888-cd32c5fa6bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dc3d65-1729-4541-9dc3-bd673e9bdc5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72dc3d65-1729-4541-9dc3-bd673e9bdc5d.jpg?1",
             "name": "Devil",
             "text": "",
             "colours": [
@@ -11340,7 +11340,7 @@
         },
         {
             "id": "f1a101af-6b87-576d-b9a1-e62aa9729e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a195b254-bc3c-4259-9219-5a9e085d7947.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a195b254-bc3c-4259-9219-5a9e085d7947.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -11374,7 +11374,7 @@
         },
         {
             "id": "4dc37821-5a65-5c3c-9fe6-d8cd57b5c540",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0861b13-6cf8-4078-9178-e223a4041a8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0861b13-6cf8-4078-9178-e223a4041a8b.jpg?1",
             "name": "Goblin",
             "text": "",
             "colours": [
@@ -11408,7 +11408,7 @@
         },
         {
             "id": "d5bb1bad-8652-591d-a221-e91004d64993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f3219-3e98-4354-abcd-db22c3253105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f3219-3e98-4354-abcd-db22c3253105.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [
@@ -11442,7 +11442,7 @@
         },
         {
             "id": "f383fb18-f9c7-5ae5-a5b3-6145bc1ff24b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ba875-f77b-404f-8b75-4ba6f81da410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de7ba875-f77b-404f-8b75-4ba6f81da410.jpg?1",
             "name": "Citizen",
             "text": "",
             "colours": [
@@ -11484,7 +11484,7 @@
         },
         {
             "id": "39d9e3f7-e989-5ddb-bdc6-db7b3f17463b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39475e91-1e71-4546-ae4a-47ea66e47536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39475e91-1e71-4546-ae4a-47ea66e47536.jpg?1",
             "name": "Voja, Friend to Elves",
             "text": "",
             "colours": [
@@ -11522,7 +11522,7 @@
         },
         {
             "id": "a74ffa4e-54c6-5945-bfc4-8890cd279b60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761507d5-d36a-4123-a074-95d7f6ffb4c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/761507d5-d36a-4123-a074-95d7f6ffb4c5.jpg?1",
             "name": "Servo",
             "text": "",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "7f8a2b3a-365f-5825-8d10-4ce16e3cd201",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b191fe-7a92-4d08-91a4-036699d08bc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b191fe-7a92-4d08-91a4-036699d08bc4.jpg?1",
             "name": "Nissa, Who Shakes the World Emblem",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/WHO.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/WHO.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "9d7695d0-cfcd-5923-8f16-0513ec31b047",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c5bd2b-cf68-4e5e-819d-53917a6c5275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59c5bd2b-cf68-4e5e-819d-53917a6c5275.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -52,7 +52,7 @@
         },
         {
             "id": "91f13aee-1fea-522f-ba42-20c14b400f82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84ea0fd-efc7-4614-9f8f-41a3c71fceaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c84ea0fd-efc7-4614-9f8f-41a3c71fceaa.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -98,7 +98,7 @@
         },
         {
             "id": "10bc8c49-2239-58ec-92a8-9ccb9298331f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1499f49-793b-4265-9ad0-883a431941ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1499f49-793b-4265-9ad0-883a431941ab.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "845adf01-30b9-59f5-940b-2200b70f713d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc4ec90-1650-4b98-9350-66341394cf0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc4ec90-1650-4b98-9350-66341394cf0b.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -190,7 +190,7 @@
         },
         {
             "id": "397dcc00-a00c-5bb0-80a0-35bafe2dae4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa8d034-f98c-4e27-b6af-850eadf59941.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa8d034-f98c-4e27-b6af-850eadf59941.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -231,7 +231,7 @@
         },
         {
             "id": "71bb3a62-bf3e-5f3b-b334-7e68d27b72de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba76f68-e647-4786-903c-92dbd3cef05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba76f68-e647-4786-903c-92dbd3cef05d.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -273,7 +273,7 @@
         },
         {
             "id": "87ba4c05-0385-584d-a6c0-44ce59fec23d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b09a4f-bb62-4766-8115-cae4d5cc4c12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b09a4f-bb62-4766-8115-cae4d5cc4c12.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -315,7 +315,7 @@
         },
         {
             "id": "7efb45e4-cfa8-51aa-8e02-8f13e8d549ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfae7d1-c09b-47e0-92d8-49b21402207d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dfae7d1-c09b-47e0-92d8-49b21402207d.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -361,7 +361,7 @@
         },
         {
             "id": "f662c683-4f09-5969-8cf2-9400e7be82f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1ee042-6713-4e9e-9901-9b94d99d33f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a1ee042-6713-4e9e-9901-9b94d99d33f1.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -398,7 +398,7 @@
         },
         {
             "id": "4ec26b49-a6e1-53d5-a186-dabfab42a03f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f91092-b679-46c1-9f0c-3b286ee1d02f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68f91092-b679-46c1-9f0c-3b286ee1d02f.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -436,7 +436,7 @@
         },
         {
             "id": "d52e93d3-4e3b-58a6-b87b-afb838b1e14f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda3aa2-5fac-4188-bdad-dc369a089d00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cda3aa2-5fac-4188-bdad-dc369a089d00.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "1e7cdeab-8cf8-50d9-a611-c5fbc81b36bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03868f8d-1f1b-4892-abb0-be2b00fc2ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03868f8d-1f1b-4892-abb0-be2b00fc2ba7.jpg?1",
             "name": "Atraxi Warden",
             "text": "",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "cd2d7494-b120-5586-b052-d76caca08d96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f39d4c-af2d-486d-9408-b987474f8352.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f39d4c-af2d-486d-9408-b987474f8352.jpg?1",
             "name": "Banish to Another Universe",
             "text": "",
             "colours": [
@@ -547,7 +547,7 @@
         },
         {
             "id": "f2521d48-6edd-5af8-836c-f6b8ce04c110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bdd33-549d-4690-917c-ea48decffbbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414bdd33-549d-4690-917c-ea48decffbbb.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -588,7 +588,7 @@
         },
         {
             "id": "0b41e207-bfed-51e0-98c7-1c355c71bec3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b260c0a-b9dc-4a4f-83ee-5a7fbd9b3f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b260c0a-b9dc-4a4f-83ee-5a7fbd9b3f67.jpg?1",
             "name": "The Caves of Androzani",
             "text": "",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "c2f4a7a9-cbd2-5f94-8b95-ae1f20327e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559e77be-42a2-47cf-a2cf-057b37384cb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559e77be-42a2-47cf-a2cf-057b37384cb4.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -660,7 +660,7 @@
         },
         {
             "id": "8b3787ae-4e73-5c7b-ab15-74cdb00554fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d9672-58a7-4ec8-a20d-7054d76fde37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d9672-58a7-4ec8-a20d-7054d76fde37.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -696,7 +696,7 @@
         },
         {
             "id": "3607ba30-c979-5339-9844-390b7b5bebca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab0052-7f0c-4b56-847f-20552666a271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dab0052-7f0c-4b56-847f-20552666a271.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -732,7 +732,7 @@
         },
         {
             "id": "f1889911-bdea-5069-9ccc-6199059f3918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4b912c-07d4-42a1-8f3b-d5f34cca087f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb4b912c-07d4-42a1-8f3b-d5f34cca087f.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -768,7 +768,7 @@
         },
         {
             "id": "1aa57ee1-1c18-5cea-96c5-71ba653f68a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe50fc-6c6c-43e7-ad0e-8f13a254da2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02fe50fc-6c6c-43e7-ad0e-8f13a254da2a.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -804,7 +804,7 @@
         },
         {
             "id": "b551ecb5-b178-50c2-81c6-6d34aba900a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5da4-0d8e-4db1-b827-ddfeb5ce0f1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e3a5da4-0d8e-4db1-b827-ddfeb5ce0f1d.jpg?1",
             "name": "The Girl in the Fireplace",
             "text": "",
             "colours": [
@@ -840,7 +840,7 @@
         },
         {
             "id": "3034ca97-3b46-571c-86ba-139a9bc6cca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bce4bde-33af-4c91-903f-c46218664353.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bce4bde-33af-4c91-903f-c46218664353.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "971a4715-46c2-59b3-9703-59edca1a09a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c73220-363e-44d7-b406-436246c02a75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c73220-363e-44d7-b406-436246c02a75.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "f5ccdd28-1d48-5f18-8656-674c2c3e05f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513d33fb-becc-4804-806a-764d08fc7b7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/513d33fb-becc-4804-806a-764d08fc7b7d.jpg?1",
             "name": "The Night of the Doctor",
             "text": "",
             "colours": [
@@ -958,7 +958,7 @@
         },
         {
             "id": "5f9a321d-cce3-534e-86bd-3378eec528e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1642e04-d39a-46dc-8157-549c225c992f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1642e04-d39a-46dc-8157-549c225c992f.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -996,7 +996,7 @@
         },
         {
             "id": "37ddbd3f-7409-5415-b3cb-59b6b46cca38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f81beb-4565-4cfe-80a2-456f3d44f461.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2f81beb-4565-4cfe-80a2-456f3d44f461.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -1036,7 +1036,7 @@
         },
         {
             "id": "31687180-43c2-5eda-98d8-313686d0e576",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc3ebd-34e1-421c-87b4-0be905954289.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ccc3ebd-34e1-421c-87b4-0be905954289.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -1077,7 +1077,7 @@
         },
         {
             "id": "7ba8c775-f6dc-5195-8f9e-a9aefed6ea12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361769b3-7e10-4e0f-b623-c00e2144463d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/361769b3-7e10-4e0f-b623-c00e2144463d.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -1117,7 +1117,7 @@
         },
         {
             "id": "a9e22411-55f6-559a-858a-f37a3cf79d86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b68ed3-0d26-4334-8d0c-2d28ced8ee4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b68ed3-0d26-4334-8d0c-2d28ced8ee4c.jpg?1",
             "name": "Trial of a Time Lord",
             "text": "",
             "colours": [
@@ -1153,7 +1153,7 @@
         },
         {
             "id": "3837f4b6-83e7-5dd4-af64-271b9f3414d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0662fee0-a6bc-4a1c-8a0f-6e7efc6b8a21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0662fee0-a6bc-4a1c-8a0f-6e7efc6b8a21.jpg?1",
             "name": "The War Games",
             "text": "",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "fdf7019b-53a0-5a4a-9040-9e5fd95d94aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc4ce53-7805-4448-bc20-f5bf85fdefa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc4ce53-7805-4448-bc20-f5bf85fdefa3.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -1225,7 +1225,7 @@
         },
         {
             "id": "82292f40-e2de-57a7-ac0a-802eb5b17a8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10918b68-b442-4895-b8a6-57f65274a39e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10918b68-b442-4895-b8a6-57f65274a39e.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -1266,7 +1266,7 @@
         },
         {
             "id": "37c414e4-79e3-5089-a62b-a2137ff3da3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f290a17-699e-420d-8322-3e28300a0d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f290a17-699e-420d-8322-3e28300a0d2e.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "6fa1ea60-10a3-57a1-9cde-32ecc32cc715",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6c639c-0b8a-4369-b7d0-57aa1f83279a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb6c639c-0b8a-4369-b7d0-57aa1f83279a.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -1343,7 +1343,7 @@
         },
         {
             "id": "47a1c0fb-a889-5976-a94d-00ae435f0aef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b20b07-2983-4b5e-9351-b8d7a5bcd72a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72b20b07-2983-4b5e-9351-b8d7a5bcd72a.jpg?1",
             "name": "An Unearthly Child",
             "text": "",
             "colours": [
@@ -1379,7 +1379,7 @@
         },
         {
             "id": "95fb3704-6701-5c6b-9e4f-b05566bd959e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc35b82-a233-4460-968e-d90980fb2074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4cc35b82-a233-4460-968e-d90980fb2074.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -1419,7 +1419,7 @@
         },
         {
             "id": "dacf01c0-9684-55e9-bc08-fb6de61ba4a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15927163-f203-4d45-b78f-70eafb941bfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15927163-f203-4d45-b78f-70eafb941bfd.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "12e69b0a-bdbc-54cf-a694-5fcab53d6f64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ce5aa7-70cb-4ab2-9a25-4363aa2b370f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4ce5aa7-70cb-4ab2-9a25-4363aa2b370f.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -1493,7 +1493,7 @@
         },
         {
             "id": "0115b361-604d-5e3f-a0e3-0464eeacd4c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e0a50-304c-4b3f-b5f7-1ca1213c0282.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf5e0a50-304c-4b3f-b5f7-1ca1213c0282.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -1535,7 +1535,7 @@
         },
         {
             "id": "726aed83-c456-5f46-b0f3-32af922f9f1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31cf95-6e1d-4786-ae92-e1eebdb1da13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef31cf95-6e1d-4786-ae92-e1eebdb1da13.jpg?1",
             "name": "Don't Blink",
             "text": "",
             "colours": [
@@ -1569,7 +1569,7 @@
         },
         {
             "id": "d6fefffc-d6b7-5125-90f8-7d8e661456a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c90a9-697a-4bff-a738-0cebfb238bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac5c90a9-697a-4bff-a738-0cebfb238bff.jpg?1",
             "name": "The Eleventh Hour",
             "text": "",
             "colours": [
@@ -1605,7 +1605,7 @@
         },
         {
             "id": "ade5c3bc-0e55-5e9b-8213-7622ad5b3622",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c1ebc5-6775-47f3-be43-e59b281eba55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89c1ebc5-6775-47f3-be43-e59b281eba55.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -1645,7 +1645,7 @@
         },
         {
             "id": "4147ea73-7091-5d15-bb87-9732b6c827d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baea4cd3-cc62-4138-ac2e-5c96c70bbcce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baea4cd3-cc62-4138-ac2e-5c96c70bbcce.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -1681,7 +1681,7 @@
         },
         {
             "id": "0abb16eb-77d7-5275-930f-7d7a8dada1db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512e9bd2-77b9-4c1c-8d30-e6249dbd930e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/512e9bd2-77b9-4c1c-8d30-e6249dbd930e.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -1720,7 +1720,7 @@
         },
         {
             "id": "50ea2745-f009-5c51-a2ee-8379fee0e852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3474c4-9466-46fc-8327-50950d75e79f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c3474c4-9466-46fc-8327-50950d75e79f.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -1760,7 +1760,7 @@
         },
         {
             "id": "50d901b8-93d3-566a-97cf-9a1191262b71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b0a2a9-ba95-4330-a8ab-9cb530eb4257.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04b0a2a9-ba95-4330-a8ab-9cb530eb4257.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -1796,7 +1796,7 @@
         },
         {
             "id": "dda3992c-f23b-558a-b015-46c9b465d74a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e46695-7bd3-448c-a5ea-6d544943ec5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e46695-7bd3-448c-a5ea-6d544943ec5f.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "8e74cc47-2aa9-5870-8286-4c4c4ae0aabd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9f97c9-825b-43dc-96a5-807d1a15fdce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a9f97c9-825b-43dc-96a5-807d1a15fdce.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -1881,7 +1881,7 @@
         },
         {
             "id": "06b3fb7d-5569-5bb7-945a-30d5c00776d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aa8dbd-ae18-4d62-a721-94afcb12bf27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81aa8dbd-ae18-4d62-a721-94afcb12bf27.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -1917,7 +1917,7 @@
         },
         {
             "id": "0f045bf3-7c9e-5859-8232-c10662921538",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5c463-6b5c-49c9-84c9-666aa8c19fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03a5c463-6b5c-49c9-84c9-666aa8c19fbf.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -1958,7 +1958,7 @@
         },
         {
             "id": "08552412-cca5-5ffa-9c84-21bd39ac98a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed41499-759d-4a3b-aabb-c462d5831956.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bed41499-759d-4a3b-aabb-c462d5831956.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -1999,7 +1999,7 @@
         },
         {
             "id": "8b14a0f6-c32d-53c0-8652-94273a1d38da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceba3080-4e10-46b3-887c-e2d45581962b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceba3080-4e10-46b3-887c-e2d45581962b.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -2035,7 +2035,7 @@
         },
         {
             "id": "fc451067-fefd-5e40-87f4-d331676d2639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6deb8b33-723d-4927-934c-5d049125d235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6deb8b33-723d-4927-934c-5d049125d235.jpg?1",
             "name": "Renegade Silent",
             "text": "",
             "colours": [
@@ -2072,7 +2072,7 @@
         },
         {
             "id": "89f69343-a889-5338-9202-b2196798f647",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3ea66-555c-490d-b34f-12c267bc4e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f3ea66-555c-490d-b34f-12c267bc4e9b.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -2108,7 +2108,7 @@
         },
         {
             "id": "f4e25f3a-4912-521e-acac-c183ebe6b46f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dca4c3-efd6-4b6b-ac49-5a916135a592.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82dca4c3-efd6-4b6b-ac49-5a916135a592.jpg?1",
             "name": "Star Whale",
             "text": "",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "5bd3b8bd-d965-5af1-bbf0-b117dc29fb34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3574926-dd5a-4997-b9e2-7b051bc59c57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3574926-dd5a-4997-b9e2-7b051bc59c57.jpg?1",
             "name": "Start the TARDIS",
             "text": "",
             "colours": [
@@ -2179,7 +2179,7 @@
         },
         {
             "id": "0afa3289-1551-5be3-b661-a130c7cd7fad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001c639-8bd0-426f-89cb-4ca61f3cc054.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001c639-8bd0-426f-89cb-4ca61f3cc054.jpg?1",
             "name": "Surge of Brilliance",
             "text": "",
             "colours": [
@@ -2213,7 +2213,7 @@
         },
         {
             "id": "0f81e2ce-7d82-5fb5-a314-eec32e6d5e1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c592af4-5470-4311-af05-761e5a9c46be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c592af4-5470-4311-af05-761e5a9c46be.jpg?1",
             "name": "Time Beetle",
             "text": "",
             "colours": [
@@ -2250,7 +2250,7 @@
         },
         {
             "id": "cc5956a1-dd9d-5a8a-87f6-f9944c46fc11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeba907-5dc7-4dbb-b5a4-c86e8151f2ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aeba907-5dc7-4dbb-b5a4-c86e8151f2ec.jpg?1",
             "name": "Time Lord Regeneration",
             "text": "",
             "colours": [
@@ -2284,7 +2284,7 @@
         },
         {
             "id": "6dc44610-e521-5488-8067-03014b0231ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6570c23-f135-4e81-9a4c-934c298a51ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6570c23-f135-4e81-9a4c-934c298a51ad.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -2320,7 +2320,7 @@
         },
         {
             "id": "57edcefc-f5a2-5b18-9d1a-2f97a583c826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -2354,7 +2354,7 @@
         },
         {
             "id": "0af22e84-fc91-5aa4-bd5b-642499164d47",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -2390,7 +2390,7 @@
         },
         {
             "id": "74cbfeee-1233-5e2b-9b96-fb7291fbf157",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55412d31-fba2-46fd-b1a1-d47fb41c4b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55412d31-fba2-46fd-b1a1-d47fb41c4b8d.jpg?1",
             "name": "Wibbly-wobbly, Timey-wimey",
             "text": "",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "b2cd3d8b-6284-5641-b8dd-e482f5fe67e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b5538b-4561-4929-8e1c-9763e75cad0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71b5538b-4561-4929-8e1c-9763e75cad0e.jpg?1",
             "name": "Zygon Infiltrator",
             "text": "",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "e8f7a181-3ee5-5d8f-8fbf-141407daec36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77763c-b50c-4787-b352-68af16e4c741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba77763c-b50c-4787-b352-68af16e4c741.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -2501,7 +2501,7 @@
         },
         {
             "id": "2ffa5566-3934-5dab-a0da-919fda8adf94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76573f9d-f0f2-47b8-88e7-17d58d0d20d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76573f9d-f0f2-47b8-88e7-17d58d0d20d3.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "750d7ebb-0f67-57b8-bd22-a9797def63cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c55c73-eed0-433c-b1a4-c2edae06a77f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c55c73-eed0-433c-b1a4-c2edae06a77f.jpg?1",
             "name": "Death in Heaven",
             "text": "",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "2456a8b5-6547-5c07-987e-26ef5df3deaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e86622-6f30-41b2-87d0-d345110e2387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4e86622-6f30-41b2-87d0-d345110e2387.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -2612,7 +2612,7 @@
         },
         {
             "id": "b5a3b520-41c2-5646-8b10-f64d3714293a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da54bbfd-48d8-4b1f-9336-e45be7e0b0e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da54bbfd-48d8-4b1f-9336-e45be7e0b0e5.jpg?1",
             "name": "Exterminate!",
             "text": "",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "59218706-6ecd-5fee-883d-b53b71b810c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce10eb6-9718-4739-a796-da33d823a463.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ce10eb6-9718-4739-a796-da33d823a463.jpg?1",
             "name": "Genesis of the Daleks",
             "text": "",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "ba37142f-1df5-5d4d-b4a6-4a7b0d9908ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f6265-c0c8-4f51-bea8-408caf0a58d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/250f6265-c0c8-4f51-bea8-408caf0a58d8.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -2718,7 +2718,7 @@
         },
         {
             "id": "004badc6-e7a8-5173-94c6-7ec2d4722c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05bca9-a756-4492-b085-221daa384a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05bca9-a756-4492-b085-221daa384a93.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -2757,7 +2757,7 @@
         },
         {
             "id": "dcf12813-8ec4-5bc6-be53-40aea8e16f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381de078-6eac-462c-b6d9-095779279d42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381de078-6eac-462c-b6d9-095779279d42.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -2793,7 +2793,7 @@
         },
         {
             "id": "142b0cc6-cc11-5418-9a2a-4f0266166d9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2765f-4016-4e41-9db4-5ad463faceab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb2765f-4016-4e41-9db4-5ad463faceab.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -2832,7 +2832,7 @@
         },
         {
             "id": "d1932cee-1d5f-5aa1-8f71-4f83fef914c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ec946-036b-480a-bab6-c4102e5c31db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25ec946-036b-480a-bab6-c4102e5c31db.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -2872,7 +2872,7 @@
         },
         {
             "id": "748e2651-e95f-5da1-94f6-08be6668aed1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a2faa-91e3-4e89-ba8d-2cbf7ac005c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e50a2faa-91e3-4e89-ba8d-2cbf7ac005c0.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -2912,7 +2912,7 @@
         },
         {
             "id": "a331d3d4-3ff5-54e0-9941-2a1dcb17d2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74185710-3877-4080-b1d2-014fabbc7186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74185710-3877-4080-b1d2-014fabbc7186.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -2952,7 +2952,7 @@
         },
         {
             "id": "80dd3856-f141-5ef1-985a-0d4761d97a6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "91fe54b6-8cd1-5924-b2b0-2f60244cc98f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "7a61cb6e-4d43-55e4-8b29-0da85dbe6e92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b5c60e-f2f5-40d7-8713-edc3ecedb5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24b5c60e-f2f5-40d7-8713-edc3ecedb5e0.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -3060,7 +3060,7 @@
         },
         {
             "id": "d9cf21d7-fe90-549c-af07-c5d1a35afadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc53534-f362-4871-a594-9855a4923cd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adc53534-f362-4871-a594-9855a4923cd0.jpg?1",
             "name": "Day of the Moon",
             "text": "",
             "colours": [
@@ -3096,7 +3096,7 @@
         },
         {
             "id": "5c706f9d-de09-5551-8d73-4236219de2fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cedaa9-f08a-4d7b-8314-1d0a09a657bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cedaa9-f08a-4d7b-8314-1d0a09a657bd.jpg?1",
             "name": "Decaying Time Loop",
             "text": "",
             "colours": [
@@ -3130,7 +3130,7 @@
         },
         {
             "id": "83450fa2-1694-5d4d-8035-34188d5bafd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875c7337-78af-4e13-89e5-3255ba2d4053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/875c7337-78af-4e13-89e5-3255ba2d4053.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -3166,7 +3166,7 @@
         },
         {
             "id": "1d62e349-5c7f-514b-bb4a-118ced504b26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ffec6a-fbba-46cc-becb-4ee5ef8c4971.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6ffec6a-fbba-46cc-becb-4ee5ef8c4971.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -3206,7 +3206,7 @@
         },
         {
             "id": "f1622b69-bdd2-5734-a538-64d6d2a0f0d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ae18ff-e9df-4712-a0d0-a02621740b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86ae18ff-e9df-4712-a0d0-a02621740b5a.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -3242,7 +3242,7 @@
         },
         {
             "id": "1234be43-ed79-54aa-848c-8ba367fbff3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11454c82-3f1d-4456-8857-0dcb01d34298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11454c82-3f1d-4456-8857-0dcb01d34298.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "7a5054f8-b6ee-5f47-bb51-f8adbaf0a674",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc8ecfd-7388-4725-8c58-bed2cc61400f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc8ecfd-7388-4725-8c58-bed2cc61400f.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -3316,7 +3316,7 @@
         },
         {
             "id": "f78e9fdf-bc2b-51f4-9fa8-606e6dbdd89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026611f8-ae07-464f-afe5-6e94bcfac05e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/026611f8-ae07-464f-afe5-6e94bcfac05e.jpg?1",
             "name": "The Flux",
             "text": "",
             "colours": [
@@ -3352,7 +3352,7 @@
         },
         {
             "id": "bd7b55f3-12c2-50df-8080-2d6e5bbca5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cc159d-74f7-41fe-a866-c18d96219794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98cc159d-74f7-41fe-a866-c18d96219794.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -3388,7 +3388,7 @@
         },
         {
             "id": "c954bda2-3aff-584f-a2f6-1a55b8f1c3c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a3cb61-b760-4cd4-838c-b26310103719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a3cb61-b760-4cd4-838c-b26310103719.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "bc0e3fe3-08d2-5f26-8068-5afe265c7acc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a74a-a4d5-4b9f-8c62-74cdfcc67825.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0861a74a-a4d5-4b9f-8c62-74cdfcc67825.jpg?1",
             "name": "Iraxxa, Empress of Mars",
             "text": "",
             "colours": [
@@ -3463,7 +3463,7 @@
         },
         {
             "id": "3045627c-fd1b-5be2-9bb9-fcd8ec121373",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63837f16-8157-43c7-8da0-88441ac62f04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63837f16-8157-43c7-8da0-88441ac62f04.jpg?1",
             "name": "Memory Worm",
             "text": "",
             "colours": [
@@ -3500,7 +3500,7 @@
         },
         {
             "id": "d9b06a17-7b41-5791-9362-5b7a9c4a092a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65015afb-cfdb-4373-a0db-0ca5e95c49a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65015afb-cfdb-4373-a0db-0ca5e95c49a1.jpg?1",
             "name": "The Parting of the Ways",
             "text": "",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "64a2146b-1d3c-5356-aca4-d82a8c3448a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de4341-d10a-47c6-8a60-9dfa491f1d02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74de4341-d10a-47c6-8a60-9dfa491f1d02.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -3572,7 +3572,7 @@
         },
         {
             "id": "fb2caba6-dab7-51a5-a806-aa3e41485483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5bcf60-f956-4e0d-beb7-a7f5c1c83692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5bcf60-f956-4e0d-beb7-a7f5c1c83692.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "df14933e-ffa4-561a-8d9b-2e7a47de6be9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42684d97-fce6-4a96-9c64-20e2cb382dca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42684d97-fce6-4a96-9c64-20e2cb382dca.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -3652,7 +3652,7 @@
         },
         {
             "id": "b2701af9-6b59-5866-a5bb-d8e61b0bb6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145daf0b-55a3-45a9-b653-e6e4a461d629.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/145daf0b-55a3-45a9-b653-e6e4a461d629.jpg?1",
             "name": "Sibylline Soothsayer",
             "text": "",
             "colours": [
@@ -3689,7 +3689,7 @@
         },
         {
             "id": "0714ba2a-6e7e-57c2-b427-922a2818e043",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb70fa62-fea1-4e91-a8a1-64b43b777091.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb70fa62-fea1-4e91-a8a1-64b43b777091.jpg?1",
             "name": "Sontaran General",
             "text": "",
             "colours": [
@@ -3726,7 +3726,7 @@
         },
         {
             "id": "3881d44d-b962-517c-bf8a-1200213167c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff2141a-a3ed-4ad0-9338-560502b1c85c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5ff2141a-a3ed-4ad0-9338-560502b1c85c.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "11c63657-d34e-59ba-a1bc-901376718b9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f001a0-8393-4977-84bb-cde39740606c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75f001a0-8393-4977-84bb-cde39740606c.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -3805,7 +3805,7 @@
         },
         {
             "id": "1fd504a0-5d23-5962-b465-2b6d33aedc6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4d9b25-02ea-4ce3-a35f-7f427a74f591.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4d9b25-02ea-4ce3-a35f-7f427a74f591.jpg?1",
             "name": "City of Death",
             "text": "",
             "colours": [
@@ -3841,7 +3841,7 @@
         },
         {
             "id": "812911df-e114-5069-b2b5-d0acbf0c47f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43319645-53b0-41f6-be90-9690e86e12d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43319645-53b0-41f6-be90-9690e86e12d3.jpg?1",
             "name": "Displaced Dinosaurs",
             "text": "",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "619f1e25-0543-5dd8-b0b3-b2727f3171df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada5e97f-c079-445c-8071-1c2a6dd00001.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada5e97f-c079-445c-8071-1c2a6dd00001.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -3913,7 +3913,7 @@
         },
         {
             "id": "996d025b-572d-5c19-84ea-59cd4be596d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93391c14-a22c-4223-a980-5f98350c6a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93391c14-a22c-4223-a980-5f98350c6a99.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -3953,7 +3953,7 @@
         },
         {
             "id": "23eab821-f82c-518d-89f7-d48a1cae00b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15f1891-4f80-4c68-8421-8e16ff8d6a6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e15f1891-4f80-4c68-8421-8e16ff8d6a6d.jpg?1",
             "name": "Fugitive of the Judoon",
             "text": "",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "cfc5c533-b26d-5ee5-9321-b779c431b29f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467d66e-1a81-40d6-945a-f2c679d214d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3467d66e-1a81-40d6-945a-f2c679d214d1.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -4030,7 +4030,7 @@
         },
         {
             "id": "6cc454c0-cfb5-5541-bf7e-675ba9849f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cececf-8547-4355-972b-7ffbafcda1c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cececf-8547-4355-972b-7ffbafcda1c2.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -4071,7 +4071,7 @@
         },
         {
             "id": "10367b9f-2b3e-5e0a-b9cc-0c5948e225b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -4111,7 +4111,7 @@
         },
         {
             "id": "71340907-c46a-5913-b200-c8b94570fc27",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -4147,7 +4147,7 @@
         },
         {
             "id": "f6ab7e9f-28db-558b-85c5-2e9fb44d5cfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4e5b5-70c8-4488-9e7d-7d68fe8219d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a4e5b5-70c8-4488-9e7d-7d68fe8219d7.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -4188,7 +4188,7 @@
         },
         {
             "id": "8474cb69-577c-56f8-be28-49d82825b2a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcb0cb-0df9-4a45-beab-08dc39cf6b3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96fcb0cb-0df9-4a45-beab-08dc39cf6b3b.jpg?1",
             "name": "The Sea Devils",
             "text": "",
             "colours": [
@@ -4224,7 +4224,7 @@
         },
         {
             "id": "95d7240c-2b11-53e5-87ef-d94bc799c848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b94f939-5f3b-4b55-8514-b7d296509ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b94f939-5f3b-4b55-8514-b7d296509ac1.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -4262,7 +4262,7 @@
         },
         {
             "id": "d5d92453-e001-5ab9-bff8-0585c1bb139e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40ec4f-37e7-4e6d-b47b-8b13ea2c9157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad40ec4f-37e7-4e6d-b47b-8b13ea2c9157.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -4302,7 +4302,7 @@
         },
         {
             "id": "b5566e98-c6b4-55cc-bced-b54469ac1daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05e23b-419f-4023-9ad4-1227bb1b53be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da05e23b-419f-4023-9ad4-1227bb1b53be.jpg?1",
             "name": "Thijarian Witness",
             "text": "",
             "colours": [
@@ -4339,7 +4339,7 @@
         },
         {
             "id": "daa89de4-3acc-569a-828f-c1cc111bc1ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf952d23-291d-42fa-8f2a-e4002a04b95f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf952d23-291d-42fa-8f2a-e4002a04b95f.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -4384,7 +4384,7 @@
         },
         {
             "id": "b52f0857-9580-50b8-89e8-61777d302780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc19e32-4f78-492f-8586-54ad4ae6fcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc19e32-4f78-492f-8586-54ad4ae6fcec.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -4429,7 +4429,7 @@
         },
         {
             "id": "44c96465-c93b-5ce6-8ef3-dafc7743158f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6218badd-d352-4e6d-9c84-f1e3f2f84695.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6218badd-d352-4e6d-9c84-f1e3f2f84695.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -4471,7 +4471,7 @@
         },
         {
             "id": "5b258614-c529-5650-820d-0c7be58228a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1178ac-35b9-4086-8ad4-6c629d976ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d1178ac-35b9-4086-8ad4-6c629d976ce2.jpg?1",
             "name": "Bigger on the Inside",
             "text": "",
             "colours": [
@@ -4509,7 +4509,7 @@
         },
         {
             "id": "3979b72e-2f7c-5bc7-8389-e59fe478eb1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032adfbd-3898-410c-acf0-79b88f924520.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/032adfbd-3898-410c-acf0-79b88f924520.jpg?1",
             "name": "Blink",
             "text": "",
             "colours": [
@@ -4547,7 +4547,7 @@
         },
         {
             "id": "ef81d167-9608-5a88-b3a0-dfbf38fb3a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3913111c-6a77-4536-bbb4-0ac5bf18fe53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/3913111c-6a77-4536-bbb4-0ac5bf18fe53.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -4592,7 +4592,7 @@
         },
         {
             "id": "50259ff1-5c04-5a18-b848-23c0e46f6d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e399b70-d793-4833-8317-557fa98a611c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e399b70-d793-4833-8317-557fa98a611c.jpg?1",
             "name": "The Curse of Fenric",
             "text": "",
             "colours": [
@@ -4630,7 +4630,7 @@
         },
         {
             "id": "cd652568-6481-527f-b7ad-c51238b6f90a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab0df1-d53f-4208-9ff9-d015aac20141.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab0df1-d53f-4208-9ff9-d015aac20141.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "01ce6836-0f32-54d3-8fd2-a83b342c3629",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96e1793-cf1c-452d-9443-b0aad4475d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e96e1793-cf1c-452d-9443-b0aad4475d50.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -4716,7 +4716,7 @@
         },
         {
             "id": "87424e00-3915-568e-8ec7-af1a796d785a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9767f42c-df04-4426-929a-87e51aa2b8a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9767f42c-df04-4426-929a-87e51aa2b8a5.jpg?1",
             "name": "The Day of the Doctor",
             "text": "",
             "colours": [
@@ -4754,7 +4754,7 @@
         },
         {
             "id": "55b5c4eb-a009-58da-9b95-f9cbe7236709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816242c4-54ec-4f49-8f77-b3dbf1576247.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/816242c4-54ec-4f49-8f77-b3dbf1576247.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -4794,7 +4794,7 @@
         },
         {
             "id": "1e054b6d-d4f5-5fd4-8963-bff427672204",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21aafe-c093-40db-830e-da4c87055254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad21aafe-c093-40db-830e-da4c87055254.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -4837,7 +4837,7 @@
         },
         {
             "id": "c15037dc-c621-510c-8a30-54756aee587c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf6fd-ced3-4c37-8adb-9a75c6d6d5cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a26bf6fd-ced3-4c37-8adb-9a75c6d6d5cc.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -4883,7 +4883,7 @@
         },
         {
             "id": "88f87268-3d13-5ebd-9b5a-4bdd15df76cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590849a7-9abc-4757-8e13-f680d3b1dceb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/590849a7-9abc-4757-8e13-f680d3b1dceb.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -4929,7 +4929,7 @@
         },
         {
             "id": "1910ae62-1cef-5a76-8963-a91bb37cb01b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b207088-b63c-4d9f-9a42-377736855101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b207088-b63c-4d9f-9a42-377736855101.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -4974,7 +4974,7 @@
         },
         {
             "id": "8b2f2a3b-ae06-5ad1-9dfc-e56d4a4efe99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f548f4b-77b9-47bb-b262-a851fdf0124f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f548f4b-77b9-47bb-b262-a851fdf0124f.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -5020,7 +5020,7 @@
         },
         {
             "id": "dd4920cd-d411-515c-84c9-bf5d3e35641a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4d7db-56b1-4110-b4e4-11748201caf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b4d7db-56b1-4110-b4e4-11748201caf9.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -5066,7 +5066,7 @@
         },
         {
             "id": "0de89a00-936c-5a23-9528-cb6130760f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d85d8c7-07b2-4577-8c62-7a34dca73ad8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d85d8c7-07b2-4577-8c62-7a34dca73ad8.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -5106,7 +5106,7 @@
         },
         {
             "id": "2d3eec1d-71b5-53bc-971c-6af9adfdb14a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea8bd29-80a4-463f-b3bd-e15f4bd5f5ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fea8bd29-80a4-463f-b3bd-e15f4bd5f5ce.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -5151,7 +5151,7 @@
         },
         {
             "id": "7bec4bef-6974-521c-b3d3-7f0d2608b266",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -5186,7 +5186,7 @@
         },
         {
             "id": "b2cc771f-7836-5527-b2fb-97a9f7cf7e71",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a15c30fe-fe57-4551-ace5-42e5568809b3.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -5221,7 +5221,7 @@
         },
         {
             "id": "f1ebe024-a571-5726-81b8-ea3b1924905d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1f865e-759e-4303-81b5-74a558d270ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd1f865e-759e-4303-81b5-74a558d270ec.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "98053eb2-3381-5476-98c9-b7e6f32a371c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a798feb4-561b-4bb9-bdc9-771325faec57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a798feb4-561b-4bb9-bdc9-771325faec57.jpg?1",
             "name": "Great Intelligence's Plan",
             "text": "",
             "colours": [
@@ -5297,7 +5297,7 @@
         },
         {
             "id": "e5797504-39cc-501a-b924-f7174faf4738",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14692f-f1c3-4d7f-8baf-3248621e36fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e14692f-f1c3-4d7f-8baf-3248621e36fb.jpg?1",
             "name": "Heaven Sent",
             "text": "",
             "colours": [
@@ -5335,7 +5335,7 @@
         },
         {
             "id": "255b83dc-2618-5ce7-be21-7cb525140d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0018c07-73dc-4762-ad55-78b18f885877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0018c07-73dc-4762-ad55-78b18f885877.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -5378,7 +5378,7 @@
         },
         {
             "id": "a0f888ef-f97c-5d3f-8bba-9b3f910e80d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebd099-ce57-4053-8f25-d18b3d47fac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74ebd099-ce57-4053-8f25-d18b3d47fac4.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -5421,7 +5421,7 @@
         },
         {
             "id": "2b9eac38-9be2-5a6d-8d73-c908fef66c70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abedc7b1-b6a4-48ab-a336-c0b8edb426a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abedc7b1-b6a4-48ab-a336-c0b8edb426a2.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -5464,7 +5464,7 @@
         },
         {
             "id": "bb29c428-4263-5353-a9ce-233f7fd895d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab1e87e-e778-46fb-9f6d-563463447159.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab1e87e-e778-46fb-9f6d-563463447159.jpg?1",
             "name": "Judoon Enforcers",
             "text": "",
             "colours": [
@@ -5504,7 +5504,7 @@
         },
         {
             "id": "bfbb4441-5b1e-574f-a680-1b709d85912d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c2b4d-5627-4264-943f-9be029c0ee92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1c2b4d-5627-4264-943f-9be029c0ee92.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -5549,7 +5549,7 @@
         },
         {
             "id": "ef0b5f80-c8d5-5979-9962-0c167f0a643f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ed521-eff6-4bdd-939d-8304b26ad256.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d4ed521-eff6-4bdd-939d-8304b26ad256.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "9d29ea37-79ed-5456-bde9-0276a21cc60d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd60763-8954-4502-99ef-f4f38bf7671b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cd60763-8954-4502-99ef-f4f38bf7671b.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -5628,7 +5628,7 @@
         },
         {
             "id": "e9dab452-6e51-54ca-bb3a-d6fd7d8d8b17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94849571-928a-4c6d-9868-58f606941679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94849571-928a-4c6d-9868-58f606941679.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -5671,7 +5671,7 @@
         },
         {
             "id": "ad74deda-2c54-5298-90af-d83964ae22fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85edffb-37ce-45ca-b8d2-ddbbbee3b571.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a85edffb-37ce-45ca-b8d2-ddbbbee3b571.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -5716,7 +5716,7 @@
         },
         {
             "id": "d17541d1-d6ce-58a5-b453-eff4b46c3c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efb5dd0-abc4-4741-9d90-d8d93b03cf21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7efb5dd0-abc4-4741-9d90-d8d93b03cf21.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "115ac423-6328-563b-ae29-11c9992591b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772306d4-63d1-4d90-8c1b-4e4d6edb9aab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/772306d4-63d1-4d90-8c1b-4e4d6edb9aab.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -5806,7 +5806,7 @@
         },
         {
             "id": "a99a7fb9-2077-526d-8ee0-9cdbe2222386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f734ca0-91bc-4496-9bd7-2d09415e850f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f734ca0-91bc-4496-9bd7-2d09415e850f.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -5851,7 +5851,7 @@
         },
         {
             "id": "905b45a6-fc6e-5906-aa8f-da25b13cfb85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfbf6bf-c0e1-48a1-9223-73099fe470aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddfbf6bf-c0e1-48a1-9223-73099fe470aa.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -5896,7 +5896,7 @@
         },
         {
             "id": "717aea21-f13f-5cd3-b38e-1930fe148565",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74785b3b-44df-4555-a036-082572b7f4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74785b3b-44df-4555-a036-082572b7f4e7.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -5942,7 +5942,7 @@
         },
         {
             "id": "5323bf11-29c3-5e54-b53d-d6860ee3e2bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b44c52-b3a3-4954-adcc-53b79921ea24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b44c52-b3a3-4954-adcc-53b79921ea24.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -5987,7 +5987,7 @@
         },
         {
             "id": "18710f57-cf0b-5587-9c02-e6014b8040c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564120cb-dbe5-4a28-947c-d79ad3123152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/564120cb-dbe5-4a28-947c-d79ad3123152.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -6030,7 +6030,7 @@
         },
         {
             "id": "1de6265f-5c91-5d4c-9fbc-47652c4f66ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7c35e0-b304-4b24-a8a1-5ccc4bb2aad0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f7c35e0-b304-4b24-a8a1-5ccc4bb2aad0.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -6068,7 +6068,7 @@
         },
         {
             "id": "be068f89-ae05-56a8-ac38-e854a7aa5630",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1efb084-d2a0-44c4-a89d-6445156bb298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1efb084-d2a0-44c4-a89d-6445156bb298.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -6114,7 +6114,7 @@
         },
         {
             "id": "c9921b30-46c8-5cac-9c4e-1d11fbc17852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51a010d-641c-413f-8f91-0c8ff3b2085c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51a010d-641c-413f-8f91-0c8ff3b2085c.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -6157,7 +6157,7 @@
         },
         {
             "id": "7d720df5-dcfe-5467-8c09-bbe4aac5af4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95452998-7196-4a9b-b8a3-93cb3ec24f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95452998-7196-4a9b-b8a3-93cb3ec24f93.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -6195,7 +6195,7 @@
         },
         {
             "id": "72b69aca-ca1e-569b-992e-ff1e1b43df66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33354a5-d99a-46dd-8715-34dbc5f0ec3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33354a5-d99a-46dd-8715-34dbc5f0ec3b.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -6238,7 +6238,7 @@
         },
         {
             "id": "a082edcd-f75c-557c-afe9-d7f1ed1d1b21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568c2687-4381-4954-9cab-f669d1fe6306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/568c2687-4381-4954-9cab-f669d1fe6306.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -6284,7 +6284,7 @@
         },
         {
             "id": "a85ccad7-1f6b-505b-8d35-b76a828ef1e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f40e07-f565-4b9e-87a5-5b28b4e9fb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01f40e07-f565-4b9e-87a5-5b28b4e9fb0b.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -6327,7 +6327,7 @@
         },
         {
             "id": "480b85ce-223e-5d48-887a-dd183888f667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd6bfb3-1338-4ee6-9281-30a7428200d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dd6bfb3-1338-4ee6-9281-30a7428200d2.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -6373,7 +6373,7 @@
         },
         {
             "id": "a45490c0-0295-5e76-8ff8-6e1f754a894c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c045ccb2-28d1-4bbe-9feb-3e86988fd24d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c045ccb2-28d1-4bbe-9feb-3e86988fd24d.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -6419,7 +6419,7 @@
         },
         {
             "id": "66718e9c-6227-5d46-81a7-2b506a0cf6aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4801775-70e2-4cda-959c-27f9aa623767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4801775-70e2-4cda-959c-27f9aa623767.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -6462,7 +6462,7 @@
         },
         {
             "id": "5f6f7741-a29b-5d13-a79a-6c430236c52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d27ceaf-f4cf-489b-b305-552a9d065584.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d27ceaf-f4cf-489b-b305-552a9d065584.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -6503,7 +6503,7 @@
         },
         {
             "id": "11117d33-3a7e-51a2-b96d-a558162c2f38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2934f5e5-2274-4de7-a8c7-ca034f1fec29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2934f5e5-2274-4de7-a8c7-ca034f1fec29.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -6549,7 +6549,7 @@
         },
         {
             "id": "0a1f1e1a-ff99-55f0-8a73-ecb64070f984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8771cc-1042-47b1-b4fa-459c3eeece04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce8771cc-1042-47b1-b4fa-459c3eeece04.jpg?1",
             "name": "Truth or Consequences",
             "text": "",
             "colours": [
@@ -6585,7 +6585,7 @@
         },
         {
             "id": "620caa98-ebdb-5638-b9d8-ebf7a2f26f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2400d681-05ef-43b1-b720-c15ca4226c27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2400d681-05ef-43b1-b720-c15ca4226c27.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -6631,7 +6631,7 @@
         },
         {
             "id": "497b45b3-0b1d-599b-acec-22c38e49e138",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63218a4-afaf-4ad8-9ca4-4f9af87877b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d63218a4-afaf-4ad8-9ca4-4f9af87877b9.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -6676,7 +6676,7 @@
         },
         {
             "id": "fec33c7d-adf9-5a0f-b358-def9a6b4eb7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b117d388-ac94-4e20-84f0-f4d242121d7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b117d388-ac94-4e20-84f0-f4d242121d7f.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -6720,7 +6720,7 @@
         },
         {
             "id": "9e61d464-ea19-5190-84d5-7a13a46ac2db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a51472c-b61f-4d31-8753-a9ec90d12889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a51472c-b61f-4d31-8753-a9ec90d12889.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -6765,7 +6765,7 @@
         },
         {
             "id": "ba5f5c5d-82ee-5a94-9cde-b0179ec14cef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd7b66-28f1-407b-bd60-6bcc577288cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0fd7b66-28f1-407b-bd60-6bcc577288cb.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -6809,7 +6809,7 @@
         },
         {
             "id": "d88f6609-8119-54c9-97ed-5a7fef871ea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e7d2ca-3fa9-4cb2-adc2-dae4e161f186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44e7d2ca-3fa9-4cb2-adc2-dae4e161f186.jpg?1",
             "name": "Wreck and Rebuild",
             "text": "",
             "colours": [
@@ -6845,7 +6845,7 @@
         },
         {
             "id": "dd0a86e7-e194-5050-aedf-862a871c415e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1132b6-9db6-440c-9e0a-fae6c157e8a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1132b6-9db6-440c-9e0a-fae6c157e8a3.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -6881,7 +6881,7 @@
         },
         {
             "id": "53cb982c-b5f4-581e-aec9-d64524cb9dfc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb585d-2b49-44a0-93d0-98dc8e0727c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5bb585d-2b49-44a0-93d0-98dc8e0727c2.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -6917,7 +6917,7 @@
         },
         {
             "id": "cbdf4991-cf78-52fa-940c-ea5fe304c8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa6d0-dc2d-4903-bbba-6cf83be2b187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b4fa6d0-dc2d-4903-bbba-6cf83be2b187.jpg?1",
             "name": "Clockwork Droid",
             "text": "",
             "colours": [],
@@ -6950,7 +6950,7 @@
         },
         {
             "id": "c2e5393f-8e25-5574-a1df-9613c246d13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2e0de7-e29d-432e-8782-766c0c31c05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df2e0de7-e29d-432e-8782-766c0c31c05d.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -6982,7 +6982,7 @@
         },
         {
             "id": "9929467d-00dd-5303-801a-5e4e9f2c7d94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566ae475-48cd-42d0-8d96-168529b2180d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/566ae475-48cd-42d0-8d96-168529b2180d.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -7017,7 +7017,7 @@
         },
         {
             "id": "33941334-1369-5643-8525-ff87c523dca0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db625a36-5b87-4ddd-8c9e-0969ff8e6488.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db625a36-5b87-4ddd-8c9e-0969ff8e6488.jpg?1",
             "name": "Cybermat",
             "text": "",
             "colours": [],
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "9c6725a6-283e-5899-8c4f-85cadae733f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce660ef-0c6f-413d-8ddd-b755a19ab731.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7ce660ef-0c6f-413d-8ddd-b755a19ab731.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -7085,7 +7085,7 @@
         },
         {
             "id": "d9265bb2-bed2-50b8-a518-b3c8dd297cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9d006-7179-4d59-88ef-34b4d4b2e2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0b9d006-7179-4d59-88ef-34b4d4b2e2fc.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -7119,7 +7119,7 @@
         },
         {
             "id": "65f93992-9dbc-565b-a025-560dc44fd8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e646af0-1a7a-4e2c-83ba-78e748737846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e646af0-1a7a-4e2c-83ba-78e748737846.jpg?1",
             "name": "Laser Screwdriver",
             "text": "",
             "colours": [],
@@ -7149,7 +7149,7 @@
         },
         {
             "id": "741652c3-c6c0-5805-8654-fdf21a010be0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8dcf01-8e2c-439c-81c4-650dd01ecb65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a8dcf01-8e2c-439c-81c4-650dd01ecb65.jpg?1",
             "name": "Midnight Crusader Shuttle",
             "text": "",
             "colours": [],
@@ -7181,7 +7181,7 @@
         },
         {
             "id": "e7a9bcb9-e0d8-5dbe-b158-236594e79e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f233e7db-321f-4ab1-ae49-e45eae188f3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f233e7db-321f-4ab1-ae49-e45eae188f3f.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -7215,7 +7215,7 @@
         },
         {
             "id": "4855f17d-2d72-5ffe-951c-7326982870ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae12c61-0125-4810-b0e4-139c27b1b08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eae12c61-0125-4810-b0e4-139c27b1b08b.jpg?1",
             "name": "Psychic Paper",
             "text": "",
             "colours": [],
@@ -7247,7 +7247,7 @@
         },
         {
             "id": "d434bc7b-a0f7-5561-9540-1b9bc0c11c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96476a30-72b0-4f91-9d2d-85fc196f89c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96476a30-72b0-4f91-9d2d-85fc196f89c5.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -7279,7 +7279,7 @@
         },
         {
             "id": "d1b20507-16c2-50e9-a03c-7b2c52811b36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a06389-7e2b-49f1-a4d2-bb8ea580057a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a06389-7e2b-49f1-a4d2-bb8ea580057a.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -7311,7 +7311,7 @@
         },
         {
             "id": "8d87cd62-b99c-55c2-ab17-6ad81d0f7a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131027a-9776-41fa-8a5f-d9ef80e0dc2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f131027a-9776-41fa-8a5f-d9ef80e0dc2e.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -7345,7 +7345,7 @@
         },
         {
             "id": "e51f0c25-2676-5dde-a93a-6d032ed9cb95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57896797-af41-42f7-90fb-0319b9592ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57896797-af41-42f7-90fb-0319b9592ff3.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -7379,7 +7379,7 @@
         },
         {
             "id": "f576aed3-fd07-5bb2-8403-3321b7d88e19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a55d514-b670-4fe2-825b-9ba955977cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a55d514-b670-4fe2-825b-9ba955977cac.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -7413,7 +7413,7 @@
         },
         {
             "id": "3eafd064-26ad-5367-b956-9df24a87e8c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059b1d8-3bfb-40c9-9344-addda43509ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b059b1d8-3bfb-40c9-9344-addda43509ab.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -7447,7 +7447,7 @@
         },
         {
             "id": "cbd79cea-9782-5689-94b7-6af390a11639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d990f5-a7b7-4482-95e6-b03a397192e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83d990f5-a7b7-4482-95e6-b03a397192e2.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -7481,7 +7481,7 @@
         },
         {
             "id": "2878f5a6-5948-557a-9fca-dce84477d470",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e843c57-fae3-4127-94e7-cad8c8bb9486.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e843c57-fae3-4127-94e7-cad8c8bb9486.jpg?1",
             "name": "Ominous Cemetery",
             "text": "",
             "colours": [],
@@ -7511,7 +7511,7 @@
         },
         {
             "id": "1282eb59-b73c-5ff6-81aa-4d41f111a76d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64444549-1198-4465-91d5-02a7903691dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64444549-1198-4465-91d5-02a7903691dc.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -7547,7 +7547,7 @@
         },
         {
             "id": "68432632-d503-5ebd-96aa-97152c3408b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d180a882-84d9-4e38-8aed-1fc6ecd1df72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d180a882-84d9-4e38-8aed-1fc6ecd1df72.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -7589,7 +7589,7 @@
         },
         {
             "id": "fa5b7ee1-7b63-5c14-a9a0-42c442a966e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1838aa-591f-4694-b772-beaab94587c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da1838aa-591f-4694-b772-beaab94587c3.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -7637,7 +7637,7 @@
         },
         {
             "id": "aa00fb56-4d2d-512a-8693-bafddc9b5ab2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f14a4-7b8d-4e1d-a48d-4920130b8e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/482f14a4-7b8d-4e1d-a48d-4920130b8e23.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -7683,7 +7683,7 @@
         },
         {
             "id": "c74f7497-f307-5486-9861-b2e53034c902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea9e80-0d3a-4b75-8f29-56e88d6fe66a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ea9e80-0d3a-4b75-8f29-56e88d6fe66a.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -7729,7 +7729,7 @@
         },
         {
             "id": "a4d8b55a-7761-5685-a768-d6bcae2809b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e79f4fc-c56b-49b7-82cb-138f6e3bcefa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e79f4fc-c56b-49b7-82cb-138f6e3bcefa.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -7775,7 +7775,7 @@
         },
         {
             "id": "400f0f2b-5d12-56b1-85ee-2a2c421af71c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4d8ef3-2b26-4376-a00e-ccd58e3ea2eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c4d8ef3-2b26-4376-a00e-ccd58e3ea2eb.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7813,7 +7813,7 @@
         },
         {
             "id": "314c360b-6d1b-52f9-91aa-c843bb4106ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaea970-a19c-400a-a8cb-5d30f9cc2672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1aaea970-a19c-400a-a8cb-5d30f9cc2672.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -7851,7 +7851,7 @@
         },
         {
             "id": "5be2515d-c1f8-5991-9fa6-a7c4d24311db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98e0fb-5f07-40c8-9958-84379bcdc35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca98e0fb-5f07-40c8-9958-84379bcdc35c.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7889,7 +7889,7 @@
         },
         {
             "id": "d4c75420-bcb3-5593-a8a3-e340bd55504b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b2aae2-a0b4-4c52-8a43-a4155527bae9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12b2aae2-a0b4-4c52-8a43-a4155527bae9.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -7927,7 +7927,7 @@
         },
         {
             "id": "eb75cae2-e4a8-54dd-9b2f-fcb6fee3cda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5788684f-1339-4cb4-863a-a9883ccab79b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5788684f-1339-4cb4-863a-a9883ccab79b.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -7965,7 +7965,7 @@
         },
         {
             "id": "47e88022-28fe-51fe-80a1-57b34268de9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5d8a2c-b98a-4dae-8b89-4a2435fa7103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5d8a2c-b98a-4dae-8b89-4a2435fa7103.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -8003,7 +8003,7 @@
         },
         {
             "id": "6300fa51-8df9-5a70-9fa9-bf2ea711352c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c34fe0-77ec-4ba3-a214-00d0eb42ebae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c34fe0-77ec-4ba3-a214-00d0eb42ebae.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8041,7 +8041,7 @@
         },
         {
             "id": "bbec3756-04a7-5d84-822f-f73f17e89616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f1fe4e-8da1-4879-8129-bd8a440a45be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f1fe4e-8da1-4879-8129-bd8a440a45be.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -8079,7 +8079,7 @@
         },
         {
             "id": "3b4999ec-8f2b-5670-a047-22484d107f00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c95d38-c135-4059-9379-051b2dd33f9c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5c95d38-c135-4059-9379-051b2dd33f9c.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8117,7 +8117,7 @@
         },
         {
             "id": "13fa4399-8e16-578b-8974-5dbc0babf0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3f35e-451e-4de6-a4f7-249287566964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b3f35e-451e-4de6-a4f7-249287566964.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -8155,7 +8155,7 @@
         },
         {
             "id": "a875ad4a-06bc-5815-a30f-40afb5b90da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f2bd7a-4d14-43ef-b04a-3383aeae615c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0f2bd7a-4d14-43ef-b04a-3383aeae615c.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -8193,7 +8193,7 @@
         },
         {
             "id": "decd2674-7136-5a0f-b462-7cd141a82b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c922516-7a2d-41a6-b546-4e73c5ccdb0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c922516-7a2d-41a6-b546-4e73c5ccdb0b.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -8229,7 +8229,7 @@
         },
         {
             "id": "8a0e3f10-9a7a-5551-976c-ed61c87c7be4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bae9eca-8cc9-490b-a9b5-ba2a083bcb08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bae9eca-8cc9-490b-a9b5-ba2a083bcb08.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "e383532d-d317-5982-a750-ce1eb7d5554d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0c372-bc10-49f6-9fd4-a482790846e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44b0c372-bc10-49f6-9fd4-a482790846e4.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -8301,7 +8301,7 @@
         },
         {
             "id": "fa6d924d-8945-5de9-9621-13e75e37a3af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b5c4d1-4271-4e89-9947-95ca9ff1d63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0b5c4d1-4271-4e89-9947-95ca9ff1d63d.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -8335,7 +8335,7 @@
         },
         {
             "id": "48e05954-29f7-556b-a71b-906041f3f0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516678c-37ce-4958-a149-aff03ef1dfd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c516678c-37ce-4958-a149-aff03ef1dfd6.jpg?1",
             "name": "Return to Dust",
             "text": "",
             "colours": [
@@ -8369,7 +8369,7 @@
         },
         {
             "id": "c9c2eaa3-ab5b-51d9-bb5d-8acd02600b7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc8dea8-a6af-4bba-affa-92aca36a8413.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc8dea8-a6af-4bba-affa-92aca36a8413.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "61f9041c-a7e9-5fc5-a5ac-f5ba89320a86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8fd9a7-d1bd-43bd-a136-49dc26621e4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d8fd9a7-d1bd-43bd-a136-49dc26621e4d.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -8439,7 +8439,7 @@
         },
         {
             "id": "a2f1d4a2-bd45-53ec-9bd4-42e69967e5c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfcd573-dc06-4b2a-9a9a-7e35267ac800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6dfcd573-dc06-4b2a-9a9a-7e35267ac800.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -8475,7 +8475,7 @@
         },
         {
             "id": "9a02c104-991c-5260-bdef-922c8a3d1f49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01aeee52-1fb0-4eeb-8fd8-455fdd91db15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01aeee52-1fb0-4eeb-8fd8-455fdd91db15.jpg?1",
             "name": "Clockspinning",
             "text": "",
             "colours": [
@@ -8509,7 +8509,7 @@
         },
         {
             "id": "89e9586b-4ede-59f6-a8cc-de02e6f422ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5798d2-52d2-4294-8cc4-7cd8f380da92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed5798d2-52d2-4294-8cc4-7cd8f380da92.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -8545,7 +8545,7 @@
         },
         {
             "id": "fdeb0622-f3d4-5c3c-b697-326c4c22c773",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262285ab-3a6f-4932-b53b-8ab20bcad955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/262285ab-3a6f-4932-b53b-8ab20bcad955.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -8579,7 +8579,7 @@
         },
         {
             "id": "aed2dc95-6a43-5598-bbbe-2e7a7610432c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3757f89-56fe-4234-bb8e-a2f3ae645a06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3757f89-56fe-4234-bb8e-a2f3ae645a06.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -8613,7 +8613,7 @@
         },
         {
             "id": "14d3fbb1-59f8-518d-8d1e-99f3266bb38f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16023fe1-f5e7-4ec0-aef2-c34c131b8ff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16023fe1-f5e7-4ec0-aef2-c34c131b8ff3.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -8647,7 +8647,7 @@
         },
         {
             "id": "f4e62bc5-157e-57aa-95b4-43ddd46dffb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988111df-e398-4e87-aaf9-5872f36710de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/988111df-e398-4e87-aaf9-5872f36710de.jpg?1",
             "name": "Think Twice",
             "text": "",
             "colours": [
@@ -8681,7 +8681,7 @@
         },
         {
             "id": "3b7e933a-1d2e-5252-86f9-36d77bb13c95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ca70f4-2fb2-4e0b-b1d6-c9220766807f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5ca70f4-2fb2-4e0b-b1d6-c9220766807f.jpg?1",
             "name": "Feed the Swarm",
             "text": "",
             "colours": [
@@ -8715,7 +8715,7 @@
         },
         {
             "id": "e24184f7-be08-5132-9cb9-91187f87f30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760660d0-06f2-49ea-afbf-647d7f1ea151.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/760660d0-06f2-49ea-afbf-647d7f1ea151.jpg?1",
             "name": "Snuff Out",
             "text": "",
             "colours": [
@@ -8749,7 +8749,7 @@
         },
         {
             "id": "45f562f2-7452-558e-91b1-849aec609292",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d7dcdd-bec4-4795-b04f-63430228e48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d7dcdd-bec4-4795-b04f-63430228e48c.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -8785,7 +8785,7 @@
         },
         {
             "id": "729786e1-134a-5cae-a278-1faeea103be2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e5d93b-2f1f-43ed-b8ff-ee00d98eb46c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34e5d93b-2f1f-43ed-b8ff-ee00d98eb46c.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -8821,7 +8821,7 @@
         },
         {
             "id": "f86c009c-393e-56da-8038-8c5644518a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff37491-f496-4810-80a4-d13470434994.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/fff37491-f496-4810-80a4-d13470434994.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -8857,7 +8857,7 @@
         },
         {
             "id": "b3fcfb5e-e2d4-5b22-9e8f-e8d6aa2466ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb9aadf-a50e-4542-82e8-6d8cbc2ea350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb9aadf-a50e-4542-82e8-6d8cbc2ea350.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -8893,7 +8893,7 @@
         },
         {
             "id": "4643dc08-ada4-590b-8ddf-66d77b01deec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74881c8f-f21d-4901-90cf-2ae8d0f46c3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74881c8f-f21d-4901-90cf-2ae8d0f46c3d.jpg?1",
             "name": "Throes of Chaos",
             "text": "",
             "colours": [
@@ -8927,7 +8927,7 @@
         },
         {
             "id": "5d4caee9-9c1f-5e20-b4eb-e7b38535b3ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df0ecf-9161-4515-8511-fb042b9562ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05df0ecf-9161-4515-8511-fb042b9562ae.jpg?1",
             "name": "Beast Within",
             "text": "",
             "colours": [
@@ -8961,7 +8961,7 @@
         },
         {
             "id": "4095ce76-4aa7-5a56-aeff-d8d3e5ea5c08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd374915-323c-4d98-9b59-94d405c1dde8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd374915-323c-4d98-9b59-94d405c1dde8.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -8997,7 +8997,7 @@
         },
         {
             "id": "6384c4da-ec41-5029-b74e-1eafb59f68df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6396ba2-ea82-4ca8-9848-08751a1bf45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6396ba2-ea82-4ca8-9848-08751a1bf45a.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "bba7e759-5e05-5e08-969d-e6097296b6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25768b76-c6d7-4b0b-8427-d0a80633aa39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25768b76-c6d7-4b0b-8427-d0a80633aa39.jpg?1",
             "name": "Explore",
             "text": "",
             "colours": [
@@ -9065,7 +9065,7 @@
         },
         {
             "id": "b1a2c4f8-6e67-5b2d-b012-62de7ac31cf0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befd2137-bd91-4209-bdec-219cf53b7be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/befd2137-bd91-4209-bdec-219cf53b7be7.jpg?1",
             "name": "Farseek",
             "text": "",
             "colours": [
@@ -9099,7 +9099,7 @@
         },
         {
             "id": "5c5d4284-1c9f-5a56-849a-575c12c88251",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11d822-51c7-41dd-8f78-718d884019e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd11d822-51c7-41dd-8f78-718d884019e8.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -9135,7 +9135,7 @@
         },
         {
             "id": "f1a3f175-c2d9-56d8-90f9-7f94aa9263a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857818d8-454b-4c2c-8cf2-7aa9c2898b18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/857818d8-454b-4c2c-8cf2-7aa9c2898b18.jpg?1",
             "name": "Search for Tomorrow",
             "text": "",
             "colours": [
@@ -9169,7 +9169,7 @@
         },
         {
             "id": "12504f7c-221b-5cea-920e-440d52d0c3b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc20bfa9-6d55-49f4-a86a-8fb3b433ee29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc20bfa9-6d55-49f4-a86a-8fb3b433ee29.jpg?1",
             "name": "Three Visits",
             "text": "",
             "colours": [
@@ -9203,7 +9203,7 @@
         },
         {
             "id": "9593fd56-7e99-50ea-a1a8-f1878424b227",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1e9cd6-7be2-4c9a-a94f-3ea7e69e49db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1e9cd6-7be2-4c9a-a94f-3ea7e69e49db.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -9241,7 +9241,7 @@
         },
         {
             "id": "14125cf2-d3b5-5c66-ba58-ae6a04cfe0fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac9e381-dbb8-478b-b385-9f09f0325e87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac9e381-dbb8-478b-b385-9f09f0325e87.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -9277,7 +9277,7 @@
         },
         {
             "id": "57e462ae-a87f-5ef7-936d-6aac8be9721c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e5358a-23b6-4dac-893e-48f4481609ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e5358a-23b6-4dac-893e-48f4481609ab.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -9315,7 +9315,7 @@
         },
         {
             "id": "6781d9ff-2fd2-5ff7-bd04-96bd7eee5a98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d58eb-b95a-48d9-a174-e2d72a29c167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87d58eb-b95a-48d9-a174-e2d72a29c167.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -9345,7 +9345,7 @@
         },
         {
             "id": "cf67df45-bf86-5ea4-8a29-6a321f4ec7e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331338ed-5b1e-4cc0-8a3f-ea43539b9346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331338ed-5b1e-4cc0-8a3f-ea43539b9346.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -9375,7 +9375,7 @@
         },
         {
             "id": "40fbd46c-01c7-5bf7-9a56-91c835349da1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84f5c57-0589-4eac-bad7-775122c767c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a84f5c57-0589-4eac-bad7-775122c767c1.jpg?1",
             "name": "Hero's Blade",
             "text": "",
             "colours": [],
@@ -9407,7 +9407,7 @@
         },
         {
             "id": "36d2a82b-42b5-52a1-a6df-ada0b448d5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4503b65f-416e-49af-88c8-0871bca2c050.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4503b65f-416e-49af-88c8-0871bca2c050.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -9441,7 +9441,7 @@
         },
         {
             "id": "76cc05b6-2333-56de-8544-b86543197e3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb10b3-6856-4355-94a7-a14c516887d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb10b3-6856-4355-94a7-a14c516887d5.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -9473,7 +9473,7 @@
         },
         {
             "id": "72d0be83-a544-5b6e-9318-74aecbf0bff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8db7a-009a-4141-bba7-b5fdfaf8d245.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ac8db7a-009a-4141-bba7-b5fdfaf8d245.jpg?1",
             "name": "Mind Stone",
             "text": "",
             "colours": [],
@@ -9503,7 +9503,7 @@
         },
         {
             "id": "4611290b-ebd7-5d68-ba79-8767aeb24a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f44a54b-512e-45ef-80ee-7982d2eaf762.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f44a54b-512e-45ef-80ee-7982d2eaf762.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -9533,7 +9533,7 @@
         },
         {
             "id": "6935c0a7-c050-5fb8-9dba-68da7387a8f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd72802-8eab-4700-9bd2-d3997c17438f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bd72802-8eab-4700-9bd2-d3997c17438f.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -9568,7 +9568,7 @@
         },
         {
             "id": "f6a8ef03-0cc5-59bf-90fa-551699879d48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cde405f-ac69-45f4-af7f-c4d892a7a42d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cde405f-ac69-45f4-af7f-c4d892a7a42d.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "e6cbca04-4378-5736-adc6-7d65f7e2fa73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6104a32-95ba-4003-bd02-12c567631990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6104a32-95ba-4003-bd02-12c567631990.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -9634,7 +9634,7 @@
         },
         {
             "id": "abfb7498-c0c8-5ae8-9e6a-709503ba3fdc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f45b45-86ca-48cb-adb1-1d01c197ece4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f45b45-86ca-48cb-adb1-1d01c197ece4.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -9667,7 +9667,7 @@
         },
         {
             "id": "dccee3ab-5136-5f96-bc77-31569e73772c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827edf4f-2442-4c9d-8aac-3dead3af3146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/827edf4f-2442-4c9d-8aac-3dead3af3146.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -9700,7 +9700,7 @@
         },
         {
             "id": "c1046482-5e5d-5fa2-9eac-9b74faedda5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d55e1f0-26ce-4ad2-b175-4c64a9638431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d55e1f0-26ce-4ad2-b175-4c64a9638431.jpg?1",
             "name": "Talisman of Impulse",
             "text": "",
             "colours": [],
@@ -9733,7 +9733,7 @@
         },
         {
             "id": "f57ddf89-273a-52fc-831e-51d183e8d4db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e2fad-0aab-4ead-9b25-509c83ad4a93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f1e2fad-0aab-4ead-9b25-509c83ad4a93.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -9766,7 +9766,7 @@
         },
         {
             "id": "3cf6ddf9-e917-5a41-b6ea-a5ff2fe66e39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f67117-3d40-466d-9ea8-f75e1ad10b45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1f67117-3d40-466d-9ea8-f75e1ad10b45.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "c32055bc-2f4f-5616-b3ed-5181ab8dd0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a395b259-1f3f-43ab-9636-d1c218661c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a395b259-1f3f-43ab-9636-d1c218661c15.jpg?1",
             "name": "Talisman of Unity",
             "text": "",
             "colours": [],
@@ -9832,7 +9832,7 @@
         },
         {
             "id": "e54ed6d0-6f1f-5602-b302-52cf3baf3392",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84506a3f-46ee-4482-9f7d-0409c2699ae4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84506a3f-46ee-4482-9f7d-0409c2699ae4.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -9862,7 +9862,7 @@
         },
         {
             "id": "a955e6af-57e5-54e5-bf7e-e25494abee0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3660a-4141-46fe-b34b-3aeb45589cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fa3660a-4141-46fe-b34b-3aeb45589cac.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "",
             "colours": [],
@@ -9892,7 +9892,7 @@
         },
         {
             "id": "75a2b2b2-d1a6-56b6-bb58-eb92245a44f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fec728-2bf5-40a5-b3d7-02f366271c0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82fec728-2bf5-40a5-b3d7-02f366271c0c.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -9922,7 +9922,7 @@
         },
         {
             "id": "d5a59d79-8a09-5b29-bc8e-7ee42f03d5ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b93de5-52e6-4a30-88e9-e636f18dccc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11b93de5-52e6-4a30-88e9-e636f18dccc8.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -9960,7 +9960,7 @@
         },
         {
             "id": "b8d4990e-1ce9-5ffe-8c6e-1f3e7d87fa0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221cd894-19e2-433b-a624-f6838fadd6fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/221cd894-19e2-433b-a624-f6838fadd6fd.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -9998,7 +9998,7 @@
         },
         {
             "id": "c08a3102-f5a2-572c-bd4b-be1196fd94ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d71183-509f-40b8-85af-8f118cad5c13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5d71183-509f-40b8-85af-8f118cad5c13.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -10033,7 +10033,7 @@
         },
         {
             "id": "23d60cda-40e2-5d8f-80ea-4ce9d322c2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33320e-8dcb-40e2-a356-038f2eea77d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f33320e-8dcb-40e2-a356-038f2eea77d7.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -10068,7 +10068,7 @@
         },
         {
             "id": "7110460e-c256-5349-846f-3b86a0e9ff33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d3cd1f-3971-45ae-83c5-f7c2b3f5758a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82d3cd1f-3971-45ae-83c5-f7c2b3f5758a.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -10106,7 +10106,7 @@
         },
         {
             "id": "8fc7a497-9211-5a33-b5e9-a28972a49923",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811d6e5d-c8a3-41ae-910e-e0f194f42292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811d6e5d-c8a3-41ae-910e-e0f194f42292.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10142,7 +10142,7 @@
         },
         {
             "id": "a05717ef-8c3d-5001-9398-2cf1071db042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd4f68-f006-4ad5-9bf8-8757e498736a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5bd4f68-f006-4ad5-9bf8-8757e498736a.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10178,7 +10178,7 @@
         },
         {
             "id": "7866f4e4-ed56-5a43-9870-9852547ae358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b82ac1b-c2d8-45f0-851a-97b0cdcff0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b82ac1b-c2d8-45f0-851a-97b0cdcff0ee.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10214,7 +10214,7 @@
         },
         {
             "id": "e4e89e65-534f-5585-9118-6844088c7f72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e819e5-573c-49d3-87d7-9abd60532e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98e819e5-573c-49d3-87d7-9abd60532e71.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -10250,7 +10250,7 @@
         },
         {
             "id": "1428325f-c9d6-58e2-9687-a6af598a1e5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a6531-7cf7-4c74-9050-65fe4b273744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a6531-7cf7-4c74-9050-65fe4b273744.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -10285,7 +10285,7 @@
         },
         {
             "id": "016ec506-f301-5975-9905-7225a36cc174",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb7fadc-dcd8-473a-9b12-d9c8f0a19f79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eeb7fadc-dcd8-473a-9b12-d9c8f0a19f79.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "",
             "colours": [],
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "1955620d-103d-579c-96bc-86425c8775f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8036733-de99-4f33-a7a2-b1dde43606f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8036733-de99-4f33-a7a2-b1dde43606f1.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -10354,7 +10354,7 @@
         },
         {
             "id": "3c476cd0-9333-5d19-8148-9e46ca2022a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed66e849-8fc9-46a1-9b8a-6845b5bc0734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed66e849-8fc9-46a1-9b8a-6845b5bc0734.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -10389,7 +10389,7 @@
         },
         {
             "id": "fa0dfbb9-0f79-5dbe-b64c-642f46963d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7223-20ce-4802-93f5-be41dcce1c15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb9a7223-20ce-4802-93f5-be41dcce1c15.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -10424,7 +10424,7 @@
         },
         {
             "id": "e4ac3e48-9581-5e78-bbd0-d8da5bb049d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787c5c8e-7274-4d74-8a8d-728b28ec0b71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787c5c8e-7274-4d74-8a8d-728b28ec0b71.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -10459,7 +10459,7 @@
         },
         {
             "id": "fab6b6f1-77aa-5297-ad37-d6a35eae2fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8c7416-c0af-419d-892a-ee989585bf79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8c7416-c0af-419d-892a-ee989585bf79.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -10494,7 +10494,7 @@
         },
         {
             "id": "a466e821-6f0e-5189-8f52-c2d6f3c36b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f3d434-bab7-48c2-961d-347735d61d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f3d434-bab7-48c2-961d-347735d61d38.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -10529,7 +10529,7 @@
         },
         {
             "id": "f94aee4a-c458-5be2-9581-a5d8f610123b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7387895f-8697-4755-8abb-7f81af4a2717.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7387895f-8697-4755-8abb-7f81af4a2717.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -10559,7 +10559,7 @@
         },
         {
             "id": "1ea782bf-2c57-5141-84fd-c686a2f27d24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bc648d-def5-4442-9cfe-0f93fee631f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2bc648d-def5-4442-9cfe-0f93fee631f4.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -10591,7 +10591,7 @@
         },
         {
             "id": "04897a44-6088-5b8c-989f-506094356328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4830469e-2323-4e00-9c97-8fa8a5a03580.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/4830469e-2323-4e00-9c97-8fa8a5a03580.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -10629,7 +10629,7 @@
         },
         {
             "id": "dc2b01e3-ba97-524f-a0be-f05b1a143126",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf68138-63c1-4201-998c-eb412463f664.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daf68138-63c1-4201-998c-eb412463f664.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -10664,7 +10664,7 @@
         },
         {
             "id": "b389833b-a8b9-5150-bd2b-3a48ff00bc75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724c72-8e0e-4380-82ba-1f9ec8e45f01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1724c72-8e0e-4380-82ba-1f9ec8e45f01.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -10699,7 +10699,7 @@
         },
         {
             "id": "a983e412-308d-51a6-8922-a0b9ae153b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58be08-7988-4ea5-8338-019a03171d16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb58be08-7988-4ea5-8338-019a03171d16.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -10734,7 +10734,7 @@
         },
         {
             "id": "c8501d12-a1e0-5591-be14-db3fc8213fbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadb4128-62f4-47ea-8435-e06dfdb8e964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cadb4128-62f4-47ea-8435-e06dfdb8e964.jpg?1",
             "name": "Frontier Bivouac",
             "text": "",
             "colours": [],
@@ -10768,7 +10768,7 @@
         },
         {
             "id": "e010a134-c131-53d1-b7eb-21b3f1e3a176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1d2c3d-e6ec-4130-8765-346adbb79d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e1d2c3d-e6ec-4130-8765-346adbb79d31.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -10803,7 +10803,7 @@
         },
         {
             "id": "88d7e892-9c6b-5765-a181-699341387bff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ddcd8b-a9b1-479f-85c6-5bd8b9ac4f2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21ddcd8b-a9b1-479f-85c6-5bd8b9ac4f2d.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -10838,7 +10838,7 @@
         },
         {
             "id": "17678747-c8a8-530a-a2ed-8fa2cc56d2fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066326c9-c1d7-4eca-84fe-fdd95b659ac1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/066326c9-c1d7-4eca-84fe-fdd95b659ac1.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -10873,7 +10873,7 @@
         },
         {
             "id": "619fb78b-f2ea-57f8-9eef-277675d6f726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e28187-fece-4f78-b8fe-43ee6df4d338.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65e28187-fece-4f78-b8fe-43ee6df4d338.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -10908,7 +10908,7 @@
         },
         {
             "id": "3dc5c8b5-e7e1-5449-a605-0f0af55f9438",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b62353-e170-4c29-bda1-7cd8441c01c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01b62353-e170-4c29-bda1-7cd8441c01c2.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -10943,7 +10943,7 @@
         },
         {
             "id": "236d5bf0-df73-55b5-ae15-51c111513a29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf2baad-0160-419d-bba5-f4f35596aa61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cf2baad-0160-419d-bba5-f4f35596aa61.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -10978,7 +10978,7 @@
         },
         {
             "id": "66a26d7e-9eff-512d-985b-d451b1854d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1422a65-5bda-4d75-8682-8c7351b3dba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1422a65-5bda-4d75-8682-8c7351b3dba6.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -11016,7 +11016,7 @@
         },
         {
             "id": "f696b6f7-f5c9-5f05-aa33-a6620280dd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59735c0d-5793-478a-b40c-f8d13413f67b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59735c0d-5793-478a-b40c-f8d13413f67b.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -11051,7 +11051,7 @@
         },
         {
             "id": "81361ff9-80b2-595f-9ade-680ee6a794c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcfd8e-e069-4489-8498-2c7b742bf4fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23bcfd8e-e069-4489-8498-2c7b742bf4fe.jpg?1",
             "name": "Myriad Landscape",
             "text": "",
             "colours": [],
@@ -11081,7 +11081,7 @@
         },
         {
             "id": "41302153-e089-56ca-9519-c028a9c86eed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698de613-bd07-49b8-bbc3-d89d26565593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698de613-bd07-49b8-bbc3-d89d26565593.jpg?1",
             "name": "Mystic Monastery",
             "text": "",
             "colours": [],
@@ -11115,7 +11115,7 @@
         },
         {
             "id": "cd4bf199-6ddc-5402-8c39-f2fadf0e6983",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7790ee3-87dc-497f-87ea-9554ca67600d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7790ee3-87dc-497f-87ea-9554ca67600d.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -11150,7 +11150,7 @@
         },
         {
             "id": "391da408-7607-59db-9fab-4deacbfedd40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c6f93e-e03f-4749-8b30-9375c79f10f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c6f93e-e03f-4749-8b30-9375c79f10f4.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -11180,7 +11180,7 @@
         },
         {
             "id": "d9b5646c-6379-5791-947f-b2ab561e962c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df58d745-2f08-447f-a7db-41765731e36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df58d745-2f08-447f-a7db-41765731e36c.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -11215,7 +11215,7 @@
         },
         {
             "id": "63250dba-b376-5cdd-b22c-b1abcb1440ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32fcfa0-50df-4815-ad8f-0e0db32c307b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32fcfa0-50df-4815-ad8f-0e0db32c307b.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -11253,7 +11253,7 @@
         },
         {
             "id": "e7f4fff3-43b8-57ef-b771-eda2508697a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afb2f16-4364-439e-a5ce-6598b351cb4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3afb2f16-4364-439e-a5ce-6598b351cb4c.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -11283,7 +11283,7 @@
         },
         {
             "id": "e6c4b3a4-5f07-569c-adda-fe24726663ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebb072-492c-4ec0-8b1d-f8ea48221647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1ebb072-492c-4ec0-8b1d-f8ea48221647.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -11318,7 +11318,7 @@
         },
         {
             "id": "8f909000-4f61-5d96-a532-850b57c75a42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ea91-d31f-4862-8ec0-6e24ef40545c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b782ea91-d31f-4862-8ec0-6e24ef40545c.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -11353,7 +11353,7 @@
         },
         {
             "id": "1ad7b737-9b07-5226-97f2-18853dd23af1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f3b1cb-e436-40f9-904c-f5696aa6f383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f3b1cb-e436-40f9-904c-f5696aa6f383.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -11383,7 +11383,7 @@
         },
         {
             "id": "6b09ce6c-994a-5eea-bc69-a9265df3f380",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72232b23-d59b-4bf4-aa55-b8f5ab691504.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72232b23-d59b-4bf4-aa55-b8f5ab691504.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -11418,7 +11418,7 @@
         },
         {
             "id": "d823ddb2-b369-5022-b018-cbaa5c718701",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12f441a-4d58-4ea5-90b8-f4e32db391a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12f441a-4d58-4ea5-90b8-f4e32db391a1.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -11456,7 +11456,7 @@
         },
         {
             "id": "9390adb9-a07f-5a4b-a505-29555e222a65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88308a2d-5d93-4bc3-a5db-e895a0db76e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88308a2d-5d93-4bc3-a5db-e895a0db76e2.jpg?1",
             "name": "Seaside Citadel",
             "text": "",
             "colours": [],
@@ -11490,7 +11490,7 @@
         },
         {
             "id": "740da7c2-6d05-5620-bab0-2cb0f8729ee3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e7104-debd-474c-a602-3226dae5a553.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be9e7104-debd-474c-a602-3226dae5a553.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -11525,7 +11525,7 @@
         },
         {
             "id": "68a5017d-be04-5edc-93de-5ab46f3e5395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e230ab-9cae-43e2-b4dd-54fd2baea76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00e230ab-9cae-43e2-b4dd-54fd2baea76f.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -11563,7 +11563,7 @@
         },
         {
             "id": "86fe02ab-3978-5eba-a76b-6bacba06ea26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0dfc2d-5d13-4051-b24c-108b566b5e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d0dfc2d-5d13-4051-b24c-108b566b5e23.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -11598,7 +11598,7 @@
         },
         {
             "id": "5ac0ca93-a550-504c-b395-9c5b717aa110",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9761639c-8b54-4ef2-83cf-d45f9da33388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/9761639c-8b54-4ef2-83cf-d45f9da33388.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -11633,7 +11633,7 @@
         },
         {
             "id": "d01c1d12-01d2-5ec0-bdc4-be261e48e7a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b65ecb-ace2-4247-a654-1e704d24319a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1b65ecb-ace2-4247-a654-1e704d24319a.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -11671,7 +11671,7 @@
         },
         {
             "id": "7f5236ab-1f11-5429-bdd4-c7bcb20a2b3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe029f-e173-4a16-bdb4-394847b4e50b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54fe029f-e173-4a16-bdb4-394847b4e50b.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -11706,7 +11706,7 @@
         },
         {
             "id": "76ffdba8-c1c6-59f7-913f-8f3fcf0fed09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da58ad9-3584-4881-9c98-f60cd09fc519.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da58ad9-3584-4881-9c98-f60cd09fc519.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -11741,7 +11741,7 @@
         },
         {
             "id": "53eeb9aa-3ecf-51b7-a8b8-4d588b7ef688",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8b5b0b-a8bc-4244-b457-44ccb92ede5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b8b5b0b-a8bc-4244-b457-44ccb92ede5c.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -11776,7 +11776,7 @@
         },
         {
             "id": "0d89e104-847f-5d79-9f43-fb48ebcce2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4a9124-a692-4086-8f22-574fdcd81ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db4a9124-a692-4086-8f22-574fdcd81ae2.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -11811,7 +11811,7 @@
         },
         {
             "id": "96c75b0b-95fd-5682-a36e-a4315e610213",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4247c058-7f27-4195-b847-db883a430e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4247c058-7f27-4195-b847-db883a430e6a.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -11849,7 +11849,7 @@
         },
         {
             "id": "2136cf4e-c1fa-5a1c-b733-68ea9da1003c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1511f21-d9ae-4949-859a-3246a01c1166.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1511f21-d9ae-4949-859a-3246a01c1166.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -11884,7 +11884,7 @@
         },
         {
             "id": "094e6db2-3b6b-5d0e-af43-da5977a41bd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfbb9b-f2b8-42ed-89ba-c0d894e1e8d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbbfbb9b-f2b8-42ed-89ba-c0d894e1e8d4.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -11919,7 +11919,7 @@
         },
         {
             "id": "a90ffa3f-2e23-5cc3-8cae-451547161469",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345eb1f-3a44-432c-8bee-39099e1947e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c345eb1f-3a44-432c-8bee-39099e1947e6.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -11954,7 +11954,7 @@
         },
         {
             "id": "f29b6cf0-4032-5e62-92eb-9462aceeea51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7df0f35-81a1-439f-a9b0-0c3afd4bce68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7df0f35-81a1-439f-a9b0-0c3afd4bce68.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -11989,7 +11989,7 @@
         },
         {
             "id": "dd406f3b-6b2a-5074-bf4c-bf56093b810b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fabb0-9f83-49a3-9da3-d2b1d89fdb61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee9fabb0-9f83-49a3-9da3-d2b1d89fdb61.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -12024,7 +12024,7 @@
         },
         {
             "id": "584f478a-8258-529b-8711-4f861e00f6f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f1a8ce-a7c2-4e74-a4f2-22c914e998c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12f1a8ce-a7c2-4e74-a4f2-22c914e998c4.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -12059,7 +12059,7 @@
         },
         {
             "id": "38f48830-eb5b-54d4-ae83-9e580c68afa2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a47d5-e96b-4e90-8e63-a0e9376f2359.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6a47d5-e96b-4e90-8e63-a0e9376f2359.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -12094,7 +12094,7 @@
         },
         {
             "id": "4bcd57db-d281-5f0b-8cdd-426bc7c17794",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca70d08-1468-407d-80e6-a58c6655b4f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ca70d08-1468-407d-80e6-a58c6655b4f0.jpg?1",
             "name": "Temple of the False God",
             "text": "",
             "colours": [],
@@ -12124,7 +12124,7 @@
         },
         {
             "id": "11ac6a0c-4b4c-50c9-8ab2-4a6fa9b39d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e7e74-07ac-4aed-b58f-f4b045730cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d59e7e74-07ac-4aed-b58f-f4b045730cfe.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -12159,7 +12159,7 @@
         },
         {
             "id": "cbf2fbde-eb4e-58b0-a39e-c7a71fc086e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa85babf-6764-4cf7-9108-ec15cda6ada5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa85babf-6764-4cf7-9108-ec15cda6ada5.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -12189,7 +12189,7 @@
         },
         {
             "id": "80787ac9-822d-51b3-b0a3-aa35ea1cf23f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3d9d-e269-4a83-9b2d-cfe34f5f0f78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3d9d-e269-4a83-9b2d-cfe34f5f0f78.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -12221,7 +12221,7 @@
         },
         {
             "id": "b15e50f2-d578-5780-9e51-02876e3a46ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb29495-5cc8-4f78-adb5-a7302bb9743b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceb29495-5cc8-4f78-adb5-a7302bb9743b.jpg?1",
             "name": "Thriving Bluff",
             "text": "",
             "colours": [],
@@ -12253,7 +12253,7 @@
         },
         {
             "id": "ea5efbc5-bcb3-5ff4-a372-fe34b6546323",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ccec9-7377-4038-b23b-58a714e797b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea2ccec9-7377-4038-b23b-58a714e797b9.jpg?1",
             "name": "Thriving Grove",
             "text": "",
             "colours": [],
@@ -12285,7 +12285,7 @@
         },
         {
             "id": "4330b00d-9c1c-5ccb-abc7-a76aa69f59c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d230b-43ac-4980-80b8-ae7b9aa63e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227d230b-43ac-4980-80b8-ae7b9aa63e6d.jpg?1",
             "name": "Thriving Heath",
             "text": "",
             "colours": [],
@@ -12317,7 +12317,7 @@
         },
         {
             "id": "2a094dea-0474-5a82-b28c-a079bda2bd64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352b106e-46de-4087-9533-a9f4b5536220.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/352b106e-46de-4087-9533-a9f4b5536220.jpg?1",
             "name": "Thriving Isle",
             "text": "",
             "colours": [],
@@ -12349,7 +12349,7 @@
         },
         {
             "id": "eaae9724-05ff-514a-b5ed-31f96c9175ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3a27-cd9a-4344-8879-1ed81932aaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50ae3a27-cd9a-4344-8879-1ed81932aaec.jpg?1",
             "name": "Thriving Moor",
             "text": "",
             "colours": [],
@@ -12381,7 +12381,7 @@
         },
         {
             "id": "deb0ad53-6570-55fd-91ee-2b03cf251fa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44297b-fd89-4d95-a502-cdd98fd4fbc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee44297b-fd89-4d95-a502-cdd98fd4fbc3.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -12416,7 +12416,7 @@
         },
         {
             "id": "2d421cc3-d9be-5700-bb60-06d8a2ca9ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f90fe-f5f1-47bb-8601-f3f18735b647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/446f90fe-f5f1-47bb-8601-f3f18735b647.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -12448,7 +12448,7 @@
         },
         {
             "id": "097a63b0-c766-584f-84e0-80bb634d9927",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46931098-ae3c-409a-8789-7071205e11ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46931098-ae3c-409a-8789-7071205e11ee.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -12483,7 +12483,7 @@
         },
         {
             "id": "07ea979c-255c-5405-ba4e-0939ebfffac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c0b868-a688-4ccb-97b7-58fd424a7864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50c0b868-a688-4ccb-97b7-58fd424a7864.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -12520,7 +12520,7 @@
         },
         {
             "id": "6548eb60-64c0-53e3-a3b6-ded5062c66ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1974b3-59dd-40ed-8d82-61d2b1b7fad5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc1974b3-59dd-40ed-8d82-61d2b1b7fad5.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -12558,7 +12558,7 @@
         },
         {
             "id": "74234a23-77fa-5284-be19-d58aeed8c8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540398df-27db-4103-bc28-92fd3aa9cbcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/540398df-27db-4103-bc28-92fd3aa9cbcd.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -12598,7 +12598,7 @@
         },
         {
             "id": "a788871c-e1d7-55ee-9429-ea8467e9425c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd853b51-906f-49ef-a21e-5716317af8fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd853b51-906f-49ef-a21e-5716317af8fc.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -12639,7 +12639,7 @@
         },
         {
             "id": "4df7c60b-67b3-543d-8527-b048aa21020b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c9f47c-be91-4d77-a76e-2963a6d75864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c9f47c-be91-4d77-a76e-2963a6d75864.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -12675,7 +12675,7 @@
         },
         {
             "id": "258b27ed-9328-5e85-b5d1-2e3db6362761",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6932a-5714-4e9e-9229-ea182a175779.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6932a-5714-4e9e-9229-ea182a175779.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -12711,7 +12711,7 @@
         },
         {
             "id": "379c8989-8d72-5b6e-80df-6c9585e009e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9558e30-7ea9-4841-a742-5d7941c0241f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9558e30-7ea9-4841-a742-5d7941c0241f.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -12747,7 +12747,7 @@
         },
         {
             "id": "73b50c71-b86c-516b-8d5c-71ac83c48281",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8a2f7f-477d-441c-9677-1346c8622fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e8a2f7f-477d-441c-9677-1346c8622fff.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -12783,7 +12783,7 @@
         },
         {
             "id": "99b99294-c8f4-57c7-a97c-40ca810dbef6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafd4914-71e9-436e-acd7-9e2d17769044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bafd4914-71e9-436e-acd7-9e2d17769044.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -12819,7 +12819,7 @@
         },
         {
             "id": "3d1b551e-c075-5d1d-9b76-3fa0654d1709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d52ef49-528c-4859-8b8f-9eae12d6d7ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d52ef49-528c-4859-8b8f-9eae12d6d7ca.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -12860,7 +12860,7 @@
         },
         {
             "id": "e6315b72-c7fa-5ff3-9817-dd4433b2ac23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697a5e9-4229-4bf9-9161-c3b768df5bd3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b697a5e9-4229-4bf9-9161-c3b768df5bd3.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -12901,7 +12901,7 @@
         },
         {
             "id": "0699b22e-8175-51b9-80d7-d4ece2f77fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6974ba-658c-4747-9a25-68670142c487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c6974ba-658c-4747-9a25-68670142c487.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -12939,7 +12939,7 @@
         },
         {
             "id": "f83a0070-0361-5bc3-aa94-8fc89fea8407",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeb6a54-3d0a-4a64-a9e4-acd683e42761.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/feeb6a54-3d0a-4a64-a9e4-acd683e42761.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -12979,7 +12979,7 @@
         },
         {
             "id": "1c9b693b-e215-5f19-968f-b17e5d74cb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f9086a-40e0-4dd0-ba2c-338015bd4d73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95f9086a-40e0-4dd0-ba2c-338015bd4d73.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -13020,7 +13020,7 @@
         },
         {
             "id": "1340ef0d-480b-5503-863d-1500cc8a1102",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57508c8-22f6-45ca-abd7-4cdd775ff4b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f57508c8-22f6-45ca-abd7-4cdd775ff4b6.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -13062,7 +13062,7 @@
         },
         {
             "id": "35b8f1b7-8644-5367-91ad-42f90dffb2a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb3b95-9540-45f4-8600-bedaff98e624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3eb3b95-9540-45f4-8600-bedaff98e624.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -13105,7 +13105,7 @@
         },
         {
             "id": "fe50a530-6c57-5fd9-a06c-191e5fe25198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b6f28a-bca5-4f5c-8102-085316088a11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19b6f28a-bca5-4f5c-8102-085316088a11.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -13145,7 +13145,7 @@
         },
         {
             "id": "a6b7e616-54dc-5796-be52-c86a5fd5af2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc2d77-ec3c-408f-9259-0c511790fa34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3fc2d77-ec3c-408f-9259-0c511790fa34.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -13181,7 +13181,7 @@
         },
         {
             "id": "ec9973ee-ea26-5950-a797-3f348c501666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39de636c-87e7-4de7-98de-41b285bc9c52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39de636c-87e7-4de7-98de-41b285bc9c52.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -13222,7 +13222,7 @@
         },
         {
             "id": "601fb6ec-1938-51d6-83cd-fe76ed5bf8a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1974e2c-1ce5-41a0-8b52-1950d7cca0d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1974e2c-1ce5-41a0-8b52-1950d7cca0d5.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -13263,7 +13263,7 @@
         },
         {
             "id": "8da7d10f-cbae-512b-ad36-81743effc98e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27c960e-864d-4dbf-861b-a862039579a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d27c960e-864d-4dbf-861b-a862039579a8.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -13299,7 +13299,7 @@
         },
         {
             "id": "2b09b81f-4acd-561c-8793-03909512e88a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2697012c-81a6-48e7-96cd-e6745078e0d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2697012c-81a6-48e7-96cd-e6745078e0d9.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -13339,7 +13339,7 @@
         },
         {
             "id": "f4fff64a-f755-5e63-bae9-b11b00e10769",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d19d6-0fe0-4534-898e-706336c95af7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0d19d6-0fe0-4534-898e-706336c95af7.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -13377,7 +13377,7 @@
         },
         {
             "id": "924903b9-abd0-5d38-b3cc-ba044caaa8d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a779222-d591-4f08-9383-b29895e8d2b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a779222-d591-4f08-9383-b29895e8d2b6.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -13413,7 +13413,7 @@
         },
         {
             "id": "45f98d44-de9d-53ed-bc6a-0963c9519877",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a12bf-0078-446e-9471-01d43ec099d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/141a12bf-0078-446e-9471-01d43ec099d1.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -13455,7 +13455,7 @@
         },
         {
             "id": "70da4325-3bcb-5ef8-a4f4-eb66851877bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a5990-f61e-4533-a598-1839b209f2f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc2a5990-f61e-4533-a598-1839b209f2f3.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -13495,7 +13495,7 @@
         },
         {
             "id": "54a8b5d5-5f07-545b-9fb4-6c42e7d14ff8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d36ecf-5508-4fe6-9ad4-72df934b5c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d36ecf-5508-4fe6-9ad4-72df934b5c40.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -13531,7 +13531,7 @@
         },
         {
             "id": "b983d026-4a82-5d25-88fb-1b0686867b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebb1d26-13d1-4907-95d6-8766b233fc73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0ebb1d26-13d1-4907-95d6-8766b233fc73.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -13570,7 +13570,7 @@
         },
         {
             "id": "4368275b-5d84-5d8e-827e-beaf1335299e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c6b33d-c1c7-442b-91ac-d7ef56ce8fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/07c6b33d-c1c7-442b-91ac-d7ef56ce8fdd.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -13610,7 +13610,7 @@
         },
         {
             "id": "52ea3d20-2aca-5f0a-baa4-5a86e4163d01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2c9623-6b4c-457e-9235-a39a84b49b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b2c9623-6b4c-457e-9235-a39a84b49b7b.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -13646,7 +13646,7 @@
         },
         {
             "id": "1a84f306-5fb8-59e0-a9b1-e7f4f4543a3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb58f17-5d98-4b17-b635-3e27e94a3673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cb58f17-5d98-4b17-b635-3e27e94a3673.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -13690,7 +13690,7 @@
         },
         {
             "id": "1dc39f2f-0d20-57e7-af59-2a3a29663d9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e23c4f-06bf-4f34-8221-408ce90ec672.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e23c4f-06bf-4f34-8221-408ce90ec672.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -13731,7 +13731,7 @@
         },
         {
             "id": "59fa9768-a43e-50bb-9e19-d9fca54c3337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f2135a-75a5-497f-ab71-b440c56d17cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f2135a-75a5-497f-ab71-b440c56d17cf.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -13767,7 +13767,7 @@
         },
         {
             "id": "ec208732-17bb-5291-aecc-c10cf8465894",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5043369d-966c-49c4-a249-92c700ecd28a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/5043369d-966c-49c4-a249-92c700ecd28a.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -13808,7 +13808,7 @@
         },
         {
             "id": "72466cfa-6d8d-5378-9854-02ebf1f2d5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834219e4-ccae-4fd9-bc75-b82fdbd7f47e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/834219e4-ccae-4fd9-bc75-b82fdbd7f47e.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -13849,7 +13849,7 @@
         },
         {
             "id": "87207a2b-fe4d-50c3-9d16-bee213ae8859",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986a1243-712d-4139-b9a1-27f935c9439b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986a1243-712d-4139-b9a1-27f935c9439b.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -13891,7 +13891,7 @@
         },
         {
             "id": "8ec6a77d-ff36-5c4f-878c-543b04fc321c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497f3315-13d2-41be-bf3a-a75de57a5e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/497f3315-13d2-41be-bf3a-a75de57a5e08.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "a7f49d4f-2078-5edc-805d-d959304b47f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67e7988-fbed-43f3-a25c-2b422b3d6594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e67e7988-fbed-43f3-a25c-2b422b3d6594.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -13963,7 +13963,7 @@
         },
         {
             "id": "b2cb1eca-40f0-5178-a19b-3636dd72f3cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7513ebd-272b-4e50-be9f-0ff84b50444a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7513ebd-272b-4e50-be9f-0ff84b50444a.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -13999,7 +13999,7 @@
         },
         {
             "id": "a6956ae6-e876-511b-9dbe-c87485b7ff52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb77dfb-c072-4557-ace7-3166ae72fb38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efb77dfb-c072-4557-ace7-3166ae72fb38.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -14038,7 +14038,7 @@
         },
         {
             "id": "31843d6a-7d0e-5724-bdc2-1be7e6171d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d38653a-c170-4cda-8ded-860537e54bae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d38653a-c170-4cda-8ded-860537e54bae.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -14074,7 +14074,7 @@
         },
         {
             "id": "637c9b2f-b5b9-5fac-a16e-51d59622f28c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4f9b2d-f7b3-4ea4-b4b4-2f0734ae295f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e4f9b2d-f7b3-4ea4-b4b4-2f0734ae295f.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -14110,7 +14110,7 @@
         },
         {
             "id": "9d817228-8450-5ff3-8b87-2b34f1464167",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69807079-995f-4b15-a9f1-cad3eb66c526.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69807079-995f-4b15-a9f1-cad3eb66c526.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -14149,7 +14149,7 @@
         },
         {
             "id": "9f8e4525-8cb7-5470-996d-255bc5629e37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25b6dcd-12aa-449d-b734-d1dc4b053df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c25b6dcd-12aa-449d-b734-d1dc4b053df4.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -14185,7 +14185,7 @@
         },
         {
             "id": "e7964257-b3a4-5f93-9797-ae6b058669d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7db07e-9332-488a-a9ae-b90d6180098e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab7db07e-9332-488a-a9ae-b90d6180098e.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -14224,7 +14224,7 @@
         },
         {
             "id": "f2aef294-3fa3-5046-84de-30a541afd526",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65da12f9-8fcb-4f58-b123-adcff8e6ea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65da12f9-8fcb-4f58-b123-adcff8e6ea20.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -14264,7 +14264,7 @@
         },
         {
             "id": "c06366cf-3732-5d5d-b298-cdfe87761f7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d4b61-136b-41b8-8de3-9a1b40f90216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/915d4b61-136b-41b8-8de3-9a1b40f90216.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -14304,7 +14304,7 @@
         },
         {
             "id": "f98b090e-9ad3-5ca7-9847-7c264203ff89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e04f552-c6a8-4c3d-898b-7cf1523f9440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e04f552-c6a8-4c3d-898b-7cf1523f9440.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -14344,7 +14344,7 @@
         },
         {
             "id": "26d17299-7174-5982-9f54-3ebf318b07ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08448af-6f7d-4587-be37-de360fe6199c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f08448af-6f7d-4587-be37-de360fe6199c.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -14384,7 +14384,7 @@
         },
         {
             "id": "43a871d5-8d90-5157-96f3-64762855743f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d085c152-d492-4ff6-9c98-d7db658a36c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d085c152-d492-4ff6-9c98-d7db658a36c7.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -14420,7 +14420,7 @@
         },
         {
             "id": "6e1933ea-2545-5ff6-bc41-4d8aae7d3e5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9fe657-e9c8-4b74-bda5-ee03b909c97b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a9fe657-e9c8-4b74-bda5-ee03b909c97b.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -14460,7 +14460,7 @@
         },
         {
             "id": "5fc8df13-6c96-5d00-8a2b-7660069ec8b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d749a92e-7bb4-44b2-9849-98414a416208.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d749a92e-7bb4-44b2-9849-98414a416208.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -14496,7 +14496,7 @@
         },
         {
             "id": "beb3c121-f856-504c-863c-122eef2e62cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d53c12-2e7c-4b71-b2b5-3abfbd26b4b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85d53c12-2e7c-4b71-b2b5-3abfbd26b4b9.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -14532,7 +14532,7 @@
         },
         {
             "id": "fc58a20f-23b0-546a-b313-4218c7f87e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21f29c1-545f-4ab5-bb8c-3ea7bf453188.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b21f29c1-545f-4ab5-bb8c-3ea7bf453188.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -14570,7 +14570,7 @@
         },
         {
             "id": "ff79b368-5b95-5edb-b9b8-799d6fb4f75c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727e54-94d4-4606-91a3-2d11b463a9f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29727e54-94d4-4606-91a3-2d11b463a9f4.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -14606,7 +14606,7 @@
         },
         {
             "id": "597f8351-68a8-54b0-a68d-d26a2f03653a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f84d1c2-c96b-4cd8-9fa7-34c8f5b4bec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f84d1c2-c96b-4cd8-9fa7-34c8f5b4bec0.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -14642,7 +14642,7 @@
         },
         {
             "id": "e7853e73-7de5-5617-b24c-86d2aa036bb9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3618e0-3cbc-409b-9d08-a75a2c840496.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3618e0-3cbc-409b-9d08-a75a2c840496.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -14678,7 +14678,7 @@
         },
         {
             "id": "01de6d7e-816a-5343-89af-437527660785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94727f3-4d5f-44aa-b66a-30a670ac07ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f94727f3-4d5f-44aa-b66a-30a670ac07ed.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -14718,7 +14718,7 @@
         },
         {
             "id": "d7744796-8e38-58ca-b80b-3824e69298fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942e0d0-399b-48e6-be18-1687232f75a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6942e0d0-399b-48e6-be18-1687232f75a0.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -14758,7 +14758,7 @@
         },
         {
             "id": "3ee53c5a-64a6-5c3d-b543-b9f9f034f932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff3fbe7-1c11-4cce-a43b-b6b4cb4d1594.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff3fbe7-1c11-4cce-a43b-b6b4cb4d1594.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -14796,7 +14796,7 @@
         },
         {
             "id": "2c0123c3-271d-572d-ad1d-bf899f3c3c0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f325e7-2585-4c7a-a6cf-91f8cd91f22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26f325e7-2585-4c7a-a6cf-91f8cd91f22c.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -14839,7 +14839,7 @@
         },
         {
             "id": "203f1fdb-7385-529e-b4b6-32e4b72ed05a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce6d329-9c3a-4fb0-bf1e-9b72346ca3ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce6d329-9c3a-4fb0-bf1e-9b72346ca3ad.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -14880,7 +14880,7 @@
         },
         {
             "id": "725c3cc1-9f0b-56c9-9185-d5de33164dfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a4c23c-fbf0-4edd-8503-37d4f87d680a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a4c23c-fbf0-4edd-8503-37d4f87d680a.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -14916,7 +14916,7 @@
         },
         {
             "id": "21a5dd63-ffc6-5b96-8950-5cb295ef8109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a3e73e-9c81-4102-8163-4158e6e2f602.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a3e73e-9c81-4102-8163-4158e6e2f602.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -14956,7 +14956,7 @@
         },
         {
             "id": "0bbde221-de7e-5062-a3ad-77ecd68b505d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d33a0-8e3f-40e4-a36d-db0e5001fa1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18d33a0-8e3f-40e4-a36d-db0e5001fa1c.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -14997,7 +14997,7 @@
         },
         {
             "id": "7c565e99-ab6f-52ba-8414-757bc6bf287d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d31cc1f-a53e-45bb-9568-082c09a6ea28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d31cc1f-a53e-45bb-9568-082c09a6ea28.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -15038,7 +15038,7 @@
         },
         {
             "id": "549b267c-ace3-58f3-adbc-c749664afa69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d666c6e-dfa3-4e15-9841-675c596df906.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d666c6e-dfa3-4e15-9841-675c596df906.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -15079,7 +15079,7 @@
         },
         {
             "id": "35308b0a-b890-56b9-b215-9e02a4dd3c5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7a8297-5612-4f87-9d14-e8c1ee4c1d0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b7a8297-5612-4f87-9d14-e8c1ee4c1d0e.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -15117,7 +15117,7 @@
         },
         {
             "id": "cd9e2907-5974-585a-bb91-4cf7f13903cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7c1b5-5d40-4ac5-b4bc-42fb726693f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d7c1b5-5d40-4ac5-b4bc-42fb726693f4.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -15157,7 +15157,7 @@
         },
         {
             "id": "15fa4942-0c25-544a-82ae-02780787c95e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd85a71e-e090-4071-bc07-a05abd802782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd85a71e-e090-4071-bc07-a05abd802782.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -15202,7 +15202,7 @@
         },
         {
             "id": "31e78ebf-bf1e-5185-9d01-8a95104ff419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d579c01-7d65-4492-88dc-00aff3be6ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d579c01-7d65-4492-88dc-00aff3be6ab3.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -15247,7 +15247,7 @@
         },
         {
             "id": "a2b77583-00a7-5693-8157-b0956783f185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32903c6-1230-436c-9913-6abf3a97f10e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e32903c6-1230-436c-9913-6abf3a97f10e.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -15289,7 +15289,7 @@
         },
         {
             "id": "ea5a2595-37d9-5e37-b15a-f35d34a58483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be38267-fa28-49c8-b8df-d08df4106d95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6be38267-fa28-49c8-b8df-d08df4106d95.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -15334,7 +15334,7 @@
         },
         {
             "id": "4bacd7b4-ff25-5b27-83d1-4856abcce34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf41cbb6-1d43-4197-b3c6-a5a70f96f135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf41cbb6-1d43-4197-b3c6-a5a70f96f135.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -15377,7 +15377,7 @@
         },
         {
             "id": "a94d60f2-17c0-51e2-9a27-c68434e070c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc16ca7-7ece-4889-a6e6-a79563847b88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cdc16ca7-7ece-4889-a6e6-a79563847b88.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -15420,7 +15420,7 @@
         },
         {
             "id": "0429f742-83b2-5401-9e92-ccf95b9eebf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bcb234-012b-47f1-ad8c-2223d12fe1f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bcb234-012b-47f1-ad8c-2223d12fe1f2.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -15469,7 +15469,7 @@
         },
         {
             "id": "6342aab5-213b-5d84-9923-2fb70968abc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391e1747-69b0-47e0-9210-317f5febca59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/391e1747-69b0-47e0-9210-317f5febca59.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -15509,7 +15509,7 @@
         },
         {
             "id": "b794afa4-d0cc-5e97-b07a-22c64b9025ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4f9d74-c6ed-45f5-96b3-69b918ec9462.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f4f9d74-c6ed-45f5-96b3-69b918ec9462.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -15552,7 +15552,7 @@
         },
         {
             "id": "aa03d352-7546-5bf5-83d7-18c8a0ccc71a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46827983-517e-45bb-b27e-b9766185f7ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46827983-517e-45bb-b27e-b9766185f7ed.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -15598,7 +15598,7 @@
         },
         {
             "id": "bcc769bc-4e5a-5912-9e77-ac9670ee4f3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe6a5a0-3c1f-4e97-9bc6-aa74daeec7a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe6a5a0-3c1f-4e97-9bc6-aa74daeec7a0.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -15644,7 +15644,7 @@
         },
         {
             "id": "11179ff2-5aa5-5695-9ca6-c9fed8d7bd37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7495b342-7397-4957-afa6-00529a6e86b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7495b342-7397-4957-afa6-00529a6e86b7.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -15689,7 +15689,7 @@
         },
         {
             "id": "ac719064-3847-5d7d-a4c3-4a5eaa932a08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aedb9b-5dd6-4e93-a470-e57e24e1f6de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67aedb9b-5dd6-4e93-a470-e57e24e1f6de.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -15735,7 +15735,7 @@
         },
         {
             "id": "dc9aaad1-2103-5a07-a782-91ada382e846",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9ec14-87a1-4ac1-a778-c1e962bca4c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71f9ec14-87a1-4ac1-a778-c1e962bca4c4.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -15781,7 +15781,7 @@
         },
         {
             "id": "6e2cb859-8676-51ce-b486-931465a93c69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e22e8-7e88-4786-b349-e4472c1086fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1e22e8-7e88-4786-b349-e4472c1086fd.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -15828,7 +15828,7 @@
         },
         {
             "id": "ae379ee8-debb-51f4-be50-bde5f78723ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f08ba37-15dd-4ad8-a35a-4f5cf776139d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f08ba37-15dd-4ad8-a35a-4f5cf776139d.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -15868,7 +15868,7 @@
         },
         {
             "id": "3b273a91-9346-5358-945c-1f3167644932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a07db6-db90-4584-9d73-64e56c05601a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61a07db6-db90-4584-9d73-64e56c05601a.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -15913,7 +15913,7 @@
         },
         {
             "id": "dcc9ab07-16dd-52c6-a91c-81f9847006ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e364cf-afb5-41b1-8f56-2e70ca51a64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29e364cf-afb5-41b1-8f56-2e70ca51a64b.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -15953,7 +15953,7 @@
         },
         {
             "id": "188bb547-69fb-593e-b6a2-2f45441a99b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013fe4db-615c-433f-a1cf-b5144cd877a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/013fe4db-615c-433f-a1cf-b5144cd877a3.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -15996,7 +15996,7 @@
         },
         {
             "id": "d278b1e5-eff5-5c59-8238-b9b96490212b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f821-7239-4aa0-97bc-3c187c7eb9b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bc5f821-7239-4aa0-97bc-3c187c7eb9b5.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -16039,7 +16039,7 @@
         },
         {
             "id": "ae46cd7a-a005-571e-bd83-d9fc329504da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c430ce-b6c4-4b05-9439-07b4fbfdfe62.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c430ce-b6c4-4b05-9439-07b4fbfdfe62.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -16082,7 +16082,7 @@
         },
         {
             "id": "7095d691-1552-56b1-b6be-0530164d28cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bce6c7-4864-406d-a693-d47cc8026425.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4bce6c7-4864-406d-a693-d47cc8026425.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -16127,7 +16127,7 @@
         },
         {
             "id": "0041da35-5459-5726-9203-789822885bc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98048265-cdab-4a21-89f9-3403babf34e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98048265-cdab-4a21-89f9-3403babf34e6.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -16165,7 +16165,7 @@
         },
         {
             "id": "bdbd483c-0c8d-58d0-a978-28a08606b823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e306f3-65b3-420d-a50c-fa5cf74677ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e306f3-65b3-420d-a50c-fa5cf74677ad.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -16206,7 +16206,7 @@
         },
         {
             "id": "99085d59-f02b-572b-8a12-326da02c51a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2861f7-1b2c-436a-848f-02f1142e6e2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf2861f7-1b2c-436a-848f-02f1142e6e2e.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -16249,7 +16249,7 @@
         },
         {
             "id": "fa2f139a-01e3-539f-8213-2c788a877579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867721ef-0329-4711-968e-62eb95c14df5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/867721ef-0329-4711-968e-62eb95c14df5.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -16294,7 +16294,7 @@
         },
         {
             "id": "3acdd9d3-075c-5178-aa63-95002cf5ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdf1881-b1a5-4422-b722-2eb03e1bcc4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdf1881-b1a5-4422-b722-2eb03e1bcc4e.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -16339,7 +16339,7 @@
         },
         {
             "id": "1949022f-b8b5-5578-83d4-366bbd14a802",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee2b585-a26b-4a1a-9fa4-79b54505be3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ee2b585-a26b-4a1a-9fa4-79b54505be3c.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -16384,7 +16384,7 @@
         },
         {
             "id": "fe2ccca1-a6a6-5829-bdc1-fd68c10311ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d86fee-e217-42b9-82c1-238e48297cff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57d86fee-e217-42b9-82c1-238e48297cff.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -16429,7 +16429,7 @@
         },
         {
             "id": "34a5de36-283b-55e9-9888-d1c389b7e10f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfab366-8c79-42ec-89b1-c987ed9e9846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abfab366-8c79-42ec-89b1-c987ed9e9846.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -16474,7 +16474,7 @@
         },
         {
             "id": "f48d09f6-0a2d-5acd-aacc-79f8b78abcc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c1232e-0104-4295-a1de-3eebe2ac6a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c1232e-0104-4295-a1de-3eebe2ac6a5f.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -16521,7 +16521,7 @@
         },
         {
             "id": "12fca8fa-648e-5c02-b90b-2cd94499d2b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d57465e-24de-48dd-a748-91885710c88f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d57465e-24de-48dd-a748-91885710c88f.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -16567,7 +16567,7 @@
         },
         {
             "id": "4aa9c671-d9a0-5514-8944-803b7ce3a9e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f6be27-73e9-4978-b972-0a531e4bf3db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5f6be27-73e9-4978-b972-0a531e4bf3db.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -16612,7 +16612,7 @@
         },
         {
             "id": "e2048660-decc-57c6-b9e4-9ea43d8ca17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7047e7-d1fd-4b2c-b548-5c9c7590ab0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d7047e7-d1fd-4b2c-b548-5c9c7590ab0b.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -16655,7 +16655,7 @@
         },
         {
             "id": "819d1717-2f1e-5288-ac7e-33c902fa7d18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df450d9a-a556-4d2c-bce0-0aabe1eef8cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df450d9a-a556-4d2c-bce0-0aabe1eef8cd.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -16693,7 +16693,7 @@
         },
         {
             "id": "cda8d298-7f0d-534d-9b22-1d033ee827a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6b98f9-5317-4fd9-944e-c1fd5e7f6d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb6b98f9-5317-4fd9-944e-c1fd5e7f6d3f.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -16739,7 +16739,7 @@
         },
         {
             "id": "bb22e50c-9f1c-5633-9484-b2fc5b6ede67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035109e7-56e9-4ce4-a81c-404dec8c0690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/035109e7-56e9-4ce4-a81c-404dec8c0690.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -16782,7 +16782,7 @@
         },
         {
             "id": "63dca8e2-f4be-58e9-8c05-1e0168f7fd84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5ecb3c-5da8-41fc-9196-0d67b4234de3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c5ecb3c-5da8-41fc-9196-0d67b4234de3.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -16820,7 +16820,7 @@
         },
         {
             "id": "72fa9d08-5a6b-5544-9de4-811429246dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80447e9-a359-49cf-82fa-9ee36ed730d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a80447e9-a359-49cf-82fa-9ee36ed730d3.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -16863,7 +16863,7 @@
         },
         {
             "id": "dec8aa79-7faa-5b75-ac42-1ff7c43c9193",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c071154-145f-4a37-9869-dea71ac2f997.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c071154-145f-4a37-9869-dea71ac2f997.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -16909,7 +16909,7 @@
         },
         {
             "id": "1dff694b-e5d3-53a3-870f-d0caafbc4063",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c96909-1150-4126-a21d-7842670bbaf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c96909-1150-4126-a21d-7842670bbaf8.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -16952,7 +16952,7 @@
         },
         {
             "id": "89b6bcc7-a513-5635-820f-1243d90d5502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c642d-3c32-4a16-8da5-fd1505e571d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c642d-3c32-4a16-8da5-fd1505e571d1.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -16998,7 +16998,7 @@
         },
         {
             "id": "a1c7ed1b-b6ae-5f77-83a2-31b85252af15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129ea0f5-67f6-4364-b8db-ee582b3e23fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/129ea0f5-67f6-4364-b8db-ee582b3e23fd.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -17044,7 +17044,7 @@
         },
         {
             "id": "fe8a6635-a0ce-53d6-bbaa-a36765dbec03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9410dc-7f2b-432b-8025-ec26f77446d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b9410dc-7f2b-432b-8025-ec26f77446d7.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -17087,7 +17087,7 @@
         },
         {
             "id": "3432a3a2-e3dc-5f79-96f9-34ca82ec9dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf34ac5c-85fb-4a75-8bf9-ba68c7a1059d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf34ac5c-85fb-4a75-8bf9-ba68c7a1059d.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -17128,7 +17128,7 @@
         },
         {
             "id": "6473ce86-9815-5d18-8049-7bcf2e901ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f6f6ce-410d-4c84-8a57-cf9f41016441.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59f6f6ce-410d-4c84-8a57-cf9f41016441.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -17175,7 +17175,7 @@
         },
         {
             "id": "21cf766f-12a3-535a-bfc4-b0f3166542ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757f142-b3fd-45a5-ab99-c82f956bc3a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d757f142-b3fd-45a5-ab99-c82f956bc3a3.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -17221,7 +17221,7 @@
         },
         {
             "id": "be61e9c2-20bf-59b8-bfae-3a5f64a7fc28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43174baf-eb78-41a4-834c-61cdb50eb452.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43174baf-eb78-41a4-834c-61cdb50eb452.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -17268,7 +17268,7 @@
         },
         {
             "id": "f6112f63-64fd-5524-8be0-6742aa81e675",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501152a4-776e-4c08-a573-f482d5bb29fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/501152a4-776e-4c08-a573-f482d5bb29fb.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -17314,7 +17314,7 @@
         },
         {
             "id": "434138b2-559d-52ff-b872-b2b895faaccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddf0067-2453-44b3-8ea7-248a8bb1268f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0ddf0067-2453-44b3-8ea7-248a8bb1268f.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -17359,7 +17359,7 @@
         },
         {
             "id": "b84b08da-0c4f-58a8-a34f-fc087c731aed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7072dba-30a0-46b1-ad77-2a1a3995ffcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7072dba-30a0-46b1-ad77-2a1a3995ffcd.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -17403,7 +17403,7 @@
         },
         {
             "id": "54f4f71b-9c4d-5648-b700-7f284f5de6dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcb7f51-be3f-4e32-ae8c-d19ecc219b10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcb7f51-be3f-4e32-ae8c-d19ecc219b10.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -17448,7 +17448,7 @@
         },
         {
             "id": "66561544-acbf-5385-b308-6bf07f1c9b0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60a02f-741a-4304-852e-f446e43bb46f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab60a02f-741a-4304-852e-f446e43bb46f.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -17492,7 +17492,7 @@
         },
         {
             "id": "4cad2899-b846-5b83-add8-6ac466f0c24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a9bbe6-d1fc-49a7-8abe-fbf629d545d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/81a9bbe6-d1fc-49a7-8abe-fbf629d545d5.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -17528,7 +17528,7 @@
         },
         {
             "id": "a89de3af-7c56-5aa8-9c77-27cb0f786685",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82b7f05-a73e-4db3-85cf-4fb2be77073f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e82b7f05-a73e-4db3-85cf-4fb2be77073f.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -17564,7 +17564,7 @@
         },
         {
             "id": "b12f19d2-b8ef-5745-b05f-0b9807ee716a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50e018-2536-457b-b1b0-8f8cb27529cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b50e018-2536-457b-b1b0-8f8cb27529cc.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -17596,7 +17596,7 @@
         },
         {
             "id": "e4b6b5fd-95c4-5f5a-a355-327335966c42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c952d35-e18d-44b3-9c7e-9d09bc58a774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c952d35-e18d-44b3-9c7e-9d09bc58a774.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -17631,7 +17631,7 @@
         },
         {
             "id": "6730fd40-38ab-5d67-b3d3-bb75e374cfff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c6fe5d-3964-440a-93ee-0e193263a5b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71c6fe5d-3964-440a-93ee-0e193263a5b6.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -17665,7 +17665,7 @@
         },
         {
             "id": "b7e845e7-20bc-5c11-b1c3-42627d03c3b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683237b7-b3a9-4e34-abb4-ee0293385397.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/683237b7-b3a9-4e34-abb4-ee0293385397.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -17699,7 +17699,7 @@
         },
         {
             "id": "c229f841-175f-55b3-bce1-5140b0038deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c73ab0-79ed-44cd-90bf-b0debdc04fad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c73ab0-79ed-44cd-90bf-b0debdc04fad.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -17731,7 +17731,7 @@
         },
         {
             "id": "304936d9-a5f3-556e-8432-297ad27fae1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c07ff4-7579-44f2-b7ec-2b51c0ac34f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6c07ff4-7579-44f2-b7ec-2b51c0ac34f4.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -17763,7 +17763,7 @@
         },
         {
             "id": "7f9fcd82-cc84-57d0-80ef-d641e6bd0cf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8e2bc9-8fa7-4112-ad66-3e5b7fa69793.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a8e2bc9-8fa7-4112-ad66-3e5b7fa69793.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -17797,7 +17797,7 @@
         },
         {
             "id": "6eb787ac-45dd-50b2-89b3-3a9cc161b2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93bea89-4ade-459d-a0e0-2a35fdf043af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a93bea89-4ade-459d-a0e0-2a35fdf043af.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -17833,7 +17833,7 @@
         },
         {
             "id": "bf544e3b-73a3-5646-a91e-09c6a3b3c570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c48ce9d-4158-421a-9a4f-50159188ef1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c48ce9d-4158-421a-9a4f-50159188ef1f.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -17871,7 +17871,7 @@
         },
         {
             "id": "8899ac0b-2438-507f-8e8b-acbbf2a6d015",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7912ef76-6a99-4018-9fd1-4dff5ad92285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7912ef76-6a99-4018-9fd1-4dff5ad92285.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -17907,7 +17907,7 @@
         },
         {
             "id": "15e7a2dd-2589-54e8-b16b-aeaa169ad47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a91ea06-154c-4d55-b0b3-9c49dbafddc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a91ea06-154c-4d55-b0b3-9c49dbafddc7.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -17943,7 +17943,7 @@
         },
         {
             "id": "3e49d23e-ad4b-523e-9ea4-d9711aecf356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116e94fb-c9cc-4ebe-a64b-51e88f938a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/116e94fb-c9cc-4ebe-a64b-51e88f938a58.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -17979,7 +17979,7 @@
         },
         {
             "id": "ee70da02-f9f1-5292-9fcc-5b3d6363f65d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99645e5-4125-4f23-8911-0a027a0ac9fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f99645e5-4125-4f23-8911-0a027a0ac9fe.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -18015,7 +18015,7 @@
         },
         {
             "id": "8381fd0c-f174-535b-911f-050f4f7d051d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef29d1d1-10a1-4aa3-9e20-342396b8e126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef29d1d1-10a1-4aa3-9e20-342396b8e126.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -18051,7 +18051,7 @@
         },
         {
             "id": "91b5e3f1-553b-5a5a-b67b-0599741711d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba9e2-9b21-49da-bd53-9364517f2c95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1ba9e2-9b21-49da-bd53-9364517f2c95.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -18087,7 +18087,7 @@
         },
         {
             "id": "44058c68-eea4-5098-8036-b4d29f40d049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4057379b-f886-486f-830a-e8f2f42afe6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4057379b-f886-486f-830a-e8f2f42afe6a.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -18123,7 +18123,7 @@
         },
         {
             "id": "3992500d-b29a-5f72-9a77-abf0aa1d6dc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37d8206-22a1-436c-bb1a-62cdd9f8a266.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b37d8206-22a1-436c-bb1a-62cdd9f8a266.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -18159,7 +18159,7 @@
         },
         {
             "id": "3ee8bc93-84bc-5cfd-94d6-43ef9c8e0a22",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550ed1d8-916a-4a5b-9672-1b0756620e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/550ed1d8-916a-4a5b-9672-1b0756620e4a.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -18195,7 +18195,7 @@
         },
         {
             "id": "6c4cd391-60e8-5263-aedc-e205605ba455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a31283-7174-4b7e-9f29-b04bef0b9309.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a31283-7174-4b7e-9f29-b04bef0b9309.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -18231,7 +18231,7 @@
         },
         {
             "id": "b5b1b778-e2b9-5a4f-98e9-a31e8392cffd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c649c4-b9e9-4aa5-8b82-a8e1f9f998e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0c649c4-b9e9-4aa5-8b82-a8e1f9f998e0.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -18267,7 +18267,7 @@
         },
         {
             "id": "bc0bda20-4719-5b02-ac27-c4c17cbd282e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c79de71-98f9-4807-8b01-915b5ad393e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c79de71-98f9-4807-8b01-915b5ad393e6.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -18303,7 +18303,7 @@
         },
         {
             "id": "3977c330-4f16-5138-819e-20db693ea5b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6477d-d1f5-4890-a1ba-abdbd8094b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7d6477d-d1f5-4890-a1ba-abdbd8094b23.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -18341,7 +18341,7 @@
         },
         {
             "id": "0d0c28bc-362b-5a51-927e-b93af5d91fba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce230228-caed-4f1a-8197-507056d6e417.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce230228-caed-4f1a-8197-507056d6e417.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -18379,7 +18379,7 @@
         },
         {
             "id": "77be96bc-bfa0-568a-9293-799dfedbdaf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ef8f63-1224-495e-ae0b-7789c2b94e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98ef8f63-1224-495e-ae0b-7789c2b94e3a.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -18413,7 +18413,7 @@
         },
         {
             "id": "e97dda3d-a485-5ea8-b252-c3b9787a972a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b2c09d-d317-4f0e-a544-71ee80524201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8b2c09d-d317-4f0e-a544-71ee80524201.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -18448,7 +18448,7 @@
         },
         {
             "id": "4a8386b9-3122-5e5b-ba21-e48cfa0da3e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bcda96-890c-4f27-b85d-7d0c7e56e641.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6bcda96-890c-4f27-b85d-7d0c7e56e641.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -18486,7 +18486,7 @@
         },
         {
             "id": "dea98583-83da-523e-8891-5ff3a66b03b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f25c02e-9d38-4c4c-8b00-183052fb2307.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f25c02e-9d38-4c4c-8b00-183052fb2307.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -18524,7 +18524,7 @@
         },
         {
             "id": "abfb48ff-b5c3-5708-bfd3-064ad5997354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d8924a-3792-4c47-8b2c-72e8358266d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66d8924a-3792-4c47-8b2c-72e8358266d5.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -18559,7 +18559,7 @@
         },
         {
             "id": "4679ae78-6f8b-58bc-8b42-95f7fdd58850",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7651beb-c2d7-4547-9fe5-ac27f711aaa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7651beb-c2d7-4547-9fe5-ac27f711aaa2.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -18594,7 +18594,7 @@
         },
         {
             "id": "96d4a284-6b56-5466-accf-6b4608cd38e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aa5ec4-d5ea-41a0-acdc-703f03491d10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6aa5ec4-d5ea-41a0-acdc-703f03491d10.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -18632,7 +18632,7 @@
         },
         {
             "id": "8113e3ec-2829-52b9-b291-f76733b1618d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec64c304-3233-4004-90e4-a9592ea633da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec64c304-3233-4004-90e4-a9592ea633da.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -18667,7 +18667,7 @@
         },
         {
             "id": "f478b510-7c7d-5d59-9f5c-c36d65ee422c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a631d41c-e4a6-4fc1-8ea7-9b9a5b5509b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a631d41c-e4a6-4fc1-8ea7-9b9a5b5509b4.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -18702,7 +18702,7 @@
         },
         {
             "id": "f75f4935-00a3-5481-8d78-d6ac831ae583",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03fd757-9997-497c-a572-b8744dd94681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c03fd757-9997-497c-a572-b8744dd94681.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -18737,7 +18737,7 @@
         },
         {
             "id": "f0b03496-7882-5df0-bd4d-0bfad98d60eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a44a44-491a-4184-8db6-5e914f017c3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3a44a44-491a-4184-8db6-5e914f017c3a.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -18772,7 +18772,7 @@
         },
         {
             "id": "8ff395ef-db97-5f71-825a-6fe5ebd17ecc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80569a69-7a6b-41f4-a9c4-d970dae1bd51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80569a69-7a6b-41f4-a9c4-d970dae1bd51.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -18807,7 +18807,7 @@
         },
         {
             "id": "b41b663e-171e-5bfc-9926-ad787bbf0b6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad53306-7abf-46bb-a0d7-a87df7b40c1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ad53306-7abf-46bb-a0d7-a87df7b40c1b.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -18842,7 +18842,7 @@
         },
         {
             "id": "8a4852e3-4ea6-51f3-9cc4-6da0ee1adeb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fd96c-fb06-44d1-b8e3-f06ecdaa484c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e0fd96c-fb06-44d1-b8e3-f06ecdaa484c.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -18877,7 +18877,7 @@
         },
         {
             "id": "e8da3b28-a20c-59a9-ba95-fcd0122f1e47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d06112-9d7d-4d1b-8b2d-b948b13035d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2d06112-9d7d-4d1b-8b2d-b948b13035d6.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -18909,7 +18909,7 @@
         },
         {
             "id": "e7892e37-e97e-5738-917a-c0725972e89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fad548-ce37-43a5-98b1-e15ff04daa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2fad548-ce37-43a5-98b1-e15ff04daa30.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -18947,7 +18947,7 @@
         },
         {
             "id": "01aa2274-8671-51fb-b4ff-bfdec3a44df1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63161520-b60d-4cea-91c3-a1b83ce8e292.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63161520-b60d-4cea-91c3-a1b83ce8e292.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -18982,7 +18982,7 @@
         },
         {
             "id": "1fd82ed2-0fd0-567a-b84b-a18a9c33e29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a3f9b0-9f83-45b7-9697-3fe19f31a79e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19a3f9b0-9f83-45b7-9697-3fe19f31a79e.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -19017,7 +19017,7 @@
         },
         {
             "id": "51b8cdcd-c97b-577f-a3a2-c6ddb1f819e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56b25f-1b83-4a11-8b88-c32dc1eb0cd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a56b25f-1b83-4a11-8b88-c32dc1eb0cd5.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -19052,7 +19052,7 @@
         },
         {
             "id": "b31d34d7-8080-5648-8b82-b603514c1d4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2829b-6f48-418b-a4ca-000d3241c5ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2c2829b-6f48-418b-a4ca-000d3241c5ca.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -19087,7 +19087,7 @@
         },
         {
             "id": "4519d410-e1bd-5b5f-97a5-5b37684acbb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82f79d0-5eeb-4247-8625-91c770555409.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d82f79d0-5eeb-4247-8625-91c770555409.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -19122,7 +19122,7 @@
         },
         {
             "id": "3b465a24-6574-5ae1-940a-006385014f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df66186f-b287-4d5c-9d8a-b1683f947846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df66186f-b287-4d5c-9d8a-b1683f947846.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -19157,7 +19157,7 @@
         },
         {
             "id": "f99ea2f0-a313-5e8e-9759-0888654eb89e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59cd65b-f86f-4b13-b89e-000768c80cfe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e59cd65b-f86f-4b13-b89e-000768c80cfe.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -19192,7 +19192,7 @@
         },
         {
             "id": "69b53f6e-8eaa-5646-be4d-1e8e264d5d88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8483fc-a4f8-4c61-8913-6d1b634b14c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c8483fc-a4f8-4c61-8913-6d1b634b14c2.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -19227,7 +19227,7 @@
         },
         {
             "id": "93341cf1-3557-5686-9ea7-247c376d7b6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014281b4-172c-4c4e-b859-4ca9ba110cce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014281b4-172c-4c4e-b859-4ca9ba110cce.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -19262,7 +19262,7 @@
         },
         {
             "id": "40a8fc04-6298-555a-9025-f06817ba8c31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05da6e31-2aa1-4ed2-94f8-c611252f2242.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05da6e31-2aa1-4ed2-94f8-c611252f2242.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -19300,7 +19300,7 @@
         },
         {
             "id": "958f228a-90f0-535b-b592-8efcd8a5aac5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ccf65-7f40-420c-b55d-4d4d0fe187c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac7ccf65-7f40-420c-b55d-4d4d0fe187c1.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -19335,7 +19335,7 @@
         },
         {
             "id": "6c311f87-46ef-5e50-b93b-906d2de623e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93434d1f-ff3c-45d6-8162-982244839f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93434d1f-ff3c-45d6-8162-982244839f53.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -19370,7 +19370,7 @@
         },
         {
             "id": "bad195d8-0d7c-5f6a-9e13-7d669a64e73d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d81e162-1c69-4b5f-b68a-1fbb10443db3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d81e162-1c69-4b5f-b68a-1fbb10443db3.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -19405,7 +19405,7 @@
         },
         {
             "id": "ede1dcd3-83aa-5c67-95a5-cbac543d1ed6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88e1616-e480-46c3-9aa7-dad032dde577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d88e1616-e480-46c3-9aa7-dad032dde577.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -19443,7 +19443,7 @@
         },
         {
             "id": "6e676e1f-f4a8-56de-8042-7c2a9b590268",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ac15ec-0d93-43a1-8e18-97df3c0dcdf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39ac15ec-0d93-43a1-8e18-97df3c0dcdf6.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -19478,7 +19478,7 @@
         },
         {
             "id": "5e1211ff-7ceb-5ee2-bc90-7f39e81dcb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc5afd8-0607-4f35-80e8-764643607f88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc5afd8-0607-4f35-80e8-764643607f88.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -19513,7 +19513,7 @@
         },
         {
             "id": "28251081-3951-5cfc-b70e-4657a7d8c8a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9acaf17-b6bf-44b1-9062-8593668b47a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9acaf17-b6bf-44b1-9062-8593668b47a2.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -19548,7 +19548,7 @@
         },
         {
             "id": "49abd9e5-ec57-538b-993f-0889be1330e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebe189-c508-4174-b7d6-80cd01956057.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cebe189-c508-4174-b7d6-80cd01956057.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -19586,7 +19586,7 @@
         },
         {
             "id": "d9c260eb-e889-522a-8275-3ca90a457132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57bb0a6-56f5-4f55-b7c0-0d1323f1e435.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b57bb0a6-56f5-4f55-b7c0-0d1323f1e435.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -19621,7 +19621,7 @@
         },
         {
             "id": "f60efff3-205a-523a-8596-56adf755b24c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b506dd0-460c-4023-a6f7-e61345fe0ebe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b506dd0-460c-4023-a6f7-e61345fe0ebe.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -19659,7 +19659,7 @@
         },
         {
             "id": "1a35af6c-0398-53c0-9451-6f82cabeadb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e7eb01-4ecc-4260-bcc2-6230c0e42586.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18e7eb01-4ecc-4260-bcc2-6230c0e42586.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -19694,7 +19694,7 @@
         },
         {
             "id": "ed27c57f-3c58-5b7f-ab8c-a3e625e48604",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eac1a3-afc7-43ff-86f1-dce4fb1bc1e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08eac1a3-afc7-43ff-86f1-dce4fb1bc1e3.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -19729,7 +19729,7 @@
         },
         {
             "id": "fc9b154d-fe4e-5a31-9652-8fd47e3040bc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e070da-8b2b-4ddc-9b14-91790d7cb955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1e070da-8b2b-4ddc-9b14-91790d7cb955.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -19767,7 +19767,7 @@
         },
         {
             "id": "cdc260ba-9b38-5e67-915c-fa643c203a91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7f70a-31c6-4094-914f-ecb8109a0cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47c7f70a-31c6-4094-914f-ecb8109a0cfa.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -19802,7 +19802,7 @@
         },
         {
             "id": "31ad4aca-b90d-5526-b7b3-84574932080c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1974c2-f125-450f-86d4-d235a382ee2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e1974c2-f125-450f-86d4-d235a382ee2f.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -19837,7 +19837,7 @@
         },
         {
             "id": "39950cc4-80b6-527e-bd5d-b7743a700ca4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686dd8f1-9c21-45b9-8db0-4b0da9505f2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/686dd8f1-9c21-45b9-8db0-4b0da9505f2a.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -19872,7 +19872,7 @@
         },
         {
             "id": "ec3625d1-3b80-54dc-9c8a-3292f9f4c9db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af441250-94d9-4bf6-96e2-c79c76214f47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af441250-94d9-4bf6-96e2-c79c76214f47.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -19907,7 +19907,7 @@
         },
         {
             "id": "0db37645-f244-5aa8-bd22-79667627a8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227746a8-8816-4488-ab3e-20566a42970b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227746a8-8816-4488-ab3e-20566a42970b.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -19945,7 +19945,7 @@
         },
         {
             "id": "2f20ad55-b060-5c82-add6-8a1650574a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b9443b-60d6-4afb-b365-432184b4d79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/94b9443b-60d6-4afb-b365-432184b4d79a.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -19980,7 +19980,7 @@
         },
         {
             "id": "59d67f61-8903-5779-b9c9-944c2d246c96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3f19c8-ae36-4538-884f-89c75fbd6180.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e3f19c8-ae36-4538-884f-89c75fbd6180.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -20015,7 +20015,7 @@
         },
         {
             "id": "c31afb2b-bcf0-5e88-bb57-ad7c58b90acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c055c1-a81a-4d6e-9776-95fd0d4b0f0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38c055c1-a81a-4d6e-9776-95fd0d4b0f0c.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -20050,7 +20050,7 @@
         },
         {
             "id": "8d390203-57c9-503e-a1da-34bc336f28af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c473c770-9cd9-4151-b055-9875d5f13932.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c473c770-9cd9-4151-b055-9875d5f13932.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -20085,7 +20085,7 @@
         },
         {
             "id": "ddfcdc57-75b3-564f-bba6-cac6474bafde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803b87ea-8927-4056-92a2-3e47e55b698d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/803b87ea-8927-4056-92a2-3e47e55b698d.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -20120,7 +20120,7 @@
         },
         {
             "id": "39d70d95-58fb-58d5-af45-90291554b5e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68772d59-d3ca-4872-b2f8-311b17b936aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68772d59-d3ca-4872-b2f8-311b17b936aa.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -20155,7 +20155,7 @@
         },
         {
             "id": "8e48ac48-3590-5a96-80db-09d11b76a270",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30e4141-57d8-4096-986d-4e7f4854655c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30e4141-57d8-4096-986d-4e7f4854655c.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -20190,7 +20190,7 @@
         },
         {
             "id": "b26b230a-b5f8-5600-bfc0-d0693d1411c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd04e0f-8016-44aa-bb74-d275695ff811.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd04e0f-8016-44aa-bb74-d275695ff811.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -20225,7 +20225,7 @@
         },
         {
             "id": "e543b30a-16b9-5100-a826-6dca729d9ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490e699-a796-42c9-87d1-90673644a379.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3490e699-a796-42c9-87d1-90673644a379.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -20257,7 +20257,7 @@
         },
         {
             "id": "2c12835e-afbd-533b-a915-3a0253b9c1a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25a6cfd-61a0-454e-910b-5adfdad839c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25a6cfd-61a0-454e-910b-5adfdad839c2.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -20292,7 +20292,7 @@
         },
         {
             "id": "7d43b30a-d112-5f27-b20c-b808fa96ac35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7975a1d1-191e-4870-a2dc-6d852d7c2984.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7975a1d1-191e-4870-a2dc-6d852d7c2984.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -20324,7 +20324,7 @@
         },
         {
             "id": "c90050c4-ad16-5ff8-84cb-0a47d98dc65e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069e7426-07c1-4a48-8e70-894905c10f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/069e7426-07c1-4a48-8e70-894905c10f0d.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -20359,7 +20359,7 @@
         },
         {
             "id": "c4ea1528-346c-53f5-a0d4-b40adcd77b48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f305be6-c51d-423d-8283-39e3ffc2d790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f305be6-c51d-423d-8283-39e3ffc2d790.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -20401,7 +20401,7 @@
         },
         {
             "id": "fd679f3b-f90d-51e9-b5b3-952704c3cd0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59b2b4-34d8-4add-a187-61677c7a3b0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb59b2b4-34d8-4add-a187-61677c7a3b0d.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -20444,7 +20444,7 @@
         },
         {
             "id": "1f7c38df-ae27-58de-b44a-85d843ee0d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51905ce-9146-46e4-8d7f-643843d48edb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f51905ce-9146-46e4-8d7f-643843d48edb.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -20488,7 +20488,7 @@
         },
         {
             "id": "8aa00a47-210c-5fe9-9f78-e2ada7f3e6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34eebf0-36be-4632-8687-cbe35eedcc13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b34eebf0-36be-4632-8687-cbe35eedcc13.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -20527,7 +20527,7 @@
         },
         {
             "id": "3a42e0c7-e101-5d42-886d-057b0e271875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f884ca5-76b7-4eb8-857e-d347f3e70b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f884ca5-76b7-4eb8-857e-d347f3e70b1c.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -20570,7 +20570,7 @@
         },
         {
             "id": "108d4f21-52cb-5ef5-9c8c-44cc4e5395d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a8776-e1bd-47c0-bdb9-cb120424e76d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed3a8776-e1bd-47c0-bdb9-cb120424e76d.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -20619,7 +20619,7 @@
         },
         {
             "id": "b9d606df-af8b-5708-b7a2-8b2374e156e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc49c0-1a6f-4569-a0eb-1a11dbb56ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56cc49c0-1a6f-4569-a0eb-1a11dbb56ea6.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -20664,7 +20664,7 @@
         },
         {
             "id": "be33cee0-d263-5403-a752-a5679856425a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b13f4ef-c140-4401-a2d2-c80af2514539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b13f4ef-c140-4401-a2d2-c80af2514539.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -20709,7 +20709,7 @@
         },
         {
             "id": "54034287-361c-5e3d-9b43-70623b53f250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7815e26-b547-47a9-90e3-d1242407b9ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7815e26-b547-47a9-90e3-d1242407b9ce.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -20754,7 +20754,7 @@
         },
         {
             "id": "2d770e4d-c64b-528a-834c-bb30cb60a530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b202ad-3aca-4d50-a235-caf5ddcf99ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b202ad-3aca-4d50-a235-caf5ddcf99ee.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -20799,7 +20799,7 @@
         },
         {
             "id": "f0486636-5fef-55c4-9219-8ffd62a7c57b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb40a56-80bd-4566-a005-2b385865b1dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fb40a56-80bd-4566-a005-2b385865b1dd.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -20844,7 +20844,7 @@
         },
         {
             "id": "4311caa5-a886-542e-a01a-b7f7ce99133f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106cb2c6-d282-4ff0-86b2-3c680973ebe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/106cb2c6-d282-4ff0-86b2-3c680973ebe1.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -20891,7 +20891,7 @@
         },
         {
             "id": "a05e0525-cc9f-5dbc-9cdc-512ed0a25942",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1705e68d-4649-4c51-b34a-2e18498b72f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1705e68d-4649-4c51-b34a-2e18498b72f2.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -20937,7 +20937,7 @@
         },
         {
             "id": "93d24e7c-d671-5c8e-9796-7eb70d3b7020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf2d71d-f662-470d-bd99-68e69ea516d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddf2d71d-f662-470d-bd99-68e69ea516d5.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -20982,7 +20982,7 @@
         },
         {
             "id": "bc8e7ec5-ade7-5b21-8e76-db1d91ff0765",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf93dd13-03f4-481c-9ad0-4808a4d679b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf93dd13-03f4-481c-9ad0-4808a4d679b2.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -21026,7 +21026,7 @@
         },
         {
             "id": "d062485b-d840-52ee-bd54-50ff693a5db6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c4675f-1fcc-49ea-a43f-8540140689c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63c4675f-1fcc-49ea-a43f-8540140689c8.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -21061,7 +21061,7 @@
         },
         {
             "id": "445698b3-85b3-5acf-b3a2-60a3640f3868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb150502-96ed-44c0-ae03-2fe0a3cbb0e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb150502-96ed-44c0-ae03-2fe0a3cbb0e9.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -21095,7 +21095,7 @@
         },
         {
             "id": "3faac8a8-e74d-5877-bd63-8d3bcdbdf2d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b487e0b-7824-475c-ae58-d7852789e213.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b487e0b-7824-475c-ae58-d7852789e213.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -21141,7 +21141,7 @@
         },
         {
             "id": "53c5a3b9-a1fc-5ed7-9ea2-f860bf1049e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a040be4-4ffb-49f6-82fe-24140aa6be19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a040be4-4ffb-49f6-82fe-24140aa6be19.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -21186,7 +21186,7 @@
         },
         {
             "id": "0b59aee3-3ca1-5339-87d5-accf42fb9a85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdf625-d257-48b8-8714-f49d99135706.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbcdf625-d257-48b8-8714-f49d99135706.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -21232,7 +21232,7 @@
         },
         {
             "id": "cd916af2-120b-552a-b521-7f7fa3388662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eca0143-5ba3-484d-b177-b31e1a1c90b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3eca0143-5ba3-484d-b177-b31e1a1c90b6.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -21277,7 +21277,7 @@
         },
         {
             "id": "1d166839-8c5f-5e73-a65e-832b46d082a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc91319-2905-44a2-a339-5ff518e0bd02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cc91319-2905-44a2-a339-5ff518e0bd02.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -21323,7 +21323,7 @@
         },
         {
             "id": "bd18bd1b-6edd-5a4a-a534-9a14102a80f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ef0850-a822-43b7-88fa-a3756c1b7675.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31ef0850-a822-43b7-88fa-a3756c1b7675.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -21368,7 +21368,7 @@
         },
         {
             "id": "0e3f2f87-ebf2-5040-89be-0700f4aa0146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10414d81-177d-43f4-9381-0d10ac51507f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10414d81-177d-43f4-9381-0d10ac51507f.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -21415,7 +21415,7 @@
         },
         {
             "id": "7cc0cc00-41fa-5c25-8f95-b24097fedf62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10611b-38a0-4947-a36b-f5503584d59e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf10611b-38a0-4947-a36b-f5503584d59e.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -21461,7 +21461,7 @@
         },
         {
             "id": "7375d156-a91c-5307-9f8e-36995f1db164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf1e0f5-0358-4a90-bc00-967c5967ff8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf1e0f5-0358-4a90-bc00-967c5967ff8f.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -21507,7 +21507,7 @@
         },
         {
             "id": "60557799-4162-57f3-ac76-22aefa7a2723",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90007d91-554e-4613-8be1-4506fd4773bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90007d91-554e-4613-8be1-4506fd4773bb.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -21552,7 +21552,7 @@
         },
         {
             "id": "ba8f9e6a-e0ea-5e6e-8002-f54f12c29194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0566c86-b433-4c9a-b8b3-96ff6183ddb5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0566c86-b433-4c9a-b8b3-96ff6183ddb5.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -21598,7 +21598,7 @@
         },
         {
             "id": "8e9b5c06-cb99-58d6-9822-922b69e4d221",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c934f0d6-b67a-4554-9061-720064a13d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c934f0d6-b67a-4554-9061-720064a13d99.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -21643,7 +21643,7 @@
         },
         {
             "id": "f51cf188-81a7-57fd-935f-f497c0f5fca1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec9e2a0-8eff-494c-b4a3-8bf60a1dedc8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cec9e2a0-8eff-494c-b4a3-8bf60a1dedc8.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -21689,7 +21689,7 @@
         },
         {
             "id": "fdd44187-0300-5af1-9c59-afad5c5955f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9499f326-3ebe-4544-8dc3-30b7e16d1d89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/9499f326-3ebe-4544-8dc3-30b7e16d1d89.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -21734,7 +21734,7 @@
         },
         {
             "id": "8b3275a3-cb63-5026-a7f4-bf423fc62b8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449500a1-c143-469a-a1dd-3e0c278fa28b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/449500a1-c143-469a-a1dd-3e0c278fa28b.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -21780,7 +21780,7 @@
         },
         {
             "id": "f4feadc1-3a2e-5599-b955-00513fa12e62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd796f8-4d34-4a92-b4e2-40bfbe741846.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cd796f8-4d34-4a92-b4e2-40bfbe741846.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -21825,7 +21825,7 @@
         },
         {
             "id": "5fb2da3e-5aa2-563c-aec2-c9b9014f29db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1040a5-4a3b-4821-9c29-e9347f2e47d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca1040a5-4a3b-4821-9c29-e9347f2e47d6.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -21871,7 +21871,7 @@
         },
         {
             "id": "e58d4937-d6fb-54c1-9028-b487a4579f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe06db4-5e06-4504-b8a7-03021a695730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe06db4-5e06-4504-b8a7-03021a695730.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -21916,7 +21916,7 @@
         },
         {
             "id": "74e469da-8c09-5563-bd42-c2dbd05a3aac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d6e52-e6ba-4268-99ad-e22345866a51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302d6e52-e6ba-4268-99ad-e22345866a51.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -21963,7 +21963,7 @@
         },
         {
             "id": "5a401fd9-02d6-59b9-9cf8-65f4d386ede1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520b89b6-53f5-4cad-b842-9dcc0a46224e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/520b89b6-53f5-4cad-b842-9dcc0a46224e.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -22009,7 +22009,7 @@
         },
         {
             "id": "f5c46be1-7e6b-5e4e-bb34-51cd7dbe2efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fbb90d-0338-4673-8c2c-65a500662b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8fbb90d-0338-4673-8c2c-65a500662b01.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -22055,7 +22055,7 @@
         },
         {
             "id": "7d8d18d0-c520-52d0-b211-033755419d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20991b-bab8-4fc7-8d66-fca55ff341db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd20991b-bab8-4fc7-8d66-fca55ff341db.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -22100,7 +22100,7 @@
         },
         {
             "id": "3fb6af06-725c-5db8-9e3d-22200602aed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08239a3-ed5a-4345-8772-6bcbed164d7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08239a3-ed5a-4345-8772-6bcbed164d7b.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -22146,7 +22146,7 @@
         },
         {
             "id": "dcee069f-496b-50a5-ba50-952cfa966498",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0ca0-9b2d-4c27-9ecd-0b2a7661952e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/822d0ca0-9b2d-4c27-9ecd-0b2a7661952e.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -22191,7 +22191,7 @@
         },
         {
             "id": "a4072135-41e9-54e1-8905-4a853e6cf9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d71fe21-04ac-473c-9b93-1b4e129b8155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d71fe21-04ac-473c-9b93-1b4e129b8155.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -22238,7 +22238,7 @@
         },
         {
             "id": "4f3671e6-6faa-533a-9ba9-f05f5bf09e8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25da713c-55c0-4842-b199-5659028cda74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25da713c-55c0-4842-b199-5659028cda74.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -22284,7 +22284,7 @@
         },
         {
             "id": "d7563ec5-9258-5552-a697-1f68f6ce6a6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b828e-eaf6-4599-925a-64e59201de6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba2b828e-eaf6-4599-925a-64e59201de6e.jpg?1",
             "name": "Past in Flames",
             "text": "",
             "colours": [
@@ -22315,7 +22315,7 @@
         },
         {
             "id": "a14698b3-9a83-51ec-8e37-9127fc209716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0615cc-860a-4fed-9e9c-4377ba8ed22a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac0615cc-860a-4fed-9e9c-4377ba8ed22a.jpg?1",
             "name": "Amy's Home",
             "text": "",
             "colours": [],
@@ -22344,7 +22344,7 @@
         },
         {
             "id": "82e9fcb7-2e78-5cf3-aff0-c4aed5dc8e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc61f60-2f9d-4f67-8390-62873b4b8ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cc61f60-2f9d-4f67-8390-62873b4b8ddb.jpg?1",
             "name": "Antarctic Research Base",
             "text": "",
             "colours": [],
@@ -22373,7 +22373,7 @@
         },
         {
             "id": "a4030564-a0b0-5672-b741-b08a58fdec83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855978a6-c81c-4e5e-a34f-41a54fef0c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/855978a6-c81c-4e5e-a34f-41a54fef0c10.jpg?1",
             "name": "Aplan Mortarium",
             "text": "",
             "colours": [],
@@ -22402,7 +22402,7 @@
         },
         {
             "id": "09a19712-f09f-50a9-be4e-1c19e4a113da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a068875e-9294-403d-a6db-15092b6c42d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a068875e-9294-403d-a6db-15092b6c42d3.jpg?1",
             "name": "Bad Wolf Bay",
             "text": "",
             "colours": [],
@@ -22431,7 +22431,7 @@
         },
         {
             "id": "6bbcf9e2-3e41-5879-9608-7498f895873f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb62bd5-79e5-4af0-aafd-c1bd53765c67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8bb62bd5-79e5-4af0-aafd-c1bd53765c67.jpg?1",
             "name": "Besieged Viking Village",
             "text": "",
             "colours": [],
@@ -22460,7 +22460,7 @@
         },
         {
             "id": "635eb13f-9918-56df-8f2e-afc012ee1f44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e3ec5a-4bd5-452f-873a-3801253754dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22e3ec5a-4bd5-452f-873a-3801253754dd.jpg?1",
             "name": "Bowie Base One",
             "text": "",
             "colours": [],
@@ -22489,7 +22489,7 @@
         },
         {
             "id": "38be451d-cfa3-52e5-81e8-1e20077ec531",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddc6d0-50cc-4914-a6f2-00fb93d4402a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ddc6d0-50cc-4914-a6f2-00fb93d4402a.jpg?1",
             "name": "Caught in a Parallel Universe",
             "text": "",
             "colours": [],
@@ -22516,7 +22516,7 @@
         },
         {
             "id": "e62e352e-aaf8-50a3-9174-6be4483a2b5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74560139-0870-4184-887b-72d67c57b6ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74560139-0870-4184-887b-72d67c57b6ed.jpg?1",
             "name": "The Cave of Skulls",
             "text": "",
             "colours": [],
@@ -22545,7 +22545,7 @@
         },
         {
             "id": "b7d109e1-cd35-5004-ab04-2bbd909b2b92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6bd680-18c6-46d9-b747-825fb0fee6dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b6bd680-18c6-46d9-b747-825fb0fee6dd.jpg?1",
             "name": "The Cheetah Planet",
             "text": "",
             "colours": [],
@@ -22574,7 +22574,7 @@
         },
         {
             "id": "78630b32-b5c9-581b-9918-10c854642c89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f82f5b7-b4b9-489a-bbd7-98faaa566515.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f82f5b7-b4b9-489a-bbd7-98faaa566515.jpg?1",
             "name": "City of the Daleks",
             "text": "",
             "colours": [],
@@ -22603,7 +22603,7 @@
         },
         {
             "id": "bafa58fe-881e-5f87-bc9a-0924d8edc785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e09673-c7f0-4377-abbd-b1ea4922d4b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82e09673-c7f0-4377-abbd-b1ea4922d4b3.jpg?1",
             "name": "Coal Hill School",
             "text": "",
             "colours": [],
@@ -22632,7 +22632,7 @@
         },
         {
             "id": "a739436b-6338-5d81-8bdc-3884a67d46c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd9d2c-f1d3-4dbf-8101-e4fab9f42e40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13dd9d2c-f1d3-4dbf-8101-e4fab9f42e40.jpg?1",
             "name": "Dalek Intensive Care",
             "text": "",
             "colours": [],
@@ -22661,7 +22661,7 @@
         },
         {
             "id": "6a4b9a52-0d62-5d43-83bf-8103321dd0d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6193ea-4906-4097-8e30-431220f9e35c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf6193ea-4906-4097-8e30-431220f9e35c.jpg?1",
             "name": "The Dining Car",
             "text": "",
             "colours": [],
@@ -22690,7 +22690,7 @@
         },
         {
             "id": "22418a5b-2b8f-5e3e-8ff3-70a963211917",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c583ab-ad15-436b-9151-8b4d212cbeda.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4c583ab-ad15-436b-9151-8b4d212cbeda.jpg?1",
             "name": "The Doctor's Childhood Barn",
             "text": "",
             "colours": [],
@@ -22719,7 +22719,7 @@
         },
         {
             "id": "98454da5-96a9-59dc-9c7d-829781d33130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2456bb33-6380-4b4d-bf23-7b071fc22be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/2456bb33-6380-4b4d-bf23-7b071fc22be2.jpg?1",
             "name": "The Doctor's Tomb",
             "text": "",
             "colours": [],
@@ -22748,7 +22748,7 @@
         },
         {
             "id": "7df1c7d2-8342-5be5-ba5f-9687544d85d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdb7dca-017a-49a7-b8de-4a8ccf7ac679.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fdb7dca-017a-49a7-b8de-4a8ccf7ac679.jpg?1",
             "name": "The Drum, Mining Facility",
             "text": "",
             "colours": [],
@@ -22777,7 +22777,7 @@
         },
         {
             "id": "47604611-0a78-5ea8-b0ef-21531a47ce40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05478f9-3a9a-4887-a8e7-63550eaa6030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05478f9-3a9a-4887-a8e7-63550eaa6030.jpg?1",
             "name": "Fixed Point in Time",
             "text": "",
             "colours": [],
@@ -22804,7 +22804,7 @@
         },
         {
             "id": "d51dbcf4-ba7c-5d5e-be6e-68964c1f4d4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb753c00-303d-49f3-ad98-b7772cc4a274.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb753c00-303d-49f3-ad98-b7772cc4a274.jpg?1",
             "name": "Gardens of Tranquil Repose",
             "text": "",
             "colours": [],
@@ -22833,7 +22833,7 @@
         },
         {
             "id": "f84f5164-6029-57cc-a7db-78c3de3e9a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b164271-6438-4135-b7a9-8573c3921052.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b164271-6438-4135-b7a9-8573c3921052.jpg?1",
             "name": "Hotel of Fears",
             "text": "",
             "colours": [],
@@ -22862,7 +22862,7 @@
         },
         {
             "id": "5abd4084-405d-5312-ba65-82fc5461cc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5def75a-f511-42e8-a652-7de4abfbd968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5def75a-f511-42e8-a652-7de4abfbd968.jpg?1",
             "name": "Human-Time Lord Meta-Crisis",
             "text": "",
             "colours": [],
@@ -22889,7 +22889,7 @@
         },
         {
             "id": "464da0d0-dfdf-5efd-a504-7e224c248b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c46b6c1-0c84-4bd3-b317-9b8191ad937e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c46b6c1-0c84-4bd3-b317-9b8191ad937e.jpg?1",
             "name": "Kerblam! Warehouse",
             "text": "",
             "colours": [],
@@ -22918,7 +22918,7 @@
         },
         {
             "id": "813a5a51-d2bb-52c7-8af0-3c39994a090d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45091d2b-d872-4beb-af87-7675aaf0c2c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45091d2b-d872-4beb-af87-7675aaf0c2c8.jpg?1",
             "name": "Lake Silencio",
             "text": "",
             "colours": [],
@@ -22947,7 +22947,7 @@
         },
         {
             "id": "3cb4628c-99d6-5758-a937-1ebbadbf099a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cd9db0-b417-42e8-b3be-00fdc9330014.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3cd9db0-b417-42e8-b3be-00fdc9330014.jpg?1",
             "name": "The Lux Foundation Library",
             "text": "",
             "colours": [],
@@ -22976,7 +22976,7 @@
         },
         {
             "id": "24e5c16d-4607-5cb3-bdfc-908d6c2a3a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c343b9dd-edce-46ee-bdd6-f240cf061d59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c343b9dd-edce-46ee-bdd6-f240cf061d59.jpg?1",
             "name": "The Matrix of Time",
             "text": "",
             "colours": [],
@@ -23005,7 +23005,7 @@
         },
         {
             "id": "97833a41-cc53-514a-94d7-d67156193e1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6728e1-12f0-40a7-90f9-520f3572b190.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba6728e1-12f0-40a7-90f9-520f3572b190.jpg?1",
             "name": "Mondassian Colony Ship",
             "text": "",
             "colours": [],
@@ -23034,7 +23034,7 @@
         },
         {
             "id": "70f88220-9341-5bf2-915e-a3aa7f18b8f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715df92-e504-4844-9d74-6f4965fd32ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b715df92-e504-4844-9d74-6f4965fd32ee.jpg?1",
             "name": "The Moonbase",
             "text": "",
             "colours": [],
@@ -23063,7 +23063,7 @@
         },
         {
             "id": "d0695847-8740-5850-83b8-ebc114c2d96f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185dfce-d3ad-4509-b356-f6750d7c6a09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185dfce-d3ad-4509-b356-f6750d7c6a09.jpg?1",
             "name": "New New York",
             "text": "",
             "colours": [],
@@ -23092,7 +23092,7 @@
         },
         {
             "id": "4be7f5b0-0dca-5626-beab-f5aee3d6b68f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6489955c-1571-41dd-9419-5c071a8b3e30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6489955c-1571-41dd-9419-5c071a8b3e30.jpg?1",
             "name": "North Pole Research Base",
             "text": "",
             "colours": [],
@@ -23121,7 +23121,7 @@
         },
         {
             "id": "f2d459d3-7028-5c73-ba35-7e322cedb434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c9e68-4d5f-4e7f-894b-56dec4081fc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642c9e68-4d5f-4e7f-894b-56dec4081fc7.jpg?1",
             "name": "Ood Sphere",
             "text": "",
             "colours": [],
@@ -23150,7 +23150,7 @@
         },
         {
             "id": "b9083c96-30db-5cfe-96f6-6cda111e4613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549ee7a-276b-45eb-a2c7-f74c85dc6a0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a549ee7a-276b-45eb-a2c7-f74c85dc6a0d.jpg?1",
             "name": "Pompeii",
             "text": "",
             "colours": [],
@@ -23179,7 +23179,7 @@
         },
         {
             "id": "534af165-6b05-5c7d-b0c4-5a9a583c9882",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291478b8-a8f6-4449-8cd8-9d70484d3398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/291478b8-a8f6-4449-8cd8-9d70484d3398.jpg?1",
             "name": "Prime Minister's Cabinet Room",
             "text": "",
             "colours": [],
@@ -23208,7 +23208,7 @@
         },
         {
             "id": "4857443f-7980-5838-9163-a1c6449cfb77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec22c6-4986-45aa-9b6b-8517bbbaed4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8aec22c6-4986-45aa-9b6b-8517bbbaed4e.jpg?1",
             "name": "The Pyramid of Mars",
             "text": "",
             "colours": [],
@@ -23237,7 +23237,7 @@
         },
         {
             "id": "edaa95c4-4a8c-58bb-9182-4721a7e13b9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30f88bd-426a-48fb-a921-c7c5831120bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b30f88bd-426a-48fb-a921-c7c5831120bd.jpg?1",
             "name": "Singing Towers of Darillium",
             "text": "",
             "colours": [],
@@ -23266,7 +23266,7 @@
         },
         {
             "id": "a200ec7c-6c36-5bd2-b3f4-6b96c30aa760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84933e48-8b10-4ccf-a7e8-140fbb9c0c9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84933e48-8b10-4ccf-a7e8-140fbb9c0c9b.jpg?1",
             "name": "Spectrox Mines",
             "text": "",
             "colours": [],
@@ -23295,7 +23295,7 @@
         },
         {
             "id": "6570ab5c-4582-5b8a-8072-11340f966e53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665c85f-f564-47fe-a123-4e5a70e179d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665c85f-f564-47fe-a123-4e5a70e179d9.jpg?1",
             "name": "Stormcage Containment Facility",
             "text": "",
             "colours": [],
@@ -23324,7 +23324,7 @@
         },
         {
             "id": "b80c362d-3cba-5db1-9eee-81219c7071d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2d8456-6e3c-42ee-8bd4-215db5fbda98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e2d8456-6e3c-42ee-8bd4-215db5fbda98.jpg?1",
             "name": "TARDIS Bay",
             "text": "",
             "colours": [],
@@ -23353,7 +23353,7 @@
         },
         {
             "id": "6b313e3f-3c83-55f2-a984-eea562169f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75481e04-ab27-4fdd-b789-4a53ffc92430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75481e04-ab27-4fdd-b789-4a53ffc92430.jpg?1",
             "name": "Temple of Atropos",
             "text": "",
             "colours": [],
@@ -23382,7 +23382,7 @@
         },
         {
             "id": "64f6f47e-3881-5342-9503-e9889d206d7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40732207-291c-4cea-be87-dd4dbb8b6259.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40732207-291c-4cea-be87-dd4dbb8b6259.jpg?1",
             "name": "Two Streams Facility",
             "text": "",
             "colours": [],
@@ -23411,7 +23411,7 @@
         },
         {
             "id": "08873df2-d77b-52bb-adae-3056bcf45bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7ec46f-1499-4c75-8568-d9266a3d1e69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7ec46f-1499-4c75-8568-d9266a3d1e69.jpg?1",
             "name": "UNIT Headquarters",
             "text": "",
             "colours": [],
@@ -23440,7 +23440,7 @@
         },
         {
             "id": "18ff2672-ceda-531f-9608-f7632e79d300",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c04ad-a8b5-453a-aff4-dce743b1c693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e3c04ad-a8b5-453a-aff4-dce743b1c693.jpg?1",
             "name": "Unleash the Flux",
             "text": "",
             "colours": [],
@@ -23467,7 +23467,7 @@
         },
         {
             "id": "cce86856-3691-56b1-924f-90b22e98d89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb0761-820f-43b6-bedc-e6103faf45ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bb0761-820f-43b6-bedc-e6103faf45ea.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -23515,7 +23515,7 @@
         },
         {
             "id": "085184f5-6b60-5886-9f2e-c9daf7440124",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fa1d9-adcb-43b4-bfce-42d9e7530ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f82fa1d9-adcb-43b4-bfce-42d9e7530ac6.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -23561,7 +23561,7 @@
         },
         {
             "id": "e4ef2794-38b9-5642-8540-f9c37a63e296",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef59ead-4854-47ee-b31a-74acccb59728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aef59ead-4854-47ee-b31a-74acccb59728.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -23607,7 +23607,7 @@
         },
         {
             "id": "47adf329-3c8e-5af4-801a-c361a3e647f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d087c16-33f5-44a3-b036-cc6322c7e578.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d087c16-33f5-44a3-b036-cc6322c7e578.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -23653,7 +23653,7 @@
         },
         {
             "id": "25116c7a-8a6c-5c49-b86d-81119d66aaf5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac4cfec-1e78-4877-95a4-43a0a41cc75c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ac4cfec-1e78-4877-95a4-43a0a41cc75c.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -23694,7 +23694,7 @@
         },
         {
             "id": "3ecdf34a-dd1a-5da8-8142-d3ad1f57a59d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d676054-fdd0-44a8-b723-0aac048e6e28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d676054-fdd0-44a8-b723-0aac048e6e28.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -23736,7 +23736,7 @@
         },
         {
             "id": "0ed1379f-9731-56af-804c-9766222e270c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959d587-d723-42ce-9339-b50c307d2882.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8959d587-d723-42ce-9339-b50c307d2882.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -23778,7 +23778,7 @@
         },
         {
             "id": "410bdc3c-5730-5a53-afa9-6c29f11b5a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b81c472-ebf3-4451-9716-242a7962b598.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b81c472-ebf3-4451-9716-242a7962b598.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -23824,7 +23824,7 @@
         },
         {
             "id": "1b923193-d70f-5428-b366-14e1602e2051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9eee5f-29c0-4f2f-996c-1ba23a55ec81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd9eee5f-29c0-4f2f-996c-1ba23a55ec81.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -23860,7 +23860,7 @@
         },
         {
             "id": "059ac58a-a6c9-50fb-92c4-5503c3e9f92c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b98e0b0-ff76-4e71-a266-82e1f1c00e54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b98e0b0-ff76-4e71-a266-82e1f1c00e54.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -23897,7 +23897,7 @@
         },
         {
             "id": "a4713ba5-7741-54ef-aad6-8a876978383b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fde7632-c2ac-45e4-a135-9bdfa135c77d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fde7632-c2ac-45e4-a135-9bdfa135c77d.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -23936,7 +23936,7 @@
         },
         {
             "id": "b1247395-590c-5974-9c25-0f08db81f824",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2ef5dc-77e4-40b9-b724-868c99c28cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de2ef5dc-77e4-40b9-b724-868c99c28cee.jpg?1",
             "name": "Atraxi Warden",
             "text": "",
             "colours": [
@@ -23972,7 +23972,7 @@
         },
         {
             "id": "6acee774-1cae-5bd6-9ec2-8e62b4c86d49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bf2b8-f318-4ec2-b040-00820d8f7832.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc4bf2b8-f318-4ec2-b040-00820d8f7832.jpg?1",
             "name": "Banish to Another Universe",
             "text": "",
             "colours": [
@@ -24005,7 +24005,7 @@
         },
         {
             "id": "64ba0a74-752f-5780-aac3-3d9fbe22b311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f1fd2-ada7-40b7-99bf-73f0e38d71db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8f1fd2-ada7-40b7-99bf-73f0e38d71db.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -24045,7 +24045,7 @@
         },
         {
             "id": "7d6fc082-289c-58a9-b3ef-d1486f9f6c09",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0bda4e-c7f3-4585-980b-d9e2ed9ff64b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c0bda4e-c7f3-4585-980b-d9e2ed9ff64b.jpg?1",
             "name": "The Caves of Androzani",
             "text": "",
             "colours": [
@@ -24080,7 +24080,7 @@
         },
         {
             "id": "84c7ea05-20e4-5076-96e0-b52e0a2be160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae92a01-7bba-4f11-a88d-b34e18363da1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae92a01-7bba-4f11-a88d-b34e18363da1.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -24115,7 +24115,7 @@
         },
         {
             "id": "9d8cc000-91b8-5656-93dc-cf6eb65a6d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee59476-d94d-4c2a-be2c-831c1e89c4f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6ee59476-d94d-4c2a-be2c-831c1e89c4f3.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -24150,7 +24150,7 @@
         },
         {
             "id": "009dc028-259b-5110-b61c-2ce1297e9835",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4b08d-1882-4c8c-abb5-f0e9e5e9292d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f4b08d-1882-4c8c-abb5-f0e9e5e9292d.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -24185,7 +24185,7 @@
         },
         {
             "id": "a7e94205-125b-5877-9698-677239e2a8d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136bd8c3-a54f-40cd-96c9-5023a67e7fd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/136bd8c3-a54f-40cd-96c9-5023a67e7fd6.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -24220,7 +24220,7 @@
         },
         {
             "id": "1b66b35a-bcf0-5da8-a231-7d173c15ec39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853506d3-200c-4829-9032-168e45f120bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/853506d3-200c-4829-9032-168e45f120bf.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -24255,7 +24255,7 @@
         },
         {
             "id": "bd5dea71-7d9a-5646-a596-a866d2f4136c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da19a75-e018-4cde-b2b5-1f7b19e8e41f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9da19a75-e018-4cde-b2b5-1f7b19e8e41f.jpg?1",
             "name": "The Girl in the Fireplace",
             "text": "",
             "colours": [
@@ -24290,7 +24290,7 @@
         },
         {
             "id": "542feaa5-aa01-5ba3-ab6e-a9a762b1d17d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5347feac-78cb-4444-9516-574f7c5526c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5347feac-78cb-4444-9516-574f7c5526c7.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -24330,7 +24330,7 @@
         },
         {
             "id": "5bee9cc2-8be3-5cfc-bc20-531c010ada72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f11d2-f450-4a89-9b3d-20df669e255c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec9f11d2-f450-4a89-9b3d-20df669e255c.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -24370,7 +24370,7 @@
         },
         {
             "id": "b8675248-77e4-593a-8a03-1ce0147edb7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82931c7d-4e6a-44f4-a487-ecfbd287e778.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/82931c7d-4e6a-44f4-a487-ecfbd287e778.jpg?1",
             "name": "The Night of the Doctor",
             "text": "",
             "colours": [
@@ -24405,7 +24405,7 @@
         },
         {
             "id": "b5299c80-b455-500f-82fa-16623d800059",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecb2f79-5e9a-4c38-950e-57be6dfe79d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ecb2f79-5e9a-4c38-950e-57be6dfe79d9.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -24442,7 +24442,7 @@
         },
         {
             "id": "871e6b19-a6f1-51fd-8455-339f9d4c60c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc386fc-eb04-4d5b-b83e-c383112b4815.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc386fc-eb04-4d5b-b83e-c383112b4815.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -24481,7 +24481,7 @@
         },
         {
             "id": "20b2c6d8-9e33-51fd-882c-2f80bf5167e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c2114b-257c-4151-968f-74cb42d1c350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c2114b-257c-4151-968f-74cb42d1c350.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -24521,7 +24521,7 @@
         },
         {
             "id": "99b8077d-a803-523a-87c1-34621e3c68c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbdd3fe-7e86-408f-a787-e9dec27343ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbdd3fe-7e86-408f-a787-e9dec27343ae.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -24560,7 +24560,7 @@
         },
         {
             "id": "963cbf45-2012-5a22-9b50-3f75aabd888c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139dab8d-88f5-4a59-9db1-9b8b81c78822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139dab8d-88f5-4a59-9db1-9b8b81c78822.jpg?1",
             "name": "Trial of a Time Lord",
             "text": "",
             "colours": [
@@ -24595,7 +24595,7 @@
         },
         {
             "id": "55df0c16-192f-5579-8abe-6b806c204d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20d978b-f854-4225-a420-b013889b0783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f20d978b-f854-4225-a420-b013889b0783.jpg?1",
             "name": "The War Games",
             "text": "",
             "colours": [
@@ -24630,7 +24630,7 @@
         },
         {
             "id": "86fec126-6494-5e53-82a6-fa5dc22e6695",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cdfa73-4e56-4364-82eb-744a1680911d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47cdfa73-4e56-4364-82eb-744a1680911d.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -24665,7 +24665,7 @@
         },
         {
             "id": "325d7109-ba59-59a0-804a-1c0dba66c64b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b0534e-b59a-4b90-88f1-de45917556da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63b0534e-b59a-4b90-88f1-de45917556da.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -24705,7 +24705,7 @@
         },
         {
             "id": "4a09684d-2be5-5447-8b5a-09f5e0ff1390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f3de2b-c0ec-4448-9a49-8f41732494b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f3de2b-c0ec-4448-9a49-8f41732494b7.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -24745,7 +24745,7 @@
         },
         {
             "id": "58e74769-ed94-5a94-a709-bf531534174f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc08a16-d2ef-44d2-ae6b-7ff9ce27ef00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc08a16-d2ef-44d2-ae6b-7ff9ce27ef00.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -24780,7 +24780,7 @@
         },
         {
             "id": "eb217b37-6017-5b03-acf7-9c209fb702e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6d87d6-e89c-4b84-b1d0-2aad21cb1c47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b6d87d6-e89c-4b84-b1d0-2aad21cb1c47.jpg?1",
             "name": "An Unearthly Child",
             "text": "",
             "colours": [
@@ -24815,7 +24815,7 @@
         },
         {
             "id": "f336f3b2-b389-5454-b0aa-346f4873aadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aa293d-6354-4285-b692-9f846aef9f5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50aa293d-6354-4285-b692-9f846aef9f5c.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -24854,7 +24854,7 @@
         },
         {
             "id": "c1708300-53cb-579e-a5d6-3a1f4353708c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a3912f-0e03-4c87-884e-955f84dbea6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32a3912f-0e03-4c87-884e-955f84dbea6d.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -24891,7 +24891,7 @@
         },
         {
             "id": "241c8c9f-9fbb-59d9-be23-3271090863de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6573c-13cb-4ad9-a9d0-6f3029440246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5c6573c-13cb-4ad9-a9d0-6f3029440246.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -24926,7 +24926,7 @@
         },
         {
             "id": "b6aca4b0-0359-56d5-98f3-fc066c3dfd28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d45933-35e0-4562-b9a8-27aede3294d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2d45933-35e0-4562-b9a8-27aede3294d1.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -24967,7 +24967,7 @@
         },
         {
             "id": "e1596c2c-f3dc-57c3-85e7-61a247b11e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92aed2-9f40-4507-bd91-fd1b4d405c91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b92aed2-9f40-4507-bd91-fd1b4d405c91.jpg?1",
             "name": "Don't Blink",
             "text": "",
             "colours": [
@@ -25000,7 +25000,7 @@
         },
         {
             "id": "bf5c6743-88c9-5a44-b945-b16431de0949",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed22dc33-d3c0-454e-aa41-29b653742964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed22dc33-d3c0-454e-aa41-29b653742964.jpg?1",
             "name": "The Eleventh Hour",
             "text": "",
             "colours": [
@@ -25035,7 +25035,7 @@
         },
         {
             "id": "c5fdd5f4-ce3a-5998-95ba-c4a733b49fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b79758-1d7c-484c-9b23-8e8fa3a9c560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54b79758-1d7c-484c-9b23-8e8fa3a9c560.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -25074,7 +25074,7 @@
         },
         {
             "id": "9f2e8c9a-04f3-56c2-9405-b67e301e11c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0541308b-0ff0-4c88-8d11-4bd324047b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0541308b-0ff0-4c88-8d11-4bd324047b06.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -25109,7 +25109,7 @@
         },
         {
             "id": "625cd890-5ccc-5555-9189-4bc846f1dd90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b017dead-b202-400d-ab08-e0081ac0f39f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b017dead-b202-400d-ab08-e0081ac0f39f.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -25147,7 +25147,7 @@
         },
         {
             "id": "e99f8774-225b-5f67-bf87-7fb48adaa515",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ac277c-c581-4552-9363-0b43c37d402a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ac277c-c581-4552-9363-0b43c37d402a.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -25186,7 +25186,7 @@
         },
         {
             "id": "f2d6e28a-56df-5968-97d4-cfbd40712c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a217740c-1793-4832-b3ef-dd87ef9aec0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a217740c-1793-4832-b3ef-dd87ef9aec0a.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -25221,7 +25221,7 @@
         },
         {
             "id": "da1cbab2-303c-54d8-ab0f-8fc2bbe25838",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca07223-8057-4687-be8f-730d952d6a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/eca07223-8057-4687-be8f-730d952d6a58.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -25264,7 +25264,7 @@
         },
         {
             "id": "632c218f-f7ea-5477-9ff1-b7fe09b1db04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028f347-24e8-4e14-bce5-3d88134a6bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/7028f347-24e8-4e14-bce5-3d88134a6bec.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -25304,7 +25304,7 @@
         },
         {
             "id": "e90b543f-ed09-5c1e-8095-3a19c389e54f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d113fcac-095b-43c5-94e9-299592cf7aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d113fcac-095b-43c5-94e9-299592cf7aa1.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -25339,7 +25339,7 @@
         },
         {
             "id": "4f80fd48-83dc-5035-b82a-041e7d5222e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e360c6e-da94-4384-aad7-85f300c9c332.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e360c6e-da94-4384-aad7-85f300c9c332.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -25379,7 +25379,7 @@
         },
         {
             "id": "5c3db9e7-1210-5a00-9e14-c2e357fe447c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e908f2-5717-48e6-80a0-508029b4a016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36e908f2-5717-48e6-80a0-508029b4a016.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -25419,7 +25419,7 @@
         },
         {
             "id": "6dd41c86-ed05-5171-b27c-92e075a17532",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530a366-d59f-466f-a3fc-d858a5854564.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e530a366-d59f-466f-a3fc-d858a5854564.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -25454,7 +25454,7 @@
         },
         {
             "id": "9aed667f-8672-53ac-8981-0fbd54dbef95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984a09f-91e5-4566-9f8e-e8e12e4dcb5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0984a09f-91e5-4566-9f8e-e8e12e4dcb5b.jpg?1",
             "name": "Renegade Silent",
             "text": "",
             "colours": [
@@ -25490,7 +25490,7 @@
         },
         {
             "id": "5c42beeb-ea5e-55a0-8017-7223732d65ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9744f-bfc7-4597-9928-1b1029c24ff4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4a9744f-bfc7-4597-9928-1b1029c24ff4.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -25525,7 +25525,7 @@
         },
         {
             "id": "f1892b7f-f9ce-508b-a35f-133bf3028b47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c0b0e-4f10-4a34-855c-423839b4b828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f15c0b0e-4f10-4a34-855c-423839b4b828.jpg?1",
             "name": "Star Whale",
             "text": "",
             "colours": [
@@ -25561,7 +25561,7 @@
         },
         {
             "id": "a2ed44e1-a091-50f2-b0ac-3c3275580275",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87455d11-f5e7-45fc-b79c-ddd5f4e78d53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87455d11-f5e7-45fc-b79c-ddd5f4e78d53.jpg?1",
             "name": "Start the TARDIS",
             "text": "",
             "colours": [
@@ -25594,7 +25594,7 @@
         },
         {
             "id": "d07a8375-5c52-5260-a659-e58c1338efb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e202cf6-d7a0-47a8-94fc-0345ea53c21b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e202cf6-d7a0-47a8-94fc-0345ea53c21b.jpg?1",
             "name": "Surge of Brilliance",
             "text": "",
             "colours": [
@@ -25627,7 +25627,7 @@
         },
         {
             "id": "8d149d8b-d8bc-58da-a9a9-27ff814b889b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a8197-55c2-4abd-9979-b62014240796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/813a8197-55c2-4abd-9979-b62014240796.jpg?1",
             "name": "Time Beetle",
             "text": "",
             "colours": [
@@ -25663,7 +25663,7 @@
         },
         {
             "id": "8176bd36-ea10-5e02-8308-24eadee680bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47559f8-d634-48b9-828a-d16485eb9ea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e47559f8-d634-48b9-828a-d16485eb9ea0.jpg?1",
             "name": "Time Lord Regeneration",
             "text": "",
             "colours": [
@@ -25696,7 +25696,7 @@
         },
         {
             "id": "50ccd68b-51e5-58c4-9fa8-76cefad9bae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad33b-aad4-438b-8063-003c98d53df7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c23ad33b-aad4-438b-8063-003c98d53df7.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -25731,7 +25731,7 @@
         },
         {
             "id": "fc11911e-c839-50cf-b958-70453603e3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -25764,7 +25764,7 @@
         },
         {
             "id": "5d883850-1d97-5a59-8cb0-2bf9ee3f5be0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/f/bf556076-bf59-4531-ba42-8d4d0c1c23a8.jpg?1",
             "name": "Twice Upon a Time // Unlikely Meeting",
             "text": "",
             "colours": [
@@ -25799,7 +25799,7 @@
         },
         {
             "id": "665b2044-386c-5f16-952d-454565d63a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2355e847-f147-421a-8fc3-7e244b4a70ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2355e847-f147-421a-8fc3-7e244b4a70ee.jpg?1",
             "name": "Wibbly-wobbly, Timey-wimey",
             "text": "",
             "colours": [
@@ -25832,7 +25832,7 @@
         },
         {
             "id": "f828e0f3-b308-5742-9346-0080511dc8a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4fc3c3-6fc5-4e9b-8fe2-91d3889c9558.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4fc3c3-6fc5-4e9b-8fe2-91d3889c9558.jpg?1",
             "name": "Zygon Infiltrator",
             "text": "",
             "colours": [
@@ -25869,7 +25869,7 @@
         },
         {
             "id": "f8e7c8c9-f395-5c5e-b89b-349bf4dfa2ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5333c5-b0c8-4ce1-8ee5-cd2f7b54d5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea5333c5-b0c8-4ce1-8ee5-cd2f7b54d5fb.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -25907,7 +25907,7 @@
         },
         {
             "id": "0d8f3901-57cb-5ccd-a85c-e260a20d2914",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a5f1c9-8164-43c6-96f1-894d6981a2ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a5f1c9-8164-43c6-96f1-894d6981a2ea.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -25945,7 +25945,7 @@
         },
         {
             "id": "277d8e11-3bd4-595c-9715-69298a9583cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bedb9c9-8ed5-4aad-b594-722041a7e393.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bedb9c9-8ed5-4aad-b594-722041a7e393.jpg?1",
             "name": "Death in Heaven",
             "text": "",
             "colours": [
@@ -25980,7 +25980,7 @@
         },
         {
             "id": "e263f5fc-72ea-5609-829d-c7f02f7b41fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e6ec7f-4b98-43c2-bdf8-c662263cda51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12e6ec7f-4b98-43c2-bdf8-c662263cda51.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -26015,7 +26015,7 @@
         },
         {
             "id": "dfcc1cfe-24f4-5606-a1e3-7a45e3b9c265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53f2c88-0719-4a4e-849f-239358cb3518.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53f2c88-0719-4a4e-849f-239358cb3518.jpg?1",
             "name": "Exterminate!",
             "text": "",
             "colours": [
@@ -26048,7 +26048,7 @@
         },
         {
             "id": "d46006ed-cc63-56e9-98ac-383d0abfd2bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59cf715-271c-4f65-9f53-56b822f46ea5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a59cf715-271c-4f65-9f53-56b822f46ea5.jpg?1",
             "name": "Genesis of the Daleks",
             "text": "",
             "colours": [
@@ -26083,7 +26083,7 @@
         },
         {
             "id": "eae9decb-7f85-57b6-9d1d-2a985447bdf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686d1c6-bebe-45ac-b82e-78cf420b5e33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0686d1c6-bebe-45ac-b82e-78cf420b5e33.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -26118,7 +26118,7 @@
         },
         {
             "id": "2adfdcad-2730-54fa-9616-921a91a80b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e904743-37b7-462e-80c5-963fc94528b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e904743-37b7-462e-80c5-963fc94528b5.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -26156,7 +26156,7 @@
         },
         {
             "id": "a2fe40a9-238c-5ac5-8f0e-2844bdc9bd85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574546c1-c023-4250-990a-010fc630934b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/574546c1-c023-4250-990a-010fc630934b.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -26191,7 +26191,7 @@
         },
         {
             "id": "1c91b71c-52cb-592e-bff8-73a30dd8c596",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4defc65-1473-4e4f-8b39-9d7e004170d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4defc65-1473-4e4f-8b39-9d7e004170d3.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -26229,7 +26229,7 @@
         },
         {
             "id": "3c3c7d0b-3e69-5fe0-9b66-70548864ef53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0879d8-fa00-47b2-9c94-298e51bf7d99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c0879d8-fa00-47b2-9c94-298e51bf7d99.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -26268,7 +26268,7 @@
         },
         {
             "id": "9665dee8-cfc0-5597-955f-75581129fd91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f90c5f-d45d-49ec-a597-fde8b4c27331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f90c5f-d45d-49ec-a597-fde8b4c27331.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -26307,7 +26307,7 @@
         },
         {
             "id": "e2f12d83-c224-5706-afbe-8580cb9498a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a7ecf0-70db-4619-981e-f67bf9c9d2d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5a7ecf0-70db-4619-981e-f67bf9c9d2d2.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -26346,7 +26346,7 @@
         },
         {
             "id": "a4e0d81e-48ac-53aa-85bb-b3a9b7f599f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -26379,7 +26379,7 @@
         },
         {
             "id": "f056591c-dd6e-5a32-b4b7-a6ee73c9168e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/7/0717b6ee-99f8-4b02-91f4-6ca07a08b2c0.jpg?1",
             "name": "Coward // Killer",
             "text": "",
             "colours": [
@@ -26412,7 +26412,7 @@
         },
         {
             "id": "1e7d2e89-6afb-5bd3-b31b-aef29cf843fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bf6c2-c7c2-48f5-a1a5-0aac4a08e567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184bf6c2-c7c2-48f5-a1a5-0aac4a08e567.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -26451,7 +26451,7 @@
         },
         {
             "id": "9af17119-f546-5bc5-98a8-37a0f28e6c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0b79b-874b-4ae2-b60e-ee6cb6753e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e0b79b-874b-4ae2-b60e-ee6cb6753e6d.jpg?1",
             "name": "Day of the Moon",
             "text": "",
             "colours": [
@@ -26486,7 +26486,7 @@
         },
         {
             "id": "083bcb03-a7b8-58d5-86b0-b3613ff153e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d63dfcc-49c2-49df-8542-649f659ccf0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d63dfcc-49c2-49df-8542-649f659ccf0d.jpg?1",
             "name": "Decaying Time Loop",
             "text": "",
             "colours": [
@@ -26519,7 +26519,7 @@
         },
         {
             "id": "dfeac889-07fa-5ce6-a0b1-38040a0f5716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6753b6-3c7d-447b-b76c-dd1ae5da8fbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be6753b6-3c7d-447b-b76c-dd1ae5da8fbc.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -26554,7 +26554,7 @@
         },
         {
             "id": "118538d9-a080-57a1-88ea-99ace54271c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73c605b-7173-419f-843d-566ad9cc85ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b73c605b-7173-419f-843d-566ad9cc85ef.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -26593,7 +26593,7 @@
         },
         {
             "id": "b59da021-3271-5a88-944a-e830ebc84fd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a5ecf-74e5-4c70-99e1-c06ffeb71c19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/403a5ecf-74e5-4c70-99e1-c06ffeb71c19.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -26628,7 +26628,7 @@
         },
         {
             "id": "b8aa4a76-dacb-51c5-b85c-ab860e112d41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d44c31-b19b-45f2-a8c0-d0cc9276f9b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29d44c31-b19b-45f2-a8c0-d0cc9276f9b3.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -26663,7 +26663,7 @@
         },
         {
             "id": "90a7cbd2-f325-5c93-a840-977c845c4b9b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef18b36-7dad-4861-84bd-d6de7e192a7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ef18b36-7dad-4861-84bd-d6de7e192a7a.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -26700,7 +26700,7 @@
         },
         {
             "id": "92cd319b-1a4e-5eb0-9640-8df48cc9bd7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fc939e-bc5f-4150-8b4d-bb3e92ecde5e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52fc939e-bc5f-4150-8b4d-bb3e92ecde5e.jpg?1",
             "name": "The Flux",
             "text": "",
             "colours": [
@@ -26735,7 +26735,7 @@
         },
         {
             "id": "c789c13e-b615-507a-bb79-0be213d11af8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4cde0cf-e422-4b51-9a5e-6324079974cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4cde0cf-e422-4b51-9a5e-6324079974cb.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -26770,7 +26770,7 @@
         },
         {
             "id": "1636c235-9220-51eb-9232-d6a7875c7663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703dcd8a-a4a6-47c8-bb05-f336ff92b6ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/703dcd8a-a4a6-47c8-bb05-f336ff92b6ca.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -26805,7 +26805,7 @@
         },
         {
             "id": "4444174b-51ea-53fc-8a48-3043ef8c0631",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10053fd4-b38a-49d0-aa3a-3ee3367102e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10053fd4-b38a-49d0-aa3a-3ee3367102e2.jpg?1",
             "name": "Iraxxa, Empress of Mars",
             "text": "",
             "colours": [
@@ -26843,7 +26843,7 @@
         },
         {
             "id": "24fa27de-5f37-5b68-ab4d-1b868f33fb84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f405f-a6f4-4a94-abd3-4a3bdfdaaeb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c0f405f-a6f4-4a94-abd3-4a3bdfdaaeb0.jpg?1",
             "name": "Memory Worm",
             "text": "",
             "colours": [
@@ -26879,7 +26879,7 @@
         },
         {
             "id": "be025435-a7d3-5751-96fb-221c1635bd82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6892f67c-055e-490a-9c77-894f44c3762f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6892f67c-055e-490a-9c77-894f44c3762f.jpg?1",
             "name": "The Parting of the Ways",
             "text": "",
             "colours": [
@@ -26914,7 +26914,7 @@
         },
         {
             "id": "eb51cae4-9025-5353-991c-364f3f7e039c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec322d-f229-489f-8982-5be22ac4e020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dec322d-f229-489f-8982-5be22ac4e020.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -26949,7 +26949,7 @@
         },
         {
             "id": "0263cfd7-74a5-5af2-8b9d-5d49c6f5400d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758982ce-9283-465f-ba10-e1a3d5f5c1c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/758982ce-9283-465f-ba10-e1a3d5f5c1c3.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -26988,7 +26988,7 @@
         },
         {
             "id": "ea9cc9b6-e13f-50db-bd58-1e619a836da8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c8271-f814-4d00-b719-984120dd18b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038c8271-f814-4d00-b719-984120dd18b5.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -27027,7 +27027,7 @@
         },
         {
             "id": "e7919782-60cc-53e8-bae4-e8c38e63734b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a217b61-e2ec-4852-ae4e-f4c40dcc2851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a217b61-e2ec-4852-ae4e-f4c40dcc2851.jpg?1",
             "name": "Sibylline Soothsayer",
             "text": "",
             "colours": [
@@ -27063,7 +27063,7 @@
         },
         {
             "id": "0e3d1995-b8ca-57c7-bee9-b1674e0ba40d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010e983d-e84c-4fb1-82c1-fab0885934f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/010e983d-e84c-4fb1-82c1-fab0885934f7.jpg?1",
             "name": "Sontaran General",
             "text": "",
             "colours": [
@@ -27099,7 +27099,7 @@
         },
         {
             "id": "8bf81549-0111-54e8-9bde-78ba7ab03f47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48636d77-a335-4c46-9019-d8b84462b645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48636d77-a335-4c46-9019-d8b84462b645.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -27136,7 +27136,7 @@
         },
         {
             "id": "e54d02a3-5115-5884-b1a4-25d04ead9b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af646ff7-b3ee-4e95-9fce-7d48d4987e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af646ff7-b3ee-4e95-9fce-7d48d4987e4e.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -27176,7 +27176,7 @@
         },
         {
             "id": "6c6f0b59-3fdd-5f2c-82ed-6d4bf6db8b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02242155-5612-4be7-b4db-c94f3ff34383.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02242155-5612-4be7-b4db-c94f3ff34383.jpg?1",
             "name": "City of Death",
             "text": "",
             "colours": [
@@ -27211,7 +27211,7 @@
         },
         {
             "id": "d3d3c07e-7b62-5742-8153-4f892384cd9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f46c447-23e6-4d6d-88d0-f5322734bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f46c447-23e6-4d6d-88d0-f5322734bc82.jpg?1",
             "name": "Displaced Dinosaurs",
             "text": "",
             "colours": [
@@ -27246,7 +27246,7 @@
         },
         {
             "id": "093c3129-ad19-52fb-b2a2-64cf00cf8621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18385ef8-2af8-47bc-8863-046dc5b4e8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18385ef8-2af8-47bc-8863-046dc5b4e8df.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -27281,7 +27281,7 @@
         },
         {
             "id": "4e1a869e-657e-59ee-b8ef-388adee47d2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923ce269-f8a6-4d4b-adbf-463241a001b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923ce269-f8a6-4d4b-adbf-463241a001b0.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -27320,7 +27320,7 @@
         },
         {
             "id": "1ca114e6-17c8-5aa5-8323-68c4b25c7823",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836ff17-553c-4545-a132-2e2d6eeeb66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f836ff17-553c-4545-a132-2e2d6eeeb66e.jpg?1",
             "name": "Fugitive of the Judoon",
             "text": "",
             "colours": [
@@ -27355,7 +27355,7 @@
         },
         {
             "id": "6facfd27-7058-5533-9f86-0684f9598b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3a420-bfbf-4197-8dcb-d7af5784dd8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3a420-bfbf-4197-8dcb-d7af5784dd8e.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -27395,7 +27395,7 @@
         },
         {
             "id": "e2bdfa2c-a49a-5a0d-a488-d6f3437223ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098150bc-a865-48d0-95c2-39c2bee9bbb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/098150bc-a865-48d0-95c2-39c2bee9bbb4.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -27435,7 +27435,7 @@
         },
         {
             "id": "99968926-9f09-5c58-8951-1e00ca13a209",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -27474,7 +27474,7 @@
         },
         {
             "id": "e42a5190-a109-52d6-9270-33beef0be9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ad76824e-2d58-42d4-9543-2baaf6b0046b.jpg?1",
             "name": "Karvanista, Loyal Lupari // Lupari Shield",
             "text": "",
             "colours": [
@@ -27509,7 +27509,7 @@
         },
         {
             "id": "b3e23464-fc86-55ca-9271-901f5973fbdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a43e73f-2d9e-41f3-89bc-fd9991753955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a43e73f-2d9e-41f3-89bc-fd9991753955.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -27549,7 +27549,7 @@
         },
         {
             "id": "b9c7392c-e716-550c-ba33-c5326c4c89a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdb8d0d-cdae-4a4d-a6fc-6a8fafb3e892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cdb8d0d-cdae-4a4d-a6fc-6a8fafb3e892.jpg?1",
             "name": "The Sea Devils",
             "text": "",
             "colours": [
@@ -27584,7 +27584,7 @@
         },
         {
             "id": "03fb3375-a82e-5d25-af26-657bce84ff6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d537988-13ab-4b36-8bbd-0d7abf796f26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d537988-13ab-4b36-8bbd-0d7abf796f26.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -27621,7 +27621,7 @@
         },
         {
             "id": "ea30b6c1-408f-5b95-9d76-6f69335ed7cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181c4373-5576-4acd-9c56-26df29e7d021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/181c4373-5576-4acd-9c56-26df29e7d021.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -27660,7 +27660,7 @@
         },
         {
             "id": "ac7383de-68b0-5c23-9161-2eb4336b4832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c0c32-f770-4012-ae3e-33b1808b3dc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e21c0c32-f770-4012-ae3e-33b1808b3dc4.jpg?1",
             "name": "Thijarian Witness",
             "text": "",
             "colours": [
@@ -27696,7 +27696,7 @@
         },
         {
             "id": "2670ba2f-1d46-5943-a7bf-92aee870a58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a202892-3bbc-454f-83c6-51451c8e6215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a202892-3bbc-454f-83c6-51451c8e6215.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -27740,7 +27740,7 @@
         },
         {
             "id": "3e80d212-d64a-5684-bafd-2d446e5559fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d0f5ba-babd-4e05-89bf-acda8570a876.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8d0f5ba-babd-4e05-89bf-acda8570a876.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -27784,7 +27784,7 @@
         },
         {
             "id": "eb4e4888-57f2-50fd-8aea-d7c151ead975",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa958e1-c3f4-41a2-8c32-92f8b36bd108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaa958e1-c3f4-41a2-8c32-92f8b36bd108.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -27825,7 +27825,7 @@
         },
         {
             "id": "361b2fcc-e3f3-595d-8d18-fce978f3ffb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb9935-ecbc-4bbd-af56-05de3652973f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acfb9935-ecbc-4bbd-af56-05de3652973f.jpg?1",
             "name": "Bigger on the Inside",
             "text": "",
             "colours": [
@@ -27862,7 +27862,7 @@
         },
         {
             "id": "24fd08ea-f07a-5fa4-bea9-8bd5c56582b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73a2404-9400-4628-a799-23b48026f27d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f73a2404-9400-4628-a799-23b48026f27d.jpg?1",
             "name": "Blink",
             "text": "",
             "colours": [
@@ -27899,7 +27899,7 @@
         },
         {
             "id": "75384a8f-8b46-543e-b632-c0216b618d0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d0f99-ecc8-41ad-8cd5-d52da07c41a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/604d0f99-ecc8-41ad-8cd5-d52da07c41a4.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -27943,7 +27943,7 @@
         },
         {
             "id": "eff6a0e0-a6a3-5128-85bd-96216c6d8804",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8129a46-ba17-454c-801f-81eb07d61bdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8129a46-ba17-454c-801f-81eb07d61bdf.jpg?1",
             "name": "The Curse of Fenric",
             "text": "",
             "colours": [
@@ -27980,7 +27980,7 @@
         },
         {
             "id": "8d9610e1-f552-578e-8791-d6deda22e086",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e965848-fadb-4522-95f1-5e330a72e871.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e965848-fadb-4522-95f1-5e330a72e871.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -28022,7 +28022,7 @@
         },
         {
             "id": "dd9b73f2-c932-554e-adab-0e796df85dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18bf54-88b0-46a4-a2c7-fded41e524cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be18bf54-88b0-46a4-a2c7-fded41e524cb.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -28064,7 +28064,7 @@
         },
         {
             "id": "950f63e9-e786-58ac-ada3-7ae7f1c78512",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf289cf8-c792-4198-9310-02a7a02c248f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf289cf8-c792-4198-9310-02a7a02c248f.jpg?1",
             "name": "The Day of the Doctor",
             "text": "",
             "colours": [
@@ -28101,7 +28101,7 @@
         },
         {
             "id": "a743437c-789a-5d33-9f2a-982c04202ff3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab556a2-eed3-4b75-af34-ad1ee147558e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ab556a2-eed3-4b75-af34-ad1ee147558e.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -28140,7 +28140,7 @@
         },
         {
             "id": "d3add04c-610f-5eee-ba60-d9a0fa8af6f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d669c14-a549-4d17-bd1a-ddd5e9a1a4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d669c14-a549-4d17-bd1a-ddd5e9a1a4c6.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -28182,7 +28182,7 @@
         },
         {
             "id": "ae63afa9-34d5-5b78-9388-b10ecd630daa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99bf3d7-732c-4e1b-972a-efd49d2b3725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d99bf3d7-732c-4e1b-972a-efd49d2b3725.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -28227,7 +28227,7 @@
         },
         {
             "id": "70cad508-b4a6-54c9-9240-4ec450592570",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb88d0-d1a0-48e5-8e7a-c0fd0b7ef691.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb88d0-d1a0-48e5-8e7a-c0fd0b7ef691.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -28272,7 +28272,7 @@
         },
         {
             "id": "e000482f-1eff-571c-a12d-08ad42a0f687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7194b-36dd-418b-948f-09669f3b2479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7194b-36dd-418b-948f-09669f3b2479.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -28316,7 +28316,7 @@
         },
         {
             "id": "526c0c84-0f3a-581f-914a-0e6f1aec18eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a20c3-b2cf-489b-8cfd-65ae3f935a78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce3a20c3-b2cf-489b-8cfd-65ae3f935a78.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -28361,7 +28361,7 @@
         },
         {
             "id": "f6e8c4f3-ebac-509d-9397-bd90afa2d1fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0af9cc9-ee39-4b0c-a7b0-c067cdd60f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0af9cc9-ee39-4b0c-a7b0-c067cdd60f30.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -28406,7 +28406,7 @@
         },
         {
             "id": "b351ede1-7884-50cb-82c6-07a4b69a5503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cd33c6-e593-4606-9e03-ae4c17073f30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0cd33c6-e593-4606-9e03-ae4c17073f30.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -28445,7 +28445,7 @@
         },
         {
             "id": "90966d74-d4cd-53b8-a191-f77cf96aaa4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8ed973-a94d-46b1-8584-12d553d170e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c8ed973-a94d-46b1-8584-12d553d170e6.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -28489,7 +28489,7 @@
         },
         {
             "id": "51577b19-b686-55a5-ba74-51d55447bc82",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -28523,7 +28523,7 @@
         },
         {
             "id": "a9705d33-3e85-5a6a-81f2-82c17b87adb8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/2/6265bf1d-07a8-4f84-a39f-ee02d9921771.jpg?1",
             "name": "Gallifrey Falls // No More",
             "text": "",
             "colours": [
@@ -28557,7 +28557,7 @@
         },
         {
             "id": "2935af5a-6f2d-586e-a493-38e7874e8194",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eab11a2-9df7-42e9-a762-e5003f7927e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eab11a2-9df7-42e9-a762-e5003f7927e4.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -28596,7 +28596,7 @@
         },
         {
             "id": "1186f779-afef-5996-838a-c07eb988ff83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280c4d2c-6832-4ba5-958a-0527ba3cbc71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/280c4d2c-6832-4ba5-958a-0527ba3cbc71.jpg?1",
             "name": "Great Intelligence's Plan",
             "text": "",
             "colours": [
@@ -28631,7 +28631,7 @@
         },
         {
             "id": "c908fa25-797e-5c48-8272-5696a8524f8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47239168-df82-4b54-8400-7a4b6e9cc40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47239168-df82-4b54-8400-7a4b6e9cc40f.jpg?1",
             "name": "Heaven Sent",
             "text": "",
             "colours": [
@@ -28668,7 +28668,7 @@
         },
         {
             "id": "b310671a-8310-5d46-a728-4981c26a7799",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3cbf0d-c0ed-44ab-afe0-3d51635e2073.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc3cbf0d-c0ed-44ab-afe0-3d51635e2073.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -28710,7 +28710,7 @@
         },
         {
             "id": "7a232529-d600-5be1-8c5c-b3b88c985b01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e792d96-bba9-4fa2-a57e-3ba9485e238f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e792d96-bba9-4fa2-a57e-3ba9485e238f.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -28752,7 +28752,7 @@
         },
         {
             "id": "edc3a456-9244-54db-9059-f34ecb4b739f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41604c3f-9568-4bb4-813b-80d8f2be7530.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41604c3f-9568-4bb4-813b-80d8f2be7530.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -28794,7 +28794,7 @@
         },
         {
             "id": "34681833-149e-5ea8-9148-6960f86d28d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d08f5f4-db1a-4d59-abe5-5a509fbfa32c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d08f5f4-db1a-4d59-abe5-5a509fbfa32c.jpg?1",
             "name": "Judoon Enforcers",
             "text": "",
             "colours": [
@@ -28833,7 +28833,7 @@
         },
         {
             "id": "b18ff8e0-7891-5e59-af73-eef8b56374ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab585eec-db82-4d4e-a4a1-d8d21e5a9146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab585eec-db82-4d4e-a4a1-d8d21e5a9146.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -28877,7 +28877,7 @@
         },
         {
             "id": "545fb8a3-f477-5be8-8789-d1fc6ce1e492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fbaf77-8afa-41c7-804b-ba7b740fffe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08fbaf77-8afa-41c7-804b-ba7b740fffe8.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -28914,7 +28914,7 @@
         },
         {
             "id": "cb53e262-6617-50ae-936e-c6b1420f3288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12481875-102f-414c-9c28-9e2e7e5edb28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12481875-102f-414c-9c28-9e2e7e5edb28.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -28954,7 +28954,7 @@
         },
         {
             "id": "bea5833b-193b-59c2-87c8-f49d7f716656",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf3fc0-c6da-4662-94b1-ac114e0d5123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bf3fc0-c6da-4662-94b1-ac114e0d5123.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -28996,7 +28996,7 @@
         },
         {
             "id": "009c238b-e596-5caf-8f52-c70e8aca6535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a24e966-df2c-467b-a62d-243782eb37ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a24e966-df2c-467b-a62d-243782eb37ca.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -29040,7 +29040,7 @@
         },
         {
             "id": "52b6c2c9-36e4-57fc-a153-342fba647fce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc8cc351-831f-47c0-ad1f-f8ca031204de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc8cc351-831f-47c0-ad1f-f8ca031204de.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -29084,7 +29084,7 @@
         },
         {
             "id": "b0c4fcd2-4183-5c57-a543-7c7afc4306dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830ce411-9f63-4aa3-8846-df48520e35e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/830ce411-9f63-4aa3-8846-df48520e35e2.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -29128,7 +29128,7 @@
         },
         {
             "id": "2ba90430-8767-5c8e-9600-294bbc6698e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69741c34-d433-4c0b-8c21-a9e122758070.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69741c34-d433-4c0b-8c21-a9e122758070.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -29172,7 +29172,7 @@
         },
         {
             "id": "b390f93f-e046-514b-b47e-c06a50f6ee4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aee3c03-9d03-4088-8557-6bf5dcb7acc4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aee3c03-9d03-4088-8557-6bf5dcb7acc4.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -29216,7 +29216,7 @@
         },
         {
             "id": "534829f2-2760-52bf-85a6-48f67858e990",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717bfcc5-32f8-4944-8aa1-a2cd178354ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/717bfcc5-32f8-4944-8aa1-a2cd178354ec.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -29261,7 +29261,7 @@
         },
         {
             "id": "695cdceb-e904-550a-ab9e-26aab1ddc2ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f85a38e-eb8c-4af3-bd74-758b1c46ff92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f85a38e-eb8c-4af3-bd74-758b1c46ff92.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -29305,7 +29305,7 @@
         },
         {
             "id": "7ac2bb6b-5551-5716-8a28-baa3e000dd68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46782d62-52d2-414d-a55e-c48bc2ae93c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46782d62-52d2-414d-a55e-c48bc2ae93c4.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -29347,7 +29347,7 @@
         },
         {
             "id": "1b73cd5e-0bd9-5ada-9b0f-869ae47e928f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d38ec3-5028-42ac-97c3-af2aa04314ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44d38ec3-5028-42ac-97c3-af2aa04314ae.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -29384,7 +29384,7 @@
         },
         {
             "id": "5809fb11-9f6b-5d14-8153-3b3d0dea5eeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841e20fb-8607-481d-b690-c70a0e0f2daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/841e20fb-8607-481d-b690-c70a0e0f2daa.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -29429,7 +29429,7 @@
         },
         {
             "id": "ce050c5d-1e7b-5f84-8a46-4fca188de099",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7bb09-7c22-4d39-9aab-b0016ee2d5ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2ff7bb09-7c22-4d39-9aab-b0016ee2d5ab.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -29471,7 +29471,7 @@
         },
         {
             "id": "526170ed-7a63-5341-968a-3f21a0dcc00d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e479d60-0da2-48b8-b7e3-16505506004a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e479d60-0da2-48b8-b7e3-16505506004a.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -29508,7 +29508,7 @@
         },
         {
             "id": "2425a276-ad7d-5986-aab1-4009356ce375",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e085b17-e3a8-49eb-adff-6c748ca5a611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e085b17-e3a8-49eb-adff-6c748ca5a611.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -29550,7 +29550,7 @@
         },
         {
             "id": "16d8447e-95e7-5efa-8658-d9fc9c84b2b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052b234-d8e5-4da9-8c68-77e76ece2285.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4052b234-d8e5-4da9-8c68-77e76ece2285.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -29595,7 +29595,7 @@
         },
         {
             "id": "b7a9222f-7390-583b-90c4-5d3709ab49e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db451876-fa9d-4cfd-9105-c6ceb562fa4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db451876-fa9d-4cfd-9105-c6ceb562fa4d.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -29637,7 +29637,7 @@
         },
         {
             "id": "e8942658-62b9-5c5e-8a0e-d3f089a0643e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce1351f-3643-4d7e-99a8-9c1a31abe970.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce1351f-3643-4d7e-99a8-9c1a31abe970.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -29682,7 +29682,7 @@
         },
         {
             "id": "2526171a-9f2d-5f4b-bbcd-9133c341f09f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947207ae-24a1-4c85-a5fc-d650a5deafe0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/947207ae-24a1-4c85-a5fc-d650a5deafe0.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -29727,7 +29727,7 @@
         },
         {
             "id": "8c816aee-db03-5ee5-b4c2-bf7f67d3c4b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5aabb06-d4e5-40b5-84a8-4f74d4763567.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5aabb06-d4e5-40b5-84a8-4f74d4763567.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -29769,7 +29769,7 @@
         },
         {
             "id": "fce87a06-ff62-5638-91fc-c5719318786f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c12a66b-3a89-49a5-8a2f-7d260f4d68d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c12a66b-3a89-49a5-8a2f-7d260f4d68d4.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -29809,7 +29809,7 @@
         },
         {
             "id": "12b33414-e37d-5eff-823c-9d10946ef103",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769fa42b-65ad-4231-863e-1c7923726975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/769fa42b-65ad-4231-863e-1c7923726975.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -29854,7 +29854,7 @@
         },
         {
             "id": "51b3b435-a5f8-51fb-9356-78f846d37af2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec190b44-7761-4eb1-8b24-8142c25add4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec190b44-7761-4eb1-8b24-8142c25add4b.jpg?1",
             "name": "Truth or Consequences",
             "text": "",
             "colours": [
@@ -29889,7 +29889,7 @@
         },
         {
             "id": "8e97f9d1-ef3a-5f91-9be0-9c37a29c43db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ae7218-e99f-49ef-87be-2462101a1c31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3ae7218-e99f-49ef-87be-2462101a1c31.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -29934,7 +29934,7 @@
         },
         {
             "id": "51a671fa-9106-5a39-a7b2-6069ec0d5478",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4bf74-1ca1-48ea-9f82-511c3c2eb04a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6b4bf74-1ca1-48ea-9f82-511c3c2eb04a.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -29978,7 +29978,7 @@
         },
         {
             "id": "472e530e-5796-5ad1-806c-6c088fa2c30f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce4479c-157e-4821-bdf3-053a9f483d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8ce4479c-157e-4821-bdf3-053a9f483d9e.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -30021,7 +30021,7 @@
         },
         {
             "id": "b5aface2-1ce0-5a0d-b9e2-d2b47927b11b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178d195b-fa8b-429a-b4b3-86d2a2be24b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/178d195b-fa8b-429a-b4b3-86d2a2be24b9.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -30065,7 +30065,7 @@
         },
         {
             "id": "c98bca32-1e92-520d-8011-72a8fdffcea7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20e4595-ebf0-475f-937c-b78d8beb1e01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e20e4595-ebf0-475f-937c-b78d8beb1e01.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -30108,7 +30108,7 @@
         },
         {
             "id": "f4aab596-2db9-5c63-96c3-ba0e2adde39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bbe175-5b19-4c7e-b5bc-85fe25b63004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bbe175-5b19-4c7e-b5bc-85fe25b63004.jpg?1",
             "name": "Wreck and Rebuild",
             "text": "",
             "colours": [
@@ -30143,7 +30143,7 @@
         },
         {
             "id": "9d4801a6-ca6a-583c-bfe1-e3aaaa4909e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aa1467-f359-4b69-bbe8-6d59a87378b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98aa1467-f359-4b69-bbe8-6d59a87378b8.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -30178,7 +30178,7 @@
         },
         {
             "id": "b8912a59-8185-5e53-a5ef-d8539a43beae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000a902-9f18-4823-9d85-d1d12d03ad4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8000a902-9f18-4823-9d85-d1d12d03ad4a.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -30213,7 +30213,7 @@
         },
         {
             "id": "e3af39e9-5ee1-554a-86d9-418c7a7b0b5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe714c2-5358-4ba8-b990-5bb5f5757a57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abe714c2-5358-4ba8-b990-5bb5f5757a57.jpg?1",
             "name": "Clockwork Droid",
             "text": "",
             "colours": [],
@@ -30245,7 +30245,7 @@
         },
         {
             "id": "d4f90445-8401-570e-9abb-93a8c115486a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64077b-2c50-4511-8424-684c97c2a3f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a64077b-2c50-4511-8424-684c97c2a3f9.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -30276,7 +30276,7 @@
         },
         {
             "id": "9e2ff142-4988-5a98-a7fd-42a91492943a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe32187-ce41-48b8-9bb9-ddca2ca0bab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fe32187-ce41-48b8-9bb9-ddca2ca0bab6.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -30310,7 +30310,7 @@
         },
         {
             "id": "90c8e4bc-4a81-5c1b-bbaa-fb0369f86c6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04debb05-5303-4b0a-8224-d00f3512639e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04debb05-5303-4b0a-8224-d00f3512639e.jpg?1",
             "name": "Cybermat",
             "text": "",
             "colours": [],
@@ -30342,7 +30342,7 @@
         },
         {
             "id": "ce38ee77-809a-55b2-bf23-f774fda0bed4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf58737-3e09-4c09-85d8-bdf2364db30c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bf58737-3e09-4c09-85d8-bdf2364db30c.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -30376,7 +30376,7 @@
         },
         {
             "id": "3e4589ad-c71a-53a8-86a0-af373d978e4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41185e7-d6e2-49a9-aac8-597e5aab197a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e41185e7-d6e2-49a9-aac8-597e5aab197a.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -30409,7 +30409,7 @@
         },
         {
             "id": "395b6143-b981-5213-91c8-64114254d2e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431a6798-2a82-44b8-bd2e-3e3a425d3473.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/431a6798-2a82-44b8-bd2e-3e3a425d3473.jpg?1",
             "name": "Laser Screwdriver",
             "text": "",
             "colours": [],
@@ -30438,7 +30438,7 @@
         },
         {
             "id": "3a28d68a-d0eb-5a15-91cb-e1638f1e9970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13c9eac-7b53-4b90-94b9-890fa8c522dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d13c9eac-7b53-4b90-94b9-890fa8c522dc.jpg?1",
             "name": "Midnight Crusader Shuttle",
             "text": "",
             "colours": [],
@@ -30469,7 +30469,7 @@
         },
         {
             "id": "2a21aaf0-c818-5101-8889-c1f418475740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7209964-432a-4318-b9f3-c341bda7256c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7209964-432a-4318-b9f3-c341bda7256c.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -30502,7 +30502,7 @@
         },
         {
             "id": "1d93a02d-1bc5-55d8-a5b6-ac1b438deb5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0aea96-932a-498b-8520-e9b88c788e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e0aea96-932a-498b-8520-e9b88c788e3a.jpg?1",
             "name": "Psychic Paper",
             "text": "",
             "colours": [],
@@ -30533,7 +30533,7 @@
         },
         {
             "id": "36ed2049-af0f-521b-a062-bb25d97d4be6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98833afa-fc8a-4c1b-b670-b772bde076bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98833afa-fc8a-4c1b-b670-b772bde076bb.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -30564,7 +30564,7 @@
         },
         {
             "id": "3414b895-39d6-5f9f-a1fe-ffd3159a76bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151084cd-49cb-4361-85c1-f0485f3f52dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151084cd-49cb-4361-85c1-f0485f3f52dd.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -30595,7 +30595,7 @@
         },
         {
             "id": "2d15bad9-e73d-5ada-9160-4be6ad69846a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81fb890-3165-43fe-b2c8-876c8fb0431b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e81fb890-3165-43fe-b2c8-876c8fb0431b.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30628,7 +30628,7 @@
         },
         {
             "id": "2ca3bc12-f9c7-5a62-8fa2-c17d1de4e240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64912428-5156-4167-b890-a30e2e594a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64912428-5156-4167-b890-a30e2e594a35.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30661,7 +30661,7 @@
         },
         {
             "id": "98cf9b51-3fca-5c20-89a2-b0aef23f0617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0476000-798e-4a19-a241-bb1e43a7b5fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0476000-798e-4a19-a241-bb1e43a7b5fe.jpg?1",
             "name": "Sonic Screwdriver",
             "text": "",
             "colours": [],
@@ -30694,7 +30694,7 @@
         },
         {
             "id": "b0ecaec4-0c26-5ac8-9a97-ed5008ef18c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69ef4-a95b-48c8-9720-18e2d862e926.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76f69ef4-a95b-48c8-9720-18e2d862e926.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -30727,7 +30727,7 @@
         },
         {
             "id": "c52a4ad0-ce68-5652-b646-d8865b064a94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a316539-e2eb-4321-a73c-075dafb01cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a316539-e2eb-4321-a73c-075dafb01cc9.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -30760,7 +30760,7 @@
         },
         {
             "id": "892bdc76-0a7c-5369-b865-ba9a7112603d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742df7f-cf92-4749-8c33-d88e5987b4c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e742df7f-cf92-4749-8c33-d88e5987b4c6.jpg?1",
             "name": "Ominous Cemetery",
             "text": "",
             "colours": [],
@@ -30789,7 +30789,7 @@
         },
         {
             "id": "424e6e78-b458-5b70-83b1-a83aa87cbcb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0b3429-e42f-4eb7-acd5-8fddf100f0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0b3429-e42f-4eb7-acd5-8fddf100f0c4.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -30824,7 +30824,7 @@
         },
         {
             "id": "db550dba-6c16-5574-a9d4-f940d240dace",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf098980-26e4-4df1-bca3-439b405c3ae7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf098980-26e4-4df1-bca3-439b405c3ae7.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -30865,7 +30865,7 @@
         },
         {
             "id": "7e4c698c-f756-5060-bc07-6f1c94e26c80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de768e49-acd0-4575-8800-db15c71dc719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de768e49-acd0-4575-8800-db15c71dc719.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -30902,7 +30902,7 @@
         },
         {
             "id": "10dec3d1-e766-5830-a519-1b5c69672c37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b2f41-4ee6-4eb7-a01f-155a3752d150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b6b2f41-4ee6-4eb7-a01f-155a3752d150.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -30937,7 +30937,7 @@
         },
         {
             "id": "6626e117-3f73-5711-8629-2199c4cd81d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad46a46-4221-4e0e-8b46-49f517c231c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1ad46a46-4221-4e0e-8b46-49f517c231c1.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -30972,7 +30972,7 @@
         },
         {
             "id": "77db5f6a-2361-5657-8de7-c15a7a8bd109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bc66ca-5909-49cf-bf5b-1dd6c209c03b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16bc66ca-5909-49cf-bf5b-1dd6c209c03b.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -31007,7 +31007,7 @@
         },
         {
             "id": "62cabb9e-2c00-5432-ac74-c9cd5cdba4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6f35c8-d25c-4d06-b80c-c2e2744cdaec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea6f35c8-d25c-4d06-b80c-c2e2744cdaec.jpg?1",
             "name": "Path to Exile",
             "text": "",
             "colours": [
@@ -31040,7 +31040,7 @@
         },
         {
             "id": "cb6a2e4b-de36-5d19-9a25-196fb91bf933",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a1bb38-5cb4-4188-995d-8ee73071abee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26a1bb38-5cb4-4188-995d-8ee73071abee.jpg?1",
             "name": "Return to Dust",
             "text": "",
             "colours": [
@@ -31073,7 +31073,7 @@
         },
         {
             "id": "b117cc2b-9096-5e1f-a1f0-3a2c42c243af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d09581-e8da-4169-82d1-14389b53c375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96d09581-e8da-4169-82d1-14389b53c375.jpg?1",
             "name": "Swords to Plowshares",
             "text": "",
             "colours": [
@@ -31106,7 +31106,7 @@
         },
         {
             "id": "ecc866ed-0e78-5933-9764-4ebf8fb04262",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79d396b-cd84-4088-8996-d33b19841286.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a79d396b-cd84-4088-8996-d33b19841286.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -31141,7 +31141,7 @@
         },
         {
             "id": "c5cc39d1-afbf-5ae6-86d8-298c8c4cf316",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2833c9d0-ed79-4413-922d-41be9f522a49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2833c9d0-ed79-4413-922d-41be9f522a49.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -31176,7 +31176,7 @@
         },
         {
             "id": "68e1ec40-2db5-5d84-858f-45525b20bf9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7939bd65-b5b2-4a11-90f2-234a146280ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/7939bd65-b5b2-4a11-90f2-234a146280ff.jpg?1",
             "name": "Clockspinning",
             "text": "",
             "colours": [
@@ -31209,7 +31209,7 @@
         },
         {
             "id": "157cfa18-74b9-50be-9892-206a325a5459",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed2c7dc-0727-4b38-9623-14f943f93feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ed2c7dc-0727-4b38-9623-14f943f93feb.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -31244,7 +31244,7 @@
         },
         {
             "id": "fdea3a25-63aa-58b4-ad7c-baddd72b6d07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d4ee7-d188-47e0-b1be-8add6e229356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308d4ee7-d188-47e0-b1be-8add6e229356.jpg?1",
             "name": "Ponder",
             "text": "",
             "colours": [
@@ -31277,7 +31277,7 @@
         },
         {
             "id": "4e9d5e10-a85c-54ce-bf63-a7a2cb2204bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f076fa76-5aef-4fa6-894c-f57e1926177a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f076fa76-5aef-4fa6-894c-f57e1926177a.jpg?1",
             "name": "Preordain",
             "text": "",
             "colours": [
@@ -31310,7 +31310,7 @@
         },
         {
             "id": "65f51606-0d40-5100-985d-9fc992fbe80b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3308ce8-df83-4f8e-b493-39f95b2d0237.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3308ce8-df83-4f8e-b493-39f95b2d0237.jpg?1",
             "name": "Propaganda",
             "text": "",
             "colours": [
@@ -31343,7 +31343,7 @@
         },
         {
             "id": "7728af0b-f119-535b-a71a-a6d6fe0599e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b90a2cc-a87d-4024-bc31-66ef00e04a90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b90a2cc-a87d-4024-bc31-66ef00e04a90.jpg?1",
             "name": "Think Twice",
             "text": "",
             "colours": [
@@ -31376,7 +31376,7 @@
         },
         {
             "id": "25e0f6f8-a37c-5586-88e9-e806599c530c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0ce1dd-befa-428b-b7e9-2c71e328f8b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d0ce1dd-befa-428b-b7e9-2c71e328f8b1.jpg?1",
             "name": "Feed the Swarm",
             "text": "",
             "colours": [
@@ -31409,7 +31409,7 @@
         },
         {
             "id": "0145b249-f2b1-5d54-8b9d-867f205e9b81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d70f4ea-49fb-46f0-b917-5607d944515c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d70f4ea-49fb-46f0-b917-5607d944515c.jpg?1",
             "name": "Snuff Out",
             "text": "",
             "colours": [
@@ -31442,7 +31442,7 @@
         },
         {
             "id": "9a2a0683-8300-52c6-9c46-43d499ea8d61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758383e-e70f-477b-a70b-09b2d25a6a92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0758383e-e70f-477b-a70b-09b2d25a6a92.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -31477,7 +31477,7 @@
         },
         {
             "id": "82f768aa-584f-5d23-a7f4-5217339532cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14e29c-a4f6-4491-a318-bf0cff4ae91c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f14e29c-a4f6-4491-a318-bf0cff4ae91c.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -31512,7 +31512,7 @@
         },
         {
             "id": "9a49e1ca-c163-5dbb-af4a-ec8c93d639ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ca8c7c-6c67-4d8d-abd2-0b4135a7072e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6ca8c7c-6c67-4d8d-abd2-0b4135a7072e.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -31547,7 +31547,7 @@
         },
         {
             "id": "6c48b689-2184-5a67-9a15-49595625adfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a325c-a0c2-4c9f-9162-063fc6071c22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c94a325c-a0c2-4c9f-9162-063fc6071c22.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -31582,7 +31582,7 @@
         },
         {
             "id": "819e2511-e6a3-5d6e-9da3-8f34c08de2b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e05245-54bf-4162-82ca-bc436b45e55b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e05245-54bf-4162-82ca-bc436b45e55b.jpg?1",
             "name": "Throes of Chaos",
             "text": "",
             "colours": [
@@ -31615,7 +31615,7 @@
         },
         {
             "id": "e1a57cc7-ab09-5e20-8fed-8e8a8d72dd5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072db20-b134-47bd-9b5b-a19a131ee738.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0072db20-b134-47bd-9b5b-a19a131ee738.jpg?1",
             "name": "Beast Within",
             "text": "",
             "colours": [
@@ -31648,7 +31648,7 @@
         },
         {
             "id": "06049f0d-404e-5120-af45-59a5dd288523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e6f8f9-c17c-4f96-9283-a8a4d27b4746.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86e6f8f9-c17c-4f96-9283-a8a4d27b4746.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -31683,7 +31683,7 @@
         },
         {
             "id": "b4df6209-d09c-596d-bacb-c196fa844c56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3889ea3-b7e0-446e-a8af-be284198a758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3889ea3-b7e0-446e-a8af-be284198a758.jpg?1",
             "name": "Cultivate",
             "text": "",
             "colours": [
@@ -31716,7 +31716,7 @@
         },
         {
             "id": "662c5c2b-4d18-5849-a012-23bc540270ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f8f2a4-ddfb-48b5-9ecb-73cf03a65f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f8f2a4-ddfb-48b5-9ecb-73cf03a65f8d.jpg?1",
             "name": "Explore",
             "text": "",
             "colours": [
@@ -31749,7 +31749,7 @@
         },
         {
             "id": "e3111845-03e8-5d76-8699-170a6e9ec16d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df75b100-b02c-41de-9292-798750e7c89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df75b100-b02c-41de-9292-798750e7c89f.jpg?1",
             "name": "Farseek",
             "text": "",
             "colours": [
@@ -31782,7 +31782,7 @@
         },
         {
             "id": "6abf4d32-e920-567f-a54f-6eb34a6aa649",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3c402f-3133-40f2-bfda-613e2d936044.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d3c402f-3133-40f2-bfda-613e2d936044.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -31817,7 +31817,7 @@
         },
         {
             "id": "e69f745b-476d-5301-83ff-459d00c4f709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b145c299-311a-4a76-944e-7d8aabb6857c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b145c299-311a-4a76-944e-7d8aabb6857c.jpg?1",
             "name": "Search for Tomorrow",
             "text": "",
             "colours": [
@@ -31850,7 +31850,7 @@
         },
         {
             "id": "5d214df8-fdb8-5fb6-bd14-b3ba01cc822f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a515b75-0adf-4f33-a33a-2ddf524b14d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a515b75-0adf-4f33-a33a-2ddf524b14d9.jpg?1",
             "name": "Three Visits",
             "text": "",
             "colours": [
@@ -31883,7 +31883,7 @@
         },
         {
             "id": "d1c28bcc-b189-5298-9d25-4347eb889ae5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3373a8a7-69a3-4011-a3dc-4e7c252dcd92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3373a8a7-69a3-4011-a3dc-4e7c252dcd92.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -31920,7 +31920,7 @@
         },
         {
             "id": "ac638550-1cf8-5428-b463-d6055cb3e844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db3b871-55fa-4a6a-8bae-b54ee642d039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3db3b871-55fa-4a6a-8bae-b54ee642d039.jpg?1",
             "name": "Growth Spiral",
             "text": "",
             "colours": [
@@ -31955,7 +31955,7 @@
         },
         {
             "id": "fee16a4a-ccba-548c-bbc9-83db79bbfe9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdde5ea-4a4f-4ca7-8326-92e83506518a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbdde5ea-4a4f-4ca7-8326-92e83506518a.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -31992,7 +31992,7 @@
         },
         {
             "id": "cd7d2432-c6a6-500b-a4d9-c700df5f155d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc52210-9de3-4392-9a11-87a67f56b92a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebc52210-9de3-4392-9a11-87a67f56b92a.jpg?1",
             "name": "Arcane Signet",
             "text": "",
             "colours": [],
@@ -32021,7 +32021,7 @@
         },
         {
             "id": "050ea007-3100-51bf-9a8b-19de08cf1c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7b3575-4942-4ce3-a6de-87c9c4568927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/ef7b3575-4942-4ce3-a6de-87c9c4568927.jpg?1",
             "name": "Commander's Sphere",
             "text": "",
             "colours": [],
@@ -32050,7 +32050,7 @@
         },
         {
             "id": "85110529-9f73-547b-8790-350a0537378e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99c9918-b7fb-4366-b15f-4645ea45928b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e99c9918-b7fb-4366-b15f-4645ea45928b.jpg?1",
             "name": "Hero's Blade",
             "text": "",
             "colours": [],
@@ -32081,7 +32081,7 @@
         },
         {
             "id": "34a3bb1f-4020-5038-8501-0df05cf9e21b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc631ce-4b0d-49da-a5ad-6f419678abb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc631ce-4b0d-49da-a5ad-6f419678abb4.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -32114,7 +32114,7 @@
         },
         {
             "id": "4e6f8602-7d44-5191-b4a1-a582cd3cacb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49404d84-bcd2-4893-906f-13c8a3b0d25b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49404d84-bcd2-4893-906f-13c8a3b0d25b.jpg?1",
             "name": "Lightning Greaves",
             "text": "",
             "colours": [],
@@ -32145,7 +32145,7 @@
         },
         {
             "id": "984464b0-0e87-59d5-8d22-c07018140ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3817d9a-0e1c-4eed-9593-78d481d3001b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3817d9a-0e1c-4eed-9593-78d481d3001b.jpg?1",
             "name": "Mind Stone",
             "text": "",
             "colours": [],
@@ -32174,7 +32174,7 @@
         },
         {
             "id": "5806536c-179c-5e58-864d-c1190a7039be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8262-4636-4a2c-a0c8-de741cf45aed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06be8262-4636-4a2c-a0c8-de741cf45aed.jpg?1",
             "name": "Sol Ring",
             "text": "",
             "colours": [],
@@ -32203,7 +32203,7 @@
         },
         {
             "id": "bf446c5f-05f5-5644-8767-4534d68dc383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea91e4d-c355-49ae-82e0-6dbd387714c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cea91e4d-c355-49ae-82e0-6dbd387714c3.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -32237,7 +32237,7 @@
         },
         {
             "id": "d4cf4001-f010-5b4c-ac2e-939b60fb0954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb81c294-f7cb-4351-96c5-d867c677ba15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb81c294-f7cb-4351-96c5-d867c677ba15.jpg?1",
             "name": "Talisman of Conviction",
             "text": "",
             "colours": [],
@@ -32269,7 +32269,7 @@
         },
         {
             "id": "5564510a-7281-5f76-b740-5bb297f1f299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43aa0a-d063-48af-b6d1-a89dbd803c83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f43aa0a-d063-48af-b6d1-a89dbd803c83.jpg?1",
             "name": "Talisman of Creativity",
             "text": "",
             "colours": [],
@@ -32301,7 +32301,7 @@
         },
         {
             "id": "33ad92bd-b638-51bc-b8e7-c48a7f2279b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fc32b4-d58d-4f9a-9af8-af145dd4c4a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72fc32b4-d58d-4f9a-9af8-af145dd4c4a8.jpg?1",
             "name": "Talisman of Curiosity",
             "text": "",
             "colours": [],
@@ -32333,7 +32333,7 @@
         },
         {
             "id": "6017edec-bca1-5c8c-b341-6dc19e4569ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e195d8cd-8c26-460d-85fc-964931a89b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e195d8cd-8c26-460d-85fc-964931a89b0b.jpg?1",
             "name": "Talisman of Dominance",
             "text": "",
             "colours": [],
@@ -32365,7 +32365,7 @@
         },
         {
             "id": "831d3854-e604-5ebe-9282-84fdce7df47a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6acffe-89ac-4426-8a7a-048d1f298362.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c6acffe-89ac-4426-8a7a-048d1f298362.jpg?1",
             "name": "Talisman of Impulse",
             "text": "",
             "colours": [],
@@ -32397,7 +32397,7 @@
         },
         {
             "id": "5bacfa30-0b59-5b4e-a59d-9acf91e49bc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eee538-03b1-4faa-af73-5897b9f41a5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13eee538-03b1-4faa-af73-5897b9f41a5d.jpg?1",
             "name": "Talisman of Indulgence",
             "text": "",
             "colours": [],
@@ -32429,7 +32429,7 @@
         },
         {
             "id": "eb8d8be8-6a4f-557a-885c-5375fb209de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a7fd9-0c09-4d61-8440-b9a82b71930a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254a7fd9-0c09-4d61-8440-b9a82b71930a.jpg?1",
             "name": "Talisman of Progress",
             "text": "",
             "colours": [],
@@ -32461,7 +32461,7 @@
         },
         {
             "id": "e13362f4-6a1e-5d1e-b16f-4c2d94bd060f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ecf6f5-b29a-4fd4-9fc4-e4947ff7c681.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ecf6f5-b29a-4fd4-9fc4-e4947ff7c681.jpg?1",
             "name": "Talisman of Unity",
             "text": "",
             "colours": [],
@@ -32493,7 +32493,7 @@
         },
         {
             "id": "1c5c5647-3acb-5902-a5c5-054a43aaf880",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf7e43-d0ba-4340-8d48-d775c7b36ab3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccf7e43-d0ba-4340-8d48-d775c7b36ab3.jpg?1",
             "name": "Thought Vessel",
             "text": "",
             "colours": [],
@@ -32522,7 +32522,7 @@
         },
         {
             "id": "10a0eccb-6989-5d2b-8e18-915a4de8ff2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ba5e0-9e25-4b9c-a992-2e818d9377bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a8ba5e0-9e25-4b9c-a992-2e818d9377bd.jpg?1",
             "name": "Wayfarer's Bauble",
             "text": "",
             "colours": [],
@@ -32551,7 +32551,7 @@
         },
         {
             "id": "c80d1a36-f2ba-50b0-b467-6e068b1b49e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494938cf-03a9-403a-bfd6-25ad9647b2e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/494938cf-03a9-403a-bfd6-25ad9647b2e6.jpg?1",
             "name": "Ash Barrens",
             "text": "",
             "colours": [],
@@ -32580,7 +32580,7 @@
         },
         {
             "id": "190f95cb-24b4-5abc-a7ff-eb3552faaf08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46f1b58-1948-47b0-94ba-18932691a4b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f46f1b58-1948-47b0-94ba-18932691a4b7.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -32617,7 +32617,7 @@
         },
         {
             "id": "b8396e38-f472-5dab-a3ee-1a482912d7c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d87fff-92c9-45eb-aebb-ed522a3e9e0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36d87fff-92c9-45eb-aebb-ed522a3e9e0a.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -32654,7 +32654,7 @@
         },
         {
             "id": "a55b639f-9146-5099-9722-64b8fd2c63f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b8a70b-94cd-431e-a0ac-1c1c04181df1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b8a70b-94cd-431e-a0ac-1c1c04181df1.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -32688,7 +32688,7 @@
         },
         {
             "id": "24047e9d-5cf8-5f3c-a68b-82ff270e68f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af9770-ecd5-47a1-9414-e6b53f959790.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20af9770-ecd5-47a1-9414-e6b53f959790.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -32722,7 +32722,7 @@
         },
         {
             "id": "0b5845dd-6604-5031-adf6-373c2c7fa415",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb1bb0b-4533-4c11-a9ee-f80438d031ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fb1bb0b-4533-4c11-a9ee-f80438d031ba.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -32759,7 +32759,7 @@
         },
         {
             "id": "2a60c795-b818-5ca6-9471-6316d5daaaa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b81040-cbce-4833-bc13-89aa707dcda7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6b81040-cbce-4833-bc13-89aa707dcda7.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32794,7 +32794,7 @@
         },
         {
             "id": "3d746924-163a-566b-ad6c-ce6747dbffa9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a60c53-4ba2-48cf-8b5f-08b80dbb960c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3a60c53-4ba2-48cf-8b5f-08b80dbb960c.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32829,7 +32829,7 @@
         },
         {
             "id": "14253164-b9e3-5069-9fa2-b2a76337f5c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef33ca3-9f5d-4e4a-a416-1dd3d1272e35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ef33ca3-9f5d-4e4a-a416-1dd3d1272e35.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32864,7 +32864,7 @@
         },
         {
             "id": "33a3057d-67f9-5df6-87c7-90ad1d0acad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cc78a-7bb0-4fa2-a63a-f8526ec5472b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a58cc78a-7bb0-4fa2-a63a-f8526ec5472b.jpg?1",
             "name": "Command Tower",
             "text": "",
             "colours": [],
@@ -32899,7 +32899,7 @@
         },
         {
             "id": "246de69d-1dae-5c22-b332-86fe18820123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2d6d-82ab-4e0a-8b0d-cc3c128b22b5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac9b2d6d-82ab-4e0a-8b0d-cc3c128b22b5.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -32933,7 +32933,7 @@
         },
         {
             "id": "b9aaadc5-7ad7-5b05-837e-c1753156c9d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda76016-58d1-4867-a55c-0f670ea4500b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dda76016-58d1-4867-a55c-0f670ea4500b.jpg?1",
             "name": "Crumbling Necropolis",
             "text": "",
             "colours": [],
@@ -32966,7 +32966,7 @@
         },
         {
             "id": "9ecacc1d-f494-57e4-abd8-fba1d9881b86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6916a-d487-4998-9d1b-15d34f1a56bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13f6916a-d487-4998-9d1b-15d34f1a56bb.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -33000,7 +33000,7 @@
         },
         {
             "id": "91aab8db-ec58-5e02-9e86-47b7d3f403e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98967b8d-d2ee-4131-b614-44cc3e403917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98967b8d-d2ee-4131-b614-44cc3e403917.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -33034,7 +33034,7 @@
         },
         {
             "id": "f1e65d28-b8d3-5f0f-b5c2-2263954e39f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6680767-a84a-4a98-9075-596adfc5dc88.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6680767-a84a-4a98-9075-596adfc5dc88.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -33068,7 +33068,7 @@
         },
         {
             "id": "bec7d13b-7344-5f86-ba7b-650b2615bd95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4970a2-4f9d-46a1-a80d-c0764eed3023.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be4970a2-4f9d-46a1-a80d-c0764eed3023.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -33102,7 +33102,7 @@
         },
         {
             "id": "25a9310f-6b09-5b9d-8c03-5a1a947f6932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3279f8e-c508-428d-ab5e-f25d635d8444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3279f8e-c508-428d-ab5e-f25d635d8444.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -33136,7 +33136,7 @@
         },
         {
             "id": "68885dbb-c6bc-590d-9e9e-8db6b27e4432",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5043715-8ad3-44cc-a694-400b67db269d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a5043715-8ad3-44cc-a694-400b67db269d.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -33170,7 +33170,7 @@
         },
         {
             "id": "fd654771-7cac-545e-a8a5-0fe5f870d4eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aa2331-4bd0-482d-8009-d5dd820f5725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aa2331-4bd0-482d-8009-d5dd820f5725.jpg?1",
             "name": "Evolving Wilds",
             "text": "",
             "colours": [],
@@ -33199,7 +33199,7 @@
         },
         {
             "id": "b08321bb-d1dc-54c6-bd7d-ef53ade3f491",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d78fb5e-35e9-4759-b783-bf13bae271fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d78fb5e-35e9-4759-b783-bf13bae271fa.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -33230,7 +33230,7 @@
         },
         {
             "id": "0316309c-49bd-5099-b6fc-5d020dca34ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f00c7f-8fe9-4570-886a-e43f6206efbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08f00c7f-8fe9-4570-886a-e43f6206efbf.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -33267,7 +33267,7 @@
         },
         {
             "id": "dfbb5316-5cbe-5312-beb2-2c05b213f00b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b51d3e-a870-4e96-9396-7d47ae4f2961.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22b51d3e-a870-4e96-9396-7d47ae4f2961.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -33301,7 +33301,7 @@
         },
         {
             "id": "c14b0ae4-9e78-5b76-9790-31fa31480cb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecc8eb-6e28-49b6-b2db-6c9fadb084f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aecc8eb-6e28-49b6-b2db-6c9fadb084f8.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -33335,7 +33335,7 @@
         },
         {
             "id": "451039b2-4476-5516-a3be-c3a5d5d0ce5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd50305e-3c7b-4ef5-a093-da7bbdbd6249.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd50305e-3c7b-4ef5-a093-da7bbdbd6249.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -33369,7 +33369,7 @@
         },
         {
             "id": "3d5e1b82-1f9a-5760-a02b-b198b341bb21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24442f-b01e-4af8-8039-49373ebc4016.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d24442f-b01e-4af8-8039-49373ebc4016.jpg?1",
             "name": "Frontier Bivouac",
             "text": "",
             "colours": [],
@@ -33402,7 +33402,7 @@
         },
         {
             "id": "e495d9da-4352-5efe-abdf-27e0d9d4abeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51446e-b198-4495-9cbc-296a8e7bf2fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e51446e-b198-4495-9cbc-296a8e7bf2fc.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -33436,7 +33436,7 @@
         },
         {
             "id": "68bc0a1b-762e-525e-b2be-92312aa988bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c091056b-25bd-4014-b19b-ceae26a293a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c091056b-25bd-4014-b19b-ceae26a293a8.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -33470,7 +33470,7 @@
         },
         {
             "id": "dcad56c0-1d03-52f2-9133-b17ba5f69075",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10831dd5-d048-4751-94bb-560a1f03277d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10831dd5-d048-4751-94bb-560a1f03277d.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -33504,7 +33504,7 @@
         },
         {
             "id": "76bb3b6e-98b9-53c2-880d-280bae3630e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9759472-1f44-4c2b-9afb-8507f3168840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9759472-1f44-4c2b-9afb-8507f3168840.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -33538,7 +33538,7 @@
         },
         {
             "id": "b51e8c32-ae2a-585e-966d-892b8be8a664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298d6db-daf6-4aed-91f9-076debdf9533.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b298d6db-daf6-4aed-91f9-076debdf9533.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -33572,7 +33572,7 @@
         },
         {
             "id": "9114a647-9d45-5788-9d12-5c027b7ae875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb64334-a911-49c3-934a-7d77f4fb4f5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cb64334-a911-49c3-934a-7d77f4fb4f5b.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -33606,7 +33606,7 @@
         },
         {
             "id": "c62de117-4541-5943-8899-f2705290567d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873ea903-cbbc-48b8-8a67-fe612996deab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/873ea903-cbbc-48b8-8a67-fe612996deab.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -33643,7 +33643,7 @@
         },
         {
             "id": "ae1f57f1-0895-57cf-bf18-20a6ca42b6b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d94b75-22e5-4696-bfde-11777e2aee2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11d94b75-22e5-4696-bfde-11777e2aee2f.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -33677,7 +33677,7 @@
         },
         {
             "id": "caa6382c-a8ee-5b67-9230-1a65268a94ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375e1986-678a-4a51-b2a7-61b1f936fe39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/375e1986-678a-4a51-b2a7-61b1f936fe39.jpg?1",
             "name": "Myriad Landscape",
             "text": "",
             "colours": [],
@@ -33706,7 +33706,7 @@
         },
         {
             "id": "bb57af21-d243-592a-9e6a-c3c573ebd159",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51faff0a-1006-4bc5-adb6-4ff3d7f07326.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51faff0a-1006-4bc5-adb6-4ff3d7f07326.jpg?1",
             "name": "Mystic Monastery",
             "text": "",
             "colours": [],
@@ -33739,7 +33739,7 @@
         },
         {
             "id": "c97638b8-289a-55b1-9bfc-0fed06fce55b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef2c66-853d-4b49-9a88-42c6c9b0d47b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ef2c66-853d-4b49-9a88-42c6c9b0d47b.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -33773,7 +33773,7 @@
         },
         {
             "id": "770564c0-1e82-532d-8cbf-8f4dfc8da3f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afc4565-923f-4ad4-a9e9-5113a53386c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7afc4565-923f-4ad4-a9e9-5113a53386c5.jpg?1",
             "name": "Path of Ancestry",
             "text": "",
             "colours": [],
@@ -33802,7 +33802,7 @@
         },
         {
             "id": "3656fe4d-8bfe-57e1-badd-6e42938b769e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fcd68-1b41-47a1-bb31-7bf91f80168f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c38fcd68-1b41-47a1-bb31-7bf91f80168f.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -33836,7 +33836,7 @@
         },
         {
             "id": "e3831ca0-6df1-5ce0-bbf2-ee07c6f0003b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d35c1c-dbc3-4787-a7e5-9c1a02f95222.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d35c1c-dbc3-4787-a7e5-9c1a02f95222.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -33873,7 +33873,7 @@
         },
         {
             "id": "fc1e3294-eb39-5c19-96f4-54e6623fe841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add0acb4-9f98-46d7-9c4b-7945dc1b05d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/add0acb4-9f98-46d7-9c4b-7945dc1b05d1.jpg?1",
             "name": "Reliquary Tower",
             "text": "",
             "colours": [],
@@ -33902,7 +33902,7 @@
         },
         {
             "id": "49457a5d-8cca-54c3-b074-91fc578f2f87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56002ea-7c0d-4d7b-9887-477340370b16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d56002ea-7c0d-4d7b-9887-477340370b16.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -33936,7 +33936,7 @@
         },
         {
             "id": "e0660bf9-6453-54f9-a13a-af2ad23d2747",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a6e6e-90b6-4fd7-a3df-a669327ca24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f70a6e6e-90b6-4fd7-a3df-a669327ca24c.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -33970,7 +33970,7 @@
         },
         {
             "id": "41180796-455b-5bf5-ace8-237681868908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c55a2e4-a041-4190-ae69-645347cb3b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c55a2e4-a041-4190-ae69-645347cb3b58.jpg?1",
             "name": "Rogue's Passage",
             "text": "",
             "colours": [],
@@ -33999,7 +33999,7 @@
         },
         {
             "id": "fdcc0a59-a9aa-5eb7-9d7f-f92a278277ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e244138-e378-4bff-98be-03693a87b9af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e244138-e378-4bff-98be-03693a87b9af.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -34033,7 +34033,7 @@
         },
         {
             "id": "e2315f15-87a4-5de8-a5a3-947304034a5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f0a4f-6eec-47ef-ae66-38d99c5bf402.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f0a4f-6eec-47ef-ae66-38d99c5bf402.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -34070,7 +34070,7 @@
         },
         {
             "id": "7d66d225-ca10-5420-8054-063b6db13cbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f6558d-ee71-4d37-9354-8bd36a0aacc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f6558d-ee71-4d37-9354-8bd36a0aacc9.jpg?1",
             "name": "Seaside Citadel",
             "text": "",
             "colours": [],
@@ -34103,7 +34103,7 @@
         },
         {
             "id": "7a467680-2360-50cd-b94f-cd9f58908480",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cbf21e-2789-4d1b-ac91-3539f809f68f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51cbf21e-2789-4d1b-ac91-3539f809f68f.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -34137,7 +34137,7 @@
         },
         {
             "id": "4916e3ab-6f37-52ed-97b6-7eedbf0f513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daab81ac-9adc-4b82-b2e5-16f0f13475b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/daab81ac-9adc-4b82-b2e5-16f0f13475b7.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -34174,7 +34174,7 @@
         },
         {
             "id": "b58366da-8437-5569-8ee7-41e2afa538d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fca63-a979-40d1-9c5e-54f667c5c1f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf7fca63-a979-40d1-9c5e-54f667c5c1f5.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -34208,7 +34208,7 @@
         },
         {
             "id": "51b33d23-9c9e-5a98-873c-b5b6336adddb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3c66d4-c12f-4cc1-863d-4b48c64a812d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b3c66d4-c12f-4cc1-863d-4b48c64a812d.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -34242,7 +34242,7 @@
         },
         {
             "id": "fe9f8a1a-dcab-545a-b208-e26937eb3cd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c89e444-8292-4784-bfe8-8a8ea7d8cdcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c89e444-8292-4784-bfe8-8a8ea7d8cdcd.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -34279,7 +34279,7 @@
         },
         {
             "id": "4e6d1c0b-12f4-5cc9-9f8b-9e406e4103e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a4c8d-fdc1-4140-bc2e-eabc4c91d1c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/293a4c8d-fdc1-4140-bc2e-eabc4c91d1c1.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -34313,7 +34313,7 @@
         },
         {
             "id": "2e5c84fb-e904-5087-8364-4c7caeb711b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2510ee-9454-4792-8209-ab62d0bc02bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d2510ee-9454-4792-8209-ab62d0bc02bb.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -34347,7 +34347,7 @@
         },
         {
             "id": "ce0ec101-d6e5-5575-82b6-797c5c01e98b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a983e29-cb13-4000-b09d-c325152eb481.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a983e29-cb13-4000-b09d-c325152eb481.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -34381,7 +34381,7 @@
         },
         {
             "id": "edc9095b-937d-5fe8-87d1-00e9bacfe3f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302e3173-f035-4d26-9aa6-7c4351739cf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/302e3173-f035-4d26-9aa6-7c4351739cf2.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -34415,7 +34415,7 @@
         },
         {
             "id": "7fe06800-acd3-5b92-b22a-b3a2189850de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576525b-ab90-4e06-8d70-95dd27eb5588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9576525b-ab90-4e06-8d70-95dd27eb5588.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -34452,7 +34452,7 @@
         },
         {
             "id": "bc5c4ae5-2077-588a-ab6b-6111a590457d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03148778-0471-47a6-a43f-232dbf52b0e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03148778-0471-47a6-a43f-232dbf52b0e2.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -34486,7 +34486,7 @@
         },
         {
             "id": "88b26d20-4359-54aa-9ae7-c9d7fe0c7694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22e560-353c-45aa-bfc7-ad56dab01445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf22e560-353c-45aa-bfc7-ad56dab01445.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -34520,7 +34520,7 @@
         },
         {
             "id": "a31d9c36-4db6-5c41-be7e-63014a4cbb39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108131c-9a63-4217-bcaa-ea994260b517.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f108131c-9a63-4217-bcaa-ea994260b517.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -34554,7 +34554,7 @@
         },
         {
             "id": "f1749655-cf27-50a4-9b3d-e9cbebd7d8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879164f3-2434-4393-8901-7e51c9c9472f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/879164f3-2434-4393-8901-7e51c9c9472f.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -34588,7 +34588,7 @@
         },
         {
             "id": "e3918349-ac37-55e0-8370-efa157aa84ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee649-5464-45b4-8fa6-05333c577420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9ee649-5464-45b4-8fa6-05333c577420.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -34622,7 +34622,7 @@
         },
         {
             "id": "b1ef436d-6e96-5b32-b894-54855029f115",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee03d883-7693-408e-9bc2-1db4cbcf005e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee03d883-7693-408e-9bc2-1db4cbcf005e.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -34656,7 +34656,7 @@
         },
         {
             "id": "83d1a97c-d00d-5b03-9149-4c2d8ed638c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cf35a-d9ce-4f14-8a9c-7f4ec4613a22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a5cf35a-d9ce-4f14-8a9c-7f4ec4613a22.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -34690,7 +34690,7 @@
         },
         {
             "id": "e5b21aea-a627-5454-84c6-200fc0118967",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b63bd2-38ad-4a41-9a08-0580bdfb30fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59b63bd2-38ad-4a41-9a08-0580bdfb30fd.jpg?1",
             "name": "Temple of the False God",
             "text": "",
             "colours": [],
@@ -34719,7 +34719,7 @@
         },
         {
             "id": "5a6830ee-bc5a-572f-b7d9-4deea6393a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd210e96-7499-431b-aac2-2412ada82431.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd210e96-7499-431b-aac2-2412ada82431.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -34753,7 +34753,7 @@
         },
         {
             "id": "d52a6d03-f550-564e-a7e2-74c9c201c621",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537f1fa1-1ae6-4ec1-ba87-4d64f9d3b12b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/537f1fa1-1ae6-4ec1-ba87-4d64f9d3b12b.jpg?1",
             "name": "Terramorphic Expanse",
             "text": "",
             "colours": [],
@@ -34782,7 +34782,7 @@
         },
         {
             "id": "f6d38a0d-41c6-5cd2-b108-82a97d7ec402",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc82744-f5da-438c-9ecf-1c286d9d78d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4bc82744-f5da-438c-9ecf-1c286d9d78d3.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -34813,7 +34813,7 @@
         },
         {
             "id": "ce02bc5a-917e-5a0f-9f67-742d07a4109c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754e057-2ce2-4c19-a04f-35e646a32817.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f754e057-2ce2-4c19-a04f-35e646a32817.jpg?1",
             "name": "Thriving Bluff",
             "text": "",
             "colours": [],
@@ -34844,7 +34844,7 @@
         },
         {
             "id": "b819fd62-6023-520c-af46-c91827b07b33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e65150-4990-48b2-88c9-affdc5333e8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27e65150-4990-48b2-88c9-affdc5333e8b.jpg?1",
             "name": "Thriving Grove",
             "text": "",
             "colours": [],
@@ -34875,7 +34875,7 @@
         },
         {
             "id": "c2879176-085e-5bf2-9eac-4ccb3d1dc79e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bea150-fc4b-4ee9-9563-d52abd9ca848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98bea150-fc4b-4ee9-9563-d52abd9ca848.jpg?1",
             "name": "Thriving Heath",
             "text": "",
             "colours": [],
@@ -34906,7 +34906,7 @@
         },
         {
             "id": "09555fa1-ac6e-5792-8f0e-81aa09e5ce3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1ad2a-7e0a-4e1d-9a43-98e76c52cd7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47a1ad2a-7e0a-4e1d-9a43-98e76c52cd7a.jpg?1",
             "name": "Thriving Isle",
             "text": "",
             "colours": [],
@@ -34937,7 +34937,7 @@
         },
         {
             "id": "5248a83c-1e52-5fd3-91ce-a82f0566d2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceadb155-d6dc-4b02-9ce8-bf1452cf655d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ceadb155-d6dc-4b02-9ce8-bf1452cf655d.jpg?1",
             "name": "Thriving Moor",
             "text": "",
             "colours": [],
@@ -34968,7 +34968,7 @@
         },
         {
             "id": "7df78c1c-ba7e-549e-94c2-95ef108d9b67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185e41a-bad8-4732-9396-a412bce67a73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5185e41a-bad8-4732-9396-a412bce67a73.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -35002,7 +35002,7 @@
         },
         {
             "id": "f27df5d6-1ffc-523c-a777-25ada9eca1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf2cbe-fb56-424f-b1f8-ef80bdf0ae77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cf2cbe-fb56-424f-b1f8-ef80bdf0ae77.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -35033,7 +35033,7 @@
         },
         {
             "id": "e8ee3dfd-5734-562d-8e96-3f2c620b6152",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ca4c3e-9d81-4897-bece-fec88d3a58e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20ca4c3e-9d81-4897-bece-fec88d3a58e7.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -35067,7 +35067,7 @@
         },
         {
             "id": "910509c6-7a6a-561d-a311-20a655561a9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f7d709-74bb-4085-bf69-bdab4c1ae26d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f7d709-74bb-4085-bf69-bdab4c1ae26d.jpg?1",
             "name": "Clara Oswald",
             "text": "",
             "colours": [],
@@ -35103,7 +35103,7 @@
         },
         {
             "id": "fa50e9be-81c2-5a53-9b68-47947f2a75d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333c352-9edd-425e-80d8-7d61c76da298.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d333c352-9edd-425e-80d8-7d61c76da298.jpg?1",
             "name": "Adipose Offspring",
             "text": "",
             "colours": [
@@ -35140,7 +35140,7 @@
         },
         {
             "id": "e5e2ec3a-e943-5ff9-b2f2-aa2e23e98982",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c48102-e213-4188-a2a7-5a9adae3f693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c48102-e213-4188-a2a7-5a9adae3f693.jpg?1",
             "name": "Astrid Peth",
             "text": "",
             "colours": [
@@ -35179,7 +35179,7 @@
         },
         {
             "id": "8dfb33ef-e879-5ffb-a18b-b21258eb84c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653b9e87-9230-4f96-bf60-d6be6b150e7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/653b9e87-9230-4f96-bf60-d6be6b150e7a.jpg?1",
             "name": "Barbara Wright",
             "text": "",
             "colours": [
@@ -35219,7 +35219,7 @@
         },
         {
             "id": "5748324e-aa24-52fc-a6c7-4938c87ef0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cca38da-6278-4ebe-8b62-a457876a2669.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cca38da-6278-4ebe-8b62-a457876a2669.jpg?1",
             "name": "Crack in Time",
             "text": "",
             "colours": [
@@ -35254,7 +35254,7 @@
         },
         {
             "id": "dcd929c6-3826-539a-92e7-006a70519317",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de3ee91-b361-45ae-8a8a-cdb5eb9e4f11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de3ee91-b361-45ae-8a8a-cdb5eb9e4f11.jpg?1",
             "name": "Crisis of Conscience",
             "text": "",
             "colours": [
@@ -35289,7 +35289,7 @@
         },
         {
             "id": "f5b1b77e-19d8-5fd9-a528-f92f8d863253",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2e371e-7f5b-4fb5-9c6c-49443ef19703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac2e371e-7f5b-4fb5-9c6c-49443ef19703.jpg?1",
             "name": "Everybody Lives!",
             "text": "",
             "colours": [
@@ -35324,7 +35324,7 @@
         },
         {
             "id": "ddbb35ac-4e23-59e5-900d-4805e02a9cc3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c825df-8fa8-4c07-a9b7-cafbb6508c3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43c825df-8fa8-4c07-a9b7-cafbb6508c3c.jpg?1",
             "name": "Everything Comes to Dust",
             "text": "",
             "colours": [
@@ -35359,7 +35359,7 @@
         },
         {
             "id": "cf5c336a-b400-5210-83e0-7221fc7d9724",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fd8cdb-4608-4bfa-b100-51b964439179.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64fd8cdb-4608-4bfa-b100-51b964439179.jpg?1",
             "name": "Four Knocks",
             "text": "",
             "colours": [
@@ -35394,7 +35394,7 @@
         },
         {
             "id": "e23310f7-1e90-5e36-8e3c-3d18d3e9355e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3b424b-8695-40e7-bb50-933c9c62f4cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3b424b-8695-40e7-bb50-933c9c62f4cf.jpg?1",
             "name": "Ian Chesterton",
             "text": "",
             "colours": [
@@ -35434,7 +35434,7 @@
         },
         {
             "id": "527e8bcd-f648-5225-a2a4-2267ddaac1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa35c60-3d9d-4022-97c3-4eeff398c895.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa35c60-3d9d-4022-97c3-4eeff398c895.jpg?1",
             "name": "Jo Grant",
             "text": "",
             "colours": [
@@ -35474,7 +35474,7 @@
         },
         {
             "id": "a5788234-60a8-5196-87d7-a79e19e3a363",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0777c9e1-0c21-44a1-93ce-bbac00e4cff3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0777c9e1-0c21-44a1-93ce-bbac00e4cff3.jpg?1",
             "name": "The Pandorica",
             "text": "",
             "colours": [
@@ -35511,7 +35511,7 @@
         },
         {
             "id": "55dd12de-a230-5928-9125-9b16fd8c926d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abda47c-a50e-4354-a044-4186c1d22f89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4abda47c-a50e-4354-a044-4186c1d22f89.jpg?1",
             "name": "Peri Brown",
             "text": "",
             "colours": [
@@ -35550,7 +35550,7 @@
         },
         {
             "id": "83647813-09f2-53cb-9841-0fb67f702e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a7d6e5-9372-46cc-be26-03f66a21d539.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a7d6e5-9372-46cc-be26-03f66a21d539.jpg?1",
             "name": "Romana II",
             "text": "",
             "colours": [
@@ -35590,7 +35590,7 @@
         },
         {
             "id": "5aa23ff5-f53b-5c43-ac03-094f6558b828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832a6eb-72c9-4480-a173-20588e688b11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7832a6eb-72c9-4480-a173-20588e688b11.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -35631,7 +35631,7 @@
         },
         {
             "id": "da170d24-a691-53f0-a819-4a30a6da773d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a86e0-413c-45a0-a4c0-d85fe74361c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f1a86e0-413c-45a0-a4c0-d85fe74361c1.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -35673,7 +35673,7 @@
         },
         {
             "id": "e174bf4b-3b6b-54fa-8889-ab4973f0b654",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbda79c-5d9a-4b66-b7a9-556b296d71fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fbda79c-5d9a-4b66-b7a9-556b296d71fd.jpg?1",
             "name": "Tegan Jovanka",
             "text": "",
             "colours": [
@@ -35712,7 +35712,7 @@
         },
         {
             "id": "9d6a0ecd-d23d-5816-a89d-5d5034cabfb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be35975-fac5-448d-a18e-7b05dcc57f02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4be35975-fac5-448d-a18e-7b05dcc57f02.jpg?1",
             "name": "The Wedding of River Song",
             "text": "",
             "colours": [
@@ -35747,7 +35747,7 @@
         },
         {
             "id": "f2080843-b480-5aee-a8c2-e1baa437f557",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2488d86-a7ea-4c00-bc0a-7ebafc6e165f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2488d86-a7ea-4c00-bc0a-7ebafc6e165f.jpg?1",
             "name": "Wilfred Mott",
             "text": "",
             "colours": [
@@ -35787,7 +35787,7 @@
         },
         {
             "id": "0d73347f-ad5c-522c-ada8-20460181b9a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176a1504-262b-48f5-92a8-9e29cb397366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/176a1504-262b-48f5-92a8-9e29cb397366.jpg?1",
             "name": "Adric, Mathematical Genius",
             "text": "",
             "colours": [
@@ -35827,7 +35827,7 @@
         },
         {
             "id": "d672fa55-dc78-53c0-9de5-a5796c3796d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c61ba76-14fa-4a57-b2a8-3b701ba1df30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c61ba76-14fa-4a57-b2a8-3b701ba1df30.jpg?1",
             "name": "All of History, All at Once",
             "text": "",
             "colours": [
@@ -35862,7 +35862,7 @@
         },
         {
             "id": "62d8f92b-8e8e-502a-aa53-d80a3d085f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44771a2-899e-4259-af49-4993f8a5865b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a44771a2-899e-4259-af49-4993f8a5865b.jpg?1",
             "name": "Auton Soldier",
             "text": "",
             "colours": [
@@ -35901,7 +35901,7 @@
         },
         {
             "id": "f8635a28-98f5-56db-bcef-1e9efa7b3b0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0a7b62-ac10-4f71-91e3-870853e43b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db0a7b62-ac10-4f71-91e3-870853e43b1c.jpg?1",
             "name": "Become the Pilot",
             "text": "",
             "colours": [
@@ -35938,7 +35938,7 @@
         },
         {
             "id": "0779716b-f728-5665-90f1-7fcafb1427d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed19c7cb-41cc-499f-ae76-fa08262f0834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed19c7cb-41cc-499f-ae76-fa08262f0834.jpg?1",
             "name": "Cyber Conversion",
             "text": "",
             "colours": [
@@ -35973,7 +35973,7 @@
         },
         {
             "id": "12de237a-6fe8-582f-a542-654fcaf350f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93c9838-e041-4ca4-9a39-49df328e3dd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93c9838-e041-4ca4-9a39-49df328e3dd1.jpg?1",
             "name": "Danny Pink",
             "text": "",
             "colours": [
@@ -36014,7 +36014,7 @@
         },
         {
             "id": "8b658c18-6ef1-5958-999a-d02bfc22fce2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00932f-96eb-414f-a8f5-c4f627fdba98.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac00932f-96eb-414f-a8f5-c4f627fdba98.jpg?1",
             "name": "Five Hundred Year Diary",
             "text": "",
             "colours": [
@@ -36053,7 +36053,7 @@
         },
         {
             "id": "71faa59b-31f8-555d-ac56-780ca02f6b08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5e0f58-5cc1-4cf5-9bb7-da45a6e0bd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a5e0f58-5cc1-4cf5-9bb7-da45a6e0bd0e.jpg?1",
             "name": "Flatline",
             "text": "",
             "colours": [
@@ -36088,7 +36088,7 @@
         },
         {
             "id": "fbd246eb-a514-5978-b723-fcb0df42bc0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b37617e-bba7-4d85-8092-9b43be7fec40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b37617e-bba7-4d85-8092-9b43be7fec40.jpg?1",
             "name": "Flesh Duplicate",
             "text": "",
             "colours": [
@@ -36126,7 +36126,7 @@
         },
         {
             "id": "4c5cdba4-105e-5c99-94d5-4cf0e3ea27cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e77feb-1a6a-4183-bcae-3e3d4d4566d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96e77feb-1a6a-4183-bcae-3e3d4d4566d4.jpg?1",
             "name": "The Flood of Mars",
             "text": "",
             "colours": [
@@ -36165,7 +36165,7 @@
         },
         {
             "id": "118043dd-0754-5b87-b1c8-497e9be28832",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78332c23-4d73-4aec-b3fc-2d6340a03f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78332c23-4d73-4aec-b3fc-2d6340a03f1c.jpg?1",
             "name": "Hunted by The Family",
             "text": "",
             "colours": [
@@ -36200,7 +36200,7 @@
         },
         {
             "id": "6372ae20-fdd8-5e72-b4cd-e28d8258a440",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f151285-08a7-4148-950e-82ccb36502bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f151285-08a7-4148-950e-82ccb36502bf.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -36243,7 +36243,7 @@
         },
         {
             "id": "6d90869c-4c2e-5c07-b7f1-67df42f5f6a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6335929d-6de3-4278-9f4b-883453ad1dc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6335929d-6de3-4278-9f4b-883453ad1dc6.jpg?1",
             "name": "Martha Jones",
             "text": "",
             "colours": [
@@ -36283,7 +36283,7 @@
         },
         {
             "id": "65ca1316-7d08-5260-89c9-c2a4016829a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69086404-c405-4d08-a6d4-7daaa1d2f11c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69086404-c405-4d08-a6d4-7daaa1d2f11c.jpg?1",
             "name": "Nanogene Conversion",
             "text": "",
             "colours": [
@@ -36318,7 +36318,7 @@
         },
         {
             "id": "4309d7c6-3632-5216-8160-654386d67bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42832b1c-e38e-4d06-809c-31a7250566ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42832b1c-e38e-4d06-809c-31a7250566ad.jpg?1",
             "name": "Nardole, Resourceful Cyborg",
             "text": "",
             "colours": [
@@ -36358,7 +36358,7 @@
         },
         {
             "id": "b29c9281-9d80-57a3-9c64-2404b384168c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b212e7d-2ea1-4ba7-a060-c67d44e259a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b212e7d-2ea1-4ba7-a060-c67d44e259a7.jpg?1",
             "name": "Nyssa of Traken",
             "text": "",
             "colours": [
@@ -36398,7 +36398,7 @@
         },
         {
             "id": "1b1529b2-b4e6-58b6-aabd-fdef9131465b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ce4ff5-7b9e-4ef8-9a7e-9d148983b04e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ce4ff5-7b9e-4ef8-9a7e-9d148983b04e.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -36439,7 +36439,7 @@
         },
         {
             "id": "4305c4de-832f-5386-a2f2-1174ad5c0636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cddd4ff-0c56-41b5-a865-5d3f55141ae3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cddd4ff-0c56-41b5-a865-5d3f55141ae3.jpg?1",
             "name": "Quantum Misalignment",
             "text": "",
             "colours": [
@@ -36474,7 +36474,7 @@
         },
         {
             "id": "0b8fc043-5bcd-5f60-8f93-fcd6c005adcc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b101a18-cb20-4511-96bc-03d32bfe1a03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b101a18-cb20-4511-96bc-03d32bfe1a03.jpg?1",
             "name": "Reverse the Polarity",
             "text": "",
             "colours": [
@@ -36509,7 +36509,7 @@
         },
         {
             "id": "e6b4d18f-31e2-521c-ae80-d0a4ecfaa203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c512b-adc8-4ce2-80e5-28a3b827d40f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c6c512b-adc8-4ce2-80e5-28a3b827d40f.jpg?1",
             "name": "Traverse Eternity",
             "text": "",
             "colours": [
@@ -36544,7 +36544,7 @@
         },
         {
             "id": "2311bcd9-8759-582a-8545-0dbf8a51e01a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0829742d-7268-46a3-a8f3-172559b1315f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0829742d-7268-46a3-a8f3-172559b1315f.jpg?1",
             "name": "Dalek Drone",
             "text": "",
             "colours": [
@@ -36582,7 +36582,7 @@
         },
         {
             "id": "8c49c218-8c3d-5069-b6db-7c948ac7b661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70606b58-b72e-46b4-931e-5e2490a83b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70606b58-b72e-46b4-931e-5e2490a83b29.jpg?1",
             "name": "Doomsday Confluence",
             "text": "",
             "colours": [
@@ -36617,7 +36617,7 @@
         },
         {
             "id": "0fe916df-29c8-5444-a257-072631740462",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecb70ba-2b35-4032-9d2c-ce64099b9719.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ecb70ba-2b35-4032-9d2c-ce64099b9719.jpg?1",
             "name": "This Is How It Ends",
             "text": "",
             "colours": [
@@ -36652,7 +36652,7 @@
         },
         {
             "id": "10411783-1b13-577b-b9be-1d74ee483140",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fb923e-bf9a-46e6-827a-035b3c360edf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fb923e-bf9a-46e6-827a-035b3c360edf.jpg?1",
             "name": "Time Reaper",
             "text": "",
             "colours": [
@@ -36690,7 +36690,7 @@
         },
         {
             "id": "e686f379-50f2-55c8-bfa6-3c3671e6a558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf950d-bf1b-4ee6-9ffe-326473d7c704.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70bf950d-bf1b-4ee6-9ffe-326473d7c704.jpg?1",
             "name": "The Toymaker's Trap",
             "text": "",
             "colours": [
@@ -36725,7 +36725,7 @@
         },
         {
             "id": "5de3c0d5-5b87-5022-83af-10eb31d20694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abacd86-9e99-4a9a-863c-260596201039.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8abacd86-9e99-4a9a-863c-260596201039.jpg?1",
             "name": "Vashta Nerada",
             "text": "",
             "colours": [
@@ -36763,7 +36763,7 @@
         },
         {
             "id": "341f8754-c5cd-5aeb-af39-aef4dd58c32c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab01ba9-0f4a-49b9-b7dc-0db1b48e7420.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ab01ba9-0f4a-49b9-b7dc-0db1b48e7420.jpg?1",
             "name": "Vislor Turlough",
             "text": "",
             "colours": [
@@ -36802,7 +36802,7 @@
         },
         {
             "id": "a1167081-6848-5839-866f-01bc8c58ff97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb9f82-bccd-4444-8439-b6c872a17589.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dafb9f82-bccd-4444-8439-b6c872a17589.jpg?1",
             "name": "Amy Pond",
             "text": "",
             "colours": [
@@ -36841,7 +36841,7 @@
         },
         {
             "id": "bfe95642-3aeb-557f-be5a-3ecce4176d34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff8d9c3-143b-4558-81bc-82845bc45342.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7ff8d9c3-143b-4558-81bc-82845bc45342.jpg?1",
             "name": "Bill Potts",
             "text": "",
             "colours": [
@@ -36880,7 +36880,7 @@
         },
         {
             "id": "77c279ca-fa98-5e30-9ec1-7abf117511ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51591756-3a27-4b2b-9ee4-cf2e24656246.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51591756-3a27-4b2b-9ee4-cf2e24656246.jpg?1",
             "name": "Dan Lewis",
             "text": "",
             "colours": [
@@ -36919,7 +36919,7 @@
         },
         {
             "id": "0faf45c6-d4c2-564b-a867-6c97f23a342d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08f8c11-7f61-4856-bc45-5f3d91750093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b08f8c11-7f61-4856-bc45-5f3d91750093.jpg?1",
             "name": "Delete",
             "text": "",
             "colours": [
@@ -36954,7 +36954,7 @@
         },
         {
             "id": "da1de919-89a7-5097-8451-66095ed3b346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804d844b-9aae-46fe-8146-3b1b08c4cb50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/804d844b-9aae-46fe-8146-3b1b08c4cb50.jpg?1",
             "name": "Donna Noble",
             "text": "",
             "colours": [
@@ -36993,7 +36993,7 @@
         },
         {
             "id": "6e39ea1a-f12d-56b9-a253-26cf197d0efd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e1fe57-63db-4fe0-8ecc-877f808555b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6e1fe57-63db-4fe0-8ecc-877f808555b8.jpg?1",
             "name": "Ecstatic Beauty",
             "text": "",
             "colours": [
@@ -37028,7 +37028,7 @@
         },
         {
             "id": "e2959175-e879-5fd8-8e1f-2e1d809c9d36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d5e7c-4f8f-4802-8da4-50a369a5b31f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d5e7c-4f8f-4802-8da4-50a369a5b31f.jpg?1",
             "name": "Ensnared by the Mara",
             "text": "",
             "colours": [
@@ -37063,7 +37063,7 @@
         },
         {
             "id": "60148b85-80d8-56ca-8eae-10c7faa94eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d476b1-1096-49ce-9acf-53b1c5e94df6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d476b1-1096-49ce-9acf-53b1c5e94df6.jpg?1",
             "name": "Flaming Tyrannosaurus",
             "text": "",
             "colours": [
@@ -37100,7 +37100,7 @@
         },
         {
             "id": "0f57f719-0a73-52e4-959d-3461697ea104",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b846507-2573-4435-8a12-706e42b4cdd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b846507-2573-4435-8a12-706e42b4cdd2.jpg?1",
             "name": "Impending Flux",
             "text": "",
             "colours": [
@@ -37135,7 +37135,7 @@
         },
         {
             "id": "dafb95b2-c2cd-524d-b5b9-c7d9c01e615c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d239db59-d011-472f-bb65-97ed8da0dcc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d239db59-d011-472f-bb65-97ed8da0dcc3.jpg?1",
             "name": "Into the Time Vortex",
             "text": "",
             "colours": [
@@ -37170,7 +37170,7 @@
         },
         {
             "id": "3a8cdb29-4d8f-5d04-b981-3c200a8ba289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2cb24-311f-4411-8f17-c481caf132c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffd2cb24-311f-4411-8f17-c481caf132c2.jpg?1",
             "name": "Return the Past",
             "text": "",
             "colours": [
@@ -37205,7 +37205,7 @@
         },
         {
             "id": "39bb292c-efe7-54dc-8daa-1b7d694be9a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6d214-87e8-4b39-ae22-8f0a69c9933c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bac6d214-87e8-4b39-ae22-8f0a69c9933c.jpg?1",
             "name": "RMS Titanic",
             "text": "",
             "colours": [
@@ -37244,7 +37244,7 @@
         },
         {
             "id": "34670d37-d584-514b-9f12-2e5b1e79e8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976ceca5-3222-46d0-ba8e-205781b17466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/976ceca5-3222-46d0-ba8e-205781b17466.jpg?1",
             "name": "Ryan Sinclair",
             "text": "",
             "colours": [
@@ -37283,7 +37283,7 @@
         },
         {
             "id": "ed11893d-e191-574d-8bf2-2a6d35ca1e25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed24e12a-e08b-4c0e-abe3-4d108d5ece79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed24e12a-e08b-4c0e-abe3-4d108d5ece79.jpg?1",
             "name": "The Sound of Drums",
             "text": "",
             "colours": [
@@ -37320,7 +37320,7 @@
         },
         {
             "id": "64a5b1e9-bd9a-59e3-b11e-4fcaaa8dc5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1aefd-fb8a-42a7-b59f-b05c05cef8f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60c1aefd-fb8a-42a7-b59f-b05c05cef8f8.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -37362,7 +37362,7 @@
         },
         {
             "id": "5b0ce0ce-e4f6-574a-a9ef-86e5cc992113",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8cc91a-dedf-4a35-b0e7-31a3fedbe2d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd8cc91a-dedf-4a35-b0e7-31a3fedbe2d3.jpg?1",
             "name": "Ace, Fearless Rebel",
             "text": "",
             "colours": [
@@ -37402,7 +37402,7 @@
         },
         {
             "id": "974623d8-2ca6-58b9-bfba-21fda8a79d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ec96e9-5326-4726-bb94-c3b5c6aaccb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0ec96e9-5326-4726-bb94-c3b5c6aaccb6.jpg?1",
             "name": "The Five Doctors",
             "text": "",
             "colours": [
@@ -37437,7 +37437,7 @@
         },
         {
             "id": "419833a4-647b-503e-a02f-196d7306fdfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b952c053-0c26-4690-86d2-1b28e664e7a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b952c053-0c26-4690-86d2-1b28e664e7a6.jpg?1",
             "name": "The Foretold Soldier",
             "text": "",
             "colours": [
@@ -37476,7 +37476,7 @@
         },
         {
             "id": "a2ab23e2-41b5-5826-931f-b17c6d3ab93f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0410cb-e202-4bad-a6a5-e3e58e574157.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a0410cb-e202-4bad-a6a5-e3e58e574157.jpg?1",
             "name": "Graham O'Brien",
             "text": "",
             "colours": [
@@ -37516,7 +37516,7 @@
         },
         {
             "id": "ab8eaac5-8a48-53cd-9908-7aa1f04ab953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215f5c44-c1e0-4a2e-a950-7d26426f002e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215f5c44-c1e0-4a2e-a950-7d26426f002e.jpg?1",
             "name": "Jamie McCrimmon",
             "text": "",
             "colours": [
@@ -37556,7 +37556,7 @@
         },
         {
             "id": "8b9c47a2-bb8e-5f76-bd1a-35ce1c255b16",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a41b0c-36ca-4e93-9ae4-0632bd483e6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34a41b0c-36ca-4e93-9ae4-0632bd483e6f.jpg?1",
             "name": "Leela, Sevateem Warrior",
             "text": "",
             "colours": [
@@ -37596,7 +37596,7 @@
         },
         {
             "id": "f91bb568-b246-595e-8a3d-30ee047d723d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc4062-61d8-4e51-a500-bea82279568b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dbc4062-61d8-4e51-a500-bea82279568b.jpg?1",
             "name": "Sisterhood of Karn",
             "text": "",
             "colours": [
@@ -37633,7 +37633,7 @@
         },
         {
             "id": "bb5f1706-b1b0-5d36-8b0b-f6759ee0a755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca13436-2e25-4853-be97-cff5675b41f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca13436-2e25-4853-be97-cff5675b41f8.jpg?1",
             "name": "Susan Foreman",
             "text": "",
             "colours": [
@@ -37672,7 +37672,7 @@
         },
         {
             "id": "347d967d-59e5-5371-8c15-028680fc9bb0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bf944a-8fad-4107-a9c5-5d98fd1a07df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bf944a-8fad-4107-a9c5-5d98fd1a07df.jpg?1",
             "name": "Alistair, the Brigadier",
             "text": "",
             "colours": [
@@ -37716,7 +37716,7 @@
         },
         {
             "id": "f09c9b98-6c3b-5211-bd14-b5f06e86cd9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91390e37-3239-4caf-b194-5bee36d1b67a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91390e37-3239-4caf-b194-5bee36d1b67a.jpg?1",
             "name": "Ashad, the Lone Cyberman",
             "text": "",
             "colours": [
@@ -37760,7 +37760,7 @@
         },
         {
             "id": "837f520a-de77-5d42-91e8-9935d525fc46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae56274-d001-48ca-9312-a1aa744cf643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ae56274-d001-48ca-9312-a1aa744cf643.jpg?1",
             "name": "The Beast, Deathless Prince",
             "text": "",
             "colours": [
@@ -37801,7 +37801,7 @@
         },
         {
             "id": "bd53b3db-9c49-5e2f-b70d-ed46e1cd2b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4a0b3-89b2-4db5-a8c5-a5d8d1c1ed1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0ff4a0b3-89b2-4db5-a8c5-a5d8d1c1ed1d.jpg?1",
             "name": "Cult of Skaro",
             "text": "",
             "colours": [
@@ -37845,7 +37845,7 @@
         },
         {
             "id": "d237b6c2-c936-5c7c-9231-e66fba45a4e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa858045-c3cf-457b-b7f9-a0b4fa70f2df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa858045-c3cf-457b-b7f9-a0b4fa70f2df.jpg?1",
             "name": "The Cyber-Controller",
             "text": "",
             "colours": [
@@ -37887,7 +37887,7 @@
         },
         {
             "id": "21427448-94e8-5c71-85fc-5e2a8218b319",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6a050-7486-4210-93cf-3ce7cc957a1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4f6a050-7486-4210-93cf-3ce7cc957a1c.jpg?1",
             "name": "The Dalek Emperor",
             "text": "",
             "colours": [
@@ -37929,7 +37929,7 @@
         },
         {
             "id": "7ca8c7e1-1bfb-5799-a8b0-4a83a4b999bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24057902-f0a7-4ca9-bbe0-cd74b68dbd8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24057902-f0a7-4ca9-bbe0-cd74b68dbd8d.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -37977,7 +37977,7 @@
         },
         {
             "id": "11a6f40a-7e9f-5d16-9bdb-f1522d9de673",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8bfda3-ea87-470d-94eb-0951b7f4ab1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c8bfda3-ea87-470d-94eb-0951b7f4ab1c.jpg?1",
             "name": "Dinosaurs on a Spaceship",
             "text": "",
             "colours": [
@@ -38016,7 +38016,7 @@
         },
         {
             "id": "a3943a6c-d9dd-5a1f-8c03-b990e7435afd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0cfc0e-6a38-4fa2-8e4b-64a893591fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0cfc0e-6a38-4fa2-8e4b-64a893591fec.jpg?1",
             "name": "Duggan, Private Detective",
             "text": "",
             "colours": [
@@ -38058,7 +38058,7 @@
         },
         {
             "id": "dd7f9395-a353-5ece-b1f5-8d2f5949767f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b80dd3-589f-493d-ae3c-a663b520da79.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4b80dd3-589f-493d-ae3c-a663b520da79.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -38103,7 +38103,7 @@
         },
         {
             "id": "c25cd7d8-0c6e-5fc8-91d1-00ef9c2a908e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d3891a-25e8-47ff-a516-4f3b8ce7fe24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21d3891a-25e8-47ff-a516-4f3b8ce7fe24.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -38148,7 +38148,7 @@
         },
         {
             "id": "85d9bfa2-ec83-5eb6-9aa0-0f5ca512199d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc5252a-77d7-419a-8d78-161e106352ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc5252a-77d7-419a-8d78-161e106352ee.jpg?1",
             "name": "The Face of Boe",
             "text": "",
             "colours": [
@@ -38192,7 +38192,7 @@
         },
         {
             "id": "e587e5eb-6820-5875-9e2e-43f6125cd1f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038279a1-76fd-4bf0-8ebb-d06db9747a64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038279a1-76fd-4bf0-8ebb-d06db9747a64.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -38237,7 +38237,7 @@
         },
         {
             "id": "0245ed25-66b3-56e1-8f64-d5af3299ec81",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0902ee20-bb26-4eca-ac34-e0cb3909a32e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/0902ee20-bb26-4eca-ac34-e0cb3909a32e.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -38282,7 +38282,7 @@
         },
         {
             "id": "b755f788-9968-50b0-a354-413eb3984431",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae754d-33a2-4a07-8b10-fe4dda9af745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7ae754d-33a2-4a07-8b10-fe4dda9af745.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -38328,7 +38328,7 @@
         },
         {
             "id": "9bc7384e-38a6-53d1-a482-2d0ebd157809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2136c09b-f27d-40f1-b3fd-44a399d1d021.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/2136c09b-f27d-40f1-b3fd-44a399d1d021.jpg?1",
             "name": "Frost Fair Lure Fish",
             "text": "",
             "colours": [
@@ -38367,7 +38367,7 @@
         },
         {
             "id": "6b1ef8bc-276f-590d-910d-d0fb21515c27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7f02c6-384a-41ba-ba9c-e0f0984ec2a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f7f02c6-384a-41ba-ba9c-e0f0984ec2a1.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -38411,7 +38411,7 @@
         },
         {
             "id": "390ca56d-111f-5c91-bc49-67357da7fdcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dc4f0d-88f1-4434-a36e-ac9aae7b295c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15dc4f0d-88f1-4434-a36e-ac9aae7b295c.jpg?1",
             "name": "Gallifrey Stands",
             "text": "",
             "colours": [
@@ -38450,7 +38450,7 @@
         },
         {
             "id": "1a6bc687-8ef7-552b-970e-6727b4b3101c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476ec84a-4618-4ead-85cb-c6c2e426fd91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/476ec84a-4618-4ead-85cb-c6c2e426fd91.jpg?1",
             "name": "Idris, Soul of the TARDIS",
             "text": "",
             "colours": [
@@ -38492,7 +38492,7 @@
         },
         {
             "id": "7a81d223-87bd-5584-b932-c71c6eb92617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bc3ef-7a2e-4d5f-8c6a-a1a4409b1ea2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb7bc3ef-7a2e-4d5f-8c6a-a1a4409b1ea2.jpg?1",
             "name": "Jenny Flint",
             "text": "",
             "colours": [
@@ -38534,7 +38534,7 @@
         },
         {
             "id": "72d85e5e-fb7e-5cc0-ba36-dbcbb3c346dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e4a50-b844-4306-af1d-a986050def36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9e4a50-b844-4306-af1d-a986050def36.jpg?1",
             "name": "Jenny, Generated Anomaly",
             "text": "",
             "colours": [
@@ -38576,7 +38576,7 @@
         },
         {
             "id": "0b64d023-91b4-5ba3-a5a9-62d96ae789d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf13c77b-8b5b-45c3-9a1e-e8fb13640e8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf13c77b-8b5b-45c3-9a1e-e8fb13640e8d.jpg?1",
             "name": "Kate Stewart",
             "text": "",
             "colours": [
@@ -38620,7 +38620,7 @@
         },
         {
             "id": "56446903-6b89-5cf8-a2d2-ea254fe4a37b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964a050-bed3-4e2e-b44b-e93561c4c643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2964a050-bed3-4e2e-b44b-e93561c4c643.jpg?1",
             "name": "Last Night Together",
             "text": "",
             "colours": [
@@ -38657,7 +38657,7 @@
         },
         {
             "id": "f0adb48f-2f0d-5654-99f8-18433953f455",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321f0fa-0df0-4388-86a0-456f7ab721de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f321f0fa-0df0-4388-86a0-456f7ab721de.jpg?1",
             "name": "Lunar Hatchling",
             "text": "",
             "colours": [
@@ -38697,7 +38697,7 @@
         },
         {
             "id": "25c745a7-d790-5ccb-b40a-c2737648937d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a73bf1-cf14-4a36-97ff-868212e0bfb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a73bf1-cf14-4a36-97ff-868212e0bfb8.jpg?1",
             "name": "Madame Vastra",
             "text": "",
             "colours": [
@@ -38739,7 +38739,7 @@
         },
         {
             "id": "35fee6cf-7329-5843-8c11-22f7e807b4f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225fd1e5-cd42-4c33-bfcd-9287289d2098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/225fd1e5-cd42-4c33-bfcd-9287289d2098.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -38783,7 +38783,7 @@
         },
         {
             "id": "7572c1d5-1319-5622-833e-5ac9dd0e39fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db03b22-a9ad-43e9-875f-66e9bdc9cd90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7db03b22-a9ad-43e9-875f-66e9bdc9cd90.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -38827,7 +38827,7 @@
         },
         {
             "id": "460bda83-cfcc-5561-900d-88a9bc6bd27c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b4f8d-44bb-40ac-a2e0-bd28690887de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/838b4f8d-44bb-40ac-a2e0-bd28690887de.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -38871,7 +38871,7 @@
         },
         {
             "id": "a827cde2-508d-52e7-b6ed-8d411072f205",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df77bd5-9880-4813-b85e-fe157a7bea9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df77bd5-9880-4813-b85e-fe157a7bea9e.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -38915,7 +38915,7 @@
         },
         {
             "id": "4cc3dd2c-7b1d-5b1f-bbcb-fcdb0796f190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2859f7ca-6b21-4c08-8860-12d9cd82d00a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2859f7ca-6b21-4c08-8860-12d9cd82d00a.jpg?1",
             "name": "Me, the Immortal",
             "text": "",
             "colours": [
@@ -38959,7 +38959,7 @@
         },
         {
             "id": "658e63fe-1714-5324-8fd5-6f98d2e754d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f72af9-7b86-4c52-a7fe-9db2afcbcd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87f72af9-7b86-4c52-a7fe-9db2afcbcd14.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -39005,7 +39005,7 @@
         },
         {
             "id": "962b2e17-dd2d-5f6a-b402-496172acc177",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3e0b24-2bf1-451b-9f02-e3704949ae7d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b3e0b24-2bf1-451b-9f02-e3704949ae7d.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -39050,7 +39050,7 @@
         },
         {
             "id": "43295484-e091-504e-be3d-9d56c5bf2baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6439d491-1be8-4f70-8385-4da79ae4aef7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6439d491-1be8-4f70-8385-4da79ae4aef7.jpg?1",
             "name": "The Rani",
             "text": "",
             "colours": [
@@ -39094,7 +39094,7 @@
         },
         {
             "id": "a726d769-b6e5-590f-be6c-ee5cbd8765d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b23c9f1-1474-4df1-b1a2-b98eae2248ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b23c9f1-1474-4df1-b1a2-b98eae2248ad.jpg?1",
             "name": "Rassilon, the War President",
             "text": "",
             "colours": [
@@ -39136,7 +39136,7 @@
         },
         {
             "id": "43938db2-fc23-5661-b771-639a800fe58f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0245b04-c2a6-43dd-b9d2-5150d0ebb24c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0245b04-c2a6-43dd-b9d2-5150d0ebb24c.jpg?1",
             "name": "Regenerations Restored",
             "text": "",
             "colours": [
@@ -39173,7 +39173,7 @@
         },
         {
             "id": "f5b0ad2d-af13-5d7e-a405-6329a6cb3801",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2666846e-fde4-4b28-97c6-a0296771081d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2666846e-fde4-4b28-97c6-a0296771081d.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -39218,7 +39218,7 @@
         },
         {
             "id": "a111cc37-1191-5330-a517-ef5e6a9bbdfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dc2162-3350-4fd4-995a-b2080f8fb94e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48dc2162-3350-4fd4-995a-b2080f8fb94e.jpg?1",
             "name": "Rory Williams",
             "text": "",
             "colours": [
@@ -39260,7 +39260,7 @@
         },
         {
             "id": "9a3740e3-1b8a-57ec-8cc1-03bd3f6b0a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bac5d4-b83e-457e-bdf1-da7dbaf8ded4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bac5d4-b83e-457e-bdf1-da7dbaf8ded4.jpg?1",
             "name": "Run for Your Life",
             "text": "",
             "colours": [
@@ -39297,7 +39297,7 @@
         },
         {
             "id": "980737f6-c3ff-5878-a628-6238b6dc5e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209b79d-02a4-40d5-9301-98cf97ac095a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6209b79d-02a4-40d5-9301-98cf97ac095a.jpg?1",
             "name": "Sally Sparrow",
             "text": "",
             "colours": [
@@ -39339,7 +39339,7 @@
         },
         {
             "id": "075bb03b-5c0c-57c5-bff2-5dac5046543f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb7f9-232b-4c1e-9c27-d9d8f7fd3752.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24cdb7f9-232b-4c1e-9c27-d9d8f7fd3752.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -39384,7 +39384,7 @@
         },
         {
             "id": "b8d3e966-2eb5-5505-85c2-f50a4f3a67b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26393e65-d137-4c36-ba39-6da7e32b16d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26393e65-d137-4c36-ba39-6da7e32b16d0.jpg?1",
             "name": "Sergeant John Benton",
             "text": "",
             "colours": [
@@ -39426,7 +39426,7 @@
         },
         {
             "id": "40ac61b3-4e77-5055-8c2e-3b0711b3dbf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d19bf30-4e95-470b-a81b-a6595816eeed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d19bf30-4e95-470b-a81b-a6595816eeed.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -39471,7 +39471,7 @@
         },
         {
             "id": "15628c88-0911-5ef5-87d4-92bf624b9d20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae21ef3-9e4a-43da-83f3-4b4cd30bc2cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/cae21ef3-9e4a-43da-83f3-4b4cd30bc2cd.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -39516,7 +39516,7 @@
         },
         {
             "id": "f5de9c0a-e834-5680-a109-b6e9ad103dc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e411f4-d1b9-415f-8769-01b274a1b17e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5e411f4-d1b9-415f-8769-01b274a1b17e.jpg?1",
             "name": "Strax, Sontaran Nurse",
             "text": "",
             "colours": [
@@ -39558,7 +39558,7 @@
         },
         {
             "id": "6929276e-2cd9-50d1-bc83-62eedae72eaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a24ee3-2e35-4918-ab6d-5ee839cab23d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2a24ee3-2e35-4918-ab6d-5ee839cab23d.jpg?1",
             "name": "Sycorax Commander",
             "text": "",
             "colours": [
@@ -39598,7 +39598,7 @@
         },
         {
             "id": "00f2cd58-c460-57af-a941-b7e8dd5ce937",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7d3ae-e15a-4e5c-8c9e-f90aa334b0cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0e7d3ae-e15a-4e5c-8c9e-f90aa334b0cd.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -39644,7 +39644,7 @@
         },
         {
             "id": "40cdf738-a80e-58ed-b4a9-84a9f5b6d9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee72f96-0989-42ca-a60a-7f88ce7440c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee72f96-0989-42ca-a60a-7f88ce7440c2.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -39689,7 +39689,7 @@
         },
         {
             "id": "6129fe0e-e952-5b75-b5f5-8cb46cc58b77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801fedfb-f5bb-44c2-9956-b14ca2adc3ed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/801fedfb-f5bb-44c2-9956-b14ca2adc3ed.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -39735,7 +39735,7 @@
         },
         {
             "id": "71ed2476-1fa2-5134-ac27-8f0bb074f699",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc9f5cb-700b-4b99-bca4-3c7d03cc180a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc9f5cb-700b-4b99-bca4-3c7d03cc180a.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -39780,7 +39780,7 @@
         },
         {
             "id": "f390a0de-00c6-5daf-95d2-1172b8a0a13a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d154b5ec-9fd0-4627-bcf8-7993f1ab5b6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d154b5ec-9fd0-4627-bcf8-7993f1ab5b6b.jpg?1",
             "name": "The Valeyard",
             "text": "",
             "colours": [
@@ -39824,7 +39824,7 @@
         },
         {
             "id": "c7e76f2a-74fa-5fad-b3a0-5ccdfb0c2b13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78130eb5-fa5d-4007-9b6b-714732bf97c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78130eb5-fa5d-4007-9b6b-714732bf97c5.jpg?1",
             "name": "Vrestin, Menoptra Leader",
             "text": "",
             "colours": [
@@ -39867,7 +39867,7 @@
         },
         {
             "id": "bb4a6fe5-6b23-5183-bf7e-d8b0dd31f222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33148ef-e7f7-4e34-8f0a-7c209feb572c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e33148ef-e7f7-4e34-8f0a-7c209feb572c.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -39911,7 +39911,7 @@
         },
         {
             "id": "d6e75c59-affb-5070-89f5-af428a379240",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9430043-f452-4bb6-bff3-d6f91420b756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9430043-f452-4bb6-bff3-d6f91420b756.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -39954,7 +39954,7 @@
         },
         {
             "id": "5c9d305d-af50-5dc2-9bd0-24c95f6fcdda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a6cc57-6b6b-4e7e-8488-181c0999df60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65a6cc57-6b6b-4e7e-8488-181c0999df60.jpg?1",
             "name": "Ace's Baseball Bat",
             "text": "",
             "colours": [],
@@ -39989,7 +39989,7 @@
         },
         {
             "id": "49be8185-c349-51e6-8e64-466a8c03be44",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39166adc-6b0e-4549-965b-a8dded70c54c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39166adc-6b0e-4549-965b-a8dded70c54c.jpg?1",
             "name": "Bessie, the Doctor's Roadster",
             "text": "",
             "colours": [],
@@ -40024,7 +40024,7 @@
         },
         {
             "id": "a3c03f2f-6e44-5f06-91f3-ef7b43d0fcf8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33f4765-f5cc-4c94-afa7-32fd841c07ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a33f4765-f5cc-4c94-afa7-32fd841c07ca.jpg?1",
             "name": "Confession Dial",
             "text": "",
             "colours": [],
@@ -40055,7 +40055,7 @@
         },
         {
             "id": "2126b1cd-a876-5648-a117-42e4cce43cd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdf8ea-e3a7-4121-805a-417361c8d58d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08bdf8ea-e3a7-4121-805a-417361c8d58d.jpg?1",
             "name": "Cybermen Squadron",
             "text": "",
             "colours": [],
@@ -40089,7 +40089,7 @@
         },
         {
             "id": "1e7ed733-a4c4-5f83-aa99-ccee3fcfedd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96b99e-07e1-41b6-b9ce-dca3f75ecfa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96b99e-07e1-41b6-b9ce-dca3f75ecfa1.jpg?1",
             "name": "Cybership",
             "text": "",
             "colours": [],
@@ -40122,7 +40122,7 @@
         },
         {
             "id": "c7498bc7-3ae6-5ee8-a710-9a299bdf2fef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc1dec-87a1-413d-afa9-2d4d1b0479b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eefc1dec-87a1-413d-afa9-2d4d1b0479b0.jpg?1",
             "name": "The Moment",
             "text": "",
             "colours": [],
@@ -40155,7 +40155,7 @@
         },
         {
             "id": "cea05c21-f79d-5ac6-9747-6a1787b9d5d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8baa1c-7dd4-46b0-824f-405b44829caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad8baa1c-7dd4-46b0-824f-405b44829caa.jpg?1",
             "name": "River Song's Diary",
             "text": "",
             "colours": [],
@@ -40186,7 +40186,7 @@
         },
         {
             "id": "5e626544-7ecf-5318-95c5-933fc62b1289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e251c4-72bd-42b5-91ed-b0d4ea312fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3e251c4-72bd-42b5-91ed-b0d4ea312fae.jpg?1",
             "name": "Rotating Fireplace",
             "text": "",
             "colours": [],
@@ -40217,7 +40217,7 @@
         },
         {
             "id": "ba6b312c-a1be-5f63-8145-e26b5f7168e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e03370a-05a7-4f84-aadd-9eba459e2696.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e03370a-05a7-4f84-aadd-9eba459e2696.jpg?1",
             "name": "Gallifrey Council Chamber",
             "text": "",
             "colours": [],
@@ -40250,7 +40250,7 @@
         },
         {
             "id": "907adc2f-2ac9-5252-b8c3-6ec4deb8a39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f517d29-aa30-4890-ba4e-b572ac873bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f517d29-aa30-4890-ba4e-b572ac873bb4.jpg?1",
             "name": "Trenzalore Clocktower",
             "text": "",
             "colours": [],
@@ -40285,7 +40285,7 @@
         },
         {
             "id": "0b5bd532-26f4-5ae8-981d-a0ed20ee56e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e329faf-f122-44d8-bd7d-decf296404e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e329faf-f122-44d8-bd7d-decf296404e9.jpg?1",
             "name": "Day of Destiny",
             "text": "",
             "colours": [
@@ -40322,7 +40322,7 @@
         },
         {
             "id": "685c712b-ab6a-528a-be08-3f6022e555cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b2e80f-7dd9-4d0f-a3b7-ea2dbbd7ada2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75b2e80f-7dd9-4d0f-a3b7-ea2dbbd7ada2.jpg?1",
             "name": "Farewell",
             "text": "",
             "colours": [
@@ -40357,7 +40357,7 @@
         },
         {
             "id": "fb2cb877-d854-5e75-b94f-741429601ffc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1df61a7-f87b-48bc-9ea0-0b7799cbd4ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1df61a7-f87b-48bc-9ea0-0b7799cbd4ae.jpg?1",
             "name": "Grasp of Fate",
             "text": "",
             "colours": [
@@ -40392,7 +40392,7 @@
         },
         {
             "id": "5679fe0e-1bcd-5082-86fd-2442b00cf7a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39ad9da-f71a-48a5-b5d3-e6e0bfb7402e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e39ad9da-f71a-48a5-b5d3-e6e0bfb7402e.jpg?1",
             "name": "Out of Time",
             "text": "",
             "colours": [
@@ -40427,7 +40427,7 @@
         },
         {
             "id": "b3994c69-d1b2-53aa-8f8a-76e461a8024d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcac03a0-c4e3-4761-93f1-d4a64c0d46f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcac03a0-c4e3-4761-93f1-d4a64c0d46f8.jpg?1",
             "name": "Wedding Ring",
             "text": "",
             "colours": [
@@ -40462,7 +40462,7 @@
         },
         {
             "id": "93176330-4188-5d0d-9437-3aa232d08de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8107bd96-3570-458e-b76c-73af227f9955.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8107bd96-3570-458e-b76c-73af227f9955.jpg?1",
             "name": "As Foretold",
             "text": "",
             "colours": [
@@ -40497,7 +40497,7 @@
         },
         {
             "id": "a5fe2048-d427-58ce-a243-28362a9415ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c678c4-7b36-42a9-88d3-1b4c5dadae36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49c678c4-7b36-42a9-88d3-1b4c5dadae36.jpg?1",
             "name": "Inspiring Refrain",
             "text": "",
             "colours": [
@@ -40532,7 +40532,7 @@
         },
         {
             "id": "58849d31-6d97-5c18-8bf6-b35ced7fb7f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4070bf-315a-4fe4-826d-7507ea4b2d12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4070bf-315a-4fe4-826d-7507ea4b2d12.jpg?1",
             "name": "Wound Reflection",
             "text": "",
             "colours": [
@@ -40567,7 +40567,7 @@
         },
         {
             "id": "41b06296-ecdb-575a-8450-64f7bc988b10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb016ec-ceff-4145-8118-8902e96aba57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cb016ec-ceff-4145-8118-8902e96aba57.jpg?1",
             "name": "Blasphemous Act",
             "text": "",
             "colours": [
@@ -40602,7 +40602,7 @@
         },
         {
             "id": "7ffa9a2e-0078-530f-85fc-6ded93f77c55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed48a-d2d2-46bc-82c1-487e6fa66f53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/533ed48a-d2d2-46bc-82c1-487e6fa66f53.jpg?1",
             "name": "Chaos Warp",
             "text": "",
             "colours": [
@@ -40637,7 +40637,7 @@
         },
         {
             "id": "53d49e01-782d-5aca-9cfb-a2953bfa9c39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d4da83-beaf-448f-8877-9a17236cb8f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d4da83-beaf-448f-8877-9a17236cb8f6.jpg?1",
             "name": "Cursed Mirror",
             "text": "",
             "colours": [
@@ -40672,7 +40672,7 @@
         },
         {
             "id": "abfbf57d-3256-5701-ac1e-3e4d41d8ae00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68a5679-87a1-4d35-b5ef-59c1803e43aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b68a5679-87a1-4d35-b5ef-59c1803e43aa.jpg?1",
             "name": "Carpet of Flowers",
             "text": "",
             "colours": [
@@ -40707,7 +40707,7 @@
         },
         {
             "id": "52affaaf-6849-5c23-ad59-ba3417ba0257",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77ce389-1610-4122-b1a5-bbbfa7b80a74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77ce389-1610-4122-b1a5-bbbfa7b80a74.jpg?1",
             "name": "Heroic Intervention",
             "text": "",
             "colours": [
@@ -40742,7 +40742,7 @@
         },
         {
             "id": "49c04e73-35ca-5d17-9400-56e413cb34b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c69c743-59bd-4cac-b8e7-f3424677ac57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c69c743-59bd-4cac-b8e7-f3424677ac57.jpg?1",
             "name": "Fractured Identity",
             "text": "",
             "colours": [
@@ -40779,7 +40779,7 @@
         },
         {
             "id": "ce124ada-e5ed-5947-ab71-c28f762558bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac538d7-ec0c-4fca-ac97-39f14e02152e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7ac538d7-ec0c-4fca-ac97-39f14e02152e.jpg?1",
             "name": "Time Wipe",
             "text": "",
             "colours": [
@@ -40816,7 +40816,7 @@
         },
         {
             "id": "16d62079-8847-58cf-a032-43566bc79f45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f585e6-4435-437a-98f0-b9159211067c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85f585e6-4435-437a-98f0-b9159211067c.jpg?1",
             "name": "Heroes' Podium",
             "text": "",
             "colours": [],
@@ -40849,7 +40849,7 @@
         },
         {
             "id": "9b151253-c311-5b50-a4ff-626e63be886d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464305af-870c-46b0-9962-b69b6cd5b12d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/464305af-870c-46b0-9962-b69b6cd5b12d.jpg?1",
             "name": "Solemn Simulacrum",
             "text": "",
             "colours": [],
@@ -40883,7 +40883,7 @@
         },
         {
             "id": "b4db40dd-f1f1-50d2-9c48-76aca8b0cd1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519b3bb3-5179-4b2e-ac8f-6e594e0d09d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519b3bb3-5179-4b2e-ac8f-6e594e0d09d5.jpg?1",
             "name": "Canopy Vista",
             "text": "",
             "colours": [],
@@ -40920,7 +40920,7 @@
         },
         {
             "id": "538c9830-fcfb-596e-81b3-dd109c89ac23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0be6643-50dc-4916-a284-fafef1127421.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0be6643-50dc-4916-a284-fafef1127421.jpg?1",
             "name": "Canyon Slough",
             "text": "",
             "colours": [],
@@ -40957,7 +40957,7 @@
         },
         {
             "id": "f7088618-1553-5031-bd9e-557e1df0642f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f191dfbe-31bf-4a5f-8307-4e63a9ef89b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f191dfbe-31bf-4a5f-8307-4e63a9ef89b9.jpg?1",
             "name": "Celestial Colonnade",
             "text": "",
             "colours": [],
@@ -40991,7 +40991,7 @@
         },
         {
             "id": "6fa92d5a-05c6-5e5c-917b-4dc4800cb09d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40227b-8a9a-402d-bb3d-ae92b84b6951.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a40227b-8a9a-402d-bb3d-ae92b84b6951.jpg?1",
             "name": "Choked Estuary",
             "text": "",
             "colours": [],
@@ -41025,7 +41025,7 @@
         },
         {
             "id": "e0b9e822-8270-59cb-a5d4-423c3186d739",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447821-caed-44f4-995f-3d120c892626.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31447821-caed-44f4-995f-3d120c892626.jpg?1",
             "name": "Cinder Glade",
             "text": "",
             "colours": [],
@@ -41062,7 +41062,7 @@
         },
         {
             "id": "979bfc0f-8106-5b86-a9f6-0f1a2b3427b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42bc75-42df-4dd0-b18d-eec5213562db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d42bc75-42df-4dd0-b18d-eec5213562db.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "",
             "colours": [],
@@ -41096,7 +41096,7 @@
         },
         {
             "id": "754a5d42-9392-5176-95d1-d8e3ad2dc0f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88d373-04a2-4877-a01a-468f8075e4d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b88d373-04a2-4877-a01a-468f8075e4d9.jpg?1",
             "name": "Darkwater Catacombs",
             "text": "",
             "colours": [],
@@ -41130,7 +41130,7 @@
         },
         {
             "id": "a8a6a607-8cc7-5e9b-b720-910126eb9ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311ce87a-5a0f-4fa2-884c-813b71d109c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/311ce87a-5a0f-4fa2-884c-813b71d109c3.jpg?1",
             "name": "Deserted Beach",
             "text": "",
             "colours": [],
@@ -41164,7 +41164,7 @@
         },
         {
             "id": "41aa9419-5440-5c61-9598-900084635f4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09143c06-e17a-4fed-b4b1-c90773f7a32d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09143c06-e17a-4fed-b4b1-c90773f7a32d.jpg?1",
             "name": "Desolate Lighthouse",
             "text": "",
             "colours": [],
@@ -41198,7 +41198,7 @@
         },
         {
             "id": "a4f8ed85-9c24-581d-81a3-85a3576861d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d3a41-fe2b-459d-998b-c38a8177ba83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f21d3a41-fe2b-459d-998b-c38a8177ba83.jpg?1",
             "name": "Dragonskull Summit",
             "text": "",
             "colours": [],
@@ -41232,7 +41232,7 @@
         },
         {
             "id": "59c066f3-44dc-5a91-8b83-893bb3f06c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a8b62-4247-4f98-9340-ec897556e993.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/407a8b62-4247-4f98-9340-ec897556e993.jpg?1",
             "name": "Dreamroot Cascade",
             "text": "",
             "colours": [],
@@ -41266,7 +41266,7 @@
         },
         {
             "id": "b7a530ec-f048-5cf9-87eb-44764e632ea6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8096a898-6f78-459b-ac0a-d2fbaf50a118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8096a898-6f78-459b-ac0a-d2fbaf50a118.jpg?1",
             "name": "Drowned Catacomb",
             "text": "",
             "colours": [],
@@ -41300,7 +41300,7 @@
         },
         {
             "id": "d1dcd098-27e7-5d6f-b7f9-48f072b151a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad795109-0aaf-452c-80b4-243e8501572d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad795109-0aaf-452c-80b4-243e8501572d.jpg?1",
             "name": "Exotic Orchard",
             "text": "",
             "colours": [],
@@ -41331,7 +41331,7 @@
         },
         {
             "id": "ade751c0-5d50-5833-a068-3d046f3db88c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092fb6c6-ae24-422e-8085-3e699eb9aed8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092fb6c6-ae24-422e-8085-3e699eb9aed8.jpg?1",
             "name": "Fetid Pools",
             "text": "",
             "colours": [],
@@ -41368,7 +41368,7 @@
         },
         {
             "id": "e49c9e42-97da-5b08-a8f6-206904c4bf5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3bd973-04c8-4890-b44b-031e46f2372c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa3bd973-04c8-4890-b44b-031e46f2372c.jpg?1",
             "name": "Fiery Islet",
             "text": "",
             "colours": [],
@@ -41402,7 +41402,7 @@
         },
         {
             "id": "d06404a4-8788-5c56-9aa7-6cd2828d9805",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d947c-e4c7-409b-886e-affb1c68264d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a9d947c-e4c7-409b-886e-affb1c68264d.jpg?1",
             "name": "Foreboding Ruins",
             "text": "",
             "colours": [],
@@ -41436,7 +41436,7 @@
         },
         {
             "id": "d1282c34-1a3c-57a7-ad8e-e3caa2844256",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90cfebc-4a26-43fa-be37-26318d5449f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d90cfebc-4a26-43fa-be37-26318d5449f1.jpg?1",
             "name": "Fortified Village",
             "text": "",
             "colours": [],
@@ -41470,7 +41470,7 @@
         },
         {
             "id": "460932e9-3369-57eb-8fb9-6e6cad6b2a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0c27-95f1-4425-8cc4-c287b1317119.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cf0c27-95f1-4425-8cc4-c287b1317119.jpg?1",
             "name": "Frostboil Snarl",
             "text": "",
             "colours": [],
@@ -41504,7 +41504,7 @@
         },
         {
             "id": "81777356-aa97-5e28-80ac-46f08c007760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1799d0-0b50-480a-8f30-5936b211f904.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d1799d0-0b50-480a-8f30-5936b211f904.jpg?1",
             "name": "Furycalm Snarl",
             "text": "",
             "colours": [],
@@ -41538,7 +41538,7 @@
         },
         {
             "id": "6211fff2-5e5b-5558-a232-39fd6614598c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2258e2-0f03-4280-8a83-d592949d778c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc2258e2-0f03-4280-8a83-d592949d778c.jpg?1",
             "name": "Game Trail",
             "text": "",
             "colours": [],
@@ -41572,7 +41572,7 @@
         },
         {
             "id": "a649050f-e5fb-5f0a-9e1d-1bec725dfe68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f367f4-7389-438f-8abe-43ccb824c968.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f367f4-7389-438f-8abe-43ccb824c968.jpg?1",
             "name": "Glacial Fortress",
             "text": "",
             "colours": [],
@@ -41606,7 +41606,7 @@
         },
         {
             "id": "5f0830db-81af-5a20-929c-a7a5365b6a92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96354af0-e074-4057-8224-667e7294795a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96354af0-e074-4057-8224-667e7294795a.jpg?1",
             "name": "Haunted Ridge",
             "text": "",
             "colours": [],
@@ -41640,7 +41640,7 @@
         },
         {
             "id": "dbbacbfb-568d-51ad-b838-36a78f94ddda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ae31a-3109-4f55-9f2d-cccb3af5d123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/241ae31a-3109-4f55-9f2d-cccb3af5d123.jpg?1",
             "name": "Horizon Canopy",
             "text": "",
             "colours": [],
@@ -41674,7 +41674,7 @@
         },
         {
             "id": "ca64a498-0013-55ce-b8d2-5a35f7037453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794ba355-7bee-4808-8161-3584e3505bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794ba355-7bee-4808-8161-3584e3505bf1.jpg?1",
             "name": "Irrigated Farmland",
             "text": "",
             "colours": [],
@@ -41711,7 +41711,7 @@
         },
         {
             "id": "532bc546-9d30-5b03-abac-3c649234b090",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce1760-2325-4af1-ad70-5cf5a0781c8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14ce1760-2325-4af1-ad70-5cf5a0781c8e.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "",
             "colours": [],
@@ -41745,7 +41745,7 @@
         },
         {
             "id": "edd3011d-c9c2-58f0-b648-543e5fe1ed20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f831e9ac-e10a-40bd-a7f6-4be90cc313b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f831e9ac-e10a-40bd-a7f6-4be90cc313b3.jpg?1",
             "name": "Overgrown Farmland",
             "text": "",
             "colours": [],
@@ -41779,7 +41779,7 @@
         },
         {
             "id": "fe5d456d-ff6d-5b9d-8de2-b6023f074d79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c9c3c0-039e-47b7-9b88-b1114d110a12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25c9c3c0-039e-47b7-9b88-b1114d110a12.jpg?1",
             "name": "Port Town",
             "text": "",
             "colours": [],
@@ -41813,7 +41813,7 @@
         },
         {
             "id": "e07bdbd0-e05e-5604-aade-1ed8cae53fc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bdc124-52a8-4993-aaa5-35190e78d08b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4bdc124-52a8-4993-aaa5-35190e78d08b.jpg?1",
             "name": "Prairie Stream",
             "text": "",
             "colours": [],
@@ -41850,7 +41850,7 @@
         },
         {
             "id": "55b7aed5-45d1-57f5-91f8-f9b9a9c9379c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83200ef-069f-4344-93b0-23c2eff16027.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83200ef-069f-4344-93b0-23c2eff16027.jpg?1",
             "name": "River of Tears",
             "text": "",
             "colours": [],
@@ -41884,7 +41884,7 @@
         },
         {
             "id": "ae13dd1b-c4d1-5314-888f-3854ec711fb1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34dbf00-1f3b-4946-ae43-2c8e339d4e5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34dbf00-1f3b-4946-ae43-2c8e339d4e5b.jpg?1",
             "name": "Rockfall Vale",
             "text": "",
             "colours": [],
@@ -41918,7 +41918,7 @@
         },
         {
             "id": "5c45a43a-ae2b-55f8-b873-e6c1b6630a2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c0e91b-1377-465c-a00e-4e788bbbddc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48c0e91b-1377-465c-a00e-4e788bbbddc6.jpg?1",
             "name": "Rootbound Crag",
             "text": "",
             "colours": [],
@@ -41952,7 +41952,7 @@
         },
         {
             "id": "feb1539a-f63d-56f0-ad18-11fe5116df8f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffb5a5e-050e-4f2e-a671-461c9de521cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bffb5a5e-050e-4f2e-a671-461c9de521cf.jpg?1",
             "name": "Scattered Groves",
             "text": "",
             "colours": [],
@@ -41989,7 +41989,7 @@
         },
         {
             "id": "b29f0b97-cd60-5b72-ba20-512804e228ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4328db-edfd-40c3-8b13-b97dbcdff3c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4328db-edfd-40c3-8b13-b97dbcdff3c8.jpg?1",
             "name": "Shadowblood Ridge",
             "text": "",
             "colours": [],
@@ -42023,7 +42023,7 @@
         },
         {
             "id": "eba20585-d4ad-52c1-9bbe-38ce4745b0a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec84099-b8b4-4a3b-88f9-37fd02e848de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bec84099-b8b4-4a3b-88f9-37fd02e848de.jpg?1",
             "name": "Sheltered Thicket",
             "text": "",
             "colours": [],
@@ -42060,7 +42060,7 @@
         },
         {
             "id": "f32febb4-6fef-5ef7-84ac-99d58cbad372",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054022c8-0273-4853-b353-3b792e8063b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054022c8-0273-4853-b353-3b792e8063b3.jpg?1",
             "name": "Shipwreck Marsh",
             "text": "",
             "colours": [],
@@ -42094,7 +42094,7 @@
         },
         {
             "id": "0f8cfb8a-55dd-5f99-8082-4bd4c63b1a4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c0c7aa-d060-4ad7-8a6a-fcfe5f8e010e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c0c7aa-d060-4ad7-8a6a-fcfe5f8e010e.jpg?1",
             "name": "Skycloud Expanse",
             "text": "",
             "colours": [],
@@ -42128,7 +42128,7 @@
         },
         {
             "id": "82a92042-8182-5ce3-b99d-59e327284572",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc8ec97-5a84-4111-8f7e-fc9687532080.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fc8ec97-5a84-4111-8f7e-fc9687532080.jpg?1",
             "name": "Smoldering Marsh",
             "text": "",
             "colours": [],
@@ -42165,7 +42165,7 @@
         },
         {
             "id": "7aa7495d-4dec-57c6-966c-20629a10e7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a366b83d-ce0a-4916-a9da-73bb6aa4f101.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a366b83d-ce0a-4916-a9da-73bb6aa4f101.jpg?1",
             "name": "Stormcarved Coast",
             "text": "",
             "colours": [],
@@ -42199,7 +42199,7 @@
         },
         {
             "id": "934cbedf-8da9-5ca2-9794-72e48db5bb3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5b4e01-313c-4560-bc29-64f3169eab91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe5b4e01-313c-4560-bc29-64f3169eab91.jpg?1",
             "name": "Sunbaked Canyon",
             "text": "",
             "colours": [],
@@ -42233,7 +42233,7 @@
         },
         {
             "id": "6b71a06f-9224-5a28-b555-c13c48a2b0d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70ac99-1c83-4155-9854-5e666e8f8b09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc70ac99-1c83-4155-9854-5e666e8f8b09.jpg?1",
             "name": "Sundown Pass",
             "text": "",
             "colours": [],
@@ -42267,7 +42267,7 @@
         },
         {
             "id": "1207dcf5-9433-592b-b354-ab14b1426610",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e711b70e-4b8c-4cd7-8ad6-e543e3301a65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e711b70e-4b8c-4cd7-8ad6-e543e3301a65.jpg?1",
             "name": "Sungrass Prairie",
             "text": "",
             "colours": [],
@@ -42301,7 +42301,7 @@
         },
         {
             "id": "1d732491-ff55-589d-bcca-6e6051a4f6e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb058da2-150c-435c-ba4b-2c668b588c5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb058da2-150c-435c-ba4b-2c668b588c5a.jpg?1",
             "name": "Sunken Hollow",
             "text": "",
             "colours": [],
@@ -42338,7 +42338,7 @@
         },
         {
             "id": "8685acd6-d905-543f-9655-4eccb130febe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f94647-cd6c-4ac7-87fb-e5a6e646fe09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f94647-cd6c-4ac7-87fb-e5a6e646fe09.jpg?1",
             "name": "Temple of Abandon",
             "text": "",
             "colours": [],
@@ -42372,7 +42372,7 @@
         },
         {
             "id": "1df87f93-d0a5-5312-984f-adb13fc40e94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71051848-3983-462a-8189-aff8c56f163f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71051848-3983-462a-8189-aff8c56f163f.jpg?1",
             "name": "Temple of Deceit",
             "text": "",
             "colours": [],
@@ -42406,7 +42406,7 @@
         },
         {
             "id": "fbf9e855-0f2b-544c-8b76-29aaca31b8a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cd8dc-9ea0-48d6-8723-0cfd43eca60d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4cd8dc-9ea0-48d6-8723-0cfd43eca60d.jpg?1",
             "name": "Temple of Enlightenment",
             "text": "",
             "colours": [],
@@ -42440,7 +42440,7 @@
         },
         {
             "id": "b9aab5d9-4d47-509d-97b0-5a529f128efc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6632dc47-5fe4-4527-9c31-9f81c27c8840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6632dc47-5fe4-4527-9c31-9f81c27c8840.jpg?1",
             "name": "Temple of Epiphany",
             "text": "",
             "colours": [],
@@ -42474,7 +42474,7 @@
         },
         {
             "id": "af0e33ac-143f-5e24-9d22-ad595355896b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b683c2a-edf4-49d7-8de8-f9f33b2d4d5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b683c2a-edf4-49d7-8de8-f9f33b2d4d5a.jpg?1",
             "name": "Temple of Malice",
             "text": "",
             "colours": [],
@@ -42508,7 +42508,7 @@
         },
         {
             "id": "52b6db86-e617-5a80-9fb7-f1c6f42ddfd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d09204-e1f0-438a-9c74-b703fef96e4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47d09204-e1f0-438a-9c74-b703fef96e4a.jpg?1",
             "name": "Temple of Mystery",
             "text": "",
             "colours": [],
@@ -42542,7 +42542,7 @@
         },
         {
             "id": "c432fc39-9ce8-5405-83f3-c9ea861af38a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f65fd-645a-4869-8852-2a1183aa0c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a18f65fd-645a-4869-8852-2a1183aa0c04.jpg?1",
             "name": "Temple of Plenty",
             "text": "",
             "colours": [],
@@ -42576,7 +42576,7 @@
         },
         {
             "id": "86da52b4-15ff-5900-84eb-56cffc289d64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2255311-0e94-4d29-b5ee-78a7fa530fc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d2255311-0e94-4d29-b5ee-78a7fa530fc1.jpg?1",
             "name": "Temple of Triumph",
             "text": "",
             "colours": [],
@@ -42610,7 +42610,7 @@
         },
         {
             "id": "6f56137d-b400-54ab-aacd-c45d61704ffa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90b10f7-474d-4947-aec9-ac4196a84a35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e90b10f7-474d-4947-aec9-ac4196a84a35.jpg?1",
             "name": "Thespian's Stage",
             "text": "",
             "colours": [],
@@ -42641,7 +42641,7 @@
         },
         {
             "id": "d37db091-c0af-5280-9bc9-2f9599142e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707d0e5-41b6-4c8b-9ef1-dc7ac0084ddb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/3707d0e5-41b6-4c8b-9ef1-dc7ac0084ddb.jpg?1",
             "name": "Vineglimmer Snarl",
             "text": "",
             "colours": [],
@@ -42675,7 +42675,7 @@
         },
         {
             "id": "2483d66b-fe70-56da-84c4-8cdfd9d118d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb05a447-fe4f-4eec-81ef-2dcd171ef3c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb05a447-fe4f-4eec-81ef-2dcd171ef3c1.jpg?1",
             "name": "War Room",
             "text": "",
             "colours": [],
@@ -42706,7 +42706,7 @@
         },
         {
             "id": "3cc39a79-34aa-523c-a8fa-526188103423",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f5b07-0507-4dfd-b5b6-6a032e76e4fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b16f5b07-0507-4dfd-b5b6-6a032e76e4fd.jpg?1",
             "name": "Waterlogged Grove",
             "text": "",
             "colours": [],
@@ -42740,7 +42740,7 @@
         },
         {
             "id": "de207c52-cef8-59a0-834a-6436450f0a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ca7fac-d0df-4d96-887f-16be6c995476.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08ca7fac-d0df-4d96-887f-16be6c995476.jpg?1",
             "name": "Rose Tyler",
             "text": "",
             "colours": [
@@ -42781,7 +42781,7 @@
         },
         {
             "id": "f1a18c25-78df-5986-9ab1-7579c86ee7e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba416ffc-dea7-4272-b391-c66540031366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba416ffc-dea7-4272-b391-c66540031366.jpg?1",
             "name": "Sarah Jane Smith",
             "text": "",
             "colours": [
@@ -42823,7 +42823,7 @@
         },
         {
             "id": "ec43d1a8-1794-5d8b-865f-eea39097c001",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ab508a-db3d-42d1-885a-d49fa751dc18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ab508a-db3d-42d1-885a-d49fa751dc18.jpg?1",
             "name": "K-9, Mark I",
             "text": "",
             "colours": [
@@ -42866,7 +42866,7 @@
         },
         {
             "id": "aac50a26-8bb2-5c0f-aa73-11cbdd7f8ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cc9021-db64-439a-8c6c-4ed36a8cd9c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1cc9021-db64-439a-8c6c-4ed36a8cd9c0.jpg?1",
             "name": "Dalek Squadron",
             "text": "",
             "colours": [
@@ -42904,7 +42904,7 @@
         },
         {
             "id": "cd4f81e5-04e7-510b-be60-34012dc08ccb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59e33ae-598c-44d3-89bc-b773ceade7c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f59e33ae-598c-44d3-89bc-b773ceade7c7.jpg?1",
             "name": "Yasmin Khan",
             "text": "",
             "colours": [
@@ -42946,7 +42946,7 @@
         },
         {
             "id": "26d54a9a-bee2-5a8e-845c-aed0c060990d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6356a904-0510-4652-b054-b116c0708f58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/6356a904-0510-4652-b054-b116c0708f58.jpg?1",
             "name": "Davros, Dalek Creator",
             "text": "",
             "colours": [
@@ -42994,7 +42994,7 @@
         },
         {
             "id": "7e5c0723-15fb-5b04-b04b-300ad02e4b19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdba5b9-235c-411b-b031-7f6ff5368158.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bdba5b9-235c-411b-b031-7f6ff5368158.jpg?1",
             "name": "The Fugitive Doctor",
             "text": "",
             "colours": [
@@ -43038,7 +43038,7 @@
         },
         {
             "id": "48baa900-8f48-5155-bc1b-e56b96e3d68d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee2efd-a295-411c-8291-18f5ea13a387.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bee2efd-a295-411c-8291-18f5ea13a387.jpg?1",
             "name": "The Master, Formed Anew",
             "text": "",
             "colours": [
@@ -43082,7 +43082,7 @@
         },
         {
             "id": "26675346-5dc5-50a3-8559-baf2fef95e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d458bd-ac12-4980-85d5-81cfb2a105e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31d458bd-ac12-4980-85d5-81cfb2a105e9.jpg?1",
             "name": "The Master, Gallifrey's End",
             "text": "",
             "colours": [
@@ -43126,7 +43126,7 @@
         },
         {
             "id": "b7ab1fdc-86e9-57a4-aad5-f7e683c9823c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f0ce15-bf8a-4212-b196-a1b601222ab6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1f0ce15-bf8a-4212-b196-a1b601222ab6.jpg?1",
             "name": "The Master, Mesmerist",
             "text": "",
             "colours": [
@@ -43170,7 +43170,7 @@
         },
         {
             "id": "613688d9-7d38-5ed2-96cd-3d6463af3223",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198c8bec-d484-42cb-8950-221138e17960.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/198c8bec-d484-42cb-8950-221138e17960.jpg?1",
             "name": "The Master, Multiplied",
             "text": "",
             "colours": [
@@ -43214,7 +43214,7 @@
         },
         {
             "id": "c912907a-6b21-582e-b426-5df0984c39b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77d817b-b4af-451b-9c5b-8df59b1b4d81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b77d817b-b4af-451b-9c5b-8df59b1b4d81.jpg?1",
             "name": "Missy",
             "text": "",
             "colours": [
@@ -43260,7 +43260,7 @@
         },
         {
             "id": "e92a6f94-b580-5c61-8377-802d6ced4070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d064ea-85c8-4daa-8ee2-ccde9bb84115.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09d064ea-85c8-4daa-8ee2-ccde9bb84115.jpg?1",
             "name": "River Song",
             "text": "",
             "colours": [
@@ -43305,7 +43305,7 @@
         },
         {
             "id": "a34ab002-f665-538e-ae97-590453128f2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a42c16-ce18-47f5-8b57-00740b1fa0c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54a42c16-ce18-47f5-8b57-00740b1fa0c1.jpg?1",
             "name": "The War Doctor",
             "text": "",
             "colours": [
@@ -43349,7 +43349,7 @@
         },
         {
             "id": "25e860d0-2545-53be-af71-1224999047c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b95a3-efdd-4437-8a22-2f19b44cf9a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a12b95a3-efdd-4437-8a22-2f19b44cf9a7.jpg?1",
             "name": "Weeping Angel",
             "text": "",
             "colours": [
@@ -43392,7 +43392,7 @@
         },
         {
             "id": "69a4d675-d68a-5265-aefb-edd32f10faea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fad0f5-37ed-456b-bc17-7a7739f5c01b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2fad0f5-37ed-456b-bc17-7a7739f5c01b.jpg?1",
             "name": "Cyberman Patrol",
             "text": "",
             "colours": [],
@@ -43426,7 +43426,7 @@
         },
         {
             "id": "c0f10bd2-511f-5c2d-a1a3-3fd6d422d4c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694373e5-91f4-4092-a05d-ab721a9d633a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694373e5-91f4-4092-a05d-ab721a9d633a.jpg?1",
             "name": "TARDIS",
             "text": "",
             "colours": [],
@@ -43459,7 +43459,7 @@
         },
         {
             "id": "da0aa706-4e37-5b80-bd96-2c393ebae574",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4462460-caf0-4795-a60a-72fa877fd9b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/4/e4462460-caf0-4795-a60a-72fa877fd9b8.jpg?1",
             "name": "The First Doctor",
             "text": "",
             "colours": [
@@ -43504,7 +43504,7 @@
         },
         {
             "id": "9b5ec2d9-2761-5488-adf7-6a61b0bc6ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ceb335-50fa-406b-a681-b4afae6a531b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ceb335-50fa-406b-a681-b4afae6a531b.jpg?1",
             "name": "The Second Doctor",
             "text": "",
             "colours": [
@@ -43549,7 +43549,7 @@
         },
         {
             "id": "a384d205-cd24-5831-81be-71bc539a936d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d25476-cab1-4035-843f-19da73c4dac7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6d25476-cab1-4035-843f-19da73c4dac7.jpg?1",
             "name": "The Third Doctor",
             "text": "",
             "colours": [
@@ -43594,7 +43594,7 @@
         },
         {
             "id": "524b1c44-1e58-5f85-a116-c3d5c1ec63d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0292a859-79b4-46ae-b2fe-293dae5cba7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0292a859-79b4-46ae-b2fe-293dae5cba7a.jpg?1",
             "name": "The Fourth Doctor",
             "text": "",
             "colours": [
@@ -43640,7 +43640,7 @@
         },
         {
             "id": "e1e7d62e-6919-5d5d-a857-59a7fdfb4cd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a035cc61-591f-4742-a4ec-0d07e5b4e74e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a035cc61-591f-4742-a4ec-0d07e5b4e74e.jpg?1",
             "name": "The Fifth Doctor",
             "text": "",
             "colours": [
@@ -43685,7 +43685,7 @@
         },
         {
             "id": "6531091b-6f62-549e-abdd-d4bfc8c9a6cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be3c60-cd96-49d2-bc4f-8072c981e456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7be3c60-cd96-49d2-bc4f-8072c981e456.jpg?1",
             "name": "The Sixth Doctor",
             "text": "",
             "colours": [
@@ -43730,7 +43730,7 @@
         },
         {
             "id": "310ce04c-7aee-58fc-892e-7e76be942dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce91239-0003-4e77-91af-a00eab10e98c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3ce91239-0003-4e77-91af-a00eab10e98c.jpg?1",
             "name": "The Seventh Doctor",
             "text": "",
             "colours": [
@@ -43775,7 +43775,7 @@
         },
         {
             "id": "fd4ee443-045b-5936-b0c2-26583b78af45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b8e37e-85ac-4682-b2d9-3fdec751f9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88b8e37e-85ac-4682-b2d9-3fdec751f9bc.jpg?1",
             "name": "The Eighth Doctor",
             "text": "",
             "colours": [
@@ -43820,7 +43820,7 @@
         },
         {
             "id": "c2b580ea-550c-5df5-8867-2acd40e225eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f0779c-7d8f-438a-949f-fde3e0bac7a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22f0779c-7d8f-438a-949f-fde3e0bac7a2.jpg?1",
             "name": "The Ninth Doctor",
             "text": "",
             "colours": [
@@ -43865,7 +43865,7 @@
         },
         {
             "id": "78c24e6f-c5a8-5641-bc78-1509e4548d62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503b89a5-d8cc-47c7-87f7-0c4a72508447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/503b89a5-d8cc-47c7-87f7-0c4a72508447.jpg?1",
             "name": "The Tenth Doctor",
             "text": "",
             "colours": [
@@ -43911,7 +43911,7 @@
         },
         {
             "id": "b5b6ad28-b8eb-5694-8523-096083dc84a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e2ffe-3d90-4e8f-bf62-c5c382dfffc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa8e2ffe-3d90-4e8f-bf62-c5c382dfffc5.jpg?1",
             "name": "The Eleventh Doctor",
             "text": "",
             "colours": [
@@ -43956,7 +43956,7 @@
         },
         {
             "id": "01f17da9-5d96-52cf-838a-dd2b13c93deb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba997437-76f0-4a96-9628-31b283bc292d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba997437-76f0-4a96-9628-31b283bc292d.jpg?1",
             "name": "The Twelfth Doctor",
             "text": "",
             "colours": [
@@ -44001,7 +44001,7 @@
         },
         {
             "id": "882be6aa-fac2-52b8-9b47-a0980d475a11",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698cc758-f0bc-4e09-9845-baa460bb1364.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/698cc758-f0bc-4e09-9845-baa460bb1364.jpg?1",
             "name": "The Thirteenth Doctor",
             "text": "",
             "colours": [
@@ -44047,7 +44047,7 @@
         },
         {
             "id": "4912ba49-ee69-5cc2-be16-cacf6cf9b3bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a95b348-a12e-4ed6-9e95-00bc8ef03982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a95b348-a12e-4ed6-9e95-00bc8ef03982.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44084,7 +44084,7 @@
         },
         {
             "id": "acb82f79-c4e5-5194-9027-18972bb4a04a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2da8374-7e37-49cd-affa-14cfafd12822.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2da8374-7e37-49cd-affa-14cfafd12822.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -44121,7 +44121,7 @@
         },
         {
             "id": "5cb9febb-4523-5d55-ada8-ba7e88e8d58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96b4124-ebc2-443c-981d-9869b5a3fcf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f96b4124-ebc2-443c-981d-9869b5a3fcf3.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -44158,7 +44158,7 @@
         },
         {
             "id": "5ee757a0-a87b-51f0-97e4-9127e4a322d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda6712-1730-48a0-b86d-2e7765e3db74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cda6712-1730-48a0-b86d-2e7765e3db74.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -44195,7 +44195,7 @@
         },
         {
             "id": "8ae2713d-882a-5db3-969b-739c753bcc84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dec693-a086-4a6b-8af9-a67ee093719a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92dec693-a086-4a6b-8af9-a67ee093719a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -44232,7 +44232,7 @@
         },
         {
             "id": "7c1715e8-85fc-5bf1-9a58-f3b6188384b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df93f14-494f-4051-8a55-8d23eb2fc012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9df93f14-494f-4051-8a55-8d23eb2fc012.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -44269,7 +44269,7 @@
         },
         {
             "id": "95afeb32-a382-579b-9df6-2232d7b2a53b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4038773a-2fa6-47c3-8064-fb49da90816c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4038773a-2fa6-47c3-8064-fb49da90816c.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -44306,7 +44306,7 @@
         },
         {
             "id": "64677110-701f-5f26-a68a-189337480b41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b8829d-7ac3-4563-8c3e-959c660dbe32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b8829d-7ac3-4563-8c3e-959c660dbe32.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -44343,7 +44343,7 @@
         },
         {
             "id": "325ed4ef-fe13-5cfa-b1a8-b211aec496a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8d9bd-b8c0-4628-bb19-6867336df7a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72d8d9bd-b8c0-4628-bb19-6867336df7a8.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -44380,7 +44380,7 @@
         },
         {
             "id": "fcd17bcf-4bc8-553a-8673-93f2f855122a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0230af7-0edf-4f76-af57-44cd4ebad552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0230af7-0edf-4f76-af57-44cd4ebad552.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -44417,7 +44417,7 @@
         },
         {
             "id": "8244ce5a-599a-573d-a0ad-5a6d96e2ddf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd96dce-0cc4-4417-bec1-863b2c44f844.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8cd96dce-0cc4-4417-bec1-863b2c44f844.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -44445,7 +44445,7 @@
         },
         {
             "id": "df497901-ee26-5687-8569-c236ec3346b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92520769-1e59-45d0-bfe9-cbaf80a4591e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92520769-1e59-45d0-bfe9-cbaf80a4591e.jpg?1",
             "name": "Alien",
             "text": "",
             "colours": [
@@ -44480,7 +44480,7 @@
         },
         {
             "id": "b367754a-d8af-568a-8b47-3719214c2ea4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68243f3e-c311-47cf-b1f4-583625919a2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68243f3e-c311-47cf-b1f4-583625919a2c.jpg?1",
             "name": "Alien Rhino",
             "text": "",
             "colours": [
@@ -44516,7 +44516,7 @@
         },
         {
             "id": "18bca77f-d2a0-501b-a469-d8475badfa6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e29c393-6d89-481d-8f33-19c61c46621a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e29c393-6d89-481d-8f33-19c61c46621a.jpg?1",
             "name": "Horse",
             "text": "",
             "colours": [
@@ -44551,7 +44551,7 @@
         },
         {
             "id": "fc618d70-fe8c-5bf4-9437-bf88e1f700af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ed2bb3-93b9-43a3-8b4a-97dc746f3d2b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9ed2bb3-93b9-43a3-8b4a-97dc746f3d2b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -44586,7 +44586,7 @@
         },
         {
             "id": "e60475cd-0dbe-5a46-b363-d2cd6b6f3f13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abaff2e5-32b2-404b-a4a9-2612062f6499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abaff2e5-32b2-404b-a4a9-2612062f6499.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -44621,7 +44621,7 @@
         },
         {
             "id": "ae65b9f8-8811-55d8-b44f-7eb7939047d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1bb221-bf45-4ce2-b38e-b121859235ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d1bb221-bf45-4ce2-b38e-b121859235ad.jpg?1",
             "name": "Human Noble",
             "text": "",
             "colours": [
@@ -44657,7 +44657,7 @@
         },
         {
             "id": "3459327e-38e0-52c6-a20d-8c866d674693",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2a3ff-a2f6-40c1-a246-0041c6145fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c2a3ff-a2f6-40c1-a246-0041c6145fc0.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -44692,7 +44692,7 @@
         },
         {
             "id": "1dcfdfd8-836b-5bfd-9dd7-0b9f5809cbac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41567b9a-80cf-44fc-9c82-5a5f95014428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41567b9a-80cf-44fc-9c82-5a5f95014428.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -44727,7 +44727,7 @@
         },
         {
             "id": "0efae50b-9876-5264-bd35-1504d8e5f345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297fc694-08f6-4477-b898-60ec641a0757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/297fc694-08f6-4477-b898-60ec641a0757.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -44762,7 +44762,7 @@
         },
         {
             "id": "8edcf37f-13f9-578d-9ccf-d137455f0d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65e872a-ba16-4df2-9214-60019fd6456a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b65e872a-ba16-4df2-9214-60019fd6456a.jpg?1",
             "name": "Alien Angel",
             "text": "",
             "colours": [
@@ -44799,7 +44799,7 @@
         },
         {
             "id": "128d056e-eddd-5133-9652-b9e059c22d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f176f6ec-1ff8-4cd4-b7a6-b95830532f6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f176f6ec-1ff8-4cd4-b7a6-b95830532f6a.jpg?1",
             "name": "Dalek",
             "text": "",
             "colours": [
@@ -44835,7 +44835,7 @@
         },
         {
             "id": "16528ba1-8ff5-5249-9cc0-7aa74d1e08e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b8e1c-ea36-4b5a-91a0-a15d109cc25a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a8b8e1c-ea36-4b5a-91a0-a15d109cc25a.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -44871,7 +44871,7 @@
         },
         {
             "id": "670f1571-ba7b-58bb-847f-525055b82c6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6155e7ce-3e8c-4bb3-941d-dac686d4eb57.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/6155e7ce-3e8c-4bb3-941d-dac686d4eb57.jpg?1",
             "name": "Alien Warrior",
             "text": "",
             "colours": [
@@ -44907,7 +44907,7 @@
         },
         {
             "id": "834e89d7-fa9d-5f99-9226-e87ff3b652fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c1206-c36f-4fb4-9014-e8a822c97085.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a4c1206-c36f-4fb4-9014-e8a822c97085.jpg?1",
             "name": "Mark of the Rani",
             "text": "",
             "colours": [
@@ -44942,7 +44942,7 @@
         },
         {
             "id": "40c852ca-959e-5bc7-9e71-a4b2ee1468bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45133d-ce37-42b4-b068-fbcc8be0e907.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db45133d-ce37-42b4-b068-fbcc8be0e907.jpg?1",
             "name": "Alien Salamander",
             "text": "",
             "colours": [
@@ -44978,7 +44978,7 @@
         },
         {
             "id": "8f74eb21-8ace-5fc6-9aa1-9eac3d061ab9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf1eac-279f-4264-93f6-9058a6a83d0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5aaf1eac-279f-4264-93f6-9058a6a83d0a.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -45013,7 +45013,7 @@
         },
         {
             "id": "733c6587-68fd-5dcb-9823-933a18a13dd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa61fa5-f0ca-4933-ac57-9db95f891889.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fa61fa5-f0ca-4933-ac57-9db95f891889.jpg?1",
             "name": "Mutant",
             "text": "",
             "colours": [
@@ -45048,7 +45048,7 @@
         },
         {
             "id": "ab863556-b4e5-5b95-9cde-267027545314",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609bcaff-c903-40ce-9b3e-bb7b07bb9125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609bcaff-c903-40ce-9b3e-bb7b07bb9125.jpg?1",
             "name": "Alien Insect",
             "text": "",
             "colours": [
@@ -45086,7 +45086,7 @@
         },
         {
             "id": "1eedd8ec-5ea2-52c5-887c-337040311ee2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890d9d05-3be1-467c-9b6f-a2fd9f907657.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890d9d05-3be1-467c-9b6f-a2fd9f907657.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -45123,7 +45123,7 @@
         },
         {
             "id": "4070e76d-b950-57a8-8b4c-0a6327b221eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008f776f-c7ce-47ed-bc04-2ab9f9bcd8ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/008f776f-c7ce-47ed-bc04-2ab9f9bcd8ae.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -45154,7 +45154,7 @@
         },
         {
             "id": "e6488883-6375-5415-8ec0-aec7307d6feb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de94d6e-2c7c-46d8-897d-4f0e56cc583b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de94d6e-2c7c-46d8-897d-4f0e56cc583b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -45185,7 +45185,7 @@
         },
         {
             "id": "e3caf8d3-4c7a-5aa7-9154-e701ded8b984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5cf37-da4d-481f-a7d6-975a05798201.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2c5cf37-da4d-481f-a7d6-975a05798201.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -45216,7 +45216,7 @@
         },
         {
             "id": "f632859f-fb8c-5d4b-a02e-14c7ce32d46c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc273b8-05bb-4c8f-92b1-c178d4bbadb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bc273b8-05bb-4c8f-92b1-c178d4bbadb0.jpg?1",
             "name": "Cyberman",
             "text": "",
             "colours": [],
@@ -45247,7 +45247,7 @@
         },
         {
             "id": "ff16f71d-c50b-5929-86bc-bb7467c399ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a8ba9-6a3c-4f3b-876e-ec47a08dbb8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/883a8ba9-6a3c-4f3b-876e-ec47a08dbb8a.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -45278,7 +45278,7 @@
         },
         {
             "id": "95cccd10-bb21-5afa-a2c3-8b6d68f48f24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a31a8f-5576-4ab7-bc3b-778a252d4c10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2a31a8f-5576-4ab7-bc3b-778a252d4c10.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -45309,7 +45309,7 @@
         },
         {
             "id": "94866a37-6db0-5be1-9d44-fb38145a6979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1660fd-ef35-4b95-b901-af3dda687f08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc1660fd-ef35-4b95-b901-af3dda687f08.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -45340,7 +45340,7 @@
         },
         {
             "id": "5c61ec07-6ebc-51ec-bd6c-f909ec6ebbb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38144274-f5c9-4276-b63e-a3c32aec971e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38144274-f5c9-4276-b63e-a3c32aec971e.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45371,7 +45371,7 @@
         },
         {
             "id": "1bd4264f-22b6-5b3d-9ffe-05d33718dfe4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ce40c-0744-4976-9855-b7a7b08fdac4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f40ce40c-0744-4976-9855-b7a7b08fdac4.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45402,7 +45402,7 @@
         },
         {
             "id": "55ca5784-6689-582a-a7e8-06a663f42fdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64159e56-a781-416d-a071-41a7b0c8263b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64159e56-a781-416d-a071-41a7b0c8263b.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45433,7 +45433,7 @@
         },
         {
             "id": "91c7ddb5-749c-5fcd-acbe-aa3ab3417f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77825935-2f71-4bd1-8ec7-9e8be26853c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77825935-2f71-4bd1-8ec7-9e8be26853c0.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -45464,7 +45464,7 @@
         },
         {
             "id": "1378472c-7518-5091-af60-d40f3c7f664b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d0482-c747-4eca-947b-9af1a2cc9b29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b3d0482-c747-4eca-947b-9af1a2cc9b29.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [
@@ -45501,7 +45501,7 @@
         },
         {
             "id": "553b5e02-de02-59fb-9901-28d367ab1c19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d9dfbb-1bd8-4e7b-9945-498fde093d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d9dfbb-1bd8-4e7b-9945-498fde093d6c.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],
@@ -45528,7 +45528,7 @@
         },
         {
             "id": "b7e1f480-5560-5f11-8f61-3c9b1cc963fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce150eb-7d3d-4882-8e1a-2eafe9d9b356.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2ce150eb-7d3d-4882-8e1a-2eafe9d9b356.jpg?1",
             "name": "Alien",
             "text": "",
             "colours": [
@@ -45562,7 +45562,7 @@
         },
         {
             "id": "bc5e5622-5b3f-5857-b5ef-204dd83e196b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28cb34f-04c3-4cb8-9d4c-90c98b11bfe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28cb34f-04c3-4cb8-9d4c-90c98b11bfe3.jpg?1",
             "name": "Alien Rhino",
             "text": "",
             "colours": [
@@ -45597,7 +45597,7 @@
         },
         {
             "id": "ed01af5a-fc62-57b3-bf96-e73e9829883b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea25527-2c98-4c6b-ac1c-cabf69fda851.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dea25527-2c98-4c6b-ac1c-cabf69fda851.jpg?1",
             "name": "Horse",
             "text": "",
             "colours": [
@@ -45631,7 +45631,7 @@
         },
         {
             "id": "824e4285-56ea-5d9f-9db2-48a34f3fddd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe939f-c680-403f-a5be-0f0cca020ef2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30fe939f-c680-403f-a5be-0f0cca020ef2.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -45665,7 +45665,7 @@
         },
         {
             "id": "08e6cdff-da21-5a62-b87d-d80eaa6703dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b58706-9140-4908-b613-702e607b7d8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65b58706-9140-4908-b613-702e607b7d8b.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -45699,7 +45699,7 @@
         },
         {
             "id": "1407fe64-0a46-5d5f-85d3-6ab80374df0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207efdc-c416-4918-80d9-8b18905eaa90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/1207efdc-c416-4918-80d9-8b18905eaa90.jpg?1",
             "name": "Human Noble",
             "text": "",
             "colours": [
@@ -45734,7 +45734,7 @@
         },
         {
             "id": "03c72458-0406-598c-953f-8f204503744c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c10957-0b04-4a7b-879f-76d70f023818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29c10957-0b04-4a7b-879f-76d70f023818.jpg?1",
             "name": "Soldier",
             "text": "",
             "colours": [
@@ -45768,7 +45768,7 @@
         },
         {
             "id": "c0907e3c-e290-5768-b885-6bc88459ecdd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b566e0d-5680-4b06-8360-b722beedef2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b566e0d-5680-4b06-8360-b722beedef2e.jpg?1",
             "name": "Warrior",
             "text": "",
             "colours": [
@@ -45802,7 +45802,7 @@
         },
         {
             "id": "a1b995bd-aec0-5b7f-8db9-65b77d465558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779b2dbe-70d9-4690-b05e-e828197f3afa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/779b2dbe-70d9-4690-b05e-e828197f3afa.jpg?1",
             "name": "Fish",
             "text": "",
             "colours": [
@@ -45836,7 +45836,7 @@
         },
         {
             "id": "07ba385a-72ad-50a1-935c-9e1717f565b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d928b9e7-2b21-4fd3-bb33-d69c0e91b415.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d928b9e7-2b21-4fd3-bb33-d69c0e91b415.jpg?1",
             "name": "Alien Angel",
             "text": "",
             "colours": [
@@ -45872,7 +45872,7 @@
         },
         {
             "id": "f50201d6-3e20-541a-89c9-b44ceaf4c0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde90b3-cd39-4ac5-b326-9ecc3d7d0d04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fde90b3-cd39-4ac5-b326-9ecc3d7d0d04.jpg?1",
             "name": "Dalek",
             "text": "",
             "colours": [
@@ -45907,7 +45907,7 @@
         },
         {
             "id": "1f5fc2a7-0ac2-5e82-b473-688241c0a5d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578a760b-26c7-4cbb-892a-7d8f2a92ece3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/578a760b-26c7-4cbb-892a-7d8f2a92ece3.jpg?1",
             "name": "Human Rogue",
             "text": "",
             "colours": [
@@ -45942,7 +45942,7 @@
         },
         {
             "id": "64f5b6ae-4946-576c-bdf9-545659758984",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba581b6-1866-4f5c-9785-98a14ec84ebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/aba581b6-1866-4f5c-9785-98a14ec84ebc.jpg?1",
             "name": "Alien Warrior",
             "text": "",
             "colours": [
@@ -45977,7 +45977,7 @@
         },
         {
             "id": "503c446b-a8f5-5791-a42e-4dd984bed366",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da780e8b-55a9-4fbe-b37f-b7b9043f9cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da780e8b-55a9-4fbe-b37f-b7b9043f9cdf.jpg?1",
             "name": "Mark of the Rani",
             "text": "",
             "colours": [
@@ -46011,7 +46011,7 @@
         },
         {
             "id": "a0b261b5-37b1-5fe4-85e5-c8f2bd31be21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f247c-edb7-438a-b004-be3d4fcd3d3f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/248f247c-edb7-438a-b004-be3d4fcd3d3f.jpg?1",
             "name": "Alien Salamander",
             "text": "",
             "colours": [
@@ -46046,7 +46046,7 @@
         },
         {
             "id": "5ba0df90-4985-53bf-9118-fbd40384d716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0375ff38-d2db-4866-a979-3fe94b286405.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/0375ff38-d2db-4866-a979-3fe94b286405.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -46080,7 +46080,7 @@
         },
         {
             "id": "3f5e883a-baaf-58ec-9f48-a8e8af76dbeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4fa4c-b68c-406c-80af-97257518a884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e4fa4c-b68c-406c-80af-97257518a884.jpg?1",
             "name": "Mutant",
             "text": "",
             "colours": [
@@ -46114,7 +46114,7 @@
         },
         {
             "id": "8febb223-d127-5c7e-8584-2b9bef54942e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832e03c-111a-409e-a88c-6edbb528a239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c832e03c-111a-409e-a88c-6edbb528a239.jpg?1",
             "name": "Alien Insect",
             "text": "",
             "colours": [
@@ -46151,7 +46151,7 @@
         },
         {
             "id": "1d186e0e-3028-52e1-8537-d1c52575e57c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406b2d4-d227-4b03-801f-38230161c708.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3406b2d4-d227-4b03-801f-38230161c708.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -46187,7 +46187,7 @@
         },
         {
             "id": "16b5f074-63da-51a6-bc86-5da72774d0ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad1e6e0-c2e6-4a03-9ee0-a3643801e7c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad1e6e0-c2e6-4a03-9ee0-a3643801e7c8.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -46217,7 +46217,7 @@
         },
         {
             "id": "33138258-8135-5875-ba96-57a1cebaf1f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa00d7c-359c-4c80-9d71-f9e39e87829b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa00d7c-359c-4c80-9d71-f9e39e87829b.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -46247,7 +46247,7 @@
         },
         {
             "id": "915356b7-202a-5619-b003-e613d245d5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145be5c-62f5-43ef-8dea-3a1e85ad9b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/1145be5c-62f5-43ef-8dea-3a1e85ad9b72.jpg?1",
             "name": "Clue",
             "text": "",
             "colours": [],
@@ -46277,7 +46277,7 @@
         },
         {
             "id": "52622c86-375f-5342-963b-e5cdac14f354",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392db1d2-9d75-4d19-88e0-9b0ffdc88541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392db1d2-9d75-4d19-88e0-9b0ffdc88541.jpg?1",
             "name": "Cyberman",
             "text": "",
             "colours": [],
@@ -46307,7 +46307,7 @@
         },
         {
             "id": "b9848bcd-fba3-5290-bfcc-15b590061511",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7db322-83fb-49ae-bb03-509d516adc12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b7db322-83fb-49ae-bb03-509d516adc12.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -46337,7 +46337,7 @@
         },
         {
             "id": "fbe51736-4f09-5854-ab11-d7e15b141a67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36bd92-5cec-46a5-9ab3-ce4c81574770.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e36bd92-5cec-46a5-9ab3-ce4c81574770.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -46367,7 +46367,7 @@
         },
         {
             "id": "e5a3f019-74a1-5996-91b2-3e8750cf0841",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be99852d-54f7-42bd-b2a2-e123302650eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be99852d-54f7-42bd-b2a2-e123302650eb.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -46397,7 +46397,7 @@
         },
         {
             "id": "fb19c769-de84-5f88-ae6c-fdbb80a5cf48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4656467d-947e-43cd-81cb-19ebd504d156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4656467d-947e-43cd-81cb-19ebd504d156.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46427,7 +46427,7 @@
         },
         {
             "id": "feaa3126-d549-54f5-b99c-222e4b3606f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7db254-48c7-4870-b060-70050908abff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e7db254-48c7-4870-b060-70050908abff.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46457,7 +46457,7 @@
         },
         {
             "id": "3a44cd3e-fe02-5af3-b1e6-281027660e31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1e7e9c-cd70-40a6-a0cd-8dbd5db23d06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e1e7e9c-cd70-40a6-a0cd-8dbd5db23d06.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46487,7 +46487,7 @@
         },
         {
             "id": "4f5f8c15-0464-5138-a9b6-07a65429f4f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31e197-a322-4310-95a9-67f806f904a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd31e197-a322-4310-95a9-67f806f904a6.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -46517,7 +46517,7 @@
         },
         {
             "id": "0a02e8fd-b70d-544d-a438-64d5f72cbba9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c9567-4e2a-4537-b391-5ce509f34382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e7c9567-4e2a-4537-b391-5ce509f34382.jpg?1",
             "name": "Osgood, Operation Double",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/WOE.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/WOE.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "ba7f1dad-ad9d-5634-b868-8c8e15c74bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1",
             "name": "Archon of the Wild Rose",
             "text": "Flying\nOther creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.",
             "colours": [
@@ -40,7 +40,7 @@
         },
         {
             "id": "3b1e5466-13eb-5d70-9226-3b0b800dbd38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71768e7-4ef7-4fb2-838b-eb3a7f662d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e71768e7-4ef7-4fb2-838b-eb3a7f662d38.jpg?1",
             "name": "Archon's Glory",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTarget creature gets +2/+2 until end of turn. If this spell was bargained, that creature also gains flying and lifelink until end of turn.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "5a54f9fa-82a6-59ad-8af3-94dd74790e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b041949-6fb6-40a6-9329-f209be537219.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b041949-6fb6-40a6-9329-f209be537219.jpg?1",
             "name": "Armory Mice",
             "text": "Celebration \u2014 Armory Mice gets +0/+2 as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "03c147e7-aaf5-52ac-9a9f-264bacd6f797",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg?1",
             "name": "Besotted Knight // Betroth the Beast",
             "text": "",
             "colours": [
@@ -141,7 +141,7 @@
         },
         {
             "id": "cd7cb0c4-f317-5f0e-9b2d-e5ac83dfb0ed",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg?1",
             "name": "Besotted Knight // Betroth the Beast",
             "text": "Create a Royal Role token attached to target creature you control. (Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -175,7 +175,7 @@
         },
         {
             "id": "f47f48fd-5552-5ba4-8139-b25c3f8570cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7094fc0-1d26-429c-9b49-37718c4a5c80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7094fc0-1d26-429c-9b49-37718c4a5c80.jpg?1",
             "name": "Break the Spell",
             "text": "Destroy target enchantment. If a permanent you controlled or a token was destroyed this way, draw a card.",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "d2864645-8c0f-5442-b971-504bc426181d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994f4473-dfc9-45cd-8528-945db3aa6a9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/994f4473-dfc9-45cd-8528-945db3aa6a9a.jpg?1",
             "name": "Charmed Clothier",
             "text": "Flying\nWhen Charmed Clothier enters the battlefield, create a Royal Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -242,7 +242,7 @@
         },
         {
             "id": "f923a228-3c44-5ac9-8ddb-b11d62fcb667",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg?1",
             "name": "Cheeky House-Mouse // Squeak By",
             "text": "",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "8ab58188-e111-52ce-942d-0a73a47c6fef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg?1",
             "name": "Cheeky House-Mouse // Squeak By",
             "text": "Target creature you control gets +1/+1 until end of turn. It can't be blocked by creatures with power 3 or greater this turn.",
             "colours": [
@@ -310,7 +310,7 @@
         },
         {
             "id": "fd9017a3-a53c-5ac1-b779-fb3c9cec9725",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb8758-09c5-4e19-ada1-904e36ece1fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8acb8758-09c5-4e19-ada1-904e36ece1fc.jpg?1",
             "name": "Cooped Up",
             "text": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
             "colours": [
@@ -344,7 +344,7 @@
         },
         {
             "id": "463e9b43-02c0-5264-be3f-6b95bf162edf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2d5a71-d6e1-4c96-9a53-0e370047a56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d2d5a71-d6e1-4c96-9a53-0e370047a56e.jpg?1",
             "name": "Cursed Courtier",
             "text": "Lifelink\nWhen Cursed Courtier enters the battlefield, create a Cursed Role token attached to it. (Enchanted creature is 1/1.)",
             "colours": [
@@ -379,7 +379,7 @@
         },
         {
             "id": "9250b35b-016d-5e5c-9a6a-e1e79ead10e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584774b5-640f-45e0-810b-f5faf119645b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/584774b5-640f-45e0-810b-f5faf119645b.jpg?1",
             "name": "Discerning Financier",
             "text": "At the beginning of your upkeep, if an opponent controls more lands than you, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\n{2}{W}: Choose another player. That player gains control of target Treasure you control. You draw a card.",
             "colours": [
@@ -414,7 +414,7 @@
         },
         {
             "id": "ff83ed32-caa5-5e76-aec7-3154b06fe07d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e40377-990f-41ea-8dd2-62a998dcd128.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8e40377-990f-41ea-8dd2-62a998dcd128.jpg?1",
             "name": "Dutiful Griffin",
             "text": "Flying\n{2}{W}, Sacrifice two enchantments: Return Dutiful Griffin from your graveyard to your hand.",
             "colours": [
@@ -448,7 +448,7 @@
         },
         {
             "id": "64210b86-3837-5114-b73d-cabffab30b1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a74545-75c8-4a6b-bee1-ac5665d9bcf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42a74545-75c8-4a6b-bee1-ac5665d9bcf0.jpg?1",
             "name": "Eerie Interference",
             "text": "Prevent all damage that would be dealt to you and creatures you control this turn by creatures.",
             "colours": [
@@ -480,7 +480,7 @@
         },
         {
             "id": "1cf78934-5d8e-5d69-9a4d-d05f188b2f14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1094eef0-6c57-4bfa-a584-f708b87354fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1094eef0-6c57-4bfa-a584-f708b87354fb.jpg?1",
             "name": "Expel the Interlopers",
             "text": "Choose a number between 0 and 10. Destroy all creatures with power greater than or equal to the chosen number.",
             "colours": [
@@ -515,7 +515,7 @@
         },
         {
             "id": "8eb00e55-c619-5986-9c35-35c164a3d7d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dec431-a20e-4c1c-9855-904779756509.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9dec431-a20e-4c1c-9855-904779756509.jpg?1",
             "name": "Frostbridge Guard",
             "text": "{2}{W}, {T}: Tap target creature.",
             "colours": [
@@ -550,7 +550,7 @@
         },
         {
             "id": "a488b25b-4576-5ed4-a801-574f8210b27e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053d330-d0a2-4468-afba-42bf165b8fbf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e053d330-d0a2-4468-afba-42bf165b8fbf.jpg?1",
             "name": "Gallant Pie-Wielder",
             "text": "First strike\nCelebration \u2014 Gallant Pie-Wielder has double strike as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -585,7 +585,7 @@
         },
         {
             "id": "67d666a3-1b95-57d3-b1d4-50d8bc63a9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c5c395-ee8b-47fd-ac52-256354c19cdf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02c5c395-ee8b-47fd-ac52-256354c19cdf.jpg?1",
             "name": "Glass Casket",
             "text": "When Glass Casket enters the battlefield, exile target creature an opponent controls with mana value 3 or less until Glass Casket leaves the battlefield.",
             "colours": [
@@ -617,7 +617,7 @@
         },
         {
             "id": "6ea683dc-eacb-5080-a215-18ab8440aa17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382fd32-b1f5-4ec7-9d42-fc2915ed3bc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d382fd32-b1f5-4ec7-9d42-fc2915ed3bc9.jpg?1",
             "name": "Hopeful Vigil",
             "text": "When Hopeful Vigil enters the battlefield, create a 2/2 white Knight creature token with vigilance.\nWhen Hopeful Vigil is put into a graveyard from the battlefield, scry 2.\n{2}{W}: Sacrifice Hopeful Vigil.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "3cab7d98-fa65-5def-95ea-063a6a46223a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc727a6-f875-49b1-b7a4-67f22fbc3d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cc727a6-f875-49b1-b7a4-67f22fbc3d50.jpg?1",
             "name": "Kellan's Lightblades",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nKellan's Lightblades deals 3 damage to target attacking or blocking creature. If this spell was bargained, destroy that creature instead.",
             "colours": [
@@ -681,7 +681,7 @@
         },
         {
             "id": "30aa1b7d-3a65-5799-95a6-ef4cf3aa3026",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f33617-ad19-4d42-ab94-6f21a7fb3dd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4f33617-ad19-4d42-ab94-6f21a7fb3dd4.jpg?1",
             "name": "Knight of Doves",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 white Bird creature token with flying.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "03fcd050-09df-5444-a3fa-26aa4663d120",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f257fd6-24a4-4cc1-89e0-99cf5d821e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f257fd6-24a4-4cc1-89e0-99cf5d821e3a.jpg?1",
             "name": "Moment of Valor",
             "text": "Choose one \u2014\n\u2022 Untap target creature. It gets +1/+0 and gains indestructible until end of turn.\n\u2022 Destroy target creature with power 4 or greater.",
             "colours": [
@@ -748,7 +748,7 @@
         },
         {
             "id": "0fcec908-a1cf-59f7-9547-8b91beb02908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092c48bd-b648-4c9e-aa99-cac3c407911d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/092c48bd-b648-4c9e-aa99-cac3c407911d.jpg?1",
             "name": "Moonshaker Cavalry",
             "text": "Flying\nWhen Moonshaker Cavalry enters the battlefield, creatures you control gain flying and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -785,7 +785,7 @@
         },
         {
             "id": "e04e83e1-f258-5983-8e19-e78873c45bfa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4aceba-f386-457c-bc68-6382eda46754.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe4aceba-f386-457c-bc68-6382eda46754.jpg?1",
             "name": "Plunge into Winter",
             "text": "Tap up to one target creature. Scry 1, then draw a card.",
             "colours": [
@@ -817,7 +817,7 @@
         },
         {
             "id": "6b7b537f-6330-5d27-a9ec-102fee17a362",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad7bd06-22e4-40f8-bda9-bcdbb2d8f632.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dad7bd06-22e4-40f8-bda9-bcdbb2d8f632.jpg?1",
             "name": "The Princess Takes Flight",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Exile up to one target creature.\nII \u2014 Target creature you control gets +2/+2 and gains flying until end of turn.\nIII \u2014 Return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -851,7 +851,7 @@
         },
         {
             "id": "97567c04-351a-58bf-a4b0-c8e7bbf6512a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cc9653-80ef-4606-a0ec-6d4228fdb118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68cc9653-80ef-4606-a0ec-6d4228fdb118.jpg?1",
             "name": "Protective Parents",
             "text": "When Protective Parents dies, create a Young Hero Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -886,7 +886,7 @@
         },
         {
             "id": "d70bc68c-ab73-5bf9-a2e1-e5e7dd4b0288",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg?1",
             "name": "Regal Bunnicorn",
             "text": "Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control.",
             "colours": [
@@ -923,7 +923,7 @@
         },
         {
             "id": "8962d1c7-43c7-5036-b5d3-83c8c86733b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5209c13-9591-48eb-8d6c-112b3bdd429a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5209c13-9591-48eb-8d6c-112b3bdd429a.jpg?1",
             "name": "Return Triumphant",
             "text": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Create a Young Hero Role token attached to it. (Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\" If you put another Role on the creature later, put this one into the graveyard.)",
             "colours": [
@@ -955,7 +955,7 @@
         },
         {
             "id": "5bd4ee6a-a6e1-5eff-a6f9-51da71d59541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60acc0b7-6842-44aa-a7cc-c5d315d90287.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60acc0b7-6842-44aa-a7cc-c5d315d90287.jpg?1",
             "name": "Rimefur Reindeer",
             "text": "Whenever an enchantment enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -989,7 +989,7 @@
         },
         {
             "id": "bc59a5bc-2a1e-5bdd-a7a1-322e7fc6911e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg?1",
             "name": "Savior of the Sleeping",
             "text": "Vigilance\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Savior of the Sleeping.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "b518c769-3b5e-5878-b7f3-d54950f6517d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f41ae2-ebc6-439f-95af-c34818a3f4e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f41ae2-ebc6-439f-95af-c34818a3f4e6.jpg?1",
             "name": "Slumbering Keepguard",
             "text": "Whenever an enchantment enters the battlefield under your control, scry 1.\n{2}{W}: Slumbering Keepguard gets +1/+1 until end of turn for each enchantment you control.",
             "colours": [
@@ -1059,7 +1059,7 @@
         },
         {
             "id": "d49e32ee-a399-59be-87e3-9b4a0d8319b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155693c-def0-4290-b662-ab9932e07fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d155693c-def0-4290-b662-ab9932e07fe5.jpg?1",
             "name": "Solitary Sanctuary",
             "text": "When Solitary Sanctuary enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "31c5bab0-394a-5f46-abe5-36e8c3da1c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ceac5b5-05eb-4f00-9477-3db490be24dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ceac5b5-05eb-4f00-9477-3db490be24dd.jpg?1",
             "name": "Spellbook Vendor",
             "text": "Vigilance\nAt the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -1128,7 +1128,7 @@
         },
         {
             "id": "43ae2fba-6d21-5ea9-8681-9c86a3445ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0214ebc6-c59f-4170-8dd2-ce07caa6e6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0214ebc6-c59f-4170-8dd2-ce07caa6e6ad.jpg?1",
             "name": "Stockpiling Celebrant",
             "text": "When Stockpiling Celebrant enters the battlefield, you may return another target nonland permanent you control to its owner's hand. If you do, scry 2.",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "3f0293de-14f8-5256-acf2-788e35944c6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289ba7ec-e30e-436f-b8d4-c88b65ecd137.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/289ba7ec-e30e-436f-b8d4-c88b65ecd137.jpg?1",
             "name": "Stroke of Midnight",
             "text": "Destroy target nonland permanent. Its controller creates a 1/1 white Human creature token.",
             "colours": [
@@ -1197,7 +1197,7 @@
         },
         {
             "id": "0dca050f-64cb-5f0a-a515-f431d95f7249",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg?1",
             "name": "A Tale for the Ages",
             "text": "Enchanted creatures you control get +2/+2.",
             "colours": [
@@ -1231,7 +1231,7 @@
         },
         {
             "id": "110832cc-0948-5a98-b4bc-2540e3c37f1f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2ba371-854c-4529-b72b-e4a1887e33ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d2ba371-854c-4529-b72b-e4a1887e33ab.jpg?1",
             "name": "Three Blind Mice",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI \u2014 Create a 1/1 white Mouse creature token.\nII, III \u2014 Create a token that's a copy of target token you control.\nIV \u2014 Creatures you control get +1/+1 and gain vigilance until end of turn.",
             "colours": [
@@ -1265,7 +1265,7 @@
         },
         {
             "id": "297649c5-7508-5579-91d8-1190f3838516",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01334fed-781e-4864-83fd-d37f787a778b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01334fed-781e-4864-83fd-d37f787a778b.jpg?1",
             "name": "Tuinvale Guide",
             "text": "Flying\nCelebration \u2014 Tuinvale Guide gets +1/+0 and has lifelink as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "b3f6794e-4f70-5fba-973d-ea93851ba61a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66fbaeb-1624-43b3-83e2-a37ce7588a5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66fbaeb-1624-43b3-83e2-a37ce7588a5a.jpg?1",
             "name": "Unassuming Sage",
             "text": "When Unassuming Sage enters the battlefield, you may pay {2}. If you do, create a Sorcerer Role token attached to it. (Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "20b7b28c-4498-5b96-afb1-6f044fe373b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control. Untap those creatures.",
             "colours": [
@@ -1370,7 +1370,7 @@
         },
         {
             "id": "71767870-dbd5-54fe-97aa-e56816c5162f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -1406,7 +1406,7 @@
         },
         {
             "id": "315030cd-5e10-5e29-a154-4e15ae5601df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg?1",
             "name": "Werefox Bodyguard",
             "text": "Flash\nWhen Werefox Bodyguard enters the battlefield, exile up to one other target non-Fox creature until Werefox Bodyguard leaves the battlefield.\n{1}{W}, Sacrifice Werefox Bodyguard: You gain 2 life.",
             "colours": [
@@ -1444,7 +1444,7 @@
         },
         {
             "id": "69fa5e30-fdb9-53bf-837f-ea3972e658fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg?1",
             "name": "Aquatic Alchemist // Bubble Up",
             "text": "Whenever you cast your first instant or sorcery spell each turn, Aquatic Alchemist gets +2/+0 until end of turn.",
             "colours": [
@@ -1478,7 +1478,7 @@
         },
         {
             "id": "7300ecbb-91a2-5ee3-a7e4-cea6d87dc020",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg?1",
             "name": "Aquatic Alchemist // Bubble Up",
             "text": "Put target instant or sorcery card from your graveyard on top of your library. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1512,7 +1512,7 @@
         },
         {
             "id": "49a4a855-8bd0-5597-9898-e0c96a4ede96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2979104f-7570-487c-8024-131d7ee3ab91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2979104f-7570-487c-8024-131d7ee3ab91.jpg?1",
             "name": "Archive Dragon",
             "text": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen Archive Dragon enters the battlefield, scry 2.",
             "colours": [
@@ -1547,7 +1547,7 @@
         },
         {
             "id": "cbc25ae8-c4b9-5dbb-9a9b-a3207adaaa1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b96a97-0d7d-4e05-9e2f-0b99a039b655.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b96a97-0d7d-4e05-9e2f-0b99a039b655.jpg?1",
             "name": "Asinine Antics",
             "text": "You may cast Asinine Antics as though it had flash if you pay {2} more to cast it.\nFor each creature your opponents control, create a Cursed Role token attached to that creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
             "colours": [
@@ -1581,7 +1581,7 @@
         },
         {
             "id": "fa124a29-a69e-59de-af95-93cdddc067bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg?1",
             "name": "Beluna's Gatekeeper // Entry Denied",
             "text": "",
             "colours": [
@@ -1616,7 +1616,7 @@
         },
         {
             "id": "beb603e9-2e1d-5865-aafe-75ec96448938",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg?1",
             "name": "Beluna's Gatekeeper // Entry Denied",
             "text": "Return target creature you don't control with mana value 3 or less to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1650,7 +1650,7 @@
         },
         {
             "id": "330f1f04-b727-5267-bfa4-931126480bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e3c71-e21d-4e77-b1b6-09769f9cd3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/888e3c71-e21d-4e77-b1b6-09769f9cd3d6.jpg?1",
             "name": "Bitter Chill",
             "text": "Enchant creature\nWhen Bitter Chill enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhen Bitter Chill is put into a graveyard from the battlefield, you may pay {1}. If you do, scry 1, then draw a card.",
             "colours": [
@@ -1684,7 +1684,7 @@
         },
         {
             "id": "bf8c4aa4-6c05-55dc-a8be-c0b0f3778650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67bd5ef-305b-4bf7-990b-3014778b14a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67bd5ef-305b-4bf7-990b-3014778b14a0.jpg?1",
             "name": "Chancellor of Tales",
             "text": "Flying\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
             "colours": [
@@ -1719,7 +1719,7 @@
         },
         {
             "id": "032bb6cd-99dd-569f-b863-2dd7ece33617",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d604f-b187-4122-bd4b-67634654b6f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/646d604f-b187-4122-bd4b-67634654b6f1.jpg?1",
             "name": "Diminisher Witch",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen Diminisher Witch enters the battlefield, if it was bargained, create a Cursed Role token attached to target creature an opponent controls. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "36df8846-a152-5c7d-a5a4-97209a55dc8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588c6217-c460-417e-98bf-de5475780baf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/588c6217-c460-417e-98bf-de5475780baf.jpg?1",
             "name": "Disdainful Stroke",
             "text": "Counter target spell with mana value 4 or greater.",
             "colours": [
@@ -1786,7 +1786,7 @@
         },
         {
             "id": "62756386-775d-53eb-93d1-37a1121945bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69fb480-a9fc-4f09-ac4e-3ce52c485ea9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69fb480-a9fc-4f09-ac4e-3ce52c485ea9.jpg?1",
             "name": "Extraordinary Journey",
             "text": "When Extraordinary Journey enters the battlefield, exile up to X target creatures. For each of those cards, its owner may play it for as long as it remains exiled.\nWhenever one or more nontoken creatures enter the battlefield, if one or more of them entered from exile or was cast from exile, you draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "62ade95b-4f77-5c77-96f9-bf5c350c7a27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg?1",
             "name": "Farsight Ritual",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nLook at the top four cards of your library. If this spell was bargained, look at the top eight cards of your library instead. Put two of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "0026b37c-bc3a-5a1e-a6d5-429840baf32a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8bb9c7-2c4b-48a1-806e-742addb72b4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a8bb9c7-2c4b-48a1-806e-742addb72b4b.jpg?1",
             "name": "Freeze in Place",
             "text": "Tap target creature an opponent controls and put three stun counters on it. Scry 2. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -1886,7 +1886,7 @@
         },
         {
             "id": "a9bc2b67-27db-5b10-a0a9-02f3ab65e571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af07c47f-8b4e-43cb-b469-2efb82aa5590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af07c47f-8b4e-43cb-b469-2efb82aa5590.jpg?1",
             "name": "Gadwick's First Duel",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a Cursed Role token attached to up to one target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)\nII \u2014 Scry 2.\nIII \u2014 When you cast your next instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -1920,7 +1920,7 @@
         },
         {
             "id": "3378d03b-838c-5fce-bd6f-d162f06e1ec4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg?1",
             "name": "Galvanic Giant // Storm Reading",
             "text": "Whenever you cast a spell with mana value 5 or greater, tap target creature an opponent controls and put a stun counter on it.",
             "colours": [
@@ -1955,7 +1955,7 @@
         },
         {
             "id": "88494e55-ec96-50fc-9c28-47057efa0da8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg?1",
             "name": "Galvanic Giant // Storm Reading",
             "text": "Draw four cards, then discard two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -1989,7 +1989,7 @@
         },
         {
             "id": "a64e3d37-4934-51f5-b48d-bad9f3951535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "Flash\nWard {2}\nHorned Loch-Whale enters the battlefield tapped unless it's your turn.",
             "colours": [
@@ -2025,7 +2025,7 @@
         },
         {
             "id": "183b20c9-2733-5d22-9498-e105a672a276",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "The owner of target attacking creature you don't control puts it on the top or bottom of their library.",
             "colours": [
@@ -2061,7 +2061,7 @@
         },
         {
             "id": "7069b991-8751-5132-bd10-33ccd1071049",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ffafda-c852-497a-8156-4f759cdf3693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ffafda-c852-497a-8156-4f759cdf3693.jpg?1",
             "name": "Ice Out",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {1} less to cast if it's bargained.\nCounter target spell.",
             "colours": [
@@ -2093,7 +2093,7 @@
         },
         {
             "id": "51b15a14-517d-56c7-afff-c61107c7c0b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859419d3-cd15-4362-98b3-a7ff98e29692.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859419d3-cd15-4362-98b3-a7ff98e29692.jpg?1",
             "name": "Icewrought Sentry",
             "text": "Vigilance\nWhenever Icewrought Sentry attacks, you may pay {1}{U}. When you do, tap target creature an opponent controls.\nWhenever you tap an untapped creature an opponent controls, Icewrought Sentry gets +2/+1 until end of turn.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "236c7bcb-fc0b-5664-a1ac-db263a5e717d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf224968-b676-40dd-83c1-a9ee2ceba574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf224968-b676-40dd-83c1-a9ee2ceba574.jpg?1",
             "name": "Ingenious Prodigy",
             "text": "Skulk (This creature can't be blocked by creatures with greater power.)\nIngenious Prodigy enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, if Ingenious Prodigy has one or more +1/+1 counters on it, you may remove a +1/+1 counter from it. If you do, draw a card.",
             "colours": [
@@ -2165,7 +2165,7 @@
         },
         {
             "id": "4e70427f-be31-5535-bdbd-50c928649078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969b13bb-6411-41f9-b6b4-af4ffca62e17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969b13bb-6411-41f9-b6b4-af4ffca62e17.jpg?1",
             "name": "Into the Fae Court",
             "text": "Draw three cards. Create a 1/1 blue Faerie creature token with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -2197,7 +2197,7 @@
         },
         {
             "id": "9bf0b366-1471-5484-8016-fe1e5e66ccaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31408397-36f5-479f-b822-fa97411b7872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31408397-36f5-479f-b822-fa97411b7872.jpg?1",
             "name": "Johann's Stopgap",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {2} less to cast if it's bargained.\nReturn target nonland permanent to its owner's hand. Draw a card.",
             "colours": [
@@ -2229,7 +2229,7 @@
         },
         {
             "id": "6c9b9f4d-7df2-525b-8fa9-bae5aaae48e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169afcaf-7ebf-4590-9e51-2a1a5eb3ac76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/169afcaf-7ebf-4590-9e51-2a1a5eb3ac76.jpg?1",
             "name": "Living Lectern",
             "text": "{1}, Sacrifice Living Lectern: Draw a card. Create a Sorcerer Role token attached to up to one other target creature you control. Activate only as a sorcery. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -2264,7 +2264,7 @@
         },
         {
             "id": "d60d7ee8-c2aa-5b62-997c-87313b264ebe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f6a79c-aa2f-47d2-a929-1606a61f9341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7f6a79c-aa2f-47d2-a929-1606a61f9341.jpg?1",
             "name": "Merfolk Coralsmith",
             "text": "{1}: Merfolk Coralsmith gets +1/-1 until end of turn.\nWhen Merfolk Coralsmith dies, scry 2.",
             "colours": [
@@ -2298,7 +2298,7 @@
         },
         {
             "id": "cfb11b8e-e343-5461-ae59-9520a7a2f3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6c7a43-c3d1-450e-834a-54e1b9def1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4c6c7a43-c3d1-450e-834a-54e1b9def1cd.jpg?1",
             "name": "Misleading Motes",
             "text": "Target creature's owner puts it on the top or bottom of their library.",
             "colours": [
@@ -2330,7 +2330,7 @@
         },
         {
             "id": "f0f5b133-4ea2-5cb0-8bf3-5861b34146d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e595014d-4ff4-4561-b7f2-a9bd56300b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e595014d-4ff4-4561-b7f2-a9bd56300b01.jpg?1",
             "name": "Mocking Sprite",
             "text": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.",
             "colours": [
@@ -2365,7 +2365,7 @@
         },
         {
             "id": "6a89f54b-9895-5d2c-93e6-ef9cbbca9e42",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1",
             "name": "Obyra's Attendants // Desperate Parry",
             "text": "Flying",
             "colours": [
@@ -2400,7 +2400,7 @@
         },
         {
             "id": "584734e9-6a31-54e7-96e9-17c8dca59e1d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1",
             "name": "Obyra's Attendants // Desperate Parry",
             "text": "Target creature gets -4/-0 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -2434,7 +2434,7 @@
         },
         {
             "id": "fe7def44-a9a8-5dd1-8ee9-9d5f839ab3fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg?1",
             "name": "Picklock Prankster // Free the Fae",
             "text": "Flying, vigilance",
             "colours": [
@@ -2469,7 +2469,7 @@
         },
         {
             "id": "687b6cf1-2e49-5655-a440-077a7df5b2ca",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg?1",
             "name": "Picklock Prankster // Free the Fae",
             "text": "Mill four cards. Then put an instant, sorcery, or Faerie card from among the milled cards into your hand.",
             "colours": [
@@ -2503,7 +2503,7 @@
         },
         {
             "id": "fb16e675-35b8-551e-9989-e281caa5e5c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78e2bca-bc93-464a-8911-8361abff2ac6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b78e2bca-bc93-464a-8911-8361abff2ac6.jpg?1",
             "name": "Quick Study",
             "text": "Draw two cards.",
             "colours": [
@@ -2535,7 +2535,7 @@
         },
         {
             "id": "b7cf0005-fc24-5821-8cec-e57e57519f84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31051436-68f2-457e-8293-2b10ccf7684e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31051436-68f2-457e-8293-2b10ccf7684e.jpg?1",
             "name": "Sleep-Cursed Faerie",
             "text": "Flying, ward {2}\nSleep-Cursed Faerie enters the battlefield tapped with three stun counters on it. (If it would become untapped, remove a stun counter from it instead.)\n{1}{U}: Untap Sleep-Cursed Faerie.",
             "colours": [
@@ -2572,7 +2572,7 @@
         },
         {
             "id": "848a81e7-d20e-51e8-a6d9-c74227fa2acb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dea5c0-ada3-488a-9f2b-f895b92c762f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80dea5c0-ada3-488a-9f2b-f895b92c762f.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -2606,7 +2606,7 @@
         },
         {
             "id": "4eca08d5-3d00-5ded-a92b-2fde310f2dcf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa37390-5c32-46ae-89d1-c094c9aa01e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eaa37390-5c32-46ae-89d1-c094c9aa01e5.jpg?1",
             "name": "Snaremaster Sprite",
             "text": "Flying\nWhen Snaremaster Sprite enters the battlefield, you may pay {2}. When you do, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2641,7 +2641,7 @@
         },
         {
             "id": "1490c515-b0b0-534f-8507-c87497b31520",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24447e36-a42f-40a9-ad44-e904b6f9b276.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24447e36-a42f-40a9-ad44-e904b6f9b276.jpg?1",
             "name": "Spell Stutter",
             "text": "Counter target spell unless its controller pays {2} plus an additional {1} for each Faerie you control.",
             "colours": [
@@ -2673,7 +2673,7 @@
         },
         {
             "id": "3443fcc0-19d5-5769-a1d4-8ed770839970",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ebd7f0-a54d-43a8-a5ee-9d6835308794.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73ebd7f0-a54d-43a8-a5ee-9d6835308794.jpg?1",
             "name": "Splashy Spellcaster",
             "text": "Whenever you cast an instant or sorcery spell, create a Sorcerer Role token attached to up to one other target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
             "colours": [
@@ -2708,7 +2708,7 @@
         },
         {
             "id": "0d432b92-a349-53ed-997e-6b98c8dc2994",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff065dbf-77e3-45a8-bcca-aff9eaeb151f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff065dbf-77e3-45a8-bcca-aff9eaeb151f.jpg?1",
             "name": "Stormkeld Prowler",
             "text": "Whenever you cast a spell with mana value 5 or greater, put two +1/+1 counters on Stormkeld Prowler.",
             "colours": [
@@ -2743,7 +2743,7 @@
         },
         {
             "id": "6b0d550e-ea7f-5ec1-8285-879a8c6a5ccc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg?1",
             "name": "Succumb to the Cold",
             "text": "Tap one or two target creatures an opponent controls. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
             "colours": [
@@ -2775,7 +2775,7 @@
         },
         {
             "id": "309d02a7-77d9-57be-9b42-5ccddadec7ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg?1",
             "name": "Talion's Messenger",
             "text": "Flying\nWhenever you attack with one or more Faeries, draw a card, then discard a card. When you discard a card this way, put a +1/+1 counter on target Faerie you control.",
             "colours": [
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "9a4f5738-fffd-5684-ac32-aaeb3af5c828",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40be735-0780-459b-8dd2-a298575beaab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c40be735-0780-459b-8dd2-a298575beaab.jpg?1",
             "name": "Tenacious Tomeseeker",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen Tenacious Tomeseeker enters the battlefield, if it was bargained, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -2847,7 +2847,7 @@
         },
         {
             "id": "1b5049e6-c899-519d-a3d8-cfd181c9531e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg?1",
             "name": "Vantress Transmuter // Croaking Curse",
             "text": "",
             "colours": [
@@ -2882,7 +2882,7 @@
         },
         {
             "id": "967749a3-058f-578c-b584-61f59bbe637a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg?1",
             "name": "Vantress Transmuter // Croaking Curse",
             "text": "Tap target creature. Create a Cursed Role token attached to it. (Enchanted creature is 1/1.)",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "3462dd3d-467f-551a-8db3-094ed01eea08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "If a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -2950,7 +2950,7 @@
         },
         {
             "id": "2f3a4fd7-9caa-5d20-ae97-3e31c367a6be",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "Copy target activated or triggered ability you control. You may choose new targets for the copy.",
             "colours": [
@@ -2986,7 +2986,7 @@
         },
         {
             "id": "292858b5-e333-55e9-afe3-d45461bda602",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea4993c-d1ba-4b33-955b-e0874fd2132f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ea4993c-d1ba-4b33-955b-e0874fd2132f.jpg?1",
             "name": "Water Wings",
             "text": "Until end of turn, target creature you control has base power and toughness 4/4 and gains flying and hexproof. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -3018,7 +3018,7 @@
         },
         {
             "id": "dbdbc120-09cd-59ac-9d1d-1ad7d011ba25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg?1",
             "name": "Ashiok, Wicked Manipulator",
             "text": "If you would pay life while your library has at least that many cards in it, exile that many cards from the top of your library instead.\n+1: Look at the top two cards of your library. Exile one of them and put the other into your hand.\n\u22122: Create two 1/1 black Nightmare creature tokens with \"At the beginning of combat on your turn, if a card was put into exile this turn, put a +1/+1 counter on this creature.\"\n\u22127: Target player exiles the top X cards of their library, where X is the total mana value of cards you own in exile.",
             "colours": [
@@ -3056,7 +3056,7 @@
         },
         {
             "id": "9322bef7-e0cb-5aa8-8606-5eca401ec387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83957fe0-6500-420c-9b7a-2448a1c1d3b3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83957fe0-6500-420c-9b7a-2448a1c1d3b3.jpg?1",
             "name": "Ashiok's Reaper",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, draw a card.",
             "colours": [
@@ -3090,7 +3090,7 @@
         },
         {
             "id": "fb832eaf-4e3c-524c-a674-0fb64ff980fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660845b5-96fa-4484-822b-aa0508801306.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/660845b5-96fa-4484-822b-aa0508801306.jpg?1",
             "name": "Back for Seconds",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nReturn up to two target creature cards from your graveyard to your hand. If this spell was bargained, you may put one of those cards with mana value 4 or less onto the battlefield instead of putting it into your hand.",
             "colours": [
@@ -3122,7 +3122,7 @@
         },
         {
             "id": "054405f6-e8f5-5ea5-9dc0-7e0ab52a3386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67da5ad8-4de2-4bd4-8b95-f2657e1fdee5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67da5ad8-4de2-4bd4-8b95-f2657e1fdee5.jpg?1",
             "name": "Barrow Naughty",
             "text": "Flying\nBarrow Naughty has lifelink as long as you control another Faerie.\n{2}{B}: Barrow Naughty gets +1/+0 until end of turn.",
             "colours": [
@@ -3156,7 +3156,7 @@
         },
         {
             "id": "e430ff2e-182f-5aaa-a0b2-8c6b9d2291a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg?1",
             "name": "Beseech the Mirror",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nSearch your library for a card, exile it face down, then shuffle. If this spell was bargained, you may cast the exiled card without paying its mana cost if that spell's mana value is 4 or less. Put the exiled card into your hand if it wasn't cast this way.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "a46f57ac-821b-5466-a580-1f99be187dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190d97bc-dbef-496d-9bd1-b785bdf8a964.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/190d97bc-dbef-496d-9bd1-b785bdf8a964.jpg?1",
             "name": "Candy Grapple",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTarget creature gets -3/-3 until end of turn. If this spell was bargained, that creature gets -5/-5 until end of turn instead.",
             "colours": [
@@ -3222,7 +3222,7 @@
         },
         {
             "id": "473adc97-07a9-56f2-81f2-9b3ca0f92fd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg?1",
             "name": "Conceited Witch // Price of Beauty",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -3257,7 +3257,7 @@
         },
         {
             "id": "f78d2a67-e333-5fdb-bc2a-68e7f025edd1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg?1",
             "name": "Conceited Witch // Price of Beauty",
             "text": "Create a Wicked Role token attached to target creature you control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "f936ed70-13e4-51e0-be57-d7492ecd9076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd1963-fe71-42c1-8ad7-53fd80145ca6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4efd1963-fe71-42c1-8ad7-53fd80145ca6.jpg?1",
             "name": "Dream Spoilers",
             "text": "Flying\nWhenever you cast a spell during an opponent's turn, up to one target creature an opponent controls gets -1/-1 until end of turn.",
             "colours": [
@@ -3326,7 +3326,7 @@
         },
         {
             "id": "c45f42b7-cdc6-5b94-a6b6-01cfdbcec7a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf36da-bbad-4d6e-a530-502d47a2dd23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8faf36da-bbad-4d6e-a530-502d47a2dd23.jpg?1",
             "name": "Ego Drain",
             "text": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. If you don't control a Faerie, exile a card from your hand.",
             "colours": [
@@ -3358,7 +3358,7 @@
         },
         {
             "id": "f5efba23-55ca-54cf-967e-2ee555e46185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg?1",
             "name": "The End",
             "text": "This spell costs {2} less to cast if your life total is 5 or less.\nExile target creature or planeswalker. Search its controller's graveyard, hand, and library for any number of cards with the same name as that permanent and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "b2c9b409-afbf-5adc-8b52-323aed61b483",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfed2acf-9ac8-447b-94f5-7db3a713c991.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfed2acf-9ac8-447b-94f5-7db3a713c991.jpg?1",
             "name": "Eriette's Whisper",
             "text": "Target opponent discards two cards. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "73d2ebf9-308f-512f-9fdd-d201bf533ae7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ca2ec5-442d-4909-be28-93c50fbc5f7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57ca2ec5-442d-4909-be28-93c50fbc5f7a.jpg?1",
             "name": "Faerie Dreamthief",
             "text": "Flying\nWhen Faerie Dreamthief enters the battlefield, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{2}{B}, Exile Faerie Dreamthief from your graveyard: You draw a card and you lose 1 life.",
             "colours": [
@@ -3461,7 +3461,7 @@
         },
         {
             "id": "614f9fad-2b6f-5170-ab8f-6a5d8d112690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdcaf24-4352-47cf-a043-899be47ab1bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bdcaf24-4352-47cf-a043-899be47ab1bb.jpg?1",
             "name": "Faerie Fencing",
             "text": "Target creature gets -X/-X until end of turn. That creature gets an additional -3/-3 until end of turn if you controlled a Faerie as you cast this spell.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "1de97d22-eb9a-547a-9b62-45db51f8b291",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd18a5-e06a-4cb5-b78e-de18ec641321.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cfd18a5-e06a-4cb5-b78e-de18ec641321.jpg?1",
             "name": "Feed the Cauldron",
             "text": "Destroy target creature with mana value 3 or less. If it's your turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "1ec2e1b0-8f30-5065-9608-6310f5b926f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg?1",
             "name": "Fell Horseman // Deathly Ride",
             "text": "When Fell Horseman dies, put it on the bottom of its owner's library.",
             "colours": [
@@ -3560,7 +3560,7 @@
         },
         {
             "id": "bbaccea0-bebf-5cf4-b843-0fa5392f0c64",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg?1",
             "name": "Fell Horseman // Deathly Ride",
             "text": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "c6aeb737-eee3-59bc-8c92-d9d34649a184",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Lifelink\nWhen Gumdrop Poisoner enters the battlefield, up to one target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -3631,7 +3631,7 @@
         },
         {
             "id": "17a51d13-a713-5ec8-aa0c-2e23705ab335",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -3667,7 +3667,7 @@
         },
         {
             "id": "9e610d96-1b0e-53d6-8b0a-8c3e4047dc32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fc77e7-154d-4433-93b3-1a1dee34791b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fc77e7-154d-4433-93b3-1a1dee34791b.jpg?1",
             "name": "High Fae Negotiator",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nFlying\nWhen High Fae Negotiator enters the battlefield, if it was bargained, each opponent loses 3 life and you gain 3 life.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "10e84fc4-3212-52c0-bb7f-26ee0b90fadb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg?1",
             "name": "Hopeless Nightmare",
             "text": "When Hopeless Nightmare enters the battlefield, each opponent discards a card and loses 2 life.\nWhen Hopeless Nightmare is put into a graveyard from the battlefield, scry 2.\n{2}{B}: Sacrifice Hopeless Nightmare.",
             "colours": [
@@ -3734,7 +3734,7 @@
         },
         {
             "id": "232167d7-3f62-5823-99c6-f26f04023d30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg?1",
             "name": "Lich-Knights' Conquest",
             "text": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -3769,7 +3769,7 @@
         },
         {
             "id": "857768d3-3e69-5026-a984-28780427d9b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729877be-4894-4ef5-9e60-de8a8fb2bdc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/729877be-4894-4ef5-9e60-de8a8fb2bdc0.jpg?1",
             "name": "Lord Skitter, Sewer King",
             "text": "Whenever another Rat enters the battlefield under your control, exile up to one target card from an opponent's graveyard.\nAt the beginning of combat on your turn, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -3808,7 +3808,7 @@
         },
         {
             "id": "060fcbf9-b8fa-5f4a-9047-b39c77253327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg?1",
             "name": "Lord Skitter's Blessing",
             "text": "When Lord Skitter's Blessing enters the battlefield, create a Wicked Role token attached to target creature you control. (Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)\nAt the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you draw an additional card.",
             "colours": [
@@ -3842,7 +3842,7 @@
         },
         {
             "id": "c7942950-5c26-5983-82d2-264afcaa3eb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b31d2b-ef66-4e16-a75e-4e27eb5ebfe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21b31d2b-ef66-4e16-a75e-4e27eb5ebfe9.jpg?1",
             "name": "Lord Skitter's Butcher",
             "text": "When Lord Skitter's Butcher enters the battlefield, choose one \u2014\n\u2022 Create a 1/1 black Rat creature token with \"This creature can't block.\"\n\u2022 You may sacrifice another creature. If you do, scry 2, then draw a card.\n\u2022 Creatures you control gain menace until end of turn.",
             "colours": [
@@ -3877,7 +3877,7 @@
         },
         {
             "id": "cfd45651-7e0e-5c12-85f7-8a761295c657",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902f154-6fe8-4b97-aa67-4d4696abf887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d902f154-6fe8-4b97-aa67-4d4696abf887.jpg?1",
             "name": "Mintstrosity",
             "text": "When Mintstrosity dies, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -3911,7 +3911,7 @@
         },
         {
             "id": "b40c1cf4-5b32-5981-8403-0e32e918e775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a2b68-efe6-4027-846d-db7b19d9eef6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d01a2b68-efe6-4027-846d-db7b19d9eef6.jpg?1",
             "name": "Not Dead After All",
             "text": "Until end of turn, target creature you control gains \"When this creature dies, return it to the battlefield tapped under its owner's control, then create a Wicked Role token attached to it.\" (Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -3943,7 +3943,7 @@
         },
         {
             "id": "f188abe9-2e40-5c76-9cca-fafe0a028207",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9bdcf-160a-48c9-9750-778c910b805d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8a9bdcf-160a-48c9-9750-778c910b805d.jpg?1",
             "name": "Rankle's Prank",
             "text": "Choose one or more \u2014\n\u2022 Each player discards two cards.\n\u2022 Each player loses 4 life.\n\u2022 Each player sacrifices two creatures.",
             "colours": [
@@ -3977,7 +3977,7 @@
         },
         {
             "id": "d91e7aa5-7d44-557f-8da7-ba8bb2e2f229",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c42755-bf91-4c75-95c6-d2a60ba3492a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2c42755-bf91-4c75-95c6-d2a60ba3492a.jpg?1",
             "name": "Rat Out",
             "text": "Up to one target creature gets -1/-1 until end of turn. You create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -4009,7 +4009,7 @@
         },
         {
             "id": "6e7d199f-0902-5730-b007-2bd54d0676a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be6786e-0569-42dd-b03c-82da7b32a14f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1be6786e-0569-42dd-b03c-82da7b32a14f.jpg?1",
             "name": "Rowan's Grim Search",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nIf this spell was bargained, look at the top four cards of your library, then put up to two of them back on top of your library in any order and the rest into your graveyard.\nYou draw two cards and you lose 2 life.",
             "colours": [
@@ -4041,7 +4041,7 @@
         },
         {
             "id": "04241ce3-be46-57f2-99a1-2f2531b519a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg?1",
             "name": "Scream Puff",
             "text": "Deathtouch\nWhenever Scream Puff deals combat damage to a player, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -4075,7 +4075,7 @@
         },
         {
             "id": "83ff0b76-7daa-5f24-a1a1-ead8cec399dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc79f0f7-0a09-4a74-b2b9-cc1ce608d89f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc79f0f7-0a09-4a74-b2b9-cc1ce608d89f.jpg?1",
             "name": "Shatter the Oath",
             "text": "Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -4107,7 +4107,7 @@
         },
         {
             "id": "ce4d1b50-e968-542b-99f6-65e1bfa5c909",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg?1",
             "name": "Specter of Mortality",
             "text": "Flying\nWhen Specter of Mortality enters the battlefield, you may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way.",
             "colours": [
@@ -4143,7 +4143,7 @@
         },
         {
             "id": "002cd42a-3ee0-55e2-98da-b5616a767b69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1",
             "name": "Spiteful Hexmage",
             "text": "When Spiteful Hexmage enters the battlefield, create a Cursed Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
             "colours": [
@@ -4180,7 +4180,7 @@
         },
         {
             "id": "99a22cf3-81b4-5e6f-90a7-db9af68ff7df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b7dd9-6a1d-4c71-873b-782a0a2e7d1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b71b7dd9-6a1d-4c71-873b-782a0a2e7d1d.jpg?1",
             "name": "Stingblade Assassin",
             "text": "Flash\nFlying\nWhen Stingblade Assassin enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -4215,7 +4215,7 @@
         },
         {
             "id": "1eef5617-e8fd-569b-a6dc-79763444433e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a638c9ba-45d6-4b50-a8ab-ef580a0a5d8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a638c9ba-45d6-4b50-a8ab-ef580a0a5d8e.jpg?1",
             "name": "Sugar Rush",
             "text": "Target creature gets +3/+0 until end of turn.\nDraw a card.",
             "colours": [
@@ -4247,7 +4247,7 @@
         },
         {
             "id": "a05e7e4f-3000-5b88-a74a-c5b8bd57eeac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bdb984-06f8-4bca-a943-17fe5db97682.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a6bdb984-06f8-4bca-a943-17fe5db97682.jpg?1",
             "name": "Sweettooth Witch",
             "text": "When Sweettooth Witch enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}, Sacrifice a Food: Target player loses 2 life.",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "dbc04033-fb53-5127-bbd1-eb782cb7df4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f858d83d-a13e-4ffa-a91d-d695e5e5d71a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f858d83d-a13e-4ffa-a91d-d695e5e5d71a.jpg?1",
             "name": "Taken by Nightmares",
             "text": "Exile target creature. If you control an enchantment, scry 2.",
             "colours": [
@@ -4314,7 +4314,7 @@
         },
         {
             "id": "69bc34db-458c-500d-a7b7-463bd4da0b14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg?1",
             "name": "Tangled Colony",
             "text": "Tangled Colony can't block.\nWhen Tangled Colony dies, create X 1/1 black Rat creature tokens with \"This creature can't block,\" where X is the amount of damage dealt to it this turn.",
             "colours": [
@@ -4350,7 +4350,7 @@
         },
         {
             "id": "0f2e7013-3540-55cf-8aff-ae639158afde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3ddf7-582d-4923-be30-8428e52237e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e3ddf7-582d-4923-be30-8428e52237e4.jpg?1",
             "name": "Twisted Sewer-Witch",
             "text": "When Twisted Sewer-Witch enters the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\" Then for each Rat you control, create a Wicked Role token attached to that Rat. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -4385,7 +4385,7 @@
         },
         {
             "id": "a49ddadf-ae35-55d3-a47e-3a5d232d795b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -4419,7 +4419,7 @@
         },
         {
             "id": "6b30127f-aca1-52a2-89f9-d0a4e886078a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "Target creature gets -3/-3 until end of turn. You gain 2 life.",
             "colours": [
@@ -4455,7 +4455,7 @@
         },
         {
             "id": "881b67b1-34db-51a2-be24-a390b5f10cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059be65-3c73-49bb-a3b6-c346ce2f9fa4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8059be65-3c73-49bb-a3b6-c346ce2f9fa4.jpg?1",
             "name": "Voracious Vermin",
             "text": "When Voracious Vermin enters the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\"\nWhenever another creature you control dies, put a +1/+1 counter on Voracious Vermin.",
             "colours": [
@@ -4489,7 +4489,7 @@
         },
         {
             "id": "fc1f83e6-d4cb-54c2-87e1-a9137d61accd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d500ad81-9659-4a00-8f99-8be7c23587e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d500ad81-9659-4a00-8f99-8be7c23587e8.jpg?1",
             "name": "Warehouse Tabby",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\"\n{1}{B}: Warehouse Tabby gains deathtouch until end of turn.",
             "colours": [
@@ -4523,7 +4523,7 @@
         },
         {
             "id": "ad13e55f-f8d8-5b59-b8f2-d747c251d24f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ec4b8-0012-48c4-9ccb-0f062df0c250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e26ec4b8-0012-48c4-9ccb-0f062df0c250.jpg?1",
             "name": "Wicked Visitor",
             "text": "Whenever an enchantment you control is put into a graveyard from the battlefield, each opponent loses 1 life.",
             "colours": [
@@ -4557,7 +4557,7 @@
         },
         {
             "id": "11dca0c0-72f0-5fd7-b965-3756bbae5f65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ca4926-b5ac-405a-8b58-f8db6df400ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47ca4926-b5ac-405a-8b58-f8db6df400ff.jpg?1",
             "name": "The Witch's Vanity",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Destroy target creature an opponent controls with mana value 2 or less.\nII \u2014 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nIII \u2014 Create a Wicked Role token attached to target creature you control.",
             "colours": [
@@ -4591,7 +4591,7 @@
         },
         {
             "id": "afa8ec60-f18b-5aa6-b10d-b375c75c1f5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6658398a-46a5-4f41-9b1b-4a47f2822cf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6658398a-46a5-4f41-9b1b-4a47f2822cf8.jpg?1",
             "name": "Belligerent of the Ball",
             "text": "Celebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4626,7 +4626,7 @@
         },
         {
             "id": "0d99bc2d-e2cc-59f5-baca-d9f447b14fa8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg?1",
             "name": "Bellowing Bruiser // Beat a Path",
             "text": "Haste",
             "colours": [
@@ -4660,7 +4660,7 @@
         },
         {
             "id": "e370b8b0-fdbb-573a-84c0-b5d3c4b1579d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg?1",
             "name": "Bellowing Bruiser // Beat a Path",
             "text": "Up to two target creatures can't block this turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -4694,7 +4694,7 @@
         },
         {
             "id": "cce1a4da-add2-562c-b96f-6f7c5981fb57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ecd59-9166-473c-bafc-cb3c54c21388.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a28ecd59-9166-473c-bafc-cb3c54c21388.jpg?1",
             "name": "Bespoke Battlegarb",
             "text": "Equipped creature gets +2/+0.\nCelebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, attach Bespoke Battlegarb to up to one target creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -4728,7 +4728,7 @@
         },
         {
             "id": "0cb6ae90-3bf5-572e-bcc6-275325b621f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdcbb1d-702e-4832-8eed-7ed3deffefe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdcbb1d-702e-4832-8eed-7ed3deffefe3.jpg?1",
             "name": "Boundary Lands Ranger",
             "text": "At the beginning of combat on your turn, if you control a creature with power 4 or greater, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "d0410196-5daa-5bbe-8d9c-efa5ca3207d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1",
             "name": "Charming Scoundrel",
             "text": "Haste\nWhen Charming Scoundrel enters the battlefield, choose one \u2014\n\u2022 Discard a card, then draw a card.\n\u2022 Create a Treasure token.\n\u2022 Create a Wicked Role token attached to target creature you control.",
             "colours": [
@@ -4800,7 +4800,7 @@
         },
         {
             "id": "0052ff0c-2279-5fdc-9864-3636f6279644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4d40a-7657-4ff8-9fc2-915b99432275.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ea4d40a-7657-4ff8-9fc2-915b99432275.jpg?1",
             "name": "Cut In",
             "text": "Cut In deals 4 damage to target creature.\nCreate a Young Hero Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -4832,7 +4832,7 @@
         },
         {
             "id": "321cc413-a881-54b0-bb50-28a78c97fdb5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acda9d02-00fc-49e2-a9f3-176e9c0a8c5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acda9d02-00fc-49e2-a9f3-176e9c0a8c5f.jpg?1",
             "name": "Edgewall Pack",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen Edgewall Pack enters the battlefield, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "f0865396-489a-5188-a2e8-6cfe85888b98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7130b8-3168-421f-912a-46ed5b769807.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7130b8-3168-421f-912a-46ed5b769807.jpg?1",
             "name": "Embereth Veteran",
             "text": "{1}, Sacrifice Embereth Veteran: Create a Young Hero Role token attached to another target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "1875d390-9464-53e5-a44f-f978b0ce3a89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a67b2-fbb0-4be4-9edd-93946a583f23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/673a67b2-fbb0-4be4-9edd-93946a583f23.jpg?1",
             "name": "Flick a Coin",
             "text": "Flick a Coin deals 1 damage to any target. You create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nDraw a card.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "0f4a972f-0bac-537c-ae12-d2269be741bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg?1",
             "name": "Food Fight",
             "text": "Artifacts you control have \"{2}, Sacrifice this artifact: It deals damage to any target equal to 1 plus the number of permanents named Food Fight you control.\"",
             "colours": [
@@ -4967,7 +4967,7 @@
         },
         {
             "id": "b4cc9cb6-c48f-5309-9839-654ce17cbc73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd85f5a-258b-4ced-bf9e-3abe7fe72395.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd85f5a-258b-4ced-bf9e-3abe7fe72395.jpg?1",
             "name": "Frantic Firebolt",
             "text": "Frantic Firebolt deals X damage to target creature, where X is 2 plus the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "9480c67b-1459-5e64-8111-1793fa24660b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fc64a-9734-44a6-8869-ab03512f1a99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/254fc64a-9734-44a6-8869-ab03512f1a99.jpg?1",
             "name": "Gnawing Crescendo",
             "text": "Creatures you control get +2/+0 until end of turn. Whenever a nontoken creature you control dies this turn, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -5031,7 +5031,7 @@
         },
         {
             "id": "33dec57b-a287-53f3-980c-6448b7b92356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg?1",
             "name": "Goddric, Cloaked Reveler",
             "text": "Haste\nCelebration \u2014 As long as two or more nonland permanents entered the battlefield under your control this turn, Goddric, Cloaked Reveler is a Dragon with base power and toughness 4/4, flying, and \"{R}: Dragons you control get +1/+0 until end of turn.\" (It loses all other creature types.)",
             "colours": [
@@ -5070,7 +5070,7 @@
         },
         {
             "id": "60ba491d-cf8d-53b7-8ab0-8a9b2dc0b7b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg?1",
             "name": "Grabby Giant // That's Mine",
             "text": "Reach\n{2}{R}, Sacrifice an artifact or land: Draw a card.",
             "colours": [
@@ -5104,7 +5104,7 @@
         },
         {
             "id": "160a82ef-eb39-5c24-a477-ee5d3f579b90",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg?1",
             "name": "Grabby Giant // That's Mine",
             "text": "Create a Treasure token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5138,7 +5138,7 @@
         },
         {
             "id": "581fdb53-ba90-5171-9f0f-96faafdf687c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e75228-16af-42b0-8441-ed253a660cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6e75228-16af-42b0-8441-ed253a660cc9.jpg?1",
             "name": "Grand Ball Guest",
             "text": "Celebration \u2014 Grand Ball Guest gets +1/+1 and has trample as long as two or more nonland permanents entered the battlefield under your control this turn.",
             "colours": [
@@ -5173,7 +5173,7 @@
         },
         {
             "id": "f068b094-4af5-5c57-beb5-802f956d9c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db79785-4f55-445f-93f2-14c6e4606fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1db79785-4f55-445f-93f2-14c6e4606fc5.jpg?1",
             "name": "Harried Spearguard",
             "text": "Haste\nWhen Harried Spearguard dies, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -5208,7 +5208,7 @@
         },
         {
             "id": "6b340d2e-ac98-5ab8-b08f-3a1095eeecd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg?1",
             "name": "Hearth Elemental // Stoke Genius",
             "text": "This spell costs {X} less to cast, where X is the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
             "colours": [
@@ -5242,7 +5242,7 @@
         },
         {
             "id": "32acb6a2-9f95-504a-b2cf-98c5154cb1db",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg?1",
             "name": "Hearth Elemental // Stoke Genius",
             "text": "Discard your hand, then draw two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5276,7 +5276,7 @@
         },
         {
             "id": "9e7d8455-d673-5293-a53c-53d3132e6800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b44833-0482-4b47-a594-4050bb87f1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/14b44833-0482-4b47-a594-4050bb87f1a5.jpg?1",
             "name": "Imodane, the Pyrohammer",
             "text": "Whenever an instant or sorcery spell you control that targets only a single creature deals damage to that creature, Imodane deals that much damage to each opponent.",
             "colours": [
@@ -5315,7 +5315,7 @@
         },
         {
             "id": "6e415046-796c-5657-be6e-fd0578cca4f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6d05e-e566-4a85-bcf8-9d0fbea3dd14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22a6d05e-e566-4a85-bcf8-9d0fbea3dd14.jpg?1",
             "name": "Kindled Heroism",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
             "colours": [
@@ -5347,7 +5347,7 @@
         },
         {
             "id": "16f85be5-e384-51c9-8a33-c205e6671906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a811b2cb-ffc7-4100-ac3e-bc4125842bb2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a811b2cb-ffc7-4100-ac3e-bc4125842bb2.jpg?1",
             "name": "Korvold and the Noble Thief",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")\nIII \u2014 Exile the top three cards of target opponent's library. You may play those cards this turn.",
             "colours": [
@@ -5381,7 +5381,7 @@
         },
         {
             "id": "8c675f35-61c4-5e02-9159-4b8a6bfd0883",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058b9b-e919-45eb-9da0-690f62aa252e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0058b9b-e919-45eb-9da0-690f62aa252e.jpg?1",
             "name": "Merry Bards",
             "text": "When Merry Bards enters the battlefield, you may pay {1}. When you do, create a Young Hero Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
             "colours": [
@@ -5416,7 +5416,7 @@
         },
         {
             "id": "254befee-8635-5ad1-8f6f-df3f8b55410d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg?1",
             "name": "Minecart Daredevil // Ride the Rails",
             "text": "",
             "colours": [
@@ -5451,7 +5451,7 @@
         },
         {
             "id": "6f30b8b7-1ea7-5ab9-be83-0ca7c20fd6e7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg?1",
             "name": "Minecart Daredevil // Ride the Rails",
             "text": "Target creature gets +2/+1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5485,7 +5485,7 @@
         },
         {
             "id": "fe8379d6-22f2-54c5-b187-f68de50e0094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg?1",
             "name": "Monstrous Rage",
             "text": "Target creature gets +2/+0 until end of turn. Create a Monster Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)",
             "colours": [
@@ -5517,7 +5517,7 @@
         },
         {
             "id": "ec59fc72-c9a8-53b5-81ab-615bd3799810",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg?1",
             "name": "Raging Battle Mouse",
             "text": "The second spell you cast each turn costs {1} less to cast.\nCelebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -5553,7 +5553,7 @@
         },
         {
             "id": "b7ef9f57-e717-58af-bc96-93ea3b3cd0c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg?1",
             "name": "Ratcatcher Trainee // Pest Problem",
             "text": "As long as it's your turn, Ratcatcher Trainee has first strike.",
             "colours": [
@@ -5588,7 +5588,7 @@
         },
         {
             "id": "725f44a8-8011-5d6b-be7d-4d349ca015da",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg?1",
             "name": "Ratcatcher Trainee // Pest Problem",
             "text": "Create two 1/1 black Rat creature tokens with \"This creature can't block.\" (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -5622,7 +5622,7 @@
         },
         {
             "id": "a599aaac-0e13-58fe-9f68-abcb4e2e3b8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg?1",
             "name": "Realm-Scorcher Hellkite",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nFlying, haste\nWhen Realm-Scorcher Hellkite enters the battlefield, if it was bargained, add four mana in any combination of colors.\n{1}{R}: Realm-Scorcher Hellkite deals 1 damage to any target.",
             "colours": [
@@ -5658,7 +5658,7 @@
         },
         {
             "id": "449e0ab5-a806-590c-aa53-10970d2661b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96bcd5f0-da79-47ab-83cf-976198b458d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96bcd5f0-da79-47ab-83cf-976198b458d1.jpg?1",
             "name": "Redcap Gutter-Dweller",
             "text": "Menace\nWhen Redcap Gutter-Dweller enters the battlefield, create two 1/1 black Rat creature tokens with \"This creature can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on Redcap Gutter-Dweller and exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -5695,7 +5695,7 @@
         },
         {
             "id": "bfa0cb20-a3f4-5a1e-b169-e56235ad51d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda6bdeb-a0d6-46ca-ba8c-317ee0096416.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cda6bdeb-a0d6-46ca-ba8c-317ee0096416.jpg?1",
             "name": "Redcap Thief",
             "text": "When Redcap Thief enters the battlefield, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [
@@ -5730,7 +5730,7 @@
         },
         {
             "id": "93b2bc6b-6202-5fcd-9611-024bbb53649f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg?1",
             "name": "Rotisserie Elemental",
             "text": "Menace\nWhenever Rotisserie Elemental deals combat damage to a player, put a skewer counter on Rotisserie Elemental. Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the number of skewer counters on Rotisserie Elemental. You may play those cards this turn.",
             "colours": [
@@ -5766,7 +5766,7 @@
         },
         {
             "id": "23ac2f89-0bd2-5baf-bf29-cb440ebc4a23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e50ca-d27b-45db-91fa-7fef3cad16d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e78e50ca-d27b-45db-91fa-7fef3cad16d0.jpg?1",
             "name": "Skewer Slinger",
             "text": "Reach\nWhenever Skewer Slinger blocks or becomes blocked by a creature, Skewer Slinger deals 1 damage to that creature.",
             "colours": [
@@ -5801,7 +5801,7 @@
         },
         {
             "id": "7af6f656-46d9-5bb6-89a2-ad72e82f3785",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg?1",
             "name": "Song of Totentanz",
             "text": "Create X 1/1 black Rat creature tokens with \"This creature can't block.\" Creatures you control gain haste until end of turn.",
             "colours": [
@@ -5835,7 +5835,7 @@
         },
         {
             "id": "1b60be20-2689-5060-bcbd-df7d5bc83bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb22f79c-3075-439d-a072-ceaabe35d76f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb22f79c-3075-439d-a072-ceaabe35d76f.jpg?1",
             "name": "Stonesplitter Bolt",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nStonesplitter Bolt deals X damage to target creature or planeswalker. If this spell was bargained, it deals twice X damage to that permanent instead.",
             "colours": [
@@ -5867,7 +5867,7 @@
         },
         {
             "id": "a47d71c0-601c-5e6c-9577-bcdba578c7d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f505b4-d61c-4da8-ab45-37125260d556.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30f505b4-d61c-4da8-ab45-37125260d556.jpg?1",
             "name": "Tattered Ratter",
             "text": "Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.",
             "colours": [
@@ -5902,7 +5902,7 @@
         },
         {
             "id": "1ff5912e-ded1-5227-8387-a2f64e21c778",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6027c-813f-46df-95b4-e2e305a67620.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3d6027c-813f-46df-95b4-e2e305a67620.jpg?1",
             "name": "Torch the Tower",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTorch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained, instead it deals 3 damage to that permanent and you scry 1.\nIf a permanent dealt damage by Torch the Tower would die this turn, exile it instead.",
             "colours": [
@@ -5936,7 +5936,7 @@
         },
         {
             "id": "12c1f4ec-ec8d-50a0-9980-e91915084ba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382d6085-79b9-48f7-8949-9f44dde2c753.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/382d6085-79b9-48f7-8949-9f44dde2c753.jpg?1",
             "name": "Twisted Fealty",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\nCreate a Wicked Role token attached to up to one target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -5968,7 +5968,7 @@
         },
         {
             "id": "1c0671d8-3030-5577-9ac5-3cfea3a70866",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg?1",
             "name": "Two-Headed Hunter // Twice the Rage",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)",
             "colours": [
@@ -6002,7 +6002,7 @@
         },
         {
             "id": "3a553b11-2640-5b61-b786-0255ebb21253",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg?1",
             "name": "Two-Headed Hunter // Twice the Rage",
             "text": "Target creature gains double strike until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6036,7 +6036,7 @@
         },
         {
             "id": "53d8a613-cc08-546f-aee8-e0facc3c9b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc275f8-f060-4c15-9b8f-63cf3857eaa7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc275f8-f060-4c15-9b8f-63cf3857eaa7.jpg?1",
             "name": "Unruly Catapult",
             "text": "Defender\n{T}: Unruly Catapult deals 1 damage to each opponent.\nWhenever you cast an instant or sorcery spell, untap Unruly Catapult.",
             "colours": [
@@ -6071,7 +6071,7 @@
         },
         {
             "id": "08d36f7b-44ac-590d-86e6-01cf565f007c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library. You may play those cards this turn.",
             "colours": [
@@ -6105,7 +6105,7 @@
         },
         {
             "id": "b9f3c067-23f0-5a09-9829-2c566a7c03cd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Embereth Blaze deals 2 damage to any target. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -6141,7 +6141,7 @@
         },
         {
             "id": "172d4bb3-56bd-5250-a439-28597a587986",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0685afcb-06f6-4d18-b8c2-510764558dc1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0685afcb-06f6-4d18-b8c2-510764558dc1.jpg?1",
             "name": "Witch's Mark",
             "text": "You may discard a card. If you do, draw two cards.\nCreate a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Aura is put into a graveyard, each opponent loses 1 life.)",
             "colours": [
@@ -6173,7 +6173,7 @@
         },
         {
             "id": "0bff791f-b7a1-5e4d-a554-c4bd794eb29a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649025a7-79d1-4d7c-b1db-d46bcf5a1ae2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/649025a7-79d1-4d7c-b1db-d46bcf5a1ae2.jpg?1",
             "name": "Witchstalker Frenzy",
             "text": "This spell costs {1} less to cast for each creature that attacked this turn.\nWitchstalker Frenzy deals 5 damage to target creature.",
             "colours": [
@@ -6205,7 +6205,7 @@
         },
         {
             "id": "d4cf54ae-f7b8-5192-874c-eed2f9ce5175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92652c41-1239-4299-a486-11fe1a96e912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92652c41-1239-4299-a486-11fe1a96e912.jpg?1",
             "name": "Agatha's Champion",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTrample\nWhen Agatha's Champion enters the battlefield, if it was bargained, it fights up to one target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6240,7 +6240,7 @@
         },
         {
             "id": "17163145-7124-548c-a245-450295c0e330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg?1",
             "name": "Beanstalk Wurm // Plant Beans",
             "text": "Reach",
             "colours": [
@@ -6275,7 +6275,7 @@
         },
         {
             "id": "f9eafba8-3c7f-518f-86fe-b669701cd7dd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg?1",
             "name": "Beanstalk Wurm // Plant Beans",
             "text": "You may play an additional land this turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6309,7 +6309,7 @@
         },
         {
             "id": "1681479c-c3a3-50d9-8caf-2f55cdf5ea89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9b8e5-1ed8-4be0-aad5-041a599c6841.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55b9b8e5-1ed8-4be0-aad5-041a599c6841.jpg?1",
             "name": "Bestial Bloodline",
             "text": "Enchant creature\nEnchanted creature gets +2/+2.\n{4}{G}: Return Bestial Bloodline from your graveyard to your hand.",
             "colours": [
@@ -6343,7 +6343,7 @@
         },
         {
             "id": "5d4db9b0-dcd7-5cd4-9cca-1240e4de5009",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg?1",
             "name": "Blossoming Tortoise",
             "text": "Whenever Blossoming Tortoise enters the battlefield or attacks, mill three cards, then return a land card from your graveyard to the battlefield tapped.\nActivated abilities of lands you control cost {1} less to activate.\nLand creatures you control get +1/+1.",
             "colours": [
@@ -6379,7 +6379,7 @@
         },
         {
             "id": "15f61e7d-bd56-59d7-a6ac-c234330cc241",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "{T}: Add {G}.\n{1}{G}, {T}, Discard a card: Return Bramble Familiar to its owner's hand.",
             "colours": [
@@ -6416,7 +6416,7 @@
         },
         {
             "id": "95d8eabe-b154-5305-92e2-fc21780b1e06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "Mill seven cards. Then put a creature, enchantment, or land card from among the milled cards onto the battlefield.",
             "colours": [
@@ -6452,7 +6452,7 @@
         },
         {
             "id": "aed9dab7-f56b-5fee-8141-1d33b7d26e55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b9e86-d108-42e5-b642-c5e07ab16c37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b9e86-d108-42e5-b642-c5e07ab16c37.jpg?1",
             "name": "Brave the Wilds",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nIf this spell was bargained, target land you control becomes a 3/3 Elemental creature with haste that's still a land.\nSearch your library for a basic land card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -6484,7 +6484,7 @@
         },
         {
             "id": "e8cd13be-ecee-5480-99b4-521b9775f0e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5224eec3-2941-4d16-a713-099e34e93eee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/5224eec3-2941-4d16-a713-099e34e93eee.jpg?1",
             "name": "Commune with Nature",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6516,7 +6516,7 @@
         },
         {
             "id": "e4274ade-59c2-58db-b1a0-d9319843c58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89148458-1fd6-48ef-a2d9-7b434c9723ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89148458-1fd6-48ef-a2d9-7b434c9723ec.jpg?1",
             "name": "Curse of the Werefox",
             "text": "Create a Monster Role token attached to target creature you control. When you do, that creature fights up to one target creature you don't control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample. Creatures that fight each deal damage equal to their power to the other.)",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "3dd84e7a-b1bd-5db2-9102-74a9f1143b05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg?1",
             "name": "Elvish Archivist",
             "text": "Whenever one or more artifacts enter the battlefield under your control, put two +1/+1 counters on Elvish Archivist. This ability triggers only once each turn.\nWhenever one or more enchantments enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -6585,7 +6585,7 @@
         },
         {
             "id": "c24ab91f-6d03-5647-8f3b-1fdb92652960",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg?1",
             "name": "Feral Encounter",
             "text": "Look at the top five cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card this turn. At the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.",
             "colours": [
@@ -6619,7 +6619,7 @@
         },
         {
             "id": "9381787d-1762-503f-8855-268713f1639e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg?1",
             "name": "Ferocious Werefox // Guard Change",
             "text": "Trample",
             "colours": [
@@ -6655,7 +6655,7 @@
         },
         {
             "id": "8b948fec-cc6e-5b93-a78c-0057d95a6d43",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg?1",
             "name": "Ferocious Werefox // Guard Change",
             "text": "Create a Monster Role token attached to target creature you control. (Enchanted creature gets +1/+1 and has trample.)",
             "colours": [
@@ -6689,7 +6689,7 @@
         },
         {
             "id": "6ee711a1-c74f-56b8-80e6-479a2f09f5f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83edf626-ed34-417f-818d-597ecf439167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83edf626-ed34-417f-818d-597ecf439167.jpg?1",
             "name": "Graceful Takedown",
             "text": "Any number of target enchanted creatures you control and up to one other target creature you control each deal damage equal to their power to target creature you don't control.",
             "colours": [
@@ -6721,7 +6721,7 @@
         },
         {
             "id": "daeb92c6-cce4-550b-bdda-0feacf2c5977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8760ab9-ac76-4e2e-b82f-0ee2a6dc5634.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8760ab9-ac76-4e2e-b82f-0ee2a6dc5634.jpg?1",
             "name": "Gruff Triplets",
             "text": "Trample\nWhen Gruff Triplets enters the battlefield, if it isn't a token, create two tokens that are copies of it.\nWhen Gruff Triplets dies, put a number of +1/+1 counters equal to its power on each creature you control named Gruff Triplets.",
             "colours": [
@@ -6758,7 +6758,7 @@
         },
         {
             "id": "e3cd81af-936a-5bce-b92c-d043779d2b2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ec5544-c138-44bb-a807-5798313c9a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4ec5544-c138-44bb-a807-5798313c9a50.jpg?1",
             "name": "Hamlet Glutton",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {2} less to cast if it's bargained.\nTrample\nWhen Hamlet Glutton enters the battlefield, you gain 3 life.",
             "colours": [
@@ -6792,7 +6792,7 @@
         },
         {
             "id": "cf6b1023-c7e6-5f9c-af52-9001b0aaedb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg?1",
             "name": "Hollow Scavenger // Bakery Raid",
             "text": "{1}, Sacrifice a Food: Hollow Scavenger gets +2/+2 until end of turn. Activate only once each turn.",
             "colours": [
@@ -6826,7 +6826,7 @@
         },
         {
             "id": "dfcaffd3-3139-5b66-9d9f-5663ff72e562",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg?1",
             "name": "Hollow Scavenger // Bakery Raid",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -6860,7 +6860,7 @@
         },
         {
             "id": "63bab65c-d73b-56db-ac53-80198875cf93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86311523-d0eb-4db3-b586-8349de9c2d37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86311523-d0eb-4db3-b586-8349de9c2d37.jpg?1",
             "name": "Howling Galefang",
             "text": "Vigilance\nHowling Galefang has haste as long as you own a card in exile that has an Adventure.",
             "colours": [
@@ -6894,7 +6894,7 @@
         },
         {
             "id": "e45ccc75-08ab-5206-84af-ba8b37c32328",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg?1",
             "name": "The Huntsman's Redemption",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 3/3 green Beast creature token.\nII \u2014 You may sacrifice a creature. If you do, search your library for a creature or basic land card, reveal it, put it into your hand, then shuffle.\nIII \u2014 Up to two target creatures each get +2/+2 and gain trample until end of turn.",
             "colours": [
@@ -6928,7 +6928,7 @@
         },
         {
             "id": "612b753d-3d0c-5a4b-9023-3e156fb7fcd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2785f716-274c-495c-b4e3-71a72e22f856.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2785f716-274c-495c-b4e3-71a72e22f856.jpg?1",
             "name": "Leaping Ambush",
             "text": "Target creature gets +1/+3 and gains reach until end of turn. Untap it.",
             "colours": [
@@ -6960,7 +6960,7 @@
         },
         {
             "id": "a0e30175-fbfa-529e-96cd-c8da356c2bf2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f53bed-7075-4303-aa9e-fcca0a266e19.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/27f53bed-7075-4303-aa9e-fcca0a266e19.jpg?1",
             "name": "Night of the Sweets' Revenge",
             "text": "When Night of the Sweets' Revenge enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nFoods you control have \"{T}: Add {G}.\"\n{5}{G}{G}, Sacrifice Night of the Sweets' Revenge: Creatures you control get +X/+X until end of turn, where X is the number of Foods you control. Activate only as a sorcery.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "e90f6fbf-d5af-59b2-81b4-e57fc83f45ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c81440-66eb-4443-a83f-e2f15cb68a3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99c81440-66eb-4443-a83f-e2f15cb68a3e.jpg?1",
             "name": "Redtooth Genealogist",
             "text": "When Redtooth Genealogist enters the battlefield, create a Royal Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -7027,7 +7027,7 @@
         },
         {
             "id": "aa1769ac-7e79-5db6-9ac5-8780205ea0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55271960-b9bd-4bea-93ca-3321bf30be78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55271960-b9bd-4bea-93ca-3321bf30be78.jpg?1",
             "name": "Redtooth Vanguard",
             "text": "Trample\nWhenever an enchantment enters the battlefield under your control, you may pay {2}. If you do, return Redtooth Vanguard from your graveyard to your hand.",
             "colours": [
@@ -7062,7 +7062,7 @@
         },
         {
             "id": "68dc84af-8f5c-541e-82db-00ada25a0943",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597d9ea-d9b2-4009-8e7c-02caa3585bc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9597d9ea-d9b2-4009-8e7c-02caa3585bc5.jpg?1",
             "name": "Return from the Wilds",
             "text": "Choose two \u2014\n\u2022 Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n\u2022 Create a 1/1 white Human creature token.\n\u2022 Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7094,7 +7094,7 @@
         },
         {
             "id": "112025db-dec3-557d-8054-f346ae95cee9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e87db5a-1a70-42df-83a2-c0f71fe8533a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e87db5a-1a70-42df-83a2-c0f71fe8533a.jpg?1",
             "name": "Rootrider Faun",
             "text": "{T}: Add {G}.\n{1}, {T}: Add one mana of any color.",
             "colours": [
@@ -7129,7 +7129,7 @@
         },
         {
             "id": "1a0d8560-021d-5213-a4b9-ffff114607da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6516b8f-ecfb-401e-ba8e-bf561aa2be64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6516b8f-ecfb-401e-ba8e-bf561aa2be64.jpg?1",
             "name": "Royal Treatment",
             "text": "Target creature you control gains hexproof until end of turn. Create a Royal Role token attached to that creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
             "colours": [
@@ -7161,7 +7161,7 @@
         },
         {
             "id": "c10d2d6d-6c6d-565d-ba62-c36ac6d48f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg?1",
             "name": "Sentinel of Lost Lore",
             "text": "When Sentinel of Lost Lore enters the battlefield, choose one or more \u2014\n\u2022 Return target card you own in exile that has an Adventure to your hand.\n\u2022 Put target card you don't own in exile that has an Adventure on the bottom of its owner's library.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -7198,7 +7198,7 @@
         },
         {
             "id": "50aaf7b1-e52d-5bd2-b795-cde0f09ee22b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08da5c6-ebe7-4166-99d5-2aca5b0b529f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a08da5c6-ebe7-4166-99d5-2aca5b0b529f.jpg?1",
             "name": "Skybeast Tracker",
             "text": "Reach\nWhenever you cast a spell with mana value 5 or greater, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7233,7 +7233,7 @@
         },
         {
             "id": "65c19016-ca91-5e0d-9552-fe0022f61d8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9fd720b-e9c2-4e82-917e-bab6c544afb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9fd720b-e9c2-4e82-917e-bab6c544afb0.jpg?1",
             "name": "Spider Food",
             "text": "Destroy up to one target artifact, enchantment, or creature with flying. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -7265,7 +7265,7 @@
         },
         {
             "id": "ed4a0fc3-840d-59b1-895a-5618a6f47ad2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg?1",
             "name": "Stormkeld Vanguard // Bear Down",
             "text": "Stormkeld Vanguard can't be blocked by creatures with power 2 or less.",
             "colours": [
@@ -7300,7 +7300,7 @@
         },
         {
             "id": "8754f01b-8b1f-5a8a-a566-5b9cadb7d6d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg?1",
             "name": "Stormkeld Vanguard // Bear Down",
             "text": "Destroy target artifact or enchantment. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -7334,7 +7334,7 @@
         },
         {
             "id": "c91131a8-b1dc-5aac-8aa4-43c9e6cc0865",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc5c32d-be0a-4a5f-a8c7-9767a895bc76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc5c32d-be0a-4a5f-a8c7-9767a895bc76.jpg?1",
             "name": "Tanglespan Lookout",
             "text": "Whenever an Aura enters the battlefield under your control, draw a card.",
             "colours": [
@@ -7370,7 +7370,7 @@
         },
         {
             "id": "49be0d1e-699e-52ae-aa6f-b4324aa47fcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2515d53d-7a50-4da3-980d-91d91fea2020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/2515d53d-7a50-4da3-980d-91d91fea2020.jpg?1",
             "name": "Territorial Witchstalker",
             "text": "Defender\nAt the beginning of combat on your turn, if you control a creature with power 4 or greater, Territorial Witchstalker gets +1/+0 until end of turn and can attack this turn as though it didn't have defender.",
             "colours": [
@@ -7404,7 +7404,7 @@
         },
         {
             "id": "38259300-9897-5d05-8dbe-43d3604f408d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98f51ec-8eae-434a-ab62-85bdb6586fa2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d98f51ec-8eae-434a-ab62-85bdb6586fa2.jpg?1",
             "name": "Thunderous Debut",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nLook at the top twenty cards of your library. You may reveal up to two creature cards from among them. If this spell was bargained, put the revealed cards onto the battlefield. Otherwise, put the revealed cards into your hand. Then shuffle.",
             "colours": [
@@ -7438,7 +7438,7 @@
         },
         {
             "id": "283ebd75-0109-54be-8710-c98bc0d728e7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46917de3-5e98-4dd6-8950-fc10338515df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46917de3-5e98-4dd6-8950-fc10338515df.jpg?1",
             "name": "Titanic Growth",
             "text": "Target creature gets +4/+4 until end of turn.",
             "colours": [
@@ -7470,7 +7470,7 @@
         },
         {
             "id": "c3f2a632-4f05-5bc3-b802-c94984146f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a6349a-beff-4abd-b005-86d27c1e2957.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0a6349a-beff-4abd-b005-86d27c1e2957.jpg?1",
             "name": "Toadstool Admirer",
             "text": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\n{3}{G}: Put a +1/+1 counter on Toadstool Admirer.",
             "colours": [
@@ -7504,7 +7504,7 @@
         },
         {
             "id": "a6c05b85-21b7-5981-82b7-3b3d0ce4397e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa37f85-5336-4372-97a2-9c8b00798c7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa37f85-5336-4372-97a2-9c8b00798c7a.jpg?1",
             "name": "Tough Cookie",
             "text": "When Tough Cookie enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}{G}: Target noncreature artifact you control becomes a 4/4 artifact creature until end of turn.\n{2}, {T}, Sacrifice Tough Cookie: You gain 3 life.",
             "colours": [
@@ -7540,7 +7540,7 @@
         },
         {
             "id": "e7a1c142-6fd2-5074-9103-19ad8dbc1b64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7b2fc0-d3f6-4c4d-a163-986a372e5b12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f7b2fc0-d3f6-4c4d-a163-986a372e5b12.jpg?1",
             "name": "Troublemaker Ouphe",
             "text": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen Troublemaker Ouphe enters the battlefield, if it was bargained, exile target artifact or enchantment an opponent controls.",
             "colours": [
@@ -7574,7 +7574,7 @@
         },
         {
             "id": "f62e346d-027a-5bd5-b6a8-62413c3b1ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg?1",
             "name": "Up the Beanstalk",
             "text": "When Up the Beanstalk enters the battlefield and whenever you cast a spell with mana value 5 or greater, draw a card.",
             "colours": [
@@ -7606,7 +7606,7 @@
         },
         {
             "id": "d0b8b82b-f467-52f1-aaa2-a6c29de1575f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg?1",
             "name": "Verdant Outrider",
             "text": "{1}{G}: Verdant Outrider can't be blocked by creatures with power 2 or less this turn.",
             "colours": [
@@ -7641,7 +7641,7 @@
         },
         {
             "id": "ca4fa4fd-af26-548d-9610-afa82adbbe08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "If you tap a basic land for mana, it produces three times as much of that mana instead.",
             "colours": [
@@ -7675,7 +7675,7 @@
         },
         {
             "id": "8915762e-e344-50cd-ac88-2a70fe32faaf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "Return target creature or land card from your graveyard to your hand. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -7711,7 +7711,7 @@
         },
         {
             "id": "1fb17e72-43a0-58b4-828b-89170d1c0ebf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e629a31-2e06-4f95-9628-34670dcf68b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e629a31-2e06-4f95-9628-34670dcf68b9.jpg?1",
             "name": "Welcome to Sweettooth",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI \u2014 Create a 1/1 white Human creature token.\nII \u2014 Create a Food token.\nIII \u2014 Put X +1/+1 counters on target creature you control, where X is one plus the number of Foods you control.",
             "colours": [
@@ -7745,7 +7745,7 @@
         },
         {
             "id": "a1e8a6cd-14fe-5973-b970-91dd6807d2a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c48f07-63b7-4a60-8da6-ce77405abf1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6c48f07-63b7-4a60-8da6-ce77405abf1e.jpg?1",
             "name": "Agatha of the Vile Cauldron",
             "text": "Activated abilities of creatures you control cost {X} less to activate, where X is Agatha of the Vile Cauldron's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "fb1ece4b-1170-563f-9268-78c0990ec9e3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb58bb-8ff3-4e34-b3d1-d83b5bd8c178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0edb58bb-8ff3-4e34-b3d1-d83b5bd8c178.jpg?1",
             "name": "The Apprentice's Folly",
             "text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II \u2014 Choose target nontoken creature you control that doesn't have the same name as a token you control. Create a token that's a copy of it, except it isn't legendary, is a Reflection in addition to its other types, and has haste.\nIII \u2014 Sacrifice all Reflections you control.",
             "colours": [
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "e69e533d-5229-5ece-b011-d8b5329f3c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51e6610-25b6-4d8e-92d7-c50a2ff844ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d51e6610-25b6-4d8e-92d7-c50a2ff844ff.jpg?1",
             "name": "Ash, Party Crasher",
             "text": "Haste\nCelebration \u2014 Whenever Ash, Party Crasher attacks, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Ash.",
             "colours": [
@@ -7861,7 +7861,7 @@
         },
         {
             "id": "8968ffde-f692-5e49-b491-bbd2251667ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecead4cd-47ae-4c42-b15c-1b29b5caba18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecead4cd-47ae-4c42-b15c-1b29b5caba18.jpg?1",
             "name": "Eriette of the Charmed Apple",
             "text": "Each creature that's enchanted by an Aura you control can't attack you or planeswalkers you control.\nAt the beginning of your end step, each opponent loses X life and you gain X life, where X is the number of Auras you control.",
             "colours": [
@@ -7902,7 +7902,7 @@
         },
         {
             "id": "2dc4f472-a88d-5d84-a5b8-28825225b8c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd585-c5ea-46f8-8e11-f33c067f2f8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d8bd585-c5ea-46f8-8e11-f33c067f2f8e.jpg?1",
             "name": "Faunsbane Troll",
             "text": "When Faunsbane Troll enters the battlefield, create a Monster Role token attached to it. (Enchanted creature gets +1/+1 and has trample.)\n{1}, Sacrifice an Aura attached to Faunsbane Troll: Faunsbane Troll fights target creature you don't control. If that creature would die this turn, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -7940,7 +7940,7 @@
         },
         {
             "id": "d6807e37-228b-5dfb-b1b9-7b60fc938e70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55c370-d396-4c73-8ee2-83dc4c124005.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a55c370-d396-4c73-8ee2-83dc4c124005.jpg?1",
             "name": "The Goose Mother",
             "text": "Flying\nThe Goose Mother enters the battlefield with X +1/+1 counters on it.\nWhen The Goose Mother enters the battlefield, create half X Food tokens, rounded up.\nWhenever The Goose Mother attacks, you may sacrifice a Food. If you do, draw a card.",
             "colours": [
@@ -7981,7 +7981,7 @@
         },
         {
             "id": "3d6c03e9-1530-5d2a-b96f-35ab4a98522c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd365e-34d1-4224-b925-119000311934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2cfd365e-34d1-4224-b925-119000311934.jpg?1",
             "name": "Greta, Sweettooth Scourge",
             "text": "When Greta, Sweettooth Scourge enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{G}, Sacrifice a Food: Put a +1/+1 counter on target creature. Activate only as a sorcery.\n{1}{B}, Sacrifice a Food: You draw a card and you lose 1 life.",
             "colours": [
@@ -8020,7 +8020,7 @@
         },
         {
             "id": "86809f1b-60a5-5e27-8042-a356783105bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9231fd-053d-4b84-a7a8-86063465bc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae9231fd-053d-4b84-a7a8-86063465bc49.jpg?1",
             "name": "Hylda of the Icy Crown",
             "text": "Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do, choose one \u2014\n\u2022 Create a 4/4 white and blue Elemental creature token.\n\u2022 Put a +1/+1 counter on each creature you control.\n\u2022 Scry 2, then draw a card.",
             "colours": [
@@ -8061,7 +8061,7 @@
         },
         {
             "id": "82e31be5-24c3-5267-a55e-171136daeef7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a762d-19ed-451d-a3a9-b3e7eea40f67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b88a762d-19ed-451d-a3a9-b3e7eea40f67.jpg?1",
             "name": "Johann, Apprentice Sorcerer",
             "text": "You may look at the top card of your library any time.\nOnce each turn, you may cast an instant or sorcery spell from the top of your library. (You still pay its costs. Timing rules still apply.)",
             "colours": [
@@ -8100,7 +8100,7 @@
         },
         {
             "id": "0211fc43-5065-54ec-8fbf-59ddc1b9b993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2957472a-825e-4904-b7e8-62bef1cb432d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2957472a-825e-4904-b7e8-62bef1cb432d.jpg?1",
             "name": "Likeness Looter",
             "text": "Flying\n{T}: Draw a card, then discard a card.\n{X}: Likeness Looter becomes a copy of target creature card in your graveyard with mana value X, except it has flying and this ability. Activate only as a sorcery.",
             "colours": [
@@ -8139,7 +8139,7 @@
         },
         {
             "id": "4874fad0-0a3b-5d82-bc31-e81cff47ba00",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f925ab-ade7-4da8-a791-185e098d18f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f925ab-ade7-4da8-a791-185e098d18f2.jpg?1",
             "name": "Neva, Stalked by Nightmares",
             "text": "Menace\nWhen Neva, Stalked by Nightmares enters the battlefield, return target creature or enchantment card from your graveyard to your hand.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Neva, then scry 1.",
             "colours": [
@@ -8178,7 +8178,7 @@
         },
         {
             "id": "a26a043a-87b0-5adf-9ce1-223ddadd24aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ce03ee-279b-4955-98e3-9ce1990f8b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63ce03ee-279b-4955-98e3-9ce1990f8b7b.jpg?1",
             "name": "Obyra, Dreaming Duelist",
             "text": "Flash\nFlying\nWhenever another Faerie enters the battlefield under your control, each opponent loses 1 life.",
             "colours": [
@@ -8217,7 +8217,7 @@
         },
         {
             "id": "a5025e25-31e0-5dd1-bc02-b422c8348387",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee179ab-a15b-4bd6-b7f8-1e1abeeb31b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4ee179ab-a15b-4bd6-b7f8-1e1abeeb31b7.jpg?1",
             "name": "Rowan, Scion of War",
             "text": "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
             "colours": [
@@ -8258,7 +8258,7 @@
         },
         {
             "id": "b581278d-b7dc-56d4-a0a1-c050aadef29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb5786b-6825-4ebf-a1e1-80011340adbb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffb5786b-6825-4ebf-a1e1-80011340adbb.jpg?1",
             "name": "Ruby, Daring Tracker",
             "text": "Haste\nWhenever Ruby, Daring Tracker attacks while you control a creature with power 4 or greater, Ruby gets +2/+2 until end of turn.\n{T}: Add {R} or {G}.",
             "colours": [
@@ -8297,7 +8297,7 @@
         },
         {
             "id": "773b348f-4203-50b7-857a-26773a0a11b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600bc36a-3ef0-459c-9a93-94ec45b8c3d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/600bc36a-3ef0-459c-9a93-94ec45b8c3d9.jpg?1",
             "name": "Sharae of Numbing Depths",
             "text": "When Sharae of Numbing Depths enters the battlefield, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you tap one or more untapped creatures your opponents control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "53cfa3a2-180e-547f-a962-d57aa21c8f12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85050609-baf0-430a-ab33-83a6ea6d4741.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85050609-baf0-430a-ab33-83a6ea6d4741.jpg?1",
             "name": "Syr Armont, the Redeemer",
             "text": "When Syr Armont, the Redeemer enters the battlefield, create a Monster Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)\nEnchanted creatures you control get +1/+1.",
             "colours": [
@@ -8375,7 +8375,7 @@
         },
         {
             "id": "2d2bb8d6-0baf-5ddb-a5f9-2122dad998f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6b452-c796-45c6-b4d1-0ae3d675e38e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62a6b452-c796-45c6-b4d1-0ae3d675e38e.jpg?1",
             "name": "Talion, the Kindly Lord",
             "text": "Flying\nAs Talion, the Kindly Lord enters the battlefield, choose a number between 1 and 10.\nWhenever an opponent casts a spell with mana value, power, or toughness equal to the chosen number, that player loses 2 life and you draw a card.",
             "colours": [
@@ -8416,7 +8416,7 @@
         },
         {
             "id": "9240b281-0ade-5aca-b6ab-acbd02c7a5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422d6db-fe5b-4a89-951a-fbd7985a29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/1422d6db-fe5b-4a89-951a-fbd7985a29fc.jpg?1",
             "name": "Totentanz, Swarm Piper",
             "text": "Whenever Totentanz, Swarm Piper or another nontoken creature you control dies, create a 1/1 black Rat creature token with \"This creature can't block.\"\n{1}{B}: Target attacking Rat you control gains deathtouch until end of turn.",
             "colours": [
@@ -8456,7 +8456,7 @@
         },
         {
             "id": "3522035a-1bc3-5c00-a73b-12a5e918ea75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadd2a1a-93a0-4257-897d-1aaee279449f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/eadd2a1a-93a0-4257-897d-1aaee279449f.jpg?1",
             "name": "Troyan, Gutsy Explorer",
             "text": "{T}: Add {G}{U}. Spend this mana only to cast spells with mana value 5 or greater or spells with {X} in their mana costs.\n{U}, {T}: Draw a card, then discard a card.",
             "colours": [
@@ -8495,7 +8495,7 @@
         },
         {
             "id": "278c3136-f379-58ba-91e3-11b28941de1d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162088ea-5f99-4244-9427-2fdfb2168fc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162088ea-5f99-4244-9427-2fdfb2168fc3.jpg?1",
             "name": "Will, Scion of Peace",
             "text": "Vigilance\n{T}: Spells you cast this turn that are white and/or blue cost {X} less to cast, where X is the amount of life you gained this turn. Activate only as a sorcery.",
             "colours": [
@@ -8536,7 +8536,7 @@
         },
         {
             "id": "455c5c51-a66a-5ca5-a531-f80f5b41ee02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635d461-254a-434e-8e5d-dea61dd8ca4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e635d461-254a-434e-8e5d-dea61dd8ca4f.jpg?1",
             "name": "Yenna, Redtooth Regent",
             "text": "{2}, {T}: Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, Redtooth Regent, then scry 2. Activate only as a sorcery.",
             "colours": [
@@ -8577,7 +8577,7 @@
         },
         {
             "id": "ac11ebbb-d5c6-5214-8a17-e2924415430a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Trample\nPermanent spells you cast that have an Adventure cost {1} less to cast.",
             "colours": [
@@ -8620,7 +8620,7 @@
         },
         {
             "id": "669150c9-9a54-5f3d-bdda-180d0a5ac4e6",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Mill seven cards. Then put all cards that have an Adventure from among the milled cards into your hand.",
             "colours": [
@@ -8660,7 +8660,7 @@
         },
         {
             "id": "c76d53fd-2435-54c7-a66e-db7bceb3b39e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg?1",
             "name": "Callous Sell-Sword // Burn Together",
             "text": "Callous Sell-Sword enters the battlefield with a +1/+1 counter on it for each creature that died under your control this turn.",
             "colours": [
@@ -8696,7 +8696,7 @@
         },
         {
             "id": "8f9c2348-0888-57bf-930e-5bb704ab6d62",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg?1",
             "name": "Callous Sell-Sword // Burn Together",
             "text": "Target creature you control deals damage equal to its power to any other target. Then sacrifice it.",
             "colours": [
@@ -8731,7 +8731,7 @@
         },
         {
             "id": "cd098713-dace-57c3-94d9-4031d688961a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Cruel Somnophage's power and toughness are each equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -8768,7 +8768,7 @@
         },
         {
             "id": "faaa6da4-1e7d-5664-a40a-f5147e18aeeb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8805,7 +8805,7 @@
         },
         {
             "id": "c1760b74-0fb5-53b2-995c-f34110eb3c3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Flying, trample\nWhenever Decadent Dragon attacks, create a Treasure token.",
             "colours": [
@@ -8842,7 +8842,7 @@
         },
         {
             "id": "375be560-1c58-51f0-aab7-5784ddeea1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Exile the top two cards of target opponent's library face down. You may look at and play those cards for as long as they remain exiled.",
             "colours": [
@@ -8879,7 +8879,7 @@
         },
         {
             "id": "6373326c-e354-569a-bb1b-f9226aec3988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Menace, trample\nAt the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. If you don't, tap Devouring Sugarmaw.",
             "colours": [
@@ -8916,7 +8916,7 @@
         },
         {
             "id": "c9dcce7e-3adf-586a-961c-f5a07d5c20a7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Create a 1/1 white Human creature token and a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -8953,7 +8953,7 @@
         },
         {
             "id": "fc7af2c3-0f96-51f9-94b9-cf73bd60a076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nCreatures with power less than Elusive Otter's power can't block it.",
             "colours": [
@@ -8990,7 +8990,7 @@
         },
         {
             "id": "34033da4-c22f-5e08-a431-5221c8fee107",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc9bdf96-3e3b-4dca-aae2-e81d4cbeafe8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Distribute X +1/+1 counters among any number of target creatures you control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9027,7 +9027,7 @@
         },
         {
             "id": "54578bf7-e702-59fd-b873-74540d60102c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg?1",
             "name": "Frolicking Familiar // Blow Off Steam",
             "text": "Flying\nWhenever you cast an instant or sorcery spell, Frolicking Familiar gets +1/+1 until end of turn.",
             "colours": [
@@ -9063,7 +9063,7 @@
         },
         {
             "id": "31bd771d-a1b9-5625-bb14-f9518406564d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg?1",
             "name": "Frolicking Familiar // Blow Off Steam",
             "text": "Blow Off Steam deals 1 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9098,7 +9098,7 @@
         },
         {
             "id": "408eb47f-db3b-5e15-800c-fae23e244dcd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg?1",
             "name": "Gingerbread Hunter // Puny Snack",
             "text": "When Gingerbread Hunter enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -9133,7 +9133,7 @@
         },
         {
             "id": "46ce4c69-a894-56f4-8620-54425ec91517",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg?1",
             "name": "Gingerbread Hunter // Puny Snack",
             "text": "Target creature gets -2/-2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9168,7 +9168,7 @@
         },
         {
             "id": "cc1074d9-5095-591f-bdd5-7f8bc811effd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Instant and sorcery spells you control have lifelink.",
             "colours": [
@@ -9206,7 +9206,7 @@
         },
         {
             "id": "347af62e-7577-5d46-95f7-76496ae4d02a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Heartflame Slash deals 3 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9243,7 +9243,7 @@
         },
         {
             "id": "d07c6d79-289a-5a83-a221-13eff0e629ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg?1",
             "name": "Imodane's Recruiter // Train Troops",
             "text": "When Imodane's Recruiter enters the battlefield, creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -9279,7 +9279,7 @@
         },
         {
             "id": "f358ec5c-ad0d-5b68-8d2f-edc92b13022d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg?1",
             "name": "Imodane's Recruiter // Train Troops",
             "text": "Create two 2/2 white Knight creature tokens with vigilance. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9314,7 +9314,7 @@
         },
         {
             "id": "4f5c190b-aab1-58fc-86f4-df0e92b69453",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan, the Fae-Blooded.",
             "colours": [
@@ -9355,7 +9355,7 @@
         },
         {
             "id": "c5eb6c3f-d8b0-5483-82e8-5c62cbba92c7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -9393,7 +9393,7 @@
         },
         {
             "id": "e7195a14-e92e-5e5d-b52f-f0206a47e710",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "Trample\nWhen Mosswood Dreadknight dies, you may cast it from your graveyard as an Adventure until the end of your next turn.",
             "colours": [
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "0df7cfd8-230d-5028-846b-111e110383fe",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9468,7 +9468,7 @@
         },
         {
             "id": "8f56053c-db00-5913-8a17-63ec7a8931f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg?1",
             "name": "Picnic Ruiner // Stolen Goodies",
             "text": "Whenever Picnic Ruiner attacks while you control a creature with power 4 or greater, Picnic Ruiner gains double strike until end of turn.",
             "colours": [
@@ -9504,7 +9504,7 @@
         },
         {
             "id": "6f95e294-707b-5eb4-a603-84a0e954cd16",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg?1",
             "name": "Picnic Ruiner // Stolen Goodies",
             "text": "Distribute three +1/+1 counters among any number of target creatures you control.",
             "colours": [
@@ -9539,7 +9539,7 @@
         },
         {
             "id": "d93b450c-bd76-58ab-ade3-f9b2de06e25a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Creature tokens you control get +1/+1.",
             "colours": [
@@ -9576,7 +9576,7 @@
         },
         {
             "id": "ceadedae-2096-50bc-be0c-759bdc0f9060",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Target creature you control gains vigilance and gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -9613,7 +9613,7 @@
         },
         {
             "id": "78b47c1b-d6ab-59ed-a378-296d1debfb0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on Questing Druid.",
             "colours": [
@@ -9651,7 +9651,7 @@
         },
         {
             "id": "976f9483-014b-54f4-a961-94e209b8c50b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Exile the top two cards of your library. Until your next end step, you may play those cards.",
             "colours": [
@@ -9688,7 +9688,7 @@
         },
         {
             "id": "09ec3da9-2c92-5e8f-affc-b3f24fa77e01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Whenever an opponent casts a spell with mana value 3 or less, Scalding Viper deals 1 damage to that player.",
             "colours": [
@@ -9726,7 +9726,7 @@
         },
         {
             "id": "44d639ca-0422-5578-87e5-ae8304bd4055",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Return target nonland permanent to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9763,7 +9763,7 @@
         },
         {
             "id": "e47fea04-1518-54ff-887e-c22523863586",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg?1",
             "name": "Shrouded Shepherd // Cleave Shadows",
             "text": "When Shrouded Shepherd enters the battlefield, target creature you control gets +2/+2 until end of turn.",
             "colours": [
@@ -9799,7 +9799,7 @@
         },
         {
             "id": "0e26f681-97bf-50b0-a321-f02cdfd9a53a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg?1",
             "name": "Shrouded Shepherd // Cleave Shadows",
             "text": "Creatures your opponents control get -1/-1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9834,7 +9834,7 @@
         },
         {
             "id": "fa765318-c9ca-50c2-ac97-b7220928b383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg?1",
             "name": "Spellscorn Coven // Take It Back",
             "text": "Flying\nWhen Spellscorn Coven enters the battlefield, each opponent discards a card.",
             "colours": [
@@ -9870,7 +9870,7 @@
         },
         {
             "id": "7a749949-b0a4-57ec-85a2-224ff28b606f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg?1",
             "name": "Spellscorn Coven // Take It Back",
             "text": "Return target spell to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9905,7 +9905,7 @@
         },
         {
             "id": "622420ae-fa6a-5c03-befc-871d0da983fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg?1",
             "name": "Tempest Hart // Scan the Clouds",
             "text": "Trample\nWhenever you cast a spell with mana value 5 or greater, put a +1/+1 counter on Tempest Hart.",
             "colours": [
@@ -9941,7 +9941,7 @@
         },
         {
             "id": "e2b3bb4d-ca56-55bf-a3cb-8b65c05e1e94",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg?1",
             "name": "Tempest Hart // Scan the Clouds",
             "text": "Draw two cards, then discard two cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -9976,7 +9976,7 @@
         },
         {
             "id": "d215b905-d954-5ef7-a197-43f6ddc9f59a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg?1",
             "name": "Threadbind Clique // Rip the Seams",
             "text": "Flying",
             "colours": [
@@ -10011,7 +10011,7 @@
         },
         {
             "id": "25741935-6add-5aa2-8ea8-711d53325531",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg?1",
             "name": "Threadbind Clique // Rip the Seams",
             "text": "Destroy target tapped creature. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -10046,7 +10046,7 @@
         },
         {
             "id": "ceae5d60-9d6b-5afd-a5e8-8a304fe1410a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Flying, vigilance, ward {1}",
             "colours": [
@@ -10084,7 +10084,7 @@
         },
         {
             "id": "39a65d01-1e88-58ca-80c0-4cffc621edbf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -10121,7 +10121,7 @@
         },
         {
             "id": "e32cb62e-af7a-5404-b90b-77a4a4367ff4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg?1",
             "name": "Woodland Acolyte // Mend the Wilds",
             "text": "When Woodland Acolyte enters the battlefield, draw a card.",
             "colours": [
@@ -10157,7 +10157,7 @@
         },
         {
             "id": "09d6a819-f481-55b9-b715-3e4a87885f0d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg?1",
             "name": "Woodland Acolyte // Mend the Wilds",
             "text": "Put target permanent card from your graveyard on top of your library. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -10192,7 +10192,7 @@
         },
         {
             "id": "aaf24b85-b4ac-55c3-81c9-c46632d23e3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019b51b0-e5c6-4208-922b-7736686dddcd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/019b51b0-e5c6-4208-922b-7736686dddcd.jpg?1",
             "name": "Agatha's Soul Cauldron",
             "text": "You may spend mana as though it were mana of any color to activate abilities of creatures you control.\nCreatures you control with +1/+1 counters on them have all activated abilities of all creature cards exiled with Agatha's Soul Cauldron.\n{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -10224,7 +10224,7 @@
         },
         {
             "id": "0761cdc2-eb74-5a58-896b-32d548e955c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a860925-d912-49e5-9ddc-41ab26916bb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a860925-d912-49e5-9ddc-41ab26916bb3.jpg?1",
             "name": "Candy Trail",
             "text": "When Candy Trail enters the battlefield, scry 2.\n{2}, {T}, Sacrifice Candy Trail: You gain 3 life and draw a card.",
             "colours": [],
@@ -10255,7 +10255,7 @@
         },
         {
             "id": "0366cae7-b50f-5838-bdcb-0e41b3eaffc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a4f27-8cd6-437d-8c05-8aedbc7ddc4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967a4f27-8cd6-437d-8c05-8aedbc7ddc4b.jpg?1",
             "name": "Collector's Vault",
             "text": "{2}, {T}: Draw a card, then discard a card. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this artifact: Add one mana of any color.\")",
             "colours": [],
@@ -10283,7 +10283,7 @@
         },
         {
             "id": "ea042ab2-ddf3-55d7-a559-3a93b6baa8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b61711f-8982-4ff0-86ba-01e0125cd705.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b61711f-8982-4ff0-86ba-01e0125cd705.jpg?1",
             "name": "Eriette's Tempting Apple",
             "text": "When Eriette's Tempting Apple enters the battlefield, gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n{2}, {T}, Sacrifice Eriette's Tempting Apple: You gain 3 life.\n{2}, {T}, Sacrifice Eriette's Tempting Apple: Target opponent loses 3 life.",
             "colours": [],
@@ -10315,7 +10315,7 @@
         },
         {
             "id": "8532e156-9ec1-5319-ae8f-8fc896c60aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4578a-7dc6-4da3-93ee-913b10be5740.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09a4578a-7dc6-4da3-93ee-913b10be5740.jpg?1",
             "name": "Gingerbrute",
             "text": "Haste\n{1}: Gingerbrute can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice Gingerbrute: You gain 3 life.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "1e06bf77-0b18-5191-8e75-d7e4eee69ec8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4a6c0-f00e-45a7-9c88-899460007020.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0d4a6c0-f00e-45a7-9c88-899460007020.jpg?1",
             "name": "Hylda's Crown of Winter",
             "text": "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.\n{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control.",
             "colours": [],
@@ -10379,7 +10379,7 @@
         },
         {
             "id": "43105e5e-803f-5c31-af4d-c476edd23f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8051c5ec-54a6-45a8-8945-fb93c5feaa39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8051c5ec-54a6-45a8-8945-fb93c5feaa39.jpg?1",
             "name": "The Irencrag",
             "text": "{T}: Add {C}.\nWhenever a legendary creature enters the battlefield under your control, you may have The Irencrag become a legendary Equipment artifact named Everflame, Heroes' Legacy. If you do, it gains equip {3} and \"Equipped creature gets +3/+3\" and loses all other abilities.",
             "colours": [],
@@ -10411,7 +10411,7 @@
         },
         {
             "id": "e288d02f-ff28-5594-8e88-6b0d2fb6bc48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fae351c-b918-4648-a361-d5239ae63156.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fae351c-b918-4648-a361-d5239ae63156.jpg?1",
             "name": "Prophetic Prism",
             "text": "When Prophetic Prism enters the battlefield, draw a card.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -10439,7 +10439,7 @@
         },
         {
             "id": "f6b8b3c4-32c2-5e38-985a-c928881ea340",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc08461-bec6-4a18-b782-da4c92abb789.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dc08461-bec6-4a18-b782-da4c92abb789.jpg?1",
             "name": "Scarecrow Guide",
             "text": "Reach\n{1}: Add one mana of any color. Activate only once each turn.",
             "colours": [],
@@ -10470,7 +10470,7 @@
         },
         {
             "id": "28d77d9e-ec33-5aa2-abbd-4fb5f40879d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571173-29e7-4915-af5f-05f13b463061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13571173-29e7-4915-af5f-05f13b463061.jpg?1",
             "name": "Soul-Guide Lantern",
             "text": "When Soul-Guide Lantern enters the battlefield, exile target card from a graveyard.\n{T}, Sacrifice Soul-Guide Lantern: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice Soul-Guide Lantern: Draw a card.",
             "colours": [],
@@ -10498,7 +10498,7 @@
         },
         {
             "id": "40b7bb97-33de-5d4b-ae77-6d413b70839d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdba12-1369-41ae-b0e9-c405c0f0a2e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7fbdba12-1369-41ae-b0e9-c405c0f0a2e5.jpg?1",
             "name": "Syr Ginger, the Meal Ender",
             "text": "Syr Ginger, the Meal Ender has trample, hexproof, and haste as long as an opponent controls a planeswalker.\nWhenever another artifact you control is put into a graveyard from the battlefield, put a +1/+1 counter on Syr Ginger and scry 1.\n{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power.",
             "colours": [],
@@ -10534,7 +10534,7 @@
         },
         {
             "id": "eea49276-523d-5a62-ad19-f626e1b7bf21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a508e040-d1e5-46aa-8404-1adc18f0f8bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a508e040-d1e5-46aa-8404-1adc18f0f8bd.jpg?1",
             "name": "Three Bowls of Porridge",
             "text": "{2}, {T}: Choose one that hasn't been chosen \u2014\n\u2022 Three Bowls of Porridge deals 2 damage to target creature.\n\u2022 Tap target creature.\n\u2022 Sacrifice Three Bowls of Porridge. You gain 3 life.",
             "colours": [],
@@ -10564,7 +10564,7 @@
         },
         {
             "id": "98a570c5-3136-574a-bc75-8dc530f9417a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6f9d3d-600d-43f3-a915-612e5d53aaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6f9d3d-600d-43f3-a915-612e5d53aaa1.jpg?1",
             "name": "Crystal Grotto",
             "text": "When Crystal Grotto enters the battlefield, scry 1.\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
             "colours": [],
@@ -10592,7 +10592,7 @@
         },
         {
             "id": "39ec1aad-886d-5f16-a10d-b8d282336677",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec435e54-628a-43bd-8804-cbc37e375bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec435e54-628a-43bd-8804-cbc37e375bce.jpg?1",
             "name": "Edgewall Inn",
             "text": "Edgewall Inn enters the battlefield tapped.\nAs Edgewall Inn enters the battlefield, choose a color.\n{T}: Add one mana of the chosen color.\n{3}, {T}, Sacrifice Edgewall Inn: Return target card that has an Adventure from your graveyard to your hand.",
             "colours": [],
@@ -10620,7 +10620,7 @@
         },
         {
             "id": "6e8581ed-33f1-5129-a2e4-0fe8eff02079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f9c819-719a-461b-8e7e-a26c88e8099b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74f9c819-719a-461b-8e7e-a26c88e8099b.jpg?1",
             "name": "Evolving Wilds",
             "text": "{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
             "colours": [],
@@ -10648,7 +10648,7 @@
         },
         {
             "id": "2bf07df7-22e8-57a4-843f-1fbcbb2896f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85e0aed-bfb2-4aa8-a754-849c4d9a6a58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b85e0aed-bfb2-4aa8-a754-849c4d9a6a58.jpg?1",
             "name": "Restless Bivouac",
             "text": "Restless Bivouac enters the battlefield tapped.\n{T}: Add {R} or {W}.\n{1}{R}{W}: Restless Bivouac becomes a 2/2 red and white Ox creature until end of turn. It's still a land.\nWhenever Restless Bivouac attacks, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -10681,7 +10681,7 @@
         },
         {
             "id": "85be7c0e-6f6d-5f29-9ddd-2c4e4fa4c0f9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787eadf3-5005-4ae5-820f-4012a4d4e1a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/787eadf3-5005-4ae5-820f-4012a4d4e1a5.jpg?1",
             "name": "Restless Cottage",
             "text": "Restless Cottage enters the battlefield tapped.\n{T}: Add {B} or {G}.\n{2}{B}{G}: Restless Cottage becomes a 4/4 black and green Horror creature until end of turn. It's still a land.\nWhenever Restless Cottage attacks, create a Food token and exile up to one target card from a graveyard.",
             "colours": [],
@@ -10714,7 +10714,7 @@
         },
         {
             "id": "bac3e0a1-5d81-53cc-9814-2a8d704fd664",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675213bb-28d7-460c-a4f3-950f5b9090af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/675213bb-28d7-460c-a4f3-950f5b9090af.jpg?1",
             "name": "Restless Fortress",
             "text": "Restless Fortress enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{2}{W}{B}: Restless Fortress becomes a 1/4 white and black Nightmare creature until end of turn. It's still a land.\nWhenever Restless Fortress attacks, defending player loses 2 life and you gain 2 life.",
             "colours": [],
@@ -10747,7 +10747,7 @@
         },
         {
             "id": "63928c50-c1a2-5db7-a404-a2b2f641d37d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66386fe8-9d3c-47f7-9cd3-4cd30051535f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66386fe8-9d3c-47f7-9cd3-4cd30051535f.jpg?1",
             "name": "Restless Spire",
             "text": "Restless Spire enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{U}{R}: Until end of turn, Restless Spire becomes a 2/1 blue and red Elemental creature with \"As long as it's your turn, this creature has first strike.\" It's still a land.\nWhenever Restless Spire attacks, scry 1.",
             "colours": [],
@@ -10780,7 +10780,7 @@
         },
         {
             "id": "a29e9f42-dfb6-5701-a964-c1d87572f276",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3161d-3f69-4b06-ab73-c31fc0c1520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5f3161d-3f69-4b06-ab73-c31fc0c1520c.jpg?1",
             "name": "Restless Vinestalk",
             "text": "Restless Vinestalk enters the battlefield tapped.\n{T}: Add {G} or {U}.\n{3}{G}{U}: Until end of turn, Restless Vinestalk becomes a 5/5 green and blue Plant creature with trample. It's still a land.\nWhenever Restless Vinestalk attacks, up to one other target creature has base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -10813,7 +10813,7 @@
         },
         {
             "id": "65ab0fa3-4cec-5857-93cf-8c7192a7e56c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd4d57-8c51-4fcf-8a9f-5d6a61c33e3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9cd4d57-8c51-4fcf-8a9f-5d6a61c33e3d.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10850,7 +10850,7 @@
         },
         {
             "id": "5c12baf8-10b5-5e4e-87fe-6859dd6ba5ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4b4da4-83f6-4280-880b-b6033308f2a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4b4da4-83f6-4280-880b-b6033308f2a2.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10887,7 +10887,7 @@
         },
         {
             "id": "bff6310e-be44-5140-984f-5b296851fbdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee68f2cb-851b-4196-ac58-844d72628e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee68f2cb-851b-4196-ac58-844d72628e6a.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -10924,7 +10924,7 @@
         },
         {
             "id": "713663b4-62fb-5e9b-9aed-9e5d8d452020",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8822db23-34dc-452a-92bc-a3ceee4db375.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8822db23-34dc-452a-92bc-a3ceee4db375.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -10961,7 +10961,7 @@
         },
         {
             "id": "01d3c9dd-c727-5999-9808-4915028ee395",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd6d8fb-780c-446c-a8bf-93386b22fe95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ecd6d8fb-780c-446c-a8bf-93386b22fe95.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -10998,7 +10998,7 @@
         },
         {
             "id": "ff9bd747-5b27-57a5-9fd1-831349822771",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed1af19-e075-4e6f-9394-d258143e15a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eed1af19-e075-4e6f-9394-d258143e15a4.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11035,7 +11035,7 @@
         },
         {
             "id": "ce2a4840-e3d3-5372-8063-ba8a1e3e4e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fbcf9-3a04-47f6-8927-886c2a454499.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/486fbcf9-3a04-47f6-8927-886c2a454499.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -11072,7 +11072,7 @@
         },
         {
             "id": "6fc01ceb-dcc3-58b9-9522-716c81c74ef0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6245d2f8-8ef0-4d2a-9abb-99839dc3abf0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/6245d2f8-8ef0-4d2a-9abb-99839dc3abf0.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11109,7 +11109,7 @@
         },
         {
             "id": "6a308810-b7d9-5c75-93ab-7dc8077719e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9798d6-34b3-4438-992d-d3616a7c8536.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a9798d6-34b3-4438-992d-d3616a7c8536.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11146,7 +11146,7 @@
         },
         {
             "id": "dac84a33-a870-5c5c-acea-d9d4658e7a83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a801ba-ebf7-4b9e-98c2-db50448845b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0a801ba-ebf7-4b9e-98c2-db50448845b7.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11183,7 +11183,7 @@
         },
         {
             "id": "2b932496-65bf-58ed-9cdc-fc4ae97c8bc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0de4ea5-77e6-474e-99f9-36192bbd37d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0de4ea5-77e6-474e-99f9-36192bbd37d5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11220,7 +11220,7 @@
         },
         {
             "id": "bc728528-08ee-54d0-a461-5b2c9c61359f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8996cd43-5ecd-4a05-a5a9-e49326befaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/8996cd43-5ecd-4a05-a5a9-e49326befaa1.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11257,7 +11257,7 @@
         },
         {
             "id": "d520b320-f920-5580-a9f4-50a1cf00b45b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e747bba-b521-4f81-9d9a-3e85747cefe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e747bba-b521-4f81-9d9a-3e85747cefe9.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11294,7 +11294,7 @@
         },
         {
             "id": "ce43ab42-734a-5b98-ae8b-b29ba26293cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c99f1b-f304-42d5-bbea-32283b01d43b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4c99f1b-f304-42d5-bbea-32283b01d43b.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11331,7 +11331,7 @@
         },
         {
             "id": "fb64325c-6a8f-5fca-8469-48be32a5ad36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd51a22-3e0d-4826-aab7-0adbfce4478a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bd51a22-3e0d-4826-aab7-0adbfce4478a.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11368,7 +11368,7 @@
         },
         {
             "id": "c7b3238e-5112-5143-adfd-8a2987b15ac2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "At the beginning of your end step, put a +1/+1 counter on each creature you control. Untap those creatures.",
             "colours": [
@@ -11402,7 +11402,7 @@
         },
         {
             "id": "f4e52ae1-d067-5d00-80b5-8a80914bc1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/6/9622e597-dc7c-4198-9ce5-4df53bb0c96c.jpg?1",
             "name": "Virtue of Loyalty // Ardenvale Fealty",
             "text": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -11438,7 +11438,7 @@
         },
         {
             "id": "42af1bcf-279a-5b74-810f-cd104f3b912a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "Flash\nWard {2}\nHorned Loch-Whale enters the battlefield tapped unless it's your turn.",
             "colours": [
@@ -11474,7 +11474,7 @@
         },
         {
             "id": "a166c05a-d3d2-54bd-b6dd-d7bd955914fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/f/af969428-8dd2-47d6-bdbf-65eca632c3d4.jpg?1",
             "name": "Horned Loch-Whale // Lagoon Breach",
             "text": "The owner of target attacking creature you don't control puts it on the top or bottom of their library.",
             "colours": [
@@ -11510,7 +11510,7 @@
         },
         {
             "id": "0b108d51-ff44-5460-8fd8-1341fbe2dfc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "If a permanent entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -11544,7 +11544,7 @@
         },
         {
             "id": "d638567a-c71e-5cab-b4af-f4fe7dab540f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7cc2173a-b7fb-4bd6-9c8e-73de91c6903a.jpg?1",
             "name": "Virtue of Knowledge // Vantress Visions",
             "text": "Copy target activated or triggered ability you control. You may choose new targets for the copy.",
             "colours": [
@@ -11580,7 +11580,7 @@
         },
         {
             "id": "6ec9325c-7265-51c1-b138-ba03f8b6c63a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Lifelink\nWhen Gumdrop Poisoner enters the battlefield, up to one target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
             "colours": [
@@ -11617,7 +11617,7 @@
         },
         {
             "id": "9cd1e51a-a52b-56bf-9d7f-805a629ebff2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/c/ec5d0453-ef17-47f0-81d4-13941f1380d5.jpg?1",
             "name": "Gumdrop Poisoner // Tempt with Treats",
             "text": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -11653,7 +11653,7 @@
         },
         {
             "id": "dc47fdb9-28d6-5449-b678-9880d3394817",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.",
             "colours": [
@@ -11687,7 +11687,7 @@
         },
         {
             "id": "64068d9f-2621-520f-8765-89378210c79d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/3/337393e3-9081-4251-b4ca-afd7ce10dc99.jpg?1",
             "name": "Virtue of Persistence // Locthwain Scorn",
             "text": "Target creature gets -3/-3 until end of turn. You gain 2 life.",
             "colours": [
@@ -11723,7 +11723,7 @@
         },
         {
             "id": "299cb4dc-d21d-568a-bfaa-2862841e5b30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library. You may play those cards this turn.",
             "colours": [
@@ -11757,7 +11757,7 @@
         },
         {
             "id": "32714b92-87df-551c-a7c3-dd0d96c0fb67",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/ed585964-68ed-4889-8d20-678b43c46018.jpg?1",
             "name": "Virtue of Courage // Embereth Blaze",
             "text": "Embereth Blaze deals 2 damage to any target. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -11793,7 +11793,7 @@
         },
         {
             "id": "3255f414-6bb0-5f27-ba1a-4aeba15b7cd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "{T}: Add {G}.\n{1}{G}, {T}, Discard a card: Return Bramble Familiar to its owner's hand.",
             "colours": [
@@ -11830,7 +11830,7 @@
         },
         {
             "id": "c3ec02b6-41ca-5ad5-805f-887b76856c41",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/e/1ee74605-63be-41cd-a6ba-1b33f8094ec9.jpg?1",
             "name": "Bramble Familiar // Fetch Quest",
             "text": "Mill seven cards. Then put a creature, enchantment, or land card from among the milled cards onto the battlefield.",
             "colours": [
@@ -11866,7 +11866,7 @@
         },
         {
             "id": "43d5b7cd-7ec0-5e3f-90b8-e1d095f002d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "If you tap a basic land for mana, it produces three times as much of that mana instead.",
             "colours": [
@@ -11900,7 +11900,7 @@
         },
         {
             "id": "e3d5fbfb-5dfa-5c1a-a68c-457254486d7b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/8/684f8568-390f-426f-ba71-e4be5fdaceee.jpg?1",
             "name": "Virtue of Strength // Garenbrig Growth",
             "text": "Return target creature or land card from your graveyard to your hand. (Then exile this card. You may cast the enchantment later from exile.)",
             "colours": [
@@ -11936,7 +11936,7 @@
         },
         {
             "id": "95a861ba-0aaf-57cf-818d-b10f264e203b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Trample\nPermanent spells you cast that have an Adventure cost {1} less to cast.",
             "colours": [
@@ -11979,7 +11979,7 @@
         },
         {
             "id": "3754c023-d52b-5c66-9e17-ad104976ea40",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/e/5ed9d78f-a556-435f-b95f-7317ae66e5e3.jpg?1",
             "name": "Beluna Grandsquall // Seek Thrills",
             "text": "Mill seven cards. Then put all cards that have an Adventure from among the milled cards into your hand.",
             "colours": [
@@ -12019,7 +12019,7 @@
         },
         {
             "id": "d7bbc2cc-7b08-5ef9-a3e3-321784c6ed43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Cruel Somnophage's power and toughness are each equal to the number of creature cards in all graveyards.",
             "colours": [
@@ -12056,7 +12056,7 @@
         },
         {
             "id": "94d3f9d8-f311-546f-8f43-8afa6efbf529",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/5/852d840c-c9b5-4486-b1f5-95ea88577fa0.jpg?1",
             "name": "Cruel Somnophage // Can't Wake Up",
             "text": "Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12093,7 +12093,7 @@
         },
         {
             "id": "a12d6f01-42a9-56a4-992a-d081c300e361",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Flying, trample\nWhenever Decadent Dragon attacks, create a Treasure token.",
             "colours": [
@@ -12130,7 +12130,7 @@
         },
         {
             "id": "5c26ef96-3d35-5452-a6ad-cc7f0fbd4351",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/a/8a717d27-596d-4341-b592-4f9777f778e5.jpg?1",
             "name": "Decadent Dragon // Expensive Taste",
             "text": "Exile the top two cards of target opponent's library face down. You may look at and play those cards for as long as they remain exiled.",
             "colours": [
@@ -12167,7 +12167,7 @@
         },
         {
             "id": "e0fd1c17-c6a3-5683-805e-a4b16e57b394",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Menace, trample\nAt the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. If you don't, tap Devouring Sugarmaw.",
             "colours": [
@@ -12204,7 +12204,7 @@
         },
         {
             "id": "db09c0ac-a86b-5c9e-99dd-8f13ebd4db7f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2848594-1718-43f2-8ccf-34a18a55e4b2.jpg?1",
             "name": "Devouring Sugarmaw // Have for Dinner",
             "text": "Create a 1/1 white Human creature token and a Food token. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12241,7 +12241,7 @@
         },
         {
             "id": "d1de0b55-99df-59aa-b441-aa25fbf7e9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nCreatures with power less than Elusive Otter's power can't block it.",
             "colours": [
@@ -12278,7 +12278,7 @@
         },
         {
             "id": "fe2f90a1-4630-5579-b77b-2c4e4ba74539",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5a61619-f951-42ff-8246-c51ee5dc18c8.jpg?1",
             "name": "Elusive Otter // Grove's Bounty",
             "text": "Distribute X +1/+1 counters among any number of target creatures you control. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12315,7 +12315,7 @@
         },
         {
             "id": "9efa7fb0-cd2b-590e-85d5-38d658441cc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Instant and sorcery spells you control have lifelink.",
             "colours": [
@@ -12353,7 +12353,7 @@
         },
         {
             "id": "4e8aaec5-5033-5851-91b8-102b6515357a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/5/f54b25e1-193a-41fb-9d24-3147cb381dbe.jpg?1",
             "name": "Heartflame Duelist // Heartflame Slash",
             "text": "Heartflame Slash deals 3 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12390,7 +12390,7 @@
         },
         {
             "id": "d700fc99-a622-5dad-a6e9-1651ce9e015d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan, the Fae-Blooded.",
             "colours": [
@@ -12431,7 +12431,7 @@
         },
         {
             "id": "4835d6e4-92b2-5c22-afd5-5333c5069191",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e662dfa5-edf8-4e7b-8a29-86935e95ac35.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -12469,7 +12469,7 @@
         },
         {
             "id": "a0f5895a-ca32-52f9-b41e-b728f593e5f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "Trample\nWhen Mosswood Dreadknight dies, you may cast it from your graveyard as an Adventure until the end of your next turn.",
             "colours": [
@@ -12507,7 +12507,7 @@
         },
         {
             "id": "ac55df2b-83ba-5d84-9018-7ca59cdeb2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/a/2ab293c3-64cf-4d8a-909d-4cf73ffd828a.jpg?1",
             "name": "Mosswood Dreadknight // Dread Whispers",
             "text": "You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12544,7 +12544,7 @@
         },
         {
             "id": "263b5c17-9b90-508e-b013-3e8516733571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Creature tokens you control get +1/+1.",
             "colours": [
@@ -12581,7 +12581,7 @@
         },
         {
             "id": "d5fe9923-a01a-53d1-93a1-264f75688331",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f2d517ad-6df7-4cf9-982f-763379724d24.jpg?1",
             "name": "Pollen-Shield Hare // Hare Raising",
             "text": "Target creature you control gains vigilance and gets +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -12618,7 +12618,7 @@
         },
         {
             "id": "ec45edae-ddb7-514c-ae97-edfa6a854c21",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on Questing Druid.",
             "colours": [
@@ -12656,7 +12656,7 @@
         },
         {
             "id": "e2dc501c-0081-5975-980f-db6e1e543b18",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/6/c6406eba-da58-4264-a213-20e22c1c3bec.jpg?1",
             "name": "Questing Druid // Seek the Beast",
             "text": "Exile the top two cards of your library. Until your next end step, you may play those cards.",
             "colours": [
@@ -12693,7 +12693,7 @@
         },
         {
             "id": "ccd1a2cc-2130-5492-8f35-3a335bfa43fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Whenever an opponent casts a spell with mana value 3 or less, Scalding Viper deals 1 damage to that player.",
             "colours": [
@@ -12731,7 +12731,7 @@
         },
         {
             "id": "c4810281-3086-5699-8dc0-b92329bc5feb",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/3014de04-66ce-4641-b36f-6ff1cc1c116a.jpg?1",
             "name": "Scalding Viper // Steam Clean",
             "text": "Return target nonland permanent to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -12768,7 +12768,7 @@
         },
         {
             "id": "5905a2fa-322b-55f2-af9e-e7441b9f5a47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Flying, vigilance, ward {1}",
             "colours": [
@@ -12806,7 +12806,7 @@
         },
         {
             "id": "592923ad-e978-51b0-9499-7404c310bda1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/8/38708b07-df7d-4ea4-b10e-ead7cd03d849.jpg?1",
             "name": "Twining Twins // Swift Spiral",
             "text": "Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step.",
             "colours": [
@@ -12843,7 +12843,7 @@
         },
         {
             "id": "ea89690e-34ce-5610-9432-8dd06eb27795",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f57de-21af-4c25-8a21-df3a75157939.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd6f57de-21af-4c25-8a21-df3a75157939.jpg?1",
             "name": "Ashiok, Wicked Manipulator",
             "text": "If you would pay life while your library has at least that many cards in it, exile that many cards from the top of your library instead.\n+1: Look at the top two cards of your library. Exile one of them and put the other into your hand.\n\u22122: Create two 1/1 black Nightmare creature tokens with \"At the beginning of combat on your turn, if a card was put into exile this turn, put a +1/+1 counter on this creature.\"\n\u22127: Target player exiles the top X cards of their library, where X is the total mana value of cards you own in exile.",
             "colours": [
@@ -12881,7 +12881,7 @@
         },
         {
             "id": "6d54b2a5-3a9c-5d31-8231-73c35eb7fb92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan, the Fae-Blooded.",
             "colours": [
@@ -12922,7 +12922,7 @@
         },
         {
             "id": "4629025b-2f8f-5f29-a6ec-f5e1dd4cdee2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/a/aa5b622a-66a6-4097-8478-e22854b9984d.jpg?1",
             "name": "Kellan, the Fae-Blooded // Birthright Boon",
             "text": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.",
             "colours": [
@@ -12960,7 +12960,7 @@
         },
         {
             "id": "09ef2fd3-aab8-549e-976e-8d927ae9fcde",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487a2cc0-ddbf-46b9-90ed-9455347724d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/487a2cc0-ddbf-46b9-90ed-9455347724d5.jpg?1",
             "name": "Eriette of the Charmed Apple",
             "text": "Each creature that's enchanted by an Aura you control can't attack you or planeswalkers you control.\nAt the beginning of your end step, each opponent loses X life and you gain X life, where X is the number of Auras you control.",
             "colours": [
@@ -13001,7 +13001,7 @@
         },
         {
             "id": "c8cc5d4f-508c-599e-8399-8fe3e2c48ca3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e29e9-e870-4433-ad63-0ff918a3e41a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/844e29e9-e870-4433-ad63-0ff918a3e41a.jpg?1",
             "name": "Rowan, Scion of War",
             "text": "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
             "colours": [
@@ -13042,7 +13042,7 @@
         },
         {
             "id": "180dd859-f481-5105-9d17-b68c26606546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1f05ef-7607-4a63-a710-18d0061ec982.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1f05ef-7607-4a63-a710-18d0061ec982.jpg?1",
             "name": "Talion, the Kindly Lord",
             "text": "Flying\nAs Talion, the Kindly Lord enters the battlefield, choose a number between 1 and 10.\nWhenever an opponent casts a spell with mana value, power, or toughness equal to the chosen number, that player loses 2 life and you draw a card.",
             "colours": [
@@ -13083,7 +13083,7 @@
         },
         {
             "id": "7fdd72f5-c8bf-5429-a281-1439c4cd92a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e3db-19ae-4f89-80ec-bf0ad561be39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f25e3db-19ae-4f89-80ec-bf0ad561be39.jpg?1",
             "name": "Will, Scion of Peace",
             "text": "Vigilance\n{T}: Spells you cast this turn that are white and/or blue cost {X} less to cast, where X is the amount of life you gained this turn. Activate only as a sorcery.",
             "colours": [
@@ -13124,7 +13124,7 @@
         },
         {
             "id": "bec04914-0e09-5b2f-9dd4-298562302175",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901796b2-c567-41e2-a87b-6147a966c9a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/901796b2-c567-41e2-a87b-6147a966c9a8.jpg?1",
             "name": "Restless Bivouac",
             "text": "Restless Bivouac enters the battlefield tapped.\n{T}: Add {R} or {W}.\n{1}{R}{W}: Restless Bivouac becomes a 2/2 red and white Ox creature until end of turn. It's still a land.\nWhenever Restless Bivouac attacks, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -13157,7 +13157,7 @@
         },
         {
             "id": "e1f13f95-cda1-5ce2-8474-588109638cb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb97ff-9356-4be7-8991-091f950c0b63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dcb97ff-9356-4be7-8991-091f950c0b63.jpg?1",
             "name": "Restless Cottage",
             "text": "Restless Cottage enters the battlefield tapped.\n{T}: Add {B} or {G}.\n{2}{B}{G}: Restless Cottage becomes a 4/4 black and green Horror creature until end of turn. It's still a land.\nWhenever Restless Cottage attacks, create a Food token and exile up to one target card from a graveyard.",
             "colours": [],
@@ -13190,7 +13190,7 @@
         },
         {
             "id": "1e724296-d370-5b52-8307-00c6acc5ab89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8034589b-3b57-49be-b0fd-a306f915d864.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8034589b-3b57-49be-b0fd-a306f915d864.jpg?1",
             "name": "Restless Fortress",
             "text": "Restless Fortress enters the battlefield tapped.\n{T}: Add {W} or {B}.\n{2}{W}{B}: Restless Fortress becomes a 1/4 white and black Nightmare creature until end of turn. It's still a land.\nWhenever Restless Fortress attacks, defending player loses 2 life and you gain 2 life.",
             "colours": [],
@@ -13223,7 +13223,7 @@
         },
         {
             "id": "4b97a0b2-e2de-5c4e-ad86-285db5afc279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc42bb4f-475e-4c76-bcbd-a9d8cf03117c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc42bb4f-475e-4c76-bcbd-a9d8cf03117c.jpg?1",
             "name": "Restless Spire",
             "text": "Restless Spire enters the battlefield tapped.\n{T}: Add {U} or {R}.\n{U}{R}: Until end of turn, Restless Spire becomes a 2/1 blue and red Elemental creature with \"As long as it's your turn, this creature has first strike.\" It's still a land.\nWhenever Restless Spire attacks, scry 1.",
             "colours": [],
@@ -13256,7 +13256,7 @@
         },
         {
             "id": "3d90e022-6dae-58f0-ab02-6ea1a758b83d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a710643a-b9dd-49bf-a375-d9986b05ed7a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a710643a-b9dd-49bf-a375-d9986b05ed7a.jpg?1",
             "name": "Restless Vinestalk",
             "text": "Restless Vinestalk enters the battlefield tapped.\n{T}: Add {G} or {U}.\n{3}{G}{U}: Until end of turn, Restless Vinestalk becomes a 5/5 green and blue Plant creature with trample. It's still a land.\nWhenever Restless Vinestalk attacks, up to one other target creature has base power and toughness 3/3 until end of turn.",
             "colours": [],
@@ -13289,7 +13289,7 @@
         },
         {
             "id": "0a5e7e8d-82d3-51dc-9e42-f929b7efb4d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2aed-3514-4db9-8da0-329620b12f63.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61ba2aed-3514-4db9-8da0-329620b12f63.jpg?1",
             "name": "Food Coma",
             "text": "When Food Coma enters the battlefield, exile target creature an opponent controls until Food Coma leaves the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -13321,7 +13321,7 @@
         },
         {
             "id": "59b3a982-1cf5-5469-b9b6-0c4c39f59c6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg?1",
             "name": "Lady of Laughter",
             "text": "Flying\nCelebration \u2014\u00a0\nAt the beginning of your end step, if two or more nonland permanents entered the battlefield under your control this turn, draw a card.",
             "colours": [
@@ -13358,7 +13358,7 @@
         },
         {
             "id": "b9e304cd-0698-5616-bff0-00fd8b69e1fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671c2a0-51e8-4d5e-8409-87abd6c0a8ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5671c2a0-51e8-4d5e-8409-87abd6c0a8ab.jpg?1",
             "name": "Pests of Honor",
             "text": "Celebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Pests of Honor.",
             "colours": [
@@ -13392,7 +13392,7 @@
         },
         {
             "id": "70a53330-bd36-5136-9701-a2751844797b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg?1",
             "name": "Faerie Slumber Party",
             "text": "Return all creatures to their owners' hands. For each opponent who controlled a creature returned this way, you create two 1/1 blue Faerie creature tokens with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -13426,7 +13426,7 @@
         },
         {
             "id": "2b4a9a76-7da2-5d54-bc9b-7dff7f7ca056",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg?1",
             "name": "Rowdy Research",
             "text": "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",
             "colours": [
@@ -13458,7 +13458,7 @@
         },
         {
             "id": "2c11c746-7882-5244-b784-16713e4a5a75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f4cf85-2120-4897-aecd-4ee4b02d6f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f4cf85-2120-4897-aecd-4ee4b02d6f9b.jpg?1",
             "name": "Storyteller Pixie",
             "text": "Flying\nWhenever you cast an Adventure spell, draw a card.",
             "colours": [
@@ -13493,7 +13493,7 @@
         },
         {
             "id": "d98f370d-ea20-54e2-ba04-04397ccad43c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aaf5db-9418-4b97-97da-736c674905d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49aaf5db-9418-4b97-97da-736c674905d4.jpg?1",
             "name": "Experimental Confectioner",
             "text": "When Experimental Confectioner enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever you sacrifice a Food, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -13528,7 +13528,7 @@
         },
         {
             "id": "a97bc16f-1983-5e89-a171-e8bd8c115185",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cb3c6d-560d-40ca-b5c0-27322863cead.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6cb3c6d-560d-40ca-b5c0-27322863cead.jpg?1",
             "name": "Malevolent Witchkite",
             "text": "Flying\nWhen Malevolent Witchkite enters the battlefield, sacrifice any number of artifacts, enchantments, and/or tokens, then draw that many cards.",
             "colours": [
@@ -13565,7 +13565,7 @@
         },
         {
             "id": "547c1f98-7f93-5743-b524-43a7c4ebbb75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c77d6f-de14-423c-bf55-0fb289171004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67c77d6f-de14-423c-bf55-0fb289171004.jpg?1",
             "name": "Old Flitterfang",
             "text": "Flying\nAt the beginning of each end step, if a creature died this turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\n{2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets +2/+2 until end of turn.",
             "colours": [
@@ -13602,7 +13602,7 @@
         },
         {
             "id": "cd9565bc-6c28-536d-b8e8-dd4ab031b7a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a154dadc-be5b-4ad6-9946-bdc54c251bff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a154dadc-be5b-4ad6-9946-bdc54c251bff.jpg?1",
             "name": "Become Brutes",
             "text": "One or two target creatures each gain haste until end of turn. For each of those creatures, create a Monster Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)",
             "colours": [
@@ -13634,7 +13634,7 @@
         },
         {
             "id": "2d2dc7fe-461a-5624-905b-216b43f63644",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddc6f47-202d-4764-abc1-ee453a8917c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fddc6f47-202d-4764-abc1-ee453a8917c2.jpg?1",
             "name": "Charging Hooligan",
             "text": "Whenever Charging Hooligan attacks, it gets +1/+0 until end of turn for each attacking creature. If a Rat is attacking, Charging Hooligan gains trample until end of turn.",
             "colours": [
@@ -13669,7 +13669,7 @@
         },
         {
             "id": "e1a431ee-d95b-521b-9429-63885fab45a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg?1",
             "name": "Ogre Chitterlord",
             "text": "Menace\nWhenever Ogre Chitterlord enters the battlefield or attacks, create two 1/1 black Rat creature tokens with \"This creature can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn.",
             "colours": [
@@ -13706,7 +13706,7 @@
         },
         {
             "id": "6141fd5d-4051-530e-850c-e35a82c990a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg?1",
             "name": "Intrepid Trufflesnout // Go Hog Wild",
             "text": "Whenever Intrepid Trufflesnout attacks alone, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")",
             "colours": [
@@ -13740,7 +13740,7 @@
         },
         {
             "id": "cdabd5c7-4a86-5f76-aa43-22e00c9b2334",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg?1",
             "name": "Intrepid Trufflesnout // Go Hog Wild",
             "text": "Target creature gets +2/+2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
             "colours": [
@@ -13774,7 +13774,7 @@
         },
         {
             "id": "f5c9b1a7-3c21-51e5-a15b-0278d9f748e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015282d-bcd4-44ab-ae26-41e4e3b23fc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a015282d-bcd4-44ab-ae26-41e4e3b23fc0.jpg?1",
             "name": "Provisions Merchant",
             "text": "When Provisions Merchant enters the battlefield, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\")\nWhenever Provisions Merchant attacks, you may sacrifice a Food. If you do, attacking creatures get +1/+1 and gain trample until end of turn.",
             "colours": [
@@ -13809,7 +13809,7 @@
         },
         {
             "id": "ea9f1a7d-7337-5e9c-8d77-a77106469b80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg?1",
             "name": "Wildwood Mentor",
             "text": "Whenever a token enters the battlefield under your control, put a +1/+1 counter on Wildwood Mentor.\nWhenever Wildwood Mentor attacks, another target attacking creature gets +X/+X until end of turn, where X is Wildwood Mentor's power.",
             "colours": [
@@ -13845,7 +13845,7 @@
         },
         {
             "id": "48acb8d7-95ec-5563-b5d3-ce00aaf0a8f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2b19f1-2f92-458d-a658-25481c57dea0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2b19f1-2f92-458d-a658-25481c57dea0.jpg?1",
             "name": "Archon of the Wild Rose",
             "text": "Flying\nOther creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.",
             "colours": [
@@ -13881,7 +13881,7 @@
         },
         {
             "id": "798bf4f2-da0a-5c23-89ec-dce521f4f123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5907a-2d70-46a9-b9f9-0ae7bcf35d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/92f5907a-2d70-46a9-b9f9-0ae7bcf35d48.jpg?1",
             "name": "Expel the Interlopers",
             "text": "Choose a number between 0 and 10. Destroy all creatures with power greater than or equal to the chosen number.",
             "colours": [
@@ -13916,7 +13916,7 @@
         },
         {
             "id": "94243eb5-2846-5f29-aa58-7214f7df5f30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e06198-b96a-4b52-ba86-3df8278c0785.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/08e06198-b96a-4b52-ba86-3df8278c0785.jpg?1",
             "name": "Moonshaker Cavalry",
             "text": "Flying\nWhen Moonshaker Cavalry enters the battlefield, creatures you control gain flying and get +X/+X until end of turn, where X is the number of creatures you control.",
             "colours": [
@@ -13953,7 +13953,7 @@
         },
         {
             "id": "c50b0d4d-2aa0-5f60-a2c5-d1df319bdf3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e650b3f-30a7-4943-8829-055e8aa7b9cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e650b3f-30a7-4943-8829-055e8aa7b9cd.jpg?1",
             "name": "Regal Bunnicorn",
             "text": "Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control.",
             "colours": [
@@ -13990,7 +13990,7 @@
         },
         {
             "id": "d6f73032-235c-511a-80b7-d27bc94c711f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6973853c-2e95-4b5b-9008-4b06ffc8a078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6973853c-2e95-4b5b-9008-4b06ffc8a078.jpg?1",
             "name": "Spellbook Vendor",
             "text": "Vigilance\nAt the beginning of combat on your turn, you may pay {1}. When you do, create a Sorcerer Role token attached to target creature you control.",
             "colours": [
@@ -14027,7 +14027,7 @@
         },
         {
             "id": "e50f1073-3afe-5729-8ea3-fbad1383d921",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc7d7d8-0965-4097-98ee-e89cfa05fd05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fc7d7d8-0965-4097-98ee-e89cfa05fd05.jpg?1",
             "name": "A Tale for the Ages",
             "text": "Enchanted creatures you control get +2/+2.",
             "colours": [
@@ -14061,7 +14061,7 @@
         },
         {
             "id": "a2049cae-c3f4-5d14-a7e2-2a53d3edd67b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eff52-c141-4587-857b-e71050899bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/572eff52-c141-4587-857b-e71050899bdb.jpg?1",
             "name": "Werefox Bodyguard",
             "text": "Flash\nWhen Werefox Bodyguard enters the battlefield, exile up to one other target non-Fox creature until Werefox Bodyguard leaves the battlefield.\n{1}{W}, Sacrifice Werefox Bodyguard: You gain 2 life.",
             "colours": [
@@ -14099,7 +14099,7 @@
         },
         {
             "id": "583daff2-3348-5037-a272-fb0ff0a988e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba9c281-a6e0-4af9-a217-e6aee7a38ff0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dba9c281-a6e0-4af9-a217-e6aee7a38ff0.jpg?1",
             "name": "Asinine Antics",
             "text": "You may cast Asinine Antics as though it had flash if you pay {2} more to cast it.\nFor each creature your opponents control, create a Cursed Role token attached to that creature.",
             "colours": [
@@ -14133,7 +14133,7 @@
         },
         {
             "id": "d077ae38-7c95-5e4a-8261-5b67ac41bd98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd423cc-7a86-4b15-b591-85940faa323e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abd423cc-7a86-4b15-b591-85940faa323e.jpg?1",
             "name": "Extraordinary Journey",
             "text": "When Extraordinary Journey enters the battlefield, exile up to X target creatures. For each of those cards, its owner may play it for as long as it remains exiled.\nWhenever one or more nontoken creatures enter the battlefield, if one or more of them entered from exile or was cast from exile, you draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -14167,7 +14167,7 @@
         },
         {
             "id": "ccf2da29-aaa3-515a-b8f4-905b12dcf01e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f484b9-486f-4aff-8b23-d8e555b476d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3f484b9-486f-4aff-8b23-d8e555b476d3.jpg?1",
             "name": "Farsight Ritual",
             "text": "Bargain\nLook at the top four cards of your library. If this spell was bargained, look at the top eight cards of your library instead. Put two of them into your hand and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14201,7 +14201,7 @@
         },
         {
             "id": "16f8fcf7-24a1-51a4-a9dc-de0ea79625c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bf6c34-429b-4213-856b-e8189276f2db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49bf6c34-429b-4213-856b-e8189276f2db.jpg?1",
             "name": "Ingenious Prodigy",
             "text": "Skulk\nIngenious Prodigy enters the battlefield with X +1/+1 counters on it.\nAt the beginning of your upkeep, if Ingenious Prodigy has one or more +1/+1 counters on it, you may remove a +1/+1 counter from it. If you do, draw a card.",
             "colours": [
@@ -14238,7 +14238,7 @@
         },
         {
             "id": "0022d876-c3a5-57cb-b1f0-944eaf73e1ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb94d9f-d679-4eb2-97d4-b519d8a166b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cb94d9f-d679-4eb2-97d4-b519d8a166b0.jpg?1",
             "name": "Sleep-Cursed Faerie",
             "text": "Flying, ward {2}\nSleep-Cursed Faerie enters the battlefield tapped with three stun counters on it.\n{1}{U}: Untap Sleep-Cursed Faerie.",
             "colours": [
@@ -14275,7 +14275,7 @@
         },
         {
             "id": "252e222a-d9a4-53f3-b4d2-9566f6403f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54e69e4-c6c9-4735-ab86-c437eba8d4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b54e69e4-c6c9-4735-ab86-c437eba8d4e2.jpg?1",
             "name": "Talion's Messenger",
             "text": "Flying\nWhenever you attack with one or more Faeries, draw a card, then discard a card. When you discard a card this way, put a +1/+1 counter on target Faerie you control.",
             "colours": [
@@ -14312,7 +14312,7 @@
         },
         {
             "id": "ee499002-5e27-5b5a-9c2c-fe0d644bda78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3d7fa-2b43-4b9e-85eb-ef96537942fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5df3d7fa-2b43-4b9e-85eb-ef96537942fb.jpg?1",
             "name": "Beseech the Mirror",
             "text": "Bargain\nSearch your library for a card, exile it face down, then shuffle. If this spell was bargained, you may cast the exiled card without paying its mana cost if that spell's mana value is 4 or less. Put the exiled card into your hand if it wasn't cast this way.",
             "colours": [
@@ -14346,7 +14346,7 @@
         },
         {
             "id": "1a409bd0-d391-5f08-b888-f59b457f0745",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79220c46-01df-41c1-877e-577f9ce78593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79220c46-01df-41c1-877e-577f9ce78593.jpg?1",
             "name": "The End",
             "text": "This spell costs {2} less to cast if your life total is 5 or less.\nExile target creature or planeswalker. Search its controller's graveyard, hand, and library for any number of cards with the same name as that permanent and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
             "colours": [
@@ -14380,7 +14380,7 @@
         },
         {
             "id": "cb66f2dd-2d3e-5c75-a1f4-d0185ff42c8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee2cc6-955c-43fb-b359-9d0e261c6925.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edee2cc6-955c-43fb-b359-9d0e261c6925.jpg?1",
             "name": "Lich-Knights' Conquest",
             "text": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -14415,7 +14415,7 @@
         },
         {
             "id": "98186e5f-6889-5f41-a531-664a56aa6a54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728520b3-fd90-46e4-ad51-3121a2557e86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/728520b3-fd90-46e4-ad51-3121a2557e86.jpg?1",
             "name": "Lord Skitter, Sewer King",
             "text": "Whenever another Rat enters the battlefield under your control, exile up to one target card from an opponent's graveyard.\nAt the beginning of combat on your turn, create a 1/1 black Rat creature token with \"This creature can't block.\"",
             "colours": [
@@ -14454,7 +14454,7 @@
         },
         {
             "id": "4215208e-0067-5ba5-819e-d7db269bfbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c78dde-4059-4e8d-9feb-f03653773787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77c78dde-4059-4e8d-9feb-f03653773787.jpg?1",
             "name": "Lord Skitter's Blessing",
             "text": "When Lord Skitter's Blessing enters the battlefield, create a Wicked Role token attached to target creature you control.\nAt the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you draw an additional card.",
             "colours": [
@@ -14488,7 +14488,7 @@
         },
         {
             "id": "8fa4be54-8007-575c-a019-6f69874c15a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342061c-6992-47d2-b862-db310d389b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c342061c-6992-47d2-b862-db310d389b3d.jpg?1",
             "name": "Rankle's Prank",
             "text": "Choose one or more \u2014\n\u2022 Each player discards two cards.\n\u2022 Each player loses 4 life.\n\u2022 Each player sacrifices two creatures.",
             "colours": [
@@ -14522,7 +14522,7 @@
         },
         {
             "id": "2eba4813-73b8-576a-80ff-c646b63ba04f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3026523f-65a0-49a4-a46e-bb91a8988ea4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/3026523f-65a0-49a4-a46e-bb91a8988ea4.jpg?1",
             "name": "Specter of Mortality",
             "text": "Flying\nWhen Specter of Mortality enters the battlefield, you may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way.",
             "colours": [
@@ -14558,7 +14558,7 @@
         },
         {
             "id": "eba0a8cf-566a-5100-b431-0d7a01aac12d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d527d48d-d6f7-4587-955e-de23b80ce0d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d527d48d-d6f7-4587-955e-de23b80ce0d6.jpg?1",
             "name": "Spiteful Hexmage",
             "text": "When Spiteful Hexmage enters the battlefield, create a Cursed Role token attached to target creature you control.",
             "colours": [
@@ -14595,7 +14595,7 @@
         },
         {
             "id": "329d2c6f-2e7f-5f25-81c5-7c70ec336ad8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ba866b-eda5-45c0-8878-235abadc0a3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45ba866b-eda5-45c0-8878-235abadc0a3c.jpg?1",
             "name": "Tangled Colony",
             "text": "Tangled Colony can't block.\nWhen Tangled Colony dies, create X 1/1 black Rat creature tokens with \"This creature can't block,\" where X is the amount of damage dealt to it this turn.",
             "colours": [
@@ -14631,7 +14631,7 @@
         },
         {
             "id": "29ab8f3e-480a-523e-8301-5dab2f655190",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f94c92-cf88-4770-8ab8-874cd6634510.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51f94c92-cf88-4770-8ab8-874cd6634510.jpg?1",
             "name": "Charming Scoundrel",
             "text": "Haste\nWhen Charming Scoundrel enters the battlefield, choose one \u2014\n\u2022 Discard a card, then draw a card.\n\u2022 Create a Treasure token.\n\u2022 Create a Wicked Role token attached to target creature you control.",
             "colours": [
@@ -14668,7 +14668,7 @@
         },
         {
             "id": "00851b83-9fe6-575f-b838-d7444e6a5279",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef34fc2-8d37-484d-9adf-e3bb70283f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fef34fc2-8d37-484d-9adf-e3bb70283f33.jpg?1",
             "name": "Food Fight",
             "text": "Artifacts you control have \"{2}, Sacrifice this artifact: It deals damage to any target equal to 1 plus the number of permanents named Food Fight you control.\"",
             "colours": [
@@ -14702,7 +14702,7 @@
         },
         {
             "id": "12ac820b-f2c2-5ce7-a9cc-d1d78b6ca107",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb884762-5468-43be-870a-96328f8172c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb884762-5468-43be-870a-96328f8172c2.jpg?1",
             "name": "Goddric, Cloaked Reveler",
             "text": "Haste\nCelebration \u2014 As long as two or more nonland permanents entered the battlefield under your control this turn, Goddric, Cloaked Reveler is a Dragon with base power and toughness 4/4, flying, and \"{R}: Dragons you control get +1/+0 until end of turn.\"",
             "colours": [
@@ -14741,7 +14741,7 @@
         },
         {
             "id": "6961cc28-b9b4-5386-b5de-f9d6de7e7c73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77bf3c05-4cbb-4525-9724-2d04cb2084f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77bf3c05-4cbb-4525-9724-2d04cb2084f3.jpg?1",
             "name": "Imodane, the Pyrohammer",
             "text": "Whenever an instant or sorcery spell you control that targets only a single creature deals damage to that creature, Imodane deals that much damage to each opponent.",
             "colours": [
@@ -14780,7 +14780,7 @@
         },
         {
             "id": "682e1bc2-8c5f-579f-8a6e-1f7cf80a4826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cabc6-f3a6-4992-acfc-1bed6bc5f05d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/640cabc6-f3a6-4992-acfc-1bed6bc5f05d.jpg?1",
             "name": "Raging Battle Mouse",
             "text": "The second spell you cast each turn costs {1} less to cast.\nCelebration \u2014 At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+1 until end of turn.",
             "colours": [
@@ -14816,7 +14816,7 @@
         },
         {
             "id": "fd0550d7-baf8-590a-bc50-f1ab049c22b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2d38fe-7fa5-4b29-b3e2-dd20d5afd127.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d2d38fe-7fa5-4b29-b3e2-dd20d5afd127.jpg?1",
             "name": "Realm-Scorcher Hellkite",
             "text": "Bargain\nFlying, haste\nWhen Realm-Scorcher Hellkite enters the battlefield, if it was bargained, add four mana in any combination of colors.\n{1}{R}: Realm-Scorcher Hellkite deals 1 damage to any target.",
             "colours": [
@@ -14852,7 +14852,7 @@
         },
         {
             "id": "e86cd4cc-590f-5e0c-bec2-2a3ace590741",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb9275-07f2-46b1-a64b-2971390a35de.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59cb9275-07f2-46b1-a64b-2971390a35de.jpg?1",
             "name": "Redcap Gutter-Dweller",
             "text": "Menace\nWhen Redcap Gutter-Dweller enters the battlefield, create two 1/1 black Rat creature tokens with \"This creature can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on Redcap Gutter-Dweller and exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -14889,7 +14889,7 @@
         },
         {
             "id": "9c1b40b5-7e2f-59f3-8208-3ad0bcacc082",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a55780-cb3b-429a-b0a8-ac616f85582f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4a55780-cb3b-429a-b0a8-ac616f85582f.jpg?1",
             "name": "Rotisserie Elemental",
             "text": "Menace\nWhenever Rotisserie Elemental deals combat damage to a player, put a skewer counter on Rotisserie Elemental. Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the number of skewer counters on Rotisserie Elemental. You may play those cards this turn.",
             "colours": [
@@ -14925,7 +14925,7 @@
         },
         {
             "id": "41745161-4031-50f8-8171-96a2cdef93b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c2f106-0df8-4d4f-a6ef-7946fe8e47c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30c2f106-0df8-4d4f-a6ef-7946fe8e47c4.jpg?1",
             "name": "Song of Totentanz",
             "text": "Create X 1/1 black Rat creature tokens with \"This creature can't block.\" Creatures you control gain haste until end of turn.",
             "colours": [
@@ -14959,7 +14959,7 @@
         },
         {
             "id": "77f469b2-0eda-5930-80c5-8c8913d9c9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79593c3a-00d9-4d24-a49c-753520a1ce30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79593c3a-00d9-4d24-a49c-753520a1ce30.jpg?1",
             "name": "Blossoming Tortoise",
             "text": "Whenever Blossoming Tortoise enters the battlefield or attacks, mill three cards, then return a land card from your graveyard to the battlefield tapped.\nActivated abilities of lands you control cost {1} less to activate.\nLand creatures you control get +1/+1.",
             "colours": [
@@ -14995,7 +14995,7 @@
         },
         {
             "id": "7295be11-284c-5235-9fb4-967f016f82e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7678157-e18e-45bd-a28e-7594a49bf2d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7678157-e18e-45bd-a28e-7594a49bf2d7.jpg?1",
             "name": "Elvish Archivist",
             "text": "Whenever one or more artifacts enter the battlefield under your control, put two +1/+1 counters on Elvish Archivist. This ability triggers only once each turn.\nWhenever one or more enchantments enter the battlefield under your control, draw a card. This ability triggers only once each turn.",
             "colours": [
@@ -15032,7 +15032,7 @@
         },
         {
             "id": "a3858001-977a-55c7-90c3-b94b817b1391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794c5066-724b-4f94-aa6e-7b0690dd706e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/794c5066-724b-4f94-aa6e-7b0690dd706e.jpg?1",
             "name": "Feral Encounter",
             "text": "Look at the top five cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card this turn. At the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.",
             "colours": [
@@ -15066,7 +15066,7 @@
         },
         {
             "id": "e5e23350-edf6-557e-93be-bf7c3d5de6b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7bd4-c12d-48a7-b39f-36033636e5c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f48f7bd4-c12d-48a7-b39f-36033636e5c7.jpg?1",
             "name": "Gruff Triplets",
             "text": "Trample\nWhen Gruff Triplets enters the battlefield, if it isn't a token, create two tokens that are copies of it.\nWhen Gruff Triplets dies, put a number of +1/+1 counters equal to its power on each creature you control named Gruff Triplets.",
             "colours": [
@@ -15103,7 +15103,7 @@
         },
         {
             "id": "fffbfc17-a457-565d-a1ed-aefe5810c86a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8556d3c-9290-4600-afa5-5928d74e3c96.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/8/a8556d3c-9290-4600-afa5-5928d74e3c96.jpg?1",
             "name": "Sentinel of Lost Lore",
             "text": "When Sentinel of Lost Lore enters the battlefield, choose one or more \u2014\n\u2022 Return target card you own in exile that has an Adventure to your hand.\n\u2022 Put target card you don't own in exile that has an Adventure on the bottom of its owner's library.\n\u2022 Exile target player's graveyard.",
             "colours": [
@@ -15140,7 +15140,7 @@
         },
         {
             "id": "b9658d09-b766-50c0-b94b-8c3c5b838755",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742aa20-4b18-4296-9693-c2c5a8ba6c04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b742aa20-4b18-4296-9693-c2c5a8ba6c04.jpg?1",
             "name": "Thunderous Debut",
             "text": "Bargain\nLook at the top twenty cards of your library. You may reveal up to two creature cards from among them. If this spell was bargained, put the revealed cards onto the battlefield. Otherwise, put the revealed cards into your hand. Then shuffle.",
             "colours": [
@@ -15174,7 +15174,7 @@
         },
         {
             "id": "b8ac45f9-eded-5424-a747-6b15290fbdcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f6c96-698d-4f5c-81ec-91176bd2e6e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd5f6c96-698d-4f5c-81ec-91176bd2e6e8.jpg?1",
             "name": "Agatha of the Vile Cauldron",
             "text": "Activated abilities of creatures you control cost {X} less to activate, where X is Agatha of the Vile Cauldron's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.",
             "colours": [
@@ -15215,7 +15215,7 @@
         },
         {
             "id": "21f2e03c-458d-554d-8c3d-7673fb4c535e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf2ce6a-f2ee-42a4-a026-b1d0c18a3ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bf2ce6a-f2ee-42a4-a026-b1d0c18a3ed4.jpg?1",
             "name": "Faunsbane Troll",
             "text": "When Faunsbane Troll enters the battlefield, create a Monster Role token attached to it.\n{1}, Sacrifice an Aura attached to Faunsbane Troll: Faunsbane Troll fights target creature you don't control. If that creature would die this turn, exile it instead. Activate only as a sorcery.",
             "colours": [
@@ -15253,7 +15253,7 @@
         },
         {
             "id": "cb7f0b43-5a9a-566d-96d2-0ae388d419a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1024d5f1-69f4-4a09-ba83-6fcc249217fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/1024d5f1-69f4-4a09-ba83-6fcc249217fa.jpg?1",
             "name": "The Goose Mother",
             "text": "Flying\nThe Goose Mother enters the battlefield with X +1/+1 counters on it.\nWhen The Goose Mother enters the battlefield, create half X Food tokens, rounded up.\nWhenever The Goose Mother attacks, you may sacrifice a Food. If you do, draw a card.",
             "colours": [
@@ -15294,7 +15294,7 @@
         },
         {
             "id": "d5616af1-36f0-5dae-ad13-073a50895c1a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f5f043-0b59-40ba-bdab-1706adf44075.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18f5f043-0b59-40ba-bdab-1706adf44075.jpg?1",
             "name": "Hylda of the Icy Crown",
             "text": "Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do, choose one \u2014\n\u2022 Create a 4/4 white and blue Elemental creature token.\n\u2022 Put a +1/+1 counter on each creature you control.\n\u2022 Scry 2, then draw a card.",
             "colours": [
@@ -15335,7 +15335,7 @@
         },
         {
             "id": "bfe0e975-ca97-515f-8fe2-66ac484fecd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51232f-ee63-4929-adab-042101c97b23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d51232f-ee63-4929-adab-042101c97b23.jpg?1",
             "name": "Likeness Looter",
             "text": "Flying\n{T}: Draw a card, then discard a card.\n{X}: Likeness Looter becomes a copy of target creature card in your graveyard with mana value X, except it has flying and this ability. Activate only as a sorcery.",
             "colours": [
@@ -15374,7 +15374,7 @@
         },
         {
             "id": "1d453913-e73b-5c22-8180-650e683ef7ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02f04f7-a345-4aa9-933c-1969f0cdd5c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a02f04f7-a345-4aa9-933c-1969f0cdd5c6.jpg?1",
             "name": "Yenna, Redtooth Regent",
             "text": "{2}, {T}: Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, Redtooth Regent, then scry 2. Activate only as a sorcery.",
             "colours": [
@@ -15415,7 +15415,7 @@
         },
         {
             "id": "2e211814-80eb-5ab1-86dc-51a377a159c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec5fc59-73d8-4735-88f1-3dbd1f15a546.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/dec5fc59-73d8-4735-88f1-3dbd1f15a546.jpg?1",
             "name": "Agatha's Soul Cauldron",
             "text": "You may spend mana as though it were mana of any color to activate abilities of creatures you control.\nCreatures you control with +1/+1 counters on them have all activated abilities of all creature cards exiled with Agatha's Soul Cauldron.\n{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1 counter on target creature you control.",
             "colours": [],
@@ -15447,7 +15447,7 @@
         },
         {
             "id": "ab96d9fe-5fea-5f8e-b97b-293de0253edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141f900-a87b-40ce-8439-02c000aafa30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/1/8141f900-a87b-40ce-8439-02c000aafa30.jpg?1",
             "name": "Hylda's Crown of Winter",
             "text": "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.\n{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control.",
             "colours": [],
@@ -15479,7 +15479,7 @@
         },
         {
             "id": "81f2c321-536e-5156-bab8-ea0a1c8ec8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c50432-28af-40e8-ae98-d4f33a5a936e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93c50432-28af-40e8-ae98-d4f33a5a936e.jpg?1",
             "name": "The Irencrag",
             "text": "{T}: Add {C}.\nWhenever a legendary creature enters the battlefield under your control, you may have The Irencrag become a legendary Equipment artifact named Everflame, Heroes' Legacy. If you do, it gains equip {3} and \"Equipped creature gets +3/+3\" and loses all other abilities.",
             "colours": [],
@@ -15511,7 +15511,7 @@
         },
         {
             "id": "30586399-0435-5a87-922a-de165a64feee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522e43f3-4f9a-4f40-a5f5-d84277172040.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/522e43f3-4f9a-4f40-a5f5-d84277172040.jpg?1",
             "name": "Syr Ginger, the Meal Ender",
             "text": "Syr Ginger, the Meal Ender has trample, hexproof, and haste as long as an opponent controls a planeswalker.\nWhenever another artifact you control is put into a graveyard from the battlefield, put a +1/+1 counter on Syr Ginger and scry 1.\n{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power.",
             "colours": [],
@@ -15547,7 +15547,7 @@
         },
         {
             "id": "3155d297-4e02-5323-bdd3-b107f7d1b47b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ba4b10-5667-414c-a692-166a19b7d748.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10ba4b10-5667-414c-a692-166a19b7d748.jpg?1",
             "name": "Lady of Laughter",
             "text": "Flying\nCelebration \u2014\u00a0\nAt the beginning of your end step, if two or more nonland permanents entered the battlefield under your control this turn, draw a card.",
             "colours": [
@@ -15584,7 +15584,7 @@
         },
         {
             "id": "e30a3e2f-5afb-521f-9765-64d721a5d32b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d1945f-6462-4ec3-a966-3a8dafc0f5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4d1945f-6462-4ec3-a966-3a8dafc0f5d8.jpg?1",
             "name": "Faerie Slumber Party",
             "text": "Return all creatures to their owners' hands. For each opponent who controlled a creature returned this way, you create two 1/1 blue Faerie creature tokens with flying and \"This creature can block only creatures with flying.\"",
             "colours": [
@@ -15618,7 +15618,7 @@
         },
         {
             "id": "2aa5adcd-257a-5012-803a-cce5b8cb7730",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee6723-9b90-4d39-9cbb-9d3765a4fcb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58ee6723-9b90-4d39-9cbb-9d3765a4fcb0.jpg?1",
             "name": "Malevolent Witchkite",
             "text": "Flying\nWhen Malevolent Witchkite enters the battlefield, sacrifice any number of artifacts, enchantments, and/or tokens, then draw that many cards.",
             "colours": [
@@ -15655,7 +15655,7 @@
         },
         {
             "id": "073cfe6f-5684-53c8-a961-fb59d9b5b862",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8d687a-8935-4907-909f-4cadac6cdf67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd8d687a-8935-4907-909f-4cadac6cdf67.jpg?1",
             "name": "Ogre Chitterlord",
             "text": "Menace\nWhenever Ogre Chitterlord enters the battlefield or attacks, create two 1/1 black Rat creature tokens with \"This creature can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn.",
             "colours": [
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "c162db73-73e6-5646-82c3-314cccbe70da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7b456e-e56d-45dd-88b3-1ac58a9bfb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb7b456e-e56d-45dd-88b3-1ac58a9bfb5f.jpg?1",
             "name": "Wildwood Mentor",
             "text": "Whenever a token enters the battlefield under your control, put a +1/+1 counter on Wildwood Mentor.\nWhenever Wildwood Mentor attacks, another target attacking creature gets +X/+X until end of turn, where X is Wildwood Mentor's power.",
             "colours": [
@@ -15728,7 +15728,7 @@
         },
         {
             "id": "68a4071d-c149-5137-8a5f-696b9a1ae762",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73014a95-5251-4404-b3a3-037fb5ca3327.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73014a95-5251-4404-b3a3-037fb5ca3327.jpg?1",
             "name": "Stroke of Midnight",
             "text": "Destroy target nonland permanent. Its controller creates a 1/1 white Human creature token.",
             "colours": [
@@ -15762,7 +15762,7 @@
         },
         {
             "id": "0972ac2b-b2f9-5966-ac3b-1215246cb487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c81647-6586-4c9c-93fc-9d5ee40b377b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c81647-6586-4c9c-93fc-9d5ee40b377b.jpg?1",
             "name": "Sleight of Hand",
             "text": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
             "colours": [
@@ -15796,7 +15796,7 @@
         },
         {
             "id": "73dc1a50-648a-5f9b-93b3-8ba14291b874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373f235b-ce93-48b0-8e36-71f5bc5efcc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373f235b-ce93-48b0-8e36-71f5bc5efcc2.jpg?1",
             "name": "Faerie Dreamthief",
             "text": "Flying\nWhen Faerie Dreamthief enters the battlefield, surveil 1.\n{2}{B}, Exile Faerie Dreamthief from your graveyard: You draw a card and you lose 1 life.",
             "colours": [
@@ -15833,7 +15833,7 @@
         },
         {
             "id": "9e71ec2e-e579-5ddb-994e-8d957c59fbaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603675e-84df-4dd2-b45b-47349341f64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f603675e-84df-4dd2-b45b-47349341f64c.jpg?1",
             "name": "Torch the Tower",
             "text": "Bargain\nTorch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained, instead it deals 3 damage to that permanent and you scry 1.\nIf a permanent dealt damage by Torch the Tower would die this turn, exile it instead.",
             "colours": [
@@ -15867,7 +15867,7 @@
         },
         {
             "id": "69d23eb9-bc04-5366-94e6-9da048ff2886",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca603dc-8a2d-484d-8b95-25dfa39369fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca603dc-8a2d-484d-8b95-25dfa39369fd.jpg?1",
             "name": "Tanglespan Lookout",
             "text": "Whenever an Aura enters the battlefield under your control, draw a card.",
             "colours": [
@@ -15903,7 +15903,7 @@
         },
         {
             "id": "9e160b1e-06ad-58c9-a6bc-55bae755f3e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ffe314-b66b-48d8-b94d-36c8bb5861e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89ffe314-b66b-48d8-b94d-36c8bb5861e4.jpg?1",
             "name": "Lich-Knights' Conquest",
             "text": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
             "colours": [
@@ -15937,7 +15937,7 @@
         },
         {
             "id": "b4604969-4a00-521b-bcf3-2257fe3a44c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaac375-57ce-432b-b718-b547367faec7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdaac375-57ce-432b-b718-b547367faec7.jpg?1",
             "name": "Expel the Interlopers",
             "text": "Choose a number between 0 and 10. Destroy all creatures with power greater than or equal to the chosen number.",
             "colours": [
@@ -15971,7 +15971,7 @@
         },
         {
             "id": "3b0fa459-5153-5fea-8dff-cb16c1c932dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -16006,7 +16006,7 @@
         },
         {
             "id": "b10c0494-4000-52fd-b93c-6af7da4e71d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1",
             "name": "Human",
             "text": "",
             "colours": [
@@ -16041,7 +16041,7 @@
         },
         {
             "id": "8e024fa2-e2fc-5eb3-a2ff-295d496c0d3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg?1",
             "name": "Knight",
             "text": "",
             "colours": [
@@ -16076,7 +16076,7 @@
         },
         {
             "id": "27f0061d-f29b-5058-8d71-7d99ee87b052",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80435c8-9a41-47cb-be84-784a278adcae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d80435c8-9a41-47cb-be84-784a278adcae.jpg?1",
             "name": "Mouse",
             "text": "",
             "colours": [
@@ -16111,7 +16111,7 @@
         },
         {
             "id": "ebe161d9-962f-584c-b10b-5a87dfdd24a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg?1",
             "name": "Faerie",
             "text": "",
             "colours": [
@@ -16146,7 +16146,7 @@
         },
         {
             "id": "2a779ede-71be-5f0c-8ccf-c434f2892afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858428ee-3a9c-4dfc-84c2-751e59df2ed7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/858428ee-3a9c-4dfc-84c2-751e59df2ed7.jpg?1",
             "name": "Nightmare",
             "text": "",
             "colours": [
@@ -16181,7 +16181,7 @@
         },
         {
             "id": "2ff9f472-d654-56b6-bba6-cb501a09ad5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1",
             "name": "Rat",
             "text": "",
             "colours": [
@@ -16216,7 +16216,7 @@
         },
         {
             "id": "5bcd3bc9-e9c5-52ca-964f-12d045535a12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d33cf3-c803-4e90-9d4b-fa34136b600e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a2d33cf3-c803-4e90-9d4b-fa34136b600e.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -16251,7 +16251,7 @@
         },
         {
             "id": "d2cce550-6244-5702-a711-1464205e0709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff615495-a230-484e-a858-ead84f880bdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff615495-a230-484e-a858-ead84f880bdd.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -16288,7 +16288,7 @@
         },
         {
             "id": "2c699539-fec1-5ef0-b8a8-7c9bf3c4216d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4f83dd-94c0-4594-8e72-611eb76fa4e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4f83dd-94c0-4594-8e72-611eb76fa4e2.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16319,7 +16319,7 @@
         },
         {
             "id": "da4e6e00-e477-5fba-9f49-993015cbbdab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaec411-0590-4662-ac88-11bb0008d69c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0eaec411-0590-4662-ac88-11bb0008d69c.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16350,7 +16350,7 @@
         },
         {
             "id": "f24d9414-a9cc-50f6-aac6-16e596b7c671",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a40362-be01-4a16-9c98-0761fffb2560.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29a40362-be01-4a16-9c98-0761fffb2560.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16381,7 +16381,7 @@
         },
         {
             "id": "fb8bf330-86de-566c-ae38-09bbc290c33a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67727b7-819c-4e96-aa8e-1e01ecaf9f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f67727b7-819c-4e96-aa8e-1e01ecaf9f33.jpg?1",
             "name": "Food",
             "text": "",
             "colours": [],
@@ -16412,7 +16412,7 @@
         },
         {
             "id": "8fb72ba2-7332-5577-b7bd-d75df4c727c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbf189-a79b-4dca-8b29-33aef6306b5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73cbf189-a79b-4dca-8b29-33aef6306b5a.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -16443,7 +16443,7 @@
         },
         {
             "id": "246f948c-eea9-5f6a-8d19-f8c11c51de94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg?1",
             "name": "Monster // Sorcerer",
             "text": "",
             "colours": [],
@@ -16475,7 +16475,7 @@
         },
         {
             "id": "dd6f5274-9bb4-5acc-9855-55815f497831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg?1",
             "name": "Monster // Sorcerer",
             "text": "",
             "colours": [],
@@ -16507,7 +16507,7 @@
         },
         {
             "id": "4c23fc6d-6c85-5c7b-9176-eeee951c3b31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg?1",
             "name": "Royal // Young Hero",
             "text": "",
             "colours": [],
@@ -16539,7 +16539,7 @@
         },
         {
             "id": "1498b1ca-31fb-50bd-b106-b9298eaece80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg?1",
             "name": "Royal // Young Hero",
             "text": "",
             "colours": [],
@@ -16571,7 +16571,7 @@
         },
         {
             "id": "be188b68-76b3-5695-88ae-97d7383f3679",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg?1",
             "name": "Wicked // Cursed",
             "text": "",
             "colours": [],
@@ -16603,7 +16603,7 @@
         },
         {
             "id": "a8e38737-ad9f-538b-a910-3dbdea354ade",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg?1",
             "name": "Wicked // Cursed",
             "text": "",
             "colours": [],
@@ -16635,7 +16635,7 @@
         },
         {
             "id": "cf472819-5911-5d3a-bafb-4bbd7994dda4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf4c7fb-7859-4c11-8552-6817f5119d2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcf4c7fb-7859-4c11-8552-6817f5119d2e.jpg?1",
             "name": "On an Adventure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/WTH.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/WTH.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "a34bafca-4ebb-585e-b3a7-abe39cfb6718",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125a355d-bfcf-4125-aa6c-35e7dea6f63e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/125a355d-bfcf-4125-aa6c-35e7dea6f63e.jpg?1",
             "name": "Abeyance",
             "text": "Until end of turn, target player cannot play instants, interrupts, sorceries, or abilities requiring an activation cost.\nDraw a card.",
             "colours": [
@@ -35,7 +35,7 @@
         },
         {
             "id": "4da40510-af07-5549-8acb-a1eca56bb4d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fcc23-ac09-4ada-b194-424739c9c734.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a2fcc23-ac09-4ada-b194-424739c9c734.jpg?1",
             "name": "Alabaster Dragon",
             "text": "Flying\nIf Alabaster Dragon is put into any graveyard from play, shuffle Alabaster Dragon into its owner's library.",
             "colours": [
@@ -68,7 +68,7 @@
         },
         {
             "id": "d01447aa-5007-5b4d-8ecb-b1cfc81fa638",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97382dd8-2754-4ca3-8ba8-d655acaf22ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97382dd8-2754-4ca3-8ba8-d655acaf22ac.jpg?1",
             "name": "Alms",
             "text": "o1, Remove the top card in your graveyard from the game: Prevent 1 damage to any creature.",
             "colours": [
@@ -99,7 +99,7 @@
         },
         {
             "id": "31ef5ac7-0db5-52f0-b632-4a8632b44aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dddde7d-8565-45a7-a1db-f2dea2a6a3ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7dddde7d-8565-45a7-a1db-f2dea2a6a3ba.jpg?1",
             "name": "Angelic Renewal",
             "text": "If any creatures are put into your graveyard from play, you may bury Angelic Renewal and put one of those creatures into play.",
             "colours": [
@@ -130,7 +130,7 @@
         },
         {
             "id": "b2ed0166-a592-5ea6-8839-441c57b4050b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb212ca5-bbb5-4c83-9a7b-9d5ab451e032.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb212ca5-bbb5-4c83-9a7b-9d5ab451e032.jpg?1",
             "name": "Ardent Militia",
             "text": "Attacking does not cause Ardent Militia to tap.",
             "colours": [
@@ -164,7 +164,7 @@
         },
         {
             "id": "d4cfbe5a-0264-5e4a-813e-e5307af7b99e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f23295-ad0a-4e2d-ae04-1a9c065e575d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/89f23295-ad0a-4e2d-ae04-1a9c065e575d.jpg?1",
             "name": "Argivian Find",
             "text": "Return target artifact or enchantment card from your graveyard to your hand.",
             "colours": [
@@ -195,7 +195,7 @@
         },
         {
             "id": "99bcf6d4-186b-5637-8a16-8025909fd977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6c366-b8c7-4f66-b8e1-82dc69c0081c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57e6c366-b8c7-4f66-b8e1-82dc69c0081c.jpg?1",
             "name": "Aura of Silence",
             "text": "Artifact and enchantment spells cost target opponent an additional o2 to play.\nSacrifice Aura of Silence: Destroy target artifact or enchantment.",
             "colours": [
@@ -226,7 +226,7 @@
         },
         {
             "id": "c7a963e8-bd55-5f5a-83ed-aa4ff18f674b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8472303-b8ee-402b-a9ea-49abe2e01152.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8472303-b8ee-402b-a9ea-49abe2e01152.jpg?1",
             "name": "Benalish Infantry",
             "text": "Banding",
             "colours": [
@@ -260,7 +260,7 @@
         },
         {
             "id": "d5ae66df-17a6-5c8a-873b-357ef1304345",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c184bb-6c7d-4118-a111-ef27171cfee6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2c184bb-6c7d-4118-a111-ef27171cfee6.jpg?1",
             "name": "Benalish Knight",
             "text": "First strike\nYou may play Benalish Knight whenever you could play an instant.",
             "colours": [
@@ -294,7 +294,7 @@
         },
         {
             "id": "82b73ff1-318a-5dc9-bccc-1abb9ad39873",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac1992-6212-4f05-af16-c892dfc40643.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9ac1992-6212-4f05-af16-c892dfc40643.jpg?1",
             "name": "Benalish Missionary",
             "text": "o1o\nW, oc\nT: Target blocked creature deals no combat damage this turn.",
             "colours": [
@@ -328,7 +328,7 @@
         },
         {
             "id": "7c67a640-ea4d-5514-8937-3fc7a1a1d872",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19ed33b-42d4-4a5d-a763-cfb43348769c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d19ed33b-42d4-4a5d-a763-cfb43348769c.jpg?1",
             "name": "Debt of Loyalty",
             "text": "Regenerate target creature. Gain control of that creature.",
             "colours": [
@@ -359,7 +359,7 @@
         },
         {
             "id": "9635dd0b-1ae2-56ab-9f6c-fb5e4101ad0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee3a23a-6ecf-439c-8637-e096fa8c1a80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bee3a23a-6ecf-439c-8637-e096fa8c1a80.jpg?1",
             "name": "Duskrider Falcon",
             "text": "Flying, protection from black",
             "colours": [
@@ -392,7 +392,7 @@
         },
         {
             "id": "f7336763-42f1-529a-8f07-2f0ce6e0c062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5518a79f-bcae-417a-b01b-b6ff572be0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5518a79f-bcae-417a-b01b-b6ff572be0be.jpg?1",
             "name": "Empyrial Armor",
             "text": "Enchanted creature gets +X/+X, where X is equal to the number of cards in your hand.",
             "colours": [
@@ -425,7 +425,7 @@
         },
         {
             "id": "586ee364-c862-509b-bd79-9362a3be0e33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d11b6ef-3a24-4709-a62f-c5e062a6cee1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d11b6ef-3a24-4709-a62f-c5e062a6cee1.jpg?1",
             "name": "Foriysian Brigade",
             "text": "Foriysian Brigade may block two creatures each combat. (All blocking assignments must still be legal.)",
             "colours": [
@@ -459,7 +459,7 @@
         },
         {
             "id": "95d7e590-35b1-5c5e-b5da-186f9d191ddd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81defa5-edb4-4f1f-b13c-7cfb34511138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f81defa5-edb4-4f1f-b13c-7cfb34511138.jpg?1",
             "name": "Gerrard's Wisdom",
             "text": "For each card in your hand, gain 2 life.",
             "colours": [
@@ -490,7 +490,7 @@
         },
         {
             "id": "de12a3f2-fe70-5e05-999f-840c86d53fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e8ec37-abe8-45a9-a1a0-6d4e37c74c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6e8ec37-abe8-45a9-a1a0-6d4e37c74c45.jpg?1",
             "name": "Guided Strike",
             "text": "Target creature gets +1/+0 and gains first strike until end of turn.\nDraw a card.",
             "colours": [
@@ -521,7 +521,7 @@
         },
         {
             "id": "ad85dabf-d7b2-5940-a4dc-760f924c47a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfe3eed-e415-4b28-8b4d-e50a19235683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdfe3eed-e415-4b28-8b4d-e50a19235683.jpg?1",
             "name": "Heavy Ballista",
             "text": "oc\nT: Heavy Ballista deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -555,7 +555,7 @@
         },
         {
             "id": "52a0e66b-de11-553d-94ec-2915171a876b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2298faae-370e-4b87-bf32-d20c2282a928.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2298faae-370e-4b87-bf32-d20c2282a928.jpg?1",
             "name": "Inner Sanctum",
             "text": "Cumulative upkeep\u20142 life\nAll damage dealt to creatures you control is reduced to 0.",
             "colours": [
@@ -586,7 +586,7 @@
         },
         {
             "id": "9ff1796b-8d42-5699-8092-3d1aa2df7424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395e7882-0429-46aa-8e38-be707067c588.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/395e7882-0429-46aa-8e38-be707067c588.jpg?1",
             "name": "Kithkin Armor",
             "text": "Enchanted creature cannot be blocked by creatures with power 3 or greater.\nSacrifice Kithkin Armor: Prevent all damage to enchanted creature from one source.",
             "colours": [
@@ -619,7 +619,7 @@
         },
         {
             "id": "d71ccc8d-65f0-5d70-8475-5f5022f44cd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97ff43-c0b6-4f67-ad09-5ba8710c681a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac97ff43-c0b6-4f67-ad09-5ba8710c681a.jpg?1",
             "name": "Master of Arms",
             "text": "First strike\no1oo\nW Tap target creature blocking Master of Arms.",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "2392ab36-0423-568a-a798-eb048d573dd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec71a29-19db-4747-8276-7fd4d563d4df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ec71a29-19db-4747-8276-7fd4d563d4df.jpg?1",
             "name": "Mistmoon Griffin",
             "text": "Flying\nIf Mistmoon Griffin is put into any graveyard from play, remove Mistmoon Griffin from the game, then put the top creature card from your graveyard into play.",
             "colours": [
@@ -686,7 +686,7 @@
         },
         {
             "id": "13f662e5-3f79-5ebe-a0f4-b8385fa28352",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a5683-5f2f-4933-9fc3-5f7773f72f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/592a5683-5f2f-4933-9fc3-5f7773f72f93.jpg?1",
             "name": "Peacekeeper",
             "text": "During your upkeep, pay o1o\nW or bury Peacekeeper.\nCreatures cannot attack.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "1309151d-a711-55a3-a1fa-81fb94f71a7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c642dd2-1a3e-4b08-917e-6e8aed358b72.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c642dd2-1a3e-4b08-917e-6e8aed358b72.jpg?1",
             "name": "Revered Unicorn",
             "text": "Cumulative upkeep o1\nIf Revered Unicorn leaves play, its controller gains life equal to Revered Unicorn's last paid cumulative upkeep.",
             "colours": [
@@ -752,7 +752,7 @@
         },
         {
             "id": "ff0d24fd-6ca7-5393-b8e5-4ec785eb10c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca975ab-b3ee-4584-9f92-860b4c2369f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dca975ab-b3ee-4584-9f92-860b4c2369f3.jpg?1",
             "name": "Serenity",
             "text": "During your upkeep, bury all artifacts and enchantments.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "7c6f354e-91ee-571c-aa41-557f575add9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794cca9-3df0-4864-8a98-4de71a2bcf17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2794cca9-3df0-4864-8a98-4de71a2bcf17.jpg?1",
             "name": "Serra's Blessing",
             "text": "Attacking does not cause creatures you control to tap.",
             "colours": [
@@ -814,7 +814,7 @@
         },
         {
             "id": "15ab3ce8-fb2f-5606-a01f-409153ce215a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a39ba-5fbf-46c3-8dc7-3058ac6d24e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f45a39ba-5fbf-46c3-8dc7-3058ac6d24e8.jpg?1",
             "name": "Soul Shepherd",
             "text": "o\nW, Remove a creature card in your graveyard from the game: Gain 1 life.",
             "colours": [
@@ -848,7 +848,7 @@
         },
         {
             "id": "3988b97f-c1f0-550b-b84f-fe6d607ac434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3c94a1-8455-4521-a0d5-ee2982527b89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a3c94a1-8455-4521-a0d5-ee2982527b89.jpg?1",
             "name": "Southern Paladin",
             "text": "o\nWo\nW, oc\nT: Destroy target red permanent.",
             "colours": [
@@ -882,7 +882,7 @@
         },
         {
             "id": "38fef905-c0ed-559b-a003-692d02489716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24333832-2a87-4810-9443-ec993468d103.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24333832-2a87-4810-9443-ec993468d103.jpg?1",
             "name": "Tariff",
             "text": "Each player chooses a creature with the highest total casting cost he or she controls, then pays an amount of mana equal to that creature's total casting cost or buries the creature.",
             "colours": [
@@ -913,7 +913,7 @@
         },
         {
             "id": "0109faa4-6e05-5c3f-b2fc-d8d71fa9e42a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5344911f-25e8-45ce-87b9-607e42db0139.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5344911f-25e8-45ce-87b9-607e42db0139.jpg?1",
             "name": "Volunteer Reserves",
             "text": "Banding\nCumulative upkeep o1",
             "colours": [
@@ -947,7 +947,7 @@
         },
         {
             "id": "91f2ff1a-5634-5995-aba0-c57029cbcbac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81264d-0e03-44ac-8ff5-049b9aaebcca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81264d-0e03-44ac-8ff5-049b9aaebcca.jpg?1",
             "name": "Abduction",
             "text": "When Abduction comes into play, untap enchanted creature.\nGain control of enchanted creature.\nIf enchanted creature is put into any graveyard, put that creature into play under its owner's control.",
             "colours": [
@@ -980,7 +980,7 @@
         },
         {
             "id": "1e41e6e3-df48-516d-844f-35e38beefa7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbad9449-d09c-4fd0-b2ad-2aa3a29e03bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbad9449-d09c-4fd0-b2ad-2aa3a29e03bf.jpg?1",
             "name": "Abjure",
             "text": "Sacrifice a blue permanent: Counter target spell.",
             "colours": [
@@ -1011,7 +1011,7 @@
         },
         {
             "id": "938f41e0-5bb6-5567-8134-4730e2113bd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b90d72-00ac-4423-8cdf-e1471c6cd0ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05b90d72-00ac-4423-8cdf-e1471c6cd0ae.jpg?1",
             "name": "Ancestral Knowledge",
             "text": "Cumulative upkeep o1\nWhen Ancestral Knowledge comes into play, look at the top ten cards of your library, then remove any number of them from the game and put the rest back on top of your library in any order.\nIf Ancestral Knowledge leaves play, shuffle your library.",
             "colours": [
@@ -1042,7 +1042,7 @@
         },
         {
             "id": "def7fe6b-c4ef-592b-ac8d-bd5795cd929d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3a6fe-e234-4c3f-96fc-3eb5eb22c0b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adf3a6fe-e234-4c3f-96fc-3eb5eb22c0b8.jpg?1",
             "name": "Apathy",
             "text": "Enchanted creature does not untap during its controller's untap phase.\nDuring the upkeep of enchanted creature's controller, that player may discard a card at random to untap that creature.",
             "colours": [
@@ -1075,7 +1075,7 @@
         },
         {
             "id": "14c50c6f-57e8-52d8-b24c-3822dcb99129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1a9d35-1b2a-44a2-9bbc-8529a7487905.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9f1a9d35-1b2a-44a2-9bbc-8529a7487905.jpg?1",
             "name": "Argivian Restoration",
             "text": "Put target artifact card from your graveyard into play.",
             "colours": [
@@ -1106,7 +1106,7 @@
         },
         {
             "id": "6b72ec90-56a5-55bb-9871-ef2ddeafec3d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993986c-e8f1-41b1-86e6-c72021c53b87.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a993986c-e8f1-41b1-86e6-c72021c53b87.jpg?1",
             "name": "Avizoa",
             "text": "Flying\nSkip your next untap phase: Avizoa gets +2/+2 until end of turn. Use this ability only once each turn.",
             "colours": [
@@ -1139,7 +1139,7 @@
         },
         {
             "id": "e67a6a41-b468-5fc4-bcc6-254f9e1b00ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c857a151-45fe-43af-a9be-a93d26f220f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c857a151-45fe-43af-a9be-a93d26f220f3.jpg?1",
             "name": "Cloud Djinn",
             "text": "Flying\nCloud Djinn can block only creatures with flying.",
             "colours": [
@@ -1172,7 +1172,7 @@
         },
         {
             "id": "658271cb-eed8-585b-bc1d-341da9d7e71d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cc89b0-9acf-452b-ac1a-bc7e90eb32fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6cc89b0-9acf-452b-ac1a-bc7e90eb32fc.jpg?1",
             "name": "Disrupt",
             "text": "Counter target instant, interrupt, or sorcery spell unless its caster pays an additional o1.\nDraw a card.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "08368163-1cc6-5144-a323-760f28b0b218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354c9de7-0cdf-4302-9d1a-ae17eca13053.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/354c9de7-0cdf-4302-9d1a-ae17eca13053.jpg?1",
             "name": "Ertai's Familiar",
             "text": "Phasing\nIf Ertai's Familiar leaves play, put the top three cards of your library into your graveyard.\noo\nU Ertai's Familiar cannot phase out until the beginning of your next upkeep.",
             "colours": [
@@ -1236,7 +1236,7 @@
         },
         {
             "id": "96281193-2feb-5cd7-8efd-44b8e9a2cfbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b28e4-a367-4a38-866d-c3768bd9b7ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/368b28e4-a367-4a38-866d-c3768bd9b7ad.jpg?1",
             "name": "Flux",
             "text": "Each player chooses and discards any number of cards, then draws that many cards.\nDraw a card.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "9664a030-e660-576a-b8d7-d171fbdc1a71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b454d0-7dc7-419f-aefa-f20f37444658.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28b454d0-7dc7-419f-aefa-f20f37444658.jpg?1",
             "name": "Fog Elemental",
             "text": "Flying\nIf Fog Elemental attacks or blocks, bury it at end of combat.",
             "colours": [
@@ -1300,7 +1300,7 @@
         },
         {
             "id": "ca7d4f1b-f412-5c29-b5b8-f56e1f15a57d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77802038-0d86-4911-97ed-e6bd2ed55e23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77802038-0d86-4911-97ed-e6bd2ed55e23.jpg?1",
             "name": "Mana Chains",
             "text": "Enchanted creature gains \"Cumulative upkeep o1.\"",
             "colours": [
@@ -1333,7 +1333,7 @@
         },
         {
             "id": "4ba4cf27-05e8-5d13-91ea-13790ed58868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f74884-9b82-419d-9e97-c947a6b7d09f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80f74884-9b82-419d-9e97-c947a6b7d09f.jpg?1",
             "name": "Manta Ray",
             "text": "Islandhome (If defending player controls no islands, this creature cannot attack. If you control no islands, bury this creature.)\nManta Ray cannot be blocked except by blue creatures.",
             "colours": [
@@ -1366,7 +1366,7 @@
         },
         {
             "id": "a49f8695-0e31-5d7a-b30b-4dd49a5b3618",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebacbf23-4b69-481c-aaf7-5de7b4a6db6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebacbf23-4b69-481c-aaf7-5de7b4a6db6f.jpg?1",
             "name": "Merfolk Traders",
             "text": "When Merfolk Traders comes into play, draw a card, then choose and discard a card.",
             "colours": [
@@ -1399,7 +1399,7 @@
         },
         {
             "id": "ffe20b98-92b7-5be9-917d-d6286f720a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd221f30-1773-4e05-a40f-022a9306ef89.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd221f30-1773-4e05-a40f-022a9306ef89.jpg?1",
             "name": "Noble Benefactor",
             "text": "If Noble Benefactor is put into any graveyard from play, each player may search his or her library for any one card and put that card into his or her hand. Each player who searches his or her library shuffles it afterwards.",
             "colours": [
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "bfaa812c-1286-580c-bd2e-57992a1c763f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0a010-76a7-460f-bb4e-a152c10c3bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de0a010-76a7-460f-bb4e-a152c10c3bb7.jpg?1",
             "name": "Ophidian",
             "text": "o0: Draw a card. Ophidian deals no combat damage this turn. Use this ability only if Ophidian is attacking and unblocked and only once each turn.",
             "colours": [
@@ -1466,7 +1466,7 @@
         },
         {
             "id": "3cfa89e5-a4c4-5235-b1bd-a8e8636f6f8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64a17a8-091d-4029-908e-31d6a050b479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e64a17a8-091d-4029-908e-31d6a050b479.jpg?1",
             "name": "Paradigm Shift",
             "text": "Remove all cards in your library from the game. Shuffle your graveyard into your library.",
             "colours": [
@@ -1497,7 +1497,7 @@
         },
         {
             "id": "d827080e-55a3-5186-b342-09dcca532573",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b902b972-3a93-4e4e-aa77-02ada81e6b95.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b902b972-3a93-4e4e-aa77-02ada81e6b95.jpg?1",
             "name": "Pendrell Mists",
             "text": "Each creature gains \"During your upkeep, pay o1 or bury this creature.\"",
             "colours": [
@@ -1528,7 +1528,7 @@
         },
         {
             "id": "abb1ad2b-f7b9-53df-8391-1bbcd2dd9329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414c9f8-ee46-4368-a8dc-0767c645a9c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b414c9f8-ee46-4368-a8dc-0767c645a9c1.jpg?1",
             "name": "Phantom Warrior",
             "text": "Phantom Warrior is unblockable.",
             "colours": [
@@ -1562,7 +1562,7 @@
         },
         {
             "id": "f914572b-2a31-577b-846d-e939c68467eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0db4c6c-aa51-487b-a591-78d93c67c775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0db4c6c-aa51-487b-a591-78d93c67c775.jpg?1",
             "name": "Phantom Wings",
             "text": "Enchanted creature gains flying.\nSacrifice Phantom Wings: Return enchanted creature to owner's hand.",
             "colours": [
@@ -1595,7 +1595,7 @@
         },
         {
             "id": "5577e714-42f2-59e4-9ada-18b75ecdb0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2a419-7122-4eeb-bb64-738a647cfd82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bc2a419-7122-4eeb-bb64-738a647cfd82.jpg?1",
             "name": "Psychic Vortex",
             "text": "Cumulative upkeep\u2014\nDraw a card\nAt the end of each of your turns, sacrifice a land and discard your hand.",
             "colours": [
@@ -1626,7 +1626,7 @@
         },
         {
             "id": "7355c802-5add-5dbd-b679-db6178e81299",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f8480-8ae7-4b5f-abdf-1bd46066049e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902f8480-8ae7-4b5f-abdf-1bd46066049e.jpg?1",
             "name": "Relearn",
             "text": "Return target instant, interrupt, or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -1657,7 +1657,7 @@
         },
         {
             "id": "982a4c3e-2103-5e40-9855-d1994b3f3b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee2d6a1-8b1e-47e5-9720-5683ac458250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee2d6a1-8b1e-47e5-9720-5683ac458250.jpg?1",
             "name": "Sage Owl",
             "text": "Flying\nWhen Sage Owl comes into play, look at the top four cards of your library and put them back in any order.",
             "colours": [
@@ -1690,7 +1690,7 @@
         },
         {
             "id": "61131cb1-5215-538c-83fe-89af1702b43f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf39b80-d972-4f79-902f-cc613c32e446.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbf39b80-d972-4f79-902f-cc613c32e446.jpg?1",
             "name": "Teferi's Veil",
             "text": "Whenever any creature you control attacks, it phases out at end of combat.",
             "colours": [
@@ -1721,7 +1721,7 @@
         },
         {
             "id": "0a89058b-218d-52c0-a48d-046df9fd15db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bbdbd8-1517-4bfd-926b-465a32724082.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01bbdbd8-1517-4bfd-926b-465a32724082.jpg?1",
             "name": "Timid Drake",
             "text": "Flying\nIf any other creature comes into play, return Timid Drake to owner's hand.",
             "colours": [
@@ -1754,7 +1754,7 @@
         },
         {
             "id": "5e5dc6fa-2521-50e8-8167-9e0fc697bd2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04bba8a-48ee-4981-adc2-4f82c0f2c1bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e04bba8a-48ee-4981-adc2-4f82c0f2c1bd.jpg?1",
             "name": "Tolarian Drake",
             "text": "Flying, phasing",
             "colours": [
@@ -1787,7 +1787,7 @@
         },
         {
             "id": "6f75126e-8a34-5924-bf28-c83e6be1e02a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29dd04a-b3aa-48b6-beef-3314344b84a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c29dd04a-b3aa-48b6-beef-3314344b84a6.jpg?1",
             "name": "Tolarian Entrancer",
             "text": "Whenever Tolarian Entrancer is blocked by any creature, gain control of that creature at end of combat.",
             "colours": [
@@ -1821,7 +1821,7 @@
         },
         {
             "id": "050a8d8f-eb5a-531d-acd6-9a7f85e8a1a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236a857-c4ca-4de2-a4a2-e0914d16b54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9236a857-c4ca-4de2-a4a2-e0914d16b54b.jpg?1",
             "name": "Tolarian Serpent",
             "text": "During your upkeep, put the top seven cards of your library into your graveyard.",
             "colours": [
@@ -1854,7 +1854,7 @@
         },
         {
             "id": "0d3c1110-b288-5533-b828-84f7b08ce0b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0e28b-9fd6-4763-8d6b-952b530358ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ce0e28b-9fd6-4763-8d6b-952b530358ab.jpg?1",
             "name": "Vodalian Illusionist",
             "text": "o\nUo\nU, oc\nT: Target creature phases out.",
             "colours": [
@@ -1888,7 +1888,7 @@
         },
         {
             "id": "0e3b0422-09bd-5129-a8f7-faead877b250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1734df5a-7d3a-46c7-a0ad-adbbd1be958f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1734df5a-7d3a-46c7-a0ad-adbbd1be958f.jpg?1",
             "name": "Abyssal Gatekeeper",
             "text": "If Abyssal Gatekeeper is put into any graveyard from play, each player chooses and buries a creature he or she controls.",
             "colours": [
@@ -1921,7 +1921,7 @@
         },
         {
             "id": "57159e63-3a03-5417-b7af-862236f69780",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be277367-a58e-429e-af1b-58163becf861.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be277367-a58e-429e-af1b-58163becf861.jpg?1",
             "name": "Agonizing Memories",
             "text": "Look at target player's hand. Choose two of those cards and put them on top of his or her library in any order.",
             "colours": [
@@ -1952,7 +1952,7 @@
         },
         {
             "id": "4b07f526-213c-55f3-a74d-798d3c5af503",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7055007-83dd-40fe-b2a1-4b3132f636db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7055007-83dd-40fe-b2a1-4b3132f636db.jpg?1",
             "name": "Barrow Ghoul",
             "text": "During your upkeep, remove the top creature card in your graveyard from the game or bury Barrow Ghoul.",
             "colours": [
@@ -1985,7 +1985,7 @@
         },
         {
             "id": "d5e5cfbd-067a-53d5-b9fa-8184307233de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207bb4cd-4525-47e0-b412-0d0e29717d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/207bb4cd-4525-47e0-b412-0d0e29717d44.jpg?1",
             "name": "Bone Dancer",
             "text": "o0: Put the top creature card of defending player's graveyard into play under your control. Bone Dancer deals no combat damage this turn. Use this ability only if Bone Dancer is attacking and unblocked and only once each turn.",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "b28a4df3-b461-5bbb-94d4-be602b806f9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b92eb5-72b0-46b4-8b16-8a7a7ac80f56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56b92eb5-72b0-46b4-8b16-8a7a7ac80f56.jpg?1",
             "name": "Buried Alive",
             "text": "Search your library for up to three creature cards and put them into your graveyard. Shuffle your library afterwards.",
             "colours": [
@@ -2049,7 +2049,7 @@
         },
         {
             "id": "b7d9ee60-5f59-5173-b3d5-61b32d0debaf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dae8e49-c2b6-4965-9249-49f93449d271.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dae8e49-c2b6-4965-9249-49f93449d271.jpg?1",
             "name": "Circling Vultures",
             "text": "Flying\nDuring your upkeep, remove the top creature card in your graveyard from the game or bury Circling Vultures.\nIf Circling Vultures is in your hand, you may discard it. Play this ability as an instant.",
             "colours": [
@@ -2082,7 +2082,7 @@
         },
         {
             "id": "1448ea45-5468-595e-bcd9-277ce69e2c67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502bfb38-4a37-4053-af20-d5606ffc67c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/502bfb38-4a37-4053-af20-d5606ffc67c8.jpg?1",
             "name": "Coils of the Medusa",
             "text": "Enchanted creature gets +1/-1.\nSacrifice Coils of the Medusa: Destroy all non-Wall creatures blocking enchanted creature.",
             "colours": [
@@ -2115,7 +2115,7 @@
         },
         {
             "id": "ce95ba02-a79d-5681-bfd4-137d00af93b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c6d87-9383-450b-bba5-33435b6b0d08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b3c6d87-9383-450b-bba5-33435b6b0d08.jpg?1",
             "name": "Doomsday",
             "text": "Pay half your life, rounded up: Put your graveyard on top of your library, then remove all but five cards of your library from the game. Put the rest on top of your library in any order.",
             "colours": [
@@ -2146,7 +2146,7 @@
         },
         {
             "id": "4e3a342c-c428-5665-995c-6818cb1de51b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dc7c2-6198-4526-b79a-f3d8ee7a157a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/044dc7c2-6198-4526-b79a-f3d8ee7a157a.jpg?1",
             "name": "Fatal Blow",
             "text": "Bury target creature that was damaged this turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "9ba47561-fc9f-581b-ac68-28e7425c4721",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d688bda-fee2-496d-9793-794c2568b54e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d688bda-fee2-496d-9793-794c2568b54e.jpg?1",
             "name": "Festering Evil",
             "text": "During your upkeep, Festering Evil deals 1 damage to each creature and player.\no\nBo\nB, Sacrifice Festering Evil: Festering Evil deals 3 damage to each creature and player.",
             "colours": [
@@ -2208,7 +2208,7 @@
         },
         {
             "id": "872f9571-d64a-586b-ad06-c19209445258",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fdf2a-d6d2-42da-8f41-0f67dd0bf4d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b0fdf2a-d6d2-42da-8f41-0f67dd0bf4d2.jpg?1",
             "name": "Fledgling Djinn",
             "text": "Flying\nDuring your upkeep, Fledgling Djinn deals 1 damage to you.",
             "colours": [
@@ -2241,7 +2241,7 @@
         },
         {
             "id": "2b6db985-e24d-5225-854e-4416197485f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df86192-6374-42ac-94bc-95e2e8284bd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8df86192-6374-42ac-94bc-95e2e8284bd6.jpg?1",
             "name": "Gallowbraid",
             "text": "Trample\nCumulative upkeep\u20141 life",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "614477fa-8978-5e32-b407-2d8175ecaf07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b83ba-8ba8-4b98-8a13-a037ba7805e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/939b83ba-8ba8-4b98-8a13-a037ba7805e9.jpg?1",
             "name": "Haunting Misery",
             "text": "Remove X creature cards in your graveyard from the game: Haunting Misery deals X damage to target player.",
             "colours": [
@@ -2308,7 +2308,7 @@
         },
         {
             "id": "ef202c6a-1e37-5218-8eb6-a4f9a475a80c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885dc4c5-2ade-4497-b579-0307c67ac783.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/885dc4c5-2ade-4497-b579-0307c67ac783.jpg?1",
             "name": "Hidden Horror",
             "text": "When Hidden Horror comes into play, choose and discard a creature card or bury Hidden Horror.",
             "colours": [
@@ -2341,7 +2341,7 @@
         },
         {
             "id": "03665df8-906c-5b6a-a8f0-f19e1e975e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569739b2-f212-4cc9-84db-1be17b3f90fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569739b2-f212-4cc9-84db-1be17b3f90fb.jpg?1",
             "name": "Infernal Tribute",
             "text": "o2, Sacrifice a card in play: Draw a card.",
             "colours": [
@@ -2372,7 +2372,7 @@
         },
         {
             "id": "a00fb642-7230-5389-a413-b27d30821b8a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054254ee-29cf-48d7-afbf-cb6de83e513e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/054254ee-29cf-48d7-afbf-cb6de83e513e.jpg?1",
             "name": "Mischievous Poltergeist",
             "text": "Flying\nPay 1 life: Regenerate",
             "colours": [
@@ -2405,7 +2405,7 @@
         },
         {
             "id": "42abe983-7dde-5c0b-a569-b243474b64d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5006ad3-16ca-4be3-8d56-d4fe4e9e0a44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5006ad3-16ca-4be3-8d56-d4fe4e9e0a44.jpg?1",
             "name": "Morinfen",
             "text": "Flying\nCumulative upkeep\u20141 life",
             "colours": [
@@ -2441,7 +2441,7 @@
         },
         {
             "id": "a402ecbd-a723-5d06-924b-101e6d7637a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb19c519-c09a-44a0-8d4b-ab6c15dabdef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb19c519-c09a-44a0-8d4b-ab6c15dabdef.jpg?1",
             "name": "Necratog",
             "text": "Remove the top creature card in your graveyard from the game: +2/+2 until end of turn",
             "colours": [
@@ -2474,7 +2474,7 @@
         },
         {
             "id": "60fa0ea7-eef9-5ae6-b910-1ad6c60a45fc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3b7cd1-051c-43a8-b5f0-72a9d704efbc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a3b7cd1-051c-43a8-b5f0-72a9d704efbc.jpg?1",
             "name": "Odylic Wraith",
             "text": "Swampwalk\nIf Odylic Wraith damages any player, that player chooses and discards a card.",
             "colours": [
@@ -2507,7 +2507,7 @@
         },
         {
             "id": "54316737-1c30-5b6c-abbf-4ee7ca57d95a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae869780-27e8-4a6d-9ac6-cdab617725e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae869780-27e8-4a6d-9ac6-cdab617725e2.jpg?1",
             "name": "Razortooth Rats",
             "text": "Razortooth Rats cannot be blocked except by artifact creatures and black creatures.",
             "colours": [
@@ -2540,7 +2540,7 @@
         },
         {
             "id": "f48edb58-edca-5c0c-b85e-26e7eb330afb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfdec24-e689-4cca-a546-a8f5d0929f8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5bfdec24-e689-4cca-a546-a8f5d0929f8d.jpg?1",
             "name": "Shadow Rider",
             "text": "Flanking (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [
@@ -2573,7 +2573,7 @@
         },
         {
             "id": "574ba43c-5ac9-5002-8e61-c7eca7329d97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117df45d-4500-459b-96b5-ca41952580c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/117df45d-4500-459b-96b5-ca41952580c1.jpg?1",
             "name": "Shattered Crypt",
             "text": "Return X target creature cards from your graveyard to your hand and lose X life.",
             "colours": [
@@ -2604,7 +2604,7 @@
         },
         {
             "id": "436bb0c8-3f93-5192-a24b-2da71fbbb50b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e64a8e-84b1-416c-9fa7-8b10130dc9e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58e64a8e-84b1-416c-9fa7-8b10130dc9e9.jpg?1",
             "name": "Spinning Darkness",
             "text": "You may remove the top three black cards in your graveyard from the game instead of paying Spinning Darkness's casting cost. Spinning Darkness deals 3 damage to target nonblack creature. Gain 3 life.",
             "colours": [
@@ -2635,7 +2635,7 @@
         },
         {
             "id": "fd0934f1-a1e5-5e8e-b7f5-e6b6a46dcd03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ef62f-e119-470b-b212-9beb48469095.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/872ef62f-e119-470b-b212-9beb48469095.jpg?1",
             "name": "Strands of Night",
             "text": "o\nBo\nB, Pay 2 life, Sacrifice a swamp: Put target creature card from your graveyard into play.",
             "colours": [
@@ -2666,7 +2666,7 @@
         },
         {
             "id": "be0a030c-acb0-59cc-ac05-44d991ad5b6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d73ddb-bd3c-4625-9f75-ba2079553915.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d73ddb-bd3c-4625-9f75-ba2079553915.jpg?1",
             "name": "Tendrils of Despair",
             "text": "Sacrifice a creature: Target opponent chooses and discards two cards.",
             "colours": [
@@ -2697,7 +2697,7 @@
         },
         {
             "id": "c0c3ab4c-92ab-54f2-b2fe-f2fa92796f05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f322ff-0b04-41ce-90cd-9896f941e703.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39f322ff-0b04-41ce-90cd-9896f941e703.jpg?1",
             "name": "Urborg Justice",
             "text": "Target opponent chooses and buries a number of creatures he or she controls equal to the number of creatures put into your graveyard from play so far this turn.",
             "colours": [
@@ -2728,7 +2728,7 @@
         },
         {
             "id": "edcea703-7050-526e-a82e-a815c61053a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33e3d5-c608-4ba8-8614-0b9d0385af64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d33e3d5-c608-4ba8-8614-0b9d0385af64.jpg?1",
             "name": "Urborg Stalker",
             "text": "During each player's upkeep, if that player controls any nonblack permanents other than lands, Urborg Stalker deals 1 damage to that player.",
             "colours": [
@@ -2761,7 +2761,7 @@
         },
         {
             "id": "4ed32200-2e0b-55ce-868c-3bc05872ee07",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40ab3e7-9abb-4acc-9932-de03b533722f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d40ab3e7-9abb-4acc-9932-de03b533722f.jpg?1",
             "name": "Wave of Terror",
             "text": "Cumulative upkeep o1\nAt the end of your upkeep, bury each creature with casting cost equal to Wave of Terror's last paid cumulative upkeep.",
             "colours": [
@@ -2792,7 +2792,7 @@
         },
         {
             "id": "e5afce68-8fdf-587f-9248-4a47ba8b7d55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec786b1-6097-4e97-99b0-571d6e3e73e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ec786b1-6097-4e97-99b0-571d6e3e73e7.jpg?1",
             "name": "Zombie Scavengers",
             "text": "Remove the top creature card in your graveyard from the game: Regenerate",
             "colours": [
@@ -2825,7 +2825,7 @@
         },
         {
             "id": "98c1c36c-2b6c-59c9-8ee0-3c80d00216d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6642d-393d-49a5-8c49-c1f62524ea20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28f6642d-393d-49a5-8c49-c1f62524ea20.jpg?1",
             "name": "Aether Flash",
             "text": "Whenever any creature comes into play, \u00c6ther Flash deals 2 damage to that creature.",
             "colours": [
@@ -2856,7 +2856,7 @@
         },
         {
             "id": "abb64ff2-883a-5b53-8bf7-4b60ac4f203a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e517aa4-d8ba-4a49-bf9f-172bf029fa52.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e517aa4-d8ba-4a49-bf9f-172bf029fa52.jpg?1",
             "name": "Betrothed of Fire",
             "text": "Sacrifice an untapped creature: Enchanted creature gets +2/+0 until end of turn.\nSacrifice enchanted creature: All creatures you control get +2/+0 until end of turn.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "170e747a-b397-5cd9-aa8f-d0ca6159add9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c642fd9-38f7-4029-ab93-e1dc5636c1ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c642fd9-38f7-4029-ab93-e1dc5636c1ad.jpg?1",
             "name": "Bloodrock Cyclops",
             "text": "Bloodrock Cyclops attacks each turn if able.",
             "colours": [
@@ -2922,7 +2922,7 @@
         },
         {
             "id": "a68e07a9-611d-561b-9276-82ea3e445993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ff9650-d25f-4c6b-b96e-794b50af3f14.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80ff9650-d25f-4c6b-b96e-794b50af3f14.jpg?1",
             "name": "Bogardan Firefiend",
             "text": "If Bogardan Firefiend is put into any graveyard from play, it deals 2 damage to target creature.",
             "colours": [
@@ -2956,7 +2956,7 @@
         },
         {
             "id": "2ed6b5e1-9f19-52be-b88a-bb3e68ee30b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcb85b6-ab5a-40db-aaae-555315f32877.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3fcb85b6-ab5a-40db-aaae-555315f32877.jpg?1",
             "name": "Boiling Blood",
             "text": "Target creature attacks this turn if able.\nDraw a card.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "189fe929-6902-5a86-9305-aaa1a9748dc2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de97c939-2c44-4c43-9d66-1087bcee692b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de97c939-2c44-4c43-9d66-1087bcee692b.jpg?1",
             "name": "Cinder Giant",
             "text": "During your upkeep, Cinder Giant deals 2 damage to each other creature you control.",
             "colours": [
@@ -3020,7 +3020,7 @@
         },
         {
             "id": "6423f5fa-e9e1-5ee1-9ea4-657300b9b732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1e429c-2e66-4363-b50a-b12b72efa060.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c1e429c-2e66-4363-b50a-b12b72efa060.jpg?1",
             "name": "Cinder Wall",
             "text": "If Cinder Wall blocks, destroy it at end of combat.",
             "colours": [
@@ -3053,7 +3053,7 @@
         },
         {
             "id": "6f37c6a4-cf9f-5fd0-b814-c9c284bca1f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5713f17a-9a57-41f8-b492-ced876e1a37f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/5713f17a-9a57-41f8-b492-ced876e1a37f.jpg?1",
             "name": "Cone of Flame",
             "text": "Choose three target creatures and/or players. Cone of Flame deals 1 damage to the first, 2 damage to the second, and 3 damage to the third.",
             "colours": [
@@ -3084,7 +3084,7 @@
         },
         {
             "id": "5cfcc217-2569-5a86-a1df-32586d34e1e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4245160-274e-4c39-9bcd-c64e9a44dfdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4245160-274e-4c39-9bcd-c64e9a44dfdb.jpg?1",
             "name": "Desperate Gambit",
             "text": "Flip a coin; target opponent calls heads or tails while coin is in the air. If the flip ends up in your favor, double the damage dealt by a source you control. Otherwise, prevent all damage from that source.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "cfd71fd1-94db-542a-9d25-049dbea3522b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc734e9-fb09-4094-94b6-76c0458649e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bc734e9-fb09-4094-94b6-76c0458649e9.jpg?1",
             "name": "Dwarven Berserker",
             "text": "If Dwarven Berserker is blocked, it gets +3/+0 and gains trample until end of turn.",
             "colours": [
@@ -3149,7 +3149,7 @@
         },
         {
             "id": "eca5c951-cf73-5436-8950-f2a8944623c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68aa29-9f38-48a2-b00a-39aef9d91f6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e68aa29-9f38-48a2-b00a-39aef9d91f6d.jpg?1",
             "name": "Dwarven Thaumaturgist",
             "text": "oc\nT: Switch power and toughness of target creature until end of turn. Effects that alter that creature's power alter its toughness instead, and vice versa, until end of turn.",
             "colours": [
@@ -3183,7 +3183,7 @@
         },
         {
             "id": "16782e9c-3488-52f2-9c8e-7cdfe837dab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4df70ea-2b6b-4e25-a564-655989ef16fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4df70ea-2b6b-4e25-a564-655989ef16fa.jpg?1",
             "name": "Fervor",
             "text": "All creatures you control are unaffected by summoning sickness.",
             "colours": [
@@ -3214,7 +3214,7 @@
         },
         {
             "id": "2b566230-e0c5-59b9-aea9-50cec43cb0a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee194b4-f18f-4ebd-b42f-c7dfef42f22e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3ee194b4-f18f-4ebd-b42f-c7dfef42f22e.jpg?1",
             "name": "Fire Whip",
             "text": "Play only on a creature you control.\nTap enchanted creature: Enchanted creature deals 1 damage to target creature or player.\nSacrifice Fire Whip: Fire Whip deals 1 damage to target creature or player.",
             "colours": [
@@ -3247,7 +3247,7 @@
         },
         {
             "id": "261392bb-cbee-5cfb-93ed-3804ab6aa8f0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e674aa8a-668a-4345-95ee-73a0b87bbcb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e674aa8a-668a-4345-95ee-73a0b87bbcb1.jpg?1",
             "name": "Firestorm",
             "text": "Choose and discard X cards: Firestorm deals X damage to each of X target creatures and/or players.",
             "colours": [
@@ -3278,7 +3278,7 @@
         },
         {
             "id": "02cae858-ed56-5a28-aec0-8bad52b0b3a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7b9ec-90cf-4d23-af5e-48394398ff06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09e7b9ec-90cf-4d23-af5e-48394398ff06.jpg?1",
             "name": "Fit of Rage",
             "text": "Target creature gets +3/+3 and gains first strike until end of turn.",
             "colours": [
@@ -3309,7 +3309,7 @@
         },
         {
             "id": "0ca7e0b3-4a30-5465-8922-be853faf7d73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8a436-9fd0-409f-a020-0f9f41602d50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97e8a436-9fd0-409f-a020-0f9f41602d50.jpg?1",
             "name": "Goblin Bomb",
             "text": "During your upkeep, you may choose to flip a coin. Target opponent calls heads or tails while the coin is in the air. If the flip ends up in your favor, put a fuse counter on Goblin Bomb. Otherwise, remove a fuse counter from Goblin Bomb.\nRemove 5 fuse counters from Goblin Bomb, Sacrifice Goblin Bomb: Goblin Bomb deals 20 damage to target player.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "5cf66c5f-c128-5ed9-95dc-4c1adb9dc5b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73db23-727f-4d63-97d7-2ca542276722.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a73db23-727f-4d63-97d7-2ca542276722.jpg?1",
             "name": "Goblin Grenadiers",
             "text": "Sacrifice Goblin Grenadiers: Destroy target creature and target land. Use this ability only if Goblin Grenadiers is attacking and unblocked.",
             "colours": [
@@ -3373,7 +3373,7 @@
         },
         {
             "id": "042a6374-aa12-5645-8e24-31de0b9feaca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad3b81-f706-4b33-b1ec-7600182a5232.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7ad3b81-f706-4b33-b1ec-7600182a5232.jpg?1",
             "name": "Goblin Vandal",
             "text": "oo\nR Destroy target artifact defending player controls. Goblin Vandal deals no combat damage this turn. Use this ability only if Goblin Vandal is attacking and unblocked and only once each turn.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "a5920156-d27e-523f-b12c-e2b05c1c15c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e30d025-1df9-4a08-b686-037e9cbf23a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e30d025-1df9-4a08-b686-037e9cbf23a6.jpg?1",
             "name": "Heart of Bogardan",
             "text": "Cumulative upkeep o2\nIf Heart of Bogardan's cumulative upkeep cost is not paid, Heart of Bogardan deals damage equal to its last paid cumulative upkeep to target player and each creature he or she controls.",
             "colours": [
@@ -3438,7 +3438,7 @@
         },
         {
             "id": "2823d21f-a786-5748-8e6e-6751b1a13f6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baf2a6c-57ec-4b38-8b08-4b3f800dbe99.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1baf2a6c-57ec-4b38-8b08-4b3f800dbe99.jpg?1",
             "name": "Heat Stroke",
             "text": "At the end of each combat, destroy all creatures that blocked or were blocked this turn.",
             "colours": [
@@ -3469,7 +3469,7 @@
         },
         {
             "id": "8779e0f7-447c-544e-aeff-d7bc8bc22613",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a359c9-1889-426d-acaf-074cfd9f274d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70a359c9-1889-426d-acaf-074cfd9f274d.jpg?1",
             "name": "Hurloon Shaman",
             "text": "If Hurloon Shaman is put into any graveyard from play, each player chooses and buries a land he or she controls.",
             "colours": [
@@ -3503,7 +3503,7 @@
         },
         {
             "id": "cb9e1229-b847-520a-b152-a0283b16b129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896dcaf0-3e52-4189-990f-cabab40ffbd1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/896dcaf0-3e52-4189-990f-cabab40ffbd1.jpg?1",
             "name": "Lava Hounds",
             "text": "Lava Hounds is unaffected by summoning sickness.\nWhen Lava Hounds comes into play, it deals 4 damage to you.",
             "colours": [
@@ -3536,7 +3536,7 @@
         },
         {
             "id": "f3425340-944d-58af-bc7c-25c65f7c7db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fcd58e-e5e2-45f4-9edd-300a871ae5f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61fcd58e-e5e2-45f4-9edd-300a871ae5f5.jpg?1",
             "name": "Lava Storm",
             "text": "Lava Storm deals 2 damage to each attacking creature or 2 damage to each blocking creature.",
             "colours": [
@@ -3567,7 +3567,7 @@
         },
         {
             "id": "3476c2fe-8c17-5e75-9064-17455588cd14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59329155-a423-4e8d-a7d4-c99555ff5ed1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59329155-a423-4e8d-a7d4-c99555ff5ed1.jpg?1",
             "name": "Maraxus of Keld",
             "text": "Maraxus of Keld has power and toughness each equal to the total number of untapped artifacts, creatures, and lands you control.",
             "colours": [
@@ -3603,7 +3603,7 @@
         },
         {
             "id": "ec037601-f72d-58df-aa90-0cadf9134a61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54764f6-6f65-405c-ba30-1e485ce3fe21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d54764f6-6f65-405c-ba30-1e485ce3fe21.jpg?1",
             "name": "Orcish Settlers",
             "text": "o\nXo\nXo\nR, oc\nT, Sacrifice Orcish Settlers: Destroy X target lands.",
             "colours": [
@@ -3636,7 +3636,7 @@
         },
         {
             "id": "bea821a3-217c-579c-98f5-1177451cde04",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25857884-6bb7-4a8e-a08b-fa610af8a5c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25857884-6bb7-4a8e-a08b-fa610af8a5c3.jpg?1",
             "name": "Roc Hatchling",
             "text": "When Roc Hatchling comes into play, put four shell counters on it.\nDuring your upkeep, remove a shell counter from Roc Hatchling.\nAs long as Roc Hatchling has no shell counters on it, it gets +3/+2 and gains flying.",
             "colours": [
@@ -3669,7 +3669,7 @@
         },
         {
             "id": "3e837f1d-302b-5c66-83df-6fcab88b04e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a237580-f7f6-4d6b-a342-0d11fc0b5a59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a237580-f7f6-4d6b-a342-0d11fc0b5a59.jpg?1",
             "name": "Sawtooth Ogre",
             "text": "If Sawtooth Ogre blocks or is blocked by any creature, Sawtooth Ogre deals 1 damage to that creature at end of combat.",
             "colours": [
@@ -3702,7 +3702,7 @@
         },
         {
             "id": "ac58d030-0d6a-5958-8444-f15a9108ba28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a4b641-2eb3-482b-91a1-236ebe2a7a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0a4b641-2eb3-482b-91a1-236ebe2a7a41.jpg?1",
             "name": "Thunderbolt",
             "text": "Thunderbolt deals 3 damage to target player or 4 damage to target creature with flying.",
             "colours": [
@@ -3733,7 +3733,7 @@
         },
         {
             "id": "b080e8ee-cc70-5a2c-8676-ff57ef3377cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e936e5cb-0a8e-4348-afea-e5f96b19fe23.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e936e5cb-0a8e-4348-afea-e5f96b19fe23.jpg?1",
             "name": "Thundermare",
             "text": "Thundermare is unaffected by summoning sickness.\nWhen Thundermare comes into play, tap all other creatures.",
             "colours": [
@@ -3767,7 +3767,7 @@
         },
         {
             "id": "7b434d33-dbe8-5eee-bb33-0cbb016bec7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72ac67-e4fb-49a1-b1e5-cd2e414bec28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c72ac67-e4fb-49a1-b1e5-cd2e414bec28.jpg?1",
             "name": "Aboroth",
             "text": "Cumulative upkeep\u2014\nPut a -1/-1 counter on Aboroth",
             "colours": [
@@ -3800,7 +3800,7 @@
         },
         {
             "id": "98c7bec5-a6c6-597d-be24-6e552460d250",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb56a2-5138-4c31-aa4b-0824a1a24573.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5fb56a2-5138-4c31-aa4b-0824a1a24573.jpg?1",
             "name": "Arctic Wolves",
             "text": "Cumulative upkeep o2\nWhen Arctic Wolves comes into play, draw a card.",
             "colours": [
@@ -3833,7 +3833,7 @@
         },
         {
             "id": "075d1e34-518b-54b7-ad4d-a08f9abb46d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f263eb80-f8f2-4b32-8e8b-a297de9f3666.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f263eb80-f8f2-4b32-8e8b-a297de9f3666.jpg?1",
             "name": "Barishi",
             "text": "If Barishi is put into any graveyard from play, remove Barishi from the game, then shuffle all creature cards from your graveyard into your library.",
             "colours": [
@@ -3866,7 +3866,7 @@
         },
         {
             "id": "0c962d17-9aa2-5210-8781-93ed4ca1a36e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f944ad9-c9ce-47b2-80fa-d0f7fcf0fd5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f944ad9-c9ce-47b2-80fa-d0f7fcf0fd5d.jpg?1",
             "name": "Blossoming Wreath",
             "text": "Gain life equal to the number of creature cards in your graveyard.",
             "colours": [
@@ -3897,7 +3897,7 @@
         },
         {
             "id": "e8be34cf-01a1-55b0-8112-439b3a2e5939",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68100ac2-9677-4eb5-93dc-54e49b15985d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68100ac2-9677-4eb5-93dc-54e49b15985d.jpg?1",
             "name": "Briar Shield",
             "text": "Enchanted creature gets +1/+1.\nSacrifice Briar Shield: Enchanted creature gets +3/+3 until end of turn.",
             "colours": [
@@ -3930,7 +3930,7 @@
         },
         {
             "id": "a2d98280-535b-566d-92e1-c9787606011c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742bc7c-7f0d-4dff-b229-f16d54fe1347.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a742bc7c-7f0d-4dff-b229-f16d54fe1347.jpg?1",
             "name": "Call of the Wild",
             "text": "o2o\nGoo\nG Reveal the top card of your library to all players. If that card is a creature card, put it into play. Otherwise, bury it.",
             "colours": [
@@ -3961,7 +3961,7 @@
         },
         {
             "id": "de881043-1730-5a73-be0a-6a083181a800",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4a7ee-f6f0-454a-9074-5988fdee1f34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6cc4a7ee-f6f0-454a-9074-5988fdee1f34.jpg?1",
             "name": "Choking Vines",
             "text": "Play only when blockers are declared.\nX target attacking creatures are considered blocked. Choking Vines deals 1 damage to each of those creatures.",
             "colours": [
@@ -3992,7 +3992,7 @@
         },
         {
             "id": "e85519f2-5178-5e1f-bb48-50d6251db50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a2035-59cb-426e-b2ae-45d8d6ce0bb8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c60a2035-59cb-426e-b2ae-45d8d6ce0bb8.jpg?1",
             "name": "Dense Foliage",
             "text": "Creatures cannot be the target of spells.",
             "colours": [
@@ -4023,7 +4023,7 @@
         },
         {
             "id": "98cc0e35-202e-58cb-a9d4-b088fdf4d4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4ced80-926a-4e4d-8ebd-d4fe7374a6ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab4ced80-926a-4e4d-8ebd-d4fe7374a6ad.jpg?1",
             "name": "Downdraft",
             "text": "oo\nG Target creature loses flying until end of turn.\nSacrifice Downdraft: Downdraft deals 2 damage to each creature with flying.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "ecd4eaa6-5a47-5e9d-bced-85d87e645fae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba02b6f-6010-47a4-8670-406391a52a68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba02b6f-6010-47a4-8670-406391a52a68.jpg?1",
             "name": "Fallow Wurm",
             "text": "When Fallow Wurm comes into play, choose and discard a land card or bury Fallow Wurm.",
             "colours": [
@@ -4087,7 +4087,7 @@
         },
         {
             "id": "9fca5531-df5d-5d87-9f02-0ca6a6e42ca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f993f517-999f-4ee6-8ffb-946bffdcf7fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f993f517-999f-4ee6-8ffb-946bffdcf7fe.jpg?1",
             "name": "Familiar Ground",
             "text": "Each creature you control cannot be blocked by more than one creature.",
             "colours": [
@@ -4118,7 +4118,7 @@
         },
         {
             "id": "94b9e41a-582d-5685-aefa-e82820af9a5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4336bfd1-27a4-414d-b6fe-f186a0563dc0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4336bfd1-27a4-414d-b6fe-f186a0563dc0.jpg?1",
             "name": "Fungus Elemental",
             "text": "o\nG, Sacrifice a forest: Put a +2/+2 counter on Fungus Elemental. Use this ability only if Fungus Elemental came into play this turn.",
             "colours": [
@@ -4152,7 +4152,7 @@
         },
         {
             "id": "b167e1e6-88fe-5a68-ac22-b192a946cde6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee83d511-57e0-40fb-a4db-62f6c2c39888.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee83d511-57e0-40fb-a4db-62f6c2c39888.jpg?1",
             "name": "Gaea's Blessing",
             "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nIf Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
             "colours": [
@@ -4183,7 +4183,7 @@
         },
         {
             "id": "5f805b73-8047-5015-abf5-c24793b1075f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21139d-edfc-4140-aa43-d4165331d7f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d21139d-edfc-4140-aa43-d4165331d7f3.jpg?1",
             "name": "Harvest Wurm",
             "text": "When Harvest Wurm comes into play, return any basic land card from your graveyard to your hand or bury Harvest Wurm.",
             "colours": [
@@ -4216,7 +4216,7 @@
         },
         {
             "id": "496b01f4-c990-56e7-9b81-c9f6719f3179",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff4512b-8244-4e38-bffb-0062a97d9531.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dff4512b-8244-4e38-bffb-0062a97d9531.jpg?1",
             "name": "Liege of the Hollows",
             "text": "If Liege of the Hollows is put into any graveyard from play, each player may pay any amount of mana to put that number of Squirrel tokens into play under his or her control. Treat those tokens as 1/1 green creatures.",
             "colours": [
@@ -4249,7 +4249,7 @@
         },
         {
             "id": "58cea5cf-4885-51aa-b587-d901e2cb3277",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d9bd0-7ce9-4a1e-a8b2-5c1dbb014917.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d5d9bd0-7ce9-4a1e-a8b2-5c1dbb014917.jpg?1",
             "name": "Llanowar Behemoth",
             "text": "Tap a creature you control: +1/+1 until end of turn",
             "colours": [
@@ -4282,7 +4282,7 @@
         },
         {
             "id": "c5b8f6f4-334d-55d2-9f36-218ef1408c3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffad279c-762a-42cf-ac20-f4e48734c194.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffad279c-762a-42cf-ac20-f4e48734c194.jpg?1",
             "name": "Llanowar Druid",
             "text": "oc\nT, Sacrifice Llanowar Druid: Untap all forests.",
             "colours": [
@@ -4316,7 +4316,7 @@
         },
         {
             "id": "47340e8c-4688-549e-b19c-5e41a2055d43",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37ea4b-66e2-4ad5-ae7f-d02fd59131bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f37ea4b-66e2-4ad5-ae7f-d02fd59131bd.jpg?1",
             "name": "Llanowar Sentinel",
             "text": "When Llanowar Sentinel comes into play, you may pay o1o\nG to search your library for a Llanowar Sentinel card. Put that card into play. Shuffle your library afterwards.",
             "colours": [
@@ -4349,7 +4349,7 @@
         },
         {
             "id": "497a2d54-28fc-58db-9828-553bea9546a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f65-93a1-4913-87e7-a17ebfcc7780.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9c6f65-93a1-4913-87e7-a17ebfcc7780.jpg?1",
             "name": "Mwonvuli Ooze",
             "text": "Cumulative upkeep o2\nMwonvuli Ooze has power and toughness each equal to 1 plus its last paid cumulative upkeep.",
             "colours": [
@@ -4382,7 +4382,7 @@
         },
         {
             "id": "43a0c776-1f6d-56d8-b852-4dcffd7febfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b09c44-d463-45a9-9fa2-89407c21200b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64b09c44-d463-45a9-9fa2-89407c21200b.jpg?1",
             "name": "Nature's Kiss",
             "text": "o1, Remove the top card in your graveyard from the game: Enchanted creature gets +1/+1 until end of turn.",
             "colours": [
@@ -4415,7 +4415,7 @@
         },
         {
             "id": "23f1b8eb-f404-5b7d-9592-13ce9371e1e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df9fb85-f7fa-4617-87bd-4d457c830f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2df9fb85-f7fa-4617-87bd-4d457c830f46.jpg?1",
             "name": "Nature's Resurgence",
             "text": "Each player draws a number of cards equal to the number of creature cards in his or her graveyard.",
             "colours": [
@@ -4446,7 +4446,7 @@
         },
         {
             "id": "b8c62645-ed74-5dbe-bea3-3782018191ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0274e162-33e4-4604-a6ea-51fc1a5c6a04.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0274e162-33e4-4604-a6ea-51fc1a5c6a04.jpg?1",
             "name": "Redwood Treefolk",
             "text": "",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "b3b97f21-9389-52f3-8cc2-1db9fc614dc7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b622b2f-84ad-4203-97fa-35af09e1c370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b622b2f-84ad-4203-97fa-35af09e1c370.jpg?1",
             "name": "Rogue Elephant",
             "text": "When Rogue Elephant comes into play, sacrifice a forest or bury Rogue Elephant.",
             "colours": [
@@ -4512,7 +4512,7 @@
         },
         {
             "id": "693a86d8-4a1d-5aa0-8249-4f311de5bc87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf54365-56ae-485d-b931-784a4cf9d8f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bf54365-56ae-485d-b931-784a4cf9d8f2.jpg?1",
             "name": "Striped Bears",
             "text": "When Striped Bears comes into play, draw a card.",
             "colours": [
@@ -4545,7 +4545,7 @@
         },
         {
             "id": "95c55fb2-352b-5763-b32b-cddebe7d5be1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432a6908-0ee3-45c5-9089-b7f8cf1184bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/432a6908-0ee3-45c5-9089-b7f8cf1184bb.jpg?1",
             "name": "Sylvan Hierophant",
             "text": "If Sylvan Hierophant is put into any graveyard from play, remove Sylvan Hierophant from the game, then return a creature card from your graveyard to your hand.",
             "colours": [
@@ -4579,7 +4579,7 @@
         },
         {
             "id": "b0f9f86e-d17b-55a2-859c-40e6f3ae48bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a145f2-b59d-4728-922c-9bc228451432.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a145f2-b59d-4728-922c-9bc228451432.jpg?1",
             "name": "Tranquil Grove",
             "text": "o1o\nGoo\nG Destroy all other enchantments.",
             "colours": [
@@ -4610,7 +4610,7 @@
         },
         {
             "id": "e9176a11-d1f9-5f1a-b4aa-3d8ca8f8a07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678a224-d314-4108-8a39-de0c1b635b5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3678a224-d314-4108-8a39-de0c1b635b5c.jpg?1",
             "name": "Uktabi Efreet",
             "text": "Cumulative upkeep o\nG",
             "colours": [
@@ -4643,7 +4643,7 @@
         },
         {
             "id": "f68ce1ee-36fb-5e69-a3e4-73cd738ff806",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdac36f2-99ce-4d48-90fa-aa7439778ffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdac36f2-99ce-4d48-90fa-aa7439778ffc.jpg?1",
             "name": "Veteran Explorer",
             "text": "If Veteran Explorer is put into any graveyard from play, each player may search his or her library for up to two basic land cards and put those lands into play. Each player shuffles his or her library afterwards.",
             "colours": [
@@ -4678,7 +4678,7 @@
         },
         {
             "id": "6a2a8be8-9616-50cd-996b-7676f7138f60",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ee4997-4b1a-4e03-88ac-63b451bb7b38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6ee4997-4b1a-4e03-88ac-63b451bb7b38.jpg?1",
             "name": "Vitalize",
             "text": "Untap all creatures you control.",
             "colours": [
@@ -4709,7 +4709,7 @@
         },
         {
             "id": "05004c1f-d03c-5ca0-9b0e-9a7fc77c4264",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca9c239-84ff-4527-aa23-bdb11856744c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ca9c239-84ff-4527-aa23-bdb11856744c.jpg?1",
             "name": "Bubble Matrix",
             "text": "All damage dealt to creatures is reduced to 0.",
             "colours": [],
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "7f3ac419-e560-55e4-9cdd-8fa60e8a652f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884bede-df28-42e8-9ac9-ae03118b1985.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/3884bede-df28-42e8-9ac9-ae03118b1985.jpg?1",
             "name": "B\u00f6sium Strip",
             "text": "o3, oc\nT: Until end of turn, if at any time the top card in your graveyard is an instant, interrupt, or sorcery card, you may play that card as though it were in your hand. If you do so, remove the card from the game.",
             "colours": [],
@@ -4763,7 +4763,7 @@
         },
         {
             "id": "9507a71b-0049-58cc-a0dc-b73d0f6a990b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96857c-b38e-4614-9838-cacd3700e3ee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc96857c-b38e-4614-9838-cacd3700e3ee.jpg?1",
             "name": "Chimeric Sphere",
             "text": "o2: Until end of turn, Chimeric Sphere is a 2/1 artifact creature with flying.\no2: Until end of turn, Chimeric Sphere is a 3/2 artifact creature without flying.",
             "colours": [],
@@ -4790,7 +4790,7 @@
         },
         {
             "id": "479ed27e-56a8-5694-b066-fae719a1e3ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065b4358-5dee-4f13-bff9-8254bdb92069.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/065b4358-5dee-4f13-bff9-8254bdb92069.jpg?1",
             "name": "Dingus Staff",
             "text": "Whenever a creature is put into any graveyard from play, Dingus Staff deals 2 damage to that creature's controller.",
             "colours": [],
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "0ba745fa-3873-518a-af55-1b60ea880024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51a496-1ca6-4286-bdbe-990d43196a25.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d51a496-1ca6-4286-bdbe-990d43196a25.jpg?1",
             "name": "Jabari's Banner",
             "text": "o1, oc\nT: Target creature gains flanking until end of turn. (Whenever a creature without flanking is assigned to block this creature, the blocking creature gets -1/-1 until end of turn.)",
             "colours": [],
@@ -4844,7 +4844,7 @@
         },
         {
             "id": "6371d8ed-ce7d-5056-85dc-99d0c97825e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a427b-9869-4059-aeeb-d9b97b324e4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e2a427b-9869-4059-aeeb-d9b97b324e4e.jpg?1",
             "name": "Jangling Automaton",
             "text": "If Jangling Automaton attacks, untap all creatures defending player controls.",
             "colours": [],
@@ -4874,7 +4874,7 @@
         },
         {
             "id": "621b819d-2d49-5c52-b70a-f389de18a844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c72ec90-dacc-496f-a7f5-f18bfce5eb3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c72ec90-dacc-496f-a7f5-f18bfce5eb3e.jpg?1",
             "name": "Mana Web",
             "text": "Whenever any land target opponent controls is tapped for mana, tap all lands he or she controls that can produce any type of mana that land can produce.",
             "colours": [],
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "aa06fbe5-fca7-5098-bee0-1cd431c2352a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162e81d3-6cd4-4cb8-8ed8-cfbd8d34ca71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/162e81d3-6cd4-4cb8-8ed8-cfbd8d34ca71.jpg?1",
             "name": "Mind Stone",
             "text": "oc\nT: Add one colorless mana to your mana pool. Play this ability as a mana source.\no1, oc\nT, Sacrifice Mind Stone: Draw a card.",
             "colours": [],
@@ -4928,7 +4928,7 @@
         },
         {
             "id": "8453c949-7d44-50cf-8fe8-8940d1ba746a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc45f2cb-c256-4a0f-879a-c7db5b1a0b94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc45f2cb-c256-4a0f-879a-c7db5b1a0b94.jpg?1",
             "name": "Null Rod",
             "text": "Players cannot play any artifact abilities requiring an activation cost.",
             "colours": [],
@@ -4955,7 +4955,7 @@
         },
         {
             "id": "e44019e8-6d96-50b3-badc-c5d63b328267",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98bca31-8c05-430b-b5d7-331bdc55710a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e98bca31-8c05-430b-b5d7-331bdc55710a.jpg?1",
             "name": "Phyrexian Furnace",
             "text": "oc\nT: Remove the bottom card of target player's graveyard from the game.\no1, Sacrifice Phyrexian Furnace: Remove target card in any graveyard from the game and draw a card.",
             "colours": [],
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "39f6986c-f779-552a-bd52-84f2e3209c63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c449126c-ac01-4a90-b967-8c3ad112091b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c449126c-ac01-4a90-b967-8c3ad112091b.jpg?1",
             "name": "Serrated Biskelion",
             "text": "oc\nT: Put a -1/-1 counter on Serrated Biskelion and a -1/-1 counter on target creature.",
             "colours": [],
@@ -5012,7 +5012,7 @@
         },
         {
             "id": "90adb877-f20e-5221-adf5-1f0a02dfa14b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa927e0-5a65-4ac1-8eca-c000bb8080e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9aa927e0-5a65-4ac1-8eca-c000bb8080e7.jpg?1",
             "name": "Steel Golem",
             "text": "You cannot play summon or artifact creature spells.",
             "colours": [],
@@ -5042,7 +5042,7 @@
         },
         {
             "id": "80049fdd-a93b-517b-91d4-2606f11ccd4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d62479-92ac-43e2-a3d3-b41dfe0fbb20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43d62479-92ac-43e2-a3d3-b41dfe0fbb20.jpg?1",
             "name": "Straw Golem",
             "text": "If any opponent successfully casts a summon or artifact creature spell, bury Straw Golem.",
             "colours": [],
@@ -5072,7 +5072,7 @@
         },
         {
             "id": "23bb3494-e1ce-566b-8aa2-c88374761c92",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c9691b-bee8-4251-8275-5f6ba14a8ecd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9c9691b-bee8-4251-8275-5f6ba14a8ecd.jpg?1",
             "name": "Thran Forge",
             "text": "o2: Until end of turn, target nonartifact creature gets +1/+0 and is an artifact creature.",
             "colours": [],
@@ -5099,7 +5099,7 @@
         },
         {
             "id": "ee5a608e-8e75-581f-8c23-aca781d81546",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63db7360-fe6e-430f-bfee-a2f80bcb6fec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63db7360-fe6e-430f-bfee-a2f80bcb6fec.jpg?1",
             "name": "Thran Tome",
             "text": "o5, oc\nT: Reveal the top three cards of your library to target opponent. Bury one of those cards of that opponent's choice. Draw the remaining cards.",
             "colours": [],
@@ -5126,7 +5126,7 @@
         },
         {
             "id": "062a76f1-f489-5a9b-8c65-1635145c8f0b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923afe8a-e82c-4b93-bb42-8f5073acae13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/923afe8a-e82c-4b93-bb42-8f5073acae13.jpg?1",
             "name": "Touchstone",
             "text": "oc\nT: Tap target artifact you do not control.",
             "colours": [],
@@ -5153,7 +5153,7 @@
         },
         {
             "id": "0bf9ea17-d141-5652-818a-76c25483b4b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5184b967-f474-4c9b-9a20-65ddb0d6e4f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/5184b967-f474-4c9b-9a20-65ddb0d6e4f8.jpg?1",
             "name": "Well of Knowledge",
             "text": "Any player may pay o2 during his or her draw phase to draw a card. Players may use this ability as many times as they choose.",
             "colours": [],
@@ -5180,7 +5180,7 @@
         },
         {
             "id": "ec5174db-aab9-546d-8967-2f05162ccd4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8becb285-cd91-4de0-af59-ddaa7d8c5366.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8becb285-cd91-4de0-af59-ddaa7d8c5366.jpg?1",
             "name": "Xanthic Statue",
             "text": "o5: Until end of turn, Xanthic Statue is an 8/8 artifact creature with trample.",
             "colours": [],
@@ -5207,7 +5207,7 @@
         },
         {
             "id": "38d0f073-95d5-514d-8fe8-21e04aaecfd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09507f7f-c58f-4f57-b878-b39811a5b619.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09507f7f-c58f-4f57-b878-b39811a5b619.jpg?1",
             "name": "Gemstone Mine",
             "text": "When Gemstone Mine comes into play, put three mining counters on it.\noc\nT, Remove a mining counter from Gemstone Mine: Add one mana of any color to your mana pool. If there are no mining counters on Gemstone Mine, bury it.",
             "colours": [],
@@ -5234,7 +5234,7 @@
         },
         {
             "id": "344ab473-e5d3-57ed-9ec4-96d91abcc680",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5cd12a-2a07-44a8-8eac-de00d26fe9e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2e5cd12a-2a07-44a8-8eac-de00d26fe9e3.jpg?1",
             "name": "Lotus Vale",
             "text": "When Lotus Vale comes into play, sacrifice two untapped lands or bury Lotus Vale.\noc\nT: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -5261,7 +5261,7 @@
         },
         {
             "id": "9733a606-9856-5077-a0fa-27d52dad1d80",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4e843-937c-47fb-8768-0f42c5cb4e4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75a4e843-937c-47fb-8768-0f42c5cb4e4f.jpg?1",
             "name": "Scorched Ruins",
             "text": "When Scorched Ruins comes into play, sacrifice two untapped lands or bury Scorched Ruins.\noc\nT: Add four colorless mana to your mana pool.",
             "colours": [],
@@ -5288,7 +5288,7 @@
         },
         {
             "id": "675ce267-e99d-523e-8722-402debaa9717",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26672a8-f4ff-4c64-bb3e-f5072bbc9e3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f26672a8-f4ff-4c64-bb3e-f5072bbc9e3e.jpg?1",
             "name": "Winding Canyons",
             "text": "oc\nT: Add one colorless mana to your mana pool.\no2, oc\nT: Until end of turn, you may play creature cards whenever you could play instants.",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/WWK.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/WWK.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "c4c30137-bb7f-5d54-b9bd-d98e7ed1c161",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feddbd0-3d29-4428-b70d-107c1e26930d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5feddbd0-3d29-4428-b70d-107c1e26930d.jpg?1",
             "name": "Admonition Angel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may exile target nonland permanent other than Admonition Angel.\nWhen Admonition Angel leaves the battlefield, return all cards exiled with it to the battlefield under their owners' control.",
             "colours": [
@@ -38,7 +38,7 @@
         },
         {
             "id": "fece374b-77c5-5d4a-8700-4f0b235d553d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f038f0-6f50-4f89-855c-6bbd68d84436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9f038f0-6f50-4f89-855c-6bbd68d84436.jpg?1",
             "name": "Apex Hawks",
             "text": "Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nFlying\nApex Hawks enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -72,7 +72,7 @@
         },
         {
             "id": "87f62994-3bf2-5b27-b92a-04fbb03eae85",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7dfcf6-c41b-48d6-a3b4-4b4a7bed82eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f7dfcf6-c41b-48d6-a3b4-4b4a7bed82eb.jpg?1",
             "name": "Archon of Redemption",
             "text": "Flying\nWhenever Archon of Redemption or another creature with flying enters the battlefield under your control, you may gain life equal to that creature's power.",
             "colours": [
@@ -106,7 +106,7 @@
         },
         {
             "id": "1ce74470-c2cf-58d9-9d27-02ca5256b821",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f540b83-67fd-4630-a461-69bc84b88ed3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f540b83-67fd-4630-a461-69bc84b88ed3.jpg?1",
             "name": "Battle Hurda",
             "text": "First strike",
             "colours": [
@@ -140,7 +140,7 @@
         },
         {
             "id": "2dfb1f15-09ae-5f52-8a4d-d5cad1e2a75e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1739550d-3bd8-421b-b2a9-95dd3bff2ce2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1739550d-3bd8-421b-b2a9-95dd3bff2ce2.jpg?1",
             "name": "Fledgling Griffin",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Fledgling Griffin gains flying until end of turn.",
             "colours": [
@@ -174,7 +174,7 @@
         },
         {
             "id": "b2cc6529-70c3-517b-ba23-d407fa51ed63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20b710-6d09-4080-acd5-e88ad98460a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc20b710-6d09-4080-acd5-e88ad98460a9.jpg?1",
             "name": "Guardian Zendikon",
             "text": "Enchant land\nEnchanted land is a 2/6 white Wall creature with defender. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -208,7 +208,7 @@
         },
         {
             "id": "67d48853-391c-56d7-8f35-f9867b4ce4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22700453-e1aa-43d1-9b51-cda8a37fc00d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/22700453-e1aa-43d1-9b51-cda8a37fc00d.jpg?1",
             "name": "Hada Freeblade",
             "text": "Whenever Hada Freeblade or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Hada Freeblade.",
             "colours": [
@@ -244,7 +244,7 @@
         },
         {
             "id": "49e7b289-44dc-5299-bd97-77d711e99aff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2c308c-e681-4eba-8b62-bcc95f1e8548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c2c308c-e681-4eba-8b62-bcc95f1e8548.jpg?1",
             "name": "Iona's Judgment",
             "text": "Exile target creature or enchantment.",
             "colours": [
@@ -276,7 +276,7 @@
         },
         {
             "id": "463b2a37-ef0a-5c44-8ecf-323b1c758b45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27e2eb4-d48b-43c3-bd19-e1748f310c54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e27e2eb4-d48b-43c3-bd19-e1748f310c54.jpg?1",
             "name": "Join the Ranks",
             "text": "Put two 1/1 white Soldier Ally creature tokens onto the battlefield.",
             "colours": [
@@ -308,7 +308,7 @@
         },
         {
             "id": "563c0af6-d47f-5c11-90f0-1700491329b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e2315e-41d9-4e46-bee4-c8f92e91e2a9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88e2315e-41d9-4e46-bee4-c8f92e91e2a9.jpg?1",
             "name": "Kitesail Apprentice",
             "text": "As long as Kitesail Apprentice is equipped, it gets +1/+1 and has flying.",
             "colours": [
@@ -343,7 +343,7 @@
         },
         {
             "id": "ce60a1d7-443d-5acb-9b15-8f1b91e8a062",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3b88ad-9d65-4873-8527-8f420570aad3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc3b88ad-9d65-4873-8527-8f420570aad3.jpg?1",
             "name": "Kor Firewalker",
             "text": "Protection from red\nWhenever a player casts a red spell, you may gain 1 life.",
             "colours": [
@@ -378,7 +378,7 @@
         },
         {
             "id": "b95ddf82-4726-59ba-8aca-fa8da7bbc151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d0234f-d712-4ac3-bd3b-10f9c530e167.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79d0234f-d712-4ac3-bd3b-10f9c530e167.jpg?1",
             "name": "Lightkeeper of Emeria",
             "text": "Multikicker {W} (You may pay an additional {W} any number of times as you cast this spell.)\nFlying\nWhen Lightkeeper of Emeria enters the battlefield, you gain 2 life for each time it was kicked.",
             "colours": [
@@ -412,7 +412,7 @@
         },
         {
             "id": "0a320645-87c5-581f-9501-5b6007d06b89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbb5f-6cb4-4971-b159-ee5f875ba260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4edfbb5f-6cb4-4971-b159-ee5f875ba260.jpg?1",
             "name": "Loam Lion",
             "text": "Loam Lion gets +1/+2 as long as you control a Forest.",
             "colours": [
@@ -446,7 +446,7 @@
         },
         {
             "id": "d385f53b-ef4c-5310-9107-9b8f04b8d2b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0c439a-25e4-4ff7-8080-b3be59d5dbe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b0c439a-25e4-4ff7-8080-b3be59d5dbe6.jpg?1",
             "name": "Marsh Threader",
             "text": "Swampwalk",
             "colours": [
@@ -481,7 +481,7 @@
         },
         {
             "id": "ead550f5-f1b8-56ec-9a16-09aca2e17501",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38b1b7a-2f20-4a82-b143-7aeafc686dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f38b1b7a-2f20-4a82-b143-7aeafc686dee.jpg?1",
             "name": "Marshal's Anthem",
             "text": "Multikicker {1}{W} (You may pay an additional {1}{W} any number of times as you cast this spell.)\nCreatures you control get +1/+1.\nWhen Marshal's Anthem enters the battlefield, return up to X target creature cards from your graveyard to the battlefield, where X is the number of times Marshal's Anthem was kicked.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "3061388d-03aa-5c2f-8548-dc58c75292dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e532309-5cf9-4d12-b673-f9baad30b800.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e532309-5cf9-4d12-b673-f9baad30b800.jpg?1",
             "name": "Perimeter Captain",
             "text": "Defender\nWhenever a creature you control with defender blocks, you may gain 2 life.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "c790eafd-cf9f-5f61-8fd5-a0da4cebf935",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdceb36-fd36-4315-8ebe-9b8fc3777428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcdceb36-fd36-4315-8ebe-9b8fc3777428.jpg?1",
             "name": "Refraction Trap",
             "text": "If an opponent cast a red instant or sorcery spell this turn, you may pay {W} rather than pay Refraction Trap's mana cost.\nPrevent the next 3 damage that a source of your choice would deal to you and/or permanents you control this turn. If damage is prevented this way, Refraction Trap deals that much damage to target creature or player.",
             "colours": [
@@ -582,7 +582,7 @@
         },
         {
             "id": "3325f013-5260-535a-8e69-bea31aa34e56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eb8537-42c9-41d5-be0a-1186bc8dee0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75eb8537-42c9-41d5-be0a-1186bc8dee0b.jpg?1",
             "name": "Rest for the Weary",
             "text": "Target player gains 4 life.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that player gains 8 life instead.",
             "colours": [
@@ -614,7 +614,7 @@
         },
         {
             "id": "d79a1cd0-8507-596b-9b3e-6dce56ba1c57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b60f10-0997-46ec-8914-f5cdde76cf75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0b60f10-0997-46ec-8914-f5cdde76cf75.jpg?1",
             "name": "Ruin Ghost",
             "text": "{W}, {T}: Exile target land you control, then return it to the battlefield under your control.",
             "colours": [
@@ -648,7 +648,7 @@
         },
         {
             "id": "42a128a8-aa5d-5aac-aaf1-cb2fc7702368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19557351-b65f-4b04-b971-66abdc07000a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19557351-b65f-4b04-b971-66abdc07000a.jpg?1",
             "name": "Stoneforge Mystic",
             "text": "When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.\n{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
             "colours": [
@@ -683,7 +683,7 @@
         },
         {
             "id": "15857090-ea13-5df0-a6b9-d9275e69c068",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5212f4-f04c-4ca3-b254-654bb263829b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f5212f4-f04c-4ca3-b254-654bb263829b.jpg?1",
             "name": "Talus Paladin",
             "text": "Whenever Talus Paladin or another Ally enters the battlefield under your control, you may have Allies you control gain lifelink until end of turn, and you may put a +1/+1 counter on Talus Paladin.",
             "colours": [
@@ -719,7 +719,7 @@
         },
         {
             "id": "a94c032a-10d1-5fa8-bd98-2bb7f878cbab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bad0759-4132-42b5-9a26-0fcf321a60e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bad0759-4132-42b5-9a26-0fcf321a60e0.jpg?1",
             "name": "Terra Eternal",
             "text": "All lands are indestructible.",
             "colours": [
@@ -751,7 +751,7 @@
         },
         {
             "id": "b82489f2-47cb-5f71-9cf9-010919a7bba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f220b-f860-4ebb-a424-22598bdd6fae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/783f220b-f860-4ebb-a424-22598bdd6fae.jpg?1",
             "name": "Veteran's Reflexes",
             "text": "Target creature gets +1/+1 until end of turn. Untap that creature.",
             "colours": [
@@ -783,7 +783,7 @@
         },
         {
             "id": "7eacf37b-0921-567b-9f8e-e6bfafaa098b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f31a77-a4a9-4783-8885-c44552379ae6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99f31a77-a4a9-4783-8885-c44552379ae6.jpg?1",
             "name": "Aether Tradewinds",
             "text": "Return target permanent you control and target permanent you don't control to their owners' hands.",
             "colours": [
@@ -815,7 +815,7 @@
         },
         {
             "id": "88cca0ba-0e63-5e49-8bf6-2b13d1f5cdbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec0c914-1188-45c9-a68c-c3b915dbebf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec0c914-1188-45c9-a68c-c3b915dbebf7.jpg?1",
             "name": "Calcite Snapper",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may switch Calcite Snapper's power and toughness until end of turn.",
             "colours": [
@@ -849,7 +849,7 @@
         },
         {
             "id": "19ec5137-4148-50be-8166-dfc4d2106c13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f178d0cc-5dd1-41ab-a2e8-218ece6f2a86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f178d0cc-5dd1-41ab-a2e8-218ece6f2a86.jpg?1",
             "name": "Dispel",
             "text": "Counter target instant spell.",
             "colours": [
@@ -881,7 +881,7 @@
         },
         {
             "id": "3e1d7823-11e2-5968-8941-33777109e6d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af0ef2e-4273-432a-8d03-3480165f1be7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5af0ef2e-4273-432a-8d03-3480165f1be7.jpg?1",
             "name": "Enclave Elite",
             "text": "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\nIslandwalk\nEnclave Elite enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -916,7 +916,7 @@
         },
         {
             "id": "16775cf9-7bbe-5a45-80f8-e312a8eea9a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a792b-ad04-4892-92d9-0f6abe3759e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/864a792b-ad04-4892-92d9-0f6abe3759e8.jpg?1",
             "name": "Goliath Sphinx",
             "text": "Flying",
             "colours": [
@@ -950,7 +950,7 @@
         },
         {
             "id": "1a49b151-d274-5559-a87e-333f2d7ad587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147dce7-b2dd-426a-9ff7-843d50bb8b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d147dce7-b2dd-426a-9ff7-843d50bb8b01.jpg?1",
             "name": "Halimar Excavator",
             "text": "Whenever Halimar Excavator or another Ally enters the battlefield under your control, target player puts the top X cards of his or her library into his or her graveyard, where X is the number of Allies you control.",
             "colours": [
@@ -986,7 +986,7 @@
         },
         {
             "id": "2c5db1e7-9779-5f61-9384-1c1715616093",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022f07c5-c644-41cd-9434-a57068f73ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/022f07c5-c644-41cd-9434-a57068f73ab2.jpg?1",
             "name": "Horizon Drake",
             "text": "Flying, protection from lands",
             "colours": [
@@ -1020,7 +1020,7 @@
         },
         {
             "id": "635f9f1e-4ea0-50d4-8f8b-0dd6b0d609b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e606072-a3aa-4300-ba90-ec92a721fa76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/e/0e606072-a3aa-4300-ba90-ec92a721fa76.jpg?1",
             "name": "Jace, the Mind Sculptor",
             "text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n-1: Return target creature to its owner's hand.\n-12: Exile all cards from target player's library, then that player shuffles his or her hand into his or her library.",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "805e5277-8346-5fa8-833b-dad4566b3881",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587f91f6-b46e-4dd5-a86d-1048054dd3c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/587f91f6-b46e-4dd5-a86d-1048054dd3c0.jpg?1",
             "name": "Jwari Shapeshifter",
             "text": "You may have Jwari Shapeshifter enter the battlefield as a copy of any Ally creature on the battlefield.",
             "colours": [
@@ -1091,7 +1091,7 @@
         },
         {
             "id": "a9ea12f6-adfc-5abe-a8be-e71429d02d75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1907b1e9-ae1e-43fb-9033-3c4322277fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1907b1e9-ae1e-43fb-9033-3c4322277fff.jpg?1",
             "name": "Mysteries of the Deep",
             "text": "Draw two cards.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, draw three cards instead.",
             "colours": [
@@ -1123,7 +1123,7 @@
         },
         {
             "id": "4436145d-3ba0-5e4b-972f-c2e5e760b6b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b6dc43-62d3-4572-a2e1-b0e67dcc21c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03b6dc43-62d3-4572-a2e1-b0e67dcc21c7.jpg?1",
             "name": "Permafrost Trap",
             "text": "If an opponent had a green creature enter the battlefield under his or her control this turn, you may pay {U} rather than pay Permafrost Trap's mana cost.\nTap up to two target creatures. Those creatures don't untap during their controller's next untap step.",
             "colours": [
@@ -1157,7 +1157,7 @@
         },
         {
             "id": "0dbb20da-58bf-5e7b-95e7-e0f8d8a26f97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77983bbf-6761-4126-82b4-bdcdd6b8e1dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77983bbf-6761-4126-82b4-bdcdd6b8e1dc.jpg?1",
             "name": "Quest for Ula's Temple",
             "text": "At the beginning of your upkeep, you may look at the top card of your library. If it's a creature card, you may reveal it and put a quest counter on Quest for Ula's Temple.\nAt the beginning of each end step, if there are three or more quest counters on Quest for Ula's Temple, you may put a Kraken, Leviathan, Octopus, or Serpent creature card from your hand onto the battlefield.",
             "colours": [
@@ -1189,7 +1189,7 @@
         },
         {
             "id": "32b473f1-e135-5f81-9020-29856aa7771b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae04d82-56f5-4c72-b1c1-40c7d9640b7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae04d82-56f5-4c72-b1c1-40c7d9640b7c.jpg?1",
             "name": "Sejiri Merfolk",
             "text": "As long as you control a Plains, Sejiri Merfolk has first strike and lifelink. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
             "colours": [
@@ -1224,7 +1224,7 @@
         },
         {
             "id": "091c88e3-0ea6-5d37-b3f7-7fa01e86da5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555063cc-99ad-4014-b17b-c4c6b40d2e81.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/555063cc-99ad-4014-b17b-c4c6b40d2e81.jpg?1",
             "name": "Selective Memory",
             "text": "Search your library for any number of nonland cards and exile them. Then shuffle your library.",
             "colours": [
@@ -1256,7 +1256,7 @@
         },
         {
             "id": "b4d21b75-a035-5d04-8919-e7c57b789a59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b748d8b-898f-4b55-bc33-f5bbbc823c45.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b748d8b-898f-4b55-bc33-f5bbbc823c45.jpg?1",
             "name": "Spell Contortion",
             "text": "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\nCounter target spell unless its controller pays {2}. Draw a card for each time Spell Contortion was kicked.",
             "colours": [
@@ -1288,7 +1288,7 @@
         },
         {
             "id": "922727f0-34db-5fa7-9b27-2623b1a0764f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ec4dc0-09ae-437d-a7d6-cb27c2cb7590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88ec4dc0-09ae-437d-a7d6-cb27c2cb7590.jpg?1",
             "name": "Surrakar Banisher",
             "text": "When Surrakar Banisher enters the battlefield, you may return target tapped creature to its owner's hand.",
             "colours": [
@@ -1322,7 +1322,7 @@
         },
         {
             "id": "6141938d-9bf0-5fa3-bc2f-0b6a7d439b29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcbeab-7a1e-4dcf-99bf-98f42c2b6a6f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bfcbeab-7a1e-4dcf-99bf-98f42c2b6a6f.jpg?1",
             "name": "Thada Adel, Acquisitor",
             "text": "Islandwalk\nWhenever Thada Adel, Acquisitor deals combat damage to a player, search that player's library for an artifact card and exile it. Then that player shuffles his or her library. Until end of turn, you may play that card.",
             "colours": [
@@ -1359,7 +1359,7 @@
         },
         {
             "id": "8433ff54-3ce4-5fcc-8c7c-928c89e82fee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23e758d-c9a4-4f8e-b366-634f8c451b61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f23e758d-c9a4-4f8e-b366-634f8c451b61.jpg?1",
             "name": "Tideforce Elemental",
             "text": "{U}, {T}: You may tap or untap another target creature.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may untap Tideforce Elemental.",
             "colours": [
@@ -1393,7 +1393,7 @@
         },
         {
             "id": "ebbb1e8b-94e6-522e-8e7b-bcf356600a0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce73b174-2448-4914-bca3-70564191da16.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce73b174-2448-4914-bca3-70564191da16.jpg?1",
             "name": "Treasure Hunt",
             "text": "Reveal cards from the top of your library until you reveal a nonland card, then put all cards revealed this way into your hand.",
             "colours": [
@@ -1425,7 +1425,7 @@
         },
         {
             "id": "19f79314-cc01-5541-8cf9-a24d18397a13",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267f18b9-efe7-4ff4-9932-7fbb3cfe5436.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/267f18b9-efe7-4ff4-9932-7fbb3cfe5436.jpg?1",
             "name": "Twitch",
             "text": "You may tap or untap target artifact, creature, or land.\nDraw a card.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "5253de9f-cfad-58b5-af74-0fdee0562579",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09358e-099a-4115-807e-48ceb024d186.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf09358e-099a-4115-807e-48ceb024d186.jpg?1",
             "name": "Vapor Snare",
             "text": "Enchant creature\nYou control enchanted creature.\nAt the beginning of your upkeep, sacrifice Vapor Snare unless you return a land you control to its owner's hand.",
             "colours": [
@@ -1491,7 +1491,7 @@
         },
         {
             "id": "cf855559-65a3-5997-a64a-f3ca349095ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6fb960-58cb-42db-975f-fd9329e852fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6fb960-58cb-42db-975f-fd9329e852fd.jpg?1",
             "name": "Voyager Drake",
             "text": "Multikicker {U} (You may pay an additional {U} any number of times as you cast this spell.)\nFlying\nWhen Voyager Drake enters the battlefield, up to X target creatures gain flying until end of turn, where X is the number of times Voyager Drake was kicked.",
             "colours": [
@@ -1525,7 +1525,7 @@
         },
         {
             "id": "a9ca4c7d-f227-59d6-9281-c8bc2cedbd6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaae63e-6269-4aca-aa45-956f6bf4e112.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbaae63e-6269-4aca-aa45-956f6bf4e112.jpg?1",
             "name": "Wind Zendikon",
             "text": "Enchant land\nEnchanted land is a 2/2 blue Elemental creature with flying. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -1559,7 +1559,7 @@
         },
         {
             "id": "727c5cb9-f943-5885-9a79-7ee8a32d7a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee68b52-6377-419b-b772-2af1e57cbe5d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aee68b52-6377-419b-b772-2af1e57cbe5d.jpg?1",
             "name": "Abyssal Persecutor",
             "text": "Flying, trample\nYou can't win the game and your opponents can't lose the game.",
             "colours": [
@@ -1593,7 +1593,7 @@
         },
         {
             "id": "acf25960-685d-5797-b77b-21f49337993a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c592ef76-d612-4cfe-b906-0e63c44d36f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c592ef76-d612-4cfe-b906-0e63c44d36f8.jpg?1",
             "name": "Agadeem Occultist",
             "text": "{T}: Put target creature card from an opponent's graveyard onto the battlefield under your control if its converted mana cost is less than or equal to the number of Allies you control.",
             "colours": [
@@ -1629,7 +1629,7 @@
         },
         {
             "id": "82e5f4e3-23ef-530f-96cb-d2be70d008da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b247681-1cf6-42a0-ad44-76261c690596.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b247681-1cf6-42a0-ad44-76261c690596.jpg?1",
             "name": "Anowon, the Ruin Sage",
             "text": "At the beginning of your upkeep, each player sacrifices a non-Vampire creature.",
             "colours": [
@@ -1666,7 +1666,7 @@
         },
         {
             "id": "477b2c97-c304-51bc-b704-7ea6a67611af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5445e2-1fa8-4c66-b441-892a76675810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b5445e2-1fa8-4c66-b441-892a76675810.jpg?1",
             "name": "Bloodhusk Ritualist",
             "text": "Multikicker {B} (You may pay an additional {B} any number of times as you cast this spell.)\nWhen Bloodhusk Ritualist enters the battlefield, target opponent discards a card for each time it was kicked.",
             "colours": [
@@ -1701,7 +1701,7 @@
         },
         {
             "id": "9f5eaa1a-3bcc-5ba2-b1d4-780a2c907726",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e0aa67-0ea9-4c50-8297-369ab486fd0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33e0aa67-0ea9-4c50-8297-369ab486fd0f.jpg?1",
             "name": "Bojuka Brigand",
             "text": "Bojuka Brigand can't block.\nWhenever Bojuka Brigand or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Bojuka Brigand.",
             "colours": [
@@ -1737,7 +1737,7 @@
         },
         {
             "id": "c02a7b76-81e5-518c-b044-c60b5fd0f3ae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c841c3e-e0d1-49d7-bcec-3c45f73c13c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c841c3e-e0d1-49d7-bcec-3c45f73c13c5.jpg?1",
             "name": "Brink of Disaster",
             "text": "Enchant creature or land\nWhen enchanted permanent becomes tapped, destroy it.",
             "colours": [
@@ -1771,7 +1771,7 @@
         },
         {
             "id": "6e272c6a-d49b-5e74-aa59-905a6d1bc571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73131341-0fde-4eca-aefa-ce69c933af07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73131341-0fde-4eca-aefa-ce69c933af07.jpg?1",
             "name": "Butcher of Malakir",
             "text": "Flying\nWhenever Butcher of Malakir or another creature you control is put into a graveyard from the battlefield, each opponent sacrifices a creature.",
             "colours": [
@@ -1806,7 +1806,7 @@
         },
         {
             "id": "b6b88afc-be90-56ee-ac0c-f345e0c1e46e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80076580-23f1-4008-ab91-9dad8c806cfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80076580-23f1-4008-ab91-9dad8c806cfa.jpg?1",
             "name": "Caustic Crawler",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have target creature get -1/-1 until end of turn.",
             "colours": [
@@ -1840,7 +1840,7 @@
         },
         {
             "id": "1e1bdd58-94c1-5098-91f5-92ba9ea44a8b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce7d93d-3998-4486-b277-e4f91f6e3feb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0ce7d93d-3998-4486-b277-e4f91f6e3feb.jpg?1",
             "name": "Corrupted Zendikon",
             "text": "Enchant land\nEnchanted land is a 3/3 black Ooze creature. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -1874,7 +1874,7 @@
         },
         {
             "id": "3c8755d7-9029-5e21-9de7-f72603fac77c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad16a3b8-e99e-47ed-92ce-ef42310f9f46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad16a3b8-e99e-47ed-92ce-ef42310f9f46.jpg?1",
             "name": "Dead Reckoning",
             "text": "You may put target creature card from your graveyard on top of your library. If you do, Dead Reckoning deals damage equal to that card's power to target creature.",
             "colours": [
@@ -1906,7 +1906,7 @@
         },
         {
             "id": "6d14524d-c088-5505-9403-7d7e8cf90070",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e040c3-bf42-4a5b-aeb3-5dc9921151e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e040c3-bf42-4a5b-aeb3-5dc9921151e5.jpg?1",
             "name": "Death's Shadow",
             "text": "Death's Shadow gets -X/-X, where X is your life total.",
             "colours": [
@@ -1940,7 +1940,7 @@
         },
         {
             "id": "484f855b-033a-5ef6-a1a6-882a1f97cb4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4e933b-de65-4089-877f-c598004b8e7e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd4e933b-de65-4089-877f-c598004b8e7e.jpg?1",
             "name": "Jagwasp Swarm",
             "text": "Flying",
             "colours": [
@@ -1974,7 +1974,7 @@
         },
         {
             "id": "85a85d88-54d0-54b6-a1ae-3a46e65bcf2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1efd1dd-903c-47a0-b746-5571a3ea1755.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1efd1dd-903c-47a0-b746-5571a3ea1755.jpg?1",
             "name": "Kalastria Highborn",
             "text": "Whenever Kalastria Highborn or another Vampire you control is put into a graveyard from the battlefield, you may pay {B}. If you do, target player loses 2 life and you gain 2 life.",
             "colours": [
@@ -2009,7 +2009,7 @@
         },
         {
             "id": "f2cec1fb-02f3-5202-bf3e-26f299bd22d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6976c2-f2a0-4993-a428-9469ada5ca37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d6976c2-f2a0-4993-a428-9469ada5ca37.jpg?1",
             "name": "Mire's Toll",
             "text": "Target player reveals a number of cards from his or her hand equal to the number of Swamps you control. You choose one of them. That player discards that card.",
             "colours": [
@@ -2041,7 +2041,7 @@
         },
         {
             "id": "20bd9b73-8f79-5da7-bbab-f10773cca8c2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a9f5cb-3139-4c6e-a2d4-69e1659b8db2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20a9f5cb-3139-4c6e-a2d4-69e1659b8db2.jpg?1",
             "name": "Nemesis Trap",
             "text": "If a white creature is attacking, you may pay {B}{B} rather than pay Nemesis Trap's mana cost.\nExile target attacking creature. Put a creature token that's a copy of that creature onto the battlefield. Exile it at the beginning of the next end step.",
             "colours": [
@@ -2075,7 +2075,7 @@
         },
         {
             "id": "01e5971c-1fe4-5b35-b923-40c2421fbce1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4604a63c-ebe0-420f-968e-3ffc7641ce22.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/4604a63c-ebe0-420f-968e-3ffc7641ce22.jpg?1",
             "name": "Pulse Tracker",
             "text": "Whenever Pulse Tracker attacks, each opponent loses 1 life.",
             "colours": [
@@ -2110,7 +2110,7 @@
         },
         {
             "id": "947249c6-668d-570b-9baa-7812135ce749",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f0220f-6120-433a-b37f-f655f25322c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6f0220f-6120-433a-b37f-f655f25322c5.jpg?1",
             "name": "Quag Vampires",
             "text": "Multikicker {1}{B} (You may pay an additional {1}{B} any number of times as you cast this spell.)\nSwampwalk\nQuag Vampires enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -2145,7 +2145,7 @@
         },
         {
             "id": "505682ec-c30d-5d46-9b4d-801f86a92836",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c604a567-71dd-47d9-ae5d-b87b4db98df4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c604a567-71dd-47d9-ae5d-b87b4db98df4.jpg?1",
             "name": "Quest for the Nihil Stone",
             "text": "Whenever an opponent discards a card, you may put a quest counter on Quest for the Nihil Stone.\nAt the beginning of each opponent's upkeep, if that player has no cards in hand and Quest for the Nihil Stone has two or more quest counters on it, you may have that player lose 5 life.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "ee8912c0-6f63-5b01-b388-d49591413f0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da2dc92-0352-4757-8249-67f08a2464d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1da2dc92-0352-4757-8249-67f08a2464d1.jpg?1",
             "name": "Ruthless Cullblade",
             "text": "Ruthless Cullblade gets +2/+1 as long as an opponent has 10 or less life.",
             "colours": [
@@ -2212,7 +2212,7 @@
         },
         {
             "id": "95798fc2-76ed-531b-93cd-e5dd9607ab19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4170ddd3-53bd-4ec7-82c0-4fb48f400aa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/4170ddd3-53bd-4ec7-82c0-4fb48f400aa5.jpg?1",
             "name": "Scrib Nibblers",
             "text": "{T}: Exile the top card of target player's library. If it's a land card, you gain 1 life.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may untap Scrib Nibblers.",
             "colours": [
@@ -2246,7 +2246,7 @@
         },
         {
             "id": "dcfc85a9-b87a-5636-9057-00a2c3279b34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d87345-9f89-4b65-ae9c-a0f46b1e9f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17d87345-9f89-4b65-ae9c-a0f46b1e9f31.jpg?1",
             "name": "Shoreline Salvager",
             "text": "Whenever Shoreline Salvager deals combat damage to a player, if you control an Island, you may draw a card.",
             "colours": [
@@ -2280,7 +2280,7 @@
         },
         {
             "id": "d0db8e8d-9257-5516-81b5-9bcc241c6424",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b4deea-c077-46ab-898f-41b3907ecf33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09b4deea-c077-46ab-898f-41b3907ecf33.jpg?1",
             "name": "Smother",
             "text": "Destroy target creature with converted mana cost 3 or less. It can't be regenerated.",
             "colours": [
@@ -2312,7 +2312,7 @@
         },
         {
             "id": "418fe18d-007a-52fa-a490-05d56e1efa6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beaaa66-0dae-4631-895d-06570834ba7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9beaaa66-0dae-4631-895d-06570834ba7c.jpg?1",
             "name": "Tomb Hex",
             "text": "Target creature gets -2/-2 until end of turn.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that creature gets -4/-4 until end of turn instead.",
             "colours": [
@@ -2344,7 +2344,7 @@
         },
         {
             "id": "71191575-3405-5c75-a88d-0cd03b9631ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b388d4d9-62b6-4174-897e-f933a4badcf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b388d4d9-62b6-4174-897e-f933a4badcf9.jpg?1",
             "name": "Urge to Feed",
             "text": "Target creature gets -3/-3 until end of turn. You may tap any number of untapped Vampire creatures you control. If you do, put a +1/+1 counter on each of those Vampires.",
             "colours": [
@@ -2376,7 +2376,7 @@
         },
         {
             "id": "a2bc3620-557a-54ac-8bb4-95d6bc2d3289",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031950b6-110f-4e20-b31b-afe5ffdd6086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/031950b6-110f-4e20-b31b-afe5ffdd6086.jpg?1",
             "name": "Akoum Battlesinger",
             "text": "Haste\nWhenever Akoum Battlesinger or another Ally enters the battlefield under your control, you may have Ally creatures you control get +1/+0 until end of turn.",
             "colours": [
@@ -2412,7 +2412,7 @@
         },
         {
             "id": "f2db73e3-7236-578c-b4e2-22be6c058ae9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ef13-a363-4cab-b69d-39093a621a5c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9235ef13-a363-4cab-b69d-39093a621a5c.jpg?1",
             "name": "Bazaar Trader",
             "text": "{T}: Target player gains control of target artifact, creature, or land you control.",
             "colours": [
@@ -2446,7 +2446,7 @@
         },
         {
             "id": "300aa07c-f72e-5798-8362-7388c6210073",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed55a4d-d99c-44ae-a5b9-fd9d1b8477f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed55a4d-d99c-44ae-a5b9-fd9d1b8477f9.jpg?1",
             "name": "Bull Rush",
             "text": "Target creature gets +2/+0 until end of turn.",
             "colours": [
@@ -2478,7 +2478,7 @@
         },
         {
             "id": "4dc05df0-59cd-548f-8e19-8fb45afb0556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614b9df9-c959-4bdb-91c0-75ae60b724e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/614b9df9-c959-4bdb-91c0-75ae60b724e4.jpg?1",
             "name": "Chain Reaction",
             "text": "Chain Reaction deals X damage to each creature, where X is the number of creatures on the battlefield.",
             "colours": [
@@ -2510,7 +2510,7 @@
         },
         {
             "id": "c36228aa-9493-51e2-98e8-94129972a06c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85fb3ef-be24-4ea4-9f0e-0bb73f8baf90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c85fb3ef-be24-4ea4-9f0e-0bb73f8baf90.jpg?1",
             "name": "Claws of Valakut",
             "text": "Enchant creature\nEnchanted creature gets +1/+0 for each Mountain you control and has first strike.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "25ee4245-abf4-5f69-8ab8-3ba17a94be86",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8b2c8-7afe-4299-b59b-8cd2cdc8d4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58d8b2c8-7afe-4299-b59b-8cd2cdc8d4cb.jpg?1",
             "name": "Comet Storm",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature or player, then choose another target creature or player for each time Comet Storm was kicked. Comet Storm deals X damage to each of them.",
             "colours": [
@@ -2576,7 +2576,7 @@
         },
         {
             "id": "89b7bd38-deda-521e-905d-395baf25f356",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e73e-f6ac-46b7-9029-ef389a9ebe9f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e73e-f6ac-46b7-9029-ef389a9ebe9f.jpg?1",
             "name": "Cosi's Ravager",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have Cosi's Ravager deal 1 damage to target player.",
             "colours": [
@@ -2610,7 +2610,7 @@
         },
         {
             "id": "ae09c2b7-9db0-56e4-8366-0fc962575d2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf140fa-a901-41a5-a10f-f97ccef72fcc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fbf140fa-a901-41a5-a10f-f97ccef72fcc.jpg?1",
             "name": "Crusher Zendikon",
             "text": "Enchant land\nEnchanted land is a 4/2 red Beast creature with trample. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -2644,7 +2644,7 @@
         },
         {
             "id": "dcd44266-8b92-51fa-bc94-d4fd256c5646",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699842c1-6507-48ee-b98b-3774d1f07c76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/699842c1-6507-48ee-b98b-3774d1f07c76.jpg?1",
             "name": "Cunning Sparkmage",
             "text": "Haste\n{T}: Cunning Sparkmage deals 1 damage to target creature or player.",
             "colours": [
@@ -2679,7 +2679,7 @@
         },
         {
             "id": "e4e660fe-c091-5bcf-8eec-f70c63e9ae0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd079fe-83fc-4a9d-8185-dfe620b9d1e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbd079fe-83fc-4a9d-8185-dfe620b9d1e0.jpg?1",
             "name": "Deathforge Shaman",
             "text": "Multikicker {R} (You may pay an additional {R} any number of times as you cast this spell.)\nWhen Deathforge Shaman enters the battlefield, it deals damage to target player equal to twice the number of times it was kicked.",
             "colours": [
@@ -2714,7 +2714,7 @@
         },
         {
             "id": "069e72dc-2034-5d75-85bc-17a25df7cfd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2297a4e-3c19-4748-9150-efbd2513066a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2297a4e-3c19-4748-9150-efbd2513066a.jpg?1",
             "name": "Dragonmaster Outcast",
             "text": "At the beginning of your upkeep, if you control six or more lands, put a 5/5 red Dragon creature token with flying onto the battlefield.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "2ff93cf7-154f-5417-9449-f471cfdfd735",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79787dd-6d2f-4773-aefe-16a4eb93d3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e79787dd-6d2f-4773-aefe-16a4eb93d3cc.jpg?1",
             "name": "Goblin Roughrider",
             "text": "",
             "colours": [
@@ -2784,7 +2784,7 @@
         },
         {
             "id": "408f0958-083a-58cf-9442-7f58e59be34e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9275cb0a-e777-40f8-934a-a3f6e6071ec6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/9275cb0a-e777-40f8-934a-a3f6e6071ec6.jpg?1",
             "name": "Grotag Thrasher",
             "text": "Whenever Grotag Thrasher attacks, target creature can't block this turn.",
             "colours": [
@@ -2818,7 +2818,7 @@
         },
         {
             "id": "a0b9ffa0-87a2-517b-987d-dbad9acb2968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09154170-70f5-45ca-8903-027ad04bc98b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09154170-70f5-45ca-8903-027ad04bc98b.jpg?1",
             "name": "Kazuul, Tyrant of the Cliffs",
             "text": "Whenever a creature an opponent controls attacks, if you're the defending player, put a 3/3 red Ogre creature token onto the battlefield unless that creature's controller pays {3}.",
             "colours": [
@@ -2855,7 +2855,7 @@
         },
         {
             "id": "561a92ad-a6d7-5dcf-8c22-c70ad136865a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b32069-a707-4a4b-8379-c097d829bb90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c8b32069-a707-4a4b-8379-c097d829bb90.jpg?1",
             "name": "Mordant Dragon",
             "text": "Flying\n{1}{R}: Mordant Dragon gets +1/+0 until end of turn.\nWhenever Mordant Dragon deals combat damage to a player, you may have it deal that much damage to target creature that player controls.",
             "colours": [
@@ -2889,7 +2889,7 @@
         },
         {
             "id": "2601ec8c-460b-5381-8bb6-d43cd1a4fcad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23adb09-d216-47f5-a7d4-cb6a2ce48ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e23adb09-d216-47f5-a7d4-cb6a2ce48ada.jpg?1",
             "name": "Quest for the Goblin Lord",
             "text": "Whenever a Goblin enters the battlefield under your control, you may put a quest counter on Quest for the Goblin Lord.\nAs long as Quest for the Goblin Lord has five or more quest counters on it, creatures you control get +2/+0.",
             "colours": [
@@ -2921,7 +2921,7 @@
         },
         {
             "id": "579cc858-d51e-5eba-87bd-f9cbf20b87e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d782375-9192-4ed0-bd79-f3404e5a1b01.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d782375-9192-4ed0-bd79-f3404e5a1b01.jpg?1",
             "name": "Ricochet Trap",
             "text": "If an opponent cast a blue spell this turn, you may pay {R} rather than pay Ricochet Trap's mana cost.\nChange the target of target spell with a single target.",
             "colours": [
@@ -2955,7 +2955,7 @@
         },
         {
             "id": "59879d00-2a5d-5838-81f2-482250c1bca8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d3a425-01d1-4001-92f9-8e297dd862b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87d3a425-01d1-4001-92f9-8e297dd862b7.jpg?1",
             "name": "Roiling Terrain",
             "text": "Destroy target land, then Roiling Terrain deals damage to that land's controller equal to the number of land cards in that player's graveyard.",
             "colours": [
@@ -2987,7 +2987,7 @@
         },
         {
             "id": "93266b71-9edc-5bb4-a88e-497cb03b8666",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fd58c6-5bca-4160-bc1e-63b9cb3996ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01fd58c6-5bca-4160-bc1e-63b9cb3996ab.jpg?1",
             "name": "Rumbling Aftershocks",
             "text": "Whenever you cast a kicked spell, you may have Rumbling Aftershocks deal damage to target creature or player equal to the number of times that spell was kicked.",
             "colours": [
@@ -3019,7 +3019,7 @@
         },
         {
             "id": "4ca819cb-a58e-5578-a4d6-3a492ba2122c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301f13dd-39b8-4a93-9c05-3dc4fa1f1c75.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301f13dd-39b8-4a93-9c05-3dc4fa1f1c75.jpg?1",
             "name": "Searing Blaze",
             "text": "Searing Blaze deals 1 damage to target player and 1 damage to target creature that player controls.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, Searing Blaze deals 3 damage to that player and 3 damage to that creature instead.",
             "colours": [
@@ -3051,7 +3051,7 @@
         },
         {
             "id": "64667284-43e9-508d-9c6c-8f1b66e25318",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153c1465-9cbc-424b-8147-79e95fd45b3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/153c1465-9cbc-424b-8147-79e95fd45b3d.jpg?1",
             "name": "Skitter of Lizards",
             "text": "Multikicker {1}{R} (You may pay an additional {1}{R} any number of times as you cast this spell.)\nHaste\nSkitter of Lizards enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -3085,7 +3085,7 @@
         },
         {
             "id": "fc56bb51-4437-55e4-9304-a7b731b830fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71790058-3362-421f-b248-a3b2095100eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71790058-3362-421f-b248-a3b2095100eb.jpg?1",
             "name": "Slavering Nulls",
             "text": "Whenever Slavering Nulls deals combat damage to a player, if you control a Swamp, you may have that player discard a card.",
             "colours": [
@@ -3120,7 +3120,7 @@
         },
         {
             "id": "efed22a5-d50d-52fe-95ba-f523004c0900",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dee4b3-f3c1-4ef5-8dfa-fa10c860be1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44dee4b3-f3c1-4ef5-8dfa-fa10c860be1e.jpg?1",
             "name": "Stone Idol Trap",
             "text": "Stone Idol Trap costs {1} less to cast for each attacking creature.\nPut a 6/12 colorless Construct artifact creature token with trample onto the battlefield. Exile it at the beginning of your next end step.",
             "colours": [
@@ -3154,7 +3154,7 @@
         },
         {
             "id": "3d56d4b1-0a60-5ef2-852e-0f2b1dcdae6c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a84a2a-6384-497a-8ee2-de0fa74fcc80.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/3/d3a84a2a-6384-497a-8ee2-de0fa74fcc80.jpg?1",
             "name": "Tuktuk Scrapper",
             "text": "Whenever Tuktuk Scrapper or another Ally enters the battlefield under your control, you may destroy target artifact. If that artifact is put into a graveyard this way, Tuktuk Scrapper deals damage to that artifact's controller equal to the number of Allies you control.",
             "colours": [
@@ -3190,7 +3190,7 @@
         },
         {
             "id": "bfd63672-033f-58da-a8ba-25d17da6611b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32a4ed-6b43-4473-91ec-08cd5414f2f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d32a4ed-6b43-4473-91ec-08cd5414f2f0.jpg?1",
             "name": "Arbor Elf",
             "text": "{T}: Untap target Forest.",
             "colours": [
@@ -3225,7 +3225,7 @@
         },
         {
             "id": "0d9a4b4e-f301-55d8-bed3-83101ff81652",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde073e0-f329-4ab0-8e31-a48929e017ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dde073e0-f329-4ab0-8e31-a48929e017ce.jpg?1",
             "name": "Avenger of Zendikar",
             "text": "When Avenger of Zendikar enters the battlefield, put a 0/1 green Plant creature token onto the battlefield for each land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a +1/+1 counter on each Plant creature you control.",
             "colours": [
@@ -3259,7 +3259,7 @@
         },
         {
             "id": "24ea3143-811a-5c31-a2e9-a4a2b755086a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434b99c2-26f5-4d45-8453-77d9dedb7892.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/434b99c2-26f5-4d45-8453-77d9dedb7892.jpg?1",
             "name": "Bestial Menace",
             "text": "Put a 1/1 green Snake creature token, a 2/2 green Wolf creature token, and a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -3291,7 +3291,7 @@
         },
         {
             "id": "1f5ccff6-eb58-5b7e-bc9c-1f4fa871882c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc34db-60be-4017-adfa-6bdfacec793f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fcc34db-60be-4017-adfa-6bdfacec793f.jpg?1",
             "name": "Canopy Cover",
             "text": "Enchant creature\nEnchanted creature can't be blocked except by creatures with flying or reach.\nEnchanted creature can't be the target of spells or abilities your opponents control.",
             "colours": [
@@ -3325,7 +3325,7 @@
         },
         {
             "id": "f91c219b-93e5-5ba0-b179-4c22f2714d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f81e8a-e309-4bac-81de-326756cd8901.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8f81e8a-e309-4bac-81de-326756cd8901.jpg?1",
             "name": "Explore",
             "text": "You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -3357,7 +3357,7 @@
         },
         {
             "id": "abd9d3a2-2327-59ef-9c37-648cdb4d5198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215115fa-50a6-42c0-b3c6-8d18e7f65174.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/215115fa-50a6-42c0-b3c6-8d18e7f65174.jpg?1",
             "name": "Feral Contest",
             "text": "Put a +1/+1 counter on target creature you control. Another target creature blocks it this turn if able.",
             "colours": [
@@ -3389,7 +3389,7 @@
         },
         {
             "id": "e817e712-7d3d-5e57-98e2-2cd5196cafbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68716387-c5ec-4967-be5f-723783722c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68716387-c5ec-4967-be5f-723783722c64.jpg?1",
             "name": "Gnarlid Pack",
             "text": "Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nGnarlid Pack enters the battlefield with a +1/+1 counter on it for each time it was kicked.",
             "colours": [
@@ -3423,7 +3423,7 @@
         },
         {
             "id": "12ae2f53-26ce-5228-97ac-be02dbd126c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2324d0b-ac63-45e5-ba27-a643c61538c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2324d0b-ac63-45e5-ba27-a643c61538c7.jpg?1",
             "name": "Grappler Spider",
             "text": "Reach (This creature can block creatures with flying.)",
             "colours": [
@@ -3457,7 +3457,7 @@
         },
         {
             "id": "b96ad4bc-052c-507e-a91d-490c52b783b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed04a5a7-f7d0-4dd8-9c23-6a767814316a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed04a5a7-f7d0-4dd8-9c23-6a767814316a.jpg?1",
             "name": "Graypelt Hunter",
             "text": "Trample\nWhenever Graypelt Hunter or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Graypelt Hunter.",
             "colours": [
@@ -3493,7 +3493,7 @@
         },
         {
             "id": "a76cc52c-09f2-5de0-937b-66a6e9f46722",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca76e9a-672f-49eb-86c6-00fac60d3065.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/c/4ca76e9a-672f-49eb-86c6-00fac60d3065.jpg?1",
             "name": "Groundswell",
             "text": "Target creature gets +2/+2 until end of turn.\nLandfall \u2014 If you had a land enter the battlefield under your control this turn, that creature gets +4/+4 until end of turn instead.",
             "colours": [
@@ -3525,7 +3525,7 @@
         },
         {
             "id": "7eee1d89-a46a-5475-9d67-f6a29bdf1ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a538cf-2291-49aa-8429-17d97d454479.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78a538cf-2291-49aa-8429-17d97d454479.jpg?1",
             "name": "Harabaz Druid",
             "text": "{T}: Add X mana of any one color to your mana pool, where X is the number of Allies you control.",
             "colours": [
@@ -3561,7 +3561,7 @@
         },
         {
             "id": "3a015537-2f9b-5d23-b442-f6d25858320b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650200df-4408-4d2c-97b0-ef4cd744196c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/650200df-4408-4d2c-97b0-ef4cd744196c.jpg?1",
             "name": "Joraga Warcaller",
             "text": "Multikicker {1}{G} (You may pay an additional {1}{G} any number of times as you cast this spell.)\nJoraga Warcaller enters the battlefield with a +1/+1 counter on it for each time it was kicked.\nOther Elf creatures you control get +1/+1 for each +1/+1 counter on Joraga Warcaller.",
             "colours": [
@@ -3596,7 +3596,7 @@
         },
         {
             "id": "2c07c923-6fde-51e8-b648-9f79be5c8d6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f97b4c-42c7-4986-a150-0b8de11f0537.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55f97b4c-42c7-4986-a150-0b8de11f0537.jpg?1",
             "name": "Leatherback Baloth",
             "text": "",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "d88d537a-0d75-5188-842d-d094d7c3b4c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae5a91-ac54-4222-832e-d7a740a3f7cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64ae5a91-ac54-4222-832e-d7a740a3f7cb.jpg?1",
             "name": "Nature's Claim",
             "text": "Destroy target artifact or enchantment. Its controller gains 4 life.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "44c91697-cae7-5a67-afb1-b8fc84279608",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694579c6-f739-45df-8adf-b0c540a904a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/694579c6-f739-45df-8adf-b0c540a904a1.jpg?1",
             "name": "Omnath, Locus of Mana",
             "text": "Green mana doesn't empty from your mana pool as steps and phases end.\nOmnath, Locus of Mana gets +1/+1 for each green mana in your mana pool.",
             "colours": [
@@ -3698,7 +3698,7 @@
         },
         {
             "id": "dbc247d7-e679-59cf-9b11-fd2796790adf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b7ad82-1115-4f80-886a-3f59f568423f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41b7ad82-1115-4f80-886a-3f59f568423f.jpg?1",
             "name": "Quest for Renewal",
             "text": "Whenever a creature you control becomes tapped, you may put a quest counter on Quest for Renewal.\nAs long as there are four or more quest counters on Quest for Renewal, untap all creatures you control during each other player's untap step.",
             "colours": [
@@ -3730,7 +3730,7 @@
         },
         {
             "id": "8062ba17-35e0-54d9-a46e-78596af1edc1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def592b9-9d8b-4e2d-9b52-e1bc9f4bd019.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/def592b9-9d8b-4e2d-9b52-e1bc9f4bd019.jpg?1",
             "name": "Slingbow Trap",
             "text": "If a black creature with flying is attacking, you may pay {G} rather than pay Slingbow Trap's mana cost.\nDestroy target attacking creature with flying.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "ea80be9e-9a97-5d46-b867-bfa900b7be25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8860c3d5-8b93-4c52-b374-8814fb8546bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/8860c3d5-8b93-4c52-b374-8814fb8546bd.jpg?1",
             "name": "Snapping Creeper",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Snapping Creeper gains vigilance until end of turn.",
             "colours": [
@@ -3798,7 +3798,7 @@
         },
         {
             "id": "d5b7afe2-88b9-54d2-a99f-afeddb3d4a35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a06885-08e9-4f5a-8752-fa0945ad7701.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6a06885-08e9-4f5a-8752-fa0945ad7701.jpg?1",
             "name": "Strength of the Tajuru",
             "text": "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\nChoose target creature, then choose another target creature for each time Strength of the Tajuru was kicked. Put X +1/+1 counters on each of them.",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "89fa8aae-95d9-5b86-be42-038a8fd6c19d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367e7821-44f1-4064-a9a3-d9852c7c235c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/367e7821-44f1-4064-a9a3-d9852c7c235c.jpg?1",
             "name": "Summit Apes",
             "text": "As long as you control a Mountain, Summit Apes can't be blocked except by two or more creatures.",
             "colours": [
@@ -3864,7 +3864,7 @@
         },
         {
             "id": "36ea67df-8a41-5f75-a16c-faf2ace90d45",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d2f62-8a4a-4e8d-93e1-5dc802684106.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e66d2f62-8a4a-4e8d-93e1-5dc802684106.jpg?1",
             "name": "Terastodon",
             "text": "When Terastodon enters the battlefield, you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller puts a 3/3 green Elephant creature token onto the battlefield.",
             "colours": [
@@ -3898,7 +3898,7 @@
         },
         {
             "id": "b66534df-b4ce-5e44-acb8-ce124a431e2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cc40e7-fb31-4540-81a1-d0c0f514c8a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5cc40e7-fb31-4540-81a1-d0c0f514c8a8.jpg?1",
             "name": "Vastwood Animist",
             "text": "{T}: Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.",
             "colours": [
@@ -3934,7 +3934,7 @@
         },
         {
             "id": "02e663ec-66c3-5edf-9896-d57ec3ba6d58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bca11e1-3c75-4dba-b4a2-c77595cc3022.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bca11e1-3c75-4dba-b4a2-c77595cc3022.jpg?1",
             "name": "Vastwood Zendikon",
             "text": "Enchant land\nEnchanted land is a 6/4 green Elemental creature. It's still a land.\nWhen enchanted land is put into a graveyard, return that card to its owner's hand.",
             "colours": [
@@ -3968,7 +3968,7 @@
         },
         {
             "id": "c890f85d-335d-5c49-ba4a-4affad67a2f5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffbd5e-113a-4f24-baa1-b65a5082d893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35ffbd5e-113a-4f24-baa1-b65a5082d893.jpg?1",
             "name": "Wolfbriar Elemental",
             "text": "Multikicker {G} (You may pay an additional {G} any number of times as you cast this spell.)\nWhen Wolfbriar Elemental enters the battlefield, put a 2/2 green Wolf creature token onto the battlefield for each time it was kicked.",
             "colours": [
@@ -4002,7 +4002,7 @@
         },
         {
             "id": "64fed9e8-3721-51ab-bcf6-18258e3bf0c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64733f34-2eb4-4df5-8656-57bdb8b3a983.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64733f34-2eb4-4df5-8656-57bdb8b3a983.jpg?1",
             "name": "Novablast Wurm",
             "text": "Whenever Novablast Wurm attacks, destroy all other creatures.",
             "colours": [
@@ -4038,7 +4038,7 @@
         },
         {
             "id": "7496f155-c591-5d89-a472-ae84a0bfd2fa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb989b-aff4-4232-9ae1-c4f73dacf728.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/deeb989b-aff4-4232-9ae1-c4f73dacf728.jpg?1",
             "name": "Wrexial, the Risen Deep",
             "text": "Islandwalk, swampwalk\nWhenever Wrexial, the Risen Deep deals combat damage to a player, you may cast target instant or sorcery card from that player's graveyard without paying its mana cost. If that card would be put into a graveyard this turn, exile it instead.",
             "colours": [
@@ -4076,7 +4076,7 @@
         },
         {
             "id": "635685a0-fcc4-5ff0-af0c-bf4e291923bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997bc933-ac30-477b-a4e1-5333b796a99d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/997bc933-ac30-477b-a4e1-5333b796a99d.jpg?1",
             "name": "Amulet of Vigor",
             "text": "Whenever a permanent enters the battlefield tapped and under your control, untap it.",
             "colours": [],
@@ -4104,7 +4104,7 @@
         },
         {
             "id": "91ae3442-e707-5660-b335-c2400f368890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cdba1b-7a80-435f-9cff-b9365f62e311.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55cdba1b-7a80-435f-9cff-b9365f62e311.jpg?1",
             "name": "Basilisk Collar",
             "text": "Equipped creature has deathtouch and lifelink.\nEquip {2}",
             "colours": [],
@@ -4134,7 +4134,7 @@
         },
         {
             "id": "1c703d17-aefe-5649-a734-503085588a7c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdcc0c3-4029-4fc3-a486-5d7f45c910bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fdcc0c3-4029-4fc3-a486-5d7f45c910bd.jpg?1",
             "name": "Everflowing Chalice",
             "text": "Multikicker {2} (You may pay an additional {2} any number of times as you cast this spell.)\nEverflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.\n{T}: Add {1} to your mana pool for each charge counter on Everflowing Chalice.",
             "colours": [],
@@ -4162,7 +4162,7 @@
         },
         {
             "id": "71f55e12-dcfa-549e-8185-80a56589709c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c6bc5-701d-4ae8-bb52-c2e2c6956946.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/308c6bc5-701d-4ae8-bb52-c2e2c6956946.jpg?1",
             "name": "Hammer of Ruin",
             "text": "Equipped creature gets +2/+0.\nWhenever equipped creature deals combat damage to a player, you may destroy target Equipment that player controls.\nEquip {2}",
             "colours": [],
@@ -4192,7 +4192,7 @@
         },
         {
             "id": "42a6d085-c6ff-5acc-ac39-9ce91dde25ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a36448-ca96-4c10-baf9-89c248c3510b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0a36448-ca96-4c10-baf9-89c248c3510b.jpg?1",
             "name": "Hedron Rover",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Hedron Rover gets +2/+2 until end of turn.",
             "colours": [],
@@ -4223,7 +4223,7 @@
         },
         {
             "id": "57203bca-ca54-51d4-a984-14f746f7ea10",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217a05a7-557f-4879-8fd1-d6c003f1751e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/217a05a7-557f-4879-8fd1-d6c003f1751e.jpg?1",
             "name": "Kitesail",
             "text": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -4253,7 +4253,7 @@
         },
         {
             "id": "5415f22d-07de-57dd-9021-7d4c58ee8bb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0ee6a-852a-4f1e-8f03-40b6d505bc82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bb0ee6a-852a-4f1e-8f03-40b6d505bc82.jpg?1",
             "name": "Lodestone Golem",
             "text": "Nonartifact spells cost {1} more to cast.",
             "colours": [],
@@ -4284,7 +4284,7 @@
         },
         {
             "id": "a1ef8321-927d-5ba5-8750-03ee1bb5f663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2a474b-5eac-4e0d-b65c-5610385f2011.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/d/cd2a474b-5eac-4e0d-b65c-5610385f2011.jpg?1",
             "name": "Pilgrim's Eye",
             "text": "Flying\nWhen Pilgrim's Eye enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [],
@@ -4315,7 +4315,7 @@
         },
         {
             "id": "91fdedee-6ca6-5b8a-8ce3-81d29a1ee9a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41526ad7-730d-44ad-bd19-e1b8a2717cf7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41526ad7-730d-44ad-bd19-e1b8a2717cf7.jpg?1",
             "name": "Razor Boomerang",
             "text": "Equipped creature has \"{T}, Unattach Razor Boomerang: Razor Boomerang deals 1 damage to target creature or player. Return Razor Boomerang to its owner's hand.\"\nEquip {2}",
             "colours": [],
@@ -4345,7 +4345,7 @@
         },
         {
             "id": "063a462e-88e8-55c6-b4ca-b8d71efb682c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314cb009-bd0e-40eb-98ea-c6dea8d83dcf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/314cb009-bd0e-40eb-98ea-c6dea8d83dcf.jpg?1",
             "name": "Seer's Sundial",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may pay {2}. If you do, draw a card.",
             "colours": [],
@@ -4373,7 +4373,7 @@
         },
         {
             "id": "af90513a-7686-5cc0-b0de-d14f8236650b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53515042-e729-4a7c-ac3b-36ef70dbbe8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53515042-e729-4a7c-ac3b-36ef70dbbe8d.jpg?1",
             "name": "Walking Atlas",
             "text": "{T}: You may put a land card from your hand onto the battlefield.",
             "colours": [],
@@ -4404,7 +4404,7 @@
         },
         {
             "id": "58a8d275-ea92-5816-aca1-013ced94efdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c38b3-7397-4dac-9859-acd9cd451c32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/529c38b3-7397-4dac-9859-acd9cd451c32.jpg?1",
             "name": "Bojuka Bog",
             "text": "Bojuka Bog enters the battlefield tapped.\nWhen Bojuka Bog enters the battlefield, exile all cards from target player's graveyard.\n{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -4434,7 +4434,7 @@
         },
         {
             "id": "f98a936a-0cf7-54fb-9c67-4c6d0162b8d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929259-2903-4f6f-9b06-42048fd55c6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6929259-2903-4f6f-9b06-42048fd55c6a.jpg?1",
             "name": "Celestial Colonnade",
             "text": "Celestial Colonnade enters the battlefield tapped.\n{T}: Add {W} or {U} to your mana pool.\n{3}{W}{U}: Until end of turn, Celestial Colonnade becomes a 4/4 white and blue Elemental creature with flying and vigilance. It's still a land.",
             "colours": [],
@@ -4465,7 +4465,7 @@
         },
         {
             "id": "54e22f20-4cd2-5253-b7a8-5d5ab9861042",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f427f0b-034c-4821-8758-e395c0042d8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f427f0b-034c-4821-8758-e395c0042d8a.jpg?1",
             "name": "Creeping Tar Pit",
             "text": "Creeping Tar Pit enters the battlefield tapped.\n{T}: Add {U} or {B} to your mana pool.\n{1}{U}{B}: Until end of turn, Creeping Tar Pit becomes a 3/2 blue and black Elemental creature and is unblockable. It's still a land.",
             "colours": [],
@@ -4496,7 +4496,7 @@
         },
         {
             "id": "ca787441-7dcf-556f-a8bc-2e701bb6b9eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6814d15f-e7a5-4a73-9adc-88a1a4dec6cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/6814d15f-e7a5-4a73-9adc-88a1a4dec6cc.jpg?1",
             "name": "Dread Statuary",
             "text": "{T}: Add {1} to your mana pool.\n{4}: Dread Statuary becomes a 4/2 Golem artifact creature until end of turn. It's still a land.",
             "colours": [],
@@ -4524,7 +4524,7 @@
         },
         {
             "id": "820ca3a0-e631-5d0e-8e44-94b45d801f0f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b21941-1b7d-4fde-8b1d-7edbd5e5b796.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3b21941-1b7d-4fde-8b1d-7edbd5e5b796.jpg?1",
             "name": "Eye of Ugin",
             "text": "Colorless Eldrazi spells you cast cost {2} less to cast.\n{7}, {T}: Search your library for a colorless creature card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -4554,7 +4554,7 @@
         },
         {
             "id": "51c0557d-5573-5a0c-bd81-7351b5c2501a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5651e5e-2314-4e3d-a2c8-2579239314e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5651e5e-2314-4e3d-a2c8-2579239314e1.jpg?1",
             "name": "Halimar Depths",
             "text": "Halimar Depths enters the battlefield tapped.\nWhen Halimar Depths enters the battlefield, look at the top three cards of your library, then put them back in any order.\n{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -4584,7 +4584,7 @@
         },
         {
             "id": "d4f445fd-d8d9-53ef-97c7-b877ef3a86d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc6a5e6-0b73-4488-8954-4b168ce7106d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1cc6a5e6-0b73-4488-8954-4b168ce7106d.jpg?1",
             "name": "Khalni Garden",
             "text": "Khalni Garden enters the battlefield tapped.\nWhen Khalni Garden enters the battlefield, put a 0/1 green Plant creature token onto the battlefield.\n{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -4614,7 +4614,7 @@
         },
         {
             "id": "f5926324-ddb6-5a8b-80d0-53b429c6ee3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7066095-f05a-4f2e-ab9c-47c498608ccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c7066095-f05a-4f2e-ab9c-47c498608ccb.jpg?1",
             "name": "Lavaclaw Reaches",
             "text": "Lavaclaw Reaches enters the battlefield tapped.\n{T}: Add {B} or {R} to your mana pool.\n{1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with \"{X}: This creature gets +X/+0 until end of turn.\" It's still a land.",
             "colours": [],
@@ -4645,7 +4645,7 @@
         },
         {
             "id": "f2a41d81-9a31-5127-b985-13437554d792",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e396df7-9931-43f6-b009-27cf93c4a3e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e396df7-9931-43f6-b009-27cf93c4a3e5.jpg?1",
             "name": "Quicksand",
             "text": "{T}: Add {1} to your mana pool.\n{T}, Sacrifice Quicksand: Target attacking creature without flying gets -1/-2 until end of turn.",
             "colours": [],
@@ -4673,7 +4673,7 @@
         },
         {
             "id": "52c21e6b-ff2d-58c6-a167-4b8af9713a7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b6fb5-4d38-4734-b46f-923322cff24e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb7b6fb5-4d38-4734-b46f-923322cff24e.jpg?1",
             "name": "Raging Ravine",
             "text": "Raging Ravine enters the battlefield tapped.\n{T}: Add {R} or {G} to your mana pool.\n{2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with \"Whenever this creature attacks, put a +1/+1 counter on it.\" It's still a land.",
             "colours": [],
@@ -4704,7 +4704,7 @@
         },
         {
             "id": "10b798c5-8e88-5f0e-b424-9461fb5e5fec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668f5732-da88-4d42-9186-70cfef81f689.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/668f5732-da88-4d42-9186-70cfef81f689.jpg?1",
             "name": "Sejiri Steppe",
             "text": "Sejiri Steppe enters the battlefield tapped.\nWhen Sejiri Steppe enters the battlefield, target creature you control gains protection from the color of your choice until end of turn.\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -4734,7 +4734,7 @@
         },
         {
             "id": "57eac5b2-0467-598e-91f1-efe463250775",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1b05db-4475-49cd-99a3-5e5640c6da9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad1b05db-4475-49cd-99a3-5e5640c6da9b.jpg?1",
             "name": "Smoldering Spires",
             "text": "Smoldering Spires enters the battlefield tapped.\nWhen Smoldering Spires enters the battlefield, target creature can't block this turn.\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -4764,7 +4764,7 @@
         },
         {
             "id": "1033c9a0-83f3-58f6-9e0b-51effa86d0f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556d10b-83cc-4736-b269-4ce65aae2837.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d556d10b-83cc-4736-b269-4ce65aae2837.jpg?1",
             "name": "Stirring Wildwood",
             "text": "Stirring Wildwood enters the battlefield tapped.\n{T}: Add {G} or {W} to your mana pool.\n{1}{G}{W}: Until end of turn, Stirring Wildwood becomes a 3/4 green and white Elemental creature with reach. It's still a land.",
             "colours": [],
@@ -4795,7 +4795,7 @@
         },
         {
             "id": "73944cb3-28db-5ca6-87c8-f47c8cdab8c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcf5c0f-9d18-406d-a930-c179a781264f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdcf5c0f-9d18-406d-a930-c179a781264f.jpg?1",
             "name": "Tectonic Edge",
             "text": "{T}: Add {1} to your mana pool.\n{1}, {T}, Sacrifice Tectonic Edge: Destroy target nonbasic land. Activate this ability only if an opponent controls four or more lands.",
             "colours": [],
@@ -4823,7 +4823,7 @@
         },
         {
             "id": "eb5ad563-b821-5096-9ed9-c46714b21a48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05abf2df-833f-4172-af74-6533b022dfa9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05abf2df-833f-4172-af74-6533b022dfa9.jpg?1",
             "name": "Soldier Ally",
             "text": "",
             "colours": [
@@ -4858,7 +4858,7 @@
         },
         {
             "id": "921f2257-6e27-5e00-945a-dc599f4711b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87835c7-4739-45c9-a15a-889aa6b6b7ab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b87835c7-4739-45c9-a15a-889aa6b6b7ab.jpg?1",
             "name": "Dragon",
             "text": "",
             "colours": [
@@ -4892,7 +4892,7 @@
         },
         {
             "id": "8de388a3-945c-5afd-b555-fa73ef6fd938",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99c10f3-9f11-42f1-9007-c0320a1929e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a99c10f3-9f11-42f1-9007-c0320a1929e0.jpg?1",
             "name": "Ogre",
             "text": "",
             "colours": [
@@ -4926,7 +4926,7 @@
         },
         {
             "id": "873837b0-d1e4-5a5a-b08a-7864eb2d9c51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5a05d3-7824-4570-b32d-91fe2dced952.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1c5a05d3-7824-4570-b32d-91fe2dced952.jpg?1",
             "name": "Elephant",
             "text": "",
             "colours": [
@@ -4960,7 +4960,7 @@
         },
         {
             "id": "539e2a1f-f221-56c1-ade0-73473e15bab4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1424e8d-1f96-44af-9382-c337b6695ddf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1424e8d-1f96-44af-9382-c337b6695ddf.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -4994,7 +4994,7 @@
         },
         {
             "id": "79943663-ab50-529b-8619-f4a7f0ceef51",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6b47f-5c2a-4771-90ee-4aa8c1eda0be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04d6b47f-5c2a-4771-90ee-4aa8c1eda0be.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/XLN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/XLN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4f651d96-55d5-5cbc-9bb8-863c8c58d8ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c950d7-b4f6-4902-8c9a-98f2933f9fa5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21c950d7-b4f6-4902-8c9a-98f2933f9fa5.jpg?1",
             "name": "Adanto Vanguard",
             "text": "As long as Adanto Vanguard is attacking, it gets +2/+0.\nPay 4 life: Adanto Vanguard gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "b36c8384-bcfd-53c7-ac7d-3816f17a0955",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8eb264-dadb-440c-af85-273e755f1db6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e8eb264-dadb-440c-af85-273e755f1db6.jpg?1",
             "name": "Ashes of the Abhorrent",
             "text": "Players can't cast spells from graveyards or activate abilities of cards in graveyards.\nWhenever a creature dies, you gain 1 life.",
             "colours": [
@@ -71,7 +71,7 @@
         },
         {
             "id": "0bd4b1f5-c131-5b41-9c21-63f63af87cea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d72a8-8acf-42c6-8adf-cbaecb4a985a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b9d72a8-8acf-42c6-8adf-cbaecb4a985a.jpg?1",
             "name": "Axis of Mortality",
             "text": "At the beginning of your upkeep, you may have two target players exchange life totals.",
             "colours": [
@@ -103,7 +103,7 @@
         },
         {
             "id": "d63b8b73-3331-5631-8a25-24203d155911",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e3b6c5-fd30-4d45-a122-ce60d5707357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3e3b6c5-fd30-4d45-a122-ce60d5707357.jpg?1",
             "name": "Bellowing Aegisaur",
             "text": "Enrage \u2014 Whenever Bellowing Aegisaur is dealt damage, put a +1/+1 counter on each other creature you control.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "92eeae92-0e05-55ce-a55f-b52b9fe808fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg?1",
             "name": "Bishop of Rebirth",
             "text": "Vigilance\nWhenever Bishop of Rebirth attacks, you may return target creature card with converted mana cost 3 or less from your graveyard to the battlefield.",
             "colours": [
@@ -172,7 +172,7 @@
         },
         {
             "id": "cef747aa-5ca6-5786-906b-d509d87a689f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d954677c-2de6-440a-90d0-bab2e0c8b4af.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d954677c-2de6-440a-90d0-bab2e0c8b4af.jpg?1",
             "name": "Bishop's Soldier",
             "text": "Lifelink",
             "colours": [
@@ -207,7 +207,7 @@
         },
         {
             "id": "e22acc4f-714f-5575-ad53-7a84d621707c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3340ffb9-9513-4551-ad64-821600596b2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3340ffb9-9513-4551-ad64-821600596b2e.jpg?1",
             "name": "Bright Reprisal",
             "text": "Destroy target attacking creature.\nDraw a card.",
             "colours": [
@@ -239,7 +239,7 @@
         },
         {
             "id": "8854c02f-90aa-5bb9-a9fd-739d9370594d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3979b88-ac58-420a-8c03-37ea5d93d0f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3979b88-ac58-420a-8c03-37ea5d93d0f1.jpg?1",
             "name": "Demystify",
             "text": "Destroy target enchantment.",
             "colours": [
@@ -271,7 +271,7 @@
         },
         {
             "id": "02dcd43f-da36-5c2e-930a-2471cdd8197e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa524bb-0ce7-4c30-93c3-ae15c3b05e92.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/baa524bb-0ce7-4c30-93c3-ae15c3b05e92.jpg?1",
             "name": "Duskborne Skymarcher",
             "text": "Flying\n{W}, {T}: Target attacking Vampire gets +1/+1 until end of turn.",
             "colours": [
@@ -306,7 +306,7 @@
         },
         {
             "id": "d7582621-fda1-5ea5-9f16-7ac80668ec67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0636cd47-d2a3-4320-97bf-40db805fca51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0636cd47-d2a3-4320-97bf-40db805fca51.jpg?1",
             "name": "Emissary of Sunrise",
             "text": "First strike\nWhen Emissary of Sunrise enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -341,7 +341,7 @@
         },
         {
             "id": "8b728334-f043-53a2-989b-8ad755661d27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe64569-c1b6-4bd4-a742-6ee46ea5181c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6fe64569-c1b6-4bd4-a742-6ee46ea5181c.jpg?1",
             "name": "Encampment Keeper",
             "text": "First strike\n{7}{W}, {T}, Sacrifice Encampment Keeper: Creatures you control get +2/+2 until end of turn.",
             "colours": [
@@ -375,7 +375,7 @@
         },
         {
             "id": "0b467201-d5e5-5a19-b34f-8817c866d919",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf87f95-1c77-455a-8feb-57bfd4d159c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aaf87f95-1c77-455a-8feb-57bfd4d159c9.jpg?1",
             "name": "Glorifier of Dusk",
             "text": "Pay 2 life: Glorifier of Dusk gains flying until end of turn.\nPay 2 life: Glorifier of Dusk gains vigilance until end of turn.",
             "colours": [
@@ -410,7 +410,7 @@
         },
         {
             "id": "a82602e3-c4dc-539d-97e9-a4302376cf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8309f684-5912-4191-9f64-d573f1cc84c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8309f684-5912-4191-9f64-d573f1cc84c9.jpg?1",
             "name": "Goring Ceratops",
             "text": "Double strike\nWhenever Goring Ceratops attacks, other creatures you control gain double strike until end of turn.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "b59e8868-dbb2-56b5-85dd-f54aad1c24d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d08f90b-9b98-4237-9826-578fb812d412.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d08f90b-9b98-4237-9826-578fb812d412.jpg?1",
             "name": "Imperial Aerosaur",
             "text": "Flying\nWhen Imperial Aerosaur enters the battlefield, another target creature you control gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -478,7 +478,7 @@
         },
         {
             "id": "4d66feca-bd10-5e9f-9052-a2604c586ecb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed3784a-2dc0-4626-aa6a-268c1e2ac83c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7ed3784a-2dc0-4626-aa6a-268c1e2ac83c.jpg?1",
             "name": "Imperial Lancer",
             "text": "Imperial Lancer has double strike as long as you control a Dinosaur.",
             "colours": [
@@ -513,7 +513,7 @@
         },
         {
             "id": "db3cce92-d51d-567f-9ffd-168500808198",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b8f1da-c8ea-41d5-b1ad-b714c22d3683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31b8f1da-c8ea-41d5-b1ad-b714c22d3683.jpg?1",
             "name": "Inspiring Cleric",
             "text": "When Inspiring Cleric enters the battlefield, you gain 4 life.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "7b3bae10-6ecf-5c23-8685-7cc9e966c68c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c8c31-ceb8-4a2c-beb6-0ff5f7b6ae07.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3c8c31-ceb8-4a2c-beb6-0ff5f7b6ae07.jpg?1",
             "name": "Ixalan's Binding",
             "text": "When Ixalan's Binding enters the battlefield, exile target nonland permanent an opponent controls until Ixalan's Binding leaves the battlefield.\nYour opponents can't cast spells with the same name as the exiled card.",
             "colours": [
@@ -580,7 +580,7 @@
         },
         {
             "id": "940e35dd-6988-5847-829d-649440171da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625211d4-c89c-4aee-a0b0-4bfabd3509ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/625211d4-c89c-4aee-a0b0-4bfabd3509ad.jpg?1",
             "name": "Kinjalli's Caller",
             "text": "Dinosaur spells you cast cost {1} less to cast.",
             "colours": [
@@ -615,7 +615,7 @@
         },
         {
             "id": "ee041a1a-d11b-5af7-99bb-3ecd8c0380d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9e0b0f-651a-44e6-8fb0-e46bfda0ada9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b9e0b0f-651a-44e6-8fb0-e46bfda0ada9.jpg?1",
             "name": "Kinjalli's Sunwing",
             "text": "Flying\nCreatures your opponents control enter the battlefield tapped.",
             "colours": [
@@ -649,7 +649,7 @@
         },
         {
             "id": "01bdcc3a-29e3-5972-af02-726fee266cfd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30590d7-59c7-4a1a-a8e5-3cc13f69bd41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30590d7-59c7-4a1a-a8e5-3cc13f69bd41.jpg?1",
             "name": "Legion Conquistador",
             "text": "When Legion Conquistador enters the battlefield, you may search your library for any number of cards named Legion Conquistador, reveal them, put them into your hand, then shuffle your library.",
             "colours": [
@@ -684,7 +684,7 @@
         },
         {
             "id": "f360e708-8fe7-53b8-8c1f-a67793bb1c01",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bea20-c196-4da8-bc3e-36f8d50dcc17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/385bea20-c196-4da8-bc3e-36f8d50dcc17.jpg?1",
             "name": "Legion's Judgment",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -716,7 +716,7 @@
         },
         {
             "id": "b6db5d31-1ddf-5752-9d3e-24dac3911669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg?1",
             "name": "Legion's Landing // Adanto, the First Fort",
             "text": "When Legion's Landing enters the battlefield, create a 1/1 white Vampire creature token with lifelink.\nWhen you attack with three or more creatures, transform Legion's Landing.",
             "colours": [
@@ -750,7 +750,7 @@
         },
         {
             "id": "aa4d38d2-0eb8-5dd8-86ca-0fe28f6472f8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/05e2a5e6-3aaa-4096-bdd0-fcc1afe5a36c.jpg?1",
             "name": "Legion's Landing // Adanto, the First Fort",
             "text": "(Transforms from Legion's Landing.)\n{T}: Add {W} to your mana pool.\n{2}{W}, {T}: Create a 1/1 white Vampire creature token with lifelink.",
             "colours": [],
@@ -782,7 +782,7 @@
         },
         {
             "id": "f5f63f44-6008-5ca8-ac18-a9a524710e2a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcff1c6-0db6-4ff6-b4af-d7048b426368.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cfcff1c6-0db6-4ff6-b4af-d7048b426368.jpg?1",
             "name": "Looming Altisaur",
             "text": "",
             "colours": [
@@ -816,7 +816,7 @@
         },
         {
             "id": "2dcd3003-17c8-5ae2-b033-5ad923f64f40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7294e40-11b3-4d5c-82d0-c8ec6bd3a6c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7294e40-11b3-4d5c-82d0-c8ec6bd3a6c9.jpg?1",
             "name": "Mavren Fein, Dusk Apostle",
             "text": "Whenever one or more nontoken Vampires you control attack, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -853,7 +853,7 @@
         },
         {
             "id": "11b4d963-7125-59ee-846c-8bb094766819",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0385d5-d0f4-40b8-af28-6557ffdfb625.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a0385d5-d0f4-40b8-af28-6557ffdfb625.jpg?1",
             "name": "Paladin of the Bloodstained",
             "text": "When Paladin of the Bloodstained enters the battlefield, create a 1/1 white Vampire creature token with lifelink.",
             "colours": [
@@ -888,7 +888,7 @@
         },
         {
             "id": "ffcbd82f-db34-574b-9835-7c3b44b7edc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670b9645-ce34-41eb-a527-4af3e13c3a54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/670b9645-ce34-41eb-a527-4af3e13c3a54.jpg?1",
             "name": "Pious Interdiction",
             "text": "Enchant creature\nWhen Pious Interdiction enters the battlefield, you gain 2 life.\nEnchanted creature can't attack or block.",
             "colours": [
@@ -922,7 +922,7 @@
         },
         {
             "id": "ee82a5a2-b844-5ca2-a73b-5d52e62f5b7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051dc73e-f04a-4901-b0ed-3b33c33ac72f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/051dc73e-f04a-4901-b0ed-3b33c33ac72f.jpg?1",
             "name": "Priest of the Wakening Sun",
             "text": "At the beginning of your upkeep, you may reveal a Dinosaur card from your hand. If you do, you gain 2 life.\n{3}{W}{W}, Sacrifice Priest of the Wakening Sun: Search your library for a Dinosaur card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -957,7 +957,7 @@
         },
         {
             "id": "d9b7dbb5-b807-5306-addf-ad17833f2a63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f00a04-1336-4830-a6c2-514848afefd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41f00a04-1336-4830-a6c2-514848afefd2.jpg?1",
             "name": "Pterodon Knight",
             "text": "Pterodon Knight has flying as long as you control a Dinosaur.",
             "colours": [
@@ -992,7 +992,7 @@
         },
         {
             "id": "96d9f72f-e4bf-5b81-9d6d-87f0f17e643a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06c0007-299e-4d71-99c3-f905d942759d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f06c0007-299e-4d71-99c3-f905d942759d.jpg?1",
             "name": "Queen's Commission",
             "text": "Create two 1/1 white Vampire creature tokens with lifelink.",
             "colours": [
@@ -1024,7 +1024,7 @@
         },
         {
             "id": "b596de8a-9c3c-5aae-a67b-f916dcc135d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a5efb-fde9-4bba-be80-d073eba2ad8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03a5efb-fde9-4bba-be80-d073eba2ad8d.jpg?1",
             "name": "Rallying Roar",
             "text": "Creatures you control get +1/+1 until end of turn. Untap them.",
             "colours": [
@@ -1056,7 +1056,7 @@
         },
         {
             "id": "9bcda218-9eda-5dc6-b41d-5aec21bffab8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d37fc42-0a7c-46b3-9270-333d370e479f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d37fc42-0a7c-46b3-9270-333d370e479f.jpg?1",
             "name": "Raptor Companion",
             "text": "",
             "colours": [
@@ -1090,7 +1090,7 @@
         },
         {
             "id": "39434f90-0a00-5813-99d4-441e7be7c954",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691c0acb-1882-482f-9513-e7d010cc1d15.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/691c0acb-1882-482f-9513-e7d010cc1d15.jpg?1",
             "name": "Ritual of Rejuvenation",
             "text": "You gain 4 life.\nDraw a card.",
             "colours": [
@@ -1122,7 +1122,7 @@
         },
         {
             "id": "f19625c8-a237-598d-947b-5b294459fa56",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fae153-d86a-42b5-9c1c-6dbd56118ecb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9fae153-d86a-42b5-9c1c-6dbd56118ecb.jpg?1",
             "name": "Sanguine Sacrament",
             "text": "You gain twice X life. Put Sanguine Sacrament on the bottom of its owner's library.",
             "colours": [
@@ -1154,7 +1154,7 @@
         },
         {
             "id": "76b5f757-ce53-595b-8958-293fb5bb8cc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg?1",
             "name": "Settle the Wreckage",
             "text": "Exile all attacking creatures target player controls. That player may search his or her library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -1186,7 +1186,7 @@
         },
         {
             "id": "c956fc7f-ea47-54c6-b589-d93431936df2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c945c7-6c31-4c4f-9203-3dc2aef50820.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0c945c7-6c31-4c4f-9203-3dc2aef50820.jpg?1",
             "name": "Sheltering Light",
             "text": "Target creature gains indestructible until end of turn. Scry 1. (Damage and effects that say \"destroy\" don't destroy the creature.)",
             "colours": [
@@ -1218,7 +1218,7 @@
         },
         {
             "id": "be5a1016-18b1-5864-b86b-b95c3009393a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e900d0d-6f35-4e5d-9365-6ade227d218d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e900d0d-6f35-4e5d-9365-6ade227d218d.jpg?1",
             "name": "Shining Aerosaur",
             "text": "Flying",
             "colours": [
@@ -1252,7 +1252,7 @@
         },
         {
             "id": "5bfba646-3546-5e17-a736-f327c311f55e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e788e2-12e9-4041-8210-753aaef2576c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67e788e2-12e9-4041-8210-753aaef2576c.jpg?1",
             "name": "Skyblade of the Legion",
             "text": "Flying",
             "colours": [
@@ -1287,7 +1287,7 @@
         },
         {
             "id": "db1c1c78-e40a-57be-86fa-066a2bea81b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97d474e-83b6-4969-81b4-51f5315057d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a97d474e-83b6-4969-81b4-51f5315057d7.jpg?1",
             "name": "Slash of Talons",
             "text": "Slash of Talons deals 2 damage to target attacking or blocking creature.",
             "colours": [
@@ -1319,7 +1319,7 @@
         },
         {
             "id": "456de4f4-1459-59ab-b107-758adcf98947",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197934d5-726c-4cd3-a934-3d6449a5a56e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/197934d5-726c-4cd3-a934-3d6449a5a56e.jpg?1",
             "name": "Steadfast Armasaur",
             "text": "Vigilance\n{1}{W}, {T}: Steadfast Armasaur deals damage equal to its toughness to target creature blocking or blocked by it.",
             "colours": [
@@ -1353,7 +1353,7 @@
         },
         {
             "id": "086cc976-0eaf-5c65-9bcd-d0ae33a1b18f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d87b3-bf42-47ed-961d-d0e86d3e1d90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/709d87b3-bf42-47ed-961d-d0e86d3e1d90.jpg?1",
             "name": "Sunrise Seeker",
             "text": "Vigilance\nWhen Sunrise Seeker enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -1388,7 +1388,7 @@
         },
         {
             "id": "ce34a8c8-2368-5711-a949-4efe2244fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5a237a-31e7-43ee-8d47-3eb12dd1a60c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af5a237a-31e7-43ee-8d47-3eb12dd1a60c.jpg?1",
             "name": "Territorial Hammerskull",
             "text": "Whenever Territorial Hammerskull attacks, tap target creature an opponent controls.",
             "colours": [
@@ -1422,7 +1422,7 @@
         },
         {
             "id": "394717f7-84dd-5f57-a670-e25588faccea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fc3501-e7bd-4589-98c5-4476258842ea.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3fc3501-e7bd-4589-98c5-4476258842ea.jpg?1",
             "name": "Tocatli Honor Guard",
             "text": "Creatures entering the battlefield don't cause abilities to trigger.",
             "colours": [
@@ -1457,7 +1457,7 @@
         },
         {
             "id": "497f02db-ae3f-506a-a59f-dcf5b7b52c7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c507f6-c178-40be-bca7-3bd5adb1c5b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/8/88c507f6-c178-40be-bca7-3bd5adb1c5b1.jpg?1",
             "name": "Vampire's Zeal",
             "text": "Target creature gets +2/+2 until end of turn. If it's a Vampire, it gains first strike until end of turn.",
             "colours": [
@@ -1489,7 +1489,7 @@
         },
         {
             "id": "cb7f6021-e86e-5e60-919d-ead37a7c7694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7434abe4-87eb-4709-a26d-4e23154b4d31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/7434abe4-87eb-4709-a26d-4e23154b4d31.jpg?1",
             "name": "Wakening Sun's Avatar",
             "text": "When Wakening Sun's Avatar enters the battlefield, if you cast it from your hand, destroy all non-Dinosaur creatures.",
             "colours": [
@@ -1524,7 +1524,7 @@
         },
         {
             "id": "690d6a1f-6b49-5308-ac80-5bf2ecd48518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc9ba0a-2840-48cb-8cf4-ef2a5f273849.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fc9ba0a-2840-48cb-8cf4-ef2a5f273849.jpg?1",
             "name": "Air Elemental",
             "text": "Flying",
             "colours": [
@@ -1558,7 +1558,7 @@
         },
         {
             "id": "b60ea5bc-3ad8-55d2-a184-791ab33a244f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3edaaf-cf63-4e17-94ae-9d9991d9fb5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/f/bf3edaaf-cf63-4e17-94ae-9d9991d9fb5f.jpg?1",
             "name": "Arcane Adaptation",
             "text": "As Arcane Adaptation enters the battlefield, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
             "colours": [
@@ -1590,7 +1590,7 @@
         },
         {
             "id": "19981a7f-e2b3-5e8f-97c2-0d4494972146",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6e5ad6-ffe2-4588-b357-c415c33fbc11.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf6e5ad6-ffe2-4588-b357-c415c33fbc11.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1622,7 +1622,7 @@
         },
         {
             "id": "cefd1be9-025f-524c-8950-7645d9cb3f57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98291778-2ec2-47e2-ac99-5f8cfbb3cf24.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98291778-2ec2-47e2-ac99-5f8cfbb3cf24.jpg?1",
             "name": "Chart a Course",
             "text": "Draw two cards. Then discard a card unless you attacked with a creature this turn.",
             "colours": [
@@ -1654,7 +1654,7 @@
         },
         {
             "id": "8fb184ab-2ef0-5edd-a75f-f6bfcdf92b49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cb012c-947c-4281-8619-1384acf6df54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57cb012c-947c-4281-8619-1384acf6df54.jpg?1",
             "name": "Daring Saboteur",
             "text": "{2}{U}: Daring Saboteur can't be blocked this turn.\nWhenever Daring Saboteur deals combat damage to a player, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -1689,7 +1689,7 @@
         },
         {
             "id": "7a109ac9-3555-52b3-ab4c-0f801d9cf3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba70d58-69fd-4675-85d2-90bc2595c01c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5ba70d58-69fd-4675-85d2-90bc2595c01c.jpg?1",
             "name": "Deadeye Quartermaster",
             "text": "When Deadeye Quartermaster enters the battlefield, you may search your library for an Equipment or Vehicle card, reveal it, put it into your hand, then shuffle your library.",
             "colours": [
@@ -1724,7 +1724,7 @@
         },
         {
             "id": "4663572d-e950-551d-a7a9-8ccd7e03d11c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bec3b7-5dfc-4b48-ae8f-5bf49470d030.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24bec3b7-5dfc-4b48-ae8f-5bf49470d030.jpg?1",
             "name": "Deeproot Waters",
             "text": "Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token with hexproof. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1756,7 +1756,7 @@
         },
         {
             "id": "a3f8cfd2-6d26-5988-9d7b-575533967dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63420437-76a9-40cf-aedc-0ca1e73fcc0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63420437-76a9-40cf-aedc-0ca1e73fcc0b.jpg?1",
             "name": "Depths of Desire",
             "text": "Return target creature to its owner's hand. Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -1788,7 +1788,7 @@
         },
         {
             "id": "6238baf3-cb3e-5ade-bfea-6698fea93ba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33e493e-1aef-43b3-9716-52158b002430.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33e493e-1aef-43b3-9716-52158b002430.jpg?1",
             "name": "Dive Down",
             "text": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -1820,7 +1820,7 @@
         },
         {
             "id": "ae050434-1875-5e46-9b2a-56b0a92ec329",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548c92c8-1ae1-48b4-8cbe-aa18f59c1efb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/548c92c8-1ae1-48b4-8cbe-aa18f59c1efb.jpg?1",
             "name": "Dreamcaller Siren",
             "text": "Flash\nFlying\nDreamcaller Siren can block only creatures with flying.\nWhen Dreamcaller Siren enters the battlefield, if you control another Pirate, tap up to two target nonland permanents.",
             "colours": [
@@ -1855,7 +1855,7 @@
         },
         {
             "id": "a20eff8c-6ced-515a-9e23-a766b7e738e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15732049-7e56-432f-881f-215e45b7a70e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15732049-7e56-432f-881f-215e45b7a70e.jpg?1",
             "name": "Entrancing Melody",
             "text": "Gain control of target creature with converted mana cost X.",
             "colours": [
@@ -1887,7 +1887,7 @@
         },
         {
             "id": "611a7959-b28d-578c-9a7b-a8b360d4cf27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfe8174-4e75-4e8f-b59c-f80a98492b5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/adfe8174-4e75-4e8f-b59c-f80a98492b5f.jpg?1",
             "name": "Favorable Winds",
             "text": "Creatures you control with flying get +1/+1.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "8446098a-8754-5bcd-81e0-87ce8e8b0c8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edbde38-1653-4eb5-b196-8881375781cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7edbde38-1653-4eb5-b196-8881375781cb.jpg?1",
             "name": "Fleet Swallower",
             "text": "Whenever Fleet Swallower attacks, target player puts the top half of his or her library, rounded up, into his or her graveyard.",
             "colours": [
@@ -1953,7 +1953,7 @@
         },
         {
             "id": "8c461a8d-6c72-5a2f-b938-17171eb7d2e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2c338-f5e9-4596-9435-c6aa965ae541.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2af2c338-f5e9-4596-9435-c6aa965ae541.jpg?1",
             "name": "Headwater Sentries",
             "text": "",
             "colours": [
@@ -1988,7 +1988,7 @@
         },
         {
             "id": "7d3b0a5d-9da1-538b-a7de-64d868e51662",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168cbca9-0124-478b-8dd7-0bd9dc711c6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/168cbca9-0124-478b-8dd7-0bd9dc711c6d.jpg?1",
             "name": "Herald of Secret Streams",
             "text": "Creatures you control with +1/+1 counters on them can't be blocked.",
             "colours": [
@@ -2023,7 +2023,7 @@
         },
         {
             "id": "a046cc01-aef9-504c-9238-76eb83cec9f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f56f2-88fd-44ba-ad02-56ea3391f173.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b75f56f2-88fd-44ba-ad02-56ea3391f173.jpg?1",
             "name": "Jace, Cunning Castaway",
             "text": "+1: Whenever one or more creatures you control deal combat damage to a player this turn, draw a card, then discard a card.\n\u22122: Create a 2/2 blue Illusion creature token with \"When this creature becomes the target of a spell, sacrifice it.\"\n\u22125: Create two tokens that are copies of Jace, Cunning Castaway, except they're not legendary.",
             "colours": [
@@ -2059,7 +2059,7 @@
         },
         {
             "id": "02e7db1a-dccf-5f0e-b145-abc06cf6bfa4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34561f87-09d9-4f23-8a05-907fe1303e70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/34561f87-09d9-4f23-8a05-907fe1303e70.jpg?1",
             "name": "Kopala, Warden of Waves",
             "text": "Spells your opponents cast that target a Merfolk you control cost {2} more to cast.\nAbilities your opponents activate that target a Merfolk you control cost {2} more to activate.",
             "colours": [
@@ -2096,7 +2096,7 @@
         },
         {
             "id": "11dd43a3-dc7b-50a6-9b2a-99b360d99e93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5751a3c-7695-4c47-9cbd-92fd5b1b7ec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f5751a3c-7695-4c47-9cbd-92fd5b1b7ec9.jpg?1",
             "name": "Lookout's Dispersal",
             "text": "Lookout's Dispersal costs {1} less to cast if you control a Pirate.\nCounter target spell unless its controller pays {4}.",
             "colours": [
@@ -2128,7 +2128,7 @@
         },
         {
             "id": "03a9fcdc-cd3e-525e-b21b-e3c6abf09669",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb082e5e-770a-4c5a-8976-ee394ab73c86.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb082e5e-770a-4c5a-8976-ee394ab73c86.jpg?1",
             "name": "Navigator's Ruin",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked with a creature this turn, target opponent puts the top four cards of his or her library into his or her graveyard.",
             "colours": [
@@ -2160,7 +2160,7 @@
         },
         {
             "id": "cf3ea1fd-a327-5bc1-a1af-182db284ace1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c00f8bf-0088-44ad-b40b-26a2951a2428.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c00f8bf-0088-44ad-b40b-26a2951a2428.jpg?1",
             "name": "One With the Wind",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
             "colours": [
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "b9837f4b-8b26-5f7c-ba7d-16c495493672",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c3aa9f-5cb0-4c8d-a050-42938398071b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66c3aa9f-5cb0-4c8d-a050-42938398071b.jpg?1",
             "name": "Opt",
             "text": "Scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\nDraw a card.",
             "colours": [
@@ -2226,7 +2226,7 @@
         },
         {
             "id": "11aa5157-c7b1-5080-991b-d238b23d346c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg?1",
             "name": "Overflowing Insight",
             "text": "Target player draws seven cards.",
             "colours": [
@@ -2258,7 +2258,7 @@
         },
         {
             "id": "f3dc9db0-c51d-59e7-af34-037f55c6874c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6623e-2784-4bc9-9d8c-3eee9c78c350.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9f6623e-2784-4bc9-9d8c-3eee9c78c350.jpg?1",
             "name": "Perilous Voyage",
             "text": "Return target nonland permanent you don't control to its owner's hand. If its converted mana cost was 2 or less, scry 2.",
             "colours": [
@@ -2290,7 +2290,7 @@
         },
         {
             "id": "8e1caa33-dd20-54ee-a901-731181fc2151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d97373-9b55-4eb7-99b6-8912f09bd0bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48d97373-9b55-4eb7-99b6-8912f09bd0bb.jpg?1",
             "name": "Pirate's Prize",
             "text": "Draw two cards. Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2322,7 +2322,7 @@
         },
         {
             "id": "932244b0-3108-5e88-824e-8d7a72242094",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fed2d67-fc51-45e8-825b-fe7565e8a65d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fed2d67-fc51-45e8-825b-fe7565e8a65d.jpg?1",
             "name": "Prosperous Pirates",
             "text": "When Prosperous Pirates enters the battlefield, create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2357,7 +2357,7 @@
         },
         {
             "id": "c1b52e32-8ccd-59c3-adcf-a88babea37d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32ffc-dc1d-4bb2-926f-51d110392b06.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2be32ffc-dc1d-4bb2-926f-51d110392b06.jpg?1",
             "name": "River Sneak",
             "text": "River Sneak can't be blocked.\nWhenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "d75fea1a-dbae-5e2a-8fa9-5054c70d8558",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda8ef30-bbfa-4857-9750-0dd0def8b13f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fda8ef30-bbfa-4857-9750-0dd0def8b13f.jpg?1",
             "name": "River's Rebuke",
             "text": "Return all nonland permanents target player controls to their owner's hand.",
             "colours": [
@@ -2424,7 +2424,7 @@
         },
         {
             "id": "01e71d23-71b2-5713-9d09-6ab8d88085d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed573c6-2b95-4052-8b43-106cbaacb721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ed573c6-2b95-4052-8b43-106cbaacb721.jpg?1",
             "name": "Run Aground",
             "text": "Put target artifact or creature on top of its owner's library.",
             "colours": [
@@ -2456,7 +2456,7 @@
         },
         {
             "id": "b66f420a-39f6-5701-a0e7-dff8d9724c40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f15157-6017-4b05-8c74-b3f8728d764b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f15157-6017-4b05-8c74-b3f8728d764b.jpg?1",
             "name": "Sailor of Means",
             "text": "When Sailor of Means enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2491,7 +2491,7 @@
         },
         {
             "id": "934fb7c2-a194-5a67-b87c-0fea6f280dbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "At the beginning of your upkeep, look at the top card of your library. You may put it into your graveyard. Then if you have seven or more cards in your graveyard, you may transform Search for Azcanta.",
             "colours": [
@@ -2525,7 +2525,7 @@
         },
         {
             "id": "83013969-fdab-58c7-8649-5640b6bdb57e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/a/1a7e242e-bb48-4134-a1c2-6033713d658f.jpg?1",
             "name": "Search for Azcanta // Azcanta, the Sunken Ruin",
             "text": "(Transforms from Search for Azcanta.)\n{T}: Add {U} to your mana pool.\n{2}{U}, {T}: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [],
@@ -2557,7 +2557,7 @@
         },
         {
             "id": "c2da5b80-3ff9-5a15-a0d1-e436e049edb6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02955471-5ffc-4c7b-83fe-a69816415ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02955471-5ffc-4c7b-83fe-a69816415ca1.jpg?1",
             "name": "Shaper Apprentice",
             "text": "Shaper Apprentice has flying as long as you control another Merfolk.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "da3320be-8678-5127-810c-910e34ce7cdb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891cbde7-0dff-4877-b373-03f9f4332002.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/891cbde7-0dff-4877-b373-03f9f4332002.jpg?1",
             "name": "Shipwreck Looter",
             "text": "Raid \u2014 When Shipwreck Looter enters the battlefield, if you attacked with a creature this turn, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -2627,7 +2627,7 @@
         },
         {
             "id": "569d86aa-f607-5aee-bf7c-0843bc2490c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d1145-8640-44e1-8079-45832fa2556d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/135d1145-8640-44e1-8079-45832fa2556d.jpg?1",
             "name": "Shore Keeper",
             "text": "{7}{U}, {T}, Sacrifice Shore Keeper: Draw three cards.",
             "colours": [
@@ -2661,7 +2661,7 @@
         },
         {
             "id": "0d3b852b-b340-59fa-a471-49d6647e9b18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0000cd57-91fe-411f-b798-646e965eec37.jpg?1",
             "name": "Siren Lookout",
             "text": "Flying\nWhen Siren Lookout enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -2696,7 +2696,7 @@
         },
         {
             "id": "4c508df8-5c1b-5d35-9469-3399189b3c5b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f7375c-2d9b-4738-b539-00e1949980e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72f7375c-2d9b-4738-b539-00e1949980e7.jpg?1",
             "name": "Siren Stormtamer",
             "text": "Flying\n{U}, Sacrifice Siren Stormtamer: Counter target spell or ability that targets you or a creature you control.",
             "colours": [
@@ -2732,7 +2732,7 @@
         },
         {
             "id": "bb1c6f33-b999-5437-93d5-8fd9a3cec52e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f389872-d1f4-4828-a527-e820a6f2ac21.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f389872-d1f4-4828-a527-e820a6f2ac21.jpg?1",
             "name": "Siren's Ruse",
             "text": "Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card.",
             "colours": [
@@ -2764,7 +2764,7 @@
         },
         {
             "id": "789f2a24-d67a-5892-8d84-d09480b18c79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf4dfc0-c58b-4535-b660-54ceaa6e0217.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf4dfc0-c58b-4535-b660-54ceaa6e0217.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2796,7 +2796,7 @@
         },
         {
             "id": "b93b0988-491c-5ab5-b03f-7b6450169ef9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e619ada-e9ce-4758-afd8-8def853877eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e619ada-e9ce-4758-afd8-8def853877eb.jpg?1",
             "name": "Spell Swindle",
             "text": "Counter target spell. Create X colorless Treasure artifact tokens, where X is that spell's converted mana cost. They have \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -2828,7 +2828,7 @@
         },
         {
             "id": "e5275fef-0f05-554f-94c3-486833cce0df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1acd5-bee4-48fe-951d-7936e20f0a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9de1acd5-bee4-48fe-951d-7936e20f0a71.jpg?1",
             "name": "Storm Fleet Aerialist",
             "text": "Flying\nRaid \u2014 Storm Fleet Aerialist enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.",
             "colours": [
@@ -2863,7 +2863,7 @@
         },
         {
             "id": "4e7a3596-414d-5ab0-82ab-e118ddf45c83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c33ef4-60bb-4f95-92a5-7abedaac6767.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7c33ef4-60bb-4f95-92a5-7abedaac6767.jpg?1",
             "name": "Storm Fleet Spy",
             "text": "Raid \u2014 When Storm Fleet Spy enters the battlefield, if you attacked with a creature this turn, draw a card.",
             "colours": [
@@ -2898,7 +2898,7 @@
         },
         {
             "id": "ccedda2f-9dd9-5ce2-bd9b-8a8a75548ca9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9532b735-8390-4379-ae43-2bd00d281dd6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9532b735-8390-4379-ae43-2bd00d281dd6.jpg?1",
             "name": "Storm Sculptor",
             "text": "Storm Sculptor can't be blocked.\nWhen Storm Sculptor enters the battlefield, return a creature you control to its owner's hand.",
             "colours": [
@@ -2933,7 +2933,7 @@
         },
         {
             "id": "08a12f6a-5b63-56d4-a217-94dbe97cda70",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d0f22d-0448-4039-b6f3-75d12e10f48c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/64d0f22d-0448-4039-b6f3-75d12e10f48c.jpg?1",
             "name": "Tempest Caller",
             "text": "When Tempest Caller enters the battlefield, tap all creatures target opponent controls.",
             "colours": [
@@ -2968,7 +2968,7 @@
         },
         {
             "id": "c300ad97-90ac-599d-93ca-5f6c15051636",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d973568-d7b0-443f-a09d-44f6b02da5d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d973568-d7b0-443f-a09d-44f6b02da5d4.jpg?1",
             "name": "Watertrap Weaver",
             "text": "When Watertrap Weaver enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -3003,7 +3003,7 @@
         },
         {
             "id": "4103e89b-43fb-531c-a0e3-112b372e42f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613a8ab1-9c5e-4b56-aa51-daeb8c1983b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/613a8ab1-9c5e-4b56-aa51-daeb8c1983b9.jpg?1",
             "name": "Wind Strider",
             "text": "Flash\nFlying",
             "colours": [
@@ -3038,7 +3038,7 @@
         },
         {
             "id": "6b6a0625-b380-5bca-8e2a-bedc4c4959a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae5e75-0048-41fd-8bbb-89607ab96d6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bae5e75-0048-41fd-8bbb-89607ab96d6e.jpg?1",
             "name": "Anointed Deacon",
             "text": "At the beginning of combat on your turn, you may have target Vampire get +2/+0 until end of turn.",
             "colours": [
@@ -3073,7 +3073,7 @@
         },
         {
             "id": "c1ba207f-a6c3-5076-b6f3-aa8cd8d2759e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg?1",
             "name": "Arguel's Blood Fast // Temple of Aclazotz",
             "text": "{1}{B}, Pay 2 life: Draw a card.\nAt the beginning of your upkeep, if you have 5 or less life, you may transform Arguel's Blood Fast.",
             "colours": [
@@ -3107,7 +3107,7 @@
         },
         {
             "id": "56e48acf-d6bd-56c6-a030-bb02221a2c85",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c4ac7570-e74e-4081-ac53-cf41e695b7eb.jpg?1",
             "name": "Arguel's Blood Fast // Temple of Aclazotz",
             "text": "(Transforms from Arguel's Blood Fast.)\n{T}: Add {B} to your mana pool.\n{T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.",
             "colours": [],
@@ -3139,7 +3139,7 @@
         },
         {
             "id": "8fd928b1-21a9-5fca-9881-64b2640392f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373131be-bd66-49f5-80fa-836ced03fedf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/373131be-bd66-49f5-80fa-836ced03fedf.jpg?1",
             "name": "Bishop of the Bloodstained",
             "text": "When Bishop of the Bloodstained enters the battlefield, target opponent loses 1 life for each Vampire you control.",
             "colours": [
@@ -3174,7 +3174,7 @@
         },
         {
             "id": "4ed26f1c-5dd2-505b-bc8e-9d966d256c3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bcabe2d-82d2-4c1b-8f28-21dc29c9dbf2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bcabe2d-82d2-4c1b-8f28-21dc29c9dbf2.jpg?1",
             "name": "Blight Keeper",
             "text": "Flying\n{7}{B}, {T}, Sacrifice Blight Keeper: Target opponent loses 4 life and you gain 4 life.",
             "colours": [
@@ -3209,7 +3209,7 @@
         },
         {
             "id": "b866547c-c1ae-55b7-976b-5293ff76c127",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2160e9-14a0-4c75-b7b0-fb09051ddb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e2160e9-14a0-4c75-b7b0-fb09051ddb32.jpg?1",
             "name": "Bloodcrazed Paladin",
             "text": "Flash\nBloodcrazed Paladin enters the battlefield with a +1/+1 counter on it for each creature that died this turn.",
             "colours": [
@@ -3244,7 +3244,7 @@
         },
         {
             "id": "f9600ec0-367d-593e-b815-1ea190879740",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35989b1e-9bad-4f8d-a559-bf14d1342aa3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35989b1e-9bad-4f8d-a559-bf14d1342aa3.jpg?1",
             "name": "Boneyard Parley",
             "text": "Exile up to five target creature cards from graveyards. An opponent separates those cards into two piles. Put all cards from the pile of your choice onto the battlefield under your control and the rest into their owners' graveyards.",
             "colours": [
@@ -3276,7 +3276,7 @@
         },
         {
             "id": "aa9384ea-83df-5d58-8a08-09d3491c1236",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20feb-b1ed-4d80-bef9-f3cc44ffb7b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1f20feb-b1ed-4d80-bef9-f3cc44ffb7b0.jpg?1",
             "name": "Contract Killing",
             "text": "Destroy target creature. Create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3308,7 +3308,7 @@
         },
         {
             "id": "39b61b96-9a8e-5376-b6f4-0fdc8b7ea736",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f1f41e-98fc-4f6b-b287-c8899dff8ab0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c3f1f41e-98fc-4f6b-b287-c8899dff8ab0.jpg?1",
             "name": "Costly Plunder",
             "text": "As an additional cost to cast Costly Plunder, sacrifice an artifact or creature.\nDraw two cards.",
             "colours": [
@@ -3340,7 +3340,7 @@
         },
         {
             "id": "295f770c-2bae-501f-89d4-920fe9b39535",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053c4cf0-992b-4f76-b8d1-cd67f894172c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/053c4cf0-992b-4f76-b8d1-cd67f894172c.jpg?1",
             "name": "Dark Nourishment",
             "text": "Dark Nourishment deals 3 damage to target creature or player. You gain 3 life.",
             "colours": [
@@ -3372,7 +3372,7 @@
         },
         {
             "id": "08faf10b-bba4-5271-9af4-b461a69e0619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d219fb0a-49a3-4711-9b37-a0c1b36f68d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d219fb0a-49a3-4711-9b37-a0c1b36f68d0.jpg?1",
             "name": "Deadeye Tormentor",
             "text": "Raid \u2014 When Deadeye Tormentor enters the battlefield, if you attacked with a creature this turn, target opponent discards a card.",
             "colours": [
@@ -3407,7 +3407,7 @@
         },
         {
             "id": "4720323c-a728-5763-88ff-64f9d8e15b65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848902db-7a10-4754-b50a-57a9e845705a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/848902db-7a10-4754-b50a-57a9e845705a.jpg?1",
             "name": "Deadeye Tracker",
             "text": "{1}{B}, {T}: Exile two target cards from an opponent's graveyard. Deadeye Tracker explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3442,7 +3442,7 @@
         },
         {
             "id": "30ee39c2-2cc5-5c5b-883d-8f33e03f749c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc1cd9-22ff-4263-856b-0aaa990a3893.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8adc1cd9-22ff-4263-856b-0aaa990a3893.jpg?1",
             "name": "Deathless Ancient",
             "text": "Flying\nTap three untapped Vampires you control: Return Deathless Ancient from your graveyard to your hand.",
             "colours": [
@@ -3477,7 +3477,7 @@
         },
         {
             "id": "f7b8f3a7-b8e2-5daf-a160-5fd52f5d9e12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a92dde-7a84-40fb-a11e-54c7d3057126.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98a92dde-7a84-40fb-a11e-54c7d3057126.jpg?1",
             "name": "Desperate Castaways",
             "text": "Desperate Castaways can't attack unless you control an artifact.",
             "colours": [
@@ -3512,7 +3512,7 @@
         },
         {
             "id": "bc5e3b38-e46c-5e49-850a-7117d270b968",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd719e-fa21-42bb-968b-ccc0cd3829c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0fcd719e-fa21-42bb-968b-ccc0cd3829c6.jpg?1",
             "name": "Dire Fleet Hoarder",
             "text": "When Dire Fleet Hoarder dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "70582ea8-1f08-5b19-8bff-68e152401222",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e3f7ee-98d0-45bd-97ae-3dc8050085a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2e3f7ee-98d0-45bd-97ae-3dc8050085a1.jpg?1",
             "name": "Dire Fleet Interloper",
             "text": "Menace\nWhen Dire Fleet Interloper enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "5e674510-d098-55c5-aa76-221448b8c8cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bd7ccc-aa71-4a3f-a86e-936cb3b2cce3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53bd7ccc-aa71-4a3f-a86e-936cb3b2cce3.jpg?1",
             "name": "Dire Fleet Ravager",
             "text": "Menace, deathtouch\nWhen Dire Fleet Ravager enters the battlefield, each player loses a third of his or her life, rounded up.",
             "colours": [
@@ -3618,7 +3618,7 @@
         },
         {
             "id": "7f0f58cb-d8ab-51a5-b355-c4fc39d85baa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006cbb74-7447-45fb-b44b-bac31832b392.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/006cbb74-7447-45fb-b44b-bac31832b392.jpg?1",
             "name": "Duress",
             "text": "Target opponent reveals his or her hand. You choose a noncreature, nonland card from it. That player discards that card.",
             "colours": [
@@ -3650,7 +3650,7 @@
         },
         {
             "id": "cc7ec1e8-068e-5e9d-b13a-1946e56f187f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd7467-ff8c-4a92-ae55-6894213d6c0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36cd7467-ff8c-4a92-ae55-6894213d6c0b.jpg?1",
             "name": "Fathom Fleet Captain",
             "text": "Menace\nWhenever Fathom Fleet Captain attacks, if you control another nontoken Pirate, you may pay {2}. If you do, create a 2/2 black Pirate creature token with menace.",
             "colours": [
@@ -3685,7 +3685,7 @@
         },
         {
             "id": "d32bd811-ae7b-5752-96c9-9c48b74b28cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83500ed-8c46-488e-bd8e-197bedb8f4bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83500ed-8c46-488e-bd8e-197bedb8f4bd.jpg?1",
             "name": "Fathom Fleet Cutthroat",
             "text": "When Fathom Fleet Cutthroat enters the battlefield, destroy target creature an opponent controls that was dealt damage this turn.",
             "colours": [
@@ -3720,7 +3720,7 @@
         },
         {
             "id": "dab650ac-404d-5a00-90f1-7c1c75ecbab7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055934f-1567-4207-aaad-d32d0fe1cdba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0055934f-1567-4207-aaad-d32d0fe1cdba.jpg?1",
             "name": "Grim Captain's Call",
             "text": "Return a Pirate card from your graveyard to your hand, then do the same for Vampire, Dinosaur, and Merfolk.",
             "colours": [
@@ -3752,7 +3752,7 @@
         },
         {
             "id": "45f2320a-e322-5c83-9c7d-bc6023ec3486",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e791ce-1380-4de0-b314-246ea6dfc3cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5e791ce-1380-4de0-b314-246ea6dfc3cc.jpg?1",
             "name": "Heartless Pillage",
             "text": "Target opponent discards two cards.\nRaid \u2014 If you attacked with a creature this turn, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -3784,7 +3784,7 @@
         },
         {
             "id": "5a6be60b-a93a-543f-bfb8-7db8933f8132",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62fd592-4910-417d-a500-e7029f3d119f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f62fd592-4910-417d-a500-e7029f3d119f.jpg?1",
             "name": "Kitesail Freebooter",
             "text": "Flying\nWhen Kitesail Freebooter enters the battlefield, target opponent reveals his or her hand. You choose a noncreature, nonland card from it. Exile that card until Kitesail Freebooter leaves the battlefield.",
             "colours": [
@@ -3819,7 +3819,7 @@
         },
         {
             "id": "2ae2d538-5d6a-5f4a-b4c8-4623464f13e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdbaa34-1ee5-4a2a-bdb3-2f04809a5b42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abdbaa34-1ee5-4a2a-bdb3-2f04809a5b42.jpg?1",
             "name": "Lurking Chupacabra",
             "text": "Whenever a creature you control explores, target creature an opponent controls gets -2/-2 until end of turn.",
             "colours": [
@@ -3854,7 +3854,7 @@
         },
         {
             "id": "bede4658-97a1-504c-b119-ddff8482f15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8ae9-c6ea-4fab-ac9e-b25c62c540c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3dfb8ae9-c6ea-4fab-ac9e-b25c62c540c6.jpg?1",
             "name": "March of the Drowned",
             "text": "Choose one \u2014\n\u2022 Return target creature card from your graveyard to your hand.\n\u2022 Return two target Pirate cards from your graveyard to your hand.",
             "colours": [
@@ -3886,7 +3886,7 @@
         },
         {
             "id": "54747a6a-adfe-5e36-9984-0bd5cfd0165d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fec80c-81d5-4d3b-bc07-6fc6c2513ef8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/55fec80c-81d5-4d3b-bc07-6fc6c2513ef8.jpg?1",
             "name": "Mark of the Vampire",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
             "colours": [
@@ -3920,7 +3920,7 @@
         },
         {
             "id": "d8ecbf8c-42e2-53f0-a161-dc9e177dccc0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3562f65a-bd69-47e4-9d9d-ab5c2c6ceb35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/3562f65a-bd69-47e4-9d9d-ab5c2c6ceb35.jpg?1",
             "name": "Queen's Agent",
             "text": "Lifelink\nWhen Queen's Agent enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -3955,7 +3955,7 @@
         },
         {
             "id": "ac19f1bb-da8c-579d-83f3-32e1348e0878",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ca2e6-f920-4529-88d2-d984bdb7490a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce2ca2e6-f920-4529-88d2-d984bdb7490a.jpg?1",
             "name": "Queen's Bay Soldier",
             "text": "",
             "colours": [
@@ -3990,7 +3990,7 @@
         },
         {
             "id": "f45399ac-4cd4-5af5-a360-f94e1edd35de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd81dd41-a982-46d2-a572-432580be73c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd81dd41-a982-46d2-a572-432580be73c5.jpg?1",
             "name": "Raiders' Wake",
             "text": "Whenever an opponent discards a card, that player loses 2 life.\nRaid \u2014 At the beginning of your end step, if you attacked with a creature this turn, target opponent discards a card.",
             "colours": [
@@ -4022,7 +4022,7 @@
         },
         {
             "id": "b2c955c0-7f0b-5748-ab5d-98af82d8c682",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b0e035-8716-469d-99ae-a530cd96ef09.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/79b0e035-8716-469d-99ae-a530cd96ef09.jpg?1",
             "name": "Revel in Riches",
             "text": "Whenever a creature an opponent controls dies, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nAt the beginning of your upkeep, if you control ten or more Treasures, you win the game.",
             "colours": [
@@ -4054,7 +4054,7 @@
         },
         {
             "id": "d0732a5c-d4da-5b05-a6a3-fc19aa5a6556",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457ba695-3637-40de-a8a8-e3a43a71674f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/457ba695-3637-40de-a8a8-e3a43a71674f.jpg?1",
             "name": "Ruin Raider",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked with a creature this turn, reveal the top card of your library and put that card into your hand. You lose life equal to the card's converted mana cost.",
             "colours": [
@@ -4089,7 +4089,7 @@
         },
         {
             "id": "1a58a484-ca1a-5fe3-b68c-11432d7f618f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce91e38-4601-4354-ad1b-2c5c1c70da17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ce91e38-4601-4354-ad1b-2c5c1c70da17.jpg?1",
             "name": "Ruthless Knave",
             "text": "{2}{B}, Sacrifice a creature: Create two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nSacrifice three Treasures: Draw a card.",
             "colours": [
@@ -4124,7 +4124,7 @@
         },
         {
             "id": "09173e5f-5cde-5dcb-b5e4-6d33c92786d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72150779-0bb6-4d20-a898-cda93a66e7cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72150779-0bb6-4d20-a898-cda93a66e7cd.jpg?1",
             "name": "Sanctum Seeker",
             "text": "Whenever a Vampire you control attacks, each opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "04032b71-8d05-5e61-ad5a-ba561d022389",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37a6802-7a1d-4d37-bd65-f3e3e5127aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e37a6802-7a1d-4d37-bd65-f3e3e5127aca.jpg?1",
             "name": "Seekers' Squire",
             "text": "When Seekers' Squire enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -4194,7 +4194,7 @@
         },
         {
             "id": "9f832092-9f4d-51f8-b710-f369bd512ae3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0722fbdf-c092-4e80-913f-29390177cdcb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/0722fbdf-c092-4e80-913f-29390177cdcb.jpg?1",
             "name": "Skittering Heartstopper",
             "text": "{B}: Skittering Heartstopper gains deathtouch until end of turn.",
             "colours": [
@@ -4228,7 +4228,7 @@
         },
         {
             "id": "5b116bf1-6032-5b42-9865-779c77d12fe9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30343b-1637-490f-810e-d614219789e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba30343b-1637-490f-810e-d614219789e3.jpg?1",
             "name": "Skulduggery",
             "text": "Until end of turn, target creature you control gets +1/+1 and target creature an opponent controls gets -1/-1.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "8b7254f9-54a6-5f1c-8fcf-118f46a2283c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b41d7-30fa-43ab-8f8d-c1de68a19add.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f4b41d7-30fa-43ab-8f8d-c1de68a19add.jpg?1",
             "name": "Skymarch Bloodletter",
             "text": "Flying\nWhen Skymarch Bloodletter enters the battlefield, target opponent loses 1 life and you gain 1 life.",
             "colours": [
@@ -4295,7 +4295,7 @@
         },
         {
             "id": "73233dad-3486-5d57-93a6-9f0e9eeb3575",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8a160c-5e89-4347-8e88-3541b6d221e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8a160c-5e89-4347-8e88-3541b6d221e0.jpg?1",
             "name": "Spreading Rot",
             "text": "Destroy target land. Its controller loses 2 life.",
             "colours": [
@@ -4327,7 +4327,7 @@
         },
         {
             "id": "a20cb5f6-ef4d-564a-b014-ebc0f80d977d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25750098-02a1-48e4-917d-187c41e111b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25750098-02a1-48e4-917d-187c41e111b6.jpg?1",
             "name": "Sword-Point Diplomacy",
             "text": "Reveal the top three cards of your library. For each of those cards, put that card into your hand unless any opponent pays 3 life. Then exile the rest.",
             "colours": [
@@ -4359,7 +4359,7 @@
         },
         {
             "id": "a3ea6836-cb9d-5b79-a3d2-9774a62363bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e599ed0b-4b3b-4341-b6ac-7fdfdc6799a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e599ed0b-4b3b-4341-b6ac-7fdfdc6799a3.jpg?1",
             "name": "Vanquish the Weak",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "d5d2900a-15d7-5d94-b2a1-1fcd14ed2996",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4b6ced-e8d3-47e9-bd27-3e0cb644afe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a4b6ced-e8d3-47e9-bd27-3e0cb644afe4.jpg?1",
             "name": "Vicious Conquistador",
             "text": "Whenever Vicious Conquistador attacks, each opponent loses 1 life.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "0c2dcc7c-e499-5049-b7a7-d8057dc47c7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg?1",
             "name": "Vraska's Contempt",
             "text": "Exile target creature or planeswalker. You gain 2 life.",
             "colours": [
@@ -4458,7 +4458,7 @@
         },
         {
             "id": "a2bcb4aa-0f5f-588d-9dac-c15eac9b71dd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ac6a-318f-44fb-bb64-7ae172c4aca3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/0038ac6a-318f-44fb-bb64-7ae172c4aca3.jpg?1",
             "name": "Walk the Plank",
             "text": "Destroy target non-Merfolk creature.",
             "colours": [
@@ -4490,7 +4490,7 @@
         },
         {
             "id": "fa3c4031-f1fa-5cda-8946-e265ba2ff71e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6704e4c9-3b5e-4ba5-a5bc-6d684e2983e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6704e4c9-3b5e-4ba5-a5bc-6d684e2983e9.jpg?1",
             "name": "Wanted Scoundrels",
             "text": "When Wanted Scoundrels dies, target opponent creates two colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -4525,7 +4525,7 @@
         },
         {
             "id": "764a3368-0ca0-50ce-8ca9-c449082f1a05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfc9e0-14e8-43ce-8fca-773b7f2387dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0bfc9e0-14e8-43ce-8fca-773b7f2387dc.jpg?1",
             "name": "Angrath's Marauders",
             "text": "If a source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
             "colours": [
@@ -4560,7 +4560,7 @@
         },
         {
             "id": "a7dcc141-1112-55ee-b7a6-74cbd4a8c4a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ad54a-73f8-4b97-b890-2be9a178bc42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a50ad54a-73f8-4b97-b890-2be9a178bc42.jpg?1",
             "name": "Bonded Horncrest",
             "text": "Bonded Horncrest can't attack or block alone.",
             "colours": [
@@ -4594,7 +4594,7 @@
         },
         {
             "id": "818933f6-0665-53aa-8cdc-a8576e5fb90f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca29a73-9606-4422-9187-67e00dcd52aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9ca29a73-9606-4422-9187-67e00dcd52aa.jpg?1",
             "name": "Brazen Buccaneers",
             "text": "Haste\nWhen Brazen Buccaneers enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -4629,7 +4629,7 @@
         },
         {
             "id": "3f0a0a83-b889-5aa3-bafb-6994ca7a91ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146c0cab-5f6b-425d-9f50-33d8da266235.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/4/146c0cab-5f6b-425d-9f50-33d8da266235.jpg?1",
             "name": "Burning Sun's Avatar",
             "text": "When Burning Sun's Avatar enters the battlefield, it deals 3 damage to target opponent and 3 damage to up to one target creature.",
             "colours": [
@@ -4664,7 +4664,7 @@
         },
         {
             "id": "168ba29e-f991-59b9-958c-f172da872a15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab86a8a-7a0a-473e-9a97-da2fe0ab866c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5ab86a8a-7a0a-473e-9a97-da2fe0ab866c.jpg?1",
             "name": "Captain Lannery Storm",
             "text": "Haste\nWhenever Captain Lannery Storm attacks, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nWhenever you sacrifice a Treasure, Captain Lannery Storm gets +1/+0 until end of turn.",
             "colours": [
@@ -4701,7 +4701,7 @@
         },
         {
             "id": "03c080ad-4643-53d6-ad5e-8c6ca6f172e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76e66c1-dbe2-4346-b4b3-20e8386e7d76.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76e66c1-dbe2-4346-b4b3-20e8386e7d76.jpg?1",
             "name": "Captivating Crew",
             "text": "{3}{R}: Gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn. Activate this ability only any time you could cast a sorcery.",
             "colours": [
@@ -4736,7 +4736,7 @@
         },
         {
             "id": "9b94c686-6364-5424-ba67-8c4782d0576f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5222448-95d1-4b63-ab76-d5060febcf38.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5222448-95d1-4b63-ab76-d5060febcf38.jpg?1",
             "name": "Charging Monstrosaur",
             "text": "Trample, haste",
             "colours": [
@@ -4770,7 +4770,7 @@
         },
         {
             "id": "cba2630b-a44a-5157-ad36-9dd3492b7bbc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48aa427-b2d5-4562-bd69-e98913d53fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d48aa427-b2d5-4562-bd69-e98913d53fb1.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4802,7 +4802,7 @@
         },
         {
             "id": "af759d90-8794-57cf-946e-e9a75cef5c91",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31bda74-8455-45ab-8142-65fbde2f39c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a31bda74-8455-45ab-8142-65fbde2f39c3.jpg?1",
             "name": "Dinosaur Stampede",
             "text": "Attacking creatures get +2/+0 until end of turn. Dinosaurs you control gain trample until end of turn.",
             "colours": [
@@ -4834,7 +4834,7 @@
         },
         {
             "id": "103eafc3-ee91-541f-8426-2508fc273daf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb504d2-d3de-4b09-9007-3d403fc9a216.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0bb504d2-d3de-4b09-9007-3d403fc9a216.jpg?1",
             "name": "Dual Shot",
             "text": "Dual Shot deals 1 damage to each of up to two target creatures.",
             "colours": [
@@ -4866,7 +4866,7 @@
         },
         {
             "id": "a038d27b-2492-5223-a927-f5445d31fcd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52280963-ba5b-4735-b5cb-67866f8624c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52280963-ba5b-4735-b5cb-67866f8624c9.jpg?1",
             "name": "Fathom Fleet Firebrand",
             "text": "{1}{R}: Fathom Fleet Firebrand gets +1/+0 until end of turn.",
             "colours": [
@@ -4901,7 +4901,7 @@
         },
         {
             "id": "39c19f81-70a0-5f08-84d9-b3ab1d45212d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d21c9-4b6c-4797-845f-7bca79c2b76b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/664d21c9-4b6c-4797-845f-7bca79c2b76b.jpg?1",
             "name": "Fiery Cannonade",
             "text": "Fiery Cannonade deals 2 damage to each non-Pirate creature.",
             "colours": [
@@ -4933,7 +4933,7 @@
         },
         {
             "id": "92480b66-f8f0-575a-b1f9-6e707fed6b02",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54135905-9b15-4bf9-8f4d-4ea7a0c75b77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54135905-9b15-4bf9-8f4d-4ea7a0c75b77.jpg?1",
             "name": "Fire Shrine Keeper",
             "text": "Menace\n{7}{R}, {T}, Sacrifice Fire Shrine Keeper: It deals 3 damage to each of up to two target creatures.",
             "colours": [
@@ -4967,7 +4967,7 @@
         },
         {
             "id": "b5817d4c-5af6-524c-9d63-47f40c904d83",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f083c3-d7b0-4d3d-8551-af52c7883d83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b1f083c3-d7b0-4d3d-8551-af52c7883d83.jpg?1",
             "name": "Firecannon Blast",
             "text": "Firecannon Blast deals 3 damage to target creature.\nRaid \u2014 Firecannon Blast deals 6 damage to that creature instead if you attacked with a creature this turn.",
             "colours": [
@@ -4999,7 +4999,7 @@
         },
         {
             "id": "385aba97-41fc-5b0a-b918-e7fd29e10cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c3a1c9-ffa2-4990-aa4b-db9d688f1ed4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a7c3a1c9-ffa2-4990-aa4b-db9d688f1ed4.jpg?1",
             "name": "Frenzied Raptor",
             "text": "",
             "colours": [
@@ -5033,7 +5033,7 @@
         },
         {
             "id": "17b9d20d-2782-5f5b-a7d0-695d81e3e13d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66973e90-0c8b-4438-bc22-6e78930c194d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66973e90-0c8b-4438-bc22-6e78930c194d.jpg?1",
             "name": "Headstrong Brute",
             "text": "Headstrong Brute can't block.\nHeadstrong Brute has menace as long as you control another Pirate.",
             "colours": [
@@ -5068,7 +5068,7 @@
         },
         {
             "id": "623ef364-5281-59a1-bd07-d862f65f8529",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519c5660-4daf-4404-b808-66d1c840ab70.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/519c5660-4daf-4404-b808-66d1c840ab70.jpg?1",
             "name": "Hijack",
             "text": "Gain control of target artifact or creature until end of turn. Untap it. It gains haste until end of turn.",
             "colours": [
@@ -5100,7 +5100,7 @@
         },
         {
             "id": "ae7e8264-759e-5b87-adc5-bd8de1181384",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f55dee-7e39-4183-8e74-844d9c299bf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f55dee-7e39-4183-8e74-844d9c299bf5.jpg?1",
             "name": "Lightning Strike",
             "text": "Lightning Strike deals 3 damage to target creature or player.",
             "colours": [
@@ -5132,7 +5132,7 @@
         },
         {
             "id": "c171b9ab-2716-5ff9-861a-a6b703eb5e5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4a34ce-94d5-4e4d-97cc-1326cf5241f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb4a34ce-94d5-4e4d-97cc-1326cf5241f5.jpg?1",
             "name": "Lightning-Rig Crew",
             "text": "{T}: Lightning-Rig Crew deals 1 damage to each opponent.\nWhenever you cast a Pirate spell, untap Lightning-Rig Crew.",
             "colours": [
@@ -5167,7 +5167,7 @@
         },
         {
             "id": "168069b8-68bc-5ee1-ae76-7ddeef22fe98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65689442-e679-4844-91a8-f6a39a7c1f9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/65689442-e679-4844-91a8-f6a39a7c1f9b.jpg?1",
             "name": "Makeshift Munitions",
             "text": "{1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to target creature or player.",
             "colours": [
@@ -5199,7 +5199,7 @@
         },
         {
             "id": "e96b1a6b-58b3-5394-8613-8069a59135e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576d3845-f45a-4db0-9f7c-845cedb64c49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/576d3845-f45a-4db0-9f7c-845cedb64c49.jpg?1",
             "name": "Nest Robber",
             "text": "Haste",
             "colours": [
@@ -5233,7 +5233,7 @@
         },
         {
             "id": "f2624362-a4e6-512d-8a8b-f2405bb070db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c334e6f3-1378-4429-b4f1-fa8ed7ab7123.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c334e6f3-1378-4429-b4f1-fa8ed7ab7123.jpg?1",
             "name": "Otepec Huntmaster",
             "text": "Dinosaur spells you cast cost {1} less to cast.\n{T}: Target Dinosaur gains haste until end of turn.",
             "colours": [
@@ -5268,7 +5268,7 @@
         },
         {
             "id": "98e6a6ec-5068-5db7-a4ae-3e8618fd2192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d3c658-1927-4af3-9077-88c4a669c730.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39d3c658-1927-4af3-9077-88c4a669c730.jpg?1",
             "name": "Rampaging Ferocidon",
             "text": "Menace\nPlayers can't gain life.\nWhenever another creature enters the battlefield, Rampaging Ferocidon deals 1 damage to that creature's controller.",
             "colours": [
@@ -5302,7 +5302,7 @@
         },
         {
             "id": "a8cc4ab7-29e5-5455-b4ca-b2584347bc61",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093e88d-fd3c-43d3-a025-9ebb9f02a84f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/8093e88d-fd3c-43d3-a025-9ebb9f02a84f.jpg?1",
             "name": "Raptor Hatchling",
             "text": "Enrage \u2014 Whenever Raptor Hatchling is dealt damage, create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -5336,7 +5336,7 @@
         },
         {
             "id": "6f240a9b-e1af-5d71-a159-625bfde06d76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90a2d6-8292-4ff1-91d0-b30ae9775f12.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba90a2d6-8292-4ff1-91d0-b30ae9775f12.jpg?1",
             "name": "Repeating Barrage",
             "text": "Repeating Barrage deals 3 damage to target creature or player.\nRaid \u2014 {3}{R}{R}: Return Repeating Barrage from your graveyard to your hand. Activate this ability only if you attacked with a creature this turn.",
             "colours": [
@@ -5368,7 +5368,7 @@
         },
         {
             "id": "fdcd8856-159d-555e-b8d8-2ac2d354fd33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9983ce-8ca6-450a-9cac-5396ba8e1690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb9983ce-8ca6-450a-9cac-5396ba8e1690.jpg?1",
             "name": "Rigging Runner",
             "text": "First strike\nRaid \u2014 Rigging Runner enters the battlefield with a +1/+1 counter on it if you attacked with a creature this turn.",
             "colours": [
@@ -5403,7 +5403,7 @@
         },
         {
             "id": "0da19f41-11d4-5136-9889-acf39ea483db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80925750-6c90-42d1-9525-27f1f0313398.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80925750-6c90-42d1-9525-27f1f0313398.jpg?1",
             "name": "Rile",
             "text": "Rile deals 1 damage to target creature you control. That creature gains trample until end of turn.\nDraw a card.",
             "colours": [
@@ -5435,7 +5435,7 @@
         },
         {
             "id": "37b9996f-e867-50f2-89e2-f2dd92cb4117",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb3821a-ecc8-478d-93de-57200476868c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bdb3821a-ecc8-478d-93de-57200476868c.jpg?1",
             "name": "Rowdy Crew",
             "text": "Trample\nWhen Rowdy Crew enters the battlefield, draw three cards, then discard two cards at random. If two cards that share a card type are discarded this way, put two +1/+1 counters on Rowdy Crew.",
             "colours": [
@@ -5470,7 +5470,7 @@
         },
         {
             "id": "b6007468-4947-582a-ae70-2f81b1b12948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8342ad27-f2cd-47c3-bc30-6fae8523f250.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/8342ad27-f2cd-47c3-bc30-6fae8523f250.jpg?1",
             "name": "Rummaging Goblin",
             "text": "{T}, Discard a card: Draw a card.",
             "colours": [
@@ -5505,7 +5505,7 @@
         },
         {
             "id": "b1c28fb2-de80-514a-8567-ddab9d1d3f7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021f57dc-80f3-4ede-99d5-4a44aade44e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/021f57dc-80f3-4ede-99d5-4a44aade44e2.jpg?1",
             "name": "Star of Extinction",
             "text": "Destroy target land. Star of Extinction deals 20 damage to each creature and each planeswalker.",
             "colours": [
@@ -5537,7 +5537,7 @@
         },
         {
             "id": "e9e6a68d-c39b-50f8-9562-06c3e7dd3fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ecb6d-f794-468b-8399-60a50aaa13ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d8ecb6d-f794-468b-8399-60a50aaa13ac.jpg?1",
             "name": "Storm Fleet Arsonist",
             "text": "Raid \u2014 When Storm Fleet Arsonist enters the battlefield, if you attacked with a creature this turn, target opponent sacrifices a permanent.",
             "colours": [
@@ -5572,7 +5572,7 @@
         },
         {
             "id": "6b8ff733-8514-5c82-8185-d7b9de8d2690",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5f5e45-2abb-43e1-aecb-97f0390282a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab5f5e45-2abb-43e1-aecb-97f0390282a7.jpg?1",
             "name": "Storm Fleet Pyromancer",
             "text": "Raid \u2014 When Storm Fleet Pyromancer enters the battlefield, if you attacked with a creature this turn, Storm Fleet Pyromancer deals 2 damage to target creature or player.",
             "colours": [
@@ -5608,7 +5608,7 @@
         },
         {
             "id": "1e0724ee-6c9d-53a3-8682-fa24e7c7e0be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab793e-0e17-4940-9cab-a30d62df5c20.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cab793e-0e17-4940-9cab-a30d62df5c20.jpg?1",
             "name": "Sun-Crowned Hunters",
             "text": "Enrage \u2014 Whenever Sun-Crowned Hunters is dealt damage, it deals 3 damage to target opponent.",
             "colours": [
@@ -5642,7 +5642,7 @@
         },
         {
             "id": "f4562e59-1f33-5ed8-b8c6-5ae9aa7372fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52480-8faf-4418-af70-fd999096e3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee52480-8faf-4418-af70-fd999096e3bb.jpg?1",
             "name": "Sunbird's Invocation",
             "text": "Whenever you cast a spell from your hand, reveal the top X cards of your library, where X is that spell's converted mana cost. You may cast a card revealed this way with converted mana cost X or less without paying its mana cost. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -5674,7 +5674,7 @@
         },
         {
             "id": "cb0ef290-9cef-537b-b27a-b90835a61944",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5370060a-653b-453d-8daf-bef46f9bb4d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/5370060a-653b-453d-8daf-bef46f9bb4d5.jpg?1",
             "name": "Sure Strike",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5706,7 +5706,7 @@
         },
         {
             "id": "a5a0c5a6-36cf-5460-a8fc-668ecf87c3d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ed59b1-968b-4297-9e98-42d940f9478c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01ed59b1-968b-4297-9e98-42d940f9478c.jpg?1",
             "name": "Swashbuckling",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -5740,7 +5740,7 @@
         },
         {
             "id": "0d64ba46-c3ce-5c81-8a92-8dd55dd283e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a03b859-811c-45ff-8d8a-9e87e4bbf113.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a03b859-811c-45ff-8d8a-9e87e4bbf113.jpg?1",
             "name": "Thrash of Raptors",
             "text": "As long as you control another Dinosaur, Thrash of Raptors gets +2/+0 and has trample.",
             "colours": [
@@ -5774,7 +5774,7 @@
         },
         {
             "id": "b7bb6933-e350-5809-ae71-8968e123650c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25c2f33-1707-4ff3-a22e-58f51936b733.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b25c2f33-1707-4ff3-a22e-58f51936b733.jpg?1",
             "name": "Tilonalli's Knight",
             "text": "Whenever Tilonalli's Knight attacks, if you control a Dinosaur, Tilonalli's Knight gets +1/+1 until end of turn.",
             "colours": [
@@ -5809,7 +5809,7 @@
         },
         {
             "id": "a185ec34-e362-504d-a4ba-34ea9bd440d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab2765d-cfc4-4381-8cce-adce5aaf05ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aab2765d-cfc4-4381-8cce-adce5aaf05ad.jpg?1",
             "name": "Tilonalli's Skinshifter",
             "text": "Haste\nWhenever Tilonalli's Skinshifter attacks, it becomes a copy of another target nonlegendary attacking creature until end of turn.",
             "colours": [
@@ -5844,7 +5844,7 @@
         },
         {
             "id": "7371ea25-f0b1-58ff-ab1c-4fa1a6576cec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2df914-bb56-449e-9ef8-8b1012a76f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb2df914-bb56-449e-9ef8-8b1012a76f64.jpg?1",
             "name": "Trove of Temptation",
             "text": "Each opponent must attack you or a planeswalker you control with at least one creature each combat if able.\nAt the beginning of your end step, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -5876,7 +5876,7 @@
         },
         {
             "id": "c94f8b97-d6bf-5faa-969d-8207e9861e38",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b274-0499-4cb6-a2e4-f5e18ad7fd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a61b274-0499-4cb6-a2e4-f5e18ad7fd2d.jpg?1",
             "name": "Unfriendly Fire",
             "text": "Unfriendly Fire deals 4 damage to target creature or player.",
             "colours": [
@@ -5908,7 +5908,7 @@
         },
         {
             "id": "5638a279-f2e0-5fc6-bc07-daf5e1dd7980",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg?1",
             "name": "Vance's Blasting Cannons // Spitfire Bastion",
             "text": "At the beginning of your upkeep, exile the top card of your library. If it's a nonland card, you may cast that card this turn.\nWhenever you cast your third spell in a turn, you may transform Vance's Blasting Cannons.",
             "colours": [
@@ -5942,7 +5942,7 @@
         },
         {
             "id": "6eb85348-da9f-5443-939f-46e3471e1f2e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/e/9e8c0009-787f-480b-84b6-bf297f1fb466.jpg?1",
             "name": "Vance's Blasting Cannons // Spitfire Bastion",
             "text": "(Transforms from Vance's Blasting Cannons.)\n{T}: Add {R} to your mana pool.\n{2}{R}, {T}: Spitfire Bastion deals 3 damage to target creature or player.",
             "colours": [],
@@ -5974,7 +5974,7 @@
         },
         {
             "id": "964a97b7-c581-5fcc-bb6c-e734ec61b89a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175b24c-c256-45a8-b24a-6b83e42d5efa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a175b24c-c256-45a8-b24a-6b83e42d5efa.jpg?1",
             "name": "Wily Goblin",
             "text": "When Wily Goblin enters the battlefield, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -6009,7 +6009,7 @@
         },
         {
             "id": "432af4a6-b941-5d5a-8d16-bd53e7c422df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39421ce8-86d5-4739-b6fd-78d63c0bb258.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39421ce8-86d5-4739-b6fd-78d63c0bb258.jpg?1",
             "name": "Ancient Brontodon",
             "text": "",
             "colours": [
@@ -6043,7 +6043,7 @@
         },
         {
             "id": "248ce605-8f10-5ff0-b648-8dc9d46d95f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e214e0d-bd3d-467b-83fb-d8a232e166e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/e/3e214e0d-bd3d-467b-83fb-d8a232e166e4.jpg?1",
             "name": "Atzocan Archer",
             "text": "Reach\nWhen Atzocan Archer enters the battlefield, you may have it fight another target creature. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6078,7 +6078,7 @@
         },
         {
             "id": "ec120f6c-0344-5b2b-9b23-b29cd6781e6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae7d501-72a1-43c2-9f72-d768ac5e9320.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/bae7d501-72a1-43c2-9f72-d768ac5e9320.jpg?1",
             "name": "Blinding Fog",
             "text": "Prevent all damage that would be dealt to creatures this turn. Creatures you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)",
             "colours": [
@@ -6110,7 +6110,7 @@
         },
         {
             "id": "401c2610-840a-541f-8402-0119cba7b751",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a3645f-2b71-4816-a1f2-6cd4e987882f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66a3645f-2b71-4816-a1f2-6cd4e987882f.jpg?1",
             "name": "Blossom Dryad",
             "text": "{T}: Untap target land.",
             "colours": [
@@ -6144,7 +6144,7 @@
         },
         {
             "id": "a3f8c02e-733e-5753-80de-6d31e71adb30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg?1",
             "name": "Carnage Tyrant",
             "text": "Carnage Tyrant can't be countered.\nTrample, hexproof",
             "colours": [
@@ -6178,7 +6178,7 @@
         },
         {
             "id": "29d5afaf-6c80-5505-9a34-e8d79b5b9522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac5b70-47db-4cdb-91e7-e5c18c42e516.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76ac5b70-47db-4cdb-91e7-e5c18c42e516.jpg?1",
             "name": "Colossal Dreadmaw",
             "text": "Trample",
             "colours": [
@@ -6212,7 +6212,7 @@
         },
         {
             "id": "5a8a8323-29fe-5dbf-84ae-4cfa26fb54bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b9a07-6631-477a-8c77-3b04f211439d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/e/de4b9a07-6631-477a-8c77-3b04f211439d.jpg?1",
             "name": "Commune with Dinosaurs",
             "text": "Look at the top five cards of your library. You may reveal a Dinosaur or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6244,7 +6244,7 @@
         },
         {
             "id": "31774bdb-5b35-5bb1-8e01-8904e15f87a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b52d17-7efb-4c6e-9e6a-4763d1ef1daa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b52d17-7efb-4c6e-9e6a-4763d1ef1daa.jpg?1",
             "name": "Crash the Ramparts",
             "text": "Target creature gets +3/+3 and gains trample until end of turn.",
             "colours": [
@@ -6276,7 +6276,7 @@
         },
         {
             "id": "7d16e6f3-da9a-504f-a2a4-60d84353f123",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66b0e45-e585-44f3-8d2b-e887330ba138.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a66b0e45-e585-44f3-8d2b-e887330ba138.jpg?1",
             "name": "Crushing Canopy",
             "text": "Choose one \u2014\n\u2022 Destroy target creature with flying.\n\u2022 Destroy target enchantment.",
             "colours": [
@@ -6308,7 +6308,7 @@
         },
         {
             "id": "c240c240-508c-5e1b-afc6-b53b2daaa4e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e9d8a4-dfc2-4451-a15f-98592b817155.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0e9d8a4-dfc2-4451-a15f-98592b817155.jpg?1",
             "name": "Deathgorge Scavenger",
             "text": "Whenever Deathgorge Scavenger enters the battlefield or attacks, you may exile target card from a graveyard. If a creature card is exiled this way, you gain 2 life. If a noncreature card is exiled this way, Deathgorge Scavenger gets +1/+1 until end of turn.",
             "colours": [
@@ -6342,7 +6342,7 @@
         },
         {
             "id": "e924db67-ed0d-51c1-9508-d4805e8e2f69",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg?1",
             "name": "Deeproot Champion",
             "text": "Whenever you cast a noncreature spell, put a +1/+1 counter on Deeproot Champion.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "60e8849a-67ec-5a12-ba3b-d77476f3a4da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a1963-ec46-4ed3-9be1-e4cc09687922.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c1a1963-ec46-4ed3-9be1-e4cc09687922.jpg?1",
             "name": "Deeproot Warrior",
             "text": "Whenever Deeproot Warrior becomes blocked, it gets +1/+1 until end of turn.",
             "colours": [
@@ -6412,7 +6412,7 @@
         },
         {
             "id": "167788bd-e9dc-5f93-94ac-342780d4b14c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdf2fc-d948-4c64-a34e-2f90eab83212.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51fdf2fc-d948-4c64-a34e-2f90eab83212.jpg?1",
             "name": "Drover of the Mighty",
             "text": "Drover of the Mighty gets +2/+2 as long as you control a Dinosaur.\n{T}: Add one mana of any color to your mana pool.",
             "colours": [
@@ -6447,7 +6447,7 @@
         },
         {
             "id": "50fad4bc-9ddc-5dc7-ab8f-67dc38a7e50c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e396762-fe76-4b2d-b571-373ab2c240ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e396762-fe76-4b2d-b571-373ab2c240ad.jpg?1",
             "name": "Emergent Growth",
             "text": "Target creature gets +5/+5 until end of turn and must be blocked this turn if able.",
             "colours": [
@@ -6479,7 +6479,7 @@
         },
         {
             "id": "d5760eae-5650-52c7-bbd8-aa88874ace9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c22b9-bdb7-4933-a58a-c53d040ae3bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f10c22b9-bdb7-4933-a58a-c53d040ae3bb.jpg?1",
             "name": "Emperor's Vanguard",
             "text": "Whenever Emperor's Vanguard deals combat damage to a player, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6514,7 +6514,7 @@
         },
         {
             "id": "05691d13-a1f7-5e33-bd5f-1f050dc3ab7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cbd690-4d6e-49a7-bded-e6ecee2c76b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75cbd690-4d6e-49a7-bded-e6ecee2c76b6.jpg?1",
             "name": "Grazing Whiptail",
             "text": "Reach",
             "colours": [
@@ -6548,7 +6548,7 @@
         },
         {
             "id": "d8d96736-acc9-58e2-81a5-0360b35521de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "When Growing Rites of Itlimoc enters the battlefield, look at the top four cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nAt the beginning of your end step, if you control four or more creatures, transform Growing Rites of Itlimoc.",
             "colours": [
@@ -6582,7 +6582,7 @@
         },
         {
             "id": "fb418740-d772-5e20-8b7d-ec446e905436",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/3/b3b87bfc-f97f-4734-94f6-e3e2f335fc4d.jpg?1",
             "name": "Growing Rites of Itlimoc // Itlimoc, Cradle of the Sun",
             "text": "(Transforms from Growing Rites of Itlimoc.)\n{T}: Add {G} to your mana pool.\n{T}: Add {G} to your mana pool for each creature you control.",
             "colours": [],
@@ -6614,7 +6614,7 @@
         },
         {
             "id": "2c7a21dc-e154-599c-b9e0-a7f0fa61ab66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22b55f6-681f-45da-bc57-a0cf7b8f671d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b22b55f6-681f-45da-bc57-a0cf7b8f671d.jpg?1",
             "name": "Ixalli's Diviner",
             "text": "When Ixalli's Diviner enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6649,7 +6649,7 @@
         },
         {
             "id": "392b0aed-b2c3-5814-84ac-90407020aca2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b98537-abf4-46cb-853f-9561811ab439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e5b98537-abf4-46cb-853f-9561811ab439.jpg?1",
             "name": "Ixalli's Keeper",
             "text": "{7}{G}, {T}, Sacrifice Ixalli's Keeper: Target creature gets +5/+5 and gains trample until end of turn.",
             "colours": [
@@ -6684,7 +6684,7 @@
         },
         {
             "id": "149e1f90-ba8e-5378-820e-f45d7094cc71",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca83e48-6e32-477f-8714-6103e77c06df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/aca83e48-6e32-477f-8714-6103e77c06df.jpg?1",
             "name": "Jade Guardian",
             "text": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhen Jade Guardian enters the battlefield, put a +1/+1 counter on target Merfolk you control.",
             "colours": [
@@ -6719,7 +6719,7 @@
         },
         {
             "id": "4646e507-01e1-5a48-9803-8d783444c8fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0e3547-d8cb-4b68-a396-8c8fbc3b2b1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be0e3547-d8cb-4b68-a396-8c8fbc3b2b1c.jpg?1",
             "name": "Jungle Delver",
             "text": "{3}{G}: Put a +1/+1 counter on Jungle Delver.",
             "colours": [
@@ -6754,7 +6754,7 @@
         },
         {
             "id": "fc712a61-0a5f-5aa1-8bf8-e5b4d3fc17af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e96ddf-ac9e-4cc5-8c9a-afee421d99a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e96ddf-ac9e-4cc5-8c9a-afee421d99a6.jpg?1",
             "name": "Kumena's Speaker",
             "text": "Kumena's Speaker gets +1/+1 as long as you control another Merfolk or an Island.",
             "colours": [
@@ -6789,7 +6789,7 @@
         },
         {
             "id": "41a24ddd-aef5-5331-96bb-96d086cc73d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6f0d4a-4827-47b6-8af6-803949c195f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c6f0d4a-4827-47b6-8af6-803949c195f8.jpg?1",
             "name": "Merfolk Branchwalker",
             "text": "When Merfolk Branchwalker enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -6824,7 +6824,7 @@
         },
         {
             "id": "757cbe1a-1a6d-5d98-a864-9cc4d5c1d07e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b12c75-1248-4c81-90cf-28e341a885cf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15b12c75-1248-4c81-90cf-28e341a885cf.jpg?1",
             "name": "New Horizons",
             "text": "Enchant land\nWhen New Horizons enters the battlefield, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color to your mana pool.\"",
             "colours": [
@@ -6858,7 +6858,7 @@
         },
         {
             "id": "4ba1a9cd-fe26-55ca-8f81-fab8de96e6e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06458882-94c8-4d92-a21c-955e9d70f0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06458882-94c8-4d92-a21c-955e9d70f0d4.jpg?1",
             "name": "Old-Growth Dryads",
             "text": "When Old-Growth Dryads enters the battlefield, each opponent may search his or her library for a basic land card, put it onto the battlefield tapped, then shuffle his or her library.",
             "colours": [
@@ -6892,7 +6892,7 @@
         },
         {
             "id": "eacb92f6-8aeb-5cda-ac80-6c03278036eb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b96cba6-33d7-4e1d-88f7-da3da681540d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b96cba6-33d7-4e1d-88f7-da3da681540d.jpg?1",
             "name": "Pounce",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -6924,7 +6924,7 @@
         },
         {
             "id": "8f06808b-3839-56d1-9c78-06e82f31e7b0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e91efc6-0e6a-4a9e-a486-adf53e53d3f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e91efc6-0e6a-4a9e-a486-adf53e53d3f1.jpg?1",
             "name": "Ranging Raptors",
             "text": "Enrage \u2014 Whenever Ranging Raptors is dealt damage, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -6958,7 +6958,7 @@
         },
         {
             "id": "733f822c-c115-5f2d-9ba0-752af5b49e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b204b-774a-47bc-aead-c78db90f3be2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b204b-774a-47bc-aead-c78db90f3be2.jpg?1",
             "name": "Ravenous Daggertooth",
             "text": "Enrage \u2014 Whenever Ravenous Daggertooth is dealt damage, you gain 2 life.",
             "colours": [
@@ -6992,7 +6992,7 @@
         },
         {
             "id": "34fdb84e-cdff-51c5-9d75-55822f34d05e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5368c6-87e0-4f83-aaf7-f4af96d2bf30.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c5368c6-87e0-4f83-aaf7-f4af96d2bf30.jpg?1",
             "name": "Ripjaw Raptor",
             "text": "Enrage \u2014 Whenever Ripjaw Raptor is dealt damage, draw a card.",
             "colours": [
@@ -7026,7 +7026,7 @@
         },
         {
             "id": "20f5cec2-0ca0-5f51-9cd8-7d1f2b8a0203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e355a98d-093d-4ab2-84f2-f560d08f1fca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e355a98d-093d-4ab2-84f2-f560d08f1fca.jpg?1",
             "name": "River Heralds' Boon",
             "text": "Put a +1/+1 counter on target creature and a +1/+1 counter on up to one target Merfolk.",
             "colours": [
@@ -7058,7 +7058,7 @@
         },
         {
             "id": "72e2f4cb-d13d-530b-88b6-c60680673076",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb862587-8821-43c7-ad08-2b7d2b82cc71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb862587-8821-43c7-ad08-2b7d2b82cc71.jpg?1",
             "name": "Savage Stomp",
             "text": "Savage Stomp costs {2} less to cast if it targets a Dinosaur you control.\nPut a +1/+1 counter on target creature you control. Then that creature fights target creature you don't control. (Each deals damage equal to its power to the other.)",
             "colours": [
@@ -7090,7 +7090,7 @@
         },
         {
             "id": "e7147fa7-b9fc-5ed7-afb7-1adde49cf17b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930240dc-9c8c-4857-b6ce-85f1689c60e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/930240dc-9c8c-4857-b6ce-85f1689c60e5.jpg?1",
             "name": "Shapers' Sanctuary",
             "text": "Whenever a creature you control becomes the target of a spell or ability an opponent controls, you may draw a card.",
             "colours": [
@@ -7122,7 +7122,7 @@
         },
         {
             "id": "ab7b5872-3f9f-57d7-b452-2f558e7a1eef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433634b9-b26c-4935-a4f1-735373415548.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/433634b9-b26c-4935-a4f1-735373415548.jpg?1",
             "name": "Slice in Twain",
             "text": "Destroy target artifact or enchantment.\nDraw a card.",
             "colours": [
@@ -7154,7 +7154,7 @@
         },
         {
             "id": "83684508-ade0-5aa4-bda5-6620ce580260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af1eadf-f7ea-40be-a0cc-b79e4161db34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0af1eadf-f7ea-40be-a0cc-b79e4161db34.jpg?1",
             "name": "Snapping Sailback",
             "text": "Flash\nEnrage \u2014 Whenever Snapping Sailback is dealt damage, put a +1/+1 counter on it. (It must survive the damage to get the counter.)",
             "colours": [
@@ -7188,7 +7188,7 @@
         },
         {
             "id": "fbf4d717-0b5a-5fef-9abd-3f5b712f48ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a3b5f2-0b0b-42e0-a15b-4bb2fce05927.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/41a3b5f2-0b0b-42e0-a15b-4bb2fce05927.jpg?1",
             "name": "Spike-Tailed Ceratops",
             "text": "Spike-Tailed Ceratops can block an additional creature each combat.",
             "colours": [
@@ -7222,7 +7222,7 @@
         },
         {
             "id": "42a762a8-1232-5788-aa61-cd203cdc3bb8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35711da6-aac4-4c2a-b324-aebeaa843adc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/35711da6-aac4-4c2a-b324-aebeaa843adc.jpg?1",
             "name": "Thundering Spineback",
             "text": "Other Dinosaurs you control get +1/+1.\n{5}{G}: Create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -7256,7 +7256,7 @@
         },
         {
             "id": "1e55b8dd-b8bd-5f55-b82f-03d8c93c49b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af52383b-545e-4b64-93f9-317ba6dcf5a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af52383b-545e-4b64-93f9-317ba6dcf5a8.jpg?1",
             "name": "Tishana's Wayfinder",
             "text": "When Tishana's Wayfinder enters the battlefield, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
             "colours": [
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "341b5188-d08a-58af-8a84-b35d60e8ea39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993f4343-8f0a-4c50-b6fd-49f1f11d96f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/993f4343-8f0a-4c50-b6fd-49f1f11d96f0.jpg?1",
             "name": "Verdant Rebirth",
             "text": "Until end of turn, target creature gains \"When this creature dies, return it to its owner's hand.\"\nDraw a card.",
             "colours": [
@@ -7323,7 +7323,7 @@
         },
         {
             "id": "0fe25e23-b31b-5891-affe-93fd80cbf1a4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb5b6a-dc74-4e3e-9de1-5b379abdf2b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9dbb5b6a-dc74-4e3e-9de1-5b379abdf2b4.jpg?1",
             "name": "Verdant Sun's Avatar",
             "text": "Whenever Verdant Sun's Avatar or another creature enters the battlefield under your control, you gain life equal to that creature's toughness.",
             "colours": [
@@ -7358,7 +7358,7 @@
         },
         {
             "id": "35aaa0c0-2dc6-5bbe-8b9b-7b88461409ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a27502-f6f4-4c12-af0e-eab00d942ada.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4a27502-f6f4-4c12-af0e-eab00d942ada.jpg?1",
             "name": "Vineshaper Mystic",
             "text": "When Vineshaper Mystic enters the battlefield, put a +1/+1 counter on each of up to two target Merfolk you control.",
             "colours": [
@@ -7393,7 +7393,7 @@
         },
         {
             "id": "af929716-6b4f-5196-8b81-6e53c44e39bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46c4db-e12e-4c79-a17f-2166ed78e9bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/d/7d46c4db-e12e-4c79-a17f-2166ed78e9bc.jpg?1",
             "name": "Waker of the Wilds",
             "text": "{X}{G}{G}: Put X +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.",
             "colours": [
@@ -7428,7 +7428,7 @@
         },
         {
             "id": "8476beb7-65b1-5fbb-b769-17d9e07f5874",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e4c0f8-d5f0-4224-9974-190606911480.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52e4c0f8-d5f0-4224-9974-190606911480.jpg?1",
             "name": "Wildgrowth Walker",
             "text": "Whenever a creature you control explores, put a +1/+1 counter on Wildgrowth Walker and you gain 3 life.",
             "colours": [
@@ -7462,7 +7462,7 @@
         },
         {
             "id": "6830aa31-aaa5-5aee-9eeb-03d98363373d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854c2ec-0e53-4ac7-b417-554a9331c5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9854c2ec-0e53-4ac7-b417-554a9331c5e0.jpg?1",
             "name": "Admiral Beckett Brass",
             "text": "Other Pirates you control get +1/+1.\nAt the beginning of your end step, gain control of target nonland permanent controlled by a player who was dealt combat damage by three or more Pirates this turn.",
             "colours": [
@@ -7503,7 +7503,7 @@
         },
         {
             "id": "b15730bd-8df3-5af8-b5dc-db3bca67eb2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bab75a-2c1f-4ff1-a26e-134e52f61d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39bab75a-2c1f-4ff1-a26e-134e52f61d39.jpg?1",
             "name": "Belligerent Brontodon",
             "text": "Each creature you control assigns combat damage equal to its toughness rather than its power.",
             "colours": [
@@ -7539,7 +7539,7 @@
         },
         {
             "id": "84b86c18-6b24-5e2b-92db-24474e12db94",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7226de1-0e05-4baf-8c2f-54297fee43c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7226de1-0e05-4baf-8c2f-54297fee43c1.jpg?1",
             "name": "Call to the Feast",
             "text": "Create three 1/1 white Vampire creature tokens with lifelink.",
             "colours": [
@@ -7573,7 +7573,7 @@
         },
         {
             "id": "6329d8a3-0c7e-59c0-baa2-cd47f463f7e0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a7a1a4-aec2-467d-91a1-1a2605718c7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63a7a1a4-aec2-467d-91a1-1a2605718c7c.jpg?1",
             "name": "Deadeye Plunderers",
             "text": "Deadeye Plunderers gets +1/+1 for each artifact you control.\n{2}{U}{B}: Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [
@@ -7610,7 +7610,7 @@
         },
         {
             "id": "77b849ce-1fd1-5bb5-a215-dda3064153a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200f8a3-d60b-470a-a558-0c3555d1f10b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8200f8a3-d60b-470a-a558-0c3555d1f10b.jpg?1",
             "name": "Dire Fleet Captain",
             "text": "Whenever Dire Fleet Captain attacks, it gets +1/+1 until end of turn for each other attacking Pirate.",
             "colours": [
@@ -7647,7 +7647,7 @@
         },
         {
             "id": "56822088-92d6-5604-8471-42526b8d56f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e500-342d-476d-975c-817512e6e3d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7335e500-342d-476d-975c-817512e6e3d6.jpg?1",
             "name": "Gishath, Sun's Avatar",
             "text": "Trample, vigilance, haste\nWhenever Gishath, Sun's Avatar deals combat damage to a player, reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order.",
             "colours": [
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "3bc83f75-d0e0-5ddd-b568-899ab9c0b5f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc67a0-05d9-463e-9794-30a7e951c240.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8dc67a0-05d9-463e-9794-30a7e951c240.jpg?1",
             "name": "Hostage Taker",
             "text": "When Hostage Taker enters the battlefield, exile target artifact or creature until Hostage Taker leaves the battlefield. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.",
             "colours": [
@@ -7725,7 +7725,7 @@
         },
         {
             "id": "06367b6f-a30f-5acc-9035-9b979af7785d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc61ba-e91a-4b30-841c-cae8dd288b40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0cc61ba-e91a-4b30-841c-cae8dd288b40.jpg?1",
             "name": "Huatli, Warrior Poet",
             "text": "+2: You gain life equal to the greatest power among creatures you control.\n0: Create a 3/3 green Dinosaur creature token with trample.\n\u2212X: Huatli, Warrior Poet deals X damage divided as you choose among any number of target creatures. Creatures dealt damage this way can't block this turn.",
             "colours": [
@@ -7763,7 +7763,7 @@
         },
         {
             "id": "72ca1334-aeb4-551e-805a-472b7ad87f29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c41fee8-7b03-4dc8-babb-f8c8369a74c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c41fee8-7b03-4dc8-babb-f8c8369a74c2.jpg?1",
             "name": "Marauding Looter",
             "text": "Raid \u2014 At the beginning of your end step, if you attacked with a creature this turn, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -7800,7 +7800,7 @@
         },
         {
             "id": "41625e33-4623-5670-8b9b-e0aede92a844",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a79137-9589-4c24-9bea-31041fd3c9ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15a79137-9589-4c24-9bea-31041fd3c9ae.jpg?1",
             "name": "Raging Swordtooth",
             "text": "Trample\nWhen Raging Swordtooth enters the battlefield, it deals 1 damage to each other creature.",
             "colours": [
@@ -7836,7 +7836,7 @@
         },
         {
             "id": "4ae5eeef-531c-50ae-9bef-fef68d4af19e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a322c5-aa4c-4a99-a3ca-48c1353104f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d6a322c5-aa4c-4a99-a3ca-48c1353104f0.jpg?1",
             "name": "Regisaur Alpha",
             "text": "Other Dinosaurs you control have haste.\nWhen Regisaur Alpha enters the battlefield, create a 3/3 green Dinosaur creature token with trample.",
             "colours": [
@@ -7872,7 +7872,7 @@
         },
         {
             "id": "3a5a725c-f9af-5c6e-bdef-12c83f926383",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa682fb-f5b6-41c1-9428-6043b0b76744.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aa682fb-f5b6-41c1-9428-6043b0b76744.jpg?1",
             "name": "Shapers of Nature",
             "text": "{3}{G}: Put a +1/+1 counter on target creature.\n{2}{U}, Remove a +1/+1 counter from a creature you control: Draw a card.",
             "colours": [
@@ -7909,7 +7909,7 @@
         },
         {
             "id": "a331fe91-c60d-56cf-855b-c56802cad40f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167ed739-2953-47af-841f-bc1a092b3aa6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/167ed739-2953-47af-841f-bc1a092b3aa6.jpg?1",
             "name": "Sky Terror",
             "text": "Flying, menace",
             "colours": [
@@ -7945,7 +7945,7 @@
         },
         {
             "id": "0c06b325-e60c-5d95-a5fd-0600ab4307bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c5cfbe-3972-4d2e-a37f-e96cca33bb33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19c5cfbe-3972-4d2e-a37f-e96cca33bb33.jpg?1",
             "name": "Tishana, Voice of Thunder",
             "text": "Tishana, Voice of Thunder's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhen Tishana enters the battlefield, draw a card for each creature you control.",
             "colours": [
@@ -7984,7 +7984,7 @@
         },
         {
             "id": "eba10c93-0d30-5d89-aaa7-7e9f1aafcff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fd4101-d531-43aa-9cb6-79e36a8121d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c1fd4101-d531-43aa-9cb6-79e36a8121d8.jpg?1",
             "name": "Vona, Butcher of Magan",
             "text": "Vigilance, lifelink\n{T}, Pay 7 life: Destroy target nonland permanent. Activate this ability only during your turn.",
             "colours": [
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "a40640ef-45fb-510c-9d10-142dfd91db31",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b7272-33a6-46e9-b0aa-4757aee54b3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/967b7272-33a6-46e9-b0aa-4757aee54b3a.jpg?1",
             "name": "Vraska, Relic Seeker",
             "text": "+2: Create a 2/2 black Pirate creature token with menace.\n\u22123: Destroy target artifact, creature, or enchantment. Create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\n\u221210: Target player's life total becomes 1.",
             "colours": [
@@ -8061,7 +8061,7 @@
         },
         {
             "id": "dcc549f3-63b6-5b8c-8159-3e5e7ba62e9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2ff4f0-0dd1-4551-826b-68e8ff1e5860.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/b/3b2ff4f0-0dd1-4551-826b-68e8ff1e5860.jpg?1",
             "name": "Cobbled Wings",
             "text": "Equipped creature has flying.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8091,7 +8091,7 @@
         },
         {
             "id": "7e5f352a-6a66-59e7-bf17-d93e2fb3e0ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg?1",
             "name": "Conqueror's Galleon // Conqueror's Foothold",
             "text": "When Conqueror's Galleon attacks, exile it at end of combat, then return it to the battlefield transformed under your control.\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8121,7 +8121,7 @@
         },
         {
             "id": "c1713a78-e74a-5049-bd68-205f6702400f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/02bb4b2a-3c9f-48ab-b2a5-ae31f06b82d9.jpg?1",
             "name": "Conqueror's Galleon // Conqueror's Foothold",
             "text": "(Transforms from Conqueror's Galleon.)\n{T}: Add {C} to your mana pool.\n{2}, {T}: Draw a card, then discard a card.\n{4}, {T}: Draw a card.\n{6}, {T}: Return target card from your graveyard to your hand.",
             "colours": [],
@@ -8149,7 +8149,7 @@
         },
         {
             "id": "040b2583-1896-585a-9a56-681e7597c304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg?1",
             "name": "Dowsing Dagger // Lost Vale",
             "text": "When Dowsing Dagger enters the battlefield, target opponent creates two 0/2 green Plant creature tokens with defender.\nEquipped creature gets +2/+1.\nWhenever equipped creature deals combat damage to a player, you may transform Dowsing Dagger.\nEquip {2}",
             "colours": [],
@@ -8179,7 +8179,7 @@
         },
         {
             "id": "4194a0e5-6575-56a0-a841-569172c330ca",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/1/514d53be-6ade-4f73-a844-e9ae2dafd6ce.jpg?1",
             "name": "Dowsing Dagger // Lost Vale",
             "text": "(Transforms from Dowsing Dagger.)\n{T}: Add three mana of any one color to your mana pool.",
             "colours": [],
@@ -8207,7 +8207,7 @@
         },
         {
             "id": "95da6cee-80c2-51ca-b771-1d559ae6f47d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec26144-9acf-43b7-8614-1a2952df613d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aec26144-9acf-43b7-8614-1a2952df613d.jpg?1",
             "name": "Dusk Legion Dreadnought",
             "text": "Vigilance\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8237,7 +8237,7 @@
         },
         {
             "id": "68b553dc-f3e7-5deb-a7b5-b35d3f6ec38b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9170f0-d332-42ba-98c7-7e99922fa3fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9170f0-d332-42ba-98c7-7e99922fa3fb.jpg?1",
             "name": "Elaborate Firecannon",
             "text": "Elaborate Firecannon doesn't untap during your untap step.\n{4}, {T}: Elaborate Firecannon deals 2 damage to target creature or player.\nAt the beginning of your upkeep, you may discard a card. If you do, untap Elaborate Firecannon.",
             "colours": [],
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "507ba3af-28ae-5ecf-b742-0f2a7834761a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774bdb6-7a02-43c9-9e6f-75d0b09570ca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774bdb6-7a02-43c9-9e6f-75d0b09570ca.jpg?1",
             "name": "Fell Flagship",
             "text": "Pirates you control get +1/+0.\nWhenever Fell Flagship deals combat damage to a player, that player discards a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8295,7 +8295,7 @@
         },
         {
             "id": "effa2c58-9606-5bb3-8975-f20990cbed1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cc1a59-76bf-4721-b4a7-ef746f3d3990.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01cc1a59-76bf-4721-b4a7-ef746f3d3990.jpg?1",
             "name": "Gilded Sentinel",
             "text": "",
             "colours": [],
@@ -8326,7 +8326,7 @@
         },
         {
             "id": "c9435bb9-b73b-53b3-8d3c-15f94b6f0cae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8be52c-25ce-49da-8435-58797550f058.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e8be52c-25ce-49da-8435-58797550f058.jpg?1",
             "name": "Hierophant's Chalice",
             "text": "When Hierophant's Chalice enters the battlefield, target opponent loses 1 life and you gain 1 life.\n{T}: Add {C} to your mana pool.",
             "colours": [],
@@ -8354,7 +8354,7 @@
         },
         {
             "id": "ef746800-e68e-56db-a035-c0c483bddb28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888facd-e462-4794-a774-d765d1a1edfd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f888facd-e462-4794-a774-d765d1a1edfd.jpg?1",
             "name": "Pillar of Origins",
             "text": "As Pillar of Origins enters the battlefield, choose a creature type.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -8382,7 +8382,7 @@
         },
         {
             "id": "ce58d2f6-def0-5ad1-8008-63f3d41da164",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7e871-19cf-486d-bacb-1499fe066974.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3e7e871-19cf-486d-bacb-1499fe066974.jpg?1",
             "name": "Pirate's Cutlass",
             "text": "When Pirate's Cutlass enters the battlefield, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8412,7 +8412,7 @@
         },
         {
             "id": "b05dcfd1-37a5-5ea9-850f-acfb1837b43b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg?1",
             "name": "Primal Amulet // Primal Wellspring",
             "text": "Instant and sorcery spells you cast cost {1} less to cast.\nWhenever you cast an instant or sorcery spell, put a charge counter on Primal Amulet. Then if there are four or more charge counters on it, you may remove those counters and transform it.",
             "colours": [],
@@ -8440,7 +8440,7 @@
         },
         {
             "id": "f7642222-7218-5fe6-9d78-7d436c5bdaef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/4/d4d379b5-7f56-4a7d-a4ac-131fc3d579c6.jpg?1",
             "name": "Primal Amulet // Primal Wellspring",
             "text": "(Transforms from Primal Amulet.)\n{T}: Add one mana of any color to your mana pool. When that mana is spent to cast an instant or sorcery spell, copy that spell and you may choose new targets for the copy.",
             "colours": [],
@@ -8468,7 +8468,7 @@
         },
         {
             "id": "f89d8a19-1028-504a-bc94-4ea487b8ca14",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad45720e-2870-414d-8119-8e48c5600d3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad45720e-2870-414d-8119-8e48c5600d3b.jpg?1",
             "name": "Prying Blade",
             "text": "Equipped creature gets +1/+0.\nWhenever equipped creature deals combat damage to a player, create a colorless Treasure artifact token with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -8498,7 +8498,7 @@
         },
         {
             "id": "240de12c-ca10-5fac-b63e-b1af94b59ebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8097eb-518a-4b8e-8d6a-a139d4ddcc8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d8097eb-518a-4b8e-8d6a-a139d4ddcc8f.jpg?1",
             "name": "Sentinel Totem",
             "text": "When Sentinel Totem enters the battlefield, scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)\n{T}, Exile Sentinel Totem: Exile all cards from all graveyards.",
             "colours": [],
@@ -8526,7 +8526,7 @@
         },
         {
             "id": "47414e80-bd37-53f1-bb5b-f41ca48e3a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ab3ed-32cd-4168-9763-96884491aaa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b28ab3ed-32cd-4168-9763-96884491aaa1.jpg?1",
             "name": "Shadowed Caravel",
             "text": "Whenever a creature you control explores, put a +1/+1 counter on Shadowed Caravel.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8556,7 +8556,7 @@
         },
         {
             "id": "695546f1-c67b-50d0-bcb3-efeaac1fbe19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767e2bfb-bcf5-442c-b092-bdb1f4f13561.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/767e2bfb-bcf5-442c-b092-bdb1f4f13561.jpg?1",
             "name": "Sleek Schooner",
             "text": "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
             "colours": [],
@@ -8586,7 +8586,7 @@
         },
         {
             "id": "3438d2d9-4e87-573a-bc3f-28e703fe47ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85506a24-8d60-475c-9f43-65994caca7d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/85506a24-8d60-475c-9f43-65994caca7d4.jpg?1",
             "name": "Sorcerous Spyglass",
             "text": "As Sorcerous Spyglass enters the battlefield, look at an opponent's hand, then choose any card name.\nActivated abilities of sources with the chosen name can't be activated unless they're mana abilities.",
             "colours": [],
@@ -8614,7 +8614,7 @@
         },
         {
             "id": "4a0f0d48-4079-5ce7-94cb-507eacc11cac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg?1",
             "name": "Thaumatic Compass // Spires of Orazca",
             "text": "{3}, {T}: Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.\nAt the beginning of your end step, if you control seven or more lands, transform Thaumatic Compass.",
             "colours": [],
@@ -8642,7 +8642,7 @@
         },
         {
             "id": "fd15aeb4-ad00-5e72-9e4f-395c0573ee84",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/9/392af78e-34d5-4b1b-8b29-0e702271e4d7.jpg?1",
             "name": "Thaumatic Compass // Spires of Orazca",
             "text": "(Transforms from Thaumatic Compass.)\n{T}: Add {C} to your mana pool.\n{T}: Untap target attacking creature an opponent controls and remove it from combat.",
             "colours": [],
@@ -8670,7 +8670,7 @@
         },
         {
             "id": "27c48a7a-d2a2-5459-b13c-461fcea64473",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "{1}, {T}: Scry 1. Put a landmark counter on Treasure Map. Then if there are three or more landmark counters on it, remove those counters, transform Treasure Map, and create three colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\"",
             "colours": [],
@@ -8698,7 +8698,7 @@
         },
         {
             "id": "9df98469-8e7f-5e59-aae6-255b850cef43",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1",
             "name": "Treasure Map // Treasure Cove",
             "text": "(Transforms from Treasure Map.)\n{T}: Add {C} to your mana pool.\n{T}, Sacrifice a Treasure: Draw a card.",
             "colours": [],
@@ -8726,7 +8726,7 @@
         },
         {
             "id": "713e12ef-815d-5f68-b151-52962f16e9d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7a85f-3a30-4ece-9bbb-61f3c4b796b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60b7a85f-3a30-4ece-9bbb-61f3c4b796b8.jpg?1",
             "name": "Vanquisher's Banner",
             "text": "As Vanquisher's Banner enters the battlefield, choose a creature type.\nCreatures you control of the chosen type get +1/+1.\nWhenever you cast a creature spell of the chosen type, draw a card.",
             "colours": [],
@@ -8754,7 +8754,7 @@
         },
         {
             "id": "d0dfae9c-f5d0-5717-adb1-00cecf309902",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91570836-9e36-4774-8d5d-7cbcee0012ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91570836-9e36-4774-8d5d-7cbcee0012ba.jpg?1",
             "name": "Dragonskull Summit",
             "text": "Dragonskull Summit enters the battlefield tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -8785,7 +8785,7 @@
         },
         {
             "id": "3ace6f06-fa88-53d2-95b4-58f4f9a997ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef728f1-5153-47d6-8f9c-dfd473ee0750.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8ef728f1-5153-47d6-8f9c-dfd473ee0750.jpg?1",
             "name": "Drowned Catacomb",
             "text": "Drowned Catacomb enters the battlefield tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -8816,7 +8816,7 @@
         },
         {
             "id": "b72dcc93-14d6-5510-9b30-a0e22ef0432f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72afb21-7bb0-4fd8-a529-ada92a654f61.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d72afb21-7bb0-4fd8-a529-ada92a654f61.jpg?1",
             "name": "Field of Ruin",
             "text": "{T}: Add {C} to your mana pool.\n{2}, {T}, Sacrifice Field of Ruin: Destroy target nonbasic land an opponent controls. Each player searches his or her library for a basic land card, puts it onto the battlefield, then shuffles his or her library.",
             "colours": [],
@@ -8844,7 +8844,7 @@
         },
         {
             "id": "3f3c4617-31d6-5fc1-aaf3-e3e66edb604c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef133d9-26d2-4a1e-8d6a-829f1067c169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/cef133d9-26d2-4a1e-8d6a-829f1067c169.jpg?1",
             "name": "Glacial Fortress",
             "text": "Glacial Fortress enters the battlefield tapped unless you control a Plains or an Island.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -8875,7 +8875,7 @@
         },
         {
             "id": "a31b60ce-aa8e-573b-847f-ffde6e50df54",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f59e19-9ac1-4f86-893e-5b3364122fc6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6f59e19-9ac1-4f86-893e-5b3364122fc6.jpg?1",
             "name": "Rootbound Crag",
             "text": "Rootbound Crag enters the battlefield tapped unless you control a Mountain or a Forest.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -8906,7 +8906,7 @@
         },
         {
             "id": "fbd740b8-0149-5cb5-8218-b64aa3d2471d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f234312-00e8-49f7-a489-f4c316b0a81a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/f/0f234312-00e8-49f7-a489-f4c316b0a81a.jpg?1",
             "name": "Sunpetal Grove",
             "text": "Sunpetal Grove enters the battlefield tapped unless you control a Forest or a Plains.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -8937,7 +8937,7 @@
         },
         {
             "id": "ec6ee728-9eb9-5bab-a0be-869e83620e63",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765732-6fe3-4594-bff5-6ce47a79f45a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff765732-6fe3-4594-bff5-6ce47a79f45a.jpg?1",
             "name": "Unclaimed Territory",
             "text": "As Unclaimed Territory enters the battlefield, choose a creature type.\n{T}: Add {C} to your mana pool.\n{T}: Add one mana of any color to your mana pool. Spend this mana only to cast a creature spell of the chosen type.",
             "colours": [],
@@ -8965,7 +8965,7 @@
         },
         {
             "id": "ee3c5db5-0fce-563f-8efd-0491b5e37ac7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517315dc-591f-4af4-a319-542ad9a2e4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/517315dc-591f-4af4-a319-542ad9a2e4b8.jpg?1",
             "name": "Unknown Shores",
             "text": "{T}: Add {C} to your mana pool.\n{1}, {T}: Add one mana of any color to your mana pool.",
             "colours": [],
@@ -8993,7 +8993,7 @@
         },
         {
             "id": "6daa541d-46eb-52c8-85b6-43f1eedc9a50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff6ee0-01f4-432f-916b-ed771904d64c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51ff6ee0-01f4-432f-916b-ed771904d64c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9031,7 +9031,7 @@
         },
         {
             "id": "d3936e64-10b3-5448-8a6d-648b94ab5a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed39f11e-a7c4-4a35-aed6-7cd7590723b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed39f11e-a7c4-4a35-aed6-7cd7590723b7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9069,7 +9069,7 @@
         },
         {
             "id": "6eccbfe4-8f9d-55db-b10e-c3bc34ed256e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39965b8e-0ddc-4c9d-9eb1-7536ec4a8723.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/39965b8e-0ddc-4c9d-9eb1-7536ec4a8723.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9107,7 +9107,7 @@
         },
         {
             "id": "5efc6e9a-33bb-5b05-a07f-72299b732116",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9fda9-50b0-4ce4-b351-cd2b5e6409c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0f9fda9-50b0-4ce4-b351-cd2b5e6409c8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -9145,7 +9145,7 @@
         },
         {
             "id": "f649b2c2-02d4-5908-a466-5e32eb9c6d39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c840af-9a13-4716-8458-09071239cc26.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40c840af-9a13-4716-8458-09071239cc26.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9183,7 +9183,7 @@
         },
         {
             "id": "528061fa-3f03-5935-9803-71e4f02be1b7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1bec1a-72cd-4a1f-8386-a228fbbdc04d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf1bec1a-72cd-4a1f-8386-a228fbbdc04d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9221,7 +9221,7 @@
         },
         {
             "id": "59cd28fb-41f1-5b7c-a934-a7aa185ad4f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb839476-63ba-4e17-b97d-4bc282a85648.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb839476-63ba-4e17-b97d-4bc282a85648.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9259,7 +9259,7 @@
         },
         {
             "id": "aa89b479-e374-5711-a8a8-8a57bb5a38a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc35243-3801-4c02-a8df-2ccf6ea71a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fc35243-3801-4c02-a8df-2ccf6ea71a17.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -9297,7 +9297,7 @@
         },
         {
             "id": "8815c804-1d8c-5546-9948-9a93a713ae99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db69a637-5770-4eea-9b04-c00e6f90a12a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db69a637-5770-4eea-9b04-c00e6f90a12a.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9335,7 +9335,7 @@
         },
         {
             "id": "f8e11f1c-b59a-5bb6-9563-5e0f33d44912",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74c620-a445-46a4-a1aa-b5b8ef657f18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e74c620-a445-46a4-a1aa-b5b8ef657f18.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9373,7 +9373,7 @@
         },
         {
             "id": "d273eb35-8069-5d43-8bcf-a919e8e81dce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af26e12-8518-4b15-afcd-c44faaebb574.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af26e12-8518-4b15-afcd-c44faaebb574.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9411,7 +9411,7 @@
         },
         {
             "id": "e2ca5787-2346-53a2-9dc3-0465d3c55109",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf4e561-d430-432e-8c65-a5a12616f552.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcf4e561-d430-432e-8c65-a5a12616f552.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -9449,7 +9449,7 @@
         },
         {
             "id": "5fa4c8b8-7930-5953-9842-be734844d078",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c96b83-d0b3-4da9-bb2d-249cc18b55e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15c96b83-d0b3-4da9-bb2d-249cc18b55e9.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9487,7 +9487,7 @@
         },
         {
             "id": "ea302b64-2c4c-5213-bc3b-8b4d3980de18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a456b1c-de58-4ba2-ac39-9e0b3e2a9b51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2a456b1c-de58-4ba2-ac39-9e0b3e2a9b51.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9525,7 +9525,7 @@
         },
         {
             "id": "9d2470e9-3428-56d4-a808-6414253abfc9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96328602-bf67-42a5-8cca-1fcea5656b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96328602-bf67-42a5-8cca-1fcea5656b8a.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9563,7 +9563,7 @@
         },
         {
             "id": "c5bba943-c38e-572d-839c-cf4da257371f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df190cfa-ebb6-48e8-9980-950a26d0f2d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df190cfa-ebb6-48e8-9980-950a26d0f2d8.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -9601,7 +9601,7 @@
         },
         {
             "id": "8f941e15-8ba1-5408-8727-cebb522b7c30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eef5e5c-27be-45f2-a9c8-4e0a65c984d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7eef5e5c-27be-45f2-a9c8-4e0a65c984d4.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9639,7 +9639,7 @@
         },
         {
             "id": "057df7fb-238d-55b1-93dd-ec76548a0fca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab82f8e3-6f48-4974-bb5c-39feddc51344.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab82f8e3-6f48-4974-bb5c-39feddc51344.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9677,7 +9677,7 @@
         },
         {
             "id": "a510d2df-c04f-5177-afb0-8790f887139a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398ee871-7b30-4e8c-b0d0-b85e0a37d3b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/9/398ee871-7b30-4e8c-b0d0-b85e0a37d3b1.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9715,7 +9715,7 @@
         },
         {
             "id": "6ad57a1f-4f19-521a-98dc-c44348286625",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676702c-523a-4e57-9cb3-171405cab782.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1676702c-523a-4e57-9cb3-171405cab782.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9753,7 +9753,7 @@
         },
         {
             "id": "76dd0fa9-8795-5466-838f-fc861716a176",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b274f6-833f-430f-ac1a-d1d1d5b03e71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b274f6-833f-430f-ac1a-d1d1d5b03e71.jpg?1",
             "name": "Jace, Ingenious Mind-Mage",
             "text": "+1: Draw a card.\n+1: Untap all creatures you control.\n\u22129: Gain control of up to three target creatures.",
             "colours": [
@@ -9788,7 +9788,7 @@
         },
         {
             "id": "d84de62a-0d45-5f6a-ae93-90773792acc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a26ba9-84b8-4f54-918c-f75d4cacad0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3a26ba9-84b8-4f54-918c-f75d4cacad0b.jpg?1",
             "name": "Castaway's Despair",
             "text": "Enchant creature\nWhen Castaway's Despair enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -9821,7 +9821,7 @@
         },
         {
             "id": "635a1ad4-597b-526c-bf58-267ee1911fb3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7344ffb-aada-4be1-bc82-2ed96e6cb5bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7344ffb-aada-4be1-bc82-2ed96e6cb5bf.jpg?1",
             "name": "Grasping Current",
             "text": "Return up to two target creatures to their owner's hand.\nSearch your library and/or graveyard for a card named Jace, Ingenious Mind-Mage, reveal it, and put it into your hand. If you searched your library this way, shuffle it.",
             "colours": [
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "204dd11f-849b-5417-bc11-ca930aadc417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9131361b-ec1e-4390-82c9-b9b9f77792a8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/9131361b-ec1e-4390-82c9-b9b9f77792a8.jpg?1",
             "name": "Jace's Sentinel",
             "text": "As long as you control a Jace planeswalker, Jace's Sentinel gets +1/+0 and can't be blocked.",
             "colours": [
@@ -9886,7 +9886,7 @@
         },
         {
             "id": "326f44f0-908e-55e8-b50e-ada49aec93f7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740bb19c-0c91-4fc1-9b3c-be84425a3523.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/740bb19c-0c91-4fc1-9b3c-be84425a3523.jpg?1",
             "name": "Woodland Stream",
             "text": "Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U} to your mana pool.",
             "colours": [],
@@ -9916,7 +9916,7 @@
         },
         {
             "id": "35f59e7e-7606-5170-94e2-0e212ce2ba96",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5a6f7b-149d-46d3-9814-d38a302db17c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6a5a6f7b-149d-46d3-9814-d38a302db17c.jpg?1",
             "name": "Huatli, Dinosaur Knight",
             "text": "+2: Put two +1/+1 counters on up to one target Dinosaur you control.\n\u22123: Target Dinosaur you control deals damage equal to its power to target creature you don't control.\n\u22127: Dinosaurs you control get +4/+4 until end of turn.",
             "colours": [
@@ -9953,7 +9953,7 @@
         },
         {
             "id": "27bf07d4-e1db-5580-a75b-73aba922dbf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d88e6c-4aa8-4175-9f5d-a4c0182cdf74.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2d88e6c-4aa8-4175-9f5d-a4c0182cdf74.jpg?1",
             "name": "Huatli's Snubhorn",
             "text": "Vigilance (Attacking doesn't cause this creature to tap.)",
             "colours": [
@@ -9986,7 +9986,7 @@
         },
         {
             "id": "545e5adb-a937-58d6-b324-103a1d4db753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19440e2-855f-4f60-a443-b99500394611.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a19440e2-855f-4f60-a443-b99500394611.jpg?1",
             "name": "Huatli's Spurring",
             "text": "Target creature gets +2/+0 until end of turn. If you control a Huatli planeswalker, that creature gets +4/+0 until end of turn instead.",
             "colours": [
@@ -10017,7 +10017,7 @@
         },
         {
             "id": "3e1d0bc3-ecab-504e-ba83-9177c1256e50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f06ac1f-0bae-4aaa-9ff4-28c806828c40.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f06ac1f-0bae-4aaa-9ff4-28c806828c40.jpg?1",
             "name": "Sun-Blessed Mount",
             "text": "When Sun-Blessed Mount enters the battlefield, you may search your library and/or graveyard for a card named Huatli, Dinosaur Knight, reveal it, then put it into your hand. If you searched your library this way, shuffle it.",
             "colours": [
@@ -10052,7 +10052,7 @@
         },
         {
             "id": "80ce0f76-4542-5111-94c1-8953ca7b0129",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06da82de-fd37-4c8f-a37d-61da66db567e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06da82de-fd37-4c8f-a37d-61da66db567e.jpg?1",
             "name": "Stone Quarry",
             "text": "Stone Quarry enters the battlefield tapped.\n{T}: Add {R} or {W} to your mana pool.",
             "colours": [],
@@ -10082,7 +10082,7 @@
         },
         {
             "id": "625decf2-a1bc-53b6-b601-342906413033",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09293ae7-0629-417b-9eda-9bd3f6d8e118.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09293ae7-0629-417b-9eda-9bd3f6d8e118.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -10116,7 +10116,7 @@
         },
         {
             "id": "945c18bc-34dc-553c-bdd6-663d53ac09de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b3030-5495-404b-938c-8c4a387a1341.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a8b3030-5495-404b-938c-8c4a387a1341.jpg?1",
             "name": "Ixalan Checklist",
             "text": "",
             "colours": [],
@@ -10143,7 +10143,7 @@
         },
         {
             "id": "e25abbdd-fc0e-57b2-857d-e493e78d42d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10729a5-061a-4daf-91d6-0f6ce813a992.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a10729a5-061a-4daf-91d6-0f6ce813a992.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -10177,7 +10177,7 @@
         },
         {
             "id": "08f919c7-a885-5483-b26c-e2b2e0c4b1a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90317f5e-d121-4c00-86cc-5bbee953f600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90317f5e-d121-4c00-86cc-5bbee953f600.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -10211,7 +10211,7 @@
         },
         {
             "id": "4b906342-8344-55ed-aa84-af278b7b0d0a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7fc721-6b5b-4920-86fa-0fbfd90adaf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2d7fc721-6b5b-4920-86fa-0fbfd90adaf5.jpg?1",
             "name": "Pirate",
             "text": "",
             "colours": [
@@ -10245,7 +10245,7 @@
         },
         {
             "id": "3123b918-b1a5-522b-bad1-174bedb81e28",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccee594-e1e6-4a82-bc17-93bcdeb36198.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/c/1ccee594-e1e6-4a82-bc17-93bcdeb36198.jpg?1",
             "name": "Dinosaur",
             "text": "",
             "colours": [
@@ -10279,7 +10279,7 @@
         },
         {
             "id": "f0127dde-c191-5bef-82b7-4cca8adc9585",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d1d93-22d0-43f9-8691-6790876185a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/642d1d93-22d0-43f9-8691-6790876185a0.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -10313,7 +10313,7 @@
         },
         {
             "id": "340d30ce-7bbd-51b7-8a0d-503e2b47035f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720f3e68-84c0-462e-a0d1-90236ccc494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/720f3e68-84c0-462e-a0d1-90236ccc494a.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10343,7 +10343,7 @@
         },
         {
             "id": "de25c8dd-8190-559a-86fa-adaf7192f463",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e89101-f1cf-4bbd-a1d5-c5d48512e0dd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/21e89101-f1cf-4bbd-a1d5-c5d48512e0dd.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10373,7 +10373,7 @@
         },
         {
             "id": "a04220a7-422e-5d17-9350-b42b214e2f35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f06ec6-634d-454b-a46a-dfefe4600d27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56f06ec6-634d-454b-a46a-dfefe4600d27.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],
@@ -10403,7 +10403,7 @@
         },
         {
             "id": "d71e6c2f-7c07-58e3-af7b-9b966f5c0403",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe8bced-9524-47f6-a600-bf4ddc072698.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bbe8bced-9524-47f6-a600-bf4ddc072698.jpg?1",
             "name": "Treasure",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/ReducedSets/ZEN.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ZEN.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "4416fff6-179b-5a46-aec1-701bcb513da5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f7752-e981-4046-ae9b-90b20db6b23a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/975f7752-e981-4046-ae9b-90b20db6b23a.jpg?1",
             "name": "Armament Master",
             "text": "Other Kor creatures you control get +2/+2 for each Equipment attached to Armament Master.",
             "colours": [
@@ -39,7 +39,7 @@
         },
         {
             "id": "a1bd1a36-4928-5800-b745-6fd83339fdd1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94d5ae2-4d37-4c5f-b490-e578297d87c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d94d5ae2-4d37-4c5f-b490-e578297d87c2.jpg?1",
             "name": "Arrow Volley Trap",
             "text": "If four or more creatures are attacking, you may pay {1}{W} rather than pay Arrow Volley Trap's mana cost.\nArrow Volley Trap deals 5 damage divided as you choose among any number of target attacking creatures.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "60a9af82-1964-5eb5-ae56-a576ee5f4708",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f657723-dd5d-4786-9d9b-ac7ed279615a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f657723-dd5d-4786-9d9b-ac7ed279615a.jpg?1",
             "name": "Bold Defense",
             "text": "Kicker {3}{W} (You may pay an additional {3}{W} as you cast this spell.)\nCreatures you control get +1/+1 until end of turn. If Bold Defense was kicked, instead creatures you control get +2/+2 and gain first strike until end of turn.",
             "colours": [
@@ -105,7 +105,7 @@
         },
         {
             "id": "9ef4080d-f1e5-5d65-9ea9-c9b78e4b9ddc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14c492d-3fd7-4b2a-910e-bfcb33752eba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c14c492d-3fd7-4b2a-910e-bfcb33752eba.jpg?1",
             "name": "Brave the Elements",
             "text": "Choose a color. White creatures you control gain protection from the chosen color until end of turn.",
             "colours": [
@@ -137,7 +137,7 @@
         },
         {
             "id": "c0a79fc8-72eb-5f13-8544-1e667f92e852",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf3a3d-292d-40b9-b28c-34ad33a76bb4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ffdf3a3d-292d-40b9-b28c-34ad33a76bb4.jpg?1",
             "name": "Caravan Hurda",
             "text": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -171,7 +171,7 @@
         },
         {
             "id": "37b6cdd5-516f-5729-82d4-652faf8d3f03",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4599c159-386e-4b13-a386-185924333fc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4599c159-386e-4b13-a386-185924333fc5.jpg?1",
             "name": "Celestial Mantle",
             "text": "Enchant creature\nEnchanted creature gets +3/+3.\nWhenever enchanted creature deals combat damage to a player, double its controller's life total.",
             "colours": [
@@ -205,7 +205,7 @@
         },
         {
             "id": "b0e3daff-3476-5f5a-836c-08d00982b689",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743b625-e937-4cac-8701-9e2dd709a9a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/1743b625-e937-4cac-8701-9e2dd709a9a4.jpg?1",
             "name": "Cliff Threader",
             "text": "Mountainwalk",
             "colours": [
@@ -240,7 +240,7 @@
         },
         {
             "id": "6ab11d68-e0aa-5148-814a-df7e1ec12c36",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af1844a-601a-48c1-bf96-921d2d2e2aa1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1af1844a-601a-48c1-bf96-921d2d2e2aa1.jpg?1",
             "name": "Conqueror's Pledge",
             "text": "Kicker {6} (You may pay an additional {6} as you cast this spell.)\nPut six 1/1 white Kor Soldier creature tokens onto the battlefield. If Conqueror's Pledge was kicked, put twelve of those tokens onto the battlefield instead.",
             "colours": [
@@ -272,7 +272,7 @@
         },
         {
             "id": "cecca0fd-b83e-5510-be01-cd3c70857216",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa98fca-972b-46c2-bdec-6ace35c988d5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2aa98fca-972b-46c2-bdec-6ace35c988d5.jpg?1",
             "name": "Day of Judgment",
             "text": "Destroy all creatures.",
             "colours": [
@@ -304,7 +304,7 @@
         },
         {
             "id": "11075751-ae22-5d00-9c03-6db8fc3bebaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e31e43-84d3-429e-9e81-60b325989c93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16e31e43-84d3-429e-9e81-60b325989c93.jpg?1",
             "name": "Devout Lightcaster",
             "text": "Protection from black\nWhen Devout Lightcaster enters the battlefield, exile target black permanent.",
             "colours": [
@@ -339,7 +339,7 @@
         },
         {
             "id": "63f93f13-17fb-5bec-ad85-5eaa4e046eae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b386d39-ba41-42f8-ba05-f9ed602ee23f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b386d39-ba41-42f8-ba05-f9ed602ee23f.jpg?1",
             "name": "Emeria Angel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a 1/1 white Bird creature token with flying onto the battlefield.",
             "colours": [
@@ -373,7 +373,7 @@
         },
         {
             "id": "c017f486-8cb7-521f-88ff-99bf3f71946c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3c93e6-af75-4d7e-86b0-8a38425f51a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc3c93e6-af75-4d7e-86b0-8a38425f51a1.jpg?1",
             "name": "Felidar Sovereign",
             "text": "Vigilance, lifelink\nAt the beginning of your upkeep, if you have 40 or more life, you win the game.",
             "colours": [
@@ -408,7 +408,7 @@
         },
         {
             "id": "a1688c15-a96b-56ba-bc25-752e5e33f25d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62458cfe-7231-4e09-b398-9c4d9330d08e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62458cfe-7231-4e09-b398-9c4d9330d08e.jpg?1",
             "name": "Iona, Shield of Emeria",
             "text": "Flying\nAs Iona, Shield of Emeria enters the battlefield, choose a color.\nYour opponents can't cast spells of the chosen color.",
             "colours": [
@@ -444,7 +444,7 @@
         },
         {
             "id": "7d8659c5-4d50-5d72-8a86-655f5f4c2f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfe585-8a55-4b27-89e0-dfb6946fe1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09cfe585-8a55-4b27-89e0-dfb6946fe1f3.jpg?1",
             "name": "Journey to Nowhere",
             "text": "When Journey to Nowhere enters the battlefield, exile target creature.\nWhen Journey to Nowhere leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
             "colours": [
@@ -476,7 +476,7 @@
         },
         {
             "id": "c8f53013-c530-5e16-9dab-18268035a4c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f05d96-42d5-4e1d-a9c6-229a3f42dda9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/7/57f05d96-42d5-4e1d-a9c6-229a3f42dda9.jpg?1",
             "name": "Kabira Evangel",
             "text": "Whenever Kabira Evangel or another Ally enters the battlefield under your control, you may choose a color. If you do, Allies you control gain protection from the chosen color until end of turn.",
             "colours": [
@@ -512,7 +512,7 @@
         },
         {
             "id": "a15a2a06-e862-5bca-913e-f1ab9ddf15dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642bdbf-c03f-4c48-a5c8-c9201a08b834.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/9642bdbf-c03f-4c48-a5c8-c9201a08b834.jpg?1",
             "name": "Kazandu Blademaster",
             "text": "First strike, vigilance\nWhenever Kazandu Blademaster or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Kazandu Blademaster.",
             "colours": [
@@ -548,7 +548,7 @@
         },
         {
             "id": "f1febd5b-1483-5880-bcf1-1aa109a84192",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae3eb8-b570-4129-9d4e-b7afa8fc4840.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87ae3eb8-b570-4129-9d4e-b7afa8fc4840.jpg?1",
             "name": "Kor Aeronaut",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nFlying\nWhen Kor Aeronaut enters the battlefield, if it was kicked, target creature gains flying until end of turn.",
             "colours": [
@@ -583,7 +583,7 @@
         },
         {
             "id": "1f9b78ff-2754-5e14-98fb-f16b5368f313",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6063b7ee-94ae-4a5b-9902-6aa0335af593.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6063b7ee-94ae-4a5b-9902-6aa0335af593.jpg?1",
             "name": "Kor Cartographer",
             "text": "When Kor Cartographer enters the battlefield, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -618,7 +618,7 @@
         },
         {
             "id": "f76070c3-1083-5d94-9690-d5044453c457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1af74-ba3b-4528-9490-99edd54e9fe1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fd1af74-ba3b-4528-9490-99edd54e9fe1.jpg?1",
             "name": "Kor Duelist",
             "text": "As long as Kor Duelist is equipped, it has double strike. (It deals both first-strike and regular combat damage.)",
             "colours": [
@@ -653,7 +653,7 @@
         },
         {
             "id": "ffafc190-b3d3-5306-b625-07c47da6fa7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3199-c202-4b71-8a36-53547e70c39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68ad3199-c202-4b71-8a36-53547e70c39b.jpg?1",
             "name": "Kor Hookmaster",
             "text": "When Kor Hookmaster enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -688,7 +688,7 @@
         },
         {
             "id": "1ede19f5-c7fd-5afe-974d-6d657e428a64",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00006596-1166-4a79-8443-ca9f82e6db4e.jpg?1",
             "name": "Kor Outfitter",
             "text": "When Kor Outfitter enters the battlefield, you may attach target Equipment you control to target creature you control.",
             "colours": [
@@ -723,7 +723,7 @@
         },
         {
             "id": "575d1ff0-8bab-5bc9-b050-5d5ca3e5962e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038b04fe-d77a-4192-a084-654ef39aa9ff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/038b04fe-d77a-4192-a084-654ef39aa9ff.jpg?1",
             "name": "Kor Sanctifiers",
             "text": "Kicker {W} (You may pay an additional {W} as you cast this spell.)\nWhen Kor Sanctifiers enters the battlefield, if it was kicked, destroy target artifact or enchantment.",
             "colours": [
@@ -758,7 +758,7 @@
         },
         {
             "id": "dc15067d-f356-5f77-b3ee-11ed6e185c9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2e9465-f5ba-4c7b-9f03-d40dc8394acd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb2e9465-f5ba-4c7b-9f03-d40dc8394acd.jpg?1",
             "name": "Kor Skyfisher",
             "text": "Flying\nWhen Kor Skyfisher enters the battlefield, return a permanent you control to its owner's hand.",
             "colours": [
@@ -793,7 +793,7 @@
         },
         {
             "id": "51dc3de7-007b-5dbd-a507-e844ab1572c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245357c6-b4cd-40f3-b7c2-413eee767239.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/245357c6-b4cd-40f3-b7c2-413eee767239.jpg?1",
             "name": "Landbind Ritual",
             "text": "You gain 2 life for each Plains you control.",
             "colours": [
@@ -825,7 +825,7 @@
         },
         {
             "id": "b08e425e-dc91-58fe-a97d-3bd6c1564932",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f3a20f-a788-4d8b-946b-d9c1c983a85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9f3a20f-a788-4d8b-946b-d9c1c983a85a.jpg?1",
             "name": "Luminarch Ascension",
             "text": "At the beginning of each opponent's end step, if you didn't lose life this turn, you may put a quest counter on Luminarch Ascension. (Damage causes loss of life.)\n{1}{W}: Put a 4/4 white Angel creature token with flying onto the battlefield. Activate this ability only if Luminarch Ascension has four or more quest counters on it.",
             "colours": [
@@ -857,7 +857,7 @@
         },
         {
             "id": "42d9a2ae-71f6-5e32-94c6-5bce1a4f50ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76e9555-966c-4fc3-9ef4-a0154ccb8329.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e76e9555-966c-4fc3-9ef4-a0154ccb8329.jpg?1",
             "name": "Makindi Shieldmate",
             "text": "Defender\nWhenever Makindi Shieldmate or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Makindi Shieldmate.",
             "colours": [
@@ -893,7 +893,7 @@
         },
         {
             "id": "22dd680e-60ef-501f-baa8-95cd8ca38a46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9942a2-11d2-403b-89c6-35c23ac9e9da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c9942a2-11d2-403b-89c6-35c23ac9e9da.jpg?1",
             "name": "Narrow Escape",
             "text": "Return target permanent you control to its owner's hand. You gain 4 life.",
             "colours": [
@@ -925,7 +925,7 @@
         },
         {
             "id": "6db50e08-9248-5ff0-adfa-ec0a94f3a1a9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae4042-8806-437c-8fc1-2d6996ff38c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dae4042-8806-437c-8fc1-2d6996ff38c6.jpg?1",
             "name": "Nimbus Wings",
             "text": "Enchant creature\nEnchanted creature gets +1/+2 and has flying.",
             "colours": [
@@ -959,7 +959,7 @@
         },
         {
             "id": "8609392b-23d9-5898-a0ce-9d6c7eed0f53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae1e55c-bdf2-4327-9f97-032c2c3c7d0c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dae1e55c-bdf2-4327-9f97-032c2c3c7d0c.jpg?1",
             "name": "Noble Vestige",
             "text": "Flying\n{T}: Prevent the next 1 damage that would be dealt to target player this turn.",
             "colours": [
@@ -993,7 +993,7 @@
         },
         {
             "id": "0debb9fa-8bf8-561d-9e96-4f06a2f455e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced43447-fefc-482a-b8fa-33b9616aa532.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ced43447-fefc-482a-b8fa-33b9616aa532.jpg?1",
             "name": "Ondu Cleric",
             "text": "Whenever Ondu Cleric or another Ally enters the battlefield under your control, you may gain life equal to the number of Allies you control.",
             "colours": [
@@ -1029,7 +1029,7 @@
         },
         {
             "id": "1d61021d-ddb0-53ae-af93-0354392d4130",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70a8ff1-f0cf-4aef-ad90-06902f98d434.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d70a8ff1-f0cf-4aef-ad90-06902f98d434.jpg?1",
             "name": "Pillarfield Ox",
             "text": "",
             "colours": [
@@ -1063,7 +1063,7 @@
         },
         {
             "id": "b6a0e349-8be2-539e-9f1f-de41e36f8a79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2823d9a5-dd2f-4e6a-8e3d-554c4204aa32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/2823d9a5-dd2f-4e6a-8e3d-554c4204aa32.jpg?1",
             "name": "Pitfall Trap",
             "text": "If exactly one creature is attacking, you may pay {W} rather than pay Pitfall Trap's mana cost.\nDestroy target attacking creature without flying.",
             "colours": [
@@ -1097,7 +1097,7 @@
         },
         {
             "id": "fc63c39f-5837-5592-8e98-173b1661c7ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d6b8bb-ec11-4ded-a7fc-fa4ea0bb96cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/00d6b8bb-ec11-4ded-a7fc-fa4ea0bb96cc.jpg?1",
             "name": "Quest for the Holy Relic",
             "text": "Whenever you cast a creature spell, you may put a quest counter on Quest for the Holy Relic.\nRemove five quest counters from Quest for the Holy Relic and sacrifice it: Search your library for an Equipment card, put it onto the battlefield, and attach it to a creature you control. Then shuffle your library.",
             "colours": [
@@ -1129,7 +1129,7 @@
         },
         {
             "id": "0a3e9b59-1225-584c-9234-dab90567c2a1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff23b1c2-7b99-4504-8944-ada264725524.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff23b1c2-7b99-4504-8944-ada264725524.jpg?1",
             "name": "Shepherd of the Lost",
             "text": "Flying, first strike, vigilance",
             "colours": [
@@ -1163,7 +1163,7 @@
         },
         {
             "id": "10619cab-8862-56b5-95b1-c95a6cda0447",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58a26f8-a2c9-48e5-8662-7cbd43c00411.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f58a26f8-a2c9-48e5-8662-7cbd43c00411.jpg?1",
             "name": "Shieldmate's Blessing",
             "text": "Prevent the next 3 damage that would be dealt to target creature or player this turn.",
             "colours": [
@@ -1195,7 +1195,7 @@
         },
         {
             "id": "9d9afb7d-18b4-5b67-bea1-cb376a13117f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aaec1c-8084-4468-82e7-2e4cc5ebe244.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0aaec1c-8084-4468-82e7-2e4cc5ebe244.jpg?1",
             "name": "Steppe Lynx",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Steppe Lynx gets +2/+2 until end of turn.",
             "colours": [
@@ -1229,7 +1229,7 @@
         },
         {
             "id": "46769dfe-05a9-55d4-b43e-7b3e7f1bc789",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0811c4c-9e91-4785-b3d2-e4221c5d92d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0811c4c-9e91-4785-b3d2-e4221c5d92d8.jpg?1",
             "name": "Sunspring Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Sunspring Expedition.\nRemove three quest counters from Sunspring Expedition and sacrifice it: You gain 8 life.",
             "colours": [
@@ -1261,7 +1261,7 @@
         },
         {
             "id": "cceed302-397a-519c-a5d6-dd5c32cc7ee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b0fd3-ae3e-41eb-b31b-d941b84b6c64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a8b0fd3-ae3e-41eb-b31b-d941b84b6c64.jpg?1",
             "name": "Windborne Charge",
             "text": "Two target creatures you control each get +2/+2 and gain flying until end of turn.",
             "colours": [
@@ -1293,7 +1293,7 @@
         },
         {
             "id": "7c905265-8d75-51b9-8e0d-8fcd41901f6f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134ff41d-1645-4d3a-94b6-e13a30dedb8e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/134ff41d-1645-4d3a-94b6-e13a30dedb8e.jpg?1",
             "name": "World Queller",
             "text": "At the beginning of your upkeep, you may choose a card type. If you do, each player sacrifices a permanent of that type.",
             "colours": [
@@ -1327,7 +1327,7 @@
         },
         {
             "id": "9b20cf14-1fad-5f6e-99bd-ffe632e2fe47",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a4657b-98de-4f4c-b921-46d15a8e6f5a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/73a4657b-98de-4f4c-b921-46d15a8e6f5a.jpg?1",
             "name": "Aether Figment",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\n\u00c6ther Figment is unblockable.\nIf \u00c6ther Figment was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -1361,7 +1361,7 @@
         },
         {
             "id": "72fbb71e-5bbd-52ee-8f79-59d5a95e5172",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bb2ca9-32b8-442d-b6a0-d624a87f5af8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67bb2ca9-32b8-442d-b6a0-d624a87f5af8.jpg?1",
             "name": "Archive Trap",
             "text": "If an opponent searched his or her library this turn, you may pay {0} rather than pay Archive Trap's mana cost.\nTarget opponent puts the top thirteen cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1395,7 +1395,7 @@
         },
         {
             "id": "b6fd66a3-b9b4-5e34-91fa-99f9e55671b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe803d-88d7-4ad2-b3d8-c41c123d8bf3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/dbfe803d-88d7-4ad2-b3d8-c41c123d8bf3.jpg?1",
             "name": "Archmage Ascension",
             "text": "At the beginning of each end step, if you drew two or more cards this turn, you may put a quest counter on Archmage Ascension.\nAs long as Archmage Ascension has six or more quest counters on it, if you would draw a card, you may instead search your library for a card, put that card into your hand, then shuffle your library.",
             "colours": [
@@ -1427,7 +1427,7 @@
         },
         {
             "id": "b51ee243-29cd-5c8e-8cc2-8e5e18e147ef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5aabef2-982b-42c9-9804-08ce4d8910cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5aabef2-982b-42c9-9804-08ce4d8910cd.jpg?1",
             "name": "Caller of Gales",
             "text": "{1}{U}, {T}: Target creature gains flying until end of turn.",
             "colours": [
@@ -1462,7 +1462,7 @@
         },
         {
             "id": "9d4b826c-50b9-5cc2-b3c7-e217b17ccbe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e557f54-3d9d-4610-a0d0-5874feacc76e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9e557f54-3d9d-4610-a0d0-5874feacc76e.jpg?1",
             "name": "Cancel",
             "text": "Counter target spell.",
             "colours": [
@@ -1494,7 +1494,7 @@
         },
         {
             "id": "2c746c3c-8295-56b3-8e9b-a20efda5157e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb7372-481a-44a6-937d-21430ee02ff9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1eb7372-481a-44a6-937d-21430ee02ff9.jpg?1",
             "name": "Cosi's Trickster",
             "text": "Whenever an opponent shuffles his or her library, you may put a +1/+1 counter on Cosi's Trickster.",
             "colours": [
@@ -1529,7 +1529,7 @@
         },
         {
             "id": "ad04c7c8-7818-5372-83a5-b9383e293f08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119d2661-ba22-4901-b89a-a0a8ec25d004.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/119d2661-ba22-4901-b89a-a0a8ec25d004.jpg?1",
             "name": "Gomazoa",
             "text": "Defender, flying\n{T}: Put Gomazoa and each creature it's blocking on top of their owners' libraries, then those players shuffle their libraries.",
             "colours": [
@@ -1563,7 +1563,7 @@
         },
         {
             "id": "f40e3484-5bc4-56c7-b392-a96f55a0282d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa1946-4f97-4c52-b5f2-b80571230616.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0fa1946-4f97-4c52-b5f2-b80571230616.jpg?1",
             "name": "Hedron Crab",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, target player puts the top three cards of his or her library into his or her graveyard.",
             "colours": [
@@ -1597,7 +1597,7 @@
         },
         {
             "id": "7e36ced8-b2bf-5a1f-b3c9-af76f385c831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba9972-dd8b-407b-9374-a8f0ed1a96db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dba9972-dd8b-407b-9374-a8f0ed1a96db.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If Into the Roil was kicked, draw a card.",
             "colours": [
@@ -1629,7 +1629,7 @@
         },
         {
             "id": "82c2fdfb-c6f6-591a-9c85-8913e559a5de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acdba29-3a09-42d4-bce2-ce615c36bb3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/a/2acdba29-3a09-42d4-bce2-ce615c36bb3c.jpg?1",
             "name": "Ior Ruin Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Ior Ruin Expedition.\nRemove three quest counters from Ior Ruin Expedition and sacrifice it: Draw two cards.",
             "colours": [
@@ -1661,7 +1661,7 @@
         },
         {
             "id": "262f8bab-bac7-5a91-8cfc-6d4ec12c3e27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d100a3-93f2-428c-8f54-8807e71f2638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45d100a3-93f2-428c-8f54-8807e71f2638.jpg?1",
             "name": "Kraken Hatchling",
             "text": "",
             "colours": [
@@ -1695,7 +1695,7 @@
         },
         {
             "id": "c3799994-26df-5192-80d1-891d46021dd4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351aa3f2-864a-4921-a01c-8712560087bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/351aa3f2-864a-4921-a01c-8712560087bb.jpg?1",
             "name": "Lethargy Trap",
             "text": "If three or more creatures are attacking, you may pay {U} rather than pay Lethargy Trap's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
             "colours": [
@@ -1729,7 +1729,7 @@
         },
         {
             "id": "705e5baa-a916-5879-af79-6a3df2b8782d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107a4e2b-e463-46f3-a431-66ea954ef487.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/107a4e2b-e463-46f3-a431-66ea954ef487.jpg?1",
             "name": "Living Tsunami",
             "text": "Flying\nAt the beginning of your upkeep, sacrifice Living Tsunami unless you return a land you control to its owner's hand.",
             "colours": [
@@ -1763,7 +1763,7 @@
         },
         {
             "id": "bd329887-2a1d-58c2-94ef-7299c769ff23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf68e-e78e-4709-9c7a-c6e8cbb1f56f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60ddf68e-e78e-4709-9c7a-c6e8cbb1f56f.jpg?1",
             "name": "Lorthos, the Tidemaker",
             "text": "Whenever Lorthos, the Tidemaker attacks, you may pay {8}. If you do, tap up to eight target permanents. Those permanents don't untap during their controllers' next untap steps.",
             "colours": [
@@ -1799,7 +1799,7 @@
         },
         {
             "id": "d8e819e1-53e6-514f-b189-66caac711079",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34de3df-3236-4281-a043-7583c76d89cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e34de3df-3236-4281-a043-7583c76d89cc.jpg?1",
             "name": "Lullmage Mentor",
             "text": "Whenever a spell or ability you control counters a spell, you may put a 1/1 blue Merfolk creature token onto the battlefield.\nTap seven untapped Merfolk you control: Counter target spell.",
             "colours": [
@@ -1834,7 +1834,7 @@
         },
         {
             "id": "5df2bf8e-06ed-54cf-b3ca-f8c19e5b3854",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5d069-45a0-46ea-b3ec-4e75f0531382.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4fe5d069-45a0-46ea-b3ec-4e75f0531382.jpg?1",
             "name": "Merfolk Seastalkers",
             "text": "Islandwalk\n{2}{U}: Tap target creature without flying.",
             "colours": [
@@ -1869,7 +1869,7 @@
         },
         {
             "id": "0f3598e3-7512-5be9-8f45-deea1c66024c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ab86f3-aa75-40ce-a71e-90d40dad4bdc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71ab86f3-aa75-40ce-a71e-90d40dad4bdc.jpg?1",
             "name": "Merfolk Wayfinder",
             "text": "Flying\nWhen Merfolk Wayfinder enters the battlefield, reveal the top three cards of your library. Put all Island cards revealed this way into your hand and the rest on the bottom of your library in any order.",
             "colours": [
@@ -1904,7 +1904,7 @@
         },
         {
             "id": "a9cf898e-2d22-5df8-b0aa-985caf1ee918",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f51140b-6254-431a-8810-94307bfdfbbe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f51140b-6254-431a-8810-94307bfdfbbe.jpg?1",
             "name": "Mindbreak Trap",
             "text": "If an opponent cast three or more spells this turn, you may pay {0} rather than pay Mindbreak Trap's mana cost.\nExile any number of target spells.",
             "colours": [
@@ -1938,7 +1938,7 @@
         },
         {
             "id": "0d643615-3bfd-59ff-8ba8-16f9fd449ce5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af35801-9280-4ec1-9399-e34501919a8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4af35801-9280-4ec1-9399-e34501919a8f.jpg?1",
             "name": "Paralyzing Grasp",
             "text": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1972,7 +1972,7 @@
         },
         {
             "id": "8defd487-1060-59ca-ba4f-243a2eadb391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de22b67-968e-49e1-ae96-6dd0ee75cd54.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0de22b67-968e-49e1-ae96-6dd0ee75cd54.jpg?1",
             "name": "Quest for Ancient Secrets",
             "text": "Whenever a card is put into your graveyard from anywhere, you may put a quest counter on Quest for Ancient Secrets.\nRemove five quest counters from Quest for Ancient Secrets and sacrifice it: Target player shuffles his or her graveyard into his or her library.",
             "colours": [
@@ -2004,7 +2004,7 @@
         },
         {
             "id": "ca3077e0-a8b0-546a-8bfc-6e6cb0fd4a73",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b059c5-6812-42eb-a010-87fb9e0bb2b9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9b059c5-6812-42eb-a010-87fb9e0bb2b9.jpg?1",
             "name": "Reckless Scholar",
             "text": "{T}: Target player draws a card, then discards a card.",
             "colours": [
@@ -2039,7 +2039,7 @@
         },
         {
             "id": "64a013a1-6586-5461-b241-f68063e6af5d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4530fe45-8a3d-48e9-a7a5-abf8fb1485e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4530fe45-8a3d-48e9-a7a5-abf8fb1485e3.jpg?1",
             "name": "Rite of Replication",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nPut a token onto the battlefield that's a copy of target creature. If Rite of Replication was kicked, put five of those tokens onto the battlefield instead.",
             "colours": [
@@ -2071,7 +2071,7 @@
         },
         {
             "id": "acb9994e-eaaa-565e-944b-6defc6149211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66139c73-8e14-433d-bcb6-ae3e518bcdfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66139c73-8e14-433d-bcb6-ae3e518bcdfb.jpg?1",
             "name": "Roil Elemental",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may gain control of target creature for as long as you control Roil Elemental.",
             "colours": [
@@ -2105,7 +2105,7 @@
         },
         {
             "id": "62f2579c-6993-515a-bb59-ba204c17ac27",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd723c8-4b3d-4fbb-a825-79934279382d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd723c8-4b3d-4fbb-a825-79934279382d.jpg?1",
             "name": "Sea Gate Loremaster",
             "text": "{T}: Draw a card for each Ally you control.",
             "colours": [
@@ -2141,7 +2141,7 @@
         },
         {
             "id": "5b7a3834-b00d-5414-aa8a-038df96ef271",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690efc8-de2b-4476-87da-d8ed9572dc84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/3690efc8-de2b-4476-87da-d8ed9572dc84.jpg?1",
             "name": "Seascape Aerialist",
             "text": "Whenever Seascape Aerialist or another Ally enters the battlefield under your control, you may have Ally creatures you control gain flying until end of turn.",
             "colours": [
@@ -2177,7 +2177,7 @@
         },
         {
             "id": "51e9c4b3-86c6-53de-9b35-ebd154079c12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a98047-8e6d-416c-b11d-cc4c2a56b624.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4a98047-8e6d-416c-b11d-cc4c2a56b624.jpg?1",
             "name": "Shoal Serpent",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, Shoal Serpent loses defender until end of turn.",
             "colours": [
@@ -2211,7 +2211,7 @@
         },
         {
             "id": "0c805d6a-51c7-534f-835e-2c40622126a0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb5850-df1e-4d8a-af7a-15cab080fb8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2bdb5850-df1e-4d8a-af7a-15cab080fb8f.jpg?1",
             "name": "Sky Ruin Drake",
             "text": "Flying",
             "colours": [
@@ -2245,7 +2245,7 @@
         },
         {
             "id": "2eeadebc-9233-558c-b8bd-9e64b5e6f154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d3901-e4a6-45ab-a7b5-c65d91e1875e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cb3d3901-e4a6-45ab-a7b5-c65d91e1875e.jpg?1",
             "name": "Spell Pierce",
             "text": "Counter target noncreature spell unless its controller pays {2}.",
             "colours": [
@@ -2277,7 +2277,7 @@
         },
         {
             "id": "cc0adef2-9607-53c5-b7ad-d0b8e1111822",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d13a9c-8757-46f4-be83-eb9917a5bbe3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0d13a9c-8757-46f4-be83-eb9917a5bbe3.jpg?1",
             "name": "Sphinx of Jwar Isle",
             "text": "Flying, shroud\nYou may look at the top card of your library. (You may do this at any time.)",
             "colours": [
@@ -2311,7 +2311,7 @@
         },
         {
             "id": "68962dda-3ca9-58ed-9d77-f81e32025a72",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b61b6-bf80-4326-a646-a1985e0b50d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d97b61b6-bf80-4326-a646-a1985e0b50d7.jpg?1",
             "name": "Sphinx of Lost Truths",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nFlying\nWhen Sphinx of Lost Truths enters the battlefield, draw three cards. Then if it wasn't kicked, discard three cards.",
             "colours": [
@@ -2345,7 +2345,7 @@
         },
         {
             "id": "98516940-e05f-5fc5-8b86-a433e36cdc95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37454c1c-4098-4ac2-884e-3f65f1384bdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37454c1c-4098-4ac2-884e-3f65f1384bdb.jpg?1",
             "name": "Spreading Seas",
             "text": "Enchant land\nWhen Spreading Seas enters the battlefield, draw a card.\nEnchanted land is an Island.",
             "colours": [
@@ -2379,7 +2379,7 @@
         },
         {
             "id": "a4f1e3ae-44fb-5d94-8b7d-b3437f5332f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82afba-df51-4bd9-853c-d3ef323095a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/ed82afba-df51-4bd9-853c-d3ef323095a6.jpg?1",
             "name": "Summoner's Bane",
             "text": "Counter target creature spell. Put a 2/2 blue Illusion creature token onto the battlefield.",
             "colours": [
@@ -2411,7 +2411,7 @@
         },
         {
             "id": "a3dcd016-a41d-505d-9487-27431f461cda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d173dda8-de9f-4148-b5be-85d1a4c4faf6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d173dda8-de9f-4148-b5be-85d1a4c4faf6.jpg?1",
             "name": "Tempest Owl",
             "text": "Kicker {4}{U} (You may pay an additional {4}{U} as you cast this spell.)\nFlying\nWhen Tempest Owl enters the battlefield, if it was kicked, tap up to three target permanents.",
             "colours": [
@@ -2445,7 +2445,7 @@
         },
         {
             "id": "4b0e2dca-2a85-54ba-8bef-4a23c272932c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9dfda7-c034-478e-a52a-e4a272c7d160.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c9dfda7-c034-478e-a52a-e4a272c7d160.jpg?1",
             "name": "Trapfinder's Trick",
             "text": "Target player reveals his or her hand and discards all Trap cards.",
             "colours": [
@@ -2477,7 +2477,7 @@
         },
         {
             "id": "5024ce88-2bf2-59bb-a26f-c88d3296a6e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbc98ab-9f8a-41ed-b368-22f1f4ae594b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cbc98ab-9f8a-41ed-b368-22f1f4ae594b.jpg?1",
             "name": "Trapmaker's Snare",
             "text": "Search your library for a Trap card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [
@@ -2509,7 +2509,7 @@
         },
         {
             "id": "03733223-ccbf-586e-872c-b8acc9a3531a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6049cc80-1faa-48bf-897e-fefe5a8e7ab2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/6049cc80-1faa-48bf-897e-fefe5a8e7ab2.jpg?1",
             "name": "Umara Raptor",
             "text": "Flying\nWhenever Umara Raptor or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Umara Raptor.",
             "colours": [
@@ -2544,7 +2544,7 @@
         },
         {
             "id": "372a1334-2f19-5467-8edc-7c9c4ebe3903",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357931d0-8ba6-4857-9db9-7f42d81514a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/5/357931d0-8ba6-4857-9db9-7f42d81514a5.jpg?1",
             "name": "Welkin Tern",
             "text": "Flying\nWelkin Tern can block only creatures with flying.",
             "colours": [
@@ -2578,7 +2578,7 @@
         },
         {
             "id": "5a549456-2e8d-5951-923d-5d6dbb06fb79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80e6ae-13e0-46f7-baef-5fa7dfcedcec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0a80e6ae-13e0-46f7-baef-5fa7dfcedcec.jpg?1",
             "name": "Whiplash Trap",
             "text": "If an opponent had two or more creatures enter the battlefield under his or her control this turn, you may pay {U} rather than pay Whiplash Trap's mana cost.\nReturn two target creatures to their owners' hands.",
             "colours": [
@@ -2612,7 +2612,7 @@
         },
         {
             "id": "67be7cbb-9009-5edd-949d-f8da3f685d7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18b11f0-19cc-4169-84e0-fbb038a5c848.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c18b11f0-19cc-4169-84e0-fbb038a5c848.jpg?1",
             "name": "Windrider Eel",
             "text": "Flying\nLandfall \u2014 Whenever a land enters the battlefield under your control, Windrider Eel gets +2/+2 until end of turn.",
             "colours": [
@@ -2646,7 +2646,7 @@
         },
         {
             "id": "eca011d2-7116-5ff5-94b3-46bd3591530c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4598ec-cf36-4a51-9f67-b91c146c3c4f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4598ec-cf36-4a51-9f67-b91c146c3c4f.jpg?1",
             "name": "Bala Ged Thief",
             "text": "Whenever Bala Ged Thief or another Ally enters the battlefield under your control, target player reveals a number of cards from his or her hand equal to the number of Allies you control. You choose one of them. That player discards that card.",
             "colours": [
@@ -2682,7 +2682,7 @@
         },
         {
             "id": "851aaead-54bc-5977-87ad-d47fcd21a502",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abc9e8-9ecf-4665-9ea5-ee18ab83c148.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d1abc9e8-9ecf-4665-9ea5-ee18ab83c148.jpg?1",
             "name": "Blood Seeker",
             "text": "Whenever a creature enters the battlefield under an opponent's control, you may have that player lose 1 life.",
             "colours": [
@@ -2717,7 +2717,7 @@
         },
         {
             "id": "1a5c7633-14e2-521f-8d6c-2cb7eccd4154",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76487d3-1d52-4c31-917e-eb929907218d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c76487d3-1d52-4c31-917e-eb929907218d.jpg?1",
             "name": "Blood Tribute",
             "text": "Kicker\u2014\nTap an untapped Vampire you control. (You may tap a Vampire you control in addition to any other costs as you cast this spell.)\nTarget opponent loses half his or her life, rounded up. If Blood Tribute was kicked, you gain life equal to the life lost this way.",
             "colours": [
@@ -2749,7 +2749,7 @@
         },
         {
             "id": "8132184d-a780-5c7d-8a72-2ce4a71eaf90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa213dbb-c52a-4084-92aa-d0b5d97a97d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa213dbb-c52a-4084-92aa-d0b5d97a97d9.jpg?1",
             "name": "Bloodchief Ascension",
             "text": "At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)\nWhenever a card is put into an opponent's graveyard from anywhere, if Bloodchief Ascension has three or more quest counters on it, you may have that player lose 2 life. If you do, you gain 2 life.",
             "colours": [
@@ -2781,7 +2781,7 @@
         },
         {
             "id": "43c48749-6978-59eb-8560-0fd120092e18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63870c81-63bf-4a9a-aeb5-74c6eaded9f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63870c81-63bf-4a9a-aeb5-74c6eaded9f1.jpg?1",
             "name": "Bloodghast",
             "text": "Bloodghast can't block.\nBloodghast has haste as long as an opponent has 10 or less life.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may return Bloodghast from your graveyard to the battlefield.",
             "colours": [
@@ -2816,7 +2816,7 @@
         },
         {
             "id": "98a3b428-6a9a-54c4-a07f-925a702c3650",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0830c00-02fa-4fc8-907c-19d4b7f9cd6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a0830c00-02fa-4fc8-907c-19d4b7f9cd6e.jpg?1",
             "name": "Bog Tatters",
             "text": "Swampwalk",
             "colours": [
@@ -2850,7 +2850,7 @@
         },
         {
             "id": "9e09f095-86c0-5a54-815f-454f3d45125f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9920e91d-58c1-4c1a-a177-43423db96842.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9920e91d-58c1-4c1a-a177-43423db96842.jpg?1",
             "name": "Crypt Ripper",
             "text": "Haste\n{B}: Crypt Ripper gets +1/+1 until end of turn.",
             "colours": [
@@ -2884,7 +2884,7 @@
         },
         {
             "id": "ce36b15e-d83a-587a-9c9b-495dd25ea5fb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05e478-8712-41de-94af-ecb90432e562.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3f05e478-8712-41de-94af-ecb90432e562.jpg?1",
             "name": "Desecrated Earth",
             "text": "Destroy target land. Its controller discards a card.",
             "colours": [
@@ -2916,7 +2916,7 @@
         },
         {
             "id": "15269cf5-9eb9-5b7d-8c79-42154e8ece24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3842ad2-a449-4963-8c96-276554125757.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3842ad2-a449-4963-8c96-276554125757.jpg?1",
             "name": "Disfigure",
             "text": "Target creature gets -2/-2 until end of turn.",
             "colours": [
@@ -2948,7 +2948,7 @@
         },
         {
             "id": "562835c6-dc41-52e4-a315-63ea1878d05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7dd5e2-b2a5-46ab-a67c-499451706505.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a7dd5e2-b2a5-46ab-a67c-499451706505.jpg?1",
             "name": "Feast of Blood",
             "text": "Cast Feast of Blood only if you control two or more Vampires.\nDestroy target creature. You gain 4 life.",
             "colours": [
@@ -2980,7 +2980,7 @@
         },
         {
             "id": "c68fbb19-ed45-578e-863f-072a69142c49",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db3698-a45c-4eaf-87e6-30502c0c10f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/71db3698-a45c-4eaf-87e6-30502c0c10f4.jpg?1",
             "name": "Gatekeeper of Malakir",
             "text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen Gatekeeper of Malakir enters the battlefield, if it was kicked, target player sacrifices a creature.",
             "colours": [
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "3da693a5-1291-5806-8fab-4a8ef90094a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27221df-ec7a-4c51-b3a8-34b65b236b49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c27221df-ec7a-4c51-b3a8-34b65b236b49.jpg?1",
             "name": "Giant Scorpion",
             "text": "Deathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)",
             "colours": [
@@ -3049,7 +3049,7 @@
         },
         {
             "id": "64d244b3-2175-5373-bd4d-01a25628b346",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeec3f1-1f12-4237-95ec-54bbc9a901f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4eeec3f1-1f12-4237-95ec-54bbc9a901f9.jpg?1",
             "name": "Grim Discovery",
             "text": "Choose one or both \u2014 Return target creature card from your graveyard to your hand; and/or return target land card from your graveyard to your hand.",
             "colours": [
@@ -3081,7 +3081,7 @@
         },
         {
             "id": "6f293180-2355-5196-a006-af2344b7d783",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6ee73e-fe6e-4698-b92e-606d5d10e5e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f6ee73e-fe6e-4698-b92e-606d5d10e5e0.jpg?1",
             "name": "Guul Draz Specter",
             "text": "Flying\nGuul Draz Specter gets +3/+3 as long as an opponent has no cards in hand.\nWhenever Guul Draz Specter deals combat damage to a player, that player discards a card.",
             "colours": [
@@ -3115,7 +3115,7 @@
         },
         {
             "id": "518f8f85-d008-57fc-bed2-541f35b3abf3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c92575-1c97-48bf-801b-22f34040cf9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3c92575-1c97-48bf-801b-22f34040cf9a.jpg?1",
             "name": "Guul Draz Vampire",
             "text": "As long as an opponent has 10 or less life, Guul Draz Vampire gets +2/+1 and has intimidate. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3150,7 +3150,7 @@
         },
         {
             "id": "10db3566-d1d1-5e42-985c-6858149a2906",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394a7a2-8f1a-4f07-843a-77db62de49bd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/3394a7a2-8f1a-4f07-843a-77db62de49bd.jpg?1",
             "name": "Hagra Crocodile",
             "text": "Hagra Crocodile can't block.\nLandfall \u2014 Whenever a land enters the battlefield under your control, Hagra Crocodile gets +2/+2 until end of turn.",
             "colours": [
@@ -3184,7 +3184,7 @@
         },
         {
             "id": "d890d460-3d2d-56bd-b72f-368c1b738a4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303e7e2-cb22-4dea-889f-d03e2494ed0f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c303e7e2-cb22-4dea-889f-d03e2494ed0f.jpg?1",
             "name": "Hagra Diabolist",
             "text": "Whenever Hagra Diabolist or another Ally enters the battlefield under your control, you may have target player lose life equal to the number of Allies you control.",
             "colours": [
@@ -3220,7 +3220,7 @@
         },
         {
             "id": "319ee0df-a9d8-5be8-967d-66f72be6638f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96344c-4b1f-42a6-bbf2-dc5cf11cdb02.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f96344c-4b1f-42a6-bbf2-dc5cf11cdb02.jpg?1",
             "name": "Halo Hunter",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhen Halo Hunter enters the battlefield, destroy target Angel.",
             "colours": [
@@ -3254,7 +3254,7 @@
         },
         {
             "id": "7d756a17-8fc8-5ae5-87c4-534689e5a396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20016d-2b5a-445e-a59b-5305e76f549c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/d/1d20016d-2b5a-445e-a59b-5305e76f549c.jpg?1",
             "name": "Heartstabber Mosquito",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nFlying\nWhen Heartstabber Mosquito enters the battlefield, if it was kicked, destroy target creature.",
             "colours": [
@@ -3288,7 +3288,7 @@
         },
         {
             "id": "8eb76067-15bd-5c40-955a-4e461dac77b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a09ee1-99d9-432f-a4e2-a1377edef9d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30a09ee1-99d9-432f-a4e2-a1377edef9d2.jpg?1",
             "name": "Hideous End",
             "text": "Destroy target nonblack creature. Its controller loses 2 life.",
             "colours": [
@@ -3320,7 +3320,7 @@
         },
         {
             "id": "ff5aec29-8757-5ff5-bf8b-b65e5a011641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859aab70-8192-414c-839b-dd0fbcbd8bf1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/5/859aab70-8192-414c-839b-dd0fbcbd8bf1.jpg?1",
             "name": "Kalitas, Bloodchief of Ghet",
             "text": "{B}{B}{B}, {T}: Destroy target creature. If that creature is put into a graveyard this way, put a black Vampire creature token onto the battlefield. Its power is equal to that creature's power and its toughness is equal to that creature's toughness.",
             "colours": [
@@ -3357,7 +3357,7 @@
         },
         {
             "id": "ed863689-41bd-5741-a5ed-2c6f8e232370",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865ac36f-4c61-468b-a2ed-ed2d1bbbf4e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/865ac36f-4c61-468b-a2ed-ed2d1bbbf4e3.jpg?1",
             "name": "Malakir Bloodwitch",
             "text": "Flying, protection from white\nWhen Malakir Bloodwitch enters the battlefield, each opponent loses life equal to the number of Vampires you control. You gain life equal to the life lost this way.",
             "colours": [
@@ -3392,7 +3392,7 @@
         },
         {
             "id": "e56e89b3-a055-5153-aab1-153a1e20627b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28476d0d-60ea-4d08-890c-0e6502ee3d2a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28476d0d-60ea-4d08-890c-0e6502ee3d2a.jpg?1",
             "name": "Marsh Casualties",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nCreatures target player controls get -1/-1 until end of turn. If Marsh Casualties was kicked, those creatures get -2/-2 until end of turn instead.",
             "colours": [
@@ -3424,7 +3424,7 @@
         },
         {
             "id": "dec042e7-9ccf-5a82-9059-f41f7bd8701d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaedf6d-171b-4845-8815-debbe06b5b66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7aaedf6d-171b-4845-8815-debbe06b5b66.jpg?1",
             "name": "Mind Sludge",
             "text": "Target player discards a card for each Swamp you control.",
             "colours": [
@@ -3456,7 +3456,7 @@
         },
         {
             "id": "418bdc38-4e11-5150-ba0b-3ff2cce8d6d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d43b60-5bbc-4f9d-a96b-8d886b0c6dbd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5d43b60-5bbc-4f9d-a96b-8d886b0c6dbd.jpg?1",
             "name": "Mindless Null",
             "text": "Mindless Null can't block unless you control a Vampire.",
             "colours": [
@@ -3490,7 +3490,7 @@
         },
         {
             "id": "dc1e1c2f-2b07-5777-a64e-b4d6e464e993",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63238d-a022-4ea1-a83d-0b2260d56a17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e63238d-a022-4ea1-a83d-0b2260d56a17.jpg?1",
             "name": "Mire Blight",
             "text": "Enchant creature\nWhen enchanted creature is dealt damage, destroy it.",
             "colours": [
@@ -3524,7 +3524,7 @@
         },
         {
             "id": "a3f55b21-f817-54c2-80b7-3cb9d6af1bd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dee4c4e-9505-43e5-88af-db5f9e56a749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8dee4c4e-9505-43e5-88af-db5f9e56a749.jpg?1",
             "name": "Needlebite Trap",
             "text": "If an opponent gained life this turn, you may pay {B} rather than pay Needlebite Trap's mana cost.\nTarget player loses 5 life and you gain 5 life.",
             "colours": [
@@ -3558,7 +3558,7 @@
         },
         {
             "id": "ffa55b75-5138-5eff-94d3-c8dd1c4c2d08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504d12-a3ef-4588-a52d-734c20f6ac58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/c/8c504d12-a3ef-4588-a52d-734c20f6ac58.jpg?1",
             "name": "Nimana Sell-Sword",
             "text": "Whenever Nimana Sell-Sword or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Nimana Sell-Sword.",
             "colours": [
@@ -3594,7 +3594,7 @@
         },
         {
             "id": "e792373d-60be-58cc-9894-29f82539f13e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824a001-3f0e-4ac5-8406-e58f4288f2f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/7824a001-3f0e-4ac5-8406-e58f4288f2f2.jpg?1",
             "name": "Ob Nixilis, the Fallen",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may have target player lose 3 life. If you do, put three +1/+1 counters on Ob Nixilis, the Fallen.",
             "colours": [
@@ -3630,7 +3630,7 @@
         },
         {
             "id": "3c15b10c-d09c-5c93-be42-98ff3515262a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b3d28-fe57-4d6a-a5d2-cc7cc44973d9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/821b3d28-fe57-4d6a-a5d2-cc7cc44973d9.jpg?1",
             "name": "Quest for the Gravelord",
             "text": "Whenever a creature is put into a graveyard from the battlefield, you may put a quest counter on Quest for the Gravelord.\nRemove three quest counters from Quest for the Gravelord and sacrifice it: Put a 5/5 black Zombie Giant creature token onto the battlefield.",
             "colours": [
@@ -3662,7 +3662,7 @@
         },
         {
             "id": "d0d5d824-55cd-5124-8548-680a2a5b2396",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4540013-11f9-4a8b-ad54-61f467f04756.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4540013-11f9-4a8b-ad54-61f467f04756.jpg?1",
             "name": "Ravenous Trap",
             "text": "If an opponent had three or more cards put into his or her graveyard from anywhere this turn, you may pay {0} rather than pay Ravenous Trap's mana cost.\nExile all cards from target player's graveyard.",
             "colours": [
@@ -3696,7 +3696,7 @@
         },
         {
             "id": "c997beef-77e0-5e95-828e-89e5fd90e0a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d82fd7-6af1-4a97-9d51-486a41224b35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f3d82fd7-6af1-4a97-9d51-486a41224b35.jpg?1",
             "name": "Sadistic Sacrament",
             "text": "Kicker {7} (You may pay an additional {7} as you cast this spell.)\nSearch target player's library for up to three cards, exile them, then that player shuffles his or her library. If Sadistic Sacrament was kicked, instead search that player's library for up to fifteen cards, exile them, then that player shuffles his or her library.",
             "colours": [
@@ -3728,7 +3728,7 @@
         },
         {
             "id": "37b090ca-a6b0-5411-939c-b57e9eefd5bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29606aca-f23f-4dfe-b685-2065193109c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/29606aca-f23f-4dfe-b685-2065193109c8.jpg?1",
             "name": "Sorin Markov",
             "text": "+2: Sorin Markov deals 2 damage to target creature or player and you gain 2 life.\n-3: Target opponent's life total becomes 10.\n-7: You control target player's next turn.",
             "colours": [
@@ -3764,7 +3764,7 @@
         },
         {
             "id": "22b41c42-6a08-5efd-9959-b125f48535cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902d03cd-2df7-4f87-ab99-fd52f0df6339.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/902d03cd-2df7-4f87-ab99-fd52f0df6339.jpg?1",
             "name": "Soul Stair Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Soul Stair Expedition.\nRemove three quest counters from Soul Stair Expedition and sacrifice it: Return up to two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3796,7 +3796,7 @@
         },
         {
             "id": "bff3824b-c13c-5f41-ac17-dad318306a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a1af-14f2-4e22-bd27-9207e837d5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/28a7a1af-14f2-4e22-bd27-9207e837d5fb.jpg?1",
             "name": "Surrakar Marauder",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Surrakar Marauder gains intimidate until end of turn. (It can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -3830,7 +3830,7 @@
         },
         {
             "id": "18e2f84b-be65-55c1-ae66-982daf4643c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d2c4d1-6205-404a-b03d-995b90a3a33a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93d2c4d1-6205-404a-b03d-995b90a3a33a.jpg?1",
             "name": "Vampire Hexmage",
             "text": "First strike\nSacrifice Vampire Hexmage: Remove all counters from target permanent.",
             "colours": [
@@ -3865,7 +3865,7 @@
         },
         {
             "id": "cfafaf14-9b3f-52cd-ab32-68c568f0761f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114eca6c-76de-4b87-8174-78e2d17ad0e3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/114eca6c-76de-4b87-8174-78e2d17ad0e3.jpg?1",
             "name": "Vampire Lacerator",
             "text": "At the beginning of your upkeep, you lose 1 life unless an opponent has 10 or less life.",
             "colours": [
@@ -3900,7 +3900,7 @@
         },
         {
             "id": "2cbc21ec-00db-5f68-b682-c56ef783a4f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f19fe3-7a17-4c45-adfa-590f73dfebfa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/4/44f19fe3-7a17-4c45-adfa-590f73dfebfa.jpg?1",
             "name": "Vampire Nighthawk",
             "text": "Flying\nDeathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
             "colours": [
@@ -3935,7 +3935,7 @@
         },
         {
             "id": "454ef2b6-366e-56b5-8b87-1a199897fcae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6460a752-e5a7-4fd0-9ae5-e0773b86f19b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6460a752-e5a7-4fd0-9ae5-e0773b86f19b.jpg?1",
             "name": "Vampire's Bite",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nTarget creature gets +3/+0 until end of turn. If Vampire's Bite was kicked, that creature gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
             "colours": [
@@ -3967,7 +3967,7 @@
         },
         {
             "id": "89b3a880-fef6-51d7-be6b-12b952c24ff7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1558dfaf-15ed-4220-9051-bf0bf442b2e9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/1558dfaf-15ed-4220-9051-bf0bf442b2e9.jpg?1",
             "name": "Bladetusk Boar",
             "text": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)",
             "colours": [
@@ -4001,7 +4001,7 @@
         },
         {
             "id": "55a6022a-92ae-5622-bd55-fdb95344a75b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc16614-5cf8-444d-a5ae-cac25018af68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/d/2dc16614-5cf8-444d-a5ae-cac25018af68.jpg?1",
             "name": "Burst Lightning",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to target creature or player. If Burst Lightning was kicked, it deals 4 damage to that creature or player instead.",
             "colours": [
@@ -4033,7 +4033,7 @@
         },
         {
             "id": "10c0dcdc-3bce-5942-ab79-10e10e5a92a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da8995-77da-4ec4-94a5-5e7932a3c969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43da8995-77da-4ec4-94a5-5e7932a3c969.jpg?1",
             "name": "Chandra Ablaze",
             "text": "+1: Discard a card. If a red card is discarded this way, Chandra Ablaze deals 4 damage to target creature or player.\n-2: Each player discards his or her hand, then draws three cards.\n-7: Cast any number of red instant and/or sorcery cards from your graveyard without paying their mana costs.",
             "colours": [
@@ -4069,7 +4069,7 @@
         },
         {
             "id": "99b909d6-de41-56a1-96eb-b5bf13109952",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0df49a-b60b-4987-aa99-36791a30f453.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c0df49a-b60b-4987-aa99-36791a30f453.jpg?1",
             "name": "Demolish",
             "text": "Destroy target artifact or land.",
             "colours": [
@@ -4101,7 +4101,7 @@
         },
         {
             "id": "a48639fd-0a31-580a-9e48-c75a8e6c480a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9830b9e9-950c-4763-9396-8194d08bf8df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9830b9e9-950c-4763-9396-8194d08bf8df.jpg?1",
             "name": "Electropotence",
             "text": "Whenever a creature enters the battlefield under your control, you may pay {2}{R}. If you do, that creature deals damage equal to its power to target creature or player.",
             "colours": [
@@ -4133,7 +4133,7 @@
         },
         {
             "id": "c5eda3cf-a072-5c50-b49f-f7a9a07e6d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a583f30-a3e0-4c4f-81b3-01452edaf22c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a583f30-a3e0-4c4f-81b3-01452edaf22c.jpg?1",
             "name": "Elemental Appeal",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nPut a 7/1 red Elemental creature token with trample and haste onto the battlefield. Exile it at the beginning of the next end step. If Elemental Appeal was kicked, that creature gets +7/+0 until end of turn.",
             "colours": [
@@ -4165,7 +4165,7 @@
         },
         {
             "id": "2cd9f97d-6781-524a-b25b-eaed4ffbc33f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aec169-4c62-4d53-a19c-68baa20c8e59.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b8aec169-4c62-4d53-a19c-68baa20c8e59.jpg?1",
             "name": "Geyser Glider",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Geyser Glider gains flying until end of turn.",
             "colours": [
@@ -4200,7 +4200,7 @@
         },
         {
             "id": "4a55c4da-0316-50c0-b00e-d037f2f9484e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4085a5bf-a71b-4c73-9b39-0dcc328fe11b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/4085a5bf-a71b-4c73-9b39-0dcc328fe11b.jpg?1",
             "name": "Goblin Bushwhacker",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nWhen Goblin Bushwhacker enters the battlefield, if it was kicked, creatures you control get +1/+0 and gain haste until end of turn.",
             "colours": [
@@ -4235,7 +4235,7 @@
         },
         {
             "id": "06551013-d5a8-5323-b5e4-002d0e652211",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e2a777-0705-4a37-937d-c6e020ebc0f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2e2a777-0705-4a37-937d-c6e020ebc0f0.jpg?1",
             "name": "Goblin Guide",
             "text": "Haste\nWhenever Goblin Guide attacks, defending player reveals the top card of his or her library. If it's a land card, that player puts it into his or her hand.",
             "colours": [
@@ -4270,7 +4270,7 @@
         },
         {
             "id": "94893096-8a64-5adf-9a35-5e1a250fa1ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95d1f3-7ec1-4279-ade7-3f339f2f33da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d95d1f3-7ec1-4279-ade7-3f339f2f33da.jpg?1",
             "name": "Goblin Ruinblaster",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nHaste\nWhen Goblin Ruinblaster enters the battlefield, if it was kicked, destroy target nonbasic land.",
             "colours": [
@@ -4305,7 +4305,7 @@
         },
         {
             "id": "456eda3b-035d-59e8-8cd7-64786203513b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daeaa2e-68e5-4f49-9220-58c0c9b1a3d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5daeaa2e-68e5-4f49-9220-58c0c9b1a3d0.jpg?1",
             "name": "Goblin Shortcutter",
             "text": "When Goblin Shortcutter enters the battlefield, target creature can't block this turn.",
             "colours": [
@@ -4340,7 +4340,7 @@
         },
         {
             "id": "3e3f994e-07ec-5324-8960-851648933eda",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4388e57e-0c87-4d66-a862-58261d76c5ac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/4388e57e-0c87-4d66-a862-58261d76c5ac.jpg?1",
             "name": "Goblin War Paint",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
             "colours": [
@@ -4374,7 +4374,7 @@
         },
         {
             "id": "96fc59f6-41ce-5b8f-b94e-d1bb8f7d79ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f975874-24a6-4a14-bc5c-898c3d8e90e5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8f975874-24a6-4a14-bc5c-898c3d8e90e5.jpg?1",
             "name": "Hellfire Mongrel",
             "text": "At the beginning of each opponent's upkeep, if that player has two or fewer cards in hand, Hellfire Mongrel deals 2 damage to him or her.",
             "colours": [
@@ -4409,7 +4409,7 @@
         },
         {
             "id": "d36bfe91-c837-5760-b0d2-7017a2898a33",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70c645d-d170-4a91-a6bb-0175ec900e93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70c645d-d170-4a91-a6bb-0175ec900e93.jpg?1",
             "name": "Hellkite Charger",
             "text": "Flying, haste\nWhenever Hellkite Charger attacks, you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase.",
             "colours": [
@@ -4443,7 +4443,7 @@
         },
         {
             "id": "fde65f15-3bbb-5c0e-9f13-7090ac2de76e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c22bf3-2ba6-4d8f-a2b8-a5d5e26f1316.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3c22bf3-2ba6-4d8f-a2b8-a5d5e26f1316.jpg?1",
             "name": "Highland Berserker",
             "text": "Whenever Highland Berserker or another Ally enters the battlefield under your control, you may have Ally creatures you control gain first strike until end of turn.",
             "colours": [
@@ -4479,7 +4479,7 @@
         },
         {
             "id": "0e2760d0-000a-5457-83a1-38177453278f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a81ac38-c477-4797-ab91-cb7804cb727b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a81ac38-c477-4797-ab91-cb7804cb727b.jpg?1",
             "name": "Inferno Trap",
             "text": "If you've been dealt damage by two or more creatures this turn, you may pay {R} rather than pay Inferno Trap's mana cost.\nInferno Trap deals 4 damage to target creature.",
             "colours": [
@@ -4513,7 +4513,7 @@
         },
         {
             "id": "39ca5513-6ceb-5f79-9e11-798c5c94ac8c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da42df13-eded-48e2-ad1a-ff74d718ce3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da42df13-eded-48e2-ad1a-ff74d718ce3c.jpg?1",
             "name": "Kazuul Warlord",
             "text": "Whenever Kazuul Warlord or another Ally enters the battlefield under your control, you may put a +1/+1 counter on each Ally creature you control.",
             "colours": [
@@ -4549,7 +4549,7 @@
         },
         {
             "id": "520acc7e-c78a-56d3-8e5e-e48c59d6d391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d411e1-5488-4818-95a4-9f637efb9be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0d411e1-5488-4818-95a4-9f637efb9be6.jpg?1",
             "name": "Lavaball Trap",
             "text": "If an opponent had two or more lands enter the battlefield under his or her control this turn, you may pay {3}{R}{R} rather than pay Lavaball Trap's mana cost.\nDestroy two target lands. Lavaball Trap deals 4 damage to each creature.",
             "colours": [
@@ -4583,7 +4583,7 @@
         },
         {
             "id": "2229270a-0c82-526e-9f2a-ddd656ea9aa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee526306-6959-421c-9969-3c19b666d6da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/ee526306-6959-421c-9969-3c19b666d6da.jpg?1",
             "name": "Magma Rift",
             "text": "As an additional cost to cast Magma Rift, sacrifice a land.\nMagma Rift deals 5 damage to target creature.",
             "colours": [
@@ -4615,7 +4615,7 @@
         },
         {
             "id": "5be9ecd2-8855-5d47-8b23-0f220380a5a2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a0a019-239d-428e-85a2-e19cae8f4b58.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/58a0a019-239d-428e-85a2-e19cae8f4b58.jpg?1",
             "name": "Mark of Mutiny",
             "text": "Gain control of target creature until end of turn. Put a +1/+1 counter on it and untap it. That creature gains haste until end of turn.",
             "colours": [
@@ -4647,7 +4647,7 @@
         },
         {
             "id": "06a1ac15-dd8b-5d90-951c-2afc1716a814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebc7622-e7a7-419c-abb4-d9d339e6cdb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ebc7622-e7a7-419c-abb4-d9d339e6cdb0.jpg?1",
             "name": "Molten Ravager",
             "text": "{R}: Molten Ravager gets +1/+0 until end of turn.",
             "colours": [
@@ -4681,7 +4681,7 @@
         },
         {
             "id": "a5a0169f-924e-5325-ac27-305bf317e210",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60daf59f-ffba-403b-8028-787ff33f2d6c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60daf59f-ffba-403b-8028-787ff33f2d6c.jpg?1",
             "name": "Murasa Pyromancer",
             "text": "Whenever Murasa Pyromancer or another Ally enters the battlefield under your control, you may have Murasa Pyromancer deal damage to target creature equal to the number of Allies you control.",
             "colours": [
@@ -4717,7 +4717,7 @@
         },
         {
             "id": "b35dd7e8-5334-5f09-8bc4-822b90eb0659",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbf7e23-5610-45d7-a273-923433d10934.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fbf7e23-5610-45d7-a273-923433d10934.jpg?1",
             "name": "Obsidian Fireheart",
             "text": "{1}{R}{R}: Put a blaze counter on target land without a blaze counter on it. As long as that land has a blaze counter on it, it has \"At the beginning of your upkeep, this land deals 1 damage to you.\" (The land continues to burn after Obsidian Fireheart has left the battlefield.)",
             "colours": [
@@ -4751,7 +4751,7 @@
         },
         {
             "id": "42d19a53-3dce-5e2b-8760-048260b6b002",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8b5c0c-acda-411e-9f17-6d9292628a56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd8b5c0c-acda-411e-9f17-6d9292628a56.jpg?1",
             "name": "Plated Geopede",
             "text": "First strike\nLandfall \u2014 Whenever a land enters the battlefield under your control, Plated Geopede gets +2/+2 until end of turn.",
             "colours": [
@@ -4785,7 +4785,7 @@
         },
         {
             "id": "ebd24dcd-4197-5edd-8aef-794149bb1908",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e76f1c-5a07-455a-a3df-4c45b5b25b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/56e76f1c-5a07-455a-a3df-4c45b5b25b82.jpg?1",
             "name": "Punishing Fire",
             "text": "Punishing Fire deals 2 damage to target creature or player.\nWhenever an opponent gains life, you may pay {R}. If you do, return Punishing Fire from your graveyard to your hand.",
             "colours": [
@@ -4817,7 +4817,7 @@
         },
         {
             "id": "8b3e65c4-7fc8-5c8d-966e-5b061ab71544",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288d624e-d72e-4a4b-bb74-5a8b0b2e3cb0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/288d624e-d72e-4a4b-bb74-5a8b0b2e3cb0.jpg?1",
             "name": "Pyromancer Ascension",
             "text": "Whenever you cast an instant or sorcery spell that has the same name as a card in your graveyard, you may put a quest counter on Pyromancer Ascension.\nWhenever you cast an instant or sorcery spell while Pyromancer Ascension has two or more quest counters on it, you may copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -4849,7 +4849,7 @@
         },
         {
             "id": "03fcb278-4971-58a7-860b-9999263c347b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ac5a-21b9-4abe-b8be-86b9056ad70d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b43ac5a-21b9-4abe-b8be-86b9056ad70d.jpg?1",
             "name": "Quest for Pure Flame",
             "text": "Whenever a source you control deals damage to an opponent, you may put a quest counter on Quest for Pure Flame.\nRemove four quest counters from Quest for Pure Flame and sacrifice it: If any source you control would deal damage to a creature or player this turn, it deals double that damage to that creature or player instead.",
             "colours": [
@@ -4881,7 +4881,7 @@
         },
         {
             "id": "0a4e7c21-cbdd-5e42-9dd7-97ab7b836d50",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e800a3fe-bb1a-45f1-8c81-5ec88ff8647b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e800a3fe-bb1a-45f1-8c81-5ec88ff8647b.jpg?1",
             "name": "Ruinous Minotaur",
             "text": "Whenever Ruinous Minotaur deals damage to an opponent, sacrifice a land.",
             "colours": [
@@ -4916,7 +4916,7 @@
         },
         {
             "id": "aff3807b-9aa9-5c0b-b45a-2c6dc6f3bb5f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ceff22-0270-4c9d-9ae2-f40a7047335b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ceff22-0270-4c9d-9ae2-f40a7047335b.jpg?1",
             "name": "Runeflare Trap",
             "text": "If an opponent drew three or more cards this turn, you may pay {R} rather than pay Runeflare Trap's mana cost.\nRuneflare Trap deals damage to target player equal to the number of cards in that player's hand.",
             "colours": [
@@ -4950,7 +4950,7 @@
         },
         {
             "id": "347ba0f7-f96c-5e15-b3ae-3ee1efe1c419",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20365082-6102-4e3b-8791-c9b66846270d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20365082-6102-4e3b-8791-c9b66846270d.jpg?1",
             "name": "Seismic Shudder",
             "text": "Seismic Shudder deals 1 damage to each creature without flying.",
             "colours": [
@@ -4982,7 +4982,7 @@
         },
         {
             "id": "2e26814d-3aaa-5940-b5c4-21d224b0878f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfbb4dd-56a2-4a94-9b15-b3ef8b2f1d0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfbb4dd-56a2-4a94-9b15-b3ef8b2f1d0b.jpg?1",
             "name": "Shatterskull Giant",
             "text": "",
             "colours": [
@@ -5017,7 +5017,7 @@
         },
         {
             "id": "2f962346-439b-55c0-ad4d-3f3ed0323145",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93b0eda-693e-4a17-be1d-1df162702146.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c93b0eda-693e-4a17-be1d-1df162702146.jpg?1",
             "name": "Slaughter Cry",
             "text": "Target creature gets +3/+0 and gains first strike until end of turn.",
             "colours": [
@@ -5049,7 +5049,7 @@
         },
         {
             "id": "6bc3fee4-beb8-531d-811c-e2518ef920f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c8fe2a-3203-4545-bb25-b1f107b13cca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8c8fe2a-3203-4545-bb25-b1f107b13cca.jpg?1",
             "name": "Spire Barrage",
             "text": "Spire Barrage deals damage to target creature or player equal to the number of Mountains you control.",
             "colours": [
@@ -5081,7 +5081,7 @@
         },
         {
             "id": "caf46460-0d3f-51b5-9bce-e06146ca1848",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4648820-9e87-4c67-8d97-cd7603f2e484.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/4/f4648820-9e87-4c67-8d97-cd7603f2e484.jpg?1",
             "name": "Torch Slinger",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nWhen Torch Slinger enters the battlefield, if it was kicked, it deals 2 damage to target creature.",
             "colours": [
@@ -5116,7 +5116,7 @@
         },
         {
             "id": "b4da9dbf-87f5-5a31-88ca-b4d948dd452d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f37982-d2ae-4ff1-b5da-3936733f8108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e6f37982-d2ae-4ff1-b5da-3936733f8108.jpg?1",
             "name": "Tuktuk Grunts",
             "text": "Haste\nWhenever Tuktuk Grunts or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Tuktuk Grunts.",
             "colours": [
@@ -5152,7 +5152,7 @@
         },
         {
             "id": "3fca9d9c-0bb6-5b33-bb4d-30ff51edb2cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41c658e-68ec-4b55-bc5b-fd9fe8dbbdb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d41c658e-68ec-4b55-bc5b-fd9fe8dbbdb3.jpg?1",
             "name": "Unstable Footing",
             "text": "Kicker {3}{R} (You may pay an additional {3}{R} as you cast this spell.)\nDamage can't be prevented this turn. If Unstable Footing was kicked, it deals 5 damage to target player.",
             "colours": [
@@ -5184,7 +5184,7 @@
         },
         {
             "id": "6cc06280-1fe3-5694-8a98-b5399a502c68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98637219-40d8-414c-939d-e2c90b909725.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98637219-40d8-414c-939d-e2c90b909725.jpg?1",
             "name": "Warren Instigator",
             "text": "Double strike\nWhenever Warren Instigator deals damage to an opponent, you may put a Goblin creature card from your hand onto the battlefield.",
             "colours": [
@@ -5219,7 +5219,7 @@
         },
         {
             "id": "d2525841-d3a3-55ea-99bf-ea8d2f2dfda6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12d2c01-0ef2-40e6-8c7d-8512e2c8c074.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f12d2c01-0ef2-40e6-8c7d-8512e2c8c074.jpg?1",
             "name": "Zektar Shrine Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Zektar Shrine Expedition.\nRemove three quest counters from Zektar Shrine Expedition and sacrifice it: Put a 7/1 red Elemental creature token with trample and haste onto the battlefield. Exile it at the beginning of the next end step.",
             "colours": [
@@ -5251,7 +5251,7 @@
         },
         {
             "id": "f0b54fe8-5dcb-51b6-96b4-1e2ffd7a1fd3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00ac173-ea82-4364-812c-13173a700dd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c00ac173-ea82-4364-812c-13173a700dd0.jpg?1",
             "name": "Baloth Cage Trap",
             "text": "If an opponent had an artifact enter the battlefield under his or her control this turn, you may pay {1}{G} rather than pay Baloth Cage Trap's mana cost.\nPut a 4/4 green Beast creature token onto the battlefield.",
             "colours": [
@@ -5285,7 +5285,7 @@
         },
         {
             "id": "2d0cec7f-9ae5-544f-9d6a-9e654bce9709",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223dc6a-2bee-4be9-86d5-f0a17a24c33e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/8223dc6a-2bee-4be9-86d5-f0a17a24c33e.jpg?1",
             "name": "Baloth Woodcrasher",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Baloth Woodcrasher gets +4/+4 and gains trample until end of turn.",
             "colours": [
@@ -5319,7 +5319,7 @@
         },
         {
             "id": "aea4101d-57fc-518d-88a7-b8603003db79",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46465b5f-26fa-4a07-9dc9-55486edee31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46465b5f-26fa-4a07-9dc9-55486edee31a.jpg?1",
             "name": "Beast Hunt",
             "text": "Reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest into your graveyard.",
             "colours": [
@@ -5351,7 +5351,7 @@
         },
         {
             "id": "4edccf17-3d7f-5511-8f98-b58e87a589c3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d7ea78-d539-4c34-8bb3-941353e3da46.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d7ea78-d539-4c34-8bb3-941353e3da46.jpg?1",
             "name": "Beastmaster Ascension",
             "text": "Whenever a creature you control attacks, you may put a quest counter on Beastmaster Ascension.\nAs long as Beastmaster Ascension has seven or more quest counters on it, creatures you control get +5/+5.",
             "colours": [
@@ -5383,7 +5383,7 @@
         },
         {
             "id": "a2427f58-0390-5a0b-adee-d996df761321",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e2966-c163-4e02-a315-4fe66e482884.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a4e2966-c163-4e02-a315-4fe66e482884.jpg?1",
             "name": "Cobra Trap",
             "text": "If a noncreature permanent under your control was destroyed this turn by a spell or ability an opponent controlled, you may pay {G} rather than pay Cobra Trap's mana cost.\nPut four 1/1 green Snake creature tokens onto the battlefield.",
             "colours": [
@@ -5417,7 +5417,7 @@
         },
         {
             "id": "a6ecaed9-7834-5fa9-a333-795c9dce4c84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a418a-2386-49b9-b48d-67a52448e65c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b99a418a-2386-49b9-b48d-67a52448e65c.jpg?1",
             "name": "Frontier Guide",
             "text": "{3}{G}, {T}: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.",
             "colours": [
@@ -5452,7 +5452,7 @@
         },
         {
             "id": "16c04080-954d-5902-8b70-a91cd191bc59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa476306-9d6b-45ed-9e6c-fd4aee6592e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa476306-9d6b-45ed-9e6c-fd4aee6592e7.jpg?1",
             "name": "Gigantiform",
             "text": "Kicker {4}\nEnchant creature\nEnchanted creature is 8/8 and has trample.\nWhen Gigantiform enters the battlefield, if it was kicked, you may search your library for a card named Gigantiform, put it onto the battlefield, then shuffle your library.",
             "colours": [
@@ -5486,7 +5486,7 @@
         },
         {
             "id": "5ce32715-8dee-5c47-986a-88d00e87c506",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b5290-a613-496f-bd23-8fd109549f31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/7/078b5290-a613-496f-bd23-8fd109549f31.jpg?1",
             "name": "Grazing Gladehart",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may gain 2 life.",
             "colours": [
@@ -5520,7 +5520,7 @@
         },
         {
             "id": "fdb17ac5-bbfd-5596-90ed-2fede299ce3e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747099f7-ce5b-4366-a8a4-f3d80100f66e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/747099f7-ce5b-4366-a8a4-f3d80100f66e.jpg?1",
             "name": "Greenweaver Druid",
             "text": "{T}: Add {G}{G} to your mana pool.",
             "colours": [
@@ -5555,7 +5555,7 @@
         },
         {
             "id": "62454305-aa7f-5dce-9048-7b8af6ed09db",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e309c1fc-3a7c-4624-8b48-9b152c2590ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e309c1fc-3a7c-4624-8b48-9b152c2590ae.jpg?1",
             "name": "Harrow",
             "text": "As an additional cost to cast Harrow, sacrifice a land.\nSearch your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5587,7 +5587,7 @@
         },
         {
             "id": "eb256b35-474b-5b47-b693-738d7c12a988",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5a5f-d851-4ceb-96e7-9ba216062072.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b53f5a5f-d851-4ceb-96e7-9ba216062072.jpg?1",
             "name": "Joraga Bard",
             "text": "Whenever Joraga Bard or another Ally enters the battlefield under your control, you may have Ally creatures you control gain vigilance until end of turn.",
             "colours": [
@@ -5624,7 +5624,7 @@
         },
         {
             "id": "0e4db2dc-36a6-5164-a5f7-d6e2efc3fbd0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797d8cd6-fc6b-4560-9c6f-1a867dfce85a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/797d8cd6-fc6b-4560-9c6f-1a867dfce85a.jpg?1",
             "name": "Khalni Heart Expedition",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may put a quest counter on Khalni Heart Expedition.\nRemove three quest counters from Khalni Heart Expedition and sacrifice it: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -5656,7 +5656,7 @@
         },
         {
             "id": "3280ccbd-c1eb-533a-aefb-ce9b7a3d48aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19adde22-e5eb-4815-beb6-c520b3274cc9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/19adde22-e5eb-4815-beb6-c520b3274cc9.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you may add one mana of any color to your mana pool.",
             "colours": [
@@ -5690,7 +5690,7 @@
         },
         {
             "id": "09a6d117-8ccc-545c-b55c-9b071ef93391",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903cb570-d769-4d7f-afbe-90ebad96657c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/903cb570-d769-4d7f-afbe-90ebad96657c.jpg?1",
             "name": "Mold Shambler",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Mold Shambler enters the battlefield, if it was kicked, destroy target noncreature permanent.",
             "colours": [
@@ -5725,7 +5725,7 @@
         },
         {
             "id": "a77415ec-938c-5709-869b-bd084b3f7a0c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4c26ab-0f7b-4163-b9e4-a415b91352a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1b4c26ab-0f7b-4163-b9e4-a415b91352a6.jpg?1",
             "name": "Nissa Revane",
             "text": "+1: Search your library for a card named Nissa's Chosen and put it onto the battlefield. Then shuffle your library.\n+1: You gain 2 life for each Elf you control.\n-7: Search your library for any number of Elf creature cards and put them onto the battlefield. Then shuffle your library.",
             "colours": [
@@ -5761,7 +5761,7 @@
         },
         {
             "id": "b783a1fb-3395-5d73-91a9-521c54c09dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a740584f-2ec2-46a9-9344-eac220759e85.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a740584f-2ec2-46a9-9344-eac220759e85.jpg?1",
             "name": "Nissa's Chosen",
             "text": "If Nissa's Chosen would be put into a graveyard from the battlefield, put it on the bottom of its owner's library instead.",
             "colours": [
@@ -5796,7 +5796,7 @@
         },
         {
             "id": "043bf4ea-aa82-5ce5-9b29-02e90e77c58c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89a173-0b2f-4a6a-b706-9aed8dbcabec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f89a173-0b2f-4a6a-b706-9aed8dbcabec.jpg?1",
             "name": "Oracle of Mul Daya",
             "text": "You may play an additional land on each of your turns.\nPlay with the top card of your library revealed.\nYou may play the top card of your library if it's a land card.",
             "colours": [
@@ -5831,7 +5831,7 @@
         },
         {
             "id": "4d94e393-6c33-5e66-b321-edcaec2af36c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a69043-23f5-478e-bf9b-f170e326c0e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37a69043-23f5-478e-bf9b-f170e326c0e0.jpg?1",
             "name": "Oran-Rief Recluse",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nReach (This creature can block creatures with flying.)\nWhen Oran-Rief Recluse enters the battlefield, if it was kicked, destroy target creature with flying.",
             "colours": [
@@ -5865,7 +5865,7 @@
         },
         {
             "id": "5bfba302-4f2d-5e43-8265-add2a66caa98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d598220-bddd-48a4-8c80-eb149c6292a3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d598220-bddd-48a4-8c80-eb149c6292a3.jpg?1",
             "name": "Oran-Rief Survivalist",
             "text": "Whenever Oran-Rief Survivalist or another Ally enters the battlefield under your control, you may put a +1/+1 counter on Oran-Rief Survivalist.",
             "colours": [
@@ -5901,7 +5901,7 @@
         },
         {
             "id": "56b6d7e6-3cbc-57b2-9d4c-829775b3bf05",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f8adaa-2852-4e9c-b91d-ce80a21859c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/7/d7f8adaa-2852-4e9c-b91d-ce80a21859c9.jpg?1",
             "name": "Predatory Urge",
             "text": "Enchant creature\nEnchanted creature has \"{T}: This creature deals damage equal to its power to target creature. That creature deals damage equal to its power to this creature.\"",
             "colours": [
@@ -5935,7 +5935,7 @@
         },
         {
             "id": "3af7a402-0d79-57b3-ab7b-04b920fda645",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b0c6a9-a7c0-4518-8580-653712062265.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/23b0c6a9-a7c0-4518-8580-653712062265.jpg?1",
             "name": "Primal Bellow",
             "text": "Target creature gets +1/+1 until end of turn for each Forest you control.",
             "colours": [
@@ -5967,7 +5967,7 @@
         },
         {
             "id": "72d2c199-508a-566e-a058-bb604d7817ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12a160-9c05-4f66-bd80-035ea52f415b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea12a160-9c05-4f66-bd80-035ea52f415b.jpg?1",
             "name": "Quest for the Gemblades",
             "text": "Whenever a creature you control deals combat damage to a creature, you may put a quest counter on Quest for the Gemblades.\nRemove a quest counter from Quest for the Gemblades and sacrifice it: Put four +1/+1 counters on target creature.",
             "colours": [
@@ -5999,7 +5999,7 @@
         },
         {
             "id": "d576014d-7c81-57af-92cd-341a31d7d20b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ae703d-b133-4749-9d38-216abe6c6647.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/66ae703d-b133-4749-9d38-216abe6c6647.jpg?1",
             "name": "Rampaging Baloths",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may put a 4/4 green Beast creature token onto the battlefield.",
             "colours": [
@@ -6033,7 +6033,7 @@
         },
         {
             "id": "064c94a9-8f62-5cf4-8d81-d658fd0b36d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c924b2-3b10-4bb0-b51d-122bfdd298aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/01c924b2-3b10-4bb0-b51d-122bfdd298aa.jpg?1",
             "name": "Relic Crush",
             "text": "Destroy target artifact or enchantment and up to one other target artifact or enchantment.",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "6b63e705-de6f-5047-9426-063030bbda3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a81be06-b685-461b-80a8-2f23139106e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4a81be06-b685-461b-80a8-2f23139106e7.jpg?1",
             "name": "River Boa",
             "text": "Islandwalk\n{G}: Regenerate River Boa.",
             "colours": [
@@ -6099,7 +6099,7 @@
         },
         {
             "id": "0cc480f5-6079-54fd-bdb9-c1ceb2610457",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8547e0-2928-4edc-a15a-a613cb4d1eac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b8547e0-2928-4edc-a15a-a613cb4d1eac.jpg?1",
             "name": "Savage Silhouette",
             "text": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\"",
             "colours": [
@@ -6133,7 +6133,7 @@
         },
         {
             "id": "10253e7c-a2a8-5e2d-bf40-4647a6a98687",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e2fcc6-96d3-45f5-b4dd-e049d9ec6cec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43e2fcc6-96d3-45f5-b4dd-e049d9ec6cec.jpg?1",
             "name": "Scute Mob",
             "text": "At the beginning of your upkeep, if you control five or more lands, put four +1/+1 counters on Scute Mob.",
             "colours": [
@@ -6167,7 +6167,7 @@
         },
         {
             "id": "2b6a41e5-b51f-58eb-bbc5-cb03ac955867",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d289043-edb5-4a7e-801b-4881709edb32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d289043-edb5-4a7e-801b-4881709edb32.jpg?1",
             "name": "Scythe Tiger",
             "text": "Shroud (This creature can't be the target of spells or abilities.)\nWhen Scythe Tiger enters the battlefield, sacrifice it unless you sacrifice a land.",
             "colours": [
@@ -6201,7 +6201,7 @@
         },
         {
             "id": "85c406f8-807c-5aa4-8a2b-f78f5abb180b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ce4a96-9cb2-4032-9291-7fa0849aeab9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/2/72ce4a96-9cb2-4032-9291-7fa0849aeab9.jpg?1",
             "name": "Summoning Trap",
             "text": "If a creature spell you cast this turn was countered by a spell or ability an opponent controlled, you may pay {0} rather than pay Summoning Trap's mana cost.\nLook at the top seven cards of your library. You may put a creature card from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
             "colours": [
@@ -6235,7 +6235,7 @@
         },
         {
             "id": "c447c078-c72f-5295-b4e6-a890b2a1f8cf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46dbeb-f9b3-4e0f-a61f-52a91da6f087.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/c/ec46dbeb-f9b3-4e0f-a61f-52a91da6f087.jpg?1",
             "name": "Tajuru Archer",
             "text": "Whenever Tajuru Archer or another Ally enters the battlefield under your control, you may have Tajuru Archer deal damage to target creature with flying equal to the number of Allies you control.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "4964680f-1ef2-5443-90b2-49c418cb6d12",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e15b-7460-4d61-a209-6de27e4df6bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c4e15b-7460-4d61-a209-6de27e4df6bb.jpg?1",
             "name": "Tanglesap",
             "text": "Prevent all combat damage that would be dealt this turn by creatures without trample.",
             "colours": [
@@ -6303,7 +6303,7 @@
         },
         {
             "id": "6fe4ea5f-b07c-5acc-b57a-9ca8aff0101e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab062f4-e4b1-4129-9027-d0ca1a723273.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/a/4ab062f4-e4b1-4129-9027-d0ca1a723273.jpg?1",
             "name": "Terra Stomper",
             "text": "Terra Stomper can't be countered.\nTrample",
             "colours": [
@@ -6337,7 +6337,7 @@
         },
         {
             "id": "e248f976-b5af-5464-868b-0ab6a8e792ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45033b8a-f3a8-4a23-b6b0-e011e3e7a4c1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45033b8a-f3a8-4a23-b6b0-e011e3e7a4c1.jpg?1",
             "name": "Territorial Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Territorial Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -6371,7 +6371,7 @@
         },
         {
             "id": "e7a1666e-7fee-5d76-9347-e30d7bcf4335",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fc3bc-eb3b-4504-93a3-8943d07b23f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d68fc3bc-eb3b-4504-93a3-8943d07b23f8.jpg?1",
             "name": "Timbermaw Larva",
             "text": "Whenever Timbermaw Larva attacks, it gets +1/+1 until end of turn for each Forest you control.",
             "colours": [
@@ -6405,7 +6405,7 @@
         },
         {
             "id": "2dba9d5e-9dfd-5dd3-aa15-1ddf81b897b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b774563a-d2d4-4bdf-ad82-dd9e1fa953ba.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b774563a-d2d4-4bdf-ad82-dd9e1fa953ba.jpg?1",
             "name": "Turntimber Basilisk",
             "text": "Deathtouch (Creatures dealt damage by this creature are destroyed. You can divide this creature's combat damage among any of the creatures blocking or blocked by it.)\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have target creature block Turntimber Basilisk this turn if able.",
             "colours": [
@@ -6439,7 +6439,7 @@
         },
         {
             "id": "f0628638-ae53-5e9c-a1ff-3586524f774a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24bba56-3256-489b-82a2-22748388e110.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a24bba56-3256-489b-82a2-22748388e110.jpg?1",
             "name": "Turntimber Ranger",
             "text": "Whenever Turntimber Ranger or another Ally enters the battlefield under your control, you may put a 2/2 green Wolf creature token onto the battlefield. If you do, put a +1/+1 counter on Turntimber Ranger.",
             "colours": [
@@ -6476,7 +6476,7 @@
         },
         {
             "id": "310e58c0-0895-573f-a89c-72a85fd18f89",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5daf96-ceae-4c9a-95cd-f6d706e9b1fa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5daf96-ceae-4c9a-95cd-f6d706e9b1fa.jpg?1",
             "name": "Vastwood Gorger",
             "text": "",
             "colours": [
@@ -6510,7 +6510,7 @@
         },
         {
             "id": "56f22031-170c-54b5-a297-610e388ddb9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bd8b10-de86-4bb6-b49f-6ccb5297c81c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8bd8b10-de86-4bb6-b49f-6ccb5297c81c.jpg?1",
             "name": "Vines of Vastwood",
             "text": "Kicker {G} (You may pay an additional {G} as you cast this spell.)\nTarget creature can't be the target of spells or abilities your opponents control this turn. If Vines of Vastwood was kicked, that creature gets +4/+4 until end of turn.",
             "colours": [
@@ -6542,7 +6542,7 @@
         },
         {
             "id": "b2b0789a-bbeb-5a12-ba9b-dc7325b17206",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb7fb-8618-4595-84b4-20881b824b3e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b3aeb7fb-8618-4595-84b4-20881b824b3e.jpg?1",
             "name": "Zendikar Farguide",
             "text": "Forestwalk",
             "colours": [
@@ -6576,7 +6576,7 @@
         },
         {
             "id": "63af049c-be3d-50a7-8ccc-ad9e50b1bb40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa395f2-656e-4bf3-bd9b-6240bd3e2774.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3aa395f2-656e-4bf3-bd9b-6240bd3e2774.jpg?1",
             "name": "Adventuring Gear",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "f5c15e35-854f-5e2b-aa05-57478411ed95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b42e5-0e60-4148-907e-456d9f3043be.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/e/7e4b42e5-0e60-4148-907e-456d9f3043be.jpg?1",
             "name": "Blade of the Bloodchief",
             "text": "Whenever a creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature. If equipped creature is a Vampire, put two +1/+1 counters on it instead.\nEquip {1}",
             "colours": [],
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "4cbcc725-b6d8-55a0-b130-63618b13a351",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9d1ff2-9ce3-4737-af1d-9fc82e4dffe6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e9d1ff2-9ce3-4737-af1d-9fc82e4dffe6.jpg?1",
             "name": "Blazing Torch",
             "text": "Equipped creature can't be blocked by Vampires or Zombies.\nEquipped creature has \"{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to target creature or player.\"\nEquip {1}",
             "colours": [],
@@ -6666,7 +6666,7 @@
         },
         {
             "id": "65950970-fea4-5aa0-9f80-e409f43f2e26",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52688a03-26a4-40ff-8a99-a268113a9802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52688a03-26a4-40ff-8a99-a268113a9802.jpg?1",
             "name": "Carnage Altar",
             "text": "{3}, Sacrifice a creature: Draw a card.",
             "colours": [],
@@ -6694,7 +6694,7 @@
         },
         {
             "id": "94ae28a6-7456-5e6d-859a-85d69ed3468f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4169-8c49-41f4-9e01-20de06ca4ad9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f4169-8c49-41f4-9e01-20de06ca4ad9.jpg?1",
             "name": "Eldrazi Monument",
             "text": "Creatures you control get +1/+1, have flying, and are indestructible.\nAt the beginning of your upkeep, sacrifice a creature. If you can't, sacrifice Eldrazi Monument.",
             "colours": [],
@@ -6722,7 +6722,7 @@
         },
         {
             "id": "fe4ae6e4-0c9a-5fba-a09e-5dcda5580293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9222e18-41b3-423f-8715-305a0d8fd410.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9222e18-41b3-423f-8715-305a0d8fd410.jpg?1",
             "name": "Eternity Vessel",
             "text": "Eternity Vessel enters the battlefield with X charge counters on it, where X is your life total.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you may have your life total become the number of charge counters on Eternity Vessel.",
             "colours": [],
@@ -6750,7 +6750,7 @@
         },
         {
             "id": "cba1eb11-a729-58b3-b63e-07277901ff1b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55bee97-593f-441f-b96c-a998d5212a55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c55bee97-593f-441f-b96c-a998d5212a55.jpg?1",
             "name": "Expedition Map",
             "text": "{2}, {T}, Sacrifice Expedition Map: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library.",
             "colours": [],
@@ -6778,7 +6778,7 @@
         },
         {
             "id": "e134ea22-7904-553f-852d-b40ef0f5b05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3a9cdb-4842-44b3-8143-0fda31692600.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea3a9cdb-4842-44b3-8143-0fda31692600.jpg?1",
             "name": "Explorer's Scope",
             "text": "Whenever equipped creature attacks, look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6808,7 +6808,7 @@
         },
         {
             "id": "dbe29b6d-b206-5f4b-885a-59631866866f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c29a90-639b-479d-b822-d5fb54b1d690.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/4/54c29a90-639b-479d-b822-d5fb54b1d690.jpg?1",
             "name": "Grappling Hook",
             "text": "Equipped creature has double strike.\nWhenever equipped creature attacks, you may have target creature block it this turn if able.\nEquip {4}",
             "colours": [],
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "7ba36c44-42a1-5c70-a324-ca29a685b90d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6422e062-0ce1-4239-8c2d-06449627a55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6422e062-0ce1-4239-8c2d-06449627a55a.jpg?1",
             "name": "Hedron Scrabbler",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Hedron Scrabbler gets +1/+1 until end of turn.",
             "colours": [],
@@ -6869,7 +6869,7 @@
         },
         {
             "id": "6459301e-638e-56dc-9dd4-8b98be4f9baf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f6b2b-8d98-4609-b991-a69523b5a07d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/b/8b5f6b2b-8d98-4609-b991-a69523b5a07d.jpg?1",
             "name": "Khalni Gem",
             "text": "When Khalni Gem enters the battlefield, return two lands you control to their owner's hand.\n{T}: Add two mana of any one color to your mana pool.",
             "colours": [],
@@ -6897,7 +6897,7 @@
         },
         {
             "id": "0d5851a3-5c32-5881-a28e-945f2b87a1d3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f75f13e-43e6-4118-83a3-0446c2089d84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f75f13e-43e6-4118-83a3-0446c2089d84.jpg?1",
             "name": "Spidersilk Net",
             "text": "Equipped creature gets +0/+2 and has reach. (It can block creatures with flying.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -6927,7 +6927,7 @@
         },
         {
             "id": "bf84e585-ad01-5519-8988-6f56b10486f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg?1",
             "name": "Stonework Puma",
             "text": "",
             "colours": [],
@@ -6959,7 +6959,7 @@
         },
         {
             "id": "7e001275-440c-5997-9884-8bdb11891e9d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb5a30-016a-465f-bdf0-e2df2d1bef8c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afeb5a30-016a-465f-bdf0-e2df2d1bef8c.jpg?1",
             "name": "Trailblazer's Boots",
             "text": "Equipped creature has nonbasic landwalk. (It's unblockable as long as defending player controls a nonbasic land.)\nEquip {2}",
             "colours": [],
@@ -6989,7 +6989,7 @@
         },
         {
             "id": "75df09b9-7388-5764-82d0-8ef129af92c5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c9838e-aa72-49fc-bae2-f880bcbc9313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86c9838e-aa72-49fc-bae2-f880bcbc9313.jpg?1",
             "name": "Trusty Machete",
             "text": "Equipped creature gets +2/+1.\nEquip {2}",
             "colours": [],
@@ -7019,7 +7019,7 @@
         },
         {
             "id": "3dcda88c-02b1-5e2e-b7d0-189309941ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed95b4a-1452-4337-a4b2-e67e624d33df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/e/2ed95b4a-1452-4337-a4b2-e67e624d33df.jpg?1",
             "name": "Akoum Refuge",
             "text": "Akoum Refuge enters the battlefield tapped.\nWhen Akoum Refuge enters the battlefield, you gain 1 life.\n{T}: Add {B} or {R} to your mana pool.",
             "colours": [],
@@ -7050,7 +7050,7 @@
         },
         {
             "id": "ac7a549d-deb4-56c5-8941-4da1ba8a3293",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c8d2fa-54a7-46e8-980c-905258497c90.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16c8d2fa-54a7-46e8-980c-905258497c90.jpg?1",
             "name": "Arid Mesa",
             "text": "{T}, Pay 1 life, Sacrifice Arid Mesa: Search your library for a Mountain or Plains card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7078,7 +7078,7 @@
         },
         {
             "id": "e354d5d9-606c-50d4-a21d-006e15bd9d6a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672869d6-5314-422e-92f6-6a328fe0c6f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/672869d6-5314-422e-92f6-6a328fe0c6f6.jpg?1",
             "name": "Crypt of Agadeem",
             "text": "Crypt of Agadeem enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\n{2}, {T}: Add {B} to your mana pool for each black creature card in your graveyard.",
             "colours": [],
@@ -7108,7 +7108,7 @@
         },
         {
             "id": "7ecf25a1-e4b4-50a2-ae3d-af8f48523342",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf6016e-71e7-4339-80f9-78e9aa44c54b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fdf6016e-71e7-4339-80f9-78e9aa44c54b.jpg?1",
             "name": "Emeria, the Sky Ruin",
             "text": "Emeria, the Sky Ruin enters the battlefield tapped.\nAt the beginning of your upkeep, if you control seven or more Plains, you may return target creature card from your graveyard to the battlefield.\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -7138,7 +7138,7 @@
         },
         {
             "id": "15e3500a-a85d-56d0-aec1-bc1170424e4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46324e3-52e7-4b21-a9a0-a3aae9f7dd5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c46324e3-52e7-4b21-a9a0-a3aae9f7dd5b.jpg?1",
             "name": "Graypelt Refuge",
             "text": "Graypelt Refuge enters the battlefield tapped.\nWhen Graypelt Refuge enters the battlefield, you gain 1 life.\n{T}: Add {G} or {W} to your mana pool.",
             "colours": [],
@@ -7169,7 +7169,7 @@
         },
         {
             "id": "dc786df5-cda6-5049-962c-c3b6ef0927cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd9463f-d029-459d-a933-432b7bbd7a41.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/ddd9463f-d029-459d-a933-432b7bbd7a41.jpg?1",
             "name": "Jwar Isle Refuge",
             "text": "Jwar Isle Refuge enters the battlefield tapped.\nWhen Jwar Isle Refuge enters the battlefield, you gain 1 life.\n{T}: Add {U} or {B} to your mana pool.",
             "colours": [],
@@ -7200,7 +7200,7 @@
         },
         {
             "id": "44d00f1a-7e11-56cc-a734-7e8b10b52f88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776decb-cdb5-4f41-8a3a-c0cece18eb35.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/7/a776decb-cdb5-4f41-8a3a-c0cece18eb35.jpg?1",
             "name": "Kabira Crossroads",
             "text": "Kabira Crossroads enters the battlefield tapped.\nWhen Kabira Crossroads enters the battlefield, you gain 2 life.\n{T}: Add {W} to your mana pool.",
             "colours": [],
@@ -7230,7 +7230,7 @@
         },
         {
             "id": "1b44835a-134b-5ff1-a225-303b9c2f2aaa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af66f9c-c90b-45e0-a54c-a76e7e1b9dff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8af66f9c-c90b-45e0-a54c-a76e7e1b9dff.jpg?1",
             "name": "Kazandu Refuge",
             "text": "Kazandu Refuge enters the battlefield tapped.\nWhen Kazandu Refuge enters the battlefield, you gain 1 life.\n{T}: Add {R} or {G} to your mana pool.",
             "colours": [],
@@ -7261,7 +7261,7 @@
         },
         {
             "id": "a7ffab36-f986-588c-a56f-bf5db806010a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c84cf70-4164-47ea-8da1-c0ca1ac132e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c84cf70-4164-47ea-8da1-c0ca1ac132e1.jpg?1",
             "name": "Magosi, the Waterveil",
             "text": "Magosi, the Waterveil enters the battlefield tapped.\n{T}: Add {U} to your mana pool.\n{U}, {T}: Put an eon counter on Magosi, the Waterveil. Skip your next turn.\n{T}, Remove an eon counter from Magosi, the Waterveil and return it to its owner's hand: Take an extra turn after this one.",
             "colours": [],
@@ -7291,7 +7291,7 @@
         },
         {
             "id": "7c6b5635-469e-5116-a091-d8c585578814",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45026d57-0324-4312-8b86-2e7d4f581ee9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45026d57-0324-4312-8b86-2e7d4f581ee9.jpg?1",
             "name": "Marsh Flats",
             "text": "{T}, Pay 1 life, Sacrifice Marsh Flats: Search your library for a Plains or Swamp card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7319,7 +7319,7 @@
         },
         {
             "id": "613e3626-6735-549f-a37f-f8dfaf1fd61d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a5cc2c-0fbf-4a5f-b175-6e0ffd0d0787.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24a5cc2c-0fbf-4a5f-b175-6e0ffd0d0787.jpg?1",
             "name": "Misty Rainforest",
             "text": "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7347,7 +7347,7 @@
         },
         {
             "id": "f190ea49-c050-54f6-9a0b-eae644fe4bb4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcc3bab-46f8-4ed2-abdb-7a117ad07d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9bcc3bab-46f8-4ed2-abdb-7a117ad07d03.jpg?1",
             "name": "Oran-Rief, the Vastwood",
             "text": "Oran-Rief, the Vastwood enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{T}: Put a +1/+1 counter on each green creature that entered the battlefield this turn.",
             "colours": [],
@@ -7377,7 +7377,7 @@
         },
         {
             "id": "5610381e-bf89-5766-b301-7629354768a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea077cff-b5c9-4a40-8e66-8810c37be5cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea077cff-b5c9-4a40-8e66-8810c37be5cb.jpg?1",
             "name": "Piranha Marsh",
             "text": "Piranha Marsh enters the battlefield tapped.\nWhen Piranha Marsh enters the battlefield, target player loses 1 life.\n{T}: Add {B} to your mana pool.",
             "colours": [],
@@ -7407,7 +7407,7 @@
         },
         {
             "id": "2776db51-8343-5762-8f56-9b15be46e3a7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327cf118-cc92-4073-85d0-94d2a0a6989a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/327cf118-cc92-4073-85d0-94d2a0a6989a.jpg?1",
             "name": "Scalding Tarn",
             "text": "{T}, Pay 1 life, Sacrifice Scalding Tarn: Search your library for an Island or Mountain card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7435,7 +7435,7 @@
         },
         {
             "id": "abec0112-bfdc-5f4a-ad78-a87d1ee08fa6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd8cb0d-d651-44e7-ae14-4035b0f1aa77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fd8cb0d-d651-44e7-ae14-4035b0f1aa77.jpg?1",
             "name": "Sejiri Refuge",
             "text": "Sejiri Refuge enters the battlefield tapped.\nWhen Sejiri Refuge enters the battlefield, you gain 1 life.\n{T}: Add {W} or {U} to your mana pool.",
             "colours": [],
@@ -7466,7 +7466,7 @@
         },
         {
             "id": "ee55ee6f-8389-521e-9587-006f60135bd8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf0de91-765a-49e3-bd8a-94f266b3bdd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6bf0de91-765a-49e3-bd8a-94f266b3bdd8.jpg?1",
             "name": "Soaring Seacliff",
             "text": "Soaring Seacliff enters the battlefield tapped.\nWhen Soaring Seacliff enters the battlefield, target creature gains flying until end of turn.\n{T}: Add {U} to your mana pool.",
             "colours": [],
@@ -7496,7 +7496,7 @@
         },
         {
             "id": "cf46ecb1-6ad2-5ed0-8b85-ebdb914a5fe7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56aca36-bb51-45e3-9ef9-9f9f2aa1e088.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e56aca36-bb51-45e3-9ef9-9f9f2aa1e088.jpg?1",
             "name": "Teetering Peaks",
             "text": "Teetering Peaks enters the battlefield tapped.\nWhen Teetering Peaks enters the battlefield, target creature gets +2/+0 until end of turn.\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -7526,7 +7526,7 @@
         },
         {
             "id": "062922a9-8dfb-532f-9f96-c75f972c15de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc92d6ef-a578-4320-b5c8-3da192eea1f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc92d6ef-a578-4320-b5c8-3da192eea1f3.jpg?1",
             "name": "Turntimber Grove",
             "text": "Turntimber Grove enters the battlefield tapped.\nWhen Turntimber Grove enters the battlefield, target creature gets +1/+1 until end of turn.\n{T}: Add {G} to your mana pool.",
             "colours": [],
@@ -7556,7 +7556,7 @@
         },
         {
             "id": "ea154084-9fef-5195-a0ee-34f46314ca6d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bce60d-2cb0-4772-9f5c-122a7ed426a0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/7/37bce60d-2cb0-4772-9f5c-122a7ed426a0.jpg?1",
             "name": "Valakut, the Molten Pinnacle",
             "text": "Valakut, the Molten Pinnacle enters the battlefield tapped.\nWhenever a Mountain enters the battlefield under your control, if you control at least five other Mountains, you may have Valakut, the Molten Pinnacle deal 3 damage to target creature or player.\n{T}: Add {R} to your mana pool.",
             "colours": [],
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "f2bcbbfd-d681-59be-b020-5468029b46de",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd2723-2851-4f1a-b2d0-dfcb526472c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7abd2723-2851-4f1a-b2d0-dfcb526472c3.jpg?1",
             "name": "Verdant Catacombs",
             "text": "{T}, Pay 1 life, Sacrifice Verdant Catacombs: Search your library for a Swamp or Forest card and put it onto the battlefield. Then shuffle your library.",
             "colours": [],
@@ -7614,7 +7614,7 @@
         },
         {
             "id": "15ffebe7-d12a-5c01-91a3-02a8becb6f41",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b6d-ff35-4b1f-974b-f39569e6b3c7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4f4b6d-ff35-4b1f-974b-f39569e6b3c7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "9667babc-eadb-53ce-a476-8c18f881ab23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51afc6cd-1a39-4160-a265-d92610db1d44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/1/51afc6cd-1a39-4160-a265-d92610db1d44.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7697,7 +7697,7 @@
         },
         {
             "id": "bb0061d9-5f98-59d3-8adb-47a6cc12c3e1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b362e9b-8d25-405e-b70e-f3c9533627a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b362e9b-8d25-405e-b70e-f3c9533627a7.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7739,7 +7739,7 @@
         },
         {
             "id": "735b8fcb-0a0f-50c8-abb3-453e46a62de5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e53e2e-0703-45d3-ab91-78f5241c32bb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87e53e2e-0703-45d3-ab91-78f5241c32bb.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7780,7 +7780,7 @@
         },
         {
             "id": "bf04c6b3-f7e4-5116-a50f-1b698d292cc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36446ad6-8bf0-4e4e-bbab-379c22dbf4f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/36446ad6-8bf0-4e4e-bbab-379c22dbf4f6.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7822,7 +7822,7 @@
         },
         {
             "id": "c54b1457-7f32-537d-ad11-d51768510784",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4da90d5-d793-4412-acc3-e0c2a5c10e18.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4da90d5-d793-4412-acc3-e0c2a5c10e18.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7863,7 +7863,7 @@
         },
         {
             "id": "df458f48-668f-5f23-bfb2-816aac2e234d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9646663-ba93-446b-ad83-71503924e7f8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e9646663-ba93-446b-ad83-71503924e7f8.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7905,7 +7905,7 @@
         },
         {
             "id": "b649e837-05ce-5dc5-b179-37f3f612db55",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a087d3-54b1-4000-89d1-0c428659158c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a087d3-54b1-4000-89d1-0c428659158c.jpg?1",
             "name": "Plains",
             "text": "W",
             "colours": [],
@@ -7946,7 +7946,7 @@
         },
         {
             "id": "aed5fe79-ddec-5bf7-93b3-63a042faf863",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd86f2a-bd28-4731-838d-78e67be8b49e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efd86f2a-bd28-4731-838d-78e67be8b49e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -7988,7 +7988,7 @@
         },
         {
             "id": "76a8c558-a2bc-56fc-b3e7-de053e39a6ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ec37bf-80bd-4f51-a79e-9c20e4048a00.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c4ec37bf-80bd-4f51-a79e-9c20e4048a00.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8029,7 +8029,7 @@
         },
         {
             "id": "1801bcf6-b3e2-5e0e-aad9-aaaf12393787",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b4cbcc-c394-4be3-8072-8893b48c866d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20b4cbcc-c394-4be3-8072-8893b48c866d.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8071,7 +8071,7 @@
         },
         {
             "id": "bd892174-c6c2-59c6-9373-5b401943eee1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3c4a0-892d-4e74-bb21-00786705766e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8a3c4a0-892d-4e74-bb21-00786705766e.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8112,7 +8112,7 @@
         },
         {
             "id": "671e0285-dd5b-5eed-b5c5-b2534d73e8ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f905b-4ce0-4071-a721-7e51be14d114.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/551f905b-4ce0-4071-a721-7e51be14d114.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8154,7 +8154,7 @@
         },
         {
             "id": "5263fe25-8015-5201-8443-bfba346cede5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a50ced-f89d-4636-a681-8c1de18ee712.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/8/68a50ced-f89d-4636-a681-8c1de18ee712.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8195,7 +8195,7 @@
         },
         {
             "id": "1570300a-543b-5f6f-80f4-d8363a3bf809",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3a90f-23c4-4c54-8825-32cb17977b48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dc3a90f-23c4-4c54-8825-32cb17977b48.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8237,7 +8237,7 @@
         },
         {
             "id": "1018c35b-0e4c-5e57-b4fb-d06d1bbf57cc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f8662-8294-4924-a4c0-e26b709ea4a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/a/aa9f8662-8294-4924-a4c0-e26b709ea4a6.jpg?1",
             "name": "Island",
             "text": "U",
             "colours": [],
@@ -8278,7 +8278,7 @@
         },
         {
             "id": "025fb02d-5479-55f1-af9e-3cd5c02f20d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd6becc-f06a-4fd3-8305-70604b92a187.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7cd6becc-f06a-4fd3-8305-70604b92a187.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8320,7 +8320,7 @@
         },
         {
             "id": "2086b5e7-6f55-5dcb-9de5-2de7a9a66f18",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3e999-c75b-4be3-ae7f-ac5430b760b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8a3e999-c75b-4be3-ae7f-ac5430b760b6.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8361,7 +8361,7 @@
         },
         {
             "id": "be1b0ff1-b113-5fa2-ae1e-7c3c0c3b4826",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847cac15-b404-4e0f-964e-7aee41c93346.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847cac15-b404-4e0f-964e-7aee41c93346.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8403,7 +8403,7 @@
         },
         {
             "id": "8f213ece-b3fc-5013-91cf-2967feff1732",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485df5c7-5653-4bb2-ae0b-8ec83359f192.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/485df5c7-5653-4bb2-ae0b-8ec83359f192.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8444,7 +8444,7 @@
         },
         {
             "id": "0a0f53ed-2640-5848-936d-50de61cb5c9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095fed4-0a2a-4092-b923-8f46c8ea22d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a095fed4-0a2a-4092-b923-8f46c8ea22d8.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8486,7 +8486,7 @@
         },
         {
             "id": "69ec3d81-1e22-5c88-83fd-34944bfb1d25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d5f86d-19c3-4a9a-956f-8c52cec5ba83.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32d5f86d-19c3-4a9a-956f-8c52cec5ba83.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8527,7 +8527,7 @@
         },
         {
             "id": "fb083deb-30ea-5ff4-8aa8-cee8531cd7ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9e2d99-a3ad-4bfb-a781-a8a9454085c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc9e2d99-a3ad-4bfb-a781-a8a9454085c9.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8569,7 +8569,7 @@
         },
         {
             "id": "512e7ce6-124b-5c2b-abed-43796e7a0e67",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80906a47-ef4b-4e59-889c-946d40a79d94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/80906a47-ef4b-4e59-889c-946d40a79d94.jpg?1",
             "name": "Swamp",
             "text": "B",
             "colours": [],
@@ -8610,7 +8610,7 @@
         },
         {
             "id": "ffa3a1b1-a69b-5098-a9a6-9dae5ac7f661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232ee129-0db1-4a03-9eda-4692a8495b53.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/232ee129-0db1-4a03-9eda-4692a8495b53.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8652,7 +8652,7 @@
         },
         {
             "id": "4168bae9-8e35-5c8d-b23b-b37f2f1e4046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f570888-effb-44ff-a250-a7726a0b01f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/f/4f570888-effb-44ff-a250-a7726a0b01f4.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8693,7 +8693,7 @@
         },
         {
             "id": "2eee4910-9ccf-504d-8464-fced3f661831",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de70f1-6fb1-4191-b66f-491c794f9c05.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3de70f1-6fb1-4191-b66f-491c794f9c05.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8735,7 +8735,7 @@
         },
         {
             "id": "36ed46db-8731-5f03-988c-8502737fc99c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45651533-0c76-476a-bfaf-1b5ec74427cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45651533-0c76-476a-bfaf-1b5ec74427cd.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8776,7 +8776,7 @@
         },
         {
             "id": "b1d2a944-d6b5-5fe1-9431-962f7ed1b080",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bacab3-25fb-4a0c-81b3-7e9e22899c2c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03bacab3-25fb-4a0c-81b3-7e9e22899c2c.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8818,7 +8818,7 @@
         },
         {
             "id": "3701118e-8443-56ca-bfce-325ea86a37be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0571374-26b4-403c-b6da-4fd8b930cda6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0571374-26b4-403c-b6da-4fd8b930cda6.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8859,7 +8859,7 @@
         },
         {
             "id": "3ff0e334-7b61-57ee-b312-cacadd08716c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a298c5d-9937-4df6-a544-7b3bcfe84885.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a298c5d-9937-4df6-a544-7b3bcfe84885.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8901,7 +8901,7 @@
         },
         {
             "id": "70532549-6396-5ce0-878e-20a2fd58a9d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf03952-6d9d-4e57-acb5-44c855f3ad69.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acf03952-6d9d-4e57-acb5-44c855f3ad69.jpg?1",
             "name": "Mountain",
             "text": "R",
             "colours": [],
@@ -8942,7 +8942,7 @@
         },
         {
             "id": "8b2b4813-187c-53d1-8ee6-d9109ce4c427",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ca4b9f-4ee6-4ad8-a95f-326ada9de3cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/0/f0ca4b9f-4ee6-4ad8-a95f-326ada9de3cd.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -8984,7 +8984,7 @@
         },
         {
             "id": "d86dc958-7b41-55e3-856c-a74c55852ae2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d6876e-7d83-44bd-b721-5070f4087325.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6d6876e-7d83-44bd-b721-5070f4087325.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9025,7 +9025,7 @@
         },
         {
             "id": "7c0ffc88-34ff-5436-bfe7-ac9f1dd62888",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6744c441-42b3-48b2-af06-1e27ec776d97.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/6744c441-42b3-48b2-af06-1e27ec776d97.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9067,7 +9067,7 @@
         },
         {
             "id": "e24c5554-22b3-54c0-84c6-387bfb179a17",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfbcefd-8b2d-4b9e-a11a-18274c3a8dd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3cfbcefd-8b2d-4b9e-a11a-18274c3a8dd2.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9108,7 +9108,7 @@
         },
         {
             "id": "59cea094-ebc9-5afa-bdf3-f0cc832a2136",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c21f91-6679-4adb-baf2-b06cf505150c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52c21f91-6679-4adb-baf2-b06cf505150c.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9150,7 +9150,7 @@
         },
         {
             "id": "ec4af441-2ff2-5259-8df8-b69caf0a9464",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1908f8d2-95df-44e3-8943-568c596cd8aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1908f8d2-95df-44e3-8943-568c596cd8aa.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9191,7 +9191,7 @@
         },
         {
             "id": "41d883ae-9018-5218-887e-502b03a2b89f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341b05e6-93bb-4071-b8c6-1644f56e026d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/341b05e6-93bb-4071-b8c6-1644f56e026d.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9233,7 +9233,7 @@
         },
         {
             "id": "55e52247-87e9-52a6-86f4-f33b0ae82226",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30f54e8-eba3-4412-a805-3a834922c260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/3/f30f54e8-eba3-4412-a805-3a834922c260.jpg?1",
             "name": "Forest",
             "text": "G",
             "colours": [],
@@ -9274,7 +9274,7 @@
         },
         {
             "id": "4ce057df-27f1-57f6-8a11-13d1641775e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc37484-b58b-4a42-9281-b4272dc7c872.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1fc37484-b58b-4a42-9281-b4272dc7c872.jpg?1",
             "name": "Angel",
             "text": "",
             "colours": [
@@ -9308,7 +9308,7 @@
         },
         {
             "id": "00bc234b-f9c2-54ce-9033-84fbf420cc7e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbb3c16-a7ef-4b83-b1a9-637a905229d7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/abbb3c16-a7ef-4b83-b1a9-637a905229d7.jpg?1",
             "name": "Bird",
             "text": "",
             "colours": [
@@ -9342,7 +9342,7 @@
         },
         {
             "id": "4ee8e1b3-61d9-5633-9585-e53d127a3a95",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9623e74-3b94-4842-903f-ed52931bdf6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9623e74-3b94-4842-903f-ed52931bdf6a.jpg?1",
             "name": "Kor Soldier",
             "text": "",
             "colours": [
@@ -9377,7 +9377,7 @@
         },
         {
             "id": "29dab46f-15d2-516d-b549-663a56422696",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dcbf662-7263-414a-b64b-ccf9aab20faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5dcbf662-7263-414a-b64b-ccf9aab20faa.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -9411,7 +9411,7 @@
         },
         {
             "id": "b13404ba-d911-5474-b6a9-75f61d5734c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b292b-2da6-4601-9f93-5eb273ce3a50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb1b292b-2da6-4601-9f93-5eb273ce3a50.jpg?1",
             "name": "Merfolk",
             "text": "",
             "colours": [
@@ -9445,7 +9445,7 @@
         },
         {
             "id": "34a7d9ba-1821-58bc-bac4-cb9f6d73ffe6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969eff58-d91e-49e2-a1e1-8f32b4598810.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/969eff58-d91e-49e2-a1e1-8f32b4598810.jpg?1",
             "name": "Vampire",
             "text": "",
             "colours": [
@@ -9479,7 +9479,7 @@
         },
         {
             "id": "6bb07111-9fd4-5c6f-b130-96531e843c25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1999ff2f-5797-496e-9917-ad19507ecec9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1999ff2f-5797-496e-9917-ad19507ecec9.jpg?1",
             "name": "Zombie Giant",
             "text": "",
             "colours": [
@@ -9514,7 +9514,7 @@
         },
         {
             "id": "c58cd9b2-decb-5789-81db-7de4f7db8e75",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e12780-9c25-4cb0-b1ff-a36ca50b19d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f9e12780-9c25-4cb0-b1ff-a36ca50b19d8.jpg?1",
             "name": "Elemental",
             "text": "",
             "colours": [
@@ -9548,7 +9548,7 @@
         },
         {
             "id": "8dc57fdf-8072-5f4d-9969-046050d5eb78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e455-053d-4a86-93b2-2436b554b638.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/6/76b5e455-053d-4a86-93b2-2436b554b638.jpg?1",
             "name": "Beast",
             "text": "",
             "colours": [
@@ -9582,7 +9582,7 @@
         },
         {
             "id": "b00a6f47-fe8c-53f5-a49d-d175f4325e8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6a142-f065-4a74-9a73-8105be29bc94.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/83a6a142-f065-4a74-9a73-8105be29bc94.jpg?1",
             "name": "Snake",
             "text": "",
             "colours": [
@@ -9616,7 +9616,7 @@
         },
         {
             "id": "4a62fd92-1384-56e3-a5cc-d6e2d8dda434",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9e4b4-c0fb-4627-92cf-69544e0c875d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dcc9e4b4-c0fb-4627-92cf-69544e0c875d.jpg?1",
             "name": "Wolf",
             "text": "",
             "colours": [

--- a/MTG-Docs/CardDatabase/ReducedSets/ZNR.json
+++ b/MTG-Docs/CardDatabase/ReducedSets/ZNR.json
@@ -4,7 +4,7 @@
     "cards": [
         {
             "id": "f85cb2cb-34b1-5d26-bffc-eb86ebe23fbd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340df0d4-9848-4372-9f45-a73a8e94058a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/340df0d4-9848-4372-9f45-a73a8e94058a.jpg?1",
             "name": "Allied Assault",
             "text": "Up to two target creatures each get +X/+X until end of turn, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -36,7 +36,7 @@
         },
         {
             "id": "014e7ff4-baf3-5f8f-998c-85de7c9716e6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897074a-0ac4-4d1a-9aac-e77830cc5c78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/9897074a-0ac4-4d1a-9aac-e77830cc5c78.jpg?1",
             "name": "Angel of Destiny",
             "text": "Flying, double strike\nWhenever a creature you control deals combat damage to a player, you and that player each gain that much life.\nAt the beginning of your end step, if you have at least 15 life more than your starting life total, each player Angel of Destiny attacked this turn loses the game.",
             "colours": [
@@ -73,7 +73,7 @@
         },
         {
             "id": "85c9c43d-4296-5c4a-bbda-c04fd26da05f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06cc03f-da73-4ba5-96c9-618b497a7ea3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c06cc03f-da73-4ba5-96c9-618b497a7ea3.jpg?1",
             "name": "Angelheart Protector",
             "text": "When Angelheart Protector enters the battlefield, target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -108,7 +108,7 @@
         },
         {
             "id": "e6456927-05f5-5682-a76d-f9df6caaedef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228c1650-da3c-4099-91b6-18e3873c9cdb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228c1650-da3c-4099-91b6-18e3873c9cdb.jpg?1",
             "name": "Archon of Emeria",
             "text": "Flying\nEach player can't cast more than one spell each turn.\nNonbasic lands your opponents control enter the battlefield tapped.",
             "colours": [
@@ -144,7 +144,7 @@
         },
         {
             "id": "6c096234-980f-5483-a18c-da4c6e0a9bfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc61e4-46e3-473b-90f8-27e71e1088e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7dc61e4-46e3-473b-90f8-27e71e1088e8.jpg?1",
             "name": "Archpriest of Iona",
             "text": "Archpriest of Iona's power is equal to the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -181,7 +181,7 @@
         },
         {
             "id": "84ad24f9-d124-5e3b-a0fb-f85e8531aa40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca80b5a-3943-41ca-8cd1-8e3db1b2a1c8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6ca80b5a-3943-41ca-8cd1-8e3db1b2a1c8.jpg?1",
             "name": "Attended Healer",
             "text": "Whenever you gain life for the first time each turn, create a 1/1 white Cat creature token.\n{2}{W}: Another target Cleric gains lifelink until end of turn.",
             "colours": [
@@ -216,7 +216,7 @@
         },
         {
             "id": "36309bf0-11e4-5489-a624-fdcf6f121523",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b3938e-ebd7-4668-be3a-422c02ff5b08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26b3938e-ebd7-4668-be3a-422c02ff5b08.jpg?1",
             "name": "Canyon Jerboa",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -252,7 +252,7 @@
         },
         {
             "id": "b8c9b683-4aeb-5860-99f8-2700d3f53344",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f334767-4353-4379-a934-fa67075db439.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f334767-4353-4379-a934-fa67075db439.jpg?1",
             "name": "Cliffhaven Sell-Sword",
             "text": "",
             "colours": [
@@ -287,7 +287,7 @@
         },
         {
             "id": "97d5cdbb-7d5b-5a3b-87d1-5641926daa39",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a4d17-68e6-4133-99fd-e501e24e6c6b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/1/b12a4d17-68e6-4133-99fd-e501e24e6c6b.jpg?1",
             "name": "Dauntless Unity",
             "text": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nCreatures you control get +1/+1 until end of turn. If this spell was kicked, those creatures get +2/+1 until end of turn instead.",
             "colours": [
@@ -319,7 +319,7 @@
         },
         {
             "id": "48bfb87c-c329-5505-a81f-8a53bc0ba6d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c37ba56-e22c-4b10-821a-2827c5cd81ad.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5c37ba56-e22c-4b10-821a-2827c5cd81ad.jpg?1",
             "name": "Disenchant",
             "text": "Destroy target artifact or enchantment.",
             "colours": [
@@ -351,7 +351,7 @@
         },
         {
             "id": "8c89d234-8842-5627-9433-4bd110339eea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6490370e-fff5-4f17-b715-74ff8df5bc7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/4/6490370e-fff5-4f17-b715-74ff8df5bc7c.jpg?1",
             "name": "Emeria Captain",
             "text": "Flying, vigilance\nWhen Emeria Captain enters the battlefield, put a +1/+1 counter on it for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -386,7 +386,7 @@
         },
         {
             "id": "d1222c93-0aee-5d60-970a-7342b6f8cba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "Create two 4/4 white Angel Warrior creature tokens with flying. Non-Angel creatures you control gain indestructible until your next turn.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -420,7 +420,7 @@
         },
         {
             "id": "dde525a3-231d-58c4-a49d-4d6b6d811f19",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "As Emeria, Shattered Skyclave enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.\n\n\nSorcery\n{4}{W}{W}{W}",
             "colours": [],
@@ -452,7 +452,7 @@
         },
         {
             "id": "f3cdc8d5-012a-5c61-9f3c-59e8beaf2f15",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a00a88-de0e-4012-9ad8-ccb187dff7df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11a00a88-de0e-4012-9ad8-ccb187dff7df.jpg?1",
             "name": "Expedition Healer",
             "text": "Vigilance\nExpedition Healer has lifelink as long as you control another Cleric.",
             "colours": [
@@ -487,7 +487,7 @@
         },
         {
             "id": "2d9d9030-0291-5539-b6dc-bd3fc621b9aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949bb9a-b4e8-4992-a12d-8e31953aff0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5949bb9a-b4e8-4992-a12d-8e31953aff0d.jpg?1",
             "name": "Farsight Adept",
             "text": "When Farsight Adept enters the battlefield, you and target opponent each draw a card.",
             "colours": [
@@ -522,7 +522,7 @@
         },
         {
             "id": "f4712ff2-22fe-54d1-bac8-7ef326cedb7d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d73eb7-4e76-48d4-90fa-fa972dc0fccb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02d73eb7-4e76-48d4-90fa-fa972dc0fccb.jpg?1",
             "name": "Fearless Fledgling",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Fearless Fledgling. It gains flying until end of turn.",
             "colours": [
@@ -558,7 +558,7 @@
         },
         {
             "id": "07a07a01-4daf-5b6c-aeba-13353f593f5e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45340647-4d3e-4be1-b0e6-e40cc56a438b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/45340647-4d3e-4be1-b0e6-e40cc56a438b.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -592,7 +592,7 @@
         },
         {
             "id": "e4d9e639-6f3d-5a34-bd14-900f31efe30b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47120e3c-73aa-468d-96b7-47aead342e31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47120e3c-73aa-468d-96b7-47aead342e31.jpg?1",
             "name": "Journey to Oblivion",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nWhen Journey to Oblivion enters the battlefield, exile target nonland permanent an opponent controls until Journey to Oblivion leaves the battlefield.",
             "colours": [
@@ -624,7 +624,7 @@
         },
         {
             "id": "1bd6493e-af7c-5efa-a243-accb8a5ee6f8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c81719-f820-4674-9cfb-cd5eaf0c1f0d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/53c81719-f820-4674-9cfb-cd5eaf0c1f0d.jpg?1",
             "name": "Kabira Outrider",
             "text": "When Kabira Outrider enters the battlefield, target creature gets +1/+1 until end of turn for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -659,7 +659,7 @@
         },
         {
             "id": "c3f3ff5b-5c29-5b6c-a794-69efe192f2d5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1",
             "name": "Kabira Takedown // Kabira Plateau",
             "text": "Kabira Takedown deals damage equal to the number of creatures you control to target creature or planeswalker.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -691,7 +691,7 @@
         },
         {
             "id": "320fbcfe-e6f5-5e22-84b3-1b58565ff4d8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1",
             "name": "Kabira Takedown // Kabira Plateau",
             "text": "Kabira Plateau enters the battlefield tapped.\n{T}: Add {W}.\n\n\nInstant\n{1}{W}",
             "colours": [],
@@ -721,7 +721,7 @@
         },
         {
             "id": "c2725771-c75b-5e1c-91e4-116d78df7ed2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16626f84-00d3-4ec9-b62c-19fff380cd3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/16626f84-00d3-4ec9-b62c-19fff380cd3a.jpg?1",
             "name": "Kitesail Cleric",
             "text": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nFlying\nWhen Kitesail Cleric enters the battlefield, if it was kicked, tap up to two target creatures.",
             "colours": [
@@ -756,7 +756,7 @@
         },
         {
             "id": "39bd3a4c-1ea9-5e88-9dc4-99ad8b3ca5ac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6049-5599-47eb-ae58-a8eb96927ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fc6d6049-5599-47eb-ae58-a8eb96927ece.jpg?1",
             "name": "Kor Blademaster",
             "text": "Double strike\nEquipped Warriors you control have double strike.",
             "colours": [
@@ -791,7 +791,7 @@
         },
         {
             "id": "c794e071-41dc-5738-b9c9-2b0f34f17697",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c37e46-a961-4739-8893-f783013e2be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/7/87c37e46-a961-4739-8893-f783013e2be6.jpg?1",
             "name": "Kor Celebrant",
             "text": "Whenever Kor Celebrant or another creature enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -826,7 +826,7 @@
         },
         {
             "id": "d23b96b7-fc82-59dc-a7e4-35d79e06e487",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda5609a-ab22-4f03-988b-8056c97fdc9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bda5609a-ab22-4f03-988b-8056c97fdc9e.jpg?1",
             "name": "Legion Angel",
             "text": "Flying\nWhen Legion Angel enters the battlefield, you may reveal a card you own named Legion Angel from outside the game and put it into your hand.",
             "colours": [
@@ -863,7 +863,7 @@
         },
         {
             "id": "c05a79d5-f08f-5a11-a2d9-5b058b81f492",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe964e7e-e2c5-4263-889d-0a531eb51442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe964e7e-e2c5-4263-889d-0a531eb51442.jpg?1",
             "name": "Luminarch Aspirant",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -900,7 +900,7 @@
         },
         {
             "id": "3d0deee6-d05f-5b94-a925-81b00ae53e2c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d164a-bce2-4474-abe0-b735eb6c9442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd0d164a-bce2-4474-abe0-b735eb6c9442.jpg?1",
             "name": "Makindi Ox",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -936,7 +936,7 @@
         },
         {
             "id": "3a1ffbe7-7f31-5df5-9697-830124b8d3ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg?1",
             "name": "Makindi Stampede // Makindi Mesas",
             "text": "Creatures you control get +2/+2 until end of turn.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -968,7 +968,7 @@
         },
         {
             "id": "8301bdda-54b5-5c36-a3b7-2a85e0870250",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/d/ada9a974-8f1f-4148-bd61-200fc14714b2.jpg?1",
             "name": "Makindi Stampede // Makindi Mesas",
             "text": "Makindi Mesas enters the battlefield tapped.\n{T}: Add {W}.\n\n\nSorcery\n{3}{W}{W}",
             "colours": [],
@@ -998,7 +998,7 @@
         },
         {
             "id": "a3a20ff0-f502-5bb4-8f5a-bc9b03bbfca7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2608-0d44-442c-97a1-12ac94b7abac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f18f2608-0d44-442c-97a1-12ac94b7abac.jpg?1",
             "name": "Maul of the Skyclaves",
             "text": "When Maul of the Skyclaves enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+2 and has flying and first strike.\nEquip {2}{W}{W}",
             "colours": [
@@ -1034,7 +1034,7 @@
         },
         {
             "id": "828859ab-c060-5586-bfbb-09abcbfeceeb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65af09b-656f-4d81-b95d-b4f902e56bb7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f65af09b-656f-4d81-b95d-b4f902e56bb7.jpg?1",
             "name": "Mesa Lynx",
             "text": "As long as it's not your turn, Mesa Lynx gets +0/+2.",
             "colours": [
@@ -1068,7 +1068,7 @@
         },
         {
             "id": "088e395b-423a-55ae-9c25-ee6fe8b33953",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421eac28-d6f2-44f2-b7ca-eb73fbf23887.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/421eac28-d6f2-44f2-b7ca-eb73fbf23887.jpg?1",
             "name": "Nahiri's Binding",
             "text": "Enchant creature or planeswalker\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
             "colours": [
@@ -1102,7 +1102,7 @@
         },
         {
             "id": "8c2835f3-d8fc-5755-8194-89bf5f2ffeff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Destroy all nonland permanents.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -1136,7 +1136,7 @@
         },
         {
             "id": "df15adcf-2c3a-559b-a40d-b135b7a1ebd5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/6/b6e6be8c-41c3-4348-a8dd-b40ceb24e9b4.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Ondu Skyruins enters the battlefield tapped.\n{T}: Add {W}.\n\n\nSorcery\n{6}{W}{W}",
             "colours": [],
@@ -1168,7 +1168,7 @@
         },
         {
             "id": "a425cc1c-256c-5630-9579-0077a07628b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67930e10-4de8-4d40-af27-4a38d35ab16f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67930e10-4de8-4d40-af27-4a38d35ab16f.jpg?1",
             "name": "Paired Tactician",
             "text": "Whenever Paired Tactician and at least one other Warrior attack, put a +1/+1 counter on Paired Tactician.",
             "colours": [
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "10303416-af27-5575-ba24-c3d99647ab57",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b448f4-aa0c-42c7-a771-e8dd20e0520c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91b448f4-aa0c-42c7-a771-e8dd20e0520c.jpg?1",
             "name": "Practiced Tactics",
             "text": "Choose target attacking or blocking creature. Practiced Tactics deals damage to that creature equal to twice the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -1235,7 +1235,7 @@
         },
         {
             "id": "d3d993ba-345e-5028-b5bb-732b90fd5de8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe82bbf-9b92-4684-a42d-fbc50c4c5903.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2fe82bbf-9b92-4684-a42d-fbc50c4c5903.jpg?1",
             "name": "Pressure Point",
             "text": "Tap target creature.\nDraw a card.",
             "colours": [
@@ -1267,7 +1267,7 @@
         },
         {
             "id": "335f6fe2-0924-52cc-8d92-53ed579212c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d1c11a-a32c-449c-95c6-450dce6c26d2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9d1c11a-a32c-449c-95c6-450dce6c26d2.jpg?1",
             "name": "Prowling Felidar",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Prowling Felidar.",
             "colours": [
@@ -1304,7 +1304,7 @@
         },
         {
             "id": "1c69a680-efd1-569c-a28b-d73b22626358",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b82476-4320-4719-9785-af8d68503234.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78b82476-4320-4719-9785-af8d68503234.jpg?1",
             "name": "Resolute Strike",
             "text": "Target creature gets +2/+2 until end of turn. If it's a Warrior, you may attach an Equipment you control to it.",
             "colours": [
@@ -1336,7 +1336,7 @@
         },
         {
             "id": "74a178c0-e75b-5935-8565-0e2427277b9f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4634e-1487-4b66-8f70-bcb4b1fa6e77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/a/6ae4634e-1487-4b66-8f70-bcb4b1fa6e77.jpg?1",
             "name": "Sea Gate Banneret",
             "text": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -1371,7 +1371,7 @@
         },
         {
             "id": "c1b2f597-ae58-5fac-93af-e1e95af87e68",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1",
             "name": "Sejiri Shelter // Sejiri Glacier",
             "text": "Target creature you control gains protection from the color of your choice until end of turn.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -1403,7 +1403,7 @@
         },
         {
             "id": "8371d026-41cc-5f24-af86-ffe3f57a967a",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1",
             "name": "Sejiri Shelter // Sejiri Glacier",
             "text": "Sejiri Glacier enters the battlefield tapped.\n{T}: Add {W}.\n\n\nInstant\n{1}{W}",
             "colours": [],
@@ -1433,7 +1433,7 @@
         },
         {
             "id": "540b1682-b4e1-553c-8470-6fb0f21cf8ca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70baa3-5232-4e10-80b4-a9ead6ed6ec3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/f/1f70baa3-5232-4e10-80b4-a9ead6ed6ec3.jpg?1",
             "name": "Shepherd of Heroes",
             "text": "Flying\nWhen Shepherd of Heroes enters the battlefield, you gain 2 life for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -1468,7 +1468,7 @@
         },
         {
             "id": "ef368548-311c-53fd-9941-f1ad13636f90",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83cfbaa-7890-4f6f-878b-4edb45677371.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/8/b83cfbaa-7890-4f6f-878b-4edb45677371.jpg?1",
             "name": "Skyclave Apparition",
             "text": "When Skyclave Apparition enters the battlefield, exile up to one target nonland, nontoken permanent you don't control with converted mana cost 4 or less.\nWhen Skyclave Apparition leaves the battlefield, the exiled card's owner creates an X/X blue Illusion creature token, where X is the converted mana cost of the exiled card.",
             "colours": [
@@ -1505,7 +1505,7 @@
         },
         {
             "id": "2026fabc-fe54-5c55-9fbd-917d79a0b52b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg?1",
             "name": "Skyclave Cleric // Skyclave Basilica",
             "text": "When Skyclave Cleric enters the battlefield, you gain 2 life.\n\n\nLand\n{T}: Add {W}.",
             "colours": [
@@ -1540,7 +1540,7 @@
         },
         {
             "id": "8406e4c9-605b-5473-956f-7d2094c68424",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/1/014027c4-7f9d-4096-b308-ea4be574c0d4.jpg?1",
             "name": "Skyclave Cleric // Skyclave Basilica",
             "text": "Skyclave Basilica enters the battlefield tapped.\n{T}: Add {W}.\n\n\nCleric\n{1}{W}",
             "colours": [],
@@ -1570,7 +1570,7 @@
         },
         {
             "id": "04921058-5ce3-5d02-874a-a54783625da9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce186d-c9cd-41e9-bac2-ad9d36c4939f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/2/c2ce186d-c9cd-41e9-bac2-ad9d36c4939f.jpg?1",
             "name": "Squad Commander",
             "text": "When Squad Commander enters the battlefield, create a 1/1 white Kor Warrior creature token for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nAt the beginning of combat on your turn, if you have a full party, creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -1607,7 +1607,7 @@
         },
         {
             "id": "0ac29ad3-b84d-5624-95c3-ca9fb50e70d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c103163-31b7-4d25-aa2c-02ca082ee1bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9c103163-31b7-4d25-aa2c-02ca082ee1bf.jpg?1",
             "name": "Smite the Monstrous",
             "text": "Destroy target creature with power 4 or greater.",
             "colours": [
@@ -1639,7 +1639,7 @@
         },
         {
             "id": "d8728257-a03b-51bf-80ab-02248d503743",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299d60b9-0ba7-40ee-b9d0-ee8f1ea288c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/299d60b9-0ba7-40ee-b9d0-ee8f1ea288c9.jpg?1",
             "name": "Tazeem Raptor",
             "text": "Flying\nWhen Tazeem Raptor enters the battlefield, you may return a land you control to its owner's hand.",
             "colours": [
@@ -1673,7 +1673,7 @@
         },
         {
             "id": "48b84b4d-c550-590b-b220-f47ce8966729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b79138-5728-4541-9ea5-dce1a5ae7e6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d4b79138-5728-4541-9ea5-dce1a5ae7e6a.jpg?1",
             "name": "Tazri, Beacon of Unity",
             "text": "This spell costs {1} less to cast for each creature in your party.\n{2\nU}{2\nB}{2\nR}{2\nG}: Look at the top six cards of your library. You may reveal up to two Cleric, Rogue, Warrior, Wizard, and/or Ally cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -1716,7 +1716,7 @@
         },
         {
             "id": "0ad2c31c-7e2c-5126-8f61-a17c2d69bd37",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db99b872-77c7-4471-9c44-a36d4ff5d33f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db99b872-77c7-4471-9c44-a36d4ff5d33f.jpg?1",
             "name": "Anticognition",
             "text": "Counter target creature or planeswalker spell unless its controller pays {2}. If an opponent has eight or more cards in their graveyard, instead counter that spell, then scry 2.",
             "colours": [
@@ -1748,7 +1748,7 @@
         },
         {
             "id": "ce100595-c59e-51cd-b03e-28e2d65feab1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg?1",
             "name": "Beyeen Veil // Beyeen Coast",
             "text": "Creatures your opponents control get -2/-0 until end of turn.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -1780,7 +1780,7 @@
         },
         {
             "id": "a4ceb7d1-c98f-53bd-b891-d1e8dec60bf0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/f/5f411f08-45dd-4d73-8894-daf51c175150.jpg?1",
             "name": "Beyeen Veil // Beyeen Coast",
             "text": "Beyeen Coast enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{1}{U}",
             "colours": [],
@@ -1810,7 +1810,7 @@
         },
         {
             "id": "27f9c8b6-64ce-5d30-b323-7bfd2ade82bd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfba7a0-d5ca-4197-9e58-21f28345f1a6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bfba7a0-d5ca-4197-9e58-21f28345f1a6.jpg?1",
             "name": "Bubble Snare",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nEnchant creature\nWhen Bubble Snare enters the battlefield, if it was kicked, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
             "colours": [
@@ -1844,7 +1844,7 @@
         },
         {
             "id": "6c9b84c4-fd63-5f89-9c64-af20e01c76b6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13105c88-2926-40ad-bc7a-09d515aa36c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13105c88-2926-40ad-bc7a-09d515aa36c6.jpg?1",
             "name": "Cascade Seer",
             "text": "When Cascade Seer enters the battlefield, scry X, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -1879,7 +1879,7 @@
         },
         {
             "id": "5108f3bc-571f-5de3-8646-b996c113464a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a6804-1e3c-428c-af5e-1d56ba11c108.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e83a6804-1e3c-428c-af5e-1d56ba11c108.jpg?1",
             "name": "Charix, the Raging Isle",
             "text": "Spells your opponents cast that target Charix, the Raging Isle cost {2} more to cast.\n{3}: Charix gets +X/-X until end of turn, where X is the number of Islands you control.",
             "colours": [
@@ -1919,7 +1919,7 @@
         },
         {
             "id": "4855d940-293b-524b-9898-52c345920698",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f9adfd-a940-4d62-894b-84f17c693a10.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/60f9adfd-a940-4d62-894b-84f17c693a10.jpg?1",
             "name": "Chilling Trap",
             "text": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
             "colours": [
@@ -1951,7 +1951,7 @@
         },
         {
             "id": "d2353848-c3dd-50bb-abf5-270bab0faa59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ea262c-ea32-4aca-b96b-58f556a8dffc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4ea262c-ea32-4aca-b96b-58f556a8dffc.jpg?1",
             "name": "Cleric of Chill Depths",
             "text": "Whenever Cleric of Chill Depths blocks a creature, that creature doesn't untap during its controller's next untap step.",
             "colours": [
@@ -1986,7 +1986,7 @@
         },
         {
             "id": "a3d0ecc7-23b3-5a48-bab3-262a11f9728b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c108d-3902-4c2e-919c-a5449cd2dc3c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235c108d-3902-4c2e-919c-a5449cd2dc3c.jpg?1",
             "name": "Concerted Defense",
             "text": "Counter target noncreature spell unless its controller pays {1} plus an additional {1} for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -2018,7 +2018,7 @@
         },
         {
             "id": "7dc7049e-192f-5bbc-bfd0-ee452c17e48c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e37936-913e-4b16-a5a8-8aed733d702d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95e37936-913e-4b16-a5a8-8aed733d702d.jpg?1",
             "name": "Confounding Conundrum",
             "text": "When Confounding Conundrum enters the battlefield, draw a card.\nWhenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under their control this turn, they return a land they control to its owner's hand.",
             "colours": [
@@ -2052,7 +2052,7 @@
         },
         {
             "id": "597f2b12-15ee-5f2f-88fa-9f99fb245b62",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b54524-8345-4b47-913f-d883a1cbe3a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50b54524-8345-4b47-913f-d883a1cbe3a1.jpg?1",
             "name": "Coralhelm Chronicler",
             "text": "Whenever you cast a kicked spell, draw a card, then discard a card.\nWhen Coralhelm Chronicler enters the battlefield, look at the top five cards of your library. You may reveal a card with a kicker ability from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -2089,7 +2089,7 @@
         },
         {
             "id": "5adbe097-fdd3-590f-b67d-349b195046d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217f0a9-5af5-45cc-8cf7-8878d4f66dd8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/2217f0a9-5af5-45cc-8cf7-8878d4f66dd8.jpg?1",
             "name": "Cunning Geysermage",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nWhen Cunning Geysermage enters the battlefield, if it was kicked, return up to one other target creature to its owner's hand.",
             "colours": [
@@ -2124,7 +2124,7 @@
         },
         {
             "id": "ecc2d863-0dd4-58d8-af5a-234bdb63085f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41c0dd0-fef2-4f3c-8f3c-9c9c521b5442.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/4/c41c0dd0-fef2-4f3c-8f3c-9c9c521b5442.jpg?1",
             "name": "Deliberate",
             "text": "Scry 2, then draw a card.",
             "colours": [
@@ -2156,7 +2156,7 @@
         },
         {
             "id": "f9806f43-a79c-5b21-9f2d-242cadc49f5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f6e94-fb5f-4861-a465-f11766303676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090f6e94-fb5f-4861-a465-f11766303676.jpg?1",
             "name": "Expedition Diviner",
             "text": "Flying\nAs long as you control another Wizard, Expedition Diviner has \"When this creature dies, draw a card.\"",
             "colours": [
@@ -2191,7 +2191,7 @@
         },
         {
             "id": "3b8905a0-c91d-5e42-9c8e-2ba51cb21759",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c3a2f-678b-4e70-a53f-258457d88d29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a48c3a2f-678b-4e70-a53f-258457d88d29.jpg?1",
             "name": "Field Research",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nDraw two cards. If this spell was kicked, draw three cards instead.",
             "colours": [
@@ -2223,7 +2223,7 @@
         },
         {
             "id": "89d1d1d2-f69b-54df-b18d-f4ace7c72acd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381d84d6-7b34-44cb-a697-54b835ba1281.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/8/381d84d6-7b34-44cb-a697-54b835ba1281.jpg?1",
             "name": "Glacial Grasp",
             "text": "Tap target creature. Its controller mills two cards. That creature doesn't untap during its controller's next untap step. (They put the top two cards of their library into their graveyard.)\nDraw a card.",
             "colours": [
@@ -2255,7 +2255,7 @@
         },
         {
             "id": "992af866-53ec-5530-bd0a-bd94d4be939e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "You may have Glasspool Mimic enter the battlefield as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -2292,7 +2292,7 @@
         },
         {
             "id": "5632d048-68aa-5867-aea0-d4b21284dc82",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5adcb500-8c77-4925-8e2c-1243502827d1.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "Glasspool Shore enters the battlefield tapped.\n{T}: Add {U}.\n\n\nRogue\n{2}{U}",
             "colours": [],
@@ -2324,7 +2324,7 @@
         },
         {
             "id": "2c48aa0e-796b-5d48-9add-625b25250d9c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281cdb1c-21ae-4430-8e0f-c993f52ba891.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281cdb1c-21ae-4430-8e0f-c993f52ba891.jpg?1",
             "name": "Inscription of Insight",
             "text": "Kicker {2}{U}{U}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Return up to two target creatures to their owners' hands.\n\u2022 Scry 2, then draw two cards.\n\u2022 Target player creates an X/X blue Illusion creature token, where X is the number of cards in their hand.",
             "colours": [
@@ -2358,7 +2358,7 @@
         },
         {
             "id": "dd604910-0e81-5d56-b022-e08f21de0879",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899540b0-c17a-4a73-912c-9b8925203de1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/899540b0-c17a-4a73-912c-9b8925203de1.jpg?1",
             "name": "Into the Roil",
             "text": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
             "colours": [
@@ -2392,7 +2392,7 @@
         },
         {
             "id": "19914d4f-3f02-5050-a11e-c1c72acda20d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ed348-e4ed-4b6a-b9d9-03539a6fb42a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fe0ed348-e4ed-4b6a-b9d9-03539a6fb42a.jpg?1",
             "name": "Jace, Mirror Mage",
             "text": "Kicker {2}\nWhen Jace, Mirror Mage enters the battlefield, if Jace was kicked, create a token that's a copy of Jace, Mirror Mage, except it's not legendary and its starting loyalty is 1.\n+1: Scry 2.\n0: Draw a card and reveal it. Remove a number of loyalty counters equal to that card's converted mana cost from Jace, Mirror Mage.",
             "colours": [
@@ -2430,7 +2430,7 @@
         },
         {
             "id": "688d303d-a159-567e-9a5e-d7e43401d9c6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg?1",
             "name": "Jwari Disruption // Jwari Ruins",
             "text": "Counter target spell unless its controller pays {1}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -2462,7 +2462,7 @@
         },
         {
             "id": "d998ffd8-ff81-5e94-b6b7-49fc35e5c8b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/0/301750a7-d1fd-435e-bfa8-9d2fb22ad627.jpg?1",
             "name": "Jwari Disruption // Jwari Ruins",
             "text": "Jwari Ruins enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{1}{U}",
             "colours": [],
@@ -2492,7 +2492,7 @@
         },
         {
             "id": "01d1ef65-cbcd-5b28-85c8-0edeca7ed330",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05ed233-9b53-4c67-ab1c-0217386c9fe4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a05ed233-9b53-4c67-ab1c-0217386c9fe4.jpg?1",
             "name": "Living Tempest",
             "text": "Flash\nFlying",
             "colours": [
@@ -2526,7 +2526,7 @@
         },
         {
             "id": "b253e3c4-9bda-5698-9c3b-b25ac231d15e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9944393-348f-4f0e-a0c7-9adcc5a30749.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/9/c9944393-348f-4f0e-a0c7-9adcc5a30749.jpg?1",
             "name": "Lullmage's Domination",
             "text": "This spell costs {3} less to cast if it targets a creature whose controller has eight or more cards in their graveyard.\nGain control of target creature with converted mana cost X.",
             "colours": [
@@ -2558,7 +2558,7 @@
         },
         {
             "id": "53df80cc-d023-58b6-96ba-a22494041997",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a79733-702c-4611-b073-71db7f1158b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/10a79733-702c-4611-b073-71db7f1158b2.jpg?1",
             "name": "Maddening Cacophony",
             "text": "Kicker {3}{U}\nEach opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.",
             "colours": [
@@ -2592,7 +2592,7 @@
         },
         {
             "id": "074f2c80-fced-5d43-aab8-f8fcb056e390",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaf92a-3d9d-4c52-acff-cf960ec55e47.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0caaf92a-3d9d-4c52-acff-cf960ec55e47.jpg?1",
             "name": "Master of Winds",
             "text": "Flying\nWhen Master of Winds enters the battlefield, draw two cards, then discard a card.\nWhenever you cast an instant, sorcery, or Wizard spell, you may have Master of Winds's base power and toughness become 4/1 or 1/4 until end of turn.",
             "colours": [
@@ -2629,7 +2629,7 @@
         },
         {
             "id": "d3eb610b-27a0-51e5-bc80-0f45fa16263c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a96105-8448-44cb-b60a-36648a1bdbac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2a96105-8448-44cb-b60a-36648a1bdbac.jpg?1",
             "name": "A-Master of Winds",
             "text": "",
             "colours": [
@@ -2663,7 +2663,7 @@
         },
         {
             "id": "1d011237-4e72-52a2-abbe-7ea805d1af4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb0d55a-9d6a-443d-aa82-5cea93188fd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/acb0d55a-9d6a-443d-aa82-5cea93188fd2.jpg?1",
             "name": "Merfolk Falconer",
             "text": "Flying\nWhenever you cast a kicked spell, scry 2.",
             "colours": [
@@ -2698,7 +2698,7 @@
         },
         {
             "id": "41c8ddc1-bb00-510b-86e5-012961dbb51a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112077b8-1514-4320-a70f-b23f3c7ce18a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/112077b8-1514-4320-a70f-b23f3c7ce18a.jpg?1",
             "name": "Merfolk Windrobber",
             "text": "Flying\nWhenever Merfolk Windrobber deals combat damage to a player, that player mills a card. (They put the top card of their library into their graveyard.)\nSacrifice Merfolk Windrobber: Draw a card. Activate this ability only if an opponent has eight or more cards in their graveyard.",
             "colours": [
@@ -2733,7 +2733,7 @@
         },
         {
             "id": "6bf9586f-5404-5ae5-be10-57973407f4b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c7477-d453-4fa4-acf4-3835ab9eb55a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/9/e92c7477-d453-4fa4-acf4-3835ab9eb55a.jpg?1",
             "name": "Negate",
             "text": "Counter target noncreature spell.",
             "colours": [
@@ -2765,7 +2765,7 @@
         },
         {
             "id": "3f65c9b3-fedc-58e5-854b-1bb5c5c77977",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee1a550-b7e7-48e0-bd96-a41986dbd879.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1ee1a550-b7e7-48e0-bd96-a41986dbd879.jpg?1",
             "name": "Nimble Trapfinder",
             "text": "Nimble Trapfinder can't be blocked if you had another Cleric, Rogue, Warrior, or Wizard enter the battlefield under your control this turn.\nAt the beginning of combat on your turn, if you have a full party, creatures you control gain \"Whenever this creature deals combat damage to a player, draw a card\" until end of turn.",
             "colours": [
@@ -2802,7 +2802,7 @@
         },
         {
             "id": "e6bc516d-a9dd-54cd-85ed-747de0ea5729",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6455009-030c-4a33-a60b-80863d8f8aaf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6455009-030c-4a33-a60b-80863d8f8aaf.jpg?1",
             "name": "Risen Riptide",
             "text": "Whenever you cast a kicked spell, Risen Riptide has base power and toughness 5/5 until end of turn.",
             "colours": [
@@ -2836,7 +2836,7 @@
         },
         {
             "id": "749d1824-be3b-52d4-8855-45e96ea4e41f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1240d4-dbd0-483b-934a-5f7c505fad42.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/a/ba1240d4-dbd0-483b-934a-5f7c505fad42.jpg?1",
             "name": "Roost of Drakes",
             "text": "Kicker {2}{U} (You may pay an additional {2}{U} as you cast this spell.)\nWhen Roost of Drakes enters the battlefield, if it was kicked, create a 2/2 blue Drake creature token with flying.\nWhenever you cast a kicked spell, create a 2/2 blue Drake creature token with flying.",
             "colours": [
@@ -2868,7 +2868,7 @@
         },
         {
             "id": "4289ce68-7cf8-5fa3-b2c2-84d0132b8151",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ce273-c938-42d2-83b2-c4f5f4000b0b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ce273-c938-42d2-83b2-c4f5f4000b0b.jpg?1",
             "name": "Ruin Crab",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, each opponent mills three cards. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -2904,7 +2904,7 @@
         },
         {
             "id": "302d4e22-af48-562b-86f3-182b142969f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "Draw cards equal to the number of cards in your hand plus one. You have no maximum hand size for the rest of the game.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -2938,7 +2938,7 @@
         },
         {
             "id": "56eadd50-8594-5dab-be75-36e74035e68d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "As Sea Gate, Reborn enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.\n\n\nSorcery\n{4}{U}{U}{U}",
             "colours": [],
@@ -2970,7 +2970,7 @@
         },
         {
             "id": "413aadac-d2ed-5f73-9331-051e0d7605ee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e14e677-9bfa-4bcc-9772-8e7758d7538a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e14e677-9bfa-4bcc-9772-8e7758d7538a.jpg?1",
             "name": "Sea Gate Stormcaller",
             "text": "Kicker {4}{U}\nWhen Sea Gate Stormcaller enters the battlefield, copy the next instant or sorcery spell with converted mana cost 2 or less you cast this turn when you cast it. If Sea Gate Stormcaller was kicked, copy that spell twice instead. You may choose new targets for the copies.",
             "colours": [
@@ -3007,7 +3007,7 @@
         },
         {
             "id": "25e05e59-8afb-57b9-99f8-fda315e99265",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e9696-6c76-4241-97fc-f166fe2420ce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/985e9696-6c76-4241-97fc-f166fe2420ce.jpg?1",
             "name": "Seafloor Stalker",
             "text": "{4}{U}: Seafloor Stalker gets +1/+0 until end of turn and can't be blocked this turn. This ability costs {1} less to activate for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3042,7 +3042,7 @@
         },
         {
             "id": "3d361e8a-1863-5b13-b914-3cdc7b13c87c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3daede39-8eef-4272-a483-312dbd2dd30f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3daede39-8eef-4272-a483-312dbd2dd30f.jpg?1",
             "name": "Shell Shield",
             "text": "Kicker {1} (You may pay an additional {1} as you cast this spell.)\nTarget creature you control gets +0/+3 until end of turn. If this spell was kicked, that creature also gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
             "colours": [
@@ -3074,7 +3074,7 @@
         },
         {
             "id": "3f332ab3-f2d6-5a61-bca7-38992453fb48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg?1",
             "name": "Silundi Vision // Silundi Isle",
             "text": "Look at the top six cards of your library. You may reveal an instant or sorcery card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -3106,7 +3106,7 @@
         },
         {
             "id": "659aebc2-277a-54f3-a533-9380fb1daa6d",
-            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/1/1/11568cdf-6148-494c-8b98-f5ca5797d775.jpg?1",
             "name": "Silundi Vision // Silundi Isle",
             "text": "Silundi Isle enters the battlefield tapped.\n{T}: Add {U}.\n\n\nInstant\n{2}{U}",
             "colours": [],
@@ -3136,7 +3136,7 @@
         },
         {
             "id": "54cbe878-7ebd-5235-986b-60ed7b3d13d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff05312-787e-4e5e-a0d5-8f3fb576fc49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/f/3ff05312-787e-4e5e-a0d5-8f3fb576fc49.jpg?1",
             "name": "Skyclave Plunder",
             "text": "Look at the top X cards of your library, where X is three plus the number of creatures in your party. Put three of those cards into your hand and the rest on the bottom of your library in a random order. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3168,7 +3168,7 @@
         },
         {
             "id": "d5e8d92b-251f-56fb-9ee1-6fa5ba8cffd2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ed049-7b5b-47d9-96af-f737631a221f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/581ed049-7b5b-47d9-96af-f737631a221f.jpg?1",
             "name": "Skyclave Squid",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Squid can attack this turn as though it didn't have defender.",
             "colours": [
@@ -3204,7 +3204,7 @@
         },
         {
             "id": "cce4bb9b-3192-528e-bfb7-8f0cd2f9e1cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0505053c-8a9c-43ed-b44a-b52c56ba4f77.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0505053c-8a9c-43ed-b44a-b52c56ba4f77.jpg?1",
             "name": "Sure-Footed Infiltrator",
             "text": "Tap another untapped Rogue you control: Sure-Footed Infiltrator can't be blocked this turn.\nWhenever Sure-Footed Infiltrator deals combat damage to a player, draw a card.",
             "colours": [
@@ -3239,7 +3239,7 @@
         },
         {
             "id": "9c7cc6d6-eb38-55fd-b24e-c50ba1e1d290",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f222fb7-375d-4ee2-9ff6-bd71f63ab31a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f222fb7-375d-4ee2-9ff6-bd71f63ab31a.jpg?1",
             "name": "Tazeem Roilmage",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nWhen Tazeem Roilmage enters the battlefield, if it was kicked, return target instant or sorcery card from your graveyard to your hand.",
             "colours": [
@@ -3274,7 +3274,7 @@
         },
         {
             "id": "4ab19108-6acb-5e15-944e-36cd6f5aa94f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff84ea71-e477-44f7-a3f8-77fef708efeb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/f/ff84ea71-e477-44f7-a3f8-77fef708efeb.jpg?1",
             "name": "Thieving Skydiver",
             "text": "Kicker {X}. X can't be 0. (You may pay an additional {X} as you cast this spell.)\nFlying\nWhen Thieving Skydiver enters the battlefield, if it was kicked, gain control of target artifact with converted mana cost X or less. If that artifact is an Equipment, attach it to Thieving Skydiver.",
             "colours": [
@@ -3311,7 +3311,7 @@
         },
         {
             "id": "8b9b0a75-561a-5a7a-88e9-1f559165eff1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg?1",
             "name": "Umara Wizard // Umara Skyfalls",
             "text": "Whenever you cast an instant, sorcery, or Wizard spell, Umara Wizard gains flying until end of turn.\n\n\nLand\n{T}: Add {U}.",
             "colours": [
@@ -3346,7 +3346,7 @@
         },
         {
             "id": "076d18b9-3a90-5a31-b29e-c16edf07e786",
-            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/8/9/890eee8d-a339-4143-adfa-1b17ec10c099.jpg?1",
             "name": "Umara Wizard // Umara Skyfalls",
             "text": "Umara Skyfalls enters the battlefield tapped.\n{T}: Add {U}.\n\n\nWizard\n{4}{U}",
             "colours": [],
@@ -3376,7 +3376,7 @@
         },
         {
             "id": "6a52b40c-620d-5376-bac3-20c1ce872aae",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790a86d-db91-4a87-aa3a-3f9fc4d4b662.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/7/c790a86d-db91-4a87-aa3a-3f9fc4d4b662.jpg?1",
             "name": "Windrider Wizard",
             "text": "Flying\nWhenever you cast an instant, sorcery, or Wizard spell, you may draw a card. If you do, discard a card.",
             "colours": [
@@ -3411,7 +3411,7 @@
         },
         {
             "id": "3f49533b-0ff4-5094-8e54-ced99b051aad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4c7268-60c6-4038-8ce9-d9d51bed4577.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b4c7268-60c6-4038-8ce9-d9d51bed4577.jpg?1",
             "name": "Zulaport Duelist",
             "text": "Flash\nWhen Zulaport Duelist enters the battlefield, up to one target creature gets -2/-0 until end of turn. Its controller mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -3446,7 +3446,7 @@
         },
         {
             "id": "16b73777-ebad-5771-b1c7-0726eeda9f3c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281336c7-ca7c-4c91-bdfb-d253a965cb7c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/8/281336c7-ca7c-4c91-bdfb-d253a965cb7c.jpg?1",
             "name": "Acquisitions Expert",
             "text": "When Acquisitions Expert enters the battlefield, target opponent reveals a number of cards from their hand equal to the number of creatures in your party. You choose one of those cards. That player discards that card. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3481,7 +3481,7 @@
         },
         {
             "id": "12c64bd4-83e3-53f4-b037-a7306121cdb7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "Return from your graveyard to the battlefield any number of target creature cards that each have a different converted mana cost X or less.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -3515,7 +3515,7 @@
         },
         {
             "id": "d5ea3ded-5799-5625-8a3c-bad72e6aeb39",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "As Agadeem, the Undercrypt enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.\n\n\nSorcery\n{X}{B}{B}{B}",
             "colours": [],
@@ -3547,7 +3547,7 @@
         },
         {
             "id": "963e7d0a-f4e0-55d2-ba98-4bf4e131f961",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg?1",
             "name": "Blackbloom Rogue // Blackbloom Bog",
             "text": "Menace (This creature can't be blocked except by two or more creatures.)\nBlackbloom Rogue gets +3/+0 as long as an opponent has eight or more cards in their graveyard.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -3582,7 +3582,7 @@
         },
         {
             "id": "e709a2b9-c819-52c1-b2e6-54f9736580fa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/2/32779721-b021-4bd4-95d1-4a19b78d9faa.jpg?1",
             "name": "Blackbloom Rogue // Blackbloom Bog",
             "text": "Blackbloom Bog enters the battlefield tapped.\n{T}: Add {B}.\n\n\nRogue\n{2}{B}",
             "colours": [],
@@ -3612,7 +3612,7 @@
         },
         {
             "id": "aa9b8a27-4336-5f5f-ade7-c80655a5e9c0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb88075-14f8-4ac9-b947-5ca1d30938f1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0cb88075-14f8-4ac9-b947-5ca1d30938f1.jpg?1",
             "name": "Blood Beckoning",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nReturn target creature card from your graveyard to your hand. If this spell was kicked, instead return two target creature cards from your graveyard to your hand.",
             "colours": [
@@ -3644,7 +3644,7 @@
         },
         {
             "id": "c0f42223-7bd2-5d6c-a26f-1cf9b0d4c793",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14d32d-fe53-4370-8298-fab528ff12db.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/df14d32d-fe53-4370-8298-fab528ff12db.jpg?1",
             "name": "Blood Price",
             "text": "Look at the top four cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order. You lose 2 life.",
             "colours": [
@@ -3676,7 +3676,7 @@
         },
         {
             "id": "d947d9cd-f855-5496-b5de-88006b49865f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8447-6b1c-4651-a734-a8fea2cbf7b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/059e8447-6b1c-4651-a734-a8fea2cbf7b2.jpg?1",
             "name": "Bloodchief's Thirst",
             "text": "Kicker {2}{B} (You may pay an additional {2}{B} as you cast this spell.)\nDestroy target creature or planeswalker with converted mana cost 2 or less. If this spell was kicked, instead destroy target creature or planeswalker.",
             "colours": [
@@ -3710,7 +3710,7 @@
         },
         {
             "id": "5c56c095-1c7c-5fd4-bb7f-4308e3479dd6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afbc5d3-318f-4545-88d6-fc81e5466238.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5afbc5d3-318f-4545-88d6-fc81e5466238.jpg?1",
             "name": "Coveted Prize",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nSearch your library for a card, put it into your hand, then shuffle your library. If you have a full party, you may cast a spell with converted mana cost 4 or less from your hand without paying its mana cost.",
             "colours": [
@@ -3744,7 +3744,7 @@
         },
         {
             "id": "0ab082c4-ede2-5cd6-88ab-2fa066e7c43e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007a5c8c-ed0b-4844-9393-a3d25d4ffa1d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/0/007a5c8c-ed0b-4844-9393-a3d25d4ffa1d.jpg?1",
             "name": "Deadly Alliance",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nDestroy target creature or planeswalker.",
             "colours": [
@@ -3776,7 +3776,7 @@
         },
         {
             "id": "8104eec8-4d71-537c-aa04-86cf85f40876",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f5197-e42b-45e0-8170-1b0a8a5beebd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/3/836f5197-e42b-45e0-8170-1b0a8a5beebd.jpg?1",
             "name": "Demon's Disciple",
             "text": "When Demon's Disciple enters the battlefield, each player sacrifices a creature or planeswalker.",
             "colours": [
@@ -3811,7 +3811,7 @@
         },
         {
             "id": "3ad614e1-4de8-575f-866c-8fe3456a2280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd4154e-7681-444b-a0f2-33e887791ba7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/c/5cd4154e-7681-444b-a0f2-33e887791ba7.jpg?1",
             "name": "Drana, the Last Bloodchief",
             "text": "Flying\nWhenever Drana, the Last Bloodchief attacks, defending player chooses a nonlegendary creature card in your graveyard. You return that card to the battlefield with a +1/+1 counter on it. The creature is a Vampire in addition to its other types.",
             "colours": [
@@ -3850,7 +3850,7 @@
         },
         {
             "id": "f28c3b12-31c7-5286-b461-60757029d43a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59224f9a-deb2-4dd4-b2d4-967232c14254.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/59224f9a-deb2-4dd4-b2d4-967232c14254.jpg?1",
             "name": "Drana's Silencer",
             "text": "When Drana's Silencer enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -3885,7 +3885,7 @@
         },
         {
             "id": "9db2791b-bf23-526c-aac5-bdbb84f23f34",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339736a8-a00f-4e21-8d92-38486f73dba9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/339736a8-a00f-4e21-8d92-38486f73dba9.jpg?1",
             "name": "Dreadwurm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Dreadwurm gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
             "colours": [
@@ -3922,7 +3922,7 @@
         },
         {
             "id": "07c2e89c-093b-532d-a898-a7a0d235e9d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2966b1f0-3d30-4d92-87e5-f39ceacefbd2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/9/2966b1f0-3d30-4d92-87e5-f39ceacefbd2.jpg?1",
             "name": "Expedition Skulker",
             "text": "Expedition Skulker has deathtouch as long as you control another Rogue.",
             "colours": [
@@ -3957,7 +3957,7 @@
         },
         {
             "id": "c2c689ac-4752-5d10-8ec4-8c359e5df42e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b2eba7-862a-4efd-9f65-065fb2070855.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/6/f6b2eba7-862a-4efd-9f65-065fb2070855.jpg?1",
             "name": "Feed the Swarm",
             "text": "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's converted mana cost.",
             "colours": [
@@ -3989,7 +3989,7 @@
         },
         {
             "id": "77262c37-53a5-51d0-9e01-09bde26b66cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f272ac54-fea8-4044-83e2-f8fdc10f467d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f272ac54-fea8-4044-83e2-f8fdc10f467d.jpg?1",
             "name": "Ghastly Gloomhunter",
             "text": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nFlying, lifelink\nIf Ghastly Gloomhunter was kicked, it enters the battlefield with two +1/+1 counters on it.",
             "colours": [
@@ -4024,7 +4024,7 @@
         },
         {
             "id": "6c99a42f-c90e-5397-bb85-5ffd43ad02ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b996743e-7f48-49d8-948b-ceb75bddf215.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b996743e-7f48-49d8-948b-ceb75bddf215.jpg?1",
             "name": "Guul Draz Mucklord",
             "text": "When Guul Draz Mucklord dies, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -4058,7 +4058,7 @@
         },
         {
             "id": "9c1b3814-fb66-57f1-8d30-abc3a51cfebc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f971b71a-af69-43a7-b06c-e80eaaaf4a5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/9/f971b71a-af69-43a7-b06c-e80eaaaf4a5f.jpg?1",
             "name": "Hagra Constrictor",
             "text": "Hagra Constrictor enters the battlefield with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has menace. (A creature with menace can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4092,7 +4092,7 @@
         },
         {
             "id": "73110484-d3a9-5ffc-a829-08b05dad2d93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcad1-00d2-4e26-8230-82f0768bdd67.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7bdcad1-00d2-4e26-8230-82f0768bdd67.jpg?1",
             "name": "A-Hagra Constrictor",
             "text": "",
             "colours": [
@@ -4125,7 +4125,7 @@
         },
         {
             "id": "bd6c333d-346c-5178-a15d-917f86ac3e7a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c04c734-354d-4925-8161-7052110951df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c04c734-354d-4925-8161-7052110951df.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "This spell costs {1} less to cast if an opponent controls no basic lands.\nDestroy target creature.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -4159,7 +4159,7 @@
         },
         {
             "id": "c3dbece1-31b6-5e2b-89eb-5a31c5473ebd",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c04c734-354d-4925-8161-7052110951df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/c/7c04c734-354d-4925-8161-7052110951df.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "Hagra Broodpit enters the battlefield tapped.\n{T}: Add {B}.\n\n\nInstant\n{2}{B}{B}",
             "colours": [],
@@ -4191,7 +4191,7 @@
         },
         {
             "id": "ddfe362c-16a1-5ddf-be15-5b235c8f13b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c40082-516e-4381-a4cc-e61c5a9a6cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/24c40082-516e-4381-a4cc-e61c5a9a6cac.jpg?1",
             "name": "Highborn Vampire",
             "text": "",
             "colours": [
@@ -4226,7 +4226,7 @@
         },
         {
             "id": "f5b4df8e-eafe-5af7-bfe8-ad1468f80a25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93612079-0b8d-489d-9ae1-3593414a8cee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/93612079-0b8d-489d-9ae1-3593414a8cee.jpg?1",
             "name": "Inscription of Ruin",
             "text": "Kicker {2}{B}{B}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Target opponent discards two cards.\n\u2022 Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u2022 Destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -4260,7 +4260,7 @@
         },
         {
             "id": "3adcbcc9-a9cf-50f3-95ab-0d52cd96e1da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b36d12e-9a68-4d3d-92e8-9840cd5320bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b36d12e-9a68-4d3d-92e8-9840cd5320bc.jpg?1",
             "name": "Lithoform Blight",
             "text": "Enchant land\nWhen Lithoform Blight enters the battlefield, draw a card.\nEnchanted land loses all land types and abilities and has \"{T}: Add {C}\" and \"{T}, Pay 1 life: Add one mana of any color.\"",
             "colours": [
@@ -4294,7 +4294,7 @@
         },
         {
             "id": "3dc126c9-19a2-57cf-bef7-947fbf0c47e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14ea81-d303-47db-90b4-7d10588f7ea6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/d/3d14ea81-d303-47db-90b4-7d10588f7ea6.jpg?1",
             "name": "Malakir Blood-Priest",
             "text": "When Malakir Blood-Priest enters the battlefield, each opponent loses X life and you gain X life, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -4329,7 +4329,7 @@
         },
         {
             "id": "08321af6-5548-53c6-88c0-99537f2bf5d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1",
             "name": "Malakir Rebirth // Malakir Mire",
             "text": "Choose target creature. You lose 2 life. Until end of turn, that creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control.\"\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -4361,7 +4361,7 @@
         },
         {
             "id": "08438b77-41e3-5bdf-bbe4-5c76a95f04d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1",
             "name": "Malakir Rebirth // Malakir Mire",
             "text": "Malakir Mire enters the battlefield tapped.\n{T}: Add {B}.\n\n\nInstant\n{B}",
             "colours": [],
@@ -4391,7 +4391,7 @@
         },
         {
             "id": "349b037f-2ce1-54ec-b06a-1c3fc3a03061",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730ddbcd-0814-4e22-85e9-78b0878324b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/730ddbcd-0814-4e22-85e9-78b0878324b6.jpg?1",
             "name": "Marauding Blight-Priest",
             "text": "Whenever you gain life, each opponent loses 1 life.",
             "colours": [
@@ -4426,7 +4426,7 @@
         },
         {
             "id": "4173674f-b2b7-52b7-8a7c-11059b323eac",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b6e18-bcd8-43b7-870d-6c7e5c06f99b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/0/105b6e18-bcd8-43b7-870d-6c7e5c06f99b.jpg?1",
             "name": "Mind Carver",
             "text": "When Mind Carver enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0. It gets +3/+1 instead as long as an opponent has eight or more cards in their graveyard.\nEquip {2}{B}",
             "colours": [
@@ -4460,7 +4460,7 @@
         },
         {
             "id": "88d932a2-296a-5d1e-bf2f-10cd6564e0d1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0683d586-a54b-425a-a24d-2efb2342f150.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/0683d586-a54b-425a-a24d-2efb2342f150.jpg?1",
             "name": "Mind Drain",
             "text": "Target opponent discards two cards, mills a card, and loses 1 life. You gain 1 life. (To mill a card, a player puts the top card of their library into their graveyard.)",
             "colours": [
@@ -4492,7 +4492,7 @@
         },
         {
             "id": "f5bf1c79-b32b-5150-ae9b-1978698aa01c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb348f07-1d48-4877-8a56-60655d64a3f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb348f07-1d48-4877-8a56-60655d64a3f7.jpg?1",
             "name": "Nighthawk Scavenger",
             "text": "Flying, deathtouch, lifelink\nNighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards. (Cards in graveyards have only the characteristics of their front face.)",
             "colours": [
@@ -4529,7 +4529,7 @@
         },
         {
             "id": "eb67e9ad-a112-50b3-a1ab-0c895e396def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea080141-6262-4595-8058-b2969b3f016b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/a/ea080141-6262-4595-8058-b2969b3f016b.jpg?1",
             "name": "Nimana Skitter-Sneak",
             "text": "As long as an opponent has eight or more cards in their graveyard, Nimana Skitter-Sneak gets +1/+0 and has menace. (It can't be blocked except by two or more creatures.)",
             "colours": [
@@ -4564,7 +4564,7 @@
         },
         {
             "id": "81acbee0-ea7f-5c24-8a14-e3f41985b8f4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72eaa0f-cbec-45a1-b390-cbbedf5a02f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e72eaa0f-cbec-45a1-b390-cbbedf5a02f2.jpg?1",
             "name": "Nimana Skydancer",
             "text": "Flash\nFlying\nWhen Nimana Skydancer enters the battlefield, target opponent mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [
@@ -4599,7 +4599,7 @@
         },
         {
             "id": "b85990b9-479d-5492-925d-7f3ff241b50a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086fc7fb-efcf-4676-8455-39b63edaec6a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/086fc7fb-efcf-4676-8455-39b63edaec6a.jpg?1",
             "name": "Nullpriest of Oblivion",
             "text": "Kicker {3}{B}\nMenace, lifelink\nWhen Nullpriest of Oblivion enters the battlefield, if it was kicked, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -4636,7 +4636,7 @@
         },
         {
             "id": "b25066a0-c638-5051-8968-b1f25f833e06",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf65512-8228-48f4-ba7b-d861b66d28c9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/faf65512-8228-48f4-ba7b-d861b66d28c9.jpg?1",
             "name": "Oblivion's Hunger",
             "text": "Target creature you control gains indestructible until end of turn. Draw a card if that creature has a +1/+1 counter on it. (Damage and effects that say \"destroy\" don't destroy the creature.)",
             "colours": [
@@ -4668,7 +4668,7 @@
         },
         {
             "id": "75ba9201-7ad8-589e-a46a-67cf08e4a694",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg?1",
             "name": "Pelakka Predation // Pelakka Caverns",
             "text": "Target opponent reveals their hand. You choose a card from it with converted mana cost 3 or greater. That player discards that card.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -4700,7 +4700,7 @@
         },
         {
             "id": "956cb1d0-2beb-51f9-8f33-38cb28280d2b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/6/e63f8b20-f45b-4293-9aac-cdc021939be6.jpg?1",
             "name": "Pelakka Predation // Pelakka Caverns",
             "text": "Pelakka Caverns enters the battlefield tapped.\n{T}: Add {B}.\n\n\nSorcery\n{2}{B}",
             "colours": [],
@@ -4730,7 +4730,7 @@
         },
         {
             "id": "e10af705-d59c-5abd-afdd-c130a4ee50b3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043926fe-d25f-40b4-b556-181503434e68.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/043926fe-d25f-40b4-b556-181503434e68.jpg?1",
             "name": "Scion of the Swarm",
             "text": "Flying\nWhenever you gain life, put a +1/+1 counter on Scion of the Swarm.",
             "colours": [
@@ -4765,7 +4765,7 @@
         },
         {
             "id": "294dd93b-a5d4-5969-b6f7-0936f6c6426f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7bcc-3ff8-40b0-8264-0cd678d6ff31.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/d/4dea7bcc-3ff8-40b0-8264-0cd678d6ff31.jpg?1",
             "name": "Scourge of the Skyclaves",
             "text": "Kicker {4}{B}\nWhen you cast this spell, if it was kicked, each player loses half their life, rounded up.\nScourge of the Skyclaves's power and toughness are each equal to 20 minus the highest life total among players.",
             "colours": [
@@ -4801,7 +4801,7 @@
         },
         {
             "id": "95ff4a99-0080-5977-8b4f-5dcd15ba63b8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093e0b1e-2cd9-4743-9c0e-b8f3fbc41798.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/093e0b1e-2cd9-4743-9c0e-b8f3fbc41798.jpg?1",
             "name": "Shadow Stinger",
             "text": "Tap another untapped Rogue you control: Shadow Stinger gains deathtouch until end of turn.\nWhenever Shadow Stinger deals combat damage to a player, that player mills three cards. (They put the top three cards of their library into their graveyard.)",
             "colours": [
@@ -4836,7 +4836,7 @@
         },
         {
             "id": "c520e095-d4d6-56dc-b770-0ddeb29a38b4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52470883-b44d-415b-9324-8074e66f79ae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52470883-b44d-415b-9324-8074e66f79ae.jpg?1",
             "name": "Shadows' Verdict",
             "text": "Exile all creatures and planeswalkers with converted mana cost 3 or less from the battlefield and all creature and planeswalker cards with converted mana cost 3 or less from all graveyards.",
             "colours": [
@@ -4870,7 +4870,7 @@
         },
         {
             "id": "4d56da12-590e-5994-b4ce-1a1927a380c1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bbc0e7-48ce-41e2-a014-1f2eb0427550.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/0/50bbc0e7-48ce-41e2-a014-1f2eb0427550.jpg?1",
             "name": "Skyclave Shade",
             "text": "Kicker {2}{B}\nSkyclave Shade can't block.\nIf Skyclave Shade was kicked, it enters the battlefield with two +1/+1 counters on it.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if Skyclave Shade is in your graveyard and it's your turn, you may cast it from your graveyard this turn.",
             "colours": [
@@ -4906,7 +4906,7 @@
         },
         {
             "id": "6c9b17b7-87a7-5e41-9f83-e7831bf97c4b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27fcfc5-a1a9-4b21-8240-2ed6346c64e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b27fcfc5-a1a9-4b21-8240-2ed6346c64e1.jpg?1",
             "name": "Skyclave Shadowcat",
             "text": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on Skyclave Shadowcat.\nWhenever a creature you control with a +1/+1 counter on it dies, draw a card.",
             "colours": [
@@ -4941,7 +4941,7 @@
         },
         {
             "id": "8c964741-16ec-54eb-8fc7-1ddccd9adf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fd304-d8e4-4ba4-ab0e-2ebeebea8fdd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc5fd304-d8e4-4ba4-ab0e-2ebeebea8fdd.jpg?1",
             "name": "A-Skyclave Shadowcat",
             "text": "",
             "colours": [
@@ -4975,7 +4975,7 @@
         },
         {
             "id": "672fcb99-8a44-551e-b079-eef0c3c5f024",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fb07b-0f70-403b-be8b-b5217f12e671.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/c/2c2fb07b-0f70-403b-be8b-b5217f12e671.jpg?1",
             "name": "Soul Shatter",
             "text": "Each opponent sacrifices a creature or planeswalker with the highest converted mana cost among creatures and planeswalkers they control.",
             "colours": [
@@ -5009,7 +5009,7 @@
         },
         {
             "id": "7c0bc355-f965-5ace-b176-c572e1ec2612",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3f531a-ce45-4cba-be24-6db749e38abd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d3f531a-ce45-4cba-be24-6db749e38abd.jpg?1",
             "name": "Subtle Strike",
             "text": "Choose one or both \u2014\n\u2022 Target creature gets -1/-1 until end of turn.\n\u2022 Put a +1/+1 counter on target creature.",
             "colours": [
@@ -5041,7 +5041,7 @@
         },
         {
             "id": "8f1eecc2-d5c5-5284-ba45-740b1c155bc6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331bf97d-f447-4c68-bfc7-2bb593106d66.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/331bf97d-f447-4c68-bfc7-2bb593106d66.jpg?1",
             "name": "Taborax, Hope's Demise",
             "text": "Flying\nTaborax, Hope's Demise has lifelink as long as it has five or more +1/+1 counters on it.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on Taborax. If that creature was a Cleric, you may draw a card. If you do, you lose 1 life.",
             "colours": [
@@ -5080,7 +5080,7 @@
         },
         {
             "id": "8571832c-1faa-501b-8f7c-20ea14b7bf53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd037e51-9088-4145-8289-00a86fb72ca1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd037e51-9088-4145-8289-00a86fb72ca1.jpg?1",
             "name": "Thwart the Grave",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nReturn target creature card and up to one target Cleric, Rogue, Warrior, or Wizard creature card from your graveyard to the battlefield.",
             "colours": [
@@ -5112,7 +5112,7 @@
         },
         {
             "id": "2caff408-bba3-5572-9091-cecf1f128b46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15852d4-2c79-4841-bb65-6661d88fdfab.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/1/c15852d4-2c79-4841-bb65-6661d88fdfab.jpg?1",
             "name": "Vanquish the Weak",
             "text": "Destroy target creature with power 3 or less.",
             "colours": [
@@ -5144,7 +5144,7 @@
         },
         {
             "id": "c097250b-2e07-5484-8507-5e9f075b244e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg?1",
             "name": "Zof Consumption // Zof Bloodbog",
             "text": "Each opponent loses 4 life and you gain 4 life.\n\n\nLand\n{T}: Add {B}.",
             "colours": [
@@ -5176,7 +5176,7 @@
         },
         {
             "id": "ca78ebc5-2b25-5141-8fcf-efbc71fb333b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/8/98496d5b-1519-4f0c-8b46-0a43be643dfb.jpg?1",
             "name": "Zof Consumption // Zof Bloodbog",
             "text": "Zof Bloodbog enters the battlefield tapped.\n{T}: Add {B}.\n\n\nSorcery\n{4}{B}{B}",
             "colours": [],
@@ -5206,7 +5206,7 @@
         },
         {
             "id": "3408090b-fa31-545e-8714-a4b850deb21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5ad1c8-3d70-43ed-9539-2aa6289c5c4a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a5ad1c8-3d70-43ed-9539-2aa6289c5c4a.jpg?1",
             "name": "Akoum Hellhound",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Akoum Hellhound gets +2/+2 until end of turn.",
             "colours": [
@@ -5243,7 +5243,7 @@
         },
         {
             "id": "d57817ff-61f3-52df-b3dd-f7209909467c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg?1",
             "name": "Akoum Warrior // Akoum Teeth",
             "text": "Trample\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -5278,7 +5278,7 @@
         },
         {
             "id": "09d8b7ad-bd05-5db3-9a4e-5417a42073d5",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/8/d8ed0335-daa6-4dbe-a94d-4d56c8cfd093.jpg?1",
             "name": "Akoum Warrior // Akoum Teeth",
             "text": "Akoum Teeth enters the battlefield tapped.\n{T}: Add {R}.\n\n\nWarrior\n{5}{R}",
             "colours": [],
@@ -5308,7 +5308,7 @@
         },
         {
             "id": "d1a1ad66-98f2-52b0-80d9-cc1ab0eaf49b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8685c8e-935f-49f2-acf2-8e3c41c5b330.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8685c8e-935f-49f2-acf2-8e3c41c5b330.jpg?1",
             "name": "Ardent Electromancer",
             "text": "When Ardent Electromancer enters the battlefield, add {R} for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -5343,7 +5343,7 @@
         },
         {
             "id": "24f6a2c0-f421-58b1-8e2a-f902af60ffd5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516cf97-805f-4a21-a4c6-2d6e55865336.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/5516cf97-805f-4a21-a4c6-2d6e55865336.jpg?1",
             "name": "Cinderclasm",
             "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nCinderclasm deals 1 damage to each creature. If it was kicked, it deals 2 damage to each creature instead.",
             "colours": [
@@ -5375,7 +5375,7 @@
         },
         {
             "id": "577e0ed1-a830-51d7-869c-09332f00f05b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492d77e5-acc6-41b8-8930-f39d69234919.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/492d77e5-acc6-41b8-8930-f39d69234919.jpg?1",
             "name": "Cleansing Wildfire",
             "text": "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle their library.\nDraw a card.",
             "colours": [
@@ -5407,7 +5407,7 @@
         },
         {
             "id": "60a47f13-ed69-5cfd-a0a4-2015793bfc88",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30084dc1-f501-4b7c-972d-1a3b9137083a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/30084dc1-f501-4b7c-972d-1a3b9137083a.jpg?1",
             "name": "Expedition Champion",
             "text": "Expedition Champion gets +2/+0 as long as you control another Warrior.",
             "colours": [
@@ -5442,7 +5442,7 @@
         },
         {
             "id": "de599aa8-838e-5e2a-b9b3-b46ba844d7fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca657846-f352-4ac4-b2b3-d0ced6607163.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca657846-f352-4ac4-b2b3-d0ced6607163.jpg?1",
             "name": "Fireblade Charger",
             "text": "As long as Fireblade Charger is equipped, it has haste.\nWhen Fireblade Charger dies, it deals damage equal to its power to any target.",
             "colours": [
@@ -5477,7 +5477,7 @@
         },
         {
             "id": "283ce812-3533-5846-8445-5ffccecd2ff9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa10a18-5059-46ab-9983-0ea78b507331.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/f/9fa10a18-5059-46ab-9983-0ea78b507331.jpg?1",
             "name": "Fissure Wizard",
             "text": "When Fissure Wizard enters the battlefield, you may discard a card. If you do, draw a card.",
             "colours": [
@@ -5512,7 +5512,7 @@
         },
         {
             "id": "fdbb5212-a128-5df1-b366-c37544d24b53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83962b-445a-4b44-ad8a-fada2c0a15b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/e/ce83962b-445a-4b44-ad8a-fada2c0a15b8.jpg?1",
             "name": "Goma Fada Vanguard",
             "text": "Whenever Goma Fada Vanguard attacks, target creature an opponent controls with power less than or equal to the number of Warriors you control can't block this turn.",
             "colours": [
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "5b32081e-f78d-5f3b-80a4-c4f5c8a9967f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7762d48f-9088-4856-a0b0-cbf62540caf5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/7762d48f-9088-4856-a0b0-cbf62540caf5.jpg?1",
             "name": "A-Goma Fada Vanguard",
             "text": "",
             "colours": [
@@ -5581,7 +5581,7 @@
         },
         {
             "id": "789a9e29-9514-5da2-a1e8-d483e95f4979",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b310b01-f9cb-48ce-8af3-5957d3abf098.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/b/5b310b01-f9cb-48ce-8af3-5957d3abf098.jpg?1",
             "name": "Grotag Bug-Catcher",
             "text": "Trample\nWhenever Grotag Bug-Catcher attacks, it gets +1/+0 until end of turn for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -5616,7 +5616,7 @@
         },
         {
             "id": "16f880fa-f909-5a7f-892c-182972cffc78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0568341b-f972-407f-92ce-1b7c9ef742f6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0568341b-f972-407f-92ce-1b7c9ef742f6.jpg?1",
             "name": "Grotag Night-Runner",
             "text": "Whenever Grotag Night-Runner deals combat damage to a player, exile the top card of your library. You may play that card this turn.",
             "colours": [
@@ -5651,7 +5651,7 @@
         },
         {
             "id": "fcf5d326-0db8-5e9b-bf16-5e7f5ca2d03a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f62bdc-50a0-41a0-ac37-9b0eeb21b6aa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d0f62bdc-50a0-41a0-ac37-9b0eeb21b6aa.jpg?1",
             "name": "Inordinate Rage",
             "text": "Target creature gets +3/+2 until end of turn. Scry 1.",
             "colours": [
@@ -5683,7 +5683,7 @@
         },
         {
             "id": "dd45841b-24e5-56a8-8ac1-ac93b2837915",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0885acdc-9b4c-4e28-8785-9e721a27e81e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/8/0885acdc-9b4c-4e28-8785-9e721a27e81e.jpg?1",
             "name": "Kargan Intimidator",
             "text": "Cowards can't block Warriors.\n{1}: Choose one that hasn't been chosen this turn \u2014\n\u2022 Kargan Intimidator gets +1/+1 until end of turn.\n\u2022 Target creature becomes a Coward until end of turn.\n\u2022 Target Warrior gains trample until end of turn.",
             "colours": [
@@ -5720,7 +5720,7 @@
         },
         {
             "id": "f28398a2-36d3-54b7-aa01-5cc5422f8f52",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d4bac-9433-4956-9126-358432c22818.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/2/825d4bac-9433-4956-9126-358432c22818.jpg?1",
             "name": "A-Kargan Intimidator",
             "text": "",
             "colours": [
@@ -5754,7 +5754,7 @@
         },
         {
             "id": "8c9a078d-7a7a-5b9c-a195-163136d901ce",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg?1",
             "name": "Kazuul's Fury // Kazuul's Cliffs",
             "text": "As an additional cost to cast this spell, sacrifice a creature.\nKazuul's Fury deals damage equal to the sacrificed creature's power to any target.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -5786,7 +5786,7 @@
         },
         {
             "id": "56ce8024-a3fd-51bf-a4fe-b1709b3a8a35",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/5/75240bbc-adc7-48ff-9523-c79776d710d3.jpg?1",
             "name": "Kazuul's Fury // Kazuul's Cliffs",
             "text": "Kazuul's Cliffs enters the battlefield tapped.\n{T}: Add {R}.\n\n\nInstant\n{2}{R}",
             "colours": [],
@@ -5816,7 +5816,7 @@
         },
         {
             "id": "091650a7-76ef-5250-8b67-5215b9242619",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847ae75b-1c0f-4d0a-9933-9a302c88dc27.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/847ae75b-1c0f-4d0a-9933-9a302c88dc27.jpg?1",
             "name": "Leyline Tyrant",
             "text": "Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.",
             "colours": [
@@ -5852,7 +5852,7 @@
         },
         {
             "id": "5b5ec259-c82f-51b4-8b13-e0e7d7cf2522",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8be6570-5b5f-4ffc-a5e5-67d7c41c8caa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d8be6570-5b5f-4ffc-a5e5-67d7c41c8caa.jpg?1",
             "name": "Magmatic Channeler",
             "text": "As long as there are four or more instant and/or sorcery cards in your graveyard, Magmatic Channeler gets +3/+1.\n{T}, Discard a card: Exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -5889,7 +5889,7 @@
         },
         {
             "id": "ac49d8fe-0353-530d-9c30-6c7870b9cf0e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1beef2-788b-469b-883b-cf1cca04eeff.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb1beef2-788b-469b-883b-cf1cca04eeff.jpg?1",
             "name": "Molten Blast",
             "text": "Choose one \u2014\n\u2022 Molten Blast deals 2 damage to target creature or planeswalker.\n\u2022 Destroy target artifact.",
             "colours": [
@@ -5921,7 +5921,7 @@
         },
         {
             "id": "9ab4ff1f-158e-5f25-aaea-3a442ed95890",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5eacd7-aaa7-4720-9794-52e7b098c82c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/cc5eacd7-aaa7-4720-9794-52e7b098c82c.jpg?1",
             "name": "Moraug, Fury of Akoum",
             "text": "Each creature you control gets +1/+0 for each time it has attacked this turn.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if it's your main phase, there's an additional combat phase after this phase. At the beginning of that combat, untap all creatures you control.",
             "colours": [
@@ -5960,7 +5960,7 @@
         },
         {
             "id": "605aebe3-8782-5efd-b7aa-459ea8b93fc8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb4bc1-6ef9-4015-9f5f-36f51dbac87e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06bb4bc1-6ef9-4015-9f5f-36f51dbac87e.jpg?1",
             "name": "Nahiri's Lithoforming",
             "text": "Sacrifice X lands. For each land sacrificed this way, draw a card. You may play X additional lands this turn. Lands you control enter the battlefield tapped this turn.",
             "colours": [
@@ -5994,7 +5994,7 @@
         },
         {
             "id": "96b800e9-dee2-54b7-8bf4-f665a5daf33b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5929c89b-8c61-47f5-a8ec-b64bf41e9d5b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/9/5929c89b-8c61-47f5-a8ec-b64bf41e9d5b.jpg?1",
             "name": "Pyroclastic Hellion",
             "text": "When Pyroclastic Hellion enters the battlefield, you may return a land you control to its owner's hand. When you do, Pyroclastic Hellion deals 2 damage to each opponent.",
             "colours": [
@@ -6028,7 +6028,7 @@
         },
         {
             "id": "c42e4832-443e-5dae-9e1c-ae10e465cb46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540205c-eee8-4db3-8757-710de874b313.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/5/4540205c-eee8-4db3-8757-710de874b313.jpg?1",
             "name": "Relic Robber",
             "text": "Haste\nWhenever Relic Robber deals combat damage to a player, that player creates a 0/1 colorless Goblin Construct artifact creature token with \"This creature can't block\" and \"At the beginning of your upkeep, this creature deals 1 damage to you.\"",
             "colours": [
@@ -6065,7 +6065,7 @@
         },
         {
             "id": "340af055-57af-5efe-8e5f-d2e9767471ea",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e105c546-ce4f-49c7-97ba-ea5fbe70df82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e105c546-ce4f-49c7-97ba-ea5fbe70df82.jpg?1",
             "name": "Rockslide Sorcerer",
             "text": "Whenever you cast an instant, sorcery, or Wizard spell, Rockslide Sorcerer deals 1 damage to any target.",
             "colours": [
@@ -6100,7 +6100,7 @@
         },
         {
             "id": "ac99bc36-28c2-59a7-af7b-152085ec4218",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e350e531-1ce1-48dc-b458-c2ace44cad1e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e350e531-1ce1-48dc-b458-c2ace44cad1e.jpg?1",
             "name": "A-Rockslide Sorcerer",
             "text": "",
             "colours": [
@@ -6134,7 +6134,7 @@
         },
         {
             "id": "dbd65728-bba8-536e-a908-5dfa56068dcb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86572747-8faa-4242-b059-07d11e6be1cd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/6/86572747-8faa-4242-b059-07d11e6be1cd.jpg?1",
             "name": "Roil Eruption",
             "text": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nRoil Eruption deals 3 damage to any target. If this spell was kicked, it deals 5 damage instead.",
             "colours": [
@@ -6168,7 +6168,7 @@
         },
         {
             "id": "82ddb9b0-1fd3-5969-8eff-1b4b24db10d6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b057eb7-8439-4d26-89df-c345ab2773e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b057eb7-8439-4d26-89df-c345ab2773e1.jpg?1",
             "name": "Roiling Vortex",
             "text": "At the beginning of each player's upkeep, Roiling Vortex deals 1 damage to them.\nWhenever a player casts a spell, if no mana was spent to cast that spell, Roiling Vortex deals 5 damage to that player.\n{R}: Your opponents can't gain life this turn.",
             "colours": [
@@ -6202,7 +6202,7 @@
         },
         {
             "id": "7638da7d-57bd-5d59-bd6c-7bbe2ed788ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3280f0d0-de0d-4f87-a6ef-c941cb7c9784.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/2/3280f0d0-de0d-4f87-a6ef-c941cb7c9784.jpg?1",
             "name": "Scavenged Blade",
             "text": "When Scavenged Blade enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {2}{R} ({2}{R}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [
@@ -6236,7 +6236,7 @@
         },
         {
             "id": "bf594864-1a37-5968-8130-20aa03bad92a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec9d3eb-4729-49a9-8146-7388ff2629df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/e/9ec9d3eb-4729-49a9-8146-7388ff2629df.jpg?1",
             "name": "Scorch Rider",
             "text": "Kicker {1}{R} (You may pay an additional {1}{R} as you cast this spell.)\nWhen Scorch Rider enters the battlefield, if it was kicked, it gains haste until end of turn.",
             "colours": [
@@ -6271,7 +6271,7 @@
         },
         {
             "id": "076636d3-9d74-50c0-83fa-5988d64c9f98",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6d6bc3-2162-4c2b-a5de-25103e706e37.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/c/6c6d6bc3-2162-4c2b-a5de-25103e706e37.jpg?1",
             "name": "Shatterskull Charger",
             "text": "Kicker {2}\nTrample, haste\nIf Shatterskull Charger was kicked, it enters the battlefield with a +1/+1 counter on it.\nAt the beginning of your end step, if Shatterskull Charger doesn't have a +1/+1 counter on it, return it to its owner's hand.",
             "colours": [
@@ -6308,7 +6308,7 @@
         },
         {
             "id": "5af95a50-ea56-5626-9e06-f720399f9368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d311f5f-ad68-48d4-aa5d-66916034ddb9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/d/9d311f5f-ad68-48d4-aa5d-66916034ddb9.jpg?1",
             "name": "Shatterskull Minotaur",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nHaste",
             "colours": [
@@ -6343,7 +6343,7 @@
         },
         {
             "id": "8475caa4-359c-55b2-8de3-900c40a48468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "Shatterskull Smashing deals X damage divided as you choose among up to two target creatures and/or planeswalkers. If X is 6 or more, Shatterskull Smashing deals twice X damage divided as you choose among them instead.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6377,7 +6377,7 @@
         },
         {
             "id": "5f636702-105c-5538-a3c6-b74a18bf2c2e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "As Shatterskull, the Hammer Pass enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.\n\n\nSorcery\n{X}{R}{R}",
             "colours": [],
@@ -6409,7 +6409,7 @@
         },
         {
             "id": "b0ab98ac-cbcb-5967-bd9c-9a979f5b7948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf5843a-a01f-4d1c-b8fe-c586d5160f6e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1bf5843a-a01f-4d1c-b8fe-c586d5160f6e.jpg?1",
             "name": "Sizzling Barrage",
             "text": "Sizzling Barrage deals 4 damage to target creature that blocked this turn.",
             "colours": [
@@ -6441,7 +6441,7 @@
         },
         {
             "id": "ab2c2f19-8620-5785-9687-76b3838ebc20",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9103c9-084f-4ad2-8b7b-ca52be97619d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9103c9-084f-4ad2-8b7b-ca52be97619d.jpg?1",
             "name": "Skyclave Geopede",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Geopede gets +2/+2 until end of turn.",
             "colours": [
@@ -6477,7 +6477,7 @@
         },
         {
             "id": "37d01d0d-f2a5-5c8f-b4ec-c52dddf2a5ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c9e8c-7808-49d0-82c1-72d5b835f51c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/569c9e8c-7808-49d0-82c1-72d5b835f51c.jpg?1",
             "name": "Sneaking Guide",
             "text": "{2}, {T}: Target creature with power 2 or less can't be blocked this turn.",
             "colours": [
@@ -6512,7 +6512,7 @@
         },
         {
             "id": "00810124-9bb5-5981-8385-941cb2783a74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg?1",
             "name": "Song-Mad Treachery // Song-Mad Ruins",
             "text": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6544,7 +6544,7 @@
         },
         {
             "id": "214bc31f-aba3-56b9-b2dc-028759edf38e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/782ca27f-9f18-476c-b582-89c06fb2e322.jpg?1",
             "name": "Song-Mad Treachery // Song-Mad Ruins",
             "text": "Song-Mad Ruins enters the battlefield tapped.\n{T}: Add {R}.\n\n\nSorcery\n{3}{R}{R}",
             "colours": [],
@@ -6574,7 +6574,7 @@
         },
         {
             "id": "b00297e5-063f-59fc-b284-5ef2dce4aff2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1",
             "name": "Spikefield Hazard // Spikefield Cave",
             "text": "Spikefield Hazard deals 1 damage to any target. If a permanent dealt damage this way would die this turn, exile it instead.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6606,7 +6606,7 @@
         },
         {
             "id": "d0566eb7-d5b9-57d5-80be-195dbd71595c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1",
             "name": "Spikefield Hazard // Spikefield Cave",
             "text": "Spikefield Cave enters the battlefield tapped.\n{T}: Add {R}.\n\n\nInstant\n{R}",
             "colours": [],
@@ -6636,7 +6636,7 @@
         },
         {
             "id": "e7d3cac3-b017-5e22-b6f5-e984ae9cb716",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f26493-812f-4c14-91c4-d2ab549a7b8a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/7/47f26493-812f-4c14-91c4-d2ab549a7b8a.jpg?1",
             "name": "Spitfire Lagac",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Spitfire Lagac deals 1 damage to each opponent.",
             "colours": [
@@ -6672,7 +6672,7 @@
         },
         {
             "id": "aa44fa15-47cc-511d-94d0-486de9a9e616",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87f4637-1ad3-4d61-98ff-98c0b0be46a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/8/d87f4637-1ad3-4d61-98ff-98c0b0be46a1.jpg?1",
             "name": "Synchronized Spellcraft",
             "text": "Synchronized Spellcraft deals 4 damage to target creature and X damage to that creature's controller, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -6704,7 +6704,7 @@
         },
         {
             "id": "a1d75fca-fee5-5e09-af9a-8dc1373fc0b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad57c2f3-d9cb-4165-bb39-897b5b12689e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/d/ad57c2f3-d9cb-4165-bb39-897b5b12689e.jpg?1",
             "name": "Teeterpeak Ambusher",
             "text": "{2}{R}: Teeterpeak Ambusher gets +2/+0 until end of turn.",
             "colours": [
@@ -6739,7 +6739,7 @@
         },
         {
             "id": "6f7f647e-6e17-529e-aaa3-790c76349d9a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc671707-4708-44d8-8ec8-d5332599adf9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc671707-4708-44d8-8ec8-d5332599adf9.jpg?1",
             "name": "Thundering Rebuke",
             "text": "Thundering Rebuke deals 4 damage to target creature or planeswalker.",
             "colours": [
@@ -6771,7 +6771,7 @@
         },
         {
             "id": "957a05e6-c042-57eb-aaa4-6d32c6c46587",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e6de80-3516-426b-8a1b-bda45f8c0cac.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a9e6de80-3516-426b-8a1b-bda45f8c0cac.jpg?1",
             "name": "Thundering Sparkmage",
             "text": "When Thundering Sparkmage enters the battlefield, it deals X damage to target creature or planeswalker, where X is the number of creatures in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -6806,7 +6806,7 @@
         },
         {
             "id": "f26366bd-0e31-5f33-b023-03f125bf710c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da46103-a14c-4aa2-92fc-fd758335caf4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6da46103-a14c-4aa2-92fc-fd758335caf4.jpg?1",
             "name": "Tormenting Voice",
             "text": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
             "colours": [
@@ -6838,7 +6838,7 @@
         },
         {
             "id": "eb3df8ba-df7d-577b-a2a0-927e023b7b6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eedf9d-e26c-405c-aee5-1b3493dc5e9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02eedf9d-e26c-405c-aee5-1b3493dc5e9b.jpg?1",
             "name": "Tuktuk Rubblefort",
             "text": "Defender, reach\nCreatures you control have haste.",
             "colours": [
@@ -6872,7 +6872,7 @@
         },
         {
             "id": "f3a5ac3a-7540-536a-8cfb-a9eb2ef6791c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.\n\n\nLand\n{T}: Add {R}.",
             "colours": [
@@ -6906,7 +6906,7 @@
         },
         {
             "id": "833aa414-f3da-5e3a-8abf-f312610f1820",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Valakut Stoneforge enters the battlefield tapped.\n{T}: Add {R}.\n\n\nInstant\n{2}{R}",
             "colours": [],
@@ -6938,7 +6938,7 @@
         },
         {
             "id": "fe94459b-9c97-5302-9cde-1a2fdaf11e77",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cb7bf6-9c7c-4e62-a678-7b75862e2f64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18cb7bf6-9c7c-4e62-a678-7b75862e2f64.jpg?1",
             "name": "Valakut Exploration",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, exile the top card of your library. You may play that card for as long as it remains exiled.\nAt the beginning of your end step, if there are cards exiled with Valakut Exploration, put them into their owner's graveyard, then Valakut Exploration deals that much damage to each opponent.",
             "colours": [
@@ -6972,7 +6972,7 @@
         },
         {
             "id": "a7160591-6b7c-5f1c-bf98-820b3c7b01da",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00f8ab0-61cd-4721-b974-a2516da77d39.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d00f8ab0-61cd-4721-b974-a2516da77d39.jpg?1",
             "name": "Wayward Guide-Beast",
             "text": "Trample, haste\nWhenever Wayward Guide-Beast deals combat damage to a player, return a land you control to its owner's hand.",
             "colours": [
@@ -7008,7 +7008,7 @@
         },
         {
             "id": "68d76993-3cf0-5f43-9ae6-4fba76e99119",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50f988-da46-4b9b-9cc5-78497df2df8b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db50f988-da46-4b9b-9cc5-78497df2df8b.jpg?1",
             "name": "Adventure Awaits",
             "text": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. If you didn't put a card into your hand this way, draw a card.",
             "colours": [
@@ -7040,7 +7040,7 @@
         },
         {
             "id": "d9464359-036d-515d-9bd1-8888f97e722c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe08e59-fdc4-436f-b05c-6ad386c46310.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/f/dfe08e59-fdc4-436f-b05c-6ad386c46310.jpg?1",
             "name": "Ancient Greenwarden",
             "text": "Reach\nYou may play lands from your graveyard.\nIf a land entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -7076,7 +7076,7 @@
         },
         {
             "id": "4f0e2df4-7c35-5fab-a10f-b1314ce2b456",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74943390-d25f-47cb-90bb-cbf70c87f4a2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/4/74943390-d25f-47cb-90bb-cbf70c87f4a2.jpg?1",
             "name": "Ashaya, Soul of the Wild",
             "text": "Ashaya, Soul of the Wild's power and toughness are each equal to the number of lands you control.\nNontoken creatures you control are Forest lands in addition to their other types. (They're still affected by summoning sickness.)",
             "colours": [
@@ -7114,7 +7114,7 @@
         },
         {
             "id": "5fc410b3-69aa-5409-aad0-bfa838811d7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg?1",
             "name": "Bala Ged Recovery // Bala Ged Sanctuary",
             "text": "Return target card from your graveyard to your hand.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -7146,7 +7146,7 @@
         },
         {
             "id": "5a27401e-98b0-5056-9f43-265ebdb570aa",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/5/c5cb3052-358d-44a7-8cfd-cd31b236494a.jpg?1",
             "name": "Bala Ged Recovery // Bala Ged Sanctuary",
             "text": "Bala Ged Sanctuary enters the battlefield tapped.\n{T}: Add {G}.\n\n\nSorcery\n{2}{G}",
             "colours": [],
@@ -7176,7 +7176,7 @@
         },
         {
             "id": "7b8674e8-659b-5ca6-98b1-2db2734a037e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fc2dfd-85b0-4add-be18-b39549235921.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0fc2dfd-85b0-4add-be18-b39549235921.jpg?1",
             "name": "Broken Wings",
             "text": "Destroy target artifact, enchantment, or creature with flying.",
             "colours": [
@@ -7208,7 +7208,7 @@
         },
         {
             "id": "5cbec624-a214-5810-900e-ec2069421337",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b04160c-89a7-4dcd-b05d-5dc846824d64.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b04160c-89a7-4dcd-b05d-5dc846824d64.jpg?1",
             "name": "Canopy Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Canopy Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -7244,7 +7244,7 @@
         },
         {
             "id": "542ddbd7-39b1-56ea-b2a3-4b446ed8ec2e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab62382d-2dc9-4a60-b031-c845ebad0357.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/b/ab62382d-2dc9-4a60-b031-c845ebad0357.jpg?1",
             "name": "Cragplate Baloth",
             "text": "Kicker {2}{G}\nThis spell can't be countered.\nHexproof, haste\nIf Cragplate Baloth was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -7280,7 +7280,7 @@
         },
         {
             "id": "cac64ccf-e714-5154-9f02-3058c8e6e327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b1b4a2-52a7-4fcd-aa96-f7d9e459657b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52b1b4a2-52a7-4fcd-aa96-f7d9e459657b.jpg?1",
             "name": "Dauntless Survivor",
             "text": "When Dauntless Survivor enters the battlefield, put a +1/+1 counter on target creature.",
             "colours": [
@@ -7315,7 +7315,7 @@
         },
         {
             "id": "7fa3bb33-527a-5dc1-b214-fef991a64fd7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327289d-eed8-44b1-8495-7172e2b49d5f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/7327289d-eed8-44b1-8495-7172e2b49d5f.jpg?1",
             "name": "Gnarlid Colony",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nIf Gnarlid Colony was kicked, it enters the battlefield with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has trample.",
             "colours": [
@@ -7349,7 +7349,7 @@
         },
         {
             "id": "ec61c6b8-292b-59bc-a16b-755c284e1cd9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f644a6-9621-429e-a0a0-4c74d0ecff2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/6/46f644a6-9621-429e-a0a0-4c74d0ecff2e.jpg?1",
             "name": "A-Gnarlid Colony",
             "text": "",
             "colours": [
@@ -7382,7 +7382,7 @@
         },
         {
             "id": "07ad0849-a384-579a-b01a-0ecdba840ad0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2e01e-a143-4b62-8b01-d253fb35c590.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/c/fcd2e01e-a143-4b62-8b01-d253fb35c590.jpg?1",
             "name": "Inscription of Abundance",
             "text": "Kicker {2}{G}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player gains X life, where X is the greatest power among creatures they control.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -7416,7 +7416,7 @@
         },
         {
             "id": "2bb54e1c-50f3-5f27-8f74-b6a03ab76648",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ef641-b08c-42d0-94a5-3054fa7fcebc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/1/214ef641-b08c-42d0-94a5-3054fa7fcebc.jpg?1",
             "name": "Iridescent Hornbeetle",
             "text": "At the beginning of your end step, create a 1/1 green Insect creature token for each +1/+1 counter you've put on creatures under your control this turn.",
             "colours": [
@@ -7450,7 +7450,7 @@
         },
         {
             "id": "734e5608-3cbc-5bbc-bb43-548b8bd5da3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538103da-aa42-436b-8d1a-8f774d005c9a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/538103da-aa42-436b-8d1a-8f774d005c9a.jpg?1",
             "name": "A-Iridescent Hornbeetle",
             "text": "",
             "colours": [
@@ -7483,7 +7483,7 @@
         },
         {
             "id": "a28fc05a-fbdc-58ea-ae1a-107218664cfb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea2c17-382a-45e4-ac34-88bf8ba47169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a1ea2c17-382a-45e4-ac34-88bf8ba47169.jpg?1",
             "name": "Joraga Visionary",
             "text": "When Joraga Visionary enters the battlefield, draw a card.",
             "colours": [
@@ -7518,7 +7518,7 @@
         },
         {
             "id": "7116797b-4b94-550c-ba99-3c0d002a4b4e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Kazandu Mammoth gets +2/+2 until end of turn.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -7554,7 +7554,7 @@
         },
         {
             "id": "7c3af9ec-7098-5de6-b37e-02b0868628a4",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/f/2f632537-63bf-4490-86e6-e6067b9c1a3b.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Kazandu Valley enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElephant\n{1}{G}{G}",
             "colours": [],
@@ -7586,7 +7586,7 @@
         },
         {
             "id": "0d2dd7a9-908d-575e-b391-3033aae3da6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d3f4a-ef83-454e-b8a1-1fc5d5f44be8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c9d3f4a-ef83-454e-b8a1-1fc5d5f44be8.jpg?1",
             "name": "Kazandu Nectarpot",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -7622,7 +7622,7 @@
         },
         {
             "id": "3630473b-9aaf-59f0-9075-3da04b90b44b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afdfe5aa-8b15-4a89-a22a-03baf6afa4e7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/afdfe5aa-8b15-4a89-a22a-03baf6afa4e7.jpg?1",
             "name": "Kazandu Stomper",
             "text": "Trample\nWhen Kazandu Stomper enters the battlefield, return up to two lands you control to their owner's hand.",
             "colours": [
@@ -7656,7 +7656,7 @@
         },
         {
             "id": "70e2e9da-30ca-5b38-9738-01c84cf51dc5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg?1",
             "name": "Khalni Ambush // Khalni Territory",
             "text": "Target creature you control fights target creature you don't control. (Each deals damage equal to its power to the other.)\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -7688,7 +7688,7 @@
         },
         {
             "id": "27426996-767f-545a-808b-1272003b645f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/9/99535539-aa73-41ed-86ab-21c97b92620d.jpg?1",
             "name": "Khalni Ambush // Khalni Territory",
             "text": "Khalni Territory enters the battlefield tapped.\n{T}: Add {G}.\n\n\nInstant\n{2}{G}",
             "colours": [],
@@ -7718,7 +7718,7 @@
         },
         {
             "id": "85245ba1-faf6-5b7c-925c-5d9056cf20d9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b759f0-901f-4be3-93fa-224609b08d48.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/4/a4b759f0-901f-4be3-93fa-224609b08d48.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color.",
             "colours": [
@@ -7754,7 +7754,7 @@
         },
         {
             "id": "416ccd41-0cfc-5235-9bc4-a1233a6a12bf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42914fd9-e56e-4c3e-a445-fdfa45a45178.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/2/42914fd9-e56e-4c3e-a445-fdfa45a45178.jpg?1",
             "name": "Might of Murasa",
             "text": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nTarget creature gets +3/+3 until end of turn. If this spell was kicked, that creature gets +5/+5 until end of turn instead.",
             "colours": [
@@ -7786,7 +7786,7 @@
         },
         {
             "id": "9c0927bd-cea6-55ef-a7d6-ca9322b1773a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe1c5b2-4356-41ae-ab7e-ad9fc835a911.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efe1c5b2-4356-41ae-ab7e-ad9fc835a911.jpg?1",
             "name": "Murasa Brute",
             "text": "",
             "colours": [
@@ -7821,7 +7821,7 @@
         },
         {
             "id": "24c268af-4642-5f2b-bf97-48bd9cb0b591",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53472b7-53da-4833-b7f9-204706dfb721.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/5/f53472b7-53da-4833-b7f9-204706dfb721.jpg?1",
             "name": "Murasa Sproutling",
             "text": "Kicker {1}{G} (You may pay an additional {1}{G} as you cast this spell.)\nWhen Murasa Sproutling enters the battlefield, if it was kicked, return target card with a kicker ability from your graveyard to your hand.",
             "colours": [
@@ -7856,7 +7856,7 @@
         },
         {
             "id": "2ea8424b-129c-5b24-a638-ae36bbc03474",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd37ea0e-ff72-4522-aa5b-d46bff832a34.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd37ea0e-ff72-4522-aa5b-d46bff832a34.jpg?1",
             "name": "Nissa's Zendikon",
             "text": "Enchant land\nEnchanted land is a 4/4 Elemental creature with reach and haste. It's still a land.\nWhen enchanted land dies, return that card to its owner's hand.",
             "colours": [
@@ -7890,7 +7890,7 @@
         },
         {
             "id": "6ed2eb75-a324-515e-9ee4-6a3a10d1efbe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2ad967-dd77-4c3a-b53c-2929ecf7750f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/d/fd2ad967-dd77-4c3a-b53c-2929ecf7750f.jpg?1",
             "name": "Oran-Rief Ooze",
             "text": "When Oran-Rief Ooze enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Oran-Rief Ooze attacks, put a +1/+1 counter on each attacking creature with a +1/+1 counter on it.",
             "colours": [
@@ -7926,7 +7926,7 @@
         },
         {
             "id": "27fc283e-887b-5c06-a6b0-b37a975252d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52abea40-2736-49a8-a372-16b7b93d510a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/2/52abea40-2736-49a8-a372-16b7b93d510a.jpg?1",
             "name": "A-Oran-Rief Ooze",
             "text": "",
             "colours": [
@@ -7959,7 +7959,7 @@
         },
         {
             "id": "6f1d3541-b056-5b97-9ffa-fe283eb53e2d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe3fab-6d13-4603-8a21-8a3c2a0d9e08.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/effe3fab-6d13-4603-8a21-8a3c2a0d9e08.jpg?1",
             "name": "Rabid Bite",
             "text": "Target creature you control deals damage equal to its power to target creature you don't control.",
             "colours": [
@@ -7991,7 +7991,7 @@
         },
         {
             "id": "efa6966e-1b65-59fc-bd2f-1075b3052577",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805faf2e-97dc-4b77-bc02-a4cae980f041.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/0/805faf2e-97dc-4b77-bc02-a4cae980f041.jpg?1",
             "name": "Reclaim the Wastes",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nSearch your library for a basic land card, reveal it, put it into your hand, then shuffle your library. If this spell was kicked, search your library for two basic land cards instead of one.",
             "colours": [
@@ -8023,7 +8023,7 @@
         },
         {
             "id": "7ef6cffb-335a-5831-8319-20b6a020f1c4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa259096-b24f-414c-af59-301bed4b4627.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa259096-b24f-414c-af59-301bed4b4627.jpg?1",
             "name": "Roiling Regrowth",
             "text": "Sacrifice a land. Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.",
             "colours": [
@@ -8057,7 +8057,7 @@
         },
         {
             "id": "fc03eaaa-bdfa-5121-9ffd-9e1d250382df",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e781d6ad-950e-49bf-9645-e2354086ae49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e781d6ad-950e-49bf-9645-e2354086ae49.jpg?1",
             "name": "Scale the Heights",
             "text": "Put a +1/+1 counter on up to one target creature. You gain 2 life. You may play an additional land this turn.\nDraw a card.",
             "colours": [
@@ -8089,7 +8089,7 @@
         },
         {
             "id": "7930cea5-8e5a-521d-92ad-0ac5e89b604c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f42823-8a48-4b81-a037-664ba1c69f29.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61f42823-8a48-4b81-a037-664ba1c69f29.jpg?1",
             "name": "Scute Swarm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 1/1 green Insect creature token. If you control six or more lands, create a token that's a copy of Scute Swarm instead.",
             "colours": [
@@ -8125,7 +8125,7 @@
         },
         {
             "id": "60fc1701-a723-58f0-96de-c21c9e0c98bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965a54b-8b22-418c-9a0d-bf154932f2e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/9/9965a54b-8b22-418c-9a0d-bf154932f2e2.jpg?1",
             "name": "Skyclave Pick-Axe",
             "text": "When Skyclave Pick-Axe enters the battlefield, attach it to target creature you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {2}{G}",
             "colours": [
@@ -8161,7 +8161,7 @@
         },
         {
             "id": "e0d350f2-2e72-583d-8123-dd28a4a32928",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d822730-6d81-4dbc-a3c3-ce96d29a1078.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/d/8d822730-6d81-4dbc-a3c3-ce96d29a1078.jpg?1",
             "name": "Springmantle Cleric",
             "text": "Springmantle Cleric enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.",
             "colours": [
@@ -8196,7 +8196,7 @@
         },
         {
             "id": "0e34b99a-5e5d-5187-b9eb-5d6cf4030641",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090b3da4-c942-480e-9997-bb9c20e8d62d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/090b3da4-c942-480e-9997-bb9c20e8d62d.jpg?1",
             "name": "Strength of Solidarity",
             "text": "Choose target creature you control. Put a +1/+1 counter on it for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [
@@ -8228,7 +8228,7 @@
         },
         {
             "id": "6a084be6-b0db-5521-afbd-c772afa72c3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7e4f99-ece4-473e-b712-40e4c53558e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a7e4f99-ece4-473e-b712-40e4c53558e8.jpg?1",
             "name": "Swarm Shambler",
             "text": "Swarm Shambler enters the battlefield with a +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.\n{1}, {T}: Put a +1/+1 counter on Swarm Shambler.",
             "colours": [
@@ -8265,7 +8265,7 @@
         },
         {
             "id": "b5d84c08-0d16-5520-a819-1e11dff1cca5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d6020-6767-406c-bf28-6b3e9ae72f50.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/f/7f3d6020-6767-406c-bf28-6b3e9ae72f50.jpg?1",
             "name": "Tajuru Blightblade",
             "text": "Deathtouch",
             "colours": [
@@ -8300,7 +8300,7 @@
         },
         {
             "id": "cbcc15f4-7db2-5e22-866c-362f916e11ab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a045dd0f-953a-4022-8f29-0758f2b6ccaa.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/0/a045dd0f-953a-4022-8f29-0758f2b6ccaa.jpg?1",
             "name": "Tajuru Paragon",
             "text": "Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.\nKicker {3}\nWhen Tajuru Paragon enters the battlefield, if it was kicked, reveal the top six cards of your library. You may put a card that shares a creature type with it from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -8336,7 +8336,7 @@
         },
         {
             "id": "38f41bd1-411e-551a-a05c-4bea756120d8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1894cf9-7d53-4b7e-aaae-8db42bdd8e49.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e1894cf9-7d53-4b7e-aaae-8db42bdd8e49.jpg?1",
             "name": "Tajuru Snarecaster",
             "text": "Reach",
             "colours": [
@@ -8371,7 +8371,7 @@
         },
         {
             "id": "9b9ee2cb-4f20-573a-86d4-fe43209a310f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg?1",
             "name": "Tangled Florahedron // Tangled Vale",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -8405,7 +8405,7 @@
         },
         {
             "id": "6f56a117-5df1-50b0-be53-c18842f847f3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/3/235d1ffc-72aa-40a2-95dc-3f6a8d495061.jpg?1",
             "name": "Tangled Florahedron // Tangled Vale",
             "text": "Tangled Vale enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElemental\n{1}{G}",
             "colours": [],
@@ -8435,7 +8435,7 @@
         },
         {
             "id": "737c795d-701c-544c-9779-3a05489ff2c7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f8996-bf72-4e55-944f-5b8202b6068c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca6f8996-bf72-4e55-944f-5b8202b6068c.jpg?1",
             "name": "Taunting Arbormage",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nWhen Taunting Arbormage enters the battlefield, if it was kicked, all creatures able to block target creature this turn do so.",
             "colours": [
@@ -8470,7 +8470,7 @@
         },
         {
             "id": "5447072f-af3d-5a7f-a8d6-207329848d3a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e0f725c-8d1f-47ff-ad81-a5007199a5e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/e/5e0f725c-8d1f-47ff-ad81-a5007199a5e2.jpg?1",
             "name": "Territorial Scythecat",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Territorial Scythecat.",
             "colours": [
@@ -8506,7 +8506,7 @@
         },
         {
             "id": "4a4817f5-7f77-56f0-86a9-57d859ae87ad",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b6922-2584-43e1-98d4-e722e7c9393c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b33b6922-2584-43e1-98d4-e722e7c9393c.jpg?1",
             "name": "Turntimber Ascetic",
             "text": "When Turntimber Ascetic enters the battlefield, you gain 3 life.",
             "colours": [
@@ -8541,7 +8541,7 @@
         },
         {
             "id": "01d98db6-acc5-5fed-ad07-050bf80c26ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. If that card has converted mana cost 3 or less, it enters with three additional +1/+1 counters on it. Put the rest on the bottom of your library in a random order.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -8575,7 +8575,7 @@
         },
         {
             "id": "b37eea80-116a-5b82-86c6-51962f4eb7d1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "As Turntimber, Serpentine Wood enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.\n\n\nSorcery\n{4}{G}{G}{G}",
             "colours": [],
@@ -8607,7 +8607,7 @@
         },
         {
             "id": "fd9fea99-a02c-5357-bc14-f8c9575d1d65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg?1",
             "name": "Vastwood Fortification // Vastwood Thicket",
             "text": "Put a +1/+1 counter on target creature.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -8639,7 +8639,7 @@
         },
         {
             "id": "e4bff9ce-8ce4-5e04-8884-fb433696f4b9",
-            "imageUrl": "https://cards.scryfall.io/normal/back/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/3/a/3a7fd24e-84d8-405d-86e4-0571a9e23cc2.jpg?1",
             "name": "Vastwood Fortification // Vastwood Thicket",
             "text": "Vastwood Thicket enters the battlefield tapped.\n{T}: Add {G}.\n\n\nInstant\n{G}",
             "colours": [],
@@ -8669,7 +8669,7 @@
         },
         {
             "id": "a918645b-4f30-5005-9f13-d51aab298868",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6974363c-0d0d-4270-a25e-ab84b0c03f4e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6974363c-0d0d-4270-a25e-ab84b0c03f4e.jpg?1",
             "name": "Vastwood Surge",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nSearch your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library. If this spell was kicked, put two +1/+1 counters on each creature you control.",
             "colours": [
@@ -8701,7 +8701,7 @@
         },
         {
             "id": "40045e21-d8ed-5a18-ace0-ac1216ef5405",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e524ddf0-9a2f-4c1c-ae72-4b5b48f55645.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/5/e524ddf0-9a2f-4c1c-ae72-4b5b48f55645.jpg?1",
             "name": "Veteran Adventurer",
             "text": "Veteran Adventurer is also a Cleric, Rogue, Warrior, and Wizard.\nThis spell costs {1} less to cast for each creature in your party.\nVigilance",
             "colours": [
@@ -8735,7 +8735,7 @@
         },
         {
             "id": "aadf7487-1cdd-5271-a3e2-a83b7bf1b7ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6f9984-dec7-4a1f-91d6-1e85b5df5e4c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/a/7a6f9984-dec7-4a1f-91d6-1e85b5df5e4c.jpg?1",
             "name": "Vine Gecko",
             "text": "The first kicked spell you cast each turn costs {1} less to cast.\nWhenever you cast a kicked spell, put a +1/+1 counter on Vine Gecko.",
             "colours": [
@@ -8770,7 +8770,7 @@
         },
         {
             "id": "92640531-043c-5de7-9455-298c8715cf7f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e42511-f653-4a6f-a5d4-50e21dfc8077.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/69e42511-f653-4a6f-a5d4-50e21dfc8077.jpg?1",
             "name": "Akiri, Fearless Voyager",
             "text": "Whenever you attack a player with one or more equipped creatures, draw a card.\n{W}: You may unattach an Equipment from a creature you control. If you do, tap that creature and it gains indestructible until end of turn.",
             "colours": [
@@ -8811,7 +8811,7 @@
         },
         {
             "id": "74e7d5ff-5e9e-56e0-ba85-6e74861f81cd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc448f6-a7fe-47c4-ac7c-385a77326469.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/f/8fc448f6-a7fe-47c4-ac7c-385a77326469.jpg?1",
             "name": "Brushfire Elemental",
             "text": "Haste\nBrushfire Elemental can't be blocked by creatures with power 2 or less.\nLandfall \u2014 Whenever a land enters the battlefield under your control, Brushfire Elemental gets +2/+2 until end of turn.",
             "colours": [
@@ -8849,7 +8849,7 @@
         },
         {
             "id": "14fdfbef-e73e-5a01-bc5c-8fffc2693d59",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953db280-6999-4b91-bc40-c6e7f7dd13ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/953db280-6999-4b91-bc40-c6e7f7dd13ef.jpg?1",
             "name": "Cleric of Life's Bond",
             "text": "Whenever another Cleric enters the battlefield under your control, you gain 1 life.\nWhenever you gain life for the first time each turn, put a +1/+1 counter on Cleric of Life's Bond.",
             "colours": [
@@ -8886,7 +8886,7 @@
         },
         {
             "id": "b7a2baeb-e50b-584e-8225-9797048ebaef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd227384-e0e3-40ce-98bb-8b7cf1900ad7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/d/bd227384-e0e3-40ce-98bb-8b7cf1900ad7.jpg?1",
             "name": "Grakmaw, Skyclave Ravager",
             "text": "Grakmaw, Skyclave Ravager enters the battlefield with three +1/+1 counters on it.\nWhenever another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on Grakmaw.\nWhen Grakmaw dies, create an X/X black and green Hydra creature token, where X is the number of +1/+1 counters on Grakmaw.",
             "colours": [
@@ -8927,7 +8927,7 @@
         },
         {
             "id": "f3434acf-7796-572c-a889-487c84cf7948",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f921dca-ce93-42d1-87b1-149973558467.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/f/6f921dca-ce93-42d1-87b1-149973558467.jpg?1",
             "name": "Kargan Warleader",
             "text": "Other Warriors you control get +1/+1.",
             "colours": [
@@ -8966,7 +8966,7 @@
         },
         {
             "id": "dbc5f0ea-7bed-5d69-a639-a2ee6c8aa78a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d44c40-cdd0-42d5-a250-e7d95ae926c0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13d44c40-cdd0-42d5-a250-e7d95ae926c0.jpg?1",
             "name": "A-Kargan Warleader",
             "text": "",
             "colours": [
@@ -9002,7 +9002,7 @@
         },
         {
             "id": "866edde7-ea78-5b96-aed9-e7d3c5f980aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6bc333-79c0-4de8-9874-80f2254f9ad2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af6bc333-79c0-4de8-9874-80f2254f9ad2.jpg?1",
             "name": "Kaza, Roil Chaser",
             "text": "Flying, haste\n{T}: The next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of Wizards you control as this ability resolves.",
             "colours": [
@@ -9043,7 +9043,7 @@
         },
         {
             "id": "39ef7d4c-e9ec-507b-8c3b-aadb90a43490",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b66956-82e1-402f-9088-2201bdc0d4b8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49b66956-82e1-402f-9088-2201bdc0d4b8.jpg?1",
             "name": "Linvala, Shield of Sea Gate",
             "text": "Flying\nAt the beginning of combat on your turn, if you have a full party, choose target nonland permanent an opponent controls. Until your next turn, it can't attack or block, and its activated abilities can't be activated.\nSacrifice Linvala: Choose hexproof or indestructible. Creatures you control gain that ability until end of turn.",
             "colours": [
@@ -9084,7 +9084,7 @@
         },
         {
             "id": "f05ab4a8-f4ec-5406-969e-9951be880fab",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31a81e8-df0e-4540-93c1-c30c31ea9be9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/3/b31a81e8-df0e-4540-93c1-c30c31ea9be9.jpg?1",
             "name": "Lullmage's Familiar",
             "text": "{T}: Add {G} or {U}.\nWhenever you cast a kicked spell, you gain 2 life.",
             "colours": [
@@ -9120,7 +9120,7 @@
         },
         {
             "id": "b292a2a1-fee9-5725-82d3-09ccb7d519ed",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a445dc-3aea-4281-a145-0ab3a28ec6c6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a445dc-3aea-4281-a145-0ab3a28ec6c6.jpg?1",
             "name": "Moss-Pit Skeleton",
             "text": "Kicker {3} (You may pay an additional {3} as you cast this spell.)\nIf Moss-Pit Skeleton was kicked, it enters the battlefield with three +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on a creature you control, if Moss-Pit Skeleton is in your graveyard, you may put Moss-Pit Skeleton on top of your library.",
             "colours": [
@@ -9157,7 +9157,7 @@
         },
         {
             "id": "7750b55c-d734-5d12-86f4-f86fafde4a1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd748df0-b7af-4438-b567-5fabe0731438.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/d/dd748df0-b7af-4438-b567-5fabe0731438.jpg?1",
             "name": "A-Moss-Pit Skeleton",
             "text": "",
             "colours": [
@@ -9193,7 +9193,7 @@
         },
         {
             "id": "903377a4-e1aa-57f9-a479-e6a9e9f21368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b3b78-9bdc-449b-82a9-c2fc3dd7f120.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e70b3b78-9bdc-449b-82a9-c2fc3dd7f120.jpg?1",
             "name": "Murasa Rootgrazer",
             "text": "Vigilance\n{T}: You may put a basic land card from your hand onto the battlefield.\n{T}: Return target basic land you control to its owner's hand.",
             "colours": [
@@ -9229,7 +9229,7 @@
         },
         {
             "id": "42158c39-091a-5392-9379-823e17cf011c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408be425-b8a6-4c03-b2a6-7ff7bd6555e0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/408be425-b8a6-4c03-b2a6-7ff7bd6555e0.jpg?1",
             "name": "Nahiri, Heir of the Ancients",
             "text": "+1: Create a 1/1 white Kor Warrior creature token. You may attach an Equipment you control to it.\n\u22122: Look at the top six cards of your library. You may reveal a Warrior or Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Nahiri, Heir of the Ancients deals damage to target creature or planeswalker equal to twice the number of Equipment you control.",
             "colours": [
@@ -9269,7 +9269,7 @@
         },
         {
             "id": "97555cf3-7fe0-5f54-b580-112bbb3437b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e33233-fc29-489b-bcf4-fa7d771db0cc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/02e33233-fc29-489b-bcf4-fa7d771db0cc.jpg?1",
             "name": "A-Nahiri, Heir of the Ancients",
             "text": "",
             "colours": [
@@ -9306,7 +9306,7 @@
         },
         {
             "id": "143d09da-3fe5-588d-a004-1e1a6dd69ba1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d69f943-d474-47c0-bc6b-1b247a5dd6f3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d69f943-d474-47c0-bc6b-1b247a5dd6f3.jpg?1",
             "name": "Nissa of Shadowed Boughs",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a loyalty counter on Nissa of Shadowed Boughs.\n+1: Untap target land you control. You may have it become a 3/3 Elemental creature with haste and menace until end of turn. It's still a land.\n\u22125: You may put a creature card with converted mana cost less than or equal to the number of lands you control onto the battlefield from your hand or graveyard with two +1/+1 counters on it.",
             "colours": [
@@ -9346,7 +9346,7 @@
         },
         {
             "id": "815c6d28-81bb-5c0d-99cb-e0dd7bced29e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4fb50c-a81f-44d3-93c5-fa9a0b37f617.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/e/4e4fb50c-a81f-44d3-93c5-fa9a0b37f617.jpg?1",
             "name": "Omnath, Locus of Creation",
             "text": "When Omnath, Locus of Creation enters the battlefield, draw a card.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, Omnath deals 4 damage to each opponent and each planeswalker you don't control.",
             "colours": [
@@ -9390,7 +9390,7 @@
         },
         {
             "id": "9d995a92-bc5c-5dcf-87ee-cb1d85cd113b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f5fbd5-b045-4da7-a996-54f163b35b8d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5f5fbd5-b045-4da7-a996-54f163b35b8d.jpg?1",
             "name": "A-Omnath, Locus of Creation",
             "text": "",
             "colours": [
@@ -9431,7 +9431,7 @@
         },
         {
             "id": "c17b8231-1fbd-5c52-8653-ed1b31b361fe",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336c8bf-fcad-41f9-9041-80b8aa3cd79a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2336c8bf-fcad-41f9-9041-80b8aa3cd79a.jpg?1",
             "name": "Orah, Skyclave Hierophant",
             "text": "Lifelink\nWhenever Orah, Skyclave Hierophant or another Cleric you control dies, return target Cleric card with lesser converted mana cost from your graveyard to the battlefield.",
             "colours": [
@@ -9473,7 +9473,7 @@
         },
         {
             "id": "20fcd345-f48e-5cc7-9902-be2f723bd386",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af88c9-70ca-484c-bddf-b705e0ea7bc7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/7/e7af88c9-70ca-484c-bddf-b705e0ea7bc7.jpg?1",
             "name": "Phylath, World Sculptor",
             "text": "When Phylath, World Sculptor enters the battlefield, create a 0/1 green Plant creature token for each basic land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, put four +1/+1 counters on target Plant you control.",
             "colours": [
@@ -9513,7 +9513,7 @@
         },
         {
             "id": "cde3abea-d57f-5aeb-8305-38b61335d21c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c4a2f5-b942-4c94-b28c-e04d0609cfb3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/0/e0c4a2f5-b942-4c94-b28c-e04d0609cfb3.jpg?1",
             "name": "A-Phylath, World Sculptor",
             "text": "",
             "colours": [
@@ -9550,7 +9550,7 @@
         },
         {
             "id": "da12cbef-13f4-5e21-a381-f03bebe067c9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af484140-57d6-4505-9960-5e7b0306cc9b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/f/af484140-57d6-4505-9960-5e7b0306cc9b.jpg?1",
             "name": "Ravager's Mace",
             "text": "When Ravager's Mace enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+0 for each creature in your party and has menace. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nEquip {2}{B}{R}",
             "colours": [
@@ -9586,7 +9586,7 @@
         },
         {
             "id": "f11616b0-805e-5201-843b-cc806c9ab304",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d73c9c4-8955-499f-8f87-6500b35b4977.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d73c9c4-8955-499f-8f87-6500b35b4977.jpg?1",
             "name": "Soaring Thought-Thief",
             "text": "Flash\nFlying\nAs long as an opponent has eight or more cards in their graveyard, Rogues you control get +1/+0.\nWhenever one or more Rogues you control attack, each opponent mills two cards.",
             "colours": [
@@ -9623,7 +9623,7 @@
         },
         {
             "id": "985471ec-473a-5032-a104-395da40a8589",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3b1ef0-a653-4adb-8112-82d4822446b4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b3b1ef0-a653-4adb-8112-82d4822446b4.jpg?1",
             "name": "Spoils of Adventure",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)\nYou gain 3 life and draw three cards.",
             "colours": [
@@ -9657,7 +9657,7 @@
         },
         {
             "id": "49f713e2-972a-5a50-a250-ccc04220bd08",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb979cfc-3e5b-42c9-b78d-584c274ed912.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb979cfc-3e5b-42c9-b78d-584c274ed912.jpg?1",
             "name": "Umara Mystic",
             "text": "Flying\nWhenever you cast an instant, sorcery, or Wizard spell, Umara Mystic gets +2/+0 until end of turn.",
             "colours": [
@@ -9694,7 +9694,7 @@
         },
         {
             "id": "4acf2687-ac7d-57cf-adf3-9c18a94a2753",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559ebc64-3412-413f-8ef3-f058a0d60f33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/5/559ebc64-3412-413f-8ef3-f058a0d60f33.jpg?1",
             "name": "A-Umara Mystic",
             "text": "",
             "colours": [
@@ -9730,7 +9730,7 @@
         },
         {
             "id": "d49a3cb8-6f6f-5339-bd4e-8cf85e03294f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752a2aa9-40ed-4c64-b945-bc6fec606b7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/5/752a2aa9-40ed-4c64-b945-bc6fec606b7b.jpg?1",
             "name": "Verazol, the Split Current",
             "text": "Verazol, the Split Current enters the battlefield with a +1/+1 counter on it for each mana spent to cast it.\nWhenever you cast a kicked spell, you may remove two +1/+1 counters from Verazol. If you do, copy that spell. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
             "colours": [
@@ -9770,7 +9770,7 @@
         },
         {
             "id": "ca63f098-759e-5d62-b5ee-0db862f41f48",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12878fbd-dbe5-44bc-9f34-38fd374ec10a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/2/12878fbd-dbe5-44bc-9f34-38fd374ec10a.jpg?1",
             "name": "Yasharn, Implacable Earth",
             "text": "When Yasharn enters the battlefield, search your library for a basic Forest card and a basic Plains card, reveal those cards, put them into your hand, then shuffle your library.\nPlayers can't pay life or sacrifice nonland permanents to cast spells or activate abilities.",
             "colours": [
@@ -9811,7 +9811,7 @@
         },
         {
             "id": "525b57a0-036f-51af-bb73-dd1eb6bd8203",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81448c-f87b-4ca1-b951-b359216ab1d0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/c/ac81448c-f87b-4ca1-b951-b359216ab1d0.jpg?1",
             "name": "Zagras, Thief of Heartbeats",
             "text": "This spell costs {1} less to cast for each creature in your party.\nFlying, deathtouch, haste\nOther creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -9852,7 +9852,7 @@
         },
         {
             "id": "eb9d9c5a-3939-5f33-8781-2389f1383e87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfe4fbe-277f-410c-9eee-f7617f4cb850.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/c/9cfe4fbe-277f-410c-9eee-f7617f4cb850.jpg?1",
             "name": "Zareth San, the Trickster",
             "text": "Flash\n{2}{U}{B}, Return an unblocked attacking Rogue you control to its owner's hand: Put Zareth San, the Trickster from your hand onto the battlefield tapped and attacking.\nWhenever Zareth San deals combat damage to a player, you may put target permanent card from that player's graveyard onto the battlefield under your control.",
             "colours": [
@@ -9893,7 +9893,7 @@
         },
         {
             "id": "b8c785d9-9996-565a-bf1b-f3a3a8e77d0d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eebf8f67-49d0-42de-a5cc-ad13d19d2c55.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/e/eebf8f67-49d0-42de-a5cc-ad13d19d2c55.jpg?1",
             "name": "Cliffhaven Kitesail",
             "text": "When Cliffhaven Kitesail enters the battlefield, attach it to target creature you control.\nEquipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -9923,7 +9923,7 @@
         },
         {
             "id": "8c8728b6-c369-5d10-896e-3ec0967bbe1e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33568871-dab0-4c09-b9f0-0ae78a46a06d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/3/33568871-dab0-4c09-b9f0-0ae78a46a06d.jpg?1",
             "name": "Forsaken Monument",
             "text": "Colorless creatures you control get +2/+2.\nWhenever you tap a permanent for {C}, add an additional {C}.\nWhenever you cast a colorless spell, you gain 2 life.",
             "colours": [],
@@ -9955,7 +9955,7 @@
         },
         {
             "id": "798c7a62-d5cc-51a9-9a7c-c63cdd8f79f3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6683416a-5820-4cd0-b28a-60a53239e9ef.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/6/6683416a-5820-4cd0-b28a-60a53239e9ef.jpg?1",
             "name": "Lithoform Engine",
             "text": "{2}, {T}: Copy target activated or triggered ability you control. You may choose new targets for the copy.\n{3}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}, {T}: Copy target permanent spell you control. (The copy becomes a token.)",
             "colours": [],
@@ -9987,7 +9987,7 @@
         },
         {
             "id": "266b4838-deb2-5cdc-88b1-ab16712a30f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1de4-9aba-4145-804d-2072f258af3b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/b/db9b1de4-9aba-4145-804d-2072f258af3b.jpg?1",
             "name": "Myriad Construct",
             "text": "Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.",
             "colours": [],
@@ -10020,7 +10020,7 @@
         },
         {
             "id": "d4c8282d-60bf-57bd-9dbc-66e0dc501a78",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab97a84-fe8c-4986-afd8-3abdcc029f7f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/a/0ab97a84-fe8c-4986-afd8-3abdcc029f7f.jpg?1",
             "name": "Relic Amulet",
             "text": "Whenever you cast an instant, sorcery, or Wizard spell, put a charge counter on Relic Amulet.\n{2}, {T}, Remove all charge counters from Relic Amulet: It deals that much damage to target creature.",
             "colours": [],
@@ -10048,7 +10048,7 @@
         },
         {
             "id": "923ad797-50a9-5272-a6b2-058a6b024db9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8705e3-0e44-45c9-bcdf-c24507b038fe.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca8705e3-0e44-45c9-bcdf-c24507b038fe.jpg?1",
             "name": "Relic Axe",
             "text": "When Relic Axe enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1. If it's a Warrior, it gets +2/+1 instead.\nEquip {2}",
             "colours": [],
@@ -10078,7 +10078,7 @@
         },
         {
             "id": "530eb0dc-e169-55c1-b844-d300b6516ed9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b59c75b-d8f8-4f95-9030-ed73c67d988e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/b/0b59c75b-d8f8-4f95-9030-ed73c67d988e.jpg?1",
             "name": "Relic Golem",
             "text": "Relic Golem can't attack or block unless an opponent has eight or more cards in their graveyard.\n{2}, {T}: Target player mills two cards. (They put the top two cards of their library into their graveyard.)",
             "colours": [],
@@ -10109,7 +10109,7 @@
         },
         {
             "id": "427d0306-238a-52d4-b0bd-87973432683e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9ae607-e0bc-4415-ad58-65944848bbe9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/b/4b9ae607-e0bc-4415-ad58-65944848bbe9.jpg?1",
             "name": "Relic Vial",
             "text": "{2}, {T}, Sacrifice a creature: Draw a card.\nAs long as you control a Cleric, Relic Vial has \"Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\"",
             "colours": [],
@@ -10137,7 +10137,7 @@
         },
         {
             "id": "75d703db-274d-5239-82a6-fba47a3fa69f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04fd8e8-ee8d-4cb7-87ab-955303c46ece.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b04fd8e8-ee8d-4cb7-87ab-955303c46ece.jpg?1",
             "name": "Sea Gate Colossus",
             "text": "This spell costs {1} less to cast for each creature in your party. (Your party consists of up to one each of Cleric, Rogue, Warrior, and Wizard.)",
             "colours": [],
@@ -10169,7 +10169,7 @@
         },
         {
             "id": "ba20b3d8-eb35-592d-b0d0-afdeb0145108",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20259dff-4984-4d0b-aa49-34f3aaf31e3a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/0/20259dff-4984-4d0b-aa49-34f3aaf31e3a.jpg?1",
             "name": "Skyclave Relic",
             "text": "Kicker {3}\nIndestructible\nWhen Skyclave Relic enters the battlefield, if it was kicked, create two tapped tokens that are copies of Skyclave Relic.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -10199,7 +10199,7 @@
         },
         {
             "id": "c80ad8a0-aaf0-5d4d-8579-a94c7f5f20af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8809a-77cd-4090-8a89-12121a8da676.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fac8809a-77cd-4090-8a89-12121a8da676.jpg?1",
             "name": "Skyclave Sentinel",
             "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nFlying, defender\nIf Skyclave Sentinel was kicked, it enters the battlefield with two +1/+1 counters on it.\nAs long as Skyclave Sentinel has a +1/+1 counter on it, it can attack as though it didn't have defender.",
             "colours": [],
@@ -10230,7 +10230,7 @@
         },
         {
             "id": "e51c3a28-5719-5f1f-856a-ccdadf9411e5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53baf25-1782-427b-a9dd-fc9b8dc6444f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/5/a53baf25-1782-427b-a9dd-fc9b8dc6444f.jpg?1",
             "name": "Spare Supplies",
             "text": "Spare Supplies enters the battlefield tapped.\nWhen Spare Supplies enters the battlefield, draw a card.\n{2}, {T}, Sacrifice Spare Supplies: Draw a card.",
             "colours": [],
@@ -10258,7 +10258,7 @@
         },
         {
             "id": "51c154c6-a67b-56bb-9713-c2b10b936e4f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29e17ba-d584-4296-9f43-17467edaa25f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a29e17ba-d584-4296-9f43-17467edaa25f.jpg?1",
             "name": "Stonework Packbeast",
             "text": "Stonework Packbeast is also a Cleric, Rogue, Warrior, and Wizard.\n{2}: Add one mana of any color.",
             "colours": [],
@@ -10289,7 +10289,7 @@
         },
         {
             "id": "4c3776b8-e3fb-5dd9-9a6b-8bdcc6943fb2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5c781d-cd89-4671-8fbe-fae82c33357b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e5c781d-cd89-4671-8fbe-fae82c33357b.jpg?1",
             "name": "Utility Knife",
             "text": "When Utility Knife enters the battlefield, attach it to target creature you control.\nEquipped creature gets +1/+1.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
             "colours": [],
@@ -10319,7 +10319,7 @@
         },
         {
             "id": "ffa1ae56-535f-51de-8455-2cd52335abee",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc85412e-333d-4e7d-8c85-40618cf1b6c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/c/dc85412e-333d-4e7d-8c85-40618cf1b6c2.jpg?1",
             "name": "Base Camp",
             "text": "Base Camp enters the battlefield tapped.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Cleric, Rogue, Warrior, or Wizard spell or to activate an ability of a Cleric, Rogue, Warrior, or Wizard.",
             "colours": [],
@@ -10347,7 +10347,7 @@
         },
         {
             "id": "cd9ac675-aeaa-55cc-b33a-4b00a580ec5c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56f7e2a-150c-4daa-811c-a0347ff850bf.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b56f7e2a-150c-4daa-811c-a0347ff850bf.jpg?1",
             "name": "A-Base Camp",
             "text": "",
             "colours": [],
@@ -10374,7 +10374,7 @@
         },
         {
             "id": "6072997d-fb42-5bc9-b7ee-b82f00165c4d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10407,7 +10407,7 @@
         },
         {
             "id": "239da818-3951-5513-bb3c-e3deedae10d2",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -10440,7 +10440,7 @@
         },
         {
             "id": "14a82225-1e50-5ba9-b4fe-c1b23d9b869c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -10473,7 +10473,7 @@
         },
         {
             "id": "79ef228a-7fb6-5043-9f0f-ac02a09ce92c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10506,7 +10506,7 @@
         },
         {
             "id": "4aecc7ae-e72d-53f4-b7d6-b07099cb28f6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {B}.",
             "colours": [],
@@ -10539,7 +10539,7 @@
         },
         {
             "id": "386b656e-9795-5656-a79a-98c8a3e7398c",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -10572,7 +10572,7 @@
         },
         {
             "id": "85d7e791-1aa2-50d9-ad8b-d9bed3f500aa",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {G}.",
             "colours": [],
@@ -10605,7 +10605,7 @@
         },
         {
             "id": "dc222dc4-d430-5485-8b44-fd75d8608aa8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -10638,7 +10638,7 @@
         },
         {
             "id": "95c20144-a11c-5b20-b5b9-206c907eb9d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0e025-7a75-4641-a51a-27df9dcde05f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7bd0e025-7a75-4641-a51a-27df9dcde05f.jpg?1",
             "name": "Crawling Barrens",
             "text": "{T}: Add {C}.\n{4}: Put two +1/+1 counters on Crawling Barrens. Then you may have it become a 0/0 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -10668,7 +10668,7 @@
         },
         {
             "id": "94b0d788-b3e1-5d16-9417-6eb676a10368",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -10702,7 +10702,7 @@
         },
         {
             "id": "47632a4c-8baa-59af-8669-8e692748eaf8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -10736,7 +10736,7 @@
         },
         {
             "id": "b444c54f-a0fe-5c23-b89a-5ff49adab445",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -10769,7 +10769,7 @@
         },
         {
             "id": "1cb8e283-5796-548c-af19-c44d9ac863e0",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {R}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -10802,7 +10802,7 @@
         },
         {
             "id": "a1119869-e9b5-5e0e-af8f-da00eea52b25",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a0563e-c83b-40df-abf6-51c83bf6792d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d5a0563e-c83b-40df-abf6-51c83bf6792d.jpg?1",
             "name": "Throne of Makindi",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a charge counter on Throne of Makindi.\n{T}, Remove a charge counter from Throne of Makindi: Add two mana of any one color. Spend this mana only to cast kicked spells.",
             "colours": [],
@@ -10832,7 +10832,7 @@
         },
         {
             "id": "5c4273d7-d8c6-5bbb-bbe2-365d45378d66",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591fd15-78d9-4089-a075-031ab2affd2d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/9591fd15-78d9-4089-a075-031ab2affd2d.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10870,7 +10870,7 @@
         },
         {
             "id": "e94465e5-39c4-56f3-b6bd-294805b2db3b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665190e-ea2a-498e-9c4f-f0bc514bd80c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/5665190e-ea2a-498e-9c4f-f0bc514bd80c.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10908,7 +10908,7 @@
         },
         {
             "id": "341e8922-05d7-59aa-84bf-a387dd34f79b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d918248-85ff-4fea-ac91-aa5466dd2829.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/d/5d918248-85ff-4fea-ac91-aa5466dd2829.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -10946,7 +10946,7 @@
         },
         {
             "id": "945fd1a5-d0e9-5f85-be86-654dcc7f1d8d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea783b-adaa-47be-9918-ca2f161c5d9e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/7/77ea783b-adaa-47be-9918-ca2f161c5d9e.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -10984,7 +10984,7 @@
         },
         {
             "id": "1e2b8e90-5158-5992-a792-a492b8b8c9ff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb695ab9-72dc-4b07-b42d-e2109a5254b6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/b/bb695ab9-72dc-4b07-b42d-e2109a5254b6.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11022,7 +11022,7 @@
         },
         {
             "id": "e6c1b9fa-bd00-5c5d-bd24-b1bb81d15929",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba4b3ad-1aef-44d3-889a-aedd9e070975.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/b/1ba4b3ad-1aef-44d3-889a-aedd9e070975.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -11060,7 +11060,7 @@
         },
         {
             "id": "4b6c32d3-1277-56a3-8da0-dbf098b48c23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a58ce4-e07f-4c9c-98ae-3173d6d63cc5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95a58ce4-e07f-4c9c-98ae-3173d6d63cc5.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11098,7 +11098,7 @@
         },
         {
             "id": "7c91ca01-5bcc-5639-839a-1421d18ab3ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26142ae3-5aa1-4b9b-989a-21c0e4e5089d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/6/26142ae3-5aa1-4b9b-989a-21c0e4e5089d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11136,7 +11136,7 @@
         },
         {
             "id": "ea273c8a-4b17-5fe1-8594-51f8dba92e99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418335b2-398f-499e-92ad-8d21a5a5b69f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/418335b2-398f-499e-92ad-8d21a5a5b69f.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -11174,7 +11174,7 @@
         },
         {
             "id": "9fbe0e9c-dad4-53da-90da-1b58ab725311",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96297bcc-8480-4b14-8612-1c395d481bce.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/96297bcc-8480-4b14-8612-1c395d481bce.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11212,7 +11212,7 @@
         },
         {
             "id": "63fcd42f-12bd-5a19-895c-bd6ca55894cb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aefd4-074a-47b8-88a3-32fb90b09dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/701aefd4-074a-47b8-88a3-32fb90b09dee.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11250,7 +11250,7 @@
         },
         {
             "id": "6c7d678a-b7a8-51d5-bbed-e67594bd3def",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89b3c3a-3dba-47b3-9620-d4dd754a59e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/8/c89b3c3a-3dba-47b3-9620-d4dd754a59e6.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -11288,7 +11288,7 @@
         },
         {
             "id": "37a9e1bd-4217-51cc-bc44-38c19db3ea40",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d949485e-5188-49f4-9d30-5e135532d445.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d949485e-5188-49f4-9d30-5e135532d445.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11326,7 +11326,7 @@
         },
         {
             "id": "dbbfcc96-b9f2-508e-8cc5-22f6616fabef",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a9654-ce17-4378-b52b-fb6efbbf042f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/184a9654-ce17-4378-b52b-fb6efbbf042f.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11364,7 +11364,7 @@
         },
         {
             "id": "0ed86207-9b2f-558a-9172-1932bae2f143",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef9b74-481b-424b-8e33-f0b910f66370.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2ef9b74-481b-424b-8e33-f0b910f66370.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -11402,7 +11402,7 @@
         },
         {
             "id": "1e6cfbf9-83b7-5999-a544-d2b78b9f1a30",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961bb827-f13a-417d-8284-5cd2aac3d034.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/6/961bb827-f13a-417d-8284-5cd2aac3d034.jpg?1",
             "name": "Jace, Mirror Mage",
             "text": "Kicker {2}\nWhen Jace, Mirror Mage enters the battlefield, if Jace was kicked, create a token that's a copy of Jace, Mirror Mage, except it's not legendary and its starting loyalty is 1.\n+1: Scry 2.\n0: Draw a card and reveal it. Remove a number of loyalty counters equal to that card's converted mana cost from Jace, Mirror Mage.",
             "colours": [
@@ -11440,7 +11440,7 @@
         },
         {
             "id": "57c09509-89f1-5318-9a1c-9c61e198dc29",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90ad3d-8d88-470b-897e-2f64376f7f43.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d90ad3d-8d88-470b-897e-2f64376f7f43.jpg?1",
             "name": "Nahiri, Heir of the Ancients",
             "text": "+1: Create a 1/1 white Kor Warrior creature token. You may attach an Equipment you control to it.\n\u22122: Look at the top six cards of your library. You may reveal a Warrior or Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n\u22123: Nahiri, Heir of the Ancients deals damage to target creature or planeswalker equal to twice the number of Equipment you control.",
             "colours": [
@@ -11480,7 +11480,7 @@
         },
         {
             "id": "e4e1b07e-02b1-5171-b2b0-e0887cfc4f9e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabac59d-8319-417e-9cd5-e4ee59b2e5f2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/a/dabac59d-8319-417e-9cd5-e4ee59b2e5f2.jpg?1",
             "name": "Nissa of Shadowed Boughs",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a loyalty counter on Nissa of Shadowed Boughs.\n+1: Untap target land you control. You may have it become a 3/3 Elemental creature with haste and menace until end of turn. It's still a land.\n\u22125: You may put a creature card with converted mana cost less than or equal to the number of lands you control onto the battlefield from your hand or graveyard with two +1/+1 counters on it.",
             "colours": [
@@ -11520,7 +11520,7 @@
         },
         {
             "id": "18691760-a467-52fe-ba32-ab6051585479",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11553,7 +11553,7 @@
         },
         {
             "id": "0c44b423-d106-5fa9-9f4d-d69ad70ceef7",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/3/738ebafa-04be-4ba9-ae65-5f85e00c645a.jpg?1",
             "name": "Branchloft Pathway // Boulderloft Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11586,7 +11586,7 @@
         },
         {
             "id": "7e47679e-24a0-57dc-970f-b29efb7d55ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11619,7 +11619,7 @@
         },
         {
             "id": "7236f50c-3d65-5b7e-9aee-62e521bc6959",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/b/eb55e544-ab9d-403d-93ee-19e792a256c5.jpg?1",
             "name": "Brightclimb Pathway // Grimclimb Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {W}.",
             "colours": [],
@@ -11652,7 +11652,7 @@
         },
         {
             "id": "a7f50521-110a-5572-ba96-5fe748b56d87",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -11685,7 +11685,7 @@
         },
         {
             "id": "f31fdd39-6824-5bf5-b6a1-f8333aeae539",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/0/b0fe4b53-18f6-42eb-b03f-cab3e5a7fba6.jpg?1",
             "name": "Clearwater Pathway // Murkwater Pathway",
             "text": "{T}: Add {B}.\n\n\nLand\n{T}: Add {U}.",
             "colours": [],
@@ -11718,7 +11718,7 @@
         },
         {
             "id": "b6e0a606-671c-55d5-b312-132a3d86098e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11751,7 +11751,7 @@
         },
         {
             "id": "3f4e0b67-3ab9-591b-9675-6fdd2f34d033",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/5/050602c0-b5b7-4076-af33-0f7a58d0b260.jpg?1",
             "name": "Cragcrown Pathway // Timbercrown Pathway",
             "text": "{T}: Add {G}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11784,7 +11784,7 @@
         },
         {
             "id": "c4f04cbb-7139-5e80-9d6b-3e29ac3cde84",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11818,7 +11818,7 @@
         },
         {
             "id": "2b18cf5f-bdc1-575c-8c1e-fe95d24b15e3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/e/ae420b3f-2f5b-4a4a-8d3a-8e6a3288c35a.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "{T}: Add {W}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11852,7 +11852,7 @@
         },
         {
             "id": "4cd78a0c-794d-5014-93cf-b032d5a8aba4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "",
             "colours": [],
@@ -11885,7 +11885,7 @@
         },
         {
             "id": "6ac8128d-c1f8-57c5-a5ae-47706e062d06",
-            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/e/d/edc71870-656c-40f9-b2b0-f69a46bf8c51.jpg?1",
             "name": "Needleverge Pathway // Pillarverge Pathway",
             "text": "",
             "colours": [],
@@ -11918,7 +11918,7 @@
         },
         {
             "id": "3d3b5b44-e3ec-5ca4-a24a-3468369483e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11951,7 +11951,7 @@
         },
         {
             "id": "e3a27a1c-52cb-5e6c-9dad-464d23d7c307",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1",
             "name": "Riverglide Pathway // Lavaglide Pathway",
             "text": "{T}: Add {U}.\n\n\nLand\n{T}: Add {R}.",
             "colours": [],
@@ -11984,7 +11984,7 @@
         },
         {
             "id": "9e6e6056-0ecf-5b8e-880c-aae2e3869816",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0250dc8-9d4c-428a-9e34-9e3577be4745.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/0/c0250dc8-9d4c-428a-9e34-9e3577be4745.jpg?1",
             "name": "Canyon Jerboa",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, creatures you control get +1/+1 until end of turn.",
             "colours": [
@@ -12020,7 +12020,7 @@
         },
         {
             "id": "0a9f5ef2-5d55-5ab7-8752-df29072c5cdf",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8024d-a300-43cb-9dde-6b4cb1fa19f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/8/48b8024d-a300-43cb-9dde-6b4cb1fa19f7.jpg?1",
             "name": "Fearless Fledgling",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Fearless Fledgling. It gains flying until end of turn.",
             "colours": [
@@ -12056,7 +12056,7 @@
         },
         {
             "id": "da647a9b-fda1-5d5d-a903-2e32b542c71f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c32d-457d-4fef-bba2-33a07bf23125.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/4/d442c32d-457d-4fef-bba2-33a07bf23125.jpg?1",
             "name": "Felidar Retreat",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, choose one \u2014\n\u2022 Create a 2/2 white Cat Beast creature token.\n\u2022 Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.",
             "colours": [
@@ -12090,7 +12090,7 @@
         },
         {
             "id": "8cbd59e2-0c20-59c6-9c35-04d88f06191c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97b691-f9f5-4fb4-8e44-8ffe32d13d03.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/be97b691-f9f5-4fb4-8e44-8ffe32d13d03.jpg?1",
             "name": "Makindi Ox",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, tap target creature an opponent controls.",
             "colours": [
@@ -12126,7 +12126,7 @@
         },
         {
             "id": "bdd0a49a-e7d3-51f7-8f46-4d299fdf71e2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8df0aed-dd2b-4f1e-8dfe-aec07462b1e1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/8/e8df0aed-dd2b-4f1e-8dfe-aec07462b1e1.jpg?1",
             "name": "Prowling Felidar",
             "text": "Vigilance\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Prowling Felidar.",
             "colours": [
@@ -12163,7 +12163,7 @@
         },
         {
             "id": "68c703c8-ef41-5b91-932a-fb7a6b7900d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc72e9f-2cda-47b9-84fd-4eed88312404.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/f/efc72e9f-2cda-47b9-84fd-4eed88312404.jpg?1",
             "name": "Ruin Crab",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, each opponent mills three cards.",
             "colours": [
@@ -12199,7 +12199,7 @@
         },
         {
             "id": "f185ff3c-caa7-5e84-ab16-17fdce789518",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04833fcc-cef7-4152-8191-c552288c83e4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/4/04833fcc-cef7-4152-8191-c552288c83e4.jpg?1",
             "name": "Skyclave Squid",
             "text": "Defender\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Squid can attack this turn as though it didn't have defender.",
             "colours": [
@@ -12235,7 +12235,7 @@
         },
         {
             "id": "fc96e0dd-630f-57f0-be8c-ad79beee374f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60c9b15-c824-4203-bdda-ff9c041f9e2f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/6/d60c9b15-c824-4203-bdda-ff9c041f9e2f.jpg?1",
             "name": "Dreadwurm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Dreadwurm gains indestructible until end of turn.",
             "colours": [
@@ -12272,7 +12272,7 @@
         },
         {
             "id": "496e4c41-1e58-5927-8d55-7b8791997e65",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05347539-de61-4a37-929f-c909e65033f5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/05347539-de61-4a37-929f-c909e65033f5.jpg?1",
             "name": "Skyclave Shade",
             "text": "Kicker {2}{B}\nSkyclave Shade can't block.\nIf Skyclave Shade was kicked, it enters the battlefield with two +1/+1 counters on it.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if Skyclave Shade is in your graveyard and it's your turn, you may cast it from your graveyard this turn.",
             "colours": [
@@ -12308,7 +12308,7 @@
         },
         {
             "id": "444f35a4-be3b-5ea2-a958-c20cc759dc7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5757230-08b8-4808-af61-d343f9748fb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/5/b5757230-08b8-4808-af61-d343f9748fb1.jpg?1",
             "name": "Akoum Hellhound",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Akoum Hellhound gets +2/+2 until end of turn.",
             "colours": [
@@ -12345,7 +12345,7 @@
         },
         {
             "id": "623bc456-243e-5679-9d7e-b626e599066d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecfbd48-7da0-4b44-b9a2-d31412f65eb1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/aecfbd48-7da0-4b44-b9a2-d31412f65eb1.jpg?1",
             "name": "Moraug, Fury of Akoum",
             "text": "Each creature you control gets +1/+0 for each time it has attacked this turn.\nLandfall \u2014 Whenever a land enters the battlefield under your control, if it's your main phase, there's an additional combat phase after this phase. At the beginning of that combat, untap all creatures you control.",
             "colours": [
@@ -12384,7 +12384,7 @@
         },
         {
             "id": "077cb5b9-40cf-552b-b410-b5ac8879c6a8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490f3d74-6144-4cbc-80ed-37cfcdbd159a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/490f3d74-6144-4cbc-80ed-37cfcdbd159a.jpg?1",
             "name": "Skyclave Geopede",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, Skyclave Geopede gets +2/+2 until end of turn.",
             "colours": [
@@ -12420,7 +12420,7 @@
         },
         {
             "id": "4f7e5b3e-3329-53eb-ae26-c63447c4976b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6008794-a7ca-4a3e-b88b-e5dbb9e0f39b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b6008794-a7ca-4a3e-b88b-e5dbb9e0f39b.jpg?1",
             "name": "Spitfire Lagac",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Spitfire Lagac deals 1 damage to each opponent.",
             "colours": [
@@ -12456,7 +12456,7 @@
         },
         {
             "id": "3b1f8dd0-4735-5d1b-96c0-9c3c073c6b32",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954cc66-ab80-4457-b0da-61d80e80e25e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/9/6954cc66-ab80-4457-b0da-61d80e80e25e.jpg?1",
             "name": "Valakut Exploration",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, exile the top card of your library. You may play that card for as long as it remains exiled.\nAt the beginning of your end step, if there are cards exiled with Valakut Exploration, put them into their owner's graveyard, then Valakut Exploration deals that much damage to each opponent.",
             "colours": [
@@ -12490,7 +12490,7 @@
         },
         {
             "id": "9908c952-3bc1-5e4e-a015-442cafece95c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52e90d3-d356-4b23-8f5c-a4004b20394c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/5/d52e90d3-d356-4b23-8f5c-a4004b20394c.jpg?1",
             "name": "Canopy Baloth",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Canopy Baloth gets +2/+2 until end of turn.",
             "colours": [
@@ -12526,7 +12526,7 @@
         },
         {
             "id": "8c33b1af-2d15-5a7f-a62b-89ab070c8a5a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, Kazandu Mammoth gets +2/+2 until end of turn.\n\n\nLand\n{T}: Add {G}.",
             "colours": [
@@ -12562,7 +12562,7 @@
         },
         {
             "id": "d8b73b4b-41a3-5b69-91cb-9d52225b5bef",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/0/9/09c8c150-a0d8-4254-9169-7697e9c540da.jpg?1",
             "name": "Kazandu Mammoth // Kazandu Valley",
             "text": "Kazandu Valley enters the battlefield tapped.\n{T}: Add {G}.\n\n\nElephant\n{1}{G}{G}",
             "colours": [],
@@ -12594,7 +12594,7 @@
         },
         {
             "id": "ecdb729a-a9b0-5f88-9a51-abd95dcdd3e4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796b5899-97e5-4682-aac8-51378f0c904e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/9/796b5899-97e5-4682-aac8-51378f0c904e.jpg?1",
             "name": "Kazandu Nectarpot",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, you gain 1 life.",
             "colours": [
@@ -12630,7 +12630,7 @@
         },
         {
             "id": "5e255230-447d-5262-9006-d600e9c661a3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151bdf3a-4445-43b1-8cea-2737c13d9dee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/151bdf3a-4445-43b1-8cea-2737c13d9dee.jpg?1",
             "name": "Lotus Cobra",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, add one mana of any color.",
             "colours": [
@@ -12666,7 +12666,7 @@
         },
         {
             "id": "c7a49031-605d-576e-a0bc-a35cf25b2661",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b2cb5-b9a8-417d-b5ae-0a7d03ff93f0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/0/309b2cb5-b9a8-417d-b5ae-0a7d03ff93f0.jpg?1",
             "name": "Scute Swarm",
             "text": "Landfall \u2014 Whenever a land enters the battlefield under your control, create a 1/1 green Insect creature token. If you control six or more lands, create a token that's a copy of Scute Swarm instead.",
             "colours": [
@@ -12702,7 +12702,7 @@
         },
         {
             "id": "85b6f1f4-58e0-5d5f-a16a-1354c04035b9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d6d8a4-c51d-4b4a-86e7-df9e9c7a171d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/3/03d6d8a4-c51d-4b4a-86e7-df9e9c7a171d.jpg?1",
             "name": "Skyclave Pick-Axe",
             "text": "When Skyclave Pick-Axe enters the battlefield, attach it to target creature you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, equipped creature gets +2/+2 until end of turn.\nEquip {2}{G}",
             "colours": [
@@ -12738,7 +12738,7 @@
         },
         {
             "id": "d72578e7-d99c-56f3-a87d-fcbd91c8d6a6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4aba-3391-4259-9a5f-a163a45d943c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/f/cf4a4aba-3391-4259-9a5f-a163a45d943c.jpg?1",
             "name": "Territorial Scythecat",
             "text": "Trample\nLandfall \u2014 Whenever a land enters the battlefield under your control, put a +1/+1 counter on Territorial Scythecat.",
             "colours": [
@@ -12774,7 +12774,7 @@
         },
         {
             "id": "7542bc87-0494-5749-8a55-7f0ba5a2eb6e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0954df-07f0-430d-90ee-d1fe40af546f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d0954df-07f0-430d-90ee-d1fe40af546f.jpg?1",
             "name": "Brushfire Elemental",
             "text": "Haste\nBrushfire Elemental can't be blocked by creatures with power 2 or less.\nLandfall \u2014 Whenever a land enters the battlefield under your control, Brushfire Elemental gets +2/+2 until end of turn.",
             "colours": [
@@ -12812,7 +12812,7 @@
         },
         {
             "id": "1c47b784-e283-5122-b128-ed6f4414d8d2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5bc5d7-c0f8-4632-adb7-dd3b75a3d87d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/b/9b5bc5d7-c0f8-4632-adb7-dd3b75a3d87d.jpg?1",
             "name": "Omnath, Locus of Creation",
             "text": "When Omnath, Locus of Creation enters the battlefield, draw a card.\nLandfall \u2014 Whenever a land enters the battlefield under your control, you gain 4 life if this is the first time this ability has resolved this turn. If it's the second time, add {R}{G}{W}{U}. If it's the third time, Omnath deals 4 damage to each opponent and each planeswalker you don't control.",
             "colours": [
@@ -12856,7 +12856,7 @@
         },
         {
             "id": "58217603-1efd-5bde-b9c8-06a8abf949e9",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344a3cd-43e0-4333-83ec-081f0e39530a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/3/c344a3cd-43e0-4333-83ec-081f0e39530a.jpg?1",
             "name": "Phylath, World Sculptor",
             "text": "When Phylath, World Sculptor enters the battlefield, create a 0/1 green Plant creature token for each basic land you control.\nLandfall \u2014 Whenever a land enters the battlefield under your control, put four +1/+1 counters on target Plant you control.",
             "colours": [
@@ -12896,7 +12896,7 @@
         },
         {
             "id": "55474870-ba85-59e7-a2e2-5e707c4271a5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f3282-b88e-4843-9569-af20940559b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f3f3282-b88e-4843-9569-af20940559b0.jpg?1",
             "name": "Angel of Destiny",
             "text": "Flying, double strike\nWhenever a creature you control deals combat damage to a player, you and that player each gain that much life.\nAt the beginning of your end step, if you have at least 15 life more than your starting life total, each player Angel of Destiny attacked this turn loses the game.",
             "colours": [
@@ -12933,7 +12933,7 @@
         },
         {
             "id": "a65f4408-2069-5fb4-9237-bf0b226f24ba",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ed3d8-d176-44c8-ba54-f2536ceeb497.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/3/530ed3d8-d176-44c8-ba54-f2536ceeb497.jpg?1",
             "name": "Archon of Emeria",
             "text": "Flying\nEach player can't cast more than one spell each turn.\nNonbasic lands your opponents control enter the battlefield tapped.",
             "colours": [
@@ -12969,7 +12969,7 @@
         },
         {
             "id": "6b5deeb0-9f8d-5aa5-9787-38bc93caad76",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23d588e-f7d8-4a11-9bf5-77b9f6faffd4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a23d588e-f7d8-4a11-9bf5-77b9f6faffd4.jpg?1",
             "name": "Archpriest of Iona",
             "text": "Archpriest of Iona's power is equal to the number of creatures in your party.\nAt the beginning of combat on your turn, if you have a full party, target creature gets +1/+1 and gains flying until end of turn.",
             "colours": [
@@ -13006,7 +13006,7 @@
         },
         {
             "id": "6d82730a-9c18-5030-9aa7-bb1eb590556a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "Create two 4/4 white Angel Warrior creature tokens with flying. Non-Angel creatures you control gain indestructible until your next turn.",
             "colours": [
@@ -13040,7 +13040,7 @@
         },
         {
             "id": "b31428a0-3a18-54aa-82db-a4fa8e155e6b",
-            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/c/a/ca50edb2-e50e-4601-ae18-1a313e041105.jpg?1",
             "name": "Emeria's Call // Emeria, Shattered Skyclave",
             "text": "As Emeria, Shattered Skyclave enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -13072,7 +13072,7 @@
         },
         {
             "id": "4799dad8-1bb9-51f4-b968-c5c093823bca",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc4014f-f9aa-4a46-b772-474e56ed72c3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bcc4014f-f9aa-4a46-b772-474e56ed72c3.jpg?1",
             "name": "Legion Angel",
             "text": "Flying\nWhen Legion Angel enters the battlefield, you may reveal a card you own named Legion Angel from outside the game and put it into your hand.",
             "colours": [
@@ -13109,7 +13109,7 @@
         },
         {
             "id": "27a31b08-41a6-548a-af5d-96b7eb16a7d4",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9427d-068f-487c-9263-b40366a164bc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebe9427d-068f-487c-9263-b40366a164bc.jpg?1",
             "name": "Luminarch Aspirant",
             "text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
             "colours": [
@@ -13146,7 +13146,7 @@
         },
         {
             "id": "701020e7-6acb-5c66-8f2d-4c42f8604248",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9da1e4-4554-42eb-aed5-9d068c39e727.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/b/fb9da1e4-4554-42eb-aed5-9d068c39e727.jpg?1",
             "name": "Maul of the Skyclaves",
             "text": "When Maul of the Skyclaves enters the battlefield, attach it to target creature you control.\nEquipped creature gets +2/+2 and has flying and first strike.\nEquip {2}{W}{W}",
             "colours": [
@@ -13182,7 +13182,7 @@
         },
         {
             "id": "96218570-8362-55f7-93ad-1f518cadd468",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Destroy all nonland permanents.",
             "colours": [
@@ -13216,7 +13216,7 @@
         },
         {
             "id": "1e8f76b3-01b2-50ea-971a-df9ee31605ba",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/7/b/7b300a1d-22a6-410c-9fe4-293fefe49969.jpg?1",
             "name": "Ondu Inversion // Ondu Skyruins",
             "text": "Ondu Skyruins enters the battlefield tapped.\n{T}: Add {W}.",
             "colours": [],
@@ -13248,7 +13248,7 @@
         },
         {
             "id": "44d43cf5-d486-5171-bce5-e03eb43bcaec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4b938f-a600-4d10-8030-ed60cf6ade56.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/c/bc4b938f-a600-4d10-8030-ed60cf6ade56.jpg?1",
             "name": "Skyclave Apparition",
             "text": "When Skyclave Apparition enters the battlefield, exile up to one target nonland, nontoken permanent you don't control with converted mana cost 4 or less.\nWhen Skyclave Apparition leaves the battlefield, the exiled card's owner creates an X/X blue Illusion creature token, where X is the converted mana cost of the exiled card.",
             "colours": [
@@ -13285,7 +13285,7 @@
         },
         {
             "id": "74a69a2e-1c59-5582-a99c-ef86babe1f3f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c56de4d-cb23-45f8-864d-3e7d640d62b0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/c/7c56de4d-cb23-45f8-864d-3e7d640d62b0.jpg?1",
             "name": "Squad Commander",
             "text": "When Squad Commander enters the battlefield, create a 1/1 white Kor Warrior creature token for each creature in your party.\nAt the beginning of combat on your turn, if you have a full party, creatures you control get +1/+0 and gain indestructible until end of turn.",
             "colours": [
@@ -13322,7 +13322,7 @@
         },
         {
             "id": "a12b36d9-1284-59d1-85ef-eb4e61df4985",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c1ab6-a67e-4258-8156-de21ccb2277d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/e/8e4c1ab6-a67e-4258-8156-de21ccb2277d.jpg?1",
             "name": "Tazri, Beacon of Unity",
             "text": "This spell costs {1} less to cast for each creature in your party.\n{2\nU}{2\nB}{2\nR}{2\nG}: Look at the top six cards of your library. You may reveal up to two Cleric, Rogue, Warrior, Wizard, and/or Ally cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13365,7 +13365,7 @@
         },
         {
             "id": "0fac0334-e2ab-5d86-8da3-9a3c81d496b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97982bcc-e1b1-4d21-b208-a6587613b8a1.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/7/97982bcc-e1b1-4d21-b208-a6587613b8a1.jpg?1",
             "name": "Charix, the Raging Isle",
             "text": "Spells your opponents cast that target Charix, the Raging Isle cost {2} more to cast.\n{3}: Charix gets +X/-X until end of turn, where X is the number of Islands you control.",
             "colours": [
@@ -13405,7 +13405,7 @@
         },
         {
             "id": "ac9cfb31-2793-5db2-baa2-95e3a37c6332",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c18e39-5173-48f1-8690-5a261b872758.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/7/b7c18e39-5173-48f1-8690-5a261b872758.jpg?1",
             "name": "Confounding Conundrum",
             "text": "When Confounding Conundrum enters the battlefield, draw a card.\nWhenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under their control this turn, they return a land they control to its owner's hand.",
             "colours": [
@@ -13439,7 +13439,7 @@
         },
         {
             "id": "709dd8e1-acfb-5b59-ab59-0a0f1ff99a19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937f3ea1-7966-4fd1-8ec7-bdca6edabdd0.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/3/937f3ea1-7966-4fd1-8ec7-bdca6edabdd0.jpg?1",
             "name": "Coralhelm Chronicler",
             "text": "Whenever you cast a kicked spell, draw a card, then discard a card.\nWhen Coralhelm Chronicler enters the battlefield, look at the top five cards of your library. You may reveal a card with a kicker ability from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -13476,7 +13476,7 @@
         },
         {
             "id": "71caa444-42a9-57d1-8e3c-7c4dd2d957f2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "You may have Glasspool Mimic enter the battlefield as a copy of a creature you control, except it's a Shapeshifter Rogue in addition to its other types.",
             "colours": [
@@ -13513,7 +13513,7 @@
         },
         {
             "id": "3e09ab49-3a49-5ae8-8098-9903bfbf08df",
-            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/f/e/fee79733-4df7-4870-9e42-03407b5e1528.jpg?1",
             "name": "Glasspool Mimic // Glasspool Shore",
             "text": "Glasspool Shore enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -13545,7 +13545,7 @@
         },
         {
             "id": "cf8f334c-a03f-507b-b094-21828459be93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea9e50b-f76e-4797-8e52-1e30ccfdb284.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/e/bea9e50b-f76e-4797-8e52-1e30ccfdb284.jpg?1",
             "name": "Inscription of Insight",
             "text": "Kicker {2}{U}{U}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Return up to two target creatures to their owners' hands.\n\u2022 Scry 2, then draw two cards.\n\u2022 Target player creates an X/X blue Illusion creature token, where X is the number of cards in their hand.",
             "colours": [
@@ -13579,7 +13579,7 @@
         },
         {
             "id": "51077a97-d423-5916-8e21-ea9b74627404",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62da66b8-c16a-4fa3-bd7f-bbf89591c5d8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/2/62da66b8-c16a-4fa3-bd7f-bbf89591c5d8.jpg?1",
             "name": "Maddening Cacophony",
             "text": "Kicker {3}{U}\nEach opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.",
             "colours": [
@@ -13613,7 +13613,7 @@
         },
         {
             "id": "d0cca18d-5ea1-56f2-a4c0-eef5b44c0f74",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63663faa-3ccb-4299-b393-347eefaf3c7b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63663faa-3ccb-4299-b393-347eefaf3c7b.jpg?1",
             "name": "Master of Winds",
             "text": "Flying\nWhen Master of Winds enters the battlefield, draw two cards, then discard a card.\nWhenever you cast an instant, sorcery, or Wizard spell, you may have Master of Winds's base power and toughness become 4/1 or 1/4 until end of turn.",
             "colours": [
@@ -13650,7 +13650,7 @@
         },
         {
             "id": "0c5b0732-dd62-5b88-88f7-ffc5f2bef530",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdc085a-8d97-45fe-86bf-2f4783ebf65e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/c/ccdc085a-8d97-45fe-86bf-2f4783ebf65e.jpg?1",
             "name": "Nimble Trapfinder",
             "text": "Nimble Trapfinder can't be blocked if you had another Cleric, Rogue, Warrior, or Wizard enter the battlefield under your control this turn.\nAt the beginning of combat on your turn, if you have a full party, creatures you control gain \"Whenever this creature deals combat damage to a player, draw a card\" until end of turn.",
             "colours": [
@@ -13687,7 +13687,7 @@
         },
         {
             "id": "445127ae-b2dd-5346-b98d-f894a11dcba6",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "Draw cards equal to the number of cards in your hand plus one. You have no maximum hand size for the rest of the game.",
             "colours": [
@@ -13721,7 +13721,7 @@
         },
         {
             "id": "53f9fe28-58ce-5aae-9f75-0f966247eb60",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/9/a910d400-8053-4c90-82e7-bf3e22e81633.jpg?1",
             "name": "Sea Gate Restoration // Sea Gate, Reborn",
             "text": "As Sea Gate, Reborn enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {U}.",
             "colours": [],
@@ -13753,7 +13753,7 @@
         },
         {
             "id": "a83f7191-b210-53af-82ff-1d5cf763d999",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b79895-30ac-4bb4-bbe3-033a0dfcf1d6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/7/17b79895-30ac-4bb4-bbe3-033a0dfcf1d6.jpg?1",
             "name": "Sea Gate Stormcaller",
             "text": "Kicker {4}{U}\nWhen Sea Gate Stormcaller enters the battlefield, copy the next instant or sorcery spell with converted mana cost 2 or less you cast this turn when you cast it. If Sea Gate Stormcaller was kicked, copy that spell twice instead. You may choose new targets for the copies.",
             "colours": [
@@ -13790,7 +13790,7 @@
         },
         {
             "id": "4ba1ec71-e57e-53c0-ba57-d4fc3cbf09b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3eb41-2351-4dca-becb-7ecb1fcfa14b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/8/f8b3eb41-2351-4dca-becb-7ecb1fcfa14b.jpg?1",
             "name": "Thieving Skydiver",
             "text": "Kicker {X}. X can't be 0.\nFlying\nWhen Thieving Skydiver enters the battlefield, if it was kicked, gain control of target artifact with converted mana cost X or less. If that artifact is an Equipment, attach it to Thieving Skydiver.",
             "colours": [
@@ -13827,7 +13827,7 @@
         },
         {
             "id": "349defa8-44a5-5ff4-8c1b-a5c82e216e1c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "Return from your graveyard to the battlefield any number of target creature cards that each have a different converted mana cost X or less.",
             "colours": [
@@ -13861,7 +13861,7 @@
         },
         {
             "id": "8deee4f4-b892-5ac8-bbd1-2dcca27e1571",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/4/9/499c2b20-e83e-40ff-919e-1d134ad50c0a.jpg?1",
             "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
             "text": "As Agadeem, the Undercrypt enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -13893,7 +13893,7 @@
         },
         {
             "id": "5971056b-bc98-5b6c-ab80-3dd260bbc37c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c86ad5-5384-4a62-971c-05abc995da91.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/5/95c86ad5-5384-4a62-971c-05abc995da91.jpg?1",
             "name": "Coveted Prize",
             "text": "This spell costs {1} less to cast for each creature in your party.\nSearch your library for a card, put it into your hand, then shuffle your library. If you have a full party, you may cast a spell with converted mana cost 4 or less from your hand without paying its mana cost.",
             "colours": [
@@ -13927,7 +13927,7 @@
         },
         {
             "id": "c7333229-7fcc-53df-aeec-7f6107204d4c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927297f6-5480-441f-ae05-a4064f493eed.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/2/927297f6-5480-441f-ae05-a4064f493eed.jpg?1",
             "name": "Drana, the Last Bloodchief",
             "text": "Flying\nWhenever Drana, the Last Bloodchief attacks, defending player chooses a nonlegendary creature card in your graveyard. You return that card to the battlefield with a +1/+1 counter on it. The creature is a Vampire in addition to its other types.",
             "colours": [
@@ -13966,7 +13966,7 @@
         },
         {
             "id": "ee07b2ff-7520-5e0f-952d-675a7ec95965",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "This spell costs {1} less to cast if an opponent controls no basic lands.\nDestroy target creature.",
             "colours": [
@@ -14000,7 +14000,7 @@
         },
         {
             "id": "30489ca2-a650-5638-995e-ebd5f7c1014f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/b/2/b2274cda-b97f-4027-9cd8-c35eeaa0b5e6.jpg?1",
             "name": "Hagra Mauling // Hagra Broodpit",
             "text": "Hagra Broodpit enters the battlefield tapped.\n{T}: Add {B}.",
             "colours": [],
@@ -14032,7 +14032,7 @@
         },
         {
             "id": "4329adcd-a317-5e28-8edd-5d703f8deb19",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267c7c9-dc93-445a-92e0-8cda9742e4cb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/2/a267c7c9-dc93-445a-92e0-8cda9742e4cb.jpg?1",
             "name": "Inscription of Ruin",
             "text": "Kicker {2}{B}{B}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Target opponent discards two cards.\n\u2022 Return target creature card with converted mana cost 2 or less from your graveyard to the battlefield.\n\u2022 Destroy target creature with converted mana cost 3 or less.",
             "colours": [
@@ -14066,7 +14066,7 @@
         },
         {
             "id": "39ec1458-b7bc-5bd7-b09c-93948b242f58",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9522009-4fc9-439a-95ea-5800842c5ee2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b9522009-4fc9-439a-95ea-5800842c5ee2.jpg?1",
             "name": "Nighthawk Scavenger",
             "text": "Flying, deathtouch, lifelink\nNighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards.",
             "colours": [
@@ -14103,7 +14103,7 @@
         },
         {
             "id": "5da824a6-be1e-5a67-b2e8-fa1c967a8ce0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774af92-db1a-4541-bf5c-0c34bf543aca.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/7/2774af92-db1a-4541-bf5c-0c34bf543aca.jpg?1",
             "name": "Nullpriest of Oblivion",
             "text": "Kicker {3}{B}\nMenace, lifelink\nWhen Nullpriest of Oblivion enters the battlefield, if it was kicked, return target creature card from your graveyard to the battlefield.",
             "colours": [
@@ -14140,7 +14140,7 @@
         },
         {
             "id": "2fd9b7cd-42f0-5556-99e5-9ce26b817686",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fec4b5-2a9c-4448-9fef-045d0e6725c2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/3/43fec4b5-2a9c-4448-9fef-045d0e6725c2.jpg?1",
             "name": "Scourge of the Skyclaves",
             "text": "Kicker {4}{B}\nWhen you cast this spell, if it was kicked, each player loses half their life, rounded up.\nScourge of the Skyclaves's power and toughness are each equal to 20 minus the highest life total among players.",
             "colours": [
@@ -14176,7 +14176,7 @@
         },
         {
             "id": "e37d7af7-414f-5622-a0a5-bfc9fe93badc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c1e4ca-4528-4637-9452-cc3e5da75456.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/1/31c1e4ca-4528-4637-9452-cc3e5da75456.jpg?1",
             "name": "Shadows' Verdict",
             "text": "Exile all creatures and planeswalkers with converted mana cost 3 or less from the battlefield and all creature and planeswalker cards with converted mana cost 3 or less from all graveyards.",
             "colours": [
@@ -14210,7 +14210,7 @@
         },
         {
             "id": "7c6131c9-759a-5dc3-bb99-d1e71af4dfa5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e40b3f9-8eed-41b1-afe1-eaf61a618407.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/e/1e40b3f9-8eed-41b1-afe1-eaf61a618407.jpg?1",
             "name": "Soul Shatter",
             "text": "Each opponent sacrifices a creature or planeswalker with the highest converted mana cost among creatures and planeswalkers they control.",
             "colours": [
@@ -14244,7 +14244,7 @@
         },
         {
             "id": "a975e75a-c8dd-51ca-bcd8-d3d0765c2d53",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d014ddb-c545-4f59-aa8e-e324399722e8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/d/6d014ddb-c545-4f59-aa8e-e324399722e8.jpg?1",
             "name": "Taborax, Hope's Demise",
             "text": "Flying\nTaborax, Hope's Demise has lifelink as long as it has five or more +1/+1 counters on it.\nWhenever another nontoken creature you control dies, put a +1/+1 counter on Taborax. If that creature was a Cleric, you may draw a card. If you do, you lose 1 life.",
             "colours": [
@@ -14283,7 +14283,7 @@
         },
         {
             "id": "f9de2b29-56a5-5f1f-8f76-18d58d9deba3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18442d4e-931f-4a41-b8c1-51ab3ea696df.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/8/18442d4e-931f-4a41-b8c1-51ab3ea696df.jpg?1",
             "name": "Kargan Intimidator",
             "text": "Cowards can't block Warriors.\n{1}: Choose one that hasn't been chosen this turn \u2014\n\u2022 Kargan Intimidator gets +1/+1 until end of turn.\n\u2022 Target creature becomes a Coward until end of turn.\n\u2022 Target Warrior gains trample until end of turn.",
             "colours": [
@@ -14320,7 +14320,7 @@
         },
         {
             "id": "c9d574cb-f1c3-5d4c-9984-0b60f3c29541",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633ebe69-493b-486a-a5b3-5a12418623f9.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/633ebe69-493b-486a-a5b3-5a12418623f9.jpg?1",
             "name": "Leyline Tyrant",
             "text": "Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.",
             "colours": [
@@ -14356,7 +14356,7 @@
         },
         {
             "id": "2b236209-66a2-5db0-90e3-8c47ea9ba571",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c3023-1429-4aa1-b822-85ab1badf086.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/1/711c3023-1429-4aa1-b822-85ab1badf086.jpg?1",
             "name": "Magmatic Channeler",
             "text": "As long as there are four or more instant and/or sorcery cards in your graveyard, Magmatic Channeler gets +3/+1.\n{T}, Discard a card: Exile the top two cards of your library, then choose one of them. You may play that card this turn.",
             "colours": [
@@ -14393,7 +14393,7 @@
         },
         {
             "id": "7ef69894-b07c-5918-942d-17a0af788ef3",
-            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2af06c-4c00-49ec-b13b-32be5bc6869a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/b/7b2af06c-4c00-49ec-b13b-32be5bc6869a.jpg?1",
             "name": "Nahiri's Lithoforming",
             "text": "Sacrifice X lands. For each land sacrificed this way, draw a card. You may play X additional lands this turn. Lands you control enter the battlefield tapped this turn.",
             "colours": [
@@ -14427,7 +14427,7 @@
         },
         {
             "id": "0fc56dc7-6902-5902-8e97-5f4a99da7e2b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6a537-fa85-44ab-a853-7a32812a4b32.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/9/49f6a537-fa85-44ab-a853-7a32812a4b32.jpg?1",
             "name": "Relic Robber",
             "text": "Haste\nWhenever Relic Robber deals combat damage to a player, that player creates a 0/1 colorless Goblin Construct artifact creature token with \"This creature can't block\" and \"At the beginning of your upkeep, this creature deals 1 damage to you.\"",
             "colours": [
@@ -14464,7 +14464,7 @@
         },
         {
             "id": "012ccd43-697b-5fd8-8c60-37430012599c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64940bb-c92f-4c2f-aef6-927cdc070b13.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/6/b64940bb-c92f-4c2f-aef6-927cdc070b13.jpg?1",
             "name": "Roiling Vortex",
             "text": "At the beginning of each player's upkeep, Roiling Vortex deals 1 damage to them.\nWhenever a player casts a spell, if no mana was spent to cast that spell, Roiling Vortex deals 5 damage to that player.\n{R}: Your opponents can't gain life this turn.",
             "colours": [
@@ -14498,7 +14498,7 @@
         },
         {
             "id": "af333115-4484-5fbd-8a40-303d96fdaf35",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f194ce88-3206-4263-9ae9-01a4c2f4467e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f194ce88-3206-4263-9ae9-01a4c2f4467e.jpg?1",
             "name": "Shatterskull Charger",
             "text": "Kicker {2}\nTrample, haste\nIf Shatterskull Charger was kicked, it enters the battlefield with a +1/+1 counter on it.\nAt the beginning of your end step, if Shatterskull Charger doesn't have a +1/+1 counter on it, return it to its owner's hand.",
             "colours": [
@@ -14535,7 +14535,7 @@
         },
         {
             "id": "903bfc0b-3ad5-51cc-9a7c-ee6ed13790fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "Shatterskull Smashing deals X damage divided as you choose among up to two target creatures and/or planeswalkers. If X is 6 or more, Shatterskull Smashing deals twice X damage divided as you choose among them instead.",
             "colours": [
@@ -14569,7 +14569,7 @@
         },
         {
             "id": "bb2109b7-8ecf-558e-829f-cc2b455634ab",
-            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/2/4/243d374f-5b40-4cff-99f5-079ba873d44b.jpg?1",
             "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
             "text": "As Shatterskull, the Hammer Pass enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -14601,7 +14601,7 @@
         },
         {
             "id": "90a8dcab-fe91-579e-bb10-55c67f9c5f4a",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Put any number of cards from your hand on the bottom of your library, then draw that many cards plus one.",
             "colours": [
@@ -14635,7 +14635,7 @@
         },
         {
             "id": "518f1b89-f077-5315-a6b6-c7ae28f50035",
-            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/a/1/a156b510-8879-4a7b-b15b-71374cb1e6f7.jpg?1",
             "name": "Valakut Awakening // Valakut Stoneforge",
             "text": "Valakut Stoneforge enters the battlefield tapped.\n{T}: Add {R}.",
             "colours": [],
@@ -14667,7 +14667,7 @@
         },
         {
             "id": "3ddc34dc-2364-53da-a9a2-b7c813eb4639",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebfe94fc-7a98-4f53-8fd0-f5fd016b1873.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/b/ebfe94fc-7a98-4f53-8fd0-f5fd016b1873.jpg?1",
             "name": "Wayward Guide-Beast",
             "text": "Trample, haste\nWhenever Wayward Guide-Beast deals combat damage to a player, return a land you control to its owner's hand.",
             "colours": [
@@ -14703,7 +14703,7 @@
         },
         {
             "id": "f0e55194-46e6-518c-8bbd-5deb749e92d0",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a058aa-f620-4a1f-af32-6e6be2cb3e4b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/6/c6a058aa-f620-4a1f-af32-6e6be2cb3e4b.jpg?1",
             "name": "Ancient Greenwarden",
             "text": "Reach\nYou may play lands from your graveyard.\nIf a land entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
             "colours": [
@@ -14739,7 +14739,7 @@
         },
         {
             "id": "ce1ad15d-07a3-5bb5-bde7-6f85e8d9bf23",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a883f-55e2-43f5-90a9-34494c14c0c4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/a/8a6a883f-55e2-43f5-90a9-34494c14c0c4.jpg?1",
             "name": "Ashaya, Soul of the Wild",
             "text": "Ashaya, Soul of the Wild's power and toughness are each equal to the number of lands you control.\nNontoken creatures you control are Forest lands in addition to their other types.",
             "colours": [
@@ -14777,7 +14777,7 @@
         },
         {
             "id": "b3991ddc-d928-58e8-a7f6-8800c600f2c8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227be7a0-de77-48ae-9a07-91d671985168.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/2/227be7a0-de77-48ae-9a07-91d671985168.jpg?1",
             "name": "Cragplate Baloth",
             "text": "Kicker {2}{G}\nThis spell can't be countered.\nHexproof, haste\nIf Cragplate Baloth was kicked, it enters the battlefield with four +1/+1 counters on it.",
             "colours": [
@@ -14813,7 +14813,7 @@
         },
         {
             "id": "d040c0c1-9ca5-5b9f-9493-075135381989",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14c74a8-be66-4268-93fa-b32765fd82e2.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/1/e14c74a8-be66-4268-93fa-b32765fd82e2.jpg?1",
             "name": "Inscription of Abundance",
             "text": "Kicker {2}{G}\nChoose one. If this spell was kicked, choose any number instead.\n\u2022 Put two +1/+1 counters on target creature.\n\u2022 Target player gains X life, where X is the greatest power among creatures they control.\n\u2022 Target creature you control fights target creature you don't control.",
             "colours": [
@@ -14847,7 +14847,7 @@
         },
         {
             "id": "7e716f38-634c-5605-aeb2-aa695dea2417",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f4293f-94ba-4702-9515-fd06df806169.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f4293f-94ba-4702-9515-fd06df806169.jpg?1",
             "name": "Oran-Rief Ooze",
             "text": "When Oran-Rief Ooze enters the battlefield, put a +1/+1 counter on target creature you control.\nWhenever Oran-Rief Ooze attacks, put a +1/+1 counter on each attacking creature with a +1/+1 counter on it.",
             "colours": [
@@ -14883,7 +14883,7 @@
         },
         {
             "id": "18a79249-3563-557f-91de-b93dd8d618e8",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e0cde7-ec96-4428-b368-572154c97f1c.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/3/63e0cde7-ec96-4428-b368-572154c97f1c.jpg?1",
             "name": "Swarm Shambler",
             "text": "Swarm Shambler enters the battlefield with a +1/+1 counter on it.\nWhenever a creature you control with a +1/+1 counter on it becomes the target of a spell an opponent controls, create a 1/1 green Insect creature token.\n{1}, {T}: Put a +1/+1 counter on Swarm Shambler.",
             "colours": [
@@ -14920,7 +14920,7 @@
         },
         {
             "id": "a448a7e2-6861-505b-ad5d-ba613aa70051",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a2ec1-23c1-4826-94b8-3df24172d764.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0d1a2ec1-23c1-4826-94b8-3df24172d764.jpg?1",
             "name": "Tajuru Paragon",
             "text": "Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.\nKicker {3}\nWhen Tajuru Paragon enters the battlefield, if it was kicked, reveal the top six cards of your library. You may put a card that shares a creature type with it from among them into your hand. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14956,7 +14956,7 @@
         },
         {
             "id": "f6aeb170-0112-5224-8df5-274ce7558327",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "Look at the top seven cards of your library. You may put a creature card from among them onto the battlefield. If that card has converted mana cost 3 or less, it enters with three additional +1/+1 counters on it. Put the rest on the bottom of your library in a random order.",
             "colours": [
@@ -14990,7 +14990,7 @@
         },
         {
             "id": "3bdeba6f-fa4d-5d1d-b169-6840a87e279e",
-            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/back/9/0/90df87c1-59df-4244-8653-15e7f13cdacc.jpg?1",
             "name": "Turntimber Symbiosis // Turntimber, Serpentine Wood",
             "text": "As Turntimber, Serpentine Wood enters the battlefield, you may pay 3 life. If you don't, it enters the battlefield tapped.\n{T}: Add {G}.",
             "colours": [],
@@ -15022,7 +15022,7 @@
         },
         {
             "id": "fb7f1969-d094-5d75-ad52-fa42dde3ddff",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b24f6-7def-4e2c-9e7b-a347dd3cdcee.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/8/986b24f6-7def-4e2c-9e7b-a347dd3cdcee.jpg?1",
             "name": "Akiri, Fearless Voyager",
             "text": "Whenever you attack a player with one or more equipped creatures, draw a card.\n{W}: You may unattach an Equipment from a creature you control. If you do, tap that creature and it gains indestructible until end of turn.",
             "colours": [
@@ -15063,7 +15063,7 @@
         },
         {
             "id": "94bd2963-670a-5f0d-9cbd-020cf360c39b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25975f58-a6b7-4cbc-bdc5-d0eedeb3ef1b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/5/25975f58-a6b7-4cbc-bdc5-d0eedeb3ef1b.jpg?1",
             "name": "Grakmaw, Skyclave Ravager",
             "text": "Grakmaw, Skyclave Ravager enters the battlefield with three +1/+1 counters on it.\nWhenever another creature you control dies, if it had a +1/+1 counter on it, put a +1/+1 counter on Grakmaw.\nWhen Grakmaw dies, create an X/X black and green Hydra creature token, where X is the number of +1/+1 counters on Grakmaw.",
             "colours": [
@@ -15104,7 +15104,7 @@
         },
         {
             "id": "f31ced07-f01b-5bd9-9cad-2a7a27e988d7",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9f9c0a-1ea6-44ac-b0af-6a6a32359494.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/b/6b9f9c0a-1ea6-44ac-b0af-6a6a32359494.jpg?1",
             "name": "Kaza, Roil Chaser",
             "text": "Flying, haste\n{T}: The next instant or sorcery spell you cast this turn costs {X} less to cast, where X is the number of Wizards you control as this ability resolves.",
             "colours": [
@@ -15145,7 +15145,7 @@
         },
         {
             "id": "fbe1c556-c85d-5da0-bfa5-1660855f0280",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15500025-e5ba-4f02-b875-bfa1b1a76875.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/5/15500025-e5ba-4f02-b875-bfa1b1a76875.jpg?1",
             "name": "Linvala, Shield of Sea Gate",
             "text": "Flying\nAt the beginning of combat on your turn, if you have a full party, choose target nonland permanent an opponent controls. Until your next turn, it can't attack or block, and its activated abilities can't be activated.\nSacrifice Linvala: Choose hexproof or indestructible. Creatures you control gain that ability until end of turn.",
             "colours": [
@@ -15186,7 +15186,7 @@
         },
         {
             "id": "7bab8861-40c1-5895-91d7-504b0eaaeae1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a323ac2-b7c0-4eae-8c12-253ec1f81317.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/a/1a323ac2-b7c0-4eae-8c12-253ec1f81317.jpg?1",
             "name": "Orah, Skyclave Hierophant",
             "text": "Lifelink\nWhenever Orah, Skyclave Hierophant or another Cleric you control dies, return target Cleric card with lesser converted mana cost from your graveyard to the battlefield.",
             "colours": [
@@ -15228,7 +15228,7 @@
         },
         {
             "id": "901e82f0-e2f1-5011-9e6e-acbf265b3412",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0584fc6c-88c6-46b5-8cc5-42d4a6f7e2f4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/5/0584fc6c-88c6-46b5-8cc5-42d4a6f7e2f4.jpg?1",
             "name": "Verazol, the Split Current",
             "text": "Verazol, the Split Current enters the battlefield with a +1/+1 counter on it for each mana spent to cast it.\nWhenever you cast a kicked spell, you may remove two +1/+1 counters from Verazol. If you do, copy that spell. You may choose new targets for the copy.",
             "colours": [
@@ -15268,7 +15268,7 @@
         },
         {
             "id": "a4c05416-faac-5c33-9282-b0e2540fec93",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59fa96-9bf1-41e2-b687-87704d2ec3a7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c59fa96-9bf1-41e2-b687-87704d2ec3a7.jpg?1",
             "name": "Yasharn, Implacable Earth",
             "text": "When Yasharn enters the battlefield, search your library for a basic Forest card and a basic Plains card, reveal those cards, put them into your hand, then shuffle your library.\nPlayers can't pay life or sacrifice nonland permanents to cast spells or activate abilities.",
             "colours": [
@@ -15309,7 +15309,7 @@
         },
         {
             "id": "01a77bd3-365b-5053-a9a0-a72effcd9976",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1158d64-50fa-41ac-9967-c95237fc207a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/1/f1158d64-50fa-41ac-9967-c95237fc207a.jpg?1",
             "name": "Zagras, Thief of Heartbeats",
             "text": "This spell costs {1} less to cast for each creature in your party.\nFlying, deathtouch, haste\nOther creatures you control have deathtouch.\nWhenever a creature you control deals combat damage to a planeswalker, destroy that planeswalker.",
             "colours": [
@@ -15350,7 +15350,7 @@
         },
         {
             "id": "b7c4d629-4cdd-573d-a19a-363ad7f095dc",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f0b9a-d8a2-4b34-a23e-61cd6630ce3d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/9/b93f0b9a-d8a2-4b34-a23e-61cd6630ce3d.jpg?1",
             "name": "Zareth San, the Trickster",
             "text": "Flash\n{2}{U}{B}, Return an unblocked attacking Rogue you control to its owner's hand: Put Zareth San, the Trickster from your hand onto the battlefield tapped and attacking.\nWhenever Zareth San deals combat damage to a player, you may put target permanent card from that player's graveyard onto the battlefield under your control.",
             "colours": [
@@ -15391,7 +15391,7 @@
         },
         {
             "id": "bece5558-8292-58ec-b2e5-9705ee174c97",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8f362c-f035-48b3-8e74-ef23240b44f7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/c/0c8f362c-f035-48b3-8e74-ef23240b44f7.jpg?1",
             "name": "Forsaken Monument",
             "text": "Colorless creatures you control get +2/+2.\nWhenever you tap a permanent for {C}, add an additional {C}.\nWhenever you cast a colorless spell, you gain 2 life.",
             "colours": [],
@@ -15423,7 +15423,7 @@
         },
         {
             "id": "3d0db380-3fa9-5ed1-8106-535eba2c266d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b02012-56b1-4386-936b-139480162e8f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/3/e3b02012-56b1-4386-936b-139480162e8f.jpg?1",
             "name": "Lithoform Engine",
             "text": "{2}, {T}: Copy target activated or triggered ability you control. You may choose new targets for the copy.\n{3}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n{4}, {T}: Copy target permanent spell you control.",
             "colours": [],
@@ -15455,7 +15455,7 @@
         },
         {
             "id": "82e28780-671f-5813-8d68-0a32d45a79f1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11e4bb6-8ab3-4402-b474-0fb8cbccd802.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/1/d11e4bb6-8ab3-4402-b474-0fb8cbccd802.jpg?1",
             "name": "Myriad Construct",
             "text": "Kicker {3}\nIf Myriad Construct was kicked, it enters the battlefield with a +1/+1 counter on it for each nonbasic land your opponents control.\nWhen Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colorless Construct artifact creature tokens equal to its power.",
             "colours": [],
@@ -15488,7 +15488,7 @@
         },
         {
             "id": "190b0d86-3791-5333-a7c6-e8e7a676345e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2fb74a-d235-4ba6-bd7e-d439478dce44.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/a/fa2fb74a-d235-4ba6-bd7e-d439478dce44.jpg?1",
             "name": "Skyclave Relic",
             "text": "Kicker {3}\nIndestructible\nWhen Skyclave Relic enters the battlefield, if it was kicked, create two tapped tokens that are copies of Skyclave Relic.\n{T}: Add one mana of any color.",
             "colours": [],
@@ -15518,7 +15518,7 @@
         },
         {
             "id": "35b3e481-2f8c-595f-ac85-b56d1b20111e",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9078dbd-65c5-4b02-ac21-c3d2da05b8ec.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/9/d9078dbd-65c5-4b02-ac21-c3d2da05b8ec.jpg?1",
             "name": "Crawling Barrens",
             "text": "{T}: Add {C}.\n{4}: Put two +1/+1 counters on Crawling Barrens. Then you may have it become a 0/0 Elemental creature until end of turn. It's still a land.",
             "colours": [],
@@ -15548,7 +15548,7 @@
         },
         {
             "id": "0728d7e5-314a-5480-bea1-928524185260",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2731e9-ea63-4615-9ca4-8759fb15881e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/a/9a2731e9-ea63-4615-9ca4-8759fb15881e.jpg?1",
             "name": "Throne of Makindi",
             "text": "{T}: Add {C}.\n{1}, {T}: Put a charge counter on Throne of Makindi.\n{T}, Remove a charge counter from Throne of Makindi: Add two mana of any one color. Spend this mana only to cast kicked spells.",
             "colours": [],
@@ -15578,7 +15578,7 @@
         },
         {
             "id": "45260a6a-bb6a-521c-98c3-cd6643ac4f46",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae92e656-6c9d-48c3-a238-5a11c2c62ec8.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/e/ae92e656-6c9d-48c3-a238-5a11c2c62ec8.jpg?1",
             "name": "Plains",
             "text": "",
             "colours": [],
@@ -15616,7 +15616,7 @@
         },
         {
             "id": "bc649741-e3df-531f-b52c-b3634cb80c7b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589a324f-4466-4d4a-8cfb-806a041d7c1f.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/8/589a324f-4466-4d4a-8cfb-806a041d7c1f.jpg?1",
             "name": "Island",
             "text": "",
             "colours": [],
@@ -15654,7 +15654,7 @@
         },
         {
             "id": "8148c863-ee4b-5204-b115-3f172931e08c",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1967d4a8-6cc4-4a4d-9d24-93257de35e6d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/9/1967d4a8-6cc4-4a4d-9d24-93257de35e6d.jpg?1",
             "name": "Swamp",
             "text": "",
             "colours": [],
@@ -15692,7 +15692,7 @@
         },
         {
             "id": "6c9650e9-4b6c-5954-94eb-dc6c0418a760",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6a38dd-e8f5-420f-9576-66937c71286b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/c/3c6a38dd-e8f5-420f-9576-66937c71286b.jpg?1",
             "name": "Mountain",
             "text": "",
             "colours": [],
@@ -15730,7 +15730,7 @@
         },
         {
             "id": "2f8a3f3d-3b11-5f26-b766-0b0bbda0a5bb",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90e88b-60a3-4d1d-bb8c-14633e5005a5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/b/2b90e88b-60a3-4d1d-bb8c-14633e5005a5.jpg?1",
             "name": "Forest",
             "text": "",
             "colours": [],
@@ -15768,7 +15768,7 @@
         },
         {
             "id": "fce0a486-fb7e-5e33-bea2-573c4e6529be",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc715da-970a-4525-a752-a3b7a0f1e87b.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/d/0dc715da-970a-4525-a752-a3b7a0f1e87b.jpg?1",
             "name": "Orah, Skyclave Hierophant",
             "text": "",
             "colours": [
@@ -15809,7 +15809,7 @@
         },
         {
             "id": "b335008d-c678-52cd-8f87-7fc71832365b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e23886b-8200-427d-99af-068a0133795d.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/e/6e23886b-8200-427d-99af-068a0133795d.jpg?1",
             "name": "Charix, the Raging Isle",
             "text": "",
             "colours": [
@@ -15848,7 +15848,7 @@
         },
         {
             "id": "3f492516-7767-5ed7-a1d4-e3f7c06aee2f",
-            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c2c3d7-3437-44b8-8d39-d3abe02af50e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/a/3/a3c2c3d7-3437-44b8-8d39-d3abe02af50e.jpg?1",
             "name": "Into the Roil",
             "text": "",
             "colours": [
@@ -15882,7 +15882,7 @@
         },
         {
             "id": "3f9a0369-5fe7-5aee-85fe-3cfaacd275af",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7be5c0a-b538-4bc5-89c7-f5a81de7ccc3.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/7/f7be5c0a-b538-4bc5-89c7-f5a81de7ccc3.jpg?1",
             "name": "Bloodchief's Thirst",
             "text": "",
             "colours": [
@@ -15916,7 +15916,7 @@
         },
         {
             "id": "97577e9e-69a9-5a8b-9c24-a72703790046",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c02ec-f21e-405b-8267-7f7ff089904a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/6/560c02ec-f21e-405b-8267-7f7ff089904a.jpg?1",
             "name": "Roil Eruption",
             "text": "",
             "colours": [
@@ -15950,7 +15950,7 @@
         },
         {
             "id": "deb51cbd-b890-5b2d-9d6f-7b896e16c6fd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa531b2-ccd5-489b-9edf-4cab01aca7fd.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5fa531b2-ccd5-489b-9edf-4cab01aca7fd.jpg?1",
             "name": "Roiling Regrowth",
             "text": "",
             "colours": [
@@ -15984,7 +15984,7 @@
         },
         {
             "id": "46407d93-df48-5161-95fe-f24086746663",
-            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1409-4e7c-445e-ae6b-b3133faf1f73.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/c/b/cbef1409-4e7c-445e-ae6b-b3133faf1f73.jpg?1",
             "name": "Kargan Warleader",
             "text": "",
             "colours": [
@@ -16023,7 +16023,7 @@
         },
         {
             "id": "d640859a-29e8-5cff-a0c0-5816ae2813b1",
-            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91098481-46c2-49bf-8123-e9cab2f22b84.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/9/1/91098481-46c2-49bf-8123-e9cab2f22b84.jpg?1",
             "name": "Angel Warrior",
             "text": "",
             "colours": [
@@ -16059,7 +16059,7 @@
         },
         {
             "id": "11584d9e-92a2-5ed4-acd9-df46cbe26f99",
-            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f458f39-27b6-4121-bda9-1a0d1b42f5fb.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/f/5f458f39-27b6-4121-bda9-1a0d1b42f5fb.jpg?1",
             "name": "Cat",
             "text": "",
             "colours": [
@@ -16094,7 +16094,7 @@
         },
         {
             "id": "e20db866-4106-56e6-b6e6-898d17870875",
-            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c91781-acf9-4cff-be1a-85148ad2a683.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/e/2/e2c91781-acf9-4cff-be1a-85148ad2a683.jpg?1",
             "name": "Cat Beast",
             "text": "",
             "colours": [
@@ -16130,7 +16130,7 @@
         },
         {
             "id": "04bfbf2c-20cb-5e2a-b32d-118d9e12c9ec",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13412797-f831-49fe-adf3-369cdfacdbd5.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/3/13412797-f831-49fe-adf3-369cdfacdbd5.jpg?1",
             "name": "Kor Warrior",
             "text": "",
             "colours": [
@@ -16166,7 +16166,7 @@
         },
         {
             "id": "f21130a4-98f8-5e32-875a-b0ffe39d1d6b",
-            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1659d2ee-1831-4ba1-a08d-03af31c9a043.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/1/6/1659d2ee-1831-4ba1-a08d-03af31c9a043.jpg?1",
             "name": "Drake",
             "text": "",
             "colours": [
@@ -16201,7 +16201,7 @@
         },
         {
             "id": "e06431b6-e469-59ea-ae40-070e3c7d224d",
-            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300635e-7771-4676-a5a5-29a9d8f49f1a.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/2/3/2300635e-7771-4676-a5a5-29a9d8f49f1a.jpg?1",
             "name": "Illusion",
             "text": "",
             "colours": [
@@ -16236,7 +16236,7 @@
         },
         {
             "id": "c260fa03-ae9a-5bda-8c06-aab126a23edd",
-            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84da9c36-5d9c-4e29-b6cc-c5c10e490f2e.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/8/4/84da9c36-5d9c-4e29-b6cc-c5c10e490f2e.jpg?1",
             "name": "Insect",
             "text": "",
             "colours": [
@@ -16271,7 +16271,7 @@
         },
         {
             "id": "eca9a6c2-1883-5ba3-9e0f-4317701db374",
-            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03d87f5-0ac6-45ca-a54b-6a36132a8eae.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/d/0/d03d87f5-0ac6-45ca-a54b-6a36132a8eae.jpg?1",
             "name": "Plant",
             "text": "",
             "colours": [
@@ -16306,7 +16306,7 @@
         },
         {
             "id": "d3514110-ce8f-5d62-9991-f498505241b2",
-            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ad0395-190d-4779-81b7-2832dc257828.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/f/2/f2ad0395-190d-4779-81b7-2832dc257828.jpg?1",
             "name": "Hydra",
             "text": "",
             "colours": [
@@ -16343,7 +16343,7 @@
         },
         {
             "id": "5f94537e-fc38-5705-9ad7-753043780a24",
-            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462c167-e6cf-46f8-9b77-2a88815e3b82.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/3/4/3462c167-e6cf-46f8-9b77-2a88815e3b82.jpg?1",
             "name": "Construct",
             "text": "",
             "colours": [],
@@ -16375,7 +16375,7 @@
         },
         {
             "id": "c7db9aee-80eb-537f-8b1c-e643957e87b5",
-            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24a63e2-c2b3-43f8-a15a-68886bec7d60.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/b/2/b24a63e2-c2b3-43f8-a15a-68886bec7d60.jpg?1",
             "name": "Goblin Construct",
             "text": "",
             "colours": [],
@@ -16408,7 +16408,7 @@
         },
         {
             "id": "61aa5086-680f-5638-801a-69b49c0fe160",
-            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f62ebf-1600-4eaa-a998-3fd7d1ea2f65.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/6/06f62ebf-1600-4eaa-a998-3fd7d1ea2f65.jpg?1",
             "name": "Copy",
             "text": "",
             "colours": [],

--- a/MTG-Docs/CardDatabase/getCardsFromAllSets.py
+++ b/MTG-Docs/CardDatabase/getCardsFromAllSets.py
@@ -23,7 +23,7 @@ setReadDirectory = "./Sets/"
 setWriteDirectory = "./ReducedSets/"
 
 # Included sets (https://arraytext.com/)
-includedSets = ["LEA", "LEB", "ARN", "ATQ", "LEG", "DRK", "FEM", "4ED", "ICE", "HML", "ALL", "MIR", "VIS", "WTH", "5ED", "POR", "P02", "PTK", "TMP", "STH", "EXO", "UGL", "USG", "ULG", "UDS", "6ED", "MMQ", "NEM", "PCY", "INV", "PLS", "APC", "7ED", "ODY", "TOR", "JUD", "ONS", "LGN", "SCG", "8ED", "MRD", "DST", "5DN", "UNH", "CHK", "BOK", "SOK", "9ED", "RAV", "GPT", "DIS", "CSP", "TSP", "PLC", "FUT", "10E", "LRW", "MOR", "SHM", "EVE", "ALA", "CONX", "ARB", "M10", "ZEN", "WWK", "ROE", "M11", "SOM", "MBS", "NPH", "M12", "ISD", "DKA", "AVR", "M13", "RTR", "GTC", "DGM", "MMA", "M14", "THS", "BNG", "JOU", "M15", "KTK", "FRF", "DTK", "ORI", "MM2", "BFZ", "OGW", "SOI", "EMN", "EMA", "KLD", "AER", "MM3", "AKH", "HOU", "UST", "IMA", "XLN", "RIX", "A25", "DOM", "M19", "GRN", "UMA", "RNA", "WAR", "MH1", "M20", "ELD", "THB", "IKO", "UND", "M21", "JMP", "2XM", "ANB", "ZNR", "CMR", "KHM", "TSR", "STX", "STA", "MH2", "AFR", "MID", "VOW", "NEO", "SNC", "CLB", "2X2", "DMU", "UNF", "BRO", "J22", "DMR", "ONE", "MOM", "MAT", "LTR", "CMM", "WOE", "LCI", "PIP", "MKM", "OTJ", "BIG", "MH3", "ACR", "BLB", "DSK", "SLD", "FDN"]
+includedSets = ["LEA", "LEB", "ARN", "ATQ", "LEG", "DRK", "FEM", "4ED", "ICE", "HML", "ALL", "MIR", "VIS", "WTH", "5ED", "POR", "P02", "PTK", "TMP", "STH", "EXO", "UGL", "USG", "ULG", "UDS", "6ED", "MMQ", "NEM", "PCY", "INV", "PLS", "APC", "7ED", "ODY", "TOR", "JUD", "ONS", "LGN", "SCG", "8ED", "MRD", "DST", "5DN", "UNH", "CHK", "BOK", "SOK", "9ED", "RAV", "GPT", "DIS", "CSP", "TSP", "PLC", "FUT", "10E", "LRW", "MOR", "SHM", "EVE", "ALA", "CONX", "ARB", "M10", "ZEN", "WWK", "ROE", "M11", "SOM", "MBS", "NPH", "M12", "ISD", "DKA", "AVR", "M13", "RTR", "GTC", "DGM", "MMA", "M14", "THS", "BNG", "JOU", "M15", "KTK", "FRF", "DTK", "ORI", "MM2", "BFZ", "OGW", "SOI", "EMN", "EMA", "KLD", "AER", "MM3", "AKH", "HOU", "UST", "IMA", "XLN", "RIX", "A25", "DOM", "M19", "GRN", "UMA", "RNA", "WAR", "MH1", "M20", "ELD", "THB", "IKO", "UND", "M21", "JMP", "2XM", "ANB", "ZNR", "CMR", "KHM", "TSR", "STX", "STA", "MH2", "AFR", "MID", "VOW", "NEO", "SNC", "CLB", "2X2", "DMU", "UNF", "BRO", "J22", "DMR", "ONE", "MOM", "MAT", "LTR", "CMM", "WOE", "WHO", "LCI", "PIP", "MKM", "OTJ", "BIG", "MH3", "ACR", "BLB", "DSK", "SLD", "FDN", "DFT", "TDM"]
 
 setCounter = 1
 for setCode in includedSets:
@@ -104,11 +104,11 @@ for setCode in includedSets:
         scryfallId = card["identifiers"]["scryfallId"]
         if isBack:
             if layout == "meld":
-                imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+                imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
             else:
-                imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+                imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
         else:
-            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
 
         thisCard = {
             "id": card["uuid"],
@@ -163,9 +163,9 @@ for setCode in includedSets:
         imageUrl = ""
         scryfallId = token["identifiers"]["scryfallId"]
         if isBack:
-            imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
         else:
-            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
 
         thisToken = {
             "id": token["uuid"],

--- a/MTG-Docs/CardDatabase/getCardsFromSet.py
+++ b/MTG-Docs/CardDatabase/getCardsFromSet.py
@@ -100,11 +100,11 @@ for card in cards:
     scryfallId = card["identifiers"]["scryfallId"]
     if isBack:
         if layout == "meld":
-            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
         else:
-            imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
     else:
-        imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+        imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
 
     thisCard = {
         "id": card["uuid"],
@@ -160,9 +160,9 @@ for token in tokens:
     imageUrl = ""
     scryfallId = token["identifiers"]["scryfallId"]
     if isBack:
-        imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+        imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
     else:
-        imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+        imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg?1"
 
     thisToken = {
         "id": token["uuid"],


### PR DESCRIPTION
## What does this Pull Request do?

The Scryfall image URLs have slightly changed, causing some images to point to an incorrect variation
- Altered the URL for the single and the batch set preprocessor
- Regenerated the set information for all sets